### PR TITLE
JS: Add HostHeaderPoisoningInEmailGeneration query

### DIFF
--- a/change-notes/1.19/analysis-javascript.md
+++ b/change-notes/1.19/analysis-javascript.md
@@ -17,6 +17,7 @@
 | Enabling Node.js integration for Electron web content renderers (`js/enabling-electron-renderer-node-integration`) | security, frameworks/electron, external/cwe/cwe-094  | Highlights Electron web content renderer preferences with Node.js integration enabled, indicating a violation of [CWE-94](https://cwe.mitre.org/data/definitions/94.html). Results are not shown on LGTM by default. |
 | Stored cross-site scripting (`js/stored-xss`) | security, external/cwe/cwe-079, external/cwe/cwe-116 | Highlights uncontrolled stored values flowing into HTML content, indicating a violation of [CWE-079](https://cwe.mitre.org/data/definitions/79.html). Results shown on LGTM by default. |
 | Replacement of a substring with itself (`js/identity-replacement`) | correctness, security, external/cwe/cwe-116 | Highlights string replacements that replace a string with itself, which usually indicates a mistake. Results shown on LGTM by default. |
+| Host header poisoning in email generation |  security, external/cwe/cwe-640 | Highlights code that generates emails with links that can be hijacked by HTTP host header poisoning, indicating a violation of [CWE-640](https://cwe.mitre.org/data/definitions/640.html). Results shown on LGTM by default.  |
 
 ## Changes to existing queries
 

--- a/javascript/config/suites/javascript/security
+++ b/javascript/config/suites/javascript/security
@@ -22,6 +22,7 @@
 + semmlecode-javascript-queries/Security/CWE-601/ClientSideUrlRedirect.ql: /Security/CWE/CWE-601
 + semmlecode-javascript-queries/Security/CWE-601/ServerSideUrlRedirect.ql: /Security/CWE/CWE-601
 + semmlecode-javascript-queries/Security/CWE-611/Xxe.ql: /Security/CWE/CWE-611
++ semmlecode-javascript-queries/Security/CWE-640/HostHeaderPoisoningInEmailGeneration.ql: /Security/CWE/CWE-640
 + semmlecode-javascript-queries/Security/CWE-643/XpathInjection.ql: /Security/CWE/CWE-643
 + semmlecode-javascript-queries/Security/CWE-730/RegExpInjection.ql: /Security/CWE/CWE-730
 + semmlecode-javascript-queries/Security/CWE-770/MissingRateLimiting.ql: /Security/CWE/CWE-770

--- a/javascript/ql/src/Security/CWE-640/HostHeaderPoisoningInEmailGeneration.qhelp
+++ b/javascript/ql/src/Security/CWE-640/HostHeaderPoisoningInEmailGeneration.qhelp
@@ -1,0 +1,46 @@
+<!DOCTYPE qhelp PUBLIC "-//Semmle//qhelp//EN" "qhelp.dtd">
+<qhelp>
+
+<overview>
+<p>
+Using the HTTP Host header to construct a link in an email can facilitate phishing attacks and leak password reset tokens.
+A malicious user can send an HTTP request to the targeted web site, but with a Host header that refers to his own web site.
+This means the emails will be sent out to potential victims, originating from a server they trust but with
+links leading to a malicious web site.
+</p>
+<p>
+If the email contains a password reset link, and should the victim click the link, the secret reset token will be leaked to the attacker.
+Using the leaked token, the attacker can then construct the real reset link and use it to change the victim's password.
+</p>
+</overview>
+
+<recommendation>
+<p>
+Obtain the server's host name from a configuration file and avoid relying on the Host header.
+</p>
+</recommendation>
+
+<example>
+<p>
+The following example uses the <code>req.host</code> to generate a password reset link.
+This value is derived from the Host header, and can thus be set to anything by an attacker:
+</p>
+<sample src="examples/HostHeaderPoisoningInEmailGeneration.js"/>
+
+<p>
+To ensure the link refers to the correct web site, get the host name from a configuration file:
+</p>
+<sample src="examples/HostHeaderPoisoningInEmailGenerationGood.js"/>
+</example>
+
+<references>
+<li>
+Mitre:
+<a href="https://cwe.mitre.org/data/definitions/640.html">CWE-640: Weak Password Recovery Mechanism for Forgotten Password</a>.
+</li>
+<li>
+Ian Muscat:
+<a href="https://www.acunetix.com/blog/articles/automated-detection-of-host-header-attacks/">What is a Host Header Attack?</a>.
+</li>
+</references>
+</qhelp>

--- a/javascript/ql/src/Security/CWE-640/HostHeaderPoisoningInEmailGeneration.qhelp
+++ b/javascript/ql/src/Security/CWE-640/HostHeaderPoisoningInEmailGeneration.qhelp
@@ -5,7 +5,7 @@
 <p>
 Using the HTTP Host header to construct a link in an email can facilitate phishing attacks and leak password reset tokens.
 A malicious user can send an HTTP request to the targeted web site, but with a Host header that refers to his own web site.
-This means the emails will be sent out to potential victims, originating from a server they trust but with
+This means the emails will be sent out to potential victims, originating from a server they trust, but with
 links leading to a malicious web site.
 </p>
 <p>

--- a/javascript/ql/src/Security/CWE-640/HostHeaderPoisoningInEmailGeneration.ql
+++ b/javascript/ql/src/Security/CWE-640/HostHeaderPoisoningInEmailGeneration.ql
@@ -14,7 +14,7 @@ class TaintedHostHeader extends TaintTracking::Configuration {
   TaintedHostHeader() { this = "TaintedHostHeader" }
 
   override predicate isSource(DataFlow::Node node) {
-    exists (HTTP::RequestInputAccess input | node = input |
+    exists (HTTP::RequestHeaderAccess input | node = input |
       input.getKind() = "header" and
       input.getAHeaderName() = "host")
   }

--- a/javascript/ql/src/Security/CWE-640/HostHeaderPoisoningInEmailGeneration.ql
+++ b/javascript/ql/src/Security/CWE-640/HostHeaderPoisoningInEmailGeneration.ql
@@ -1,0 +1,29 @@
+/**
+ * @name Host header poisoning in email generation
+ * @description Using the HTTP Host header to construct a link in an email can facilitate phishing attacks and leak password reset tokens.
+ * @kind problem
+ * @problem.severity error
+ * @precision high
+ * @id js/host-header-forgery-in-email-generation
+ * @tags security
+ *       external/cwe/cwe-640
+ */
+import javascript
+
+class TaintedHostHeader extends TaintTracking::Configuration {
+  TaintedHostHeader() { this = "TaintedHostHeader" }
+
+  override predicate isSource(DataFlow::Node node) {
+    exists (HTTP::RequestInputAccess input | node = input |
+      input.getKind() = "header" and
+      input.getAHeaderName() = "host")
+  }
+
+  override predicate isSink(DataFlow::Node node) {
+    exists (EmailSender email | node = email.getABody())
+  }
+}
+
+from TaintedHostHeader taint, DataFlow::Node src, DataFlow::Node sink
+where taint.hasFlow(src, sink)
+select sink, "Links in this email can be hijacked by poisoning the HTTP host header $@.", src, "here"

--- a/javascript/ql/src/Security/CWE-640/examples/HostHeaderPoisoningInEmailGeneration.js
+++ b/javascript/ql/src/Security/CWE-640/examples/HostHeaderPoisoningInEmailGeneration.js
@@ -1,0 +1,19 @@
+let nodemailer = require('nodemailer');
+let express = require('express');
+let backend = require('./backend');
+
+let app = express();
+
+let config = JSON.parse(fs.readFileSync('config.json', 'utf8'));
+
+app.post('/resetpass', (req, res) => {
+  let email = req.query.email;
+  let transport = nodemailer.createTransport(config.smtp);
+  let token = backend.getUserSecretResetToken(email);
+  transport.sendMail({
+    from: 'webmaster@example.com',
+    to: email,
+    subject: 'Forgot password',
+    text: `Forgot your password?. Click here to reset: https://${req.host}/resettoken/${token}`,
+  });
+});

--- a/javascript/ql/src/Security/CWE-640/examples/HostHeaderPoisoningInEmailGeneration.js
+++ b/javascript/ql/src/Security/CWE-640/examples/HostHeaderPoisoningInEmailGeneration.js
@@ -14,6 +14,6 @@ app.post('/resetpass', (req, res) => {
     from: 'webmaster@example.com',
     to: email,
     subject: 'Forgot password',
-    text: `Forgot your password?. Click here to reset: https://${req.host}/resettoken/${token}`,
+    text: `Click to reset password: https://${req.host}/resettoken/${token}`,
   });
 });

--- a/javascript/ql/src/Security/CWE-640/examples/HostHeaderPoisoningInEmailGenerationGood.js
+++ b/javascript/ql/src/Security/CWE-640/examples/HostHeaderPoisoningInEmailGenerationGood.js
@@ -1,0 +1,19 @@
+let nodemailer = require('nodemailer');
+let express = require('express');
+let backend = require('./backend');
+
+let app = express();
+
+let config = JSON.parse(fs.readFileSync('config.json', 'utf8'));
+
+app.post('/resetpass', (req, res) => {
+  let email = req.query.email;
+  let transport = nodemailer.createTransport(config.smtp);
+  let token = backend.getUserSecretResetToken(email);
+  transport.sendMail({
+    from: 'webmaster@example.com',
+    to: email,
+    subject: 'Forgot password',
+    text: `Forgot your password?. Click here to reset: https://${config.hostname}/resettoken/${token}`,
+  });
+});

--- a/javascript/ql/src/Security/CWE-640/examples/HostHeaderPoisoningInEmailGenerationGood.js
+++ b/javascript/ql/src/Security/CWE-640/examples/HostHeaderPoisoningInEmailGenerationGood.js
@@ -14,6 +14,6 @@ app.post('/resetpass', (req, res) => {
     from: 'webmaster@example.com',
     to: email,
     subject: 'Forgot password',
-    text: `Forgot your password?. Click here to reset: https://${config.hostname}/resettoken/${token}`,
+    text: `Click to reset password: https://${config.hostname}/resettoken/${token}`,
   });
 });

--- a/javascript/ql/src/javascript.qll
+++ b/javascript/ql/src/javascript.qll
@@ -13,6 +13,7 @@ import semmle.javascript.Constants
 import semmle.javascript.DataFlow
 import semmle.javascript.DefUse
 import semmle.javascript.DOM
+import semmle.javascript.EmailClients
 import semmle.javascript.Errors
 import semmle.javascript.ES2015Modules
 import semmle.javascript.Expr

--- a/javascript/ql/src/semmle/javascript/EmailClients.qll
+++ b/javascript/ql/src/semmle/javascript/EmailClients.qll
@@ -1,0 +1,68 @@
+import javascript
+
+/**
+ * An operation that sends an email.
+ */
+abstract class EmailSender extends DataFlow::DefaultSourceNode {
+  /**
+   * Gets a data flow node holding the plaintext version of the email body.
+   */
+  abstract DataFlow::Node getPlainTextBody();
+
+  /**
+   * Gets a data flow node holding the HTML body of the email.
+   */
+  abstract DataFlow::Node getHtmlBody();
+
+  /**
+   * Gets a data flow node holding the address of the email recipient(s).
+   */
+  abstract DataFlow::Node getTo();
+
+  /**
+   * Gets a data flow node holding the address of the email sender.
+   */
+  abstract DataFlow::Node getFrom();
+
+  /**
+   * Gets a data flow node holding the email subject.
+   */
+  abstract DataFlow::Node getSubject();
+
+  /**
+   * Gets a data flow node that refers to the HTML body or plaintext body of the email.
+   */
+  DataFlow::Node getABody() {
+    result = getPlainTextBody() or
+    result = getHtmlBody()
+  }
+}
+
+/**
+ * An email-sending call based on the `nodemailer` package.
+ */
+private class NodemailerEmailSender extends EmailSender, DataFlow::MethodCallNode {
+  NodemailerEmailSender() {
+    this = DataFlow::moduleMember("nodemailer", "createTransport").getACall().getAMethodCall("sendMail")
+  }
+
+  override DataFlow::Node getPlainTextBody() {
+    result = getOptionArgument(0, "text")
+  }
+
+  override DataFlow::Node getHtmlBody() {
+    result = getOptionArgument(0, "html")
+  }
+
+  override DataFlow::Node getTo() {
+    result = getOptionArgument(0, "to")
+   }
+
+  override DataFlow::Node getFrom() {
+    result = getOptionArgument(0, "from")
+   }
+
+  override DataFlow::Node getSubject() {
+    result = getOptionArgument(0, "subject")
+  }
+}

--- a/javascript/ql/src/semmle/javascript/frameworks/Express.qll
+++ b/javascript/ql/src/semmle/javascript/frameworks/Express.qll
@@ -503,6 +503,19 @@ module Express {
     override string getKind() {
       result = kind
     }
+
+    override string getAHeaderName() {
+      kind = "header" and
+      exists (string name |
+        name = this.(DataFlow::PropRead).getPropertyName()
+        or
+        this.(DataFlow::CallNode).getArgument(0).mayHaveStringValue(name)
+        |
+        if name = "hostname" then
+          result = "host"
+        else
+          result = name.toLowerCase())
+    }
   }
 
   /**

--- a/javascript/ql/src/semmle/javascript/frameworks/HTTP.qll
+++ b/javascript/ql/src/semmle/javascript/frameworks/HTTP.qll
@@ -399,8 +399,17 @@ module HTTP {
      * Note that this predicate is functional.
      */
     abstract string getKind();
+
+    /**
+     * Gets the lower-case name of an HTTP header from which this input is derived,
+     * if this can be determined.
+     *
+     * When the input is not derived from a header, or the header name is
+     * unknown, this has no result.
+     */
+    string getAHeaderName() { none() }
   }
