### PR TITLE
CPP: Permit more typedefs in WrongTypeFormatArguments.ql

### DIFF
--- a/change-notes/1.19/analysis-cpp.md
+++ b/change-notes/1.19/analysis-cpp.md
@@ -13,7 +13,7 @@
 | **Query**                  | **Expected impact**    | **Change**                                                       |
 |----------------------------|------------------------|------------------------------------------------------------------|
 | Resource not released in destructor | Fewer false positive results | Placement new is now excluded from the query. |
-
+| Wrong type of arguments to formatting function | Fewer false positive results | False positive results involving typedefs have been removed. |
 
 ## Changes to QL libraries
 

--- a/cpp/ql/test/query-tests/Likely Bugs/Format/WrongTypeFormatArguments/Linux_signed_chars/WrongTypeFormatArguments.expected
+++ b/cpp/ql/test/query-tests/Likely Bugs/Format/WrongTypeFormatArguments/Linux_signed_chars/WrongTypeFormatArguments.expected
@@ -11,16 +11,6 @@
 | printf1.h:45:18:45:20 | ull | This argument should be of type 'unsigned int' but is of type 'unsigned long long' |
 | printf1.h:46:18:46:20 | ull | This argument should be of type 'unsigned int' but is of type 'unsigned long long' |
 | printf1.h:47:19:47:21 | ull | This argument should be of type 'unsigned int' but is of type 'unsigned long long' |
-| printf1.h:68:19:68:21 | sst | This argument should be of type 'size_t' but is of type 'long' |
-| printf1.h:70:19:70:20 | ul | This argument should be of type 'ssize_t' but is of type 'unsigned long' |
-| printf1.h:71:19:71:20 | st | This argument should be of type 'ssize_t' but is of type 'unsigned long' |
-| printf1.h:72:19:72:20 | ST | This argument should be of type 'ssize_t' but is of type 'unsigned long' |
-| printf1.h:73:19:73:22 | c_st | This argument should be of type 'ssize_t' but is of type 'unsigned long' |
-| printf1.h:74:19:74:22 | C_ST | This argument should be of type 'ssize_t' but is of type 'unsigned long' |
-| printf1.h:75:19:75:28 | sizeof(<expr>) | This argument should be of type 'ssize_t' but is of type 'unsigned long' |
-| printf1.h:82:23:82:35 | ... - ... | This argument should be of type 'ptrdiff_t' but is of type 'long' |
-| printf1.h:83:23:83:35 | ... - ... | This argument should be of type 'size_t' but is of type 'long' |
-| printf1.h:102:19:102:21 | ... - ... | This argument should be of type 'ptrdiff_t' but is of type 'long' |
 | real_world.h:61:21:61:22 | & ... | This argument should be of type 'int *' but is of type 'short *' |
 | real_world.h:62:22:62:23 | & ... | This argument should be of type 'short *' but is of type 'int *' |
 | real_world.h:63:22:63:24 | & ... | This argument should be of type 'short *' but is of type 'unsigned int *' |

--- a/cpp/ql/test/query-tests/Likely Bugs/Format/WrongTypeFormatArguments/Linux_signed_chars/WrongTypeFormatArguments.expected
+++ b/cpp/ql/test/query-tests/Likely Bugs/Format/WrongTypeFormatArguments/Linux_signed_chars/WrongTypeFormatArguments.expected
@@ -18,7 +18,9 @@
 | printf1.h:73:19:73:22 | c_st | This argument should be of type 'ssize_t' but is of type 'unsigned long' |
 | printf1.h:74:19:74:22 | C_ST | This argument should be of type 'ssize_t' but is of type 'unsigned long' |
 | printf1.h:75:19:75:28 | sizeof(<expr>) | This argument should be of type 'ssize_t' but is of type 'unsigned long' |
+| printf1.h:82:23:82:35 | ... - ... | This argument should be of type 'ptrdiff_t' but is of type 'long' |
 | printf1.h:83:23:83:35 | ... - ... | This argument should be of type 'size_t' but is of type 'long' |
