### PR TITLE
C++: Downgrade cpp/incomplete-parity-check from high to medium precision [CPP-236]

### DIFF
--- a/cpp/ql/src/Likely Bugs/Arithmetic/BadCheckOdd.ql
+++ b/cpp/ql/src/Likely Bugs/Arithmetic/BadCheckOdd.ql
@@ -4,7 +4,7 @@
  *              negative numbers.
  * @kind problem
  * @problem.severity warning
- * @precision high
+ * @precision medium
  * @id cpp/incomplete-parity-check
  * @tags reliability
  *       correctness


### PR DESCRIPTION
As reported in CPP-236, this query has false positives on signed integers that cannot be negative. It could possibly be improved with a local range analysis, but the query would most likely still have so many false positives that we would have to lower its precision.

Under our current policy, this change will make the query hidden by default on LGTM.