### PR TITLE
JS: Recognize Express headers as RequestInputAccess

### DIFF
--- a/javascript/ql/src/semmle/javascript/frameworks/Express.qll
+++ b/javascript/ql/src/semmle/javascript/frameworks/Express.qll
@@ -479,6 +479,17 @@ module Express {
           methodName = "header"
         )
         or
+        exists (DataFlow::PropRead headers |
+          // `req.headers.name`
+          kind = "header" and
+          headers.accesses(request, "headers") and
+          this = headers.getAPropertyRead(_))
+        or
+        exists (string propName | propName = "host" or propName = "hostname" |
+          // `req.host` and `req.hostname` are derived from headers
+          kind = "header" and
+          this.(DataFlow::PropRead).accesses(request, propName))
+        or
         // `req.cookies`
         kind = "cookie" and
         this.(DataFlow::PropRef).accesses(request, "cookies")

--- a/javascript/ql/src/semmle/javascript/frameworks/Express.qll
+++ b/javascript/ql/src/semmle/javascript/frameworks/Express.qll
@@ -483,7 +483,7 @@ module Express {
           // `req.headers.name`
           kind = "header" and
           headers.accesses(request, "headers") and
-          this = headers.getAPropertyRead(_))
+          this = headers.getAPropertyRead())
         or
         exists (string propName | propName = "host" or propName = "hostname" |
           // `req.host` and `req.hostname` are derived from headers

--- a/javascript/ql/test/library-tests/frameworks/Express/RequestExpr.expected
+++ b/javascript/ql/test/library-tests/frameworks/Express/RequestExpr.expected
@@ -14,4 +14,7 @@
 | src/express.js:28:3:28:5 | req | src/express.js:22:30:32:1 | functio ... ar');\\n} |
 | src/express.js:29:3:29:5 | req | src/express.js:22:30:32:1 | functio ... ar');\\n} |
 | src/express.js:30:3:30:5 | req | src/express.js:22:30:32:1 | functio ... ar');\\n} |
+| src/express.js:47:3:47:5 | req | src/express.js:46:22:50:1 | functio ... name;\\n} |
+| src/express.js:48:3:48:5 | req | src/express.js:46:22:50:1 | functio ... name;\\n} |
+| src/express.js:49:3:49:5 | req | src/express.js:46:22:50:1 | functio ... name;\\n} |
 | src/responseExprs.js:17:5:17:7 | req | src/responseExprs.js:16:30:42:1 | functio ...     }\\n} |

--- a/javascript/ql/test/library-tests/frameworks/Express/RequestExpr.expected
+++ b/javascript/ql/test/library-tests/frameworks/Express/RequestExpr.expected
@@ -14,7 +14,8 @@
 | src/express.js:28:3:28:5 | req | src/express.js:22:30:32:1 | functio ... ar');\\n} |
 | src/express.js:29:3:29:5 | req | src/express.js:22:30:32:1 | functio ... ar');\\n} |
 | src/express.js:30:3:30:5 | req | src/express.js:22:30:32:1 | functio ... ar');\\n} |
-| src/express.js:47:3:47:5 | req | src/express.js:46:22:50:1 | functio ... name;\\n} |
-| src/express.js:48:3:48:5 | req | src/express.js:46:22:50:1 | functio ... name;\\n} |
-| src/express.js:49:3:49:5 | req | src/express.js:46:22:50:1 | functio ... name;\\n} |
+| src/express.js:47:3:47:5 | req | src/express.js:46:22:51:1 | functio ... ame];\\n} |
+| src/express.js:48:3:48:5 | req | src/express.js:46:22:51:1 | functio ... ame];\\n} |
+| src/express.js:49:3:49:5 | req | src/express.js:46:22:51:1 | functio ... ame];\\n} |
+| src/express.js:50:3:50:5 | req | src/express.js:46:22:51:1 | functio ... ame];\\n} |
 | src/responseExprs.js:17:5:17:7 | req | src/responseExprs.js:16:30:42:1 | functio ...     }\\n} |

--- a/javascript/ql/test/library-tests/frameworks/Express/RequestInputAccess.expected
+++ b/javascript/ql/test/library-tests/frameworks/Express/RequestInputAccess.expected
@@ -12,3 +12,6 @@
 | src/express.js:28:3:28:16 | req.get("foo") | header | src/express.js:22:30:32:1 | functio ... ar');\\n} |
 | src/express.js:29:3:29:19 | req.header("bar") | header | src/express.js:22:30:32:1 | functio ... ar');\\n} |
 | src/express.js:30:3:30:13 | req.cookies | cookie | src/express.js:22:30:32:1 | functio ... ar');\\n} |
+| src/express.js:47:3:47:17 | req.headers.baz | header | src/express.js:46:22:50:1 | functio ... name;\\n} |
+| src/express.js:48:3:48:10 | req.host | header | src/express.js:46:22:50:1 | functio ... name;\\n} |
+| src/express.js:49:3:49:14 | req.hostname | header | src/express.js:46:22:50:1 | functio ... name;\\n} |

--- a/javascript/ql/test/library-tests/frameworks/Express/RequestInputAccess.expected
+++ b/javascript/ql/test/library-tests/frameworks/Express/RequestInputAccess.expected
@@ -12,6 +12,7 @@
 | src/express.js:28:3:28:16 | req.get("foo") | header | src/express.js:22:30:32:1 | functio ... ar');\\n} |
 | src/express.js:29:3:29:19 | req.header("bar") | header | src/express.js:22:30:32:1 | functio ... ar');\\n} |
 | src/express.js:30:3:30:13 | req.cookies | cookie | src/express.js:22:30:32:1 | functio ... ar');\\n} |
-| src/express.js:47:3:47:17 | req.headers.baz | header | src/express.js:46:22:50:1 | functio ... name;\\n} |
-| src/express.js:48:3:48:10 | req.host | header | src/express.js:46:22:50:1 | functio ... name;\\n} |
-| src/express.js:49:3:49:14 | req.hostname | header | src/express.js:46:22:50:1 | functio ... name;\\n} |
+| src/express.js:47:3:47:17 | req.headers.baz | header | src/express.js:46:22:51:1 | functio ... ame];\\n} |
+| src/express.js:48:3:48:10 | req.host | header | src/express.js:46:22:51:1 | functio ... ame];\\n} |
+| src/express.js:49:3:49:14 | req.hostname | header | src/express.js:46:22:51:1 | functio ... ame];\\n} |
+| src/express.js:50:3:50:32 | req.hea ... erName] | header | src/express.js:46:22:51:1 | functio ... ame];\\n} |

--- a/javascript/ql/test/library-tests/frameworks/Express/RouteHandler.expected
+++ b/javascript/ql/test/library-tests/frameworks/Express/RouteHandler.expected
@@ -14,7 +14,7 @@
 | src/express.js:22:30:32:1 | functio ... ar');\\n} | src/express.js:22:39:22:41 | req | src/express.js:22:44:22:46 | res |
 | src/express.js:37:12:37:32 | functio ...  res){} | src/express.js:37:22:37:24 | req | src/express.js:37:27:37:29 | res |
 | src/express.js:42:12:42:28 | (req, res) => f() | src/express.js:42:13:42:15 | req | src/express.js:42:18:42:20 | res |
