### PR TITLE
Only check for mismatched (de)alloc in C++

### DIFF
--- a/cpp/ql/src/Critical/NewArrayDeleteMismatch.ql
+++ b/cpp/ql/src/Critical/NewArrayDeleteMismatch.ql
@@ -9,8 +9,9 @@
  */
 import NewDelete
 
-from Expr alloc, Expr free, Expr freed
+from File f, Expr alloc, Expr free, Expr freed
 where
+  f.compiledAsCpp() and
   allocReaches(freed, alloc, "new[]") and
   freeExprOrIndirect(free, freed, "delete")
 select

--- a/cpp/ql/src/Critical/NewDeleteArrayMismatch.ql
+++ b/cpp/ql/src/Critical/NewDeleteArrayMismatch.ql
@@ -9,8 +9,9 @@
  */
 import NewDelete
 
-from Expr alloc, Expr free, Expr freed
+from File f, Expr alloc, Expr free, Expr freed
 where
+  f.compiledAsCpp() and
   allocReaches(freed, alloc, "new") and
   freeExprOrIndirect(free, freed, "delete[]")
 select

--- a/cpp/ql/src/Critical/NewFreeMismatch.ql
+++ b/cpp/ql/src/Critical/NewFreeMismatch.ql
@@ -26,9 +26,10 @@ predicate correspondingKinds(string allocKind, string freeKind) {
 }
 
 from
-  Expr alloc, string allocKind, string allocKindSimple,
+  File f, Expr alloc, string allocKind, string allocKindSimple,
   Expr free, Expr freed, string freeKind, string freeKindSimple
 where
+  f.compiledAsCpp() and
   allocReaches(freed, alloc, allocKind) and
   freeExprOrIndirect(free, freed, freeKind) and
   allocKindSimple = allocKind.replaceAll("[]", "") and


### PR DESCRIPTION
C++ can use any of `{*alloc,new,new[]}`, each of which requires matching
deallocator. C, on the other hand, can only use `*alloc` to allocate and
all of the pointers obtained such way are disposed of with `free`.
Therefore it should not be needed to run the check on C code.

Note: the statement above dismisses existence of such functions as
`VirtualAlloc`, `mmap`, `sbrk`, etc., but they were not part of this
check anyway.