### PR TITLE
CPP: Support crement operations in CWE-190

### DIFF
--- a/change-notes/1.18/analysis-cpp.md
+++ b/change-notes/1.18/analysis-cpp.md
@@ -26,9 +26,9 @@
 | [Variable used in its own initializer] | Fewer false positive results | Results where a macro is used to indicate deliberate uninitialization are now excluded |
 | [Assignment where comparison was intended] | Fewer false positive results | Results are no longer reported if the variable is not yet defined. |
 | [Comparison where assignment was intended] | More correct results | "This query now includes results where an overloaded `operator==` is used in the wrong context. |
-| [User-controlled data in arithmetic expression] | More correct results | Increment / decrement operations are now understood as arithmetic operations in this query. |
-| [Uncontrolled data in arithmetic expression] | More correct results | Increment / decrement operations are now understood as arithmetic operations in this query. |
-| [Use of extreme values in arithmetic expression] | More correct results | Increment / decrement operations are now understood as arithmetic operations in this query. |
+| [User-controlled data in arithmetic expression] | More correct results | Increment / decrement / addition assignment / subtraction assignment operations are now understood as arithmetic operations in this query. |
+| [Uncontrolled data in arithmetic expression] | More correct results | Increment / decrement / addition assignment / subtraction assignment operations are now understood as arithmetic operations in this query. |
+| [Use of extreme values in arithmetic expression] | More correct results | Increment / decrement / addition assignment / subtraction assignment operations are now understood as arithmetic operations in this query. |
 | [Use of extreme values in arithmetic expression] | Fewer false positives | The query now considers whether a particular expression might cause an overflow of minimum or maximum values only. |
  
 ## Changes to QL libraries

--- a/change-notes/1.18/analysis-cpp.md
+++ b/change-notes/1.18/analysis-cpp.md
@@ -26,7 +26,11 @@
 | [Variable used in its own initializer] | Fewer false positive results | Results where a macro is used to indicate deliberate uninitialization are now excluded |
 | [Assignment where comparison was intended] | Fewer false positive results | Results are no longer reported if the variable is not yet defined. |
 | [Comparison where assignment was intended] | More correct results | "This query now includes results where an overloaded `operator==` is used in the wrong context. |
-
+| [User-controlled data in arithmetic expression] | More correct results | Crement operations are now understood as arithmetic operations in this query. |
+| [Uncontrolled data in arithmetic expression] | More correct results | Crement operations are now understood as arithmetic operations in this query. |
+| [Use of extreme values in arithmetic expression] | More correct results | Crement operations are now understood as arithmetic operations in this query. |
+| [Use of extreme values in arithmetic expression] | Fewer false positives | The query now considers whether a particular expression might cause an overflow of minimum or maximum values only. |
+ 
 ## Changes to QL libraries
 
 * *Series of bullet points*

--- a/change-notes/1.18/analysis-cpp.md
+++ b/change-notes/1.18/analysis-cpp.md
@@ -26,9 +26,9 @@
 | [Variable used in its own initializer] | Fewer false positive results | Results where a macro is used to indicate deliberate uninitialization are now excluded |
 | [Assignment where comparison was intended] | Fewer false positive results | Results are no longer reported if the variable is not yet defined. |
 | [Comparison where assignment was intended] | More correct results | "This query now includes results where an overloaded `operator==` is used in the wrong context. |
-| [User-controlled data in arithmetic expression] | More correct results | Crement operations are now understood as arithmetic operations in this query. |
-| [Uncontrolled data in arithmetic expression] | More correct results | Crement operations are now understood as arithmetic operations in this query. |
-| [Use of extreme values in arithmetic expression] | More correct results | Crement operations are now understood as arithmetic operations in this query. |
+| [User-controlled data in arithmetic expression] | More correct results | Increment / decrement operations are now understood as arithmetic operations in this query. |
+| [Uncontrolled data in arithmetic expression] | More correct results | Increment / decrement operations are now understood as arithmetic operations in this query. |
+| [Use of extreme values in arithmetic expression] | More correct results | Increment / decrement operations are now understood as arithmetic operations in this query. |
 | [Use of extreme values in arithmetic expression] | Fewer false positives | The query now considers whether a particular expression might cause an overflow of minimum or maximum values only. |
  
 ## Changes to QL libraries

--- a/cpp/ql/src/Security/CWE/CWE-190/ArithmeticTainted.ql
+++ b/cpp/ql/src/Security/CWE/CWE-190/ArithmeticTainted.ql
@@ -21,7 +21,7 @@ predicate taintedVarAccess(Expr origin, VariableAccess va) {
   tainted(origin, va)
 }
 