-| src/express.js:46:22:50:1 | functio ... name;\\n} | src/express.js:46:31:46:33 | req | src/express.js:46:36:46:38 | res |
+| src/express.js:46:22:51:1 | functio ... ame];\\n} | src/express.js:46:31:46:33 | req | src/express.js:46:36:46:38 | res |
 | src/responseExprs.js:4:23:6:1 | functio ...  res1\\n} | src/responseExprs.js:4:32:4:34 | req | src/responseExprs.js:4:37:4:40 | res1 |
 | src/responseExprs.js:7:23:9:1 | functio ... res2;\\n} | src/responseExprs.js:7:32:7:34 | req | src/responseExprs.js:7:37:7:40 | res2 |
 | src/responseExprs.js:10:23:12:1 | functio ... res3;\\n} | src/responseExprs.js:10:39:10:41 | req | src/responseExprs.js:10:44:10:47 | res3 |

--- a/javascript/ql/test/library-tests/frameworks/Express/RouteHandler.expected
+++ b/javascript/ql/test/library-tests/frameworks/Express/RouteHandler.expected
@@ -14,6 +14,7 @@
 | src/express.js:22:30:32:1 | functio ... ar');\\n} | src/express.js:22:39:22:41 | req | src/express.js:22:44:22:46 | res |
 | src/express.js:37:12:37:32 | functio ...  res){} | src/express.js:37:22:37:24 | req | src/express.js:37:27:37:29 | res |
 | src/express.js:42:12:42:28 | (req, res) => f() | src/express.js:42:13:42:15 | req | src/express.js:42:18:42:20 | res |
+| src/express.js:46:22:50:1 | functio ... name;\\n} | src/express.js:46:31:46:33 | req | src/express.js:46:36:46:38 | res |
 | src/responseExprs.js:4:23:6:1 | functio ...  res1\\n} | src/responseExprs.js:4:32:4:34 | req | src/responseExprs.js:4:37:4:40 | res1 |
 | src/responseExprs.js:7:23:9:1 | functio ... res2;\\n} | src/responseExprs.js:7:32:7:34 | req | src/responseExprs.js:7:37:7:40 | res2 |
 | src/responseExprs.js:10:23:12:1 | functio ... res3;\\n} | src/responseExprs.js:10:39:10:41 | req | src/responseExprs.js:10:44:10:47 | res3 |

--- a/javascript/ql/test/library-tests/frameworks/Express/RouteHandlerExpr.expected
+++ b/javascript/ql/test/library-tests/frameworks/Express/RouteHandlerExpr.expected
@@ -20,6 +20,7 @@
 | src/express.js:34:14:34:52 | require ... handler | src/express.js:34:1:34:53 | app.get ... andler) | true |
 | src/express.js:39:9:39:20 | getHandler() | src/express.js:39:1:39:21 | app.use ... dler()) | false |
 | src/express.js:44:9:44:25 | getArrowHandler() | src/express.js:44:1:44:26 | app.use ... dler()) | false |
+| src/express.js:46:22:50:1 | functio ... name;\\n} | src/express.js:46:1:50:2 | app.pos ... ame;\\n}) | true |
 | src/responseExprs.js:4:23:6:1 | functio ...  res1\\n} | src/responseExprs.js:4:1:6:2 | app.get ... res1\\n}) | true |
 | src/responseExprs.js:7:23:9:1 | functio ... res2;\\n} | src/responseExprs.js:7:1:9:2 | app.get ... es2;\\n}) | true |
 | src/responseExprs.js:10:23:12:1 | functio ... res3;\\n} | src/responseExprs.js:10:1:12:2 | app.get ... es3;\\n}) | true |

--- a/javascript/ql/test/library-tests/frameworks/Express/RouteHandlerExpr.expected
+++ b/javascript/ql/test/library-tests/frameworks/Express/RouteHandlerExpr.expected
@@ -20,7 +20,7 @@
 | src/express.js:34:14:34:52 | require ... handler | src/express.js:34:1:34:53 | app.get ... andler) | true |
 | src/express.js:39:9:39:20 | getHandler() | src/express.js:39:1:39:21 | app.use ... dler()) | false |
 | src/express.js:44:9:44:25 | getArrowHandler() | src/express.js:44:1:44:26 | app.use ... dler()) | false |
-| src/express.js:46:22:50:1 | functio ... name;\\n} | src/express.js:46:1:50:2 | app.pos ... ame;\\n}) | true |
+| src/express.js:46:22:51:1 | functio ... ame];\\n} | src/express.js:46:1:51:2 | app.pos ... me];\\n}) | true |
 | src/responseExprs.js:4:23:6:1 | functio ...  res1\\n} | src/responseExprs.js:4:1:6:2 | app.get ... res1\\n}) | true |
 | src/responseExprs.js:7:23:9:1 | functio ... res2;\\n} | src/responseExprs.js:7:1:9:2 | app.get ... es2;\\n}) | true |
 | src/responseExprs.js:10:23:12:1 | functio ... res3;\\n} | src/responseExprs.js:10:1:12:2 | app.get ... es3;\\n}) | true |

--- a/javascript/ql/test/library-tests/frameworks/Express/RouteHandlerExpr_getAMatchingAncestor.expected
+++ b/javascript/ql/test/library-tests/frameworks/Express/RouteHandlerExpr_getAMatchingAncestor.expected
@@ -16,3 +16,5 @@
 | src/express.js:16:19:18:3 | functio ... ");\\n  } | src/express.js:39:9:39:20 | getHandler() |
 | src/express.js:16:19:18:3 | functio ... ");\\n  } | src/express.js:44:9:44:25 | getArrowHandler() |
 | src/express.js:44:9:44:25 | getArrowHandler() | src/express.js:39:9:39:20 | getHandler() |
+| src/express.js:46:22:50:1 | functio ... name;\\n} | src/express.js:39:9:39:20 | getHandler() |
+| src/express.js:46:22:50:1 | functio ... name;\\n} | src/express.js:44:9:44:25 | getArrowHandler() |

--- a/javascript/ql/test/library-tests/frameworks/Express/RouteHandlerExpr_getAMatchingAncestor.expected
+++ b/javascript/ql/test/library-tests/frameworks/Express/RouteHandlerExpr_getAMatchingAncestor.expected
@@ -16,5 +16,5 @@
 | src/express.js:16:19:18:3 | functio ... ");\\n  } | src/express.js:39:9:39:20 | getHandler() |
 | src/express.js:16:19:18:3 | functio ... ");\\n  } | src/express.js:44:9:44:25 | getArrowHandler() |
 | src/express.js:44:9:44:25 | getArrowHandler() | src/express.js:39:9:39:20 | getHandler() |
-| src/express.js:46:22:50:1 | functio ... name;\\n} | src/express.js:39:9:39:20 | getHandler() |
-| src/express.js:46:22:50:1 | functio ... name;\\n} | src/express.js:44:9:44:25 | getArrowHandler() |
+| src/express.js:46:22:51:1 | functio ... ame];\\n} | src/express.js:39:9:39:20 | getHandler() |
+| src/express.js:46:22:51:1 | functio ... ame];\\n} | src/express.js:44:9:44:25 | getArrowHandler() |

