### PR TITLE
Revert "Version: Bump to 1.19.0 dev."

### DIFF
--- a/cpp/ql/src/META-INF/MANIFEST.MF
+++ b/cpp/ql/src/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Semmle C/C++ Default Queries
 Bundle-SymbolicName: com.semmle.plugin.semmlecode.cpp.queries;singleton:=true
-Bundle-Version: 1.19.0.qualifier
+Bundle-Version: 1.18.0.qualifier
 Bundle-Vendor: Semmle Ltd.
 Bundle-ActivationPolicy: lazy
-Require-Bundle: com.semmle.plugin.qdt.ui;bundle-version="[1.19.0.qualifier,1.19.0.qualifier]"
+Require-Bundle: com.semmle.plugin.qdt.ui;bundle-version="[1.18.0.qualifier,1.18.0.qualifier]"

--- a/csharp/ql/src/META-INF/MANIFEST.MF
+++ b/csharp/ql/src/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Semmle C# Default Queries
 Bundle-SymbolicName: com.semmle.plugin.semmlecode.csharp.queries;singleton:=true
-Bundle-Version: 1.19.0.qualifier
+Bundle-Version: 1.18.0.qualifier
 Bundle-Vendor: Semmle Ltd.
 Bundle-ActivationPolicy: lazy
-Require-Bundle: com.semmle.plugin.qdt.ui;bundle-version="[1.19.0.qualifier, 1.19.0.qualifier]"
+Require-Bundle: com.semmle.plugin.qdt.ui;bundle-version="[1.18.0.qualifier, 1.18.0.qualifier]"

--- a/java/ql/src/META-INF/MANIFEST.MF
+++ b/java/ql/src/META-INF/MANIFEST.MF
@@ -2,8 +2,8 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Semmle Default Java Queries
 Bundle-SymbolicName: com.semmle.plugin.semmlecode.queries;singleton:=true
-Bundle-Version: 1.19.0.qualifier
+Bundle-Version: 1.18.0.qualifier
 Bundle-Vendor: Semmle Ltd.
 Bundle-ActivationPolicy: lazy
-Require-Bundle: com.semmle.plugin.qdt.ui;bundle-version="[1.19.0.qualifier,1.19.0.qualifier]"
+Require-Bundle: com.semmle.plugin.qdt.ui;bundle-version="[1.18.0.qualifier,1.18.0.qualifier]"
 

--- a/javascript/ql/src/META-INF/MANIFEST.MF
+++ b/javascript/ql/src/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Semmle JavaScript Default Queries
 Bundle-SymbolicName: com.semmle.plugin.semmlecode.javascript.queries;singleton:=true
-Bundle-Version: 1.19.0.qualifier
+Bundle-Version: 1.18.0.qualifier
 Bundle-Vendor: Semmle Ltd.
 Bundle-ActivationPolicy: lazy
-Require-Bundle: com.semmle.plugin.qdt.ui;bundle-version="[1.19.0.qualifier, 1.19.0.qualifier]"
+Require-Bundle: com.semmle.plugin.qdt.ui;bundle-version="[1.18.0.qualifier, 1.18.0.qualifier]"


### PR DESCRIPTION
The version bump should now go into the `next` branch rather than `master`.
This reverts commit 2363f49e3a720b634aabbef8ea6cea3438f372a1.