### PR TITLE
C++: test for __declspec(guard(...))

### DIFF
--- a/cpp/ql/test/library-tests/declspec/guard/test.cpp
+++ b/cpp/ql/test/library-tests/declspec/guard/test.cpp
@@ -1,0 +1,8 @@
+// semmle-extractor-options: --edg --microsoft
+
+void f(__declspec(guard(overflow)) size_t length) {
+}
+
+__declspec(guard(ignore))
+void g(void) {
+}

--- a/cpp/ql/test/library-tests/declspec/guard/test.expected
+++ b/cpp/ql/test/library-tests/declspec/guard/test.expected
@@ -1,0 +1,2 @@
+| test.cpp:3:6:3:6 | f | 0 | length |
+| test.cpp:7:6:7:6 | g | -1 | <none> |

--- a/cpp/ql/test/library-tests/declspec/guard/test.ql
+++ b/cpp/ql/test/library-tests/declspec/guard/test.ql
@@ -1,0 +1,10 @@
+import cpp
+
+// What we select here isn't too important; we're just testing the
+// __declspec(guard(...)) attributes don't cause extractor errors.
+
+from Function f, string p, int n
+where if f.getNumberOfParameters() = 0
+  then (p = "<none>" and n = -1)
+  else p = f.getParameter(n).toString()
+select f, n, p


### PR DESCRIPTION
We see projects in the wild using `__declspec(guard(...))` with MSVC. This PR adds a test to show they don't cause any errors; it depends on a corresponding change in the extractor.