### PR TITLE
Merge rc/1.18 into next.

### DIFF
--- a/cpp/ql/src/definitions.qll
+++ b/cpp/ql/src/definitions.qll
@@ -102,7 +102,8 @@ private predicate constructorCallStartLoc(ConstructorCall cc, File f, int line, 
 
 /**
  * Holds if `f`, `line`, `column` indicate the start character
- * of `tm`, which mentions `t`.
+ * of `tm`, which mentions `t`. Type mentions for instantiations
+ * are filtered out.
  */
 private predicate typeMentionStartLoc(TypeMention tm, Type t, File f, int line, int column) {
   exists(Location l |
@@ -111,7 +112,8 @@ private predicate typeMentionStartLoc(TypeMention tm, Type t, File f, int line, 
     l.getStartLine() = line and
     l.getStartColumn() = column
   ) and
-  t = tm.getMentionedType()
+  t = tm.getMentionedType() and
+  not t instanceof ClassTemplateInstantiation
 }
 
 /**

--- a/cpp/ql/src/semmle/code/cpp/Parameter.qll
+++ b/cpp/ql/src/semmle/code/cpp/Parameter.qll
@@ -68,10 +68,9 @@ class Parameter extends LocalScopeVariable, @parameter {
    */
   private VariableDeclarationEntry getAnEffectiveDeclarationEntry() {
     if getFunction().isConstructedFrom(_)
-      then exists (Parameter prototype
-           | prototype = result.getVariable() and
-             prototype.getIndex() = getIndex() and
-             getFunction().isConstructedFrom(prototype.getFunction()))
+      then exists (Function prototypeInstantiation
+           | prototypeInstantiation.getParameter(getIndex()) = result.getVariable() and
+             getFunction().isConstructedFrom(prototypeInstantiation))
       else result = getADeclarationEntry()
   }
 

--- a/cpp/ql/test/library-tests/ir/ir/PrintAST.expected
+++ b/cpp/ql/test/library-tests/ir/ir/PrintAST.expected
@@ -6303,3 +6303,35 @@ ir.cpp:
 #  958|             Type = int
 #  958|             ValueCategory = prvalue(load)
 #  959|     8: return ...
+#  961| designatedInit() -> int
+#  961|   params: 
+#  961|   body: { ... }
+#  962|     0: declaration
+#  962|       0: definition of a1
+#  962|           Type = int[1000]
+#  962|         init: initializer for a1
+#  962|           expr: {...}
+#  962|               Type = int[1000]
+#  962|               ValueCategory = prvalue
+#  962|             0: 10002
+#  962|                 Type = int
+#  962|                 Value = 10002
+#  962|                 ValueCategory = prvalue
+#  962|             1: 10900
+#  962|                 Type = int
+#  962|                 Value = 10900
+#  962|                 ValueCategory = prvalue
+#  963|     1: return ...
+#  963|       0: access to array
+#  963|           Type = int
+#  963|           ValueCategory = prvalue(load)
+#  963|         0: array to pointer conversion
+#  963|             Type = int *
+#  963|             ValueCategory = prvalue
+#  963|           expr: a1
+#  963|               Type = int[1000]
+#  963|               ValueCategory = lvalue
+#  963|         1: 900
+#  963|             Type = int
+#  963|             Value = 900
+#  963|             ValueCategory = prvalue

--- a/cpp/ql/test/library-tests/ir/ir/aliased_ssa_ir.expected
+++ b/cpp/ql/test/library-tests/ir/ir/aliased_ssa_ir.expected
@@ -3906,3 +3906,49 @@ ir.cpp:
 #  950|     v0_65(void)                          = ReturnVoid                      : 
 #  950|     v0_66(void)                          = UnmodeledUse                    : mu*
 #  950|     v0_67(void)                          = ExitFunction                    : 
+
+#  961| designatedInit() -> int
+#  961|   Block 0
+#  961|     v0_0(void)             = EnterFunction       : 
+#  961|     mu0_1(unknown)         = UnmodeledDefinition : 
+#  962|     r0_2(glval<int[1000]>) = VariableAddress[a1] : 
+#  962|     r0_3(int)              = Constant[0]         : 
+#  962|     r0_4(glval<int>)       = PointerAdd          : r0_2, r0_3
+#  962|     r0_5(unknown[8])       = Constant[0]         : 
+#  962|     mu0_6(unknown[8])      = Store               : r0_4, r0_5
+#-----|   Goto -> Block 2
+
+#  962|   Block 1
+#  962|     r1_0(int)           = Constant[900]   : 
+#  962|     r1_1(glval<int>)    = PointerAdd      : r0_2, r1_0
+#  962|     r1_2(int)           = Constant[10900] : 
+#  962|     mu1_3(int)          = Store           : r1_1, r1_2
+#  962|     r1_4(int)           = Constant[901]   : 
+#  962|     r1_5(glval<int>)    = PointerAdd      : r0_2, r1_4
+#  962|     r1_6(unknown[396])  = Constant[0]     : 
+#  962|     mu1_7(unknown[396]) = Store           : r1_5, r1_6
+#-----|   Goto -> Block 2
+
+#  963|   Block 2
+#  963|     r2_0(glval<int>)       = VariableAddress[#return] : 
+#  963|     r2_1(glval<int[1000]>) = VariableAddress[a1]      : 
+#  963|     r2_2(int *)            = Convert                  : r2_1
+#  963|     r2_3(int)              = Constant[900]            : 
+#  963|     r2_4(int *)            = PointerAdd[4]            : r2_2, r2_3
+#  963|     r2_5(int)              = Load                     : r2_4, mu0_1
+#  963|     m2_6(int)              = Store                    : r2_0, r2_5
+#  961|     r2_7(glval<int>)       = VariableAddress[#return] : 
+#  961|     v2_8(void)             = ReturnValue              : r2_7, m2_6
+#  961|     v2_9(void)             = UnmodeledUse             : mu*
+#  961|     v2_10(void)            = ExitFunction             : 
+
+#  962|   Block 3
+#  962|     r3_0(int)            = Constant[2]     : 
+#  962|     r3_1(glval<int>)     = PointerAdd      : r0_2, r3_0
+#  962|     r3_2(int)            = Constant[10002] : 
+#  962|     mu3_3(int)           = Store           : r3_1, r3_2
+#  962|     r3_4(int)            = Constant[3]     : 
+#  962|     r3_5(glval<int>)     = PointerAdd      : r0_2, r3_4
+#  962|     r3_6(unknown[3588])  = Constant[0]     : 
+#  962|     mu3_7(unknown[3588]) = Store           : r3_5, r3_6
+#-----|   Goto -> Block 2

--- a/cpp/ql/test/library-tests/ir/ir/ir.cpp
+++ b/cpp/ql/test/library-tests/ir/ir/ir.cpp
@@ -958,6 +958,11 @@ void OperatorNewArray(int n) {
   new int[n] { 0, 1, 2 };
 }
 
+int designatedInit() {
+  int a1[1000] = { [2] = 10002, [900] = 10900 };
+  return a1[900];
+}
+
 #if 0
 void OperatorDelete() {
   delete static_cast<int*>(nullptr);  // No destructor

--- a/cpp/ql/test/library-tests/ir/ir/raw_ir.expected
+++ b/cpp/ql/test/library-tests/ir/ir/raw_ir.expected
@@ -3885,3 +3885,49 @@ ir.cpp:
 #  950|     v0_65(void)                          = ReturnVoid                      : 
 #  950|     v0_66(void)                          = UnmodeledUse                    : mu*
 #  950|     v0_67(void)                          = ExitFunction                    : 
+
+#  961| designatedInit() -> int
+#  961|   Block 0
+#  961|     v0_0(void)             = EnterFunction       : 
+#  961|     mu0_1(unknown)         = UnmodeledDefinition : 
+#  962|     r0_2(glval<int[1000]>) = VariableAddress[a1] : 
+#  962|     r0_3(int)              = Constant[0]         : 
+#  962|     r0_4(glval<int>)       = PointerAdd          : r0_2, r0_3
+#  962|     r0_5(unknown[8])       = Constant[0]         : 
+#  962|     mu0_6(unknown[8])      = Store               : r0_4, r0_5
+#-----|   Goto -> Block 2
+
+#  962|   Block 1
+#  962|     r1_0(int)           = Constant[900]   : 
+#  962|     r1_1(glval<int>)    = PointerAdd      : r0_2, r1_0
+#  962|     r1_2(int)           = Constant[10900] : 
+#  962|     mu1_3(int)          = Store           : r1_1, r1_2
+#  962|     r1_4(int)           = Constant[901]   : 
+#  962|     r1_5(glval<int>)    = PointerAdd      : r0_2, r1_4
+#  962|     r1_6(unknown[396])  = Constant[0]     : 
+#  962|     mu1_7(unknown[396]) = Store           : r1_5, r1_6
+#-----|   Goto -> Block 2
+
+#  963|   Block 2
+#  963|     r2_0(glval<int>)       = VariableAddress[#return] : 
+#  963|     r2_1(glval<int[1000]>) = VariableAddress[a1]      : 
+#  963|     r2_2(int *)            = Convert                  : r2_1
+#  963|     r2_3(int)              = Constant[900]            : 
+#  963|     r2_4(int *)            = PointerAdd[4]            : r2_2, r2_3
+#  963|     r2_5(int)              = Load                     : r2_4, mu0_1
+#  963|     mu2_6(int)             = Store                    : r2_0, r2_5
+#  961|     r2_7(glval<int>)       = VariableAddress[#return] : 
+#  961|     v2_8(void)             = ReturnValue              : r2_7, mu0_1
+#  961|     v2_9(void)             = UnmodeledUse             : mu*
+#  961|     v2_10(void)            = ExitFunction             : 
+
+#  962|   Block 3
+#  962|     r3_0(int)            = Constant[2]     : 
+#  962|     r3_1(glval<int>)     = PointerAdd      : r0_2, r3_0
+#  962|     r3_2(int)            = Constant[10002] : 
+#  962|     mu3_3(int)           = Store           : r3_1, r3_2
+#  962|     r3_4(int)            = Constant[3]     : 
+#  962|     r3_5(glval<int>)     = PointerAdd      : r0_2, r3_4
+#  962|     r3_6(unknown[3588])  = Constant[0]     : 
+#  962|     mu3_7(unknown[3588]) = Store           : r3_5, r3_6
+#-----|   Goto -> Block 2

--- a/cpp/ql/test/library-tests/ir/ir/ssa_block_count.expected
+++ b/cpp/ql/test/library-tests/ir/ir/ssa_block_count.expected
@@ -92,6 +92,7 @@
 | IR: VarArgs | 1 |
 | IR: VirtualMemberFunction | 1 |
 | IR: WhileStatements | 4 |
+| IR: designatedInit | 4 |
 | IR: min | 4 |
 | IR: operator= | 1 |
 | IR: ~Base | 1 |

--- a/cpp/ql/test/library-tests/ir/ir/unaliased_ssa_ir.expected
+++ b/cpp/ql/test/library-tests/ir/ir/unaliased_ssa_ir.expected
@@ -3906,3 +3906,49 @@ ir.cpp:
 #  950|     v0_65(void)                          = ReturnVoid                      : 
 #  950|     v0_66(void)                          = UnmodeledUse                    : mu*
 #  950|     v0_67(void)                          = ExitFunction                    : 
+
+#  961| designatedInit() -> int
+#  961|   Block 0
+#  961|     v0_0(void)             = EnterFunction       : 
+#  961|     mu0_1(unknown)         = UnmodeledDefinition : 
+#  962|     r0_2(glval<int[1000]>) = VariableAddress[a1] : 
+#  962|     r0_3(int)              = Constant[0]         : 
+#  962|     r0_4(glval<int>)       = PointerAdd          : r0_2, r0_3
+#  962|     r0_5(unknown[8])       = Constant[0]         : 
+#  962|     mu0_6(unknown[8])      = Store               : r0_4, r0_5
+#-----|   Goto -> Block 2
+
+#  962|   Block 1
+#  962|     r1_0(int)           = Constant[900]   : 
+#  962|     r1_1(glval<int>)    = PointerAdd      : r0_2, r1_0
+#  962|     r1_2(int)           = Constant[10900] : 
+#  962|     mu1_3(int)          = Store           : r1_1, r1_2
+#  962|     r1_4(int)           = Constant[901]   : 
+#  962|     r1_5(glval<int>)    = PointerAdd      : r0_2, r1_4
+#  962|     r1_6(unknown[396])  = Constant[0]     : 
+#  962|     mu1_7(unknown[396]) = Store           : r1_5, r1_6
+#-----|   Goto -> Block 2
+
+#  963|   Block 2
+#  963|     r2_0(glval<int>)       = VariableAddress[#return] : 
+#  963|     r2_1(glval<int[1000]>) = VariableAddress[a1]      : 
+#  963|     r2_2(int *)            = Convert                  : r2_1
+#  963|     r2_3(int)              = Constant[900]            : 
+#  963|     r2_4(int *)            = PointerAdd[4]            : r2_2, r2_3
+#  963|     r2_5(int)              = Load                     : r2_4, mu0_1
+#  963|     m2_6(int)              = Store                    : r2_0, r2_5
+#  961|     r2_7(glval<int>)       = VariableAddress[#return] : 
+#  961|     v2_8(void)             = ReturnValue              : r2_7, m2_6
+#  961|     v2_9(void)             = UnmodeledUse             : mu*
+#  961|     v2_10(void)            = ExitFunction             : 
+
+#  962|   Block 3
+#  962|     r3_0(int)            = Constant[2]     : 
+#  962|     r3_1(glval<int>)     = PointerAdd      : r0_2, r3_0
+#  962|     r3_2(int)            = Constant[10002] : 
+#  962|     mu3_3(int)           = Store           : r3_1, r3_2
+#  962|     r3_4(int)            = Constant[3]     : 
+#  962|     r3_5(glval<int>)     = PointerAdd      : r0_2, r3_4
+#  962|     r3_6(unknown[3588])  = Constant[0]     : 
+#  962|     mu3_7(unknown[3588]) = Store           : r3_5, r3_6
+#-----|   Goto -> Block 2

--- a/cpp/ql/test/library-tests/structs/compatible_cpp/b1.cpp
+++ b/cpp/ql/test/library-tests/structs/compatible_cpp/b1.cpp
@@ -24,3 +24,9 @@ class Damson {
   int damson_x;
   void foo();
 };
+
+namespace unrelated {
+  class AppleCompatible {
+    long apple_x;
+  };
+}

--- a/cpp/ql/test/library-tests/structs/compatible_cpp/compatible.expected
+++ b/cpp/ql/test/library-tests/structs/compatible_cpp/compatible.expected
@@ -32,6 +32,9 @@
 | b1.cpp:23:7:23:12 | Damson | 5 members | 2 locations | 1 | foo |
 | b1.cpp:23:7:23:12 | Damson | 5 members | 2 locations | 2 | operator= |
 | b1.cpp:23:7:23:12 | Damson | 5 members | 2 locations | 3 | operator= |
+| b1.cpp:29:9:29:23 | AppleCompatible | 3 members | 1 locations | 0 | apple_x |
+| b1.cpp:29:9:29:23 | AppleCompatible | 3 members | 1 locations | 1 | operator= |
+| b1.cpp:29:9:29:23 | AppleCompatible | 3 members | 1 locations | 2 | operator= |
 | b2.cpp:2:7:2:21 | AppleCompatible | 3 members | 2 locations | 0 | apple_x |
 | b2.cpp:2:7:2:21 | AppleCompatible | 3 members | 2 locations | 1 | operator= |
 | b2.cpp:2:7:2:21 | AppleCompatible | 3 members | 2 locations | 2 | operator= |

--- a/cpp/ql/test/library-tests/structs/compatible_cpp/compatible_types.expected
+++ b/cpp/ql/test/library-tests/structs/compatible_cpp/compatible_types.expected
@@ -10,6 +10,7 @@
 | b1.cpp:11:7:11:22 | BananaCompatible | 0 | file://:0:0:0:0 | int | 1 types |
 | b1.cpp:16:7:16:12 | Cherry | 0 | file://:0:0:0:0 | int | 1 types |
 | b1.cpp:23:7:23:12 | Damson | 0 | file://:0:0:0:0 | int | 1 types |
+| b1.cpp:29:9:29:23 | AppleCompatible | 0 | file://:0:0:0:0 | long | 1 types |
 | b2.cpp:2:7:2:21 | AppleCompatible | 0 | file://:0:0:0:0 | int | 1 types |
 | b2.cpp:9:7:9:22 | BananaCompatible | 0 | file://:0:0:0:0 | int | 1 types |
 | b2.cpp:14:7:14:12 | Cherry | 0 | file://:0:0:0:0 | short | 1 types |

--- a/cpp/ql/test/library-tests/structs/incomplete_definition/pointerbasetype.expected
+++ b/cpp/ql/test/library-tests/structs/incomplete_definition/pointerbasetype.expected
@@ -1,2 +1,6 @@
 | a.h:5:8:5:13 | cheese | y.cpp:4:8:4:10 | Foo | 3 |
 | x.cpp:3:6:3:10 | bar_x | a.h:4:8:4:10 | Bar | 3 |
+| x.cpp:19:6:19:10 | foo_x | y.cpp:4:8:4:10 | Foo | 3 |
+| x.cpp:23:5:23:17 | templateField | x.cpp:6:10:6:12 | Foo | 3 |
+| x.cpp:23:5:23:17 | templateField | x.cpp:12:9:12:11 | Foo | 3 |
+| x.cpp:26:18:26:29 | template_foo | x.cpp:22:7:22:14 | Template<Foo *> | 0 |

--- a/cpp/ql/test/library-tests/structs/incomplete_definition/x.cpp
+++ b/cpp/ql/test/library-tests/structs/incomplete_definition/x.cpp
@@ -1,3 +1,31 @@
 #include "a.h"
 
 Bar *bar_x;
+
+namespace unrelated {
+  struct Foo {
+    short val;
+  };
+}
+
+struct ContainsAnotherFoo {
+  class Foo {
+    long val;
+  };
+};
+
+// The type of `foo_x` should not refer to any of the above classes, none of
+// which are named `Foo` in the global scope.
+Foo *foo_x;
+
+template<typename T>
+class Template {
+  T templateField;
+};
+
+Template<Foo *> *template_foo;
+
+// Instantiation of the template with unrelated classes named `Foo` should not
+// get mixed up with the instantiation above.
+template class Template<unrelated::Foo *>;
+template class Template<ContainsAnotherFoo::Foo *>;

--- a/cpp/ql/test/library-tests/structs/qualified_names/c1.cpp
+++ b/cpp/ql/test/library-tests/structs/qualified_names/c1.cpp
@@ -1,0 +1,9 @@
+#include "header.h"
+
+struct MultipleDefsButSameHeader {
+  int i;
+};
+
+struct OneDefInDifferentFile {
+  int i;
+};

--- a/cpp/ql/test/library-tests/structs/qualified_names/c2.cpp
+++ b/cpp/ql/test/library-tests/structs/qualified_names/c2.cpp
@@ -1,0 +1,6 @@
+#include "header.h"
+
+struct MultipleDefsButSameHeader {
+  char char1;
+  char char2;
+};

--- a/cpp/ql/test/library-tests/structs/qualified_names/decls.cpp
+++ b/cpp/ql/test/library-tests/structs/qualified_names/decls.cpp
@@ -1,0 +1,5 @@
+namespace foo {
+  class C;
+
+  C *x;
+}

--- a/cpp/ql/test/library-tests/structs/qualified_names/defs.cpp
+++ b/cpp/ql/test/library-tests/structs/qualified_names/defs.cpp
@@ -1,0 +1,29 @@
+namespace foo {
+  class C {
+  };
+}
+
+namespace bar {
+  class C {
+  };
+}
+
+class DefinedAndDeclared {
+};
+
+// Despite this declaration being present, the variable below is associated
+// with the definition above rather than this declaration.
+class DefinedAndDeclared;
+
+DefinedAndDeclared *definedAndDeclared;
+
+#include "header.h"
+
+// Because there are multiple definitions of `MultipleDefsButSameHeader`, the
+// type of this variable will refer to the declaration in `header.h` rather
+// than any of the definitions.
+MultipleDefsButSameHeader *mdbsh;
+
+// Because there is only one definition of `OneDefInDifferentFile`, the type of
+// this variable will refer to that definition.
+OneDefInDifferentFile *odidf;

--- a/cpp/ql/test/library-tests/structs/qualified_names/header.h
+++ b/cpp/ql/test/library-tests/structs/qualified_names/header.h
@@ -1,0 +1,3 @@
+struct MultipleDefsButSameHeader;
+
+struct OneDefInDifferentFile;

--- a/cpp/ql/test/library-tests/structs/qualified_names/pointerBaseType.expected
+++ b/cpp/ql/test/library-tests/structs/qualified_names/pointerBaseType.expected
@@ -1,0 +1,4 @@
+| decls.cpp:4:6:4:6 | x | decls.cpp:2:9:2:9 | C |
+| defs.cpp:18:21:18:38 | definedAndDeclared | defs.cpp:11:7:11:24 | DefinedAndDeclared |
+| defs.cpp:25:28:25:32 | mdbsh | header.h:1:8:1:32 | MultipleDefsButSameHeader |
+| defs.cpp:29:24:29:28 | odidf | c1.cpp:7:8:7:28 | OneDefInDifferentFile |

--- a/cpp/ql/test/library-tests/structs/qualified_names/pointerBaseType.ql
+++ b/cpp/ql/test/library-tests/structs/qualified_names/pointerBaseType.ql
@@ -1,0 +1,5 @@
+import cpp
+
+from Variable x
+where exists(x.getFile().getRelativePath())
+select x, x.getType().(PointerType).getBaseType()

--- a/cpp/ql/test/library-tests/templates/isfromtemplateinstantiation/isfromtemplateinstantiation.expected
+++ b/cpp/ql/test/library-tests/templates/isfromtemplateinstantiation/isfromtemplateinstantiation.expected
@@ -116,32 +116,13 @@
 | isfromtemplateinstantiation.cpp:134:29:134:29 | Outer<int>::operator=(const Outer<int> &) | isfromtemplateinstantiation.cpp:134:29:134:33 | Outer<int> |
 | isfromtemplateinstantiation.cpp:134:29:134:29 | declaration of operator= | isfromtemplateinstantiation.cpp:134:29:134:33 | Outer<int> |
 | isfromtemplateinstantiation.cpp:134:29:134:29 | declaration of operator= | isfromtemplateinstantiation.cpp:134:29:134:33 | Outer<int> |
-| isfromtemplateinstantiation.cpp:135:31:135:31 | Outer<T>::Inner<long>::operator=(Inner<long> &&) | isfromtemplateinstantiation.cpp:134:29:134:33 | Outer<int> |
 | isfromtemplateinstantiation.cpp:135:31:135:31 | Outer<T>::Inner<long>::operator=(Inner<long> &&) | isfromtemplateinstantiation.cpp:135:31:135:35 | Inner<long> |
-| isfromtemplateinstantiation.cpp:135:31:135:31 | Outer<T>::Inner<long>::operator=(const Inner<long> &) | isfromtemplateinstantiation.cpp:134:29:134:33 | Outer<int> |
 | isfromtemplateinstantiation.cpp:135:31:135:31 | Outer<T>::Inner<long>::operator=(const Inner<long> &) | isfromtemplateinstantiation.cpp:135:31:135:35 | Inner<long> |
-| isfromtemplateinstantiation.cpp:135:31:135:31 | Outer<int>::Inner<long>::operator=(Inner<long> &&) | isfromtemplateinstantiation.cpp:134:29:134:33 | Outer<int> |
-| isfromtemplateinstantiation.cpp:135:31:135:31 | Outer<int>::Inner<long>::operator=(Inner<long> &&) | isfromtemplateinstantiation.cpp:135:31:135:35 | Inner<long> |
-| isfromtemplateinstantiation.cpp:135:31:135:31 | Outer<int>::Inner<long>::operator=(const Inner<long> &) | isfromtemplateinstantiation.cpp:134:29:134:33 | Outer<int> |
-| isfromtemplateinstantiation.cpp:135:31:135:31 | Outer<int>::Inner<long>::operator=(const Inner<long> &) | isfromtemplateinstantiation.cpp:135:31:135:35 | Inner<long> |
-| isfromtemplateinstantiation.cpp:135:31:135:31 | declaration of operator= | isfromtemplateinstantiation.cpp:134:29:134:33 | Outer<int> |
-| isfromtemplateinstantiation.cpp:135:31:135:31 | declaration of operator= | isfromtemplateinstantiation.cpp:134:29:134:33 | Outer<int> |
 | isfromtemplateinstantiation.cpp:135:31:135:31 | declaration of operator= | isfromtemplateinstantiation.cpp:135:31:135:35 | Inner<long> |
 | isfromtemplateinstantiation.cpp:135:31:135:31 | declaration of operator= | isfromtemplateinstantiation.cpp:135:31:135:35 | Inner<long> |
-| isfromtemplateinstantiation.cpp:135:31:135:35 | Inner<U> | isfromtemplateinstantiation.cpp:134:29:134:33 | Outer<int> |
-| isfromtemplateinstantiation.cpp:135:31:135:35 | Inner<long> | isfromtemplateinstantiation.cpp:134:29:134:33 | Outer<int> |
-| isfromtemplateinstantiation.cpp:135:31:135:35 | definition of Inner<U> | isfromtemplateinstantiation.cpp:134:29:134:33 | Outer<int> |
-| isfromtemplateinstantiation.cpp:136:7:136:7 | definition of x | isfromtemplateinstantiation.cpp:134:29:134:33 | Outer<int> |
-| isfromtemplateinstantiation.cpp:136:7:136:7 | definition of x | isfromtemplateinstantiation.cpp:134:29:134:33 | Outer<int> |
 | isfromtemplateinstantiation.cpp:136:7:136:7 | definition of x | isfromtemplateinstantiation.cpp:135:31:135:35 | Inner<long> |
-| isfromtemplateinstantiation.cpp:136:7:136:7 | x | isfromtemplateinstantiation.cpp:134:29:134:33 | Outer<int> |
-| isfromtemplateinstantiation.cpp:136:7:136:7 | x | isfromtemplateinstantiation.cpp:134:29:134:33 | Outer<int> |
 | isfromtemplateinstantiation.cpp:136:7:136:7 | x | isfromtemplateinstantiation.cpp:135:31:135:35 | Inner<long> |
-| isfromtemplateinstantiation.cpp:137:7:137:7 | definition of y | isfromtemplateinstantiation.cpp:134:29:134:33 | Outer<int> |
-| isfromtemplateinstantiation.cpp:137:7:137:7 | definition of y | isfromtemplateinstantiation.cpp:134:29:134:33 | Outer<int> |
 | isfromtemplateinstantiation.cpp:137:7:137:7 | definition of y | isfromtemplateinstantiation.cpp:135:31:135:35 | Inner<long> |
-| isfromtemplateinstantiation.cpp:137:7:137:7 | y | isfromtemplateinstantiation.cpp:134:29:134:33 | Outer<int> |
-| isfromtemplateinstantiation.cpp:137:7:137:7 | y | isfromtemplateinstantiation.cpp:134:29:134:33 | Outer<int> |
 | isfromtemplateinstantiation.cpp:137:7:137:7 | y | isfromtemplateinstantiation.cpp:135:31:135:35 | Inner<long> |
 | load.cpp:13:7:13:7 | basic_text_iprimitive<std_istream_mockup>::basic_text_iprimitive(basic_text_iprimitive<std_istream_mockup> &&) | load.cpp:13:7:13:27 | basic_text_iprimitive<std_istream_mockup> |
 | load.cpp:13:7:13:7 | basic_text_iprimitive<std_istream_mockup>::basic_text_iprimitive(const basic_text_iprimitive<std_istream_mockup> &) | load.cpp:13:7:13:27 | basic_text_iprimitive<std_istream_mockup> |

--- a/cpp/ql/test/library-tests/templates/isfromtemplateinstantiation/isfromuninstantiatedtemplate.expected
+++ b/cpp/ql/test/library-tests/templates/isfromtemplateinstantiation/isfromuninstantiatedtemplate.expected
@@ -3,6 +3,7 @@ isFromUninstantiatedTemplate
 | file://:0:0:0:0 | 0 | isfromtemplateinstantiation.cpp:77:26:77:45 | AnotherTemplateClass<T> |
 | file://:0:0:0:0 | (int)... | isfromtemplateinstantiation.cpp:77:26:77:45 | AnotherTemplateClass<T> |
 | file://:0:0:0:0 | (int)... | isfromtemplateinstantiation.cpp:77:26:77:45 | AnotherTemplateClass<T> |
+| file://:0:0:0:0 | Inner<U> | file://:0:0:0:0 | Inner<U> |
 | file://:0:0:0:0 | declaration of 1st parameter | isfromtemplateinstantiation.cpp:134:29:134:33 | Outer<T> |
 | file://:0:0:0:0 | declaration of 1st parameter | isfromtemplateinstantiation.cpp:134:29:134:33 | Outer<T> |
 | file://:0:0:0:0 | initializer for MyClassEnumConst | isfromtemplateinstantiation.cpp:77:26:77:45 | AnotherTemplateClass<T> |
@@ -433,15 +434,15 @@ isFromUninstantiatedTemplate
 | isfromtemplateinstantiation.cpp:135:31:135:31 | declaration of operator= | I | T | DeclarationEntry |  |
 | isfromtemplateinstantiation.cpp:135:31:135:31 | operator= | I | T | Declaration |  |
 | isfromtemplateinstantiation.cpp:135:31:135:31 | operator= | I | T | Declaration |  |
-| isfromtemplateinstantiation.cpp:135:31:135:35 | Inner<U> | I | T | Declaration |  |
+| isfromtemplateinstantiation.cpp:135:31:135:35 | Inner<U> |  | T | Declaration |  |
 | isfromtemplateinstantiation.cpp:135:31:135:35 | Inner<long> | I | T | Declaration |  |
+| isfromtemplateinstantiation.cpp:136:7:136:7 | definition of x |  | T | Definition |  |
 | isfromtemplateinstantiation.cpp:136:7:136:7 | definition of x | I | T | Definition |  |
-| isfromtemplateinstantiation.cpp:136:7:136:7 | definition of x | I | T | Definition |  |
+| isfromtemplateinstantiation.cpp:136:7:136:7 | x |  | T | Declaration |  |
 | isfromtemplateinstantiation.cpp:136:7:136:7 | x | I | T | Declaration |  |
-| isfromtemplateinstantiation.cpp:136:7:136:7 | x | I | T | Declaration |  |
+| isfromtemplateinstantiation.cpp:137:7:137:7 | definition of y |  | T | Definition |  |
 | isfromtemplateinstantiation.cpp:137:7:137:7 | definition of y | I | T | Definition |  |
-| isfromtemplateinstantiation.cpp:137:7:137:7 | definition of y | I | T | Definition |  |
-| isfromtemplateinstantiation.cpp:137:7:137:7 | y | I | T | Declaration |  |
+| isfromtemplateinstantiation.cpp:137:7:137:7 | y |  | T | Declaration |  |
 | isfromtemplateinstantiation.cpp:137:7:137:7 | y | I | T | Declaration |  |
 | isfromtemplateinstantiation.cpp:144:28:144:56 | incomplete_never_instantiated<T> |  | T | Declaration |  |
 | isfromtemplateinstantiation.cpp:146:28:146:45 | never_instantiated<T> |  | T | Declaration |  |


### PR DESCRIPTION
Enables direct internal mergeback PR. This should be merged together with the corresponding internal PR. The tests on this PR can be ignored.

One minor conflict resolved: QLDoc for `hasCompleteTwin` in `ResolveClass.qll`.