### PR TITLE
C#: Improve `AccessorCall::getArgument()`

### DIFF
--- a/change-notes/1.19/analysis-csharp.md
+++ b/change-notes/1.19/analysis-csharp.md
@@ -3,7 +3,7 @@
 ## General improvements
 
 * Control flow graph improvements:
-* The control flow graph construction now takes simple Boolean conditions on local scope variables into account. For example, in `if (b) x = 0; if (b) x = 1;`, the control flow graph will reflect that taking the `true` (resp. `false`) branch in the first condition implies taking the same branch in the second condition. In effect, the first assignment to `x` will now be identified as being dead.
+  * The control flow graph construction now takes simple Boolean conditions on local scope variables into account. For example, in `if (b) x = 0; if (b) x = 1;`, the control flow graph will reflect that taking the `true` (resp. `false`) branch in the first condition implies taking the same branch in the second condition. In effect, the first assignment to `x` will now be identified as being dead.
   * Code that is only reachable from a constant failing assertion, such as `Debug.Assert(false)`, is considered to be unreachable.
 
 ## New queries
@@ -21,3 +21,5 @@
 
 
 ## Changes to QL libraries
+
+* `getArgument()` on `AccessorCall` has been improved so it now takes tuple assignments into account. For example, the argument for the implicit `value` parameter in the setter of property `P` is `0` in `(P, x) = (0, 1)`. Additionally, the argument for the `value` parameter in compound assignments is now only the expanded value, for example, in `P += 7` the argument is `P + 7` and not `7`.

