### PR TITLE
CPP: Deprecate the PointsTo debug queries.

### DIFF
--- a/cpp/ql/src/PointsTo/Debug.ql
+++ b/cpp/ql/src/PointsTo/Debug.ql
@@ -3,7 +3,11 @@
  * @description Query to help investigate mysterious results with ReturnStackAllocatedObject
  * @kind table
  * @id cpp/points-to/debug
+ * @deprecated
  */
+
+// This query is not suitable for production use and has been deprecated.
+
 import cpp
 import semmle.code.cpp.pointsto.PointsTo
 

--- a/cpp/ql/src/PointsTo/PreparedStagedPointsTo.ql
+++ b/cpp/ql/src/PointsTo/PreparedStagedPointsTo.ql
@@ -3,7 +3,10 @@
  * @description Query to force evaluation of staged points-to predicates
  * @kind table
  * @id cpp/points-to/prepared-staged-points-to
+ * @deprecated
  */
+
+// This query is not suitable for production use and has been deprecated.
 
  import semmle.code.cpp.pointsto.PointsTo
 

--- a/cpp/ql/src/PointsTo/Stats.ql
+++ b/cpp/ql/src/PointsTo/Stats.ql
@@ -3,7 +3,11 @@
  * @description Count the number points-to sets with 0 or 1 incoming flow edges, and the total number of points-to sets
  * @kind table
  * @id cpp/points-to/stats
+ * @deprecated
  */
+
+// This query is not suitable for production use and has been deprecated.
+
 import cpp
 import semmle.code.cpp.pointsto.PointsTo
 

--- a/cpp/ql/src/PointsTo/TaintedFormatStrings.ql
+++ b/cpp/ql/src/PointsTo/TaintedFormatStrings.ql
@@ -2,7 +2,11 @@
  * @name Taint test
  * @kind table
  * @id cpp/points-to/tainted-format-strings
+ * @deprecated
  */
+
+// This query is not suitable for production use and has been deprecated.
+
 import cpp
 import semmle.code.cpp.pointsto.PointsTo
 import semmle.code.cpp.pointsto.CallGraph


### PR DESCRIPTION
Deprecate the four queries in `cpp\ql\src\PointsTo`.

Three of them are debug queries for the `PointsTo` library.  We have pretty good tests for them in `cpp\ql\test\library-tests\pointsto`, so I think the presence of these three queries in `src` adds little and is confusing (to both QL developers and users who might come across them).

The fourth query appears to be a cache warmup query, which as far as I can tell is no longer used anywhere.

Note that in the long run we have plans to deprecate the `PointsTo` library itself.