### PR TITLE
C#: Account for split SSA definitions in guards library

### DIFF
--- a/csharp/ql/test/library-tests/controlflow/guards/BooleanGuardedExpr.expected
+++ b/csharp/ql/test/library-tests/controlflow/guards/BooleanGuardedExpr.expected
@@ -81,4 +81,3 @@
 | Splitting.cs:119:13:119:13 | access to parameter o | Splitting.cs:116:22:116:30 | ... != ... | Splitting.cs:116:22:116:22 | access to parameter o | true |
 | Splitting.cs:120:16:120:16 | access to parameter o | Splitting.cs:116:22:116:30 | ... != ... | Splitting.cs:116:22:116:22 | access to parameter o | true |
 | Splitting.cs:132:25:132:25 | access to parameter b | Splitting.cs:130:21:130:21 | access to parameter b | Splitting.cs:130:21:130:21 | access to parameter b | false |
-| Splitting.cs:133:17:133:17 | access to local variable o | Splitting.cs:128:17:128:25 | ... != ... | Splitting.cs:128:17:128:17 | access to local variable o | true |

--- a/csharp/ql/test/library-tests/controlflow/guards/BooleanGuardedExpr.expected
+++ b/csharp/ql/test/library-tests/controlflow/guards/BooleanGuardedExpr.expected
@@ -80,3 +80,5 @@
 | Splitting.cs:117:9:117:9 | access to parameter o | Splitting.cs:116:22:116:30 | ... != ... | Splitting.cs:116:22:116:22 | access to parameter o | true |
 | Splitting.cs:119:13:119:13 | access to parameter o | Splitting.cs:116:22:116:30 | ... != ... | Splitting.cs:116:22:116:22 | access to parameter o | true |
 | Splitting.cs:120:16:120:16 | access to parameter o | Splitting.cs:116:22:116:30 | ... != ... | Splitting.cs:116:22:116:22 | access to parameter o | true |
+| Splitting.cs:132:25:132:25 | access to parameter b | Splitting.cs:130:21:130:21 | access to parameter b | Splitting.cs:130:21:130:21 | access to parameter b | false |
+| Splitting.cs:133:17:133:17 | access to local variable o | Splitting.cs:128:17:128:25 | ... != ... | Splitting.cs:128:17:128:17 | access to local variable o | true |

--- a/csharp/ql/test/library-tests/controlflow/guards/GuardedExpr.expected
+++ b/csharp/ql/test/library-tests/controlflow/guards/GuardedExpr.expected
@@ -192,5 +192,3 @@
 | Splitting.cs:120:16:120:16 | access to parameter o | Splitting.cs:116:22:116:22 | access to parameter o | Splitting.cs:116:22:116:22 | access to parameter o | non-null |
 | Splitting.cs:120:16:120:16 | access to parameter o | Splitting.cs:116:22:116:30 | ... != ... | Splitting.cs:116:22:116:22 | access to parameter o | true |
 | Splitting.cs:132:25:132:25 | access to parameter b | Splitting.cs:130:21:130:21 | access to parameter b | Splitting.cs:130:21:130:21 | access to parameter b | false |
-| Splitting.cs:133:17:133:17 | access to local variable o | Splitting.cs:128:17:128:17 | access to local variable o | Splitting.cs:128:17:128:17 | access to local variable o | non-null |
-| Splitting.cs:133:17:133:17 | access to local variable o | Splitting.cs:128:17:128:25 | ... != ... | Splitting.cs:128:17:128:17 | access to local variable o | true |

--- a/csharp/ql/test/library-tests/controlflow/guards/GuardedExpr.expected
+++ b/csharp/ql/test/library-tests/controlflow/guards/GuardedExpr.expected
@@ -191,3 +191,6 @@
 | Splitting.cs:119:13:119:13 | access to parameter o | Splitting.cs:116:22:116:30 | ... != ... | Splitting.cs:116:22:116:22 | access to parameter o | true |
 | Splitting.cs:120:16:120:16 | access to parameter o | Splitting.cs:116:22:116:22 | access to parameter o | Splitting.cs:116:22:116:22 | access to parameter o | non-null |
 | Splitting.cs:120:16:120:16 | access to parameter o | Splitting.cs:116:22:116:30 | ... != ... | Splitting.cs:116:22:116:22 | access to parameter o | true |
