### PR TITLE
JS: recognize sanitizing slashes in URL redirection queries

### DIFF
--- a/change-notes/1.19/analysis-javascript.md
+++ b/change-notes/1.19/analysis-javascript.md
@@ -49,6 +49,8 @@
 | Unused variable, import, function or class | Fewer results | This rule now flags import statements with multiple unused imports once. |
 | Useless assignment to local variable | Fewer false-positive results | This rule now recognizes additional ways default values can be set. |
 | Whitespace contradicts operator precedence | Fewer false-positive results | This rule no longer flags operators with asymmetric whitespace. |
+| Client-side URL redirect | Fewer false-positive results | This rule now recognizes safe redirects in more cases. |
+| Server-side URL redirect | Fewer false-positive results | This rule now recognizes safe redirects in more cases. |
 
 ## Changes to QL libraries
 

--- a/javascript/ql/src/semmle/javascript/security/dataflow/ClientSideUrlRedirect.qll
+++ b/javascript/ql/src/semmle/javascript/security/dataflow/ClientSideUrlRedirect.qll
@@ -58,7 +58,7 @@ module ClientSideUrlRedirect {
     }
 
     override predicate isSanitizer(DataFlow::Node source, DataFlow::Node sink) {
-      sanitizingPrefixEdge(source, sink)
+      hostnameSanitizingPrefixEdge(source, sink)
     }
 
     override predicate isAdditionalFlowStep(DataFlow::Node pred, DataFlow::Node succ, DataFlow::FlowLabel f, DataFlow::FlowLabel g) {

--- a/javascript/ql/src/semmle/javascript/security/dataflow/ServerSideUrlRedirect.qll
+++ b/javascript/ql/src/semmle/javascript/security/dataflow/ServerSideUrlRedirect.qll
@@ -43,7 +43,7 @@ module ServerSideUrlRedirect {
     }
 
     override predicate isSanitizer(DataFlow::Node source, DataFlow::Node sink) {
-      sanitizingPrefixEdge(source, sink)
+      hostnameSanitizingPrefixEdge(source, sink)
     }
 
     override predicate isSanitizerGuard(TaintTracking::SanitizerGuardNode guard) {

--- a/javascript/ql/src/semmle/javascript/security/dataflow/UrlConcatenation.qll
+++ b/javascript/ql/src/semmle/javascript/security/dataflow/UrlConcatenation.qll
@@ -65,5 +65,5 @@ private predicate hasHostnameSanitizingSubstring(DataFlow::Node nd) {
 predicate hostnameSanitizingPrefixEdge(DataFlow::Node source, DataFlow::Node sink) {
   exists (DataFlow::Node operator, int n |
     StringConcatenation::taintStep(source, sink, operator, n) and
-    hasSanitizingSubstring(StringConcatenation::getOperand(operator, [0..n-1])))
+    hasHostnameSanitizingSubstring(StringConcatenation::getOperand(operator, [0..n-1])))
 }

--- a/javascript/ql/src/semmle/javascript/security/dataflow/UrlConcatenation.qll
+++ b/javascript/ql/src/semmle/javascript/security/dataflow/UrlConcatenation.qll
@@ -8,18 +8,12 @@ import javascript
 
 /**
  * Holds if the string value of `nd` prevents anything appended after it
- * from affecting the hostname of a URL.
+ * from affecting the hostname or path of a URL.
  *
- * Specifically, this holds if the string contains any of the following:
- * - `?` (any suffix becomes part of query)
- * - `#` (any suffix becomes part of fragment)
- * - `/` or `\`, immediately prefixed by a character other than `:`, `/`, or `\` (any suffix becomes part of the path)
- *
- * In the latter case, the additional prefix check is necessary to avoid a `/` that could be interpreted as
- * the `//` separating the (optional) scheme from the hostname.
+ * Specifically, this holds if the string contains `?` or `#`.
  */
-predicate hasSanitizingSubstring(DataFlow::Node nd) {
-  nd.asExpr().getStringValue().regexpMatch(".*([?#]|[^?#:/\\\\][/\\\\]).*") 
+private predicate hasSanitizingSubstring(DataFlow::Node nd) {
+  nd.asExpr().getStringValue().regexpMatch(".*[?#].*")
   or
   hasSanitizingSubstring(StringConcatenation::getAnOperand(nd))
   or
@@ -30,11 +24,45 @@ predicate hasSanitizingSubstring(DataFlow::Node nd) {
 
 /**
  * Holds if data that flows from `source` to `sink` cannot affect the
- * hostname of the resulting string when interpreted as a URL.
+ * path or earlier part of the resulting string when interpreted as a URL.
  *
  * This is considered as a sanitizing edge for the URL redirection queries.
  */
 predicate sanitizingPrefixEdge(DataFlow::Node source, DataFlow::Node sink) {
+  exists (DataFlow::Node operator, int n |
+    StringConcatenation::taintStep(source, sink, operator, n) and
+    hasSanitizingSubstring(StringConcatenation::getOperand(operator, [0..n-1])))
+}
+
+/**
+ * Holds if the string value of `nd` prevents anything appended after it
+ * from affecting the hostname of a URL.
+ *
+ * Specifically, this holds if the string contains any of the following:
+ * - `?` (any suffix becomes part of query)
+ * - `#` (any suffix becomes part of fragment)
+ * - `/` or `\`, immediately prefixed by a character other than `:`, `/`, or `\` (any suffix becomes part of the path)
+ *
+ * In the latter case, the additional prefix check is necessary to avoid a `/` that could be interpreted as
+ * the `//` separating the (optional) scheme from the hostname.
+ */
+private predicate hasHostnameSanitizingSubstring(DataFlow::Node nd) {
+  nd.asExpr().getStringValue().regexpMatch(".*([?#]|[^?#:/\\\\][/\\\\]).*") 
+  or
+  hasHostnameSanitizingSubstring(StringConcatenation::getAnOperand(nd))
+  or
+  hasHostnameSanitizingSubstring(nd.getAPredecessor())
+  or
+  nd.isIncomplete(_)
+}
+
+/**
+ * Holds if data that flows from `source` to `sink` cannot affect the
+ * hostname or scheme of the resulting string when interpreted as a URL.
+ *
+ * This is considered as a sanitizing edge for the URL redirection queries.
+ */
+predicate hostnameSanitizingPrefixEdge(DataFlow::Node source, DataFlow::Node sink) {
   exists (DataFlow::Node operator, int n |
     StringConcatenation::taintStep(source, sink, operator, n) and
     hasSanitizingSubstring(StringConcatenation::getOperand(operator, [0..n-1])))

--- a/javascript/ql/test/query-tests/Security/CWE-601/ServerSideUrlRedirect/ServerSideUrlRedirect.expected
+++ b/javascript/ql/test/query-tests/Security/CWE-601/ServerSideUrlRedirect/ServerSideUrlRedirect.expected
@@ -7,14 +7,6 @@ nodes
 | express.js:35:16:35:21 | target |
 | express.js:40:16:40:108 | (req.pa ... ntacts" |
 | express.js:40:69:40:87 | req.param('action') |
-| express.js:44:7:44:28 | handle |
-| express.js:44:16:44:28 | req.params[0] |
-| express.js:45:7:45:33 | url |
-| express.js:45:13:45:27 | "/Me/" + handle |
-| express.js:45:13:45:33 | "/Me/"  ... e + "/" |
-| express.js:45:22:45:27 | handle |
-| express.js:49:3:49:3 | url |
-| express.js:49:26:49:28 | url |
 | express.js:74:16:74:43 | `${req. ... )}/foo` |
 | express.js:74:19:74:37 | req.param("target") |
 | express.js:83:7:83:34 | target |
@@ -24,6 +16,18 @@ nodes
 | express.js:118:16:118:63 | [req.qu ... ection] |
 | express.js:118:16:118:72 | [req.qu ... oin('') |
 | express.js:118:17:118:30 | req.query.page |
+| express.js:134:16:134:36 | '/' + r ... ms.user |
+| express.js:134:22:134:36 | req.params.user |
+| express.js:135:16:135:37 | '//' +  ... ms.user |
+| express.js:135:23:135:37 | req.params.user |
+| express.js:136:16:136:36 | 'u' + r ... ms.user |
+| express.js:136:22:136:36 | req.params.user |
+| express.js:138:16:138:45 | '/' + ( ... s.user) |
+| express.js:138:22:138:45 | ('/u' + ... s.user) |
+| express.js:138:23:138:44 | '/u' +  ... ms.user |
+| express.js:138:30:138:44 | req.params.user |
+| express.js:139:16:139:37 | '/u' +  ... ms.user |
+| express.js:139:23:139:37 | req.params.user |
 | node.js:6:7:6:52 | target |
 | node.js:6:16:6:39 | url.par ... , true) |
 | node.js:6:16:6:45 | url.par ... ).query |
@@ -54,19 +58,19 @@ edges
 | express.js:27:7:27:34 | target | express.js:35:16:35:21 | target |
 | express.js:27:16:27:34 | req.param("target") | express.js:27:7:27:34 | target |
 | express.js:40:69:40:87 | req.param('action') | express.js:40:16:40:108 | (req.pa ... ntacts" |
-| express.js:44:7:44:28 | handle | express.js:45:22:45:27 | handle |
-| express.js:44:16:44:28 | req.params[0] | express.js:44:7:44:28 | handle |
-| express.js:45:7:45:33 | url | express.js:49:3:49:3 | url |
-| express.js:45:13:45:27 | "/Me/" + handle | express.js:45:13:45:33 | "/Me/"  ... e + "/" |
-| express.js:45:13:45:33 | "/Me/"  ... e + "/" | express.js:45:7:45:33 | url |
-| express.js:45:22:45:27 | handle | express.js:45:13:45:27 | "/Me/" + handle |
-| express.js:49:3:49:3 | url | express.js:49:26:49:28 | url |
 | express.js:74:19:74:37 | req.param("target") | express.js:74:16:74:43 | `${req. ... )}/foo` |
 | express.js:83:7:83:34 | target | express.js:90:18:90:23 | target |
 | express.js:83:7:83:34 | target | express.js:97:16:97:21 | target |
 | express.js:83:16:83:34 | req.param("target") | express.js:83:7:83:34 | target |
 | express.js:118:16:118:63 | [req.qu ... ection] | express.js:118:16:118:72 | [req.qu ... oin('') |
 | express.js:118:17:118:30 | req.query.page | express.js:118:16:118:63 | [req.qu ... ection] |
+| express.js:134:22:134:36 | req.params.user | express.js:134:16:134:36 | '/' + r ... ms.user |
+| express.js:135:23:135:37 | req.params.user | express.js:135:16:135:37 | '//' +  ... ms.user |
+| express.js:136:22:136:36 | req.params.user | express.js:136:16:136:36 | 'u' + r ... ms.user |
+| express.js:138:22:138:45 | ('/u' + ... s.user) | express.js:138:16:138:45 | '/' + ( ... s.user) |
+| express.js:138:23:138:44 | '/u' +  ... ms.user | express.js:138:22:138:45 | ('/u' + ... s.user) |
+| express.js:138:30:138:44 | req.params.user | express.js:138:23:138:44 | '/u' +  ... ms.user |
+| express.js:139:23:139:37 | req.params.user | express.js:139:16:139:37 | '/u' +  ... ms.user |
 | node.js:6:7:6:52 | target | node.js:7:34:7:39 | target |
 | node.js:6:16:6:39 | url.par ... , true) | node.js:6:16:6:45 | url.par ... ).query |
 | node.js:6:16:6:45 | url.par ... ).query | node.js:6:16:6:52 | url.par ... .target |
@@ -94,11 +98,15 @@ edges
 | express.js:33:18:33:23 | target | express.js:27:16:27:34 | req.param("target") | express.js:33:18:33:23 | target | Untrusted URL redirection due to $@. | express.js:27:16:27:34 | req.param("target") | user-provided value |
 | express.js:35:16:35:21 | target | express.js:27:16:27:34 | req.param("target") | express.js:35:16:35:21 | target | Untrusted URL redirection due to $@. | express.js:27:16:27:34 | req.param("target") | user-provided value |
 | express.js:40:16:40:108 | (req.pa ... ntacts" | express.js:40:69:40:87 | req.param('action') | express.js:40:16:40:108 | (req.pa ... ntacts" | Untrusted URL redirection due to $@. | express.js:40:69:40:87 | req.param('action') | user-provided value |
-| express.js:49:26:49:28 | url | express.js:44:16:44:28 | req.params[0] | express.js:49:26:49:28 | url | Untrusted URL redirection due to $@. | express.js:44:16:44:28 | req.params[0] | user-provided value |
 | express.js:74:16:74:43 | `${req. ... )}/foo` | express.js:74:19:74:37 | req.param("target") | express.js:74:16:74:43 | `${req. ... )}/foo` | Untrusted URL redirection due to $@. | express.js:74:19:74:37 | req.param("target") | user-provided value |
 | express.js:90:18:90:23 | target | express.js:83:16:83:34 | req.param("target") | express.js:90:18:90:23 | target | Untrusted URL redirection due to $@. | express.js:83:16:83:34 | req.param("target") | user-provided value |
 | express.js:97:16:97:21 | target | express.js:83:16:83:34 | req.param("target") | express.js:97:16:97:21 | target | Untrusted URL redirection due to $@. | express.js:83:16:83:34 | req.param("target") | user-provided value |
 | express.js:118:16:118:72 | [req.qu ... oin('') | express.js:118:17:118:30 | req.query.page | express.js:118:16:118:72 | [req.qu ... oin('') | Untrusted URL redirection due to $@. | express.js:118:17:118:30 | req.query.page | user-provided value |
+| express.js:134:16:134:36 | '/' + r ... ms.user | express.js:134:22:134:36 | req.params.user | express.js:134:16:134:36 | '/' + r ... ms.user | Untrusted URL redirection due to $@. | express.js:134:22:134:36 | req.params.user | user-provided value |
+| express.js:135:16:135:37 | '//' +  ... ms.user | express.js:135:23:135:37 | req.params.user | express.js:135:16:135:37 | '//' +  ... ms.user | Untrusted URL redirection due to $@. | express.js:135:23:135:37 | req.params.user | user-provided value |
+| express.js:136:16:136:36 | 'u' + r ... ms.user | express.js:136:22:136:36 | req.params.user | express.js:136:16:136:36 | 'u' + r ... ms.user | Untrusted URL redirection due to $@. | express.js:136:22:136:36 | req.params.user | user-provided value |
+| express.js:138:16:138:45 | '/' + ( ... s.user) | express.js:138:30:138:44 | req.params.user | express.js:138:16:138:45 | '/' + ( ... s.user) | Untrusted URL redirection due to $@. | express.js:138:30:138:44 | req.params.user | user-provided value |
+| express.js:139:16:139:37 | '/u' +  ... ms.user | express.js:139:23:139:37 | req.params.user | express.js:139:16:139:37 | '/u' +  ... ms.user | Untrusted URL redirection due to $@. | express.js:139:23:139:37 | req.params.user | user-provided value |
 | node.js:7:34:7:39 | target | node.js:6:26:6:32 | req.url | node.js:7:34:7:39 | target | Untrusted URL redirection due to $@. | node.js:6:26:6:32 | req.url | user-provided value |
 | node.js:15:34:15:45 | '/' + target | node.js:11:26:11:32 | req.url | node.js:15:34:15:45 | '/' + target | Untrusted URL redirection due to $@. | node.js:11:26:11:32 | req.url | user-provided value |
 | node.js:32:34:32:55 | target  ... =" + me | node.js:29:26:29:32 | req.url | node.js:32:34:32:55 | target  ... =" + me | Untrusted URL redirection due to $@. | node.js:29:26:29:32 | req.url | user-provided value |

--- a/javascript/ql/test/query-tests/Security/CWE-601/ServerSideUrlRedirect/express.js
+++ b/javascript/ql/test/query-tests/Security/CWE-601/ServerSideUrlRedirect/express.js
@@ -126,3 +126,15 @@ function sendUserToUrl(res, nextUrl) {
 app.get('/call', function(req, res) {
   sendUserToUrl(res, req.query.nextUrl);
 });
+
+app.get('/redirect/:user', function(req, res) {
+  res.redirect('/users/' + req.params.user); // GOOD
+  res.redirect('users/' + req.params.user); // GOOD
+
+  res.redirect('/' + req.params.user); // BAD - could go to //evil.com
+  res.redirect('//' + req.params.user); // BAD - could go to //evil.com
+  res.redirect('u' + req.params.user); // BAD - could go to u.evil.com
+
+  res.redirect('/' + ('/u' + req.params.user)); // BAD - could go to //u.evil.com
+  res.redirect('/u' + req.params.user); // GOOD - but flagged anyway
+});


### PR DESCRIPTION
The sanitizer for our URL redirection queries is now more precise, so we no longer get false positives from things like:
```javascript
res.redirect("/users/" + req.params.id);
```

The tricky thing about slashes is that they are used in multiple parts of the URL:

1. separating the (optional) scheme from the hostname
2. separating the hostname from the path
3. occurring inside the path, query, and/or fragment

The attacker must not be able to control the hostname, so we need to make sure a slash cannot be interpreted as (1). A redirection such as
```javascript
res.redirect("/" + req.query.redirect)
```
is unsafe because it can lead to `//evil.com`.

I've also removed the `Sink.maybeNonLocal()` predicate from ServerSideUrlRedirect as it appears to implement the same sanitizer as the sanitizing prefix.

I'll run an evaluation, but just putting up for review now.