### PR TITLE
JS: Use guard nodes in useless-conditionals

### DIFF
--- a/change-notes/1.19/analysis-javascript.md
+++ b/change-notes/1.19/analysis-javascript.md
@@ -39,6 +39,7 @@
 | User-controlled bypass of security check | Fewer results | This rule no longer flags conditions that guard early returns. The precision of this rule has been revised to "medium". Results are no longer shown on LGTM by default. | 
 | Whitespace contradicts operator precedence | Fewer false-positive results | This rule no longer flags operators with asymmetric whitespace. |
 | Unused import | Fewer false-positive results | This rule no longer flags imports used by the `transform-react-jsx` Babel plugin. |
+| Useless conditional | More true-positive results | This rule now flags useless conditions in more cases. |
 
 ## Changes to QL libraries
 

--- a/javascript/ql/test/query-tests/Statements/UselessConditional/UselessConditional.expected
+++ b/javascript/ql/test/query-tests/Statements/UselessConditional/UselessConditional.expected
@@ -1,4 +1,4 @@
-| UselessConditional.js:5:7:5:12 | !lines | This expression always evaluates to false. |
+| UselessConditional.js:5:8:5:12 | lines | Variable 'lines' always evaluates to true here. |
 | UselessConditional.js:12:34:12:79 | (v = ne ... k] = v) | This logical 'and' expression can be replaced with a comma expression. |
 | UselessConditional.js:17:9:17:9 | a | Variable 'a' always evaluates to false here. |
 | UselessConditional.js:18:9:18:9 | b | Variable 'b' always evaluates to false here. |

--- a/javascript/ql/test/query-tests/Statements/UselessConditional/UselessConditional.expected
+++ b/javascript/ql/test/query-tests/Statements/UselessConditional/UselessConditional.expected
@@ -15,7 +15,8 @@
 | UselessConditional.js:65:5:65:5 | x | Variable 'x' always evaluates to true here. |
 | UselessConditional.js:76:13:76:13 | x | Variable 'x' always evaluates to true here. |
 | UselessConditional.js:82:13:82:13 | x | Variable 'x' always evaluates to true here. |
-| UselessConditional.js:89:10:89:16 | x, true | This expression always evaluates to true. |
+| UselessConditional.js:94:16:94:16 | x | Variable 'x' always evaluates to false here. |
+| UselessConditional.js:101:18:101:18 | x | Variable 'x' always evaluates to false here. |
 | UselessConditionalGood.js:58:12:58:13 | x2 | Variable 'x2' always evaluates to false here. |
 | UselessConditionalGood.js:69:12:69:13 | xy | Variable 'xy' always evaluates to false here. |
 | UselessConditionalGood.js:85:12:85:13 | xy | Variable 'xy' always evaluates to false here. |

--- a/javascript/ql/test/query-tests/Statements/UselessConditional/UselessConditional.js
+++ b/javascript/ql/test/query-tests/Statements/UselessConditional/UselessConditional.js
@@ -89,4 +89,17 @@ async function awaitFlow(){
     if ((x, true));
 });
 
+(function (x, y) {
+    if (!x) {
+        while (x) { // NOT OK
+            f();
+        }
+        while (true) { // OK
+            break;
+        }
+        if (true && true) {} // OK
+        if (y && x) {} // NOT OK
+    }
+});
+
 // semmle-extractor-options: --experimental


### PR DESCRIPTION
This changes `useless-conditional` to use `ConditionGuardNode` as the basis to determine if something is a condition. This has a few consequences:
- It recognises loop conditions.
- It recognises `z` in `if (x && z)` as a conditional. Previously only `x` and `x && z` were recognised.
- For `!p` it will report that the variable `p` is always true/false, rather than pointing to the whole `!p` expression.
- The whitelisting rules apply to the "inner" condition, such `p` instead of `!p`. This means trivial expressions like `!true` and `true && true` will not be reported anymore, since `true` is already whitelisted.

The two latter ones are debatable, but for now I've just kept it like this for simplicity.

Moving to `ConditionGuardNode` is also necessary in order to report range analysis results with this query. Putting this up separately so the results won't interfere with the evaluation of range analysis.