### PR TITLE
Element::getEnclosingElement: Skip macro information.

### DIFF
--- a/cpp/ql/src/semmle/code/cpp/Element.qll
+++ b/cpp/ql/src/semmle/code/cpp/Element.qll
@@ -154,8 +154,6 @@ class Element extends @element {
     namequalifiers(this, result, _, _) or
     initialisers(this, result, _, _) or
     exprconv(result, this) or
-    this = result.(MacroAccess).getParentInvocation() or
-    result = this.(MacroInvocation).getExpr() or // macroinvocation -> outer Expr
     param_decl_bind(this,_,result)
   }
 
@@ -165,17 +163,6 @@ class Element extends @element {
     (
       not exists(getEnclosingElementPref()) and
       (
-        // macroinvocation -> all enclosed elements
-        inmacroexpansion(result, this)
-        or
-        macrolocationbind(
-          this.(MacroInvocation),
-          result.(VariableDeclarationEntry).getLocation())
-        or
-        macrolocationbind(
-          this.(MacroInvocation),
-          result.(FunctionDeclarationEntry).getLocation())
-        or
         this = result.(Class).getAMember()
         or
         result = exprEnclosingElement(this)
@@ -225,8 +212,7 @@ private predicate isFromTemplateInstantiationRec(Element e, Element instantiatio
   instantiation.(Variable).isConstructedFrom(_) and
   e = instantiation
   or
-  isFromTemplateInstantiationRec(e.getEnclosingElement(), instantiation) and
-  not e instanceof MacroAccess
+  isFromTemplateInstantiationRec(e.getEnclosingElement(), instantiation)
 }
 
 private predicate isFromUninstantiatedTemplateRec(Element e, Element template) {
@@ -239,8 +225,7 @@ private predicate isFromUninstantiatedTemplateRec(Element e, Element template) {
   is_variable_template(template) and
   e = template
   or
-  isFromUninstantiatedTemplateRec(e.getEnclosingElement(), template) and
-  not e instanceof MacroAccess
+  isFromUninstantiatedTemplateRec(e.getEnclosingElement(), template)
 }
 
 /**


### PR DESCRIPTION
Previously, we would try to find an element enclosing each macro
access. This is not in general well-defined, especially in the
context of template instantiations -- macros are a lexing-time
concept, and don't map cleanly onto AST elements.

We briefly discussed this internally. Intuitively, the attempt to associate macros with enclosing AST nodes is doomed, and goes particularly wrong where a macro affects a template, as previously it would be considered "enclosed" in each distinct template instantiation -- thus invalidating any implied uniqueness properties of this predicate.

@geoffw0 you said you wanted to be pinged about this.