### PR TITLE
C++: Add JSF note to qhelp for sub-set of JSF queries

### DIFF
--- a/cpp/ql/src/Critical/NotInitialised.ql
+++ b/cpp/ql/src/Critical/NotInitialised.ql
@@ -9,9 +9,7 @@
  */
 import cpp
 
-// This query is the JSF version
-//
-// (see also InitialisationNotRun.ql and GlobalUseBeforeInit.ql)
+// See also InitialisationNotRun.ql and GlobalUseBeforeInit.ql
 
 // Holds if s defines variable v (conservative)
 predicate defines(ControlFlowNode s, Variable lv) {

--- a/cpp/ql/src/jsf/4.05 Libraries/AV Rule 24.qhelp
+++ b/cpp/ql/src/jsf/4.05 Libraries/AV Rule 24.qhelp
@@ -5,8 +5,12 @@
 
 
 <overview>
+
+<!-- Mention that this rule may not be applicable in projects that don't follow the JSF standard. -->
+<include src="cpp/jsfNote.qhelp" />
+
 <p>
-This rule finds calls to the standard library functions <code>abort, exit, getenv</code> and <code>system</code>.
+This query highlights calls to the standard library functions <code>abort, exit, getenv</code> and <code>system</code>.
 The functions <code>abort</code> and <code>exit</code> should not be called as they immediately terminate the program
 and will bypass all the normal error and exception handling routines in the software. This is especially important in
 software which is run on systems without an interactive OS, as restarting the software may require a complete reboot

--- a/cpp/ql/src/jsf/4.10 Classes/AV Rule 85.qhelp
+++ b/cpp/ql/src/jsf/4.10 Classes/AV Rule 85.qhelp
@@ -5,8 +5,12 @@
 
 
 <overview>
+
+<!-- Mention that this rule may not be applicable in projects that don't follow the JSF standard. -->
+<include src="cpp/jsfNote.qhelp" />
+
 <p>
-This rule ensures that all operators with opposites (e.g. == and !=) are both defined, and
+This query ensures that all operators with opposites (e.g. == and !=) are both defined, and
 that one of them is defined in terms of the other. This just enforces the consistency of meaning
 of the operators.
 </p>

--- a/cpp/ql/src/jsf/4.13 Functions/AV Rule 111.qhelp
+++ b/cpp/ql/src/jsf/4.13 Functions/AV Rule 111.qhelp
@@ -5,8 +5,12 @@
 
 
 <overview>
+
+<!-- Mention that this rule may not be applicable in projects that don't follow the JSF standard. -->
+<include src="cpp/jsfNote.qhelp" />
+
 <p>
-This rule finds return statements that return pointers to an object allocated on the stack. The lifetime
+This query highlights return statements that return pointers to an object allocated on the stack. The lifetime
 of a stack allocated memory location only lasts until the function returns, , and 
 the contents of that memory become undefined after that. Clearly, using a pointer to stack 
 memory after the function has already returned will have undefined results.

--- a/cpp/ql/src/jsf/4.15 Declarations and Definitions/AV Rule 135.qhelp
+++ b/cpp/ql/src/jsf/4.15 Declarations and Definitions/AV Rule 135.qhelp
@@ -5,8 +5,12 @@
 
 
 <overview>
+
+<!-- Mention that this rule may not be applicable in projects that don't follow the JSF standard. -->
+<include src="cpp/jsfNote.qhelp" />
+
 <p>
-This rule finds identifiers in an inner scope that hide (have the same name as) an identifier in an outer scope.
+This query highlights identifiers in an inner scope that hide (have the same name as) an identifier in an outer scope.
 This should be avoided as it can cause confusion about the actual variable being used in an expression.
 </p>
 

--- a/cpp/ql/src/jsf/4.15 Declarations and Definitions/AV Rule 140.qhelp
+++ b/cpp/ql/src/jsf/4.15 Declarations and Definitions/AV Rule 140.qhelp
@@ -5,8 +5,12 @@
 
 
 <overview>
+
+<!-- Mention that this rule may not be applicable in projects that don't follow the JSF standard. -->
+<include src="cpp/jsfNote.qhelp" />
+
 <p>
-This rule finds variables with the <code>register</code> storage class specifier. Modern compilers are now capable of
+This query highlights variables with the <code>register</code> storage class specifier. Modern compilers are now capable of
 optimal register placement, and overriding it could lead to worse performance.
 </p>
 

--- a/cpp/ql/src/jsf/4.17 Types/AV Rule 147.qhelp
+++ b/cpp/ql/src/jsf/4.17 Types/AV Rule 147.qhelp
@@ -5,8 +5,12 @@
 
 
 <overview>
+
+<!-- Mention that this rule may not be applicable in projects that don't follow the JSF standard. -->
+<include src="cpp/jsfNote.qhelp" />
+
 <p>
-This rule finds portions of code that can expose the floating point implementation of the underlying
+This query highlights portions of code that can expose the floating point implementation of the underlying
 machine. Manually manipulating the bits in the float is prone to mistakes and is unportable. Floating point
 implementations can vary across architectures, and bit-field packing can differ across compilers,
 making manual bit-manipulation of floats inadvisable.

--- a/cpp/ql/src/jsf/4.18 Constants/AV Rule 151.1.qhelp
+++ b/cpp/ql/src/jsf/4.18 Constants/AV Rule 151.1.qhelp
@@ -5,8 +5,12 @@
 
 
 <overview>
+
+<!-- Mention that this rule may not be applicable in projects that don't follow the JSF standard. -->
+<include src="cpp/jsfNote.qhelp" />
+
 <p>
-This rule finds string literals that are assigned to a non-<code>const</code> variable. String literals
+This query highlights string literals that are assigned to a non-<code>const</code> variable. String literals
 should not be changed, since they are usually stored in the data section, and depending on the architecture, 
 writing to the data section will cause undefined behavior, such as memory corruption or memory write error.
 </p>

--- a/cpp/ql/src/jsf/4.20 Unions and Bit Fields/AV Rule 154.qhelp
+++ b/cpp/ql/src/jsf/4.20 Unions and Bit Fields/AV Rule 154.qhelp
@@ -5,6 +5,10 @@
 
 
 <overview>
+
+<!-- Mention that this rule may not be applicable in projects that don't follow the JSF standard. -->
+<include src="cpp/jsfNote.qhelp" />
+
 <p>
 This rule finds bit fields with members that are not explicitly declared to be unsigned.
 The sign of plain char, short, int, or long bit field is implementation-specific, and declaring

--- a/cpp/ql/src/jsf/4.21 Operators/AV Rule 165.qhelp
+++ b/cpp/ql/src/jsf/4.21 Operators/AV Rule 165.qhelp
@@ -5,8 +5,12 @@
 
 
 <overview>
+
+<!-- Mention that this rule may not be applicable in projects that don't follow the JSF standard. -->
+<include src="cpp/jsfNote.qhelp" />
+
 <p>
-This rule finds unsigned values that are being negated. Behavior is undefined in such cases.
+This query finds unsigned values that are being negated. Behavior is undefined in such cases.
 Negating integer values produces the two's complement of that number, which cannot represent negative
 values of large unsigned values (values where the sign bit is used) and are most likely to be interpreted 
 as a smaller positive integer instead.

--- a/cpp/ql/src/jsf/4.24 Control Flow Structures/AV Rule 189.qhelp
+++ b/cpp/ql/src/jsf/4.24 Control Flow Structures/AV Rule 189.qhelp
@@ -4,6 +4,10 @@
 <qhelp>
 
 <overview>
+
+<!-- Mention that this rule may not be applicable in projects that don't follow the JSF standard. -->
+<include src="cpp/jsfNote.qhelp" />
+
 <p>Use of goto statements makes code more difficult to understand and maintain. Consequently, the use 
 of goto statements is deprecated except as a mechanism for breaking out of multiple nested loops. 
 This rule identifies any goto statements that are called directly or from a single nested loop as violations.</p>


### PR DESCRIPTION
This PR adds a note to the qhelp for some of the JSF queries. It also removes an inaccurate comment from one query.

This depends on 29081 being merged.