### PR TITLE
JS: whitelist the "uknown" `"no use strict"` directive

### DIFF
--- a/javascript/ql/src/Expressions/UnknownDirective.ql
+++ b/javascript/ql/src/Expressions/UnknownDirective.ql
@@ -13,5 +13,6 @@ import javascript
 from Directive d
 where not d instanceof KnownDirective and
       // but exclude attribute top-levels: `<a href="javascript:'some-attribute-string'">`
-      not (d.getParent() instanceof CodeInAttribute)
+      not (d.getParent() instanceof CodeInAttribute) and
+      not d.getDirectiveText() = "no use strict"
 select d, "Unknown directive: '" + truncate(d.getDirectiveText(), 20, " ... (truncated)")  + "'."

--- a/javascript/ql/test/query-tests/Expressions/UnknownDirective/UnknownDirective.js
+++ b/javascript/ql/test/query-tests/Expressions/UnknownDirective/UnknownDirective.js
@@ -38,3 +38,7 @@ function data() {
     "[0, 0, 0];"; // NOT OK
     "[0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0];"; // NOT OK
 }
+
+function deliberate(){
+    "no use strict"; // whitelisted
+};


### PR DESCRIPTION
This change whitelists the "uknown" `"no use strict"` directive. It seems to be used to avoid accidentally introducing "use strict":

-   <https://lgtm.com/projects/g/ajaxorg/ace/snapshot/77e3515ed06e0419724853bac7240247b0721c03/files/lib/ace/worker/worker.js?sort=name&dir=ASC&mode=heatmap&showExcluded=true#xa249ed76082a45d1:1>
-   <https://lgtm.com/projects/g/ajaxorg/ace/snapshot/77e3515ed06e0419724853bac7240247b0721c03/files/lib/ace/config.js?sort=name&dir=ASC&mode=heatmap&showExcluded=true#x3c20bdd1db93cd0c:1>
-   <https://lgtm.com/projects/g/ajaxorg/ace/snapshot/77e3515ed06e0419724853bac7240247b0721c03/files/lib/ace/lib/app_config.js?sort=name&dir=ASC&mode=heatmap&showExcluded=true#x83d2dfaadb8365f:1>