### PR TITLE
C++: Remove @precision from AV Rule 78

### DIFF
--- a/cpp/ql/src/jsf/4.10 Classes/AV Rule 78.ql
+++ b/cpp/ql/src/jsf/4.10 Classes/AV Rule 78.ql
@@ -3,7 +3,6 @@
  * @description All base classes with a virtual function should define a virtual destructor. If an application attempts to delete a derived class object through a base class pointer, the result is undefined if the base class destructor is non-virtual.
  * @kind problem
  * @problem.severity warning
- * @precision high
  * @id cpp/jsf/av-rule-78
  * @tags reliability
  *       readability


### PR DESCRIPTION
This rule, named "No virtual destructor", was supposed to be superseded by `cpp/virtual-destructor` in #408, but that PR didn't actually disable this rule, so both rules are now active in the LGTM suite.

This PR disables the rule by removing `@precision`. We're still discussing the best way to disable rules that are precise and valid but not universally applicable. For now, removing `@precision` is consistent with how we're keeping most other JSF queries from appearing on LGTM.