### PR TITLE
C#: Generic control flow graph splitting

### DIFF
--- a/csharp/ql/src/semmle/code/csharp/Stmt.qll
+++ b/csharp/ql/src/semmle/code/csharp/Stmt.qll
@@ -971,6 +971,8 @@ class TryStmt extends Stmt, @try_stmt {
  * general `catch` clause (`GeneralCatchClause`).
  */
 class CatchClause extends Stmt, @catch {
+  /** Gets the `try` statement that this `catch` clause belongs to. */
+  TryStmt getTryStmt() { result.getACatchClause() = this }
 
   /** Gets the block of this `catch` clause. */
   BlockStmt getBlock() { result.getParent() = this }
@@ -1007,6 +1009,15 @@ class CatchClause extends Stmt, @catch {
 
   /** Holds if this `catch` clause has a filter. */
   predicate hasFilterClause() { exists(getFilterClause()) }
+
+  /** Holds if this is the last `catch` clause in the `try` statement that it belongs to. */
+  predicate isLast() {
+    exists(TryStmt ts, int last |
+      ts = this.getTryStmt() and
+      last = max(int i | exists(ts.getCatchClause(i))) and
+      this = ts.getCatchClause(last)
+    )
+  }
 }
 
 /**

--- a/csharp/ql/src/semmle/code/csharp/controlflow/Completion.qll
+++ b/csharp/ql/src/semmle/code/csharp/controlflow/Completion.qll
@@ -123,11 +123,6 @@ class Completion extends TCompletion {
     this instanceof NormalCompletion or
     this instanceof ContinueCompletion
   }
-
-  /** Holds if this completion is a valid completion for exiting a callable. */
-  predicate isValidCallableExitCompletion() {
-    not this instanceof GotoCompletion
-  }
 }
 
 /** Holds if expression `e` has the Boolean constant value `value`. */

--- a/csharp/ql/src/semmle/code/csharp/controlflow/ControlFlowGraph.qll
+++ b/csharp/ql/src/semmle/code/csharp/controlflow/ControlFlowGraph.qll
@@ -337,7 +337,7 @@ class FinallySplitControlFlowNode extends ControlFlowNode, TFinallySplitNode {
   }
 
   override string toString() {
-    result = "[" + getSplitType().toString() + "] " + getElement().toString()
+    result = "[finally: " + getSplitType().toString() + "] " + getElement().toString()
   }
 }
 

--- a/csharp/ql/test/library-tests/controlflow/graph/BasicBlock.expected
+++ b/csharp/ql/test/library-tests/controlflow/graph/BasicBlock.expected
@@ -79,8 +79,10 @@
 | ExitMethods.cs:30:10:30:11 | enter M5 | ExitMethods.cs:30:10:30:11 | exit M5 | 6 |
 | ExitMethods.cs:36:10:36:11 | enter M6 | ExitMethods.cs:40:13:40:30 | call to method ErrorAlways | 7 |
 | ExitMethods.cs:36:10:36:11 | exit M6 | ExitMethods.cs:36:10:36:11 | exit M6 | 1 |
-| ExitMethods.cs:42:9:45:9 | catch (...) {...} | ExitMethods.cs:44:13:44:19 | return ...; | 3 |
-| ExitMethods.cs:46:9:49:9 | catch (...) {...} | ExitMethods.cs:48:13:48:19 | return ...; | 3 |
+| ExitMethods.cs:42:9:45:9 | [exception: ArgumentException] catch (...) {...} | ExitMethods.cs:42:9:45:9 | [exception: ArgumentException] catch (...) {...} | 1 |
+| ExitMethods.cs:42:9:45:9 | [exception: Exception] catch (...) {...} | ExitMethods.cs:42:9:45:9 | [exception: Exception] catch (...) {...} | 1 |
+| ExitMethods.cs:43:9:45:9 | {...} | ExitMethods.cs:44:13:44:19 | return ...; | 2 |
+| ExitMethods.cs:46:9:49:9 | [exception: Exception] catch (...) {...} | ExitMethods.cs:48:13:48:19 | return ...; | 3 |
 | ExitMethods.cs:52:17:52:26 | enter ErrorMaybe | ExitMethods.cs:54:13:54:13 | access to parameter b | 4 |
 | ExitMethods.cs:52:17:52:26 | exit ErrorMaybe | ExitMethods.cs:52:17:52:26 | exit ErrorMaybe | 1 |
 | ExitMethods.cs:55:19:55:33 | object creation of type Exception | ExitMethods.cs:55:13:55:34 | throw ...; | 2 |
@@ -303,13 +305,20 @@
 | cflow.cs:153:9:155:9 | {...} | cflow.cs:159:31:159:36 | "Try2" | 8 |
 | cflow.cs:159:13:159:37 | call to method WriteLine | cflow.cs:159:13:159:37 | call to method WriteLine | 1 |
 | cflow.cs:160:13:160:19 | return ...; | cflow.cs:186:13:186:40 | [finally: return] call to method WriteLine | 5 |
-| cflow.cs:162:9:165:9 | catch (...) {...} | cflow.cs:186:13:186:40 | [finally: exception(IOException)] call to method WriteLine | 9 |
-| cflow.cs:166:9:176:9 | catch (...) {...} | cflow.cs:186:13:186:40 | [finally: exception(Exception)] call to method WriteLine | 16 |
-| cflow.cs:177:9:179:9 | catch (...) {...} | cflow.cs:191:31:191:36 | "Try3" | 10 |
+| cflow.cs:162:9:165:9 | [exception: Exception] catch (...) {...} | cflow.cs:162:9:165:9 | [exception: Exception] catch (...) {...} | 1 |
+| cflow.cs:162:9:165:9 | [exception: OutOfMemoryException] catch (...) {...} | cflow.cs:177:9:179:9 | [exception: OutOfMemoryException] catch (...) {...} | 3 |
+| cflow.cs:162:38:162:39 | [exception: Exception] IOException ex | cflow.cs:186:13:186:40 | [finally: exception(IOException)] call to method WriteLine | 8 |
+| cflow.cs:166:9:176:9 | [exception: Exception] catch (...) {...} | cflow.cs:166:9:176:9 | [exception: Exception] catch (...) {...} | 1 |
+| cflow.cs:166:41:166:42 | [exception: Exception] ArgumentException ex | cflow.cs:186:13:186:40 | [finally: exception(Exception)] call to method WriteLine | 15 |
+| cflow.cs:177:9:179:9 | [exception: Exception] catch (...) {...} | cflow.cs:177:9:179:9 | [exception: Exception] catch (...) {...} | 1 |
+| cflow.cs:178:9:179:9 | {...} | cflow.cs:191:31:191:36 | "Try3" | 9 |
 | cflow.cs:191:13:191:37 | call to method WriteLine | cflow.cs:191:13:191:37 | call to method WriteLine | 1 |
 | cflow.cs:192:13:192:19 | return ...; | cflow.cs:203:13:203:40 | [finally: return] call to method WriteLine | 5 |
-| cflow.cs:194:9:197:9 | catch (...) {...} | cflow.cs:203:13:203:40 | [finally: exception(IOException)] call to method WriteLine | 9 |
-| cflow.cs:198:9:200:9 | catch (...) {...} | cflow.cs:207:9:230:9 | while (...) ... | 16 |
+| cflow.cs:194:9:197:9 | [exception: Exception] catch (...) {...} | cflow.cs:194:9:197:9 | [exception: Exception] catch (...) {...} | 1 |
+| cflow.cs:194:9:197:9 | [exception: OutOfMemoryException] catch (...) {...} | cflow.cs:198:35:198:51 | [exception: OutOfMemoryException] ... != ... | 7 |
+| cflow.cs:194:38:194:39 | [exception: Exception] IOException ex | cflow.cs:203:13:203:40 | [finally: exception(IOException)] call to method WriteLine | 8 |
+| cflow.cs:198:9:200:9 | [exception: Exception] catch (...) {...} | cflow.cs:198:35:198:51 | [exception: Exception] ... != ... | 6 |
+| cflow.cs:199:9:200:9 | {...} | cflow.cs:207:9:230:9 | while (...) ... | 10 |
 | cflow.cs:202:9:204:9 | [finally: exception(Exception)] {...} | cflow.cs:203:13:203:40 | [finally: exception(Exception)] call to method WriteLine | 4 |
 | cflow.cs:202:9:204:9 | [finally: exception(OutOfMemoryException)] {...} | cflow.cs:203:13:203:40 | [finally: exception(OutOfMemoryException)] call to method WriteLine | 4 |
 | cflow.cs:207:16:207:16 | access to local variable i | cflow.cs:207:16:207:20 | ... > ... | 3 |

--- a/csharp/ql/test/library-tests/controlflow/graph/BasicBlock.expected
+++ b/csharp/ql/test/library-tests/controlflow/graph/BasicBlock.expected
@@ -41,6 +41,33 @@
 | BreakInTry.cs:65:26:65:28 | [finally: return] String arg | BreakInTry.cs:67:21:67:31 | [finally: return] ... == ... | 6 |
 | BreakInTry.cs:68:21:68:26 | [finally: return] break; | BreakInTry.cs:68:21:68:26 | [finally: return] break; | 1 |
 | BreakInTry.cs:68:21:68:26 | break; | BreakInTry.cs:68:21:68:26 | break; | 1 |
+| CatchInFinally.cs:5:10:5:11 | enter M1 | CatchInFinally.cs:9:17:9:28 | ... == ... | 8 |
+| CatchInFinally.cs:5:10:5:11 | exit M1 | CatchInFinally.cs:5:10:5:11 | exit M1 | 1 |
+| CatchInFinally.cs:10:17:10:50 | throw ...; | CatchInFinally.cs:16:21:16:31 | [finally: exception(ArgumentNullException)] access to property Length | 7 |
+| CatchInFinally.cs:10:23:10:49 | object creation of type ArgumentNullException | CatchInFinally.cs:10:23:10:49 | object creation of type ArgumentNullException | 1 |
+| CatchInFinally.cs:13:9:27:9 | [finally: exception(Exception)] {...} | CatchInFinally.cs:16:21:16:31 | [finally: exception(Exception)] access to property Length | 6 |
+| CatchInFinally.cs:13:9:27:9 | {...} | CatchInFinally.cs:16:21:16:31 | access to property Length | 6 |
+| CatchInFinally.cs:16:36:16:36 | 1 | CatchInFinally.cs:16:21:16:36 | ... == ... | 2 |
+| CatchInFinally.cs:16:36:16:36 | [finally: exception(ArgumentNullException)] 1 | CatchInFinally.cs:16:21:16:36 | [finally: exception(ArgumentNullException)] ... == ... | 2 |
+| CatchInFinally.cs:16:36:16:36 | [finally: exception(Exception)] 1 | CatchInFinally.cs:16:21:16:36 | [finally: exception(Exception)] ... == ... | 2 |
+| CatchInFinally.cs:17:21:17:45 | [finally: exception(ArgumentNullException)] throw ...; | CatchInFinally.cs:17:21:17:45 | [finally: exception(ArgumentNullException)] throw ...; | 1 |
+| CatchInFinally.cs:17:21:17:45 | [finally: exception(Exception)] throw ...; | CatchInFinally.cs:17:21:17:45 | [finally: exception(Exception)] throw ...; | 1 |
+| CatchInFinally.cs:17:21:17:45 | throw ...; | CatchInFinally.cs:17:21:17:45 | throw ...; | 1 |
+| CatchInFinally.cs:17:41:17:43 | "1" | CatchInFinally.cs:17:27:17:44 | object creation of type Exception | 2 |
+| CatchInFinally.cs:17:41:17:43 | [finally: exception(ArgumentNullException)] "1" | CatchInFinally.cs:17:27:17:44 | [finally: exception(ArgumentNullException)] object creation of type Exception | 2 |
+| CatchInFinally.cs:17:41:17:43 | [finally: exception(Exception)] "1" | CatchInFinally.cs:17:27:17:44 | [finally: exception(Exception)] object creation of type Exception | 2 |
+| CatchInFinally.cs:19:13:22:13 | [exception: Exception, finally: exception(ArgumentNullException)] catch (...) {...} | CatchInFinally.cs:19:39:19:54 | [exception: Exception, finally: exception(ArgumentNullException)] ... == ... | 6 |
+| CatchInFinally.cs:19:13:22:13 | [exception: Exception, finally: exception(Exception)] catch (...) {...} | CatchInFinally.cs:19:39:19:54 | [exception: Exception, finally: exception(Exception)] ... == ... | 6 |
+| CatchInFinally.cs:19:13:22:13 | [exception: Exception] catch (...) {...} | CatchInFinally.cs:19:39:19:54 | [exception: Exception] ... == ... | 6 |
+| CatchInFinally.cs:19:13:22:13 | [exception: NullReferenceException, finally: exception(ArgumentNullException)] catch (...) {...} | CatchInFinally.cs:19:39:19:54 | [exception: NullReferenceException, finally: exception(ArgumentNullException)] ... == ... | 6 |
+| CatchInFinally.cs:19:13:22:13 | [exception: NullReferenceException, finally: exception(Exception)] catch (...) {...} | CatchInFinally.cs:19:39:19:54 | [exception: NullReferenceException, finally: exception(Exception)] ... == ... | 6 |
+| CatchInFinally.cs:19:13:22:13 | [exception: NullReferenceException] catch (...) {...} | CatchInFinally.cs:19:39:19:54 | [exception: NullReferenceException] ... == ... | 6 |
+| CatchInFinally.cs:20:13:22:13 | [finally: exception(ArgumentNullException)] {...} | CatchInFinally.cs:21:17:21:42 | [finally: exception(ArgumentNullException)] call to method WriteLine | 6 |
+| CatchInFinally.cs:20:13:22:13 | [finally: exception(Exception)] {...} | CatchInFinally.cs:21:17:21:42 | [finally: exception(Exception)] call to method WriteLine | 6 |
+| CatchInFinally.cs:20:13:22:13 | {...} | CatchInFinally.cs:21:17:21:42 | call to method WriteLine | 6 |
+| CatchInFinally.cs:23:13:26:13 | [finally: exception(ArgumentNullException)] catch {...} | CatchInFinally.cs:25:17:25:37 | [finally: exception(ArgumentNullException)] call to method WriteLine | 5 |
+| CatchInFinally.cs:23:13:26:13 | [finally: exception(Exception)] catch {...} | CatchInFinally.cs:25:17:25:37 | [finally: exception(Exception)] call to method WriteLine | 5 |
+| CatchInFinally.cs:23:13:26:13 | catch {...} | CatchInFinally.cs:25:17:25:37 | call to method WriteLine | 5 |
 | CompileTimeOperators.cs:5:9:5:15 | enter Default | CompileTimeOperators.cs:5:9:5:15 | exit Default | 5 |
 | CompileTimeOperators.cs:10:9:10:14 | enter Sizeof | CompileTimeOperators.cs:10:9:10:14 | exit Sizeof | 5 |
 | CompileTimeOperators.cs:15:10:15:15 | enter Typeof | CompileTimeOperators.cs:15:10:15:15 | exit Typeof | 5 |

--- a/csharp/ql/test/library-tests/controlflow/graph/BasicBlock.expected
+++ b/csharp/ql/test/library-tests/controlflow/graph/BasicBlock.expected
@@ -15,31 +15,31 @@
 | BreakInTry.cs:20:10:20:11 | enter M2 | BreakInTry.cs:22:29:22:32 | access to parameter args | 3 |
 | BreakInTry.cs:22:9:34:9 | foreach (... ... in ...) ... | BreakInTry.cs:22:9:34:9 | foreach (... ... in ...) ... | 1 |
 | BreakInTry.cs:22:22:22:24 | String arg | BreakInTry.cs:26:21:26:31 | ... == ... | 8 |
-| BreakInTry.cs:27:21:27:26 | break; | BreakInTry.cs:31:21:31:32 | [break] ... == ... | 6 |
+| BreakInTry.cs:27:21:27:26 | break; | BreakInTry.cs:31:21:31:32 | [finally: break] ... == ... | 6 |
 | BreakInTry.cs:30:13:33:13 | {...} | BreakInTry.cs:31:21:31:32 | ... == ... | 5 |
 | BreakInTry.cs:32:21:32:21 | ; | BreakInTry.cs:32:21:32:21 | ; | 1 |
-| BreakInTry.cs:32:21:32:21 | [break] ; | BreakInTry.cs:32:21:32:21 | [break] ; | 1 |
+| BreakInTry.cs:32:21:32:21 | [finally: break] ; | BreakInTry.cs:32:21:32:21 | [finally: break] ; | 1 |
 | BreakInTry.cs:35:7:35:7 | ; | BreakInTry.cs:20:10:20:11 | exit M2 | 2 |
 | BreakInTry.cs:38:10:38:11 | enter M3 | BreakInTry.cs:42:17:42:28 | ... == ... | 8 |
 | BreakInTry.cs:38:10:38:11 | exit M3 | BreakInTry.cs:38:10:38:11 | exit M3 | 1 |
-| BreakInTry.cs:43:17:43:23 | return ...; | BreakInTry.cs:47:33:47:36 | [return] access to parameter args | 3 |
+| BreakInTry.cs:43:17:43:23 | return ...; | BreakInTry.cs:47:33:47:36 | [finally: return] access to parameter args | 3 |
 | BreakInTry.cs:46:9:52:9 | {...} | BreakInTry.cs:47:33:47:36 | access to parameter args | 2 |
-| BreakInTry.cs:47:13:51:13 | [return] foreach (... ... in ...) ... | BreakInTry.cs:47:13:51:13 | [return] foreach (... ... in ...) ... | 1 |
+| BreakInTry.cs:47:13:51:13 | [finally: return] foreach (... ... in ...) ... | BreakInTry.cs:47:13:51:13 | [finally: return] foreach (... ... in ...) ... | 1 |
 | BreakInTry.cs:47:13:51:13 | foreach (... ... in ...) ... | BreakInTry.cs:47:13:51:13 | foreach (... ... in ...) ... | 1 |
 | BreakInTry.cs:47:26:47:28 | String arg | BreakInTry.cs:49:21:49:31 | ... == ... | 6 |
-| BreakInTry.cs:47:26:47:28 | [return] String arg | BreakInTry.cs:49:21:49:31 | [return] ... == ... | 6 |
-| BreakInTry.cs:50:21:50:26 | [return] break; | BreakInTry.cs:50:21:50:26 | [return] break; | 1 |
+| BreakInTry.cs:47:26:47:28 | [finally: return] String arg | BreakInTry.cs:49:21:49:31 | [finally: return] ... == ... | 6 |
+| BreakInTry.cs:50:21:50:26 | [finally: return] break; | BreakInTry.cs:50:21:50:26 | [finally: return] break; | 1 |
 | BreakInTry.cs:50:21:50:26 | break; | BreakInTry.cs:50:21:50:26 | break; | 1 |
 | BreakInTry.cs:53:7:53:7 | ; | BreakInTry.cs:53:7:53:7 | ; | 1 |
 | BreakInTry.cs:56:10:56:11 | enter M4 | BreakInTry.cs:60:17:60:28 | ... == ... | 8 |
 | BreakInTry.cs:56:10:56:11 | exit M4 | BreakInTry.cs:56:10:56:11 | exit M4 | 1 |
-| BreakInTry.cs:61:17:61:23 | return ...; | BreakInTry.cs:65:33:65:36 | [return] access to parameter args | 3 |
+| BreakInTry.cs:61:17:61:23 | return ...; | BreakInTry.cs:65:33:65:36 | [finally: return] access to parameter args | 3 |
 | BreakInTry.cs:64:9:70:9 | {...} | BreakInTry.cs:65:33:65:36 | access to parameter args | 2 |
-| BreakInTry.cs:65:13:69:13 | [return] foreach (... ... in ...) ... | BreakInTry.cs:65:13:69:13 | [return] foreach (... ... in ...) ... | 1 |
+| BreakInTry.cs:65:13:69:13 | [finally: return] foreach (... ... in ...) ... | BreakInTry.cs:65:13:69:13 | [finally: return] foreach (... ... in ...) ... | 1 |
 | BreakInTry.cs:65:13:69:13 | foreach (... ... in ...) ... | BreakInTry.cs:65:13:69:13 | foreach (... ... in ...) ... | 1 |
 | BreakInTry.cs:65:26:65:28 | String arg | BreakInTry.cs:67:21:67:31 | ... == ... | 6 |
-| BreakInTry.cs:65:26:65:28 | [return] String arg | BreakInTry.cs:67:21:67:31 | [return] ... == ... | 6 |
-| BreakInTry.cs:68:21:68:26 | [return] break; | BreakInTry.cs:68:21:68:26 | [return] break; | 1 |
+| BreakInTry.cs:65:26:65:28 | [finally: return] String arg | BreakInTry.cs:67:21:67:31 | [finally: return] ... == ... | 6 |
+| BreakInTry.cs:68:21:68:26 | [finally: return] break; | BreakInTry.cs:68:21:68:26 | [finally: return] break; | 1 |
 | BreakInTry.cs:68:21:68:26 | break; | BreakInTry.cs:68:21:68:26 | break; | 1 |
 | CompileTimeOperators.cs:5:9:5:15 | enter Default | CompileTimeOperators.cs:5:9:5:15 | exit Default | 5 |
 | CompileTimeOperators.cs:10:9:10:14 | enter Sizeof | CompileTimeOperators.cs:10:9:10:14 | exit Sizeof | 5 |
@@ -298,68 +298,68 @@
 | cflow.cs:146:10:146:19 | enter TryFinally | cflow.cs:150:31:150:36 | "Try1" | 6 |
 | cflow.cs:146:10:146:19 | exit TryFinally | cflow.cs:146:10:146:19 | exit TryFinally | 1 |
 | cflow.cs:150:13:150:37 | call to method WriteLine | cflow.cs:150:13:150:37 | call to method WriteLine | 1 |
-| cflow.cs:153:9:155:9 | [exception(Exception)] {...} | cflow.cs:154:13:154:40 | [exception(Exception)] call to method WriteLine | 4 |
-| cflow.cs:153:9:155:9 | [exception(OutOfMemoryException)] {...} | cflow.cs:154:13:154:40 | [exception(OutOfMemoryException)] call to method WriteLine | 4 |
+| cflow.cs:153:9:155:9 | [finally: exception(Exception)] {...} | cflow.cs:154:13:154:40 | [finally: exception(Exception)] call to method WriteLine | 4 |
+| cflow.cs:153:9:155:9 | [finally: exception(OutOfMemoryException)] {...} | cflow.cs:154:13:154:40 | [finally: exception(OutOfMemoryException)] call to method WriteLine | 4 |
 | cflow.cs:153:9:155:9 | {...} | cflow.cs:159:31:159:36 | "Try2" | 8 |
 | cflow.cs:159:13:159:37 | call to method WriteLine | cflow.cs:159:13:159:37 | call to method WriteLine | 1 |
-| cflow.cs:160:13:160:19 | return ...; | cflow.cs:186:13:186:40 | [return] call to method WriteLine | 5 |
-| cflow.cs:162:9:165:9 | catch (...) {...} | cflow.cs:186:13:186:40 | [exception(IOException)] call to method WriteLine | 9 |
-| cflow.cs:166:9:176:9 | catch (...) {...} | cflow.cs:186:13:186:40 | [exception(Exception)] call to method WriteLine | 16 |
+| cflow.cs:160:13:160:19 | return ...; | cflow.cs:186:13:186:40 | [finally: return] call to method WriteLine | 5 |
+| cflow.cs:162:9:165:9 | catch (...) {...} | cflow.cs:186:13:186:40 | [finally: exception(IOException)] call to method WriteLine | 9 |
+| cflow.cs:166:9:176:9 | catch (...) {...} | cflow.cs:186:13:186:40 | [finally: exception(Exception)] call to method WriteLine | 16 |
 | cflow.cs:177:9:179:9 | catch (...) {...} | cflow.cs:191:31:191:36 | "Try3" | 10 |
 | cflow.cs:191:13:191:37 | call to method WriteLine | cflow.cs:191:13:191:37 | call to method WriteLine | 1 |
-| cflow.cs:192:13:192:19 | return ...; | cflow.cs:203:13:203:40 | [return] call to method WriteLine | 5 |
-| cflow.cs:194:9:197:9 | catch (...) {...} | cflow.cs:203:13:203:40 | [exception(IOException)] call to method WriteLine | 9 |
-| cflow.cs:198:9:200:9 | catch (...) {...} | cflow.cs:207:9:230:9 | while (...) ... | 12 |
-| cflow.cs:202:9:204:9 | [exception(Exception)] {...} | cflow.cs:203:13:203:40 | [exception(Exception)] call to method WriteLine | 4 |
-| cflow.cs:202:9:204:9 | [exception(OutOfMemoryException)] {...} | cflow.cs:203:13:203:40 | [exception(OutOfMemoryException)] call to method WriteLine | 4 |
+| cflow.cs:192:13:192:19 | return ...; | cflow.cs:203:13:203:40 | [finally: return] call to method WriteLine | 5 |
+| cflow.cs:194:9:197:9 | catch (...) {...} | cflow.cs:203:13:203:40 | [finally: exception(IOException)] call to method WriteLine | 9 |
+| cflow.cs:198:9:200:9 | catch (...) {...} | cflow.cs:207:9:230:9 | while (...) ... | 16 |
+| cflow.cs:202:9:204:9 | [finally: exception(Exception)] {...} | cflow.cs:203:13:203:40 | [finally: exception(Exception)] call to method WriteLine | 4 |
+| cflow.cs:202:9:204:9 | [finally: exception(OutOfMemoryException)] {...} | cflow.cs:203:13:203:40 | [finally: exception(OutOfMemoryException)] call to method WriteLine | 4 |
 | cflow.cs:207:16:207:16 | access to local variable i | cflow.cs:207:16:207:20 | ... > ... | 3 |
 | cflow.cs:208:9:230:9 | {...} | cflow.cs:211:21:211:26 | ... == ... | 7 |
-| cflow.cs:212:21:212:27 | return ...; | cflow.cs:222:25:222:30 | [return] ... == ... | 8 |
+| cflow.cs:212:21:212:27 | return ...; | cflow.cs:222:25:222:30 | [finally: return] ... == ... | 8 |
 | cflow.cs:213:17:214:29 | if (...) ... | cflow.cs:213:21:213:26 | ... == ... | 4 |
-| cflow.cs:214:21:214:29 | continue; | cflow.cs:222:25:222:30 | [continue] ... == ... | 8 |
+| cflow.cs:214:21:214:29 | continue; | cflow.cs:222:25:222:30 | [finally: continue] ... == ... | 8 |
 | cflow.cs:215:17:216:26 | if (...) ... | cflow.cs:215:21:215:26 | ... == ... | 4 |
-| cflow.cs:216:21:216:26 | break; | cflow.cs:222:25:222:30 | [break] ... == ... | 8 |
+| cflow.cs:216:21:216:26 | break; | cflow.cs:222:25:222:30 | [finally: break] ... == ... | 8 |
 | cflow.cs:219:13:229:13 | {...} | cflow.cs:222:25:222:30 | ... == ... | 7 |
-| cflow.cs:223:25:223:46 | [break] throw ...; | cflow.cs:223:25:223:46 | [break] throw ...; | 1 |
-| cflow.cs:223:25:223:46 | [continue] throw ...; | cflow.cs:223:25:223:46 | [continue] throw ...; | 1 |
-| cflow.cs:223:25:223:46 | [return] throw ...; | cflow.cs:223:25:223:46 | [return] throw ...; | 1 |
+| cflow.cs:223:25:223:46 | [finally: break] throw ...; | cflow.cs:223:25:223:46 | [finally: break] throw ...; | 1 |
+| cflow.cs:223:25:223:46 | [finally: continue] throw ...; | cflow.cs:223:25:223:46 | [finally: continue] throw ...; | 1 |
+| cflow.cs:223:25:223:46 | [finally: return] throw ...; | cflow.cs:223:25:223:46 | [finally: return] throw ...; | 1 |
 | cflow.cs:223:25:223:46 | throw ...; | cflow.cs:223:25:223:46 | throw ...; | 1 |
-| cflow.cs:223:31:223:45 | [break] object creation of type Exception | cflow.cs:223:31:223:45 | [break] object creation of type Exception | 1 |
-| cflow.cs:223:31:223:45 | [continue] object creation of type Exception | cflow.cs:223:31:223:45 | [continue] object creation of type Exception | 1 |
-| cflow.cs:223:31:223:45 | [return] object creation of type Exception | cflow.cs:223:31:223:45 | [return] object creation of type Exception | 1 |
+| cflow.cs:223:31:223:45 | [finally: break] object creation of type Exception | cflow.cs:223:31:223:45 | [finally: break] object creation of type Exception | 1 |
+| cflow.cs:223:31:223:45 | [finally: continue] object creation of type Exception | cflow.cs:223:31:223:45 | [finally: continue] object creation of type Exception | 1 |
+| cflow.cs:223:31:223:45 | [finally: return] object creation of type Exception | cflow.cs:223:31:223:45 | [finally: return] object creation of type Exception | 1 |
 | cflow.cs:223:31:223:45 | object creation of type Exception | cflow.cs:223:31:223:45 | object creation of type Exception | 1 |
-| cflow.cs:226:17:228:17 | [break] {...} | cflow.cs:227:21:227:23 | [break] ...-- | 4 |
-| cflow.cs:226:17:228:17 | [continue] {...} | cflow.cs:227:21:227:23 | [continue] ...-- | 4 |
-| cflow.cs:226:17:228:17 | [exception(Exception)] {...} | cflow.cs:227:21:227:23 | [exception(Exception)] ...-- | 4 |
-| cflow.cs:226:17:228:17 | [return] {...} | cflow.cs:227:21:227:23 | [return] ...-- | 4 |
+| cflow.cs:226:17:228:17 | [finally: break] {...} | cflow.cs:227:21:227:23 | [finally: break] ...-- | 4 |
+| cflow.cs:226:17:228:17 | [finally: continue] {...} | cflow.cs:227:21:227:23 | [finally: continue] ...-- | 4 |
+| cflow.cs:226:17:228:17 | [finally: exception(Exception)] {...} | cflow.cs:227:21:227:23 | [finally: exception(Exception)] ...-- | 4 |
+| cflow.cs:226:17:228:17 | [finally: return] {...} | cflow.cs:227:21:227:23 | [finally: return] ...-- | 4 |
 | cflow.cs:226:17:228:17 | {...} | cflow.cs:227:21:227:23 | ...-- | 4 |
 | cflow.cs:232:9:245:9 | try {...} ... | cflow.cs:234:17:234:21 | access to field Field | 5 |
 | cflow.cs:234:17:234:28 | access to property Length | cflow.cs:234:17:234:28 | access to property Length | 1 |
 | cflow.cs:234:33:234:33 | 0 | cflow.cs:234:17:234:33 | ... == ... | 2 |
-| cflow.cs:235:17:235:23 | return ...; | cflow.cs:241:19:241:35 | [return] ... == ... | 9 |
+| cflow.cs:235:17:235:23 | return ...; | cflow.cs:241:19:241:35 | [finally: return] ... == ... | 9 |
 | cflow.cs:236:13:237:49 | if (...) ... | cflow.cs:236:17:236:21 | access to field Field | 3 |
 | cflow.cs:236:17:236:28 | access to property Length | cflow.cs:236:17:236:28 | access to property Length | 1 |
 | cflow.cs:236:33:236:33 | 1 | cflow.cs:236:17:236:33 | ... == ... | 2 |
-| cflow.cs:237:17:237:49 | throw ...; | cflow.cs:241:19:241:35 | [exception(OutOfMemoryException)] ... == ... | 9 |
+| cflow.cs:237:17:237:49 | throw ...; | cflow.cs:241:19:241:35 | [finally: exception(OutOfMemoryException)] ... == ... | 9 |
 | cflow.cs:237:23:237:48 | object creation of type OutOfMemoryException | cflow.cs:237:23:237:48 | object creation of type OutOfMemoryException | 1 |
-| cflow.cs:240:9:245:9 | [exception(Exception)] {...} | cflow.cs:241:19:241:35 | [exception(Exception)] ... == ... | 8 |
-| cflow.cs:240:9:245:9 | [exception(NullReferenceException)] {...} | cflow.cs:241:19:241:35 | [exception(NullReferenceException)] ... == ... | 8 |
+| cflow.cs:240:9:245:9 | [finally: exception(Exception)] {...} | cflow.cs:241:19:241:35 | [finally: exception(Exception)] ... == ... | 8 |
+| cflow.cs:240:9:245:9 | [finally: exception(NullReferenceException)] {...} | cflow.cs:241:19:241:35 | [finally: exception(NullReferenceException)] ... == ... | 8 |
 | cflow.cs:240:9:245:9 | {...} | cflow.cs:241:19:241:35 | ... == ... | 8 |
 | cflow.cs:242:17:242:41 | ...; | cflow.cs:242:17:242:40 | call to method WriteLine | 4 |
-| cflow.cs:242:17:242:41 | [exception(Exception)] ...; | cflow.cs:242:17:242:40 | [exception(Exception)] call to method WriteLine | 4 |
-| cflow.cs:242:17:242:41 | [exception(NullReferenceException)] ...; | cflow.cs:242:17:242:40 | [exception(NullReferenceException)] call to method WriteLine | 4 |
-| cflow.cs:242:17:242:41 | [exception(OutOfMemoryException)] ...; | cflow.cs:242:17:242:40 | [exception(OutOfMemoryException)] call to method WriteLine | 4 |
-| cflow.cs:242:17:242:41 | [return] ...; | cflow.cs:242:17:242:40 | [return] call to method WriteLine | 4 |
-| cflow.cs:243:13:244:37 | [exception(Exception)] if (...) ... | cflow.cs:243:17:243:32 | [exception(Exception)] ... > ... | 6 |
-| cflow.cs:243:13:244:37 | [exception(NullReferenceException)] if (...) ... | cflow.cs:243:17:243:32 | [exception(NullReferenceException)] ... > ... | 6 |
-| cflow.cs:243:13:244:37 | [exception(OutOfMemoryException)] if (...) ... | cflow.cs:243:17:243:32 | [exception(OutOfMemoryException)] ... > ... | 6 |
-| cflow.cs:243:13:244:37 | [return] if (...) ... | cflow.cs:243:17:243:32 | [return] ... > ... | 6 |
+| cflow.cs:242:17:242:41 | [finally: exception(Exception)] ...; | cflow.cs:242:17:242:40 | [finally: exception(Exception)] call to method WriteLine | 4 |
+| cflow.cs:242:17:242:41 | [finally: exception(NullReferenceException)] ...; | cflow.cs:242:17:242:40 | [finally: exception(NullReferenceException)] call to method WriteLine | 4 |
+| cflow.cs:242:17:242:41 | [finally: exception(OutOfMemoryException)] ...; | cflow.cs:242:17:242:40 | [finally: exception(OutOfMemoryException)] call to method WriteLine | 4 |
+| cflow.cs:242:17:242:41 | [finally: return] ...; | cflow.cs:242:17:242:40 | [finally: return] call to method WriteLine | 4 |
+| cflow.cs:243:13:244:37 | [finally: exception(Exception)] if (...) ... | cflow.cs:243:17:243:32 | [finally: exception(Exception)] ... > ... | 6 |
+| cflow.cs:243:13:244:37 | [finally: exception(NullReferenceException)] if (...) ... | cflow.cs:243:17:243:32 | [finally: exception(NullReferenceException)] ... > ... | 6 |
+| cflow.cs:243:13:244:37 | [finally: exception(OutOfMemoryException)] if (...) ... | cflow.cs:243:17:243:32 | [finally: exception(OutOfMemoryException)] ... > ... | 6 |
+| cflow.cs:243:13:244:37 | [finally: return] if (...) ... | cflow.cs:243:17:243:32 | [finally: return] ... > ... | 6 |
 | cflow.cs:243:13:244:37 | if (...) ... | cflow.cs:243:17:243:32 | ... > ... | 6 |
 | cflow.cs:244:17:244:37 | ...; | cflow.cs:244:17:244:36 | call to method WriteLine | 3 |
-| cflow.cs:244:17:244:37 | [exception(Exception)] ...; | cflow.cs:244:17:244:36 | [exception(Exception)] call to method WriteLine | 3 |
-| cflow.cs:244:17:244:37 | [exception(NullReferenceException)] ...; | cflow.cs:244:17:244:36 | [exception(NullReferenceException)] call to method WriteLine | 3 |
-| cflow.cs:244:17:244:37 | [exception(OutOfMemoryException)] ...; | cflow.cs:244:17:244:36 | [exception(OutOfMemoryException)] call to method WriteLine | 3 |
-| cflow.cs:244:17:244:37 | [return] ...; | cflow.cs:244:17:244:36 | [return] call to method WriteLine | 3 |
+| cflow.cs:244:17:244:37 | [finally: exception(Exception)] ...; | cflow.cs:244:17:244:36 | [finally: exception(Exception)] call to method WriteLine | 3 |
+| cflow.cs:244:17:244:37 | [finally: exception(NullReferenceException)] ...; | cflow.cs:244:17:244:36 | [finally: exception(NullReferenceException)] call to method WriteLine | 3 |
+| cflow.cs:244:17:244:37 | [finally: exception(OutOfMemoryException)] ...; | cflow.cs:244:17:244:36 | [finally: exception(OutOfMemoryException)] call to method WriteLine | 3 |
+| cflow.cs:244:17:244:37 | [finally: return] ...; | cflow.cs:244:17:244:36 | [finally: return] call to method WriteLine | 3 |
 | cflow.cs:248:10:248:12 | enter For | cflow.cs:251:9:252:33 | for (...;...;...) ... | 7 |
 | cflow.cs:248:10:248:12 | exit For | cflow.cs:248:10:248:12 | exit For | 1 |
 | cflow.cs:251:16:251:16 | access to local variable x | cflow.cs:251:16:251:21 | ... < ... | 3 |
@@ -429,8 +429,8 @@
 | cflow.cs:393:10:393:10 | enter M | cflow.cs:397:31:397:35 | "Try" | 6 |
 | cflow.cs:393:10:393:10 | exit M | cflow.cs:393:10:393:10 | exit M | 1 |
 | cflow.cs:397:13:397:36 | call to method WriteLine | cflow.cs:397:13:397:36 | call to method WriteLine | 1 |
-| cflow.cs:400:9:403:9 | [exception(Exception)] {...} | cflow.cs:401:13:401:44 | [exception(Exception)] throw ...; | 4 |
-| cflow.cs:400:9:403:9 | [exception(OutOfMemoryException)] {...} | cflow.cs:401:13:401:44 | [exception(OutOfMemoryException)] throw ...; | 4 |
+| cflow.cs:400:9:403:9 | [finally: exception(Exception)] {...} | cflow.cs:401:13:401:44 | [finally: exception(Exception)] throw ...; | 4 |
+| cflow.cs:400:9:403:9 | [finally: exception(OutOfMemoryException)] {...} | cflow.cs:401:13:401:44 | [finally: exception(OutOfMemoryException)] throw ...; | 4 |
 | cflow.cs:400:9:403:9 | {...} | cflow.cs:401:13:401:44 | throw ...; | 4 |
 | cflow.cs:410:12:410:12 | enter M | cflow.cs:410:12:410:12 | exit M | 5 |
 | cflow.cs:415:5:415:25 | enter NegationInConstructor | cflow.cs:415:5:415:25 | exit NegationInConstructor | 3 |

--- a/csharp/ql/test/library-tests/controlflow/graph/BasicBlockDominance.expected
+++ b/csharp/ql/test/library-tests/controlflow/graph/BasicBlockDominance.expected
@@ -148,10 +148,15 @@
 | post | ExitMethods.cs:36:10:36:11 | enter M6 | ExitMethods.cs:36:10:36:11 | enter M6 |
 | post | ExitMethods.cs:36:10:36:11 | exit M6 | ExitMethods.cs:36:10:36:11 | enter M6 |
 | post | ExitMethods.cs:36:10:36:11 | exit M6 | ExitMethods.cs:36:10:36:11 | exit M6 |
-| post | ExitMethods.cs:36:10:36:11 | exit M6 | ExitMethods.cs:42:9:45:9 | catch (...) {...} |
-| post | ExitMethods.cs:36:10:36:11 | exit M6 | ExitMethods.cs:46:9:49:9 | catch (...) {...} |
-| post | ExitMethods.cs:42:9:45:9 | catch (...) {...} | ExitMethods.cs:42:9:45:9 | catch (...) {...} |
-| post | ExitMethods.cs:46:9:49:9 | catch (...) {...} | ExitMethods.cs:46:9:49:9 | catch (...) {...} |
+| post | ExitMethods.cs:36:10:36:11 | exit M6 | ExitMethods.cs:42:9:45:9 | [exception: ArgumentException] catch (...) {...} |
+| post | ExitMethods.cs:36:10:36:11 | exit M6 | ExitMethods.cs:42:9:45:9 | [exception: Exception] catch (...) {...} |
+| post | ExitMethods.cs:36:10:36:11 | exit M6 | ExitMethods.cs:43:9:45:9 | {...} |
+| post | ExitMethods.cs:36:10:36:11 | exit M6 | ExitMethods.cs:46:9:49:9 | [exception: Exception] catch (...) {...} |
+| post | ExitMethods.cs:42:9:45:9 | [exception: ArgumentException] catch (...) {...} | ExitMethods.cs:42:9:45:9 | [exception: ArgumentException] catch (...) {...} |
+| post | ExitMethods.cs:42:9:45:9 | [exception: Exception] catch (...) {...} | ExitMethods.cs:42:9:45:9 | [exception: Exception] catch (...) {...} |
+| post | ExitMethods.cs:43:9:45:9 | {...} | ExitMethods.cs:42:9:45:9 | [exception: ArgumentException] catch (...) {...} |
+| post | ExitMethods.cs:43:9:45:9 | {...} | ExitMethods.cs:43:9:45:9 | {...} |
+| post | ExitMethods.cs:46:9:49:9 | [exception: Exception] catch (...) {...} | ExitMethods.cs:46:9:49:9 | [exception: Exception] catch (...) {...} |
 | post | ExitMethods.cs:52:17:52:26 | enter ErrorMaybe | ExitMethods.cs:52:17:52:26 | enter ErrorMaybe |
 | post | ExitMethods.cs:52:17:52:26 | exit ErrorMaybe | ExitMethods.cs:52:17:52:26 | enter ErrorMaybe |
 | post | ExitMethods.cs:52:17:52:26 | exit ErrorMaybe | ExitMethods.cs:52:17:52:26 | exit ErrorMaybe |
@@ -619,13 +624,20 @@
 | post | cflow.cs:146:10:146:19 | exit TryFinally | cflow.cs:153:9:155:9 | {...} |
 | post | cflow.cs:146:10:146:19 | exit TryFinally | cflow.cs:159:13:159:37 | call to method WriteLine |
 | post | cflow.cs:146:10:146:19 | exit TryFinally | cflow.cs:160:13:160:19 | return ...; |
-| post | cflow.cs:146:10:146:19 | exit TryFinally | cflow.cs:162:9:165:9 | catch (...) {...} |
-| post | cflow.cs:146:10:146:19 | exit TryFinally | cflow.cs:166:9:176:9 | catch (...) {...} |
-| post | cflow.cs:146:10:146:19 | exit TryFinally | cflow.cs:177:9:179:9 | catch (...) {...} |
+| post | cflow.cs:146:10:146:19 | exit TryFinally | cflow.cs:162:9:165:9 | [exception: Exception] catch (...) {...} |
+| post | cflow.cs:146:10:146:19 | exit TryFinally | cflow.cs:162:9:165:9 | [exception: OutOfMemoryException] catch (...) {...} |
+| post | cflow.cs:146:10:146:19 | exit TryFinally | cflow.cs:162:38:162:39 | [exception: Exception] IOException ex |
+| post | cflow.cs:146:10:146:19 | exit TryFinally | cflow.cs:166:9:176:9 | [exception: Exception] catch (...) {...} |
+| post | cflow.cs:146:10:146:19 | exit TryFinally | cflow.cs:166:41:166:42 | [exception: Exception] ArgumentException ex |
+| post | cflow.cs:146:10:146:19 | exit TryFinally | cflow.cs:177:9:179:9 | [exception: Exception] catch (...) {...} |
+| post | cflow.cs:146:10:146:19 | exit TryFinally | cflow.cs:178:9:179:9 | {...} |
 | post | cflow.cs:146:10:146:19 | exit TryFinally | cflow.cs:191:13:191:37 | call to method WriteLine |
 | post | cflow.cs:146:10:146:19 | exit TryFinally | cflow.cs:192:13:192:19 | return ...; |
-| post | cflow.cs:146:10:146:19 | exit TryFinally | cflow.cs:194:9:197:9 | catch (...) {...} |
-| post | cflow.cs:146:10:146:19 | exit TryFinally | cflow.cs:198:9:200:9 | catch (...) {...} |
+| post | cflow.cs:146:10:146:19 | exit TryFinally | cflow.cs:194:9:197:9 | [exception: Exception] catch (...) {...} |
+| post | cflow.cs:146:10:146:19 | exit TryFinally | cflow.cs:194:9:197:9 | [exception: OutOfMemoryException] catch (...) {...} |
+| post | cflow.cs:146:10:146:19 | exit TryFinally | cflow.cs:194:38:194:39 | [exception: Exception] IOException ex |
+| post | cflow.cs:146:10:146:19 | exit TryFinally | cflow.cs:198:9:200:9 | [exception: Exception] catch (...) {...} |
+| post | cflow.cs:146:10:146:19 | exit TryFinally | cflow.cs:199:9:200:9 | {...} |
 | post | cflow.cs:146:10:146:19 | exit TryFinally | cflow.cs:202:9:204:9 | [finally: exception(Exception)] {...} |
 | post | cflow.cs:146:10:146:19 | exit TryFinally | cflow.cs:202:9:204:9 | [finally: exception(OutOfMemoryException)] {...} |
 | post | cflow.cs:146:10:146:19 | exit TryFinally | cflow.cs:207:16:207:16 | access to local variable i |
@@ -682,16 +694,25 @@
 | post | cflow.cs:153:9:155:9 | {...} | cflow.cs:153:9:155:9 | {...} |
 | post | cflow.cs:159:13:159:37 | call to method WriteLine | cflow.cs:159:13:159:37 | call to method WriteLine |
 | post | cflow.cs:160:13:160:19 | return ...; | cflow.cs:160:13:160:19 | return ...; |
-| post | cflow.cs:162:9:165:9 | catch (...) {...} | cflow.cs:162:9:165:9 | catch (...) {...} |
-| post | cflow.cs:166:9:176:9 | catch (...) {...} | cflow.cs:166:9:176:9 | catch (...) {...} |
-| post | cflow.cs:177:9:179:9 | catch (...) {...} | cflow.cs:177:9:179:9 | catch (...) {...} |
+| post | cflow.cs:162:9:165:9 | [exception: Exception] catch (...) {...} | cflow.cs:162:9:165:9 | [exception: Exception] catch (...) {...} |
+| post | cflow.cs:162:9:165:9 | [exception: OutOfMemoryException] catch (...) {...} | cflow.cs:162:9:165:9 | [exception: OutOfMemoryException] catch (...) {...} |
+| post | cflow.cs:162:38:162:39 | [exception: Exception] IOException ex | cflow.cs:162:38:162:39 | [exception: Exception] IOException ex |
+| post | cflow.cs:166:9:176:9 | [exception: Exception] catch (...) {...} | cflow.cs:166:9:176:9 | [exception: Exception] catch (...) {...} |
+| post | cflow.cs:166:41:166:42 | [exception: Exception] ArgumentException ex | cflow.cs:166:41:166:42 | [exception: Exception] ArgumentException ex |
+| post | cflow.cs:177:9:179:9 | [exception: Exception] catch (...) {...} | cflow.cs:177:9:179:9 | [exception: Exception] catch (...) {...} |
+| post | cflow.cs:178:9:179:9 | {...} | cflow.cs:162:9:165:9 | [exception: OutOfMemoryException] catch (...) {...} |
+| post | cflow.cs:178:9:179:9 | {...} | cflow.cs:177:9:179:9 | [exception: Exception] catch (...) {...} |
+| post | cflow.cs:178:9:179:9 | {...} | cflow.cs:178:9:179:9 | {...} |
 | post | cflow.cs:191:13:191:37 | call to method WriteLine | cflow.cs:191:13:191:37 | call to method WriteLine |
 | post | cflow.cs:192:13:192:19 | return ...; | cflow.cs:192:13:192:19 | return ...; |
-| post | cflow.cs:194:9:197:9 | catch (...) {...} | cflow.cs:194:9:197:9 | catch (...) {...} |
-| post | cflow.cs:198:9:200:9 | catch (...) {...} | cflow.cs:198:9:200:9 | catch (...) {...} |
+| post | cflow.cs:194:9:197:9 | [exception: Exception] catch (...) {...} | cflow.cs:194:9:197:9 | [exception: Exception] catch (...) {...} |
+| post | cflow.cs:194:9:197:9 | [exception: OutOfMemoryException] catch (...) {...} | cflow.cs:194:9:197:9 | [exception: OutOfMemoryException] catch (...) {...} |
+| post | cflow.cs:194:38:194:39 | [exception: Exception] IOException ex | cflow.cs:194:38:194:39 | [exception: Exception] IOException ex |
+| post | cflow.cs:198:9:200:9 | [exception: Exception] catch (...) {...} | cflow.cs:198:9:200:9 | [exception: Exception] catch (...) {...} |
+| post | cflow.cs:199:9:200:9 | {...} | cflow.cs:199:9:200:9 | {...} |
 | post | cflow.cs:202:9:204:9 | [finally: exception(Exception)] {...} | cflow.cs:202:9:204:9 | [finally: exception(Exception)] {...} |
 | post | cflow.cs:202:9:204:9 | [finally: exception(OutOfMemoryException)] {...} | cflow.cs:202:9:204:9 | [finally: exception(OutOfMemoryException)] {...} |
-| post | cflow.cs:207:16:207:16 | access to local variable i | cflow.cs:198:9:200:9 | catch (...) {...} |
+| post | cflow.cs:207:16:207:16 | access to local variable i | cflow.cs:199:9:200:9 | {...} |
 | post | cflow.cs:207:16:207:16 | access to local variable i | cflow.cs:207:16:207:16 | access to local variable i |
 | post | cflow.cs:207:16:207:16 | access to local variable i | cflow.cs:226:17:228:17 | [finally: continue] {...} |
 | post | cflow.cs:207:16:207:16 | access to local variable i | cflow.cs:226:17:228:17 | {...} |
@@ -1178,11 +1199,16 @@
 | pre | ExitMethods.cs:30:10:30:11 | enter M5 | ExitMethods.cs:30:10:30:11 | enter M5 |
 | pre | ExitMethods.cs:36:10:36:11 | enter M6 | ExitMethods.cs:36:10:36:11 | enter M6 |
 | pre | ExitMethods.cs:36:10:36:11 | enter M6 | ExitMethods.cs:36:10:36:11 | exit M6 |
-| pre | ExitMethods.cs:36:10:36:11 | enter M6 | ExitMethods.cs:42:9:45:9 | catch (...) {...} |
-| pre | ExitMethods.cs:36:10:36:11 | enter M6 | ExitMethods.cs:46:9:49:9 | catch (...) {...} |
+| pre | ExitMethods.cs:36:10:36:11 | enter M6 | ExitMethods.cs:42:9:45:9 | [exception: ArgumentException] catch (...) {...} |
+| pre | ExitMethods.cs:36:10:36:11 | enter M6 | ExitMethods.cs:42:9:45:9 | [exception: Exception] catch (...) {...} |
+| pre | ExitMethods.cs:36:10:36:11 | enter M6 | ExitMethods.cs:43:9:45:9 | {...} |
+| pre | ExitMethods.cs:36:10:36:11 | enter M6 | ExitMethods.cs:46:9:49:9 | [exception: Exception] catch (...) {...} |
 | pre | ExitMethods.cs:36:10:36:11 | exit M6 | ExitMethods.cs:36:10:36:11 | exit M6 |
-| pre | ExitMethods.cs:42:9:45:9 | catch (...) {...} | ExitMethods.cs:42:9:45:9 | catch (...) {...} |
-| pre | ExitMethods.cs:46:9:49:9 | catch (...) {...} | ExitMethods.cs:46:9:49:9 | catch (...) {...} |
+| pre | ExitMethods.cs:42:9:45:9 | [exception: ArgumentException] catch (...) {...} | ExitMethods.cs:42:9:45:9 | [exception: ArgumentException] catch (...) {...} |
+| pre | ExitMethods.cs:42:9:45:9 | [exception: Exception] catch (...) {...} | ExitMethods.cs:42:9:45:9 | [exception: Exception] catch (...) {...} |
+| pre | ExitMethods.cs:42:9:45:9 | [exception: Exception] catch (...) {...} | ExitMethods.cs:46:9:49:9 | [exception: Exception] catch (...) {...} |
+| pre | ExitMethods.cs:43:9:45:9 | {...} | ExitMethods.cs:43:9:45:9 | {...} |
+| pre | ExitMethods.cs:46:9:49:9 | [exception: Exception] catch (...) {...} | ExitMethods.cs:46:9:49:9 | [exception: Exception] catch (...) {...} |
 | pre | ExitMethods.cs:52:17:52:26 | enter ErrorMaybe | ExitMethods.cs:52:17:52:26 | enter ErrorMaybe |
 | pre | ExitMethods.cs:52:17:52:26 | enter ErrorMaybe | ExitMethods.cs:52:17:52:26 | exit ErrorMaybe |
 | pre | ExitMethods.cs:52:17:52:26 | enter ErrorMaybe | ExitMethods.cs:55:19:55:33 | object creation of type Exception |
@@ -1812,13 +1838,20 @@
 | pre | cflow.cs:146:10:146:19 | enter TryFinally | cflow.cs:153:9:155:9 | {...} |
 | pre | cflow.cs:146:10:146:19 | enter TryFinally | cflow.cs:159:13:159:37 | call to method WriteLine |
 | pre | cflow.cs:146:10:146:19 | enter TryFinally | cflow.cs:160:13:160:19 | return ...; |
-| pre | cflow.cs:146:10:146:19 | enter TryFinally | cflow.cs:162:9:165:9 | catch (...) {...} |
-| pre | cflow.cs:146:10:146:19 | enter TryFinally | cflow.cs:166:9:176:9 | catch (...) {...} |
-| pre | cflow.cs:146:10:146:19 | enter TryFinally | cflow.cs:177:9:179:9 | catch (...) {...} |
+| pre | cflow.cs:146:10:146:19 | enter TryFinally | cflow.cs:162:9:165:9 | [exception: Exception] catch (...) {...} |
+| pre | cflow.cs:146:10:146:19 | enter TryFinally | cflow.cs:162:9:165:9 | [exception: OutOfMemoryException] catch (...) {...} |
+| pre | cflow.cs:146:10:146:19 | enter TryFinally | cflow.cs:162:38:162:39 | [exception: Exception] IOException ex |
+| pre | cflow.cs:146:10:146:19 | enter TryFinally | cflow.cs:166:9:176:9 | [exception: Exception] catch (...) {...} |
+| pre | cflow.cs:146:10:146:19 | enter TryFinally | cflow.cs:166:41:166:42 | [exception: Exception] ArgumentException ex |
+| pre | cflow.cs:146:10:146:19 | enter TryFinally | cflow.cs:177:9:179:9 | [exception: Exception] catch (...) {...} |
+| pre | cflow.cs:146:10:146:19 | enter TryFinally | cflow.cs:178:9:179:9 | {...} |
 | pre | cflow.cs:146:10:146:19 | enter TryFinally | cflow.cs:191:13:191:37 | call to method WriteLine |
 | pre | cflow.cs:146:10:146:19 | enter TryFinally | cflow.cs:192:13:192:19 | return ...; |
-| pre | cflow.cs:146:10:146:19 | enter TryFinally | cflow.cs:194:9:197:9 | catch (...) {...} |
-| pre | cflow.cs:146:10:146:19 | enter TryFinally | cflow.cs:198:9:200:9 | catch (...) {...} |
+| pre | cflow.cs:146:10:146:19 | enter TryFinally | cflow.cs:194:9:197:9 | [exception: Exception] catch (...) {...} |
+| pre | cflow.cs:146:10:146:19 | enter TryFinally | cflow.cs:194:9:197:9 | [exception: OutOfMemoryException] catch (...) {...} |
+| pre | cflow.cs:146:10:146:19 | enter TryFinally | cflow.cs:194:38:194:39 | [exception: Exception] IOException ex |
+| pre | cflow.cs:146:10:146:19 | enter TryFinally | cflow.cs:198:9:200:9 | [exception: Exception] catch (...) {...} |
+| pre | cflow.cs:146:10:146:19 | enter TryFinally | cflow.cs:199:9:200:9 | {...} |
 | pre | cflow.cs:146:10:146:19 | enter TryFinally | cflow.cs:202:9:204:9 | [finally: exception(Exception)] {...} |
 | pre | cflow.cs:146:10:146:19 | enter TryFinally | cflow.cs:202:9:204:9 | [finally: exception(OutOfMemoryException)] {...} |
 | pre | cflow.cs:146:10:146:19 | enter TryFinally | cflow.cs:207:16:207:16 | access to local variable i |
@@ -1875,13 +1908,20 @@
 | pre | cflow.cs:150:13:150:37 | call to method WriteLine | cflow.cs:153:9:155:9 | {...} |
 | pre | cflow.cs:150:13:150:37 | call to method WriteLine | cflow.cs:159:13:159:37 | call to method WriteLine |
 | pre | cflow.cs:150:13:150:37 | call to method WriteLine | cflow.cs:160:13:160:19 | return ...; |
-| pre | cflow.cs:150:13:150:37 | call to method WriteLine | cflow.cs:162:9:165:9 | catch (...) {...} |
-| pre | cflow.cs:150:13:150:37 | call to method WriteLine | cflow.cs:166:9:176:9 | catch (...) {...} |
-| pre | cflow.cs:150:13:150:37 | call to method WriteLine | cflow.cs:177:9:179:9 | catch (...) {...} |
+| pre | cflow.cs:150:13:150:37 | call to method WriteLine | cflow.cs:162:9:165:9 | [exception: Exception] catch (...) {...} |
+| pre | cflow.cs:150:13:150:37 | call to method WriteLine | cflow.cs:162:9:165:9 | [exception: OutOfMemoryException] catch (...) {...} |
+| pre | cflow.cs:150:13:150:37 | call to method WriteLine | cflow.cs:162:38:162:39 | [exception: Exception] IOException ex |
+| pre | cflow.cs:150:13:150:37 | call to method WriteLine | cflow.cs:166:9:176:9 | [exception: Exception] catch (...) {...} |
+| pre | cflow.cs:150:13:150:37 | call to method WriteLine | cflow.cs:166:41:166:42 | [exception: Exception] ArgumentException ex |
+| pre | cflow.cs:150:13:150:37 | call to method WriteLine | cflow.cs:177:9:179:9 | [exception: Exception] catch (...) {...} |
+| pre | cflow.cs:150:13:150:37 | call to method WriteLine | cflow.cs:178:9:179:9 | {...} |
 | pre | cflow.cs:150:13:150:37 | call to method WriteLine | cflow.cs:191:13:191:37 | call to method WriteLine |
 | pre | cflow.cs:150:13:150:37 | call to method WriteLine | cflow.cs:192:13:192:19 | return ...; |
-| pre | cflow.cs:150:13:150:37 | call to method WriteLine | cflow.cs:194:9:197:9 | catch (...) {...} |
-| pre | cflow.cs:150:13:150:37 | call to method WriteLine | cflow.cs:198:9:200:9 | catch (...) {...} |
+| pre | cflow.cs:150:13:150:37 | call to method WriteLine | cflow.cs:194:9:197:9 | [exception: Exception] catch (...) {...} |
+| pre | cflow.cs:150:13:150:37 | call to method WriteLine | cflow.cs:194:9:197:9 | [exception: OutOfMemoryException] catch (...) {...} |
+| pre | cflow.cs:150:13:150:37 | call to method WriteLine | cflow.cs:194:38:194:39 | [exception: Exception] IOException ex |
+| pre | cflow.cs:150:13:150:37 | call to method WriteLine | cflow.cs:198:9:200:9 | [exception: Exception] catch (...) {...} |
+| pre | cflow.cs:150:13:150:37 | call to method WriteLine | cflow.cs:199:9:200:9 | {...} |
 | pre | cflow.cs:150:13:150:37 | call to method WriteLine | cflow.cs:202:9:204:9 | [finally: exception(Exception)] {...} |
 | pre | cflow.cs:150:13:150:37 | call to method WriteLine | cflow.cs:202:9:204:9 | [finally: exception(OutOfMemoryException)] {...} |
 | pre | cflow.cs:150:13:150:37 | call to method WriteLine | cflow.cs:207:16:207:16 | access to local variable i |
@@ -1937,13 +1977,20 @@
 | pre | cflow.cs:153:9:155:9 | {...} | cflow.cs:153:9:155:9 | {...} |
 | pre | cflow.cs:153:9:155:9 | {...} | cflow.cs:159:13:159:37 | call to method WriteLine |
 | pre | cflow.cs:153:9:155:9 | {...} | cflow.cs:160:13:160:19 | return ...; |
-| pre | cflow.cs:153:9:155:9 | {...} | cflow.cs:162:9:165:9 | catch (...) {...} |
-| pre | cflow.cs:153:9:155:9 | {...} | cflow.cs:166:9:176:9 | catch (...) {...} |
-| pre | cflow.cs:153:9:155:9 | {...} | cflow.cs:177:9:179:9 | catch (...) {...} |
+| pre | cflow.cs:153:9:155:9 | {...} | cflow.cs:162:9:165:9 | [exception: Exception] catch (...) {...} |
+| pre | cflow.cs:153:9:155:9 | {...} | cflow.cs:162:9:165:9 | [exception: OutOfMemoryException] catch (...) {...} |
+| pre | cflow.cs:153:9:155:9 | {...} | cflow.cs:162:38:162:39 | [exception: Exception] IOException ex |
+| pre | cflow.cs:153:9:155:9 | {...} | cflow.cs:166:9:176:9 | [exception: Exception] catch (...) {...} |
+| pre | cflow.cs:153:9:155:9 | {...} | cflow.cs:166:41:166:42 | [exception: Exception] ArgumentException ex |
+| pre | cflow.cs:153:9:155:9 | {...} | cflow.cs:177:9:179:9 | [exception: Exception] catch (...) {...} |
+| pre | cflow.cs:153:9:155:9 | {...} | cflow.cs:178:9:179:9 | {...} |
 | pre | cflow.cs:153:9:155:9 | {...} | cflow.cs:191:13:191:37 | call to method WriteLine |
 | pre | cflow.cs:153:9:155:9 | {...} | cflow.cs:192:13:192:19 | return ...; |
-| pre | cflow.cs:153:9:155:9 | {...} | cflow.cs:194:9:197:9 | catch (...) {...} |
-| pre | cflow.cs:153:9:155:9 | {...} | cflow.cs:198:9:200:9 | catch (...) {...} |
+| pre | cflow.cs:153:9:155:9 | {...} | cflow.cs:194:9:197:9 | [exception: Exception] catch (...) {...} |
+| pre | cflow.cs:153:9:155:9 | {...} | cflow.cs:194:9:197:9 | [exception: OutOfMemoryException] catch (...) {...} |
+| pre | cflow.cs:153:9:155:9 | {...} | cflow.cs:194:38:194:39 | [exception: Exception] IOException ex |
+| pre | cflow.cs:153:9:155:9 | {...} | cflow.cs:198:9:200:9 | [exception: Exception] catch (...) {...} |
+| pre | cflow.cs:153:9:155:9 | {...} | cflow.cs:199:9:200:9 | {...} |
 | pre | cflow.cs:153:9:155:9 | {...} | cflow.cs:202:9:204:9 | [finally: exception(Exception)] {...} |
 | pre | cflow.cs:153:9:155:9 | {...} | cflow.cs:202:9:204:9 | [finally: exception(OutOfMemoryException)] {...} |
 | pre | cflow.cs:153:9:155:9 | {...} | cflow.cs:207:16:207:16 | access to local variable i |
@@ -1996,170 +2043,147 @@
 | pre | cflow.cs:153:9:155:9 | {...} | cflow.cs:244:17:244:37 | [finally: return] ...; |
 | pre | cflow.cs:159:13:159:37 | call to method WriteLine | cflow.cs:159:13:159:37 | call to method WriteLine |
 | pre | cflow.cs:159:13:159:37 | call to method WriteLine | cflow.cs:160:13:160:19 | return ...; |
-| pre | cflow.cs:159:13:159:37 | call to method WriteLine | cflow.cs:162:9:165:9 | catch (...) {...} |
-| pre | cflow.cs:159:13:159:37 | call to method WriteLine | cflow.cs:166:9:176:9 | catch (...) {...} |
+| pre | cflow.cs:159:13:159:37 | call to method WriteLine | cflow.cs:162:9:165:9 | [exception: Exception] catch (...) {...} |
+| pre | cflow.cs:159:13:159:37 | call to method WriteLine | cflow.cs:162:38:162:39 | [exception: Exception] IOException ex |
+| pre | cflow.cs:159:13:159:37 | call to method WriteLine | cflow.cs:166:9:176:9 | [exception: Exception] catch (...) {...} |
+| pre | cflow.cs:159:13:159:37 | call to method WriteLine | cflow.cs:166:41:166:42 | [exception: Exception] ArgumentException ex |
+| pre | cflow.cs:159:13:159:37 | call to method WriteLine | cflow.cs:177:9:179:9 | [exception: Exception] catch (...) {...} |
 | pre | cflow.cs:160:13:160:19 | return ...; | cflow.cs:160:13:160:19 | return ...; |
-| pre | cflow.cs:162:9:165:9 | catch (...) {...} | cflow.cs:162:9:165:9 | catch (...) {...} |
-| pre | cflow.cs:166:9:176:9 | catch (...) {...} | cflow.cs:166:9:176:9 | catch (...) {...} |
-| pre | cflow.cs:177:9:179:9 | catch (...) {...} | cflow.cs:177:9:179:9 | catch (...) {...} |
-| pre | cflow.cs:177:9:179:9 | catch (...) {...} | cflow.cs:191:13:191:37 | call to method WriteLine |
-| pre | cflow.cs:177:9:179:9 | catch (...) {...} | cflow.cs:192:13:192:19 | return ...; |
-| pre | cflow.cs:177:9:179:9 | catch (...) {...} | cflow.cs:194:9:197:9 | catch (...) {...} |
-| pre | cflow.cs:177:9:179:9 | catch (...) {...} | cflow.cs:198:9:200:9 | catch (...) {...} |
-| pre | cflow.cs:177:9:179:9 | catch (...) {...} | cflow.cs:202:9:204:9 | [finally: exception(Exception)] {...} |
-| pre | cflow.cs:177:9:179:9 | catch (...) {...} | cflow.cs:202:9:204:9 | [finally: exception(OutOfMemoryException)] {...} |
-| pre | cflow.cs:177:9:179:9 | catch (...) {...} | cflow.cs:207:16:207:16 | access to local variable i |
-| pre | cflow.cs:177:9:179:9 | catch (...) {...} | cflow.cs:208:9:230:9 | {...} |
-| pre | cflow.cs:177:9:179:9 | catch (...) {...} | cflow.cs:212:21:212:27 | return ...; |
-| pre | cflow.cs:177:9:179:9 | catch (...) {...} | cflow.cs:213:17:214:29 | if (...) ... |
-| pre | cflow.cs:177:9:179:9 | catch (...) {...} | cflow.cs:214:21:214:29 | continue; |
-| pre | cflow.cs:177:9:179:9 | catch (...) {...} | cflow.cs:215:17:216:26 | if (...) ... |
-| pre | cflow.cs:177:9:179:9 | catch (...) {...} | cflow.cs:216:21:216:26 | break; |
-| pre | cflow.cs:177:9:179:9 | catch (...) {...} | cflow.cs:219:13:229:13 | {...} |
-| pre | cflow.cs:177:9:179:9 | catch (...) {...} | cflow.cs:223:25:223:46 | [finally: break] throw ...; |
-| pre | cflow.cs:177:9:179:9 | catch (...) {...} | cflow.cs:223:25:223:46 | [finally: continue] throw ...; |
-| pre | cflow.cs:177:9:179:9 | catch (...) {...} | cflow.cs:223:25:223:46 | [finally: return] throw ...; |
-| pre | cflow.cs:177:9:179:9 | catch (...) {...} | cflow.cs:223:25:223:46 | throw ...; |
-| pre | cflow.cs:177:9:179:9 | catch (...) {...} | cflow.cs:223:31:223:45 | [finally: break] object creation of type Exception |
-| pre | cflow.cs:177:9:179:9 | catch (...) {...} | cflow.cs:223:31:223:45 | [finally: continue] object creation of type Exception |
-| pre | cflow.cs:177:9:179:9 | catch (...) {...} | cflow.cs:223:31:223:45 | [finally: return] object creation of type Exception |
-| pre | cflow.cs:177:9:179:9 | catch (...) {...} | cflow.cs:223:31:223:45 | object creation of type Exception |
-| pre | cflow.cs:177:9:179:9 | catch (...) {...} | cflow.cs:226:17:228:17 | [finally: break] {...} |
-| pre | cflow.cs:177:9:179:9 | catch (...) {...} | cflow.cs:226:17:228:17 | [finally: continue] {...} |
-| pre | cflow.cs:177:9:179:9 | catch (...) {...} | cflow.cs:226:17:228:17 | [finally: exception(Exception)] {...} |
-| pre | cflow.cs:177:9:179:9 | catch (...) {...} | cflow.cs:226:17:228:17 | [finally: return] {...} |
-| pre | cflow.cs:177:9:179:9 | catch (...) {...} | cflow.cs:226:17:228:17 | {...} |
-| pre | cflow.cs:177:9:179:9 | catch (...) {...} | cflow.cs:232:9:245:9 | try {...} ... |
-| pre | cflow.cs:177:9:179:9 | catch (...) {...} | cflow.cs:234:17:234:28 | access to property Length |
-| pre | cflow.cs:177:9:179:9 | catch (...) {...} | cflow.cs:234:33:234:33 | 0 |
-| pre | cflow.cs:177:9:179:9 | catch (...) {...} | cflow.cs:235:17:235:23 | return ...; |
-| pre | cflow.cs:177:9:179:9 | catch (...) {...} | cflow.cs:236:13:237:49 | if (...) ... |
-| pre | cflow.cs:177:9:179:9 | catch (...) {...} | cflow.cs:236:17:236:28 | access to property Length |
-| pre | cflow.cs:177:9:179:9 | catch (...) {...} | cflow.cs:236:33:236:33 | 1 |
-| pre | cflow.cs:177:9:179:9 | catch (...) {...} | cflow.cs:237:17:237:49 | throw ...; |
-| pre | cflow.cs:177:9:179:9 | catch (...) {...} | cflow.cs:237:23:237:48 | object creation of type OutOfMemoryException |
-| pre | cflow.cs:177:9:179:9 | catch (...) {...} | cflow.cs:240:9:245:9 | [finally: exception(Exception)] {...} |
-| pre | cflow.cs:177:9:179:9 | catch (...) {...} | cflow.cs:240:9:245:9 | [finally: exception(NullReferenceException)] {...} |
-| pre | cflow.cs:177:9:179:9 | catch (...) {...} | cflow.cs:240:9:245:9 | {...} |
-| pre | cflow.cs:177:9:179:9 | catch (...) {...} | cflow.cs:242:17:242:41 | ...; |
-| pre | cflow.cs:177:9:179:9 | catch (...) {...} | cflow.cs:242:17:242:41 | [finally: exception(Exception)] ...; |
-| pre | cflow.cs:177:9:179:9 | catch (...) {...} | cflow.cs:242:17:242:41 | [finally: exception(NullReferenceException)] ...; |
-| pre | cflow.cs:177:9:179:9 | catch (...) {...} | cflow.cs:242:17:242:41 | [finally: exception(OutOfMemoryException)] ...; |
-| pre | cflow.cs:177:9:179:9 | catch (...) {...} | cflow.cs:242:17:242:41 | [finally: return] ...; |
-| pre | cflow.cs:177:9:179:9 | catch (...) {...} | cflow.cs:243:13:244:37 | [finally: exception(Exception)] if (...) ... |
-| pre | cflow.cs:177:9:179:9 | catch (...) {...} | cflow.cs:243:13:244:37 | [finally: exception(NullReferenceException)] if (...) ... |
-| pre | cflow.cs:177:9:179:9 | catch (...) {...} | cflow.cs:243:13:244:37 | [finally: exception(OutOfMemoryException)] if (...) ... |
-| pre | cflow.cs:177:9:179:9 | catch (...) {...} | cflow.cs:243:13:244:37 | [finally: return] if (...) ... |
-| pre | cflow.cs:177:9:179:9 | catch (...) {...} | cflow.cs:243:13:244:37 | if (...) ... |
-| pre | cflow.cs:177:9:179:9 | catch (...) {...} | cflow.cs:244:17:244:37 | ...; |
-| pre | cflow.cs:177:9:179:9 | catch (...) {...} | cflow.cs:244:17:244:37 | [finally: exception(Exception)] ...; |
-| pre | cflow.cs:177:9:179:9 | catch (...) {...} | cflow.cs:244:17:244:37 | [finally: exception(NullReferenceException)] ...; |
-| pre | cflow.cs:177:9:179:9 | catch (...) {...} | cflow.cs:244:17:244:37 | [finally: exception(OutOfMemoryException)] ...; |
-| pre | cflow.cs:177:9:179:9 | catch (...) {...} | cflow.cs:244:17:244:37 | [finally: return] ...; |
+| pre | cflow.cs:162:9:165:9 | [exception: Exception] catch (...) {...} | cflow.cs:162:9:165:9 | [exception: Exception] catch (...) {...} |
+| pre | cflow.cs:162:9:165:9 | [exception: Exception] catch (...) {...} | cflow.cs:162:38:162:39 | [exception: Exception] IOException ex |
+| pre | cflow.cs:162:9:165:9 | [exception: Exception] catch (...) {...} | cflow.cs:166:9:176:9 | [exception: Exception] catch (...) {...} |
+| pre | cflow.cs:162:9:165:9 | [exception: Exception] catch (...) {...} | cflow.cs:166:41:166:42 | [exception: Exception] ArgumentException ex |
+| pre | cflow.cs:162:9:165:9 | [exception: Exception] catch (...) {...} | cflow.cs:177:9:179:9 | [exception: Exception] catch (...) {...} |
+| pre | cflow.cs:162:9:165:9 | [exception: OutOfMemoryException] catch (...) {...} | cflow.cs:162:9:165:9 | [exception: OutOfMemoryException] catch (...) {...} |
+| pre | cflow.cs:162:38:162:39 | [exception: Exception] IOException ex | cflow.cs:162:38:162:39 | [exception: Exception] IOException ex |
+| pre | cflow.cs:166:9:176:9 | [exception: Exception] catch (...) {...} | cflow.cs:166:9:176:9 | [exception: Exception] catch (...) {...} |
+| pre | cflow.cs:166:9:176:9 | [exception: Exception] catch (...) {...} | cflow.cs:166:41:166:42 | [exception: Exception] ArgumentException ex |
+| pre | cflow.cs:166:9:176:9 | [exception: Exception] catch (...) {...} | cflow.cs:177:9:179:9 | [exception: Exception] catch (...) {...} |
+| pre | cflow.cs:166:41:166:42 | [exception: Exception] ArgumentException ex | cflow.cs:166:41:166:42 | [exception: Exception] ArgumentException ex |
+| pre | cflow.cs:177:9:179:9 | [exception: Exception] catch (...) {...} | cflow.cs:177:9:179:9 | [exception: Exception] catch (...) {...} |
+| pre | cflow.cs:178:9:179:9 | {...} | cflow.cs:178:9:179:9 | {...} |
+| pre | cflow.cs:178:9:179:9 | {...} | cflow.cs:191:13:191:37 | call to method WriteLine |
+| pre | cflow.cs:178:9:179:9 | {...} | cflow.cs:192:13:192:19 | return ...; |
+| pre | cflow.cs:178:9:179:9 | {...} | cflow.cs:194:9:197:9 | [exception: Exception] catch (...) {...} |
+| pre | cflow.cs:178:9:179:9 | {...} | cflow.cs:194:9:197:9 | [exception: OutOfMemoryException] catch (...) {...} |
+| pre | cflow.cs:178:9:179:9 | {...} | cflow.cs:194:38:194:39 | [exception: Exception] IOException ex |
+| pre | cflow.cs:178:9:179:9 | {...} | cflow.cs:198:9:200:9 | [exception: Exception] catch (...) {...} |
+| pre | cflow.cs:178:9:179:9 | {...} | cflow.cs:199:9:200:9 | {...} |
+| pre | cflow.cs:178:9:179:9 | {...} | cflow.cs:202:9:204:9 | [finally: exception(Exception)] {...} |
+| pre | cflow.cs:178:9:179:9 | {...} | cflow.cs:202:9:204:9 | [finally: exception(OutOfMemoryException)] {...} |
+| pre | cflow.cs:178:9:179:9 | {...} | cflow.cs:207:16:207:16 | access to local variable i |
+| pre | cflow.cs:178:9:179:9 | {...} | cflow.cs:208:9:230:9 | {...} |
+| pre | cflow.cs:178:9:179:9 | {...} | cflow.cs:212:21:212:27 | return ...; |
+| pre | cflow.cs:178:9:179:9 | {...} | cflow.cs:213:17:214:29 | if (...) ... |
+| pre | cflow.cs:178:9:179:9 | {...} | cflow.cs:214:21:214:29 | continue; |
+| pre | cflow.cs:178:9:179:9 | {...} | cflow.cs:215:17:216:26 | if (...) ... |
+| pre | cflow.cs:178:9:179:9 | {...} | cflow.cs:216:21:216:26 | break; |
+| pre | cflow.cs:178:9:179:9 | {...} | cflow.cs:219:13:229:13 | {...} |
+| pre | cflow.cs:178:9:179:9 | {...} | cflow.cs:223:25:223:46 | [finally: break] throw ...; |
+| pre | cflow.cs:178:9:179:9 | {...} | cflow.cs:223:25:223:46 | [finally: continue] throw ...; |
+| pre | cflow.cs:178:9:179:9 | {...} | cflow.cs:223:25:223:46 | [finally: return] throw ...; |
+| pre | cflow.cs:178:9:179:9 | {...} | cflow.cs:223:25:223:46 | throw ...; |
+| pre | cflow.cs:178:9:179:9 | {...} | cflow.cs:223:31:223:45 | [finally: break] object creation of type Exception |
+| pre | cflow.cs:178:9:179:9 | {...} | cflow.cs:223:31:223:45 | [finally: continue] object creation of type Exception |
+| pre | cflow.cs:178:9:179:9 | {...} | cflow.cs:223:31:223:45 | [finally: return] object creation of type Exception |
+| pre | cflow.cs:178:9:179:9 | {...} | cflow.cs:223:31:223:45 | object creation of type Exception |
+| pre | cflow.cs:178:9:179:9 | {...} | cflow.cs:226:17:228:17 | [finally: break] {...} |
+| pre | cflow.cs:178:9:179:9 | {...} | cflow.cs:226:17:228:17 | [finally: continue] {...} |
+| pre | cflow.cs:178:9:179:9 | {...} | cflow.cs:226:17:228:17 | [finally: exception(Exception)] {...} |
+| pre | cflow.cs:178:9:179:9 | {...} | cflow.cs:226:17:228:17 | [finally: return] {...} |
+| pre | cflow.cs:178:9:179:9 | {...} | cflow.cs:226:17:228:17 | {...} |
+| pre | cflow.cs:178:9:179:9 | {...} | cflow.cs:232:9:245:9 | try {...} ... |
+| pre | cflow.cs:178:9:179:9 | {...} | cflow.cs:234:17:234:28 | access to property Length |
+| pre | cflow.cs:178:9:179:9 | {...} | cflow.cs:234:33:234:33 | 0 |
+| pre | cflow.cs:178:9:179:9 | {...} | cflow.cs:235:17:235:23 | return ...; |
+| pre | cflow.cs:178:9:179:9 | {...} | cflow.cs:236:13:237:49 | if (...) ... |
+| pre | cflow.cs:178:9:179:9 | {...} | cflow.cs:236:17:236:28 | access to property Length |
+| pre | cflow.cs:178:9:179:9 | {...} | cflow.cs:236:33:236:33 | 1 |
+| pre | cflow.cs:178:9:179:9 | {...} | cflow.cs:237:17:237:49 | throw ...; |
+| pre | cflow.cs:178:9:179:9 | {...} | cflow.cs:237:23:237:48 | object creation of type OutOfMemoryException |
+| pre | cflow.cs:178:9:179:9 | {...} | cflow.cs:240:9:245:9 | [finally: exception(Exception)] {...} |
+| pre | cflow.cs:178:9:179:9 | {...} | cflow.cs:240:9:245:9 | [finally: exception(NullReferenceException)] {...} |
+| pre | cflow.cs:178:9:179:9 | {...} | cflow.cs:240:9:245:9 | {...} |
+| pre | cflow.cs:178:9:179:9 | {...} | cflow.cs:242:17:242:41 | ...; |
+| pre | cflow.cs:178:9:179:9 | {...} | cflow.cs:242:17:242:41 | [finally: exception(Exception)] ...; |
+| pre | cflow.cs:178:9:179:9 | {...} | cflow.cs:242:17:242:41 | [finally: exception(NullReferenceException)] ...; |
+| pre | cflow.cs:178:9:179:9 | {...} | cflow.cs:242:17:242:41 | [finally: exception(OutOfMemoryException)] ...; |
+| pre | cflow.cs:178:9:179:9 | {...} | cflow.cs:242:17:242:41 | [finally: return] ...; |
+| pre | cflow.cs:178:9:179:9 | {...} | cflow.cs:243:13:244:37 | [finally: exception(Exception)] if (...) ... |
+| pre | cflow.cs:178:9:179:9 | {...} | cflow.cs:243:13:244:37 | [finally: exception(NullReferenceException)] if (...) ... |
+| pre | cflow.cs:178:9:179:9 | {...} | cflow.cs:243:13:244:37 | [finally: exception(OutOfMemoryException)] if (...) ... |
+| pre | cflow.cs:178:9:179:9 | {...} | cflow.cs:243:13:244:37 | [finally: return] if (...) ... |
+| pre | cflow.cs:178:9:179:9 | {...} | cflow.cs:243:13:244:37 | if (...) ... |
+| pre | cflow.cs:178:9:179:9 | {...} | cflow.cs:244:17:244:37 | ...; |
+| pre | cflow.cs:178:9:179:9 | {...} | cflow.cs:244:17:244:37 | [finally: exception(Exception)] ...; |
+| pre | cflow.cs:178:9:179:9 | {...} | cflow.cs:244:17:244:37 | [finally: exception(NullReferenceException)] ...; |
+| pre | cflow.cs:178:9:179:9 | {...} | cflow.cs:244:17:244:37 | [finally: exception(OutOfMemoryException)] ...; |
+| pre | cflow.cs:178:9:179:9 | {...} | cflow.cs:244:17:244:37 | [finally: return] ...; |
 | pre | cflow.cs:191:13:191:37 | call to method WriteLine | cflow.cs:191:13:191:37 | call to method WriteLine |
 | pre | cflow.cs:191:13:191:37 | call to method WriteLine | cflow.cs:192:13:192:19 | return ...; |
-| pre | cflow.cs:191:13:191:37 | call to method WriteLine | cflow.cs:194:9:197:9 | catch (...) {...} |
-| pre | cflow.cs:191:13:191:37 | call to method WriteLine | cflow.cs:198:9:200:9 | catch (...) {...} |
+| pre | cflow.cs:191:13:191:37 | call to method WriteLine | cflow.cs:194:9:197:9 | [exception: Exception] catch (...) {...} |
+| pre | cflow.cs:191:13:191:37 | call to method WriteLine | cflow.cs:194:38:194:39 | [exception: Exception] IOException ex |
+| pre | cflow.cs:191:13:191:37 | call to method WriteLine | cflow.cs:198:9:200:9 | [exception: Exception] catch (...) {...} |
 | pre | cflow.cs:191:13:191:37 | call to method WriteLine | cflow.cs:202:9:204:9 | [finally: exception(Exception)] {...} |
-| pre | cflow.cs:191:13:191:37 | call to method WriteLine | cflow.cs:207:16:207:16 | access to local variable i |
-| pre | cflow.cs:191:13:191:37 | call to method WriteLine | cflow.cs:208:9:230:9 | {...} |
-| pre | cflow.cs:191:13:191:37 | call to method WriteLine | cflow.cs:212:21:212:27 | return ...; |
-| pre | cflow.cs:191:13:191:37 | call to method WriteLine | cflow.cs:213:17:214:29 | if (...) ... |
-| pre | cflow.cs:191:13:191:37 | call to method WriteLine | cflow.cs:214:21:214:29 | continue; |
-| pre | cflow.cs:191:13:191:37 | call to method WriteLine | cflow.cs:215:17:216:26 | if (...) ... |
-| pre | cflow.cs:191:13:191:37 | call to method WriteLine | cflow.cs:216:21:216:26 | break; |
-| pre | cflow.cs:191:13:191:37 | call to method WriteLine | cflow.cs:219:13:229:13 | {...} |
-| pre | cflow.cs:191:13:191:37 | call to method WriteLine | cflow.cs:223:25:223:46 | [finally: break] throw ...; |
-| pre | cflow.cs:191:13:191:37 | call to method WriteLine | cflow.cs:223:25:223:46 | [finally: continue] throw ...; |
-| pre | cflow.cs:191:13:191:37 | call to method WriteLine | cflow.cs:223:25:223:46 | [finally: return] throw ...; |
-| pre | cflow.cs:191:13:191:37 | call to method WriteLine | cflow.cs:223:25:223:46 | throw ...; |
-| pre | cflow.cs:191:13:191:37 | call to method WriteLine | cflow.cs:223:31:223:45 | [finally: break] object creation of type Exception |
-| pre | cflow.cs:191:13:191:37 | call to method WriteLine | cflow.cs:223:31:223:45 | [finally: continue] object creation of type Exception |
-| pre | cflow.cs:191:13:191:37 | call to method WriteLine | cflow.cs:223:31:223:45 | [finally: return] object creation of type Exception |
-| pre | cflow.cs:191:13:191:37 | call to method WriteLine | cflow.cs:223:31:223:45 | object creation of type Exception |
-| pre | cflow.cs:191:13:191:37 | call to method WriteLine | cflow.cs:226:17:228:17 | [finally: break] {...} |
-| pre | cflow.cs:191:13:191:37 | call to method WriteLine | cflow.cs:226:17:228:17 | [finally: continue] {...} |
-| pre | cflow.cs:191:13:191:37 | call to method WriteLine | cflow.cs:226:17:228:17 | [finally: exception(Exception)] {...} |
-| pre | cflow.cs:191:13:191:37 | call to method WriteLine | cflow.cs:226:17:228:17 | [finally: return] {...} |
-| pre | cflow.cs:191:13:191:37 | call to method WriteLine | cflow.cs:226:17:228:17 | {...} |
-| pre | cflow.cs:191:13:191:37 | call to method WriteLine | cflow.cs:232:9:245:9 | try {...} ... |
-| pre | cflow.cs:191:13:191:37 | call to method WriteLine | cflow.cs:234:17:234:28 | access to property Length |
-| pre | cflow.cs:191:13:191:37 | call to method WriteLine | cflow.cs:234:33:234:33 | 0 |
-| pre | cflow.cs:191:13:191:37 | call to method WriteLine | cflow.cs:235:17:235:23 | return ...; |
-| pre | cflow.cs:191:13:191:37 | call to method WriteLine | cflow.cs:236:13:237:49 | if (...) ... |
-| pre | cflow.cs:191:13:191:37 | call to method WriteLine | cflow.cs:236:17:236:28 | access to property Length |
-| pre | cflow.cs:191:13:191:37 | call to method WriteLine | cflow.cs:236:33:236:33 | 1 |
-| pre | cflow.cs:191:13:191:37 | call to method WriteLine | cflow.cs:237:17:237:49 | throw ...; |
-| pre | cflow.cs:191:13:191:37 | call to method WriteLine | cflow.cs:237:23:237:48 | object creation of type OutOfMemoryException |
-| pre | cflow.cs:191:13:191:37 | call to method WriteLine | cflow.cs:240:9:245:9 | [finally: exception(Exception)] {...} |
-| pre | cflow.cs:191:13:191:37 | call to method WriteLine | cflow.cs:240:9:245:9 | [finally: exception(NullReferenceException)] {...} |
-| pre | cflow.cs:191:13:191:37 | call to method WriteLine | cflow.cs:240:9:245:9 | {...} |
-| pre | cflow.cs:191:13:191:37 | call to method WriteLine | cflow.cs:242:17:242:41 | ...; |
-| pre | cflow.cs:191:13:191:37 | call to method WriteLine | cflow.cs:242:17:242:41 | [finally: exception(Exception)] ...; |
-| pre | cflow.cs:191:13:191:37 | call to method WriteLine | cflow.cs:242:17:242:41 | [finally: exception(NullReferenceException)] ...; |
-| pre | cflow.cs:191:13:191:37 | call to method WriteLine | cflow.cs:242:17:242:41 | [finally: exception(OutOfMemoryException)] ...; |
-| pre | cflow.cs:191:13:191:37 | call to method WriteLine | cflow.cs:242:17:242:41 | [finally: return] ...; |
-| pre | cflow.cs:191:13:191:37 | call to method WriteLine | cflow.cs:243:13:244:37 | [finally: exception(Exception)] if (...) ... |
-| pre | cflow.cs:191:13:191:37 | call to method WriteLine | cflow.cs:243:13:244:37 | [finally: exception(NullReferenceException)] if (...) ... |
-| pre | cflow.cs:191:13:191:37 | call to method WriteLine | cflow.cs:243:13:244:37 | [finally: exception(OutOfMemoryException)] if (...) ... |
-| pre | cflow.cs:191:13:191:37 | call to method WriteLine | cflow.cs:243:13:244:37 | [finally: return] if (...) ... |
-| pre | cflow.cs:191:13:191:37 | call to method WriteLine | cflow.cs:243:13:244:37 | if (...) ... |
-| pre | cflow.cs:191:13:191:37 | call to method WriteLine | cflow.cs:244:17:244:37 | ...; |
-| pre | cflow.cs:191:13:191:37 | call to method WriteLine | cflow.cs:244:17:244:37 | [finally: exception(Exception)] ...; |
-| pre | cflow.cs:191:13:191:37 | call to method WriteLine | cflow.cs:244:17:244:37 | [finally: exception(NullReferenceException)] ...; |
-| pre | cflow.cs:191:13:191:37 | call to method WriteLine | cflow.cs:244:17:244:37 | [finally: exception(OutOfMemoryException)] ...; |
-| pre | cflow.cs:191:13:191:37 | call to method WriteLine | cflow.cs:244:17:244:37 | [finally: return] ...; |
 | pre | cflow.cs:192:13:192:19 | return ...; | cflow.cs:192:13:192:19 | return ...; |
-| pre | cflow.cs:194:9:197:9 | catch (...) {...} | cflow.cs:194:9:197:9 | catch (...) {...} |
-| pre | cflow.cs:198:9:200:9 | catch (...) {...} | cflow.cs:198:9:200:9 | catch (...) {...} |
-| pre | cflow.cs:198:9:200:9 | catch (...) {...} | cflow.cs:207:16:207:16 | access to local variable i |
-| pre | cflow.cs:198:9:200:9 | catch (...) {...} | cflow.cs:208:9:230:9 | {...} |
-| pre | cflow.cs:198:9:200:9 | catch (...) {...} | cflow.cs:212:21:212:27 | return ...; |
-| pre | cflow.cs:198:9:200:9 | catch (...) {...} | cflow.cs:213:17:214:29 | if (...) ... |
-| pre | cflow.cs:198:9:200:9 | catch (...) {...} | cflow.cs:214:21:214:29 | continue; |
-| pre | cflow.cs:198:9:200:9 | catch (...) {...} | cflow.cs:215:17:216:26 | if (...) ... |
-| pre | cflow.cs:198:9:200:9 | catch (...) {...} | cflow.cs:216:21:216:26 | break; |
-| pre | cflow.cs:198:9:200:9 | catch (...) {...} | cflow.cs:219:13:229:13 | {...} |
-| pre | cflow.cs:198:9:200:9 | catch (...) {...} | cflow.cs:223:25:223:46 | [finally: break] throw ...; |
-| pre | cflow.cs:198:9:200:9 | catch (...) {...} | cflow.cs:223:25:223:46 | [finally: continue] throw ...; |
-| pre | cflow.cs:198:9:200:9 | catch (...) {...} | cflow.cs:223:25:223:46 | [finally: return] throw ...; |
-| pre | cflow.cs:198:9:200:9 | catch (...) {...} | cflow.cs:223:25:223:46 | throw ...; |
-| pre | cflow.cs:198:9:200:9 | catch (...) {...} | cflow.cs:223:31:223:45 | [finally: break] object creation of type Exception |
-| pre | cflow.cs:198:9:200:9 | catch (...) {...} | cflow.cs:223:31:223:45 | [finally: continue] object creation of type Exception |
-| pre | cflow.cs:198:9:200:9 | catch (...) {...} | cflow.cs:223:31:223:45 | [finally: return] object creation of type Exception |
-| pre | cflow.cs:198:9:200:9 | catch (...) {...} | cflow.cs:223:31:223:45 | object creation of type Exception |
-| pre | cflow.cs:198:9:200:9 | catch (...) {...} | cflow.cs:226:17:228:17 | [finally: break] {...} |
-| pre | cflow.cs:198:9:200:9 | catch (...) {...} | cflow.cs:226:17:228:17 | [finally: continue] {...} |
-| pre | cflow.cs:198:9:200:9 | catch (...) {...} | cflow.cs:226:17:228:17 | [finally: exception(Exception)] {...} |
-| pre | cflow.cs:198:9:200:9 | catch (...) {...} | cflow.cs:226:17:228:17 | [finally: return] {...} |
-| pre | cflow.cs:198:9:200:9 | catch (...) {...} | cflow.cs:226:17:228:17 | {...} |
-| pre | cflow.cs:198:9:200:9 | catch (...) {...} | cflow.cs:232:9:245:9 | try {...} ... |
-| pre | cflow.cs:198:9:200:9 | catch (...) {...} | cflow.cs:234:17:234:28 | access to property Length |
-| pre | cflow.cs:198:9:200:9 | catch (...) {...} | cflow.cs:234:33:234:33 | 0 |
-| pre | cflow.cs:198:9:200:9 | catch (...) {...} | cflow.cs:235:17:235:23 | return ...; |
-| pre | cflow.cs:198:9:200:9 | catch (...) {...} | cflow.cs:236:13:237:49 | if (...) ... |
-| pre | cflow.cs:198:9:200:9 | catch (...) {...} | cflow.cs:236:17:236:28 | access to property Length |
-| pre | cflow.cs:198:9:200:9 | catch (...) {...} | cflow.cs:236:33:236:33 | 1 |
-| pre | cflow.cs:198:9:200:9 | catch (...) {...} | cflow.cs:237:17:237:49 | throw ...; |
-| pre | cflow.cs:198:9:200:9 | catch (...) {...} | cflow.cs:237:23:237:48 | object creation of type OutOfMemoryException |
-| pre | cflow.cs:198:9:200:9 | catch (...) {...} | cflow.cs:240:9:245:9 | [finally: exception(Exception)] {...} |
-| pre | cflow.cs:198:9:200:9 | catch (...) {...} | cflow.cs:240:9:245:9 | [finally: exception(NullReferenceException)] {...} |
-| pre | cflow.cs:198:9:200:9 | catch (...) {...} | cflow.cs:240:9:245:9 | {...} |
-| pre | cflow.cs:198:9:200:9 | catch (...) {...} | cflow.cs:242:17:242:41 | ...; |
-| pre | cflow.cs:198:9:200:9 | catch (...) {...} | cflow.cs:242:17:242:41 | [finally: exception(Exception)] ...; |
-| pre | cflow.cs:198:9:200:9 | catch (...) {...} | cflow.cs:242:17:242:41 | [finally: exception(NullReferenceException)] ...; |
-| pre | cflow.cs:198:9:200:9 | catch (...) {...} | cflow.cs:242:17:242:41 | [finally: exception(OutOfMemoryException)] ...; |
-| pre | cflow.cs:198:9:200:9 | catch (...) {...} | cflow.cs:242:17:242:41 | [finally: return] ...; |
-| pre | cflow.cs:198:9:200:9 | catch (...) {...} | cflow.cs:243:13:244:37 | [finally: exception(Exception)] if (...) ... |
-| pre | cflow.cs:198:9:200:9 | catch (...) {...} | cflow.cs:243:13:244:37 | [finally: exception(NullReferenceException)] if (...) ... |
-| pre | cflow.cs:198:9:200:9 | catch (...) {...} | cflow.cs:243:13:244:37 | [finally: exception(OutOfMemoryException)] if (...) ... |
-| pre | cflow.cs:198:9:200:9 | catch (...) {...} | cflow.cs:243:13:244:37 | [finally: return] if (...) ... |
-| pre | cflow.cs:198:9:200:9 | catch (...) {...} | cflow.cs:243:13:244:37 | if (...) ... |
-| pre | cflow.cs:198:9:200:9 | catch (...) {...} | cflow.cs:244:17:244:37 | ...; |
-| pre | cflow.cs:198:9:200:9 | catch (...) {...} | cflow.cs:244:17:244:37 | [finally: exception(Exception)] ...; |
-| pre | cflow.cs:198:9:200:9 | catch (...) {...} | cflow.cs:244:17:244:37 | [finally: exception(NullReferenceException)] ...; |
-| pre | cflow.cs:198:9:200:9 | catch (...) {...} | cflow.cs:244:17:244:37 | [finally: exception(OutOfMemoryException)] ...; |
-| pre | cflow.cs:198:9:200:9 | catch (...) {...} | cflow.cs:244:17:244:37 | [finally: return] ...; |
+| pre | cflow.cs:194:9:197:9 | [exception: Exception] catch (...) {...} | cflow.cs:194:9:197:9 | [exception: Exception] catch (...) {...} |
+| pre | cflow.cs:194:9:197:9 | [exception: Exception] catch (...) {...} | cflow.cs:194:38:194:39 | [exception: Exception] IOException ex |
+| pre | cflow.cs:194:9:197:9 | [exception: Exception] catch (...) {...} | cflow.cs:198:9:200:9 | [exception: Exception] catch (...) {...} |
+| pre | cflow.cs:194:9:197:9 | [exception: Exception] catch (...) {...} | cflow.cs:202:9:204:9 | [finally: exception(Exception)] {...} |
+| pre | cflow.cs:194:9:197:9 | [exception: OutOfMemoryException] catch (...) {...} | cflow.cs:194:9:197:9 | [exception: OutOfMemoryException] catch (...) {...} |
+| pre | cflow.cs:194:9:197:9 | [exception: OutOfMemoryException] catch (...) {...} | cflow.cs:202:9:204:9 | [finally: exception(OutOfMemoryException)] {...} |
+| pre | cflow.cs:194:38:194:39 | [exception: Exception] IOException ex | cflow.cs:194:38:194:39 | [exception: Exception] IOException ex |
+| pre | cflow.cs:198:9:200:9 | [exception: Exception] catch (...) {...} | cflow.cs:198:9:200:9 | [exception: Exception] catch (...) {...} |
+| pre | cflow.cs:198:9:200:9 | [exception: Exception] catch (...) {...} | cflow.cs:202:9:204:9 | [finally: exception(Exception)] {...} |
+| pre | cflow.cs:199:9:200:9 | {...} | cflow.cs:199:9:200:9 | {...} |
+| pre | cflow.cs:199:9:200:9 | {...} | cflow.cs:207:16:207:16 | access to local variable i |
+| pre | cflow.cs:199:9:200:9 | {...} | cflow.cs:208:9:230:9 | {...} |
+| pre | cflow.cs:199:9:200:9 | {...} | cflow.cs:212:21:212:27 | return ...; |
+| pre | cflow.cs:199:9:200:9 | {...} | cflow.cs:213:17:214:29 | if (...) ... |
+| pre | cflow.cs:199:9:200:9 | {...} | cflow.cs:214:21:214:29 | continue; |
+| pre | cflow.cs:199:9:200:9 | {...} | cflow.cs:215:17:216:26 | if (...) ... |
+| pre | cflow.cs:199:9:200:9 | {...} | cflow.cs:216:21:216:26 | break; |
+| pre | cflow.cs:199:9:200:9 | {...} | cflow.cs:219:13:229:13 | {...} |
+| pre | cflow.cs:199:9:200:9 | {...} | cflow.cs:223:25:223:46 | [finally: break] throw ...; |
+| pre | cflow.cs:199:9:200:9 | {...} | cflow.cs:223:25:223:46 | [finally: continue] throw ...; |
+| pre | cflow.cs:199:9:200:9 | {...} | cflow.cs:223:25:223:46 | [finally: return] throw ...; |
+| pre | cflow.cs:199:9:200:9 | {...} | cflow.cs:223:25:223:46 | throw ...; |
+| pre | cflow.cs:199:9:200:9 | {...} | cflow.cs:223:31:223:45 | [finally: break] object creation of type Exception |
+| pre | cflow.cs:199:9:200:9 | {...} | cflow.cs:223:31:223:45 | [finally: continue] object creation of type Exception |
+| pre | cflow.cs:199:9:200:9 | {...} | cflow.cs:223:31:223:45 | [finally: return] object creation of type Exception |
+| pre | cflow.cs:199:9:200:9 | {...} | cflow.cs:223:31:223:45 | object creation of type Exception |
+| pre | cflow.cs:199:9:200:9 | {...} | cflow.cs:226:17:228:17 | [finally: break] {...} |
+| pre | cflow.cs:199:9:200:9 | {...} | cflow.cs:226:17:228:17 | [finally: continue] {...} |
+| pre | cflow.cs:199:9:200:9 | {...} | cflow.cs:226:17:228:17 | [finally: exception(Exception)] {...} |
+| pre | cflow.cs:199:9:200:9 | {...} | cflow.cs:226:17:228:17 | [finally: return] {...} |
+| pre | cflow.cs:199:9:200:9 | {...} | cflow.cs:226:17:228:17 | {...} |
+| pre | cflow.cs:199:9:200:9 | {...} | cflow.cs:232:9:245:9 | try {...} ... |
+| pre | cflow.cs:199:9:200:9 | {...} | cflow.cs:234:17:234:28 | access to property Length |
+| pre | cflow.cs:199:9:200:9 | {...} | cflow.cs:234:33:234:33 | 0 |
+| pre | cflow.cs:199:9:200:9 | {...} | cflow.cs:235:17:235:23 | return ...; |
+| pre | cflow.cs:199:9:200:9 | {...} | cflow.cs:236:13:237:49 | if (...) ... |
+| pre | cflow.cs:199:9:200:9 | {...} | cflow.cs:236:17:236:28 | access to property Length |
+| pre | cflow.cs:199:9:200:9 | {...} | cflow.cs:236:33:236:33 | 1 |
+| pre | cflow.cs:199:9:200:9 | {...} | cflow.cs:237:17:237:49 | throw ...; |
+| pre | cflow.cs:199:9:200:9 | {...} | cflow.cs:237:23:237:48 | object creation of type OutOfMemoryException |
+| pre | cflow.cs:199:9:200:9 | {...} | cflow.cs:240:9:245:9 | [finally: exception(Exception)] {...} |
+| pre | cflow.cs:199:9:200:9 | {...} | cflow.cs:240:9:245:9 | [finally: exception(NullReferenceException)] {...} |
+| pre | cflow.cs:199:9:200:9 | {...} | cflow.cs:240:9:245:9 | {...} |
+| pre | cflow.cs:199:9:200:9 | {...} | cflow.cs:242:17:242:41 | ...; |
+| pre | cflow.cs:199:9:200:9 | {...} | cflow.cs:242:17:242:41 | [finally: exception(Exception)] ...; |
+| pre | cflow.cs:199:9:200:9 | {...} | cflow.cs:242:17:242:41 | [finally: exception(NullReferenceException)] ...; |
+| pre | cflow.cs:199:9:200:9 | {...} | cflow.cs:242:17:242:41 | [finally: exception(OutOfMemoryException)] ...; |
+| pre | cflow.cs:199:9:200:9 | {...} | cflow.cs:242:17:242:41 | [finally: return] ...; |
+| pre | cflow.cs:199:9:200:9 | {...} | cflow.cs:243:13:244:37 | [finally: exception(Exception)] if (...) ... |
+| pre | cflow.cs:199:9:200:9 | {...} | cflow.cs:243:13:244:37 | [finally: exception(NullReferenceException)] if (...) ... |
+| pre | cflow.cs:199:9:200:9 | {...} | cflow.cs:243:13:244:37 | [finally: exception(OutOfMemoryException)] if (...) ... |
+| pre | cflow.cs:199:9:200:9 | {...} | cflow.cs:243:13:244:37 | [finally: return] if (...) ... |
+| pre | cflow.cs:199:9:200:9 | {...} | cflow.cs:243:13:244:37 | if (...) ... |
+| pre | cflow.cs:199:9:200:9 | {...} | cflow.cs:244:17:244:37 | ...; |
+| pre | cflow.cs:199:9:200:9 | {...} | cflow.cs:244:17:244:37 | [finally: exception(Exception)] ...; |
+| pre | cflow.cs:199:9:200:9 | {...} | cflow.cs:244:17:244:37 | [finally: exception(NullReferenceException)] ...; |
+| pre | cflow.cs:199:9:200:9 | {...} | cflow.cs:244:17:244:37 | [finally: exception(OutOfMemoryException)] ...; |
+| pre | cflow.cs:199:9:200:9 | {...} | cflow.cs:244:17:244:37 | [finally: return] ...; |
 | pre | cflow.cs:202:9:204:9 | [finally: exception(Exception)] {...} | cflow.cs:202:9:204:9 | [finally: exception(Exception)] {...} |
 | pre | cflow.cs:202:9:204:9 | [finally: exception(OutOfMemoryException)] {...} | cflow.cs:202:9:204:9 | [finally: exception(OutOfMemoryException)] {...} |
 | pre | cflow.cs:207:16:207:16 | access to local variable i | cflow.cs:207:16:207:16 | access to local variable i |

--- a/csharp/ql/test/library-tests/controlflow/graph/BasicBlockDominance.expected
+++ b/csharp/ql/test/library-tests/controlflow/graph/BasicBlockDominance.expected
@@ -89,6 +89,65 @@
 | post | BreakInTry.cs:65:26:65:28 | [finally: return] String arg | BreakInTry.cs:65:26:65:28 | [finally: return] String arg |
 | post | BreakInTry.cs:68:21:68:26 | [finally: return] break; | BreakInTry.cs:68:21:68:26 | [finally: return] break; |
 | post | BreakInTry.cs:68:21:68:26 | break; | BreakInTry.cs:68:21:68:26 | break; |
+| post | CatchInFinally.cs:5:10:5:11 | enter M1 | CatchInFinally.cs:5:10:5:11 | enter M1 |
+| post | CatchInFinally.cs:5:10:5:11 | exit M1 | CatchInFinally.cs:5:10:5:11 | enter M1 |
+| post | CatchInFinally.cs:5:10:5:11 | exit M1 | CatchInFinally.cs:5:10:5:11 | exit M1 |
+| post | CatchInFinally.cs:5:10:5:11 | exit M1 | CatchInFinally.cs:10:17:10:50 | throw ...; |
+| post | CatchInFinally.cs:5:10:5:11 | exit M1 | CatchInFinally.cs:10:23:10:49 | object creation of type ArgumentNullException |
+| post | CatchInFinally.cs:5:10:5:11 | exit M1 | CatchInFinally.cs:13:9:27:9 | [finally: exception(Exception)] {...} |
+| post | CatchInFinally.cs:5:10:5:11 | exit M1 | CatchInFinally.cs:13:9:27:9 | {...} |
+| post | CatchInFinally.cs:5:10:5:11 | exit M1 | CatchInFinally.cs:16:36:16:36 | 1 |
+| post | CatchInFinally.cs:5:10:5:11 | exit M1 | CatchInFinally.cs:16:36:16:36 | [finally: exception(ArgumentNullException)] 1 |
+| post | CatchInFinally.cs:5:10:5:11 | exit M1 | CatchInFinally.cs:16:36:16:36 | [finally: exception(Exception)] 1 |
+| post | CatchInFinally.cs:5:10:5:11 | exit M1 | CatchInFinally.cs:17:21:17:45 | [finally: exception(ArgumentNullException)] throw ...; |
+| post | CatchInFinally.cs:5:10:5:11 | exit M1 | CatchInFinally.cs:17:21:17:45 | [finally: exception(Exception)] throw ...; |
+| post | CatchInFinally.cs:5:10:5:11 | exit M1 | CatchInFinally.cs:17:21:17:45 | throw ...; |
+| post | CatchInFinally.cs:5:10:5:11 | exit M1 | CatchInFinally.cs:17:41:17:43 | "1" |
+| post | CatchInFinally.cs:5:10:5:11 | exit M1 | CatchInFinally.cs:17:41:17:43 | [finally: exception(ArgumentNullException)] "1" |
+| post | CatchInFinally.cs:5:10:5:11 | exit M1 | CatchInFinally.cs:17:41:17:43 | [finally: exception(Exception)] "1" |
+| post | CatchInFinally.cs:5:10:5:11 | exit M1 | CatchInFinally.cs:19:13:22:13 | [exception: Exception, finally: exception(ArgumentNullException)] catch (...) {...} |
+| post | CatchInFinally.cs:5:10:5:11 | exit M1 | CatchInFinally.cs:19:13:22:13 | [exception: Exception, finally: exception(Exception)] catch (...) {...} |
+| post | CatchInFinally.cs:5:10:5:11 | exit M1 | CatchInFinally.cs:19:13:22:13 | [exception: Exception] catch (...) {...} |
+| post | CatchInFinally.cs:5:10:5:11 | exit M1 | CatchInFinally.cs:19:13:22:13 | [exception: NullReferenceException, finally: exception(ArgumentNullException)] catch (...) {...} |
+| post | CatchInFinally.cs:5:10:5:11 | exit M1 | CatchInFinally.cs:19:13:22:13 | [exception: NullReferenceException, finally: exception(Exception)] catch (...) {...} |
+| post | CatchInFinally.cs:5:10:5:11 | exit M1 | CatchInFinally.cs:19:13:22:13 | [exception: NullReferenceException] catch (...) {...} |
+| post | CatchInFinally.cs:5:10:5:11 | exit M1 | CatchInFinally.cs:20:13:22:13 | [finally: exception(ArgumentNullException)] {...} |
+| post | CatchInFinally.cs:5:10:5:11 | exit M1 | CatchInFinally.cs:20:13:22:13 | [finally: exception(Exception)] {...} |
+| post | CatchInFinally.cs:5:10:5:11 | exit M1 | CatchInFinally.cs:20:13:22:13 | {...} |
+| post | CatchInFinally.cs:5:10:5:11 | exit M1 | CatchInFinally.cs:23:13:26:13 | [finally: exception(ArgumentNullException)] catch {...} |
+| post | CatchInFinally.cs:5:10:5:11 | exit M1 | CatchInFinally.cs:23:13:26:13 | [finally: exception(Exception)] catch {...} |
+| post | CatchInFinally.cs:5:10:5:11 | exit M1 | CatchInFinally.cs:23:13:26:13 | catch {...} |
+| post | CatchInFinally.cs:10:17:10:50 | throw ...; | CatchInFinally.cs:10:17:10:50 | throw ...; |
+| post | CatchInFinally.cs:10:23:10:49 | object creation of type ArgumentNullException | CatchInFinally.cs:10:23:10:49 | object creation of type ArgumentNullException |
+| post | CatchInFinally.cs:13:9:27:9 | [finally: exception(Exception)] {...} | CatchInFinally.cs:13:9:27:9 | [finally: exception(Exception)] {...} |
+| post | CatchInFinally.cs:13:9:27:9 | {...} | CatchInFinally.cs:13:9:27:9 | {...} |
+| post | CatchInFinally.cs:16:36:16:36 | 1 | CatchInFinally.cs:16:36:16:36 | 1 |
+| post | CatchInFinally.cs:16:36:16:36 | [finally: exception(ArgumentNullException)] 1 | CatchInFinally.cs:16:36:16:36 | [finally: exception(ArgumentNullException)] 1 |
+| post | CatchInFinally.cs:16:36:16:36 | [finally: exception(Exception)] 1 | CatchInFinally.cs:16:36:16:36 | [finally: exception(Exception)] 1 |
+| post | CatchInFinally.cs:17:21:17:45 | [finally: exception(ArgumentNullException)] throw ...; | CatchInFinally.cs:17:21:17:45 | [finally: exception(ArgumentNullException)] throw ...; |
+| post | CatchInFinally.cs:17:21:17:45 | [finally: exception(Exception)] throw ...; | CatchInFinally.cs:17:21:17:45 | [finally: exception(Exception)] throw ...; |
+| post | CatchInFinally.cs:17:21:17:45 | throw ...; | CatchInFinally.cs:17:21:17:45 | throw ...; |
+| post | CatchInFinally.cs:17:41:17:43 | "1" | CatchInFinally.cs:17:41:17:43 | "1" |
+| post | CatchInFinally.cs:17:41:17:43 | [finally: exception(ArgumentNullException)] "1" | CatchInFinally.cs:17:41:17:43 | [finally: exception(ArgumentNullException)] "1" |
+| post | CatchInFinally.cs:17:41:17:43 | [finally: exception(Exception)] "1" | CatchInFinally.cs:17:41:17:43 | [finally: exception(Exception)] "1" |
+| post | CatchInFinally.cs:19:13:22:13 | [exception: Exception, finally: exception(ArgumentNullException)] catch (...) {...} | CatchInFinally.cs:17:21:17:45 | [finally: exception(ArgumentNullException)] throw ...; |
+| post | CatchInFinally.cs:19:13:22:13 | [exception: Exception, finally: exception(ArgumentNullException)] catch (...) {...} | CatchInFinally.cs:17:41:17:43 | [finally: exception(ArgumentNullException)] "1" |
+| post | CatchInFinally.cs:19:13:22:13 | [exception: Exception, finally: exception(ArgumentNullException)] catch (...) {...} | CatchInFinally.cs:19:13:22:13 | [exception: Exception, finally: exception(ArgumentNullException)] catch (...) {...} |
+| post | CatchInFinally.cs:19:13:22:13 | [exception: Exception, finally: exception(Exception)] catch (...) {...} | CatchInFinally.cs:17:21:17:45 | [finally: exception(Exception)] throw ...; |
+| post | CatchInFinally.cs:19:13:22:13 | [exception: Exception, finally: exception(Exception)] catch (...) {...} | CatchInFinally.cs:17:41:17:43 | [finally: exception(Exception)] "1" |
+| post | CatchInFinally.cs:19:13:22:13 | [exception: Exception, finally: exception(Exception)] catch (...) {...} | CatchInFinally.cs:19:13:22:13 | [exception: Exception, finally: exception(Exception)] catch (...) {...} |
+| post | CatchInFinally.cs:19:13:22:13 | [exception: Exception] catch (...) {...} | CatchInFinally.cs:17:21:17:45 | throw ...; |
+| post | CatchInFinally.cs:19:13:22:13 | [exception: Exception] catch (...) {...} | CatchInFinally.cs:17:41:17:43 | "1" |
+| post | CatchInFinally.cs:19:13:22:13 | [exception: Exception] catch (...) {...} | CatchInFinally.cs:19:13:22:13 | [exception: Exception] catch (...) {...} |
+| post | CatchInFinally.cs:19:13:22:13 | [exception: NullReferenceException, finally: exception(ArgumentNullException)] catch (...) {...} | CatchInFinally.cs:19:13:22:13 | [exception: NullReferenceException, finally: exception(ArgumentNullException)] catch (...) {...} |
+| post | CatchInFinally.cs:19:13:22:13 | [exception: NullReferenceException, finally: exception(Exception)] catch (...) {...} | CatchInFinally.cs:19:13:22:13 | [exception: NullReferenceException, finally: exception(Exception)] catch (...) {...} |
+| post | CatchInFinally.cs:19:13:22:13 | [exception: NullReferenceException] catch (...) {...} | CatchInFinally.cs:19:13:22:13 | [exception: NullReferenceException] catch (...) {...} |
+| post | CatchInFinally.cs:20:13:22:13 | [finally: exception(ArgumentNullException)] {...} | CatchInFinally.cs:20:13:22:13 | [finally: exception(ArgumentNullException)] {...} |
+| post | CatchInFinally.cs:20:13:22:13 | [finally: exception(Exception)] {...} | CatchInFinally.cs:20:13:22:13 | [finally: exception(Exception)] {...} |
+| post | CatchInFinally.cs:20:13:22:13 | {...} | CatchInFinally.cs:20:13:22:13 | {...} |
+| post | CatchInFinally.cs:23:13:26:13 | [finally: exception(ArgumentNullException)] catch {...} | CatchInFinally.cs:23:13:26:13 | [finally: exception(ArgumentNullException)] catch {...} |
+| post | CatchInFinally.cs:23:13:26:13 | [finally: exception(Exception)] catch {...} | CatchInFinally.cs:23:13:26:13 | [finally: exception(Exception)] catch {...} |
+| post | CatchInFinally.cs:23:13:26:13 | catch {...} | CatchInFinally.cs:23:13:26:13 | catch {...} |
 | post | CompileTimeOperators.cs:5:9:5:15 | enter Default | CompileTimeOperators.cs:5:9:5:15 | enter Default |
 | post | CompileTimeOperators.cs:10:9:10:14 | enter Sizeof | CompileTimeOperators.cs:10:9:10:14 | enter Sizeof |
 | post | CompileTimeOperators.cs:15:10:15:15 | enter Typeof | CompileTimeOperators.cs:15:10:15:15 | enter Typeof |
@@ -1139,6 +1198,105 @@
 | pre | BreakInTry.cs:65:26:65:28 | [finally: return] String arg | BreakInTry.cs:68:21:68:26 | [finally: return] break; |
 | pre | BreakInTry.cs:68:21:68:26 | [finally: return] break; | BreakInTry.cs:68:21:68:26 | [finally: return] break; |
 | pre | BreakInTry.cs:68:21:68:26 | break; | BreakInTry.cs:68:21:68:26 | break; |
+| pre | CatchInFinally.cs:5:10:5:11 | enter M1 | CatchInFinally.cs:5:10:5:11 | enter M1 |
+| pre | CatchInFinally.cs:5:10:5:11 | enter M1 | CatchInFinally.cs:5:10:5:11 | exit M1 |
+| pre | CatchInFinally.cs:5:10:5:11 | enter M1 | CatchInFinally.cs:10:17:10:50 | throw ...; |
+| pre | CatchInFinally.cs:5:10:5:11 | enter M1 | CatchInFinally.cs:10:23:10:49 | object creation of type ArgumentNullException |
+| pre | CatchInFinally.cs:5:10:5:11 | enter M1 | CatchInFinally.cs:13:9:27:9 | [finally: exception(Exception)] {...} |
+| pre | CatchInFinally.cs:5:10:5:11 | enter M1 | CatchInFinally.cs:13:9:27:9 | {...} |
+| pre | CatchInFinally.cs:5:10:5:11 | enter M1 | CatchInFinally.cs:16:36:16:36 | 1 |
+| pre | CatchInFinally.cs:5:10:5:11 | enter M1 | CatchInFinally.cs:16:36:16:36 | [finally: exception(ArgumentNullException)] 1 |
+| pre | CatchInFinally.cs:5:10:5:11 | enter M1 | CatchInFinally.cs:16:36:16:36 | [finally: exception(Exception)] 1 |
+| pre | CatchInFinally.cs:5:10:5:11 | enter M1 | CatchInFinally.cs:17:21:17:45 | [finally: exception(ArgumentNullException)] throw ...; |
+| pre | CatchInFinally.cs:5:10:5:11 | enter M1 | CatchInFinally.cs:17:21:17:45 | [finally: exception(Exception)] throw ...; |
+| pre | CatchInFinally.cs:5:10:5:11 | enter M1 | CatchInFinally.cs:17:21:17:45 | throw ...; |
+| pre | CatchInFinally.cs:5:10:5:11 | enter M1 | CatchInFinally.cs:17:41:17:43 | "1" |
+| pre | CatchInFinally.cs:5:10:5:11 | enter M1 | CatchInFinally.cs:17:41:17:43 | [finally: exception(ArgumentNullException)] "1" |
+| pre | CatchInFinally.cs:5:10:5:11 | enter M1 | CatchInFinally.cs:17:41:17:43 | [finally: exception(Exception)] "1" |
+| pre | CatchInFinally.cs:5:10:5:11 | enter M1 | CatchInFinally.cs:19:13:22:13 | [exception: Exception, finally: exception(ArgumentNullException)] catch (...) {...} |
+| pre | CatchInFinally.cs:5:10:5:11 | enter M1 | CatchInFinally.cs:19:13:22:13 | [exception: Exception, finally: exception(Exception)] catch (...) {...} |
+| pre | CatchInFinally.cs:5:10:5:11 | enter M1 | CatchInFinally.cs:19:13:22:13 | [exception: Exception] catch (...) {...} |
+| pre | CatchInFinally.cs:5:10:5:11 | enter M1 | CatchInFinally.cs:19:13:22:13 | [exception: NullReferenceException, finally: exception(ArgumentNullException)] catch (...) {...} |
+| pre | CatchInFinally.cs:5:10:5:11 | enter M1 | CatchInFinally.cs:19:13:22:13 | [exception: NullReferenceException, finally: exception(Exception)] catch (...) {...} |
+| pre | CatchInFinally.cs:5:10:5:11 | enter M1 | CatchInFinally.cs:19:13:22:13 | [exception: NullReferenceException] catch (...) {...} |
+| pre | CatchInFinally.cs:5:10:5:11 | enter M1 | CatchInFinally.cs:20:13:22:13 | [finally: exception(ArgumentNullException)] {...} |
+| pre | CatchInFinally.cs:5:10:5:11 | enter M1 | CatchInFinally.cs:20:13:22:13 | [finally: exception(Exception)] {...} |
+| pre | CatchInFinally.cs:5:10:5:11 | enter M1 | CatchInFinally.cs:20:13:22:13 | {...} |
+| pre | CatchInFinally.cs:5:10:5:11 | enter M1 | CatchInFinally.cs:23:13:26:13 | [finally: exception(ArgumentNullException)] catch {...} |
+| pre | CatchInFinally.cs:5:10:5:11 | enter M1 | CatchInFinally.cs:23:13:26:13 | [finally: exception(Exception)] catch {...} |
+| pre | CatchInFinally.cs:5:10:5:11 | enter M1 | CatchInFinally.cs:23:13:26:13 | catch {...} |
+| pre | CatchInFinally.cs:5:10:5:11 | exit M1 | CatchInFinally.cs:5:10:5:11 | exit M1 |
+| pre | CatchInFinally.cs:10:17:10:50 | throw ...; | CatchInFinally.cs:10:17:10:50 | throw ...; |
+| pre | CatchInFinally.cs:10:17:10:50 | throw ...; | CatchInFinally.cs:16:36:16:36 | [finally: exception(ArgumentNullException)] 1 |
+| pre | CatchInFinally.cs:10:17:10:50 | throw ...; | CatchInFinally.cs:17:21:17:45 | [finally: exception(ArgumentNullException)] throw ...; |
+| pre | CatchInFinally.cs:10:17:10:50 | throw ...; | CatchInFinally.cs:17:41:17:43 | [finally: exception(ArgumentNullException)] "1" |
+| pre | CatchInFinally.cs:10:17:10:50 | throw ...; | CatchInFinally.cs:19:13:22:13 | [exception: Exception, finally: exception(ArgumentNullException)] catch (...) {...} |
+| pre | CatchInFinally.cs:10:17:10:50 | throw ...; | CatchInFinally.cs:19:13:22:13 | [exception: NullReferenceException, finally: exception(ArgumentNullException)] catch (...) {...} |
+| pre | CatchInFinally.cs:10:17:10:50 | throw ...; | CatchInFinally.cs:20:13:22:13 | [finally: exception(ArgumentNullException)] {...} |
+| pre | CatchInFinally.cs:10:17:10:50 | throw ...; | CatchInFinally.cs:23:13:26:13 | [finally: exception(ArgumentNullException)] catch {...} |
+| pre | CatchInFinally.cs:10:23:10:49 | object creation of type ArgumentNullException | CatchInFinally.cs:10:17:10:50 | throw ...; |
+| pre | CatchInFinally.cs:10:23:10:49 | object creation of type ArgumentNullException | CatchInFinally.cs:10:23:10:49 | object creation of type ArgumentNullException |
+| pre | CatchInFinally.cs:10:23:10:49 | object creation of type ArgumentNullException | CatchInFinally.cs:13:9:27:9 | [finally: exception(Exception)] {...} |
+| pre | CatchInFinally.cs:10:23:10:49 | object creation of type ArgumentNullException | CatchInFinally.cs:16:36:16:36 | [finally: exception(ArgumentNullException)] 1 |
+| pre | CatchInFinally.cs:10:23:10:49 | object creation of type ArgumentNullException | CatchInFinally.cs:16:36:16:36 | [finally: exception(Exception)] 1 |
+| pre | CatchInFinally.cs:10:23:10:49 | object creation of type ArgumentNullException | CatchInFinally.cs:17:21:17:45 | [finally: exception(ArgumentNullException)] throw ...; |
+| pre | CatchInFinally.cs:10:23:10:49 | object creation of type ArgumentNullException | CatchInFinally.cs:17:21:17:45 | [finally: exception(Exception)] throw ...; |
+| pre | CatchInFinally.cs:10:23:10:49 | object creation of type ArgumentNullException | CatchInFinally.cs:17:41:17:43 | [finally: exception(ArgumentNullException)] "1" |
+| pre | CatchInFinally.cs:10:23:10:49 | object creation of type ArgumentNullException | CatchInFinally.cs:17:41:17:43 | [finally: exception(Exception)] "1" |
+| pre | CatchInFinally.cs:10:23:10:49 | object creation of type ArgumentNullException | CatchInFinally.cs:19:13:22:13 | [exception: Exception, finally: exception(ArgumentNullException)] catch (...) {...} |
+| pre | CatchInFinally.cs:10:23:10:49 | object creation of type ArgumentNullException | CatchInFinally.cs:19:13:22:13 | [exception: Exception, finally: exception(Exception)] catch (...) {...} |
+| pre | CatchInFinally.cs:10:23:10:49 | object creation of type ArgumentNullException | CatchInFinally.cs:19:13:22:13 | [exception: NullReferenceException, finally: exception(ArgumentNullException)] catch (...) {...} |
+| pre | CatchInFinally.cs:10:23:10:49 | object creation of type ArgumentNullException | CatchInFinally.cs:19:13:22:13 | [exception: NullReferenceException, finally: exception(Exception)] catch (...) {...} |
+| pre | CatchInFinally.cs:10:23:10:49 | object creation of type ArgumentNullException | CatchInFinally.cs:20:13:22:13 | [finally: exception(ArgumentNullException)] {...} |
+| pre | CatchInFinally.cs:10:23:10:49 | object creation of type ArgumentNullException | CatchInFinally.cs:20:13:22:13 | [finally: exception(Exception)] {...} |
+| pre | CatchInFinally.cs:10:23:10:49 | object creation of type ArgumentNullException | CatchInFinally.cs:23:13:26:13 | [finally: exception(ArgumentNullException)] catch {...} |
+| pre | CatchInFinally.cs:10:23:10:49 | object creation of type ArgumentNullException | CatchInFinally.cs:23:13:26:13 | [finally: exception(Exception)] catch {...} |
+| pre | CatchInFinally.cs:13:9:27:9 | [finally: exception(Exception)] {...} | CatchInFinally.cs:13:9:27:9 | [finally: exception(Exception)] {...} |
+| pre | CatchInFinally.cs:13:9:27:9 | [finally: exception(Exception)] {...} | CatchInFinally.cs:16:36:16:36 | [finally: exception(Exception)] 1 |
+| pre | CatchInFinally.cs:13:9:27:9 | [finally: exception(Exception)] {...} | CatchInFinally.cs:17:21:17:45 | [finally: exception(Exception)] throw ...; |
+| pre | CatchInFinally.cs:13:9:27:9 | [finally: exception(Exception)] {...} | CatchInFinally.cs:17:41:17:43 | [finally: exception(Exception)] "1" |
+| pre | CatchInFinally.cs:13:9:27:9 | [finally: exception(Exception)] {...} | CatchInFinally.cs:19:13:22:13 | [exception: Exception, finally: exception(Exception)] catch (...) {...} |
+| pre | CatchInFinally.cs:13:9:27:9 | [finally: exception(Exception)] {...} | CatchInFinally.cs:19:13:22:13 | [exception: NullReferenceException, finally: exception(Exception)] catch (...) {...} |
+| pre | CatchInFinally.cs:13:9:27:9 | [finally: exception(Exception)] {...} | CatchInFinally.cs:20:13:22:13 | [finally: exception(Exception)] {...} |
+| pre | CatchInFinally.cs:13:9:27:9 | [finally: exception(Exception)] {...} | CatchInFinally.cs:23:13:26:13 | [finally: exception(Exception)] catch {...} |
+| pre | CatchInFinally.cs:13:9:27:9 | {...} | CatchInFinally.cs:13:9:27:9 | {...} |
+| pre | CatchInFinally.cs:13:9:27:9 | {...} | CatchInFinally.cs:16:36:16:36 | 1 |
+| pre | CatchInFinally.cs:13:9:27:9 | {...} | CatchInFinally.cs:17:21:17:45 | throw ...; |
+| pre | CatchInFinally.cs:13:9:27:9 | {...} | CatchInFinally.cs:17:41:17:43 | "1" |
+| pre | CatchInFinally.cs:13:9:27:9 | {...} | CatchInFinally.cs:19:13:22:13 | [exception: Exception] catch (...) {...} |
+| pre | CatchInFinally.cs:13:9:27:9 | {...} | CatchInFinally.cs:19:13:22:13 | [exception: NullReferenceException] catch (...) {...} |
+| pre | CatchInFinally.cs:13:9:27:9 | {...} | CatchInFinally.cs:20:13:22:13 | {...} |
+| pre | CatchInFinally.cs:13:9:27:9 | {...} | CatchInFinally.cs:23:13:26:13 | catch {...} |
+| pre | CatchInFinally.cs:16:36:16:36 | 1 | CatchInFinally.cs:16:36:16:36 | 1 |
+| pre | CatchInFinally.cs:16:36:16:36 | 1 | CatchInFinally.cs:17:21:17:45 | throw ...; |
+| pre | CatchInFinally.cs:16:36:16:36 | 1 | CatchInFinally.cs:17:41:17:43 | "1" |
+| pre | CatchInFinally.cs:16:36:16:36 | [finally: exception(ArgumentNullException)] 1 | CatchInFinally.cs:16:36:16:36 | [finally: exception(ArgumentNullException)] 1 |
+| pre | CatchInFinally.cs:16:36:16:36 | [finally: exception(ArgumentNullException)] 1 | CatchInFinally.cs:17:21:17:45 | [finally: exception(ArgumentNullException)] throw ...; |
+| pre | CatchInFinally.cs:16:36:16:36 | [finally: exception(ArgumentNullException)] 1 | CatchInFinally.cs:17:41:17:43 | [finally: exception(ArgumentNullException)] "1" |
+| pre | CatchInFinally.cs:16:36:16:36 | [finally: exception(Exception)] 1 | CatchInFinally.cs:16:36:16:36 | [finally: exception(Exception)] 1 |
+| pre | CatchInFinally.cs:16:36:16:36 | [finally: exception(Exception)] 1 | CatchInFinally.cs:17:21:17:45 | [finally: exception(Exception)] throw ...; |
+| pre | CatchInFinally.cs:16:36:16:36 | [finally: exception(Exception)] 1 | CatchInFinally.cs:17:41:17:43 | [finally: exception(Exception)] "1" |
+| pre | CatchInFinally.cs:17:21:17:45 | [finally: exception(ArgumentNullException)] throw ...; | CatchInFinally.cs:17:21:17:45 | [finally: exception(ArgumentNullException)] throw ...; |
+| pre | CatchInFinally.cs:17:21:17:45 | [finally: exception(Exception)] throw ...; | CatchInFinally.cs:17:21:17:45 | [finally: exception(Exception)] throw ...; |
+| pre | CatchInFinally.cs:17:21:17:45 | throw ...; | CatchInFinally.cs:17:21:17:45 | throw ...; |
+| pre | CatchInFinally.cs:17:41:17:43 | "1" | CatchInFinally.cs:17:21:17:45 | throw ...; |
+| pre | CatchInFinally.cs:17:41:17:43 | "1" | CatchInFinally.cs:17:41:17:43 | "1" |
+| pre | CatchInFinally.cs:17:41:17:43 | [finally: exception(ArgumentNullException)] "1" | CatchInFinally.cs:17:21:17:45 | [finally: exception(ArgumentNullException)] throw ...; |
+| pre | CatchInFinally.cs:17:41:17:43 | [finally: exception(ArgumentNullException)] "1" | CatchInFinally.cs:17:41:17:43 | [finally: exception(ArgumentNullException)] "1" |
+| pre | CatchInFinally.cs:17:41:17:43 | [finally: exception(Exception)] "1" | CatchInFinally.cs:17:21:17:45 | [finally: exception(Exception)] throw ...; |
+| pre | CatchInFinally.cs:17:41:17:43 | [finally: exception(Exception)] "1" | CatchInFinally.cs:17:41:17:43 | [finally: exception(Exception)] "1" |
+| pre | CatchInFinally.cs:19:13:22:13 | [exception: Exception, finally: exception(ArgumentNullException)] catch (...) {...} | CatchInFinally.cs:19:13:22:13 | [exception: Exception, finally: exception(ArgumentNullException)] catch (...) {...} |
+| pre | CatchInFinally.cs:19:13:22:13 | [exception: Exception, finally: exception(Exception)] catch (...) {...} | CatchInFinally.cs:19:13:22:13 | [exception: Exception, finally: exception(Exception)] catch (...) {...} |
+| pre | CatchInFinally.cs:19:13:22:13 | [exception: Exception] catch (...) {...} | CatchInFinally.cs:19:13:22:13 | [exception: Exception] catch (...) {...} |
+| pre | CatchInFinally.cs:19:13:22:13 | [exception: NullReferenceException, finally: exception(ArgumentNullException)] catch (...) {...} | CatchInFinally.cs:19:13:22:13 | [exception: NullReferenceException, finally: exception(ArgumentNullException)] catch (...) {...} |
+| pre | CatchInFinally.cs:19:13:22:13 | [exception: NullReferenceException, finally: exception(Exception)] catch (...) {...} | CatchInFinally.cs:19:13:22:13 | [exception: NullReferenceException, finally: exception(Exception)] catch (...) {...} |
+| pre | CatchInFinally.cs:19:13:22:13 | [exception: NullReferenceException] catch (...) {...} | CatchInFinally.cs:19:13:22:13 | [exception: NullReferenceException] catch (...) {...} |
+| pre | CatchInFinally.cs:20:13:22:13 | [finally: exception(ArgumentNullException)] {...} | CatchInFinally.cs:20:13:22:13 | [finally: exception(ArgumentNullException)] {...} |
+| pre | CatchInFinally.cs:20:13:22:13 | [finally: exception(Exception)] {...} | CatchInFinally.cs:20:13:22:13 | [finally: exception(Exception)] {...} |
+| pre | CatchInFinally.cs:20:13:22:13 | {...} | CatchInFinally.cs:20:13:22:13 | {...} |
+| pre | CatchInFinally.cs:23:13:26:13 | [finally: exception(ArgumentNullException)] catch {...} | CatchInFinally.cs:23:13:26:13 | [finally: exception(ArgumentNullException)] catch {...} |
+| pre | CatchInFinally.cs:23:13:26:13 | [finally: exception(Exception)] catch {...} | CatchInFinally.cs:23:13:26:13 | [finally: exception(Exception)] catch {...} |
+| pre | CatchInFinally.cs:23:13:26:13 | catch {...} | CatchInFinally.cs:23:13:26:13 | catch {...} |
 | pre | CompileTimeOperators.cs:5:9:5:15 | enter Default | CompileTimeOperators.cs:5:9:5:15 | enter Default |
 | pre | CompileTimeOperators.cs:10:9:10:14 | enter Sizeof | CompileTimeOperators.cs:10:9:10:14 | enter Sizeof |
 | pre | CompileTimeOperators.cs:15:10:15:15 | enter Typeof | CompileTimeOperators.cs:15:10:15:15 | enter Typeof |

--- a/csharp/ql/test/library-tests/controlflow/graph/BasicBlockDominance.expected
+++ b/csharp/ql/test/library-tests/controlflow/graph/BasicBlockDominance.expected
@@ -32,36 +32,36 @@
 | post | BreakInTry.cs:27:21:27:26 | break; | BreakInTry.cs:27:21:27:26 | break; |
 | post | BreakInTry.cs:30:13:33:13 | {...} | BreakInTry.cs:30:13:33:13 | {...} |
 | post | BreakInTry.cs:32:21:32:21 | ; | BreakInTry.cs:32:21:32:21 | ; |
-| post | BreakInTry.cs:32:21:32:21 | [break] ; | BreakInTry.cs:32:21:32:21 | [break] ; |
+| post | BreakInTry.cs:32:21:32:21 | [finally: break] ; | BreakInTry.cs:32:21:32:21 | [finally: break] ; |
 | post | BreakInTry.cs:35:7:35:7 | ; | BreakInTry.cs:20:10:20:11 | enter M2 |
 | post | BreakInTry.cs:35:7:35:7 | ; | BreakInTry.cs:22:9:34:9 | foreach (... ... in ...) ... |
 | post | BreakInTry.cs:35:7:35:7 | ; | BreakInTry.cs:22:22:22:24 | String arg |
 | post | BreakInTry.cs:35:7:35:7 | ; | BreakInTry.cs:27:21:27:26 | break; |
 | post | BreakInTry.cs:35:7:35:7 | ; | BreakInTry.cs:30:13:33:13 | {...} |
 | post | BreakInTry.cs:35:7:35:7 | ; | BreakInTry.cs:32:21:32:21 | ; |
-| post | BreakInTry.cs:35:7:35:7 | ; | BreakInTry.cs:32:21:32:21 | [break] ; |
+| post | BreakInTry.cs:35:7:35:7 | ; | BreakInTry.cs:32:21:32:21 | [finally: break] ; |
 | post | BreakInTry.cs:35:7:35:7 | ; | BreakInTry.cs:35:7:35:7 | ; |
 | post | BreakInTry.cs:38:10:38:11 | enter M3 | BreakInTry.cs:38:10:38:11 | enter M3 |
 | post | BreakInTry.cs:38:10:38:11 | exit M3 | BreakInTry.cs:38:10:38:11 | enter M3 |
 | post | BreakInTry.cs:38:10:38:11 | exit M3 | BreakInTry.cs:38:10:38:11 | exit M3 |
 | post | BreakInTry.cs:38:10:38:11 | exit M3 | BreakInTry.cs:43:17:43:23 | return ...; |
 | post | BreakInTry.cs:38:10:38:11 | exit M3 | BreakInTry.cs:46:9:52:9 | {...} |
-| post | BreakInTry.cs:38:10:38:11 | exit M3 | BreakInTry.cs:47:13:51:13 | [return] foreach (... ... in ...) ... |
+| post | BreakInTry.cs:38:10:38:11 | exit M3 | BreakInTry.cs:47:13:51:13 | [finally: return] foreach (... ... in ...) ... |
 | post | BreakInTry.cs:38:10:38:11 | exit M3 | BreakInTry.cs:47:13:51:13 | foreach (... ... in ...) ... |
 | post | BreakInTry.cs:38:10:38:11 | exit M3 | BreakInTry.cs:47:26:47:28 | String arg |
-| post | BreakInTry.cs:38:10:38:11 | exit M3 | BreakInTry.cs:47:26:47:28 | [return] String arg |
-| post | BreakInTry.cs:38:10:38:11 | exit M3 | BreakInTry.cs:50:21:50:26 | [return] break; |
+| post | BreakInTry.cs:38:10:38:11 | exit M3 | BreakInTry.cs:47:26:47:28 | [finally: return] String arg |
+| post | BreakInTry.cs:38:10:38:11 | exit M3 | BreakInTry.cs:50:21:50:26 | [finally: return] break; |
 | post | BreakInTry.cs:38:10:38:11 | exit M3 | BreakInTry.cs:50:21:50:26 | break; |
 | post | BreakInTry.cs:38:10:38:11 | exit M3 | BreakInTry.cs:53:7:53:7 | ; |
 | post | BreakInTry.cs:43:17:43:23 | return ...; | BreakInTry.cs:43:17:43:23 | return ...; |
 | post | BreakInTry.cs:46:9:52:9 | {...} | BreakInTry.cs:46:9:52:9 | {...} |
-| post | BreakInTry.cs:47:13:51:13 | [return] foreach (... ... in ...) ... | BreakInTry.cs:43:17:43:23 | return ...; |
-| post | BreakInTry.cs:47:13:51:13 | [return] foreach (... ... in ...) ... | BreakInTry.cs:47:13:51:13 | [return] foreach (... ... in ...) ... |
+| post | BreakInTry.cs:47:13:51:13 | [finally: return] foreach (... ... in ...) ... | BreakInTry.cs:43:17:43:23 | return ...; |
+| post | BreakInTry.cs:47:13:51:13 | [finally: return] foreach (... ... in ...) ... | BreakInTry.cs:47:13:51:13 | [finally: return] foreach (... ... in ...) ... |
 | post | BreakInTry.cs:47:13:51:13 | foreach (... ... in ...) ... | BreakInTry.cs:46:9:52:9 | {...} |
 | post | BreakInTry.cs:47:13:51:13 | foreach (... ... in ...) ... | BreakInTry.cs:47:13:51:13 | foreach (... ... in ...) ... |
 | post | BreakInTry.cs:47:26:47:28 | String arg | BreakInTry.cs:47:26:47:28 | String arg |
-| post | BreakInTry.cs:47:26:47:28 | [return] String arg | BreakInTry.cs:47:26:47:28 | [return] String arg |
-| post | BreakInTry.cs:50:21:50:26 | [return] break; | BreakInTry.cs:50:21:50:26 | [return] break; |
+| post | BreakInTry.cs:47:26:47:28 | [finally: return] String arg | BreakInTry.cs:47:26:47:28 | [finally: return] String arg |
+| post | BreakInTry.cs:50:21:50:26 | [finally: return] break; | BreakInTry.cs:50:21:50:26 | [finally: return] break; |
 | post | BreakInTry.cs:50:21:50:26 | break; | BreakInTry.cs:50:21:50:26 | break; |
 | post | BreakInTry.cs:53:7:53:7 | ; | BreakInTry.cs:46:9:52:9 | {...} |
 | post | BreakInTry.cs:53:7:53:7 | ; | BreakInTry.cs:47:13:51:13 | foreach (... ... in ...) ... |
@@ -73,21 +73,21 @@
 | post | BreakInTry.cs:56:10:56:11 | exit M4 | BreakInTry.cs:56:10:56:11 | exit M4 |
 | post | BreakInTry.cs:56:10:56:11 | exit M4 | BreakInTry.cs:61:17:61:23 | return ...; |
 | post | BreakInTry.cs:56:10:56:11 | exit M4 | BreakInTry.cs:64:9:70:9 | {...} |
-| post | BreakInTry.cs:56:10:56:11 | exit M4 | BreakInTry.cs:65:13:69:13 | [return] foreach (... ... in ...) ... |
+| post | BreakInTry.cs:56:10:56:11 | exit M4 | BreakInTry.cs:65:13:69:13 | [finally: return] foreach (... ... in ...) ... |
 | post | BreakInTry.cs:56:10:56:11 | exit M4 | BreakInTry.cs:65:13:69:13 | foreach (... ... in ...) ... |
 | post | BreakInTry.cs:56:10:56:11 | exit M4 | BreakInTry.cs:65:26:65:28 | String arg |
-| post | BreakInTry.cs:56:10:56:11 | exit M4 | BreakInTry.cs:65:26:65:28 | [return] String arg |
-| post | BreakInTry.cs:56:10:56:11 | exit M4 | BreakInTry.cs:68:21:68:26 | [return] break; |
+| post | BreakInTry.cs:56:10:56:11 | exit M4 | BreakInTry.cs:65:26:65:28 | [finally: return] String arg |
+| post | BreakInTry.cs:56:10:56:11 | exit M4 | BreakInTry.cs:68:21:68:26 | [finally: return] break; |
 | post | BreakInTry.cs:56:10:56:11 | exit M4 | BreakInTry.cs:68:21:68:26 | break; |
 | post | BreakInTry.cs:61:17:61:23 | return ...; | BreakInTry.cs:61:17:61:23 | return ...; |
 | post | BreakInTry.cs:64:9:70:9 | {...} | BreakInTry.cs:64:9:70:9 | {...} |
-| post | BreakInTry.cs:65:13:69:13 | [return] foreach (... ... in ...) ... | BreakInTry.cs:61:17:61:23 | return ...; |
-| post | BreakInTry.cs:65:13:69:13 | [return] foreach (... ... in ...) ... | BreakInTry.cs:65:13:69:13 | [return] foreach (... ... in ...) ... |
+| post | BreakInTry.cs:65:13:69:13 | [finally: return] foreach (... ... in ...) ... | BreakInTry.cs:61:17:61:23 | return ...; |
+| post | BreakInTry.cs:65:13:69:13 | [finally: return] foreach (... ... in ...) ... | BreakInTry.cs:65:13:69:13 | [finally: return] foreach (... ... in ...) ... |
 | post | BreakInTry.cs:65:13:69:13 | foreach (... ... in ...) ... | BreakInTry.cs:64:9:70:9 | {...} |
 | post | BreakInTry.cs:65:13:69:13 | foreach (... ... in ...) ... | BreakInTry.cs:65:13:69:13 | foreach (... ... in ...) ... |
 | post | BreakInTry.cs:65:26:65:28 | String arg | BreakInTry.cs:65:26:65:28 | String arg |
-| post | BreakInTry.cs:65:26:65:28 | [return] String arg | BreakInTry.cs:65:26:65:28 | [return] String arg |
-| post | BreakInTry.cs:68:21:68:26 | [return] break; | BreakInTry.cs:68:21:68:26 | [return] break; |
+| post | BreakInTry.cs:65:26:65:28 | [finally: return] String arg | BreakInTry.cs:65:26:65:28 | [finally: return] String arg |
+| post | BreakInTry.cs:68:21:68:26 | [finally: return] break; | BreakInTry.cs:68:21:68:26 | [finally: return] break; |
 | post | BreakInTry.cs:68:21:68:26 | break; | BreakInTry.cs:68:21:68:26 | break; |
 | post | CompileTimeOperators.cs:5:9:5:15 | enter Default | CompileTimeOperators.cs:5:9:5:15 | enter Default |
 | post | CompileTimeOperators.cs:10:9:10:14 | enter Sizeof | CompileTimeOperators.cs:10:9:10:14 | enter Sizeof |
@@ -614,8 +614,8 @@
 | post | cflow.cs:146:10:146:19 | exit TryFinally | cflow.cs:146:10:146:19 | enter TryFinally |
 | post | cflow.cs:146:10:146:19 | exit TryFinally | cflow.cs:146:10:146:19 | exit TryFinally |
 | post | cflow.cs:146:10:146:19 | exit TryFinally | cflow.cs:150:13:150:37 | call to method WriteLine |
-| post | cflow.cs:146:10:146:19 | exit TryFinally | cflow.cs:153:9:155:9 | [exception(Exception)] {...} |
-| post | cflow.cs:146:10:146:19 | exit TryFinally | cflow.cs:153:9:155:9 | [exception(OutOfMemoryException)] {...} |
+| post | cflow.cs:146:10:146:19 | exit TryFinally | cflow.cs:153:9:155:9 | [finally: exception(Exception)] {...} |
+| post | cflow.cs:146:10:146:19 | exit TryFinally | cflow.cs:153:9:155:9 | [finally: exception(OutOfMemoryException)] {...} |
 | post | cflow.cs:146:10:146:19 | exit TryFinally | cflow.cs:153:9:155:9 | {...} |
 | post | cflow.cs:146:10:146:19 | exit TryFinally | cflow.cs:159:13:159:37 | call to method WriteLine |
 | post | cflow.cs:146:10:146:19 | exit TryFinally | cflow.cs:160:13:160:19 | return ...; |
@@ -626,8 +626,8 @@
 | post | cflow.cs:146:10:146:19 | exit TryFinally | cflow.cs:192:13:192:19 | return ...; |
 | post | cflow.cs:146:10:146:19 | exit TryFinally | cflow.cs:194:9:197:9 | catch (...) {...} |
 | post | cflow.cs:146:10:146:19 | exit TryFinally | cflow.cs:198:9:200:9 | catch (...) {...} |
-| post | cflow.cs:146:10:146:19 | exit TryFinally | cflow.cs:202:9:204:9 | [exception(Exception)] {...} |
-| post | cflow.cs:146:10:146:19 | exit TryFinally | cflow.cs:202:9:204:9 | [exception(OutOfMemoryException)] {...} |
+| post | cflow.cs:146:10:146:19 | exit TryFinally | cflow.cs:202:9:204:9 | [finally: exception(Exception)] {...} |
+| post | cflow.cs:146:10:146:19 | exit TryFinally | cflow.cs:202:9:204:9 | [finally: exception(OutOfMemoryException)] {...} |
 | post | cflow.cs:146:10:146:19 | exit TryFinally | cflow.cs:207:16:207:16 | access to local variable i |
 | post | cflow.cs:146:10:146:19 | exit TryFinally | cflow.cs:208:9:230:9 | {...} |
 | post | cflow.cs:146:10:146:19 | exit TryFinally | cflow.cs:212:21:212:27 | return ...; |
@@ -636,18 +636,18 @@
 | post | cflow.cs:146:10:146:19 | exit TryFinally | cflow.cs:215:17:216:26 | if (...) ... |
 | post | cflow.cs:146:10:146:19 | exit TryFinally | cflow.cs:216:21:216:26 | break; |
 | post | cflow.cs:146:10:146:19 | exit TryFinally | cflow.cs:219:13:229:13 | {...} |
-| post | cflow.cs:146:10:146:19 | exit TryFinally | cflow.cs:223:25:223:46 | [break] throw ...; |
-| post | cflow.cs:146:10:146:19 | exit TryFinally | cflow.cs:223:25:223:46 | [continue] throw ...; |
-| post | cflow.cs:146:10:146:19 | exit TryFinally | cflow.cs:223:25:223:46 | [return] throw ...; |
+| post | cflow.cs:146:10:146:19 | exit TryFinally | cflow.cs:223:25:223:46 | [finally: break] throw ...; |
+| post | cflow.cs:146:10:146:19 | exit TryFinally | cflow.cs:223:25:223:46 | [finally: continue] throw ...; |
+| post | cflow.cs:146:10:146:19 | exit TryFinally | cflow.cs:223:25:223:46 | [finally: return] throw ...; |
 | post | cflow.cs:146:10:146:19 | exit TryFinally | cflow.cs:223:25:223:46 | throw ...; |
-| post | cflow.cs:146:10:146:19 | exit TryFinally | cflow.cs:223:31:223:45 | [break] object creation of type Exception |
-| post | cflow.cs:146:10:146:19 | exit TryFinally | cflow.cs:223:31:223:45 | [continue] object creation of type Exception |
-| post | cflow.cs:146:10:146:19 | exit TryFinally | cflow.cs:223:31:223:45 | [return] object creation of type Exception |
+| post | cflow.cs:146:10:146:19 | exit TryFinally | cflow.cs:223:31:223:45 | [finally: break] object creation of type Exception |
+| post | cflow.cs:146:10:146:19 | exit TryFinally | cflow.cs:223:31:223:45 | [finally: continue] object creation of type Exception |
+| post | cflow.cs:146:10:146:19 | exit TryFinally | cflow.cs:223:31:223:45 | [finally: return] object creation of type Exception |
 | post | cflow.cs:146:10:146:19 | exit TryFinally | cflow.cs:223:31:223:45 | object creation of type Exception |
-| post | cflow.cs:146:10:146:19 | exit TryFinally | cflow.cs:226:17:228:17 | [break] {...} |
-| post | cflow.cs:146:10:146:19 | exit TryFinally | cflow.cs:226:17:228:17 | [continue] {...} |
-| post | cflow.cs:146:10:146:19 | exit TryFinally | cflow.cs:226:17:228:17 | [exception(Exception)] {...} |
-| post | cflow.cs:146:10:146:19 | exit TryFinally | cflow.cs:226:17:228:17 | [return] {...} |
+| post | cflow.cs:146:10:146:19 | exit TryFinally | cflow.cs:226:17:228:17 | [finally: break] {...} |
+| post | cflow.cs:146:10:146:19 | exit TryFinally | cflow.cs:226:17:228:17 | [finally: continue] {...} |
+| post | cflow.cs:146:10:146:19 | exit TryFinally | cflow.cs:226:17:228:17 | [finally: exception(Exception)] {...} |
+| post | cflow.cs:146:10:146:19 | exit TryFinally | cflow.cs:226:17:228:17 | [finally: return] {...} |
 | post | cflow.cs:146:10:146:19 | exit TryFinally | cflow.cs:226:17:228:17 | {...} |
 | post | cflow.cs:146:10:146:19 | exit TryFinally | cflow.cs:232:9:245:9 | try {...} ... |
 | post | cflow.cs:146:10:146:19 | exit TryFinally | cflow.cs:234:17:234:28 | access to property Length |
@@ -658,27 +658,27 @@
 | post | cflow.cs:146:10:146:19 | exit TryFinally | cflow.cs:236:33:236:33 | 1 |
 | post | cflow.cs:146:10:146:19 | exit TryFinally | cflow.cs:237:17:237:49 | throw ...; |
 | post | cflow.cs:146:10:146:19 | exit TryFinally | cflow.cs:237:23:237:48 | object creation of type OutOfMemoryException |
-| post | cflow.cs:146:10:146:19 | exit TryFinally | cflow.cs:240:9:245:9 | [exception(Exception)] {...} |
-| post | cflow.cs:146:10:146:19 | exit TryFinally | cflow.cs:240:9:245:9 | [exception(NullReferenceException)] {...} |
+| post | cflow.cs:146:10:146:19 | exit TryFinally | cflow.cs:240:9:245:9 | [finally: exception(Exception)] {...} |
+| post | cflow.cs:146:10:146:19 | exit TryFinally | cflow.cs:240:9:245:9 | [finally: exception(NullReferenceException)] {...} |
 | post | cflow.cs:146:10:146:19 | exit TryFinally | cflow.cs:240:9:245:9 | {...} |
 | post | cflow.cs:146:10:146:19 | exit TryFinally | cflow.cs:242:17:242:41 | ...; |
-| post | cflow.cs:146:10:146:19 | exit TryFinally | cflow.cs:242:17:242:41 | [exception(Exception)] ...; |
-| post | cflow.cs:146:10:146:19 | exit TryFinally | cflow.cs:242:17:242:41 | [exception(NullReferenceException)] ...; |
-| post | cflow.cs:146:10:146:19 | exit TryFinally | cflow.cs:242:17:242:41 | [exception(OutOfMemoryException)] ...; |
-| post | cflow.cs:146:10:146:19 | exit TryFinally | cflow.cs:242:17:242:41 | [return] ...; |
-| post | cflow.cs:146:10:146:19 | exit TryFinally | cflow.cs:243:13:244:37 | [exception(Exception)] if (...) ... |
-| post | cflow.cs:146:10:146:19 | exit TryFinally | cflow.cs:243:13:244:37 | [exception(NullReferenceException)] if (...) ... |
-| post | cflow.cs:146:10:146:19 | exit TryFinally | cflow.cs:243:13:244:37 | [exception(OutOfMemoryException)] if (...) ... |
-| post | cflow.cs:146:10:146:19 | exit TryFinally | cflow.cs:243:13:244:37 | [return] if (...) ... |
+| post | cflow.cs:146:10:146:19 | exit TryFinally | cflow.cs:242:17:242:41 | [finally: exception(Exception)] ...; |
+| post | cflow.cs:146:10:146:19 | exit TryFinally | cflow.cs:242:17:242:41 | [finally: exception(NullReferenceException)] ...; |
+| post | cflow.cs:146:10:146:19 | exit TryFinally | cflow.cs:242:17:242:41 | [finally: exception(OutOfMemoryException)] ...; |
+| post | cflow.cs:146:10:146:19 | exit TryFinally | cflow.cs:242:17:242:41 | [finally: return] ...; |
+| post | cflow.cs:146:10:146:19 | exit TryFinally | cflow.cs:243:13:244:37 | [finally: exception(Exception)] if (...) ... |
+| post | cflow.cs:146:10:146:19 | exit TryFinally | cflow.cs:243:13:244:37 | [finally: exception(NullReferenceException)] if (...) ... |
+| post | cflow.cs:146:10:146:19 | exit TryFinally | cflow.cs:243:13:244:37 | [finally: exception(OutOfMemoryException)] if (...) ... |
+| post | cflow.cs:146:10:146:19 | exit TryFinally | cflow.cs:243:13:244:37 | [finally: return] if (...) ... |
 | post | cflow.cs:146:10:146:19 | exit TryFinally | cflow.cs:243:13:244:37 | if (...) ... |
 | post | cflow.cs:146:10:146:19 | exit TryFinally | cflow.cs:244:17:244:37 | ...; |
-| post | cflow.cs:146:10:146:19 | exit TryFinally | cflow.cs:244:17:244:37 | [exception(Exception)] ...; |
-| post | cflow.cs:146:10:146:19 | exit TryFinally | cflow.cs:244:17:244:37 | [exception(NullReferenceException)] ...; |
-| post | cflow.cs:146:10:146:19 | exit TryFinally | cflow.cs:244:17:244:37 | [exception(OutOfMemoryException)] ...; |
-| post | cflow.cs:146:10:146:19 | exit TryFinally | cflow.cs:244:17:244:37 | [return] ...; |
+| post | cflow.cs:146:10:146:19 | exit TryFinally | cflow.cs:244:17:244:37 | [finally: exception(Exception)] ...; |
+| post | cflow.cs:146:10:146:19 | exit TryFinally | cflow.cs:244:17:244:37 | [finally: exception(NullReferenceException)] ...; |
+| post | cflow.cs:146:10:146:19 | exit TryFinally | cflow.cs:244:17:244:37 | [finally: exception(OutOfMemoryException)] ...; |
+| post | cflow.cs:146:10:146:19 | exit TryFinally | cflow.cs:244:17:244:37 | [finally: return] ...; |
 | post | cflow.cs:150:13:150:37 | call to method WriteLine | cflow.cs:150:13:150:37 | call to method WriteLine |
-| post | cflow.cs:153:9:155:9 | [exception(Exception)] {...} | cflow.cs:153:9:155:9 | [exception(Exception)] {...} |
-| post | cflow.cs:153:9:155:9 | [exception(OutOfMemoryException)] {...} | cflow.cs:153:9:155:9 | [exception(OutOfMemoryException)] {...} |
+| post | cflow.cs:153:9:155:9 | [finally: exception(Exception)] {...} | cflow.cs:153:9:155:9 | [finally: exception(Exception)] {...} |
+| post | cflow.cs:153:9:155:9 | [finally: exception(OutOfMemoryException)] {...} | cflow.cs:153:9:155:9 | [finally: exception(OutOfMemoryException)] {...} |
 | post | cflow.cs:153:9:155:9 | {...} | cflow.cs:153:9:155:9 | {...} |
 | post | cflow.cs:159:13:159:37 | call to method WriteLine | cflow.cs:159:13:159:37 | call to method WriteLine |
 | post | cflow.cs:160:13:160:19 | return ...; | cflow.cs:160:13:160:19 | return ...; |
@@ -689,11 +689,11 @@
 | post | cflow.cs:192:13:192:19 | return ...; | cflow.cs:192:13:192:19 | return ...; |
 | post | cflow.cs:194:9:197:9 | catch (...) {...} | cflow.cs:194:9:197:9 | catch (...) {...} |
 | post | cflow.cs:198:9:200:9 | catch (...) {...} | cflow.cs:198:9:200:9 | catch (...) {...} |
-| post | cflow.cs:202:9:204:9 | [exception(Exception)] {...} | cflow.cs:202:9:204:9 | [exception(Exception)] {...} |
-| post | cflow.cs:202:9:204:9 | [exception(OutOfMemoryException)] {...} | cflow.cs:202:9:204:9 | [exception(OutOfMemoryException)] {...} |
+| post | cflow.cs:202:9:204:9 | [finally: exception(Exception)] {...} | cflow.cs:202:9:204:9 | [finally: exception(Exception)] {...} |
+| post | cflow.cs:202:9:204:9 | [finally: exception(OutOfMemoryException)] {...} | cflow.cs:202:9:204:9 | [finally: exception(OutOfMemoryException)] {...} |
 | post | cflow.cs:207:16:207:16 | access to local variable i | cflow.cs:198:9:200:9 | catch (...) {...} |
 | post | cflow.cs:207:16:207:16 | access to local variable i | cflow.cs:207:16:207:16 | access to local variable i |
-| post | cflow.cs:207:16:207:16 | access to local variable i | cflow.cs:226:17:228:17 | [continue] {...} |
+| post | cflow.cs:207:16:207:16 | access to local variable i | cflow.cs:226:17:228:17 | [finally: continue] {...} |
 | post | cflow.cs:207:16:207:16 | access to local variable i | cflow.cs:226:17:228:17 | {...} |
 | post | cflow.cs:208:9:230:9 | {...} | cflow.cs:208:9:230:9 | {...} |
 | post | cflow.cs:212:21:212:27 | return ...; | cflow.cs:212:21:212:27 | return ...; |
@@ -702,28 +702,28 @@
 | post | cflow.cs:215:17:216:26 | if (...) ... | cflow.cs:215:17:216:26 | if (...) ... |
 | post | cflow.cs:216:21:216:26 | break; | cflow.cs:216:21:216:26 | break; |
 | post | cflow.cs:219:13:229:13 | {...} | cflow.cs:219:13:229:13 | {...} |
-| post | cflow.cs:223:25:223:46 | [break] throw ...; | cflow.cs:223:25:223:46 | [break] throw ...; |
-| post | cflow.cs:223:25:223:46 | [continue] throw ...; | cflow.cs:223:25:223:46 | [continue] throw ...; |
-| post | cflow.cs:223:25:223:46 | [return] throw ...; | cflow.cs:223:25:223:46 | [return] throw ...; |
+| post | cflow.cs:223:25:223:46 | [finally: break] throw ...; | cflow.cs:223:25:223:46 | [finally: break] throw ...; |
+| post | cflow.cs:223:25:223:46 | [finally: continue] throw ...; | cflow.cs:223:25:223:46 | [finally: continue] throw ...; |
+| post | cflow.cs:223:25:223:46 | [finally: return] throw ...; | cflow.cs:223:25:223:46 | [finally: return] throw ...; |
 | post | cflow.cs:223:25:223:46 | throw ...; | cflow.cs:223:25:223:46 | throw ...; |
-| post | cflow.cs:223:31:223:45 | [break] object creation of type Exception | cflow.cs:223:31:223:45 | [break] object creation of type Exception |
-| post | cflow.cs:223:31:223:45 | [continue] object creation of type Exception | cflow.cs:223:31:223:45 | [continue] object creation of type Exception |
-| post | cflow.cs:223:31:223:45 | [return] object creation of type Exception | cflow.cs:223:31:223:45 | [return] object creation of type Exception |
+| post | cflow.cs:223:31:223:45 | [finally: break] object creation of type Exception | cflow.cs:223:31:223:45 | [finally: break] object creation of type Exception |
+| post | cflow.cs:223:31:223:45 | [finally: continue] object creation of type Exception | cflow.cs:223:31:223:45 | [finally: continue] object creation of type Exception |
+| post | cflow.cs:223:31:223:45 | [finally: return] object creation of type Exception | cflow.cs:223:31:223:45 | [finally: return] object creation of type Exception |
 | post | cflow.cs:223:31:223:45 | object creation of type Exception | cflow.cs:223:31:223:45 | object creation of type Exception |
-| post | cflow.cs:226:17:228:17 | [break] {...} | cflow.cs:226:17:228:17 | [break] {...} |
-| post | cflow.cs:226:17:228:17 | [continue] {...} | cflow.cs:226:17:228:17 | [continue] {...} |
-| post | cflow.cs:226:17:228:17 | [exception(Exception)] {...} | cflow.cs:223:25:223:46 | [break] throw ...; |
-| post | cflow.cs:226:17:228:17 | [exception(Exception)] {...} | cflow.cs:223:25:223:46 | [continue] throw ...; |
-| post | cflow.cs:226:17:228:17 | [exception(Exception)] {...} | cflow.cs:223:25:223:46 | [return] throw ...; |
-| post | cflow.cs:226:17:228:17 | [exception(Exception)] {...} | cflow.cs:223:25:223:46 | throw ...; |
-| post | cflow.cs:226:17:228:17 | [exception(Exception)] {...} | cflow.cs:223:31:223:45 | [break] object creation of type Exception |
-| post | cflow.cs:226:17:228:17 | [exception(Exception)] {...} | cflow.cs:223:31:223:45 | [continue] object creation of type Exception |
-| post | cflow.cs:226:17:228:17 | [exception(Exception)] {...} | cflow.cs:223:31:223:45 | [return] object creation of type Exception |
-| post | cflow.cs:226:17:228:17 | [exception(Exception)] {...} | cflow.cs:223:31:223:45 | object creation of type Exception |
-| post | cflow.cs:226:17:228:17 | [exception(Exception)] {...} | cflow.cs:226:17:228:17 | [exception(Exception)] {...} |
-| post | cflow.cs:226:17:228:17 | [return] {...} | cflow.cs:226:17:228:17 | [return] {...} |
+| post | cflow.cs:226:17:228:17 | [finally: break] {...} | cflow.cs:226:17:228:17 | [finally: break] {...} |
+| post | cflow.cs:226:17:228:17 | [finally: continue] {...} | cflow.cs:226:17:228:17 | [finally: continue] {...} |
+| post | cflow.cs:226:17:228:17 | [finally: exception(Exception)] {...} | cflow.cs:223:25:223:46 | [finally: break] throw ...; |
+| post | cflow.cs:226:17:228:17 | [finally: exception(Exception)] {...} | cflow.cs:223:25:223:46 | [finally: continue] throw ...; |
+| post | cflow.cs:226:17:228:17 | [finally: exception(Exception)] {...} | cflow.cs:223:25:223:46 | [finally: return] throw ...; |
+| post | cflow.cs:226:17:228:17 | [finally: exception(Exception)] {...} | cflow.cs:223:25:223:46 | throw ...; |
+| post | cflow.cs:226:17:228:17 | [finally: exception(Exception)] {...} | cflow.cs:223:31:223:45 | [finally: break] object creation of type Exception |
+| post | cflow.cs:226:17:228:17 | [finally: exception(Exception)] {...} | cflow.cs:223:31:223:45 | [finally: continue] object creation of type Exception |
+| post | cflow.cs:226:17:228:17 | [finally: exception(Exception)] {...} | cflow.cs:223:31:223:45 | [finally: return] object creation of type Exception |
+| post | cflow.cs:226:17:228:17 | [finally: exception(Exception)] {...} | cflow.cs:223:31:223:45 | object creation of type Exception |
+| post | cflow.cs:226:17:228:17 | [finally: exception(Exception)] {...} | cflow.cs:226:17:228:17 | [finally: exception(Exception)] {...} |
+| post | cflow.cs:226:17:228:17 | [finally: return] {...} | cflow.cs:226:17:228:17 | [finally: return] {...} |
 | post | cflow.cs:226:17:228:17 | {...} | cflow.cs:226:17:228:17 | {...} |
-| post | cflow.cs:232:9:245:9 | try {...} ... | cflow.cs:226:17:228:17 | [break] {...} |
+| post | cflow.cs:232:9:245:9 | try {...} ... | cflow.cs:226:17:228:17 | [finally: break] {...} |
 | post | cflow.cs:232:9:245:9 | try {...} ... | cflow.cs:232:9:245:9 | try {...} ... |
 | post | cflow.cs:234:17:234:28 | access to property Length | cflow.cs:234:17:234:28 | access to property Length |
 | post | cflow.cs:234:33:234:33 | 0 | cflow.cs:234:33:234:33 | 0 |
@@ -733,34 +733,34 @@
 | post | cflow.cs:236:33:236:33 | 1 | cflow.cs:236:33:236:33 | 1 |
 | post | cflow.cs:237:17:237:49 | throw ...; | cflow.cs:237:17:237:49 | throw ...; |
 | post | cflow.cs:237:23:237:48 | object creation of type OutOfMemoryException | cflow.cs:237:23:237:48 | object creation of type OutOfMemoryException |
-| post | cflow.cs:240:9:245:9 | [exception(Exception)] {...} | cflow.cs:240:9:245:9 | [exception(Exception)] {...} |
-| post | cflow.cs:240:9:245:9 | [exception(NullReferenceException)] {...} | cflow.cs:240:9:245:9 | [exception(NullReferenceException)] {...} |
+| post | cflow.cs:240:9:245:9 | [finally: exception(Exception)] {...} | cflow.cs:240:9:245:9 | [finally: exception(Exception)] {...} |
+| post | cflow.cs:240:9:245:9 | [finally: exception(NullReferenceException)] {...} | cflow.cs:240:9:245:9 | [finally: exception(NullReferenceException)] {...} |
 | post | cflow.cs:240:9:245:9 | {...} | cflow.cs:240:9:245:9 | {...} |
 | post | cflow.cs:242:17:242:41 | ...; | cflow.cs:242:17:242:41 | ...; |
-| post | cflow.cs:242:17:242:41 | [exception(Exception)] ...; | cflow.cs:242:17:242:41 | [exception(Exception)] ...; |
-| post | cflow.cs:242:17:242:41 | [exception(NullReferenceException)] ...; | cflow.cs:242:17:242:41 | [exception(NullReferenceException)] ...; |
-| post | cflow.cs:242:17:242:41 | [exception(OutOfMemoryException)] ...; | cflow.cs:242:17:242:41 | [exception(OutOfMemoryException)] ...; |
-| post | cflow.cs:242:17:242:41 | [return] ...; | cflow.cs:242:17:242:41 | [return] ...; |
-| post | cflow.cs:243:13:244:37 | [exception(Exception)] if (...) ... | cflow.cs:240:9:245:9 | [exception(Exception)] {...} |
-| post | cflow.cs:243:13:244:37 | [exception(Exception)] if (...) ... | cflow.cs:242:17:242:41 | [exception(Exception)] ...; |
-| post | cflow.cs:243:13:244:37 | [exception(Exception)] if (...) ... | cflow.cs:243:13:244:37 | [exception(Exception)] if (...) ... |
-| post | cflow.cs:243:13:244:37 | [exception(NullReferenceException)] if (...) ... | cflow.cs:240:9:245:9 | [exception(NullReferenceException)] {...} |
-| post | cflow.cs:243:13:244:37 | [exception(NullReferenceException)] if (...) ... | cflow.cs:242:17:242:41 | [exception(NullReferenceException)] ...; |
-| post | cflow.cs:243:13:244:37 | [exception(NullReferenceException)] if (...) ... | cflow.cs:243:13:244:37 | [exception(NullReferenceException)] if (...) ... |
-| post | cflow.cs:243:13:244:37 | [exception(OutOfMemoryException)] if (...) ... | cflow.cs:237:17:237:49 | throw ...; |
-| post | cflow.cs:243:13:244:37 | [exception(OutOfMemoryException)] if (...) ... | cflow.cs:242:17:242:41 | [exception(OutOfMemoryException)] ...; |
-| post | cflow.cs:243:13:244:37 | [exception(OutOfMemoryException)] if (...) ... | cflow.cs:243:13:244:37 | [exception(OutOfMemoryException)] if (...) ... |
-| post | cflow.cs:243:13:244:37 | [return] if (...) ... | cflow.cs:235:17:235:23 | return ...; |
-| post | cflow.cs:243:13:244:37 | [return] if (...) ... | cflow.cs:242:17:242:41 | [return] ...; |
-| post | cflow.cs:243:13:244:37 | [return] if (...) ... | cflow.cs:243:13:244:37 | [return] if (...) ... |
+| post | cflow.cs:242:17:242:41 | [finally: exception(Exception)] ...; | cflow.cs:242:17:242:41 | [finally: exception(Exception)] ...; |
+| post | cflow.cs:242:17:242:41 | [finally: exception(NullReferenceException)] ...; | cflow.cs:242:17:242:41 | [finally: exception(NullReferenceException)] ...; |
+| post | cflow.cs:242:17:242:41 | [finally: exception(OutOfMemoryException)] ...; | cflow.cs:242:17:242:41 | [finally: exception(OutOfMemoryException)] ...; |
+| post | cflow.cs:242:17:242:41 | [finally: return] ...; | cflow.cs:242:17:242:41 | [finally: return] ...; |
+| post | cflow.cs:243:13:244:37 | [finally: exception(Exception)] if (...) ... | cflow.cs:240:9:245:9 | [finally: exception(Exception)] {...} |
+| post | cflow.cs:243:13:244:37 | [finally: exception(Exception)] if (...) ... | cflow.cs:242:17:242:41 | [finally: exception(Exception)] ...; |
+| post | cflow.cs:243:13:244:37 | [finally: exception(Exception)] if (...) ... | cflow.cs:243:13:244:37 | [finally: exception(Exception)] if (...) ... |
+| post | cflow.cs:243:13:244:37 | [finally: exception(NullReferenceException)] if (...) ... | cflow.cs:240:9:245:9 | [finally: exception(NullReferenceException)] {...} |
+| post | cflow.cs:243:13:244:37 | [finally: exception(NullReferenceException)] if (...) ... | cflow.cs:242:17:242:41 | [finally: exception(NullReferenceException)] ...; |
+| post | cflow.cs:243:13:244:37 | [finally: exception(NullReferenceException)] if (...) ... | cflow.cs:243:13:244:37 | [finally: exception(NullReferenceException)] if (...) ... |
+| post | cflow.cs:243:13:244:37 | [finally: exception(OutOfMemoryException)] if (...) ... | cflow.cs:237:17:237:49 | throw ...; |
+| post | cflow.cs:243:13:244:37 | [finally: exception(OutOfMemoryException)] if (...) ... | cflow.cs:242:17:242:41 | [finally: exception(OutOfMemoryException)] ...; |
+| post | cflow.cs:243:13:244:37 | [finally: exception(OutOfMemoryException)] if (...) ... | cflow.cs:243:13:244:37 | [finally: exception(OutOfMemoryException)] if (...) ... |
+| post | cflow.cs:243:13:244:37 | [finally: return] if (...) ... | cflow.cs:235:17:235:23 | return ...; |
+| post | cflow.cs:243:13:244:37 | [finally: return] if (...) ... | cflow.cs:242:17:242:41 | [finally: return] ...; |
+| post | cflow.cs:243:13:244:37 | [finally: return] if (...) ... | cflow.cs:243:13:244:37 | [finally: return] if (...) ... |
 | post | cflow.cs:243:13:244:37 | if (...) ... | cflow.cs:240:9:245:9 | {...} |
 | post | cflow.cs:243:13:244:37 | if (...) ... | cflow.cs:242:17:242:41 | ...; |
 | post | cflow.cs:243:13:244:37 | if (...) ... | cflow.cs:243:13:244:37 | if (...) ... |
 | post | cflow.cs:244:17:244:37 | ...; | cflow.cs:244:17:244:37 | ...; |
-| post | cflow.cs:244:17:244:37 | [exception(Exception)] ...; | cflow.cs:244:17:244:37 | [exception(Exception)] ...; |
-| post | cflow.cs:244:17:244:37 | [exception(NullReferenceException)] ...; | cflow.cs:244:17:244:37 | [exception(NullReferenceException)] ...; |
-| post | cflow.cs:244:17:244:37 | [exception(OutOfMemoryException)] ...; | cflow.cs:244:17:244:37 | [exception(OutOfMemoryException)] ...; |
-| post | cflow.cs:244:17:244:37 | [return] ...; | cflow.cs:244:17:244:37 | [return] ...; |
+| post | cflow.cs:244:17:244:37 | [finally: exception(Exception)] ...; | cflow.cs:244:17:244:37 | [finally: exception(Exception)] ...; |
+| post | cflow.cs:244:17:244:37 | [finally: exception(NullReferenceException)] ...; | cflow.cs:244:17:244:37 | [finally: exception(NullReferenceException)] ...; |
+| post | cflow.cs:244:17:244:37 | [finally: exception(OutOfMemoryException)] ...; | cflow.cs:244:17:244:37 | [finally: exception(OutOfMemoryException)] ...; |
+| post | cflow.cs:244:17:244:37 | [finally: return] ...; | cflow.cs:244:17:244:37 | [finally: return] ...; |
 | post | cflow.cs:248:10:248:12 | enter For | cflow.cs:248:10:248:12 | enter For |
 | post | cflow.cs:248:10:248:12 | exit For | cflow.cs:248:10:248:12 | enter For |
 | post | cflow.cs:248:10:248:12 | exit For | cflow.cs:248:10:248:12 | exit For |
@@ -983,12 +983,12 @@
 | post | cflow.cs:393:10:393:10 | exit M | cflow.cs:393:10:393:10 | enter M |
 | post | cflow.cs:393:10:393:10 | exit M | cflow.cs:393:10:393:10 | exit M |
 | post | cflow.cs:393:10:393:10 | exit M | cflow.cs:397:13:397:36 | call to method WriteLine |
-| post | cflow.cs:393:10:393:10 | exit M | cflow.cs:400:9:403:9 | [exception(Exception)] {...} |
-| post | cflow.cs:393:10:393:10 | exit M | cflow.cs:400:9:403:9 | [exception(OutOfMemoryException)] {...} |
+| post | cflow.cs:393:10:393:10 | exit M | cflow.cs:400:9:403:9 | [finally: exception(Exception)] {...} |
+| post | cflow.cs:393:10:393:10 | exit M | cflow.cs:400:9:403:9 | [finally: exception(OutOfMemoryException)] {...} |
 | post | cflow.cs:393:10:393:10 | exit M | cflow.cs:400:9:403:9 | {...} |
 | post | cflow.cs:397:13:397:36 | call to method WriteLine | cflow.cs:397:13:397:36 | call to method WriteLine |
-| post | cflow.cs:400:9:403:9 | [exception(Exception)] {...} | cflow.cs:400:9:403:9 | [exception(Exception)] {...} |
-| post | cflow.cs:400:9:403:9 | [exception(OutOfMemoryException)] {...} | cflow.cs:400:9:403:9 | [exception(OutOfMemoryException)] {...} |
+| post | cflow.cs:400:9:403:9 | [finally: exception(Exception)] {...} | cflow.cs:400:9:403:9 | [finally: exception(Exception)] {...} |
+| post | cflow.cs:400:9:403:9 | [finally: exception(OutOfMemoryException)] {...} | cflow.cs:400:9:403:9 | [finally: exception(OutOfMemoryException)] {...} |
 | post | cflow.cs:400:9:403:9 | {...} | cflow.cs:400:9:403:9 | {...} |
 | post | cflow.cs:410:12:410:12 | enter M | cflow.cs:410:12:410:12 | enter M |
 | post | cflow.cs:415:5:415:25 | enter NegationInConstructor | cflow.cs:415:5:415:25 | enter NegationInConstructor |
@@ -1031,92 +1031,92 @@
 | pre | BreakInTry.cs:20:10:20:11 | enter M2 | BreakInTry.cs:27:21:27:26 | break; |
 | pre | BreakInTry.cs:20:10:20:11 | enter M2 | BreakInTry.cs:30:13:33:13 | {...} |
 | pre | BreakInTry.cs:20:10:20:11 | enter M2 | BreakInTry.cs:32:21:32:21 | ; |
-| pre | BreakInTry.cs:20:10:20:11 | enter M2 | BreakInTry.cs:32:21:32:21 | [break] ; |
+| pre | BreakInTry.cs:20:10:20:11 | enter M2 | BreakInTry.cs:32:21:32:21 | [finally: break] ; |
 | pre | BreakInTry.cs:20:10:20:11 | enter M2 | BreakInTry.cs:35:7:35:7 | ; |
 | pre | BreakInTry.cs:22:9:34:9 | foreach (... ... in ...) ... | BreakInTry.cs:22:9:34:9 | foreach (... ... in ...) ... |
 | pre | BreakInTry.cs:22:9:34:9 | foreach (... ... in ...) ... | BreakInTry.cs:22:22:22:24 | String arg |
 | pre | BreakInTry.cs:22:9:34:9 | foreach (... ... in ...) ... | BreakInTry.cs:27:21:27:26 | break; |
 | pre | BreakInTry.cs:22:9:34:9 | foreach (... ... in ...) ... | BreakInTry.cs:30:13:33:13 | {...} |
 | pre | BreakInTry.cs:22:9:34:9 | foreach (... ... in ...) ... | BreakInTry.cs:32:21:32:21 | ; |
-| pre | BreakInTry.cs:22:9:34:9 | foreach (... ... in ...) ... | BreakInTry.cs:32:21:32:21 | [break] ; |
+| pre | BreakInTry.cs:22:9:34:9 | foreach (... ... in ...) ... | BreakInTry.cs:32:21:32:21 | [finally: break] ; |
 | pre | BreakInTry.cs:22:9:34:9 | foreach (... ... in ...) ... | BreakInTry.cs:35:7:35:7 | ; |
 | pre | BreakInTry.cs:22:22:22:24 | String arg | BreakInTry.cs:22:22:22:24 | String arg |
 | pre | BreakInTry.cs:22:22:22:24 | String arg | BreakInTry.cs:27:21:27:26 | break; |
 | pre | BreakInTry.cs:22:22:22:24 | String arg | BreakInTry.cs:30:13:33:13 | {...} |
 | pre | BreakInTry.cs:22:22:22:24 | String arg | BreakInTry.cs:32:21:32:21 | ; |
-| pre | BreakInTry.cs:22:22:22:24 | String arg | BreakInTry.cs:32:21:32:21 | [break] ; |
+| pre | BreakInTry.cs:22:22:22:24 | String arg | BreakInTry.cs:32:21:32:21 | [finally: break] ; |
 | pre | BreakInTry.cs:27:21:27:26 | break; | BreakInTry.cs:27:21:27:26 | break; |
-| pre | BreakInTry.cs:27:21:27:26 | break; | BreakInTry.cs:32:21:32:21 | [break] ; |
+| pre | BreakInTry.cs:27:21:27:26 | break; | BreakInTry.cs:32:21:32:21 | [finally: break] ; |
 | pre | BreakInTry.cs:30:13:33:13 | {...} | BreakInTry.cs:30:13:33:13 | {...} |
 | pre | BreakInTry.cs:30:13:33:13 | {...} | BreakInTry.cs:32:21:32:21 | ; |
 | pre | BreakInTry.cs:32:21:32:21 | ; | BreakInTry.cs:32:21:32:21 | ; |
-| pre | BreakInTry.cs:32:21:32:21 | [break] ; | BreakInTry.cs:32:21:32:21 | [break] ; |
+| pre | BreakInTry.cs:32:21:32:21 | [finally: break] ; | BreakInTry.cs:32:21:32:21 | [finally: break] ; |
 | pre | BreakInTry.cs:35:7:35:7 | ; | BreakInTry.cs:35:7:35:7 | ; |
 | pre | BreakInTry.cs:38:10:38:11 | enter M3 | BreakInTry.cs:38:10:38:11 | enter M3 |
 | pre | BreakInTry.cs:38:10:38:11 | enter M3 | BreakInTry.cs:38:10:38:11 | exit M3 |
 | pre | BreakInTry.cs:38:10:38:11 | enter M3 | BreakInTry.cs:43:17:43:23 | return ...; |
 | pre | BreakInTry.cs:38:10:38:11 | enter M3 | BreakInTry.cs:46:9:52:9 | {...} |
-| pre | BreakInTry.cs:38:10:38:11 | enter M3 | BreakInTry.cs:47:13:51:13 | [return] foreach (... ... in ...) ... |
+| pre | BreakInTry.cs:38:10:38:11 | enter M3 | BreakInTry.cs:47:13:51:13 | [finally: return] foreach (... ... in ...) ... |
 | pre | BreakInTry.cs:38:10:38:11 | enter M3 | BreakInTry.cs:47:13:51:13 | foreach (... ... in ...) ... |
 | pre | BreakInTry.cs:38:10:38:11 | enter M3 | BreakInTry.cs:47:26:47:28 | String arg |
-| pre | BreakInTry.cs:38:10:38:11 | enter M3 | BreakInTry.cs:47:26:47:28 | [return] String arg |
-| pre | BreakInTry.cs:38:10:38:11 | enter M3 | BreakInTry.cs:50:21:50:26 | [return] break; |
+| pre | BreakInTry.cs:38:10:38:11 | enter M3 | BreakInTry.cs:47:26:47:28 | [finally: return] String arg |
+| pre | BreakInTry.cs:38:10:38:11 | enter M3 | BreakInTry.cs:50:21:50:26 | [finally: return] break; |
 | pre | BreakInTry.cs:38:10:38:11 | enter M3 | BreakInTry.cs:50:21:50:26 | break; |
 | pre | BreakInTry.cs:38:10:38:11 | enter M3 | BreakInTry.cs:53:7:53:7 | ; |
 | pre | BreakInTry.cs:38:10:38:11 | exit M3 | BreakInTry.cs:38:10:38:11 | exit M3 |
 | pre | BreakInTry.cs:43:17:43:23 | return ...; | BreakInTry.cs:43:17:43:23 | return ...; |
-| pre | BreakInTry.cs:43:17:43:23 | return ...; | BreakInTry.cs:47:13:51:13 | [return] foreach (... ... in ...) ... |
-| pre | BreakInTry.cs:43:17:43:23 | return ...; | BreakInTry.cs:47:26:47:28 | [return] String arg |
-| pre | BreakInTry.cs:43:17:43:23 | return ...; | BreakInTry.cs:50:21:50:26 | [return] break; |
+| pre | BreakInTry.cs:43:17:43:23 | return ...; | BreakInTry.cs:47:13:51:13 | [finally: return] foreach (... ... in ...) ... |
+| pre | BreakInTry.cs:43:17:43:23 | return ...; | BreakInTry.cs:47:26:47:28 | [finally: return] String arg |
+| pre | BreakInTry.cs:43:17:43:23 | return ...; | BreakInTry.cs:50:21:50:26 | [finally: return] break; |
 | pre | BreakInTry.cs:46:9:52:9 | {...} | BreakInTry.cs:46:9:52:9 | {...} |
 | pre | BreakInTry.cs:46:9:52:9 | {...} | BreakInTry.cs:47:13:51:13 | foreach (... ... in ...) ... |
 | pre | BreakInTry.cs:46:9:52:9 | {...} | BreakInTry.cs:47:26:47:28 | String arg |
 | pre | BreakInTry.cs:46:9:52:9 | {...} | BreakInTry.cs:50:21:50:26 | break; |
 | pre | BreakInTry.cs:46:9:52:9 | {...} | BreakInTry.cs:53:7:53:7 | ; |
-| pre | BreakInTry.cs:47:13:51:13 | [return] foreach (... ... in ...) ... | BreakInTry.cs:47:13:51:13 | [return] foreach (... ... in ...) ... |
-| pre | BreakInTry.cs:47:13:51:13 | [return] foreach (... ... in ...) ... | BreakInTry.cs:47:26:47:28 | [return] String arg |
-| pre | BreakInTry.cs:47:13:51:13 | [return] foreach (... ... in ...) ... | BreakInTry.cs:50:21:50:26 | [return] break; |
+| pre | BreakInTry.cs:47:13:51:13 | [finally: return] foreach (... ... in ...) ... | BreakInTry.cs:47:13:51:13 | [finally: return] foreach (... ... in ...) ... |
+| pre | BreakInTry.cs:47:13:51:13 | [finally: return] foreach (... ... in ...) ... | BreakInTry.cs:47:26:47:28 | [finally: return] String arg |
+| pre | BreakInTry.cs:47:13:51:13 | [finally: return] foreach (... ... in ...) ... | BreakInTry.cs:50:21:50:26 | [finally: return] break; |
 | pre | BreakInTry.cs:47:13:51:13 | foreach (... ... in ...) ... | BreakInTry.cs:47:13:51:13 | foreach (... ... in ...) ... |
 | pre | BreakInTry.cs:47:13:51:13 | foreach (... ... in ...) ... | BreakInTry.cs:47:26:47:28 | String arg |
 | pre | BreakInTry.cs:47:13:51:13 | foreach (... ... in ...) ... | BreakInTry.cs:50:21:50:26 | break; |
 | pre | BreakInTry.cs:47:13:51:13 | foreach (... ... in ...) ... | BreakInTry.cs:53:7:53:7 | ; |
 | pre | BreakInTry.cs:47:26:47:28 | String arg | BreakInTry.cs:47:26:47:28 | String arg |
 | pre | BreakInTry.cs:47:26:47:28 | String arg | BreakInTry.cs:50:21:50:26 | break; |
-| pre | BreakInTry.cs:47:26:47:28 | [return] String arg | BreakInTry.cs:47:26:47:28 | [return] String arg |
-| pre | BreakInTry.cs:47:26:47:28 | [return] String arg | BreakInTry.cs:50:21:50:26 | [return] break; |
-| pre | BreakInTry.cs:50:21:50:26 | [return] break; | BreakInTry.cs:50:21:50:26 | [return] break; |
+| pre | BreakInTry.cs:47:26:47:28 | [finally: return] String arg | BreakInTry.cs:47:26:47:28 | [finally: return] String arg |
+| pre | BreakInTry.cs:47:26:47:28 | [finally: return] String arg | BreakInTry.cs:50:21:50:26 | [finally: return] break; |
+| pre | BreakInTry.cs:50:21:50:26 | [finally: return] break; | BreakInTry.cs:50:21:50:26 | [finally: return] break; |
 | pre | BreakInTry.cs:50:21:50:26 | break; | BreakInTry.cs:50:21:50:26 | break; |
 | pre | BreakInTry.cs:53:7:53:7 | ; | BreakInTry.cs:53:7:53:7 | ; |
 | pre | BreakInTry.cs:56:10:56:11 | enter M4 | BreakInTry.cs:56:10:56:11 | enter M4 |
 | pre | BreakInTry.cs:56:10:56:11 | enter M4 | BreakInTry.cs:56:10:56:11 | exit M4 |
 | pre | BreakInTry.cs:56:10:56:11 | enter M4 | BreakInTry.cs:61:17:61:23 | return ...; |
 | pre | BreakInTry.cs:56:10:56:11 | enter M4 | BreakInTry.cs:64:9:70:9 | {...} |
-| pre | BreakInTry.cs:56:10:56:11 | enter M4 | BreakInTry.cs:65:13:69:13 | [return] foreach (... ... in ...) ... |
+| pre | BreakInTry.cs:56:10:56:11 | enter M4 | BreakInTry.cs:65:13:69:13 | [finally: return] foreach (... ... in ...) ... |
 | pre | BreakInTry.cs:56:10:56:11 | enter M4 | BreakInTry.cs:65:13:69:13 | foreach (... ... in ...) ... |
 | pre | BreakInTry.cs:56:10:56:11 | enter M4 | BreakInTry.cs:65:26:65:28 | String arg |
-| pre | BreakInTry.cs:56:10:56:11 | enter M4 | BreakInTry.cs:65:26:65:28 | [return] String arg |
-| pre | BreakInTry.cs:56:10:56:11 | enter M4 | BreakInTry.cs:68:21:68:26 | [return] break; |
+| pre | BreakInTry.cs:56:10:56:11 | enter M4 | BreakInTry.cs:65:26:65:28 | [finally: return] String arg |
+| pre | BreakInTry.cs:56:10:56:11 | enter M4 | BreakInTry.cs:68:21:68:26 | [finally: return] break; |
 | pre | BreakInTry.cs:56:10:56:11 | enter M4 | BreakInTry.cs:68:21:68:26 | break; |
 | pre | BreakInTry.cs:56:10:56:11 | exit M4 | BreakInTry.cs:56:10:56:11 | exit M4 |
 | pre | BreakInTry.cs:61:17:61:23 | return ...; | BreakInTry.cs:61:17:61:23 | return ...; |
-| pre | BreakInTry.cs:61:17:61:23 | return ...; | BreakInTry.cs:65:13:69:13 | [return] foreach (... ... in ...) ... |
-| pre | BreakInTry.cs:61:17:61:23 | return ...; | BreakInTry.cs:65:26:65:28 | [return] String arg |
-| pre | BreakInTry.cs:61:17:61:23 | return ...; | BreakInTry.cs:68:21:68:26 | [return] break; |
+| pre | BreakInTry.cs:61:17:61:23 | return ...; | BreakInTry.cs:65:13:69:13 | [finally: return] foreach (... ... in ...) ... |
+| pre | BreakInTry.cs:61:17:61:23 | return ...; | BreakInTry.cs:65:26:65:28 | [finally: return] String arg |
+| pre | BreakInTry.cs:61:17:61:23 | return ...; | BreakInTry.cs:68:21:68:26 | [finally: return] break; |
 | pre | BreakInTry.cs:64:9:70:9 | {...} | BreakInTry.cs:64:9:70:9 | {...} |
 | pre | BreakInTry.cs:64:9:70:9 | {...} | BreakInTry.cs:65:13:69:13 | foreach (... ... in ...) ... |
 | pre | BreakInTry.cs:64:9:70:9 | {...} | BreakInTry.cs:65:26:65:28 | String arg |
 | pre | BreakInTry.cs:64:9:70:9 | {...} | BreakInTry.cs:68:21:68:26 | break; |
-| pre | BreakInTry.cs:65:13:69:13 | [return] foreach (... ... in ...) ... | BreakInTry.cs:65:13:69:13 | [return] foreach (... ... in ...) ... |
-| pre | BreakInTry.cs:65:13:69:13 | [return] foreach (... ... in ...) ... | BreakInTry.cs:65:26:65:28 | [return] String arg |
-| pre | BreakInTry.cs:65:13:69:13 | [return] foreach (... ... in ...) ... | BreakInTry.cs:68:21:68:26 | [return] break; |
+| pre | BreakInTry.cs:65:13:69:13 | [finally: return] foreach (... ... in ...) ... | BreakInTry.cs:65:13:69:13 | [finally: return] foreach (... ... in ...) ... |
+| pre | BreakInTry.cs:65:13:69:13 | [finally: return] foreach (... ... in ...) ... | BreakInTry.cs:65:26:65:28 | [finally: return] String arg |
+| pre | BreakInTry.cs:65:13:69:13 | [finally: return] foreach (... ... in ...) ... | BreakInTry.cs:68:21:68:26 | [finally: return] break; |
 | pre | BreakInTry.cs:65:13:69:13 | foreach (... ... in ...) ... | BreakInTry.cs:65:13:69:13 | foreach (... ... in ...) ... |
 | pre | BreakInTry.cs:65:13:69:13 | foreach (... ... in ...) ... | BreakInTry.cs:65:26:65:28 | String arg |
 | pre | BreakInTry.cs:65:13:69:13 | foreach (... ... in ...) ... | BreakInTry.cs:68:21:68:26 | break; |
 | pre | BreakInTry.cs:65:26:65:28 | String arg | BreakInTry.cs:65:26:65:28 | String arg |
 | pre | BreakInTry.cs:65:26:65:28 | String arg | BreakInTry.cs:68:21:68:26 | break; |
-| pre | BreakInTry.cs:65:26:65:28 | [return] String arg | BreakInTry.cs:65:26:65:28 | [return] String arg |
-| pre | BreakInTry.cs:65:26:65:28 | [return] String arg | BreakInTry.cs:68:21:68:26 | [return] break; |
-| pre | BreakInTry.cs:68:21:68:26 | [return] break; | BreakInTry.cs:68:21:68:26 | [return] break; |
+| pre | BreakInTry.cs:65:26:65:28 | [finally: return] String arg | BreakInTry.cs:65:26:65:28 | [finally: return] String arg |
+| pre | BreakInTry.cs:65:26:65:28 | [finally: return] String arg | BreakInTry.cs:68:21:68:26 | [finally: return] break; |
+| pre | BreakInTry.cs:68:21:68:26 | [finally: return] break; | BreakInTry.cs:68:21:68:26 | [finally: return] break; |
 | pre | BreakInTry.cs:68:21:68:26 | break; | BreakInTry.cs:68:21:68:26 | break; |
 | pre | CompileTimeOperators.cs:5:9:5:15 | enter Default | CompileTimeOperators.cs:5:9:5:15 | enter Default |
 | pre | CompileTimeOperators.cs:10:9:10:14 | enter Sizeof | CompileTimeOperators.cs:10:9:10:14 | enter Sizeof |
@@ -1807,8 +1807,8 @@
 | pre | cflow.cs:146:10:146:19 | enter TryFinally | cflow.cs:146:10:146:19 | enter TryFinally |
 | pre | cflow.cs:146:10:146:19 | enter TryFinally | cflow.cs:146:10:146:19 | exit TryFinally |
 | pre | cflow.cs:146:10:146:19 | enter TryFinally | cflow.cs:150:13:150:37 | call to method WriteLine |
-| pre | cflow.cs:146:10:146:19 | enter TryFinally | cflow.cs:153:9:155:9 | [exception(Exception)] {...} |
-| pre | cflow.cs:146:10:146:19 | enter TryFinally | cflow.cs:153:9:155:9 | [exception(OutOfMemoryException)] {...} |
+| pre | cflow.cs:146:10:146:19 | enter TryFinally | cflow.cs:153:9:155:9 | [finally: exception(Exception)] {...} |
+| pre | cflow.cs:146:10:146:19 | enter TryFinally | cflow.cs:153:9:155:9 | [finally: exception(OutOfMemoryException)] {...} |
 | pre | cflow.cs:146:10:146:19 | enter TryFinally | cflow.cs:153:9:155:9 | {...} |
 | pre | cflow.cs:146:10:146:19 | enter TryFinally | cflow.cs:159:13:159:37 | call to method WriteLine |
 | pre | cflow.cs:146:10:146:19 | enter TryFinally | cflow.cs:160:13:160:19 | return ...; |
@@ -1819,8 +1819,8 @@
 | pre | cflow.cs:146:10:146:19 | enter TryFinally | cflow.cs:192:13:192:19 | return ...; |
 | pre | cflow.cs:146:10:146:19 | enter TryFinally | cflow.cs:194:9:197:9 | catch (...) {...} |
 | pre | cflow.cs:146:10:146:19 | enter TryFinally | cflow.cs:198:9:200:9 | catch (...) {...} |
-| pre | cflow.cs:146:10:146:19 | enter TryFinally | cflow.cs:202:9:204:9 | [exception(Exception)] {...} |
-| pre | cflow.cs:146:10:146:19 | enter TryFinally | cflow.cs:202:9:204:9 | [exception(OutOfMemoryException)] {...} |
+| pre | cflow.cs:146:10:146:19 | enter TryFinally | cflow.cs:202:9:204:9 | [finally: exception(Exception)] {...} |
+| pre | cflow.cs:146:10:146:19 | enter TryFinally | cflow.cs:202:9:204:9 | [finally: exception(OutOfMemoryException)] {...} |
 | pre | cflow.cs:146:10:146:19 | enter TryFinally | cflow.cs:207:16:207:16 | access to local variable i |
 | pre | cflow.cs:146:10:146:19 | enter TryFinally | cflow.cs:208:9:230:9 | {...} |
 | pre | cflow.cs:146:10:146:19 | enter TryFinally | cflow.cs:212:21:212:27 | return ...; |
@@ -1829,18 +1829,18 @@
 | pre | cflow.cs:146:10:146:19 | enter TryFinally | cflow.cs:215:17:216:26 | if (...) ... |
 | pre | cflow.cs:146:10:146:19 | enter TryFinally | cflow.cs:216:21:216:26 | break; |
 | pre | cflow.cs:146:10:146:19 | enter TryFinally | cflow.cs:219:13:229:13 | {...} |
-| pre | cflow.cs:146:10:146:19 | enter TryFinally | cflow.cs:223:25:223:46 | [break] throw ...; |
-| pre | cflow.cs:146:10:146:19 | enter TryFinally | cflow.cs:223:25:223:46 | [continue] throw ...; |
-| pre | cflow.cs:146:10:146:19 | enter TryFinally | cflow.cs:223:25:223:46 | [return] throw ...; |
+| pre | cflow.cs:146:10:146:19 | enter TryFinally | cflow.cs:223:25:223:46 | [finally: break] throw ...; |
+| pre | cflow.cs:146:10:146:19 | enter TryFinally | cflow.cs:223:25:223:46 | [finally: continue] throw ...; |
+| pre | cflow.cs:146:10:146:19 | enter TryFinally | cflow.cs:223:25:223:46 | [finally: return] throw ...; |
 | pre | cflow.cs:146:10:146:19 | enter TryFinally | cflow.cs:223:25:223:46 | throw ...; |
-| pre | cflow.cs:146:10:146:19 | enter TryFinally | cflow.cs:223:31:223:45 | [break] object creation of type Exception |
-| pre | cflow.cs:146:10:146:19 | enter TryFinally | cflow.cs:223:31:223:45 | [continue] object creation of type Exception |
-| pre | cflow.cs:146:10:146:19 | enter TryFinally | cflow.cs:223:31:223:45 | [return] object creation of type Exception |
+| pre | cflow.cs:146:10:146:19 | enter TryFinally | cflow.cs:223:31:223:45 | [finally: break] object creation of type Exception |
+| pre | cflow.cs:146:10:146:19 | enter TryFinally | cflow.cs:223:31:223:45 | [finally: continue] object creation of type Exception |
+| pre | cflow.cs:146:10:146:19 | enter TryFinally | cflow.cs:223:31:223:45 | [finally: return] object creation of type Exception |
 | pre | cflow.cs:146:10:146:19 | enter TryFinally | cflow.cs:223:31:223:45 | object creation of type Exception |
-| pre | cflow.cs:146:10:146:19 | enter TryFinally | cflow.cs:226:17:228:17 | [break] {...} |
-| pre | cflow.cs:146:10:146:19 | enter TryFinally | cflow.cs:226:17:228:17 | [continue] {...} |
-| pre | cflow.cs:146:10:146:19 | enter TryFinally | cflow.cs:226:17:228:17 | [exception(Exception)] {...} |
-| pre | cflow.cs:146:10:146:19 | enter TryFinally | cflow.cs:226:17:228:17 | [return] {...} |
+| pre | cflow.cs:146:10:146:19 | enter TryFinally | cflow.cs:226:17:228:17 | [finally: break] {...} |
+| pre | cflow.cs:146:10:146:19 | enter TryFinally | cflow.cs:226:17:228:17 | [finally: continue] {...} |
+| pre | cflow.cs:146:10:146:19 | enter TryFinally | cflow.cs:226:17:228:17 | [finally: exception(Exception)] {...} |
+| pre | cflow.cs:146:10:146:19 | enter TryFinally | cflow.cs:226:17:228:17 | [finally: return] {...} |
 | pre | cflow.cs:146:10:146:19 | enter TryFinally | cflow.cs:226:17:228:17 | {...} |
 | pre | cflow.cs:146:10:146:19 | enter TryFinally | cflow.cs:232:9:245:9 | try {...} ... |
 | pre | cflow.cs:146:10:146:19 | enter TryFinally | cflow.cs:234:17:234:28 | access to property Length |
@@ -1851,27 +1851,27 @@
 | pre | cflow.cs:146:10:146:19 | enter TryFinally | cflow.cs:236:33:236:33 | 1 |
 | pre | cflow.cs:146:10:146:19 | enter TryFinally | cflow.cs:237:17:237:49 | throw ...; |
 | pre | cflow.cs:146:10:146:19 | enter TryFinally | cflow.cs:237:23:237:48 | object creation of type OutOfMemoryException |
-| pre | cflow.cs:146:10:146:19 | enter TryFinally | cflow.cs:240:9:245:9 | [exception(Exception)] {...} |
-| pre | cflow.cs:146:10:146:19 | enter TryFinally | cflow.cs:240:9:245:9 | [exception(NullReferenceException)] {...} |
+| pre | cflow.cs:146:10:146:19 | enter TryFinally | cflow.cs:240:9:245:9 | [finally: exception(Exception)] {...} |
+| pre | cflow.cs:146:10:146:19 | enter TryFinally | cflow.cs:240:9:245:9 | [finally: exception(NullReferenceException)] {...} |
 | pre | cflow.cs:146:10:146:19 | enter TryFinally | cflow.cs:240:9:245:9 | {...} |
 | pre | cflow.cs:146:10:146:19 | enter TryFinally | cflow.cs:242:17:242:41 | ...; |
-| pre | cflow.cs:146:10:146:19 | enter TryFinally | cflow.cs:242:17:242:41 | [exception(Exception)] ...; |
-| pre | cflow.cs:146:10:146:19 | enter TryFinally | cflow.cs:242:17:242:41 | [exception(NullReferenceException)] ...; |
-| pre | cflow.cs:146:10:146:19 | enter TryFinally | cflow.cs:242:17:242:41 | [exception(OutOfMemoryException)] ...; |
-| pre | cflow.cs:146:10:146:19 | enter TryFinally | cflow.cs:242:17:242:41 | [return] ...; |
-| pre | cflow.cs:146:10:146:19 | enter TryFinally | cflow.cs:243:13:244:37 | [exception(Exception)] if (...) ... |
-| pre | cflow.cs:146:10:146:19 | enter TryFinally | cflow.cs:243:13:244:37 | [exception(NullReferenceException)] if (...) ... |
-| pre | cflow.cs:146:10:146:19 | enter TryFinally | cflow.cs:243:13:244:37 | [exception(OutOfMemoryException)] if (...) ... |
-| pre | cflow.cs:146:10:146:19 | enter TryFinally | cflow.cs:243:13:244:37 | [return] if (...) ... |
+| pre | cflow.cs:146:10:146:19 | enter TryFinally | cflow.cs:242:17:242:41 | [finally: exception(Exception)] ...; |
+| pre | cflow.cs:146:10:146:19 | enter TryFinally | cflow.cs:242:17:242:41 | [finally: exception(NullReferenceException)] ...; |
+| pre | cflow.cs:146:10:146:19 | enter TryFinally | cflow.cs:242:17:242:41 | [finally: exception(OutOfMemoryException)] ...; |
+| pre | cflow.cs:146:10:146:19 | enter TryFinally | cflow.cs:242:17:242:41 | [finally: return] ...; |
+| pre | cflow.cs:146:10:146:19 | enter TryFinally | cflow.cs:243:13:244:37 | [finally: exception(Exception)] if (...) ... |
+| pre | cflow.cs:146:10:146:19 | enter TryFinally | cflow.cs:243:13:244:37 | [finally: exception(NullReferenceException)] if (...) ... |
+| pre | cflow.cs:146:10:146:19 | enter TryFinally | cflow.cs:243:13:244:37 | [finally: exception(OutOfMemoryException)] if (...) ... |
+| pre | cflow.cs:146:10:146:19 | enter TryFinally | cflow.cs:243:13:244:37 | [finally: return] if (...) ... |
 | pre | cflow.cs:146:10:146:19 | enter TryFinally | cflow.cs:243:13:244:37 | if (...) ... |
 | pre | cflow.cs:146:10:146:19 | enter TryFinally | cflow.cs:244:17:244:37 | ...; |
-| pre | cflow.cs:146:10:146:19 | enter TryFinally | cflow.cs:244:17:244:37 | [exception(Exception)] ...; |
-| pre | cflow.cs:146:10:146:19 | enter TryFinally | cflow.cs:244:17:244:37 | [exception(NullReferenceException)] ...; |
-| pre | cflow.cs:146:10:146:19 | enter TryFinally | cflow.cs:244:17:244:37 | [exception(OutOfMemoryException)] ...; |
-| pre | cflow.cs:146:10:146:19 | enter TryFinally | cflow.cs:244:17:244:37 | [return] ...; |
+| pre | cflow.cs:146:10:146:19 | enter TryFinally | cflow.cs:244:17:244:37 | [finally: exception(Exception)] ...; |
+| pre | cflow.cs:146:10:146:19 | enter TryFinally | cflow.cs:244:17:244:37 | [finally: exception(NullReferenceException)] ...; |
+| pre | cflow.cs:146:10:146:19 | enter TryFinally | cflow.cs:244:17:244:37 | [finally: exception(OutOfMemoryException)] ...; |
+| pre | cflow.cs:146:10:146:19 | enter TryFinally | cflow.cs:244:17:244:37 | [finally: return] ...; |
 | pre | cflow.cs:146:10:146:19 | exit TryFinally | cflow.cs:146:10:146:19 | exit TryFinally |
 | pre | cflow.cs:150:13:150:37 | call to method WriteLine | cflow.cs:150:13:150:37 | call to method WriteLine |
-| pre | cflow.cs:150:13:150:37 | call to method WriteLine | cflow.cs:153:9:155:9 | [exception(Exception)] {...} |
+| pre | cflow.cs:150:13:150:37 | call to method WriteLine | cflow.cs:153:9:155:9 | [finally: exception(Exception)] {...} |
 | pre | cflow.cs:150:13:150:37 | call to method WriteLine | cflow.cs:153:9:155:9 | {...} |
 | pre | cflow.cs:150:13:150:37 | call to method WriteLine | cflow.cs:159:13:159:37 | call to method WriteLine |
 | pre | cflow.cs:150:13:150:37 | call to method WriteLine | cflow.cs:160:13:160:19 | return ...; |
@@ -1882,8 +1882,8 @@
 | pre | cflow.cs:150:13:150:37 | call to method WriteLine | cflow.cs:192:13:192:19 | return ...; |
 | pre | cflow.cs:150:13:150:37 | call to method WriteLine | cflow.cs:194:9:197:9 | catch (...) {...} |
 | pre | cflow.cs:150:13:150:37 | call to method WriteLine | cflow.cs:198:9:200:9 | catch (...) {...} |
-| pre | cflow.cs:150:13:150:37 | call to method WriteLine | cflow.cs:202:9:204:9 | [exception(Exception)] {...} |
-| pre | cflow.cs:150:13:150:37 | call to method WriteLine | cflow.cs:202:9:204:9 | [exception(OutOfMemoryException)] {...} |
+| pre | cflow.cs:150:13:150:37 | call to method WriteLine | cflow.cs:202:9:204:9 | [finally: exception(Exception)] {...} |
+| pre | cflow.cs:150:13:150:37 | call to method WriteLine | cflow.cs:202:9:204:9 | [finally: exception(OutOfMemoryException)] {...} |
 | pre | cflow.cs:150:13:150:37 | call to method WriteLine | cflow.cs:207:16:207:16 | access to local variable i |
 | pre | cflow.cs:150:13:150:37 | call to method WriteLine | cflow.cs:208:9:230:9 | {...} |
 | pre | cflow.cs:150:13:150:37 | call to method WriteLine | cflow.cs:212:21:212:27 | return ...; |
@@ -1892,18 +1892,18 @@
 | pre | cflow.cs:150:13:150:37 | call to method WriteLine | cflow.cs:215:17:216:26 | if (...) ... |
 | pre | cflow.cs:150:13:150:37 | call to method WriteLine | cflow.cs:216:21:216:26 | break; |
 | pre | cflow.cs:150:13:150:37 | call to method WriteLine | cflow.cs:219:13:229:13 | {...} |
-| pre | cflow.cs:150:13:150:37 | call to method WriteLine | cflow.cs:223:25:223:46 | [break] throw ...; |
-| pre | cflow.cs:150:13:150:37 | call to method WriteLine | cflow.cs:223:25:223:46 | [continue] throw ...; |
-| pre | cflow.cs:150:13:150:37 | call to method WriteLine | cflow.cs:223:25:223:46 | [return] throw ...; |
+| pre | cflow.cs:150:13:150:37 | call to method WriteLine | cflow.cs:223:25:223:46 | [finally: break] throw ...; |
+| pre | cflow.cs:150:13:150:37 | call to method WriteLine | cflow.cs:223:25:223:46 | [finally: continue] throw ...; |
+| pre | cflow.cs:150:13:150:37 | call to method WriteLine | cflow.cs:223:25:223:46 | [finally: return] throw ...; |
 | pre | cflow.cs:150:13:150:37 | call to method WriteLine | cflow.cs:223:25:223:46 | throw ...; |
-| pre | cflow.cs:150:13:150:37 | call to method WriteLine | cflow.cs:223:31:223:45 | [break] object creation of type Exception |
-| pre | cflow.cs:150:13:150:37 | call to method WriteLine | cflow.cs:223:31:223:45 | [continue] object creation of type Exception |
-| pre | cflow.cs:150:13:150:37 | call to method WriteLine | cflow.cs:223:31:223:45 | [return] object creation of type Exception |
+| pre | cflow.cs:150:13:150:37 | call to method WriteLine | cflow.cs:223:31:223:45 | [finally: break] object creation of type Exception |
+| pre | cflow.cs:150:13:150:37 | call to method WriteLine | cflow.cs:223:31:223:45 | [finally: continue] object creation of type Exception |
+| pre | cflow.cs:150:13:150:37 | call to method WriteLine | cflow.cs:223:31:223:45 | [finally: return] object creation of type Exception |
 | pre | cflow.cs:150:13:150:37 | call to method WriteLine | cflow.cs:223:31:223:45 | object creation of type Exception |
-| pre | cflow.cs:150:13:150:37 | call to method WriteLine | cflow.cs:226:17:228:17 | [break] {...} |
-| pre | cflow.cs:150:13:150:37 | call to method WriteLine | cflow.cs:226:17:228:17 | [continue] {...} |
-| pre | cflow.cs:150:13:150:37 | call to method WriteLine | cflow.cs:226:17:228:17 | [exception(Exception)] {...} |
-| pre | cflow.cs:150:13:150:37 | call to method WriteLine | cflow.cs:226:17:228:17 | [return] {...} |
+| pre | cflow.cs:150:13:150:37 | call to method WriteLine | cflow.cs:226:17:228:17 | [finally: break] {...} |
+| pre | cflow.cs:150:13:150:37 | call to method WriteLine | cflow.cs:226:17:228:17 | [finally: continue] {...} |
+| pre | cflow.cs:150:13:150:37 | call to method WriteLine | cflow.cs:226:17:228:17 | [finally: exception(Exception)] {...} |
+| pre | cflow.cs:150:13:150:37 | call to method WriteLine | cflow.cs:226:17:228:17 | [finally: return] {...} |
 | pre | cflow.cs:150:13:150:37 | call to method WriteLine | cflow.cs:226:17:228:17 | {...} |
 | pre | cflow.cs:150:13:150:37 | call to method WriteLine | cflow.cs:232:9:245:9 | try {...} ... |
 | pre | cflow.cs:150:13:150:37 | call to method WriteLine | cflow.cs:234:17:234:28 | access to property Length |
@@ -1914,26 +1914,26 @@
 | pre | cflow.cs:150:13:150:37 | call to method WriteLine | cflow.cs:236:33:236:33 | 1 |
 | pre | cflow.cs:150:13:150:37 | call to method WriteLine | cflow.cs:237:17:237:49 | throw ...; |
 | pre | cflow.cs:150:13:150:37 | call to method WriteLine | cflow.cs:237:23:237:48 | object creation of type OutOfMemoryException |
-| pre | cflow.cs:150:13:150:37 | call to method WriteLine | cflow.cs:240:9:245:9 | [exception(Exception)] {...} |
-| pre | cflow.cs:150:13:150:37 | call to method WriteLine | cflow.cs:240:9:245:9 | [exception(NullReferenceException)] {...} |
+| pre | cflow.cs:150:13:150:37 | call to method WriteLine | cflow.cs:240:9:245:9 | [finally: exception(Exception)] {...} |
+| pre | cflow.cs:150:13:150:37 | call to method WriteLine | cflow.cs:240:9:245:9 | [finally: exception(NullReferenceException)] {...} |
 | pre | cflow.cs:150:13:150:37 | call to method WriteLine | cflow.cs:240:9:245:9 | {...} |
 | pre | cflow.cs:150:13:150:37 | call to method WriteLine | cflow.cs:242:17:242:41 | ...; |
-| pre | cflow.cs:150:13:150:37 | call to method WriteLine | cflow.cs:242:17:242:41 | [exception(Exception)] ...; |
-| pre | cflow.cs:150:13:150:37 | call to method WriteLine | cflow.cs:242:17:242:41 | [exception(NullReferenceException)] ...; |
-| pre | cflow.cs:150:13:150:37 | call to method WriteLine | cflow.cs:242:17:242:41 | [exception(OutOfMemoryException)] ...; |
-| pre | cflow.cs:150:13:150:37 | call to method WriteLine | cflow.cs:242:17:242:41 | [return] ...; |
-| pre | cflow.cs:150:13:150:37 | call to method WriteLine | cflow.cs:243:13:244:37 | [exception(Exception)] if (...) ... |
-| pre | cflow.cs:150:13:150:37 | call to method WriteLine | cflow.cs:243:13:244:37 | [exception(NullReferenceException)] if (...) ... |
-| pre | cflow.cs:150:13:150:37 | call to method WriteLine | cflow.cs:243:13:244:37 | [exception(OutOfMemoryException)] if (...) ... |
-| pre | cflow.cs:150:13:150:37 | call to method WriteLine | cflow.cs:243:13:244:37 | [return] if (...) ... |
+| pre | cflow.cs:150:13:150:37 | call to method WriteLine | cflow.cs:242:17:242:41 | [finally: exception(Exception)] ...; |
+| pre | cflow.cs:150:13:150:37 | call to method WriteLine | cflow.cs:242:17:242:41 | [finally: exception(NullReferenceException)] ...; |
+| pre | cflow.cs:150:13:150:37 | call to method WriteLine | cflow.cs:242:17:242:41 | [finally: exception(OutOfMemoryException)] ...; |
+| pre | cflow.cs:150:13:150:37 | call to method WriteLine | cflow.cs:242:17:242:41 | [finally: return] ...; |
+| pre | cflow.cs:150:13:150:37 | call to method WriteLine | cflow.cs:243:13:244:37 | [finally: exception(Exception)] if (...) ... |
+| pre | cflow.cs:150:13:150:37 | call to method WriteLine | cflow.cs:243:13:244:37 | [finally: exception(NullReferenceException)] if (...) ... |
+| pre | cflow.cs:150:13:150:37 | call to method WriteLine | cflow.cs:243:13:244:37 | [finally: exception(OutOfMemoryException)] if (...) ... |
+| pre | cflow.cs:150:13:150:37 | call to method WriteLine | cflow.cs:243:13:244:37 | [finally: return] if (...) ... |
 | pre | cflow.cs:150:13:150:37 | call to method WriteLine | cflow.cs:243:13:244:37 | if (...) ... |
 | pre | cflow.cs:150:13:150:37 | call to method WriteLine | cflow.cs:244:17:244:37 | ...; |
-| pre | cflow.cs:150:13:150:37 | call to method WriteLine | cflow.cs:244:17:244:37 | [exception(Exception)] ...; |
-| pre | cflow.cs:150:13:150:37 | call to method WriteLine | cflow.cs:244:17:244:37 | [exception(NullReferenceException)] ...; |
-| pre | cflow.cs:150:13:150:37 | call to method WriteLine | cflow.cs:244:17:244:37 | [exception(OutOfMemoryException)] ...; |
-| pre | cflow.cs:150:13:150:37 | call to method WriteLine | cflow.cs:244:17:244:37 | [return] ...; |
-| pre | cflow.cs:153:9:155:9 | [exception(Exception)] {...} | cflow.cs:153:9:155:9 | [exception(Exception)] {...} |
-| pre | cflow.cs:153:9:155:9 | [exception(OutOfMemoryException)] {...} | cflow.cs:153:9:155:9 | [exception(OutOfMemoryException)] {...} |
+| pre | cflow.cs:150:13:150:37 | call to method WriteLine | cflow.cs:244:17:244:37 | [finally: exception(Exception)] ...; |
+| pre | cflow.cs:150:13:150:37 | call to method WriteLine | cflow.cs:244:17:244:37 | [finally: exception(NullReferenceException)] ...; |
+| pre | cflow.cs:150:13:150:37 | call to method WriteLine | cflow.cs:244:17:244:37 | [finally: exception(OutOfMemoryException)] ...; |
+| pre | cflow.cs:150:13:150:37 | call to method WriteLine | cflow.cs:244:17:244:37 | [finally: return] ...; |
+| pre | cflow.cs:153:9:155:9 | [finally: exception(Exception)] {...} | cflow.cs:153:9:155:9 | [finally: exception(Exception)] {...} |
+| pre | cflow.cs:153:9:155:9 | [finally: exception(OutOfMemoryException)] {...} | cflow.cs:153:9:155:9 | [finally: exception(OutOfMemoryException)] {...} |
 | pre | cflow.cs:153:9:155:9 | {...} | cflow.cs:153:9:155:9 | {...} |
 | pre | cflow.cs:153:9:155:9 | {...} | cflow.cs:159:13:159:37 | call to method WriteLine |
 | pre | cflow.cs:153:9:155:9 | {...} | cflow.cs:160:13:160:19 | return ...; |
@@ -1944,8 +1944,8 @@
 | pre | cflow.cs:153:9:155:9 | {...} | cflow.cs:192:13:192:19 | return ...; |
 | pre | cflow.cs:153:9:155:9 | {...} | cflow.cs:194:9:197:9 | catch (...) {...} |
 | pre | cflow.cs:153:9:155:9 | {...} | cflow.cs:198:9:200:9 | catch (...) {...} |
-| pre | cflow.cs:153:9:155:9 | {...} | cflow.cs:202:9:204:9 | [exception(Exception)] {...} |
-| pre | cflow.cs:153:9:155:9 | {...} | cflow.cs:202:9:204:9 | [exception(OutOfMemoryException)] {...} |
+| pre | cflow.cs:153:9:155:9 | {...} | cflow.cs:202:9:204:9 | [finally: exception(Exception)] {...} |
+| pre | cflow.cs:153:9:155:9 | {...} | cflow.cs:202:9:204:9 | [finally: exception(OutOfMemoryException)] {...} |
 | pre | cflow.cs:153:9:155:9 | {...} | cflow.cs:207:16:207:16 | access to local variable i |
 | pre | cflow.cs:153:9:155:9 | {...} | cflow.cs:208:9:230:9 | {...} |
 | pre | cflow.cs:153:9:155:9 | {...} | cflow.cs:212:21:212:27 | return ...; |
@@ -1954,18 +1954,18 @@
 | pre | cflow.cs:153:9:155:9 | {...} | cflow.cs:215:17:216:26 | if (...) ... |
 | pre | cflow.cs:153:9:155:9 | {...} | cflow.cs:216:21:216:26 | break; |
 | pre | cflow.cs:153:9:155:9 | {...} | cflow.cs:219:13:229:13 | {...} |
-| pre | cflow.cs:153:9:155:9 | {...} | cflow.cs:223:25:223:46 | [break] throw ...; |
-| pre | cflow.cs:153:9:155:9 | {...} | cflow.cs:223:25:223:46 | [continue] throw ...; |
-| pre | cflow.cs:153:9:155:9 | {...} | cflow.cs:223:25:223:46 | [return] throw ...; |
+| pre | cflow.cs:153:9:155:9 | {...} | cflow.cs:223:25:223:46 | [finally: break] throw ...; |
+| pre | cflow.cs:153:9:155:9 | {...} | cflow.cs:223:25:223:46 | [finally: continue] throw ...; |
+| pre | cflow.cs:153:9:155:9 | {...} | cflow.cs:223:25:223:46 | [finally: return] throw ...; |
 | pre | cflow.cs:153:9:155:9 | {...} | cflow.cs:223:25:223:46 | throw ...; |
-| pre | cflow.cs:153:9:155:9 | {...} | cflow.cs:223:31:223:45 | [break] object creation of type Exception |
-| pre | cflow.cs:153:9:155:9 | {...} | cflow.cs:223:31:223:45 | [continue] object creation of type Exception |
-| pre | cflow.cs:153:9:155:9 | {...} | cflow.cs:223:31:223:45 | [return] object creation of type Exception |
+| pre | cflow.cs:153:9:155:9 | {...} | cflow.cs:223:31:223:45 | [finally: break] object creation of type Exception |
+| pre | cflow.cs:153:9:155:9 | {...} | cflow.cs:223:31:223:45 | [finally: continue] object creation of type Exception |
+| pre | cflow.cs:153:9:155:9 | {...} | cflow.cs:223:31:223:45 | [finally: return] object creation of type Exception |
 | pre | cflow.cs:153:9:155:9 | {...} | cflow.cs:223:31:223:45 | object creation of type Exception |
-| pre | cflow.cs:153:9:155:9 | {...} | cflow.cs:226:17:228:17 | [break] {...} |
-| pre | cflow.cs:153:9:155:9 | {...} | cflow.cs:226:17:228:17 | [continue] {...} |
-| pre | cflow.cs:153:9:155:9 | {...} | cflow.cs:226:17:228:17 | [exception(Exception)] {...} |
-| pre | cflow.cs:153:9:155:9 | {...} | cflow.cs:226:17:228:17 | [return] {...} |
+| pre | cflow.cs:153:9:155:9 | {...} | cflow.cs:226:17:228:17 | [finally: break] {...} |
+| pre | cflow.cs:153:9:155:9 | {...} | cflow.cs:226:17:228:17 | [finally: continue] {...} |
+| pre | cflow.cs:153:9:155:9 | {...} | cflow.cs:226:17:228:17 | [finally: exception(Exception)] {...} |
+| pre | cflow.cs:153:9:155:9 | {...} | cflow.cs:226:17:228:17 | [finally: return] {...} |
 | pre | cflow.cs:153:9:155:9 | {...} | cflow.cs:226:17:228:17 | {...} |
 | pre | cflow.cs:153:9:155:9 | {...} | cflow.cs:232:9:245:9 | try {...} ... |
 | pre | cflow.cs:153:9:155:9 | {...} | cflow.cs:234:17:234:28 | access to property Length |
@@ -1976,24 +1976,24 @@
 | pre | cflow.cs:153:9:155:9 | {...} | cflow.cs:236:33:236:33 | 1 |
 | pre | cflow.cs:153:9:155:9 | {...} | cflow.cs:237:17:237:49 | throw ...; |
 | pre | cflow.cs:153:9:155:9 | {...} | cflow.cs:237:23:237:48 | object creation of type OutOfMemoryException |
-| pre | cflow.cs:153:9:155:9 | {...} | cflow.cs:240:9:245:9 | [exception(Exception)] {...} |
-| pre | cflow.cs:153:9:155:9 | {...} | cflow.cs:240:9:245:9 | [exception(NullReferenceException)] {...} |
+| pre | cflow.cs:153:9:155:9 | {...} | cflow.cs:240:9:245:9 | [finally: exception(Exception)] {...} |
+| pre | cflow.cs:153:9:155:9 | {...} | cflow.cs:240:9:245:9 | [finally: exception(NullReferenceException)] {...} |
 | pre | cflow.cs:153:9:155:9 | {...} | cflow.cs:240:9:245:9 | {...} |
 | pre | cflow.cs:153:9:155:9 | {...} | cflow.cs:242:17:242:41 | ...; |
-| pre | cflow.cs:153:9:155:9 | {...} | cflow.cs:242:17:242:41 | [exception(Exception)] ...; |
-| pre | cflow.cs:153:9:155:9 | {...} | cflow.cs:242:17:242:41 | [exception(NullReferenceException)] ...; |
-| pre | cflow.cs:153:9:155:9 | {...} | cflow.cs:242:17:242:41 | [exception(OutOfMemoryException)] ...; |
-| pre | cflow.cs:153:9:155:9 | {...} | cflow.cs:242:17:242:41 | [return] ...; |
-| pre | cflow.cs:153:9:155:9 | {...} | cflow.cs:243:13:244:37 | [exception(Exception)] if (...) ... |
-| pre | cflow.cs:153:9:155:9 | {...} | cflow.cs:243:13:244:37 | [exception(NullReferenceException)] if (...) ... |
-| pre | cflow.cs:153:9:155:9 | {...} | cflow.cs:243:13:244:37 | [exception(OutOfMemoryException)] if (...) ... |
-| pre | cflow.cs:153:9:155:9 | {...} | cflow.cs:243:13:244:37 | [return] if (...) ... |
+| pre | cflow.cs:153:9:155:9 | {...} | cflow.cs:242:17:242:41 | [finally: exception(Exception)] ...; |
+| pre | cflow.cs:153:9:155:9 | {...} | cflow.cs:242:17:242:41 | [finally: exception(NullReferenceException)] ...; |
+| pre | cflow.cs:153:9:155:9 | {...} | cflow.cs:242:17:242:41 | [finally: exception(OutOfMemoryException)] ...; |
+| pre | cflow.cs:153:9:155:9 | {...} | cflow.cs:242:17:242:41 | [finally: return] ...; |
+| pre | cflow.cs:153:9:155:9 | {...} | cflow.cs:243:13:244:37 | [finally: exception(Exception)] if (...) ... |
+| pre | cflow.cs:153:9:155:9 | {...} | cflow.cs:243:13:244:37 | [finally: exception(NullReferenceException)] if (...) ... |
+| pre | cflow.cs:153:9:155:9 | {...} | cflow.cs:243:13:244:37 | [finally: exception(OutOfMemoryException)] if (...) ... |
+| pre | cflow.cs:153:9:155:9 | {...} | cflow.cs:243:13:244:37 | [finally: return] if (...) ... |
 | pre | cflow.cs:153:9:155:9 | {...} | cflow.cs:243:13:244:37 | if (...) ... |
 | pre | cflow.cs:153:9:155:9 | {...} | cflow.cs:244:17:244:37 | ...; |
-| pre | cflow.cs:153:9:155:9 | {...} | cflow.cs:244:17:244:37 | [exception(Exception)] ...; |
-| pre | cflow.cs:153:9:155:9 | {...} | cflow.cs:244:17:244:37 | [exception(NullReferenceException)] ...; |
-| pre | cflow.cs:153:9:155:9 | {...} | cflow.cs:244:17:244:37 | [exception(OutOfMemoryException)] ...; |
-| pre | cflow.cs:153:9:155:9 | {...} | cflow.cs:244:17:244:37 | [return] ...; |
+| pre | cflow.cs:153:9:155:9 | {...} | cflow.cs:244:17:244:37 | [finally: exception(Exception)] ...; |
+| pre | cflow.cs:153:9:155:9 | {...} | cflow.cs:244:17:244:37 | [finally: exception(NullReferenceException)] ...; |
+| pre | cflow.cs:153:9:155:9 | {...} | cflow.cs:244:17:244:37 | [finally: exception(OutOfMemoryException)] ...; |
+| pre | cflow.cs:153:9:155:9 | {...} | cflow.cs:244:17:244:37 | [finally: return] ...; |
 | pre | cflow.cs:159:13:159:37 | call to method WriteLine | cflow.cs:159:13:159:37 | call to method WriteLine |
 | pre | cflow.cs:159:13:159:37 | call to method WriteLine | cflow.cs:160:13:160:19 | return ...; |
 | pre | cflow.cs:159:13:159:37 | call to method WriteLine | cflow.cs:162:9:165:9 | catch (...) {...} |
@@ -2006,8 +2006,8 @@
 | pre | cflow.cs:177:9:179:9 | catch (...) {...} | cflow.cs:192:13:192:19 | return ...; |
 | pre | cflow.cs:177:9:179:9 | catch (...) {...} | cflow.cs:194:9:197:9 | catch (...) {...} |
 | pre | cflow.cs:177:9:179:9 | catch (...) {...} | cflow.cs:198:9:200:9 | catch (...) {...} |
-| pre | cflow.cs:177:9:179:9 | catch (...) {...} | cflow.cs:202:9:204:9 | [exception(Exception)] {...} |
-| pre | cflow.cs:177:9:179:9 | catch (...) {...} | cflow.cs:202:9:204:9 | [exception(OutOfMemoryException)] {...} |
+| pre | cflow.cs:177:9:179:9 | catch (...) {...} | cflow.cs:202:9:204:9 | [finally: exception(Exception)] {...} |
+| pre | cflow.cs:177:9:179:9 | catch (...) {...} | cflow.cs:202:9:204:9 | [finally: exception(OutOfMemoryException)] {...} |
 | pre | cflow.cs:177:9:179:9 | catch (...) {...} | cflow.cs:207:16:207:16 | access to local variable i |
 | pre | cflow.cs:177:9:179:9 | catch (...) {...} | cflow.cs:208:9:230:9 | {...} |
 | pre | cflow.cs:177:9:179:9 | catch (...) {...} | cflow.cs:212:21:212:27 | return ...; |
@@ -2016,18 +2016,18 @@
 | pre | cflow.cs:177:9:179:9 | catch (...) {...} | cflow.cs:215:17:216:26 | if (...) ... |
 | pre | cflow.cs:177:9:179:9 | catch (...) {...} | cflow.cs:216:21:216:26 | break; |
 | pre | cflow.cs:177:9:179:9 | catch (...) {...} | cflow.cs:219:13:229:13 | {...} |
-| pre | cflow.cs:177:9:179:9 | catch (...) {...} | cflow.cs:223:25:223:46 | [break] throw ...; |
-| pre | cflow.cs:177:9:179:9 | catch (...) {...} | cflow.cs:223:25:223:46 | [continue] throw ...; |
-| pre | cflow.cs:177:9:179:9 | catch (...) {...} | cflow.cs:223:25:223:46 | [return] throw ...; |
+| pre | cflow.cs:177:9:179:9 | catch (...) {...} | cflow.cs:223:25:223:46 | [finally: break] throw ...; |
+| pre | cflow.cs:177:9:179:9 | catch (...) {...} | cflow.cs:223:25:223:46 | [finally: continue] throw ...; |
+| pre | cflow.cs:177:9:179:9 | catch (...) {...} | cflow.cs:223:25:223:46 | [finally: return] throw ...; |
 | pre | cflow.cs:177:9:179:9 | catch (...) {...} | cflow.cs:223:25:223:46 | throw ...; |
-| pre | cflow.cs:177:9:179:9 | catch (...) {...} | cflow.cs:223:31:223:45 | [break] object creation of type Exception |
-| pre | cflow.cs:177:9:179:9 | catch (...) {...} | cflow.cs:223:31:223:45 | [continue] object creation of type Exception |
-| pre | cflow.cs:177:9:179:9 | catch (...) {...} | cflow.cs:223:31:223:45 | [return] object creation of type Exception |
+| pre | cflow.cs:177:9:179:9 | catch (...) {...} | cflow.cs:223:31:223:45 | [finally: break] object creation of type Exception |
+| pre | cflow.cs:177:9:179:9 | catch (...) {...} | cflow.cs:223:31:223:45 | [finally: continue] object creation of type Exception |
+| pre | cflow.cs:177:9:179:9 | catch (...) {...} | cflow.cs:223:31:223:45 | [finally: return] object creation of type Exception |
 | pre | cflow.cs:177:9:179:9 | catch (...) {...} | cflow.cs:223:31:223:45 | object creation of type Exception |
-| pre | cflow.cs:177:9:179:9 | catch (...) {...} | cflow.cs:226:17:228:17 | [break] {...} |
-| pre | cflow.cs:177:9:179:9 | catch (...) {...} | cflow.cs:226:17:228:17 | [continue] {...} |
-| pre | cflow.cs:177:9:179:9 | catch (...) {...} | cflow.cs:226:17:228:17 | [exception(Exception)] {...} |
-| pre | cflow.cs:177:9:179:9 | catch (...) {...} | cflow.cs:226:17:228:17 | [return] {...} |
+| pre | cflow.cs:177:9:179:9 | catch (...) {...} | cflow.cs:226:17:228:17 | [finally: break] {...} |
+| pre | cflow.cs:177:9:179:9 | catch (...) {...} | cflow.cs:226:17:228:17 | [finally: continue] {...} |
+| pre | cflow.cs:177:9:179:9 | catch (...) {...} | cflow.cs:226:17:228:17 | [finally: exception(Exception)] {...} |
+| pre | cflow.cs:177:9:179:9 | catch (...) {...} | cflow.cs:226:17:228:17 | [finally: return] {...} |
 | pre | cflow.cs:177:9:179:9 | catch (...) {...} | cflow.cs:226:17:228:17 | {...} |
 | pre | cflow.cs:177:9:179:9 | catch (...) {...} | cflow.cs:232:9:245:9 | try {...} ... |
 | pre | cflow.cs:177:9:179:9 | catch (...) {...} | cflow.cs:234:17:234:28 | access to property Length |
@@ -2038,29 +2038,29 @@
 | pre | cflow.cs:177:9:179:9 | catch (...) {...} | cflow.cs:236:33:236:33 | 1 |
 | pre | cflow.cs:177:9:179:9 | catch (...) {...} | cflow.cs:237:17:237:49 | throw ...; |
 | pre | cflow.cs:177:9:179:9 | catch (...) {...} | cflow.cs:237:23:237:48 | object creation of type OutOfMemoryException |
-| pre | cflow.cs:177:9:179:9 | catch (...) {...} | cflow.cs:240:9:245:9 | [exception(Exception)] {...} |
-| pre | cflow.cs:177:9:179:9 | catch (...) {...} | cflow.cs:240:9:245:9 | [exception(NullReferenceException)] {...} |
+| pre | cflow.cs:177:9:179:9 | catch (...) {...} | cflow.cs:240:9:245:9 | [finally: exception(Exception)] {...} |
+| pre | cflow.cs:177:9:179:9 | catch (...) {...} | cflow.cs:240:9:245:9 | [finally: exception(NullReferenceException)] {...} |
 | pre | cflow.cs:177:9:179:9 | catch (...) {...} | cflow.cs:240:9:245:9 | {...} |
 | pre | cflow.cs:177:9:179:9 | catch (...) {...} | cflow.cs:242:17:242:41 | ...; |
-| pre | cflow.cs:177:9:179:9 | catch (...) {...} | cflow.cs:242:17:242:41 | [exception(Exception)] ...; |
-| pre | cflow.cs:177:9:179:9 | catch (...) {...} | cflow.cs:242:17:242:41 | [exception(NullReferenceException)] ...; |
-| pre | cflow.cs:177:9:179:9 | catch (...) {...} | cflow.cs:242:17:242:41 | [exception(OutOfMemoryException)] ...; |
-| pre | cflow.cs:177:9:179:9 | catch (...) {...} | cflow.cs:242:17:242:41 | [return] ...; |
-| pre | cflow.cs:177:9:179:9 | catch (...) {...} | cflow.cs:243:13:244:37 | [exception(Exception)] if (...) ... |
-| pre | cflow.cs:177:9:179:9 | catch (...) {...} | cflow.cs:243:13:244:37 | [exception(NullReferenceException)] if (...) ... |
-| pre | cflow.cs:177:9:179:9 | catch (...) {...} | cflow.cs:243:13:244:37 | [exception(OutOfMemoryException)] if (...) ... |
-| pre | cflow.cs:177:9:179:9 | catch (...) {...} | cflow.cs:243:13:244:37 | [return] if (...) ... |
+| pre | cflow.cs:177:9:179:9 | catch (...) {...} | cflow.cs:242:17:242:41 | [finally: exception(Exception)] ...; |
+| pre | cflow.cs:177:9:179:9 | catch (...) {...} | cflow.cs:242:17:242:41 | [finally: exception(NullReferenceException)] ...; |
+| pre | cflow.cs:177:9:179:9 | catch (...) {...} | cflow.cs:242:17:242:41 | [finally: exception(OutOfMemoryException)] ...; |
+| pre | cflow.cs:177:9:179:9 | catch (...) {...} | cflow.cs:242:17:242:41 | [finally: return] ...; |
+| pre | cflow.cs:177:9:179:9 | catch (...) {...} | cflow.cs:243:13:244:37 | [finally: exception(Exception)] if (...) ... |
+| pre | cflow.cs:177:9:179:9 | catch (...) {...} | cflow.cs:243:13:244:37 | [finally: exception(NullReferenceException)] if (...) ... |
+| pre | cflow.cs:177:9:179:9 | catch (...) {...} | cflow.cs:243:13:244:37 | [finally: exception(OutOfMemoryException)] if (...) ... |
+| pre | cflow.cs:177:9:179:9 | catch (...) {...} | cflow.cs:243:13:244:37 | [finally: return] if (...) ... |
 | pre | cflow.cs:177:9:179:9 | catch (...) {...} | cflow.cs:243:13:244:37 | if (...) ... |
 | pre | cflow.cs:177:9:179:9 | catch (...) {...} | cflow.cs:244:17:244:37 | ...; |
-| pre | cflow.cs:177:9:179:9 | catch (...) {...} | cflow.cs:244:17:244:37 | [exception(Exception)] ...; |
-| pre | cflow.cs:177:9:179:9 | catch (...) {...} | cflow.cs:244:17:244:37 | [exception(NullReferenceException)] ...; |
-| pre | cflow.cs:177:9:179:9 | catch (...) {...} | cflow.cs:244:17:244:37 | [exception(OutOfMemoryException)] ...; |
-| pre | cflow.cs:177:9:179:9 | catch (...) {...} | cflow.cs:244:17:244:37 | [return] ...; |
+| pre | cflow.cs:177:9:179:9 | catch (...) {...} | cflow.cs:244:17:244:37 | [finally: exception(Exception)] ...; |
+| pre | cflow.cs:177:9:179:9 | catch (...) {...} | cflow.cs:244:17:244:37 | [finally: exception(NullReferenceException)] ...; |
+| pre | cflow.cs:177:9:179:9 | catch (...) {...} | cflow.cs:244:17:244:37 | [finally: exception(OutOfMemoryException)] ...; |
+| pre | cflow.cs:177:9:179:9 | catch (...) {...} | cflow.cs:244:17:244:37 | [finally: return] ...; |
 | pre | cflow.cs:191:13:191:37 | call to method WriteLine | cflow.cs:191:13:191:37 | call to method WriteLine |
 | pre | cflow.cs:191:13:191:37 | call to method WriteLine | cflow.cs:192:13:192:19 | return ...; |
 | pre | cflow.cs:191:13:191:37 | call to method WriteLine | cflow.cs:194:9:197:9 | catch (...) {...} |
 | pre | cflow.cs:191:13:191:37 | call to method WriteLine | cflow.cs:198:9:200:9 | catch (...) {...} |
-| pre | cflow.cs:191:13:191:37 | call to method WriteLine | cflow.cs:202:9:204:9 | [exception(Exception)] {...} |
+| pre | cflow.cs:191:13:191:37 | call to method WriteLine | cflow.cs:202:9:204:9 | [finally: exception(Exception)] {...} |
 | pre | cflow.cs:191:13:191:37 | call to method WriteLine | cflow.cs:207:16:207:16 | access to local variable i |
 | pre | cflow.cs:191:13:191:37 | call to method WriteLine | cflow.cs:208:9:230:9 | {...} |
 | pre | cflow.cs:191:13:191:37 | call to method WriteLine | cflow.cs:212:21:212:27 | return ...; |
@@ -2069,18 +2069,18 @@
 | pre | cflow.cs:191:13:191:37 | call to method WriteLine | cflow.cs:215:17:216:26 | if (...) ... |
 | pre | cflow.cs:191:13:191:37 | call to method WriteLine | cflow.cs:216:21:216:26 | break; |
 | pre | cflow.cs:191:13:191:37 | call to method WriteLine | cflow.cs:219:13:229:13 | {...} |
-| pre | cflow.cs:191:13:191:37 | call to method WriteLine | cflow.cs:223:25:223:46 | [break] throw ...; |
-| pre | cflow.cs:191:13:191:37 | call to method WriteLine | cflow.cs:223:25:223:46 | [continue] throw ...; |
-| pre | cflow.cs:191:13:191:37 | call to method WriteLine | cflow.cs:223:25:223:46 | [return] throw ...; |
+| pre | cflow.cs:191:13:191:37 | call to method WriteLine | cflow.cs:223:25:223:46 | [finally: break] throw ...; |
+| pre | cflow.cs:191:13:191:37 | call to method WriteLine | cflow.cs:223:25:223:46 | [finally: continue] throw ...; |
+| pre | cflow.cs:191:13:191:37 | call to method WriteLine | cflow.cs:223:25:223:46 | [finally: return] throw ...; |
 | pre | cflow.cs:191:13:191:37 | call to method WriteLine | cflow.cs:223:25:223:46 | throw ...; |
-| pre | cflow.cs:191:13:191:37 | call to method WriteLine | cflow.cs:223:31:223:45 | [break] object creation of type Exception |
-| pre | cflow.cs:191:13:191:37 | call to method WriteLine | cflow.cs:223:31:223:45 | [continue] object creation of type Exception |
-| pre | cflow.cs:191:13:191:37 | call to method WriteLine | cflow.cs:223:31:223:45 | [return] object creation of type Exception |
+| pre | cflow.cs:191:13:191:37 | call to method WriteLine | cflow.cs:223:31:223:45 | [finally: break] object creation of type Exception |
+| pre | cflow.cs:191:13:191:37 | call to method WriteLine | cflow.cs:223:31:223:45 | [finally: continue] object creation of type Exception |
+| pre | cflow.cs:191:13:191:37 | call to method WriteLine | cflow.cs:223:31:223:45 | [finally: return] object creation of type Exception |
 | pre | cflow.cs:191:13:191:37 | call to method WriteLine | cflow.cs:223:31:223:45 | object creation of type Exception |
-| pre | cflow.cs:191:13:191:37 | call to method WriteLine | cflow.cs:226:17:228:17 | [break] {...} |
-| pre | cflow.cs:191:13:191:37 | call to method WriteLine | cflow.cs:226:17:228:17 | [continue] {...} |
-| pre | cflow.cs:191:13:191:37 | call to method WriteLine | cflow.cs:226:17:228:17 | [exception(Exception)] {...} |
-| pre | cflow.cs:191:13:191:37 | call to method WriteLine | cflow.cs:226:17:228:17 | [return] {...} |
+| pre | cflow.cs:191:13:191:37 | call to method WriteLine | cflow.cs:226:17:228:17 | [finally: break] {...} |
+| pre | cflow.cs:191:13:191:37 | call to method WriteLine | cflow.cs:226:17:228:17 | [finally: continue] {...} |
+| pre | cflow.cs:191:13:191:37 | call to method WriteLine | cflow.cs:226:17:228:17 | [finally: exception(Exception)] {...} |
+| pre | cflow.cs:191:13:191:37 | call to method WriteLine | cflow.cs:226:17:228:17 | [finally: return] {...} |
 | pre | cflow.cs:191:13:191:37 | call to method WriteLine | cflow.cs:226:17:228:17 | {...} |
 | pre | cflow.cs:191:13:191:37 | call to method WriteLine | cflow.cs:232:9:245:9 | try {...} ... |
 | pre | cflow.cs:191:13:191:37 | call to method WriteLine | cflow.cs:234:17:234:28 | access to property Length |
@@ -2091,24 +2091,24 @@
 | pre | cflow.cs:191:13:191:37 | call to method WriteLine | cflow.cs:236:33:236:33 | 1 |
 | pre | cflow.cs:191:13:191:37 | call to method WriteLine | cflow.cs:237:17:237:49 | throw ...; |
 | pre | cflow.cs:191:13:191:37 | call to method WriteLine | cflow.cs:237:23:237:48 | object creation of type OutOfMemoryException |
-| pre | cflow.cs:191:13:191:37 | call to method WriteLine | cflow.cs:240:9:245:9 | [exception(Exception)] {...} |
-| pre | cflow.cs:191:13:191:37 | call to method WriteLine | cflow.cs:240:9:245:9 | [exception(NullReferenceException)] {...} |
+| pre | cflow.cs:191:13:191:37 | call to method WriteLine | cflow.cs:240:9:245:9 | [finally: exception(Exception)] {...} |
+| pre | cflow.cs:191:13:191:37 | call to method WriteLine | cflow.cs:240:9:245:9 | [finally: exception(NullReferenceException)] {...} |
 | pre | cflow.cs:191:13:191:37 | call to method WriteLine | cflow.cs:240:9:245:9 | {...} |
 | pre | cflow.cs:191:13:191:37 | call to method WriteLine | cflow.cs:242:17:242:41 | ...; |
-| pre | cflow.cs:191:13:191:37 | call to method WriteLine | cflow.cs:242:17:242:41 | [exception(Exception)] ...; |
-| pre | cflow.cs:191:13:191:37 | call to method WriteLine | cflow.cs:242:17:242:41 | [exception(NullReferenceException)] ...; |
-| pre | cflow.cs:191:13:191:37 | call to method WriteLine | cflow.cs:242:17:242:41 | [exception(OutOfMemoryException)] ...; |
-| pre | cflow.cs:191:13:191:37 | call to method WriteLine | cflow.cs:242:17:242:41 | [return] ...; |
-| pre | cflow.cs:191:13:191:37 | call to method WriteLine | cflow.cs:243:13:244:37 | [exception(Exception)] if (...) ... |
-| pre | cflow.cs:191:13:191:37 | call to method WriteLine | cflow.cs:243:13:244:37 | [exception(NullReferenceException)] if (...) ... |
-| pre | cflow.cs:191:13:191:37 | call to method WriteLine | cflow.cs:243:13:244:37 | [exception(OutOfMemoryException)] if (...) ... |
-| pre | cflow.cs:191:13:191:37 | call to method WriteLine | cflow.cs:243:13:244:37 | [return] if (...) ... |
+| pre | cflow.cs:191:13:191:37 | call to method WriteLine | cflow.cs:242:17:242:41 | [finally: exception(Exception)] ...; |
+| pre | cflow.cs:191:13:191:37 | call to method WriteLine | cflow.cs:242:17:242:41 | [finally: exception(NullReferenceException)] ...; |
+| pre | cflow.cs:191:13:191:37 | call to method WriteLine | cflow.cs:242:17:242:41 | [finally: exception(OutOfMemoryException)] ...; |
+| pre | cflow.cs:191:13:191:37 | call to method WriteLine | cflow.cs:242:17:242:41 | [finally: return] ...; |
+| pre | cflow.cs:191:13:191:37 | call to method WriteLine | cflow.cs:243:13:244:37 | [finally: exception(Exception)] if (...) ... |
+| pre | cflow.cs:191:13:191:37 | call to method WriteLine | cflow.cs:243:13:244:37 | [finally: exception(NullReferenceException)] if (...) ... |
+| pre | cflow.cs:191:13:191:37 | call to method WriteLine | cflow.cs:243:13:244:37 | [finally: exception(OutOfMemoryException)] if (...) ... |
+| pre | cflow.cs:191:13:191:37 | call to method WriteLine | cflow.cs:243:13:244:37 | [finally: return] if (...) ... |
 | pre | cflow.cs:191:13:191:37 | call to method WriteLine | cflow.cs:243:13:244:37 | if (...) ... |
 | pre | cflow.cs:191:13:191:37 | call to method WriteLine | cflow.cs:244:17:244:37 | ...; |
-| pre | cflow.cs:191:13:191:37 | call to method WriteLine | cflow.cs:244:17:244:37 | [exception(Exception)] ...; |
-| pre | cflow.cs:191:13:191:37 | call to method WriteLine | cflow.cs:244:17:244:37 | [exception(NullReferenceException)] ...; |
-| pre | cflow.cs:191:13:191:37 | call to method WriteLine | cflow.cs:244:17:244:37 | [exception(OutOfMemoryException)] ...; |
-| pre | cflow.cs:191:13:191:37 | call to method WriteLine | cflow.cs:244:17:244:37 | [return] ...; |
+| pre | cflow.cs:191:13:191:37 | call to method WriteLine | cflow.cs:244:17:244:37 | [finally: exception(Exception)] ...; |
+| pre | cflow.cs:191:13:191:37 | call to method WriteLine | cflow.cs:244:17:244:37 | [finally: exception(NullReferenceException)] ...; |
+| pre | cflow.cs:191:13:191:37 | call to method WriteLine | cflow.cs:244:17:244:37 | [finally: exception(OutOfMemoryException)] ...; |
+| pre | cflow.cs:191:13:191:37 | call to method WriteLine | cflow.cs:244:17:244:37 | [finally: return] ...; |
 | pre | cflow.cs:192:13:192:19 | return ...; | cflow.cs:192:13:192:19 | return ...; |
 | pre | cflow.cs:194:9:197:9 | catch (...) {...} | cflow.cs:194:9:197:9 | catch (...) {...} |
 | pre | cflow.cs:198:9:200:9 | catch (...) {...} | cflow.cs:198:9:200:9 | catch (...) {...} |
@@ -2120,18 +2120,18 @@
 | pre | cflow.cs:198:9:200:9 | catch (...) {...} | cflow.cs:215:17:216:26 | if (...) ... |
 | pre | cflow.cs:198:9:200:9 | catch (...) {...} | cflow.cs:216:21:216:26 | break; |
 | pre | cflow.cs:198:9:200:9 | catch (...) {...} | cflow.cs:219:13:229:13 | {...} |
-| pre | cflow.cs:198:9:200:9 | catch (...) {...} | cflow.cs:223:25:223:46 | [break] throw ...; |
-| pre | cflow.cs:198:9:200:9 | catch (...) {...} | cflow.cs:223:25:223:46 | [continue] throw ...; |
-| pre | cflow.cs:198:9:200:9 | catch (...) {...} | cflow.cs:223:25:223:46 | [return] throw ...; |
+| pre | cflow.cs:198:9:200:9 | catch (...) {...} | cflow.cs:223:25:223:46 | [finally: break] throw ...; |
+| pre | cflow.cs:198:9:200:9 | catch (...) {...} | cflow.cs:223:25:223:46 | [finally: continue] throw ...; |
+| pre | cflow.cs:198:9:200:9 | catch (...) {...} | cflow.cs:223:25:223:46 | [finally: return] throw ...; |
 | pre | cflow.cs:198:9:200:9 | catch (...) {...} | cflow.cs:223:25:223:46 | throw ...; |
-| pre | cflow.cs:198:9:200:9 | catch (...) {...} | cflow.cs:223:31:223:45 | [break] object creation of type Exception |
-| pre | cflow.cs:198:9:200:9 | catch (...) {...} | cflow.cs:223:31:223:45 | [continue] object creation of type Exception |
-| pre | cflow.cs:198:9:200:9 | catch (...) {...} | cflow.cs:223:31:223:45 | [return] object creation of type Exception |
+| pre | cflow.cs:198:9:200:9 | catch (...) {...} | cflow.cs:223:31:223:45 | [finally: break] object creation of type Exception |
+| pre | cflow.cs:198:9:200:9 | catch (...) {...} | cflow.cs:223:31:223:45 | [finally: continue] object creation of type Exception |
+| pre | cflow.cs:198:9:200:9 | catch (...) {...} | cflow.cs:223:31:223:45 | [finally: return] object creation of type Exception |
 | pre | cflow.cs:198:9:200:9 | catch (...) {...} | cflow.cs:223:31:223:45 | object creation of type Exception |
-| pre | cflow.cs:198:9:200:9 | catch (...) {...} | cflow.cs:226:17:228:17 | [break] {...} |
-| pre | cflow.cs:198:9:200:9 | catch (...) {...} | cflow.cs:226:17:228:17 | [continue] {...} |
-| pre | cflow.cs:198:9:200:9 | catch (...) {...} | cflow.cs:226:17:228:17 | [exception(Exception)] {...} |
-| pre | cflow.cs:198:9:200:9 | catch (...) {...} | cflow.cs:226:17:228:17 | [return] {...} |
+| pre | cflow.cs:198:9:200:9 | catch (...) {...} | cflow.cs:226:17:228:17 | [finally: break] {...} |
+| pre | cflow.cs:198:9:200:9 | catch (...) {...} | cflow.cs:226:17:228:17 | [finally: continue] {...} |
+| pre | cflow.cs:198:9:200:9 | catch (...) {...} | cflow.cs:226:17:228:17 | [finally: exception(Exception)] {...} |
+| pre | cflow.cs:198:9:200:9 | catch (...) {...} | cflow.cs:226:17:228:17 | [finally: return] {...} |
 | pre | cflow.cs:198:9:200:9 | catch (...) {...} | cflow.cs:226:17:228:17 | {...} |
 | pre | cflow.cs:198:9:200:9 | catch (...) {...} | cflow.cs:232:9:245:9 | try {...} ... |
 | pre | cflow.cs:198:9:200:9 | catch (...) {...} | cflow.cs:234:17:234:28 | access to property Length |
@@ -2142,26 +2142,26 @@
 | pre | cflow.cs:198:9:200:9 | catch (...) {...} | cflow.cs:236:33:236:33 | 1 |
 | pre | cflow.cs:198:9:200:9 | catch (...) {...} | cflow.cs:237:17:237:49 | throw ...; |
 | pre | cflow.cs:198:9:200:9 | catch (...) {...} | cflow.cs:237:23:237:48 | object creation of type OutOfMemoryException |
-| pre | cflow.cs:198:9:200:9 | catch (...) {...} | cflow.cs:240:9:245:9 | [exception(Exception)] {...} |
-| pre | cflow.cs:198:9:200:9 | catch (...) {...} | cflow.cs:240:9:245:9 | [exception(NullReferenceException)] {...} |
+| pre | cflow.cs:198:9:200:9 | catch (...) {...} | cflow.cs:240:9:245:9 | [finally: exception(Exception)] {...} |
+| pre | cflow.cs:198:9:200:9 | catch (...) {...} | cflow.cs:240:9:245:9 | [finally: exception(NullReferenceException)] {...} |
 | pre | cflow.cs:198:9:200:9 | catch (...) {...} | cflow.cs:240:9:245:9 | {...} |
 | pre | cflow.cs:198:9:200:9 | catch (...) {...} | cflow.cs:242:17:242:41 | ...; |
-| pre | cflow.cs:198:9:200:9 | catch (...) {...} | cflow.cs:242:17:242:41 | [exception(Exception)] ...; |
-| pre | cflow.cs:198:9:200:9 | catch (...) {...} | cflow.cs:242:17:242:41 | [exception(NullReferenceException)] ...; |
-| pre | cflow.cs:198:9:200:9 | catch (...) {...} | cflow.cs:242:17:242:41 | [exception(OutOfMemoryException)] ...; |
-| pre | cflow.cs:198:9:200:9 | catch (...) {...} | cflow.cs:242:17:242:41 | [return] ...; |
-| pre | cflow.cs:198:9:200:9 | catch (...) {...} | cflow.cs:243:13:244:37 | [exception(Exception)] if (...) ... |
-| pre | cflow.cs:198:9:200:9 | catch (...) {...} | cflow.cs:243:13:244:37 | [exception(NullReferenceException)] if (...) ... |
-| pre | cflow.cs:198:9:200:9 | catch (...) {...} | cflow.cs:243:13:244:37 | [exception(OutOfMemoryException)] if (...) ... |
-| pre | cflow.cs:198:9:200:9 | catch (...) {...} | cflow.cs:243:13:244:37 | [return] if (...) ... |
+| pre | cflow.cs:198:9:200:9 | catch (...) {...} | cflow.cs:242:17:242:41 | [finally: exception(Exception)] ...; |
+| pre | cflow.cs:198:9:200:9 | catch (...) {...} | cflow.cs:242:17:242:41 | [finally: exception(NullReferenceException)] ...; |
+| pre | cflow.cs:198:9:200:9 | catch (...) {...} | cflow.cs:242:17:242:41 | [finally: exception(OutOfMemoryException)] ...; |
+| pre | cflow.cs:198:9:200:9 | catch (...) {...} | cflow.cs:242:17:242:41 | [finally: return] ...; |
+| pre | cflow.cs:198:9:200:9 | catch (...) {...} | cflow.cs:243:13:244:37 | [finally: exception(Exception)] if (...) ... |
+| pre | cflow.cs:198:9:200:9 | catch (...) {...} | cflow.cs:243:13:244:37 | [finally: exception(NullReferenceException)] if (...) ... |
+| pre | cflow.cs:198:9:200:9 | catch (...) {...} | cflow.cs:243:13:244:37 | [finally: exception(OutOfMemoryException)] if (...) ... |
+| pre | cflow.cs:198:9:200:9 | catch (...) {...} | cflow.cs:243:13:244:37 | [finally: return] if (...) ... |
 | pre | cflow.cs:198:9:200:9 | catch (...) {...} | cflow.cs:243:13:244:37 | if (...) ... |
 | pre | cflow.cs:198:9:200:9 | catch (...) {...} | cflow.cs:244:17:244:37 | ...; |
-| pre | cflow.cs:198:9:200:9 | catch (...) {...} | cflow.cs:244:17:244:37 | [exception(Exception)] ...; |
-| pre | cflow.cs:198:9:200:9 | catch (...) {...} | cflow.cs:244:17:244:37 | [exception(NullReferenceException)] ...; |
-| pre | cflow.cs:198:9:200:9 | catch (...) {...} | cflow.cs:244:17:244:37 | [exception(OutOfMemoryException)] ...; |
-| pre | cflow.cs:198:9:200:9 | catch (...) {...} | cflow.cs:244:17:244:37 | [return] ...; |
-| pre | cflow.cs:202:9:204:9 | [exception(Exception)] {...} | cflow.cs:202:9:204:9 | [exception(Exception)] {...} |
-| pre | cflow.cs:202:9:204:9 | [exception(OutOfMemoryException)] {...} | cflow.cs:202:9:204:9 | [exception(OutOfMemoryException)] {...} |
+| pre | cflow.cs:198:9:200:9 | catch (...) {...} | cflow.cs:244:17:244:37 | [finally: exception(Exception)] ...; |
+| pre | cflow.cs:198:9:200:9 | catch (...) {...} | cflow.cs:244:17:244:37 | [finally: exception(NullReferenceException)] ...; |
+| pre | cflow.cs:198:9:200:9 | catch (...) {...} | cflow.cs:244:17:244:37 | [finally: exception(OutOfMemoryException)] ...; |
+| pre | cflow.cs:198:9:200:9 | catch (...) {...} | cflow.cs:244:17:244:37 | [finally: return] ...; |
+| pre | cflow.cs:202:9:204:9 | [finally: exception(Exception)] {...} | cflow.cs:202:9:204:9 | [finally: exception(Exception)] {...} |
+| pre | cflow.cs:202:9:204:9 | [finally: exception(OutOfMemoryException)] {...} | cflow.cs:202:9:204:9 | [finally: exception(OutOfMemoryException)] {...} |
 | pre | cflow.cs:207:16:207:16 | access to local variable i | cflow.cs:207:16:207:16 | access to local variable i |
 | pre | cflow.cs:207:16:207:16 | access to local variable i | cflow.cs:208:9:230:9 | {...} |
 | pre | cflow.cs:207:16:207:16 | access to local variable i | cflow.cs:212:21:212:27 | return ...; |
@@ -2170,18 +2170,18 @@
 | pre | cflow.cs:207:16:207:16 | access to local variable i | cflow.cs:215:17:216:26 | if (...) ... |
 | pre | cflow.cs:207:16:207:16 | access to local variable i | cflow.cs:216:21:216:26 | break; |
 | pre | cflow.cs:207:16:207:16 | access to local variable i | cflow.cs:219:13:229:13 | {...} |
-| pre | cflow.cs:207:16:207:16 | access to local variable i | cflow.cs:223:25:223:46 | [break] throw ...; |
-| pre | cflow.cs:207:16:207:16 | access to local variable i | cflow.cs:223:25:223:46 | [continue] throw ...; |
-| pre | cflow.cs:207:16:207:16 | access to local variable i | cflow.cs:223:25:223:46 | [return] throw ...; |
+| pre | cflow.cs:207:16:207:16 | access to local variable i | cflow.cs:223:25:223:46 | [finally: break] throw ...; |
+| pre | cflow.cs:207:16:207:16 | access to local variable i | cflow.cs:223:25:223:46 | [finally: continue] throw ...; |
+| pre | cflow.cs:207:16:207:16 | access to local variable i | cflow.cs:223:25:223:46 | [finally: return] throw ...; |
 | pre | cflow.cs:207:16:207:16 | access to local variable i | cflow.cs:223:25:223:46 | throw ...; |
-| pre | cflow.cs:207:16:207:16 | access to local variable i | cflow.cs:223:31:223:45 | [break] object creation of type Exception |
-| pre | cflow.cs:207:16:207:16 | access to local variable i | cflow.cs:223:31:223:45 | [continue] object creation of type Exception |
-| pre | cflow.cs:207:16:207:16 | access to local variable i | cflow.cs:223:31:223:45 | [return] object creation of type Exception |
+| pre | cflow.cs:207:16:207:16 | access to local variable i | cflow.cs:223:31:223:45 | [finally: break] object creation of type Exception |
+| pre | cflow.cs:207:16:207:16 | access to local variable i | cflow.cs:223:31:223:45 | [finally: continue] object creation of type Exception |
+| pre | cflow.cs:207:16:207:16 | access to local variable i | cflow.cs:223:31:223:45 | [finally: return] object creation of type Exception |
 | pre | cflow.cs:207:16:207:16 | access to local variable i | cflow.cs:223:31:223:45 | object creation of type Exception |
-| pre | cflow.cs:207:16:207:16 | access to local variable i | cflow.cs:226:17:228:17 | [break] {...} |
-| pre | cflow.cs:207:16:207:16 | access to local variable i | cflow.cs:226:17:228:17 | [continue] {...} |
-| pre | cflow.cs:207:16:207:16 | access to local variable i | cflow.cs:226:17:228:17 | [exception(Exception)] {...} |
-| pre | cflow.cs:207:16:207:16 | access to local variable i | cflow.cs:226:17:228:17 | [return] {...} |
+| pre | cflow.cs:207:16:207:16 | access to local variable i | cflow.cs:226:17:228:17 | [finally: break] {...} |
+| pre | cflow.cs:207:16:207:16 | access to local variable i | cflow.cs:226:17:228:17 | [finally: continue] {...} |
+| pre | cflow.cs:207:16:207:16 | access to local variable i | cflow.cs:226:17:228:17 | [finally: exception(Exception)] {...} |
+| pre | cflow.cs:207:16:207:16 | access to local variable i | cflow.cs:226:17:228:17 | [finally: return] {...} |
 | pre | cflow.cs:207:16:207:16 | access to local variable i | cflow.cs:226:17:228:17 | {...} |
 | pre | cflow.cs:207:16:207:16 | access to local variable i | cflow.cs:232:9:245:9 | try {...} ... |
 | pre | cflow.cs:207:16:207:16 | access to local variable i | cflow.cs:234:17:234:28 | access to property Length |
@@ -2192,24 +2192,24 @@
 | pre | cflow.cs:207:16:207:16 | access to local variable i | cflow.cs:236:33:236:33 | 1 |
 | pre | cflow.cs:207:16:207:16 | access to local variable i | cflow.cs:237:17:237:49 | throw ...; |
 | pre | cflow.cs:207:16:207:16 | access to local variable i | cflow.cs:237:23:237:48 | object creation of type OutOfMemoryException |
-| pre | cflow.cs:207:16:207:16 | access to local variable i | cflow.cs:240:9:245:9 | [exception(Exception)] {...} |
-| pre | cflow.cs:207:16:207:16 | access to local variable i | cflow.cs:240:9:245:9 | [exception(NullReferenceException)] {...} |
+| pre | cflow.cs:207:16:207:16 | access to local variable i | cflow.cs:240:9:245:9 | [finally: exception(Exception)] {...} |
+| pre | cflow.cs:207:16:207:16 | access to local variable i | cflow.cs:240:9:245:9 | [finally: exception(NullReferenceException)] {...} |
 | pre | cflow.cs:207:16:207:16 | access to local variable i | cflow.cs:240:9:245:9 | {...} |
 | pre | cflow.cs:207:16:207:16 | access to local variable i | cflow.cs:242:17:242:41 | ...; |
-| pre | cflow.cs:207:16:207:16 | access to local variable i | cflow.cs:242:17:242:41 | [exception(Exception)] ...; |
-| pre | cflow.cs:207:16:207:16 | access to local variable i | cflow.cs:242:17:242:41 | [exception(NullReferenceException)] ...; |
-| pre | cflow.cs:207:16:207:16 | access to local variable i | cflow.cs:242:17:242:41 | [exception(OutOfMemoryException)] ...; |
-| pre | cflow.cs:207:16:207:16 | access to local variable i | cflow.cs:242:17:242:41 | [return] ...; |
-| pre | cflow.cs:207:16:207:16 | access to local variable i | cflow.cs:243:13:244:37 | [exception(Exception)] if (...) ... |
-| pre | cflow.cs:207:16:207:16 | access to local variable i | cflow.cs:243:13:244:37 | [exception(NullReferenceException)] if (...) ... |
-| pre | cflow.cs:207:16:207:16 | access to local variable i | cflow.cs:243:13:244:37 | [exception(OutOfMemoryException)] if (...) ... |
-| pre | cflow.cs:207:16:207:16 | access to local variable i | cflow.cs:243:13:244:37 | [return] if (...) ... |
+| pre | cflow.cs:207:16:207:16 | access to local variable i | cflow.cs:242:17:242:41 | [finally: exception(Exception)] ...; |
+| pre | cflow.cs:207:16:207:16 | access to local variable i | cflow.cs:242:17:242:41 | [finally: exception(NullReferenceException)] ...; |
+| pre | cflow.cs:207:16:207:16 | access to local variable i | cflow.cs:242:17:242:41 | [finally: exception(OutOfMemoryException)] ...; |
+| pre | cflow.cs:207:16:207:16 | access to local variable i | cflow.cs:242:17:242:41 | [finally: return] ...; |
+| pre | cflow.cs:207:16:207:16 | access to local variable i | cflow.cs:243:13:244:37 | [finally: exception(Exception)] if (...) ... |
+| pre | cflow.cs:207:16:207:16 | access to local variable i | cflow.cs:243:13:244:37 | [finally: exception(NullReferenceException)] if (...) ... |
+| pre | cflow.cs:207:16:207:16 | access to local variable i | cflow.cs:243:13:244:37 | [finally: exception(OutOfMemoryException)] if (...) ... |
+| pre | cflow.cs:207:16:207:16 | access to local variable i | cflow.cs:243:13:244:37 | [finally: return] if (...) ... |
 | pre | cflow.cs:207:16:207:16 | access to local variable i | cflow.cs:243:13:244:37 | if (...) ... |
 | pre | cflow.cs:207:16:207:16 | access to local variable i | cflow.cs:244:17:244:37 | ...; |
-| pre | cflow.cs:207:16:207:16 | access to local variable i | cflow.cs:244:17:244:37 | [exception(Exception)] ...; |
-| pre | cflow.cs:207:16:207:16 | access to local variable i | cflow.cs:244:17:244:37 | [exception(NullReferenceException)] ...; |
-| pre | cflow.cs:207:16:207:16 | access to local variable i | cflow.cs:244:17:244:37 | [exception(OutOfMemoryException)] ...; |
-| pre | cflow.cs:207:16:207:16 | access to local variable i | cflow.cs:244:17:244:37 | [return] ...; |
+| pre | cflow.cs:207:16:207:16 | access to local variable i | cflow.cs:244:17:244:37 | [finally: exception(Exception)] ...; |
+| pre | cflow.cs:207:16:207:16 | access to local variable i | cflow.cs:244:17:244:37 | [finally: exception(NullReferenceException)] ...; |
+| pre | cflow.cs:207:16:207:16 | access to local variable i | cflow.cs:244:17:244:37 | [finally: exception(OutOfMemoryException)] ...; |
+| pre | cflow.cs:207:16:207:16 | access to local variable i | cflow.cs:244:17:244:37 | [finally: return] ...; |
 | pre | cflow.cs:208:9:230:9 | {...} | cflow.cs:208:9:230:9 | {...} |
 | pre | cflow.cs:208:9:230:9 | {...} | cflow.cs:212:21:212:27 | return ...; |
 | pre | cflow.cs:208:9:230:9 | {...} | cflow.cs:213:17:214:29 | if (...) ... |
@@ -2217,74 +2217,74 @@
 | pre | cflow.cs:208:9:230:9 | {...} | cflow.cs:215:17:216:26 | if (...) ... |
 | pre | cflow.cs:208:9:230:9 | {...} | cflow.cs:216:21:216:26 | break; |
 | pre | cflow.cs:208:9:230:9 | {...} | cflow.cs:219:13:229:13 | {...} |
-| pre | cflow.cs:208:9:230:9 | {...} | cflow.cs:223:25:223:46 | [break] throw ...; |
-| pre | cflow.cs:208:9:230:9 | {...} | cflow.cs:223:25:223:46 | [continue] throw ...; |
-| pre | cflow.cs:208:9:230:9 | {...} | cflow.cs:223:25:223:46 | [return] throw ...; |
+| pre | cflow.cs:208:9:230:9 | {...} | cflow.cs:223:25:223:46 | [finally: break] throw ...; |
+| pre | cflow.cs:208:9:230:9 | {...} | cflow.cs:223:25:223:46 | [finally: continue] throw ...; |
+| pre | cflow.cs:208:9:230:9 | {...} | cflow.cs:223:25:223:46 | [finally: return] throw ...; |
 | pre | cflow.cs:208:9:230:9 | {...} | cflow.cs:223:25:223:46 | throw ...; |
-| pre | cflow.cs:208:9:230:9 | {...} | cflow.cs:223:31:223:45 | [break] object creation of type Exception |
-| pre | cflow.cs:208:9:230:9 | {...} | cflow.cs:223:31:223:45 | [continue] object creation of type Exception |
-| pre | cflow.cs:208:9:230:9 | {...} | cflow.cs:223:31:223:45 | [return] object creation of type Exception |
+| pre | cflow.cs:208:9:230:9 | {...} | cflow.cs:223:31:223:45 | [finally: break] object creation of type Exception |
+| pre | cflow.cs:208:9:230:9 | {...} | cflow.cs:223:31:223:45 | [finally: continue] object creation of type Exception |
+| pre | cflow.cs:208:9:230:9 | {...} | cflow.cs:223:31:223:45 | [finally: return] object creation of type Exception |
 | pre | cflow.cs:208:9:230:9 | {...} | cflow.cs:223:31:223:45 | object creation of type Exception |
-| pre | cflow.cs:208:9:230:9 | {...} | cflow.cs:226:17:228:17 | [break] {...} |
-| pre | cflow.cs:208:9:230:9 | {...} | cflow.cs:226:17:228:17 | [continue] {...} |
-| pre | cflow.cs:208:9:230:9 | {...} | cflow.cs:226:17:228:17 | [exception(Exception)] {...} |
-| pre | cflow.cs:208:9:230:9 | {...} | cflow.cs:226:17:228:17 | [return] {...} |
+| pre | cflow.cs:208:9:230:9 | {...} | cflow.cs:226:17:228:17 | [finally: break] {...} |
+| pre | cflow.cs:208:9:230:9 | {...} | cflow.cs:226:17:228:17 | [finally: continue] {...} |
+| pre | cflow.cs:208:9:230:9 | {...} | cflow.cs:226:17:228:17 | [finally: exception(Exception)] {...} |
+| pre | cflow.cs:208:9:230:9 | {...} | cflow.cs:226:17:228:17 | [finally: return] {...} |
 | pre | cflow.cs:208:9:230:9 | {...} | cflow.cs:226:17:228:17 | {...} |
 | pre | cflow.cs:212:21:212:27 | return ...; | cflow.cs:212:21:212:27 | return ...; |
-| pre | cflow.cs:212:21:212:27 | return ...; | cflow.cs:223:25:223:46 | [return] throw ...; |
-| pre | cflow.cs:212:21:212:27 | return ...; | cflow.cs:223:31:223:45 | [return] object creation of type Exception |
-| pre | cflow.cs:212:21:212:27 | return ...; | cflow.cs:226:17:228:17 | [return] {...} |
+| pre | cflow.cs:212:21:212:27 | return ...; | cflow.cs:223:25:223:46 | [finally: return] throw ...; |
+| pre | cflow.cs:212:21:212:27 | return ...; | cflow.cs:223:31:223:45 | [finally: return] object creation of type Exception |
+| pre | cflow.cs:212:21:212:27 | return ...; | cflow.cs:226:17:228:17 | [finally: return] {...} |
 | pre | cflow.cs:213:17:214:29 | if (...) ... | cflow.cs:213:17:214:29 | if (...) ... |
 | pre | cflow.cs:213:17:214:29 | if (...) ... | cflow.cs:214:21:214:29 | continue; |
 | pre | cflow.cs:213:17:214:29 | if (...) ... | cflow.cs:215:17:216:26 | if (...) ... |
 | pre | cflow.cs:213:17:214:29 | if (...) ... | cflow.cs:216:21:216:26 | break; |
 | pre | cflow.cs:213:17:214:29 | if (...) ... | cflow.cs:219:13:229:13 | {...} |
-| pre | cflow.cs:213:17:214:29 | if (...) ... | cflow.cs:223:25:223:46 | [break] throw ...; |
-| pre | cflow.cs:213:17:214:29 | if (...) ... | cflow.cs:223:25:223:46 | [continue] throw ...; |
+| pre | cflow.cs:213:17:214:29 | if (...) ... | cflow.cs:223:25:223:46 | [finally: break] throw ...; |
+| pre | cflow.cs:213:17:214:29 | if (...) ... | cflow.cs:223:25:223:46 | [finally: continue] throw ...; |
 | pre | cflow.cs:213:17:214:29 | if (...) ... | cflow.cs:223:25:223:46 | throw ...; |
-| pre | cflow.cs:213:17:214:29 | if (...) ... | cflow.cs:223:31:223:45 | [break] object creation of type Exception |
-| pre | cflow.cs:213:17:214:29 | if (...) ... | cflow.cs:223:31:223:45 | [continue] object creation of type Exception |
+| pre | cflow.cs:213:17:214:29 | if (...) ... | cflow.cs:223:31:223:45 | [finally: break] object creation of type Exception |
+| pre | cflow.cs:213:17:214:29 | if (...) ... | cflow.cs:223:31:223:45 | [finally: continue] object creation of type Exception |
 | pre | cflow.cs:213:17:214:29 | if (...) ... | cflow.cs:223:31:223:45 | object creation of type Exception |
-| pre | cflow.cs:213:17:214:29 | if (...) ... | cflow.cs:226:17:228:17 | [break] {...} |
-| pre | cflow.cs:213:17:214:29 | if (...) ... | cflow.cs:226:17:228:17 | [continue] {...} |
+| pre | cflow.cs:213:17:214:29 | if (...) ... | cflow.cs:226:17:228:17 | [finally: break] {...} |
+| pre | cflow.cs:213:17:214:29 | if (...) ... | cflow.cs:226:17:228:17 | [finally: continue] {...} |
 | pre | cflow.cs:213:17:214:29 | if (...) ... | cflow.cs:226:17:228:17 | {...} |
 | pre | cflow.cs:214:21:214:29 | continue; | cflow.cs:214:21:214:29 | continue; |
-| pre | cflow.cs:214:21:214:29 | continue; | cflow.cs:223:25:223:46 | [continue] throw ...; |
-| pre | cflow.cs:214:21:214:29 | continue; | cflow.cs:223:31:223:45 | [continue] object creation of type Exception |
-| pre | cflow.cs:214:21:214:29 | continue; | cflow.cs:226:17:228:17 | [continue] {...} |
+| pre | cflow.cs:214:21:214:29 | continue; | cflow.cs:223:25:223:46 | [finally: continue] throw ...; |
+| pre | cflow.cs:214:21:214:29 | continue; | cflow.cs:223:31:223:45 | [finally: continue] object creation of type Exception |
+| pre | cflow.cs:214:21:214:29 | continue; | cflow.cs:226:17:228:17 | [finally: continue] {...} |
 | pre | cflow.cs:215:17:216:26 | if (...) ... | cflow.cs:215:17:216:26 | if (...) ... |
 | pre | cflow.cs:215:17:216:26 | if (...) ... | cflow.cs:216:21:216:26 | break; |
 | pre | cflow.cs:215:17:216:26 | if (...) ... | cflow.cs:219:13:229:13 | {...} |
-| pre | cflow.cs:215:17:216:26 | if (...) ... | cflow.cs:223:25:223:46 | [break] throw ...; |
+| pre | cflow.cs:215:17:216:26 | if (...) ... | cflow.cs:223:25:223:46 | [finally: break] throw ...; |
 | pre | cflow.cs:215:17:216:26 | if (...) ... | cflow.cs:223:25:223:46 | throw ...; |
-| pre | cflow.cs:215:17:216:26 | if (...) ... | cflow.cs:223:31:223:45 | [break] object creation of type Exception |
+| pre | cflow.cs:215:17:216:26 | if (...) ... | cflow.cs:223:31:223:45 | [finally: break] object creation of type Exception |
 | pre | cflow.cs:215:17:216:26 | if (...) ... | cflow.cs:223:31:223:45 | object creation of type Exception |
-| pre | cflow.cs:215:17:216:26 | if (...) ... | cflow.cs:226:17:228:17 | [break] {...} |
+| pre | cflow.cs:215:17:216:26 | if (...) ... | cflow.cs:226:17:228:17 | [finally: break] {...} |
 | pre | cflow.cs:215:17:216:26 | if (...) ... | cflow.cs:226:17:228:17 | {...} |
 | pre | cflow.cs:216:21:216:26 | break; | cflow.cs:216:21:216:26 | break; |
-| pre | cflow.cs:216:21:216:26 | break; | cflow.cs:223:25:223:46 | [break] throw ...; |
-| pre | cflow.cs:216:21:216:26 | break; | cflow.cs:223:31:223:45 | [break] object creation of type Exception |
-| pre | cflow.cs:216:21:216:26 | break; | cflow.cs:226:17:228:17 | [break] {...} |
+| pre | cflow.cs:216:21:216:26 | break; | cflow.cs:223:25:223:46 | [finally: break] throw ...; |
+| pre | cflow.cs:216:21:216:26 | break; | cflow.cs:223:31:223:45 | [finally: break] object creation of type Exception |
+| pre | cflow.cs:216:21:216:26 | break; | cflow.cs:226:17:228:17 | [finally: break] {...} |
 | pre | cflow.cs:219:13:229:13 | {...} | cflow.cs:219:13:229:13 | {...} |
 | pre | cflow.cs:219:13:229:13 | {...} | cflow.cs:223:25:223:46 | throw ...; |
 | pre | cflow.cs:219:13:229:13 | {...} | cflow.cs:223:31:223:45 | object creation of type Exception |
 | pre | cflow.cs:219:13:229:13 | {...} | cflow.cs:226:17:228:17 | {...} |
-| pre | cflow.cs:223:25:223:46 | [break] throw ...; | cflow.cs:223:25:223:46 | [break] throw ...; |
-| pre | cflow.cs:223:25:223:46 | [continue] throw ...; | cflow.cs:223:25:223:46 | [continue] throw ...; |
-| pre | cflow.cs:223:25:223:46 | [return] throw ...; | cflow.cs:223:25:223:46 | [return] throw ...; |
+| pre | cflow.cs:223:25:223:46 | [finally: break] throw ...; | cflow.cs:223:25:223:46 | [finally: break] throw ...; |
+| pre | cflow.cs:223:25:223:46 | [finally: continue] throw ...; | cflow.cs:223:25:223:46 | [finally: continue] throw ...; |
+| pre | cflow.cs:223:25:223:46 | [finally: return] throw ...; | cflow.cs:223:25:223:46 | [finally: return] throw ...; |
 | pre | cflow.cs:223:25:223:46 | throw ...; | cflow.cs:223:25:223:46 | throw ...; |
-| pre | cflow.cs:223:31:223:45 | [break] object creation of type Exception | cflow.cs:223:25:223:46 | [break] throw ...; |
-| pre | cflow.cs:223:31:223:45 | [break] object creation of type Exception | cflow.cs:223:31:223:45 | [break] object creation of type Exception |
-| pre | cflow.cs:223:31:223:45 | [continue] object creation of type Exception | cflow.cs:223:25:223:46 | [continue] throw ...; |
-| pre | cflow.cs:223:31:223:45 | [continue] object creation of type Exception | cflow.cs:223:31:223:45 | [continue] object creation of type Exception |
-| pre | cflow.cs:223:31:223:45 | [return] object creation of type Exception | cflow.cs:223:25:223:46 | [return] throw ...; |
-| pre | cflow.cs:223:31:223:45 | [return] object creation of type Exception | cflow.cs:223:31:223:45 | [return] object creation of type Exception |
+| pre | cflow.cs:223:31:223:45 | [finally: break] object creation of type Exception | cflow.cs:223:25:223:46 | [finally: break] throw ...; |
+| pre | cflow.cs:223:31:223:45 | [finally: break] object creation of type Exception | cflow.cs:223:31:223:45 | [finally: break] object creation of type Exception |
+| pre | cflow.cs:223:31:223:45 | [finally: continue] object creation of type Exception | cflow.cs:223:25:223:46 | [finally: continue] throw ...; |
+| pre | cflow.cs:223:31:223:45 | [finally: continue] object creation of type Exception | cflow.cs:223:31:223:45 | [finally: continue] object creation of type Exception |
+| pre | cflow.cs:223:31:223:45 | [finally: return] object creation of type Exception | cflow.cs:223:25:223:46 | [finally: return] throw ...; |
+| pre | cflow.cs:223:31:223:45 | [finally: return] object creation of type Exception | cflow.cs:223:31:223:45 | [finally: return] object creation of type Exception |
 | pre | cflow.cs:223:31:223:45 | object creation of type Exception | cflow.cs:223:25:223:46 | throw ...; |
 | pre | cflow.cs:223:31:223:45 | object creation of type Exception | cflow.cs:223:31:223:45 | object creation of type Exception |
-| pre | cflow.cs:226:17:228:17 | [break] {...} | cflow.cs:226:17:228:17 | [break] {...} |
-| pre | cflow.cs:226:17:228:17 | [continue] {...} | cflow.cs:226:17:228:17 | [continue] {...} |
-| pre | cflow.cs:226:17:228:17 | [exception(Exception)] {...} | cflow.cs:226:17:228:17 | [exception(Exception)] {...} |
-| pre | cflow.cs:226:17:228:17 | [return] {...} | cflow.cs:226:17:228:17 | [return] {...} |
+| pre | cflow.cs:226:17:228:17 | [finally: break] {...} | cflow.cs:226:17:228:17 | [finally: break] {...} |
+| pre | cflow.cs:226:17:228:17 | [finally: continue] {...} | cflow.cs:226:17:228:17 | [finally: continue] {...} |
+| pre | cflow.cs:226:17:228:17 | [finally: exception(Exception)] {...} | cflow.cs:226:17:228:17 | [finally: exception(Exception)] {...} |
+| pre | cflow.cs:226:17:228:17 | [finally: return] {...} | cflow.cs:226:17:228:17 | [finally: return] {...} |
 | pre | cflow.cs:226:17:228:17 | {...} | cflow.cs:226:17:228:17 | {...} |
 | pre | cflow.cs:232:9:245:9 | try {...} ... | cflow.cs:232:9:245:9 | try {...} ... |
 | pre | cflow.cs:232:9:245:9 | try {...} ... | cflow.cs:234:17:234:28 | access to property Length |
@@ -2295,24 +2295,24 @@
 | pre | cflow.cs:232:9:245:9 | try {...} ... | cflow.cs:236:33:236:33 | 1 |
 | pre | cflow.cs:232:9:245:9 | try {...} ... | cflow.cs:237:17:237:49 | throw ...; |
 | pre | cflow.cs:232:9:245:9 | try {...} ... | cflow.cs:237:23:237:48 | object creation of type OutOfMemoryException |
-| pre | cflow.cs:232:9:245:9 | try {...} ... | cflow.cs:240:9:245:9 | [exception(Exception)] {...} |
-| pre | cflow.cs:232:9:245:9 | try {...} ... | cflow.cs:240:9:245:9 | [exception(NullReferenceException)] {...} |
+| pre | cflow.cs:232:9:245:9 | try {...} ... | cflow.cs:240:9:245:9 | [finally: exception(Exception)] {...} |
+| pre | cflow.cs:232:9:245:9 | try {...} ... | cflow.cs:240:9:245:9 | [finally: exception(NullReferenceException)] {...} |
 | pre | cflow.cs:232:9:245:9 | try {...} ... | cflow.cs:240:9:245:9 | {...} |
 | pre | cflow.cs:232:9:245:9 | try {...} ... | cflow.cs:242:17:242:41 | ...; |
-| pre | cflow.cs:232:9:245:9 | try {...} ... | cflow.cs:242:17:242:41 | [exception(Exception)] ...; |
-| pre | cflow.cs:232:9:245:9 | try {...} ... | cflow.cs:242:17:242:41 | [exception(NullReferenceException)] ...; |
-| pre | cflow.cs:232:9:245:9 | try {...} ... | cflow.cs:242:17:242:41 | [exception(OutOfMemoryException)] ...; |
-| pre | cflow.cs:232:9:245:9 | try {...} ... | cflow.cs:242:17:242:41 | [return] ...; |
-| pre | cflow.cs:232:9:245:9 | try {...} ... | cflow.cs:243:13:244:37 | [exception(Exception)] if (...) ... |
-| pre | cflow.cs:232:9:245:9 | try {...} ... | cflow.cs:243:13:244:37 | [exception(NullReferenceException)] if (...) ... |
-| pre | cflow.cs:232:9:245:9 | try {...} ... | cflow.cs:243:13:244:37 | [exception(OutOfMemoryException)] if (...) ... |
-| pre | cflow.cs:232:9:245:9 | try {...} ... | cflow.cs:243:13:244:37 | [return] if (...) ... |
+| pre | cflow.cs:232:9:245:9 | try {...} ... | cflow.cs:242:17:242:41 | [finally: exception(Exception)] ...; |
+| pre | cflow.cs:232:9:245:9 | try {...} ... | cflow.cs:242:17:242:41 | [finally: exception(NullReferenceException)] ...; |
+| pre | cflow.cs:232:9:245:9 | try {...} ... | cflow.cs:242:17:242:41 | [finally: exception(OutOfMemoryException)] ...; |
+| pre | cflow.cs:232:9:245:9 | try {...} ... | cflow.cs:242:17:242:41 | [finally: return] ...; |
+| pre | cflow.cs:232:9:245:9 | try {...} ... | cflow.cs:243:13:244:37 | [finally: exception(Exception)] if (...) ... |
+| pre | cflow.cs:232:9:245:9 | try {...} ... | cflow.cs:243:13:244:37 | [finally: exception(NullReferenceException)] if (...) ... |
+| pre | cflow.cs:232:9:245:9 | try {...} ... | cflow.cs:243:13:244:37 | [finally: exception(OutOfMemoryException)] if (...) ... |
+| pre | cflow.cs:232:9:245:9 | try {...} ... | cflow.cs:243:13:244:37 | [finally: return] if (...) ... |
 | pre | cflow.cs:232:9:245:9 | try {...} ... | cflow.cs:243:13:244:37 | if (...) ... |
 | pre | cflow.cs:232:9:245:9 | try {...} ... | cflow.cs:244:17:244:37 | ...; |
-| pre | cflow.cs:232:9:245:9 | try {...} ... | cflow.cs:244:17:244:37 | [exception(Exception)] ...; |
-| pre | cflow.cs:232:9:245:9 | try {...} ... | cflow.cs:244:17:244:37 | [exception(NullReferenceException)] ...; |
-| pre | cflow.cs:232:9:245:9 | try {...} ... | cflow.cs:244:17:244:37 | [exception(OutOfMemoryException)] ...; |
-| pre | cflow.cs:232:9:245:9 | try {...} ... | cflow.cs:244:17:244:37 | [return] ...; |
+| pre | cflow.cs:232:9:245:9 | try {...} ... | cflow.cs:244:17:244:37 | [finally: exception(Exception)] ...; |
+| pre | cflow.cs:232:9:245:9 | try {...} ... | cflow.cs:244:17:244:37 | [finally: exception(NullReferenceException)] ...; |
+| pre | cflow.cs:232:9:245:9 | try {...} ... | cflow.cs:244:17:244:37 | [finally: exception(OutOfMemoryException)] ...; |
+| pre | cflow.cs:232:9:245:9 | try {...} ... | cflow.cs:244:17:244:37 | [finally: return] ...; |
 | pre | cflow.cs:234:17:234:28 | access to property Length | cflow.cs:234:17:234:28 | access to property Length |
 | pre | cflow.cs:234:17:234:28 | access to property Length | cflow.cs:234:33:234:33 | 0 |
 | pre | cflow.cs:234:17:234:28 | access to property Length | cflow.cs:235:17:235:23 | return ...; |
@@ -2321,20 +2321,20 @@
 | pre | cflow.cs:234:17:234:28 | access to property Length | cflow.cs:236:33:236:33 | 1 |
 | pre | cflow.cs:234:17:234:28 | access to property Length | cflow.cs:237:17:237:49 | throw ...; |
 | pre | cflow.cs:234:17:234:28 | access to property Length | cflow.cs:237:23:237:48 | object creation of type OutOfMemoryException |
-| pre | cflow.cs:234:17:234:28 | access to property Length | cflow.cs:240:9:245:9 | [exception(Exception)] {...} |
+| pre | cflow.cs:234:17:234:28 | access to property Length | cflow.cs:240:9:245:9 | [finally: exception(Exception)] {...} |
 | pre | cflow.cs:234:17:234:28 | access to property Length | cflow.cs:240:9:245:9 | {...} |
 | pre | cflow.cs:234:17:234:28 | access to property Length | cflow.cs:242:17:242:41 | ...; |
-| pre | cflow.cs:234:17:234:28 | access to property Length | cflow.cs:242:17:242:41 | [exception(Exception)] ...; |
-| pre | cflow.cs:234:17:234:28 | access to property Length | cflow.cs:242:17:242:41 | [exception(OutOfMemoryException)] ...; |
-| pre | cflow.cs:234:17:234:28 | access to property Length | cflow.cs:242:17:242:41 | [return] ...; |
-| pre | cflow.cs:234:17:234:28 | access to property Length | cflow.cs:243:13:244:37 | [exception(Exception)] if (...) ... |
-| pre | cflow.cs:234:17:234:28 | access to property Length | cflow.cs:243:13:244:37 | [exception(OutOfMemoryException)] if (...) ... |
-| pre | cflow.cs:234:17:234:28 | access to property Length | cflow.cs:243:13:244:37 | [return] if (...) ... |
+| pre | cflow.cs:234:17:234:28 | access to property Length | cflow.cs:242:17:242:41 | [finally: exception(Exception)] ...; |
+| pre | cflow.cs:234:17:234:28 | access to property Length | cflow.cs:242:17:242:41 | [finally: exception(OutOfMemoryException)] ...; |
+| pre | cflow.cs:234:17:234:28 | access to property Length | cflow.cs:242:17:242:41 | [finally: return] ...; |
+| pre | cflow.cs:234:17:234:28 | access to property Length | cflow.cs:243:13:244:37 | [finally: exception(Exception)] if (...) ... |
+| pre | cflow.cs:234:17:234:28 | access to property Length | cflow.cs:243:13:244:37 | [finally: exception(OutOfMemoryException)] if (...) ... |
+| pre | cflow.cs:234:17:234:28 | access to property Length | cflow.cs:243:13:244:37 | [finally: return] if (...) ... |
 | pre | cflow.cs:234:17:234:28 | access to property Length | cflow.cs:243:13:244:37 | if (...) ... |
 | pre | cflow.cs:234:17:234:28 | access to property Length | cflow.cs:244:17:244:37 | ...; |
-| pre | cflow.cs:234:17:234:28 | access to property Length | cflow.cs:244:17:244:37 | [exception(Exception)] ...; |
-| pre | cflow.cs:234:17:234:28 | access to property Length | cflow.cs:244:17:244:37 | [exception(OutOfMemoryException)] ...; |
-| pre | cflow.cs:234:17:234:28 | access to property Length | cflow.cs:244:17:244:37 | [return] ...; |
+| pre | cflow.cs:234:17:234:28 | access to property Length | cflow.cs:244:17:244:37 | [finally: exception(Exception)] ...; |
+| pre | cflow.cs:234:17:234:28 | access to property Length | cflow.cs:244:17:244:37 | [finally: exception(OutOfMemoryException)] ...; |
+| pre | cflow.cs:234:17:234:28 | access to property Length | cflow.cs:244:17:244:37 | [finally: return] ...; |
 | pre | cflow.cs:234:33:234:33 | 0 | cflow.cs:234:33:234:33 | 0 |
 | pre | cflow.cs:234:33:234:33 | 0 | cflow.cs:235:17:235:23 | return ...; |
 | pre | cflow.cs:234:33:234:33 | 0 | cflow.cs:236:13:237:49 | if (...) ... |
@@ -2344,18 +2344,18 @@
 | pre | cflow.cs:234:33:234:33 | 0 | cflow.cs:237:23:237:48 | object creation of type OutOfMemoryException |
 | pre | cflow.cs:234:33:234:33 | 0 | cflow.cs:240:9:245:9 | {...} |
 | pre | cflow.cs:234:33:234:33 | 0 | cflow.cs:242:17:242:41 | ...; |
-| pre | cflow.cs:234:33:234:33 | 0 | cflow.cs:242:17:242:41 | [exception(OutOfMemoryException)] ...; |
-| pre | cflow.cs:234:33:234:33 | 0 | cflow.cs:242:17:242:41 | [return] ...; |
-| pre | cflow.cs:234:33:234:33 | 0 | cflow.cs:243:13:244:37 | [exception(OutOfMemoryException)] if (...) ... |
-| pre | cflow.cs:234:33:234:33 | 0 | cflow.cs:243:13:244:37 | [return] if (...) ... |
+| pre | cflow.cs:234:33:234:33 | 0 | cflow.cs:242:17:242:41 | [finally: exception(OutOfMemoryException)] ...; |
+| pre | cflow.cs:234:33:234:33 | 0 | cflow.cs:242:17:242:41 | [finally: return] ...; |
+| pre | cflow.cs:234:33:234:33 | 0 | cflow.cs:243:13:244:37 | [finally: exception(OutOfMemoryException)] if (...) ... |
+| pre | cflow.cs:234:33:234:33 | 0 | cflow.cs:243:13:244:37 | [finally: return] if (...) ... |
 | pre | cflow.cs:234:33:234:33 | 0 | cflow.cs:243:13:244:37 | if (...) ... |
 | pre | cflow.cs:234:33:234:33 | 0 | cflow.cs:244:17:244:37 | ...; |
-| pre | cflow.cs:234:33:234:33 | 0 | cflow.cs:244:17:244:37 | [exception(OutOfMemoryException)] ...; |
-| pre | cflow.cs:234:33:234:33 | 0 | cflow.cs:244:17:244:37 | [return] ...; |
+| pre | cflow.cs:234:33:234:33 | 0 | cflow.cs:244:17:244:37 | [finally: exception(OutOfMemoryException)] ...; |
+| pre | cflow.cs:234:33:234:33 | 0 | cflow.cs:244:17:244:37 | [finally: return] ...; |
 | pre | cflow.cs:235:17:235:23 | return ...; | cflow.cs:235:17:235:23 | return ...; |
-| pre | cflow.cs:235:17:235:23 | return ...; | cflow.cs:242:17:242:41 | [return] ...; |
-| pre | cflow.cs:235:17:235:23 | return ...; | cflow.cs:243:13:244:37 | [return] if (...) ... |
-| pre | cflow.cs:235:17:235:23 | return ...; | cflow.cs:244:17:244:37 | [return] ...; |
+| pre | cflow.cs:235:17:235:23 | return ...; | cflow.cs:242:17:242:41 | [finally: return] ...; |
+| pre | cflow.cs:235:17:235:23 | return ...; | cflow.cs:243:13:244:37 | [finally: return] if (...) ... |
+| pre | cflow.cs:235:17:235:23 | return ...; | cflow.cs:244:17:244:37 | [finally: return] ...; |
 | pre | cflow.cs:236:13:237:49 | if (...) ... | cflow.cs:236:13:237:49 | if (...) ... |
 | pre | cflow.cs:236:13:237:49 | if (...) ... | cflow.cs:236:17:236:28 | access to property Length |
 | pre | cflow.cs:236:13:237:49 | if (...) ... | cflow.cs:236:33:236:33 | 1 |
@@ -2363,73 +2363,73 @@
 | pre | cflow.cs:236:13:237:49 | if (...) ... | cflow.cs:237:23:237:48 | object creation of type OutOfMemoryException |
 | pre | cflow.cs:236:13:237:49 | if (...) ... | cflow.cs:240:9:245:9 | {...} |
 | pre | cflow.cs:236:13:237:49 | if (...) ... | cflow.cs:242:17:242:41 | ...; |
-| pre | cflow.cs:236:13:237:49 | if (...) ... | cflow.cs:242:17:242:41 | [exception(OutOfMemoryException)] ...; |
-| pre | cflow.cs:236:13:237:49 | if (...) ... | cflow.cs:243:13:244:37 | [exception(OutOfMemoryException)] if (...) ... |
+| pre | cflow.cs:236:13:237:49 | if (...) ... | cflow.cs:242:17:242:41 | [finally: exception(OutOfMemoryException)] ...; |
+| pre | cflow.cs:236:13:237:49 | if (...) ... | cflow.cs:243:13:244:37 | [finally: exception(OutOfMemoryException)] if (...) ... |
 | pre | cflow.cs:236:13:237:49 | if (...) ... | cflow.cs:243:13:244:37 | if (...) ... |
 | pre | cflow.cs:236:13:237:49 | if (...) ... | cflow.cs:244:17:244:37 | ...; |
-| pre | cflow.cs:236:13:237:49 | if (...) ... | cflow.cs:244:17:244:37 | [exception(OutOfMemoryException)] ...; |
+| pre | cflow.cs:236:13:237:49 | if (...) ... | cflow.cs:244:17:244:37 | [finally: exception(OutOfMemoryException)] ...; |
 | pre | cflow.cs:236:17:236:28 | access to property Length | cflow.cs:236:17:236:28 | access to property Length |
 | pre | cflow.cs:236:17:236:28 | access to property Length | cflow.cs:236:33:236:33 | 1 |
 | pre | cflow.cs:236:17:236:28 | access to property Length | cflow.cs:237:17:237:49 | throw ...; |
 | pre | cflow.cs:236:17:236:28 | access to property Length | cflow.cs:237:23:237:48 | object creation of type OutOfMemoryException |
 | pre | cflow.cs:236:17:236:28 | access to property Length | cflow.cs:240:9:245:9 | {...} |
 | pre | cflow.cs:236:17:236:28 | access to property Length | cflow.cs:242:17:242:41 | ...; |
-| pre | cflow.cs:236:17:236:28 | access to property Length | cflow.cs:242:17:242:41 | [exception(OutOfMemoryException)] ...; |
-| pre | cflow.cs:236:17:236:28 | access to property Length | cflow.cs:243:13:244:37 | [exception(OutOfMemoryException)] if (...) ... |
+| pre | cflow.cs:236:17:236:28 | access to property Length | cflow.cs:242:17:242:41 | [finally: exception(OutOfMemoryException)] ...; |
+| pre | cflow.cs:236:17:236:28 | access to property Length | cflow.cs:243:13:244:37 | [finally: exception(OutOfMemoryException)] if (...) ... |
 | pre | cflow.cs:236:17:236:28 | access to property Length | cflow.cs:243:13:244:37 | if (...) ... |
 | pre | cflow.cs:236:17:236:28 | access to property Length | cflow.cs:244:17:244:37 | ...; |
-| pre | cflow.cs:236:17:236:28 | access to property Length | cflow.cs:244:17:244:37 | [exception(OutOfMemoryException)] ...; |
+| pre | cflow.cs:236:17:236:28 | access to property Length | cflow.cs:244:17:244:37 | [finally: exception(OutOfMemoryException)] ...; |
 | pre | cflow.cs:236:33:236:33 | 1 | cflow.cs:236:33:236:33 | 1 |
 | pre | cflow.cs:236:33:236:33 | 1 | cflow.cs:237:17:237:49 | throw ...; |
 | pre | cflow.cs:236:33:236:33 | 1 | cflow.cs:237:23:237:48 | object creation of type OutOfMemoryException |
 | pre | cflow.cs:236:33:236:33 | 1 | cflow.cs:240:9:245:9 | {...} |
 | pre | cflow.cs:236:33:236:33 | 1 | cflow.cs:242:17:242:41 | ...; |
-| pre | cflow.cs:236:33:236:33 | 1 | cflow.cs:242:17:242:41 | [exception(OutOfMemoryException)] ...; |
-| pre | cflow.cs:236:33:236:33 | 1 | cflow.cs:243:13:244:37 | [exception(OutOfMemoryException)] if (...) ... |
+| pre | cflow.cs:236:33:236:33 | 1 | cflow.cs:242:17:242:41 | [finally: exception(OutOfMemoryException)] ...; |
+| pre | cflow.cs:236:33:236:33 | 1 | cflow.cs:243:13:244:37 | [finally: exception(OutOfMemoryException)] if (...) ... |
 | pre | cflow.cs:236:33:236:33 | 1 | cflow.cs:243:13:244:37 | if (...) ... |
 | pre | cflow.cs:236:33:236:33 | 1 | cflow.cs:244:17:244:37 | ...; |
-| pre | cflow.cs:236:33:236:33 | 1 | cflow.cs:244:17:244:37 | [exception(OutOfMemoryException)] ...; |
+| pre | cflow.cs:236:33:236:33 | 1 | cflow.cs:244:17:244:37 | [finally: exception(OutOfMemoryException)] ...; |
 | pre | cflow.cs:237:17:237:49 | throw ...; | cflow.cs:237:17:237:49 | throw ...; |
-| pre | cflow.cs:237:17:237:49 | throw ...; | cflow.cs:242:17:242:41 | [exception(OutOfMemoryException)] ...; |
-| pre | cflow.cs:237:17:237:49 | throw ...; | cflow.cs:243:13:244:37 | [exception(OutOfMemoryException)] if (...) ... |
-| pre | cflow.cs:237:17:237:49 | throw ...; | cflow.cs:244:17:244:37 | [exception(OutOfMemoryException)] ...; |
+| pre | cflow.cs:237:17:237:49 | throw ...; | cflow.cs:242:17:242:41 | [finally: exception(OutOfMemoryException)] ...; |
+| pre | cflow.cs:237:17:237:49 | throw ...; | cflow.cs:243:13:244:37 | [finally: exception(OutOfMemoryException)] if (...) ... |
+| pre | cflow.cs:237:17:237:49 | throw ...; | cflow.cs:244:17:244:37 | [finally: exception(OutOfMemoryException)] ...; |
 | pre | cflow.cs:237:23:237:48 | object creation of type OutOfMemoryException | cflow.cs:237:17:237:49 | throw ...; |
 | pre | cflow.cs:237:23:237:48 | object creation of type OutOfMemoryException | cflow.cs:237:23:237:48 | object creation of type OutOfMemoryException |
-| pre | cflow.cs:237:23:237:48 | object creation of type OutOfMemoryException | cflow.cs:242:17:242:41 | [exception(OutOfMemoryException)] ...; |
-| pre | cflow.cs:237:23:237:48 | object creation of type OutOfMemoryException | cflow.cs:243:13:244:37 | [exception(OutOfMemoryException)] if (...) ... |
-| pre | cflow.cs:237:23:237:48 | object creation of type OutOfMemoryException | cflow.cs:244:17:244:37 | [exception(OutOfMemoryException)] ...; |
-| pre | cflow.cs:240:9:245:9 | [exception(Exception)] {...} | cflow.cs:240:9:245:9 | [exception(Exception)] {...} |
-| pre | cflow.cs:240:9:245:9 | [exception(Exception)] {...} | cflow.cs:242:17:242:41 | [exception(Exception)] ...; |
-| pre | cflow.cs:240:9:245:9 | [exception(Exception)] {...} | cflow.cs:243:13:244:37 | [exception(Exception)] if (...) ... |
-| pre | cflow.cs:240:9:245:9 | [exception(Exception)] {...} | cflow.cs:244:17:244:37 | [exception(Exception)] ...; |
-| pre | cflow.cs:240:9:245:9 | [exception(NullReferenceException)] {...} | cflow.cs:240:9:245:9 | [exception(NullReferenceException)] {...} |
-| pre | cflow.cs:240:9:245:9 | [exception(NullReferenceException)] {...} | cflow.cs:242:17:242:41 | [exception(NullReferenceException)] ...; |
-| pre | cflow.cs:240:9:245:9 | [exception(NullReferenceException)] {...} | cflow.cs:243:13:244:37 | [exception(NullReferenceException)] if (...) ... |
-| pre | cflow.cs:240:9:245:9 | [exception(NullReferenceException)] {...} | cflow.cs:244:17:244:37 | [exception(NullReferenceException)] ...; |
+| pre | cflow.cs:237:23:237:48 | object creation of type OutOfMemoryException | cflow.cs:242:17:242:41 | [finally: exception(OutOfMemoryException)] ...; |
+| pre | cflow.cs:237:23:237:48 | object creation of type OutOfMemoryException | cflow.cs:243:13:244:37 | [finally: exception(OutOfMemoryException)] if (...) ... |
+| pre | cflow.cs:237:23:237:48 | object creation of type OutOfMemoryException | cflow.cs:244:17:244:37 | [finally: exception(OutOfMemoryException)] ...; |
+| pre | cflow.cs:240:9:245:9 | [finally: exception(Exception)] {...} | cflow.cs:240:9:245:9 | [finally: exception(Exception)] {...} |
+| pre | cflow.cs:240:9:245:9 | [finally: exception(Exception)] {...} | cflow.cs:242:17:242:41 | [finally: exception(Exception)] ...; |
+| pre | cflow.cs:240:9:245:9 | [finally: exception(Exception)] {...} | cflow.cs:243:13:244:37 | [finally: exception(Exception)] if (...) ... |
+| pre | cflow.cs:240:9:245:9 | [finally: exception(Exception)] {...} | cflow.cs:244:17:244:37 | [finally: exception(Exception)] ...; |
+| pre | cflow.cs:240:9:245:9 | [finally: exception(NullReferenceException)] {...} | cflow.cs:240:9:245:9 | [finally: exception(NullReferenceException)] {...} |
+| pre | cflow.cs:240:9:245:9 | [finally: exception(NullReferenceException)] {...} | cflow.cs:242:17:242:41 | [finally: exception(NullReferenceException)] ...; |
+| pre | cflow.cs:240:9:245:9 | [finally: exception(NullReferenceException)] {...} | cflow.cs:243:13:244:37 | [finally: exception(NullReferenceException)] if (...) ... |
+| pre | cflow.cs:240:9:245:9 | [finally: exception(NullReferenceException)] {...} | cflow.cs:244:17:244:37 | [finally: exception(NullReferenceException)] ...; |
 | pre | cflow.cs:240:9:245:9 | {...} | cflow.cs:240:9:245:9 | {...} |
 | pre | cflow.cs:240:9:245:9 | {...} | cflow.cs:242:17:242:41 | ...; |
 | pre | cflow.cs:240:9:245:9 | {...} | cflow.cs:243:13:244:37 | if (...) ... |
 | pre | cflow.cs:240:9:245:9 | {...} | cflow.cs:244:17:244:37 | ...; |
 | pre | cflow.cs:242:17:242:41 | ...; | cflow.cs:242:17:242:41 | ...; |
-| pre | cflow.cs:242:17:242:41 | [exception(Exception)] ...; | cflow.cs:242:17:242:41 | [exception(Exception)] ...; |
-| pre | cflow.cs:242:17:242:41 | [exception(NullReferenceException)] ...; | cflow.cs:242:17:242:41 | [exception(NullReferenceException)] ...; |
-| pre | cflow.cs:242:17:242:41 | [exception(OutOfMemoryException)] ...; | cflow.cs:242:17:242:41 | [exception(OutOfMemoryException)] ...; |
-| pre | cflow.cs:242:17:242:41 | [return] ...; | cflow.cs:242:17:242:41 | [return] ...; |
-| pre | cflow.cs:243:13:244:37 | [exception(Exception)] if (...) ... | cflow.cs:243:13:244:37 | [exception(Exception)] if (...) ... |
-| pre | cflow.cs:243:13:244:37 | [exception(Exception)] if (...) ... | cflow.cs:244:17:244:37 | [exception(Exception)] ...; |
-| pre | cflow.cs:243:13:244:37 | [exception(NullReferenceException)] if (...) ... | cflow.cs:243:13:244:37 | [exception(NullReferenceException)] if (...) ... |
-| pre | cflow.cs:243:13:244:37 | [exception(NullReferenceException)] if (...) ... | cflow.cs:244:17:244:37 | [exception(NullReferenceException)] ...; |
-| pre | cflow.cs:243:13:244:37 | [exception(OutOfMemoryException)] if (...) ... | cflow.cs:243:13:244:37 | [exception(OutOfMemoryException)] if (...) ... |
-| pre | cflow.cs:243:13:244:37 | [exception(OutOfMemoryException)] if (...) ... | cflow.cs:244:17:244:37 | [exception(OutOfMemoryException)] ...; |
-| pre | cflow.cs:243:13:244:37 | [return] if (...) ... | cflow.cs:243:13:244:37 | [return] if (...) ... |
-| pre | cflow.cs:243:13:244:37 | [return] if (...) ... | cflow.cs:244:17:244:37 | [return] ...; |
+| pre | cflow.cs:242:17:242:41 | [finally: exception(Exception)] ...; | cflow.cs:242:17:242:41 | [finally: exception(Exception)] ...; |
+| pre | cflow.cs:242:17:242:41 | [finally: exception(NullReferenceException)] ...; | cflow.cs:242:17:242:41 | [finally: exception(NullReferenceException)] ...; |
+| pre | cflow.cs:242:17:242:41 | [finally: exception(OutOfMemoryException)] ...; | cflow.cs:242:17:242:41 | [finally: exception(OutOfMemoryException)] ...; |
+| pre | cflow.cs:242:17:242:41 | [finally: return] ...; | cflow.cs:242:17:242:41 | [finally: return] ...; |
+| pre | cflow.cs:243:13:244:37 | [finally: exception(Exception)] if (...) ... | cflow.cs:243:13:244:37 | [finally: exception(Exception)] if (...) ... |
+| pre | cflow.cs:243:13:244:37 | [finally: exception(Exception)] if (...) ... | cflow.cs:244:17:244:37 | [finally: exception(Exception)] ...; |
+| pre | cflow.cs:243:13:244:37 | [finally: exception(NullReferenceException)] if (...) ... | cflow.cs:243:13:244:37 | [finally: exception(NullReferenceException)] if (...) ... |
+| pre | cflow.cs:243:13:244:37 | [finally: exception(NullReferenceException)] if (...) ... | cflow.cs:244:17:244:37 | [finally: exception(NullReferenceException)] ...; |
+| pre | cflow.cs:243:13:244:37 | [finally: exception(OutOfMemoryException)] if (...) ... | cflow.cs:243:13:244:37 | [finally: exception(OutOfMemoryException)] if (...) ... |
+| pre | cflow.cs:243:13:244:37 | [finally: exception(OutOfMemoryException)] if (...) ... | cflow.cs:244:17:244:37 | [finally: exception(OutOfMemoryException)] ...; |
+| pre | cflow.cs:243:13:244:37 | [finally: return] if (...) ... | cflow.cs:243:13:244:37 | [finally: return] if (...) ... |
+| pre | cflow.cs:243:13:244:37 | [finally: return] if (...) ... | cflow.cs:244:17:244:37 | [finally: return] ...; |
 | pre | cflow.cs:243:13:244:37 | if (...) ... | cflow.cs:243:13:244:37 | if (...) ... |
 | pre | cflow.cs:243:13:244:37 | if (...) ... | cflow.cs:244:17:244:37 | ...; |
 | pre | cflow.cs:244:17:244:37 | ...; | cflow.cs:244:17:244:37 | ...; |
-| pre | cflow.cs:244:17:244:37 | [exception(Exception)] ...; | cflow.cs:244:17:244:37 | [exception(Exception)] ...; |
-| pre | cflow.cs:244:17:244:37 | [exception(NullReferenceException)] ...; | cflow.cs:244:17:244:37 | [exception(NullReferenceException)] ...; |
-| pre | cflow.cs:244:17:244:37 | [exception(OutOfMemoryException)] ...; | cflow.cs:244:17:244:37 | [exception(OutOfMemoryException)] ...; |
-| pre | cflow.cs:244:17:244:37 | [return] ...; | cflow.cs:244:17:244:37 | [return] ...; |
+| pre | cflow.cs:244:17:244:37 | [finally: exception(Exception)] ...; | cflow.cs:244:17:244:37 | [finally: exception(Exception)] ...; |
+| pre | cflow.cs:244:17:244:37 | [finally: exception(NullReferenceException)] ...; | cflow.cs:244:17:244:37 | [finally: exception(NullReferenceException)] ...; |
+| pre | cflow.cs:244:17:244:37 | [finally: exception(OutOfMemoryException)] ...; | cflow.cs:244:17:244:37 | [finally: exception(OutOfMemoryException)] ...; |
+| pre | cflow.cs:244:17:244:37 | [finally: return] ...; | cflow.cs:244:17:244:37 | [finally: return] ...; |
 | pre | cflow.cs:248:10:248:12 | enter For | cflow.cs:248:10:248:12 | enter For |
 | pre | cflow.cs:248:10:248:12 | enter For | cflow.cs:248:10:248:12 | exit For |
 | pre | cflow.cs:248:10:248:12 | enter For | cflow.cs:251:16:251:16 | access to local variable x |
@@ -2683,15 +2683,15 @@
 | pre | cflow.cs:393:10:393:10 | enter M | cflow.cs:393:10:393:10 | enter M |
 | pre | cflow.cs:393:10:393:10 | enter M | cflow.cs:393:10:393:10 | exit M |
 | pre | cflow.cs:393:10:393:10 | enter M | cflow.cs:397:13:397:36 | call to method WriteLine |
-| pre | cflow.cs:393:10:393:10 | enter M | cflow.cs:400:9:403:9 | [exception(Exception)] {...} |
-| pre | cflow.cs:393:10:393:10 | enter M | cflow.cs:400:9:403:9 | [exception(OutOfMemoryException)] {...} |
+| pre | cflow.cs:393:10:393:10 | enter M | cflow.cs:400:9:403:9 | [finally: exception(Exception)] {...} |
+| pre | cflow.cs:393:10:393:10 | enter M | cflow.cs:400:9:403:9 | [finally: exception(OutOfMemoryException)] {...} |
 | pre | cflow.cs:393:10:393:10 | enter M | cflow.cs:400:9:403:9 | {...} |
 | pre | cflow.cs:393:10:393:10 | exit M | cflow.cs:393:10:393:10 | exit M |
 | pre | cflow.cs:397:13:397:36 | call to method WriteLine | cflow.cs:397:13:397:36 | call to method WriteLine |
-| pre | cflow.cs:397:13:397:36 | call to method WriteLine | cflow.cs:400:9:403:9 | [exception(Exception)] {...} |
+| pre | cflow.cs:397:13:397:36 | call to method WriteLine | cflow.cs:400:9:403:9 | [finally: exception(Exception)] {...} |
 | pre | cflow.cs:397:13:397:36 | call to method WriteLine | cflow.cs:400:9:403:9 | {...} |
-| pre | cflow.cs:400:9:403:9 | [exception(Exception)] {...} | cflow.cs:400:9:403:9 | [exception(Exception)] {...} |
-| pre | cflow.cs:400:9:403:9 | [exception(OutOfMemoryException)] {...} | cflow.cs:400:9:403:9 | [exception(OutOfMemoryException)] {...} |
+| pre | cflow.cs:400:9:403:9 | [finally: exception(Exception)] {...} | cflow.cs:400:9:403:9 | [finally: exception(Exception)] {...} |
+| pre | cflow.cs:400:9:403:9 | [finally: exception(OutOfMemoryException)] {...} | cflow.cs:400:9:403:9 | [finally: exception(OutOfMemoryException)] {...} |
 | pre | cflow.cs:400:9:403:9 | {...} | cflow.cs:400:9:403:9 | {...} |
 | pre | cflow.cs:410:12:410:12 | enter M | cflow.cs:410:12:410:12 | enter M |
 | pre | cflow.cs:415:5:415:25 | enter NegationInConstructor | cflow.cs:415:5:415:25 | enter NegationInConstructor |

--- a/csharp/ql/test/library-tests/controlflow/graph/CatchInFinally.cs
+++ b/csharp/ql/test/library-tests/controlflow/graph/CatchInFinally.cs
@@ -1,0 +1,29 @@
+using System;
+
+class CatchInFinally
+{
+    void M1(string[] args)
+    {
+        try
+        {
+            if (args == null)
+                throw new ArgumentNullException();
+        }
+        finally
+        {
+            try
+            {
+                if (args.Length == 1)
+                    throw new Exception("1");
+            }
+            catch (Exception e) when (e.Message == "1")
+            {
+                Console.WriteLine(args[0]);
+            }
+            catch
+            {
+                Console.WriteLine("");
+            }
+        }
+    }
+}

--- a/csharp/ql/test/library-tests/controlflow/graph/ConditionBlock.expected
+++ b/csharp/ql/test/library-tests/controlflow/graph/ConditionBlock.expected
@@ -3,30 +3,30 @@
 | BreakInTry.cs:26:21:26:31 | ... == ... | BreakInTry.cs:27:21:27:26 | break; | true |
 | BreakInTry.cs:26:21:26:31 | ... == ... | BreakInTry.cs:30:13:33:13 | {...} | false |
 | BreakInTry.cs:26:21:26:31 | ... == ... | BreakInTry.cs:32:21:32:21 | ; | false |
-| BreakInTry.cs:26:21:26:31 | ... == ... | BreakInTry.cs:32:21:32:21 | [break] ; | true |
+| BreakInTry.cs:26:21:26:31 | ... == ... | BreakInTry.cs:32:21:32:21 | [finally: break] ; | true |
 | BreakInTry.cs:31:21:31:32 | ... == ... | BreakInTry.cs:32:21:32:21 | ; | true |
-| BreakInTry.cs:31:21:31:32 | [break] ... == ... | BreakInTry.cs:32:21:32:21 | [break] ; | true |
+| BreakInTry.cs:31:21:31:32 | [finally: break] ... == ... | BreakInTry.cs:32:21:32:21 | [finally: break] ; | true |
 | BreakInTry.cs:42:17:42:28 | ... == ... | BreakInTry.cs:43:17:43:23 | return ...; | true |
 | BreakInTry.cs:42:17:42:28 | ... == ... | BreakInTry.cs:46:9:52:9 | {...} | false |
-| BreakInTry.cs:42:17:42:28 | ... == ... | BreakInTry.cs:47:13:51:13 | [return] foreach (... ... in ...) ... | true |
+| BreakInTry.cs:42:17:42:28 | ... == ... | BreakInTry.cs:47:13:51:13 | [finally: return] foreach (... ... in ...) ... | true |
 | BreakInTry.cs:42:17:42:28 | ... == ... | BreakInTry.cs:47:13:51:13 | foreach (... ... in ...) ... | false |
 | BreakInTry.cs:42:17:42:28 | ... == ... | BreakInTry.cs:47:26:47:28 | String arg | false |
-| BreakInTry.cs:42:17:42:28 | ... == ... | BreakInTry.cs:47:26:47:28 | [return] String arg | true |
-| BreakInTry.cs:42:17:42:28 | ... == ... | BreakInTry.cs:50:21:50:26 | [return] break; | true |
+| BreakInTry.cs:42:17:42:28 | ... == ... | BreakInTry.cs:47:26:47:28 | [finally: return] String arg | true |
+| BreakInTry.cs:42:17:42:28 | ... == ... | BreakInTry.cs:50:21:50:26 | [finally: return] break; | true |
 | BreakInTry.cs:42:17:42:28 | ... == ... | BreakInTry.cs:50:21:50:26 | break; | false |
 | BreakInTry.cs:42:17:42:28 | ... == ... | BreakInTry.cs:53:7:53:7 | ; | false |
 | BreakInTry.cs:49:21:49:31 | ... == ... | BreakInTry.cs:50:21:50:26 | break; | true |
-| BreakInTry.cs:49:21:49:31 | [return] ... == ... | BreakInTry.cs:50:21:50:26 | [return] break; | true |
+| BreakInTry.cs:49:21:49:31 | [finally: return] ... == ... | BreakInTry.cs:50:21:50:26 | [finally: return] break; | true |
 | BreakInTry.cs:60:17:60:28 | ... == ... | BreakInTry.cs:61:17:61:23 | return ...; | true |
 | BreakInTry.cs:60:17:60:28 | ... == ... | BreakInTry.cs:64:9:70:9 | {...} | false |
-| BreakInTry.cs:60:17:60:28 | ... == ... | BreakInTry.cs:65:13:69:13 | [return] foreach (... ... in ...) ... | true |
+| BreakInTry.cs:60:17:60:28 | ... == ... | BreakInTry.cs:65:13:69:13 | [finally: return] foreach (... ... in ...) ... | true |
 | BreakInTry.cs:60:17:60:28 | ... == ... | BreakInTry.cs:65:13:69:13 | foreach (... ... in ...) ... | false |
 | BreakInTry.cs:60:17:60:28 | ... == ... | BreakInTry.cs:65:26:65:28 | String arg | false |
-| BreakInTry.cs:60:17:60:28 | ... == ... | BreakInTry.cs:65:26:65:28 | [return] String arg | true |
-| BreakInTry.cs:60:17:60:28 | ... == ... | BreakInTry.cs:68:21:68:26 | [return] break; | true |
+| BreakInTry.cs:60:17:60:28 | ... == ... | BreakInTry.cs:65:26:65:28 | [finally: return] String arg | true |
+| BreakInTry.cs:60:17:60:28 | ... == ... | BreakInTry.cs:68:21:68:26 | [finally: return] break; | true |
 | BreakInTry.cs:60:17:60:28 | ... == ... | BreakInTry.cs:68:21:68:26 | break; | false |
 | BreakInTry.cs:67:21:67:31 | ... == ... | BreakInTry.cs:68:21:68:26 | break; | true |
-| BreakInTry.cs:67:21:67:31 | [return] ... == ... | BreakInTry.cs:68:21:68:26 | [return] break; | true |
+| BreakInTry.cs:67:21:67:31 | [finally: return] ... == ... | BreakInTry.cs:68:21:68:26 | [finally: return] break; | true |
 | ConditionalAccess.cs:13:13:13:25 | ... > ... | ConditionalAccess.cs:14:20:14:20 | 0 | true |
 | ConditionalAccess.cs:13:13:13:25 | ... > ... | ConditionalAccess.cs:16:20:16:20 | 1 | false |
 | ExitMethods.cs:54:13:54:13 | access to parameter b | ExitMethods.cs:55:19:55:33 | object creation of type Exception | true |
@@ -141,18 +141,18 @@
 | cflow.cs:207:16:207:20 | ... > ... | cflow.cs:215:17:216:26 | if (...) ... | true |
 | cflow.cs:207:16:207:20 | ... > ... | cflow.cs:216:21:216:26 | break; | true |
 | cflow.cs:207:16:207:20 | ... > ... | cflow.cs:219:13:229:13 | {...} | true |
-| cflow.cs:207:16:207:20 | ... > ... | cflow.cs:223:25:223:46 | [break] throw ...; | true |
-| cflow.cs:207:16:207:20 | ... > ... | cflow.cs:223:25:223:46 | [continue] throw ...; | true |
-| cflow.cs:207:16:207:20 | ... > ... | cflow.cs:223:25:223:46 | [return] throw ...; | true |
+| cflow.cs:207:16:207:20 | ... > ... | cflow.cs:223:25:223:46 | [finally: break] throw ...; | true |
+| cflow.cs:207:16:207:20 | ... > ... | cflow.cs:223:25:223:46 | [finally: continue] throw ...; | true |
+| cflow.cs:207:16:207:20 | ... > ... | cflow.cs:223:25:223:46 | [finally: return] throw ...; | true |
 | cflow.cs:207:16:207:20 | ... > ... | cflow.cs:223:25:223:46 | throw ...; | true |
-| cflow.cs:207:16:207:20 | ... > ... | cflow.cs:223:31:223:45 | [break] object creation of type Exception | true |
-| cflow.cs:207:16:207:20 | ... > ... | cflow.cs:223:31:223:45 | [continue] object creation of type Exception | true |
-| cflow.cs:207:16:207:20 | ... > ... | cflow.cs:223:31:223:45 | [return] object creation of type Exception | true |
+| cflow.cs:207:16:207:20 | ... > ... | cflow.cs:223:31:223:45 | [finally: break] object creation of type Exception | true |
+| cflow.cs:207:16:207:20 | ... > ... | cflow.cs:223:31:223:45 | [finally: continue] object creation of type Exception | true |
+| cflow.cs:207:16:207:20 | ... > ... | cflow.cs:223:31:223:45 | [finally: return] object creation of type Exception | true |
 | cflow.cs:207:16:207:20 | ... > ... | cflow.cs:223:31:223:45 | object creation of type Exception | true |
-| cflow.cs:207:16:207:20 | ... > ... | cflow.cs:226:17:228:17 | [break] {...} | true |
-| cflow.cs:207:16:207:20 | ... > ... | cflow.cs:226:17:228:17 | [continue] {...} | true |
-| cflow.cs:207:16:207:20 | ... > ... | cflow.cs:226:17:228:17 | [exception(Exception)] {...} | true |
-| cflow.cs:207:16:207:20 | ... > ... | cflow.cs:226:17:228:17 | [return] {...} | true |
+| cflow.cs:207:16:207:20 | ... > ... | cflow.cs:226:17:228:17 | [finally: break] {...} | true |
+| cflow.cs:207:16:207:20 | ... > ... | cflow.cs:226:17:228:17 | [finally: continue] {...} | true |
+| cflow.cs:207:16:207:20 | ... > ... | cflow.cs:226:17:228:17 | [finally: exception(Exception)] {...} | true |
+| cflow.cs:207:16:207:20 | ... > ... | cflow.cs:226:17:228:17 | [finally: return] {...} | true |
 | cflow.cs:207:16:207:20 | ... > ... | cflow.cs:226:17:228:17 | {...} | true |
 | cflow.cs:211:21:211:26 | ... == ... | cflow.cs:212:21:212:27 | return ...; | true |
 | cflow.cs:211:21:211:26 | ... == ... | cflow.cs:213:17:214:29 | if (...) ... | false |
@@ -160,51 +160,51 @@
 | cflow.cs:211:21:211:26 | ... == ... | cflow.cs:215:17:216:26 | if (...) ... | false |
 | cflow.cs:211:21:211:26 | ... == ... | cflow.cs:216:21:216:26 | break; | false |
 | cflow.cs:211:21:211:26 | ... == ... | cflow.cs:219:13:229:13 | {...} | false |
-| cflow.cs:211:21:211:26 | ... == ... | cflow.cs:223:25:223:46 | [break] throw ...; | false |
-| cflow.cs:211:21:211:26 | ... == ... | cflow.cs:223:25:223:46 | [continue] throw ...; | false |
-| cflow.cs:211:21:211:26 | ... == ... | cflow.cs:223:25:223:46 | [return] throw ...; | true |
+| cflow.cs:211:21:211:26 | ... == ... | cflow.cs:223:25:223:46 | [finally: break] throw ...; | false |
+| cflow.cs:211:21:211:26 | ... == ... | cflow.cs:223:25:223:46 | [finally: continue] throw ...; | false |
+| cflow.cs:211:21:211:26 | ... == ... | cflow.cs:223:25:223:46 | [finally: return] throw ...; | true |
 | cflow.cs:211:21:211:26 | ... == ... | cflow.cs:223:25:223:46 | throw ...; | false |
-| cflow.cs:211:21:211:26 | ... == ... | cflow.cs:223:31:223:45 | [break] object creation of type Exception | false |
-| cflow.cs:211:21:211:26 | ... == ... | cflow.cs:223:31:223:45 | [continue] object creation of type Exception | false |
-| cflow.cs:211:21:211:26 | ... == ... | cflow.cs:223:31:223:45 | [return] object creation of type Exception | true |
+| cflow.cs:211:21:211:26 | ... == ... | cflow.cs:223:31:223:45 | [finally: break] object creation of type Exception | false |
+| cflow.cs:211:21:211:26 | ... == ... | cflow.cs:223:31:223:45 | [finally: continue] object creation of type Exception | false |
+| cflow.cs:211:21:211:26 | ... == ... | cflow.cs:223:31:223:45 | [finally: return] object creation of type Exception | true |
 | cflow.cs:211:21:211:26 | ... == ... | cflow.cs:223:31:223:45 | object creation of type Exception | false |
-| cflow.cs:211:21:211:26 | ... == ... | cflow.cs:226:17:228:17 | [break] {...} | false |
-| cflow.cs:211:21:211:26 | ... == ... | cflow.cs:226:17:228:17 | [continue] {...} | false |
-| cflow.cs:211:21:211:26 | ... == ... | cflow.cs:226:17:228:17 | [return] {...} | true |
+| cflow.cs:211:21:211:26 | ... == ... | cflow.cs:226:17:228:17 | [finally: break] {...} | false |
+| cflow.cs:211:21:211:26 | ... == ... | cflow.cs:226:17:228:17 | [finally: continue] {...} | false |
+| cflow.cs:211:21:211:26 | ... == ... | cflow.cs:226:17:228:17 | [finally: return] {...} | true |
 | cflow.cs:211:21:211:26 | ... == ... | cflow.cs:226:17:228:17 | {...} | false |
 | cflow.cs:213:21:213:26 | ... == ... | cflow.cs:214:21:214:29 | continue; | true |
 | cflow.cs:213:21:213:26 | ... == ... | cflow.cs:215:17:216:26 | if (...) ... | false |
 | cflow.cs:213:21:213:26 | ... == ... | cflow.cs:216:21:216:26 | break; | false |
 | cflow.cs:213:21:213:26 | ... == ... | cflow.cs:219:13:229:13 | {...} | false |
-| cflow.cs:213:21:213:26 | ... == ... | cflow.cs:223:25:223:46 | [break] throw ...; | false |
-| cflow.cs:213:21:213:26 | ... == ... | cflow.cs:223:25:223:46 | [continue] throw ...; | true |
+| cflow.cs:213:21:213:26 | ... == ... | cflow.cs:223:25:223:46 | [finally: break] throw ...; | false |
+| cflow.cs:213:21:213:26 | ... == ... | cflow.cs:223:25:223:46 | [finally: continue] throw ...; | true |
 | cflow.cs:213:21:213:26 | ... == ... | cflow.cs:223:25:223:46 | throw ...; | false |
-| cflow.cs:213:21:213:26 | ... == ... | cflow.cs:223:31:223:45 | [break] object creation of type Exception | false |
-| cflow.cs:213:21:213:26 | ... == ... | cflow.cs:223:31:223:45 | [continue] object creation of type Exception | true |
+| cflow.cs:213:21:213:26 | ... == ... | cflow.cs:223:31:223:45 | [finally: break] object creation of type Exception | false |
+| cflow.cs:213:21:213:26 | ... == ... | cflow.cs:223:31:223:45 | [finally: continue] object creation of type Exception | true |
 | cflow.cs:213:21:213:26 | ... == ... | cflow.cs:223:31:223:45 | object creation of type Exception | false |
-| cflow.cs:213:21:213:26 | ... == ... | cflow.cs:226:17:228:17 | [break] {...} | false |
-| cflow.cs:213:21:213:26 | ... == ... | cflow.cs:226:17:228:17 | [continue] {...} | true |
+| cflow.cs:213:21:213:26 | ... == ... | cflow.cs:226:17:228:17 | [finally: break] {...} | false |
+| cflow.cs:213:21:213:26 | ... == ... | cflow.cs:226:17:228:17 | [finally: continue] {...} | true |
 | cflow.cs:213:21:213:26 | ... == ... | cflow.cs:226:17:228:17 | {...} | false |
 | cflow.cs:215:21:215:26 | ... == ... | cflow.cs:216:21:216:26 | break; | true |
 | cflow.cs:215:21:215:26 | ... == ... | cflow.cs:219:13:229:13 | {...} | false |
-| cflow.cs:215:21:215:26 | ... == ... | cflow.cs:223:25:223:46 | [break] throw ...; | true |
+| cflow.cs:215:21:215:26 | ... == ... | cflow.cs:223:25:223:46 | [finally: break] throw ...; | true |
 | cflow.cs:215:21:215:26 | ... == ... | cflow.cs:223:25:223:46 | throw ...; | false |
-| cflow.cs:215:21:215:26 | ... == ... | cflow.cs:223:31:223:45 | [break] object creation of type Exception | true |
+| cflow.cs:215:21:215:26 | ... == ... | cflow.cs:223:31:223:45 | [finally: break] object creation of type Exception | true |
 | cflow.cs:215:21:215:26 | ... == ... | cflow.cs:223:31:223:45 | object creation of type Exception | false |
-| cflow.cs:215:21:215:26 | ... == ... | cflow.cs:226:17:228:17 | [break] {...} | true |
+| cflow.cs:215:21:215:26 | ... == ... | cflow.cs:226:17:228:17 | [finally: break] {...} | true |
 | cflow.cs:215:21:215:26 | ... == ... | cflow.cs:226:17:228:17 | {...} | false |
 | cflow.cs:222:25:222:30 | ... == ... | cflow.cs:223:25:223:46 | throw ...; | true |
 | cflow.cs:222:25:222:30 | ... == ... | cflow.cs:223:31:223:45 | object creation of type Exception | true |
 | cflow.cs:222:25:222:30 | ... == ... | cflow.cs:226:17:228:17 | {...} | false |
-| cflow.cs:222:25:222:30 | [break] ... == ... | cflow.cs:223:25:223:46 | [break] throw ...; | true |
-| cflow.cs:222:25:222:30 | [break] ... == ... | cflow.cs:223:31:223:45 | [break] object creation of type Exception | true |
-| cflow.cs:222:25:222:30 | [break] ... == ... | cflow.cs:226:17:228:17 | [break] {...} | false |
-| cflow.cs:222:25:222:30 | [continue] ... == ... | cflow.cs:223:25:223:46 | [continue] throw ...; | true |
-| cflow.cs:222:25:222:30 | [continue] ... == ... | cflow.cs:223:31:223:45 | [continue] object creation of type Exception | true |
-| cflow.cs:222:25:222:30 | [continue] ... == ... | cflow.cs:226:17:228:17 | [continue] {...} | false |
-| cflow.cs:222:25:222:30 | [return] ... == ... | cflow.cs:223:25:223:46 | [return] throw ...; | true |
-| cflow.cs:222:25:222:30 | [return] ... == ... | cflow.cs:223:31:223:45 | [return] object creation of type Exception | true |
-| cflow.cs:222:25:222:30 | [return] ... == ... | cflow.cs:226:17:228:17 | [return] {...} | false |
+| cflow.cs:222:25:222:30 | [finally: break] ... == ... | cflow.cs:223:25:223:46 | [finally: break] throw ...; | true |
+| cflow.cs:222:25:222:30 | [finally: break] ... == ... | cflow.cs:223:31:223:45 | [finally: break] object creation of type Exception | true |
+| cflow.cs:222:25:222:30 | [finally: break] ... == ... | cflow.cs:226:17:228:17 | [finally: break] {...} | false |
+| cflow.cs:222:25:222:30 | [finally: continue] ... == ... | cflow.cs:223:25:223:46 | [finally: continue] throw ...; | true |
+| cflow.cs:222:25:222:30 | [finally: continue] ... == ... | cflow.cs:223:31:223:45 | [finally: continue] object creation of type Exception | true |
+| cflow.cs:222:25:222:30 | [finally: continue] ... == ... | cflow.cs:226:17:228:17 | [finally: continue] {...} | false |
+| cflow.cs:222:25:222:30 | [finally: return] ... == ... | cflow.cs:223:25:223:46 | [finally: return] throw ...; | true |
+| cflow.cs:222:25:222:30 | [finally: return] ... == ... | cflow.cs:223:31:223:45 | [finally: return] object creation of type Exception | true |
+| cflow.cs:222:25:222:30 | [finally: return] ... == ... | cflow.cs:226:17:228:17 | [finally: return] {...} | false |
 | cflow.cs:234:17:234:33 | ... == ... | cflow.cs:235:17:235:23 | return ...; | true |
 | cflow.cs:234:17:234:33 | ... == ... | cflow.cs:236:13:237:49 | if (...) ... | false |
 | cflow.cs:234:17:234:33 | ... == ... | cflow.cs:236:17:236:28 | access to property Length | false |
@@ -213,33 +213,33 @@
 | cflow.cs:234:17:234:33 | ... == ... | cflow.cs:237:23:237:48 | object creation of type OutOfMemoryException | false |
 | cflow.cs:234:17:234:33 | ... == ... | cflow.cs:240:9:245:9 | {...} | false |
 | cflow.cs:234:17:234:33 | ... == ... | cflow.cs:242:17:242:41 | ...; | false |
-| cflow.cs:234:17:234:33 | ... == ... | cflow.cs:242:17:242:41 | [exception(OutOfMemoryException)] ...; | false |
-| cflow.cs:234:17:234:33 | ... == ... | cflow.cs:242:17:242:41 | [return] ...; | true |
-| cflow.cs:234:17:234:33 | ... == ... | cflow.cs:243:13:244:37 | [exception(OutOfMemoryException)] if (...) ... | false |
-| cflow.cs:234:17:234:33 | ... == ... | cflow.cs:243:13:244:37 | [return] if (...) ... | true |
+| cflow.cs:234:17:234:33 | ... == ... | cflow.cs:242:17:242:41 | [finally: exception(OutOfMemoryException)] ...; | false |
+| cflow.cs:234:17:234:33 | ... == ... | cflow.cs:242:17:242:41 | [finally: return] ...; | true |
+| cflow.cs:234:17:234:33 | ... == ... | cflow.cs:243:13:244:37 | [finally: exception(OutOfMemoryException)] if (...) ... | false |
+| cflow.cs:234:17:234:33 | ... == ... | cflow.cs:243:13:244:37 | [finally: return] if (...) ... | true |
 | cflow.cs:234:17:234:33 | ... == ... | cflow.cs:243:13:244:37 | if (...) ... | false |
 | cflow.cs:234:17:234:33 | ... == ... | cflow.cs:244:17:244:37 | ...; | false |
-| cflow.cs:234:17:234:33 | ... == ... | cflow.cs:244:17:244:37 | [exception(OutOfMemoryException)] ...; | false |
-| cflow.cs:234:17:234:33 | ... == ... | cflow.cs:244:17:244:37 | [return] ...; | true |
+| cflow.cs:234:17:234:33 | ... == ... | cflow.cs:244:17:244:37 | [finally: exception(OutOfMemoryException)] ...; | false |
+| cflow.cs:234:17:234:33 | ... == ... | cflow.cs:244:17:244:37 | [finally: return] ...; | true |
 | cflow.cs:236:17:236:33 | ... == ... | cflow.cs:237:17:237:49 | throw ...; | true |
 | cflow.cs:236:17:236:33 | ... == ... | cflow.cs:237:23:237:48 | object creation of type OutOfMemoryException | true |
 | cflow.cs:236:17:236:33 | ... == ... | cflow.cs:240:9:245:9 | {...} | false |
 | cflow.cs:236:17:236:33 | ... == ... | cflow.cs:242:17:242:41 | ...; | false |
-| cflow.cs:236:17:236:33 | ... == ... | cflow.cs:242:17:242:41 | [exception(OutOfMemoryException)] ...; | true |
-| cflow.cs:236:17:236:33 | ... == ... | cflow.cs:243:13:244:37 | [exception(OutOfMemoryException)] if (...) ... | true |
+| cflow.cs:236:17:236:33 | ... == ... | cflow.cs:242:17:242:41 | [finally: exception(OutOfMemoryException)] ...; | true |
+| cflow.cs:236:17:236:33 | ... == ... | cflow.cs:243:13:244:37 | [finally: exception(OutOfMemoryException)] if (...) ... | true |
 | cflow.cs:236:17:236:33 | ... == ... | cflow.cs:243:13:244:37 | if (...) ... | false |
 | cflow.cs:236:17:236:33 | ... == ... | cflow.cs:244:17:244:37 | ...; | false |
-| cflow.cs:236:17:236:33 | ... == ... | cflow.cs:244:17:244:37 | [exception(OutOfMemoryException)] ...; | true |
+| cflow.cs:236:17:236:33 | ... == ... | cflow.cs:244:17:244:37 | [finally: exception(OutOfMemoryException)] ...; | true |
 | cflow.cs:241:19:241:35 | ... == ... | cflow.cs:242:17:242:41 | ...; | false |
-| cflow.cs:241:19:241:35 | [exception(Exception)] ... == ... | cflow.cs:242:17:242:41 | [exception(Exception)] ...; | false |
-| cflow.cs:241:19:241:35 | [exception(NullReferenceException)] ... == ... | cflow.cs:242:17:242:41 | [exception(NullReferenceException)] ...; | false |
-| cflow.cs:241:19:241:35 | [exception(OutOfMemoryException)] ... == ... | cflow.cs:242:17:242:41 | [exception(OutOfMemoryException)] ...; | false |
-| cflow.cs:241:19:241:35 | [return] ... == ... | cflow.cs:242:17:242:41 | [return] ...; | false |
+| cflow.cs:241:19:241:35 | [finally: exception(Exception)] ... == ... | cflow.cs:242:17:242:41 | [finally: exception(Exception)] ...; | false |
+| cflow.cs:241:19:241:35 | [finally: exception(NullReferenceException)] ... == ... | cflow.cs:242:17:242:41 | [finally: exception(NullReferenceException)] ...; | false |
+| cflow.cs:241:19:241:35 | [finally: exception(OutOfMemoryException)] ... == ... | cflow.cs:242:17:242:41 | [finally: exception(OutOfMemoryException)] ...; | false |
+| cflow.cs:241:19:241:35 | [finally: return] ... == ... | cflow.cs:242:17:242:41 | [finally: return] ...; | false |
 | cflow.cs:243:17:243:32 | ... > ... | cflow.cs:244:17:244:37 | ...; | true |
-| cflow.cs:243:17:243:32 | [exception(Exception)] ... > ... | cflow.cs:244:17:244:37 | [exception(Exception)] ...; | true |
-| cflow.cs:243:17:243:32 | [exception(NullReferenceException)] ... > ... | cflow.cs:244:17:244:37 | [exception(NullReferenceException)] ...; | true |
-| cflow.cs:243:17:243:32 | [exception(OutOfMemoryException)] ... > ... | cflow.cs:244:17:244:37 | [exception(OutOfMemoryException)] ...; | true |
-| cflow.cs:243:17:243:32 | [return] ... > ... | cflow.cs:244:17:244:37 | [return] ...; | true |
+| cflow.cs:243:17:243:32 | [finally: exception(Exception)] ... > ... | cflow.cs:244:17:244:37 | [finally: exception(Exception)] ...; | true |
+| cflow.cs:243:17:243:32 | [finally: exception(NullReferenceException)] ... > ... | cflow.cs:244:17:244:37 | [finally: exception(NullReferenceException)] ...; | true |
+| cflow.cs:243:17:243:32 | [finally: exception(OutOfMemoryException)] ... > ... | cflow.cs:244:17:244:37 | [finally: exception(OutOfMemoryException)] ...; | true |
+| cflow.cs:243:17:243:32 | [finally: return] ... > ... | cflow.cs:244:17:244:37 | [finally: return] ...; | true |
 | cflow.cs:251:16:251:21 | ... < ... | cflow.cs:248:10:248:12 | exit For | false |
 | cflow.cs:251:16:251:21 | ... < ... | cflow.cs:252:13:252:33 | ...; | true |
 | cflow.cs:251:16:251:21 | ... < ... | cflow.cs:254:9:259:9 | for (...;...;...) ... | false |

--- a/csharp/ql/test/library-tests/controlflow/graph/ConditionBlock.expected
+++ b/csharp/ql/test/library-tests/controlflow/graph/ConditionBlock.expected
@@ -27,6 +27,37 @@
 | BreakInTry.cs:60:17:60:28 | ... == ... | BreakInTry.cs:68:21:68:26 | break; | false |
 | BreakInTry.cs:67:21:67:31 | ... == ... | BreakInTry.cs:68:21:68:26 | break; | true |
 | BreakInTry.cs:67:21:67:31 | [finally: return] ... == ... | BreakInTry.cs:68:21:68:26 | [finally: return] break; | true |
+| CatchInFinally.cs:9:17:9:28 | ... == ... | CatchInFinally.cs:10:17:10:50 | throw ...; | true |
+| CatchInFinally.cs:9:17:9:28 | ... == ... | CatchInFinally.cs:10:23:10:49 | object creation of type ArgumentNullException | true |
+| CatchInFinally.cs:9:17:9:28 | ... == ... | CatchInFinally.cs:13:9:27:9 | [finally: exception(Exception)] {...} | true |
+| CatchInFinally.cs:9:17:9:28 | ... == ... | CatchInFinally.cs:13:9:27:9 | {...} | false |
+| CatchInFinally.cs:9:17:9:28 | ... == ... | CatchInFinally.cs:16:36:16:36 | 1 | false |
+| CatchInFinally.cs:9:17:9:28 | ... == ... | CatchInFinally.cs:16:36:16:36 | [finally: exception(ArgumentNullException)] 1 | true |
+| CatchInFinally.cs:9:17:9:28 | ... == ... | CatchInFinally.cs:16:36:16:36 | [finally: exception(Exception)] 1 | true |
+| CatchInFinally.cs:9:17:9:28 | ... == ... | CatchInFinally.cs:17:21:17:45 | [finally: exception(ArgumentNullException)] throw ...; | true |
+| CatchInFinally.cs:9:17:9:28 | ... == ... | CatchInFinally.cs:17:21:17:45 | [finally: exception(Exception)] throw ...; | true |
+| CatchInFinally.cs:9:17:9:28 | ... == ... | CatchInFinally.cs:17:21:17:45 | throw ...; | false |
+| CatchInFinally.cs:9:17:9:28 | ... == ... | CatchInFinally.cs:17:41:17:43 | "1" | false |
+| CatchInFinally.cs:9:17:9:28 | ... == ... | CatchInFinally.cs:17:41:17:43 | [finally: exception(ArgumentNullException)] "1" | true |
+| CatchInFinally.cs:9:17:9:28 | ... == ... | CatchInFinally.cs:17:41:17:43 | [finally: exception(Exception)] "1" | true |
+| CatchInFinally.cs:9:17:9:28 | ... == ... | CatchInFinally.cs:19:13:22:13 | [exception: Exception, finally: exception(ArgumentNullException)] catch (...) {...} | true |
+| CatchInFinally.cs:9:17:9:28 | ... == ... | CatchInFinally.cs:19:13:22:13 | [exception: Exception, finally: exception(Exception)] catch (...) {...} | true |
+| CatchInFinally.cs:9:17:9:28 | ... == ... | CatchInFinally.cs:19:13:22:13 | [exception: Exception] catch (...) {...} | false |
+| CatchInFinally.cs:9:17:9:28 | ... == ... | CatchInFinally.cs:19:13:22:13 | [exception: NullReferenceException, finally: exception(ArgumentNullException)] catch (...) {...} | true |
+| CatchInFinally.cs:9:17:9:28 | ... == ... | CatchInFinally.cs:19:13:22:13 | [exception: NullReferenceException, finally: exception(Exception)] catch (...) {...} | true |
+| CatchInFinally.cs:9:17:9:28 | ... == ... | CatchInFinally.cs:19:13:22:13 | [exception: NullReferenceException] catch (...) {...} | false |
+| CatchInFinally.cs:9:17:9:28 | ... == ... | CatchInFinally.cs:20:13:22:13 | [finally: exception(ArgumentNullException)] {...} | true |
+| CatchInFinally.cs:9:17:9:28 | ... == ... | CatchInFinally.cs:20:13:22:13 | [finally: exception(Exception)] {...} | true |
+| CatchInFinally.cs:9:17:9:28 | ... == ... | CatchInFinally.cs:20:13:22:13 | {...} | false |
+| CatchInFinally.cs:9:17:9:28 | ... == ... | CatchInFinally.cs:23:13:26:13 | [finally: exception(ArgumentNullException)] catch {...} | true |
+| CatchInFinally.cs:9:17:9:28 | ... == ... | CatchInFinally.cs:23:13:26:13 | [finally: exception(Exception)] catch {...} | true |
+| CatchInFinally.cs:9:17:9:28 | ... == ... | CatchInFinally.cs:23:13:26:13 | catch {...} | false |
+| CatchInFinally.cs:16:21:16:36 | ... == ... | CatchInFinally.cs:17:21:17:45 | throw ...; | true |
+| CatchInFinally.cs:16:21:16:36 | ... == ... | CatchInFinally.cs:17:41:17:43 | "1" | true |
+| CatchInFinally.cs:16:21:16:36 | [finally: exception(ArgumentNullException)] ... == ... | CatchInFinally.cs:17:21:17:45 | [finally: exception(ArgumentNullException)] throw ...; | true |
+| CatchInFinally.cs:16:21:16:36 | [finally: exception(ArgumentNullException)] ... == ... | CatchInFinally.cs:17:41:17:43 | [finally: exception(ArgumentNullException)] "1" | true |
+| CatchInFinally.cs:16:21:16:36 | [finally: exception(Exception)] ... == ... | CatchInFinally.cs:17:21:17:45 | [finally: exception(Exception)] throw ...; | true |
+| CatchInFinally.cs:16:21:16:36 | [finally: exception(Exception)] ... == ... | CatchInFinally.cs:17:41:17:43 | [finally: exception(Exception)] "1" | true |
 | ConditionalAccess.cs:13:13:13:25 | ... > ... | ConditionalAccess.cs:14:20:14:20 | 0 | true |
 | ConditionalAccess.cs:13:13:13:25 | ... > ... | ConditionalAccess.cs:16:20:16:20 | 1 | false |
 | ExitMethods.cs:54:13:54:13 | access to parameter b | ExitMethods.cs:55:19:55:33 | object creation of type Exception | true |

--- a/csharp/ql/test/library-tests/controlflow/graph/ConditionalFlow.expected
+++ b/csharp/ql/test/library-tests/controlflow/graph/ConditionalFlow.expected
@@ -101,7 +101,11 @@
 | 110 | 20 | cflow.cs:110:20:110:23 | true | true | 111 | 13 | cflow.cs:111:13:113:13 | {...} |
 | 127 | 32 | cflow.cs:127:32:127:44 | ... == ... | false | 127 | 53 | cflow.cs:127:53:127:57 | this access |
 | 127 | 32 | cflow.cs:127:32:127:44 | ... == ... | true | 127 | 48 | cflow.cs:127:48:127:49 | "" |
+| 162 | 48 | cflow.cs:162:48:162:51 | [exception: Exception] true | true | 163 | 9 | cflow.cs:163:9:165:9 | {...} |
 | 170 | 21 | cflow.cs:170:21:170:24 | true | true | 170 | 27 | cflow.cs:170:27:170:32 | throw ...; |
+| 194 | 48 | cflow.cs:194:48:194:51 | [exception: Exception] true | true | 195 | 9 | cflow.cs:195:9:197:9 | {...} |
+| 198 | 35 | cflow.cs:198:35:198:51 | [exception: Exception] ... != ... | true | 199 | 9 | cflow.cs:199:9:200:9 | {...} |
+| 198 | 35 | cflow.cs:198:35:198:51 | [exception: OutOfMemoryException] ... != ... | true | 199 | 9 | cflow.cs:199:9:200:9 | {...} |
 | 207 | 16 | cflow.cs:207:16:207:20 | ... > ... | false | 232 | 9 | cflow.cs:232:9:245:9 | try {...} ... |
 | 207 | 16 | cflow.cs:207:16:207:20 | ... > ... | true | 208 | 9 | cflow.cs:208:9:230:9 | {...} |
 | 211 | 21 | cflow.cs:211:21:211:26 | ... == ... | false | 213 | 17 | cflow.cs:213:17:214:29 | if (...) ... |

--- a/csharp/ql/test/library-tests/controlflow/graph/ConditionalFlow.expected
+++ b/csharp/ql/test/library-tests/controlflow/graph/ConditionalFlow.expected
@@ -53,13 +53,13 @@
 | 30 | 22 | cflow.cs:30:22:30:31 | ... == ... | true | 31 | 17 | cflow.cs:31:17:31:42 | ...; |
 | 31 | 21 | BreakInTry.cs:31:21:31:32 | ... == ... | false | 22 | 9 | BreakInTry.cs:22:9:34:9 | foreach (... ... in ...) ... |
 | 31 | 21 | BreakInTry.cs:31:21:31:32 | ... == ... | true | 32 | 21 | BreakInTry.cs:32:21:32:21 | ; |
-| 31 | 21 | BreakInTry.cs:31:21:31:32 | [break] ... == ... | true | 32 | 21 | BreakInTry.cs:32:21:32:21 | [break] ; |
+| 31 | 21 | BreakInTry.cs:31:21:31:32 | [finally: break] ... == ... | true | 32 | 21 | BreakInTry.cs:32:21:32:21 | [finally: break] ; |
 | 42 | 17 | BreakInTry.cs:42:17:42:28 | ... == ... | false | 46 | 9 | BreakInTry.cs:46:9:52:9 | {...} |
 | 42 | 17 | BreakInTry.cs:42:17:42:28 | ... == ... | true | 43 | 17 | BreakInTry.cs:43:17:43:23 | return ...; |
 | 49 | 21 | BreakInTry.cs:49:21:49:31 | ... == ... | false | 47 | 13 | BreakInTry.cs:47:13:51:13 | foreach (... ... in ...) ... |
 | 49 | 21 | BreakInTry.cs:49:21:49:31 | ... == ... | true | 50 | 21 | BreakInTry.cs:50:21:50:26 | break; |
-| 49 | 21 | BreakInTry.cs:49:21:49:31 | [return] ... == ... | false | 47 | 13 | BreakInTry.cs:47:13:51:13 | [return] foreach (... ... in ...) ... |
-| 49 | 21 | BreakInTry.cs:49:21:49:31 | [return] ... == ... | true | 50 | 21 | BreakInTry.cs:50:21:50:26 | [return] break; |
+| 49 | 21 | BreakInTry.cs:49:21:49:31 | [finally: return] ... == ... | false | 47 | 13 | BreakInTry.cs:47:13:51:13 | [finally: return] foreach (... ... in ...) ... |
+| 49 | 21 | BreakInTry.cs:49:21:49:31 | [finally: return] ... == ... | true | 50 | 21 | BreakInTry.cs:50:21:50:26 | [finally: return] break; |
 | 50 | 30 | Switch.cs:50:30:50:38 | ... != ... | false | 44 | 10 | Switch.cs:44:10:44:11 | exit M4 |
 | 50 | 30 | Switch.cs:50:30:50:38 | ... != ... | true | 51 | 17 | Switch.cs:51:17:51:22 | break; |
 | 54 | 13 | ExitMethods.cs:54:13:54:13 | access to parameter b | false | 52 | 17 | ExitMethods.cs:52:17:52:26 | exit ErrorMaybe |
@@ -72,8 +72,8 @@
 | 63 | 23 | cflow.cs:63:23:63:33 | ... == ... | true | 65 | 17 | cflow.cs:65:17:65:22 | break; |
 | 67 | 21 | BreakInTry.cs:67:21:67:31 | ... == ... | false | 65 | 13 | BreakInTry.cs:65:13:69:13 | foreach (... ... in ...) ... |
 | 67 | 21 | BreakInTry.cs:67:21:67:31 | ... == ... | true | 68 | 21 | BreakInTry.cs:68:21:68:26 | break; |
-| 67 | 21 | BreakInTry.cs:67:21:67:31 | [return] ... == ... | false | 65 | 13 | BreakInTry.cs:65:13:69:13 | [return] foreach (... ... in ...) ... |
-| 67 | 21 | BreakInTry.cs:67:21:67:31 | [return] ... == ... | true | 68 | 21 | BreakInTry.cs:68:21:68:26 | [return] break; |
+| 67 | 21 | BreakInTry.cs:67:21:67:31 | [finally: return] ... == ... | false | 65 | 13 | BreakInTry.cs:65:13:69:13 | [finally: return] foreach (... ... in ...) ... |
+| 67 | 21 | BreakInTry.cs:67:21:67:31 | [finally: return] ... == ... | true | 68 | 21 | BreakInTry.cs:68:21:68:26 | [finally: return] break; |
 | 72 | 13 | cflow.cs:72:13:72:21 | ... == ... | false | 74 | 9 | cflow.cs:74:9:81:9 | if (...) ... |
 | 72 | 13 | cflow.cs:72:13:72:21 | ... == ... | true | 73 | 13 | cflow.cs:73:13:73:19 | return ...; |
 | 74 | 13 | cflow.cs:74:13:74:24 | ... > ... | false | 79 | 9 | cflow.cs:79:9:81:9 | {...} |
@@ -112,32 +112,32 @@
 | 215 | 21 | cflow.cs:215:21:215:26 | ... == ... | true | 216 | 21 | cflow.cs:216:21:216:26 | break; |
 | 222 | 25 | cflow.cs:222:25:222:30 | ... == ... | false | 226 | 17 | cflow.cs:226:17:228:17 | {...} |
 | 222 | 25 | cflow.cs:222:25:222:30 | ... == ... | true | 223 | 31 | cflow.cs:223:31:223:45 | object creation of type Exception |
-| 222 | 25 | cflow.cs:222:25:222:30 | [break] ... == ... | false | 226 | 17 | cflow.cs:226:17:228:17 | [break] {...} |
-| 222 | 25 | cflow.cs:222:25:222:30 | [break] ... == ... | true | 223 | 31 | cflow.cs:223:31:223:45 | [break] object creation of type Exception |
-| 222 | 25 | cflow.cs:222:25:222:30 | [continue] ... == ... | false | 226 | 17 | cflow.cs:226:17:228:17 | [continue] {...} |
-| 222 | 25 | cflow.cs:222:25:222:30 | [continue] ... == ... | true | 223 | 31 | cflow.cs:223:31:223:45 | [continue] object creation of type Exception |
-| 222 | 25 | cflow.cs:222:25:222:30 | [return] ... == ... | false | 226 | 17 | cflow.cs:226:17:228:17 | [return] {...} |
-| 222 | 25 | cflow.cs:222:25:222:30 | [return] ... == ... | true | 223 | 31 | cflow.cs:223:31:223:45 | [return] object creation of type Exception |
+| 222 | 25 | cflow.cs:222:25:222:30 | [finally: break] ... == ... | false | 226 | 17 | cflow.cs:226:17:228:17 | [finally: break] {...} |
+| 222 | 25 | cflow.cs:222:25:222:30 | [finally: break] ... == ... | true | 223 | 31 | cflow.cs:223:31:223:45 | [finally: break] object creation of type Exception |
+| 222 | 25 | cflow.cs:222:25:222:30 | [finally: continue] ... == ... | false | 226 | 17 | cflow.cs:226:17:228:17 | [finally: continue] {...} |
+| 222 | 25 | cflow.cs:222:25:222:30 | [finally: continue] ... == ... | true | 223 | 31 | cflow.cs:223:31:223:45 | [finally: continue] object creation of type Exception |
+| 222 | 25 | cflow.cs:222:25:222:30 | [finally: return] ... == ... | false | 226 | 17 | cflow.cs:226:17:228:17 | [finally: return] {...} |
+| 222 | 25 | cflow.cs:222:25:222:30 | [finally: return] ... == ... | true | 223 | 31 | cflow.cs:223:31:223:45 | [finally: return] object creation of type Exception |
 | 234 | 17 | cflow.cs:234:17:234:33 | ... == ... | false | 236 | 13 | cflow.cs:236:13:237:49 | if (...) ... |
 | 234 | 17 | cflow.cs:234:17:234:33 | ... == ... | true | 235 | 17 | cflow.cs:235:17:235:23 | return ...; |
 | 236 | 17 | cflow.cs:236:17:236:33 | ... == ... | false | 240 | 9 | cflow.cs:240:9:245:9 | {...} |
 | 236 | 17 | cflow.cs:236:17:236:33 | ... == ... | true | 237 | 23 | cflow.cs:237:23:237:48 | object creation of type OutOfMemoryException |
 | 241 | 19 | cflow.cs:241:19:241:35 | ... == ... | false | 242 | 17 | cflow.cs:242:17:242:41 | ...; |
 | 241 | 19 | cflow.cs:241:19:241:35 | ... == ... | true | 243 | 13 | cflow.cs:243:13:244:37 | if (...) ... |
-| 241 | 19 | cflow.cs:241:19:241:35 | [exception(Exception)] ... == ... | false | 242 | 17 | cflow.cs:242:17:242:41 | [exception(Exception)] ...; |
-| 241 | 19 | cflow.cs:241:19:241:35 | [exception(Exception)] ... == ... | true | 243 | 13 | cflow.cs:243:13:244:37 | [exception(Exception)] if (...) ... |
-| 241 | 19 | cflow.cs:241:19:241:35 | [exception(NullReferenceException)] ... == ... | false | 242 | 17 | cflow.cs:242:17:242:41 | [exception(NullReferenceException)] ...; |
-| 241 | 19 | cflow.cs:241:19:241:35 | [exception(NullReferenceException)] ... == ... | true | 243 | 13 | cflow.cs:243:13:244:37 | [exception(NullReferenceException)] if (...) ... |
-| 241 | 19 | cflow.cs:241:19:241:35 | [exception(OutOfMemoryException)] ... == ... | false | 242 | 17 | cflow.cs:242:17:242:41 | [exception(OutOfMemoryException)] ...; |
-| 241 | 19 | cflow.cs:241:19:241:35 | [exception(OutOfMemoryException)] ... == ... | true | 243 | 13 | cflow.cs:243:13:244:37 | [exception(OutOfMemoryException)] if (...) ... |
-| 241 | 19 | cflow.cs:241:19:241:35 | [return] ... == ... | false | 242 | 17 | cflow.cs:242:17:242:41 | [return] ...; |
-| 241 | 19 | cflow.cs:241:19:241:35 | [return] ... == ... | true | 243 | 13 | cflow.cs:243:13:244:37 | [return] if (...) ... |
+| 241 | 19 | cflow.cs:241:19:241:35 | [finally: exception(Exception)] ... == ... | false | 242 | 17 | cflow.cs:242:17:242:41 | [finally: exception(Exception)] ...; |
+| 241 | 19 | cflow.cs:241:19:241:35 | [finally: exception(Exception)] ... == ... | true | 243 | 13 | cflow.cs:243:13:244:37 | [finally: exception(Exception)] if (...) ... |
+| 241 | 19 | cflow.cs:241:19:241:35 | [finally: exception(NullReferenceException)] ... == ... | false | 242 | 17 | cflow.cs:242:17:242:41 | [finally: exception(NullReferenceException)] ...; |
+| 241 | 19 | cflow.cs:241:19:241:35 | [finally: exception(NullReferenceException)] ... == ... | true | 243 | 13 | cflow.cs:243:13:244:37 | [finally: exception(NullReferenceException)] if (...) ... |
+| 241 | 19 | cflow.cs:241:19:241:35 | [finally: exception(OutOfMemoryException)] ... == ... | false | 242 | 17 | cflow.cs:242:17:242:41 | [finally: exception(OutOfMemoryException)] ...; |
+| 241 | 19 | cflow.cs:241:19:241:35 | [finally: exception(OutOfMemoryException)] ... == ... | true | 243 | 13 | cflow.cs:243:13:244:37 | [finally: exception(OutOfMemoryException)] if (...) ... |
+| 241 | 19 | cflow.cs:241:19:241:35 | [finally: return] ... == ... | false | 242 | 17 | cflow.cs:242:17:242:41 | [finally: return] ...; |
+| 241 | 19 | cflow.cs:241:19:241:35 | [finally: return] ... == ... | true | 243 | 13 | cflow.cs:243:13:244:37 | [finally: return] if (...) ... |
 | 243 | 17 | cflow.cs:243:17:243:32 | ... > ... | false | 146 | 10 | cflow.cs:146:10:146:19 | exit TryFinally |
 | 243 | 17 | cflow.cs:243:17:243:32 | ... > ... | true | 244 | 17 | cflow.cs:244:17:244:37 | ...; |
-| 243 | 17 | cflow.cs:243:17:243:32 | [exception(Exception)] ... > ... | true | 244 | 17 | cflow.cs:244:17:244:37 | [exception(Exception)] ...; |
-| 243 | 17 | cflow.cs:243:17:243:32 | [exception(NullReferenceException)] ... > ... | true | 244 | 17 | cflow.cs:244:17:244:37 | [exception(NullReferenceException)] ...; |
-| 243 | 17 | cflow.cs:243:17:243:32 | [exception(OutOfMemoryException)] ... > ... | true | 244 | 17 | cflow.cs:244:17:244:37 | [exception(OutOfMemoryException)] ...; |
-| 243 | 17 | cflow.cs:243:17:243:32 | [return] ... > ... | true | 244 | 17 | cflow.cs:244:17:244:37 | [return] ...; |
+| 243 | 17 | cflow.cs:243:17:243:32 | [finally: exception(Exception)] ... > ... | true | 244 | 17 | cflow.cs:244:17:244:37 | [finally: exception(Exception)] ...; |
+| 243 | 17 | cflow.cs:243:17:243:32 | [finally: exception(NullReferenceException)] ... > ... | true | 244 | 17 | cflow.cs:244:17:244:37 | [finally: exception(NullReferenceException)] ...; |
+| 243 | 17 | cflow.cs:243:17:243:32 | [finally: exception(OutOfMemoryException)] ... > ... | true | 244 | 17 | cflow.cs:244:17:244:37 | [finally: exception(OutOfMemoryException)] ...; |
+| 243 | 17 | cflow.cs:243:17:243:32 | [finally: return] ... > ... | true | 244 | 17 | cflow.cs:244:17:244:37 | [finally: return] ...; |
 | 251 | 16 | cflow.cs:251:16:251:21 | ... < ... | false | 254 | 9 | cflow.cs:254:9:259:9 | for (...;...;...) ... |
 | 251 | 16 | cflow.cs:251:16:251:21 | ... < ... | true | 252 | 13 | cflow.cs:252:13:252:33 | ...; |
 | 257 | 17 | cflow.cs:257:17:257:22 | ... > ... | false | 254 | 18 | cflow.cs:254:18:254:18 | access to local variable x |

--- a/csharp/ql/test/library-tests/controlflow/graph/ConditionalFlow.expected
+++ b/csharp/ql/test/library-tests/controlflow/graph/ConditionalFlow.expected
@@ -5,6 +5,8 @@
 | 7 | 13 | TypeAccesses.cs:7:13:7:22 | ... is ... | true | 7 | 25 | TypeAccesses.cs:7:25:7:25 | ; |
 | 8 | 13 | Patterns.cs:8:13:8:23 | ... is ... | false | 12 | 14 | Patterns.cs:12:14:18:9 | if (...) ... |
 | 8 | 13 | Patterns.cs:8:13:8:23 | ... is ... | true | 9 | 9 | Patterns.cs:9:9:11:9 | {...} |
+| 9 | 17 | CatchInFinally.cs:9:17:9:28 | ... == ... | false | 13 | 9 | CatchInFinally.cs:13:9:27:9 | {...} |
+| 9 | 17 | CatchInFinally.cs:9:17:9:28 | ... == ... | true | 10 | 23 | CatchInFinally.cs:10:23:10:49 | object creation of type ArgumentNullException |
 | 9 | 21 | BreakInTry.cs:9:21:9:31 | ... == ... | false | 7 | 13 | BreakInTry.cs:7:13:11:13 | foreach (... ... in ...) ... |
 | 9 | 21 | BreakInTry.cs:9:21:9:31 | ... == ... | true | 10 | 21 | BreakInTry.cs:10:21:10:26 | break; |
 | 9 | 37 | NullCoalescing.cs:9:37:9:37 | access to parameter b | false | 9 | 45 | NullCoalescing.cs:9:45:9:45 | access to parameter s |
@@ -27,6 +29,22 @@
 | 15 | 17 | BreakInTry.cs:15:17:15:28 | ... == ... | true | 16 | 17 | BreakInTry.cs:16:17:16:17 | ; |
 | 16 | 18 | Patterns.cs:16:18:16:28 | ... is ... | false | 20 | 9 | Patterns.cs:20:9:38:9 | switch (...) {...} |
 | 16 | 18 | Patterns.cs:16:18:16:28 | ... is ... | true | 17 | 9 | Patterns.cs:17:9:18:9 | {...} |
+| 16 | 21 | CatchInFinally.cs:16:21:16:36 | ... == ... | false | 5 | 10 | CatchInFinally.cs:5:10:5:11 | exit M1 |
+| 16 | 21 | CatchInFinally.cs:16:21:16:36 | ... == ... | true | 17 | 41 | CatchInFinally.cs:17:41:17:43 | "1" |
+| 16 | 21 | CatchInFinally.cs:16:21:16:36 | [finally: exception(ArgumentNullException)] ... == ... | true | 17 | 41 | CatchInFinally.cs:17:41:17:43 | [finally: exception(ArgumentNullException)] "1" |
+| 16 | 21 | CatchInFinally.cs:16:21:16:36 | [finally: exception(Exception)] ... == ... | true | 17 | 41 | CatchInFinally.cs:17:41:17:43 | [finally: exception(Exception)] "1" |
+| 19 | 39 | CatchInFinally.cs:19:39:19:54 | [exception: Exception, finally: exception(ArgumentNullException)] ... == ... | false | 23 | 13 | CatchInFinally.cs:23:13:26:13 | [finally: exception(ArgumentNullException)] catch {...} |
+| 19 | 39 | CatchInFinally.cs:19:39:19:54 | [exception: Exception, finally: exception(ArgumentNullException)] ... == ... | true | 20 | 13 | CatchInFinally.cs:20:13:22:13 | [finally: exception(ArgumentNullException)] {...} |
+| 19 | 39 | CatchInFinally.cs:19:39:19:54 | [exception: Exception, finally: exception(Exception)] ... == ... | false | 23 | 13 | CatchInFinally.cs:23:13:26:13 | [finally: exception(Exception)] catch {...} |
+| 19 | 39 | CatchInFinally.cs:19:39:19:54 | [exception: Exception, finally: exception(Exception)] ... == ... | true | 20 | 13 | CatchInFinally.cs:20:13:22:13 | [finally: exception(Exception)] {...} |
+| 19 | 39 | CatchInFinally.cs:19:39:19:54 | [exception: Exception] ... == ... | false | 23 | 13 | CatchInFinally.cs:23:13:26:13 | catch {...} |
+| 19 | 39 | CatchInFinally.cs:19:39:19:54 | [exception: Exception] ... == ... | true | 20 | 13 | CatchInFinally.cs:20:13:22:13 | {...} |
+| 19 | 39 | CatchInFinally.cs:19:39:19:54 | [exception: NullReferenceException, finally: exception(ArgumentNullException)] ... == ... | false | 23 | 13 | CatchInFinally.cs:23:13:26:13 | [finally: exception(ArgumentNullException)] catch {...} |
+| 19 | 39 | CatchInFinally.cs:19:39:19:54 | [exception: NullReferenceException, finally: exception(ArgumentNullException)] ... == ... | true | 20 | 13 | CatchInFinally.cs:20:13:22:13 | [finally: exception(ArgumentNullException)] {...} |
+| 19 | 39 | CatchInFinally.cs:19:39:19:54 | [exception: NullReferenceException, finally: exception(Exception)] ... == ... | false | 23 | 13 | CatchInFinally.cs:23:13:26:13 | [finally: exception(Exception)] catch {...} |
+| 19 | 39 | CatchInFinally.cs:19:39:19:54 | [exception: NullReferenceException, finally: exception(Exception)] ... == ... | true | 20 | 13 | CatchInFinally.cs:20:13:22:13 | [finally: exception(Exception)] {...} |
+| 19 | 39 | CatchInFinally.cs:19:39:19:54 | [exception: NullReferenceException] ... == ... | false | 23 | 13 | CatchInFinally.cs:23:13:26:13 | catch {...} |
+| 19 | 39 | CatchInFinally.cs:19:39:19:54 | [exception: NullReferenceException] ... == ... | true | 20 | 13 | CatchInFinally.cs:20:13:22:13 | {...} |
 | 21 | 21 | Switch.cs:21:21:21:29 | ... == ... | false | 23 | 27 | Switch.cs:23:27:23:27 | 0 |
 | 21 | 21 | Switch.cs:21:21:21:29 | ... == ... | true | 22 | 21 | Switch.cs:22:21:22:27 | return ...; |
 | 22 | 18 | cflow.cs:22:18:22:23 | ... < ... | false | 24 | 9 | cflow.cs:24:9:34:9 | for (...;...;...) ... |

--- a/csharp/ql/test/library-tests/controlflow/graph/Dominance.expected
+++ b/csharp/ql/test/library-tests/controlflow/graph/Dominance.expected
@@ -159,6 +159,107 @@
 | post | BreakInTry.cs:67:21:67:31 | [finally: return] ... == ... | BreakInTry.cs:67:28:67:31 | [finally: return] null |
 | post | BreakInTry.cs:67:28:67:31 | [finally: return] null | BreakInTry.cs:67:21:67:23 | [finally: return] access to local variable arg |
 | post | BreakInTry.cs:67:28:67:31 | null | BreakInTry.cs:67:21:67:23 | access to local variable arg |
+| post | CatchInFinally.cs:5:10:5:11 | exit M1 | CatchInFinally.cs:16:21:16:36 | ... == ... |
+| post | CatchInFinally.cs:5:10:5:11 | exit M1 | CatchInFinally.cs:16:21:16:36 | [finally: exception(ArgumentNullException)] ... == ... |
+| post | CatchInFinally.cs:5:10:5:11 | exit M1 | CatchInFinally.cs:16:21:16:36 | [finally: exception(Exception)] ... == ... |
+| post | CatchInFinally.cs:5:10:5:11 | exit M1 | CatchInFinally.cs:21:17:21:42 | [finally: exception(ArgumentNullException)] call to method WriteLine |
+| post | CatchInFinally.cs:5:10:5:11 | exit M1 | CatchInFinally.cs:21:17:21:42 | [finally: exception(Exception)] call to method WriteLine |
+| post | CatchInFinally.cs:5:10:5:11 | exit M1 | CatchInFinally.cs:21:17:21:42 | call to method WriteLine |
+| post | CatchInFinally.cs:5:10:5:11 | exit M1 | CatchInFinally.cs:25:17:25:37 | [finally: exception(ArgumentNullException)] call to method WriteLine |
+| post | CatchInFinally.cs:5:10:5:11 | exit M1 | CatchInFinally.cs:25:17:25:37 | [finally: exception(Exception)] call to method WriteLine |
+| post | CatchInFinally.cs:5:10:5:11 | exit M1 | CatchInFinally.cs:25:17:25:37 | call to method WriteLine |
+| post | CatchInFinally.cs:6:5:28:5 | {...} | CatchInFinally.cs:5:10:5:11 | enter M1 |
+| post | CatchInFinally.cs:7:9:27:9 | try {...} ... | CatchInFinally.cs:6:5:28:5 | {...} |
+| post | CatchInFinally.cs:8:9:11:9 | {...} | CatchInFinally.cs:7:9:27:9 | try {...} ... |
+| post | CatchInFinally.cs:9:13:10:50 | if (...) ... | CatchInFinally.cs:8:9:11:9 | {...} |
+| post | CatchInFinally.cs:9:17:9:20 | access to parameter args | CatchInFinally.cs:9:13:10:50 | if (...) ... |
+| post | CatchInFinally.cs:9:17:9:28 | ... == ... | CatchInFinally.cs:9:25:9:28 | null |
+| post | CatchInFinally.cs:9:25:9:28 | null | CatchInFinally.cs:9:17:9:20 | access to parameter args |
+| post | CatchInFinally.cs:13:9:27:9 | [finally: exception(ArgumentNullException)] {...} | CatchInFinally.cs:10:17:10:50 | throw ...; |
+| post | CatchInFinally.cs:14:13:26:13 | [finally: exception(ArgumentNullException)] try {...} ... | CatchInFinally.cs:13:9:27:9 | [finally: exception(ArgumentNullException)] {...} |
+| post | CatchInFinally.cs:14:13:26:13 | [finally: exception(Exception)] try {...} ... | CatchInFinally.cs:13:9:27:9 | [finally: exception(Exception)] {...} |
+| post | CatchInFinally.cs:14:13:26:13 | try {...} ... | CatchInFinally.cs:13:9:27:9 | {...} |
+| post | CatchInFinally.cs:15:13:18:13 | [finally: exception(ArgumentNullException)] {...} | CatchInFinally.cs:14:13:26:13 | [finally: exception(ArgumentNullException)] try {...} ... |
+| post | CatchInFinally.cs:15:13:18:13 | [finally: exception(Exception)] {...} | CatchInFinally.cs:14:13:26:13 | [finally: exception(Exception)] try {...} ... |
+| post | CatchInFinally.cs:15:13:18:13 | {...} | CatchInFinally.cs:14:13:26:13 | try {...} ... |
+| post | CatchInFinally.cs:16:17:17:45 | [finally: exception(ArgumentNullException)] if (...) ... | CatchInFinally.cs:15:13:18:13 | [finally: exception(ArgumentNullException)] {...} |
+| post | CatchInFinally.cs:16:17:17:45 | [finally: exception(Exception)] if (...) ... | CatchInFinally.cs:15:13:18:13 | [finally: exception(Exception)] {...} |
+| post | CatchInFinally.cs:16:17:17:45 | if (...) ... | CatchInFinally.cs:15:13:18:13 | {...} |
+| post | CatchInFinally.cs:16:21:16:24 | [finally: exception(ArgumentNullException)] access to parameter args | CatchInFinally.cs:16:17:17:45 | [finally: exception(ArgumentNullException)] if (...) ... |
+| post | CatchInFinally.cs:16:21:16:24 | [finally: exception(Exception)] access to parameter args | CatchInFinally.cs:16:17:17:45 | [finally: exception(Exception)] if (...) ... |
+| post | CatchInFinally.cs:16:21:16:24 | access to parameter args | CatchInFinally.cs:16:17:17:45 | if (...) ... |
+| post | CatchInFinally.cs:16:21:16:31 | [finally: exception(ArgumentNullException)] access to property Length | CatchInFinally.cs:16:21:16:24 | [finally: exception(ArgumentNullException)] access to parameter args |
+| post | CatchInFinally.cs:16:21:16:31 | [finally: exception(Exception)] access to property Length | CatchInFinally.cs:16:21:16:24 | [finally: exception(Exception)] access to parameter args |
+| post | CatchInFinally.cs:16:21:16:31 | access to property Length | CatchInFinally.cs:16:21:16:24 | access to parameter args |
+| post | CatchInFinally.cs:16:21:16:36 | ... == ... | CatchInFinally.cs:16:36:16:36 | 1 |
+| post | CatchInFinally.cs:16:21:16:36 | [finally: exception(ArgumentNullException)] ... == ... | CatchInFinally.cs:16:36:16:36 | [finally: exception(ArgumentNullException)] 1 |
+| post | CatchInFinally.cs:16:21:16:36 | [finally: exception(Exception)] ... == ... | CatchInFinally.cs:16:36:16:36 | [finally: exception(Exception)] 1 |
+| post | CatchInFinally.cs:17:27:17:44 | [finally: exception(ArgumentNullException)] object creation of type Exception | CatchInFinally.cs:17:41:17:43 | [finally: exception(ArgumentNullException)] "1" |
+| post | CatchInFinally.cs:17:27:17:44 | [finally: exception(Exception)] object creation of type Exception | CatchInFinally.cs:17:41:17:43 | [finally: exception(Exception)] "1" |
+| post | CatchInFinally.cs:17:27:17:44 | object creation of type Exception | CatchInFinally.cs:17:41:17:43 | "1" |
+| post | CatchInFinally.cs:19:13:22:13 | [exception: Exception, finally: exception(ArgumentNullException)] catch (...) {...} | CatchInFinally.cs:17:21:17:45 | [finally: exception(ArgumentNullException)] throw ...; |
+| post | CatchInFinally.cs:19:13:22:13 | [exception: Exception, finally: exception(ArgumentNullException)] catch (...) {...} | CatchInFinally.cs:17:27:17:44 | [finally: exception(ArgumentNullException)] object creation of type Exception |
+| post | CatchInFinally.cs:19:13:22:13 | [exception: Exception, finally: exception(Exception)] catch (...) {...} | CatchInFinally.cs:17:21:17:45 | [finally: exception(Exception)] throw ...; |
+| post | CatchInFinally.cs:19:13:22:13 | [exception: Exception, finally: exception(Exception)] catch (...) {...} | CatchInFinally.cs:17:27:17:44 | [finally: exception(Exception)] object creation of type Exception |
+| post | CatchInFinally.cs:19:13:22:13 | [exception: Exception] catch (...) {...} | CatchInFinally.cs:17:21:17:45 | throw ...; |
+| post | CatchInFinally.cs:19:13:22:13 | [exception: Exception] catch (...) {...} | CatchInFinally.cs:17:27:17:44 | object creation of type Exception |
+| post | CatchInFinally.cs:19:30:19:30 | [exception: Exception, finally: exception(ArgumentNullException)] Exception e | CatchInFinally.cs:19:13:22:13 | [exception: Exception, finally: exception(ArgumentNullException)] catch (...) {...} |
+| post | CatchInFinally.cs:19:30:19:30 | [exception: Exception, finally: exception(Exception)] Exception e | CatchInFinally.cs:19:13:22:13 | [exception: Exception, finally: exception(Exception)] catch (...) {...} |
+| post | CatchInFinally.cs:19:30:19:30 | [exception: Exception] Exception e | CatchInFinally.cs:19:13:22:13 | [exception: Exception] catch (...) {...} |
+| post | CatchInFinally.cs:19:30:19:30 | [exception: NullReferenceException, finally: exception(ArgumentNullException)] Exception e | CatchInFinally.cs:19:13:22:13 | [exception: NullReferenceException, finally: exception(ArgumentNullException)] catch (...) {...} |
+| post | CatchInFinally.cs:19:30:19:30 | [exception: NullReferenceException, finally: exception(Exception)] Exception e | CatchInFinally.cs:19:13:22:13 | [exception: NullReferenceException, finally: exception(Exception)] catch (...) {...} |
+| post | CatchInFinally.cs:19:30:19:30 | [exception: NullReferenceException] Exception e | CatchInFinally.cs:19:13:22:13 | [exception: NullReferenceException] catch (...) {...} |
+| post | CatchInFinally.cs:19:39:19:39 | [exception: Exception, finally: exception(ArgumentNullException)] access to local variable e | CatchInFinally.cs:19:30:19:30 | [exception: Exception, finally: exception(ArgumentNullException)] Exception e |
+| post | CatchInFinally.cs:19:39:19:39 | [exception: Exception, finally: exception(Exception)] access to local variable e | CatchInFinally.cs:19:30:19:30 | [exception: Exception, finally: exception(Exception)] Exception e |
+| post | CatchInFinally.cs:19:39:19:39 | [exception: Exception] access to local variable e | CatchInFinally.cs:19:30:19:30 | [exception: Exception] Exception e |
+| post | CatchInFinally.cs:19:39:19:39 | [exception: NullReferenceException, finally: exception(ArgumentNullException)] access to local variable e | CatchInFinally.cs:19:30:19:30 | [exception: NullReferenceException, finally: exception(ArgumentNullException)] Exception e |
+| post | CatchInFinally.cs:19:39:19:39 | [exception: NullReferenceException, finally: exception(Exception)] access to local variable e | CatchInFinally.cs:19:30:19:30 | [exception: NullReferenceException, finally: exception(Exception)] Exception e |
+| post | CatchInFinally.cs:19:39:19:39 | [exception: NullReferenceException] access to local variable e | CatchInFinally.cs:19:30:19:30 | [exception: NullReferenceException] Exception e |
+| post | CatchInFinally.cs:19:39:19:47 | [exception: Exception, finally: exception(ArgumentNullException)] access to property Message | CatchInFinally.cs:19:39:19:39 | [exception: Exception, finally: exception(ArgumentNullException)] access to local variable e |
+| post | CatchInFinally.cs:19:39:19:47 | [exception: Exception, finally: exception(Exception)] access to property Message | CatchInFinally.cs:19:39:19:39 | [exception: Exception, finally: exception(Exception)] access to local variable e |
+| post | CatchInFinally.cs:19:39:19:47 | [exception: Exception] access to property Message | CatchInFinally.cs:19:39:19:39 | [exception: Exception] access to local variable e |
+| post | CatchInFinally.cs:19:39:19:47 | [exception: NullReferenceException, finally: exception(ArgumentNullException)] access to property Message | CatchInFinally.cs:19:39:19:39 | [exception: NullReferenceException, finally: exception(ArgumentNullException)] access to local variable e |
+| post | CatchInFinally.cs:19:39:19:47 | [exception: NullReferenceException, finally: exception(Exception)] access to property Message | CatchInFinally.cs:19:39:19:39 | [exception: NullReferenceException, finally: exception(Exception)] access to local variable e |
+| post | CatchInFinally.cs:19:39:19:47 | [exception: NullReferenceException] access to property Message | CatchInFinally.cs:19:39:19:39 | [exception: NullReferenceException] access to local variable e |
+| post | CatchInFinally.cs:19:39:19:54 | [exception: Exception, finally: exception(ArgumentNullException)] ... == ... | CatchInFinally.cs:19:52:19:54 | [exception: Exception, finally: exception(ArgumentNullException)] "1" |
+| post | CatchInFinally.cs:19:39:19:54 | [exception: Exception, finally: exception(Exception)] ... == ... | CatchInFinally.cs:19:52:19:54 | [exception: Exception, finally: exception(Exception)] "1" |
+| post | CatchInFinally.cs:19:39:19:54 | [exception: Exception] ... == ... | CatchInFinally.cs:19:52:19:54 | [exception: Exception] "1" |
+| post | CatchInFinally.cs:19:39:19:54 | [exception: NullReferenceException, finally: exception(ArgumentNullException)] ... == ... | CatchInFinally.cs:19:52:19:54 | [exception: NullReferenceException, finally: exception(ArgumentNullException)] "1" |
+| post | CatchInFinally.cs:19:39:19:54 | [exception: NullReferenceException, finally: exception(Exception)] ... == ... | CatchInFinally.cs:19:52:19:54 | [exception: NullReferenceException, finally: exception(Exception)] "1" |
+| post | CatchInFinally.cs:19:39:19:54 | [exception: NullReferenceException] ... == ... | CatchInFinally.cs:19:52:19:54 | [exception: NullReferenceException] "1" |
+| post | CatchInFinally.cs:19:52:19:54 | [exception: Exception, finally: exception(ArgumentNullException)] "1" | CatchInFinally.cs:19:39:19:47 | [exception: Exception, finally: exception(ArgumentNullException)] access to property Message |
+| post | CatchInFinally.cs:19:52:19:54 | [exception: Exception, finally: exception(Exception)] "1" | CatchInFinally.cs:19:39:19:47 | [exception: Exception, finally: exception(Exception)] access to property Message |
+| post | CatchInFinally.cs:19:52:19:54 | [exception: Exception] "1" | CatchInFinally.cs:19:39:19:47 | [exception: Exception] access to property Message |
+| post | CatchInFinally.cs:19:52:19:54 | [exception: NullReferenceException, finally: exception(ArgumentNullException)] "1" | CatchInFinally.cs:19:39:19:47 | [exception: NullReferenceException, finally: exception(ArgumentNullException)] access to property Message |
+| post | CatchInFinally.cs:19:52:19:54 | [exception: NullReferenceException, finally: exception(Exception)] "1" | CatchInFinally.cs:19:39:19:47 | [exception: NullReferenceException, finally: exception(Exception)] access to property Message |
+| post | CatchInFinally.cs:19:52:19:54 | [exception: NullReferenceException] "1" | CatchInFinally.cs:19:39:19:47 | [exception: NullReferenceException] access to property Message |
+| post | CatchInFinally.cs:21:17:21:42 | [finally: exception(ArgumentNullException)] call to method WriteLine | CatchInFinally.cs:21:35:21:41 | [finally: exception(ArgumentNullException)] access to array element |
+| post | CatchInFinally.cs:21:17:21:42 | [finally: exception(Exception)] call to method WriteLine | CatchInFinally.cs:21:35:21:41 | [finally: exception(Exception)] access to array element |
+| post | CatchInFinally.cs:21:17:21:42 | call to method WriteLine | CatchInFinally.cs:21:35:21:41 | access to array element |
+| post | CatchInFinally.cs:21:17:21:43 | ...; | CatchInFinally.cs:20:13:22:13 | {...} |
+| post | CatchInFinally.cs:21:17:21:43 | [finally: exception(ArgumentNullException)] ...; | CatchInFinally.cs:20:13:22:13 | [finally: exception(ArgumentNullException)] {...} |
+| post | CatchInFinally.cs:21:17:21:43 | [finally: exception(Exception)] ...; | CatchInFinally.cs:20:13:22:13 | [finally: exception(Exception)] {...} |
+| post | CatchInFinally.cs:21:35:21:38 | [finally: exception(ArgumentNullException)] access to parameter args | CatchInFinally.cs:21:17:21:43 | [finally: exception(ArgumentNullException)] ...; |
+| post | CatchInFinally.cs:21:35:21:38 | [finally: exception(Exception)] access to parameter args | CatchInFinally.cs:21:17:21:43 | [finally: exception(Exception)] ...; |
+| post | CatchInFinally.cs:21:35:21:38 | access to parameter args | CatchInFinally.cs:21:17:21:43 | ...; |
+| post | CatchInFinally.cs:21:35:21:41 | [finally: exception(ArgumentNullException)] access to array element | CatchInFinally.cs:21:40:21:40 | [finally: exception(ArgumentNullException)] 0 |
+| post | CatchInFinally.cs:21:35:21:41 | [finally: exception(Exception)] access to array element | CatchInFinally.cs:21:40:21:40 | [finally: exception(Exception)] 0 |
+| post | CatchInFinally.cs:21:35:21:41 | access to array element | CatchInFinally.cs:21:40:21:40 | 0 |
+| post | CatchInFinally.cs:21:40:21:40 | 0 | CatchInFinally.cs:21:35:21:38 | access to parameter args |
+| post | CatchInFinally.cs:21:40:21:40 | [finally: exception(ArgumentNullException)] 0 | CatchInFinally.cs:21:35:21:38 | [finally: exception(ArgumentNullException)] access to parameter args |
+| post | CatchInFinally.cs:21:40:21:40 | [finally: exception(Exception)] 0 | CatchInFinally.cs:21:35:21:38 | [finally: exception(Exception)] access to parameter args |
+| post | CatchInFinally.cs:24:13:26:13 | [finally: exception(ArgumentNullException)] {...} | CatchInFinally.cs:23:13:26:13 | [finally: exception(ArgumentNullException)] catch {...} |
+| post | CatchInFinally.cs:24:13:26:13 | [finally: exception(Exception)] {...} | CatchInFinally.cs:23:13:26:13 | [finally: exception(Exception)] catch {...} |
+| post | CatchInFinally.cs:24:13:26:13 | {...} | CatchInFinally.cs:23:13:26:13 | catch {...} |
+| post | CatchInFinally.cs:25:17:25:37 | [finally: exception(ArgumentNullException)] call to method WriteLine | CatchInFinally.cs:25:35:25:36 | [finally: exception(ArgumentNullException)] "" |
+| post | CatchInFinally.cs:25:17:25:37 | [finally: exception(Exception)] call to method WriteLine | CatchInFinally.cs:25:35:25:36 | [finally: exception(Exception)] "" |
+| post | CatchInFinally.cs:25:17:25:37 | call to method WriteLine | CatchInFinally.cs:25:35:25:36 | "" |
+| post | CatchInFinally.cs:25:17:25:38 | ...; | CatchInFinally.cs:24:13:26:13 | {...} |
+| post | CatchInFinally.cs:25:17:25:38 | [finally: exception(ArgumentNullException)] ...; | CatchInFinally.cs:24:13:26:13 | [finally: exception(ArgumentNullException)] {...} |
+| post | CatchInFinally.cs:25:17:25:38 | [finally: exception(Exception)] ...; | CatchInFinally.cs:24:13:26:13 | [finally: exception(Exception)] {...} |
+| post | CatchInFinally.cs:25:35:25:36 | "" | CatchInFinally.cs:25:17:25:38 | ...; |
+| post | CatchInFinally.cs:25:35:25:36 | [finally: exception(ArgumentNullException)] "" | CatchInFinally.cs:25:17:25:38 | [finally: exception(ArgumentNullException)] ...; |
+| post | CatchInFinally.cs:25:35:25:36 | [finally: exception(Exception)] "" | CatchInFinally.cs:25:17:25:38 | [finally: exception(Exception)] ...; |
 | post | CompileTimeOperators.cs:5:9:5:15 | exit Default | CompileTimeOperators.cs:7:9:7:28 | return ...; |
 | post | CompileTimeOperators.cs:6:5:8:5 | {...} | CompileTimeOperators.cs:5:9:5:15 | enter Default |
 | post | CompileTimeOperators.cs:7:9:7:28 | return ...; | CompileTimeOperators.cs:7:16:7:27 | default(...) |
@@ -1861,6 +1962,111 @@
 | pre | BreakInTry.cs:67:21:67:31 | [finally: return] ... == ... | BreakInTry.cs:68:21:68:26 | [finally: return] break; |
 | pre | BreakInTry.cs:67:28:67:31 | [finally: return] null | BreakInTry.cs:67:21:67:31 | [finally: return] ... == ... |
 | pre | BreakInTry.cs:67:28:67:31 | null | BreakInTry.cs:67:21:67:31 | ... == ... |
+| pre | CatchInFinally.cs:5:10:5:11 | enter M1 | CatchInFinally.cs:6:5:28:5 | {...} |
+| pre | CatchInFinally.cs:6:5:28:5 | {...} | CatchInFinally.cs:7:9:27:9 | try {...} ... |
+| pre | CatchInFinally.cs:7:9:27:9 | try {...} ... | CatchInFinally.cs:8:9:11:9 | {...} |
+| pre | CatchInFinally.cs:8:9:11:9 | {...} | CatchInFinally.cs:9:13:10:50 | if (...) ... |
+| pre | CatchInFinally.cs:9:13:10:50 | if (...) ... | CatchInFinally.cs:9:17:9:20 | access to parameter args |
+| pre | CatchInFinally.cs:9:17:9:20 | access to parameter args | CatchInFinally.cs:9:25:9:28 | null |
+| pre | CatchInFinally.cs:9:17:9:28 | ... == ... | CatchInFinally.cs:10:23:10:49 | object creation of type ArgumentNullException |
+| pre | CatchInFinally.cs:9:17:9:28 | ... == ... | CatchInFinally.cs:13:9:27:9 | {...} |
+| pre | CatchInFinally.cs:9:25:9:28 | null | CatchInFinally.cs:9:17:9:28 | ... == ... |
+| pre | CatchInFinally.cs:10:17:10:50 | throw ...; | CatchInFinally.cs:13:9:27:9 | [finally: exception(ArgumentNullException)] {...} |
+| pre | CatchInFinally.cs:10:23:10:49 | object creation of type ArgumentNullException | CatchInFinally.cs:10:17:10:50 | throw ...; |
+| pre | CatchInFinally.cs:10:23:10:49 | object creation of type ArgumentNullException | CatchInFinally.cs:13:9:27:9 | [finally: exception(Exception)] {...} |
+| pre | CatchInFinally.cs:13:9:27:9 | [finally: exception(ArgumentNullException)] {...} | CatchInFinally.cs:14:13:26:13 | [finally: exception(ArgumentNullException)] try {...} ... |
+| pre | CatchInFinally.cs:13:9:27:9 | [finally: exception(Exception)] {...} | CatchInFinally.cs:14:13:26:13 | [finally: exception(Exception)] try {...} ... |
+| pre | CatchInFinally.cs:13:9:27:9 | {...} | CatchInFinally.cs:14:13:26:13 | try {...} ... |
+| pre | CatchInFinally.cs:14:13:26:13 | [finally: exception(ArgumentNullException)] try {...} ... | CatchInFinally.cs:15:13:18:13 | [finally: exception(ArgumentNullException)] {...} |
+| pre | CatchInFinally.cs:14:13:26:13 | [finally: exception(Exception)] try {...} ... | CatchInFinally.cs:15:13:18:13 | [finally: exception(Exception)] {...} |
+| pre | CatchInFinally.cs:14:13:26:13 | try {...} ... | CatchInFinally.cs:15:13:18:13 | {...} |
+| pre | CatchInFinally.cs:15:13:18:13 | [finally: exception(ArgumentNullException)] {...} | CatchInFinally.cs:16:17:17:45 | [finally: exception(ArgumentNullException)] if (...) ... |
+| pre | CatchInFinally.cs:15:13:18:13 | [finally: exception(Exception)] {...} | CatchInFinally.cs:16:17:17:45 | [finally: exception(Exception)] if (...) ... |
+| pre | CatchInFinally.cs:15:13:18:13 | {...} | CatchInFinally.cs:16:17:17:45 | if (...) ... |
+| pre | CatchInFinally.cs:16:17:17:45 | [finally: exception(ArgumentNullException)] if (...) ... | CatchInFinally.cs:16:21:16:24 | [finally: exception(ArgumentNullException)] access to parameter args |
+| pre | CatchInFinally.cs:16:17:17:45 | [finally: exception(Exception)] if (...) ... | CatchInFinally.cs:16:21:16:24 | [finally: exception(Exception)] access to parameter args |
+| pre | CatchInFinally.cs:16:17:17:45 | if (...) ... | CatchInFinally.cs:16:21:16:24 | access to parameter args |
+| pre | CatchInFinally.cs:16:21:16:24 | [finally: exception(ArgumentNullException)] access to parameter args | CatchInFinally.cs:16:21:16:31 | [finally: exception(ArgumentNullException)] access to property Length |
+| pre | CatchInFinally.cs:16:21:16:24 | [finally: exception(Exception)] access to parameter args | CatchInFinally.cs:16:21:16:31 | [finally: exception(Exception)] access to property Length |
+| pre | CatchInFinally.cs:16:21:16:24 | access to parameter args | CatchInFinally.cs:16:21:16:31 | access to property Length |
+| pre | CatchInFinally.cs:16:21:16:31 | [finally: exception(ArgumentNullException)] access to property Length | CatchInFinally.cs:16:36:16:36 | [finally: exception(ArgumentNullException)] 1 |
+| pre | CatchInFinally.cs:16:21:16:31 | [finally: exception(ArgumentNullException)] access to property Length | CatchInFinally.cs:19:13:22:13 | [exception: Exception, finally: exception(ArgumentNullException)] catch (...) {...} |
+| pre | CatchInFinally.cs:16:21:16:31 | [finally: exception(ArgumentNullException)] access to property Length | CatchInFinally.cs:19:13:22:13 | [exception: NullReferenceException, finally: exception(ArgumentNullException)] catch (...) {...} |
+| pre | CatchInFinally.cs:16:21:16:31 | [finally: exception(Exception)] access to property Length | CatchInFinally.cs:16:36:16:36 | [finally: exception(Exception)] 1 |
+| pre | CatchInFinally.cs:16:21:16:31 | [finally: exception(Exception)] access to property Length | CatchInFinally.cs:19:13:22:13 | [exception: Exception, finally: exception(Exception)] catch (...) {...} |
+| pre | CatchInFinally.cs:16:21:16:31 | [finally: exception(Exception)] access to property Length | CatchInFinally.cs:19:13:22:13 | [exception: NullReferenceException, finally: exception(Exception)] catch (...) {...} |
+| pre | CatchInFinally.cs:16:21:16:31 | access to property Length | CatchInFinally.cs:16:36:16:36 | 1 |
+| pre | CatchInFinally.cs:16:21:16:31 | access to property Length | CatchInFinally.cs:19:13:22:13 | [exception: Exception] catch (...) {...} |
+| pre | CatchInFinally.cs:16:21:16:31 | access to property Length | CatchInFinally.cs:19:13:22:13 | [exception: NullReferenceException] catch (...) {...} |
+| pre | CatchInFinally.cs:16:21:16:36 | ... == ... | CatchInFinally.cs:17:41:17:43 | "1" |
+| pre | CatchInFinally.cs:16:21:16:36 | [finally: exception(ArgumentNullException)] ... == ... | CatchInFinally.cs:17:41:17:43 | [finally: exception(ArgumentNullException)] "1" |
+| pre | CatchInFinally.cs:16:21:16:36 | [finally: exception(Exception)] ... == ... | CatchInFinally.cs:17:41:17:43 | [finally: exception(Exception)] "1" |
+| pre | CatchInFinally.cs:16:36:16:36 | 1 | CatchInFinally.cs:16:21:16:36 | ... == ... |
+| pre | CatchInFinally.cs:16:36:16:36 | [finally: exception(ArgumentNullException)] 1 | CatchInFinally.cs:16:21:16:36 | [finally: exception(ArgumentNullException)] ... == ... |
+| pre | CatchInFinally.cs:16:36:16:36 | [finally: exception(Exception)] 1 | CatchInFinally.cs:16:21:16:36 | [finally: exception(Exception)] ... == ... |
+| pre | CatchInFinally.cs:17:27:17:44 | [finally: exception(ArgumentNullException)] object creation of type Exception | CatchInFinally.cs:17:21:17:45 | [finally: exception(ArgumentNullException)] throw ...; |
+| pre | CatchInFinally.cs:17:27:17:44 | [finally: exception(Exception)] object creation of type Exception | CatchInFinally.cs:17:21:17:45 | [finally: exception(Exception)] throw ...; |
+| pre | CatchInFinally.cs:17:27:17:44 | object creation of type Exception | CatchInFinally.cs:17:21:17:45 | throw ...; |
+| pre | CatchInFinally.cs:17:41:17:43 | "1" | CatchInFinally.cs:17:27:17:44 | object creation of type Exception |
+| pre | CatchInFinally.cs:17:41:17:43 | [finally: exception(ArgumentNullException)] "1" | CatchInFinally.cs:17:27:17:44 | [finally: exception(ArgumentNullException)] object creation of type Exception |
+| pre | CatchInFinally.cs:17:41:17:43 | [finally: exception(Exception)] "1" | CatchInFinally.cs:17:27:17:44 | [finally: exception(Exception)] object creation of type Exception |
+| pre | CatchInFinally.cs:19:13:22:13 | [exception: Exception, finally: exception(ArgumentNullException)] catch (...) {...} | CatchInFinally.cs:19:30:19:30 | [exception: Exception, finally: exception(ArgumentNullException)] Exception e |
+| pre | CatchInFinally.cs:19:13:22:13 | [exception: Exception, finally: exception(Exception)] catch (...) {...} | CatchInFinally.cs:19:30:19:30 | [exception: Exception, finally: exception(Exception)] Exception e |
+| pre | CatchInFinally.cs:19:13:22:13 | [exception: Exception] catch (...) {...} | CatchInFinally.cs:19:30:19:30 | [exception: Exception] Exception e |
+| pre | CatchInFinally.cs:19:13:22:13 | [exception: NullReferenceException, finally: exception(ArgumentNullException)] catch (...) {...} | CatchInFinally.cs:19:30:19:30 | [exception: NullReferenceException, finally: exception(ArgumentNullException)] Exception e |
+| pre | CatchInFinally.cs:19:13:22:13 | [exception: NullReferenceException, finally: exception(Exception)] catch (...) {...} | CatchInFinally.cs:19:30:19:30 | [exception: NullReferenceException, finally: exception(Exception)] Exception e |
+| pre | CatchInFinally.cs:19:13:22:13 | [exception: NullReferenceException] catch (...) {...} | CatchInFinally.cs:19:30:19:30 | [exception: NullReferenceException] Exception e |
+| pre | CatchInFinally.cs:19:30:19:30 | [exception: Exception, finally: exception(ArgumentNullException)] Exception e | CatchInFinally.cs:19:39:19:39 | [exception: Exception, finally: exception(ArgumentNullException)] access to local variable e |
+| pre | CatchInFinally.cs:19:30:19:30 | [exception: Exception, finally: exception(Exception)] Exception e | CatchInFinally.cs:19:39:19:39 | [exception: Exception, finally: exception(Exception)] access to local variable e |
+| pre | CatchInFinally.cs:19:30:19:30 | [exception: Exception] Exception e | CatchInFinally.cs:19:39:19:39 | [exception: Exception] access to local variable e |
+| pre | CatchInFinally.cs:19:30:19:30 | [exception: NullReferenceException, finally: exception(ArgumentNullException)] Exception e | CatchInFinally.cs:19:39:19:39 | [exception: NullReferenceException, finally: exception(ArgumentNullException)] access to local variable e |
+| pre | CatchInFinally.cs:19:30:19:30 | [exception: NullReferenceException, finally: exception(Exception)] Exception e | CatchInFinally.cs:19:39:19:39 | [exception: NullReferenceException, finally: exception(Exception)] access to local variable e |
+| pre | CatchInFinally.cs:19:30:19:30 | [exception: NullReferenceException] Exception e | CatchInFinally.cs:19:39:19:39 | [exception: NullReferenceException] access to local variable e |
+| pre | CatchInFinally.cs:19:39:19:39 | [exception: Exception, finally: exception(ArgumentNullException)] access to local variable e | CatchInFinally.cs:19:39:19:47 | [exception: Exception, finally: exception(ArgumentNullException)] access to property Message |
+| pre | CatchInFinally.cs:19:39:19:39 | [exception: Exception, finally: exception(Exception)] access to local variable e | CatchInFinally.cs:19:39:19:47 | [exception: Exception, finally: exception(Exception)] access to property Message |
+| pre | CatchInFinally.cs:19:39:19:39 | [exception: Exception] access to local variable e | CatchInFinally.cs:19:39:19:47 | [exception: Exception] access to property Message |
+| pre | CatchInFinally.cs:19:39:19:39 | [exception: NullReferenceException, finally: exception(ArgumentNullException)] access to local variable e | CatchInFinally.cs:19:39:19:47 | [exception: NullReferenceException, finally: exception(ArgumentNullException)] access to property Message |
+| pre | CatchInFinally.cs:19:39:19:39 | [exception: NullReferenceException, finally: exception(Exception)] access to local variable e | CatchInFinally.cs:19:39:19:47 | [exception: NullReferenceException, finally: exception(Exception)] access to property Message |
+| pre | CatchInFinally.cs:19:39:19:39 | [exception: NullReferenceException] access to local variable e | CatchInFinally.cs:19:39:19:47 | [exception: NullReferenceException] access to property Message |
+| pre | CatchInFinally.cs:19:39:19:47 | [exception: Exception, finally: exception(ArgumentNullException)] access to property Message | CatchInFinally.cs:19:52:19:54 | [exception: Exception, finally: exception(ArgumentNullException)] "1" |
+| pre | CatchInFinally.cs:19:39:19:47 | [exception: Exception, finally: exception(Exception)] access to property Message | CatchInFinally.cs:19:52:19:54 | [exception: Exception, finally: exception(Exception)] "1" |
+| pre | CatchInFinally.cs:19:39:19:47 | [exception: Exception] access to property Message | CatchInFinally.cs:19:52:19:54 | [exception: Exception] "1" |
+| pre | CatchInFinally.cs:19:39:19:47 | [exception: NullReferenceException, finally: exception(ArgumentNullException)] access to property Message | CatchInFinally.cs:19:52:19:54 | [exception: NullReferenceException, finally: exception(ArgumentNullException)] "1" |
+| pre | CatchInFinally.cs:19:39:19:47 | [exception: NullReferenceException, finally: exception(Exception)] access to property Message | CatchInFinally.cs:19:52:19:54 | [exception: NullReferenceException, finally: exception(Exception)] "1" |
+| pre | CatchInFinally.cs:19:39:19:47 | [exception: NullReferenceException] access to property Message | CatchInFinally.cs:19:52:19:54 | [exception: NullReferenceException] "1" |
+| pre | CatchInFinally.cs:19:52:19:54 | [exception: Exception, finally: exception(ArgumentNullException)] "1" | CatchInFinally.cs:19:39:19:54 | [exception: Exception, finally: exception(ArgumentNullException)] ... == ... |
+| pre | CatchInFinally.cs:19:52:19:54 | [exception: Exception, finally: exception(Exception)] "1" | CatchInFinally.cs:19:39:19:54 | [exception: Exception, finally: exception(Exception)] ... == ... |
+| pre | CatchInFinally.cs:19:52:19:54 | [exception: Exception] "1" | CatchInFinally.cs:19:39:19:54 | [exception: Exception] ... == ... |
+| pre | CatchInFinally.cs:19:52:19:54 | [exception: NullReferenceException, finally: exception(ArgumentNullException)] "1" | CatchInFinally.cs:19:39:19:54 | [exception: NullReferenceException, finally: exception(ArgumentNullException)] ... == ... |
+| pre | CatchInFinally.cs:19:52:19:54 | [exception: NullReferenceException, finally: exception(Exception)] "1" | CatchInFinally.cs:19:39:19:54 | [exception: NullReferenceException, finally: exception(Exception)] ... == ... |
+| pre | CatchInFinally.cs:19:52:19:54 | [exception: NullReferenceException] "1" | CatchInFinally.cs:19:39:19:54 | [exception: NullReferenceException] ... == ... |
+| pre | CatchInFinally.cs:20:13:22:13 | [finally: exception(ArgumentNullException)] {...} | CatchInFinally.cs:21:17:21:43 | [finally: exception(ArgumentNullException)] ...; |
+| pre | CatchInFinally.cs:20:13:22:13 | [finally: exception(Exception)] {...} | CatchInFinally.cs:21:17:21:43 | [finally: exception(Exception)] ...; |
+| pre | CatchInFinally.cs:20:13:22:13 | {...} | CatchInFinally.cs:21:17:21:43 | ...; |
+| pre | CatchInFinally.cs:21:17:21:43 | ...; | CatchInFinally.cs:21:35:21:38 | access to parameter args |
+| pre | CatchInFinally.cs:21:17:21:43 | [finally: exception(ArgumentNullException)] ...; | CatchInFinally.cs:21:35:21:38 | [finally: exception(ArgumentNullException)] access to parameter args |
+| pre | CatchInFinally.cs:21:17:21:43 | [finally: exception(Exception)] ...; | CatchInFinally.cs:21:35:21:38 | [finally: exception(Exception)] access to parameter args |
+| pre | CatchInFinally.cs:21:35:21:38 | [finally: exception(ArgumentNullException)] access to parameter args | CatchInFinally.cs:21:40:21:40 | [finally: exception(ArgumentNullException)] 0 |
+| pre | CatchInFinally.cs:21:35:21:38 | [finally: exception(Exception)] access to parameter args | CatchInFinally.cs:21:40:21:40 | [finally: exception(Exception)] 0 |
+| pre | CatchInFinally.cs:21:35:21:38 | access to parameter args | CatchInFinally.cs:21:40:21:40 | 0 |
+| pre | CatchInFinally.cs:21:35:21:41 | [finally: exception(ArgumentNullException)] access to array element | CatchInFinally.cs:21:17:21:42 | [finally: exception(ArgumentNullException)] call to method WriteLine |
+| pre | CatchInFinally.cs:21:35:21:41 | [finally: exception(Exception)] access to array element | CatchInFinally.cs:21:17:21:42 | [finally: exception(Exception)] call to method WriteLine |
+| pre | CatchInFinally.cs:21:35:21:41 | access to array element | CatchInFinally.cs:21:17:21:42 | call to method WriteLine |
+| pre | CatchInFinally.cs:21:40:21:40 | 0 | CatchInFinally.cs:21:35:21:41 | access to array element |
+| pre | CatchInFinally.cs:21:40:21:40 | [finally: exception(ArgumentNullException)] 0 | CatchInFinally.cs:21:35:21:41 | [finally: exception(ArgumentNullException)] access to array element |
+| pre | CatchInFinally.cs:21:40:21:40 | [finally: exception(Exception)] 0 | CatchInFinally.cs:21:35:21:41 | [finally: exception(Exception)] access to array element |
+| pre | CatchInFinally.cs:23:13:26:13 | [finally: exception(ArgumentNullException)] catch {...} | CatchInFinally.cs:24:13:26:13 | [finally: exception(ArgumentNullException)] {...} |
+| pre | CatchInFinally.cs:23:13:26:13 | [finally: exception(Exception)] catch {...} | CatchInFinally.cs:24:13:26:13 | [finally: exception(Exception)] {...} |
+| pre | CatchInFinally.cs:23:13:26:13 | catch {...} | CatchInFinally.cs:24:13:26:13 | {...} |
+| pre | CatchInFinally.cs:24:13:26:13 | [finally: exception(ArgumentNullException)] {...} | CatchInFinally.cs:25:17:25:38 | [finally: exception(ArgumentNullException)] ...; |
+| pre | CatchInFinally.cs:24:13:26:13 | [finally: exception(Exception)] {...} | CatchInFinally.cs:25:17:25:38 | [finally: exception(Exception)] ...; |
+| pre | CatchInFinally.cs:24:13:26:13 | {...} | CatchInFinally.cs:25:17:25:38 | ...; |
+| pre | CatchInFinally.cs:25:17:25:38 | ...; | CatchInFinally.cs:25:35:25:36 | "" |
+| pre | CatchInFinally.cs:25:17:25:38 | [finally: exception(ArgumentNullException)] ...; | CatchInFinally.cs:25:35:25:36 | [finally: exception(ArgumentNullException)] "" |
+| pre | CatchInFinally.cs:25:17:25:38 | [finally: exception(Exception)] ...; | CatchInFinally.cs:25:35:25:36 | [finally: exception(Exception)] "" |
+| pre | CatchInFinally.cs:25:35:25:36 | "" | CatchInFinally.cs:25:17:25:37 | call to method WriteLine |
+| pre | CatchInFinally.cs:25:35:25:36 | [finally: exception(ArgumentNullException)] "" | CatchInFinally.cs:25:17:25:37 | [finally: exception(ArgumentNullException)] call to method WriteLine |
+| pre | CatchInFinally.cs:25:35:25:36 | [finally: exception(Exception)] "" | CatchInFinally.cs:25:17:25:37 | [finally: exception(Exception)] call to method WriteLine |
 | pre | CompileTimeOperators.cs:5:9:5:15 | enter Default | CompileTimeOperators.cs:6:5:8:5 | {...} |
 | pre | CompileTimeOperators.cs:6:5:8:5 | {...} | CompileTimeOperators.cs:7:16:7:27 | default(...) |
 | pre | CompileTimeOperators.cs:7:9:7:28 | return ...; | CompileTimeOperators.cs:5:9:5:15 | exit Default |

--- a/csharp/ql/test/library-tests/controlflow/graph/Dominance.expected
+++ b/csharp/ql/test/library-tests/controlflow/graph/Dominance.expected
@@ -94,20 +94,20 @@
 | post | BreakInTry.cs:26:21:26:23 | access to local variable arg | BreakInTry.cs:26:17:27:26 | if (...) ... |
 | post | BreakInTry.cs:26:21:26:31 | ... == ... | BreakInTry.cs:26:28:26:31 | null |
 | post | BreakInTry.cs:26:28:26:31 | null | BreakInTry.cs:26:21:26:23 | access to local variable arg |
-| post | BreakInTry.cs:30:13:33:13 | [break] {...} | BreakInTry.cs:27:21:27:26 | break; |
-| post | BreakInTry.cs:31:17:32:21 | [break] if (...) ... | BreakInTry.cs:30:13:33:13 | [break] {...} |
+| post | BreakInTry.cs:30:13:33:13 | [finally: break] {...} | BreakInTry.cs:27:21:27:26 | break; |
+| post | BreakInTry.cs:31:17:32:21 | [finally: break] if (...) ... | BreakInTry.cs:30:13:33:13 | [finally: break] {...} |
 | post | BreakInTry.cs:31:17:32:21 | if (...) ... | BreakInTry.cs:30:13:33:13 | {...} |
-| post | BreakInTry.cs:31:21:31:24 | [break] access to parameter args | BreakInTry.cs:31:17:32:21 | [break] if (...) ... |
+| post | BreakInTry.cs:31:21:31:24 | [finally: break] access to parameter args | BreakInTry.cs:31:17:32:21 | [finally: break] if (...) ... |
 | post | BreakInTry.cs:31:21:31:24 | access to parameter args | BreakInTry.cs:31:17:32:21 | if (...) ... |
 | post | BreakInTry.cs:31:21:31:32 | ... == ... | BreakInTry.cs:31:29:31:32 | null |
-| post | BreakInTry.cs:31:21:31:32 | [break] ... == ... | BreakInTry.cs:31:29:31:32 | [break] null |
-| post | BreakInTry.cs:31:29:31:32 | [break] null | BreakInTry.cs:31:21:31:24 | [break] access to parameter args |
+| post | BreakInTry.cs:31:21:31:32 | [finally: break] ... == ... | BreakInTry.cs:31:29:31:32 | [finally: break] null |
+| post | BreakInTry.cs:31:29:31:32 | [finally: break] null | BreakInTry.cs:31:21:31:24 | [finally: break] access to parameter args |
 | post | BreakInTry.cs:31:29:31:32 | null | BreakInTry.cs:31:21:31:24 | access to parameter args |
 | post | BreakInTry.cs:35:7:35:7 | ; | BreakInTry.cs:22:9:34:9 | foreach (... ... in ...) ... |
-| post | BreakInTry.cs:35:7:35:7 | ; | BreakInTry.cs:31:21:31:32 | [break] ... == ... |
-| post | BreakInTry.cs:35:7:35:7 | ; | BreakInTry.cs:32:21:32:21 | [break] ; |
-| post | BreakInTry.cs:38:10:38:11 | exit M3 | BreakInTry.cs:47:13:51:13 | [return] foreach (... ... in ...) ... |
-| post | BreakInTry.cs:38:10:38:11 | exit M3 | BreakInTry.cs:50:21:50:26 | [return] break; |
+| post | BreakInTry.cs:35:7:35:7 | ; | BreakInTry.cs:31:21:31:32 | [finally: break] ... == ... |
+| post | BreakInTry.cs:35:7:35:7 | ; | BreakInTry.cs:32:21:32:21 | [finally: break] ; |
+| post | BreakInTry.cs:38:10:38:11 | exit M3 | BreakInTry.cs:47:13:51:13 | [finally: return] foreach (... ... in ...) ... |
+| post | BreakInTry.cs:38:10:38:11 | exit M3 | BreakInTry.cs:50:21:50:26 | [finally: return] break; |
 | post | BreakInTry.cs:38:10:38:11 | exit M3 | BreakInTry.cs:53:7:53:7 | ; |
 | post | BreakInTry.cs:39:5:54:5 | {...} | BreakInTry.cs:38:10:38:11 | enter M3 |
 | post | BreakInTry.cs:40:9:52:9 | try {...} ... | BreakInTry.cs:39:5:54:5 | {...} |
@@ -116,26 +116,26 @@
 | post | BreakInTry.cs:42:17:42:20 | access to parameter args | BreakInTry.cs:42:13:43:23 | if (...) ... |
 | post | BreakInTry.cs:42:17:42:28 | ... == ... | BreakInTry.cs:42:25:42:28 | null |
 | post | BreakInTry.cs:42:25:42:28 | null | BreakInTry.cs:42:17:42:20 | access to parameter args |
-| post | BreakInTry.cs:46:9:52:9 | [return] {...} | BreakInTry.cs:43:17:43:23 | return ...; |
-| post | BreakInTry.cs:47:13:51:13 | [return] foreach (... ... in ...) ... | BreakInTry.cs:47:33:47:36 | [return] access to parameter args |
+| post | BreakInTry.cs:46:9:52:9 | [finally: return] {...} | BreakInTry.cs:43:17:43:23 | return ...; |
+| post | BreakInTry.cs:47:13:51:13 | [finally: return] foreach (... ... in ...) ... | BreakInTry.cs:47:33:47:36 | [finally: return] access to parameter args |
 | post | BreakInTry.cs:47:13:51:13 | foreach (... ... in ...) ... | BreakInTry.cs:47:33:47:36 | access to parameter args |
-| post | BreakInTry.cs:47:33:47:36 | [return] access to parameter args | BreakInTry.cs:46:9:52:9 | [return] {...} |
+| post | BreakInTry.cs:47:33:47:36 | [finally: return] access to parameter args | BreakInTry.cs:46:9:52:9 | [finally: return] {...} |
 | post | BreakInTry.cs:47:33:47:36 | access to parameter args | BreakInTry.cs:46:9:52:9 | {...} |
-| post | BreakInTry.cs:48:13:51:13 | [return] {...} | BreakInTry.cs:47:26:47:28 | [return] String arg |
+| post | BreakInTry.cs:48:13:51:13 | [finally: return] {...} | BreakInTry.cs:47:26:47:28 | [finally: return] String arg |
 | post | BreakInTry.cs:48:13:51:13 | {...} | BreakInTry.cs:47:26:47:28 | String arg |
-| post | BreakInTry.cs:49:17:50:26 | [return] if (...) ... | BreakInTry.cs:48:13:51:13 | [return] {...} |
+| post | BreakInTry.cs:49:17:50:26 | [finally: return] if (...) ... | BreakInTry.cs:48:13:51:13 | [finally: return] {...} |
 | post | BreakInTry.cs:49:17:50:26 | if (...) ... | BreakInTry.cs:48:13:51:13 | {...} |
-| post | BreakInTry.cs:49:21:49:23 | [return] access to local variable arg | BreakInTry.cs:49:17:50:26 | [return] if (...) ... |
+| post | BreakInTry.cs:49:21:49:23 | [finally: return] access to local variable arg | BreakInTry.cs:49:17:50:26 | [finally: return] if (...) ... |
 | post | BreakInTry.cs:49:21:49:23 | access to local variable arg | BreakInTry.cs:49:17:50:26 | if (...) ... |
 | post | BreakInTry.cs:49:21:49:31 | ... == ... | BreakInTry.cs:49:28:49:31 | null |
-| post | BreakInTry.cs:49:21:49:31 | [return] ... == ... | BreakInTry.cs:49:28:49:31 | [return] null |
-| post | BreakInTry.cs:49:28:49:31 | [return] null | BreakInTry.cs:49:21:49:23 | [return] access to local variable arg |
+| post | BreakInTry.cs:49:21:49:31 | [finally: return] ... == ... | BreakInTry.cs:49:28:49:31 | [finally: return] null |
+| post | BreakInTry.cs:49:28:49:31 | [finally: return] null | BreakInTry.cs:49:21:49:23 | [finally: return] access to local variable arg |
 | post | BreakInTry.cs:49:28:49:31 | null | BreakInTry.cs:49:21:49:23 | access to local variable arg |
 | post | BreakInTry.cs:53:7:53:7 | ; | BreakInTry.cs:47:13:51:13 | foreach (... ... in ...) ... |
 | post | BreakInTry.cs:53:7:53:7 | ; | BreakInTry.cs:50:21:50:26 | break; |
-| post | BreakInTry.cs:56:10:56:11 | exit M4 | BreakInTry.cs:65:13:69:13 | [return] foreach (... ... in ...) ... |
+| post | BreakInTry.cs:56:10:56:11 | exit M4 | BreakInTry.cs:65:13:69:13 | [finally: return] foreach (... ... in ...) ... |
 | post | BreakInTry.cs:56:10:56:11 | exit M4 | BreakInTry.cs:65:13:69:13 | foreach (... ... in ...) ... |
-| post | BreakInTry.cs:56:10:56:11 | exit M4 | BreakInTry.cs:68:21:68:26 | [return] break; |
+| post | BreakInTry.cs:56:10:56:11 | exit M4 | BreakInTry.cs:68:21:68:26 | [finally: return] break; |
 | post | BreakInTry.cs:56:10:56:11 | exit M4 | BreakInTry.cs:68:21:68:26 | break; |
 | post | BreakInTry.cs:57:5:71:5 | {...} | BreakInTry.cs:56:10:56:11 | enter M4 |
 | post | BreakInTry.cs:58:9:70:9 | try {...} ... | BreakInTry.cs:57:5:71:5 | {...} |
@@ -144,20 +144,20 @@
 | post | BreakInTry.cs:60:17:60:20 | access to parameter args | BreakInTry.cs:60:13:61:23 | if (...) ... |
 | post | BreakInTry.cs:60:17:60:28 | ... == ... | BreakInTry.cs:60:25:60:28 | null |
 | post | BreakInTry.cs:60:25:60:28 | null | BreakInTry.cs:60:17:60:20 | access to parameter args |
-| post | BreakInTry.cs:64:9:70:9 | [return] {...} | BreakInTry.cs:61:17:61:23 | return ...; |
-| post | BreakInTry.cs:65:13:69:13 | [return] foreach (... ... in ...) ... | BreakInTry.cs:65:33:65:36 | [return] access to parameter args |
+| post | BreakInTry.cs:64:9:70:9 | [finally: return] {...} | BreakInTry.cs:61:17:61:23 | return ...; |
+| post | BreakInTry.cs:65:13:69:13 | [finally: return] foreach (... ... in ...) ... | BreakInTry.cs:65:33:65:36 | [finally: return] access to parameter args |
 | post | BreakInTry.cs:65:13:69:13 | foreach (... ... in ...) ... | BreakInTry.cs:65:33:65:36 | access to parameter args |
-| post | BreakInTry.cs:65:33:65:36 | [return] access to parameter args | BreakInTry.cs:64:9:70:9 | [return] {...} |
+| post | BreakInTry.cs:65:33:65:36 | [finally: return] access to parameter args | BreakInTry.cs:64:9:70:9 | [finally: return] {...} |
 | post | BreakInTry.cs:65:33:65:36 | access to parameter args | BreakInTry.cs:64:9:70:9 | {...} |
-| post | BreakInTry.cs:66:13:69:13 | [return] {...} | BreakInTry.cs:65:26:65:28 | [return] String arg |
+| post | BreakInTry.cs:66:13:69:13 | [finally: return] {...} | BreakInTry.cs:65:26:65:28 | [finally: return] String arg |
 | post | BreakInTry.cs:66:13:69:13 | {...} | BreakInTry.cs:65:26:65:28 | String arg |
-| post | BreakInTry.cs:67:17:68:26 | [return] if (...) ... | BreakInTry.cs:66:13:69:13 | [return] {...} |
+| post | BreakInTry.cs:67:17:68:26 | [finally: return] if (...) ... | BreakInTry.cs:66:13:69:13 | [finally: return] {...} |
 | post | BreakInTry.cs:67:17:68:26 | if (...) ... | BreakInTry.cs:66:13:69:13 | {...} |
-| post | BreakInTry.cs:67:21:67:23 | [return] access to local variable arg | BreakInTry.cs:67:17:68:26 | [return] if (...) ... |
+| post | BreakInTry.cs:67:21:67:23 | [finally: return] access to local variable arg | BreakInTry.cs:67:17:68:26 | [finally: return] if (...) ... |
 | post | BreakInTry.cs:67:21:67:23 | access to local variable arg | BreakInTry.cs:67:17:68:26 | if (...) ... |
 | post | BreakInTry.cs:67:21:67:31 | ... == ... | BreakInTry.cs:67:28:67:31 | null |
-| post | BreakInTry.cs:67:21:67:31 | [return] ... == ... | BreakInTry.cs:67:28:67:31 | [return] null |
-| post | BreakInTry.cs:67:28:67:31 | [return] null | BreakInTry.cs:67:21:67:23 | [return] access to local variable arg |
+| post | BreakInTry.cs:67:21:67:31 | [finally: return] ... == ... | BreakInTry.cs:67:28:67:31 | [finally: return] null |
+| post | BreakInTry.cs:67:28:67:31 | [finally: return] null | BreakInTry.cs:67:21:67:23 | [finally: return] access to local variable arg |
 | post | BreakInTry.cs:67:28:67:31 | null | BreakInTry.cs:67:21:67:23 | access to local variable arg |
 | post | CompileTimeOperators.cs:5:9:5:15 | exit Default | CompileTimeOperators.cs:7:9:7:28 | return ...; |
 | post | CompileTimeOperators.cs:6:5:8:5 | {...} | CompileTimeOperators.cs:5:9:5:15 | enter Default |
@@ -180,11 +180,11 @@
 | post | CompileTimeOperators.cs:30:9:38:9 | try {...} ... | CompileTimeOperators.cs:29:5:41:5 | {...} |
 | post | CompileTimeOperators.cs:31:9:34:9 | {...} | CompileTimeOperators.cs:30:9:38:9 | try {...} ... |
 | post | CompileTimeOperators.cs:32:13:32:21 | goto ...; | CompileTimeOperators.cs:31:9:34:9 | {...} |
-| post | CompileTimeOperators.cs:36:9:38:9 | [goto(End)] {...} | CompileTimeOperators.cs:32:13:32:21 | goto ...; |
-| post | CompileTimeOperators.cs:37:13:37:40 | [goto(End)] call to method WriteLine | CompileTimeOperators.cs:37:31:37:39 | [goto(End)] "Finally" |
-| post | CompileTimeOperators.cs:37:13:37:41 | [goto(End)] ...; | CompileTimeOperators.cs:36:9:38:9 | [goto(End)] {...} |
-| post | CompileTimeOperators.cs:37:31:37:39 | [goto(End)] "Finally" | CompileTimeOperators.cs:37:13:37:41 | [goto(End)] ...; |
-| post | CompileTimeOperators.cs:40:9:40:11 | End: | CompileTimeOperators.cs:37:13:37:40 | [goto(End)] call to method WriteLine |
+| post | CompileTimeOperators.cs:36:9:38:9 | [finally: goto(End)] {...} | CompileTimeOperators.cs:32:13:32:21 | goto ...; |
+| post | CompileTimeOperators.cs:37:13:37:40 | [finally: goto(End)] call to method WriteLine | CompileTimeOperators.cs:37:31:37:39 | [finally: goto(End)] "Finally" |
+| post | CompileTimeOperators.cs:37:13:37:41 | [finally: goto(End)] ...; | CompileTimeOperators.cs:36:9:38:9 | [finally: goto(End)] {...} |
+| post | CompileTimeOperators.cs:37:31:37:39 | [finally: goto(End)] "Finally" | CompileTimeOperators.cs:37:13:37:41 | [finally: goto(End)] ...; |
+| post | CompileTimeOperators.cs:40:9:40:11 | End: | CompileTimeOperators.cs:37:13:37:40 | [finally: goto(End)] call to method WriteLine |
 | post | CompileTimeOperators.cs:40:14:40:37 | call to method WriteLine | CompileTimeOperators.cs:40:32:40:36 | "End" |
 | post | CompileTimeOperators.cs:40:14:40:38 | ...; | CompileTimeOperators.cs:40:9:40:11 | End: |
 | post | CompileTimeOperators.cs:40:32:40:36 | "End" | CompileTimeOperators.cs:40:14:40:38 | ...; |
@@ -1070,41 +1070,41 @@
 | post | cflow.cs:144:50:144:51 | "" | cflow.cs:144:46:144:46 | (...) ... |
 | post | cflow.cs:144:56:144:58 | exit set_Item | cflow.cs:144:60:144:62 | {...} |
 | post | cflow.cs:144:60:144:62 | {...} | cflow.cs:144:56:144:58 | enter set_Item |
-| post | cflow.cs:146:10:146:19 | exit TryFinally | cflow.cs:154:13:154:40 | [exception(Exception)] call to method WriteLine |
-| post | cflow.cs:146:10:146:19 | exit TryFinally | cflow.cs:154:13:154:40 | [exception(OutOfMemoryException)] call to method WriteLine |
-| post | cflow.cs:146:10:146:19 | exit TryFinally | cflow.cs:186:13:186:40 | [exception(Exception)] call to method WriteLine |
-| post | cflow.cs:146:10:146:19 | exit TryFinally | cflow.cs:186:13:186:40 | [exception(IOException)] call to method WriteLine |
-| post | cflow.cs:146:10:146:19 | exit TryFinally | cflow.cs:186:13:186:40 | [return] call to method WriteLine |
-| post | cflow.cs:146:10:146:19 | exit TryFinally | cflow.cs:203:13:203:40 | [exception(Exception)] call to method WriteLine |
-| post | cflow.cs:146:10:146:19 | exit TryFinally | cflow.cs:203:13:203:40 | [exception(IOException)] call to method WriteLine |
-| post | cflow.cs:146:10:146:19 | exit TryFinally | cflow.cs:203:13:203:40 | [exception(OutOfMemoryException)] call to method WriteLine |
-| post | cflow.cs:146:10:146:19 | exit TryFinally | cflow.cs:203:13:203:40 | [return] call to method WriteLine |
-| post | cflow.cs:146:10:146:19 | exit TryFinally | cflow.cs:227:21:227:23 | [exception(Exception)] ...-- |
-| post | cflow.cs:146:10:146:19 | exit TryFinally | cflow.cs:227:21:227:23 | [return] ...-- |
+| post | cflow.cs:146:10:146:19 | exit TryFinally | cflow.cs:154:13:154:40 | [finally: exception(Exception)] call to method WriteLine |
+| post | cflow.cs:146:10:146:19 | exit TryFinally | cflow.cs:154:13:154:40 | [finally: exception(OutOfMemoryException)] call to method WriteLine |
+| post | cflow.cs:146:10:146:19 | exit TryFinally | cflow.cs:186:13:186:40 | [finally: exception(Exception)] call to method WriteLine |
+| post | cflow.cs:146:10:146:19 | exit TryFinally | cflow.cs:186:13:186:40 | [finally: exception(IOException)] call to method WriteLine |
+| post | cflow.cs:146:10:146:19 | exit TryFinally | cflow.cs:186:13:186:40 | [finally: return] call to method WriteLine |
+| post | cflow.cs:146:10:146:19 | exit TryFinally | cflow.cs:203:13:203:40 | [finally: exception(Exception)] call to method WriteLine |
+| post | cflow.cs:146:10:146:19 | exit TryFinally | cflow.cs:203:13:203:40 | [finally: exception(IOException)] call to method WriteLine |
+| post | cflow.cs:146:10:146:19 | exit TryFinally | cflow.cs:203:13:203:40 | [finally: exception(OutOfMemoryException)] call to method WriteLine |
+| post | cflow.cs:146:10:146:19 | exit TryFinally | cflow.cs:203:13:203:40 | [finally: return] call to method WriteLine |
+| post | cflow.cs:146:10:146:19 | exit TryFinally | cflow.cs:227:21:227:23 | [finally: exception(Exception)] ...-- |
+| post | cflow.cs:146:10:146:19 | exit TryFinally | cflow.cs:227:21:227:23 | [finally: return] ...-- |
 | post | cflow.cs:146:10:146:19 | exit TryFinally | cflow.cs:243:17:243:32 | ... > ... |
-| post | cflow.cs:146:10:146:19 | exit TryFinally | cflow.cs:243:17:243:32 | [exception(Exception)] ... > ... |
-| post | cflow.cs:146:10:146:19 | exit TryFinally | cflow.cs:243:17:243:32 | [exception(NullReferenceException)] ... > ... |
-| post | cflow.cs:146:10:146:19 | exit TryFinally | cflow.cs:243:17:243:32 | [exception(OutOfMemoryException)] ... > ... |
-| post | cflow.cs:146:10:146:19 | exit TryFinally | cflow.cs:243:17:243:32 | [return] ... > ... |
-| post | cflow.cs:146:10:146:19 | exit TryFinally | cflow.cs:244:17:244:36 | [exception(Exception)] call to method WriteLine |
-| post | cflow.cs:146:10:146:19 | exit TryFinally | cflow.cs:244:17:244:36 | [exception(NullReferenceException)] call to method WriteLine |
-| post | cflow.cs:146:10:146:19 | exit TryFinally | cflow.cs:244:17:244:36 | [exception(OutOfMemoryException)] call to method WriteLine |
-| post | cflow.cs:146:10:146:19 | exit TryFinally | cflow.cs:244:17:244:36 | [return] call to method WriteLine |
+| post | cflow.cs:146:10:146:19 | exit TryFinally | cflow.cs:243:17:243:32 | [finally: exception(Exception)] ... > ... |
+| post | cflow.cs:146:10:146:19 | exit TryFinally | cflow.cs:243:17:243:32 | [finally: exception(NullReferenceException)] ... > ... |
+| post | cflow.cs:146:10:146:19 | exit TryFinally | cflow.cs:243:17:243:32 | [finally: exception(OutOfMemoryException)] ... > ... |
+| post | cflow.cs:146:10:146:19 | exit TryFinally | cflow.cs:243:17:243:32 | [finally: return] ... > ... |
+| post | cflow.cs:146:10:146:19 | exit TryFinally | cflow.cs:244:17:244:36 | [finally: exception(Exception)] call to method WriteLine |
+| post | cflow.cs:146:10:146:19 | exit TryFinally | cflow.cs:244:17:244:36 | [finally: exception(NullReferenceException)] call to method WriteLine |
+| post | cflow.cs:146:10:146:19 | exit TryFinally | cflow.cs:244:17:244:36 | [finally: exception(OutOfMemoryException)] call to method WriteLine |
+| post | cflow.cs:146:10:146:19 | exit TryFinally | cflow.cs:244:17:244:36 | [finally: return] call to method WriteLine |
 | post | cflow.cs:146:10:146:19 | exit TryFinally | cflow.cs:244:17:244:36 | call to method WriteLine |
 | post | cflow.cs:147:5:246:5 | {...} | cflow.cs:146:10:146:19 | enter TryFinally |
 | post | cflow.cs:148:9:155:9 | try {...} ... | cflow.cs:147:5:246:5 | {...} |
 | post | cflow.cs:149:9:151:9 | {...} | cflow.cs:148:9:155:9 | try {...} ... |
 | post | cflow.cs:150:13:150:38 | ...; | cflow.cs:149:9:151:9 | {...} |
 | post | cflow.cs:150:31:150:36 | "Try1" | cflow.cs:150:13:150:38 | ...; |
-| post | cflow.cs:154:13:154:40 | [exception(Exception)] call to method WriteLine | cflow.cs:154:31:154:39 | [exception(Exception)] "Finally" |
-| post | cflow.cs:154:13:154:40 | [exception(OutOfMemoryException)] call to method WriteLine | cflow.cs:154:31:154:39 | [exception(OutOfMemoryException)] "Finally" |
+| post | cflow.cs:154:13:154:40 | [finally: exception(Exception)] call to method WriteLine | cflow.cs:154:31:154:39 | [finally: exception(Exception)] "Finally" |
+| post | cflow.cs:154:13:154:40 | [finally: exception(OutOfMemoryException)] call to method WriteLine | cflow.cs:154:31:154:39 | [finally: exception(OutOfMemoryException)] "Finally" |
 | post | cflow.cs:154:13:154:40 | call to method WriteLine | cflow.cs:154:31:154:39 | "Finally" |
 | post | cflow.cs:154:13:154:41 | ...; | cflow.cs:153:9:155:9 | {...} |
-| post | cflow.cs:154:13:154:41 | [exception(Exception)] ...; | cflow.cs:153:9:155:9 | [exception(Exception)] {...} |
-| post | cflow.cs:154:13:154:41 | [exception(OutOfMemoryException)] ...; | cflow.cs:153:9:155:9 | [exception(OutOfMemoryException)] {...} |
+| post | cflow.cs:154:13:154:41 | [finally: exception(Exception)] ...; | cflow.cs:153:9:155:9 | [finally: exception(Exception)] {...} |
+| post | cflow.cs:154:13:154:41 | [finally: exception(OutOfMemoryException)] ...; | cflow.cs:153:9:155:9 | [finally: exception(OutOfMemoryException)] {...} |
 | post | cflow.cs:154:31:154:39 | "Finally" | cflow.cs:154:13:154:41 | ...; |
-| post | cflow.cs:154:31:154:39 | [exception(Exception)] "Finally" | cflow.cs:154:13:154:41 | [exception(Exception)] ...; |
-| post | cflow.cs:154:31:154:39 | [exception(OutOfMemoryException)] "Finally" | cflow.cs:154:13:154:41 | [exception(OutOfMemoryException)] ...; |
+| post | cflow.cs:154:31:154:39 | [finally: exception(Exception)] "Finally" | cflow.cs:154:13:154:41 | [finally: exception(Exception)] ...; |
+| post | cflow.cs:154:31:154:39 | [finally: exception(OutOfMemoryException)] "Finally" | cflow.cs:154:13:154:41 | [finally: exception(OutOfMemoryException)] ...; |
 | post | cflow.cs:157:9:187:9 | try {...} ... | cflow.cs:154:13:154:40 | call to method WriteLine |
 | post | cflow.cs:158:9:161:9 | {...} | cflow.cs:157:9:187:9 | try {...} ... |
 | post | cflow.cs:159:13:159:38 | ...; | cflow.cs:158:9:161:9 | {...} |
@@ -1120,27 +1120,27 @@
 | post | cflow.cs:170:17:170:32 | if (...) ... | cflow.cs:169:13:171:13 | {...} |
 | post | cflow.cs:170:21:170:24 | true | cflow.cs:170:17:170:32 | if (...) ... |
 | post | cflow.cs:170:27:170:32 | throw ...; | cflow.cs:170:21:170:24 | true |
-| post | cflow.cs:173:13:175:13 | [exception(ArgumentException)] {...} | cflow.cs:170:27:170:32 | throw ...; |
-| post | cflow.cs:174:17:174:44 | [exception(ArgumentException)] throw ...; | cflow.cs:174:23:174:43 | [exception(ArgumentException)] object creation of type Exception |
-| post | cflow.cs:174:23:174:43 | [exception(ArgumentException)] object creation of type Exception | cflow.cs:174:37:174:42 | [exception(ArgumentException)] "Boo!" |
-| post | cflow.cs:174:37:174:42 | [exception(ArgumentException)] "Boo!" | cflow.cs:173:13:175:13 | [exception(ArgumentException)] {...} |
+| post | cflow.cs:173:13:175:13 | [finally: exception(ArgumentException)] {...} | cflow.cs:170:27:170:32 | throw ...; |
+| post | cflow.cs:174:17:174:44 | [finally: exception(ArgumentException)] throw ...; | cflow.cs:174:23:174:43 | [finally: exception(ArgumentException)] object creation of type Exception |
+| post | cflow.cs:174:23:174:43 | [finally: exception(ArgumentException)] object creation of type Exception | cflow.cs:174:37:174:42 | [finally: exception(ArgumentException)] "Boo!" |
+| post | cflow.cs:174:37:174:42 | [finally: exception(ArgumentException)] "Boo!" | cflow.cs:173:13:175:13 | [finally: exception(ArgumentException)] {...} |
 | post | cflow.cs:178:9:179:9 | {...} | cflow.cs:177:9:179:9 | catch (...) {...} |
-| post | cflow.cs:185:9:187:9 | [exception(Exception)] {...} | cflow.cs:174:17:174:44 | [exception(ArgumentException)] throw ...; |
-| post | cflow.cs:185:9:187:9 | [exception(IOException)] {...} | cflow.cs:164:13:164:18 | throw ...; |
-| post | cflow.cs:185:9:187:9 | [return] {...} | cflow.cs:160:13:160:19 | return ...; |
+| post | cflow.cs:185:9:187:9 | [finally: exception(Exception)] {...} | cflow.cs:174:17:174:44 | [finally: exception(ArgumentException)] throw ...; |
+| post | cflow.cs:185:9:187:9 | [finally: exception(IOException)] {...} | cflow.cs:164:13:164:18 | throw ...; |
+| post | cflow.cs:185:9:187:9 | [finally: return] {...} | cflow.cs:160:13:160:19 | return ...; |
 | post | cflow.cs:185:9:187:9 | {...} | cflow.cs:178:9:179:9 | {...} |
-| post | cflow.cs:186:13:186:40 | [exception(Exception)] call to method WriteLine | cflow.cs:186:31:186:39 | [exception(Exception)] "Finally" |
-| post | cflow.cs:186:13:186:40 | [exception(IOException)] call to method WriteLine | cflow.cs:186:31:186:39 | [exception(IOException)] "Finally" |
-| post | cflow.cs:186:13:186:40 | [return] call to method WriteLine | cflow.cs:186:31:186:39 | [return] "Finally" |
+| post | cflow.cs:186:13:186:40 | [finally: exception(Exception)] call to method WriteLine | cflow.cs:186:31:186:39 | [finally: exception(Exception)] "Finally" |
+| post | cflow.cs:186:13:186:40 | [finally: exception(IOException)] call to method WriteLine | cflow.cs:186:31:186:39 | [finally: exception(IOException)] "Finally" |
+| post | cflow.cs:186:13:186:40 | [finally: return] call to method WriteLine | cflow.cs:186:31:186:39 | [finally: return] "Finally" |
 | post | cflow.cs:186:13:186:40 | call to method WriteLine | cflow.cs:186:31:186:39 | "Finally" |
 | post | cflow.cs:186:13:186:41 | ...; | cflow.cs:185:9:187:9 | {...} |
-| post | cflow.cs:186:13:186:41 | [exception(Exception)] ...; | cflow.cs:185:9:187:9 | [exception(Exception)] {...} |
-| post | cflow.cs:186:13:186:41 | [exception(IOException)] ...; | cflow.cs:185:9:187:9 | [exception(IOException)] {...} |
-| post | cflow.cs:186:13:186:41 | [return] ...; | cflow.cs:185:9:187:9 | [return] {...} |
+| post | cflow.cs:186:13:186:41 | [finally: exception(Exception)] ...; | cflow.cs:185:9:187:9 | [finally: exception(Exception)] {...} |
+| post | cflow.cs:186:13:186:41 | [finally: exception(IOException)] ...; | cflow.cs:185:9:187:9 | [finally: exception(IOException)] {...} |
+| post | cflow.cs:186:13:186:41 | [finally: return] ...; | cflow.cs:185:9:187:9 | [finally: return] {...} |
 | post | cflow.cs:186:31:186:39 | "Finally" | cflow.cs:186:13:186:41 | ...; |
-| post | cflow.cs:186:31:186:39 | [exception(Exception)] "Finally" | cflow.cs:186:13:186:41 | [exception(Exception)] ...; |
-| post | cflow.cs:186:31:186:39 | [exception(IOException)] "Finally" | cflow.cs:186:13:186:41 | [exception(IOException)] ...; |
-| post | cflow.cs:186:31:186:39 | [return] "Finally" | cflow.cs:186:13:186:41 | [return] ...; |
+| post | cflow.cs:186:31:186:39 | [finally: exception(Exception)] "Finally" | cflow.cs:186:13:186:41 | [finally: exception(Exception)] ...; |
+| post | cflow.cs:186:31:186:39 | [finally: exception(IOException)] "Finally" | cflow.cs:186:13:186:41 | [finally: exception(IOException)] ...; |
+| post | cflow.cs:186:31:186:39 | [finally: return] "Finally" | cflow.cs:186:13:186:41 | [finally: return] ...; |
 | post | cflow.cs:189:9:204:9 | try {...} ... | cflow.cs:186:13:186:40 | call to method WriteLine |
 | post | cflow.cs:190:9:193:9 | {...} | cflow.cs:189:9:204:9 | try {...} ... |
 | post | cflow.cs:191:13:191:38 | ...; | cflow.cs:190:9:193:9 | {...} |
@@ -1149,26 +1149,30 @@
 | post | cflow.cs:194:48:194:51 | true | cflow.cs:194:38:194:39 | IOException ex |
 | post | cflow.cs:195:9:197:9 | {...} | cflow.cs:194:48:194:51 | true |
 | post | cflow.cs:196:13:196:18 | throw ...; | cflow.cs:195:9:197:9 | {...} |
-| post | cflow.cs:198:33:198:37 | false | cflow.cs:198:9:200:9 | catch (...) {...} |
-| post | cflow.cs:199:9:200:9 | {...} | cflow.cs:198:33:198:37 | false |
-| post | cflow.cs:202:9:204:9 | [exception(IOException)] {...} | cflow.cs:196:13:196:18 | throw ...; |
-| post | cflow.cs:202:9:204:9 | [return] {...} | cflow.cs:192:13:192:19 | return ...; |
+| post | cflow.cs:198:26:198:26 | Exception e | cflow.cs:198:9:200:9 | catch (...) {...} |
+| post | cflow.cs:198:35:198:35 | access to local variable e | cflow.cs:198:26:198:26 | Exception e |
+| post | cflow.cs:198:35:198:43 | access to property Message | cflow.cs:198:35:198:35 | access to local variable e |
+| post | cflow.cs:198:35:198:51 | ... != ... | cflow.cs:198:48:198:51 | null |
+| post | cflow.cs:198:48:198:51 | null | cflow.cs:198:35:198:43 | access to property Message |
+| post | cflow.cs:199:9:200:9 | {...} | cflow.cs:198:35:198:51 | ... != ... |
+| post | cflow.cs:202:9:204:9 | [finally: exception(IOException)] {...} | cflow.cs:196:13:196:18 | throw ...; |
+| post | cflow.cs:202:9:204:9 | [finally: return] {...} | cflow.cs:192:13:192:19 | return ...; |
 | post | cflow.cs:202:9:204:9 | {...} | cflow.cs:199:9:200:9 | {...} |
-| post | cflow.cs:203:13:203:40 | [exception(Exception)] call to method WriteLine | cflow.cs:203:31:203:39 | [exception(Exception)] "Finally" |
-| post | cflow.cs:203:13:203:40 | [exception(IOException)] call to method WriteLine | cflow.cs:203:31:203:39 | [exception(IOException)] "Finally" |
-| post | cflow.cs:203:13:203:40 | [exception(OutOfMemoryException)] call to method WriteLine | cflow.cs:203:31:203:39 | [exception(OutOfMemoryException)] "Finally" |
-| post | cflow.cs:203:13:203:40 | [return] call to method WriteLine | cflow.cs:203:31:203:39 | [return] "Finally" |
+| post | cflow.cs:203:13:203:40 | [finally: exception(Exception)] call to method WriteLine | cflow.cs:203:31:203:39 | [finally: exception(Exception)] "Finally" |
+| post | cflow.cs:203:13:203:40 | [finally: exception(IOException)] call to method WriteLine | cflow.cs:203:31:203:39 | [finally: exception(IOException)] "Finally" |
+| post | cflow.cs:203:13:203:40 | [finally: exception(OutOfMemoryException)] call to method WriteLine | cflow.cs:203:31:203:39 | [finally: exception(OutOfMemoryException)] "Finally" |
+| post | cflow.cs:203:13:203:40 | [finally: return] call to method WriteLine | cflow.cs:203:31:203:39 | [finally: return] "Finally" |
 | post | cflow.cs:203:13:203:40 | call to method WriteLine | cflow.cs:203:31:203:39 | "Finally" |
 | post | cflow.cs:203:13:203:41 | ...; | cflow.cs:202:9:204:9 | {...} |
-| post | cflow.cs:203:13:203:41 | [exception(Exception)] ...; | cflow.cs:202:9:204:9 | [exception(Exception)] {...} |
-| post | cflow.cs:203:13:203:41 | [exception(IOException)] ...; | cflow.cs:202:9:204:9 | [exception(IOException)] {...} |
-| post | cflow.cs:203:13:203:41 | [exception(OutOfMemoryException)] ...; | cflow.cs:202:9:204:9 | [exception(OutOfMemoryException)] {...} |
-| post | cflow.cs:203:13:203:41 | [return] ...; | cflow.cs:202:9:204:9 | [return] {...} |
+| post | cflow.cs:203:13:203:41 | [finally: exception(Exception)] ...; | cflow.cs:202:9:204:9 | [finally: exception(Exception)] {...} |
+| post | cflow.cs:203:13:203:41 | [finally: exception(IOException)] ...; | cflow.cs:202:9:204:9 | [finally: exception(IOException)] {...} |
+| post | cflow.cs:203:13:203:41 | [finally: exception(OutOfMemoryException)] ...; | cflow.cs:202:9:204:9 | [finally: exception(OutOfMemoryException)] {...} |
+| post | cflow.cs:203:13:203:41 | [finally: return] ...; | cflow.cs:202:9:204:9 | [finally: return] {...} |
 | post | cflow.cs:203:31:203:39 | "Finally" | cflow.cs:203:13:203:41 | ...; |
-| post | cflow.cs:203:31:203:39 | [exception(Exception)] "Finally" | cflow.cs:203:13:203:41 | [exception(Exception)] ...; |
-| post | cflow.cs:203:31:203:39 | [exception(IOException)] "Finally" | cflow.cs:203:13:203:41 | [exception(IOException)] ...; |
-| post | cflow.cs:203:31:203:39 | [exception(OutOfMemoryException)] "Finally" | cflow.cs:203:13:203:41 | [exception(OutOfMemoryException)] ...; |
-| post | cflow.cs:203:31:203:39 | [return] "Finally" | cflow.cs:203:13:203:41 | [return] ...; |
+| post | cflow.cs:203:31:203:39 | [finally: exception(Exception)] "Finally" | cflow.cs:203:13:203:41 | [finally: exception(Exception)] ...; |
+| post | cflow.cs:203:31:203:39 | [finally: exception(IOException)] "Finally" | cflow.cs:203:13:203:41 | [finally: exception(IOException)] ...; |
+| post | cflow.cs:203:31:203:39 | [finally: exception(OutOfMemoryException)] "Finally" | cflow.cs:203:13:203:41 | [finally: exception(OutOfMemoryException)] ...; |
+| post | cflow.cs:203:31:203:39 | [finally: return] "Finally" | cflow.cs:203:13:203:41 | [finally: return] ...; |
 | post | cflow.cs:206:9:206:19 | ... ...; | cflow.cs:203:13:203:40 | call to method WriteLine |
 | post | cflow.cs:206:13:206:13 | access to local variable i | cflow.cs:206:9:206:19 | ... ...; |
 | post | cflow.cs:206:13:206:18 | Int32 i = ... | cflow.cs:206:17:206:18 | 10 |
@@ -1176,7 +1180,7 @@
 | post | cflow.cs:207:9:230:9 | while (...) ... | cflow.cs:206:13:206:18 | Int32 i = ... |
 | post | cflow.cs:207:16:207:16 | access to local variable i | cflow.cs:207:9:230:9 | while (...) ... |
 | post | cflow.cs:207:16:207:16 | access to local variable i | cflow.cs:227:21:227:23 | ...-- |
-| post | cflow.cs:207:16:207:16 | access to local variable i | cflow.cs:227:21:227:23 | [continue] ...-- |
+| post | cflow.cs:207:16:207:16 | access to local variable i | cflow.cs:227:21:227:23 | [finally: continue] ...-- |
 | post | cflow.cs:207:16:207:20 | ... > ... | cflow.cs:207:20:207:20 | 0 |
 | post | cflow.cs:207:20:207:20 | 0 | cflow.cs:207:16:207:16 | access to local variable i |
 | post | cflow.cs:209:13:229:13 | try {...} ... | cflow.cs:208:9:230:9 | {...} |
@@ -1191,57 +1195,57 @@
 | post | cflow.cs:215:21:215:21 | access to local variable i | cflow.cs:215:17:216:26 | if (...) ... |
 | post | cflow.cs:215:21:215:26 | ... == ... | cflow.cs:215:26:215:26 | 2 |
 | post | cflow.cs:215:26:215:26 | 2 | cflow.cs:215:21:215:21 | access to local variable i |
-| post | cflow.cs:219:13:229:13 | [break] {...} | cflow.cs:216:21:216:26 | break; |
-| post | cflow.cs:219:13:229:13 | [continue] {...} | cflow.cs:214:21:214:29 | continue; |
-| post | cflow.cs:219:13:229:13 | [return] {...} | cflow.cs:212:21:212:27 | return ...; |
-| post | cflow.cs:220:17:228:17 | [break] try {...} ... | cflow.cs:219:13:229:13 | [break] {...} |
-| post | cflow.cs:220:17:228:17 | [continue] try {...} ... | cflow.cs:219:13:229:13 | [continue] {...} |
-| post | cflow.cs:220:17:228:17 | [return] try {...} ... | cflow.cs:219:13:229:13 | [return] {...} |
+| post | cflow.cs:219:13:229:13 | [finally: break] {...} | cflow.cs:216:21:216:26 | break; |
+| post | cflow.cs:219:13:229:13 | [finally: continue] {...} | cflow.cs:214:21:214:29 | continue; |
+| post | cflow.cs:219:13:229:13 | [finally: return] {...} | cflow.cs:212:21:212:27 | return ...; |
+| post | cflow.cs:220:17:228:17 | [finally: break] try {...} ... | cflow.cs:219:13:229:13 | [finally: break] {...} |
+| post | cflow.cs:220:17:228:17 | [finally: continue] try {...} ... | cflow.cs:219:13:229:13 | [finally: continue] {...} |
+| post | cflow.cs:220:17:228:17 | [finally: return] try {...} ... | cflow.cs:219:13:229:13 | [finally: return] {...} |
 | post | cflow.cs:220:17:228:17 | try {...} ... | cflow.cs:219:13:229:13 | {...} |
-| post | cflow.cs:221:17:224:17 | [break] {...} | cflow.cs:220:17:228:17 | [break] try {...} ... |
-| post | cflow.cs:221:17:224:17 | [continue] {...} | cflow.cs:220:17:228:17 | [continue] try {...} ... |
-| post | cflow.cs:221:17:224:17 | [return] {...} | cflow.cs:220:17:228:17 | [return] try {...} ... |
+| post | cflow.cs:221:17:224:17 | [finally: break] {...} | cflow.cs:220:17:228:17 | [finally: break] try {...} ... |
+| post | cflow.cs:221:17:224:17 | [finally: continue] {...} | cflow.cs:220:17:228:17 | [finally: continue] try {...} ... |
+| post | cflow.cs:221:17:224:17 | [finally: return] {...} | cflow.cs:220:17:228:17 | [finally: return] try {...} ... |
 | post | cflow.cs:221:17:224:17 | {...} | cflow.cs:220:17:228:17 | try {...} ... |
-| post | cflow.cs:222:21:223:46 | [break] if (...) ... | cflow.cs:221:17:224:17 | [break] {...} |
-| post | cflow.cs:222:21:223:46 | [continue] if (...) ... | cflow.cs:221:17:224:17 | [continue] {...} |
-| post | cflow.cs:222:21:223:46 | [return] if (...) ... | cflow.cs:221:17:224:17 | [return] {...} |
+| post | cflow.cs:222:21:223:46 | [finally: break] if (...) ... | cflow.cs:221:17:224:17 | [finally: break] {...} |
+| post | cflow.cs:222:21:223:46 | [finally: continue] if (...) ... | cflow.cs:221:17:224:17 | [finally: continue] {...} |
+| post | cflow.cs:222:21:223:46 | [finally: return] if (...) ... | cflow.cs:221:17:224:17 | [finally: return] {...} |
 | post | cflow.cs:222:21:223:46 | if (...) ... | cflow.cs:221:17:224:17 | {...} |
-| post | cflow.cs:222:25:222:25 | [break] access to local variable i | cflow.cs:222:21:223:46 | [break] if (...) ... |
-| post | cflow.cs:222:25:222:25 | [continue] access to local variable i | cflow.cs:222:21:223:46 | [continue] if (...) ... |
-| post | cflow.cs:222:25:222:25 | [return] access to local variable i | cflow.cs:222:21:223:46 | [return] if (...) ... |
+| post | cflow.cs:222:25:222:25 | [finally: break] access to local variable i | cflow.cs:222:21:223:46 | [finally: break] if (...) ... |
+| post | cflow.cs:222:25:222:25 | [finally: continue] access to local variable i | cflow.cs:222:21:223:46 | [finally: continue] if (...) ... |
+| post | cflow.cs:222:25:222:25 | [finally: return] access to local variable i | cflow.cs:222:21:223:46 | [finally: return] if (...) ... |
 | post | cflow.cs:222:25:222:25 | access to local variable i | cflow.cs:222:21:223:46 | if (...) ... |
 | post | cflow.cs:222:25:222:30 | ... == ... | cflow.cs:222:30:222:30 | 3 |
-| post | cflow.cs:222:25:222:30 | [break] ... == ... | cflow.cs:222:30:222:30 | [break] 3 |
-| post | cflow.cs:222:25:222:30 | [continue] ... == ... | cflow.cs:222:30:222:30 | [continue] 3 |
-| post | cflow.cs:222:25:222:30 | [return] ... == ... | cflow.cs:222:30:222:30 | [return] 3 |
+| post | cflow.cs:222:25:222:30 | [finally: break] ... == ... | cflow.cs:222:30:222:30 | [finally: break] 3 |
+| post | cflow.cs:222:25:222:30 | [finally: continue] ... == ... | cflow.cs:222:30:222:30 | [finally: continue] 3 |
+| post | cflow.cs:222:25:222:30 | [finally: return] ... == ... | cflow.cs:222:30:222:30 | [finally: return] 3 |
 | post | cflow.cs:222:30:222:30 | 3 | cflow.cs:222:25:222:25 | access to local variable i |
-| post | cflow.cs:222:30:222:30 | [break] 3 | cflow.cs:222:25:222:25 | [break] access to local variable i |
-| post | cflow.cs:222:30:222:30 | [continue] 3 | cflow.cs:222:25:222:25 | [continue] access to local variable i |
-| post | cflow.cs:222:30:222:30 | [return] 3 | cflow.cs:222:25:222:25 | [return] access to local variable i |
-| post | cflow.cs:226:17:228:17 | [exception(Exception)] {...} | cflow.cs:223:25:223:46 | [break] throw ...; |
-| post | cflow.cs:226:17:228:17 | [exception(Exception)] {...} | cflow.cs:223:25:223:46 | [continue] throw ...; |
-| post | cflow.cs:226:17:228:17 | [exception(Exception)] {...} | cflow.cs:223:25:223:46 | [return] throw ...; |
-| post | cflow.cs:226:17:228:17 | [exception(Exception)] {...} | cflow.cs:223:25:223:46 | throw ...; |
-| post | cflow.cs:226:17:228:17 | [exception(Exception)] {...} | cflow.cs:223:31:223:45 | [break] object creation of type Exception |
-| post | cflow.cs:226:17:228:17 | [exception(Exception)] {...} | cflow.cs:223:31:223:45 | [continue] object creation of type Exception |
-| post | cflow.cs:226:17:228:17 | [exception(Exception)] {...} | cflow.cs:223:31:223:45 | [return] object creation of type Exception |
-| post | cflow.cs:226:17:228:17 | [exception(Exception)] {...} | cflow.cs:223:31:223:45 | object creation of type Exception |
-| post | cflow.cs:227:21:227:21 | [break] access to local variable i | cflow.cs:227:21:227:24 | [break] ...; |
-| post | cflow.cs:227:21:227:21 | [continue] access to local variable i | cflow.cs:227:21:227:24 | [continue] ...; |
-| post | cflow.cs:227:21:227:21 | [exception(Exception)] access to local variable i | cflow.cs:227:21:227:24 | [exception(Exception)] ...; |
-| post | cflow.cs:227:21:227:21 | [return] access to local variable i | cflow.cs:227:21:227:24 | [return] ...; |
+| post | cflow.cs:222:30:222:30 | [finally: break] 3 | cflow.cs:222:25:222:25 | [finally: break] access to local variable i |
+| post | cflow.cs:222:30:222:30 | [finally: continue] 3 | cflow.cs:222:25:222:25 | [finally: continue] access to local variable i |
+| post | cflow.cs:222:30:222:30 | [finally: return] 3 | cflow.cs:222:25:222:25 | [finally: return] access to local variable i |
+| post | cflow.cs:226:17:228:17 | [finally: exception(Exception)] {...} | cflow.cs:223:25:223:46 | [finally: break] throw ...; |
+| post | cflow.cs:226:17:228:17 | [finally: exception(Exception)] {...} | cflow.cs:223:25:223:46 | [finally: continue] throw ...; |
+| post | cflow.cs:226:17:228:17 | [finally: exception(Exception)] {...} | cflow.cs:223:25:223:46 | [finally: return] throw ...; |
+| post | cflow.cs:226:17:228:17 | [finally: exception(Exception)] {...} | cflow.cs:223:25:223:46 | throw ...; |
+| post | cflow.cs:226:17:228:17 | [finally: exception(Exception)] {...} | cflow.cs:223:31:223:45 | [finally: break] object creation of type Exception |
+| post | cflow.cs:226:17:228:17 | [finally: exception(Exception)] {...} | cflow.cs:223:31:223:45 | [finally: continue] object creation of type Exception |
+| post | cflow.cs:226:17:228:17 | [finally: exception(Exception)] {...} | cflow.cs:223:31:223:45 | [finally: return] object creation of type Exception |
+| post | cflow.cs:226:17:228:17 | [finally: exception(Exception)] {...} | cflow.cs:223:31:223:45 | object creation of type Exception |
+| post | cflow.cs:227:21:227:21 | [finally: break] access to local variable i | cflow.cs:227:21:227:24 | [finally: break] ...; |
+| post | cflow.cs:227:21:227:21 | [finally: continue] access to local variable i | cflow.cs:227:21:227:24 | [finally: continue] ...; |
+| post | cflow.cs:227:21:227:21 | [finally: exception(Exception)] access to local variable i | cflow.cs:227:21:227:24 | [finally: exception(Exception)] ...; |
+| post | cflow.cs:227:21:227:21 | [finally: return] access to local variable i | cflow.cs:227:21:227:24 | [finally: return] ...; |
 | post | cflow.cs:227:21:227:21 | access to local variable i | cflow.cs:227:21:227:24 | ...; |
 | post | cflow.cs:227:21:227:23 | ...-- | cflow.cs:227:21:227:21 | access to local variable i |
-| post | cflow.cs:227:21:227:23 | [break] ...-- | cflow.cs:227:21:227:21 | [break] access to local variable i |
-| post | cflow.cs:227:21:227:23 | [continue] ...-- | cflow.cs:227:21:227:21 | [continue] access to local variable i |
-| post | cflow.cs:227:21:227:23 | [exception(Exception)] ...-- | cflow.cs:227:21:227:21 | [exception(Exception)] access to local variable i |
-| post | cflow.cs:227:21:227:23 | [return] ...-- | cflow.cs:227:21:227:21 | [return] access to local variable i |
+| post | cflow.cs:227:21:227:23 | [finally: break] ...-- | cflow.cs:227:21:227:21 | [finally: break] access to local variable i |
+| post | cflow.cs:227:21:227:23 | [finally: continue] ...-- | cflow.cs:227:21:227:21 | [finally: continue] access to local variable i |
+| post | cflow.cs:227:21:227:23 | [finally: exception(Exception)] ...-- | cflow.cs:227:21:227:21 | [finally: exception(Exception)] access to local variable i |
+| post | cflow.cs:227:21:227:23 | [finally: return] ...-- | cflow.cs:227:21:227:21 | [finally: return] access to local variable i |
 | post | cflow.cs:227:21:227:24 | ...; | cflow.cs:226:17:228:17 | {...} |
-| post | cflow.cs:227:21:227:24 | [break] ...; | cflow.cs:226:17:228:17 | [break] {...} |
-| post | cflow.cs:227:21:227:24 | [continue] ...; | cflow.cs:226:17:228:17 | [continue] {...} |
-| post | cflow.cs:227:21:227:24 | [exception(Exception)] ...; | cflow.cs:226:17:228:17 | [exception(Exception)] {...} |
-| post | cflow.cs:227:21:227:24 | [return] ...; | cflow.cs:226:17:228:17 | [return] {...} |
-| post | cflow.cs:232:9:245:9 | try {...} ... | cflow.cs:227:21:227:23 | [break] ...-- |
+| post | cflow.cs:227:21:227:24 | [finally: break] ...; | cflow.cs:226:17:228:17 | [finally: break] {...} |
+| post | cflow.cs:227:21:227:24 | [finally: continue] ...; | cflow.cs:226:17:228:17 | [finally: continue] {...} |
+| post | cflow.cs:227:21:227:24 | [finally: exception(Exception)] ...; | cflow.cs:226:17:228:17 | [finally: exception(Exception)] {...} |
+| post | cflow.cs:227:21:227:24 | [finally: return] ...; | cflow.cs:226:17:228:17 | [finally: return] {...} |
+| post | cflow.cs:232:9:245:9 | try {...} ... | cflow.cs:227:21:227:23 | [finally: break] ...-- |
 | post | cflow.cs:233:9:238:9 | {...} | cflow.cs:232:9:245:9 | try {...} ... |
 | post | cflow.cs:234:13:235:23 | if (...) ... | cflow.cs:233:9:238:9 | {...} |
 | post | cflow.cs:234:17:234:21 | access to field Field | cflow.cs:234:17:234:21 | this access |
@@ -1250,103 +1254,103 @@
 | post | cflow.cs:236:17:236:21 | access to field Field | cflow.cs:236:17:236:21 | this access |
 | post | cflow.cs:236:17:236:21 | this access | cflow.cs:236:13:237:49 | if (...) ... |
 | post | cflow.cs:236:17:236:33 | ... == ... | cflow.cs:236:33:236:33 | 1 |
-| post | cflow.cs:240:9:245:9 | [exception(OutOfMemoryException)] {...} | cflow.cs:237:17:237:49 | throw ...; |
-| post | cflow.cs:240:9:245:9 | [return] {...} | cflow.cs:235:17:235:23 | return ...; |
-| post | cflow.cs:241:13:242:41 | [exception(Exception)] if (...) ... | cflow.cs:240:9:245:9 | [exception(Exception)] {...} |
-| post | cflow.cs:241:13:242:41 | [exception(NullReferenceException)] if (...) ... | cflow.cs:240:9:245:9 | [exception(NullReferenceException)] {...} |
-| post | cflow.cs:241:13:242:41 | [exception(OutOfMemoryException)] if (...) ... | cflow.cs:240:9:245:9 | [exception(OutOfMemoryException)] {...} |
-| post | cflow.cs:241:13:242:41 | [return] if (...) ... | cflow.cs:240:9:245:9 | [return] {...} |
+| post | cflow.cs:240:9:245:9 | [finally: exception(OutOfMemoryException)] {...} | cflow.cs:237:17:237:49 | throw ...; |
+| post | cflow.cs:240:9:245:9 | [finally: return] {...} | cflow.cs:235:17:235:23 | return ...; |
+| post | cflow.cs:241:13:242:41 | [finally: exception(Exception)] if (...) ... | cflow.cs:240:9:245:9 | [finally: exception(Exception)] {...} |
+| post | cflow.cs:241:13:242:41 | [finally: exception(NullReferenceException)] if (...) ... | cflow.cs:240:9:245:9 | [finally: exception(NullReferenceException)] {...} |
+| post | cflow.cs:241:13:242:41 | [finally: exception(OutOfMemoryException)] if (...) ... | cflow.cs:240:9:245:9 | [finally: exception(OutOfMemoryException)] {...} |
+| post | cflow.cs:241:13:242:41 | [finally: return] if (...) ... | cflow.cs:240:9:245:9 | [finally: return] {...} |
 | post | cflow.cs:241:13:242:41 | if (...) ... | cflow.cs:240:9:245:9 | {...} |
 | post | cflow.cs:241:17:241:36 | !... | cflow.cs:241:13:242:41 | if (...) ... |
-| post | cflow.cs:241:17:241:36 | [exception(Exception)] !... | cflow.cs:241:13:242:41 | [exception(Exception)] if (...) ... |
-| post | cflow.cs:241:17:241:36 | [exception(NullReferenceException)] !... | cflow.cs:241:13:242:41 | [exception(NullReferenceException)] if (...) ... |
-| post | cflow.cs:241:17:241:36 | [exception(OutOfMemoryException)] !... | cflow.cs:241:13:242:41 | [exception(OutOfMemoryException)] if (...) ... |
-| post | cflow.cs:241:17:241:36 | [return] !... | cflow.cs:241:13:242:41 | [return] if (...) ... |
-| post | cflow.cs:241:19:241:23 | [exception(Exception)] access to field Field | cflow.cs:241:19:241:23 | [exception(Exception)] this access |
-| post | cflow.cs:241:19:241:23 | [exception(Exception)] this access | cflow.cs:241:17:241:36 | [exception(Exception)] !... |
-| post | cflow.cs:241:19:241:23 | [exception(NullReferenceException)] access to field Field | cflow.cs:241:19:241:23 | [exception(NullReferenceException)] this access |
-| post | cflow.cs:241:19:241:23 | [exception(NullReferenceException)] this access | cflow.cs:241:17:241:36 | [exception(NullReferenceException)] !... |
-| post | cflow.cs:241:19:241:23 | [exception(OutOfMemoryException)] access to field Field | cflow.cs:241:19:241:23 | [exception(OutOfMemoryException)] this access |
-| post | cflow.cs:241:19:241:23 | [exception(OutOfMemoryException)] this access | cflow.cs:241:17:241:36 | [exception(OutOfMemoryException)] !... |
-| post | cflow.cs:241:19:241:23 | [return] access to field Field | cflow.cs:241:19:241:23 | [return] this access |
-| post | cflow.cs:241:19:241:23 | [return] this access | cflow.cs:241:17:241:36 | [return] !... |
+| post | cflow.cs:241:17:241:36 | [finally: exception(Exception)] !... | cflow.cs:241:13:242:41 | [finally: exception(Exception)] if (...) ... |
+| post | cflow.cs:241:17:241:36 | [finally: exception(NullReferenceException)] !... | cflow.cs:241:13:242:41 | [finally: exception(NullReferenceException)] if (...) ... |
+| post | cflow.cs:241:17:241:36 | [finally: exception(OutOfMemoryException)] !... | cflow.cs:241:13:242:41 | [finally: exception(OutOfMemoryException)] if (...) ... |
+| post | cflow.cs:241:17:241:36 | [finally: return] !... | cflow.cs:241:13:242:41 | [finally: return] if (...) ... |
+| post | cflow.cs:241:19:241:23 | [finally: exception(Exception)] access to field Field | cflow.cs:241:19:241:23 | [finally: exception(Exception)] this access |
+| post | cflow.cs:241:19:241:23 | [finally: exception(Exception)] this access | cflow.cs:241:17:241:36 | [finally: exception(Exception)] !... |
+| post | cflow.cs:241:19:241:23 | [finally: exception(NullReferenceException)] access to field Field | cflow.cs:241:19:241:23 | [finally: exception(NullReferenceException)] this access |
+| post | cflow.cs:241:19:241:23 | [finally: exception(NullReferenceException)] this access | cflow.cs:241:17:241:36 | [finally: exception(NullReferenceException)] !... |
+| post | cflow.cs:241:19:241:23 | [finally: exception(OutOfMemoryException)] access to field Field | cflow.cs:241:19:241:23 | [finally: exception(OutOfMemoryException)] this access |
+| post | cflow.cs:241:19:241:23 | [finally: exception(OutOfMemoryException)] this access | cflow.cs:241:17:241:36 | [finally: exception(OutOfMemoryException)] !... |
+| post | cflow.cs:241:19:241:23 | [finally: return] access to field Field | cflow.cs:241:19:241:23 | [finally: return] this access |
+| post | cflow.cs:241:19:241:23 | [finally: return] this access | cflow.cs:241:17:241:36 | [finally: return] !... |
 | post | cflow.cs:241:19:241:23 | access to field Field | cflow.cs:241:19:241:23 | this access |
 | post | cflow.cs:241:19:241:23 | this access | cflow.cs:241:17:241:36 | !... |
-| post | cflow.cs:241:19:241:30 | [exception(Exception)] access to property Length | cflow.cs:241:19:241:23 | [exception(Exception)] access to field Field |
-| post | cflow.cs:241:19:241:30 | [exception(NullReferenceException)] access to property Length | cflow.cs:241:19:241:23 | [exception(NullReferenceException)] access to field Field |
-| post | cflow.cs:241:19:241:30 | [exception(OutOfMemoryException)] access to property Length | cflow.cs:241:19:241:23 | [exception(OutOfMemoryException)] access to field Field |
-| post | cflow.cs:241:19:241:30 | [return] access to property Length | cflow.cs:241:19:241:23 | [return] access to field Field |
+| post | cflow.cs:241:19:241:30 | [finally: exception(Exception)] access to property Length | cflow.cs:241:19:241:23 | [finally: exception(Exception)] access to field Field |
+| post | cflow.cs:241:19:241:30 | [finally: exception(NullReferenceException)] access to property Length | cflow.cs:241:19:241:23 | [finally: exception(NullReferenceException)] access to field Field |
+| post | cflow.cs:241:19:241:30 | [finally: exception(OutOfMemoryException)] access to property Length | cflow.cs:241:19:241:23 | [finally: exception(OutOfMemoryException)] access to field Field |
+| post | cflow.cs:241:19:241:30 | [finally: return] access to property Length | cflow.cs:241:19:241:23 | [finally: return] access to field Field |
 | post | cflow.cs:241:19:241:30 | access to property Length | cflow.cs:241:19:241:23 | access to field Field |
 | post | cflow.cs:241:19:241:35 | ... == ... | cflow.cs:241:35:241:35 | 0 |
-| post | cflow.cs:241:19:241:35 | [exception(Exception)] ... == ... | cflow.cs:241:35:241:35 | [exception(Exception)] 0 |
-| post | cflow.cs:241:19:241:35 | [exception(NullReferenceException)] ... == ... | cflow.cs:241:35:241:35 | [exception(NullReferenceException)] 0 |
-| post | cflow.cs:241:19:241:35 | [exception(OutOfMemoryException)] ... == ... | cflow.cs:241:35:241:35 | [exception(OutOfMemoryException)] 0 |
-| post | cflow.cs:241:19:241:35 | [return] ... == ... | cflow.cs:241:35:241:35 | [return] 0 |
+| post | cflow.cs:241:19:241:35 | [finally: exception(Exception)] ... == ... | cflow.cs:241:35:241:35 | [finally: exception(Exception)] 0 |
+| post | cflow.cs:241:19:241:35 | [finally: exception(NullReferenceException)] ... == ... | cflow.cs:241:35:241:35 | [finally: exception(NullReferenceException)] 0 |
+| post | cflow.cs:241:19:241:35 | [finally: exception(OutOfMemoryException)] ... == ... | cflow.cs:241:35:241:35 | [finally: exception(OutOfMemoryException)] 0 |
+| post | cflow.cs:241:19:241:35 | [finally: return] ... == ... | cflow.cs:241:35:241:35 | [finally: return] 0 |
 | post | cflow.cs:241:35:241:35 | 0 | cflow.cs:241:19:241:30 | access to property Length |
-| post | cflow.cs:241:35:241:35 | [exception(Exception)] 0 | cflow.cs:241:19:241:30 | [exception(Exception)] access to property Length |
-| post | cflow.cs:241:35:241:35 | [exception(NullReferenceException)] 0 | cflow.cs:241:19:241:30 | [exception(NullReferenceException)] access to property Length |
-| post | cflow.cs:241:35:241:35 | [exception(OutOfMemoryException)] 0 | cflow.cs:241:19:241:30 | [exception(OutOfMemoryException)] access to property Length |
-| post | cflow.cs:241:35:241:35 | [return] 0 | cflow.cs:241:19:241:30 | [return] access to property Length |
-| post | cflow.cs:242:17:242:40 | [exception(Exception)] call to method WriteLine | cflow.cs:242:35:242:39 | [exception(Exception)] access to field Field |
-| post | cflow.cs:242:17:242:40 | [exception(NullReferenceException)] call to method WriteLine | cflow.cs:242:35:242:39 | [exception(NullReferenceException)] access to field Field |
-| post | cflow.cs:242:17:242:40 | [exception(OutOfMemoryException)] call to method WriteLine | cflow.cs:242:35:242:39 | [exception(OutOfMemoryException)] access to field Field |
-| post | cflow.cs:242:17:242:40 | [return] call to method WriteLine | cflow.cs:242:35:242:39 | [return] access to field Field |
+| post | cflow.cs:241:35:241:35 | [finally: exception(Exception)] 0 | cflow.cs:241:19:241:30 | [finally: exception(Exception)] access to property Length |
+| post | cflow.cs:241:35:241:35 | [finally: exception(NullReferenceException)] 0 | cflow.cs:241:19:241:30 | [finally: exception(NullReferenceException)] access to property Length |
+| post | cflow.cs:241:35:241:35 | [finally: exception(OutOfMemoryException)] 0 | cflow.cs:241:19:241:30 | [finally: exception(OutOfMemoryException)] access to property Length |
+| post | cflow.cs:241:35:241:35 | [finally: return] 0 | cflow.cs:241:19:241:30 | [finally: return] access to property Length |
+| post | cflow.cs:242:17:242:40 | [finally: exception(Exception)] call to method WriteLine | cflow.cs:242:35:242:39 | [finally: exception(Exception)] access to field Field |
+| post | cflow.cs:242:17:242:40 | [finally: exception(NullReferenceException)] call to method WriteLine | cflow.cs:242:35:242:39 | [finally: exception(NullReferenceException)] access to field Field |
+| post | cflow.cs:242:17:242:40 | [finally: exception(OutOfMemoryException)] call to method WriteLine | cflow.cs:242:35:242:39 | [finally: exception(OutOfMemoryException)] access to field Field |
+| post | cflow.cs:242:17:242:40 | [finally: return] call to method WriteLine | cflow.cs:242:35:242:39 | [finally: return] access to field Field |
 | post | cflow.cs:242:17:242:40 | call to method WriteLine | cflow.cs:242:35:242:39 | access to field Field |
-| post | cflow.cs:242:35:242:39 | [exception(Exception)] access to field Field | cflow.cs:242:35:242:39 | [exception(Exception)] this access |
-| post | cflow.cs:242:35:242:39 | [exception(Exception)] this access | cflow.cs:242:17:242:41 | [exception(Exception)] ...; |
-| post | cflow.cs:242:35:242:39 | [exception(NullReferenceException)] access to field Field | cflow.cs:242:35:242:39 | [exception(NullReferenceException)] this access |
-| post | cflow.cs:242:35:242:39 | [exception(NullReferenceException)] this access | cflow.cs:242:17:242:41 | [exception(NullReferenceException)] ...; |
-| post | cflow.cs:242:35:242:39 | [exception(OutOfMemoryException)] access to field Field | cflow.cs:242:35:242:39 | [exception(OutOfMemoryException)] this access |
-| post | cflow.cs:242:35:242:39 | [exception(OutOfMemoryException)] this access | cflow.cs:242:17:242:41 | [exception(OutOfMemoryException)] ...; |
-| post | cflow.cs:242:35:242:39 | [return] access to field Field | cflow.cs:242:35:242:39 | [return] this access |
-| post | cflow.cs:242:35:242:39 | [return] this access | cflow.cs:242:17:242:41 | [return] ...; |
+| post | cflow.cs:242:35:242:39 | [finally: exception(Exception)] access to field Field | cflow.cs:242:35:242:39 | [finally: exception(Exception)] this access |
+| post | cflow.cs:242:35:242:39 | [finally: exception(Exception)] this access | cflow.cs:242:17:242:41 | [finally: exception(Exception)] ...; |
+| post | cflow.cs:242:35:242:39 | [finally: exception(NullReferenceException)] access to field Field | cflow.cs:242:35:242:39 | [finally: exception(NullReferenceException)] this access |
+| post | cflow.cs:242:35:242:39 | [finally: exception(NullReferenceException)] this access | cflow.cs:242:17:242:41 | [finally: exception(NullReferenceException)] ...; |
+| post | cflow.cs:242:35:242:39 | [finally: exception(OutOfMemoryException)] access to field Field | cflow.cs:242:35:242:39 | [finally: exception(OutOfMemoryException)] this access |
+| post | cflow.cs:242:35:242:39 | [finally: exception(OutOfMemoryException)] this access | cflow.cs:242:17:242:41 | [finally: exception(OutOfMemoryException)] ...; |
+| post | cflow.cs:242:35:242:39 | [finally: return] access to field Field | cflow.cs:242:35:242:39 | [finally: return] this access |
+| post | cflow.cs:242:35:242:39 | [finally: return] this access | cflow.cs:242:17:242:41 | [finally: return] ...; |
 | post | cflow.cs:242:35:242:39 | access to field Field | cflow.cs:242:35:242:39 | this access |
 | post | cflow.cs:242:35:242:39 | this access | cflow.cs:242:17:242:41 | ...; |
-| post | cflow.cs:243:13:244:37 | [exception(Exception)] if (...) ... | cflow.cs:241:19:241:35 | [exception(Exception)] ... == ... |
-| post | cflow.cs:243:13:244:37 | [exception(Exception)] if (...) ... | cflow.cs:242:17:242:40 | [exception(Exception)] call to method WriteLine |
-| post | cflow.cs:243:13:244:37 | [exception(NullReferenceException)] if (...) ... | cflow.cs:241:19:241:35 | [exception(NullReferenceException)] ... == ... |
-| post | cflow.cs:243:13:244:37 | [exception(NullReferenceException)] if (...) ... | cflow.cs:242:17:242:40 | [exception(NullReferenceException)] call to method WriteLine |
-| post | cflow.cs:243:13:244:37 | [exception(OutOfMemoryException)] if (...) ... | cflow.cs:241:19:241:35 | [exception(OutOfMemoryException)] ... == ... |
-| post | cflow.cs:243:13:244:37 | [exception(OutOfMemoryException)] if (...) ... | cflow.cs:242:17:242:40 | [exception(OutOfMemoryException)] call to method WriteLine |
-| post | cflow.cs:243:13:244:37 | [return] if (...) ... | cflow.cs:241:19:241:35 | [return] ... == ... |
-| post | cflow.cs:243:13:244:37 | [return] if (...) ... | cflow.cs:242:17:242:40 | [return] call to method WriteLine |
+| post | cflow.cs:243:13:244:37 | [finally: exception(Exception)] if (...) ... | cflow.cs:241:19:241:35 | [finally: exception(Exception)] ... == ... |
+| post | cflow.cs:243:13:244:37 | [finally: exception(Exception)] if (...) ... | cflow.cs:242:17:242:40 | [finally: exception(Exception)] call to method WriteLine |
+| post | cflow.cs:243:13:244:37 | [finally: exception(NullReferenceException)] if (...) ... | cflow.cs:241:19:241:35 | [finally: exception(NullReferenceException)] ... == ... |
+| post | cflow.cs:243:13:244:37 | [finally: exception(NullReferenceException)] if (...) ... | cflow.cs:242:17:242:40 | [finally: exception(NullReferenceException)] call to method WriteLine |
+| post | cflow.cs:243:13:244:37 | [finally: exception(OutOfMemoryException)] if (...) ... | cflow.cs:241:19:241:35 | [finally: exception(OutOfMemoryException)] ... == ... |
+| post | cflow.cs:243:13:244:37 | [finally: exception(OutOfMemoryException)] if (...) ... | cflow.cs:242:17:242:40 | [finally: exception(OutOfMemoryException)] call to method WriteLine |
+| post | cflow.cs:243:13:244:37 | [finally: return] if (...) ... | cflow.cs:241:19:241:35 | [finally: return] ... == ... |
+| post | cflow.cs:243:13:244:37 | [finally: return] if (...) ... | cflow.cs:242:17:242:40 | [finally: return] call to method WriteLine |
 | post | cflow.cs:243:13:244:37 | if (...) ... | cflow.cs:241:19:241:35 | ... == ... |
 | post | cflow.cs:243:13:244:37 | if (...) ... | cflow.cs:242:17:242:40 | call to method WriteLine |
-| post | cflow.cs:243:17:243:21 | [exception(Exception)] access to field Field | cflow.cs:243:17:243:21 | [exception(Exception)] this access |
-| post | cflow.cs:243:17:243:21 | [exception(Exception)] this access | cflow.cs:243:13:244:37 | [exception(Exception)] if (...) ... |
-| post | cflow.cs:243:17:243:21 | [exception(NullReferenceException)] access to field Field | cflow.cs:243:17:243:21 | [exception(NullReferenceException)] this access |
-| post | cflow.cs:243:17:243:21 | [exception(NullReferenceException)] this access | cflow.cs:243:13:244:37 | [exception(NullReferenceException)] if (...) ... |
-| post | cflow.cs:243:17:243:21 | [exception(OutOfMemoryException)] access to field Field | cflow.cs:243:17:243:21 | [exception(OutOfMemoryException)] this access |
-| post | cflow.cs:243:17:243:21 | [exception(OutOfMemoryException)] this access | cflow.cs:243:13:244:37 | [exception(OutOfMemoryException)] if (...) ... |
-| post | cflow.cs:243:17:243:21 | [return] access to field Field | cflow.cs:243:17:243:21 | [return] this access |
-| post | cflow.cs:243:17:243:21 | [return] this access | cflow.cs:243:13:244:37 | [return] if (...) ... |
+| post | cflow.cs:243:17:243:21 | [finally: exception(Exception)] access to field Field | cflow.cs:243:17:243:21 | [finally: exception(Exception)] this access |
+| post | cflow.cs:243:17:243:21 | [finally: exception(Exception)] this access | cflow.cs:243:13:244:37 | [finally: exception(Exception)] if (...) ... |
+| post | cflow.cs:243:17:243:21 | [finally: exception(NullReferenceException)] access to field Field | cflow.cs:243:17:243:21 | [finally: exception(NullReferenceException)] this access |
+| post | cflow.cs:243:17:243:21 | [finally: exception(NullReferenceException)] this access | cflow.cs:243:13:244:37 | [finally: exception(NullReferenceException)] if (...) ... |
+| post | cflow.cs:243:17:243:21 | [finally: exception(OutOfMemoryException)] access to field Field | cflow.cs:243:17:243:21 | [finally: exception(OutOfMemoryException)] this access |
+| post | cflow.cs:243:17:243:21 | [finally: exception(OutOfMemoryException)] this access | cflow.cs:243:13:244:37 | [finally: exception(OutOfMemoryException)] if (...) ... |
+| post | cflow.cs:243:17:243:21 | [finally: return] access to field Field | cflow.cs:243:17:243:21 | [finally: return] this access |
+| post | cflow.cs:243:17:243:21 | [finally: return] this access | cflow.cs:243:13:244:37 | [finally: return] if (...) ... |
 | post | cflow.cs:243:17:243:21 | access to field Field | cflow.cs:243:17:243:21 | this access |
 | post | cflow.cs:243:17:243:21 | this access | cflow.cs:243:13:244:37 | if (...) ... |
-| post | cflow.cs:243:17:243:28 | [exception(Exception)] access to property Length | cflow.cs:243:17:243:21 | [exception(Exception)] access to field Field |
-| post | cflow.cs:243:17:243:28 | [exception(NullReferenceException)] access to property Length | cflow.cs:243:17:243:21 | [exception(NullReferenceException)] access to field Field |
-| post | cflow.cs:243:17:243:28 | [exception(OutOfMemoryException)] access to property Length | cflow.cs:243:17:243:21 | [exception(OutOfMemoryException)] access to field Field |
-| post | cflow.cs:243:17:243:28 | [return] access to property Length | cflow.cs:243:17:243:21 | [return] access to field Field |
+| post | cflow.cs:243:17:243:28 | [finally: exception(Exception)] access to property Length | cflow.cs:243:17:243:21 | [finally: exception(Exception)] access to field Field |
+| post | cflow.cs:243:17:243:28 | [finally: exception(NullReferenceException)] access to property Length | cflow.cs:243:17:243:21 | [finally: exception(NullReferenceException)] access to field Field |
+| post | cflow.cs:243:17:243:28 | [finally: exception(OutOfMemoryException)] access to property Length | cflow.cs:243:17:243:21 | [finally: exception(OutOfMemoryException)] access to field Field |
+| post | cflow.cs:243:17:243:28 | [finally: return] access to property Length | cflow.cs:243:17:243:21 | [finally: return] access to field Field |
 | post | cflow.cs:243:17:243:28 | access to property Length | cflow.cs:243:17:243:21 | access to field Field |
 | post | cflow.cs:243:17:243:32 | ... > ... | cflow.cs:243:32:243:32 | 0 |
-| post | cflow.cs:243:17:243:32 | [exception(Exception)] ... > ... | cflow.cs:243:32:243:32 | [exception(Exception)] 0 |
-| post | cflow.cs:243:17:243:32 | [exception(NullReferenceException)] ... > ... | cflow.cs:243:32:243:32 | [exception(NullReferenceException)] 0 |
-| post | cflow.cs:243:17:243:32 | [exception(OutOfMemoryException)] ... > ... | cflow.cs:243:32:243:32 | [exception(OutOfMemoryException)] 0 |
-| post | cflow.cs:243:17:243:32 | [return] ... > ... | cflow.cs:243:32:243:32 | [return] 0 |
+| post | cflow.cs:243:17:243:32 | [finally: exception(Exception)] ... > ... | cflow.cs:243:32:243:32 | [finally: exception(Exception)] 0 |
+| post | cflow.cs:243:17:243:32 | [finally: exception(NullReferenceException)] ... > ... | cflow.cs:243:32:243:32 | [finally: exception(NullReferenceException)] 0 |
+| post | cflow.cs:243:17:243:32 | [finally: exception(OutOfMemoryException)] ... > ... | cflow.cs:243:32:243:32 | [finally: exception(OutOfMemoryException)] 0 |
+| post | cflow.cs:243:17:243:32 | [finally: return] ... > ... | cflow.cs:243:32:243:32 | [finally: return] 0 |
 | post | cflow.cs:243:32:243:32 | 0 | cflow.cs:243:17:243:28 | access to property Length |
-| post | cflow.cs:243:32:243:32 | [exception(Exception)] 0 | cflow.cs:243:17:243:28 | [exception(Exception)] access to property Length |
-| post | cflow.cs:243:32:243:32 | [exception(NullReferenceException)] 0 | cflow.cs:243:17:243:28 | [exception(NullReferenceException)] access to property Length |
-| post | cflow.cs:243:32:243:32 | [exception(OutOfMemoryException)] 0 | cflow.cs:243:17:243:28 | [exception(OutOfMemoryException)] access to property Length |
-| post | cflow.cs:243:32:243:32 | [return] 0 | cflow.cs:243:17:243:28 | [return] access to property Length |
-| post | cflow.cs:244:17:244:36 | [exception(Exception)] call to method WriteLine | cflow.cs:244:35:244:35 | [exception(Exception)] 1 |
-| post | cflow.cs:244:17:244:36 | [exception(NullReferenceException)] call to method WriteLine | cflow.cs:244:35:244:35 | [exception(NullReferenceException)] 1 |
-| post | cflow.cs:244:17:244:36 | [exception(OutOfMemoryException)] call to method WriteLine | cflow.cs:244:35:244:35 | [exception(OutOfMemoryException)] 1 |
-| post | cflow.cs:244:17:244:36 | [return] call to method WriteLine | cflow.cs:244:35:244:35 | [return] 1 |
+| post | cflow.cs:243:32:243:32 | [finally: exception(Exception)] 0 | cflow.cs:243:17:243:28 | [finally: exception(Exception)] access to property Length |
+| post | cflow.cs:243:32:243:32 | [finally: exception(NullReferenceException)] 0 | cflow.cs:243:17:243:28 | [finally: exception(NullReferenceException)] access to property Length |
+| post | cflow.cs:243:32:243:32 | [finally: exception(OutOfMemoryException)] 0 | cflow.cs:243:17:243:28 | [finally: exception(OutOfMemoryException)] access to property Length |
+| post | cflow.cs:243:32:243:32 | [finally: return] 0 | cflow.cs:243:17:243:28 | [finally: return] access to property Length |
+| post | cflow.cs:244:17:244:36 | [finally: exception(Exception)] call to method WriteLine | cflow.cs:244:35:244:35 | [finally: exception(Exception)] 1 |
+| post | cflow.cs:244:17:244:36 | [finally: exception(NullReferenceException)] call to method WriteLine | cflow.cs:244:35:244:35 | [finally: exception(NullReferenceException)] 1 |
+| post | cflow.cs:244:17:244:36 | [finally: exception(OutOfMemoryException)] call to method WriteLine | cflow.cs:244:35:244:35 | [finally: exception(OutOfMemoryException)] 1 |
+| post | cflow.cs:244:17:244:36 | [finally: return] call to method WriteLine | cflow.cs:244:35:244:35 | [finally: return] 1 |
 | post | cflow.cs:244:17:244:36 | call to method WriteLine | cflow.cs:244:35:244:35 | 1 |
 | post | cflow.cs:244:35:244:35 | 1 | cflow.cs:244:17:244:37 | ...; |
-| post | cflow.cs:244:35:244:35 | [exception(Exception)] 1 | cflow.cs:244:17:244:37 | [exception(Exception)] ...; |
-| post | cflow.cs:244:35:244:35 | [exception(NullReferenceException)] 1 | cflow.cs:244:17:244:37 | [exception(NullReferenceException)] ...; |
-| post | cflow.cs:244:35:244:35 | [exception(OutOfMemoryException)] 1 | cflow.cs:244:17:244:37 | [exception(OutOfMemoryException)] ...; |
-| post | cflow.cs:244:35:244:35 | [return] 1 | cflow.cs:244:17:244:37 | [return] ...; |
+| post | cflow.cs:244:35:244:35 | [finally: exception(Exception)] 1 | cflow.cs:244:17:244:37 | [finally: exception(Exception)] ...; |
+| post | cflow.cs:244:35:244:35 | [finally: exception(NullReferenceException)] 1 | cflow.cs:244:17:244:37 | [finally: exception(NullReferenceException)] ...; |
+| post | cflow.cs:244:35:244:35 | [finally: exception(OutOfMemoryException)] 1 | cflow.cs:244:17:244:37 | [finally: exception(OutOfMemoryException)] ...; |
+| post | cflow.cs:244:35:244:35 | [finally: return] 1 | cflow.cs:244:17:244:37 | [finally: return] ...; |
 | post | cflow.cs:248:10:248:12 | exit For | cflow.cs:275:32:275:41 | ... < ... |
 | post | cflow.cs:249:5:279:5 | {...} | cflow.cs:248:10:248:12 | enter For |
 | post | cflow.cs:250:9:250:18 | ... ...; | cflow.cs:249:5:279:5 | {...} |
@@ -1614,7 +1618,7 @@
 | post | cflow.cs:358:17:358:37 | ...; | cflow.cs:357:13:357:20 | default: |
 | post | cflow.cs:358:35:358:35 | 0 | cflow.cs:358:17:358:37 | ...; |
 | post | cflow.cs:359:17:359:22 | break; | cflow.cs:358:17:358:36 | call to method WriteLine |
-| post | cflow.cs:363:49:363:53 | exit Yield | cflow.cs:377:13:377:41 | [return] call to method WriteLine |
+| post | cflow.cs:363:49:363:53 | exit Yield | cflow.cs:377:13:377:41 | [finally: return] call to method WriteLine |
 | post | cflow.cs:364:5:379:5 | {...} | cflow.cs:363:49:363:53 | enter Yield |
 | post | cflow.cs:365:9:365:23 | yield return ...; | cflow.cs:365:22:365:22 | 0 |
 | post | cflow.cs:365:22:365:22 | 0 | cflow.cs:364:5:379:5 | {...} |
@@ -1633,10 +1637,10 @@
 | post | cflow.cs:370:9:378:9 | try {...} ... | cflow.cs:366:25:366:30 | ... < ... |
 | post | cflow.cs:371:9:374:9 | {...} | cflow.cs:370:9:378:9 | try {...} ... |
 | post | cflow.cs:372:13:372:24 | yield break; | cflow.cs:371:9:374:9 | {...} |
-| post | cflow.cs:376:9:378:9 | [return] {...} | cflow.cs:372:13:372:24 | yield break; |
-| post | cflow.cs:377:13:377:41 | [return] call to method WriteLine | cflow.cs:377:31:377:40 | [return] "not dead" |
-| post | cflow.cs:377:13:377:42 | [return] ...; | cflow.cs:376:9:378:9 | [return] {...} |
-| post | cflow.cs:377:31:377:40 | [return] "not dead" | cflow.cs:377:13:377:42 | [return] ...; |
+| post | cflow.cs:376:9:378:9 | [finally: return] {...} | cflow.cs:372:13:372:24 | yield break; |
+| post | cflow.cs:377:13:377:41 | [finally: return] call to method WriteLine | cflow.cs:377:31:377:40 | [finally: return] "not dead" |
+| post | cflow.cs:377:13:377:42 | [finally: return] ...; | cflow.cs:376:9:378:9 | [finally: return] {...} |
+| post | cflow.cs:377:31:377:40 | [finally: return] "not dead" | cflow.cs:377:13:377:42 | [finally: return] ...; |
 | post | cflow.cs:384:5:384:18 | exit ControlFlowSub | cflow.cs:384:31:384:33 | {...} |
 | post | cflow.cs:384:24:384:27 | call to constructor ControlFlow | cflow.cs:384:5:384:18 | enter ControlFlowSub |
 | post | cflow.cs:384:31:384:33 | {...} | cflow.cs:384:24:384:27 | call to constructor ControlFlow |
@@ -1648,23 +1652,23 @@
 | post | cflow.cs:388:34:388:34 | access to parameter i | cflow.cs:388:5:388:18 | enter ControlFlowSub |
 | post | cflow.cs:388:34:388:45 | call to method ToString | cflow.cs:388:34:388:34 | access to parameter i |
 | post | cflow.cs:388:48:388:50 | {...} | cflow.cs:388:29:388:32 | call to constructor ControlFlowSub |
-| post | cflow.cs:393:10:393:10 | exit M | cflow.cs:401:13:401:44 | [exception(Exception)] throw ...; |
-| post | cflow.cs:393:10:393:10 | exit M | cflow.cs:401:13:401:44 | [exception(OutOfMemoryException)] throw ...; |
+| post | cflow.cs:393:10:393:10 | exit M | cflow.cs:401:13:401:44 | [finally: exception(Exception)] throw ...; |
+| post | cflow.cs:393:10:393:10 | exit M | cflow.cs:401:13:401:44 | [finally: exception(OutOfMemoryException)] throw ...; |
 | post | cflow.cs:393:10:393:10 | exit M | cflow.cs:401:13:401:44 | throw ...; |
 | post | cflow.cs:394:5:405:5 | {...} | cflow.cs:393:10:393:10 | enter M |
 | post | cflow.cs:395:9:403:9 | try {...} ... | cflow.cs:394:5:405:5 | {...} |
 | post | cflow.cs:396:9:398:9 | {...} | cflow.cs:395:9:403:9 | try {...} ... |
 | post | cflow.cs:397:13:397:37 | ...; | cflow.cs:396:9:398:9 | {...} |
 | post | cflow.cs:397:31:397:35 | "Try" | cflow.cs:397:13:397:37 | ...; |
-| post | cflow.cs:401:13:401:44 | [exception(Exception)] throw ...; | cflow.cs:401:19:401:43 | [exception(Exception)] object creation of type ArgumentException |
-| post | cflow.cs:401:13:401:44 | [exception(OutOfMemoryException)] throw ...; | cflow.cs:401:19:401:43 | [exception(OutOfMemoryException)] object creation of type ArgumentException |
+| post | cflow.cs:401:13:401:44 | [finally: exception(Exception)] throw ...; | cflow.cs:401:19:401:43 | [finally: exception(Exception)] object creation of type ArgumentException |
+| post | cflow.cs:401:13:401:44 | [finally: exception(OutOfMemoryException)] throw ...; | cflow.cs:401:19:401:43 | [finally: exception(OutOfMemoryException)] object creation of type ArgumentException |
 | post | cflow.cs:401:13:401:44 | throw ...; | cflow.cs:401:19:401:43 | object creation of type ArgumentException |
-| post | cflow.cs:401:19:401:43 | [exception(Exception)] object creation of type ArgumentException | cflow.cs:401:41:401:42 | [exception(Exception)] "" |
-| post | cflow.cs:401:19:401:43 | [exception(OutOfMemoryException)] object creation of type ArgumentException | cflow.cs:401:41:401:42 | [exception(OutOfMemoryException)] "" |
+| post | cflow.cs:401:19:401:43 | [finally: exception(Exception)] object creation of type ArgumentException | cflow.cs:401:41:401:42 | [finally: exception(Exception)] "" |
+| post | cflow.cs:401:19:401:43 | [finally: exception(OutOfMemoryException)] object creation of type ArgumentException | cflow.cs:401:41:401:42 | [finally: exception(OutOfMemoryException)] "" |
 | post | cflow.cs:401:19:401:43 | object creation of type ArgumentException | cflow.cs:401:41:401:42 | "" |
 | post | cflow.cs:401:41:401:42 | "" | cflow.cs:400:9:403:9 | {...} |
-| post | cflow.cs:401:41:401:42 | [exception(Exception)] "" | cflow.cs:400:9:403:9 | [exception(Exception)] {...} |
-| post | cflow.cs:401:41:401:42 | [exception(OutOfMemoryException)] "" | cflow.cs:400:9:403:9 | [exception(OutOfMemoryException)] {...} |
+| post | cflow.cs:401:41:401:42 | [finally: exception(Exception)] "" | cflow.cs:400:9:403:9 | [finally: exception(Exception)] {...} |
+| post | cflow.cs:401:41:401:42 | [finally: exception(OutOfMemoryException)] "" | cflow.cs:400:9:403:9 | [finally: exception(OutOfMemoryException)] {...} |
 | post | cflow.cs:410:12:410:12 | exit M | cflow.cs:410:38:410:41 | delegate call |
 | post | cflow.cs:410:38:410:38 | access to parameter f | cflow.cs:410:12:410:12 | enter M |
 | post | cflow.cs:410:38:410:41 | delegate call | cflow.cs:410:40:410:40 | 0 |
@@ -1783,16 +1787,16 @@
 | pre | BreakInTry.cs:26:21:26:31 | ... == ... | BreakInTry.cs:27:21:27:26 | break; |
 | pre | BreakInTry.cs:26:21:26:31 | ... == ... | BreakInTry.cs:30:13:33:13 | {...} |
 | pre | BreakInTry.cs:26:28:26:31 | null | BreakInTry.cs:26:21:26:31 | ... == ... |
-| pre | BreakInTry.cs:27:21:27:26 | break; | BreakInTry.cs:30:13:33:13 | [break] {...} |
-| pre | BreakInTry.cs:30:13:33:13 | [break] {...} | BreakInTry.cs:31:17:32:21 | [break] if (...) ... |
+| pre | BreakInTry.cs:27:21:27:26 | break; | BreakInTry.cs:30:13:33:13 | [finally: break] {...} |
+| pre | BreakInTry.cs:30:13:33:13 | [finally: break] {...} | BreakInTry.cs:31:17:32:21 | [finally: break] if (...) ... |
 | pre | BreakInTry.cs:30:13:33:13 | {...} | BreakInTry.cs:31:17:32:21 | if (...) ... |
-| pre | BreakInTry.cs:31:17:32:21 | [break] if (...) ... | BreakInTry.cs:31:21:31:24 | [break] access to parameter args |
+| pre | BreakInTry.cs:31:17:32:21 | [finally: break] if (...) ... | BreakInTry.cs:31:21:31:24 | [finally: break] access to parameter args |
 | pre | BreakInTry.cs:31:17:32:21 | if (...) ... | BreakInTry.cs:31:21:31:24 | access to parameter args |
-| pre | BreakInTry.cs:31:21:31:24 | [break] access to parameter args | BreakInTry.cs:31:29:31:32 | [break] null |
+| pre | BreakInTry.cs:31:21:31:24 | [finally: break] access to parameter args | BreakInTry.cs:31:29:31:32 | [finally: break] null |
 | pre | BreakInTry.cs:31:21:31:24 | access to parameter args | BreakInTry.cs:31:29:31:32 | null |
 | pre | BreakInTry.cs:31:21:31:32 | ... == ... | BreakInTry.cs:32:21:32:21 | ; |
-| pre | BreakInTry.cs:31:21:31:32 | [break] ... == ... | BreakInTry.cs:32:21:32:21 | [break] ; |
-| pre | BreakInTry.cs:31:29:31:32 | [break] null | BreakInTry.cs:31:21:31:32 | [break] ... == ... |
+| pre | BreakInTry.cs:31:21:31:32 | [finally: break] ... == ... | BreakInTry.cs:32:21:32:21 | [finally: break] ; |
+| pre | BreakInTry.cs:31:29:31:32 | [finally: break] null | BreakInTry.cs:31:21:31:32 | [finally: break] ... == ... |
 | pre | BreakInTry.cs:31:29:31:32 | null | BreakInTry.cs:31:21:31:32 | ... == ... |
 | pre | BreakInTry.cs:35:7:35:7 | ; | BreakInTry.cs:20:10:20:11 | exit M2 |
 | pre | BreakInTry.cs:38:10:38:11 | enter M3 | BreakInTry.cs:39:5:54:5 | {...} |
@@ -1804,25 +1808,25 @@
 | pre | BreakInTry.cs:42:17:42:28 | ... == ... | BreakInTry.cs:43:17:43:23 | return ...; |
 | pre | BreakInTry.cs:42:17:42:28 | ... == ... | BreakInTry.cs:46:9:52:9 | {...} |
 | pre | BreakInTry.cs:42:25:42:28 | null | BreakInTry.cs:42:17:42:28 | ... == ... |
-| pre | BreakInTry.cs:43:17:43:23 | return ...; | BreakInTry.cs:46:9:52:9 | [return] {...} |
-| pre | BreakInTry.cs:46:9:52:9 | [return] {...} | BreakInTry.cs:47:33:47:36 | [return] access to parameter args |
+| pre | BreakInTry.cs:43:17:43:23 | return ...; | BreakInTry.cs:46:9:52:9 | [finally: return] {...} |
+| pre | BreakInTry.cs:46:9:52:9 | [finally: return] {...} | BreakInTry.cs:47:33:47:36 | [finally: return] access to parameter args |
 | pre | BreakInTry.cs:46:9:52:9 | {...} | BreakInTry.cs:47:33:47:36 | access to parameter args |
-| pre | BreakInTry.cs:47:13:51:13 | [return] foreach (... ... in ...) ... | BreakInTry.cs:47:26:47:28 | [return] String arg |
+| pre | BreakInTry.cs:47:13:51:13 | [finally: return] foreach (... ... in ...) ... | BreakInTry.cs:47:26:47:28 | [finally: return] String arg |
 | pre | BreakInTry.cs:47:13:51:13 | foreach (... ... in ...) ... | BreakInTry.cs:47:26:47:28 | String arg |
 | pre | BreakInTry.cs:47:13:51:13 | foreach (... ... in ...) ... | BreakInTry.cs:53:7:53:7 | ; |
 | pre | BreakInTry.cs:47:26:47:28 | String arg | BreakInTry.cs:48:13:51:13 | {...} |
-| pre | BreakInTry.cs:47:26:47:28 | [return] String arg | BreakInTry.cs:48:13:51:13 | [return] {...} |
-| pre | BreakInTry.cs:47:33:47:36 | [return] access to parameter args | BreakInTry.cs:47:13:51:13 | [return] foreach (... ... in ...) ... |
+| pre | BreakInTry.cs:47:26:47:28 | [finally: return] String arg | BreakInTry.cs:48:13:51:13 | [finally: return] {...} |
+| pre | BreakInTry.cs:47:33:47:36 | [finally: return] access to parameter args | BreakInTry.cs:47:13:51:13 | [finally: return] foreach (... ... in ...) ... |
 | pre | BreakInTry.cs:47:33:47:36 | access to parameter args | BreakInTry.cs:47:13:51:13 | foreach (... ... in ...) ... |
-| pre | BreakInTry.cs:48:13:51:13 | [return] {...} | BreakInTry.cs:49:17:50:26 | [return] if (...) ... |
+| pre | BreakInTry.cs:48:13:51:13 | [finally: return] {...} | BreakInTry.cs:49:17:50:26 | [finally: return] if (...) ... |
 | pre | BreakInTry.cs:48:13:51:13 | {...} | BreakInTry.cs:49:17:50:26 | if (...) ... |
-| pre | BreakInTry.cs:49:17:50:26 | [return] if (...) ... | BreakInTry.cs:49:21:49:23 | [return] access to local variable arg |
+| pre | BreakInTry.cs:49:17:50:26 | [finally: return] if (...) ... | BreakInTry.cs:49:21:49:23 | [finally: return] access to local variable arg |
 | pre | BreakInTry.cs:49:17:50:26 | if (...) ... | BreakInTry.cs:49:21:49:23 | access to local variable arg |
-| pre | BreakInTry.cs:49:21:49:23 | [return] access to local variable arg | BreakInTry.cs:49:28:49:31 | [return] null |
+| pre | BreakInTry.cs:49:21:49:23 | [finally: return] access to local variable arg | BreakInTry.cs:49:28:49:31 | [finally: return] null |
 | pre | BreakInTry.cs:49:21:49:23 | access to local variable arg | BreakInTry.cs:49:28:49:31 | null |
 | pre | BreakInTry.cs:49:21:49:31 | ... == ... | BreakInTry.cs:50:21:50:26 | break; |
-| pre | BreakInTry.cs:49:21:49:31 | [return] ... == ... | BreakInTry.cs:50:21:50:26 | [return] break; |
-| pre | BreakInTry.cs:49:28:49:31 | [return] null | BreakInTry.cs:49:21:49:31 | [return] ... == ... |
+| pre | BreakInTry.cs:49:21:49:31 | [finally: return] ... == ... | BreakInTry.cs:50:21:50:26 | [finally: return] break; |
+| pre | BreakInTry.cs:49:28:49:31 | [finally: return] null | BreakInTry.cs:49:21:49:31 | [finally: return] ... == ... |
 | pre | BreakInTry.cs:49:28:49:31 | null | BreakInTry.cs:49:21:49:31 | ... == ... |
 | pre | BreakInTry.cs:56:10:56:11 | enter M4 | BreakInTry.cs:57:5:71:5 | {...} |
 | pre | BreakInTry.cs:57:5:71:5 | {...} | BreakInTry.cs:58:9:70:9 | try {...} ... |
@@ -1833,24 +1837,24 @@
 | pre | BreakInTry.cs:60:17:60:28 | ... == ... | BreakInTry.cs:61:17:61:23 | return ...; |
 | pre | BreakInTry.cs:60:17:60:28 | ... == ... | BreakInTry.cs:64:9:70:9 | {...} |
 | pre | BreakInTry.cs:60:25:60:28 | null | BreakInTry.cs:60:17:60:28 | ... == ... |
-| pre | BreakInTry.cs:61:17:61:23 | return ...; | BreakInTry.cs:64:9:70:9 | [return] {...} |
-| pre | BreakInTry.cs:64:9:70:9 | [return] {...} | BreakInTry.cs:65:33:65:36 | [return] access to parameter args |
+| pre | BreakInTry.cs:61:17:61:23 | return ...; | BreakInTry.cs:64:9:70:9 | [finally: return] {...} |
+| pre | BreakInTry.cs:64:9:70:9 | [finally: return] {...} | BreakInTry.cs:65:33:65:36 | [finally: return] access to parameter args |
 | pre | BreakInTry.cs:64:9:70:9 | {...} | BreakInTry.cs:65:33:65:36 | access to parameter args |
-| pre | BreakInTry.cs:65:13:69:13 | [return] foreach (... ... in ...) ... | BreakInTry.cs:65:26:65:28 | [return] String arg |
+| pre | BreakInTry.cs:65:13:69:13 | [finally: return] foreach (... ... in ...) ... | BreakInTry.cs:65:26:65:28 | [finally: return] String arg |
 | pre | BreakInTry.cs:65:13:69:13 | foreach (... ... in ...) ... | BreakInTry.cs:65:26:65:28 | String arg |
 | pre | BreakInTry.cs:65:26:65:28 | String arg | BreakInTry.cs:66:13:69:13 | {...} |
-| pre | BreakInTry.cs:65:26:65:28 | [return] String arg | BreakInTry.cs:66:13:69:13 | [return] {...} |
-| pre | BreakInTry.cs:65:33:65:36 | [return] access to parameter args | BreakInTry.cs:65:13:69:13 | [return] foreach (... ... in ...) ... |
+| pre | BreakInTry.cs:65:26:65:28 | [finally: return] String arg | BreakInTry.cs:66:13:69:13 | [finally: return] {...} |
+| pre | BreakInTry.cs:65:33:65:36 | [finally: return] access to parameter args | BreakInTry.cs:65:13:69:13 | [finally: return] foreach (... ... in ...) ... |
 | pre | BreakInTry.cs:65:33:65:36 | access to parameter args | BreakInTry.cs:65:13:69:13 | foreach (... ... in ...) ... |
-| pre | BreakInTry.cs:66:13:69:13 | [return] {...} | BreakInTry.cs:67:17:68:26 | [return] if (...) ... |
+| pre | BreakInTry.cs:66:13:69:13 | [finally: return] {...} | BreakInTry.cs:67:17:68:26 | [finally: return] if (...) ... |
 | pre | BreakInTry.cs:66:13:69:13 | {...} | BreakInTry.cs:67:17:68:26 | if (...) ... |
-| pre | BreakInTry.cs:67:17:68:26 | [return] if (...) ... | BreakInTry.cs:67:21:67:23 | [return] access to local variable arg |
+| pre | BreakInTry.cs:67:17:68:26 | [finally: return] if (...) ... | BreakInTry.cs:67:21:67:23 | [finally: return] access to local variable arg |
 | pre | BreakInTry.cs:67:17:68:26 | if (...) ... | BreakInTry.cs:67:21:67:23 | access to local variable arg |
-| pre | BreakInTry.cs:67:21:67:23 | [return] access to local variable arg | BreakInTry.cs:67:28:67:31 | [return] null |
+| pre | BreakInTry.cs:67:21:67:23 | [finally: return] access to local variable arg | BreakInTry.cs:67:28:67:31 | [finally: return] null |
 | pre | BreakInTry.cs:67:21:67:23 | access to local variable arg | BreakInTry.cs:67:28:67:31 | null |
 | pre | BreakInTry.cs:67:21:67:31 | ... == ... | BreakInTry.cs:68:21:68:26 | break; |
-| pre | BreakInTry.cs:67:21:67:31 | [return] ... == ... | BreakInTry.cs:68:21:68:26 | [return] break; |
-| pre | BreakInTry.cs:67:28:67:31 | [return] null | BreakInTry.cs:67:21:67:31 | [return] ... == ... |
+| pre | BreakInTry.cs:67:21:67:31 | [finally: return] ... == ... | BreakInTry.cs:68:21:68:26 | [finally: return] break; |
+| pre | BreakInTry.cs:67:28:67:31 | [finally: return] null | BreakInTry.cs:67:21:67:31 | [finally: return] ... == ... |
 | pre | BreakInTry.cs:67:28:67:31 | null | BreakInTry.cs:67:21:67:31 | ... == ... |
 | pre | CompileTimeOperators.cs:5:9:5:15 | enter Default | CompileTimeOperators.cs:6:5:8:5 | {...} |
 | pre | CompileTimeOperators.cs:6:5:8:5 | {...} | CompileTimeOperators.cs:7:16:7:27 | default(...) |
@@ -1872,11 +1876,11 @@
 | pre | CompileTimeOperators.cs:29:5:41:5 | {...} | CompileTimeOperators.cs:30:9:38:9 | try {...} ... |
 | pre | CompileTimeOperators.cs:30:9:38:9 | try {...} ... | CompileTimeOperators.cs:31:9:34:9 | {...} |
 | pre | CompileTimeOperators.cs:31:9:34:9 | {...} | CompileTimeOperators.cs:32:13:32:21 | goto ...; |
-| pre | CompileTimeOperators.cs:32:13:32:21 | goto ...; | CompileTimeOperators.cs:36:9:38:9 | [goto(End)] {...} |
-| pre | CompileTimeOperators.cs:36:9:38:9 | [goto(End)] {...} | CompileTimeOperators.cs:37:13:37:41 | [goto(End)] ...; |
-| pre | CompileTimeOperators.cs:37:13:37:40 | [goto(End)] call to method WriteLine | CompileTimeOperators.cs:40:9:40:11 | End: |
-| pre | CompileTimeOperators.cs:37:13:37:41 | [goto(End)] ...; | CompileTimeOperators.cs:37:31:37:39 | [goto(End)] "Finally" |
-| pre | CompileTimeOperators.cs:37:31:37:39 | [goto(End)] "Finally" | CompileTimeOperators.cs:37:13:37:40 | [goto(End)] call to method WriteLine |
+| pre | CompileTimeOperators.cs:32:13:32:21 | goto ...; | CompileTimeOperators.cs:36:9:38:9 | [finally: goto(End)] {...} |
+| pre | CompileTimeOperators.cs:36:9:38:9 | [finally: goto(End)] {...} | CompileTimeOperators.cs:37:13:37:41 | [finally: goto(End)] ...; |
+| pre | CompileTimeOperators.cs:37:13:37:40 | [finally: goto(End)] call to method WriteLine | CompileTimeOperators.cs:40:9:40:11 | End: |
+| pre | CompileTimeOperators.cs:37:13:37:41 | [finally: goto(End)] ...; | CompileTimeOperators.cs:37:31:37:39 | [finally: goto(End)] "Finally" |
+| pre | CompileTimeOperators.cs:37:31:37:39 | [finally: goto(End)] "Finally" | CompileTimeOperators.cs:37:13:37:40 | [finally: goto(End)] call to method WriteLine |
 | pre | CompileTimeOperators.cs:40:9:40:11 | End: | CompileTimeOperators.cs:40:14:40:38 | ...; |
 | pre | CompileTimeOperators.cs:40:14:40:37 | call to method WriteLine | CompileTimeOperators.cs:28:10:28:10 | exit M |
 | pre | CompileTimeOperators.cs:40:14:40:38 | ...; | CompileTimeOperators.cs:40:32:40:36 | "End" |
@@ -2792,21 +2796,21 @@
 | pre | cflow.cs:147:5:246:5 | {...} | cflow.cs:148:9:155:9 | try {...} ... |
 | pre | cflow.cs:148:9:155:9 | try {...} ... | cflow.cs:149:9:151:9 | {...} |
 | pre | cflow.cs:149:9:151:9 | {...} | cflow.cs:150:13:150:38 | ...; |
-| pre | cflow.cs:150:13:150:37 | call to method WriteLine | cflow.cs:153:9:155:9 | [exception(Exception)] {...} |
+| pre | cflow.cs:150:13:150:37 | call to method WriteLine | cflow.cs:153:9:155:9 | [finally: exception(Exception)] {...} |
 | pre | cflow.cs:150:13:150:37 | call to method WriteLine | cflow.cs:153:9:155:9 | {...} |
 | pre | cflow.cs:150:13:150:38 | ...; | cflow.cs:150:31:150:36 | "Try1" |
 | pre | cflow.cs:150:31:150:36 | "Try1" | cflow.cs:150:13:150:37 | call to method WriteLine |
-| pre | cflow.cs:150:31:150:36 | "Try1" | cflow.cs:153:9:155:9 | [exception(OutOfMemoryException)] {...} |
-| pre | cflow.cs:153:9:155:9 | [exception(Exception)] {...} | cflow.cs:154:13:154:41 | [exception(Exception)] ...; |
-| pre | cflow.cs:153:9:155:9 | [exception(OutOfMemoryException)] {...} | cflow.cs:154:13:154:41 | [exception(OutOfMemoryException)] ...; |
+| pre | cflow.cs:150:31:150:36 | "Try1" | cflow.cs:153:9:155:9 | [finally: exception(OutOfMemoryException)] {...} |
+| pre | cflow.cs:153:9:155:9 | [finally: exception(Exception)] {...} | cflow.cs:154:13:154:41 | [finally: exception(Exception)] ...; |
+| pre | cflow.cs:153:9:155:9 | [finally: exception(OutOfMemoryException)] {...} | cflow.cs:154:13:154:41 | [finally: exception(OutOfMemoryException)] ...; |
 | pre | cflow.cs:153:9:155:9 | {...} | cflow.cs:154:13:154:41 | ...; |
 | pre | cflow.cs:154:13:154:40 | call to method WriteLine | cflow.cs:157:9:187:9 | try {...} ... |
 | pre | cflow.cs:154:13:154:41 | ...; | cflow.cs:154:31:154:39 | "Finally" |
-| pre | cflow.cs:154:13:154:41 | [exception(Exception)] ...; | cflow.cs:154:31:154:39 | [exception(Exception)] "Finally" |
-| pre | cflow.cs:154:13:154:41 | [exception(OutOfMemoryException)] ...; | cflow.cs:154:31:154:39 | [exception(OutOfMemoryException)] "Finally" |
+| pre | cflow.cs:154:13:154:41 | [finally: exception(Exception)] ...; | cflow.cs:154:31:154:39 | [finally: exception(Exception)] "Finally" |
+| pre | cflow.cs:154:13:154:41 | [finally: exception(OutOfMemoryException)] ...; | cflow.cs:154:31:154:39 | [finally: exception(OutOfMemoryException)] "Finally" |
 | pre | cflow.cs:154:31:154:39 | "Finally" | cflow.cs:154:13:154:40 | call to method WriteLine |
-| pre | cflow.cs:154:31:154:39 | [exception(Exception)] "Finally" | cflow.cs:154:13:154:40 | [exception(Exception)] call to method WriteLine |
-| pre | cflow.cs:154:31:154:39 | [exception(OutOfMemoryException)] "Finally" | cflow.cs:154:13:154:40 | [exception(OutOfMemoryException)] call to method WriteLine |
+| pre | cflow.cs:154:31:154:39 | [finally: exception(Exception)] "Finally" | cflow.cs:154:13:154:40 | [finally: exception(Exception)] call to method WriteLine |
+| pre | cflow.cs:154:31:154:39 | [finally: exception(OutOfMemoryException)] "Finally" | cflow.cs:154:13:154:40 | [finally: exception(OutOfMemoryException)] call to method WriteLine |
 | pre | cflow.cs:157:9:187:9 | try {...} ... | cflow.cs:158:9:161:9 | {...} |
 | pre | cflow.cs:158:9:161:9 | {...} | cflow.cs:159:13:159:38 | ...; |
 | pre | cflow.cs:159:13:159:37 | call to method WriteLine | cflow.cs:160:13:160:19 | return ...; |
@@ -2815,12 +2819,12 @@
 | pre | cflow.cs:159:13:159:38 | ...; | cflow.cs:159:31:159:36 | "Try2" |
 | pre | cflow.cs:159:31:159:36 | "Try2" | cflow.cs:159:13:159:37 | call to method WriteLine |
 | pre | cflow.cs:159:31:159:36 | "Try2" | cflow.cs:177:9:179:9 | catch (...) {...} |
-| pre | cflow.cs:160:13:160:19 | return ...; | cflow.cs:185:9:187:9 | [return] {...} |
+| pre | cflow.cs:160:13:160:19 | return ...; | cflow.cs:185:9:187:9 | [finally: return] {...} |
 | pre | cflow.cs:162:9:165:9 | catch (...) {...} | cflow.cs:162:38:162:39 | IOException ex |
 | pre | cflow.cs:162:38:162:39 | IOException ex | cflow.cs:162:48:162:51 | true |
 | pre | cflow.cs:162:48:162:51 | true | cflow.cs:163:9:165:9 | {...} |
 | pre | cflow.cs:163:9:165:9 | {...} | cflow.cs:164:13:164:18 | throw ...; |
-| pre | cflow.cs:164:13:164:18 | throw ...; | cflow.cs:185:9:187:9 | [exception(IOException)] {...} |
+| pre | cflow.cs:164:13:164:18 | throw ...; | cflow.cs:185:9:187:9 | [finally: exception(IOException)] {...} |
 | pre | cflow.cs:166:9:176:9 | catch (...) {...} | cflow.cs:166:41:166:42 | ArgumentException ex |
 | pre | cflow.cs:166:41:166:42 | ArgumentException ex | cflow.cs:167:9:176:9 | {...} |
 | pre | cflow.cs:167:9:176:9 | {...} | cflow.cs:168:13:175:13 | try {...} ... |
@@ -2828,60 +2832,64 @@
 | pre | cflow.cs:169:13:171:13 | {...} | cflow.cs:170:17:170:32 | if (...) ... |
 | pre | cflow.cs:170:17:170:32 | if (...) ... | cflow.cs:170:21:170:24 | true |
 | pre | cflow.cs:170:21:170:24 | true | cflow.cs:170:27:170:32 | throw ...; |
-| pre | cflow.cs:170:27:170:32 | throw ...; | cflow.cs:173:13:175:13 | [exception(ArgumentException)] {...} |
-| pre | cflow.cs:173:13:175:13 | [exception(ArgumentException)] {...} | cflow.cs:174:37:174:42 | [exception(ArgumentException)] "Boo!" |
-| pre | cflow.cs:174:17:174:44 | [exception(ArgumentException)] throw ...; | cflow.cs:185:9:187:9 | [exception(Exception)] {...} |
-| pre | cflow.cs:174:23:174:43 | [exception(ArgumentException)] object creation of type Exception | cflow.cs:174:17:174:44 | [exception(ArgumentException)] throw ...; |
-| pre | cflow.cs:174:37:174:42 | [exception(ArgumentException)] "Boo!" | cflow.cs:174:23:174:43 | [exception(ArgumentException)] object creation of type Exception |
+| pre | cflow.cs:170:27:170:32 | throw ...; | cflow.cs:173:13:175:13 | [finally: exception(ArgumentException)] {...} |
+| pre | cflow.cs:173:13:175:13 | [finally: exception(ArgumentException)] {...} | cflow.cs:174:37:174:42 | [finally: exception(ArgumentException)] "Boo!" |
+| pre | cflow.cs:174:17:174:44 | [finally: exception(ArgumentException)] throw ...; | cflow.cs:185:9:187:9 | [finally: exception(Exception)] {...} |
+| pre | cflow.cs:174:23:174:43 | [finally: exception(ArgumentException)] object creation of type Exception | cflow.cs:174:17:174:44 | [finally: exception(ArgumentException)] throw ...; |
+| pre | cflow.cs:174:37:174:42 | [finally: exception(ArgumentException)] "Boo!" | cflow.cs:174:23:174:43 | [finally: exception(ArgumentException)] object creation of type Exception |
 | pre | cflow.cs:177:9:179:9 | catch (...) {...} | cflow.cs:178:9:179:9 | {...} |
 | pre | cflow.cs:178:9:179:9 | {...} | cflow.cs:185:9:187:9 | {...} |
-| pre | cflow.cs:185:9:187:9 | [exception(Exception)] {...} | cflow.cs:186:13:186:41 | [exception(Exception)] ...; |
-| pre | cflow.cs:185:9:187:9 | [exception(IOException)] {...} | cflow.cs:186:13:186:41 | [exception(IOException)] ...; |
-| pre | cflow.cs:185:9:187:9 | [return] {...} | cflow.cs:186:13:186:41 | [return] ...; |
+| pre | cflow.cs:185:9:187:9 | [finally: exception(Exception)] {...} | cflow.cs:186:13:186:41 | [finally: exception(Exception)] ...; |
+| pre | cflow.cs:185:9:187:9 | [finally: exception(IOException)] {...} | cflow.cs:186:13:186:41 | [finally: exception(IOException)] ...; |
+| pre | cflow.cs:185:9:187:9 | [finally: return] {...} | cflow.cs:186:13:186:41 | [finally: return] ...; |
 | pre | cflow.cs:185:9:187:9 | {...} | cflow.cs:186:13:186:41 | ...; |
 | pre | cflow.cs:186:13:186:40 | call to method WriteLine | cflow.cs:189:9:204:9 | try {...} ... |
 | pre | cflow.cs:186:13:186:41 | ...; | cflow.cs:186:31:186:39 | "Finally" |
-| pre | cflow.cs:186:13:186:41 | [exception(Exception)] ...; | cflow.cs:186:31:186:39 | [exception(Exception)] "Finally" |
-| pre | cflow.cs:186:13:186:41 | [exception(IOException)] ...; | cflow.cs:186:31:186:39 | [exception(IOException)] "Finally" |
-| pre | cflow.cs:186:13:186:41 | [return] ...; | cflow.cs:186:31:186:39 | [return] "Finally" |
+| pre | cflow.cs:186:13:186:41 | [finally: exception(Exception)] ...; | cflow.cs:186:31:186:39 | [finally: exception(Exception)] "Finally" |
+| pre | cflow.cs:186:13:186:41 | [finally: exception(IOException)] ...; | cflow.cs:186:31:186:39 | [finally: exception(IOException)] "Finally" |
+| pre | cflow.cs:186:13:186:41 | [finally: return] ...; | cflow.cs:186:31:186:39 | [finally: return] "Finally" |
 | pre | cflow.cs:186:31:186:39 | "Finally" | cflow.cs:186:13:186:40 | call to method WriteLine |
-| pre | cflow.cs:186:31:186:39 | [exception(Exception)] "Finally" | cflow.cs:186:13:186:40 | [exception(Exception)] call to method WriteLine |
-| pre | cflow.cs:186:31:186:39 | [exception(IOException)] "Finally" | cflow.cs:186:13:186:40 | [exception(IOException)] call to method WriteLine |
-| pre | cflow.cs:186:31:186:39 | [return] "Finally" | cflow.cs:186:13:186:40 | [return] call to method WriteLine |
+| pre | cflow.cs:186:31:186:39 | [finally: exception(Exception)] "Finally" | cflow.cs:186:13:186:40 | [finally: exception(Exception)] call to method WriteLine |
+| pre | cflow.cs:186:31:186:39 | [finally: exception(IOException)] "Finally" | cflow.cs:186:13:186:40 | [finally: exception(IOException)] call to method WriteLine |
+| pre | cflow.cs:186:31:186:39 | [finally: return] "Finally" | cflow.cs:186:13:186:40 | [finally: return] call to method WriteLine |
 | pre | cflow.cs:189:9:204:9 | try {...} ... | cflow.cs:190:9:193:9 | {...} |
 | pre | cflow.cs:190:9:193:9 | {...} | cflow.cs:191:13:191:38 | ...; |
 | pre | cflow.cs:191:13:191:37 | call to method WriteLine | cflow.cs:192:13:192:19 | return ...; |
 | pre | cflow.cs:191:13:191:37 | call to method WriteLine | cflow.cs:194:9:197:9 | catch (...) {...} |
 | pre | cflow.cs:191:13:191:37 | call to method WriteLine | cflow.cs:198:9:200:9 | catch (...) {...} |
-| pre | cflow.cs:191:13:191:37 | call to method WriteLine | cflow.cs:202:9:204:9 | [exception(Exception)] {...} |
+| pre | cflow.cs:191:13:191:37 | call to method WriteLine | cflow.cs:202:9:204:9 | [finally: exception(Exception)] {...} |
 | pre | cflow.cs:191:13:191:38 | ...; | cflow.cs:191:31:191:36 | "Try3" |
 | pre | cflow.cs:191:31:191:36 | "Try3" | cflow.cs:191:13:191:37 | call to method WriteLine |
-| pre | cflow.cs:191:31:191:36 | "Try3" | cflow.cs:202:9:204:9 | [exception(OutOfMemoryException)] {...} |
-| pre | cflow.cs:192:13:192:19 | return ...; | cflow.cs:202:9:204:9 | [return] {...} |
+| pre | cflow.cs:191:31:191:36 | "Try3" | cflow.cs:202:9:204:9 | [finally: exception(OutOfMemoryException)] {...} |
+| pre | cflow.cs:192:13:192:19 | return ...; | cflow.cs:202:9:204:9 | [finally: return] {...} |
 | pre | cflow.cs:194:9:197:9 | catch (...) {...} | cflow.cs:194:38:194:39 | IOException ex |
 | pre | cflow.cs:194:38:194:39 | IOException ex | cflow.cs:194:48:194:51 | true |
 | pre | cflow.cs:194:48:194:51 | true | cflow.cs:195:9:197:9 | {...} |
 | pre | cflow.cs:195:9:197:9 | {...} | cflow.cs:196:13:196:18 | throw ...; |
-| pre | cflow.cs:196:13:196:18 | throw ...; | cflow.cs:202:9:204:9 | [exception(IOException)] {...} |
-| pre | cflow.cs:198:9:200:9 | catch (...) {...} | cflow.cs:198:33:198:37 | false |
-| pre | cflow.cs:198:33:198:37 | false | cflow.cs:199:9:200:9 | {...} |
+| pre | cflow.cs:196:13:196:18 | throw ...; | cflow.cs:202:9:204:9 | [finally: exception(IOException)] {...} |
+| pre | cflow.cs:198:9:200:9 | catch (...) {...} | cflow.cs:198:26:198:26 | Exception e |
+| pre | cflow.cs:198:26:198:26 | Exception e | cflow.cs:198:35:198:35 | access to local variable e |
+| pre | cflow.cs:198:35:198:35 | access to local variable e | cflow.cs:198:35:198:43 | access to property Message |
+| pre | cflow.cs:198:35:198:43 | access to property Message | cflow.cs:198:48:198:51 | null |
+| pre | cflow.cs:198:35:198:51 | ... != ... | cflow.cs:199:9:200:9 | {...} |
+| pre | cflow.cs:198:48:198:51 | null | cflow.cs:198:35:198:51 | ... != ... |
 | pre | cflow.cs:199:9:200:9 | {...} | cflow.cs:202:9:204:9 | {...} |
-| pre | cflow.cs:202:9:204:9 | [exception(Exception)] {...} | cflow.cs:203:13:203:41 | [exception(Exception)] ...; |
-| pre | cflow.cs:202:9:204:9 | [exception(IOException)] {...} | cflow.cs:203:13:203:41 | [exception(IOException)] ...; |
-| pre | cflow.cs:202:9:204:9 | [exception(OutOfMemoryException)] {...} | cflow.cs:203:13:203:41 | [exception(OutOfMemoryException)] ...; |
-| pre | cflow.cs:202:9:204:9 | [return] {...} | cflow.cs:203:13:203:41 | [return] ...; |
+| pre | cflow.cs:202:9:204:9 | [finally: exception(Exception)] {...} | cflow.cs:203:13:203:41 | [finally: exception(Exception)] ...; |
+| pre | cflow.cs:202:9:204:9 | [finally: exception(IOException)] {...} | cflow.cs:203:13:203:41 | [finally: exception(IOException)] ...; |
+| pre | cflow.cs:202:9:204:9 | [finally: exception(OutOfMemoryException)] {...} | cflow.cs:203:13:203:41 | [finally: exception(OutOfMemoryException)] ...; |
+| pre | cflow.cs:202:9:204:9 | [finally: return] {...} | cflow.cs:203:13:203:41 | [finally: return] ...; |
 | pre | cflow.cs:202:9:204:9 | {...} | cflow.cs:203:13:203:41 | ...; |
 | pre | cflow.cs:203:13:203:40 | call to method WriteLine | cflow.cs:206:9:206:19 | ... ...; |
 | pre | cflow.cs:203:13:203:41 | ...; | cflow.cs:203:31:203:39 | "Finally" |
-| pre | cflow.cs:203:13:203:41 | [exception(Exception)] ...; | cflow.cs:203:31:203:39 | [exception(Exception)] "Finally" |
-| pre | cflow.cs:203:13:203:41 | [exception(IOException)] ...; | cflow.cs:203:31:203:39 | [exception(IOException)] "Finally" |
-| pre | cflow.cs:203:13:203:41 | [exception(OutOfMemoryException)] ...; | cflow.cs:203:31:203:39 | [exception(OutOfMemoryException)] "Finally" |
-| pre | cflow.cs:203:13:203:41 | [return] ...; | cflow.cs:203:31:203:39 | [return] "Finally" |
+| pre | cflow.cs:203:13:203:41 | [finally: exception(Exception)] ...; | cflow.cs:203:31:203:39 | [finally: exception(Exception)] "Finally" |
+| pre | cflow.cs:203:13:203:41 | [finally: exception(IOException)] ...; | cflow.cs:203:31:203:39 | [finally: exception(IOException)] "Finally" |
+| pre | cflow.cs:203:13:203:41 | [finally: exception(OutOfMemoryException)] ...; | cflow.cs:203:31:203:39 | [finally: exception(OutOfMemoryException)] "Finally" |
+| pre | cflow.cs:203:13:203:41 | [finally: return] ...; | cflow.cs:203:31:203:39 | [finally: return] "Finally" |
 | pre | cflow.cs:203:31:203:39 | "Finally" | cflow.cs:203:13:203:40 | call to method WriteLine |
-| pre | cflow.cs:203:31:203:39 | [exception(Exception)] "Finally" | cflow.cs:203:13:203:40 | [exception(Exception)] call to method WriteLine |
-| pre | cflow.cs:203:31:203:39 | [exception(IOException)] "Finally" | cflow.cs:203:13:203:40 | [exception(IOException)] call to method WriteLine |
-| pre | cflow.cs:203:31:203:39 | [exception(OutOfMemoryException)] "Finally" | cflow.cs:203:13:203:40 | [exception(OutOfMemoryException)] call to method WriteLine |
-| pre | cflow.cs:203:31:203:39 | [return] "Finally" | cflow.cs:203:13:203:40 | [return] call to method WriteLine |
+| pre | cflow.cs:203:31:203:39 | [finally: exception(Exception)] "Finally" | cflow.cs:203:13:203:40 | [finally: exception(Exception)] call to method WriteLine |
+| pre | cflow.cs:203:31:203:39 | [finally: exception(IOException)] "Finally" | cflow.cs:203:13:203:40 | [finally: exception(IOException)] call to method WriteLine |
+| pre | cflow.cs:203:31:203:39 | [finally: exception(OutOfMemoryException)] "Finally" | cflow.cs:203:13:203:40 | [finally: exception(OutOfMemoryException)] call to method WriteLine |
+| pre | cflow.cs:203:31:203:39 | [finally: return] "Finally" | cflow.cs:203:13:203:40 | [finally: return] call to method WriteLine |
 | pre | cflow.cs:206:9:206:19 | ... ...; | cflow.cs:206:13:206:13 | access to local variable i |
 | pre | cflow.cs:206:13:206:13 | access to local variable i | cflow.cs:206:17:206:18 | 10 |
 | pre | cflow.cs:206:13:206:18 | Int32 i = ... | cflow.cs:207:9:230:9 | while (...) ... |
@@ -2899,82 +2907,82 @@
 | pre | cflow.cs:211:21:211:26 | ... == ... | cflow.cs:212:21:212:27 | return ...; |
 | pre | cflow.cs:211:21:211:26 | ... == ... | cflow.cs:213:17:214:29 | if (...) ... |
 | pre | cflow.cs:211:26:211:26 | 0 | cflow.cs:211:21:211:26 | ... == ... |
-| pre | cflow.cs:212:21:212:27 | return ...; | cflow.cs:219:13:229:13 | [return] {...} |
+| pre | cflow.cs:212:21:212:27 | return ...; | cflow.cs:219:13:229:13 | [finally: return] {...} |
 | pre | cflow.cs:213:17:214:29 | if (...) ... | cflow.cs:213:21:213:21 | access to local variable i |
 | pre | cflow.cs:213:21:213:21 | access to local variable i | cflow.cs:213:26:213:26 | 1 |
 | pre | cflow.cs:213:21:213:26 | ... == ... | cflow.cs:214:21:214:29 | continue; |
 | pre | cflow.cs:213:21:213:26 | ... == ... | cflow.cs:215:17:216:26 | if (...) ... |
 | pre | cflow.cs:213:26:213:26 | 1 | cflow.cs:213:21:213:26 | ... == ... |
-| pre | cflow.cs:214:21:214:29 | continue; | cflow.cs:219:13:229:13 | [continue] {...} |
+| pre | cflow.cs:214:21:214:29 | continue; | cflow.cs:219:13:229:13 | [finally: continue] {...} |
 | pre | cflow.cs:215:17:216:26 | if (...) ... | cflow.cs:215:21:215:21 | access to local variable i |
 | pre | cflow.cs:215:21:215:21 | access to local variable i | cflow.cs:215:26:215:26 | 2 |
 | pre | cflow.cs:215:21:215:26 | ... == ... | cflow.cs:216:21:216:26 | break; |
 | pre | cflow.cs:215:21:215:26 | ... == ... | cflow.cs:219:13:229:13 | {...} |
 | pre | cflow.cs:215:26:215:26 | 2 | cflow.cs:215:21:215:26 | ... == ... |
-| pre | cflow.cs:216:21:216:26 | break; | cflow.cs:219:13:229:13 | [break] {...} |
-| pre | cflow.cs:219:13:229:13 | [break] {...} | cflow.cs:220:17:228:17 | [break] try {...} ... |
-| pre | cflow.cs:219:13:229:13 | [continue] {...} | cflow.cs:220:17:228:17 | [continue] try {...} ... |
-| pre | cflow.cs:219:13:229:13 | [return] {...} | cflow.cs:220:17:228:17 | [return] try {...} ... |
+| pre | cflow.cs:216:21:216:26 | break; | cflow.cs:219:13:229:13 | [finally: break] {...} |
+| pre | cflow.cs:219:13:229:13 | [finally: break] {...} | cflow.cs:220:17:228:17 | [finally: break] try {...} ... |
+| pre | cflow.cs:219:13:229:13 | [finally: continue] {...} | cflow.cs:220:17:228:17 | [finally: continue] try {...} ... |
+| pre | cflow.cs:219:13:229:13 | [finally: return] {...} | cflow.cs:220:17:228:17 | [finally: return] try {...} ... |
 | pre | cflow.cs:219:13:229:13 | {...} | cflow.cs:220:17:228:17 | try {...} ... |
-| pre | cflow.cs:220:17:228:17 | [break] try {...} ... | cflow.cs:221:17:224:17 | [break] {...} |
-| pre | cflow.cs:220:17:228:17 | [continue] try {...} ... | cflow.cs:221:17:224:17 | [continue] {...} |
-| pre | cflow.cs:220:17:228:17 | [return] try {...} ... | cflow.cs:221:17:224:17 | [return] {...} |
+| pre | cflow.cs:220:17:228:17 | [finally: break] try {...} ... | cflow.cs:221:17:224:17 | [finally: break] {...} |
+| pre | cflow.cs:220:17:228:17 | [finally: continue] try {...} ... | cflow.cs:221:17:224:17 | [finally: continue] {...} |
+| pre | cflow.cs:220:17:228:17 | [finally: return] try {...} ... | cflow.cs:221:17:224:17 | [finally: return] {...} |
 | pre | cflow.cs:220:17:228:17 | try {...} ... | cflow.cs:221:17:224:17 | {...} |
-| pre | cflow.cs:221:17:224:17 | [break] {...} | cflow.cs:222:21:223:46 | [break] if (...) ... |
-| pre | cflow.cs:221:17:224:17 | [continue] {...} | cflow.cs:222:21:223:46 | [continue] if (...) ... |
-| pre | cflow.cs:221:17:224:17 | [return] {...} | cflow.cs:222:21:223:46 | [return] if (...) ... |
+| pre | cflow.cs:221:17:224:17 | [finally: break] {...} | cflow.cs:222:21:223:46 | [finally: break] if (...) ... |
+| pre | cflow.cs:221:17:224:17 | [finally: continue] {...} | cflow.cs:222:21:223:46 | [finally: continue] if (...) ... |
+| pre | cflow.cs:221:17:224:17 | [finally: return] {...} | cflow.cs:222:21:223:46 | [finally: return] if (...) ... |
 | pre | cflow.cs:221:17:224:17 | {...} | cflow.cs:222:21:223:46 | if (...) ... |
-| pre | cflow.cs:222:21:223:46 | [break] if (...) ... | cflow.cs:222:25:222:25 | [break] access to local variable i |
-| pre | cflow.cs:222:21:223:46 | [continue] if (...) ... | cflow.cs:222:25:222:25 | [continue] access to local variable i |
-| pre | cflow.cs:222:21:223:46 | [return] if (...) ... | cflow.cs:222:25:222:25 | [return] access to local variable i |
+| pre | cflow.cs:222:21:223:46 | [finally: break] if (...) ... | cflow.cs:222:25:222:25 | [finally: break] access to local variable i |
+| pre | cflow.cs:222:21:223:46 | [finally: continue] if (...) ... | cflow.cs:222:25:222:25 | [finally: continue] access to local variable i |
+| pre | cflow.cs:222:21:223:46 | [finally: return] if (...) ... | cflow.cs:222:25:222:25 | [finally: return] access to local variable i |
 | pre | cflow.cs:222:21:223:46 | if (...) ... | cflow.cs:222:25:222:25 | access to local variable i |
-| pre | cflow.cs:222:25:222:25 | [break] access to local variable i | cflow.cs:222:30:222:30 | [break] 3 |
-| pre | cflow.cs:222:25:222:25 | [continue] access to local variable i | cflow.cs:222:30:222:30 | [continue] 3 |
-| pre | cflow.cs:222:25:222:25 | [return] access to local variable i | cflow.cs:222:30:222:30 | [return] 3 |
+| pre | cflow.cs:222:25:222:25 | [finally: break] access to local variable i | cflow.cs:222:30:222:30 | [finally: break] 3 |
+| pre | cflow.cs:222:25:222:25 | [finally: continue] access to local variable i | cflow.cs:222:30:222:30 | [finally: continue] 3 |
+| pre | cflow.cs:222:25:222:25 | [finally: return] access to local variable i | cflow.cs:222:30:222:30 | [finally: return] 3 |
 | pre | cflow.cs:222:25:222:25 | access to local variable i | cflow.cs:222:30:222:30 | 3 |
 | pre | cflow.cs:222:25:222:30 | ... == ... | cflow.cs:223:31:223:45 | object creation of type Exception |
 | pre | cflow.cs:222:25:222:30 | ... == ... | cflow.cs:226:17:228:17 | {...} |
-| pre | cflow.cs:222:25:222:30 | [break] ... == ... | cflow.cs:223:31:223:45 | [break] object creation of type Exception |
-| pre | cflow.cs:222:25:222:30 | [break] ... == ... | cflow.cs:226:17:228:17 | [break] {...} |
-| pre | cflow.cs:222:25:222:30 | [continue] ... == ... | cflow.cs:223:31:223:45 | [continue] object creation of type Exception |
-| pre | cflow.cs:222:25:222:30 | [continue] ... == ... | cflow.cs:226:17:228:17 | [continue] {...} |
-| pre | cflow.cs:222:25:222:30 | [return] ... == ... | cflow.cs:223:31:223:45 | [return] object creation of type Exception |
-| pre | cflow.cs:222:25:222:30 | [return] ... == ... | cflow.cs:226:17:228:17 | [return] {...} |
+| pre | cflow.cs:222:25:222:30 | [finally: break] ... == ... | cflow.cs:223:31:223:45 | [finally: break] object creation of type Exception |
+| pre | cflow.cs:222:25:222:30 | [finally: break] ... == ... | cflow.cs:226:17:228:17 | [finally: break] {...} |
+| pre | cflow.cs:222:25:222:30 | [finally: continue] ... == ... | cflow.cs:223:31:223:45 | [finally: continue] object creation of type Exception |
+| pre | cflow.cs:222:25:222:30 | [finally: continue] ... == ... | cflow.cs:226:17:228:17 | [finally: continue] {...} |
+| pre | cflow.cs:222:25:222:30 | [finally: return] ... == ... | cflow.cs:223:31:223:45 | [finally: return] object creation of type Exception |
+| pre | cflow.cs:222:25:222:30 | [finally: return] ... == ... | cflow.cs:226:17:228:17 | [finally: return] {...} |
 | pre | cflow.cs:222:30:222:30 | 3 | cflow.cs:222:25:222:30 | ... == ... |
-| pre | cflow.cs:222:30:222:30 | [break] 3 | cflow.cs:222:25:222:30 | [break] ... == ... |
-| pre | cflow.cs:222:30:222:30 | [continue] 3 | cflow.cs:222:25:222:30 | [continue] ... == ... |
-| pre | cflow.cs:222:30:222:30 | [return] 3 | cflow.cs:222:25:222:30 | [return] ... == ... |
-| pre | cflow.cs:223:31:223:45 | [break] object creation of type Exception | cflow.cs:223:25:223:46 | [break] throw ...; |
-| pre | cflow.cs:223:31:223:45 | [continue] object creation of type Exception | cflow.cs:223:25:223:46 | [continue] throw ...; |
-| pre | cflow.cs:223:31:223:45 | [return] object creation of type Exception | cflow.cs:223:25:223:46 | [return] throw ...; |
+| pre | cflow.cs:222:30:222:30 | [finally: break] 3 | cflow.cs:222:25:222:30 | [finally: break] ... == ... |
+| pre | cflow.cs:222:30:222:30 | [finally: continue] 3 | cflow.cs:222:25:222:30 | [finally: continue] ... == ... |
+| pre | cflow.cs:222:30:222:30 | [finally: return] 3 | cflow.cs:222:25:222:30 | [finally: return] ... == ... |
+| pre | cflow.cs:223:31:223:45 | [finally: break] object creation of type Exception | cflow.cs:223:25:223:46 | [finally: break] throw ...; |
+| pre | cflow.cs:223:31:223:45 | [finally: continue] object creation of type Exception | cflow.cs:223:25:223:46 | [finally: continue] throw ...; |
+| pre | cflow.cs:223:31:223:45 | [finally: return] object creation of type Exception | cflow.cs:223:25:223:46 | [finally: return] throw ...; |
 | pre | cflow.cs:223:31:223:45 | object creation of type Exception | cflow.cs:223:25:223:46 | throw ...; |
-| pre | cflow.cs:226:17:228:17 | [break] {...} | cflow.cs:227:21:227:24 | [break] ...; |
-| pre | cflow.cs:226:17:228:17 | [continue] {...} | cflow.cs:227:21:227:24 | [continue] ...; |
-| pre | cflow.cs:226:17:228:17 | [exception(Exception)] {...} | cflow.cs:227:21:227:24 | [exception(Exception)] ...; |
-| pre | cflow.cs:226:17:228:17 | [return] {...} | cflow.cs:227:21:227:24 | [return] ...; |
+| pre | cflow.cs:226:17:228:17 | [finally: break] {...} | cflow.cs:227:21:227:24 | [finally: break] ...; |
+| pre | cflow.cs:226:17:228:17 | [finally: continue] {...} | cflow.cs:227:21:227:24 | [finally: continue] ...; |
+| pre | cflow.cs:226:17:228:17 | [finally: exception(Exception)] {...} | cflow.cs:227:21:227:24 | [finally: exception(Exception)] ...; |
+| pre | cflow.cs:226:17:228:17 | [finally: return] {...} | cflow.cs:227:21:227:24 | [finally: return] ...; |
 | pre | cflow.cs:226:17:228:17 | {...} | cflow.cs:227:21:227:24 | ...; |
-| pre | cflow.cs:227:21:227:21 | [break] access to local variable i | cflow.cs:227:21:227:23 | [break] ...-- |
-| pre | cflow.cs:227:21:227:21 | [continue] access to local variable i | cflow.cs:227:21:227:23 | [continue] ...-- |
-| pre | cflow.cs:227:21:227:21 | [exception(Exception)] access to local variable i | cflow.cs:227:21:227:23 | [exception(Exception)] ...-- |
-| pre | cflow.cs:227:21:227:21 | [return] access to local variable i | cflow.cs:227:21:227:23 | [return] ...-- |
+| pre | cflow.cs:227:21:227:21 | [finally: break] access to local variable i | cflow.cs:227:21:227:23 | [finally: break] ...-- |
+| pre | cflow.cs:227:21:227:21 | [finally: continue] access to local variable i | cflow.cs:227:21:227:23 | [finally: continue] ...-- |
+| pre | cflow.cs:227:21:227:21 | [finally: exception(Exception)] access to local variable i | cflow.cs:227:21:227:23 | [finally: exception(Exception)] ...-- |
+| pre | cflow.cs:227:21:227:21 | [finally: return] access to local variable i | cflow.cs:227:21:227:23 | [finally: return] ...-- |
 | pre | cflow.cs:227:21:227:21 | access to local variable i | cflow.cs:227:21:227:23 | ...-- |
 | pre | cflow.cs:227:21:227:24 | ...; | cflow.cs:227:21:227:21 | access to local variable i |
-| pre | cflow.cs:227:21:227:24 | [break] ...; | cflow.cs:227:21:227:21 | [break] access to local variable i |
-| pre | cflow.cs:227:21:227:24 | [continue] ...; | cflow.cs:227:21:227:21 | [continue] access to local variable i |
-| pre | cflow.cs:227:21:227:24 | [exception(Exception)] ...; | cflow.cs:227:21:227:21 | [exception(Exception)] access to local variable i |
-| pre | cflow.cs:227:21:227:24 | [return] ...; | cflow.cs:227:21:227:21 | [return] access to local variable i |
+| pre | cflow.cs:227:21:227:24 | [finally: break] ...; | cflow.cs:227:21:227:21 | [finally: break] access to local variable i |
+| pre | cflow.cs:227:21:227:24 | [finally: continue] ...; | cflow.cs:227:21:227:21 | [finally: continue] access to local variable i |
+| pre | cflow.cs:227:21:227:24 | [finally: exception(Exception)] ...; | cflow.cs:227:21:227:21 | [finally: exception(Exception)] access to local variable i |
+| pre | cflow.cs:227:21:227:24 | [finally: return] ...; | cflow.cs:227:21:227:21 | [finally: return] access to local variable i |
 | pre | cflow.cs:232:9:245:9 | try {...} ... | cflow.cs:233:9:238:9 | {...} |
 | pre | cflow.cs:233:9:238:9 | {...} | cflow.cs:234:13:235:23 | if (...) ... |
 | pre | cflow.cs:234:13:235:23 | if (...) ... | cflow.cs:234:17:234:21 | this access |
 | pre | cflow.cs:234:17:234:21 | access to field Field | cflow.cs:234:17:234:28 | access to property Length |
-| pre | cflow.cs:234:17:234:21 | access to field Field | cflow.cs:240:9:245:9 | [exception(NullReferenceException)] {...} |
+| pre | cflow.cs:234:17:234:21 | access to field Field | cflow.cs:240:9:245:9 | [finally: exception(NullReferenceException)] {...} |
 | pre | cflow.cs:234:17:234:21 | this access | cflow.cs:234:17:234:21 | access to field Field |
 | pre | cflow.cs:234:17:234:28 | access to property Length | cflow.cs:234:33:234:33 | 0 |
-| pre | cflow.cs:234:17:234:28 | access to property Length | cflow.cs:240:9:245:9 | [exception(Exception)] {...} |
+| pre | cflow.cs:234:17:234:28 | access to property Length | cflow.cs:240:9:245:9 | [finally: exception(Exception)] {...} |
 | pre | cflow.cs:234:17:234:33 | ... == ... | cflow.cs:235:17:235:23 | return ...; |
 | pre | cflow.cs:234:17:234:33 | ... == ... | cflow.cs:236:13:237:49 | if (...) ... |
 | pre | cflow.cs:234:33:234:33 | 0 | cflow.cs:234:17:234:33 | ... == ... |
-| pre | cflow.cs:235:17:235:23 | return ...; | cflow.cs:240:9:245:9 | [return] {...} |
+| pre | cflow.cs:235:17:235:23 | return ...; | cflow.cs:240:9:245:9 | [finally: return] {...} |
 | pre | cflow.cs:236:13:237:49 | if (...) ... | cflow.cs:236:17:236:21 | this access |
 | pre | cflow.cs:236:17:236:21 | access to field Field | cflow.cs:236:17:236:28 | access to property Length |
 | pre | cflow.cs:236:17:236:21 | this access | cflow.cs:236:17:236:21 | access to field Field |
@@ -2982,108 +2990,108 @@
 | pre | cflow.cs:236:17:236:33 | ... == ... | cflow.cs:237:23:237:48 | object creation of type OutOfMemoryException |
 | pre | cflow.cs:236:17:236:33 | ... == ... | cflow.cs:240:9:245:9 | {...} |
 | pre | cflow.cs:236:33:236:33 | 1 | cflow.cs:236:17:236:33 | ... == ... |
-| pre | cflow.cs:237:17:237:49 | throw ...; | cflow.cs:240:9:245:9 | [exception(OutOfMemoryException)] {...} |
+| pre | cflow.cs:237:17:237:49 | throw ...; | cflow.cs:240:9:245:9 | [finally: exception(OutOfMemoryException)] {...} |
 | pre | cflow.cs:237:23:237:48 | object creation of type OutOfMemoryException | cflow.cs:237:17:237:49 | throw ...; |
-| pre | cflow.cs:240:9:245:9 | [exception(Exception)] {...} | cflow.cs:241:13:242:41 | [exception(Exception)] if (...) ... |
-| pre | cflow.cs:240:9:245:9 | [exception(NullReferenceException)] {...} | cflow.cs:241:13:242:41 | [exception(NullReferenceException)] if (...) ... |
-| pre | cflow.cs:240:9:245:9 | [exception(OutOfMemoryException)] {...} | cflow.cs:241:13:242:41 | [exception(OutOfMemoryException)] if (...) ... |
-| pre | cflow.cs:240:9:245:9 | [return] {...} | cflow.cs:241:13:242:41 | [return] if (...) ... |
+| pre | cflow.cs:240:9:245:9 | [finally: exception(Exception)] {...} | cflow.cs:241:13:242:41 | [finally: exception(Exception)] if (...) ... |
+| pre | cflow.cs:240:9:245:9 | [finally: exception(NullReferenceException)] {...} | cflow.cs:241:13:242:41 | [finally: exception(NullReferenceException)] if (...) ... |
+| pre | cflow.cs:240:9:245:9 | [finally: exception(OutOfMemoryException)] {...} | cflow.cs:241:13:242:41 | [finally: exception(OutOfMemoryException)] if (...) ... |
+| pre | cflow.cs:240:9:245:9 | [finally: return] {...} | cflow.cs:241:13:242:41 | [finally: return] if (...) ... |
 | pre | cflow.cs:240:9:245:9 | {...} | cflow.cs:241:13:242:41 | if (...) ... |
-| pre | cflow.cs:241:13:242:41 | [exception(Exception)] if (...) ... | cflow.cs:241:17:241:36 | [exception(Exception)] !... |
-| pre | cflow.cs:241:13:242:41 | [exception(NullReferenceException)] if (...) ... | cflow.cs:241:17:241:36 | [exception(NullReferenceException)] !... |
-| pre | cflow.cs:241:13:242:41 | [exception(OutOfMemoryException)] if (...) ... | cflow.cs:241:17:241:36 | [exception(OutOfMemoryException)] !... |
-| pre | cflow.cs:241:13:242:41 | [return] if (...) ... | cflow.cs:241:17:241:36 | [return] !... |
+| pre | cflow.cs:241:13:242:41 | [finally: exception(Exception)] if (...) ... | cflow.cs:241:17:241:36 | [finally: exception(Exception)] !... |
+| pre | cflow.cs:241:13:242:41 | [finally: exception(NullReferenceException)] if (...) ... | cflow.cs:241:17:241:36 | [finally: exception(NullReferenceException)] !... |
+| pre | cflow.cs:241:13:242:41 | [finally: exception(OutOfMemoryException)] if (...) ... | cflow.cs:241:17:241:36 | [finally: exception(OutOfMemoryException)] !... |
+| pre | cflow.cs:241:13:242:41 | [finally: return] if (...) ... | cflow.cs:241:17:241:36 | [finally: return] !... |
 | pre | cflow.cs:241:13:242:41 | if (...) ... | cflow.cs:241:17:241:36 | !... |
 | pre | cflow.cs:241:17:241:36 | !... | cflow.cs:241:19:241:23 | this access |
-| pre | cflow.cs:241:17:241:36 | [exception(Exception)] !... | cflow.cs:241:19:241:23 | [exception(Exception)] this access |
-| pre | cflow.cs:241:17:241:36 | [exception(NullReferenceException)] !... | cflow.cs:241:19:241:23 | [exception(NullReferenceException)] this access |
-| pre | cflow.cs:241:17:241:36 | [exception(OutOfMemoryException)] !... | cflow.cs:241:19:241:23 | [exception(OutOfMemoryException)] this access |
-| pre | cflow.cs:241:17:241:36 | [return] !... | cflow.cs:241:19:241:23 | [return] this access |
-| pre | cflow.cs:241:19:241:23 | [exception(Exception)] access to field Field | cflow.cs:241:19:241:30 | [exception(Exception)] access to property Length |
-| pre | cflow.cs:241:19:241:23 | [exception(Exception)] this access | cflow.cs:241:19:241:23 | [exception(Exception)] access to field Field |
-| pre | cflow.cs:241:19:241:23 | [exception(NullReferenceException)] access to field Field | cflow.cs:241:19:241:30 | [exception(NullReferenceException)] access to property Length |
-| pre | cflow.cs:241:19:241:23 | [exception(NullReferenceException)] this access | cflow.cs:241:19:241:23 | [exception(NullReferenceException)] access to field Field |
-| pre | cflow.cs:241:19:241:23 | [exception(OutOfMemoryException)] access to field Field | cflow.cs:241:19:241:30 | [exception(OutOfMemoryException)] access to property Length |
-| pre | cflow.cs:241:19:241:23 | [exception(OutOfMemoryException)] this access | cflow.cs:241:19:241:23 | [exception(OutOfMemoryException)] access to field Field |
-| pre | cflow.cs:241:19:241:23 | [return] access to field Field | cflow.cs:241:19:241:30 | [return] access to property Length |
-| pre | cflow.cs:241:19:241:23 | [return] this access | cflow.cs:241:19:241:23 | [return] access to field Field |
+| pre | cflow.cs:241:17:241:36 | [finally: exception(Exception)] !... | cflow.cs:241:19:241:23 | [finally: exception(Exception)] this access |
+| pre | cflow.cs:241:17:241:36 | [finally: exception(NullReferenceException)] !... | cflow.cs:241:19:241:23 | [finally: exception(NullReferenceException)] this access |
+| pre | cflow.cs:241:17:241:36 | [finally: exception(OutOfMemoryException)] !... | cflow.cs:241:19:241:23 | [finally: exception(OutOfMemoryException)] this access |
+| pre | cflow.cs:241:17:241:36 | [finally: return] !... | cflow.cs:241:19:241:23 | [finally: return] this access |
+| pre | cflow.cs:241:19:241:23 | [finally: exception(Exception)] access to field Field | cflow.cs:241:19:241:30 | [finally: exception(Exception)] access to property Length |
+| pre | cflow.cs:241:19:241:23 | [finally: exception(Exception)] this access | cflow.cs:241:19:241:23 | [finally: exception(Exception)] access to field Field |
+| pre | cflow.cs:241:19:241:23 | [finally: exception(NullReferenceException)] access to field Field | cflow.cs:241:19:241:30 | [finally: exception(NullReferenceException)] access to property Length |
+| pre | cflow.cs:241:19:241:23 | [finally: exception(NullReferenceException)] this access | cflow.cs:241:19:241:23 | [finally: exception(NullReferenceException)] access to field Field |
+| pre | cflow.cs:241:19:241:23 | [finally: exception(OutOfMemoryException)] access to field Field | cflow.cs:241:19:241:30 | [finally: exception(OutOfMemoryException)] access to property Length |
+| pre | cflow.cs:241:19:241:23 | [finally: exception(OutOfMemoryException)] this access | cflow.cs:241:19:241:23 | [finally: exception(OutOfMemoryException)] access to field Field |
+| pre | cflow.cs:241:19:241:23 | [finally: return] access to field Field | cflow.cs:241:19:241:30 | [finally: return] access to property Length |
+| pre | cflow.cs:241:19:241:23 | [finally: return] this access | cflow.cs:241:19:241:23 | [finally: return] access to field Field |
 | pre | cflow.cs:241:19:241:23 | access to field Field | cflow.cs:241:19:241:30 | access to property Length |
 | pre | cflow.cs:241:19:241:23 | this access | cflow.cs:241:19:241:23 | access to field Field |
-| pre | cflow.cs:241:19:241:30 | [exception(Exception)] access to property Length | cflow.cs:241:35:241:35 | [exception(Exception)] 0 |
-| pre | cflow.cs:241:19:241:30 | [exception(NullReferenceException)] access to property Length | cflow.cs:241:35:241:35 | [exception(NullReferenceException)] 0 |
-| pre | cflow.cs:241:19:241:30 | [exception(OutOfMemoryException)] access to property Length | cflow.cs:241:35:241:35 | [exception(OutOfMemoryException)] 0 |
-| pre | cflow.cs:241:19:241:30 | [return] access to property Length | cflow.cs:241:35:241:35 | [return] 0 |
+| pre | cflow.cs:241:19:241:30 | [finally: exception(Exception)] access to property Length | cflow.cs:241:35:241:35 | [finally: exception(Exception)] 0 |
+| pre | cflow.cs:241:19:241:30 | [finally: exception(NullReferenceException)] access to property Length | cflow.cs:241:35:241:35 | [finally: exception(NullReferenceException)] 0 |
+| pre | cflow.cs:241:19:241:30 | [finally: exception(OutOfMemoryException)] access to property Length | cflow.cs:241:35:241:35 | [finally: exception(OutOfMemoryException)] 0 |
+| pre | cflow.cs:241:19:241:30 | [finally: return] access to property Length | cflow.cs:241:35:241:35 | [finally: return] 0 |
 | pre | cflow.cs:241:19:241:30 | access to property Length | cflow.cs:241:35:241:35 | 0 |
 | pre | cflow.cs:241:19:241:35 | ... == ... | cflow.cs:242:17:242:41 | ...; |
 | pre | cflow.cs:241:19:241:35 | ... == ... | cflow.cs:243:13:244:37 | if (...) ... |
-| pre | cflow.cs:241:19:241:35 | [exception(Exception)] ... == ... | cflow.cs:242:17:242:41 | [exception(Exception)] ...; |
-| pre | cflow.cs:241:19:241:35 | [exception(Exception)] ... == ... | cflow.cs:243:13:244:37 | [exception(Exception)] if (...) ... |
-| pre | cflow.cs:241:19:241:35 | [exception(NullReferenceException)] ... == ... | cflow.cs:242:17:242:41 | [exception(NullReferenceException)] ...; |
-| pre | cflow.cs:241:19:241:35 | [exception(NullReferenceException)] ... == ... | cflow.cs:243:13:244:37 | [exception(NullReferenceException)] if (...) ... |
-| pre | cflow.cs:241:19:241:35 | [exception(OutOfMemoryException)] ... == ... | cflow.cs:242:17:242:41 | [exception(OutOfMemoryException)] ...; |
-| pre | cflow.cs:241:19:241:35 | [exception(OutOfMemoryException)] ... == ... | cflow.cs:243:13:244:37 | [exception(OutOfMemoryException)] if (...) ... |
-| pre | cflow.cs:241:19:241:35 | [return] ... == ... | cflow.cs:242:17:242:41 | [return] ...; |
-| pre | cflow.cs:241:19:241:35 | [return] ... == ... | cflow.cs:243:13:244:37 | [return] if (...) ... |
+| pre | cflow.cs:241:19:241:35 | [finally: exception(Exception)] ... == ... | cflow.cs:242:17:242:41 | [finally: exception(Exception)] ...; |
+| pre | cflow.cs:241:19:241:35 | [finally: exception(Exception)] ... == ... | cflow.cs:243:13:244:37 | [finally: exception(Exception)] if (...) ... |
+| pre | cflow.cs:241:19:241:35 | [finally: exception(NullReferenceException)] ... == ... | cflow.cs:242:17:242:41 | [finally: exception(NullReferenceException)] ...; |
+| pre | cflow.cs:241:19:241:35 | [finally: exception(NullReferenceException)] ... == ... | cflow.cs:243:13:244:37 | [finally: exception(NullReferenceException)] if (...) ... |
+| pre | cflow.cs:241:19:241:35 | [finally: exception(OutOfMemoryException)] ... == ... | cflow.cs:242:17:242:41 | [finally: exception(OutOfMemoryException)] ...; |
+| pre | cflow.cs:241:19:241:35 | [finally: exception(OutOfMemoryException)] ... == ... | cflow.cs:243:13:244:37 | [finally: exception(OutOfMemoryException)] if (...) ... |
+| pre | cflow.cs:241:19:241:35 | [finally: return] ... == ... | cflow.cs:242:17:242:41 | [finally: return] ...; |
+| pre | cflow.cs:241:19:241:35 | [finally: return] ... == ... | cflow.cs:243:13:244:37 | [finally: return] if (...) ... |
 | pre | cflow.cs:241:35:241:35 | 0 | cflow.cs:241:19:241:35 | ... == ... |
-| pre | cflow.cs:241:35:241:35 | [exception(Exception)] 0 | cflow.cs:241:19:241:35 | [exception(Exception)] ... == ... |
-| pre | cflow.cs:241:35:241:35 | [exception(NullReferenceException)] 0 | cflow.cs:241:19:241:35 | [exception(NullReferenceException)] ... == ... |
-| pre | cflow.cs:241:35:241:35 | [exception(OutOfMemoryException)] 0 | cflow.cs:241:19:241:35 | [exception(OutOfMemoryException)] ... == ... |
-| pre | cflow.cs:241:35:241:35 | [return] 0 | cflow.cs:241:19:241:35 | [return] ... == ... |
+| pre | cflow.cs:241:35:241:35 | [finally: exception(Exception)] 0 | cflow.cs:241:19:241:35 | [finally: exception(Exception)] ... == ... |
+| pre | cflow.cs:241:35:241:35 | [finally: exception(NullReferenceException)] 0 | cflow.cs:241:19:241:35 | [finally: exception(NullReferenceException)] ... == ... |
+| pre | cflow.cs:241:35:241:35 | [finally: exception(OutOfMemoryException)] 0 | cflow.cs:241:19:241:35 | [finally: exception(OutOfMemoryException)] ... == ... |
+| pre | cflow.cs:241:35:241:35 | [finally: return] 0 | cflow.cs:241:19:241:35 | [finally: return] ... == ... |
 | pre | cflow.cs:242:17:242:41 | ...; | cflow.cs:242:35:242:39 | this access |
-| pre | cflow.cs:242:17:242:41 | [exception(Exception)] ...; | cflow.cs:242:35:242:39 | [exception(Exception)] this access |
-| pre | cflow.cs:242:17:242:41 | [exception(NullReferenceException)] ...; | cflow.cs:242:35:242:39 | [exception(NullReferenceException)] this access |
-| pre | cflow.cs:242:17:242:41 | [exception(OutOfMemoryException)] ...; | cflow.cs:242:35:242:39 | [exception(OutOfMemoryException)] this access |
-| pre | cflow.cs:242:17:242:41 | [return] ...; | cflow.cs:242:35:242:39 | [return] this access |
-| pre | cflow.cs:242:35:242:39 | [exception(Exception)] access to field Field | cflow.cs:242:17:242:40 | [exception(Exception)] call to method WriteLine |
-| pre | cflow.cs:242:35:242:39 | [exception(Exception)] this access | cflow.cs:242:35:242:39 | [exception(Exception)] access to field Field |
-| pre | cflow.cs:242:35:242:39 | [exception(NullReferenceException)] access to field Field | cflow.cs:242:17:242:40 | [exception(NullReferenceException)] call to method WriteLine |
-| pre | cflow.cs:242:35:242:39 | [exception(NullReferenceException)] this access | cflow.cs:242:35:242:39 | [exception(NullReferenceException)] access to field Field |
-| pre | cflow.cs:242:35:242:39 | [exception(OutOfMemoryException)] access to field Field | cflow.cs:242:17:242:40 | [exception(OutOfMemoryException)] call to method WriteLine |
-| pre | cflow.cs:242:35:242:39 | [exception(OutOfMemoryException)] this access | cflow.cs:242:35:242:39 | [exception(OutOfMemoryException)] access to field Field |
-| pre | cflow.cs:242:35:242:39 | [return] access to field Field | cflow.cs:242:17:242:40 | [return] call to method WriteLine |
-| pre | cflow.cs:242:35:242:39 | [return] this access | cflow.cs:242:35:242:39 | [return] access to field Field |
+| pre | cflow.cs:242:17:242:41 | [finally: exception(Exception)] ...; | cflow.cs:242:35:242:39 | [finally: exception(Exception)] this access |
+| pre | cflow.cs:242:17:242:41 | [finally: exception(NullReferenceException)] ...; | cflow.cs:242:35:242:39 | [finally: exception(NullReferenceException)] this access |
+| pre | cflow.cs:242:17:242:41 | [finally: exception(OutOfMemoryException)] ...; | cflow.cs:242:35:242:39 | [finally: exception(OutOfMemoryException)] this access |
+| pre | cflow.cs:242:17:242:41 | [finally: return] ...; | cflow.cs:242:35:242:39 | [finally: return] this access |
+| pre | cflow.cs:242:35:242:39 | [finally: exception(Exception)] access to field Field | cflow.cs:242:17:242:40 | [finally: exception(Exception)] call to method WriteLine |
+| pre | cflow.cs:242:35:242:39 | [finally: exception(Exception)] this access | cflow.cs:242:35:242:39 | [finally: exception(Exception)] access to field Field |
+| pre | cflow.cs:242:35:242:39 | [finally: exception(NullReferenceException)] access to field Field | cflow.cs:242:17:242:40 | [finally: exception(NullReferenceException)] call to method WriteLine |
+| pre | cflow.cs:242:35:242:39 | [finally: exception(NullReferenceException)] this access | cflow.cs:242:35:242:39 | [finally: exception(NullReferenceException)] access to field Field |
+| pre | cflow.cs:242:35:242:39 | [finally: exception(OutOfMemoryException)] access to field Field | cflow.cs:242:17:242:40 | [finally: exception(OutOfMemoryException)] call to method WriteLine |
+| pre | cflow.cs:242:35:242:39 | [finally: exception(OutOfMemoryException)] this access | cflow.cs:242:35:242:39 | [finally: exception(OutOfMemoryException)] access to field Field |
+| pre | cflow.cs:242:35:242:39 | [finally: return] access to field Field | cflow.cs:242:17:242:40 | [finally: return] call to method WriteLine |
+| pre | cflow.cs:242:35:242:39 | [finally: return] this access | cflow.cs:242:35:242:39 | [finally: return] access to field Field |
 | pre | cflow.cs:242:35:242:39 | access to field Field | cflow.cs:242:17:242:40 | call to method WriteLine |
 | pre | cflow.cs:242:35:242:39 | this access | cflow.cs:242:35:242:39 | access to field Field |
-| pre | cflow.cs:243:13:244:37 | [exception(Exception)] if (...) ... | cflow.cs:243:17:243:21 | [exception(Exception)] this access |
-| pre | cflow.cs:243:13:244:37 | [exception(NullReferenceException)] if (...) ... | cflow.cs:243:17:243:21 | [exception(NullReferenceException)] this access |
-| pre | cflow.cs:243:13:244:37 | [exception(OutOfMemoryException)] if (...) ... | cflow.cs:243:17:243:21 | [exception(OutOfMemoryException)] this access |
-| pre | cflow.cs:243:13:244:37 | [return] if (...) ... | cflow.cs:243:17:243:21 | [return] this access |
+| pre | cflow.cs:243:13:244:37 | [finally: exception(Exception)] if (...) ... | cflow.cs:243:17:243:21 | [finally: exception(Exception)] this access |
+| pre | cflow.cs:243:13:244:37 | [finally: exception(NullReferenceException)] if (...) ... | cflow.cs:243:17:243:21 | [finally: exception(NullReferenceException)] this access |
+| pre | cflow.cs:243:13:244:37 | [finally: exception(OutOfMemoryException)] if (...) ... | cflow.cs:243:17:243:21 | [finally: exception(OutOfMemoryException)] this access |
+| pre | cflow.cs:243:13:244:37 | [finally: return] if (...) ... | cflow.cs:243:17:243:21 | [finally: return] this access |
 | pre | cflow.cs:243:13:244:37 | if (...) ... | cflow.cs:243:17:243:21 | this access |
-| pre | cflow.cs:243:17:243:21 | [exception(Exception)] access to field Field | cflow.cs:243:17:243:28 | [exception(Exception)] access to property Length |
-| pre | cflow.cs:243:17:243:21 | [exception(Exception)] this access | cflow.cs:243:17:243:21 | [exception(Exception)] access to field Field |
-| pre | cflow.cs:243:17:243:21 | [exception(NullReferenceException)] access to field Field | cflow.cs:243:17:243:28 | [exception(NullReferenceException)] access to property Length |
-| pre | cflow.cs:243:17:243:21 | [exception(NullReferenceException)] this access | cflow.cs:243:17:243:21 | [exception(NullReferenceException)] access to field Field |
-| pre | cflow.cs:243:17:243:21 | [exception(OutOfMemoryException)] access to field Field | cflow.cs:243:17:243:28 | [exception(OutOfMemoryException)] access to property Length |
-| pre | cflow.cs:243:17:243:21 | [exception(OutOfMemoryException)] this access | cflow.cs:243:17:243:21 | [exception(OutOfMemoryException)] access to field Field |
-| pre | cflow.cs:243:17:243:21 | [return] access to field Field | cflow.cs:243:17:243:28 | [return] access to property Length |
-| pre | cflow.cs:243:17:243:21 | [return] this access | cflow.cs:243:17:243:21 | [return] access to field Field |
+| pre | cflow.cs:243:17:243:21 | [finally: exception(Exception)] access to field Field | cflow.cs:243:17:243:28 | [finally: exception(Exception)] access to property Length |
+| pre | cflow.cs:243:17:243:21 | [finally: exception(Exception)] this access | cflow.cs:243:17:243:21 | [finally: exception(Exception)] access to field Field |
+| pre | cflow.cs:243:17:243:21 | [finally: exception(NullReferenceException)] access to field Field | cflow.cs:243:17:243:28 | [finally: exception(NullReferenceException)] access to property Length |
+| pre | cflow.cs:243:17:243:21 | [finally: exception(NullReferenceException)] this access | cflow.cs:243:17:243:21 | [finally: exception(NullReferenceException)] access to field Field |
+| pre | cflow.cs:243:17:243:21 | [finally: exception(OutOfMemoryException)] access to field Field | cflow.cs:243:17:243:28 | [finally: exception(OutOfMemoryException)] access to property Length |
+| pre | cflow.cs:243:17:243:21 | [finally: exception(OutOfMemoryException)] this access | cflow.cs:243:17:243:21 | [finally: exception(OutOfMemoryException)] access to field Field |
+| pre | cflow.cs:243:17:243:21 | [finally: return] access to field Field | cflow.cs:243:17:243:28 | [finally: return] access to property Length |
+| pre | cflow.cs:243:17:243:21 | [finally: return] this access | cflow.cs:243:17:243:21 | [finally: return] access to field Field |
 | pre | cflow.cs:243:17:243:21 | access to field Field | cflow.cs:243:17:243:28 | access to property Length |
 | pre | cflow.cs:243:17:243:21 | this access | cflow.cs:243:17:243:21 | access to field Field |
-| pre | cflow.cs:243:17:243:28 | [exception(Exception)] access to property Length | cflow.cs:243:32:243:32 | [exception(Exception)] 0 |
-| pre | cflow.cs:243:17:243:28 | [exception(NullReferenceException)] access to property Length | cflow.cs:243:32:243:32 | [exception(NullReferenceException)] 0 |
-| pre | cflow.cs:243:17:243:28 | [exception(OutOfMemoryException)] access to property Length | cflow.cs:243:32:243:32 | [exception(OutOfMemoryException)] 0 |
-| pre | cflow.cs:243:17:243:28 | [return] access to property Length | cflow.cs:243:32:243:32 | [return] 0 |
+| pre | cflow.cs:243:17:243:28 | [finally: exception(Exception)] access to property Length | cflow.cs:243:32:243:32 | [finally: exception(Exception)] 0 |
+| pre | cflow.cs:243:17:243:28 | [finally: exception(NullReferenceException)] access to property Length | cflow.cs:243:32:243:32 | [finally: exception(NullReferenceException)] 0 |
+| pre | cflow.cs:243:17:243:28 | [finally: exception(OutOfMemoryException)] access to property Length | cflow.cs:243:32:243:32 | [finally: exception(OutOfMemoryException)] 0 |
+| pre | cflow.cs:243:17:243:28 | [finally: return] access to property Length | cflow.cs:243:32:243:32 | [finally: return] 0 |
 | pre | cflow.cs:243:17:243:28 | access to property Length | cflow.cs:243:32:243:32 | 0 |
 | pre | cflow.cs:243:17:243:32 | ... > ... | cflow.cs:244:17:244:37 | ...; |
-| pre | cflow.cs:243:17:243:32 | [exception(Exception)] ... > ... | cflow.cs:244:17:244:37 | [exception(Exception)] ...; |
-| pre | cflow.cs:243:17:243:32 | [exception(NullReferenceException)] ... > ... | cflow.cs:244:17:244:37 | [exception(NullReferenceException)] ...; |
-| pre | cflow.cs:243:17:243:32 | [exception(OutOfMemoryException)] ... > ... | cflow.cs:244:17:244:37 | [exception(OutOfMemoryException)] ...; |
-| pre | cflow.cs:243:17:243:32 | [return] ... > ... | cflow.cs:244:17:244:37 | [return] ...; |
+| pre | cflow.cs:243:17:243:32 | [finally: exception(Exception)] ... > ... | cflow.cs:244:17:244:37 | [finally: exception(Exception)] ...; |
+| pre | cflow.cs:243:17:243:32 | [finally: exception(NullReferenceException)] ... > ... | cflow.cs:244:17:244:37 | [finally: exception(NullReferenceException)] ...; |
+| pre | cflow.cs:243:17:243:32 | [finally: exception(OutOfMemoryException)] ... > ... | cflow.cs:244:17:244:37 | [finally: exception(OutOfMemoryException)] ...; |
+| pre | cflow.cs:243:17:243:32 | [finally: return] ... > ... | cflow.cs:244:17:244:37 | [finally: return] ...; |
 | pre | cflow.cs:243:32:243:32 | 0 | cflow.cs:243:17:243:32 | ... > ... |
-| pre | cflow.cs:243:32:243:32 | [exception(Exception)] 0 | cflow.cs:243:17:243:32 | [exception(Exception)] ... > ... |
-| pre | cflow.cs:243:32:243:32 | [exception(NullReferenceException)] 0 | cflow.cs:243:17:243:32 | [exception(NullReferenceException)] ... > ... |
-| pre | cflow.cs:243:32:243:32 | [exception(OutOfMemoryException)] 0 | cflow.cs:243:17:243:32 | [exception(OutOfMemoryException)] ... > ... |
-| pre | cflow.cs:243:32:243:32 | [return] 0 | cflow.cs:243:17:243:32 | [return] ... > ... |
+| pre | cflow.cs:243:32:243:32 | [finally: exception(Exception)] 0 | cflow.cs:243:17:243:32 | [finally: exception(Exception)] ... > ... |
+| pre | cflow.cs:243:32:243:32 | [finally: exception(NullReferenceException)] 0 | cflow.cs:243:17:243:32 | [finally: exception(NullReferenceException)] ... > ... |
+| pre | cflow.cs:243:32:243:32 | [finally: exception(OutOfMemoryException)] 0 | cflow.cs:243:17:243:32 | [finally: exception(OutOfMemoryException)] ... > ... |
+| pre | cflow.cs:243:32:243:32 | [finally: return] 0 | cflow.cs:243:17:243:32 | [finally: return] ... > ... |
 | pre | cflow.cs:244:17:244:37 | ...; | cflow.cs:244:35:244:35 | 1 |
-| pre | cflow.cs:244:17:244:37 | [exception(Exception)] ...; | cflow.cs:244:35:244:35 | [exception(Exception)] 1 |
-| pre | cflow.cs:244:17:244:37 | [exception(NullReferenceException)] ...; | cflow.cs:244:35:244:35 | [exception(NullReferenceException)] 1 |
-| pre | cflow.cs:244:17:244:37 | [exception(OutOfMemoryException)] ...; | cflow.cs:244:35:244:35 | [exception(OutOfMemoryException)] 1 |
-| pre | cflow.cs:244:17:244:37 | [return] ...; | cflow.cs:244:35:244:35 | [return] 1 |
+| pre | cflow.cs:244:17:244:37 | [finally: exception(Exception)] ...; | cflow.cs:244:35:244:35 | [finally: exception(Exception)] 1 |
+| pre | cflow.cs:244:17:244:37 | [finally: exception(NullReferenceException)] ...; | cflow.cs:244:35:244:35 | [finally: exception(NullReferenceException)] 1 |
+| pre | cflow.cs:244:17:244:37 | [finally: exception(OutOfMemoryException)] ...; | cflow.cs:244:35:244:35 | [finally: exception(OutOfMemoryException)] 1 |
+| pre | cflow.cs:244:17:244:37 | [finally: return] ...; | cflow.cs:244:35:244:35 | [finally: return] 1 |
 | pre | cflow.cs:244:35:244:35 | 1 | cflow.cs:244:17:244:36 | call to method WriteLine |
-| pre | cflow.cs:244:35:244:35 | [exception(Exception)] 1 | cflow.cs:244:17:244:36 | [exception(Exception)] call to method WriteLine |
-| pre | cflow.cs:244:35:244:35 | [exception(NullReferenceException)] 1 | cflow.cs:244:17:244:36 | [exception(NullReferenceException)] call to method WriteLine |
-| pre | cflow.cs:244:35:244:35 | [exception(OutOfMemoryException)] 1 | cflow.cs:244:17:244:36 | [exception(OutOfMemoryException)] call to method WriteLine |
-| pre | cflow.cs:244:35:244:35 | [return] 1 | cflow.cs:244:17:244:36 | [return] call to method WriteLine |
+| pre | cflow.cs:244:35:244:35 | [finally: exception(Exception)] 1 | cflow.cs:244:17:244:36 | [finally: exception(Exception)] call to method WriteLine |
+| pre | cflow.cs:244:35:244:35 | [finally: exception(NullReferenceException)] 1 | cflow.cs:244:17:244:36 | [finally: exception(NullReferenceException)] call to method WriteLine |
+| pre | cflow.cs:244:35:244:35 | [finally: exception(OutOfMemoryException)] 1 | cflow.cs:244:17:244:36 | [finally: exception(OutOfMemoryException)] call to method WriteLine |
+| pre | cflow.cs:244:35:244:35 | [finally: return] 1 | cflow.cs:244:17:244:36 | [finally: return] call to method WriteLine |
 | pre | cflow.cs:248:10:248:12 | enter For | cflow.cs:249:5:279:5 | {...} |
 | pre | cflow.cs:249:5:279:5 | {...} | cflow.cs:250:9:250:18 | ... ...; |
 | pre | cflow.cs:250:9:250:18 | ... ...; | cflow.cs:250:13:250:13 | access to local variable x |
@@ -3372,11 +3380,11 @@
 | pre | cflow.cs:368:26:368:26 | access to local variable i | cflow.cs:368:13:368:27 | yield return ...; |
 | pre | cflow.cs:370:9:378:9 | try {...} ... | cflow.cs:371:9:374:9 | {...} |
 | pre | cflow.cs:371:9:374:9 | {...} | cflow.cs:372:13:372:24 | yield break; |
-| pre | cflow.cs:372:13:372:24 | yield break; | cflow.cs:376:9:378:9 | [return] {...} |
-| pre | cflow.cs:376:9:378:9 | [return] {...} | cflow.cs:377:13:377:42 | [return] ...; |
-| pre | cflow.cs:377:13:377:41 | [return] call to method WriteLine | cflow.cs:363:49:363:53 | exit Yield |
-| pre | cflow.cs:377:13:377:42 | [return] ...; | cflow.cs:377:31:377:40 | [return] "not dead" |
-| pre | cflow.cs:377:31:377:40 | [return] "not dead" | cflow.cs:377:13:377:41 | [return] call to method WriteLine |
+| pre | cflow.cs:372:13:372:24 | yield break; | cflow.cs:376:9:378:9 | [finally: return] {...} |
+| pre | cflow.cs:376:9:378:9 | [finally: return] {...} | cflow.cs:377:13:377:42 | [finally: return] ...; |
+| pre | cflow.cs:377:13:377:41 | [finally: return] call to method WriteLine | cflow.cs:363:49:363:53 | exit Yield |
+| pre | cflow.cs:377:13:377:42 | [finally: return] ...; | cflow.cs:377:31:377:40 | [finally: return] "not dead" |
+| pre | cflow.cs:377:31:377:40 | [finally: return] "not dead" | cflow.cs:377:13:377:41 | [finally: return] call to method WriteLine |
 | pre | cflow.cs:384:5:384:18 | enter ControlFlowSub | cflow.cs:384:24:384:27 | call to constructor ControlFlow |
 | pre | cflow.cs:384:24:384:27 | call to constructor ControlFlow | cflow.cs:384:31:384:33 | {...} |
 | pre | cflow.cs:384:31:384:33 | {...} | cflow.cs:384:5:384:18 | exit ControlFlowSub |
@@ -3392,20 +3400,20 @@
 | pre | cflow.cs:394:5:405:5 | {...} | cflow.cs:395:9:403:9 | try {...} ... |
 | pre | cflow.cs:395:9:403:9 | try {...} ... | cflow.cs:396:9:398:9 | {...} |
 | pre | cflow.cs:396:9:398:9 | {...} | cflow.cs:397:13:397:37 | ...; |
-| pre | cflow.cs:397:13:397:36 | call to method WriteLine | cflow.cs:400:9:403:9 | [exception(Exception)] {...} |
+| pre | cflow.cs:397:13:397:36 | call to method WriteLine | cflow.cs:400:9:403:9 | [finally: exception(Exception)] {...} |
 | pre | cflow.cs:397:13:397:36 | call to method WriteLine | cflow.cs:400:9:403:9 | {...} |
 | pre | cflow.cs:397:13:397:37 | ...; | cflow.cs:397:31:397:35 | "Try" |
 | pre | cflow.cs:397:31:397:35 | "Try" | cflow.cs:397:13:397:36 | call to method WriteLine |
-| pre | cflow.cs:397:31:397:35 | "Try" | cflow.cs:400:9:403:9 | [exception(OutOfMemoryException)] {...} |
-| pre | cflow.cs:400:9:403:9 | [exception(Exception)] {...} | cflow.cs:401:41:401:42 | [exception(Exception)] "" |
-| pre | cflow.cs:400:9:403:9 | [exception(OutOfMemoryException)] {...} | cflow.cs:401:41:401:42 | [exception(OutOfMemoryException)] "" |
+| pre | cflow.cs:397:31:397:35 | "Try" | cflow.cs:400:9:403:9 | [finally: exception(OutOfMemoryException)] {...} |
+| pre | cflow.cs:400:9:403:9 | [finally: exception(Exception)] {...} | cflow.cs:401:41:401:42 | [finally: exception(Exception)] "" |
+| pre | cflow.cs:400:9:403:9 | [finally: exception(OutOfMemoryException)] {...} | cflow.cs:401:41:401:42 | [finally: exception(OutOfMemoryException)] "" |
 | pre | cflow.cs:400:9:403:9 | {...} | cflow.cs:401:41:401:42 | "" |
-| pre | cflow.cs:401:19:401:43 | [exception(Exception)] object creation of type ArgumentException | cflow.cs:401:13:401:44 | [exception(Exception)] throw ...; |
-| pre | cflow.cs:401:19:401:43 | [exception(OutOfMemoryException)] object creation of type ArgumentException | cflow.cs:401:13:401:44 | [exception(OutOfMemoryException)] throw ...; |
+| pre | cflow.cs:401:19:401:43 | [finally: exception(Exception)] object creation of type ArgumentException | cflow.cs:401:13:401:44 | [finally: exception(Exception)] throw ...; |
+| pre | cflow.cs:401:19:401:43 | [finally: exception(OutOfMemoryException)] object creation of type ArgumentException | cflow.cs:401:13:401:44 | [finally: exception(OutOfMemoryException)] throw ...; |
 | pre | cflow.cs:401:19:401:43 | object creation of type ArgumentException | cflow.cs:401:13:401:44 | throw ...; |
 | pre | cflow.cs:401:41:401:42 | "" | cflow.cs:401:19:401:43 | object creation of type ArgumentException |
-| pre | cflow.cs:401:41:401:42 | [exception(Exception)] "" | cflow.cs:401:19:401:43 | [exception(Exception)] object creation of type ArgumentException |
-| pre | cflow.cs:401:41:401:42 | [exception(OutOfMemoryException)] "" | cflow.cs:401:19:401:43 | [exception(OutOfMemoryException)] object creation of type ArgumentException |
+| pre | cflow.cs:401:41:401:42 | [finally: exception(Exception)] "" | cflow.cs:401:19:401:43 | [finally: exception(Exception)] object creation of type ArgumentException |
+| pre | cflow.cs:401:41:401:42 | [finally: exception(OutOfMemoryException)] "" | cflow.cs:401:19:401:43 | [finally: exception(OutOfMemoryException)] object creation of type ArgumentException |
 | pre | cflow.cs:410:12:410:12 | enter M | cflow.cs:410:38:410:38 | access to parameter f |
 | pre | cflow.cs:410:38:410:38 | access to parameter f | cflow.cs:410:40:410:40 | 0 |
 | pre | cflow.cs:410:38:410:41 | delegate call | cflow.cs:410:12:410:12 | exit M |

--- a/csharp/ql/test/library-tests/controlflow/graph/Dominance.expected
+++ b/csharp/ql/test/library-tests/controlflow/graph/Dominance.expected
@@ -278,9 +278,9 @@
 | post | ExitMethods.cs:40:13:40:30 | call to method ErrorAlways | ExitMethods.cs:40:25:40:29 | false |
 | post | ExitMethods.cs:40:13:40:31 | ...; | ExitMethods.cs:39:9:41:9 | {...} |
 | post | ExitMethods.cs:40:25:40:29 | false | ExitMethods.cs:40:13:40:31 | ...; |
-| post | ExitMethods.cs:43:9:45:9 | {...} | ExitMethods.cs:42:9:45:9 | catch (...) {...} |
+| post | ExitMethods.cs:43:9:45:9 | {...} | ExitMethods.cs:42:9:45:9 | [exception: ArgumentException] catch (...) {...} |
 | post | ExitMethods.cs:44:13:44:19 | return ...; | ExitMethods.cs:43:9:45:9 | {...} |
-| post | ExitMethods.cs:47:9:49:9 | {...} | ExitMethods.cs:46:9:49:9 | catch (...) {...} |
+| post | ExitMethods.cs:47:9:49:9 | {...} | ExitMethods.cs:46:9:49:9 | [exception: Exception] catch (...) {...} |
 | post | ExitMethods.cs:48:13:48:19 | return ...; | ExitMethods.cs:47:9:49:9 | {...} |
 | post | ExitMethods.cs:52:17:52:26 | exit ErrorMaybe | ExitMethods.cs:54:13:54:13 | access to parameter b |
 | post | ExitMethods.cs:52:17:52:26 | exit ErrorMaybe | ExitMethods.cs:55:13:55:34 | throw ...; |
@@ -1109,12 +1109,11 @@
 | post | cflow.cs:158:9:161:9 | {...} | cflow.cs:157:9:187:9 | try {...} ... |
 | post | cflow.cs:159:13:159:38 | ...; | cflow.cs:158:9:161:9 | {...} |
 | post | cflow.cs:159:31:159:36 | "Try2" | cflow.cs:159:13:159:38 | ...; |
-| post | cflow.cs:162:38:162:39 | IOException ex | cflow.cs:162:9:165:9 | catch (...) {...} |
-| post | cflow.cs:162:48:162:51 | true | cflow.cs:162:38:162:39 | IOException ex |
-| post | cflow.cs:163:9:165:9 | {...} | cflow.cs:162:48:162:51 | true |
+| post | cflow.cs:162:48:162:51 | [exception: Exception] true | cflow.cs:162:38:162:39 | [exception: Exception] IOException ex |
+| post | cflow.cs:163:9:165:9 | {...} | cflow.cs:162:48:162:51 | [exception: Exception] true |
 | post | cflow.cs:164:13:164:18 | throw ...; | cflow.cs:163:9:165:9 | {...} |
-| post | cflow.cs:166:41:166:42 | ArgumentException ex | cflow.cs:166:9:176:9 | catch (...) {...} |
-| post | cflow.cs:167:9:176:9 | {...} | cflow.cs:166:41:166:42 | ArgumentException ex |
+| post | cflow.cs:166:9:176:9 | [exception: OutOfMemoryException] catch (...) {...} | cflow.cs:162:9:165:9 | [exception: OutOfMemoryException] catch (...) {...} |
+| post | cflow.cs:167:9:176:9 | {...} | cflow.cs:166:41:166:42 | [exception: Exception] ArgumentException ex |
 | post | cflow.cs:168:13:175:13 | try {...} ... | cflow.cs:167:9:176:9 | {...} |
 | post | cflow.cs:169:13:171:13 | {...} | cflow.cs:168:13:175:13 | try {...} ... |
 | post | cflow.cs:170:17:170:32 | if (...) ... | cflow.cs:169:13:171:13 | {...} |
@@ -1124,7 +1123,9 @@
 | post | cflow.cs:174:17:174:44 | [finally: exception(ArgumentException)] throw ...; | cflow.cs:174:23:174:43 | [finally: exception(ArgumentException)] object creation of type Exception |
 | post | cflow.cs:174:23:174:43 | [finally: exception(ArgumentException)] object creation of type Exception | cflow.cs:174:37:174:42 | [finally: exception(ArgumentException)] "Boo!" |
 | post | cflow.cs:174:37:174:42 | [finally: exception(ArgumentException)] "Boo!" | cflow.cs:173:13:175:13 | [finally: exception(ArgumentException)] {...} |
-| post | cflow.cs:178:9:179:9 | {...} | cflow.cs:177:9:179:9 | catch (...) {...} |
+| post | cflow.cs:177:9:179:9 | [exception: OutOfMemoryException] catch (...) {...} | cflow.cs:166:9:176:9 | [exception: OutOfMemoryException] catch (...) {...} |
+| post | cflow.cs:178:9:179:9 | {...} | cflow.cs:177:9:179:9 | [exception: Exception] catch (...) {...} |
+| post | cflow.cs:178:9:179:9 | {...} | cflow.cs:177:9:179:9 | [exception: OutOfMemoryException] catch (...) {...} |
 | post | cflow.cs:185:9:187:9 | [finally: exception(Exception)] {...} | cflow.cs:174:17:174:44 | [finally: exception(ArgumentException)] throw ...; |
 | post | cflow.cs:185:9:187:9 | [finally: exception(IOException)] {...} | cflow.cs:164:13:164:18 | throw ...; |
 | post | cflow.cs:185:9:187:9 | [finally: return] {...} | cflow.cs:160:13:160:19 | return ...; |
@@ -1145,16 +1146,20 @@
 | post | cflow.cs:190:9:193:9 | {...} | cflow.cs:189:9:204:9 | try {...} ... |
 | post | cflow.cs:191:13:191:38 | ...; | cflow.cs:190:9:193:9 | {...} |
 | post | cflow.cs:191:31:191:36 | "Try3" | cflow.cs:191:13:191:38 | ...; |
-| post | cflow.cs:194:38:194:39 | IOException ex | cflow.cs:194:9:197:9 | catch (...) {...} |
-| post | cflow.cs:194:48:194:51 | true | cflow.cs:194:38:194:39 | IOException ex |
-| post | cflow.cs:195:9:197:9 | {...} | cflow.cs:194:48:194:51 | true |
+| post | cflow.cs:194:48:194:51 | [exception: Exception] true | cflow.cs:194:38:194:39 | [exception: Exception] IOException ex |
+| post | cflow.cs:195:9:197:9 | {...} | cflow.cs:194:48:194:51 | [exception: Exception] true |
 | post | cflow.cs:196:13:196:18 | throw ...; | cflow.cs:195:9:197:9 | {...} |
-| post | cflow.cs:198:26:198:26 | Exception e | cflow.cs:198:9:200:9 | catch (...) {...} |
-| post | cflow.cs:198:35:198:35 | access to local variable e | cflow.cs:198:26:198:26 | Exception e |
-| post | cflow.cs:198:35:198:43 | access to property Message | cflow.cs:198:35:198:35 | access to local variable e |
-| post | cflow.cs:198:35:198:51 | ... != ... | cflow.cs:198:48:198:51 | null |
-| post | cflow.cs:198:48:198:51 | null | cflow.cs:198:35:198:43 | access to property Message |
-| post | cflow.cs:199:9:200:9 | {...} | cflow.cs:198:35:198:51 | ... != ... |
+| post | cflow.cs:198:9:200:9 | [exception: OutOfMemoryException] catch (...) {...} | cflow.cs:194:9:197:9 | [exception: OutOfMemoryException] catch (...) {...} |
+| post | cflow.cs:198:26:198:26 | [exception: Exception] Exception e | cflow.cs:198:9:200:9 | [exception: Exception] catch (...) {...} |
+| post | cflow.cs:198:26:198:26 | [exception: OutOfMemoryException] Exception e | cflow.cs:198:9:200:9 | [exception: OutOfMemoryException] catch (...) {...} |
+| post | cflow.cs:198:35:198:35 | [exception: Exception] access to local variable e | cflow.cs:198:26:198:26 | [exception: Exception] Exception e |
+| post | cflow.cs:198:35:198:35 | [exception: OutOfMemoryException] access to local variable e | cflow.cs:198:26:198:26 | [exception: OutOfMemoryException] Exception e |
+| post | cflow.cs:198:35:198:43 | [exception: Exception] access to property Message | cflow.cs:198:35:198:35 | [exception: Exception] access to local variable e |
+| post | cflow.cs:198:35:198:43 | [exception: OutOfMemoryException] access to property Message | cflow.cs:198:35:198:35 | [exception: OutOfMemoryException] access to local variable e |
+| post | cflow.cs:198:35:198:51 | [exception: Exception] ... != ... | cflow.cs:198:48:198:51 | [exception: Exception] null |
+| post | cflow.cs:198:35:198:51 | [exception: OutOfMemoryException] ... != ... | cflow.cs:198:48:198:51 | [exception: OutOfMemoryException] null |
+| post | cflow.cs:198:48:198:51 | [exception: Exception] null | cflow.cs:198:35:198:43 | [exception: Exception] access to property Message |
+| post | cflow.cs:198:48:198:51 | [exception: OutOfMemoryException] null | cflow.cs:198:35:198:43 | [exception: OutOfMemoryException] access to property Message |
 | post | cflow.cs:202:9:204:9 | [finally: exception(IOException)] {...} | cflow.cs:196:13:196:18 | throw ...; |
 | post | cflow.cs:202:9:204:9 | [finally: return] {...} | cflow.cs:192:13:192:19 | return ...; |
 | post | cflow.cs:202:9:204:9 | {...} | cflow.cs:199:9:200:9 | {...} |
@@ -1971,13 +1976,13 @@
 | pre | ExitMethods.cs:37:5:50:5 | {...} | ExitMethods.cs:38:9:49:9 | try {...} ... |
 | pre | ExitMethods.cs:38:9:49:9 | try {...} ... | ExitMethods.cs:39:9:41:9 | {...} |
 | pre | ExitMethods.cs:39:9:41:9 | {...} | ExitMethods.cs:40:13:40:31 | ...; |
-| pre | ExitMethods.cs:40:13:40:30 | call to method ErrorAlways | ExitMethods.cs:42:9:45:9 | catch (...) {...} |
-| pre | ExitMethods.cs:40:13:40:30 | call to method ErrorAlways | ExitMethods.cs:46:9:49:9 | catch (...) {...} |
+| pre | ExitMethods.cs:40:13:40:30 | call to method ErrorAlways | ExitMethods.cs:42:9:45:9 | [exception: ArgumentException] catch (...) {...} |
+| pre | ExitMethods.cs:40:13:40:30 | call to method ErrorAlways | ExitMethods.cs:42:9:45:9 | [exception: Exception] catch (...) {...} |
 | pre | ExitMethods.cs:40:13:40:31 | ...; | ExitMethods.cs:40:25:40:29 | false |
 | pre | ExitMethods.cs:40:25:40:29 | false | ExitMethods.cs:40:13:40:30 | call to method ErrorAlways |
-| pre | ExitMethods.cs:42:9:45:9 | catch (...) {...} | ExitMethods.cs:43:9:45:9 | {...} |
+| pre | ExitMethods.cs:42:9:45:9 | [exception: Exception] catch (...) {...} | ExitMethods.cs:46:9:49:9 | [exception: Exception] catch (...) {...} |
 | pre | ExitMethods.cs:43:9:45:9 | {...} | ExitMethods.cs:44:13:44:19 | return ...; |
-| pre | ExitMethods.cs:46:9:49:9 | catch (...) {...} | ExitMethods.cs:47:9:49:9 | {...} |
+| pre | ExitMethods.cs:46:9:49:9 | [exception: Exception] catch (...) {...} | ExitMethods.cs:47:9:49:9 | {...} |
 | pre | ExitMethods.cs:47:9:49:9 | {...} | ExitMethods.cs:48:13:48:19 | return ...; |
 | pre | ExitMethods.cs:52:17:52:26 | enter ErrorMaybe | ExitMethods.cs:53:5:56:5 | {...} |
 | pre | ExitMethods.cs:53:5:56:5 | {...} | ExitMethods.cs:54:9:55:34 | if (...) ... |
@@ -2814,19 +2819,22 @@
 | pre | cflow.cs:157:9:187:9 | try {...} ... | cflow.cs:158:9:161:9 | {...} |
 | pre | cflow.cs:158:9:161:9 | {...} | cflow.cs:159:13:159:38 | ...; |
 | pre | cflow.cs:159:13:159:37 | call to method WriteLine | cflow.cs:160:13:160:19 | return ...; |
-| pre | cflow.cs:159:13:159:37 | call to method WriteLine | cflow.cs:162:9:165:9 | catch (...) {...} |
-| pre | cflow.cs:159:13:159:37 | call to method WriteLine | cflow.cs:166:9:176:9 | catch (...) {...} |
+| pre | cflow.cs:159:13:159:37 | call to method WriteLine | cflow.cs:162:9:165:9 | [exception: Exception] catch (...) {...} |
 | pre | cflow.cs:159:13:159:38 | ...; | cflow.cs:159:31:159:36 | "Try2" |
 | pre | cflow.cs:159:31:159:36 | "Try2" | cflow.cs:159:13:159:37 | call to method WriteLine |
-| pre | cflow.cs:159:31:159:36 | "Try2" | cflow.cs:177:9:179:9 | catch (...) {...} |
+| pre | cflow.cs:159:31:159:36 | "Try2" | cflow.cs:162:9:165:9 | [exception: OutOfMemoryException] catch (...) {...} |
 | pre | cflow.cs:160:13:160:19 | return ...; | cflow.cs:185:9:187:9 | [finally: return] {...} |
-| pre | cflow.cs:162:9:165:9 | catch (...) {...} | cflow.cs:162:38:162:39 | IOException ex |
-| pre | cflow.cs:162:38:162:39 | IOException ex | cflow.cs:162:48:162:51 | true |
-| pre | cflow.cs:162:48:162:51 | true | cflow.cs:163:9:165:9 | {...} |
+| pre | cflow.cs:162:9:165:9 | [exception: Exception] catch (...) {...} | cflow.cs:162:38:162:39 | [exception: Exception] IOException ex |
+| pre | cflow.cs:162:9:165:9 | [exception: Exception] catch (...) {...} | cflow.cs:166:9:176:9 | [exception: Exception] catch (...) {...} |
+| pre | cflow.cs:162:9:165:9 | [exception: OutOfMemoryException] catch (...) {...} | cflow.cs:166:9:176:9 | [exception: OutOfMemoryException] catch (...) {...} |
+| pre | cflow.cs:162:38:162:39 | [exception: Exception] IOException ex | cflow.cs:162:48:162:51 | [exception: Exception] true |
+| pre | cflow.cs:162:48:162:51 | [exception: Exception] true | cflow.cs:163:9:165:9 | {...} |
 | pre | cflow.cs:163:9:165:9 | {...} | cflow.cs:164:13:164:18 | throw ...; |
 | pre | cflow.cs:164:13:164:18 | throw ...; | cflow.cs:185:9:187:9 | [finally: exception(IOException)] {...} |
-| pre | cflow.cs:166:9:176:9 | catch (...) {...} | cflow.cs:166:41:166:42 | ArgumentException ex |
-| pre | cflow.cs:166:41:166:42 | ArgumentException ex | cflow.cs:167:9:176:9 | {...} |
+| pre | cflow.cs:166:9:176:9 | [exception: Exception] catch (...) {...} | cflow.cs:166:41:166:42 | [exception: Exception] ArgumentException ex |
+| pre | cflow.cs:166:9:176:9 | [exception: Exception] catch (...) {...} | cflow.cs:177:9:179:9 | [exception: Exception] catch (...) {...} |
+| pre | cflow.cs:166:9:176:9 | [exception: OutOfMemoryException] catch (...) {...} | cflow.cs:177:9:179:9 | [exception: OutOfMemoryException] catch (...) {...} |
+| pre | cflow.cs:166:41:166:42 | [exception: Exception] ArgumentException ex | cflow.cs:167:9:176:9 | {...} |
 | pre | cflow.cs:167:9:176:9 | {...} | cflow.cs:168:13:175:13 | try {...} ... |
 | pre | cflow.cs:168:13:175:13 | try {...} ... | cflow.cs:169:13:171:13 | {...} |
 | pre | cflow.cs:169:13:171:13 | {...} | cflow.cs:170:17:170:32 | if (...) ... |
@@ -2837,7 +2845,6 @@
 | pre | cflow.cs:174:17:174:44 | [finally: exception(ArgumentException)] throw ...; | cflow.cs:185:9:187:9 | [finally: exception(Exception)] {...} |
 | pre | cflow.cs:174:23:174:43 | [finally: exception(ArgumentException)] object creation of type Exception | cflow.cs:174:17:174:44 | [finally: exception(ArgumentException)] throw ...; |
 | pre | cflow.cs:174:37:174:42 | [finally: exception(ArgumentException)] "Boo!" | cflow.cs:174:23:174:43 | [finally: exception(ArgumentException)] object creation of type Exception |
-| pre | cflow.cs:177:9:179:9 | catch (...) {...} | cflow.cs:178:9:179:9 | {...} |
 | pre | cflow.cs:178:9:179:9 | {...} | cflow.cs:185:9:187:9 | {...} |
 | pre | cflow.cs:185:9:187:9 | [finally: exception(Exception)] {...} | cflow.cs:186:13:186:41 | [finally: exception(Exception)] ...; |
 | pre | cflow.cs:185:9:187:9 | [finally: exception(IOException)] {...} | cflow.cs:186:13:186:41 | [finally: exception(IOException)] ...; |
@@ -2855,24 +2862,30 @@
 | pre | cflow.cs:189:9:204:9 | try {...} ... | cflow.cs:190:9:193:9 | {...} |
 | pre | cflow.cs:190:9:193:9 | {...} | cflow.cs:191:13:191:38 | ...; |
 | pre | cflow.cs:191:13:191:37 | call to method WriteLine | cflow.cs:192:13:192:19 | return ...; |
-| pre | cflow.cs:191:13:191:37 | call to method WriteLine | cflow.cs:194:9:197:9 | catch (...) {...} |
-| pre | cflow.cs:191:13:191:37 | call to method WriteLine | cflow.cs:198:9:200:9 | catch (...) {...} |
-| pre | cflow.cs:191:13:191:37 | call to method WriteLine | cflow.cs:202:9:204:9 | [finally: exception(Exception)] {...} |
+| pre | cflow.cs:191:13:191:37 | call to method WriteLine | cflow.cs:194:9:197:9 | [exception: Exception] catch (...) {...} |
 | pre | cflow.cs:191:13:191:38 | ...; | cflow.cs:191:31:191:36 | "Try3" |
 | pre | cflow.cs:191:31:191:36 | "Try3" | cflow.cs:191:13:191:37 | call to method WriteLine |
-| pre | cflow.cs:191:31:191:36 | "Try3" | cflow.cs:202:9:204:9 | [finally: exception(OutOfMemoryException)] {...} |
+| pre | cflow.cs:191:31:191:36 | "Try3" | cflow.cs:194:9:197:9 | [exception: OutOfMemoryException] catch (...) {...} |
 | pre | cflow.cs:192:13:192:19 | return ...; | cflow.cs:202:9:204:9 | [finally: return] {...} |
-| pre | cflow.cs:194:9:197:9 | catch (...) {...} | cflow.cs:194:38:194:39 | IOException ex |
-| pre | cflow.cs:194:38:194:39 | IOException ex | cflow.cs:194:48:194:51 | true |
-| pre | cflow.cs:194:48:194:51 | true | cflow.cs:195:9:197:9 | {...} |
+| pre | cflow.cs:194:9:197:9 | [exception: Exception] catch (...) {...} | cflow.cs:194:38:194:39 | [exception: Exception] IOException ex |
+| pre | cflow.cs:194:9:197:9 | [exception: Exception] catch (...) {...} | cflow.cs:198:9:200:9 | [exception: Exception] catch (...) {...} |
+| pre | cflow.cs:194:9:197:9 | [exception: OutOfMemoryException] catch (...) {...} | cflow.cs:198:9:200:9 | [exception: OutOfMemoryException] catch (...) {...} |
+| pre | cflow.cs:194:38:194:39 | [exception: Exception] IOException ex | cflow.cs:194:48:194:51 | [exception: Exception] true |
+| pre | cflow.cs:194:48:194:51 | [exception: Exception] true | cflow.cs:195:9:197:9 | {...} |
 | pre | cflow.cs:195:9:197:9 | {...} | cflow.cs:196:13:196:18 | throw ...; |
 | pre | cflow.cs:196:13:196:18 | throw ...; | cflow.cs:202:9:204:9 | [finally: exception(IOException)] {...} |
-| pre | cflow.cs:198:9:200:9 | catch (...) {...} | cflow.cs:198:26:198:26 | Exception e |
-| pre | cflow.cs:198:26:198:26 | Exception e | cflow.cs:198:35:198:35 | access to local variable e |
-| pre | cflow.cs:198:35:198:35 | access to local variable e | cflow.cs:198:35:198:43 | access to property Message |
-| pre | cflow.cs:198:35:198:43 | access to property Message | cflow.cs:198:48:198:51 | null |
-| pre | cflow.cs:198:35:198:51 | ... != ... | cflow.cs:199:9:200:9 | {...} |
-| pre | cflow.cs:198:48:198:51 | null | cflow.cs:198:35:198:51 | ... != ... |
+| pre | cflow.cs:198:9:200:9 | [exception: Exception] catch (...) {...} | cflow.cs:198:26:198:26 | [exception: Exception] Exception e |
+| pre | cflow.cs:198:9:200:9 | [exception: OutOfMemoryException] catch (...) {...} | cflow.cs:198:26:198:26 | [exception: OutOfMemoryException] Exception e |
+| pre | cflow.cs:198:26:198:26 | [exception: Exception] Exception e | cflow.cs:198:35:198:35 | [exception: Exception] access to local variable e |
+| pre | cflow.cs:198:26:198:26 | [exception: OutOfMemoryException] Exception e | cflow.cs:198:35:198:35 | [exception: OutOfMemoryException] access to local variable e |
+| pre | cflow.cs:198:35:198:35 | [exception: Exception] access to local variable e | cflow.cs:198:35:198:43 | [exception: Exception] access to property Message |
+| pre | cflow.cs:198:35:198:35 | [exception: OutOfMemoryException] access to local variable e | cflow.cs:198:35:198:43 | [exception: OutOfMemoryException] access to property Message |
+| pre | cflow.cs:198:35:198:43 | [exception: Exception] access to property Message | cflow.cs:198:48:198:51 | [exception: Exception] null |
+| pre | cflow.cs:198:35:198:43 | [exception: OutOfMemoryException] access to property Message | cflow.cs:198:48:198:51 | [exception: OutOfMemoryException] null |
+| pre | cflow.cs:198:35:198:51 | [exception: Exception] ... != ... | cflow.cs:202:9:204:9 | [finally: exception(Exception)] {...} |
+| pre | cflow.cs:198:35:198:51 | [exception: OutOfMemoryException] ... != ... | cflow.cs:202:9:204:9 | [finally: exception(OutOfMemoryException)] {...} |
+| pre | cflow.cs:198:48:198:51 | [exception: Exception] null | cflow.cs:198:35:198:51 | [exception: Exception] ... != ... |
+| pre | cflow.cs:198:48:198:51 | [exception: OutOfMemoryException] null | cflow.cs:198:35:198:51 | [exception: OutOfMemoryException] ... != ... |
 | pre | cflow.cs:199:9:200:9 | {...} | cflow.cs:202:9:204:9 | {...} |
 | pre | cflow.cs:202:9:204:9 | [finally: exception(Exception)] {...} | cflow.cs:203:13:203:41 | [finally: exception(Exception)] ...; |
 | pre | cflow.cs:202:9:204:9 | [finally: exception(IOException)] {...} | cflow.cs:203:13:203:41 | [finally: exception(IOException)] ...; |

--- a/csharp/ql/test/library-tests/controlflow/graph/ElementGraph.expected
+++ b/csharp/ql/test/library-tests/controlflow/graph/ElementGraph.expected
@@ -131,6 +131,47 @@
 | BreakInTry.cs:67:21:67:31 | ... == ... | BreakInTry.cs:65:13:69:13 | foreach (... ... in ...) ... | semmle.label | false |
 | BreakInTry.cs:67:21:67:31 | ... == ... | BreakInTry.cs:68:21:68:26 | break; | semmle.label | true |
 | BreakInTry.cs:67:28:67:31 | null | BreakInTry.cs:67:21:67:31 | ... == ... | semmle.label | successor |
+| CatchInFinally.cs:6:5:28:5 | {...} | CatchInFinally.cs:7:9:27:9 | try {...} ... | semmle.label | successor |
+| CatchInFinally.cs:7:9:27:9 | try {...} ... | CatchInFinally.cs:8:9:11:9 | {...} | semmle.label | successor |
+| CatchInFinally.cs:8:9:11:9 | {...} | CatchInFinally.cs:9:13:10:50 | if (...) ... | semmle.label | successor |
+| CatchInFinally.cs:9:13:10:50 | if (...) ... | CatchInFinally.cs:9:17:9:20 | access to parameter args | semmle.label | successor |
+| CatchInFinally.cs:9:17:9:20 | access to parameter args | CatchInFinally.cs:9:25:9:28 | null | semmle.label | successor |
+| CatchInFinally.cs:9:17:9:28 | ... == ... | CatchInFinally.cs:10:23:10:49 | object creation of type ArgumentNullException | semmle.label | true |
+| CatchInFinally.cs:9:17:9:28 | ... == ... | CatchInFinally.cs:13:9:27:9 | {...} | semmle.label | false |
+| CatchInFinally.cs:9:25:9:28 | null | CatchInFinally.cs:9:17:9:28 | ... == ... | semmle.label | successor |
+| CatchInFinally.cs:10:17:10:50 | throw ...; | CatchInFinally.cs:13:9:27:9 | {...} | semmle.label | exception(ArgumentNullException) |
+| CatchInFinally.cs:10:23:10:49 | object creation of type ArgumentNullException | CatchInFinally.cs:10:17:10:50 | throw ...; | semmle.label | successor |
+| CatchInFinally.cs:10:23:10:49 | object creation of type ArgumentNullException | CatchInFinally.cs:13:9:27:9 | {...} | semmle.label | exception(Exception) |
+| CatchInFinally.cs:13:9:27:9 | {...} | CatchInFinally.cs:14:13:26:13 | try {...} ... | semmle.label | successor |
+| CatchInFinally.cs:14:13:26:13 | try {...} ... | CatchInFinally.cs:15:13:18:13 | {...} | semmle.label | successor |
+| CatchInFinally.cs:15:13:18:13 | {...} | CatchInFinally.cs:16:17:17:45 | if (...) ... | semmle.label | successor |
+| CatchInFinally.cs:16:17:17:45 | if (...) ... | CatchInFinally.cs:16:21:16:24 | access to parameter args | semmle.label | successor |
+| CatchInFinally.cs:16:21:16:24 | access to parameter args | CatchInFinally.cs:16:21:16:31 | access to property Length | semmle.label | successor |
+| CatchInFinally.cs:16:21:16:31 | access to property Length | CatchInFinally.cs:16:36:16:36 | 1 | semmle.label | successor |
+| CatchInFinally.cs:16:21:16:31 | access to property Length | CatchInFinally.cs:19:13:22:13 | catch (...) {...} | semmle.label | exception(Exception) |
+| CatchInFinally.cs:16:21:16:31 | access to property Length | CatchInFinally.cs:19:13:22:13 | catch (...) {...} | semmle.label | exception(NullReferenceException) |
+| CatchInFinally.cs:16:21:16:36 | ... == ... | CatchInFinally.cs:17:41:17:43 | "1" | semmle.label | true |
+| CatchInFinally.cs:16:36:16:36 | 1 | CatchInFinally.cs:16:21:16:36 | ... == ... | semmle.label | successor |
+| CatchInFinally.cs:17:21:17:45 | throw ...; | CatchInFinally.cs:19:13:22:13 | catch (...) {...} | semmle.label | exception(Exception) |
+| CatchInFinally.cs:17:27:17:44 | object creation of type Exception | CatchInFinally.cs:17:21:17:45 | throw ...; | semmle.label | successor |
+| CatchInFinally.cs:17:27:17:44 | object creation of type Exception | CatchInFinally.cs:19:13:22:13 | catch (...) {...} | semmle.label | exception(Exception) |
+| CatchInFinally.cs:17:41:17:43 | "1" | CatchInFinally.cs:17:27:17:44 | object creation of type Exception | semmle.label | successor |
+| CatchInFinally.cs:19:13:22:13 | catch (...) {...} | CatchInFinally.cs:19:30:19:30 | Exception e | semmle.label | match |
+| CatchInFinally.cs:19:30:19:30 | Exception e | CatchInFinally.cs:19:39:19:39 | access to local variable e | semmle.label | successor |
+| CatchInFinally.cs:19:39:19:39 | access to local variable e | CatchInFinally.cs:19:39:19:47 | access to property Message | semmle.label | successor |
+| CatchInFinally.cs:19:39:19:47 | access to property Message | CatchInFinally.cs:19:52:19:54 | "1" | semmle.label | successor |
+| CatchInFinally.cs:19:39:19:54 | ... == ... | CatchInFinally.cs:20:13:22:13 | {...} | semmle.label | true |
+| CatchInFinally.cs:19:39:19:54 | ... == ... | CatchInFinally.cs:23:13:26:13 | catch {...} | semmle.label | false |
+| CatchInFinally.cs:19:52:19:54 | "1" | CatchInFinally.cs:19:39:19:54 | ... == ... | semmle.label | successor |
+| CatchInFinally.cs:20:13:22:13 | {...} | CatchInFinally.cs:21:17:21:43 | ...; | semmle.label | successor |
+| CatchInFinally.cs:21:17:21:43 | ...; | CatchInFinally.cs:21:35:21:38 | access to parameter args | semmle.label | successor |
+| CatchInFinally.cs:21:35:21:38 | access to parameter args | CatchInFinally.cs:21:40:21:40 | 0 | semmle.label | successor |
+| CatchInFinally.cs:21:35:21:41 | access to array element | CatchInFinally.cs:21:17:21:42 | call to method WriteLine | semmle.label | successor |
+| CatchInFinally.cs:21:40:21:40 | 0 | CatchInFinally.cs:21:35:21:41 | access to array element | semmle.label | successor |
+| CatchInFinally.cs:23:13:26:13 | catch {...} | CatchInFinally.cs:24:13:26:13 | {...} | semmle.label | successor |
+| CatchInFinally.cs:24:13:26:13 | {...} | CatchInFinally.cs:25:17:25:38 | ...; | semmle.label | successor |
+| CatchInFinally.cs:25:17:25:38 | ...; | CatchInFinally.cs:25:35:25:36 | "" | semmle.label | successor |
+| CatchInFinally.cs:25:35:25:36 | "" | CatchInFinally.cs:25:17:25:37 | call to method WriteLine | semmle.label | successor |
 | CompileTimeOperators.cs:6:5:8:5 | {...} | CompileTimeOperators.cs:7:16:7:27 | default(...) | semmle.label | successor |
 | CompileTimeOperators.cs:7:16:7:27 | default(...) | CompileTimeOperators.cs:7:9:7:28 | return ...; | semmle.label | successor |
 | CompileTimeOperators.cs:11:5:13:5 | {...} | CompileTimeOperators.cs:12:16:12:26 | sizeof(..) | semmle.label | successor |

--- a/csharp/ql/test/library-tests/controlflow/graph/ElementGraph.expected
+++ b/csharp/ql/test/library-tests/controlflow/graph/ElementGraph.expected
@@ -217,12 +217,12 @@
 | ExitMethods.cs:39:9:41:9 | {...} | ExitMethods.cs:40:13:40:31 | ...; | semmle.label | successor |
 | ExitMethods.cs:40:13:40:30 | call to method ErrorAlways | ExitMethods.cs:42:9:45:9 | catch (...) {...} | semmle.label | exception(ArgumentException) |
 | ExitMethods.cs:40:13:40:30 | call to method ErrorAlways | ExitMethods.cs:42:9:45:9 | catch (...) {...} | semmle.label | exception(Exception) |
-| ExitMethods.cs:40:13:40:30 | call to method ErrorAlways | ExitMethods.cs:46:9:49:9 | catch (...) {...} | semmle.label | exception(Exception) |
 | ExitMethods.cs:40:13:40:31 | ...; | ExitMethods.cs:40:25:40:29 | false | semmle.label | successor |
 | ExitMethods.cs:40:25:40:29 | false | ExitMethods.cs:40:13:40:30 | call to method ErrorAlways | semmle.label | successor |
-| ExitMethods.cs:42:9:45:9 | catch (...) {...} | ExitMethods.cs:43:9:45:9 | {...} | semmle.label | successor |
+| ExitMethods.cs:42:9:45:9 | catch (...) {...} | ExitMethods.cs:43:9:45:9 | {...} | semmle.label | match |
+| ExitMethods.cs:42:9:45:9 | catch (...) {...} | ExitMethods.cs:46:9:49:9 | catch (...) {...} | semmle.label | no-match |
 | ExitMethods.cs:43:9:45:9 | {...} | ExitMethods.cs:44:13:44:19 | return ...; | semmle.label | successor |
-| ExitMethods.cs:46:9:49:9 | catch (...) {...} | ExitMethods.cs:47:9:49:9 | {...} | semmle.label | successor |
+| ExitMethods.cs:46:9:49:9 | catch (...) {...} | ExitMethods.cs:47:9:49:9 | {...} | semmle.label | match |
 | ExitMethods.cs:47:9:49:9 | {...} | ExitMethods.cs:48:13:48:19 | return ...; | semmle.label | successor |
 | ExitMethods.cs:53:5:56:5 | {...} | ExitMethods.cs:54:9:55:34 | if (...) ... | semmle.label | successor |
 | ExitMethods.cs:54:9:55:34 | if (...) ... | ExitMethods.cs:54:13:54:13 | access to parameter b | semmle.label | successor |
@@ -1010,18 +1010,18 @@
 | cflow.cs:158:9:161:9 | {...} | cflow.cs:159:13:159:38 | ...; | semmle.label | successor |
 | cflow.cs:159:13:159:37 | call to method WriteLine | cflow.cs:160:13:160:19 | return ...; | semmle.label | successor |
 | cflow.cs:159:13:159:37 | call to method WriteLine | cflow.cs:162:9:165:9 | catch (...) {...} | semmle.label | exception(Exception) |
-| cflow.cs:159:13:159:37 | call to method WriteLine | cflow.cs:166:9:176:9 | catch (...) {...} | semmle.label | exception(Exception) |
-| cflow.cs:159:13:159:37 | call to method WriteLine | cflow.cs:177:9:179:9 | catch (...) {...} | semmle.label | exception(Exception) |
 | cflow.cs:159:13:159:38 | ...; | cflow.cs:159:31:159:36 | "Try2" | semmle.label | successor |
 | cflow.cs:159:31:159:36 | "Try2" | cflow.cs:159:13:159:37 | call to method WriteLine | semmle.label | successor |
-| cflow.cs:159:31:159:36 | "Try2" | cflow.cs:177:9:179:9 | catch (...) {...} | semmle.label | exception(OutOfMemoryException) |
+| cflow.cs:159:31:159:36 | "Try2" | cflow.cs:162:9:165:9 | catch (...) {...} | semmle.label | exception(OutOfMemoryException) |
 | cflow.cs:160:13:160:19 | return ...; | cflow.cs:185:9:187:9 | {...} | semmle.label | return |
-| cflow.cs:162:9:165:9 | catch (...) {...} | cflow.cs:162:38:162:39 | IOException ex | semmle.label | successor |
+| cflow.cs:162:9:165:9 | catch (...) {...} | cflow.cs:162:38:162:39 | IOException ex | semmle.label | match |
+| cflow.cs:162:9:165:9 | catch (...) {...} | cflow.cs:166:9:176:9 | catch (...) {...} | semmle.label | no-match |
 | cflow.cs:162:38:162:39 | IOException ex | cflow.cs:162:48:162:51 | true | semmle.label | successor |
-| cflow.cs:162:48:162:51 | true | cflow.cs:163:9:165:9 | {...} | semmle.label | successor |
+| cflow.cs:162:48:162:51 | true | cflow.cs:163:9:165:9 | {...} | semmle.label | true |
 | cflow.cs:163:9:165:9 | {...} | cflow.cs:164:13:164:18 | throw ...; | semmle.label | successor |
 | cflow.cs:164:13:164:18 | throw ...; | cflow.cs:185:9:187:9 | {...} | semmle.label | exception(IOException) |
-| cflow.cs:166:9:176:9 | catch (...) {...} | cflow.cs:166:41:166:42 | ArgumentException ex | semmle.label | successor |
+| cflow.cs:166:9:176:9 | catch (...) {...} | cflow.cs:166:41:166:42 | ArgumentException ex | semmle.label | match |
+| cflow.cs:166:9:176:9 | catch (...) {...} | cflow.cs:177:9:179:9 | catch (...) {...} | semmle.label | no-match |
 | cflow.cs:166:41:166:42 | ArgumentException ex | cflow.cs:167:9:176:9 | {...} | semmle.label | successor |
 | cflow.cs:167:9:176:9 | {...} | cflow.cs:168:13:175:13 | try {...} ... | semmle.label | successor |
 | cflow.cs:168:13:175:13 | try {...} ... | cflow.cs:169:13:171:13 | {...} | semmle.label | successor |
@@ -1033,7 +1033,7 @@
 | cflow.cs:174:17:174:44 | throw ...; | cflow.cs:185:9:187:9 | {...} | semmle.label | exception(Exception) |
 | cflow.cs:174:23:174:43 | object creation of type Exception | cflow.cs:174:17:174:44 | throw ...; | semmle.label | successor |
 | cflow.cs:174:37:174:42 | "Boo!" | cflow.cs:174:23:174:43 | object creation of type Exception | semmle.label | successor |
-| cflow.cs:177:9:179:9 | catch (...) {...} | cflow.cs:178:9:179:9 | {...} | semmle.label | successor |
+| cflow.cs:177:9:179:9 | catch (...) {...} | cflow.cs:178:9:179:9 | {...} | semmle.label | match |
 | cflow.cs:178:9:179:9 | {...} | cflow.cs:185:9:187:9 | {...} | semmle.label | successor |
 | cflow.cs:185:9:187:9 | {...} | cflow.cs:186:13:186:41 | ...; | semmle.label | successor |
 | cflow.cs:186:13:186:40 | call to method WriteLine | cflow.cs:189:9:204:9 | try {...} ... | semmle.label | successor |
@@ -1043,22 +1043,23 @@
 | cflow.cs:190:9:193:9 | {...} | cflow.cs:191:13:191:38 | ...; | semmle.label | successor |
 | cflow.cs:191:13:191:37 | call to method WriteLine | cflow.cs:192:13:192:19 | return ...; | semmle.label | successor |
 | cflow.cs:191:13:191:37 | call to method WriteLine | cflow.cs:194:9:197:9 | catch (...) {...} | semmle.label | exception(Exception) |
-| cflow.cs:191:13:191:37 | call to method WriteLine | cflow.cs:198:9:200:9 | catch (...) {...} | semmle.label | exception(Exception) |
-| cflow.cs:191:13:191:37 | call to method WriteLine | cflow.cs:202:9:204:9 | {...} | semmle.label | exception(Exception) |
 | cflow.cs:191:13:191:38 | ...; | cflow.cs:191:31:191:36 | "Try3" | semmle.label | successor |
 | cflow.cs:191:31:191:36 | "Try3" | cflow.cs:191:13:191:37 | call to method WriteLine | semmle.label | successor |
-| cflow.cs:191:31:191:36 | "Try3" | cflow.cs:202:9:204:9 | {...} | semmle.label | exception(OutOfMemoryException) |
+| cflow.cs:191:31:191:36 | "Try3" | cflow.cs:194:9:197:9 | catch (...) {...} | semmle.label | exception(OutOfMemoryException) |
 | cflow.cs:192:13:192:19 | return ...; | cflow.cs:202:9:204:9 | {...} | semmle.label | return |
-| cflow.cs:194:9:197:9 | catch (...) {...} | cflow.cs:194:38:194:39 | IOException ex | semmle.label | successor |
+| cflow.cs:194:9:197:9 | catch (...) {...} | cflow.cs:194:38:194:39 | IOException ex | semmle.label | match |
+| cflow.cs:194:9:197:9 | catch (...) {...} | cflow.cs:198:9:200:9 | catch (...) {...} | semmle.label | no-match |
 | cflow.cs:194:38:194:39 | IOException ex | cflow.cs:194:48:194:51 | true | semmle.label | successor |
-| cflow.cs:194:48:194:51 | true | cflow.cs:195:9:197:9 | {...} | semmle.label | successor |
+| cflow.cs:194:48:194:51 | true | cflow.cs:195:9:197:9 | {...} | semmle.label | true |
 | cflow.cs:195:9:197:9 | {...} | cflow.cs:196:13:196:18 | throw ...; | semmle.label | successor |
 | cflow.cs:196:13:196:18 | throw ...; | cflow.cs:202:9:204:9 | {...} | semmle.label | exception(IOException) |
-| cflow.cs:198:9:200:9 | catch (...) {...} | cflow.cs:198:26:198:26 | Exception e | semmle.label | successor |
+| cflow.cs:198:9:200:9 | catch (...) {...} | cflow.cs:198:26:198:26 | Exception e | semmle.label | match |
 | cflow.cs:198:26:198:26 | Exception e | cflow.cs:198:35:198:35 | access to local variable e | semmle.label | successor |
 | cflow.cs:198:35:198:35 | access to local variable e | cflow.cs:198:35:198:43 | access to property Message | semmle.label | successor |
 | cflow.cs:198:35:198:43 | access to property Message | cflow.cs:198:48:198:51 | null | semmle.label | successor |
-| cflow.cs:198:35:198:51 | ... != ... | cflow.cs:199:9:200:9 | {...} | semmle.label | successor |
+| cflow.cs:198:35:198:51 | ... != ... | cflow.cs:199:9:200:9 | {...} | semmle.label | true |
+| cflow.cs:198:35:198:51 | ... != ... | cflow.cs:202:9:204:9 | {...} | semmle.label | exception(Exception) |
+| cflow.cs:198:35:198:51 | ... != ... | cflow.cs:202:9:204:9 | {...} | semmle.label | exception(OutOfMemoryException) |
 | cflow.cs:198:48:198:51 | null | cflow.cs:198:35:198:51 | ... != ... | semmle.label | successor |
 | cflow.cs:199:9:200:9 | {...} | cflow.cs:202:9:204:9 | {...} | semmle.label | successor |
 | cflow.cs:202:9:204:9 | {...} | cflow.cs:203:13:203:41 | ...; | semmle.label | successor |

--- a/csharp/ql/test/library-tests/controlflow/graph/ElementGraph.expected
+++ b/csharp/ql/test/library-tests/controlflow/graph/ElementGraph.expected
@@ -1054,8 +1054,12 @@
 | cflow.cs:194:48:194:51 | true | cflow.cs:195:9:197:9 | {...} | semmle.label | successor |
 | cflow.cs:195:9:197:9 | {...} | cflow.cs:196:13:196:18 | throw ...; | semmle.label | successor |
 | cflow.cs:196:13:196:18 | throw ...; | cflow.cs:202:9:204:9 | {...} | semmle.label | exception(IOException) |
-| cflow.cs:198:9:200:9 | catch (...) {...} | cflow.cs:198:33:198:37 | false | semmle.label | successor |
-| cflow.cs:198:33:198:37 | false | cflow.cs:199:9:200:9 | {...} | semmle.label | successor |
+| cflow.cs:198:9:200:9 | catch (...) {...} | cflow.cs:198:26:198:26 | Exception e | semmle.label | successor |
+| cflow.cs:198:26:198:26 | Exception e | cflow.cs:198:35:198:35 | access to local variable e | semmle.label | successor |
+| cflow.cs:198:35:198:35 | access to local variable e | cflow.cs:198:35:198:43 | access to property Message | semmle.label | successor |
+| cflow.cs:198:35:198:43 | access to property Message | cflow.cs:198:48:198:51 | null | semmle.label | successor |
+| cflow.cs:198:35:198:51 | ... != ... | cflow.cs:199:9:200:9 | {...} | semmle.label | successor |
+| cflow.cs:198:48:198:51 | null | cflow.cs:198:35:198:51 | ... != ... | semmle.label | successor |
 | cflow.cs:199:9:200:9 | {...} | cflow.cs:202:9:204:9 | {...} | semmle.label | successor |
 | cflow.cs:202:9:204:9 | {...} | cflow.cs:203:13:203:41 | ...; | semmle.label | successor |
 | cflow.cs:203:13:203:40 | call to method WriteLine | cflow.cs:206:9:206:19 | ... ...; | semmle.label | successor |

--- a/csharp/ql/test/library-tests/controlflow/graph/EntryElement.expected
+++ b/csharp/ql/test/library-tests/controlflow/graph/EntryElement.expected
@@ -1090,7 +1090,11 @@
 | cflow.cs:195:9:197:9 | {...} | cflow.cs:195:9:197:9 | {...} |
 | cflow.cs:196:13:196:18 | throw ...; | cflow.cs:196:13:196:18 | throw ...; |
 | cflow.cs:198:9:200:9 | catch (...) {...} | cflow.cs:198:9:200:9 | catch (...) {...} |
-| cflow.cs:198:33:198:37 | false | cflow.cs:198:33:198:37 | false |
+| cflow.cs:198:26:198:26 | Exception e | cflow.cs:198:26:198:26 | Exception e |
+| cflow.cs:198:35:198:35 | access to local variable e | cflow.cs:198:35:198:35 | access to local variable e |
+| cflow.cs:198:35:198:43 | access to property Message | cflow.cs:198:35:198:35 | access to local variable e |
+| cflow.cs:198:35:198:51 | ... != ... | cflow.cs:198:35:198:35 | access to local variable e |
+| cflow.cs:198:48:198:51 | null | cflow.cs:198:48:198:51 | null |
 | cflow.cs:199:9:200:9 | {...} | cflow.cs:199:9:200:9 | {...} |
 | cflow.cs:202:9:204:9 | {...} | cflow.cs:202:9:204:9 | {...} |
 | cflow.cs:203:13:203:40 | call to method WriteLine | cflow.cs:203:31:203:39 | "Finally" |

--- a/csharp/ql/test/library-tests/controlflow/graph/EntryElement.expected
+++ b/csharp/ql/test/library-tests/controlflow/graph/EntryElement.expected
@@ -136,6 +136,43 @@
 | BreakInTry.cs:67:21:67:31 | ... == ... | BreakInTry.cs:67:21:67:23 | access to local variable arg |
 | BreakInTry.cs:67:28:67:31 | null | BreakInTry.cs:67:28:67:31 | null |
 | BreakInTry.cs:68:21:68:26 | break; | BreakInTry.cs:68:21:68:26 | break; |
+| CatchInFinally.cs:6:5:28:5 | {...} | CatchInFinally.cs:6:5:28:5 | {...} |
+| CatchInFinally.cs:7:9:27:9 | try {...} ... | CatchInFinally.cs:7:9:27:9 | try {...} ... |
+| CatchInFinally.cs:8:9:11:9 | {...} | CatchInFinally.cs:8:9:11:9 | {...} |
+| CatchInFinally.cs:9:13:10:50 | if (...) ... | CatchInFinally.cs:9:13:10:50 | if (...) ... |
+| CatchInFinally.cs:9:17:9:20 | access to parameter args | CatchInFinally.cs:9:17:9:20 | access to parameter args |
+| CatchInFinally.cs:9:17:9:28 | ... == ... | CatchInFinally.cs:9:17:9:20 | access to parameter args |
+| CatchInFinally.cs:9:25:9:28 | null | CatchInFinally.cs:9:25:9:28 | null |
+| CatchInFinally.cs:10:17:10:50 | throw ...; | CatchInFinally.cs:10:23:10:49 | object creation of type ArgumentNullException |
+| CatchInFinally.cs:10:23:10:49 | object creation of type ArgumentNullException | CatchInFinally.cs:10:23:10:49 | object creation of type ArgumentNullException |
+| CatchInFinally.cs:13:9:27:9 | {...} | CatchInFinally.cs:13:9:27:9 | {...} |
+| CatchInFinally.cs:14:13:26:13 | try {...} ... | CatchInFinally.cs:14:13:26:13 | try {...} ... |
+| CatchInFinally.cs:15:13:18:13 | {...} | CatchInFinally.cs:15:13:18:13 | {...} |
+| CatchInFinally.cs:16:17:17:45 | if (...) ... | CatchInFinally.cs:16:17:17:45 | if (...) ... |
+| CatchInFinally.cs:16:21:16:24 | access to parameter args | CatchInFinally.cs:16:21:16:24 | access to parameter args |
+| CatchInFinally.cs:16:21:16:31 | access to property Length | CatchInFinally.cs:16:21:16:24 | access to parameter args |
+| CatchInFinally.cs:16:21:16:36 | ... == ... | CatchInFinally.cs:16:21:16:24 | access to parameter args |
+| CatchInFinally.cs:16:36:16:36 | 1 | CatchInFinally.cs:16:36:16:36 | 1 |
+| CatchInFinally.cs:17:21:17:45 | throw ...; | CatchInFinally.cs:17:41:17:43 | "1" |
+| CatchInFinally.cs:17:27:17:44 | object creation of type Exception | CatchInFinally.cs:17:41:17:43 | "1" |
+| CatchInFinally.cs:17:41:17:43 | "1" | CatchInFinally.cs:17:41:17:43 | "1" |
+| CatchInFinally.cs:19:13:22:13 | catch (...) {...} | CatchInFinally.cs:19:13:22:13 | catch (...) {...} |
+| CatchInFinally.cs:19:30:19:30 | Exception e | CatchInFinally.cs:19:30:19:30 | Exception e |
+| CatchInFinally.cs:19:39:19:39 | access to local variable e | CatchInFinally.cs:19:39:19:39 | access to local variable e |
+| CatchInFinally.cs:19:39:19:47 | access to property Message | CatchInFinally.cs:19:39:19:39 | access to local variable e |
+| CatchInFinally.cs:19:39:19:54 | ... == ... | CatchInFinally.cs:19:39:19:39 | access to local variable e |
+| CatchInFinally.cs:19:52:19:54 | "1" | CatchInFinally.cs:19:52:19:54 | "1" |
+| CatchInFinally.cs:20:13:22:13 | {...} | CatchInFinally.cs:20:13:22:13 | {...} |
+| CatchInFinally.cs:21:17:21:42 | call to method WriteLine | CatchInFinally.cs:21:35:21:38 | access to parameter args |
+| CatchInFinally.cs:21:17:21:43 | ...; | CatchInFinally.cs:21:17:21:43 | ...; |
+| CatchInFinally.cs:21:35:21:38 | access to parameter args | CatchInFinally.cs:21:35:21:38 | access to parameter args |
+| CatchInFinally.cs:21:35:21:41 | access to array element | CatchInFinally.cs:21:35:21:38 | access to parameter args |
+| CatchInFinally.cs:21:40:21:40 | 0 | CatchInFinally.cs:21:40:21:40 | 0 |
+| CatchInFinally.cs:23:13:26:13 | catch {...} | CatchInFinally.cs:23:13:26:13 | catch {...} |
+| CatchInFinally.cs:24:13:26:13 | {...} | CatchInFinally.cs:24:13:26:13 | {...} |
+| CatchInFinally.cs:25:17:25:37 | call to method WriteLine | CatchInFinally.cs:25:35:25:36 | "" |
+| CatchInFinally.cs:25:17:25:38 | ...; | CatchInFinally.cs:25:17:25:38 | ...; |
+| CatchInFinally.cs:25:35:25:36 | "" | CatchInFinally.cs:25:35:25:36 | "" |
 | CompileTimeOperators.cs:6:5:8:5 | {...} | CompileTimeOperators.cs:6:5:8:5 | {...} |
 | CompileTimeOperators.cs:7:9:7:28 | return ...; | CompileTimeOperators.cs:7:16:7:27 | default(...) |
 | CompileTimeOperators.cs:7:16:7:27 | default(...) | CompileTimeOperators.cs:7:16:7:27 | default(...) |

--- a/csharp/ql/test/library-tests/controlflow/graph/EntryPoint.expected
+++ b/csharp/ql/test/library-tests/controlflow/graph/EntryPoint.expected
@@ -9,6 +9,7 @@
 | BreakInTry.cs:20:10:20:11 | M2 | BreakInTry.cs:21:5:36:5 | {...} |
 | BreakInTry.cs:38:10:38:11 | M3 | BreakInTry.cs:39:5:54:5 | {...} |
 | BreakInTry.cs:56:10:56:11 | M4 | BreakInTry.cs:57:5:71:5 | {...} |
+| CatchInFinally.cs:5:10:5:11 | M1 | CatchInFinally.cs:6:5:28:5 | {...} |
 | CompileTimeOperators.cs:5:9:5:15 | Default | CompileTimeOperators.cs:6:5:8:5 | {...} |
 | CompileTimeOperators.cs:10:9:10:14 | Sizeof | CompileTimeOperators.cs:11:5:13:5 | {...} |
 | CompileTimeOperators.cs:15:10:15:15 | Typeof | CompileTimeOperators.cs:16:5:18:5 | {...} |

--- a/csharp/ql/test/library-tests/controlflow/graph/ExitElement.expected
+++ b/csharp/ql/test/library-tests/controlflow/graph/ExitElement.expected
@@ -349,6 +349,7 @@
 | ExitMethods.cs:40:13:40:31 | ...; | ExitMethods.cs:40:13:40:30 | call to method ErrorAlways | throw(ArgumentException) |
 | ExitMethods.cs:40:13:40:31 | ...; | ExitMethods.cs:40:13:40:30 | call to method ErrorAlways | throw(Exception) |
 | ExitMethods.cs:40:25:40:29 | false | ExitMethods.cs:40:25:40:29 | false | normal |
+| ExitMethods.cs:42:9:45:9 | catch (...) {...} | ExitMethods.cs:42:9:45:9 | catch (...) {...} | no-match |
 | ExitMethods.cs:42:9:45:9 | catch (...) {...} | ExitMethods.cs:44:13:44:19 | return ...; | return |
 | ExitMethods.cs:43:9:45:9 | {...} | ExitMethods.cs:44:13:44:19 | return ...; | return |
 | ExitMethods.cs:44:13:44:19 | return ...; | ExitMethods.cs:44:13:44:19 | return ...; | return |
@@ -1412,11 +1413,13 @@
 | cflow.cs:159:31:159:36 | "Try2" | cflow.cs:159:31:159:36 | "Try2" | normal |
 | cflow.cs:159:31:159:36 | "Try2" | cflow.cs:159:31:159:36 | "Try2" | throw(OutOfMemoryException) |
 | cflow.cs:160:13:160:19 | return ...; | cflow.cs:160:13:160:19 | return ...; | return |
+| cflow.cs:162:9:165:9 | catch (...) {...} | cflow.cs:162:9:165:9 | catch (...) {...} | no-match |
 | cflow.cs:162:9:165:9 | catch (...) {...} | cflow.cs:164:13:164:18 | throw ...; | throw(IOException) |
 | cflow.cs:162:38:162:39 | IOException ex | cflow.cs:162:38:162:39 | IOException ex | normal |
-| cflow.cs:162:48:162:51 | true | cflow.cs:162:48:162:51 | true | normal |
+| cflow.cs:162:48:162:51 | true | cflow.cs:162:48:162:51 | true | true/true |
 | cflow.cs:163:9:165:9 | {...} | cflow.cs:164:13:164:18 | throw ...; | throw(IOException) |
 | cflow.cs:164:13:164:18 | throw ...; | cflow.cs:164:13:164:18 | throw ...; | throw(IOException) |
+| cflow.cs:166:9:176:9 | catch (...) {...} | cflow.cs:166:9:176:9 | catch (...) {...} | no-match |
 | cflow.cs:166:9:176:9 | catch (...) {...} | cflow.cs:174:17:174:44 | throw ...; | throw(Exception) |
 | cflow.cs:166:41:166:42 | ArgumentException ex | cflow.cs:166:41:166:42 | ArgumentException ex | normal |
 | cflow.cs:167:9:176:9 | {...} | cflow.cs:174:17:174:44 | throw ...; | throw(Exception) |
@@ -1429,6 +1432,7 @@
 | cflow.cs:174:17:174:44 | throw ...; | cflow.cs:174:17:174:44 | throw ...; | throw(Exception) |
 | cflow.cs:174:23:174:43 | object creation of type Exception | cflow.cs:174:23:174:43 | object creation of type Exception | normal |
 | cflow.cs:174:37:174:42 | "Boo!" | cflow.cs:174:37:174:42 | "Boo!" | normal |
+| cflow.cs:177:9:179:9 | catch (...) {...} | cflow.cs:177:9:179:9 | catch (...) {...} | no-match |
 | cflow.cs:177:9:179:9 | catch (...) {...} | cflow.cs:178:9:179:9 | {...} | normal |
 | cflow.cs:178:9:179:9 | {...} | cflow.cs:178:9:179:9 | {...} | normal |
 | cflow.cs:180:9:183:9 | catch {...} | cflow.cs:182:13:182:19 | return ...; | return |
@@ -1455,16 +1459,22 @@
 | cflow.cs:191:31:191:36 | "Try3" | cflow.cs:191:31:191:36 | "Try3" | normal |
 | cflow.cs:191:31:191:36 | "Try3" | cflow.cs:191:31:191:36 | "Try3" | throw(OutOfMemoryException) |
 | cflow.cs:192:13:192:19 | return ...; | cflow.cs:192:13:192:19 | return ...; | return |
+| cflow.cs:194:9:197:9 | catch (...) {...} | cflow.cs:194:9:197:9 | catch (...) {...} | no-match |
 | cflow.cs:194:9:197:9 | catch (...) {...} | cflow.cs:196:13:196:18 | throw ...; | throw(IOException) |
 | cflow.cs:194:38:194:39 | IOException ex | cflow.cs:194:38:194:39 | IOException ex | normal |
-| cflow.cs:194:48:194:51 | true | cflow.cs:194:48:194:51 | true | normal |
+| cflow.cs:194:48:194:51 | true | cflow.cs:194:48:194:51 | true | true/true |
 | cflow.cs:195:9:197:9 | {...} | cflow.cs:196:13:196:18 | throw ...; | throw(IOException) |
 | cflow.cs:196:13:196:18 | throw ...; | cflow.cs:196:13:196:18 | throw ...; | throw(IOException) |
+| cflow.cs:198:9:200:9 | catch (...) {...} | cflow.cs:198:9:200:9 | catch (...) {...} | throw(Exception) |
+| cflow.cs:198:9:200:9 | catch (...) {...} | cflow.cs:198:9:200:9 | catch (...) {...} | throw(OutOfMemoryException) |
+| cflow.cs:198:9:200:9 | catch (...) {...} | cflow.cs:198:35:198:51 | ... != ... | throw(Exception) |
+| cflow.cs:198:9:200:9 | catch (...) {...} | cflow.cs:198:35:198:51 | ... != ... | throw(OutOfMemoryException) |
 | cflow.cs:198:9:200:9 | catch (...) {...} | cflow.cs:199:9:200:9 | {...} | normal |
 | cflow.cs:198:26:198:26 | Exception e | cflow.cs:198:26:198:26 | Exception e | normal |
 | cflow.cs:198:35:198:35 | access to local variable e | cflow.cs:198:35:198:35 | access to local variable e | normal |
 | cflow.cs:198:35:198:43 | access to property Message | cflow.cs:198:35:198:43 | access to property Message | normal |
-| cflow.cs:198:35:198:51 | ... != ... | cflow.cs:198:35:198:51 | ... != ... | normal |
+| cflow.cs:198:35:198:51 | ... != ... | cflow.cs:198:35:198:51 | ... != ... | false/false |
+| cflow.cs:198:35:198:51 | ... != ... | cflow.cs:198:35:198:51 | ... != ... | true/true |
 | cflow.cs:198:48:198:51 | null | cflow.cs:198:48:198:51 | null | normal |
 | cflow.cs:199:9:200:9 | {...} | cflow.cs:199:9:200:9 | {...} | normal |
 | cflow.cs:202:9:204:9 | {...} | cflow.cs:203:13:203:40 | call to method WriteLine | normal |

--- a/csharp/ql/test/library-tests/controlflow/graph/ExitElement.expected
+++ b/csharp/ql/test/library-tests/controlflow/graph/ExitElement.expected
@@ -187,6 +187,89 @@
 | BreakInTry.cs:67:21:67:31 | ... == ... | BreakInTry.cs:67:21:67:31 | ... == ... | true/true |
 | BreakInTry.cs:67:28:67:31 | null | BreakInTry.cs:67:28:67:31 | null | normal |
 | BreakInTry.cs:68:21:68:26 | break; | BreakInTry.cs:68:21:68:26 | break; | break |
+| CatchInFinally.cs:6:5:28:5 | {...} | CatchInFinally.cs:16:21:16:36 | ... == ... | false/false |
+| CatchInFinally.cs:6:5:28:5 | {...} | CatchInFinally.cs:16:21:16:36 | ... == ... | throw(ArgumentNullException) |
+| CatchInFinally.cs:6:5:28:5 | {...} | CatchInFinally.cs:16:21:16:36 | ... == ... | throw(Exception) |
+| CatchInFinally.cs:6:5:28:5 | {...} | CatchInFinally.cs:21:17:21:42 | call to method WriteLine | normal |
+| CatchInFinally.cs:6:5:28:5 | {...} | CatchInFinally.cs:21:17:21:42 | call to method WriteLine | throw(ArgumentNullException) |
+| CatchInFinally.cs:6:5:28:5 | {...} | CatchInFinally.cs:21:17:21:42 | call to method WriteLine | throw(Exception) |
+| CatchInFinally.cs:6:5:28:5 | {...} | CatchInFinally.cs:25:17:25:37 | call to method WriteLine | normal |
+| CatchInFinally.cs:6:5:28:5 | {...} | CatchInFinally.cs:25:17:25:37 | call to method WriteLine | throw(ArgumentNullException) |
+| CatchInFinally.cs:6:5:28:5 | {...} | CatchInFinally.cs:25:17:25:37 | call to method WriteLine | throw(Exception) |
+| CatchInFinally.cs:7:9:27:9 | try {...} ... | CatchInFinally.cs:16:21:16:36 | ... == ... | false/false |
+| CatchInFinally.cs:7:9:27:9 | try {...} ... | CatchInFinally.cs:16:21:16:36 | ... == ... | throw(ArgumentNullException) |
+| CatchInFinally.cs:7:9:27:9 | try {...} ... | CatchInFinally.cs:16:21:16:36 | ... == ... | throw(Exception) |
+| CatchInFinally.cs:7:9:27:9 | try {...} ... | CatchInFinally.cs:21:17:21:42 | call to method WriteLine | normal |
+| CatchInFinally.cs:7:9:27:9 | try {...} ... | CatchInFinally.cs:21:17:21:42 | call to method WriteLine | throw(ArgumentNullException) |
+| CatchInFinally.cs:7:9:27:9 | try {...} ... | CatchInFinally.cs:21:17:21:42 | call to method WriteLine | throw(Exception) |
+| CatchInFinally.cs:7:9:27:9 | try {...} ... | CatchInFinally.cs:25:17:25:37 | call to method WriteLine | normal |
+| CatchInFinally.cs:7:9:27:9 | try {...} ... | CatchInFinally.cs:25:17:25:37 | call to method WriteLine | throw(ArgumentNullException) |
+| CatchInFinally.cs:7:9:27:9 | try {...} ... | CatchInFinally.cs:25:17:25:37 | call to method WriteLine | throw(Exception) |
+| CatchInFinally.cs:8:9:11:9 | {...} | CatchInFinally.cs:9:17:9:28 | ... == ... | false/false |
+| CatchInFinally.cs:8:9:11:9 | {...} | CatchInFinally.cs:10:17:10:50 | throw ...; | throw(ArgumentNullException) |
+| CatchInFinally.cs:8:9:11:9 | {...} | CatchInFinally.cs:10:23:10:49 | object creation of type ArgumentNullException | throw(Exception) |
+| CatchInFinally.cs:9:13:10:50 | if (...) ... | CatchInFinally.cs:9:17:9:28 | ... == ... | false/false |
+| CatchInFinally.cs:9:13:10:50 | if (...) ... | CatchInFinally.cs:10:17:10:50 | throw ...; | throw(ArgumentNullException) |
+| CatchInFinally.cs:9:13:10:50 | if (...) ... | CatchInFinally.cs:10:23:10:49 | object creation of type ArgumentNullException | throw(Exception) |
+| CatchInFinally.cs:9:17:9:20 | access to parameter args | CatchInFinally.cs:9:17:9:20 | access to parameter args | normal |
+| CatchInFinally.cs:9:17:9:28 | ... == ... | CatchInFinally.cs:9:17:9:28 | ... == ... | false/false |
+| CatchInFinally.cs:9:17:9:28 | ... == ... | CatchInFinally.cs:9:17:9:28 | ... == ... | true/true |
+| CatchInFinally.cs:9:25:9:28 | null | CatchInFinally.cs:9:25:9:28 | null | normal |
+| CatchInFinally.cs:10:17:10:50 | throw ...; | CatchInFinally.cs:10:17:10:50 | throw ...; | throw(ArgumentNullException) |
+| CatchInFinally.cs:10:17:10:50 | throw ...; | CatchInFinally.cs:10:23:10:49 | object creation of type ArgumentNullException | throw(Exception) |
+| CatchInFinally.cs:10:23:10:49 | object creation of type ArgumentNullException | CatchInFinally.cs:10:23:10:49 | object creation of type ArgumentNullException | normal |
+| CatchInFinally.cs:10:23:10:49 | object creation of type ArgumentNullException | CatchInFinally.cs:10:23:10:49 | object creation of type ArgumentNullException | throw(Exception) |
+| CatchInFinally.cs:13:9:27:9 | {...} | CatchInFinally.cs:16:21:16:36 | ... == ... | false/false |
+| CatchInFinally.cs:13:9:27:9 | {...} | CatchInFinally.cs:21:17:21:42 | call to method WriteLine | normal |
+| CatchInFinally.cs:13:9:27:9 | {...} | CatchInFinally.cs:25:17:25:37 | call to method WriteLine | normal |
+| CatchInFinally.cs:14:13:26:13 | try {...} ... | CatchInFinally.cs:16:21:16:36 | ... == ... | false/false |
+| CatchInFinally.cs:14:13:26:13 | try {...} ... | CatchInFinally.cs:21:17:21:42 | call to method WriteLine | normal |
+| CatchInFinally.cs:14:13:26:13 | try {...} ... | CatchInFinally.cs:25:17:25:37 | call to method WriteLine | normal |
+| CatchInFinally.cs:15:13:18:13 | {...} | CatchInFinally.cs:16:21:16:31 | access to property Length | throw(Exception) |
+| CatchInFinally.cs:15:13:18:13 | {...} | CatchInFinally.cs:16:21:16:31 | access to property Length | throw(NullReferenceException) |
+| CatchInFinally.cs:15:13:18:13 | {...} | CatchInFinally.cs:16:21:16:36 | ... == ... | false/false |
+| CatchInFinally.cs:15:13:18:13 | {...} | CatchInFinally.cs:17:21:17:45 | throw ...; | throw(Exception) |
+| CatchInFinally.cs:15:13:18:13 | {...} | CatchInFinally.cs:17:27:17:44 | object creation of type Exception | throw(Exception) |
+| CatchInFinally.cs:16:17:17:45 | if (...) ... | CatchInFinally.cs:16:21:16:31 | access to property Length | throw(Exception) |
+| CatchInFinally.cs:16:17:17:45 | if (...) ... | CatchInFinally.cs:16:21:16:31 | access to property Length | throw(NullReferenceException) |
+| CatchInFinally.cs:16:17:17:45 | if (...) ... | CatchInFinally.cs:16:21:16:36 | ... == ... | false/false |
+| CatchInFinally.cs:16:17:17:45 | if (...) ... | CatchInFinally.cs:17:21:17:45 | throw ...; | throw(Exception) |
+| CatchInFinally.cs:16:17:17:45 | if (...) ... | CatchInFinally.cs:17:27:17:44 | object creation of type Exception | throw(Exception) |
+| CatchInFinally.cs:16:21:16:24 | access to parameter args | CatchInFinally.cs:16:21:16:24 | access to parameter args | normal |
+| CatchInFinally.cs:16:21:16:31 | access to property Length | CatchInFinally.cs:16:21:16:31 | access to property Length | normal |
+| CatchInFinally.cs:16:21:16:31 | access to property Length | CatchInFinally.cs:16:21:16:31 | access to property Length | throw(Exception) |
+| CatchInFinally.cs:16:21:16:31 | access to property Length | CatchInFinally.cs:16:21:16:31 | access to property Length | throw(NullReferenceException) |
+| CatchInFinally.cs:16:21:16:36 | ... == ... | CatchInFinally.cs:16:21:16:31 | access to property Length | throw(Exception) |
+| CatchInFinally.cs:16:21:16:36 | ... == ... | CatchInFinally.cs:16:21:16:31 | access to property Length | throw(NullReferenceException) |
+| CatchInFinally.cs:16:21:16:36 | ... == ... | CatchInFinally.cs:16:21:16:36 | ... == ... | false/false |
+| CatchInFinally.cs:16:21:16:36 | ... == ... | CatchInFinally.cs:16:21:16:36 | ... == ... | true/true |
+| CatchInFinally.cs:16:36:16:36 | 1 | CatchInFinally.cs:16:36:16:36 | 1 | normal |
+| CatchInFinally.cs:17:21:17:45 | throw ...; | CatchInFinally.cs:17:21:17:45 | throw ...; | throw(Exception) |
+| CatchInFinally.cs:17:21:17:45 | throw ...; | CatchInFinally.cs:17:27:17:44 | object creation of type Exception | throw(Exception) |
+| CatchInFinally.cs:17:27:17:44 | object creation of type Exception | CatchInFinally.cs:17:27:17:44 | object creation of type Exception | normal |
+| CatchInFinally.cs:17:27:17:44 | object creation of type Exception | CatchInFinally.cs:17:27:17:44 | object creation of type Exception | throw(Exception) |
+| CatchInFinally.cs:17:41:17:43 | "1" | CatchInFinally.cs:17:41:17:43 | "1" | normal |
+| CatchInFinally.cs:17:41:17:43 | "1" | CatchInFinally.cs:17:41:17:43 | "1" | throw(OutOfMemoryException) |
+| CatchInFinally.cs:19:13:22:13 | catch (...) {...} | CatchInFinally.cs:19:13:22:13 | catch (...) {...} | no-match |
+| CatchInFinally.cs:19:13:22:13 | catch (...) {...} | CatchInFinally.cs:19:39:19:54 | ... == ... | false/false |
+| CatchInFinally.cs:19:13:22:13 | catch (...) {...} | CatchInFinally.cs:21:17:21:42 | call to method WriteLine | normal |
+| CatchInFinally.cs:19:30:19:30 | Exception e | CatchInFinally.cs:19:30:19:30 | Exception e | normal |
+| CatchInFinally.cs:19:39:19:39 | access to local variable e | CatchInFinally.cs:19:39:19:39 | access to local variable e | normal |
+| CatchInFinally.cs:19:39:19:47 | access to property Message | CatchInFinally.cs:19:39:19:47 | access to property Message | normal |
+| CatchInFinally.cs:19:39:19:54 | ... == ... | CatchInFinally.cs:19:39:19:54 | ... == ... | false/false |
+| CatchInFinally.cs:19:39:19:54 | ... == ... | CatchInFinally.cs:19:39:19:54 | ... == ... | true/true |
+| CatchInFinally.cs:19:52:19:54 | "1" | CatchInFinally.cs:19:52:19:54 | "1" | normal |
+| CatchInFinally.cs:20:13:22:13 | {...} | CatchInFinally.cs:21:17:21:42 | call to method WriteLine | normal |
+| CatchInFinally.cs:21:17:21:42 | call to method WriteLine | CatchInFinally.cs:21:17:21:42 | call to method WriteLine | normal |
+| CatchInFinally.cs:21:17:21:43 | ...; | CatchInFinally.cs:21:17:21:42 | call to method WriteLine | normal |
+| CatchInFinally.cs:21:35:21:38 | access to parameter args | CatchInFinally.cs:21:35:21:38 | access to parameter args | normal |
+| CatchInFinally.cs:21:35:21:41 | access to array element | CatchInFinally.cs:21:35:21:41 | access to array element | normal |
+| CatchInFinally.cs:21:40:21:40 | 0 | CatchInFinally.cs:21:40:21:40 | 0 | normal |
+| CatchInFinally.cs:23:13:26:13 | catch {...} | CatchInFinally.cs:25:17:25:37 | call to method WriteLine | normal |
+| CatchInFinally.cs:24:13:26:13 | {...} | CatchInFinally.cs:25:17:25:37 | call to method WriteLine | normal |
+| CatchInFinally.cs:25:17:25:37 | call to method WriteLine | CatchInFinally.cs:25:17:25:37 | call to method WriteLine | normal |
+| CatchInFinally.cs:25:17:25:38 | ...; | CatchInFinally.cs:25:17:25:37 | call to method WriteLine | normal |
+| CatchInFinally.cs:25:35:25:36 | "" | CatchInFinally.cs:25:35:25:36 | "" | normal |
 | CompileTimeOperators.cs:6:5:8:5 | {...} | CompileTimeOperators.cs:7:9:7:28 | return ...; | return |
 | CompileTimeOperators.cs:7:9:7:28 | return ...; | CompileTimeOperators.cs:7:9:7:28 | return ...; | return |
 | CompileTimeOperators.cs:7:16:7:27 | default(...) | CompileTimeOperators.cs:7:16:7:27 | default(...) | normal |

--- a/csharp/ql/test/library-tests/controlflow/graph/ExitElement.expected
+++ b/csharp/ql/test/library-tests/controlflow/graph/ExitElement.expected
@@ -1461,7 +1461,11 @@
 | cflow.cs:195:9:197:9 | {...} | cflow.cs:196:13:196:18 | throw ...; | throw(IOException) |
 | cflow.cs:196:13:196:18 | throw ...; | cflow.cs:196:13:196:18 | throw ...; | throw(IOException) |
 | cflow.cs:198:9:200:9 | catch (...) {...} | cflow.cs:199:9:200:9 | {...} | normal |
-| cflow.cs:198:33:198:37 | false | cflow.cs:198:33:198:37 | false | normal |
+| cflow.cs:198:26:198:26 | Exception e | cflow.cs:198:26:198:26 | Exception e | normal |
+| cflow.cs:198:35:198:35 | access to local variable e | cflow.cs:198:35:198:35 | access to local variable e | normal |
+| cflow.cs:198:35:198:43 | access to property Message | cflow.cs:198:35:198:43 | access to property Message | normal |
+| cflow.cs:198:35:198:51 | ... != ... | cflow.cs:198:35:198:51 | ... != ... | normal |
+| cflow.cs:198:48:198:51 | null | cflow.cs:198:48:198:51 | null | normal |
 | cflow.cs:199:9:200:9 | {...} | cflow.cs:199:9:200:9 | {...} | normal |
 | cflow.cs:202:9:204:9 | {...} | cflow.cs:203:13:203:40 | call to method WriteLine | normal |
 | cflow.cs:203:13:203:40 | call to method WriteLine | cflow.cs:203:13:203:40 | call to method WriteLine | normal |

--- a/csharp/ql/test/library-tests/controlflow/graph/FinallyNode.expected
+++ b/csharp/ql/test/library-tests/controlflow/graph/FinallyNode.expected
@@ -1,209 +1,209 @@
-| BreakInTry.cs:24:13:33:13 | try {...} ... | BreakInTry.cs:30:13:33:13 | [break] {...} |
-| BreakInTry.cs:24:13:33:13 | try {...} ... | BreakInTry.cs:31:17:32:21 | [break] if (...) ... |
-| BreakInTry.cs:24:13:33:13 | try {...} ... | BreakInTry.cs:31:21:31:24 | [break] access to parameter args |
-| BreakInTry.cs:24:13:33:13 | try {...} ... | BreakInTry.cs:31:21:31:32 | [break] ... == ... |
-| BreakInTry.cs:24:13:33:13 | try {...} ... | BreakInTry.cs:31:29:31:32 | [break] null |
-| BreakInTry.cs:24:13:33:13 | try {...} ... | BreakInTry.cs:32:21:32:21 | [break] ; |
-| BreakInTry.cs:40:9:52:9 | try {...} ... | BreakInTry.cs:46:9:52:9 | [return] {...} |
-| BreakInTry.cs:40:9:52:9 | try {...} ... | BreakInTry.cs:47:13:51:13 | [return] foreach (... ... in ...) ... |
-| BreakInTry.cs:40:9:52:9 | try {...} ... | BreakInTry.cs:47:26:47:28 | [return] String arg |
-| BreakInTry.cs:40:9:52:9 | try {...} ... | BreakInTry.cs:47:33:47:36 | [return] access to parameter args |
-| BreakInTry.cs:40:9:52:9 | try {...} ... | BreakInTry.cs:48:13:51:13 | [return] {...} |
-| BreakInTry.cs:40:9:52:9 | try {...} ... | BreakInTry.cs:49:17:50:26 | [return] if (...) ... |
-| BreakInTry.cs:40:9:52:9 | try {...} ... | BreakInTry.cs:49:21:49:23 | [return] access to local variable arg |
-| BreakInTry.cs:40:9:52:9 | try {...} ... | BreakInTry.cs:49:21:49:31 | [return] ... == ... |
-| BreakInTry.cs:40:9:52:9 | try {...} ... | BreakInTry.cs:49:28:49:31 | [return] null |
-| BreakInTry.cs:40:9:52:9 | try {...} ... | BreakInTry.cs:50:21:50:26 | [return] break; |
-| BreakInTry.cs:58:9:70:9 | try {...} ... | BreakInTry.cs:64:9:70:9 | [return] {...} |
-| BreakInTry.cs:58:9:70:9 | try {...} ... | BreakInTry.cs:65:13:69:13 | [return] foreach (... ... in ...) ... |
-| BreakInTry.cs:58:9:70:9 | try {...} ... | BreakInTry.cs:65:26:65:28 | [return] String arg |
-| BreakInTry.cs:58:9:70:9 | try {...} ... | BreakInTry.cs:65:33:65:36 | [return] access to parameter args |
-| BreakInTry.cs:58:9:70:9 | try {...} ... | BreakInTry.cs:66:13:69:13 | [return] {...} |
-| BreakInTry.cs:58:9:70:9 | try {...} ... | BreakInTry.cs:67:17:68:26 | [return] if (...) ... |
-| BreakInTry.cs:58:9:70:9 | try {...} ... | BreakInTry.cs:67:21:67:23 | [return] access to local variable arg |
-| BreakInTry.cs:58:9:70:9 | try {...} ... | BreakInTry.cs:67:21:67:31 | [return] ... == ... |
-| BreakInTry.cs:58:9:70:9 | try {...} ... | BreakInTry.cs:67:28:67:31 | [return] null |
-| BreakInTry.cs:58:9:70:9 | try {...} ... | BreakInTry.cs:68:21:68:26 | [return] break; |
-| CompileTimeOperators.cs:30:9:38:9 | try {...} ... | CompileTimeOperators.cs:36:9:38:9 | [goto(End)] {...} |
-| CompileTimeOperators.cs:30:9:38:9 | try {...} ... | CompileTimeOperators.cs:37:13:37:40 | [goto(End)] call to method WriteLine |
-| CompileTimeOperators.cs:30:9:38:9 | try {...} ... | CompileTimeOperators.cs:37:13:37:41 | [goto(End)] ...; |
-| CompileTimeOperators.cs:30:9:38:9 | try {...} ... | CompileTimeOperators.cs:37:31:37:39 | [goto(End)] "Finally" |
-| cflow.cs:148:9:155:9 | try {...} ... | cflow.cs:153:9:155:9 | [exception(Exception)] {...} |
-| cflow.cs:148:9:155:9 | try {...} ... | cflow.cs:153:9:155:9 | [exception(OutOfMemoryException)] {...} |
-| cflow.cs:148:9:155:9 | try {...} ... | cflow.cs:154:13:154:40 | [exception(Exception)] call to method WriteLine |
-| cflow.cs:148:9:155:9 | try {...} ... | cflow.cs:154:13:154:40 | [exception(OutOfMemoryException)] call to method WriteLine |
-| cflow.cs:148:9:155:9 | try {...} ... | cflow.cs:154:13:154:41 | [exception(Exception)] ...; |
-| cflow.cs:148:9:155:9 | try {...} ... | cflow.cs:154:13:154:41 | [exception(OutOfMemoryException)] ...; |
-| cflow.cs:148:9:155:9 | try {...} ... | cflow.cs:154:31:154:39 | [exception(Exception)] "Finally" |
-| cflow.cs:148:9:155:9 | try {...} ... | cflow.cs:154:31:154:39 | [exception(OutOfMemoryException)] "Finally" |
-| cflow.cs:157:9:187:9 | try {...} ... | cflow.cs:185:9:187:9 | [exception(Exception)] {...} |
-| cflow.cs:157:9:187:9 | try {...} ... | cflow.cs:185:9:187:9 | [exception(IOException)] {...} |
-| cflow.cs:157:9:187:9 | try {...} ... | cflow.cs:185:9:187:9 | [return] {...} |
-| cflow.cs:157:9:187:9 | try {...} ... | cflow.cs:186:13:186:40 | [exception(Exception)] call to method WriteLine |
-| cflow.cs:157:9:187:9 | try {...} ... | cflow.cs:186:13:186:40 | [exception(IOException)] call to method WriteLine |
-| cflow.cs:157:9:187:9 | try {...} ... | cflow.cs:186:13:186:40 | [return] call to method WriteLine |
-| cflow.cs:157:9:187:9 | try {...} ... | cflow.cs:186:13:186:41 | [exception(Exception)] ...; |
-| cflow.cs:157:9:187:9 | try {...} ... | cflow.cs:186:13:186:41 | [exception(IOException)] ...; |
-| cflow.cs:157:9:187:9 | try {...} ... | cflow.cs:186:13:186:41 | [return] ...; |
-| cflow.cs:157:9:187:9 | try {...} ... | cflow.cs:186:31:186:39 | [exception(Exception)] "Finally" |
-| cflow.cs:157:9:187:9 | try {...} ... | cflow.cs:186:31:186:39 | [exception(IOException)] "Finally" |
-| cflow.cs:157:9:187:9 | try {...} ... | cflow.cs:186:31:186:39 | [return] "Finally" |
-| cflow.cs:168:13:175:13 | try {...} ... | cflow.cs:173:13:175:13 | [exception(ArgumentException)] {...} |
-| cflow.cs:168:13:175:13 | try {...} ... | cflow.cs:174:17:174:44 | [exception(ArgumentException)] throw ...; |
-| cflow.cs:168:13:175:13 | try {...} ... | cflow.cs:174:23:174:43 | [exception(ArgumentException)] object creation of type Exception |
-| cflow.cs:168:13:175:13 | try {...} ... | cflow.cs:174:37:174:42 | [exception(ArgumentException)] "Boo!" |
-| cflow.cs:189:9:204:9 | try {...} ... | cflow.cs:202:9:204:9 | [exception(Exception)] {...} |
-| cflow.cs:189:9:204:9 | try {...} ... | cflow.cs:202:9:204:9 | [exception(IOException)] {...} |
-| cflow.cs:189:9:204:9 | try {...} ... | cflow.cs:202:9:204:9 | [exception(OutOfMemoryException)] {...} |
-| cflow.cs:189:9:204:9 | try {...} ... | cflow.cs:202:9:204:9 | [return] {...} |
-| cflow.cs:189:9:204:9 | try {...} ... | cflow.cs:203:13:203:40 | [exception(Exception)] call to method WriteLine |
-| cflow.cs:189:9:204:9 | try {...} ... | cflow.cs:203:13:203:40 | [exception(IOException)] call to method WriteLine |
-| cflow.cs:189:9:204:9 | try {...} ... | cflow.cs:203:13:203:40 | [exception(OutOfMemoryException)] call to method WriteLine |
-| cflow.cs:189:9:204:9 | try {...} ... | cflow.cs:203:13:203:40 | [return] call to method WriteLine |
-| cflow.cs:189:9:204:9 | try {...} ... | cflow.cs:203:13:203:41 | [exception(Exception)] ...; |
-| cflow.cs:189:9:204:9 | try {...} ... | cflow.cs:203:13:203:41 | [exception(IOException)] ...; |
-| cflow.cs:189:9:204:9 | try {...} ... | cflow.cs:203:13:203:41 | [exception(OutOfMemoryException)] ...; |
-| cflow.cs:189:9:204:9 | try {...} ... | cflow.cs:203:13:203:41 | [return] ...; |
-| cflow.cs:189:9:204:9 | try {...} ... | cflow.cs:203:31:203:39 | [exception(Exception)] "Finally" |
-| cflow.cs:189:9:204:9 | try {...} ... | cflow.cs:203:31:203:39 | [exception(IOException)] "Finally" |
-| cflow.cs:189:9:204:9 | try {...} ... | cflow.cs:203:31:203:39 | [exception(OutOfMemoryException)] "Finally" |
-| cflow.cs:189:9:204:9 | try {...} ... | cflow.cs:203:31:203:39 | [return] "Finally" |
-| cflow.cs:209:13:229:13 | try {...} ... | cflow.cs:219:13:229:13 | [break] {...} |
-| cflow.cs:209:13:229:13 | try {...} ... | cflow.cs:219:13:229:13 | [continue] {...} |
-| cflow.cs:209:13:229:13 | try {...} ... | cflow.cs:219:13:229:13 | [return] {...} |
-| cflow.cs:209:13:229:13 | try {...} ... | cflow.cs:220:17:228:17 | [break] try {...} ... |
-| cflow.cs:209:13:229:13 | try {...} ... | cflow.cs:220:17:228:17 | [continue] try {...} ... |
-| cflow.cs:209:13:229:13 | try {...} ... | cflow.cs:220:17:228:17 | [return] try {...} ... |
-| cflow.cs:209:13:229:13 | try {...} ... | cflow.cs:221:17:224:17 | [break] {...} |
-| cflow.cs:209:13:229:13 | try {...} ... | cflow.cs:221:17:224:17 | [continue] {...} |
-| cflow.cs:209:13:229:13 | try {...} ... | cflow.cs:221:17:224:17 | [return] {...} |
-| cflow.cs:209:13:229:13 | try {...} ... | cflow.cs:222:21:223:46 | [break] if (...) ... |
-| cflow.cs:209:13:229:13 | try {...} ... | cflow.cs:222:21:223:46 | [continue] if (...) ... |
-| cflow.cs:209:13:229:13 | try {...} ... | cflow.cs:222:21:223:46 | [return] if (...) ... |
-| cflow.cs:209:13:229:13 | try {...} ... | cflow.cs:222:25:222:25 | [break] access to local variable i |
-| cflow.cs:209:13:229:13 | try {...} ... | cflow.cs:222:25:222:25 | [continue] access to local variable i |
-| cflow.cs:209:13:229:13 | try {...} ... | cflow.cs:222:25:222:25 | [return] access to local variable i |
-| cflow.cs:209:13:229:13 | try {...} ... | cflow.cs:222:25:222:30 | [break] ... == ... |
-| cflow.cs:209:13:229:13 | try {...} ... | cflow.cs:222:25:222:30 | [continue] ... == ... |
-| cflow.cs:209:13:229:13 | try {...} ... | cflow.cs:222:25:222:30 | [return] ... == ... |
-| cflow.cs:209:13:229:13 | try {...} ... | cflow.cs:222:30:222:30 | [break] 3 |
-| cflow.cs:209:13:229:13 | try {...} ... | cflow.cs:222:30:222:30 | [continue] 3 |
-| cflow.cs:209:13:229:13 | try {...} ... | cflow.cs:222:30:222:30 | [return] 3 |
-| cflow.cs:209:13:229:13 | try {...} ... | cflow.cs:223:25:223:46 | [break] throw ...; |
-| cflow.cs:209:13:229:13 | try {...} ... | cflow.cs:223:25:223:46 | [continue] throw ...; |
-| cflow.cs:209:13:229:13 | try {...} ... | cflow.cs:223:25:223:46 | [return] throw ...; |
-| cflow.cs:209:13:229:13 | try {...} ... | cflow.cs:223:31:223:45 | [break] object creation of type Exception |
-| cflow.cs:209:13:229:13 | try {...} ... | cflow.cs:223:31:223:45 | [continue] object creation of type Exception |
-| cflow.cs:209:13:229:13 | try {...} ... | cflow.cs:223:31:223:45 | [return] object creation of type Exception |
-| cflow.cs:220:17:228:17 | try {...} ... | cflow.cs:226:17:228:17 | [break] {...} |
-| cflow.cs:220:17:228:17 | try {...} ... | cflow.cs:226:17:228:17 | [continue] {...} |
-| cflow.cs:220:17:228:17 | try {...} ... | cflow.cs:226:17:228:17 | [exception(Exception)] {...} |
-| cflow.cs:220:17:228:17 | try {...} ... | cflow.cs:226:17:228:17 | [return] {...} |
-| cflow.cs:220:17:228:17 | try {...} ... | cflow.cs:227:21:227:21 | [break] access to local variable i |
-| cflow.cs:220:17:228:17 | try {...} ... | cflow.cs:227:21:227:21 | [continue] access to local variable i |
-| cflow.cs:220:17:228:17 | try {...} ... | cflow.cs:227:21:227:21 | [exception(Exception)] access to local variable i |
-| cflow.cs:220:17:228:17 | try {...} ... | cflow.cs:227:21:227:21 | [return] access to local variable i |
-| cflow.cs:220:17:228:17 | try {...} ... | cflow.cs:227:21:227:23 | [break] ...-- |
-| cflow.cs:220:17:228:17 | try {...} ... | cflow.cs:227:21:227:23 | [continue] ...-- |
-| cflow.cs:220:17:228:17 | try {...} ... | cflow.cs:227:21:227:23 | [exception(Exception)] ...-- |
-| cflow.cs:220:17:228:17 | try {...} ... | cflow.cs:227:21:227:23 | [return] ...-- |
-| cflow.cs:220:17:228:17 | try {...} ... | cflow.cs:227:21:227:24 | [break] ...; |
-| cflow.cs:220:17:228:17 | try {...} ... | cflow.cs:227:21:227:24 | [continue] ...; |
-| cflow.cs:220:17:228:17 | try {...} ... | cflow.cs:227:21:227:24 | [exception(Exception)] ...; |
-| cflow.cs:220:17:228:17 | try {...} ... | cflow.cs:227:21:227:24 | [return] ...; |
-| cflow.cs:232:9:245:9 | try {...} ... | cflow.cs:240:9:245:9 | [exception(Exception)] {...} |
-| cflow.cs:232:9:245:9 | try {...} ... | cflow.cs:240:9:245:9 | [exception(NullReferenceException)] {...} |
-| cflow.cs:232:9:245:9 | try {...} ... | cflow.cs:240:9:245:9 | [exception(OutOfMemoryException)] {...} |
-| cflow.cs:232:9:245:9 | try {...} ... | cflow.cs:240:9:245:9 | [return] {...} |
-| cflow.cs:232:9:245:9 | try {...} ... | cflow.cs:241:13:242:41 | [exception(Exception)] if (...) ... |
-| cflow.cs:232:9:245:9 | try {...} ... | cflow.cs:241:13:242:41 | [exception(NullReferenceException)] if (...) ... |
-| cflow.cs:232:9:245:9 | try {...} ... | cflow.cs:241:13:242:41 | [exception(OutOfMemoryException)] if (...) ... |
-| cflow.cs:232:9:245:9 | try {...} ... | cflow.cs:241:13:242:41 | [return] if (...) ... |
-| cflow.cs:232:9:245:9 | try {...} ... | cflow.cs:241:17:241:36 | [exception(Exception)] !... |
-| cflow.cs:232:9:245:9 | try {...} ... | cflow.cs:241:17:241:36 | [exception(NullReferenceException)] !... |
-| cflow.cs:232:9:245:9 | try {...} ... | cflow.cs:241:17:241:36 | [exception(OutOfMemoryException)] !... |
-| cflow.cs:232:9:245:9 | try {...} ... | cflow.cs:241:17:241:36 | [return] !... |
-| cflow.cs:232:9:245:9 | try {...} ... | cflow.cs:241:19:241:23 | [exception(Exception)] access to field Field |
-| cflow.cs:232:9:245:9 | try {...} ... | cflow.cs:241:19:241:23 | [exception(Exception)] this access |
-| cflow.cs:232:9:245:9 | try {...} ... | cflow.cs:241:19:241:23 | [exception(NullReferenceException)] access to field Field |
-| cflow.cs:232:9:245:9 | try {...} ... | cflow.cs:241:19:241:23 | [exception(NullReferenceException)] this access |
-| cflow.cs:232:9:245:9 | try {...} ... | cflow.cs:241:19:241:23 | [exception(OutOfMemoryException)] access to field Field |
-| cflow.cs:232:9:245:9 | try {...} ... | cflow.cs:241:19:241:23 | [exception(OutOfMemoryException)] this access |
-| cflow.cs:232:9:245:9 | try {...} ... | cflow.cs:241:19:241:23 | [return] access to field Field |
-| cflow.cs:232:9:245:9 | try {...} ... | cflow.cs:241:19:241:23 | [return] this access |
-| cflow.cs:232:9:245:9 | try {...} ... | cflow.cs:241:19:241:30 | [exception(Exception)] access to property Length |
-| cflow.cs:232:9:245:9 | try {...} ... | cflow.cs:241:19:241:30 | [exception(NullReferenceException)] access to property Length |
-| cflow.cs:232:9:245:9 | try {...} ... | cflow.cs:241:19:241:30 | [exception(OutOfMemoryException)] access to property Length |
-| cflow.cs:232:9:245:9 | try {...} ... | cflow.cs:241:19:241:30 | [return] access to property Length |
-| cflow.cs:232:9:245:9 | try {...} ... | cflow.cs:241:19:241:35 | [exception(Exception)] ... == ... |
-| cflow.cs:232:9:245:9 | try {...} ... | cflow.cs:241:19:241:35 | [exception(NullReferenceException)] ... == ... |
-| cflow.cs:232:9:245:9 | try {...} ... | cflow.cs:241:19:241:35 | [exception(OutOfMemoryException)] ... == ... |
-| cflow.cs:232:9:245:9 | try {...} ... | cflow.cs:241:19:241:35 | [return] ... == ... |
-| cflow.cs:232:9:245:9 | try {...} ... | cflow.cs:241:35:241:35 | [exception(Exception)] 0 |
-| cflow.cs:232:9:245:9 | try {...} ... | cflow.cs:241:35:241:35 | [exception(NullReferenceException)] 0 |
-| cflow.cs:232:9:245:9 | try {...} ... | cflow.cs:241:35:241:35 | [exception(OutOfMemoryException)] 0 |
-| cflow.cs:232:9:245:9 | try {...} ... | cflow.cs:241:35:241:35 | [return] 0 |
-| cflow.cs:232:9:245:9 | try {...} ... | cflow.cs:242:17:242:40 | [exception(Exception)] call to method WriteLine |
-| cflow.cs:232:9:245:9 | try {...} ... | cflow.cs:242:17:242:40 | [exception(NullReferenceException)] call to method WriteLine |
-| cflow.cs:232:9:245:9 | try {...} ... | cflow.cs:242:17:242:40 | [exception(OutOfMemoryException)] call to method WriteLine |
-| cflow.cs:232:9:245:9 | try {...} ... | cflow.cs:242:17:242:40 | [return] call to method WriteLine |
-| cflow.cs:232:9:245:9 | try {...} ... | cflow.cs:242:17:242:41 | [exception(Exception)] ...; |
-| cflow.cs:232:9:245:9 | try {...} ... | cflow.cs:242:17:242:41 | [exception(NullReferenceException)] ...; |
-| cflow.cs:232:9:245:9 | try {...} ... | cflow.cs:242:17:242:41 | [exception(OutOfMemoryException)] ...; |
-| cflow.cs:232:9:245:9 | try {...} ... | cflow.cs:242:17:242:41 | [return] ...; |
-| cflow.cs:232:9:245:9 | try {...} ... | cflow.cs:242:35:242:39 | [exception(Exception)] access to field Field |
-| cflow.cs:232:9:245:9 | try {...} ... | cflow.cs:242:35:242:39 | [exception(Exception)] this access |
-| cflow.cs:232:9:245:9 | try {...} ... | cflow.cs:242:35:242:39 | [exception(NullReferenceException)] access to field Field |
-| cflow.cs:232:9:245:9 | try {...} ... | cflow.cs:242:35:242:39 | [exception(NullReferenceException)] this access |
-| cflow.cs:232:9:245:9 | try {...} ... | cflow.cs:242:35:242:39 | [exception(OutOfMemoryException)] access to field Field |
-| cflow.cs:232:9:245:9 | try {...} ... | cflow.cs:242:35:242:39 | [exception(OutOfMemoryException)] this access |
-| cflow.cs:232:9:245:9 | try {...} ... | cflow.cs:242:35:242:39 | [return] access to field Field |
-| cflow.cs:232:9:245:9 | try {...} ... | cflow.cs:242:35:242:39 | [return] this access |
-| cflow.cs:232:9:245:9 | try {...} ... | cflow.cs:243:13:244:37 | [exception(Exception)] if (...) ... |
-| cflow.cs:232:9:245:9 | try {...} ... | cflow.cs:243:13:244:37 | [exception(NullReferenceException)] if (...) ... |
-| cflow.cs:232:9:245:9 | try {...} ... | cflow.cs:243:13:244:37 | [exception(OutOfMemoryException)] if (...) ... |
-| cflow.cs:232:9:245:9 | try {...} ... | cflow.cs:243:13:244:37 | [return] if (...) ... |
-| cflow.cs:232:9:245:9 | try {...} ... | cflow.cs:243:17:243:21 | [exception(Exception)] access to field Field |
-| cflow.cs:232:9:245:9 | try {...} ... | cflow.cs:243:17:243:21 | [exception(Exception)] this access |
-| cflow.cs:232:9:245:9 | try {...} ... | cflow.cs:243:17:243:21 | [exception(NullReferenceException)] access to field Field |
-| cflow.cs:232:9:245:9 | try {...} ... | cflow.cs:243:17:243:21 | [exception(NullReferenceException)] this access |
-| cflow.cs:232:9:245:9 | try {...} ... | cflow.cs:243:17:243:21 | [exception(OutOfMemoryException)] access to field Field |
-| cflow.cs:232:9:245:9 | try {...} ... | cflow.cs:243:17:243:21 | [exception(OutOfMemoryException)] this access |
-| cflow.cs:232:9:245:9 | try {...} ... | cflow.cs:243:17:243:21 | [return] access to field Field |
-| cflow.cs:232:9:245:9 | try {...} ... | cflow.cs:243:17:243:21 | [return] this access |
-| cflow.cs:232:9:245:9 | try {...} ... | cflow.cs:243:17:243:28 | [exception(Exception)] access to property Length |
-| cflow.cs:232:9:245:9 | try {...} ... | cflow.cs:243:17:243:28 | [exception(NullReferenceException)] access to property Length |
-| cflow.cs:232:9:245:9 | try {...} ... | cflow.cs:243:17:243:28 | [exception(OutOfMemoryException)] access to property Length |
-| cflow.cs:232:9:245:9 | try {...} ... | cflow.cs:243:17:243:28 | [return] access to property Length |
-| cflow.cs:232:9:245:9 | try {...} ... | cflow.cs:243:17:243:32 | [exception(Exception)] ... > ... |
-| cflow.cs:232:9:245:9 | try {...} ... | cflow.cs:243:17:243:32 | [exception(NullReferenceException)] ... > ... |
-| cflow.cs:232:9:245:9 | try {...} ... | cflow.cs:243:17:243:32 | [exception(OutOfMemoryException)] ... > ... |
-| cflow.cs:232:9:245:9 | try {...} ... | cflow.cs:243:17:243:32 | [return] ... > ... |
-| cflow.cs:232:9:245:9 | try {...} ... | cflow.cs:243:32:243:32 | [exception(Exception)] 0 |
-| cflow.cs:232:9:245:9 | try {...} ... | cflow.cs:243:32:243:32 | [exception(NullReferenceException)] 0 |
-| cflow.cs:232:9:245:9 | try {...} ... | cflow.cs:243:32:243:32 | [exception(OutOfMemoryException)] 0 |
-| cflow.cs:232:9:245:9 | try {...} ... | cflow.cs:243:32:243:32 | [return] 0 |
-| cflow.cs:232:9:245:9 | try {...} ... | cflow.cs:244:17:244:36 | [exception(Exception)] call to method WriteLine |
-| cflow.cs:232:9:245:9 | try {...} ... | cflow.cs:244:17:244:36 | [exception(NullReferenceException)] call to method WriteLine |
-| cflow.cs:232:9:245:9 | try {...} ... | cflow.cs:244:17:244:36 | [exception(OutOfMemoryException)] call to method WriteLine |
-| cflow.cs:232:9:245:9 | try {...} ... | cflow.cs:244:17:244:36 | [return] call to method WriteLine |
-| cflow.cs:232:9:245:9 | try {...} ... | cflow.cs:244:17:244:37 | [exception(Exception)] ...; |
-| cflow.cs:232:9:245:9 | try {...} ... | cflow.cs:244:17:244:37 | [exception(NullReferenceException)] ...; |
-| cflow.cs:232:9:245:9 | try {...} ... | cflow.cs:244:17:244:37 | [exception(OutOfMemoryException)] ...; |
-| cflow.cs:232:9:245:9 | try {...} ... | cflow.cs:244:17:244:37 | [return] ...; |
-| cflow.cs:232:9:245:9 | try {...} ... | cflow.cs:244:35:244:35 | [exception(Exception)] 1 |
-| cflow.cs:232:9:245:9 | try {...} ... | cflow.cs:244:35:244:35 | [exception(NullReferenceException)] 1 |
-| cflow.cs:232:9:245:9 | try {...} ... | cflow.cs:244:35:244:35 | [exception(OutOfMemoryException)] 1 |
-| cflow.cs:232:9:245:9 | try {...} ... | cflow.cs:244:35:244:35 | [return] 1 |
-| cflow.cs:370:9:378:9 | try {...} ... | cflow.cs:376:9:378:9 | [return] {...} |
-| cflow.cs:370:9:378:9 | try {...} ... | cflow.cs:377:13:377:41 | [return] call to method WriteLine |
-| cflow.cs:370:9:378:9 | try {...} ... | cflow.cs:377:13:377:42 | [return] ...; |
-| cflow.cs:370:9:378:9 | try {...} ... | cflow.cs:377:31:377:40 | [return] "not dead" |
-| cflow.cs:395:9:403:9 | try {...} ... | cflow.cs:400:9:403:9 | [exception(Exception)] {...} |
-| cflow.cs:395:9:403:9 | try {...} ... | cflow.cs:400:9:403:9 | [exception(OutOfMemoryException)] {...} |
-| cflow.cs:395:9:403:9 | try {...} ... | cflow.cs:401:13:401:44 | [exception(Exception)] throw ...; |
-| cflow.cs:395:9:403:9 | try {...} ... | cflow.cs:401:13:401:44 | [exception(OutOfMemoryException)] throw ...; |
-| cflow.cs:395:9:403:9 | try {...} ... | cflow.cs:401:19:401:43 | [exception(Exception)] object creation of type ArgumentException |
-| cflow.cs:395:9:403:9 | try {...} ... | cflow.cs:401:19:401:43 | [exception(OutOfMemoryException)] object creation of type ArgumentException |
-| cflow.cs:395:9:403:9 | try {...} ... | cflow.cs:401:41:401:42 | [exception(Exception)] "" |
-| cflow.cs:395:9:403:9 | try {...} ... | cflow.cs:401:41:401:42 | [exception(OutOfMemoryException)] "" |
+| BreakInTry.cs:24:13:33:13 | try {...} ... | BreakInTry.cs:30:13:33:13 | [finally: break] {...} |
+| BreakInTry.cs:24:13:33:13 | try {...} ... | BreakInTry.cs:31:17:32:21 | [finally: break] if (...) ... |
+| BreakInTry.cs:24:13:33:13 | try {...} ... | BreakInTry.cs:31:21:31:24 | [finally: break] access to parameter args |
+| BreakInTry.cs:24:13:33:13 | try {...} ... | BreakInTry.cs:31:21:31:32 | [finally: break] ... == ... |
+| BreakInTry.cs:24:13:33:13 | try {...} ... | BreakInTry.cs:31:29:31:32 | [finally: break] null |
+| BreakInTry.cs:24:13:33:13 | try {...} ... | BreakInTry.cs:32:21:32:21 | [finally: break] ; |
+| BreakInTry.cs:40:9:52:9 | try {...} ... | BreakInTry.cs:46:9:52:9 | [finally: return] {...} |
+| BreakInTry.cs:40:9:52:9 | try {...} ... | BreakInTry.cs:47:13:51:13 | [finally: return] foreach (... ... in ...) ... |
+| BreakInTry.cs:40:9:52:9 | try {...} ... | BreakInTry.cs:47:26:47:28 | [finally: return] String arg |
+| BreakInTry.cs:40:9:52:9 | try {...} ... | BreakInTry.cs:47:33:47:36 | [finally: return] access to parameter args |
+| BreakInTry.cs:40:9:52:9 | try {...} ... | BreakInTry.cs:48:13:51:13 | [finally: return] {...} |
+| BreakInTry.cs:40:9:52:9 | try {...} ... | BreakInTry.cs:49:17:50:26 | [finally: return] if (...) ... |
+| BreakInTry.cs:40:9:52:9 | try {...} ... | BreakInTry.cs:49:21:49:23 | [finally: return] access to local variable arg |
+| BreakInTry.cs:40:9:52:9 | try {...} ... | BreakInTry.cs:49:21:49:31 | [finally: return] ... == ... |
+| BreakInTry.cs:40:9:52:9 | try {...} ... | BreakInTry.cs:49:28:49:31 | [finally: return] null |
+| BreakInTry.cs:40:9:52:9 | try {...} ... | BreakInTry.cs:50:21:50:26 | [finally: return] break; |
+| BreakInTry.cs:58:9:70:9 | try {...} ... | BreakInTry.cs:64:9:70:9 | [finally: return] {...} |
+| BreakInTry.cs:58:9:70:9 | try {...} ... | BreakInTry.cs:65:13:69:13 | [finally: return] foreach (... ... in ...) ... |
+| BreakInTry.cs:58:9:70:9 | try {...} ... | BreakInTry.cs:65:26:65:28 | [finally: return] String arg |
+| BreakInTry.cs:58:9:70:9 | try {...} ... | BreakInTry.cs:65:33:65:36 | [finally: return] access to parameter args |
+| BreakInTry.cs:58:9:70:9 | try {...} ... | BreakInTry.cs:66:13:69:13 | [finally: return] {...} |
+| BreakInTry.cs:58:9:70:9 | try {...} ... | BreakInTry.cs:67:17:68:26 | [finally: return] if (...) ... |
+| BreakInTry.cs:58:9:70:9 | try {...} ... | BreakInTry.cs:67:21:67:23 | [finally: return] access to local variable arg |
+| BreakInTry.cs:58:9:70:9 | try {...} ... | BreakInTry.cs:67:21:67:31 | [finally: return] ... == ... |
+| BreakInTry.cs:58:9:70:9 | try {...} ... | BreakInTry.cs:67:28:67:31 | [finally: return] null |
+| BreakInTry.cs:58:9:70:9 | try {...} ... | BreakInTry.cs:68:21:68:26 | [finally: return] break; |
+| CompileTimeOperators.cs:30:9:38:9 | try {...} ... | CompileTimeOperators.cs:36:9:38:9 | [finally: goto(End)] {...} |
+| CompileTimeOperators.cs:30:9:38:9 | try {...} ... | CompileTimeOperators.cs:37:13:37:40 | [finally: goto(End)] call to method WriteLine |
+| CompileTimeOperators.cs:30:9:38:9 | try {...} ... | CompileTimeOperators.cs:37:13:37:41 | [finally: goto(End)] ...; |
+| CompileTimeOperators.cs:30:9:38:9 | try {...} ... | CompileTimeOperators.cs:37:31:37:39 | [finally: goto(End)] "Finally" |
+| cflow.cs:148:9:155:9 | try {...} ... | cflow.cs:153:9:155:9 | [finally: exception(Exception)] {...} |
+| cflow.cs:148:9:155:9 | try {...} ... | cflow.cs:153:9:155:9 | [finally: exception(OutOfMemoryException)] {...} |
+| cflow.cs:148:9:155:9 | try {...} ... | cflow.cs:154:13:154:40 | [finally: exception(Exception)] call to method WriteLine |
+| cflow.cs:148:9:155:9 | try {...} ... | cflow.cs:154:13:154:40 | [finally: exception(OutOfMemoryException)] call to method WriteLine |
+| cflow.cs:148:9:155:9 | try {...} ... | cflow.cs:154:13:154:41 | [finally: exception(Exception)] ...; |
+| cflow.cs:148:9:155:9 | try {...} ... | cflow.cs:154:13:154:41 | [finally: exception(OutOfMemoryException)] ...; |
+| cflow.cs:148:9:155:9 | try {...} ... | cflow.cs:154:31:154:39 | [finally: exception(Exception)] "Finally" |
+| cflow.cs:148:9:155:9 | try {...} ... | cflow.cs:154:31:154:39 | [finally: exception(OutOfMemoryException)] "Finally" |
+| cflow.cs:157:9:187:9 | try {...} ... | cflow.cs:185:9:187:9 | [finally: exception(Exception)] {...} |
+| cflow.cs:157:9:187:9 | try {...} ... | cflow.cs:185:9:187:9 | [finally: exception(IOException)] {...} |
+| cflow.cs:157:9:187:9 | try {...} ... | cflow.cs:185:9:187:9 | [finally: return] {...} |
+| cflow.cs:157:9:187:9 | try {...} ... | cflow.cs:186:13:186:40 | [finally: exception(Exception)] call to method WriteLine |
+| cflow.cs:157:9:187:9 | try {...} ... | cflow.cs:186:13:186:40 | [finally: exception(IOException)] call to method WriteLine |
+| cflow.cs:157:9:187:9 | try {...} ... | cflow.cs:186:13:186:40 | [finally: return] call to method WriteLine |
+| cflow.cs:157:9:187:9 | try {...} ... | cflow.cs:186:13:186:41 | [finally: exception(Exception)] ...; |
+| cflow.cs:157:9:187:9 | try {...} ... | cflow.cs:186:13:186:41 | [finally: exception(IOException)] ...; |
+| cflow.cs:157:9:187:9 | try {...} ... | cflow.cs:186:13:186:41 | [finally: return] ...; |
+| cflow.cs:157:9:187:9 | try {...} ... | cflow.cs:186:31:186:39 | [finally: exception(Exception)] "Finally" |
+| cflow.cs:157:9:187:9 | try {...} ... | cflow.cs:186:31:186:39 | [finally: exception(IOException)] "Finally" |
+| cflow.cs:157:9:187:9 | try {...} ... | cflow.cs:186:31:186:39 | [finally: return] "Finally" |
+| cflow.cs:168:13:175:13 | try {...} ... | cflow.cs:173:13:175:13 | [finally: exception(ArgumentException)] {...} |
+| cflow.cs:168:13:175:13 | try {...} ... | cflow.cs:174:17:174:44 | [finally: exception(ArgumentException)] throw ...; |
+| cflow.cs:168:13:175:13 | try {...} ... | cflow.cs:174:23:174:43 | [finally: exception(ArgumentException)] object creation of type Exception |
+| cflow.cs:168:13:175:13 | try {...} ... | cflow.cs:174:37:174:42 | [finally: exception(ArgumentException)] "Boo!" |
+| cflow.cs:189:9:204:9 | try {...} ... | cflow.cs:202:9:204:9 | [finally: exception(Exception)] {...} |
+| cflow.cs:189:9:204:9 | try {...} ... | cflow.cs:202:9:204:9 | [finally: exception(IOException)] {...} |
+| cflow.cs:189:9:204:9 | try {...} ... | cflow.cs:202:9:204:9 | [finally: exception(OutOfMemoryException)] {...} |
+| cflow.cs:189:9:204:9 | try {...} ... | cflow.cs:202:9:204:9 | [finally: return] {...} |
+| cflow.cs:189:9:204:9 | try {...} ... | cflow.cs:203:13:203:40 | [finally: exception(Exception)] call to method WriteLine |
+| cflow.cs:189:9:204:9 | try {...} ... | cflow.cs:203:13:203:40 | [finally: exception(IOException)] call to method WriteLine |
+| cflow.cs:189:9:204:9 | try {...} ... | cflow.cs:203:13:203:40 | [finally: exception(OutOfMemoryException)] call to method WriteLine |
+| cflow.cs:189:9:204:9 | try {...} ... | cflow.cs:203:13:203:40 | [finally: return] call to method WriteLine |
+| cflow.cs:189:9:204:9 | try {...} ... | cflow.cs:203:13:203:41 | [finally: exception(Exception)] ...; |
+| cflow.cs:189:9:204:9 | try {...} ... | cflow.cs:203:13:203:41 | [finally: exception(IOException)] ...; |
+| cflow.cs:189:9:204:9 | try {...} ... | cflow.cs:203:13:203:41 | [finally: exception(OutOfMemoryException)] ...; |
+| cflow.cs:189:9:204:9 | try {...} ... | cflow.cs:203:13:203:41 | [finally: return] ...; |
+| cflow.cs:189:9:204:9 | try {...} ... | cflow.cs:203:31:203:39 | [finally: exception(Exception)] "Finally" |
+| cflow.cs:189:9:204:9 | try {...} ... | cflow.cs:203:31:203:39 | [finally: exception(IOException)] "Finally" |
+| cflow.cs:189:9:204:9 | try {...} ... | cflow.cs:203:31:203:39 | [finally: exception(OutOfMemoryException)] "Finally" |
+| cflow.cs:189:9:204:9 | try {...} ... | cflow.cs:203:31:203:39 | [finally: return] "Finally" |
+| cflow.cs:209:13:229:13 | try {...} ... | cflow.cs:219:13:229:13 | [finally: break] {...} |
+| cflow.cs:209:13:229:13 | try {...} ... | cflow.cs:219:13:229:13 | [finally: continue] {...} |
+| cflow.cs:209:13:229:13 | try {...} ... | cflow.cs:219:13:229:13 | [finally: return] {...} |
+| cflow.cs:209:13:229:13 | try {...} ... | cflow.cs:220:17:228:17 | [finally: break] try {...} ... |
+| cflow.cs:209:13:229:13 | try {...} ... | cflow.cs:220:17:228:17 | [finally: continue] try {...} ... |
+| cflow.cs:209:13:229:13 | try {...} ... | cflow.cs:220:17:228:17 | [finally: return] try {...} ... |
+| cflow.cs:209:13:229:13 | try {...} ... | cflow.cs:221:17:224:17 | [finally: break] {...} |
+| cflow.cs:209:13:229:13 | try {...} ... | cflow.cs:221:17:224:17 | [finally: continue] {...} |
+| cflow.cs:209:13:229:13 | try {...} ... | cflow.cs:221:17:224:17 | [finally: return] {...} |
+| cflow.cs:209:13:229:13 | try {...} ... | cflow.cs:222:21:223:46 | [finally: break] if (...) ... |
+| cflow.cs:209:13:229:13 | try {...} ... | cflow.cs:222:21:223:46 | [finally: continue] if (...) ... |
+| cflow.cs:209:13:229:13 | try {...} ... | cflow.cs:222:21:223:46 | [finally: return] if (...) ... |
+| cflow.cs:209:13:229:13 | try {...} ... | cflow.cs:222:25:222:25 | [finally: break] access to local variable i |
+| cflow.cs:209:13:229:13 | try {...} ... | cflow.cs:222:25:222:25 | [finally: continue] access to local variable i |
+| cflow.cs:209:13:229:13 | try {...} ... | cflow.cs:222:25:222:25 | [finally: return] access to local variable i |
+| cflow.cs:209:13:229:13 | try {...} ... | cflow.cs:222:25:222:30 | [finally: break] ... == ... |
+| cflow.cs:209:13:229:13 | try {...} ... | cflow.cs:222:25:222:30 | [finally: continue] ... == ... |
+| cflow.cs:209:13:229:13 | try {...} ... | cflow.cs:222:25:222:30 | [finally: return] ... == ... |
+| cflow.cs:209:13:229:13 | try {...} ... | cflow.cs:222:30:222:30 | [finally: break] 3 |
+| cflow.cs:209:13:229:13 | try {...} ... | cflow.cs:222:30:222:30 | [finally: continue] 3 |
+| cflow.cs:209:13:229:13 | try {...} ... | cflow.cs:222:30:222:30 | [finally: return] 3 |
+| cflow.cs:209:13:229:13 | try {...} ... | cflow.cs:223:25:223:46 | [finally: break] throw ...; |
+| cflow.cs:209:13:229:13 | try {...} ... | cflow.cs:223:25:223:46 | [finally: continue] throw ...; |
+| cflow.cs:209:13:229:13 | try {...} ... | cflow.cs:223:25:223:46 | [finally: return] throw ...; |
+| cflow.cs:209:13:229:13 | try {...} ... | cflow.cs:223:31:223:45 | [finally: break] object creation of type Exception |
+| cflow.cs:209:13:229:13 | try {...} ... | cflow.cs:223:31:223:45 | [finally: continue] object creation of type Exception |
+| cflow.cs:209:13:229:13 | try {...} ... | cflow.cs:223:31:223:45 | [finally: return] object creation of type Exception |
+| cflow.cs:220:17:228:17 | try {...} ... | cflow.cs:226:17:228:17 | [finally: break] {...} |
+| cflow.cs:220:17:228:17 | try {...} ... | cflow.cs:226:17:228:17 | [finally: continue] {...} |
+| cflow.cs:220:17:228:17 | try {...} ... | cflow.cs:226:17:228:17 | [finally: exception(Exception)] {...} |
+| cflow.cs:220:17:228:17 | try {...} ... | cflow.cs:226:17:228:17 | [finally: return] {...} |
+| cflow.cs:220:17:228:17 | try {...} ... | cflow.cs:227:21:227:21 | [finally: break] access to local variable i |
+| cflow.cs:220:17:228:17 | try {...} ... | cflow.cs:227:21:227:21 | [finally: continue] access to local variable i |
+| cflow.cs:220:17:228:17 | try {...} ... | cflow.cs:227:21:227:21 | [finally: exception(Exception)] access to local variable i |
+| cflow.cs:220:17:228:17 | try {...} ... | cflow.cs:227:21:227:21 | [finally: return] access to local variable i |
+| cflow.cs:220:17:228:17 | try {...} ... | cflow.cs:227:21:227:23 | [finally: break] ...-- |
+| cflow.cs:220:17:228:17 | try {...} ... | cflow.cs:227:21:227:23 | [finally: continue] ...-- |
+| cflow.cs:220:17:228:17 | try {...} ... | cflow.cs:227:21:227:23 | [finally: exception(Exception)] ...-- |
+| cflow.cs:220:17:228:17 | try {...} ... | cflow.cs:227:21:227:23 | [finally: return] ...-- |
+| cflow.cs:220:17:228:17 | try {...} ... | cflow.cs:227:21:227:24 | [finally: break] ...; |
+| cflow.cs:220:17:228:17 | try {...} ... | cflow.cs:227:21:227:24 | [finally: continue] ...; |
+| cflow.cs:220:17:228:17 | try {...} ... | cflow.cs:227:21:227:24 | [finally: exception(Exception)] ...; |
+| cflow.cs:220:17:228:17 | try {...} ... | cflow.cs:227:21:227:24 | [finally: return] ...; |
+| cflow.cs:232:9:245:9 | try {...} ... | cflow.cs:240:9:245:9 | [finally: exception(Exception)] {...} |
+| cflow.cs:232:9:245:9 | try {...} ... | cflow.cs:240:9:245:9 | [finally: exception(NullReferenceException)] {...} |
+| cflow.cs:232:9:245:9 | try {...} ... | cflow.cs:240:9:245:9 | [finally: exception(OutOfMemoryException)] {...} |
+| cflow.cs:232:9:245:9 | try {...} ... | cflow.cs:240:9:245:9 | [finally: return] {...} |
+| cflow.cs:232:9:245:9 | try {...} ... | cflow.cs:241:13:242:41 | [finally: exception(Exception)] if (...) ... |
+| cflow.cs:232:9:245:9 | try {...} ... | cflow.cs:241:13:242:41 | [finally: exception(NullReferenceException)] if (...) ... |
+| cflow.cs:232:9:245:9 | try {...} ... | cflow.cs:241:13:242:41 | [finally: exception(OutOfMemoryException)] if (...) ... |
+| cflow.cs:232:9:245:9 | try {...} ... | cflow.cs:241:13:242:41 | [finally: return] if (...) ... |
+| cflow.cs:232:9:245:9 | try {...} ... | cflow.cs:241:17:241:36 | [finally: exception(Exception)] !... |
+| cflow.cs:232:9:245:9 | try {...} ... | cflow.cs:241:17:241:36 | [finally: exception(NullReferenceException)] !... |
+| cflow.cs:232:9:245:9 | try {...} ... | cflow.cs:241:17:241:36 | [finally: exception(OutOfMemoryException)] !... |
+| cflow.cs:232:9:245:9 | try {...} ... | cflow.cs:241:17:241:36 | [finally: return] !... |
+| cflow.cs:232:9:245:9 | try {...} ... | cflow.cs:241:19:241:23 | [finally: exception(Exception)] access to field Field |
+| cflow.cs:232:9:245:9 | try {...} ... | cflow.cs:241:19:241:23 | [finally: exception(Exception)] this access |
+| cflow.cs:232:9:245:9 | try {...} ... | cflow.cs:241:19:241:23 | [finally: exception(NullReferenceException)] access to field Field |
+| cflow.cs:232:9:245:9 | try {...} ... | cflow.cs:241:19:241:23 | [finally: exception(NullReferenceException)] this access |
+| cflow.cs:232:9:245:9 | try {...} ... | cflow.cs:241:19:241:23 | [finally: exception(OutOfMemoryException)] access to field Field |
+| cflow.cs:232:9:245:9 | try {...} ... | cflow.cs:241:19:241:23 | [finally: exception(OutOfMemoryException)] this access |
+| cflow.cs:232:9:245:9 | try {...} ... | cflow.cs:241:19:241:23 | [finally: return] access to field Field |
+| cflow.cs:232:9:245:9 | try {...} ... | cflow.cs:241:19:241:23 | [finally: return] this access |
+| cflow.cs:232:9:245:9 | try {...} ... | cflow.cs:241:19:241:30 | [finally: exception(Exception)] access to property Length |
+| cflow.cs:232:9:245:9 | try {...} ... | cflow.cs:241:19:241:30 | [finally: exception(NullReferenceException)] access to property Length |
+| cflow.cs:232:9:245:9 | try {...} ... | cflow.cs:241:19:241:30 | [finally: exception(OutOfMemoryException)] access to property Length |
+| cflow.cs:232:9:245:9 | try {...} ... | cflow.cs:241:19:241:30 | [finally: return] access to property Length |
+| cflow.cs:232:9:245:9 | try {...} ... | cflow.cs:241:19:241:35 | [finally: exception(Exception)] ... == ... |
+| cflow.cs:232:9:245:9 | try {...} ... | cflow.cs:241:19:241:35 | [finally: exception(NullReferenceException)] ... == ... |
+| cflow.cs:232:9:245:9 | try {...} ... | cflow.cs:241:19:241:35 | [finally: exception(OutOfMemoryException)] ... == ... |
+| cflow.cs:232:9:245:9 | try {...} ... | cflow.cs:241:19:241:35 | [finally: return] ... == ... |
+| cflow.cs:232:9:245:9 | try {...} ... | cflow.cs:241:35:241:35 | [finally: exception(Exception)] 0 |
+| cflow.cs:232:9:245:9 | try {...} ... | cflow.cs:241:35:241:35 | [finally: exception(NullReferenceException)] 0 |
+| cflow.cs:232:9:245:9 | try {...} ... | cflow.cs:241:35:241:35 | [finally: exception(OutOfMemoryException)] 0 |
+| cflow.cs:232:9:245:9 | try {...} ... | cflow.cs:241:35:241:35 | [finally: return] 0 |
+| cflow.cs:232:9:245:9 | try {...} ... | cflow.cs:242:17:242:40 | [finally: exception(Exception)] call to method WriteLine |
+| cflow.cs:232:9:245:9 | try {...} ... | cflow.cs:242:17:242:40 | [finally: exception(NullReferenceException)] call to method WriteLine |
+| cflow.cs:232:9:245:9 | try {...} ... | cflow.cs:242:17:242:40 | [finally: exception(OutOfMemoryException)] call to method WriteLine |
+| cflow.cs:232:9:245:9 | try {...} ... | cflow.cs:242:17:242:40 | [finally: return] call to method WriteLine |
+| cflow.cs:232:9:245:9 | try {...} ... | cflow.cs:242:17:242:41 | [finally: exception(Exception)] ...; |
+| cflow.cs:232:9:245:9 | try {...} ... | cflow.cs:242:17:242:41 | [finally: exception(NullReferenceException)] ...; |
+| cflow.cs:232:9:245:9 | try {...} ... | cflow.cs:242:17:242:41 | [finally: exception(OutOfMemoryException)] ...; |
+| cflow.cs:232:9:245:9 | try {...} ... | cflow.cs:242:17:242:41 | [finally: return] ...; |
+| cflow.cs:232:9:245:9 | try {...} ... | cflow.cs:242:35:242:39 | [finally: exception(Exception)] access to field Field |
+| cflow.cs:232:9:245:9 | try {...} ... | cflow.cs:242:35:242:39 | [finally: exception(Exception)] this access |
+| cflow.cs:232:9:245:9 | try {...} ... | cflow.cs:242:35:242:39 | [finally: exception(NullReferenceException)] access to field Field |
+| cflow.cs:232:9:245:9 | try {...} ... | cflow.cs:242:35:242:39 | [finally: exception(NullReferenceException)] this access |
+| cflow.cs:232:9:245:9 | try {...} ... | cflow.cs:242:35:242:39 | [finally: exception(OutOfMemoryException)] access to field Field |
+| cflow.cs:232:9:245:9 | try {...} ... | cflow.cs:242:35:242:39 | [finally: exception(OutOfMemoryException)] this access |
+| cflow.cs:232:9:245:9 | try {...} ... | cflow.cs:242:35:242:39 | [finally: return] access to field Field |
+| cflow.cs:232:9:245:9 | try {...} ... | cflow.cs:242:35:242:39 | [finally: return] this access |
+| cflow.cs:232:9:245:9 | try {...} ... | cflow.cs:243:13:244:37 | [finally: exception(Exception)] if (...) ... |
+| cflow.cs:232:9:245:9 | try {...} ... | cflow.cs:243:13:244:37 | [finally: exception(NullReferenceException)] if (...) ... |
+| cflow.cs:232:9:245:9 | try {...} ... | cflow.cs:243:13:244:37 | [finally: exception(OutOfMemoryException)] if (...) ... |
+| cflow.cs:232:9:245:9 | try {...} ... | cflow.cs:243:13:244:37 | [finally: return] if (...) ... |
+| cflow.cs:232:9:245:9 | try {...} ... | cflow.cs:243:17:243:21 | [finally: exception(Exception)] access to field Field |
+| cflow.cs:232:9:245:9 | try {...} ... | cflow.cs:243:17:243:21 | [finally: exception(Exception)] this access |
+| cflow.cs:232:9:245:9 | try {...} ... | cflow.cs:243:17:243:21 | [finally: exception(NullReferenceException)] access to field Field |
+| cflow.cs:232:9:245:9 | try {...} ... | cflow.cs:243:17:243:21 | [finally: exception(NullReferenceException)] this access |
+| cflow.cs:232:9:245:9 | try {...} ... | cflow.cs:243:17:243:21 | [finally: exception(OutOfMemoryException)] access to field Field |
+| cflow.cs:232:9:245:9 | try {...} ... | cflow.cs:243:17:243:21 | [finally: exception(OutOfMemoryException)] this access |
+| cflow.cs:232:9:245:9 | try {...} ... | cflow.cs:243:17:243:21 | [finally: return] access to field Field |
+| cflow.cs:232:9:245:9 | try {...} ... | cflow.cs:243:17:243:21 | [finally: return] this access |
+| cflow.cs:232:9:245:9 | try {...} ... | cflow.cs:243:17:243:28 | [finally: exception(Exception)] access to property Length |
+| cflow.cs:232:9:245:9 | try {...} ... | cflow.cs:243:17:243:28 | [finally: exception(NullReferenceException)] access to property Length |
+| cflow.cs:232:9:245:9 | try {...} ... | cflow.cs:243:17:243:28 | [finally: exception(OutOfMemoryException)] access to property Length |
+| cflow.cs:232:9:245:9 | try {...} ... | cflow.cs:243:17:243:28 | [finally: return] access to property Length |
+| cflow.cs:232:9:245:9 | try {...} ... | cflow.cs:243:17:243:32 | [finally: exception(Exception)] ... > ... |
+| cflow.cs:232:9:245:9 | try {...} ... | cflow.cs:243:17:243:32 | [finally: exception(NullReferenceException)] ... > ... |
+| cflow.cs:232:9:245:9 | try {...} ... | cflow.cs:243:17:243:32 | [finally: exception(OutOfMemoryException)] ... > ... |
+| cflow.cs:232:9:245:9 | try {...} ... | cflow.cs:243:17:243:32 | [finally: return] ... > ... |
+| cflow.cs:232:9:245:9 | try {...} ... | cflow.cs:243:32:243:32 | [finally: exception(Exception)] 0 |
+| cflow.cs:232:9:245:9 | try {...} ... | cflow.cs:243:32:243:32 | [finally: exception(NullReferenceException)] 0 |
+| cflow.cs:232:9:245:9 | try {...} ... | cflow.cs:243:32:243:32 | [finally: exception(OutOfMemoryException)] 0 |
+| cflow.cs:232:9:245:9 | try {...} ... | cflow.cs:243:32:243:32 | [finally: return] 0 |
+| cflow.cs:232:9:245:9 | try {...} ... | cflow.cs:244:17:244:36 | [finally: exception(Exception)] call to method WriteLine |
+| cflow.cs:232:9:245:9 | try {...} ... | cflow.cs:244:17:244:36 | [finally: exception(NullReferenceException)] call to method WriteLine |
+| cflow.cs:232:9:245:9 | try {...} ... | cflow.cs:244:17:244:36 | [finally: exception(OutOfMemoryException)] call to method WriteLine |
+| cflow.cs:232:9:245:9 | try {...} ... | cflow.cs:244:17:244:36 | [finally: return] call to method WriteLine |
+| cflow.cs:232:9:245:9 | try {...} ... | cflow.cs:244:17:244:37 | [finally: exception(Exception)] ...; |
+| cflow.cs:232:9:245:9 | try {...} ... | cflow.cs:244:17:244:37 | [finally: exception(NullReferenceException)] ...; |
+| cflow.cs:232:9:245:9 | try {...} ... | cflow.cs:244:17:244:37 | [finally: exception(OutOfMemoryException)] ...; |
+| cflow.cs:232:9:245:9 | try {...} ... | cflow.cs:244:17:244:37 | [finally: return] ...; |
+| cflow.cs:232:9:245:9 | try {...} ... | cflow.cs:244:35:244:35 | [finally: exception(Exception)] 1 |
+| cflow.cs:232:9:245:9 | try {...} ... | cflow.cs:244:35:244:35 | [finally: exception(NullReferenceException)] 1 |
+| cflow.cs:232:9:245:9 | try {...} ... | cflow.cs:244:35:244:35 | [finally: exception(OutOfMemoryException)] 1 |
+| cflow.cs:232:9:245:9 | try {...} ... | cflow.cs:244:35:244:35 | [finally: return] 1 |
+| cflow.cs:370:9:378:9 | try {...} ... | cflow.cs:376:9:378:9 | [finally: return] {...} |
+| cflow.cs:370:9:378:9 | try {...} ... | cflow.cs:377:13:377:41 | [finally: return] call to method WriteLine |
+| cflow.cs:370:9:378:9 | try {...} ... | cflow.cs:377:13:377:42 | [finally: return] ...; |
+| cflow.cs:370:9:378:9 | try {...} ... | cflow.cs:377:31:377:40 | [finally: return] "not dead" |
+| cflow.cs:395:9:403:9 | try {...} ... | cflow.cs:400:9:403:9 | [finally: exception(Exception)] {...} |
+| cflow.cs:395:9:403:9 | try {...} ... | cflow.cs:400:9:403:9 | [finally: exception(OutOfMemoryException)] {...} |
+| cflow.cs:395:9:403:9 | try {...} ... | cflow.cs:401:13:401:44 | [finally: exception(Exception)] throw ...; |
+| cflow.cs:395:9:403:9 | try {...} ... | cflow.cs:401:13:401:44 | [finally: exception(OutOfMemoryException)] throw ...; |
+| cflow.cs:395:9:403:9 | try {...} ... | cflow.cs:401:19:401:43 | [finally: exception(Exception)] object creation of type ArgumentException |
+| cflow.cs:395:9:403:9 | try {...} ... | cflow.cs:401:19:401:43 | [finally: exception(OutOfMemoryException)] object creation of type ArgumentException |
+| cflow.cs:395:9:403:9 | try {...} ... | cflow.cs:401:41:401:42 | [finally: exception(Exception)] "" |
+| cflow.cs:395:9:403:9 | try {...} ... | cflow.cs:401:41:401:42 | [finally: exception(OutOfMemoryException)] "" |

--- a/csharp/ql/test/library-tests/controlflow/graph/FinallyNode.expected
+++ b/csharp/ql/test/library-tests/controlflow/graph/FinallyNode.expected
@@ -24,6 +24,74 @@
 | BreakInTry.cs:58:9:70:9 | try {...} ... | BreakInTry.cs:67:21:67:31 | [finally: return] ... == ... |
 | BreakInTry.cs:58:9:70:9 | try {...} ... | BreakInTry.cs:67:28:67:31 | [finally: return] null |
 | BreakInTry.cs:58:9:70:9 | try {...} ... | BreakInTry.cs:68:21:68:26 | [finally: return] break; |
+| CatchInFinally.cs:7:9:27:9 | try {...} ... | CatchInFinally.cs:13:9:27:9 | [finally: exception(ArgumentNullException)] {...} |
+| CatchInFinally.cs:7:9:27:9 | try {...} ... | CatchInFinally.cs:13:9:27:9 | [finally: exception(Exception)] {...} |
+| CatchInFinally.cs:7:9:27:9 | try {...} ... | CatchInFinally.cs:14:13:26:13 | [finally: exception(ArgumentNullException)] try {...} ... |
+| CatchInFinally.cs:7:9:27:9 | try {...} ... | CatchInFinally.cs:14:13:26:13 | [finally: exception(Exception)] try {...} ... |
+| CatchInFinally.cs:7:9:27:9 | try {...} ... | CatchInFinally.cs:15:13:18:13 | [finally: exception(ArgumentNullException)] {...} |
+| CatchInFinally.cs:7:9:27:9 | try {...} ... | CatchInFinally.cs:15:13:18:13 | [finally: exception(Exception)] {...} |
+| CatchInFinally.cs:7:9:27:9 | try {...} ... | CatchInFinally.cs:16:17:17:45 | [finally: exception(ArgumentNullException)] if (...) ... |
+| CatchInFinally.cs:7:9:27:9 | try {...} ... | CatchInFinally.cs:16:17:17:45 | [finally: exception(Exception)] if (...) ... |
+| CatchInFinally.cs:7:9:27:9 | try {...} ... | CatchInFinally.cs:16:21:16:24 | [finally: exception(ArgumentNullException)] access to parameter args |
+| CatchInFinally.cs:7:9:27:9 | try {...} ... | CatchInFinally.cs:16:21:16:24 | [finally: exception(Exception)] access to parameter args |
+| CatchInFinally.cs:7:9:27:9 | try {...} ... | CatchInFinally.cs:16:21:16:31 | [finally: exception(ArgumentNullException)] access to property Length |
+| CatchInFinally.cs:7:9:27:9 | try {...} ... | CatchInFinally.cs:16:21:16:31 | [finally: exception(Exception)] access to property Length |
+| CatchInFinally.cs:7:9:27:9 | try {...} ... | CatchInFinally.cs:16:21:16:36 | [finally: exception(ArgumentNullException)] ... == ... |
+| CatchInFinally.cs:7:9:27:9 | try {...} ... | CatchInFinally.cs:16:21:16:36 | [finally: exception(Exception)] ... == ... |
+| CatchInFinally.cs:7:9:27:9 | try {...} ... | CatchInFinally.cs:16:36:16:36 | [finally: exception(ArgumentNullException)] 1 |
+| CatchInFinally.cs:7:9:27:9 | try {...} ... | CatchInFinally.cs:16:36:16:36 | [finally: exception(Exception)] 1 |
+| CatchInFinally.cs:7:9:27:9 | try {...} ... | CatchInFinally.cs:17:21:17:45 | [finally: exception(ArgumentNullException)] throw ...; |
+| CatchInFinally.cs:7:9:27:9 | try {...} ... | CatchInFinally.cs:17:21:17:45 | [finally: exception(Exception)] throw ...; |
+| CatchInFinally.cs:7:9:27:9 | try {...} ... | CatchInFinally.cs:17:27:17:44 | [finally: exception(ArgumentNullException)] object creation of type Exception |
+| CatchInFinally.cs:7:9:27:9 | try {...} ... | CatchInFinally.cs:17:27:17:44 | [finally: exception(Exception)] object creation of type Exception |
+| CatchInFinally.cs:7:9:27:9 | try {...} ... | CatchInFinally.cs:17:41:17:43 | [finally: exception(ArgumentNullException)] "1" |
+| CatchInFinally.cs:7:9:27:9 | try {...} ... | CatchInFinally.cs:17:41:17:43 | [finally: exception(Exception)] "1" |
+| CatchInFinally.cs:7:9:27:9 | try {...} ... | CatchInFinally.cs:19:13:22:13 | [exception: Exception, finally: exception(ArgumentNullException)] catch (...) {...} |
+| CatchInFinally.cs:7:9:27:9 | try {...} ... | CatchInFinally.cs:19:13:22:13 | [exception: Exception, finally: exception(Exception)] catch (...) {...} |
+| CatchInFinally.cs:7:9:27:9 | try {...} ... | CatchInFinally.cs:19:13:22:13 | [exception: NullReferenceException, finally: exception(ArgumentNullException)] catch (...) {...} |
+| CatchInFinally.cs:7:9:27:9 | try {...} ... | CatchInFinally.cs:19:13:22:13 | [exception: NullReferenceException, finally: exception(Exception)] catch (...) {...} |
+| CatchInFinally.cs:7:9:27:9 | try {...} ... | CatchInFinally.cs:19:30:19:30 | [exception: Exception, finally: exception(ArgumentNullException)] Exception e |
+| CatchInFinally.cs:7:9:27:9 | try {...} ... | CatchInFinally.cs:19:30:19:30 | [exception: Exception, finally: exception(Exception)] Exception e |
+| CatchInFinally.cs:7:9:27:9 | try {...} ... | CatchInFinally.cs:19:30:19:30 | [exception: NullReferenceException, finally: exception(ArgumentNullException)] Exception e |
+| CatchInFinally.cs:7:9:27:9 | try {...} ... | CatchInFinally.cs:19:30:19:30 | [exception: NullReferenceException, finally: exception(Exception)] Exception e |
+| CatchInFinally.cs:7:9:27:9 | try {...} ... | CatchInFinally.cs:19:39:19:39 | [exception: Exception, finally: exception(ArgumentNullException)] access to local variable e |
+| CatchInFinally.cs:7:9:27:9 | try {...} ... | CatchInFinally.cs:19:39:19:39 | [exception: Exception, finally: exception(Exception)] access to local variable e |
+| CatchInFinally.cs:7:9:27:9 | try {...} ... | CatchInFinally.cs:19:39:19:39 | [exception: NullReferenceException, finally: exception(ArgumentNullException)] access to local variable e |
+| CatchInFinally.cs:7:9:27:9 | try {...} ... | CatchInFinally.cs:19:39:19:39 | [exception: NullReferenceException, finally: exception(Exception)] access to local variable e |
+| CatchInFinally.cs:7:9:27:9 | try {...} ... | CatchInFinally.cs:19:39:19:47 | [exception: Exception, finally: exception(ArgumentNullException)] access to property Message |
+| CatchInFinally.cs:7:9:27:9 | try {...} ... | CatchInFinally.cs:19:39:19:47 | [exception: Exception, finally: exception(Exception)] access to property Message |
+| CatchInFinally.cs:7:9:27:9 | try {...} ... | CatchInFinally.cs:19:39:19:47 | [exception: NullReferenceException, finally: exception(ArgumentNullException)] access to property Message |
+| CatchInFinally.cs:7:9:27:9 | try {...} ... | CatchInFinally.cs:19:39:19:47 | [exception: NullReferenceException, finally: exception(Exception)] access to property Message |
+| CatchInFinally.cs:7:9:27:9 | try {...} ... | CatchInFinally.cs:19:39:19:54 | [exception: Exception, finally: exception(ArgumentNullException)] ... == ... |
+| CatchInFinally.cs:7:9:27:9 | try {...} ... | CatchInFinally.cs:19:39:19:54 | [exception: Exception, finally: exception(Exception)] ... == ... |
+| CatchInFinally.cs:7:9:27:9 | try {...} ... | CatchInFinally.cs:19:39:19:54 | [exception: NullReferenceException, finally: exception(ArgumentNullException)] ... == ... |
+| CatchInFinally.cs:7:9:27:9 | try {...} ... | CatchInFinally.cs:19:39:19:54 | [exception: NullReferenceException, finally: exception(Exception)] ... == ... |
+| CatchInFinally.cs:7:9:27:9 | try {...} ... | CatchInFinally.cs:19:52:19:54 | [exception: Exception, finally: exception(ArgumentNullException)] "1" |
+| CatchInFinally.cs:7:9:27:9 | try {...} ... | CatchInFinally.cs:19:52:19:54 | [exception: Exception, finally: exception(Exception)] "1" |
+| CatchInFinally.cs:7:9:27:9 | try {...} ... | CatchInFinally.cs:19:52:19:54 | [exception: NullReferenceException, finally: exception(ArgumentNullException)] "1" |
+| CatchInFinally.cs:7:9:27:9 | try {...} ... | CatchInFinally.cs:19:52:19:54 | [exception: NullReferenceException, finally: exception(Exception)] "1" |
+| CatchInFinally.cs:7:9:27:9 | try {...} ... | CatchInFinally.cs:20:13:22:13 | [finally: exception(ArgumentNullException)] {...} |
+| CatchInFinally.cs:7:9:27:9 | try {...} ... | CatchInFinally.cs:20:13:22:13 | [finally: exception(Exception)] {...} |
+| CatchInFinally.cs:7:9:27:9 | try {...} ... | CatchInFinally.cs:21:17:21:42 | [finally: exception(ArgumentNullException)] call to method WriteLine |
+| CatchInFinally.cs:7:9:27:9 | try {...} ... | CatchInFinally.cs:21:17:21:42 | [finally: exception(Exception)] call to method WriteLine |
+| CatchInFinally.cs:7:9:27:9 | try {...} ... | CatchInFinally.cs:21:17:21:43 | [finally: exception(ArgumentNullException)] ...; |
+| CatchInFinally.cs:7:9:27:9 | try {...} ... | CatchInFinally.cs:21:17:21:43 | [finally: exception(Exception)] ...; |
+| CatchInFinally.cs:7:9:27:9 | try {...} ... | CatchInFinally.cs:21:35:21:38 | [finally: exception(ArgumentNullException)] access to parameter args |
+| CatchInFinally.cs:7:9:27:9 | try {...} ... | CatchInFinally.cs:21:35:21:38 | [finally: exception(Exception)] access to parameter args |
+| CatchInFinally.cs:7:9:27:9 | try {...} ... | CatchInFinally.cs:21:35:21:41 | [finally: exception(ArgumentNullException)] access to array element |
+| CatchInFinally.cs:7:9:27:9 | try {...} ... | CatchInFinally.cs:21:35:21:41 | [finally: exception(Exception)] access to array element |
+| CatchInFinally.cs:7:9:27:9 | try {...} ... | CatchInFinally.cs:21:40:21:40 | [finally: exception(ArgumentNullException)] 0 |
+| CatchInFinally.cs:7:9:27:9 | try {...} ... | CatchInFinally.cs:21:40:21:40 | [finally: exception(Exception)] 0 |
+| CatchInFinally.cs:7:9:27:9 | try {...} ... | CatchInFinally.cs:23:13:26:13 | [finally: exception(ArgumentNullException)] catch {...} |
+| CatchInFinally.cs:7:9:27:9 | try {...} ... | CatchInFinally.cs:23:13:26:13 | [finally: exception(Exception)] catch {...} |
+| CatchInFinally.cs:7:9:27:9 | try {...} ... | CatchInFinally.cs:24:13:26:13 | [finally: exception(ArgumentNullException)] {...} |
+| CatchInFinally.cs:7:9:27:9 | try {...} ... | CatchInFinally.cs:24:13:26:13 | [finally: exception(Exception)] {...} |
+| CatchInFinally.cs:7:9:27:9 | try {...} ... | CatchInFinally.cs:25:17:25:37 | [finally: exception(ArgumentNullException)] call to method WriteLine |
+| CatchInFinally.cs:7:9:27:9 | try {...} ... | CatchInFinally.cs:25:17:25:37 | [finally: exception(Exception)] call to method WriteLine |
+| CatchInFinally.cs:7:9:27:9 | try {...} ... | CatchInFinally.cs:25:17:25:38 | [finally: exception(ArgumentNullException)] ...; |
+| CatchInFinally.cs:7:9:27:9 | try {...} ... | CatchInFinally.cs:25:17:25:38 | [finally: exception(Exception)] ...; |
+| CatchInFinally.cs:7:9:27:9 | try {...} ... | CatchInFinally.cs:25:35:25:36 | [finally: exception(ArgumentNullException)] "" |
+| CatchInFinally.cs:7:9:27:9 | try {...} ... | CatchInFinally.cs:25:35:25:36 | [finally: exception(Exception)] "" |
 | CompileTimeOperators.cs:30:9:38:9 | try {...} ... | CompileTimeOperators.cs:36:9:38:9 | [finally: goto(End)] {...} |
 | CompileTimeOperators.cs:30:9:38:9 | try {...} ... | CompileTimeOperators.cs:37:13:37:40 | [finally: goto(End)] call to method WriteLine |
 | CompileTimeOperators.cs:30:9:38:9 | try {...} ... | CompileTimeOperators.cs:37:13:37:41 | [finally: goto(End)] ...; |

--- a/csharp/ql/test/library-tests/controlflow/graph/FinallyNode.ql
+++ b/csharp/ql/test/library-tests/controlflow/graph/FinallyNode.ql
@@ -1,5 +1,19 @@
 import csharp
 import semmle.code.csharp.controlflow.ControlFlowGraph
+import Internal
 
-from FinallySplitControlFlowNode f
+class MyFinallySplitControlFlowNode extends ControlFlowElementNode {
+  MyFinallySplitControlFlowNode() {
+    exists(FinallySplitting::FinallySplitType type |
+      type = this.getASplit().(FinallySplit).getType() |
+      not type instanceof ControlFlowEdgeSuccessor
+    )
+  }
+
+  TryStmt getTryStmt() {
+    this.getElement() = FinallySplitting::getAFinallyDescendant(result)
+  }
+}
+
+from MyFinallySplitControlFlowNode f
 select f.getTryStmt(), f

--- a/csharp/ql/test/library-tests/controlflow/graph/NodeGraph.expected
+++ b/csharp/ql/test/library-tests/controlflow/graph/NodeGraph.expected
@@ -313,15 +313,16 @@
 | ExitMethods.cs:37:5:50:5 | {...} | ExitMethods.cs:38:9:49:9 | try {...} ... | semmle.label | successor |
 | ExitMethods.cs:38:9:49:9 | try {...} ... | ExitMethods.cs:39:9:41:9 | {...} | semmle.label | successor |
 | ExitMethods.cs:39:9:41:9 | {...} | ExitMethods.cs:40:13:40:31 | ...; | semmle.label | successor |
-| ExitMethods.cs:40:13:40:30 | call to method ErrorAlways | ExitMethods.cs:42:9:45:9 | catch (...) {...} | semmle.label | exception(ArgumentException) |
-| ExitMethods.cs:40:13:40:30 | call to method ErrorAlways | ExitMethods.cs:42:9:45:9 | catch (...) {...} | semmle.label | exception(Exception) |
-| ExitMethods.cs:40:13:40:30 | call to method ErrorAlways | ExitMethods.cs:46:9:49:9 | catch (...) {...} | semmle.label | exception(Exception) |
+| ExitMethods.cs:40:13:40:30 | call to method ErrorAlways | ExitMethods.cs:42:9:45:9 | [exception: ArgumentException] catch (...) {...} | semmle.label | exception(ArgumentException) |
+| ExitMethods.cs:40:13:40:30 | call to method ErrorAlways | ExitMethods.cs:42:9:45:9 | [exception: Exception] catch (...) {...} | semmle.label | exception(Exception) |
 | ExitMethods.cs:40:13:40:31 | ...; | ExitMethods.cs:40:25:40:29 | false | semmle.label | successor |
 | ExitMethods.cs:40:25:40:29 | false | ExitMethods.cs:40:13:40:30 | call to method ErrorAlways | semmle.label | successor |
-| ExitMethods.cs:42:9:45:9 | catch (...) {...} | ExitMethods.cs:43:9:45:9 | {...} | semmle.label | successor |
+| ExitMethods.cs:42:9:45:9 | [exception: ArgumentException] catch (...) {...} | ExitMethods.cs:43:9:45:9 | {...} | semmle.label | match |
+| ExitMethods.cs:42:9:45:9 | [exception: Exception] catch (...) {...} | ExitMethods.cs:43:9:45:9 | {...} | semmle.label | match |
+| ExitMethods.cs:42:9:45:9 | [exception: Exception] catch (...) {...} | ExitMethods.cs:46:9:49:9 | [exception: Exception] catch (...) {...} | semmle.label | no-match |
 | ExitMethods.cs:43:9:45:9 | {...} | ExitMethods.cs:44:13:44:19 | return ...; | semmle.label | successor |
 | ExitMethods.cs:44:13:44:19 | return ...; | ExitMethods.cs:36:10:36:11 | exit M6 | semmle.label | return |
-| ExitMethods.cs:46:9:49:9 | catch (...) {...} | ExitMethods.cs:47:9:49:9 | {...} | semmle.label | successor |
+| ExitMethods.cs:46:9:49:9 | [exception: Exception] catch (...) {...} | ExitMethods.cs:47:9:49:9 | {...} | semmle.label | match |
 | ExitMethods.cs:47:9:49:9 | {...} | ExitMethods.cs:48:13:48:19 | return ...; | semmle.label | successor |
 | ExitMethods.cs:48:13:48:19 | return ...; | ExitMethods.cs:36:10:36:11 | exit M6 | semmle.label | return |
 | ExitMethods.cs:52:17:52:26 | enter ErrorMaybe | ExitMethods.cs:53:5:56:5 | {...} | semmle.label | successor |
@@ -1261,20 +1262,22 @@
 | cflow.cs:157:9:187:9 | try {...} ... | cflow.cs:158:9:161:9 | {...} | semmle.label | successor |
 | cflow.cs:158:9:161:9 | {...} | cflow.cs:159:13:159:38 | ...; | semmle.label | successor |
 | cflow.cs:159:13:159:37 | call to method WriteLine | cflow.cs:160:13:160:19 | return ...; | semmle.label | successor |
-| cflow.cs:159:13:159:37 | call to method WriteLine | cflow.cs:162:9:165:9 | catch (...) {...} | semmle.label | exception(Exception) |
-| cflow.cs:159:13:159:37 | call to method WriteLine | cflow.cs:166:9:176:9 | catch (...) {...} | semmle.label | exception(Exception) |
-| cflow.cs:159:13:159:37 | call to method WriteLine | cflow.cs:177:9:179:9 | catch (...) {...} | semmle.label | exception(Exception) |
+| cflow.cs:159:13:159:37 | call to method WriteLine | cflow.cs:162:9:165:9 | [exception: Exception] catch (...) {...} | semmle.label | exception(Exception) |
 | cflow.cs:159:13:159:38 | ...; | cflow.cs:159:31:159:36 | "Try2" | semmle.label | successor |
 | cflow.cs:159:31:159:36 | "Try2" | cflow.cs:159:13:159:37 | call to method WriteLine | semmle.label | successor |
-| cflow.cs:159:31:159:36 | "Try2" | cflow.cs:177:9:179:9 | catch (...) {...} | semmle.label | exception(OutOfMemoryException) |
+| cflow.cs:159:31:159:36 | "Try2" | cflow.cs:162:9:165:9 | [exception: OutOfMemoryException] catch (...) {...} | semmle.label | exception(OutOfMemoryException) |
 | cflow.cs:160:13:160:19 | return ...; | cflow.cs:185:9:187:9 | [finally: return] {...} | semmle.label | return |
-| cflow.cs:162:9:165:9 | catch (...) {...} | cflow.cs:162:38:162:39 | IOException ex | semmle.label | successor |
-| cflow.cs:162:38:162:39 | IOException ex | cflow.cs:162:48:162:51 | true | semmle.label | successor |
-| cflow.cs:162:48:162:51 | true | cflow.cs:163:9:165:9 | {...} | semmle.label | successor |
+| cflow.cs:162:9:165:9 | [exception: Exception] catch (...) {...} | cflow.cs:162:38:162:39 | [exception: Exception] IOException ex | semmle.label | match |
+| cflow.cs:162:9:165:9 | [exception: Exception] catch (...) {...} | cflow.cs:166:9:176:9 | [exception: Exception] catch (...) {...} | semmle.label | no-match |
+| cflow.cs:162:9:165:9 | [exception: OutOfMemoryException] catch (...) {...} | cflow.cs:166:9:176:9 | [exception: OutOfMemoryException] catch (...) {...} | semmle.label | no-match |
+| cflow.cs:162:38:162:39 | [exception: Exception] IOException ex | cflow.cs:162:48:162:51 | [exception: Exception] true | semmle.label | successor |
+| cflow.cs:162:48:162:51 | [exception: Exception] true | cflow.cs:163:9:165:9 | {...} | semmle.label | true |
 | cflow.cs:163:9:165:9 | {...} | cflow.cs:164:13:164:18 | throw ...; | semmle.label | successor |
 | cflow.cs:164:13:164:18 | throw ...; | cflow.cs:185:9:187:9 | [finally: exception(IOException)] {...} | semmle.label | exception(IOException) |
-| cflow.cs:166:9:176:9 | catch (...) {...} | cflow.cs:166:41:166:42 | ArgumentException ex | semmle.label | successor |
-| cflow.cs:166:41:166:42 | ArgumentException ex | cflow.cs:167:9:176:9 | {...} | semmle.label | successor |
+| cflow.cs:166:9:176:9 | [exception: Exception] catch (...) {...} | cflow.cs:166:41:166:42 | [exception: Exception] ArgumentException ex | semmle.label | match |
+| cflow.cs:166:9:176:9 | [exception: Exception] catch (...) {...} | cflow.cs:177:9:179:9 | [exception: Exception] catch (...) {...} | semmle.label | no-match |
+| cflow.cs:166:9:176:9 | [exception: OutOfMemoryException] catch (...) {...} | cflow.cs:177:9:179:9 | [exception: OutOfMemoryException] catch (...) {...} | semmle.label | no-match |
+| cflow.cs:166:41:166:42 | [exception: Exception] ArgumentException ex | cflow.cs:167:9:176:9 | {...} | semmle.label | successor |
 | cflow.cs:167:9:176:9 | {...} | cflow.cs:168:13:175:13 | try {...} ... | semmle.label | successor |
 | cflow.cs:168:13:175:13 | try {...} ... | cflow.cs:169:13:171:13 | {...} | semmle.label | successor |
 | cflow.cs:169:13:171:13 | {...} | cflow.cs:170:17:170:32 | if (...) ... | semmle.label | successor |
@@ -1285,7 +1288,8 @@
 | cflow.cs:174:17:174:44 | [finally: exception(ArgumentException)] throw ...; | cflow.cs:185:9:187:9 | [finally: exception(Exception)] {...} | semmle.label | exception(Exception) |
 | cflow.cs:174:23:174:43 | [finally: exception(ArgumentException)] object creation of type Exception | cflow.cs:174:17:174:44 | [finally: exception(ArgumentException)] throw ...; | semmle.label | successor |
 | cflow.cs:174:37:174:42 | [finally: exception(ArgumentException)] "Boo!" | cflow.cs:174:23:174:43 | [finally: exception(ArgumentException)] object creation of type Exception | semmle.label | successor |
-| cflow.cs:177:9:179:9 | catch (...) {...} | cflow.cs:178:9:179:9 | {...} | semmle.label | successor |
+| cflow.cs:177:9:179:9 | [exception: Exception] catch (...) {...} | cflow.cs:178:9:179:9 | {...} | semmle.label | match |
+| cflow.cs:177:9:179:9 | [exception: OutOfMemoryException] catch (...) {...} | cflow.cs:178:9:179:9 | {...} | semmle.label | match |
 | cflow.cs:178:9:179:9 | {...} | cflow.cs:185:9:187:9 | {...} | semmle.label | successor |
 | cflow.cs:185:9:187:9 | [finally: exception(Exception)] {...} | cflow.cs:186:13:186:41 | [finally: exception(Exception)] ...; | semmle.label | successor |
 | cflow.cs:185:9:187:9 | [finally: exception(IOException)] {...} | cflow.cs:186:13:186:41 | [finally: exception(IOException)] ...; | semmle.label | successor |
@@ -1306,24 +1310,32 @@
 | cflow.cs:189:9:204:9 | try {...} ... | cflow.cs:190:9:193:9 | {...} | semmle.label | successor |
 | cflow.cs:190:9:193:9 | {...} | cflow.cs:191:13:191:38 | ...; | semmle.label | successor |
 | cflow.cs:191:13:191:37 | call to method WriteLine | cflow.cs:192:13:192:19 | return ...; | semmle.label | successor |
-| cflow.cs:191:13:191:37 | call to method WriteLine | cflow.cs:194:9:197:9 | catch (...) {...} | semmle.label | exception(Exception) |
-| cflow.cs:191:13:191:37 | call to method WriteLine | cflow.cs:198:9:200:9 | catch (...) {...} | semmle.label | exception(Exception) |
-| cflow.cs:191:13:191:37 | call to method WriteLine | cflow.cs:202:9:204:9 | [finally: exception(Exception)] {...} | semmle.label | exception(Exception) |
+| cflow.cs:191:13:191:37 | call to method WriteLine | cflow.cs:194:9:197:9 | [exception: Exception] catch (...) {...} | semmle.label | exception(Exception) |
 | cflow.cs:191:13:191:38 | ...; | cflow.cs:191:31:191:36 | "Try3" | semmle.label | successor |
 | cflow.cs:191:31:191:36 | "Try3" | cflow.cs:191:13:191:37 | call to method WriteLine | semmle.label | successor |
-| cflow.cs:191:31:191:36 | "Try3" | cflow.cs:202:9:204:9 | [finally: exception(OutOfMemoryException)] {...} | semmle.label | exception(OutOfMemoryException) |
+| cflow.cs:191:31:191:36 | "Try3" | cflow.cs:194:9:197:9 | [exception: OutOfMemoryException] catch (...) {...} | semmle.label | exception(OutOfMemoryException) |
 | cflow.cs:192:13:192:19 | return ...; | cflow.cs:202:9:204:9 | [finally: return] {...} | semmle.label | return |
-| cflow.cs:194:9:197:9 | catch (...) {...} | cflow.cs:194:38:194:39 | IOException ex | semmle.label | successor |
-| cflow.cs:194:38:194:39 | IOException ex | cflow.cs:194:48:194:51 | true | semmle.label | successor |
-| cflow.cs:194:48:194:51 | true | cflow.cs:195:9:197:9 | {...} | semmle.label | successor |
+| cflow.cs:194:9:197:9 | [exception: Exception] catch (...) {...} | cflow.cs:194:38:194:39 | [exception: Exception] IOException ex | semmle.label | match |
+| cflow.cs:194:9:197:9 | [exception: Exception] catch (...) {...} | cflow.cs:198:9:200:9 | [exception: Exception] catch (...) {...} | semmle.label | no-match |
+| cflow.cs:194:9:197:9 | [exception: OutOfMemoryException] catch (...) {...} | cflow.cs:198:9:200:9 | [exception: OutOfMemoryException] catch (...) {...} | semmle.label | no-match |
+| cflow.cs:194:38:194:39 | [exception: Exception] IOException ex | cflow.cs:194:48:194:51 | [exception: Exception] true | semmle.label | successor |
+| cflow.cs:194:48:194:51 | [exception: Exception] true | cflow.cs:195:9:197:9 | {...} | semmle.label | true |
 | cflow.cs:195:9:197:9 | {...} | cflow.cs:196:13:196:18 | throw ...; | semmle.label | successor |
 | cflow.cs:196:13:196:18 | throw ...; | cflow.cs:202:9:204:9 | [finally: exception(IOException)] {...} | semmle.label | exception(IOException) |
-| cflow.cs:198:9:200:9 | catch (...) {...} | cflow.cs:198:26:198:26 | Exception e | semmle.label | successor |
-| cflow.cs:198:26:198:26 | Exception e | cflow.cs:198:35:198:35 | access to local variable e | semmle.label | successor |
-| cflow.cs:198:35:198:35 | access to local variable e | cflow.cs:198:35:198:43 | access to property Message | semmle.label | successor |
-| cflow.cs:198:35:198:43 | access to property Message | cflow.cs:198:48:198:51 | null | semmle.label | successor |
-| cflow.cs:198:35:198:51 | ... != ... | cflow.cs:199:9:200:9 | {...} | semmle.label | successor |
-| cflow.cs:198:48:198:51 | null | cflow.cs:198:35:198:51 | ... != ... | semmle.label | successor |
+| cflow.cs:198:9:200:9 | [exception: Exception] catch (...) {...} | cflow.cs:198:26:198:26 | [exception: Exception] Exception e | semmle.label | match |
+| cflow.cs:198:9:200:9 | [exception: OutOfMemoryException] catch (...) {...} | cflow.cs:198:26:198:26 | [exception: OutOfMemoryException] Exception e | semmle.label | match |
+| cflow.cs:198:26:198:26 | [exception: Exception] Exception e | cflow.cs:198:35:198:35 | [exception: Exception] access to local variable e | semmle.label | successor |
+| cflow.cs:198:26:198:26 | [exception: OutOfMemoryException] Exception e | cflow.cs:198:35:198:35 | [exception: OutOfMemoryException] access to local variable e | semmle.label | successor |
+| cflow.cs:198:35:198:35 | [exception: Exception] access to local variable e | cflow.cs:198:35:198:43 | [exception: Exception] access to property Message | semmle.label | successor |
+| cflow.cs:198:35:198:35 | [exception: OutOfMemoryException] access to local variable e | cflow.cs:198:35:198:43 | [exception: OutOfMemoryException] access to property Message | semmle.label | successor |
+| cflow.cs:198:35:198:43 | [exception: Exception] access to property Message | cflow.cs:198:48:198:51 | [exception: Exception] null | semmle.label | successor |
+| cflow.cs:198:35:198:43 | [exception: OutOfMemoryException] access to property Message | cflow.cs:198:48:198:51 | [exception: OutOfMemoryException] null | semmle.label | successor |
+| cflow.cs:198:35:198:51 | [exception: Exception] ... != ... | cflow.cs:199:9:200:9 | {...} | semmle.label | true |
+| cflow.cs:198:35:198:51 | [exception: Exception] ... != ... | cflow.cs:202:9:204:9 | [finally: exception(Exception)] {...} | semmle.label | exception(Exception) |
+| cflow.cs:198:35:198:51 | [exception: OutOfMemoryException] ... != ... | cflow.cs:199:9:200:9 | {...} | semmle.label | true |
+| cflow.cs:198:35:198:51 | [exception: OutOfMemoryException] ... != ... | cflow.cs:202:9:204:9 | [finally: exception(OutOfMemoryException)] {...} | semmle.label | exception(OutOfMemoryException) |
+| cflow.cs:198:48:198:51 | [exception: Exception] null | cflow.cs:198:35:198:51 | [exception: Exception] ... != ... | semmle.label | successor |
+| cflow.cs:198:48:198:51 | [exception: OutOfMemoryException] null | cflow.cs:198:35:198:51 | [exception: OutOfMemoryException] ... != ... | semmle.label | successor |
 | cflow.cs:199:9:200:9 | {...} | cflow.cs:202:9:204:9 | {...} | semmle.label | successor |
 | cflow.cs:202:9:204:9 | [finally: exception(Exception)] {...} | cflow.cs:203:13:203:41 | [finally: exception(Exception)] ...; | semmle.label | successor |
 | cflow.cs:202:9:204:9 | [finally: exception(IOException)] {...} | cflow.cs:203:13:203:41 | [finally: exception(IOException)] ...; | semmle.label | successor |

--- a/csharp/ql/test/library-tests/controlflow/graph/NodeGraph.expected
+++ b/csharp/ql/test/library-tests/controlflow/graph/NodeGraph.expected
@@ -99,21 +99,21 @@
 | BreakInTry.cs:26:21:26:31 | ... == ... | BreakInTry.cs:27:21:27:26 | break; | semmle.label | true |
 | BreakInTry.cs:26:21:26:31 | ... == ... | BreakInTry.cs:30:13:33:13 | {...} | semmle.label | false |
 | BreakInTry.cs:26:28:26:31 | null | BreakInTry.cs:26:21:26:31 | ... == ... | semmle.label | successor |
-| BreakInTry.cs:27:21:27:26 | break; | BreakInTry.cs:30:13:33:13 | [break] {...} | semmle.label | break |
-| BreakInTry.cs:30:13:33:13 | [break] {...} | BreakInTry.cs:31:17:32:21 | [break] if (...) ... | semmle.label | successor |
+| BreakInTry.cs:27:21:27:26 | break; | BreakInTry.cs:30:13:33:13 | [finally: break] {...} | semmle.label | break |
+| BreakInTry.cs:30:13:33:13 | [finally: break] {...} | BreakInTry.cs:31:17:32:21 | [finally: break] if (...) ... | semmle.label | successor |
 | BreakInTry.cs:30:13:33:13 | {...} | BreakInTry.cs:31:17:32:21 | if (...) ... | semmle.label | successor |
-| BreakInTry.cs:31:17:32:21 | [break] if (...) ... | BreakInTry.cs:31:21:31:24 | [break] access to parameter args | semmle.label | successor |
+| BreakInTry.cs:31:17:32:21 | [finally: break] if (...) ... | BreakInTry.cs:31:21:31:24 | [finally: break] access to parameter args | semmle.label | successor |
 | BreakInTry.cs:31:17:32:21 | if (...) ... | BreakInTry.cs:31:21:31:24 | access to parameter args | semmle.label | successor |
-| BreakInTry.cs:31:21:31:24 | [break] access to parameter args | BreakInTry.cs:31:29:31:32 | [break] null | semmle.label | successor |
+| BreakInTry.cs:31:21:31:24 | [finally: break] access to parameter args | BreakInTry.cs:31:29:31:32 | [finally: break] null | semmle.label | successor |
 | BreakInTry.cs:31:21:31:24 | access to parameter args | BreakInTry.cs:31:29:31:32 | null | semmle.label | successor |
 | BreakInTry.cs:31:21:31:32 | ... == ... | BreakInTry.cs:22:9:34:9 | foreach (... ... in ...) ... | semmle.label | false |
 | BreakInTry.cs:31:21:31:32 | ... == ... | BreakInTry.cs:32:21:32:21 | ; | semmle.label | true |
-| BreakInTry.cs:31:21:31:32 | [break] ... == ... | BreakInTry.cs:32:21:32:21 | [break] ; | semmle.label | true |
-| BreakInTry.cs:31:21:31:32 | [break] ... == ... | BreakInTry.cs:35:7:35:7 | ; | semmle.label | break |
-| BreakInTry.cs:31:29:31:32 | [break] null | BreakInTry.cs:31:21:31:32 | [break] ... == ... | semmle.label | successor |
+| BreakInTry.cs:31:21:31:32 | [finally: break] ... == ... | BreakInTry.cs:32:21:32:21 | [finally: break] ; | semmle.label | true |
+| BreakInTry.cs:31:21:31:32 | [finally: break] ... == ... | BreakInTry.cs:35:7:35:7 | ; | semmle.label | break |
+| BreakInTry.cs:31:29:31:32 | [finally: break] null | BreakInTry.cs:31:21:31:32 | [finally: break] ... == ... | semmle.label | successor |
 | BreakInTry.cs:31:29:31:32 | null | BreakInTry.cs:31:21:31:32 | ... == ... | semmle.label | successor |
 | BreakInTry.cs:32:21:32:21 | ; | BreakInTry.cs:22:9:34:9 | foreach (... ... in ...) ... | semmle.label | successor |
-| BreakInTry.cs:32:21:32:21 | [break] ; | BreakInTry.cs:35:7:35:7 | ; | semmle.label | break |
+| BreakInTry.cs:32:21:32:21 | [finally: break] ; | BreakInTry.cs:35:7:35:7 | ; | semmle.label | break |
 | BreakInTry.cs:35:7:35:7 | ; | BreakInTry.cs:20:10:20:11 | exit M2 | semmle.label | successor |
 | BreakInTry.cs:38:10:38:11 | enter M3 | BreakInTry.cs:39:5:54:5 | {...} | semmle.label | successor |
 | BreakInTry.cs:39:5:54:5 | {...} | BreakInTry.cs:40:9:52:9 | try {...} ... | semmle.label | successor |
@@ -124,30 +124,30 @@
 | BreakInTry.cs:42:17:42:28 | ... == ... | BreakInTry.cs:43:17:43:23 | return ...; | semmle.label | true |
 | BreakInTry.cs:42:17:42:28 | ... == ... | BreakInTry.cs:46:9:52:9 | {...} | semmle.label | false |
 | BreakInTry.cs:42:25:42:28 | null | BreakInTry.cs:42:17:42:28 | ... == ... | semmle.label | successor |
-| BreakInTry.cs:43:17:43:23 | return ...; | BreakInTry.cs:46:9:52:9 | [return] {...} | semmle.label | return |
-| BreakInTry.cs:46:9:52:9 | [return] {...} | BreakInTry.cs:47:33:47:36 | [return] access to parameter args | semmle.label | successor |
+| BreakInTry.cs:43:17:43:23 | return ...; | BreakInTry.cs:46:9:52:9 | [finally: return] {...} | semmle.label | return |
+| BreakInTry.cs:46:9:52:9 | [finally: return] {...} | BreakInTry.cs:47:33:47:36 | [finally: return] access to parameter args | semmle.label | successor |
 | BreakInTry.cs:46:9:52:9 | {...} | BreakInTry.cs:47:33:47:36 | access to parameter args | semmle.label | successor |
-| BreakInTry.cs:47:13:51:13 | [return] foreach (... ... in ...) ... | BreakInTry.cs:38:10:38:11 | exit M3 | semmle.label | return |
-| BreakInTry.cs:47:13:51:13 | [return] foreach (... ... in ...) ... | BreakInTry.cs:47:26:47:28 | [return] String arg | semmle.label | non-empty |
+| BreakInTry.cs:47:13:51:13 | [finally: return] foreach (... ... in ...) ... | BreakInTry.cs:38:10:38:11 | exit M3 | semmle.label | return |
+| BreakInTry.cs:47:13:51:13 | [finally: return] foreach (... ... in ...) ... | BreakInTry.cs:47:26:47:28 | [finally: return] String arg | semmle.label | non-empty |
 | BreakInTry.cs:47:13:51:13 | foreach (... ... in ...) ... | BreakInTry.cs:47:26:47:28 | String arg | semmle.label | non-empty |
 | BreakInTry.cs:47:13:51:13 | foreach (... ... in ...) ... | BreakInTry.cs:53:7:53:7 | ; | semmle.label | empty |
 | BreakInTry.cs:47:26:47:28 | String arg | BreakInTry.cs:48:13:51:13 | {...} | semmle.label | successor |
-| BreakInTry.cs:47:26:47:28 | [return] String arg | BreakInTry.cs:48:13:51:13 | [return] {...} | semmle.label | successor |
-| BreakInTry.cs:47:33:47:36 | [return] access to parameter args | BreakInTry.cs:47:13:51:13 | [return] foreach (... ... in ...) ... | semmle.label | successor |
+| BreakInTry.cs:47:26:47:28 | [finally: return] String arg | BreakInTry.cs:48:13:51:13 | [finally: return] {...} | semmle.label | successor |
+| BreakInTry.cs:47:33:47:36 | [finally: return] access to parameter args | BreakInTry.cs:47:13:51:13 | [finally: return] foreach (... ... in ...) ... | semmle.label | successor |
 | BreakInTry.cs:47:33:47:36 | access to parameter args | BreakInTry.cs:47:13:51:13 | foreach (... ... in ...) ... | semmle.label | successor |
-| BreakInTry.cs:48:13:51:13 | [return] {...} | BreakInTry.cs:49:17:50:26 | [return] if (...) ... | semmle.label | successor |
+| BreakInTry.cs:48:13:51:13 | [finally: return] {...} | BreakInTry.cs:49:17:50:26 | [finally: return] if (...) ... | semmle.label | successor |
 | BreakInTry.cs:48:13:51:13 | {...} | BreakInTry.cs:49:17:50:26 | if (...) ... | semmle.label | successor |
-| BreakInTry.cs:49:17:50:26 | [return] if (...) ... | BreakInTry.cs:49:21:49:23 | [return] access to local variable arg | semmle.label | successor |
+| BreakInTry.cs:49:17:50:26 | [finally: return] if (...) ... | BreakInTry.cs:49:21:49:23 | [finally: return] access to local variable arg | semmle.label | successor |
 | BreakInTry.cs:49:17:50:26 | if (...) ... | BreakInTry.cs:49:21:49:23 | access to local variable arg | semmle.label | successor |
-| BreakInTry.cs:49:21:49:23 | [return] access to local variable arg | BreakInTry.cs:49:28:49:31 | [return] null | semmle.label | successor |
+| BreakInTry.cs:49:21:49:23 | [finally: return] access to local variable arg | BreakInTry.cs:49:28:49:31 | [finally: return] null | semmle.label | successor |
 | BreakInTry.cs:49:21:49:23 | access to local variable arg | BreakInTry.cs:49:28:49:31 | null | semmle.label | successor |
 | BreakInTry.cs:49:21:49:31 | ... == ... | BreakInTry.cs:47:13:51:13 | foreach (... ... in ...) ... | semmle.label | false |
 | BreakInTry.cs:49:21:49:31 | ... == ... | BreakInTry.cs:50:21:50:26 | break; | semmle.label | true |
-| BreakInTry.cs:49:21:49:31 | [return] ... == ... | BreakInTry.cs:47:13:51:13 | [return] foreach (... ... in ...) ... | semmle.label | false |
-| BreakInTry.cs:49:21:49:31 | [return] ... == ... | BreakInTry.cs:50:21:50:26 | [return] break; | semmle.label | true |
-| BreakInTry.cs:49:28:49:31 | [return] null | BreakInTry.cs:49:21:49:31 | [return] ... == ... | semmle.label | successor |
+| BreakInTry.cs:49:21:49:31 | [finally: return] ... == ... | BreakInTry.cs:47:13:51:13 | [finally: return] foreach (... ... in ...) ... | semmle.label | false |
+| BreakInTry.cs:49:21:49:31 | [finally: return] ... == ... | BreakInTry.cs:50:21:50:26 | [finally: return] break; | semmle.label | true |
+| BreakInTry.cs:49:28:49:31 | [finally: return] null | BreakInTry.cs:49:21:49:31 | [finally: return] ... == ... | semmle.label | successor |
 | BreakInTry.cs:49:28:49:31 | null | BreakInTry.cs:49:21:49:31 | ... == ... | semmle.label | successor |
-| BreakInTry.cs:50:21:50:26 | [return] break; | BreakInTry.cs:38:10:38:11 | exit M3 | semmle.label | return |
+| BreakInTry.cs:50:21:50:26 | [finally: return] break; | BreakInTry.cs:38:10:38:11 | exit M3 | semmle.label | return |
 | BreakInTry.cs:50:21:50:26 | break; | BreakInTry.cs:53:7:53:7 | ; | semmle.label | break |
 | BreakInTry.cs:53:7:53:7 | ; | BreakInTry.cs:38:10:38:11 | exit M3 | semmle.label | successor |
 | BreakInTry.cs:56:10:56:11 | enter M4 | BreakInTry.cs:57:5:71:5 | {...} | semmle.label | successor |
@@ -159,30 +159,30 @@
 | BreakInTry.cs:60:17:60:28 | ... == ... | BreakInTry.cs:61:17:61:23 | return ...; | semmle.label | true |
 | BreakInTry.cs:60:17:60:28 | ... == ... | BreakInTry.cs:64:9:70:9 | {...} | semmle.label | false |
 | BreakInTry.cs:60:25:60:28 | null | BreakInTry.cs:60:17:60:28 | ... == ... | semmle.label | successor |
-| BreakInTry.cs:61:17:61:23 | return ...; | BreakInTry.cs:64:9:70:9 | [return] {...} | semmle.label | return |
-| BreakInTry.cs:64:9:70:9 | [return] {...} | BreakInTry.cs:65:33:65:36 | [return] access to parameter args | semmle.label | successor |
+| BreakInTry.cs:61:17:61:23 | return ...; | BreakInTry.cs:64:9:70:9 | [finally: return] {...} | semmle.label | return |
+| BreakInTry.cs:64:9:70:9 | [finally: return] {...} | BreakInTry.cs:65:33:65:36 | [finally: return] access to parameter args | semmle.label | successor |
 | BreakInTry.cs:64:9:70:9 | {...} | BreakInTry.cs:65:33:65:36 | access to parameter args | semmle.label | successor |
-| BreakInTry.cs:65:13:69:13 | [return] foreach (... ... in ...) ... | BreakInTry.cs:56:10:56:11 | exit M4 | semmle.label | return |
-| BreakInTry.cs:65:13:69:13 | [return] foreach (... ... in ...) ... | BreakInTry.cs:65:26:65:28 | [return] String arg | semmle.label | non-empty |
+| BreakInTry.cs:65:13:69:13 | [finally: return] foreach (... ... in ...) ... | BreakInTry.cs:56:10:56:11 | exit M4 | semmle.label | return |
+| BreakInTry.cs:65:13:69:13 | [finally: return] foreach (... ... in ...) ... | BreakInTry.cs:65:26:65:28 | [finally: return] String arg | semmle.label | non-empty |
 | BreakInTry.cs:65:13:69:13 | foreach (... ... in ...) ... | BreakInTry.cs:56:10:56:11 | exit M4 | semmle.label | empty |
 | BreakInTry.cs:65:13:69:13 | foreach (... ... in ...) ... | BreakInTry.cs:65:26:65:28 | String arg | semmle.label | non-empty |
 | BreakInTry.cs:65:26:65:28 | String arg | BreakInTry.cs:66:13:69:13 | {...} | semmle.label | successor |
-| BreakInTry.cs:65:26:65:28 | [return] String arg | BreakInTry.cs:66:13:69:13 | [return] {...} | semmle.label | successor |
-| BreakInTry.cs:65:33:65:36 | [return] access to parameter args | BreakInTry.cs:65:13:69:13 | [return] foreach (... ... in ...) ... | semmle.label | successor |
+| BreakInTry.cs:65:26:65:28 | [finally: return] String arg | BreakInTry.cs:66:13:69:13 | [finally: return] {...} | semmle.label | successor |
+| BreakInTry.cs:65:33:65:36 | [finally: return] access to parameter args | BreakInTry.cs:65:13:69:13 | [finally: return] foreach (... ... in ...) ... | semmle.label | successor |
 | BreakInTry.cs:65:33:65:36 | access to parameter args | BreakInTry.cs:65:13:69:13 | foreach (... ... in ...) ... | semmle.label | successor |
-| BreakInTry.cs:66:13:69:13 | [return] {...} | BreakInTry.cs:67:17:68:26 | [return] if (...) ... | semmle.label | successor |
+| BreakInTry.cs:66:13:69:13 | [finally: return] {...} | BreakInTry.cs:67:17:68:26 | [finally: return] if (...) ... | semmle.label | successor |
 | BreakInTry.cs:66:13:69:13 | {...} | BreakInTry.cs:67:17:68:26 | if (...) ... | semmle.label | successor |
-| BreakInTry.cs:67:17:68:26 | [return] if (...) ... | BreakInTry.cs:67:21:67:23 | [return] access to local variable arg | semmle.label | successor |
+| BreakInTry.cs:67:17:68:26 | [finally: return] if (...) ... | BreakInTry.cs:67:21:67:23 | [finally: return] access to local variable arg | semmle.label | successor |
 | BreakInTry.cs:67:17:68:26 | if (...) ... | BreakInTry.cs:67:21:67:23 | access to local variable arg | semmle.label | successor |
-| BreakInTry.cs:67:21:67:23 | [return] access to local variable arg | BreakInTry.cs:67:28:67:31 | [return] null | semmle.label | successor |
+| BreakInTry.cs:67:21:67:23 | [finally: return] access to local variable arg | BreakInTry.cs:67:28:67:31 | [finally: return] null | semmle.label | successor |
 | BreakInTry.cs:67:21:67:23 | access to local variable arg | BreakInTry.cs:67:28:67:31 | null | semmle.label | successor |
 | BreakInTry.cs:67:21:67:31 | ... == ... | BreakInTry.cs:65:13:69:13 | foreach (... ... in ...) ... | semmle.label | false |
 | BreakInTry.cs:67:21:67:31 | ... == ... | BreakInTry.cs:68:21:68:26 | break; | semmle.label | true |
-| BreakInTry.cs:67:21:67:31 | [return] ... == ... | BreakInTry.cs:65:13:69:13 | [return] foreach (... ... in ...) ... | semmle.label | false |
-| BreakInTry.cs:67:21:67:31 | [return] ... == ... | BreakInTry.cs:68:21:68:26 | [return] break; | semmle.label | true |
-| BreakInTry.cs:67:28:67:31 | [return] null | BreakInTry.cs:67:21:67:31 | [return] ... == ... | semmle.label | successor |
+| BreakInTry.cs:67:21:67:31 | [finally: return] ... == ... | BreakInTry.cs:65:13:69:13 | [finally: return] foreach (... ... in ...) ... | semmle.label | false |
+| BreakInTry.cs:67:21:67:31 | [finally: return] ... == ... | BreakInTry.cs:68:21:68:26 | [finally: return] break; | semmle.label | true |
+| BreakInTry.cs:67:28:67:31 | [finally: return] null | BreakInTry.cs:67:21:67:31 | [finally: return] ... == ... | semmle.label | successor |
 | BreakInTry.cs:67:28:67:31 | null | BreakInTry.cs:67:21:67:31 | ... == ... | semmle.label | successor |
-| BreakInTry.cs:68:21:68:26 | [return] break; | BreakInTry.cs:56:10:56:11 | exit M4 | semmle.label | return |
+| BreakInTry.cs:68:21:68:26 | [finally: return] break; | BreakInTry.cs:56:10:56:11 | exit M4 | semmle.label | return |
 | BreakInTry.cs:68:21:68:26 | break; | BreakInTry.cs:56:10:56:11 | exit M4 | semmle.label | break |
 | CompileTimeOperators.cs:5:9:5:15 | enter Default | CompileTimeOperators.cs:6:5:8:5 | {...} | semmle.label | successor |
 | CompileTimeOperators.cs:6:5:8:5 | {...} | CompileTimeOperators.cs:7:16:7:27 | default(...) | semmle.label | successor |
@@ -204,11 +204,11 @@
 | CompileTimeOperators.cs:29:5:41:5 | {...} | CompileTimeOperators.cs:30:9:38:9 | try {...} ... | semmle.label | successor |
 | CompileTimeOperators.cs:30:9:38:9 | try {...} ... | CompileTimeOperators.cs:31:9:34:9 | {...} | semmle.label | successor |
 | CompileTimeOperators.cs:31:9:34:9 | {...} | CompileTimeOperators.cs:32:13:32:21 | goto ...; | semmle.label | successor |
-| CompileTimeOperators.cs:32:13:32:21 | goto ...; | CompileTimeOperators.cs:36:9:38:9 | [goto(End)] {...} | semmle.label | goto(End) |
-| CompileTimeOperators.cs:36:9:38:9 | [goto(End)] {...} | CompileTimeOperators.cs:37:13:37:41 | [goto(End)] ...; | semmle.label | successor |
-| CompileTimeOperators.cs:37:13:37:40 | [goto(End)] call to method WriteLine | CompileTimeOperators.cs:40:9:40:11 | End: | semmle.label | goto(End) |
-| CompileTimeOperators.cs:37:13:37:41 | [goto(End)] ...; | CompileTimeOperators.cs:37:31:37:39 | [goto(End)] "Finally" | semmle.label | successor |
-| CompileTimeOperators.cs:37:31:37:39 | [goto(End)] "Finally" | CompileTimeOperators.cs:37:13:37:40 | [goto(End)] call to method WriteLine | semmle.label | successor |
+| CompileTimeOperators.cs:32:13:32:21 | goto ...; | CompileTimeOperators.cs:36:9:38:9 | [finally: goto(End)] {...} | semmle.label | goto(End) |
+| CompileTimeOperators.cs:36:9:38:9 | [finally: goto(End)] {...} | CompileTimeOperators.cs:37:13:37:41 | [finally: goto(End)] ...; | semmle.label | successor |
+| CompileTimeOperators.cs:37:13:37:40 | [finally: goto(End)] call to method WriteLine | CompileTimeOperators.cs:40:9:40:11 | End: | semmle.label | goto(End) |
+| CompileTimeOperators.cs:37:13:37:41 | [finally: goto(End)] ...; | CompileTimeOperators.cs:37:31:37:39 | [finally: goto(End)] "Finally" | semmle.label | successor |
+| CompileTimeOperators.cs:37:31:37:39 | [finally: goto(End)] "Finally" | CompileTimeOperators.cs:37:13:37:40 | [finally: goto(End)] call to method WriteLine | semmle.label | successor |
 | CompileTimeOperators.cs:40:9:40:11 | End: | CompileTimeOperators.cs:40:14:40:38 | ...; | semmle.label | successor |
 | CompileTimeOperators.cs:40:14:40:37 | call to method WriteLine | CompileTimeOperators.cs:28:10:28:10 | exit M | semmle.label | successor |
 | CompileTimeOperators.cs:40:14:40:38 | ...; | CompileTimeOperators.cs:40:32:40:36 | "End" | semmle.label | successor |
@@ -1241,23 +1241,23 @@
 | cflow.cs:147:5:246:5 | {...} | cflow.cs:148:9:155:9 | try {...} ... | semmle.label | successor |
 | cflow.cs:148:9:155:9 | try {...} ... | cflow.cs:149:9:151:9 | {...} | semmle.label | successor |
 | cflow.cs:149:9:151:9 | {...} | cflow.cs:150:13:150:38 | ...; | semmle.label | successor |
-| cflow.cs:150:13:150:37 | call to method WriteLine | cflow.cs:153:9:155:9 | [exception(Exception)] {...} | semmle.label | exception(Exception) |
+| cflow.cs:150:13:150:37 | call to method WriteLine | cflow.cs:153:9:155:9 | [finally: exception(Exception)] {...} | semmle.label | exception(Exception) |
 | cflow.cs:150:13:150:37 | call to method WriteLine | cflow.cs:153:9:155:9 | {...} | semmle.label | successor |
 | cflow.cs:150:13:150:38 | ...; | cflow.cs:150:31:150:36 | "Try1" | semmle.label | successor |
 | cflow.cs:150:31:150:36 | "Try1" | cflow.cs:150:13:150:37 | call to method WriteLine | semmle.label | successor |
-| cflow.cs:150:31:150:36 | "Try1" | cflow.cs:153:9:155:9 | [exception(OutOfMemoryException)] {...} | semmle.label | exception(OutOfMemoryException) |
-| cflow.cs:153:9:155:9 | [exception(Exception)] {...} | cflow.cs:154:13:154:41 | [exception(Exception)] ...; | semmle.label | successor |
-| cflow.cs:153:9:155:9 | [exception(OutOfMemoryException)] {...} | cflow.cs:154:13:154:41 | [exception(OutOfMemoryException)] ...; | semmle.label | successor |
+| cflow.cs:150:31:150:36 | "Try1" | cflow.cs:153:9:155:9 | [finally: exception(OutOfMemoryException)] {...} | semmle.label | exception(OutOfMemoryException) |
+| cflow.cs:153:9:155:9 | [finally: exception(Exception)] {...} | cflow.cs:154:13:154:41 | [finally: exception(Exception)] ...; | semmle.label | successor |
+| cflow.cs:153:9:155:9 | [finally: exception(OutOfMemoryException)] {...} | cflow.cs:154:13:154:41 | [finally: exception(OutOfMemoryException)] ...; | semmle.label | successor |
 | cflow.cs:153:9:155:9 | {...} | cflow.cs:154:13:154:41 | ...; | semmle.label | successor |
-| cflow.cs:154:13:154:40 | [exception(Exception)] call to method WriteLine | cflow.cs:146:10:146:19 | exit TryFinally | semmle.label | exception(Exception) |
-| cflow.cs:154:13:154:40 | [exception(OutOfMemoryException)] call to method WriteLine | cflow.cs:146:10:146:19 | exit TryFinally | semmle.label | exception(OutOfMemoryException) |
+| cflow.cs:154:13:154:40 | [finally: exception(Exception)] call to method WriteLine | cflow.cs:146:10:146:19 | exit TryFinally | semmle.label | exception(Exception) |
+| cflow.cs:154:13:154:40 | [finally: exception(OutOfMemoryException)] call to method WriteLine | cflow.cs:146:10:146:19 | exit TryFinally | semmle.label | exception(OutOfMemoryException) |
 | cflow.cs:154:13:154:40 | call to method WriteLine | cflow.cs:157:9:187:9 | try {...} ... | semmle.label | successor |
 | cflow.cs:154:13:154:41 | ...; | cflow.cs:154:31:154:39 | "Finally" | semmle.label | successor |
-| cflow.cs:154:13:154:41 | [exception(Exception)] ...; | cflow.cs:154:31:154:39 | [exception(Exception)] "Finally" | semmle.label | successor |
-| cflow.cs:154:13:154:41 | [exception(OutOfMemoryException)] ...; | cflow.cs:154:31:154:39 | [exception(OutOfMemoryException)] "Finally" | semmle.label | successor |
+| cflow.cs:154:13:154:41 | [finally: exception(Exception)] ...; | cflow.cs:154:31:154:39 | [finally: exception(Exception)] "Finally" | semmle.label | successor |
+| cflow.cs:154:13:154:41 | [finally: exception(OutOfMemoryException)] ...; | cflow.cs:154:31:154:39 | [finally: exception(OutOfMemoryException)] "Finally" | semmle.label | successor |
 | cflow.cs:154:31:154:39 | "Finally" | cflow.cs:154:13:154:40 | call to method WriteLine | semmle.label | successor |
-| cflow.cs:154:31:154:39 | [exception(Exception)] "Finally" | cflow.cs:154:13:154:40 | [exception(Exception)] call to method WriteLine | semmle.label | successor |
-| cflow.cs:154:31:154:39 | [exception(OutOfMemoryException)] "Finally" | cflow.cs:154:13:154:40 | [exception(OutOfMemoryException)] call to method WriteLine | semmle.label | successor |
+| cflow.cs:154:31:154:39 | [finally: exception(Exception)] "Finally" | cflow.cs:154:13:154:40 | [finally: exception(Exception)] call to method WriteLine | semmle.label | successor |
+| cflow.cs:154:31:154:39 | [finally: exception(OutOfMemoryException)] "Finally" | cflow.cs:154:13:154:40 | [finally: exception(OutOfMemoryException)] call to method WriteLine | semmle.label | successor |
 | cflow.cs:157:9:187:9 | try {...} ... | cflow.cs:158:9:161:9 | {...} | semmle.label | successor |
 | cflow.cs:158:9:161:9 | {...} | cflow.cs:159:13:159:38 | ...; | semmle.label | successor |
 | cflow.cs:159:13:159:37 | call to method WriteLine | cflow.cs:160:13:160:19 | return ...; | semmle.label | successor |
@@ -1267,12 +1267,12 @@
 | cflow.cs:159:13:159:38 | ...; | cflow.cs:159:31:159:36 | "Try2" | semmle.label | successor |
 | cflow.cs:159:31:159:36 | "Try2" | cflow.cs:159:13:159:37 | call to method WriteLine | semmle.label | successor |
 | cflow.cs:159:31:159:36 | "Try2" | cflow.cs:177:9:179:9 | catch (...) {...} | semmle.label | exception(OutOfMemoryException) |
-| cflow.cs:160:13:160:19 | return ...; | cflow.cs:185:9:187:9 | [return] {...} | semmle.label | return |
+| cflow.cs:160:13:160:19 | return ...; | cflow.cs:185:9:187:9 | [finally: return] {...} | semmle.label | return |
 | cflow.cs:162:9:165:9 | catch (...) {...} | cflow.cs:162:38:162:39 | IOException ex | semmle.label | successor |
 | cflow.cs:162:38:162:39 | IOException ex | cflow.cs:162:48:162:51 | true | semmle.label | successor |
 | cflow.cs:162:48:162:51 | true | cflow.cs:163:9:165:9 | {...} | semmle.label | successor |
 | cflow.cs:163:9:165:9 | {...} | cflow.cs:164:13:164:18 | throw ...; | semmle.label | successor |
-| cflow.cs:164:13:164:18 | throw ...; | cflow.cs:185:9:187:9 | [exception(IOException)] {...} | semmle.label | exception(IOException) |
+| cflow.cs:164:13:164:18 | throw ...; | cflow.cs:185:9:187:9 | [finally: exception(IOException)] {...} | semmle.label | exception(IOException) |
 | cflow.cs:166:9:176:9 | catch (...) {...} | cflow.cs:166:41:166:42 | ArgumentException ex | semmle.label | successor |
 | cflow.cs:166:41:166:42 | ArgumentException ex | cflow.cs:167:9:176:9 | {...} | semmle.label | successor |
 | cflow.cs:167:9:176:9 | {...} | cflow.cs:168:13:175:13 | try {...} ... | semmle.label | successor |
@@ -1280,67 +1280,71 @@
 | cflow.cs:169:13:171:13 | {...} | cflow.cs:170:17:170:32 | if (...) ... | semmle.label | successor |
 | cflow.cs:170:17:170:32 | if (...) ... | cflow.cs:170:21:170:24 | true | semmle.label | successor |
 | cflow.cs:170:21:170:24 | true | cflow.cs:170:27:170:32 | throw ...; | semmle.label | true |
-| cflow.cs:170:27:170:32 | throw ...; | cflow.cs:173:13:175:13 | [exception(ArgumentException)] {...} | semmle.label | exception(ArgumentException) |
-| cflow.cs:173:13:175:13 | [exception(ArgumentException)] {...} | cflow.cs:174:37:174:42 | [exception(ArgumentException)] "Boo!" | semmle.label | successor |
-| cflow.cs:174:17:174:44 | [exception(ArgumentException)] throw ...; | cflow.cs:185:9:187:9 | [exception(Exception)] {...} | semmle.label | exception(Exception) |
-| cflow.cs:174:23:174:43 | [exception(ArgumentException)] object creation of type Exception | cflow.cs:174:17:174:44 | [exception(ArgumentException)] throw ...; | semmle.label | successor |
-| cflow.cs:174:37:174:42 | [exception(ArgumentException)] "Boo!" | cflow.cs:174:23:174:43 | [exception(ArgumentException)] object creation of type Exception | semmle.label | successor |
+| cflow.cs:170:27:170:32 | throw ...; | cflow.cs:173:13:175:13 | [finally: exception(ArgumentException)] {...} | semmle.label | exception(ArgumentException) |
+| cflow.cs:173:13:175:13 | [finally: exception(ArgumentException)] {...} | cflow.cs:174:37:174:42 | [finally: exception(ArgumentException)] "Boo!" | semmle.label | successor |
+| cflow.cs:174:17:174:44 | [finally: exception(ArgumentException)] throw ...; | cflow.cs:185:9:187:9 | [finally: exception(Exception)] {...} | semmle.label | exception(Exception) |
+| cflow.cs:174:23:174:43 | [finally: exception(ArgumentException)] object creation of type Exception | cflow.cs:174:17:174:44 | [finally: exception(ArgumentException)] throw ...; | semmle.label | successor |
+| cflow.cs:174:37:174:42 | [finally: exception(ArgumentException)] "Boo!" | cflow.cs:174:23:174:43 | [finally: exception(ArgumentException)] object creation of type Exception | semmle.label | successor |
 | cflow.cs:177:9:179:9 | catch (...) {...} | cflow.cs:178:9:179:9 | {...} | semmle.label | successor |
 | cflow.cs:178:9:179:9 | {...} | cflow.cs:185:9:187:9 | {...} | semmle.label | successor |
-| cflow.cs:185:9:187:9 | [exception(Exception)] {...} | cflow.cs:186:13:186:41 | [exception(Exception)] ...; | semmle.label | successor |
-| cflow.cs:185:9:187:9 | [exception(IOException)] {...} | cflow.cs:186:13:186:41 | [exception(IOException)] ...; | semmle.label | successor |
-| cflow.cs:185:9:187:9 | [return] {...} | cflow.cs:186:13:186:41 | [return] ...; | semmle.label | successor |
+| cflow.cs:185:9:187:9 | [finally: exception(Exception)] {...} | cflow.cs:186:13:186:41 | [finally: exception(Exception)] ...; | semmle.label | successor |
+| cflow.cs:185:9:187:9 | [finally: exception(IOException)] {...} | cflow.cs:186:13:186:41 | [finally: exception(IOException)] ...; | semmle.label | successor |
+| cflow.cs:185:9:187:9 | [finally: return] {...} | cflow.cs:186:13:186:41 | [finally: return] ...; | semmle.label | successor |
 | cflow.cs:185:9:187:9 | {...} | cflow.cs:186:13:186:41 | ...; | semmle.label | successor |
-| cflow.cs:186:13:186:40 | [exception(Exception)] call to method WriteLine | cflow.cs:146:10:146:19 | exit TryFinally | semmle.label | exception(Exception) |
-| cflow.cs:186:13:186:40 | [exception(IOException)] call to method WriteLine | cflow.cs:146:10:146:19 | exit TryFinally | semmle.label | exception(IOException) |
-| cflow.cs:186:13:186:40 | [return] call to method WriteLine | cflow.cs:146:10:146:19 | exit TryFinally | semmle.label | return |
+| cflow.cs:186:13:186:40 | [finally: exception(Exception)] call to method WriteLine | cflow.cs:146:10:146:19 | exit TryFinally | semmle.label | exception(Exception) |
+| cflow.cs:186:13:186:40 | [finally: exception(IOException)] call to method WriteLine | cflow.cs:146:10:146:19 | exit TryFinally | semmle.label | exception(IOException) |
+| cflow.cs:186:13:186:40 | [finally: return] call to method WriteLine | cflow.cs:146:10:146:19 | exit TryFinally | semmle.label | return |
 | cflow.cs:186:13:186:40 | call to method WriteLine | cflow.cs:189:9:204:9 | try {...} ... | semmle.label | successor |
 | cflow.cs:186:13:186:41 | ...; | cflow.cs:186:31:186:39 | "Finally" | semmle.label | successor |
-| cflow.cs:186:13:186:41 | [exception(Exception)] ...; | cflow.cs:186:31:186:39 | [exception(Exception)] "Finally" | semmle.label | successor |
-| cflow.cs:186:13:186:41 | [exception(IOException)] ...; | cflow.cs:186:31:186:39 | [exception(IOException)] "Finally" | semmle.label | successor |
-| cflow.cs:186:13:186:41 | [return] ...; | cflow.cs:186:31:186:39 | [return] "Finally" | semmle.label | successor |
+| cflow.cs:186:13:186:41 | [finally: exception(Exception)] ...; | cflow.cs:186:31:186:39 | [finally: exception(Exception)] "Finally" | semmle.label | successor |
+| cflow.cs:186:13:186:41 | [finally: exception(IOException)] ...; | cflow.cs:186:31:186:39 | [finally: exception(IOException)] "Finally" | semmle.label | successor |
+| cflow.cs:186:13:186:41 | [finally: return] ...; | cflow.cs:186:31:186:39 | [finally: return] "Finally" | semmle.label | successor |
 | cflow.cs:186:31:186:39 | "Finally" | cflow.cs:186:13:186:40 | call to method WriteLine | semmle.label | successor |
-| cflow.cs:186:31:186:39 | [exception(Exception)] "Finally" | cflow.cs:186:13:186:40 | [exception(Exception)] call to method WriteLine | semmle.label | successor |
-| cflow.cs:186:31:186:39 | [exception(IOException)] "Finally" | cflow.cs:186:13:186:40 | [exception(IOException)] call to method WriteLine | semmle.label | successor |
-| cflow.cs:186:31:186:39 | [return] "Finally" | cflow.cs:186:13:186:40 | [return] call to method WriteLine | semmle.label | successor |
+| cflow.cs:186:31:186:39 | [finally: exception(Exception)] "Finally" | cflow.cs:186:13:186:40 | [finally: exception(Exception)] call to method WriteLine | semmle.label | successor |
+| cflow.cs:186:31:186:39 | [finally: exception(IOException)] "Finally" | cflow.cs:186:13:186:40 | [finally: exception(IOException)] call to method WriteLine | semmle.label | successor |
+| cflow.cs:186:31:186:39 | [finally: return] "Finally" | cflow.cs:186:13:186:40 | [finally: return] call to method WriteLine | semmle.label | successor |
 | cflow.cs:189:9:204:9 | try {...} ... | cflow.cs:190:9:193:9 | {...} | semmle.label | successor |
 | cflow.cs:190:9:193:9 | {...} | cflow.cs:191:13:191:38 | ...; | semmle.label | successor |
 | cflow.cs:191:13:191:37 | call to method WriteLine | cflow.cs:192:13:192:19 | return ...; | semmle.label | successor |
 | cflow.cs:191:13:191:37 | call to method WriteLine | cflow.cs:194:9:197:9 | catch (...) {...} | semmle.label | exception(Exception) |
 | cflow.cs:191:13:191:37 | call to method WriteLine | cflow.cs:198:9:200:9 | catch (...) {...} | semmle.label | exception(Exception) |
-| cflow.cs:191:13:191:37 | call to method WriteLine | cflow.cs:202:9:204:9 | [exception(Exception)] {...} | semmle.label | exception(Exception) |
+| cflow.cs:191:13:191:37 | call to method WriteLine | cflow.cs:202:9:204:9 | [finally: exception(Exception)] {...} | semmle.label | exception(Exception) |
 | cflow.cs:191:13:191:38 | ...; | cflow.cs:191:31:191:36 | "Try3" | semmle.label | successor |
 | cflow.cs:191:31:191:36 | "Try3" | cflow.cs:191:13:191:37 | call to method WriteLine | semmle.label | successor |
-| cflow.cs:191:31:191:36 | "Try3" | cflow.cs:202:9:204:9 | [exception(OutOfMemoryException)] {...} | semmle.label | exception(OutOfMemoryException) |
-| cflow.cs:192:13:192:19 | return ...; | cflow.cs:202:9:204:9 | [return] {...} | semmle.label | return |
+| cflow.cs:191:31:191:36 | "Try3" | cflow.cs:202:9:204:9 | [finally: exception(OutOfMemoryException)] {...} | semmle.label | exception(OutOfMemoryException) |
+| cflow.cs:192:13:192:19 | return ...; | cflow.cs:202:9:204:9 | [finally: return] {...} | semmle.label | return |
 | cflow.cs:194:9:197:9 | catch (...) {...} | cflow.cs:194:38:194:39 | IOException ex | semmle.label | successor |
 | cflow.cs:194:38:194:39 | IOException ex | cflow.cs:194:48:194:51 | true | semmle.label | successor |
 | cflow.cs:194:48:194:51 | true | cflow.cs:195:9:197:9 | {...} | semmle.label | successor |
 | cflow.cs:195:9:197:9 | {...} | cflow.cs:196:13:196:18 | throw ...; | semmle.label | successor |
-| cflow.cs:196:13:196:18 | throw ...; | cflow.cs:202:9:204:9 | [exception(IOException)] {...} | semmle.label | exception(IOException) |
-| cflow.cs:198:9:200:9 | catch (...) {...} | cflow.cs:198:33:198:37 | false | semmle.label | successor |
-| cflow.cs:198:33:198:37 | false | cflow.cs:199:9:200:9 | {...} | semmle.label | successor |
+| cflow.cs:196:13:196:18 | throw ...; | cflow.cs:202:9:204:9 | [finally: exception(IOException)] {...} | semmle.label | exception(IOException) |
+| cflow.cs:198:9:200:9 | catch (...) {...} | cflow.cs:198:26:198:26 | Exception e | semmle.label | successor |
+| cflow.cs:198:26:198:26 | Exception e | cflow.cs:198:35:198:35 | access to local variable e | semmle.label | successor |
+| cflow.cs:198:35:198:35 | access to local variable e | cflow.cs:198:35:198:43 | access to property Message | semmle.label | successor |
+| cflow.cs:198:35:198:43 | access to property Message | cflow.cs:198:48:198:51 | null | semmle.label | successor |
+| cflow.cs:198:35:198:51 | ... != ... | cflow.cs:199:9:200:9 | {...} | semmle.label | successor |
+| cflow.cs:198:48:198:51 | null | cflow.cs:198:35:198:51 | ... != ... | semmle.label | successor |
 | cflow.cs:199:9:200:9 | {...} | cflow.cs:202:9:204:9 | {...} | semmle.label | successor |
-| cflow.cs:202:9:204:9 | [exception(Exception)] {...} | cflow.cs:203:13:203:41 | [exception(Exception)] ...; | semmle.label | successor |
-| cflow.cs:202:9:204:9 | [exception(IOException)] {...} | cflow.cs:203:13:203:41 | [exception(IOException)] ...; | semmle.label | successor |
-| cflow.cs:202:9:204:9 | [exception(OutOfMemoryException)] {...} | cflow.cs:203:13:203:41 | [exception(OutOfMemoryException)] ...; | semmle.label | successor |
-| cflow.cs:202:9:204:9 | [return] {...} | cflow.cs:203:13:203:41 | [return] ...; | semmle.label | successor |
+| cflow.cs:202:9:204:9 | [finally: exception(Exception)] {...} | cflow.cs:203:13:203:41 | [finally: exception(Exception)] ...; | semmle.label | successor |
+| cflow.cs:202:9:204:9 | [finally: exception(IOException)] {...} | cflow.cs:203:13:203:41 | [finally: exception(IOException)] ...; | semmle.label | successor |
+| cflow.cs:202:9:204:9 | [finally: exception(OutOfMemoryException)] {...} | cflow.cs:203:13:203:41 | [finally: exception(OutOfMemoryException)] ...; | semmle.label | successor |
+| cflow.cs:202:9:204:9 | [finally: return] {...} | cflow.cs:203:13:203:41 | [finally: return] ...; | semmle.label | successor |
 | cflow.cs:202:9:204:9 | {...} | cflow.cs:203:13:203:41 | ...; | semmle.label | successor |
-| cflow.cs:203:13:203:40 | [exception(Exception)] call to method WriteLine | cflow.cs:146:10:146:19 | exit TryFinally | semmle.label | exception(Exception) |
-| cflow.cs:203:13:203:40 | [exception(IOException)] call to method WriteLine | cflow.cs:146:10:146:19 | exit TryFinally | semmle.label | exception(IOException) |
-| cflow.cs:203:13:203:40 | [exception(OutOfMemoryException)] call to method WriteLine | cflow.cs:146:10:146:19 | exit TryFinally | semmle.label | exception(OutOfMemoryException) |
-| cflow.cs:203:13:203:40 | [return] call to method WriteLine | cflow.cs:146:10:146:19 | exit TryFinally | semmle.label | return |
+| cflow.cs:203:13:203:40 | [finally: exception(Exception)] call to method WriteLine | cflow.cs:146:10:146:19 | exit TryFinally | semmle.label | exception(Exception) |
+| cflow.cs:203:13:203:40 | [finally: exception(IOException)] call to method WriteLine | cflow.cs:146:10:146:19 | exit TryFinally | semmle.label | exception(IOException) |
+| cflow.cs:203:13:203:40 | [finally: exception(OutOfMemoryException)] call to method WriteLine | cflow.cs:146:10:146:19 | exit TryFinally | semmle.label | exception(OutOfMemoryException) |
+| cflow.cs:203:13:203:40 | [finally: return] call to method WriteLine | cflow.cs:146:10:146:19 | exit TryFinally | semmle.label | return |
 | cflow.cs:203:13:203:40 | call to method WriteLine | cflow.cs:206:9:206:19 | ... ...; | semmle.label | successor |
 | cflow.cs:203:13:203:41 | ...; | cflow.cs:203:31:203:39 | "Finally" | semmle.label | successor |
-| cflow.cs:203:13:203:41 | [exception(Exception)] ...; | cflow.cs:203:31:203:39 | [exception(Exception)] "Finally" | semmle.label | successor |
-| cflow.cs:203:13:203:41 | [exception(IOException)] ...; | cflow.cs:203:31:203:39 | [exception(IOException)] "Finally" | semmle.label | successor |
-| cflow.cs:203:13:203:41 | [exception(OutOfMemoryException)] ...; | cflow.cs:203:31:203:39 | [exception(OutOfMemoryException)] "Finally" | semmle.label | successor |
-| cflow.cs:203:13:203:41 | [return] ...; | cflow.cs:203:31:203:39 | [return] "Finally" | semmle.label | successor |
+| cflow.cs:203:13:203:41 | [finally: exception(Exception)] ...; | cflow.cs:203:31:203:39 | [finally: exception(Exception)] "Finally" | semmle.label | successor |
+| cflow.cs:203:13:203:41 | [finally: exception(IOException)] ...; | cflow.cs:203:31:203:39 | [finally: exception(IOException)] "Finally" | semmle.label | successor |
+| cflow.cs:203:13:203:41 | [finally: exception(OutOfMemoryException)] ...; | cflow.cs:203:31:203:39 | [finally: exception(OutOfMemoryException)] "Finally" | semmle.label | successor |
+| cflow.cs:203:13:203:41 | [finally: return] ...; | cflow.cs:203:31:203:39 | [finally: return] "Finally" | semmle.label | successor |
 | cflow.cs:203:31:203:39 | "Finally" | cflow.cs:203:13:203:40 | call to method WriteLine | semmle.label | successor |
-| cflow.cs:203:31:203:39 | [exception(Exception)] "Finally" | cflow.cs:203:13:203:40 | [exception(Exception)] call to method WriteLine | semmle.label | successor |
-| cflow.cs:203:31:203:39 | [exception(IOException)] "Finally" | cflow.cs:203:13:203:40 | [exception(IOException)] call to method WriteLine | semmle.label | successor |
-| cflow.cs:203:31:203:39 | [exception(OutOfMemoryException)] "Finally" | cflow.cs:203:13:203:40 | [exception(OutOfMemoryException)] call to method WriteLine | semmle.label | successor |
-| cflow.cs:203:31:203:39 | [return] "Finally" | cflow.cs:203:13:203:40 | [return] call to method WriteLine | semmle.label | successor |
+| cflow.cs:203:31:203:39 | [finally: exception(Exception)] "Finally" | cflow.cs:203:13:203:40 | [finally: exception(Exception)] call to method WriteLine | semmle.label | successor |
+| cflow.cs:203:31:203:39 | [finally: exception(IOException)] "Finally" | cflow.cs:203:13:203:40 | [finally: exception(IOException)] call to method WriteLine | semmle.label | successor |
+| cflow.cs:203:31:203:39 | [finally: exception(OutOfMemoryException)] "Finally" | cflow.cs:203:13:203:40 | [finally: exception(OutOfMemoryException)] call to method WriteLine | semmle.label | successor |
+| cflow.cs:203:31:203:39 | [finally: return] "Finally" | cflow.cs:203:13:203:40 | [finally: return] call to method WriteLine | semmle.label | successor |
 | cflow.cs:206:9:206:19 | ... ...; | cflow.cs:206:13:206:13 | access to local variable i | semmle.label | successor |
 | cflow.cs:206:13:206:13 | access to local variable i | cflow.cs:206:17:206:18 | 10 | semmle.label | successor |
 | cflow.cs:206:13:206:18 | Int32 i = ... | cflow.cs:207:9:230:9 | while (...) ... | semmle.label | successor |
@@ -1358,224 +1362,224 @@
 | cflow.cs:211:21:211:26 | ... == ... | cflow.cs:212:21:212:27 | return ...; | semmle.label | true |
 | cflow.cs:211:21:211:26 | ... == ... | cflow.cs:213:17:214:29 | if (...) ... | semmle.label | false |
 | cflow.cs:211:26:211:26 | 0 | cflow.cs:211:21:211:26 | ... == ... | semmle.label | successor |
-| cflow.cs:212:21:212:27 | return ...; | cflow.cs:219:13:229:13 | [return] {...} | semmle.label | return |
+| cflow.cs:212:21:212:27 | return ...; | cflow.cs:219:13:229:13 | [finally: return] {...} | semmle.label | return |
 | cflow.cs:213:17:214:29 | if (...) ... | cflow.cs:213:21:213:21 | access to local variable i | semmle.label | successor |
 | cflow.cs:213:21:213:21 | access to local variable i | cflow.cs:213:26:213:26 | 1 | semmle.label | successor |
 | cflow.cs:213:21:213:26 | ... == ... | cflow.cs:214:21:214:29 | continue; | semmle.label | true |
 | cflow.cs:213:21:213:26 | ... == ... | cflow.cs:215:17:216:26 | if (...) ... | semmle.label | false |
 | cflow.cs:213:26:213:26 | 1 | cflow.cs:213:21:213:26 | ... == ... | semmle.label | successor |
-| cflow.cs:214:21:214:29 | continue; | cflow.cs:219:13:229:13 | [continue] {...} | semmle.label | continue |
+| cflow.cs:214:21:214:29 | continue; | cflow.cs:219:13:229:13 | [finally: continue] {...} | semmle.label | continue |
 | cflow.cs:215:17:216:26 | if (...) ... | cflow.cs:215:21:215:21 | access to local variable i | semmle.label | successor |
 | cflow.cs:215:21:215:21 | access to local variable i | cflow.cs:215:26:215:26 | 2 | semmle.label | successor |
 | cflow.cs:215:21:215:26 | ... == ... | cflow.cs:216:21:216:26 | break; | semmle.label | true |
 | cflow.cs:215:21:215:26 | ... == ... | cflow.cs:219:13:229:13 | {...} | semmle.label | false |
 | cflow.cs:215:26:215:26 | 2 | cflow.cs:215:21:215:26 | ... == ... | semmle.label | successor |
-| cflow.cs:216:21:216:26 | break; | cflow.cs:219:13:229:13 | [break] {...} | semmle.label | break |
-| cflow.cs:219:13:229:13 | [break] {...} | cflow.cs:220:17:228:17 | [break] try {...} ... | semmle.label | successor |
-| cflow.cs:219:13:229:13 | [continue] {...} | cflow.cs:220:17:228:17 | [continue] try {...} ... | semmle.label | successor |
-| cflow.cs:219:13:229:13 | [return] {...} | cflow.cs:220:17:228:17 | [return] try {...} ... | semmle.label | successor |
+| cflow.cs:216:21:216:26 | break; | cflow.cs:219:13:229:13 | [finally: break] {...} | semmle.label | break |
+| cflow.cs:219:13:229:13 | [finally: break] {...} | cflow.cs:220:17:228:17 | [finally: break] try {...} ... | semmle.label | successor |
+| cflow.cs:219:13:229:13 | [finally: continue] {...} | cflow.cs:220:17:228:17 | [finally: continue] try {...} ... | semmle.label | successor |
+| cflow.cs:219:13:229:13 | [finally: return] {...} | cflow.cs:220:17:228:17 | [finally: return] try {...} ... | semmle.label | successor |
 | cflow.cs:219:13:229:13 | {...} | cflow.cs:220:17:228:17 | try {...} ... | semmle.label | successor |
-| cflow.cs:220:17:228:17 | [break] try {...} ... | cflow.cs:221:17:224:17 | [break] {...} | semmle.label | successor |
-| cflow.cs:220:17:228:17 | [continue] try {...} ... | cflow.cs:221:17:224:17 | [continue] {...} | semmle.label | successor |
-| cflow.cs:220:17:228:17 | [return] try {...} ... | cflow.cs:221:17:224:17 | [return] {...} | semmle.label | successor |
+| cflow.cs:220:17:228:17 | [finally: break] try {...} ... | cflow.cs:221:17:224:17 | [finally: break] {...} | semmle.label | successor |
+| cflow.cs:220:17:228:17 | [finally: continue] try {...} ... | cflow.cs:221:17:224:17 | [finally: continue] {...} | semmle.label | successor |
+| cflow.cs:220:17:228:17 | [finally: return] try {...} ... | cflow.cs:221:17:224:17 | [finally: return] {...} | semmle.label | successor |
 | cflow.cs:220:17:228:17 | try {...} ... | cflow.cs:221:17:224:17 | {...} | semmle.label | successor |
-| cflow.cs:221:17:224:17 | [break] {...} | cflow.cs:222:21:223:46 | [break] if (...) ... | semmle.label | successor |
-| cflow.cs:221:17:224:17 | [continue] {...} | cflow.cs:222:21:223:46 | [continue] if (...) ... | semmle.label | successor |
-| cflow.cs:221:17:224:17 | [return] {...} | cflow.cs:222:21:223:46 | [return] if (...) ... | semmle.label | successor |
+| cflow.cs:221:17:224:17 | [finally: break] {...} | cflow.cs:222:21:223:46 | [finally: break] if (...) ... | semmle.label | successor |
+| cflow.cs:221:17:224:17 | [finally: continue] {...} | cflow.cs:222:21:223:46 | [finally: continue] if (...) ... | semmle.label | successor |
+| cflow.cs:221:17:224:17 | [finally: return] {...} | cflow.cs:222:21:223:46 | [finally: return] if (...) ... | semmle.label | successor |
 | cflow.cs:221:17:224:17 | {...} | cflow.cs:222:21:223:46 | if (...) ... | semmle.label | successor |
-| cflow.cs:222:21:223:46 | [break] if (...) ... | cflow.cs:222:25:222:25 | [break] access to local variable i | semmle.label | successor |
-| cflow.cs:222:21:223:46 | [continue] if (...) ... | cflow.cs:222:25:222:25 | [continue] access to local variable i | semmle.label | successor |
-| cflow.cs:222:21:223:46 | [return] if (...) ... | cflow.cs:222:25:222:25 | [return] access to local variable i | semmle.label | successor |
+| cflow.cs:222:21:223:46 | [finally: break] if (...) ... | cflow.cs:222:25:222:25 | [finally: break] access to local variable i | semmle.label | successor |
+| cflow.cs:222:21:223:46 | [finally: continue] if (...) ... | cflow.cs:222:25:222:25 | [finally: continue] access to local variable i | semmle.label | successor |
+| cflow.cs:222:21:223:46 | [finally: return] if (...) ... | cflow.cs:222:25:222:25 | [finally: return] access to local variable i | semmle.label | successor |
 | cflow.cs:222:21:223:46 | if (...) ... | cflow.cs:222:25:222:25 | access to local variable i | semmle.label | successor |
-| cflow.cs:222:25:222:25 | [break] access to local variable i | cflow.cs:222:30:222:30 | [break] 3 | semmle.label | successor |
-| cflow.cs:222:25:222:25 | [continue] access to local variable i | cflow.cs:222:30:222:30 | [continue] 3 | semmle.label | successor |
-| cflow.cs:222:25:222:25 | [return] access to local variable i | cflow.cs:222:30:222:30 | [return] 3 | semmle.label | successor |
+| cflow.cs:222:25:222:25 | [finally: break] access to local variable i | cflow.cs:222:30:222:30 | [finally: break] 3 | semmle.label | successor |
+| cflow.cs:222:25:222:25 | [finally: continue] access to local variable i | cflow.cs:222:30:222:30 | [finally: continue] 3 | semmle.label | successor |
+| cflow.cs:222:25:222:25 | [finally: return] access to local variable i | cflow.cs:222:30:222:30 | [finally: return] 3 | semmle.label | successor |
 | cflow.cs:222:25:222:25 | access to local variable i | cflow.cs:222:30:222:30 | 3 | semmle.label | successor |
 | cflow.cs:222:25:222:30 | ... == ... | cflow.cs:223:31:223:45 | object creation of type Exception | semmle.label | true |
 | cflow.cs:222:25:222:30 | ... == ... | cflow.cs:226:17:228:17 | {...} | semmle.label | false |
-| cflow.cs:222:25:222:30 | [break] ... == ... | cflow.cs:223:31:223:45 | [break] object creation of type Exception | semmle.label | true |
-| cflow.cs:222:25:222:30 | [break] ... == ... | cflow.cs:226:17:228:17 | [break] {...} | semmle.label | false |
-| cflow.cs:222:25:222:30 | [continue] ... == ... | cflow.cs:223:31:223:45 | [continue] object creation of type Exception | semmle.label | true |
-| cflow.cs:222:25:222:30 | [continue] ... == ... | cflow.cs:226:17:228:17 | [continue] {...} | semmle.label | false |
-| cflow.cs:222:25:222:30 | [return] ... == ... | cflow.cs:223:31:223:45 | [return] object creation of type Exception | semmle.label | true |
-| cflow.cs:222:25:222:30 | [return] ... == ... | cflow.cs:226:17:228:17 | [return] {...} | semmle.label | false |
+| cflow.cs:222:25:222:30 | [finally: break] ... == ... | cflow.cs:223:31:223:45 | [finally: break] object creation of type Exception | semmle.label | true |
+| cflow.cs:222:25:222:30 | [finally: break] ... == ... | cflow.cs:226:17:228:17 | [finally: break] {...} | semmle.label | false |
+| cflow.cs:222:25:222:30 | [finally: continue] ... == ... | cflow.cs:223:31:223:45 | [finally: continue] object creation of type Exception | semmle.label | true |
+| cflow.cs:222:25:222:30 | [finally: continue] ... == ... | cflow.cs:226:17:228:17 | [finally: continue] {...} | semmle.label | false |
+| cflow.cs:222:25:222:30 | [finally: return] ... == ... | cflow.cs:223:31:223:45 | [finally: return] object creation of type Exception | semmle.label | true |
+| cflow.cs:222:25:222:30 | [finally: return] ... == ... | cflow.cs:226:17:228:17 | [finally: return] {...} | semmle.label | false |
 | cflow.cs:222:30:222:30 | 3 | cflow.cs:222:25:222:30 | ... == ... | semmle.label | successor |
-| cflow.cs:222:30:222:30 | [break] 3 | cflow.cs:222:25:222:30 | [break] ... == ... | semmle.label | successor |
-| cflow.cs:222:30:222:30 | [continue] 3 | cflow.cs:222:25:222:30 | [continue] ... == ... | semmle.label | successor |
-| cflow.cs:222:30:222:30 | [return] 3 | cflow.cs:222:25:222:30 | [return] ... == ... | semmle.label | successor |
-| cflow.cs:223:25:223:46 | [break] throw ...; | cflow.cs:226:17:228:17 | [exception(Exception)] {...} | semmle.label | exception(Exception) |
-| cflow.cs:223:25:223:46 | [continue] throw ...; | cflow.cs:226:17:228:17 | [exception(Exception)] {...} | semmle.label | exception(Exception) |
-| cflow.cs:223:25:223:46 | [return] throw ...; | cflow.cs:226:17:228:17 | [exception(Exception)] {...} | semmle.label | exception(Exception) |
-| cflow.cs:223:25:223:46 | throw ...; | cflow.cs:226:17:228:17 | [exception(Exception)] {...} | semmle.label | exception(Exception) |
-| cflow.cs:223:31:223:45 | [break] object creation of type Exception | cflow.cs:223:25:223:46 | [break] throw ...; | semmle.label | successor |
-| cflow.cs:223:31:223:45 | [break] object creation of type Exception | cflow.cs:226:17:228:17 | [exception(Exception)] {...} | semmle.label | exception(Exception) |
-| cflow.cs:223:31:223:45 | [continue] object creation of type Exception | cflow.cs:223:25:223:46 | [continue] throw ...; | semmle.label | successor |
-| cflow.cs:223:31:223:45 | [continue] object creation of type Exception | cflow.cs:226:17:228:17 | [exception(Exception)] {...} | semmle.label | exception(Exception) |
-| cflow.cs:223:31:223:45 | [return] object creation of type Exception | cflow.cs:223:25:223:46 | [return] throw ...; | semmle.label | successor |
-| cflow.cs:223:31:223:45 | [return] object creation of type Exception | cflow.cs:226:17:228:17 | [exception(Exception)] {...} | semmle.label | exception(Exception) |
+| cflow.cs:222:30:222:30 | [finally: break] 3 | cflow.cs:222:25:222:30 | [finally: break] ... == ... | semmle.label | successor |
+| cflow.cs:222:30:222:30 | [finally: continue] 3 | cflow.cs:222:25:222:30 | [finally: continue] ... == ... | semmle.label | successor |
+| cflow.cs:222:30:222:30 | [finally: return] 3 | cflow.cs:222:25:222:30 | [finally: return] ... == ... | semmle.label | successor |
+| cflow.cs:223:25:223:46 | [finally: break] throw ...; | cflow.cs:226:17:228:17 | [finally: exception(Exception)] {...} | semmle.label | exception(Exception) |
+| cflow.cs:223:25:223:46 | [finally: continue] throw ...; | cflow.cs:226:17:228:17 | [finally: exception(Exception)] {...} | semmle.label | exception(Exception) |
+| cflow.cs:223:25:223:46 | [finally: return] throw ...; | cflow.cs:226:17:228:17 | [finally: exception(Exception)] {...} | semmle.label | exception(Exception) |
+| cflow.cs:223:25:223:46 | throw ...; | cflow.cs:226:17:228:17 | [finally: exception(Exception)] {...} | semmle.label | exception(Exception) |
+| cflow.cs:223:31:223:45 | [finally: break] object creation of type Exception | cflow.cs:223:25:223:46 | [finally: break] throw ...; | semmle.label | successor |
+| cflow.cs:223:31:223:45 | [finally: break] object creation of type Exception | cflow.cs:226:17:228:17 | [finally: exception(Exception)] {...} | semmle.label | exception(Exception) |
+| cflow.cs:223:31:223:45 | [finally: continue] object creation of type Exception | cflow.cs:223:25:223:46 | [finally: continue] throw ...; | semmle.label | successor |
+| cflow.cs:223:31:223:45 | [finally: continue] object creation of type Exception | cflow.cs:226:17:228:17 | [finally: exception(Exception)] {...} | semmle.label | exception(Exception) |
+| cflow.cs:223:31:223:45 | [finally: return] object creation of type Exception | cflow.cs:223:25:223:46 | [finally: return] throw ...; | semmle.label | successor |
+| cflow.cs:223:31:223:45 | [finally: return] object creation of type Exception | cflow.cs:226:17:228:17 | [finally: exception(Exception)] {...} | semmle.label | exception(Exception) |
 | cflow.cs:223:31:223:45 | object creation of type Exception | cflow.cs:223:25:223:46 | throw ...; | semmle.label | successor |
-| cflow.cs:223:31:223:45 | object creation of type Exception | cflow.cs:226:17:228:17 | [exception(Exception)] {...} | semmle.label | exception(Exception) |
-| cflow.cs:226:17:228:17 | [break] {...} | cflow.cs:227:21:227:24 | [break] ...; | semmle.label | successor |
-| cflow.cs:226:17:228:17 | [continue] {...} | cflow.cs:227:21:227:24 | [continue] ...; | semmle.label | successor |
-| cflow.cs:226:17:228:17 | [exception(Exception)] {...} | cflow.cs:227:21:227:24 | [exception(Exception)] ...; | semmle.label | successor |
-| cflow.cs:226:17:228:17 | [return] {...} | cflow.cs:227:21:227:24 | [return] ...; | semmle.label | successor |
+| cflow.cs:223:31:223:45 | object creation of type Exception | cflow.cs:226:17:228:17 | [finally: exception(Exception)] {...} | semmle.label | exception(Exception) |
+| cflow.cs:226:17:228:17 | [finally: break] {...} | cflow.cs:227:21:227:24 | [finally: break] ...; | semmle.label | successor |
+| cflow.cs:226:17:228:17 | [finally: continue] {...} | cflow.cs:227:21:227:24 | [finally: continue] ...; | semmle.label | successor |
+| cflow.cs:226:17:228:17 | [finally: exception(Exception)] {...} | cflow.cs:227:21:227:24 | [finally: exception(Exception)] ...; | semmle.label | successor |
+| cflow.cs:226:17:228:17 | [finally: return] {...} | cflow.cs:227:21:227:24 | [finally: return] ...; | semmle.label | successor |
 | cflow.cs:226:17:228:17 | {...} | cflow.cs:227:21:227:24 | ...; | semmle.label | successor |
-| cflow.cs:227:21:227:21 | [break] access to local variable i | cflow.cs:227:21:227:23 | [break] ...-- | semmle.label | successor |
-| cflow.cs:227:21:227:21 | [continue] access to local variable i | cflow.cs:227:21:227:23 | [continue] ...-- | semmle.label | successor |
-| cflow.cs:227:21:227:21 | [exception(Exception)] access to local variable i | cflow.cs:227:21:227:23 | [exception(Exception)] ...-- | semmle.label | successor |
-| cflow.cs:227:21:227:21 | [return] access to local variable i | cflow.cs:227:21:227:23 | [return] ...-- | semmle.label | successor |
+| cflow.cs:227:21:227:21 | [finally: break] access to local variable i | cflow.cs:227:21:227:23 | [finally: break] ...-- | semmle.label | successor |
+| cflow.cs:227:21:227:21 | [finally: continue] access to local variable i | cflow.cs:227:21:227:23 | [finally: continue] ...-- | semmle.label | successor |
+| cflow.cs:227:21:227:21 | [finally: exception(Exception)] access to local variable i | cflow.cs:227:21:227:23 | [finally: exception(Exception)] ...-- | semmle.label | successor |
+| cflow.cs:227:21:227:21 | [finally: return] access to local variable i | cflow.cs:227:21:227:23 | [finally: return] ...-- | semmle.label | successor |
 | cflow.cs:227:21:227:21 | access to local variable i | cflow.cs:227:21:227:23 | ...-- | semmle.label | successor |
 | cflow.cs:227:21:227:23 | ...-- | cflow.cs:207:16:207:16 | access to local variable i | semmle.label | successor |
-| cflow.cs:227:21:227:23 | [break] ...-- | cflow.cs:232:9:245:9 | try {...} ... | semmle.label | break |
-| cflow.cs:227:21:227:23 | [continue] ...-- | cflow.cs:207:16:207:16 | access to local variable i | semmle.label | continue |
-| cflow.cs:227:21:227:23 | [exception(Exception)] ...-- | cflow.cs:146:10:146:19 | exit TryFinally | semmle.label | exception(Exception) |
-| cflow.cs:227:21:227:23 | [return] ...-- | cflow.cs:146:10:146:19 | exit TryFinally | semmle.label | return |
+| cflow.cs:227:21:227:23 | [finally: break] ...-- | cflow.cs:232:9:245:9 | try {...} ... | semmle.label | break |
+| cflow.cs:227:21:227:23 | [finally: continue] ...-- | cflow.cs:207:16:207:16 | access to local variable i | semmle.label | continue |
+| cflow.cs:227:21:227:23 | [finally: exception(Exception)] ...-- | cflow.cs:146:10:146:19 | exit TryFinally | semmle.label | exception(Exception) |
+| cflow.cs:227:21:227:23 | [finally: return] ...-- | cflow.cs:146:10:146:19 | exit TryFinally | semmle.label | return |
 | cflow.cs:227:21:227:24 | ...; | cflow.cs:227:21:227:21 | access to local variable i | semmle.label | successor |
-| cflow.cs:227:21:227:24 | [break] ...; | cflow.cs:227:21:227:21 | [break] access to local variable i | semmle.label | successor |
-| cflow.cs:227:21:227:24 | [continue] ...; | cflow.cs:227:21:227:21 | [continue] access to local variable i | semmle.label | successor |
-| cflow.cs:227:21:227:24 | [exception(Exception)] ...; | cflow.cs:227:21:227:21 | [exception(Exception)] access to local variable i | semmle.label | successor |
-| cflow.cs:227:21:227:24 | [return] ...; | cflow.cs:227:21:227:21 | [return] access to local variable i | semmle.label | successor |
+| cflow.cs:227:21:227:24 | [finally: break] ...; | cflow.cs:227:21:227:21 | [finally: break] access to local variable i | semmle.label | successor |
+| cflow.cs:227:21:227:24 | [finally: continue] ...; | cflow.cs:227:21:227:21 | [finally: continue] access to local variable i | semmle.label | successor |
+| cflow.cs:227:21:227:24 | [finally: exception(Exception)] ...; | cflow.cs:227:21:227:21 | [finally: exception(Exception)] access to local variable i | semmle.label | successor |
+| cflow.cs:227:21:227:24 | [finally: return] ...; | cflow.cs:227:21:227:21 | [finally: return] access to local variable i | semmle.label | successor |
 | cflow.cs:232:9:245:9 | try {...} ... | cflow.cs:233:9:238:9 | {...} | semmle.label | successor |
 | cflow.cs:233:9:238:9 | {...} | cflow.cs:234:13:235:23 | if (...) ... | semmle.label | successor |
 | cflow.cs:234:13:235:23 | if (...) ... | cflow.cs:234:17:234:21 | this access | semmle.label | successor |
 | cflow.cs:234:17:234:21 | access to field Field | cflow.cs:234:17:234:28 | access to property Length | semmle.label | successor |
-| cflow.cs:234:17:234:21 | access to field Field | cflow.cs:240:9:245:9 | [exception(NullReferenceException)] {...} | semmle.label | exception(NullReferenceException) |
+| cflow.cs:234:17:234:21 | access to field Field | cflow.cs:240:9:245:9 | [finally: exception(NullReferenceException)] {...} | semmle.label | exception(NullReferenceException) |
 | cflow.cs:234:17:234:21 | this access | cflow.cs:234:17:234:21 | access to field Field | semmle.label | successor |
 | cflow.cs:234:17:234:28 | access to property Length | cflow.cs:234:33:234:33 | 0 | semmle.label | successor |
-| cflow.cs:234:17:234:28 | access to property Length | cflow.cs:240:9:245:9 | [exception(Exception)] {...} | semmle.label | exception(Exception) |
-| cflow.cs:234:17:234:28 | access to property Length | cflow.cs:240:9:245:9 | [exception(NullReferenceException)] {...} | semmle.label | exception(NullReferenceException) |
+| cflow.cs:234:17:234:28 | access to property Length | cflow.cs:240:9:245:9 | [finally: exception(Exception)] {...} | semmle.label | exception(Exception) |
+| cflow.cs:234:17:234:28 | access to property Length | cflow.cs:240:9:245:9 | [finally: exception(NullReferenceException)] {...} | semmle.label | exception(NullReferenceException) |
 | cflow.cs:234:17:234:33 | ... == ... | cflow.cs:235:17:235:23 | return ...; | semmle.label | true |
 | cflow.cs:234:17:234:33 | ... == ... | cflow.cs:236:13:237:49 | if (...) ... | semmle.label | false |
 | cflow.cs:234:33:234:33 | 0 | cflow.cs:234:17:234:33 | ... == ... | semmle.label | successor |
-| cflow.cs:235:17:235:23 | return ...; | cflow.cs:240:9:245:9 | [return] {...} | semmle.label | return |
+| cflow.cs:235:17:235:23 | return ...; | cflow.cs:240:9:245:9 | [finally: return] {...} | semmle.label | return |
 | cflow.cs:236:13:237:49 | if (...) ... | cflow.cs:236:17:236:21 | this access | semmle.label | successor |
 | cflow.cs:236:17:236:21 | access to field Field | cflow.cs:236:17:236:28 | access to property Length | semmle.label | successor |
-| cflow.cs:236:17:236:21 | access to field Field | cflow.cs:240:9:245:9 | [exception(NullReferenceException)] {...} | semmle.label | exception(NullReferenceException) |
+| cflow.cs:236:17:236:21 | access to field Field | cflow.cs:240:9:245:9 | [finally: exception(NullReferenceException)] {...} | semmle.label | exception(NullReferenceException) |
 | cflow.cs:236:17:236:21 | this access | cflow.cs:236:17:236:21 | access to field Field | semmle.label | successor |
 | cflow.cs:236:17:236:28 | access to property Length | cflow.cs:236:33:236:33 | 1 | semmle.label | successor |
-| cflow.cs:236:17:236:28 | access to property Length | cflow.cs:240:9:245:9 | [exception(Exception)] {...} | semmle.label | exception(Exception) |
-| cflow.cs:236:17:236:28 | access to property Length | cflow.cs:240:9:245:9 | [exception(NullReferenceException)] {...} | semmle.label | exception(NullReferenceException) |
+| cflow.cs:236:17:236:28 | access to property Length | cflow.cs:240:9:245:9 | [finally: exception(Exception)] {...} | semmle.label | exception(Exception) |
+| cflow.cs:236:17:236:28 | access to property Length | cflow.cs:240:9:245:9 | [finally: exception(NullReferenceException)] {...} | semmle.label | exception(NullReferenceException) |
 | cflow.cs:236:17:236:33 | ... == ... | cflow.cs:237:23:237:48 | object creation of type OutOfMemoryException | semmle.label | true |
 | cflow.cs:236:17:236:33 | ... == ... | cflow.cs:240:9:245:9 | {...} | semmle.label | false |
 | cflow.cs:236:33:236:33 | 1 | cflow.cs:236:17:236:33 | ... == ... | semmle.label | successor |
-| cflow.cs:237:17:237:49 | throw ...; | cflow.cs:240:9:245:9 | [exception(OutOfMemoryException)] {...} | semmle.label | exception(OutOfMemoryException) |
+| cflow.cs:237:17:237:49 | throw ...; | cflow.cs:240:9:245:9 | [finally: exception(OutOfMemoryException)] {...} | semmle.label | exception(OutOfMemoryException) |
 | cflow.cs:237:23:237:48 | object creation of type OutOfMemoryException | cflow.cs:237:17:237:49 | throw ...; | semmle.label | successor |
-| cflow.cs:237:23:237:48 | object creation of type OutOfMemoryException | cflow.cs:240:9:245:9 | [exception(Exception)] {...} | semmle.label | exception(Exception) |
-| cflow.cs:240:9:245:9 | [exception(Exception)] {...} | cflow.cs:241:13:242:41 | [exception(Exception)] if (...) ... | semmle.label | successor |
-| cflow.cs:240:9:245:9 | [exception(NullReferenceException)] {...} | cflow.cs:241:13:242:41 | [exception(NullReferenceException)] if (...) ... | semmle.label | successor |
-| cflow.cs:240:9:245:9 | [exception(OutOfMemoryException)] {...} | cflow.cs:241:13:242:41 | [exception(OutOfMemoryException)] if (...) ... | semmle.label | successor |
-| cflow.cs:240:9:245:9 | [return] {...} | cflow.cs:241:13:242:41 | [return] if (...) ... | semmle.label | successor |
+| cflow.cs:237:23:237:48 | object creation of type OutOfMemoryException | cflow.cs:240:9:245:9 | [finally: exception(Exception)] {...} | semmle.label | exception(Exception) |
+| cflow.cs:240:9:245:9 | [finally: exception(Exception)] {...} | cflow.cs:241:13:242:41 | [finally: exception(Exception)] if (...) ... | semmle.label | successor |
+| cflow.cs:240:9:245:9 | [finally: exception(NullReferenceException)] {...} | cflow.cs:241:13:242:41 | [finally: exception(NullReferenceException)] if (...) ... | semmle.label | successor |
+| cflow.cs:240:9:245:9 | [finally: exception(OutOfMemoryException)] {...} | cflow.cs:241:13:242:41 | [finally: exception(OutOfMemoryException)] if (...) ... | semmle.label | successor |
+| cflow.cs:240:9:245:9 | [finally: return] {...} | cflow.cs:241:13:242:41 | [finally: return] if (...) ... | semmle.label | successor |
 | cflow.cs:240:9:245:9 | {...} | cflow.cs:241:13:242:41 | if (...) ... | semmle.label | successor |
-| cflow.cs:241:13:242:41 | [exception(Exception)] if (...) ... | cflow.cs:241:17:241:36 | [exception(Exception)] !... | semmle.label | successor |
-| cflow.cs:241:13:242:41 | [exception(NullReferenceException)] if (...) ... | cflow.cs:241:17:241:36 | [exception(NullReferenceException)] !... | semmle.label | successor |
-| cflow.cs:241:13:242:41 | [exception(OutOfMemoryException)] if (...) ... | cflow.cs:241:17:241:36 | [exception(OutOfMemoryException)] !... | semmle.label | successor |
-| cflow.cs:241:13:242:41 | [return] if (...) ... | cflow.cs:241:17:241:36 | [return] !... | semmle.label | successor |
+| cflow.cs:241:13:242:41 | [finally: exception(Exception)] if (...) ... | cflow.cs:241:17:241:36 | [finally: exception(Exception)] !... | semmle.label | successor |
+| cflow.cs:241:13:242:41 | [finally: exception(NullReferenceException)] if (...) ... | cflow.cs:241:17:241:36 | [finally: exception(NullReferenceException)] !... | semmle.label | successor |
+| cflow.cs:241:13:242:41 | [finally: exception(OutOfMemoryException)] if (...) ... | cflow.cs:241:17:241:36 | [finally: exception(OutOfMemoryException)] !... | semmle.label | successor |
+| cflow.cs:241:13:242:41 | [finally: return] if (...) ... | cflow.cs:241:17:241:36 | [finally: return] !... | semmle.label | successor |
 | cflow.cs:241:13:242:41 | if (...) ... | cflow.cs:241:17:241:36 | !... | semmle.label | successor |
 | cflow.cs:241:17:241:36 | !... | cflow.cs:241:19:241:23 | this access | semmle.label | successor |
-| cflow.cs:241:17:241:36 | [exception(Exception)] !... | cflow.cs:241:19:241:23 | [exception(Exception)] this access | semmle.label | successor |
-| cflow.cs:241:17:241:36 | [exception(NullReferenceException)] !... | cflow.cs:241:19:241:23 | [exception(NullReferenceException)] this access | semmle.label | successor |
-| cflow.cs:241:17:241:36 | [exception(OutOfMemoryException)] !... | cflow.cs:241:19:241:23 | [exception(OutOfMemoryException)] this access | semmle.label | successor |
-| cflow.cs:241:17:241:36 | [return] !... | cflow.cs:241:19:241:23 | [return] this access | semmle.label | successor |
-| cflow.cs:241:19:241:23 | [exception(Exception)] access to field Field | cflow.cs:241:19:241:30 | [exception(Exception)] access to property Length | semmle.label | successor |
-| cflow.cs:241:19:241:23 | [exception(Exception)] this access | cflow.cs:241:19:241:23 | [exception(Exception)] access to field Field | semmle.label | successor |
-| cflow.cs:241:19:241:23 | [exception(NullReferenceException)] access to field Field | cflow.cs:241:19:241:30 | [exception(NullReferenceException)] access to property Length | semmle.label | successor |
-| cflow.cs:241:19:241:23 | [exception(NullReferenceException)] this access | cflow.cs:241:19:241:23 | [exception(NullReferenceException)] access to field Field | semmle.label | successor |
-| cflow.cs:241:19:241:23 | [exception(OutOfMemoryException)] access to field Field | cflow.cs:241:19:241:30 | [exception(OutOfMemoryException)] access to property Length | semmle.label | successor |
-| cflow.cs:241:19:241:23 | [exception(OutOfMemoryException)] this access | cflow.cs:241:19:241:23 | [exception(OutOfMemoryException)] access to field Field | semmle.label | successor |
-| cflow.cs:241:19:241:23 | [return] access to field Field | cflow.cs:241:19:241:30 | [return] access to property Length | semmle.label | successor |
-| cflow.cs:241:19:241:23 | [return] this access | cflow.cs:241:19:241:23 | [return] access to field Field | semmle.label | successor |
+| cflow.cs:241:17:241:36 | [finally: exception(Exception)] !... | cflow.cs:241:19:241:23 | [finally: exception(Exception)] this access | semmle.label | successor |
+| cflow.cs:241:17:241:36 | [finally: exception(NullReferenceException)] !... | cflow.cs:241:19:241:23 | [finally: exception(NullReferenceException)] this access | semmle.label | successor |
+| cflow.cs:241:17:241:36 | [finally: exception(OutOfMemoryException)] !... | cflow.cs:241:19:241:23 | [finally: exception(OutOfMemoryException)] this access | semmle.label | successor |
+| cflow.cs:241:17:241:36 | [finally: return] !... | cflow.cs:241:19:241:23 | [finally: return] this access | semmle.label | successor |
+| cflow.cs:241:19:241:23 | [finally: exception(Exception)] access to field Field | cflow.cs:241:19:241:30 | [finally: exception(Exception)] access to property Length | semmle.label | successor |
+| cflow.cs:241:19:241:23 | [finally: exception(Exception)] this access | cflow.cs:241:19:241:23 | [finally: exception(Exception)] access to field Field | semmle.label | successor |
+| cflow.cs:241:19:241:23 | [finally: exception(NullReferenceException)] access to field Field | cflow.cs:241:19:241:30 | [finally: exception(NullReferenceException)] access to property Length | semmle.label | successor |
+| cflow.cs:241:19:241:23 | [finally: exception(NullReferenceException)] this access | cflow.cs:241:19:241:23 | [finally: exception(NullReferenceException)] access to field Field | semmle.label | successor |
+| cflow.cs:241:19:241:23 | [finally: exception(OutOfMemoryException)] access to field Field | cflow.cs:241:19:241:30 | [finally: exception(OutOfMemoryException)] access to property Length | semmle.label | successor |
+| cflow.cs:241:19:241:23 | [finally: exception(OutOfMemoryException)] this access | cflow.cs:241:19:241:23 | [finally: exception(OutOfMemoryException)] access to field Field | semmle.label | successor |
+| cflow.cs:241:19:241:23 | [finally: return] access to field Field | cflow.cs:241:19:241:30 | [finally: return] access to property Length | semmle.label | successor |
+| cflow.cs:241:19:241:23 | [finally: return] this access | cflow.cs:241:19:241:23 | [finally: return] access to field Field | semmle.label | successor |
 | cflow.cs:241:19:241:23 | access to field Field | cflow.cs:241:19:241:30 | access to property Length | semmle.label | successor |
 | cflow.cs:241:19:241:23 | this access | cflow.cs:241:19:241:23 | access to field Field | semmle.label | successor |
-| cflow.cs:241:19:241:30 | [exception(Exception)] access to property Length | cflow.cs:241:35:241:35 | [exception(Exception)] 0 | semmle.label | successor |
-| cflow.cs:241:19:241:30 | [exception(NullReferenceException)] access to property Length | cflow.cs:241:35:241:35 | [exception(NullReferenceException)] 0 | semmle.label | successor |
-| cflow.cs:241:19:241:30 | [exception(OutOfMemoryException)] access to property Length | cflow.cs:241:35:241:35 | [exception(OutOfMemoryException)] 0 | semmle.label | successor |
-| cflow.cs:241:19:241:30 | [return] access to property Length | cflow.cs:241:35:241:35 | [return] 0 | semmle.label | successor |
+| cflow.cs:241:19:241:30 | [finally: exception(Exception)] access to property Length | cflow.cs:241:35:241:35 | [finally: exception(Exception)] 0 | semmle.label | successor |
+| cflow.cs:241:19:241:30 | [finally: exception(NullReferenceException)] access to property Length | cflow.cs:241:35:241:35 | [finally: exception(NullReferenceException)] 0 | semmle.label | successor |
+| cflow.cs:241:19:241:30 | [finally: exception(OutOfMemoryException)] access to property Length | cflow.cs:241:35:241:35 | [finally: exception(OutOfMemoryException)] 0 | semmle.label | successor |
+| cflow.cs:241:19:241:30 | [finally: return] access to property Length | cflow.cs:241:35:241:35 | [finally: return] 0 | semmle.label | successor |
 | cflow.cs:241:19:241:30 | access to property Length | cflow.cs:241:35:241:35 | 0 | semmle.label | successor |
 | cflow.cs:241:19:241:35 | ... == ... | cflow.cs:242:17:242:41 | ...; | semmle.label | false |
 | cflow.cs:241:19:241:35 | ... == ... | cflow.cs:243:13:244:37 | if (...) ... | semmle.label | true |
-| cflow.cs:241:19:241:35 | [exception(Exception)] ... == ... | cflow.cs:242:17:242:41 | [exception(Exception)] ...; | semmle.label | false |
-| cflow.cs:241:19:241:35 | [exception(Exception)] ... == ... | cflow.cs:243:13:244:37 | [exception(Exception)] if (...) ... | semmle.label | true |
-| cflow.cs:241:19:241:35 | [exception(NullReferenceException)] ... == ... | cflow.cs:242:17:242:41 | [exception(NullReferenceException)] ...; | semmle.label | false |
-| cflow.cs:241:19:241:35 | [exception(NullReferenceException)] ... == ... | cflow.cs:243:13:244:37 | [exception(NullReferenceException)] if (...) ... | semmle.label | true |
-| cflow.cs:241:19:241:35 | [exception(OutOfMemoryException)] ... == ... | cflow.cs:242:17:242:41 | [exception(OutOfMemoryException)] ...; | semmle.label | false |
-| cflow.cs:241:19:241:35 | [exception(OutOfMemoryException)] ... == ... | cflow.cs:243:13:244:37 | [exception(OutOfMemoryException)] if (...) ... | semmle.label | true |
-| cflow.cs:241:19:241:35 | [return] ... == ... | cflow.cs:242:17:242:41 | [return] ...; | semmle.label | false |
-| cflow.cs:241:19:241:35 | [return] ... == ... | cflow.cs:243:13:244:37 | [return] if (...) ... | semmle.label | true |
+| cflow.cs:241:19:241:35 | [finally: exception(Exception)] ... == ... | cflow.cs:242:17:242:41 | [finally: exception(Exception)] ...; | semmle.label | false |
+| cflow.cs:241:19:241:35 | [finally: exception(Exception)] ... == ... | cflow.cs:243:13:244:37 | [finally: exception(Exception)] if (...) ... | semmle.label | true |
+| cflow.cs:241:19:241:35 | [finally: exception(NullReferenceException)] ... == ... | cflow.cs:242:17:242:41 | [finally: exception(NullReferenceException)] ...; | semmle.label | false |
+| cflow.cs:241:19:241:35 | [finally: exception(NullReferenceException)] ... == ... | cflow.cs:243:13:244:37 | [finally: exception(NullReferenceException)] if (...) ... | semmle.label | true |
+| cflow.cs:241:19:241:35 | [finally: exception(OutOfMemoryException)] ... == ... | cflow.cs:242:17:242:41 | [finally: exception(OutOfMemoryException)] ...; | semmle.label | false |
+| cflow.cs:241:19:241:35 | [finally: exception(OutOfMemoryException)] ... == ... | cflow.cs:243:13:244:37 | [finally: exception(OutOfMemoryException)] if (...) ... | semmle.label | true |
+| cflow.cs:241:19:241:35 | [finally: return] ... == ... | cflow.cs:242:17:242:41 | [finally: return] ...; | semmle.label | false |
+| cflow.cs:241:19:241:35 | [finally: return] ... == ... | cflow.cs:243:13:244:37 | [finally: return] if (...) ... | semmle.label | true |
 | cflow.cs:241:35:241:35 | 0 | cflow.cs:241:19:241:35 | ... == ... | semmle.label | successor |
-| cflow.cs:241:35:241:35 | [exception(Exception)] 0 | cflow.cs:241:19:241:35 | [exception(Exception)] ... == ... | semmle.label | successor |
-| cflow.cs:241:35:241:35 | [exception(NullReferenceException)] 0 | cflow.cs:241:19:241:35 | [exception(NullReferenceException)] ... == ... | semmle.label | successor |
-| cflow.cs:241:35:241:35 | [exception(OutOfMemoryException)] 0 | cflow.cs:241:19:241:35 | [exception(OutOfMemoryException)] ... == ... | semmle.label | successor |
-| cflow.cs:241:35:241:35 | [return] 0 | cflow.cs:241:19:241:35 | [return] ... == ... | semmle.label | successor |
-| cflow.cs:242:17:242:40 | [exception(Exception)] call to method WriteLine | cflow.cs:243:13:244:37 | [exception(Exception)] if (...) ... | semmle.label | successor |
-| cflow.cs:242:17:242:40 | [exception(NullReferenceException)] call to method WriteLine | cflow.cs:243:13:244:37 | [exception(NullReferenceException)] if (...) ... | semmle.label | successor |
-| cflow.cs:242:17:242:40 | [exception(OutOfMemoryException)] call to method WriteLine | cflow.cs:243:13:244:37 | [exception(OutOfMemoryException)] if (...) ... | semmle.label | successor |
-| cflow.cs:242:17:242:40 | [return] call to method WriteLine | cflow.cs:243:13:244:37 | [return] if (...) ... | semmle.label | successor |
+| cflow.cs:241:35:241:35 | [finally: exception(Exception)] 0 | cflow.cs:241:19:241:35 | [finally: exception(Exception)] ... == ... | semmle.label | successor |
+| cflow.cs:241:35:241:35 | [finally: exception(NullReferenceException)] 0 | cflow.cs:241:19:241:35 | [finally: exception(NullReferenceException)] ... == ... | semmle.label | successor |
+| cflow.cs:241:35:241:35 | [finally: exception(OutOfMemoryException)] 0 | cflow.cs:241:19:241:35 | [finally: exception(OutOfMemoryException)] ... == ... | semmle.label | successor |
+| cflow.cs:241:35:241:35 | [finally: return] 0 | cflow.cs:241:19:241:35 | [finally: return] ... == ... | semmle.label | successor |
+| cflow.cs:242:17:242:40 | [finally: exception(Exception)] call to method WriteLine | cflow.cs:243:13:244:37 | [finally: exception(Exception)] if (...) ... | semmle.label | successor |
+| cflow.cs:242:17:242:40 | [finally: exception(NullReferenceException)] call to method WriteLine | cflow.cs:243:13:244:37 | [finally: exception(NullReferenceException)] if (...) ... | semmle.label | successor |
+| cflow.cs:242:17:242:40 | [finally: exception(OutOfMemoryException)] call to method WriteLine | cflow.cs:243:13:244:37 | [finally: exception(OutOfMemoryException)] if (...) ... | semmle.label | successor |
+| cflow.cs:242:17:242:40 | [finally: return] call to method WriteLine | cflow.cs:243:13:244:37 | [finally: return] if (...) ... | semmle.label | successor |
 | cflow.cs:242:17:242:40 | call to method WriteLine | cflow.cs:243:13:244:37 | if (...) ... | semmle.label | successor |
 | cflow.cs:242:17:242:41 | ...; | cflow.cs:242:35:242:39 | this access | semmle.label | successor |
-| cflow.cs:242:17:242:41 | [exception(Exception)] ...; | cflow.cs:242:35:242:39 | [exception(Exception)] this access | semmle.label | successor |
-| cflow.cs:242:17:242:41 | [exception(NullReferenceException)] ...; | cflow.cs:242:35:242:39 | [exception(NullReferenceException)] this access | semmle.label | successor |
-| cflow.cs:242:17:242:41 | [exception(OutOfMemoryException)] ...; | cflow.cs:242:35:242:39 | [exception(OutOfMemoryException)] this access | semmle.label | successor |
-| cflow.cs:242:17:242:41 | [return] ...; | cflow.cs:242:35:242:39 | [return] this access | semmle.label | successor |
-| cflow.cs:242:35:242:39 | [exception(Exception)] access to field Field | cflow.cs:242:17:242:40 | [exception(Exception)] call to method WriteLine | semmle.label | successor |
-| cflow.cs:242:35:242:39 | [exception(Exception)] this access | cflow.cs:242:35:242:39 | [exception(Exception)] access to field Field | semmle.label | successor |
-| cflow.cs:242:35:242:39 | [exception(NullReferenceException)] access to field Field | cflow.cs:242:17:242:40 | [exception(NullReferenceException)] call to method WriteLine | semmle.label | successor |
-| cflow.cs:242:35:242:39 | [exception(NullReferenceException)] this access | cflow.cs:242:35:242:39 | [exception(NullReferenceException)] access to field Field | semmle.label | successor |
-| cflow.cs:242:35:242:39 | [exception(OutOfMemoryException)] access to field Field | cflow.cs:242:17:242:40 | [exception(OutOfMemoryException)] call to method WriteLine | semmle.label | successor |
-| cflow.cs:242:35:242:39 | [exception(OutOfMemoryException)] this access | cflow.cs:242:35:242:39 | [exception(OutOfMemoryException)] access to field Field | semmle.label | successor |
-| cflow.cs:242:35:242:39 | [return] access to field Field | cflow.cs:242:17:242:40 | [return] call to method WriteLine | semmle.label | successor |
-| cflow.cs:242:35:242:39 | [return] this access | cflow.cs:242:35:242:39 | [return] access to field Field | semmle.label | successor |
+| cflow.cs:242:17:242:41 | [finally: exception(Exception)] ...; | cflow.cs:242:35:242:39 | [finally: exception(Exception)] this access | semmle.label | successor |
+| cflow.cs:242:17:242:41 | [finally: exception(NullReferenceException)] ...; | cflow.cs:242:35:242:39 | [finally: exception(NullReferenceException)] this access | semmle.label | successor |
+| cflow.cs:242:17:242:41 | [finally: exception(OutOfMemoryException)] ...; | cflow.cs:242:35:242:39 | [finally: exception(OutOfMemoryException)] this access | semmle.label | successor |
+| cflow.cs:242:17:242:41 | [finally: return] ...; | cflow.cs:242:35:242:39 | [finally: return] this access | semmle.label | successor |
+| cflow.cs:242:35:242:39 | [finally: exception(Exception)] access to field Field | cflow.cs:242:17:242:40 | [finally: exception(Exception)] call to method WriteLine | semmle.label | successor |
+| cflow.cs:242:35:242:39 | [finally: exception(Exception)] this access | cflow.cs:242:35:242:39 | [finally: exception(Exception)] access to field Field | semmle.label | successor |
+| cflow.cs:242:35:242:39 | [finally: exception(NullReferenceException)] access to field Field | cflow.cs:242:17:242:40 | [finally: exception(NullReferenceException)] call to method WriteLine | semmle.label | successor |
+| cflow.cs:242:35:242:39 | [finally: exception(NullReferenceException)] this access | cflow.cs:242:35:242:39 | [finally: exception(NullReferenceException)] access to field Field | semmle.label | successor |
+| cflow.cs:242:35:242:39 | [finally: exception(OutOfMemoryException)] access to field Field | cflow.cs:242:17:242:40 | [finally: exception(OutOfMemoryException)] call to method WriteLine | semmle.label | successor |
+| cflow.cs:242:35:242:39 | [finally: exception(OutOfMemoryException)] this access | cflow.cs:242:35:242:39 | [finally: exception(OutOfMemoryException)] access to field Field | semmle.label | successor |
+| cflow.cs:242:35:242:39 | [finally: return] access to field Field | cflow.cs:242:17:242:40 | [finally: return] call to method WriteLine | semmle.label | successor |
+| cflow.cs:242:35:242:39 | [finally: return] this access | cflow.cs:242:35:242:39 | [finally: return] access to field Field | semmle.label | successor |
 | cflow.cs:242:35:242:39 | access to field Field | cflow.cs:242:17:242:40 | call to method WriteLine | semmle.label | successor |
 | cflow.cs:242:35:242:39 | this access | cflow.cs:242:35:242:39 | access to field Field | semmle.label | successor |
-| cflow.cs:243:13:244:37 | [exception(Exception)] if (...) ... | cflow.cs:243:17:243:21 | [exception(Exception)] this access | semmle.label | successor |
-| cflow.cs:243:13:244:37 | [exception(NullReferenceException)] if (...) ... | cflow.cs:243:17:243:21 | [exception(NullReferenceException)] this access | semmle.label | successor |
-| cflow.cs:243:13:244:37 | [exception(OutOfMemoryException)] if (...) ... | cflow.cs:243:17:243:21 | [exception(OutOfMemoryException)] this access | semmle.label | successor |
-| cflow.cs:243:13:244:37 | [return] if (...) ... | cflow.cs:243:17:243:21 | [return] this access | semmle.label | successor |
+| cflow.cs:243:13:244:37 | [finally: exception(Exception)] if (...) ... | cflow.cs:243:17:243:21 | [finally: exception(Exception)] this access | semmle.label | successor |
+| cflow.cs:243:13:244:37 | [finally: exception(NullReferenceException)] if (...) ... | cflow.cs:243:17:243:21 | [finally: exception(NullReferenceException)] this access | semmle.label | successor |
+| cflow.cs:243:13:244:37 | [finally: exception(OutOfMemoryException)] if (...) ... | cflow.cs:243:17:243:21 | [finally: exception(OutOfMemoryException)] this access | semmle.label | successor |
+| cflow.cs:243:13:244:37 | [finally: return] if (...) ... | cflow.cs:243:17:243:21 | [finally: return] this access | semmle.label | successor |
 | cflow.cs:243:13:244:37 | if (...) ... | cflow.cs:243:17:243:21 | this access | semmle.label | successor |
-| cflow.cs:243:17:243:21 | [exception(Exception)] access to field Field | cflow.cs:243:17:243:28 | [exception(Exception)] access to property Length | semmle.label | successor |
-| cflow.cs:243:17:243:21 | [exception(Exception)] this access | cflow.cs:243:17:243:21 | [exception(Exception)] access to field Field | semmle.label | successor |
-| cflow.cs:243:17:243:21 | [exception(NullReferenceException)] access to field Field | cflow.cs:243:17:243:28 | [exception(NullReferenceException)] access to property Length | semmle.label | successor |
-| cflow.cs:243:17:243:21 | [exception(NullReferenceException)] this access | cflow.cs:243:17:243:21 | [exception(NullReferenceException)] access to field Field | semmle.label | successor |
-| cflow.cs:243:17:243:21 | [exception(OutOfMemoryException)] access to field Field | cflow.cs:243:17:243:28 | [exception(OutOfMemoryException)] access to property Length | semmle.label | successor |
-| cflow.cs:243:17:243:21 | [exception(OutOfMemoryException)] this access | cflow.cs:243:17:243:21 | [exception(OutOfMemoryException)] access to field Field | semmle.label | successor |
-| cflow.cs:243:17:243:21 | [return] access to field Field | cflow.cs:243:17:243:28 | [return] access to property Length | semmle.label | successor |
-| cflow.cs:243:17:243:21 | [return] this access | cflow.cs:243:17:243:21 | [return] access to field Field | semmle.label | successor |
+| cflow.cs:243:17:243:21 | [finally: exception(Exception)] access to field Field | cflow.cs:243:17:243:28 | [finally: exception(Exception)] access to property Length | semmle.label | successor |
+| cflow.cs:243:17:243:21 | [finally: exception(Exception)] this access | cflow.cs:243:17:243:21 | [finally: exception(Exception)] access to field Field | semmle.label | successor |
+| cflow.cs:243:17:243:21 | [finally: exception(NullReferenceException)] access to field Field | cflow.cs:243:17:243:28 | [finally: exception(NullReferenceException)] access to property Length | semmle.label | successor |
+| cflow.cs:243:17:243:21 | [finally: exception(NullReferenceException)] this access | cflow.cs:243:17:243:21 | [finally: exception(NullReferenceException)] access to field Field | semmle.label | successor |
+| cflow.cs:243:17:243:21 | [finally: exception(OutOfMemoryException)] access to field Field | cflow.cs:243:17:243:28 | [finally: exception(OutOfMemoryException)] access to property Length | semmle.label | successor |
+| cflow.cs:243:17:243:21 | [finally: exception(OutOfMemoryException)] this access | cflow.cs:243:17:243:21 | [finally: exception(OutOfMemoryException)] access to field Field | semmle.label | successor |
+| cflow.cs:243:17:243:21 | [finally: return] access to field Field | cflow.cs:243:17:243:28 | [finally: return] access to property Length | semmle.label | successor |
+| cflow.cs:243:17:243:21 | [finally: return] this access | cflow.cs:243:17:243:21 | [finally: return] access to field Field | semmle.label | successor |
 | cflow.cs:243:17:243:21 | access to field Field | cflow.cs:243:17:243:28 | access to property Length | semmle.label | successor |
 | cflow.cs:243:17:243:21 | this access | cflow.cs:243:17:243:21 | access to field Field | semmle.label | successor |
-| cflow.cs:243:17:243:28 | [exception(Exception)] access to property Length | cflow.cs:243:32:243:32 | [exception(Exception)] 0 | semmle.label | successor |
-| cflow.cs:243:17:243:28 | [exception(NullReferenceException)] access to property Length | cflow.cs:243:32:243:32 | [exception(NullReferenceException)] 0 | semmle.label | successor |
-| cflow.cs:243:17:243:28 | [exception(OutOfMemoryException)] access to property Length | cflow.cs:243:32:243:32 | [exception(OutOfMemoryException)] 0 | semmle.label | successor |
-| cflow.cs:243:17:243:28 | [return] access to property Length | cflow.cs:243:32:243:32 | [return] 0 | semmle.label | successor |
+| cflow.cs:243:17:243:28 | [finally: exception(Exception)] access to property Length | cflow.cs:243:32:243:32 | [finally: exception(Exception)] 0 | semmle.label | successor |
+| cflow.cs:243:17:243:28 | [finally: exception(NullReferenceException)] access to property Length | cflow.cs:243:32:243:32 | [finally: exception(NullReferenceException)] 0 | semmle.label | successor |
+| cflow.cs:243:17:243:28 | [finally: exception(OutOfMemoryException)] access to property Length | cflow.cs:243:32:243:32 | [finally: exception(OutOfMemoryException)] 0 | semmle.label | successor |
+| cflow.cs:243:17:243:28 | [finally: return] access to property Length | cflow.cs:243:32:243:32 | [finally: return] 0 | semmle.label | successor |
 | cflow.cs:243:17:243:28 | access to property Length | cflow.cs:243:32:243:32 | 0 | semmle.label | successor |
 | cflow.cs:243:17:243:32 | ... > ... | cflow.cs:146:10:146:19 | exit TryFinally | semmle.label | false |
 | cflow.cs:243:17:243:32 | ... > ... | cflow.cs:244:17:244:37 | ...; | semmle.label | true |
-| cflow.cs:243:17:243:32 | [exception(Exception)] ... > ... | cflow.cs:146:10:146:19 | exit TryFinally | semmle.label | exception(Exception) |
-| cflow.cs:243:17:243:32 | [exception(Exception)] ... > ... | cflow.cs:244:17:244:37 | [exception(Exception)] ...; | semmle.label | true |
-| cflow.cs:243:17:243:32 | [exception(NullReferenceException)] ... > ... | cflow.cs:146:10:146:19 | exit TryFinally | semmle.label | exception(NullReferenceException) |
-| cflow.cs:243:17:243:32 | [exception(NullReferenceException)] ... > ... | cflow.cs:244:17:244:37 | [exception(NullReferenceException)] ...; | semmle.label | true |
-| cflow.cs:243:17:243:32 | [exception(OutOfMemoryException)] ... > ... | cflow.cs:146:10:146:19 | exit TryFinally | semmle.label | exception(OutOfMemoryException) |
-| cflow.cs:243:17:243:32 | [exception(OutOfMemoryException)] ... > ... | cflow.cs:244:17:244:37 | [exception(OutOfMemoryException)] ...; | semmle.label | true |
-| cflow.cs:243:17:243:32 | [return] ... > ... | cflow.cs:146:10:146:19 | exit TryFinally | semmle.label | return |
-| cflow.cs:243:17:243:32 | [return] ... > ... | cflow.cs:244:17:244:37 | [return] ...; | semmle.label | true |
+| cflow.cs:243:17:243:32 | [finally: exception(Exception)] ... > ... | cflow.cs:146:10:146:19 | exit TryFinally | semmle.label | exception(Exception) |
+| cflow.cs:243:17:243:32 | [finally: exception(Exception)] ... > ... | cflow.cs:244:17:244:37 | [finally: exception(Exception)] ...; | semmle.label | true |
+| cflow.cs:243:17:243:32 | [finally: exception(NullReferenceException)] ... > ... | cflow.cs:146:10:146:19 | exit TryFinally | semmle.label | exception(NullReferenceException) |
+| cflow.cs:243:17:243:32 | [finally: exception(NullReferenceException)] ... > ... | cflow.cs:244:17:244:37 | [finally: exception(NullReferenceException)] ...; | semmle.label | true |
+| cflow.cs:243:17:243:32 | [finally: exception(OutOfMemoryException)] ... > ... | cflow.cs:146:10:146:19 | exit TryFinally | semmle.label | exception(OutOfMemoryException) |
+| cflow.cs:243:17:243:32 | [finally: exception(OutOfMemoryException)] ... > ... | cflow.cs:244:17:244:37 | [finally: exception(OutOfMemoryException)] ...; | semmle.label | true |
+| cflow.cs:243:17:243:32 | [finally: return] ... > ... | cflow.cs:146:10:146:19 | exit TryFinally | semmle.label | return |
+| cflow.cs:243:17:243:32 | [finally: return] ... > ... | cflow.cs:244:17:244:37 | [finally: return] ...; | semmle.label | true |
 | cflow.cs:243:32:243:32 | 0 | cflow.cs:243:17:243:32 | ... > ... | semmle.label | successor |
-| cflow.cs:243:32:243:32 | [exception(Exception)] 0 | cflow.cs:243:17:243:32 | [exception(Exception)] ... > ... | semmle.label | successor |
-| cflow.cs:243:32:243:32 | [exception(NullReferenceException)] 0 | cflow.cs:243:17:243:32 | [exception(NullReferenceException)] ... > ... | semmle.label | successor |
-| cflow.cs:243:32:243:32 | [exception(OutOfMemoryException)] 0 | cflow.cs:243:17:243:32 | [exception(OutOfMemoryException)] ... > ... | semmle.label | successor |
-| cflow.cs:243:32:243:32 | [return] 0 | cflow.cs:243:17:243:32 | [return] ... > ... | semmle.label | successor |
-| cflow.cs:244:17:244:36 | [exception(Exception)] call to method WriteLine | cflow.cs:146:10:146:19 | exit TryFinally | semmle.label | exception(Exception) |
-| cflow.cs:244:17:244:36 | [exception(NullReferenceException)] call to method WriteLine | cflow.cs:146:10:146:19 | exit TryFinally | semmle.label | exception(NullReferenceException) |
-| cflow.cs:244:17:244:36 | [exception(OutOfMemoryException)] call to method WriteLine | cflow.cs:146:10:146:19 | exit TryFinally | semmle.label | exception(OutOfMemoryException) |
-| cflow.cs:244:17:244:36 | [return] call to method WriteLine | cflow.cs:146:10:146:19 | exit TryFinally | semmle.label | return |
+| cflow.cs:243:32:243:32 | [finally: exception(Exception)] 0 | cflow.cs:243:17:243:32 | [finally: exception(Exception)] ... > ... | semmle.label | successor |
+| cflow.cs:243:32:243:32 | [finally: exception(NullReferenceException)] 0 | cflow.cs:243:17:243:32 | [finally: exception(NullReferenceException)] ... > ... | semmle.label | successor |
+| cflow.cs:243:32:243:32 | [finally: exception(OutOfMemoryException)] 0 | cflow.cs:243:17:243:32 | [finally: exception(OutOfMemoryException)] ... > ... | semmle.label | successor |
+| cflow.cs:243:32:243:32 | [finally: return] 0 | cflow.cs:243:17:243:32 | [finally: return] ... > ... | semmle.label | successor |
+| cflow.cs:244:17:244:36 | [finally: exception(Exception)] call to method WriteLine | cflow.cs:146:10:146:19 | exit TryFinally | semmle.label | exception(Exception) |
+| cflow.cs:244:17:244:36 | [finally: exception(NullReferenceException)] call to method WriteLine | cflow.cs:146:10:146:19 | exit TryFinally | semmle.label | exception(NullReferenceException) |
+| cflow.cs:244:17:244:36 | [finally: exception(OutOfMemoryException)] call to method WriteLine | cflow.cs:146:10:146:19 | exit TryFinally | semmle.label | exception(OutOfMemoryException) |
+| cflow.cs:244:17:244:36 | [finally: return] call to method WriteLine | cflow.cs:146:10:146:19 | exit TryFinally | semmle.label | return |
 | cflow.cs:244:17:244:36 | call to method WriteLine | cflow.cs:146:10:146:19 | exit TryFinally | semmle.label | successor |
 | cflow.cs:244:17:244:37 | ...; | cflow.cs:244:35:244:35 | 1 | semmle.label | successor |
-| cflow.cs:244:17:244:37 | [exception(Exception)] ...; | cflow.cs:244:35:244:35 | [exception(Exception)] 1 | semmle.label | successor |
-| cflow.cs:244:17:244:37 | [exception(NullReferenceException)] ...; | cflow.cs:244:35:244:35 | [exception(NullReferenceException)] 1 | semmle.label | successor |
-| cflow.cs:244:17:244:37 | [exception(OutOfMemoryException)] ...; | cflow.cs:244:35:244:35 | [exception(OutOfMemoryException)] 1 | semmle.label | successor |
-| cflow.cs:244:17:244:37 | [return] ...; | cflow.cs:244:35:244:35 | [return] 1 | semmle.label | successor |
+| cflow.cs:244:17:244:37 | [finally: exception(Exception)] ...; | cflow.cs:244:35:244:35 | [finally: exception(Exception)] 1 | semmle.label | successor |
+| cflow.cs:244:17:244:37 | [finally: exception(NullReferenceException)] ...; | cflow.cs:244:35:244:35 | [finally: exception(NullReferenceException)] 1 | semmle.label | successor |
+| cflow.cs:244:17:244:37 | [finally: exception(OutOfMemoryException)] ...; | cflow.cs:244:35:244:35 | [finally: exception(OutOfMemoryException)] 1 | semmle.label | successor |
+| cflow.cs:244:17:244:37 | [finally: return] ...; | cflow.cs:244:35:244:35 | [finally: return] 1 | semmle.label | successor |
 | cflow.cs:244:35:244:35 | 1 | cflow.cs:244:17:244:36 | call to method WriteLine | semmle.label | successor |
-| cflow.cs:244:35:244:35 | [exception(Exception)] 1 | cflow.cs:244:17:244:36 | [exception(Exception)] call to method WriteLine | semmle.label | successor |
-| cflow.cs:244:35:244:35 | [exception(NullReferenceException)] 1 | cflow.cs:244:17:244:36 | [exception(NullReferenceException)] call to method WriteLine | semmle.label | successor |
-| cflow.cs:244:35:244:35 | [exception(OutOfMemoryException)] 1 | cflow.cs:244:17:244:36 | [exception(OutOfMemoryException)] call to method WriteLine | semmle.label | successor |
-| cflow.cs:244:35:244:35 | [return] 1 | cflow.cs:244:17:244:36 | [return] call to method WriteLine | semmle.label | successor |
+| cflow.cs:244:35:244:35 | [finally: exception(Exception)] 1 | cflow.cs:244:17:244:36 | [finally: exception(Exception)] call to method WriteLine | semmle.label | successor |
+| cflow.cs:244:35:244:35 | [finally: exception(NullReferenceException)] 1 | cflow.cs:244:17:244:36 | [finally: exception(NullReferenceException)] call to method WriteLine | semmle.label | successor |
+| cflow.cs:244:35:244:35 | [finally: exception(OutOfMemoryException)] 1 | cflow.cs:244:17:244:36 | [finally: exception(OutOfMemoryException)] call to method WriteLine | semmle.label | successor |
+| cflow.cs:244:35:244:35 | [finally: return] 1 | cflow.cs:244:17:244:36 | [finally: return] call to method WriteLine | semmle.label | successor |
 | cflow.cs:248:10:248:12 | enter For | cflow.cs:249:5:279:5 | {...} | semmle.label | successor |
 | cflow.cs:249:5:279:5 | {...} | cflow.cs:250:9:250:18 | ... ...; | semmle.label | successor |
 | cflow.cs:250:9:250:18 | ... ...; | cflow.cs:250:13:250:13 | access to local variable x | semmle.label | successor |
@@ -1894,11 +1898,11 @@
 | cflow.cs:368:26:368:26 | access to local variable i | cflow.cs:368:13:368:27 | yield return ...; | semmle.label | successor |
 | cflow.cs:370:9:378:9 | try {...} ... | cflow.cs:371:9:374:9 | {...} | semmle.label | successor |
 | cflow.cs:371:9:374:9 | {...} | cflow.cs:372:13:372:24 | yield break; | semmle.label | successor |
-| cflow.cs:372:13:372:24 | yield break; | cflow.cs:376:9:378:9 | [return] {...} | semmle.label | return |
-| cflow.cs:376:9:378:9 | [return] {...} | cflow.cs:377:13:377:42 | [return] ...; | semmle.label | successor |
-| cflow.cs:377:13:377:41 | [return] call to method WriteLine | cflow.cs:363:49:363:53 | exit Yield | semmle.label | return |
-| cflow.cs:377:13:377:42 | [return] ...; | cflow.cs:377:31:377:40 | [return] "not dead" | semmle.label | successor |
-| cflow.cs:377:31:377:40 | [return] "not dead" | cflow.cs:377:13:377:41 | [return] call to method WriteLine | semmle.label | successor |
+| cflow.cs:372:13:372:24 | yield break; | cflow.cs:376:9:378:9 | [finally: return] {...} | semmle.label | return |
+| cflow.cs:376:9:378:9 | [finally: return] {...} | cflow.cs:377:13:377:42 | [finally: return] ...; | semmle.label | successor |
+| cflow.cs:377:13:377:41 | [finally: return] call to method WriteLine | cflow.cs:363:49:363:53 | exit Yield | semmle.label | return |
+| cflow.cs:377:13:377:42 | [finally: return] ...; | cflow.cs:377:31:377:40 | [finally: return] "not dead" | semmle.label | successor |
+| cflow.cs:377:31:377:40 | [finally: return] "not dead" | cflow.cs:377:13:377:41 | [finally: return] call to method WriteLine | semmle.label | successor |
 | cflow.cs:384:5:384:18 | enter ControlFlowSub | cflow.cs:384:24:384:27 | call to constructor ControlFlow | semmle.label | successor |
 | cflow.cs:384:24:384:27 | call to constructor ControlFlow | cflow.cs:384:31:384:33 | {...} | semmle.label | successor |
 | cflow.cs:384:31:384:33 | {...} | cflow.cs:384:5:384:18 | exit ControlFlowSub | semmle.label | successor |
@@ -1914,23 +1918,23 @@
 | cflow.cs:394:5:405:5 | {...} | cflow.cs:395:9:403:9 | try {...} ... | semmle.label | successor |
 | cflow.cs:395:9:403:9 | try {...} ... | cflow.cs:396:9:398:9 | {...} | semmle.label | successor |
 | cflow.cs:396:9:398:9 | {...} | cflow.cs:397:13:397:37 | ...; | semmle.label | successor |
-| cflow.cs:397:13:397:36 | call to method WriteLine | cflow.cs:400:9:403:9 | [exception(Exception)] {...} | semmle.label | exception(Exception) |
+| cflow.cs:397:13:397:36 | call to method WriteLine | cflow.cs:400:9:403:9 | [finally: exception(Exception)] {...} | semmle.label | exception(Exception) |
 | cflow.cs:397:13:397:36 | call to method WriteLine | cflow.cs:400:9:403:9 | {...} | semmle.label | successor |
 | cflow.cs:397:13:397:37 | ...; | cflow.cs:397:31:397:35 | "Try" | semmle.label | successor |
 | cflow.cs:397:31:397:35 | "Try" | cflow.cs:397:13:397:36 | call to method WriteLine | semmle.label | successor |
-| cflow.cs:397:31:397:35 | "Try" | cflow.cs:400:9:403:9 | [exception(OutOfMemoryException)] {...} | semmle.label | exception(OutOfMemoryException) |
-| cflow.cs:400:9:403:9 | [exception(Exception)] {...} | cflow.cs:401:41:401:42 | [exception(Exception)] "" | semmle.label | successor |
-| cflow.cs:400:9:403:9 | [exception(OutOfMemoryException)] {...} | cflow.cs:401:41:401:42 | [exception(OutOfMemoryException)] "" | semmle.label | successor |
+| cflow.cs:397:31:397:35 | "Try" | cflow.cs:400:9:403:9 | [finally: exception(OutOfMemoryException)] {...} | semmle.label | exception(OutOfMemoryException) |
+| cflow.cs:400:9:403:9 | [finally: exception(Exception)] {...} | cflow.cs:401:41:401:42 | [finally: exception(Exception)] "" | semmle.label | successor |
+| cflow.cs:400:9:403:9 | [finally: exception(OutOfMemoryException)] {...} | cflow.cs:401:41:401:42 | [finally: exception(OutOfMemoryException)] "" | semmle.label | successor |
 | cflow.cs:400:9:403:9 | {...} | cflow.cs:401:41:401:42 | "" | semmle.label | successor |
-| cflow.cs:401:13:401:44 | [exception(Exception)] throw ...; | cflow.cs:393:10:393:10 | exit M | semmle.label | exception(ArgumentException) |
-| cflow.cs:401:13:401:44 | [exception(OutOfMemoryException)] throw ...; | cflow.cs:393:10:393:10 | exit M | semmle.label | exception(ArgumentException) |
+| cflow.cs:401:13:401:44 | [finally: exception(Exception)] throw ...; | cflow.cs:393:10:393:10 | exit M | semmle.label | exception(ArgumentException) |
+| cflow.cs:401:13:401:44 | [finally: exception(OutOfMemoryException)] throw ...; | cflow.cs:393:10:393:10 | exit M | semmle.label | exception(ArgumentException) |
 | cflow.cs:401:13:401:44 | throw ...; | cflow.cs:393:10:393:10 | exit M | semmle.label | exception(ArgumentException) |
-| cflow.cs:401:19:401:43 | [exception(Exception)] object creation of type ArgumentException | cflow.cs:401:13:401:44 | [exception(Exception)] throw ...; | semmle.label | successor |
-| cflow.cs:401:19:401:43 | [exception(OutOfMemoryException)] object creation of type ArgumentException | cflow.cs:401:13:401:44 | [exception(OutOfMemoryException)] throw ...; | semmle.label | successor |
+| cflow.cs:401:19:401:43 | [finally: exception(Exception)] object creation of type ArgumentException | cflow.cs:401:13:401:44 | [finally: exception(Exception)] throw ...; | semmle.label | successor |
+| cflow.cs:401:19:401:43 | [finally: exception(OutOfMemoryException)] object creation of type ArgumentException | cflow.cs:401:13:401:44 | [finally: exception(OutOfMemoryException)] throw ...; | semmle.label | successor |
 | cflow.cs:401:19:401:43 | object creation of type ArgumentException | cflow.cs:401:13:401:44 | throw ...; | semmle.label | successor |
 | cflow.cs:401:41:401:42 | "" | cflow.cs:401:19:401:43 | object creation of type ArgumentException | semmle.label | successor |
-| cflow.cs:401:41:401:42 | [exception(Exception)] "" | cflow.cs:401:19:401:43 | [exception(Exception)] object creation of type ArgumentException | semmle.label | successor |
-| cflow.cs:401:41:401:42 | [exception(OutOfMemoryException)] "" | cflow.cs:401:19:401:43 | [exception(OutOfMemoryException)] object creation of type ArgumentException | semmle.label | successor |
+| cflow.cs:401:41:401:42 | [finally: exception(Exception)] "" | cflow.cs:401:19:401:43 | [finally: exception(Exception)] object creation of type ArgumentException | semmle.label | successor |
+| cflow.cs:401:41:401:42 | [finally: exception(OutOfMemoryException)] "" | cflow.cs:401:19:401:43 | [finally: exception(OutOfMemoryException)] object creation of type ArgumentException | semmle.label | successor |
 | cflow.cs:410:12:410:12 | enter M | cflow.cs:410:38:410:38 | access to parameter f | semmle.label | successor |
 | cflow.cs:410:38:410:38 | access to parameter f | cflow.cs:410:40:410:40 | 0 | semmle.label | successor |
 | cflow.cs:410:38:410:41 | delegate call | cflow.cs:410:12:410:12 | exit M | semmle.label | successor |

--- a/csharp/ql/test/library-tests/controlflow/graph/NodeGraph.expected
+++ b/csharp/ql/test/library-tests/controlflow/graph/NodeGraph.expected
@@ -184,6 +184,138 @@
 | BreakInTry.cs:67:28:67:31 | null | BreakInTry.cs:67:21:67:31 | ... == ... | semmle.label | successor |
 | BreakInTry.cs:68:21:68:26 | [finally: return] break; | BreakInTry.cs:56:10:56:11 | exit M4 | semmle.label | return |
 | BreakInTry.cs:68:21:68:26 | break; | BreakInTry.cs:56:10:56:11 | exit M4 | semmle.label | break |
+| CatchInFinally.cs:5:10:5:11 | enter M1 | CatchInFinally.cs:6:5:28:5 | {...} | semmle.label | successor |
+| CatchInFinally.cs:6:5:28:5 | {...} | CatchInFinally.cs:7:9:27:9 | try {...} ... | semmle.label | successor |
+| CatchInFinally.cs:7:9:27:9 | try {...} ... | CatchInFinally.cs:8:9:11:9 | {...} | semmle.label | successor |
+| CatchInFinally.cs:8:9:11:9 | {...} | CatchInFinally.cs:9:13:10:50 | if (...) ... | semmle.label | successor |
+| CatchInFinally.cs:9:13:10:50 | if (...) ... | CatchInFinally.cs:9:17:9:20 | access to parameter args | semmle.label | successor |
+| CatchInFinally.cs:9:17:9:20 | access to parameter args | CatchInFinally.cs:9:25:9:28 | null | semmle.label | successor |
+| CatchInFinally.cs:9:17:9:28 | ... == ... | CatchInFinally.cs:10:23:10:49 | object creation of type ArgumentNullException | semmle.label | true |
+| CatchInFinally.cs:9:17:9:28 | ... == ... | CatchInFinally.cs:13:9:27:9 | {...} | semmle.label | false |
+| CatchInFinally.cs:9:25:9:28 | null | CatchInFinally.cs:9:17:9:28 | ... == ... | semmle.label | successor |
+| CatchInFinally.cs:10:17:10:50 | throw ...; | CatchInFinally.cs:13:9:27:9 | [finally: exception(ArgumentNullException)] {...} | semmle.label | exception(ArgumentNullException) |
+| CatchInFinally.cs:10:23:10:49 | object creation of type ArgumentNullException | CatchInFinally.cs:10:17:10:50 | throw ...; | semmle.label | successor |
+| CatchInFinally.cs:10:23:10:49 | object creation of type ArgumentNullException | CatchInFinally.cs:13:9:27:9 | [finally: exception(Exception)] {...} | semmle.label | exception(Exception) |
+| CatchInFinally.cs:13:9:27:9 | [finally: exception(ArgumentNullException)] {...} | CatchInFinally.cs:14:13:26:13 | [finally: exception(ArgumentNullException)] try {...} ... | semmle.label | successor |
+| CatchInFinally.cs:13:9:27:9 | [finally: exception(Exception)] {...} | CatchInFinally.cs:14:13:26:13 | [finally: exception(Exception)] try {...} ... | semmle.label | successor |
+| CatchInFinally.cs:13:9:27:9 | {...} | CatchInFinally.cs:14:13:26:13 | try {...} ... | semmle.label | successor |
+| CatchInFinally.cs:14:13:26:13 | [finally: exception(ArgumentNullException)] try {...} ... | CatchInFinally.cs:15:13:18:13 | [finally: exception(ArgumentNullException)] {...} | semmle.label | successor |
+| CatchInFinally.cs:14:13:26:13 | [finally: exception(Exception)] try {...} ... | CatchInFinally.cs:15:13:18:13 | [finally: exception(Exception)] {...} | semmle.label | successor |
+| CatchInFinally.cs:14:13:26:13 | try {...} ... | CatchInFinally.cs:15:13:18:13 | {...} | semmle.label | successor |
+| CatchInFinally.cs:15:13:18:13 | [finally: exception(ArgumentNullException)] {...} | CatchInFinally.cs:16:17:17:45 | [finally: exception(ArgumentNullException)] if (...) ... | semmle.label | successor |
+| CatchInFinally.cs:15:13:18:13 | [finally: exception(Exception)] {...} | CatchInFinally.cs:16:17:17:45 | [finally: exception(Exception)] if (...) ... | semmle.label | successor |
+| CatchInFinally.cs:15:13:18:13 | {...} | CatchInFinally.cs:16:17:17:45 | if (...) ... | semmle.label | successor |
+| CatchInFinally.cs:16:17:17:45 | [finally: exception(ArgumentNullException)] if (...) ... | CatchInFinally.cs:16:21:16:24 | [finally: exception(ArgumentNullException)] access to parameter args | semmle.label | successor |
+| CatchInFinally.cs:16:17:17:45 | [finally: exception(Exception)] if (...) ... | CatchInFinally.cs:16:21:16:24 | [finally: exception(Exception)] access to parameter args | semmle.label | successor |
+| CatchInFinally.cs:16:17:17:45 | if (...) ... | CatchInFinally.cs:16:21:16:24 | access to parameter args | semmle.label | successor |
+| CatchInFinally.cs:16:21:16:24 | [finally: exception(ArgumentNullException)] access to parameter args | CatchInFinally.cs:16:21:16:31 | [finally: exception(ArgumentNullException)] access to property Length | semmle.label | successor |
+| CatchInFinally.cs:16:21:16:24 | [finally: exception(Exception)] access to parameter args | CatchInFinally.cs:16:21:16:31 | [finally: exception(Exception)] access to property Length | semmle.label | successor |
+| CatchInFinally.cs:16:21:16:24 | access to parameter args | CatchInFinally.cs:16:21:16:31 | access to property Length | semmle.label | successor |
+| CatchInFinally.cs:16:21:16:31 | [finally: exception(ArgumentNullException)] access to property Length | CatchInFinally.cs:16:36:16:36 | [finally: exception(ArgumentNullException)] 1 | semmle.label | successor |
+| CatchInFinally.cs:16:21:16:31 | [finally: exception(ArgumentNullException)] access to property Length | CatchInFinally.cs:19:13:22:13 | [exception: Exception, finally: exception(ArgumentNullException)] catch (...) {...} | semmle.label | exception(Exception) |
+| CatchInFinally.cs:16:21:16:31 | [finally: exception(ArgumentNullException)] access to property Length | CatchInFinally.cs:19:13:22:13 | [exception: NullReferenceException, finally: exception(ArgumentNullException)] catch (...) {...} | semmle.label | exception(NullReferenceException) |
+| CatchInFinally.cs:16:21:16:31 | [finally: exception(Exception)] access to property Length | CatchInFinally.cs:16:36:16:36 | [finally: exception(Exception)] 1 | semmle.label | successor |
+| CatchInFinally.cs:16:21:16:31 | [finally: exception(Exception)] access to property Length | CatchInFinally.cs:19:13:22:13 | [exception: Exception, finally: exception(Exception)] catch (...) {...} | semmle.label | exception(Exception) |
+| CatchInFinally.cs:16:21:16:31 | [finally: exception(Exception)] access to property Length | CatchInFinally.cs:19:13:22:13 | [exception: NullReferenceException, finally: exception(Exception)] catch (...) {...} | semmle.label | exception(NullReferenceException) |
+| CatchInFinally.cs:16:21:16:31 | access to property Length | CatchInFinally.cs:16:36:16:36 | 1 | semmle.label | successor |
+| CatchInFinally.cs:16:21:16:31 | access to property Length | CatchInFinally.cs:19:13:22:13 | [exception: Exception] catch (...) {...} | semmle.label | exception(Exception) |
+| CatchInFinally.cs:16:21:16:31 | access to property Length | CatchInFinally.cs:19:13:22:13 | [exception: NullReferenceException] catch (...) {...} | semmle.label | exception(NullReferenceException) |
+| CatchInFinally.cs:16:21:16:36 | ... == ... | CatchInFinally.cs:5:10:5:11 | exit M1 | semmle.label | false |
+| CatchInFinally.cs:16:21:16:36 | ... == ... | CatchInFinally.cs:17:41:17:43 | "1" | semmle.label | true |
+| CatchInFinally.cs:16:21:16:36 | [finally: exception(ArgumentNullException)] ... == ... | CatchInFinally.cs:5:10:5:11 | exit M1 | semmle.label | exception(ArgumentNullException) |
+| CatchInFinally.cs:16:21:16:36 | [finally: exception(ArgumentNullException)] ... == ... | CatchInFinally.cs:17:41:17:43 | [finally: exception(ArgumentNullException)] "1" | semmle.label | true |
+| CatchInFinally.cs:16:21:16:36 | [finally: exception(Exception)] ... == ... | CatchInFinally.cs:5:10:5:11 | exit M1 | semmle.label | exception(Exception) |
+| CatchInFinally.cs:16:21:16:36 | [finally: exception(Exception)] ... == ... | CatchInFinally.cs:17:41:17:43 | [finally: exception(Exception)] "1" | semmle.label | true |
+| CatchInFinally.cs:16:36:16:36 | 1 | CatchInFinally.cs:16:21:16:36 | ... == ... | semmle.label | successor |
+| CatchInFinally.cs:16:36:16:36 | [finally: exception(ArgumentNullException)] 1 | CatchInFinally.cs:16:21:16:36 | [finally: exception(ArgumentNullException)] ... == ... | semmle.label | successor |
+| CatchInFinally.cs:16:36:16:36 | [finally: exception(Exception)] 1 | CatchInFinally.cs:16:21:16:36 | [finally: exception(Exception)] ... == ... | semmle.label | successor |
+| CatchInFinally.cs:17:21:17:45 | [finally: exception(ArgumentNullException)] throw ...; | CatchInFinally.cs:19:13:22:13 | [exception: Exception, finally: exception(ArgumentNullException)] catch (...) {...} | semmle.label | exception(Exception) |
+| CatchInFinally.cs:17:21:17:45 | [finally: exception(Exception)] throw ...; | CatchInFinally.cs:19:13:22:13 | [exception: Exception, finally: exception(Exception)] catch (...) {...} | semmle.label | exception(Exception) |
+| CatchInFinally.cs:17:21:17:45 | throw ...; | CatchInFinally.cs:19:13:22:13 | [exception: Exception] catch (...) {...} | semmle.label | exception(Exception) |
+| CatchInFinally.cs:17:27:17:44 | [finally: exception(ArgumentNullException)] object creation of type Exception | CatchInFinally.cs:17:21:17:45 | [finally: exception(ArgumentNullException)] throw ...; | semmle.label | successor |
+| CatchInFinally.cs:17:27:17:44 | [finally: exception(ArgumentNullException)] object creation of type Exception | CatchInFinally.cs:19:13:22:13 | [exception: Exception, finally: exception(ArgumentNullException)] catch (...) {...} | semmle.label | exception(Exception) |
+| CatchInFinally.cs:17:27:17:44 | [finally: exception(Exception)] object creation of type Exception | CatchInFinally.cs:17:21:17:45 | [finally: exception(Exception)] throw ...; | semmle.label | successor |
+| CatchInFinally.cs:17:27:17:44 | [finally: exception(Exception)] object creation of type Exception | CatchInFinally.cs:19:13:22:13 | [exception: Exception, finally: exception(Exception)] catch (...) {...} | semmle.label | exception(Exception) |
+| CatchInFinally.cs:17:27:17:44 | object creation of type Exception | CatchInFinally.cs:17:21:17:45 | throw ...; | semmle.label | successor |
+| CatchInFinally.cs:17:27:17:44 | object creation of type Exception | CatchInFinally.cs:19:13:22:13 | [exception: Exception] catch (...) {...} | semmle.label | exception(Exception) |
+| CatchInFinally.cs:17:41:17:43 | "1" | CatchInFinally.cs:17:27:17:44 | object creation of type Exception | semmle.label | successor |
+| CatchInFinally.cs:17:41:17:43 | [finally: exception(ArgumentNullException)] "1" | CatchInFinally.cs:17:27:17:44 | [finally: exception(ArgumentNullException)] object creation of type Exception | semmle.label | successor |
+| CatchInFinally.cs:17:41:17:43 | [finally: exception(Exception)] "1" | CatchInFinally.cs:17:27:17:44 | [finally: exception(Exception)] object creation of type Exception | semmle.label | successor |
+| CatchInFinally.cs:19:13:22:13 | [exception: Exception, finally: exception(ArgumentNullException)] catch (...) {...} | CatchInFinally.cs:19:30:19:30 | [exception: Exception, finally: exception(ArgumentNullException)] Exception e | semmle.label | match |
+| CatchInFinally.cs:19:13:22:13 | [exception: Exception, finally: exception(Exception)] catch (...) {...} | CatchInFinally.cs:19:30:19:30 | [exception: Exception, finally: exception(Exception)] Exception e | semmle.label | match |
+| CatchInFinally.cs:19:13:22:13 | [exception: Exception] catch (...) {...} | CatchInFinally.cs:19:30:19:30 | [exception: Exception] Exception e | semmle.label | match |
+| CatchInFinally.cs:19:13:22:13 | [exception: NullReferenceException, finally: exception(ArgumentNullException)] catch (...) {...} | CatchInFinally.cs:19:30:19:30 | [exception: NullReferenceException, finally: exception(ArgumentNullException)] Exception e | semmle.label | match |
+| CatchInFinally.cs:19:13:22:13 | [exception: NullReferenceException, finally: exception(Exception)] catch (...) {...} | CatchInFinally.cs:19:30:19:30 | [exception: NullReferenceException, finally: exception(Exception)] Exception e | semmle.label | match |
+| CatchInFinally.cs:19:13:22:13 | [exception: NullReferenceException] catch (...) {...} | CatchInFinally.cs:19:30:19:30 | [exception: NullReferenceException] Exception e | semmle.label | match |
+| CatchInFinally.cs:19:30:19:30 | [exception: Exception, finally: exception(ArgumentNullException)] Exception e | CatchInFinally.cs:19:39:19:39 | [exception: Exception, finally: exception(ArgumentNullException)] access to local variable e | semmle.label | successor |
+| CatchInFinally.cs:19:30:19:30 | [exception: Exception, finally: exception(Exception)] Exception e | CatchInFinally.cs:19:39:19:39 | [exception: Exception, finally: exception(Exception)] access to local variable e | semmle.label | successor |
+| CatchInFinally.cs:19:30:19:30 | [exception: Exception] Exception e | CatchInFinally.cs:19:39:19:39 | [exception: Exception] access to local variable e | semmle.label | successor |
+| CatchInFinally.cs:19:30:19:30 | [exception: NullReferenceException, finally: exception(ArgumentNullException)] Exception e | CatchInFinally.cs:19:39:19:39 | [exception: NullReferenceException, finally: exception(ArgumentNullException)] access to local variable e | semmle.label | successor |
+| CatchInFinally.cs:19:30:19:30 | [exception: NullReferenceException, finally: exception(Exception)] Exception e | CatchInFinally.cs:19:39:19:39 | [exception: NullReferenceException, finally: exception(Exception)] access to local variable e | semmle.label | successor |
+| CatchInFinally.cs:19:30:19:30 | [exception: NullReferenceException] Exception e | CatchInFinally.cs:19:39:19:39 | [exception: NullReferenceException] access to local variable e | semmle.label | successor |
+| CatchInFinally.cs:19:39:19:39 | [exception: Exception, finally: exception(ArgumentNullException)] access to local variable e | CatchInFinally.cs:19:39:19:47 | [exception: Exception, finally: exception(ArgumentNullException)] access to property Message | semmle.label | successor |
+| CatchInFinally.cs:19:39:19:39 | [exception: Exception, finally: exception(Exception)] access to local variable e | CatchInFinally.cs:19:39:19:47 | [exception: Exception, finally: exception(Exception)] access to property Message | semmle.label | successor |
+| CatchInFinally.cs:19:39:19:39 | [exception: Exception] access to local variable e | CatchInFinally.cs:19:39:19:47 | [exception: Exception] access to property Message | semmle.label | successor |
+| CatchInFinally.cs:19:39:19:39 | [exception: NullReferenceException, finally: exception(ArgumentNullException)] access to local variable e | CatchInFinally.cs:19:39:19:47 | [exception: NullReferenceException, finally: exception(ArgumentNullException)] access to property Message | semmle.label | successor |
+| CatchInFinally.cs:19:39:19:39 | [exception: NullReferenceException, finally: exception(Exception)] access to local variable e | CatchInFinally.cs:19:39:19:47 | [exception: NullReferenceException, finally: exception(Exception)] access to property Message | semmle.label | successor |
+| CatchInFinally.cs:19:39:19:39 | [exception: NullReferenceException] access to local variable e | CatchInFinally.cs:19:39:19:47 | [exception: NullReferenceException] access to property Message | semmle.label | successor |
+| CatchInFinally.cs:19:39:19:47 | [exception: Exception, finally: exception(ArgumentNullException)] access to property Message | CatchInFinally.cs:19:52:19:54 | [exception: Exception, finally: exception(ArgumentNullException)] "1" | semmle.label | successor |
+| CatchInFinally.cs:19:39:19:47 | [exception: Exception, finally: exception(Exception)] access to property Message | CatchInFinally.cs:19:52:19:54 | [exception: Exception, finally: exception(Exception)] "1" | semmle.label | successor |
+| CatchInFinally.cs:19:39:19:47 | [exception: Exception] access to property Message | CatchInFinally.cs:19:52:19:54 | [exception: Exception] "1" | semmle.label | successor |
+| CatchInFinally.cs:19:39:19:47 | [exception: NullReferenceException, finally: exception(ArgumentNullException)] access to property Message | CatchInFinally.cs:19:52:19:54 | [exception: NullReferenceException, finally: exception(ArgumentNullException)] "1" | semmle.label | successor |
+| CatchInFinally.cs:19:39:19:47 | [exception: NullReferenceException, finally: exception(Exception)] access to property Message | CatchInFinally.cs:19:52:19:54 | [exception: NullReferenceException, finally: exception(Exception)] "1" | semmle.label | successor |
+| CatchInFinally.cs:19:39:19:47 | [exception: NullReferenceException] access to property Message | CatchInFinally.cs:19:52:19:54 | [exception: NullReferenceException] "1" | semmle.label | successor |
+| CatchInFinally.cs:19:39:19:54 | [exception: Exception, finally: exception(ArgumentNullException)] ... == ... | CatchInFinally.cs:20:13:22:13 | [finally: exception(ArgumentNullException)] {...} | semmle.label | true |
+| CatchInFinally.cs:19:39:19:54 | [exception: Exception, finally: exception(ArgumentNullException)] ... == ... | CatchInFinally.cs:23:13:26:13 | [finally: exception(ArgumentNullException)] catch {...} | semmle.label | false |
+| CatchInFinally.cs:19:39:19:54 | [exception: Exception, finally: exception(Exception)] ... == ... | CatchInFinally.cs:20:13:22:13 | [finally: exception(Exception)] {...} | semmle.label | true |
+| CatchInFinally.cs:19:39:19:54 | [exception: Exception, finally: exception(Exception)] ... == ... | CatchInFinally.cs:23:13:26:13 | [finally: exception(Exception)] catch {...} | semmle.label | false |
+| CatchInFinally.cs:19:39:19:54 | [exception: Exception] ... == ... | CatchInFinally.cs:20:13:22:13 | {...} | semmle.label | true |
+| CatchInFinally.cs:19:39:19:54 | [exception: Exception] ... == ... | CatchInFinally.cs:23:13:26:13 | catch {...} | semmle.label | false |
+| CatchInFinally.cs:19:39:19:54 | [exception: NullReferenceException, finally: exception(ArgumentNullException)] ... == ... | CatchInFinally.cs:20:13:22:13 | [finally: exception(ArgumentNullException)] {...} | semmle.label | true |
+| CatchInFinally.cs:19:39:19:54 | [exception: NullReferenceException, finally: exception(ArgumentNullException)] ... == ... | CatchInFinally.cs:23:13:26:13 | [finally: exception(ArgumentNullException)] catch {...} | semmle.label | false |
+| CatchInFinally.cs:19:39:19:54 | [exception: NullReferenceException, finally: exception(Exception)] ... == ... | CatchInFinally.cs:20:13:22:13 | [finally: exception(Exception)] {...} | semmle.label | true |
+| CatchInFinally.cs:19:39:19:54 | [exception: NullReferenceException, finally: exception(Exception)] ... == ... | CatchInFinally.cs:23:13:26:13 | [finally: exception(Exception)] catch {...} | semmle.label | false |
+| CatchInFinally.cs:19:39:19:54 | [exception: NullReferenceException] ... == ... | CatchInFinally.cs:20:13:22:13 | {...} | semmle.label | true |
+| CatchInFinally.cs:19:39:19:54 | [exception: NullReferenceException] ... == ... | CatchInFinally.cs:23:13:26:13 | catch {...} | semmle.label | false |
+| CatchInFinally.cs:19:52:19:54 | [exception: Exception, finally: exception(ArgumentNullException)] "1" | CatchInFinally.cs:19:39:19:54 | [exception: Exception, finally: exception(ArgumentNullException)] ... == ... | semmle.label | successor |
+| CatchInFinally.cs:19:52:19:54 | [exception: Exception, finally: exception(Exception)] "1" | CatchInFinally.cs:19:39:19:54 | [exception: Exception, finally: exception(Exception)] ... == ... | semmle.label | successor |
+| CatchInFinally.cs:19:52:19:54 | [exception: Exception] "1" | CatchInFinally.cs:19:39:19:54 | [exception: Exception] ... == ... | semmle.label | successor |
+| CatchInFinally.cs:19:52:19:54 | [exception: NullReferenceException, finally: exception(ArgumentNullException)] "1" | CatchInFinally.cs:19:39:19:54 | [exception: NullReferenceException, finally: exception(ArgumentNullException)] ... == ... | semmle.label | successor |
+| CatchInFinally.cs:19:52:19:54 | [exception: NullReferenceException, finally: exception(Exception)] "1" | CatchInFinally.cs:19:39:19:54 | [exception: NullReferenceException, finally: exception(Exception)] ... == ... | semmle.label | successor |
+| CatchInFinally.cs:19:52:19:54 | [exception: NullReferenceException] "1" | CatchInFinally.cs:19:39:19:54 | [exception: NullReferenceException] ... == ... | semmle.label | successor |
+| CatchInFinally.cs:20:13:22:13 | [finally: exception(ArgumentNullException)] {...} | CatchInFinally.cs:21:17:21:43 | [finally: exception(ArgumentNullException)] ...; | semmle.label | successor |
+| CatchInFinally.cs:20:13:22:13 | [finally: exception(Exception)] {...} | CatchInFinally.cs:21:17:21:43 | [finally: exception(Exception)] ...; | semmle.label | successor |
+| CatchInFinally.cs:20:13:22:13 | {...} | CatchInFinally.cs:21:17:21:43 | ...; | semmle.label | successor |
+| CatchInFinally.cs:21:17:21:42 | [finally: exception(ArgumentNullException)] call to method WriteLine | CatchInFinally.cs:5:10:5:11 | exit M1 | semmle.label | exception(ArgumentNullException) |
+| CatchInFinally.cs:21:17:21:42 | [finally: exception(Exception)] call to method WriteLine | CatchInFinally.cs:5:10:5:11 | exit M1 | semmle.label | exception(Exception) |
+| CatchInFinally.cs:21:17:21:42 | call to method WriteLine | CatchInFinally.cs:5:10:5:11 | exit M1 | semmle.label | successor |
+| CatchInFinally.cs:21:17:21:43 | ...; | CatchInFinally.cs:21:35:21:38 | access to parameter args | semmle.label | successor |
+| CatchInFinally.cs:21:17:21:43 | [finally: exception(ArgumentNullException)] ...; | CatchInFinally.cs:21:35:21:38 | [finally: exception(ArgumentNullException)] access to parameter args | semmle.label | successor |
+| CatchInFinally.cs:21:17:21:43 | [finally: exception(Exception)] ...; | CatchInFinally.cs:21:35:21:38 | [finally: exception(Exception)] access to parameter args | semmle.label | successor |
+| CatchInFinally.cs:21:35:21:38 | [finally: exception(ArgumentNullException)] access to parameter args | CatchInFinally.cs:21:40:21:40 | [finally: exception(ArgumentNullException)] 0 | semmle.label | successor |
+| CatchInFinally.cs:21:35:21:38 | [finally: exception(Exception)] access to parameter args | CatchInFinally.cs:21:40:21:40 | [finally: exception(Exception)] 0 | semmle.label | successor |
+| CatchInFinally.cs:21:35:21:38 | access to parameter args | CatchInFinally.cs:21:40:21:40 | 0 | semmle.label | successor |
+| CatchInFinally.cs:21:35:21:41 | [finally: exception(ArgumentNullException)] access to array element | CatchInFinally.cs:21:17:21:42 | [finally: exception(ArgumentNullException)] call to method WriteLine | semmle.label | successor |
+| CatchInFinally.cs:21:35:21:41 | [finally: exception(Exception)] access to array element | CatchInFinally.cs:21:17:21:42 | [finally: exception(Exception)] call to method WriteLine | semmle.label | successor |
+| CatchInFinally.cs:21:35:21:41 | access to array element | CatchInFinally.cs:21:17:21:42 | call to method WriteLine | semmle.label | successor |
+| CatchInFinally.cs:21:40:21:40 | 0 | CatchInFinally.cs:21:35:21:41 | access to array element | semmle.label | successor |
+| CatchInFinally.cs:21:40:21:40 | [finally: exception(ArgumentNullException)] 0 | CatchInFinally.cs:21:35:21:41 | [finally: exception(ArgumentNullException)] access to array element | semmle.label | successor |
+| CatchInFinally.cs:21:40:21:40 | [finally: exception(Exception)] 0 | CatchInFinally.cs:21:35:21:41 | [finally: exception(Exception)] access to array element | semmle.label | successor |
+| CatchInFinally.cs:23:13:26:13 | [finally: exception(ArgumentNullException)] catch {...} | CatchInFinally.cs:24:13:26:13 | [finally: exception(ArgumentNullException)] {...} | semmle.label | successor |
+| CatchInFinally.cs:23:13:26:13 | [finally: exception(Exception)] catch {...} | CatchInFinally.cs:24:13:26:13 | [finally: exception(Exception)] {...} | semmle.label | successor |
+| CatchInFinally.cs:23:13:26:13 | catch {...} | CatchInFinally.cs:24:13:26:13 | {...} | semmle.label | successor |
+| CatchInFinally.cs:24:13:26:13 | [finally: exception(ArgumentNullException)] {...} | CatchInFinally.cs:25:17:25:38 | [finally: exception(ArgumentNullException)] ...; | semmle.label | successor |
+| CatchInFinally.cs:24:13:26:13 | [finally: exception(Exception)] {...} | CatchInFinally.cs:25:17:25:38 | [finally: exception(Exception)] ...; | semmle.label | successor |
+| CatchInFinally.cs:24:13:26:13 | {...} | CatchInFinally.cs:25:17:25:38 | ...; | semmle.label | successor |
+| CatchInFinally.cs:25:17:25:37 | [finally: exception(ArgumentNullException)] call to method WriteLine | CatchInFinally.cs:5:10:5:11 | exit M1 | semmle.label | exception(ArgumentNullException) |
+| CatchInFinally.cs:25:17:25:37 | [finally: exception(Exception)] call to method WriteLine | CatchInFinally.cs:5:10:5:11 | exit M1 | semmle.label | exception(Exception) |
+| CatchInFinally.cs:25:17:25:37 | call to method WriteLine | CatchInFinally.cs:5:10:5:11 | exit M1 | semmle.label | successor |
+| CatchInFinally.cs:25:17:25:38 | ...; | CatchInFinally.cs:25:35:25:36 | "" | semmle.label | successor |
+| CatchInFinally.cs:25:17:25:38 | [finally: exception(ArgumentNullException)] ...; | CatchInFinally.cs:25:35:25:36 | [finally: exception(ArgumentNullException)] "" | semmle.label | successor |
+| CatchInFinally.cs:25:17:25:38 | [finally: exception(Exception)] ...; | CatchInFinally.cs:25:35:25:36 | [finally: exception(Exception)] "" | semmle.label | successor |
+| CatchInFinally.cs:25:35:25:36 | "" | CatchInFinally.cs:25:17:25:37 | call to method WriteLine | semmle.label | successor |
+| CatchInFinally.cs:25:35:25:36 | [finally: exception(ArgumentNullException)] "" | CatchInFinally.cs:25:17:25:37 | [finally: exception(ArgumentNullException)] call to method WriteLine | semmle.label | successor |
+| CatchInFinally.cs:25:35:25:36 | [finally: exception(Exception)] "" | CatchInFinally.cs:25:17:25:37 | [finally: exception(Exception)] call to method WriteLine | semmle.label | successor |
 | CompileTimeOperators.cs:5:9:5:15 | enter Default | CompileTimeOperators.cs:6:5:8:5 | {...} | semmle.label | successor |
 | CompileTimeOperators.cs:6:5:8:5 | {...} | CompileTimeOperators.cs:7:16:7:27 | default(...) | semmle.label | successor |
 | CompileTimeOperators.cs:7:9:7:28 | return ...; | CompileTimeOperators.cs:5:9:5:15 | exit Default | semmle.label | return |

--- a/csharp/ql/test/library-tests/controlflow/graph/cflow.cs
+++ b/csharp/ql/test/library-tests/controlflow/graph/cflow.cs
@@ -195,7 +195,7 @@ public class ControlFlow
         {
             throw;  // Go to the finally block
         }
-        catch (Exception) when (false)
+        catch (Exception e) when (e.Message != null)
         {
         }
         finally


### PR DESCRIPTION
## Background
The background for this PR is that I wanted to change the CFG for `try-catch` statements, to properly model control flow in the presence of exception filters:

```
using System;

class Test
{
    int M(string s, bool b)
    {
        try
        {
            return s.Length;
        }
        catch (Exception e) when (b)
        {
            return -1;
        }
        catch (NullReferenceException)
        {
            return -2;
        }
    }
}
```

Before this PR, it looked like this:

![before](https://user-images.githubusercontent.com/3667920/44337622-8a1eb100-a47b-11e8-8308-3f05e6a156bc.png)

The filter `b` has just a `successor` edge, no `true`/`false` edges.  The `true` edge needs to go to the `catch` block, whereas the `false` edge needs to go to the next `catch` clause. However, in order to do that, we need to _remember_, which type of exception was thrown,  i.e., we need to split the `catch` nodes on the possible exception types.

After this PR, the CFG looks like this:

![after](https://user-images.githubusercontent.com/3667920/44337777-192bc900-a47c-11e8-8c00-9b6e6edf9415.png)

Now, each `catch` clause is tried in order (`match` or `no-match`, just like for `switch` statements), and exception filters behave like normal conditionals. Note how the `catch` nodes are tagged with `[exception: ...]` to indicate the type of exception that is thrown.

## CFG splitting
The C# CFG library already does splitting for nodes belonging to a `finally` block. However, the implementation is very ad hoc, and adding new kinds of splits in the same fashion would be quite hard, in particular when elements can have multiple different kinds of splits (for example, a `catch` clause inside a `finally` block). The solution that I propose on this PR is to implement splitting in terms of this interface:
```
    class Split extends TSplit {
      predicate hasEntry(ControlFlowElement pred, ControlFlowElement succ, Completion c) {
        none()
      }

      predicate hasExit(ControlFlowElement pred, ControlFlowElement succ, Completion c) {
        none()
      }

      predicate hasExit(ControlFlowElement pred, Completion c) {
        none()
      }

      predicate hasSuccessor(ControlFlowElement pred, ControlFlowElement succ, Completion c) {
        none()
      }
    }
```
Each kind of split (for now, `finally` splitting and `catch` clause splitting) must then specify when a split is entered (`hasEntry()`), when it is left (`hasExit()`), and when to stay in the split (`hasSuccessor()`). A control flow node is then a control flow element tagged with a *set* of splits that apply to it. The generality of the approach lies in that new kinds of splits only need to implement the interface above; calculating sets of relevant splits and lifting the successor relation to nodes with splits is handled once and for all.

## Commits

The PR is structured into 4 commits, that are best reviewed independently and in order.

1365761: A warm-up commit that changes the `toString()` predicate for `finally` split control flow nodes.
a705b3a: The main commit that implements generic CFG splitting, and redefines the old implementation for `finally` nodes using the new approach.
91ed111: Use generic CFG splitting to improve control flow for `catch` handlers (see example above).
b1451b0: Add a test case that demonstrates that the approach also works when nodes have multiple kinds of splits (a `catch` clause inside a `finally` block).