### PR TITLE
C++ definitions: Ignore type mentions of class inatantiations.

### DIFF
--- a/cpp/ql/src/definitions.qll
+++ b/cpp/ql/src/definitions.qll
@@ -102,7 +102,8 @@ private predicate constructorCallStartLoc(ConstructorCall cc, File f, int line, 
 
 /**
  * Holds if `f`, `line`, `column` indicate the start character
- * of `tm`, which mentions `t`.
+ * of `tm`, which mentions `t`. Type mentions for instantiations
+ * are filtered out.
  */
 private predicate typeMentionStartLoc(TypeMention tm, Type t, File f, int line, int column) {
   exists(Location l |
@@ -111,7 +112,8 @@ private predicate typeMentionStartLoc(TypeMention tm, Type t, File f, int line, 
     l.getStartLine() = line and
     l.getStartColumn() = column
   ) and
-  t = tm.getMentionedType()
+  t = tm.getMentionedType() and
+  not t instanceof ClassTemplateInstantiation
 }
 
 /**


### PR DESCRIPTION
We currently erroneously keep mentions of class instantiations, which
can lead to bad performance on template-heavy code bases. We never
want to link those anyway, so we can simply suppress them.

@rdmarsh2 @jbj As discussed, this helps on my test codebases.