### PR TITLE
.gitignore everything under .vs in repo root dir

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,5 @@
 # editor and OS artifacts
 *~
-/.vs
 .DS_STORE
 
 # query compilation caches
@@ -9,3 +8,7 @@
 # qltest projects and artifacts
 */ql/test/**/*.testproj
 */ql/test/**/*.actual
+
+# Visual studio temporaries, except a file used by QL4VS
+.vs/*
+!.vs/VSWorkspaceSettings.json

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 # editor and OS artifacts
 *~
+/.vs
 .DS_STORE
 
 # query compilation caches
@@ -8,8 +9,3 @@
 # qltest projects and artifacts
 */ql/test/**/*.testproj
 */ql/test/**/*.actual
-/.vs/slnx.sqlite
-/.vs/ql/v15/Browse.VC.opendb
-/.vs/ql/v15/Browse.VC.db
-/.vs/ProjectSettings.json
-


### PR DESCRIPTION
We have external users editing queries with Visual Studio, and it seems to automatically add very specific files to `.gitignore`. These changes cause conflicts between unrelated PRs.

This commit adds all of `/.vs` to `.gitignore`, which should hopfully make Visual Studio stop adding more entries.

@raulgarciamsft FYI.