### PR TITLE
JavaScript: Generalize description of `js/unused-local-variable`.

### DIFF
--- a/change-notes/1.18/analysis-javascript.md
+++ b/change-notes/1.18/analysis-javascript.md
@@ -45,6 +45,7 @@
 | Server-side URL redirect | More true-positive results | This rule now treats header names case-insensitively. |
 | Uncontrolled command line | More true-positive results | This rule now recognizes indirect command injection through `sh -c` and similar. |
 | Unused variable | Fewer results | This rule no longer flags class expressions that could be made anonymous. While technically true, these results are not interesting. |
+| Unused variable | Renamed | This rule has been renamed to "Unused variable, import, function or class" to reflect the fact that it flags different kinds of unused program elements. |
 
 ## Changes to QL libraries
 

--- a/javascript/ql/src/Declarations/UnusedVariable.qhelp
+++ b/javascript/ql/src/Declarations/UnusedVariable.qhelp
@@ -7,11 +7,15 @@
 Unused local variables make code hard to read and understand. Any computation used to initialize
 an unused variable is wasted, which may lead to performance problems.
 </p>
+<p>
+Similarly, unused imports and unused functions or classes can be confusing. They may even be
+a symptom of a bug caused, for example, by an incomplete refactoring.
+</p>
 
 </overview>
 <recommendation>
 
-<p>Remove the unused variable.</p>
+<p>Remove the unused program element.</p>
 
 </recommendation>
 <example>

--- a/javascript/ql/src/Declarations/UnusedVariable.ql
+++ b/javascript/ql/src/Declarations/UnusedVariable.ql
@@ -1,6 +1,7 @@
 /**
- * @name Unused variable
- * @description Unused variables may be a symptom of a bug and should be examined carefully.
+ * @name Unused variable, import, function or class
+ * @description Unused variables, imports, functions or classes may be a symptom of a bug
+ *              and should be examined carefully.
  * @kind problem
  * @problem.severity recommendation
  * @id js/unused-local-variable


### PR DESCRIPTION
The query also flags unused imports, functions and classes (which, of course, are just unused variables at the end of the day). This is now made more explicit in the description.