--- a/javascript/ql/test/library-tests/frameworks/Express/RouteHandlerExpr_getBody.expected
+++ b/javascript/ql/test/library-tests/frameworks/Express/RouteHandlerExpr_getBody.expected
@@ -10,6 +10,7 @@
 | src/express.js:4:23:9:1 | functio ... res);\\n} | src/express.js:4:23:9:1 | functio ... res);\\n} |
 | src/express.js:16:19:18:3 | functio ... ");\\n  } | src/express.js:16:19:18:3 | functio ... ");\\n  } |
 | src/express.js:22:30:32:1 | functio ... ar');\\n} | src/express.js:22:30:32:1 | functio ... ar');\\n} |
+| src/express.js:46:22:50:1 | functio ... name;\\n} | src/express.js:46:22:50:1 | functio ... name;\\n} |
 | src/responseExprs.js:4:23:6:1 | functio ...  res1\\n} | src/responseExprs.js:4:23:6:1 | functio ...  res1\\n} |
 | src/responseExprs.js:7:23:9:1 | functio ... res2;\\n} | src/responseExprs.js:7:23:9:1 | functio ... res2;\\n} |
 | src/responseExprs.js:10:23:12:1 | functio ... res3;\\n} | src/responseExprs.js:10:23:12:1 | functio ... res3;\\n} |

--- a/javascript/ql/test/library-tests/frameworks/Express/RouteHandlerExpr_getBody.expected
+++ b/javascript/ql/test/library-tests/frameworks/Express/RouteHandlerExpr_getBody.expected
@@ -10,7 +10,7 @@
 | src/express.js:4:23:9:1 | functio ... res);\\n} | src/express.js:4:23:9:1 | functio ... res);\\n} |
 | src/express.js:16:19:18:3 | functio ... ");\\n  } | src/express.js:16:19:18:3 | functio ... ");\\n  } |
 | src/express.js:22:30:32:1 | functio ... ar');\\n} | src/express.js:22:30:32:1 | functio ... ar');\\n} |
-| src/express.js:46:22:50:1 | functio ... name;\\n} | src/express.js:46:22:50:1 | functio ... name;\\n} |
+| src/express.js:46:22:51:1 | functio ... ame];\\n} | src/express.js:46:22:51:1 | functio ... ame];\\n} |
 | src/responseExprs.js:4:23:6:1 | functio ...  res1\\n} | src/responseExprs.js:4:23:6:1 | functio ...  res1\\n} |
 | src/responseExprs.js:7:23:9:1 | functio ... res2;\\n} | src/responseExprs.js:7:23:9:1 | functio ... res2;\\n} |
 | src/responseExprs.js:10:23:12:1 | functio ... res3;\\n} | src/responseExprs.js:10:23:12:1 | functio ... res3;\\n} |

--- a/javascript/ql/test/library-tests/frameworks/Express/RouteHandlerExpr_getNextMiddleware.expected
+++ b/javascript/ql/test/library-tests/frameworks/Express/RouteHandlerExpr_getNextMiddleware.expected
@@ -7,4 +7,5 @@
 | src/csurf-example.js:18:9:18:30 | csrf({  ... true }) | src/csurf-example.js:40:27:40:48 | functio ... res) {} |
 | src/express.js:39:9:39:20 | getHandler() | src/express.js:44:9:44:25 | getArrowHandler() |
 | src/express.js:44:9:44:25 | getArrowHandler() | src/express.js:16:19:18:3 | functio ... ");\\n  } |
+| src/express.js:44:9:44:25 | getArrowHandler() | src/express.js:46:22:50:1 | functio ... name;\\n} |
 | src/subrouter.js:4:19:4:25 | protect | src/subrouter.js:5:14:5:28 | makeSubRouter() |

--- a/javascript/ql/test/library-tests/frameworks/Express/RouteHandlerExpr_getNextMiddleware.expected
+++ b/javascript/ql/test/library-tests/frameworks/Express/RouteHandlerExpr_getNextMiddleware.expected
@@ -7,5 +7,5 @@
 | src/csurf-example.js:18:9:18:30 | csrf({  ... true }) | src/csurf-example.js:40:27:40:48 | functio ... res) {} |
 | src/express.js:39:9:39:20 | getHandler() | src/express.js:44:9:44:25 | getArrowHandler() |
 | src/express.js:44:9:44:25 | getArrowHandler() | src/express.js:16:19:18:3 | functio ... ");\\n  } |
-| src/express.js:44:9:44:25 | getArrowHandler() | src/express.js:46:22:50:1 | functio ... name;\\n} |
+| src/express.js:44:9:44:25 | getArrowHandler() | src/express.js:46:22:51:1 | functio ... ame];\\n} |
 | src/subrouter.js:4:19:4:25 | protect | src/subrouter.js:5:14:5:28 | makeSubRouter() |

--- a/javascript/ql/test/library-tests/frameworks/Express/RouteHandlerExpr_getPreviousMiddleware.expected
+++ b/javascript/ql/test/library-tests/frameworks/Express/RouteHandlerExpr_getPreviousMiddleware.expected
@@ -7,5 +7,5 @@
 | src/csurf-example.js:40:27:40:48 | functio ... res) {} | src/csurf-example.js:18:9:18:30 | csrf({  ... true }) |
 | src/express.js:16:19:18:3 | functio ... ");\\n  } | src/express.js:44:9:44:25 | getArrowHandler() |
 | src/express.js:44:9:44:25 | getArrowHandler() | src/express.js:39:9:39:20 | getHandler() |
-| src/express.js:46:22:50:1 | functio ... name;\\n} | src/express.js:44:9:44:25 | getArrowHandler() |
+| src/express.js:46:22:51:1 | functio ... ame];\\n} | src/express.js:44:9:44:25 | getArrowHandler() |
 | src/subrouter.js:5:14:5:28 | makeSubRouter() | src/subrouter.js:4:19:4:25 | protect |

--- a/javascript/ql/test/library-tests/frameworks/Express/RouteHandlerExpr_getPreviousMiddleware.expected
+++ b/javascript/ql/test/library-tests/frameworks/Express/RouteHandlerExpr_getPreviousMiddleware.expected
@@ -7,4 +7,5 @@
 | src/csurf-example.js:40:27:40:48 | functio ... res) {} | src/csurf-example.js:18:9:18:30 | csrf({  ... true }) |
 | src/express.js:16:19:18:3 | functio ... ");\\n  } | src/express.js:44:9:44:25 | getArrowHandler() |
 | src/express.js:44:9:44:25 | getArrowHandler() | src/express.js:39:9:39:20 | getHandler() |
+| src/express.js:46:22:50:1 | functio ... name;\\n} | src/express.js:44:9:44:25 | getArrowHandler() |
 | src/subrouter.js:5:14:5:28 | makeSubRouter() | src/subrouter.js:4:19:4:25 | protect |

--- a/javascript/ql/test/library-tests/frameworks/Express/RouteHandler_getARequestExpr.expected
+++ b/javascript/ql/test/library-tests/frameworks/Express/RouteHandler_getARequestExpr.expected
@@ -14,4 +14,7 @@
 | src/express.js:22:30:32:1 | functio ... ar');\\n} | src/express.js:28:3:28:5 | req |
 | src/express.js:22:30:32:1 | functio ... ar');\\n} | src/express.js:29:3:29:5 | req |
 | src/express.js:22:30:32:1 | functio ... ar');\\n} | src/express.js:30:3:30:5 | req |
