### PR TITLE
C++: built-in type tweaks

### DIFF
--- a/cpp/ql/test/library-tests/type_sizes/type_sizes.expected
+++ b/cpp/ql/test/library-tests/type_sizes/type_sizes.expected
@@ -60,7 +60,7 @@
 | file://:0:0:0:0 | const char[5] | 5 |
 | file://:0:0:0:0 | decltype(nullptr) | 8 |
 | file://:0:0:0:0 | double | 8 |
-| file://:0:0:0:0 | error | 0 |
+| file://:0:0:0:0 | error | 1 |
 | file://:0:0:0:0 | float | 4 |
 | file://:0:0:0:0 | int | 4 |
 | file://:0:0:0:0 | int & | 8 |
@@ -78,7 +78,7 @@
 | file://:0:0:0:0 | signed long | 8 |
 | file://:0:0:0:0 | signed long long | 8 |
 | file://:0:0:0:0 | signed short | 2 |
-| file://:0:0:0:0 | unknown | 0 |
+| file://:0:0:0:0 | unknown | 1 |
 | file://:0:0:0:0 | unsigned __int128 | 16 |
 | file://:0:0:0:0 | unsigned char | 1 |
 | file://:0:0:0:0 | unsigned int | 4 |


### PR DESCRIPTION
Two changes that go hand-in-hand with internal extractor improvements, related to handling of built-in types:

1. Properly formatted (and complete) comments for each built-in type kind.
2. A test change to match the new behaviour that the `error` and `unknown` types have size 1, not 0.