### PR TITLE
JavaScript: Rename `hasPathFlow` to `hasFlowPath` for consistency with other languages.

### DIFF
--- a/javascript/ql/src/Security/CWE-022/TaintedPath.ql
+++ b/javascript/ql/src/Security/CWE-022/TaintedPath.ql
@@ -19,6 +19,6 @@ import semmle.javascript.security.dataflow.TaintedPath::TaintedPath
 import DataFlow::PathGraph
 
 from Configuration cfg, DataFlow::PathNode source, DataFlow::PathNode sink
-where cfg.hasPathFlow(source, sink)
+where cfg.hasFlowPath(source, sink)
 select sink.getNode(), source, sink, "This path depends on $@.",
        source.getNode(), "a user-provided value"

--- a/javascript/ql/src/Security/CWE-078/CommandInjection.ql
+++ b/javascript/ql/src/Security/CWE-078/CommandInjection.ql
@@ -17,7 +17,7 @@ import semmle.javascript.security.dataflow.CommandInjection::CommandInjection
 import DataFlow::PathGraph
 
 from Configuration cfg, DataFlow::PathNode source, DataFlow::PathNode sink, DataFlow::Node highlight
-where cfg.hasPathFlow(source, sink) and
+where cfg.hasFlowPath(source, sink) and
       if cfg.isSinkWithHighlight(sink.getNode(), _) then
         cfg.isSinkWithHighlight(sink.getNode(), highlight)
       else

--- a/javascript/ql/src/Security/CWE-079/ReflectedXss.ql
+++ b/javascript/ql/src/Security/CWE-079/ReflectedXss.ql
@@ -16,6 +16,6 @@ import semmle.javascript.security.dataflow.ReflectedXss::ReflectedXss
 import DataFlow::PathGraph
 
 from Configuration cfg, DataFlow::PathNode source, DataFlow::PathNode sink
-where cfg.hasPathFlow(source, sink)
+where cfg.hasFlowPath(source, sink)
 select sink.getNode(), source, sink, "Cross-site scripting vulnerability due to $@.",
        source.getNode(), "user-provided value"

--- a/javascript/ql/src/Security/CWE-079/StoredXss.ql
+++ b/javascript/ql/src/Security/CWE-079/StoredXss.ql
@@ -16,6 +16,6 @@ import semmle.javascript.security.dataflow.StoredXss::StoredXss
 import DataFlow::PathGraph
 
 from Configuration cfg, DataFlow::PathNode source, DataFlow::PathNode sink
-where cfg.hasPathFlow(source, sink)
+where cfg.hasFlowPath(source, sink)
 select sink.getNode(), source, sink, "Stored cross-site scripting vulnerability due to $@.",
        source.getNode(), "stored value"

--- a/javascript/ql/src/Security/CWE-079/Xss.ql
+++ b/javascript/ql/src/Security/CWE-079/Xss.ql
@@ -16,6 +16,6 @@ import semmle.javascript.security.dataflow.DomBasedXss::DomBasedXss
 import DataFlow::PathGraph
 
 from Configuration cfg, DataFlow::PathNode source, DataFlow::PathNode sink
-where cfg.hasPathFlow(source, sink)
+where cfg.hasFlowPath(source, sink)
 select sink.getNode(), source, sink, sink.getNode().(Sink).getVulnerabilityKind() + " vulnerability due to $@.",
        source.getNode(), "user-provided value"

--- a/javascript/ql/src/Security/CWE-089/SqlInjection.ql
+++ b/javascript/ql/src/Security/CWE-089/SqlInjection.ql
@@ -18,6 +18,6 @@ import DataFlow::PathGraph
 from DataFlow::Configuration cfg, DataFlow::PathNode source, DataFlow::PathNode sink
 where (cfg instanceof SqlInjection::Configuration or
        cfg instanceof NosqlInjection::Configuration) and
-      cfg.hasPathFlow(source, sink)
+      cfg.hasFlowPath(source, sink)
 select sink.getNode(), source, sink, "This query depends on $@.",
        source.getNode(), "a user-provided value"

--- a/javascript/ql/src/Security/CWE-094/CodeInjection.ql
+++ b/javascript/ql/src/Security/CWE-094/CodeInjection.ql
@@ -17,6 +17,6 @@ import semmle.javascript.security.dataflow.CodeInjection::CodeInjection
 import DataFlow::PathGraph
 
 from Configuration cfg, DataFlow::PathNode source, DataFlow::PathNode sink
