### PR TITLE
JS: support "xyz:nomunge" YUI compressor directives

### DIFF
--- a/change-notes/1.19/analysis-javascript.md
+++ b/change-notes/1.19/analysis-javascript.md
@@ -51,6 +51,7 @@
 | Server-side URL redirect | More results | This rule now recognizes redirection calls in more cases. |
 | Unbound event handler receiver | Fewer false-positive results | This rule now recognizes additional ways class methods can be bound. |
 | Uncontrolled data used in remote request | More results | This rule now recognizes additional kinds of requests. |
+| Unknown directive | Fewer false positives results | This rule now recognizes YUI compressor directives. |
 | Unused import | Fewer false-positive results | This rule no longer flags imports used by the `transform-react-jsx` Babel plugin. |
 | Unused variable, import, function or class | Fewer false-positive results | This rule now flags fewer variables that may be used by `eval` calls. |
 | Unused variable, import, function or class | Fewer results | This rule now flags import statements with multiple unused imports once. |

--- a/javascript/ql/src/semmle/javascript/Stmt.qll
+++ b/javascript/ql/src/semmle/javascript/Stmt.qll
@@ -224,6 +224,12 @@ class NgInjectDirective extends KnownDirective {
   NgInjectDirective() { getDirectiveText().regexpMatch("ng(No)?Inject") }
 }
 
+/** A YUI compressor directive. */
+class YuiDirective extends KnownDirective {
+  YuiDirective() {
+    getDirectiveText().regexpMatch("([a-z0-9_]+:nomunge, ?)*([a-z0-9_]+:nomunge)")
+  }
+}
 
 /** A SystemJS `deps` directive. */
 class SystemJSDepsDirective extends KnownDirective {

--- a/javascript/ql/test/query-tests/Expressions/UnknownDirective/UnknownDirective.expected
+++ b/javascript/ql/test/query-tests/Expressions/UnknownDirective/UnknownDirective.expected
@@ -13,3 +13,5 @@
 | UnknownDirective.js:14:5:14:14 | "use bar"; | Unknown directive: 'use bar'. |
 | UnknownDirective.js:38:5:38:17 | "[0, 0, 0];"; | Unknown directive: '[0, 0, 0];'. |
 | UnknownDirective.js:39:5:39:65 | "[0, 0, ... , 0];"; | Unknown directive: '[0, 0, 0, 0, 0, 0, 0 ... (truncated)'. |
+| UnknownDirective.js:45:5:45:15 | ":nomunge"; | Unknown directive: ':nomunge'. |
+| UnknownDirective.js:46:5:46:30 | "foo(), ... munge"; | Unknown directive: 'foo(), bar, baz:nomu ... (truncated)'. |

--- a/javascript/ql/test/query-tests/Expressions/UnknownDirective/UnknownDirective.js
+++ b/javascript/ql/test/query-tests/Expressions/UnknownDirective/UnknownDirective.js
@@ -38,3 +38,10 @@ function data() {
     "[0, 0, 0];"; // NOT OK
     "[0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0];"; // NOT OK
 }
+
+function yui() {
+    "foo:nomunge"; // OK
+    "bar:nomunge, baz:nomunge,qux:nomunge"; // OK
+    ":nomunge"; // NOT OK
+    "foo(), bar, baz:nomunge"; // NOT OK
+}


### PR DESCRIPTION
Recognize  `"foo:nomunge"`-directives to prevent false positives like these:

https://lgtm.com/projects/g/cowboy/jquery-misc/alerts?rule=js%2Funknown-directive&mode=tree&ruleFocus=1505884426079