### PR TITLE
JavaScript: Make `TargetBlank` only highlight the first line of the link.

### DIFF
--- a/javascript/ql/src/DOM/TargetBlank.ql
+++ b/javascript/ql/src/DOM/TargetBlank.ql
@@ -13,6 +13,7 @@
 
 import javascript
 import semmle.javascript.frameworks.Templating
+import semmle.javascript.RestrictedLocations
 
 /**
  * Holds if the href attribute contains a host that we cannot determine statically.
@@ -53,4 +54,4 @@ where // `e` is a link that opens in a new browsing context (that is, it has `ta
       not exists (DOM::AttributeDefinition attr | attr = e.getAnAttribute() |
         not exists(attr.getName())
       )
-select e, "External links without noopener/noreferrer are a potential security risk."
+select (FirstLineOf)e, "External links without noopener/noreferrer are a potential security risk."

--- a/javascript/ql/test/query-tests/DOM/TargetBlank/TargetBlank.expected
+++ b/javascript/ql/test/query-tests/DOM/TargetBlank/TargetBlank.expected
@@ -1,3 +1,6 @@
+| tst.html:23:1:23:61 | <a>...</> | External links without noopener/noreferrer are a potential security risk. |
+| tst.html:24:1:24:48 | <a>...</> | External links without noopener/noreferrer are a potential security risk. |
+| tst.html:25:1:25:36 | <a>...</> | External links without noopener/noreferrer are a potential security risk. |
 | tst.js:18:1:18:43 | <a href ... ple</a> | External links without noopener/noreferrer are a potential security risk. |
 | tst.js:19:1:19:58 | <a href ... ple</a> | External links without noopener/noreferrer are a potential security risk. |
 | tst.js:20:1:20:51 | <a data ... ple</a> | External links without noopener/noreferrer are a potential security risk. |

--- a/javascript/ql/test/query-tests/DOM/TargetBlank/tst.html
+++ b/javascript/ql/test/query-tests/DOM/TargetBlank/tst.html
@@ -14,10 +14,17 @@
 <a href="http://example.com" target="_blank" rel="nopoener">Example</a>
 <a data-ng-href="https://example.com" target="_blank">Example</a>
 
-<h1>NOT OK, because of dynamic URL</h1>
+<h1>OK, because of constant prefix</h1>
 <a href="http://example.com/{{X}}" target="_blank">Example</a>
 <a href="http://example.com/{{X}}" target="_blank" rel="nopoener">Example</a>
 <a data-ng-href="https://example.com/{{X}}" target="_blank">Example</a>
+
+<h1>NOT OK, because of dynamic URL</h1>
+<a href="http://example.com{{X}}" target="_blank">Example</a>
+<a href="{{target}}" target="_blank">Example</a>
+<a href="{{target}}" target="_blank">
+  Example
+</a>
 
 </body>
 </html>


### PR DESCRIPTION
Otherwise alerts for multi-line `<a>` elements end up looking very red.

I also took the opportunity to improve the tests slightly.