### PR TITLE
C++: pragma[nomagic] on bbStrictlyDominates

### DIFF
--- a/cpp/ql/src/semmle/code/cpp/controlflow/Dominance.qll
+++ b/cpp/ql/src/semmle/code/cpp/controlflow/Dominance.qll
@@ -126,6 +126,7 @@ predicate bbIPostDominates(BasicBlock pDom, BasicBlock node) = idominance(bb_exi
  * Holds if `dominator` is a strict dominator of `node` in the control-flow
  * graph of basic blocks. Being strict means that `dominator != node`.
  */
+pragma[nomagic] // magic prevents fastTC
 predicate bbStrictlyDominates(BasicBlock dominator, BasicBlock node) {
   bbIDominates+(dominator, node)
 }

--- a/cpp/ql/src/semmle/code/cpp/controlflow/Dominance.qll
+++ b/cpp/ql/src/semmle/code/cpp/controlflow/Dominance.qll
@@ -135,6 +135,7 @@ predicate bbStrictlyDominates(BasicBlock dominator, BasicBlock node) {
  * Holds if `postDominator` is a strict post-dominator of `node` in the control-flow
  * graph of basic blocks. Being strict means that `postDominator != node`.
  */
+pragma[nomagic] // magic prevents fastTC
 predicate bbStrictlyPostDominates(BasicBlock postDominator, BasicBlock node) {
   bbIPostDominates+(postDominator, node)
 }


### PR DESCRIPTION
I noticed that queries using the data flow library spent significant time in `#Dominance::bbIDominates#fbPlus`, which is the body of the `bbStrictlyDominates` predicate. That predicate took 28 seconds to compute on Wireshark.

The `b` in the predicate name means that magic was applied, and the application of magic meant that it could not be evaluated with the built-in `fastTC` HOP but became an explicit recursion instead. Applying `pragma[nomagic]` to this predicate means that we will always get it evaluated with `fastTC`, and that takes less than a second in my test case.

This is not a regression since 1.18 AFAIK, so I haven't aimed this PR at 1.19.