### PR TITLE
JS: classify twitter-text library instances

### DIFF
--- a/javascript/ql/src/semmle/javascript/dependencies/FrameworkLibraries.qll
+++ b/javascript/ql/src/semmle/javascript/dependencies/FrameworkLibraries.qll
@@ -844,6 +844,41 @@ private class ApplicationInsights extends FrameworkLibraryWithURLRegex {
 }
 
 /**
+ * The twitter-text framework.
+ */
+private class TwitterText extends FrameworkLibraryWithGenericURL, FrameworkLibraryWithMarkerComment {
+  TwitterText() { this = "twitter-text" }
+
+  override string getAMarkerCommentRegex() {
+    result = "(?s).*twitter-text\\s*(<VERSION>).*"
+  }
+}
+
+/**
+ * The classic version of twitter-text, as seen in the wild.
+ */
+private class TwitterTextClassic extends FrameworkLibraryWithURLRegex {
+  TwitterTextClassic() { this = "twitter-text" }
+
+  override string getAURLRegex() {
+    result = ".*(?:^|/)twitter_text" + variantRegex() + "\\.js"
+  }
+}
+
+/**
+ * A copy of twitter-text.
+ */
+private class TwitterTextClassicInstance extends FrameworkLibraryInstance {
+  TwitterTextClassicInstance() {
+    this.(TopLevel).getFile().getAbsolutePath().regexpMatch(any(TwitterTextClassic t).getAURLRegex())
+  }
+  override predicate info(FrameworkLibrary fl, string v) {
+    fl instanceof TwitterTextClassic and
+    v = ""
+  }
+}
+
+/**
  * A `FrameworkLibraryReference` that refers to a recognised `FrameworkLibraryInstance`,
  * that is, a `<script>` tag where the `src` attribute can be resolved to a local file
  * that is recognised as an instance of a framework library.

--- a/javascript/ql/test/query-tests/filters/ClassifyFiles/ClassifyFiles.expected
+++ b/javascript/ql/test/query-tests/filters/ClassifyFiles/ClassifyFiles.expected
@@ -19,6 +19,8 @@
 | tmpl.html:0:0:0:0 | tmpl.html | template |
 | tst.browserify.js:0:0:0:0 | tst.browserify.js | generated |
 | tst.dart.js:0:0:0:0 | tst.dart.js | generated |
+| twitter-text.js:0:0:0:0 | twitter-text.js | library |
+| twitter_text.js:0:0:0:0 | twitter_text.js | library |
 | unannotated-externs-1.js:0:0:0:0 | unannotated-externs-1.js | externs |
 | unannotated-externs-2.js:0:0:0:0 | unannotated-externs-2.js | externs |
 | unannotated-externs-3.js:0:0:0:0 | unannotated-externs-3.js | externs |

--- a/javascript/ql/test/query-tests/filters/ClassifyFiles/twitter-text.js
+++ b/javascript/ql/test/query-tests/filters/ClassifyFiles/twitter-text.js
@@ -1,0 +1,11 @@
+/*!
+ * twitter-text 2.0.4
+ *
+ * Copyright 2012 Twitter, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this work except in compliance with the License.
+ * You may obtain a copy of the License at:
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ */

--- a/javascript/ql/test/query-tests/filters/ClassifyFiles/twitter_text.js
+++ b/javascript/ql/test/query-tests/filters/ClassifyFiles/twitter_text.js
@@ -1,0 +1,1 @@
+// classic version of twitter-text, as seen in the wild


### PR DESCRIPTION
The [twitter-text library](https://github.com/twitter/twitter-text/tree/master/js) is included as source code in many of the projects we analyze. This PR classifies the library to prevent displaying alerts in it by default.

Example project with the library:
https://lgtm.com/projects/g/kneath/kneath.github.com/snapshot/5d889d781964a472f63b08337e73dbba9f18c15d/files/experiments/history-api/javascripts/lib/twitter_text.js?sort=name&dir=ASC&mode=heatmap&showExcluded=true