-where cfg.hasPathFlow(source, sink)
+where cfg.hasFlowPath(source, sink)
 select sink.getNode(), source, sink, "$@ flows to here and is interpreted as code.",
        source.getNode(), "User-provided value"

--- a/javascript/ql/src/Security/CWE-134/TaintedFormatString.ql
+++ b/javascript/ql/src/Security/CWE-134/TaintedFormatString.ql
@@ -14,6 +14,6 @@ import semmle.javascript.security.dataflow.TaintedFormatString::TaintedFormatStr
 import DataFlow::PathGraph
 
 from Configuration cfg, DataFlow::PathNode source, DataFlow::PathNode sink
-where cfg.hasPathFlow(source, sink)
+where cfg.hasFlowPath(source, sink)
 select sink.getNode(), source, sink, "$@ flows here and is used in a format string.",
        source.getNode(), "User-provided value"

--- a/javascript/ql/src/Security/CWE-200/FileAccessToHttp.ql
+++ b/javascript/ql/src/Security/CWE-200/FileAccessToHttp.ql
@@ -13,6 +13,6 @@ import semmle.javascript.security.dataflow.FileAccessToHttp::FileAccessToHttp
 import DataFlow::PathGraph
 
 from Configuration cfg, DataFlow::PathNode source, DataFlow::PathNode sink
-where cfg.hasPathFlow(source, sink)
+where cfg.hasFlowPath(source, sink)
 select sink.getNode(), source, sink, "$@ flows directly to outbound network request",
        source.getNode(), "File data"

--- a/javascript/ql/src/Security/CWE-209/StackTraceExposure.ql
+++ b/javascript/ql/src/Security/CWE-209/StackTraceExposure.ql
@@ -16,6 +16,6 @@ import semmle.javascript.security.dataflow.StackTraceExposure::StackTraceExposur
 import DataFlow::PathGraph
 
 from Configuration cfg, DataFlow::PathNode source, DataFlow::PathNode sink
-where cfg.hasPathFlow(source, sink)
+where cfg.hasFlowPath(source, sink)
 select sink.getNode(), source, sink, "Stack trace information from $@ may be exposed to an external user here.",
        source.getNode(), "here"

--- a/javascript/ql/src/Security/CWE-312/CleartextLogging.ql
+++ b/javascript/ql/src/Security/CWE-312/CleartextLogging.ql
@@ -33,7 +33,7 @@ predicate inBrowserEnvironment(TopLevel tl) {
 }
 
 from Configuration cfg, DataFlow::PathNode source, DataFlow::PathNode sink
-where cfg.hasPathFlow(source, sink) and
+where cfg.hasFlowPath(source, sink) and
       // ignore logging to the browser console (even though it is not a good practice)
       not inBrowserEnvironment(sink.getNode().asExpr().getTopLevel())
 select sink.getNode(), source, sink, "Sensitive data returned by $@ is logged here.",

--- a/javascript/ql/src/Security/CWE-312/CleartextStorage.ql
+++ b/javascript/ql/src/Security/CWE-312/CleartextStorage.ql
@@ -17,6 +17,6 @@ import semmle.javascript.security.dataflow.CleartextStorage::CleartextStorage
 import DataFlow::PathGraph
 
 from Configuration cfg, DataFlow::PathNode source, DataFlow::PathNode sink
-where cfg.hasPathFlow(source, sink)
+where cfg.hasFlowPath(source, sink)
 select sink.getNode(), source, sink, "Sensitive data returned by $@ is stored here.",
        source.getNode(), source.getNode().(Source).describe()

--- a/javascript/ql/src/Security/CWE-327/BrokenCryptoAlgorithm.ql
+++ b/javascript/ql/src/Security/CWE-327/BrokenCryptoAlgorithm.ql
@@ -15,7 +15,7 @@ import semmle.javascript.security.SensitiveActions
 import DataFlow::PathGraph
 
 from Configuration cfg, DataFlow::PathNode source, DataFlow::PathNode sink
-where cfg.hasPathFlow(source, sink) and
+where cfg.hasFlowPath(source, sink) and
       not source.getNode().asExpr() instanceof CleartextPasswordExpr // flagged by js/insufficient-password-hash
 select sink.getNode(), source, sink, "Sensitive data from $@ is used in a broken or weak cryptographic algorithm.",
        source.getNode(), source.getNode().(Source).describe()

--- a/javascript/ql/src/Security/CWE-338/InsecureRandomness.ql
+++ b/javascript/ql/src/Security/CWE-338/InsecureRandomness.ql
@@ -15,6 +15,6 @@ import semmle.javascript.security.dataflow.InsecureRandomness::InsecureRandomnes
 import DataFlow::PathGraph
 
 from Configuration cfg, DataFlow::PathNode source, DataFlow::PathNode sink
