### PR TITLE
CPP: Fix WrongTypeFormatArguments.ql char16_t * issues (and others)

### DIFF
--- a/change-notes/1.19/analysis-cpp.md
+++ b/change-notes/1.19/analysis-cpp.md
@@ -13,8 +13,8 @@
 | **Query**                  | **Expected impact**    | **Change**                                                       |
 |----------------------------|------------------------|------------------------------------------------------------------|
 | Resource not released in destructor | Fewer false positive results | Placement new is now excluded from the query. |
-| Wrong type of arguments to formatting function | Fewer false positive results | False positive results involving typedefs have been removed. |
 | Missing return statement (`cpp/missing-return`) | Visible by default | The precision of this query has been increased from 'medium' to 'high', which makes it visible by default in LGTM. It was 'medium' in release 1.17 and 1.18 because it had false positives due to an extractor bug that was fixed in 1.18. |
+| Wrong type of arguments to formatting function | Fewer false positive results | False positive results involving typedefs have been removed.  Expected argument types are determined more accurately, especially for wide string and pointer types.  Custom (non-standard) formatting functions are also identified more accurately. |
 
 ## Changes to QL libraries
 

--- a/cpp/ql/src/Likely Bugs/Format/WrongTypeFormatArguments.ql
+++ b/cpp/ql/src/Likely Bugs/Format/WrongTypeFormatArguments.ql
@@ -25,7 +25,8 @@ private predicate formattingFunctionCallExpectedType(FormattingFunctionCall ffc,
       ffc.getTarget() = f and
       f.getFormatParameterIndex() = i and
       ffc.getArgument(i) = fl and
-      fl.getConversionType(pos) = expected
+      fl.getConversionType(pos) = expected and
+      count(fl.getConversionType(pos)) = 1
     )
 }
 

--- a/cpp/ql/src/semmle/code/cpp/commons/Printf.qll
+++ b/cpp/ql/src/semmle/code/cpp/commons/Printf.qll
@@ -28,6 +28,15 @@ class AttributeFormattingFunction extends FormattingFunction {
   }
 }
 
