### PR TITLE
JS: Add flow label for tainted objects and sharpen NosqlInjection

### DIFF
--- a/javascript/ql/src/semmle/javascript/dataflow/Configuration.qll
+++ b/javascript/ql/src/semmle/javascript/dataflow/Configuration.qll
@@ -311,12 +311,17 @@ abstract class BarrierGuardNode extends DataFlow::Node {
   abstract predicate blocks(boolean outcome, Expr e);
 
   /**
-   * Holds if this barrier guard blocks all labels.
+   * Holds if this barrier guard should block all labels.
+   *
+   * To block specific labels only, subclasses should override this with `none()` and
+   * also override `blocksSpecificLabel`.
    */
   predicate blocksAllLabels() { any() }
 
   /**
    * Holds if this barrier guard only blocks specific labels, and `label` is one of them.
+   *
+   * Subclasses that override this predicate should also override `blocksAllLabels`.
    */
   predicate blocksSpecificLabel(FlowLabel label) { none() }
 }

--- a/javascript/ql/src/semmle/javascript/dataflow/TaintTracking.qll
+++ b/javascript/ql/src/semmle/javascript/dataflow/TaintTracking.qll
@@ -160,6 +160,12 @@ module TaintTracking {
   }
 
   /**
+   * A sanitizer guard node that only blocks specific flow labels.
+   */
+  abstract class LabeledSanitizerGuardNode extends SanitizerGuardNode, DataFlow::LabeledBarrierGuardNode {
+  }
+
+  /**
    * DEPRECATED: Override `Configuration::isAdditionalTaintStep` or use
    * `AdditionalTaintStep` instead.
    */

