### PR TITLE
JavaScript: Make externs extractor options more sensible.

### DIFF
--- a/javascript/extractor/src/com/semmle/js/extractor/AutoBuild.java
+++ b/javascript/extractor/src/com/semmle/js/extractor/AutoBuild.java
@@ -373,7 +373,7 @@ public class AutoBuild {
 	 * externs.
 	 */
 	private void extractExterns() throws IOException {
-		ExtractorConfig config = new ExtractorConfig(true).withExterns(true);
+		ExtractorConfig config = new ExtractorConfig(false).withExterns(true);
 		FileExtractor extractor = new FileExtractor(config, outputConfig, trapCache, extractorState);
 		FileVisitor<? super Path> visitor = new SimpleFileVisitor<Path>() {
 			@Override

--- a/javascript/extractor/src/com/semmle/js/extractor/ExtractorConfig.java
+++ b/javascript/extractor/src/com/semmle/js/extractor/ExtractorConfig.java
@@ -162,7 +162,7 @@ public class ExtractorConfig {
         this.ecmaVersion = experimental ? ECMAVersion.ECMA2019 : ECMAVersion.ECMA2018;
         this.platform = Platform.AUTO;
         this.jsx = true;
-        this.sourceType = SourceType.SCRIPT;
+        this.sourceType = SourceType.AUTO;
         this.htmlHandling = HTMLHandling.ELEMENTS;
         this.tolerateParseErrors = true;
         if (experimental) {
@@ -171,6 +171,7 @@ public class ExtractorConfig {
             this.esnext = true;
             this.v8Extensions = true;
         }
+        this.typescriptMode = TypeScriptMode.NONE;
         this.defaultEncoding = StandardCharsets.UTF_8.name();
     }
 


### PR DESCRIPTION
See commit messages for details; the end result is that `AutoBuild` extracts externs with the same settings as a bootstrap-generated `project` file, that is, with module auto-detection turned on, TypeScript support turned off, and experimental features turned off.

I've verified that this has no practical effect on extractor behaviour with current externs (which contain neither modules nor TypeScript nor experimental features), but it's nice to be consistent.