### PR TITLE
CPP: Add detail to the CPP-205 test

### DIFF
--- a/cpp/ql/test/library-tests/CPP-205/elements.expected
+++ b/cpp/ql/test/library-tests/CPP-205/elements.expected
@@ -27,8 +27,8 @@
 | CPP-205.cpp:8:10:8:11 | call to fn |  |
 | CPP-205.cpp:8:13:8:13 | 0 |  |
 | file://:0:0:0:0 | __va_list_tag |  |
-| file://:0:0:0:0 | operator= | function operator=(__va_list_tag &&) -> __va_list_tag & |
-| file://:0:0:0:0 | operator= | function operator=(const __va_list_tag &) -> __va_list_tag & |
-| file://:0:0:0:0 | p#0 | parameter for operator=(__va_list_tag &&) -> __va_list_tag & |
-| file://:0:0:0:0 | p#0 | parameter for operator=(const __va_list_tag &) -> __va_list_tag & |
+| file://:0:0:0:0 | operator= | function __va_list_tag::operator=(__va_list_tag &&) -> __va_list_tag & |
+| file://:0:0:0:0 | operator= | function __va_list_tag::operator=(const __va_list_tag &) -> __va_list_tag & |
+| file://:0:0:0:0 | p#0 | parameter for __va_list_tag::operator=(__va_list_tag &&) -> __va_list_tag & |
+| file://:0:0:0:0 | p#0 | parameter for __va_list_tag::operator=(const __va_list_tag &) -> __va_list_tag & |
 | file://:0:0:0:0 | y |  |

--- a/cpp/ql/test/library-tests/CPP-205/elements.expected
+++ b/cpp/ql/test/library-tests/CPP-205/elements.expected
@@ -1,12 +1,12 @@
 | CPP-205.cpp:0:0:0:0 | CPP-205.cpp |  |
 | CPP-205.cpp:1:20:1:20 | T |  |
 | CPP-205.cpp:1:20:1:20 | definition of T |  |
-| CPP-205.cpp:2:5:2:6 | definition of fn | from fn<T>(T) -> int |
-| CPP-205.cpp:2:5:2:6 | fn | from fn<T>(T) -> int |
-| CPP-205.cpp:2:5:2:6 | fn | from fn<int>(int) -> int |
-| CPP-205.cpp:2:10:2:12 | definition of out | from fn<T>(T) -> int |
-| CPP-205.cpp:2:10:2:12 | out | from fn<T>(T) -> int |
-| CPP-205.cpp:2:10:2:12 | out | from fn<int>(int) -> int |
+| CPP-205.cpp:2:5:2:6 | definition of fn | function declaration entry for fn<T>(T) -> int |
+| CPP-205.cpp:2:5:2:6 | fn | function fn<T>(T) -> int |
+| CPP-205.cpp:2:5:2:6 | fn | function fn<int>(int) -> int |
+| CPP-205.cpp:2:10:2:12 | definition of out | parameter declaration entry for fn<T>(T) -> int |
+| CPP-205.cpp:2:10:2:12 | out | parameter for fn<T>(T) -> int |
+| CPP-205.cpp:2:10:2:12 | out | parameter for fn<int>(int) -> int |
 | CPP-205.cpp:2:15:5:1 | { ... } |  |
 | CPP-205.cpp:2:15:5:1 | { ... } |  |
 | CPP-205.cpp:3:3:3:33 | declaration |  |
@@ -20,11 +20,11 @@
 | CPP-205.cpp:4:3:4:11 | return ... |  |
 | CPP-205.cpp:4:10:4:10 | 0 |  |
 | CPP-205.cpp:4:10:4:10 | 0 |  |
-| CPP-205.cpp:7:5:7:8 | definition of main | from main() -> int |
-| CPP-205.cpp:7:5:7:8 | main | from main() -> int |
+| CPP-205.cpp:7:5:7:8 | definition of main | function declaration entry for main() -> int |
+| CPP-205.cpp:7:5:7:8 | main | function main() -> int |
 | CPP-205.cpp:7:12:9:1 | { ... } |  |
 | CPP-205.cpp:8:3:8:15 | return ... |  |
 | CPP-205.cpp:8:10:8:11 | call to fn |  |
 | CPP-205.cpp:8:13:8:13 | 0 |  |
-| file://:0:0:0:0 | operator= | from __va_list_tag::operator=() -> __va_list_tag & |
-| file://:0:0:0:0 | operator= | from __va_list_tag::operator=() -> __va_list_tag & |
+| file://:0:0:0:0 | operator= | function __va_list_tag::operator=() -> __va_list_tag & |
+| file://:0:0:0:0 | operator= | function __va_list_tag::operator=() -> __va_list_tag & |

