### PR TITLE
Java: deprecate queries that use `VCS.qll`

### DIFF
--- a/java/ql/src/Metrics/History/HChurn.ql
+++ b/java/ql/src/Metrics/History/HChurn.ql
@@ -6,6 +6,7 @@
  * @metricType file
  * @metricAggregate avg sum max
  * @id java/vcs/churn-per-file
+ * @deprecated
  */
 
 import java

--- a/java/ql/src/Metrics/History/HLinesAdded.ql
+++ b/java/ql/src/Metrics/History/HLinesAdded.ql
@@ -6,6 +6,7 @@
  * @metricType file
  * @metricAggregate avg sum max
  * @id java/vcs/added-lines-per-file
+ * @deprecated
  */
 
 import java

--- a/java/ql/src/Metrics/History/HLinesDeleted.ql
+++ b/java/ql/src/Metrics/History/HLinesDeleted.ql
@@ -6,6 +6,7 @@
  * @metricType file
  * @metricAggregate avg sum max
  * @id java/vcs/deleted-lines-per-file
+ * @deprecated
  */
 
 import java

--- a/java/ql/src/Metrics/History/HNumberOfAuthors.ql
+++ b/java/ql/src/Metrics/History/HNumberOfAuthors.ql
@@ -6,6 +6,7 @@
  * @metricType file
  * @metricAggregate avg min max
  * @id java/vcs/authors-per-file
+ * @deprecated
  */
 
 import java

--- a/java/ql/src/Metrics/History/HNumberOfChanges.ql
+++ b/java/ql/src/Metrics/History/HNumberOfChanges.ql
@@ -6,6 +6,7 @@
  * @metricType file
  * @metricAggregate avg min max sum
  * @id java/vcs/commits-per-file
+ * @deprecated
  */
 
 import java

--- a/java/ql/src/Metrics/History/HNumberOfRecentChanges.ql
+++ b/java/ql/src/Metrics/History/HNumberOfRecentChanges.ql
@@ -6,6 +6,7 @@
  * @metricType file
  * @metricAggregate avg min max sum
  * @id java/vcs/recent-commits-per-file
+ * @deprecated
  */
 
 import java

--- a/java/ql/src/filters/RecentDefects.ql
+++ b/java/ql/src/filters/RecentDefects.ql
@@ -3,6 +3,7 @@
  * @description Filter a defect query to only include results in files that have been changed recently, and modify the message.
  * @kind problem
  * @id java/recently-changed-file-filter
+ * @deprecated
  */
 
 import java

--- a/java/ql/src/filters/RecentDefectsForMetric.ql
+++ b/java/ql/src/filters/RecentDefectsForMetric.ql
@@ -3,6 +3,7 @@
  * @description Filter a metric query to only include results in files that have been changed recently, and modify the message.
  * @kind treemap
  * @id java/recently-changed-file-metric-filter
+ * @deprecated
  */
 
 import java


### PR DESCRIPTION
Analogous to #518.