+Type getAPrimitiveVariadicFormatterWideType() {
+  exists(TopLevelFunction f, int formatParamIndex |
+    primitiveVariadicFormatter(f, formatParamIndex, true) and
+    result = f.getParameter(formatParamIndex).getType().getUnspecifiedType() and
+    result.(PointerType).getBaseType().getSize() != 1 and
+    f.hasDefinition()
+  )
+}
+
 /**
  * A standard function such as `vprintf` that has a format parameter
  * and a variable argument list of type `va_arg`.
@@ -722,7 +731,13 @@ class FormatLiteral extends Literal {
 
   private Type getConversionType5(int n) {
     exists(string cnv | cnv = this.getEffectiveStringConversionChar(n) |
-      cnv="S" and result.(PointerType).getBaseType().hasName("wchar_t") 
+      cnv="S" and
+      (
+        result = getAPrimitiveVariadicFormatterWideType()
+        or
+        not exists(getAPrimitiveVariadicFormatterWideType()) and
+        result.(PointerType).getBaseType().hasName("wchar_t")
+      )
     )
   }
 

--- a/cpp/ql/src/semmle/code/cpp/commons/Printf.qll
+++ b/cpp/ql/src/semmle/code/cpp/commons/Printf.qll
@@ -28,6 +28,10 @@ class AttributeFormattingFunction extends FormattingFunction {
   }
 }
 
+/**
+ * A type that is used as a format string by a wide variadic formatter such as
+ * `vwprintf`.
+ */
 Type getAPrimitiveVariadicFormatterWideType() {
   exists(TopLevelFunction f, int formatParamIndex |
     primitiveVariadicFormatter(f, formatParamIndex, true) and

--- a/cpp/ql/src/semmle/code/cpp/commons/Printf.qll
+++ b/cpp/ql/src/semmle/code/cpp/commons/Printf.qll
@@ -30,14 +30,20 @@ class AttributeFormattingFunction extends FormattingFunction {
 
 /**
  * A type that is used as a format string by a wide variadic formatter such as
- * `vwprintf`.
+ * `vwprintf` or by a user-defined formatting function with the GNU `format`
+ * attribute.
  */
-Type getAPrimitiveVariadicFormatterWideType() {
+Type getAFormatterWideType() {
   exists(TopLevelFunction f, int formatParamIndex |
     primitiveVariadicFormatter(f, formatParamIndex, true) and
     result = f.getParameter(formatParamIndex).getType().getUnspecifiedType() and
     result.(PointerType).getBaseType().getSize() != 1 and
     f.hasDefinition()
+  )
+  or
+  exists(AttributeFormattingFunction f, int formatParamIndex |
+    result = f.getParameter(formatParamIndex).getType().getUnspecifiedType() and
+    result.(PointerType).getBaseType().getSize() != 1
   )
 }
 
@@ -737,9 +743,9 @@ class FormatLiteral extends Literal {
     exists(string cnv | cnv = this.getEffectiveStringConversionChar(n) |
       cnv="S" and
       (
-        result = getAPrimitiveVariadicFormatterWideType()
+        result = getAFormatterWideType()
         or
-        not exists(getAPrimitiveVariadicFormatterWideType()) and
+        not exists(getAFormatterWideType()) and
         result.(PointerType).getBaseType().hasName("wchar_t")
       )
     )

--- a/cpp/ql/src/semmle/code/cpp/commons/Printf.qll
+++ b/cpp/ql/src/semmle/code/cpp/commons/Printf.qll
@@ -29,25 +29,6 @@ class AttributeFormattingFunction extends FormattingFunction {
 }
 
 /**
- * A type that is used as a format string by a wide variadic formatter such as
- * `vwprintf` or by a user-defined formatting function with the GNU `format`
- * attribute.
- */
-Type getAFormatterWideType() {
-  exists(TopLevelFunction f, int formatParamIndex |
-    primitiveVariadicFormatter(f, formatParamIndex, true) and
-    result = f.getParameter(formatParamIndex).getType().getUnspecifiedType() and
-    result.(PointerType).getBaseType().getSize() != 1 and
-    f.hasDefinition()
-  )
-  or
-  exists(AttributeFormattingFunction f, int formatParamIndex |
-    result = f.getParameter(formatParamIndex).getType().getUnspecifiedType() and
-    result.(PointerType).getBaseType().getSize() != 1
-  )
-}
-
-/**
  * A standard function such as `vprintf` that has a format parameter
  * and a variable argument list of type `va_arg`.
  */

--- a/cpp/ql/src/semmle/code/cpp/models/implementations/Printf.qll
+++ b/cpp/ql/src/semmle/code/cpp/models/implementations/Printf.qll
@@ -203,7 +203,7 @@ class Syslog extends FormattingFunction {
     this instanceof TopLevelFunction and (
       hasGlobalName("syslog")
     ) and
-    not hasDefinition()
+    not exists(getDefinition().getFile().getRelativePath())
   }
 
   override int getFormatParameterIndex() { result=1 }

--- a/cpp/ql/src/semmle/code/cpp/models/implementations/Printf.qll
+++ b/cpp/ql/src/semmle/code/cpp/models/implementations/Printf.qll
@@ -13,7 +13,7 @@ class Printf extends FormattingFunction {
       hasGlobalName("wprintf_s") or
       hasGlobalName("g_printf")
     ) and
-    not hasDefinition()
+    not exists(getADeclarationEntry().getFile().getRelativePath())
   }
 
   override int getFormatParameterIndex() { result=0 }
@@ -34,7 +34,7 @@ class Fprintf extends FormattingFunction {
       hasGlobalName("fwprintf") or
       hasGlobalName("g_fprintf")
     ) and
-    not hasDefinition()
+    not exists(getADeclarationEntry().getFile().getRelativePath())
   }
 
   override int getFormatParameterIndex() { result=1 }
@@ -57,7 +57,7 @@ class Sprintf extends FormattingFunction {
       hasGlobalName("g_sprintf") or
       hasGlobalName("__builtin___sprintf_chk")
     ) and
-    not hasDefinition()
+    not exists(getADeclarationEntry().getFile().getRelativePath())
   }
 
   override predicate isWideCharDefault() {
@@ -111,7 +111,7 @@ class Snprintf extends FormattingFunction {
       or hasGlobalName("wnsprintf")
       or hasGlobalName("__builtin___snprintf_chk")
     ) and
-    not hasDefinition()
+    not exists(getADeclarationEntry().getFile().getRelativePath())
   }
 
   override int getFormatParameterIndex() {
@@ -150,7 +150,7 @@ class Snprintf extends FormattingFunction {
       hasGlobalName("__builtin___snprintf_chk") or
       hasGlobalName("snprintf_s")
     ) and
-    not hasDefinition()
+    not exists(getADeclarationEntry().getFile().getRelativePath())
   }
 
   override int getSizeParameterIndex() {
@@ -173,7 +173,7 @@ class StringCchPrintf extends FormattingFunction {
       or hasGlobalName("StringCbPrintf_l")
       or hasGlobalName("StringCbPrintf_lEx")
     ) and
-    not hasDefinition()
+    not exists(getADeclarationEntry().getFile().getRelativePath())
   }
 
   override int getFormatParameterIndex() {

--- a/cpp/ql/src/semmle/code/cpp/models/implementations/Printf.qll
+++ b/cpp/ql/src/semmle/code/cpp/models/implementations/Printf.qll
@@ -12,7 +12,8 @@ class Printf extends FormattingFunction {
       hasGlobalName("wprintf") or
       hasGlobalName("wprintf_s") or
       hasGlobalName("g_printf")
-    )
+    ) and
+    not hasDefinition()
   }
 
   override int getFormatParameterIndex() { result=0 }
@@ -26,7 +27,15 @@ class Printf extends FormattingFunction {
  * The standard functions `fprintf`, `fwprintf` and their glib variants.
  */
 class Fprintf extends FormattingFunction {
-  Fprintf() { this instanceof TopLevelFunction and (hasGlobalName("fprintf") or hasGlobalName("fwprintf") or hasGlobalName("g_fprintf"))}
+  Fprintf() {
+    this instanceof TopLevelFunction and
+    (
+      hasGlobalName("fprintf") or
+      hasGlobalName("fwprintf") or
+      hasGlobalName("g_fprintf")
+    ) and
+    not hasDefinition()
+  }
 
   override int getFormatParameterIndex() { result=1 }
   override predicate isWideCharDefault() { hasGlobalName("fwprintf") }
@@ -47,7 +56,8 @@ class Sprintf extends FormattingFunction {
       hasGlobalName("g_strdup_printf") or
       hasGlobalName("g_sprintf") or
       hasGlobalName("__builtin___sprintf_chk")
-    )
+    ) and
+    not hasDefinition()
   }
 
   override predicate isWideCharDefault() {
@@ -100,7 +110,8 @@ class Snprintf extends FormattingFunction {
       or hasGlobalName("g_snprintf")
       or hasGlobalName("wnsprintf")
       or hasGlobalName("__builtin___snprintf_chk")
-    )
+    ) and
+    not hasDefinition()
   }
 
   override int getFormatParameterIndex() {
@@ -133,10 +144,13 @@ class Snprintf extends FormattingFunction {
    * in the buffer.
    */
   predicate returnsFullFormatLength() {
-    hasGlobalName("snprintf") or
-    hasGlobalName("g_snprintf") or
-    hasGlobalName("__builtin___snprintf_chk") or
-    hasGlobalName("snprintf_s")
+    (
+      hasGlobalName("snprintf") or
+      hasGlobalName("g_snprintf") or
+      hasGlobalName("__builtin___snprintf_chk") or
+      hasGlobalName("snprintf_s")
+    ) and
+    not hasDefinition()
   }
 
   override int getSizeParameterIndex() {
@@ -158,7 +172,8 @@ class StringCchPrintf extends FormattingFunction {
       or hasGlobalName("StringCbPrintfEx")
       or hasGlobalName("StringCbPrintf_l")
       or hasGlobalName("StringCbPrintf_lEx")
-    )
+    ) and
+    not hasDefinition()
   }
 
   override int getFormatParameterIndex() {
@@ -187,7 +202,8 @@ class Syslog extends FormattingFunction {
   Syslog() {
     this instanceof TopLevelFunction and (
       hasGlobalName("syslog")
-    )
+    ) and
+    not hasDefinition()
   }
 
   override int getFormatParameterIndex() { result=1 }

--- a/cpp/ql/src/semmle/code/cpp/models/implementations/Printf.qll
+++ b/cpp/ql/src/semmle/code/cpp/models/implementations/Printf.qll
@@ -13,7 +13,7 @@ class Printf extends FormattingFunction {
       hasGlobalName("wprintf_s") or
       hasGlobalName("g_printf")
     ) and
-    not exists(getADeclarationEntry().getFile().getRelativePath())
+    not exists(getDefinition().getFile().getRelativePath())
   }
 
   override int getFormatParameterIndex() { result=0 }
@@ -34,7 +34,7 @@ class Fprintf extends FormattingFunction {
       hasGlobalName("fwprintf") or
       hasGlobalName("g_fprintf")
     ) and
-    not exists(getADeclarationEntry().getFile().getRelativePath())
+    not exists(getDefinition().getFile().getRelativePath())
   }
 
   override int getFormatParameterIndex() { result=1 }
@@ -57,7 +57,7 @@ class Sprintf extends FormattingFunction {
       hasGlobalName("g_sprintf") or
       hasGlobalName("__builtin___sprintf_chk")
     ) and