--- a/csharp/ql/src/semmle/code/csharp/exprs/Call.qll
+++ b/csharp/ql/src/semmle/code/csharp/exprs/Call.qll
@@ -643,8 +643,7 @@ class PropertyCall extends AccessorCall, PropertyAccessExpr {
 
   override Expr getArgument(int i) {
     i = 0 and
-    this instanceof AssignableWrite and
-    exists(Assignment a | a.getLValue() = this and result = a.getRValue())
+    result = AssignableInternal::getAccessorCallValueArgument(this)
   }
 
   override string toString() {
@@ -681,9 +680,8 @@ class IndexerCall extends AccessorCall, IndexerAccessExpr {
   override Expr getArgument(int i) {
     result = this.(ElementAccess).getIndex(i)
     or
-    this instanceof AssignableWrite and
     i = count(this.(ElementAccess).getAnIndex()) and
-    exists(Assignment a | a.getLValue() = this and result = a.getRValue())
+    result = AssignableInternal::getAccessorCallValueArgument(this)
   }
 
   override string toString() { result = IndexerAccessExpr.super.toString() }

--- a/csharp/ql/src/semmle/code/csharp/frameworks/system/Xml.qll
+++ b/csharp/ql/src/semmle/code/csharp/frameworks/system/Xml.qll
@@ -138,6 +138,10 @@ class SystemXmlSchemaXmlSchemaValidationFlags extends EnumConstant {
   }
 }
 
+private Expr getBitwiseOrOperand(Expr e) {
+  result = e.(BitwiseOrExpr).getAnOperand()
+}
+
 /** A creation of an instance of `System.Xml.XmlReaderSettings`. */
 class XmlReaderSettingsCreation extends ObjectCreation {
   XmlReaderSettingsCreation() {
@@ -157,10 +161,11 @@ class XmlReaderSettingsCreation extends ObjectCreation {
   /** Gets a value set for the given property in this local context. */
   private Expr getPropertyValue(Property p) {
     p = this.getType().(RefType).getAProperty() and
-    exists(PropertyCall set |
+    exists(PropertyCall set, Expr arg |
       set.getTarget() = p.getSetter() and
       DataFlow::localFlow(DataFlow::exprNode(this), DataFlow::exprNode(set.getQualifier())) and
-      result = set.getAnArgument()
+      arg = set.getAnArgument() and
+      result = getBitwiseOrOperand*(arg)
     )
   }
 }

--- a/csharp/ql/test/library-tests/arguments/argumentByName.expected
+++ b/csharp/ql/test/library-tests/arguments/argumentByName.expected
@@ -17,3 +17,21 @@
 | arguments.cs:39:9:39:28 | call to method f3 | arguments.cs:39:27:39:27 | 0 | o |
 | arguments.cs:40:9:40:42 | call to method f3 | arguments.cs:40:18:40:35 | array creation of type Int32[] | args |
 | arguments.cs:40:9:40:42 | call to method f3 | arguments.cs:40:41:40:41 | 0 | o |
+| arguments.cs:54:9:54:12 | access to property Prop | arguments.cs:54:16:54:16 | 0 | value |
+| arguments.cs:55:9:55:12 | access to property Prop | arguments.cs:55:16:55:25 | access to indexer | value |
+| arguments.cs:55:16:55:25 | access to indexer | arguments.cs:55:21:55:21 | 1 | a |
+| arguments.cs:55:16:55:25 | access to indexer | arguments.cs:55:24:55:24 | 2 | b |
+| arguments.cs:56:16:56:25 | access to indexer | arguments.cs:56:21:56:21 | 3 | a |
+| arguments.cs:56:16:56:25 | access to indexer | arguments.cs:56:24:56:24 | 4 | b |
+| arguments.cs:58:9:58:12 | access to property Prop | arguments.cs:58:9:58:17 | ... + ... | value |
+| arguments.cs:58:9:58:12 | access to property Prop | arguments.cs:58:17:58:17 | 7 | value |
+| arguments.cs:59:9:59:18 | access to indexer | arguments.cs:59:14:59:14 | 8 | a |
+| arguments.cs:59:9:59:18 | access to indexer | arguments.cs:59:17:59:17 | 9 | b |
+| arguments.cs:60:9:60:20 | access to indexer | arguments.cs:60:9:60:26 | ... + ... | value |
+| arguments.cs:60:9:60:20 | access to indexer | arguments.cs:60:14:60:15 | 10 | a |
+| arguments.cs:60:9:60:20 | access to indexer | arguments.cs:60:14:60:15 | 10 | a |
+| arguments.cs:60:9:60:20 | access to indexer | arguments.cs:60:18:60:19 | 11 | b |
+| arguments.cs:60:9:60:20 | access to indexer | arguments.cs:60:18:60:19 | 11 | b |
+| arguments.cs:60:9:60:20 | access to indexer | arguments.cs:60:25:60:26 | 12 | value |
+| arguments.cs:62:16:62:27 | access to indexer | arguments.cs:62:21:62:22 | 15 | a |
+| arguments.cs:62:16:62:27 | access to indexer | arguments.cs:62:25:62:26 | 16 | b |

--- a/csharp/ql/test/library-tests/arguments/argumentByName.expected
+++ b/csharp/ql/test/library-tests/arguments/argumentByName.expected
@@ -21,10 +21,11 @@
 | arguments.cs:55:9:55:12 | access to property Prop | arguments.cs:55:16:55:25 | access to indexer | value |
 | arguments.cs:55:16:55:25 | access to indexer | arguments.cs:55:21:55:21 | 1 | a |
 | arguments.cs:55:16:55:25 | access to indexer | arguments.cs:55:24:55:24 | 2 | b |
+| arguments.cs:56:10:56:13 | access to property Prop | arguments.cs:56:31:56:31 | 5 | value |
 | arguments.cs:56:16:56:25 | access to indexer | arguments.cs:56:21:56:21 | 3 | a |
 | arguments.cs:56:16:56:25 | access to indexer | arguments.cs:56:24:56:24 | 4 | b |
+| arguments.cs:56:16:56:25 | access to indexer | arguments.cs:56:34:56:34 | 6 | value |
 | arguments.cs:58:9:58:12 | access to property Prop | arguments.cs:58:9:58:17 | ... + ... | value |
-| arguments.cs:58:9:58:12 | access to property Prop | arguments.cs:58:17:58:17 | 7 | value |
 | arguments.cs:59:9:59:18 | access to indexer | arguments.cs:59:14:59:14 | 8 | a |
 | arguments.cs:59:9:59:18 | access to indexer | arguments.cs:59:17:59:17 | 9 | b |
 | arguments.cs:60:9:60:20 | access to indexer | arguments.cs:60:9:60:26 | ... + ... | value |
@@ -32,6 +33,5 @@
 | arguments.cs:60:9:60:20 | access to indexer | arguments.cs:60:14:60:15 | 10 | a |
 | arguments.cs:60:9:60:20 | access to indexer | arguments.cs:60:18:60:19 | 11 | b |
 | arguments.cs:60:9:60:20 | access to indexer | arguments.cs:60:18:60:19 | 11 | b |
-| arguments.cs:60:9:60:20 | access to indexer | arguments.cs:60:25:60:26 | 12 | value |
 | arguments.cs:62:16:62:27 | access to indexer | arguments.cs:62:21:62:22 | 15 | a |
 | arguments.cs:62:16:62:27 | access to indexer | arguments.cs:62:25:62:26 | 16 | b |

--- a/csharp/ql/test/library-tests/arguments/argumentByParameter.expected
+++ b/csharp/ql/test/library-tests/arguments/argumentByParameter.expected
@@ -21,10 +21,11 @@
 | arguments.cs:55:9:55:12 | access to property Prop | arguments.cs:55:16:55:25 | access to indexer | arguments.cs:48:21:48:23 | value |
 | arguments.cs:55:16:55:25 | access to indexer | arguments.cs:55:21:55:21 | 1 | arguments.cs:50:18:50:18 | a |
 | arguments.cs:55:16:55:25 | access to indexer | arguments.cs:55:24:55:24 | 2 | arguments.cs:50:25:50:25 | b |
+| arguments.cs:56:10:56:13 | access to property Prop | arguments.cs:56:31:56:31 | 5 | arguments.cs:48:21:48:23 | value |
 | arguments.cs:56:16:56:25 | access to indexer | arguments.cs:56:21:56:21 | 3 | arguments.cs:50:18:50:18 | a |
 | arguments.cs:56:16:56:25 | access to indexer | arguments.cs:56:24:56:24 | 4 | arguments.cs:50:25:50:25 | b |
+| arguments.cs:56:16:56:25 | access to indexer | arguments.cs:56:34:56:34 | 6 | arguments.cs:50:44:50:46 | value |
 | arguments.cs:58:9:58:12 | access to property Prop | arguments.cs:58:9:58:17 | ... + ... | arguments.cs:48:21:48:23 | value |
-| arguments.cs:58:9:58:12 | access to property Prop | arguments.cs:58:17:58:17 | 7 | arguments.cs:48:21:48:23 | value |
 | arguments.cs:59:9:59:18 | access to indexer | arguments.cs:59:14:59:14 | 8 | arguments.cs:50:18:50:18 | a |
 | arguments.cs:59:9:59:18 | access to indexer | arguments.cs:59:14:59:14 | 8 | arguments.cs:50:18:50:18 | a |
 | arguments.cs:59:9:59:18 | access to indexer | arguments.cs:59:17:59:17 | 9 | arguments.cs:50:25:50:25 | b |
@@ -34,6 +35,5 @@
 | arguments.cs:60:9:60:20 | access to indexer | arguments.cs:60:14:60:15 | 10 | arguments.cs:50:18:50:18 | a |
 | arguments.cs:60:9:60:20 | access to indexer | arguments.cs:60:18:60:19 | 11 | arguments.cs:50:25:50:25 | b |
 | arguments.cs:60:9:60:20 | access to indexer | arguments.cs:60:18:60:19 | 11 | arguments.cs:50:25:50:25 | b |
-| arguments.cs:60:9:60:20 | access to indexer | arguments.cs:60:25:60:26 | 12 | arguments.cs:50:44:50:46 | value |
 | arguments.cs:62:16:62:27 | access to indexer | arguments.cs:62:21:62:22 | 15 | arguments.cs:50:18:50:18 | a |
 | arguments.cs:62:16:62:27 | access to indexer | arguments.cs:62:25:62:26 | 16 | arguments.cs:50:25:50:25 | b |

--- a/csharp/ql/test/library-tests/arguments/argumentByParameter.expected
+++ b/csharp/ql/test/library-tests/arguments/argumentByParameter.expected
@@ -17,3 +17,23 @@
 | arguments.cs:39:9:39:28 | call to method f3 | arguments.cs:39:27:39:27 | 0 | arguments.cs:33:17:33:17 | o |
 | arguments.cs:40:9:40:42 | call to method f3 | arguments.cs:40:18:40:35 | array creation of type Int32[] | arguments.cs:33:33:33:36 | args |
 | arguments.cs:40:9:40:42 | call to method f3 | arguments.cs:40:41:40:41 | 0 | arguments.cs:33:17:33:17 | o |
+| arguments.cs:54:9:54:12 | access to property Prop | arguments.cs:54:16:54:16 | 0 | arguments.cs:48:21:48:23 | value |
+| arguments.cs:55:9:55:12 | access to property Prop | arguments.cs:55:16:55:25 | access to indexer | arguments.cs:48:21:48:23 | value |
+| arguments.cs:55:16:55:25 | access to indexer | arguments.cs:55:21:55:21 | 1 | arguments.cs:50:18:50:18 | a |
+| arguments.cs:55:16:55:25 | access to indexer | arguments.cs:55:24:55:24 | 2 | arguments.cs:50:25:50:25 | b |
+| arguments.cs:56:16:56:25 | access to indexer | arguments.cs:56:21:56:21 | 3 | arguments.cs:50:18:50:18 | a |
+| arguments.cs:56:16:56:25 | access to indexer | arguments.cs:56:24:56:24 | 4 | arguments.cs:50:25:50:25 | b |
+| arguments.cs:58:9:58:12 | access to property Prop | arguments.cs:58:9:58:17 | ... + ... | arguments.cs:48:21:48:23 | value |
+| arguments.cs:58:9:58:12 | access to property Prop | arguments.cs:58:17:58:17 | 7 | arguments.cs:48:21:48:23 | value |
+| arguments.cs:59:9:59:18 | access to indexer | arguments.cs:59:14:59:14 | 8 | arguments.cs:50:18:50:18 | a |
+| arguments.cs:59:9:59:18 | access to indexer | arguments.cs:59:14:59:14 | 8 | arguments.cs:50:18:50:18 | a |
+| arguments.cs:59:9:59:18 | access to indexer | arguments.cs:59:17:59:17 | 9 | arguments.cs:50:25:50:25 | b |
+| arguments.cs:59:9:59:18 | access to indexer | arguments.cs:59:17:59:17 | 9 | arguments.cs:50:25:50:25 | b |
+| arguments.cs:60:9:60:20 | access to indexer | arguments.cs:60:9:60:26 | ... + ... | arguments.cs:50:44:50:46 | value |
+| arguments.cs:60:9:60:20 | access to indexer | arguments.cs:60:14:60:15 | 10 | arguments.cs:50:18:50:18 | a |
+| arguments.cs:60:9:60:20 | access to indexer | arguments.cs:60:14:60:15 | 10 | arguments.cs:50:18:50:18 | a |
+| arguments.cs:60:9:60:20 | access to indexer | arguments.cs:60:18:60:19 | 11 | arguments.cs:50:25:50:25 | b |
+| arguments.cs:60:9:60:20 | access to indexer | arguments.cs:60:18:60:19 | 11 | arguments.cs:50:25:50:25 | b |
+| arguments.cs:60:9:60:20 | access to indexer | arguments.cs:60:25:60:26 | 12 | arguments.cs:50:44:50:46 | value |
+| arguments.cs:62:16:62:27 | access to indexer | arguments.cs:62:21:62:22 | 15 | arguments.cs:50:18:50:18 | a |
+| arguments.cs:62:16:62:27 | access to indexer | arguments.cs:62:25:62:26 | 16 | arguments.cs:50:25:50:25 | b |

--- a/csharp/ql/test/library-tests/arguments/arguments.cs
+++ b/csharp/ql/test/library-tests/arguments/arguments.cs
@@ -44,4 +44,21 @@ class ArgumentsTest
     {
         f4(new object[] { null }, null);
     }
+
+    int Prop { get; set; }
+
+    int this[int a, int b] { get => a + b; set { } }
+
+    void f5()
+    {
+        Prop = 0;
+        Prop = this[1, 2];
+        (Prop, this[3, 4]) = (5, 6);
+        Prop++;
+        Prop += 7;
+        this[8, 9]++;
+        this[10, 11] += 12;
+        var tuple = (13, 14);
+        (Prop, this[15, 16]) = tuple;
+    }
 }

--- a/csharp/ql/test/library-tests/arguments/parameterGetArguments.expected
+++ b/csharp/ql/test/library-tests/arguments/parameterGetArguments.expected
@@ -19,8 +19,8 @@
 | arguments.cs:33:33:33:36 | args | arguments.cs:40:18:40:35 | array creation of type Int32[] |
 | arguments.cs:48:21:48:23 | value | arguments.cs:54:16:54:16 | 0 |
 | arguments.cs:48:21:48:23 | value | arguments.cs:55:16:55:25 | access to indexer |
+| arguments.cs:48:21:48:23 | value | arguments.cs:56:31:56:31 | 5 |
 | arguments.cs:48:21:48:23 | value | arguments.cs:58:9:58:17 | ... + ... |
-| arguments.cs:48:21:48:23 | value | arguments.cs:58:17:58:17 | 7 |
 | arguments.cs:50:18:50:18 | a | arguments.cs:55:21:55:21 | 1 |
 | arguments.cs:50:18:50:18 | a | arguments.cs:56:21:56:21 | 3 |
 | arguments.cs:50:18:50:18 | a | arguments.cs:59:14:59:14 | 8 |
@@ -35,5 +35,5 @@
 | arguments.cs:50:25:50:25 | b | arguments.cs:60:18:60:19 | 11 |
 | arguments.cs:50:25:50:25 | b | arguments.cs:60:18:60:19 | 11 |
 | arguments.cs:50:25:50:25 | b | arguments.cs:62:25:62:26 | 16 |
+| arguments.cs:50:44:50:46 | value | arguments.cs:56:34:56:34 | 6 |
 | arguments.cs:50:44:50:46 | value | arguments.cs:60:9:60:26 | ... + ... |
-| arguments.cs:50:44:50:46 | value | arguments.cs:60:25:60:26 | 12 |

--- a/csharp/ql/test/library-tests/arguments/parameterGetArguments.expected
+++ b/csharp/ql/test/library-tests/arguments/parameterGetArguments.expected
@@ -17,3 +17,23 @@
 | arguments.cs:33:33:33:36 | args | arguments.cs:38:15:38:18 | access to parameter args |
 | arguments.cs:33:33:33:36 | args | arguments.cs:39:18:39:21 | access to parameter args |
 | arguments.cs:33:33:33:36 | args | arguments.cs:40:18:40:35 | array creation of type Int32[] |
+| arguments.cs:48:21:48:23 | value | arguments.cs:54:16:54:16 | 0 |
+| arguments.cs:48:21:48:23 | value | arguments.cs:55:16:55:25 | access to indexer |
+| arguments.cs:48:21:48:23 | value | arguments.cs:58:9:58:17 | ... + ... |
+| arguments.cs:48:21:48:23 | value | arguments.cs:58:17:58:17 | 7 |
+| arguments.cs:50:18:50:18 | a | arguments.cs:55:21:55:21 | 1 |
+| arguments.cs:50:18:50:18 | a | arguments.cs:56:21:56:21 | 3 |
+| arguments.cs:50:18:50:18 | a | arguments.cs:59:14:59:14 | 8 |
+| arguments.cs:50:18:50:18 | a | arguments.cs:59:14:59:14 | 8 |
+| arguments.cs:50:18:50:18 | a | arguments.cs:60:14:60:15 | 10 |
+| arguments.cs:50:18:50:18 | a | arguments.cs:60:14:60:15 | 10 |
+| arguments.cs:50:18:50:18 | a | arguments.cs:62:21:62:22 | 15 |
+| arguments.cs:50:25:50:25 | b | arguments.cs:55:24:55:24 | 2 |
+| arguments.cs:50:25:50:25 | b | arguments.cs:56:24:56:24 | 4 |
+| arguments.cs:50:25:50:25 | b | arguments.cs:59:17:59:17 | 9 |
+| arguments.cs:50:25:50:25 | b | arguments.cs:59:17:59:17 | 9 |
+| arguments.cs:50:25:50:25 | b | arguments.cs:60:18:60:19 | 11 |
+| arguments.cs:50:25:50:25 | b | arguments.cs:60:18:60:19 | 11 |
+| arguments.cs:50:25:50:25 | b | arguments.cs:62:25:62:26 | 16 |
+| arguments.cs:50:44:50:46 | value | arguments.cs:60:9:60:26 | ... + ... |
+| arguments.cs:50:44:50:46 | value | arguments.cs:60:25:60:26 | 12 |


### PR DESCRIPTION
My attention was drawn to this predicate because of an unexpected recursive dependency:
```
Evaluating SCC with predicates:
                      Assignable::AssignableDefinitionImpl::TOutRefDefinition#ff
                      Assignable::AssignableDefinitionImpl::getAnAnalyzableRefDef#ffff
                      Assignable::AssignableDefinitionImpl::getArgumentForParameter#bfb#reorder_0_2_1
                      Assignable::AssignableDefinitionImpl::getExplicitArgument#fff#reorder_0_2_1
                      Assignable::AssignableDefinitionImpl::getRefCallTarget#ffff
                      Assignable::AssignableDefinitionImpl::getTarget#ff#reorder_1_0
                      Assignable::AssignableDefinitionImpl::getTargetAccess#ff
                      Assignable::AssignableDefinitionImpl::isAnalyzableRefCall#fff#reorder_2_0_1
                      Assignable::AssignableDefinitionImpl::isNonAnalyzableRefCall#fff
                      Assignable::AssignableDefinitionImpl::isRelevantRefCall#ff
                      Assignable::AssignableWrite#b
                      Call::AccessorCall::getArgument_dispred#fff
                      Call::Call::getArgument_dispred#fff
                      Call::Call::getArgument_dispred#fff#reorder_2_0_1
                      branch#TOutRefDefinition#ff
                      dom#Assignable::AssignableDefinitionImpl::TOutRefDefinition#f
                      num#branch#TOutRefDefinition#fff
                      num#dom#Assignable::AssignableDefinitionImpl::TOutRefDefinition#ff
```
In addition to breaking the recursive dependency, I also made fixes for tuple assignments and compound assignments (e.g. `+=`).

@calumgrant 