### PR TITLE
JS: Improved inter-procedural type inference

### DIFF
--- a/change-notes/1.18/analysis-javascript.md
+++ b/change-notes/1.18/analysis-javascript.md
@@ -87,7 +87,7 @@
 | **Query**                  | **Expected impact**    | **Change**                                                       |
 |----------------------------|------------------------|------------------------------------------------------------------|
 | Arguments redefined | Fewer results | This rule previously also flagged redefinitions of `eval`. This was an oversight that is now fixed. |
-| Comparison between inconvertible types | Fewer results | This rule now flags fewer comparisons involving IIFE parameters. |
+| Comparison between inconvertible types | Fewer results | This rule now flags fewer comparisons involving parameters. |
 | Comparison between inconvertible types | Lower severity | The severity of this rule has been revised to "warning". |
 | CORS misconfiguration for credentials transfer | More true-positive results | This rule now treats header names case-insensitively. |
 | Hard-coded credentials | More true-positive results | This rule now recognizes secret cryptographic keys. |
@@ -102,8 +102,8 @@
 | Unused variable | Fewer results | This rule no longer flags class expressions that could be made anonymous. While technically true, these results are not interesting. |
 | Unused variable | Renamed | This rule has been renamed to "Unused variable, import, function or class" to reflect the fact that it flags different kinds of unused program elements. |
 | Use of incompletely initialized object| Fewer results | This rule now flags the constructor instead its errorneous `this` or `super` expressions. |
-| Useless conditional | Fewer results | This rule no longer flags uses of boolean IIFE return values. | 
-| Useless conditional | Fewer results | This rule now flags fewer comparisons involving IIFE parameters. | 
+| Useless conditional | Fewer results | This rule no longer flags uses of boolean return values. | 
+| Useless conditional | Fewer results | This rule now flags fewer comparisons involving parameters. | 
 
 ## Changes to QL libraries
 

--- a/change-notes/1.18/analysis-javascript.md
+++ b/change-notes/1.18/analysis-javascript.md
@@ -14,6 +14,8 @@
 
 * The taint tracking library now recognizes additional sanitization patterns. This may give fewer false-positive results for the security queries.
 
