### PR TITLE
C#: Fix for type mentions of type parameter constraints

### DIFF
--- a/csharp/ql/test/library-tests/regressions/Program.cs
+++ b/csharp/ql/test/library-tests/regressions/Program.cs
@@ -139,4 +139,12 @@ class LocalVariableTags
     };
 }
 
+partial class C1<T> where T: DynamicType
+{
+}
+
+partial class C1<T> where T: DynamicType
+{
+}
+
 // semmle-extractor-options: /r:System.Dynamic.Runtime.dll

--- a/csharp/ql/test/library-tests/regressions/TypeMentions.expected
+++ b/csharp/ql/test/library-tests/regressions/TypeMentions.expected
@@ -64,3 +64,7 @@
 | Program.cs:135:33:135:38 | String |
 | Program.cs:135:41:135:46 | Object |
 | Program.cs:137:10:137:15 | Object |
+| Program.cs:142:27:142:27 | T |
+| Program.cs:142:30:142:40 | DynamicType |
+| Program.cs:146:27:146:27 | T |
+| Program.cs:146:30:146:40 | DynamicType |


### PR DESCRIPTION
When generating type mentions for type-parameter constraints, it was not always the case that the order of the constraints matched their syntactic order, particular when using partial classes.

Develop a test case for this scenario, which previously caused the extractor to log an exception.