### PR TITLE
TypeScript: bugfixes for import-assign statement

### DIFF
--- a/javascript/ql/src/semmle/javascript/DefUse.qll
+++ b/javascript/ql/src/semmle/javascript/DefUse.qll
@@ -43,8 +43,8 @@ private predicate defn(ControlFlowNode def, Expr lhs, AST::ValueNode rhs) {
   exists (EnumDeclaration ed | def = ed.getIdentifier() |
     lhs = def and rhs = ed
   ) or
-  exists (ImportEqualsDeclaration i | def = i.getId() |
-    lhs = def and rhs = i.getImportedEntity()
+  exists (ImportEqualsDeclaration i | def = i |
+    lhs = i.getId() and rhs = i.getImportedEntity()
   ) or
   exists (EnumMember member | def = member.getIdentifier() |
     lhs = def and rhs = member.getInitializer()

--- a/javascript/ql/src/semmle/javascript/ES2015Modules.qll
+++ b/javascript/ql/src/semmle/javascript/ES2015Modules.qll
@@ -308,7 +308,8 @@ class ExportNamedDeclaration extends ExportDeclaration, @exportnameddeclaration 
       result = op.(NamespaceDeclaration).getId() or
       result = op.(EnumDeclaration).getIdentifier() or
       result = op.(InterfaceDeclaration).getIdentifier() or
-      result = op.(TypeAliasDeclaration).getIdentifier()
+      result = op.(TypeAliasDeclaration).getIdentifier() or
+      result = op.(ImportEqualsDeclaration).getId()
     )
   }
 

--- a/javascript/ql/src/semmle/javascript/TypeScript.qll
+++ b/javascript/ql/src/semmle/javascript/TypeScript.qll
@@ -224,6 +224,10 @@ class ImportEqualsDeclaration extends Stmt, @importequalsdeclaration {
   Expr getImportedEntity() {
     result = getChildExpr(1)
   }
+
+  override ControlFlowNode getFirstControlFlowNode() {
+    result = getId()
+  }
 }
 
 /**

--- a/javascript/ql/test/query-tests/Expressions/SuspiciousPropAccess/export_import.ts
+++ b/javascript/ql/test/query-tests/Expressions/SuspiciousPropAccess/export_import.ts
@@ -1,0 +1,3 @@
+import * as Something from 'somewhere';
+
+export import importExport = Something.thingy;

--- a/javascript/ql/test/query-tests/Expressions/SuspiciousPropAccess/export_import_client.ts
+++ b/javascript/ql/test/query-tests/Expressions/SuspiciousPropAccess/export_import_client.ts
@@ -1,0 +1,5 @@
+import { importExport } from "./export_import";
+
+function test() {
+  let f = importExport.prop; // OK
+}


### PR DESCRIPTION
Fixes some bugs in the treatment of TypeScript's `import` assignments.

Note that this depends on some changes in the extractor.