### PR TITLE
C#: Remove results from cs/local-shadows-member

### DIFF
--- a/change-notes/1.19/analysis-csharp.md
+++ b/change-notes/1.19/analysis-csharp.md
@@ -13,7 +13,7 @@
 ## Changes to existing queries
 
 | Inconsistent lock sequence (`cs/inconsistent-lock-sequence`) | More results | This query now finds inconsistent lock sequences globally across calls. |
-
+| Local scope variable shadows member (`cs/local-shadows-member`) | Fewer results | Results have been removed where a constructor parameter shadows a member, because the parameter is probably used to initialise the member. |
 | *@name of query (Query ID)*| *Impact on results*    | *How/why the query has changed*                                  |
 
 

--- a/csharp/extractor/Semmle.Extraction.CIL/Entities/Field.cs
+++ b/csharp/extractor/Semmle.Extraction.CIL/Entities/Field.cs
@@ -62,9 +62,9 @@ namespace Semmle.Extraction.CIL.Entities
             }
         }
 
-        public void Extract(Context cx)
+        public void Extract(Context cx2)
         {
-            cx.Populate(this);
+            cx2.Populate(this);
         }
 
         TrapStackBehaviour IEntity.TrapStackBehaviour => TrapStackBehaviour.NoLabel;

--- a/csharp/extractor/Semmle.Extraction.CIL/Entities/Type.cs
+++ b/csharp/extractor/Semmle.Extraction.CIL/Entities/Type.cs
@@ -60,7 +60,7 @@ namespace Semmle.Extraction.CIL.Entities
 
         Location IEntity.ReportingLocation => throw new NotImplementedException();
 
-        public void Extract(Context cx) { cx.Populate(this); }
+        public void Extract(Context cx2) { cx2.Populate(this); }
 
         public abstract IEnumerable<IExtractionProduct> Contents { get; }
 
@@ -83,13 +83,13 @@ namespace Semmle.Extraction.CIL.Entities
         /// <summary>
         /// Find the method in this type matching the name and signature.
         /// </summary>
-        /// <param name="Name">The handle to the name.</param>
+        /// <param name="MethodNmae">The handle to the name.</param>
         /// <param name="signature">
         /// The handle to the signature. Note that comparing handles is a valid
         /// shortcut to comparing the signature bytes since handles are unique.
         /// </param>
         /// <returns>The method, or 'null' if not found or not supported.</returns>
-        internal virtual Method LookupMethod(StringHandle Name, BlobHandle signature)
+        internal virtual Method LookupMethod(StringHandle MethodNmae, BlobHandle signature)
         {
             return null;
         }
@@ -338,16 +338,16 @@ namespace Semmle.Extraction.CIL.Entities
             if (ThisTypeParameters == 0)
                 return Enumerable.Empty<TypeTypeParameter>();
 
-            var typeParams = new TypeTypeParameter[ThisTypeParameters];
+            var newTypeParams = new TypeTypeParameter[ThisTypeParameters];
             var genericParams = td.GetGenericParameters();
-            int toSkip = genericParams.Count - typeParams.Length;
+            int toSkip = genericParams.Count - newTypeParams.Length;
 
             // Two-phase population because type parameters can be mutually dependent
-            for (int i = 0; i < typeParams.Length; ++i)
-                typeParams[i] = cx.Populate(new TypeTypeParameter(this, this, i));
-            for (int i = 0; i < typeParams.Length; ++i)
-                typeParams[i].PopulateHandle(this, genericParams[i + toSkip]);
-            return typeParams;
+            for (int i = 0; i < newTypeParams.Length; ++i)
+                newTypeParams[i] = cx.Populate(new TypeTypeParameter(this, this, i));
+            for (int i = 0; i < newTypeParams.Length; ++i)
+                newTypeParams[i].PopulateHandle(this, genericParams[i + toSkip]);
+            return newTypeParams;
         }
 
         readonly Lazy<IEnumerable<TypeTypeParameter>> typeParams;
@@ -482,12 +482,12 @@ namespace Semmle.Extraction.CIL.Entities
 
         TypeTypeParameter[] MakeTypeParameters()
         {
-            var typeParams = new TypeTypeParameter[ThisTypeParameters];
-            for (int i = 0; i < typeParams.Length; ++i)
+            var newTypeParams = new TypeTypeParameter[ThisTypeParameters];
+            for (int i = 0; i < newTypeParams.Length; ++i)
             {
-                typeParams[i] = new TypeTypeParameter(this, this, i);
+                newTypeParams[i] = new TypeTypeParameter(this, this, i);
             }
-            return typeParams;
+            return newTypeParams;
         }
 
         public override IEnumerable<IExtractionProduct> Contents

