### PR TITLE
C++: Rewrite `reachable` without mutual recursion

### DIFF
--- a/cpp/ql/src/semmle/code/cpp/controlflow/ControlFlowGraph.qll
+++ b/cpp/ql/src/semmle/code/cpp/controlflow/ControlFlowGraph.qll
@@ -88,14 +88,21 @@ private cached module Cached {
   cached
   predicate reachable(ControlFlowNode n)
   {
-    exists(Function f | f.getEntryPoint() = n)
-    or
     // Okay to use successors_extended directly here
     (not successors_extended(_,n) and not successors_extended(n,_))
     or
-    reachable(n.getAPredecessor())
-    or
-    n instanceof CatchBlock
+    reachableNode(n)
+  }
+
+  /**
+   * An adapted version of the `successors_extended` relation that excludes
+   * impossible control-flow edges - flow will never occur along these
+   * edges, so it is safe (and indeed sensible) to remove them.
+   */
+  cached
+  predicate successors_adapted(ControlFlowNode pred, ControlFlowNode succ) {
+    successors_before_adapted(pred, succ) and
+    reachable(succ)
   }
 
   /** Holds if `condition` always evaluates to a nonzero value. */


### PR DESCRIPTION
This gives a measurable speedup, and I think it makes the code clearer. Before this, the `reachable` and `successors_adapted` predicates were mutually recursive together with four other predicates over two files.

I measured these benchmarks, where the numbers came from subtracting timestamps in the log rather than trusting the "Clause timing report" at the end:

- wireshark: reduced from 204s to 121s.
- linux: reduced from 59s to 36s.
- postgres: reduced from 28s to 12s.

I tested correctness and performance with this query, which gives the same results before and after:

```
select strictcount(ControlFlowNode node | reachable(node))
```

These changes were supposed to be a refactoring to enable even more ambitious speedups of the `reachable` predicate, but they bring large enough improvements on their own that I'd like to submit them as a separate PR. It's not clear whether it's worth following up with changes to make the code faster but more complex.

The performance issue with `reachable` is that it has a recursive occurrence on both sides of an `and`. That was hidden before but is visible after this refactoring. It's more expensive to compute such a general case of recursion than the usual case where one side of every `and` is constant.