+| printf1.h:102:19:102:21 | ... - ... | This argument should be of type 'ptrdiff_t' but is of type 'long' |
 | real_world.h:61:21:61:22 | & ... | This argument should be of type 'int *' but is of type 'short *' |
 | real_world.h:62:22:62:23 | & ... | This argument should be of type 'short *' but is of type 'int *' |
 | real_world.h:63:22:63:24 | & ... | This argument should be of type 'short *' but is of type 'unsigned int *' |

--- a/cpp/ql/test/query-tests/Likely Bugs/Format/WrongTypeFormatArguments/Linux_signed_chars/printf1.h
+++ b/cpp/ql/test/query-tests/Likely Bugs/Format/WrongTypeFormatArguments/Linux_signed_chars/printf1.h
@@ -65,23 +65,23 @@ void g()
     printf("%zu", c_st); // ok
     printf("%zu", C_ST); // ok
     printf("%zu", sizeof(ul)); // ok
-    printf("%zu", sst); // not ok [NOT DETECTED ON MICROSOFT]
+    printf("%zu", sst); // not ok [NOT DETECTED]
 
-    printf("%zd", ul); // not ok
-    printf("%zd", st); // not ok
-    printf("%zd", ST); // not ok
-    printf("%zd", c_st); // not ok
-    printf("%zd", C_ST); // not ok
-    printf("%zd", sizeof(ul)); // not ok
+    printf("%zd", ul); // not ok [NOT DETECTED]
+    printf("%zd", st); // not ok [NOT DETECTED]
+    printf("%zd", ST); // not ok [NOT DETECTED]
+    printf("%zd", c_st); // not ok [NOT DETECTED]
+    printf("%zd", C_ST); // not ok [NOT DETECTED]
+    printf("%zd", sizeof(ul)); // not ok [NOT DETECTED]
     printf("%zd", sst); // ok
     {
         char *ptr_a, *ptr_b;
         char buf[100];
 
         printf("%tu", ptr_a - ptr_b); // ok
-        printf("%td", ptr_a - ptr_b); // ok [FALSE POSITIVE]
-        printf("%zu", ptr_a - ptr_b); // ok (dubious) [DETECTED ON LINUX ONLY]
-        printf("%zd", ptr_a - ptr_b); // ok (dubious) [DETECTED ON MICROSOFT ONLY]
+        printf("%td", ptr_a - ptr_b); // ok
+        printf("%zu", ptr_a - ptr_b); // ok (dubious)
+        printf("%zd", ptr_a - ptr_b); // ok (dubious)
     }
 }
 
@@ -99,5 +99,5 @@ void fun1(unsigned char* a, unsigned char* b) {
   ptrdiff_t pdt;
 
   printf("%td\n", pdt); // GOOD
-  printf("%td\n", a-b); // GOOD [FALSE POSITIVE]
+  printf("%td\n", a-b); // GOOD
 }

--- a/cpp/ql/test/query-tests/Likely Bugs/Format/WrongTypeFormatArguments/Linux_signed_chars/printf1.h
+++ b/cpp/ql/test/query-tests/Likely Bugs/Format/WrongTypeFormatArguments/Linux_signed_chars/printf1.h
@@ -79,7 +79,7 @@ void g()
         char buf[100];
 
         printf("%tu", ptr_a - ptr_b); // ok
-        printf("%td", ptr_a - ptr_b); // ok
+        printf("%td", ptr_a - ptr_b); // ok [FALSE POSITIVE]
         printf("%zu", ptr_a - ptr_b); // ok (dubious) [DETECTED ON LINUX ONLY]
         printf("%zd", ptr_a - ptr_b); // ok (dubious) [DETECTED ON MICROSOFT ONLY]
     }
@@ -91,4 +91,13 @@ void h(int i, struct some_type *j, int k)
 	// recognize.  We should not report a problem if we're unable to understand what's
 	// going on.
 	printf("%i %R %i", i, j, k); // GOOD (as far as we can tell)
