### PR TITLE
C++: Speed up primitive basic block calculation

### DIFF
--- a/cpp/ql/src/semmle/code/cpp/controlflow/internal/PrimitiveBasicBlocks.qll
+++ b/cpp/ql/src/semmle/code/cpp/controlflow/internal/PrimitiveBasicBlocks.qll
@@ -31,8 +31,11 @@ private cached module Cached {
     // or the node's predecessor has more than one successor,
     // then the node is the start of a new primitive basic block.
     or
-    strictcount (Node pred, Node other
-    | successors_extended(pred,node) and successors_extended(pred,other)) > 1
+    strictcount(Node pred | successors_extended(pred, node)) > 1
+    or
+    exists(ControlFlowNode pred | successors_extended(pred, node) |
+      strictcount(ControlFlowNode other | successors_extended(pred, other)) > 1
+    )
 
     // If the node has zero predecessors then it is the start of
     // a BB. However, the C++ AST contains many nodes with zero

--- a/cpp/ql/src/semmle/code/cpp/controlflow/internal/PrimitiveBasicBlocks.qll
+++ b/cpp/ql/src/semmle/code/cpp/controlflow/internal/PrimitiveBasicBlocks.qll
@@ -66,8 +66,14 @@ private cached module Cached {
   /** Holds if `node` is the `pos`th control-flow node in primitive basic block `bb`. */
   cached
   predicate primitive_basic_block_member(Node node, PrimitiveBasicBlock bb, int pos) {
-    pos = getMemberIndex(node) and
-    member_step*(bb, node)
+    primitive_basic_block_entry_node(bb) and
+    (
+      pos = 0 and
+      node = bb
+      or
+      pos = getMemberIndex(node) and
+      member_step+(bb, node)
+    )
   }
 
   /** Gets the number of control-flow nodes in the primitive basic block `bb`. */


### PR DESCRIPTION
This is an attempt to fix the timeouts we've seen in Dashboards/Internal in the last few days. I'm aiming this at 1.18.1 because the second commit fixes a regression introduced in #123 that might affect customers -- see the discussion in CPP-279.

The first commit is not a regression fix but should be Nice To Have. I've tested it for correctness by comparing the output of `select strictcount(PrimitiveBasicBlock b)` before and after. The implementation is ported from the Java basic-blocks library.