### PR TITLE
C++: remove all uses of deprecated 'extractor_flags'

### DIFF
--- a/cpp/ql/test/library-tests/CPP-207/options
+++ b/cpp/ql/test/library-tests/CPP-207/options
@@ -1,1 +1,1 @@
-extractor_flags: --edg --microsoft
+semmle-extractor-options: --edg --microsoft

--- a/cpp/ql/test/library-tests/__builtin_constant_p/options
+++ b/cpp/ql/test/library-tests/__builtin_constant_p/options
@@ -1,1 +1,1 @@
-extractor_flags: --expect_errors
+semmle-extractor-options: --expect_errors

--- a/cpp/ql/test/library-tests/abi/options
+++ b/cpp/ql/test/library-tests/abi/options
@@ -1,1 +1,1 @@
-extractor_flags: --expect_errors
+semmle-extractor-options: --expect_errors

--- a/cpp/ql/test/library-tests/allocators/allocators.cpp
+++ b/cpp/ql/test/library-tests/allocators/allocators.cpp
@@ -1,4 +1,4 @@
-// extractor_flags: -std=c++17
+// semmle-extractor-options: -std=c++17
 typedef unsigned long size_t;
 namespace std {
   enum class align_val_t : size_t {};

--- a/cpp/ql/test/library-tests/anachronisms/options
+++ b/cpp/ql/test/library-tests/anachronisms/options
@@ -1,2 +1,2 @@
-extractor_flags: --edg --anachronisms
+semmle-extractor-options: --edg --anachronisms
 

--- a/cpp/ql/test/library-tests/atomic/options
+++ b/cpp/ql/test/library-tests/atomic/options
@@ -1,1 +1,1 @@
-extractor_flags: --clang
+semmle-extractor-options: --clang

--- a/cpp/ql/test/library-tests/attributes/availability/options
+++ b/cpp/ql/test/library-tests/attributes/availability/options
@@ -1,1 +1,1 @@
-extractor_flags: --edg --clang
+semmle-extractor-options: --edg --clang

--- a/cpp/ql/test/library-tests/attributes/enumerators/options
+++ b/cpp/ql/test/library-tests/attributes/enumerators/options
@@ -1,1 +1,1 @@
-extractor_flags: --clang
+semmle-extractor-options: --clang

--- a/cpp/ql/test/library-tests/attributes/ms_repeated/options
+++ b/cpp/ql/test/library-tests/attributes/ms_repeated/options
@@ -1,1 +1,1 @@
-extractor_flags: --microsoft --microsoft_version 1700
+semmle-extractor-options: --microsoft --microsoft_version 1700

--- a/cpp/ql/test/library-tests/attributes/sal/options
+++ b/cpp/ql/test/library-tests/attributes/sal/options
@@ -1,1 +1,1 @@
-extractor_flags: --microsoft --microsoft_version 1700
+semmle-extractor-options: --microsoft --microsoft_version 1700

--- a/cpp/ql/test/library-tests/blocks/c/options
+++ b/cpp/ql/test/library-tests/blocks/c/options
@@ -1,1 +1,1 @@
-extractor_flags: -fblocks
+semmle-extractor-options: -fblocks

--- a/cpp/ql/test/library-tests/blocks/capture/options
+++ b/cpp/ql/test/library-tests/blocks/capture/options
@@ -1,1 +1,1 @@
-extractor_flags: -fblocks
+semmle-extractor-options: -fblocks

--- a/cpp/ql/test/library-tests/blocks/cpp/options
+++ b/cpp/ql/test/library-tests/blocks/cpp/options
@@ -1,1 +1,1 @@
-extractor_flags: -fblocks
+semmle-extractor-options: -fblocks

--- a/cpp/ql/test/library-tests/blocks/deduplication/options
+++ b/cpp/ql/test/library-tests/blocks/deduplication/options
@@ -1,1 +1,1 @@
-extractor_flags: -fblocks
+semmle-extractor-options: -fblocks

--- a/cpp/ql/test/library-tests/builtins/type_traits/options
+++ b/cpp/ql/test/library-tests/builtins/type_traits/options
@@ -1,1 +1,1 @@
-extractor_flags: --microsoft --microsoft_version 1600
+semmle-extractor-options: --microsoft --microsoft_version 1600

--- a/cpp/ql/test/library-tests/c_overload/options
+++ b/cpp/ql/test/library-tests/c_overload/options
@@ -1,1 +1,1 @@
-extractor_flags: --clang
+semmle-extractor-options: --clang

--- a/cpp/ql/test/library-tests/clang_builtin_macros/options
+++ b/cpp/ql/test/library-tests/clang_builtin_macros/options
@@ -1,1 +1,1 @@
-extractor_flags: --edg --clang
+semmle-extractor-options: --edg --clang

--- a/cpp/ql/test/library-tests/clang_ms/options
+++ b/cpp/ql/test/library-tests/clang_ms/options
@@ -1,1 +1,1 @@
-extractor_flags: --edg --clang --edg --ms_extensions
+semmle-extractor-options: --edg --clang --edg --ms_extensions

--- a/cpp/ql/test/library-tests/conditions/options
+++ b/cpp/ql/test/library-tests/conditions/options
@@ -1,1 +1,1 @@
-extractor_flags: --expect_errors
+semmle-extractor-options: --expect_errors

--- a/cpp/ql/test/library-tests/controlflow/assume/options
+++ b/cpp/ql/test/library-tests/controlflow/assume/options
@@ -1,1 +1,1 @@
-extractor_flags: --microsoft
+semmle-extractor-options: --microsoft

--- a/cpp/ql/test/library-tests/diagnostics/options
+++ b/cpp/ql/test/library-tests/diagnostics/options
@@ -1,1 +1,1 @@
-extractor_flags: --expect_errors
+semmle-extractor-options: --expect_errors

--- a/cpp/ql/test/library-tests/digraphs/options
+++ b/cpp/ql/test/library-tests/digraphs/options
@@ -1,1 +1,1 @@
-extractor_flags: --gnu_version 40801
+semmle-extractor-options: --gnu_version 40801

--- a/cpp/ql/test/library-tests/exprs_cast/options
+++ b/cpp/ql/test/library-tests/exprs_cast/options
@@ -1,1 +1,1 @@
-extractor_flags: --edg --target --edg win64
+semmle-extractor-options: --edg --target --edg win64

--- a/cpp/ql/test/library-tests/funcdname/options
+++ b/cpp/ql/test/library-tests/funcdname/options
@@ -1,1 +1,1 @@
-extractor_flags: --microsoft
+semmle-extractor-options: --microsoft

--- a/cpp/ql/test/library-tests/functionpointerish/options
+++ b/cpp/ql/test/library-tests/functionpointerish/options
@@ -1,1 +1,1 @@
-extractor_flags: -fblocks
+semmle-extractor-options: -fblocks

--- a/cpp/ql/test/library-tests/includes/non_existent/options
+++ b/cpp/ql/test/library-tests/includes/non_existent/options
@@ -1,1 +1,1 @@
-extractor_flags: --expect_errors
+semmle-extractor-options: --expect_errors

--- a/cpp/ql/test/library-tests/opts/options
+++ b/cpp/ql/test/library-tests/opts/options
@@ -1,1 +1,1 @@
-extractor_flags: --microsoft
+semmle-extractor-options: --microsoft

--- a/cpp/ql/test/library-tests/static_assert/options
+++ b/cpp/ql/test/library-tests/static_assert/options
@@ -1,1 +1,1 @@
-extractor_flags: --edg --target --edg win64
+semmle-extractor-options: --edg --target --edg win64

--- a/cpp/ql/test/library-tests/static_cast/options
+++ b/cpp/ql/test/library-tests/static_cast/options
@@ -1,1 +1,1 @@
-extractor_flags: --microsoft --edg --no_preserve_lvalues_with_same_type_casts
+semmle-extractor-options: --microsoft --edg --no_preserve_lvalues_with_same_type_casts

--- a/cpp/ql/test/library-tests/stmt/generated_blocks/options
+++ b/cpp/ql/test/library-tests/stmt/generated_blocks/options
@@ -1,1 +1,1 @@
-extractor_flags: -std=gnu99
+semmle-extractor-options: -std=gnu99

--- a/cpp/ql/test/library-tests/store_pointer_to_member/options
+++ b/cpp/ql/test/library-tests/store_pointer_to_member/options
@@ -1,1 +1,1 @@
-extractor_flags: --gnu_version 40400
+semmle-extractor-options: --gnu_version 40400

--- a/cpp/ql/test/library-tests/templates/variables/options
+++ b/cpp/ql/test/library-tests/templates/variables/options
@@ -1,1 +1,1 @@
-extractor_flags: -std=c++14
+semmle-extractor-options: -std=c++14

--- a/cpp/ql/test/library-tests/ti_compiler/options
+++ b/cpp/ql/test/library-tests/ti_compiler/options
@@ -1,1 +1,1 @@
-extractor_flags: --edg --ti
+semmle-extractor-options: --edg --ti

--- a/cpp/ql/test/library-tests/type_sizes/options
+++ b/cpp/ql/test/library-tests/type_sizes/options
@@ -1,1 +1,1 @@
-extractor_flags: -fblocks
+semmle-extractor-options: -fblocks

--- a/cpp/ql/test/library-tests/types/__wchar_t/options
+++ b/cpp/ql/test/library-tests/types/__wchar_t/options
@@ -1,1 +1,1 @@
-extractor_flags: --microsoft
+semmle-extractor-options: --microsoft

--- a/cpp/ql/test/library-tests/types/integral_types_ms/options
+++ b/cpp/ql/test/library-tests/types/integral_types_ms/options
@@ -1,1 +1,1 @@
-extractor_flags: --microsoft --edg --target --edg win64
+semmle-extractor-options: --microsoft --edg --target --edg win64

--- a/cpp/ql/test/library-tests/types/pointertypes/options
+++ b/cpp/ql/test/library-tests/types/pointertypes/options
@@ -1,1 +1,1 @@
-extractor_flags: -std=c99
+semmle-extractor-options: -std=c99

--- a/cpp/ql/test/library-tests/types/types/options
+++ b/cpp/ql/test/library-tests/types/types/options
@@ -1,2 +1,2 @@
-extractor_flags: --gnu_version 40700
+semmle-extractor-options: --gnu_version 40700
 

--- a/cpp/ql/test/library-tests/types/wchar_t_typedef/options
+++ b/cpp/ql/test/library-tests/types/wchar_t_typedef/options
@@ -1,1 +1,1 @@
-extractor_flags: --microsoft --edg --target --edg win32
+semmle-extractor-options: --microsoft --edg --target --edg win32

--- a/cpp/ql/test/library-tests/udl/options
+++ b/cpp/ql/test/library-tests/udl/options
@@ -1,1 +1,1 @@
-extractor_flags: --gnu_version 40801 --clang -Xclang-only=-Wno-reserved-user-defined-literal
+semmle-extractor-options: --gnu_version 40801 --clang -Xclang-only=-Wno-reserved-user-defined-literal

--- a/cpp/ql/test/library-tests/unions/options
+++ b/cpp/ql/test/library-tests/unions/options
@@ -1,1 +1,1 @@
-extractor_flags: --microsoft
+semmle-extractor-options: --microsoft

--- a/cpp/ql/test/library-tests/vector_types/options
+++ b/cpp/ql/test/library-tests/vector_types/options
@@ -1,1 +1,1 @@
-extractor_flags: --edg --clang --edg --clang_builtin_functions --edg --clang_vector_types --gnu_version 40600
+semmle-extractor-options: --edg --clang --edg --clang_builtin_functions --edg --clang_vector_types --gnu_version 40600

--- a/cpp/ql/test/query-tests/Critical/NewFree/options
+++ b/cpp/ql/test/query-tests/Critical/NewFree/options
@@ -1,1 +1,1 @@
-extractor_flags = --microsoft
+semmle-extractor-options: --microsoft

--- a/cpp/ql/test/query-tests/Likely Bugs/Format/WrongTypeFormatArguments/Linux_signed_chars/options
+++ b/cpp/ql/test/query-tests/Likely Bugs/Format/WrongTypeFormatArguments/Linux_signed_chars/options
@@ -1,1 +1,1 @@
-extractor_flags: --edg --signed_chars
+semmle-extractor-options: --edg --signed_chars

--- a/cpp/ql/test/query-tests/Likely Bugs/Format/WrongTypeFormatArguments/Linux_unsigned_chars/options
+++ b/cpp/ql/test/query-tests/Likely Bugs/Format/WrongTypeFormatArguments/Linux_unsigned_chars/options
@@ -1,1 +1,1 @@
-extractor_flags: --edg --unsigned_chars
+semmle-extractor-options: --edg --unsigned_chars

--- a/cpp/ql/test/query-tests/Likely Bugs/Format/WrongTypeFormatArguments/Microsoft/options
+++ b/cpp/ql/test/query-tests/Likely Bugs/Format/WrongTypeFormatArguments/Microsoft/options
@@ -1,1 +1,1 @@
-extractor_flags: --microsoft --edg --target --edg win64
+semmle-extractor-options: --microsoft --edg --target --edg win64

--- a/cpp/ql/test/query-tests/Likely Bugs/Format/WrongTypeFormatArguments/Microsoft_no_wchar/options
+++ b/cpp/ql/test/query-tests/Likely Bugs/Format/WrongTypeFormatArguments/Microsoft_no_wchar/options
@@ -1,1 +1,1 @@
-extractor_flags: --microsoft /Zc:wchar_t- --edg --target --edg win64
+semmle-extractor-options: --microsoft /Zc:wchar_t- --edg --target --edg win64

--- a/cpp/ql/test/successor-tests/deleteexpr/allocators/options
+++ b/cpp/ql/test/successor-tests/deleteexpr/allocators/options
@@ -1,2 +1,2 @@
-extractor_flags: --microsoft
+semmle-extractor-options: --microsoft
 


### PR DESCRIPTION
They cause deprecation warnings and can be safely replaced with `semmle-extractor-options`.