--- a/csharp/extractor/Semmle.Extraction.CIL/ExtractionProduct.cs
+++ b/csharp/extractor/Semmle.Extraction.CIL/ExtractionProduct.cs
@@ -49,9 +49,9 @@ namespace Semmle.Extraction.CIL
 
         public virtual IId Id => FreshId.Instance;
 
-        public virtual void Extract(Context cx)
+        public virtual void Extract(Context cx2)
         {
-            cx.Extract(this);
+            cx2.Extract(this);
         }
 
         public readonly Context cx;
@@ -79,9 +79,9 @@ namespace Semmle.Extraction.CIL
         public abstract Id IdSuffix { get; }
         public IId Id => ShortId + IdSuffix;
 
-        public void Extract(Context cx)
+        public void Extract(Context cx2)
         {
-            cx.Populate(this);
+            cx2.Populate(this);
         }
 
         public readonly Context cx;

--- a/csharp/extractor/Semmle.Extraction.CSharp/Entities/Attribute.cs
+++ b/csharp/extractor/Semmle.Extraction.CSharp/Entities/Attribute.cs
@@ -21,7 +21,7 @@ namespace Semmle.Extraction.CSharp.Entities
                 // existence of a syntax tree. This is not the case for compiled
                 // attributes.
                 var syntax = attribute.ApplicationSyntaxReference.GetSyntax() as AttributeSyntax;
-                ExtractAttribute(cx, syntax, attribute.AttributeClass, entity);
+                ExtractAttribute(syntax, attribute.AttributeClass, entity);
             }
         }
 
@@ -29,10 +29,10 @@ namespace Semmle.Extraction.CSharp.Entities
             : base(cx)
         {
             var info = cx.GetSymbolInfo(attribute);
-            ExtractAttribute(cx, attribute, info.Symbol.ContainingType, entity);
+            ExtractAttribute(attribute, info.Symbol.ContainingType, entity);
         }
 
-        void ExtractAttribute(Context cx, AttributeSyntax syntax, ITypeSymbol attributeClass, IEntity entity)
+        void ExtractAttribute(AttributeSyntax syntax, ITypeSymbol attributeClass, IEntity entity)
         {
             var type = Type.Create(cx, attributeClass);
             cx.Emit(Tuples.attributes(this, type.TypeRef, entity));

--- a/csharp/extractor/Semmle.Extraction.CSharp/Entities/Expression.cs
+++ b/csharp/extractor/Semmle.Extraction.CSharp/Entities/Expression.cs
@@ -202,13 +202,13 @@ namespace Semmle.Extraction.CSharp.Entities
             cx.Emit(Tuples.conditional_access(this));
         }
 
-        public void PopulateArguments(Context cx, BaseArgumentListSyntax args, int child)
+        public void PopulateArguments(BaseArgumentListSyntax args, int child)
         {
             foreach (var arg in args.Arguments)
-                PopulateArgument(cx, arg, child++);
+                PopulateArgument(arg, child++);
         }
 
