### PR TITLE
JS: support noop parentheses in js/useless-assignment-to-local

### DIFF
--- a/change-notes/1.19/analysis-javascript.md
+++ b/change-notes/1.19/analysis-javascript.md
@@ -19,6 +19,7 @@
 
 | **Query**                      | **Expected impact**        | **Change**                                   |
 |--------------------------------|----------------------------|----------------------------------------------|
+| Useless assignment to local variable | Fewer false-positive results | This rule now recognizes additional ways default values can be set. |
 | Regular expression injection | Fewer false-positive results | This rule now identifies calls to `String.prototype.search` with more precision. |
 | Unbound event handler receiver | Fewer false-positive results | This rule now recognizes additional ways class methods can be bound. |
 | Remote property injection | Fewer results | The precision of this rule has been revised to "medium". Results are no longer shown on LGTM by default. |

--- a/javascript/ql/src/Declarations/DeadStoreOfLocal.ql
+++ b/javascript/ql/src/Declarations/DeadStoreOfLocal.ql
@@ -33,12 +33,15 @@ predicate deadStoreOfLocal(VarDef vd, PurelyLocalVariable v) {
  * is itself an expression evaluating to `null` or `undefined`.
  */
 predicate isNullOrUndef(Expr e) {
-  // `null` or `undefined`
-  e instanceof NullLiteral or
-  e.(VarAccess).getName() = "undefined" or
-  e instanceof VoidExpr or
-  // recursive case to catch multi-assignments of the form `x = y = null`
-  isNullOrUndef(e.(AssignExpr).getRhs())
+  exists (Expr inner |
+    inner = e.stripParens() |
+    // `null` or `undefined`
+    inner instanceof NullLiteral or
+    inner.(VarAccess).getName() = "undefined" or
+    inner instanceof VoidExpr or
+    // recursive case to catch multi-assignments of the form `x = y = null`
+    isNullOrUndef(inner.(AssignExpr).getRhs())
+  )
 }
 
 /**

--- a/javascript/ql/test/query-tests/Declarations/DeadStoreOfLocal/tst.js
+++ b/javascript/ql/test/query-tests/Declarations/DeadStoreOfLocal/tst.js
@@ -142,3 +142,14 @@ function v() {
   x = 42;
   return x;
 }
+
+(function(){
+	var x = (void 0);
+	var y = ((void 0));
+	var z1 = z2 = (void 0);
+	x = 42;
+	y = 42;
+	z1 = 42;
+	z2 = 42;
+	return x + y + z1 + z2;
+});


### PR DESCRIPTION
The syntatic recognizer `isNullOrUndef` did not handle expressions
that were wrapped in parentheses.

This eliminates some results here:
https://lgtm.com/projects/g/vuejs/vue/alerts?mode=tree&ruleFocus=7900088