### PR TITLE
JS: fix an off-by-one error in the AngularJS expression AST

### DIFF
--- a/javascript/ql/src/semmle/javascript/frameworks/AngularJS/AngularJSExpressions.qll
+++ b/javascript/ql/src/semmle/javascript/frameworks/AngularJS/AngularJSExpressions.qll
@@ -592,7 +592,7 @@ class NgSingleFilter extends TNgSingleFilter, NgAstNode {
    * Gets the `i`th argument expression of this filter call.
    */
   NgExpr getArgument(int i) {
-    result = getChild(1).(NgFilterArgument).getElement(i)
+    result = getChild(0).(NgFilterArgument).getElement(i)
   }
 
 }

--- a/javascript/ql/test/library-tests/frameworks/AngularJS/expressions/parsing/NgCallExpr_getArgument.expected
+++ b/javascript/ql/test/library-tests/frameworks/AngularJS/expressions/parsing/NgCallExpr_getArgument.expected
@@ -1,0 +1,7 @@
+| (NgCallExpr: (NgVarExpr: VAR18a) (NgConsCallArgument: (NgVarExpr: VAR18b))) | 0 | (NgVarExpr: VAR18b) |
+| (NgCallExpr: (NgVarExpr: VAR19a) (NgConsCallArgument: (NgVarExpr: VAR19b) (NgConsCallArgument: (NgVarExpr: VAR19c)))) | 0 | (NgVarExpr: VAR19b) |
+| (NgCallExpr: (NgVarExpr: VAR19a) (NgConsCallArgument: (NgVarExpr: VAR19b) (NgConsCallArgument: (NgVarExpr: VAR19c)))) | 1 | (NgVarExpr: VAR19c) |
+| (NgCallExpr: (NgVarExpr: VAR20) (NgConsCallArgument: 20)) | 0 | 20 |
+| (NgCallExpr: (NgVarExpr: VAR21) (NgConsCallArgument: 'string21')) | 0 | 'string21' |
+| (NgCallExpr: (NgVarExpr: VAR22a) (NgConsCallArgument: (NgVarExpr: VAR22b) (NgConsCallArgument: 'string22'))) | 0 | (NgVarExpr: VAR22b) |
+| (NgCallExpr: (NgVarExpr: VAR22a) (NgConsCallArgument: (NgVarExpr: VAR22b) (NgConsCallArgument: 'string22'))) | 1 | 'string22' |

--- a/javascript/ql/test/library-tests/frameworks/AngularJS/expressions/parsing/NgCallExpr_getArgument.ql
+++ b/javascript/ql/test/library-tests/frameworks/AngularJS/expressions/parsing/NgCallExpr_getArgument.ql
@@ -1,0 +1,5 @@
+import javascript
+private import AngularJS
+
+from NgCallExpr call, int i
+select call, i, call.getArgument(i)

--- a/javascript/ql/test/library-tests/frameworks/AngularJS/expressions/parsing/NgSingleFilter_getArgument.expected
+++ b/javascript/ql/test/library-tests/frameworks/AngularJS/expressions/parsing/NgSingleFilter_getArgument.expected
@@ -1,0 +1,8 @@
+| (NgSingleFilter: FILTER10 (NgFilterArgument: (NgVarExpr: FILTER_ARG10))) | 0 | (NgVarExpr: FILTER_ARG10) |
+| (NgSingleFilter: FILTER11 (NgFilterArgument: (NgVarExpr: FILTER_ARG11a) (NgFilterArgument: (NgVarExpr: FILTER_ARG11b)))) | 0 | (NgVarExpr: FILTER_ARG11a) |
+| (NgSingleFilter: FILTER11 (NgFilterArgument: (NgVarExpr: FILTER_ARG11a) (NgFilterArgument: (NgVarExpr: FILTER_ARG11b)))) | 1 | (NgVarExpr: FILTER_ARG11b) |
+| (NgSingleFilter: FILTER14a (NgFilterArgument: (NgVarExpr: FILTER_ARG14a))) | 0 | (NgVarExpr: FILTER_ARG14a) |
+| (NgSingleFilter: FILTER15 (NgFilterArgument: (NgDotExpr: (NgVarExpr: VAR15).FIELD15))) | 0 | (NgDotExpr: (NgVarExpr: VAR15).FIELD15) |
+| (NgSingleFilter: FILTER15 (NgFilterArgument: (NgVarExpr: VAR15))) | 0 | (NgVarExpr: VAR15) |
+| (NgSingleFilter: FILTER16 (NgFilterArgument: 16)) | 0 | 16 |
+| (NgSingleFilter: FILTER_ARG11a (NgFilterArgument: (NgVarExpr: FILTER_ARG11b))) | 0 | (NgVarExpr: FILTER_ARG11b) |

--- a/javascript/ql/test/library-tests/frameworks/AngularJS/expressions/parsing/NgSingleFilter_getArgument.ql
+++ b/javascript/ql/test/library-tests/frameworks/AngularJS/expressions/parsing/NgSingleFilter_getArgument.ql
@@ -1,0 +1,5 @@
+import javascript
+private import AngularJS
+
+from NgSingleFilter filter, int i
+select filter, i, filter.getArgument(i)


### PR DESCRIPTION
This PR make `NgsingleFilter:getArgument` use a zero-offset for its arguments.
This PR also adds two tests to prevent related regressions.