### PR TITLE
CPP: Improve memberMayBeVarSize

### DIFF
--- a/change-notes/1.19/analysis-cpp.md
+++ b/change-notes/1.19/analysis-cpp.md
@@ -23,3 +23,4 @@
 ## Changes to QL libraries
 
 * Added a hash consing library for structural comparison of expressions.
+* `getBufferSize` now detects variable size structs more reliably.

--- a/cpp/ql/src/semmle/code/cpp/commons/Buffer.qll
+++ b/cpp/ql/src/semmle/code/cpp/commons/Buffer.qll
@@ -40,6 +40,9 @@ predicate memberMayBeVarSize(Class c, MemberVariable v) {
     ) or exists(AddressOfExpr aoe |
       // `&(c.v)` is taken
       aoe.getAddressable() = v
+    ) or exists(BuiltInOperationOffsetOf oo |
+      // `offsetof(c, v)` using a builtin
+      oo.getAChild().(VariableAccess).getTarget() = v
     )
   )
 }

--- a/cpp/ql/src/semmle/code/cpp/commons/Buffer.qll
+++ b/cpp/ql/src/semmle/code/cpp/commons/Buffer.qll
@@ -28,7 +28,7 @@ predicate memberMayBeVarSize(Class c, MemberVariable v) {
     v = c.getCanonicalMember(i) and
 
     // v is an array of size at most 1
-    v.getType().getUnspecifiedType().(ArrayType).getSize() <= 1
+    v.getType().getUnspecifiedType().(ArrayType).getArraySize() <= 1
   ) and (
     exists(SizeofOperator so |
       // `sizeof(c)` is taken

--- a/cpp/ql/src/semmle/code/cpp/commons/Buffer.qll
+++ b/cpp/ql/src/semmle/code/cpp/commons/Buffer.qll
@@ -16,11 +16,12 @@ import semmle.code.cpp.dataflow.DataFlow
  * ```
 */
 private predicate isDynamicallyAllocatedWithDifferentSize(Class s) {
-  exists(SizeofTypeOperator sof |
-    sof.getTypeOperand().getUnspecifiedType() = s |
+  exists(SizeofOperator so |
+    so.(SizeofTypeOperator).getTypeOperand().getUnspecifiedType() = s or
+    so.(SizeofExprOperator).getExprOperand().getType().getUnspecifiedType() = s |
     // Check all ancestor nodes except the immediate parent for
     // allocations.
-    isStdLibAllocationExpr(sof.getParent().(Expr).getParent+())
+    isStdLibAllocationExpr(so.getParent().(Expr).getParent+())
   )
 }
 

--- a/cpp/ql/src/semmle/code/cpp/commons/Buffer.qll
+++ b/cpp/ql/src/semmle/code/cpp/commons/Buffer.qll
@@ -34,13 +34,12 @@ predicate memberMayBeVarSize(Class c, MemberVariable v) {
       // `sizeof(c)` is taken
       so.(SizeofTypeOperator).getTypeOperand().getUnspecifiedType() = c or
       so.(SizeofExprOperator).getExprOperand().getType().getUnspecifiedType() = c |
-      // Check all ancestor nodes except the immediate parent for
-      // allocations.
-      isStdLibAllocationExpr(so.getParent().(Expr).getParent+())
+
+      // arithmetic is performed on the result
+      so.getParent*() instanceof BinaryArithmeticOperation
     ) or exists(AddressOfExpr aoe |
       // `&(c.v)` is taken
-      aoe.getAddressable() = v and
-      isStdLibAllocationExpr(aoe.getParent().(Expr).getParent+())
+      aoe.getAddressable() = v
     )
   )
 }

--- a/cpp/ql/src/semmle/code/cpp/commons/Buffer.qll
+++ b/cpp/ql/src/semmle/code/cpp/commons/Buffer.qll
@@ -36,7 +36,7 @@ predicate memberMayBeVarSize(Class c, MemberVariable v) {
       so.(SizeofExprOperator).getExprOperand().getType().getUnspecifiedType() = c |
 
       // arithmetic is performed on the result
-      so.getParent*() instanceof BinaryArithmeticOperation
+      so.getParent*() instanceof AddExpr
     ) or exists(AddressOfExpr aoe |
       // `&(c.v)` is taken
       aoe.getAddressable() = v


### PR DESCRIPTION
This was failing to recognize variable sized arrays at the end of a `struct` if the variable size calculation didn't contain `sizeof(class)`; alternative methods include `sizeof(var)` where `var` has type `class`, or `offsetof(class.member)` (which may be implemented using pointer arithmetic or as a builtin).

Aimed at fixing false positives that recently appeared in query differences - in particular OverflowBuffer.ql (`Call to memory access function may overflow buffer`) on php, `zend_compile.c`, line 1350 (though there are many other cases).