### PR TITLE
C++: Suppress PointlessComparison.ql in template instantiations

### DIFF
--- a/cpp/ql/src/Likely Bugs/Arithmetic/PointlessComparison.ql
+++ b/cpp/ql/src/Likely Bugs/Arithmetic/PointlessComparison.ql
@@ -22,13 +22,15 @@ import UnsignedGEZero
 // #define PRINTMSG(val,msg) { if (val >= PRINTLEVEL) printf(msg); }
 //
 // So to reduce the number of false positives, we do not report a result if
-// the comparison is in a macro expansion.
+// the comparison is in a macro expansion. Similarly for template
+// instantiations.
 from
   ComparisonOperation cmp, SmallSide ss,
   float left, float right, boolean value,
   string reason
 where
   not cmp.isInMacroExpansion() and
+  not cmp.isFromTemplateInstantiation(_) and
   reachablePointlessComparison(cmp, left, right, value, ss) and
 
   // a comparison between an enum and zero is always valid because whether

--- a/cpp/ql/test/query-tests/Likely Bugs/Arithmetic/PointlessComparison/PointlessComparison.expected
+++ b/cpp/ql/test/query-tests/Likely Bugs/Arithmetic/PointlessComparison/PointlessComparison.expected
@@ -32,7 +32,4 @@
 | PointlessComparison.c:129:12:129:16 | ... > ... | Comparison is always false because a <= 3. |
 | PointlessComparison.c:197:7:197:11 | ... < ... | Comparison is always false because x >= 0. |
 | RegressionTests.cpp:57:7:57:22 | ... <= ... | Comparison is always true because * ... <= 4294967295. |
-| Templates.cpp:3:10:3:24 | ... <= ... | Comparison is always true because param <= 32767. |
-| Templates.cpp:9:10:9:24 | ... <= ... | Comparison is always true because local <= 32767. |
-| Templates.cpp:9:10:9:24 | ... <= ... | Comparison is always true because local <= 32767. |
 | Templates.cpp:9:10:9:24 | ... <= ... | Comparison is always true because local <= 32767. |

--- a/cpp/ql/test/query-tests/Likely Bugs/Arithmetic/PointlessComparison/PointlessComparison.expected
+++ b/cpp/ql/test/query-tests/Likely Bugs/Arithmetic/PointlessComparison/PointlessComparison.expected
@@ -32,3 +32,7 @@
 | PointlessComparison.c:129:12:129:16 | ... > ... | Comparison is always false because a <= 3. |
 | PointlessComparison.c:197:7:197:11 | ... < ... | Comparison is always false because x >= 0. |
 | RegressionTests.cpp:57:7:57:22 | ... <= ... | Comparison is always true because * ... <= 4294967295. |
+| Templates.cpp:3:10:3:24 | ... <= ... | Comparison is always true because param <= 32767. |
+| Templates.cpp:9:10:9:24 | ... <= ... | Comparison is always true because local <= 32767. |
+| Templates.cpp:9:10:9:24 | ... <= ... | Comparison is always true because local <= 32767. |
+| Templates.cpp:9:10:9:24 | ... <= ... | Comparison is always true because local <= 32767. |

--- a/cpp/ql/test/query-tests/Likely Bugs/Arithmetic/PointlessComparison/Templates.cpp
+++ b/cpp/ql/test/query-tests/Likely Bugs/Arithmetic/PointlessComparison/Templates.cpp
@@ -1,6 +1,6 @@
 template<typename T>
 bool sometimesPointless(T param) {
-  return param <= 0xFFFF; // GOOD (FALSE POSITIVE: hypothetical instantiations are okay)
+  return param <= 0xFFFF; // GOOD (hypothetical instantiations are okay)
 }
 
 template<typename T>

--- a/cpp/ql/test/query-tests/Likely Bugs/Arithmetic/PointlessComparison/Templates.cpp
+++ b/cpp/ql/test/query-tests/Likely Bugs/Arithmetic/PointlessComparison/Templates.cpp
@@ -1,0 +1,17 @@
+template<typename T>
+bool sometimesPointless(T param) {
+  return param <= 0xFFFF; // GOOD (FALSE POSITIVE: hypothetical instantiations are okay)
+}
+
+template<typename T>
+bool alwaysPointless(T param) {
+  short local = param;
+  return local <= 0xFFFF; // BAD (in all instantiations)
+}
+
+static int caller(int i) {
+  return
+      sometimesPointless<short>(i) ||
+      alwaysPointless<short>(i) ||
+      alwaysPointless<int>(i);
+}


### PR DESCRIPTION
See CPP-274 and https://discuss.lgtm.com/t/false-positive-for-comparison-is-always-true/1312