### PR TITLE
JavaScript: Add support for sanitiser guards on dynamic property accesses.

### DIFF
--- a/javascript/ql/src/semmle/javascript/dataflow/internal/AccessPaths.qll
+++ b/javascript/ql/src/semmle/javascript/dataflow/internal/AccessPaths.qll
@@ -1,0 +1,117 @@
+/**
+ * Provides classes for reasoning about certain property accesses as access paths.
+ *
+ * Access paths represent SSA variables with zero or more property accesses applied to them.
+ * Each property name in the access must either be constant or itself be a use of an SSA
+ * variable.
+ *
+ * If `x` and `y` are SSA variables, then `x`, `x.p`, `x.p["q"]`, `x[y]` and `x[y].q` are
+ * access paths, but `x[x.y]` is not an access path.
+ *
+ * Access paths can be used to identify expressions that have the same value, disregarding
+ * any heap modifications. In general, expressions that are instances of the same access
+ * path are not guaranteed to evaluate to the same value nor do all expressions that evaluate
+ * to the same value have the same access paths, so access paths are neither sound nor
+ * complete as an approximation of expression semantics.
+ */
+
+import javascript
+
+/**
+ * A representation of a property name that is either statically known or is
+ * the value of an SSA variable.
+ */
+private newtype PropertyName =
+  StaticPropertyName(string name) {
+    exists (PropAccess pa | name = pa.getPropertyName())
+  }
+  or
+  DynamicPropertyName(SsaVariable var) {
+    exists (PropAccess pa | pa.getPropertyNameExpr() = var.getAUse())
+  }
+
+/**
+ * Gets the representation of the property name of `pacc`, if any.
+ */
+private PropertyName getPropertyName(PropAccess pacc) {
+  result = StaticPropertyName(pacc.getPropertyName())
+  or
+  exists (SsaVariable var |
+    pacc.getPropertyNameExpr() = var.getAUse() and
+    result = DynamicPropertyName(var)
+  )
+}
+
+/**
+ * A representation of a (nested) property access on an SSA variable
+ * where each property name is either constant or itself an SSA variable.
+ */
+private newtype TAccessPath =
+  MkRoot(SsaVariable var)
+  or
+  MkAccessStep(AccessPath base, PropertyName name) {
+    exists (PropAccess pacc |
+      pacc.getBase() = base.getAnInstance() and
+      getPropertyName(pacc) = name
+    )
+  }
+
+/**
+ * A representation of a (nested) property access on an SSA variable
+ * where each property name is either constant or itself an SSA variable.
+ */
+class AccessPath extends TAccessPath {
+  /**
+   * Gets an expression in `bb` represented by this access path.
+   */
+  Expr getAnInstanceIn(BasicBlock bb) {
+    exists (SsaVariable var |
+      this = MkRoot(var) and
+      result = var.getAUseIn(bb)
+    )
+    or
+    exists (PropertyName name |
+      result = getABaseInstanceIn(bb, name) and
+      getPropertyName(result) = name
+    )
+  }
+
+  /**
+   * Gets a property access in `bb` whose base is represented by the
+   * base of this access path, and where `name` is bound to the last
+   * component of this access path.
+   *
+   * This is an auxiliary predicate that's needed to enforce a better
+   * join order in `getAnInstanceIn` above.
+   */
+  pragma[noinline]
+  private PropAccess getABaseInstanceIn(BasicBlock bb, PropertyName name) {
+    exists (AccessPath base | this = MkAccessStep(base, name) |
+      result.getBase() = base.getAnInstanceIn(bb)
+    )
+  }
+
+  /**
+   * Gets an expression represented by this access path.
+   */
+  Expr getAnInstance() {
+    result = getAnInstanceIn(_)
+  }
+
+  /**
+   * Gets a textual representation of this access path.
+   */
+  string toString() {
+    exists (SsaVariable var | this = MkRoot(var) |
+      result = var.getSourceVariable().getName()
+    )
+    or
+    exists (AccessPath base, PropertyName name, string rest |
+      rest = "." + any(string s | name = StaticPropertyName(s))
+      or
+      rest = "[" + any(SsaVariable var | name = DynamicPropertyName(var)).getSourceVariable().getName() + "]" |
+      result = base.toString() + rest and
+      this = MkAccessStep(base, name)
+    )
+  }
+}

