### PR TITLE
CPP: Address Widechartype / WChar_t

### DIFF
--- a/cpp/ql/src/Likely Bugs/Format/NonConstantFormat.ql
+++ b/cpp/ql/src/Likely Bugs/Format/NonConstantFormat.ql
@@ -25,7 +25,7 @@ predicate stringType(Type t, Type charType) {
       charType = t.(ArrayType).getBaseType()
     ) and (
       charType.getUnspecifiedType() instanceof CharType or
-      charType.getUnspecifiedType() instanceof WideCharType
+      charType.getUnspecifiedType() instanceof Wchar_t
     )
   )
   or

--- a/cpp/ql/src/Security/CWE/CWE-676/DangerousUseOfCin.ql
+++ b/cpp/ql/src/Security/CWE/CWE-676/DangerousUseOfCin.ql
@@ -19,7 +19,7 @@ import cpp
 class AnyCharPointerType extends PointerType {
   AnyCharPointerType() {
     this.getBaseType().getUnderlyingType() instanceof CharType or
-    this.getBaseType().getUnderlyingType() instanceof WideCharType
+    this.getBaseType().getUnderlyingType() instanceof Wchar_t
   }
 }
 
@@ -29,7 +29,7 @@ class AnyCharPointerType extends PointerType {
 class AnyCharArrayType extends ArrayType {
   AnyCharArrayType() {
     this.getBaseType().getUnderlyingType() instanceof CharType or
-    this.getBaseType().getUnderlyingType() instanceof WideCharType
+    this.getBaseType().getUnderlyingType() instanceof Wchar_t
   }
 }
 

--- a/cpp/ql/src/semmle/code/cpp/Type.qll
+++ b/cpp/ql/src/semmle/code/cpp/Type.qll
@@ -601,6 +601,10 @@ class VoidType extends BuiltInType {
 
 /**
  * The C/C++ wide character type.
+ * 
+ * Note that on some platforms `wchar_t` doesn't exist as a built-in
+ * type but a typedef is provided.  Consider using the `Wchar_t` QL
+ * class to include these types.
  */
 class WideCharType extends IntegralType {
 

--- a/cpp/ql/src/semmle/code/cpp/commons/CommonType.qll
+++ b/cpp/ql/src/semmle/code/cpp/commons/CommonType.qll
@@ -80,6 +80,10 @@ class Uintmax_t extends Type {
 
 /**
  * The C/C++ wchar_t type.
+ *
+ * Note that on some platforms `wchar_t` doesn't exist as a built-in
+ * type but a typedef is provided.  This QL class includes both cases
+ * (see also `WideCharType`).
  */
 class Wchar_t extends Type {
   Wchar_t() {

--- a/cpp/ql/src/semmle/code/cpp/commons/CommonType.qll
+++ b/cpp/ql/src/semmle/code/cpp/commons/CommonType.qll
@@ -1,7 +1,7 @@
 import semmle.code.cpp.Type
 
 /**
- * The C/C++ char* type.
+ * The C/C++ `char*` type.
  */
 class CharPointerType extends PointerType {
 
@@ -10,7 +10,7 @@ class CharPointerType extends PointerType {
 }
 
 /**
- * The C/C++ int* type.
+ * The C/C++ `int*` type.
  */
 class IntPointerType extends PointerType {
 
@@ -20,7 +20,7 @@ class IntPointerType extends PointerType {
 
 
 /**
- * The C/C++ void* type.
+ * The C/C++ `void*` type.
  */
 class VoidPointerType extends PointerType {
 
@@ -29,7 +29,7 @@ class VoidPointerType extends PointerType {
 }
 
 /**
- * The C/C++ size_t type.
+ * The C/C++ `size_t` type.
  */
 class Size_t extends Type {
   Size_t() {
@@ -39,7 +39,7 @@ class Size_t extends Type {
 }
 
 /**
- * The C/C++ ssize_t type.
+ * The C/C++ `ssize_t` type.
  */
 class Ssize_t extends Type {
   Ssize_t() {
@@ -49,7 +49,7 @@ class Ssize_t extends Type {
 }
 
 /**
- * The C/C++ ptrdiff_t type.
+ * The C/C++ `ptrdiff_t` type.
  */
 class Ptrdiff_t extends Type {
   Ptrdiff_t() {
@@ -59,7 +59,7 @@ class Ptrdiff_t extends Type {
 }
 
 /**
- * The C/C++ intmax_t type.
+ * The C/C++ `intmax_t` type.
  */
 class Intmax_t extends Type {
   Intmax_t() {
@@ -69,7 +69,7 @@ class Intmax_t extends Type {
 }
 
 /**
- * The C/C++ uintmax_t type.
+ * The C/C++ `uintmax_t` type.
  */
 class Uintmax_t extends Type {
   Uintmax_t() {
@@ -79,7 +79,7 @@ class Uintmax_t extends Type {
 }
 
 /**
- * The C/C++ wchar_t type.
+ * The C/C++ `wchar_t` type.
  *
  * Note that on some platforms `wchar_t` doesn't exist as a built-in
  * type but a typedef is provided.  This QL class includes both cases


### PR DESCRIPTION
I noticed a few weeks ago that we have two very similar QL classes, 'WideCharType' and 'Wchar_t'.  This PR adds comments to clarify the difference, hinting that 'Wchar_t' is normally the right one to use.  I've also corrected some uses of 'WideCharType' where I believe it to be the wrong choice.

Investigative query at https://lgtm.com/query/1506594176863/.