### PR TITLE
C#: Fix CFG for unknown expressions

### DIFF
--- a/csharp/ql/src/semmle/code/csharp/controlflow/ControlFlowGraph.qll
+++ b/csharp/ql/src/semmle/code/csharp/controlflow/ControlFlowGraph.qll
@@ -950,6 +950,7 @@ module ControlFlow {
           not this instanceof CastExpr and
           not this instanceof AnonymousFunctionExpr and
           not this instanceof DelegateCall and
+          not this instanceof @unknown_expr and
           result = this.getChild(i)
           or
           this = any(ExtensionMethodCall emc |
@@ -967,6 +968,8 @@ module ControlFlow {
           result = getCastExprChild(this, i)
           or
           result = this.(DelegateCall).getChild(i - 1)
+          or
+          result = getUnknownExprChild(this, i)
         }
       }
 
@@ -999,6 +1002,13 @@ module ControlFlow {
       private ControlFlowElement getAsExprChild(AsExpr ae, int i) {
         // The type access at index 1 is not evaluated at run-time
         i = 0 and result = ae.getExpr()
+      }
+
+      private ControlFlowElement getUnknownExprChild(@unknown_expr e, int i) {
+        exists(int c |
+          result = e.(Expr).getChild(c) |
+          c = rank[i+1](int j | exists(e.(Expr).getChild(j)))
+        )
       }
 
       private ControlFlowElement getCastExprChild(CastExpr ce, int i) {

--- a/csharp/ql/test/library-tests/standalone/controlflow/ControlFlow.cs
+++ b/csharp/ql/test/library-tests/standalone/controlflow/ControlFlow.cs
@@ -1,0 +1,14 @@
+// semmle-extractor-options: --standalone
+
+using System;
+
+class Cfg
+{
+    void F()
+    {
+        var v = new InvalidType();
+        Debug.Assert(v.a.b, "This is true");
+
+        new CounterCreationData() { CounterHelp = string.Empty, CounterType = v.Type };
+    }
+}

--- a/csharp/ql/test/library-tests/standalone/controlflow/cfg.expected
+++ b/csharp/ql/test/library-tests/standalone/controlflow/cfg.expected
@@ -1,0 +1,18 @@
+| ControlFlow.cs:7:10:7:10 | enter F | ControlFlow.cs:8:5:13:5 | {...} |
+| ControlFlow.cs:8:5:13:5 | {...} | ControlFlow.cs:9:9:9:34 | ... ...; |
+| ControlFlow.cs:9:9:9:34 | ... ...; | ControlFlow.cs:9:13:9:13 | access to local variable v |
+| ControlFlow.cs:10:9:10:13 | Expression | ControlFlow.cs:10:22:10:22 | access to local variable v |
+| ControlFlow.cs:10:9:10:43 | Call to unknown method | ControlFlow.cs:12:9:12:87 | ...; |
+| ControlFlow.cs:10:9:10:44 | ...; | ControlFlow.cs:10:9:10:13 | Expression |
+| ControlFlow.cs:10:22:10:22 | access to local variable v | ControlFlow.cs:10:22:10:24 | Expression |
+| ControlFlow.cs:10:22:10:24 | Expression | ControlFlow.cs:10:22:10:26 | Expression |
+| ControlFlow.cs:10:22:10:26 | Expression | ControlFlow.cs:10:29:10:42 | "This is true" |
+| ControlFlow.cs:10:29:10:42 | "This is true" | ControlFlow.cs:10:9:10:43 | Call to unknown method |
+| ControlFlow.cs:12:35:12:86 | { ..., ... } | ControlFlow.cs:7:10:7:10 | exit F |
+| ControlFlow.cs:12:37:12:47 | Expression | ControlFlow.cs:12:51:12:62 | access to field Empty |
+| ControlFlow.cs:12:37:12:62 | ... = ... | ControlFlow.cs:12:65:12:75 | Expression |
+| ControlFlow.cs:12:51:12:62 | access to field Empty | ControlFlow.cs:12:37:12:62 | ... = ... |
+| ControlFlow.cs:12:65:12:75 | Expression | ControlFlow.cs:12:79:12:79 | access to local variable v |
+| ControlFlow.cs:12:65:12:84 | ... = ... | ControlFlow.cs:12:35:12:86 | { ..., ... } |
+| ControlFlow.cs:12:79:12:79 | access to local variable v | ControlFlow.cs:12:79:12:84 | Expression |
+| ControlFlow.cs:12:79:12:84 | Expression | ControlFlow.cs:12:65:12:84 | ... = ... |

--- a/csharp/ql/test/library-tests/standalone/controlflow/cfg.ql
+++ b/csharp/ql/test/library-tests/standalone/controlflow/cfg.ql
@@ -1,0 +1,18 @@
+import csharp
+import semmle.code.csharp.controlflow.ControlFlowGraph
+
+/**
+ * A method call where the target is unknown.
+ * The purpose of this is to ensure that all MethodCall expressions
+ * have a valid `toString()`.
+ */
+class UnknownCall extends MethodCall
+{
+  UnknownCall() { not exists(this.getTarget()) }
+  
+  override string toString() { result = "Call to unknown method" }
+}
+
+query predicate edges(ControlFlowNode n1, ControlFlowNode n2) {
+  n2 = n1.getASuccessor()
+}

--- a/csharp/ql/test/library-tests/standalone/controlflow/cfg.ql
+++ b/csharp/ql/test/library-tests/standalone/controlflow/cfg.ql
@@ -6,13 +6,12 @@ import semmle.code.csharp.controlflow.ControlFlowGraph
  * The purpose of this is to ensure that all MethodCall expressions
  * have a valid `toString()`.
  */
-class UnknownCall extends MethodCall
-{
+class UnknownCall extends MethodCall {
   UnknownCall() { not exists(this.getTarget()) }
   
   override string toString() { result = "Call to unknown method" }
 }
 
-query predicate edges(ControlFlowNode n1, ControlFlowNode n2) {
+query predicate edges(ControlFlow::Node n1, ControlFlow::Node n2) {
   n2 = n1.getASuccessor()
 }


### PR DESCRIPTION
1. Fix the CFG for unknown expressions, which were previously excluded from the control flow graph, which could lead to an incomplete graph.
1. Add a test for this change, and also test the extraction of initializer-lists with unknown expressions. This test will currently fail on this branch as it tests extractor changes.