-        private void PopulateArgument(Context cx, ArgumentSyntax arg, int child)
+        private void PopulateArgument(ArgumentSyntax arg, int child)
         {
             var expr = Create(cx, arg.Expression, this, child);
             int mode;

--- a/csharp/extractor/Semmle.Extraction.CSharp/Entities/Expressions/ElementAccess.cs
+++ b/csharp/extractor/Semmle.Extraction.CSharp/Entities/Expressions/ElementAccess.cs
@@ -27,7 +27,7 @@ namespace Semmle.Extraction.CSharp.Entities.Expressions
                 var add = new Expression(new ExpressionInfo(cx, qualifierInfo.Type, Location, ExprKind.ADD, this, 0, false, null));
                 qualifierInfo.SetParent(add, 0);
                 CreateFromNode(qualifierInfo);
-                PopulateArguments(cx, ArgumentList, 1);
+                PopulateArguments(ArgumentList, 1);
             }
             else
             {

--- a/csharp/extractor/Semmle.Extraction.CSharp/Entities/Expressions/Invocation.cs
+++ b/csharp/extractor/Semmle.Extraction.CSharp/Entities/Expressions/Invocation.cs
@@ -22,7 +22,7 @@ namespace Semmle.Extraction.CSharp.Entities.Expressions
         {
             if (IsNameof(Syntax))
             {
-                PopulateArguments(cx, Syntax.ArgumentList, 0);
+                PopulateArguments(Syntax.ArgumentList, 0);
                 return;
             }
 
@@ -80,7 +80,7 @@ namespace Semmle.Extraction.CSharp.Entities.Expressions
                     cx.ModelError(Syntax, "Unable to get name for dynamic call.");
             }
 
-            PopulateArguments(cx, Syntax.ArgumentList, child);
+            PopulateArguments(Syntax.ArgumentList, child);
 
             if (target == null)
             {

--- a/csharp/extractor/Semmle.Extraction.CSharp/Entities/Expressions/Lambda.cs
+++ b/csharp/extractor/Semmle.Extraction.CSharp/Entities/Expressions/Lambda.cs
@@ -14,7 +14,7 @@ namespace Semmle.Extraction.CSharp.Entities.Expressions
 
         protected override void Populate() { }
 
-        void VisitParameter(Context cx, ParameterSyntax p)
+        void VisitParameter(ParameterSyntax p)
         {
             var symbol = cx.Model(p).GetDeclaredSymbol(p);
             Parameter.Create(cx, symbol, this);
@@ -27,7 +27,7 @@ namespace Semmle.Extraction.CSharp.Entities.Expressions
             cx.PopulateLater(() =>
             {
                 foreach (var param in @params)
-                    VisitParameter(cx, param);
+                    VisitParameter(param);
 
                 if (body is ExpressionSyntax)
                     Create(cx, (ExpressionSyntax)body, this, 0);

--- a/csharp/extractor/Semmle.Extraction.CSharp/Entities/Expressions/ObjectCreation.cs
+++ b/csharp/extractor/Semmle.Extraction.CSharp/Entities/Expressions/ObjectCreation.cs
@@ -37,7 +37,7 @@ namespace Semmle.Extraction.CSharp.Entities.Expressions
         {
             if (Syntax.ArgumentList != null)
             {
-                PopulateArguments(cx, Syntax.ArgumentList, 0);
+                PopulateArguments(Syntax.ArgumentList, 0);
             }
 
             var target = cx.Model(Syntax).GetSymbolInfo(Syntax);

--- a/csharp/extractor/Semmle.Extraction.CSharp/Entities/NamespaceDeclaration.cs
+++ b/csharp/extractor/Semmle.Extraction.CSharp/Entities/NamespaceDeclaration.cs
@@ -29,11 +29,6 @@ namespace Semmle.Extraction.CSharp.Entities
             }
         }
 
-        public void Extract(Context cx, NamespaceDeclarationSyntax decl)
-        {
-            decl.Accept(new Populators.TypeOrNamespaceVisitor(cx, this));
-        }
-
         public static NamespaceDeclaration Create(Context cx, NamespaceDeclarationSyntax decl, NamespaceDeclaration parent) => new NamespaceDeclaration(cx, decl, parent);
 
         public override TrapStackBehaviour TrapStackBehaviour => TrapStackBehaviour.NoLabel;

--- a/csharp/ql/src/Bad Practices/Declarations/LocalScopeVariableShadowsMember.ql
+++ b/csharp/ql/src/Bad Practices/Declarations/LocalScopeVariableShadowsMember.ql
@@ -38,6 +38,8 @@ private predicate acceptableShadowing(LocalScopeVariable v, Member m) {
       ma.targetIsLocalInstance() and
       not ma.getQualifier().isImplicit()
     )
+    or
+    t.getAConstructor().getAParameter() = v
   )
 }
 

--- a/csharp/ql/test/query-tests/Bad Practices/Declarations/LocalScopeVariableShadowsMember/LocalScopeVariableShadowsMember.cs
+++ b/csharp/ql/test/query-tests/Bad Practices/Declarations/LocalScopeVariableShadowsMember/LocalScopeVariableShadowsMember.cs
@@ -56,4 +56,9 @@ class LocalScopeVariableShadowsMember
 
         public void M5(int f2) { } // GOOD
     }
+
+    class C4 : C
+    {
+        public C4(int f) { } // GOOD
+    }
 }


### PR DESCRIPTION
- Remove a few results in the extractor codebase.
- Change the query to remove results whereby a constructor parameter shadows a member, because it is probably used to initialise the variable, and having the same name helps document that.