### PR TITLE
CPP: Improve Overflowdest.ql

### DIFF
--- a/cpp/ql/src/Critical/OverflowDestination.cpp
+++ b/cpp/ql/src/Critical/OverflowDestination.cpp
@@ -1,13 +1,13 @@
 
 int main(int argc, char* argv[]) {
-	char param[SIZE];
+	char param[20];
+	char *arg1;
 
-	char arg1[10];
-	char arg2[20];
+	arg1 = argv[1];
 
 	//wrong: only uses the size of the source (argv[1]) when using strncpy
-	strncpy(param, argv[1], strlen(arg1));
+	strncpy(param, arg1, strlen(arg1));
 
 	//correct: uses the size of the destination array as well
-	strncpy(param, argv[1], min(strlen(arg1, sizeof(param) -1)));
+	strncpy(param, arg1, min(strlen(arg1), sizeof(param) -1));
 }

--- a/cpp/ql/src/Critical/OverflowDestination.ql
+++ b/cpp/ql/src/Critical/OverflowDestination.ql
@@ -5,6 +5,7 @@
  * @kind problem
  * @id cpp/overflow-destination
  * @problem.severity warning
+ * @precision low
  * @tags reliability
  *       security
  *       external/cwe/cwe-119

--- a/cpp/ql/src/Critical/OverflowDestination.ql
+++ b/cpp/ql/src/Critical/OverflowDestination.ql
@@ -12,7 +12,6 @@
  */
 import cpp
 import semmle.code.cpp.security.TaintTracking
-import semmle.code.cpp.pointsto.PointsTo
 
 /**
  * Holds if `fc` is a call to a copy operation where the size argument contains
@@ -44,14 +43,7 @@ predicate sourceSized(FunctionCall fc, Expr src)
       desttype.getArraySize() = srctype.getArraySize()))
 }
 
-class VulnerableArgument extends PointsToExpr
-{
-  VulnerableArgument() { sourceSized(_, this) }
-  override predicate interesting() { sourceSized(_, this) }
-}
-
-from FunctionCall fc, VulnerableArgument vuln, Expr taintSource
+from FunctionCall fc, Expr vuln, Expr taintSource
 where sourceSized(fc, vuln)
-  and tainted(taintSource, vuln.pointsTo())
-  and vuln.confidence() > 0.01
+  and tainted(taintSource, vuln)
 select fc, "To avoid overflow, this operation should be bounded by destination-buffer size, not source-buffer size."


### PR DESCRIPTION
Improvements to OverflowDestination.ql.  The main change is to use the newer taint library instead of the old PointsTo library.  This makes the query cleaner, much more efficient on large snapshots, and able to benefit from future improvements to the taint library.