### PR TITLE
CPP: Fix CWE tags on BadAdditionOverflowCheck.ql

### DIFF
--- a/cpp/ql/src/Likely Bugs/Arithmetic/BadAdditionOverflowCheck.ql
+++ b/cpp/ql/src/Likely Bugs/Arithmetic/BadAdditionOverflowCheck.ql
@@ -11,8 +11,8 @@
  * @tags reliability
  *       correctness
  *       security
- *       external/cwe/190
- *       external/cwe/192
+ *       external/cwe/cwe-190
+ *       external/cwe/cwe-192
  */
 
 import cpp


### PR DESCRIPTION
Fix incorrectly spelled CWE tags on BadAdditionOverflowCheck.ql.  Spotted by @felicity-semmle.