### PR TITLE
Java: Fix FPs for concurrent modification checks.

### DIFF
--- a/change-notes/1.19/analysis-java.md
+++ b/change-notes/1.19/analysis-java.md
@@ -13,6 +13,7 @@
 |----------------------------|------------------------|------------------------------------------------------------------|
 | Array index out of bounds (`java/index-out-of-bounds`) | Fewer false positive results | False positives involving arrays with a length evenly divisible by 3 or some greater number and an index being increased with a similar stride length are no longer reported. |
 | Unreachable catch clause (`java/unreachable-catch-clause`) | Fewer false positive results | This rule now accounts for calls to generic methods that throw generic exceptions. |
+| Useless comparison test (`java/constant-comparison`) | Fewer false positive results | Constant comparisons guarding `java.util.ConcurrentModificationException` are no longer reported, as they are intended to always be false in the absence of API misuse. |
 
 ## Changes to QL libraries
 

--- a/java/ql/test/query-tests/UselessComparisonTest/B.java
+++ b/java/ql/test/query-tests/UselessComparisonTest/B.java
@@ -1,0 +1,22 @@
+import java.util.*;
+import java.util.function.*;
+
+public class B {
+  int modcount = 0;
+
+  int[] arr;
+
+  public void modify(IntUnaryOperator func) {
+    int mc = modcount;
+    for (int i = 0; i < arr.length; i++) {
+      arr[i] = func.applyAsInt(arr[i]);
+    }
+    // Always false unless there is a call path from func.applyAsInt(..) to
+    // this method, but should not be reported, as checks guarding
+    // ConcurrentModificationExceptions are expected to always be false in the
+    // absence of API misuse.
+    if (mc != modcount)
+      throw new ConcurrentModificationException();
+    modcount++;
+  }
+}


### PR DESCRIPTION
As reported here: https://discuss.lgtm.com/t/false-positive-test-is-always-false/1405

In the absence of API misuse, these test are always false, so it doesn't make sense to report them.  And they'll occur for anyone who copies the collection implementation from JDK. 