### PR TITLE
Java/C: Improve performance when multiple configs use field flow.

### DIFF
--- a/cpp/ql/src/semmle/code/cpp/dataflow/internal/DataFlowImpl.qll
+++ b/cpp/ql/src/semmle/code/cpp/dataflow/internal/DataFlowImpl.qll
@@ -237,7 +237,7 @@
   private predicate storeCandFwd1(Content f, Configuration config) {
     exists(Node mid, Node node |
       not config.isBarrier(node) and
-      useFieldFlow(unbind(config)) and
+      useFieldFlow(config) and
       nodeCandFwd1(mid, _, config) and
       store(mid, f, node)
     )
@@ -312,7 +312,7 @@
    */
   private predicate readCand1(Content f, Configuration config) {
     exists(Node mid, Node node |
-      useFieldFlow(unbind(config)) and
+      useFieldFlow(config) and
       nodeCandFwd1(node, true, unbind(config)) and
       read(node, f, mid) and
       storeCandFwd1(f, unbind(config)) and
@@ -548,7 +548,7 @@
    */
   private predicate storeCandFwd2(Content f, Configuration config) {
     exists(Node mid, Node node |
-      useFieldFlow(unbind(config)) and
+      useFieldFlow(config) and
       nodeCand1(node, true, unbind(config)) and
       nodeCandFwd2(mid, _, _, config) and
       store(mid, f, node) and
@@ -616,7 +616,7 @@
    */
   private predicate readCand2(Content f, Configuration config) {
     exists(Node mid, Node node |
-      useFieldFlow(unbind(config)) and
+      useFieldFlow(config) and
       nodeCandFwd2(node, _, true, unbind(config)) and
       read(node, f, mid) and
       storeCandFwd2(f, unbind(config)) and

--- a/cpp/ql/src/semmle/code/cpp/dataflow/internal/DataFlowImpl2.qll
+++ b/cpp/ql/src/semmle/code/cpp/dataflow/internal/DataFlowImpl2.qll
@@ -237,7 +237,7 @@
   private predicate storeCandFwd1(Content f, Configuration config) {
     exists(Node mid, Node node |
       not config.isBarrier(node) and
-      useFieldFlow(unbind(config)) and
+      useFieldFlow(config) and
       nodeCandFwd1(mid, _, config) and
       store(mid, f, node)
     )
@@ -312,7 +312,7 @@
    */
   private predicate readCand1(Content f, Configuration config) {
     exists(Node mid, Node node |
-      useFieldFlow(unbind(config)) and
+      useFieldFlow(config) and
       nodeCandFwd1(node, true, unbind(config)) and
       read(node, f, mid) and
       storeCandFwd1(f, unbind(config)) and
@@ -548,7 +548,7 @@
    */
   private predicate storeCandFwd2(Content f, Configuration config) {
     exists(Node mid, Node node |
-      useFieldFlow(unbind(config)) and
+      useFieldFlow(config) and
       nodeCand1(node, true, unbind(config)) and
       nodeCandFwd2(mid, _, _, config) and
       store(mid, f, node) and
@@ -616,7 +616,7 @@
    */
   private predicate readCand2(Content f, Configuration config) {
     exists(Node mid, Node node |
-      useFieldFlow(unbind(config)) and
+      useFieldFlow(config) and
       nodeCandFwd2(node, _, true, unbind(config)) and
       read(node, f, mid) and
       storeCandFwd2(f, unbind(config)) and

--- a/cpp/ql/src/semmle/code/cpp/dataflow/internal/DataFlowImpl3.qll
+++ b/cpp/ql/src/semmle/code/cpp/dataflow/internal/DataFlowImpl3.qll
@@ -237,7 +237,7 @@
   private predicate storeCandFwd1(Content f, Configuration config) {
     exists(Node mid, Node node |
       not config.isBarrier(node) and
-      useFieldFlow(unbind(config)) and
+      useFieldFlow(config) and
       nodeCandFwd1(mid, _, config) and
       store(mid, f, node)
     )
@@ -312,7 +312,7 @@
    */
   private predicate readCand1(Content f, Configuration config) {
     exists(Node mid, Node node |
-      useFieldFlow(unbind(config)) and
+      useFieldFlow(config) and
       nodeCandFwd1(node, true, unbind(config)) and
       read(node, f, mid) and
       storeCandFwd1(f, unbind(config)) and
@@ -548,7 +548,7 @@
    */
   private predicate storeCandFwd2(Content f, Configuration config) {
     exists(Node mid, Node node |
-      useFieldFlow(unbind(config)) and
+      useFieldFlow(config) and
       nodeCand1(node, true, unbind(config)) and
       nodeCandFwd2(mid, _, _, config) and
       store(mid, f, node) and
@@ -616,7 +616,7 @@
    */
   private predicate readCand2(Content f, Configuration config) {
     exists(Node mid, Node node |
-      useFieldFlow(unbind(config)) and
+      useFieldFlow(config) and
       nodeCandFwd2(node, _, true, unbind(config)) and
       read(node, f, mid) and
       storeCandFwd2(f, unbind(config)) and

--- a/cpp/ql/src/semmle/code/cpp/dataflow/internal/DataFlowImpl4.qll
+++ b/cpp/ql/src/semmle/code/cpp/dataflow/internal/DataFlowImpl4.qll
@@ -237,7 +237,7 @@
   private predicate storeCandFwd1(Content f, Configuration config) {
     exists(Node mid, Node node |
       not config.isBarrier(node) and
-      useFieldFlow(unbind(config)) and
+      useFieldFlow(config) and
       nodeCandFwd1(mid, _, config) and
       store(mid, f, node)
     )
@@ -312,7 +312,7 @@
    */
   private predicate readCand1(Content f, Configuration config) {
     exists(Node mid, Node node |
-      useFieldFlow(unbind(config)) and
+      useFieldFlow(config) and
       nodeCandFwd1(node, true, unbind(config)) and
       read(node, f, mid) and
       storeCandFwd1(f, unbind(config)) and
@@ -548,7 +548,7 @@
    */
   private predicate storeCandFwd2(Content f, Configuration config) {
     exists(Node mid, Node node |
-      useFieldFlow(unbind(config)) and
+      useFieldFlow(config) and
       nodeCand1(node, true, unbind(config)) and
       nodeCandFwd2(mid, _, _, config) and
       store(mid, f, node) and
@@ -616,7 +616,7 @@
    */
   private predicate readCand2(Content f, Configuration config) {
     exists(Node mid, Node node |
-      useFieldFlow(unbind(config)) and
+      useFieldFlow(config) and
       nodeCandFwd2(node, _, true, unbind(config)) and
       read(node, f, mid) and
       storeCandFwd2(f, unbind(config)) and


### PR DESCRIPTION
`useFieldFlow` is unary and should therefore not use unbind as that just causes a cartesian product, and joining directly on the config is fine as it won't introduce other fields.