-where cfg.hasPathFlow(source, sink)
+where cfg.hasFlowPath(source, sink)
 select sink.getNode(), source, sink, "Cryptographically insecure $@ in a security context.",
        source.getNode(), "random value"

--- a/javascript/ql/src/Security/CWE-346/CorsMisconfigurationForCredentials.ql
+++ b/javascript/ql/src/Security/CWE-346/CorsMisconfigurationForCredentials.ql
@@ -16,7 +16,7 @@ import semmle.javascript.security.dataflow.CorsMisconfigurationForCredentials::C
 import DataFlow::PathGraph
 
 from Configuration cfg, DataFlow::PathNode source, DataFlow::PathNode sink
-where cfg.hasPathFlow(source, sink)
+where cfg.hasFlowPath(source, sink)
 select sink.getNode(), source, sink, "$@ leak vulnerability due to $@.",
        sink.getNode().(Sink).getCredentialsHeader(), "Credential",
        source.getNode(), "a misconfigured CORS header value"

--- a/javascript/ql/src/Security/CWE-400/RemotePropertyInjection.ql
+++ b/javascript/ql/src/Security/CWE-400/RemotePropertyInjection.ql
@@ -17,6 +17,6 @@ import semmle.javascript.security.dataflow.RemotePropertyInjection::RemoteProper
 import DataFlow::PathGraph
 
 from Configuration cfg, DataFlow::PathNode source, DataFlow::PathNode sink
-where cfg.hasPathFlow(source, sink)
+where cfg.hasFlowPath(source, sink)
 select sink.getNode(), source, sink, "A $@ is used as" + sink.getNode().(Sink).getMessage(),
        source.getNode(), "user-provided value"

--- a/javascript/ql/src/Security/CWE-502/UnsafeDeserialization.ql
+++ b/javascript/ql/src/Security/CWE-502/UnsafeDeserialization.ql
@@ -15,6 +15,6 @@ import semmle.javascript.security.dataflow.UnsafeDeserialization::UnsafeDeserial
 import DataFlow::PathGraph
 
 from Configuration cfg, DataFlow::PathNode source, DataFlow::PathNode sink
-where cfg.hasPathFlow(source, sink)
+where cfg.hasFlowPath(source, sink)
 select sink.getNode(), source, sink, "Unsafe deserialization of $@.",
        source.getNode(), "user input"

--- a/javascript/ql/src/Security/CWE-601/ClientSideUrlRedirect.ql
+++ b/javascript/ql/src/Security/CWE-601/ClientSideUrlRedirect.ql
@@ -17,6 +17,6 @@ import semmle.javascript.security.dataflow.ClientSideUrlRedirect::ClientSideUrlR
 import DataFlow::PathGraph
 
 from Configuration cfg, DataFlow::PathNode source, DataFlow::PathNode sink
-where cfg.hasPathFlow(source, sink)
+where cfg.hasFlowPath(source, sink)
 select sink.getNode(), source, sink, "Untrusted URL redirection due to $@.",
        source.getNode(), "user-provided value"

--- a/javascript/ql/src/Security/CWE-601/ServerSideUrlRedirect.ql
+++ b/javascript/ql/src/Security/CWE-601/ServerSideUrlRedirect.ql
@@ -15,6 +15,6 @@ import semmle.javascript.security.dataflow.ServerSideUrlRedirect::ServerSideUrlR
 import DataFlow::PathGraph
 
 from Configuration cfg, DataFlow::PathNode source, DataFlow::PathNode sink
-where cfg.hasPathFlow(source, sink)
+where cfg.hasFlowPath(source, sink)
 select sink.getNode(), source, sink, "Untrusted URL redirection due to $@.",
        source.getNode(), "user-provided value"

--- a/javascript/ql/src/Security/CWE-611/Xxe.ql
+++ b/javascript/ql/src/Security/CWE-611/Xxe.ql
@@ -16,6 +16,6 @@ import semmle.javascript.security.dataflow.Xxe::Xxe
 import DataFlow::PathGraph
 
 from Configuration cfg, DataFlow::PathNode source, DataFlow::PathNode sink
-where cfg.hasPathFlow(source, sink)
+where cfg.hasFlowPath(source, sink)
 select sink.getNode(), source, sink, "A $@ is parsed as XML without guarding against external entity expansion.",
        source.getNode(), "user-provided value"

