### PR TITLE
C++: Restructure UnsafeUseOfStrcat for performance

### DIFF
--- a/cpp/ql/src/Likely Bugs/Memory Management/UnsafeUseOfStrcat.ql
+++ b/cpp/ql/src/Likely Bugs/Memory Management/UnsafeUseOfStrcat.ql
@@ -29,11 +29,20 @@ predicate isEffectivelyConstAccess(VariableAccess a)
   )
 }
 
-from FunctionCall fc, VariableAccess src
-where fc.getTarget().hasName("strcat") and
-      src = fc.getArgument(1) and
-      not src.getType() instanceof ArrayType and
+class StrcatSource extends VariableAccess {
+  FunctionCall strcat;
+
+  StrcatSource() {
+    strcat.getTarget().hasName("strcat") and
+    this = strcat.getArgument(1)
+  }
+
+  FunctionCall getStrcatCall() { result = strcat }
+}
+
+from StrcatSource src
+where not src.getType() instanceof ArrayType and
       not exists(BufferSizeExpr bse |
         bse.getArg().(VariableAccess).getTarget() = src.getTarget()) and
       not isEffectivelyConstAccess(src)
-select fc, "Always check the size of the source buffer when using strcat."
+select src.getStrcatCall(), "Always check the size of the source buffer when using strcat."


### PR DESCRIPTION
This query gets optimized badly, and it has started timing out when we run it on our own code base. Most of the evaluation time is spent in an RA predicate named `#select#cpe#1#f#antijoin_rhs#1`, which takes 1m36s a Wireshark snapshot.

This restructuring of the code makes the problematic RA predicate go away.

I'm targetting 1.18 here because if this query can cause timeouts on our internal dashboard then I worry that it's an observable regression since 1.17. I haven't actually been able to reproduce the timeout from the Dashboards/Internal Jenkins job, so this change may or may not fix it, but nothing else seems slow about this query.