### PR TITLE
JS: fix typo in qhelp (parameter type confusion)

### DIFF
--- a/javascript/ql/src/Security/CWE-843/TypeConfusionThroughParameterTampering.qhelp
+++ b/javascript/ql/src/Security/CWE-843/TypeConfusionThroughParameterTampering.qhelp
@@ -15,7 +15,7 @@
 
 			However, sanitizing request parameters assuming they have type
 			<code>String</code> and using the builtin string methods such as
-			<code>String.prototye.indexOf</code> is susceptible to type confusion
+			<code>String.prototype.indexOf</code> is susceptible to type confusion
 			attacks.
 
 			In a type confusion attack, an attacker tampers with an HTTP request


### PR DESCRIPTION
I noticed this typo in the help when reading recent discussion about this query on the LGTM community forum.