### PR TITLE
JS: Canonicalize 'this' in the data-flow graph

### DIFF
--- a/change-notes/1.19/analysis-javascript.md
+++ b/change-notes/1.19/analysis-javascript.md
@@ -38,3 +38,5 @@
 * The flow configuration framework now supports distinguishing and tracking different kinds of taint, specified by an extensible class `FlowLabel` (which can also be referred to by its alias `TaintKind`).
 
 * The `DataFlow::ThisNode` class now corresponds to the implicit receiver parameter of a function, as opposed to an indivdual `this` expression. This means `getALocalSource` now maps all `this` expressions within a given function to the same source. The data-flow node associated with a `ThisExpr` can no longer be cast to `DataFlow::SourceNode` or `DataFlow::ThisNode` - it is recomended to use `getALocalSource` before casting or instead of casting.
+
+* `ReactComponent::getAThisAccess` has been renamed to `getAThisNode`. The old name is still usable but is deprecated. It no longer gets individual `this` expressions, but the `ThisNode` mentioned above.

--- a/change-notes/1.19/analysis-javascript.md
+++ b/change-notes/1.19/analysis-javascript.md
@@ -36,3 +36,5 @@
 ## Changes to QL libraries
 
 * The flow configuration framework now supports distinguishing and tracking different kinds of taint, specified by an extensible class `FlowLabel` (which can also be referred to by its alias `TaintKind`).
+
+* The `DataFlow::ThisNode` class now corresponds to the implicit receiver parameter of a function, as opposed to an indivdual `this` expression. This means `getALocalSource` now maps all `this` expressions within a given function to the same source. The data-flow node associated with a `ThisExpr` can no longer be cast to `DataFlow::SourceNode` or `DataFlow::ThisNode` - it is recomended to use `getALocalSource` before casting or instead of casting.

--- a/javascript/ql/src/semmle/javascript/Expr.qll
+++ b/javascript/ql/src/semmle/javascript/Expr.qll
@@ -303,6 +303,16 @@ class ThisExpr extends @thisexpr, Expr {
   Function getBinder() {
     result = getEnclosingFunction().getThisBinder()
   }
+
+  /**
+   * Gets the function or top-level whose `this` binding this expression refers to,
+   * which is the nearest enclosing non-arrow function or top-level.
+   */
+  StmtContainer getBindingContainer() {
+    result = getContainer().(Function).getThisBindingContainer()
+    or
+    result = getContainer().(TopLevel)
+  }
 }
 
 /** An array literal. */

--- a/javascript/ql/src/semmle/javascript/Functions.qll
+++ b/javascript/ql/src/semmle/javascript/Functions.qll
@@ -207,6 +207,17 @@ class Function extends @function, Parameterized, TypeParameterized, StmtContaine
   }
 
   /**
+   * Gets the function or top-level whose `this` binding a `this` expression in this function refers to,
+   * which is the nearest enclosing non-arrow function or top-level.
+   */
+  StmtContainer getThisBindingContainer() {
+    result = getThisBinder()
+    or
+    not exists(getThisBinder()) and
+    result = getTopLevel()
+  }
+
+  /**
    * Holds if this function has a mapped `arguments` variable whose indices are aliased
    * with the function's parameters.
    *

--- a/javascript/ql/src/semmle/javascript/StandardLibrary.qll
+++ b/javascript/ql/src/semmle/javascript/StandardLibrary.qll
@@ -62,9 +62,9 @@ class JsonParseCall extends MethodCallExpr {
  * However, since the function could be invoked in another way, we additionally
  * still infer the ordinary abstract value.
  */