-  
+
   /**
    * A node that looks like a route setup on a server.
    *

--- a/javascript/ql/src/semmle/javascript/frameworks/HTTP.qll
+++ b/javascript/ql/src/semmle/javascript/frameworks/HTTP.qll
@@ -72,9 +72,9 @@ module HTTP {
      * Holds if the header with (lower-case) name `headerName` is set to the value of `headerValue`.
      */
     abstract predicate definesExplicitly(string headerName, Expr headerValue);
-    
+
     /**
-     * Returns the expression used to compute the header name. 
+     * Returns the expression used to compute the header name.
      */
     abstract Expr getNameExpr();
   }
@@ -354,9 +354,9 @@ module HTTP {
         headerName = getNameExpr().getStringValue().toLowerCase() and
         headerValue = astNode.getArgument(1)
       }
-      
+
       override Expr getNameExpr() {
-      	 result = astNode.getArgument(0)
+         result = astNode.getArgument(0)
       }
 
     }
@@ -399,15 +399,19 @@ module HTTP {
      * Note that this predicate is functional.
      */
     abstract string getKind();
+  }
 
+  /**
+   * An access to a header on an incoming HTTP request.
+   */
+  abstract class RequestHeaderAccess extends RequestInputAccess {
     /**
      * Gets the lower-case name of an HTTP header from which this input is derived,
      * if this can be determined.
      *
-     * When the input is not derived from a header, or the header name is
-     * unknown, this has no result.
+     * When the name of the header is unknown, this has no result.
      */
-    string getAHeaderName() { none() }
+    abstract string getAHeaderName();
   }
 
   /**

--- a/javascript/ql/src/semmle/javascript/frameworks/Hapi.qll
+++ b/javascript/ql/src/semmle/javascript/frameworks/Hapi.qll
@@ -144,6 +144,11 @@ module Hapi {
     override string getKind() {
       result = kind
     }
+
+    override string getAHeaderName() {
+      kind = "header" and
+      result = this.(DataFlow::PropRead).getPropertyName().toLowerCase()
+    }
   }
 
   /**

--- a/javascript/ql/src/semmle/javascript/frameworks/Hapi.qll
+++ b/javascript/ql/src/semmle/javascript/frameworks/Hapi.qll
@@ -121,13 +121,6 @@ module Hapi {
           this.asExpr().(PropAccess).accesses(url, "path")
         )
         or
-        exists (PropAccess headers |
-          // `request.headers.<name>`
-          kind = "header" and
-          headers.accesses(request, "headers")  and
-          this.asExpr().(PropAccess).accesses(headers, _)
-        )
-        or
         exists (PropAccess state |
           // `request.state.<name>`
           kind = "cookie" and
@@ -135,6 +128,10 @@ module Hapi {
           this.asExpr().(PropAccess).accesses(state, _)
         )
       )
+      or
+      exists (RequestHeaderAccess access | this = access |
+        rh = access.getRouteHandler() and
+        kind = "header")
     }
 
     override RouteHandler getRouteHandler() {
@@ -144,10 +141,34 @@ module Hapi {
     override string getKind() {
       result = kind
     }
+  }
+
+  /**
+   * An access to an HTTP header on a Hapi request.
+   */
+  private class RequestHeaderAccess extends HTTP::RequestHeaderAccess {
+    RouteHandler rh;
+
+    RequestHeaderAccess() {
+      exists (Expr request | request = rh.getARequestExpr() |
+        exists (PropAccess headers |
+          // `request.headers.<name>`
+          headers.accesses(request, "headers")  and
+          this.asExpr().(PropAccess).accesses(headers, _)
+        )
+      )
+    }
 
     override string getAHeaderName() {
-      kind = "header" and
       result = this.(DataFlow::PropRead).getPropertyName().toLowerCase()
+    }
+
+    override RouteHandler getRouteHandler() {
+      result = rh
+    }
+
+    override string getKind() {
+      result = "header"
     }
   }
 

