### PR TITLE
C++: Fix join order in CommentedOutCode

### DIFF
--- a/cpp/ql/src/Documentation/CommentedOutCode.qll
+++ b/cpp/ql/src/Documentation/CommentedOutCode.qll
@@ -119,7 +119,7 @@ class CommentBlock extends Comment {
      */
     predicate hasLocationInfo(string filepath, int startline, int startcolumn, int endline, int endcolumn) {
         this.getLocation().hasLocationInfo(filepath, startline, startcolumn, _, _) and
-        this.lastComment().getLocation().hasLocationInfo(filepath, _, _, endline, endcolumn)
+        this.lastComment().getLocation().hasLocationInfo(_, _, _, endline, endcolumn)
     }
 }
 


### PR DESCRIPTION
After the recent inlining of `unresolveElement`, the join order in `CommentedOutCode` became a problem. The join orderer was tempted to join the two `hasLocationInfo` calls first because they had one column in common. With this commit, they have no columns in common. It follows from the other predicates in the same file that this column would be the same, so there is no need to assert it in this predicate and risk that the join orderer uses that information.

On Wireshark, the `CommentBlock::hasLocationInfo` predicate goes from taking 2m2s to taking 180ms. The query produces the same 7,448 alerts.