### PR TITLE
JS: fix typo in test case

### DIFF
--- a/javascript/ql/test/query-tests/Security/CWE-730/RegExpInjection.js
+++ b/javascript/ql/test/query-tests/Security/CWE-730/RegExpInjection.js
@@ -1,6 +1,6 @@
 var express = require('express');
 var app = express();
-var URI = reuires("urijs");
+var URI = require("urijs");
 app.get('/findKey', function(req, res) {
   var key = req.param("key"), input = req.param("input");
 


### PR DESCRIPTION
The typo had no effect in practice - the entire statement is there to give a test a better context.
Spotted in #164 