### PR TITLE
JS: recognize transform-react-jsx plugin

### DIFF
--- a/change-notes/1.19/analysis-javascript.md
+++ b/change-notes/1.19/analysis-javascript.md
@@ -38,6 +38,7 @@
 | Unused variable, import, function or class | Fewer results | This rule now flags import statements with multiple unused imports once. |
 | User-controlled bypass of security check | Fewer results | This rule no longer flags conditions that guard early returns. The precision of this rule has been revised to "medium". Results are no longer shown on LGTM by default. | 
 | Whitespace contradicts operator precedence | Fewer false-positive results | This rule no longer flags operators with asymmetric whitespace. |
+| Unused import | Fewer false-positive results | This rule no longer flags imports used by the `transform-react-jsx` Babel plugin. |
 
 ## Changes to QL libraries
 

--- a/javascript/ql/src/Declarations/UnusedVariable.ql
+++ b/javascript/ql/src/Declarations/UnusedVariable.ql
@@ -65,8 +65,8 @@ predicate isReactImportForJSX(UnusedLocal v) {
     or
     // JSX pragma from a .babelrc file
     exists (Babel::TransformReactJsxConfig plugin |
-      plugin.getConfig().getAContainerInScope() = is.getFile() and
-      plugin.getJSXFactoryVariableName() = v.getName())
+      plugin.appliesTo(is.getTopLevel()) and
+      plugin.getJsxFactoryVariableName() = v.getName())
   )
 }
 

--- a/javascript/ql/src/Declarations/UnusedVariable.ql
+++ b/javascript/ql/src/Declarations/UnusedVariable.ql
@@ -56,10 +56,17 @@ predicate isPropertyFilter(UnusedLocal v) {
 predicate isReactImportForJSX(UnusedLocal v) {
   exists (ImportSpecifier is |
     is.getLocal() = v.getADeclaration() and
-    exists (JSXNode jsx | jsx.getTopLevel() = is.getTopLevel()) |
-    v.getName() = "React" or
-    // also accept legacy `@jsx` pragmas
+    exists (JSXNode jsx | jsx.getTopLevel() = is.getTopLevel())
+    |
+    v.getName() = "React"
+    or
+    // legacy `@jsx` pragmas
     exists (JSXPragma p | p.getTopLevel() = is.getTopLevel() | p.getDOMName() = v.getName())
+    or
+    // JSX pragma from a .babelrc file
+    exists (Babel::TransformReactJsxConfig plugin |
+      plugin.getConfig().getAContainerInScope() = is.getFile() and
+      plugin.getJSXFactoryVariableName() = v.getName())
   )
 }
 

--- a/javascript/ql/src/semmle/javascript/frameworks/Babel.qll
+++ b/javascript/ql/src/semmle/javascript/frameworks/Babel.qll
@@ -28,6 +28,18 @@ module Babel {
         result.(JSONArray).getElementStringValue(0) = pluginName
       )
     }
+
+    /**
+     * Gets a file affected by this Babel configuration.
+     */
+    Container getAContainerInScope() {
+      result = getFile().getParentContainer()
+      or
+      result = getAContainerInScope().getAChildContainer() and
+      // File-relative .babelrc search stops at any package.json or .babelrc file.
+      not result.getAChildContainer() = any(PackageJSON pkg).getFile() and
+      not result.getAChildContainer() = any(Config pkg).getFile()
+    }
   }
 
   /**
@@ -150,6 +162,35 @@ module Babel {
 
     override Folder getARootFolder() {
       result = pathExpr.getConfig().getFolder()
+    }
+  }
+
+  /**
+   * A configuration object for the `transform-react-jsx` plugin.
+   *
+   * The plugin option `{"pragma": xxx}` specifies a variable name used to instantiate
+   * JSX elements.
+   */
+  class TransformReactJsxConfig extends JSONArray {
+    Config cfg;
+
+    TransformReactJsxConfig() {
+      this = cfg.getPluginConfig("transform-react-jsx")
+    }
+
+    /** Gets the Babel configuration object. */
+    Config getConfig() {
+      result = cfg
+    }
+
+    /** Gets the options passed to this plugin. */
+    JSONObject getOptions() {
+      result = getElementValue(1)
+    }
+
+    /** Gets the name of the variable used to create JSX elements. */
+    string getJSXFactoryVariableName() {
+      result = getOptions().getPropStringValue("pragma")
     }
   }
 }