--- a/javascript/ql/test/library-tests/TaintBarriers/SanitizingGuard.expected
+++ b/javascript/ql/test/library-tests/TaintBarriers/SanitizingGuard.expected
@@ -60,3 +60,5 @@
 | tst.js:356:16:356:27 | x10 !== null | ExampleConfiguration | false | tst.js:356:16:356:18 | x10 |
 | tst.js:356:32:356:48 | x10 !== undefined | ExampleConfiguration | false | tst.js:356:32:356:34 | x10 |
 | tst.js:358:9:358:14 | f10(v) | ExampleConfiguration | false | tst.js:358:13:358:13 | v |
+| tst.js:370:9:370:29 | o.p ==  ... listed" | ExampleConfiguration | true | tst.js:370:9:370:11 | o.p |
+| tst.js:377:11:377:32 | o[p] == ... listed" | ExampleConfiguration | true | tst.js:377:11:377:14 | o[p] |

--- a/javascript/ql/test/library-tests/TaintBarriers/TaintedSink.expected
+++ b/javascript/ql/test/library-tests/TaintBarriers/TaintedSink.expected
@@ -56,3 +56,7 @@
 | tst.js:350:14:350:14 | v | tst.js:248:13:248:20 | SOURCE() |
 | tst.js:352:14:352:14 | v | tst.js:248:13:248:20 | SOURCE() |
 | tst.js:359:14:359:14 | v | tst.js:248:13:248:20 | SOURCE() |
+| tst.js:368:10:368:12 | o.p | tst.js:367:13:367:20 | SOURCE() |
+| tst.js:373:14:373:16 | o.p | tst.js:367:13:367:20 | SOURCE() |
+| tst.js:380:14:380:17 | o[p] | tst.js:367:13:367:20 | SOURCE() |
+| tst.js:382:14:382:17 | o[p] | tst.js:367:13:367:20 | SOURCE() |

--- a/javascript/ql/test/library-tests/TaintBarriers/isBarrier.expected
+++ b/javascript/ql/test/library-tests/TaintBarriers/isBarrier.expected
@@ -37,3 +37,5 @@
 | tst.js:331:14:331:14 | v | ExampleConfiguration |
 | tst.js:356:16:356:27 | x10 | ExampleConfiguration |
 | tst.js:361:14:361:14 | v | ExampleConfiguration |
+| tst.js:371:14:371:16 | o.p | ExampleConfiguration |
+| tst.js:378:14:378:17 | o[p] | ExampleConfiguration |

--- a/javascript/ql/test/library-tests/TaintBarriers/tst.js
+++ b/javascript/ql/test/library-tests/TaintBarriers/tst.js
@@ -362,3 +362,24 @@ function IndirectSanitizer () {
     }
 
 }
+
+function constantComparisonSanitizer2() {
+    var o = SOURCE();
+    SINK(o.p); // flagged
+
+    if (o.p == "white-listed") {
+        SINK(o.p); // not flagged
+    } else {
+        SINK(o.p); // flagged
+    }
+
+    for (var p in o) {
+      if (o[p] == "white-listed") {
+        SINK(o[p]); // not flagged
+        p = somethingElse();
+        SINK(o[p]); // flagged
+      } else {
+        SINK(o[p]); // flagged
+      }
+    }
+}


### PR DESCRIPTION
This generalises our previous handling of sanitisers operating on property accesses to support dynamic property accesses where the property name is an SSA variable by representing them as access paths.

I thought I needed this for https://github.com/Semmle/ql/pull/555 to avoid some FPs, but then it turned out I didn't. Still putting it up as a PR, as it might come in handy later.

No changes to results or performance on our default benchmarks, so no change note.