### PR TITLE
Java: Add two double-checked-locking queries.

### DIFF
--- a/change-notes/1.20/analysis-java.md
+++ b/change-notes/1.20/analysis-java.md
@@ -1,0 +1,20 @@
+# Improvements to Java analysis
+
+## General improvements
+
+
+## New queries
+
+| **Query**                   | **Tags**  | **Purpose**                                                        |
+|-----------------------------|-----------|--------------------------------------------------------------------|
+| Double-checked locking is not thread-safe (`java/unsafe-double-checked-locking`) | reliability, correctness, concurrency, external/cwe/cwe-609 | Identifies wrong implementations of double-checked locking that does not use the `volatile` keyword. |
+| Race condition in double-checked locking object initialization (`java/unsafe-double-checked-locking-init-order`) | reliability, correctness, concurrency, external/cwe/cwe-609 | Identifies wrong implementations of double-checked locking that performs additional initialization after exposing the constructed object. |
+
+## Changes to existing queries
+
+| **Query**                  | **Expected impact**    | **Change**                                                       |
+|----------------------------|------------------------|------------------------------------------------------------------|
+
+## Changes to QL libraries
+
+

--- a/java/ql/src/Likely Bugs/Concurrency/DoubleCheckedLocking.qhelp
+++ b/java/ql/src/Likely Bugs/Concurrency/DoubleCheckedLocking.qhelp
@@ -1,0 +1,8 @@
+<!DOCTYPE qhelp PUBLIC
+  "-//Semmle//qhelp//EN"
+  "qhelp.dtd">
+<qhelp>
+
+<include src="DoubleCheckedLockingShared.qhelp" />
+
+</qhelp>

--- a/java/ql/src/Likely Bugs/Concurrency/DoubleCheckedLocking.ql
+++ b/java/ql/src/Likely Bugs/Concurrency/DoubleCheckedLocking.ql
@@ -1,0 +1,23 @@
+/**
+ * @name Double-checked locking is not thread-safe
+ * @description A repeated check on a non-volatile field is not thread-safe, and
+ *              could result in unexpected behavior.
+ * @kind problem
+ * @problem.severity error
+ * @precision high
+ * @id java/unsafe-double-checked-locking
+ * @tags reliability
+ *       correctness
+ *       concurrency
+ *       external/cwe/cwe-609
+ */
+
+import java
+import DoubleCheckedLocking
+
+from IfStmt if1, IfStmt if2, SynchronizedStmt sync, Field f
+where
+  doubleCheckedLocking(if1, if2, sync, f) and
+  not f.isVolatile()
+select sync, "Double-checked locking on the non-volatile field $@ is not thread-safe.", f,
+  f.toString()

--- a/java/ql/src/Likely Bugs/Concurrency/DoubleCheckedLocking.qll
+++ b/java/ql/src/Likely Bugs/Concurrency/DoubleCheckedLocking.qll
@@ -1,0 +1,43 @@
+import java
+import semmle.code.java.dataflow.SSA
+
+/**
+ * Gets a read of `f`. Gets both direct reads and indirect reads through
+ * assignment to a local variable.
+ */
+private Expr getAFieldRead(Field f) {
+  result = f.getAnAccess()
+  or
+  exists(SsaExplicitUpdate v | v.getSourceVariable().getVariable() instanceof LocalScopeVariable |
+    result = v.getAUse() and
+    v.getDefiningExpr().(VariableAssign).getSource() = getAFieldRead(f)
+  )
+  or
+  result.(ParExpr).getExpr() = getAFieldRead(f)
+  or
+  result.(AssignExpr).getSource() = getAFieldRead(f)
+}
+
+/**
+ * Gets an expression that corresponds to `f == null`, either directly testing
+ * `f` or indirectly through a local variable `(x = f) == null`.
+ */
+private Expr getANullCheck(Field f) {
+  exists(EqualityTest eq | eq.polarity() = true |
+    eq.hasOperands(any(NullLiteral nl), getAFieldRead(f)) and
+    result = eq
+  )
+}
+
+/**
+ * Holds if the sequence `if1`-`sync`-`if2` corresponds to a double-checked
+ * locking pattern for the field `f`. Fields with immutable types are excluded,
+ * as they are always safe to initialize with double-checked locking.
+ */
+predicate doubleCheckedLocking(IfStmt if1, IfStmt if2, SynchronizedStmt sync, Field f) {
+  if1.getThen() = sync.getParent*() and
+  sync.getBlock() = if2.getParent*() and
+  if1.getCondition() = getANullCheck(f) and
+  if2.getCondition() = getANullCheck(f) and
+  not f.getType() instanceof ImmutableType
+}

