### PR TITLE
CPP: Use newer taint tracking in Overflowdest.ql

### DIFF
--- a/cpp/ql/test/query-tests/Security/CWE/CWE-119/semmle/tests/OverflowDestination.expected
+++ b/cpp/ql/test/query-tests/Security/CWE/CWE-119/semmle/tests/OverflowDestination.expected
@@ -1,4 +1,1 @@
 | overflowdestination.cpp:30:2:30:8 | call to strncpy | To avoid overflow, this operation should be bounded by destination-buffer size, not source-buffer size. |
-| overflowdestination.cpp:46:2:46:7 | call to memcpy | To avoid overflow, this operation should be bounded by destination-buffer size, not source-buffer size. |
-| overflowdestination.cpp:53:2:53:7 | call to memcpy | To avoid overflow, this operation should be bounded by destination-buffer size, not source-buffer size. |
-| overflowdestination.cpp:64:2:64:7 | call to memcpy | To avoid overflow, this operation should be bounded by destination-buffer size, not source-buffer size. |

--- a/cpp/ql/test/query-tests/Security/CWE/CWE-119/semmle/tests/overflowdestination.cpp
+++ b/cpp/ql/test/query-tests/Security/CWE/CWE-119/semmle/tests/overflowdestination.cpp
@@ -43,14 +43,14 @@ void overflowdest_test1(FILE *f)
 	fgets(src, 128, f); // GOOD (taints `src`)
 
 	memcpy(dest, src, sizeof(dest)); // GOOD
-	memcpy(dest, src, sizeof(src)); // BAD: size derived from the source buffer
+	memcpy(dest, src, sizeof(src)); // BAD: size derived from the source buffer [NOT REPORTED]
 	memcpy(dest, dest, sizeof(dest)); // GOOD
 }
 
 void overflowdest_test2(FILE *f, char *dest, char *src)
 {
 	memcpy(dest, src, strlen(dest) + 1); // GOOD
-	memcpy(dest, src, strlen(src) + 1); // BAD: size derived from the source buffer
+	memcpy(dest, src, strlen(src) + 1); // BAD: size derived from the source buffer [NOT REPORTED]
 	memcpy(dest, dest, strlen(dest) + 1); // GOOD
 }
 
@@ -61,7 +61,7 @@ void overflowdest_test3(FILE *f, char *dest, char *src)
 	char *src3 = src;
 
 	memcpy(dest2, src2, strlen(dest2) + 1); // GOOD
-	memcpy(dest2, src2, strlen(src2) + 1); // BAD: size derived from the source buffer
+	memcpy(dest2, src2, strlen(src2) + 1); // BAD: size derived from the source buffer [NOT REPORTED]
 	memcpy(dest2, dest2, strlen(dest2) + 1); // GOOD
 }
 


### PR DESCRIPTION
Switch Overflowdest.ql from `security.TaintTracking` to newer `dataflow.TaintTracking` as has been requested.  See discussion in https://github.com/Semmle/ql/pull/329.  This will cause some test failures and should not be merged until the latter taint library has been extended to handle cases such as:
```
char array[128];

taintSource(array);

// ...

taintSink(array);
```
(@rdmarsh2 estimates early November)

In addition we should probably run query differences of some sort on this query once the tests pass.  And probably give it a change note.