### PR TITLE
C#: Remove the 'security' tag from some queries

### DIFF
--- a/csharp/ql/src/API Abuse/DisposeNotCalledOnException.ql
+++ b/csharp/ql/src/API Abuse/DisposeNotCalledOnException.ql
@@ -9,7 +9,6 @@
  * @id cs/dispose-not-called-on-throw
  * @tags efficiency
  *       maintainability
- *       security
  *       external/cwe/cwe-404
  *       external/cwe/cwe-459
  *       external/cwe/cwe-460

--- a/csharp/ql/src/API Abuse/NoDisposeCallOnLocalIDisposable.ql
+++ b/csharp/ql/src/API Abuse/NoDisposeCallOnLocalIDisposable.ql
@@ -8,7 +8,6 @@
  * @id cs/local-not-disposed
  * @tags efficiency
  *       maintainability
- *       security
  *       external/cwe/cwe-404
  *       external/cwe/cwe-459
  *       external/cwe/cwe-460

--- a/csharp/ql/src/Likely Bugs/PossibleLossOfPrecision.ql
+++ b/csharp/ql/src/Likely Bugs/PossibleLossOfPrecision.ql
@@ -8,7 +8,6 @@
  * @id cs/loss-of-precision
  * @tags reliability
  *       correctness
- *       security
  *       external/cwe/cwe-190
  *       external/cwe/cwe-192
  *       external/cwe/cwe-197


### PR DESCRIPTION
These three queries specify the `security` tag, but are usually not security critical findings. Removing the `security` tag will help rank these results appropriately in LGTM.