### PR TITLE
C++: Make cpp/missing-return visible on LGTM again

### DIFF
--- a/change-notes/1.19/analysis-cpp.md
+++ b/change-notes/1.19/analysis-cpp.md
@@ -14,6 +14,7 @@
 |----------------------------|------------------------|------------------------------------------------------------------|
 | Resource not released in destructor | Fewer false positive results | Placement new is now excluded from the query. |
 | Wrong type of arguments to formatting function | Fewer false positive results | False positive results involving typedefs have been removed. |
+| Missing return statement (`cpp/missing-return`) | Visible by default | The precision of this query has been increased from 'medium' to 'high', which makes it visible by default in LGTM. It was 'medium' in release 1.17 and 1.18 because it had false positives due to an extractor bug that was fixed in 1.18. |
 
 ## Changes to QL libraries
 

--- a/cpp/ql/src/jsf/4.13 Functions/AV Rule 114.ql
+++ b/cpp/ql/src/jsf/4.13 Functions/AV Rule 114.ql
@@ -3,7 +3,7 @@
  * @description All functions that are not void should return a value on every exit path.
  * @kind problem
  * @problem.severity error
- * @precision medium
+ * @precision high
  * @id cpp/missing-return
  * @tags reliability
  *       readability


### PR DESCRIPTION
This is for effectively reverting the workarounds in internal PR 26316 (change note in PR 26319) since PR 27166 fixed the underlying issue. See also CPP-217.