### PR TITLE
C#: Fix @kind property of CCyclomaticComplexity

### DIFF
--- a/csharp/ql/src/.qlpath
+++ b/csharp/ql/src/.qlpath
@@ -1,6 +1,10 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <ns:qlpath xmlns:ns="https://semmle.com/schemas/qlpath">
-    <librarypath></librarypath>
+    <librarypath>
+        <path>/semmlecode-csharp-queries</path>
+    </librarypath>
     <dbscheme kind="WORKSPACE">semmlecode-csharp-queries/semmlecode.csharp.dbscheme</dbscheme>
-    <defaultImports><defaultImport>csharp</defaultImport></defaultImports>
+    <defaultImports>
+        <defaultImport>csharp</defaultImport>
+    </defaultImports>
 </ns:qlpath>

--- a/csharp/ql/src/Metrics/Callables/CCyclomaticComplexity.ql
+++ b/csharp/ql/src/Metrics/Callables/CCyclomaticComplexity.ql
@@ -1,7 +1,7 @@
 /**
  * @name Cyclomatic complexity of functions
  * @description Methods with a large number of possible execution paths might be difficult to understand.
- * @kind table
+ * @kind treemap
  * @treemap.warnOn highValues
  * @metricType callable
  * @metricAggregate avg max sum


### PR DESCRIPTION
The `CCyclomaticComplexitty.ql` query has the wrong `@kind` - it is a metric query, so needs `@kind treemap` instead of `@kind table`.

In fixing this problem, I noticed that queries in the `Metrics` query directory do not compile in QL for Eclipse. This is because the `Metrics` directory has a `queries.xml` file which prevents import resolution for the top-level project directory. This has been solved by setting the appropriate library path in the `.qlpath` file, which is the same solution used by `semmlecode-cpp-queries`.