--- a/java/ql/src/Likely Bugs/Concurrency/DoubleCheckedLockingBad1.java
+++ b/java/ql/src/Likely Bugs/Concurrency/DoubleCheckedLockingBad1.java
@@ -1,0 +1,13 @@
+private Object lock = new Object();
+private MyObject f = null;
+
+public MyObject getMyObject() {
+  if (f == null) {
+    synchronized(lock) {
+      if (f == null) {
+        f = new MyObject(); // BAD
+      }
+    }
+  }
+  return f;
+}

--- a/java/ql/src/Likely Bugs/Concurrency/DoubleCheckedLockingBad2.java
+++ b/java/ql/src/Likely Bugs/Concurrency/DoubleCheckedLockingBad2.java
@@ -1,0 +1,14 @@
+private Object lock = new Object();
+private volatile MyObject f = null;
+
+public MyObject getMyObject() {
+  if (f == null) {
+    synchronized(lock) {
+      if (f == null) {
+        f = new MyObject();
+        f.init(); // BAD
+      }
+    }
+  }
+  return f;
+}

--- a/java/ql/src/Likely Bugs/Concurrency/DoubleCheckedLockingGood.java
+++ b/java/ql/src/Likely Bugs/Concurrency/DoubleCheckedLockingGood.java
@@ -1,0 +1,17 @@
+private Object lock = new Object();
+private volatile MyObject f = null;
+
+public MyObject getMyObject() {
+  MyObject result = f;
+  if (result == null) {
+    synchronized(lock) {
+      result = f;
+      if (result == null) {
+        result = new MyObject();
+        result.init();
+        f = result; // GOOD
+      }
+    }
+  }
+  return result;
+}

--- a/java/ql/src/Likely Bugs/Concurrency/DoubleCheckedLockingShared.qhelp
+++ b/java/ql/src/Likely Bugs/Concurrency/DoubleCheckedLockingShared.qhelp
@@ -1,0 +1,86 @@
+<!DOCTYPE qhelp PUBLIC
+  "-//Semmle//qhelp//EN"
+  "qhelp.dtd">
+<qhelp>
+
+<overview>
+<p>
+Double-checked locking is a common pattern for lazy initialization of a field
+accessed by multiple threads.
+Depending on the memory model of the underlying runtime, it can, however, be
+quite difficult to implement correctly, since reorderings performed by
+compiler, runtime, or CPU might expose un-initialized or half-way initialized
+objects to other threads.
+Java has since version 5 improved its memory model to support double-checked
+locking if the underlying field is marked <code>volatile</code> and if all
+initialization happens before the volatile write.
+</p>
+</overview>
+
+<recommendation>
+
+<p>
+First, it should be considered whether the getter that performs the lazy
+initialization is performance critical.
+If not, a much simpler solution is to completely avoid double-checked locking
+and simply mark the entire getter as <code>synchronized</code>.
+This is much easier to get right and guards against hard-to-find concurrency bugs.
+</p>
+<p>
+If double-checked locking is used, it is important that the underlying field is
+<code>volatile</code> and that the update to the field is the last thing that
+happens in the synchronized region, that is, all initialization must be done
+before the field is assigned.
+Furthermore, the Java version must be 5 or newer.
+Reading a <code>volatile</code> field has a slight overhead, so it is also
+useful to use a local variable to minimize the number of volatile reads.
+</p>
+
+</recommendation>
+
+<example>
+<p>
+The following code lazily initializes <code>f</code> to <code>new MyObject()</code>.
+</p>
+<sample src="DoubleCheckedLockingBad1.java"/>
+<p>
+This code is not thread-safe as another thread might see the assignment to
+<code>f</code> before the constructor finishes evaluating, for example if the
+compiler inlines the memory allocation and the constructor and reorders the
+assignment to <code>f</code> to occur just after the memory allocation.
+</p>
+
+<p>
+Another example that also is not thread-safe, even when <code>volatile</code>
+is used, is if additional initialization happens after the assignment to
+<code>f</code>, since then other threads may access the constructed object
+before it is fully initialized, even without any reorderings by the compiler or
+runtime.
+</p>
+<sample src="DoubleCheckedLockingBad2.java"/>
+
+<p>
+The code above should be rewritten to both use <code>volatile</code> and finish
+all initialization before <code>f</code> is updated. Additionally, a local
+variable can be used to avoid reading the field more times than neccessary.
+</p>
+<sample src="DoubleCheckedLockingGood.java"/>
+
+</example>
+
+<references>
+
+<li>
+<a href="http://www.cs.umd.edu/~pugh/java/memoryModel/DoubleCheckedLocking.html">The "Double-Checked Locking is Broken" Declaration</a>.
+</li>
+<li>
+Java Language Specification:
+<a href="https://docs.oracle.com/javase/specs/jls/se8/html/jls-17.html#jls-17.4">17.4. Memory Model</a>.
+</li>
+<li>
+Wikipedia: <a href="https://en.wikipedia.org/wiki/Double-checked_locking">Double-checked locking</a>.
+</li>
+
+</references>
+
+</qhelp>

