### PR TITLE
C#: Add @ids for metric queries

### DIFF
--- a/csharp/ql/src/Metrics/Callables/CCyclomaticComplexity.ql
+++ b/csharp/ql/src/Metrics/Callables/CCyclomaticComplexity.ql
@@ -8,7 +8,7 @@
  * @tags testability
  *       complexity
  *       maintainability
- * @deprecated
+ * @id cs/cyclomatic-complexity-per-function
  */
 import csharp
 

--- a/csharp/ql/src/Metrics/Callables/CLinesOfCode.ql
+++ b/csharp/ql/src/Metrics/Callables/CLinesOfCode.ql
@@ -7,7 +7,7 @@
  * @metricAggregate avg sum max
  * @tags maintainability
  *       complexity
- * @deprecated
+ * @id cs/lines-of-code-per-function
  */
 import csharp
 

--- a/csharp/ql/src/Metrics/Callables/CLinesOfComment.ql
+++ b/csharp/ql/src/Metrics/Callables/CLinesOfComment.ql
@@ -7,7 +7,7 @@
  * @metricAggregate avg sum max
  * @tags maintainability
  *       documentation
- * @deprecated
+ * @id cs/lines-of-comment-per-function
  */
 import csharp
 

--- a/csharp/ql/src/Metrics/Callables/CNumberOfParameters.ql
+++ b/csharp/ql/src/Metrics/Callables/CNumberOfParameters.ql
@@ -8,7 +8,7 @@
  * @tags testability
  *       complexity
  *       maintainability
- * @deprecated
+ * @id cs/parameters-per-function
  */
 import csharp
 

--- a/csharp/ql/src/Metrics/Callables/CNumberOfStatements.ql
+++ b/csharp/ql/src/Metrics/Callables/CNumberOfStatements.ql
@@ -7,7 +7,7 @@
  * @metricType callable
  * @metricAggregate avg sum max
  * @tags maintainability
- * @deprecated
+ * @id cs/statements-per-function
  */
 import csharp
 

--- a/csharp/ql/src/Metrics/Callables/CPercentageOfComments.ql
+++ b/csharp/ql/src/Metrics/Callables/CPercentageOfComments.ql
@@ -7,7 +7,7 @@
  * @metricAggregate avg max
  * @tags maintainability
  *       documentation
- * @deprecated
+ * @id cs/comment-ratio-per-type
  */
 import csharp
 

--- a/csharp/ql/src/Metrics/Callables/StatementNestingDepth.ql
+++ b/csharp/ql/src/Metrics/Callables/StatementNestingDepth.ql
@@ -7,7 +7,7 @@
  * @metricAggregate avg max
  * @tags maintainability
  *       complexity
- * @deprecated
+ * @id cs/statement-nesting-depth-per-function
  */
 import csharp
 

--- a/csharp/ql/src/Metrics/Files/FCommentRatio.ql
+++ b/csharp/ql/src/Metrics/Files/FCommentRatio.ql
@@ -7,7 +7,7 @@
  * @metricAggregate avg max
  * @tags maintainability
  *       documentation
- * @deprecated
+ * @id cs/comment-ratio-per-file
  */
 import csharp
 

--- a/csharp/ql/src/Metrics/Files/FCyclomaticComplexity.ql
+++ b/csharp/ql/src/Metrics/Files/FCyclomaticComplexity.ql
@@ -7,7 +7,7 @@
  * @metricAggregate avg max
  * @tags testability
  *       complexity
- * @deprecated
+ * @id cs/average-cyclomatic-complexity-per-file
  */
 import csharp
 

--- a/csharp/ql/src/Metrics/Files/FLines.ql
+++ b/csharp/ql/src/Metrics/Files/FLines.ql
@@ -5,7 +5,7 @@
  * @treemap.warnOn highValues
  * @metricType file
  * @metricAggregate avg sum max
- * @deprecated
+ * @id cs/lines-per-file
  */
 import csharp
 

--- a/csharp/ql/src/Metrics/Files/FNumberOfClasses.ql
+++ b/csharp/ql/src/Metrics/Files/FNumberOfClasses.ql
@@ -6,7 +6,7 @@
  * @metricType file
  * @metricAggregate avg sum max
  * @tags maintainability
- * @deprecated
+ * @id cs/classes-per-file
  */
 import csharp
 

