### PR TITLE
C++: Improve performance of `ExprEvaluator::getFunctionValue`.

### DIFF
--- a/cpp/ql/src/semmle/code/cpp/controlflow/internal/ConstantExprs.qll
+++ b/cpp/ql/src/semmle/code/cpp/controlflow/internal/ConstantExprs.qll
@@ -419,12 +419,17 @@ library class ExprEvaluator extends int {
     )
   }
 
+  /** Holds if the function `f` is considered by the analysis and may return `ret`. */
+  pragma[noinline]
+  private predicate interestingReturnValue(Function f, Expr ret) {
+    interestingFunction(_, f) and
+    returnStmt(f, ret)
+  }
+
   private int getFunctionValue(Function f) {
-    interestingFunction(_, f)
-    and
     // All returns must have the same int value
     // And it must have at least one return
-    forex(Expr ret | returnStmt(f, ret) | result = getValueInternalNonSubExpr(ret))
+    forex(Expr ret | interestingReturnValue(f, ret) | result = getValueInternalNonSubExpr(ret))
   }
 
   /**


### PR DESCRIPTION
Changes the `forex` range to join on both `this` (the current `ExprEvaluator`) and `ret` (the expected function return value), so that we look at the relevant return values rather than all interesting functions.