### PR TITLE
C++: Tests for two range analysis bugs

### DIFF
--- a/cpp/ql/test/query-tests/Likely Bugs/Arithmetic/PointlessComparison/PointlessComparison.c
+++ b/cpp/ql/test/query-tests/Likely Bugs/Arithmetic/PointlessComparison/PointlessComparison.c
@@ -241,3 +241,27 @@ void macroExpansionTest() {
   MAYBE_DO(x = 1); // GOOD (the problem is in the macro)
   MAYBE_DO(if (global_setting >= 0) {x = 2;}); // BAD (the problem is in the invocation)
 }
+
+int overeager_wraparound(unsigned int u32bound, unsigned long long u64bound) {
+  unsigned int u32idx;
+  unsigned long long u64idx;
+
+  for (u32idx = 1; u32idx < u32bound; u32idx++) {
+    if (u32idx == 0) // BAD [NOT DETECTED]
+      return 0;
+  }
+
+  for (u64idx = 1; u64idx < u64bound; u64idx++) {
+    if (u64idx == 0) // BAD [NOT DETECTED]
+      return 0;
+  }
+
+  return 1;
+}
+
+int negative_zero(double dbl) {
+  if (dbl >= 0) {
+    return dbl >= -dbl; // GOOD [FALSE POSITIVE]
+  }
+  return 0;
+}

--- a/cpp/ql/test/query-tests/Likely Bugs/Arithmetic/PointlessComparison/PointlessComparison.expected
+++ b/cpp/ql/test/query-tests/Likely Bugs/Arithmetic/PointlessComparison/PointlessComparison.expected
@@ -31,5 +31,6 @@
 | PointlessComparison.c:126:12:126:18 | ... >= ... | Comparison is always true because a >= 20. |
 | PointlessComparison.c:129:12:129:16 | ... > ... | Comparison is always false because a <= 3. |
 | PointlessComparison.c:197:7:197:11 | ... < ... | Comparison is always false because x >= 0. |
+| PointlessComparison.c:264:12:264:22 | ... >= ... | Comparison is always true because dbl >= 0 and -0 >= - .... |
 | RegressionTests.cpp:57:7:57:22 | ... <= ... | Comparison is always true because * ... <= 4294967295. |
 | Templates.cpp:9:10:9:24 | ... <= ... | Comparison is always true because local <= 32767. |


### PR DESCRIPTION
I had these tests lying around locally that demonstrate two shortcomings of the range analysis library.