### PR TITLE
JS: add email HTML body as XSS sink

### DIFF
--- a/change-notes/1.19/analysis-javascript.md
+++ b/change-notes/1.19/analysis-javascript.md
@@ -43,6 +43,7 @@
 | Whitespace contradicts operator precedence | Fewer false-positive results | This rule no longer flags operators with asymmetric whitespace. |
 | Unused import | Fewer false-positive results | This rule no longer flags imports used by the `transform-react-jsx` Babel plugin. |
 | Self assignment | Fewer false-positive results | This rule now ignores self-assignments preceded by a JSDoc comment with a `@type` tag. |
+| Client side cross-site scripting | More results | This rule now also flags HTML injection in the body of an email. |
 
 ## Changes to QL libraries
 

--- a/javascript/ql/src/Security/CWE-079/Xss.ql
+++ b/javascript/ql/src/Security/CWE-079/Xss.ql
@@ -14,7 +14,7 @@
 import javascript
 import semmle.javascript.security.dataflow.DomBasedXss::DomBasedXss
 
-from Configuration xss, DataFlow::Node source, DataFlow::Node sink
+from Configuration xss, DataFlow::Node source, Sink sink
 where xss.hasFlow(source, sink)
-select sink, "Cross-site scripting vulnerability due to $@.",
+select sink, sink.getVulnerabilityKind() + " vulnerability due to $@.",
        source, "user-provided value"

--- a/javascript/ql/src/semmle/javascript/security/dataflow/DomBasedXss.qll
+++ b/javascript/ql/src/semmle/javascript/security/dataflow/DomBasedXss.qll
@@ -16,7 +16,17 @@ module DomBasedXss {
   /**
    * A data flow sink for XSS vulnerabilities.
    */
-  abstract class Sink extends DataFlow::Node { }
+  abstract class Sink extends DataFlow::Node {
+    /**
+     * Gets the kind of vulnerability to report in the alert message.
+     *
+     * Defaults to `Cross-site scripting`, but may be overriden for sinks
+     * that do not allow script injection, but injection of other undesirable HTML elements.
+     */
+    string getVulnerabilityKind() {
+      result = "Cross-site scripting"
+    }
+  }
 
   /**
    * A sanitizer for XSS vulnerabilities.
@@ -164,6 +174,18 @@ module DomBasedXss {
     }
   }
 
+  /**
+   * The HTML body of an email, viewed as an XSS sink.
+   */
+  class EmailHtmlBodySink extends Sink {
+    EmailHtmlBodySink() {
+      this = any(EmailSender sender).getHtmlBody()
+    }
+
+    override string getVulnerabilityKind() {
+      result = "HTML injection"
+    }
+  }
 }
 
 /** DEPRECATED: Use `DomBasedXss::Source` instead. */

--- a/javascript/ql/test/query-tests/Security/CWE-079/Xss.expected
+++ b/javascript/ql/test/query-tests/Security/CWE-079/Xss.expected
@@ -2,6 +2,7 @@
 | jquery.js:4:5:4:11 | tainted | Cross-site scripting vulnerability due to $@. | jquery.js:2:17:2:33 | document.location | user-provided value |
 | jquery.js:7:5:7:34 | "<div i ... + "\\">" | Cross-site scripting vulnerability due to $@. | jquery.js:2:17:2:33 | document.location | user-provided value |
 | jquery.js:8:18:8:34 | "XSS: " + tainted | Cross-site scripting vulnerability due to $@. | jquery.js:2:17:2:33 | document.location | user-provided value |
+| nodemailer.js:13:11:13:69 | `Hi, yo ... sage}.` | HTML injection vulnerability due to $@. | nodemailer.js:13:50:13:66 | req.query.message | user-provided value |
 | react-native.js:8:18:8:24 | tainted | Cross-site scripting vulnerability due to $@. | react-native.js:7:17:7:33 | req.param("code") | user-provided value |
 | react-native.js:9:27:9:33 | tainted | Cross-site scripting vulnerability due to $@. | react-native.js:7:17:7:33 | req.param("code") | user-provided value |
 | string-manipulations.js:3:16:3:32 | document.location | Cross-site scripting vulnerability due to $@. | string-manipulations.js:3:16:3:32 | document.location | user-provided value |

--- a/javascript/ql/test/query-tests/Security/CWE-079/nodemailer.js
+++ b/javascript/ql/test/query-tests/Security/CWE-079/nodemailer.js
@@ -1,0 +1,15 @@
+let nodemailer = require('nodemailer');
+let express = require('express');
+let app = express();
+let backend = require('./backend');
+
+app.post('/private_message', (req, res) => {
+  let transport = nodemailer.createTransport({});
+  transport.sendMail({
+    from: 'webmaster@example.com',
+    to: backend.getUserEmail(req.query.receiver),
+    subject: 'Private message',
+    text: `Hi, you got a message from someone. ${req.query.message}.`, // OK
+    html: `Hi, you got a message from someone. ${req.query.message}.`, // NOT OK
+  });
+});


### PR DESCRIPTION
As discussed in ODASA-7216, there is no great place for this kind of sink, but `Xss.ql` currently has the right set of sources and sanitizers, so I've put it there.