### PR TITLE
CPP: Make FunctionWithWrappers `toCause` work on builtins.

### DIFF
--- a/cpp/ql/src/semmle/code/cpp/security/FunctionWithWrappers.qll
+++ b/cpp/ql/src/semmle/code/cpp/security/FunctionWithWrappers.qll
@@ -3,9 +3,14 @@ import PrintfLike
 private import TaintTracking
 
 private
+bindingset[index]
 string toCause(Function func, int index)
 {
-  result = func.getQualifiedName() + "(" + func.getParameter(index).getName() + ")"
+  result = func.getQualifiedName() + "(" + func.getParameter(index).getName() + ")" or
+  (
+    not exists(func.getParameter(index).getName()) and
+    result = func.getQualifiedName() + "(arg " + index + ")"
+  )
 }
 
 /**


### PR DESCRIPTION
Previously it wouldn't return a result if the function didn't have parameter names.  This affected anyone working with the library on builtin functions.