-private class AnalyzedThisInArrayIterationFunction extends AnalyzedValueNode, DataFlow::ThisNode {
+private class AnalyzedThisInArrayIterationFunction extends AnalyzedNode, DataFlow::ThisNode {
 
-  AnalyzedValueNode thisSource;
+  AnalyzedNode thisSource;
 
   AnalyzedThisInArrayIterationFunction() {
     exists(DataFlow::MethodCallNode bindingCall, string name |
@@ -82,7 +82,7 @@ private class AnalyzedThisInArrayIterationFunction extends AnalyzedValueNode, Da
 
   override AbstractValue getALocalValue() {
     result = thisSource.getALocalValue() or
-    result = AnalyzedValueNode.super.getALocalValue()
+    result = AnalyzedNode.super.getALocalValue()
   }
 
 }

--- a/javascript/ql/src/semmle/javascript/dataflow/DataFlow.qll
+++ b/javascript/ql/src/semmle/javascript/dataflow/DataFlow.qll
@@ -32,6 +32,7 @@ module DataFlow {
   or TReflectiveCallNode(MethodCallExpr ce, string kind) {
        ce.getMethodName() = kind and (kind = "call" or kind = "apply")
      }
+  or TThisNode(StmtContainer f) { f.(Function).getThisBinder() = f or f instanceof TopLevel }
 
   /**
    * A node in the data flow graph.
@@ -868,6 +869,13 @@ module DataFlow {
   }
 
   /**
+   * INTERNAL: Use `thisNode(StmtContainer container)` instead.
+   */
+  predicate thisNode(DataFlow::Node node, StmtContainer container) {
+    node = TThisNode(container)
+  }
+
+  /**
    * A classification of flows that are not modeled, or only modeled incompletely, by
    * `DataFlowNode`:
    *
@@ -970,6 +978,11 @@ module DataFlow {
       pred = valueNode(defSourceNode(def)) and
       succ = TDestructuringPatternNode(def.getTarget())
     )
+    or
+    // flow from 'this' parameter into 'this' expressions
+    exists (ThisExpr thiz |
+      pred = TThisNode(thiz.getBindingContainer()) and
+      succ = valueNode(thiz))
   }
 
   /**

--- a/javascript/ql/src/semmle/javascript/dataflow/Nodes.qll
+++ b/javascript/ql/src/semmle/javascript/dataflow/Nodes.qll
@@ -198,16 +198,36 @@ class NewNode extends InvokeNode {
   override DataFlow::Impl::NewNodeDef impl;
 }
 
-/** A data flow node corresponding to a `this` expression. */
-class ThisNode extends DataFlow::ValueNode, DataFlow::DefaultSourceNode {
-  override ThisExpr astNode;
+/** A data flow node corresponding to the `this` parameter in a function or `this` at the top-level. */
+class ThisNode extends DataFlow::Node, DataFlow::DefaultSourceNode {
+  ThisNode() {
+    DataFlow::thisNode(this, _)
+  }
 
   /**
    * Gets the function whose `this` binding this expression refers to,
    * which is the nearest enclosing non-arrow function.
    */
   FunctionNode getBinder() {
-    result = DataFlow::valueNode(astNode.getBinder())
+    exists (Function binder |
+      DataFlow::thisNode(this, binder) and
+      result = DataFlow::valueNode(binder))
+  }
+
+  /**
+   * Gets the function or top-level whose `this` binding this expression refers to,
+   * which is the nearest enclosing non-arrow function or top-level.
+   */
+  StmtContainer getBindingContainer() {
+    DataFlow::thisNode(this, result)
+  }
+
+  override string toString() { result = "this" }
+
+  override predicate hasLocationInfo(string filepath, int startline, int startcolumn,
+                                     int endline, int endcolumn) {
+    // Use the function entry as the location
+    getBindingContainer().getEntry().getLocation().hasLocationInfo(filepath, startline, startcolumn, endline, endcolumn)
   }
 }
 

--- a/javascript/ql/src/semmle/javascript/dataflow/Sources.qll
+++ b/javascript/ql/src/semmle/javascript/dataflow/Sources.qll
@@ -185,7 +185,6 @@ class DefaultSourceNode extends SourceNode {
       astNode instanceof ObjectExpr or
       astNode instanceof ArrayExpr or
       astNode instanceof JSXNode or
-      astNode instanceof ThisExpr or
       astNode instanceof GlobalVarAccess or
       astNode instanceof ExternalModuleReference
     )
@@ -198,5 +197,7 @@ class DefaultSourceNode extends SourceNode {
     DataFlow::parameterNode(this, _)
     or
     this instanceof DataFlow::Impl::InvokeNodeDef
+    or
+    DataFlow::thisNode(this, _)
   }
 }

--- a/javascript/ql/src/semmle/javascript/dataflow/internal/InterProceduralTypeInference.qll
+++ b/javascript/ql/src/semmle/javascript/dataflow/internal/InterProceduralTypeInference.qll
@@ -10,7 +10,7 @@ import AbstractValuesImpl
 /**
  * Flow analysis for `this` expressions inside functions.
  */
-private abstract class AnalyzedThisExpr extends DataFlow::AnalyzedValueNode, DataFlow::ThisNode {
+private abstract class AnalyzedThisExpr extends DataFlow::AnalyzedNode, DataFlow::ThisNode {
   DataFlow::FunctionNode binder;
 
   AnalyzedThisExpr() {
@@ -29,7 +29,7 @@ private abstract class AnalyzedThisExpr extends DataFlow::AnalyzedValueNode, Dat
  */
 private class AnalyzedThisInBoundFunction extends AnalyzedThisExpr {
 
-  AnalyzedValueNode thisSource;
+  AnalyzedNode thisSource;
 
   AnalyzedThisInBoundFunction() {
     exists(string name |

--- a/javascript/ql/src/semmle/javascript/frameworks/LodashUnderscore.qll
+++ b/javascript/ql/src/semmle/javascript/frameworks/LodashUnderscore.qll
@@ -27,9 +27,9 @@ module LodashUnderscore {
  * However, since the function could be invoked in another way, we additionally
  * still infer the ordinary abstract value.
  */
-private class AnalyzedThisInBoundCallback extends AnalyzedValueNode, DataFlow::ThisNode {
+private class AnalyzedThisInBoundCallback extends AnalyzedNode, DataFlow::ThisNode {
 
-  AnalyzedValueNode thisSource;
+  AnalyzedNode thisSource;
 
   AnalyzedThisInBoundCallback() {
     exists(DataFlow::CallNode bindingCall, string binderName, int callbackIndex, int contextIndex, int argumentCount |
@@ -128,7 +128,7 @@ private class AnalyzedThisInBoundCallback extends AnalyzedValueNode, DataFlow::T
 
   override AbstractValue getALocalValue() {
     result = thisSource.getALocalValue() or
-    result = AnalyzedValueNode.super.getALocalValue()
+    result = AnalyzedNode.super.getALocalValue()
   }
 
 }

--- a/javascript/ql/src/semmle/javascript/frameworks/React.qll
+++ b/javascript/ql/src/semmle/javascript/frameworks/React.qll
@@ -515,9 +515,9 @@ private class FactoryDefinition extends ReactElementDefinition {
  * However, since the function could be invoked in another way, we additionally
  * still infer the ordinary abstract value.
  */
-private class AnalyzedThisInBoundCallback extends AnalyzedValueNode, DataFlow::ThisNode {
+private class AnalyzedThisInBoundCallback extends AnalyzedNode, DataFlow::ThisNode {
 
-  AnalyzedValueNode thisSource;
+  AnalyzedNode thisSource;
 
   AnalyzedThisInBoundCallback() {
     exists(DataFlow::CallNode bindingCall, string binderName |
@@ -533,7 +533,7 @@ private class AnalyzedThisInBoundCallback extends AnalyzedValueNode, DataFlow::T
 
   override AbstractValue getALocalValue() {
     result = thisSource.getALocalValue() or
-    result = AnalyzedValueNode.super.getALocalValue()
+    result = AnalyzedNode.super.getALocalValue()
   }
 
 }

--- a/javascript/ql/src/semmle/javascript/frameworks/React.qll
+++ b/javascript/ql/src/semmle/javascript/frameworks/React.qll
@@ -52,10 +52,10 @@ abstract class ReactComponent extends ASTNode {
   }
 
   /**
-   * Gets a `this` access in an instance method of this component.
+   * Gets the `this` node in an instance method of this component.
    */
   DataFlow::SourceNode getAThisAccess() {
-    result.asExpr().(ThisExpr).getBinder() = getInstanceMethod(_)
+    result.(DataFlow::ThisNode).getBinder().getFunction() = getInstanceMethod(_)
   }
 
   /**

--- a/javascript/ql/src/semmle/javascript/frameworks/React.qll
+++ b/javascript/ql/src/semmle/javascript/frameworks/React.qll
@@ -54,8 +54,18 @@ abstract class ReactComponent extends ASTNode {
   /**
    * Gets the `this` node in an instance method of this component.
    */
-  DataFlow::SourceNode getAThisAccess() {
+  DataFlow::SourceNode getAThisNode() {
     result.(DataFlow::ThisNode).getBinder().getFunction() = getInstanceMethod(_)
+  }
+
+  /**
+   * Gets the `this` node in an instance method of this component.
+   *
+   * DEPRECATED: Use `getAThisNode` instead.
+   */
+  deprecated
+  DataFlow::SourceNode getAThisAccess() {
+    result = getAThisNode()
   }
 
   /**

--- a/javascript/ql/test/library-tests/DataFlow/flowStep.expected
+++ b/javascript/ql/test/library-tests/DataFlow/flowStep.expected
@@ -76,6 +76,7 @@
 | tst.js:37:5:42:1 | o | tst.js:83:23:83:23 | o |
 | tst.js:37:5:42:1 | o | tst.js:85:23:85:23 | o |
 | tst.js:37:9:42:1 | {\\n  x:  ... ;\\n  }\\n} | tst.js:37:5:42:1 | o |
+| tst.js:39:4:39:3 | this | tst.js:40:5:40:8 | this |
 | tst.js:46:10:46:11 | "" | tst.js:46:1:46:11 | global = "" |
 | tst.js:49:1:54:1 | A | tst.js:55:1:55:1 | A |
 | tst.js:49:1:54:1 | class A ... `\\n  }\\n} | tst.js:49:1:54:1 | A |

--- a/javascript/ql/test/library-tests/DataFlow/sources.expected
+++ b/javascript/ql/test/library-tests/DataFlow/sources.expected
@@ -1,14 +1,20 @@
+| eval.js:1:1:1:0 | this |
+| eval.js:1:1:1:0 | this |
 | eval.js:1:1:5:1 | functio ... eval`\\n} |
 | eval.js:3:3:3:6 | eval |
 | eval.js:3:3:3:16 | eval("x = 23") |
+| sources.js:1:1:1:0 | this |
 | sources.js:1:1:1:12 | new (x => x) |
 | sources.js:1:6:1:6 | x |
 | sources.js:1:6:1:11 | x => x |
 | sources.js:3:1:5:6 | (functi ... \\n})(23) |
+| sources.js:3:2:3:1 | this |
 | sources.js:3:2:5:1 | functio ... x+19;\\n} |
 | sources.js:3:11:3:11 | x |
+| tst.js:1:1:1:0 | this |
 | tst.js:1:10:1:11 | fs |
 | tst.js:16:1:20:9 | (functi ... ("arg") |
+| tst.js:16:2:16:1 | this |
 | tst.js:16:2:20:1 | functio ... n "";\\n} |
 | tst.js:16:13:16:13 | a |
 | tst.js:17:7:17:10 | Math |
@@ -17,11 +23,12 @@
 | tst.js:22:7:22:18 | readFileSync |
 | tst.js:28:1:30:3 | (() =>\\n ... les\\n)() |
 | tst.js:28:2:29:3 | () =>\\n  x |
+| tst.js:32:1:32:0 | this |
 | tst.js:32:1:34:1 | functio ... ables\\n} |
 | tst.js:35:1:35:7 | g(true) |
 | tst.js:37:9:42:1 | {\\n  x:  ... ;\\n  }\\n} |
+| tst.js:39:4:39:3 | this |
 | tst.js:39:4:41:3 | () {\\n    this;\\n  } |
-| tst.js:40:5:40:8 | this |
 | tst.js:43:1:43:3 | o.x |
 | tst.js:44:1:44:3 | o.m |
 | tst.js:44:1:44:5 | o.m() |
@@ -29,18 +36,22 @@
 | tst.js:47:1:47:6 | global |
 | tst.js:49:1:54:1 | class A ... `\\n  }\\n} |
 | tst.js:49:17:49:17 | B |
+| tst.js:50:14:50:13 | this |
 | tst.js:50:14:53:3 | () {\\n   ... et`\\n  } |
 | tst.js:51:5:51:13 | super(42) |
 | tst.js:58:1:58:3 | tag |
 | tst.js:61:3:61:5 | o.m |
+| tst.js:64:1:64:0 | this |
 | tst.js:64:1:67:1 | functio ... lysed\\n} |
 | tst.js:68:12:68:14 | h() |
 | tst.js:69:1:69:9 | iter.next |
 | tst.js:69:1:69:13 | iter.next(23) |
+| tst.js:71:1:71:0 | this |
 | tst.js:71:1:73:1 | async f ... lysed\\n} |
 | tst.js:72:9:72:9 | p |
 | tst.js:72:9:72:11 | p() |
 | tst.js:87:1:96:2 | (functi ... r: 0\\n}) |
+| tst.js:87:2:87:1 | this |
 | tst.js:87:2:92:1 | functio ...  + z;\\n} |
 | tst.js:87:11:87:24 | { p: x, ...o } |
 | tst.js:87:13:87:16 | p: x |
@@ -49,6 +60,7 @@
 | tst.js:90:6:90:9 | r: z |
 | tst.js:92:4:96:1 | {\\n  p:  ...  r: 0\\n} |
 | tst.js:98:1:103:17 | (functi ... 3, 0 ]) |
+| tst.js:98:2:98:1 | this |
 | tst.js:98:2:103:1 | functio ...  + z;\\n} |
 | tst.js:98:11:98:24 | [ x, ...rest ] |
 | tst.js:98:13:98:13 | x |
@@ -56,7 +68,9 @@
 | tst.js:99:9:99:9 | y |
 | tst.js:101:7:101:7 | z |
 | tst.js:103:4:103:16 | [ 19, 23, 0 ] |
+| tst.ts:1:1:1:0 | this |
 | tst.ts:3:3:3:8 | setX() |
+| tst.ts:7:1:7:0 | this |
 | tst.ts:7:1:9:1 | functio ... = 23;\\n} |
 | tst.ts:8:3:8:5 | A.x |
 | tst.ts:11:11:11:13 | A.x |
@@ -65,3 +79,4 @@
 | tst.ts:13:39:13:38 | (...arg ... rgs); } |
 | tst.ts:13:39:13:38 | args |
 | tst.ts:13:39:13:38 | super(...args) |
+| tst.ts:13:39:13:38 | this |

--- a/javascript/ql/test/library-tests/Nodes/globalObjectRef.expected
+++ b/javascript/ql/test/library-tests/Nodes/globalObjectRef.expected
@@ -1,10 +1,10 @@
+| tst2.js:1:1:1:0 | this |
 | tst2.js:1:9:1:25 | require("global") |
 | tst2.js:3:1:3:24 | require ... indow") |
 | tst2.js:7:1:7:6 | global |
 | tst2.js:8:1:8:6 | global |
-| tst2.js:9:1:9:4 | this |
+| tst.js:1:1:1:0 | this |
 | tst.js:1:1:1:6 | window |
-| tst.js:2:1:2:4 | this |
 | tst.js:3:1:3:6 | window |
 | tst.js:4:1:4:6 | window |
 | tst.js:4:1:4:13 | window.window |

--- a/javascript/ql/test/library-tests/PropWrite/getAPropertyRead.expected
+++ b/javascript/ql/test/library-tests/PropWrite/getAPropertyRead.expected
@@ -1,8 +1,8 @@
+| tst.js:1:1:1:0 | this | tst.js:23:15:23:29 | this.someMethod |
+| tst.js:1:1:1:0 | this | tst.js:24:36:24:45 | this.state |
 | tst.js:14:5:14:11 | console | tst.js:14:5:14:15 | console.log |
 | tst.js:17:5:17:11 | console | tst.js:17:5:17:15 | console.log |
-| tst.js:23:15:23:18 | this | tst.js:23:15:23:29 | this.someMethod |
 | tst.js:23:15:23:29 | this.someMethod | tst.js:23:15:23:34 | this.someMethod.bind |
-| tst.js:24:36:24:39 | this | tst.js:24:36:24:45 | this.state |
 | tst.js:24:36:24:45 | this.state | tst.js:24:36:24:50 | this.state.name |
 | tst.js:34:6:34:7 | vv | tst.js:34:6:34:10 | vv.pp |
 | tst.js:35:6:35:8 | vvv | tst.js:35:6:35:12 | vvv.ppp |

--- a/javascript/ql/test/library-tests/PropWrite/getAPropertyRead2.expected
+++ b/javascript/ql/test/library-tests/PropWrite/getAPropertyRead2.expected
@@ -1,8 +1,8 @@
+| tst.js:1:1:1:0 | this | someMethod | tst.js:23:15:23:29 | this.someMethod |
+| tst.js:1:1:1:0 | this | state | tst.js:24:36:24:45 | this.state |
 | tst.js:14:5:14:11 | console | log | tst.js:14:5:14:15 | console.log |
 | tst.js:17:5:17:11 | console | log | tst.js:17:5:17:15 | console.log |
-| tst.js:23:15:23:18 | this | someMethod | tst.js:23:15:23:29 | this.someMethod |
 | tst.js:23:15:23:29 | this.someMethod | bind | tst.js:23:15:23:34 | this.someMethod.bind |
-| tst.js:24:36:24:39 | this | state | tst.js:24:36:24:45 | this.state |
 | tst.js:24:36:24:45 | this.state | name | tst.js:24:36:24:50 | this.state.name |
 | tst.js:34:6:34:7 | vv | pp | tst.js:34:6:34:10 | vv.pp |
 | tst.js:35:6:35:8 | vvv | ppp | tst.js:35:6:35:12 | vvv.ppp |

--- a/javascript/ql/test/library-tests/PropWrite/getAPropertyReference.expected
+++ b/javascript/ql/test/library-tests/PropWrite/getAPropertyReference.expected
@@ -1,3 +1,5 @@
+| tst.js:1:1:1:0 | this | tst.js:23:15:23:29 | this.someMethod |
+| tst.js:1:1:1:0 | this | tst.js:24:36:24:45 | this.state |
 | tst.js:2:11:10:1 | {\\n    x ...     }\\n} | tst.js:3:5:3:8 | x: 4 |
 | tst.js:2:11:10:1 | {\\n    x ...     }\\n} | tst.js:4:5:6:5 | func: f ... ;\\n    } |
 | tst.js:2:11:10:1 | {\\n    x ...     }\\n} | tst.js:7:5:9:5 | f() {\\n  ... ;\\n    } |
@@ -5,10 +7,8 @@
 | tst.js:14:5:14:11 | console | tst.js:14:5:14:15 | console.log |
 | tst.js:17:5:17:11 | console | tst.js:17:5:17:15 | console.log |
 | tst.js:21:1:21:1 | C | tst.js:21:1:21:6 | C.prop |
-| tst.js:23:15:23:18 | this | tst.js:23:15:23:29 | this.someMethod |
 | tst.js:23:15:23:29 | this.someMethod | tst.js:23:15:23:34 | this.someMethod.bind |
 | tst.js:24:8:24:57 | <div on ... }</div> | tst.js:24:13:24:27 | onClick={click} |
-| tst.js:24:36:24:39 | this | tst.js:24:36:24:45 | this.state |
 | tst.js:24:36:24:45 | this.state | tst.js:24:36:24:50 | this.state.name |
 | tst.js:26:2:29:1 | {\\n  get ... v) {}\\n} | tst.js:27:3:27:26 | get x() ... null; } |
 | tst.js:26:2:29:1 | {\\n  get ... v) {}\\n} | tst.js:28:3:28:13 | set y(v) {} |

--- a/javascript/ql/test/library-tests/PropWrite/getAPropertyReference2.expected
+++ b/javascript/ql/test/library-tests/PropWrite/getAPropertyReference2.expected
@@ -1,3 +1,5 @@
+| tst.js:1:1:1:0 | this | someMethod | tst.js:23:15:23:29 | this.someMethod |
+| tst.js:1:1:1:0 | this | state | tst.js:24:36:24:45 | this.state |
 | tst.js:2:11:10:1 | {\\n    x ...     }\\n} | f | tst.js:7:5:9:5 | f() {\\n  ... ;\\n    } |
 | tst.js:2:11:10:1 | {\\n    x ...     }\\n} | func | tst.js:4:5:6:5 | func: f ... ;\\n    } |
 | tst.js:2:11:10:1 | {\\n    x ...     }\\n} | x | tst.js:3:5:3:8 | x: 4 |
@@ -5,10 +7,8 @@
 | tst.js:14:5:14:11 | console | log | tst.js:14:5:14:15 | console.log |
 | tst.js:17:5:17:11 | console | log | tst.js:17:5:17:15 | console.log |
 | tst.js:21:1:21:1 | C | prop | tst.js:21:1:21:6 | C.prop |
-| tst.js:23:15:23:18 | this | someMethod | tst.js:23:15:23:29 | this.someMethod |
 | tst.js:23:15:23:29 | this.someMethod | bind | tst.js:23:15:23:34 | this.someMethod.bind |
 | tst.js:24:8:24:57 | <div on ... }</div> | onClick | tst.js:24:13:24:27 | onClick={click} |
-| tst.js:24:36:24:39 | this | state | tst.js:24:36:24:45 | this.state |
 | tst.js:24:36:24:45 | this.state | name | tst.js:24:36:24:50 | this.state.name |
 | tst.js:26:2:29:1 | {\\n  get ... v) {}\\n} | x | tst.js:27:3:27:26 | get x() ... null; } |
 | tst.js:26:2:29:1 | {\\n  get ... v) {}\\n} | y | tst.js:28:3:28:13 | set y(v) {} |

--- a/javascript/ql/test/library-tests/TaintTracking/BasicTaintTracking.expected
+++ b/javascript/ql/test/library-tests/TaintTracking/BasicTaintTracking.expected
@@ -3,6 +3,8 @@
 | partialCalls.js:4:17:4:24 | source() | partialCalls.js:30:14:30:20 | x.value |
 | partialCalls.js:4:17:4:24 | source() | partialCalls.js:41:10:41:18 | id(taint) |
 | partialCalls.js:4:17:4:24 | source() | partialCalls.js:51:14:51:14 | x |
+| thisAssignments.js:4:17:4:24 | source() | thisAssignments.js:5:10:5:18 | obj.field |
+| thisAssignments.js:7:19:7:26 | source() | thisAssignments.js:8:10:8:20 | this.field2 |
 | tst.js:2:13:2:20 | source() | tst.js:4:10:4:10 | x |
 | tst.js:2:13:2:20 | source() | tst.js:5:10:5:22 | "/" + x + "!" |
 | tst.js:2:13:2:20 | source() | tst.js:14:10:14:17 | x.sort() |

--- a/javascript/ql/test/library-tests/TaintTracking/thisAssignments.js
+++ b/javascript/ql/test/library-tests/TaintTracking/thisAssignments.js
@@ -1,0 +1,10 @@
+class C {
+  foo() {
+    let obj = {};
+    obj.field = source();
+    sink(obj.field); // NOT OK - tainted
+    
+    this.field2 = source();
+    sink(this.field2); // NOT OK - tainted
+  }
+}

--- a/javascript/ql/test/library-tests/frameworks/ReactJS/ReactComponent_ref.expected
+++ b/javascript/ql/test/library-tests/frameworks/ReactJS/ReactComponent_ref.expected
@@ -1,18 +1,42 @@
 | es5.js:1:31:11:1 | {\\n  dis ... ;\\n  }\\n} | es5.js:1:31:11:1 | {\\n  dis ... ;\\n  }\\n} |
+| es5.js:1:31:11:1 | {\\n  dis ... ;\\n  }\\n} | es5.js:3:11:3:10 | this |
 | es5.js:1:31:11:1 | {\\n  dis ... ;\\n  }\\n} | es5.js:4:24:4:27 | this |
+| es5.js:1:31:11:1 | {\\n  dis ... ;\\n  }\\n} | es5.js:6:20:6:19 | this |
 | es5.js:18:33:22:1 | {\\n  ren ... ;\\n  }\\n} | es5.js:18:33:22:1 | {\\n  ren ... ;\\n  }\\n} |
+| es5.js:18:33:22:1 | {\\n  ren ... ;\\n  }\\n} | es5.js:19:11:19:10 | this |
 | es5.js:18:33:22:1 | {\\n  ren ... ;\\n  }\\n} | es5.js:20:24:20:27 | this |
+| es6.js:1:1:8:1 | class H ... ;\\n  }\\n} | es6.js:1:37:1:36 | this |
+| es6.js:1:1:8:1 | class H ... ;\\n  }\\n} | es6.js:2:9:2:8 | this |
 | es6.js:1:1:8:1 | class H ... ;\\n  }\\n} | es6.js:3:24:3:27 | this |
+| es6.js:1:1:8:1 | class H ... ;\\n  }\\n} | es6.js:5:14:5:13 | this |
+| es6.js:14:1:20:1 | class H ...     }\\n} | es6.js:15:16:15:15 | this |
 | es6.js:14:1:20:1 | class H ...     }\\n} | es6.js:16:9:16:12 | this |
 | es6.js:14:1:20:1 | class H ...     }\\n} | es6.js:17:9:17:12 | this |
 | es6.js:14:1:20:1 | class H ...     }\\n} | es6.js:18:9:18:12 | this |
+| namedImport.js:3:1:3:28 | class C ... nent {} | namedImport.js:3:27:3:26 | this |
+| namedImport.js:5:1:5:20 | class D extends C {} | namedImport.js:5:19:5:18 | this |
+| plainfn.js:1:1:3:1 | functio ... div>;\\n} | plainfn.js:1:1:1:0 | this |
+| plainfn.js:5:1:7:1 | functio ... iv");\\n} | plainfn.js:5:1:5:0 | this |
+| plainfn.js:9:1:12:1 | functio ... rn x;\\n} | plainfn.js:9:1:9:0 | this |
+| plainfn.js:20:1:24:1 | functio ... n 42;\\n} | plainfn.js:20:1:20:0 | this |
+| preact.js:1:1:7:1 | class H ...     }\\n} | preact.js:1:38:1:37 | this |
+| preact.js:1:1:7:1 | class H ...     }\\n} | preact.js:2:11:2:10 | this |
+| preact.js:9:1:11:1 | class H ... nt {\\n\\n} | preact.js:9:38:9:37 | this |
+| probably-a-component.js:1:1:6:1 | class H ...     }\\n} | probably-a-component.js:1:31:1:30 | this |
+| probably-a-component.js:1:1:6:1 | class H ...     }\\n} | probably-a-component.js:2:11:2:10 | this |
 | probably-a-component.js:1:1:6:1 | class H ...     }\\n} | probably-a-component.js:3:9:3:12 | this |
+| props.js:2:5:3:5 | class C ... {\\n    } | props.js:2:37:2:36 | this |
 | props.js:2:5:3:5 | class C ... {\\n    } | props.js:9:5:9:55 | new C({ ... ctor"}) |
 | props.js:13:31:17:5 | {\\n      ... }\\n    } | props.js:13:31:17:5 | {\\n      ... }\\n    } |
+| props.js:13:31:17:5 | {\\n      ... }\\n    } | props.js:14:24:14:23 | this |
+| props.js:26:5:28:5 | functio ... ;\\n    } | props.js:26:5:26:4 | this |
 | props.js:26:5:28:5 | functio ... ;\\n    } | props.js:34:5:34:55 | new C({ ... ctor"}) |
+| statePropertyReads.js:1:1:13:1 | class R ...     }\\n} | statePropertyReads.js:2:16:2:15 | this |
 | statePropertyReads.js:1:1:13:1 | class R ...     }\\n} | statePropertyReads.js:3:9:3:12 | this |
 | statePropertyReads.js:1:1:13:1 | class R ...     }\\n} | statePropertyReads.js:5:9:5:12 | this |
 | statePropertyReads.js:1:1:13:1 | class R ...     }\\n} | statePropertyReads.js:7:9:7:12 | this |
+| statePropertyReads.js:1:1:13:1 | class R ...     }\\n} | statePropertyReads.js:10:23:10:22 | this |
+| statePropertyWrites.js:1:1:34:1 | class W ...    };\\n} | statePropertyWrites.js:2:16:2:15 | this |
 | statePropertyWrites.js:1:1:34:1 | class W ...    };\\n} | statePropertyWrites.js:3:13:3:22 | cmp |
 | statePropertyWrites.js:1:1:34:1 | class W ...    };\\n} | statePropertyWrites.js:3:19:3:22 | this |
 | statePropertyWrites.js:1:1:34:1 | class W ...    };\\n} | statePropertyWrites.js:4:9:4:11 | cmp |
@@ -21,28 +45,45 @@
 | statePropertyWrites.js:1:1:34:1 | class W ...    };\\n} | statePropertyWrites.js:14:9:14:11 | cmp |
 | statePropertyWrites.js:1:1:34:1 | class W ...    };\\n} | statePropertyWrites.js:18:9:18:11 | cmp |
 | statePropertyWrites.js:1:1:34:1 | class W ...    };\\n} | statePropertyWrites.js:22:9:22:11 | cmp |
+| statePropertyWrites.js:1:1:34:1 | class W ...    };\\n} | statePropertyWrites.js:25:20:25:19 | this |
 | statePropertyWrites.js:36:19:45:1 | {\\n  ren ... ;\\n  }\\n} | statePropertyWrites.js:36:19:45:1 | {\\n  ren ... ;\\n  }\\n} |
+| statePropertyWrites.js:36:19:45:1 | {\\n  ren ... ;\\n  }\\n} | statePropertyWrites.js:37:11:37:10 | this |
 | statePropertyWrites.js:36:19:45:1 | {\\n  ren ... ;\\n  }\\n} | statePropertyWrites.js:38:24:38:27 | this |
+| statePropertyWrites.js:36:19:45:1 | {\\n  ren ... ;\\n  }\\n} | statePropertyWrites.js:40:20:40:19 | this |
+| thisAccesses.js:1:1:16:1 | class C ...     }\\n} | thisAccesses.js:2:17:2:16 | this |
 | thisAccesses.js:1:1:16:1 | class C ...     }\\n} | thisAccesses.js:3:9:3:12 | this |
 | thisAccesses.js:1:1:16:1 | class C ...     }\\n} | thisAccesses.js:5:13:5:22 | dis |
 | thisAccesses.js:1:1:16:1 | class C ...     }\\n} | thisAccesses.js:5:19:5:22 | this |
 | thisAccesses.js:1:1:16:1 | class C ...     }\\n} | thisAccesses.js:6:9:6:11 | dis |
+| thisAccesses.js:1:1:16:1 | class C ...     }\\n} | thisAccesses.js:8:10:8:9 | this |
 | thisAccesses.js:1:1:16:1 | class C ...     }\\n} | thisAccesses.js:9:13:9:16 | this |
 | thisAccesses.js:1:1:16:1 | class C ...     }\\n} | thisAccesses.js:10:17:10:20 | this |
+| thisAccesses.js:1:1:16:1 | class C ...     }\\n} | thisAccesses.js:13:23:13:22 | this |
 | thisAccesses.js:1:1:16:1 | class C ...     }\\n} | thisAccesses.js:14:9:14:12 | this |
 | thisAccesses.js:18:19:29:1 | {\\n    r ...     }\\n} | thisAccesses.js:18:19:29:1 | {\\n    r ...     }\\n} |
+| thisAccesses.js:18:19:29:1 | {\\n    r ...     }\\n} | thisAccesses.js:19:13:19:12 | this |
+| thisAccesses.js:18:19:29:1 | {\\n    r ...     }\\n} | thisAccesses.js:20:10:20:9 | this |
 | thisAccesses.js:18:19:29:1 | {\\n    r ...     }\\n} | thisAccesses.js:21:13:21:16 | this |
 | thisAccesses.js:18:19:29:1 | {\\n    r ...     }\\n} | thisAccesses.js:22:17:22:20 | this |
+| thisAccesses.js:18:19:29:1 | {\\n    r ...     }\\n} | thisAccesses.js:26:25:26:24 | this |
 | thisAccesses.js:18:19:29:1 | {\\n    r ...     }\\n} | thisAccesses.js:27:9:27:12 | this |
+| thisAccesses.js:31:2:36:1 | functio ... iv/>;\\n} | thisAccesses.js:31:2:31:1 | this |
+| thisAccesses.js:31:2:36:1 | functio ... iv/>;\\n} | thisAccesses.js:32:6:32:5 | this |
 | thisAccesses.js:31:2:36:1 | functio ... iv/>;\\n} | thisAccesses.js:33:9:33:12 | this |
 | thisAccesses.js:31:2:36:1 | functio ... iv/>;\\n} | thisAccesses.js:34:13:34:16 | this |
 | thisAccesses.js:38:19:45:1 | {\\n    r ...    },\\n} | thisAccesses.js:38:19:45:1 | {\\n    r ...    },\\n} |
+| thisAccesses.js:38:19:45:1 | {\\n    r ...    },\\n} | thisAccesses.js:39:13:39:12 | this |
+| thisAccesses.js:38:19:45:1 | {\\n    r ...    },\\n} | thisAccesses.js:40:38:40:37 | this |
 | thisAccesses.js:38:19:45:1 | {\\n    r ...    },\\n} | thisAccesses.js:41:13:41:16 | this |
 | thisAccesses.js:38:19:45:1 | {\\n    r ...    },\\n} | thisAccesses.js:42:12:42:15 | this |
+| thisAccesses.js:47:1:52:1 | class C ...     }\\n} | thisAccesses.js:48:17:48:16 | this |
 | thisAccesses.js:47:1:52:1 | class C ...     }\\n} | thisAccesses.js:49:9:49:12 | this |
 | thisAccesses.js:47:1:52:1 | class C ...     }\\n} | thisAccesses.js:50:9:50:12 | this |
 | thisAccesses_importedMappers.js:4:19:15:1 | {\\n    r ...    },\\n} | thisAccesses_importedMappers.js:4:19:15:1 | {\\n    r ...    },\\n} |
+| thisAccesses_importedMappers.js:4:19:15:1 | {\\n    r ...    },\\n} | thisAccesses_importedMappers.js:5:13:5:12 | this |
+| thisAccesses_importedMappers.js:4:19:15:1 | {\\n    r ...    },\\n} | thisAccesses_importedMappers.js:6:38:6:37 | this |
 | thisAccesses_importedMappers.js:4:19:15:1 | {\\n    r ...    },\\n} | thisAccesses_importedMappers.js:7:13:7:16 | this |
 | thisAccesses_importedMappers.js:4:19:15:1 | {\\n    r ...    },\\n} | thisAccesses_importedMappers.js:8:12:8:15 | this |
+| thisAccesses_importedMappers.js:4:19:15:1 | {\\n    r ...    },\\n} | thisAccesses_importedMappers.js:9:25:9:24 | this |
 | thisAccesses_importedMappers.js:4:19:15:1 | {\\n    r ...    },\\n} | thisAccesses_importedMappers.js:10:13:10:16 | this |
 | thisAccesses_importedMappers.js:4:19:15:1 | {\\n    r ...    },\\n} | thisAccesses_importedMappers.js:11:12:11:15 | this |

--- a/javascript/ql/test/query-tests/Security/CWE-079/Xss.expected
+++ b/javascript/ql/test/query-tests/Security/CWE-079/Xss.expected
@@ -1,3 +1,4 @@
+| addEventListener.js:2:20:2:29 | event.data | Cross-site scripting vulnerability due to $@. | addEventListener.js:1:43:1:47 | event | user-provided value |
 | jquery.js:4:5:4:11 | tainted | Cross-site scripting vulnerability due to $@. | jquery.js:2:17:2:33 | document.location | user-provided value |
 | jquery.js:7:5:7:34 | "<div i ... + "\\">" | Cross-site scripting vulnerability due to $@. | jquery.js:2:17:2:33 | document.location | user-provided value |
 | jquery.js:8:18:8:34 | "XSS: " + tainted | Cross-site scripting vulnerability due to $@. | jquery.js:2:17:2:33 | document.location | user-provided value |

--- a/javascript/ql/test/query-tests/Security/CWE-079/addEventListener.js
+++ b/javascript/ql/test/query-tests/Security/CWE-079/addEventListener.js
@@ -1,0 +1,3 @@
+this.addEventListener('message', function(event) {
+    document.write(event.data); // NOT OK
+})


### PR DESCRIPTION
Previously, `ThisExpr` and `ThisNode` were in 1:1 correspondence, but this meant that different uses of `this` in a given function wouldn't be seen as having the same local source.

Now, each function (other than an arrow function) has a `ThisNode` representing the `this` parameter to that function (or the global object at the top-level). There are still data-flow nodes corresponding to the `ThisExpr`, but they are not source nodes and there is no QL class for them, they just have the `ThisNode` has a predecessor .

[Evaluation](https://git.semmle.com/asger/dist-compare-reports/tree/e8549c06bb0ea4a44b62a5008de7f65d) looks ok. One new result due to [this.server](https://github.com/npm/cli/blob/59e5056a2129cb2951f4ff3b657ada20657f01a7/test/fake-registry.js#L19) being recognized as an HTTP server now. Two results were initially lost due to a bug in handling of top-level `this`, but I've since fixed that and added a regression test. I don't think the fix warrants a worth a full re-evaluation.