### PR TITLE
C++: Simplify a test's query

### DIFF
--- a/cpp/ql/test/library-tests/noexcept/copy_from_prototype/copy_from_prototype.expected
+++ b/cpp/ql/test/library-tests/noexcept/copy_from_prototype/copy_from_prototype.expected
@@ -1,32 +1,32 @@
-| copy_from_prototype.cpp:3:7:3:7 | a | a<int>::a(a<int> &&) | copy_from_prototype.cpp:3:7:3:7 | a<int> | <no expr> |
-| copy_from_prototype.cpp:3:7:3:7 | a | a<int>::a(const a<int> &) | copy_from_prototype.cpp:3:7:3:7 | a<int> | <no expr> |
-| copy_from_prototype.cpp:3:7:3:7 | operator= | a<int>::operator=(a<int> &&) | copy_from_prototype.cpp:3:7:3:7 | a<int> | <no expr> |
-| copy_from_prototype.cpp:3:7:3:7 | operator= | a<int>::operator=(const a<int> &) | copy_from_prototype.cpp:3:7:3:7 | a<int> | <no expr> |
-| copy_from_prototype.cpp:4:26:4:26 | a | a<<unnamed>>::a<(unnamed)>() | copy_from_prototype.cpp:3:7:3:7 | a<<unnamed>> | 123 |
-| copy_from_prototype.cpp:4:26:4:26 | a | a<int>::a() | copy_from_prototype.cpp:3:7:3:7 | a<int> | <no expr> |
-| copy_from_prototype.cpp:4:26:4:26 | a | a<int>::a<(unnamed)>() | copy_from_prototype.cpp:3:7:3:7 | a<int> | <no expr> |
-| copy_from_prototype.cpp:7:7:7:7 | b | b::b() | copy_from_prototype.cpp:7:7:7:7 | b | <no expr> |
-| copy_from_prototype.cpp:7:7:7:7 | b | b::b(b &&) | copy_from_prototype.cpp:7:7:7:7 | b | <no expr> |
-| copy_from_prototype.cpp:7:7:7:7 | b | b::b(const b &) | copy_from_prototype.cpp:7:7:7:7 | b | <no expr> |
-| copy_from_prototype.cpp:7:7:7:7 | operator= | b::operator=(b &&) | copy_from_prototype.cpp:7:7:7:7 | b | <no expr> |
-| copy_from_prototype.cpp:7:7:7:7 | operator= | b::operator=(const b &) | copy_from_prototype.cpp:7:7:7:7 | b | <no expr> |
-| copy_from_prototype.cpp:13:7:13:7 | c | c<int>::c(c<int> &&) | copy_from_prototype.cpp:13:7:13:7 | c<int> | <no expr> |
-| copy_from_prototype.cpp:13:7:13:7 | c | c<int>::c(const c<int> &) | copy_from_prototype.cpp:13:7:13:7 | c<int> | <no expr> |
-| copy_from_prototype.cpp:13:7:13:7 | operator= | c<int>::operator=(c<int> &&) | copy_from_prototype.cpp:13:7:13:7 | c<int> | <no expr> |
-| copy_from_prototype.cpp:13:7:13:7 | operator= | c<int>::operator=(const c<int> &) | copy_from_prototype.cpp:13:7:13:7 | c<int> | <no expr> |
-| copy_from_prototype.cpp:14:26:14:26 | c | c<T>::c<(unnamed)>() | copy_from_prototype.cpp:13:7:13:7 | c<T> | Unknown literal |
-| copy_from_prototype.cpp:14:26:14:26 | c | c<int>::c() | copy_from_prototype.cpp:13:7:13:7 | c<int> | <no expr> |
-| copy_from_prototype.cpp:14:26:14:26 | c | c<int>::c<(unnamed)>() | copy_from_prototype.cpp:13:7:13:7 | c<int> | <no expr> |
-| copy_from_prototype.cpp:17:7:17:7 | d | d::d() | copy_from_prototype.cpp:17:7:17:7 | d | <no expr> |
-| copy_from_prototype.cpp:17:7:17:7 | d | d::d(const d &) | copy_from_prototype.cpp:17:7:17:7 | d | <no expr> |
-| copy_from_prototype.cpp:17:7:17:7 | d | d::d(d &&) | copy_from_prototype.cpp:17:7:17:7 | d | <no expr> |
-| copy_from_prototype.cpp:17:7:17:7 | operator= | d::operator=(const d &) | copy_from_prototype.cpp:17:7:17:7 | d | <no expr> |
-| copy_from_prototype.cpp:17:7:17:7 | operator= | d::operator=(d &&) | copy_from_prototype.cpp:17:7:17:7 | d | <no expr> |
-| copy_from_prototype.cpp:22:8:22:8 | e | e<int>::e(const e<int> &) | copy_from_prototype.cpp:22:8:22:8 | e<int> | <no expr> |
-| copy_from_prototype.cpp:22:8:22:8 | e | e<int>::e(e<int> &&) | copy_from_prototype.cpp:22:8:22:8 | e<int> | <no expr> |
-| copy_from_prototype.cpp:22:8:22:8 | operator= | e<int>::operator=(const e<int> &) | copy_from_prototype.cpp:22:8:22:8 | e<int> | <no expr> |
-| copy_from_prototype.cpp:22:8:22:8 | operator= | e<int>::operator=(e<int> &&) | copy_from_prototype.cpp:22:8:22:8 | e<int> | <no expr> |
-| copy_from_prototype.cpp:23:26:23:26 | e | e<T>::e<(unnamed)>() | copy_from_prototype.cpp:22:8:22:8 | e<T> | 456 |
-| copy_from_prototype.cpp:26:35:26:43 | e | e<int>::e<(unnamed)>() | copy_from_prototype.cpp:22:8:22:8 | e<int> | 456 |
-| file://:0:0:0:0 | operator= | __va_list_tag::operator=() | file://:0:0:0:0 | __va_list_tag | <none> |
-| file://:0:0:0:0 | operator= | __va_list_tag::operator=() | file://:0:0:0:0 | __va_list_tag | <none> |
+| copy_from_prototype.cpp:3:7:3:7 | a | a<int>::a(a<int> &&) -> void | copy_from_prototype.cpp:3:7:3:7 | a<int> | <no expr> |
+| copy_from_prototype.cpp:3:7:3:7 | a | a<int>::a(const a<int> &) -> void | copy_from_prototype.cpp:3:7:3:7 | a<int> | <no expr> |
+| copy_from_prototype.cpp:3:7:3:7 | operator= | a<int>::operator=(a<int> &&) -> a<int> & | copy_from_prototype.cpp:3:7:3:7 | a<int> | <no expr> |
+| copy_from_prototype.cpp:3:7:3:7 | operator= | a<int>::operator=(const a<int> &) -> a<int> & | copy_from_prototype.cpp:3:7:3:7 | a<int> | <no expr> |
+| copy_from_prototype.cpp:4:26:4:26 | a | a<<unnamed>>::a<(unnamed)>() -> void | copy_from_prototype.cpp:3:7:3:7 | a<<unnamed>> | 123 |
+| copy_from_prototype.cpp:4:26:4:26 | a | a<int>::a() -> void | copy_from_prototype.cpp:3:7:3:7 | a<int> | <no expr> |
+| copy_from_prototype.cpp:4:26:4:26 | a | a<int>::a<(unnamed)>() -> void | copy_from_prototype.cpp:3:7:3:7 | a<int> | <no expr> |
+| copy_from_prototype.cpp:7:7:7:7 | b | b::b() -> void | copy_from_prototype.cpp:7:7:7:7 | b | <no expr> |
+| copy_from_prototype.cpp:7:7:7:7 | b | b::b(b &&) -> void | copy_from_prototype.cpp:7:7:7:7 | b | <no expr> |
+| copy_from_prototype.cpp:7:7:7:7 | b | b::b(const b &) -> void | copy_from_prototype.cpp:7:7:7:7 | b | <no expr> |
+| copy_from_prototype.cpp:7:7:7:7 | operator= | b::operator=(b &&) -> b & | copy_from_prototype.cpp:7:7:7:7 | b | <no expr> |
+| copy_from_prototype.cpp:7:7:7:7 | operator= | b::operator=(const b &) -> b & | copy_from_prototype.cpp:7:7:7:7 | b | <no expr> |
+| copy_from_prototype.cpp:13:7:13:7 | c | c<int>::c(c<int> &&) -> void | copy_from_prototype.cpp:13:7:13:7 | c<int> | <no expr> |
+| copy_from_prototype.cpp:13:7:13:7 | c | c<int>::c(const c<int> &) -> void | copy_from_prototype.cpp:13:7:13:7 | c<int> | <no expr> |
+| copy_from_prototype.cpp:13:7:13:7 | operator= | c<int>::operator=(c<int> &&) -> c<int> & | copy_from_prototype.cpp:13:7:13:7 | c<int> | <no expr> |
+| copy_from_prototype.cpp:13:7:13:7 | operator= | c<int>::operator=(const c<int> &) -> c<int> & | copy_from_prototype.cpp:13:7:13:7 | c<int> | <no expr> |
+| copy_from_prototype.cpp:14:26:14:26 | c | c<T>::c<(unnamed)>() -> void | copy_from_prototype.cpp:13:7:13:7 | c<T> | Unknown literal |
+| copy_from_prototype.cpp:14:26:14:26 | c | c<int>::c() -> void | copy_from_prototype.cpp:13:7:13:7 | c<int> | <no expr> |
+| copy_from_prototype.cpp:14:26:14:26 | c | c<int>::c<(unnamed)>() -> void | copy_from_prototype.cpp:13:7:13:7 | c<int> | <no expr> |
+| copy_from_prototype.cpp:17:7:17:7 | d | d::d() -> void | copy_from_prototype.cpp:17:7:17:7 | d | <no expr> |
+| copy_from_prototype.cpp:17:7:17:7 | d | d::d(const d &) -> void | copy_from_prototype.cpp:17:7:17:7 | d | <no expr> |
+| copy_from_prototype.cpp:17:7:17:7 | d | d::d(d &&) -> void | copy_from_prototype.cpp:17:7:17:7 | d | <no expr> |
+| copy_from_prototype.cpp:17:7:17:7 | operator= | d::operator=(const d &) -> d & | copy_from_prototype.cpp:17:7:17:7 | d | <no expr> |
+| copy_from_prototype.cpp:17:7:17:7 | operator= | d::operator=(d &&) -> d & | copy_from_prototype.cpp:17:7:17:7 | d | <no expr> |
+| copy_from_prototype.cpp:22:8:22:8 | e | e<int>::e(const e<int> &) -> void | copy_from_prototype.cpp:22:8:22:8 | e<int> | <no expr> |
+| copy_from_prototype.cpp:22:8:22:8 | e | e<int>::e(e<int> &&) -> void | copy_from_prototype.cpp:22:8:22:8 | e<int> | <no expr> |
+| copy_from_prototype.cpp:22:8:22:8 | operator= | e<int>::operator=(const e<int> &) -> e<int> & | copy_from_prototype.cpp:22:8:22:8 | e<int> | <no expr> |
+| copy_from_prototype.cpp:22:8:22:8 | operator= | e<int>::operator=(e<int> &&) -> e<int> & | copy_from_prototype.cpp:22:8:22:8 | e<int> | <no expr> |
+| copy_from_prototype.cpp:23:26:23:26 | e | e<T>::e<(unnamed)>() -> void | copy_from_prototype.cpp:22:8:22:8 | e<T> | 456 |
+| copy_from_prototype.cpp:26:35:26:43 | e | e<int>::e<(unnamed)>() -> void | copy_from_prototype.cpp:22:8:22:8 | e<int> | 456 |
+| file://:0:0:0:0 | operator= | __va_list_tag::operator=() -> __va_list_tag & | file://:0:0:0:0 | __va_list_tag | <none> |
+| file://:0:0:0:0 | operator= | __va_list_tag::operator=() -> __va_list_tag & | file://:0:0:0:0 | __va_list_tag | <none> |

