### PR TITLE
CPP: Fix 'Missing return statement'

### DIFF
--- a/cpp/ql/src/jsf/4.13 Functions/AV Rule 114.ql
+++ b/cpp/ql/src/jsf/4.13 Functions/AV Rule 114.ql
@@ -38,6 +38,8 @@ predicate functionImperfectlyExtracted(Function f) {
   exists(CompilerError e | f.getBlock().getLocation().subsumes(e.getLocation()))
   or
   exists(ErrorExpr ee | ee.getEnclosingFunction() = f)
+  or
+  count(f.getType()) > 1
 }
 
 from Stmt stmt, string msg, Function f, ControlFlowNode blame

--- a/cpp/ql/test/query-tests/jsf/4.13 Functions/AV Rule 114/AV Rule 114.expected
+++ b/cpp/ql/test/query-tests/jsf/4.13 Functions/AV Rule 114/AV Rule 114.expected
@@ -1,6 +1,8 @@
 | test.c:8:5:8:14 | declaration | Function f2 should return a value of type int but does not return a value here |
 | test.c:25:9:25:14 | ExprStmt | Function f4 should return a value of type int but does not return a value here |
 | test.c:39:9:39:14 | ExprStmt | Function f6 should return a value of type int but does not return a value here |
+| test.c:95:2:95:20 | if (...) ...  | Function f13_func should return a value of type int but does not return a value here |
+| test.c:95:2:95:20 | if (...) ...  | Function f13_func should return a value of type void but does not return a value here |
 | test.cpp:16:1:18:1 | { ... } | Function g2 should return a value of type MyValue but does not return a value here |
 | test.cpp:48:2:48:26 | if (...) ...  | Function g7 should return a value of type MyValue but does not return a value here |
 | test.cpp:74:1:76:1 | { ... } | Function g10 should return a value of type second but does not return a value here |

--- a/cpp/ql/test/query-tests/jsf/4.13 Functions/AV Rule 114/AV Rule 114.expected
+++ b/cpp/ql/test/query-tests/jsf/4.13 Functions/AV Rule 114/AV Rule 114.expected
@@ -1,8 +1,6 @@
 | test.c:8:5:8:14 | declaration | Function f2 should return a value of type int but does not return a value here |
 | test.c:25:9:25:14 | ExprStmt | Function f4 should return a value of type int but does not return a value here |
 | test.c:39:9:39:14 | ExprStmt | Function f6 should return a value of type int but does not return a value here |
-| test.c:95:2:95:20 | if (...) ...  | Function f13_func should return a value of type int but does not return a value here |
-| test.c:95:2:95:20 | if (...) ...  | Function f13_func should return a value of type void but does not return a value here |
 | test.cpp:16:1:18:1 | { ... } | Function g2 should return a value of type MyValue but does not return a value here |
 | test.cpp:48:2:48:26 | if (...) ...  | Function g7 should return a value of type MyValue but does not return a value here |
 | test.cpp:74:1:76:1 | { ... } | Function g10 should return a value of type second but does not return a value here |

--- a/cpp/ql/test/query-tests/jsf/4.13 Functions/AV Rule 114/test.c
+++ b/cpp/ql/test/query-tests/jsf/4.13 Functions/AV Rule 114/test.c
@@ -92,5 +92,5 @@ void f13()
 
 void f13_func(int x)
 {
-	if (x < 10) return; // GOOD [FALSE POSITIVE]
+	if (x < 10) return; // GOOD
 }

--- a/cpp/ql/test/query-tests/jsf/4.13 Functions/AV Rule 114/test.c
+++ b/cpp/ql/test/query-tests/jsf/4.13 Functions/AV Rule 114/test.c
@@ -84,3 +84,13 @@ int f12(int x)
         // ...
     }
 }
+
+void f13()
+{
+	f13_func(); // implicitly declared here
+}
+
+void f13_func(int x)
+{
+	if (x < 10) return; // GOOD [FALSE POSITIVE]
+}


### PR DESCRIPTION
We've noticed curious results from "Missing return statement" (AV Rule 114.ql) recently where there are multiple results on functions with `void` return types (that really shouldn't be reported by this query).  For example:
	- boost 'output.c' line 31 (https://jenkins.internal.semmle.com/job/Build-Snapshot/job/boost/)
	- jdku8 'p11_util.c' line 241
	- powerDNS https://lgtm.com/projects/g/PowerDNS/pdns/rev/pr-df4d3165025fea0596de157837ac0c477b323f21

It turns out these functions have been extracted with multiple return types, typically `int` due to an implicitly declared use of the function before a proper `void` declaration is encountered.  This PR adds a test and a simple solution to exclude such functions.

@ian-semmle  what *should* the extractor be doing with code such as the new test case?