### PR TITLE
Allow void* pointer arithmetic with sizeof

### DIFF
--- a/cpp/ql/src/Security/CWE/CWE-468/SuspiciousAddWithSizeof.ql
+++ b/cpp/ql/src/Security/CWE/CWE-468/SuspiciousAddWithSizeof.ql
@@ -13,18 +13,19 @@
 import cpp
 import IncorrectPointerScalingCommon
 
-private predicate isCharPtrExpr(Expr e) {
+private predicate isCharSzPtrExpr(Expr e) {
   exists (PointerType pt
   | pt = e.getFullyConverted().getUnderlyingType()
-  | pt.getBaseType().getUnspecifiedType() instanceof CharType)
+  | pt.getBaseType().getUnspecifiedType() instanceof CharType
+  or pt.getBaseType().getUnspecifiedType() instanceof VoidType)
 }
 
 from Expr sizeofExpr, Expr e
 where
   // If we see an addWithSizeof then we expect the type of
-  // the pointer expression to be char*. Otherwise it is probably
-  // a mistake.
-  addWithSizeof(e, sizeofExpr, _) and not isCharPtrExpr(e)
+  // the pointer expression to be char* or void*. Otherwise it
+  // is probably a mistake.
+  addWithSizeof(e, sizeofExpr, _) and not isCharSzPtrExpr(e)
 select
   sizeofExpr,
   "Suspicious sizeof offset in a pointer arithmetic expression. " +


### PR DESCRIPTION
Since `void` is generally considered a 1-byte type when doing pointer arithmetic, these results are usually false positives.

Technically this isn't allowed by the C spec, but it's been seen in the wild:
see https://lgtm.com/projects/g/libcsp/libcsp/snapshot/3763c7b3380f95c81636de5c95156fd3ef151a21/files/src/csp_buffer.c\#x1d04047d2bb68c21:1.

@geoffw0 