+| src/express.js:46:22:50:1 | functio ... name;\\n} | src/express.js:47:3:47:5 | req |
+| src/express.js:46:22:50:1 | functio ... name;\\n} | src/express.js:48:3:48:5 | req |
+| src/express.js:46:22:50:1 | functio ... name;\\n} | src/express.js:49:3:49:5 | req |
 | src/responseExprs.js:16:30:42:1 | functio ...     }\\n} | src/responseExprs.js:17:5:17:7 | req |

--- a/javascript/ql/test/library-tests/frameworks/Express/RouteHandler_getARequestExpr.expected
+++ b/javascript/ql/test/library-tests/frameworks/Express/RouteHandler_getARequestExpr.expected
@@ -14,7 +14,8 @@
 | src/express.js:22:30:32:1 | functio ... ar');\\n} | src/express.js:28:3:28:5 | req |
 | src/express.js:22:30:32:1 | functio ... ar');\\n} | src/express.js:29:3:29:5 | req |
 | src/express.js:22:30:32:1 | functio ... ar');\\n} | src/express.js:30:3:30:5 | req |
-| src/express.js:46:22:50:1 | functio ... name;\\n} | src/express.js:47:3:47:5 | req |
-| src/express.js:46:22:50:1 | functio ... name;\\n} | src/express.js:48:3:48:5 | req |
-| src/express.js:46:22:50:1 | functio ... name;\\n} | src/express.js:49:3:49:5 | req |
+| src/express.js:46:22:51:1 | functio ... ame];\\n} | src/express.js:47:3:47:5 | req |
+| src/express.js:46:22:51:1 | functio ... ame];\\n} | src/express.js:48:3:48:5 | req |
+| src/express.js:46:22:51:1 | functio ... ame];\\n} | src/express.js:49:3:49:5 | req |
+| src/express.js:46:22:51:1 | functio ... ame];\\n} | src/express.js:50:3:50:5 | req |
 | src/responseExprs.js:16:30:42:1 | functio ...     }\\n} | src/responseExprs.js:17:5:17:7 | req |

--- a/javascript/ql/test/library-tests/frameworks/Express/RouteSetup.expected
+++ b/javascript/ql/test/library-tests/frameworks/Express/RouteSetup.expected
@@ -9,7 +9,7 @@
 | src/express.js:4:1:9:2 | app.get ... es);\\n}) | src/express.js:2:11:2:19 | express() | false |
 | src/express.js:16:3:18:4 | router. ... );\\n  }) | src/express.js:2:11:2:19 | express() | false |
 | src/express.js:22:1:32:2 | app.pos ... r');\\n}) | src/express.js:2:11:2:19 | express() | false |
-| src/express.js:46:1:50:2 | app.pos ... ame;\\n}) | src/express.js:2:11:2:19 | express() | false |
+| src/express.js:46:1:51:2 | app.pos ... me];\\n}) | src/express.js:2:11:2:19 | express() | false |
 | src/responseExprs.js:4:1:6:2 | app.get ... res1\\n}) | src/responseExprs.js:2:11:2:19 | express() | false |
 | src/responseExprs.js:7:1:9:2 | app.get ... es2;\\n}) | src/responseExprs.js:2:11:2:19 | express() | false |
 | src/responseExprs.js:10:1:12:2 | app.get ... es3;\\n}) | src/responseExprs.js:2:11:2:19 | express() | false |

--- a/javascript/ql/test/library-tests/frameworks/Express/RouteSetup.expected
+++ b/javascript/ql/test/library-tests/frameworks/Express/RouteSetup.expected
@@ -9,6 +9,7 @@
 | src/express.js:4:1:9:2 | app.get ... es);\\n}) | src/express.js:2:11:2:19 | express() | false |
 | src/express.js:16:3:18:4 | router. ... );\\n  }) | src/express.js:2:11:2:19 | express() | false |
 | src/express.js:22:1:32:2 | app.pos ... r');\\n}) | src/express.js:2:11:2:19 | express() | false |
+| src/express.js:46:1:50:2 | app.pos ... ame;\\n}) | src/express.js:2:11:2:19 | express() | false |
 | src/responseExprs.js:4:1:6:2 | app.get ... res1\\n}) | src/responseExprs.js:2:11:2:19 | express() | false |
 | src/responseExprs.js:7:1:9:2 | app.get ... es2;\\n}) | src/responseExprs.js:2:11:2:19 | express() | false |
 | src/responseExprs.js:10:1:12:2 | app.get ... es3;\\n}) | src/responseExprs.js:2:11:2:19 | express() | false |

--- a/javascript/ql/test/library-tests/frameworks/Express/RouteSetup_getARouteHandler.expected
+++ b/javascript/ql/test/library-tests/frameworks/Express/RouteSetup_getARouteHandler.expected
@@ -25,6 +25,7 @@
 | src/express.js:39:1:39:21 | app.use ... dler()) | src/express.js:39:9:39:20 | getHandler() |
 | src/express.js:44:1:44:26 | app.use ... dler()) | src/express.js:42:12:42:28 | (req, res) => f() |
 | src/express.js:44:1:44:26 | app.use ... dler()) | src/express.js:44:9:44:25 | getArrowHandler() |
+| src/express.js:46:1:50:2 | app.pos ... ame;\\n}) | src/express.js:46:22:50:1 | functio ... name;\\n} |
 | src/responseExprs.js:4:1:6:2 | app.get ... res1\\n}) | src/responseExprs.js:4:23:6:1 | functio ...  res1\\n} |
 | src/responseExprs.js:7:1:9:2 | app.get ... es2;\\n}) | src/responseExprs.js:7:23:9:1 | functio ... res2;\\n} |
 | src/responseExprs.js:10:1:12:2 | app.get ... es3;\\n}) | src/responseExprs.js:10:23:12:1 | functio ... res3;\\n} |

--- a/javascript/ql/test/library-tests/frameworks/Express/RouteSetup_getARouteHandler.expected
+++ b/javascript/ql/test/library-tests/frameworks/Express/RouteSetup_getARouteHandler.expected
@@ -25,7 +25,7 @@
 | src/express.js:39:1:39:21 | app.use ... dler()) | src/express.js:39:9:39:20 | getHandler() |
 | src/express.js:44:1:44:26 | app.use ... dler()) | src/express.js:42:12:42:28 | (req, res) => f() |
 | src/express.js:44:1:44:26 | app.use ... dler()) | src/express.js:44:9:44:25 | getArrowHandler() |
-| src/express.js:46:1:50:2 | app.pos ... ame;\\n}) | src/express.js:46:22:50:1 | functio ... name;\\n} |
+| src/express.js:46:1:51:2 | app.pos ... me];\\n}) | src/express.js:46:22:51:1 | functio ... ame];\\n} |
 | src/responseExprs.js:4:1:6:2 | app.get ... res1\\n}) | src/responseExprs.js:4:23:6:1 | functio ...  res1\\n} |
 | src/responseExprs.js:7:1:9:2 | app.get ... es2;\\n}) | src/responseExprs.js:7:23:9:1 | functio ... res2;\\n} |
 | src/responseExprs.js:10:1:12:2 | app.get ... es3;\\n}) | src/responseExprs.js:10:23:12:1 | functio ... res3;\\n} |

