### PR TITLE
Python: named module utility

### DIFF
--- a/python/ql/src/Statements/StatementNoEffect.ql
+++ b/python/ql/src/Statements/StatementNoEffect.ql
@@ -84,11 +84,7 @@ predicate in_notebook(Expr e) {
 }
 
 FunctionObject assertRaises() {
-    exists(ModuleObject unittest, ClassObject testcase |
-        unittest.getName() = "unittest" and
-        testcase = unittest.getAttribute("TestCase") and
-        result = testcase.lookupAttribute("assertRaises")
-    )
+    result = ModuleObject::named("unittest").getAttribute("TestCase").(ClassObject).lookupAttribute("assertRaises")
 }
 
 /** Holds if expression `e` is in a `with` block that tests for exceptions being raised. */

--- a/python/ql/src/semmle/python/libraries/Zope.qll
+++ b/python/ql/src/semmle/python/libraries/Zope.qll
@@ -7,9 +7,8 @@ class ZopeInterfaceMethod extends PyFunctionObject {
 
     /** Holds if this method belongs to a class that sub-classes `zope.interface.Interface` */
     ZopeInterfaceMethod() {
-        exists(ModuleObject zope, Object interface, ClassObject owner |
-            zope.getAttribute("Interface") = interface and
-            zope.getName() = "zope.interface" and
+        exists(Object interface, ClassObject owner |
+            ModuleObject::named("zope.interface").getAttribute("Interface") = interface and
             owner.declaredAttribute(_) = this and
             owner.getAnImproperSuperType().getABaseType() = interface
         )

--- a/python/ql/src/semmle/python/regex.qll
+++ b/python/ql/src/semmle/python/regex.qll
@@ -40,7 +40,7 @@ string mode_from_mode_object(Object obj) {
         result = "MULTILINE" or result = "DOTALL" or result = "UNICODE" or
         result = "VERBOSE"
     ) and
-    exists(ModuleObject re | re.getName() = "re" and re.getAttribute(result) = obj)
+    ModuleObject::named("re").getAttribute(result) = obj
     or
     exists(BinaryExpr be, Object sub | obj.getOrigin() = be |
         be.getOp() instanceof BitOr and

--- a/python/ql/src/semmle/python/security/injection/Xml.qll
+++ b/python/ql/src/semmle/python/security/injection/Xml.qll
@@ -33,10 +33,7 @@ private class ExpatParser extends TaintKind {
 }
 
 private FunctionObject expatCreateParseFunction() {
-    exists(ModuleObject expat |
-        expat.getName() = "xml.parsers.expat" and
-        result = expat.getAttribute("ParserCreate")
-    )
+    result = ModuleObject::named("xml.parsers.expat").getAttribute("ParserCreate")
 }
 
 private class ExpatCreateParser extends TaintSource {

--- a/python/ql/src/semmle/python/types/ModuleObject.qll
+++ b/python/ql/src/semmle/python/types/ModuleObject.qll
@@ -260,7 +260,7 @@ class PackageObject extends ModuleObject {
 /** Utility module for predicates relevant to the `ModuleObject` class. */
 module ModuleObject {
 
-    /** Gets a `ModuleObject` who's name is `name` */
+    /** Gets a `ModuleObject` called `name`, if it exists. */
     ModuleObject named(string name) {
         result.getName() = name
     }

--- a/python/ql/src/semmle/python/types/ModuleObject.qll
+++ b/python/ql/src/semmle/python/types/ModuleObject.qll
@@ -257,3 +257,12 @@ class PackageObject extends ModuleObject {
 
 }
 
+/** Utility module for predicates relevant to the `ModuleObject` class. */
+module ModuleObject {
+
+    /** Gets a `ModuleObject` who's name is `name` */
+    ModuleObject named(string name) {
+        result.getName() = name
+    }
+
+}


### PR DESCRIPTION
Adds a predicate `ModuleObject::named()` so that `ModuleObject::named("foo")` can be used as a shorthand for `any(ModuleObject m | m.getName() ="foo")`

I've added a few uses as examples, but haven't bothered hunting down all cases where it could be used to avoid pointless churn.
