### PR TITLE
C++: `Invoke` -> `Call`

### DIFF
--- a/cpp/ql/src/semmle/code/cpp/ir/internal/Instruction.qll
+++ b/cpp/ql/src/semmle/code/cpp/ir/internal/Instruction.qll
@@ -36,7 +36,7 @@ module InstructionSanity {
         opcode instanceof Opcode::ReturnValue and tag instanceof ReturnValueOperand or
         opcode instanceof Opcode::ThrowValue and tag instanceof ExceptionOperand or
         opcode instanceof Opcode::UnmodeledUse and tag instanceof UnmodeledUseOperand or
-        opcode instanceof Opcode::Invoke and tag instanceof CallTargetOperand
+        opcode instanceof Opcode::Call and tag instanceof CallTargetOperand
       )
     )
   }
@@ -54,7 +54,7 @@ module InstructionSanity {
   query predicate unexpectedOperand(Instruction instr, OperandTag tag) {
     exists(instr.getOperand(tag)) and
     not expectsOperand(instr, tag) and
-    not (instr instanceof InvokeInstruction and tag instanceof ArgumentOperand) and
+    not (instr instanceof CallInstruction and tag instanceof ArgumentOperand) and
     not (instr instanceof BuiltInInstruction and tag instanceof PositionalArgumentOperand) and
     not (instr instanceof PhiInstruction and tag instanceof PhiOperand)
   }
@@ -987,9 +987,9 @@ class SwitchInstruction extends Instruction {
   }
 }
 
