### PR TITLE
JavaScript: Teach `AutoBuild` to use in-dist externs trap cache.

### DIFF
--- a/javascript/extractor/src/com/semmle/js/extractor/AutoBuild.java
+++ b/javascript/extractor/src/com/semmle/js/extractor/AutoBuild.java
@@ -380,8 +380,16 @@ public class AutoBuild {
 		ITrapCache trapCache = this.trapCache;
 		if (trapCache instanceof DummyTrapCache) {
 			Path trapCachePath = SEMMLE_DIST.resolve(".cache").resolve("trap-cache").resolve("javascript");
-			if (Files.isDirectory(trapCachePath))
-				trapCache = new DefaultTrapCache(trapCachePath.toString(), null, Main.EXTRACTOR_VERSION);
+			if (Files.isDirectory(trapCachePath)) {
+				trapCache = new DefaultTrapCache(trapCachePath.toString(), null, Main.EXTRACTOR_VERSION) {
+					@Override
+					public File lookup(String source, ExtractorConfig config, FileType type) {
+						File f = super.lookup(source, config, type);
+						// only return `f` if it exists; this has the effect of making the cache read-only
+						return f.exists() ? f : null;
+					}
+				};
+			}
 		}
 
 		FileExtractor extractor = new FileExtractor(config, outputConfig, trapCache, extractorState);

--- a/javascript/extractor/src/com/semmle/js/extractor/AutoBuild.java
+++ b/javascript/extractor/src/com/semmle/js/extractor/AutoBuild.java
@@ -374,6 +374,16 @@ public class AutoBuild {
 	 */
 	private void extractExterns() throws IOException {
 		ExtractorConfig config = new ExtractorConfig(false).withExterns(true);
+
+		// use explicitly specified trap cache, or otherwise $SEMMLE_DIST/.cache/trap-cache/javascript,
+		// which we pre-populate when building the distribution
+		ITrapCache trapCache = this.trapCache;
+		if (trapCache instanceof DummyTrapCache) {
+			Path trapCachePath = SEMMLE_DIST.resolve(".cache").resolve("trap-cache").resolve("javascript");
+			if (Files.isDirectory(trapCachePath))
+				trapCache = new DefaultTrapCache(trapCachePath.toString(), null, Main.EXTRACTOR_VERSION);
+		}
+
 		FileExtractor extractor = new FileExtractor(config, outputConfig, trapCache, extractorState);
 		FileVisitor<? super Path> visitor = new SimpleFileVisitor<Path>() {
 			@Override

--- a/javascript/extractor/src/com/semmle/js/extractor/AutoBuild.java
+++ b/javascript/extractor/src/com/semmle/js/extractor/AutoBuild.java
@@ -285,9 +285,8 @@ public class AutoBuild {
 							excludes.add(toRealPath(folderPath));
 						} catch (InvalidPathException | URISyntaxException | ResourceError e) {
 							Exceptions.ignore(e, "Ignore path and print warning message instead");
-							System.err.println("Ignoring '" + fields[0] + "' classification for " +
+							warn("Ignoring '" + fields[0] + "' classification for " +
 									folder + ", which is not a valid path.");
-							System.err.flush();
 						}
 					}
 				}
@@ -354,8 +353,7 @@ public class AutoBuild {
 			patterns.add(realPath);
 		} catch (ResourceError e) {
 			Exceptions.ignore(e, "Ignore exception and print warning instead.");
-			System.err.println("Skipping path " + path + ", which does not exist.");
-			System.err.flush();
+			warn("Skipping path " + path + ", which does not exist.");
 		}
 		return true;
 	}
@@ -557,14 +555,18 @@ public class AutoBuild {
 	protected void extract(FileExtractor extractor, Path file) throws IOException {
 		File f = file.toFile();
 		if (!f.exists()) {
-			System.err.println("Skipping " + file + ", which does not exist.");
-			System.err.flush();
+			warn("Skipping " + file + ", which does not exist.");
 			return;
 		}
 
 		logBeginProcess("Extracting " + file);
 		extractor.extract(f);
 		logEndProcess();
+	}
+
+	private void warn(String msg) {
+		System.err.println(msg);
+		System.err.flush();
 	}
 
 	private void logBeginProcess(String message) {

--- a/javascript/extractor/src/com/semmle/js/extractor/AutoBuild.java
+++ b/javascript/extractor/src/com/semmle/js/extractor/AutoBuild.java
@@ -380,13 +380,24 @@ public class AutoBuild {
 			Path trapCachePath = SEMMLE_DIST.resolve(".cache").resolve("trap-cache").resolve("javascript");
 			if (Files.isDirectory(trapCachePath)) {
 				trapCache = new DefaultTrapCache(trapCachePath.toString(), null, Main.EXTRACTOR_VERSION) {
+					boolean warnedAboutCacheMiss = false;
+
 					@Override
 					public File lookup(String source, ExtractorConfig config, FileType type) {
 						File f = super.lookup(source, config, type);
 						// only return `f` if it exists; this has the effect of making the cache read-only
-						return f.exists() ? f : null;
+						if (f.exists())
+							return f;
+						// warn on first failed lookup
+						if (!warnedAboutCacheMiss) {
+							warn("Trap cache lookup for externs failed.");
+							warnedAboutCacheMiss = true;
+						}
+						return null;
 					}
 				};
+			} else {
+				warn("No externs trap cache found");
 			}
 		}
 


### PR DESCRIPTION
This PR teaches `AutoBuild` to look for a trap cache at `.cache/trap-cache/javascript` in the Semmle distribution, and use it when extracting externs (unless a different trap cache is explicitly specified). The corresponding internal PR sets up things so we actually create the cache when building a distribution.

While logically related, the two PRs are technically independent: if `AutoBuild` doesn't find a cache, it prints a warning and keeps going. It also warns on cache misses (suggesting that the distribution build populated the cache wrongly), but never tries to update the cache (so the distribution is still treated as a read-only resource).