--- a/javascript/ql/src/semmle/javascript/frameworks/Babel.qll
+++ b/javascript/ql/src/semmle/javascript/frameworks/Babel.qll
@@ -60,7 +60,7 @@ module Babel {
       this = cfg.getPluginConfig(pluginName)
     }
 
-    /** Gets the name of the plugin begin installed. */
+    /** Gets the name of the plugin being installed. */
     string getPluginName() {
       result = pluginName
     }

--- a/javascript/ql/test/query-tests/Declarations/UnusedVariable/Babelrc/.babelrc.json
+++ b/javascript/ql/test/query-tests/Declarations/UnusedVariable/Babelrc/.babelrc.json
@@ -1,0 +1,5 @@
+{
+  "plugins": [
+    ["transform-react-jsx", { "pragma": "h" }]
+  ]
+}

--- a/javascript/ql/test/query-tests/Declarations/UnusedVariable/Babelrc/importPragma.jsx
+++ b/javascript/ql/test/query-tests/Declarations/UnusedVariable/Babelrc/importPragma.jsx
@@ -1,0 +1,4 @@
+import { h } from 'preact'; // OK - JSX element uses 'h' after babel compilation
+import { q } from 'preact'; // NOT OK - not used 
+
+export default (<div>Hello</div>);

--- a/javascript/ql/test/query-tests/Declarations/UnusedVariable/UnusedVariable.expected
+++ b/javascript/ql/test/query-tests/Declarations/UnusedVariable/UnusedVariable.expected
@@ -1,4 +1,3 @@
-| Babelrc/importPragma.jsx:1:1:1:27 | import  ... react'; | Unused import h. |
 | Babelrc/importPragma.jsx:2:1:2:27 | import  ... react'; | Unused import q. |
 | decorated.ts:1:1:1:126 | import  ... where'; | Unused import actionHandler. |
 | decorated.ts:4:10:4:12 | fun | Unused function fun. |

--- a/javascript/ql/test/query-tests/Declarations/UnusedVariable/UnusedVariable.expected
+++ b/javascript/ql/test/query-tests/Declarations/UnusedVariable/UnusedVariable.expected
@@ -1,6 +1,9 @@
+| Babelrc/importPragma.jsx:1:1:1:27 | import  ... react'; | Unused import h. |
+| Babelrc/importPragma.jsx:2:1:2:27 | import  ... react'; | Unused import q. |
 | decorated.ts:1:1:1:126 | import  ... where'; | Unused import actionHandler. |
 | decorated.ts:4:10:4:12 | fun | Unused function fun. |
 | externs.js:6:5:6:13 | iAmUnused | Unused variable iAmUnused. |
+| importWithoutPragma.jsx:1:1:1:27 | import  ... react'; | Unused import h. |
 | multi-imports.js:1:1:1:29 | import  ... om 'x'; | Unused imports a, b, d. |
 | multi-imports.js:2:1:2:42 | import  ... om 'x'; | Unused imports alphabetically, ordered. |
 | typeoftype.ts:9:7:9:7 | y | Unused variable y. |

--- a/javascript/ql/test/query-tests/Declarations/UnusedVariable/importWithoutPragma.jsx
+++ b/javascript/ql/test/query-tests/Declarations/UnusedVariable/importWithoutPragma.jsx
@@ -1,0 +1,3 @@
+import { h } from 'preact'; // NOT OK - not in scope of .babelrc file
+
+export default (<div>Hello</div>);


### PR DESCRIPTION
Fixes a false positive in UnusedVariable.ql due to imports that are used by JSX, for example:
```javascript
import { h } from "preact"; // Appears unused
<Foo x="y"/>
```
becomes
```javascript
import { h } from "preact";
h(Foo, {x: "y"}); // now used here
```
This was already supported in some cases, but not when the name of the JSX factory came from the `transform-react-jsx` plugin configuration in a `.babelrc` file.