### PR TITLE
Java: Don't construct nonsense SSA for unreachable code.

### DIFF
--- a/java/ql/src/semmle/code/java/dataflow/SSA.qll
+++ b/java/ql/src/semmle/code/java/dataflow/SSA.qll
@@ -225,7 +225,8 @@ private module SsaImpl {
   cached
   predicate certainVariableUpdate(TrackedVar v, ControlFlowNode n, BasicBlock b, int i) {
     exists(VariableUpdate a | a = n | getDestVar(a) = v) and
-    b.getNode(i) = n
+    b.getNode(i) = n and
+    hasDominanceInformation(b)
     or
     certainVariableUpdate(v.getQualifier(), n, b, i)
   }
@@ -559,7 +560,8 @@ private module SsaImpl {
   cached
   predicate uncertainVariableUpdate(TrackedVar v, ControlFlowNode n, BasicBlock b, int i) {
     exists(Call c | c = n | updatesNamedField(c, v, _)) and
-    b.getNode(i) = n
+    b.getNode(i) = n and
+    hasDominanceInformation(b)
     or
     uncertainVariableUpdate(v.getQualifier(), n, b, i)
   }

--- a/java/ql/src/semmle/code/java/dataflow/internal/BaseSSA.qll
+++ b/java/ql/src/semmle/code/java/dataflow/internal/BaseSSA.qll
@@ -72,7 +72,8 @@ private module SsaImpl {
   cached
   predicate variableUpdate(BaseSsaSourceVariable v, ControlFlowNode n, BasicBlock b, int i) {
     exists(VariableUpdate a | a = n | getDestVar(a) = v) and
-    b.getNode(i) = n
+    b.getNode(i) = n and
+    hasDominanceInformation(b)
   }
 
   /** Gets the definition point of a nested class in the parent scope. */


### PR DESCRIPTION
The SSA that was constructed on unreachable code didn't really make sense and failed all sorts of invariants. This could cause infinite looping in ModulusAnalysis in degenerate case, so it's better not to construct SSA for unreachable code at all.