### PR TITLE
CPP: Fix performance issue with AV Rule 79.ql.

### DIFF
--- a/cpp/ql/src/jsf/4.10 Classes/AV Rule 79.ql
+++ b/cpp/ql/src/jsf/4.10 Classes/AV Rule 79.ql
@@ -189,28 +189,31 @@ predicate freedInSameMethod(Resource r, Expr acquire) {
  */
 predicate leakedInSameMethod(Resource r, Expr acquire) {
   unreleasedResource(r, acquire, _, _) and
-  (
-    exists(FunctionCall fc |
-      // `r` (or something computed from it) is passed to another function
-      // near to where it's acquired, and might be stored elsewhere.
-      fc.getAnArgument().getAChild*() = r.getAnAccess() and
-      fc.getEnclosingFunction() = acquire.getEnclosingFunction()
-    ) or exists(Variable v, Expr e | 
-      // `r` (or something computed from it) is stored in another variable
-      // near to where it's acquired, and might be released through that
-      // variable.
-      v.getAnAssignedValue() = e and
-      e.getAChild*() = r.getAnAccess() and
-      e.getEnclosingFunction() = acquire.getEnclosingFunction()
-    ) or exists(FunctionCall fc |
-      // `this` (i.e. the class where `r` is acquired) is passed into `r` via a
-      // method, or the constructor.  `r` may use this to register itself with
-      // `this` in some way, ensuring it is later deleted.
-      fc.getEnclosingFunction() = acquire.getEnclosingFunction() and
-      fc.getAnArgument() instanceof ThisExpr and
-      (
-        fc.getQualifier() = r.getAnAccess() or // e.g. `r->setOwner(this)`
-        fc = acquire.getAChild*() // e.g. `r = new MyClass(this)`
+  exists(Function f |
+    acquire.getEnclosingFunction() = f and
+    (
+      exists(FunctionCall fc |
+        // `r` (or something computed from it) is passed to another function
+        // near to where it's acquired, and might be stored elsewhere.
+        fc.getAnArgument().getAChild*() = r.getAnAccess() and
+        fc.getEnclosingFunction() = f
+      ) or exists(Variable v, Expr e | 
+        // `r` (or something computed from it) is stored in another variable
+        // near to where it's acquired, and might be released through that
+        // variable.
+        v.getAnAssignedValue() = e and
+        e.getAChild*() = r.getAnAccess() and
+        e.getEnclosingFunction() = f
+      ) or exists(FunctionCall fc |
+        // `this` (i.e. the class where `r` is acquired) is passed into `r` via a
+        // method, or the constructor.  `r` may use this to register itself with
+        // `this` in some way, ensuring it is later deleted.
+        fc.getEnclosingFunction() = f and
+        fc.getAnArgument() instanceof ThisExpr and
+        (
+          fc.getQualifier() = r.getAnAccess() or // e.g. `r->setOwner(this)`
+          fc = acquire.getAChild*() // e.g. `r = new MyClass(this)`
+        )
       )
     )
   )


### PR DESCRIPTION
Fix performance issue with AV Rule 79.ql on Wireshark.  Three expressions of the form `a.getEnclosingElement() = b.getEnclosingElement()` were causing the problem.

The query now completes on my laptop in 123s on this snapshot, 204s on Firefox, with no exceptionally slow predicates.  I also verified that results are the same on some smaller snapshots (where I could get the original version to finish).

@jbj