### PR TITLE
CPP: Handle 'realloc' better in MemoryMayNotBeFreed.ql

### DIFF
--- a/change-notes/1.18/analysis-cpp.md
+++ b/change-notes/1.18/analysis-cpp.md
@@ -19,6 +19,7 @@
 | [Nested loops with same variable] | Fewer false positive results | Results where the loop variable is a member of a class or struct now account for the object. |
 | [For loop variable changed in body] | Fewer false positive results | Results where the loop variable is a member of a class or struct now account for the object. |
 | [Local variable hides global variable] | Fewer false positive results | Results for parameters are now only reported if the name of the global variable is the same as the name of the parameter as used in the function definition (not just a function declaration). |
+| [Memory may not be freed] | More correct results | This query now models calls to `realloc` more accurately. |
 | Wrong number of arguments to formatting function | Fewer false positive results | Some false positives related to custom printf-like functions have been fixed. |
 | Wrong number of arguments to formatting function | Clear separation between results of high and low severity | This query has been split into two queries: a high-severity query named [Too few arguments to formatting function] and a low-severity query named [Too many arguments to formatting function]. |
 | [Too few arguments to formatting function] | More correct and fewer false positives results | This query now understands positional format arguments as supported by some libraries. |

--- a/cpp/ql/src/Critical/MemoryMayNotBeFreed.ql
+++ b/cpp/ql/src/Critical/MemoryMayNotBeFreed.ql
@@ -62,8 +62,14 @@ predicate verifiedRealloc(FunctionCall reallocCall, Variable v, ControlFlowNode 
       // a realloc followed by a null check at 'node' (return the non-null
       // successor, i.e. where the realloc is confirmed to have succeeded)
       newV.getAnAssignedValue() = reallocCall and
-      node.(AnalysedExpr).getNonNullSuccessor(newV) = verified
+      node.(AnalysedExpr).getNonNullSuccessor(newV) = verified and
       // note: this case uses naive flow logic (getAnAssignedValue).
+
+      // special case: if the result of the 'realloc' is assigned to the
+      // same variable, we don't descriminate properly between the old
+      // and the new allocation; better to not consider this a free at
+      // all in that case.
+      newV != v
     ) or (
       // a realloc(ptr, 0), which always succeeds and frees
       // (return the realloc itself)


### PR DESCRIPTION
The `MemoryMayNotBeFreed.ql` query normally considers a `realloc` to be both an `alloc`, and a `free` of the old pointer.  A subtlety is that if `realloc` fails and returns `NULL` it does *not* free the old pointer.  To account for this the query considers the free of the old pointer to occur only if and when the return value is checked:
```
ptr_b = realloc(ptr_a, new_size);
if (ptr_b == 0)
{
  // handle failure (perhaps with an explicit free(ptr_a))
} else {
  // the realloc is considered to free ptr_a here
}
```
This works well up until we assign to the same variable:
```
ptr_a = realloc(ptr_a, new_size);
if (ptr_a == 0)
{
  // handle failure (which might be a bit awkward since we've just overwritten ptr_a)
} else {
  // the realloc is considered to free ptr_a here
}
```
Because now we get confused by the old vs new `ptr_a` and think the *new* allocation is being freed.

The ideal solution is probably to upgrade this query to use something like `DataFlow` rather than `LocalScopeVariableReachability` (I've created a JIRA ticket for this).

However, we need a quick fix because it's causing a regression on version 1.3 of the samate test-suite compared to the results we had on version 1.2.  The workaround is not to consider this particular pattern on `realloc` as to be a free at all.