### PR TITLE
JS: recognize res.sendfile as alias for res.sendFile in Express

### DIFF
--- a/javascript/ql/src/semmle/javascript/frameworks/Express.qll
+++ b/javascript/ql/src/semmle/javascript/frameworks/Express.qll
@@ -785,7 +785,8 @@ module Express {
     override MethodCallExpr astNode;
 
     ResponseSendFileAsFileSystemAccess() {
-      asExpr().(MethodCallExpr).calls(any(ResponseExpr res), "sendFile")
+      exists (string name | name = "sendFile" or name = "sendfile" |
+        asExpr().(MethodCallExpr).calls(any(ResponseExpr res), name))
     }
 
     override DataFlow::Node getAPathArgument() {

--- a/javascript/ql/test/query-tests/Security/CWE-022/TaintedPath.expected
+++ b/javascript/ql/test/query-tests/Security/CWE-022/TaintedPath.expected
@@ -25,4 +25,5 @@
 | tainted-array-steps.js:15:29:15:43 | parts.join('/') | This path depends on $@. | tainted-array-steps.js:9:24:9:30 | req.url | a user-provided value |
 | tainted-require.js:7:19:7:37 | req.param("module") | This path depends on $@. | tainted-require.js:7:19:7:37 | req.param("module") | a user-provided value |
 | tainted-sendFile.js:7:16:7:33 | req.param("gimme") | This path depends on $@. | tainted-sendFile.js:7:16:7:33 | req.param("gimme") | a user-provided value |
+| tainted-sendFile.js:9:16:9:33 | req.param("gimme") | This path depends on $@. | tainted-sendFile.js:9:16:9:33 | req.param("gimme") | a user-provided value |
 | views.js:1:43:1:55 | req.params[0] | This path depends on $@. | views.js:1:43:1:55 | req.params[0] | a user-provided value |

--- a/javascript/ql/test/query-tests/Security/CWE-022/tainted-sendFile.js
+++ b/javascript/ql/test/query-tests/Security/CWE-022/tainted-sendFile.js
@@ -5,4 +5,6 @@ var app = express();
 app.get('/some/path', function(req, res) {
   // BAD: sending a file based on un-sanitized query parameters
   res.sendFile(req.param("gimme"));
+  // BAD: same as above
+  res.sendfile(req.param("gimme"));
 });


### PR DESCRIPTION
`res.sendfile` seems to do the same as `res.sendFile` and I've seen it used a few places.

[Evaluation](https://git.semmle.com/asger/dist-compare-reports/tree/ee12038de948bfbbde40eac5c7d68b12) shows no new results, and no perf change.