### PR TITLE
C++: Performance of IRBlock and more

### DIFF
--- a/cpp/ql/src/semmle/code/cpp/ir/internal/FunctionIR.qll
+++ b/cpp/ql/src/semmle/code/cpp/ir/internal/FunctionIR.qll
@@ -38,6 +38,7 @@ class FunctionIR extends TFunctionIR {
   /**
    * Gets the entry point for this function.
    */
+  pragma[noinline]
   final EnterFunctionInstruction getEnterFunctionInstruction() {
     result.getFunctionIR() = this
   }
@@ -45,10 +46,12 @@ class FunctionIR extends TFunctionIR {
   /**
    * Gets the exit point for this function.
    */
+  pragma[noinline]
   final ExitFunctionInstruction getExitFunctionInstruction() {
     result.getFunctionIR() = this
   }
 
+  pragma[noinline]
   final UnmodeledDefinitionInstruction getUnmodeledDefinitionInstruction() {
     result.getFunctionIR() = this
   }
@@ -56,6 +59,7 @@ class FunctionIR extends TFunctionIR {
   /**
    * Gets the single return instruction for this function.
    */
+  pragma[noinline]
   final ReturnInstruction getReturnInstruction() {
     result.getFunctionIR() = this
   }
@@ -64,6 +68,7 @@ class FunctionIR extends TFunctionIR {
    * Gets the variable used to hold the return value of this function. If this
    * function does not return a value, this predicate does not hold.
    */
+  pragma[noinline]
   final IRReturnVariable getReturnVariable() {
     result.getFunctionIR() = this
   }
@@ -71,6 +76,7 @@ class FunctionIR extends TFunctionIR {
   /**
    * Gets the block containing the entry point of this function.
    */  
+  pragma[noinline]
   final IRBlock getEntryBlock() {
     result.getFirstInstruction() = getEnterFunctionInstruction()
   }

--- a/cpp/ql/src/semmle/code/cpp/ir/internal/IRBlock.qll
+++ b/cpp/ql/src/semmle/code/cpp/ir/internal/IRBlock.qll
@@ -1,4 +1,3 @@
-private import IRInternal
 import Instruction
 import cpp
 import semmle.code.cpp.ir.EdgeKind
@@ -89,8 +88,7 @@ class IRBlock extends TIRBlock {
   }
 
   final PhiInstruction getAPhiInstruction() {
-    Construction::getPhiInstructionBlockStart(result) =
-      getFirstInstruction()
+    none()
   }
 
   final Instruction getAnInstruction() {

--- a/cpp/ql/src/semmle/code/cpp/ir/internal/IRBlock.qll
+++ b/cpp/ql/src/semmle/code/cpp/ir/internal/IRBlock.qll
@@ -1,78 +1,11 @@
+private import IRInternal
+private import IRBlockConstruction
 import Instruction
-import cpp
 import semmle.code.cpp.ir.EdgeKind
 
-private predicate startsBasicBlock(Instruction instr) {
-  not instr instanceof PhiInstruction and
-  (
-    count(Instruction predecessor |
-      instr = predecessor.getASuccessor()
-    ) != 1 or  // Multiple predecessors or no predecessor
-    exists(Instruction predecessor |
-      instr = predecessor.getASuccessor() and
-      strictcount(Instruction other |
-        other = predecessor.getASuccessor()
-      ) > 1
-    ) or  // Predecessor has multiple successors
-    exists(Instruction predecessor, EdgeKind kind |
-      instr = predecessor.getSuccessor(kind) and
-      not kind instanceof GotoEdge
-    )  // Incoming edge is not a GotoEdge
-  )
-}
-
-private predicate isEntryBlock(TIRBlock block) {
-  block = MkIRBlock(any(EnterFunctionInstruction enter))
-}
-
-private import Cached
-private cached module Cached {
-  cached newtype TIRBlock =
-    MkIRBlock(Instruction firstInstr) {
-      startsBasicBlock(firstInstr)
-    }
-
-  cached Instruction getInstruction(TIRBlock block, int index) {
-    index = 0 and block = MkIRBlock(result) or
-    (
-      index > 0 and
-      not startsBasicBlock(result) and
-      exists(Instruction predecessor, GotoEdge edge |
-        predecessor = getInstruction(block, index - 1) and
-        result = predecessor.getSuccessor(edge)
-      )
-    )
-  }
-
-  cached int getInstructionCount(TIRBlock block) {
-    result = strictcount(getInstruction(block, _))
-  }
-
-  cached predicate blockSuccessor(TIRBlock pred, TIRBlock succ, EdgeKind kind) {
-    exists(Instruction predLast, Instruction succFirst |
-      predLast = getInstruction(pred, getInstructionCount(pred) - 1) and
-      succFirst = predLast.getSuccessor(kind) and
-      succ = MkIRBlock(succFirst)
-    )
-  }
-
-  cached predicate blockSuccessor(TIRBlock pred, TIRBlock succ) {
-    blockSuccessor(pred, succ, _)
-  }
-
-  cached predicate blockImmediatelyDominates(TIRBlock dominator, TIRBlock block) =
-    idominance(isEntryBlock/1, blockSuccessor/2)(_, dominator, block)
-}
-
 class IRBlock extends TIRBlock {
-  Instruction firstInstr;
-
-  IRBlock() {
-    this = MkIRBlock(firstInstr)
-  }
-
   final string toString() {
-    result = firstInstr.toString()
+    result = getFirstInstruction(this).toString()
   }
 
   final Location getLocation() {
@@ -80,7 +13,7 @@ class IRBlock extends TIRBlock {
   }
   
   final string getUniqueId() {
-    result = firstInstr.getUniqueId()
+    result = getFirstInstruction(this).getUniqueId()
   }
   
   final Instruction getInstruction(int index) {
@@ -88,7 +21,7 @@ class IRBlock extends TIRBlock {
   }
 
   final PhiInstruction getAPhiInstruction() {
-    none()
+    Construction::getPhiInstructionBlockStart(result) = getFirstInstruction()
   }
 
   final Instruction getAnInstruction() {
@@ -97,7 +30,7 @@ class IRBlock extends TIRBlock {
   }
 
   final Instruction getFirstInstruction() {
-    result = firstInstr
+    result = getFirstInstruction(this)
   }
 
   final Instruction getLastInstruction() {
@@ -109,11 +42,11 @@ class IRBlock extends TIRBlock {
   }
 
   final FunctionIR getFunctionIR() {
-    result = firstInstr.getFunctionIR()
+    result = getFirstInstruction(this).getFunctionIR()
   }
 
   final Function getFunction() {
-    result = firstInstr.getFunction()
+    result = getFirstInstruction(this).getFunction()
   }
 
   final IRBlock getASuccessor() {

--- a/cpp/ql/src/semmle/code/cpp/ir/internal/IRBlockConstruction.qll
+++ b/cpp/ql/src/semmle/code/cpp/ir/internal/IRBlockConstruction.qll
@@ -1,0 +1,70 @@
+private import IRInternal
+import Instruction
+import cpp
+import semmle.code.cpp.ir.EdgeKind
+
+private predicate startsBasicBlock(Instruction instr) {
+  not instr instanceof PhiInstruction and
+  (
+    count(Instruction predecessor |
+      instr = predecessor.getASuccessor()
+    ) != 1 or  // Multiple predecessors or no predecessor
+    exists(Instruction predecessor |
+      instr = predecessor.getASuccessor() and
+      strictcount(Instruction other |
+        other = predecessor.getASuccessor()
+      ) > 1
+    ) or  // Predecessor has multiple successors
+    exists(Instruction predecessor, EdgeKind kind |
+      instr = predecessor.getSuccessor(kind) and
+      not kind instanceof GotoEdge
+    )  // Incoming edge is not a GotoEdge
+  )
+}
+
+private predicate isEntryBlock(TIRBlock block) {
+  block = MkIRBlock(any(EnterFunctionInstruction enter))
+}
+
+import Cached
+private cached module Cached {
+  cached newtype TIRBlock =
+    MkIRBlock(Instruction firstInstr) {
+      startsBasicBlock(firstInstr)
+    }
+
+  cached Instruction getInstruction(TIRBlock block, int index) {
+    index = 0 and block = MkIRBlock(result) or
+    (
+      index > 0 and
+      not startsBasicBlock(result) and
+      exists(Instruction predecessor, GotoEdge edge |
+        predecessor = getInstruction(block, index - 1) and
+        result = predecessor.getSuccessor(edge)
+      )
+    )
+  }
+
+  cached int getInstructionCount(TIRBlock block) {
+    result = strictcount(getInstruction(block, _))
+  }
+
+  cached predicate blockSuccessor(TIRBlock pred, TIRBlock succ, EdgeKind kind) {
+    exists(Instruction predLast, Instruction succFirst |
+      predLast = getInstruction(pred, getInstructionCount(pred) - 1) and
+      succFirst = predLast.getSuccessor(kind) and
+      succ = MkIRBlock(succFirst)
+    )
+  }
+
+  cached predicate blockSuccessor(TIRBlock pred, TIRBlock succ) {
+    blockSuccessor(pred, succ, _)
+  }
+
+  cached predicate blockImmediatelyDominates(TIRBlock dominator, TIRBlock block) =
+    idominance(isEntryBlock/1, blockSuccessor/2)(_, dominator, block)
+}
+
+Instruction getFirstInstruction(TIRBlock block) {
+  block = MkIRBlock(result)
+}

--- a/cpp/ql/src/semmle/code/cpp/ir/internal/IRConstruction.qll
+++ b/cpp/ql/src/semmle/code/cpp/ir/internal/IRConstruction.qll
@@ -1,7 +1,6 @@
 import cpp
 import semmle.code.cpp.ir.IR
 private import InstructionTag
-private import Opcode
 private import TempVariableTag
 private import TranslatedElement
 private import TranslatedFunction

--- a/cpp/ql/src/semmle/code/cpp/ssa/internal/aliased_ssa/FunctionIR.qll
+++ b/cpp/ql/src/semmle/code/cpp/ssa/internal/aliased_ssa/FunctionIR.qll
@@ -38,6 +38,7 @@ class FunctionIR extends TFunctionIR {
   /**
    * Gets the entry point for this function.
    */
+  pragma[noinline]
   final EnterFunctionInstruction getEnterFunctionInstruction() {
     result.getFunctionIR() = this
   }
@@ -45,10 +46,12 @@ class FunctionIR extends TFunctionIR {
   /**
    * Gets the exit point for this function.
    */
+  pragma[noinline]
   final ExitFunctionInstruction getExitFunctionInstruction() {
     result.getFunctionIR() = this
   }
 
+  pragma[noinline]
   final UnmodeledDefinitionInstruction getUnmodeledDefinitionInstruction() {
     result.getFunctionIR() = this
   }
@@ -56,6 +59,7 @@ class FunctionIR extends TFunctionIR {
   /**
    * Gets the single return instruction for this function.
    */
+  pragma[noinline]
   final ReturnInstruction getReturnInstruction() {
     result.getFunctionIR() = this
   }
@@ -64,6 +68,7 @@ class FunctionIR extends TFunctionIR {
    * Gets the variable used to hold the return value of this function. If this
    * function does not return a value, this predicate does not hold.
    */
+  pragma[noinline]
   final IRReturnVariable getReturnVariable() {
     result.getFunctionIR() = this
   }
@@ -71,6 +76,7 @@ class FunctionIR extends TFunctionIR {
   /**
    * Gets the block containing the entry point of this function.
    */  
+  pragma[noinline]
   final IRBlock getEntryBlock() {
     result.getFirstInstruction() = getEnterFunctionInstruction()
   }

--- a/cpp/ql/src/semmle/code/cpp/ssa/internal/aliased_ssa/IRBlockConstruction.qll
+++ b/cpp/ql/src/semmle/code/cpp/ssa/internal/aliased_ssa/IRBlockConstruction.qll
@@ -1,0 +1,38 @@
+private import IRInternal
+private import Construction::OldIR as OldIR
+import Instruction
+
+import Cached
+private cached module Cached {
+  cached newtype TIRBlock = MkIRBlock(OldIR::IRBlock oldBlock)
+
+  private OldIR::IRBlock getOldBlock(TIRBlock block) {
+    block = MkIRBlock(result)
+  }
+
+  cached Instruction getInstruction(TIRBlock block, int index) {
+    Construction::getOldInstruction(result) =
+      getOldBlock(block).getInstruction(index)
+  }
+
+  cached int getInstructionCount(TIRBlock block) {
+    result = getOldBlock(block).getInstructionCount()
+  }
+
+  cached predicate blockSuccessor(TIRBlock pred, TIRBlock succ, EdgeKind kind) {
+    succ = MkIRBlock(getOldBlock(pred).getSuccessor(kind))
+  }
+
+  cached predicate blockSuccessor(TIRBlock pred, TIRBlock succ) {
+    blockSuccessor(pred, succ, _)
+  }
+
+  cached predicate blockImmediatelyDominates(TIRBlock dominator, TIRBlock block) {
+    getOldBlock(dominator).immediatelyDominates(getOldBlock(block))
+  }
+
+  cached Instruction getFirstInstruction(TIRBlock block) {
+    Construction::getOldInstruction(result) =
+      getOldBlock(block).getFirstInstruction()
+  }
+}

--- a/cpp/ql/src/semmle/code/cpp/ssa/internal/aliased_ssa/SSAConstruction.qll
+++ b/cpp/ql/src/semmle/code/cpp/ssa/internal/aliased_ssa/SSAConstruction.qll
@@ -59,7 +59,7 @@ cached private module Cached {
   }
 
   private Instruction getNewInstruction(OldIR::Instruction instr) {
-    result.getTag() = WrappedInstructionTag(instr)
+    getOldInstruction(result) = instr
   }
 
   private PhiInstruction getPhiInstruction(Function func, OldIR::IRBlock oldBlock,

--- a/cpp/ql/src/semmle/code/cpp/ssa/internal/ssa/FunctionIR.qll
+++ b/cpp/ql/src/semmle/code/cpp/ssa/internal/ssa/FunctionIR.qll
@@ -38,6 +38,7 @@ class FunctionIR extends TFunctionIR {
   /**
    * Gets the entry point for this function.
    */
+  pragma[noinline]
   final EnterFunctionInstruction getEnterFunctionInstruction() {
     result.getFunctionIR() = this
   }
@@ -45,10 +46,12 @@ class FunctionIR extends TFunctionIR {
   /**
    * Gets the exit point for this function.
    */
+  pragma[noinline]
   final ExitFunctionInstruction getExitFunctionInstruction() {
     result.getFunctionIR() = this
   }
 
+  pragma[noinline]
   final UnmodeledDefinitionInstruction getUnmodeledDefinitionInstruction() {
     result.getFunctionIR() = this
   }
@@ -56,6 +59,7 @@ class FunctionIR extends TFunctionIR {
   /**
    * Gets the single return instruction for this function.
    */
+  pragma[noinline]
   final ReturnInstruction getReturnInstruction() {
     result.getFunctionIR() = this
   }
@@ -64,6 +68,7 @@ class FunctionIR extends TFunctionIR {
    * Gets the variable used to hold the return value of this function. If this
    * function does not return a value, this predicate does not hold.
    */
+  pragma[noinline]
   final IRReturnVariable getReturnVariable() {
     result.getFunctionIR() = this
   }
@@ -71,6 +76,7 @@ class FunctionIR extends TFunctionIR {
   /**
    * Gets the block containing the entry point of this function.
    */  
+  pragma[noinline]
   final IRBlock getEntryBlock() {
     result.getFirstInstruction() = getEnterFunctionInstruction()
   }

--- a/cpp/ql/src/semmle/code/cpp/ssa/internal/ssa/IRBlockConstruction.qll
+++ b/cpp/ql/src/semmle/code/cpp/ssa/internal/ssa/IRBlockConstruction.qll
@@ -1,0 +1,38 @@
+private import IRInternal
+private import Construction::OldIR as OldIR
+import Instruction
+
+import Cached
+private cached module Cached {
+  cached newtype TIRBlock = MkIRBlock(OldIR::IRBlock oldBlock)
+
+  private OldIR::IRBlock getOldBlock(TIRBlock block) {
+    block = MkIRBlock(result)
+  }
+
+  cached Instruction getInstruction(TIRBlock block, int index) {
+    Construction::getOldInstruction(result) =
+      getOldBlock(block).getInstruction(index)
+  }
+
+  cached int getInstructionCount(TIRBlock block) {
+    result = getOldBlock(block).getInstructionCount()
+  }
+
+  cached predicate blockSuccessor(TIRBlock pred, TIRBlock succ, EdgeKind kind) {
+    succ = MkIRBlock(getOldBlock(pred).getSuccessor(kind))
+  }
+
+  cached predicate blockSuccessor(TIRBlock pred, TIRBlock succ) {
+    blockSuccessor(pred, succ, _)
+  }
+
+  cached predicate blockImmediatelyDominates(TIRBlock dominator, TIRBlock block) {
+    getOldBlock(dominator).immediatelyDominates(getOldBlock(block))
+  }
+
+  cached Instruction getFirstInstruction(TIRBlock block) {
+    Construction::getOldInstruction(result) =
+      getOldBlock(block).getFirstInstruction()
+  }
+}

--- a/cpp/ql/src/semmle/code/cpp/ssa/internal/ssa/SSAConstruction.qll
+++ b/cpp/ql/src/semmle/code/cpp/ssa/internal/ssa/SSAConstruction.qll
@@ -59,7 +59,7 @@ cached private module Cached {
   }
 
   private Instruction getNewInstruction(OldIR::Instruction instr) {
-    result.getTag() = WrappedInstructionTag(instr)
+    getOldInstruction(result) = instr
   }
 
   private PhiInstruction getPhiInstruction(Function func, OldIR::IRBlock oldBlock,


### PR DESCRIPTION
These four commits contain some low-hanging performance fruits I found in the IR. The tests pass, but please review thoroughly as I haven't necessarily understood the code I'm changing.

We can't actually merge this yet as it requires changes to `sync-identical-files.py` in Semmle/code. I'll make a separate PR for moving that file to this repo.