### PR TITLE
C++: clearer alert wording in integer-multiplication-cast-to-long

### DIFF
--- a/cpp/ql/src/Likely Bugs/Arithmetic/IntMultToLong.ql
+++ b/cpp/ql/src/Likely Bugs/Arithmetic/IntMultToLong.ql
@@ -103,4 +103,4 @@ where t1 = me.getType().getUnderlyingType() and
         ) and
         e.(Literal).getType().getSize() = t2.getSize()
       )
-select me, "Cast to '" + me.getFullyConverted().getType().toString() + "' before multiplication to avoid potential overflow."
+select me, "Multiplication result may overflow '" + me.getType().toString() + "' before it is converted to '" + me.getFullyConverted().getType().toString() + "'. Consider casting before multiplication to avoid potential overflow."

--- a/cpp/ql/src/Likely Bugs/Arithmetic/IntMultToLong.ql
+++ b/cpp/ql/src/Likely Bugs/Arithmetic/IntMultToLong.ql
@@ -103,4 +103,4 @@ where t1 = me.getType().getUnderlyingType() and
         ) and
         e.(Literal).getType().getSize() = t2.getSize()
       )
-select me, "Multiplication result may overflow '" + me.getType().toString() + "' before it is converted to '" + me.getFullyConverted().getType().toString() + "'. Consider casting before multiplication to avoid potential overflow."
+select me, "Multiplication result may overflow '" + me.getType().toString() + "' before it is converted to '" + me.getFullyConverted().getType().toString() + "'."

--- a/cpp/ql/test/query-tests/Likely Bugs/Arithmetic/IntMultToLong/IntMultToLong.expected
+++ b/cpp/ql/test/query-tests/Likely Bugs/Arithmetic/IntMultToLong/IntMultToLong.expected
@@ -1,9 +1,9 @@
-| IntMultToLong.c:4:10:4:14 | ... * ... | Multiplication result may overflow 'int' before it is converted to 'long long'. Consider casting before multiplication to avoid potential overflow. |
-| IntMultToLong.c:7:16:7:20 | ... * ... | Multiplication result may overflow 'int' before it is converted to 'long long'. Consider casting before multiplication to avoid potential overflow. |
-| IntMultToLong.c:18:19:18:23 | ... * ... | Multiplication result may overflow 'float' before it is converted to 'double'. Consider casting before multiplication to avoid potential overflow. |
-| IntMultToLong.c:21:19:21:29 | ... * ... | Multiplication result may overflow 'float' before it is converted to 'double'. Consider casting before multiplication to avoid potential overflow. |
-| IntMultToLong.c:38:19:38:23 | ... * ... | Multiplication result may overflow 'float' before it is converted to 'double'. Consider casting before multiplication to avoid potential overflow. |
-| IntMultToLong.c:59:20:59:31 | ... * ... | Multiplication result may overflow 'float' before it is converted to 'double'. Consider casting before multiplication to avoid potential overflow. |
-| IntMultToLong.c:61:23:61:33 | ... * ... | Multiplication result may overflow 'int' before it is converted to 'long long'. Consider casting before multiplication to avoid potential overflow. |
-| IntMultToLong.c:63:23:63:40 | ... * ... | Multiplication result may overflow 'int' before it is converted to 'long long'. Consider casting before multiplication to avoid potential overflow. |
-| IntMultToLong.c:75:9:75:13 | ... * ... | Multiplication result may overflow 'int' before it is converted to 'size_t'. Consider casting before multiplication to avoid potential overflow. |
+| IntMultToLong.c:4:10:4:14 | ... * ... | Multiplication result may overflow 'int' before it is converted to 'long long'. |
+| IntMultToLong.c:7:16:7:20 | ... * ... | Multiplication result may overflow 'int' before it is converted to 'long long'. |
+| IntMultToLong.c:18:19:18:23 | ... * ... | Multiplication result may overflow 'float' before it is converted to 'double'. |
+| IntMultToLong.c:21:19:21:29 | ... * ... | Multiplication result may overflow 'float' before it is converted to 'double'. |
+| IntMultToLong.c:38:19:38:23 | ... * ... | Multiplication result may overflow 'float' before it is converted to 'double'. |
+| IntMultToLong.c:59:20:59:31 | ... * ... | Multiplication result may overflow 'float' before it is converted to 'double'. |
+| IntMultToLong.c:61:23:61:33 | ... * ... | Multiplication result may overflow 'int' before it is converted to 'long long'. |
+| IntMultToLong.c:63:23:63:40 | ... * ... | Multiplication result may overflow 'int' before it is converted to 'long long'. |
+| IntMultToLong.c:75:9:75:13 | ... * ... | Multiplication result may overflow 'int' before it is converted to 'size_t'. |

