### PR TITLE
CPP: Work on OffsetUseBeforeRangeCheck.ql

### DIFF
--- a/change-notes/1.19/analysis-cpp.md
+++ b/change-notes/1.19/analysis-cpp.md
@@ -15,6 +15,7 @@
 
 | **Query**                  | **Expected impact**    | **Change**                                                       |
 |----------------------------|------------------------|------------------------------------------------------------------|
+| Array offset used before range check | More results and fewer false positive results | The query now recognizes array accesses in different positions within the expression.  False positives where the range is checked before and after the array access have been fixed. |
 | Empty branch of conditional | Fewer false positive results | The query now recognizes commented blocks more reliably. |
 | Expression has no effect | Fewer false positive results | Expressions in template instantiations are now excluded from this query. |
 | Resource not released in destructor | Fewer false positive results | Placement new is now excluded from the query. Also fixed an issue where false positives could occur if the destructor body was not in the snapshot. |

--- a/cpp/ql/src/Best Practices/Likely Errors/OffsetUseBeforeRangeCheck.ql
+++ b/cpp/ql/src/Best Practices/Likely Errors/OffsetUseBeforeRangeCheck.ql
@@ -5,6 +5,7 @@
  * @kind problem
  * @id cpp/offset-use-before-range-check
  * @problem.severity warning
+ * @precision medium
  * @tags reliability
  *       security
  *       external/cwe/cwe-120

--- a/cpp/ql/src/Best Practices/Likely Errors/OffsetUseBeforeRangeCheck.ql
+++ b/cpp/ql/src/Best Practices/Likely Errors/OffsetUseBeforeRangeCheck.ql
@@ -13,10 +13,29 @@
 
 import cpp
 
-from Variable v, LogicalAndExpr andexpr, ArrayExpr access, LTExpr rangecheck
-where access.getArrayOffset() = v.getAnAccess()
-  and andexpr.getLeftOperand().getAChild*() = access
-  and andexpr.getRightOperand() = rangecheck
-  and rangecheck.getLeftOperand() = v.getAnAccess()
-  and not access.isInMacroExpansion()
+predicate beforeArrayAccess(Variable v, ArrayExpr access, Expr before) {
+  exists(LogicalAndExpr andexpr |
+    access.getArrayOffset() = v.getAnAccess() and
+    andexpr.getRightOperand().getAChild*() = access and
+    andexpr.getLeftOperand() = before
+  )
+}
+
+predicate afterArrayAccess(Variable v, ArrayExpr access, Expr after) {
+  exists(LogicalAndExpr andexpr |
+    access.getArrayOffset() = v.getAnAccess() and
+    andexpr.getLeftOperand().getAChild*() = access and
+    andexpr.getRightOperand() = after
+  )
+}
+
+from Variable v, ArrayExpr access, LTExpr rangecheck
+where
+  afterArrayAccess(v, access, rangecheck) and
+  rangecheck.getLeftOperand() = v.getAnAccess() and
+  not access.isInMacroExpansion() and
+  not exists(LTExpr altcheck |
+    beforeArrayAccess(v, access, altcheck) and
+    altcheck.getLeftOperand() = v.getAnAccess()
+  )
 select access, "This use of offset '" + v.getName() + "' should follow the $@.", rangecheck, "range check"

--- a/cpp/ql/src/Best Practices/Likely Errors/OffsetUseBeforeRangeCheck.ql
+++ b/cpp/ql/src/Best Practices/Likely Errors/OffsetUseBeforeRangeCheck.ql
@@ -15,7 +15,7 @@ import cpp
 
 from Variable v, LogicalAndExpr andexpr, ArrayExpr access, LTExpr rangecheck
 where access.getArrayOffset() = v.getAnAccess()
-  and andexpr.getLeftOperand().getAChild() = access
+  and andexpr.getLeftOperand().getAChild*() = access
   and andexpr.getRightOperand() = rangecheck
   and rangecheck.getLeftOperand() = v.getAnAccess()
   and not access.isInMacroExpansion()

--- a/cpp/ql/test/query-tests/Best Practices/Likely Errors/OffsetUseBeforeRangeCheck/OffsetUseBeforeRangeCheck.expected
+++ b/cpp/ql/test/query-tests/Best Practices/Likely Errors/OffsetUseBeforeRangeCheck/OffsetUseBeforeRangeCheck.expected
@@ -1,10 +1,6 @@
 | test.cpp:11:10:11:18 | access to array | This use of offset 'i' should follow the $@. | test.cpp:11:32:11:45 | ... < ... | range check |
 | test.cpp:15:7:15:15 | access to array | This use of offset 'i' should follow the $@. | test.cpp:15:29:15:42 | ... < ... | range check |
 | test.cpp:27:7:27:15 | access to array | This use of offset 'i' should follow the $@. | test.cpp:27:39:27:52 | ... < ... | range check |