--- a/csharp/ql/src/Metrics/Files/FNumberOfInterfaces.ql
+++ b/csharp/ql/src/Metrics/Files/FNumberOfInterfaces.ql
@@ -6,7 +6,7 @@
  * @metricType file
  * @metricAggregate avg sum max
  * @tags maintainability
- * @deprecated
+ * @id cs/interfaces-per-file
  */
 import csharp
 

--- a/csharp/ql/src/Metrics/Files/FNumberOfStructs.ql
+++ b/csharp/ql/src/Metrics/Files/FNumberOfStructs.ql
@@ -6,7 +6,7 @@
  * @metricType file
  * @metricAggregate avg sum max
  * @tags maintainability
- * @deprecated
+ * @id cs/structs-per-file
  */
 import csharp
 

--- a/csharp/ql/src/Metrics/Files/FNumberOfUsingNamespaces.ql
+++ b/csharp/ql/src/Metrics/Files/FNumberOfUsingNamespaces.ql
@@ -6,7 +6,7 @@
  * @metricType file
  * @metricAggregate avg sum max
  * @tags maintainability
- * @deprecated
+ * @id cs/using-namespaces-per-file
  */
 import csharp
 

--- a/csharp/ql/src/Metrics/Files/FSelfContainedness.ql
+++ b/csharp/ql/src/Metrics/Files/FSelfContainedness.ql
@@ -7,7 +7,7 @@
  * @metricAggregate avg max
  * @tags portability
  *       modularity
- * @deprecated
+ * @id cs/source-dependency-ratio-per-file
  */
 import csharp
 import semmle.code.csharp.metrics.Coupling

--- a/csharp/ql/src/Metrics/History/HChurn.ql
+++ b/csharp/ql/src/Metrics/History/HChurn.ql
@@ -5,7 +5,7 @@
  * @treemap.warnOn highValues
  * @metricType file
  * @metricAggregate avg sum max
- * @deprecated
+ * @id cs/vcs/churn-per-file
  */
 import csharp
 import external.VCS

--- a/csharp/ql/src/Metrics/History/HLinesAdded.ql
+++ b/csharp/ql/src/Metrics/History/HLinesAdded.ql
@@ -5,7 +5,7 @@
  * @treemap.warnOn highValues
  * @metricType file
  * @metricAggregate avg sum max
- * @deprecated
+ * @id cs/vcs/added-lines-per-file
  */
 import csharp
 import external.VCS

--- a/csharp/ql/src/Metrics/History/HLinesDeleted.ql
+++ b/csharp/ql/src/Metrics/History/HLinesDeleted.ql
@@ -5,7 +5,7 @@
  * @treemap.warnOn highValues
  * @metricType file
  * @metricAggregate avg sum max
- * @deprecated
+ * @id cs/vcs/deleted-lines-per-file
  */
 import csharp
 import external.VCS

--- a/csharp/ql/src/Metrics/History/HNumberOfAuthors.ql
+++ b/csharp/ql/src/Metrics/History/HNumberOfAuthors.ql
@@ -5,7 +5,7 @@
  * @treemap.warnOn highValues
  * @metricType file
  * @metricAggregate avg min max
- * @deprecated
+ * @id cs/vcs/authors-per-file
  */
 import csharp
 import external.VCS

--- a/csharp/ql/src/Metrics/History/HNumberOfChanges.ql
+++ b/csharp/ql/src/Metrics/History/HNumberOfChanges.ql
@@ -5,7 +5,7 @@
  * @treemap.warnOn highValues
  * @metricType file
  * @metricAggregate avg min max sum
- * @deprecated
+ * @id cs/vcs/commits-per-file
  */
 import csharp
 import external.VCS

--- a/csharp/ql/src/Metrics/History/HNumberOfCoCommits.ql
+++ b/csharp/ql/src/Metrics/History/HNumberOfCoCommits.ql
@@ -5,7 +5,7 @@
  * @treemap.warnOn highValues
  * @metricType file
  * @metricAggregate avg min max
- * @deprecated
+ * @id cs/vcs/co-commits-per-file
  */
 import csharp
 import external.VCS

--- a/csharp/ql/src/Metrics/History/HNumberOfReCommits.ql
+++ b/csharp/ql/src/Metrics/History/HNumberOfReCommits.ql
@@ -5,7 +5,7 @@
  * @treemap.warnOn highValues
  * @metricType file
  * @metricAggregate avg min max
