### PR TITLE
C#: Reduce extractor log size

### DIFF
--- a/csharp/extractor/Semmle.Autobuild.Tests/BuildScripts.cs
+++ b/csharp/extractor/Semmle.Autobuild.Tests/BuildScripts.cs
@@ -33,6 +33,8 @@ namespace Semmle.Extraction.Tests
             FileExistsIn.Add(file);
             if (FileExists.TryGetValue(file, out var ret))
                 return ret;
+            if (FileExists.TryGetValue(System.IO.Path.GetFileName(file), out ret))
+                return ret;
             throw new ArgumentException("Missing FileExists " + file);
         }
 

--- a/csharp/extractor/Semmle.Extraction.CSharp/CompilerVersion.cs
+++ b/csharp/extractor/Semmle.Extraction.CSharp/CompilerVersion.cs
@@ -124,7 +124,7 @@ namespace Semmle.Extraction.CSharp
         /// <returns>Modified list of arguments.</returns>
         static IEnumerable<string> AddDefaultResponse(string responseFile, IEnumerable<string> args)
         {
-            return SuppressDefaultResponseFile(args) && File.Exists(responseFile) ?
+            return SuppressDefaultResponseFile(args) || !File.Exists(responseFile) ?
                 args :
                 new[] { "@" + responseFile }.Concat(args);
         }

--- a/csharp/extractor/Semmle.Extraction.CSharp/Extractor.cs
+++ b/csharp/extractor/Semmle.Extraction.CSharp/Extractor.cs
@@ -36,7 +36,7 @@ namespace Semmle.Extraction.CSharp
             {
                 if (action != AnalysisAction.UpToDate)
                 {
-                    Logger.Log(Severity.Info, "  {0} ({2})", source, output,
+                    Logger.Log(Severity.Info, "  {0} ({1})", source,
                         action == AnalysisAction.Extracted ? time.ToString() : action == AnalysisAction.Excluded ? "excluded" : "up to date");
                 }
             }

--- a/csharp/extractor/Semmle.Extraction.CSharp/Extractor.cs
+++ b/csharp/extractor/Semmle.Extraction.CSharp/Extractor.cs
@@ -34,8 +34,11 @@ namespace Semmle.Extraction.CSharp
 
             public void Analysed(int item, int total, string source, string output, TimeSpan time, AnalysisAction action)
             {
-                Logger.Log(Severity.Info, "  {0} -> {1} ({2})", source, output,
-                    action == AnalysisAction.Extracted ? time.ToString() : action == AnalysisAction.Excluded ? "excluded" : "up to date");
+                if (action != AnalysisAction.UpToDate)
+                {
+                    Logger.Log(Severity.Info, "  {0} ({2})", source, output,
+                        action == AnalysisAction.Extracted ? time.ToString() : action == AnalysisAction.Excluded ? "excluded" : "up to date");
+                }
             }
 
             public void MissingNamespace(string @namespace) { }
@@ -361,27 +364,28 @@ namespace Semmle.Extraction.CSharp
         /// <summary>
         /// Gets the path to the `csharp.log` file written to by the C# extractor.
         /// </summary>
-        public static string GetCSharpLogPath()
+        public static string GetCSharpLogPath() =>
+            Path.Combine(GetCSharpLogDirectory(), "csharp.log");
+
+        public static string GetCSharpLogDirectory()
         {
             string snapshot = Environment.GetEnvironmentVariable("ODASA_SNAPSHOT");
             string buildErrorDir = Environment.GetEnvironmentVariable("ODASA_BUILD_ERROR_DIR");
             string traps = Environment.GetEnvironmentVariable("TRAP_FOLDER");
-            string output = "csharp.log";
             if (!string.IsNullOrEmpty(snapshot))
             {
-                snapshot = Path.Combine(snapshot, "log");
-                return Path.Combine(snapshot, output);
+                return Path.Combine(snapshot, "log");
             }
             if (!string.IsNullOrEmpty(buildErrorDir))
             {
                 // Used by `qltest`
-                return Path.Combine(buildErrorDir, output);
+                return buildErrorDir;
             }
             if (!string.IsNullOrEmpty(traps))
             {
-                return Path.Combine(traps, output);
+                return traps;
             }
-            return output;
+            return Directory.GetCurrentDirectory();
         }
     }
 }

--- a/csharp/extractor/Semmle.Extraction.Tests/Options.cs
+++ b/csharp/extractor/Semmle.Extraction.Tests/Options.cs
@@ -1,6 +1,8 @@
 using Xunit;
 using Semmle.Util.Logging;
 using System;
+using System.IO;
+using Semmle.Util;
 
 namespace Semmle.Extraction.Tests
 {
@@ -183,6 +185,25 @@ namespace Semmle.Extraction.Tests
             Environment.SetEnvironmentVariable("LGTM_INDEX_EXTRACTOR", "--fast");
             options = CSharp.Options.CreateWithEnvironment(new string[] {});
             Assert.True(options.Fast);
+        }
+
+        [Fact]
+        public void ArchiveArguments()
+        {
+            var file1 = Path.GetTempFileName();
+            var file2 = Path.GetTempFileName();
+
+            try
+            {
+                File.AppendAllText(file1, "Test");
+                new string[] { "/noconfig", "@" + file1 }.ArchiveCommandLine(file2);
+                Assert.Equal("Test", File.ReadAllText(file2));
+            }
+            finally
+            {
+                File.Delete(file1);
+                File.Delete(file2);
+            }
         }
     }
 }

--- a/csharp/extractor/Semmle.Extraction/Message.cs
+++ b/csharp/extractor/Semmle.Extraction/Message.cs
@@ -14,5 +14,7 @@ namespace Semmle.Extraction
         public ISymbol symbol;
         public SyntaxNode node;
         public Exception exception;
+
+        public override string ToString() => message;
     }
 }

--- a/csharp/extractor/Semmle.Util/CommandLineExtensions.cs
+++ b/csharp/extractor/Semmle.Util/CommandLineExtensions.cs
@@ -1,0 +1,26 @@
+﻿using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+
+namespace Semmle.Util
+{
+    public static class CommandLineExtensions
+    {
+        /// <summary>
+        /// Archives the first "@" argument in a list of command line arguments.
+        /// Subsequent "@" arguments are ignored.
+        /// </summary>
+        /// <param name="commandLineArguments">The raw command line arguments.</param>
+        /// <param name="filename">The full filename to write to.</param>
+        /// <returns>True iff the file was written.</returns>
+        public static bool ArchiveCommandLine(this IEnumerable<string> commandLineArguments, string filename)
+        {
+            foreach (var arg in commandLineArguments.Where(arg => arg[0] == '@').Select(arg => arg.Substring(1)))
+            {
+                File.Copy(arg, filename, true);
+                return true;
+            }
+            return false;
+        }
+    }
+}


### PR DESCRIPTION
This PR reduces the size of `csharp.log`. For example, on OrchardCore, the old log size file was 18MB, whereas now it is 454kB. It makes the log file much more readable.

The following changes have been made:

- Log extractor arguments to separate files, `csharp.*.txt`. This is more convenient for debugging the extractor, where you can @ mention the arguments on the command line to debug.
- Fix a small bug when `csc.rsp` is missing. No user-facing changes.
- Don't log extracted files that are up to date.
- Don't log the name of the output trap file.
