### PR TITLE
JavaScript: Tweak a few predicates in the data flow library.

### DIFF
--- a/javascript/ql/src/semmle/javascript/dataflow/Configuration.qll
+++ b/javascript/ql/src/semmle/javascript/dataflow/Configuration.qll
@@ -566,6 +566,7 @@ private predicate callInputStep(Function f, DataFlow::Node invk,
  * Note that the summary does not take the initial step from argument to parameter
  * into account.
  */
+pragma[nomagic]
 private predicate reachableFromInput(Function f, DataFlow::Node invk,
                                      DataFlow::Node input, DataFlow::Node nd,
                                      DataFlow::Configuration cfg, PathSummary summary) {

--- a/javascript/ql/src/semmle/javascript/dataflow/Configuration.qll
+++ b/javascript/ql/src/semmle/javascript/dataflow/Configuration.qll
@@ -600,18 +600,26 @@ private predicate flowThroughCall(DataFlow::Node input, DataFlow::Node invk,
  * Holds if `pred` may flow into property `prop` of `succ` under configuration `cfg`
  * along a path summarized by `summary`.
  */
-private predicate storeStep(DataFlow::Node pred, DataFlow::SourceNode succ, string prop,
+pragma[nomagic]
+private predicate storeStep(DataFlow::Node pred, DataFlow::Node succ, string prop,
                             DataFlow::Configuration cfg, PathSummary summary) {
   basicStoreStep(pred, succ, prop) and
   summary = PathSummary::level()
   or
-  exists (Function f, DataFlow::Node mid, DataFlow::SourceNode base |
+  exists (Function f, DataFlow::Node mid, DataFlow::Node base |
     // `f` stores its parameter `pred` in property `prop` of a value that it returns,
     // and `succ` is an invocation of `f`
     reachableFromInput(f, succ, pred, mid, cfg, summary) and
-    base.hasPropertyWrite(prop, mid) and
-    base.flowsToExpr(f.getAReturnedExpr())
+    returnedPropWrite(f, base, prop, mid)
   )
+}
+
+/**
+ * Holds if `f` may return `base`, which has a write of property `prop` with right-hand side `rhs`.
+ */
+predicate returnedPropWrite(Function f, DataFlow::SourceNode base, string prop, DataFlow::Node rhs) {
+  base.hasPropertyWrite(prop, rhs) and
+  base.flowsToExpr(f.getAReturnedExpr())
 }
 
 /**

--- a/javascript/ql/src/semmle/javascript/dataflow/Configuration.qll
+++ b/javascript/ql/src/semmle/javascript/dataflow/Configuration.qll
@@ -537,7 +537,6 @@ private predicate isRelevant(DataFlow::Node nd, DataFlow::Configuration cfg) {
  * either `pred` is an argument of `f` and `succ` the corresponding parameter, or
  * `pred` is a variable definition whose value is captured by `f` at `succ`.
  */
-pragma[noopt]
 private predicate callInputStep(Function f, DataFlow::Node invk,
                                 DataFlow::Node pred, DataFlow::Node succ,
                                 DataFlow::Configuration cfg) {


### PR DESCRIPTION
During a recent customer visit, we noticed that a `pragma[noopt]` introduced by @asger-semmle in https://github.com/Semmle/ql/commit/0936cda0e9f71971441a8ecbc0a52caaa0402e37 was forcing a very bad join order, so I removed it (first commit). I also introduced two annotations to avoid unhelpful magic (second commit and third commit), and extracted an auxiliary predicate to enable a better join order (third commit).

On `default.slugs`, these three changes together have no impact on performance or results, but they do improve performance quite a bit on said customer's code base, and I'm always happy when I can remove a noopt.

@asger-semmle, do you remember where you observed the slow join that caused you to introduce the pragma in the first place? Was it one of our default projects?