+}
+
+typedef long ptrdiff_t;
+
+void fun1(unsigned char* a, unsigned char* b) {
+  ptrdiff_t pdt;
+
+  printf("%td\n", pdt); // GOOD
+  printf("%td\n", a-b); // GOOD [FALSE POSITIVE]
 }

--- a/cpp/ql/test/query-tests/Likely Bugs/Format/WrongTypeFormatArguments/Linux_unsigned_chars/WrongTypeFormatArguments.expected
+++ b/cpp/ql/test/query-tests/Likely Bugs/Format/WrongTypeFormatArguments/Linux_unsigned_chars/WrongTypeFormatArguments.expected
@@ -11,16 +11,6 @@
 | printf1.h:45:18:45:20 | ull | This argument should be of type 'unsigned int' but is of type 'unsigned long long' |
 | printf1.h:46:18:46:20 | ull | This argument should be of type 'unsigned int' but is of type 'unsigned long long' |
 | printf1.h:47:19:47:21 | ull | This argument should be of type 'unsigned int' but is of type 'unsigned long long' |
-| printf1.h:68:19:68:21 | sst | This argument should be of type 'size_t' but is of type 'long' |
-| printf1.h:70:19:70:20 | ul | This argument should be of type 'ssize_t' but is of type 'unsigned long' |
-| printf1.h:71:19:71:20 | st | This argument should be of type 'ssize_t' but is of type 'unsigned long' |
-| printf1.h:72:19:72:20 | ST | This argument should be of type 'ssize_t' but is of type 'unsigned long' |
-| printf1.h:73:19:73:22 | c_st | This argument should be of type 'ssize_t' but is of type 'unsigned long' |
-| printf1.h:74:19:74:22 | C_ST | This argument should be of type 'ssize_t' but is of type 'unsigned long' |
-| printf1.h:75:19:75:28 | sizeof(<expr>) | This argument should be of type 'ssize_t' but is of type 'unsigned long' |
-| printf1.h:82:23:82:35 | ... - ... | This argument should be of type 'ptrdiff_t' but is of type 'long' |
-| printf1.h:83:23:83:35 | ... - ... | This argument should be of type 'size_t' but is of type 'long' |
-| printf1.h:102:19:102:21 | ... - ... | This argument should be of type 'ptrdiff_t' but is of type 'long' |
 | real_world.h:61:21:61:22 | & ... | This argument should be of type 'int *' but is of type 'short *' |
 | real_world.h:62:22:62:23 | & ... | This argument should be of type 'short *' but is of type 'int *' |
 | real_world.h:63:22:63:24 | & ... | This argument should be of type 'short *' but is of type 'unsigned int *' |

--- a/cpp/ql/test/query-tests/Likely Bugs/Format/WrongTypeFormatArguments/Linux_unsigned_chars/WrongTypeFormatArguments.expected
+++ b/cpp/ql/test/query-tests/Likely Bugs/Format/WrongTypeFormatArguments/Linux_unsigned_chars/WrongTypeFormatArguments.expected
@@ -18,7 +18,9 @@
 | printf1.h:73:19:73:22 | c_st | This argument should be of type 'ssize_t' but is of type 'unsigned long' |
 | printf1.h:74:19:74:22 | C_ST | This argument should be of type 'ssize_t' but is of type 'unsigned long' |
 | printf1.h:75:19:75:28 | sizeof(<expr>) | This argument should be of type 'ssize_t' but is of type 'unsigned long' |
+| printf1.h:82:23:82:35 | ... - ... | This argument should be of type 'ptrdiff_t' but is of type 'long' |
 | printf1.h:83:23:83:35 | ... - ... | This argument should be of type 'size_t' but is of type 'long' |
+| printf1.h:102:19:102:21 | ... - ... | This argument should be of type 'ptrdiff_t' but is of type 'long' |
 | real_world.h:61:21:61:22 | & ... | This argument should be of type 'int *' but is of type 'short *' |
 | real_world.h:62:22:62:23 | & ... | This argument should be of type 'short *' but is of type 'int *' |
 | real_world.h:63:22:63:24 | & ... | This argument should be of type 'short *' but is of type 'unsigned int *' |

