### PR TITLE
Simplify C locations handling

### DIFF
--- a/cpp/ql/src/definitions.qll
+++ b/cpp/ql/src/definitions.qll
@@ -186,7 +186,7 @@ Top definitionOf(Top e, string kind) {
       not exists(MacroInvocation mi, Location l1, Location l2 |
         l1 = e.(Include).getLocation() and
         l2 = mi.getLocation() and
-        l1.getFile() = l2.getFile() and
+        l1.getContainer() = l2.getContainer() and
         l1.getStartLine() = l2.getStartLine()
         // (an #include directive must be always on it's own line)
       )


### PR DESCRIPTION
The first commit simplifies the various bits of location handling to refer to a shared new predicate (`Location::fullLocationInfo`, which is like `hasLocationInfo/5` but exposes the actual container entity). This avoids a certain amount of repetition, as all the predicates that explicitly called the three `locations_*` tables can now just refer to the single place that unions those tables.

The second commit is a minor simplification to `defintions.qll`, following recent changes to location handling (and more things becoming `Container`s rather than `File`s). In particular, it allows us to find a much better way of evaluating that part of the predicate.