-    not exists(getADeclarationEntry().getFile().getRelativePath())
+    not exists(getDefinition().getFile().getRelativePath())
   }
 
   override predicate isWideCharDefault() {
@@ -111,7 +111,7 @@ class Snprintf extends FormattingFunction {
       or hasGlobalName("wnsprintf")
       or hasGlobalName("__builtin___snprintf_chk")
     ) and
-    not exists(getADeclarationEntry().getFile().getRelativePath())
+    not exists(getDefinition().getFile().getRelativePath())
   }
 
   override int getFormatParameterIndex() {
@@ -150,7 +150,7 @@ class Snprintf extends FormattingFunction {
       hasGlobalName("__builtin___snprintf_chk") or
       hasGlobalName("snprintf_s")
     ) and
-    not exists(getADeclarationEntry().getFile().getRelativePath())
+    not exists(getDefinition().getFile().getRelativePath())
   }
 
   override int getSizeParameterIndex() {
@@ -173,7 +173,7 @@ class StringCchPrintf extends FormattingFunction {
       or hasGlobalName("StringCbPrintf_l")
       or hasGlobalName("StringCbPrintf_lEx")
     ) and
-    not exists(getADeclarationEntry().getFile().getRelativePath())
+    not exists(getDefinition().getFile().getRelativePath())
   }
 
   override int getFormatParameterIndex() {

--- a/cpp/ql/src/semmle/code/cpp/models/interfaces/FormattingFunction.qll
+++ b/cpp/ql/src/semmle/code/cpp/models/interfaces/FormattingFunction.qll
@@ -21,10 +21,9 @@ private Type stripTopLevelSpecifiersOnly(Type t) {
  * A type that is used as a format string by any formatting function.
  */
 Type getAFormatterWideType() {
-  exists(FormattingFunction ff, Type t |
-    t = stripTopLevelSpecifiersOnly(ff.getDefaultCharType()) and
-    t.getSize() != 1 and
-    result.(PointerType).getBaseType() = t
+  exists(FormattingFunction ff |
+    result = stripTopLevelSpecifiersOnly(ff.getDefaultCharType()) and
+    result.getSize() != 1
   )
 }
 
@@ -33,9 +32,9 @@ Type getAFormatterWideType() {
  * there is none.
  */
 private Type getAFormatterWideTypeOrDefault() {
-  result = getAFormatterWideType().(PointerType).getBaseType() or
+  result = getAFormatterWideType() or
   (
-    not exists(getAFormatterWideType().(PointerType).getBaseType()) and
+    not exists(getAFormatterWideType()) and
     result instanceof Wchar_t
   )
 }

--- a/cpp/ql/src/semmle/code/cpp/models/interfaces/FormattingFunction.qll
+++ b/cpp/ql/src/semmle/code/cpp/models/interfaces/FormattingFunction.qll
@@ -8,6 +8,18 @@
 
 import semmle.code.cpp.Function
 /**
+ * A type that is used as a format string by any formatting function, or `wchar_t` if
+ * there is none.
+ */
+private Type getAFormatterWideTypeOrDefault() {
+  result = getAFormatterWideType().(PointerType).getBaseType() or
+  (
+    not exists(getAFormatterWideType().(PointerType).getBaseType()) and
+    result instanceof Wchar_t
+  )
+}
+
+/**
  * A standard library function that uses a `printf`-like formatting string.
  */
 abstract class FormattingFunction extends Function {
@@ -19,6 +31,43 @@ abstract class FormattingFunction extends Function {
    * a `char *` (either way, `%S` will have the opposite meaning).
    */
   predicate isWideCharDefault() { none() }
+
+  /**
+   * Gets the default character type expected for `%s` by this function.  Typically
+   * `char` or `wchar_t`.
+   */
+  Type getDefaultCharType() {
+    result = getParameter(getFormatParameterIndex()).getType().
+      getUnderlyingType().(PointerType).getBaseType().stripTopLevelSpecifiers()
+  }
+
+  /**
+   * Gets the non-default character type expected for `%S` by this function.  Typically
+   * `wchar_t` or `char`.  On some snapshots there may be multiple results where we can't tell
+   * which is correct for a particular function.
+   */
+  Type getNonDefaultCharType() {
+  	(
+  	  getDefaultCharType().getSize() = 1 and
+  	  result = getAFormatterWideTypeOrDefault()
+  	) or (
+  	  getDefaultCharType().getSize() > 1 and
+  	  result instanceof PlainCharType
+  	)
+  }
+
+  /**
+   * Gets the wide character type for this function.  This is usually `wchar_t`.  On some
+   * snapshots there may be multiple results where we can't tell which is correct for a
+   * particular function.
+   */
+  Type getWideCharType() {
+    (
+      result = getDefaultCharType() or
+      result = getNonDefaultCharType()
+    ) and
+    result.getSize() > 1
+  }
 
   /**
    * Gets the position at which the output parameter, if any, occurs.

--- a/cpp/ql/src/semmle/code/cpp/models/interfaces/FormattingFunction.qll
+++ b/cpp/ql/src/semmle/code/cpp/models/interfaces/FormattingFunction.qll
@@ -19,6 +19,15 @@ private Type getAFormatterWideTypeOrDefault() {
   )
 }
 
+private Type stripTopLevelSpecifiersOnly(Type t) {
+  (
+    result = stripTopLevelSpecifiersOnly(t.(SpecifiedType).getBaseType())
+  ) or (
+    result = t and
+    not t instanceof SpecifiedType
+  )
+}
+
 /**
  * A standard library function that uses a `printf`-like formatting string.
  */
@@ -37,8 +46,8 @@ abstract class FormattingFunction extends Function {
    * `char` or `wchar_t`.
    */
   Type getDefaultCharType() {
-    result = getParameter(getFormatParameterIndex()).getType().
-      getUnderlyingType().(PointerType).getBaseType().stripTopLevelSpecifiers()
+    result = stripTopLevelSpecifiersOnly(getParameter(getFormatParameterIndex()).getType().
+      getUnderlyingType().(PointerType).getBaseType())
   }
 
   /**

--- a/cpp/ql/src/semmle/code/cpp/models/interfaces/FormattingFunction.qll
+++ b/cpp/ql/src/semmle/code/cpp/models/interfaces/FormattingFunction.qll
@@ -7,6 +7,27 @@
  */
 
 import semmle.code.cpp.Function
+
+private Type stripTopLevelSpecifiersOnly(Type t) {
+  (
+    result = stripTopLevelSpecifiersOnly(t.(SpecifiedType).getBaseType())
+  ) or (
+    result = t and
+    not t instanceof SpecifiedType
+  )
+}
+
+/**
+ * A type that is used as a format string by any formatting function.
+ */
+Type getAFormatterWideType() {
+  exists(FormattingFunction ff, Type t |
+    t = stripTopLevelSpecifiersOnly(ff.getDefaultCharType()) and
+    t.getSize() != 1 and
+    result.(PointerType).getBaseType() = t
+  )
+}
+
 /**
  * A type that is used as a format string by any formatting function, or `wchar_t` if
  * there is none.
@@ -16,15 +37,6 @@ private Type getAFormatterWideTypeOrDefault() {
   (
     not exists(getAFormatterWideType().(PointerType).getBaseType()) and
     result instanceof Wchar_t
-  )
-}
-
-private Type stripTopLevelSpecifiersOnly(Type t) {
-  (
-    result = stripTopLevelSpecifiersOnly(t.(SpecifiedType).getBaseType())
-  ) or (
-    result = t and
-    not t instanceof SpecifiedType
   )
 }
 

--- a/cpp/ql/test/query-tests/Likely Bugs/Format/WrongNumberOfFormatArguments/TooManyFormatArguments.expected
+++ b/cpp/ql/test/query-tests/Likely Bugs/Format/WrongNumberOfFormatArguments/TooManyFormatArguments.expected
@@ -1,5 +1,4 @@
 | custom_printf.cpp:31:5:31:12 | call to myPrintf | Format expects 2 arguments but given 3 |
-| custom_printf.cpp:44:2:44:7 | call to printf | Format expects 0 arguments but given 2 |
 | macros.cpp:12:2:12:31 | call to printf | Format expects 2 arguments but given 3 |
 | macros.cpp:16:2:16:30 | call to printf | Format expects 2 arguments but given 3 |
 | test.c:7:2:7:7 | call to printf | Format expects 0 arguments but given 1 |

--- a/cpp/ql/test/query-tests/Likely Bugs/Format/WrongNumberOfFormatArguments/WrongNumberOfFormatArguments.expected
+++ b/cpp/ql/test/query-tests/Likely Bugs/Format/WrongNumberOfFormatArguments/WrongNumberOfFormatArguments.expected
@@ -1,5 +1,4 @@
 | custom_printf.cpp:29:5:29:12 | call to myPrintf | Format expects 2 arguments but given 1 |
-| custom_printf.cpp:45:2:45:7 | call to printf | Format expects 2 arguments but given 0 |
 | macros.cpp:14:2:14:37 | call to printf | Format expects 4 arguments but given 3 |
 | macros.cpp:21:2:21:36 | call to printf | Format expects 4 arguments but given 3 |
 | test.c:9:2:9:7 | call to printf | Format expects 1 arguments but given 0 |

--- a/cpp/ql/test/query-tests/Likely Bugs/Format/WrongNumberOfFormatArguments/custom_printf.cpp
+++ b/cpp/ql/test/query-tests/Likely Bugs/Format/WrongNumberOfFormatArguments/custom_printf.cpp
@@ -41,6 +41,6 @@ void test_custom_printf2()
 {
 	//     notTheFormat  format    ...
 	printf(0,            "%i %i",  100, 200); // GOOD
-	printf("",           "%i %i",  100, 200); // GOOD [FALSE POSITIVE]
-	printf("%i %i",      ""        );         // GOOD [FALSE POSITIVE]
+	printf("",           "%i %i",  100, 200); // GOOD
+	printf("%i %i",      ""        );         // GOOD
 }

--- a/cpp/ql/test/query-tests/Likely Bugs/Format/WrongTypeFormatArguments/Linux_mixed_byte_wprintf/WrongTypeFormatArguments.expected
+++ b/cpp/ql/test/query-tests/Likely Bugs/Format/WrongTypeFormatArguments/Linux_mixed_byte_wprintf/WrongTypeFormatArguments.expected
@@ -1,7 +1,9 @@
 | tests.cpp:18:15:18:22 | Hello | This argument should be of type 'char *' but is of type 'char16_t *' |
 | tests.cpp:19:15:19:22 | Hello | This argument should be of type 'char *' but is of type 'wchar_t *' |
+| tests.cpp:21:15:21:21 | Hello | This argument should be of type 'char16_t *' but is of type 'char *' |
 | tests.cpp:21:15:21:21 | Hello | This argument should be of type 'wchar_t *' but is of type 'char *' |
 | tests.cpp:22:15:22:22 | Hello | This argument should be of type 'wchar_t *' but is of type 'char16_t *' |
+| tests.cpp:23:15:23:22 | Hello | This argument should be of type 'char16_t *' but is of type 'wchar_t *' |
 | tests.cpp:25:17:25:23 | Hello | This argument should be of type 'wchar_t *' but is of type 'char *' |
 | tests.cpp:26:17:26:24 | Hello | This argument should be of type 'wchar_t *' but is of type 'char16_t *' |
 | tests.cpp:30:17:30:24 | Hello | This argument should be of type 'char *' but is of type 'char16_t *' |

--- a/cpp/ql/test/query-tests/Likely Bugs/Format/WrongTypeFormatArguments/Linux_mixed_byte_wprintf/WrongTypeFormatArguments.expected
+++ b/cpp/ql/test/query-tests/Likely Bugs/Format/WrongTypeFormatArguments/Linux_mixed_byte_wprintf/WrongTypeFormatArguments.expected
@@ -1,9 +1,5 @@
 | tests.cpp:18:15:18:22 | Hello | This argument should be of type 'char *' but is of type 'char16_t *' |
 | tests.cpp:19:15:19:22 | Hello | This argument should be of type 'char *' but is of type 'wchar_t *' |
-| tests.cpp:21:15:21:21 | Hello | This argument should be of type 'char16_t *' but is of type 'char *' |
-| tests.cpp:21:15:21:21 | Hello | This argument should be of type 'wchar_t *' but is of type 'char *' |
-| tests.cpp:22:15:22:22 | Hello | This argument should be of type 'wchar_t *' but is of type 'char16_t *' |
-| tests.cpp:23:15:23:22 | Hello | This argument should be of type 'char16_t *' but is of type 'wchar_t *' |
 | tests.cpp:25:17:25:23 | Hello | This argument should be of type 'wchar_t *' but is of type 'char *' |
 | tests.cpp:26:17:26:24 | Hello | This argument should be of type 'wchar_t *' but is of type 'char16_t *' |
 | tests.cpp:30:17:30:24 | Hello | This argument should be of type 'char *' but is of type 'char16_t *' |

--- a/cpp/ql/test/query-tests/Likely Bugs/Format/WrongTypeFormatArguments/Linux_mixed_byte_wprintf/WrongTypeFormatArguments.expected
+++ b/cpp/ql/test/query-tests/Likely Bugs/Format/WrongTypeFormatArguments/Linux_mixed_byte_wprintf/WrongTypeFormatArguments.expected
@@ -1,0 +1,12 @@
+| tests.cpp:18:15:18:22 | Hello | This argument should be of type 'char *' but is of type 'char16_t *' |
+| tests.cpp:19:15:19:22 | Hello | This argument should be of type 'char *' but is of type 'wchar_t *' |
+| tests.cpp:21:15:21:21 | Hello | This argument should be of type 'wchar_t *' but is of type 'char *' |
+| tests.cpp:22:15:22:22 | Hello | This argument should be of type 'wchar_t *' but is of type 'char16_t *' |
+| tests.cpp:25:17:25:23 | Hello | This argument should be of type 'wchar_t *' but is of type 'char *' |
+| tests.cpp:26:17:26:24 | Hello | This argument should be of type 'wchar_t *' but is of type 'char16_t *' |
+| tests.cpp:30:17:30:24 | Hello | This argument should be of type 'char *' but is of type 'char16_t *' |
+| tests.cpp:31:17:31:24 | Hello | This argument should be of type 'char *' but is of type 'wchar_t *' |
+| tests.cpp:33:36:33:42 | Hello | This argument should be of type 'wchar_t *' but is of type 'char *' |
+| tests.cpp:34:36:34:43 | Hello | This argument should be of type 'wchar_t *' but is of type 'char16_t *' |
+| tests.cpp:38:36:38:43 | Hello | This argument should be of type 'char *' but is of type 'char16_t *' |
+| tests.cpp:39:36:39:43 | Hello | This argument should be of type 'char *' but is of type 'wchar_t *' |

--- a/cpp/ql/test/query-tests/Likely Bugs/Format/WrongTypeFormatArguments/Linux_mixed_byte_wprintf/WrongTypeFormatArguments.expected
+++ b/cpp/ql/test/query-tests/Likely Bugs/Format/WrongTypeFormatArguments/Linux_mixed_byte_wprintf/WrongTypeFormatArguments.expected
@@ -6,7 +6,7 @@
 | tests.cpp:26:17:26:24 | Hello | This argument should be of type 'wchar_t *' but is of type 'char16_t *' |
 | tests.cpp:30:17:30:24 | Hello | This argument should be of type 'char *' but is of type 'char16_t *' |
 | tests.cpp:31:17:31:24 | Hello | This argument should be of type 'char *' but is of type 'wchar_t *' |
-| tests.cpp:33:36:33:42 | Hello | This argument should be of type 'wchar_t *' but is of type 'char *' |
-| tests.cpp:34:36:34:43 | Hello | This argument should be of type 'wchar_t *' but is of type 'char16_t *' |
+| tests.cpp:33:36:33:42 | Hello | This argument should be of type 'char16_t *' but is of type 'char *' |
+| tests.cpp:35:36:35:43 | Hello | This argument should be of type 'char16_t *' but is of type 'wchar_t *' |
 | tests.cpp:38:36:38:43 | Hello | This argument should be of type 'char *' but is of type 'char16_t *' |
 | tests.cpp:39:36:39:43 | Hello | This argument should be of type 'char *' but is of type 'wchar_t *' |

--- a/cpp/ql/test/query-tests/Likely Bugs/Format/WrongTypeFormatArguments/Linux_mixed_byte_wprintf/WrongTypeFormatArguments.qlref
+++ b/cpp/ql/test/query-tests/Likely Bugs/Format/WrongTypeFormatArguments/Linux_mixed_byte_wprintf/WrongTypeFormatArguments.qlref
@@ -1,0 +1,1 @@
+Likely Bugs/Format/WrongTypeFormatArguments.ql

--- a/cpp/ql/test/query-tests/Likely Bugs/Format/WrongTypeFormatArguments/Linux_mixed_byte_wprintf/formattingFunction.expected
+++ b/cpp/ql/test/query-tests/Likely Bugs/Format/WrongTypeFormatArguments/Linux_mixed_byte_wprintf/formattingFunction.expected
@@ -1,3 +1,3 @@
-| tests.cpp:8:5:8:10 | printf | char | wchar_t | wchar_t |
+| tests.cpp:8:5:8:10 | printf | char | char16_t, wchar_t | char16_t, wchar_t |
 | tests.cpp:9:5:9:11 | wprintf | wchar_t | char | wchar_t |
 | tests.cpp:10:5:10:12 | swprintf | char16_t | char | char16_t |

--- a/cpp/ql/test/query-tests/Likely Bugs/Format/WrongTypeFormatArguments/Linux_mixed_byte_wprintf/formattingFunction.expected
+++ b/cpp/ql/test/query-tests/Likely Bugs/Format/WrongTypeFormatArguments/Linux_mixed_byte_wprintf/formattingFunction.expected
@@ -1,0 +1,3 @@
+| tests.cpp:8:5:8:10 | printf | char | wchar_t | wchar_t |
+| tests.cpp:9:5:9:11 | wprintf | wchar_t | char | wchar_t |
+| tests.cpp:10:5:10:12 | swprintf | char16_t | char | char16_t |

--- a/cpp/ql/test/query-tests/Likely Bugs/Format/WrongTypeFormatArguments/Linux_mixed_byte_wprintf/formattingFunction.ql
+++ b/cpp/ql/test/query-tests/Likely Bugs/Format/WrongTypeFormatArguments/Linux_mixed_byte_wprintf/formattingFunction.ql
@@ -1,0 +1,8 @@
+import cpp
+
+from FormattingFunction f
+select
+  f,
+  concat(f.getDefaultCharType().toString(), ", "),
+  concat(f.getNonDefaultCharType().toString(), ", "),
+  concat(f.getWideCharType().toString(), ", ")

--- a/cpp/ql/test/query-tests/Likely Bugs/Format/WrongTypeFormatArguments/Linux_mixed_byte_wprintf/tests.cpp
+++ b/cpp/ql/test/query-tests/Likely Bugs/Format/WrongTypeFormatArguments/Linux_mixed_byte_wprintf/tests.cpp
@@ -18,9 +18,9 @@ void tests() {
 	printf("%s", u"Hello"); // BAD: expecting char
 	printf("%s", L"Hello"); // BAD: expecting char
 
-	printf("%S", "Hello"); // BAD: expecting wchar_t or char16_t
-	printf("%S", u"Hello"); // GOOD [FALSE POSITIVE]
-	printf("%S", L"Hello"); // GOOD [FALSE POSITIVE]
+	printf("%S", "Hello"); // BAD: expecting wchar_t or char16_t [NOT DETECTED]
+	printf("%S", u"Hello"); // GOOD
+	printf("%S", L"Hello"); // GOOD
 
 	wprintf(L"%s", "Hello"); // BAD: expecting wchar_t
 	wprintf(L"%s", u"Hello"); // BAD: expecting wchar_t

--- a/cpp/ql/test/query-tests/Likely Bugs/Format/WrongTypeFormatArguments/Linux_mixed_byte_wprintf/tests.cpp
+++ b/cpp/ql/test/query-tests/Likely Bugs/Format/WrongTypeFormatArguments/Linux_mixed_byte_wprintf/tests.cpp
@@ -31,8 +31,8 @@ void tests() {
 	wprintf(L"%S", L"Hello"); // BAD: expecting char
 
 	swprintf(buffer, BUF_SIZE, u"%s", "Hello"); // BAD: expecting char16_t
-	swprintf(buffer, BUF_SIZE, u"%s", u"Hello"); // GOOD [FALSE POSITIVE]
-	swprintf(buffer, BUF_SIZE, u"%s", L"Hello"); // BAD: expecting char16_t [NOT DETECTED]
+	swprintf(buffer, BUF_SIZE, u"%s", u"Hello"); // GOOD
+	swprintf(buffer, BUF_SIZE, u"%s", L"Hello"); // BAD: expecting char16_t
 
 	swprintf(buffer, BUF_SIZE, u"%S", "Hello"); // GOOD
 	swprintf(buffer, BUF_SIZE, u"%S", u"Hello"); // BAD: expecting char

--- a/cpp/ql/test/query-tests/Likely Bugs/Format/WrongTypeFormatArguments/Linux_mixed_byte_wprintf/tests.cpp
+++ b/cpp/ql/test/query-tests/Likely Bugs/Format/WrongTypeFormatArguments/Linux_mixed_byte_wprintf/tests.cpp
@@ -20,7 +20,7 @@ void tests() {
 
 	printf("%S", "Hello"); // BAD: expecting wchar_t or char16_t
 	printf("%S", u"Hello"); // GOOD [FALSE POSITIVE]
-	printf("%S", L"Hello"); // GOOD
+	printf("%S", L"Hello"); // GOOD [FALSE POSITIVE]
 
 	wprintf(L"%s", "Hello"); // BAD: expecting wchar_t
 	wprintf(L"%s", u"Hello"); // BAD: expecting wchar_t

--- a/cpp/ql/test/query-tests/Likely Bugs/Format/WrongTypeFormatArguments/Linux_mixed_byte_wprintf/tests.cpp
+++ b/cpp/ql/test/query-tests/Likely Bugs/Format/WrongTypeFormatArguments/Linux_mixed_byte_wprintf/tests.cpp
@@ -1,0 +1,40 @@
+/*
+ * Test for custom definitions of *wprintf using different types than the
+ * platform wide character type.
+ */
+
+typedef unsigned int size_t;
+
+int printf(const char * format, ...);
+int wprintf(const wchar_t * format, ...); // on wchar_t
+int swprintf(char16_t * s, size_t n, const char16_t * format, ...); // on char16_t
+
+#define BUF_SIZE (4096)
+
+void tests() {
+	char16_t buffer[BUF_SIZE];
+
+	printf("%s", "Hello"); // GOOD
+	printf("%s", u"Hello"); // BAD: expecting char
+	printf("%s", L"Hello"); // BAD: expecting char
+
+	printf("%S", "Hello"); // BAD: expecting wchar_t or char16_t
+	printf("%S", u"Hello"); // GOOD [FALSE POSITIVE]
+	printf("%S", L"Hello"); // GOOD
+
+	wprintf(L"%s", "Hello"); // BAD: expecting wchar_t
+	wprintf(L"%s", u"Hello"); // BAD: expecting wchar_t
+	wprintf(L"%s", L"Hello"); // GOOD
+
+	wprintf(L"%S", "Hello"); // GOOD
+	wprintf(L"%S", u"Hello"); // BAD: expecting char
+	wprintf(L"%S", L"Hello"); // BAD: expecting char
+
+	swprintf(buffer, BUF_SIZE, u"%s", "Hello"); // BAD: expecting char16_t
+	swprintf(buffer, BUF_SIZE, u"%s", u"Hello"); // GOOD [FALSE POSITIVE]
+	swprintf(buffer, BUF_SIZE, u"%s", L"Hello"); // BAD: expecting char16_t [NOT DETECTED]
+
+	swprintf(buffer, BUF_SIZE, u"%S", "Hello"); // GOOD
+	swprintf(buffer, BUF_SIZE, u"%S", u"Hello"); // BAD: expecting char
+	swprintf(buffer, BUF_SIZE, u"%S", L"Hello"); // BAD: expecting char
+}

--- a/cpp/ql/test/query-tests/Likely Bugs/Format/WrongTypeFormatArguments/Linux_mixed_word_size/WrongTypeFormatArguments.expected
+++ b/cpp/ql/test/query-tests/Likely Bugs/Format/WrongTypeFormatArguments/Linux_mixed_word_size/WrongTypeFormatArguments.expected
@@ -1,0 +1,4 @@
+| tests_32.cpp:14:16:14:23 | void_ptr | This argument should be of type 'long' but is of type 'void *' |
+| tests_32.cpp:15:15:15:15 | l | This argument should be of type 'void *' but is of type 'long' |
+| tests_64.cpp:14:16:14:23 | void_ptr | This argument should be of type 'long' but is of type 'void *' |
+| tests_64.cpp:15:15:15:15 | l | This argument should be of type 'void *' but is of type 'long' |

--- a/cpp/ql/test/query-tests/Likely Bugs/Format/WrongTypeFormatArguments/Linux_mixed_word_size/WrongTypeFormatArguments.expected
+++ b/cpp/ql/test/query-tests/Likely Bugs/Format/WrongTypeFormatArguments/Linux_mixed_word_size/WrongTypeFormatArguments.expected
@@ -1,4 +1,2 @@
 | tests_32.cpp:14:16:14:23 | void_ptr | This argument should be of type 'long' but is of type 'void *' |
-| tests_32.cpp:15:15:15:15 | l | This argument should be of type 'void *' but is of type 'long' |
 | tests_64.cpp:14:16:14:23 | void_ptr | This argument should be of type 'long' but is of type 'void *' |
-| tests_64.cpp:15:15:15:15 | l | This argument should be of type 'void *' but is of type 'long' |

--- a/cpp/ql/test/query-tests/Likely Bugs/Format/WrongTypeFormatArguments/Linux_mixed_word_size/WrongTypeFormatArguments.qlref
+++ b/cpp/ql/test/query-tests/Likely Bugs/Format/WrongTypeFormatArguments/Linux_mixed_word_size/WrongTypeFormatArguments.qlref
@@ -1,0 +1,1 @@
+Likely Bugs/Format/WrongTypeFormatArguments.ql

--- a/cpp/ql/test/query-tests/Likely Bugs/Format/WrongTypeFormatArguments/Linux_mixed_word_size/tests_32.cpp
+++ b/cpp/ql/test/query-tests/Likely Bugs/Format/WrongTypeFormatArguments/Linux_mixed_word_size/tests_32.cpp
@@ -1,0 +1,17 @@
+// semmle-extractor-options: --edg --target --edg linux_i686
+/*
+ * Test for printf in a snapshot that contains multiple word/pointer sizes.
+ */
+
+int printf(const char * format, ...);
+
+void test_32()
+{
+	long l;
+	void *void_ptr;
+
+	printf("%li", l); // GOOD
+	printf("%li", void_ptr); // BAD
+	printf("%p", l); // BAD
+	printf("%p", void_ptr); // GOOD
+}

--- a/cpp/ql/test/query-tests/Likely Bugs/Format/WrongTypeFormatArguments/Linux_mixed_word_size/tests_32.cpp
+++ b/cpp/ql/test/query-tests/Likely Bugs/Format/WrongTypeFormatArguments/Linux_mixed_word_size/tests_32.cpp
@@ -12,6 +12,6 @@ void test_32()
 
 	printf("%li", l); // GOOD
 	printf("%li", void_ptr); // BAD
-	printf("%p", l); // BAD
+	printf("%p", l); // BAD [NOT DETECTED]
 	printf("%p", void_ptr); // GOOD
 }

--- a/cpp/ql/test/query-tests/Likely Bugs/Format/WrongTypeFormatArguments/Linux_mixed_word_size/tests_64.cpp
+++ b/cpp/ql/test/query-tests/Likely Bugs/Format/WrongTypeFormatArguments/Linux_mixed_word_size/tests_64.cpp
@@ -1,0 +1,17 @@
+// semmle-extractor-options: --edg --target --edg linux_x86_64
+/*
+ * Test for printf in a snapshot that contains multiple word/pointer sizes.
+ */
+
+int printf(const char * format, ...);
+
+void test_64()
+{
+	long l;
+	void *void_ptr;
+
+	printf("%li", l); // GOOD
+	printf("%li", void_ptr); // BAD
+	printf("%p", l); // BAD
+	printf("%p", void_ptr); // GOOD
+}

--- a/cpp/ql/test/query-tests/Likely Bugs/Format/WrongTypeFormatArguments/Linux_mixed_word_size/tests_64.cpp
+++ b/cpp/ql/test/query-tests/Likely Bugs/Format/WrongTypeFormatArguments/Linux_mixed_word_size/tests_64.cpp
@@ -12,6 +12,6 @@ void test_64()
 
 	printf("%li", l); // GOOD
 	printf("%li", void_ptr); // BAD
-	printf("%p", l); // BAD
+	printf("%p", l); // BAD [NOT DETECTED]
 	printf("%p", void_ptr); // GOOD
 }

--- a/cpp/ql/test/query-tests/Likely Bugs/Format/WrongTypeFormatArguments/Linux_two_byte_wprintf/WrongTypeFormatArguments.expected
+++ b/cpp/ql/test/query-tests/Likely Bugs/Format/WrongTypeFormatArguments/Linux_two_byte_wprintf/WrongTypeFormatArguments.expected
@@ -1,0 +1,2 @@
+| printf.cpp:43:29:43:35 | test | This argument should be of type 'char *' but is of type 'char16_t *' |
+| printf.cpp:50:29:50:35 | test | This argument should be of type 'char16_t *' but is of type 'wchar_t *' |

--- a/cpp/ql/test/query-tests/Likely Bugs/Format/WrongTypeFormatArguments/Linux_two_byte_wprintf/WrongTypeFormatArguments.expected
+++ b/cpp/ql/test/query-tests/Likely Bugs/Format/WrongTypeFormatArguments/Linux_two_byte_wprintf/WrongTypeFormatArguments.expected
@@ -1,2 +1,2 @@
-| printf.cpp:43:29:43:35 | test | This argument should be of type 'char *' but is of type 'char16_t *' |
-| printf.cpp:50:29:50:35 | test | This argument should be of type 'char16_t *' but is of type 'wchar_t *' |
+| printf.cpp:45:29:45:35 | test | This argument should be of type 'char *' but is of type 'char16_t *' |
+| printf.cpp:52:29:52:35 | test | This argument should be of type 'char16_t *' but is of type 'wchar_t *' |

--- a/cpp/ql/test/query-tests/Likely Bugs/Format/WrongTypeFormatArguments/Linux_two_byte_wprintf/WrongTypeFormatArguments.qlref
+++ b/cpp/ql/test/query-tests/Likely Bugs/Format/WrongTypeFormatArguments/Linux_two_byte_wprintf/WrongTypeFormatArguments.qlref
@@ -1,0 +1,1 @@
+Likely Bugs/Format/WrongTypeFormatArguments.ql

--- a/cpp/ql/test/query-tests/Likely Bugs/Format/WrongTypeFormatArguments/Linux_two_byte_wprintf/formattingFunction.expected
+++ b/cpp/ql/test/query-tests/Likely Bugs/Format/WrongTypeFormatArguments/Linux_two_byte_wprintf/formattingFunction.expected
@@ -1,0 +1,2 @@
+| printf.cpp:15:5:15:12 | swprintf | char16_t | char | char16_t |
+| printf.cpp:26:5:26:11 | sprintf | char | char16_t | char16_t |

--- a/cpp/ql/test/query-tests/Likely Bugs/Format/WrongTypeFormatArguments/Linux_two_byte_wprintf/formattingFunction.ql
+++ b/cpp/ql/test/query-tests/Likely Bugs/Format/WrongTypeFormatArguments/Linux_two_byte_wprintf/formattingFunction.ql
@@ -1,0 +1,8 @@
+import cpp
+
+from FormattingFunction f
+select
+  f,
+  concat(f.getDefaultCharType().toString(), ", "),
+  concat(f.getNonDefaultCharType().toString(), ", "),
+  concat(f.getWideCharType().toString(), ", ")

--- a/cpp/ql/test/query-tests/Likely Bugs/Format/WrongTypeFormatArguments/Linux_two_byte_wprintf/printf.cpp
+++ b/cpp/ql/test/query-tests/Likely Bugs/Format/WrongTypeFormatArguments/Linux_two_byte_wprintf/printf.cpp
@@ -1,0 +1,51 @@
+/*
+ * Test for custom definitions of *wprintf using different types than the
+ * platform wide character type.
+ */
+
+#define WCHAR char16_t
+typedef void *va_list;
+#define va_start(va, other)
+#define va_end(args)
+
+int	vswprintf(WCHAR *dest, WCHAR *format, va_list args) {
+	return 0;
+}
+
+int swprintf(WCHAR *dest, WCHAR *format, ...) {
+	va_list args;
+	va_start(args, format);
+
+	int ret = vswprintf(dest, format, args);
+
+	va_end(args);
+
+	return ret;
+}
+
+int sprintf(char *dest, char *format, ...);
+
+void test1() {
+	WCHAR string[20];
+
+	swprintf(string, u"test %s", u"test");
+}
+
+void test2() {
+	char string[20];
+
+	sprintf(string, "test %S", u"test");
+}
+
+void test3() {
+	char string[20];
+
+	sprintf(string, "test %s", u"test");
+}
+
+
+void test4() {
+	char string[20];
+
+	sprintf(string, "test %S", L"test");
+}

--- a/cpp/ql/test/query-tests/Likely Bugs/Format/WrongTypeFormatArguments/Linux_two_byte_wprintf/printf.cpp
+++ b/cpp/ql/test/query-tests/Likely Bugs/Format/WrongTypeFormatArguments/Linux_two_byte_wprintf/printf.cpp
@@ -25,27 +25,29 @@ int swprintf(WCHAR *dest, WCHAR *format, ...) {
 
 int sprintf(char *dest, char *format, ...);
 
+// ---
+
 void test1() {
 	WCHAR string[20];
 
-	swprintf(string, u"test %s", u"test");
+	swprintf(string, u"test %s", u"test"); // GOOD
 }
 
 void test2() {
 	char string[20];
 
-	sprintf(string, "test %S", u"test");
+	sprintf(string, "test %S", u"test"); // GOOD
 }
 
 void test3() {
 	char string[20];
 
-	sprintf(string, "test %s", u"test");
+	sprintf(string, "test %s", u"test"); // BAD: `char16_t` string parameter read as `char` string
 }
 
 
 void test4() {
 	char string[20];
 
-	sprintf(string, "test %S", L"test");
+	sprintf(string, "test %S", L"test"); // BAD: `wchar_t` string parameter read as `char16_t` string
 }

--- a/cpp/ql/test/query-tests/Likely Bugs/Format/WrongTypeFormatArguments/Linux_unsigned_chars/formattingFunction.expected
+++ b/cpp/ql/test/query-tests/Likely Bugs/Format/WrongTypeFormatArguments/Linux_unsigned_chars/formattingFunction.expected
@@ -1,0 +1,4 @@
+| common.h:12:12:12:17 | printf | char | wchar_t | wchar_t |
+| format.h:4:13:4:17 | error | char | wchar_t | wchar_t |
+| real_world.h:8:12:8:18 | fprintf | char | wchar_t | wchar_t |
+| real_world.h:33:6:33:12 | msg_out | char | wchar_t | wchar_t |

--- a/cpp/ql/test/query-tests/Likely Bugs/Format/WrongTypeFormatArguments/Linux_unsigned_chars/formattingFunction.ql
+++ b/cpp/ql/test/query-tests/Likely Bugs/Format/WrongTypeFormatArguments/Linux_unsigned_chars/formattingFunction.ql
@@ -1,0 +1,8 @@
+import cpp
+
+from FormattingFunction f
+select
+  f,
+  concat(f.getDefaultCharType().toString(), ", "),
+  concat(f.getNonDefaultCharType().toString(), ", "),
+  concat(f.getWideCharType().toString(), ", ")

--- a/cpp/ql/test/query-tests/Likely Bugs/Format/WrongTypeFormatArguments/Microsoft_no_wchar/WrongTypeFormatArguments.expected
+++ b/cpp/ql/test/query-tests/Likely Bugs/Format/WrongTypeFormatArguments/Microsoft_no_wchar/WrongTypeFormatArguments.expected
@@ -18,7 +18,6 @@
 | printf1.h:75:19:75:28 | sizeof(<expr>) | This argument should be of type 'ssize_t' but is of type 'unsigned long long' |
 | printf1.h:84:23:84:35 | ... - ... | This argument should be of type 'ssize_t' but is of type 'long long' |
 | printf1.h:130:18:130:18 | 0 | This argument should be of type 'void *' but is of type 'int' |
-| real_world.h:46:36:46:43 | filename | This argument should be of type 'wchar_t *' but is of type 'char16_t *' |
 | real_world.h:61:21:61:22 | & ... | This argument should be of type 'int *' but is of type 'short *' |
 | real_world.h:62:22:62:23 | & ... | This argument should be of type 'short *' but is of type 'int *' |
 | real_world.h:63:22:63:24 | & ... | This argument should be of type 'short *' but is of type 'unsigned int *' |

--- a/cpp/ql/test/query-tests/Likely Bugs/Format/WrongTypeFormatArguments/Microsoft_no_wchar/WrongTypeFormatArguments.expected
+++ b/cpp/ql/test/query-tests/Likely Bugs/Format/WrongTypeFormatArguments/Microsoft_no_wchar/WrongTypeFormatArguments.expected
@@ -17,6 +17,7 @@
 | printf1.h:74:19:74:22 | C_ST | This argument should be of type 'ssize_t' but is of type 'unsigned long long' |
 | printf1.h:75:19:75:28 | sizeof(<expr>) | This argument should be of type 'ssize_t' but is of type 'unsigned long long' |
 | printf1.h:84:23:84:35 | ... - ... | This argument should be of type 'ssize_t' but is of type 'long long' |
+| printf1.h:130:18:130:18 | 0 | This argument should be of type 'void *' but is of type 'int' |
 | real_world.h:46:36:46:43 | filename | This argument should be of type 'wchar_t *' but is of type 'char16_t *' |
 | real_world.h:61:21:61:22 | & ... | This argument should be of type 'int *' but is of type 'short *' |
 | real_world.h:62:22:62:23 | & ... | This argument should be of type 'short *' but is of type 'int *' |

--- a/cpp/ql/test/query-tests/Likely Bugs/Format/WrongTypeFormatArguments/Microsoft_no_wchar/printf1.h
+++ b/cpp/ql/test/query-tests/Likely Bugs/Format/WrongTypeFormatArguments/Microsoft_no_wchar/printf1.h
@@ -101,3 +101,31 @@ void fun1(unsigned char* a, unsigned char* b) {
   printf("%td\n", pdt); // GOOD
   printf("%td\n", a-b); // GOOD
 }
+
+typedef wchar_t WCHAR_T; // WCHAR_T -> wchar_t -> int
+typedef int MYCHAR; // MYCHAR -> int (notably not via the wchar_t typedef)
+
+void fun2() {
+  wchar_t *myString1;
+  WCHAR_T *myString2;
+  int *myString3;
+  MYCHAR *myString4;
+
+  printf("%S", myString1); // GOOD
+  printf("%S", myString2); // GOOD
+  printf("%S", myString3); // GOOD
+  printf("%S", myString4); // GOOD
+}
+
+typedef void *VOIDPTR;
+typedef int (*FUNPTR)(int);
+
+void fun3(void *p1, VOIDPTR p2, FUNPTR p3, char *p4)
+{
+  printf("%p\n", p1); // GOOD
+  printf("%p\n", p2); // GOOD
+  printf("%p\n", p3); // GOOD
+  printf("%p\n", p4); // GOOD
+  printf("%p\n", p4 + 1); // GOOD
+  printf("%p\n", 0); // GOOD [FALSE POSITIVE]
+}


### PR DESCRIPTION
Fix handling of wide string types in 'WrongTypeFormatArguments.ql'.  Previously they were assumed to always be `wchar_t *`, which lead to high numbers of false positive results on projects where, say, `char16_t *` strings are used.  Also fixed:
 - an issue where the query would get confused by a snapshot which had multiple types that naturally correspond with a single format character, for example (commonly) multiple pointer sizes and `%p`.
 - an issue where custom formatting functions were assumed to be built-in formatting functions due to exactly matching in name.

The first three commits are from an old pull request by @rdmarsh2, that was never merged due to concerns about mixing string types (which have been fixed here).

I have some smaller fixes to follow, but this PR should eliminate most of the false positives we've been looking at.

@jbj