--- a/javascript/ql/test/library-tests/frameworks/Express/RouteSetup_getARouteHandlerExpr.expected
+++ b/javascript/ql/test/library-tests/frameworks/Express/RouteSetup_getARouteHandlerExpr.expected
@@ -20,6 +20,7 @@
 | src/express.js:34:1:34:53 | app.get ... andler) | src/express.js:34:14:34:52 | require ... handler |
 | src/express.js:39:1:39:21 | app.use ... dler()) | src/express.js:39:9:39:20 | getHandler() |
 | src/express.js:44:1:44:26 | app.use ... dler()) | src/express.js:44:9:44:25 | getArrowHandler() |
+| src/express.js:46:1:50:2 | app.pos ... ame;\\n}) | src/express.js:46:22:50:1 | functio ... name;\\n} |
 | src/responseExprs.js:4:1:6:2 | app.get ... res1\\n}) | src/responseExprs.js:4:23:6:1 | functio ...  res1\\n} |
 | src/responseExprs.js:7:1:9:2 | app.get ... es2;\\n}) | src/responseExprs.js:7:23:9:1 | functio ... res2;\\n} |
 | src/responseExprs.js:10:1:12:2 | app.get ... es3;\\n}) | src/responseExprs.js:10:23:12:1 | functio ... res3;\\n} |

--- a/javascript/ql/test/library-tests/frameworks/Express/RouteSetup_getARouteHandlerExpr.expected
+++ b/javascript/ql/test/library-tests/frameworks/Express/RouteSetup_getARouteHandlerExpr.expected
@@ -20,7 +20,7 @@
 | src/express.js:34:1:34:53 | app.get ... andler) | src/express.js:34:14:34:52 | require ... handler |
 | src/express.js:39:1:39:21 | app.use ... dler()) | src/express.js:39:9:39:20 | getHandler() |
 | src/express.js:44:1:44:26 | app.use ... dler()) | src/express.js:44:9:44:25 | getArrowHandler() |
-| src/express.js:46:1:50:2 | app.pos ... ame;\\n}) | src/express.js:46:22:50:1 | functio ... name;\\n} |
+| src/express.js:46:1:51:2 | app.pos ... me];\\n}) | src/express.js:46:22:51:1 | functio ... ame];\\n} |
 | src/responseExprs.js:4:1:6:2 | app.get ... res1\\n}) | src/responseExprs.js:4:23:6:1 | functio ...  res1\\n} |
 | src/responseExprs.js:7:1:9:2 | app.get ... es2;\\n}) | src/responseExprs.js:7:23:9:1 | functio ... res2;\\n} |
 | src/responseExprs.js:10:1:12:2 | app.get ... es3;\\n}) | src/responseExprs.js:10:23:12:1 | functio ... res3;\\n} |

--- a/javascript/ql/test/library-tests/frameworks/Express/RouteSetup_getLastRouteHandlerExpr.expected
+++ b/javascript/ql/test/library-tests/frameworks/Express/RouteSetup_getLastRouteHandlerExpr.expected
@@ -20,6 +20,7 @@
 | src/express.js:34:1:34:53 | app.get ... andler) | src/express.js:34:14:34:52 | require ... handler |
 | src/express.js:39:1:39:21 | app.use ... dler()) | src/express.js:39:9:39:20 | getHandler() |
 | src/express.js:44:1:44:26 | app.use ... dler()) | src/express.js:44:9:44:25 | getArrowHandler() |
+| src/express.js:46:1:50:2 | app.pos ... ame;\\n}) | src/express.js:46:22:50:1 | functio ... name;\\n} |
 | src/responseExprs.js:4:1:6:2 | app.get ... res1\\n}) | src/responseExprs.js:4:23:6:1 | functio ...  res1\\n} |
 | src/responseExprs.js:7:1:9:2 | app.get ... es2;\\n}) | src/responseExprs.js:7:23:9:1 | functio ... res2;\\n} |
 | src/responseExprs.js:10:1:12:2 | app.get ... es3;\\n}) | src/responseExprs.js:10:23:12:1 | functio ... res3;\\n} |

--- a/javascript/ql/test/library-tests/frameworks/Express/RouteSetup_getLastRouteHandlerExpr.expected
+++ b/javascript/ql/test/library-tests/frameworks/Express/RouteSetup_getLastRouteHandlerExpr.expected
@@ -20,7 +20,7 @@
 | src/express.js:34:1:34:53 | app.get ... andler) | src/express.js:34:14:34:52 | require ... handler |
 | src/express.js:39:1:39:21 | app.use ... dler()) | src/express.js:39:9:39:20 | getHandler() |
 | src/express.js:44:1:44:26 | app.use ... dler()) | src/express.js:44:9:44:25 | getArrowHandler() |
-| src/express.js:46:1:50:2 | app.pos ... ame;\\n}) | src/express.js:46:22:50:1 | functio ... name;\\n} |
+| src/express.js:46:1:51:2 | app.pos ... me];\\n}) | src/express.js:46:22:51:1 | functio ... ame];\\n} |
 | src/responseExprs.js:4:1:6:2 | app.get ... res1\\n}) | src/responseExprs.js:4:23:6:1 | functio ...  res1\\n} |
 | src/responseExprs.js:7:1:9:2 | app.get ... es2;\\n}) | src/responseExprs.js:7:23:9:1 | functio ... res2;\\n} |
 | src/responseExprs.js:10:1:12:2 | app.get ... es3;\\n}) | src/responseExprs.js:10:23:12:1 | functio ... res3;\\n} |

--- a/javascript/ql/test/library-tests/frameworks/Express/RouteSetup_getRequestMethod.expected
+++ b/javascript/ql/test/library-tests/frameworks/Express/RouteSetup_getRequestMethod.expected
@@ -11,6 +11,7 @@
 | src/express.js:16:3:18:4 | router. ... );\\n  }) | GET |
 | src/express.js:22:1:32:2 | app.pos ... r');\\n}) | POST |
 | src/express.js:34:1:34:53 | app.get ... andler) | GET |
+| src/express.js:46:1:50:2 | app.pos ... ame;\\n}) | POST |
 | src/responseExprs.js:4:1:6:2 | app.get ... res1\\n}) | GET |
 | src/responseExprs.js:7:1:9:2 | app.get ... es2;\\n}) | GET |
 | src/responseExprs.js:10:1:12:2 | app.get ... es3;\\n}) | GET |

--- a/javascript/ql/test/library-tests/frameworks/Express/RouteSetup_getRequestMethod.expected
+++ b/javascript/ql/test/library-tests/frameworks/Express/RouteSetup_getRequestMethod.expected
@@ -11,7 +11,7 @@
 | src/express.js:16:3:18:4 | router. ... );\\n  }) | GET |
 | src/express.js:22:1:32:2 | app.pos ... r');\\n}) | POST |
 | src/express.js:34:1:34:53 | app.get ... andler) | GET |
-| src/express.js:46:1:50:2 | app.pos ... ame;\\n}) | POST |
+| src/express.js:46:1:51:2 | app.pos ... me];\\n}) | POST |
 | src/responseExprs.js:4:1:6:2 | app.get ... res1\\n}) | GET |
 | src/responseExprs.js:7:1:9:2 | app.get ... es2;\\n}) | GET |
 | src/responseExprs.js:10:1:12:2 | app.get ... es3;\\n}) | GET |

