### PR TITLE
JS: refactor UriLibraries.qll models to use `DataFlow::moduleMember`

### DIFF
--- a/javascript/ql/src/semmle/javascript/frameworks/UriLibraries.qll
+++ b/javascript/ql/src/semmle/javascript/frameworks/UriLibraries.qll
@@ -96,8 +96,15 @@ module uridashjs {
   /**
    * Gets a data flow source node for the uridashjs library.
    */
-  DataFlow::SourceNode uridashjs() {
+  deprecated DataFlow::SourceNode uridashjs() {
     result = DataFlow::moduleImport("uri-js")
+  }
+
+  /**
+   * Gets a data flow source node for member `name` of the uridashjs library.
+   */
+  DataFlow::SourceNode uridashjsMember(string name) {
+    result = DataFlow::moduleMember("uri-js", name)
   }
 
   /**
@@ -113,7 +120,7 @@ module uridashjs {
         name = "serialize" or
         name = "resolve" or
         name = "normalize" |
-        this = uridashjs().getAMemberCall(name) and
+        this = uridashjsMember(name).getACall() and
         src = getAnArgument()
       )
     }
@@ -133,8 +140,15 @@ module punycode {
   /**
    * Gets a data flow source node for the punycode library.
    */
-  DataFlow::SourceNode punycode() {
+  deprecated DataFlow::SourceNode punycode() {
     result = DataFlow::moduleImport("punycode")
+  }
+
+  /**
+   * Gets a data flow source node for member `name` of the punycode library.
+   */
+  DataFlow::SourceNode punycodeMember(string name) {
+    result = DataFlow::moduleMember("punycode", name)
   }
 
   /**
@@ -150,7 +164,7 @@ module punycode {
         name = "encode" or
         name = "toUnicode" or
         name = "toASCII" |
-        this = punycode().getAMemberCall(name) and
+        this = punycodeMember(name).getACall() and
         src = getAnArgument()
       )
     }
@@ -216,8 +230,15 @@ module querystringify {
   /**
    * Gets a data flow source node for the querystringify library.
    */
-  DataFlow::SourceNode querystringify() {
+  deprecated DataFlow::SourceNode querystringify() {
     result = DataFlow::moduleImport("querystringify")
+  }
+
+  /**
+   * Gets a data flow source node for member `name` of the querystringify library.
+   */
+  DataFlow::SourceNode querystringifyMember(string name) {
+    result = DataFlow::moduleMember("querystringify", name)
   }
 
   /**
@@ -231,7 +252,7 @@ module querystringify {
       exists (string name |
         name = "parse" or
         name = "stringify" |
-        this = querystringify().getAMemberCall(name) and
+        this = querystringifyMember(name).getACall() and
         src = getAnArgument()
       )
     }
@@ -251,8 +272,16 @@ module querydashstring {
   /**
    * Gets a data flow source node for the query-string library.
    */
-  DataFlow::SourceNode querydashstring() {
+  deprecated DataFlow::SourceNode querydashstring() {
     result = DataFlow::moduleImport("query-string")
+  }
+
+
+  /**
+   * Gets a data flow source node for member `name` of the query-string library.
+   */
+  DataFlow::SourceNode querydashstringMember(string name) {
+    result = DataFlow::moduleMember("query-string", name)
   }
 
   /**
@@ -268,7 +297,7 @@ module querydashstring {
         name = "extract" or
         name = "parseUrl" or
         name = "stringify" |
-        this = querydashstring().getAMemberCall(name) and
+        this = querydashstringMember(name).getACall() and
         src = getAnArgument()
       )
     }
@@ -288,8 +317,16 @@ module url {
   /**
    * Gets a data flow source node for the url library.
    */
-  DataFlow::SourceNode url() {
+  deprecated DataFlow::SourceNode url() {
     result = DataFlow::moduleImport("url")
+  }
+
+
+  /**
+   * Gets a data flow source node for member `name` of the url library.
+   */
+  DataFlow::SourceNode urlMember(string name) {
+    result = DataFlow::moduleMember("url", name)
   }
 
   /**
@@ -304,7 +341,7 @@ module url {
         name = "parse" or
         name = "format" or
         name = "resolve" |
-        this = url().getAMemberCall(name) and
+        this = urlMember(name).getACall() and
         src = getAnArgument()
       )
     }
@@ -324,8 +361,15 @@ module querystring {
   /**
    * Gets a data flow source node for the querystring library.
    */
-  DataFlow::SourceNode querystring() {
+  deprecated DataFlow::SourceNode querystring() {
     result = DataFlow::moduleImport("querystring")
+  }
+
+  /**
+   * Gets a data flow source node for member `name` of the querystring library.
+   */
+  DataFlow::SourceNode querystringMember(string name) {
+    result = DataFlow::moduleMember("querystring", name)
   }
 
   /**
@@ -341,7 +385,7 @@ module querystring {
         name = "unescape" or
         name = "parse" or
         name = "stringify" |
-        this = querystring().getAMemberCall(name) and
+        this = querystringMember(name).getACall() and
         src = getAnArgument()
       )
     }

--- a/javascript/ql/test/library-tests/frameworks/UriLibraries/UriLibraryStep.expected
+++ b/javascript/ql/test/library-tests/frameworks/UriLibraries/UriLibraryStep.expected
@@ -6,6 +6,7 @@
 | query-string.js:5:5:5:26 | querySt ... ract(x) | query-string.js:5:25:5:25 | x | query-string.js:5:5:5:26 | querySt ... ract(x) |
 | query-string.js:7:5:7:27 | querySt ... eUrl(x) | query-string.js:7:26:7:26 | x | query-string.js:7:5:7:27 | querySt ... eUrl(x) |
 | query-string.js:9:5:9:28 | querySt ... gify(x) | query-string.js:9:27:9:27 | x | query-string.js:9:5:9:28 | querySt ... gify(x) |
+| query-string_import.js:3:1:3:8 | parse(x) | query-string_import.js:3:7:3:7 | x | query-string_import.js:3:1:3:8 | parse(x) |
 | querystring.js:3:9:3:29 | queryst ... cape(x) | querystring.js:3:28:3:28 | x | querystring.js:3:9:3:29 | queryst ... cape(x) |
 | querystring.js:5:5:5:24 | querystring.parse(x) | querystring.js:5:23:5:23 | x | querystring.js:5:5:5:24 | querystring.parse(x) |
 | querystring.js:7:5:7:28 | queryst ... gify(x) | querystring.js:7:27:7:27 | x | querystring.js:7:5:7:28 | queryst ... gify(x) |

--- a/javascript/ql/test/library-tests/frameworks/UriLibraries/punycode.expected
+++ b/javascript/ql/test/library-tests/frameworks/UriLibraries/punycode.expected
@@ -1,1 +1,4 @@
-| punycode.js:1:16:1:34 | require("punycode") |
+| punycode.js:3:9:3:23 | punycode.decode |
+| punycode.js:5:5:5:19 | punycode.encode |
+| punycode.js:7:5:7:22 | punycode.toUnicode |
+| punycode.js:9:5:9:20 | punycode.toASCII |

--- a/javascript/ql/test/library-tests/frameworks/UriLibraries/punycode.ql
+++ b/javascript/ql/test/library-tests/frameworks/UriLibraries/punycode.ql
@@ -1,5 +1,5 @@
 import javascript
 
 from DataFlow::Node n
-where n = punycode::punycode()
+where n = punycode::punycodeMember(_)
 select n

--- a/javascript/ql/test/library-tests/frameworks/UriLibraries/query-string_import.js
+++ b/javascript/ql/test/library-tests/frameworks/UriLibraries/query-string_import.js
@@ -1,0 +1,3 @@
+import { parse } from "query-string";
+
+parse(x);

--- a/javascript/ql/test/library-tests/frameworks/UriLibraries/querydashstring.expected
+++ b/javascript/ql/test/library-tests/frameworks/UriLibraries/querydashstring.expected
@@ -1,1 +1,5 @@
-| query-string.js:1:19:1:41 | require ... tring") |
+| query-string.js:3:9:3:25 | queryString.parse |
+| query-string.js:5:5:5:23 | queryString.extract |
+| query-string.js:7:5:7:24 | queryString.parseUrl |
+| query-string.js:9:5:9:25 | querySt ... ringify |
+| query-string_import.js:1:10:1:14 | parse |

--- a/javascript/ql/test/library-tests/frameworks/UriLibraries/querydashstring.ql
+++ b/javascript/ql/test/library-tests/frameworks/UriLibraries/querydashstring.ql
@@ -1,5 +1,5 @@
 import javascript
 
 from DataFlow::Node n
-where n = querydashstring::querydashstring()
+where n = querydashstring::querydashstringMember(_)
 select n

--- a/javascript/ql/test/library-tests/frameworks/UriLibraries/querystring.expected
+++ b/javascript/ql/test/library-tests/frameworks/UriLibraries/querystring.expected
@@ -1,1 +1,4 @@
-| querystring.js:1:19:1:40 | require ... tring") |
+| querystring.js:3:9:3:26 | querystring.escape |
+| querystring.js:5:5:5:21 | querystring.parse |
+| querystring.js:7:5:7:25 | queryst ... ringify |
+| querystring.js:9:5:9:24 | querystring.unescape |

--- a/javascript/ql/test/library-tests/frameworks/UriLibraries/querystring.ql
+++ b/javascript/ql/test/library-tests/frameworks/UriLibraries/querystring.ql
@@ -1,5 +1,5 @@
 import javascript
 
 from DataFlow::Node n
-where n = querystring::querystring()
+where n = querystring::querystringMember(_)
 select n

--- a/javascript/ql/test/library-tests/frameworks/UriLibraries/querystringify.expected
+++ b/javascript/ql/test/library-tests/frameworks/UriLibraries/querystringify.expected
@@ -1,1 +1,2 @@
-| querystringify.js:1:22:1:46 | require ... ngify") |
+| querystringify.js:3:9:3:28 | querystringify.parse |
+| querystringify.js:5:5:5:28 | queryst ... ringify |

--- a/javascript/ql/test/library-tests/frameworks/UriLibraries/querystringify.ql
+++ b/javascript/ql/test/library-tests/frameworks/UriLibraries/querystringify.ql
@@ -1,5 +1,5 @@
 import javascript
 
 from DataFlow::Node n
-where n = querystringify::querystringify()
+where n = querystringify::querystringifyMember(_)
 select n

--- a/javascript/ql/test/library-tests/frameworks/UriLibraries/uridashjs.expected
+++ b/javascript/ql/test/library-tests/frameworks/UriLibraries/uridashjs.expected
@@ -1,1 +1,4 @@
-| uri-js.js:1:11:1:27 | require("uri-js") |
+| uri-js.js:3:9:3:17 | URI.parse |
+| uri-js.js:5:5:5:17 | URI.serialize |
+| uri-js.js:7:5:7:15 | URI.resolve |
+| uri-js.js:9:5:9:17 | URI.normalize |

--- a/javascript/ql/test/library-tests/frameworks/UriLibraries/uridashjs.ql
+++ b/javascript/ql/test/library-tests/frameworks/UriLibraries/uridashjs.ql
@@ -1,5 +1,5 @@
 import javascript
 
 from DataFlow::Node n
-where n = uridashjs::uridashjs()
+where n = uridashjs::uridashjsMember(_)
 select n

--- a/javascript/ql/test/library-tests/frameworks/UriLibraries/url.expected
+++ b/javascript/ql/test/library-tests/frameworks/UriLibraries/url.expected
@@ -1,1 +1,3 @@
-| url.js:1:11:1:24 | require("url") |
+| url.js:3:9:3:17 | url.parse |
+| url.js:5:5:5:14 | url.format |
+| url.js:7:5:7:15 | url.resolve |

--- a/javascript/ql/test/library-tests/frameworks/UriLibraries/url.ql
+++ b/javascript/ql/test/library-tests/frameworks/UriLibraries/url.ql
@@ -1,5 +1,5 @@
 import javascript
 
 from DataFlow::Node n
-where n = url::url()
+where n = url::urlMember(_)
 select n


### PR DESCRIPTION
As discussed.

I do not think a change note is required for each library.