### PR TITLE
JavaScript: Demote `HeterogenousComparison` to warning level.

### DIFF
--- a/change-notes/1.18/analysis-javascript.md
+++ b/change-notes/1.18/analysis-javascript.md
@@ -81,6 +81,7 @@
 | **Query**                  | **Expected impact**    | **Change**                                                       |
 |----------------------------|------------------------|------------------------------------------------------------------|
 | Arguments redefined | Fewer results | This rule previously also flagged redefinitions of `eval`. This was an oversight that is now fixed. |
+| Comparison between inconvertible types | Lower severity | The severity of this rule has been revised to "warning". |
 | CORS misconfiguration for credentials transfer | More true-positive results | This rule now treats header names case-insensitively. |
 | Hard-coded credentials | More true-positive results | This rule now recognizes secret cryptographic keys. |
 | Incomplete sanitization | More true-positive results | This rule now recognizes incomplete URL encoding and decoding. |

--- a/javascript/ql/src/Expressions/HeterogeneousComparison.ql
+++ b/javascript/ql/src/Expressions/HeterogeneousComparison.ql
@@ -4,7 +4,7 @@
  *              the same type will always yield 'false', and an inequality comparison will always
  *              yield 'true'.
  * @kind problem
- * @problem.severity error
+ * @problem.severity warning
  * @id js/comparison-between-incompatible-types
  * @tags reliability
  *       correctness


### PR DESCRIPTION
In practice, this query tends to flag superfluous but harmless tests rather than actual bugs.