### PR TITLE
Allow "badly bounded" writes to a size 0 buffer

### DIFF
--- a/cpp/ql/src/Security/CWE/CWE-120/BadlyBoundedWrite.ql
+++ b/cpp/ql/src/Security/CWE/CWE-120/BadlyBoundedWrite.ql
@@ -21,4 +21,5 @@ from BufferWrite bw, int destSize
 where bw.hasExplicitLimit()                     // has an explicit size limit
   and destSize = getBufferSize(bw.getDest(), _)
   and (bw.getExplicitLimit() > destSize)        // but it's larger than the destination
+  and not destSize = 0                          // probably just a hack if the destination size is 0
 select bw, "This '" + bw.getBWDesc() + "' operation is limited to " + bw.getExplicitLimit() + " bytes but the destination is only " + destSize + " bytes."


### PR DESCRIPTION
This probably means this is a hack to do something like set a bunch of struct fields at once. See: https://lgtm.com/projects/g/CZ-NIC/bird/snapshot/9ba0b39e4c4756944718ab9cb55efd5824527a4b/files/proto/rip/packets.c#x17ea4190ce37e101:1.

@geoffw0 