### PR TITLE
C++: support Decltype in suspicious-call-to-memset

### DIFF
--- a/cpp/ql/src/Likely Bugs/Memory Management/SuspiciousCallToMemset.ql
+++ b/cpp/ql/src/Likely Bugs/Memory Management/SuspiciousCallToMemset.ql
@@ -41,11 +41,13 @@ Type stripType(Type t) {
   result = stripType(t.(ArrayType).getBaseType()) or
   result = stripType(t.(ReferenceType).getBaseType()) or
   result = stripType(t.(SpecifiedType).getBaseType()) or
+  result = stripType(t.(Decltype).getBaseType()) or
   (
     not t instanceof TypedefType and
     not t instanceof ArrayType and
     not t instanceof ReferenceType and
     not t instanceof SpecifiedType and
+    not t instanceof Decltype and
     result = t
   )
 }

--- a/cpp/ql/test/query-tests/Likely Bugs/Memory Management/SuspiciousCallToMemset/test.cpp
+++ b/cpp/ql/test/query-tests/Likely Bugs/Memory Management/SuspiciousCallToMemset/test.cpp
@@ -171,3 +171,10 @@ void more_tests_2()
 	memset(iapa, 0, sizeof(iapa)); // GOOD
 	memset(iapa, 0, sizeof(intArrayPointer *)); // BAD
 }
+
+void more_tests_3()
+{
+	myStruct ms;
+	decltype(&ms) msPtr = &ms;
+	memset(msPtr, 0, sizeof(myStruct)); // GOOD
+}


### PR DESCRIPTION
Query `cpp/suspicious-call-to-memset` returns `memset` call in following code:

```cpp
#include <memory>
#include <zlib.h>

std::unique_ptr<z_stream> ctx { new (std::nothrow) z_stream };
if (ctx) {
  memset(ctx.get(), 0, sizeof(z_stream));
}
```

I believe this is FP and could be avoided by adding `Decltype` to `stripType()`. Is there any reason why `Decltype` was originally not included? Thanks. 