--- a/javascript/ql/src/semmle/javascript/frameworks/Koa.qll
+++ b/javascript/ql/src/semmle/javascript/frameworks/Koa.qll
@@ -212,6 +212,17 @@ module Koa {
     override string getKind() {
       result = kind
     }
+
+    override string getAHeaderName() {
+      kind = "header" and
+      (
+        result = this.(DataFlow::PropRead).getPropertyName().toLowerCase()
+        or
+        exists (string name |
+          this.(DataFlow::CallNode).getArgument(0).mayHaveStringValue(name) and
+          result = name.toLowerCase())
+      )
+    }
   }
 
   /**

--- a/javascript/ql/src/semmle/javascript/frameworks/Koa.qll
+++ b/javascript/ql/src/semmle/javascript/frameworks/Koa.qll
@@ -182,19 +182,6 @@ module Koa {
           propName = "originalUrl" or
           propName = "href"
         )
-        or
-        exists (string propName, PropAccess headers |
-          // `ctx.request.header.<name>`, `ctx.request.headers.<name>`
-          kind = "header" and
-          headers.accesses(request, propName) and
-          this.asExpr().(PropAccess).accesses(headers, _) |
-          propName = "header" or
-          propName = "headers"
-        )
-        or
-        // `ctx.request.get(<name>)`
-        kind = "header" and
-        this.asExpr().(MethodCallExpr).calls(request, "get")
       )
       or
       exists (PropAccess cookies |
@@ -203,6 +190,10 @@ module Koa {
         cookies.accesses(rh.getAContextExpr(), "cookies") and
         this.asExpr().(MethodCallExpr).calls(cookies, "get")
       )
+      or
+      exists (RequestHeaderAccess access | access = this |
+        rh = access.getRouteHandler() and
+        kind = "header")
     }
 
     override RouteHandler getRouteHandler() {
@@ -212,16 +203,43 @@ module Koa {
     override string getKind() {
       result = kind
     }
+  }
+
+  /**
+   * An access to an HTTP header on a Koa request.
+   */
+  private class RequestHeaderAccess extends HTTP::RequestHeaderAccess {
+    RouteHandler rh;
+
+    RequestHeaderAccess() {
+      exists (Expr request | request = rh.getARequestExpr() |
+        exists (string propName, PropAccess headers |
+          // `ctx.request.header.<name>`, `ctx.request.headers.<name>`
+          headers.accesses(request, propName) and
+          this.asExpr().(PropAccess).accesses(headers, _) |
+          propName = "header" or
+          propName = "headers"
+        )
+        or
+        // `ctx.request.get(<name>)`
+        this.asExpr().(MethodCallExpr).calls(request, "get")
+      )
+    }
 
     override string getAHeaderName() {
-      kind = "header" and
-      (
-        result = this.(DataFlow::PropRead).getPropertyName().toLowerCase()
-        or
-        exists (string name |
-          this.(DataFlow::CallNode).getArgument(0).mayHaveStringValue(name) and
-          result = name.toLowerCase())
-      )
+      result = this.(DataFlow::PropRead).getPropertyName().toLowerCase()
+      or
+      exists (string name |
+        this.(DataFlow::CallNode).getArgument(0).mayHaveStringValue(name) and
+        result = name.toLowerCase())
+    }
+
+    override RouteHandler getRouteHandler() {
+      result = rh
+    }
+
+    override string getKind() {
+      result = "header"
     }
   }
 

