### PR TITLE
Java: Clean up dataflow and improve path explanation toStrings.

### DIFF
--- a/cpp/ql/src/semmle/code/cpp/dataflow/internal/DataFlowImplCommon.qll
+++ b/cpp/ql/src/semmle/code/cpp/dataflow/internal/DataFlowImplCommon.qll
@@ -118,7 +118,7 @@ private module ImplCommon {
       node1.(ArgumentNode).argumentOf(call, i1) and
       node2.getPreUpdateNode().(ArgumentNode).argumentOf(call, i2) and
       compatibleTypes(node1.getTypeBound(), f.getType()) and
-      compatibleTypes(node2.getTypeBound(), f.getDeclaringType())
+      compatibleTypes(node2.getTypeBound(), f.getContainerType())
     )
   }
 
@@ -149,7 +149,7 @@ private module ImplCommon {
       setterReturn(p, f) and
       arg.argumentOf(node2.asExpr(), _) and
       compatibleTypes(node1.getTypeBound(), f.getType()) and
-      compatibleTypes(node2.getTypeBound(), f.getDeclaringType())
+      compatibleTypes(node2.getTypeBound(), f.getContainerType())
     )
   }
 
@@ -174,7 +174,7 @@ private module ImplCommon {
       viableParamArg(p, arg) and
       getter(p, f) and
       arg.argumentOf(node2.asExpr(), _) and
-      compatibleTypes(node1.getTypeBound(), f.getDeclaringType()) and
+      compatibleTypes(node1.getTypeBound(), f.getContainerType()) and
       compatibleTypes(node2.getTypeBound(), f.getType())
     )
   }

--- a/cpp/ql/src/semmle/code/cpp/dataflow/internal/DataFlowPrivate.qll
+++ b/cpp/ql/src/semmle/code/cpp/dataflow/internal/DataFlowPrivate.qll
@@ -69,18 +69,9 @@ class Content extends TContent {
     path = "" and sl = 0 and sc = 0 and el = 0 and ec = 0
   }
   /** Gets the type of the object containing this content. */
-  abstract RefType getDeclaringType();
+  abstract RefType getContainerType();
   /** Gets the type of this content. */
   abstract Type getType();
-  /**
-   * Holds if this content may contain an object of the same type as the one
-   * that contains this content, and if this fact should be used to compress
-   * access paths.
-   *
-   * Examples include the tail pointer in a linked list or the left and right
-   * pointers in a binary tree.
-   */
-  predicate isSelfRef() { none() }
 }
 private class FieldContent extends Content, TFieldContent {
   Field f;
@@ -90,17 +81,17 @@ private class FieldContent extends Content, TFieldContent {
   override predicate hasLocationInfo(string path, int sl, int sc, int el, int ec) {
     f.getLocation().hasLocationInfo(path, sl, sc, el, ec)
   }
-  override RefType getDeclaringType() { result = f.getDeclaringType() }
+  override RefType getContainerType() { result = f.getDeclaringType() }
   override Type getType() { result = f.getType() }
 }
 private class CollectionContent extends Content, TCollectionContent {
   override string toString() { result = "collection" }
-  override RefType getDeclaringType() { none() }
+  override RefType getContainerType() { none() }
   override Type getType() { none() }
 }
 private class ArrayContent extends Content, TArrayContent {
   override string toString() { result = "array" }
-  override RefType getDeclaringType() { none() }
+  override RefType getContainerType() { none() }
   override Type getType() { none() }
 }
 
@@ -130,6 +121,11 @@ predicate readStep(Node node1, Content f, Node node2) {
 RefType getErasedRepr(Type t) {
   suppressUnusedType(t) and
   result instanceof VoidType // stub implementation
+}
+
+/** Gets a string representation of a type returned by `getErasedRepr`. */
+string ppReprType(Type t) {
+  result = t.toString()
 }
 
 /**

--- a/java/ql/src/semmle/code/java/dataflow/internal/DataFlowImplCommon.qll
+++ b/java/ql/src/semmle/code/java/dataflow/internal/DataFlowImplCommon.qll
@@ -118,7 +118,7 @@ private module ImplCommon {
       node1.(ArgumentNode).argumentOf(call, i1) and
       node2.getPreUpdateNode().(ArgumentNode).argumentOf(call, i2) and
       compatibleTypes(node1.getTypeBound(), f.getType()) and
-      compatibleTypes(node2.getTypeBound(), f.getDeclaringType())
+      compatibleTypes(node2.getTypeBound(), f.getContainerType())
     )
   }
 
@@ -149,7 +149,7 @@ private module ImplCommon {
       setterReturn(p, f) and
       arg.argumentOf(node2.asExpr(), _) and
       compatibleTypes(node1.getTypeBound(), f.getType()) and
-      compatibleTypes(node2.getTypeBound(), f.getDeclaringType())
+      compatibleTypes(node2.getTypeBound(), f.getContainerType())
     )
   }
 
@@ -174,7 +174,7 @@ private module ImplCommon {
       viableParamArg(p, arg) and
       getter(p, f) and
       arg.argumentOf(node2.asExpr(), _) and
-      compatibleTypes(node1.getTypeBound(), f.getDeclaringType()) and
+      compatibleTypes(node1.getTypeBound(), f.getContainerType()) and
       compatibleTypes(node2.getTypeBound(), f.getType())
     )
   }


### PR DESCRIPTION
The `selfRef` isn't really needed anymore, since we don't manifest complete accesspaths, so there's no need for accesspath compression.  Removing this is technically a very minor precision improvement, but I doubt it'll matter.  More importantly it allows us to simplify some code.

I've also changed the `AccessPath.toString` as that's used in path explanations, and it was slightly misleading when the tracked object was of numeric type. It used to print "Double" regardless of the type, as that's the chosen numeric representative type - now it prints "Number" instead.