-| test.cpp:32:27:32:35 | access to array | This use of offset 'i' should follow the $@. | test.cpp:32:49:32:66 | ... < ... | range check |
-| test.cpp:33:28:33:36 | access to array | This use of offset 'i' should follow the $@. | test.cpp:33:50:33:67 | ... < ... | range check |
-| test.cpp:34:31:34:39 | access to array | This use of offset 'i' should follow the $@. | test.cpp:34:53:34:66 | ... < ... | range check |
-| test.cpp:35:32:35:40 | access to array | This use of offset 'i' should follow the $@. | test.cpp:35:54:35:67 | ... < ... | range check |
 | test.cpp:39:8:39:16 | access to array | This use of offset 'i' should follow the $@. | test.cpp:39:30:39:47 | ... < ... | range check |
 | test.cpp:44:7:44:15 | access to array | This use of offset 'i' should follow the $@. | test.cpp:44:22:44:35 | ... < ... | range check |
 | test.cpp:47:7:47:15 | access to array | This use of offset 'i' should follow the $@. | test.cpp:47:33:47:46 | ... < ... | range check |

--- a/cpp/ql/test/query-tests/Best Practices/Likely Errors/OffsetUseBeforeRangeCheck/OffsetUseBeforeRangeCheck.expected
+++ b/cpp/ql/test/query-tests/Best Practices/Likely Errors/OffsetUseBeforeRangeCheck/OffsetUseBeforeRangeCheck.expected
@@ -1,5 +1,10 @@
 | test.cpp:11:10:11:18 | access to array | This use of offset 'i' should follow the $@. | test.cpp:11:32:11:45 | ... < ... | range check |
 | test.cpp:15:7:15:15 | access to array | This use of offset 'i' should follow the $@. | test.cpp:15:29:15:42 | ... < ... | range check |
+| test.cpp:27:7:27:15 | access to array | This use of offset 'i' should follow the $@. | test.cpp:27:39:27:52 | ... < ... | range check |
+| test.cpp:32:27:32:35 | access to array | This use of offset 'i' should follow the $@. | test.cpp:32:49:32:66 | ... < ... | range check |
 | test.cpp:33:28:33:36 | access to array | This use of offset 'i' should follow the $@. | test.cpp:33:50:33:67 | ... < ... | range check |
+| test.cpp:34:31:34:39 | access to array | This use of offset 'i' should follow the $@. | test.cpp:34:53:34:66 | ... < ... | range check |
 | test.cpp:35:32:35:40 | access to array | This use of offset 'i' should follow the $@. | test.cpp:35:54:35:67 | ... < ... | range check |
 | test.cpp:39:8:39:16 | access to array | This use of offset 'i' should follow the $@. | test.cpp:39:30:39:47 | ... < ... | range check |
+| test.cpp:44:7:44:15 | access to array | This use of offset 'i' should follow the $@. | test.cpp:44:22:44:35 | ... < ... | range check |
+| test.cpp:47:7:47:15 | access to array | This use of offset 'i' should follow the $@. | test.cpp:47:33:47:46 | ... < ... | range check |

--- a/cpp/ql/test/query-tests/Best Practices/Likely Errors/OffsetUseBeforeRangeCheck/OffsetUseBeforeRangeCheck.expected
+++ b/cpp/ql/test/query-tests/Best Practices/Likely Errors/OffsetUseBeforeRangeCheck/OffsetUseBeforeRangeCheck.expected
@@ -1,0 +1,5 @@
+| test.cpp:11:10:11:18 | access to array | This use of offset 'i' should follow the $@. | test.cpp:11:32:11:45 | ... < ... | range check |
+| test.cpp:15:7:15:15 | access to array | This use of offset 'i' should follow the $@. | test.cpp:15:29:15:42 | ... < ... | range check |
+| test.cpp:33:28:33:36 | access to array | This use of offset 'i' should follow the $@. | test.cpp:33:50:33:67 | ... < ... | range check |
+| test.cpp:35:32:35:40 | access to array | This use of offset 'i' should follow the $@. | test.cpp:35:54:35:67 | ... < ... | range check |
+| test.cpp:39:8:39:16 | access to array | This use of offset 'i' should follow the $@. | test.cpp:39:30:39:47 | ... < ... | range check |

