### PR TITLE
Version: Fix C# and JavaScript Eclipse plugins for 1.18.

### DIFF
--- a/csharp/ql/src/META-INF/MANIFEST.MF
+++ b/csharp/ql/src/META-INF/MANIFEST.MF
@@ -5,4 +5,4 @@ Bundle-SymbolicName: com.semmle.plugin.semmlecode.csharp.queries;singleton:=true
 Bundle-Version: 1.18.0
 Bundle-Vendor: Semmle Ltd.
 Bundle-ActivationPolicy: lazy
-Require-Bundle: com.semmle.plugin.qdt.ui;bundle-version="[1.18.0.qualifier, 1.18.0.qualifier]"
+Require-Bundle: com.semmle.plugin.qdt.ui;bundle-version="[1.18.0,1.18.0]"

--- a/javascript/ql/src/META-INF/MANIFEST.MF
+++ b/javascript/ql/src/META-INF/MANIFEST.MF
@@ -5,4 +5,4 @@ Bundle-SymbolicName: com.semmle.plugin.semmlecode.javascript.queries;singleton:=
 Bundle-Version: 1.18.0
 Bundle-Vendor: Semmle Ltd.
 Bundle-ActivationPolicy: lazy
-Require-Bundle: com.semmle.plugin.qdt.ui;bundle-version="[1.18.0.qualifier, 1.18.0.qualifier]"
+Require-Bundle: com.semmle.plugin.qdt.ui;bundle-version="[1.18.0,1.18.0]"


### PR DESCRIPTION
Missed from #237 because the version bump script didn't account for spaces.