### PR TITLE
JS: classify files with many short variables as minified

### DIFF
--- a/javascript/ql/src/semmle/javascript/AST.qll
+++ b/javascript/ql/src/semmle/javascript/AST.qll
@@ -141,6 +141,10 @@ class TopLevel extends @toplevel, StmtContainer {
       // and there are at least ten statements overall
       numstmt >= 10
     )
+    or
+    // many variables, and they all have short names
+    count (VarDecl d | d.getTopLevel() = this) > 100 and
+    forall (VarDecl d | d.getTopLevel() = this | d.getName().length() <= 2)
   }
 
   /** Holds if this toplevel is an externs definitions file. */

--- a/javascript/ql/test/query-tests/filters/ClassifyFiles/ClassifyFiles.expected
+++ b/javascript/ql/test/query-tests/filters/ClassifyFiles/ClassifyFiles.expected
@@ -27,6 +27,7 @@
 | polymer.html:0:0:0:0 | polymer.html | template |
 | purs-bundle.js:0:0:0:0 | purs-bundle.js | generated |
 | purs.js:0:0:0:0 | purs.js | generated |
+| short-variables.js:0:0:0:0 | short-variables.js | generated |
 | some-template.html:0:0:0:0 | some-template.html | template |
 | templ.js:0:0:0:0 | templ.js | template |
 | textmate.html:0:0:0:0 | textmate.html | generated |

--- a/javascript/ql/test/query-tests/filters/ClassifyFiles/short-variables.js
+++ b/javascript/ql/test/query-tests/filters/ClassifyFiles/short-variables.js
@@ -1,0 +1,162 @@
+(function() {
+    var a;
+});
+(function() {
+    var a, b;
+});
+(function() {
+    var a, b, c;
+});
+(function() {
+    var a;
+});
+(function() {
+    var a, b;
+});
+(function() {
+    var a, b, c;
+});
+(function() {
+    var a;
+});
+(function() {
+    var a, b;
+});
+(function() {
+    var a, b, c;
+});
+(function() {
+    var a;
+});
+(function() {
+    var a, b;
+});
+(function() {
+    var a, b, c;
+});
+(function() {
+    var a;
+});
+(function() {
+    var a, b;
+});
+(function() {
+    var a, b, c;
+});
+(function() {
+    var a;
+});
+(function() {
+    var a, b;
+});
+(function() {
+    var a, b, c;
+});
+(function() {
+    var a;
+});
+(function() {
+    var a, b;
+});
+(function() {
+    var a, b, c;
+});
+(function() {
+    var a;
+});
+(function() {
+    var a, b;
+});
+(function() {
+    var a, b, c;
+});
+(function() {
+    var a;
+});
+(function() {
+    var a, b;
+});
+(function() {
+    var a, b, c;
+});
+(function() {
+    var a;
+});
+(function() {
+    var a, b;
+});
+(function() {
+    var a, b, c;
+});
+(function() {
+    var a;
+});
+(function() {
+    var a, b;
+});
+(function() {
+    var a, b, c;
+});
+(function() {
+    var a;
+});
+(function() {
+    var a, b;
+});
+(function() {
+    var a, b, c;
+});
+(function() {
+    var a;
+});
+(function() {
+    var a, b;
+});
+(function() {
+    var a, b, c;
+});
+(function() {
+    var a;
+});
+(function() {
+    var a, b;
+});
+(function() {
+    var a, b, c;
+});
+(function() {
+    var a;
+});
+(function() {
+    var a, b;
+});
+(function() {
+    var a, b, c;
+});
+(function() {
+    var a;
+});
+(function() {
+    var a, b;
+});
+(function() {
+    var a, b, c;
+});
+(function() {
+    var a;
+});
+(function() {
+    var a, b;
+});
+(function() {
+    var a, b, c;
+});
+(function() {
+    var a;
+});
+(function() {
+    var a, b;
+});
+(function() {
+    var a, b, c;
+});


### PR DESCRIPTION
The recent discussions of minified files motivated me to dig this one up.

This change classifies toplevels with many variables, which are all short, as minified.

The definition of "many" and "short" are debatable. But I have not observed any false positives for the proposed `many = ">100"` and `short = "length <= 2"`.

See the following query console examples here:

-   <https://lgtm.com/query/1506718038365/>
-   <https://lgtm.com/query/1506720407221/>

I am open to changing the definitions or abandoning the change completely if it seems too dangerous.

[Performance](https://git.semmle.com/esben/dist-compare-reports/tree/js/classify-minified-by-variable-names_1542720502181) is unchanged.