--- a/javascript/ql/test/library-tests/frameworks/Express/RouteSetup_getRouteHandlerExpr.expected
+++ b/javascript/ql/test/library-tests/frameworks/Express/RouteSetup_getRouteHandlerExpr.expected
@@ -20,6 +20,7 @@
 | src/express.js:34:1:34:53 | app.get ... andler) | 0 | src/express.js:34:14:34:52 | require ... handler |
 | src/express.js:39:1:39:21 | app.use ... dler()) | 0 | src/express.js:39:9:39:20 | getHandler() |
 | src/express.js:44:1:44:26 | app.use ... dler()) | 0 | src/express.js:44:9:44:25 | getArrowHandler() |
+| src/express.js:46:1:50:2 | app.pos ... ame;\\n}) | 0 | src/express.js:46:22:50:1 | functio ... name;\\n} |
 | src/responseExprs.js:4:1:6:2 | app.get ... res1\\n}) | 0 | src/responseExprs.js:4:23:6:1 | functio ...  res1\\n} |
 | src/responseExprs.js:7:1:9:2 | app.get ... es2;\\n}) | 0 | src/responseExprs.js:7:23:9:1 | functio ... res2;\\n} |
 | src/responseExprs.js:10:1:12:2 | app.get ... es3;\\n}) | 0 | src/responseExprs.js:10:23:12:1 | functio ... res3;\\n} |

--- a/javascript/ql/test/library-tests/frameworks/Express/RouteSetup_getRouteHandlerExpr.expected
+++ b/javascript/ql/test/library-tests/frameworks/Express/RouteSetup_getRouteHandlerExpr.expected
@@ -20,7 +20,7 @@
 | src/express.js:34:1:34:53 | app.get ... andler) | 0 | src/express.js:34:14:34:52 | require ... handler |
 | src/express.js:39:1:39:21 | app.use ... dler()) | 0 | src/express.js:39:9:39:20 | getHandler() |
 | src/express.js:44:1:44:26 | app.use ... dler()) | 0 | src/express.js:44:9:44:25 | getArrowHandler() |
-| src/express.js:46:1:50:2 | app.pos ... ame;\\n}) | 0 | src/express.js:46:22:50:1 | functio ... name;\\n} |
+| src/express.js:46:1:51:2 | app.pos ... me];\\n}) | 0 | src/express.js:46:22:51:1 | functio ... ame];\\n} |
 | src/responseExprs.js:4:1:6:2 | app.get ... res1\\n}) | 0 | src/responseExprs.js:4:23:6:1 | functio ...  res1\\n} |
 | src/responseExprs.js:7:1:9:2 | app.get ... es2;\\n}) | 0 | src/responseExprs.js:7:23:9:1 | functio ... res2;\\n} |
 | src/responseExprs.js:10:1:12:2 | app.get ... es3;\\n}) | 0 | src/responseExprs.js:10:23:12:1 | functio ... res3;\\n} |

--- a/javascript/ql/test/library-tests/frameworks/Express/RouteSetup_getRouter.expected
+++ b/javascript/ql/test/library-tests/frameworks/Express/RouteSetup_getRouter.expected
@@ -20,7 +20,7 @@
 | src/express.js:34:1:34:53 | app.get ... andler) | src/express.js:2:11:2:19 | express() |
 | src/express.js:39:1:39:21 | app.use ... dler()) | src/express.js:2:11:2:19 | express() |
 | src/express.js:44:1:44:26 | app.use ... dler()) | src/express.js:2:11:2:19 | express() |
-| src/express.js:46:1:50:2 | app.pos ... ame;\\n}) | src/express.js:2:11:2:19 | express() |
+| src/express.js:46:1:51:2 | app.pos ... me];\\n}) | src/express.js:2:11:2:19 | express() |
 | src/responseExprs.js:4:1:6:2 | app.get ... res1\\n}) | src/responseExprs.js:2:11:2:19 | express() |
 | src/responseExprs.js:7:1:9:2 | app.get ... es2;\\n}) | src/responseExprs.js:2:11:2:19 | express() |
 | src/responseExprs.js:10:1:12:2 | app.get ... es3;\\n}) | src/responseExprs.js:2:11:2:19 | express() |

--- a/javascript/ql/test/library-tests/frameworks/Express/RouteSetup_getRouter.expected
+++ b/javascript/ql/test/library-tests/frameworks/Express/RouteSetup_getRouter.expected
@@ -20,6 +20,7 @@
 | src/express.js:34:1:34:53 | app.get ... andler) | src/express.js:2:11:2:19 | express() |
 | src/express.js:39:1:39:21 | app.use ... dler()) | src/express.js:2:11:2:19 | express() |
 | src/express.js:44:1:44:26 | app.use ... dler()) | src/express.js:2:11:2:19 | express() |
+| src/express.js:46:1:50:2 | app.pos ... ame;\\n}) | src/express.js:2:11:2:19 | express() |
 | src/responseExprs.js:4:1:6:2 | app.get ... res1\\n}) | src/responseExprs.js:2:11:2:19 | express() |
 | src/responseExprs.js:7:1:9:2 | app.get ... es2;\\n}) | src/responseExprs.js:2:11:2:19 | express() |
 | src/responseExprs.js:10:1:12:2 | app.get ... es3;\\n}) | src/responseExprs.js:2:11:2:19 | express() |

--- a/javascript/ql/test/library-tests/frameworks/Express/RouteSetup_getServer.expected
+++ b/javascript/ql/test/library-tests/frameworks/Express/RouteSetup_getServer.expected
@@ -9,6 +9,7 @@
 | src/express.js:4:1:9:2 | app.get ... es);\\n}) | src/express.js:2:11:2:19 | express() |
 | src/express.js:16:3:18:4 | router. ... );\\n  }) | src/express.js:2:11:2:19 | express() |
 | src/express.js:22:1:32:2 | app.pos ... r');\\n}) | src/express.js:2:11:2:19 | express() |
+| src/express.js:46:1:50:2 | app.pos ... ame;\\n}) | src/express.js:2:11:2:19 | express() |
 | src/responseExprs.js:4:1:6:2 | app.get ... res1\\n}) | src/responseExprs.js:2:11:2:19 | express() |
 | src/responseExprs.js:7:1:9:2 | app.get ... es2;\\n}) | src/responseExprs.js:2:11:2:19 | express() |
 | src/responseExprs.js:10:1:12:2 | app.get ... es3;\\n}) | src/responseExprs.js:2:11:2:19 | express() |

--- a/javascript/ql/test/library-tests/frameworks/Express/RouteSetup_getServer.expected
+++ b/javascript/ql/test/library-tests/frameworks/Express/RouteSetup_getServer.expected
@@ -9,7 +9,7 @@
 | src/express.js:4:1:9:2 | app.get ... es);\\n}) | src/express.js:2:11:2:19 | express() |
 | src/express.js:16:3:18:4 | router. ... );\\n  }) | src/express.js:2:11:2:19 | express() |
 | src/express.js:22:1:32:2 | app.pos ... r');\\n}) | src/express.js:2:11:2:19 | express() |
