### PR TITLE
Java: Improve alert wording in `java/integer-multiplication-cast-to-long`.

### DIFF
--- a/java/ql/src/Likely Bugs/Arithmetic/IntMultToLong.ql
+++ b/java/ql/src/Likely Bugs/Arithmetic/IntMultToLong.ql
@@ -15,6 +15,7 @@
  *       external/cwe/cwe-197
  *       external/cwe/cwe-681
  */
+
 import java
 import semmle.code.java.dataflow.RangeUtils
 import semmle.code.java.Conversions
@@ -25,7 +26,8 @@ predicate small(MulExpr e) {
     lhs = e.getLeftOperand().getProperExpr().(ConstantIntegerExpr).getIntValue() and
     rhs = e.getRightOperand().getProperExpr().(ConstantIntegerExpr).getIntValue() and
     lhs * rhs = res and
-    t.getOrdPrimitiveType().getMinValue() <= res and res <= t.getOrdPrimitiveType().getMaxValue()
+    t.getOrdPrimitiveType().getMinValue() <= res and
+    res <= t.getOrdPrimitiveType().getMaxValue()
   )
 }
 
@@ -52,4 +54,7 @@ where
   // not obviously small and ok
   not small(e) and
   e.getEnclosingCallable().fromSource()
-select c, "Potential overflow in $@ before it is converted to "+ destType.getName() +" by use in " + ("a " + c.kind()).regexpReplaceAll("^a ([aeiou])", "an $1") + ".", e, sourceType.getName() + " multiplication"
+select c,
+  "Potential overflow in $@ before it is converted to " + destType.getName() + " by use in " +
+    ("a " + c.kind()).regexpReplaceAll("^a ([aeiou])", "an $1") + ".", e,
+  sourceType.getName() + " multiplication"

--- a/java/ql/src/Likely Bugs/Arithmetic/IntMultToLong.ql
+++ b/java/ql/src/Likely Bugs/Arithmetic/IntMultToLong.ql
@@ -52,4 +52,4 @@ where
   // not obviously small and ok
   not small(e) and
   e.getEnclosingCallable().fromSource()
-select c, "$@ converted to "+ destType.getName() +" by use in " + ("a " + c.kind()).regexpReplaceAll("^a ([aeiou])", "an $1") + ".", e, sourceType.getName() + " multiplication"
+select c, "Potential overflow in $@ before it is converted to "+ destType.getName() +" by use in " + ("a " + c.kind()).regexpReplaceAll("^a ([aeiou])", "an $1") + ".", e, sourceType.getName() + " multiplication"

--- a/java/ql/test/query-tests/security/CWE-190/semmle/tests/IntMultToLong.expected
+++ b/java/ql/test/query-tests/security/CWE-190/semmle/tests/IntMultToLong.expected
@@ -1,4 +1,4 @@
-| Test.java:20:23:20:48 | ... * ... | $@ converted to long by use in an assignment context. | Test.java:20:23:20:48 | ... * ... | int multiplication |
-| Test.java:27:23:27:52 | ... + ... | $@ converted to long by use in an assignment context. | Test.java:27:23:27:48 | ... * ... | int multiplication |
-| Test.java:34:23:34:63 | ...?...:... | $@ converted to long by use in an assignment context. | Test.java:34:30:34:55 | ... * ... | int multiplication |
-| Test.java:41:25:41:49 | ... * ... | $@ converted to double by use in an assignment context. | Test.java:41:25:41:49 | ... * ... | long multiplication |
+| Test.java:20:23:20:48 | ... * ... | Potential overflow in $@ before it is converted to long by use in an assignment context. | Test.java:20:23:20:48 | ... * ... | int multiplication |
+| Test.java:27:23:27:52 | ... + ... | Potential overflow in $@ before it is converted to long by use in an assignment context. | Test.java:27:23:27:48 | ... * ... | int multiplication |
+| Test.java:34:23:34:63 | ...?...:... | Potential overflow in $@ before it is converted to long by use in an assignment context. | Test.java:34:30:34:55 | ... * ... | int multiplication |
+| Test.java:41:25:41:49 | ... * ... | Potential overflow in $@ before it is converted to double by use in an assignment context. | Test.java:41:25:41:49 | ... * ... | long multiplication |


### PR DESCRIPTION
This alert message has been causing some confusion as it didn't mention the real problem, that is, potential overflow.