### PR TITLE
JS: whitelist js/unused-local-variable near direct `eval` calls

### DIFF
--- a/change-notes/1.19/analysis-javascript.md
+++ b/change-notes/1.19/analysis-javascript.md
@@ -35,6 +35,7 @@
 | Remote property injection | Fewer results | The precision of this rule has been revised to "medium". Results are no longer shown on LGTM by default. |
 | Missing CSRF middleware | Fewer false-positive results | This rule now recognizes additional CSRF protection middlewares. |
 | Server-side URL redirect | More results | This rule now recognizes redirection calls in more cases. |
+| Unused variable, import, function or class | Fewer false-positive results | This rule now flags fewer variables that may be used by `eval` calls. |
 | Unused variable, import, function or class | Fewer results | This rule now flags import statements with multiple unused imports once. |
 | User-controlled bypass of security check | Fewer results | This rule no longer flags conditions that guard early returns. The precision of this rule has been revised to "medium". Results are no longer shown on LGTM by default. | 
 | Whitespace contradicts operator precedence | Fewer false-positive results | This rule no longer flags operators with asymmetric whitespace. |

--- a/javascript/ql/src/Declarations/UnusedVariable.ql
+++ b/javascript/ql/src/Declarations/UnusedVariable.ql
@@ -156,6 +156,12 @@ predicate whitelisted(UnusedLocal v) {
     isEnumMember(vd) or
     // ignore ambient declarations - too noisy
     vd.isAmbient()
+  ) or
+  exists (DirectEval eval |
+    // eval nearby
+    eval.getEnclosingFunction() = v.getADeclaration().getEnclosingFunction() and
+    // ... but not on the RHS
+    not v.getAnAssignedExpr() = eval
   )
 }
 

--- a/javascript/ql/test/query-tests/Declarations/UnusedVariable/UnusedVariable.expected
+++ b/javascript/ql/test/query-tests/Declarations/UnusedVariable/UnusedVariable.expected
@@ -1,5 +1,9 @@
 | decorated.ts:1:1:1:126 | import  ... where'; | Unused import actionHandler. |
 | decorated.ts:4:10:4:12 | fun | Unused function fun. |
+| eval.js:2:9:2:20 | used_by_eval | Unused variable used_by_eval. |
+| eval.js:7:9:7:20 | used_by_eval | Unused variable used_by_eval. |
+| eval.js:10:9:10:24 | not_used_by_eval | Unused variable not_used_by_eval. |
+| eval.js:19:9:19:24 | not_used_by_eval | Unused variable not_used_by_eval. |
 | externs.js:6:5:6:13 | iAmUnused | Unused variable iAmUnused. |
 | multi-imports.js:1:1:1:29 | import  ... om 'x'; | Unused imports a, b, d. |
 | multi-imports.js:2:1:2:42 | import  ... om 'x'; | Unused imports alphabetically, ordered. |

--- a/javascript/ql/test/query-tests/Declarations/UnusedVariable/UnusedVariable.expected
+++ b/javascript/ql/test/query-tests/Declarations/UnusedVariable/UnusedVariable.expected
@@ -1,7 +1,5 @@
 | decorated.ts:1:1:1:126 | import  ... where'; | Unused import actionHandler. |
 | decorated.ts:4:10:4:12 | fun | Unused function fun. |
-| eval.js:2:9:2:20 | used_by_eval | Unused variable used_by_eval. |
-| eval.js:7:9:7:20 | used_by_eval | Unused variable used_by_eval. |
 | eval.js:10:9:10:24 | not_used_by_eval | Unused variable not_used_by_eval. |
 | eval.js:19:9:19:24 | not_used_by_eval | Unused variable not_used_by_eval. |
 | externs.js:6:5:6:13 | iAmUnused | Unused variable iAmUnused. |

--- a/javascript/ql/test/query-tests/Declarations/UnusedVariable/eval.js
+++ b/javascript/ql/test/query-tests/Declarations/UnusedVariable/eval.js
@@ -1,0 +1,20 @@
+(function(){
+    var used_by_eval = f();
+    eval(src);
+});
+(function(){
+    eval(src);
+    var used_by_eval = f();
+});
+(function(){
+    var not_used_by_eval = f();
+    (function(){
+        eval(src);
+    })
+});
+(function(){
+    (function(){
+        eval(src);
+    })
+    var not_used_by_eval = f();
+});


### PR DESCRIPTION
This PR whitelists results in `js/unused-local-variable` for variables declared near `eval` calls. Inspired by <https://github.com/Zarel/Pokemon-Showdown/pull/4843#issuecomment-433696003>. Brief [evaluation](https://git.semmle.com/esben/dist-compare-reports/tree/js/unused-eval-variable_1540824705294) shows that it scales.