### PR TITLE
cherry-pick onto rc/1.18: C++: change note for designated intializer fixes

### DIFF
--- a/change-notes/1.18/analysis-cpp.md
+++ b/change-notes/1.18/analysis-cpp.md
@@ -33,4 +33,6 @@
  
 ## Changes to QL libraries
 
-* *Series of bullet points*
+* Fixes for aggregate initializers using designators:
+** `ClassAggregateLiteral.getFieldExpr()` previously assumed initializer expressions appeared in the same order as the declaration order of the fields, causing it to associate the expressions with the wrong fields when using designated initializers. This has been fixed.
+** `ArrayAggregateLiteral.getElementExpr()` previously assumed initializer expressions appeared in the same order as the corresponding array elements, causing it to associate the expressions with the wrong array elements when using designated initializers. This has been fixed.


### PR DESCRIPTION
This changenote was committed after the `rc/1.18 branch` was taken.