### PR TITLE
JS: lower @precision of js/remote-property-injection

### DIFF
--- a/change-notes/1.19/analysis-javascript.md
+++ b/change-notes/1.19/analysis-javascript.md
@@ -14,6 +14,6 @@
 |--------------------------------|----------------------------|----------------------------------------------|
 | Regular expression injection | Fewer false-positive results | This rule now identifies calls to `String.prototype.search` with more precision. |
 | Unbound event handler receiver | Fewer false-positive results | This rule now recognizes additional ways class methods can be bound. |
-
+| Remote property injection | Fewer results | The precision of this rule has been revised to "medium". Results are no longer shown on LGTM by default. |
 
 ## Changes to QL libraries

--- a/javascript/ql/src/Security/CWE-400/RemotePropertyInjection.ql
+++ b/javascript/ql/src/Security/CWE-400/RemotePropertyInjection.ql
@@ -5,7 +5,7 @@
  *   
  * @kind problem
  * @problem.severity warning
- * @precision high
+ * @precision medium
  * @id js/remote-property-injection
  * @tags security
  *       external/cwe/cwe-250


### PR DESCRIPTION
As seen in https://git.semmle.com/esben/dist-compare-reports/commit/cf6c864569e6ff9586cd48184acdceab22c12c28#commitcomment-4862 and https://git.semmle.com/gist/esben/1bc16ef80603298656c8e9592f9d32d5#gistcomment-77, the alerts from this query are rarely true positives. I think it should have `@precision` medium.

Assigning @max for his opinion.