### PR TITLE
JS: recognize binding decorators on classes

### DIFF
--- a/javascript/ql/src/Expressions/UnboundEventHandlerReceiver.ql
+++ b/javascript/ql/src/Expressions/UnboundEventHandlerReceiver.ql
@@ -45,7 +45,11 @@ private predicate isBoundInMethod(MethodDeclaration method) {
   )
   or
   exists (Expr decoration, string name |
-    decoration = method.getADecorator().getExpression() and
+    (
+      decoration = method.getADecorator().getExpression()
+      or
+      decoration = method.getDeclaringType().(ClassDefinition).getADecorator().getExpression()
+    ) and
     name.regexpMatch("(?i).*(bind|bound).*") |
     // @autobind
     decoration.(Identifier).getName() = name or

--- a/javascript/ql/test/query-tests/Expressions/UnboundEventHandlerReceiver/tst.js
+++ b/javascript/ql/test/query-tests/Expressions/UnboundEventHandlerReceiver/tst.js
@@ -120,4 +120,18 @@ class Component1 extends React.Component {
 
 }
 
+@autobind
+class Component2 extends React.Component {
+
+    render() {
+        return <div>
+            <div onClick={this.bound_throughClassDecorator_autobind}/> // OK
+            </div>;
+    }
+
+    bound_throughClassDecorator_autobind() {
+        this.setState({ });
+    }
+
+}
 // semmle-extractor-options: --experimental


### PR DESCRIPTION
Eliminates FPs like these: https://lgtm.com/projects/g/getinsomnia/insomnia/alerts?rule=js%2Funbound-event-handler-receiver&mode=tree&ruleFocus=1506001656023