--- a/cpp/ql/test/query-tests/Best Practices/Likely Errors/OffsetUseBeforeRangeCheck/OffsetUseBeforeRangeCheck.qlref
+++ b/cpp/ql/test/query-tests/Best Practices/Likely Errors/OffsetUseBeforeRangeCheck/OffsetUseBeforeRangeCheck.qlref
@@ -1,0 +1,1 @@
+Best Practices/Likely Errors/OffsetUseBeforeRangeCheck.ql

--- a/cpp/ql/test/query-tests/Best Practices/Likely Errors/OffsetUseBeforeRangeCheck/test.cpp
+++ b/cpp/ql/test/query-tests/Best Practices/Likely Errors/OffsetUseBeforeRangeCheck/test.cpp
@@ -1,0 +1,50 @@
+
+void test(char *buffer, int bufferSize)
+{
+	int i;
+
+	// skip whitespace
+	i = 0;
+	while ((i < bufferSize) && (buffer[i] == ' ')) { i++; } // GOOD
+
+	i = 0;
+	while ((buffer[i] == ' ') && (i < bufferSize)) { i++; } // BAD
+
+	// check for 'x'
+	if ((i < bufferSize) && (buffer[i] == 'x')) {} // GOOD
+	if ((buffer[i] == 'x') && (i < bufferSize)) {} // BAD
+
+	if ((bufferSize > i) && (buffer[i] == 'x')) {} // GOOD
+	if ((buffer[i] == 'x') && (bufferSize > i)) {} // BAD [NOT DETECTED]
+
+	if ((i <= bufferSize - 1) && (buffer[i] == 'x')) {} // GOOD
+	if ((buffer[i] == 'x') && (i <= bufferSize - 1)) {} // BAD [NOT DETECTED]
+
+	if ((bufferSize >= i + 1) && (buffer[i] == 'x')) {} // GOOD
+	if ((buffer[i] == 'x') && (bufferSize >= i + 1)) {} // BAD [NOT DETECTED]
+
+	if ((i < bufferSize) && (true) && (buffer[i] == 'x')) {} // GOOD
+	if ((buffer[i] == 'x') && (true) && (i < bufferSize)) {} // BAD [NOT DETECTED]
+
+	if ((i < bufferSize - 1) && (buffer[i + 1] == 'x')) {} // GOOD
+	if ((buffer[i + 1] == 'x') && (i < bufferSize - 1)) {} // BAD [NOT DETECTED]
+
+	if ((i < bufferSize) && (buffer[i] == 'x') && (i < bufferSize - 1)) {} // GOOD
+	if ((i < bufferSize) && ((buffer[i] == 'x') && (i < bufferSize - 1))) {} // GOOD [FALSE POSITIVE]
+	if ((i < bufferSize + 1) && (buffer[i] == 'x') && (i < bufferSize)) {} // BAD [NOT DETECTED]
+	if ((i < bufferSize + 1) && ((buffer[i] == 'x') && (i < bufferSize))) {} // BAD
+
+	// look for 'ab'
+	for (i = 0; i < bufferSize; i++) {
+		if ((buffer[i] == 'a') && (i < bufferSize - 1) && (buffer[i + 1] == 'b')) // GOOD [FALSE POSITIVE]
+			break;
+	}
+
+	if ((i < bufferSize) && (buffer[i])) {} // GOOD
+	if ((buffer[i]) && (i < bufferSize)) {} // BAD [NOT DETECTED]
+
+	if ((i < bufferSize) && (buffer[i] + 1 == 'x')) {} // GOOD
+	if ((buffer[i] + 1 == 'x') && (i < bufferSize)) {} // BAD [NOT DETECTED]
+
+	if ((buffer != 0) && (i < bufferSize)) {} // GOOD
+}

--- a/cpp/ql/test/query-tests/Best Practices/Likely Errors/OffsetUseBeforeRangeCheck/test.cpp
+++ b/cpp/ql/test/query-tests/Best Practices/Likely Errors/OffsetUseBeforeRangeCheck/test.cpp
@@ -29,10 +29,10 @@ void test(char *buffer, int bufferSize)
 	if ((i < bufferSize - 1) && (buffer[i + 1] == 'x')) {} // GOOD
 	if ((buffer[i + 1] == 'x') && (i < bufferSize - 1)) {} // BAD [NOT DETECTED]
 
