### PR TITLE
JavaScript: fix two examples based on LGTM.com alerts

### DIFF
--- a/javascript/ql/src/Security/CWE-079/examples/StoredXss.js
+++ b/javascript/ql/src/Security/CWE-079/examples/StoredXss.js
@@ -6,7 +6,7 @@ express().get('/list-directory', function(req, res) {
         var list = '<ul>';
         fileNames.forEach(fileName => {
             // BAD: `fileName` can contain HTML elements
-            list += '<li>' + fileName '</li>';
+            list += '<li>' + fileName + '</li>';
         });
         list += '</ul>'
         res.send(list);

--- a/javascript/ql/src/Security/CWE-079/examples/StoredXssGood.js
+++ b/javascript/ql/src/Security/CWE-079/examples/StoredXssGood.js
@@ -7,7 +7,7 @@ express().get('/list-directory', function(req, res) {
         var list = '<ul>';
         fileNames.forEach(fileName => {
             // GOOD: escaped `fileName` can not contain HTML elements
-            list += '<li>' + escape(fileName) '</li>';
+            list += '<li>' + escape(fileName) + '</li>';
         });
         list += '</ul>'
         res.send(list);


### PR DESCRIPTION
LGTM.com flagged up two alerts in JavaScript example code:

https://lgtm.com/projects/g/Semmle/ql/snapshot/1f7ef5b0d7706803f73e97d2294a60c02f4bd511/files/javascript/ql/src/Security/CWE-079/examples/StoredXssGood.js#x95b0280fcab9007a:1
https://lgtm.com/projects/g/Semmle/ql/snapshot/1f7ef5b0d7706803f73e97d2294a60c02f4bd511/files/javascript/ql/src/Security/CWE-079/examples/StoredXss.js#xaef03a63aa3e02e4:1