--- a/cpp/ql/test/library-tests/CPP-205/elements.expected
+++ b/cpp/ql/test/library-tests/CPP-205/elements.expected
@@ -1,34 +1,30 @@
-| CPP-205.cpp:0:0:0:0 | CPP-205.cpp |
-| CPP-205.cpp:1:20:1:20 | T |
-| CPP-205.cpp:1:20:1:20 | definition of T |
-| CPP-205.cpp:2:5:2:5 | definition of fn |
-| CPP-205.cpp:2:5:2:5 | fn |
-| CPP-205.cpp:2:5:2:6 | definition of fn |
-| CPP-205.cpp:2:5:2:6 | fn |
-| CPP-205.cpp:2:10:2:12 | definition of out |
-| CPP-205.cpp:2:10:2:12 | definition of out |
-| CPP-205.cpp:2:10:2:12 | out |
-| CPP-205.cpp:2:10:2:12 | out |
-| CPP-205.cpp:2:15:5:1 | { ... } |
-| CPP-205.cpp:2:15:5:1 | { ... } |
-| CPP-205.cpp:3:3:3:33 | declaration |
-| CPP-205.cpp:3:3:3:33 | declaration |
-| CPP-205.cpp:3:15:3:15 | declaration of y |
-| CPP-205.cpp:3:15:3:15 | y |
-| CPP-205.cpp:3:17:3:31 | 5 |
-| CPP-205.cpp:4:3:4:11 | return ... |
-| CPP-205.cpp:4:3:4:11 | return ... |
-| CPP-205.cpp:4:10:4:10 | 0 |
-| CPP-205.cpp:4:10:4:10 | 0 |
-| CPP-205.cpp:7:5:7:8 | definition of main |
-| CPP-205.cpp:7:5:7:8 | main |
-| CPP-205.cpp:7:12:9:1 | { ... } |
-| CPP-205.cpp:8:3:8:15 | return ... |
-| CPP-205.cpp:8:10:8:11 | call to fn |
-| CPP-205.cpp:8:13:8:13 | 0 |
-| file://:0:0:0:0 | __va_list_tag |
-| file://:0:0:0:0 | operator= |
-| file://:0:0:0:0 | operator= |
-| file://:0:0:0:0 | p#0 |
-| file://:0:0:0:0 | p#0 |
-| file://:0:0:0:0 | y |
+| CPP-205.cpp:0:0:0:0 | CPP-205.cpp |  |
+| CPP-205.cpp:1:20:1:20 | T |  |
+| CPP-205.cpp:1:20:1:20 | definition of T |  |
+| CPP-205.cpp:2:5:2:6 | definition of fn | from fn<T>(T) -> int |
+| CPP-205.cpp:2:5:2:6 | fn | from fn<T>(T) -> int |
+| CPP-205.cpp:2:5:2:6 | fn | from fn<int>(int) -> int |
+| CPP-205.cpp:2:10:2:12 | definition of out | from fn<T>(T) -> int |
+| CPP-205.cpp:2:10:2:12 | out | from fn<T>(T) -> int |
+| CPP-205.cpp:2:10:2:12 | out | from fn<int>(int) -> int |
+| CPP-205.cpp:2:15:5:1 | { ... } |  |
+| CPP-205.cpp:2:15:5:1 | { ... } |  |
+| CPP-205.cpp:3:3:3:33 | declaration |  |
+| CPP-205.cpp:3:3:3:33 | declaration |  |
+| CPP-205.cpp:3:15:3:15 | declaration of y |  |
+| CPP-205.cpp:3:15:3:15 | declaration of y |  |
+| CPP-205.cpp:3:15:3:15 | y |  |
+| CPP-205.cpp:3:15:3:15 | y |  |
+| CPP-205.cpp:3:17:3:31 | 5 |  |
+| CPP-205.cpp:4:3:4:11 | return ... |  |
+| CPP-205.cpp:4:3:4:11 | return ... |  |
+| CPP-205.cpp:4:10:4:10 | 0 |  |
+| CPP-205.cpp:4:10:4:10 | 0 |  |
+| CPP-205.cpp:7:5:7:8 | definition of main | from main() -> int |
+| CPP-205.cpp:7:5:7:8 | main | from main() -> int |
+| CPP-205.cpp:7:12:9:1 | { ... } |  |
+| CPP-205.cpp:8:3:8:15 | return ... |  |
+| CPP-205.cpp:8:10:8:11 | call to fn |  |
+| CPP-205.cpp:8:13:8:13 | 0 |  |
+| file://:0:0:0:0 | operator= | from __va_list_tag::operator=() -> __va_list_tag & |
+| file://:0:0:0:0 | operator= | from __va_list_tag::operator=() -> __va_list_tag & |

--- a/cpp/ql/test/library-tests/CPP-205/elements.expected
+++ b/cpp/ql/test/library-tests/CPP-205/elements.expected
@@ -1,10 +1,12 @@
 | CPP-205.cpp:0:0:0:0 | CPP-205.cpp |  |
 | CPP-205.cpp:1:20:1:20 | T |  |
 | CPP-205.cpp:1:20:1:20 | definition of T |  |
