### PR TITLE
C++: Tweak qldoc for declaration names

### DIFF
--- a/cpp/ql/src/semmle/code/cpp/Declaration.qll
+++ b/cpp/ql/src/semmle/code/cpp/Declaration.qll
@@ -87,11 +87,24 @@ abstract class Declaration extends Locatable, @declaration {
 
   override string toString() { result = this.getName() }
 
-  /** Gets the name of this declaration. */
+  /**
+   * Gets the name of this declaration.
+   *
+   * This name doesn't include a namespace or any argument types, so
+   * for example both functions `::open()` and `::std::ifstream::open(...)`
+   * have the same name.
+   *
+   * To get the name including the namespace, use `getQualifiedName` or
+   * `hasQualifiedName`.
+   *
+   * To test whether this declaration has a particular name in the global
+   * namespace, use `hasGlobalName`.
+   */
   abstract string getName();
+  /** Holds if this declaration has the given name. */
   predicate hasName(string name) { name = this.getName() }
 
-  /** Holds if this element has the given name in the global namespace. */
+  /** Holds if this declaration has the given name in the global namespace. */
   predicate hasGlobalName(string name) {
     hasName(name)
     and getNamespace() instanceof GlobalNamespace

--- a/cpp/ql/src/semmle/code/cpp/Function.qll
+++ b/cpp/ql/src/semmle/code/cpp/Function.qll
@@ -17,19 +17,6 @@ private import semmle.code.cpp.internal.ResolveClass
  * in more detail in `Declaration.qll`.
  */
 class Function extends Declaration, ControlFlowNode, AccessHolder, @function {
-
-  /**
-   * Gets the name of this function.
-   *
-   * This name doesn't include a namespace or any argument types, so both
-   * `::open()` and `::std::ifstream::open(...)` have the same name.
-   *
-   * To get the name including the namespace, use `getQualifiedName` or
-   * `hasQualifiedName`.
-   *
-   * To test whether a function has a particular name in the global
-   * namespace, use `hasGlobalName`.
-   */
   override string getName() { functions(underlyingElement(this),result,_) }
 
   /**


### PR DESCRIPTION
Mostly this is moving docs from the more specific Function class.