### PR TITLE
C++: Deprecate queries using VCS.qll

### DIFF
--- a/cpp/ql/src/Metrics/History/HChurn.ql
+++ b/cpp/ql/src/Metrics/History/HChurn.ql
@@ -7,6 +7,7 @@
  * @treemap.warnOn highValues
  * @metricType file
  * @metricAggregate avg sum max
+ * @deprecated
  */
 import cpp
 import external.VCS

--- a/cpp/ql/src/Metrics/History/HLinesAdded.ql
+++ b/cpp/ql/src/Metrics/History/HLinesAdded.ql
@@ -7,6 +7,7 @@
  * @treemap.warnOn highValues
  * @metricType file
  * @metricAggregate avg sum max
+ * @deprecated
  */
 import cpp
 import external.VCS

--- a/cpp/ql/src/Metrics/History/HLinesDeleted.ql
+++ b/cpp/ql/src/Metrics/History/HLinesDeleted.ql
@@ -7,6 +7,7 @@
  * @treemap.warnOn highValues
  * @metricType file
  * @metricAggregate avg sum max
+ * @deprecated
  */
 import cpp
 import external.VCS

--- a/cpp/ql/src/Metrics/History/HNumberOfAuthors.ql
+++ b/cpp/ql/src/Metrics/History/HNumberOfAuthors.ql
@@ -6,6 +6,7 @@
  * @treemap.warnOn highValues
  * @metricType file
  * @metricAggregate avg min max
+ * @deprecated
  */
 import cpp
 import external.VCS

--- a/cpp/ql/src/Metrics/History/HNumberOfChanges.ql
+++ b/cpp/ql/src/Metrics/History/HNumberOfChanges.ql
@@ -7,6 +7,7 @@
  * @treemap.warnOn highValues
  * @metricType file
  * @metricAggregate avg min max sum
+ * @deprecated
  */
 import cpp
 import external.VCS

--- a/cpp/ql/src/Metrics/History/HNumberOfCoCommits.ql
+++ b/cpp/ql/src/Metrics/History/HNumberOfCoCommits.ql
@@ -7,6 +7,7 @@
  * @treemap.warnOn highValues
  * @metricType file
  * @metricAggregate avg min max
+ * @deprecated
  */
 import cpp
 import external.VCS

--- a/cpp/ql/src/Metrics/History/HNumberOfReCommits.ql
+++ b/cpp/ql/src/Metrics/History/HNumberOfReCommits.ql
@@ -7,6 +7,7 @@
  * @treemap.warnOn highValues
  * @metricType file
  * @metricAggregate avg min max
+ * @deprecated
  */
 import cpp
 import external.VCS

--- a/cpp/ql/src/Metrics/History/HNumberOfRecentAuthors.ql
+++ b/cpp/ql/src/Metrics/History/HNumberOfRecentAuthors.ql
@@ -7,6 +7,7 @@
  * @treemap.warnOn highValues
  * @metricType file
  * @metricAggregate avg min max
+ * @deprecated
  */
 import cpp
 import external.VCS

--- a/cpp/ql/src/Metrics/History/HNumberOfRecentChangedFiles.ql
+++ b/cpp/ql/src/Metrics/History/HNumberOfRecentChangedFiles.ql
@@ -6,6 +6,7 @@
  * @treemap.warnOn highValues
  * @metricType file
  * @metricAggregate avg min max sum
+ * @deprecated
  */
 import cpp
 import external.VCS

--- a/cpp/ql/src/Metrics/History/HNumberOfRecentChanges.ql
+++ b/cpp/ql/src/Metrics/History/HNumberOfRecentChanges.ql
@@ -6,6 +6,7 @@
  * @treemap.warnOn highValues
  * @metricType file
  * @metricAggregate avg min max sum
+ * @deprecated
  */
 import cpp
 import external.VCS

--- a/cpp/ql/src/external/tests/DefectFilter.ql
+++ b/cpp/ql/src/external/tests/DefectFilter.ql
@@ -4,7 +4,6 @@
  */
 import cpp
 import external.DefectFilter
-import external.VCS
 
 from DefectResult res
 where res.getFile().getMetrics().getNumberOfLinesOfCode() > 200

--- a/cpp/ql/src/external/tests/DefectFromSVN.ql
+++ b/cpp/ql/src/external/tests/DefectFromSVN.ql
@@ -3,6 +3,7 @@
  * @description A test case for creating a defect from SVN data.
  * @kind problem
  * @problem.severity warning
+ * @deprecated
  */
 
 import cpp

--- a/cpp/ql/src/external/tests/MetricFromSVN.ql
+++ b/cpp/ql/src/external/tests/MetricFromSVN.ql
@@ -3,6 +3,7 @@
  * @description Find number of commits for a file
  * @treemap.warnOn lowValues
  * @metricType file
+ * @deprecated
  */
 
 import cpp

--- a/cpp/ql/src/filters/RecentDefects.ql
+++ b/cpp/ql/src/filters/RecentDefects.ql
@@ -6,6 +6,7 @@
  *              before the date of the snapshot.
  * @kind problem
  * @id cpp/recent-defects-filter
+ * @deprecated
  */
 import cpp
 import external.DefectFilter

--- a/cpp/ql/src/filters/RecentDefectsForMetric.ql
+++ b/cpp/ql/src/filters/RecentDefectsForMetric.ql
@@ -6,6 +6,7 @@
  *              before the snapshot.
  * @kind treemap
  * @id cpp/recent-defects-for-metric-filter
+ * @deprecated
  */
 import cpp
 import external.MetricFilter


### PR DESCRIPTION
These are all the files I could find with `git grep 'import.*VCS'`.

One query imported VCS.qll for no reason, so I removed the import instead of deprecating the query.