+| Splitting.cs:132:25:132:25 | access to parameter b | Splitting.cs:130:21:130:21 | access to parameter b | Splitting.cs:130:21:130:21 | access to parameter b | false |
+| Splitting.cs:133:17:133:17 | access to local variable o | Splitting.cs:128:17:128:17 | access to local variable o | Splitting.cs:128:17:128:17 | access to local variable o | non-null |
+| Splitting.cs:133:17:133:17 | access to local variable o | Splitting.cs:128:17:128:25 | ... != ... | Splitting.cs:128:17:128:17 | access to local variable o | true |

--- a/csharp/ql/test/library-tests/controlflow/guards/Implications.expected
+++ b/csharp/ql/test/library-tests/controlflow/guards/Implications.expected
@@ -222,3 +222,7 @@
 | Splitting.cs:105:22:105:30 | ... != ... | true | Splitting.cs:105:22:105:22 | access to parameter o | non-null |
 | Splitting.cs:116:22:116:30 | ... != ... | false | Splitting.cs:116:22:116:22 | access to parameter o | null |
 | Splitting.cs:116:22:116:30 | ... != ... | true | Splitting.cs:116:22:116:22 | access to parameter o | non-null |
+| Splitting.cs:128:17:128:25 | ... != ... | false | Splitting.cs:128:17:128:17 | access to local variable o | null |
+| Splitting.cs:128:17:128:25 | ... != ... | true | Splitting.cs:128:17:128:17 | access to local variable o | non-null |
+| Splitting.cs:133:17:133:17 | access to local variable o | non-null | Splitting.cs:132:21:132:29 | call to method M11 | non-null |
+| Splitting.cs:133:17:133:17 | access to local variable o | null | Splitting.cs:132:21:132:29 | call to method M11 | null |

--- a/csharp/ql/test/library-tests/controlflow/guards/NullGuardedExpr.expected
+++ b/csharp/ql/test/library-tests/controlflow/guards/NullGuardedExpr.expected
@@ -53,4 +53,3 @@
 | Splitting.cs:117:9:117:9 | access to parameter o |
 | Splitting.cs:119:13:119:13 | access to parameter o |
 | Splitting.cs:120:16:120:16 | access to parameter o |
-| Splitting.cs:133:17:133:17 | access to local variable o |

--- a/csharp/ql/test/library-tests/controlflow/guards/NullGuardedExpr.expected
+++ b/csharp/ql/test/library-tests/controlflow/guards/NullGuardedExpr.expected
@@ -53,3 +53,4 @@
 | Splitting.cs:117:9:117:9 | access to parameter o |
 | Splitting.cs:119:13:119:13 | access to parameter o |
 | Splitting.cs:120:16:120:16 | access to parameter o |
+| Splitting.cs:133:17:133:17 | access to local variable o |

--- a/csharp/ql/test/library-tests/controlflow/guards/Splitting.cs
+++ b/csharp/ql/test/library-tests/controlflow/guards/Splitting.cs
@@ -119,4 +119,20 @@ public class Splitting
             o.ToString(); // null guarded
         return o.ToString(); // null guarded
     }
+
+    public void M12(int i, bool b)
+    {
+        object o = null;
+        do
+        {
+            if (o != null)
+            {
+                if (b)
+                    return;
+                o = M11(b, o);
+                o.GetHashCode(); // not null guarded
+            }
+        }
+        while (i > 0);
+    }
 }


### PR DESCRIPTION
On 03e69e9, I updated the guards library to account for control flow graph splitting. However, the logic that relates SSA qualifiers for the guard and the guarded expression was not updated accordingly.