### PR TITLE
CPP: Add deprecated metadata.

### DIFF
--- a/cpp/ql/src/Likely Bugs/OO/NonVirtualDestructor.ql
+++ b/cpp/ql/src/Likely Bugs/OO/NonVirtualDestructor.ql
@@ -7,6 +7,7 @@
  * @id cpp/non-virtual-destructor
  * @problem.severity warning
  * @tags reliability
+ * @deprecated
  */
 
 // This query is deprecated, and replaced by jsf/4.10 Classes/AV Rule 78.ql, which has far fewer false positives on typical code.


### PR DESCRIPTION
It appears we only have one deprecated query in C/C++, and it was lacking the `@deprecated` metadata.

@felicity-semmle @yh-semmle 