### PR TITLE
QL Style Guide

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,6 +4,8 @@ We welcome contributions to our standard library and standard checks, got an ide
 
 Before we accept your pull request, we will require that you have agreed to our Contributor License Agreement, this is not something that you need to do before you submit your pull request, but until you've done so, we will be unable to accept your contribution.
 
+Please read our [QL Style Guide](docs/ql-style-guide.md) for information on how to format QL code in this repository.
+
 ## Using your personal data
 
 If you contribute to this project, we will record your name and email

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ You can use the [interactive query console](https://lgtm.com/help/lgtm/using-que
 
 ## Contributing
 
-We welcome contributions to our standard library and standard checks. Do you have an idea for a new check, or how to improve an existing query? Then please go ahead and open a pull request! Before you do, though, please take the time to read our [contributing guidelines](CONTRIBUTING.md).
+We welcome contributions to our standard library and standard checks. Do you have an idea for a new check, or how to improve an existing query? Then please go ahead and open a pull request! Before you do, though, please take the time to read our [contributing guidelines](CONTRIBUTING.md) and [QL style guide](docs/ql-style-guide.md).
 
 ## License
 

--- a/docs/ql-style-guide.md
+++ b/docs/ql-style-guide.md
@@ -4,7 +4,7 @@
 
 This document describes how to format the QL code in this repository, covering aspects such as layout, white-space, naming and documentation. Adhering to consistent standards makes code easier to read and maintain. Of course, these are only guidelines, and can be overridden as the need arises on a case-by-case basis. Where existing code deviates from these guidelines, prefer consistency with the surrounding code.
 
-Words in *italic* are defined in the [Glossary](#Glossary).
+Words in *italic* are defined in the [Glossary](#glossary).
 
 ## Indentation
 1. *Always* use 2 spaces for indentation.
@@ -175,7 +175,7 @@ private predicate foo(Expr e, Expr p) {
 1. Short or single letter names for parameters and *quantifiers* *may* be used provided that they are sufficiently clear.
 1. Use names as they are used in the target-language specification.
 
-For example,
+Examples:
 
 ```ql
 /** ... */
@@ -214,13 +214,13 @@ class Type extends ... {
 1. For multi-line documentation, the `/**` and `*/` are written on separate lines. There is a `*` preceding each comment line, aligned on the first `*`.
 1. Library files (`.qll` files) *should* be documented with QLDoc.
 1. Query files, except for tests, *must* have a QLDoc query documentation comment.
-1. Documentation *should* be appropriate for users of the library. Put documentation for maintainers in non-documentation comments.
+1. Documentation *should* be appropriate for users of the library. Put documentation for maintainers in normal comments.
 1. Predicates that do not have a result *should* be documented `/** Holds if ... */`
 1. Predicates that have a result *should* be documented `/** Gets ... */`
 1. All predicate parameters *should* be referred to in the predicate documentation.
 1. Reference names, such as types and parameters, using backticks `` ` ``.
 1. Give examples of code in the target language, enclosed in ```` ``` ````  or `` ` ``.
-1. Classes *should* be documented in the singular, e.g. `/* An expression. */`
+1. Classes *should* be documented in the singular, for example `/* An expression. */`
 1. Where a class denotes a generic concept with subclasses, list those subclasses.
 1. Declarations that are deprecated *should* be documented as `DEPRECATED: ...`
 1. Declarations that are for internal use *should* be documented as `INTERNAL: Do not use`.
@@ -278,7 +278,7 @@ deprecated Expr getInitializer()
 1. Write the `and` at the end of the line. This also applies in `where` clauses.
 1. *Prefer* to write the `or` keyword on its own line.
 1. The `or` keyword *may* be written at the end of a line, or within a line, provided that it has no unparenthesised `and` operands.
-1. Single-line formulas *may* be used in order to save space or add clarity, particularly in the body of a *quantifier/aggregation*. 
+1. Single-line formulas *may* be used in order to save space or add clarity, particularly in the *body* of a *quantifier/aggregation*. 
 1. *Avoid* additional brackets to clarify the precedence of `not`, `and` and `or`.
 1. *Always* clarify the precedence of `implies` with brackets.
 1. *Always* clarify the precedence of `if`-`then`-`else` with brackets.

--- a/docs/ql-style-guide.md
+++ b/docs/ql-style-guide.md
@@ -1,0 +1,434 @@
+# QL Style Guide
+
+## Introduction
+
+This document describes how to format the QL code in this repository, covering aspects such as layout, white-space, naming and documentation. Adhering to consistent standards makes code easier to read and maintain. Of course, these are only guidelines, and can be overridden as the need arises on a case-by-case basis. Where existing code deviates from these guidelines, prefer consistency with the surrounding code.
+
+Words in *italic* are defined in the [Glossary](#Glossary).
+
+## Indentation
+1. *Always* use 2 spaces for indentation.
+1. *Always* indent:
+   - the *body* of a module, newtype, class or predicate,
+   - the second and subsequent lines after a line break used to split a long line,
+   - the *body* of a `from`, `where` or `select` clause where it spans multiple lines,
+   - the *body* of a *quantifier* that spans multiple lines.
+
+
+Examples:
+
+```ql
+module Helpers {
+  /** ... */
+  class X ... {
+    /** ... */
+    int getNumberOfChildren () {
+      result = count(int child |
+        exists(this.getChild(child))
+      )
+    }
+  }
+}
+```
+
+```ql
+from Call c, string reason
+where isDeprecated(c, reason)
+select c, "This call to '$@' is deprecated because " + reason + ".",
+  c.getTarget(), c.getTarget().getName()
+```
+
+## Line breaks
+1. Use UNIX line endings.
+1. Lines *must not* exceed 100 characters.
+1. Long lines *should* be split with a line break, and the following lines *must* be indented one level until the next "regular" line break.
+1. There *should* be a single blank line:
+   - between the file documentation and the first `import`,
+   - before each declaration, except for the first declaration in a *body*,
+   - before the `from`-`where`-`select` section in a query file.
+1. *Avoid* two or more adjacent blank lines.
+1. There *must* be a new line after the *annotations* `cached`, `deprecated`, `pragma`, `language` and `bindingset`.
+1. There *should not* be additional blank lines within a predicate.
+1. There *may* be a new line:
+   - immediately after the `from`, `where` or `select` keywords in a query,
+   - immediately after `if`, `then`, or `else` keywords. The `then` and `else` parts *should* be consistent.
+1. *Avoid* other line breaks in declarations, other than to break long lines.
+1. When operands of *binary operators* span two lines, the operator *should* be placed at the end of the first line.
+
+Examples:
+
+```ql
+cached
+private int getNumberOfParameters() {
+  ...
+}
+```
+
+```ql
+predicate methodStats(string qualifiedName, string name,
+  int numberOfParameters, int numberOfStatements, int numberOfExpressions,
+  int linesOfCode, int nestingDepth, int numberOfBranches) {
+  ...
+}
+```
+	
+```ql
+from Method main
+where main.getName() = "Main"
+select main, "This is the program entry point." 
+```
+
+```ql
+from Method main
+where main.getName() = "Main"
+select main, "This is the program entry point." 
+```
+
+```ql
+from Method main
+where
+  main.getName() = "Main" and
+  main.getNumberOfParameters() = 0
+select main, "Main method has no parameters."
+```	
+
+```ql
+  if x.isPublic()
+  then result = "public"
+  else result = "private"
+```	
+
+```ql
+  if
+    x.isPublic()
+  then
+    result = "public"
+  else
+    result = "private"
+```
+
+## Braces
+1. Braces follow "Stroustrup" style: The opening `{` *must* be placed at the end of the preceding line.
+1. The closing `}` *must* be placed on its own line, indented to the outer level, or be on the same line as the opening `{`.
+1. Braces of empty blocks *may* be placed on a single line, with a single space separating the braces.
+1. Short predicates, not exceeding the maximum line width, *may* be placed on a single line, with a space following the opening brace and preceding the closing brace.
+
+
+For example,
+
+```ql
+class ThrowException extends ThrowExpr {
+  Foo() {
+    this.getTarget() instanceof ExceptionClass
+  }
+
+  override string toString() { result = "Throw Exception" }
+}
+```
+
+## Spaces
+1. There *must* be a space or line break:
+   - surrounding each `=` and `|`,
+   - after each comma.
+1. There *should* be a space or line break:
+   - surrounding each *binary operator*, which *must* be balanced,
+   - surrounding `..` in a range.
+   - Exceptions to this are to save space or to improve readability.
+1. *Avoid* other spaces, for example:
+   - after a *quantifier/aggregation* keyword,
+   - after the predicate name in a *call*,
+   - inside brackets used for *calls*, single-line quantifiers, and parenthesised formulas,
+   - surrounding a `.`,
+   - inside the opening or closing `[ ]` In a range expression,
+   - inside casts `a.(X)`.
+1. *Avoid* multiple spaces, except for indentation, and *avoid* additional indentation to align formulas, parameters or arguments.
+1. *Do not* put whitespace on blank lines, or trailing on the end of a line.
+1. *Do not* use tabs.
+
+
+For example,
+
+```ql
+cached
+private predicate foo(Expr e, Expr p) {
+  exists(int n |
+    n in [0 .. 1] |
+    e = p.getChild(n + 1)
+  )
+}
+```
+
+## Naming
+1. Use PascalCase for:
+   - `class` names,
+   - `module` names,
+   - `newtype` names.
+1. Use camelCase for:
+   - predicate names,
+   - variable names.
+1. Newtype predicate names *should* begin with `T`.
+1. *Avoid* underscores in names.
+1. Predicates that have a result *should* be named `get...`
+1. Predicates that can return multiple results *should* be named `getA...` or `getAn...`
+1. Predicates that don't have a result or parameters *should* be named `is...` or `has...`
+1. *Avoid* short or single-letter names for classes, predicates and fields.
+1. Short or single letter names for parameters and *quantifiers* *may* be used provided that they are sufficiently clear.
+1. Use names as they are used in the target-language specification.
+
+For example,
+
+```ql
+/** ... */
+predicate calls(Callable caller, Callable callee) {
+  ...
+}
+```
+
+```ql
+/** ... */
+class Type extends ... {
+  /** ... */
+  string getName() { ... }
+
+  /** ... */
+  predicate declares(Member m) { ... }
+
+  /** ... */
+  predicate isGeneric() { ... }
+
+  /** ... */
+  Type getTypeParameter(int n) { ... }
+
+  /** ... */
+  Type getATypeParameter() { ... }
+}
+```
+
+## Documentation
+1. Documentation *must* adhere to the [QLDoc specification](https://help.semmle.com/QL/QLDocSpecification.html).
+1. Public declarations *must* be documented.
+1. Non-public declarations *should* be documented.
+1. Declarations in query files *should* be documented.
+1. Use `/** ... */` for documentation, even for single line comments.
+1. For single-line documentation, the `/**` and `*/` are written on the same line as the comment.
+1. For multi-line documentation, the `/**` and `*/` are written on separate lines. There is a `*` preceding each comment line, aligned on the first `*`.
+1. Library files (`.qll` files) *should* be documented with QLDoc.
+1. Query files, except for tests, *must* have a QLDoc query documentation comment.
+1. Documentation *should* be appropriate for users of the library. Put documentation for maintainers in non-documentation comments.
+1. Predicates that do not have a result *should* be documented `/** Holds if ... */`
+1. Predicates that have a result *should* be documented `/** Gets ... */`
+1. All predicate parameters *should* be referred to in the predicate documentation.
+1. Reference names, such as types and parameters, using backticks `` ` ``.
+1. Give examples of code in the target language, enclosed in ```` ``` ````  or `` ` ``.
+1. Classes *should* be documented in the singular, e.g. `/* An expression. */`
+1. Where a class denotes a generic concept with subclasses, list those subclasses.
+1. Declarations that are deprecated *should* be documented as `DEPRECATED: ...`
+1. Declarations that are for internal use *should* be documented as `INTERNAL: Do not use`.
+1. Use full sentences, with capital letters and full stops.
+
+
+Examples:
+
+```ql
+/** Provides logic for determining constant expressions. */
+```	
+
+```ql
+/**
+ * Holds if the qualifier of this call has type `qualifierType`.
+ * `isExactType` indicates whether the type is exact, that is, whether
+ * the qualifier is guaranteed not to be a subtype of `qualifierType`.
+ */
+```	
+```ql
+/**
+ * A delegate declaration, for example
+ * ```
+ * delegate void Logger(string text); 
+ * ```
+ */
+class Delegate extends ...
+```
+
+```ql
+/**
+ * An element that can be called.
+ *
+ * Either a method (`Method`), a constructor (`Constructor`), a destructor
+ * (`Destructor`), an operator (`Operator`), an accessor (`Accessor`),
+ * an anonymous function (`AnonymousFunctionExpr`), or a local function
+ * (`LocalFunction`).
+ */
+class Callable extends ...
+```
+
+```ql
+/** DEPRECATED: Use `getAnExpr()` instead. */
+deprecated Expr getInitializer()
+```
+
+```ql
+/**
+ * INTERNAL: Do not use.
+ */
+```
+
+## Formulas
+1. *Prefer* one *conjunct* per line.
+1. Write the `and` at the end of the line. This also applies in `where` clauses.
+1. *Prefer* to write the `or` keyword on its own line.
+1. The `or` keyword *may* be written at the end of a line, or within a line, provided that it has no unparenthesised `and` operands.
+1. Single-line formulas *may* be used in order to save space or add clarity, particularly in the body of a *quantifier/aggregation*. 
+1. *Avoid* additional brackets to clarify the precedence of `not`, `and` and `or`.
+1. *Always* clarify the precedence of `implies` with brackets.
+1. *Always* clarify the precedence of `if`-`then`-`else` with brackets.
+1. Parenthesised formulas *can* be written:
+   - within a single line. There *should not* be an additional space following the opening parenthesis or preceding the closing parenthesis.
+   - spanning multiple lines. The opening parenthesis *should* be placed at the end of the preceding line, the body should be indented one level, and the closing bracket should be placed on a new line at the outer indentation.
+1. *Quantifiers/aggregations* *can* be written:
+   - within a single line. In this case, there is no space to the inside of the parentheses, or after the quantifier keyword.
+   - across multiple lines. In this case, type declarations are on the same line as the quantifier, the `|` *may* be at the end of the line, or *may* be on its own line, and the body of the quantifier *must* be indented one level. The closing `)` is written on a new line, at the outer indentation.
+1. `if`-`then`-`else` *can* be written:
+   - on a single line,
+   - with the *body* after the `if`/`then`/`else` keyword,
+   - with the *body* indented on the next line.
+   - *Always* parenthesise the `else` part if it is a compound formula.
+1. The `and` and `else` keywords *may* be placed on the same line as the a closing parenthesis.
+1. The `and` and `else` keywords *may* be "cuddled": `) else (`
+1. *Always* qualify *calls* to predicates of the same class with `this`.
+2. *Prefer* postfix casts `a.(Expr)` to prefix casts `(Expr)a`.
+
+Examples:
+
+```ql
+  argumentType.isImplicitlyConvertibleTo(parameterType)
+  or
+  argumentType instanceof NullType and
+  result.getParameter(i).isOut() and
+  parameterType instanceof SimpleType
+  or
+  reflectionOrDynamicArg(argumentType, parameterType)
+```
+
+```ql	
+  this.getName() = "Finalize" and not exists(this.getAParameter())
+```
+
+```ql
+  e1.getType() instanceof BoolType and (
+    b1 = true
+    or
+    b1 = false
+  ) and (
+    b2 = true
+    or
+    b2 = false
+  )
+```
+
+```ql
+  if e1 instanceof BitwiseOrExpr or e1 instanceof LogicalOrExpr then (
+    impliesSub(e1.(BinaryOperation).getAnOperand(), e2, b1, b2) and
+    b1 = false
+  ) else (
+    e1.getType() instanceof BoolType and
+    e1 = e2 and
+    b1 = b2 and
+    (b1 = true or b1 = false)
+  )
+```
+
+```ql
+  (x instanceof Exception implies x.isPublic()) and y instanceof Exception
+```	
+
+```ql
+  x instanceof Exception implies (x.isPublic() and y instanceof Exception)
+```	
+
+```ql
+  exists(Type arg | arg = this.getAChild() | arg instanceof TypeParameter)
+```	
+
+```ql
+  exists(Type qualifierType |
+    this.hasNonExactQualifierType(qualifierType) |
+    result = getANonExactQualifierSubType(qualifierType)
+  )
+```	
+
+```ql
+  methods = count(Method m | t = m.getDeclaringType() and not ilc(m))
+```	
+
+```ql
+  if n = 0 then result = 1 else result = n * f(n - 1)
+```	
+
+```ql
+  if n = 0
+  then result = 1
+  else result = n * f(n - 1)
+```	
+
+```ql
+  if
+    n = 0
+  then
+    result = 1
+  else
+    result = n * f(n - 1)
+```	
+
+```ql
+  if exists(this.getContainingType()) then (
+    result = "A nested class" and
+    parentName = this.getContainingType().getFullyQualifiedName()
+  ) else (
+    result = parentName + "." + this.getName() and
+    parentName = this.getNamespace().getFullyQualifiedName()
+  )
+```
+
+## Glossary
+*[annotation](https://help.semmle.com/QL/QLLanguageSpecification.html#annotations)*:
+An additional specifier used to modify a declaration, such as `private`, `override`, `deprecated`, `pragma`, `bindingset`, or `cached`.
+
+*body*:
+The text inside `{ }`, `( )`, or each section of an `if`-`then`-`else` or `from`-`where`-`select`.
+
+*binary operator*:
+An operator with two operands, such as comparison operators, `and`, `or`, `implies`, or arithmetic operators.
+
+*call*:
+A *formula* that invokes a predicate, e.g. `this.isStatic()` or `calls(a,b)`.
+
+
+*[conjunct](https://help.semmle.com/QL/QLLanguageSpecification.html#conjunctions)*:
+A formula that is an operand to an `and`.
+
+
+*declaration*:
+A class, module, predicate, field or newtype.
+
+
+*[disjunct](https://help.semmle.com/QL/QLLanguageSpecification.html#disjunctions)*:
+A formula that is an operand to an `or`.
+
+*[formula](https://help.semmle.com/QL/QLLanguageSpecification.html#formulas)*:
+A logical expression, such as `A = B`, a *call*, a *quantifier*, `and`, `or`, `not`, 'in` or `instanceof`.
+
+*should/should not/avoid/prefer*:
+Adhere to this rule wherever possible, where it makes sense.
+
+*may/can*:
+This is a reasonable alternative, to be used with discretion.
+
+*must/always/do not*:
+Always adhere to this rule.
+
+*[quantifier/aggregation](https://help.semmle.com/QL/QLLanguageSpecification.html#aggregations)*:
+`exists`, `count`, `strictcount`, `any`, `forall`, `forex` and so on.
+
+*variable*:
+A parameter to a predicate, a field, a from variable, or a variable introduced by a *quantifier* or *aggregation*.

--- a/docs/ql-style-guide.md
+++ b/docs/ql-style-guide.md
@@ -9,10 +9,10 @@ Words in *italic* are defined in the [Glossary](#glossary).
 ## Indentation
 1. *Always* use 2 spaces for indentation.
 1. *Always* indent:
-   - the *body* of a module, newtype, class or predicate,
-   - the second and subsequent lines after you use a line break to split a long line,
-   - the *body* of a `from`, `where` or `select` clause where it spans multiple lines,
-   - the *body* of a *quantifier* that spans multiple lines.
+   - The *body* of a module, newtype, class or predicate
+   - The second and subsequent lines after you use a line break to split a long line
+   - The *body* of a `from`, `where` or `select` clause where it spans multiple lines
+   - The *body* of a *quantifier* that spans multiple lines
 
 
 ### Examples
@@ -43,15 +43,15 @@ select c, "This call to '$@' is deprecated because " + reason + ".",
 1. Lines *must not* exceed 100 characters.
 1. Long lines *should* be split with a line break, and the following lines *must* be indented one level until the next "regular" line break.
 1. There *should* be a single blank line:
-   - between the file documentation and the first `import`,
-   - before each declaration, except for the first declaration in a *body*,
-   - before the `from`-`where`-`select` section in a query file.
+   - Between the file documentation and the first `import`
+   - Before each declaration, except for the first declaration in a *body*
+   - Before the `from`-`where`-`select` section in a query file
 1. *Avoid* two or more adjacent blank lines.
 1. There *must* be a new line after the *annotations* `cached`, `deprecated`, `pragma`, `language` and `bindingset`. Other *annotations* do not have a new line.
 1. There *should not* be additional blank lines within a predicate.
 1. There *may* be a new line:
-   - immediately after the `from`, `where` or `select` keywords in a query,
-   - immediately after `if`, `then`, or `else` keywords. The `then` and `else` parts *should* be consistent.
+   - Immediately after the `from`, `where` or `select` keywords in a query.
+   - Immediately after `if`, `then`, or `else` keywords. The `then` and `else` parts *should* be consistent.
 1. *Avoid* other line breaks in declarations, other than to break long lines.
 1. When operands of *binary operators* span two lines, the operator *should* be placed at the end of the first line.
 
@@ -109,7 +109,7 @@ select main, "Main method has no parameters."
 ```
 
 ## Braces
-1. Braces follow "Stroustrup" style: The opening `{` *must* be placed at the end of the preceding line.
+1. Braces follow [Stroustrup](https://en.wikipedia.org/wiki/Indentation_style#Variant:_Stroustrup) style. The opening `{` *must* be placed at the end of the preceding line.
 1. The closing `}` *must* be placed on its own line, indented to the outer level, or be on the same line as the opening `{`.
 1. Braces of empty blocks *may* be placed on a single line, with a single space separating the braces.
 1. Short predicates, not exceeding the maximum line width, *may* be placed on a single line, with a space following the opening brace and preceding the closing brace.
@@ -128,19 +128,19 @@ class ThrowException extends ThrowExpr {
 
 ## Spaces
 1. There *must* be a space or line break:
-   - surrounding each `=` and `|`,
-   - after each comma.
+   - Surrounding each `=` and `|`
+   - After each `,`
 1. There *should* be a space or line break:
-   - surrounding each *binary operator*, which *must* be balanced,
-   - surrounding `..` in a range.
-   - Exceptions to this are to save space or to improve readability.
+   - Surrounding each *binary operator*, which *must* be balanced
+   - Surrounding `..` in a range
+   - Exceptions to this may be made to save space or to improve readability.
 1. *Avoid* other spaces, for example:
-   - after a *quantifier/aggregation* keyword,
-   - after the predicate name in a *call*,
-   - inside brackets used for *calls*, single-line quantifiers, and parenthesised formulas,
-   - surrounding a `.`,
-   - inside the opening or closing `[ ]` In a range expression,
-   - inside casts `a.(X)`.
+   - After a *quantifier/aggregation* keyword
+   - After the predicate name in a *call*
+   - Inside brackets used for *calls*, single-line quantifiers, and parenthesised formulas
+   - Surrounding a `.`
+   - Inside the opening or closing `[ ]` in a range expression
+   - Inside casts `a.(X)`
 1. *Avoid* multiple spaces, except for indentation, and *avoid* additional indentation to align formulas, parameters or arguments.
 1. *Do not* put whitespace on blank lines, or trailing on the end of a line.
 1. *Do not* use tabs.
@@ -159,18 +159,18 @@ private predicate foo(Expr e, Expr p) {
 ```
 
 ## Naming
-1. Use PascalCase for:
-   - `class` names,
-   - `module` names,
-   - `newtype` names.
-1. Use camelCase for:
-   - predicate names,
-   - variable names.
+1. Use [PascalCase](http://wiki.c2.com/?PascalCase) for:
+   - `class` names
+   - `module` names
+   - `newtype` names
+1. Use [camelCase](https://en.wikipedia.org/wiki/Camel_case) for:
+   - Predicate names
+   - Variable names
 1. Newtype predicate names *should* begin with `T`.
-1. *Avoid* underscores in names.
 1. Predicates that have a result *should* be named `get...`
 1. Predicates that can return multiple results *should* be named `getA...` or `getAn...`
 1. Predicates that don't have a result or parameters *should* be named `is...` or `has...`
+1. *Avoid* underscores in names.
 1. *Avoid* short or single-letter names for classes, predicates and fields.
 1. Short or single letter names for parameters and *quantifiers* *may* be used provided that they are sufficiently clear.
 1. Use names as they are used in the target-language specification.
@@ -218,7 +218,7 @@ General requirements:
 1. Documentation comments *should* be appropriate for users of the code.
 1. Documentation for maintainers of the code *must* use normal comments.
 
-Documenting specific items:
+Documentation for specific items:
 
 1. Public declarations *must* be documented.
 1. Non-public declarations *should* be documented.
@@ -288,18 +288,18 @@ deprecated Expr getInitializer()
 1. The `or` keyword *may* be written at the end of a line, or within a line, provided that it has no unparenthesised `and` operands.
 1. Single-line formulas *may* be used in order to save space or add clarity, particularly in the *body* of a *quantifier/aggregation*.
 1. *Always* use brackets to clarify the precedence of:
-   - `implies`,
-   - `if`-`then`-`else`.
+   - `implies`
+   - `if`-`then`-`else`
 1. Parenthesised formulas *can* be written:
-   - within a single line. There *should not* be an additional space following the opening parenthesis or preceding the closing parenthesis.
-   - spanning multiple lines. The opening parenthesis *should* be placed at the end of the preceding line, the body should be indented one level, and the closing bracket should be placed on a new line at the outer indentation.
+   - Within a single line. There *should not* be an additional space following the opening parenthesis or preceding the closing parenthesis.
+   - Spanning multiple lines. The opening parenthesis *should* be placed at the end of the preceding line, the body should be indented one level, and the closing bracket should be placed on a new line at the outer indentation.
 1. *Quantifiers/aggregations* *can* be written:
-   - within a single line. In this case, there is no space to the inside of the parentheses, or after the quantifier keyword.
-   - across multiple lines. In this case, type declarations are on the same line as the quantifier, the `|` *may* be at the end of the line, or *may* be on its own line, and the body of the quantifier *must* be indented one level. The closing `)` is written on a new line, at the outer indentation.
+   - Within a single line. In this case, there is no space to the inside of the parentheses, or after the quantifier keyword.
+   - Across multiple lines. In this case, type declarations are on the same line as the quantifier, the `|` *may* be at the end of the line, or *may* be on its own line, and the body of the quantifier *must* be indented one level. The closing `)` is written on a new line, at the outer indentation.
 1. `if`-`then`-`else` *can* be written:
-   - on a single line,
-   - with the *body* after the `if`/`then`/`else` keyword,
-   - with the *body* indented on the next line.
+   - On a single line
+   - With the *body* after the `if`/`then`/`else` keyword
+   - With the *body* indented on the next line
    - *Always* parenthesise the `else` part if it is a compound formula.
 1. The `and` and `else` keywords *may* be placed on the same line as the closing parenthesis.
 1. The `and` and `else` keywords *may* be "cuddled": `) else (`

--- a/docs/ql-style-guide.md
+++ b/docs/ql-style-guide.md
@@ -2,7 +2,7 @@
 
 ## Introduction
 
-This document describes how to format the QL code in this repository, covering aspects such as layout, white-space, naming and documentation. Adhering to consistent standards makes code easier to read and maintain. Of course, these are only guidelines, and can be overridden as the need arises on a case-by-case basis. Where existing code deviates from these guidelines, prefer consistency with the surrounding code.
+This document describes how to format the QL code you contribute to this repository. It covers aspects such as layout, white-space, naming and documentation. Adhering to consistent standards makes code easier to read and maintain. Of course, these are only guidelines, and can be overridden as the need arises on a case-by-case basis. Where existing code deviates from these guidelines, prefer consistency with the surrounding code.
 
 Words in *italic* are defined in the [Glossary](#glossary).
 
@@ -10,12 +10,12 @@ Words in *italic* are defined in the [Glossary](#glossary).
 1. *Always* use 2 spaces for indentation.
 1. *Always* indent:
    - the *body* of a module, newtype, class or predicate,
-   - the second and subsequent lines after a line break used to split a long line,
+   - the second and subsequent lines after you use a line break to split a long line,
    - the *body* of a `from`, `where` or `select` clause where it spans multiple lines,
    - the *body* of a *quantifier* that spans multiple lines.
 
 
-Examples:
+### Examples
 
 ```ql
 module Helpers {
@@ -47,7 +47,7 @@ select c, "This call to '$@' is deprecated because " + reason + ".",
    - before each declaration, except for the first declaration in a *body*,
    - before the `from`-`where`-`select` section in a query file.
 1. *Avoid* two or more adjacent blank lines.
-1. There *must* be a new line after the *annotations* `cached`, `deprecated`, `pragma`, `language` and `bindingset`.
+1. There *must* be a new line after the *annotations* `cached`, `deprecated`, `pragma`, `language` and `bindingset`. Other *annotations* do not have a new line.
 1. There *should not* be additional blank lines within a predicate.
 1. There *may* be a new line:
    - immediately after the `from`, `where` or `select` keywords in a query,
@@ -55,7 +55,7 @@ select c, "This call to '$@' is deprecated because " + reason + ".",
 1. *Avoid* other line breaks in declarations, other than to break long lines.
 1. When operands of *binary operators* span two lines, the operator *should* be placed at the end of the first line.
 
-Examples:
+### Examples
 
 ```ql
 cached
@@ -80,12 +80,6 @@ select main, "This is the program entry point."
 
 ```ql
 from Method main
-where main.getName() = "Main"
-select main, "This is the program entry point." 
-```
-
-```ql
-from Method main
 where
   main.getName() = "Main" and
   main.getNumberOfParameters() = 0
@@ -97,6 +91,13 @@ select main, "Main method has no parameters."
   then result = "public"
   else result = "private"
 ```	
+
+```ql
+  if x.isPublic() then
+    result = "public"
+  else
+    result = "private"
+```
 
 ```ql
   if
@@ -113,8 +114,7 @@ select main, "Main method has no parameters."
 1. Braces of empty blocks *may* be placed on a single line, with a single space separating the braces.
 1. Short predicates, not exceeding the maximum line width, *may* be placed on a single line, with a space following the opening brace and preceding the closing brace.
 
-
-For example,
+### Examples
 
 ```ql
 class ThrowException extends ThrowExpr {
@@ -146,7 +146,7 @@ class ThrowException extends ThrowExpr {
 1. *Do not* use tabs.
 
 
-For example,
+### Examples
 
 ```ql
 cached
@@ -174,8 +174,9 @@ private predicate foo(Expr e, Expr p) {
 1. *Avoid* short or single-letter names for classes, predicates and fields.
 1. Short or single letter names for parameters and *quantifiers* *may* be used provided that they are sufficiently clear.
 1. Use names as they are used in the target-language specification.
+1. Use American English.
 
-Examples:
+### Examples
 
 ```ql
 /** ... */
@@ -205,16 +206,25 @@ class Type extends ... {
 ```
 
 ## Documentation
+
+General requirements:
+
 1. Documentation *must* adhere to the [QLDoc specification](https://help.semmle.com/QL/QLDocSpecification.html).
-1. Public declarations *must* be documented.
-1. Non-public declarations *should* be documented.
-1. Declarations in query files *should* be documented.
 1. Use `/** ... */` for documentation, even for single line comments.
 1. For single-line documentation, the `/**` and `*/` are written on the same line as the comment.
 1. For multi-line documentation, the `/**` and `*/` are written on separate lines. There is a `*` preceding each comment line, aligned on the first `*`.
-1. Library files (`.qll` files) *should* be documented with QLDoc.
-1. Query files, except for tests, *must* have a QLDoc query documentation comment.
-1. Documentation *should* be appropriate for users of the library. Put documentation for maintainers in normal comments.
+1. Use full sentences, with capital letters and full stops.
+1. Use American English.
+1. Documentation comments *should* be appropriate for users of the code.
+1. Documentation for maintainers of the code *must* use normal comments.
+
+Documenting specific items:
+
+1. Public declarations *must* be documented.
+1. Non-public declarations *should* be documented.
+1. Declarations in query files *should* be documented.
+1. Library files (`.qll` files) *should* be have a documentation comment at the top of the file.
+1. Query files, except for tests, *must* have a QLDoc query documentation comment at the top of the file.
 1. Predicates that do not have a result *should* be documented `/** Holds if ... */`
 1. Predicates that have a result *should* be documented `/** Gets ... */`
 1. All predicate parameters *should* be referred to in the predicate documentation.
@@ -224,10 +234,8 @@ class Type extends ... {
 1. Where a class denotes a generic concept with subclasses, list those subclasses.
 1. Declarations that are deprecated *should* be documented as `DEPRECATED: ...`
 1. Declarations that are for internal use *should* be documented as `INTERNAL: Do not use`.
-1. Use full sentences, with capital letters and full stops.
 
-
-Examples:
+### Examples
 
 ```ql
 /** Provides logic for determining constant expressions. */
@@ -278,10 +286,10 @@ deprecated Expr getInitializer()
 1. Write the `and` at the end of the line. This also applies in `where` clauses.
 1. *Prefer* to write the `or` keyword on its own line.
 1. The `or` keyword *may* be written at the end of a line, or within a line, provided that it has no unparenthesised `and` operands.
-1. Single-line formulas *may* be used in order to save space or add clarity, particularly in the *body* of a *quantifier/aggregation*. 
-1. *Avoid* additional brackets to clarify the precedence of `not`, `and` and `or`.
-1. *Always* clarify the precedence of `implies` with brackets.
-1. *Always* clarify the precedence of `if`-`then`-`else` with brackets.
+1. Single-line formulas *may* be used in order to save space or add clarity, particularly in the *body* of a *quantifier/aggregation*.
+1. *Always* use brackets to clarify the precedence of:
+   - `implies`,
+   - `if`-`then`-`else`.
 1. Parenthesised formulas *can* be written:
    - within a single line. There *should not* be an additional space following the opening parenthesis or preceding the closing parenthesis.
    - spanning multiple lines. The opening parenthesis *should* be placed at the end of the preceding line, the body should be indented one level, and the closing bracket should be placed on a new line at the outer indentation.
@@ -293,12 +301,12 @@ deprecated Expr getInitializer()
    - with the *body* after the `if`/`then`/`else` keyword,
    - with the *body* indented on the next line.
    - *Always* parenthesise the `else` part if it is a compound formula.
-1. The `and` and `else` keywords *may* be placed on the same line as the a closing parenthesis.
+1. The `and` and `else` keywords *may* be placed on the same line as the closing parenthesis.
 1. The `and` and `else` keywords *may* be "cuddled": `) else (`
 1. *Always* qualify *calls* to predicates of the same class with `this`.
 2. *Prefer* postfix casts `a.(Expr)` to prefix casts `(Expr)a`.
 
-Examples:
+### Examples
 
 ```ql
   argumentType.isImplicitlyConvertibleTo(parameterType)
@@ -391,44 +399,22 @@ Examples:
 ```
 
 ## Glossary
-*[annotation](https://help.semmle.com/QL/QLLanguageSpecification.html#annotations)*:
-An additional specifier used to modify a declaration, such as `private`, `override`, `deprecated`, `pragma`, `bindingset`, or `cached`.
 
-*body*:
-The text inside `{ }`, `( )`, or each section of an `if`-`then`-`else` or `from`-`where`-`select`.
-
-*binary operator*:
-An operator with two operands, such as comparison operators, `and`, `or`, `implies`, or arithmetic operators.
-
-*call*:
-A *formula* that invokes a predicate, e.g. `this.isStatic()` or `calls(a,b)`.
-
-
-*[conjunct](https://help.semmle.com/QL/QLLanguageSpecification.html#conjunctions)*:
-A formula that is an operand to an `and`.
-
-
-*declaration*:
-A class, module, predicate, field or newtype.
-
-
-*[disjunct](https://help.semmle.com/QL/QLLanguageSpecification.html#disjunctions)*:
-A formula that is an operand to an `or`.
-
-*[formula](https://help.semmle.com/QL/QLLanguageSpecification.html#formulas)*:
-A logical expression, such as `A = B`, a *call*, a *quantifier*, `and`, `or`, `not`, 'in` or `instanceof`.
-
-*should/should not/avoid/prefer*:
-Adhere to this rule wherever possible, where it makes sense.
-
-*may/can*:
-This is a reasonable alternative, to be used with discretion.
-
-*must/always/do not*:
-Always adhere to this rule.
-
-*[quantifier/aggregation](https://help.semmle.com/QL/QLLanguageSpecification.html#aggregations)*:
-`exists`, `count`, `strictcount`, `any`, `forall`, `forex` and so on.
-
-*variable*:
-A parameter to a predicate, a field, a from variable, or a variable introduced by a *quantifier* or *aggregation*.
+|-------------|----------|
+| Phrase      | Meaning  |
+|-------------|----------|
+| *[annotation](https://help.semmle.com/QL/QLLanguageSpecification.html#annotations)* |
+An additional specifier used to modify a declaration, such as `private`, `override`, `deprecated`, `pragma`, `bindingset`, or `cached`. |
+| *body* | The text inside `{ }`, `( )`, or each section of an `if`-`then`-`else` or `from`-`where`-`select`. |
+| *binary operator* | An operator with two operands, such as comparison operators, `and`, `or`, `implies`, or arithmetic operators. |
+| *call* | A *formula* that invokes a predicate, e.g. `this.isStatic()` or `calls(a,b)`. |
+| *[conjunct](https://help.semmle.com/QL/QLLanguageSpecification.html#conjunctions)* | A formula that is an operand to an `and`. |
+| *declaration* | A class, module, predicate, field or newtype. |
+| *[disjunct](https://help.semmle.com/QL/QLLanguageSpecification.html#disjunctions)* | A formula that is an operand to an `or`. |
+| *[formula](https://help.semmle.com/QL/QLLanguageSpecification.html#formulas)* | A logical expression, such as `A = B`, a *call*, a *quantifier*, `and`, `or`, `not`, 'in` or `instanceof`. |
+| *should/should not/avoid/prefer* | Adhere to this rule wherever possible, where it makes sense. |
+| *may/can* | This is a reasonable alternative, to be used with discretion. |
+| *must/always/do not* | Always adhere to this rule. |
+| *[quantifier/aggregation](https://help.semmle.com/QL/QLLanguageSpecification.html#aggregations)* | `exists`, `count`, `strictcount`, `any`, `forall`, `forex` and so on. |
+| *variable* | A parameter to a predicate, a field, a from variable, or a variable introduced by a *quantifier* or *aggregation*. |
+|-------------|----------|

--- a/docs/ql-style-guide.md
+++ b/docs/ql-style-guide.md
@@ -400,11 +400,9 @@ deprecated Expr getInitializer()
 
 ## Glossary
 
-|-------------|----------|
 | Phrase      | Meaning  |
 |-------------|----------|
-| *[annotation](https://help.semmle.com/QL/QLLanguageSpecification.html#annotations)* |
-An additional specifier used to modify a declaration, such as `private`, `override`, `deprecated`, `pragma`, `bindingset`, or `cached`. |
+| *[annotation](https://help.semmle.com/QL/QLLanguageSpecification.html#annotations)* | An additional specifier used to modify a declaration, such as `private`, `override`, `deprecated`, `pragma`, `bindingset`, or `cached`. |
 | *body* | The text inside `{ }`, `( )`, or each section of an `if`-`then`-`else` or `from`-`where`-`select`. |
 | *binary operator* | An operator with two operands, such as comparison operators, `and`, `or`, `implies`, or arithmetic operators. |
 | *call* | A *formula* that invokes a predicate, e.g. `this.isStatic()` or `calls(a,b)`. |
@@ -417,4 +415,3 @@ An additional specifier used to modify a declaration, such as `private`, `overri
 | *must/always/do not* | Always adhere to this rule. |
 | *[quantifier/aggregation](https://help.semmle.com/QL/QLLanguageSpecification.html#aggregations)* | `exists`, `count`, `strictcount`, `any`, `forall`, `forex` and so on. |
 | *variable* | A parameter to a predicate, a field, a from variable, or a variable introduced by a *quantifier* or *aggregation*. |
-|-------------|----------|


### PR DESCRIPTION
Here is the first version of the QL Style Guide. It is based on the Google document that we reviewed recently, and I have taken all of your comments on board. There are still some unresolved issues, for example how to indent long parameter lists, however I think that what we have here is useful enough to be published as-is, and we should definitely carry on discussing and making revisions to this document in the future.

We are all agreed that an auto-formatter for QL would be extremely useful.

~~I have not put in a link from CONTRIBUTING.md as this might require everyone to re-sign the CLA yet again, however we do need to make this document more apparent somehow.~~