### PR TITLE
C#: Improvements to `cs/useless-upcast`

### DIFF
--- a/csharp/ql/src/Language Abuse/UselessUpcast.ql
+++ b/csharp/ql/src/Language Abuse/UselessUpcast.ql
@@ -149,11 +149,7 @@ class ExplicitUpcast extends ExplicitCast {
       this.isDisambiguatingStaticCall(other, args)
       |
       args >= getMinimumArguments(other) and
-      (
-        not exists(getMaximumArguments(other))
-        or
-        args <= getMaximumArguments(other)
-      )
+      not args > getMaximumArguments(other)
     )
   }
 

--- a/csharp/ql/src/semmle/code/csharp/exprs/Call.qll
+++ b/csharp/ql/src/semmle/code/csharp/exprs/Call.qll
@@ -357,7 +357,7 @@ class ExtensionMethodCall extends MethodCall {
   override Expr getArgument(int i) {
     exists(int j |
       result = this.getChildExpr(j) |
-      if isOrdinaryCall() then
+      if isOrdinaryStaticCall() then
         (j = i and j >= 0)
       else
         (j = i - 1 and j >= -1)
@@ -381,7 +381,7 @@ class ExtensionMethodCall extends MethodCall {
    * }
    * ```
    */
-  private predicate isOrdinaryCall() {
+  predicate isOrdinaryStaticCall() {
     not exists(this.getChildExpr(-1)) // `Ext(i)` case above
     or
     exists(this.getQualifier()) // `Extensions.Ext(i)` case above

--- a/csharp/ql/test/query-tests/Language Abuse/UselessUpcast/UselessUpcast.expected
+++ b/csharp/ql/test/query-tests/Language Abuse/UselessUpcast/UselessUpcast.expected
@@ -1,4 +1,7 @@
-| UselessUpcast.cs:51:13:51:16 | (...) ... | There is no need to upcast from $@ to $@ - the conversion can be done implicitly. | UselessUpcast.cs:17:7:17:7 | B | B | UselessUpcast.cs:10:7:10:7 | A | A |
-| UselessUpcast.cs:57:14:57:17 | (...) ... | There is no need to upcast from $@ to $@ - the conversion can be done implicitly. | UselessUpcast.cs:17:7:17:7 | B | B | UselessUpcast.cs:10:7:10:7 | A | A |
-| UselessUpcast.cs:66:13:66:16 | (...) ... | There is no need to upcast from $@ to $@ - the conversion can be done implicitly. | UselessUpcast.cs:17:7:17:7 | B | B | UselessUpcast.cs:10:7:10:7 | A | A |
+| UselessUpcast.cs:54:13:54:16 | (...) ... | There is no need to upcast from $@ to $@ - the conversion can be done implicitly. | UselessUpcast.cs:20:7:20:7 | B | B | UselessUpcast.cs:13:7:13:7 | A | A |
+| UselessUpcast.cs:60:14:60:17 | (...) ... | There is no need to upcast from $@ to $@ - the conversion can be done implicitly. | UselessUpcast.cs:20:7:20:7 | B | B | UselessUpcast.cs:13:7:13:7 | A | A |
+| UselessUpcast.cs:69:13:69:16 | (...) ... | There is no need to upcast from $@ to $@ - the conversion can be done implicitly. | UselessUpcast.cs:20:7:20:7 | B | B | UselessUpcast.cs:13:7:13:7 | A | A |
+| UselessUpcast.cs:85:12:85:15 | (...) ... | There is no need to upcast from $@ to $@ - the conversion can be done implicitly. | UselessUpcast.cs:20:7:20:7 | B | B | UselessUpcast.cs:13:7:13:7 | A | A |
+| UselessUpcast.cs:94:12:94:15 | (...) ... | There is no need to upcast from $@ to $@ - the conversion can be done implicitly. | UselessUpcast.cs:20:7:20:7 | B | B | UselessUpcast.cs:13:7:13:7 | A | A |
+| UselessUpcast.cs:105:16:105:19 | (...) ... | There is no need to upcast from $@ to $@ - the conversion can be done implicitly. | UselessUpcast.cs:27:7:27:7 | C | C | UselessUpcast.cs:20:7:20:7 | B | B |
 | UselessUpcastBad.cs:9:23:9:32 | (...) ... | There is no need to upcast from $@ to $@ - the conversion can be done implicitly. | UselessUpcastBad.cs:4:11:4:13 | Sub | Sub | UselessUpcastBad.cs:3:11:3:15 | Super | Super |


### PR DESCRIPTION
Fixed a few false positives related to disambiguation of static calls. We already have a change note for this query, so not added.