### PR TITLE
JavaScript: Minor updates to AMD modelling

### DIFF
--- a/javascript/ql/src/semmle/javascript/AMD.qll
+++ b/javascript/ql/src/semmle/javascript/AMD.qll
@@ -105,7 +105,7 @@ class AMDModuleDefinition extends CallExpr {
    * parameters `pdep1` and `pdep2` correspond to dependencies
    * `dep1` and `dep2`.
    */
-  private SimpleParameter getDependencyParameter(string name) {
+  Parameter getDependencyParameter(string name) {
     exists (PathExpr dep |
       dependencyParameter(dep, result) and
       dep.getValue() = name

--- a/javascript/ql/src/semmle/javascript/dataflow/Nodes.qll
+++ b/javascript/ql/src/semmle/javascript/dataflow/Nodes.qll
@@ -399,10 +399,8 @@ class ModuleImportNode extends DataFlow::DefaultSourceNode {
     )
     or
     // declared AMD dependency
-    exists (AMDModuleDefinition amd, PathExpr dep, Parameter p |
-      amd.dependencyParameter(dep, p) and
-      path = dep.getValue() and
-      this = DataFlow::parameterNode(p)
+    exists (AMDModuleDefinition amd |
+      this = DataFlow::parameterNode(amd.getDependencyParameter(path))
     )
     or
     // AMD require


### PR DESCRIPTION
The first commit allows (and ignores) extra arguments to the AMD `define` function, which we've observed at a customer's.

The second commit makes a useful predicate public. I don't remember a concrete reason for making it private in the first place, it just seems to always have been private.