### PR TITLE
JavaScript: fix CFG for EnhancedForStmt

### DIFF
--- a/javascript/ql/src/semmle/javascript/Stmt.qll
+++ b/javascript/ql/src/semmle/javascript/Stmt.qll
@@ -607,6 +607,10 @@ abstract class EnhancedForLoop extends LoopStmt {
   override Stmt getBody() {
     result = getChildStmt(2)
   }
+
+  override ControlFlowNode getFirstControlFlowNode() {
+    result = getIteratorExpr().getFirstControlFlowNode()
+  }
 }
 
 /** A `for`-`in` loop. */

--- a/javascript/ql/test/library-tests/CFG/CFG.expected
+++ b/javascript/ql/test/library-tests/CFG/CFG.expected
@@ -644,15 +644,14 @@
 | forof | 1 | entry node of functio ...     ;\\n} | 2 | {\\n    f ...     ;\\n} |
 | forof | 1 | f | 1 | functio ...     ;\\n} |
 | forof | 1 | functio ...     ;\\n} | 10 | exit node of <toplevel> |
-| forof | 2 | {\\n    f ...     ;\\n} | 3 | for (\\n  ... )\\n    ; |
-| forof | 3 | for (\\n  ... )\\n    ; | 7 | [] |
+| forof | 2 | {\\n    f ...     ;\\n} | 7 | [] |
+| forof | 3 | for (\\n  ... )\\n    ; | 4 | var\\n        x |
+| forof | 3 | for (\\n  ... )\\n    ; | 9 | exit node of functio ...     ;\\n} |
 | forof | 4 | var\\n        x | 5 | x |
 | forof | 5 | x | 5 | x |
 | forof | 5 | x | 8 | ; |
-| forof | 7 | [] | 4 | var\\n        x |
-| forof | 7 | [] | 9 | exit node of functio ...     ;\\n} |
-| forof | 8 | ; | 4 | var\\n        x |
-| forof | 8 | ; | 9 | exit node of functio ...     ;\\n} |
+| forof | 7 | [] | 3 | for (\\n  ... )\\n    ; |
+| forof | 8 | ; | 3 | for (\\n  ... )\\n    ; |
 | globals | 1 | entry node of <toplevel> | 14 | g |
 | globals | 1 | var\\n x,\\n y; | 2 | x |
 | globals | 2 | x | 2 | x |
@@ -662,15 +661,14 @@
 | globals | 4 | {\\n    var\\n     z;\\n} | 5 | var\\n     z; |
 | globals | 5 | var\\n     z; | 6 | z |
 | globals | 6 | z | 6 | z |
-| globals | 6 | z | 8 | for (\\n  ... [])\\n  ; |
-| globals | 8 | for (\\n  ... [])\\n  ; | 11 | [] |
+| globals | 6 | z | 11 | [] |
+| globals | 8 | for (\\n  ... [])\\n  ; | 9 | var\\n  a |
+| globals | 8 | for (\\n  ... [])\\n  ; | 13 | function\\n g()\\n{\\n} |
 | globals | 9 | var\\n  a | 10 | a |
 | globals | 10 | a | 10 | a |
 | globals | 10 | a | 12 | ; |
-| globals | 11 | [] | 9 | var\\n  a |
-| globals | 11 | [] | 13 | function\\n g()\\n{\\n} |
-| globals | 12 | ; | 9 | var\\n  a |
-| globals | 12 | ; | 13 | function\\n g()\\n{\\n} |
+| globals | 11 | [] | 8 | for (\\n  ... [])\\n  ; |
+| globals | 12 | ; | 8 | for (\\n  ... [])\\n  ; |
 | globals | 13 | entry node of function\\n g()\\n{\\n} | 15 | {\\n} |
 | globals | 13 | function\\n g()\\n{\\n} | 17 | !\\nfunction\\n h()\\n{\\n}; |
 | globals | 14 | g | 1 | var\\n x,\\n y; |

--- a/javascript/ql/test/query-tests/Declarations/DeadStoreOfLocal/for-of-continue.js
+++ b/javascript/ql/test/query-tests/Declarations/DeadStoreOfLocal/for-of-continue.js
@@ -1,0 +1,13 @@
+function f() {
+  let y = false;
+  for (const x of [1, 2, 3]) {
+    if (x > 0) {
+        y = true; // OK
+        continue;
+    }
+    return;
+  }
+  if (!y) {
+    console.log("Hello");
+  }
+}


### PR DESCRIPTION
Fixes a bug in the CFG for `continue` in `for..in` and `for..of` statements.

The main changes are in the extractor, this has corresponding QL updates.