+* Type inference for simple function calls has been improved. This may give additional results for queries that rely on type inference.
+
 * Support for popular libraries has been improved. Consequently, queries may produce more results on code bases that use the following libraries:
   - [bluebird](http://bluebirdjs.com)
   - [browserid-crypto](https://github.com/mozilla/browserid-crypto)
@@ -85,6 +87,7 @@
 | **Query**                  | **Expected impact**    | **Change**                                                       |
 |----------------------------|------------------------|------------------------------------------------------------------|
 | Arguments redefined | Fewer results | This rule previously also flagged redefinitions of `eval`. This was an oversight that is now fixed. |
+| Comparison between inconvertible types | Fewer results | This rule now flags fewer comparisons involving IIFE parameters. |
 | Comparison between inconvertible types | Lower severity | The severity of this rule has been revised to "warning". |
 | CORS misconfiguration for credentials transfer | More true-positive results | This rule now treats header names case-insensitively. |
 | Hard-coded credentials | More true-positive results | This rule now recognizes secret cryptographic keys. |
@@ -99,6 +102,8 @@
 | Unused variable | Fewer results | This rule no longer flags class expressions that could be made anonymous. While technically true, these results are not interesting. |
 | Unused variable | Renamed | This rule has been renamed to "Unused variable, import, function or class" to reflect the fact that it flags different kinds of unused program elements. |
 | Use of incompletely initialized object| Fewer results | This rule now flags the constructor instead its errorneous `this` or `super` expressions. |
+| Useless conditional | Fewer results | This rule no longer flags uses of boolean IIFE return values. | 
+| Useless conditional | Fewer results | This rule now flags fewer comparisons involving IIFE parameters. | 
 
 ## Changes to QL libraries
 

--- a/javascript/ql/src/Expressions/HeterogeneousComparison.ql
+++ b/javascript/ql/src/Expressions/HeterogeneousComparison.ql
@@ -185,9 +185,7 @@ predicate isInitialParameterUse(Expr e) {
 /**
  * Holds if `e` is an expression that should not be considered in a heterogeneous comparison.
  *
- * We currently whitelist these kinds of expressions:
- *
- *   - parameters, as passed in from the caller
+ * We currently whitelist expressions that rely on inter-procedural parameter information.
  */
 predicate whitelist(Expr e) {
   isInitialParameterUse(e)

--- a/javascript/ql/src/Expressions/HeterogeneousComparison.ql
+++ b/javascript/ql/src/Expressions/HeterogeneousComparison.ql
@@ -174,8 +174,9 @@ string getTypeDescription(string message1, string message2, int complexity1, int
  * Holds if `e` directly uses a parameter's initial value as passed in from the caller.
  */
 predicate isInitialParameterUse(Expr e) {
+  // unlike `SimpleParameter.getAnInitialUse` this will not include uses we have refinement information for
   exists (SimpleParameter p, SsaExplicitDefinition ssa |
-    ssa.getAContributingVarDef() = p and
+    ssa.getDef() = p and
     ssa.getVariable().getAUse() = e and
     not p.isRestParameter()
   )

--- a/javascript/ql/src/Statements/UselessConditional.ql
+++ b/javascript/ql/src/Statements/UselessConditional.ql
@@ -67,8 +67,9 @@ predicate isConstant(Expr e) {
  * Holds if `e` directly uses a parameter's initial value as passed in from the caller.
  */
 predicate isInitialParameterUse(Expr e) {
+  // unlike `SimpleParameter.getAnInitialUse` this will not include uses we have refinement information for
   exists (SimpleParameter p, SsaExplicitDefinition ssa |
-    ssa.getAContributingVarDef() = p and
+    ssa.getDef() = p and
     ssa.getVariable().getAUse() = e and
     not p.isRestParameter()
   )
@@ -80,9 +81,11 @@ predicate isInitialParameterUse(Expr e) {
  * Holds if `e` directly uses the returned value from a function call that returns a constant boolean value.
  */
 predicate isConstantBooleanReturnValue(Expr e) {
+  // unlike `SourceNode.flowsTo` this will not include uses we have refinement information for
   exists (DataFlow::CallNode call |
     exists (call.analyze().getTheBooleanValue()) |
     e = call.asExpr() or
+    // also support return values that are assigned to variables
     exists (SsaExplicitDefinition ssa |
       ssa.getDef().getSource() = call.asExpr() and
       ssa.getVariable().getAUse() = e

--- a/javascript/ql/src/Statements/UselessConditional.ql
+++ b/javascript/ql/src/Statements/UselessConditional.ql
@@ -14,6 +14,7 @@
 
 import javascript
 import semmle.javascript.RestrictedLocations
+import semmle.javascript.dataflow.Refinements
 
 /**
  * Holds if `va` is a defensive truthiness check that may be worth keeping, even if it
@@ -63,18 +64,51 @@ predicate isConstant(Expr e) {
 }
 
 /**
+ * Holds if `e` directly uses a parameter's initial value as passed in from the caller.
+ */
+predicate isInitialParameterUse(Expr e) {
+  exists (SimpleParameter p, SsaExplicitDefinition ssa |
+    ssa.getAContributingVarDef() = p and
+    ssa.getVariable().getAUse() = e and
+    not p.isRestParameter()
+  )
+  or
+  isInitialParameterUse(e.(LogNotExpr).getOperand())
+}
+
+/**
+ * Holds if `e` directly uses the returned value from a function call that returns a constant boolean value.
+ */
+predicate isConstantBooleanReturnValue(Expr e) {
+  exists (DataFlow::CallNode call |
+    exists (call.analyze().getTheBooleanValue()) |
+    e = call.asExpr() or
+    exists (SsaExplicitDefinition ssa |
+      ssa.getDef().getSource() = call.asExpr() and
+      ssa.getVariable().getAUse() = e
+    )
+  )
+  or
+  isConstantBooleanReturnValue(e.(LogNotExpr).getOperand())
+}
+
+/**
  * Holds if `e` is an expression that should not be flagged as a useless condition.
  *
- * We currently whitelist three kinds of expressions:
+ * We currently whitelist these kinds of expressions:
  *
  *   - constants (including references to literal constants);
  *   - negations of constants;
- *   - defensive checks.
+ *   - defensive checks;
+ *   - parameters, as passed in from the caller;
+ *   - constant boolean returned values
  */
 predicate whitelist(Expr e) {
   isConstant(e) or
   isConstant(e.(LogNotExpr).getOperand()) or
-  isDefensiveInit(e)
+  isDefensiveInit(e) or
+  isInitialParameterUse(e) or
+  isConstantBooleanReturnValue(e)
 }
 
 /**

--- a/javascript/ql/src/Statements/UselessConditional.ql
+++ b/javascript/ql/src/Statements/UselessConditional.ql
@@ -64,7 +64,7 @@ predicate isConstant(Expr e) {
 }
 
 /**
- * Holds if `e` directly uses a parameter's initial value as passed in from the caller.
+ * Holds if `e` directly uses a parameter's negated or initial value as passed in from the caller.
  */
 predicate isInitialParameterUse(Expr e) {
   // unlike `SimpleParameter.getAnInitialUse` this will not include uses we have refinement information for
@@ -103,8 +103,8 @@ predicate isConstantBooleanReturnValue(Expr e) {
  *   - constants (including references to literal constants);
  *   - negations of constants;
  *   - defensive checks;
- *   - parameters, as passed in from the caller;
- *   - constant boolean returned values
+ *   - expressions that rely on inter-procedural parameter information;
+ *   - constant boolean returned values.
  */
 predicate whitelist(Expr e) {
   isConstant(e) or

--- a/javascript/ql/src/semmle/javascript/dataflow/internal/BasicExprTypeInference.qll
+++ b/javascript/ql/src/semmle/javascript/dataflow/internal/BasicExprTypeInference.qll
@@ -90,15 +90,6 @@ private class AnalyzedArrayComprehensionExpr extends DataFlow::AnalyzedValueNode
 }
 
 /**
- * Flow analysis for functions.
- */
-private class AnalyzedFunction extends DataFlow::AnalyzedValueNode {
-  override Function astNode;
-
-  override AbstractValue getALocalValue() { result = TAbstractFunction(astNode) }
-}
-
-/**
  * Flow analysis for class declarations.
  */
 private class AnalyzedClassDefinition extends DataFlow::AnalyzedValueNode {

--- a/javascript/ql/src/semmle/javascript/dataflow/internal/InterProceduralTypeInference.qll
+++ b/javascript/ql/src/semmle/javascript/dataflow/internal/InterProceduralTypeInference.qll
@@ -8,69 +8,6 @@ import javascript
 import AbstractValuesImpl
 
 /**
- * Flow analysis for immediately-invoked function expressions (IIFEs).
- */
-private class IifeReturnFlow extends DataFlow::AnalyzedValueNode {
-  ImmediatelyInvokedFunctionExpr iife;
-
-  IifeReturnFlow() {
-    astNode = (CallExpr)iife.getInvocation()
-  }
-
-  override AbstractValue getALocalValue() {
-    result = getAReturnValue(iife)
-  }
-}
-
-/**
- * Gets a return value for the immediately-invoked function expression `f`.
- */
-private AbstractValue getAReturnValue(ImmediatelyInvokedFunctionExpr f) {
-  // explicit return value
-  result = f.getAReturnedExpr().analyze().getALocalValue()
-  or
-  // implicit return value
-  (
-    // either because execution of the function may terminate normally
-    mayReturnImplicitly(f)
-    or
-    // or because there is a bare `return;` statement
-    exists (ReturnStmt ret | ret = f.getAReturnStmt() | not exists(ret.getExpr()))
-  ) and
-  result = getDefaultReturnValue(f)
-}
-
-
-/**
- * Holds if the execution of function `f` may complete normally without
- * encountering a `return` or `throw` statement.
- *
- * Note that this is an overapproximation, that is, the predicate may hold
- * of functions that cannot actually complete normally, since it does not
- * account for `finally` blocks and does not check reachability.
- */
-private predicate mayReturnImplicitly(Function f) {
-  exists (ConcreteControlFlowNode final |
-    final.getContainer() = f and
-    final.isAFinalNode() and
-    not final instanceof ReturnStmt and
-    not final instanceof ThrowStmt
-  )
-}
-
-/**
- * Gets the default return value for immediately-invoked function expression `f`,
- * that is, the value that `f` returns if its execution terminates without
- * encountering an explicit `return` statement.
- */
-private AbstractValue getDefaultReturnValue(ImmediatelyInvokedFunctionExpr f) {
-  if f.isGenerator() or f.isAsync() then
-    result = TAbstractOtherObject()
-  else
-    result = TAbstractUndefined()
-}
-
-/**
  * Flow analysis for `this` expressions inside functions.
  */
 private abstract class AnalyzedThisExpr extends DataFlow::AnalyzedValueNode, DataFlow::ThisNode {
@@ -190,3 +127,75 @@ private class AnalyzedThisInPropertyFunction extends AnalyzedThisExpr {
   }
 }
 
+/**
+ * Holds if the execution of function `f` may complete normally without
+ * encountering a `return` or `throw` statement.
+ *
+ * Note that this is an overapproximation, that is, the predicate may hold
+ * of functions that cannot actually complete normally, since it does not
+ * account for `finally` blocks and does not check reachability.
+ */
+predicate mayReturnImplicitly(Function f) {
+  exists (ConcreteControlFlowNode final |
+    final.getContainer() = f and
+    final.isAFinalNode() and
+    not final instanceof ReturnStmt and
+    not final instanceof ThrowStmt
+  )
+}
+
+/**
+ * A call with inter-procedural type inference for the return value.
+ */
+abstract class CallWithAnalyzedReturnFlow extends DataFlow::CallNode, DataFlow::AnalyzedValueNode {
+
+  /**
+   * Gets a called function.
+   */
+  abstract Function getAFunction();
+  
+  /**
+   * Gets a return value for this call.
+   */
+  AbstractValue getAReturnValue() {
+    exists (Function f | f = getAFunction() |
+      if f.isGenerator() or f.isAsync() then
+        result = TAbstractOtherObject()
+      else (
+        // explicit return value
+        result = f.getAReturnedExpr().analyze().getALocalValue()
+        or
+        // implicit return value
+        (
+          // either because execution of the function may terminate normally
+          mayReturnImplicitly(f)
+          or
+          // or because there is a bare `return;` statement
+          exists (ReturnStmt ret | ret = f.getAReturnStmt() | not exists(ret.getExpr()))
+        ) and
+        result = TAbstractUndefined()
+      )
+    )
+  }
+
+  override AbstractValue getALocalValue() {
+    result = getAReturnValue()
+  }
+}
+
+/**
+ * Flow analysis for the return value of IIFEs.
+ */
+private class IIFEWithAnalyzedReturnFlow extends CallWithAnalyzedReturnFlow {
+  
+  ImmediatelyInvokedFunctionExpr iife;
+  
+  IIFEWithAnalyzedReturnFlow() {
+    this.asExpr() = iife.getInvocation()
+  }
+  
+  override Function getAFunction() {
+    result = iife
+  }
+  
+}

--- a/javascript/ql/src/semmle/javascript/dataflow/internal/InterProceduralTypeInference.qll
+++ b/javascript/ql/src/semmle/javascript/dataflow/internal/InterProceduralTypeInference.qll
@@ -191,7 +191,7 @@ private class IIFEWithAnalyzedReturnFlow extends CallWithAnalyzedReturnFlow {
   ImmediatelyInvokedFunctionExpr iife;
   
   IIFEWithAnalyzedReturnFlow() {
-    this.asExpr() = iife.getInvocation()
+    astNode = iife.getInvocation()
   }
   
   override Function getAFunction() {

--- a/javascript/ql/src/semmle/javascript/dataflow/internal/VariableTypeInference.qll
+++ b/javascript/ql/src/semmle/javascript/dataflow/internal/VariableTypeInference.qll
@@ -725,3 +725,24 @@ private class IIFEWithAnalyzedParameters extends CallWithAnalyzedParameters {
   }
 
 }
+
+/**
+ * Enables inter-procedural type inference for `LocalFunction`.
+ */
+private class LocalFunctionWithAnalyzedParameters extends CallWithAnalyzedParameters {
+
+  LocalFunction local;
+
+  LocalFunctionWithAnalyzedParameters() {
+    this = local
+  }
+
+  override DataFlow::InvokeNode getAnInvocation() {
+    result = local.getAnInvocation()
+  }
+
+  override predicate isIncomplete(DataFlow::Incompleteness cause) {
+    none()
+  }
+
+}

--- a/javascript/ql/src/semmle/javascript/dataflow/internal/VariableTypeInference.qll
+++ b/javascript/ql/src/semmle/javascript/dataflow/internal/VariableTypeInference.qll
@@ -112,47 +112,43 @@ class AnalyzedVarDef extends VarDef {
 }
 
 /**
- * Flow analysis for simple IIFE parameters.
+ * Flow analysis for simple parameters of selected functions.
  */
-private class AnalyzedIIFEParameter extends AnalyzedVarDef, @vardecl {
-  AnalyzedIIFEParameter() {
-    exists (ImmediatelyInvokedFunctionExpr iife, int parmIdx |
-      this = iife.getParameter(parmIdx) |
-      // we cannot track flow into rest parameters...
-      not this.(Parameter).isRestParameter() and
-      // ...nor flow out of spread arguments
-      exists (int argIdx | argIdx = parmIdx + iife.getArgumentOffset() |
-        not iife.isSpreadArgument([0..argIdx])
-      )
+private class AnalyzedParameter extends AnalyzedVarDef, @vardecl {
+  AnalyzedParameter() {
+    exists (FunctionWithAnalyzedParameters f, int parmIdx |
+      this = f.getParameter(parmIdx) |
+      // we cannot track flow into rest parameters
+      not this.(Parameter).isRestParameter()
     )
   }
 
-  /** Gets the IIFE this is a parameter of. */
-  ImmediatelyInvokedFunctionExpr getIIFE() {
+  /** Gets the function this is a parameter of. */
+  FunctionWithAnalyzedParameters getFunction() {
     this = result.getAParameter()
   }
 
   override DataFlow::AnalyzedNode getRhs() {
-    getIIFE().argumentPassing(this, result.asExpr()) or
+    getFunction().argumentPassing(this, result.asExpr()) or
     result = this.(Parameter).getDefault().analyze()
   }
 
   override AbstractValue getAnRhsValue() {
-    result = AnalyzedVarDef.super.getAnRhsValue() or
-    not getIIFE().argumentPassing(this, _) and result = TAbstractUndefined()
+    result = AnalyzedVarDef.super.getAnRhsValue()
+    or
+    not getFunction().mayReceiveArgument(this) and
+    result = TAbstractUndefined()
   }
 
   override predicate isIncomplete(DataFlow::Incompleteness cause) {
-    exists (ImmediatelyInvokedFunctionExpr iife | iife = getIIFE() |
-      // if the IIFE has a name and that name is referenced, we conservatively
-      // assume that there may be other calls than the direct one
-      exists (iife.getVariable().getAnAccess()) and cause = "call" or
-      // if the IIFE is non-strict and its `arguments` object is accessed, we
-      // also assume that there may be other calls (through `arguments.callee`)
-      not iife.isStrict() and
-      exists (iife.getArgumentsVariable().getAnAccess()) and cause = "call"
+    getFunction().isIncomplete(cause) or
+    (
+      not getFunction().argumentPassing(this, _) and
+      getFunction().mayReceiveArgument(this) and
+      cause = "call"
     )
   }
+  
 }
 
 /**
@@ -649,4 +645,83 @@ private class NamespaceExportVarFlow extends DataFlow::AnalyzedValueNode {
   }
 
   override AbstractValue getALocalValue() { result = TIndefiniteAbstractValue("namespace") }
+}
+
+/**
+ * A function with inter-procedural type inference for its parameters.
+ */
+abstract class FunctionWithAnalyzedParameters extends Function {
+
+  /**
+   * Holds if `p` is a parameter of this function and `arg` is
+   * the corresponding argument.
+   */
+  abstract predicate argumentPassing(SimpleParameter p, Expr arg);
+
+  /**
+   * Holds if `p` is a parameter of this function that may receive a value from an argument.
+   */
+  abstract predicate mayReceiveArgument(Parameter p);
+
+  /**
+   * Holds if flow analysis results for the parameters may be incomplete
+   * due to the given `cause`.
+   */
+  abstract predicate isIncomplete(DataFlow::Incompleteness cause);
+
+}
+
+private abstract class CallWithAnalyzedParameters extends FunctionWithAnalyzedParameters {
+
+  /**
+   * Gets an invocation of this function.
+   */
+  abstract DataFlow::InvokeNode getAnInvocation();
+
+  override predicate argumentPassing(SimpleParameter p, Expr arg) {
+    exists (DataFlow::InvokeNode invk, int argIdx |
+      invk = getAnInvocation() |
+      p = getParameter(argIdx) and not p.isRestParameter() and
+      arg = invk.getArgument(argIdx).asExpr()
+    )
+  }
+
+  override predicate mayReceiveArgument(Parameter p) {
+    exists (DataFlow::InvokeNode invk, int argIdx |
+      invk = getAnInvocation() and
+      p = getParameter(argIdx) |
+      exists (invk.getArgument(argIdx))
+      or
+      invk.asExpr().(InvokeExpr).isSpreadArgument([0..argIdx])
+    )
+  }
+
+}
+
+/**
+ * Flow analysis for simple parameters of IIFEs.
+ */
+private class IIFEWithAnalyzedParameters extends CallWithAnalyzedParameters {
+
+  ImmediatelyInvokedFunctionExpr iife;
+
+  IIFEWithAnalyzedParameters() {
+    this = iife and
+    iife.getInvocationKind() = "direct"
+  }
+
+  override DataFlow::InvokeNode getAnInvocation() {
+    result = iife.getInvocation().flow()
+  }
+
+  override predicate isIncomplete(DataFlow::Incompleteness cause) {
+    // if the IIFE has a name and that name is referenced, we conservatively
+    // assume that there may be other calls than the direct one
+    exists (iife.getVariable().getAnAccess()) and cause = "call" or
+    // if the IIFE is non-strict and its `arguments` object is accessed, we
+    // also assume that there may be other calls (through `arguments.callee`)
+    not iife.isStrict() and
+    exists (iife.getArgumentsVariable().getAnAccess()) and cause = "call"
+  }
+
 }

--- a/javascript/ql/test/library-tests/DataFlow/incomplete.expected
+++ b/javascript/ql/test/library-tests/DataFlow/incomplete.expected
@@ -26,7 +26,6 @@
 | tst.js:65:3:65:10 | yield 42 | yield |
 | tst.js:66:13:66:25 | function.sent | yield |
 | tst.js:68:12:68:14 | h() | call |
-| tst.js:69:1:69:9 | iter.next | call |
 | tst.js:69:1:69:9 | iter.next | heap |
 | tst.js:69:1:69:13 | iter.next(23) | call |
 | tst.js:72:3:72:11 | await p() | await |

--- a/javascript/ql/test/library-tests/TypeInference/CallWithAnalyzedReturnFlow/CallWithAnalyzedReturnFlow.expected
+++ b/javascript/ql/test/library-tests/TypeInference/CallWithAnalyzedReturnFlow/CallWithAnalyzedReturnFlow.expected
@@ -1,0 +1,6 @@
+| tst.js:1:1:1:16 | (function(){})() | tst.js:1:2:1:13 | function(){} | file://:0:0:0:0 | undefined |
+| tst.js:2:1:2:25 | (functi ... n; })() | tst.js:2:2:2:22 | functio ... turn; } | file://:0:0:0:0 | undefined |
+| tst.js:3:1:3:30 | (functi ... e; })() | tst.js:3:2:3:27 | functio ... true; } | file://:0:0:0:0 | true |
+| tst.js:4:1:4:51 | (functi ... e; })() | tst.js:4:2:4:48 | functio ... alse; } | file://:0:0:0:0 | false |
+| tst.js:4:1:4:51 | (functi ... e; })() | tst.js:4:2:4:48 | functio ... alse; } | file://:0:0:0:0 | true |
+| tst.js:5:1:5:27 | (functi ... x; })() | tst.js:5:2:5:24 | functio ... rn x; } | file://:0:0:0:0 | indefinite value (global) |

--- a/javascript/ql/test/library-tests/TypeInference/CallWithAnalyzedReturnFlow/CallWithAnalyzedReturnFlow.ql
+++ b/javascript/ql/test/library-tests/TypeInference/CallWithAnalyzedReturnFlow/CallWithAnalyzedReturnFlow.ql
@@ -1,0 +1,4 @@
+import javascript
+
+from CallWithAnalyzedReturnFlow call
+select call, call.getACallee(), call.getACallee().getAReturnValue()

--- a/javascript/ql/test/library-tests/TypeInference/CallWithAnalyzedReturnFlow/tst.js
+++ b/javascript/ql/test/library-tests/TypeInference/CallWithAnalyzedReturnFlow/tst.js
@@ -1,0 +1,5 @@
+(function(){})();
+(function(){ return; })();
+(function(){ return true; })();
+(function(){ if (x) return true; return false; })();
+(function(){ return x; })();

--- a/javascript/ql/test/library-tests/TypeInference/FunctionWithAnalyzedParameters/FunctionWithAnalyzedParameters.expected
+++ b/javascript/ql/test/library-tests/TypeInference/FunctionWithAnalyzedParameters/FunctionWithAnalyzedParameters.expected
@@ -1,0 +1,14 @@
+| tst.js:1:2:1:13 | function(){} | complete |
+| tst.js:2:2:2:15 | function(x){x} | complete |
+| tst.js:3:2:3:15 | function(x){x} | complete |
+| tst.js:4:2:4:15 | function(x){x} | complete |
+| tst.js:5:2:5:21 | function(x, y){x; y} | complete |
+| tst.js:8:5:8:19 | function f1(){} | complete |
+| tst.js:10:5:10:21 | function f2(x){x} | complete |
+| tst.js:12:5:12:21 | function f3(x){x} | complete |
+| tst.js:14:5:14:21 | function f4(x){x} | complete |
+| tst.js:16:5:16:27 | functio ... ){x; y} | complete |
+| tst.js:20:2:20:25 | functio ... ){x; y} | complete |
+| tst.js:21:2:21:16 | function(x){x;} | complete |
+| tst.js:22:2:22:33 | functio ... callee} | call |
+| tst.js:23:2:23:47 | functio ... callee} | complete |

--- a/javascript/ql/test/library-tests/TypeInference/FunctionWithAnalyzedParameters/FunctionWithAnalyzedParameters.ql
+++ b/javascript/ql/test/library-tests/TypeInference/FunctionWithAnalyzedParameters/FunctionWithAnalyzedParameters.ql
@@ -1,0 +1,5 @@
+import javascript
+
+from FunctionWithAnalyzedParameters f, string incompleteness
+where if f.isIncomplete(_) then f.isIncomplete(incompleteness) else incompleteness = "complete"
+select f, incompleteness

--- a/javascript/ql/test/library-tests/TypeInference/FunctionWithAnalyzedParameters/FunctionWithAnalyzedParameters_argumentPassing.expected
+++ b/javascript/ql/test/library-tests/TypeInference/FunctionWithAnalyzedParameters/FunctionWithAnalyzedParameters_argumentPassing.expected
@@ -1,0 +1,11 @@
+| tst.js:3:2:3:15 | function(x){x} | tst.js:3:11:3:11 | x | tst.js:3:18:3:22 | false |
+| tst.js:4:2:4:15 | function(x){x} | tst.js:4:11:4:11 | x | tst.js:4:18:4:21 | true |
+| tst.js:5:2:5:21 | function(x, y){x; y} | tst.js:5:11:5:11 | x | tst.js:5:24:5:27 | true |
+| tst.js:5:2:5:21 | function(x, y){x; y} | tst.js:5:14:5:14 | y | tst.js:5:30:5:34 | false |
+| tst.js:12:5:12:21 | function f3(x){x} | tst.js:12:17:12:17 | x | tst.js:13:8:13:12 | false |
+| tst.js:14:5:14:21 | function f4(x){x} | tst.js:14:17:14:17 | x | tst.js:15:8:15:11 | true |
+| tst.js:16:5:16:27 | functio ... ){x; y} | tst.js:16:17:16:17 | x | tst.js:17:8:17:11 | true |
+| tst.js:16:5:16:27 | functio ... ){x; y} | tst.js:16:20:16:20 | y | tst.js:17:14:17:18 | false |
+| tst.js:20:2:20:25 | functio ... ){x; y} | tst.js:20:11:20:11 | x | tst.js:20:28:20:31 | true |
+| tst.js:22:2:22:33 | functio ... callee} | tst.js:22:11:22:11 | x | tst.js:22:36:22:39 | true |
+| tst.js:23:2:23:47 | functio ... callee} | tst.js:23:11:23:11 | x | tst.js:23:50:23:53 | true |

--- a/javascript/ql/test/library-tests/TypeInference/FunctionWithAnalyzedParameters/FunctionWithAnalyzedParameters_argumentPassing.ql
+++ b/javascript/ql/test/library-tests/TypeInference/FunctionWithAnalyzedParameters/FunctionWithAnalyzedParameters_argumentPassing.ql
@@ -1,0 +1,5 @@
+import javascript
+
+from FunctionWithAnalyzedParameters f, SimpleParameter p, Expr arg
+where f.argumentPassing(p, arg)
+select f, p, arg

--- a/javascript/ql/test/library-tests/TypeInference/FunctionWithAnalyzedParameters/FunctionWithAnalyzedParameters_inference.expected
+++ b/javascript/ql/test/library-tests/TypeInference/FunctionWithAnalyzedParameters/FunctionWithAnalyzedParameters_inference.expected
@@ -1,0 +1,12 @@
+| tst.js:3:11:3:11 | x | file://:0:0:0:0 | false |
+| tst.js:4:11:4:11 | x | file://:0:0:0:0 | true |
+| tst.js:5:11:5:11 | x | file://:0:0:0:0 | true |
+| tst.js:5:14:5:14 | y | file://:0:0:0:0 | false |
+| tst.js:12:17:12:17 | x | file://:0:0:0:0 | false |
+| tst.js:14:17:14:17 | x | file://:0:0:0:0 | true |
+| tst.js:16:17:16:17 | x | file://:0:0:0:0 | true |
+| tst.js:16:20:16:20 | y | file://:0:0:0:0 | false |
+| tst.js:20:11:20:11 | x | file://:0:0:0:0 | true |
+| tst.js:22:11:22:11 | x | file://:0:0:0:0 | indefinite value (call) |
+| tst.js:22:11:22:11 | x | file://:0:0:0:0 | true |
+| tst.js:23:11:23:11 | x | file://:0:0:0:0 | true |

--- a/javascript/ql/test/library-tests/TypeInference/FunctionWithAnalyzedParameters/FunctionWithAnalyzedParameters_inference.ql
+++ b/javascript/ql/test/library-tests/TypeInference/FunctionWithAnalyzedParameters/FunctionWithAnalyzedParameters_inference.ql
@@ -1,0 +1,6 @@
+import javascript
+
+from FunctionWithAnalyzedParameters f, SimpleParameter p, AnalyzedVarDef var
+where f.argumentPassing(p, _) and
+      var.getAVariable() = p.getVariable()
+select p, var.(AnalyzedVarDef).getAnAssignedValue()

--- a/javascript/ql/test/library-tests/TypeInference/FunctionWithAnalyzedParameters/tst.js
+++ b/javascript/ql/test/library-tests/TypeInference/FunctionWithAnalyzedParameters/tst.js
@@ -1,0 +1,42 @@
+(function(){})();
+(function(x){x})();
+(function(x){x})(false);
+(function(x){x})(true);
+(function(x, y){x; y})(true, false);
+
+(function() {
+    function f1(){}
+    f1();
+    function f2(x){x}
+    f2();
+    function f3(x){x}
+    f3(false);
+    function f4(x){x}
+    f4(true);
+    function f5(x, y){x; y}
+    f5(true, false);
+});
+
+(function(x, ... y){x; y})(true, false);
+(function(x){x;})(... [true]);
+(function(x){x; arguments.callee})(true);
+(function(x){"use strict"; x; arguments.callee})(true);
+
+(function(){}).call(undefined);
+(function(x){x}).call(undefined);
+(function(x){x}).call(undefined, false);
+(function(x){x}).call(undefined, true);
+(function(x, y){x; y}).call(undefined, true, false);
+
+(function() {
+    function f1(){}
+    f1.call(undefined);
+    function f2(x){x}
+    f2.call(undefined);
+    function f3(x){x}
+    f3.call(undefined, false);
+    function f4(x){x}
+    f4.call(undefined, true);
+    function f5(x, y){x; y}
+    f5.call(undefined, true, false);
+});

--- a/javascript/ql/test/library-tests/TypeInference/LocalFunction/LocalFunction.expected
+++ b/javascript/ql/test/library-tests/TypeInference/LocalFunction/LocalFunction.expected
@@ -1,0 +1,8 @@
+| LocalFunction.js:4:5:4:19 | function f1(){} | LocalFunction.js:5:5:5:8 | f1() |
+| LocalFunction.js:11:5:11:19 | function f3(){} | LocalFunction.js:13:5:13:8 | f3() |
+| LocalFunction.js:12:5:12:19 | function f3(){} | LocalFunction.js:13:5:13:8 | f3() |
+| LocalFunction.js:27:5:29:5 | functio ... ;\\n    } | LocalFunction.js:33:17:33:24 | f_zero() |
+| LocalFunction.js:30:5:32:5 | functio ... ;\\n    } | LocalFunction.js:33:5:33:12 | f_null() |
+| LocalFunction.js:35:5:37:5 | functio ... ;\\n    } | LocalFunction.js:41:5:41:12 | f_id1(0) |
+| LocalFunction.js:38:5:40:5 | functio ... ;\\n    } | LocalFunction.js:41:17:41:27 | f_id2(null) |
+| LocalFunction_arguments.js:17:5:20:5 | functio ... e\\n    } | LocalFunction_arguments.js:21:5:21:7 | i() |