--- a/cpp/ql/test/query-tests/Likely Bugs/Format/WrongTypeFormatArguments/Linux_unsigned_chars/printf1.h
+++ b/cpp/ql/test/query-tests/Likely Bugs/Format/WrongTypeFormatArguments/Linux_unsigned_chars/printf1.h
@@ -65,23 +65,23 @@ void g()
     printf("%zu", c_st); // ok
     printf("%zu", C_ST); // ok
     printf("%zu", sizeof(ul)); // ok
-    printf("%zu", sst); // not ok [NOT DETECTED ON MICROSOFT]
+    printf("%zu", sst); // not ok [NOT DETECTED]
 
-    printf("%zd", ul); // not ok
-    printf("%zd", st); // not ok
-    printf("%zd", ST); // not ok
-    printf("%zd", c_st); // not ok
-    printf("%zd", C_ST); // not ok
-    printf("%zd", sizeof(ul)); // not ok
+    printf("%zd", ul); // not ok [NOT DETECTED]
+    printf("%zd", st); // not ok [NOT DETECTED]
+    printf("%zd", ST); // not ok [NOT DETECTED]
+    printf("%zd", c_st); // not ok [NOT DETECTED]
+    printf("%zd", C_ST); // not ok [NOT DETECTED]
+    printf("%zd", sizeof(ul)); // not ok [NOT DETECTED]
     printf("%zd", sst); // ok
     {
         char *ptr_a, *ptr_b;
         char buf[100];
 
         printf("%tu", ptr_a - ptr_b); // ok
-        printf("%td", ptr_a - ptr_b); // ok [FALSE POSITIVE]
-        printf("%zu", ptr_a - ptr_b); // ok (dubious) [DETECTED ON LINUX ONLY]
-        printf("%zd", ptr_a - ptr_b); // ok (dubious) [DETECTED ON MICROSOFT ONLY]
+        printf("%td", ptr_a - ptr_b); // ok
+        printf("%zu", ptr_a - ptr_b); // ok (dubious)
+        printf("%zd", ptr_a - ptr_b); // ok (dubious)
     }
 }
 
@@ -99,5 +99,5 @@ void fun1(unsigned char* a, unsigned char* b) {
   ptrdiff_t pdt;
 
   printf("%td\n", pdt); // GOOD
-  printf("%td\n", a-b); // GOOD [FALSE POSITIVE]
+  printf("%td\n", a-b); // GOOD
 }

--- a/cpp/ql/test/query-tests/Likely Bugs/Format/WrongTypeFormatArguments/Linux_unsigned_chars/printf1.h
+++ b/cpp/ql/test/query-tests/Likely Bugs/Format/WrongTypeFormatArguments/Linux_unsigned_chars/printf1.h
@@ -79,7 +79,7 @@ void g()
         char buf[100];
 
         printf("%tu", ptr_a - ptr_b); // ok
-        printf("%td", ptr_a - ptr_b); // ok
+        printf("%td", ptr_a - ptr_b); // ok [FALSE POSITIVE]
         printf("%zu", ptr_a - ptr_b); // ok (dubious) [DETECTED ON LINUX ONLY]
         printf("%zd", ptr_a - ptr_b); // ok (dubious) [DETECTED ON MICROSOFT ONLY]
     }
@@ -91,4 +91,13 @@ void h(int i, struct some_type *j, int k)
 	// recognize.  We should not report a problem if we're unable to understand what's
 	// going on.
 	printf("%i %R %i", i, j, k); // GOOD (as far as we can tell)
+}
+
+typedef long ptrdiff_t;
+
+void fun1(unsigned char* a, unsigned char* b) {
+  ptrdiff_t pdt;
+
+  printf("%td\n", pdt); // GOOD
+  printf("%td\n", a-b); // GOOD [FALSE POSITIVE]
 }

