### PR TITLE
C#: fix inconsistent type/constructor name

### DIFF
--- a/csharp/ql/src/Likely Bugs/SelfAssignment.cs
+++ b/csharp/ql/src/Likely Bugs/SelfAssignment.cs
@@ -1,7 +1,7 @@
 class SelfAssignment
 {
     private int i;
-    public TestableTest(int i)
+    public SelfAssignment(int i)
     {
         i = i;
     }


### PR DESCRIPTION
The code sample for the self-assignment query help had a different name for the class and it's (intended) constructor, so was invalid.