-	if ((i < bufferSize) && (buffer[i] == 'x') && (i < bufferSize - 1)) {} // GOOD [FALSE POSITIVE]
-	if ((i < bufferSize) && ((buffer[i] == 'x') && (i < bufferSize - 1))) {} // GOOD [FALSE POSITIVE]
-	if ((i < bufferSize + 1) && (buffer[i] == 'x') && (i < bufferSize)) {} // BAD
-	if ((i < bufferSize + 1) && ((buffer[i] == 'x') && (i < bufferSize))) {} // BAD
+	if ((i < bufferSize) && (buffer[i] == 'x') && (i < bufferSize - 1)) {} // GOOD
+	if ((i < bufferSize) && ((buffer[i] == 'x') && (i < bufferSize - 1))) {} // GOOD
+	if ((i < bufferSize + 1) && (buffer[i] == 'x') && (i < bufferSize)) {} // BAD [NOT DETECTED]
+	if ((i < bufferSize + 1) && ((buffer[i] == 'x') && (i < bufferSize))) {} // BAD [NOT DETECTED]
 
 	// look for 'ab'
 	for (i = 0; i < bufferSize; i++) {

--- a/cpp/ql/test/query-tests/Best Practices/Likely Errors/OffsetUseBeforeRangeCheck/test.cpp
+++ b/cpp/ql/test/query-tests/Best Practices/Likely Errors/OffsetUseBeforeRangeCheck/test.cpp
@@ -24,14 +24,14 @@ void test(char *buffer, int bufferSize)
 	if ((buffer[i] == 'x') && (bufferSize >= i + 1)) {} // BAD [NOT DETECTED]
 
 	if ((i < bufferSize) && (true) && (buffer[i] == 'x')) {} // GOOD
-	if ((buffer[i] == 'x') && (true) && (i < bufferSize)) {} // BAD [NOT DETECTED]
+	if ((buffer[i] == 'x') && (true) && (i < bufferSize)) {} // BAD
 
 	if ((i < bufferSize - 1) && (buffer[i + 1] == 'x')) {} // GOOD
 	if ((buffer[i + 1] == 'x') && (i < bufferSize - 1)) {} // BAD [NOT DETECTED]
 
-	if ((i < bufferSize) && (buffer[i] == 'x') && (i < bufferSize - 1)) {} // GOOD
+	if ((i < bufferSize) && (buffer[i] == 'x') && (i < bufferSize - 1)) {} // GOOD [FALSE POSITIVE]
 	if ((i < bufferSize) && ((buffer[i] == 'x') && (i < bufferSize - 1))) {} // GOOD [FALSE POSITIVE]
-	if ((i < bufferSize + 1) && (buffer[i] == 'x') && (i < bufferSize)) {} // BAD [NOT DETECTED]
+	if ((i < bufferSize + 1) && (buffer[i] == 'x') && (i < bufferSize)) {} // BAD
 	if ((i < bufferSize + 1) && ((buffer[i] == 'x') && (i < bufferSize))) {} // BAD
 
 	// look for 'ab'
@@ -41,10 +41,10 @@ void test(char *buffer, int bufferSize)
 	}
 
 	if ((i < bufferSize) && (buffer[i])) {} // GOOD
-	if ((buffer[i]) && (i < bufferSize)) {} // BAD [NOT DETECTED]
+	if ((buffer[i]) && (i < bufferSize)) {} // BAD
 
 	if ((i < bufferSize) && (buffer[i] + 1 == 'x')) {} // GOOD
-	if ((buffer[i] + 1 == 'x') && (i < bufferSize)) {} // BAD [NOT DETECTED]
+	if ((buffer[i] + 1 == 'x') && (i < bufferSize)) {} // BAD
 
 	if ((buffer != 0) && (i < bufferSize)) {} // GOOD
 }


### PR DESCRIPTION
@aibaars pointed out that this query is prominently used by a customer, but lacks a `severity` tag.  I tried the query on some projects and found that it ran quickly and usually gave zero or a small number of results, that were generally interesting.  However a high number turned out to be false positives (for example due to the query not understanding the difference between a check against buffer size and a check against the length of a terminated string or buffer, which may be OK in the 'wrong' place in most cases), though I personally would respond to most of these results by fixing the code, to improve clarity and robustness if not to fix an actual overflow bug in every case.

This PR:
 - adds a test (the query does have minimal coverage in two 'CWE-119' tests, but in both cases it actually has no expected results)
 - fixes an issue where results were missing if the array access was buried more (or less) deeply in the expression than the query expected
 - fixes an issue where accesses were flagged if the range is checked before *and* after the expression
 - gives the query a `severity` of `medium` (it will be run, but not displayed by default, on LGTM).

There's a lot more we could do to improve this query in future.