### PR TITLE
CPP: Fix false positive in EmptyBlock.ql

### DIFF
--- a/change-notes/1.19/analysis-cpp.md
+++ b/change-notes/1.19/analysis-cpp.md
@@ -15,6 +15,7 @@
 
 | **Query**                  | **Expected impact**    | **Change**                                                       |
 |----------------------------|------------------------|------------------------------------------------------------------|
+| Empty branch of conditional | Fewer false positive results | The query now recognizes commented blocks more reliably. |
 | Resource not released in destructor | Fewer false positive results | Placement new is now excluded from the query. Also fixed an issue where false positives could occur if the destructor body was not in the snapshot. |
 | Missing return statement (`cpp/missing-return`) | Visible by default | The precision of this query has been increased from 'medium' to 'high', which makes it visible by default in LGTM. It was 'medium' in release 1.17 and 1.18 because it had false positives due to an extractor bug that was fixed in 1.18. |
 | Missing return statement | Fewer false positive results | The query is now produces correct results when a function returns a template-dependent type. |

--- a/cpp/ql/src/Best Practices/Likely Errors/EmptyBlock.ql
+++ b/cpp/ql/src/Best Practices/Likely Errors/EmptyBlock.ql
@@ -91,13 +91,15 @@ predicate emptyBlockContainsNonchild(Block b) {
  */
 predicate lineComment(Block b) {
   emptyBlock(_, b) and
-  exists(File f, int line |
-    f = b.getFile() and
-    line = b.getLocation().getStartLine() and
-    line = b.getLocation().getEndLine() and
-    exists(Comment c |
-      c.getFile() = f and
-      c.getLocation().getStartLine() = line
+  exists(Location bLocation, File f, int line |
+    bLocation = b.getLocation() and
+    f = bLocation.getFile() and
+    line = bLocation.getStartLine() and
+    line = bLocation.getEndLine() and
+    exists(Comment c, Location cLocation |
+      cLocation = c.getLocation() and
+      cLocation.getFile() = f and
+      cLocation.getStartLine() = line
     )
   )
 }

--- a/cpp/ql/src/Best Practices/Likely Errors/EmptyBlock.ql
+++ b/cpp/ql/src/Best Practices/Likely Errors/EmptyBlock.ql
@@ -29,6 +29,10 @@ class AffectedFile extends File {
   }
 }
 
+/**
+ * A block, or an element we might find textually within a block that is
+ * not a child of it in the AST.
+ */
 class BlockOrNonChild extends Element {
   BlockOrNonChild() {
     ( this instanceof Block
@@ -68,6 +72,9 @@ class BlockOrNonChild extends Element {
   }
 }
 
+/**
+ * A block that contains a non-child element.
+ */
 predicate emptyBlockContainsNonchild(Block b) {
   emptyBlock(_, b) and
   exists(BlockOrNonChild c, AffectedFile file |
@@ -78,7 +85,12 @@ predicate emptyBlockContainsNonchild(Block b) {
   )
 }
 
+/**
+ * A block that is entirely on one line, which also contains a comment.  Chances
+ * are the comment is intended to refer to the block.
+ */
 predicate lineComment(Block b) {
+  emptyBlock(_, b) and
   exists(File f, int line |
     f = b.getFile() and
     line = b.getLocation().getStartLine() and

--- a/cpp/ql/src/Best Practices/Likely Errors/EmptyBlock.ql
+++ b/cpp/ql/src/Best Practices/Likely Errors/EmptyBlock.ql
@@ -78,7 +78,20 @@ predicate emptyBlockContainsNonchild(Block b) {
   )
 }
 
+predicate lineComment(Block b) {
+  exists(File f, int line |
+    f = b.getFile() and
+    line = b.getLocation().getStartLine() and
+    line = b.getLocation().getEndLine() and
+    exists(Comment c |
+      c.getFile() = f and
+      c.getLocation().getStartLine() = line
+    )
+  )
+}
+
 from ControlStructure s, Block eb
 where emptyBlock(s, eb)
   and not emptyBlockContainsNonchild(eb)
+  and not lineComment(eb)
 select eb, "Empty block without comment"

--- a/cpp/ql/test/query-tests/Best Practices/Likely Errors/EmptyBlock/EmptyBlock.expected
+++ b/cpp/ql/test/query-tests/Best Practices/Likely Errors/EmptyBlock/EmptyBlock.expected
@@ -1,3 +1,5 @@
 | empty_block.cpp:7:10:7:11 | { ... } | Empty block without comment |
 | empty_block.cpp:10:10:11:3 | { ... } | Empty block without comment |
 | empty_block.cpp:18:10:19:3 | { ... } | Empty block without comment |
+| empty_block.cpp:53:10:53:11 | { ... } | Empty block without comment |
+| empty_block.cpp:56:10:56:11 | { ... } | Empty block without comment |

--- a/cpp/ql/test/query-tests/Best Practices/Likely Errors/EmptyBlock/EmptyBlock.expected
+++ b/cpp/ql/test/query-tests/Best Practices/Likely Errors/EmptyBlock/EmptyBlock.expected
@@ -1,5 +1,3 @@
 | empty_block.cpp:7:10:7:11 | { ... } | Empty block without comment |
 | empty_block.cpp:10:10:11:3 | { ... } | Empty block without comment |
 | empty_block.cpp:18:10:19:3 | { ... } | Empty block without comment |
-| empty_block.cpp:53:10:53:11 | { ... } | Empty block without comment |
-| empty_block.cpp:56:10:56:11 | { ... } | Empty block without comment |

--- a/cpp/ql/test/query-tests/Best Practices/Likely Errors/EmptyBlock/empty_block.cpp
+++ b/cpp/ql/test/query-tests/Best Practices/Likely Errors/EmptyBlock/empty_block.cpp
@@ -48,4 +48,10 @@ int f(int x) {
 
   // GOOD (no block)
   for (;;) ;
+
+  // GOOD (has comment): [FALSE POSITIVE]
+  if (x) {} // comment
+
+  // GOOD (has comment): [FALSE POSITIVE]
+  if (x) {}  // comment
 }


### PR DESCRIPTION
Fix false positive in EmptyBlock.ql where an empty block is commented after the block, all on the same line - observed https://lgtm.com/projects/g/google/re2/alerts/?mode=list&rule=cpp%2Fempty-block