### PR TITLE
C++: Fix performance of bbEntryReachesLocally (1.19)

### DIFF
--- a/cpp/ql/src/semmle/code/cpp/controlflow/LocalScopeVariableReachability.qll
+++ b/cpp/ql/src/semmle/code/cpp/controlflow/LocalScopeVariableReachability.qll
@@ -96,9 +96,17 @@ abstract class LocalScopeVariableReachability extends string {
 
   private predicate bbEntryReachesLocally(BasicBlock bb, SemanticStackVariable v, ControlFlowNode node) {
     exists(int n |
-      node = bb.getNode(n) and isSink(node, v) |
-      not exists(int m | m < n | isBarrier(bb.getNode(m), v))
+      node = bb.getNode(n) and
+      isSink(node, v)
+    |
+      not exists(this.firstBarrierIndexIn(bb, v))
+      or
+      n <= this.firstBarrierIndexIn(bb, v)
     )
+  }
+
+  private int firstBarrierIndexIn(BasicBlock bb, SemanticStackVariable v) {
+    result = min(int m | isBarrier(bb.getNode(m), v))
   }
 }
 


### PR DESCRIPTION
This predicate was fast with the queries and engine from 1.18. With the queries from `master` it got a bad join order in the `UninitializedLocal.ql` query, which made it take 2m34s on Wireshark. This commit decomposes `bbEntryReachesLocally` into two predicates that together take only 4s.