### PR TITLE
C++: Fix wobble in PrintAST test

### DIFF
--- a/cpp/ql/test/examples/expressions/PrintAST.expected
+++ b/cpp/ql/test/examples/expressions/PrintAST.expected
@@ -2,14 +2,14 @@
 #-----|   params: 
 #-----| __va_list_tag::operator=() -> __va_list_tag &
 #-----|   params: 
-#-----| operator new(unsigned long) -> void *
-#-----|   params: 
-#-----|     0: p#0
-#-----|         Type = unsigned long
 #-----| operator delete(void *) -> void
 #-----|   params: 
 #-----|     0: p#0
 #-----|         Type = void *
+#-----| operator new(unsigned long) -> void *
+#-----|   params: 
+#-----|     0: p#0
+#-----|         Type = unsigned long
 AddressOf.c:
 #    1| AddressOf(int) -> void
 #    1|   params: 

--- a/cpp/ql/test/library-tests/ir/ir/PrintAST.expected
+++ b/cpp/ql/test/library-tests/ir/ir/PrintAST.expected
@@ -2,15 +2,21 @@
 #-----|   params: 
 #-----| __va_list_tag::operator=() -> __va_list_tag &
 #-----|   params: 
-#-----| operator new(unsigned long) -> void *
-#-----|   params: 
-#-----|     0: p#0
-#-----|         Type = unsigned long
 #-----| operator delete(void *, unsigned long) -> void
 #-----|   params: 
 #-----|     0: p#0
 #-----|         Type = void *
 #-----|     1: p#1
+#-----|         Type = unsigned long
+#-----| operator delete[](void *, unsigned long) -> void
+#-----|   params: 
+#-----|     0: p#0
+#-----|         Type = void *
+#-----|     1: p#1
+#-----|         Type = unsigned long
+#-----| operator new(unsigned long) -> void *
+#-----|   params: 
+#-----|     0: p#0
 #-----|         Type = unsigned long
 #-----| operator new(unsigned long, align_val_t) -> void *
 #-----|   params: 
@@ -21,12 +27,6 @@
 #-----| operator new[](unsigned long) -> void *
 #-----|   params: 
 #-----|     0: p#0
-#-----|         Type = unsigned long
-#-----| operator delete[](void *, unsigned long) -> void
-#-----|   params: 
-#-----|     0: p#0
-#-----|         Type = void *
-#-----|     1: p#1
 #-----|         Type = unsigned long
 #-----| operator new[](unsigned long, align_val_t) -> void *
 #-----|   params: 


### PR DESCRIPTION
PrintAST.ql orders the functions by location, then in lexicographical order of the function signature. This is supposed to ensure a stable ordering, but functions without a location were not getting assigned an order at all.