### PR TITLE
C++: IR: InstructionSanity::duplicateOperand perf

### DIFF
--- a/cpp/ql/src/semmle/code/cpp/ir/implementation/aliased_ssa/Instruction.qll
+++ b/cpp/ql/src/semmle/code/cpp/ir/implementation/aliased_ssa/Instruction.qll
@@ -63,7 +63,7 @@ module InstructionSanity {
    * Holds if instruction `instr` has multiple operands with tag `tag`.
    */
   query predicate duplicateOperand(Instruction instr, OperandTag tag) {
-    count(instr.getOperand(tag)) > 1 and
+    strictcount(instr.getOperand(tag)) > 1 and
     not tag instanceof UnmodeledUseOperand
   }
 

--- a/cpp/ql/src/semmle/code/cpp/ir/implementation/raw/Instruction.qll
+++ b/cpp/ql/src/semmle/code/cpp/ir/implementation/raw/Instruction.qll
@@ -63,7 +63,7 @@ module InstructionSanity {
    * Holds if instruction `instr` has multiple operands with tag `tag`.
    */
   query predicate duplicateOperand(Instruction instr, OperandTag tag) {
-    count(instr.getOperand(tag)) > 1 and
+    strictcount(instr.getOperand(tag)) > 1 and
     not tag instanceof UnmodeledUseOperand
   }
 

--- a/cpp/ql/src/semmle/code/cpp/ir/implementation/unaliased_ssa/Instruction.qll
+++ b/cpp/ql/src/semmle/code/cpp/ir/implementation/unaliased_ssa/Instruction.qll
@@ -63,7 +63,7 @@ module InstructionSanity {
    * Holds if instruction `instr` has multiple operands with tag `tag`.
    */
   query predicate duplicateOperand(Instruction instr, OperandTag tag) {
-    count(instr.getOperand(tag)) > 1 and
+    strictcount(instr.getOperand(tag)) > 1 and
     not tag instanceof UnmodeledUseOperand
   }
 


### PR DESCRIPTION
The `InstructionSanity::duplicateOperand` predicate used `count` instead of `strictcount`. The 0-case of this `count` was as large as the Cartesian product of `Instruction` and `OperandTag`, which made `duplicateOperand` take forever to compute on large snapshots.