### PR TITLE
JS: use DataFlow::ArrayCreationNode in additional places

### DIFF
--- a/javascript/ql/src/AngularJS/InsecureUrlWhitelist.ql
+++ b/javascript/ql/src/AngularJS/InsecureUrlWhitelist.ql
@@ -17,7 +17,7 @@ import javascript
  * Holds if `setupCall` is a call to `$sceDelegateProvider.resourceUrlWhitelist` with
  * argument `list`.
  */
-predicate isResourceUrlWhitelist(DataFlow::MethodCallNode setupCall, DataFlow::ArrayLiteralNode list) {
+predicate isResourceUrlWhitelist(DataFlow::MethodCallNode setupCall, DataFlow::ArrayCreationNode list) {
   exists (AngularJS::ServiceReference service |
     service.getName() = "$sceDelegateProvider" and
     setupCall.asExpr() = service.getAMethodCall("resourceUrlWhitelist") and
@@ -33,7 +33,7 @@ class ResourceUrlWhitelistEntry extends Expr {
   string pattern;
 
   ResourceUrlWhitelistEntry() {
-    exists (DataFlow::ArrayLiteralNode whitelist |
+    exists (DataFlow::ArrayCreationNode whitelist |
       isResourceUrlWhitelist(setupCall, whitelist) and
       this = whitelist.getAnElement().asExpr() and
       this.mayHaveStringValue(pattern)

--- a/javascript/ql/src/Expressions/UnboundEventHandlerReceiver.ql
+++ b/javascript/ql/src/Expressions/UnboundEventHandlerReceiver.ql
@@ -36,7 +36,7 @@ private predicate isBoundInMethod(MethodDeclaration method) {
         bindAll.getArgument(1).mayHaveStringValue(name)
         or
         // _.bindAll(this, [<name1>, <name2>])
-        exists (DataFlow::ArrayLiteralNode names |
+        exists (DataFlow::ArrayCreationNode names |
           names.flowsTo(bindAll.getArgument(1)) and
           names.getAnElement().mayHaveStringValue(name)
         )

--- a/javascript/ql/src/semmle/javascript/dataflow/Configuration.qll
+++ b/javascript/ql/src/semmle/javascript/dataflow/Configuration.qll
@@ -336,7 +336,7 @@ private class LibraryPartialCall extends AdditionalPartialInvokeNode {
 
   override predicate isPartialArgument(DataFlow::Node callback, DataFlow::Node argument, int index) {
     callback = getArgument(0) and
-    exists (DataFlow::ArrayLiteralNode array |
+    exists (DataFlow::ArrayCreationNode array |
       array.flowsTo(getArgument(1)) and
       argument = array.getElement(index))
   }

--- a/javascript/ql/src/semmle/javascript/frameworks/AngularJS/DependencyInjections.qll
+++ b/javascript/ql/src/semmle/javascript/frameworks/AngularJS/DependencyInjections.qll
@@ -146,7 +146,7 @@ private DataFlow::PropWrite getAPropertyDependencyInjection(Function function) {
  */
 private class FunctionWithInjectProperty extends InjectableFunction {
   override Function astNode;
-  DataFlow::ArrayLiteralNode dependencies;
+  DataFlow::ArrayCreationNode dependencies;
 
   FunctionWithInjectProperty() {
     (

--- a/javascript/ql/src/semmle/javascript/frameworks/Express.qll
+++ b/javascript/ql/src/semmle/javascript/frameworks/Express.qll
@@ -891,7 +891,7 @@ module Express {
         getMethodName() = methodName and
         exists (DataFlow::ValueNode arg |
           arg = getAnArgument() |
-          exists (DataFlow::ArrayLiteralNode array |
+          exists (DataFlow::ArrayCreationNode array |
             array.flowsTo(arg) and
             routeHandlerArg = array.getAnElement()
           ) or

--- a/javascript/ql/src/semmle/javascript/frameworks/ExpressModules.qll
+++ b/javascript/ql/src/semmle/javascript/frameworks/ExpressModules.qll
@@ -144,8 +144,8 @@ module ExpressLibraries {
 
       override DataFlow::Node getASecretKey() {
         exists (DataFlow::Node secret | secret = getOption("secret") |
-          if exists(DataFlow::ArrayLiteralNode arr | arr.flowsTo(secret)) then
-            result = any (DataFlow::ArrayLiteralNode arr | arr.flowsTo(secret)).getAnElement()
+          if exists(DataFlow::ArrayCreationNode arr | arr.flowsTo(secret)) then
+            result = any (DataFlow::ArrayCreationNode arr | arr.flowsTo(secret)).getAnElement()
           else
             result = secret
         )
@@ -182,8 +182,8 @@ module ExpressLibraries {
 
       override DataFlow::Node getASecretKey() {
         exists (DataFlow::Node arg0 | arg0 = getArgument(0) |
-          if exists(DataFlow::ArrayLiteralNode arr | arr.flowsTo(arg0)) then
-            result = any (DataFlow::ArrayLiteralNode arr | arr.flowsTo(arg0)).getAnElement()
+          if exists(DataFlow::ArrayCreationNode arr | arr.flowsTo(arg0)) then
+            result = any (DataFlow::ArrayCreationNode arr | arr.flowsTo(arg0)).getAnElement()
           else
             result = arg0
         )
@@ -220,7 +220,7 @@ module ExpressLibraries {
 
       override DataFlow::Node getASecretKey() {
         result = getOption("secret") or
-        exists (DataFlow::ArrayLiteralNode keys |
+        exists (DataFlow::ArrayCreationNode keys |
           keys.flowsTo(getOption("keys")) and
           result = keys.getAnElement()
         )

--- a/javascript/ql/src/semmle/javascript/security/dataflow/CommandInjection.qll
+++ b/javascript/ql/src/semmle/javascript/security/dataflow/CommandInjection.qll
@@ -75,7 +75,7 @@ module CommandInjection {
     ArgumentListTracking() { this = "ArgumentListTracking" }
 
     override predicate isSource(DataFlow::Node nd) {
-      nd instanceof DataFlow::ArrayLiteralNode
+      nd instanceof DataFlow::ArrayCreationNode
       or
       exists (StringLiteral shell | shellCmd(shell, _) |
         nd = DataFlow::valueNode(shell)
@@ -125,7 +125,7 @@ module CommandInjection {
    * we want to report the `spawn` call as the sink, so we bind it to `sys`.
    */
   private predicate indirectCommandInjection(DataFlow::Node sink, SystemCommandExecution sys) {
-    exists (ArgumentListTracking cfg, DataFlow::ArrayLiteralNode args,
+    exists (ArgumentListTracking cfg, DataFlow::ArrayCreationNode args,
             StringLiteral shell, string dashC |
       shellCmd(shell, dashC) and
       cfg.hasFlow(DataFlow::valueNode(shell), sys.getACommandArgument()) and


### PR DESCRIPTION
I noticed that we still had some uses of `ArrayLiteralNode` around, it looks like they could all be generalized to `ArrayCreationNode`.

I am currently doing a performance sanity check.