-| src/express.js:46:1:50:2 | app.pos ... ame;\\n}) | src/express.js:2:11:2:19 | express() |
+| src/express.js:46:1:51:2 | app.pos ... me];\\n}) | src/express.js:2:11:2:19 | express() |
 | src/responseExprs.js:4:1:6:2 | app.get ... res1\\n}) | src/responseExprs.js:2:11:2:19 | express() |
 | src/responseExprs.js:7:1:9:2 | app.get ... es2;\\n}) | src/responseExprs.js:2:11:2:19 | express() |
 | src/responseExprs.js:10:1:12:2 | app.get ... es3;\\n}) | src/responseExprs.js:2:11:2:19 | express() |

--- a/javascript/ql/test/library-tests/frameworks/Express/RouterDefinition_getARouteHandler.expected
+++ b/javascript/ql/test/library-tests/frameworks/Express/RouterDefinition_getARouteHandler.expected
@@ -9,7 +9,7 @@
 | src/express.js:2:11:2:19 | express() | src/express.js:4:23:9:1 | functio ... res);\\n} |
 | src/express.js:2:11:2:19 | express() | src/express.js:16:19:18:3 | functio ... ");\\n  } |
 | src/express.js:2:11:2:19 | express() | src/express.js:22:30:32:1 | functio ... ar');\\n} |
-| src/express.js:2:11:2:19 | express() | src/express.js:46:22:50:1 | functio ... name;\\n} |
+| src/express.js:2:11:2:19 | express() | src/express.js:46:22:51:1 | functio ... ame];\\n} |
 | src/responseExprs.js:2:11:2:19 | express() | src/responseExprs.js:4:23:6:1 | functio ...  res1\\n} |
 | src/responseExprs.js:2:11:2:19 | express() | src/responseExprs.js:7:23:9:1 | functio ... res2;\\n} |
 | src/responseExprs.js:2:11:2:19 | express() | src/responseExprs.js:10:23:12:1 | functio ... res3;\\n} |

--- a/javascript/ql/test/library-tests/frameworks/Express/RouterDefinition_getARouteHandler.expected
+++ b/javascript/ql/test/library-tests/frameworks/Express/RouterDefinition_getARouteHandler.expected
@@ -9,6 +9,7 @@
 | src/express.js:2:11:2:19 | express() | src/express.js:4:23:9:1 | functio ... res);\\n} |
 | src/express.js:2:11:2:19 | express() | src/express.js:16:19:18:3 | functio ... ");\\n  } |
 | src/express.js:2:11:2:19 | express() | src/express.js:22:30:32:1 | functio ... ar');\\n} |
+| src/express.js:2:11:2:19 | express() | src/express.js:46:22:50:1 | functio ... name;\\n} |
 | src/responseExprs.js:2:11:2:19 | express() | src/responseExprs.js:4:23:6:1 | functio ...  res1\\n} |
 | src/responseExprs.js:2:11:2:19 | express() | src/responseExprs.js:7:23:9:1 | functio ... res2;\\n} |
 | src/responseExprs.js:2:11:2:19 | express() | src/responseExprs.js:10:23:12:1 | functio ... res3;\\n} |

--- a/javascript/ql/test/library-tests/frameworks/Express/RouterDefinition_getMiddlewareStackAt.expected
+++ b/javascript/ql/test/library-tests/frameworks/Express/RouterDefinition_getMiddlewareStackAt.expected
@@ -75,7 +75,14 @@
 | src/express.js:2:11:2:19 | express() | src/express.js:44:5:44:7 | use | src/express.js:39:9:39:20 | getHandler() |
 | src/express.js:2:11:2:19 | express() | src/express.js:44:9:44:23 | getArrowHandler | src/express.js:39:9:39:20 | getHandler() |
 | src/express.js:2:11:2:19 | express() | src/express.js:44:9:44:25 | getArrowHandler() | src/express.js:39:9:39:20 | getHandler() |
-| src/express.js:2:11:2:19 | express() | src/express.js:45:1:45:0 | exit node of <toplevel> | src/express.js:44:9:44:25 | getArrowHandler() |
+| src/express.js:2:11:2:19 | express() | src/express.js:46:1:46:3 | app | src/express.js:44:9:44:25 | getArrowHandler() |
+| src/express.js:2:11:2:19 | express() | src/express.js:46:1:46:8 | app.post | src/express.js:44:9:44:25 | getArrowHandler() |
+| src/express.js:2:11:2:19 | express() | src/express.js:46:1:50:2 | app.pos ... ame;\\n}) | src/express.js:44:9:44:25 | getArrowHandler() |
+| src/express.js:2:11:2:19 | express() | src/express.js:46:1:50:3 | app.pos ... me;\\n}); | src/express.js:44:9:44:25 | getArrowHandler() |
+| src/express.js:2:11:2:19 | express() | src/express.js:46:5:46:8 | post | src/express.js:44:9:44:25 | getArrowHandler() |
+| src/express.js:2:11:2:19 | express() | src/express.js:46:10:46:19 | '/headers' | src/express.js:44:9:44:25 | getArrowHandler() |
+| src/express.js:2:11:2:19 | express() | src/express.js:46:22:50:1 | functio ... name;\\n} | src/express.js:44:9:44:25 | getArrowHandler() |
+| src/express.js:2:11:2:19 | express() | src/express.js:51:1:51:0 | exit node of <toplevel> | src/express.js:44:9:44:25 | getArrowHandler() |
 | src/subrouter.js:2:11:2:19 | express() | src/subrouter.js:4:1:4:26 | app.use ... rotect) | src/subrouter.js:4:19:4:25 | protect |
 | src/subrouter.js:2:11:2:19 | express() | src/subrouter.js:5:1:5:3 | app | src/subrouter.js:4:19:4:25 | protect |
 | src/subrouter.js:2:11:2:19 | express() | src/subrouter.js:5:1:5:7 | app.use | src/subrouter.js:4:19:4:25 | protect |

--- a/javascript/ql/test/library-tests/frameworks/Express/RouterDefinition_getMiddlewareStackAt.expected
+++ b/javascript/ql/test/library-tests/frameworks/Express/RouterDefinition_getMiddlewareStackAt.expected
@@ -77,12 +77,12 @@
 | src/express.js:2:11:2:19 | express() | src/express.js:44:9:44:25 | getArrowHandler() | src/express.js:39:9:39:20 | getHandler() |
 | src/express.js:2:11:2:19 | express() | src/express.js:46:1:46:3 | app | src/express.js:44:9:44:25 | getArrowHandler() |
 | src/express.js:2:11:2:19 | express() | src/express.js:46:1:46:8 | app.post | src/express.js:44:9:44:25 | getArrowHandler() |
-| src/express.js:2:11:2:19 | express() | src/express.js:46:1:50:2 | app.pos ... ame;\\n}) | src/express.js:44:9:44:25 | getArrowHandler() |
-| src/express.js:2:11:2:19 | express() | src/express.js:46:1:50:3 | app.pos ... me;\\n}); | src/express.js:44:9:44:25 | getArrowHandler() |
+| src/express.js:2:11:2:19 | express() | src/express.js:46:1:51:2 | app.pos ... me];\\n}) | src/express.js:44:9:44:25 | getArrowHandler() |
+| src/express.js:2:11:2:19 | express() | src/express.js:46:1:51:3 | app.pos ... e];\\n}); | src/express.js:44:9:44:25 | getArrowHandler() |
 | src/express.js:2:11:2:19 | express() | src/express.js:46:5:46:8 | post | src/express.js:44:9:44:25 | getArrowHandler() |
 | src/express.js:2:11:2:19 | express() | src/express.js:46:10:46:19 | '/headers' | src/express.js:44:9:44:25 | getArrowHandler() |
