### PR TITLE
JavaScript: Introduce aliases for compatibility with other language libraries.

### DIFF
--- a/javascript/ql/src/javascript.qll
+++ b/javascript/ql/src/javascript.qll
@@ -2,6 +2,7 @@
  * Provides classes for working with JavaScript programs, as well as JSON, YAML and HTML.
  */
 
+import semmle.javascript.Aliases
 import semmle.javascript.AMD
 import semmle.javascript.AST
 import semmle.javascript.BasicBlocks

--- a/javascript/ql/src/semmle/javascript/Aliases.qll
+++ b/javascript/ql/src/semmle/javascript/Aliases.qll
@@ -1,0 +1,37 @@
+/**
+ * Provides aliases for commonly used classes that have different names
+ * in the QL libraries for other languages.
+ */
+
+import javascript
+
+class AndBitwiseExpr = BitAndExpr;
+class AndLogicalExpr = LogAndExpr;
+class ArrayAccess = IndexExpr;
+class AssignOp = CompoundAssignExpr;
+class Block = BlockStmt;
+class BoolLiteral = BooleanLiteral;
+class CaseStmt = Case;
+class ComparisonOperation = Comparison;
+class DoStmt = DoWhileStmt;
+class EqualityOperation = EqualityTest;
+class FieldAccess = DotExpr;
+class InstanceOfExpr = InstanceofExpr;
+class LabelStmt = LabeledStmt;
+class LogicalAndExpr = LogAndExpr;
+class LogicalNotExpr = LogNotExpr;
+class LogicalOrExpr = LogOrExpr;
+class Loop = LoopStmt;
+class MultilineComment = BlockComment;
+class OrBitwiseExpr = BitOrExpr;
+class OrLogicalExpr = LogOrExpr;
+class ParenthesisExpr = ParExpr;
+class ParenthesizedExpr = ParExpr;
+class RelationalOperation = RelationalComparison;
+class RemExpr = ModExpr;
+class SingleLineComment = LineComment;
+class SuperAccess = SuperExpr;
+class SwitchCase = Case;
+class ThisAccess = ThisExpr;
+class VariableAccess = VarAccess;
+class XorBitwiseExpr = XOrExpr;


### PR DESCRIPTION
Following a suggestion by @lukecartey.

For now, this only covers some basic AST classes and introduces aliases for similar classes in the C#, C++ and Java libraries; suggestions for further additions welcome.