### PR TITLE
Workaround for getFullyConverted returning multiple results.

### DIFF
--- a/cpp/ql/src/semmle/code/cpp/valuenumbering/GlobalValueNumbering.qll
+++ b/cpp/ql/src/semmle/code/cpp/valuenumbering/GlobalValueNumbering.qll
@@ -312,7 +312,7 @@ private predicate analyzableLocalScopeVariable(VariableAccess access) {
   strictcount (SsaDefinition def, Variable v | def.getAUse(v) = access | v) = 1 and
   count (SsaDefinition def, Variable v
   | def.getAUse(v) = access
-  | def.getDefiningValue(v)) <= 1 and
+  | def.getDefiningValue(v).getFullyConverted()) <= 1 and
   not analyzableConst(access)
 }
 


### PR DESCRIPTION
It seems that `getFullyConverted` sometimes returns more than one result, which causes GlobalValueNumbering to produce a huge number of results.