--- a/javascript/ql/src/Security/CWE-640/HostHeaderPoisoningInEmailGeneration.ql
+++ b/javascript/ql/src/Security/CWE-640/HostHeaderPoisoningInEmailGeneration.ql
@@ -15,6 +15,6 @@ import semmle.javascript.security.dataflow.HostHeaderPoisoningInEmailGeneration:
 import DataFlow::PathGraph
 
 from Configuration cfg, DataFlow::PathNode source, DataFlow::PathNode sink
-where cfg.hasPathFlow(source, sink)
+where cfg.hasFlowPath(source, sink)
 select sink.getNode(), source, sink, "Links in this email can be hijacked by poisoning the HTTP host header $@.",
        source.getNode(), "here"

--- a/javascript/ql/src/Security/CWE-643/XpathInjection.ql
+++ b/javascript/ql/src/Security/CWE-643/XpathInjection.ql
@@ -15,6 +15,6 @@ import semmle.javascript.security.dataflow.XpathInjection::XpathInjection
 import DataFlow::PathGraph
 
 from Configuration cfg, DataFlow::PathNode source, DataFlow::PathNode sink
-where cfg.hasPathFlow(source, sink)
+where cfg.hasFlowPath(source, sink)
 select sink.getNode(), source, sink, "$@ flows here and is used in an XPath expression.",
        source.getNode(), "User-provided value"

--- a/javascript/ql/src/Security/CWE-730/RegExpInjection.ql
+++ b/javascript/ql/src/Security/CWE-730/RegExpInjection.ql
@@ -17,6 +17,6 @@ import semmle.javascript.security.dataflow.RegExpInjection::RegExpInjection
 import DataFlow::PathGraph
 
 from Configuration cfg, DataFlow::PathNode source, DataFlow::PathNode sink
-where cfg.hasPathFlow(source, sink)
+where cfg.hasFlowPath(source, sink)
 select sink.getNode(), source, sink, "This regular expression is constructed from a $@.",
        source.getNode(), "user-provided value"

--- a/javascript/ql/src/Security/CWE-776/XmlBomb.ql
+++ b/javascript/ql/src/Security/CWE-776/XmlBomb.ql
@@ -16,6 +16,6 @@ import semmle.javascript.security.dataflow.XmlBomb::XmlBomb
 import DataFlow::PathGraph
 
 from Configuration cfg, DataFlow::PathNode source, DataFlow::PathNode sink
-where cfg.hasPathFlow(source, sink)
+where cfg.hasFlowPath(source, sink)
 select sink.getNode(), source, sink, "A $@ is parsed as XML without guarding against uncontrolled entity expansion.",
        source.getNode(), "user-provided value"

--- a/javascript/ql/src/Security/CWE-798/HardcodedCredentials.ql
+++ b/javascript/ql/src/Security/CWE-798/HardcodedCredentials.ql
@@ -17,7 +17,7 @@ private import semmle.javascript.security.dataflow.HardcodedCredentials::Hardcod
 import DataFlow::PathGraph
 
 from Configuration cfg, DataFlow::PathNode source, DataFlow::PathNode sink, string value
-where cfg.hasPathFlow(source, sink) and
+where cfg.hasFlowPath(source, sink) and
       // use source value in message if it's available
       if source.getNode().asExpr() instanceof ConstantString then
         value = "The hard-coded value \"" + source.getNode().asExpr().(ConstantString).getStringValue() + "\""

