### PR TITLE
SuspiciousCallToMemset: Simplify pointer indirection computation

### DIFF
--- a/cpp/ql/src/Likely Bugs/Memory Management/SuspiciousCallToMemset.ql
+++ b/cpp/ql/src/Likely Bugs/Memory Management/SuspiciousCallToMemset.ql
@@ -52,13 +52,13 @@ Type stripType(Type t) {
 
 /**
  * Holds if `t` points to `base` via a specified number of levels of pointer
- * indirection.  Intermediate typedefs and array types are allowed.
+ * indirection.  Intermediate typedefs and array types are allowed. Note that
+ * `base` is a stripped type (via `stripType`).
  */
 predicate pointerIndirection(Type t, int indirection, Type base) {
-  exists(Type u |
-    u = stripType(t) and
-    u = stripType(base) and
-    not u instanceof PointerType and
+  (
+    base = stripType(t) and
+    not base instanceof PointerType and
     indirection = 0
   ) or (
     pointerIndirection(stripType(t).(PointerType).getBaseType(), indirection - 1, base)


### PR DESCRIPTION
On large and template-heavy C++ code bases, we've observed hundreds of thousands of local typedefs targetting the same type. Previously, all pairs of such typedefs would be stored as aliases of each other at indirection level 0 in `pointerIndirection`, which proved problematic.

This PR instead insists that the `base` type of a pair in `pointerIndirection` is fully stripped. In this way, we store a linear rather than quadratic number of facts.

@geoffw0, you wanted to have a look at this.