--- a/cpp/ql/test/query-tests/Likely Bugs/Arithmetic/IntMultToLong/IntMultToLong.expected
+++ b/cpp/ql/test/query-tests/Likely Bugs/Arithmetic/IntMultToLong/IntMultToLong.expected
@@ -1,9 +1,9 @@
-| IntMultToLong.c:4:10:4:14 | ... * ... | Cast to 'long long' before multiplication to avoid potential overflow. |
-| IntMultToLong.c:7:16:7:20 | ... * ... | Cast to 'long long' before multiplication to avoid potential overflow. |
-| IntMultToLong.c:18:19:18:23 | ... * ... | Cast to 'double' before multiplication to avoid potential overflow. |
-| IntMultToLong.c:21:19:21:29 | ... * ... | Cast to 'double' before multiplication to avoid potential overflow. |
-| IntMultToLong.c:38:19:38:23 | ... * ... | Cast to 'double' before multiplication to avoid potential overflow. |
-| IntMultToLong.c:59:20:59:31 | ... * ... | Cast to 'double' before multiplication to avoid potential overflow. |
-| IntMultToLong.c:61:23:61:33 | ... * ... | Cast to 'long long' before multiplication to avoid potential overflow. |
-| IntMultToLong.c:63:23:63:40 | ... * ... | Cast to 'long long' before multiplication to avoid potential overflow. |
-| IntMultToLong.c:75:9:75:13 | ... * ... | Cast to 'size_t' before multiplication to avoid potential overflow. |
+| IntMultToLong.c:4:10:4:14 | ... * ... | Multiplication result may overflow 'int' before it is converted to 'long long'. Consider casting before multiplication to avoid potential overflow. |
+| IntMultToLong.c:7:16:7:20 | ... * ... | Multiplication result may overflow 'int' before it is converted to 'long long'. Consider casting before multiplication to avoid potential overflow. |
+| IntMultToLong.c:18:19:18:23 | ... * ... | Multiplication result may overflow 'float' before it is converted to 'double'. Consider casting before multiplication to avoid potential overflow. |
+| IntMultToLong.c:21:19:21:29 | ... * ... | Multiplication result may overflow 'float' before it is converted to 'double'. Consider casting before multiplication to avoid potential overflow. |
+| IntMultToLong.c:38:19:38:23 | ... * ... | Multiplication result may overflow 'float' before it is converted to 'double'. Consider casting before multiplication to avoid potential overflow. |
+| IntMultToLong.c:59:20:59:31 | ... * ... | Multiplication result may overflow 'float' before it is converted to 'double'. Consider casting before multiplication to avoid potential overflow. |
+| IntMultToLong.c:61:23:61:33 | ... * ... | Multiplication result may overflow 'int' before it is converted to 'long long'. Consider casting before multiplication to avoid potential overflow. |
+| IntMultToLong.c:63:23:63:40 | ... * ... | Multiplication result may overflow 'int' before it is converted to 'long long'. Consider casting before multiplication to avoid potential overflow. |
+| IntMultToLong.c:75:9:75:13 | ... * ... | Multiplication result may overflow 'int' before it is converted to 'size_t'. Consider casting before multiplication to avoid potential overflow. |


### PR DESCRIPTION
I always find myself having to re-read this alert a few times before I understand it. I think this is because:

1. most other alerts describe the problem first, not the solution.
2. It's ambiguous without further context whether the 'cast' in 'cast to X' is a verb or a noun .

Perhaps it's just me, but I think with this rephrasing it's easier to understand.