-from Expr origin, BinaryArithmeticOperation op, VariableAccess va, string effect
+from Expr origin, Operation op, VariableAccess va, string effect
 where taintedVarAccess(origin, va)
   and op.getAnOperand() = va
   and

--- a/cpp/ql/src/Security/CWE/CWE-190/ArithmeticUncontrolled.ql
+++ b/cpp/ql/src/Security/CWE/CWE-190/ArithmeticUncontrolled.ql
@@ -46,7 +46,7 @@ predicate guardedByAssignDiv(Expr origin) {
          tainted(origin, va) and div.getLValue() = va)
 }
 
-from Expr origin, BinaryArithmeticOperation op, VariableAccess va, string effect
+from Expr origin, Operation op, VariableAccess va, string effect
 where taintedVarAccess(origin, va)
   and op.getAnOperand() = va
   and

--- a/cpp/ql/src/Security/CWE/CWE-190/ArithmeticWithExtremeValues.ql
+++ b/cpp/ql/src/Security/CWE/CWE-190/ArithmeticWithExtremeValues.ql
@@ -45,7 +45,7 @@ predicate taintedVarAccess(Expr origin, VariableAccess va) {
   tainted(origin, va)
 }
 
-from Expr origin, BinaryArithmeticOperation op, VariableAccess va, string effect
+from Expr origin, Operation op, VariableAccess va, string effect
 where taintedVarAccess(origin, va)
   and op.getAnOperand() = va
   and

