### PR TITLE
Set `* text=auto` in .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,3 @@
+# This ensures that all files that git considers to be text will have
+# normalized (Unix-style, LF) line endings in the repository.
+* text=auto


### PR DESCRIPTION
**Please review thoroughly as I've never tried this before.** This change should ensure that all new text files get LF-style line endings in the repository and on future check-outs regardless of the platform.

See https://help.github.com/articles/dealing-with-line-endings/ and the articles linked from there.

I tested this by adding a new CRLF-style text file to the repo. When I did `git add newfile.txt` I got the following, which is what I expected:
```
warning: CRLF will be replaced by LF in newfile.txt.
The file will have its original line endings in your working directory.
```

I couldn't provoke git into converting an existing CRLF-style file into LF-style, and I don't know whether it's good or bad that they stay as they are until somebody explicitly converts them. We currently have 325 CRLF-style files in this repository.