### PR TITLE
Parameter.qll: Tweak how effective declaration entries are computed

### DIFF
--- a/cpp/ql/src/semmle/code/cpp/Parameter.qll
+++ b/cpp/ql/src/semmle/code/cpp/Parameter.qll
@@ -68,10 +68,9 @@ class Parameter extends LocalScopeVariable, @parameter {
    */
   private VariableDeclarationEntry getAnEffectiveDeclarationEntry() {
     if getFunction().isConstructedFrom(_)
-      then exists (Parameter prototype
-           | prototype = result.getVariable() and
-             prototype.getIndex() = getIndex() and
-             getFunction().isConstructedFrom(prototype.getFunction()))
+      then exists (Function prototypeInstantiation
+           | prototypeInstantiation.getParameter(getIndex()) = result.getVariable() and
+             getFunction().isConstructedFrom(prototypeInstantiation))
       else result = getADeclarationEntry()
   }
 


### PR DESCRIPTION
With the new formulation, we can join on function and index at the
same time, leading to significant performance gains on large code
bases that use templates extensively.