### PR TITLE
JS: fix unused 'React' variable FP

### DIFF
--- a/change-notes/1.20/analysis-javascript.md
+++ b/change-notes/1.20/analysis-javascript.md
@@ -1,0 +1,17 @@
+# Improvements to JavaScript analysis
+
+## General improvements
+
+## New queries
+
+| **Query** | **Tags** | **Purpose** |
+|-----------|----------|-------------|
+|           |          |             |
+
+## Changes to existing queries
+
+| **Query**                                  | **Expected impact**          | **Change**                                                                   |
+|--------------------------------------------|------------------------------|------------------------------------------------------------------------------|
+|                                            |                              |                                                                              |
+
+## Changes to QL libraries

--- a/change-notes/1.20/analysis-javascript.md
+++ b/change-notes/1.20/analysis-javascript.md
@@ -12,6 +12,7 @@
 
 | **Query**                                  | **Expected impact**          | **Change**                                                                   |
 |--------------------------------------------|------------------------------|------------------------------------------------------------------------------|
+| Unused variable, import, function or class | Fewer false-positive results | This rule now flags fewer variables that are implictly used by JSX elements. |
 |                                            |                              |                                                                              |
 
 ## Changes to QL libraries

--- a/javascript/ql/src/Declarations/UnusedVariable.ql
+++ b/javascript/ql/src/Declarations/UnusedVariable.ql
@@ -54,19 +54,23 @@ predicate isPropertyFilter(UnusedLocal v) {
  * references it.
  */
 predicate isReactImportForJSX(UnusedLocal v) {
-  exists (ImportSpecifier is |
-    is.getLocal() = v.getADeclaration() and
-    exists (JSXNode jsx | jsx.getTopLevel() = is.getTopLevel())
+  exists(JSXNode jsx, TopLevel tl |
+    jsx.getTopLevel() = tl and
+    v.getADeclaration().getTopLevel() = tl and
+    (
+      v.getName() = "React"
+      or
+      // legacy `@jsx` pragmas
+      exists(JSXPragma p | p.getTopLevel() = tl | p.getDOMName() = v.getName())
+      or
+      // JSX pragma from a .babelrc file
+      exists(Babel::TransformReactJsxConfig plugin |
+        plugin.appliesTo(tl) and
+        plugin.getJsxFactoryVariableName() = v.getName()
+      )
+    )
     |
-    v.getName() = "React"
-    or
-    // legacy `@jsx` pragmas
-    exists (JSXPragma p | p.getTopLevel() = is.getTopLevel() | p.getDOMName() = v.getName())
-    or
-    // JSX pragma from a .babelrc file
-    exists (Babel::TransformReactJsxConfig plugin |
-      plugin.appliesTo(is.getTopLevel()) and
-      plugin.getJsxFactoryVariableName() = v.getName())
+    v.getADeclaration() = any(ImportDeclaration imp).getASpecifier().getLocal()
   )
 }
 

--- a/javascript/ql/src/Declarations/UnusedVariable.ql
+++ b/javascript/ql/src/Declarations/UnusedVariable.ql
@@ -71,6 +71,10 @@ predicate isReactImportForJSX(UnusedLocal v) {
     )
     |
     v.getADeclaration() = any(ImportDeclaration imp).getASpecifier().getLocal()
+    or
+    exists(VariableDeclarator vd | vd.getBindingPattern() = v.getADeclaration() |
+      vd.getInit() instanceof Require
+    )
   )
 }
 

--- a/javascript/ql/test/query-tests/Declarations/UnusedVariable/UnusedVariable.expected
+++ b/javascript/ql/test/query-tests/Declarations/UnusedVariable/UnusedVariable.expected
@@ -7,7 +7,7 @@
 | importWithoutPragma.jsx:1:1:1:27 | import  ... react'; | Unused import h. |
 | multi-imports.js:1:1:1:29 | import  ... om 'x'; | Unused imports a, b, d. |
 | multi-imports.js:2:1:2:42 | import  ... om 'x'; | Unused imports alphabetically, ordered. |
