### PR TITLE
CPP: Speed up inconsistentLoopDirection.ql.

### DIFF
--- a/cpp/ql/src/Likely Bugs/Likely Typos/inconsistentLoopDirection.ql
+++ b/cpp/ql/src/Likely Bugs/Likely Typos/inconsistentLoopDirection.ql
@@ -20,7 +20,7 @@ import semmle.code.cpp.dataflow.DataFlow
 predicate candidateForStmt(ForStmt forStmt, Variable v, CrementOperation update, RelationalOperation rel) {
   update = forStmt.getUpdate() and
   update.getAnOperand() = v.getAnAccess() and
-  rel = forStmt.getCondition() 
+  rel = forStmt.getCondition()
 }
 
 predicate illDefinedDecrForStmt( ForStmt forstmt, Variable v, Expr initialCondition, Expr terminalCondition ) {


### PR DESCRIPTION
Speed up the `illDefined*ForStmt` predicates in `inconsistentLoopDirection.ql`.  I believe the issue was a cartesian product between `v.getAnAccess()` and `v.getAnAssignedValue()`, which caused these predicates alone to take 3m49s when I ran the query with a clean cache on `libretro_libretro-uae`.  They now take negligible time.

The overall query time dropped from 1337s to 1115s - I believe at least 700s of the remaining time may be consumed by a similar issue in `FlowVar` in the `DataFlow` library.

@jbj @pavgust 