--- a/cpp/ql/test/query-tests/Likely Bugs/Format/WrongTypeFormatArguments/Microsoft/WrongTypeFormatArguments.expected
+++ b/cpp/ql/test/query-tests/Likely Bugs/Format/WrongTypeFormatArguments/Microsoft/WrongTypeFormatArguments.expected
@@ -17,7 +17,9 @@
 | printf1.h:73:19:73:22 | c_st | This argument should be of type 'ssize_t' but is of type 'unsigned long long' |
 | printf1.h:74:19:74:22 | C_ST | This argument should be of type 'ssize_t' but is of type 'unsigned long long' |
 | printf1.h:75:19:75:28 | sizeof(<expr>) | This argument should be of type 'ssize_t' but is of type 'unsigned long long' |
+| printf1.h:82:23:82:35 | ... - ... | This argument should be of type 'ptrdiff_t' but is of type 'long long' |
 | printf1.h:84:23:84:35 | ... - ... | This argument should be of type 'ssize_t' but is of type 'long long' |
+| printf1.h:102:19:102:21 | ... - ... | This argument should be of type 'ptrdiff_t' but is of type 'long long' |
 | real_world.h:61:21:61:22 | & ... | This argument should be of type 'int *' but is of type 'short *' |
 | real_world.h:62:22:62:23 | & ... | This argument should be of type 'short *' but is of type 'int *' |
 | real_world.h:63:22:63:24 | & ... | This argument should be of type 'short *' but is of type 'unsigned int *' |

--- a/cpp/ql/test/query-tests/Likely Bugs/Format/WrongTypeFormatArguments/Microsoft/WrongTypeFormatArguments.expected
+++ b/cpp/ql/test/query-tests/Likely Bugs/Format/WrongTypeFormatArguments/Microsoft/WrongTypeFormatArguments.expected
@@ -11,15 +11,12 @@
 | printf1.h:45:18:45:20 | ull | This argument should be of type 'unsigned int' but is of type 'unsigned long long' |
 | printf1.h:46:18:46:20 | ull | This argument should be of type 'unsigned int' but is of type 'unsigned long long' |
 | printf1.h:47:19:47:21 | ull | This argument should be of type 'unsigned int' but is of type 'unsigned long long' |
-| printf1.h:70:19:70:20 | ul | This argument should be of type 'ssize_t' but is of type 'unsigned long' |
 | printf1.h:71:19:71:20 | st | This argument should be of type 'ssize_t' but is of type 'unsigned long long' |
 | printf1.h:72:19:72:20 | ST | This argument should be of type 'ssize_t' but is of type 'unsigned long long' |
 | printf1.h:73:19:73:22 | c_st | This argument should be of type 'ssize_t' but is of type 'unsigned long long' |
 | printf1.h:74:19:74:22 | C_ST | This argument should be of type 'ssize_t' but is of type 'unsigned long long' |
 | printf1.h:75:19:75:28 | sizeof(<expr>) | This argument should be of type 'ssize_t' but is of type 'unsigned long long' |
-| printf1.h:82:23:82:35 | ... - ... | This argument should be of type 'ptrdiff_t' but is of type 'long long' |
 | printf1.h:84:23:84:35 | ... - ... | This argument should be of type 'ssize_t' but is of type 'long long' |
-| printf1.h:102:19:102:21 | ... - ... | This argument should be of type 'ptrdiff_t' but is of type 'long long' |
 | real_world.h:61:21:61:22 | & ... | This argument should be of type 'int *' but is of type 'short *' |
 | real_world.h:62:22:62:23 | & ... | This argument should be of type 'short *' but is of type 'int *' |
 | real_world.h:63:22:63:24 | & ... | This argument should be of type 'short *' but is of type 'unsigned int *' |

--- a/cpp/ql/test/query-tests/Likely Bugs/Format/WrongTypeFormatArguments/Microsoft/printf1.h
+++ b/cpp/ql/test/query-tests/Likely Bugs/Format/WrongTypeFormatArguments/Microsoft/printf1.h
@@ -65,9 +65,9 @@ void g()
     printf("%zu", c_st); // ok
     printf("%zu", C_ST); // ok
     printf("%zu", sizeof(ul)); // ok
