### PR TITLE
Java: Improve array length bounds on array phi nodes that may be null.

### DIFF
--- a/java/ql/src/Likely Bugs/Collections/ArrayIndexOutOfBounds.ql
+++ b/java/ql/src/Likely Bugs/Collections/ArrayIndexOutOfBounds.ql
@@ -13,6 +13,7 @@
 
 import java
 import semmle.code.java.dataflow.SSA
+import semmle.code.java.dataflow.RangeUtils
 import semmle.code.java.dataflow.RangeAnalysis
 
 /**
@@ -31,9 +32,7 @@ predicate boundedArrayAccess(ArrayAccess aa, int k) {
       k = delta
     )
     or
-    exists(ArrayCreationExpr arraycreation |
-      arraycreation = arr.(SsaExplicitUpdate).getDefiningExpr().(VariableAssign).getSource()
-    |
+    exists(ArrayCreationExpr arraycreation | arraycreation = getArrayDef(arr) |
       k = delta and
       arraycreation.getDimension(0) = b.getExpr()
       or

--- a/java/ql/src/semmle/code/java/dataflow/RangeAnalysis.qll
+++ b/java/ql/src/semmle/code/java/dataflow/RangeAnalysis.qll
@@ -583,18 +583,6 @@ private predicate unequalSsa(SsaVariable v, SsaReadPosition pos, Bound b, int de
   )
 }
 
-/**
- * Holds if `inp` is an input to `phi` along a back edge.
- */
-private predicate backEdge(SsaPhiNode phi, SsaVariable inp, SsaReadPositionPhiInputEdge edge) {
-  edge.phiInput(phi, inp) and
-  // Conservatively assume that every edge is a back edge if we don't have dominance information.
-  (
-    phi.getBasicBlock().bbDominates(edge.getOrigBlock()) or
-    not hasDominanceInformation(edge.getOrigBlock())
-  )
-}
-
 /** Weakens a delta to lie in the range `[-1..1]`. */
 bindingset[delta, upper]
 private int weakenDelta(boolean upper, int delta) {

--- a/java/ql/test/query-tests/RangeAnalysis/A.java
+++ b/java/ql/test/query-tests/RangeAnalysis/A.java
@@ -34,7 +34,7 @@ public class A {
     }
     for (int i = 0; i < arr1.length; ) {
       sum += arr1[i++]; // OK
-      sum += arr1[i++]; // OK - FP
+      sum += arr1[i++]; // OK
       i += 2;
     }
     for (int i = 0; i < arr2.length; ) {
@@ -160,6 +160,19 @@ public class A {
     int[] b = new int[8];
     for (int i = 2; i < 8; i += 2) {
       sum += b[i] + b[i + 1]; // OK
+    }
+  }
+
+  void m13(int n) {
+    int[] a = null;
+    if (n > 0) {
+      a = n > 0 ? new int[3 * n] : null;
+    }
+    int sum;
+    if (a != null) {
+      for (int i = 0; i < a.length; i += 3) {
+        sum += a[i + 2]; // OK
+      }
     }
   }
 }

--- a/java/ql/test/query-tests/RangeAnalysis/ArrayIndexOutOfBounds.expected
+++ b/java/ql/test/query-tests/RangeAnalysis/ArrayIndexOutOfBounds.expected
@@ -1,6 +1,5 @@
 | A.java:16:14:16:17 | ...[...] | This array access might be out of bounds, as the index might be equal to the array length. |
 | A.java:23:21:23:28 | ...[...] | This array access might be out of bounds, as the index might be equal to the array length. |
-| A.java:37:14:37:22 | ...[...] | This array access might be out of bounds, as the index might be equal to the array length. |
 | A.java:42:14:42:22 | ...[...] | This array access might be out of bounds, as the index might be equal to the array length. |
 | A.java:46:14:46:22 | ...[...] | This array access might be out of bounds, as the index might be equal to the array length. |
 | A.java:55:14:55:19 | ...[...] | This array access might be out of bounds, as the index might be equal to the array length. |


### PR DESCRIPTION
This gives a little precision improvement to the range and modulus analyses.  There's no need for a change note, as this is already adequately covered by the note on modulus analysis.