### PR TITLE
C#: Make guards library work with CFG splitting

### DIFF
--- a/csharp/ql/src/semmle/code/csharp/controlflow/ControlFlowElement.qll
+++ b/csharp/ql/src/semmle/code/csharp/controlflow/ControlFlowElement.qll
@@ -1,7 +1,10 @@
 /** Provides the class `ControlFlowElement`. */
 
- import csharp
+import csharp
 private import semmle.code.csharp.ExprOrStmtParent
+private import ControlFlow
+private import ControlFlow::BasicBlocks
+private import SuccessorTypes
 
 /**
  * A program element that can possess control flow. That is, either a statement or
@@ -25,21 +28,21 @@ class ControlFlowElement extends ExprOrStmtParent, @control_flow_element {
    * several `ControlFlow::Node`s, for example to represent the continuation
    * flow in a `try/catch/finally` construction.
    */
-  ControlFlow::Node getAControlFlowNode() {
+  Node getAControlFlowNode() {
     result.getElement() = this
   }
 
   /**
    * Gets a first control flow node executed within this element.
    */
-  ControlFlow::Node getAControlFlowEntryNode() {
+  Node getAControlFlowEntryNode() {
     result = ControlFlowGraph::Internal::getAControlFlowEntryNode(this).getAControlFlowNode()
   }
 
   /**
    * Gets a potential last control flow node executed within this element.
    */
-  ControlFlow::Node getAControlFlowExitNode() {
+  Node getAControlFlowExitNode() {
     result = ControlFlowGraph::Internal::getAControlFlowExitNode(this).getAControlFlowNode()
   }
 
@@ -59,7 +62,7 @@ class ControlFlowElement extends ExprOrStmtParent, @control_flow_element {
   /** Gets an element that is reachable from this element. */
   ControlFlowElement getAReachableElement() {
     // Reachable in same basic block
-    exists(ControlFlow::BasicBlock bb, int i, int j |
+    exists(BasicBlock bb, int i, int j |
       bb.getNode(i) = getAControlFlowNode() and
       bb.getNode(j) = result.getAControlFlowNode() and
       i < j
@@ -67,5 +70,92 @@ class ControlFlowElement extends ExprOrStmtParent, @control_flow_element {
     or
     // Reachable in different basic blocks
     getAControlFlowNode().getBasicBlock().getASuccessor+().getANode() = result.getAControlFlowNode()
+  }
+
+  /**
+   * Holds if basic block `succ` is immediately controlled by this control flow
+   * element with conditional value `s`. That is, `succ` can only be reached from
+   * the callable entry point by going via the `s` edge out of *some* basic block
+   * `pred` ending with this element, and `pred` is an immediate predecessor
+   * of `succ`.
+   *
+   * This predicate is different from
+   * `this.getAControlFlowNode().getBasicBlock().(ConditionBlock).immediatelyControls(succ, s)`
+   * in that it takes control flow splitting into account.
+   */
+  pragma[nomagic]
+  private predicate immediatelyControls(BasicBlock succ, ConditionalSuccessor s) {
+    exists(ConditionBlock cb |
+      cb.getLastNode() = this.getAControlFlowNode() |
+      succ = cb.getASuccessorByType(s) and
+      forall(BasicBlock pred, SuccessorType  t |
+        pred = succ.getAPredecessorByType(t) and pred != cb |
+        succ.dominates(pred)
+        or
+        // `pred` might be another split of `cfe`
+        pred.getLastNode().getElement() = this and
+        pred.getASuccessorByType(t) = succ and
+        t = s
+      )
+    )
+  }
+
+  pragma[nomagic]
+  private JoinBlockPredecessor getAPossiblyControlledPredecessor(JoinBlock controlled, ConditionalSuccessor s) {
+    exists(BasicBlock mid |
+      this.immediatelyControls(mid, s) |
+      result = mid.getASuccessor*()
+    ) and
+    result.getASuccessor() = controlled
+  }
+
+  pragma[nomagic]
+  private predicate isPossiblyControlledJoinBlock(JoinBlock controlled, ConditionalSuccessor s) {
+    exists(this.getAPossiblyControlledPredecessor(controlled, s)) and
+    forall(BasicBlock pred |
+      pred = controlled.getAPredecessor() |
+      pred = this.getAPossiblyControlledPredecessor(controlled, s)
+    )
+  }
+
+  /**
+   * Holds if basic block `controlled` is controlled by this control flow element
+   * with conditional value `s`. That is, `controlled` can only be reached from
+   * the callable entry point by going via the `s` edge out of *some* basic block
+   * ending with this element.
+   *
+   * This predicate is different from
+   * `this.getAControlFlowNode().getBasicBlock().(ConditionBlock).controls(controlled, s)`
+   * in that it takes control flow splitting into account.
+   */
+  cached
+  predicate controlsBlock(BasicBlock controlled, ConditionalSuccessor s) {
+    this.immediatelyControls(controlled, s)
+    or
+    if controlled instanceof JoinBlock then
+      this.isPossiblyControlledJoinBlock(controlled, s) and
+      forall(BasicBlock pred |
+        pred = this.getAPossiblyControlledPredecessor(controlled, s) |
+        this.controlsBlock(pred, s)
+      )
+    else
+      this.controlsBlock(controlled.getAPredecessor(), s)
+  }
+
+  /**
+   * Holds if control flow element `controlled` is controlled by this control flow
+   * element with conditional value `s`. That is, `controlled` can only be reached
+   * from the callable entry point by going via the `s` edge out of this element.
+   *
+   * This predicate is different from
+   * `this.getAControlFlowNode().getBasicBlock().(ConditionBlock).controls(controlled.getAControlFlowNode().getBasicBlock(), s)`
+   * in that it takes control flow splitting into account.
+   */
+  pragma[inline] // potentially very large predicate, so must be inlined
+  predicate controlsElement(ControlFlowElement controlled, ConditionalSuccessor s) {
+    forex(BasicBlock bb |
+      bb = controlled.getAControlFlowNode().getBasicBlock() |
+      this.controlsBlock(bb, s)
+    )
   }
 }

--- a/csharp/ql/src/semmle/code/csharp/controlflow/ControlFlowGraph.qll
+++ b/csharp/ql/src/semmle/code/csharp/controlflow/ControlFlowGraph.qll
@@ -183,7 +183,7 @@ module ControlFlow {
       )
     }
 
-    /** Gets a successor node of a given flow type, if any. */
+    /** Gets a successor node of a given type, if any. */
     Node getASuccessorByType(SuccessorType t) {
       result = getASuccessorByType(this, t)
     }
@@ -372,6 +372,7 @@ module ControlFlow {
     class EntryBlock = BBs::EntryBasicBlock;
     class ExitBlock = BBs::ExitBasicBlock;
     class JoinBlock = BBs::JoinBlock;
+    class JoinBlockPredecessor = BBs::JoinBlockPredecessor;
     class ConditionBlock = BBs::ConditionBlock;
   }
 
@@ -2549,7 +2550,7 @@ module ControlFlow {
           ) > 1
         }
 
-        private predicate isCandidateSuccessor(PreBasicBlock succ, ConditionalCompletion c) {
+        private predicate immediatelyControls(PreBasicBlock succ, ConditionalCompletion c) {
           succ = succ(this.getLastElement(), c) and
           forall(PreBasicBlock pred |
             pred = succ.getAPredecessor() and pred != this |
@@ -2559,7 +2560,7 @@ module ControlFlow {
 
         predicate controls(PreBasicBlock controlled, ConditionalSuccessor s) {
           exists(PreBasicBlock succ, ConditionalCompletion c |
-            isCandidateSuccessor(succ, c) |
+            immediatelyControls(succ, c) |
             succ.dominates(controlled) and
             s.matchesCompletion(c)
           )

--- a/csharp/ql/src/semmle/code/csharp/security/SensitiveActions.qll
+++ b/csharp/ql/src/semmle/code/csharp/security/SensitiveActions.qll
@@ -190,3 +190,10 @@ class SendingMethod extends SensitiveExecutionMethod {
     )
   }
 }
+
+/** A call to a method that sends data, and so should not be run conditionally on user input. */
+class SensitiveExecutionMethodCall extends MethodCall {
+  SensitiveExecutionMethodCall() {
+    this.getTarget() instanceof SensitiveExecutionMethod
+  }
+}

--- a/csharp/ql/test/library-tests/controlflow/guards/BooleanGuardedExpr.expected
+++ b/csharp/ql/test/library-tests/controlflow/guards/BooleanGuardedExpr.expected
@@ -63,39 +63,20 @@
 | Guards.cs:196:31:196:31 | access to parameter s | Guards.cs:195:13:195:27 | call to method NotNullTest4 | Guards.cs:195:26:195:26 | access to parameter s | true |
 | Guards.cs:198:31:198:31 | access to parameter s | Guards.cs:197:14:197:29 | call to method NullTestWrong | Guards.cs:197:28:197:28 | access to parameter s | false |
 | Splitting.cs:13:17:13:17 | access to parameter o | Splitting.cs:12:17:12:25 | ... != ... | Splitting.cs:12:17:12:17 | access to parameter o | true |
-| Splitting.cs:14:13:14:13 | access to parameter b | Splitting.cs:11:13:11:13 | access to parameter b | Splitting.cs:11:13:11:13 | access to parameter b | false |
-| Splitting.cs:14:13:14:13 | access to parameter b | Splitting.cs:11:13:11:13 | access to parameter b | Splitting.cs:11:13:11:13 | access to parameter b | true |
 | Splitting.cs:23:24:23:24 | access to parameter o | Splitting.cs:22:17:22:25 | ... != ... | Splitting.cs:22:17:22:17 | access to parameter o | true |
-| Splitting.cs:24:13:24:13 | access to parameter b | Splitting.cs:21:13:21:13 | access to parameter b | Splitting.cs:21:13:21:13 | access to parameter b | false |
-| Splitting.cs:24:13:24:13 | access to parameter b | Splitting.cs:21:13:21:13 | access to parameter b | Splitting.cs:21:13:21:13 | access to parameter b | true |
 | Splitting.cs:25:13:25:13 | access to parameter o | Splitting.cs:22:17:22:25 | ... != ... | Splitting.cs:22:17:22:17 | access to parameter o | false |
-| Splitting.cs:34:13:34:13 | access to parameter b | Splitting.cs:31:13:31:13 | access to parameter b | Splitting.cs:31:13:31:13 | access to parameter b | false |
-| Splitting.cs:34:13:34:13 | access to parameter b | Splitting.cs:31:13:31:13 | access to parameter b | Splitting.cs:31:13:31:13 | access to parameter b | true |
 | Splitting.cs:35:13:35:13 | access to parameter o | Splitting.cs:32:17:32:25 | ... == ... | Splitting.cs:32:17:32:17 | access to parameter o | false |
 | Splitting.cs:44:17:44:17 | access to parameter o | Splitting.cs:41:13:41:21 | ... != ... | Splitting.cs:41:13:41:13 | access to parameter o | true |
-| Splitting.cs:45:17:45:17 | access to parameter b | Splitting.cs:43:17:43:17 | access to parameter b | Splitting.cs:43:17:43:17 | access to parameter b | false |
-| Splitting.cs:45:17:45:17 | access to parameter b | Splitting.cs:43:17:43:17 | access to parameter b | Splitting.cs:43:17:43:17 | access to parameter b | true |
 | Splitting.cs:46:17:46:17 | access to parameter o | Splitting.cs:41:13:41:21 | ... != ... | Splitting.cs:41:13:41:13 | access to parameter o | true |
 | Splitting.cs:55:13:55:13 | access to parameter o | Splitting.cs:54:13:54:21 | ... != ... | Splitting.cs:54:13:54:13 | access to parameter o | true |
-| Splitting.cs:56:13:56:13 | access to parameter b | Splitting.cs:52:13:52:13 | access to parameter b | Splitting.cs:52:13:52:13 | access to parameter b | false |
-| Splitting.cs:56:13:56:13 | access to parameter b | Splitting.cs:52:13:52:13 | access to parameter b | Splitting.cs:52:13:52:13 | access to parameter b | true |
-| Splitting.cs:67:13:67:13 | access to parameter b | Splitting.cs:63:13:63:13 | access to parameter b | Splitting.cs:63:13:63:13 | access to parameter b | false |
-| Splitting.cs:67:13:67:13 | access to parameter b | Splitting.cs:63:13:63:13 | access to parameter b | Splitting.cs:63:13:63:13 | access to parameter b | true |
+| Splitting.cs:66:20:66:20 | access to parameter o | Splitting.cs:65:13:65:21 | ... != ... | Splitting.cs:65:13:65:13 | access to parameter o | true |
 | Splitting.cs:68:13:68:13 | access to parameter o | Splitting.cs:65:13:65:21 | ... != ... | Splitting.cs:65:13:65:13 | access to parameter o | false |
-| Splitting.cs:79:13:79:13 | access to parameter b | Splitting.cs:74:13:74:13 | access to parameter b | Splitting.cs:74:13:74:13 | access to parameter b | false |
-| Splitting.cs:79:13:79:13 | access to parameter b | Splitting.cs:74:13:74:13 | access to parameter b | Splitting.cs:74:13:74:13 | access to parameter b | true |
-| Splitting.cs:88:9:88:9 | access to parameter o | Splitting.cs:87:26:87:34 | ... != ... | Splitting.cs:87:26:87:26 | access to parameter o | true |
-| Splitting.cs:89:13:89:13 | access to parameter b | Splitting.cs:86:13:86:13 | access to parameter b | Splitting.cs:86:13:86:13 | access to parameter b | false |
-| Splitting.cs:89:13:89:13 | access to parameter b | Splitting.cs:86:13:86:13 | access to parameter b | Splitting.cs:86:13:86:13 | access to parameter b | true |
+| Splitting.cs:69:16:69:16 | access to parameter o | Splitting.cs:65:13:65:21 | ... != ... | Splitting.cs:65:13:65:13 | access to parameter o | false |
+| Splitting.cs:78:24:78:24 | access to parameter o | Splitting.cs:76:13:76:21 | ... != ... | Splitting.cs:76:13:76:13 | access to parameter o | true |
 | Splitting.cs:90:13:90:13 | access to parameter o | Splitting.cs:87:26:87:34 | ... != ... | Splitting.cs:87:26:87:26 | access to parameter o | true |
-| Splitting.cs:98:13:98:13 | access to parameter b | Splitting.cs:96:13:96:13 | access to parameter b | Splitting.cs:96:13:96:13 | access to parameter b | false |
-| Splitting.cs:98:13:98:13 | access to parameter b | Splitting.cs:96:13:96:13 | access to parameter b | Splitting.cs:96:13:96:13 | access to parameter b | true |
 | Splitting.cs:99:13:99:13 | access to parameter o | Splitting.cs:97:26:97:34 | ... == ... | Splitting.cs:97:26:97:26 | access to parameter o | true |
 | Splitting.cs:107:13:107:13 | access to parameter o | Splitting.cs:105:22:105:30 | ... != ... | Splitting.cs:105:22:105:22 | access to parameter o | true |
-| Splitting.cs:108:13:108:13 | access to parameter b | Splitting.cs:106:13:106:13 | access to parameter b | Splitting.cs:106:13:106:13 | access to parameter b | false |
-| Splitting.cs:108:13:108:13 | access to parameter b | Splitting.cs:106:13:106:13 | access to parameter b | Splitting.cs:106:13:106:13 | access to parameter b | true |
 | Splitting.cs:109:13:109:13 | access to parameter o | Splitting.cs:105:22:105:30 | ... != ... | Splitting.cs:105:22:105:22 | access to parameter o | true |
 | Splitting.cs:117:9:117:9 | access to parameter o | Splitting.cs:116:22:116:30 | ... != ... | Splitting.cs:116:22:116:22 | access to parameter o | true |
-| Splitting.cs:118:13:118:13 | access to parameter b | Splitting.cs:114:13:114:13 | access to parameter b | Splitting.cs:114:13:114:13 | access to parameter b | false |
-| Splitting.cs:118:13:118:13 | access to parameter b | Splitting.cs:114:13:114:13 | access to parameter b | Splitting.cs:114:13:114:13 | access to parameter b | true |
 | Splitting.cs:119:13:119:13 | access to parameter o | Splitting.cs:116:22:116:30 | ... != ... | Splitting.cs:116:22:116:22 | access to parameter o | true |
+| Splitting.cs:120:16:120:16 | access to parameter o | Splitting.cs:116:22:116:30 | ... != ... | Splitting.cs:116:22:116:22 | access to parameter o | true |

--- a/csharp/ql/test/library-tests/controlflow/guards/BooleanGuardedExpr.expected
+++ b/csharp/ql/test/library-tests/controlflow/guards/BooleanGuardedExpr.expected
@@ -62,3 +62,40 @@
 | Guards.cs:194:31:194:31 | access to parameter s | Guards.cs:193:14:193:25 | call to method NullTest3 | Guards.cs:193:24:193:24 | access to parameter s | false |
 | Guards.cs:196:31:196:31 | access to parameter s | Guards.cs:195:13:195:27 | call to method NotNullTest4 | Guards.cs:195:26:195:26 | access to parameter s | true |
 | Guards.cs:198:31:198:31 | access to parameter s | Guards.cs:197:14:197:29 | call to method NullTestWrong | Guards.cs:197:28:197:28 | access to parameter s | false |
+| Splitting.cs:13:17:13:17 | access to parameter o | Splitting.cs:12:17:12:25 | ... != ... | Splitting.cs:12:17:12:17 | access to parameter o | true |
+| Splitting.cs:14:13:14:13 | access to parameter b | Splitting.cs:11:13:11:13 | access to parameter b | Splitting.cs:11:13:11:13 | access to parameter b | false |
+| Splitting.cs:14:13:14:13 | access to parameter b | Splitting.cs:11:13:11:13 | access to parameter b | Splitting.cs:11:13:11:13 | access to parameter b | true |
+| Splitting.cs:23:24:23:24 | access to parameter o | Splitting.cs:22:17:22:25 | ... != ... | Splitting.cs:22:17:22:17 | access to parameter o | true |
+| Splitting.cs:24:13:24:13 | access to parameter b | Splitting.cs:21:13:21:13 | access to parameter b | Splitting.cs:21:13:21:13 | access to parameter b | false |
+| Splitting.cs:24:13:24:13 | access to parameter b | Splitting.cs:21:13:21:13 | access to parameter b | Splitting.cs:21:13:21:13 | access to parameter b | true |
+| Splitting.cs:25:13:25:13 | access to parameter o | Splitting.cs:22:17:22:25 | ... != ... | Splitting.cs:22:17:22:17 | access to parameter o | false |
+| Splitting.cs:34:13:34:13 | access to parameter b | Splitting.cs:31:13:31:13 | access to parameter b | Splitting.cs:31:13:31:13 | access to parameter b | false |
+| Splitting.cs:34:13:34:13 | access to parameter b | Splitting.cs:31:13:31:13 | access to parameter b | Splitting.cs:31:13:31:13 | access to parameter b | true |
+| Splitting.cs:35:13:35:13 | access to parameter o | Splitting.cs:32:17:32:25 | ... == ... | Splitting.cs:32:17:32:17 | access to parameter o | false |
+| Splitting.cs:44:17:44:17 | access to parameter o | Splitting.cs:41:13:41:21 | ... != ... | Splitting.cs:41:13:41:13 | access to parameter o | true |
+| Splitting.cs:45:17:45:17 | access to parameter b | Splitting.cs:43:17:43:17 | access to parameter b | Splitting.cs:43:17:43:17 | access to parameter b | false |
+| Splitting.cs:45:17:45:17 | access to parameter b | Splitting.cs:43:17:43:17 | access to parameter b | Splitting.cs:43:17:43:17 | access to parameter b | true |
+| Splitting.cs:46:17:46:17 | access to parameter o | Splitting.cs:41:13:41:21 | ... != ... | Splitting.cs:41:13:41:13 | access to parameter o | true |
+| Splitting.cs:55:13:55:13 | access to parameter o | Splitting.cs:54:13:54:21 | ... != ... | Splitting.cs:54:13:54:13 | access to parameter o | true |
+| Splitting.cs:56:13:56:13 | access to parameter b | Splitting.cs:52:13:52:13 | access to parameter b | Splitting.cs:52:13:52:13 | access to parameter b | false |
+| Splitting.cs:56:13:56:13 | access to parameter b | Splitting.cs:52:13:52:13 | access to parameter b | Splitting.cs:52:13:52:13 | access to parameter b | true |
+| Splitting.cs:67:13:67:13 | access to parameter b | Splitting.cs:63:13:63:13 | access to parameter b | Splitting.cs:63:13:63:13 | access to parameter b | false |
+| Splitting.cs:67:13:67:13 | access to parameter b | Splitting.cs:63:13:63:13 | access to parameter b | Splitting.cs:63:13:63:13 | access to parameter b | true |
+| Splitting.cs:68:13:68:13 | access to parameter o | Splitting.cs:65:13:65:21 | ... != ... | Splitting.cs:65:13:65:13 | access to parameter o | false |
+| Splitting.cs:79:13:79:13 | access to parameter b | Splitting.cs:74:13:74:13 | access to parameter b | Splitting.cs:74:13:74:13 | access to parameter b | false |
+| Splitting.cs:79:13:79:13 | access to parameter b | Splitting.cs:74:13:74:13 | access to parameter b | Splitting.cs:74:13:74:13 | access to parameter b | true |
+| Splitting.cs:88:9:88:9 | access to parameter o | Splitting.cs:87:26:87:34 | ... != ... | Splitting.cs:87:26:87:26 | access to parameter o | true |
+| Splitting.cs:89:13:89:13 | access to parameter b | Splitting.cs:86:13:86:13 | access to parameter b | Splitting.cs:86:13:86:13 | access to parameter b | false |
+| Splitting.cs:89:13:89:13 | access to parameter b | Splitting.cs:86:13:86:13 | access to parameter b | Splitting.cs:86:13:86:13 | access to parameter b | true |
+| Splitting.cs:90:13:90:13 | access to parameter o | Splitting.cs:87:26:87:34 | ... != ... | Splitting.cs:87:26:87:26 | access to parameter o | true |
+| Splitting.cs:98:13:98:13 | access to parameter b | Splitting.cs:96:13:96:13 | access to parameter b | Splitting.cs:96:13:96:13 | access to parameter b | false |
+| Splitting.cs:98:13:98:13 | access to parameter b | Splitting.cs:96:13:96:13 | access to parameter b | Splitting.cs:96:13:96:13 | access to parameter b | true |
+| Splitting.cs:99:13:99:13 | access to parameter o | Splitting.cs:97:26:97:34 | ... == ... | Splitting.cs:97:26:97:26 | access to parameter o | true |
+| Splitting.cs:107:13:107:13 | access to parameter o | Splitting.cs:105:22:105:30 | ... != ... | Splitting.cs:105:22:105:22 | access to parameter o | true |
+| Splitting.cs:108:13:108:13 | access to parameter b | Splitting.cs:106:13:106:13 | access to parameter b | Splitting.cs:106:13:106:13 | access to parameter b | false |
+| Splitting.cs:108:13:108:13 | access to parameter b | Splitting.cs:106:13:106:13 | access to parameter b | Splitting.cs:106:13:106:13 | access to parameter b | true |
+| Splitting.cs:109:13:109:13 | access to parameter o | Splitting.cs:105:22:105:30 | ... != ... | Splitting.cs:105:22:105:22 | access to parameter o | true |
+| Splitting.cs:117:9:117:9 | access to parameter o | Splitting.cs:116:22:116:30 | ... != ... | Splitting.cs:116:22:116:22 | access to parameter o | true |
+| Splitting.cs:118:13:118:13 | access to parameter b | Splitting.cs:114:13:114:13 | access to parameter b | Splitting.cs:114:13:114:13 | access to parameter b | false |
+| Splitting.cs:118:13:118:13 | access to parameter b | Splitting.cs:114:13:114:13 | access to parameter b | Splitting.cs:114:13:114:13 | access to parameter b | true |
+| Splitting.cs:119:13:119:13 | access to parameter o | Splitting.cs:116:22:116:30 | ... != ... | Splitting.cs:116:22:116:22 | access to parameter o | true |

--- a/csharp/ql/test/library-tests/controlflow/guards/GuardedExpr.expected
+++ b/csharp/ql/test/library-tests/controlflow/guards/GuardedExpr.expected
@@ -157,53 +157,37 @@
 | Guards.cs:198:31:198:31 | access to parameter s | Guards.cs:197:14:197:29 | call to method NullTestWrong | Guards.cs:197:28:197:28 | access to parameter s | false |
 | Splitting.cs:13:17:13:17 | access to parameter o | Splitting.cs:12:17:12:17 | access to parameter o | Splitting.cs:12:17:12:17 | access to parameter o | non-null |
 | Splitting.cs:13:17:13:17 | access to parameter o | Splitting.cs:12:17:12:25 | ... != ... | Splitting.cs:12:17:12:17 | access to parameter o | true |
-| Splitting.cs:14:13:14:13 | access to parameter b | Splitting.cs:11:13:11:13 | access to parameter b | Splitting.cs:11:13:11:13 | access to parameter b | false |
-| Splitting.cs:14:13:14:13 | access to parameter b | Splitting.cs:11:13:11:13 | access to parameter b | Splitting.cs:11:13:11:13 | access to parameter b | true |
 | Splitting.cs:23:24:23:24 | access to parameter o | Splitting.cs:22:17:22:17 | access to parameter o | Splitting.cs:22:17:22:17 | access to parameter o | non-null |
 | Splitting.cs:23:24:23:24 | access to parameter o | Splitting.cs:22:17:22:25 | ... != ... | Splitting.cs:22:17:22:17 | access to parameter o | true |
-| Splitting.cs:24:13:24:13 | access to parameter b | Splitting.cs:21:13:21:13 | access to parameter b | Splitting.cs:21:13:21:13 | access to parameter b | false |
-| Splitting.cs:24:13:24:13 | access to parameter b | Splitting.cs:21:13:21:13 | access to parameter b | Splitting.cs:21:13:21:13 | access to parameter b | true |
 | Splitting.cs:25:13:25:13 | access to parameter o | Splitting.cs:22:17:22:17 | access to parameter o | Splitting.cs:22:17:22:17 | access to parameter o | null |
 | Splitting.cs:25:13:25:13 | access to parameter o | Splitting.cs:22:17:22:25 | ... != ... | Splitting.cs:22:17:22:17 | access to parameter o | false |
-| Splitting.cs:34:13:34:13 | access to parameter b | Splitting.cs:31:13:31:13 | access to parameter b | Splitting.cs:31:13:31:13 | access to parameter b | false |
-| Splitting.cs:34:13:34:13 | access to parameter b | Splitting.cs:31:13:31:13 | access to parameter b | Splitting.cs:31:13:31:13 | access to parameter b | true |
 | Splitting.cs:35:13:35:13 | access to parameter o | Splitting.cs:32:17:32:17 | access to parameter o | Splitting.cs:32:17:32:17 | access to parameter o | non-null |
 | Splitting.cs:35:13:35:13 | access to parameter o | Splitting.cs:32:17:32:25 | ... == ... | Splitting.cs:32:17:32:17 | access to parameter o | false |
 | Splitting.cs:44:17:44:17 | access to parameter o | Splitting.cs:41:13:41:13 | access to parameter o | Splitting.cs:41:13:41:13 | access to parameter o | non-null |
 | Splitting.cs:44:17:44:17 | access to parameter o | Splitting.cs:41:13:41:21 | ... != ... | Splitting.cs:41:13:41:13 | access to parameter o | true |
-| Splitting.cs:45:17:45:17 | access to parameter b | Splitting.cs:43:17:43:17 | access to parameter b | Splitting.cs:43:17:43:17 | access to parameter b | false |
-| Splitting.cs:45:17:45:17 | access to parameter b | Splitting.cs:43:17:43:17 | access to parameter b | Splitting.cs:43:17:43:17 | access to parameter b | true |
 | Splitting.cs:46:17:46:17 | access to parameter o | Splitting.cs:41:13:41:13 | access to parameter o | Splitting.cs:41:13:41:13 | access to parameter o | non-null |
 | Splitting.cs:46:17:46:17 | access to parameter o | Splitting.cs:41:13:41:21 | ... != ... | Splitting.cs:41:13:41:13 | access to parameter o | true |
 | Splitting.cs:55:13:55:13 | access to parameter o | Splitting.cs:54:13:54:13 | access to parameter o | Splitting.cs:54:13:54:13 | access to parameter o | non-null |
 | Splitting.cs:55:13:55:13 | access to parameter o | Splitting.cs:54:13:54:21 | ... != ... | Splitting.cs:54:13:54:13 | access to parameter o | true |
-| Splitting.cs:56:13:56:13 | access to parameter b | Splitting.cs:52:13:52:13 | access to parameter b | Splitting.cs:52:13:52:13 | access to parameter b | false |
-| Splitting.cs:56:13:56:13 | access to parameter b | Splitting.cs:52:13:52:13 | access to parameter b | Splitting.cs:52:13:52:13 | access to parameter b | true |
-| Splitting.cs:67:13:67:13 | access to parameter b | Splitting.cs:63:13:63:13 | access to parameter b | Splitting.cs:63:13:63:13 | access to parameter b | false |
-| Splitting.cs:67:13:67:13 | access to parameter b | Splitting.cs:63:13:63:13 | access to parameter b | Splitting.cs:63:13:63:13 | access to parameter b | true |
+| Splitting.cs:66:20:66:20 | access to parameter o | Splitting.cs:65:13:65:13 | access to parameter o | Splitting.cs:65:13:65:13 | access to parameter o | non-null |
+| Splitting.cs:66:20:66:20 | access to parameter o | Splitting.cs:65:13:65:21 | ... != ... | Splitting.cs:65:13:65:13 | access to parameter o | true |
 | Splitting.cs:68:13:68:13 | access to parameter o | Splitting.cs:65:13:65:13 | access to parameter o | Splitting.cs:65:13:65:13 | access to parameter o | null |
 | Splitting.cs:68:13:68:13 | access to parameter o | Splitting.cs:65:13:65:21 | ... != ... | Splitting.cs:65:13:65:13 | access to parameter o | false |
-| Splitting.cs:79:13:79:13 | access to parameter b | Splitting.cs:74:13:74:13 | access to parameter b | Splitting.cs:74:13:74:13 | access to parameter b | false |
-| Splitting.cs:79:13:79:13 | access to parameter b | Splitting.cs:74:13:74:13 | access to parameter b | Splitting.cs:74:13:74:13 | access to parameter b | true |
-| Splitting.cs:88:9:88:9 | access to parameter o | Splitting.cs:87:26:87:26 | access to parameter o | Splitting.cs:87:26:87:26 | access to parameter o | non-null |
-| Splitting.cs:88:9:88:9 | access to parameter o | Splitting.cs:87:26:87:34 | ... != ... | Splitting.cs:87:26:87:26 | access to parameter o | true |
-| Splitting.cs:89:13:89:13 | access to parameter b | Splitting.cs:86:13:86:13 | access to parameter b | Splitting.cs:86:13:86:13 | access to parameter b | false |
-| Splitting.cs:89:13:89:13 | access to parameter b | Splitting.cs:86:13:86:13 | access to parameter b | Splitting.cs:86:13:86:13 | access to parameter b | true |
+| Splitting.cs:69:16:69:16 | access to parameter o | Splitting.cs:65:13:65:13 | access to parameter o | Splitting.cs:65:13:65:13 | access to parameter o | null |
+| Splitting.cs:69:16:69:16 | access to parameter o | Splitting.cs:65:13:65:21 | ... != ... | Splitting.cs:65:13:65:13 | access to parameter o | false |
+| Splitting.cs:78:24:78:24 | access to parameter o | Splitting.cs:76:13:76:13 | access to parameter o | Splitting.cs:76:13:76:13 | access to parameter o | non-null |
+| Splitting.cs:78:24:78:24 | access to parameter o | Splitting.cs:76:13:76:21 | ... != ... | Splitting.cs:76:13:76:13 | access to parameter o | true |
 | Splitting.cs:90:13:90:13 | access to parameter o | Splitting.cs:87:26:87:26 | access to parameter o | Splitting.cs:87:26:87:26 | access to parameter o | non-null |
 | Splitting.cs:90:13:90:13 | access to parameter o | Splitting.cs:87:26:87:34 | ... != ... | Splitting.cs:87:26:87:26 | access to parameter o | true |
-| Splitting.cs:98:13:98:13 | access to parameter b | Splitting.cs:96:13:96:13 | access to parameter b | Splitting.cs:96:13:96:13 | access to parameter b | false |
-| Splitting.cs:98:13:98:13 | access to parameter b | Splitting.cs:96:13:96:13 | access to parameter b | Splitting.cs:96:13:96:13 | access to parameter b | true |
 | Splitting.cs:99:13:99:13 | access to parameter o | Splitting.cs:97:26:97:26 | access to parameter o | Splitting.cs:97:26:97:26 | access to parameter o | null |
 | Splitting.cs:99:13:99:13 | access to parameter o | Splitting.cs:97:26:97:34 | ... == ... | Splitting.cs:97:26:97:26 | access to parameter o | true |
 | Splitting.cs:107:13:107:13 | access to parameter o | Splitting.cs:105:22:105:22 | access to parameter o | Splitting.cs:105:22:105:22 | access to parameter o | non-null |
 | Splitting.cs:107:13:107:13 | access to parameter o | Splitting.cs:105:22:105:30 | ... != ... | Splitting.cs:105:22:105:22 | access to parameter o | true |
-| Splitting.cs:108:13:108:13 | access to parameter b | Splitting.cs:106:13:106:13 | access to parameter b | Splitting.cs:106:13:106:13 | access to parameter b | false |
-| Splitting.cs:108:13:108:13 | access to parameter b | Splitting.cs:106:13:106:13 | access to parameter b | Splitting.cs:106:13:106:13 | access to parameter b | true |
 | Splitting.cs:109:13:109:13 | access to parameter o | Splitting.cs:105:22:105:22 | access to parameter o | Splitting.cs:105:22:105:22 | access to parameter o | non-null |
 | Splitting.cs:109:13:109:13 | access to parameter o | Splitting.cs:105:22:105:30 | ... != ... | Splitting.cs:105:22:105:22 | access to parameter o | true |
 | Splitting.cs:117:9:117:9 | access to parameter o | Splitting.cs:116:22:116:22 | access to parameter o | Splitting.cs:116:22:116:22 | access to parameter o | non-null |
 | Splitting.cs:117:9:117:9 | access to parameter o | Splitting.cs:116:22:116:30 | ... != ... | Splitting.cs:116:22:116:22 | access to parameter o | true |
-| Splitting.cs:118:13:118:13 | access to parameter b | Splitting.cs:114:13:114:13 | access to parameter b | Splitting.cs:114:13:114:13 | access to parameter b | false |
-| Splitting.cs:118:13:118:13 | access to parameter b | Splitting.cs:114:13:114:13 | access to parameter b | Splitting.cs:114:13:114:13 | access to parameter b | true |
 | Splitting.cs:119:13:119:13 | access to parameter o | Splitting.cs:116:22:116:22 | access to parameter o | Splitting.cs:116:22:116:22 | access to parameter o | non-null |
 | Splitting.cs:119:13:119:13 | access to parameter o | Splitting.cs:116:22:116:30 | ... != ... | Splitting.cs:116:22:116:22 | access to parameter o | true |
+| Splitting.cs:120:16:120:16 | access to parameter o | Splitting.cs:116:22:116:22 | access to parameter o | Splitting.cs:116:22:116:22 | access to parameter o | non-null |
+| Splitting.cs:120:16:120:16 | access to parameter o | Splitting.cs:116:22:116:30 | ... != ... | Splitting.cs:116:22:116:22 | access to parameter o | true |

--- a/csharp/ql/test/library-tests/controlflow/guards/GuardedExpr.expected
+++ b/csharp/ql/test/library-tests/controlflow/guards/GuardedExpr.expected
@@ -155,3 +155,55 @@
 | Guards.cs:196:31:196:31 | access to parameter s | Guards.cs:195:13:195:27 | call to method NotNullTest4 | Guards.cs:195:26:195:26 | access to parameter s | true |
 | Guards.cs:196:31:196:31 | access to parameter s | Guards.cs:195:26:195:26 | access to parameter s | Guards.cs:195:26:195:26 | access to parameter s | non-null |
 | Guards.cs:198:31:198:31 | access to parameter s | Guards.cs:197:14:197:29 | call to method NullTestWrong | Guards.cs:197:28:197:28 | access to parameter s | false |
+| Splitting.cs:13:17:13:17 | access to parameter o | Splitting.cs:12:17:12:17 | access to parameter o | Splitting.cs:12:17:12:17 | access to parameter o | non-null |
+| Splitting.cs:13:17:13:17 | access to parameter o | Splitting.cs:12:17:12:25 | ... != ... | Splitting.cs:12:17:12:17 | access to parameter o | true |
+| Splitting.cs:14:13:14:13 | access to parameter b | Splitting.cs:11:13:11:13 | access to parameter b | Splitting.cs:11:13:11:13 | access to parameter b | false |
+| Splitting.cs:14:13:14:13 | access to parameter b | Splitting.cs:11:13:11:13 | access to parameter b | Splitting.cs:11:13:11:13 | access to parameter b | true |
+| Splitting.cs:23:24:23:24 | access to parameter o | Splitting.cs:22:17:22:17 | access to parameter o | Splitting.cs:22:17:22:17 | access to parameter o | non-null |
+| Splitting.cs:23:24:23:24 | access to parameter o | Splitting.cs:22:17:22:25 | ... != ... | Splitting.cs:22:17:22:17 | access to parameter o | true |
+| Splitting.cs:24:13:24:13 | access to parameter b | Splitting.cs:21:13:21:13 | access to parameter b | Splitting.cs:21:13:21:13 | access to parameter b | false |
+| Splitting.cs:24:13:24:13 | access to parameter b | Splitting.cs:21:13:21:13 | access to parameter b | Splitting.cs:21:13:21:13 | access to parameter b | true |
+| Splitting.cs:25:13:25:13 | access to parameter o | Splitting.cs:22:17:22:17 | access to parameter o | Splitting.cs:22:17:22:17 | access to parameter o | null |
+| Splitting.cs:25:13:25:13 | access to parameter o | Splitting.cs:22:17:22:25 | ... != ... | Splitting.cs:22:17:22:17 | access to parameter o | false |
+| Splitting.cs:34:13:34:13 | access to parameter b | Splitting.cs:31:13:31:13 | access to parameter b | Splitting.cs:31:13:31:13 | access to parameter b | false |
+| Splitting.cs:34:13:34:13 | access to parameter b | Splitting.cs:31:13:31:13 | access to parameter b | Splitting.cs:31:13:31:13 | access to parameter b | true |
+| Splitting.cs:35:13:35:13 | access to parameter o | Splitting.cs:32:17:32:17 | access to parameter o | Splitting.cs:32:17:32:17 | access to parameter o | non-null |
+| Splitting.cs:35:13:35:13 | access to parameter o | Splitting.cs:32:17:32:25 | ... == ... | Splitting.cs:32:17:32:17 | access to parameter o | false |
+| Splitting.cs:44:17:44:17 | access to parameter o | Splitting.cs:41:13:41:13 | access to parameter o | Splitting.cs:41:13:41:13 | access to parameter o | non-null |
+| Splitting.cs:44:17:44:17 | access to parameter o | Splitting.cs:41:13:41:21 | ... != ... | Splitting.cs:41:13:41:13 | access to parameter o | true |
+| Splitting.cs:45:17:45:17 | access to parameter b | Splitting.cs:43:17:43:17 | access to parameter b | Splitting.cs:43:17:43:17 | access to parameter b | false |
+| Splitting.cs:45:17:45:17 | access to parameter b | Splitting.cs:43:17:43:17 | access to parameter b | Splitting.cs:43:17:43:17 | access to parameter b | true |
+| Splitting.cs:46:17:46:17 | access to parameter o | Splitting.cs:41:13:41:13 | access to parameter o | Splitting.cs:41:13:41:13 | access to parameter o | non-null |
+| Splitting.cs:46:17:46:17 | access to parameter o | Splitting.cs:41:13:41:21 | ... != ... | Splitting.cs:41:13:41:13 | access to parameter o | true |
+| Splitting.cs:55:13:55:13 | access to parameter o | Splitting.cs:54:13:54:13 | access to parameter o | Splitting.cs:54:13:54:13 | access to parameter o | non-null |
+| Splitting.cs:55:13:55:13 | access to parameter o | Splitting.cs:54:13:54:21 | ... != ... | Splitting.cs:54:13:54:13 | access to parameter o | true |
+| Splitting.cs:56:13:56:13 | access to parameter b | Splitting.cs:52:13:52:13 | access to parameter b | Splitting.cs:52:13:52:13 | access to parameter b | false |
+| Splitting.cs:56:13:56:13 | access to parameter b | Splitting.cs:52:13:52:13 | access to parameter b | Splitting.cs:52:13:52:13 | access to parameter b | true |
+| Splitting.cs:67:13:67:13 | access to parameter b | Splitting.cs:63:13:63:13 | access to parameter b | Splitting.cs:63:13:63:13 | access to parameter b | false |
+| Splitting.cs:67:13:67:13 | access to parameter b | Splitting.cs:63:13:63:13 | access to parameter b | Splitting.cs:63:13:63:13 | access to parameter b | true |
+| Splitting.cs:68:13:68:13 | access to parameter o | Splitting.cs:65:13:65:13 | access to parameter o | Splitting.cs:65:13:65:13 | access to parameter o | null |
+| Splitting.cs:68:13:68:13 | access to parameter o | Splitting.cs:65:13:65:21 | ... != ... | Splitting.cs:65:13:65:13 | access to parameter o | false |
+| Splitting.cs:79:13:79:13 | access to parameter b | Splitting.cs:74:13:74:13 | access to parameter b | Splitting.cs:74:13:74:13 | access to parameter b | false |
+| Splitting.cs:79:13:79:13 | access to parameter b | Splitting.cs:74:13:74:13 | access to parameter b | Splitting.cs:74:13:74:13 | access to parameter b | true |
+| Splitting.cs:88:9:88:9 | access to parameter o | Splitting.cs:87:26:87:26 | access to parameter o | Splitting.cs:87:26:87:26 | access to parameter o | non-null |
+| Splitting.cs:88:9:88:9 | access to parameter o | Splitting.cs:87:26:87:34 | ... != ... | Splitting.cs:87:26:87:26 | access to parameter o | true |
+| Splitting.cs:89:13:89:13 | access to parameter b | Splitting.cs:86:13:86:13 | access to parameter b | Splitting.cs:86:13:86:13 | access to parameter b | false |
+| Splitting.cs:89:13:89:13 | access to parameter b | Splitting.cs:86:13:86:13 | access to parameter b | Splitting.cs:86:13:86:13 | access to parameter b | true |
+| Splitting.cs:90:13:90:13 | access to parameter o | Splitting.cs:87:26:87:26 | access to parameter o | Splitting.cs:87:26:87:26 | access to parameter o | non-null |
+| Splitting.cs:90:13:90:13 | access to parameter o | Splitting.cs:87:26:87:34 | ... != ... | Splitting.cs:87:26:87:26 | access to parameter o | true |
+| Splitting.cs:98:13:98:13 | access to parameter b | Splitting.cs:96:13:96:13 | access to parameter b | Splitting.cs:96:13:96:13 | access to parameter b | false |
+| Splitting.cs:98:13:98:13 | access to parameter b | Splitting.cs:96:13:96:13 | access to parameter b | Splitting.cs:96:13:96:13 | access to parameter b | true |
+| Splitting.cs:99:13:99:13 | access to parameter o | Splitting.cs:97:26:97:26 | access to parameter o | Splitting.cs:97:26:97:26 | access to parameter o | null |
+| Splitting.cs:99:13:99:13 | access to parameter o | Splitting.cs:97:26:97:34 | ... == ... | Splitting.cs:97:26:97:26 | access to parameter o | true |
+| Splitting.cs:107:13:107:13 | access to parameter o | Splitting.cs:105:22:105:22 | access to parameter o | Splitting.cs:105:22:105:22 | access to parameter o | non-null |
+| Splitting.cs:107:13:107:13 | access to parameter o | Splitting.cs:105:22:105:30 | ... != ... | Splitting.cs:105:22:105:22 | access to parameter o | true |
+| Splitting.cs:108:13:108:13 | access to parameter b | Splitting.cs:106:13:106:13 | access to parameter b | Splitting.cs:106:13:106:13 | access to parameter b | false |
+| Splitting.cs:108:13:108:13 | access to parameter b | Splitting.cs:106:13:106:13 | access to parameter b | Splitting.cs:106:13:106:13 | access to parameter b | true |
+| Splitting.cs:109:13:109:13 | access to parameter o | Splitting.cs:105:22:105:22 | access to parameter o | Splitting.cs:105:22:105:22 | access to parameter o | non-null |
+| Splitting.cs:109:13:109:13 | access to parameter o | Splitting.cs:105:22:105:30 | ... != ... | Splitting.cs:105:22:105:22 | access to parameter o | true |
+| Splitting.cs:117:9:117:9 | access to parameter o | Splitting.cs:116:22:116:22 | access to parameter o | Splitting.cs:116:22:116:22 | access to parameter o | non-null |
+| Splitting.cs:117:9:117:9 | access to parameter o | Splitting.cs:116:22:116:30 | ... != ... | Splitting.cs:116:22:116:22 | access to parameter o | true |
+| Splitting.cs:118:13:118:13 | access to parameter b | Splitting.cs:114:13:114:13 | access to parameter b | Splitting.cs:114:13:114:13 | access to parameter b | false |
+| Splitting.cs:118:13:118:13 | access to parameter b | Splitting.cs:114:13:114:13 | access to parameter b | Splitting.cs:114:13:114:13 | access to parameter b | true |
+| Splitting.cs:119:13:119:13 | access to parameter o | Splitting.cs:116:22:116:22 | access to parameter o | Splitting.cs:116:22:116:22 | access to parameter o | non-null |
+| Splitting.cs:119:13:119:13 | access to parameter o | Splitting.cs:116:22:116:30 | ... != ... | Splitting.cs:116:22:116:22 | access to parameter o | true |

--- a/csharp/ql/test/library-tests/controlflow/guards/Implications.expected
+++ b/csharp/ql/test/library-tests/controlflow/guards/Implications.expected
@@ -200,3 +200,25 @@
 | Guards.cs:195:13:195:27 | call to method NotNullTest4 | true | Guards.cs:195:26:195:26 | access to parameter s | non-null |
 | Guards.cs:197:13:197:29 | !... | false | Guards.cs:197:14:197:29 | call to method NullTestWrong | true |
 | Guards.cs:197:13:197:29 | !... | true | Guards.cs:197:14:197:29 | call to method NullTestWrong | false |
+| Splitting.cs:12:17:12:25 | ... != ... | false | Splitting.cs:12:17:12:17 | access to parameter o | null |
+| Splitting.cs:12:17:12:25 | ... != ... | true | Splitting.cs:12:17:12:17 | access to parameter o | non-null |
+| Splitting.cs:22:17:22:25 | ... != ... | false | Splitting.cs:22:17:22:17 | access to parameter o | null |
+| Splitting.cs:22:17:22:25 | ... != ... | true | Splitting.cs:22:17:22:17 | access to parameter o | non-null |
+| Splitting.cs:32:17:32:25 | ... == ... | false | Splitting.cs:32:17:32:17 | access to parameter o | non-null |
+| Splitting.cs:32:17:32:25 | ... == ... | true | Splitting.cs:32:17:32:17 | access to parameter o | null |
+| Splitting.cs:41:13:41:21 | ... != ... | false | Splitting.cs:41:13:41:13 | access to parameter o | null |
+| Splitting.cs:41:13:41:21 | ... != ... | true | Splitting.cs:41:13:41:13 | access to parameter o | non-null |
+| Splitting.cs:54:13:54:21 | ... != ... | false | Splitting.cs:54:13:54:13 | access to parameter o | null |
+| Splitting.cs:54:13:54:21 | ... != ... | true | Splitting.cs:54:13:54:13 | access to parameter o | non-null |
+| Splitting.cs:65:13:65:21 | ... != ... | false | Splitting.cs:65:13:65:13 | access to parameter o | null |
+| Splitting.cs:65:13:65:21 | ... != ... | true | Splitting.cs:65:13:65:13 | access to parameter o | non-null |
+| Splitting.cs:76:13:76:21 | ... != ... | false | Splitting.cs:76:13:76:13 | access to parameter o | null |
+| Splitting.cs:76:13:76:21 | ... != ... | true | Splitting.cs:76:13:76:13 | access to parameter o | non-null |
+| Splitting.cs:87:26:87:34 | ... != ... | false | Splitting.cs:87:26:87:26 | access to parameter o | null |
+| Splitting.cs:87:26:87:34 | ... != ... | true | Splitting.cs:87:26:87:26 | access to parameter o | non-null |
+| Splitting.cs:97:26:97:34 | ... == ... | false | Splitting.cs:97:26:97:26 | access to parameter o | non-null |
+| Splitting.cs:97:26:97:34 | ... == ... | true | Splitting.cs:97:26:97:26 | access to parameter o | null |
+| Splitting.cs:105:22:105:30 | ... != ... | false | Splitting.cs:105:22:105:22 | access to parameter o | null |
+| Splitting.cs:105:22:105:30 | ... != ... | true | Splitting.cs:105:22:105:22 | access to parameter o | non-null |
+| Splitting.cs:116:22:116:30 | ... != ... | false | Splitting.cs:116:22:116:22 | access to parameter o | null |
+| Splitting.cs:116:22:116:30 | ... != ... | true | Splitting.cs:116:22:116:22 | access to parameter o | non-null |

--- a/csharp/ql/test/library-tests/controlflow/guards/NullGuardedExpr.expected
+++ b/csharp/ql/test/library-tests/controlflow/guards/NullGuardedExpr.expected
@@ -39,3 +39,15 @@
 | Guards.cs:192:31:192:31 | access to parameter s |
 | Guards.cs:194:31:194:31 | access to parameter s |
 | Guards.cs:196:31:196:31 | access to parameter s |
+| Splitting.cs:13:17:13:17 | access to parameter o |
+| Splitting.cs:23:24:23:24 | access to parameter o |
+| Splitting.cs:35:13:35:13 | access to parameter o |
+| Splitting.cs:44:17:44:17 | access to parameter o |
+| Splitting.cs:46:17:46:17 | access to parameter o |
+| Splitting.cs:55:13:55:13 | access to parameter o |
+| Splitting.cs:88:9:88:9 | access to parameter o |
+| Splitting.cs:90:13:90:13 | access to parameter o |
+| Splitting.cs:107:13:107:13 | access to parameter o |
+| Splitting.cs:109:13:109:13 | access to parameter o |
+| Splitting.cs:117:9:117:9 | access to parameter o |
+| Splitting.cs:119:13:119:13 | access to parameter o |

--- a/csharp/ql/test/library-tests/controlflow/guards/NullGuardedExpr.expected
+++ b/csharp/ql/test/library-tests/controlflow/guards/NullGuardedExpr.expected
@@ -45,9 +45,11 @@
 | Splitting.cs:44:17:44:17 | access to parameter o |
 | Splitting.cs:46:17:46:17 | access to parameter o |
 | Splitting.cs:55:13:55:13 | access to parameter o |
-| Splitting.cs:88:9:88:9 | access to parameter o |
+| Splitting.cs:66:20:66:20 | access to parameter o |
+| Splitting.cs:78:24:78:24 | access to parameter o |
 | Splitting.cs:90:13:90:13 | access to parameter o |
 | Splitting.cs:107:13:107:13 | access to parameter o |
 | Splitting.cs:109:13:109:13 | access to parameter o |
 | Splitting.cs:117:9:117:9 | access to parameter o |
 | Splitting.cs:119:13:119:13 | access to parameter o |
+| Splitting.cs:120:16:120:16 | access to parameter o |

--- a/csharp/ql/test/library-tests/controlflow/guards/Splitting.cs
+++ b/csharp/ql/test/library-tests/controlflow/guards/Splitting.cs
@@ -63,10 +63,10 @@ public class Splitting
         if (b)
             o.ToString(); // not null guarded
         if (o != null)
-            return o.ToString(); // null guarded (missing)
+            return o.ToString(); // null guarded
         if (b)
             o.ToString(); // anti-null guarded
-        return o.ToString(); // anti-null guarded (missing)
+        return o.ToString(); // anti-null guarded
     }
 
     string M7(bool b, object o, bool b2)
@@ -75,7 +75,7 @@ public class Splitting
             o.ToString(); // not null guarded
         if (o != null)
             if (b2)
-                return o.ToString(); // null guarded (missing)
+                return o.ToString(); // null guarded
         if (b)
             o.ToString(); // not null guarded
         return o.ToString(); // not null guarded
@@ -85,7 +85,7 @@ public class Splitting
     {
         if (b)
             Debug.Assert(o != null);
-        o.ToString(); // not null guarded (incorrect)
+        o.ToString(); // not null guarded
         if (b)
             o.ToString(); // null guarded
         o.ToString(); // not null guarded
@@ -117,6 +117,6 @@ public class Splitting
         o.ToString(); // null guarded
         if (b)
             o.ToString(); // null guarded
-        return o.ToString(); // null guarded (missing)
+        return o.ToString(); // null guarded
     }
 }

--- a/csharp/ql/test/library-tests/controlflow/guards/Splitting.cs
+++ b/csharp/ql/test/library-tests/controlflow/guards/Splitting.cs
@@ -1,0 +1,122 @@
+using System;
+using System.Diagnostics;
+
+/// <summary>
+/// Tests related to CFG splitting.
+/// </summary>
+public class Splitting
+{
+    void M1(bool b, object o)
+    {
+        if (b)
+            if (o != null)
+                o.ToString(); // null guarded
+        if (b)
+            o.ToString(); // not null guarded
+        o.ToString(); // not null guarded
+    }
+
+    string M2(bool b, object o)
+    {
+        if (b)
+            if (o != null)
+                return o.ToString(); // null guarded
+        if (b)
+            o.ToString(); // anti-null guarded
+        return o.ToString(); // not null guarded
+    }
+
+    string M3(bool b, object o)
+    {
+        if (b)
+            if (o == null)
+                return "";
+        if (b)
+            o.ToString(); // null guarded
+        return o.ToString(); // not null guarded
+    }
+
+    void M4(bool b, object o)
+    {
+        if (o != null)
+        {
+            if (b)
+                o.ToString(); // null guarded
+            if (b)
+                o.ToString(); // null guarded
+        }
+    }
+
+    string M5(bool b, object o)
+    {
+        if (b)
+            o.ToString(); // not null guarded
+        if (o != null)
+            o.ToString(); // null guarded
+        if (b)
+            o.ToString(); // not null guarded
+        return o.ToString(); // not null guarded
+    }
+
+    string M6(bool b, object o)
+    {
+        if (b)
+            o.ToString(); // not null guarded
+        if (o != null)
+            return o.ToString(); // null guarded (missing)
+        if (b)
+            o.ToString(); // anti-null guarded
+        return o.ToString(); // anti-null guarded (missing)
+    }
+
+    string M7(bool b, object o, bool b2)
+    {
+        if (b)
+            o.ToString(); // not null guarded
+        if (o != null)
+            if (b2)
+                return o.ToString(); // null guarded (missing)
+        if (b)
+            o.ToString(); // not null guarded
+        return o.ToString(); // not null guarded
+    }
+
+    void M8(bool b, object o)
+    {
+        if (b)
+            Debug.Assert(o != null);
+        o.ToString(); // not null guarded (incorrect)
+        if (b)
+            o.ToString(); // null guarded
+        o.ToString(); // not null guarded
+    }
+
+    string M9(bool b, object o)
+    {
+        if (b)
+            Debug.Assert(o == null);
+        if (b)
+            o.ToString(); // anti-null guarded
+        return o.ToString(); // not null guarded
+    }
+
+    void M10(bool b, object o)
+    {
+        Debug.Assert(o != null);
+        if (b)
+            o.ToString(); // null guarded
+        if (b)
+            o.ToString(); // null guarded
+    }
+
+    string M11(bool b, object o)
+    {
+        if (b)
+            o.ToString(); // not null guarded
+        Debug.Assert(o != null);
+        o.ToString(); // null guarded
+        if (b)
+            o.ToString(); // null guarded
+        return o.ToString(); // null guarded (missing)
+    }
+}


### PR DESCRIPTION
The guards library works on expressions rather than control flow nodes, so special care must be taken to properly support control flow splitting.

@calumgrant 