### PR TITLE
 C++: Suppress IntMultToLong alert on char-typed numbers

### DIFF
--- a/cpp/ql/src/Likely Bugs/Arithmetic/IntMultToLong.ql
+++ b/cpp/ql/src/Likely Bugs/Arithmetic/IntMultToLong.ql
@@ -21,6 +21,7 @@ import semmle.code.cpp.controlflow.SSA
 /**
  * Holds if `e` is either:
  *  - a constant
+ *  - a char-typed expression, meaning it's a small number
  *  - an array access to an array of constants
  *  - flows from one of the above
  * In these cases the value of `e` is likely to be small and
@@ -28,6 +29,7 @@ import semmle.code.cpp.controlflow.SSA
  */
 predicate effectivelyConstant(Expr e) {
   e.isConstant() or
+  e.getType().getSize() <= 1 or
   e.(ArrayExpr).getArrayBase().getType().(ArrayType).getBaseType().isConst() or
   exists(SsaDefinition def, Variable v |
     def.getAUse(v) = e and

--- a/cpp/ql/src/Likely Bugs/Arithmetic/IntMultToLong.ql
+++ b/cpp/ql/src/Likely Bugs/Arithmetic/IntMultToLong.ql
@@ -27,13 +27,13 @@ import semmle.code.cpp.controlflow.SSA
  * In these cases the value of `e` is likely to be small and
  * controlled, so we consider it less likely to cause an overflow.
  */
-predicate effectivelyConstant(Expr e) {
+predicate likelySmall(Expr e) {
   e.isConstant() or
   e.getType().getSize() <= 1 or
   e.(ArrayExpr).getArrayBase().getType().(ArrayType).getBaseType().isConst() or
   exists(SsaDefinition def, Variable v |
     def.getAUse(v) = e and
-    effectivelyConstant(def.getDefiningValue(v))
+    likelySmall(def.getDefiningValue(v))
   )
 }
 
@@ -58,7 +58,7 @@ int getEffectiveMulOperands(MulExpr me) {
   result = count(Expr op |
     op = getMulOperand*(me) and
     not op instanceof MulExpr and
-    not effectivelyConstant(op)
+    not likelySmall(op)
   )
 }
 

--- a/cpp/ql/test/query-tests/Likely Bugs/Arithmetic/IntMultToLong/IntMultToLong.c
+++ b/cpp/ql/test/query-tests/Likely Bugs/Arithmetic/IntMultToLong/IntMultToLong.c
@@ -88,3 +88,7 @@ void use_printf(float f, double d)
 		// ^ there's a float -> double varargs promotion here, but it's unlikely that the author anticipates requiring a double
 	printf("%f", d * d); // safe
 }
+
+size_t three_chars(unsigned char a, unsigned char b, unsigned char c) {
+    return a * b * c; // at most 16581375 [FALSE POSITIVE]
+}

--- a/cpp/ql/test/query-tests/Likely Bugs/Arithmetic/IntMultToLong/IntMultToLong.c
+++ b/cpp/ql/test/query-tests/Likely Bugs/Arithmetic/IntMultToLong/IntMultToLong.c
@@ -90,5 +90,5 @@ void use_printf(float f, double d)
 }
 
 size_t three_chars(unsigned char a, unsigned char b, unsigned char c) {
-    return a * b * c; // at most 16581375 [FALSE POSITIVE]
+    return a * b * c; // at most 16581375
 }

--- a/cpp/ql/test/query-tests/Likely Bugs/Arithmetic/IntMultToLong/IntMultToLong.expected
+++ b/cpp/ql/test/query-tests/Likely Bugs/Arithmetic/IntMultToLong/IntMultToLong.expected
@@ -7,4 +7,3 @@
 | IntMultToLong.c:61:23:61:33 | ... * ... | Multiplication result may overflow 'int' before it is converted to 'long long'. |
 | IntMultToLong.c:63:23:63:40 | ... * ... | Multiplication result may overflow 'int' before it is converted to 'long long'. |
 | IntMultToLong.c:75:9:75:13 | ... * ... | Multiplication result may overflow 'int' before it is converted to 'size_t'. |
-| IntMultToLong.c:93:12:93:20 | ... * ... | Multiplication result may overflow 'int' before it is converted to 'size_t'. |

--- a/cpp/ql/test/query-tests/Likely Bugs/Arithmetic/IntMultToLong/IntMultToLong.expected
+++ b/cpp/ql/test/query-tests/Likely Bugs/Arithmetic/IntMultToLong/IntMultToLong.expected
@@ -7,3 +7,4 @@
 | IntMultToLong.c:61:23:61:33 | ... * ... | Multiplication result may overflow 'int' before it is converted to 'long long'. |
 | IntMultToLong.c:63:23:63:40 | ... * ... | Multiplication result may overflow 'int' before it is converted to 'long long'. |
 | IntMultToLong.c:75:9:75:13 | ... * ... | Multiplication result may overflow 'int' before it is converted to 'size_t'. |
+| IntMultToLong.c:93:12:93:20 | ... * ... | Multiplication result may overflow 'int' before it is converted to 'size_t'. |


### PR DESCRIPTION
This change is a small refinement on top of internal PR 25314 to address https://discuss.lgtm.com/t/cpp-integer-multiplication-cast-to-long-does-not-take-size-promotion-rules-into-account/1326/5.