--- a/java/ql/src/Likely Bugs/Concurrency/DoubleCheckedLockingWithInitRace.qhelp
+++ b/java/ql/src/Likely Bugs/Concurrency/DoubleCheckedLockingWithInitRace.qhelp
@@ -1,0 +1,8 @@
+<!DOCTYPE qhelp PUBLIC
+  "-//Semmle//qhelp//EN"
+  "qhelp.dtd">
+<qhelp>
+
+<include src="DoubleCheckedLockingShared.qhelp" />
+
+</qhelp>

--- a/java/ql/src/Likely Bugs/Concurrency/DoubleCheckedLockingWithInitRace.ql
+++ b/java/ql/src/Likely Bugs/Concurrency/DoubleCheckedLockingWithInitRace.ql
@@ -5,7 +5,7 @@
  *              locking is not thread-safe, and could result in unexpected
  *              behavior.
  * @kind problem
- * @problem.severity error
+ * @problem.severity warning
  * @precision high
  * @id java/unsafe-double-checked-locking-init-order
  * @tags reliability

--- a/java/ql/src/Likely Bugs/Concurrency/DoubleCheckedLockingWithInitRace.ql
+++ b/java/ql/src/Likely Bugs/Concurrency/DoubleCheckedLockingWithInitRace.ql
@@ -1,0 +1,43 @@
+/**
+ * @name Race condition in double-checked locking object initialization
+ * @description Performing additional initialization on an object after
+ *              assignment to a shared variable guarded by double-checked
+ *              locking is not thread-safe, and could result in unexpected
+ *              behavior.
+ * @kind problem
+ * @problem.severity error
+ * @precision high
+ * @id java/unsafe-double-checked-locking-init-order
+ * @tags reliability
+ *       correctness
+ *       concurrency
+ *       external/cwe/cwe-609
+ */
+
+import java
+import DoubleCheckedLocking
+
+predicate whitelistedMethod(Method m) {
+  m.getDeclaringType().hasQualifiedName("java.io", _) and
+  m.hasName("println")
+}
+
+class SideEffect extends Expr {
+  SideEffect() {
+    this instanceof MethodAccess and
+    not whitelistedMethod(this.(MethodAccess).getMethod())
+    or
+    this.(Assignment).getDest() instanceof FieldAccess
+  }
+}
+
+from IfStmt if1, IfStmt if2, SynchronizedStmt sync, Field f, AssignExpr a, SideEffect se
+where
+  doubleCheckedLocking(if1, if2, sync, f) and
+  a.getEnclosingStmt().getParent*() = if2.getThen() and
+  se.getEnclosingStmt().getParent*() = sync.getBlock() and
+  a.(ControlFlowNode).getASuccessor+() = se and
+  a.getDest().(FieldAccess).getField() = f
+select a,
+  "Potential race condition. This assignment to $@ is visible to other threads before the subsequent statements are executed.",
+  f, f.toString()

