### PR TITLE
JS: js/reflected-xss through file names

### DIFF
--- a/change-notes/1.19/analysis-javascript.md
+++ b/change-notes/1.19/analysis-javascript.md
@@ -1,0 +1,22 @@
+# Improvements to JavaScript analysis
+
+## General improvements
+
+* Support for popular libraries has been improved. Consequently, queries may produce more results on code bases that use the following features:
+  - file system access, for example through [fs-extra](https://github.com/jprichardson/node-fs-extra)
+
+## New queries
+
+| **Query**                   | **Tags**  | **Purpose**                                                        |
+|-----------------------------|-----------|--------------------------------------------------------------------|
+| *@name of query (Query ID)* | *Tags*    |*Aim of the new query and whether it is enabled by default or not*  |
+
+## Changes to existing queries
+
+| **Query**                      | **Expected impact**        | **Change**                                   |
+|--------------------------------|----------------------------|----------------------------------------------|
+| Reflected cross-site scripting | More true-positive results | This rule now treats file names as a source. |
+
+
+## Changes to QL libraries
+

--- a/javascript/ql/src/semmle/javascript/Concepts.qll
+++ b/javascript/ql/src/semmle/javascript/Concepts.qll
@@ -30,7 +30,7 @@ abstract class FileSystemAccess extends DataFlow::Node {
 }
 
 /**
- * A data flow node that contains one or more file names from the local file system.
+ * A data flow node that contains a file name or an array of file names from the local file system.
  */
 abstract class FileNameSource extends DataFlow::Node {
 

--- a/javascript/ql/src/semmle/javascript/Concepts.qll
+++ b/javascript/ql/src/semmle/javascript/Concepts.qll
@@ -30,6 +30,13 @@ abstract class FileSystemAccess extends DataFlow::Node {
 }
 
 /**
+ * A data flow node that contains one or more file names from the local file system.
+ */
+abstract class FileNameSource extends DataFlow::Node {
+
+}
+
+/**
  * A data flow node that performs a database access.
  */
 abstract class DatabaseAccess extends DataFlow::Node {

--- a/javascript/ql/src/semmle/javascript/frameworks/NodeJSLib.qll
+++ b/javascript/ql/src/semmle/javascript/frameworks/NodeJSLib.qll
@@ -338,14 +338,14 @@ module NodeJSLib {
 
 
   /**
-   * A call to a method from module `fs` or `graceful-fs`.
+   * A call to a method from module `fs`, `graceful-fs` or `fs-extra`.
    */
   private class NodeJSFileSystemAccess extends FileSystemAccess, DataFlow::CallNode {
     string methodName;
 
     NodeJSFileSystemAccess() {
       exists (string moduleName | this = DataFlow::moduleMember(moduleName, methodName).getACall() |
-        moduleName = "fs" or moduleName = "graceful-fs"
+        moduleName = "fs" or moduleName = "graceful-fs" or moduleName = "fs-extra"
       )
     }
 

--- a/javascript/ql/src/semmle/javascript/frameworks/NodeJSLib.qll
+++ b/javascript/ql/src/semmle/javascript/frameworks/NodeJSLib.qll
@@ -336,6 +336,17 @@ module NodeJSLib {
     )
   }
 
+  /**
+   * A member `member` from module `fs` or its drop-in replacements `graceful-fs` or `fs-extra`.
+   */
+  private DataFlow::SourceNode fsModuleMember(string member) {
+    exists (string moduleName |
+      moduleName = "fs" or
+      moduleName = "graceful-fs" or
+      moduleName = "fs-extra" |
+      result = DataFlow::moduleMember(moduleName, member)
+    )
+  }
 
   /**
    * A call to a method from module `fs`, `graceful-fs` or `fs-extra`.
@@ -344,9 +355,7 @@ module NodeJSLib {
     string methodName;
 
     NodeJSFileSystemAccess() {
-      exists (string moduleName | this = DataFlow::moduleMember(moduleName, methodName).getACall() |
-        moduleName = "fs" or moduleName = "graceful-fs" or moduleName = "fs-extra"
-      )
+      this = fsModuleMember(methodName).getACall()
     }
 
     override DataFlow::Node getAPathArgument() {

--- a/javascript/ql/src/semmle/javascript/frameworks/NodeJSLib.qll
+++ b/javascript/ql/src/semmle/javascript/frameworks/NodeJSLib.qll
@@ -366,6 +366,22 @@ module NodeJSLib {
   }
 
   /**
+   * A data flow node that contains one or more file names from the local file system.
+   */
+  private class NodeJSFileNameSource extends FileNameSource {
+
+    NodeJSFileNameSource() {
+      exists (string name |
+        name = "readdir" or
+        name = "realpath" |
+        this = fsModuleMember(name).getACall().getCallback([1..2]).getParameter(1) or
+        this = fsModuleMember(name + "Sync").getACall()
+      )
+    }
+
+  }
+  
+  /**
    * A call to a method from module `child_process`.
    */
   private class ChildProcessMethodCall extends SystemCommandExecution, DataFlow::CallNode {

--- a/javascript/ql/src/semmle/javascript/security/dataflow/ReflectedXss.qll
+++ b/javascript/ql/src/semmle/javascript/security/dataflow/ReflectedXss.qll
@@ -53,6 +53,13 @@ module ReflectedXss {
     }
   }
 
+  /** A source of file name input, considered as a flow source for reflected XSS. */
+  class FileNameSourceAsSource extends Source {
+    FileNameSourceAsSource() {
+      this instanceof FileNameSource
+    }
+  }
+
   /**
    * An expression that is sent as part of an HTTP response, considered as an XSS sink.
    *

--- a/javascript/ql/src/semmle/javascript/security/dataflow/ReflectedXss.qll
+++ b/javascript/ql/src/semmle/javascript/security/dataflow/ReflectedXss.qll
@@ -53,7 +53,7 @@ module ReflectedXss {
     }
   }
 
-  /** A source of file name input, considered as a flow source for reflected XSS. */
+  /** A file name, considered as a flow source for reflected XSS. */
   class FileNameSourceAsSource extends Source {
     FileNameSourceAsSource() {
       this instanceof FileNameSource

--- a/javascript/ql/test/query-tests/Security/CWE-079/ReflectedXss.expected
+++ b/javascript/ql/test/query-tests/Security/CWE-079/ReflectedXss.expected
@@ -5,3 +5,7 @@
 | promises.js:6:25:6:25 | x | Cross-site scripting vulnerability due to $@. | promises.js:5:44:5:57 | req.query.data | user-provided value |
 | tst2.js:7:12:7:12 | p | Cross-site scripting vulnerability due to $@. | tst2.js:6:9:6:9 | p | user-provided value |
 | tst2.js:8:12:8:12 | r | Cross-site scripting vulnerability due to $@. | tst2.js:6:12:6:15 | q: r | user-provided value |
+| xss-through-filenames.js:8:18:8:23 | files1 | Cross-site scripting vulnerability due to $@. | xss-through-filenames.js:7:43:7:48 | files1 | user-provided value |
+| xss-through-filenames.js:26:19:26:24 | files1 | Cross-site scripting vulnerability due to $@. | xss-through-filenames.js:25:43:25:48 | files1 | user-provided value |
+| xss-through-filenames.js:33:19:33:24 | files2 | Cross-site scripting vulnerability due to $@. | xss-through-filenames.js:25:43:25:48 | files1 | user-provided value |
+| xss-through-filenames.js:37:19:37:24 | files3 | Cross-site scripting vulnerability due to $@. | xss-through-filenames.js:25:43:25:48 | files1 | user-provided value |

--- a/javascript/ql/test/query-tests/Security/CWE-079/xss-through-filenames.js
+++ b/javascript/ql/test/query-tests/Security/CWE-079/xss-through-filenames.js
@@ -1,0 +1,40 @@
+var http = require('http');
+var fs = require('fs');
+
+var express = require('express');
+
+express().get('/', function(req, res) {
+    fs.readdir("/myDir", function (error, files1) {
+        res.send(files1); // NOT OK
+    });
+});
+
+/**
+ * The essence of a real world vulnerability.
+ */
+http.createServer(function (req, res) {
+
+    function format(files2) {
+        var files3 = [];
+        files2.sort(sort).forEach(function (file) {
+            files3.push('<li>' + file + '</li>');
+        });
+        return files3.join('');
+    }
+
+    fs.readdir("/myDir", function (error, files1) {
+        res.write(files1); // NOT OK
+
+        var dirs = [];
+        var files2 = [];
+        files1.forEach(function (file) {
+            files2.push(file);
+        });
+        res.write(files2); // NOT OK
+
+        var files3 = format(files2);
+
+        res.write(files3);  // NOT OK
+
+    });
+});


### PR DESCRIPTION
This PR makes js/reflected-xss treat file names as sources.

Other injection queries, such as js/sql-injection, can perhaps also use this new source, but I would like to introduce this source slowly to prevent too many FPs at once if it turns out that file names in practice are benign.

The PR is inspired by this vulnerability fix: <https://github.com/nunnly/m-server/commit/b8613fd1f35b2ba1e3b0cbac254c03f7c9f95232>, where a file name ultimately is concatenated with some HTML string fragments.

[Performance and results](<https://git.semmle.com/gist/esben/da8d5b0d705b824217d375a82334c808>) are unchanged, except for a result that I suspect is a FP due to a non-HTML response content-type that we fail to identify.

I have started on the 1.19 changes notes. I think we should aim for a less verbose library listing this time. I think a category and an example library is fine WDYT?