-    printf("%zu", sst); // not ok [NOT DETECTED ON MICROSOFT]
+    printf("%zu", sst); // not ok [NOT DETECTED]
 
-    printf("%zd", ul); // not ok
+    printf("%zd", ul); // not ok [NOT DETECTED]
     printf("%zd", st); // not ok
     printf("%zd", ST); // not ok
     printf("%zd", c_st); // not ok
@@ -79,9 +79,9 @@ void g()
         char buf[100];
 
         printf("%tu", ptr_a - ptr_b); // ok
-        printf("%td", ptr_a - ptr_b); // ok [FALSE POSITIVE]
-        printf("%zu", ptr_a - ptr_b); // ok (dubious) [DETECTED ON LINUX ONLY]
-        printf("%zd", ptr_a - ptr_b); // ok (dubious) [DETECTED ON MICROSOFT ONLY]
+        printf("%td", ptr_a - ptr_b); // ok
+        printf("%zu", ptr_a - ptr_b); // ok (dubious)
+        printf("%zd", ptr_a - ptr_b); // ok (dubious) [FALSE POSITIVE]
     }
 }
 
@@ -99,5 +99,5 @@ void fun1(unsigned char* a, unsigned char* b) {
   ptrdiff_t pdt;
 
   printf("%td\n", pdt); // GOOD
-  printf("%td\n", a-b); // GOOD [FALSE POSITIVE]
+  printf("%td\n", a-b); // GOOD
 }

--- a/cpp/ql/test/query-tests/Likely Bugs/Format/WrongTypeFormatArguments/Microsoft/printf1.h
+++ b/cpp/ql/test/query-tests/Likely Bugs/Format/WrongTypeFormatArguments/Microsoft/printf1.h
@@ -79,7 +79,7 @@ void g()
         char buf[100];
 
         printf("%tu", ptr_a - ptr_b); // ok
-        printf("%td", ptr_a - ptr_b); // ok
+        printf("%td", ptr_a - ptr_b); // ok [FALSE POSITIVE]
         printf("%zu", ptr_a - ptr_b); // ok (dubious) [DETECTED ON LINUX ONLY]
         printf("%zd", ptr_a - ptr_b); // ok (dubious) [DETECTED ON MICROSOFT ONLY]
     }
@@ -91,4 +91,13 @@ void h(int i, struct some_type *j, int k)
 	// recognize.  We should not report a problem if we're unable to understand what's
 	// going on.
 	printf("%i %R %i", i, j, k); // GOOD (as far as we can tell)
+}
+
+typedef long long ptrdiff_t;
+
+void fun1(unsigned char* a, unsigned char* b) {
+  ptrdiff_t pdt;
+
+  printf("%td\n", pdt); // GOOD
+  printf("%td\n", a-b); // GOOD [FALSE POSITIVE]
 }

--- a/cpp/ql/test/query-tests/Likely Bugs/Format/WrongTypeFormatArguments/Microsoft/real_world.h
+++ b/cpp/ql/test/query-tests/Likely Bugs/Format/WrongTypeFormatArguments/Microsoft/real_world.h
@@ -43,7 +43,7 @@ void someFunction()
 	WCHAR filename[MAX_LONGPATH];
 	int linenum;
 
-	msg_out("Source file: %S @ %d\n", filename, linenum); // GOOD
+	msg_out("Source file: %S @ %d\n", filename, linenum); // GOOD [FALSE POSITIVE]
 }
 
 // --------------------------------------------------------------

--- a/cpp/ql/test/query-tests/Likely Bugs/Format/WrongTypeFormatArguments/Microsoft_no_wchar/WrongTypeFormatArguments.expected
+++ b/cpp/ql/test/query-tests/Likely Bugs/Format/WrongTypeFormatArguments/Microsoft_no_wchar/WrongTypeFormatArguments.expected
@@ -11,15 +11,13 @@
 | printf1.h:45:18:45:20 | ull | This argument should be of type 'unsigned int' but is of type 'unsigned long long' |
 | printf1.h:46:18:46:20 | ull | This argument should be of type 'unsigned int' but is of type 'unsigned long long' |
 | printf1.h:47:19:47:21 | ull | This argument should be of type 'unsigned int' but is of type 'unsigned long long' |