--- a/javascript/ql/src/semmle/javascript/dataflow/TaintTracking.qll
+++ b/javascript/ql/src/semmle/javascript/dataflow/TaintTracking.qll
@@ -130,7 +130,7 @@ module TaintTracking {
    * configurations it is used in.
    *
    * Note: For performance reasons, all subclasses of this class should be part
-   * of the standard library. Override `Configuration::isTaintSanitizerGuard`
+   * of the standard library. Override `Configuration::isSanitizer`
    * for analysis-specific taint steps.
    */
   abstract class AdditionalSanitizerGuardNode extends SanitizerGuardNode {

--- a/javascript/ql/src/semmle/javascript/dataflow/internal/FlowSteps.qll
+++ b/javascript/ql/src/semmle/javascript/dataflow/internal/FlowSteps.qll
@@ -74,10 +74,12 @@ predicate localFlowStep(DataFlow::Node pred, DataFlow::Node succ,
   any(DataFlow::AdditionalFlowStep afs).step(pred, succ) and predlbl = succlbl
   or
   exists (boolean vp | configuration.isAdditionalFlowStep(pred, succ, vp) |
-    if vp = false and (predlbl = FlowLabel::data() or predlbl = FlowLabel::taint()) then
-      succlbl = FlowLabel::taint()
-    else
-      predlbl = succlbl
+    vp = true and
+    predlbl = succlbl
+    or
+    vp = false and
+    (predlbl = FlowLabel::data() or predlbl = FlowLabel::taint()) and
+    succlbl = FlowLabel::taint()
   )
   or
   configuration.isAdditionalFlowStep(pred, succ, predlbl, succlbl)

--- a/javascript/ql/src/semmle/javascript/frameworks/Express.qll
+++ b/javascript/ql/src/semmle/javascript/frameworks/Express.qll
@@ -489,18 +489,18 @@ module Express {
       result = kind
     }
 
-    override predicate isDeepObject() {
+    override predicate isUserControlledObject() {
       kind = "body" and
       exists (ExpressLibraries::BodyParser bodyParser, RouteHandlerExpr expr |
         expr.getBody() = rh and
-        bodyParser.isDeepObject() and
+        bodyParser.producesUserControlledObjects() and
         bodyParser.flowsToExpr(expr.getAMatchingAncestor())
       )
       or
       // If we can't find the middlewares for the route handler,
       // but all known body parsers are deep, assume req.body is a deep object.
       kind = "body" and
-      forall(ExpressLibraries::BodyParser bodyParser | bodyParser.isDeepObject())
+      forall(ExpressLibraries::BodyParser bodyParser | bodyParser.producesUserControlledObjects())
       or
       kind = "parameter" and
       exists (DataFlow::Node request | request = DataFlow::valueNode(rh.getARequestExpr()) |

--- a/javascript/ql/src/semmle/javascript/frameworks/Express.qll
+++ b/javascript/ql/src/semmle/javascript/frameworks/Express.qll
@@ -488,6 +488,20 @@ module Express {
     override string getKind() {
       result = kind
     }
+
+    override predicate isDeepObject() {
+      kind = "body" and
+      exists (ExpressLibraries::BodyParser bodyParser, RouteHandlerExpr expr |
+        expr.getBody() = rh and
+        bodyParser.isDeepObject() and
+        bodyParser.flowsToExpr(expr.getAMatchingAncestor())
+      )
+      or
+      // If we can't find the middlewares for the route handler,
+      // but all known body parsers are deep, assume req.body is a deep object.
+      kind = "body" and
+      forall(ExpressLibraries::BodyParser bodyParser | bodyParser.isDeepObject())
+    }
   }
 
   /**

--- a/javascript/ql/src/semmle/javascript/frameworks/Express.qll
+++ b/javascript/ql/src/semmle/javascript/frameworks/Express.qll
@@ -501,6 +501,17 @@ module Express {
       // but all known body parsers are deep, assume req.body is a deep object.
       kind = "body" and
       forall(ExpressLibraries::BodyParser bodyParser | bodyParser.isDeepObject())
+      or
+      kind = "parameter" and
+      exists (DataFlow::Node request | request = DataFlow::valueNode(rh.getARequestExpr()) |
+        this.(DataFlow::MethodCallNode).calls(request, "param")
+        or
+        exists (DataFlow::PropRead base |
+          // `req.query.name`
+          base.accesses(request, "query") and
+          this = base.getAPropertyReference(_)
+        )
+      )
     }
   }
 

--- a/javascript/ql/src/semmle/javascript/frameworks/ExpressModules.qll
+++ b/javascript/ql/src/semmle/javascript/frameworks/ExpressModules.qll
@@ -271,9 +271,10 @@ module ExpressLibraries {
     }
 
     /**
-     * Holds if this parses the input as JSON or extended URL-encoding.
+     * Holds if this parses the input as JSON or extended URL-encoding, resulting
+     * in user-controlled objects (as opposed to user-controlled strings).
      */
-    predicate isDeepObject() {
+    predicate producesUserControlledObjects() {
       isJson() or isExtendedUrlEncoded()
     }
   }

--- a/javascript/ql/src/semmle/javascript/frameworks/ExpressModules.qll
+++ b/javascript/ql/src/semmle/javascript/frameworks/ExpressModules.qll
@@ -230,4 +230,52 @@ module ExpressLibraries {
 
   }
 
+  /**
+   * An instance of the Express `body-parser` middleware.
+   */
+  class BodyParser extends DataFlow::InvokeNode {
+    string kind;
+
+    BodyParser() {
+      this = DataFlow::moduleImport("body-parser").getACall() and kind = "json"
+      or
+      exists (string moduleName |
+        (moduleName = "body-parser" or moduleName = "express") and
+        (kind = "json" or kind = "urlencoded") and
+        this = DataFlow::moduleMember(moduleName, kind).getACall()
+      )
+    }
+
+    /**
+     * Holds if this is a JSON body parser.
+     */
+    predicate isJson() {
+      kind = "json"
+    }
+
+    /**
+     * Holds if this is a URL-encoded body parser.
+     */
+    predicate isUrlEncoded() {
+      kind = "urlencoded"
+    }
+
+    /**
+     * Holds if this is an extended URL-encoded body parser.
+     *
+     * The extended URL-encoding allows for nested objects, like JSON.
+     */
+    predicate isExtendedUrlEncoded() {
+      kind = "urlencoded" and
+      not getOptionArgument(0, "extended").mayHaveBooleanValue(false)
+    }
+
+    /**
+     * Holds if this parses the input as JSON or extended URL-encoding.
+     */
+    predicate isDeepObject() {
+      isJson() or isExtendedUrlEncoded()
+    }
+  }
+
 }

--- a/javascript/ql/src/semmle/javascript/frameworks/NoSQL.qll
+++ b/javascript/ql/src/semmle/javascript/frameworks/NoSQL.qll
@@ -62,9 +62,22 @@ private module MongoDB {
 
     QueryCall() {
       exists (string m | asExpr().(MethodCallExpr).calls(any(Collection c), m) |
+        m = "aggregate" and queryArgIdx = 0 or
         m = "count" and queryArgIdx = 0 or
+        m = "deleteMany" and queryArgIdx = 0 or
+        m = "deleteOne" and queryArgIdx = 0 or
         m = "distinct" and queryArgIdx = 1 or
-        m = "find" and queryArgIdx = 0
+        m = "find" and queryArgIdx = 0 or
+        m = "findOne" and queryArgIdx = 0 or
+        m = "findOneAndDelete" and queryArgIdx = 0 or
+        m = "findOneAndRemove" and queryArgIdx = 0 or
+        m = "findOneAndDelete" and queryArgIdx = 0 or
+        m = "findOneAndUpdate" and queryArgIdx = 0 or
+        m = "remove" and queryArgIdx = 0 or
+        m = "replaceOne" and queryArgIdx = 0 or
+        m = "update" and queryArgIdx = 0 or
+        m = "updateMany" and queryArgIdx = 0 or
+        m = "updateOne" and queryArgIdx = 0
       )
     }
 

--- a/javascript/ql/src/semmle/javascript/security/TaintedObject.qll
+++ b/javascript/ql/src/semmle/javascript/security/TaintedObject.qll
@@ -22,11 +22,11 @@ module TaintedObject {
   }
 
   /**
-   * Gets the flow label representing a deeply tainted objects.
+   * Gets the flow label representing a deeply tainted object.
    *
-   * A "tainted object" is an array or object whose values are all assumed to be tainted as well.
+   * A "tainted object" is an array or object whose properties values are all assumed to be tainted as well.
    *
-   * Note that the presence of the `object-taint` label generally implies the presence of the `taint` label as well.
+   * Note that the presence of the this label generally implies the presence of the `taint` label as well.
    */
   FlowLabel label() { result instanceof TaintedObjectLabel  }
 

--- a/javascript/ql/src/semmle/javascript/security/TaintedObject.qll
+++ b/javascript/ql/src/semmle/javascript/security/TaintedObject.qll
@@ -24,7 +24,7 @@ module TaintedObject {
   /**
    * Gets the flow label representing a deeply tainted object.
    *
-   * A "tainted object" is an array or object whose properties values are all assumed to be tainted as well.
+   * A "tainted object" is an array or object whose property values are all assumed to be tainted as well.
    *
    * Note that the presence of the this label generally implies the presence of the `taint` label as well.
    */
@@ -70,25 +70,23 @@ module TaintedObject {
   }
 
   /**
-   * A source of a user-controlled deep object object.
+   * A source of a user-controlled deep object.
    */
   abstract class Source extends DataFlow::Node {}
 
   /** Request input accesses as a JSON source. */
   private class RequestInputAsSource extends Source {
     RequestInputAsSource() {
-      this.(HTTP::RequestInputAccess).isDeepObject()
+      this.(HTTP::RequestInputAccess).isUserControlledObject()
     }
   }
 
   /**
    * Sanitizer guard that blocks deep object taint.
    */
-  abstract class SanitizerGuard extends TaintTracking::SanitizerGuardNode {
-    override predicate blocksAllLabels() { none() }
-
-    override predicate blocksSpecificLabel(FlowLabel label) {
-      label = label()
+  abstract class SanitizerGuard extends TaintTracking::LabeledSanitizerGuardNode {
+    override FlowLabel getALabel() {
+      result = label()
     }
   }
 

--- a/javascript/ql/src/semmle/javascript/security/TaintedObject.qll
+++ b/javascript/ql/src/semmle/javascript/security/TaintedObject.qll
@@ -1,0 +1,84 @@
+/**
+ * Provides methods for reasoning about the flow of deeply tainted objects, such as JSON objects
+ * parsed from user-controlled data.
+ *
+ * Deeply tainted objects are arrays or objects with user-controlled property names, containing
+ * tainted values or deeply tainted objects in their properties.
+ *
+ * To track deeply tainted objects, a flow-tracking configuration should generally include the following:
+ *
+ * 1. One or more sinks associated with the label `TaintedObject::label()`.
+ * 2. The sources from `TaintedObject::isSource`.
+ * 3. The flow steps from `TaintedObject::step`.
+ */
+import javascript
+
+module TaintedObject {
+  private import DataFlow
+
+  private class TaintedObjectLabel extends FlowLabel {
+    TaintedObjectLabel() { this = "tainted-object" }
+  }
+
+  /**
+   * Gets the flow label representing a deeply tainted objects.
+   *
+   * A "tainted object" is an array or object whose values are all assumed to be tainted as well.
+   *
+   * Note that the presence of the `object-taint` label generally implies the presence of the `taint` label as well.
+   */
+  FlowLabel label() { result instanceof TaintedObjectLabel  }
+
+  /**
+   * Holds for the flows steps that are relevant for tracking user-controlled JSON objects.
+   */
+  predicate step(Node src, Node trg, FlowLabel inlbl, FlowLabel outlbl) {
+    // JSON parsers map tainted inputs to tainted JSON
+    (inlbl = FlowLabel::data() or inlbl = FlowLabel::taint()) and
+    outlbl = label() and
+    exists (JsonParserCall parse |
+      src = parse.getInput() and
+      trg = parse.getOutput())
+    or
+    // Property reads preserve deep object taint.
+    inlbl = label() and
+    outlbl = label() and
+    trg.(PropRead).getBase() = src
+    or
+    // Property projection preserves deep object taint
+    inlbl = label() and
+    outlbl = label() and
+    trg.(PropertyProjection).getObject() = src
+    or
+    // Extending objects preserves deep object taint
+    inlbl = label() and
+    outlbl = label() and
+    exists (ExtendCall call |
+      src = call.getAnOperand() and
+      trg = call
+      or
+      src = call.getASourceOperand() and
+      trg = call.getDestinationOperand().getALocalSource())
+  }
+
+  /**
+   * Holds if `node` is a source of JSON taint and label is the JSON taint label.
+   */
+  predicate isSource(Node source, FlowLabel label) {
+    source instanceof Source and label = label()
+  }
+
+  /**
+   * A source of a user-controlled deep object object.
+   */
+  abstract class Source extends DataFlow::Node {}
+
+  /** Request input accesses as a JSON source. */
+  private class RequestInputAsSource extends Source {
+    RequestInputAsSource() {
+      this.(HTTP::RequestInputAccess).isDeepObject()
+    }
+  }
+
+  // TODO: string tests should be classified as sanitizer guards; need support for flow labels on guards
+}

--- a/javascript/ql/src/semmle/javascript/security/dataflow/ClientSideUrlRedirect.qll
+++ b/javascript/ql/src/semmle/javascript/security/dataflow/ClientSideUrlRedirect.qll
@@ -65,6 +65,11 @@ module ClientSideUrlRedirect {
       queryAccess(pred, succ) and
       f instanceof DocumentUrl and
       g = DataFlow::FlowLabel::taint()
+      or
+      // preserve document.url label in step from `location` to `location.href`
+      f instanceof DocumentUrl and
+      g instanceof DocumentUrl and
+      succ.(DataFlow::PropRead).accesses(pred, "href")
     }
   }
 

--- a/javascript/ql/src/semmle/javascript/security/dataflow/NosqlInjection.qll
+++ b/javascript/ql/src/semmle/javascript/security/dataflow/NosqlInjection.qll
@@ -4,6 +4,7 @@
  */
 
 import javascript
+import semmle.javascript.security.TaintedObject
 
 module NosqlInjection {
   /**
@@ -14,7 +15,16 @@ module NosqlInjection {
   /**
    * A data flow sink for SQL-injection vulnerabilities.
    */
-  abstract class Sink extends DataFlow::Node { }
+  abstract class Sink extends DataFlow::Node {
+    /**
+     * Gets a flow label relevant for this sink.
+     *
+     * Defaults to deeply tainted objects only.
+     */
+    DataFlow::FlowLabel getAFlowLabel() {
+      result = TaintedObject::label()
+    }
+  }
 
   /**
    * A sanitizer for SQL-injection vulnerabilities.
@@ -31,8 +41,12 @@ module NosqlInjection {
       source instanceof Source
     }
 
-    override predicate isSink(DataFlow::Node sink) {
-      sink instanceof Sink
+    override predicate isSource(DataFlow::Node source, DataFlow::FlowLabel label) {
+      TaintedObject::isSource(source, label)
+    }
+
+    override predicate isSink(DataFlow::Node sink, DataFlow::FlowLabel label) {
+      sink.(Sink).getAFlowLabel() = label
     }
 
     override predicate isSanitizer(DataFlow::Node node) {
@@ -40,12 +54,16 @@ module NosqlInjection {
       node instanceof Sanitizer
     }
 
-    override predicate isAdditionalTaintStep(DataFlow::Node pred, DataFlow::Node succ) {
+    override predicate isAdditionalFlowStep(DataFlow::Node src, DataFlow::Node trg, DataFlow::FlowLabel inlbl, DataFlow::FlowLabel outlbl) {
+      TaintedObject::step(src, trg, inlbl, outlbl)
+      or
       // additional flow step to track taint through NoSQL query objects
+      inlbl = TaintedObject::label() and
+      outlbl = TaintedObject::label() and
       exists (NoSQL::Query query, DataFlow::SourceNode queryObj |
         queryObj.flowsToExpr(query) and
-        queryObj.flowsTo(succ) and
-        pred = queryObj.getAPropertyWrite().getRhs()
+        queryObj.flowsTo(trg) and
+        src = queryObj.getAPropertyWrite().getRhs()
       )
     }
   }

--- a/javascript/ql/src/semmle/javascript/security/dataflow/NosqlInjection.qll
+++ b/javascript/ql/src/semmle/javascript/security/dataflow/NosqlInjection.qll
@@ -54,6 +54,10 @@ module NosqlInjection {
       node instanceof Sanitizer
     }
 
+    override predicate isSanitizerGuard(TaintTracking::SanitizerGuardNode guard) {
+      guard instanceof TaintedObject::SanitizerGuard
+    }
+
     override predicate isAdditionalFlowStep(DataFlow::Node src, DataFlow::Node trg, DataFlow::FlowLabel inlbl, DataFlow::FlowLabel outlbl) {
       TaintedObject::step(src, trg, inlbl, outlbl)
       or

--- a/javascript/ql/src/semmle/javascript/security/dataflow/RemoteFlowSources.qll
+++ b/javascript/ql/src/semmle/javascript/security/dataflow/RemoteFlowSources.qll
@@ -12,9 +12,9 @@ abstract class RemoteFlowSource extends DataFlow::Node {
   abstract string getSourceType();
 
   /**
-   * Holds if this can be a user-controlled deep object, such as a JSON object parsed from user-controlled data.
+   * Holds if this can be a user-controlled object, such as a JSON object parsed from user-controlled data.
    */
-  predicate isDeepObject() { none() }
+  predicate isUserControlledObject() { none() }
 }
 
 /**

--- a/javascript/ql/src/semmle/javascript/security/dataflow/RemoteFlowSources.qll
+++ b/javascript/ql/src/semmle/javascript/security/dataflow/RemoteFlowSources.qll
@@ -10,6 +10,11 @@ import semmle.javascript.security.dataflow.DOM
 abstract class RemoteFlowSource extends DataFlow::Node {
   /** Gets a string that describes the type of this remote flow source. */
   abstract string getSourceType();
+
+  /**
+   * Holds if this can be a user-controlled deep object, such as a JSON object parsed from user-controlled data.
+   */
+  predicate isDeepObject() { none() }
 }
 
 /**

--- a/javascript/ql/test/query-tests/Security/CWE-089/SqlInjection.expected
+++ b/javascript/ql/test/query-tests/Security/CWE-089/SqlInjection.expected
@@ -1,5 +1,6 @@
 | mongodb.js:18:16:18:20 | query | This query depends on $@. | mongodb.js:13:19:13:26 | req.body | a user-provided value |
-| mongodb.js:45:16:45:20 | query | This query depends on $@. | mongodb.js:40:19:40:33 | req.query.title | a user-provided value |
+| mongodb.js:32:18:32:45 | { title ... itle) } | This query depends on $@. | mongodb.js:26:19:26:26 | req.body | a user-provided value |
+| mongodb.js:54:16:54:20 | query | This query depends on $@. | mongodb.js:49:19:49:33 | req.query.title | a user-provided value |
 | mongodb_bodySafe.js:29:16:29:20 | query | This query depends on $@. | mongodb_bodySafe.js:24:19:24:33 | req.query.title | a user-provided value |
 | mongoose.js:27:20:27:24 | query | This query depends on $@. | mongoose.js:21:19:21:26 | req.body | a user-provided value |
 | mongoose.js:30:25:30:29 | query | This query depends on $@. | mongoose.js:21:19:21:26 | req.body | a user-provided value |

--- a/javascript/ql/test/query-tests/Security/CWE-089/SqlInjection.expected
+++ b/javascript/ql/test/query-tests/Security/CWE-089/SqlInjection.expected
@@ -1,5 +1,4 @@
 | mongodb.js:18:16:18:20 | query | This query depends on $@. | mongodb.js:13:19:13:26 | req.body | a user-provided value |
-| mongodb.js:39:16:39:20 | query | This query depends on $@. | mongodb.js:34:19:34:33 | req.query.title | a user-provided value |
 | mongoose.js:27:20:27:24 | query | This query depends on $@. | mongoose.js:21:19:21:26 | req.body | a user-provided value |
 | mongoose.js:30:25:30:29 | query | This query depends on $@. | mongoose.js:21:19:21:26 | req.body | a user-provided value |
 | mongoose.js:33:24:33:28 | query | This query depends on $@. | mongoose.js:21:19:21:26 | req.body | a user-provided value |

--- a/javascript/ql/test/query-tests/Security/CWE-089/SqlInjection.expected
+++ b/javascript/ql/test/query-tests/Security/CWE-089/SqlInjection.expected
@@ -1,4 +1,6 @@
 | mongodb.js:18:16:18:20 | query | This query depends on $@. | mongodb.js:13:19:13:26 | req.body | a user-provided value |
+| mongodb.js:45:16:45:20 | query | This query depends on $@. | mongodb.js:40:19:40:33 | req.query.title | a user-provided value |
+| mongodb_bodySafe.js:29:16:29:20 | query | This query depends on $@. | mongodb_bodySafe.js:24:19:24:33 | req.query.title | a user-provided value |
 | mongoose.js:27:20:27:24 | query | This query depends on $@. | mongoose.js:21:19:21:26 | req.body | a user-provided value |
 | mongoose.js:30:25:30:29 | query | This query depends on $@. | mongoose.js:21:19:21:26 | req.body | a user-provided value |
 | mongoose.js:33:24:33:28 | query | This query depends on $@. | mongoose.js:21:19:21:26 | req.body | a user-provided value |

--- a/javascript/ql/test/query-tests/Security/CWE-089/SqlInjection.expected
+++ b/javascript/ql/test/query-tests/Security/CWE-089/SqlInjection.expected
@@ -1,6 +1,18 @@
 | mongodb.js:18:16:18:20 | query | This query depends on $@. | mongodb.js:13:19:13:26 | req.body | a user-provided value |
 | mongodb.js:39:16:39:20 | query | This query depends on $@. | mongodb.js:34:19:34:33 | req.query.title | a user-provided value |
-| mongoose.js:24:19:24:23 | query | This query depends on $@. | mongoose.js:21:19:21:26 | req.body | a user-provided value |
+| mongoose.js:27:20:27:24 | query | This query depends on $@. | mongoose.js:21:19:21:26 | req.body | a user-provided value |
+| mongoose.js:30:25:30:29 | query | This query depends on $@. | mongoose.js:21:19:21:26 | req.body | a user-provided value |
+| mongoose.js:33:24:33:28 | query | This query depends on $@. | mongoose.js:21:19:21:26 | req.body | a user-provided value |
+| mongoose.js:36:31:36:35 | query | This query depends on $@. | mongoose.js:21:19:21:26 | req.body | a user-provided value |
+| mongoose.js:39:19:39:23 | query | This query depends on $@. | mongoose.js:21:19:21:26 | req.body | a user-provided value |
+| mongoose.js:42:22:42:26 | query | This query depends on $@. | mongoose.js:21:19:21:26 | req.body | a user-provided value |
+| mongoose.js:45:31:45:35 | query | This query depends on $@. | mongoose.js:21:19:21:26 | req.body | a user-provided value |
+| mongoose.js:48:31:48:35 | query | This query depends on $@. | mongoose.js:21:19:21:26 | req.body | a user-provided value |
+| mongoose.js:51:31:51:35 | query | This query depends on $@. | mongoose.js:21:19:21:26 | req.body | a user-provided value |
+| mongoose.js:54:25:54:29 | query | This query depends on $@. | mongoose.js:21:19:21:26 | req.body | a user-provided value |
+| mongoose.js:57:21:57:25 | query | This query depends on $@. | mongoose.js:21:19:21:26 | req.body | a user-provided value |
+| mongoose.js:60:25:60:29 | query | This query depends on $@. | mongoose.js:21:19:21:26 | req.body | a user-provided value |
+| mongoose.js:63:24:63:28 | query | This query depends on $@. | mongoose.js:21:19:21:26 | req.body | a user-provided value |
 | mongooseJsonParse.js:23:19:23:23 | query | This query depends on $@. | mongooseJsonParse.js:20:30:20:43 | req.query.data | a user-provided value |
 | tst2.js:9:27:9:84 | "select ... d + "'" | This query depends on $@. | tst2.js:9:66:9:78 | req.params.id | a user-provided value |
 | tst3.js:10:14:10:19 | query1 | This query depends on $@. | tst3.js:9:16:9:34 | req.params.category | a user-provided value |

--- a/javascript/ql/test/query-tests/Security/CWE-089/mongodb.js
+++ b/javascript/ql/test/query-tests/Security/CWE-089/mongodb.js
@@ -16,6 +16,12 @@ app.post('/documents/find', (req, res) => {
 
       // NOT OK: query is tainted by user-provided object value
       doc.find(query);
+
+      // OK: user-data is coerced to a string
+      doc.find({ title: '' + query.body.title });
+
+      // OK: throws unless user-data is a string
+      doc.find({ title: query.body.title.substr(1) });
     });
 });
 
@@ -36,6 +42,6 @@ app.post('/documents/find', (req, res) => {
       let doc = db.collection('doc');
 
       // NOT OK: query is tainted by user-provided object value
-      doc.find(query);
+      doc.find(query); // Not currently detected 
     });
 });

--- a/javascript/ql/test/query-tests/Security/CWE-089/mongodb.js
+++ b/javascript/ql/test/query-tests/Security/CWE-089/mongodb.js
@@ -22,6 +22,15 @@ app.post('/documents/find', (req, res) => {
 
       // OK: throws unless user-data is a string
       doc.find({ title: query.body.title.substr(1) });
+
+      let title = req.body.title;
+      if (typeof title === "string") {
+        // OK: input checked to be a string
+        doc.find({ title: title });
+
+        // NOT OK: input is parsed as JSON after string check
+        doc.find({ title: JSON.parse(title) });
+      }
     });
 });
 

--- a/javascript/ql/test/query-tests/Security/CWE-089/mongodb.js
+++ b/javascript/ql/test/query-tests/Security/CWE-089/mongodb.js
@@ -42,6 +42,6 @@ app.post('/documents/find', (req, res) => {
       let doc = db.collection('doc');
 
       // NOT OK: query is tainted by user-provided object value
-      doc.find(query); // Not currently detected 
+      doc.find(query);
     });
 });

--- a/javascript/ql/test/query-tests/Security/CWE-089/mongodb_bodySafe.js
+++ b/javascript/ql/test/query-tests/Security/CWE-089/mongodb_bodySafe.js
@@ -1,0 +1,31 @@
+const express = require('express'),
+      mongodb = require('mongodb'),
+      bodyParser = require('body-parser');
+
+const MongoClient = mongodb.MongoClient;
+
+const app = express();
+
+app.use(bodyParser.urlencoded({ extended: false }));
+
+app.post('/documents/find', (req, res) => {
+    const query = {};
+    query.title = req.body.title;
+    MongoClient.connect('mongodb://localhost:27017/test', (err, db) => {
+      let doc = db.collection('doc');
+
+      // OK: req.body is safe
+      doc.find(query);
+    });
+});
+
+app.post('/documents/find', (req, res) => {
+    const query = {};
+    query.title = req.query.title;
+    MongoClient.connect('mongodb://localhost:27017/test', (err, db) => {
+      let doc = db.collection('doc');
+
+      // NOT OK: regardless of body parser, query value is still tainted
+      doc.find(query);
+    });
+});

--- a/javascript/ql/test/query-tests/Security/CWE-089/mongoose.js
+++ b/javascript/ql/test/query-tests/Security/CWE-089/mongoose.js
@@ -21,6 +21,45 @@ app.post('/documents/find', (req, res) => {
     query.title = req.body.title;
 
     // NOT OK: query is tainted by user-provided object value
+    Document.aggregate('type', query);
+
+    // NOT OK: query is tainted by user-provided object value
+    Document.count(query);
+
+    // NOT OK: query is tainted by user-provided object value
+    Document.deleteMany(query);
+
+    // NOT OK: query is tainted by user-provided object value
+    Document.deleteOne(query);
+
+    // NOT OK: query is tainted by user-provided object value
+    Document.distinct('type', query);
+
+    // NOT OK: query is tainted by user-provided object value
     Document.find(query);
+
+    // NOT OK: query is tainted by user-provided object value
+    Document.findOne(query);
+
+    // NOT OK: query is tainted by user-provided object value
+    Document.findOneAndDelete(query);
+
+    // NOT OK: query is tainted by user-provided object value
+    Document.findOneAndRemove(query);
+
+    // NOT OK: query is tainted by user-provided object value
+    Document.findOneAndUpdate(query);
+
+    // NOT OK: query is tainted by user-provided object value
+    Document.replaceOne(query);
+
+    // NOT OK: query is tainted by user-provided object value
+    Document.update(query);
+
+    // NOT OK: query is tainted by user-provided object value
+    Document.updateMany(query);
+
+    // NOT OK: query is tainted by user-provided object value
+    Document.updateOne(query);
 });
 


### PR DESCRIPTION
Please ignore the first two commits, they are from https://github.com/Semmle/ql/pull/299 currently in flight.

This adds support for tracking objects that "deeply" user-controlled, i.e. the user controls the properties of the object and recursively the values of those properties. These are simply called "tainted objects". The result of `JSON.parse(x)` is such a tainted object if `x` is tainted.

This mechanism is then used in `NosqlInjection` to avoid false positives from things like `req.params.x` which can only be strings.

This PR does a bunch of things at once, as I'm hoping this makes it easier to check the validity of the approach. I'm happy to split out some of the commits later, such as the bugfix commit.

This definitely needs a thorough evaluation, but I would like to have the design reviewed first. It's also blocked on https://jira.semmle.com/browse/QL-716 at the moment.