### PR TITLE
C++: Add C++ analysis team to CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,3 +1,4 @@
 /csharp/ @Semmle/cs
 /java/ @Semmle/java
 /javascript/ @Semmle/js
+/cpp/ @Semmle/cpp-analysis


### PR DESCRIPTION
We previously removed our entry because the notifications got too noisy, but we agreed recently in the C++ analysis team to try adding an entry with just the analysis team and only in the public repository.