- * @deprecated
+ * @id cs/vcs/recommits-per-file
  */
 import csharp
 import external.VCS

--- a/csharp/ql/src/Metrics/History/HNumberOfRecentChanges.ql
+++ b/csharp/ql/src/Metrics/History/HNumberOfRecentChanges.ql
@@ -5,7 +5,7 @@
  * @treemap.warnOn highValues
  * @metricType file
  * @metricAggregate avg min max sum
- * @deprecated
+ * @id cs/vcs/recent-commits-per-file
  */
 import csharp
 import external.VCS

--- a/csharp/ql/src/Metrics/RefTypes/TAfferentCoupling.ql
+++ b/csharp/ql/src/Metrics/RefTypes/TAfferentCoupling.ql
@@ -7,7 +7,7 @@
  * @metricAggregate avg max
  * @tags changeability
  *       modularity
- * @deprecated
+ * @id cs/incoming-type-dependencies
  */
 import csharp
 

--- a/csharp/ql/src/Metrics/RefTypes/TEfferentCoupling.ql
+++ b/csharp/ql/src/Metrics/RefTypes/TEfferentCoupling.ql
@@ -8,7 +8,7 @@
  * @tags testability
  *       modularity
  *       maintainability
- * @deprecated
+ * @id cs/outgoing-type-dependencies
  */
 import csharp
 

--- a/csharp/ql/src/Metrics/RefTypes/TInheritanceDepth.ql
+++ b/csharp/ql/src/Metrics/RefTypes/TInheritanceDepth.ql
@@ -7,7 +7,7 @@
  * @metricAggregate avg max
  * @tags changeability
  *       modularity
- * @deprecated
+ * @id cs/inheritance-depth
  */
 import csharp
 

--- a/csharp/ql/src/Metrics/RefTypes/TLackOfCohesionCK.ql
+++ b/csharp/ql/src/Metrics/RefTypes/TLackOfCohesionCK.ql
@@ -7,7 +7,7 @@
  * @metricAggregate avg max
  * @tags modularity
  *       maintainability
- * @deprecated
+ * @id cs/lack-of-cohesion-ck
  */
 import csharp
 

--- a/csharp/ql/src/Metrics/RefTypes/TLackOfCohesionHS.ql
+++ b/csharp/ql/src/Metrics/RefTypes/TLackOfCohesionHS.ql
@@ -6,7 +6,7 @@
  * @metricType reftype
  * @metricAggregate avg max
  * @tags modularity
- * @deprecated
+ * @id cs/lack-of-cohesion-hs
  */
 import csharp
 

--- a/csharp/ql/src/Metrics/RefTypes/TNumberOfCallables.ql
+++ b/csharp/ql/src/Metrics/RefTypes/TNumberOfCallables.ql
@@ -6,7 +6,7 @@
  * @metricType reftype
  * @metricAggregate avg sum max
  * @tags maintainability
- * @deprecated
+ * @id cs/functions-per-type
  */
 import csharp
 

--- a/csharp/ql/src/Metrics/RefTypes/TNumberOfEvents.ql
+++ b/csharp/ql/src/Metrics/RefTypes/TNumberOfEvents.ql
@@ -6,7 +6,7 @@
  * @metricType reftype
  * @metricAggregate avg sum max
  * @tags maintainability
- * @deprecated
+ * @id cs/events-per-type
  */
 import csharp
 

--- a/csharp/ql/src/Metrics/RefTypes/TNumberOfFields.ql
+++ b/csharp/ql/src/Metrics/RefTypes/TNumberOfFields.ql
@@ -7,7 +7,7 @@
  * @metricAggregate avg sum max
  * @tags maintainability
  *       complexity
- * @deprecated
+ * @id cs/fields-per-type
  */
 import csharp
 

--- a/csharp/ql/src/Metrics/RefTypes/TNumberOfIndexers.ql
+++ b/csharp/ql/src/Metrics/RefTypes/TNumberOfIndexers.ql
@@ -6,7 +6,7 @@
  * @metricType reftype
  * @metricAggregate avg sum max
  * @tags maintainability
- * @deprecated
+ * @id cs/indexers-per-type
  */
 import csharp
 

