### PR TITLE
CPP: Adjust precisions for the CWE-190 queries.

### DIFF
--- a/cpp/ql/src/Security/CWE/CWE-190/ArithmeticTainted.ql
+++ b/cpp/ql/src/Security/CWE/CWE-190/ArithmeticTainted.ql
@@ -4,7 +4,7 @@
  *              not validated can cause overflows.
  * @kind problem
  * @problem.severity warning
- * @precision medium
+ * @precision low
  * @id cpp/tainted-arithmetic
  * @tags security
  *       external/cwe/cwe-190

--- a/cpp/ql/src/Security/CWE/CWE-190/IntegerOverflowTainted.ql
+++ b/cpp/ql/src/Security/CWE/CWE-190/IntegerOverflowTainted.ql
@@ -5,6 +5,7 @@
  * @kind problem
  * @id cpp/integer-overflow-tainted
  * @problem.severity warning
+ * @precision low
  * @tags security
  *       external/cwe/cwe-190
  *       external/cwe/cwe-197


### PR DESCRIPTION
Reduce the precision of ArithmeticTainted.ql from medium to low, in line with ArithmeticWithExtremeValues.ql (as discussed on [Jira](https://jira.semmle.com/browse/CPP-254)).

Gave IntegerOverflowTainted.ql a precision, since it was lacking one.