### PR TITLE
C++: Fix QL compiler warnings for 1.18

### DIFF
--- a/cpp/ql/src/semmle/code/cpp/Class.qll
+++ b/cpp/ql/src/semmle/code/cpp/Class.qll
@@ -566,7 +566,7 @@ class Class extends UserType {
    * The alignment of this type in bytes (on the machine where facts were
    * extracted).
    */
-  int getAlignment() { usertypesize(underlyingElement(this),_,result) }
+  override int getAlignment() { usertypesize(underlyingElement(this),_,result) }
 
   /**
    * Holds if this class is constructed from another class as a result of

--- a/cpp/ql/src/semmle/code/cpp/File.qll
+++ b/cpp/ql/src/semmle/code/cpp/File.qll
@@ -162,7 +162,7 @@ abstract class Container extends Locatable, @container {
    *
    * This is the absolute path of the container.
    */
-  string toString() {
+  override string toString() {
     result = getAbsolutePath()
   }
 }

--- a/cpp/ql/src/semmle/code/cpp/dataflow/internal/DataFlowPrivate.qll
+++ b/cpp/ql/src/semmle/code/cpp/dataflow/internal/DataFlowPrivate.qll
@@ -128,7 +128,7 @@ predicate readStep(Node node1, Content f, Node node2) {
  * numeric conversions, and otherwise the erasure is used.
  */
 RefType getErasedRepr(Type t) {
-  t = t and // silence compiler warning
+  suppressUnusedThis(t) and
   result instanceof VoidType // stub implementation
 }
 
@@ -140,6 +140,8 @@ pragma[inline]
 predicate compatibleTypes(Type t1, Type t2) {
   any() // stub implementation
 }
+
+private predicate suppressUnusedThis(Type t) { any() }
 
 //////////////////////////////////////////////////////////////////////////////
 // Java QL library compatibility wrappers

--- a/cpp/ql/src/semmle/code/cpp/dataflow/internal/DataFlowPrivate.qll
+++ b/cpp/ql/src/semmle/code/cpp/dataflow/internal/DataFlowPrivate.qll
@@ -128,7 +128,7 @@ predicate readStep(Node node1, Content f, Node node2) {
  * numeric conversions, and otherwise the erasure is used.
  */
 RefType getErasedRepr(Type t) {
-  suppressUnusedThis(t) and
+  suppressUnusedType(t) and
   result instanceof VoidType // stub implementation
 }
 
@@ -141,7 +141,7 @@ predicate compatibleTypes(Type t1, Type t2) {
   any() // stub implementation
 }
 
-private predicate suppressUnusedThis(Type t) { any() }
+private predicate suppressUnusedType(Type t) { any() }
 
 //////////////////////////////////////////////////////////////////////////////
 // Java QL library compatibility wrappers

--- a/cpp/ql/src/semmle/code/cpp/dataflow/internal/DataFlowPrivate.qll
+++ b/cpp/ql/src/semmle/code/cpp/dataflow/internal/DataFlowPrivate.qll
@@ -128,6 +128,7 @@ predicate readStep(Node node1, Content f, Node node2) {
  * numeric conversions, and otherwise the erasure is used.
  */
 RefType getErasedRepr(Type t) {
+  t = t and // silence compiler warning
   result instanceof VoidType // stub implementation
 }
 

--- a/cpp/ql/src/semmle/code/cpp/ir/internal/PrintIRImpl.qll
+++ b/cpp/ql/src/semmle/code/cpp/ir/internal/PrintIRImpl.qll
@@ -83,7 +83,8 @@ class PrintableFunctionIR extends PrintableIRNode, TPrintableFunctionIR {
   override int getOrder() {
     this = rank[result + 1](PrintableFunctionIR orderedFunc, Location location |
       location = orderedFunc.getFunctionIR().getLocation() |
-      orderedFunc order by location.getFile().getURL(), location.getStartLine(),
+      orderedFunc order by location.getFile().getAbsolutePath(),
+        location.getStartLine(),
         location.getStartColumn(), orderedFunc.getLabel()
     )
   }


### PR DESCRIPTION
There are some additional warnings in the IR about the name `Opcode` being used for both a file and an in-line module. Those will have to be fixed after #122 is merged.