--- a/csharp/ql/src/Metrics/RefTypes/TNumberOfNonConstFields.ql
+++ b/csharp/ql/src/Metrics/RefTypes/TNumberOfNonConstFields.ql
@@ -5,7 +5,7 @@
  * @treemap.warnOn highValues
  * @metricType reftype
  * @metricAggregate avg sum max
- * @deprecated
+ * @id cs/nonconst-fields-per-type
  */
 import csharp
 

--- a/csharp/ql/src/Metrics/RefTypes/TNumberOfProperties.ql
+++ b/csharp/ql/src/Metrics/RefTypes/TNumberOfProperties.ql
@@ -6,7 +6,7 @@
  * @metricType reftype
  * @metricAggregate avg sum max
  * @tags maintainability
- * @deprecated
+ * @id cs/properties-per-type
  */
 import csharp
 

--- a/csharp/ql/src/Metrics/RefTypes/TNumberOfStatements.ql
+++ b/csharp/ql/src/Metrics/RefTypes/TNumberOfStatements.ql
@@ -6,7 +6,7 @@
  * @metricType reftype
  * @metricAggregate avg sum max
  * @tags maintainability
- * @deprecated
+ * @id cs/statements-per-type
  */
 import csharp
 

--- a/csharp/ql/src/Metrics/RefTypes/TResponse.ql
+++ b/csharp/ql/src/Metrics/RefTypes/TResponse.ql
@@ -7,7 +7,7 @@
  * @metricAggregate avg max
  * @tags maintainability
  *       complexity
- * @deprecated
+ * @id cs/response-per-type
  */
 import csharp
 

--- a/csharp/ql/src/Metrics/RefTypes/TSizeOfAPI.ql
+++ b/csharp/ql/src/Metrics/RefTypes/TSizeOfAPI.ql
@@ -7,7 +7,7 @@
  * @metricAggregate avg sum max
  * @tags testability
  *       modularity
- * @deprecated
+ * @id cs/public-functions-per-type
  */
 import csharp
 

--- a/csharp/ql/src/Metrics/RefTypes/TSpecialisationIndex.ql
+++ b/csharp/ql/src/Metrics/RefTypes/TSpecialisationIndex.ql
@@ -7,7 +7,7 @@
  * @metricAggregate avg max
  * @tags modularity
  *       maintainability
- * @deprecated
+ * @id cs/type-specialization-index
  */
 import csharp
 

--- a/csharp/ql/src/Metrics/RefTypes/TUnmanagedCode.ql
+++ b/csharp/ql/src/Metrics/RefTypes/TUnmanagedCode.ql
@@ -6,7 +6,7 @@
  * @metricType reftype
  * @metricAggregate sum
  * @tags reliability
- * @deprecated
+ * @id cs/externs-per-type
  */
 
 import csharp

--- a/csharp/ql/src/filters/ChangedLines.ql
+++ b/csharp/ql/src/filters/ChangedLines.ql
@@ -1,7 +1,7 @@
 /**
  * @name Filter: only keep results from source that have been changed since the base line
  * @description Exclude results that have not changed since the base line.
- * @deprecated
+ * @id cs/changed-lines-filter
  * @kind problem
  */
 import csharp

--- a/csharp/ql/src/filters/ChangedLinesForMetric.ql
+++ b/csharp/ql/src/filters/ChangedLinesForMetric.ql
@@ -1,7 +1,7 @@
 /**
  * @name Filter: only keep results from source that have been changed since the base line
  * @description Exclude results that have not changed since the base line.
- * @deprecated
+ * @id cs/changed-lines-metric-filter
  * @kind treemap
  */
 import csharp

--- a/csharp/ql/src/filters/FromSource.ql
+++ b/csharp/ql/src/filters/FromSource.ql
@@ -2,7 +2,7 @@
  * @name Filter: only keep results from source
  * @description Exclude results that do not come from source code files.
  * @kind problem
- * @deprecated
+ * @id cs/source-filter
  */
 import csharp
 import external.DefectFilter

--- a/csharp/ql/src/filters/FromSourceForMetric.ql
+++ b/csharp/ql/src/filters/FromSourceForMetric.ql
@@ -2,7 +2,7 @@
  * @name Filter: only keep metric results from source
  * @description Exclude results that do not come from source code files.
  * @kind treemap