--- a/javascript/ql/test/library-tests/TypeInference/LocalFunction/LocalFunction.js
+++ b/javascript/ql/test/library-tests/TypeInference/LocalFunction/LocalFunction.js
@@ -1,0 +1,50 @@
+(function extent(){
+    function f0(){}
+
+    function f1(){}
+    f1();
+
+    function f2(){}
+    f2();
+    f2();
+
+    function f3(){}
+    function f3(){}
+    f3();
+
+    var f4 = function(){}
+    f4();
+
+    function f5(){}
+    f5 = function(){};
+    f5();
+
+    function f6(){}
+    g(f6);
+    f6();
+})();
+(function types(){
+    function f_zero() {
+        return 0;
+    }
+    function f_null() {
+        return null;
+    }
+    f_null() == f_zero();
+
+    function f_id1(v) {
+        return v;
+    }
+    function f_id2(v) {
+        return v;
+    }
+    f_id1(0) == f_id2(null);
+})();
+export function foo() {
+
+}
+foo();
+export default function bar() {
+
+}
+bar();

--- a/javascript/ql/test/library-tests/TypeInference/LocalFunction/LocalFunction.ql
+++ b/javascript/ql/test/library-tests/TypeInference/LocalFunction/LocalFunction.ql
@@ -1,0 +1,5 @@
+import javascript
+import semmle.javascript.dataflow.internal.InterProceduralTypeInference
+
+from LocalFunction e
+select e, e.getAnInvocation()