--- a/javascript/ql/src/Security/CWE-807/ConditionalBypass.ql
+++ b/javascript/ql/src/Security/CWE-807/ConditionalBypass.ql
@@ -73,13 +73,13 @@ predicate isTaintedGuardForSensitiveAction(DataFlow::PathNode sink, DataFlow::Pa
   not sink.getNode() instanceof SensitiveActionGuardComparisonOperand and
   exists (Configuration cfg  |
     // ordinary taint tracking to a guard
-    cfg.hasPathFlow(source, sink) or
+    cfg.hasFlowPath(source, sink) or
     // taint tracking to both operands of a guard comparison
     exists (SensitiveActionGuardComparison cmp, DataFlow::PathNode lSource, DataFlow::PathNode rSource,
             DataFlow::PathNode lSink, DataFlow::PathNode rSink |
       sink.getNode() = cmp.getGuard() and
-      cfg.hasPathFlow(lSource, lSink) and lSink.getNode() = DataFlow::valueNode(cmp.getLeftOperand()) and
-      cfg.hasPathFlow(rSource, rSink) and rSink.getNode() = DataFlow::valueNode(cmp.getRightOperand()) |
+      cfg.hasFlowPath(lSource, lSink) and lSink.getNode() = DataFlow::valueNode(cmp.getLeftOperand()) and
+      cfg.hasFlowPath(rSource, rSink) and rSink.getNode() = DataFlow::valueNode(cmp.getRightOperand()) |
       source = lSource or
       source = rSource
     )

--- a/javascript/ql/src/Security/CWE-843/TypeConfusionThroughParameterTampering.ql
+++ b/javascript/ql/src/Security/CWE-843/TypeConfusionThroughParameterTampering.ql
@@ -14,6 +14,6 @@ import semmle.javascript.security.dataflow.TypeConfusionThroughParameterTamperin
 import DataFlow::PathGraph
 
 from Configuration cfg, DataFlow::PathNode source, DataFlow::PathNode sink
-where cfg.hasPathFlow(source, sink)
+where cfg.hasFlowPath(source, sink)
 select sink.getNode(), source, sink, "Potential type confusion for $@.",
        source.getNode(), "HTTP request parameter"

--- a/javascript/ql/src/Security/CWE-912/HttpToFileAccess.ql
+++ b/javascript/ql/src/Security/CWE-912/HttpToFileAccess.ql
@@ -13,5 +13,5 @@ import semmle.javascript.security.dataflow.HttpToFileAccess::HttpToFileAccess
 import DataFlow::PathGraph
 
 from Configuration cfg, DataFlow::PathNode source, DataFlow::PathNode sink
-where cfg.hasPathFlow(source, sink)
+where cfg.hasFlowPath(source, sink)
 select sink.getNode(), source, sink, "$@ flows to file system", source.getNode(), "Untrusted data"

--- a/javascript/ql/src/Security/CWE-916/InsufficientPasswordHash.ql
+++ b/javascript/ql/src/Security/CWE-916/InsufficientPasswordHash.ql
@@ -14,6 +14,6 @@ import semmle.javascript.security.dataflow.InsufficientPasswordHash::Insufficien
 import DataFlow::PathGraph
 
 from Configuration cfg, DataFlow::PathNode source, DataFlow::PathNode sink
-where cfg.hasPathFlow(source, sink)
+where cfg.hasFlowPath(source, sink)
 select sink.getNode(), source, sink, "Password from $@ is hashed insecurely.",
        source.getNode(), source.getNode().(Source).describe()

--- a/javascript/ql/src/Security/CWE-918/RequestForgery.ql
+++ b/javascript/ql/src/Security/CWE-918/RequestForgery.ql
@@ -14,7 +14,7 @@ import semmle.javascript.security.dataflow.RequestForgery::RequestForgery
 import DataFlow::PathGraph
 
 from Configuration cfg, DataFlow::PathNode source, DataFlow::PathNode sink, DataFlow::Node request
-where cfg.hasPathFlow(source, sink) and
+where cfg.hasFlowPath(source, sink) and
       request = sink.getNode().(Sink).getARequest()
 select request, source, sink, "The $@ of this request depends on $@.",
        sink.getNode(), sink.getNode().(Sink).getKind(), source, "a user-provided value"

--- a/javascript/ql/src/semmle/javascript/dataflow/Configuration.qll
+++ b/javascript/ql/src/semmle/javascript/dataflow/Configuration.qll
@@ -189,7 +189,7 @@ abstract class Configuration extends string {
   predicate hasFlow(DataFlow::Node source, DataFlow::Node sink) {
     isSource(_, this, _) and isSink(_, this, _) and
     exists (SourcePathNode flowsource, SinkPathNode flowsink |
-      hasPathFlow(flowsource, flowsink) and
+      hasFlowPath(flowsource, flowsink) and
       source = flowsource.getNode() and
       sink = flowsink.getNode()
     )
@@ -198,8 +198,17 @@ abstract class Configuration extends string {
   /**
    * Holds if data may flow from `source` to `sink` for this configuration.
    */
-  predicate hasPathFlow(SourcePathNode source, SinkPathNode sink) {
+  predicate hasFlowPath(SourcePathNode source, SinkPathNode sink) {
     flowsTo(source, _, sink, _, this)
+  }
+
+  /**
+   * DEPRECATED: Use `hasFlowPath` instead.
+   *
+   * Holds if data may flow from `source` to `sink` for this configuration.
+   */
+  deprecated predicate hasPathFlow(SourcePathNode source, SinkPathNode sink) {
+    hasFlowPath(source, sink)
   }
 
   /**


### PR DESCRIPTION
I have no idea why the names were inconsistent to begin with, probably just an oversight on my part.