### PR TITLE
JS: change alert location for js/incomplete-object-initialization

### DIFF
--- a/change-notes/1.18/analysis-javascript.md
+++ b/change-notes/1.18/analysis-javascript.md
@@ -47,6 +47,7 @@
 | Uncontrolled command line | More true-positive results | This rule now recognizes indirect command injection through `sh -c` and similar. |
 | Unused variable | Fewer results | This rule no longer flags class expressions that could be made anonymous. While technically true, these results are not interesting. |
 | Unused variable | Renamed | This rule has been renamed to "Unused variable, import, function or class" to reflect the fact that it flags different kinds of unused program elements. |
+| Use of incompletely initialized object| Fewer results | This rule now flags the constructor instead its errorneous `this` or `super` expressions. |
 
 ## Changes to QL libraries
 

--- a/javascript/ql/src/LanguageFeatures/ThisBeforeSuper.ql
+++ b/javascript/ql/src/LanguageFeatures/ThisBeforeSuper.ql
@@ -11,6 +11,7 @@
  */
 
 import javascript
+import semmle.javascript.RestrictedLocations
 
 /**
  * Holds if `e` is an expression of the given `kind` that must be guarded by a
@@ -59,4 +60,4 @@ where needsGuard(e, kind) and unguarded(e, ctor) and
         sc.getBinder() = ctor and
         sc.getEnclosingFunction() != ctor
       )
-select ctor, "The super constructor must be called before using '$@'.", e, kind
+select (FirstLineOf)ctor, "The super constructor must be called before using '$@'.", e, kind

--- a/javascript/ql/src/LanguageFeatures/ThisBeforeSuper.ql
+++ b/javascript/ql/src/LanguageFeatures/ThisBeforeSuper.ql
@@ -59,4 +59,4 @@ where needsGuard(e, kind) and unguarded(e, ctor) and
         sc.getBinder() = ctor and
         sc.getEnclosingFunction() != ctor
       )
-select e, "The super constructor must be called before using '" + kind + "'."
+select ctor, "The super constructor must be called before using '$@'.", e, kind

--- a/javascript/ql/test/query-tests/LanguageFeatures/ThisBeforeSuper/ThisBeforeSuper.expected
+++ b/javascript/ql/test/query-tests/LanguageFeatures/ThisBeforeSuper/ThisBeforeSuper.expected
@@ -10,5 +10,5 @@
 | invalid.js:14:35:14:118 | () { cl ... er(); } | The super constructor must be called before using '$@'. | invalid.js:14:99:14:102 | this | this |
 | invalid.js:15:71:15:95 | () { th ... er(); } | The super constructor must be called before using '$@'. | invalid.js:15:76:15:79 | this | this |
 | invalid.js:16:35:16:66 | () { if ... .a(); } | The super constructor must be called before using '$@'. | invalid.js:16:56:16:59 | this | this |
-| invalid.js:26:16:29:5 | () {\\n   ... ;\\n    } | The super constructor must be called before using '$@'. | invalid.js:27:9:27:12 | this | this |
-| invalid.js:26:16:29:5 | () {\\n   ... ;\\n    } | The super constructor must be called before using '$@'. | invalid.js:28:9:28:12 | this | this |
+| invalid.js:26:16:26:19 | () {\\n   ... ;\\n    } | The super constructor must be called before using '$@'. | invalid.js:27:9:27:12 | this | this |
+| invalid.js:26:16:26:19 | () {\\n   ... ;\\n    } | The super constructor must be called before using '$@'. | invalid.js:28:9:28:12 | this | this |

--- a/javascript/ql/test/query-tests/LanguageFeatures/ThisBeforeSuper/ThisBeforeSuper.expected
+++ b/javascript/ql/test/query-tests/LanguageFeatures/ThisBeforeSuper/ThisBeforeSuper.expected
@@ -1,12 +1,14 @@
-| invalid.js:5:40:5:43 | this | The super constructor must be called before using 'this'. |
-| invalid.js:6:40:6:43 | this | The super constructor must be called before using 'this'. |
-| invalid.js:7:40:7:46 | super.c | The super constructor must be called before using 'super'. |
-| invalid.js:8:40:8:43 | this | The super constructor must be called before using 'this'. |
-| invalid.js:9:40:9:43 | this | The super constructor must be called before using 'this'. |
-| invalid.js:10:40:10:46 | super.c | The super constructor must be called before using 'super'. |
-| invalid.js:11:46:11:49 | this | The super constructor must be called before using 'this'. |
-| invalid.js:12:46:12:49 | this | The super constructor must be called before using 'this'. |
-| invalid.js:13:46:13:52 | super.c | The super constructor must be called before using 'super'. |
-| invalid.js:14:99:14:102 | this | The super constructor must be called before using 'this'. |
-| invalid.js:15:76:15:79 | this | The super constructor must be called before using 'this'. |
-| invalid.js:16:56:16:59 | this | The super constructor must be called before using 'this'. |
+| invalid.js:5:35:5:52 | () { this.c = 0; } | The super constructor must be called before using '$@'. | invalid.js:5:40:5:43 | this | this |
+| invalid.js:6:35:6:50 | () { this.c(); } | The super constructor must be called before using '$@'. | invalid.js:6:40:6:43 | this | this |
+| invalid.js:7:35:7:51 | () { super.c(); } | The super constructor must be called before using '$@'. | invalid.js:7:40:7:46 | super.c | super |
+| invalid.js:8:35:8:61 | () { th ... er(); } | The super constructor must be called before using '$@'. | invalid.js:8:40:8:43 | this | this |
+| invalid.js:9:35:9:59 | () { th ... er(); } | The super constructor must be called before using '$@'. | invalid.js:9:40:9:43 | this | this |
+| invalid.js:10:35:10:60 | () { su ... er(); } | The super constructor must be called before using '$@'. | invalid.js:10:40:10:46 | super.c | super |
+| invalid.js:11:35:11:55 | () { su ... s.c); } | The super constructor must be called before using '$@'. | invalid.js:11:46:11:49 | this | this |
+| invalid.js:12:35:12:57 | () { su ... c()); } | The super constructor must be called before using '$@'. | invalid.js:12:46:12:49 | this | this |
+| invalid.js:13:35:13:58 | () { su ... c()); } | The super constructor must be called before using '$@'. | invalid.js:13:46:13:52 | super.c | super |
+| invalid.js:14:35:14:118 | () { cl ... er(); } | The super constructor must be called before using '$@'. | invalid.js:14:99:14:102 | this | this |
+| invalid.js:15:71:15:95 | () { th ... er(); } | The super constructor must be called before using '$@'. | invalid.js:15:76:15:79 | this | this |
+| invalid.js:16:35:16:66 | () { if ... .a(); } | The super constructor must be called before using '$@'. | invalid.js:16:56:16:59 | this | this |
+| invalid.js:26:16:29:5 | () {\\n   ... ;\\n    } | The super constructor must be called before using '$@'. | invalid.js:27:9:27:12 | this | this |
+| invalid.js:26:16:29:5 | () {\\n   ... ;\\n    } | The super constructor must be called before using '$@'. | invalid.js:28:9:28:12 | this | this |

--- a/javascript/ql/test/query-tests/LanguageFeatures/ThisBeforeSuper/invalid.js
+++ b/javascript/ql/test/query-tests/LanguageFeatures/ThisBeforeSuper/invalid.js
@@ -21,3 +21,10 @@ class A41 extends B1 { constructor() { if (a) super(); this.a(); } }
 class B2 { constructor() { throw ""; } }
 class A42 extends B2 { constructor() { try { super(); } finally { this.a; } } }
 class A43 extends B2 { constructor() { try { super(); } catch (err) { } this.a; } }
+
+class A44 extends B1 {
+    constructor() {
+        this.p1 = 0;
+        this.p2 = 0;
+    }
+}


### PR DESCRIPTION
This PR Fixes ODASA-7268 by flagging constructors with invalid `this/super` expressions instead of the invalid expressions themselves. The expressions are still a part of the error message.

This will prevent artificially high alert counts for some (legacy?) constructors. 
Example: https://lgtm.com/projects/g/angular/watchtower.js/snapshot/50cb876f1b62f16e9beea51c8ca4209eadf84876/files/src/watch_group.js?sort=name&dir=ASC&mode=heatmap&showExcluded=true#x76858207ab8a9450:1