### PR TITLE
Java: Whitelist Cookie::getName for HTTP response splitting.

### DIFF
--- a/java/ql/src/Security/CWE/CWE-113/ResponseSplitting.qll
+++ b/java/ql/src/Security/CWE/CWE-113/ResponseSplitting.qll
@@ -32,6 +32,7 @@ class HeaderSplittingSink extends DataFlow::ExprNode {
 
 class WhitelistedSource extends RemoteUserInput {
   WhitelistedSource() {
-    this.asExpr().(MethodAccess).getMethod() instanceof HttpServletRequestGetHeaderMethod
+    this.asExpr().(MethodAccess).getMethod() instanceof HttpServletRequestGetHeaderMethod or
+    this.asExpr().(MethodAccess).getMethod() instanceof CookieGetNameMethod
   }
 }

--- a/java/ql/test/query-tests/security/CWE-113/semmle/tests/ResponseSplitting.java
+++ b/java/ql/test/query-tests/security/CWE-113/semmle/tests/ResponseSplitting.java
@@ -24,7 +24,7 @@ public class ResponseSplitting extends HttpServlet {
 		}
 
 		// BAD: setting a header with an unvalidated parameter
-		// can lead to hTTP splitting
+		// can lead to HTTP splitting
 		response.addHeader("Content-type", request.getParameter("contentType"));
 		response.setHeader("Content-type", request.getParameter("contentType"));
 
@@ -41,5 +41,11 @@ public class ResponseSplitting extends HttpServlet {
 
 	private static String removeSpecial(String str) {
 		return str.replaceAll("[^a-zA-Z ]", "");
+	}
+
+	public void addCookieName(HttpServletResponse response, Cookie cookie) {
+		// GOOD: cookie.getName() cannot lead to HTTP splitting
+		Cookie cookie2 = new Cookie("name", cookie.getName());
+		response.addCookie(cookie2);
 	}
 }


### PR DESCRIPTION
`Cookie::getName` cannot contain whitespace, and is therefore added to the source whitelist for HTTP response splitting.

@pavgust 