### PR TITLE
C++, JS: fix broken links in query help

### DIFF
--- a/cpp/ql/src/Architecture/Refactoring Opportunities/ClassesWithManyDependencies.qhelp
+++ b/cpp/ql/src/Architecture/Refactoring Opportunities/ClassesWithManyDependencies.qhelp
@@ -26,7 +26,7 @@ could be refactored into smaller, more cohesive classes.</p>
 Microsoft Patterns &amp; Practices Team. <a href="http://msdn.microsoft.com/en-us/library/ee658117.aspx">Architectural Patterns and Styles</a> <em>Microsoft Application Architecture Guide, 2nd Edition.</em> Microsoft Press, 2009.
 </li>
 <li>
-  <a href="en.wikipedia.org/wiki/Code_refactoring">Wikipedia: Code refactoring</a>
+  <a href="https://en.wikipedia.org/wiki/Code_refactoring">Wikipedia: Code refactoring</a>
 </li>
 
 

--- a/cpp/ql/src/Architecture/Refactoring Opportunities/ClassesWithManyFields.qhelp
+++ b/cpp/ql/src/Architecture/Refactoring Opportunities/ClassesWithManyFields.qhelp
@@ -28,7 +28,7 @@ and using composition.</p>
 Microsoft Patterns &amp; Practices Team, <em>Microsoft Application Architecture Guide (2nd Edition), Chapter 3: Architectural Patterns and Styles.</em> Microsoft Press, 2009 (<a href="http://msdn.microsoft.com/en-us/library/ee658117.aspx">available online</a>).
 </li>
 <li>
-  Wikipedia: <a href="en.wikipedia.org/wiki/Code_refactoring">Code refactoring</a>
+  Wikipedia: <a href="https://en.wikipedia.org/wiki/Code_refactoring">Code refactoring</a>
 </li>
 
 

--- a/cpp/ql/src/Best Practices/BlockWithTooManyStatements.qhelp
+++ b/cpp/ql/src/Best Practices/BlockWithTooManyStatements.qhelp
@@ -27,7 +27,7 @@ The top-level logic will be clearer if each complex statement is extracted to a 
   M. Fowler. <em>Refactoring</em> Addison-Wesley, 1999.
 </li>
 <li>
-  <a href="en.wikipedia.org/wiki/Code_refactoring">Wikipedia: Code refactoring</a>
+  <a href="https://en.wikipedia.org/wiki/Code_refactoring">Wikipedia: Code refactoring</a>
 </li>
 <li>
   Microsoft Patterns &amp; Practices Team. <a href="http://msdn.microsoft.com/en-us/library/ee658117.aspx">Architectural Patterns and Styles</a> <em>Microsoft Application Architecture Guide, 2nd Edition.</em> Microsoft Press, 2009.

--- a/cpp/ql/src/Metrics/Classes/CAfferentCoupling.qhelp
+++ b/cpp/ql/src/Metrics/Classes/CAfferentCoupling.qhelp
@@ -70,7 +70,7 @@ in this situation, they can often be deleted.
   M. Fowler. <em>Refactoring</em>. Addison-Wesley, 1999.
 </li>
 <li>
-  <a href="en.wikipedia.org/wiki/Code_refactoring">Wikipedia: Code refactoring</a>
+  <a href="https://en.wikipedia.org/wiki/Code_refactoring">Wikipedia: Code refactoring</a>
 </li>
 <li>
   <a href="http://www.jot.fm/issues/issue_2005_01/column1/">Refactoring as Meta Programming?</a>

--- a/cpp/ql/src/Metrics/Classes/CEfferentCoupling.qhelp
+++ b/cpp/ql/src/Metrics/Classes/CEfferentCoupling.qhelp
@@ -35,7 +35,7 @@ R. Martin. <em>Agile Software Development: Principles, Patterns and Practices</e
   M. Fowler. <em>Refactoring</em>. Addison-Wesley, 1999.
 </li>
 <li>
-  <a href="en.wikipedia.org/wiki/Code_refactoring">Wikipedia: Code refactoring</a>
+  <a href="https://en.wikipedia.org/wiki/Code_refactoring">Wikipedia: Code refactoring</a>
 </li>
 <li>
   <a href="http://www.jot.fm/issues/issue_2005_01/column1/">Refactoring as Meta Programming?</a>

