### PR TITLE
Java: tweak some query metadata

### DIFF
--- a/java/ql/src/Likely Bugs/Concurrency/NonSynchronizedOverride.ql
+++ b/java/ql/src/Likely Bugs/Concurrency/NonSynchronizedOverride.ql
@@ -3,7 +3,7 @@
  * @description If a synchronized method is overridden in a subclass, and the overriding method is
  *              not synchronized, the thread-safety of the subclass may be broken.
  * @kind problem
- * @problem.severity error
+ * @problem.severity warning
  * @precision very-high
  * @id java/non-sync-override
  * @tags reliability

--- a/java/ql/src/Likely Bugs/Resource Leaks/CloseReader.ql
+++ b/java/ql/src/Likely Bugs/Resource Leaks/CloseReader.ql
@@ -3,7 +3,7 @@
  * @description A resource that is opened for reading but not closed may cause a resource
  *              leak.
  * @kind problem
- * @problem.severity error
+ * @problem.severity warning
  * @precision high
  * @id java/input-resource-leak
  * @tags efficiency

--- a/java/ql/src/Likely Bugs/Resource Leaks/CloseSql.ql
+++ b/java/ql/src/Likely Bugs/Resource Leaks/CloseSql.ql
@@ -2,7 +2,7 @@
  * @name Potential database resource leak
  * @description A database resource that is opened but not closed may cause a resource leak.
  * @kind problem
- * @problem.severity error
+ * @problem.severity warning
  * @precision high
  * @id java/database-resource-leak
  * @tags correctness

--- a/java/ql/src/Likely Bugs/Resource Leaks/CloseWriter.ql
+++ b/java/ql/src/Likely Bugs/Resource Leaks/CloseWriter.ql
@@ -3,7 +3,7 @@
  * @description A resource that is opened for writing but not closed may cause a resource
  *              leak.
  * @kind problem
- * @problem.severity error
+ * @problem.severity warning
  * @precision high
  * @id java/output-resource-leak
  * @tags efficiency


### PR DESCRIPTION
The severity of four queries is reduced to `warning`.