### PR TITLE
Java: refine `java/unreachable-catch-clause`

### DIFF
--- a/change-notes/1.19/analysis-java.md
+++ b/change-notes/1.19/analysis-java.md
@@ -1,0 +1,16 @@
+# Improvements to Java analysis
+
+## General improvements
+
+## New queries
+
+| **Query**                                     | **Tags**                                             | **Purpose**                                                                                                                                                                 |
+|-----------------------------------------------|------------------------------------------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+
+## Changes to existing queries
+
+| **Query**                      | **Expected impact**        | **Change**                                   |
+| Unreachable catch clause | Fewer false-positive results | This rule now accounts for calls to generic methods that throw generic exceptions. |
+
+## Changes to QL libraries
+

--- a/change-notes/1.19/analysis-java.md
+++ b/change-notes/1.19/analysis-java.md
@@ -10,7 +10,7 @@
 ## Changes to existing queries
 
 | **Query**                      | **Expected impact**        | **Change**                                   |
-| Unreachable catch clause | Fewer false-positive results | This rule now accounts for calls to generic methods that throw generic exceptions. |
+| Unreachable catch clause (`java/unreachable-catch-clause`) | Fewer false-positive results | This rule now accounts for calls to generic methods that throw generic exceptions. |
 
 ## Changes to QL libraries
 

--- a/java/ql/src/Likely Bugs/Statements/PartiallyMaskedCatch.java
+++ b/java/ql/src/Likely Bugs/Statements/PartiallyMaskedCatch.java
@@ -1,11 +1,10 @@
-FileInputStream fis = null;
+FileOutputStream fos = null;
 try {
-	fis = new FileInputStream(new File("may_not_exist.txt"));
-	// read from input stream
+	fos = new FileOutputStream(new File("may_not_exist.txt"));
 } catch (FileNotFoundException e) {
 	// ask the user and try again
 } catch (IOException e) {
 	// more serious, abort
 } finally {
-	if (fis!=null) { try { fis.close(); } catch (IOException e) { /*ignore*/ } }
+	if (fos!=null) { try { fos.close(); } catch (IOException e) { /*ignore*/ } }
 }

--- a/java/ql/src/Likely Bugs/Statements/PartiallyMaskedCatch.qhelp
+++ b/java/ql/src/Likely Bugs/Statements/PartiallyMaskedCatch.qhelp
@@ -45,7 +45,13 @@ than one of the <code>catch</code> clauses, only the first matching clause is ex
 </recommendation>
 <example>
 
-<p>In the following example, the second <code>catch</code> clause is unreachable, and can be removed.</p>
+<p>
+In the following example, the second <code>catch</code> clause is unreachable.
+The code is incomplete because a <code>FileOutputStream</code> is opened but
+no methods are called to write to the stream. Such methods typically throw
+<code>IOException</code>s, which would make the second <code>catch</code> clause
+reachable.
+</p>
 
 <sample src="PartiallyMaskedCatch.java" />
 

--- a/java/ql/src/Likely Bugs/Statements/PartiallyMaskedCatch.ql
+++ b/java/ql/src/Likely Bugs/Statements/PartiallyMaskedCatch.ql
@@ -47,7 +47,10 @@ RefType getAThrownExceptionType(TryStmt t) {
     t.getBlock() = call.getEnclosingStmt().getParent*() or
     t.getAResourceDecl() = call.getEnclosingStmt()
     |
-    call.getCallee().getAnException() = e and
+    (
+      call.getCallee().getAnException() = e or
+      call.(GenericCall).getATypeArgument(call.getCallee().getAnException().getType()) = e.getType()
+    ) and
     not caughtInside(t, call.getEnclosingStmt(), e.getType()) and
     result = e.getType()
   ) or

--- a/java/ql/test/.project
+++ b/java/ql/test/.project
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>semmlecode-tests-ql</name>
+	<comment></comment>
+	<projects>
+	</projects>
+	<buildSpec>
+	</buildSpec>
+	<natures>
+		<nature>com.semmle.plugin.qdt.core.qlnature</nature>
+	</natures>
+</projectDescription>

--- a/java/ql/test/query-tests/PartiallyMaskedCatch/PartiallyMaskedCatchTest.java
+++ b/java/ql/test/query-tests/PartiallyMaskedCatch/PartiallyMaskedCatchTest.java
@@ -68,6 +68,14 @@ public class PartiallyMaskedCatchTest {
 		} catch (IOException e) {
 			// reachable: IOException is thrown by getClosableThing()
 		}
+
+		try (ClosableThing thing = new ClosableThing()) {
+			genericThrowingMethod(IOException.class);
+		} catch (ExceptionA e) {
+			// reachable: ExceptionA is thrown by implicit invocation of CloseableThing.close()
+		} catch (IOException e) {
+			// reachable: IOException is thrown by invocation of genericThrowingMethod(IOException.class)
+		}
 	}
 
 	public static ClosableThing getClosableThing() throws IOException {
@@ -94,4 +102,6 @@ public class PartiallyMaskedCatchTest {
 			throws ClassNotFoundException,
 			NoSuchMethodException, InstantiationException, IllegalAccessException,
 			InvocationTargetException {}
+
+	public static <E extends Exception> void genericThrowingMethod(Class<E> c) throws E {}
 }


### PR DESCRIPTION
- Account for generic exceptions in `java/unreachable-catch-clause` and add a test.
- Clarify query help for `java/unreachable-catch-clause` based on user feedback.