### PR TITLE
JavaScript: Improve `StackTraceExposure` query.

### DIFF
--- a/change-notes/1.19/analysis-javascript.md
+++ b/change-notes/1.19/analysis-javascript.md
@@ -44,6 +44,7 @@
 | Unused import | Fewer false-positive results | This rule no longer flags imports used by the `transform-react-jsx` Babel plugin. |
 | Self assignment | Fewer false-positive results | This rule now ignores self-assignments preceded by a JSDoc comment with a `@type` tag. |
 | Client side cross-site scripting | More results | This rule now also flags HTML injection in the body of an email. |
+| Information exposure through a stack trace | More results | This rule now also flags cases where the entire exception object (including the stack trace) may be exposed. |
 
 ## Changes to QL libraries
 

--- a/javascript/ql/test/query-tests/Security/CWE-209/StackTraceExposure.expected
+++ b/javascript/ql/test/query-tests/Security/CWE-209/StackTraceExposure.expected
@@ -1,1 +1,3 @@
-| node.js:11:13:11:21 | err.stack | Stack trace information from $@ may be exposed to an external user here. | node.js:11:13:11:21 | err.stack | here |
+| node.js:11:13:11:21 | err.stack | Stack trace information from $@ may be exposed to an external user here. | node.js:8:10:8:12 | err | here |
+| tst.js:7:13:7:13 | e | Stack trace information from $@ may be exposed to an external user here. | tst.js:6:12:6:12 | e | here |
+| tst.js:17:11:17:17 | e.stack | Stack trace information from $@ may be exposed to an external user here. | tst.js:6:12:6:12 | e | here |

--- a/javascript/ql/test/query-tests/Security/CWE-209/tst.js
+++ b/javascript/ql/test/query-tests/Security/CWE-209/tst.js
@@ -1,0 +1,18 @@
+var http = require('http');
+
+http.createServer(function onRequest(req, res) {
+  try {
+    throw new Error();
+  } catch (e) {
+    res.end(e);                        // NOT OK
+    fail(res, e);
+    res.end(e.message);                // OK
+    res.end("Caught exception " + e);  // OK
+    res.end(e.toString());             // OK
+    res.end(`Caught exception ${e}.`); // OK
+  }
+});
+
+function fail(res, e) {
+  res.end(e.stack);                    // NOT OK
+}


### PR DESCRIPTION
It now also flags exposure of the entire exception object (not just the `stack` property).