### PR TITLE
FunctionsWithWrappers: Simplify/tidy library.

### DIFF
--- a/cpp/ql/src/semmle/code/cpp/security/FunctionWithWrappers.qll
+++ b/cpp/ql/src/semmle/code/cpp/security/FunctionWithWrappers.qll
@@ -139,10 +139,14 @@ abstract class FunctionWithWrappers extends Function {
    */
   predicate outermostWrapperFunctionCall(Expr arg, string callChain)
   {
-    exists(Function func, Call call, int argIndex |
-      func = resolveCall(call)
-      and this.wrapperFunction(func, argIndex, callChain)
-      and not wrapperFunctionStep(call.getEnclosingFunction(), _, func, argIndex)
+    exists(Function targetFunc, Call call, int argIndex |
+      targetFunc = resolveCall(call)
+      and this.wrapperFunction(targetFunc, argIndex, callChain)
+      and (
+        exists(Function sourceFunc | sourceFunc = call.getEnclosingFunction() |
+          not wrapperFunctionStep(sourceFunc, _, targetFunc, argIndex)
+        ) or not exists(call.getEnclosingFunction())
+      )
       and arg = call.getArgument(argIndex)
     )
   }


### PR DESCRIPTION
`call.getEnclosingFunction()` may not have a result; by making the disjunction explicit outside the negation, we allow for a simpler evaluation strategy.