### PR TITLE
TypeScript: fix alerts in ambient code

### DIFF
--- a/change-notes/1.18/analysis-javascript.md
+++ b/change-notes/1.18/analysis-javascript.md
@@ -85,6 +85,8 @@
   - [xss](https://github.com/leizongmin/js-xss)
   - [xtend](https://github.com/Raynos/xtend)
 
+* Handling of ambient TypeScript code has been improved. As a result, fewer false positives will be reported in `.d.ts` files.
+
 ## New queries
 
 | **Query**                   | **Tags**  | **Purpose**                                                        |

--- a/javascript/ql/src/Expressions/SuspiciousInvocation.ql
+++ b/javascript/ql/src/Expressions/SuspiciousInvocation.ql
@@ -15,5 +15,6 @@ private import semmle.javascript.dataflow.InferredTypes
 
 from InvokeExpr invk, DataFlow::AnalyzedNode callee
 where callee.asExpr() = invk.getCallee() and
-      forex (InferredType tp | tp = callee.getAType() | tp != TTFunction() and tp != TTClass())
+      forex (InferredType tp | tp = callee.getAType() | tp != TTFunction() and tp != TTClass()) and
+      not invk.isAmbient()
 select invk, "Callee is not a function: it has type " + callee.ppTypes() + "."

--- a/javascript/ql/src/Expressions/SuspiciousPropAccess.ql
+++ b/javascript/ql/src/Expressions/SuspiciousPropAccess.ql
@@ -31,5 +31,6 @@ predicate namespaceOrConstEnumAccess(VarAccess e) {
 from PropAccess pacc, DataFlow::AnalyzedNode base
 where base.asExpr() = pacc.getBase() and
       forex (InferredType tp | tp = base.getAType() | tp = TTNull() or tp = TTUndefined()) and
-      not namespaceOrConstEnumAccess(pacc.getBase())
+      not namespaceOrConstEnumAccess(pacc.getBase()) and
+      not pacc.isAmbient()
 select pacc, "The base expression of this property access is always " + base.ppTypes() + "."

--- a/javascript/ql/src/semmle/javascript/AST.qll
+++ b/javascript/ql/src/semmle/javascript/AST.qll
@@ -208,6 +208,11 @@ class TopLevel extends @toplevel, StmtContainer {
   override string toString() {
     result = "<toplevel>"
   }
+
+  override predicate isAmbient() {
+    getFile().getFileType().isTypeScript() and
+    getFile().getBaseName().matches("%.d.ts")
+  }
 }
 
 /**

--- a/javascript/ql/test/query-tests/Expressions/SuspiciousInvocation/ambient_extends.d.ts
+++ b/javascript/ql/test/query-tests/Expressions/SuspiciousInvocation/ambient_extends.d.ts
@@ -1,0 +1,3 @@
+export class Subclass extends BaseClass {} // OK - ambient context
+
+export class BaseClass {}


### PR DESCRIPTION
Prevents `SuspiciousPropAccess` and `SuspiciousInvocation` from reporting issues in `.d.ts` files.

Files ending with `.d.ts` are now considered entirely ambient. Previously we would rely on the `declare` keyword for class declarations to become ambient, but apparently `declare` has become optional for classes in `.d.ts` files.

For the most part, ambient code can't contain invocations, but an implicit super call is inserted for `extends` clauses which can cause false positives.