### PR TITLE
JavaScript: Add modelling of AMD imports.

### DIFF
--- a/change-notes/1.19/analysis-javascript.md
+++ b/change-notes/1.19/analysis-javascript.md
@@ -6,6 +6,8 @@
 
 * The taint tracking library now recognizes additional sanitization patterns. This may give fewer false-positive results for the security queries.
 
+* Support for AMD modules has been improved. This may give additional results for the security queries as well as any queries that use type inference on code bases that use such modules.
+
 * Support for popular libraries has been improved. Consequently, queries may produce more results on code bases that use the following features:
   - file system access, for example through [fs-extra](https://github.com/jprichardson/node-fs-extra) or [globby](https://www.npmjs.com/package/globby)
   - outbound network access, for example through the [fetch API](https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API)

--- a/javascript/ql/src/semmle/javascript/dataflow/internal/InterModuleTypeInference.qll
+++ b/javascript/ql/src/semmle/javascript/dataflow/internal/InterModuleTypeInference.qll
@@ -233,6 +233,42 @@ private class AnalyzedAmdExport extends AnalyzedPropertyWrite, DataFlow::ValueNo
 }
 
 /**
+ * Flow analysis for AMD imports, interpreted as an implicit read of
+ * the `module.exports` property of the imported module.
+ */
+private class AnalyzedAmdImport extends AnalyzedPropertyRead, DataFlow::Node {
+  Module required;
+
+  AnalyzedAmdImport() {
+    exists (AMDModule amd, PathExpr dep, Parameter p |
+      amd.getDefine().dependencyParameter(dep, p) and
+      this = DataFlow::parameterNode(p) and
+      required.getFile() = amd.resolve(dep)
+    )
+  }
+
+  override predicate reads(AbstractValue base, string propName) {
+    base = TAbstractModuleObject(required) and
+    propName = "exports"
+  }
+}
+
+/**
+ * Flow analysis for parameters corresponding to AMD imports.
+ */
+private class AnalyzedAmdParameter extends AnalyzedVarDef, @vardecl {
+  AnalyzedAmdImport imp;
+
+  AnalyzedAmdParameter() {
+    imp = DataFlow::parameterNode(this)
+  }
+
+  override AbstractValue getAnRhsValue() {
+    result = imp.getALocalValue()
+  }
+}
+
+/**
  * Flow analysis for exports that export a single value.
  */
 private class AnalyzedValueExport extends AnalyzedPropertyWrite, DataFlow::ValueNode {

--- a/javascript/ql/test/library-tests/Flow/AbstractValues.expected
+++ b/javascript/ql/test/library-tests/Flow/AbstractValues.expected
@@ -15,6 +15,10 @@
 | amd2.js:1:8:3:1 | anonymous function |
 | amd2.js:1:8:3:1 | instance of anonymous function |
 | amd2.js:2:10:2:22 | object literal |
+| amd3.js:1:1:5:0 | exports object of module amd3 |
+| amd3.js:1:1:5:0 | module object of module amd3 |
+| amd3.js:1:24:4:1 | anonymous function |
+| amd3.js:1:24:4:1 | instance of anonymous function |
 | amd.js:1:1:7:0 | exports object of module amd |
 | amd.js:1:1:7:0 | module object of module amd |
 | amd.js:1:31:6:1 | anonymous function |

--- a/javascript/ql/test/library-tests/Flow/abseval.expected
+++ b/javascript/ql/test/library-tests/Flow/abseval.expected
@@ -7,6 +7,11 @@
 | a.js:9:5:9:5 | z | a.js:9:9:9:18 | someGlobal | file://:0:0:0:0 | non-zero value |
 | a.js:9:5:9:5 | z | a.js:9:9:9:18 | someGlobal | file://:0:0:0:0 | true |
 | a.js:14:12:14:24 | notAlwaysZero | a.js:14:28:14:28 | 0 | file://:0:0:0:0 | 0 |
+| amd3.js:2:7:2:8 | _a | amd3.js:2:12:2:12 | a | a.js:1:1:18:0 | exports object of module a |
+| amd3.js:2:7:2:8 | _a | amd3.js:2:12:2:12 | a | file://:0:0:0:0 | indefinite value (call) |
+| amd3.js:3:7:3:8 | _c | amd3.js:3:12:3:12 | c | c.js:1:1:7:0 | exports object of module c |
+| amd3.js:3:7:3:8 | _c | amd3.js:3:12:3:12 | c | c.js:1:18:1:19 | object literal |
+| amd3.js:3:7:3:8 | _c | amd3.js:3:12:3:12 | c | file://:0:0:0:0 | indefinite value (call) |
 | amd.js:2:7:2:7 | m | amd.js:2:11:2:13 | mod | amd.js:1:1:7:0 | module object of module amd |
 | amd.js:2:7:2:7 | m | amd.js:2:11:2:13 | mod | file://:0:0:0:0 | indefinite value (call) |
 | amd.js:3:7:3:7 | e | amd.js:3:11:3:13 | exp | amd.js:1:1:7:0 | exports object of module amd |

--- a/javascript/ql/test/library-tests/Flow/amd3.js
+++ b/javascript/ql/test/library-tests/Flow/amd3.js
@@ -1,0 +1,4 @@
+define(['./a', './c'], function(a, c) {
+  var _a = a;
+  var _c = c;
+});

--- a/javascript/ql/test/library-tests/Flow/types.expected
+++ b/javascript/ql/test/library-tests/Flow/types.expected
@@ -3,6 +3,8 @@
 | a.js:1:19:1:19 | y | a.js:1:23:1:23 | 0 | number |
 | a.js:9:5:9:5 | z | a.js:9:9:9:18 | someGlobal | boolean, class, date, function, null, number, object, regular expression,string or undefined |
 | a.js:14:12:14:24 | notAlwaysZero | a.js:14:28:14:28 | 0 | number |
+| amd3.js:2:7:2:8 | _a | amd3.js:2:12:2:12 | a | boolean, class, date, function, null, number, object, regular expression,string or undefined |
+| amd3.js:3:7:3:8 | _c | amd3.js:3:12:3:12 | c | boolean, class, date, function, null, number, object, regular expression,string or undefined |
 | amd.js:2:7:2:7 | m | amd.js:2:11:2:13 | mod | boolean, class, date, function, null, number, object, regular expression,string or undefined |
 | amd.js:3:7:3:7 | e | amd.js:3:11:3:13 | exp | boolean, class, date, function, null, number, object, regular expression,string or undefined |
 | arguments.js:2:7:2:7 | y | arguments.js:2:11:2:11 | x | number |


### PR DESCRIPTION
We already modelled exports, but for some reason not imports.

Evaluation report [here](https://git.semmle.com/gist/max/d8c12260617d575582c7a36e4abe6060) (internal link), one new result that looks like a TP. The slowdowns on a few projects look disappointing; in fact, it looked even worse at first, so I reran a few outliers, which caused the slowdown to disappear, suggesting that it was probably a fluke. My guess is that this is true for the remaining slowdowns as well (in particular since they are all fairly small projects). I'd be happy to rerun a few more to confirm if desired.