### PR TITLE
Revert "C++: update expected sizes of error and unknown types to be 1 byte"

### DIFF
--- a/cpp/ql/test/library-tests/type_sizes/type_sizes.expected
+++ b/cpp/ql/test/library-tests/type_sizes/type_sizes.expected
@@ -60,7 +60,7 @@
 | file://:0:0:0:0 | const char[5] | 5 |
 | file://:0:0:0:0 | decltype(nullptr) | 8 |
 | file://:0:0:0:0 | double | 8 |
-| file://:0:0:0:0 | error | 1 |
+| file://:0:0:0:0 | error | 0 |
 | file://:0:0:0:0 | float | 4 |
 | file://:0:0:0:0 | int | 4 |
 | file://:0:0:0:0 | int & | 8 |
@@ -78,7 +78,7 @@
 | file://:0:0:0:0 | signed long | 8 |
 | file://:0:0:0:0 | signed long long | 8 |
 | file://:0:0:0:0 | signed short | 2 |
-| file://:0:0:0:0 | unknown | 1 |
+| file://:0:0:0:0 | unknown | 0 |
 | file://:0:0:0:0 | unsigned __int128 | 16 |
 | file://:0:0:0:0 | unsigned char | 1 |
 | file://:0:0:0:0 | unsigned int | 4 |


### PR DESCRIPTION
This commit to update test changes got merged to Semmle/ql master but doesn't belong there because it's not compatible with how the 1.18 extractor works. The corresponding extractor change got merged to the internal-repo master right after the internal and external branches for 1.18 were taken.

@nickrolfe, please double-check that I have this right. When we mergeback this revert to `next`, we'll need to revert the revert.

This reverts commit d4f9b5eb5296b4f0c6693d576db8e55964f30f27 (PR #18).