-| printf1.h:70:19:70:20 | ul | This argument should be of type 'ssize_t' but is of type 'unsigned long' |
 | printf1.h:71:19:71:20 | st | This argument should be of type 'ssize_t' but is of type 'unsigned long long' |
 | printf1.h:72:19:72:20 | ST | This argument should be of type 'ssize_t' but is of type 'unsigned long long' |
 | printf1.h:73:19:73:22 | c_st | This argument should be of type 'ssize_t' but is of type 'unsigned long long' |
 | printf1.h:74:19:74:22 | C_ST | This argument should be of type 'ssize_t' but is of type 'unsigned long long' |
 | printf1.h:75:19:75:28 | sizeof(<expr>) | This argument should be of type 'ssize_t' but is of type 'unsigned long long' |
-| printf1.h:82:23:82:35 | ... - ... | This argument should be of type 'ptrdiff_t' but is of type 'long long' |
 | printf1.h:84:23:84:35 | ... - ... | This argument should be of type 'ssize_t' but is of type 'long long' |
-| printf1.h:102:19:102:21 | ... - ... | This argument should be of type 'ptrdiff_t' but is of type 'long long' |
+| real_world.h:46:36:46:43 | filename | This argument should be of type 'wchar_t *' but is of type 'char16_t *' |
 | real_world.h:61:21:61:22 | & ... | This argument should be of type 'int *' but is of type 'short *' |
 | real_world.h:62:22:62:23 | & ... | This argument should be of type 'short *' but is of type 'int *' |
 | real_world.h:63:22:63:24 | & ... | This argument should be of type 'short *' but is of type 'unsigned int *' |

--- a/cpp/ql/test/query-tests/Likely Bugs/Format/WrongTypeFormatArguments/Microsoft_no_wchar/WrongTypeFormatArguments.expected
+++ b/cpp/ql/test/query-tests/Likely Bugs/Format/WrongTypeFormatArguments/Microsoft_no_wchar/WrongTypeFormatArguments.expected
@@ -17,7 +17,9 @@
 | printf1.h:73:19:73:22 | c_st | This argument should be of type 'ssize_t' but is of type 'unsigned long long' |
 | printf1.h:74:19:74:22 | C_ST | This argument should be of type 'ssize_t' but is of type 'unsigned long long' |
 | printf1.h:75:19:75:28 | sizeof(<expr>) | This argument should be of type 'ssize_t' but is of type 'unsigned long long' |
+| printf1.h:82:23:82:35 | ... - ... | This argument should be of type 'ptrdiff_t' but is of type 'long long' |
 | printf1.h:84:23:84:35 | ... - ... | This argument should be of type 'ssize_t' but is of type 'long long' |
+| printf1.h:102:19:102:21 | ... - ... | This argument should be of type 'ptrdiff_t' but is of type 'long long' |
 | real_world.h:61:21:61:22 | & ... | This argument should be of type 'int *' but is of type 'short *' |
 | real_world.h:62:22:62:23 | & ... | This argument should be of type 'short *' but is of type 'int *' |
 | real_world.h:63:22:63:24 | & ... | This argument should be of type 'short *' but is of type 'unsigned int *' |

--- a/cpp/ql/test/query-tests/Likely Bugs/Format/WrongTypeFormatArguments/Microsoft_no_wchar/printf1.h
+++ b/cpp/ql/test/query-tests/Likely Bugs/Format/WrongTypeFormatArguments/Microsoft_no_wchar/printf1.h
@@ -65,9 +65,9 @@ void g()
     printf("%zu", c_st); // ok
     printf("%zu", C_ST); // ok
     printf("%zu", sizeof(ul)); // ok
-    printf("%zu", sst); // not ok [NOT DETECTED ON MICROSOFT]
+    printf("%zu", sst); // not ok [NOT DETECTED]
 
