### PR TITLE
TS: do more work in parallel

### DIFF
--- a/javascript/extractor/src/com/semmle/js/extractor/AutoBuild.java
+++ b/javascript/extractor/src/com/semmle/js/extractor/AutoBuild.java
@@ -503,10 +503,7 @@ public class AutoBuild {
 					typeScriptFiles.add(sourcePath.toFile());
 				}
 			}
-			tsParser.prepareFiles(typeScriptFiles);
-			for (File file : typeScriptFiles) {
-				extract(extractor, file.toPath());
-			}
+			extractTypeScriptFiles(typeScriptFiles, extractedFiles, extractor);
 			tsParser.closeProject(projectFile);
 		}
 
@@ -524,13 +521,7 @@ public class AutoBuild {
 			}
 		}
 		if (!remainingTypeScriptFiles.isEmpty()) {
-			tsParser.prepareFiles(remainingTypeScriptFiles);
-			for (File f : remainingTypeScriptFiles) {
-				Path path = f.toPath();
-				if (extractedFiles.add(path)) {
-					extract(extractor, path);
-				}
-			}
+			extractTypeScriptFiles(remainingTypeScriptFiles, extractedFiles, extractor);
 		}
 
 		// The TypeScript compiler instance is no longer needed.
@@ -550,6 +541,16 @@ public class AutoBuild {
 	 */
 	public void verifyTypeScriptInstallation() {
 		extractorState.getTypeScriptParser().verifyInstallation(true);
+	}
+
+	public void extractTypeScriptFiles(List<File> files, Set<Path> extractedFiles, FileExtractor extractor) throws IOException {
+		extractorState.getTypeScriptParser().prepareFiles(files);
+		for (File f : files) {
+			Path path = f.toPath();
+			if (extractedFiles.add(path)) {
+				extract(extractor, f.toPath());
+			}
+		}
 	}
 
 	private Path normalizePath(Path path) {

--- a/javascript/extractor/src/com/semmle/js/extractor/AutoBuild.java
+++ b/javascript/extractor/src/com/semmle/js/extractor/AutoBuild.java
@@ -499,7 +499,7 @@ public class AutoBuild {
 				Path sourcePath = sourceFile.toPath();
 				if (!filesToExtract.contains(normalizePath(sourcePath)))
 					continue;
-				if (extractedFiles.add(sourcePath)) {
+				if (!extractedFiles.contains(sourcePath)) {
 					typeScriptFiles.add(sourcePath.toFile());
 				}
 			}
@@ -547,9 +547,8 @@ public class AutoBuild {
 		extractorState.getTypeScriptParser().prepareFiles(files);
 		for (File f : files) {
 			Path path = f.toPath();
-			if (extractedFiles.add(path)) {
-				extract(extractor, f.toPath());
-			}
+			extractedFiles.add(path);
+			extract(extractor, f.toPath());
 		}
 	}
 

--- a/javascript/extractor/src/com/semmle/js/extractor/Main.java
+++ b/javascript/extractor/src/com/semmle/js/extractor/Main.java
@@ -2,7 +2,9 @@ package com.semmle.js.extractor;
 
 import java.io.File;
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.LinkedHashSet;
+import java.util.List;
 import java.util.Set;
 import java.util.regex.Pattern;
 
@@ -140,15 +142,21 @@ public class Main {
 			tsParser.verifyInstallation(!ap.has(P_QUIET));
 		}
 		for (File projectFile : projectFiles) {
+
 			long start = verboseLogStartTimer(ap, "Opening project " + projectFile);
 			ParsedProject project = tsParser.openProject(projectFile);
 			verboseLogEndTimer(ap, start);
 			// Extract all files belonging to this project which are also matched
 			// by our include/exclude filters.
+			List<File> filesToExtract = new ArrayList<>();
 			for (File sourceFile : project.getSourceFiles()) {
-				if (files.contains(normalizeFile(sourceFile))) {
-					ensureFileIsExtracted(sourceFile, ap);
+				if (files.contains(normalizeFile(sourceFile)) && !extractedFiles.contains(sourceFile.getAbsoluteFile())) {
+					filesToExtract.add(sourceFile);
 				}
+			}
+			tsParser.prepareFiles(filesToExtract);
+			for (int i = 0; i < filesToExtract.size(); ++i) {
+				ensureFileIsExtracted(filesToExtract.get(i), ap);
 			}
 			// Close the project to free memory. This does not need to be in a `finally` as
 			// the project is not a system resource.
@@ -159,13 +167,26 @@ public class Main {
 			// Extract all the types discovered when extracting the ASTs.
 			TypeTable typeTable = tsParser.getTypeTable();
 			extractTypeTable(projectFiles.iterator().next(), typeTable);
+		}
 
-			// The TypeScript compiler instance is no longer needed - free up some memory.
-			if (hasSharedExtractorState) {
-				tsParser.reset(); // This is called from a test runner, so keep the process alive.
-			} else {
-				tsParser.killProcess();
+		List<File> remainingTypescriptFiles = new ArrayList<>();
+		for (File f : files) {
+			if (!extractedFiles.contains(f.getAbsoluteFile()) && FileType.forFileExtension(f) == FileType.TYPESCRIPT) {
+				remainingTypescriptFiles.add(f);
 			}
+		}
+		if (!remainingTypescriptFiles.isEmpty()) {
+			tsParser.prepareFiles(remainingTypescriptFiles);
+			for (File f : remainingTypescriptFiles) {
+				ensureFileIsExtracted(f, ap);
+			}
+		}
+
+		// The TypeScript compiler instance is no longer needed - free up some memory.
+		if (hasSharedExtractorState) {
+			tsParser.reset(); // This is called from a test runner, so keep the process alive.
+		} else {
+			tsParser.killProcess();
 		}
 
 		// Extract files that were not part of a project.

--- a/javascript/extractor/src/com/semmle/js/extractor/test/AutoBuildTests.java
+++ b/javascript/extractor/src/com/semmle/js/extractor/test/AutoBuildTests.java
@@ -1,5 +1,6 @@
 package com.semmle.js.extractor.test;
 
+import java.io.File;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
@@ -99,6 +100,13 @@ public class AutoBuildTests {
 
 				@Override
 				public void verifyTypeScriptInstallation() {
+				}
+
+				@Override
+				public void extractTypeScriptFiles(List<File> files, Set<Path> extractedFiles, FileExtractor extractor) throws IOException {
+					for (File f : files) {
+						actual.add(f.toString());
+					}
 				}
 			}.run();
 			String expectedString = StringUtil.glue("\n", expected.stream().sorted().toArray());

--- a/javascript/extractor/src/com/semmle/js/parser/TypeScriptParser.java
+++ b/javascript/extractor/src/com/semmle/js/parser/TypeScriptParser.java
@@ -293,6 +293,25 @@ public class TypeScriptParser {
 	}
 
 	/**
+	 * Informs the parser process that the following files are going to be
+	 * requested, in that order.
+	 * <p>
+	 * The parser process uses this list to start work on the next file before it is
+	 * requested.
+	 */
+	public void prepareFiles(List<File> files) {
+		JsonObject request = new JsonObject();
+		request.add("command", new JsonPrimitive("prepare-files"));
+		JsonArray filenames = new JsonArray();
+		for (File file : files) {
+			filenames.add(new JsonPrimitive(file.getAbsolutePath()));
+		}
+		request.add("filenames", filenames);
+		JsonObject response = talkToParserWrapper(request);
+		checkResponseType(response, "ok");
+	}
+
+	/**
 	 * Opens a new project based on a tsconfig.json file. The compiler will analyze
 	 * all files in the project.
 	 * <p>


### PR DESCRIPTION
This PR speeds up TypeScript extraction by making the Java process and Node.js process do more work in parallel.

When the Node.js process has sent an AST, it immediately starts to work on the next AST while the Java process is processing the first one. In order for the Node.js process knows which file to work on next, a list of files to work on is sent in advance using the new `prepare-files` command.

In principle the Node.js process could prepare more than one file in advance, but then we risk being busy when the Java process is ready to receive the next file, delaying overall extraction. So it only looks one file ahead.

Extraction-time benchmarks:

| Project       | Before   | After    |    Difference |
|--------|----------|----------|---------------|
| **vscode**
| Basic  | 133s     | 114s     |  19s  (14%)   |
| Full   | 259s     | 211s     |  48s  (19%)   |
| **TypeScript**   
| Basic  | 48s      | 41s      |  7s   (15%)   |
| Full   | 466s     | 455s     |  11s  (2%)    |
| **Angular**
| Basic  | 153s     | 138s     |  15s (10%)    |
| Full   | 295s     | 235s     |  60s (20%)    |

The full-mode extraction for TypeScript itself is a bit of an outlier, but I'll look into that separately.