### PR TITLE
C++: Move LGTM suites to submodule

### DIFF
--- a/cpp/config/suites/lgtm/cpp-alerts-lgtm
+++ b/cpp/config/suites/lgtm/cpp-alerts-lgtm
@@ -1,0 +1,3 @@
+# DO NOT EDIT
+# This is a stub file. The actual suite of queries to run is generated
+# automatically based on query precision and severity.

--- a/cpp/config/suites/lgtm/cpp-lgtm
+++ b/cpp/config/suites/lgtm/cpp-lgtm
@@ -1,0 +1,2 @@
+@import "cpp-queries-lgtm"
+@import "cpp-metrics-lgtm"

--- a/cpp/config/suites/lgtm/cpp-metrics-lgtm
+++ b/cpp/config/suites/lgtm/cpp-metrics-lgtm
@@ -1,0 +1,16 @@
++ odasa-cpp-metrics/Files/FLinesOfCode.ql: /Metrics/Size
+    @_namespace com.lgtm/cpp-queries
++ odasa-cpp-metrics/Files/FLinesOfComments.ql: /Metrics/Documentation
+    @_namespace com.lgtm/cpp-queries
++ odasa-cpp-metrics/Files/FLinesOfCommentedOutCode.ql: /Metrics/Files
+    @_namespace com.lgtm/cpp-queries
++ semmlecode-cpp-queries/Metrics/Files/FLinesOfDuplicatedCode.ql: /Metrics/Coupling
+    @_namespace com.lgtm/cpp-queries
++ odasa-cpp-metrics/Files/FNumberOfTests.ql: /Metrics/Size
+    @_namespace com.lgtm/cpp-queries
+
++ semmlecode-cpp-queries/Metrics/Dependencies/ExternalDependencies.ql
+    @_namespace com.lgtm/cpp-queries
++ semmlecode-cpp-queries/Metrics/Dependencies/ExternalDependenciesSourceLinks.ql
+    @_namespace com.lgtm/cpp-queries
+

--- a/cpp/config/suites/lgtm/cpp-queries-lgtm
+++ b/cpp/config/suites/lgtm/cpp-queries-lgtm
@@ -1,0 +1,10 @@
++ semmlecode-cpp-queries/definitions.ql
+    @_namespace com.lgtm/cpp-queries
++ semmlecode-cpp-queries/AlertSuppression.ql
+    @_namespace com.lgtm/cpp-queries
++ semmlecode-cpp-queries/filters/ClassifyFiles.ql
+    @_namespace com.lgtm/cpp-queries
++ semmlecode-cpp-queries/filters/ImportAdditionalLibraries.ql
+    @_namespace com.lgtm/cpp-queries
+
+@import "cpp-alerts-lgtm"


### PR DESCRIPTION
This follows what's been done for JavaScript, except that the organization of the suite files has not changed and remains similar to csharp and java. Like for JavaScript, the `cpp-alerts-lgtm` suite is now empty and will be auto-generated when building a dist.

This commit has no effect in itself, but these files need to be in place when the corresponding changes are made in Semmle/code.