### PR TITLE
JavaScript: Make lodash/underscore recognition extensible.

### DIFF
--- a/javascript/ql/src/semmle/javascript/frameworks/LodashUnderscore.qll
+++ b/javascript/ql/src/semmle/javascript/frameworks/LodashUnderscore.qll
@@ -6,17 +6,40 @@ import javascript
 /** Provides a unified model of [lodash](https://lodash.com/) and [underscore](http://underscorejs.org/). */
 module LodashUnderscore {
   /**
+   * A data flow node that accesses a given member of `lodash` or `underscore`.
+   */
+  abstract class Member extends DataFlow::SourceNode {
+    /** Gets the name of the accessed member. */
+    abstract string getName();
+  }
+
+  /**
+   * An import of `lodash` or `underscore` accessing a given member of that package.
+   */
+  private class DefaultMember extends Member {
+    string name;
+
+    DefaultMember() {
+      this = DataFlow::moduleMember("underscore", name) or
+      this = DataFlow::moduleMember("lodash", name) or
+      this = DataFlow::moduleImport("lodash/" + name) or
+      this = DataFlow::moduleImport("lodash." + name) or
+      this = DataFlow::globalVarRef("_").getAPropertyRead(name)
+    }
+
+    override string getName() {
+      result = name
+    }
+  }
+
+  /**
    * Gets a data flow node that accesses the given member of `lodash` or `underscore`.
    *
    * In addition to normal imports, this supports per-method imports such as `require("lodash.map")` and `require("lodash/map")`.
    * In addition, the global variable `_` is assumed to refer to `lodash` or `underscore`.
    */
   DataFlow::SourceNode member(string name) {
-    result = DataFlow::moduleMember("underscore", name) or
-    result = DataFlow::moduleMember("lodash", name) or
-    result = DataFlow::moduleImport("lodash/" + name) or
-    result = DataFlow::moduleImport("lodash." + name) or
-    result = DataFlow::globalVarRef("_").getAPropertyRead(name)
+    result.(Member).getName() = name
   }
 }
 

--- a/javascript/ql/src/semmle/javascript/heuristics/AdditionalFrameworks.qll
+++ b/javascript/ql/src/semmle/javascript/heuristics/AdditionalFrameworks.qll
@@ -1,0 +1,24 @@
+/**
+ * Provides classes that heuristically identify uses of common frameworks.
+ *
+ * Note: This module should not be a permanent part of the standard library imports.
+ */
+
+import javascript
+
+/**
+ * An import of a module whose name ends in `-lodash` or `-underscore`, interpreted
+ * as a likely import of the lodash or underscore library.
+ */
+private class ImpreciseLodashMember extends LodashUnderscore::Member {
+  string name;
+
+  ImpreciseLodashMember() {
+    exists (string lodash |
+      this = DataFlow::moduleMember(lodash, name) |
+      lodash.matches("%-lodash") or lodash.matches("%-underscore")
+    )
+  }
+
+  override string getName() { result = name }
+}

--- a/javascript/ql/src/semmle/javascript/heuristics/all.qll
+++ b/javascript/ql/src/semmle/javascript/heuristics/all.qll
@@ -6,6 +6,7 @@
  * Note: This module should not be a permanent part of the standard library imports.
  */
 
+import AdditionalFrameworks
 import AdditionalPromises
 import AdditionalRouteHandlers
 import AdditionalSources


### PR DESCRIPTION
Motivated by a customer where `lodash` was imported as `ext-lodash`.