--- a/javascript/ql/test/library-tests/TypeInference/LocalFunction/LocalFunction_arguments.js
+++ b/javascript/ql/test/library-tests/TypeInference/LocalFunction/LocalFunction_arguments.js
@@ -1,0 +1,22 @@
+(function(){
+    function f() {
+        arguments.callee()
+    }
+    f();
+    function g() {
+        var args = arguments;
+        var callee = args.callee;
+        callee();
+    }
+    g();
+    function h() {
+        var args = arguments;
+        args.callee;
+    }
+    h();
+    function i() {
+        "use strict";
+        arguments.callee(); // does not work in strict mode
+    }
+    i();
+})();

--- a/javascript/ql/test/library-tests/frameworks/HTTP-heuristics/src/middleware-attacher-getter.js
+++ b/javascript/ql/test/library-tests/frameworks/HTTP-heuristics/src/middleware-attacher-getter.js
@@ -7,7 +7,7 @@ function getAttacher1 (app) {
 
 var app = express();
 getAttacher1(app);
-
+confuse(getAttacher2); // disable the type inference
 
 function getAttacher2 (app) {
     return function(h) {
@@ -17,3 +17,4 @@ function getAttacher2 (app) {
 
 var app = express();
 getAttacher2(app)(function(req, res){});
+confuse(getAttacher2); // disable the type inference

--- a/javascript/ql/test/library-tests/frameworks/HTTP-heuristics/src/route-objects.js
+++ b/javascript/ql/test/library-tests/frameworks/HTTP-heuristics/src/route-objects.js
@@ -58,3 +58,4 @@ function wrap(f){
     }
 }
 app[route3.method](route3.url, wrap(route3.handler));
+confuse(wrap); // confuse the type inference

--- a/javascript/ql/test/query-tests/Expressions/HeterogeneousComparison/HeterogeneousComparison.expected
+++ b/javascript/ql/test/query-tests/Expressions/HeterogeneousComparison/HeterogeneousComparison.expected
@@ -46,3 +46,5 @@
 | tst.js:208:5:208:6 | t5 | Variable 't5' cannot be of type function or regular expression, but it is compared to $@ of type function or regular expression. | tst.js:208:12:208:13 | t2 | variable 't2' |
 | tst.js:209:5:209:6 | t3 | Variable 't3' is of type function, object or regular expression, but it is compared to $@ of type boolean, null, number, string or undefined. | tst.js:209:12:209:13 | t5 | variable 't5' |
 | tst.js:210:5:210:6 | t5 | Variable 't5' is of type boolean, null, number, string or undefined, but it is compared to $@ of type function, object or regular expression. | tst.js:210:12:210:13 | t3 | variable 't3' |
+| tst.js:225:13:225:14 | xy | Variable 'xy' is of type undefined, but it is compared to $@ of type string. | tst.js:225:20:225:24 | "foo" | an expression |
+| tst.js:233:5:233:5 | x | Variable 'x' is of type object, but it is compared to $@ of type number. | tst.js:233:11:233:12 | 42 | an expression |

--- a/javascript/ql/test/query-tests/Expressions/HeterogeneousComparison/tst.js
+++ b/javascript/ql/test/query-tests/Expressions/HeterogeneousComparison/tst.js
@@ -212,4 +212,25 @@ function l() {
 
 1n == 1; // OK
 
+(function tooGeneralLocalFunctions(){
+    function f1(x) {
+        if (x === "foo") { // OK, whitelisted
+
+        }
+    }
+    f1(undefined);
+
+    function f2(x, y) {
+        var xy = o.q? x: y;
+        if (xy === "foo") { // NOT OK (not whitelisted like above)
+
+        }
+    }
+    f2(undefined, undefined);
+})();
+
+function f(...x) {
+    x === 42
+};
+
 // semmle-extractor-options: --experimental

--- a/javascript/ql/test/query-tests/Statements/UselessConditional/UselessConditional.expected
+++ b/javascript/ql/test/query-tests/Statements/UselessConditional/UselessConditional.expected
@@ -10,3 +10,12 @@
 | UselessConditional.js:29:8:29:8 | x | Variable 'x' always evaluates to true here. |
 | UselessConditional.js:30:8:30:14 | new X() | This expression always evaluates to true. |
 | UselessConditional.js:33:7:33:7 | x | Variable 'x' always evaluates to false here. |
+| UselessConditional.js:54:9:54:13 | known | Variable 'known' always evaluates to false here. |
+| UselessConditional.js:60:9:60:15 | unknown | Variable 'unknown' always evaluates to false here. |
+| UselessConditional.js:65:5:65:5 | x | Variable 'x' always evaluates to true here. |
+| UselessConditional.js:76:13:76:13 | x | Variable 'x' always evaluates to true here. |
+| UselessConditional.js:82:13:82:13 | x | Variable 'x' always evaluates to true here. |
+| UselessConditionalGood.js:58:12:58:13 | x2 | Variable 'x2' always evaluates to false here. |
+| UselessConditionalGood.js:69:12:69:13 | xy | Variable 'xy' always evaluates to false here. |
+| UselessConditionalGood.js:85:12:85:13 | xy | Variable 'xy' always evaluates to false here. |
+| UselessConditionalGood.js:97:12:97:13 | xy | Variable 'xy' always evaluates to false here. |

--- a/javascript/ql/test/query-tests/Statements/UselessConditional/UselessConditional.js
+++ b/javascript/ql/test/query-tests/Statements/UselessConditional/UselessConditional.js
@@ -44,4 +44,44 @@ async function awaitFlow(){
     }
 }
 
+(function(){
+    function knownF() {
+        return false;
+    }
+    var known = knownF();
+    if (known)
+        return;
+    if (known)
+        return;
+
+    var unknown = unknownF();
+    if (unknown)
+        return;
+    if (unknown) // NOT OK
+        return;
+});
+
+(function (...x) {
+    x || y // NOT OK
+});
+
+(function() {
+    function f1(x) {
+        x || y // NOT OK, but whitelisted
+    }
+    f1(true);
+
+    function f2(x) {
+        while (true)
+            x || y // NOT OK
+    }
+    f2(true);
+
+    function f3(x) {
+        (function(){
+            x || y // NOT OK
+        });
+    }
+    f3(true);
+});
 // semmle-extractor-options: --experimental

--- a/javascript/ql/test/query-tests/Statements/UselessConditional/UselessConditionalGood.js
+++ b/javascript/ql/test/query-tests/Statements/UselessConditional/UselessConditionalGood.js
@@ -6,3 +6,96 @@ function getLastLine(input) {
     throw new Error("No lines!");
   return lines[lines.length-1];
 }
+
+(function tooSpecificFunctions(){
+    function f1() {
+        return false
+    }
+    if(f1()){} // OK, whitelisted
+
+    function f2() {
+        return false
+    }
+    if(!f2()){} // OK, whitelisted
+
+    function f3() {
+        return false
+    }
+    if(!!f3()){} // OK, whitelisted
+
+    function f4() {
+        return false
+    }
+    if(f4() || o.p){} // OK, whitelisted
+
+    function f5() {
+        return false
+    }
+    var v5 = f5();
+    if(v5){} // OK, whitelisted
+
+    function f6() {
+        return false
+    }
+    var v6 = f6();
+    if(!!v6){} // OK, whitelisted
+})();
+
+(function tooGeneralFunctions(){
+    function f1(x) {
+        if(x){} // OK, whitelisted
+    }
+    f1(undefined);
+    f1({});
+
+    function f2(x) {
+        if(x){} // OK, whitelisted
+    }
+    f2(undefined);
+
+    function f3(x1) {
+        var x2 = x1;
+        if(x2){} // NOT OK, not whitelisted
+    }
+    f3(undefined);
+
+    function f4(x) {
+        if(x && o.p){} // OK, whitelisted
+    }
+    f4(undefined);
+
+    function f5(x, y) {
+        var xy = o.q? x: y;
+        if(xy && o.p){} // NOT OK, not whitelisted
+    }
+    f5(undefined, undefined);
+
+    function f6(x) {
+        if(!x){} // OK, whitelisted
+    }
+    f6(true);
+
+    function f7(x) {
+        if(!!x){} // OK, whitelisted
+    }
+    f7(true);
+
+    function f8(x, y) {
+        var xy = x || y;
+        if(xy){} // NOT OK, not whitelisted
+    }
+    f8(undefined, undefined);
+
+    function f9(x, y) {
+        var xy = !x || y;
+        if(xy){} // OK, whitelisted
+    }
+    f9(undefined, undefined);
+
+    function f10(x, y) {
+        var xy = !!x || y;
+        if(xy){} // NOT OK, not whitelisted
+    }
+    f10(undefined, undefined);
+
+})();


### PR DESCRIPTION
As discussed previously, this PR extends the interprocedural type inference for function declarations that provably have a single, simple, call site. These function declarations are now analyzed in the same way as IIFEs, i.e. their argument- and return-flow are analyzed.

   The [performance overhead](https://git.semmle.com/gist/esben/1a29161ec4a42fe848c77757405d502c) is negligible, and the new alerts are impressive at times.

   This PR is responsible for true positives of for several queries:
   - many `js/superfluous-trailing-arguments`, `js/comparison-between-incompatible-types`, `js/trivial-conditional`
   - some `js/property-access-on-non-object`, `js/call-to-non-callable`, `js/implicit-operand-conversion`

   This PR also flags a `js/path-injection`, although that seems like a FP in practice.

   Some alert filters have been added to prevent us from annoying programmers with some kinds of true positives that this PR enable. These true positives mainly appear when a polymorphic function only is used in a monomorphic way.
