### PR TITLE
Java: Rerun autoformat on all Java QL.

### DIFF
--- a/java/ql/src/AlertSuppression.ql
+++ b/java/ql/src/AlertSuppression.ql
@@ -17,7 +17,8 @@ class SuppressionComment extends Javadoc {
     isEolComment(this) and
     exists(string text | text = getChild(0).getText() |
       // match `lgtm[...]` anywhere in the comment
-      annotation = text.regexpFind("(?i)\\blgtm\\s*\\[[^\\]]*\\]", _, _) or
+      annotation = text.regexpFind("(?i)\\blgtm\\s*\\[[^\\]]*\\]", _, _)
+      or
       // match `lgtm` at the start of the comment and after semicolon
       annotation = text.regexpFind("(?i)(?<=^|;)\\s*lgtm(?!\\B|\\s*\\[)", _, _).trim()
     )

--- a/java/ql/src/Frameworks/Spring/Architecture/Refactoring Opportunities/UnusedBean.ql
+++ b/java/ql/src/Frameworks/Spring/Architecture/Refactoring Opportunities/UnusedBean.ql
@@ -156,12 +156,16 @@ class LiveSpringBean extends SpringBean {
       // If the class does not exist for this bean, or the class is not a source bean, then this is
       // likely to be a definition using a library class, in which case we should consider it to be
       // live.
-      not exists(getClass()) or
-      not getClass().fromSource() or
+      not exists(getClass())
+      or
+      not getClass().fromSource()
+      or
       // In alfresco, "webscript" beans should be considered live
-      getBeanParent*().getBeanParentName() = "webscript" or
+      getBeanParent*().getBeanParentName() = "webscript"
+      or
       // A live child bean implies this bean is live
-      exists(LiveSpringBean child | this = child.getBeanParent()) or
+      exists(LiveSpringBean child | this = child.getBeanParent())
+      or
       // Beans constructed by a bean factory are considered live
       exists(SpringBeanFactory beanFactory | this = beanFactory.getAConstructedBean())
     )

--- a/java/ql/src/Likely Bugs/Concurrency/NonSynchronizedOverride.ql
+++ b/java/ql/src/Likely Bugs/Concurrency/NonSynchronizedOverride.ql
@@ -41,7 +41,8 @@ predicate delegatingOverride(Method sub, Method sup) {
     stmt = sub.getBody().(SingletonBlock).getStmt() and
     (
       // ...that is either a delegating call to `sup` (with a possible cast)...
-      delegatingSuperCall(stmt.(ExprStmt).getExpr(), sup) or
+      delegatingSuperCall(stmt.(ExprStmt).getExpr(), sup)
+      or
       // ...or a `return` statement containing such a call.
       delegatingSuperCall(stmt.(ReturnStmt).getResult(), sup)
     )

--- a/java/ql/src/Security/CWE/CWE-129/BoundingChecks.qll
+++ b/java/ql/src/Security/CWE/CWE-129/BoundingChecks.qll
@@ -58,7 +58,8 @@ predicate lessthanLength(ArrayAccess a) {
 pragma[nomagic]
 private Expr arrayReference(ArrayAccess arrayAccess) {
   // Array is stored in a variable.
-  result = arrayAccess.getArray().(VarAccess).getVariable().getAnAccess() or
+  result = arrayAccess.getArray().(VarAccess).getVariable().getAnAccess()
+  or
   // Array is returned from a method.
   result.(MethodAccess).getMethod() = arrayAccess.getArray().(MethodAccess).getMethod()
 }

--- a/java/ql/src/Security/CWE/CWE-129/ImproperValidationOfArrayIndexCodeSpecified.ql
+++ b/java/ql/src/Security/CWE/CWE-129/ImproperValidationOfArrayIndexCodeSpecified.ql
@@ -32,13 +32,15 @@ where
   not (
     (
       // The input has a lower bound.
-      source.lowerBound() >= 0 or
+      source.lowerBound() >= 0
+      or
       // There is a condition dominating this expression ensuring that the index is >= 0.
       lowerBound(arrayAccess.getIndexExpr()) >= 0
     ) and
     (
       // The input has an upper bound, and the array has a fixed size, and that fixed size is less.
-      source.upperBound() < fixedArraySize(arrayAccess) or
+      source.upperBound() < fixedArraySize(arrayAccess)
+      or
       // There is a condition dominating this expression that ensures the index is less than the length.
       lessthanLength(arrayAccess)
     )

--- a/java/ql/src/Security/CWE/CWE-319/HttpsUrls.ql
+++ b/java/ql/src/Security/CWE/CWE-319/HttpsUrls.ql
@@ -18,7 +18,8 @@ class HTTPString extends StringLiteral {
     exists(string s | this.getRepresentedString() = s |
       (
         // Either the literal "http", ...
-        s = "http" or
+        s = "http"
+        or
         // ... or the beginning of a http URL.
         s.matches("http://%")
       ) and

--- a/java/ql/src/semmle/code/java/Expr.qll
+++ b/java/ql/src/semmle/code/java/Expr.qll
@@ -1266,7 +1266,8 @@ class VarAccess extends Expr, @varaccess {
    */
   predicate isLocal() {
     // The access has no qualifier, or...
-    not hasQualifier() or
+    not hasQualifier()
+    or
     // the qualifier is either `this` or `A.this`, where `A` is the enclosing type, or
     // the qualifier is either `super` or `A.super`, where `A` is the enclosing type.
     getQualifier().(InstanceAccess).isOwnInstanceAccess()
@@ -1705,7 +1706,8 @@ class Argument extends Expr {
       p.isVarargs() and
       ptyp = p.getType() and
       (
-        hasSubtype*(ptyp, typ) or
+        hasSubtype*(ptyp, typ)
+        or
         // If the types don't match then we'll guess based on whether there are type variables involved.
         hasInstantiation(ptyp.(Array).getComponentType())
       )

--- a/java/ql/src/semmle/code/java/Member.qll
+++ b/java/ql/src/semmle/code/java/Member.qll
@@ -370,7 +370,8 @@ class Method extends Callable, @method {
   }
 
   override predicate isStrictfp() {
-    Callable.super.isStrictfp() or
+    Callable.super.isStrictfp()
+    or
     // JLS 8.1.1.3, JLS 9.1.1.2
     getDeclaringType().isStrictfp()
   }
@@ -575,21 +576,24 @@ class Field extends Member, ExprParent, @field, Variable {
   predicate isSourceDeclaration() { this.getSourceDeclaration() = this }
 
   override predicate isPublic() {
-    Member.super.isPublic() or
+    Member.super.isPublic()
+    or
     // JLS 9.3: Every field declaration in the body of an interface is
     // implicitly public, static, and final
     getDeclaringType() instanceof Interface
   }
 
   override predicate isStatic() {
-    Member.super.isStatic() or
+    Member.super.isStatic()
+    or
     // JLS 9.3: Every field declaration in the body of an interface is
     // implicitly public, static, and final
     this.getDeclaringType() instanceof Interface
   }
 
   override predicate isFinal() {
-    Member.super.isFinal() or
+    Member.super.isFinal()
+    or
     // JLS 9.3: Every field declaration in the body of an interface is
     // implicitly public, static, and final
     this.getDeclaringType() instanceof Interface

--- a/java/ql/src/semmle/code/java/Reflection.qll
+++ b/java/ql/src/semmle/code/java/Reflection.qll
@@ -271,9 +271,11 @@ class NewInstance extends MethodAccess {
     not result instanceof TypeVariable and
     (
       // If this is called on a `Class<T>` instance, return the inferred type `T`.
-      result = inferClassParameterType(getQualifier()) or
+      result = inferClassParameterType(getQualifier())
+      or
       // If this is called on a `Constructor<T>` instance, return the inferred type `T`.
-      result = inferConstructorParameterType(getQualifier()) or
+      result = inferConstructorParameterType(getQualifier())
+      or
       // If the result of this is cast to a particular type, then use that type.
       result = getCastInferredConstructedTypes()
     )

--- a/java/ql/src/semmle/code/java/Type.qll
+++ b/java/ql/src/semmle/code/java/Type.qll
@@ -216,16 +216,19 @@ private predicate typeArgumentContainsAux1(RefType s, RefType t, int n) {
   |
     exists(RefType tUpperBound | tUpperBound = t.(Wildcard).getUpperBound().getType() |
       // ? extends T <= ? extends S if T <: S
-      hasSubtypeStar0(s.(Wildcard).getUpperBound().getType(), tUpperBound) or
+      hasSubtypeStar0(s.(Wildcard).getUpperBound().getType(), tUpperBound)
+      or
       // ? extends T <= ?
       s.(Wildcard).isUnconstrained()
     )
     or
     exists(RefType tLowerBound | tLowerBound = t.(Wildcard).getLowerBound().getType() |
       // ? super T <= ? super S if s <: T
-      hasSubtypeStar0(tLowerBound, s.(Wildcard).getLowerBound().getType()) or
+      hasSubtypeStar0(tLowerBound, s.(Wildcard).getLowerBound().getType())
+      or
       // ? super T <= ?
-      s.(Wildcard).isUnconstrained() or
+      s.(Wildcard).isUnconstrained()
+      or
       // ? super T <= ? extends Object
       wildcardExtendsObject(s)
     )
@@ -736,13 +739,15 @@ class NestedType extends RefType {
   }
 
   override predicate isPublic() {
-    super.isPublic() or
+    super.isPublic()
+    or
     // JLS 9.5: A member type declaration in an interface is implicitly public and static
     exists(Interface i | this = i.getAMember())
   }
 
   override predicate isStrictfp() {
-    super.isStrictfp() or
+    super.isStrictfp()
+    or
     // JLS 8.1.1.3, JLS 9.1.1.2
     getEnclosingType().isStrictfp()
   }
@@ -762,11 +767,14 @@ class NestedType extends RefType {
    * section 8.9 (Enums) and section 9.5 (Member Type Declarations).
    */
   override predicate isStatic() {
-    super.isStatic() or
+    super.isStatic()
+    or
     // JLS 8.5.1: A member interface is implicitly static.
-    this instanceof Interface or
+    this instanceof Interface
+    or
     // JLS 8.9: A nested enum type is implicitly static.
-    this instanceof EnumType or
+    this instanceof EnumType
+    or
     // JLS 9.5: A member type declaration in an interface is implicitly public and static
     exists(Interface i | this = i.getAMember())
   }

--- a/java/ql/src/semmle/code/java/UnitTests.qll
+++ b/java/ql/src/semmle/code/java/UnitTests.qll
@@ -148,7 +148,8 @@ class TestNGTestMethod extends Method {
             .getRepresentedString()
     |
       // Either the data provider should be on the current class, or a supertype
-      getDeclaringType().getAnAncestor() = result.getDeclaringType() or
+      getDeclaringType().getAnAncestor() = result.getDeclaringType()
+      or
       // Or the data provider class should be declared
       result.getDeclaringType() = testAnnotation
             .getValue("dataProviderClass")

--- a/java/ql/src/semmle/code/java/deadcode/DeadField.qll
+++ b/java/ql/src/semmle/code/java/deadcode/DeadField.qll
@@ -43,11 +43,14 @@ class LiveField extends SourceField {
         a.getValue(_) = access.getParent*()
       |
         // The annotated element is a live callable.
-        isLive(a.getAnnotatedElement()) or
+        isLive(a.getAnnotatedElement())
+        or
         // The annotated element is in a live callable.
-        isLive(a.getAnnotatedElement().(LocalVariableDecl).getEnclosingCallable()) or
+        isLive(a.getAnnotatedElement().(LocalVariableDecl).getEnclosingCallable())
+        or
         // The annotated element is a live field.
-        a.getAnnotatedElement() instanceof LiveField or
+        a.getAnnotatedElement() instanceof LiveField
+        or
         // The annotated element is a live source class or interface.
         // Note: We ignore annotation values on library classes, because they should only refer to
         // fields in library classes, not `fromSource()` fields.

--- a/java/ql/src/semmle/code/java/frameworks/Camel.qll
+++ b/java/ql/src/semmle/code/java/frameworks/Camel.qll
@@ -58,7 +58,8 @@ class CamelTargetClass extends Class {
   CamelTargetClass() {
     exists(SpringCamelXMLBeanRef camelXMLBeanRef |
       // A target may be defined by referencing an existing Spring Bean.
-      this = camelXMLBeanRef.getRefBean().getClass() or
+      this = camelXMLBeanRef.getRefBean().getClass()
+      or
       // A target may be defined by referencing a class, which Apache Camel will create into a bean.
       this = camelXMLBeanRef.getBeanType()
     )

--- a/java/ql/src/semmle/code/java/frameworks/Mockito.qll
+++ b/java/ql/src/semmle/code/java/frameworks/Mockito.qll
@@ -53,7 +53,8 @@ class MockitoInitedTest extends Class {
   MockitoInitedTest() {
     // Tests run with the Mockito runner.
     exists(RunWithAnnotation a | a = this.getAnAncestor().getAnAnnotation() |
-      a.getRunner().(RefType).hasQualifiedName("org.mockito.runners", "MockitoJUnitRunner") or
+      a.getRunner().(RefType).hasQualifiedName("org.mockito.runners", "MockitoJUnitRunner")
+      or
       // Deprecated style.
       a.getRunner().(RefType).hasQualifiedName("org.mockito.runners", "MockitoJUnit44Runner")
     )
@@ -124,7 +125,8 @@ class MockitoAnnotatedField extends Field {
  */
 class MockitoMockedField extends MockitoAnnotatedField {
   MockitoMockedField() {
-    hasAnnotation("org.mockito", "Mock") or
+    hasAnnotation("org.mockito", "Mock")
+    or
     // Deprecated style.
     hasAnnotation("org.mockito", "MockitoAnnotations$Mock")
   }

--- a/java/ql/src/semmle/code/java/frameworks/javaee/JavaServerFaces.qll
+++ b/java/ql/src/semmle/code/java/frameworks/javaee/JavaServerFaces.qll
@@ -61,7 +61,8 @@ class FacesComponent extends Class {
       // Must be registered using either an annotation
       exists(FacesComponentAnnotation componentAnnotation |
         this = componentAnnotation.getFacesComponentClass()
-      ) or
+      )
+      or
       // Or in an XML file
       exists(FacesConfigComponentClass componentClassXML |
         this = componentClassXML.getFacesComponentClass()

--- a/java/ql/src/semmle/code/java/frameworks/javaee/ejb/EJB.qll
+++ b/java/ql/src/semmle/code/java/frameworks/javaee/ejb/EJB.qll
@@ -153,9 +153,11 @@ class StatelessSessionEJB extends SessionEJB {
 class MessageDrivenBean extends EJB {
   MessageDrivenBean() {
     // Subtype of `javax.ejb.MessageBean`.
-    this instanceof MessageBean or
+    this instanceof MessageBean
+    or
     // EJB annotations.
-    this.getAnAnnotation().getType().hasName("MessageDriven") or
+    this.getAnAnnotation().getType().hasName("MessageDriven")
+    or
     // XML deployment descriptor.
     exists(EjbJarXMLFile f |
       this.getQualifiedName() = f
@@ -173,7 +175,8 @@ class MessageDrivenBean extends EJB {
 class EntityEJB extends EJB {
   EntityEJB() {
     // Subtype of `javax.ejb.EntityBean`.
-    this instanceof EntityBean or
+    this instanceof EntityBean
+    or
     // XML deployment descriptor.
     exists(EjbJarXMLFile f |
       this.getQualifiedName() = f
@@ -294,7 +297,8 @@ class XmlSpecifiedBusinessInterface extends BusinessInterface {
 class AnnotatedBusinessInterface extends BusinessInterface {
   AnnotatedBusinessInterface() {
     // An interface annotated as `@Remote` or `@Local`.
-    this.getAnAnnotation() instanceof BusinessInterfaceAnnotation or
+    this.getAnAnnotation() instanceof BusinessInterfaceAnnotation
+    or
     // An interface named within a `@Local` or `@Remote` annotation of another type.
     exists(BusinessInterfaceAnnotation a | a.getANamedType() = this)
   }

--- a/java/ql/src/semmle/code/java/frameworks/spring/SpringComponentScan.qll
+++ b/java/ql/src/semmle/code/java/frameworks/spring/SpringComponentScan.qll
@@ -96,7 +96,8 @@ class SpringBasePackage extends string {
 class SpringComponentAnnotation extends AnnotationType {
   SpringComponentAnnotation() {
     // Component used directly as an annotation.
-    hasQualifiedName("org.springframework.stereotype", "Component") or
+    hasQualifiedName("org.springframework.stereotype", "Component")
+    or
     // Component can be used as a meta-annotation on other annotation types.
     getAnAnnotation().getType() instanceof SpringComponentAnnotation
   }

--- a/java/ql/src/semmle/code/java/frameworks/spring/SpringController.qll
+++ b/java/ql/src/semmle/code/java/frameworks/spring/SpringController.qll
@@ -6,7 +6,8 @@ import java
 class SpringControllerAnnotation extends AnnotationType {
   SpringControllerAnnotation() {
     // `@Controller` used directly as an annotation.
-    hasQualifiedName("org.springframework.stereotype", "Controller") or
+    hasQualifiedName("org.springframework.stereotype", "Controller")
+    or
     // `@Controller` can be used as a meta-annotation on other annotation types.
     getAnAnnotation().getType() instanceof SpringControllerAnnotation
   }

--- a/java/ql/src/semmle/code/java/security/FileWritable.qll
+++ b/java/ql/src/semmle/code/java/security/FileWritable.qll
@@ -111,7 +111,8 @@ private predicate fileSetWorldWritable(VarAccess fileAccess, Expr setWorldWritab
     setPosixPerms.getMethod().hasName("setPosixFilePermissions") and
     setPosixPerms.getMethod().getDeclaringType().hasQualifiedName("java.nio.file", "Files") and
     (
-      fileAccess = setPosixPerms.getArgument(0) or
+      fileAccess = setPosixPerms.getArgument(0)
+      or
       // The argument was a file that has been converted to a path.
       fileAccess = getFileForPathConversion(setPosixPerms.getArgument(0))
     )

--- a/java/ql/src/semmle/code/xml/MavenPom.qll
+++ b/java/ql/src/semmle/code/xml/MavenPom.qll
@@ -263,7 +263,8 @@ class PomDependency extends Dependency {
       source.getADependency() = this and
       // Consider dependencies that can be used at compile time.
       (
-        getScope() = "compile" or
+        getScope() = "compile"
+        or
         // Provided dependencies are like compile time dependencies except (a) they are not packaged
         // when creating the jar and (b) they are not transitive.
         getScope() = "provided"


### PR DESCRIPTION
The latest tweak to the autoformatter means that `or` won't be kept at EOL if the disjuncts are individually commented.  This updates a few files.