--- a/cpp/ql/src/Security/CWE/CWE-190/ArithmeticWithExtremeValues.ql
+++ b/cpp/ql/src/Security/CWE/CWE-190/ArithmeticWithExtremeValues.ql
@@ -35,18 +35,18 @@ predicate isMinValue(MacroInvocationExpr mie) {
 
 class SecurityOptionsArith extends SecurityOptions {
   override predicate isUserInput(Expr expr, string cause) {
-    (isMaxValue(expr) and cause = "max value") or
-    (isMinValue(expr) and cause = "min value")
+    (isMaxValue(expr) and cause = "overflow") or
+    (isMinValue(expr) and cause = "underflow")
   }
 }
 
-predicate taintedVarAccess(Expr origin, VariableAccess va) {
-  isUserInput(origin, _) and
+predicate taintedVarAccess(Expr origin, VariableAccess va, string cause) {
+  isUserInput(origin, cause) and
   tainted(origin, va)
 }
 
 from Expr origin, Operation op, VariableAccess va, string effect
-where taintedVarAccess(origin, va)
+where taintedVarAccess(origin, va, effect)
   and op.getAnOperand() = va
   and
   (

--- a/cpp/ql/src/semmle/code/cpp/security/Overflow.qll
+++ b/cpp/ql/src/semmle/code/cpp/security/Overflow.qll
@@ -63,7 +63,7 @@ predicate missingGuardAgainstOverflow(Operation e, VariableAccess use) {
   exists(LocalScopeVariable v | use.getTarget() = v |
     // overflow possible if large
     (e instanceof AddExpr and not guardedLesser(e, varUse(v))) or
-    (e instanceof IncrementOperation and not guardedLesser(e, varUse(v))) or     
+    (e instanceof IncrementOperation and not guardedLesser(e, varUse(v)) and v.getType().getUnspecifiedType() instanceof IntegralType) or     
     // overflow possible if large or small
     (e instanceof MulExpr and
       not (guardedLesser(e, varUse(v)) and guardedGreater(e, varUse(v))))
@@ -77,7 +77,7 @@ predicate missingGuardAgainstUnderflow(Operation e, VariableAccess use) {
     // underflow possible if use is left operand and small
     (use = e.(SubExpr).getLeftOperand() and not guardedGreater(e, varUse(v))) or
     // underflow possible if small
-    (e instanceof DecrementOperation and not guardedGreater(e, varUse(v))) or
+    (e instanceof DecrementOperation and not guardedGreater(e, varUse(v)) and v.getType().getUnspecifiedType() instanceof IntegralType) or
     // underflow possible if large or small
     (e instanceof MulExpr and
       not (guardedLesser(e, varUse(v)) and guardedGreater(e, varUse(v))))

--- a/cpp/ql/src/semmle/code/cpp/security/Overflow.qll
+++ b/cpp/ql/src/semmle/code/cpp/security/Overflow.qll
@@ -63,6 +63,7 @@ predicate missingGuardAgainstOverflow(Operation e, VariableAccess use) {
   exists(LocalScopeVariable v | use.getTarget() = v |
     // overflow possible if large
     (e instanceof AddExpr and not guardedLesser(e, varUse(v))) or
+    (e instanceof AssignAddExpr and not guardedLesser(e, varUse(v))) or
     (e instanceof IncrementOperation and not guardedLesser(e, varUse(v)) and v.getType().getUnspecifiedType() instanceof IntegralType) or     
     // overflow possible if large or small
     (e instanceof MulExpr and
@@ -76,6 +77,7 @@ predicate missingGuardAgainstUnderflow(Operation e, VariableAccess use) {
   exists(LocalScopeVariable v | use.getTarget() = v |
     // underflow possible if use is left operand and small
     (use = e.(SubExpr).getLeftOperand() and not guardedGreater(e, varUse(v))) or
+    (use = e.(AssignSubExpr).getLValue() and not guardedGreater(e, varUse(v))) or
     // underflow possible if small
     (e instanceof DecrementOperation and not guardedGreater(e, varUse(v)) and v.getType().getUnspecifiedType() instanceof IntegralType) or
     // underflow possible if large or small

--- a/cpp/ql/src/semmle/code/cpp/security/Overflow.qll
+++ b/cpp/ql/src/semmle/code/cpp/security/Overflow.qll
@@ -4,7 +4,7 @@ import semmle.code.cpp.controlflow.Dominance
 /* Guarding */
 
 /** is the size of this use guarded using 'abs'? */
-predicate guardedAbs(BinaryArithmeticOperation e, Expr use) {
+predicate guardedAbs(Operation e, Expr use) {
   exists(FunctionCall fc |
     fc.getTarget().getName() = "abs" |
     fc.getArgument(0).getAChild*() = use
@@ -13,7 +13,7 @@ predicate guardedAbs(BinaryArithmeticOperation e, Expr use) {
 }
 
 /** is the size of this use guarded to be less than something? */
-predicate guardedLesser(BinaryArithmeticOperation e, Expr use) {
+predicate guardedLesser(Operation e, Expr use) {
   exists(IfStmt c, RelationalOperation guard |
     use = guard.getLesserOperand().getAChild*() and
     guard = c.getControllingExpr().getAChild*() and
@@ -33,7 +33,7 @@ predicate guardedLesser(BinaryArithmeticOperation e, Expr use) {
 }
 
 /** is the size of this use guarded to be greater than something? */
-predicate guardedGreater(BinaryArithmeticOperation e, Expr use) {
+predicate guardedGreater(Operation e, Expr use) {
   exists(IfStmt c, RelationalOperation guard |
     use = guard.getGreaterOperand().getAChild*() and
     guard = c.getControllingExpr().getAChild*() and
@@ -58,11 +58,12 @@ VariableAccess varUse(LocalScopeVariable v) {
 }
 
 /** is e not guarded against overflow by use? */
-predicate missingGuardAgainstOverflow(BinaryArithmeticOperation e, VariableAccess use) {
+predicate missingGuardAgainstOverflow(Operation e, VariableAccess use) {
   use = e.getAnOperand() and
   exists(LocalScopeVariable v | use.getTarget() = v |
     // overflow possible if large
     (e instanceof AddExpr and not guardedLesser(e, varUse(v))) or
+    (e instanceof IncrementOperation and not guardedLesser(e, varUse(v))) or     
     // overflow possible if large or small
     (e instanceof MulExpr and
       not (guardedLesser(e, varUse(v)) and guardedGreater(e, varUse(v))))
@@ -70,12 +71,13 @@ predicate missingGuardAgainstOverflow(BinaryArithmeticOperation e, VariableAcces
 }
 
 /** is e not guarded against underflow by use? */
-predicate missingGuardAgainstUnderflow(BinaryArithmeticOperation e, VariableAccess use) {
+predicate missingGuardAgainstUnderflow(Operation e, VariableAccess use) {
   use = e.getAnOperand() and
   exists(LocalScopeVariable v | use.getTarget() = v |
     // underflow possible if use is left operand and small
-    (e instanceof SubExpr and
-      (use = e.getLeftOperand() and not guardedGreater(e, varUse(v)))) or
+    (use = e.(SubExpr).getLeftOperand() and not guardedGreater(e, varUse(v))) or
+    // underflow possible if small
+    (e instanceof DecrementOperation and not guardedGreater(e, varUse(v))) or
     // underflow possible if large or small
     (e instanceof MulExpr and
       not (guardedLesser(e, varUse(v)) and guardedGreater(e, varUse(v))))


### PR DESCRIPTION
Support crement operations in the CWE-190 queries.  This fixes one of the 'regressions' we had when we changed from using Samate Juliet Test Suite version 1.2 to 1.3.

There's also a small improvement to the logic in `ArithmeticWithExtremeValues.ql` so that it understands the direction of the potential over/under-flow compared to the extreme value.