### PR TITLE
 JavaScript: support simple data flow through Electron IPC

### DIFF
--- a/javascript/ql/src/semmle/javascript/frameworks/Electron.qll
+++ b/javascript/ql/src/semmle/javascript/frameworks/Electron.qll
@@ -6,31 +6,463 @@ module Electron {
    */
   class WebPreferences extends DataFlow::ObjectLiteralNode {
     WebPreferences() {
-      exists(BrowserObject bo | this = bo.getOptionArgument(0, "webPreferences").getALocalSource())
+      exists(NewBrowserObject bo | this = bo.getOptionArgument(0, "webPreferences").getALocalSource())
     }
+  }
+  
+
+  abstract class BrowserObject extends DataFlow::Node {
   }
   
   /**
    * A data flow node that creates a new `BrowserWindow` or `BrowserView`.
    */
-  private abstract class BrowserObject extends DataFlow::NewNode {
+  abstract class NewBrowserObject extends BrowserObject, DataFlow::NewNode {
   }
   
   /**
    * A data flow node that creates a new `BrowserWindow`.
    */
-  class BrowserWindow extends BrowserObject {
+  class BrowserWindow extends NewBrowserObject {
     BrowserWindow() {
       this = DataFlow::moduleMember("electron", "BrowserWindow").getAnInstantiation()
+    }
+  }
+  
+  class TypedBrowserWindow extends BrowserObject {
+    TypedBrowserWindow() {
+      this.asExpr().getType().toString() = "BrowserWindow"
     }
   }
   
   /**
    * A data flow node that creates a new `BrowserView`.
    */
-  class BrowserView extends BrowserObject {
+  class BrowserView extends NewBrowserObject {
     BrowserView() {
       this = DataFlow::moduleMember("electron", "BrowserView").getAnInstantiation()
+    }
+  }
+  
+  class BrowserToWebContentsConfiguration extends Configuration2::Configuration {
+    BrowserToWebContentsConfiguration() {
+      this = "BrowserToWebContentsConfiguration"
+    }
+    
+    override predicate isSource(DataFlow::Node node) {
+      node instanceof BrowserObject
+    }
+    
+    override predicate isSink(DataFlow::Node node) {
+      exists(DataFlow::PropRead read |
+       read.getPropertyName() = "webContents" and
+       node = read.getBase()
+     )
+    }
+  }
+  
+  /**
+   * A data flow node that is the `webContents` property of an Electron browser object
+   */
+  cached class WebContents extends DataFlow::Node {
+    cached WebContents() {
+      exists(BrowserToWebContentsConfiguration cfg, DataFlow::Node base |
+        cfg.hasFlow(_, base) and
+        base = this.(DataFlow::PropRead).getBase()
+      )
+    }
+  }
+  
+  /**
+   * A data flow node that imports `electron.ipcMain`.
+   */
+  class IPCMain extends DataFlow::SourceNode {
+    IPCMain() {
+      this = DataFlow::moduleMember("electron", "ipcMain")
+    }
+  }
+  
+  /**
+   * A data flow node that is registered as an Electron IPC callback in the main process.
+   */
+  class IPCMainCallback extends DataFlow::FunctionNode {
+    DataFlow::Node channel;
+    
+    IPCMainCallback() {
+      exists(IPCMain ipcMain, DataFlow::MethodCallNode mc |
+        ipcMain.flowsTo(mc.getReceiver()) and
+        this.flowsTo(mc.getArgument(1)) and
+        channel = mc.getArgument(0) and
+        mc.getCalleeName() = "on"
+      )
+    }
+    
+    /**
+     * A data flow node that is the channel the callback is listening on.
+     */
+    DataFlow::Node getChannel() {
+      result = channel
+    }
+    
+    /**
+     * The string value that is the channel the callback is listening on.
+     */
+    string getChannelValue() {
+      result = channel.asExpr().getStringValue()
+    }
+  }
+  
+  /**
+   * A data flow node that is sent as an Electron IPC message from the main process.
+   */
+  abstract class IPCMainMessage extends DataFlow::ValueNode {
+    /**
+     * A data flow node that is the channel the message is sent on.
+     */
+    abstract DataFlow::Node getChannel();
+    
+    /**
+     * The string value that is the channel the message is sent on.
+     */
+    abstract string getChannelValue();
+  }
+  
+  /**
+   * A data flow node that is sent as an initial Electron IPC message from the main process.
+   */
+  class IPCMainSentMessage extends IPCMainMessage {
+    DataFlow::Node channel;
+    
+    IPCMainSentMessage() {
+      exists(IPCMain ipcMain, DataFlow::MethodCallNode mc |
+        ipcMain.flowsTo(mc.getReceiver()) and
+        this = mc.getArgument(1) and
+        channel = mc.getArgument(0) and
+        (
+          mc.getCalleeName() = "send"
+          or
+          mc.getCalleeName() = "sendSync"
+        )
+      )
+    }
+    
+    override DataFlow::Node getChannel() {
+      result = channel
+    }
+    
+    override string getChannelValue() {
+      result = channel.asExpr().getStringValue()
+    }
+  }
+  
+  /**
+   * A data flow node that is sent as an Electron IPC reply from the main process.
+   */
+  abstract class IPCMainReplyMessage extends IPCMainMessage {
+  }
+  
+  /**
+   * A data flow node that is sent as an asynchronous Electron IPC reply from the main process.
+   */
+  class IPCMainAsyncReplyMessage extends IPCMainReplyMessage {
+    DataFlow::Node channel;
+    
+    IPCMainAsyncReplyMessage() {
+      exists(IPCMainCallback callback, DataFlow::MethodCallNode mc |
+        callback.getParameter(0).getAPropertyRead("sender").flowsTo(mc.getReceiver()) and
+        this = mc.getArgument(1) and
+        mc.getCalleeName() = "send" and
+        channel = mc.getArgument(0)
+      )
+    }
+    
+    override DataFlow::Node getChannel() {
+      result = channel
+    }
+    
+    override string getChannelValue() {
+      result = channel.asExpr().getStringValue()
+    }
+  }
+
+  /**
+   * A data flow node that is sent as a synchronous Electron IPC message from the main process.
+   */
+  class IPCMainSyncReplyMessage extends IPCMainReplyMessage {
+    DataFlow::Node channel;
+    
+    IPCMainSyncReplyMessage() {
+      exists(IPCMainCallback callback, DataFlow::PropWrite write |
+        callback.getParameter(0).flowsTo(write.getBase()) and
+        this = write.getRhs() and
+        write.getPropertyName() = "returnValue" and
+        channel = callback.getChannel()
+      )
+    }
+    
+    override DataFlow::Node getChannel() {
+      result = channel
+    }
+    
+    override string getChannelValue() {
+      result = channel.asExpr().getStringValue()
+    }
+  }
+  
+  /**
+   * A data flow node that is a call to a synchronous Electron IPC method in the main process.
+   */
+  class IPCMainSendSync extends DataFlow::MethodCallNode {
+    DataFlow::Node channel;
+    
+    IPCMainSendSync() {
+      exists(IPCMain ipcMain |
+        ipcMain.flowsTo(this.getReceiver()) and
+        this.getCalleeName() = "sendSync" and
+        this.getArgument(0) = channel
+      )
+    }
+    
+    DataFlow::Node getChannel() {
+      result = channel
+    }
+    
+    string getChannelValue() {
+      result = channel.asExpr().getStringValue()
+    }
+  }
+  
+  /**
+   * A data flow node that imports `electron.ipcRenderer`.
+   */
+  class IPCRenderer extends DataFlow::SourceNode {
+    IPCRenderer() {
+      this = DataFlow::moduleMember("electron", "ipcRenderer")
+    }
+  }
+  
+  /**
+   * A data flow node that is registered as an Electron IPC callback in a renderer process.
+   */
+  class IPCRendererCallback extends DataFlow::FunctionNode {
+    DataFlow::Node channel;
+    
+    IPCRendererCallback() {
+      exists(IPCRenderer ipcRenderer, DataFlow::MethodCallNode mc |
+        ipcRenderer.flowsTo(mc.getReceiver()) and
+        this.flowsTo(mc.getArgument(1)) and
+        channel = mc.getArgument(0) and
+        mc.getCalleeName() = "on"
+      )
+    }
+    
+    /**
+     * A data flow node that is the channel the callback is listening on.
+     */
+    DataFlow::Node getChannel() {
+      result = channel
+    }
+    
+    /**
+     * The string value that is the channel the callback is listening on.
+     */
+    string getChannelValue() {
+      result = channel.asExpr().getStringValue()
+    }
+  }
+  
+  /**
+   * A data flow node that is sent as an Electron IPC message from a renderer process.
+   */
+  abstract class IPCRendererMessage extends DataFlow::ValueNode {
+    /**
+     * A data flow node that is the channel the message is sent on.
+     */
+    abstract DataFlow::Node getChannel();
+    
+    /**
+     * The string value that is the channel the message is sent on.
+     */
+    abstract string getChannelValue();
+  }
+  
+  /**
+   * A data flow node that is sent as an initial Electron IPC message from a renderer process.
+   */
+  class IPCRendererSentMessage extends IPCRendererMessage {
+    DataFlow::Node channel;
+    
+    IPCRendererSentMessage() {
+      exists(IPCRenderer ipcRenderer, DataFlow::MethodCallNode mc |
+        ipcRenderer.flowsTo(mc.getReceiver()) and
+        this = mc.getArgument(1) and
+        channel = mc.getArgument(0) and
+        (
+          mc.getCalleeName() = "send"
+          or
+          mc.getCalleeName() = "sendSync"
+        )
+      )
+    }
+    
+    override DataFlow::Node getChannel() {
+      result = channel
+    }
+    
+    override string getChannelValue() {
+      result = channel.asExpr().getStringValue()
+    }
+  }
+  
+  /**
+   * A data flow node that is sent as an Electron IPC reply from a renderer process.
+   */
+  abstract class IPCRendererReplyMessage extends IPCRendererMessage {
+  }
+  
+  /**
+   * A data flow node that is sent as an asynchronous Electron IPC reply from a renderer process.
+   */
+  class IPCRendererAsyncReplyMessage extends IPCRendererReplyMessage {
+    DataFlow::Node channel;
+    
+    IPCRendererAsyncReplyMessage() {
+      exists(IPCRendererCallback callback, DataFlow::MethodCallNode mc |
+        callback.getParameter(0).getAPropertyRead("sender").flowsTo(mc.getReceiver()) and
+        this = mc.getArgument(1) and
+        mc.getCalleeName() = "send" and
+        channel = mc.getArgument(0)
+      )
+    }
+    
+    override DataFlow::Node getChannel() {
+      result = channel
+    }
+    
+    override string getChannelValue() {
+      result = channel.asExpr().getStringValue()
+    }
+  }
+  
+
+  /**
+   * A data flow node that is sent as a synchronous Electron IPC message from a renderer process.
+   */
+  class IPCRendererSyncReplyMessage extends IPCRendererReplyMessage {
+    DataFlow::Node channel;
+    
+    IPCRendererSyncReplyMessage() {
+      exists(IPCRendererCallback callback, DataFlow::PropWrite write |
+        callback.getParameter(0).flowsTo(write.getBase()) and
+        this = write.getRhs() and
+        write.getPropertyName() = "returnValue" and
+        channel = callback.getChannel()
+      )
+    }
+    
+    override DataFlow::Node getChannel() {
+      result = channel
+    }
+    
+    override string getChannelValue() {
+      result = channel.asExpr().getStringValue()
+    }
+  }
+  
+  /**
+   * A data flow node that is a call to a synchronous Electron IPC method in a renderer process.
+   */
+  class IPCRendererSendSync extends DataFlow::MethodCallNode {
+    DataFlow::Node channel;
+    
+    IPCRendererSendSync() {
+      exists(IPCRenderer ipcRenderer |
+        ipcRenderer.flowsTo(this.getReceiver()) and
+        this.getCalleeName() = "sendSync" and
+        this.getArgument(0) = channel
+      )
+    }
+    
+    DataFlow::Node getChannel() {
+      result = channel
+    }
+    
+    string getChannelValue() {
+      result = channel.asExpr().getStringValue()
+    }
+  }
+
+  
+  /**
+   * A data flow node that is sent as an asynchronous Electron IPC message from the main process via a `webContents` object.
+   */
+  class WebContentsSendMessage extends IPCMainMessage {
+    DataFlow::Node channel;
+    
+    WebContentsSendMessage() {
+      exists(WebContents wc, DataFlow::MethodCallNode mc |
+        wc.(DataFlow::PropRead).flowsTo(mc.getReceiver()) and
+        this = mc.getArgument(1) and
+        channel = mc.getArgument(0) and
+        mc.getCalleeName() = "send"
+      )
+    }
+    
+    override DataFlow::Node getChannel() {
+      result = channel
+    }
+    
+    override string getChannelValue() {
+      result = channel.asExpr().getStringValue()
+    }
+  }
+  /**
+   * Holds if `pred` flows to `succ` via the Electron IPC channel `channel`
+   */
+  predicate ipcSimpleFlowStep(DataFlow::Node pred, DataFlow::Node succ, string channel) {
+    exists(IPCRendererCallback callback |
+      succ = callback.getParameter(1) and
+      channel = callback.getChannelValue() and
+      channel = pred.(IPCMainMessage).getChannelValue()
+    )
+    or
+    exists(IPCMainCallback callback |
+      succ = callback.getParameter(1) and
+      channel = callback.getChannelValue() and
+      channel = pred.(IPCRendererMessage).getChannelValue()
+    )
+    or
+    exists(IPCRendererSendSync sendSync |
+      succ = sendSync and
+      channel = sendSync.getChannelValue() and
+      channel = pred.(IPCMainSyncReplyMessage).getChannelValue()
+    )
+    or
+    exists(IPCMainSendSync sendSync |
+      succ = sendSync and
+      channel = sendSync.getChannelValue() and
+      channel = pred.(IPCRendererSyncReplyMessage).getChannelValue()
+    )
+    or
+    exists(IPCRendererCallback callback |
+      succ = callback.getParameter(1) and
+      channel = callback.getChannelValue() and
+      channel = pred.(WebContentsSendMessage).asExpr().getStringValue()
+    )
+  }
+  
+  /**
+   * An additional flow step  via an Electron IPC message.
+   */
+  cached class IPCAdditionalFlowStep extends DataFlow::AdditionalFlowStep {
+    cached IPCAdditionalFlowStep() {
+      this instanceof IPCMainMessage or
+      this instanceof IPCRendererMessage
+    }
+    
+    cached override predicate step(DataFlow::Node pred, DataFlow::Node succ) {
+      this = pred and
+      ipcSimpleFlowStep(pred, succ, _)
     }
   }
 }

--- a/javascript/ql/src/semmle/javascript/frameworks/Electron.qll
+++ b/javascript/ql/src/semmle/javascript/frameworks/Electron.qll
@@ -39,7 +39,7 @@ module Electron {
   }
   
   /**
-   * A data flow node with a TypeScript type  indicating it is an Electron `BrowserWindow`
+   * A data flow node with a TypeScript type indicating it is an Electron `BrowserWindow`
    */
   class TypedBrowserWindow extends BrowserObject {
     TypedBrowserWindow() {
@@ -48,7 +48,7 @@ module Electron {
   }
   
   /**
-   * A data flow node with a TypeScript type  indicating it is an Electron `BrowserView`
+   * A data flow node with a TypeScript type indicating it is an Electron `BrowserView`
    */
   class TypedBrowserView extends BrowserObject {
     TypedBrowserView() {
@@ -67,7 +67,7 @@ module Electron {
   /**
    * A data flow node that is the `webContents` property of an Electron browser object
    */
-  cached class WebContents extends DataFlow::Node {
+  cached class WebContents extends DataFlow::TrackedNode {
     cached WebContents() {
       exists(BrowserObject bo |
         bo.flowsTo(this.(DataFlow::PropRead).getBase())
@@ -403,7 +403,7 @@ module Electron {
     
     WebContentsSendMessage() {
       exists(WebContents wc, DataFlow::MethodCallNode mc |
-        wc.(DataFlow::PropRead).flowsTo(mc.getReceiver()) and
+        wc.flowsTo(mc.getReceiver()) and
         this = mc.getArgument(1) and
         channel = mc.getArgument(0) and
         mc.getCalleeName() = "send"
@@ -419,7 +419,7 @@ module Electron {
     }
   }
   /**
-   * Holds if `pred` flows to `succ` via the Electron IPC channel `channel`
+   * Holds if `pred` flows to `succ` via the Electron IPC channel `channel`, as determined from local string values.
    */
   predicate ipcSimpleFlowStep(DataFlow::Node pred, DataFlow::Node succ, string channel) {
     exists(IPCRendererCallback callback |

--- a/javascript/ql/src/semmle/javascript/frameworks/Electron.qll
+++ b/javascript/ql/src/semmle/javascript/frameworks/Electron.qll
@@ -79,369 +79,371 @@ module Electron {
     }
   }
   
-  /**
-   * A data flow node that imports `electron.ipcMain`.
-   */
-  class IPCMain extends DataFlow::SourceNode {
-    IPCMain() {
-      this = DataFlow::moduleMember("electron", "ipcMain")
-    }
-  }
-  
-  /**
-   * A data flow node that is registered as an Electron IPC callback in the main process.
-   */
-  class IPCMainCallback extends DataFlow::FunctionNode {
-    DataFlow::Node channel;
-    
-    IPCMainCallback() {
-      exists(IPCMain ipcMain, DataFlow::MethodCallNode mc |
-        mc = ipcMain.getAMemberCall("on") and
-        this.flowsTo(mc.getArgument(1)) and
-        channel = mc.getArgument(0)
-      )
-    }
-    
+  module IPC {
     /**
-     * Gets the data flow node that is the channel the callback is listening on.
+     * A data flow node that imports `electron.ipcMain`.
      */
-    DataFlow::Node getChannel() {
-      result = channel
+    class Main extends DataFlow::SourceNode {
+      Main() {
+        this = DataFlow::moduleMember("electron", "ipcMain")
+      }
     }
     
     /**
-     * Gets the string value that is the channel the callback is listening on.
+     * A data flow node that is registered as an Electron IPC callback in the main process.
      */
-    string getChannelValue() {
-      result = channel.asExpr().getStringValue()
+    class MainCallback extends DataFlow::FunctionNode {
+      DataFlow::Node channel;
+      
+      MainCallback() {
+        exists(Main ipcMain, DataFlow::MethodCallNode mc |
+          mc = ipcMain.getAMemberCall("on") and
+          this.flowsTo(mc.getArgument(1)) and
+          channel = mc.getArgument(0)
+        )
+      }
+      
+      /**
+       * Gets the data flow node that is the channel the callback is listening on.
+       */
+      DataFlow::Node getChannel() {
+        result = channel
+      }
+      
+      /**
+       * Gets the string value that is the channel the callback is listening on.
+       */
+      string getChannelValue() {
+        result = channel.asExpr().getStringValue()
+      }
     }
-  }
-  
-  /**
-   * A data flow node that is sent as an Electron IPC message from the main process.
-   */
-  abstract class IPCMainMessage extends DataFlow::ValueNode {
+    
     /**
-     * Gets the data flow node that is the channel the message is sent on.
+     * A data flow node that is sent as an Electron IPC message from the main process.
      */
-    abstract DataFlow::Node getChannel();
+    abstract class MainMessage extends DataFlow::ValueNode {
+      /**
+       * Gets the data flow node that is the channel the message is sent on.
+       */
+      abstract DataFlow::Node getChannel();
+      
+      /**
+       * Gets the string value that is the channel the message is sent on.
+       */
+      abstract string getChannelValue();
+    }
     
     /**
-     * Gets the string value that is the channel the message is sent on.
+     * A data flow node that is sent as an initial Electron IPC message from the main process.
      */
-    abstract string getChannelValue();
-  }
-  
-  /**
-   * A data flow node that is sent as an initial Electron IPC message from the main process.
-   */
-  class IPCMainSentMessage extends IPCMainMessage {
-    DataFlow::Node channel;
-    
-    IPCMainSentMessage() {
-      exists(IPCMain ipcMain, DataFlow::MethodCallNode mc |
-        (
-          ipcMain.getAMemberCall("send") = mc
-          or
-          ipcMain.getAMemberCall("sendSync") = mc
-        ) and
-        this = mc.getArgument(1) and
-        channel = mc.getArgument(0)
-      )
-    }
-    
-    override DataFlow::Node getChannel() {
-      result = channel
-    }
-    
-    override string getChannelValue() {
-      result = channel.asExpr().getStringValue()
-    }
-  }
-  
-  /**
-   * A data flow node that is sent as an asynchronous Electron IPC reply from the main process.
-   */
-  class IPCMainAsyncReplyMessage extends IPCMainMessage {
-    DataFlow::Node channel;
-    
-    IPCMainAsyncReplyMessage() {
-      exists(IPCMainCallback callback, DataFlow::MethodCallNode mc |
-        mc = callback.getParameter(0).getAPropertyRead("sender").getAMemberCall("send") and
-        this = mc.getArgument(1) and
-        channel = mc.getArgument(0)
-      )
-    }
-    
-    override DataFlow::Node getChannel() {
-      result = channel
-    }
-    
-    override string getChannelValue() {
-      result = channel.asExpr().getStringValue()
-    }
-  }
-
-  /**
-   * A data flow node that is sent as a synchronous Electron IPC message from the main process.
-   */
-  class IPCMainSyncReplyMessage extends DataFlow::Node {
-    DataFlow::Node channel;
-    
-    IPCMainSyncReplyMessage() {
-      exists(IPCMainCallback callback |
-        this = callback.getParameter(0).getAPropertyWrite("returnValue").getRhs() and
-        channel = callback.getChannel()
-      )
-    }
-    
-    DataFlow::Node getChannel() {
-      result = channel
-    }
-    
-    string getChannelValue() {
-      result = channel.asExpr().getStringValue()
-    }
-  }
-  
-  /**
-   * A data flow node that is a call to a synchronous Electron IPC method in the main process.
-   */
-  class IPCMainSendSync extends DataFlow::MethodCallNode {
-    DataFlow::Node channel;
-    
-    IPCMainSendSync() {
-      exists(IPCMain ipcMain |
-        this = ipcMain.getAMemberCall("sendSync") and
-        channel = this.getArgument(0)
-      )
-    }
-    
-    DataFlow::Node getChannel() {
-      result = channel
-    }
-    
-    string getChannelValue() {
-      result = channel.asExpr().getStringValue()
-    }
-  }
-    /**
-   * A data flow node that imports `electron.ipcRenderer`.
-   */
-  class IPCRenderer extends DataFlow::SourceNode {
-    IPCRenderer() {
-      this = DataFlow::moduleMember("electron", "ipcRenderer")
-    }
-  }
-  
-  /**
-   * A data flow node that is registered as an Electron IPC callback in the renderer process.
-   */
-  class IPCRendererCallback extends DataFlow::FunctionNode {
-    DataFlow::Node channel;
-    
-    IPCRendererCallback() {
-      exists(IPCRenderer ipcRenderer, DataFlow::MethodCallNode mc |
-        mc = ipcRenderer.getAMemberCall("on") and
-        this.flowsTo(mc.getArgument(1)) and
-        channel = mc.getArgument(0)
-      )
+    class MainSentMessage extends MainMessage {
+      DataFlow::Node channel;
+      
+      MainSentMessage() {
+        exists(Main ipcMain, DataFlow::MethodCallNode mc |
+          (
+            ipcMain.getAMemberCall("send") = mc
+            or
+            ipcMain.getAMemberCall("sendSync") = mc
+          ) and
+          this = mc.getArgument(1) and
+          channel = mc.getArgument(0)
+        )
+      }
+      
+      override DataFlow::Node getChannel() {
+        result = channel
+      }
+      
+      override string getChannelValue() {
+        result = channel.asExpr().getStringValue()
+      }
     }
     
     /**
-     * Gets the data flow node that is the channel the callback is listening on.
+     * A data flow node that is sent as an asynchronous Electron IPC reply from the main process.
      */
-    DataFlow::Node getChannel() {
-      result = channel
+    class MainAsyncReplyMessage extends MainMessage {
+      DataFlow::Node channel;
+      
+      MainAsyncReplyMessage() {
+        exists(MainCallback callback, DataFlow::MethodCallNode mc |
+          mc = callback.getParameter(0).getAPropertyRead("sender").getAMemberCall("send") and
+          this = mc.getArgument(1) and
+          channel = mc.getArgument(0)
+        )
+      }
+      
+      override DataFlow::Node getChannel() {
+        result = channel
+      }
+      
+      override string getChannelValue() {
+        result = channel.asExpr().getStringValue()
+      }
+    }
+  
+    /**
+     * A data flow node that is sent as a synchronous Electron IPC message from the main process.
+     */
+    class MainSyncReplyMessage extends DataFlow::Node {
+      DataFlow::Node channel;
+      
+      MainSyncReplyMessage() {
+        exists(MainCallback callback |
+          this = callback.getParameter(0).getAPropertyWrite("returnValue").getRhs() and
+          channel = callback.getChannel()
+        )
+      }
+      
+      DataFlow::Node getChannel() {
+        result = channel
+      }
+      
+      string getChannelValue() {
+        result = channel.asExpr().getStringValue()
+      }
     }
     
     /**
-     * Gets the string value that is the channel the callback is listening on.
+     * A data flow node that is a call to a synchronous Electron IPC method in the main process.
      */
-    string getChannelValue() {
-      result = channel.asExpr().getStringValue()
+    class MainSendSync extends DataFlow::MethodCallNode {
+      DataFlow::Node channel;
+      
+      MainSendSync() {
+        exists(Main ipcMain |
+          this = ipcMain.getAMemberCall("sendSync") and
+          channel = this.getArgument(0)
+        )
+      }
+      
+      DataFlow::Node getChannel() {
+        result = channel
+      }
+      
+      string getChannelValue() {
+        result = channel.asExpr().getStringValue()
+      }
     }
-  }
-  
-  /**
-   * A data flow node that is sent as an Electron IPC message from the renderer process.
-   */
-  abstract class IPCRendererMessage extends DataFlow::ValueNode {
+      /**
+     * A data flow node that imports `electron.ipcRenderer`.
+     */
+    class Renderer extends DataFlow::SourceNode {
+      Renderer() {
+        this = DataFlow::moduleMember("electron", "ipcRenderer")
+      }
+    }
+    
     /**
-     * Gets the data flow node that is the channel the message is sent on.
+     * A data flow node that is registered as an Electron IPC callback in the renderer process.
      */
-    abstract DataFlow::Node getChannel();
+    class RendererCallback extends DataFlow::FunctionNode {
+      DataFlow::Node channel;
+      
+      RendererCallback() {
+        exists(Renderer ipcRenderer, DataFlow::MethodCallNode mc |
+          mc = ipcRenderer.getAMemberCall("on") and
+          this.flowsTo(mc.getArgument(1)) and
+          channel = mc.getArgument(0)
+        )
+      }
+      
+      /**
+       * Gets the data flow node that is the channel the callback is listening on.
+       */
+      DataFlow::Node getChannel() {
+        result = channel
+      }
+      
+      /**
+       * Gets the string value that is the channel the callback is listening on.
+       */
+      string getChannelValue() {
+        result = channel.asExpr().getStringValue()
+      }
+    }
     
     /**
-     * Gets the string value that is the channel the message is sent on.
+     * A data flow node that is sent as an Electron IPC message from the renderer process.
      */
-    abstract string getChannelValue();
-  }
-  
-  /**
-   * A data flow node that is sent as an initial Electron IPC message from the renderer process.
-   */
-  class IPCRendererSentMessage extends IPCRendererMessage {
-    DataFlow::Node channel;
+    abstract class RendererMessage extends DataFlow::ValueNode {
+      /**
+       * Gets the data flow node that is the channel the message is sent on.
+       */
+      abstract DataFlow::Node getChannel();
+      
+      /**
+       * Gets the string value that is the channel the message is sent on.
+       */
+      abstract string getChannelValue();
+    }
     
-    IPCRendererSentMessage() {
-      exists(IPCRenderer ipcRenderer, DataFlow::MethodCallNode mc |
-        (
-          ipcRenderer.getAMemberCall("send") = mc
-          or
-          ipcRenderer.getAMemberCall("sendSync") = mc
-        ) and
-        this = mc.getArgument(1) and
-        channel = mc.getArgument(0)
+    /**
+     * A data flow node that is sent as an initial Electron IPC message from the renderer process.
+     */
+    class RendererSentMessage extends RendererMessage {
+      DataFlow::Node channel;
+      
+      RendererSentMessage() {
+        exists(Renderer ipcRenderer, DataFlow::MethodCallNode mc |
+          (
+            ipcRenderer.getAMemberCall("send") = mc
+            or
+            ipcRenderer.getAMemberCall("sendSync") = mc
+          ) and
+          this = mc.getArgument(1) and
+          channel = mc.getArgument(0)
+        )
+      }
+      
+      override DataFlow::Node getChannel() {
+        result = channel
+      }
+      
+      override string getChannelValue() {
+        result = channel.asExpr().getStringValue()
+      }
+    }
+    
+    /**
+     * A data flow node that is sent as an asynchronous Electron IPC reply from the renderer process.
+     */
+    class RendererAsyncReplyMessage extends RendererMessage {
+      DataFlow::Node channel;
+      
+      RendererAsyncReplyMessage() {
+        exists(RendererCallback callback, DataFlow::MethodCallNode mc |
+          mc = callback.getParameter(0).getAPropertyRead("sender").getAMemberCall("send") and
+          this = mc.getArgument(1) and
+          channel = mc.getArgument(0)
+        )
+      }
+      
+      override DataFlow::Node getChannel() {
+        result = channel
+      }
+      
+      override string getChannelValue() {
+        result = channel.asExpr().getStringValue()
+      }
+    }
+  
+    /**
+     * A data flow node that is sent as a synchronous Electron IPC message from the renderer process.
+     */
+    class RendererSyncReplyMessage extends DataFlow::Node {
+      DataFlow::Node channel;
+      
+      RendererSyncReplyMessage() {
+        exists(RendererCallback callback |
+          this = callback.getParameter(0).getAPropertyWrite("returnValue").getRhs() and
+          channel = callback.getChannel()
+        )
+      }
+      
+      DataFlow::Node getChannel() {
+        result = channel
+      }
+      
+      string getChannelValue() {
+        result = channel.asExpr().getStringValue()
+      }
+    }
+    
+    /**
+     * A data flow node that is a call to a synchronous Electron IPC method in the renderer process.
+     */
+    class RendererSendSync extends DataFlow::MethodCallNode {
+      DataFlow::Node channel;
+      
+      RendererSendSync() {
+        exists(Renderer ipcRenderer |
+          this = ipcRenderer.getAMemberCall("sendSync") and
+          channel = this.getArgument(0)
+        )
+      }
+      
+      DataFlow::Node getChannel() {
+        result = channel
+      }
+      
+      string getChannelValue() {
+        result = channel.asExpr().getStringValue()
+      }
+    }
+  
+    
+    /**
+     * A data flow node that is sent as an asynchronous Electron IPC message from the main process via a `webContents` object.
+     */
+    class WebContentsSendMessage extends MainMessage {
+      DataFlow::Node channel;
+      
+      WebContentsSendMessage() {
+        exists(WebContents wc, DataFlow::MethodCallNode mc |
+          wc.flowsTo(mc.getReceiver()) and
+          this = mc.getArgument(1) and
+          channel = mc.getArgument(0) and
+          mc.getCalleeName() = "send"
+        )
+      }
+      
+      override DataFlow::Node getChannel() {
+        result = channel
+      }
+      
+      override string getChannelValue() {
+        result = channel.asExpr().getStringValue()
+      }
+    }
+    /**
+     * Holds if `pred` flows to `succ` via the Electron IPC channel `channel`, as determined from local string values.
+     */
+    predicate simpleFlowStep(DataFlow::Node pred, DataFlow::Node succ, string channel) {
+      // match a message sent from the main thread with a callback parameter in the renderer thread
+      exists(RendererCallback callback |
+        succ = callback.getParameter(1) and
+        channel = callback.getChannelValue() and
+        channel = pred.(MainMessage).getChannelValue()
+      )
+      or
+      // match a message sent from the renderer thread with a callback parameter in the main thread
+      exists(MainCallback callback |
+        succ = callback.getParameter(1) and
+        channel = callback.getChannelValue() and
+        channel = pred.(RendererMessage).getChannelValue()
+      )
+      or
+      // match a synchronous reply sent from the main thread with a `sendSync` call in the renderer thread
+      exists(RendererSendSync sendSync |
+        succ = sendSync and
+        channel = sendSync.getChannelValue() and
+        channel = pred.(MainSyncReplyMessage).getChannelValue()
+      )
+      or
+      // match a synchronous reply sent from the renderer thread with a `sendSync` call in the main thread
+      exists(MainSendSync sendSync |
+        succ = sendSync and
+        channel = sendSync.getChannelValue() and
+        channel = pred.(RendererSyncReplyMessage).getChannelValue()
       )
     }
     
-    override DataFlow::Node getChannel() {
-      result = channel
+    /**
+     * An additional flow step  via an Electron IPC message.
+     */
+    class IPCAdditionalFlowStep extends DataFlow::AdditionalFlowStep {
+      IPCAdditionalFlowStep() {
+        this instanceof MainMessage or
+        this instanceof RendererMessage
+      }
+      
+      override predicate step(DataFlow::Node pred, DataFlow::Node succ) {
+        this = pred and
+        simpleFlowStep(pred, succ, _)
+      }
     }
-    
-    override string getChannelValue() {
-      result = channel.asExpr().getStringValue()
-    }
-  }
-  
-  /**
-   * A data flow node that is sent as an asynchronous Electron IPC reply from the renderer process.
-   */
-  class IPCRendererAsyncReplyMessage extends IPCRendererMessage {
-    DataFlow::Node channel;
-    
-    IPCRendererAsyncReplyMessage() {
-      exists(IPCRendererCallback callback, DataFlow::MethodCallNode mc |
-        mc = callback.getParameter(0).getAPropertyRead("sender").getAMemberCall("send") and
-        this = mc.getArgument(1) and
-        channel = mc.getArgument(0)
-      )
-    }
-    
-    override DataFlow::Node getChannel() {
-      result = channel
-    }
-    
-    override string getChannelValue() {
-      result = channel.asExpr().getStringValue()
-    }
-  }
-
-  /**
-   * A data flow node that is sent as a synchronous Electron IPC message from the renderer process.
-   */
-  class IPCRendererSyncReplyMessage extends DataFlow::Node {
-    DataFlow::Node channel;
-    
-    IPCRendererSyncReplyMessage() {
-      exists(IPCRendererCallback callback |
-        this = callback.getParameter(0).getAPropertyWrite("returnValue").getRhs() and
-        channel = callback.getChannel()
-      )
-    }
-    
-    DataFlow::Node getChannel() {
-      result = channel
-    }
-    
-    string getChannelValue() {
-      result = channel.asExpr().getStringValue()
-    }
-  }
-  
-  /**
-   * A data flow node that is a call to a synchronous Electron IPC method in the renderer process.
-   */
-  class IPCRendererSendSync extends DataFlow::MethodCallNode {
-    DataFlow::Node channel;
-    
-    IPCRendererSendSync() {
-      exists(IPCRenderer ipcRenderer |
-        this = ipcRenderer.getAMemberCall("sendSync") and
-        channel = this.getArgument(0)
-      )
-    }
-    
-    DataFlow::Node getChannel() {
-      result = channel
-    }
-    
-    string getChannelValue() {
-      result = channel.asExpr().getStringValue()
-    }
-  }
-
-  
-  /**
-   * A data flow node that is sent as an asynchronous Electron IPC message from the main process via a `webContents` object.
-   */
-  class WebContentsSendMessage extends IPCMainMessage {
-    DataFlow::Node channel;
-    
-    WebContentsSendMessage() {
-      exists(WebContents wc, DataFlow::MethodCallNode mc |
-        wc.flowsTo(mc.getReceiver()) and
-        this = mc.getArgument(1) and
-        channel = mc.getArgument(0) and
-        mc.getCalleeName() = "send"
-      )
-    }
-    
-    override DataFlow::Node getChannel() {
-      result = channel
-    }
-    
-    override string getChannelValue() {
-      result = channel.asExpr().getStringValue()
-    }
-  }
-  /**
-   * Holds if `pred` flows to `succ` via the Electron IPC channel `channel`, as determined from local string values.
-   */
-  predicate ipcSimpleFlowStep(DataFlow::Node pred, DataFlow::Node succ, string channel) {
-    // match a message sent from the main thread with a callback parameter in the renderer thread
-    exists(IPCRendererCallback callback |
-      succ = callback.getParameter(1) and
-      channel = callback.getChannelValue() and
-      channel = pred.(IPCMainMessage).getChannelValue()
-    )
-    or
-    // match a message sent from the renderer thread with a callback parameter in the main thread
-    exists(IPCMainCallback callback |
-      succ = callback.getParameter(1) and
-      channel = callback.getChannelValue() and
-      channel = pred.(IPCRendererMessage).getChannelValue()
-    )
-    or
-    // match a synchronous reply sent from the main thread with a `sendSync` call in the renderer thread
-    exists(IPCRendererSendSync sendSync |
-      succ = sendSync and
-      channel = sendSync.getChannelValue() and
-      channel = pred.(IPCMainSyncReplyMessage).getChannelValue()
-    )
-    or
-    // match a synchronous reply sent from the renderer thread with a `sendSync` call in the main thread
-    exists(IPCMainSendSync sendSync |
-      succ = sendSync and
-      channel = sendSync.getChannelValue() and
-      channel = pred.(IPCRendererSyncReplyMessage).getChannelValue()
-    )
-  }
-  
-  /**
-   * An additional flow step  via an Electron IPC message.
-   */
-  class IPCAdditionalFlowStep extends DataFlow::AdditionalFlowStep {
-    IPCAdditionalFlowStep() {
-      this instanceof IPCMainMessage or
-      this instanceof IPCRendererMessage
-    }
-    
-    override predicate step(DataFlow::Node pred, DataFlow::Node succ) {
-      this = pred and
-      ipcSimpleFlowStep(pred, succ, _)
-    }
-  }
+}
 }
 

--- a/javascript/ql/src/semmle/javascript/frameworks/Electron.qll
+++ b/javascript/ql/src/semmle/javascript/frameworks/Electron.qll
@@ -184,7 +184,7 @@ module Electron {
     }
   
     /**
-     * A data flow node that is sent as a synchronous Electron IPC message from the main process.
+     * A data flow node that is sent as a synchronous Electron IPC reply from the main process.
      */
     class MainSyncReplyMessage extends DataFlow::Node {
       DataFlow::Node channel;
@@ -330,7 +330,7 @@ module Electron {
     }
   
     /**
-     * A data flow node that is sent as a synchronous Electron IPC message from the renderer process.
+     * A data flow node that is sent as a synchronous Electron IPC reply from the renderer process.
      */
     class RendererSyncReplyMessage extends DataFlow::Node {
       DataFlow::Node channel;

--- a/javascript/ql/src/semmle/javascript/frameworks/Electron.qll
+++ b/javascript/ql/src/semmle/javascript/frameworks/Electron.qll
@@ -43,7 +43,7 @@ module Electron {
    */
   class TypedBrowserWindow extends BrowserObject {
     TypedBrowserWindow() {
-      this.asExpr().getType().toString() = "BrowserWindow"
+      this.asExpr().getType().hasUnderlyingType("electron", "BrowserWindow")
     }
   }
   
@@ -52,7 +52,7 @@ module Electron {
    */
   class TypedBrowserView extends BrowserObject {
     TypedBrowserView() {
-      this.asExpr().getType().toString() = "BrowserView"
+      this.asExpr().getType().hasUnderlyingType("electron", "BrowserView")
     }
   }
   /**

--- a/javascript/ql/src/semmle/javascript/frameworks/Electron.qll
+++ b/javascript/ql/src/semmle/javascript/frameworks/Electron.qll
@@ -11,7 +11,7 @@ module Electron {
   }
   
   /**
-   * a data flow node that is an Electron `BrowserView` or `BrowserWindow`
+   * A data flow node that is an Electron `BrowserView` or `BrowserWindow`.
    */
   abstract class BrowserObject extends DataFlow::Node {
   }
@@ -103,14 +103,14 @@ module Electron {
     }
     
     /**
-     * A data flow node that is the channel the callback is listening on.
+     * Gets the data flow node that is the channel the callback is listening on.
      */
     DataFlow::Node getChannel() {
       result = channel
     }
     
     /**
-     * The string value that is the channel the callback is listening on.
+     * Gets the string value that is the channel the callback is listening on.
      */
     string getChannelValue() {
       result = channel.asExpr().getStringValue()
@@ -122,12 +122,12 @@ module Electron {
    */
   abstract class IPCMainMessage extends DataFlow::ValueNode {
     /**
-     * A data flow node that is the channel the message is sent on.
+     * Gets the data flow node that is the channel the message is sent on.
      */
     abstract DataFlow::Node getChannel();
     
     /**
-     * The string value that is the channel the message is sent on.
+     * Gets the string value that is the channel the message is sent on.
      */
     abstract string getChannelValue();
   }
@@ -235,7 +235,7 @@ module Electron {
   }
   
   /**
-   * A data flow node that is registered as an Electron IPC callback in the main process.
+   * A data flow node that is registered as an Electron IPC callback in the renderer process.
    */
   class IPCRendererCallback extends DataFlow::FunctionNode {
     DataFlow::Node channel;
@@ -249,14 +249,14 @@ module Electron {
     }
     
     /**
-     * A data flow node that is the channel the callback is listening on.
+     * Gets the data flow node that is the channel the callback is listening on.
      */
     DataFlow::Node getChannel() {
       result = channel
     }
     
     /**
-     * The string value that is the channel the callback is listening on.
+     * Gets the string value that is the channel the callback is listening on.
      */
     string getChannelValue() {
       result = channel.asExpr().getStringValue()
@@ -264,22 +264,22 @@ module Electron {
   }
   
   /**
-   * A data flow node that is sent as an Electron IPC message from the main process.
+   * A data flow node that is sent as an Electron IPC message from the renderer process.
    */
   abstract class IPCRendererMessage extends DataFlow::ValueNode {
     /**
-     * A data flow node that is the channel the message is sent on.
+     * Gets the data flow node that is the channel the message is sent on.
      */
     abstract DataFlow::Node getChannel();
     
     /**
-     * The string value that is the channel the message is sent on.
+     * Gets the string value that is the channel the message is sent on.
      */
     abstract string getChannelValue();
   }
   
   /**
-   * A data flow node that is sent as an initial Electron IPC message from the main process.
+   * A data flow node that is sent as an initial Electron IPC message from the renderer process.
    */
   class IPCRendererSentMessage extends IPCRendererMessage {
     DataFlow::Node channel;
@@ -306,7 +306,7 @@ module Electron {
   }
   
   /**
-   * A data flow node that is sent as an asynchronous Electron IPC reply from the main process.
+   * A data flow node that is sent as an asynchronous Electron IPC reply from the renderer process.
    */
   class IPCRendererAsyncReplyMessage extends IPCRendererMessage {
     DataFlow::Node channel;
@@ -329,7 +329,7 @@ module Electron {
   }
 
   /**
-   * A data flow node that is sent as a synchronous Electron IPC message from the main process.
+   * A data flow node that is sent as a synchronous Electron IPC message from the renderer process.
    */
   class IPCRendererSyncReplyMessage extends DataFlow::Node {
     DataFlow::Node channel;
@@ -351,7 +351,7 @@ module Electron {
   }
   
   /**
-   * A data flow node that is a call to a synchronous Electron IPC method in the main process.
+   * A data flow node that is a call to a synchronous Electron IPC method in the renderer process.
    */
   class IPCRendererSendSync extends DataFlow::MethodCallNode {
     DataFlow::Node channel;

--- a/javascript/ql/test/library-tests/frameworks/Electron/IPCSimpleFlow.expected
+++ b/javascript/ql/test/library-tests/frameworks/Electron/IPCSimpleFlow.expected
@@ -1,0 +1,4 @@
+| electron.js:7:30:7:35 | 'pong' | electron.js:16:33:16:35 | arg | reply |
+| electron.js:12:23:12:28 | 'pong' | electron.js:22:1:22:36 | ipcRend ... 'ping') | sync |
+| electron.js:20:27:20:32 | 'ping' | electron.js:6:29:6:31 | arg | async |
+| electron.js:22:30:22:35 | 'ping' | electron.js:11:28:11:30 | arg | sync |

--- a/javascript/ql/test/library-tests/frameworks/Electron/IPCSimpleFlow.ql
+++ b/javascript/ql/test/library-tests/frameworks/Electron/IPCSimpleFlow.ql
@@ -2,5 +2,5 @@
 import javascript
 
 from DataFlow::Node pred, DataFlow::Node succ, string channel
-where Electron::ipcSimpleFlowStep(pred, succ, channel)
+where Electron::IPC::simpleFlowStep(pred, succ, channel)
 select pred, succ, channel

--- a/javascript/ql/test/library-tests/frameworks/Electron/IPCSimpleFlow.ql
+++ b/javascript/ql/test/library-tests/frameworks/Electron/IPCSimpleFlow.ql
@@ -1,0 +1,6 @@
+
+import javascript
+
+from DataFlow::Node pred, DataFlow::Node succ, string channel
+where Electron::ipcSimpleFlowStep(pred, succ, channel)
+select pred, succ, channel

--- a/javascript/ql/test/library-tests/frameworks/Electron/WebPreferences.expected
+++ b/javascript/ql/test/library-tests/frameworks/Electron/WebPreferences.expected
@@ -1,2 +1,2 @@
 | electron.js:3:36:3:37 | {} |
-| electron.js:4:34:4:35 | {} |
+| electron.js:4:45:4:46 | {} |

--- a/javascript/ql/test/library-tests/frameworks/Electron/electron.js
+++ b/javascript/ql/test/library-tests/frameworks/Electron/electron.js
@@ -1,4 +1,22 @@
-const {BrowserView, BrowserWindow} = require('electron')
+const {ipcMain, ipcRenderer, BrowserView, BrowserWindow} = require('electron')
 
 new BrowserWindow({webPreferences: {}})
-new BrowserView({webPreferences: {}})
+renderer = new BrowserView({webPreferences: {}})
+
+ipcMain.on('async', (event, arg) => {
+  event.sender.send('reply', 'pong');
+  arg
+})
+
+ipcMain.on('sync', (event, arg) => {
+  event.returnValue = 'pong';
+  arg;
+})
+
+ipcRenderer.on('reply', (event, arg) => {
+  arg
+})
+
+ipcRenderer.send('async', 'ping')
+
+ipcRenderer.sendSync('sync', 'ping')


### PR DESCRIPTION
This adds support for Electron inter-process communication in dataflow,
using only local flow on string literals to match calls across
processes. It is intended as a basis for future work using dataflow to
match calls between processes.