### PR TITLE
CPP: Exclude switch statements from HResultBooleanConversion.ql

### DIFF
--- a/cpp/ql/src/Security/CWE/CWE-253/HResultBooleanConversion.ql
+++ b/cpp/ql/src/Security/CWE/CWE-253/HResultBooleanConversion.ql
@@ -48,6 +48,7 @@ where exists
     ctls.getControllingExpr() = e1
     and e1.getType().(TypedefType).hasName("HRESULT")
     and not isHresultBooleanConverted(e1)
+    and not ctls instanceof SwitchStmt // not controlled by a boolean condition
     and msg = "Direct usage of a type " + e1.getType().toString() + " as a conditional expression"
   ) 
   or

--- a/cpp/ql/test/query-tests/Security/CWE/CWE-253/HResultBooleanConversion.c
+++ b/cpp/ql/test/query-tests/Security/CWE/CWE-253/HResultBooleanConversion.c
@@ -106,7 +106,7 @@ void IncorrectTypeConversionTest() {
     while (!HresultFunction()) {}; // BUG
     while (FAILED(HresultFunction())) {}; // Correct Usage
 
-    switch(hr) // Correct Usage [FALSE POSITIVE]
+    switch(hr) // Correct Usage
     {
     case S_OK:
     case S_FALSE:

--- a/cpp/ql/test/query-tests/Security/CWE/CWE-253/HResultBooleanConversion.c
+++ b/cpp/ql/test/query-tests/Security/CWE/CWE-253/HResultBooleanConversion.c
@@ -97,4 +97,26 @@ void IncorrectTypeConversionTest() {
     {
         // ...
     }
+
+    if (HresultFunction() == S_FALSE) // Correct Usage
+    {
+        // ...
+    }
+
+    while (!HresultFunction()) {}; // BUG
+    while (FAILED(HresultFunction())) {}; // Correct Usage
+
+    switch(hr) // Correct Usage [FALSE POSITIVE]
+    {
+    case S_OK:
+    case S_FALSE:
+        {
+            // ...
+        } break;
+
+    default:
+        {
+            // ...
+        } break;
+    }
 }

--- a/cpp/ql/test/query-tests/Security/CWE/CWE-253/HResultBooleanConversion.cpp
+++ b/cpp/ql/test/query-tests/Security/CWE/CWE-253/HResultBooleanConversion.cpp
@@ -94,4 +94,26 @@ void IncorrectTypeConversionTest() {
     {
         // ...
     }
+
+    if (HresultFunction() == S_FALSE) // Correct Usage
+    {
+        // ...
+    }
+
+    while (!HresultFunction()) {}; // BUG
+    while (FAILED(HresultFunction())) {}; // Correct Usage
+
+    switch(hr) // Correct Usage [FALSE POSITIVE]
+    {
+    case S_OK:
+    case S_FALSE:
+        {
+            // ...
+        } break;
+
+    default:
+        {
+            // ...
+        } break;
+    }
 }

--- a/cpp/ql/test/query-tests/Security/CWE/CWE-253/HResultBooleanConversion.cpp
+++ b/cpp/ql/test/query-tests/Security/CWE/CWE-253/HResultBooleanConversion.cpp
@@ -103,7 +103,7 @@ void IncorrectTypeConversionTest() {
     while (!HresultFunction()) {}; // BUG
     while (FAILED(HresultFunction())) {}; // Correct Usage
 
-    switch(hr) // Correct Usage [FALSE POSITIVE]
+    switch(hr) // Correct Usage
     {
     case S_OK:
     case S_FALSE:

--- a/cpp/ql/test/query-tests/Security/CWE/CWE-253/HResultBooleanConversion.expected
+++ b/cpp/ql/test/query-tests/Security/CWE/CWE-253/HResultBooleanConversion.expected
@@ -8,6 +8,8 @@
 | HResultBooleanConversion.c:79:15:79:38 | call to IncorrectHresultFunction | Implicit conversion from HRESULT to bool |
 | HResultBooleanConversion.c:82:10:82:11 | hr | Usage of a type HRESULT as an argument of a unary logical operation |
 | HResultBooleanConversion.c:92:9:92:10 | hr | Direct usage of a type HRESULT as a conditional expression |
+| HResultBooleanConversion.c:106:13:106:27 | call to HresultFunction | Usage of a type HRESULT as an argument of a unary logical operation |
+| HResultBooleanConversion.c:109:12:109:13 | hr | Direct usage of a type HRESULT as a conditional expression |
 | HResultBooleanConversion.cpp:39:12:39:23 | call to BoolFunction | Implicit conversion from BOOL to HRESULT |
 | HResultBooleanConversion.cpp:44:12:44:24 | call to BoolFunction2 | Implicit conversion from bool to HRESULT |
 | HResultBooleanConversion.cpp:50:15:50:16 | hr | Explicit conversion from HRESULT to BOOL |
@@ -18,3 +20,5 @@
 | HResultBooleanConversion.cpp:76:15:76:38 | call to IncorrectHresultFunction | Implicit conversion from HRESULT to bool |
 | HResultBooleanConversion.cpp:79:10:79:11 | hr | Implicit conversion from HRESULT to bool |
 | HResultBooleanConversion.cpp:89:9:89:10 | hr | Implicit conversion from HRESULT to bool |
+| HResultBooleanConversion.cpp:103:13:103:27 | call to HresultFunction | Implicit conversion from HRESULT to bool |
+| HResultBooleanConversion.cpp:106:12:106:13 | hr | Direct usage of a type HRESULT as a conditional expression |

--- a/cpp/ql/test/query-tests/Security/CWE/CWE-253/HResultBooleanConversion.expected
+++ b/cpp/ql/test/query-tests/Security/CWE/CWE-253/HResultBooleanConversion.expected
@@ -9,7 +9,6 @@
 | HResultBooleanConversion.c:82:10:82:11 | hr | Usage of a type HRESULT as an argument of a unary logical operation |
 | HResultBooleanConversion.c:92:9:92:10 | hr | Direct usage of a type HRESULT as a conditional expression |
 | HResultBooleanConversion.c:106:13:106:27 | call to HresultFunction | Usage of a type HRESULT as an argument of a unary logical operation |
-| HResultBooleanConversion.c:109:12:109:13 | hr | Direct usage of a type HRESULT as a conditional expression |
 | HResultBooleanConversion.cpp:39:12:39:23 | call to BoolFunction | Implicit conversion from BOOL to HRESULT |
 | HResultBooleanConversion.cpp:44:12:44:24 | call to BoolFunction2 | Implicit conversion from bool to HRESULT |
 | HResultBooleanConversion.cpp:50:15:50:16 | hr | Explicit conversion from HRESULT to BOOL |
@@ -21,4 +20,3 @@
 | HResultBooleanConversion.cpp:79:10:79:11 | hr | Implicit conversion from HRESULT to bool |
 | HResultBooleanConversion.cpp:89:9:89:10 | hr | Implicit conversion from HRESULT to bool |
 | HResultBooleanConversion.cpp:103:13:103:27 | call to HresultFunction | Implicit conversion from HRESULT to bool |
-| HResultBooleanConversion.cpp:106:12:106:13 | hr | Direct usage of a type HRESULT as a conditional expression |


### PR DESCRIPTION
This query was producing results on switch statements that I believe were false positives.  The controlling expression of a switch statement is not interpreted as a boolean condition.

@dave-bartolomeo 