--- a/cpp/ql/src/Metrics/Classes/CInheritanceDepth.qhelp
+++ b/cpp/ql/src/Metrics/Classes/CInheritanceDepth.qhelp
@@ -58,7 +58,7 @@ approach is to use a component-based architecture (i.e. composition).
   M. Fowler. <em>Refactoring</em>. Addison-Wesley, 1999.
 </li>
 <li>
-  <a href="en.wikipedia.org/wiki/Code_refactoring">Wikipedia: Code refactoring</a>
+  <a href="https://en.wikipedia.org/wiki/Code_refactoring">Wikipedia: Code refactoring</a>
 </li>
 
 

--- a/cpp/ql/src/Metrics/Classes/CPercentageOfComplexCode.qhelp
+++ b/cpp/ql/src/Metrics/Classes/CPercentageOfComplexCode.qhelp
@@ -40,7 +40,7 @@ new problem (as per the advice given for that situation).
   M. Fowler. <em>Refactoring</em>. Addison-Wesley, 1999.
 </li>
 <li>
-  <a href="en.wikipedia.org/wiki/Code_refactoring">Wikipedia: Code refactoring</a>
+  <a href="https://en.wikipedia.org/wiki/Code_refactoring">Wikipedia: Code refactoring</a>
 </li>
 <li>
   <a href="http://www.jot.fm/issues/issue_2005_01/column1/">Refactoring as Meta Programming?</a>

--- a/cpp/ql/src/Metrics/Files/FAfferentCoupling.qhelp
+++ b/cpp/ql/src/Metrics/Files/FAfferentCoupling.qhelp
@@ -44,7 +44,7 @@ with uses of its public API (augmenting it if necessary).</p>
   M. Fowler. <em>Refactoring</em>. Addison-Wesley, 1999.
 </li>
 <li>
-  <a href="en.wikipedia.org/wiki/Code_refactoring">Wikipedia: Code refactoring</a>
+  <a href="https://en.wikipedia.org/wiki/Code_refactoring">Wikipedia: Code refactoring</a>
 </li>
 <li>
   <a href="http://www.jot.fm/issues/issue_2005_01/column1/">Refactoring as Meta Programming?</a>

--- a/cpp/ql/src/Metrics/Files/FDirectIncludes.qhelp
+++ b/cpp/ql/src/Metrics/Files/FDirectIncludes.qhelp
@@ -24,7 +24,7 @@ unnecessarily long.</p>
   M. Fowler. <em>Refactoring</em>. Addison-Wesley, 1999.
 </li>
 <li>
-  <a href="en.wikipedia.org/wiki/Code_refactoring">Wikipedia: Code refactoring</a>
+  <a href="https://en.wikipedia.org/wiki/Code_refactoring">Wikipedia: Code refactoring</a>
 </li>
 <li>
   <a href="http://www.jot.fm/issues/issue_2005_01/column1/">Refactoring as Meta Programming?</a>

--- a/cpp/ql/src/Metrics/Files/FEfferentCoupling.qhelp
+++ b/cpp/ql/src/Metrics/Files/FEfferentCoupling.qhelp
@@ -28,7 +28,7 @@ purpose are more easily comprehended and maintained.</p>
   M. Fowler. <em>Refactoring</em>. Addison-Wesley, 1999.
 </li>
 <li>
-  <a href="en.wikipedia.org/wiki/Code_refactoring">Wikipedia: Code refactoring</a>
+  <a href="https://en.wikipedia.org/wiki/Code_refactoring">Wikipedia: Code refactoring</a>
 </li>
 <li>
   <a href="http://www.jot.fm/issues/issue_2005_01/column1/">Refactoring as Meta Programming?</a>

--- a/cpp/ql/src/Metrics/Files/FunctionLength.qhelp
+++ b/cpp/ql/src/Metrics/Files/FunctionLength.qhelp
@@ -18,7 +18,7 @@
   M. Fowler. <em>Refactoring</em>. Addison-Wesley, 1999.
 </li>
 <li>
