### PR TITLE
C++: Make Folder.getURL() consistent with Folder.getLocation()

### DIFF
--- a/cpp/ql/src/semmle/code/cpp/File.qll
+++ b/cpp/ql/src/semmle/code/cpp/File.qll
@@ -192,7 +192,7 @@ class Folder extends Container, @folder {
    * Gets the URL of this folder.
    */
   deprecated override string getURL() {
-    result = "folder://" + getAbsolutePath()
+    result = "file://" + this.getAbsolutePath() + ":0:0:0:0"
   }
 
   /**


### PR DESCRIPTION
This fixes confusing behaviour like:
```
from Element e, Folder f
where e = f
select e, f
```
```
file:///home/ian:0:0:0:0 | /home/ian | folder:///home/ian | /home/ian |
```