-    printf("%zd", ul); // not ok
+    printf("%zd", ul); // not ok [NOT DETECTED]
     printf("%zd", st); // not ok
     printf("%zd", ST); // not ok
     printf("%zd", c_st); // not ok
@@ -79,9 +79,9 @@ void g()
         char buf[100];
 
         printf("%tu", ptr_a - ptr_b); // ok
-        printf("%td", ptr_a - ptr_b); // ok [FALSE POSITIVE]
-        printf("%zu", ptr_a - ptr_b); // ok (dubious) [DETECTED ON LINUX ONLY]
-        printf("%zd", ptr_a - ptr_b); // ok (dubious) [DETECTED ON MICROSOFT ONLY]
+        printf("%td", ptr_a - ptr_b); // ok
+        printf("%zu", ptr_a - ptr_b); // ok (dubious)
+        printf("%zd", ptr_a - ptr_b); // ok (dubious) [FALSE POSITIVE]
     }
 }
 
@@ -99,5 +99,5 @@ void fun1(unsigned char* a, unsigned char* b) {
   ptrdiff_t pdt;
 
   printf("%td\n", pdt); // GOOD
-  printf("%td\n", a-b); // GOOD [FALSE POSITIVE]
+  printf("%td\n", a-b); // GOOD
 }

--- a/cpp/ql/test/query-tests/Likely Bugs/Format/WrongTypeFormatArguments/Microsoft_no_wchar/printf1.h
+++ b/cpp/ql/test/query-tests/Likely Bugs/Format/WrongTypeFormatArguments/Microsoft_no_wchar/printf1.h
@@ -79,7 +79,7 @@ void g()
         char buf[100];
 
         printf("%tu", ptr_a - ptr_b); // ok
-        printf("%td", ptr_a - ptr_b); // ok
+        printf("%td", ptr_a - ptr_b); // ok [FALSE POSITIVE]
         printf("%zu", ptr_a - ptr_b); // ok (dubious) [DETECTED ON LINUX ONLY]
         printf("%zd", ptr_a - ptr_b); // ok (dubious) [DETECTED ON MICROSOFT ONLY]
     }
@@ -91,4 +91,13 @@ void h(int i, struct some_type *j, int k)
 	// recognize.  We should not report a problem if we're unable to understand what's
 	// going on.
 	printf("%i %R %i", i, j, k); // GOOD (as far as we can tell)
+}
+
+typedef long long ptrdiff_t;
+
+void fun1(unsigned char* a, unsigned char* b) {
+  ptrdiff_t pdt;
+
+  printf("%td\n", pdt); // GOOD
+  printf("%td\n", a-b); // GOOD [FALSE POSITIVE]
 }


### PR DESCRIPTION
Adds a test for the `WrongTypeFormatArguments.ql` issue found earlier this week by @nick.  The fix is to make the query a lot less picky about unspecified types - for example:
```
typedef int wchar_t;
typedef wchar_t WCHAR_T; // WCHAR_T -> wchar_t -> int
typedef int MYCHAR; // MYCHAR -> int (notably not via the wchar_t typedef)

wchar_t *myString1;
WCHAR_T *myString2;
int *myString3;
MYCHAR *myString4;

printf("%S", myString1); // this was always acceptable
printf("%S", myString2); // this was always acceptable
printf("%S", myString3); // this is acceptable now
printf("%S", myString4); // this is acceptable now
```
(Nick's example looks very different but is also about underlying types of `typedef`s)

This is something I've been thinking about doing for a while.  It reduces the noise caused by results that, while somewhat questionable in theory, are likely OK in practice and are typically caused by combining different pieces of code that use different typedefs.  The change also makes the query logic simpler (though there's still a lot to be done in that regard).

I'm going to try and run query differences on this.

@jonas - it will be good to get in before I make a PR for the `char16_t` issues with the same query.  There's some crossover in real world results between the two issues that confuses things without this change.

@felicity - please check whether I've done the right thing with the change note.