### PR TITLE
JavaScript: Copy over a test left in internal repo.

### DIFF
--- a/javascript/ql/test/library-tests/TypeScript/TypeAnnotations/ImportTypeExpr.expected
+++ b/javascript/ql/test/library-tests/TypeScript/TypeAnnotations/ImportTypeExpr.expected
@@ -1,0 +1,7 @@
+| tst.ts:122:19:122:32 | import("type") | type | type |
+| tst.ts:123:26:123:39 | import("type") | type | type |
+| tst.ts:124:28:124:46 | import("namespace") | namespace | namespace |
+| tst.ts:125:35:125:53 | import("namespace") | namespace | namespace |
+| tst.ts:126:28:126:42 | import("value") | value | value |
+| tst.ts:127:37:127:51 | import("value") | value | value |
+| tst.ts:128:38:130:3 | import( ... ce'\\n  ) | awkard-namespace | namespace |

--- a/javascript/ql/test/library-tests/TypeScript/TypeAnnotations/ImportTypeExpr.ql
+++ b/javascript/ql/test/library-tests/TypeScript/TypeAnnotations/ImportTypeExpr.ql
@@ -1,0 +1,13 @@
+import javascript
+
+string getKind(ImportTypeExpr imprt) {
+  if imprt.isTypeAccess() then
+    result = "type"
+  else if imprt.isNamespaceAccess() then
+    result = "namespace"
+  else
+    result = "value"
+}
+
+from ImportTypeExpr imprt
+select imprt, imprt.getPath(), getKind(imprt)


### PR DESCRIPTION
This test seems to have been accidentally committed into the old location in the internal repo.