### PR TITLE
Fixed error in gmtime example

### DIFF
--- a/cpp/ql/src/Security/CWE/CWE-676/PotentiallyDangerousFunction.c
+++ b/cpp/ql/src/Security/CWE/CWE-676/PotentiallyDangerousFunction.c
@@ -1,12 +1,14 @@
 // BAD: using gmtime
 int is_morning_bad() {
-    struct tm *now = gmtime(time(NULL));
+    const time_t now_seconds = time(NULL);
+    struct tm *now = gmtime(&now_seconds);
     return (now->tm_hour < 12);
 }
 
 // GOOD: using gmtime_r
 int is_morning_good() {
+    const time_t now_seconds = time(NULL);
     struct tm now;
-    gmtime_r(time(NULL), &now);
+    gmtime_r(&now_seconds, &now);
     return (now.tm_hour < 12);
 }


### PR DESCRIPTION
`gmtime` and `gmtime_r` take a `time_t` pointer, so have to store the value of `time(NULL)` on the stack.

Also, if you added the include in your examples (`#include <time.h>`) you could find errors like these automatically, by running clang or gcc on all examples.