### PR TITLE
JS: add js/command-line-injection heuristic source: JSON.stringify()

### DIFF
--- a/javascript/ql/src/semmle/javascript/heuristics/AdditionalSources.qll
+++ b/javascript/ql/src/semmle/javascript/heuristics/AdditionalSources.qll
@@ -6,6 +6,7 @@
 
 import javascript
 import SyntacticHeuristics
+private import semmle.javascript.security.dataflow.CommandInjection
 
 /**
  * A heuristic source of data flow in a security query.
@@ -25,4 +26,14 @@ private class RemoteFlowPassword extends HeuristicSource, RemoteFlowSource {
     result = "a user provided password"
   }
 
+}
+
+/**
+ * A use of `JSON.stringify`, viewed as a source for command line injections
+ * since it does not properly escape single quotes and dollar symbols.
+ */
+private class JSONStringifyAsCommandInjectionSource extends HeuristicSource, CommandInjection::Source {
+  JSONStringifyAsCommandInjectionSource() {
+    this = DataFlow::globalVarRef("JSON").getAMemberCall("stringify")
+  }
 }

--- a/javascript/ql/test/library-tests/Security/heuristics/HeuristicSource.expected
+++ b/javascript/ql/test/library-tests/Security/heuristics/HeuristicSource.expected
@@ -1,2 +1,3 @@
 | additionalCommandInjections.js:2:28:2:35 | password |
 | sources.js:2:5:2:12 | password |
+| sources.js:3:5:3:20 | JSON.stringify() |

--- a/javascript/ql/test/library-tests/Security/heuristics/sources.js
+++ b/javascript/ql/test/library-tests/Security/heuristics/sources.js
@@ -1,3 +1,4 @@
 (function() {
     password;
+    JSON.stringify();
 })();


### PR DESCRIPTION
`JSON.stringify` is [sometimes used](https://git.semmle.com/gist/esben/14c9cd78f28d74fca69ba8917ea9c86f) to quote the command line components for `child_process.exec`, but that is obviously not enough for security reasons. We already support `JSON.stringify` as a taint step, but it would be nice if we could flag the `JSON.stringify`calls without knowledge of a remote flow source.

I have added the call as a heuristic source for js/command-line-injection, but I welcome ideas on how to flag it non-heuristically (perhaps in a query like js/incomplete-sanitization).

