### PR TITLE
JS: add RemoteFlowSource.isThirdPartyControllable()

### DIFF
--- a/javascript/ql/src/semmle/javascript/frameworks/HTTP.qll
+++ b/javascript/ql/src/semmle/javascript/frameworks/HTTP.qll
@@ -412,6 +412,9 @@ module HTTP {
      *
      * In these cases, the request is technically sent from the user's browser, but
      * the user is not in direct control of the URL or POST body.
+     *
+     * Headers are never considered third-party controllable by this predicate, although the
+     * third party does have some control over the the Referer and Origin headers.
      */
     predicate isThirdPartyControllable() {
       exists (string kind | kind = getKind() |

--- a/javascript/ql/src/semmle/javascript/frameworks/HTTP.qll
+++ b/javascript/ql/src/semmle/javascript/frameworks/HTTP.qll
@@ -400,7 +400,20 @@ module HTTP {
      */
     abstract string getKind();
 
-    override predicate isThirdPartyControllable() {
+    /**
+     * Holds if this part of the request may be controlled by a third party,
+     * that is, an agent other than the one who sent the request.
+     *
+     * This is true for the URL, query parameters, and request body.
+     * These can be controlled by a malicious third party in the following scenarios:
+     *
+     * - The user clicks a malicious link or is otherwise redirected to a malicious URL.
+     * - The user visits a web site that initiates a form submission or AJAX request on their behalf.
+     *
+     * In these cases, the request is technically sent from the user's browser, but
+     * the user is not in direct control of the URL or POST body.
+     */
+    predicate isThirdPartyControllable() {
       exists (string kind | kind = getKind() |
         kind = "parameter" or
         kind = "url" or

--- a/javascript/ql/src/semmle/javascript/frameworks/HTTP.qll
+++ b/javascript/ql/src/semmle/javascript/frameworks/HTTP.qll
@@ -399,6 +399,13 @@ module HTTP {
      * Note that this predicate is functional.
      */
     abstract string getKind();
+
+    override predicate isThirdPartyControllable() {
+      exists (string kind | kind = getKind() |
+        kind = "parameter" or
+        kind = "url" or
+        kind = "body")
+    }
   }
 
   /**

--- a/javascript/ql/src/semmle/javascript/security/dataflow/ReflectedXss.qll
+++ b/javascript/ql/src/semmle/javascript/security/dataflow/ReflectedXss.qll
@@ -46,10 +46,7 @@ module ReflectedXss {
   /** A source of remote user input, considered as a flow source for reflected XSS. */
   class RemoteFlowSourceAsSource extends Source {
     RemoteFlowSourceAsSource() {
-      this instanceof RemoteFlowSource and
-      // cookies cannot be controlled by a third-party attacker, and hence are
-      // not relevant for reflected XSS
-      not this.(RemoteFlowSource).getSourceType() = "Server request cookie"
+      this.(RemoteFlowSource).isThirdPartyControllable()
     }
   }
 

--- a/javascript/ql/src/semmle/javascript/security/dataflow/ReflectedXss.qll
+++ b/javascript/ql/src/semmle/javascript/security/dataflow/ReflectedXss.qll
@@ -43,10 +43,10 @@ module ReflectedXss {
     }
   }
 
-  /** A source of remote user input, considered as a flow source for reflected XSS. */
-  class RemoteFlowSourceAsSource extends Source {
-    RemoteFlowSourceAsSource() {
-      this.(RemoteFlowSource).isThirdPartyControllable()
+  /** A third-party controllable request input, considered as a flow source for reflected XSS. */
+  class ThirdPartyRequestInputAccessAsSource extends Source {
+    ThirdPartyRequestInputAccessAsSource() {
+      this.(HTTP::RequestInputAccess).isThirdPartyControllable()
     }
   }
 

--- a/javascript/ql/src/semmle/javascript/security/dataflow/ReflectedXss.qll
+++ b/javascript/ql/src/semmle/javascript/security/dataflow/ReflectedXss.qll
@@ -47,6 +47,8 @@ module ReflectedXss {
   class ThirdPartyRequestInputAccessAsSource extends Source {
     ThirdPartyRequestInputAccessAsSource() {
       this.(HTTP::RequestInputAccess).isThirdPartyControllable()
+      or
+      this.(HTTP::RequestHeaderAccess).getAHeaderName() = "referer"
     }
   }
 

--- a/javascript/ql/src/semmle/javascript/security/dataflow/RemoteFlowSources.qll
+++ b/javascript/ql/src/semmle/javascript/security/dataflow/RemoteFlowSources.qll
@@ -10,18 +10,6 @@ import semmle.javascript.security.dataflow.DOM
 abstract class RemoteFlowSource extends DataFlow::Node {
   /** Gets a string that describes the type of this remote flow source. */
   abstract string getSourceType();
-
-  /**
-   * Holds if this flow source comes from an incoming request, and this part of the
-   * request can be controlled by a third party, that is, an actor other than the one
-   * sending the request.
-   *
-   * Any web site can redirect the visitor's browser to any other domain, and in doing so control
-   * the entire URL and POST body. In this scenario, these values are technically sent by the
-   * user's browser, but the user is not in direct control of these values, so they are considered
-   * third-party controllable.
-   */
-  predicate isThirdPartyControllable() { none() }
 }
 
 /**

--- a/javascript/ql/src/semmle/javascript/security/dataflow/RemoteFlowSources.qll
+++ b/javascript/ql/src/semmle/javascript/security/dataflow/RemoteFlowSources.qll
@@ -10,8 +10,19 @@ import semmle.javascript.security.dataflow.DOM
 abstract class RemoteFlowSource extends DataFlow::Node {
   /** Gets a string that describes the type of this remote flow source. */
   abstract string getSourceType();
-}
 
+  /**
+   * Holds if this flow source comes from an incoming request, and this part of the
+   * request can be controlled by a third party, that is, an actor other than the one
+   * sending the request.
+   *
+   * Any web site can redirect the visitor's browser to any other domain, and in doing so control
+   * the entire URL and POST body. In this scenario, these values are technically sent by the
+   * user's browser, but the user is not in direct control of these values, so they are considered
+   * third-party controllable.
+   */
+  predicate isThirdPartyControllable() { none() }
+}
 
 /**
  * An access to `document.cookie`, viewed as a source of remote user input.

--- a/javascript/ql/src/semmle/javascript/security/dataflow/ServerSideUrlRedirect.qll
+++ b/javascript/ql/src/semmle/javascript/security/dataflow/ServerSideUrlRedirect.qll
@@ -91,9 +91,9 @@ module ServerSideUrlRedirect {
   }
 
   /** A source of third-party user input, considered as a flow source for URL redirects. */
-  class RemoteFlowSourceAsSource extends Source {
-    RemoteFlowSourceAsSource() {
-      this.(RemoteFlowSource).isThirdPartyControllable()
+  class ThirdPartyRequestInputAccessAsSource extends Source {
+    ThirdPartyRequestInputAccessAsSource() {
+      this.(HTTP::RequestInputAccess).isThirdPartyControllable()
     }
   }
 

--- a/javascript/ql/src/semmle/javascript/security/dataflow/ServerSideUrlRedirect.qll
+++ b/javascript/ql/src/semmle/javascript/security/dataflow/ServerSideUrlRedirect.qll
@@ -90,9 +90,11 @@ module ServerSideUrlRedirect {
 
   }
 
-  /** A source of remote user input, considered as a flow source for URL redirects. */
+  /** A source of third-party user input, considered as a flow source for URL redirects. */
   class RemoteFlowSourceAsSource extends Source {
-    RemoteFlowSourceAsSource() { this instanceof RemoteFlowSource }
+    RemoteFlowSourceAsSource() {
+      this.(RemoteFlowSource).isThirdPartyControllable()
+    }
   }
 
   /**


### PR DESCRIPTION
Adds `isThirdPartyControllable()` predicate to `RemoteFlowSource` for flow sources that can be controlled by the attacker during CSRF.

ReflectedXSS and ServerSideUrlRedirect have been updated to use this. This eliminates some [false positives](https://git.semmle.com/asger/dist-compare-reports/tree/e13abb6c9517541d8f8c76f548da9ab2).

The CorsMisconfiguration query is a bit of a conundrum. It is certainly in the CSRF category, but is different from the others in that the tracks values that may refer to a foreign URL. Most importantly, this includes the `Origin` header, which is may refer to a malicious web site, but is not otherwise directly controlled by the attacker. I see three options for how to approach this:
1. Change CORS to only use third-party controllable flow sources, with the special addition of the `Origin` header, and maybe the `Referer` header.
2. Change `isThirdPartyControllable()` to include `Origin` and `Referer` headers. Technically you could have a reflected XSS through the referer header, and a server-side URL redirect to the referer could cause information leak if a secret session/auth token is appended in the URL.
3. Leave the CORS query as it is.

So far this PR just uses option 3, but I'd like to hear your opinion on this. I haven't seen any concrete results that could motivate one choice over another.