### PR TITLE
C++: Performance fix for FlowVar.getAnAccess

### DIFF
--- a/cpp/ql/src/semmle/code/cpp/dataflow/internal/FlowVar.qll
+++ b/cpp/ql/src/semmle/code/cpp/dataflow/internal/FlowVar.qll
@@ -221,9 +221,7 @@ module FlowVar_internal {
     BlockVar() { this = TBlockVar(sbb, v) }
 
     override VariableAccess getAnAccess() {
-      result.getTarget() = v and
-      result = getAReachedBlockVarSBB(this).getANode() and
-      not overwrite(result, _)
+      variableAccessInSBB(v, getAReachedBlockVarSBB(this), result)
     }
 
     override predicate definedByInitialValue(LocalScopeVariable lsv) {
@@ -371,6 +369,15 @@ module FlowVar_internal {
       not skipLoop(mid, result, sbbDef, v) and
       not assignmentLikeOperation(result, v, _)
     )
+  }
+
+  /** Holds if `va` is a read access to `v` in `sbb`, where `v` is modeled by `BlockVar`. */
+  pragma[noinline]
+  private predicate variableAccessInSBB(Variable v, SubBasicBlock sbb, VariableAccess va) {
+    exists(TBlockVar(_, v)) and
+    va.getTarget() = v and
+    va = sbb.getANode() and
+    not overwrite(va, _)
   }
 
   /**


### PR DESCRIPTION
As noted by @geoffw0 in #401, the previous formulation of this predicate caused a CP in snapshots where a variable had a large number of definitions and also reached a large number of sub-basic-blocks.

This should fix performance of https://github.com/FrodeSolheim/fs-uae and https://github.com/libretro/libretro-uae.

The `FlowVar.getAnAccess` predicate is still at risk of CP'ing when a large group of defs has a large group of uses, but that has not been observed to happen in practice yet. We would need to make `localFlowStep` expose phi definitions in order to avoid that risk.