### PR TITLE
C++: Avoid using nullValue predicate (rc/1.19)

### DIFF
--- a/cpp/ql/src/Security/CWE/CWE-428/UnsafeCreateProcessCall.ql
+++ b/cpp/ql/src/Security/CWE/CWE-428/UnsafeCreateProcessCall.ql
@@ -68,7 +68,7 @@ class NullAppNameCreateProcessFunctionConfiguration extends DataFlow::Configurat
   }
 
   override predicate isSource(DataFlow::Node source) {
-    nullValue(source.asExpr()) 
+    source.asExpr() instanceof NullValue
   }
 
   override predicate isSink(DataFlow::Node sink) {


### PR DESCRIPTION
The `nullValue` predicate performs a slow custom data-flow analysis to find possible null values. It's so slow that it timed out after 1200s on Wireshark.

In `UnsafeCreateProcessCall.ql`, the values found with `nullValue` were used as sources in another data-flow analysis. By using the `NullValue` class as sink instead of `nullValue`, we avoid the slow-down of doing data flow twice. The `NullValue` class is essentially the base case of `nullValue`. Confusing names, yes.

I'll open the same PR for `ql:master` when this is merged.