### PR TITLE
C#: Minor extractor fixes

### DIFF
--- a/change-notes/1.19/analysis-csharp.md
+++ b/change-notes/1.19/analysis-csharp.md
@@ -23,6 +23,7 @@
 ## Changes to code extraction
 
 * Arguments passed using `in` are now extracted.
+* Fix a bug where the `dynamic` type name was not extracted correctly in certain circumstances.
 
 ## Changes to QL libraries
 

--- a/csharp/extractor/Semmle.Extraction.CSharp/Entities/Expressions/Name.cs
+++ b/csharp/extractor/Semmle.Extraction.CSharp/Entities/Expressions/Name.cs
@@ -43,6 +43,7 @@ namespace Semmle.Extraction.CSharp.Entities.Expressions
             {
                 case SymbolKind.TypeParameter:
                 case SymbolKind.NamedType:
+                case SymbolKind.DynamicType:
                     return TypeAccess.Create(info);
 
                 case SymbolKind.Property:

--- a/csharp/extractor/Semmle.Extraction.CSharp/Entities/Property.cs
+++ b/csharp/extractor/Semmle.Extraction.CSharp/Entities/Property.cs
@@ -114,6 +114,6 @@ namespace Semmle.Extraction.CSharp.Entities
             public Property Create(Context cx, IPropertySymbol init) => new Property(cx, init);
         }
 
-        public override TrapStackBehaviour TrapStackBehaviour => TrapStackBehaviour.NoLabel;
+        public override TrapStackBehaviour TrapStackBehaviour => TrapStackBehaviour.PushesLabel;
     }
 }

--- a/csharp/ql/test/library-tests/regressions/Program.cs
+++ b/csharp/ql/test/library-tests/regressions/Program.cs
@@ -119,3 +119,18 @@ class LiteralConversions
         new Point { x=1, y=2 };
     }
 }
+
+class DynamicType
+{
+    void F()
+    {
+        dynamic t = (dynamic)null;
+    }
+}
+
+class LocalVariableTags
+{
+    Func<int, int> F = x => { int y=x; return y; };
+}
+
+// semmle-extractor-options: /r:System.Dynamic.Runtime.dll

--- a/csharp/ql/test/library-tests/regressions/Program.cs
+++ b/csharp/ql/test/library-tests/regressions/Program.cs
@@ -131,6 +131,12 @@ class DynamicType
 class LocalVariableTags
 {
     Func<int, int> F = x => { int y=x; return y; };
+
+    private static Func<object, string, object> _getter => (o, n) =>
+    {
+         object x = o;
+         return x;
+    };
 }
 
 // semmle-extractor-options: /r:System.Dynamic.Runtime.dll

--- a/csharp/ql/test/library-tests/regressions/TypeMentions.expected
+++ b/csharp/ql/test/library-tests/regressions/TypeMentions.expected
@@ -52,3 +52,10 @@
 | Program.cs:114:16:114:19 | Nullable<Int32> |
 | Program.cs:117:5:117:8 | Void |
 | Program.cs:119:13:119:17 | Point |
+| Program.cs:125:5:125:8 | Void |
+| Program.cs:127:9:127:15 | dynamic |
+| Program.cs:127:22:127:28 | dynamic |
+| Program.cs:133:5:133:8 | Func<Int32,Int32> |
+| Program.cs:133:10:133:12 | Int32 |
+| Program.cs:133:15:133:17 | Int32 |
+| Program.cs:133:31:133:33 | Int32 |

--- a/csharp/ql/test/library-tests/regressions/TypeMentions.expected
+++ b/csharp/ql/test/library-tests/regressions/TypeMentions.expected
@@ -59,3 +59,8 @@
 | Program.cs:133:10:133:12 | Int32 |
 | Program.cs:133:15:133:17 | Int32 |
 | Program.cs:133:31:133:33 | Int32 |
+| Program.cs:135:20:135:23 | Func<Object,String,Object> |
+| Program.cs:135:25:135:30 | Object |
+| Program.cs:135:33:135:38 | String |
+| Program.cs:135:41:135:46 | Object |
+| Program.cs:137:10:137:15 | Object |


### PR DESCRIPTION
This fixes two small issues that were causing messages in `csharp.log`.

1. Local variables were always expecting to be used in a "tagged" context, but this failed when they were declared in lambdas in ~~fields~~ properties. ~~Change this to "optionally tagged" instead.~~
2. The `dynamic` typename was not extracted.