### PR TITLE
C++: handle __uuidof(0)

### DIFF
--- a/cpp/ql/src/semmle/code/cpp/exprs/Cast.qll
+++ b/cpp/ql/src/semmle/code/cpp/exprs/Cast.qll
@@ -497,7 +497,12 @@ class DynamicCast extends Cast, @dynamic_cast {
  * specified by the `__declspec(uuid)` attribute.
  */
 class UuidofOperator extends Expr, @uuidof {
-  override string toString() { result = "__uuidof(" + getTypeOperand().getName() + ")" }
+  override string toString() {
+    if exists(getTypeOperand()) then
+      result = "__uuidof(" + getTypeOperand().getName() + ")"
+    else
+      result = "__uuidof(0)"
+  }
 
   override int getPrecedence() { result = 15 }
 

--- a/cpp/ql/test/library-tests/literals/uuidof/uuidof.cpp
+++ b/cpp/ql/test/library-tests/literals/uuidof/uuidof.cpp
@@ -15,5 +15,6 @@ void GetUUID() {
     uuid = __uuidof(Templ<S>);
     S s;
     uuid = __uuidof(s);
+    uuid = __uuidof(0);
 }
 // semmle-extractor-options: --microsoft

--- a/cpp/ql/test/library-tests/literals/uuidof/uuidof.expected
+++ b/cpp/ql/test/library-tests/literals/uuidof/uuidof.expected
@@ -11,3 +11,4 @@ uuidofOperators
 | uuidof.cpp:14:12:14:30 | __uuidof(S) | const _GUID | 01234567-89ab-cdef-0123-456789abcdef |
 | uuidof.cpp:15:12:15:29 | __uuidof(S) | const _GUID | 01234567-89ab-cdef-0123-456789abcdef |
 | uuidof.cpp:17:12:17:22 | __uuidof(S) | const _GUID | 01234567-89ab-cdef-0123-456789abcdef |
+| uuidof.cpp:18:12:18:22 | __uuidof(0) | const _GUID | 00000000-0000-0000-0000-000000000000 |


### PR DESCRIPTION
It's a special case according to [the docs](https://docs.microsoft.com/en-us/cpp/cpp/uuidof-operator?view=vs-2017):

> A special case of this intrinsic is when either 0 or NULL is supplied as the argument. In this case, __uuidof will return a GUID made up of zeros.

This needs to be merged after the internal extractor PR.