-  <a href="en.wikipedia.org/wiki/Code_refactoring">Wikipedia: Code refactoring</a>
+  <a href="https://en.wikipedia.org/wiki/Code_refactoring">Wikipedia: Code refactoring</a>
 </li>
 <li>
   <a href="http://www.jot.fm/issues/issue_2005_01/column1/">Refactoring as Meta Programming?</a>

--- a/cpp/ql/src/Metrics/Files/NumberOfFunctions.qhelp
+++ b/cpp/ql/src/Metrics/Files/NumberOfFunctions.qhelp
@@ -27,7 +27,7 @@ and split the file according to these tasks.</p>
   M. Fowler. <em>Refactoring</em>. Addison-Wesley, 1999.
 </li>
 <li>
-  <a href="en.wikipedia.org/wiki/Code_refactoring">Wikipedia: Code refactoring</a>
+  <a href="https://en.wikipedia.org/wiki/Code_refactoring">Wikipedia: Code refactoring</a>
 </li>
 <li>
   <a href="http://www.jot.fm/issues/issue_2005_01/column1/">Refactoring as Meta Programming?</a>

--- a/cpp/ql/src/Metrics/Files/NumberOfParameters.qhelp
+++ b/cpp/ql/src/Metrics/Files/NumberOfParameters.qhelp
@@ -33,7 +33,7 @@ encapsulated into a single struct, with utility functions for common operations.
   M. Fowler. <em>Refactoring</em>. Addison-Wesley, 1999.
 </li>
 <li>
-  <a href="en.wikipedia.org/wiki/Code_refactoring">Wikipedia: Code refactoring</a>
+  <a href="https://en.wikipedia.org/wiki/Code_refactoring">Wikipedia: Code refactoring</a>
 </li>
 <li>
   <a href="http://www.jot.fm/issues/issue_2005_01/column1/">Refactoring as Meta Programming?</a>

--- a/cpp/ql/src/Metrics/Files/NumberOfPublicFunctions.qhelp
+++ b/cpp/ql/src/Metrics/Files/NumberOfPublicFunctions.qhelp
@@ -31,7 +31,7 @@ questions:</p>
   M. Fowler. <em>Refactoring</em>. Addison-Wesley, 1999.
 </li>
 <li>
-  <a href="en.wikipedia.org/wiki/Code_refactoring">Wikipedia: Code refactoring</a>
+  <a href="https://en.wikipedia.org/wiki/Code_refactoring">Wikipedia: Code refactoring</a>
 </li>
 <li>
   <a href="http://www.jot.fm/issues/issue_2005_01/column1/">Refactoring as Meta Programming?</a>

--- a/cpp/ql/src/Metrics/Functions/FunCyclomaticComplexity.qhelp
+++ b/cpp/ql/src/Metrics/Functions/FunCyclomaticComplexity.qhelp
@@ -29,7 +29,7 @@ Straight-line code has zero cyclomatic complexity, while branches and loops incr
   M. Fowler. <em>Refactoring</em>. Addison-Wesley, 1999.
 </li>
 <li>
-  <a href="en.wikipedia.org/wiki/Code_refactoring">Wikipedia: Code refactoring</a>
+  <a href="https://en.wikipedia.org/wiki/Code_refactoring">Wikipedia: Code refactoring</a>
 </li>
 <li>
   <a href="http://www.jot.fm/issues/issue_2005_01/column1/">Refactoring as Meta Programming?</a>

--- a/cpp/ql/src/Metrics/Functions/FunLinesOfCode.qhelp
+++ b/cpp/ql/src/Metrics/Functions/FunLinesOfCode.qhelp
@@ -18,7 +18,7 @@
   M. Fowler. <em>Refactoring</em>. Addison-Wesley, 1999.
 </li>
 <li>
-  <a href="en.wikipedia.org/wiki/Code_refactoring">Wikipedia: Code refactoring</a>
+  <a href="https://en.wikipedia.org/wiki/Code_refactoring">Wikipedia: Code refactoring</a>
 </li>
 <li>
   <a href="http://www.jot.fm/issues/issue_2005_01/column1/">Refactoring as Meta Programming?</a>

