### PR TITLE
C++: Suppress UnsignedGEZero.ql in template instantiations

### DIFF
--- a/cpp/ql/src/Likely Bugs/Arithmetic/UnsignedGEZero.qll
+++ b/cpp/ql/src/Likely Bugs/Arithmetic/UnsignedGEZero.qll
@@ -50,5 +50,6 @@ predicate unsignedGEZero(UnsignedGEZero ugez, string msg) {
     ugez.getLocation().getStartLine() = mi.getLocation().getStartLine() and
     ugez.getLocation().getStartColumn() = mi.getLocation().getStartColumn()
   ) and
+  not ugez.isFromTemplateInstantiation(_) and
   msg = "Pointless comparison of unsigned value to zero."
 }

--- a/cpp/ql/test/query-tests/Likely Bugs/Arithmetic/UnsignedGEZero/Templates.cpp
+++ b/cpp/ql/test/query-tests/Likely Bugs/Arithmetic/UnsignedGEZero/Templates.cpp
@@ -1,0 +1,17 @@
+template<typename T>
+bool sometimesPointless(T param) {
+  return param >= 0; // GOOD (FALSE POSITIVE: hypothetical instantiations are okay)
+}
+
+template<typename T>
+bool alwaysPointless(T param) {
+  unsigned int local = param;
+  return local >= 0; // BAD (in all instantiations)
+}
+
+static int caller(int i) {
+  return
+      sometimesPointless<unsigned int>(i) ||
+      alwaysPointless<unsigned int>(i) ||
+      alwaysPointless<int>(i);
+}

--- a/cpp/ql/test/query-tests/Likely Bugs/Arithmetic/UnsignedGEZero/UnsignedGEZero.expected
+++ b/cpp/ql/test/query-tests/Likely Bugs/Arithmetic/UnsignedGEZero/UnsignedGEZero.expected
@@ -1,3 +1,7 @@
+| Templates.cpp:3:10:3:19 | ... >= ... | Pointless comparison of unsigned value to zero. |
+| Templates.cpp:9:10:9:19 | ... >= ... | Pointless comparison of unsigned value to zero. |
+| Templates.cpp:9:10:9:19 | ... >= ... | Pointless comparison of unsigned value to zero. |
+| Templates.cpp:9:10:9:19 | ... >= ... | Pointless comparison of unsigned value to zero. |
 | UnsignedGEZero.c:40:6:40:12 | ... >= ... | Pointless comparison of unsigned value to zero. |
 | UnsignedGEZero.c:48:6:48:15 | ... >= ... | Pointless comparison of unsigned value to zero. |
 | UnsignedGEZero.c:54:6:54:12 | ... >= ... | Pointless comparison of unsigned value to zero. |

--- a/cpp/ql/test/query-tests/Likely Bugs/Arithmetic/UnsignedGEZero/UnsignedGEZero.expected
+++ b/cpp/ql/test/query-tests/Likely Bugs/Arithmetic/UnsignedGEZero/UnsignedGEZero.expected
@@ -1,6 +1,3 @@
-| Templates.cpp:3:10:3:19 | ... >= ... | Pointless comparison of unsigned value to zero. |
-| Templates.cpp:9:10:9:19 | ... >= ... | Pointless comparison of unsigned value to zero. |
-| Templates.cpp:9:10:9:19 | ... >= ... | Pointless comparison of unsigned value to zero. |
 | Templates.cpp:9:10:9:19 | ... >= ... | Pointless comparison of unsigned value to zero. |
 | UnsignedGEZero.c:40:6:40:12 | ... >= ... | Pointless comparison of unsigned value to zero. |
 | UnsignedGEZero.c:48:6:48:15 | ... >= ... | Pointless comparison of unsigned value to zero. |


### PR DESCRIPTION
This is the same change as in #276, just for a similar query. Requested in https://discuss.lgtm.com/t/false-alarm-for-unreachable-unsigned-comparison-to-zero/1392.