### PR TITLE
JavaScript: Add flow tracking through nested properties.

### DIFF
--- a/change-notes/1.18/analysis-javascript.md
+++ b/change-notes/1.18/analysis-javascript.md
@@ -12,7 +12,7 @@
 
 * Modelling of taint flow through the array operations `map` and `join` has been improved. This may give additional results for the security queries.
 
-* The taint tracking library recognizes more ways in which taint propagates. In particular, some flow through string formatters is now recognized. This may give additional results for the security queries.
+* The taint tracking library recognizes more ways in which taint propagates. In particular, some flow through nested properties and through string formatters is now recognized. This may give additional results for the security queries.
 
 * The taint tracking library now recognizes additional sanitization patterns. This may give fewer false-positive results for the security queries.
 

--- a/javascript/ql/src/semmle/javascript/dataflow/Configuration.qll
+++ b/javascript/ql/src/semmle/javascript/dataflow/Configuration.qll
@@ -344,7 +344,8 @@ private predicate exploratoryFlowStep(DataFlow::Node pred, DataFlow::Node succ,
                                       DataFlow::Configuration cfg) {
   basicFlowStep(pred, succ, _, cfg) or
   basicStoreStep(pred, succ, _) or
-  loadStep(pred, succ, _)
+  loadStep(pred, succ, _) or
+  reverseLoadStep(pred, succ, _)
 }
 
 /**
@@ -479,6 +480,72 @@ private predicate reachableFromStoreBase(string prop, DataFlow::Node rhs, DataFl
   or
   exists (DataFlow::Node mid, PathSummary oldSummary, PathSummary newSummary |
     reachableFromStoreBase(prop, rhs, mid, cfg, oldSummary) and
+    flowStep(mid, cfg, nd, newSummary) and
+    newSummary.valuePreserving() = true and
+    summary = oldSummary.append(newSummary)
+  )
+  or
+  nestedPropFlow(prop, rhs, nd, cfg, summary)
+}
+
+/**
+ * Holds if `rhs` is the right-hand side of a write to property `outerProp` and some read of
+ * another property `innerProp` is reachable from the base of that write under configuration `cfg`,
+ * and from the base of that inner read we can reach a read `succ` of the same property `innerProp`,
+ * such that the path from `rhs` to `succ` is summarized by `summary`.
+ *
+ * Example:
+ *
+ * ```
+ * let root = new A();
+ * let base = root.innerProp;
+ * base.outerProp = rhs;
+ * let succ = root.innerProp;
+ * ```
+ */
+private predicate nestedPropFlow(string outerProp, DataFlow::Node rhs, DataFlow::Node succ,
+                                 DataFlow::Configuration cfg, PathSummary summary) {
+  exists (DataFlow::PropRead nestedRead, PathSummary oldSummary |
+    reachableFromStoreBase(outerProp, rhs, nestedRead, cfg, oldSummary) and
+    loadLoadPair(nestedRead, succ, cfg, oldSummary, summary)
+  )
+}
+
+/**
+ * Holds if `load` is a read of some property `innerProp` from which we can reach a read `succ` of the same
+ * property `innerProp` under configuration `cfg`, and the concatenation of `oldSummary` with the summary
+ * of that path is `summary`.
+ *
+ * Example:
+ *
+ * ```
+ * let root = A();
+ * let load = root.innerProp;
+ * let succ = root.innerProp;
+ * ```
+ */
+pragma[noinline]
+private predicate loadLoadPair(DataFlow::PropRead load, DataFlow::Node succ,
+                               DataFlow::Configuration cfg, PathSummary oldSummary, PathSummary summary) {
+  exists (string innerProp, DataFlow::Node nd, PathSummary newSummary |
+    reachableFromLoadBase(innerProp, load, nd, cfg, newSummary) and
+    loadStep(nd, succ, innerProp) and
+    summary = oldSummary.append(newSummary)
+  )
+}
+
+/**
+ * Holds if `read` is a read of property `prop`, and `nd` is reachable from the base of that read
+ * under configuration `cfg` (possibly through callees) along a path summarized by `summary`.
+ */
+private predicate reachableFromLoadBase(string prop, DataFlow::Node read, DataFlow::Node nd,
+                                        DataFlow::Configuration cfg, PathSummary summary) {
+  reachableFromStoreBase(_, _, read, cfg, _) and
+  reverseLoadStep(read, nd, prop) and
+  summary = PathSummary::empty()
+  or
+  exists (DataFlow::Node mid, PathSummary oldSummary, PathSummary newSummary |
+    reachableFromLoadBase(prop, read, mid, cfg, oldSummary) and
     flowStep(mid, cfg, nd, newSummary) and
     newSummary.valuePreserving() = true and
     summary = oldSummary.append(newSummary)

--- a/javascript/ql/src/semmle/javascript/dataflow/TrackedNodes.qll
+++ b/javascript/ql/src/semmle/javascript/dataflow/TrackedNodes.qll
@@ -16,6 +16,7 @@ abstract class TrackedNode extends DataFlow::Node {
    * Holds if this node flows into `sink` in zero or more (possibly
    * inter-procedural) steps.
    */
+  pragma[nomagic]
   predicate flowsTo(DataFlow::Node sink) {
     NodeTracking::flowsTo(this, sink, _)
   }

--- a/javascript/ql/src/semmle/javascript/dataflow/internal/FlowSteps.qll
+++ b/javascript/ql/src/semmle/javascript/dataflow/internal/FlowSteps.qll
@@ -209,6 +209,24 @@ predicate loadStep(DataFlow::Node pred, DataFlow::PropRead succ, string prop) {
 }
 
 /**
+ * Holds if there is a "reverse load" step from `pred` to `succ` under property `prop`,
+ * that is, `pred` is a read of property `prop` from (a data flow node reachable from)
+ * `succ`.
+ *
+ * For example, for this code snippet:
+ *
+ * ```
+ * var a = new A();
+ * a.p;
+ * ```
+ *
+ * there is a reverse load step from `a.p` to `new A()` under property `prop`.
+ */
+predicate reverseLoadStep(DataFlow::Node pred, DataFlow::SourceNode succ, string prop) {
+  pred = succ.getAPropertyRead(prop)
+}
+
+/**
  * A utility class that is equivalent to `boolean` but does not require type joining.
  */
 class Boolean extends boolean {

--- a/javascript/ql/src/semmle/javascript/frameworks/Express.qll
+++ b/javascript/ql/src/semmle/javascript/frameworks/Express.qll
@@ -62,6 +62,7 @@ module Express {
   /**
    * Holds if `e` may refer to the given `router` object.
    */
+  pragma[nomagic]
   private predicate isRouter(Expr e, RouterDefinition router) {
     router.flowsTo(e)
     or

--- a/javascript/ql/src/semmle/javascript/frameworks/HTTP.qll
+++ b/javascript/ql/src/semmle/javascript/frameworks/HTTP.qll
@@ -218,6 +218,7 @@ module HTTP {
      * Gets an expression that contains a request object handled
      * by this handler.
      */
+    pragma[nomagic]
     RequestExpr getARequestExpr() {
       result.getRouteHandler() = this
     }
@@ -326,6 +327,7 @@ module HTTP {
 
       StandardRequestExpr() { src.flowsTo(DataFlow::valueNode(this)) }
 
+      pragma[nomagic]
       override RouteHandler getRouteHandler() {
         result = src.getRouteHandler()
       }
@@ -369,6 +371,7 @@ module HTTP {
       /**
        * Gets a route handler that is defined by this setup.
        */
+      pragma[nomagic]
       abstract DataFlow::SourceNode getARouteHandler();
 
       /**

--- a/javascript/ql/src/semmle/javascript/frameworks/Koa.qll
+++ b/javascript/ql/src/semmle/javascript/frameworks/Koa.qll
@@ -130,11 +130,13 @@ module Koa {
   class ContextExpr extends Expr {
     ContextSource src;
 
+    pragma[nomagic]
     ContextExpr() { src.flowsTo(DataFlow::valueNode(this)) }
 
     /**
      * Gets the route handler that provides this response.
      */
+    pragma[nomagic]
     RouteHandler getRouteHandler() {
       result = src.getRouteHandler()
     }

--- a/javascript/ql/test/library-tests/InterProceduralFlow/DataFlow.expected
+++ b/javascript/ql/test/library-tests/InterProceduralFlow/DataFlow.expected
@@ -27,6 +27,7 @@
 | properties.js:2:16:2:24 | "tainted" | properties.js:12:15:12:24 | x.someProp |
 | properties.js:2:16:2:24 | "tainted" | properties.js:14:15:14:27 | tmp1.someProp |
 | properties.js:18:26:18:42 | "tainted as well" | properties.js:20:24:20:33 | window.foo |
+| properties.js:23:22:23:35 | "also tainted" | properties.js:28:15:28:19 | b.p.q |
 | tst2.js:2:17:2:26 | "tainted1" | tst2.js:10:15:10:24 | g(source1) |
 | tst2.js:3:17:3:26 | "tainted2" | tst2.js:11:15:11:24 | g(source2) |
 | tst2.js:6:24:6:37 | "also tainted" | tst2.js:10:15:10:24 | g(source1) |

--- a/javascript/ql/test/library-tests/InterProceduralFlow/GermanFlow.expected
+++ b/javascript/ql/test/library-tests/InterProceduralFlow/GermanFlow.expected
@@ -28,6 +28,7 @@
 | properties.js:2:16:2:24 | "tainted" | properties.js:12:15:12:24 | x.someProp |
 | properties.js:2:16:2:24 | "tainted" | properties.js:14:15:14:27 | tmp1.someProp |
 | properties.js:18:26:18:42 | "tainted as well" | properties.js:20:24:20:33 | window.foo |
+| properties.js:23:22:23:35 | "also tainted" | properties.js:28:15:28:19 | b.p.q |
 | tst2.js:2:17:2:26 | "tainted1" | tst2.js:10:15:10:24 | g(source1) |
 | tst2.js:3:17:3:26 | "tainted2" | tst2.js:11:15:11:24 | g(source2) |
 | tst2.js:6:24:6:37 | "also tainted" | tst2.js:10:15:10:24 | g(source1) |

--- a/javascript/ql/test/library-tests/InterProceduralFlow/TaintTracking.expected
+++ b/javascript/ql/test/library-tests/InterProceduralFlow/TaintTracking.expected
@@ -32,6 +32,7 @@
 | properties.js:2:16:2:24 | "tainted" | properties.js:12:15:12:24 | x.someProp |
 | properties.js:2:16:2:24 | "tainted" | properties.js:14:15:14:27 | tmp1.someProp |
 | properties.js:18:26:18:42 | "tainted as well" | properties.js:20:24:20:33 | window.foo |
+| properties.js:23:22:23:35 | "also tainted" | properties.js:28:15:28:19 | b.p.q |
 | tst2.js:2:17:2:26 | "tainted1" | tst2.js:10:15:10:24 | g(source1) |
 | tst2.js:3:17:3:26 | "tainted2" | tst2.js:11:15:11:24 | g(source2) |
 | tst2.js:6:24:6:37 | "also tainted" | tst2.js:10:15:10:24 | g(source1) |

--- a/javascript/ql/test/library-tests/InterProceduralFlow/properties.js
+++ b/javascript/ql/test/library-tests/InterProceduralFlow/properties.js
@@ -18,3 +18,12 @@ function f(x) {
 var yet_another_source = "tainted as well";
 window.foo = yet_another_source;
 var yet_another_sink = window.foo;
+
+(function() {
+  var other_source = "also tainted";
+  var b = new B();
+  b.p.q = other_source;
+  var sink3 = b;
+  var sink4 = b.p;
+  var sink5 = b.p.q;
+});


### PR DESCRIPTION
The technical meat is in the first commit, the second one is a (somewhat performance-motivated) refactoring, the third is a pure performance refactoring.

No new alerts on the default benchmarks, and only moderate performance cost, except on `esprima` (11s = 6%), `goojs` (67s = 9%) and `expressCart` (12s = 12.5%); full numbers [here](https://git.semmle.com/gist/max/25cc47b90a5712d582be57d9c00fd73e) (internal link).

There is no particular rush to get this in now (or even at all), I just wanted to put it up since I had a branch anyway and the performance more or less works out.