--- a/javascript/ql/src/semmle/javascript/frameworks/NodeJSLib.qll
+++ b/javascript/ql/src/semmle/javascript/frameworks/NodeJSLib.qll
@@ -161,6 +161,11 @@ module NodeJSLib {
     override string getKind() {
       result = kind
     }
+
+    override string getAHeaderName() {
+      kind = "header" and
+      result = this.(DataFlow::PropRead).getPropertyName().toLowerCase()
+    }
   }
 
   class RouteSetup extends CallExpr, HTTP::Servers::StandardRouteSetup {

--- a/javascript/ql/test/library-tests/EmailClients/EmailClients.expected
+++ b/javascript/ql/test/library-tests/EmailClients/EmailClients.expected
@@ -1,0 +1,1 @@
+| tst.js:17:2:19:3 | transpo ... ');\\n\\t}) | tst.js:11:12:11:31 | 'sender@example.com' | tst.js:12:10:12:55 | 'receiv ... le.com' | tst.js:13:15:13:28 | 'Some subject' | tst.js:14:12:14:15 | 'Hi' | tst.js:15:12:15:22 | '<b>Hi</b>' |

--- a/javascript/ql/test/library-tests/EmailClients/EmailClients.ql
+++ b/javascript/ql/test/library-tests/EmailClients/EmailClients.ql
@@ -1,0 +1,4 @@
+import javascript
+
+from EmailSender send
+select send, send.getFrom(), send.getTo(), send.getSubject(), send.getPlainTextBody(), send.getHtmlBody()

--- a/javascript/ql/test/library-tests/EmailClients/tst.js
+++ b/javascript/ql/test/library-tests/EmailClients/tst.js
@@ -1,0 +1,20 @@
+let nodemailer = require('nodemailer');
+let config = require('./account-config');
+
+function sendMessage() {
+	let transporter = nodemailer.createTransport({
+	    host: config.host,
+	    port: config.host,
+	    auth: config.auth
+	});
+	let mailOptions = {
+	    from: 'sender@example.com',
+	    to: 'receiver1@example.com, receiver2@example.com',
+	    subject: 'Some subject',
+	    text: 'Hi',
+	    html: '<b>Hi</b>'
+	};
+	transporter.sendMail(mailOptions, (error, info) => {
+	    console.log('Message sent');
+	});
+}

--- a/javascript/ql/test/library-tests/frameworks/Express/HeaderAccess.expected
+++ b/javascript/ql/test/library-tests/frameworks/Express/HeaderAccess.expected
@@ -1,0 +1,5 @@
+| src/express.js:28:3:28:16 | req.get("foo") | foo |
+| src/express.js:29:3:29:19 | req.header("bar") | bar |
+| src/express.js:47:3:47:17 | req.headers.baz | baz |
+| src/express.js:48:3:48:10 | req.host | host |
+| src/express.js:49:3:49:14 | req.hostname | host |

--- a/javascript/ql/test/library-tests/frameworks/Express/HeaderAccess.ql
+++ b/javascript/ql/test/library-tests/frameworks/Express/HeaderAccess.ql
@@ -1,0 +1,4 @@
+import javascript
+
+from HTTP::RequestInputAccess access
+select access, access.getAHeaderName()

--- a/javascript/ql/test/library-tests/frameworks/Express/HeaderAccess.ql
+++ b/javascript/ql/test/library-tests/frameworks/Express/HeaderAccess.ql
@@ -1,4 +1,4 @@
 import javascript
 
-from HTTP::RequestInputAccess access
+from HTTP::RequestHeaderAccess access
 select access, access.getAHeaderName()

--- a/javascript/ql/test/library-tests/frameworks/NodeJSLib/HeaderAccess.expected
+++ b/javascript/ql/test/library-tests/frameworks/NodeJSLib/HeaderAccess.expected
@@ -1,0 +1,2 @@
+| src/http.js:9:3:9:17 | req.headers.foo | foo |
+| src/https.js:9:3:9:17 | req.headers.foo | foo |

--- a/javascript/ql/test/library-tests/frameworks/NodeJSLib/HeaderAccess.ql
+++ b/javascript/ql/test/library-tests/frameworks/NodeJSLib/HeaderAccess.ql
@@ -1,0 +1,4 @@
+import javascript
+
+from HTTP::RequestInputAccess access
+select access, access.getAHeaderName()

--- a/javascript/ql/test/library-tests/frameworks/NodeJSLib/HeaderAccess.ql
+++ b/javascript/ql/test/library-tests/frameworks/NodeJSLib/HeaderAccess.ql
@@ -1,4 +1,4 @@
 import javascript
 
-from HTTP::RequestInputAccess access
+from HTTP::RequestHeaderAccess access
 select access, access.getAHeaderName()

--- a/javascript/ql/test/library-tests/frameworks/hapi/HeaderAccess.expected
+++ b/javascript/ql/test/library-tests/frameworks/hapi/HeaderAccess.expected
@@ -1,0 +1,1 @@
+| src/hapi.js:25:3:25:21 | request.headers.baz | baz |

--- a/javascript/ql/test/library-tests/frameworks/hapi/HeaderAccess.ql
+++ b/javascript/ql/test/library-tests/frameworks/hapi/HeaderAccess.ql
@@ -1,0 +1,4 @@
+import javascript
+
+from HTTP::RequestInputAccess access
+select access, access.getAHeaderName()

--- a/javascript/ql/test/library-tests/frameworks/hapi/HeaderAccess.ql
+++ b/javascript/ql/test/library-tests/frameworks/hapi/HeaderAccess.ql
@@ -1,4 +1,4 @@
 import javascript
 
-from HTTP::RequestInputAccess access
+from HTTP::RequestHeaderAccess access
 select access, access.getAHeaderName()

--- a/javascript/ql/test/library-tests/frameworks/koa/HeaderAccess.expected
+++ b/javascript/ql/test/library-tests/frameworks/koa/HeaderAccess.expected
@@ -1,0 +1,3 @@
+| src/koa.js:24:3:24:24 | ctx.req ... der.bar | bar |
+| src/koa.js:25:3:25:25 | ctx.req ... ers.bar | bar |
+| src/koa.js:26:3:26:24 | ctx.req ... ('bar') | bar |

--- a/javascript/ql/test/library-tests/frameworks/koa/HeaderAccess.ql
+++ b/javascript/ql/test/library-tests/frameworks/koa/HeaderAccess.ql
@@ -1,0 +1,4 @@
+import javascript
+
+from HTTP::RequestInputAccess access
+select access, access.getAHeaderName()

--- a/javascript/ql/test/library-tests/frameworks/koa/HeaderAccess.ql
+++ b/javascript/ql/test/library-tests/frameworks/koa/HeaderAccess.ql
@@ -1,4 +1,4 @@
 import javascript
 
-from HTTP::RequestInputAccess access
+from HTTP::RequestHeaderAccess access
 select access, access.getAHeaderName()

--- a/javascript/ql/test/query-tests/Security/CWE-640/HostHeaderPoisoningInEmailGeneration.expected
+++ b/javascript/ql/test/query-tests/Security/CWE-640/HostHeaderPoisoningInEmailGeneration.expected
@@ -1,0 +1,2 @@
+| tst.js:17:11:17:113 | `Hi, lo ... token}` | Links in this email can be hijacked by poisoning the HTTP host header $@. | tst.js:17:84:17:91 | req.host | here |
+| tst.js:18:11:18:127 | `Hi, lo ... reset.` | Links in this email can be hijacked by poisoning the HTTP host header $@. | tst.js:18:78:18:85 | req.host | here |

--- a/javascript/ql/test/query-tests/Security/CWE-640/HostHeaderPoisoningInEmailGeneration.qlref
+++ b/javascript/ql/test/query-tests/Security/CWE-640/HostHeaderPoisoningInEmailGeneration.qlref
@@ -1,0 +1,1 @@
+Security/CWE-640/HostHeaderPoisoningInEmailGeneration.ql

--- a/javascript/ql/test/query-tests/Security/CWE-640/tst.js
+++ b/javascript/ql/test/query-tests/Security/CWE-640/tst.js
@@ -1,0 +1,28 @@
+let nodemailer = require('nodemailer');
+let express = require('express');
+let app = express();
+let backend = require('./backend');
+
+app.post('/resetpass', (req, res) => {
+  let email = req.query.email;
+
+  let transport = nodemailer.createTransport({});
+
+  let token = backend.getUserSecretResetToken(email);
+
+  transport.sendMail({
+    from: 'webmaster@example.com',
+    to: email,
+    subject: 'Forgot password',
+    text: `Hi, looks like you forgot your password. Click here to reset: https://${req.host}/resettoken/${token}`, // NOT OK
+    html: `Hi, looks like you forgot your password. Click <a href="https://${req.host}/resettoken/${token}">here</a> to reset.` // NOT OK
+  });
+
+  transport.sendMail({
+    from: 'webmaster@example.com',
+    to: email,
+    subject: 'Forgot password',
+    text: `Hi, looks like you forgot your password. Click here to reset: https://example.com/resettoken/${token}`, // OK
+    html: `Hi, looks like you forgot your password. Click <a href="https://example.com/resettoken/${token}">here</a> to reset.` // OK
+  });
+});


### PR DESCRIPTION
Adds a new query for detecting when an email contains URLs generated using the incoming Host header. An attacker can set the Host header to anything thus making the URL refer to a phishing site, or a site that steals secret tokens appended onto the URL.

An important special-case is emails for resetting a password, where hijacking the link can lead to account takeover (assuming the victim clicks the link, which they shouldn't).

[ODASA-7329](https://jira.semmle.com/browse/ODASA-7329) describes two occurrences of this. This query flags the first one, but the latter one ~~requires interprocedural tracking of Express servers/routes~~ fails to track the Express app due to dynamic `require` paths. It finds no other occurrences on `default.slugs`.

The PR also adds two bits of related infrastructure:
- Add the `EmailSender` concept for calls that send out an email. Not crazy about the name, but `EmailSending` sounds weird. `OutgoingEmail`? Open to ideas here.
- Adds `RequestInputAccess.getAHeaderName` for the case where the input access refers to a header and the name of that header is known. It feels like a subclass of `RequestInputAccess` is warranted here, but this is not trivial as it leads to diamond inheritance which is quite tricky with our hierarchy of abstract classes. If we want to refactor this, I'd rather do it in a separate PR with a separate perf evaluation.

I've just measured the [absolute performance](https://git.semmle.com/gist/asger/77d95fb23c7a41c3b78d1d379193f276) relative to `definitions.ql`. Nothing stands out.

Closes ODASA-7329
Closes ODASA-7216
Closes ODASA-7297