### PR TITLE
JS: add additional array-specific taint steps

### DIFF
--- a/change-notes/1.19/analysis-javascript.md
+++ b/change-notes/1.19/analysis-javascript.md
@@ -2,6 +2,8 @@
 
 ## General improvements
 
+* Modelling of taint flow through array operations has been improved. This may give additional results for the security queries.
+
 ## New queries
 
 | **Query**                   | **Tags**  | **Purpose**                                                        |

--- a/javascript/ql/test/library-tests/TaintTracking/BasicTaintTracking.expected
+++ b/javascript/ql/test/library-tests/TaintTracking/BasicTaintTracking.expected
@@ -3,3 +3,15 @@
 | tst.js:2:13:2:20 | source() | tst.js:14:10:14:17 | x.sort() |
 | tst.js:2:13:2:20 | source() | tst.js:17:10:17:10 | a |
 | tst.js:2:13:2:20 | source() | tst.js:19:10:19:10 | a |
+| tst.js:2:13:2:20 | source() | tst.js:23:10:23:10 | b |
+| tst.js:2:13:2:20 | source() | tst.js:25:10:25:16 | x.pop() |
+| tst.js:2:13:2:20 | source() | tst.js:26:10:26:18 | x.shift() |
+| tst.js:2:13:2:20 | source() | tst.js:27:10:27:18 | x.slice() |
+| tst.js:2:13:2:20 | source() | tst.js:28:10:28:19 | x.splice() |
+| tst.js:2:13:2:20 | source() | tst.js:30:10:30:22 | Array.from(x) |
+| tst.js:2:13:2:20 | source() | tst.js:33:14:33:16 | elt |
+| tst.js:2:13:2:20 | source() | tst.js:35:14:35:16 | ary |
+| tst.js:2:13:2:20 | source() | tst.js:39:14:39:16 | elt |
+| tst.js:2:13:2:20 | source() | tst.js:41:14:41:16 | ary |
+| tst.js:2:13:2:20 | source() | tst.js:44:10:44:30 | innocen ... ) => x) |
+| tst.js:2:13:2:20 | source() | tst.js:45:10:45:24 | x.map(x2 => x2) |

--- a/javascript/ql/test/library-tests/TaintTracking/tst.js
+++ b/javascript/ql/test/library-tests/TaintTracking/tst.js
@@ -18,4 +18,30 @@ function test() {
     a.push(x);
     sink(a); // NOT OK
 
+    var b = [];
+    b.unshift(x);
+    sink(b); // NOT OK
+
+    sink(x.pop()); // NOT OK
+    sink(x.shift()); // NOT OK
+    sink(x.slice()); // NOT OK
+    sink(x.splice()); // NOT OK
+
+    sink(Array.from(x)); // NOT OK
+
+    x.map((elt, i, ary) => {
+        sink(elt); // NOT OK
+        sink(i); // OK
+        sink(ary); // NOT OK
+    });
+
+    x.forEach((elt, i, ary) => {
+        sink(elt); // NOT OK
+        sink(i); // OK
+        sink(ary); // NOT OK
+    });
+
+    sink(innocent.map(() => x)); // NOT OK
+    sink(x.map(x2 => x2)); // NOT OK
+
 }


### PR DESCRIPTION
This PR adds the array methods: `.unshift`, `.pop`, `.shift`, `.slice`, `.splice`, `Array.from` as taint steps. I also did a minor refactoring in `TaintTracking.qll`.

This change seems to have a minor overhead, wihin the margin of error. [Evalution](<https://git.semmle.com/esben/dist-compare-reports/commit/cf6c864569e6ff9586cd48184acdceab22c12c28?short_path=04c6e90#diff-04c6e90faac2675aa89e2176d2eec7d8>).