### PR TITLE
C#: Regression test for extractor

### DIFF
--- a/csharp/ql/test/library-tests/regressions/Program.cs
+++ b/csharp/ql/test/library-tests/regressions/Program.cs
@@ -81,3 +81,16 @@ class Designations
         return 0;
     }
 }
+
+class LiteralConversions
+{
+    struct Point
+    {
+        public int? x, y;
+    }
+
+    void F()
+    {
+        new Point { x=1, y=2 };
+    }
+}

--- a/csharp/ql/test/library-tests/regressions/TypeMentions.expected
+++ b/csharp/ql/test/library-tests/regressions/TypeMentions.expected
@@ -39,3 +39,9 @@
 | Program.cs:69:5:69:8 | Boolean |
 | Program.cs:69:16:69:18 | Int32 |
 | Program.cs:75:5:75:7 | Int32 |
+| Program.cs:89:16:89:18 | Int32 |
+| Program.cs:89:16:89:18 | Int32 |
+| Program.cs:89:16:89:19 | Nullable<Int32> |
+| Program.cs:89:16:89:19 | Nullable<Int32> |
+| Program.cs:92:5:92:8 | Void |
+| Program.cs:94:13:94:17 | Point |


### PR DESCRIPTION
Add a new regression test for the extractor. Will only pass once the associated extractor changes are merged.