--- a/cpp/ql/src/Metrics/Functions/FunNumberOfCalls.qhelp
+++ b/cpp/ql/src/Metrics/Functions/FunNumberOfCalls.qhelp
@@ -22,7 +22,7 @@
   M. Fowler. <em>Refactoring</em>. Addison-Wesley, 1999.
 </li>
 <li>
-  <a href="en.wikipedia.org/wiki/Code_refactoring">Wikipedia: Code refactoring</a>
+  <a href="https://en.wikipedia.org/wiki/Code_refactoring">Wikipedia: Code refactoring</a>
 </li>
 <li>
   <a href="http://www.jot.fm/issues/issue_2005_01/column1/">Refactoring as Meta Programming?</a>

--- a/cpp/ql/src/Metrics/Functions/FunNumberOfParameters.qhelp
+++ b/cpp/ql/src/Metrics/Functions/FunNumberOfParameters.qhelp
@@ -27,7 +27,7 @@ functions for the different use cases.</p>
   M. Fowler. <em>Refactoring</em>. Addison-Wesley, 1999.
 </li>
 <li>
-  <a href="en.wikipedia.org/wiki/Code_refactoring">Wikipedia: Code refactoring</a>
+  <a href="https://en.wikipedia.org/wiki/Code_refactoring">Wikipedia: Code refactoring</a>
 </li>
 <li>
   <a href="http://www.jot.fm/issues/issue_2005_01/column1/">Refactoring as Meta Programming?</a>

--- a/cpp/ql/src/Metrics/Functions/FunNumberOfStatements.qhelp
+++ b/cpp/ql/src/Metrics/Functions/FunNumberOfStatements.qhelp
@@ -29,7 +29,7 @@ reuse of the extracted subfunctionality.</p>
   M. Fowler. <em>Refactoring</em>. Addison-Wesley, 1999.
 </li>
 <li>
-  <a href="en.wikipedia.org/wiki/Code_refactoring">Wikipedia: Code refactoring</a>
+  <a href="https://en.wikipedia.org/wiki/Code_refactoring">Wikipedia: Code refactoring</a>
 </li>
 <li>
   <a href="http://www.jot.fm/issues/issue_2005_01/column1/">Refactoring as Meta Programming?</a>

--- a/cpp/ql/src/Metrics/Functions/StatementNestingDepth.qhelp
+++ b/cpp/ql/src/Metrics/Functions/StatementNestingDepth.qhelp
@@ -23,7 +23,7 @@ Deep nesting makes code very difficult to read and modify, and is also a sign th
   M. Fowler. <em>Refactoring</em>. Addison-Wesley, 1999.
 </li>
 <li>
-  <a href="en.wikipedia.org/wiki/Code_refactoring">Wikipedia: Code refactoring</a>
+  <a href="https://en.wikipedia.org/wiki/Code_refactoring">Wikipedia: Code refactoring</a>
 </li>
 <li>
   <a href="http://www.jot.fm/issues/issue_2005_01/column1/">Refactoring as Meta Programming?</a>

--- a/javascript/ql/src/Metrics/FFunctions.qhelp
+++ b/javascript/ql/src/Metrics/FFunctions.qhelp
@@ -19,7 +19,7 @@ the file according to these tasks.</p>
 <references>
 
 <li>M. Fowler, <em>Refactoring</em>. Addison-Wesley, 1999.</li>
-<li>Wikipedia: <a href="en.wikipedia.org/wiki/Code_refactoring">Code refactoring</a>.</li>
+<li>Wikipedia: <a href="https://en.wikipedia.org/wiki/Code_refactoring">Code refactoring</a>.</li>
 
 
 </references>

--- a/javascript/ql/src/Metrics/FunLinesOfCode.qhelp
+++ b/javascript/ql/src/Metrics/FunLinesOfCode.qhelp
@@ -18,7 +18,7 @@
   M. Fowler. <em>Refactoring</em>. Addison-Wesley, 1999.
 </li>
 <li>
-  <a href="en.wikipedia.org/wiki/Code_refactoring">Wikipedia: Code refactoring</a>
+  <a href="https://en.wikipedia.org/wiki/Code_refactoring">Wikipedia: Code refactoring</a>
 </li>
 
 </references>


### PR DESCRIPTION
Looks like this may have been a search & replace mistake.