### PR TITLE
JavaScript: fix performance issue in ServerSideUrlRedirect.qll

### DIFF
--- a/javascript/ql/src/semmle/javascript/security/dataflow/ServerSideUrlRedirect.qll
+++ b/javascript/ql/src/semmle/javascript/security/dataflow/ServerSideUrlRedirect.qll
@@ -36,12 +36,9 @@ module ServerSideUrlRedirect {
   }
 
   /**
-   * Gets a "prefix predecessor" of `nd`, that is, either a normal data flow predecessor
-   * or the left operand of `nd` if it is a concatenation.
+   * Gets the left operand of `nd` if it is a concatenation.
    */
-  private DataFlow::Node prefixPred(DataFlow::Node nd) {
-    result = nd.getAPredecessor()
-    or
+  private DataFlow::Node getPrefixOperand(DataFlow::Node nd) {
     exists (Expr e | e instanceof AddExpr or e instanceof AssignAddExpr |
       nd = DataFlow::valueNode(e) and
       result = DataFlow::valueNode(e.getChildExpr(0))
@@ -53,7 +50,8 @@ module ServerSideUrlRedirect {
    */
   private DataFlow::Node prefixCandidate(Sink sink) {
     result = sink or
-    result = prefixPred(prefixCandidate(sink))
+    result = getPrefixOperand(prefixCandidate(sink)) or
+    result = prefixCandidate(sink).getAPredecessor()
   }
   
   /**
@@ -62,7 +60,8 @@ module ServerSideUrlRedirect {
   private Expr getAPrefix(Sink sink) {
     exists (DataFlow::Node prefix |
       prefix = prefixCandidate(sink) and
-      not exists(prefixPred(prefix)) and
+      not exists(getPrefixOperand(prefix)) and
+      not exists(prefix.getAPredecessor()) and
       result = prefix.asExpr()
     )
   }


### PR DESCRIPTION
Fixes a performance issue in ServerSideUrlRedirect discovered while switching to the string concatenation library.

I'm fixing this separately in order to have a "fair" perf comparison of string concatenation library.

The problem was that `prefixPred` included a reordered copy of all of the flow edges and was subsequently used in a negation, causing it to be materialised.

[Performance results](https://git.semmle.com/gist/asger/fc111532216310f3caf8d5a61b43fd40).