- * @deprecated
+ * @id cs/source-metric-filter
  */
 import csharp
 import external.MetricFilter

--- a/csharp/ql/src/filters/NotGenerated.ql
+++ b/csharp/ql/src/filters/NotGenerated.ql
@@ -2,7 +2,7 @@
  * @name Filter: only keep results in non-generated files
  * @description Exclude results that come from generated code.
  * @kind problem
- * @deprecated
+ * @id cs/not-generated-file-filter
  */
 import semmle.code.csharp.commons.GeneratedCode
 import external.DefectFilter

--- a/csharp/ql/src/filters/NotGeneratedForMetric.ql
+++ b/csharp/ql/src/filters/NotGeneratedForMetric.ql
@@ -2,7 +2,7 @@
  * @name Filter: only keep metric results in non-generated files
  * @description Exclude results that come from generated code.
  * @kind treemap
- * @deprecated
+ * @id cs/not-generated-file-metric-filter
  */
 import semmle.code.csharp.commons.GeneratedCode
 import external.MetricFilter

--- a/csharp/ql/src/filters/NotInTestFile.ql
+++ b/csharp/ql/src/filters/NotInTestFile.ql
@@ -2,7 +2,7 @@
  * @name Filter: only keep results that are outside of test files
  * @description Exclude results in test files.
  * @kind problem
- * @deprecated
+ * @id cs/test-file-filter
  */
 import csharp
 import semmle.code.csharp.frameworks.Test

--- a/csharp/ql/src/filters/NotInTestFileForMetric.ql
+++ b/csharp/ql/src/filters/NotInTestFileForMetric.ql
@@ -2,7 +2,7 @@
  * @name Filter: only keep results that are outside of test files
  * @description Exclude results in test files.
  * @kind treemap
- * @deprecated
+ * @id cs/test-file-metric-filter
  */
 import csharp
 import semmle.code.csharp.frameworks.Test

--- a/csharp/ql/src/filters/NotInTestMethod.ql
+++ b/csharp/ql/src/filters/NotInTestMethod.ql
@@ -2,7 +2,7 @@
  * @name Filter: only keep results that are outside of test methods
  * @description Exclude results in test methods.
  * @kind problem
- * @deprecated
+ * @id cs/test-method-filter
  */
 import csharp
 import semmle.code.csharp.frameworks.Test

--- a/csharp/ql/src/filters/NotInTestMethodExpectingException.ql
+++ b/csharp/ql/src/filters/NotInTestMethodExpectingException.ql
@@ -2,7 +2,7 @@
  * @name Filter: only keep results that are outside of a test method expecting an exception
  * @description Exclude results in test methods expecting exceptions.
  * @kind problem
- * @deprecated
+ * @id cs/test-method-exception-filter
  */
 import csharp
 import semmle.code.csharp.frameworks.Test

--- a/csharp/ql/src/filters/RecentDefects.ql
+++ b/csharp/ql/src/filters/RecentDefects.ql
@@ -2,7 +2,7 @@
  * @name Filter: only files recently edited
  * @description Filter a defect query to only include results in files that have been changed recently, and modify the message.
  * @kind problem
- * @deprecated
+ * @id cs/recently-changed-file-filter
  */
 import csharp
 import external.DefectFilter

--- a/csharp/ql/src/filters/UnchangedLines.ql
+++ b/csharp/ql/src/filters/UnchangedLines.ql
@@ -2,7 +2,7 @@
  * @name Filter: only keep results from source that have not changed since the base line
  * @description Complement of ChangedLines.ql.
  * @kind problem
- * @deprecated
+ * @id cs/unchanged-lines-filter
  */
 import csharp
 import external.ExternalArtifact

--- a/csharp/ql/src/filters/UnchangedLinesForMetric.ql
+++ b/csharp/ql/src/filters/UnchangedLinesForMetric.ql
@@ -2,7 +2,7 @@
  * @name Filter: only keep results from source that have not changed since the base line
  * @description Complement of ChangedLinesForMetric.ql.
  * @kind treemap
- * @deprecated
+ * @id cs/unchanged-lines-metric-filter
  */
 import csharp
 import external.ExternalArtifact


### PR DESCRIPTION
Remove the `@deprecated` tag from all metric queries, and give them `@id` tags. Almost all of these ids are the same as the Java queries.

@hvitved 