### PR TITLE
Python: Set precision of security queries to 'high'

### DIFF
--- a/python/ql/src/Security/CWE-022/PathInjection.ql
+++ b/python/ql/src/Security/CWE-022/PathInjection.ql
@@ -4,7 +4,7 @@
  * @kind problem
  * @problem.severity error
  * @sub-severity high
- * @precision medium
+ * @precision high
  * @id py/path-injection
  * @tags correctness
  *       security

--- a/python/ql/src/Security/CWE-078/CommandInjection.ql
+++ b/python/ql/src/Security/CWE-078/CommandInjection.ql
@@ -5,7 +5,7 @@
  * @kind problem
  * @problem.severity error
  * @sub-severity high
- * @precision medium
+ * @precision high
  * @id py/command-line-injection
  * @tags correctness
  *       security

--- a/python/ql/src/Security/CWE-079/ReflectedXss.ql
+++ b/python/ql/src/Security/CWE-079/ReflectedXss.ql
@@ -5,7 +5,7 @@
  * @kind problem
  * @problem.severity error
  * @sub-severity high
- * @precision medium
+ * @precision high
  * @id py/reflective-xss
  * @tags security
  *       external/cwe/cwe-079

--- a/python/ql/src/Security/CWE-089/SqlInjection.ql
+++ b/python/ql/src/Security/CWE-089/SqlInjection.ql
@@ -4,7 +4,7 @@
  *              malicious SQL code by the user.
  * @kind problem
  * @problem.severity error
- * @precision medium
+ * @precision high
  * @id py/sql-injection
  * @tags security
  *       external/cwe/cwe-089

--- a/python/ql/src/Security/CWE-094/CodeInjection.ql
+++ b/python/ql/src/Security/CWE-094/CodeInjection.ql
@@ -5,7 +5,7 @@
  * @kind problem
  * @problem.severity error
  * @sub-severity high
- * @precision medium
+ * @precision high
  * @id py/code-injection
  * @tags security
  *       external/owasp/owasp-a1

--- a/python/ql/src/Security/CWE-327/BrokenCryptoAlgorithm.ql
+++ b/python/ql/src/Security/CWE-327/BrokenCryptoAlgorithm.ql
@@ -3,7 +3,7 @@
  * @description Using broken or weak cryptographic algorithms can compromise security.
  * @kind problem
  * @problem.severity warning
- * @precision medium
+ * @precision high
  * @id py/weak-cryptographic-algorithm
  * @tags security
  *       external/cwe/cwe-327

--- a/python/ql/src/Security/CWE-502/UnsafeDeserialization.ql
+++ b/python/ql/src/Security/CWE-502/UnsafeDeserialization.ql
@@ -5,7 +5,7 @@
  * @id py/unsafe-deserialization
  * @problem.severity error
  * @sub-severity high
- * @precision medium
+ * @precision high
  * @tags external/cwe/cwe-502
  *       security
  *       serialization


### PR DESCRIPTION
Make sure that the given precision reflects the actual precision, and that users can see the alerts from these queries.