### PR TITLE
C++: add support for custom wide character sizes 

### DIFF
--- a/cpp/ql/src/semmle/code/cpp/commons/Printf.qll
+++ b/cpp/ql/src/semmle/code/cpp/commons/Printf.qll
@@ -28,6 +28,15 @@ class AttributeFormattingFunction extends FormattingFunction {
   }
 }
 
+Type getAPrimitiveVariadicFormatterWideType() {
+  exists(TopLevelFunction f, int formatParamIndex |
+    primitiveVariadicFormatter(f, formatParamIndex, true) and
+    result = f.getParameter(formatParamIndex).getType().getUnspecifiedType() and
+    result.(PointerType).getBaseType().getSize() != 1 and
+    f.hasDefinition()
+  )
+}
+
 /**
  * A standard function such as `vprintf` that has a format parameter
  * and a variable argument list of type `va_arg`.
@@ -722,7 +731,13 @@ class FormatLiteral extends Literal {
 
   private Type getConversionType5(int n) {
     exists(string cnv | cnv = this.getEffectiveStringConversionChar(n) |
-      cnv="S" and result.(PointerType).getBaseType().hasName("wchar_t") 
+      cnv="S" and
+      (
+        result = getAPrimitiveVariadicFormatterWideType()
+        or
+        not exists(getAPrimitiveVariadicFormatterWideType()) and
+        result.(PointerType).getBaseType().hasName("wchar_t")
+      )
     )
   }
 

--- a/cpp/ql/src/semmle/code/cpp/commons/Printf.qll
+++ b/cpp/ql/src/semmle/code/cpp/commons/Printf.qll
@@ -28,6 +28,10 @@ class AttributeFormattingFunction extends FormattingFunction {
   }
 }
 
+/**
+ * A type that is used as a format string by a wide variadic formatter such as
+ * `vwprintf`.
+ */
 Type getAPrimitiveVariadicFormatterWideType() {
   exists(TopLevelFunction f, int formatParamIndex |
     primitiveVariadicFormatter(f, formatParamIndex, true) and

--- a/cpp/ql/src/semmle/code/cpp/commons/Printf.qll
+++ b/cpp/ql/src/semmle/code/cpp/commons/Printf.qll
@@ -30,14 +30,20 @@ class AttributeFormattingFunction extends FormattingFunction {
 
 /**
  * A type that is used as a format string by a wide variadic formatter such as
- * `vwprintf`.
+ * `vwprintf` or by a user-defined formatting function with the GNU `format`
+ * attribute.
  */
-Type getAPrimitiveVariadicFormatterWideType() {
+Type getAFormatterWideType() {
   exists(TopLevelFunction f, int formatParamIndex |
     primitiveVariadicFormatter(f, formatParamIndex, true) and
     result = f.getParameter(formatParamIndex).getType().getUnspecifiedType() and
     result.(PointerType).getBaseType().getSize() != 1 and
     f.hasDefinition()
+  )
+  or
+  exists(AttributeFormattingFunction f, int formatParamIndex |
+    result = f.getParameter(formatParamIndex).getType().getUnspecifiedType() and
+    result.(PointerType).getBaseType().getSize() != 1
   )
 }
 
@@ -737,9 +743,9 @@ class FormatLiteral extends Literal {
     exists(string cnv | cnv = this.getEffectiveStringConversionChar(n) |
       cnv="S" and
       (
-        result = getAPrimitiveVariadicFormatterWideType()
+        result = getAFormatterWideType()
         or
-        not exists(getAPrimitiveVariadicFormatterWideType()) and
+        not exists(getAFormatterWideType()) and
         result.(PointerType).getBaseType().hasName("wchar_t")
       )
     )

--- a/cpp/ql/src/semmle/code/cpp/models/implementations/Printf.qll
+++ b/cpp/ql/src/semmle/code/cpp/models/implementations/Printf.qll
@@ -13,7 +13,7 @@ class Printf extends FormattingFunction {
       hasGlobalName("wprintf_s") or
       hasGlobalName("g_printf")
     ) and
-    not hasDefinition()
+    not exists(getADeclarationEntry().getFile().getRelativePath())
   }
 
   override int getFormatParameterIndex() { result=0 }
@@ -34,7 +34,7 @@ class Fprintf extends FormattingFunction {
       hasGlobalName("fwprintf") or
       hasGlobalName("g_fprintf")
     ) and
-    not hasDefinition()
+    not exists(getADeclarationEntry().getFile().getRelativePath())
   }
 
   override int getFormatParameterIndex() { result=1 }
@@ -57,7 +57,7 @@ class Sprintf extends FormattingFunction {
       hasGlobalName("g_sprintf") or
       hasGlobalName("__builtin___sprintf_chk")
     ) and
-    not hasDefinition()
+    not exists(getADeclarationEntry().getFile().getRelativePath())
   }
 
   override predicate isWideCharDefault() {
@@ -111,7 +111,7 @@ class Snprintf extends FormattingFunction {
       or hasGlobalName("wnsprintf")
       or hasGlobalName("__builtin___snprintf_chk")
     ) and
-    not hasDefinition()
+    not exists(getADeclarationEntry().getFile().getRelativePath())
   }
 
   override int getFormatParameterIndex() {
@@ -150,7 +150,7 @@ class Snprintf extends FormattingFunction {
       hasGlobalName("__builtin___snprintf_chk") or
       hasGlobalName("snprintf_s")
     ) and
-    not hasDefinition()
+    not exists(getADeclarationEntry().getFile().getRelativePath())
   }
 
   override int getSizeParameterIndex() {
@@ -173,7 +173,7 @@ class StringCchPrintf extends FormattingFunction {
       or hasGlobalName("StringCbPrintf_l")
       or hasGlobalName("StringCbPrintf_lEx")
     ) and
-    not hasDefinition()
+    not exists(getADeclarationEntry().getFile().getRelativePath())
   }
 
   override int getFormatParameterIndex() {

--- a/cpp/ql/src/semmle/code/cpp/models/implementations/Printf.qll
+++ b/cpp/ql/src/semmle/code/cpp/models/implementations/Printf.qll
@@ -12,7 +12,8 @@ class Printf extends FormattingFunction {
       hasGlobalName("wprintf") or
       hasGlobalName("wprintf_s") or
       hasGlobalName("g_printf")
-    )
+    ) and
+    not hasDefinition()
   }
 
   override int getFormatParameterIndex() { result=0 }
@@ -26,7 +27,15 @@ class Printf extends FormattingFunction {
  * The standard functions `fprintf`, `fwprintf` and their glib variants.
  */
 class Fprintf extends FormattingFunction {
-  Fprintf() { this instanceof TopLevelFunction and (hasGlobalName("fprintf") or hasGlobalName("fwprintf") or hasGlobalName("g_fprintf"))}
+  Fprintf() {
+    this instanceof TopLevelFunction and
+    (
+      hasGlobalName("fprintf") or
+      hasGlobalName("fwprintf") or
+      hasGlobalName("g_fprintf")
+    ) and
+    not hasDefinition()
+  }
 
   override int getFormatParameterIndex() { result=1 }
   override predicate isWideCharDefault() { hasGlobalName("fwprintf") }
@@ -47,7 +56,8 @@ class Sprintf extends FormattingFunction {
       hasGlobalName("g_strdup_printf") or
       hasGlobalName("g_sprintf") or
       hasGlobalName("__builtin___sprintf_chk")
-    )
+    ) and
+    not hasDefinition()
   }
 
   override predicate isWideCharDefault() {
@@ -100,7 +110,8 @@ class Snprintf extends FormattingFunction {
       or hasGlobalName("g_snprintf")
       or hasGlobalName("wnsprintf")
       or hasGlobalName("__builtin___snprintf_chk")
-    )
+    ) and
+    not hasDefinition()
   }
 
   override int getFormatParameterIndex() {
@@ -133,10 +144,13 @@ class Snprintf extends FormattingFunction {
    * in the buffer.
    */
   predicate returnsFullFormatLength() {
-    hasGlobalName("snprintf") or
-    hasGlobalName("g_snprintf") or
-    hasGlobalName("__builtin___snprintf_chk") or
-    hasGlobalName("snprintf_s")
+    (
+      hasGlobalName("snprintf") or
+      hasGlobalName("g_snprintf") or
+      hasGlobalName("__builtin___snprintf_chk") or
+      hasGlobalName("snprintf_s")
+    ) and
+    not hasDefinition()
   }
 
   override int getSizeParameterIndex() {
@@ -158,7 +172,8 @@ class StringCchPrintf extends FormattingFunction {
       or hasGlobalName("StringCbPrintfEx")
       or hasGlobalName("StringCbPrintf_l")
       or hasGlobalName("StringCbPrintf_lEx")
-    )
+    ) and
+    not hasDefinition()
   }
 
   override int getFormatParameterIndex() {
@@ -187,7 +202,8 @@ class Syslog extends FormattingFunction {
   Syslog() {
     this instanceof TopLevelFunction and (
       hasGlobalName("syslog")
-    )
+    ) and
+    not hasDefinition()
   }
 
   override int getFormatParameterIndex() { result=1 }

--- a/cpp/ql/test/query-tests/Likely Bugs/Format/WrongTypeFormatArguments/Linux_two_byte_wprintf/WrongTypeFormatArguments.expected
+++ b/cpp/ql/test/query-tests/Likely Bugs/Format/WrongTypeFormatArguments/Linux_two_byte_wprintf/WrongTypeFormatArguments.expected
@@ -1,0 +1,2 @@
+| printf.cpp:43:29:43:35 | test | This argument should be of type 'char *' but is of type 'char16_t *' |
+| printf.cpp:50:29:50:35 | test | This argument should be of type 'char16_t *' but is of type 'wchar_t *' |

--- a/cpp/ql/test/query-tests/Likely Bugs/Format/WrongTypeFormatArguments/Linux_two_byte_wprintf/WrongTypeFormatArguments.qlref
+++ b/cpp/ql/test/query-tests/Likely Bugs/Format/WrongTypeFormatArguments/Linux_two_byte_wprintf/WrongTypeFormatArguments.qlref
@@ -1,0 +1,1 @@
+Likely Bugs/Format/WrongTypeFormatArguments.ql

--- a/cpp/ql/test/query-tests/Likely Bugs/Format/WrongTypeFormatArguments/Linux_two_byte_wprintf/printf.cpp
+++ b/cpp/ql/test/query-tests/Likely Bugs/Format/WrongTypeFormatArguments/Linux_two_byte_wprintf/printf.cpp
@@ -1,0 +1,51 @@
+/*
+ * Test for custom definitions of *wprintf using different types than the
+ * platform wide character type.
+ */
+
+#define WCHAR char16_t
+typedef void *va_list;
+#define va_start(va, other)
+#define va_end(args)
+
+int	vswprintf(WCHAR *dest, WCHAR *format, va_list args) {
+	return 0;
+}
+
+int swprintf(WCHAR *dest, WCHAR *format, ...) {
+	va_list args;
+	va_start(args, format);
+
+	int ret = vswprintf(dest, format, args);
+
+	va_end(args);
+
+	return ret;
+}
+
+int sprintf(char *dest, char *format, ...);
+
+void test1() {
+	WCHAR string[20];
+
+	swprintf(string, u"test %s", u"test");
+}
+
+void test2() {
+	char string[20];
+
+	sprintf(string, "test %S", u"test");
+}
+
+void test3() {
+	char string[20];
+
+	sprintf(string, "test %s", u"test");
+}
+
+
+void test4() {
+	char string[20];
+
+	sprintf(string, "test %S", L"test");
+}


### PR DESCRIPTION
Certain Microsoft projects, such as CoreCLR and ChakraCore, use a
library called the PAL, which enables two-byte strings in the printf
family of functions, even when built on a platform with four-byte
strings. This adds support for determining the size of a wide character
from the definitions of such functions, rather than assuming that they
match the compiler's wchar_t.