-| require-react-3.js:1:7:1:11 | React | Unused variable React. |
+| require-react-in-other-scope.js:2:9:2:13 | React | Unused variable React. |
 | typeoftype.ts:9:7:9:7 | y | Unused variable y. |
 | unusedShadowed.ts:1:1:1:26 | import  ... where'; | Unused import T. |
 | unusedShadowed.ts:2:1:2:31 | import  ... where'; | Unused import object. |

--- a/javascript/ql/test/query-tests/Declarations/UnusedVariable/UnusedVariable.expected
+++ b/javascript/ql/test/query-tests/Declarations/UnusedVariable/UnusedVariable.expected
@@ -7,6 +7,7 @@
 | importWithoutPragma.jsx:1:1:1:27 | import  ... react'; | Unused import h. |
 | multi-imports.js:1:1:1:29 | import  ... om 'x'; | Unused imports a, b, d. |
 | multi-imports.js:2:1:2:42 | import  ... om 'x'; | Unused imports alphabetically, ordered. |
+| require-react-3.js:1:7:1:11 | React | Unused variable React. |
 | typeoftype.ts:9:7:9:7 | y | Unused variable y. |
 | unusedShadowed.ts:1:1:1:26 | import  ... where'; | Unused import T. |
 | unusedShadowed.ts:2:1:2:31 | import  ... where'; | Unused import object. |

--- a/javascript/ql/test/query-tests/Declarations/UnusedVariable/react-jsx.js
+++ b/javascript/ql/test/query-tests/Declarations/UnusedVariable/react-jsx.js
@@ -1,0 +1,2 @@
+var React = x; // OK
+(<e/>);

--- a/javascript/ql/test/query-tests/Declarations/UnusedVariable/require-react-1.js
+++ b/javascript/ql/test/query-tests/Declarations/UnusedVariable/require-react-1.js
@@ -1,0 +1,2 @@
+var React = require("probably-react"); // OK
+(<e/>);

--- a/javascript/ql/test/query-tests/Declarations/UnusedVariable/require-react-2.js
+++ b/javascript/ql/test/query-tests/Declarations/UnusedVariable/require-react-2.js
@@ -1,0 +1,2 @@
+var { React } = { React: require("probably-react") }; // OK
+(<e/>);

--- a/javascript/ql/test/query-tests/Declarations/UnusedVariable/require-react-3.js
+++ b/javascript/ql/test/query-tests/Declarations/UnusedVariable/require-react-3.js
@@ -1,0 +1,2 @@
+var { React } = require("probably-react"); // OK, but not yet supported
+(<e/>);

--- a/javascript/ql/test/query-tests/Declarations/UnusedVariable/require-react-3.js
+++ b/javascript/ql/test/query-tests/Declarations/UnusedVariable/require-react-3.js
@@ -1,2 +1,2 @@
-var { React } = require("probably-react"); // OK, but not yet supported
+var { React } = require("probably-react"); // OK
 (<e/>);

--- a/javascript/ql/test/query-tests/Declarations/UnusedVariable/require-react-in-other-scope.js
+++ b/javascript/ql/test/query-tests/Declarations/UnusedVariable/require-react-in-other-scope.js
@@ -1,0 +1,6 @@
+(function() {
+    var React  = require("probably-react"); // NOT OK
+})
+(function() {
+    (<e/>);
+})


### PR DESCRIPTION
Eliminates `var React = require('react')` as a `js/unused-local-variable` FP in the presence of JSX elements.

The first commit is a refactoring to make the fix simpler.

This does not whitelist the `var { React } = require("probably-react");`, it seems to be quite messy to support that potential corner case (or am I missing an obvious solution?).

[Performance is fine, and results are plenty.](https://git.semmle.com/esben/dist-compare-reports/tree/js/unused-react-variable_1543405368477)