### PR TITLE
C++: Restore `exists(getBlock())` in AV Rule 82

### DIFF
--- a/cpp/ql/src/jsf/4.10 Classes/AV Rule 82.ql
+++ b/cpp/ql/src/jsf/4.10 Classes/AV Rule 82.ql
@@ -83,6 +83,7 @@ predicate assignOperatorWithWrongType(Operator op, string msg) {
 predicate assignOperatorWithWrongResult(Operator op, string msg) {
   op.hasName("operator=")
   and not returnsDereferenceThis(op)
+  and exists(op.getBlock())
   and not op.getType() instanceof VoidType
   and not assignOperatorWithWrongType(op, _)
   and msg = "Assignment operator in class " + op.getDeclaringType().getName() + " does not return a reference to *this."

--- a/cpp/ql/test/query-tests/jsf/4.10 Classes/AV Rule 82/AV Rule 82.cpp
+++ b/cpp/ql/test/query-tests/jsf/4.10 Classes/AV Rule 82/AV Rule 82.cpp
@@ -171,6 +171,16 @@ class Reachability {
   static Reachability staticInstance;
 };
 
+class Forgivable {
+  // GOOD: wrong return type but that doesn't matter on a deleted function.
+  Forgivable operator=(const Forgivable &_val) = delete;
+
+private:
+  // GOOD: wrong return type but that doesn't matter because this operator is
+  // private and probably also unimplemented, so no code can call it.
+  Forgivable operator=(int *_val);
+};
+
 int main() {
   Container c;
   c = c;


### PR DESCRIPTION
I removed this condition in #362, thinking it was covered by the new conditions on return statements, but it turns out it wasn't in at least the following cases (that showed up in Query-Changes).

1. Assignment operators that are deleted or marked private in order to make them inaccessible.
2. Templates whose body was not extracted.

While some of these results are technically valid, they are not nearly as interesting as the results that this query was designed to produce.