--- a/cpp/ql/test/library-tests/noexcept/copy_from_prototype/copy_from_prototype.ql
+++ b/cpp/ql/test/library-tests/noexcept/copy_from_prototype/copy_from_prototype.ql
@@ -1,19 +1,9 @@
 import cpp
 
-string functionName(Function f) {
-  exists(string name, string templateArgs, string args |
-         result = name + templateArgs + args
-     and name = f.getQualifiedName()
-     and if exists(f.getATemplateArgument())
-         then templateArgs = "<" + concat(int i | exists(f.getTemplateArgument(i)) | f.getTemplateArgument(i).toString(), "," order by i) + ">"
-         else templateArgs = ""
-     and args = "(" + concat(int i | exists(f.getParameter(i)) | f.getParameter(i).getType().toString(), "," order by i) + ")")
-}
-
 from Function f, string e
 where if f.hasExceptionSpecification()
   then if exists(f.getADeclarationEntry().getNoExceptExpr())
        then e = f.getADeclarationEntry().getNoExceptExpr().toString()
        else e = "<no expr>"
   else e = "<none>"
-select f, functionName(f), f.getDeclaringType(), e
+select f, f.getFullSignature(), f.getDeclaringType(), e


### PR DESCRIPTION
This test predated Function.getFullSignature()