-| src/express.js:2:11:2:19 | express() | src/express.js:46:22:50:1 | functio ... name;\\n} | src/express.js:44:9:44:25 | getArrowHandler() |
-| src/express.js:2:11:2:19 | express() | src/express.js:51:1:51:0 | exit node of <toplevel> | src/express.js:44:9:44:25 | getArrowHandler() |
+| src/express.js:2:11:2:19 | express() | src/express.js:46:22:51:1 | functio ... ame];\\n} | src/express.js:44:9:44:25 | getArrowHandler() |
+| src/express.js:2:11:2:19 | express() | src/express.js:52:1:52:0 | exit node of <toplevel> | src/express.js:44:9:44:25 | getArrowHandler() |
 | src/subrouter.js:2:11:2:19 | express() | src/subrouter.js:4:1:4:26 | app.use ... rotect) | src/subrouter.js:4:19:4:25 | protect |
 | src/subrouter.js:2:11:2:19 | express() | src/subrouter.js:5:1:5:3 | app | src/subrouter.js:4:19:4:25 | protect |
 | src/subrouter.js:2:11:2:19 | express() | src/subrouter.js:5:1:5:7 | app.use | src/subrouter.js:4:19:4:25 | protect |

--- a/javascript/ql/test/library-tests/frameworks/Express/StandardRouteHandler.expected
+++ b/javascript/ql/test/library-tests/frameworks/Express/StandardRouteHandler.expected
@@ -9,7 +9,7 @@
 | src/express.js:4:23:9:1 | functio ... res);\\n} | src/express.js:2:11:2:19 | express() | src/express.js:4:32:4:34 | req | src/express.js:4:37:4:39 | res |
 | src/express.js:16:19:18:3 | functio ... ");\\n  } | src/express.js:2:11:2:19 | express() | src/express.js:16:28:16:30 | req | src/express.js:16:33:16:35 | res |
 | src/express.js:22:30:32:1 | functio ... ar');\\n} | src/express.js:2:11:2:19 | express() | src/express.js:22:39:22:41 | req | src/express.js:22:44:22:46 | res |
-| src/express.js:46:22:50:1 | functio ... name;\\n} | src/express.js:2:11:2:19 | express() | src/express.js:46:31:46:33 | req | src/express.js:46:36:46:38 | res |
+| src/express.js:46:22:51:1 | functio ... ame];\\n} | src/express.js:2:11:2:19 | express() | src/express.js:46:31:46:33 | req | src/express.js:46:36:46:38 | res |
 | src/responseExprs.js:4:23:6:1 | functio ...  res1\\n} | src/responseExprs.js:2:11:2:19 | express() | src/responseExprs.js:4:32:4:34 | req | src/responseExprs.js:4:37:4:40 | res1 |
 | src/responseExprs.js:7:23:9:1 | functio ... res2;\\n} | src/responseExprs.js:2:11:2:19 | express() | src/responseExprs.js:7:32:7:34 | req | src/responseExprs.js:7:37:7:40 | res2 |
 | src/responseExprs.js:10:23:12:1 | functio ... res3;\\n} | src/responseExprs.js:2:11:2:19 | express() | src/responseExprs.js:10:39:10:41 | req | src/responseExprs.js:10:44:10:47 | res3 |

--- a/javascript/ql/test/library-tests/frameworks/Express/StandardRouteHandler.expected
+++ b/javascript/ql/test/library-tests/frameworks/Express/StandardRouteHandler.expected
@@ -9,6 +9,7 @@
 | src/express.js:4:23:9:1 | functio ... res);\\n} | src/express.js:2:11:2:19 | express() | src/express.js:4:32:4:34 | req | src/express.js:4:37:4:39 | res |
 | src/express.js:16:19:18:3 | functio ... ");\\n  } | src/express.js:2:11:2:19 | express() | src/express.js:16:28:16:30 | req | src/express.js:16:33:16:35 | res |
 | src/express.js:22:30:32:1 | functio ... ar');\\n} | src/express.js:2:11:2:19 | express() | src/express.js:22:39:22:41 | req | src/express.js:22:44:22:46 | res |
+| src/express.js:46:22:50:1 | functio ... name;\\n} | src/express.js:2:11:2:19 | express() | src/express.js:46:31:46:33 | req | src/express.js:46:36:46:38 | res |
 | src/responseExprs.js:4:23:6:1 | functio ...  res1\\n} | src/responseExprs.js:2:11:2:19 | express() | src/responseExprs.js:4:32:4:34 | req | src/responseExprs.js:4:37:4:40 | res1 |
 | src/responseExprs.js:7:23:9:1 | functio ... res2;\\n} | src/responseExprs.js:2:11:2:19 | express() | src/responseExprs.js:7:32:7:34 | req | src/responseExprs.js:7:37:7:40 | res2 |
 | src/responseExprs.js:10:23:12:1 | functio ... res3;\\n} | src/responseExprs.js:2:11:2:19 | express() | src/responseExprs.js:10:39:10:41 | req | src/responseExprs.js:10:44:10:47 | res3 |

--- a/javascript/ql/test/library-tests/frameworks/Express/isRequest.expected
+++ b/javascript/ql/test/library-tests/frameworks/Express/isRequest.expected
@@ -17,4 +17,5 @@
 | src/express.js:47:3:47:5 | req |
 | src/express.js:48:3:48:5 | req |
 | src/express.js:49:3:49:5 | req |
+| src/express.js:50:3:50:5 | req |
 | src/responseExprs.js:17:5:17:7 | req |

--- a/javascript/ql/test/library-tests/frameworks/Express/isRequest.expected
+++ b/javascript/ql/test/library-tests/frameworks/Express/isRequest.expected
@@ -14,4 +14,7 @@
 | src/express.js:28:3:28:5 | req |
 | src/express.js:29:3:29:5 | req |
 | src/express.js:30:3:30:5 | req |
+| src/express.js:47:3:47:5 | req |
+| src/express.js:48:3:48:5 | req |
+| src/express.js:49:3:49:5 | req |
 | src/responseExprs.js:17:5:17:7 | req |

--- a/javascript/ql/test/library-tests/frameworks/Express/src/express.js
+++ b/javascript/ql/test/library-tests/frameworks/Express/src/express.js
@@ -47,4 +47,5 @@ app.post('/headers', function(req, res) {
   req.headers.baz;
   req.host;
   req.hostname;
+  req.headers[config.headerName];
 });

--- a/javascript/ql/test/library-tests/frameworks/Express/src/express.js
+++ b/javascript/ql/test/library-tests/frameworks/Express/src/express.js
@@ -42,3 +42,9 @@ function getArrowHandler() {
     return (req, res) => f();
 }
 app.use(getArrowHandler());
+
+app.post('/headers', function(req, res) {
+  req.headers.baz;
+  req.host;
+  req.hostname;
+});


### PR DESCRIPTION
`req.headers.x` was missing from the Express model. I've also thrown in `req.host` and `req.hostname` as they are derived from headers.

Evaluation [looks good](https://git.semmle.com/asger/dist-compare-reports/tree/7be621c07abfb29591f765f71c03f968). It gives rise to a false positive due to the Reflected XSS query treating headers as sources, which it really shouldn't. I'll put up a separate PR for that separately.