+| CPP-205.cpp:2:5:2:5 | definition of fn | function declaration entry for fn<int>(int) -> int |
+| CPP-205.cpp:2:5:2:5 | fn | function fn<int>(int) -> int |
 | CPP-205.cpp:2:5:2:6 | definition of fn | function declaration entry for fn<T>(T) -> int |
 | CPP-205.cpp:2:5:2:6 | fn | function fn<T>(T) -> int |
-| CPP-205.cpp:2:5:2:6 | fn | function fn<int>(int) -> int |
 | CPP-205.cpp:2:10:2:12 | definition of out | parameter declaration entry for fn<T>(T) -> int |
+| CPP-205.cpp:2:10:2:12 | definition of out | parameter declaration entry for fn<int>(int) -> int |
 | CPP-205.cpp:2:10:2:12 | out | parameter for fn<T>(T) -> int |
 | CPP-205.cpp:2:10:2:12 | out | parameter for fn<int>(int) -> int |
 | CPP-205.cpp:2:15:5:1 | { ... } |  |
@@ -12,8 +14,6 @@
 | CPP-205.cpp:3:3:3:33 | declaration |  |
 | CPP-205.cpp:3:3:3:33 | declaration |  |
 | CPP-205.cpp:3:15:3:15 | declaration of y |  |
-| CPP-205.cpp:3:15:3:15 | declaration of y |  |
-| CPP-205.cpp:3:15:3:15 | y |  |
 | CPP-205.cpp:3:15:3:15 | y |  |
 | CPP-205.cpp:3:17:3:31 | 5 |  |
 | CPP-205.cpp:4:3:4:11 | return ... |  |
@@ -26,5 +26,9 @@
 | CPP-205.cpp:8:3:8:15 | return ... |  |
 | CPP-205.cpp:8:10:8:11 | call to fn |  |
 | CPP-205.cpp:8:13:8:13 | 0 |  |
-| file://:0:0:0:0 | operator= | function __va_list_tag::operator=() -> __va_list_tag & |
-| file://:0:0:0:0 | operator= | function __va_list_tag::operator=() -> __va_list_tag & |
+| file://:0:0:0:0 | __va_list_tag |  |
+| file://:0:0:0:0 | operator= | function operator=(__va_list_tag &&) -> __va_list_tag & |
+| file://:0:0:0:0 | operator= | function operator=(const __va_list_tag &) -> __va_list_tag & |
+| file://:0:0:0:0 | p#0 | parameter for operator=(__va_list_tag &&) -> __va_list_tag & |
+| file://:0:0:0:0 | p#0 | parameter for operator=(const __va_list_tag &) -> __va_list_tag & |
+| file://:0:0:0:0 | y |  |

--- a/cpp/ql/test/library-tests/CPP-205/elements.ql
+++ b/cpp/ql/test/library-tests/CPP-205/elements.ql
@@ -1,13 +1,13 @@
 import cpp
 
 string describe(Element e) {
-  result = "from " + e.(Function).getFullSignature()
+  result = "function " + e.(Function).getFullSignature()
   or
-  result = "from " + e.(FunctionDeclarationEntry).getFunction().getFullSignature()
+  result = "function declaration entry for " + e.(FunctionDeclarationEntry).getFunction().getFullSignature()
   or
-  result = "from " + e.(Parameter).getFunction().getFullSignature()
+  result = "parameter for " + e.(Parameter).getFunction().getFullSignature()
   or
-  result = "from " + e.(ParameterDeclarationEntry).getFunctionDeclarationEntry().getFunction().getFullSignature()
+  result = "parameter declaration entry for " + e.(ParameterDeclarationEntry).getFunctionDeclarationEntry().getFunction().getFullSignature()
 }
 
 from Element e

--- a/cpp/ql/test/library-tests/CPP-205/elements.ql
+++ b/cpp/ql/test/library-tests/CPP-205/elements.ql
@@ -1,6 +1,16 @@
 import cpp
 
+string describe(Element e) {
+  result = "from " + e.(Function).getFullSignature()
+  or
+  result = "from " + e.(FunctionDeclarationEntry).getFunction().getFullSignature()
+  or
+  result = "from " + e.(Parameter).getFunction().getFullSignature()
+  or
+  result = "from " + e.(ParameterDeclarationEntry).getFunctionDeclarationEntry().getFunction().getFullSignature()
+}
+
 from Element e
 where not e.getLocation() instanceof UnknownLocation
   and not e instanceof Folder
-select e
+select e, concat(describe(e), ", ")


### PR DESCRIPTION
Add detail to the CPP-205 test, so that it's easier to tell which things are associated with which template / instantiation (see also the discover_walk changes https://github.com/Semmle/ql/pull/317/files#diff-9ebc04b7555032e8235243d1e995883d).

@jbj 