### PR TITLE
C++: Make XMLFile extend File again

### DIFF
--- a/cpp/ql/src/semmle/code/cpp/XML.qll
+++ b/cpp/ql/src/semmle/code/cpp/XML.qll
@@ -94,7 +94,7 @@ class XMLParent extends @xmlparent {
 }
 
 /** An XML file. */
-class XMLFile extends XMLParent {
+class XMLFile extends XMLParent, File {
   XMLFile() {
     xmlEncoding(this,_)
   }


### PR DESCRIPTION
Commit a1e44041e made `XMLFile` no longer extend `File`. I'm guessing this was necessary in the branch where `File` was an IPA-typed `Element` and `XMLFile` was not, but it broke compilation of some of our internal queries.

The proper fix may be to make `XMLFile` an `Element` or to change the code that doesn't compile, but for now I propose this quick fix.