### PR TITLE
JavaScript: Use 'moduleMember' in NodeJSLib.qll for ES6-compatibility

### DIFF
--- a/javascript/ql/src/semmle/javascript/frameworks/HTTP.qll
+++ b/javascript/ql/src/semmle/javascript/frameworks/HTTP.qll
@@ -126,6 +126,13 @@ module HTTP {
   }
 
   /**
+   * Gets the string `http` or `https`.
+   */
+  string httpOrHttps() {
+    result = "http" or result = "https"
+  }
+
+  /**
    * An expression whose value is sent as (part of) the body of an HTTP response.
    */
   abstract class ResponseBody extends Expr {

--- a/javascript/ql/test/query-tests/Security/CWE-022/TaintedPath-es6.js
+++ b/javascript/ql/test/query-tests/Security/CWE-022/TaintedPath-es6.js
@@ -1,0 +1,11 @@
+import { readFileSync } from 'fs';
+import { createServer } from 'http';
+import { parse } from 'url';
+import { join } from 'path';
+
+var server = createServer(function(req, res) {
+  let path = parse(req.url, true).query.path;
+
+  // BAD: This could read any file on the file system
+  res.write(readFileSync(join("public", path)));
+});

--- a/javascript/ql/test/query-tests/Security/CWE-022/TaintedPath.expected
+++ b/javascript/ql/test/query-tests/Security/CWE-022/TaintedPath.expected
@@ -1,3 +1,4 @@
+| TaintedPath-es6.js:10:26:10:45 | join("public", path) | This path depends on $@. | TaintedPath-es6.js:7:20:7:26 | req.url | a user-provided value |
 | TaintedPath.js:12:29:12:32 | path | This path depends on $@. | TaintedPath.js:9:24:9:30 | req.url | a user-provided value |
 | TaintedPath.js:15:29:15:48 | "/home/user/" + path | This path depends on $@. | TaintedPath.js:9:24:9:30 | req.url | a user-provided value |
 | TaintedPath.js:19:33:19:36 | path | This path depends on $@. | TaintedPath.js:9:24:9:30 | req.url | a user-provided value |


### PR DESCRIPTION
The models in `NodeJSLib.qll` didn't always support ES6-style imports; now they do.

Drive-by change: adds a predicate `HTTP::httpOrHttps()` for when you need the string `http` or `https`.

Performance is [unchanged](https://git.semmle.com/gist/asger/fccc9fc759ea72522bf9b36acf17fd05#file-nodejslib-modulemember-L50) and there are no new results on default slugs.