--- a/java/ql/test/query-tests/DoubleCheckedLocking/A.java
+++ b/java/ql/test/query-tests/DoubleCheckedLocking/A.java
@@ -1,0 +1,75 @@
+public class A {
+  public class B {
+    public int x = 2;
+    public void setX(int x) {
+      this.x = x;
+    }
+  }
+
+  private String s;
+  public String getString() {
+    if (s == null) {
+      synchronized(this) {
+        if (s == null) {
+          s = "string"; // OK, immutable
+        }
+      }
+    }
+    return s;
+  }
+
+  private B b1;
+  public B getter1() {
+    B x = b1;
+    if (x == null) {
+      synchronized(this) {
+        if ((x = b1) == null) {
+          b1 = new B(); // BAD, not volatile
+          x = b1;
+        }
+      }
+    }
+    return x;
+  }
+
+  private volatile B b2;
+  public B getter2() {
+    B x = b2;
+    if (x == null) {
+      synchronized(this) {
+        if ((x = b2) == null) {
+          b2 = new B(); // OK
+          x = b2;
+          System.out.println("OK");
+        }
+      }
+    }
+    return x;
+  }
+
+  private volatile B b3;
+  public B getter3() {
+    if (b3 == null) {
+      synchronized(this) {
+        if (b3 == null) {
+          b3 = new B();
+          b3.x = 7; // BAD, post update init
+        }
+      }
+    }
+    return b3;
+  }
+
+  private volatile B b4;
+  public B getter4() {
+    if (b4 == null) {
+      synchronized(this) {
+        if (b4 == null) {
+          b4 = new B();
+          b4.setX(7); // BAD, post update init
+        }
+      }
+    }
+    return b4;
+  }
+}

--- a/java/ql/test/query-tests/DoubleCheckedLocking/DoubleCheckedLocking.expected
+++ b/java/ql/test/query-tests/DoubleCheckedLocking/DoubleCheckedLocking.expected
@@ -1,0 +1,1 @@
+| A.java:25:7:30:7 | stmt | Double-checked locking on the non-volatile field $@ is not thread-safe. | A.java:21:13:21:14 | b1 | b1 |

--- a/java/ql/test/query-tests/DoubleCheckedLocking/DoubleCheckedLocking.qlref
+++ b/java/ql/test/query-tests/DoubleCheckedLocking/DoubleCheckedLocking.qlref
@@ -1,0 +1,1 @@
+Likely Bugs/Concurrency/DoubleCheckedLocking.ql

--- a/java/ql/test/query-tests/DoubleCheckedLocking/DoubleCheckedLockingWithInitRace.expected
+++ b/java/ql/test/query-tests/DoubleCheckedLocking/DoubleCheckedLockingWithInitRace.expected
@@ -1,0 +1,2 @@
+| A.java:55:11:55:22 | ...=... | Potential race condition. This assignment to $@ is visible to other threads before the subsequent statements are executed. | A.java:50:22:50:23 | b3 | b3 |
+| A.java:68:11:68:22 | ...=... | Potential race condition. This assignment to $@ is visible to other threads before the subsequent statements are executed. | A.java:63:22:63:23 | b4 | b4 |

--- a/java/ql/test/query-tests/DoubleCheckedLocking/DoubleCheckedLockingWithInitRace.qlref
+++ b/java/ql/test/query-tests/DoubleCheckedLocking/DoubleCheckedLockingWithInitRace.qlref
@@ -1,0 +1,1 @@
+Likely Bugs/Concurrency/DoubleCheckedLockingWithInitRace.ql


### PR DESCRIPTION
This adds two new queries to find different kinds of wrongly implemented double-checked locking.

Results appear to be mostly TPs: https://lgtm.com/query/5620636587488515274/