### PR TITLE
JS: add query: js/stored-xss

### DIFF
--- a/change-notes/1.19/analysis-javascript.md
+++ b/change-notes/1.19/analysis-javascript.md
@@ -12,7 +12,7 @@
 
 | **Query**                                     | **Tags**                                             | **Purpose**                                                                                                                                                                 |
 |-----------------------------------------------|------------------------------------------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| Stored cross-site scripting (`js/stored-xss`) | security, external/cwe/cwe-079, external/cwe/cwe-116 | Highlights uncontrolled stored values flowing into HTML content, indicating a violation of [CWE-079](https://cwe.mitre.org/data/definitions/79.html). Results shown on lgtm by default. |
+| Stored cross-site scripting (`js/stored-xss`) | security, external/cwe/cwe-079, external/cwe/cwe-116 | Highlights uncontrolled stored values flowing into HTML content, indicating a violation of [CWE-079](https://cwe.mitre.org/data/definitions/79.html). Results shown on LGTM by default. |
 
 ## Changes to existing queries
 

--- a/change-notes/1.19/analysis-javascript.md
+++ b/change-notes/1.19/analysis-javascript.md
@@ -4,11 +4,15 @@
 
 * Modelling of taint flow through array operations has been improved. This may give additional results for the security queries.
 
+* Support for popular libraries has been improved. Consequently, queries may produce more results on code bases that use the following features:
+  - file system access, for example through [fs-extra](https://github.com/jprichardson/node-fs-extra) or [globby](https://www.npmjs.com/package/globby)
+
+
 ## New queries
 
-| **Query**                   | **Tags**  | **Purpose**                                                        |
-|-----------------------------|-----------|--------------------------------------------------------------------|
-| *@name of query (Query ID)* | *Tags*    |*Aim of the new query and whether it is enabled by default or not*  |
+| **Query**                                     | **Tags**                                             | **Purpose**                                                                                                                                                                 |
+|-----------------------------------------------|------------------------------------------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| Stored cross-site scripting (`js/stored-xss`) | security, external/cwe/cwe-079, external/cwe/cwe-116 | Highlights uncontrolled stored values flowing into HTML content, indicating a violation of [CWE-079](https://cwe.mitre.org/data/definitions/79.html). Results shown on lgtm by default. |
 
 ## Changes to existing queries
 

--- a/javascript/config/suites/javascript/security
+++ b/javascript/config/suites/javascript/security
@@ -2,6 +2,7 @@
 + semmlecode-javascript-queries/Security/CWE-022/TaintedPath.ql: /Security/CWE/CWE-022
 + semmlecode-javascript-queries/Security/CWE-078/CommandInjection.ql: /Security/CWE/CWE-078
 + semmlecode-javascript-queries/Security/CWE-079/ReflectedXss.ql: /Security/CWE/CWE-079
++ semmlecode-javascript-queries/Security/CWE-079/StoredXss.ql: /Security/CWE/CWE-079
 + semmlecode-javascript-queries/Security/CWE-079/Xss.ql: /Security/CWE/CWE-079
 + semmlecode-javascript-queries/Security/CWE-089/SqlInjection.ql: /Security/CWE/CWE-089
 + semmlecode-javascript-queries/Security/CWE-094/CodeInjection.ql: /Security/CWE/CWE-094

--- a/javascript/ql/src/Security/CWE-079/StoredXss.qhelp
+++ b/javascript/ql/src/Security/CWE-079/StoredXss.qhelp
@@ -1,0 +1,63 @@
+<!DOCTYPE qhelp PUBLIC
+"-//Semmle//qhelp//EN"
+"qhelp.dtd">
+<qhelp>
+
+<overview>
+	<p>
+
+		Directly using uncontrolled stored value (for example, file names) to
+		create HTML content without properly sanitizing the input first,
+		allows for a cross-site scripting vulnerability.
+
+	</p>
+	<p>
+
+		This kind of vulnerability is also called <i>stored</i> cross-site
+		scripting, to distinguish it from other types of cross-site scripting.
+
+	</p>
+</overview>
+
+<recommendation>
+	<p>
+
+		To guard against cross-site scripting, consider using contextual
+		output encoding/escaping before using uncontrolled stored values to
+		create HTML content, or one of the other solutions that are mentioned
+		in the references.
+
+	</p>
+</recommendation>
+
+<example>
+	<p>
+
+		The following example code writes file names directly to a HTTP
+		response. This leaves the website vulnerable to cross-site scripting,
+		if an attacker can choose the file names on the disk.
+
+	</p>
+	<sample src="examples/StoredXss.js" />
+	<p>
+		Sanitizing the file names prevents the vulnerability:
+	</p>
+	<sample src="examples/StoredXssGood.js" />
+</example>
+
+<references>
+	<li>
+		OWASP:
+		<a href="https://www.owasp.org/index.php/XSS_%28Cross_Site_Scripting%29_Prevention_Cheat_Sheet">XSS
+		(Cross Site Scripting) Prevention Cheat Sheet</a>.
+	</li>
+	<li>
+		OWASP
+		<a href="https://www.owasp.org/index.php/Types_of_Cross-Site_Scripting">Types of Cross-Site
+		Scripting</a>.
+	</li>
+	<li>
+		Wikipedia: <a href="http://en.wikipedia.org/wiki/Cross-site_scripting">Cross-site scripting</a>.
+	</li>
+</references>
+</qhelp>

--- a/javascript/ql/src/Security/CWE-079/StoredXss.ql
+++ b/javascript/ql/src/Security/CWE-079/StoredXss.ql
@@ -1,0 +1,20 @@
+/**
+ * @name Stored cross-site scripting
+ * @description Using uncontrolled stored values in HTML allows for
+ *              a stored cross-site scripting vulnerability.
+ * @kind problem
+ * @problem.severity error
+ * @precision high
+ * @id js/stored-xss
+ * @tags security
+ *       external/cwe/cwe-079
+ *       external/cwe/cwe-116
+ */
+
+import javascript
+import semmle.javascript.security.dataflow.StoredXss::StoredXss
+
+from Configuration xss, DataFlow::Node source, DataFlow::Node sink
+where xss.hasFlow(source, sink)
+select sink, "Stored cross-site scripting vulnerability due to $@.",
+       source, "stored value"

--- a/javascript/ql/src/Security/CWE-079/examples/StoredXss.js
+++ b/javascript/ql/src/Security/CWE-079/examples/StoredXss.js
@@ -5,7 +5,8 @@ express().get('/list-directory', function(req, res) {
     fs.readdir('/public', function (error, fileNames) {
         var list = '<ul>';
         fileNames.forEach(fileName => {
-            list += '<li>' + fileName '</li>'; // BAD: `fileName` can contain HTML elements
+            // BAD: `fileName` can contain HTML elements
+            list += '<li>' + fileName '</li>';
         });
         list += '</ul>'
         res.send(list);

--- a/javascript/ql/src/Security/CWE-079/examples/StoredXss.js
+++ b/javascript/ql/src/Security/CWE-079/examples/StoredXss.js
@@ -1,0 +1,13 @@
+var express = require('express'),
+    fs = require('fs');
+
+express().get('/list-directory', function(req, res) {
+    fs.readdir('/public', function (error, fileNames) {
+        var list = '<ul>';
+        fileNames.forEach(fileName => {
+            list += '<li>' + fileName '</li>'; // BAD: `fileName` can contain HTML elements
+        });
+        list += '</ul>'
+        res.send(list);
+    });
+});

--- a/javascript/ql/src/Security/CWE-079/examples/StoredXssGood.js
+++ b/javascript/ql/src/Security/CWE-079/examples/StoredXssGood.js
@@ -1,0 +1,14 @@
+var express = require('express'),
+    fs = require('fs'),
+    escape = require('escape-html');
+
+express().get('/list-directory', function(req, res) {
+    fs.readdir('/public', function (error, fileNames) {
+        var list = '<ul>';
+        fileNames.forEach(fileName => {
+            list += '<li>' + escape(fileName) '</li>'; // GOOD: escaped `fileName` can not contain HTML elements
+        });
+        list += '</ul>'
+        res.send(list);
+    });
+});

--- a/javascript/ql/src/Security/CWE-079/examples/StoredXssGood.js
+++ b/javascript/ql/src/Security/CWE-079/examples/StoredXssGood.js
@@ -6,7 +6,8 @@ express().get('/list-directory', function(req, res) {
     fs.readdir('/public', function (error, fileNames) {
         var list = '<ul>';
         fileNames.forEach(fileName => {
-            list += '<li>' + escape(fileName) '</li>'; // GOOD: escaped `fileName` can not contain HTML elements
+            // GOOD: escaped `fileName` can not contain HTML elements
+            list += '<li>' + escape(fileName) '</li>';
         });
         list += '</ul>'
         res.send(list);

--- a/javascript/ql/src/javascript.qll
+++ b/javascript/ql/src/javascript.qll
@@ -59,6 +59,7 @@ import semmle.javascript.frameworks.Credentials
 import semmle.javascript.frameworks.CryptoLibraries
 import semmle.javascript.frameworks.DigitalOcean
 import semmle.javascript.frameworks.Electron
+import semmle.javascript.frameworks.Files
 import semmle.javascript.frameworks.jQuery
 import semmle.javascript.frameworks.LodashUnderscore
 import semmle.javascript.frameworks.Logging

--- a/javascript/ql/src/semmle/javascript/Concepts.qll
+++ b/javascript/ql/src/semmle/javascript/Concepts.qll
@@ -30,6 +30,13 @@ abstract class FileSystemAccess extends DataFlow::Node {
 }
 
 /**
+ * A data flow node that contains a file name or an array of file names from the local file system.
+ */
+abstract class FileNameSource extends DataFlow::Node {
+
+}
+
+/**
  * A data flow node that performs a database access.
  */
 abstract class DatabaseAccess extends DataFlow::Node {

--- a/javascript/ql/src/semmle/javascript/frameworks/Files.qll
+++ b/javascript/ql/src/semmle/javascript/frameworks/Files.qll
@@ -1,0 +1,103 @@
+/**
+ * Provides classes for working with file system libraries.
+ */
+
+import javascript
+
+/**
+ * A file name from the `walk-sync` library.
+ */
+private class WalkSyncFileNameSource extends FileNameSource {
+
+  WalkSyncFileNameSource() {
+    // `require('walkSync')()`
+    this = DataFlow::moduleImport("walkSync").getACall()
+  }
+
+}
+
+/**
+ * A file name or an array of file names from the `walk` library.
+ */
+private class WalkFileNameSource extends FileNameSource {
+
+  WalkFileNameSource() {
+    // `stats.name` in `require('walk').walk(_).on(_,  (_, stats) => stats.name)`
+    exists (DataFlow::FunctionNode callback |
+      callback = DataFlow::moduleMember("walk", "walk").getACall().getAMethodCall("on").getCallback(1) |
+      this = callback.getParameter(1).getAPropertyRead("name")
+    )
+  }
+
+}
+
+/**
+ * A file name or an array of file names from the `glob` library.
+ */
+private class GlobFileNameSource extends FileNameSource {
+
+  GlobFileNameSource() {
+    exists (string moduleName |
+      moduleName = "glob" |
+      // `require('glob').sync(_)`
+      this = DataFlow::moduleMember(moduleName, "sync").getACall()
+      or
+      // `name` in `require('glob')(_, (e, name) => ...)`
+      this = DataFlow::moduleImport(moduleName).getACall().getCallback([1..2]).getParameter(1)
+      or
+      exists (DataFlow::NewNode instance |
+        instance = DataFlow::moduleMember(moduleName, "Glob").getAnInstantiation() |
+        // `name` in `new require('glob').Glob(_, (e, name) => ...)`
+        this = instance.getCallback([1..2]).getParameter(1) or
+        // `new require('glob').Glob(_).found`
+        this = instance.getAPropertyRead("found")
+      )
+    )
+  }
+
+}
+
+/**
+ * A file name or an array of file names from the `globby` library.
+ */
+private class GlobbyFileNameSource extends FileNameSource {
+
+  GlobbyFileNameSource() {
+    exists (string moduleName |
+      moduleName = "globby" |
+      // `require('globby').sync(_)`
+      this = DataFlow::moduleMember(moduleName, "sync").getACall()
+      or
+      // `files` in `require('globby')(_).then(files => ...)`
+      this = DataFlow::moduleImport(moduleName).getACall().getAMethodCall("then").getCallback(0).getParameter(0)
+    )
+  }
+
+}
+
+/**
+ * A file name or an array of file names from the `fast-glob` library.
+ */
+private class FastGlobFileNameSource extends FileNameSource {
+
+  FastGlobFileNameSource() {
+    exists (string moduleName |
+      moduleName = "fast-glob" |
+      // `require('fast-glob').sync(_)`
+      this = DataFlow::moduleMember(moduleName, "sync").getACall()
+      or
+      exists (DataFlow::SourceNode f |
+        f = DataFlow::moduleImport(moduleName)
+        or
+        f = DataFlow::moduleMember(moduleName, "async") |
+        // `files` in `require('fast-glob')(_).then(files => ...)` and
+        // `files` in `require('fast-glob').async(_).then(files => ...)`
+        this = f.getACall().getAMethodCall("then").getCallback(0).getParameter(0)
+      )
+      or
+      // `file` in `require('fast-glob').stream(_).on(_,  file => ...)`
+      this = DataFlow::moduleMember(moduleName, "stream").getACall().getAMethodCall("on").getCallback(1).getParameter(0)
+    )
+  }
+
+}

--- a/javascript/ql/src/semmle/javascript/frameworks/NodeJSLib.qll
+++ b/javascript/ql/src/semmle/javascript/frameworks/NodeJSLib.qll
@@ -366,6 +366,22 @@ module NodeJSLib {
   }
 
   /**
+   * A data flow node that contains a file name or an array of file names from the local file system.
+   */
+  private class NodeJSFileNameSource extends FileNameSource {
+
+    NodeJSFileNameSource() {
+      exists (string name |
+        name = "readdir" or
+        name = "realpath" |
+        this = fsModuleMember(name).getACall().getCallback([1..2]).getParameter(1) or
+        this = fsModuleMember(name + "Sync").getACall()
+      )
+    }
+
+  }
+  
+  /**
    * A call to a method from module `child_process`.
    */
   private class ChildProcessMethodCall extends SystemCommandExecution, DataFlow::CallNode {

--- a/javascript/ql/src/semmle/javascript/frameworks/NodeJSLib.qll
+++ b/javascript/ql/src/semmle/javascript/frameworks/NodeJSLib.qll
@@ -338,14 +338,14 @@ module NodeJSLib {
 
 
   /**
-   * A call to a method from module `fs` or `graceful-fs`.
+   * A call to a method from module `fs`, `graceful-fs` or `fs-extra`.
    */
   private class NodeJSFileSystemAccess extends FileSystemAccess, DataFlow::CallNode {
     string methodName;
 
     NodeJSFileSystemAccess() {
       exists (string moduleName | this = DataFlow::moduleMember(moduleName, methodName).getACall() |
-        moduleName = "fs" or moduleName = "graceful-fs"
+        moduleName = "fs" or moduleName = "graceful-fs" or moduleName = "fs-extra"
       )
     }
 

--- a/javascript/ql/src/semmle/javascript/frameworks/NodeJSLib.qll
+++ b/javascript/ql/src/semmle/javascript/frameworks/NodeJSLib.qll
@@ -336,6 +336,17 @@ module NodeJSLib {
     )
   }
 
+  /**
+   * A member `member` from module `fs` or its drop-in replacements `graceful-fs` or `fs-extra`.
+   */
+  private DataFlow::SourceNode fsModuleMember(string member) {
+    exists (string moduleName |
+      moduleName = "fs" or
+      moduleName = "graceful-fs" or
+      moduleName = "fs-extra" |
+      result = DataFlow::moduleMember(moduleName, member)
+    )
+  }
 
   /**
    * A call to a method from module `fs`, `graceful-fs` or `fs-extra`.
@@ -344,9 +355,7 @@ module NodeJSLib {
     string methodName;
 
     NodeJSFileSystemAccess() {
-      exists (string moduleName | this = DataFlow::moduleMember(moduleName, methodName).getACall() |
-        moduleName = "fs" or moduleName = "graceful-fs" or moduleName = "fs-extra"
-      )
+      this = fsModuleMember(methodName).getACall()
     }
 
     override DataFlow::Node getAPathArgument() {

--- a/javascript/ql/src/semmle/javascript/security/dataflow/StoredXss.qll
+++ b/javascript/ql/src/semmle/javascript/security/dataflow/StoredXss.qll
@@ -1,0 +1,62 @@
+/**
+ * Provides a taint-tracking configuration for reasoning about stored
+ * cross-site scripting vulnerabilities.
+ */
+
+import javascript
+import semmle.javascript.security.dataflow.RemoteFlowSources
+import semmle.javascript.security.dataflow.ReflectedXss as ReflectedXss
+import semmle.javascript.security.dataflow.DomBasedXss as DomBasedXss
+
+module StoredXss {
+  /**
+   * A data flow source for XSS vulnerabilities.
+   */
+  abstract class Source extends DataFlow::Node { }
+
+  /**
+   * A data flow sink for XSS vulnerabilities.
+   */
+  abstract class Sink extends DataFlow::Node { }
+
+  /**
+   * A sanitizer for XSS vulnerabilities.
+   */
+  abstract class Sanitizer extends DataFlow::Node { }
+
+  /**
+   * A taint-tracking configuration for reasoning about XSS.
+   */
+  class Configuration extends TaintTracking::Configuration {
+    Configuration() { this = "StoredXss" }
+
+    override predicate isSource(DataFlow::Node source) {
+      source instanceof Source
+    }
+
+    override predicate isSink(DataFlow::Node sink) {
+      sink instanceof Sink
+    }
+
+    override predicate isSanitizer(DataFlow::Node node) {
+      super.isSanitizer(node) or
+      node instanceof Sanitizer
+    }
+  }
+
+  /** A file name, considered as a flow source for stored XSS. */
+  class FileNameSourceAsSource extends Source {
+    FileNameSourceAsSource() {
+      this instanceof FileNameSource
+    }
+  }
+
+  /** An ordinary XSS sink, considered as a flow sink for stored XSS. */
+  class XssSinkAsSink extends Sink {
+    XssSinkAsSink() {
+      this instanceof ReflectedXss::ReflectedXss::Sink or
+      this instanceof DomBasedXss::DomBasedXss::Sink
+    }
+  }
+
+}

--- a/javascript/ql/test/library-tests/frameworks/Concepts/FileNameSource.expected
+++ b/javascript/ql/test/library-tests/frameworks/Concepts/FileNameSource.expected
@@ -1,0 +1,12 @@
+| tst-file-names.js:7:1:7:10 | walkSync() |
+| tst-file-names.js:9:35:9:44 | stats.name |
+| tst-file-names.js:11:1:11:12 | glob.sync(_) |
+| tst-file-names.js:13:13:13:16 | name |
+| tst-file-names.js:15:22:15:25 | name |
+| tst-file-names.js:17:1:17:22 | new glo ... ).found |
+| tst-file-names.js:19:1:19:14 | globby.sync(_) |
+| tst-file-names.js:21:16:21:20 | files |
+| tst-file-names.js:23:1:23:16 | fastGlob.sync(_) |
+| tst-file-names.js:25:18:25:22 | files |
+| tst-file-names.js:27:24:27:28 | files |
+| tst-file-names.js:29:27:29:30 | file |

--- a/javascript/ql/test/library-tests/frameworks/Concepts/FileNameSource.ql
+++ b/javascript/ql/test/library-tests/frameworks/Concepts/FileNameSource.ql
@@ -1,0 +1,3 @@
+import javascript
+
+select any(FileNameSource s)

--- a/javascript/ql/test/library-tests/frameworks/Concepts/tst-file-names.js
+++ b/javascript/ql/test/library-tests/frameworks/Concepts/tst-file-names.js
@@ -1,0 +1,29 @@
+let walkSync = require('walkSync'),
+    walk = require('walk'),
+    glob = require('glob'),
+    globby = require('globby'),
+    fastGlob = require('fast-glob');
+
+walkSync();
+
+walk.walk(_).on(_,  (_, stats) => stats.name); // XXX
+
+glob.sync(_);
+
+glob(_, (e, name) => name);
+
+new glob.Glob(_, (e, name) => name);
+
+new glob.Glob(_).found;
+
+globby.sync(_);
+
+globby(_).then(files => files)
+
+fastGlob.sync(_);
+
+fastGlob(_).then(files => files);
+
+fastGlob.async(_).then(files => files);
+
+fastGlob.stream(_).on(_,  file => file); // XXX

--- a/javascript/ql/test/query-tests/Security/CWE-079/StoredXss.expected
+++ b/javascript/ql/test/query-tests/Security/CWE-079/StoredXss.expected
@@ -1,0 +1,4 @@
+| xss-through-filenames.js:8:18:8:23 | files1 | Stored cross-site scripting vulnerability due to $@. | xss-through-filenames.js:7:43:7:48 | files1 | stored value |
+| xss-through-filenames.js:26:19:26:24 | files1 | Stored cross-site scripting vulnerability due to $@. | xss-through-filenames.js:25:43:25:48 | files1 | stored value |
+| xss-through-filenames.js:33:19:33:24 | files2 | Stored cross-site scripting vulnerability due to $@. | xss-through-filenames.js:25:43:25:48 | files1 | stored value |
+| xss-through-filenames.js:37:19:37:24 | files3 | Stored cross-site scripting vulnerability due to $@. | xss-through-filenames.js:25:43:25:48 | files1 | stored value |

--- a/javascript/ql/test/query-tests/Security/CWE-079/StoredXss.qlref
+++ b/javascript/ql/test/query-tests/Security/CWE-079/StoredXss.qlref
@@ -1,0 +1,1 @@
+Security/CWE-079/StoredXss.ql

--- a/javascript/ql/test/query-tests/Security/CWE-079/xss-through-filenames.js
+++ b/javascript/ql/test/query-tests/Security/CWE-079/xss-through-filenames.js
@@ -1,0 +1,40 @@
+var http = require('http');
+var fs = require('fs');
+
+var express = require('express');
+
+express().get('/', function(req, res) {
+    fs.readdir("/myDir", function (error, files1) {
+        res.send(files1); // NOT OK
+    });
+});
+
+/**
+ * The essence of a real world vulnerability.
+ */
+http.createServer(function (req, res) {
+
+    function format(files2) {
+        var files3 = [];
+        files2.sort(sort).forEach(function (file) {
+            files3.push('<li>' + file + '</li>');
+        });
+        return files3.join('');
+    }
+
+    fs.readdir("/myDir", function (error, files1) {
+        res.write(files1); // NOT OK
+
+        var dirs = [];
+        var files2 = [];
+        files1.forEach(function (file) {
+            files2.push(file);
+        });
+        res.write(files2); // NOT OK
+
+        var files3 = format(files2);
+
+        res.write(files3);  // NOT OK
+
+    });
+});


### PR DESCRIPTION
This is a revival of #142.

Differences from #142:

-   added new query: js/stored-xss,
-   removed additional sources from js/reflected-xss
-   added models of additional file system libraries

The [Evaluation](<https://git.semmle.com/esben/dist-compare-reports/tree/a53239c49a3b37f2de70e54b8cc6cd00>) shows that performance is as expected: a bit of overhead for a new query.