### PR TITLE
C++: Tweak type_variants test

### DIFF
--- a/cpp/ql/test/header-variant-tests/type_variants/variants.expected
+++ b/cpp/ql/test/header-variant-tests/type_variants/variants.expected
@@ -1,8 +1,11 @@
-| IteratorT | 1 |
-| common_function | 2 |
-| first | 2 |
-| last | 2 |
-| operator!= | 1 |
-| operator* | 1 |
-| operator++ | 1 |
-| print_int | 1 |
+| common.h:3:6:3:14 | print_int | 1 | 1 |
+| common.h:7:6:7:20 | common_function | 2 | 1 |
+| debug.cpp:1:8:1:8 | IteratorT | 1 | 1 |
+| debug.cpp:2:3:2:11 | IteratorT | 1 | 1 |
+| debug.cpp:4:7:4:15 | operator* | 1 | 1 |
+| debug.cpp:5:14:5:23 | operator++ | 1 | 1 |
+| debug.cpp:11:6:11:15 | operator!= | 1 | 1 |
+| debug.cpp:13:11:13:15 | first | 2 | 2 |
+| debug.cpp:17:11:17:14 | last | 2 | 2 |
+| release.cpp:7:11:7:15 | first | 2 | 2 |
+| release.cpp:11:11:11:14 | last | 2 | 2 |

--- a/cpp/ql/test/header-variant-tests/type_variants/variants.ql
+++ b/cpp/ql/test/header-variant-tests/type_variants/variants.ql
@@ -1,4 +1,4 @@
 import cpp
 
 from Function f
-select f.getName(), strictcount(f.getBlock())
+select f, strictcount(f.getBlock()), count(f.getLocation())


### PR DESCRIPTION
It's now easier to see what's happening in cases where 2 functions have the same name, or a function has 2 locations.