-class InvokeInstruction extends Instruction {
-  InvokeInstruction() {
-    opcode instanceof Opcode::Invoke
+class CallInstruction extends Instruction {
+  CallInstruction() {
+    opcode instanceof Opcode::Call
   }
 
   final Instruction getCallTarget() {

--- a/cpp/ql/src/semmle/code/cpp/ir/internal/Opcode.qll
+++ b/cpp/ql/src/semmle/code/cpp/ir/internal/Opcode.qll
@@ -46,7 +46,7 @@ private newtype TOpcode =
   TStringConstant() or
   TConditionalBranch() or
   TSwitch() or
-  TInvoke() or
+  TCall() or
   TCatchByType() or
   TCatchAny() or
   TThrowValue() or
@@ -138,7 +138,7 @@ module Opcode {
   class StringConstant extends Opcode, TStringConstant { override final string toString() { result = "StringConstant" } }
   class ConditionalBranch extends OpcodeWithCondition, TConditionalBranch { override final string toString() { result = "ConditionalBranch" } }
   class Switch extends OpcodeWithCondition, TSwitch { override final string toString() { result = "Switch" } }
-  class Invoke extends Opcode, TInvoke { override final string toString() { result = "Invoke" } }
+  class Call extends Opcode, TCall { override final string toString() { result = "Call" } }
   class CatchByType extends CatchOpcode, TCatchByType { override final string toString() { result = "CatchByType" } }
   class CatchAny extends CatchOpcode, TCatchAny { override final string toString() { result = "CatchAny" } }
   class ThrowValue extends ThrowOpcode, MemoryAccessOpcode, TThrowValue { override final string toString() { result = "ThrowValue" } }

--- a/cpp/ql/src/semmle/code/cpp/ir/internal/OperandTag.qll
+++ b/cpp/ql/src/semmle/code/cpp/ir/internal/OperandTag.qll
@@ -202,7 +202,7 @@ UnmodeledUseOperand unmodeledUseOperand() {
 }
 
 /**
- * The operand representing the target function of an `Invoke` instruction.
+ * The operand representing the target function of an `Call` instruction.
  */
 class CallTargetOperand extends OperandTag, TCallTargetOperand {
   override final string toString() {

--- a/cpp/ql/src/semmle/code/cpp/ir/internal/TranslatedExpr.qll
+++ b/cpp/ql/src/semmle/code/cpp/ir/internal/TranslatedExpr.qll
@@ -1793,7 +1793,7 @@ abstract class TranslatedCall extends TranslatedExpr {
   override predicate hasInstruction(Opcode opcode, InstructionTag tag,
     Type resultType, boolean isGLValue) {
     tag = CallTag() and
-    opcode instanceof Opcode::Invoke and
+    opcode instanceof Opcode::Call and
     resultType = getCallResultType() and
     isGLValue = false
   }

--- a/cpp/ql/src/semmle/code/cpp/ssa/internal/aliased_ssa/Instruction.qll
+++ b/cpp/ql/src/semmle/code/cpp/ssa/internal/aliased_ssa/Instruction.qll
@@ -36,7 +36,7 @@ module InstructionSanity {
         opcode instanceof Opcode::ReturnValue and tag instanceof ReturnValueOperand or
         opcode instanceof Opcode::ThrowValue and tag instanceof ExceptionOperand or
         opcode instanceof Opcode::UnmodeledUse and tag instanceof UnmodeledUseOperand or
-        opcode instanceof Opcode::Invoke and tag instanceof CallTargetOperand
+        opcode instanceof Opcode::Call and tag instanceof CallTargetOperand
       )
     )
   }
@@ -54,7 +54,7 @@ module InstructionSanity {
   query predicate unexpectedOperand(Instruction instr, OperandTag tag) {
     exists(instr.getOperand(tag)) and
     not expectsOperand(instr, tag) and
-    not (instr instanceof InvokeInstruction and tag instanceof ArgumentOperand) and
+    not (instr instanceof CallInstruction and tag instanceof ArgumentOperand) and
     not (instr instanceof BuiltInInstruction and tag instanceof PositionalArgumentOperand) and
     not (instr instanceof PhiInstruction and tag instanceof PhiOperand)
   }
@@ -987,9 +987,9 @@ class SwitchInstruction extends Instruction {
   }
 }
 
-class InvokeInstruction extends Instruction {
-  InvokeInstruction() {
-    opcode instanceof Opcode::Invoke
+class CallInstruction extends Instruction {
+  CallInstruction() {
+    opcode instanceof Opcode::Call
   }
 
   final Instruction getCallTarget() {

--- a/cpp/ql/src/semmle/code/cpp/ssa/internal/aliased_ssa/OperandTag.qll
+++ b/cpp/ql/src/semmle/code/cpp/ssa/internal/aliased_ssa/OperandTag.qll
@@ -202,7 +202,7 @@ UnmodeledUseOperand unmodeledUseOperand() {
 }
 
 /**
- * The operand representing the target function of an `Invoke` instruction.
+ * The operand representing the target function of an `Call` instruction.
  */
 class CallTargetOperand extends OperandTag, TCallTargetOperand {
   override final string toString() {

--- a/cpp/ql/src/semmle/code/cpp/ssa/internal/ssa/Instruction.qll
+++ b/cpp/ql/src/semmle/code/cpp/ssa/internal/ssa/Instruction.qll
@@ -36,7 +36,7 @@ module InstructionSanity {
         opcode instanceof Opcode::ReturnValue and tag instanceof ReturnValueOperand or
         opcode instanceof Opcode::ThrowValue and tag instanceof ExceptionOperand or
         opcode instanceof Opcode::UnmodeledUse and tag instanceof UnmodeledUseOperand or
-        opcode instanceof Opcode::Invoke and tag instanceof CallTargetOperand
+        opcode instanceof Opcode::Call and tag instanceof CallTargetOperand
       )
     )
   }
@@ -54,7 +54,7 @@ module InstructionSanity {
   query predicate unexpectedOperand(Instruction instr, OperandTag tag) {
     exists(instr.getOperand(tag)) and
     not expectsOperand(instr, tag) and
-    not (instr instanceof InvokeInstruction and tag instanceof ArgumentOperand) and
+    not (instr instanceof CallInstruction and tag instanceof ArgumentOperand) and
     not (instr instanceof BuiltInInstruction and tag instanceof PositionalArgumentOperand) and
     not (instr instanceof PhiInstruction and tag instanceof PhiOperand)
   }
@@ -987,9 +987,9 @@ class SwitchInstruction extends Instruction {
   }
 }
 
-class InvokeInstruction extends Instruction {
-  InvokeInstruction() {
-    opcode instanceof Opcode::Invoke
+class CallInstruction extends Instruction {
+  CallInstruction() {
+    opcode instanceof Opcode::Call
   }
 
   final Instruction getCallTarget() {

--- a/cpp/ql/src/semmle/code/cpp/ssa/internal/ssa/OperandTag.qll
+++ b/cpp/ql/src/semmle/code/cpp/ssa/internal/ssa/OperandTag.qll
@@ -202,7 +202,7 @@ UnmodeledUseOperand unmodeledUseOperand() {
 }
 
 /**
- * The operand representing the target function of an `Invoke` instruction.
+ * The operand representing the target function of an `Call` instruction.
  */
 class CallTargetOperand extends OperandTag, TCallTargetOperand {
   override final string toString() {

--- a/cpp/ql/test/library-tests/ir/ir/aliased_ssa_ir.expected
+++ b/cpp/ql/test/library-tests/ir/ir/aliased_ssa_ir.expected
@@ -1559,7 +1559,7 @@ ir.cpp:
 #  372|     v0_0(void)           = EnterFunction             : 
 #  372|     mu0_1(unknown)       = UnmodeledDefinition       : 
 #  373|     r0_2(glval<unknown>) = FunctionAddress[VoidFunc] : 
-#  373|     v0_3(void)           = Invoke                    : r0_2
+#  373|     v0_3(void)           = Call                      : r0_2
 #  374|     v0_4(void)           = NoOp                      : 
 #  372|     v0_5(void)           = ReturnVoid                : 
 #  372|     v0_6(void)           = UnmodeledUse              : mu*
@@ -1579,7 +1579,7 @@ ir.cpp:
 #  377|     r0_9(int)            = Load                     : r0_8, m0_3
 #  377|     r0_10(glval<int>)    = VariableAddress[y]       : 
 #  377|     r0_11(int)           = Load                     : r0_10, m0_5
-#  377|     r0_12(int)           = Invoke                   : r0_7, r0_9, r0_11
+#  377|     r0_12(int)           = Call                     : r0_7, r0_9, r0_11
 #  377|     m0_13(int)           = Store                    : r0_6, r0_12
 #  376|     r0_14(glval<int>)    = VariableAddress[#return] : 
 #  376|     v0_15(void)          = ReturnValue              : r0_14, m0_13
@@ -1596,13 +1596,13 @@ ir.cpp:
 #  380|     m0_5(int)            = InitializeParameter[y]    : r0_4
 #  381|     r0_6(glval<int>)     = VariableAddress[#return]  : 
 #  381|     r0_7(glval<unknown>) = FunctionAddress[VoidFunc] : 
-#  381|     v0_8(void)           = Invoke                    : r0_7
+#  381|     v0_8(void)           = Call                      : r0_7
 #  381|     r0_9(glval<unknown>) = FunctionAddress[CallAdd]  : 
 #  381|     r0_10(glval<int>)    = VariableAddress[x]        : 
 #  381|     r0_11(int)           = Load                      : r0_10, m0_3
 #  381|     r0_12(glval<int>)    = VariableAddress[y]        : 
 #  381|     r0_13(int)           = Load                      : r0_12, m0_5
-#  381|     r0_14(int)           = Invoke                    : r0_9, r0_11, r0_13
+#  381|     r0_14(int)           = Call                      : r0_9, r0_11, r0_13
 #  381|     m0_15(int)           = Store                     : r0_6, r0_14
 #  380|     r0_16(glval<int>)    = VariableAddress[#return]  : 
 #  380|     v0_17(void)          = ReturnValue               : r0_16, m0_15
@@ -2114,12 +2114,12 @@ ir.cpp:
 
 #  493|   Block 2
 #  493|     r2_0(glval<unknown>) = FunctionAddress[VoidFunc] : 
-#  493|     v2_1(void)           = Invoke                    : r2_0
+#  493|     v2_1(void)           = Call                      : r2_0
 #-----|   Goto -> Block 1
 
 #  493|   Block 3
 #  493|     r3_0(glval<unknown>) = FunctionAddress[VoidFunc] : 
-#  493|     v3_1(void)           = Invoke                    : r3_0
+#  493|     v3_1(void)           = Call                      : r3_0
 #-----|   Goto -> Block 1
 
 #  496| Nullptr() -> void
@@ -2407,7 +2407,7 @@ ir.cpp:
 #  552|     r0_5(glval<..(*)(..)>) = VariableAddress[pfn]     : 
 #  552|     r0_6(..(*)(..))        = Load                     : r0_5, m0_3
 #  552|     r0_7(int)              = Constant[5]              : 
-#  552|     r0_8(int)              = Invoke                   : r0_6, r0_7
+#  552|     r0_8(int)              = Call                     : r0_6, r0_7
 #  552|     m0_9(int)              = Store                    : r0_4, r0_8
 #  551|     r0_10(glval<int>)      = VariableAddress[#return] : 
 #  551|     v0_11(void)            = ReturnValue              : r0_10, m0_9
@@ -2525,7 +2525,7 @@ ir.cpp:
 #  585|     r0_5(int)            = Constant[1]                     : 
 #  585|     r0_6(glval<char[7]>) = StringConstant["string"]        : 
 #  585|     r0_7(char *)         = Convert                         : r0_6
-#  585|     v0_8(void)           = Invoke                          : r0_2, r0_4, r0_5, r0_7
+#  585|     v0_8(void)           = Call                            : r0_2, r0_4, r0_5, r0_7
 #  586|     v0_9(void)           = NoOp                            : 
 #  584|     v0_10(void)          = ReturnVoid                      : 
 #  584|     v0_11(void)          = UnmodeledUse                    : mu*
@@ -2558,21 +2558,21 @@ ir.cpp:
 #  615|     mu0_1(unknown)        = UnmodeledDefinition           : 
 #  616|     r0_2(glval<String>)   = VariableAddress[s1]           : 
 #  616|     r0_3(glval<unknown>)  = FunctionAddress[String]       : 
-#  616|     v0_4(void)            = Invoke                        : r0_3, this:r0_2
+#  616|     v0_4(void)            = Call                          : r0_3, this:r0_2
 #  617|     r0_5(glval<String>)   = VariableAddress[s2]           : 
 #  617|     r0_6(glval<unknown>)  = FunctionAddress[String]       : 
 #  617|     r0_7(glval<char[6]>)  = StringConstant["hello"]       : 
 #  617|     r0_8(char *)          = Convert                       : r0_7
-#  617|     v0_9(void)            = Invoke                        : r0_6, this:r0_5, r0_8
+#  617|     v0_9(void)            = Call                          : r0_6, this:r0_5, r0_8
 #  618|     r0_10(glval<String>)  = VariableAddress[s3]           : 
 #  618|     r0_11(glval<unknown>) = FunctionAddress[ReturnObject] : 
-#  618|     r0_12(String)         = Invoke                        : r0_11
+#  618|     r0_12(String)         = Call                          : r0_11
 #  618|     m0_13(String)         = Store                         : r0_10, r0_12
 #  619|     r0_14(glval<String>)  = VariableAddress[s4]           : 
 #  619|     r0_15(glval<unknown>) = FunctionAddress[String]       : 
 #  619|     r0_16(glval<char[5]>) = StringConstant["test"]        : 
 #  619|     r0_17(char *)         = Convert                       : r0_16
-#  619|     v0_18(void)           = Invoke                        : r0_15, this:r0_14, r0_17
+#  619|     v0_18(void)           = Call                          : r0_15, this:r0_14, r0_17
 #  620|     v0_19(void)           = NoOp                          : 
 #  615|     v0_20(void)           = ReturnVoid                    : 
 #  615|     v0_21(void)           = UnmodeledUse                  : mu*
@@ -2592,16 +2592,16 @@ ir.cpp:
 #  623|     r0_9(String &)         = Load                   : r0_8, m0_3
 #  623|     r0_10(glval<String>)   = Convert                : r0_9
 #  623|     r0_11(glval<unknown>)  = FunctionAddress[c_str] : 
-#  623|     r0_12(char *)          = Invoke                 : r0_11, this:r0_10
+#  623|     r0_12(char *)          = Call                   : r0_11, this:r0_10
 #  624|     r0_13(glval<String *>) = VariableAddress[p]     : 
 #  624|     r0_14(String *)        = Load                   : r0_13, m0_5
 #  624|     r0_15(String *)        = Convert                : r0_14
 #  624|     r0_16(glval<unknown>)  = FunctionAddress[c_str] : 
-#  624|     r0_17(char *)          = Invoke                 : r0_16, this:r0_15
+#  624|     r0_17(char *)          = Call                   : r0_16, this:r0_15
 #  625|     r0_18(glval<String>)   = VariableAddress[s]     : 
 #  625|     r0_19(glval<String>)   = Convert                : r0_18
 #  625|     r0_20(glval<unknown>)  = FunctionAddress[c_str] : 
-#  625|     r0_21(char *)          = Invoke                 : r0_20, this:r0_19
+#  625|     r0_21(char *)          = Call                   : r0_20, this:r0_19
 #  626|     v0_22(void)            = NoOp                   : 
 #  622|     v0_23(void)            = ReturnVoid             : 
 #  622|     v0_24(void)            = UnmodeledUse           : mu*
@@ -2701,15 +2701,15 @@ ir.cpp:
 #  653|     r0_3(C *)             = CopyValue                               : r0_2
 #  653|     r0_4(glval<unknown>)  = FunctionAddress[InstanceMemberFunction] : 
 #  653|     r0_5(int)             = Constant[0]                             : 
-#  653|     r0_6(int)             = Invoke                                  : r0_4, this:r0_3, r0_5
+#  653|     r0_6(int)             = Call                                    : r0_4, this:r0_3, r0_5
 #  654|     r0_7(C *)             = CopyValue                               : r0_2
 #  654|     r0_8(glval<unknown>)  = FunctionAddress[InstanceMemberFunction] : 
 #  654|     r0_9(int)             = Constant[1]                             : 
-#  654|     r0_10(int)            = Invoke                                  : r0_8, this:r0_7, r0_9
+#  654|     r0_10(int)            = Call                                    : r0_8, this:r0_7, r0_9
 #-----|     r0_11(C *)            = CopyValue                               : r0_2
 #  655|     r0_12(glval<unknown>) = FunctionAddress[InstanceMemberFunction] : 
 #  655|     r0_13(int)            = Constant[2]                             : 
-#  655|     r0_14(int)            = Invoke                                  : r0_12, this:r0_11, r0_13
+#  655|     r0_14(int)            = Call                                    : r0_12, this:r0_11, r0_13
 #  656|     v0_15(void)           = NoOp                                    : 
 #  652|     v0_16(void)           = ReturnVoid                              : 
 #  652|     v0_17(void)           = UnmodeledUse                            : mu*
@@ -2725,7 +2725,7 @@ ir.cpp:
 #  659|     mu0_5(int)            = Store                   : r0_3, r0_4
 #  663|     r0_6(glval<String>)   = FieldAddress[m_b]       : r0_2
 #  663|     r0_7(glval<unknown>)  = FunctionAddress[String] : 
-#  663|     v0_8(void)            = Invoke                  : r0_7, this:r0_6
+#  663|     v0_8(void)            = Call                    : r0_7, this:r0_6
 #  660|     r0_9(glval<char>)     = FieldAddress[m_c]       : r0_2
 #  660|     r0_10(char)           = Constant[3]             : 
 #  660|     mu0_11(char)          = Store                   : r0_9, r0_10
@@ -2736,7 +2736,7 @@ ir.cpp:
 #  662|     r0_16(glval<unknown>) = FunctionAddress[String] : 
 #  662|     r0_17(glval<char[5]>) = StringConstant["test"]  : 
 #  662|     r0_18(char *)         = Convert                 : r0_17
-#  662|     v0_19(void)           = Invoke                  : r0_16, this:r0_15, r0_18
+#  662|     v0_19(void)           = Call                    : r0_16, this:r0_15, r0_18
 #  664|     v0_20(void)           = NoOp                    : 
 #  658|     v0_21(void)           = ReturnVoid              : 
 #  658|     v0_22(void)           = UnmodeledUse            : mu*
@@ -2785,7 +2785,7 @@ ir.cpp:
 #  687|     m0_10(int &)           = Store                            : r0_7, r0_9
 #  688|     r0_11(glval<String &>) = VariableAddress[r3]              : 
 #  688|     r0_12(glval<unknown>)  = FunctionAddress[ReturnReference] : 
-#  688|     r0_13(String &)        = Invoke                           : r0_12
+#  688|     r0_13(String &)        = Call                             : r0_12
 #  688|     r0_14(glval<String>)   = Convert                          : r0_13
 #  688|     m0_15(String &)        = Store                            : r0_11, r0_14
 #  689|     v0_16(void)            = NoOp                             : 
@@ -2829,7 +2829,7 @@ ir.cpp:
 #  700|     r0_9(glval<..(&)(..)>) = VariableAddress[rfn]           : 
 #  700|     r0_10(..(&)(..))       = Load                           : r0_9, m0_4
 #  700|     r0_11(int)             = Constant[5]                    : 
-#  700|     r0_12(int)             = Invoke                         : r0_10, r0_11
+#  700|     r0_12(int)             = Call                           : r0_10, r0_11
 #  701|     v0_13(void)            = NoOp                           : 
 #  697|     v0_14(void)            = ReturnVoid                     : 
 #  697|     v0_15(void)            = UnmodeledUse                   : mu*
@@ -2891,7 +2891,7 @@ ir.cpp:
 #  709|     r0_9(int)            = Load                     : r0_8, m0_3
 #  709|     r0_10(glval<int>)    = VariableAddress[y]       : 
 #  709|     r0_11(int)           = Load                     : r0_10, m0_5
-#  709|     r0_12(int)           = Invoke                   : r0_7, r0_9, r0_11
+#  709|     r0_12(int)           = Call                     : r0_7, r0_9, r0_11
 #  709|     m0_13(int)           = Store                    : r0_6, r0_12
 #  708|     r0_14(glval<int>)    = VariableAddress[#return] : 
 #  708|     v0_15(void)          = ReturnValue              : r0_14, m0_13
@@ -2922,7 +2922,7 @@ ir.cpp:
 #  721|     r0_3(glval<unknown>) = FunctionAddress[Func]    : 
 #  721|     r0_4(void *)         = Constant[0]              : 
 #  721|     r0_5(char)           = Constant[111]            : 
-#  721|     r0_6(long)           = Invoke                   : r0_3, r0_4, r0_5
+#  721|     r0_6(long)           = Call                     : r0_3, r0_4, r0_5
 #  721|     r0_7(double)         = Convert                  : r0_6
 #  721|     m0_8(double)         = Store                    : r0_2, r0_7
 #  720|     r0_9(glval<double>)  = VariableAddress[#return] : 
@@ -2992,7 +2992,7 @@ ir.cpp:
 #  731|     r7_1(glval<unknown>)  = FunctionAddress[String]         : 
 #  731|     r7_2(glval<char[14]>) = StringConstant["String object"] : 
 #  731|     r7_3(char *)          = Convert                         : r7_2
-#  731|     v7_4(void)            = Invoke                          : r7_1, this:r7_0, r7_3
+#  731|     v7_4(void)            = Call                            : r7_1, this:r7_0, r7_3
 #  731|     v7_5(void)            = ThrowValue                      : r7_0, mu0_1
 #-----|   Exception -> Block 9
 
@@ -3014,7 +3014,7 @@ ir.cpp:
 #  736|     r10_3(glval<unknown>) = FunctionAddress[String]      : 
 #  736|     r10_4(glval<char *>)  = VariableAddress[s]           : 
 #  736|     r10_5(char *)         = Load                         : r10_4, m10_1
-#  736|     v10_6(void)           = Invoke                       : r10_3, this:r10_2, r10_5
+#  736|     v10_6(void)           = Call                         : r10_3, this:r10_2, r10_5
 #  736|     v10_7(void)           = ThrowValue                   : r10_2, mu0_1
 #-----|   Exception -> Block 2
 
@@ -3048,7 +3048,7 @@ ir.cpp:
 #-----|     m0_4(Base &)         = InitializeParameter[p#0] : r0_3
 #  745|     r0_5(glval<String>)  = FieldAddress[base_s]     : r0_2
 #  745|     r0_6(glval<unknown>) = FunctionAddress[String]  : 
-#  745|     v0_7(void)           = Invoke                   : r0_6, this:r0_5
+#  745|     v0_7(void)           = Call                     : r0_6, this:r0_5
 #  745|     v0_8(void)           = NoOp                     : 
 #  745|     v0_9(void)           = ReturnVoid               : 
 #  745|     v0_10(void)          = UnmodeledUse             : mu*
@@ -3067,7 +3067,7 @@ ir.cpp:
 #-----|     r0_8(glval<Base &>)  = VariableAddress[p#0]       : 
 #-----|     r0_9(Base &)         = Load                       : r0_8, m0_4
 #-----|     r0_10(glval<String>) = FieldAddress[base_s]       : r0_9
-#  745|     r0_11(String &)      = Invoke                     : r0_7, this:r0_6, r0_10
+#  745|     r0_11(String &)      = Call                       : r0_7, this:r0_6, r0_10
 #-----|     r0_12(glval<Base &>) = VariableAddress[#return]   : 
 #-----|     r0_13(Base *)        = CopyValue                  : r0_2
 #-----|     m0_14(Base &)        = Store                      : r0_12, r0_13
@@ -3083,7 +3083,7 @@ ir.cpp:
 #  748|     r0_2(glval<Base>)    = InitializeThis          : 
 #  748|     r0_3(glval<String>)  = FieldAddress[base_s]    : r0_2
 #  748|     r0_4(glval<unknown>) = FunctionAddress[String] : 
-#  748|     v0_5(void)           = Invoke                  : r0_4, this:r0_3
+#  748|     v0_5(void)           = Call                    : r0_4, this:r0_3
 #  749|     v0_6(void)           = NoOp                    : 
 #  748|     v0_7(void)           = ReturnVoid              : 
 #  748|     v0_8(void)           = UnmodeledUse            : mu*
@@ -3097,7 +3097,7 @@ ir.cpp:
 #  751|     v0_3(void)           = NoOp                     : 
 #  751|     r0_4(glval<String>)  = FieldAddress[base_s]     : r0_2
 #  751|     r0_5(glval<unknown>) = FunctionAddress[~String] : 
-#  751|     v0_6(void)           = Invoke                   : r0_5, this:r0_4
+#  751|     v0_6(void)           = Call                     : r0_5, this:r0_4
 #  750|     v0_7(void)           = ReturnVoid               : 
 #  750|     v0_8(void)           = UnmodeledUse             : mu*
 #  750|     v0_9(void)           = ExitFunction             : 
@@ -3115,14 +3115,14 @@ ir.cpp:
 #-----|     r0_8(glval<Middle &>)  = VariableAddress[p#0]         : 
 #-----|     r0_9(Middle &)         = Load                         : r0_8, m0_4
 #-----|     r0_10(Base *)          = ConvertToBase[Middle : Base] : r0_9
-#  754|     r0_11(Base &)          = Invoke                       : r0_7, this:r0_6, r0_10
+#  754|     r0_11(Base &)          = Call                         : r0_7, this:r0_6, r0_10
 #-----|     r0_12(Middle *)        = CopyValue                    : r0_2
 #-----|     r0_13(glval<String>)   = FieldAddress[middle_s]       : r0_12
 #  754|     r0_14(glval<unknown>)  = FunctionAddress[operator=]   : 
 #-----|     r0_15(glval<Middle &>) = VariableAddress[p#0]         : 
 #-----|     r0_16(Middle &)        = Load                         : r0_15, m0_4
 #-----|     r0_17(glval<String>)   = FieldAddress[middle_s]       : r0_16
-#  754|     r0_18(String &)        = Invoke                       : r0_14, this:r0_13, r0_17
+#  754|     r0_18(String &)        = Call                         : r0_14, this:r0_13, r0_17
 #-----|     r0_19(glval<Middle &>) = VariableAddress[#return]     : 
 #-----|     r0_20(Middle *)        = CopyValue                    : r0_2
 #-----|     m0_21(Middle &)        = Store                        : r0_19, r0_20
@@ -3138,10 +3138,10 @@ ir.cpp:
 #  757|     r0_2(glval<Middle>)  = InitializeThis               : 
 #  757|     r0_3(glval<Base>)    = ConvertToBase[Middle : Base] : r0_2
 #  757|     r0_4(glval<unknown>) = FunctionAddress[Base]        : 
-#  757|     v0_5(void)           = Invoke                       : r0_4, this:r0_3
+#  757|     v0_5(void)           = Call                         : r0_4, this:r0_3
 #  757|     r0_6(glval<String>)  = FieldAddress[middle_s]       : r0_2
 #  757|     r0_7(glval<unknown>) = FunctionAddress[String]      : 
-#  757|     v0_8(void)           = Invoke                       : r0_7, this:r0_6
+#  757|     v0_8(void)           = Call                         : r0_7, this:r0_6
 #  758|     v0_9(void)           = NoOp                         : 
 #  757|     v0_10(void)          = ReturnVoid                   : 
 #  757|     v0_11(void)          = UnmodeledUse                 : mu*
@@ -3155,10 +3155,10 @@ ir.cpp:
 #  760|     v0_3(void)           = NoOp                         : 
 #  760|     r0_4(glval<String>)  = FieldAddress[middle_s]       : r0_2
 #  760|     r0_5(glval<unknown>) = FunctionAddress[~String]     : 
-#  760|     v0_6(void)           = Invoke                       : r0_5, this:r0_4
+#  760|     v0_6(void)           = Call                         : r0_5, this:r0_4
 #  760|     r0_7(glval<Base>)    = ConvertToBase[Middle : Base] : r0_2
 #  760|     r0_8(glval<unknown>) = FunctionAddress[~Base]       : 
-#  760|     v0_9(void)           = Invoke                       : r0_8, this:r0_7
+#  760|     v0_9(void)           = Call                         : r0_8, this:r0_7
 #  759|     v0_10(void)          = ReturnVoid                   : 
 #  759|     v0_11(void)          = UnmodeledUse                 : mu*
 #  759|     v0_12(void)          = ExitFunction                 : 
@@ -3176,14 +3176,14 @@ ir.cpp:
 #-----|     r0_8(glval<Derived &>)  = VariableAddress[p#0]            : 
 #-----|     r0_9(Derived &)         = Load                            : r0_8, m0_4
 #-----|     r0_10(Middle *)         = ConvertToBase[Derived : Middle] : r0_9
-#  763|     r0_11(Middle &)         = Invoke                          : r0_7, this:r0_6, r0_10
+#  763|     r0_11(Middle &)         = Call                            : r0_7, this:r0_6, r0_10
 #-----|     r0_12(Derived *)        = CopyValue                       : r0_2
 #-----|     r0_13(glval<String>)    = FieldAddress[derived_s]         : r0_12
 #  763|     r0_14(glval<unknown>)   = FunctionAddress[operator=]      : 
 #-----|     r0_15(glval<Derived &>) = VariableAddress[p#0]            : 
 #-----|     r0_16(Derived &)        = Load                            : r0_15, m0_4
 #-----|     r0_17(glval<String>)    = FieldAddress[derived_s]         : r0_16
-#  763|     r0_18(String &)         = Invoke                          : r0_14, this:r0_13, r0_17
+#  763|     r0_18(String &)         = Call                            : r0_14, this:r0_13, r0_17
 #-----|     r0_19(glval<Derived &>) = VariableAddress[#return]        : 
 #-----|     r0_20(Derived *)        = CopyValue                       : r0_2
 #-----|     m0_21(Derived &)        = Store                           : r0_19, r0_20
@@ -3199,10 +3199,10 @@ ir.cpp:
 #  766|     r0_2(glval<Derived>) = InitializeThis                  : 
 #  766|     r0_3(glval<Middle>)  = ConvertToBase[Derived : Middle] : r0_2
 #  766|     r0_4(glval<unknown>) = FunctionAddress[Middle]         : 
-#  766|     v0_5(void)           = Invoke                          : r0_4, this:r0_3
+#  766|     v0_5(void)           = Call                            : r0_4, this:r0_3
 #  766|     r0_6(glval<String>)  = FieldAddress[derived_s]         : r0_2
 #  766|     r0_7(glval<unknown>) = FunctionAddress[String]         : 
-#  766|     v0_8(void)           = Invoke                          : r0_7, this:r0_6
+#  766|     v0_8(void)           = Call                            : r0_7, this:r0_6
 #  767|     v0_9(void)           = NoOp                            : 
 #  766|     v0_10(void)          = ReturnVoid                      : 
 #  766|     v0_11(void)          = UnmodeledUse                    : mu*
@@ -3216,10 +3216,10 @@ ir.cpp:
 #  769|     v0_3(void)           = NoOp                            : 
 #  769|     r0_4(glval<String>)  = FieldAddress[derived_s]         : r0_2
 #  769|     r0_5(glval<unknown>) = FunctionAddress[~String]        : 
-#  769|     v0_6(void)           = Invoke                          : r0_5, this:r0_4
+#  769|     v0_6(void)           = Call                            : r0_5, this:r0_4
 #  769|     r0_7(glval<Middle>)  = ConvertToBase[Derived : Middle] : r0_2
 #  769|     r0_8(glval<unknown>) = FunctionAddress[~Middle]        : 
-#  769|     v0_9(void)           = Invoke                          : r0_8, this:r0_7
+#  769|     v0_9(void)           = Call                            : r0_8, this:r0_7
 #  768|     v0_10(void)          = ReturnVoid                      : 
 #  768|     v0_11(void)          = UnmodeledUse                    : mu*
 #  768|     v0_12(void)          = ExitFunction                    : 
@@ -3231,10 +3231,10 @@ ir.cpp:
 #  775|     r0_2(glval<MiddleVB1>) = InitializeThis                  : 
 #  775|     r0_3(glval<Base>)      = ConvertToBase[MiddleVB1 : Base] : r0_2
 #  775|     r0_4(glval<unknown>)   = FunctionAddress[Base]           : 
-#  775|     v0_5(void)             = Invoke                          : r0_4, this:r0_3
+#  775|     v0_5(void)             = Call                            : r0_4, this:r0_3
 #  775|     r0_6(glval<String>)    = FieldAddress[middlevb1_s]       : r0_2
 #  775|     r0_7(glval<unknown>)   = FunctionAddress[String]         : 
-#  775|     v0_8(void)             = Invoke                          : r0_7, this:r0_6
+#  775|     v0_8(void)             = Call                            : r0_7, this:r0_6
 #  776|     v0_9(void)             = NoOp                            : 
 #  775|     v0_10(void)            = ReturnVoid                      : 
 #  775|     v0_11(void)            = UnmodeledUse                    : mu*
@@ -3248,10 +3248,10 @@ ir.cpp:
 #  778|     v0_3(void)             = NoOp                            : 
 #  778|     r0_4(glval<String>)    = FieldAddress[middlevb1_s]       : r0_2
 #  778|     r0_5(glval<unknown>)   = FunctionAddress[~String]        : 
-#  778|     v0_6(void)             = Invoke                          : r0_5, this:r0_4
+#  778|     v0_6(void)             = Call                            : r0_5, this:r0_4
 #  778|     r0_7(glval<Base>)      = ConvertToBase[MiddleVB1 : Base] : r0_2
 #  778|     r0_8(glval<unknown>)   = FunctionAddress[~Base]          : 
-#  778|     v0_9(void)             = Invoke                          : r0_8, this:r0_7
+#  778|     v0_9(void)             = Call                            : r0_8, this:r0_7
 #  777|     v0_10(void)            = ReturnVoid                      : 
 #  777|     v0_11(void)            = UnmodeledUse                    : mu*
 #  777|     v0_12(void)            = ExitFunction                    : 
@@ -3263,10 +3263,10 @@ ir.cpp:
 #  784|     r0_2(glval<MiddleVB2>) = InitializeThis                  : 
 #  784|     r0_3(glval<Base>)      = ConvertToBase[MiddleVB2 : Base] : r0_2
 #  784|     r0_4(glval<unknown>)   = FunctionAddress[Base]           : 
-#  784|     v0_5(void)             = Invoke                          : r0_4, this:r0_3
+#  784|     v0_5(void)             = Call                            : r0_4, this:r0_3
 #  784|     r0_6(glval<String>)    = FieldAddress[middlevb2_s]       : r0_2
 #  784|     r0_7(glval<unknown>)   = FunctionAddress[String]         : 
-#  784|     v0_8(void)             = Invoke                          : r0_7, this:r0_6
+#  784|     v0_8(void)             = Call                            : r0_7, this:r0_6
 #  785|     v0_9(void)             = NoOp                            : 
 #  784|     v0_10(void)            = ReturnVoid                      : 
 #  784|     v0_11(void)            = UnmodeledUse                    : mu*
@@ -3280,10 +3280,10 @@ ir.cpp:
 #  787|     v0_3(void)             = NoOp                            : 
 #  787|     r0_4(glval<String>)    = FieldAddress[middlevb2_s]       : r0_2
 #  787|     r0_5(glval<unknown>)   = FunctionAddress[~String]        : 
-#  787|     v0_6(void)             = Invoke                          : r0_5, this:r0_4
+#  787|     v0_6(void)             = Call                            : r0_5, this:r0_4
 #  787|     r0_7(glval<Base>)      = ConvertToBase[MiddleVB2 : Base] : r0_2
 #  787|     r0_8(glval<unknown>)   = FunctionAddress[~Base]          : 
-#  787|     v0_9(void)             = Invoke                          : r0_8, this:r0_7
+#  787|     v0_9(void)             = Call                            : r0_8, this:r0_7
 #  786|     v0_10(void)            = ReturnVoid                      : 
 #  786|     v0_11(void)            = UnmodeledUse                    : mu*
 #  786|     v0_12(void)            = ExitFunction                    : 
@@ -3295,16 +3295,16 @@ ir.cpp:
 #  793|     r0_2(glval<DerivedVB>) = InitializeThis                       : 
 #  793|     r0_3(glval<Base>)      = ConvertToBase[DerivedVB : Base]      : r0_2
 #  793|     r0_4(glval<unknown>)   = FunctionAddress[Base]                : 
-#  793|     v0_5(void)             = Invoke                               : r0_4, this:r0_3
+#  793|     v0_5(void)             = Call                                 : r0_4, this:r0_3
 #  793|     r0_6(glval<MiddleVB1>) = ConvertToBase[DerivedVB : MiddleVB1] : r0_2
 #  793|     r0_7(glval<unknown>)   = FunctionAddress[MiddleVB1]           : 
-#  793|     v0_8(void)             = Invoke                               : r0_7, this:r0_6
+#  793|     v0_8(void)             = Call                                 : r0_7, this:r0_6
 #  793|     r0_9(glval<MiddleVB2>) = ConvertToBase[DerivedVB : MiddleVB2] : r0_2
 #  793|     r0_10(glval<unknown>)  = FunctionAddress[MiddleVB2]           : 
-#  793|     v0_11(void)            = Invoke                               : r0_10, this:r0_9
+#  793|     v0_11(void)            = Call                                 : r0_10, this:r0_9
 #  793|     r0_12(glval<String>)   = FieldAddress[derivedvb_s]            : r0_2
 #  793|     r0_13(glval<unknown>)  = FunctionAddress[String]              : 
-#  793|     v0_14(void)            = Invoke                               : r0_13, this:r0_12
+#  793|     v0_14(void)            = Call                                 : r0_13, this:r0_12
 #  794|     v0_15(void)            = NoOp                                 : 
 #  793|     v0_16(void)            = ReturnVoid                           : 
 #  793|     v0_17(void)            = UnmodeledUse                         : mu*
@@ -3318,16 +3318,16 @@ ir.cpp:
 #  796|     v0_3(void)              = NoOp                                 : 
 #  796|     r0_4(glval<String>)     = FieldAddress[derivedvb_s]            : r0_2
 #  796|     r0_5(glval<unknown>)    = FunctionAddress[~String]             : 
-#  796|     v0_6(void)              = Invoke                               : r0_5, this:r0_4
+#  796|     v0_6(void)              = Call                                 : r0_5, this:r0_4
 #  796|     r0_7(glval<MiddleVB2>)  = ConvertToBase[DerivedVB : MiddleVB2] : r0_2
 #  796|     r0_8(glval<unknown>)    = FunctionAddress[~MiddleVB2]          : 
-#  796|     v0_9(void)              = Invoke                               : r0_8, this:r0_7
+#  796|     v0_9(void)              = Call                                 : r0_8, this:r0_7
 #  796|     r0_10(glval<MiddleVB1>) = ConvertToBase[DerivedVB : MiddleVB1] : r0_2
 #  796|     r0_11(glval<unknown>)   = FunctionAddress[~MiddleVB1]          : 
-#  796|     v0_12(void)             = Invoke                               : r0_11, this:r0_10
+#  796|     v0_12(void)             = Call                                 : r0_11, this:r0_10
 #  796|     r0_13(glval<Base>)      = ConvertToBase[DerivedVB : Base]      : r0_2
 #  796|     r0_14(glval<unknown>)   = FunctionAddress[~Base]               : 
-#  796|     v0_15(void)             = Invoke                               : r0_14, this:r0_13
+#  796|     v0_15(void)             = Call                                 : r0_14, this:r0_13
 #  795|     v0_16(void)             = ReturnVoid                           : 
 #  795|     v0_17(void)             = UnmodeledUse                         : mu*
 #  795|     v0_18(void)             = ExitFunction                         : 
@@ -3338,13 +3338,13 @@ ir.cpp:
 #  799|     mu0_1(unknown)             = UnmodeledDefinition                    : 
 #  800|     r0_2(glval<Base>)          = VariableAddress[b]                     : 
 #  800|     r0_3(glval<unknown>)       = FunctionAddress[Base]                  : 
-#  800|     v0_4(void)                 = Invoke                                 : r0_3, this:r0_2
+#  800|     v0_4(void)                 = Call                                   : r0_3, this:r0_2
 #  801|     r0_5(glval<Middle>)        = VariableAddress[m]                     : 
 #  801|     r0_6(glval<unknown>)       = FunctionAddress[Middle]                : 
-#  801|     v0_7(void)                 = Invoke                                 : r0_6, this:r0_5
+#  801|     v0_7(void)                 = Call                                   : r0_6, this:r0_5
 #  802|     r0_8(glval<Derived>)       = VariableAddress[d]                     : 
 #  802|     r0_9(glval<unknown>)       = FunctionAddress[Derived]               : 
-#  802|     v0_10(void)                = Invoke                                 : r0_9, this:r0_8
+#  802|     v0_10(void)                = Call                                   : r0_9, this:r0_8
 #  804|     r0_11(glval<Base *>)       = VariableAddress[pb]                    : 
 #  804|     r0_12(glval<Base>)         = VariableAddress[b]                     : 
 #  804|     m0_13(Base *)              = Store                                  : r0_11, r0_12
@@ -3358,23 +3358,23 @@ ir.cpp:
 #  808|     r0_21(glval<unknown>)      = FunctionAddress[operator=]             : 
 #  808|     r0_22(glval<Middle>)       = VariableAddress[m]                     : 
 #  808|     r0_23(glval<Base>)         = ConvertToBase[Middle : Base]           : r0_22
-#  808|     r0_24(Base &)              = Invoke                                 : r0_21, this:r0_20, r0_23
+#  808|     r0_24(Base &)              = Call                                   : r0_21, this:r0_20, r0_23
 #  809|     r0_25(glval<Base>)         = VariableAddress[b]                     : 
 #  809|     r0_26(glval<unknown>)      = FunctionAddress[operator=]             : 
 #  809|     r0_27(glval<unknown>)      = FunctionAddress[Base]                  : 
 #  809|     r0_28(glval<Middle>)       = VariableAddress[m]                     : 
 #  809|     r0_29(glval<Base>)         = ConvertToBase[Middle : Base]           : r0_28
-#  809|     v0_30(void)                = Invoke                                 : r0_27, r0_29
+#  809|     v0_30(void)                = Call                                   : r0_27, r0_29
 #  809|     r0_31(Base)                = Convert                                : v0_30
-#  809|     r0_32(Base &)              = Invoke                                 : r0_26, this:r0_25, r0_31
+#  809|     r0_32(Base &)              = Call                                   : r0_26, this:r0_25, r0_31
 #  810|     r0_33(glval<Base>)         = VariableAddress[b]                     : 
 #  810|     r0_34(glval<unknown>)      = FunctionAddress[operator=]             : 
 #  810|     r0_35(glval<unknown>)      = FunctionAddress[Base]                  : 
 #  810|     r0_36(glval<Middle>)       = VariableAddress[m]                     : 
 #  810|     r0_37(glval<Base>)         = ConvertToBase[Middle : Base]           : r0_36
-#  810|     v0_38(void)                = Invoke                                 : r0_35, r0_37
+#  810|     v0_38(void)                = Call                                   : r0_35, r0_37
 #  810|     r0_39(Base)                = Convert                                : v0_38
-#  810|     r0_40(Base &)              = Invoke                                 : r0_34, this:r0_33, r0_39
+#  810|     r0_40(Base &)              = Call                                   : r0_34, this:r0_33, r0_39
 #  811|     r0_41(glval<Middle *>)     = VariableAddress[pm]                    : 
 #  811|     r0_42(Middle *)            = Load                                   : r0_41, m0_16
 #  811|     r0_43(Base *)              = ConvertToBase[Middle : Base]           : r0_42
@@ -3400,13 +3400,13 @@ ir.cpp:
 #  816|     r0_63(glval<Base>)         = VariableAddress[b]                     : 
 #  816|     r0_64(glval<Middle>)       = ConvertToDerived[Middle : Base]        : r0_63
 #  816|     r0_65(glval<Middle>)       = Convert                                : r0_64
-#  816|     r0_66(Middle &)            = Invoke                                 : r0_62, this:r0_61, r0_65
+#  816|     r0_66(Middle &)            = Call                                   : r0_62, this:r0_61, r0_65
 #  817|     r0_67(glval<Middle>)       = VariableAddress[m]                     : 
 #  817|     r0_68(glval<unknown>)      = FunctionAddress[operator=]             : 
 #  817|     r0_69(glval<Base>)         = VariableAddress[b]                     : 
 #  817|     r0_70(glval<Middle>)       = ConvertToDerived[Middle : Base]        : r0_69
 #  817|     r0_71(glval<Middle>)       = Convert                                : r0_70
-#  817|     r0_72(Middle &)            = Invoke                                 : r0_68, this:r0_67, r0_71
+#  817|     r0_72(Middle &)            = Call                                   : r0_68, this:r0_67, r0_71
 #  818|     r0_73(glval<Base *>)       = VariableAddress[pb]                    : 
 #  818|     r0_74(Base *)              = Load                                   : r0_73, m0_60
 #  818|     r0_75(Middle *)            = ConvertToDerived[Middle : Base]        : r0_74
@@ -3427,25 +3427,25 @@ ir.cpp:
 #  822|     r0_90(glval<Derived>)      = VariableAddress[d]                     : 
 #  822|     r0_91(glval<Middle>)       = ConvertToBase[Derived : Middle]        : r0_90
 #  822|     r0_92(glval<Base>)         = ConvertToBase[Middle : Base]           : r0_91
-#  822|     r0_93(Base &)              = Invoke                                 : r0_89, this:r0_88, r0_92
+#  822|     r0_93(Base &)              = Call                                   : r0_89, this:r0_88, r0_92
 #  823|     r0_94(glval<Base>)         = VariableAddress[b]                     : 
 #  823|     r0_95(glval<unknown>)      = FunctionAddress[operator=]             : 
 #  823|     r0_96(glval<unknown>)      = FunctionAddress[Base]                  : 
 #  823|     r0_97(glval<Derived>)      = VariableAddress[d]                     : 
 #  823|     r0_98(glval<Middle>)       = ConvertToBase[Derived : Middle]        : r0_97
 #  823|     r0_99(glval<Base>)         = ConvertToBase[Middle : Base]           : r0_98
-#  823|     v0_100(void)               = Invoke                                 : r0_96, r0_99
+#  823|     v0_100(void)               = Call                                   : r0_96, r0_99
 #  823|     r0_101(Base)               = Convert                                : v0_100
-#  823|     r0_102(Base &)             = Invoke                                 : r0_95, this:r0_94, r0_101
+#  823|     r0_102(Base &)             = Call                                   : r0_95, this:r0_94, r0_101
 #  824|     r0_103(glval<Base>)        = VariableAddress[b]                     : 
 #  824|     r0_104(glval<unknown>)     = FunctionAddress[operator=]             : 
 #  824|     r0_105(glval<unknown>)     = FunctionAddress[Base]                  : 
 #  824|     r0_106(glval<Derived>)     = VariableAddress[d]                     : 
 #  824|     r0_107(glval<Middle>)      = ConvertToBase[Derived : Middle]        : r0_106
 #  824|     r0_108(glval<Base>)        = ConvertToBase[Middle : Base]           : r0_107
-#  824|     v0_109(void)               = Invoke                                 : r0_105, r0_108
+#  824|     v0_109(void)               = Call                                   : r0_105, r0_108
 #  824|     r0_110(Base)               = Convert                                : v0_109
-#  824|     r0_111(Base &)             = Invoke                                 : r0_104, this:r0_103, r0_110
+#  824|     r0_111(Base &)             = Call                                   : r0_104, this:r0_103, r0_110
 #  825|     r0_112(glval<Derived *>)   = VariableAddress[pd]                    : 
 #  825|     r0_113(Derived *)          = Load                                   : r0_112, m0_19
 #  825|     r0_114(Middle *)           = ConvertToBase[Derived : Middle]        : r0_113
@@ -3475,14 +3475,14 @@ ir.cpp:
 #  830|     r0_138(glval<Middle>)      = ConvertToDerived[Middle : Base]        : r0_137
 #  830|     r0_139(glval<Derived>)     = ConvertToDerived[Derived : Middle]     : r0_138
 #  830|     r0_140(glval<Derived>)     = Convert                                : r0_139
-#  830|     r0_141(Derived &)          = Invoke                                 : r0_136, this:r0_135, r0_140
+#  830|     r0_141(Derived &)          = Call                                   : r0_136, this:r0_135, r0_140
 #  831|     r0_142(glval<Derived>)     = VariableAddress[d]                     : 
 #  831|     r0_143(glval<unknown>)     = FunctionAddress[operator=]             : 
 #  831|     r0_144(glval<Base>)        = VariableAddress[b]                     : 
 #  831|     r0_145(glval<Middle>)      = ConvertToDerived[Middle : Base]        : r0_144
 #  831|     r0_146(glval<Derived>)     = ConvertToDerived[Derived : Middle]     : r0_145
 #  831|     r0_147(glval<Derived>)     = Convert                                : r0_146
-#  831|     r0_148(Derived &)          = Invoke                                 : r0_143, this:r0_142, r0_147
+#  831|     r0_148(Derived &)          = Call                                   : r0_143, this:r0_142, r0_147
 #  832|     r0_149(glval<Base *>)      = VariableAddress[pb]                    : 
 #  832|     r0_150(Base *)             = Load                                   : r0_149, m0_134
 #  832|     r0_151(Middle *)           = ConvertToDerived[Middle : Base]        : r0_150
@@ -3538,7 +3538,7 @@ ir.cpp:
 #  846|     r0_2(glval<PolymorphicDerived>) = InitializeThis                                      : 
 #  846|     r0_3(glval<PolymorphicBase>)    = ConvertToBase[PolymorphicDerived : PolymorphicBase] : r0_2
 #  846|     r0_4(glval<unknown>)            = FunctionAddress[PolymorphicBase]                    : 
-#  846|     v0_5(void)                      = Invoke                                              : r0_4, this:r0_3
+#  846|     v0_5(void)                      = Call                                                : r0_4, this:r0_3
 #  846|     v0_6(void)                      = NoOp                                                : 
 #  846|     v0_7(void)                      = ReturnVoid                                          : 
 #  846|     v0_8(void)                      = UnmodeledUse                                        : mu*
@@ -3552,7 +3552,7 @@ ir.cpp:
 #-----|     v0_3(void)                      = NoOp                                                : 
 #  846|     r0_4(glval<PolymorphicBase>)    = ConvertToBase[PolymorphicDerived : PolymorphicBase] : r0_2
 #  846|     r0_5(glval<unknown>)            = FunctionAddress[~PolymorphicBase]                   : 
-#  846|     v0_6(void)                      = Invoke                                              : r0_5, this:r0_4
+#  846|     v0_6(void)                      = Call                                                : r0_5, this:r0_4
 #  846|     v0_7(void)                      = ReturnVoid                                          : 
 #  846|     v0_8(void)                      = UnmodeledUse                                        : mu*
 #  846|     v0_9(void)                      = ExitFunction                                        : 
@@ -3563,10 +3563,10 @@ ir.cpp:
 #  849|     mu0_1(unknown)                     = UnmodeledDefinition                 : 
 #  850|     r0_2(glval<PolymorphicBase>)       = VariableAddress[b]                  : 
 #-----|     r0_3(glval<unknown>)               = FunctionAddress[PolymorphicBase]    : 
-#-----|     v0_4(void)                         = Invoke                              : r0_3, this:r0_2
+#-----|     v0_4(void)                         = Call                                : r0_3, this:r0_2
 #  851|     r0_5(glval<PolymorphicDerived>)    = VariableAddress[d]                  : 
 #  851|     r0_6(glval<unknown>)               = FunctionAddress[PolymorphicDerived] : 
-#  851|     v0_7(void)                         = Invoke                              : r0_6, this:r0_5
+#  851|     v0_7(void)                         = Call                                : r0_6, this:r0_5
 #  853|     r0_8(glval<PolymorphicBase *>)     = VariableAddress[pb]                 : 
 #  853|     r0_9(glval<PolymorphicBase>)       = VariableAddress[b]                  : 
 #  853|     m0_10(PolymorphicBase *)           = Store                               : r0_8, r0_9
@@ -3614,7 +3614,7 @@ ir.cpp:
 #  868|     r0_3(glval<unknown>) = FunctionAddress[String] : 
 #  868|     r0_4(glval<char[1]>) = StringConstant[""]      : 
 #  868|     r0_5(char *)         = Convert                 : r0_4
-#  868|     v0_6(void)           = Invoke                  : r0_3, this:r0_2, r0_5
+#  868|     v0_6(void)           = Call                    : r0_3, this:r0_2, r0_5
 #  869|     v0_7(void)           = NoOp                    : 
 #  867|     v0_8(void)           = ReturnVoid              : 
 #  867|     v0_9(void)           = UnmodeledUse            : mu*
@@ -3790,44 +3790,44 @@ ir.cpp:
 #  940|     mu0_1(unknown)        = UnmodeledDefinition           : 
 #  941|     r0_2(glval<unknown>)  = FunctionAddress[operator new] : 
 #  941|     r0_3(unsigned long)   = Constant[4]                   : 
-#  941|     r0_4(void *)          = Invoke                        : r0_2, r0_3
+#  941|     r0_4(void *)          = Call                          : r0_2, r0_3
 #  941|     r0_5(int *)           = Convert                       : r0_4
 #  942|     r0_6(glval<unknown>)  = FunctionAddress[operator new] : 
 #  942|     r0_7(unsigned long)   = Constant[4]                   : 
 #  942|     r0_8(float)           = Constant[1.0]                 : 
-#  942|     r0_9(void *)          = Invoke                        : r0_6, r0_7, r0_8
+#  942|     r0_9(void *)          = Call                          : r0_6, r0_7, r0_8
 #  942|     r0_10(int *)          = Convert                       : r0_9
 #  943|     r0_11(glval<unknown>) = FunctionAddress[operator new] : 
 #  943|     r0_12(unsigned long)  = Constant[4]                   : 
-#  943|     r0_13(void *)         = Invoke                        : r0_11, r0_12
+#  943|     r0_13(void *)         = Call                          : r0_11, r0_12
 #  943|     r0_14(int *)          = Convert                       : r0_13
 #  943|     r0_15(int)            = Constant[0]                   : 
 #  943|     mu0_16(int)           = Store                         : r0_14, r0_15
 #  944|     r0_17(glval<unknown>) = FunctionAddress[operator new] : 
 #  944|     r0_18(unsigned long)  = Constant[8]                   : 
-#  944|     r0_19(void *)         = Invoke                        : r0_17, r0_18
+#  944|     r0_19(void *)         = Call                          : r0_17, r0_18
 #  944|     r0_20(String *)       = Convert                       : r0_19
 #  944|     r0_21(glval<unknown>) = FunctionAddress[String]       : 
-#  944|     v0_22(void)           = Invoke                        : r0_21, this:r0_20
+#  944|     v0_22(void)           = Call                          : r0_21, this:r0_20
 #  945|     r0_23(glval<unknown>) = FunctionAddress[operator new] : 
 #  945|     r0_24(unsigned long)  = Constant[8]                   : 
 #  945|     r0_25(float)          = Constant[1.0]                 : 
-#  945|     r0_26(void *)         = Invoke                        : r0_23, r0_24, r0_25
+#  945|     r0_26(void *)         = Call                          : r0_23, r0_24, r0_25
 #  945|     r0_27(String *)       = Convert                       : r0_26
 #  945|     r0_28(glval<unknown>) = FunctionAddress[String]       : 
 #  945|     r0_29(glval<char[6]>) = StringConstant["hello"]       : 
 #  945|     r0_30(char *)         = Convert                       : r0_29
-#  945|     v0_31(void)           = Invoke                        : r0_28, this:r0_27, r0_30
+#  945|     v0_31(void)           = Call                          : r0_28, this:r0_27, r0_30
 #  946|     r0_32(glval<unknown>) = FunctionAddress[operator new] : 
 #  946|     r0_33(unsigned long)  = Constant[256]                 : 
 #  946|     r0_34(align_val_t)    = Constant[128]                 : 
-#  946|     r0_35(void *)         = Invoke                        : r0_32, r0_33, r0_34
+#  946|     r0_35(void *)         = Call                          : r0_32, r0_33, r0_34
 #  946|     r0_36(Overaligned *)  = Convert                       : r0_35
 #  947|     r0_37(glval<unknown>) = FunctionAddress[operator new] : 
 #  947|     r0_38(unsigned long)  = Constant[256]                 : 
 #  947|     r0_39(align_val_t)    = Constant[128]                 : 
 #  947|     r0_40(float)          = Constant[1.0]                 : 
-#  947|     r0_41(void *)         = Invoke                        : r0_37, r0_38, r0_39, r0_40
+#  947|     r0_41(void *)         = Call                          : r0_37, r0_38, r0_39, r0_40
 #  947|     r0_42(Overaligned *)  = Convert                       : r0_41
 #  947|     r0_43(Overaligned)    = Constant[0]                   : 
 #  947|     mu0_44(Overaligned)   = Store                         : r0_42, r0_43
@@ -3844,7 +3844,7 @@ ir.cpp:
 #  950|     m0_3(int)                            = InitializeParameter[n]          : r0_2
 #  951|     r0_4(glval<unknown>)                 = FunctionAddress[operator new[]] : 
 #  951|     r0_5(unsigned long)                  = Constant[40]                    : 
-#  951|     r0_6(void *)                         = Invoke                          : r0_4, r0_5
+#  951|     r0_6(void *)                         = Call                            : r0_4, r0_5
 #  951|     r0_7(int *)                          = Convert                         : r0_6
 #  952|     r0_8(glval<unknown>)                 = FunctionAddress[operator new[]] : 
 #  952|     r0_9(glval<int>)                     = VariableAddress[n]              : 
@@ -3852,7 +3852,7 @@ ir.cpp:
 #  952|     r0_11(unsigned long)                 = Convert                         : r0_10
 #  952|     r0_12(unsigned long)                 = Constant[4]                     : 
 #  952|     r0_13(unsigned long)                 = Mul                             : r0_11, r0_12
-#  952|     r0_14(void *)                        = Invoke                          : r0_8, r0_13
+#  952|     r0_14(void *)                        = Call                            : r0_8, r0_13
 #  952|     r0_15(int *)                         = Convert                         : r0_14
 #  953|     r0_16(glval<unknown>)                = FunctionAddress[operator new[]] : 
 #  953|     r0_17(glval<int>)                    = VariableAddress[n]              : 
@@ -3861,7 +3861,7 @@ ir.cpp:
 #  953|     r0_20(unsigned long)                 = Constant[4]                     : 
 #  953|     r0_21(unsigned long)                 = Mul                             : r0_19, r0_20
 #  953|     r0_22(float)                         = Constant[1.0]                   : 
-#  953|     r0_23(void *)                        = Invoke                          : r0_16, r0_21, r0_22
+#  953|     r0_23(void *)                        = Call                            : r0_16, r0_21, r0_22
 #  953|     r0_24(int *)                         = Convert                         : r0_23
 #  954|     r0_25(glval<unknown>)                = FunctionAddress[operator new[]] : 
 #  954|     r0_26(glval<int>)                    = VariableAddress[n]              : 
@@ -3869,7 +3869,7 @@ ir.cpp:
 #  954|     r0_28(unsigned long)                 = Convert                         : r0_27
 #  954|     r0_29(unsigned long)                 = Constant[8]                     : 
 #  954|     r0_30(unsigned long)                 = Mul                             : r0_28, r0_29
-#  954|     r0_31(void *)                        = Invoke                          : r0_25, r0_30
+#  954|     r0_31(void *)                        = Call                            : r0_25, r0_30
 #  954|     r0_32(String *)                      = Convert                         : r0_31
 #  955|     r0_33(glval<unknown>)                = FunctionAddress[operator new[]] : 
 #  955|     r0_34(glval<int>)                    = VariableAddress[n]              : 
@@ -3878,13 +3878,13 @@ ir.cpp:
 #  955|     r0_37(unsigned long)                 = Constant[256]                   : 
 #  955|     r0_38(unsigned long)                 = Mul                             : r0_36, r0_37
 #  955|     r0_39(align_val_t)                   = Constant[128]                   : 
-#  955|     r0_40(void *)                        = Invoke                          : r0_33, r0_38, r0_39
+#  955|     r0_40(void *)                        = Call                            : r0_33, r0_38, r0_39
 #  955|     r0_41(Overaligned *)                 = Convert                         : r0_40
 #  956|     r0_42(glval<unknown>)                = FunctionAddress[operator new[]] : 
 #  956|     r0_43(unsigned long)                 = Constant[2560]                  : 
 #  956|     r0_44(align_val_t)                   = Constant[128]                   : 
 #  956|     r0_45(float)                         = Constant[1.0]                   : 
-#  956|     r0_46(void *)                        = Invoke                          : r0_42, r0_43, r0_44, r0_45
+#  956|     r0_46(void *)                        = Call                            : r0_42, r0_43, r0_44, r0_45
 #  956|     r0_47(Overaligned *)                 = Convert                         : r0_46
 #  957|     r0_48(glval<unknown>)                = FunctionAddress[operator new[]] : 
 #  957|     r0_49(glval<int>)                    = VariableAddress[n]              : 
@@ -3892,7 +3892,7 @@ ir.cpp:
 #  957|     r0_51(unsigned long)                 = Convert                         : r0_50
 #  957|     r0_52(unsigned long)                 = Constant[1]                     : 
 #  957|     r0_53(unsigned long)                 = Mul                             : r0_51, r0_52
-#  957|     r0_54(void *)                        = Invoke                          : r0_48, r0_53
+#  957|     r0_54(void *)                        = Call                            : r0_48, r0_53
 #  957|     r0_55(DefaultCtorWithDefaultParam *) = Convert                         : r0_54
 #  958|     r0_56(glval<unknown>)                = FunctionAddress[operator new[]] : 
 #  958|     r0_57(glval<int>)                    = VariableAddress[n]              : 
@@ -3900,7 +3900,7 @@ ir.cpp:
 #  958|     r0_59(unsigned long)                 = Convert                         : r0_58
 #  958|     r0_60(unsigned long)                 = Constant[4]                     : 
 #  958|     r0_61(unsigned long)                 = Mul                             : r0_59, r0_60
-#  958|     r0_62(void *)                        = Invoke                          : r0_56, r0_61
+#  958|     r0_62(void *)                        = Call                            : r0_56, r0_61
 #  958|     r0_63(int *)                         = Convert                         : r0_62
 #  959|     v0_64(void)                          = NoOp                            : 
 #  950|     v0_65(void)                          = ReturnVoid                      : 

--- a/cpp/ql/test/library-tests/ir/ir/ir.expected
+++ b/cpp/ql/test/library-tests/ir/ir/ir.expected
@@ -1547,7 +1547,7 @@ ir.cpp:
 #  372|     v0_0(void)           = EnterFunction             : 
 #  372|     mu0_1(unknown)       = UnmodeledDefinition       : 
 #  373|     r0_2(glval<unknown>) = FunctionAddress[VoidFunc] : 
-#  373|     v0_3(void)           = Invoke                    : r0_2
+#  373|     v0_3(void)           = Call                      : r0_2
 #  374|     v0_4(void)           = NoOp                      : 
 #  372|     v0_5(void)           = ReturnVoid                : 
 #  372|     v0_6(void)           = UnmodeledUse              : mu*
@@ -1567,7 +1567,7 @@ ir.cpp:
 #  377|     r0_9(int)            = Load                     : r0_8, mu0_1
 #  377|     r0_10(glval<int>)    = VariableAddress[y]       : 
 #  377|     r0_11(int)           = Load                     : r0_10, mu0_1
-#  377|     r0_12(int)           = Invoke                   : r0_7, r0_9, r0_11
+#  377|     r0_12(int)           = Call                     : r0_7, r0_9, r0_11
 #  377|     mu0_13(int)          = Store                    : r0_6, r0_12
 #  376|     r0_14(glval<int>)    = VariableAddress[#return] : 
 #  376|     v0_15(void)          = ReturnValue              : r0_14, mu0_1
@@ -1584,13 +1584,13 @@ ir.cpp:
 #  380|     mu0_5(int)           = InitializeParameter[y]    : r0_4
 #  381|     r0_6(glval<int>)     = VariableAddress[#return]  : 
 #  381|     r0_7(glval<unknown>) = FunctionAddress[VoidFunc] : 
-#  381|     v0_8(void)           = Invoke                    : r0_7
+#  381|     v0_8(void)           = Call                      : r0_7
 #  381|     r0_9(glval<unknown>) = FunctionAddress[CallAdd]  : 
 #  381|     r0_10(glval<int>)    = VariableAddress[x]        : 
 #  381|     r0_11(int)           = Load                      : r0_10, mu0_1
 #  381|     r0_12(glval<int>)    = VariableAddress[y]        : 
 #  381|     r0_13(int)           = Load                      : r0_12, mu0_1
-#  381|     r0_14(int)           = Invoke                    : r0_9, r0_11, r0_13
+#  381|     r0_14(int)           = Call                      : r0_9, r0_11, r0_13
 #  381|     mu0_15(int)          = Store                     : r0_6, r0_14
 #  380|     r0_16(glval<int>)    = VariableAddress[#return]  : 
 #  380|     v0_17(void)          = ReturnValue               : r0_16, mu0_1
@@ -2097,12 +2097,12 @@ ir.cpp:
 
 #  493|   Block 2
 #  493|     r2_0(glval<unknown>) = FunctionAddress[VoidFunc] : 
-#  493|     v2_1(void)           = Invoke                    : r2_0
+#  493|     v2_1(void)           = Call                      : r2_0
 #-----|   Goto -> Block 1
 
 #  493|   Block 3
 #  493|     r3_0(glval<unknown>) = FunctionAddress[VoidFunc] : 
-#  493|     v3_1(void)           = Invoke                    : r3_0
+#  493|     v3_1(void)           = Call                      : r3_0
 #-----|   Goto -> Block 1
 
 #  496| Nullptr() -> void
@@ -2389,7 +2389,7 @@ ir.cpp:
 #  552|     r0_5(glval<..(*)(..)>) = VariableAddress[pfn]     : 
 #  552|     r0_6(..(*)(..))        = Load                     : r0_5, mu0_1
 #  552|     r0_7(int)              = Constant[5]              : 
-#  552|     r0_8(int)              = Invoke                   : r0_6, r0_7
+#  552|     r0_8(int)              = Call                     : r0_6, r0_7
 #  552|     mu0_9(int)             = Store                    : r0_4, r0_8
 #  551|     r0_10(glval<int>)      = VariableAddress[#return] : 
 #  551|     v0_11(void)            = ReturnValue              : r0_10, mu0_1
@@ -2506,7 +2506,7 @@ ir.cpp:
 #  585|     r0_5(int)            = Constant[1]                     : 
 #  585|     r0_6(glval<char[7]>) = StringConstant["string"]        : 
 #  585|     r0_7(char *)         = Convert                         : r0_6
-#  585|     v0_8(void)           = Invoke                          : r0_2, r0_4, r0_5, r0_7
+#  585|     v0_8(void)           = Call                            : r0_2, r0_4, r0_5, r0_7
 #  586|     v0_9(void)           = NoOp                            : 
 #  584|     v0_10(void)          = ReturnVoid                      : 
 #  584|     v0_11(void)          = UnmodeledUse                    : mu*
@@ -2539,21 +2539,21 @@ ir.cpp:
 #  615|     mu0_1(unknown)        = UnmodeledDefinition           : 
 #  616|     r0_2(glval<String>)   = VariableAddress[s1]           : 
 #  616|     r0_3(glval<unknown>)  = FunctionAddress[String]       : 
-#  616|     v0_4(void)            = Invoke                        : r0_3, this:r0_2
+#  616|     v0_4(void)            = Call                          : r0_3, this:r0_2
 #  617|     r0_5(glval<String>)   = VariableAddress[s2]           : 
 #  617|     r0_6(glval<unknown>)  = FunctionAddress[String]       : 
 #  617|     r0_7(glval<char[6]>)  = StringConstant["hello"]       : 
 #  617|     r0_8(char *)          = Convert                       : r0_7
-#  617|     v0_9(void)            = Invoke                        : r0_6, this:r0_5, r0_8
+#  617|     v0_9(void)            = Call                          : r0_6, this:r0_5, r0_8
 #  618|     r0_10(glval<String>)  = VariableAddress[s3]           : 
 #  618|     r0_11(glval<unknown>) = FunctionAddress[ReturnObject] : 
-#  618|     r0_12(String)         = Invoke                        : r0_11
+#  618|     r0_12(String)         = Call                          : r0_11
 #  618|     mu0_13(String)        = Store                         : r0_10, r0_12
 #  619|     r0_14(glval<String>)  = VariableAddress[s4]           : 
 #  619|     r0_15(glval<unknown>) = FunctionAddress[String]       : 
 #  619|     r0_16(glval<char[5]>) = StringConstant["test"]        : 
 #  619|     r0_17(char *)         = Convert                       : r0_16
-#  619|     v0_18(void)           = Invoke                        : r0_15, this:r0_14, r0_17
+#  619|     v0_18(void)           = Call                          : r0_15, this:r0_14, r0_17
 #  620|     v0_19(void)           = NoOp                          : 
 #  615|     v0_20(void)           = ReturnVoid                    : 
 #  615|     v0_21(void)           = UnmodeledUse                  : mu*
@@ -2573,16 +2573,16 @@ ir.cpp:
 #  623|     r0_9(String &)         = Load                   : r0_8, mu0_1
 #  623|     r0_10(glval<String>)   = Convert                : r0_9
 #  623|     r0_11(glval<unknown>)  = FunctionAddress[c_str] : 
-#  623|     r0_12(char *)          = Invoke                 : r0_11, this:r0_10
+#  623|     r0_12(char *)          = Call                   : r0_11, this:r0_10
 #  624|     r0_13(glval<String *>) = VariableAddress[p]     : 
 #  624|     r0_14(String *)        = Load                   : r0_13, mu0_1
 #  624|     r0_15(String *)        = Convert                : r0_14
 #  624|     r0_16(glval<unknown>)  = FunctionAddress[c_str] : 
-#  624|     r0_17(char *)          = Invoke                 : r0_16, this:r0_15
+#  624|     r0_17(char *)          = Call                   : r0_16, this:r0_15
 #  625|     r0_18(glval<String>)   = VariableAddress[s]     : 
 #  625|     r0_19(glval<String>)   = Convert                : r0_18
 #  625|     r0_20(glval<unknown>)  = FunctionAddress[c_str] : 
-#  625|     r0_21(char *)          = Invoke                 : r0_20, this:r0_19
+#  625|     r0_21(char *)          = Call                   : r0_20, this:r0_19
 #  626|     v0_22(void)            = NoOp                   : 
 #  622|     v0_23(void)            = ReturnVoid             : 
 #  622|     v0_24(void)            = UnmodeledUse           : mu*
@@ -2682,15 +2682,15 @@ ir.cpp:
 #  653|     r0_3(C *)             = CopyValue                               : r0_2
 #  653|     r0_4(glval<unknown>)  = FunctionAddress[InstanceMemberFunction] : 
 #  653|     r0_5(int)             = Constant[0]                             : 
-#  653|     r0_6(int)             = Invoke                                  : r0_4, this:r0_3, r0_5
+#  653|     r0_6(int)             = Call                                    : r0_4, this:r0_3, r0_5
 #  654|     r0_7(C *)             = CopyValue                               : r0_2
 #  654|     r0_8(glval<unknown>)  = FunctionAddress[InstanceMemberFunction] : 
 #  654|     r0_9(int)             = Constant[1]                             : 
-#  654|     r0_10(int)            = Invoke                                  : r0_8, this:r0_7, r0_9
+#  654|     r0_10(int)            = Call                                    : r0_8, this:r0_7, r0_9
 #-----|     r0_11(C *)            = CopyValue                               : r0_2
 #  655|     r0_12(glval<unknown>) = FunctionAddress[InstanceMemberFunction] : 
 #  655|     r0_13(int)            = Constant[2]                             : 
-#  655|     r0_14(int)            = Invoke                                  : r0_12, this:r0_11, r0_13
+#  655|     r0_14(int)            = Call                                    : r0_12, this:r0_11, r0_13
 #  656|     v0_15(void)           = NoOp                                    : 
 #  652|     v0_16(void)           = ReturnVoid                              : 
 #  652|     v0_17(void)           = UnmodeledUse                            : mu*
@@ -2706,7 +2706,7 @@ ir.cpp:
 #  659|     mu0_5(int)            = Store                   : r0_3, r0_4
 #  663|     r0_6(glval<String>)   = FieldAddress[m_b]       : r0_2
 #  663|     r0_7(glval<unknown>)  = FunctionAddress[String] : 
-#  663|     v0_8(void)            = Invoke                  : r0_7, this:r0_6
+#  663|     v0_8(void)            = Call                    : r0_7, this:r0_6
 #  660|     r0_9(glval<char>)     = FieldAddress[m_c]       : r0_2
 #  660|     r0_10(char)           = Constant[3]             : 
 #  660|     mu0_11(char)          = Store                   : r0_9, r0_10
@@ -2717,7 +2717,7 @@ ir.cpp:
 #  662|     r0_16(glval<unknown>) = FunctionAddress[String] : 
 #  662|     r0_17(glval<char[5]>) = StringConstant["test"]  : 
 #  662|     r0_18(char *)         = Convert                 : r0_17
-#  662|     v0_19(void)           = Invoke                  : r0_16, this:r0_15, r0_18
+#  662|     v0_19(void)           = Call                    : r0_16, this:r0_15, r0_18
 #  664|     v0_20(void)           = NoOp                    : 
 #  658|     v0_21(void)           = ReturnVoid              : 
 #  658|     v0_22(void)           = UnmodeledUse            : mu*
@@ -2766,7 +2766,7 @@ ir.cpp:
 #  687|     mu0_10(int &)          = Store                            : r0_7, r0_9
 #  688|     r0_11(glval<String &>) = VariableAddress[r3]              : 
 #  688|     r0_12(glval<unknown>)  = FunctionAddress[ReturnReference] : 
-#  688|     r0_13(String &)        = Invoke                           : r0_12
+#  688|     r0_13(String &)        = Call                             : r0_12
 #  688|     r0_14(glval<String>)   = Convert                          : r0_13
 #  688|     mu0_15(String &)       = Store                            : r0_11, r0_14
 #  689|     v0_16(void)            = NoOp                             : 
@@ -2810,7 +2810,7 @@ ir.cpp:
 #  700|     r0_9(glval<..(&)(..)>) = VariableAddress[rfn]           : 
 #  700|     r0_10(..(&)(..))       = Load                           : r0_9, mu0_1
 #  700|     r0_11(int)             = Constant[5]                    : 
-#  700|     r0_12(int)             = Invoke                         : r0_10, r0_11
+#  700|     r0_12(int)             = Call                           : r0_10, r0_11
 #  701|     v0_13(void)            = NoOp                           : 
 #  697|     v0_14(void)            = ReturnVoid                     : 
 #  697|     v0_15(void)            = UnmodeledUse                   : mu*
@@ -2871,7 +2871,7 @@ ir.cpp:
 #  709|     r0_9(int)            = Load                     : r0_8, mu0_1
 #  709|     r0_10(glval<int>)    = VariableAddress[y]       : 
 #  709|     r0_11(int)           = Load                     : r0_10, mu0_1
-#  709|     r0_12(int)           = Invoke                   : r0_7, r0_9, r0_11
+#  709|     r0_12(int)           = Call                     : r0_7, r0_9, r0_11
 #  709|     mu0_13(int)          = Store                    : r0_6, r0_12
 #  708|     r0_14(glval<int>)    = VariableAddress[#return] : 
 #  708|     v0_15(void)          = ReturnValue              : r0_14, mu0_1
@@ -2902,7 +2902,7 @@ ir.cpp:
 #  721|     r0_3(glval<unknown>) = FunctionAddress[Func]    : 
 #  721|     r0_4(void *)         = Constant[0]              : 
 #  721|     r0_5(char)           = Constant[111]            : 
-#  721|     r0_6(long)           = Invoke                   : r0_3, r0_4, r0_5
+#  721|     r0_6(long)           = Call                     : r0_3, r0_4, r0_5
 #  721|     r0_7(double)         = Convert                  : r0_6
 #  721|     mu0_8(double)        = Store                    : r0_2, r0_7
 #  720|     r0_9(glval<double>)  = VariableAddress[#return] : 
@@ -2972,7 +2972,7 @@ ir.cpp:
 #  731|     r7_1(glval<unknown>)  = FunctionAddress[String]         : 
 #  731|     r7_2(glval<char[14]>) = StringConstant["String object"] : 
 #  731|     r7_3(char *)          = Convert                         : r7_2
-#  731|     v7_4(void)            = Invoke                          : r7_1, this:r7_0, r7_3
+#  731|     v7_4(void)            = Call                            : r7_1, this:r7_0, r7_3
 #  731|     v7_5(void)            = ThrowValue                      : r7_0, mu0_1
 #-----|   Exception -> Block 9
 
@@ -2994,7 +2994,7 @@ ir.cpp:
 #  736|     r10_3(glval<unknown>) = FunctionAddress[String]      : 
 #  736|     r10_4(glval<char *>)  = VariableAddress[s]           : 
 #  736|     r10_5(char *)         = Load                         : r10_4, mu0_1
-#  736|     v10_6(void)           = Invoke                       : r10_3, this:r10_2, r10_5
+#  736|     v10_6(void)           = Call                         : r10_3, this:r10_2, r10_5
 #  736|     v10_7(void)           = ThrowValue                   : r10_2, mu0_1
 #-----|   Exception -> Block 2
 
@@ -3028,7 +3028,7 @@ ir.cpp:
 #-----|     mu0_4(Base &)        = InitializeParameter[p#0] : r0_3
 #  745|     r0_5(glval<String>)  = FieldAddress[base_s]     : r0_2
 #  745|     r0_6(glval<unknown>) = FunctionAddress[String]  : 
-#  745|     v0_7(void)           = Invoke                   : r0_6, this:r0_5
+#  745|     v0_7(void)           = Call                     : r0_6, this:r0_5
 #  745|     v0_8(void)           = NoOp                     : 
 #  745|     v0_9(void)           = ReturnVoid               : 
 #  745|     v0_10(void)          = UnmodeledUse             : mu*
@@ -3047,7 +3047,7 @@ ir.cpp:
 #-----|     r0_8(glval<Base &>)  = VariableAddress[p#0]       : 
 #-----|     r0_9(Base &)         = Load                       : r0_8, mu0_1
 #-----|     r0_10(glval<String>) = FieldAddress[base_s]       : r0_9
-#  745|     r0_11(String &)      = Invoke                     : r0_7, this:r0_6, r0_10
+#  745|     r0_11(String &)      = Call                       : r0_7, this:r0_6, r0_10
 #-----|     r0_12(glval<Base &>) = VariableAddress[#return]   : 
 #-----|     r0_13(Base *)        = CopyValue                  : r0_2
 #-----|     mu0_14(Base &)       = Store                      : r0_12, r0_13
@@ -3063,7 +3063,7 @@ ir.cpp:
 #  748|     r0_2(glval<Base>)    = InitializeThis          : 
 #  748|     r0_3(glval<String>)  = FieldAddress[base_s]    : r0_2
 #  748|     r0_4(glval<unknown>) = FunctionAddress[String] : 
-#  748|     v0_5(void)           = Invoke                  : r0_4, this:r0_3
+#  748|     v0_5(void)           = Call                    : r0_4, this:r0_3
 #  749|     v0_6(void)           = NoOp                    : 
 #  748|     v0_7(void)           = ReturnVoid              : 
 #  748|     v0_8(void)           = UnmodeledUse            : mu*
@@ -3077,7 +3077,7 @@ ir.cpp:
 #  751|     v0_3(void)           = NoOp                     : 
 #  751|     r0_4(glval<String>)  = FieldAddress[base_s]     : r0_2
 #  751|     r0_5(glval<unknown>) = FunctionAddress[~String] : 
-#  751|     v0_6(void)           = Invoke                   : r0_5, this:r0_4
+#  751|     v0_6(void)           = Call                     : r0_5, this:r0_4
 #  750|     v0_7(void)           = ReturnVoid               : 
 #  750|     v0_8(void)           = UnmodeledUse             : mu*
 #  750|     v0_9(void)           = ExitFunction             : 
@@ -3095,14 +3095,14 @@ ir.cpp:
 #-----|     r0_8(glval<Middle &>)  = VariableAddress[p#0]         : 
 #-----|     r0_9(Middle &)         = Load                         : r0_8, mu0_1
 #-----|     r0_10(Base *)          = ConvertToBase[Middle : Base] : r0_9
-#  754|     r0_11(Base &)          = Invoke                       : r0_7, this:r0_6, r0_10
+#  754|     r0_11(Base &)          = Call                         : r0_7, this:r0_6, r0_10
 #-----|     r0_12(Middle *)        = CopyValue                    : r0_2
 #-----|     r0_13(glval<String>)   = FieldAddress[middle_s]       : r0_12
 #  754|     r0_14(glval<unknown>)  = FunctionAddress[operator=]   : 
 #-----|     r0_15(glval<Middle &>) = VariableAddress[p#0]         : 
 #-----|     r0_16(Middle &)        = Load                         : r0_15, mu0_1
 #-----|     r0_17(glval<String>)   = FieldAddress[middle_s]       : r0_16
-#  754|     r0_18(String &)        = Invoke                       : r0_14, this:r0_13, r0_17
+#  754|     r0_18(String &)        = Call                         : r0_14, this:r0_13, r0_17
 #-----|     r0_19(glval<Middle &>) = VariableAddress[#return]     : 
 #-----|     r0_20(Middle *)        = CopyValue                    : r0_2
 #-----|     mu0_21(Middle &)       = Store                        : r0_19, r0_20
@@ -3118,10 +3118,10 @@ ir.cpp:
 #  757|     r0_2(glval<Middle>)  = InitializeThis               : 
 #  757|     r0_3(glval<Base>)    = ConvertToBase[Middle : Base] : r0_2
 #  757|     r0_4(glval<unknown>) = FunctionAddress[Base]        : 
-#  757|     v0_5(void)           = Invoke                       : r0_4, this:r0_3
+#  757|     v0_5(void)           = Call                         : r0_4, this:r0_3
 #  757|     r0_6(glval<String>)  = FieldAddress[middle_s]       : r0_2
 #  757|     r0_7(glval<unknown>) = FunctionAddress[String]      : 
-#  757|     v0_8(void)           = Invoke                       : r0_7, this:r0_6
+#  757|     v0_8(void)           = Call                         : r0_7, this:r0_6
 #  758|     v0_9(void)           = NoOp                         : 
 #  757|     v0_10(void)          = ReturnVoid                   : 
 #  757|     v0_11(void)          = UnmodeledUse                 : mu*
@@ -3135,10 +3135,10 @@ ir.cpp:
 #  760|     v0_3(void)           = NoOp                         : 
 #  760|     r0_4(glval<String>)  = FieldAddress[middle_s]       : r0_2
 #  760|     r0_5(glval<unknown>) = FunctionAddress[~String]     : 
-#  760|     v0_6(void)           = Invoke                       : r0_5, this:r0_4
+#  760|     v0_6(void)           = Call                         : r0_5, this:r0_4
 #  760|     r0_7(glval<Base>)    = ConvertToBase[Middle : Base] : r0_2
 #  760|     r0_8(glval<unknown>) = FunctionAddress[~Base]       : 
-#  760|     v0_9(void)           = Invoke                       : r0_8, this:r0_7
+#  760|     v0_9(void)           = Call                         : r0_8, this:r0_7
 #  759|     v0_10(void)          = ReturnVoid                   : 
 #  759|     v0_11(void)          = UnmodeledUse                 : mu*
 #  759|     v0_12(void)          = ExitFunction                 : 
@@ -3156,14 +3156,14 @@ ir.cpp:
 #-----|     r0_8(glval<Derived &>)  = VariableAddress[p#0]            : 
 #-----|     r0_9(Derived &)         = Load                            : r0_8, mu0_1
 #-----|     r0_10(Middle *)         = ConvertToBase[Derived : Middle] : r0_9
-#  763|     r0_11(Middle &)         = Invoke                          : r0_7, this:r0_6, r0_10
+#  763|     r0_11(Middle &)         = Call                            : r0_7, this:r0_6, r0_10
 #-----|     r0_12(Derived *)        = CopyValue                       : r0_2
 #-----|     r0_13(glval<String>)    = FieldAddress[derived_s]         : r0_12
 #  763|     r0_14(glval<unknown>)   = FunctionAddress[operator=]      : 
 #-----|     r0_15(glval<Derived &>) = VariableAddress[p#0]            : 
 #-----|     r0_16(Derived &)        = Load                            : r0_15, mu0_1
 #-----|     r0_17(glval<String>)    = FieldAddress[derived_s]         : r0_16
-#  763|     r0_18(String &)         = Invoke                          : r0_14, this:r0_13, r0_17
+#  763|     r0_18(String &)         = Call                            : r0_14, this:r0_13, r0_17
 #-----|     r0_19(glval<Derived &>) = VariableAddress[#return]        : 
 #-----|     r0_20(Derived *)        = CopyValue                       : r0_2
 #-----|     mu0_21(Derived &)       = Store                           : r0_19, r0_20
@@ -3179,10 +3179,10 @@ ir.cpp:
 #  766|     r0_2(glval<Derived>) = InitializeThis                  : 
 #  766|     r0_3(glval<Middle>)  = ConvertToBase[Derived : Middle] : r0_2
 #  766|     r0_4(glval<unknown>) = FunctionAddress[Middle]         : 
-#  766|     v0_5(void)           = Invoke                          : r0_4, this:r0_3
+#  766|     v0_5(void)           = Call                            : r0_4, this:r0_3
 #  766|     r0_6(glval<String>)  = FieldAddress[derived_s]         : r0_2
 #  766|     r0_7(glval<unknown>) = FunctionAddress[String]         : 
-#  766|     v0_8(void)           = Invoke                          : r0_7, this:r0_6
+#  766|     v0_8(void)           = Call                            : r0_7, this:r0_6
 #  767|     v0_9(void)           = NoOp                            : 
 #  766|     v0_10(void)          = ReturnVoid                      : 
 #  766|     v0_11(void)          = UnmodeledUse                    : mu*
@@ -3196,10 +3196,10 @@ ir.cpp:
 #  769|     v0_3(void)           = NoOp                            : 
 #  769|     r0_4(glval<String>)  = FieldAddress[derived_s]         : r0_2
 #  769|     r0_5(glval<unknown>) = FunctionAddress[~String]        : 
-#  769|     v0_6(void)           = Invoke                          : r0_5, this:r0_4
+#  769|     v0_6(void)           = Call                            : r0_5, this:r0_4
 #  769|     r0_7(glval<Middle>)  = ConvertToBase[Derived : Middle] : r0_2
 #  769|     r0_8(glval<unknown>) = FunctionAddress[~Middle]        : 
-#  769|     v0_9(void)           = Invoke                          : r0_8, this:r0_7
+#  769|     v0_9(void)           = Call                            : r0_8, this:r0_7
 #  768|     v0_10(void)          = ReturnVoid                      : 
 #  768|     v0_11(void)          = UnmodeledUse                    : mu*
 #  768|     v0_12(void)          = ExitFunction                    : 
@@ -3211,10 +3211,10 @@ ir.cpp:
 #  775|     r0_2(glval<MiddleVB1>) = InitializeThis                  : 
 #  775|     r0_3(glval<Base>)      = ConvertToBase[MiddleVB1 : Base] : r0_2
 #  775|     r0_4(glval<unknown>)   = FunctionAddress[Base]           : 
-#  775|     v0_5(void)             = Invoke                          : r0_4, this:r0_3
+#  775|     v0_5(void)             = Call                            : r0_4, this:r0_3
 #  775|     r0_6(glval<String>)    = FieldAddress[middlevb1_s]       : r0_2
 #  775|     r0_7(glval<unknown>)   = FunctionAddress[String]         : 
-#  775|     v0_8(void)             = Invoke                          : r0_7, this:r0_6
+#  775|     v0_8(void)             = Call                            : r0_7, this:r0_6
 #  776|     v0_9(void)             = NoOp                            : 
 #  775|     v0_10(void)            = ReturnVoid                      : 
 #  775|     v0_11(void)            = UnmodeledUse                    : mu*
@@ -3228,10 +3228,10 @@ ir.cpp:
 #  778|     v0_3(void)             = NoOp                            : 
 #  778|     r0_4(glval<String>)    = FieldAddress[middlevb1_s]       : r0_2
 #  778|     r0_5(glval<unknown>)   = FunctionAddress[~String]        : 
-#  778|     v0_6(void)             = Invoke                          : r0_5, this:r0_4
+#  778|     v0_6(void)             = Call                            : r0_5, this:r0_4
 #  778|     r0_7(glval<Base>)      = ConvertToBase[MiddleVB1 : Base] : r0_2
 #  778|     r0_8(glval<unknown>)   = FunctionAddress[~Base]          : 
-#  778|     v0_9(void)             = Invoke                          : r0_8, this:r0_7
+#  778|     v0_9(void)             = Call                            : r0_8, this:r0_7
 #  777|     v0_10(void)            = ReturnVoid                      : 
 #  777|     v0_11(void)            = UnmodeledUse                    : mu*
 #  777|     v0_12(void)            = ExitFunction                    : 
@@ -3243,10 +3243,10 @@ ir.cpp:
 #  784|     r0_2(glval<MiddleVB2>) = InitializeThis                  : 
 #  784|     r0_3(glval<Base>)      = ConvertToBase[MiddleVB2 : Base] : r0_2
 #  784|     r0_4(glval<unknown>)   = FunctionAddress[Base]           : 
-#  784|     v0_5(void)             = Invoke                          : r0_4, this:r0_3
+#  784|     v0_5(void)             = Call                            : r0_4, this:r0_3
 #  784|     r0_6(glval<String>)    = FieldAddress[middlevb2_s]       : r0_2
 #  784|     r0_7(glval<unknown>)   = FunctionAddress[String]         : 
-#  784|     v0_8(void)             = Invoke                          : r0_7, this:r0_6
+#  784|     v0_8(void)             = Call                            : r0_7, this:r0_6
 #  785|     v0_9(void)             = NoOp                            : 
 #  784|     v0_10(void)            = ReturnVoid                      : 
 #  784|     v0_11(void)            = UnmodeledUse                    : mu*
@@ -3260,10 +3260,10 @@ ir.cpp:
 #  787|     v0_3(void)             = NoOp                            : 
 #  787|     r0_4(glval<String>)    = FieldAddress[middlevb2_s]       : r0_2
 #  787|     r0_5(glval<unknown>)   = FunctionAddress[~String]        : 
-#  787|     v0_6(void)             = Invoke                          : r0_5, this:r0_4
+#  787|     v0_6(void)             = Call                            : r0_5, this:r0_4
 #  787|     r0_7(glval<Base>)      = ConvertToBase[MiddleVB2 : Base] : r0_2
 #  787|     r0_8(glval<unknown>)   = FunctionAddress[~Base]          : 
-#  787|     v0_9(void)             = Invoke                          : r0_8, this:r0_7
+#  787|     v0_9(void)             = Call                            : r0_8, this:r0_7
 #  786|     v0_10(void)            = ReturnVoid                      : 
 #  786|     v0_11(void)            = UnmodeledUse                    : mu*
 #  786|     v0_12(void)            = ExitFunction                    : 
@@ -3275,16 +3275,16 @@ ir.cpp:
 #  793|     r0_2(glval<DerivedVB>) = InitializeThis                       : 
 #  793|     r0_3(glval<Base>)      = ConvertToBase[DerivedVB : Base]      : r0_2
 #  793|     r0_4(glval<unknown>)   = FunctionAddress[Base]                : 
-#  793|     v0_5(void)             = Invoke                               : r0_4, this:r0_3
+#  793|     v0_5(void)             = Call                                 : r0_4, this:r0_3
 #  793|     r0_6(glval<MiddleVB1>) = ConvertToBase[DerivedVB : MiddleVB1] : r0_2
 #  793|     r0_7(glval<unknown>)   = FunctionAddress[MiddleVB1]           : 
-#  793|     v0_8(void)             = Invoke                               : r0_7, this:r0_6
+#  793|     v0_8(void)             = Call                                 : r0_7, this:r0_6
 #  793|     r0_9(glval<MiddleVB2>) = ConvertToBase[DerivedVB : MiddleVB2] : r0_2
 #  793|     r0_10(glval<unknown>)  = FunctionAddress[MiddleVB2]           : 
-#  793|     v0_11(void)            = Invoke                               : r0_10, this:r0_9
+#  793|     v0_11(void)            = Call                                 : r0_10, this:r0_9
 #  793|     r0_12(glval<String>)   = FieldAddress[derivedvb_s]            : r0_2
 #  793|     r0_13(glval<unknown>)  = FunctionAddress[String]              : 
-#  793|     v0_14(void)            = Invoke                               : r0_13, this:r0_12
+#  793|     v0_14(void)            = Call                                 : r0_13, this:r0_12
 #  794|     v0_15(void)            = NoOp                                 : 
 #  793|     v0_16(void)            = ReturnVoid                           : 
 #  793|     v0_17(void)            = UnmodeledUse                         : mu*
@@ -3298,16 +3298,16 @@ ir.cpp:
 #  796|     v0_3(void)              = NoOp                                 : 
 #  796|     r0_4(glval<String>)     = FieldAddress[derivedvb_s]            : r0_2
 #  796|     r0_5(glval<unknown>)    = FunctionAddress[~String]             : 
-#  796|     v0_6(void)              = Invoke                               : r0_5, this:r0_4
+#  796|     v0_6(void)              = Call                                 : r0_5, this:r0_4
 #  796|     r0_7(glval<MiddleVB2>)  = ConvertToBase[DerivedVB : MiddleVB2] : r0_2
 #  796|     r0_8(glval<unknown>)    = FunctionAddress[~MiddleVB2]          : 
-#  796|     v0_9(void)              = Invoke                               : r0_8, this:r0_7
+#  796|     v0_9(void)              = Call                                 : r0_8, this:r0_7
 #  796|     r0_10(glval<MiddleVB1>) = ConvertToBase[DerivedVB : MiddleVB1] : r0_2
 #  796|     r0_11(glval<unknown>)   = FunctionAddress[~MiddleVB1]          : 
-#  796|     v0_12(void)             = Invoke                               : r0_11, this:r0_10
+#  796|     v0_12(void)             = Call                                 : r0_11, this:r0_10
 #  796|     r0_13(glval<Base>)      = ConvertToBase[DerivedVB : Base]      : r0_2
 #  796|     r0_14(glval<unknown>)   = FunctionAddress[~Base]               : 
-#  796|     v0_15(void)             = Invoke                               : r0_14, this:r0_13
+#  796|     v0_15(void)             = Call                                 : r0_14, this:r0_13
 #  795|     v0_16(void)             = ReturnVoid                           : 
 #  795|     v0_17(void)             = UnmodeledUse                         : mu*
 #  795|     v0_18(void)             = ExitFunction                         : 
@@ -3318,13 +3318,13 @@ ir.cpp:
 #  799|     mu0_1(unknown)             = UnmodeledDefinition                    : 
 #  800|     r0_2(glval<Base>)          = VariableAddress[b]                     : 
 #  800|     r0_3(glval<unknown>)       = FunctionAddress[Base]                  : 
-#  800|     v0_4(void)                 = Invoke                                 : r0_3, this:r0_2
+#  800|     v0_4(void)                 = Call                                   : r0_3, this:r0_2
 #  801|     r0_5(glval<Middle>)        = VariableAddress[m]                     : 
 #  801|     r0_6(glval<unknown>)       = FunctionAddress[Middle]                : 
-#  801|     v0_7(void)                 = Invoke                                 : r0_6, this:r0_5
+#  801|     v0_7(void)                 = Call                                   : r0_6, this:r0_5
 #  802|     r0_8(glval<Derived>)       = VariableAddress[d]                     : 
 #  802|     r0_9(glval<unknown>)       = FunctionAddress[Derived]               : 
-#  802|     v0_10(void)                = Invoke                                 : r0_9, this:r0_8
+#  802|     v0_10(void)                = Call                                   : r0_9, this:r0_8
 #  804|     r0_11(glval<Base *>)       = VariableAddress[pb]                    : 
 #  804|     r0_12(glval<Base>)         = VariableAddress[b]                     : 
 #  804|     mu0_13(Base *)             = Store                                  : r0_11, r0_12
@@ -3338,23 +3338,23 @@ ir.cpp:
 #  808|     r0_21(glval<unknown>)      = FunctionAddress[operator=]             : 
 #  808|     r0_22(glval<Middle>)       = VariableAddress[m]                     : 
 #  808|     r0_23(glval<Base>)         = ConvertToBase[Middle : Base]           : r0_22
-#  808|     r0_24(Base &)              = Invoke                                 : r0_21, this:r0_20, r0_23
+#  808|     r0_24(Base &)              = Call                                   : r0_21, this:r0_20, r0_23
 #  809|     r0_25(glval<Base>)         = VariableAddress[b]                     : 
 #  809|     r0_26(glval<unknown>)      = FunctionAddress[operator=]             : 
 #  809|     r0_27(glval<unknown>)      = FunctionAddress[Base]                  : 
 #  809|     r0_28(glval<Middle>)       = VariableAddress[m]                     : 
 #  809|     r0_29(glval<Base>)         = ConvertToBase[Middle : Base]           : r0_28
-#  809|     v0_30(void)                = Invoke                                 : r0_27, r0_29
+#  809|     v0_30(void)                = Call                                   : r0_27, r0_29
 #  809|     r0_31(Base)                = Convert                                : v0_30
-#  809|     r0_32(Base &)              = Invoke                                 : r0_26, this:r0_25, r0_31
+#  809|     r0_32(Base &)              = Call                                   : r0_26, this:r0_25, r0_31
 #  810|     r0_33(glval<Base>)         = VariableAddress[b]                     : 
 #  810|     r0_34(glval<unknown>)      = FunctionAddress[operator=]             : 
 #  810|     r0_35(glval<unknown>)      = FunctionAddress[Base]                  : 
 #  810|     r0_36(glval<Middle>)       = VariableAddress[m]                     : 
 #  810|     r0_37(glval<Base>)         = ConvertToBase[Middle : Base]           : r0_36
-#  810|     v0_38(void)                = Invoke                                 : r0_35, r0_37
+#  810|     v0_38(void)                = Call                                   : r0_35, r0_37
 #  810|     r0_39(Base)                = Convert                                : v0_38
-#  810|     r0_40(Base &)              = Invoke                                 : r0_34, this:r0_33, r0_39
+#  810|     r0_40(Base &)              = Call                                   : r0_34, this:r0_33, r0_39
 #  811|     r0_41(glval<Middle *>)     = VariableAddress[pm]                    : 
 #  811|     r0_42(Middle *)            = Load                                   : r0_41, mu0_1
 #  811|     r0_43(Base *)              = ConvertToBase[Middle : Base]           : r0_42
@@ -3380,13 +3380,13 @@ ir.cpp:
 #  816|     r0_63(glval<Base>)         = VariableAddress[b]                     : 
 #  816|     r0_64(glval<Middle>)       = ConvertToDerived[Middle : Base]        : r0_63
 #  816|     r0_65(glval<Middle>)       = Convert                                : r0_64
-#  816|     r0_66(Middle &)            = Invoke                                 : r0_62, this:r0_61, r0_65
+#  816|     r0_66(Middle &)            = Call                                   : r0_62, this:r0_61, r0_65
 #  817|     r0_67(glval<Middle>)       = VariableAddress[m]                     : 
 #  817|     r0_68(glval<unknown>)      = FunctionAddress[operator=]             : 
 #  817|     r0_69(glval<Base>)         = VariableAddress[b]                     : 
 #  817|     r0_70(glval<Middle>)       = ConvertToDerived[Middle : Base]        : r0_69
 #  817|     r0_71(glval<Middle>)       = Convert                                : r0_70
-#  817|     r0_72(Middle &)            = Invoke                                 : r0_68, this:r0_67, r0_71
+#  817|     r0_72(Middle &)            = Call                                   : r0_68, this:r0_67, r0_71
 #  818|     r0_73(glval<Base *>)       = VariableAddress[pb]                    : 
 #  818|     r0_74(Base *)              = Load                                   : r0_73, mu0_1
 #  818|     r0_75(Middle *)            = ConvertToDerived[Middle : Base]        : r0_74
@@ -3407,25 +3407,25 @@ ir.cpp:
 #  822|     r0_90(glval<Derived>)      = VariableAddress[d]                     : 
 #  822|     r0_91(glval<Middle>)       = ConvertToBase[Derived : Middle]        : r0_90
 #  822|     r0_92(glval<Base>)         = ConvertToBase[Middle : Base]           : r0_91
-#  822|     r0_93(Base &)              = Invoke                                 : r0_89, this:r0_88, r0_92
+#  822|     r0_93(Base &)              = Call                                   : r0_89, this:r0_88, r0_92
 #  823|     r0_94(glval<Base>)         = VariableAddress[b]                     : 
 #  823|     r0_95(glval<unknown>)      = FunctionAddress[operator=]             : 
 #  823|     r0_96(glval<unknown>)      = FunctionAddress[Base]                  : 
 #  823|     r0_97(glval<Derived>)      = VariableAddress[d]                     : 
 #  823|     r0_98(glval<Middle>)       = ConvertToBase[Derived : Middle]        : r0_97
 #  823|     r0_99(glval<Base>)         = ConvertToBase[Middle : Base]           : r0_98
-#  823|     v0_100(void)               = Invoke                                 : r0_96, r0_99
+#  823|     v0_100(void)               = Call                                   : r0_96, r0_99
 #  823|     r0_101(Base)               = Convert                                : v0_100
-#  823|     r0_102(Base &)             = Invoke                                 : r0_95, this:r0_94, r0_101
+#  823|     r0_102(Base &)             = Call                                   : r0_95, this:r0_94, r0_101
 #  824|     r0_103(glval<Base>)        = VariableAddress[b]                     : 
 #  824|     r0_104(glval<unknown>)     = FunctionAddress[operator=]             : 
 #  824|     r0_105(glval<unknown>)     = FunctionAddress[Base]                  : 
 #  824|     r0_106(glval<Derived>)     = VariableAddress[d]                     : 
 #  824|     r0_107(glval<Middle>)      = ConvertToBase[Derived : Middle]        : r0_106
 #  824|     r0_108(glval<Base>)        = ConvertToBase[Middle : Base]           : r0_107
-#  824|     v0_109(void)               = Invoke                                 : r0_105, r0_108
+#  824|     v0_109(void)               = Call                                   : r0_105, r0_108
 #  824|     r0_110(Base)               = Convert                                : v0_109
-#  824|     r0_111(Base &)             = Invoke                                 : r0_104, this:r0_103, r0_110
+#  824|     r0_111(Base &)             = Call                                   : r0_104, this:r0_103, r0_110
 #  825|     r0_112(glval<Derived *>)   = VariableAddress[pd]                    : 
 #  825|     r0_113(Derived *)          = Load                                   : r0_112, mu0_1
 #  825|     r0_114(Middle *)           = ConvertToBase[Derived : Middle]        : r0_113
@@ -3455,14 +3455,14 @@ ir.cpp:
 #  830|     r0_138(glval<Middle>)      = ConvertToDerived[Middle : Base]        : r0_137
 #  830|     r0_139(glval<Derived>)     = ConvertToDerived[Derived : Middle]     : r0_138
 #  830|     r0_140(glval<Derived>)     = Convert                                : r0_139
-#  830|     r0_141(Derived &)          = Invoke                                 : r0_136, this:r0_135, r0_140
+#  830|     r0_141(Derived &)          = Call                                   : r0_136, this:r0_135, r0_140
 #  831|     r0_142(glval<Derived>)     = VariableAddress[d]                     : 
 #  831|     r0_143(glval<unknown>)     = FunctionAddress[operator=]             : 
 #  831|     r0_144(glval<Base>)        = VariableAddress[b]                     : 
 #  831|     r0_145(glval<Middle>)      = ConvertToDerived[Middle : Base]        : r0_144
 #  831|     r0_146(glval<Derived>)     = ConvertToDerived[Derived : Middle]     : r0_145
 #  831|     r0_147(glval<Derived>)     = Convert                                : r0_146
-#  831|     r0_148(Derived &)          = Invoke                                 : r0_143, this:r0_142, r0_147
+#  831|     r0_148(Derived &)          = Call                                   : r0_143, this:r0_142, r0_147
 #  832|     r0_149(glval<Base *>)      = VariableAddress[pb]                    : 
 #  832|     r0_150(Base *)             = Load                                   : r0_149, mu0_1
 #  832|     r0_151(Middle *)           = ConvertToDerived[Middle : Base]        : r0_150
@@ -3518,7 +3518,7 @@ ir.cpp:
 #  846|     r0_2(glval<PolymorphicDerived>) = InitializeThis                                      : 
 #  846|     r0_3(glval<PolymorphicBase>)    = ConvertToBase[PolymorphicDerived : PolymorphicBase] : r0_2
 #  846|     r0_4(glval<unknown>)            = FunctionAddress[PolymorphicBase]                    : 
-#  846|     v0_5(void)                      = Invoke                                              : r0_4, this:r0_3
+#  846|     v0_5(void)                      = Call                                                : r0_4, this:r0_3
 #  846|     v0_6(void)                      = NoOp                                                : 
 #  846|     v0_7(void)                      = ReturnVoid                                          : 
 #  846|     v0_8(void)                      = UnmodeledUse                                        : mu*
@@ -3532,7 +3532,7 @@ ir.cpp:
 #-----|     v0_3(void)                      = NoOp                                                : 
 #  846|     r0_4(glval<PolymorphicBase>)    = ConvertToBase[PolymorphicDerived : PolymorphicBase] : r0_2
 #  846|     r0_5(glval<unknown>)            = FunctionAddress[~PolymorphicBase]                   : 
-#  846|     v0_6(void)                      = Invoke                                              : r0_5, this:r0_4
+#  846|     v0_6(void)                      = Call                                                : r0_5, this:r0_4
 #  846|     v0_7(void)                      = ReturnVoid                                          : 
 #  846|     v0_8(void)                      = UnmodeledUse                                        : mu*
 #  846|     v0_9(void)                      = ExitFunction                                        : 
@@ -3543,10 +3543,10 @@ ir.cpp:
 #  849|     mu0_1(unknown)                     = UnmodeledDefinition                 : 
 #  850|     r0_2(glval<PolymorphicBase>)       = VariableAddress[b]                  : 
 #-----|     r0_3(glval<unknown>)               = FunctionAddress[PolymorphicBase]    : 
-#-----|     v0_4(void)                         = Invoke                              : r0_3, this:r0_2
+#-----|     v0_4(void)                         = Call                                : r0_3, this:r0_2
 #  851|     r0_5(glval<PolymorphicDerived>)    = VariableAddress[d]                  : 
 #  851|     r0_6(glval<unknown>)               = FunctionAddress[PolymorphicDerived] : 
-#  851|     v0_7(void)                         = Invoke                              : r0_6, this:r0_5
+#  851|     v0_7(void)                         = Call                                : r0_6, this:r0_5
 #  853|     r0_8(glval<PolymorphicBase *>)     = VariableAddress[pb]                 : 
 #  853|     r0_9(glval<PolymorphicBase>)       = VariableAddress[b]                  : 
 #  853|     mu0_10(PolymorphicBase *)          = Store                               : r0_8, r0_9
@@ -3594,7 +3594,7 @@ ir.cpp:
 #  868|     r0_3(glval<unknown>) = FunctionAddress[String] : 
 #  868|     r0_4(glval<char[1]>) = StringConstant[""]      : 
 #  868|     r0_5(char *)         = Convert                 : r0_4
-#  868|     v0_6(void)           = Invoke                  : r0_3, this:r0_2, r0_5
+#  868|     v0_6(void)           = Call                    : r0_3, this:r0_2, r0_5
 #  869|     v0_7(void)           = NoOp                    : 
 #  867|     v0_8(void)           = ReturnVoid              : 
 #  867|     v0_9(void)           = UnmodeledUse            : mu*
@@ -3769,44 +3769,44 @@ ir.cpp:
 #  940|     mu0_1(unknown)        = UnmodeledDefinition           : 
 #  941|     r0_2(glval<unknown>)  = FunctionAddress[operator new] : 
 #  941|     r0_3(unsigned long)   = Constant[4]                   : 
-#  941|     r0_4(void *)          = Invoke                        : r0_2, r0_3
+#  941|     r0_4(void *)          = Call                          : r0_2, r0_3
 #  941|     r0_5(int *)           = Convert                       : r0_4
 #  942|     r0_6(glval<unknown>)  = FunctionAddress[operator new] : 
 #  942|     r0_7(unsigned long)   = Constant[4]                   : 
 #  942|     r0_8(float)           = Constant[1.0]                 : 
-#  942|     r0_9(void *)          = Invoke                        : r0_6, r0_7, r0_8
+#  942|     r0_9(void *)          = Call                          : r0_6, r0_7, r0_8
 #  942|     r0_10(int *)          = Convert                       : r0_9
 #  943|     r0_11(glval<unknown>) = FunctionAddress[operator new] : 
 #  943|     r0_12(unsigned long)  = Constant[4]                   : 
-#  943|     r0_13(void *)         = Invoke                        : r0_11, r0_12
+#  943|     r0_13(void *)         = Call                          : r0_11, r0_12
 #  943|     r0_14(int *)          = Convert                       : r0_13
 #  943|     r0_15(int)            = Constant[0]                   : 
 #  943|     mu0_16(int)           = Store                         : r0_14, r0_15
 #  944|     r0_17(glval<unknown>) = FunctionAddress[operator new] : 
 #  944|     r0_18(unsigned long)  = Constant[8]                   : 
-#  944|     r0_19(void *)         = Invoke                        : r0_17, r0_18
+#  944|     r0_19(void *)         = Call                          : r0_17, r0_18
 #  944|     r0_20(String *)       = Convert                       : r0_19
 #  944|     r0_21(glval<unknown>) = FunctionAddress[String]       : 
-#  944|     v0_22(void)           = Invoke                        : r0_21, this:r0_20
+#  944|     v0_22(void)           = Call                          : r0_21, this:r0_20
 #  945|     r0_23(glval<unknown>) = FunctionAddress[operator new] : 
 #  945|     r0_24(unsigned long)  = Constant[8]                   : 
 #  945|     r0_25(float)          = Constant[1.0]                 : 
-#  945|     r0_26(void *)         = Invoke                        : r0_23, r0_24, r0_25
+#  945|     r0_26(void *)         = Call                          : r0_23, r0_24, r0_25
 #  945|     r0_27(String *)       = Convert                       : r0_26
 #  945|     r0_28(glval<unknown>) = FunctionAddress[String]       : 
 #  945|     r0_29(glval<char[6]>) = StringConstant["hello"]       : 
 #  945|     r0_30(char *)         = Convert                       : r0_29
-#  945|     v0_31(void)           = Invoke                        : r0_28, this:r0_27, r0_30
+#  945|     v0_31(void)           = Call                          : r0_28, this:r0_27, r0_30
 #  946|     r0_32(glval<unknown>) = FunctionAddress[operator new] : 
 #  946|     r0_33(unsigned long)  = Constant[256]                 : 
 #  946|     r0_34(align_val_t)    = Constant[128]                 : 
-#  946|     r0_35(void *)         = Invoke                        : r0_32, r0_33, r0_34
+#  946|     r0_35(void *)         = Call                          : r0_32, r0_33, r0_34
 #  946|     r0_36(Overaligned *)  = Convert                       : r0_35
 #  947|     r0_37(glval<unknown>) = FunctionAddress[operator new] : 
 #  947|     r0_38(unsigned long)  = Constant[256]                 : 
 #  947|     r0_39(align_val_t)    = Constant[128]                 : 
 #  947|     r0_40(float)          = Constant[1.0]                 : 
-#  947|     r0_41(void *)         = Invoke                        : r0_37, r0_38, r0_39, r0_40
+#  947|     r0_41(void *)         = Call                          : r0_37, r0_38, r0_39, r0_40
 #  947|     r0_42(Overaligned *)  = Convert                       : r0_41
 #  947|     r0_43(Overaligned)    = Constant[0]                   : 
 #  947|     mu0_44(Overaligned)   = Store                         : r0_42, r0_43
@@ -3823,7 +3823,7 @@ ir.cpp:
 #  950|     mu0_3(int)                           = InitializeParameter[n]          : r0_2
 #  951|     r0_4(glval<unknown>)                 = FunctionAddress[operator new[]] : 
 #  951|     r0_5(unsigned long)                  = Constant[40]                    : 
-#  951|     r0_6(void *)                         = Invoke                          : r0_4, r0_5
+#  951|     r0_6(void *)                         = Call                            : r0_4, r0_5
 #  951|     r0_7(int *)                          = Convert                         : r0_6
 #  952|     r0_8(glval<unknown>)                 = FunctionAddress[operator new[]] : 
 #  952|     r0_9(glval<int>)                     = VariableAddress[n]              : 
@@ -3831,7 +3831,7 @@ ir.cpp:
 #  952|     r0_11(unsigned long)                 = Convert                         : r0_10
 #  952|     r0_12(unsigned long)                 = Constant[4]                     : 
 #  952|     r0_13(unsigned long)                 = Mul                             : r0_11, r0_12
-#  952|     r0_14(void *)                        = Invoke                          : r0_8, r0_13
+#  952|     r0_14(void *)                        = Call                            : r0_8, r0_13
 #  952|     r0_15(int *)                         = Convert                         : r0_14
 #  953|     r0_16(glval<unknown>)                = FunctionAddress[operator new[]] : 
 #  953|     r0_17(glval<int>)                    = VariableAddress[n]              : 
@@ -3840,7 +3840,7 @@ ir.cpp:
 #  953|     r0_20(unsigned long)                 = Constant[4]                     : 
 #  953|     r0_21(unsigned long)                 = Mul                             : r0_19, r0_20
 #  953|     r0_22(float)                         = Constant[1.0]                   : 
-#  953|     r0_23(void *)                        = Invoke                          : r0_16, r0_21, r0_22
+#  953|     r0_23(void *)                        = Call                            : r0_16, r0_21, r0_22
 #  953|     r0_24(int *)                         = Convert                         : r0_23
 #  954|     r0_25(glval<unknown>)                = FunctionAddress[operator new[]] : 
 #  954|     r0_26(glval<int>)                    = VariableAddress[n]              : 
@@ -3848,7 +3848,7 @@ ir.cpp:
 #  954|     r0_28(unsigned long)                 = Convert                         : r0_27
 #  954|     r0_29(unsigned long)                 = Constant[8]                     : 
 #  954|     r0_30(unsigned long)                 = Mul                             : r0_28, r0_29
-#  954|     r0_31(void *)                        = Invoke                          : r0_25, r0_30
+#  954|     r0_31(void *)                        = Call                            : r0_25, r0_30
 #  954|     r0_32(String *)                      = Convert                         : r0_31
 #  955|     r0_33(glval<unknown>)                = FunctionAddress[operator new[]] : 
 #  955|     r0_34(glval<int>)                    = VariableAddress[n]              : 
@@ -3857,13 +3857,13 @@ ir.cpp:
 #  955|     r0_37(unsigned long)                 = Constant[256]                   : 
 #  955|     r0_38(unsigned long)                 = Mul                             : r0_36, r0_37
 #  955|     r0_39(align_val_t)                   = Constant[128]                   : 
-#  955|     r0_40(void *)                        = Invoke                          : r0_33, r0_38, r0_39
+#  955|     r0_40(void *)                        = Call                            : r0_33, r0_38, r0_39
 #  955|     r0_41(Overaligned *)                 = Convert                         : r0_40
 #  956|     r0_42(glval<unknown>)                = FunctionAddress[operator new[]] : 
 #  956|     r0_43(unsigned long)                 = Constant[2560]                  : 
 #  956|     r0_44(align_val_t)                   = Constant[128]                   : 
 #  956|     r0_45(float)                         = Constant[1.0]                   : 
-#  956|     r0_46(void *)                        = Invoke                          : r0_42, r0_43, r0_44, r0_45
+#  956|     r0_46(void *)                        = Call                            : r0_42, r0_43, r0_44, r0_45
 #  956|     r0_47(Overaligned *)                 = Convert                         : r0_46
 #  957|     r0_48(glval<unknown>)                = FunctionAddress[operator new[]] : 
 #  957|     r0_49(glval<int>)                    = VariableAddress[n]              : 
@@ -3871,7 +3871,7 @@ ir.cpp:
 #  957|     r0_51(unsigned long)                 = Convert                         : r0_50
 #  957|     r0_52(unsigned long)                 = Constant[1]                     : 
 #  957|     r0_53(unsigned long)                 = Mul                             : r0_51, r0_52
-#  957|     r0_54(void *)                        = Invoke                          : r0_48, r0_53
+#  957|     r0_54(void *)                        = Call                            : r0_48, r0_53
 #  957|     r0_55(DefaultCtorWithDefaultParam *) = Convert                         : r0_54
 #  958|     r0_56(glval<unknown>)                = FunctionAddress[operator new[]] : 
 #  958|     r0_57(glval<int>)                    = VariableAddress[n]              : 
@@ -3879,7 +3879,7 @@ ir.cpp:
 #  958|     r0_59(unsigned long)                 = Convert                         : r0_58
 #  958|     r0_60(unsigned long)                 = Constant[4]                     : 
 #  958|     r0_61(unsigned long)                 = Mul                             : r0_59, r0_60
-#  958|     r0_62(void *)                        = Invoke                          : r0_56, r0_61
+#  958|     r0_62(void *)                        = Call                            : r0_56, r0_61
 #  958|     r0_63(int *)                         = Convert                         : r0_62
 #  959|     v0_64(void)                          = NoOp                            : 
 #  950|     v0_65(void)                          = ReturnVoid                      : 

--- a/cpp/ql/test/library-tests/ir/ir/ssa_ir.expected
+++ b/cpp/ql/test/library-tests/ir/ir/ssa_ir.expected
@@ -1559,7 +1559,7 @@ ir.cpp:
 #  372|     v0_0(void)           = EnterFunction             : 
 #  372|     mu0_1(unknown)       = UnmodeledDefinition       : 
 #  373|     r0_2(glval<unknown>) = FunctionAddress[VoidFunc] : 
-#  373|     v0_3(void)           = Invoke                    : r0_2
+#  373|     v0_3(void)           = Call                      : r0_2
 #  374|     v0_4(void)           = NoOp                      : 
 #  372|     v0_5(void)           = ReturnVoid                : 
 #  372|     v0_6(void)           = UnmodeledUse              : mu*
@@ -1579,7 +1579,7 @@ ir.cpp:
 #  377|     r0_9(int)            = Load                     : r0_8, m0_3
 #  377|     r0_10(glval<int>)    = VariableAddress[y]       : 
 #  377|     r0_11(int)           = Load                     : r0_10, m0_5
-#  377|     r0_12(int)           = Invoke                   : r0_7, r0_9, r0_11
+#  377|     r0_12(int)           = Call                     : r0_7, r0_9, r0_11
 #  377|     m0_13(int)           = Store                    : r0_6, r0_12
 #  376|     r0_14(glval<int>)    = VariableAddress[#return] : 
 #  376|     v0_15(void)          = ReturnValue              : r0_14, m0_13
@@ -1596,13 +1596,13 @@ ir.cpp:
 #  380|     m0_5(int)            = InitializeParameter[y]    : r0_4
 #  381|     r0_6(glval<int>)     = VariableAddress[#return]  : 
 #  381|     r0_7(glval<unknown>) = FunctionAddress[VoidFunc] : 
-#  381|     v0_8(void)           = Invoke                    : r0_7
+#  381|     v0_8(void)           = Call                      : r0_7
 #  381|     r0_9(glval<unknown>) = FunctionAddress[CallAdd]  : 
 #  381|     r0_10(glval<int>)    = VariableAddress[x]        : 
 #  381|     r0_11(int)           = Load                      : r0_10, m0_3
 #  381|     r0_12(glval<int>)    = VariableAddress[y]        : 
 #  381|     r0_13(int)           = Load                      : r0_12, m0_5
-#  381|     r0_14(int)           = Invoke                    : r0_9, r0_11, r0_13
+#  381|     r0_14(int)           = Call                      : r0_9, r0_11, r0_13
 #  381|     m0_15(int)           = Store                     : r0_6, r0_14
 #  380|     r0_16(glval<int>)    = VariableAddress[#return]  : 
 #  380|     v0_17(void)          = ReturnValue               : r0_16, m0_15
@@ -2114,12 +2114,12 @@ ir.cpp:
 
 #  493|   Block 2
 #  493|     r2_0(glval<unknown>) = FunctionAddress[VoidFunc] : 
-#  493|     v2_1(void)           = Invoke                    : r2_0
+#  493|     v2_1(void)           = Call                      : r2_0
 #-----|   Goto -> Block 1
 
 #  493|   Block 3
 #  493|     r3_0(glval<unknown>) = FunctionAddress[VoidFunc] : 
-#  493|     v3_1(void)           = Invoke                    : r3_0
+#  493|     v3_1(void)           = Call                      : r3_0
 #-----|   Goto -> Block 1
 
 #  496| Nullptr() -> void
@@ -2407,7 +2407,7 @@ ir.cpp:
 #  552|     r0_5(glval<..(*)(..)>) = VariableAddress[pfn]     : 
 #  552|     r0_6(..(*)(..))        = Load                     : r0_5, m0_3
 #  552|     r0_7(int)              = Constant[5]              : 
-#  552|     r0_8(int)              = Invoke                   : r0_6, r0_7
+#  552|     r0_8(int)              = Call                     : r0_6, r0_7
 #  552|     m0_9(int)              = Store                    : r0_4, r0_8
 #  551|     r0_10(glval<int>)      = VariableAddress[#return] : 
 #  551|     v0_11(void)            = ReturnValue              : r0_10, m0_9
@@ -2525,7 +2525,7 @@ ir.cpp:
 #  585|     r0_5(int)            = Constant[1]                     : 
 #  585|     r0_6(glval<char[7]>) = StringConstant["string"]        : 
 #  585|     r0_7(char *)         = Convert                         : r0_6
-#  585|     v0_8(void)           = Invoke                          : r0_2, r0_4, r0_5, r0_7
+#  585|     v0_8(void)           = Call                            : r0_2, r0_4, r0_5, r0_7
 #  586|     v0_9(void)           = NoOp                            : 
 #  584|     v0_10(void)          = ReturnVoid                      : 
 #  584|     v0_11(void)          = UnmodeledUse                    : mu*
@@ -2558,21 +2558,21 @@ ir.cpp:
 #  615|     mu0_1(unknown)        = UnmodeledDefinition           : 
 #  616|     r0_2(glval<String>)   = VariableAddress[s1]           : 
 #  616|     r0_3(glval<unknown>)  = FunctionAddress[String]       : 
-#  616|     v0_4(void)            = Invoke                        : r0_3, this:r0_2
+#  616|     v0_4(void)            = Call                          : r0_3, this:r0_2
 #  617|     r0_5(glval<String>)   = VariableAddress[s2]           : 
 #  617|     r0_6(glval<unknown>)  = FunctionAddress[String]       : 
 #  617|     r0_7(glval<char[6]>)  = StringConstant["hello"]       : 
 #  617|     r0_8(char *)          = Convert                       : r0_7
-#  617|     v0_9(void)            = Invoke                        : r0_6, this:r0_5, r0_8
+#  617|     v0_9(void)            = Call                          : r0_6, this:r0_5, r0_8
 #  618|     r0_10(glval<String>)  = VariableAddress[s3]           : 
 #  618|     r0_11(glval<unknown>) = FunctionAddress[ReturnObject] : 
-#  618|     r0_12(String)         = Invoke                        : r0_11
+#  618|     r0_12(String)         = Call                          : r0_11
 #  618|     m0_13(String)         = Store                         : r0_10, r0_12
 #  619|     r0_14(glval<String>)  = VariableAddress[s4]           : 
 #  619|     r0_15(glval<unknown>) = FunctionAddress[String]       : 
 #  619|     r0_16(glval<char[5]>) = StringConstant["test"]        : 
 #  619|     r0_17(char *)         = Convert                       : r0_16
-#  619|     v0_18(void)           = Invoke                        : r0_15, this:r0_14, r0_17
+#  619|     v0_18(void)           = Call                          : r0_15, this:r0_14, r0_17
 #  620|     v0_19(void)           = NoOp                          : 
 #  615|     v0_20(void)           = ReturnVoid                    : 
 #  615|     v0_21(void)           = UnmodeledUse                  : mu*
@@ -2592,16 +2592,16 @@ ir.cpp:
 #  623|     r0_9(String &)         = Load                   : r0_8, m0_3
 #  623|     r0_10(glval<String>)   = Convert                : r0_9
 #  623|     r0_11(glval<unknown>)  = FunctionAddress[c_str] : 
-#  623|     r0_12(char *)          = Invoke                 : r0_11, this:r0_10
+#  623|     r0_12(char *)          = Call                   : r0_11, this:r0_10
 #  624|     r0_13(glval<String *>) = VariableAddress[p]     : 
 #  624|     r0_14(String *)        = Load                   : r0_13, m0_5
 #  624|     r0_15(String *)        = Convert                : r0_14
 #  624|     r0_16(glval<unknown>)  = FunctionAddress[c_str] : 
-#  624|     r0_17(char *)          = Invoke                 : r0_16, this:r0_15
+#  624|     r0_17(char *)          = Call                   : r0_16, this:r0_15
 #  625|     r0_18(glval<String>)   = VariableAddress[s]     : 
 #  625|     r0_19(glval<String>)   = Convert                : r0_18
 #  625|     r0_20(glval<unknown>)  = FunctionAddress[c_str] : 
-#  625|     r0_21(char *)          = Invoke                 : r0_20, this:r0_19
+#  625|     r0_21(char *)          = Call                   : r0_20, this:r0_19
 #  626|     v0_22(void)            = NoOp                   : 
 #  622|     v0_23(void)            = ReturnVoid             : 
 #  622|     v0_24(void)            = UnmodeledUse           : mu*
@@ -2701,15 +2701,15 @@ ir.cpp:
 #  653|     r0_3(C *)             = CopyValue                               : r0_2
 #  653|     r0_4(glval<unknown>)  = FunctionAddress[InstanceMemberFunction] : 
 #  653|     r0_5(int)             = Constant[0]                             : 
-#  653|     r0_6(int)             = Invoke                                  : r0_4, this:r0_3, r0_5
+#  653|     r0_6(int)             = Call                                    : r0_4, this:r0_3, r0_5
 #  654|     r0_7(C *)             = CopyValue                               : r0_2
 #  654|     r0_8(glval<unknown>)  = FunctionAddress[InstanceMemberFunction] : 
 #  654|     r0_9(int)             = Constant[1]                             : 
-#  654|     r0_10(int)            = Invoke                                  : r0_8, this:r0_7, r0_9
+#  654|     r0_10(int)            = Call                                    : r0_8, this:r0_7, r0_9
 #-----|     r0_11(C *)            = CopyValue                               : r0_2
 #  655|     r0_12(glval<unknown>) = FunctionAddress[InstanceMemberFunction] : 
 #  655|     r0_13(int)            = Constant[2]                             : 
-#  655|     r0_14(int)            = Invoke                                  : r0_12, this:r0_11, r0_13
+#  655|     r0_14(int)            = Call                                    : r0_12, this:r0_11, r0_13
 #  656|     v0_15(void)           = NoOp                                    : 
 #  652|     v0_16(void)           = ReturnVoid                              : 
 #  652|     v0_17(void)           = UnmodeledUse                            : mu*
@@ -2725,7 +2725,7 @@ ir.cpp:
 #  659|     mu0_5(int)            = Store                   : r0_3, r0_4
 #  663|     r0_6(glval<String>)   = FieldAddress[m_b]       : r0_2
 #  663|     r0_7(glval<unknown>)  = FunctionAddress[String] : 
-#  663|     v0_8(void)            = Invoke                  : r0_7, this:r0_6
+#  663|     v0_8(void)            = Call                    : r0_7, this:r0_6
 #  660|     r0_9(glval<char>)     = FieldAddress[m_c]       : r0_2
 #  660|     r0_10(char)           = Constant[3]             : 
 #  660|     mu0_11(char)          = Store                   : r0_9, r0_10
@@ -2736,7 +2736,7 @@ ir.cpp:
 #  662|     r0_16(glval<unknown>) = FunctionAddress[String] : 
 #  662|     r0_17(glval<char[5]>) = StringConstant["test"]  : 
 #  662|     r0_18(char *)         = Convert                 : r0_17
-#  662|     v0_19(void)           = Invoke                  : r0_16, this:r0_15, r0_18
+#  662|     v0_19(void)           = Call                    : r0_16, this:r0_15, r0_18
 #  664|     v0_20(void)           = NoOp                    : 
 #  658|     v0_21(void)           = ReturnVoid              : 
 #  658|     v0_22(void)           = UnmodeledUse            : mu*
@@ -2785,7 +2785,7 @@ ir.cpp:
 #  687|     m0_10(int &)           = Store                            : r0_7, r0_9
 #  688|     r0_11(glval<String &>) = VariableAddress[r3]              : 
 #  688|     r0_12(glval<unknown>)  = FunctionAddress[ReturnReference] : 
-#  688|     r0_13(String &)        = Invoke                           : r0_12
+#  688|     r0_13(String &)        = Call                             : r0_12
 #  688|     r0_14(glval<String>)   = Convert                          : r0_13
 #  688|     m0_15(String &)        = Store                            : r0_11, r0_14
 #  689|     v0_16(void)            = NoOp                             : 
@@ -2829,7 +2829,7 @@ ir.cpp:
 #  700|     r0_9(glval<..(&)(..)>) = VariableAddress[rfn]           : 
 #  700|     r0_10(..(&)(..))       = Load                           : r0_9, m0_4
 #  700|     r0_11(int)             = Constant[5]                    : 
-#  700|     r0_12(int)             = Invoke                         : r0_10, r0_11
+#  700|     r0_12(int)             = Call                           : r0_10, r0_11
 #  701|     v0_13(void)            = NoOp                           : 
 #  697|     v0_14(void)            = ReturnVoid                     : 
 #  697|     v0_15(void)            = UnmodeledUse                   : mu*
@@ -2891,7 +2891,7 @@ ir.cpp:
 #  709|     r0_9(int)            = Load                     : r0_8, m0_3
 #  709|     r0_10(glval<int>)    = VariableAddress[y]       : 
 #  709|     r0_11(int)           = Load                     : r0_10, m0_5
-#  709|     r0_12(int)           = Invoke                   : r0_7, r0_9, r0_11
+#  709|     r0_12(int)           = Call                     : r0_7, r0_9, r0_11
 #  709|     m0_13(int)           = Store                    : r0_6, r0_12
 #  708|     r0_14(glval<int>)    = VariableAddress[#return] : 
 #  708|     v0_15(void)          = ReturnValue              : r0_14, m0_13
@@ -2922,7 +2922,7 @@ ir.cpp:
 #  721|     r0_3(glval<unknown>) = FunctionAddress[Func]    : 
 #  721|     r0_4(void *)         = Constant[0]              : 
 #  721|     r0_5(char)           = Constant[111]            : 
-#  721|     r0_6(long)           = Invoke                   : r0_3, r0_4, r0_5
+#  721|     r0_6(long)           = Call                     : r0_3, r0_4, r0_5
 #  721|     r0_7(double)         = Convert                  : r0_6
 #  721|     m0_8(double)         = Store                    : r0_2, r0_7
 #  720|     r0_9(glval<double>)  = VariableAddress[#return] : 
@@ -2992,7 +2992,7 @@ ir.cpp:
 #  731|     r7_1(glval<unknown>)  = FunctionAddress[String]         : 
 #  731|     r7_2(glval<char[14]>) = StringConstant["String object"] : 
 #  731|     r7_3(char *)          = Convert                         : r7_2
-#  731|     v7_4(void)            = Invoke                          : r7_1, this:r7_0, r7_3
+#  731|     v7_4(void)            = Call                            : r7_1, this:r7_0, r7_3
 #  731|     v7_5(void)            = ThrowValue                      : r7_0, mu0_1
 #-----|   Exception -> Block 9
 
@@ -3014,7 +3014,7 @@ ir.cpp:
 #  736|     r10_3(glval<unknown>) = FunctionAddress[String]      : 
 #  736|     r10_4(glval<char *>)  = VariableAddress[s]           : 
 #  736|     r10_5(char *)         = Load                         : r10_4, m10_1
-#  736|     v10_6(void)           = Invoke                       : r10_3, this:r10_2, r10_5
+#  736|     v10_6(void)           = Call                         : r10_3, this:r10_2, r10_5
 #  736|     v10_7(void)           = ThrowValue                   : r10_2, mu0_1
 #-----|   Exception -> Block 2
 
@@ -3048,7 +3048,7 @@ ir.cpp:
 #-----|     m0_4(Base &)         = InitializeParameter[p#0] : r0_3
 #  745|     r0_5(glval<String>)  = FieldAddress[base_s]     : r0_2
 #  745|     r0_6(glval<unknown>) = FunctionAddress[String]  : 
-#  745|     v0_7(void)           = Invoke                   : r0_6, this:r0_5
+#  745|     v0_7(void)           = Call                     : r0_6, this:r0_5
 #  745|     v0_8(void)           = NoOp                     : 
 #  745|     v0_9(void)           = ReturnVoid               : 
 #  745|     v0_10(void)          = UnmodeledUse             : mu*
@@ -3067,7 +3067,7 @@ ir.cpp:
 #-----|     r0_8(glval<Base &>)  = VariableAddress[p#0]       : 
 #-----|     r0_9(Base &)         = Load                       : r0_8, m0_4
 #-----|     r0_10(glval<String>) = FieldAddress[base_s]       : r0_9
-#  745|     r0_11(String &)      = Invoke                     : r0_7, this:r0_6, r0_10
+#  745|     r0_11(String &)      = Call                       : r0_7, this:r0_6, r0_10
 #-----|     r0_12(glval<Base &>) = VariableAddress[#return]   : 
 #-----|     r0_13(Base *)        = CopyValue                  : r0_2
 #-----|     m0_14(Base &)        = Store                      : r0_12, r0_13
@@ -3083,7 +3083,7 @@ ir.cpp:
 #  748|     r0_2(glval<Base>)    = InitializeThis          : 
 #  748|     r0_3(glval<String>)  = FieldAddress[base_s]    : r0_2
 #  748|     r0_4(glval<unknown>) = FunctionAddress[String] : 
-#  748|     v0_5(void)           = Invoke                  : r0_4, this:r0_3
+#  748|     v0_5(void)           = Call                    : r0_4, this:r0_3
 #  749|     v0_6(void)           = NoOp                    : 
 #  748|     v0_7(void)           = ReturnVoid              : 
 #  748|     v0_8(void)           = UnmodeledUse            : mu*
@@ -3097,7 +3097,7 @@ ir.cpp:
 #  751|     v0_3(void)           = NoOp                     : 
 #  751|     r0_4(glval<String>)  = FieldAddress[base_s]     : r0_2
 #  751|     r0_5(glval<unknown>) = FunctionAddress[~String] : 
-#  751|     v0_6(void)           = Invoke                   : r0_5, this:r0_4
+#  751|     v0_6(void)           = Call                     : r0_5, this:r0_4
 #  750|     v0_7(void)           = ReturnVoid               : 
 #  750|     v0_8(void)           = UnmodeledUse             : mu*
 #  750|     v0_9(void)           = ExitFunction             : 
@@ -3115,14 +3115,14 @@ ir.cpp:
 #-----|     r0_8(glval<Middle &>)  = VariableAddress[p#0]         : 
 #-----|     r0_9(Middle &)         = Load                         : r0_8, m0_4
 #-----|     r0_10(Base *)          = ConvertToBase[Middle : Base] : r0_9
-#  754|     r0_11(Base &)          = Invoke                       : r0_7, this:r0_6, r0_10
+#  754|     r0_11(Base &)          = Call                         : r0_7, this:r0_6, r0_10
 #-----|     r0_12(Middle *)        = CopyValue                    : r0_2
 #-----|     r0_13(glval<String>)   = FieldAddress[middle_s]       : r0_12
 #  754|     r0_14(glval<unknown>)  = FunctionAddress[operator=]   : 
 #-----|     r0_15(glval<Middle &>) = VariableAddress[p#0]         : 
 #-----|     r0_16(Middle &)        = Load                         : r0_15, m0_4
 #-----|     r0_17(glval<String>)   = FieldAddress[middle_s]       : r0_16
-#  754|     r0_18(String &)        = Invoke                       : r0_14, this:r0_13, r0_17
+#  754|     r0_18(String &)        = Call                         : r0_14, this:r0_13, r0_17
 #-----|     r0_19(glval<Middle &>) = VariableAddress[#return]     : 
 #-----|     r0_20(Middle *)        = CopyValue                    : r0_2
 #-----|     m0_21(Middle &)        = Store                        : r0_19, r0_20
@@ -3138,10 +3138,10 @@ ir.cpp:
 #  757|     r0_2(glval<Middle>)  = InitializeThis               : 
 #  757|     r0_3(glval<Base>)    = ConvertToBase[Middle : Base] : r0_2
 #  757|     r0_4(glval<unknown>) = FunctionAddress[Base]        : 
-#  757|     v0_5(void)           = Invoke                       : r0_4, this:r0_3
+#  757|     v0_5(void)           = Call                         : r0_4, this:r0_3
 #  757|     r0_6(glval<String>)  = FieldAddress[middle_s]       : r0_2
 #  757|     r0_7(glval<unknown>) = FunctionAddress[String]      : 
-#  757|     v0_8(void)           = Invoke                       : r0_7, this:r0_6
+#  757|     v0_8(void)           = Call                         : r0_7, this:r0_6
 #  758|     v0_9(void)           = NoOp                         : 
 #  757|     v0_10(void)          = ReturnVoid                   : 
 #  757|     v0_11(void)          = UnmodeledUse                 : mu*
@@ -3155,10 +3155,10 @@ ir.cpp:
 #  760|     v0_3(void)           = NoOp                         : 
 #  760|     r0_4(glval<String>)  = FieldAddress[middle_s]       : r0_2
 #  760|     r0_5(glval<unknown>) = FunctionAddress[~String]     : 
-#  760|     v0_6(void)           = Invoke                       : r0_5, this:r0_4
+#  760|     v0_6(void)           = Call                         : r0_5, this:r0_4
 #  760|     r0_7(glval<Base>)    = ConvertToBase[Middle : Base] : r0_2
 #  760|     r0_8(glval<unknown>) = FunctionAddress[~Base]       : 
-#  760|     v0_9(void)           = Invoke                       : r0_8, this:r0_7
+#  760|     v0_9(void)           = Call                         : r0_8, this:r0_7
 #  759|     v0_10(void)          = ReturnVoid                   : 
 #  759|     v0_11(void)          = UnmodeledUse                 : mu*
 #  759|     v0_12(void)          = ExitFunction                 : 
@@ -3176,14 +3176,14 @@ ir.cpp:
 #-----|     r0_8(glval<Derived &>)  = VariableAddress[p#0]            : 
 #-----|     r0_9(Derived &)         = Load                            : r0_8, m0_4
 #-----|     r0_10(Middle *)         = ConvertToBase[Derived : Middle] : r0_9
-#  763|     r0_11(Middle &)         = Invoke                          : r0_7, this:r0_6, r0_10
+#  763|     r0_11(Middle &)         = Call                            : r0_7, this:r0_6, r0_10
 #-----|     r0_12(Derived *)        = CopyValue                       : r0_2
 #-----|     r0_13(glval<String>)    = FieldAddress[derived_s]         : r0_12
 #  763|     r0_14(glval<unknown>)   = FunctionAddress[operator=]      : 
 #-----|     r0_15(glval<Derived &>) = VariableAddress[p#0]            : 
 #-----|     r0_16(Derived &)        = Load                            : r0_15, m0_4
 #-----|     r0_17(glval<String>)    = FieldAddress[derived_s]         : r0_16
-#  763|     r0_18(String &)         = Invoke                          : r0_14, this:r0_13, r0_17
+#  763|     r0_18(String &)         = Call                            : r0_14, this:r0_13, r0_17
 #-----|     r0_19(glval<Derived &>) = VariableAddress[#return]        : 
 #-----|     r0_20(Derived *)        = CopyValue                       : r0_2
 #-----|     m0_21(Derived &)        = Store                           : r0_19, r0_20
@@ -3199,10 +3199,10 @@ ir.cpp:
 #  766|     r0_2(glval<Derived>) = InitializeThis                  : 
 #  766|     r0_3(glval<Middle>)  = ConvertToBase[Derived : Middle] : r0_2
 #  766|     r0_4(glval<unknown>) = FunctionAddress[Middle]         : 
-#  766|     v0_5(void)           = Invoke                          : r0_4, this:r0_3
+#  766|     v0_5(void)           = Call                            : r0_4, this:r0_3
 #  766|     r0_6(glval<String>)  = FieldAddress[derived_s]         : r0_2
 #  766|     r0_7(glval<unknown>) = FunctionAddress[String]         : 
-#  766|     v0_8(void)           = Invoke                          : r0_7, this:r0_6
+#  766|     v0_8(void)           = Call                            : r0_7, this:r0_6
 #  767|     v0_9(void)           = NoOp                            : 
 #  766|     v0_10(void)          = ReturnVoid                      : 
 #  766|     v0_11(void)          = UnmodeledUse                    : mu*
@@ -3216,10 +3216,10 @@ ir.cpp:
 #  769|     v0_3(void)           = NoOp                            : 
 #  769|     r0_4(glval<String>)  = FieldAddress[derived_s]         : r0_2
 #  769|     r0_5(glval<unknown>) = FunctionAddress[~String]        : 
-#  769|     v0_6(void)           = Invoke                          : r0_5, this:r0_4
+#  769|     v0_6(void)           = Call                            : r0_5, this:r0_4
 #  769|     r0_7(glval<Middle>)  = ConvertToBase[Derived : Middle] : r0_2
 #  769|     r0_8(glval<unknown>) = FunctionAddress[~Middle]        : 
-#  769|     v0_9(void)           = Invoke                          : r0_8, this:r0_7
+#  769|     v0_9(void)           = Call                            : r0_8, this:r0_7
 #  768|     v0_10(void)          = ReturnVoid                      : 
 #  768|     v0_11(void)          = UnmodeledUse                    : mu*
 #  768|     v0_12(void)          = ExitFunction                    : 
@@ -3231,10 +3231,10 @@ ir.cpp:
 #  775|     r0_2(glval<MiddleVB1>) = InitializeThis                  : 
 #  775|     r0_3(glval<Base>)      = ConvertToBase[MiddleVB1 : Base] : r0_2
 #  775|     r0_4(glval<unknown>)   = FunctionAddress[Base]           : 
-#  775|     v0_5(void)             = Invoke                          : r0_4, this:r0_3
+#  775|     v0_5(void)             = Call                            : r0_4, this:r0_3
 #  775|     r0_6(glval<String>)    = FieldAddress[middlevb1_s]       : r0_2
 #  775|     r0_7(glval<unknown>)   = FunctionAddress[String]         : 
-#  775|     v0_8(void)             = Invoke                          : r0_7, this:r0_6
+#  775|     v0_8(void)             = Call                            : r0_7, this:r0_6
 #  776|     v0_9(void)             = NoOp                            : 
 #  775|     v0_10(void)            = ReturnVoid                      : 
 #  775|     v0_11(void)            = UnmodeledUse                    : mu*
@@ -3248,10 +3248,10 @@ ir.cpp:
 #  778|     v0_3(void)             = NoOp                            : 
 #  778|     r0_4(glval<String>)    = FieldAddress[middlevb1_s]       : r0_2
 #  778|     r0_5(glval<unknown>)   = FunctionAddress[~String]        : 
-#  778|     v0_6(void)             = Invoke                          : r0_5, this:r0_4
+#  778|     v0_6(void)             = Call                            : r0_5, this:r0_4
 #  778|     r0_7(glval<Base>)      = ConvertToBase[MiddleVB1 : Base] : r0_2
 #  778|     r0_8(glval<unknown>)   = FunctionAddress[~Base]          : 
-#  778|     v0_9(void)             = Invoke                          : r0_8, this:r0_7
+#  778|     v0_9(void)             = Call                            : r0_8, this:r0_7
 #  777|     v0_10(void)            = ReturnVoid                      : 
 #  777|     v0_11(void)            = UnmodeledUse                    : mu*
 #  777|     v0_12(void)            = ExitFunction                    : 
@@ -3263,10 +3263,10 @@ ir.cpp:
 #  784|     r0_2(glval<MiddleVB2>) = InitializeThis                  : 
 #  784|     r0_3(glval<Base>)      = ConvertToBase[MiddleVB2 : Base] : r0_2
 #  784|     r0_4(glval<unknown>)   = FunctionAddress[Base]           : 
-#  784|     v0_5(void)             = Invoke                          : r0_4, this:r0_3
+#  784|     v0_5(void)             = Call                            : r0_4, this:r0_3
 #  784|     r0_6(glval<String>)    = FieldAddress[middlevb2_s]       : r0_2
 #  784|     r0_7(glval<unknown>)   = FunctionAddress[String]         : 
-#  784|     v0_8(void)             = Invoke                          : r0_7, this:r0_6
+#  784|     v0_8(void)             = Call                            : r0_7, this:r0_6
 #  785|     v0_9(void)             = NoOp                            : 
 #  784|     v0_10(void)            = ReturnVoid                      : 
 #  784|     v0_11(void)            = UnmodeledUse                    : mu*
@@ -3280,10 +3280,10 @@ ir.cpp:
 #  787|     v0_3(void)             = NoOp                            : 
 #  787|     r0_4(glval<String>)    = FieldAddress[middlevb2_s]       : r0_2
 #  787|     r0_5(glval<unknown>)   = FunctionAddress[~String]        : 
-#  787|     v0_6(void)             = Invoke                          : r0_5, this:r0_4
+#  787|     v0_6(void)             = Call                            : r0_5, this:r0_4
 #  787|     r0_7(glval<Base>)      = ConvertToBase[MiddleVB2 : Base] : r0_2
 #  787|     r0_8(glval<unknown>)   = FunctionAddress[~Base]          : 
-#  787|     v0_9(void)             = Invoke                          : r0_8, this:r0_7
+#  787|     v0_9(void)             = Call                            : r0_8, this:r0_7
 #  786|     v0_10(void)            = ReturnVoid                      : 
 #  786|     v0_11(void)            = UnmodeledUse                    : mu*
 #  786|     v0_12(void)            = ExitFunction                    : 
@@ -3295,16 +3295,16 @@ ir.cpp:
 #  793|     r0_2(glval<DerivedVB>) = InitializeThis                       : 
 #  793|     r0_3(glval<Base>)      = ConvertToBase[DerivedVB : Base]      : r0_2
 #  793|     r0_4(glval<unknown>)   = FunctionAddress[Base]                : 
-#  793|     v0_5(void)             = Invoke                               : r0_4, this:r0_3
+#  793|     v0_5(void)             = Call                                 : r0_4, this:r0_3
 #  793|     r0_6(glval<MiddleVB1>) = ConvertToBase[DerivedVB : MiddleVB1] : r0_2
 #  793|     r0_7(glval<unknown>)   = FunctionAddress[MiddleVB1]           : 
-#  793|     v0_8(void)             = Invoke                               : r0_7, this:r0_6
+#  793|     v0_8(void)             = Call                                 : r0_7, this:r0_6
 #  793|     r0_9(glval<MiddleVB2>) = ConvertToBase[DerivedVB : MiddleVB2] : r0_2
 #  793|     r0_10(glval<unknown>)  = FunctionAddress[MiddleVB2]           : 
-#  793|     v0_11(void)            = Invoke                               : r0_10, this:r0_9
+#  793|     v0_11(void)            = Call                                 : r0_10, this:r0_9
 #  793|     r0_12(glval<String>)   = FieldAddress[derivedvb_s]            : r0_2
 #  793|     r0_13(glval<unknown>)  = FunctionAddress[String]              : 
-#  793|     v0_14(void)            = Invoke                               : r0_13, this:r0_12
+#  793|     v0_14(void)            = Call                                 : r0_13, this:r0_12
 #  794|     v0_15(void)            = NoOp                                 : 
 #  793|     v0_16(void)            = ReturnVoid                           : 
 #  793|     v0_17(void)            = UnmodeledUse                         : mu*
@@ -3318,16 +3318,16 @@ ir.cpp:
 #  796|     v0_3(void)              = NoOp                                 : 
 #  796|     r0_4(glval<String>)     = FieldAddress[derivedvb_s]            : r0_2
 #  796|     r0_5(glval<unknown>)    = FunctionAddress[~String]             : 
-#  796|     v0_6(void)              = Invoke                               : r0_5, this:r0_4
+#  796|     v0_6(void)              = Call                                 : r0_5, this:r0_4
 #  796|     r0_7(glval<MiddleVB2>)  = ConvertToBase[DerivedVB : MiddleVB2] : r0_2
 #  796|     r0_8(glval<unknown>)    = FunctionAddress[~MiddleVB2]          : 
-#  796|     v0_9(void)              = Invoke                               : r0_8, this:r0_7
+#  796|     v0_9(void)              = Call                                 : r0_8, this:r0_7
 #  796|     r0_10(glval<MiddleVB1>) = ConvertToBase[DerivedVB : MiddleVB1] : r0_2
 #  796|     r0_11(glval<unknown>)   = FunctionAddress[~MiddleVB1]          : 
-#  796|     v0_12(void)             = Invoke                               : r0_11, this:r0_10
+#  796|     v0_12(void)             = Call                                 : r0_11, this:r0_10
 #  796|     r0_13(glval<Base>)      = ConvertToBase[DerivedVB : Base]      : r0_2
 #  796|     r0_14(glval<unknown>)   = FunctionAddress[~Base]               : 
-#  796|     v0_15(void)             = Invoke                               : r0_14, this:r0_13
+#  796|     v0_15(void)             = Call                                 : r0_14, this:r0_13
 #  795|     v0_16(void)             = ReturnVoid                           : 
 #  795|     v0_17(void)             = UnmodeledUse                         : mu*
 #  795|     v0_18(void)             = ExitFunction                         : 
@@ -3338,13 +3338,13 @@ ir.cpp:
 #  799|     mu0_1(unknown)             = UnmodeledDefinition                    : 
 #  800|     r0_2(glval<Base>)          = VariableAddress[b]                     : 
 #  800|     r0_3(glval<unknown>)       = FunctionAddress[Base]                  : 
-#  800|     v0_4(void)                 = Invoke                                 : r0_3, this:r0_2
+#  800|     v0_4(void)                 = Call                                   : r0_3, this:r0_2
 #  801|     r0_5(glval<Middle>)        = VariableAddress[m]                     : 
 #  801|     r0_6(glval<unknown>)       = FunctionAddress[Middle]                : 
-#  801|     v0_7(void)                 = Invoke                                 : r0_6, this:r0_5
+#  801|     v0_7(void)                 = Call                                   : r0_6, this:r0_5
 #  802|     r0_8(glval<Derived>)       = VariableAddress[d]                     : 
 #  802|     r0_9(glval<unknown>)       = FunctionAddress[Derived]               : 
-#  802|     v0_10(void)                = Invoke                                 : r0_9, this:r0_8
+#  802|     v0_10(void)                = Call                                   : r0_9, this:r0_8
 #  804|     r0_11(glval<Base *>)       = VariableAddress[pb]                    : 
 #  804|     r0_12(glval<Base>)         = VariableAddress[b]                     : 
 #  804|     m0_13(Base *)              = Store                                  : r0_11, r0_12
@@ -3358,23 +3358,23 @@ ir.cpp:
 #  808|     r0_21(glval<unknown>)      = FunctionAddress[operator=]             : 
 #  808|     r0_22(glval<Middle>)       = VariableAddress[m]                     : 
 #  808|     r0_23(glval<Base>)         = ConvertToBase[Middle : Base]           : r0_22
-#  808|     r0_24(Base &)              = Invoke                                 : r0_21, this:r0_20, r0_23
+#  808|     r0_24(Base &)              = Call                                   : r0_21, this:r0_20, r0_23
 #  809|     r0_25(glval<Base>)         = VariableAddress[b]                     : 
 #  809|     r0_26(glval<unknown>)      = FunctionAddress[operator=]             : 
 #  809|     r0_27(glval<unknown>)      = FunctionAddress[Base]                  : 
 #  809|     r0_28(glval<Middle>)       = VariableAddress[m]                     : 
 #  809|     r0_29(glval<Base>)         = ConvertToBase[Middle : Base]           : r0_28
-#  809|     v0_30(void)                = Invoke                                 : r0_27, r0_29
+#  809|     v0_30(void)                = Call                                   : r0_27, r0_29
 #  809|     r0_31(Base)                = Convert                                : v0_30
-#  809|     r0_32(Base &)              = Invoke                                 : r0_26, this:r0_25, r0_31
+#  809|     r0_32(Base &)              = Call                                   : r0_26, this:r0_25, r0_31
 #  810|     r0_33(glval<Base>)         = VariableAddress[b]                     : 
 #  810|     r0_34(glval<unknown>)      = FunctionAddress[operator=]             : 
 #  810|     r0_35(glval<unknown>)      = FunctionAddress[Base]                  : 
 #  810|     r0_36(glval<Middle>)       = VariableAddress[m]                     : 
 #  810|     r0_37(glval<Base>)         = ConvertToBase[Middle : Base]           : r0_36
-#  810|     v0_38(void)                = Invoke                                 : r0_35, r0_37
+#  810|     v0_38(void)                = Call                                   : r0_35, r0_37
 #  810|     r0_39(Base)                = Convert                                : v0_38
-#  810|     r0_40(Base &)              = Invoke                                 : r0_34, this:r0_33, r0_39
+#  810|     r0_40(Base &)              = Call                                   : r0_34, this:r0_33, r0_39
 #  811|     r0_41(glval<Middle *>)     = VariableAddress[pm]                    : 
 #  811|     r0_42(Middle *)            = Load                                   : r0_41, m0_16
 #  811|     r0_43(Base *)              = ConvertToBase[Middle : Base]           : r0_42
@@ -3400,13 +3400,13 @@ ir.cpp:
 #  816|     r0_63(glval<Base>)         = VariableAddress[b]                     : 
 #  816|     r0_64(glval<Middle>)       = ConvertToDerived[Middle : Base]        : r0_63
 #  816|     r0_65(glval<Middle>)       = Convert                                : r0_64
-#  816|     r0_66(Middle &)            = Invoke                                 : r0_62, this:r0_61, r0_65
+#  816|     r0_66(Middle &)            = Call                                   : r0_62, this:r0_61, r0_65
 #  817|     r0_67(glval<Middle>)       = VariableAddress[m]                     : 
 #  817|     r0_68(glval<unknown>)      = FunctionAddress[operator=]             : 
 #  817|     r0_69(glval<Base>)         = VariableAddress[b]                     : 
 #  817|     r0_70(glval<Middle>)       = ConvertToDerived[Middle : Base]        : r0_69
 #  817|     r0_71(glval<Middle>)       = Convert                                : r0_70
-#  817|     r0_72(Middle &)            = Invoke                                 : r0_68, this:r0_67, r0_71
+#  817|     r0_72(Middle &)            = Call                                   : r0_68, this:r0_67, r0_71
 #  818|     r0_73(glval<Base *>)       = VariableAddress[pb]                    : 
 #  818|     r0_74(Base *)              = Load                                   : r0_73, m0_60
 #  818|     r0_75(Middle *)            = ConvertToDerived[Middle : Base]        : r0_74
@@ -3427,25 +3427,25 @@ ir.cpp:
 #  822|     r0_90(glval<Derived>)      = VariableAddress[d]                     : 
 #  822|     r0_91(glval<Middle>)       = ConvertToBase[Derived : Middle]        : r0_90
 #  822|     r0_92(glval<Base>)         = ConvertToBase[Middle : Base]           : r0_91
-#  822|     r0_93(Base &)              = Invoke                                 : r0_89, this:r0_88, r0_92
+#  822|     r0_93(Base &)              = Call                                   : r0_89, this:r0_88, r0_92
 #  823|     r0_94(glval<Base>)         = VariableAddress[b]                     : 
 #  823|     r0_95(glval<unknown>)      = FunctionAddress[operator=]             : 
 #  823|     r0_96(glval<unknown>)      = FunctionAddress[Base]                  : 
 #  823|     r0_97(glval<Derived>)      = VariableAddress[d]                     : 
 #  823|     r0_98(glval<Middle>)       = ConvertToBase[Derived : Middle]        : r0_97
 #  823|     r0_99(glval<Base>)         = ConvertToBase[Middle : Base]           : r0_98
-#  823|     v0_100(void)               = Invoke                                 : r0_96, r0_99
+#  823|     v0_100(void)               = Call                                   : r0_96, r0_99
 #  823|     r0_101(Base)               = Convert                                : v0_100
-#  823|     r0_102(Base &)             = Invoke                                 : r0_95, this:r0_94, r0_101
+#  823|     r0_102(Base &)             = Call                                   : r0_95, this:r0_94, r0_101
 #  824|     r0_103(glval<Base>)        = VariableAddress[b]                     : 
 #  824|     r0_104(glval<unknown>)     = FunctionAddress[operator=]             : 
 #  824|     r0_105(glval<unknown>)     = FunctionAddress[Base]                  : 
 #  824|     r0_106(glval<Derived>)     = VariableAddress[d]                     : 
 #  824|     r0_107(glval<Middle>)      = ConvertToBase[Derived : Middle]        : r0_106
 #  824|     r0_108(glval<Base>)        = ConvertToBase[Middle : Base]           : r0_107
-#  824|     v0_109(void)               = Invoke                                 : r0_105, r0_108
+#  824|     v0_109(void)               = Call                                   : r0_105, r0_108
 #  824|     r0_110(Base)               = Convert                                : v0_109
-#  824|     r0_111(Base &)             = Invoke                                 : r0_104, this:r0_103, r0_110
+#  824|     r0_111(Base &)             = Call                                   : r0_104, this:r0_103, r0_110
 #  825|     r0_112(glval<Derived *>)   = VariableAddress[pd]                    : 
 #  825|     r0_113(Derived *)          = Load                                   : r0_112, m0_19
 #  825|     r0_114(Middle *)           = ConvertToBase[Derived : Middle]        : r0_113
@@ -3475,14 +3475,14 @@ ir.cpp:
 #  830|     r0_138(glval<Middle>)      = ConvertToDerived[Middle : Base]        : r0_137
 #  830|     r0_139(glval<Derived>)     = ConvertToDerived[Derived : Middle]     : r0_138
 #  830|     r0_140(glval<Derived>)     = Convert                                : r0_139
-#  830|     r0_141(Derived &)          = Invoke                                 : r0_136, this:r0_135, r0_140
+#  830|     r0_141(Derived &)          = Call                                   : r0_136, this:r0_135, r0_140
 #  831|     r0_142(glval<Derived>)     = VariableAddress[d]                     : 
 #  831|     r0_143(glval<unknown>)     = FunctionAddress[operator=]             : 
 #  831|     r0_144(glval<Base>)        = VariableAddress[b]                     : 
 #  831|     r0_145(glval<Middle>)      = ConvertToDerived[Middle : Base]        : r0_144
 #  831|     r0_146(glval<Derived>)     = ConvertToDerived[Derived : Middle]     : r0_145
 #  831|     r0_147(glval<Derived>)     = Convert                                : r0_146
-#  831|     r0_148(Derived &)          = Invoke                                 : r0_143, this:r0_142, r0_147
+#  831|     r0_148(Derived &)          = Call                                   : r0_143, this:r0_142, r0_147
 #  832|     r0_149(glval<Base *>)      = VariableAddress[pb]                    : 
 #  832|     r0_150(Base *)             = Load                                   : r0_149, m0_134
 #  832|     r0_151(Middle *)           = ConvertToDerived[Middle : Base]        : r0_150
@@ -3538,7 +3538,7 @@ ir.cpp:
 #  846|     r0_2(glval<PolymorphicDerived>) = InitializeThis                                      : 
 #  846|     r0_3(glval<PolymorphicBase>)    = ConvertToBase[PolymorphicDerived : PolymorphicBase] : r0_2
 #  846|     r0_4(glval<unknown>)            = FunctionAddress[PolymorphicBase]                    : 
-#  846|     v0_5(void)                      = Invoke                                              : r0_4, this:r0_3
+#  846|     v0_5(void)                      = Call                                                : r0_4, this:r0_3
 #  846|     v0_6(void)                      = NoOp                                                : 
 #  846|     v0_7(void)                      = ReturnVoid                                          : 
 #  846|     v0_8(void)                      = UnmodeledUse                                        : mu*
@@ -3552,7 +3552,7 @@ ir.cpp:
 #-----|     v0_3(void)                      = NoOp                                                : 
 #  846|     r0_4(glval<PolymorphicBase>)    = ConvertToBase[PolymorphicDerived : PolymorphicBase] : r0_2
 #  846|     r0_5(glval<unknown>)            = FunctionAddress[~PolymorphicBase]                   : 
-#  846|     v0_6(void)                      = Invoke                                              : r0_5, this:r0_4
+#  846|     v0_6(void)                      = Call                                                : r0_5, this:r0_4
 #  846|     v0_7(void)                      = ReturnVoid                                          : 
 #  846|     v0_8(void)                      = UnmodeledUse                                        : mu*
 #  846|     v0_9(void)                      = ExitFunction                                        : 
@@ -3563,10 +3563,10 @@ ir.cpp:
 #  849|     mu0_1(unknown)                     = UnmodeledDefinition                 : 
 #  850|     r0_2(glval<PolymorphicBase>)       = VariableAddress[b]                  : 
 #-----|     r0_3(glval<unknown>)               = FunctionAddress[PolymorphicBase]    : 
-#-----|     v0_4(void)                         = Invoke                              : r0_3, this:r0_2
+#-----|     v0_4(void)                         = Call                                : r0_3, this:r0_2
 #  851|     r0_5(glval<PolymorphicDerived>)    = VariableAddress[d]                  : 
 #  851|     r0_6(glval<unknown>)               = FunctionAddress[PolymorphicDerived] : 
-#  851|     v0_7(void)                         = Invoke                              : r0_6, this:r0_5
+#  851|     v0_7(void)                         = Call                                : r0_6, this:r0_5
 #  853|     r0_8(glval<PolymorphicBase *>)     = VariableAddress[pb]                 : 
 #  853|     r0_9(glval<PolymorphicBase>)       = VariableAddress[b]                  : 
 #  853|     m0_10(PolymorphicBase *)           = Store                               : r0_8, r0_9
@@ -3614,7 +3614,7 @@ ir.cpp:
 #  868|     r0_3(glval<unknown>) = FunctionAddress[String] : 
 #  868|     r0_4(glval<char[1]>) = StringConstant[""]      : 
 #  868|     r0_5(char *)         = Convert                 : r0_4
-#  868|     v0_6(void)           = Invoke                  : r0_3, this:r0_2, r0_5
+#  868|     v0_6(void)           = Call                    : r0_3, this:r0_2, r0_5
 #  869|     v0_7(void)           = NoOp                    : 
 #  867|     v0_8(void)           = ReturnVoid              : 
 #  867|     v0_9(void)           = UnmodeledUse            : mu*
@@ -3790,44 +3790,44 @@ ir.cpp:
 #  940|     mu0_1(unknown)        = UnmodeledDefinition           : 
 #  941|     r0_2(glval<unknown>)  = FunctionAddress[operator new] : 
 #  941|     r0_3(unsigned long)   = Constant[4]                   : 
-#  941|     r0_4(void *)          = Invoke                        : r0_2, r0_3
+#  941|     r0_4(void *)          = Call                          : r0_2, r0_3
 #  941|     r0_5(int *)           = Convert                       : r0_4
 #  942|     r0_6(glval<unknown>)  = FunctionAddress[operator new] : 
 #  942|     r0_7(unsigned long)   = Constant[4]                   : 
 #  942|     r0_8(float)           = Constant[1.0]                 : 
-#  942|     r0_9(void *)          = Invoke                        : r0_6, r0_7, r0_8
+#  942|     r0_9(void *)          = Call                          : r0_6, r0_7, r0_8
 #  942|     r0_10(int *)          = Convert                       : r0_9
 #  943|     r0_11(glval<unknown>) = FunctionAddress[operator new] : 
 #  943|     r0_12(unsigned long)  = Constant[4]                   : 
-#  943|     r0_13(void *)         = Invoke                        : r0_11, r0_12
+#  943|     r0_13(void *)         = Call                          : r0_11, r0_12
 #  943|     r0_14(int *)          = Convert                       : r0_13
 #  943|     r0_15(int)            = Constant[0]                   : 
 #  943|     mu0_16(int)           = Store                         : r0_14, r0_15
 #  944|     r0_17(glval<unknown>) = FunctionAddress[operator new] : 
 #  944|     r0_18(unsigned long)  = Constant[8]                   : 
-#  944|     r0_19(void *)         = Invoke                        : r0_17, r0_18
+#  944|     r0_19(void *)         = Call                          : r0_17, r0_18
 #  944|     r0_20(String *)       = Convert                       : r0_19
 #  944|     r0_21(glval<unknown>) = FunctionAddress[String]       : 
-#  944|     v0_22(void)           = Invoke                        : r0_21, this:r0_20
+#  944|     v0_22(void)           = Call                          : r0_21, this:r0_20
 #  945|     r0_23(glval<unknown>) = FunctionAddress[operator new] : 
 #  945|     r0_24(unsigned long)  = Constant[8]                   : 
 #  945|     r0_25(float)          = Constant[1.0]                 : 
-#  945|     r0_26(void *)         = Invoke                        : r0_23, r0_24, r0_25
+#  945|     r0_26(void *)         = Call                          : r0_23, r0_24, r0_25
 #  945|     r0_27(String *)       = Convert                       : r0_26
 #  945|     r0_28(glval<unknown>) = FunctionAddress[String]       : 
 #  945|     r0_29(glval<char[6]>) = StringConstant["hello"]       : 
 #  945|     r0_30(char *)         = Convert                       : r0_29
-#  945|     v0_31(void)           = Invoke                        : r0_28, this:r0_27, r0_30
+#  945|     v0_31(void)           = Call                          : r0_28, this:r0_27, r0_30
 #  946|     r0_32(glval<unknown>) = FunctionAddress[operator new] : 
 #  946|     r0_33(unsigned long)  = Constant[256]                 : 
 #  946|     r0_34(align_val_t)    = Constant[128]                 : 
-#  946|     r0_35(void *)         = Invoke                        : r0_32, r0_33, r0_34
+#  946|     r0_35(void *)         = Call                          : r0_32, r0_33, r0_34
 #  946|     r0_36(Overaligned *)  = Convert                       : r0_35
 #  947|     r0_37(glval<unknown>) = FunctionAddress[operator new] : 
 #  947|     r0_38(unsigned long)  = Constant[256]                 : 
 #  947|     r0_39(align_val_t)    = Constant[128]                 : 
 #  947|     r0_40(float)          = Constant[1.0]                 : 
-#  947|     r0_41(void *)         = Invoke                        : r0_37, r0_38, r0_39, r0_40
+#  947|     r0_41(void *)         = Call                          : r0_37, r0_38, r0_39, r0_40
 #  947|     r0_42(Overaligned *)  = Convert                       : r0_41
 #  947|     r0_43(Overaligned)    = Constant[0]                   : 
 #  947|     mu0_44(Overaligned)   = Store                         : r0_42, r0_43
@@ -3844,7 +3844,7 @@ ir.cpp:
 #  950|     m0_3(int)                            = InitializeParameter[n]          : r0_2
 #  951|     r0_4(glval<unknown>)                 = FunctionAddress[operator new[]] : 
 #  951|     r0_5(unsigned long)                  = Constant[40]                    : 
-#  951|     r0_6(void *)                         = Invoke                          : r0_4, r0_5
+#  951|     r0_6(void *)                         = Call                            : r0_4, r0_5
 #  951|     r0_7(int *)                          = Convert                         : r0_6
 #  952|     r0_8(glval<unknown>)                 = FunctionAddress[operator new[]] : 
 #  952|     r0_9(glval<int>)                     = VariableAddress[n]              : 
@@ -3852,7 +3852,7 @@ ir.cpp:
 #  952|     r0_11(unsigned long)                 = Convert                         : r0_10
 #  952|     r0_12(unsigned long)                 = Constant[4]                     : 
 #  952|     r0_13(unsigned long)                 = Mul                             : r0_11, r0_12
-#  952|     r0_14(void *)                        = Invoke                          : r0_8, r0_13
+#  952|     r0_14(void *)                        = Call                            : r0_8, r0_13
 #  952|     r0_15(int *)                         = Convert                         : r0_14
 #  953|     r0_16(glval<unknown>)                = FunctionAddress[operator new[]] : 
 #  953|     r0_17(glval<int>)                    = VariableAddress[n]              : 
@@ -3861,7 +3861,7 @@ ir.cpp:
 #  953|     r0_20(unsigned long)                 = Constant[4]                     : 
 #  953|     r0_21(unsigned long)                 = Mul                             : r0_19, r0_20
 #  953|     r0_22(float)                         = Constant[1.0]                   : 
-#  953|     r0_23(void *)                        = Invoke                          : r0_16, r0_21, r0_22
+#  953|     r0_23(void *)                        = Call                            : r0_16, r0_21, r0_22
 #  953|     r0_24(int *)                         = Convert                         : r0_23
 #  954|     r0_25(glval<unknown>)                = FunctionAddress[operator new[]] : 
 #  954|     r0_26(glval<int>)                    = VariableAddress[n]              : 
@@ -3869,7 +3869,7 @@ ir.cpp:
 #  954|     r0_28(unsigned long)                 = Convert                         : r0_27
 #  954|     r0_29(unsigned long)                 = Constant[8]                     : 
 #  954|     r0_30(unsigned long)                 = Mul                             : r0_28, r0_29
-#  954|     r0_31(void *)                        = Invoke                          : r0_25, r0_30
+#  954|     r0_31(void *)                        = Call                            : r0_25, r0_30
 #  954|     r0_32(String *)                      = Convert                         : r0_31
 #  955|     r0_33(glval<unknown>)                = FunctionAddress[operator new[]] : 
 #  955|     r0_34(glval<int>)                    = VariableAddress[n]              : 
@@ -3878,13 +3878,13 @@ ir.cpp:
 #  955|     r0_37(unsigned long)                 = Constant[256]                   : 
 #  955|     r0_38(unsigned long)                 = Mul                             : r0_36, r0_37
 #  955|     r0_39(align_val_t)                   = Constant[128]                   : 
-#  955|     r0_40(void *)                        = Invoke                          : r0_33, r0_38, r0_39
+#  955|     r0_40(void *)                        = Call                            : r0_33, r0_38, r0_39
 #  955|     r0_41(Overaligned *)                 = Convert                         : r0_40
 #  956|     r0_42(glval<unknown>)                = FunctionAddress[operator new[]] : 
 #  956|     r0_43(unsigned long)                 = Constant[2560]                  : 
 #  956|     r0_44(align_val_t)                   = Constant[128]                   : 
 #  956|     r0_45(float)                         = Constant[1.0]                   : 
-#  956|     r0_46(void *)                        = Invoke                          : r0_42, r0_43, r0_44, r0_45
+#  956|     r0_46(void *)                        = Call                            : r0_42, r0_43, r0_44, r0_45
 #  956|     r0_47(Overaligned *)                 = Convert                         : r0_46
 #  957|     r0_48(glval<unknown>)                = FunctionAddress[operator new[]] : 
 #  957|     r0_49(glval<int>)                    = VariableAddress[n]              : 
@@ -3892,7 +3892,7 @@ ir.cpp:
 #  957|     r0_51(unsigned long)                 = Convert                         : r0_50
 #  957|     r0_52(unsigned long)                 = Constant[1]                     : 
 #  957|     r0_53(unsigned long)                 = Mul                             : r0_51, r0_52
-#  957|     r0_54(void *)                        = Invoke                          : r0_48, r0_53
+#  957|     r0_54(void *)                        = Call                            : r0_48, r0_53
 #  957|     r0_55(DefaultCtorWithDefaultParam *) = Convert                         : r0_54
 #  958|     r0_56(glval<unknown>)                = FunctionAddress[operator new[]] : 
 #  958|     r0_57(glval<int>)                    = VariableAddress[n]              : 
@@ -3900,7 +3900,7 @@ ir.cpp:
 #  958|     r0_59(unsigned long)                 = Convert                         : r0_58
 #  958|     r0_60(unsigned long)                 = Constant[4]                     : 
 #  958|     r0_61(unsigned long)                 = Mul                             : r0_59, r0_60
-#  958|     r0_62(void *)                        = Invoke                          : r0_56, r0_61
+#  958|     r0_62(void *)                        = Call                            : r0_56, r0_61
 #  958|     r0_63(int *)                         = Convert                         : r0_62
 #  959|     v0_64(void)                          = NoOp                            : 
 #  950|     v0_65(void)                          = ReturnVoid                      : 


### PR DESCRIPTION
Now that opcodes are in their own module that isn't imported into the global namespace, `Opcode::Call` no longer conflicts with `Call` from the ASTs. I've renamed `Opcode::Invoke` to `Opcode::Call`.