### PR TITLE
Avoid caching `unresolveElement`.

### DIFF
--- a/cpp/ql/src/definitions.qll
+++ b/cpp/ql/src/definitions.qll
@@ -102,7 +102,8 @@ private predicate constructorCallStartLoc(ConstructorCall cc, File f, int line, 
 
 /**
  * Holds if `f`, `line`, `column` indicate the start character
- * of `tm`, which mentions `t`.
+ * of `tm`, which mentions `t`. Type mentions for instantiations
+ * are filtered out.
  */
 private predicate typeMentionStartLoc(TypeMention tm, Type t, File f, int line, int column) {
   exists(Location l |
@@ -111,7 +112,8 @@ private predicate typeMentionStartLoc(TypeMention tm, Type t, File f, int line, 
     l.getStartLine() = line and
     l.getStartColumn() = column
   ) and
-  t = tm.getMentionedType()
+  t = tm.getMentionedType() and
+  not t instanceof ClassTemplateInstantiation
 }
 
 /**

--- a/cpp/ql/src/semmle/code/cpp/Element.qll
+++ b/cpp/ql/src/semmle/code/cpp/Element.qll
@@ -8,7 +8,8 @@ private import semmle.code.cpp.internal.ResolveClass
  * For example, for an incomplete struct `e` the result may be a
  * complete struct with the same name.
  */
-private cached @element resolveElement(@element e) {
+pragma[inline]
+private @element resolveElement(@element e) {
   if isClass(e)
   then result = resolveClass(e)
   else result = e
@@ -31,6 +32,7 @@ Element mkElement(@element e) {
  * extensional.
  * See `underlyingElement` for when `e` is `this`.
  */
+pragma[inline]
 @element unresolveElement(Element e) {
   resolveElement(result) = e
 }

--- a/cpp/ql/src/semmle/code/cpp/pointsto/PointsTo.qll
+++ b/cpp/ql/src/semmle/code/cpp/pointsto/PointsTo.qll
@@ -633,10 +633,24 @@ class PointsToExpr extends Expr
   pragma[noopt]
   Element pointsTo()
   {
-    this.interesting() and exists(int set, @element thisEntity, @element resultEntity | thisEntity = underlyingElement(this) and pointstosets(set, thisEntity) and setlocations(set, resultEntity) and resultEntity = unresolveElement(result))
+    this.interesting() and
+    exists(int set, @element thisEntity, @element resultEntity |
+      thisEntity = underlyingElement(this) and
+      pointstosets(set, thisEntity) and
+      setlocations(set, resultEntity) and
+      resultEntity = localUnresolveElement(result)
+    )
   }
 
   float confidence() { result = 1.0 / count(this.pointsTo()) }
+}
+
+/*
+ * This is used above in a `pragma[noopt]` context, which prevents its
+ * customary inlining. We materialise it explicitly here.
+ */
+private @element localUnresolveElement(Element e) {
+  result = unresolveElement(e)
 }
 
 /**


### PR DESCRIPTION
The `resolveClass` part of its definition is not functional, but the
rest is. If we do not cache it but eagerly inline it, there are more
cases where we can use that functionality to generate better code.