### PR TITLE
C#: Handle multiple-field Boolean CFG splitting

### DIFF
--- a/csharp/ql/src/semmle/code/csharp/controlflow/ControlFlowGraph.qll
+++ b/csharp/ql/src/semmle/code/csharp/controlflow/ControlFlowGraph.qll
@@ -3638,7 +3638,7 @@ module ControlFlow {
               kind = rank[r](BooleanSplitSubKind kind0 |
                 kind0.getEnclosingCallable() = c and
                 kind0.startsSplit(_) |
-                kind0 order by kind0.getLocation().getStartLine(), kind0.getLocation().getStartColumn()
+                kind0 order by kind0.getLocation().getStartLine(), kind0.getLocation().getStartColumn(), kind0.toString()
               )
             )
           }

--- a/csharp/ql/test/library-tests/controlflow/graph/BasicBlock.expected
+++ b/csharp/ql/test/library-tests/controlflow/graph/BasicBlock.expected
@@ -171,6 +171,9 @@
 | Conditions.cs:117:9:123:9 | {...} | Conditions.cs:119:18:119:21 | access to local variable last | 13 |
 | Conditions.cs:120:17:120:23 | [last (line 118): false] ...; | Conditions.cs:121:17:121:20 | [last (line 118): false] access to local variable last | 6 |
 | Conditions.cs:121:13:122:25 | [last (line 118): true] if (...) ... | Conditions.cs:122:17:122:24 | ... = ... | 6 |
+| Conditions.cs:129:10:129:12 | enter M10 | Conditions.cs:133:17:133:22 | access to field Field1 | 8 |
+| Conditions.cs:131:16:131:19 | [Field1 (line 129): false] true | Conditions.cs:133:17:133:22 | [Field1 (line 129): false] access to field Field1 | 5 |
+| Conditions.cs:134:13:139:13 | [Field1 (line 129): true] {...} | Conditions.cs:135:21:135:26 | [Field1 (line 129): true] access to field Field2 | 4 |
 | ExitMethods.cs:7:10:7:11 | enter M1 | ExitMethods.cs:7:10:7:11 | exit M1 | 7 |
 | ExitMethods.cs:13:10:13:11 | enter M2 | ExitMethods.cs:13:10:13:11 | exit M2 | 7 |
 | ExitMethods.cs:19:10:19:11 | enter M3 | ExitMethods.cs:19:10:19:11 | exit M3 | 6 |

--- a/csharp/ql/test/library-tests/controlflow/graph/BasicBlock.expected
+++ b/csharp/ql/test/library-tests/controlflow/graph/BasicBlock.expected
@@ -173,7 +173,9 @@
 | Conditions.cs:121:13:122:25 | [last (line 118): true] if (...) ... | Conditions.cs:122:17:122:24 | ... = ... | 6 |
 | Conditions.cs:129:10:129:12 | enter M10 | Conditions.cs:133:17:133:22 | access to field Field1 | 8 |
 | Conditions.cs:131:16:131:19 | [Field1 (line 129): false] true | Conditions.cs:133:17:133:22 | [Field1 (line 129): false] access to field Field1 | 5 |
+| Conditions.cs:131:16:131:19 | [Field1 (line 129): true, Field2 (line 129): false] true | Conditions.cs:135:21:135:26 | [Field1 (line 129): true, Field2 (line 129): false] access to field Field2 | 9 |
 | Conditions.cs:134:13:139:13 | [Field1 (line 129): true] {...} | Conditions.cs:135:21:135:26 | [Field1 (line 129): true] access to field Field2 | 4 |
+| Conditions.cs:136:17:138:17 | [Field1 (line 129): true, Field2 (line 129): true] {...} | Conditions.cs:135:21:135:26 | [Field1 (line 129): true, Field2 (line 129): true] access to field Field2 | 14 |
 | ExitMethods.cs:7:10:7:11 | enter M1 | ExitMethods.cs:7:10:7:11 | exit M1 | 7 |
 | ExitMethods.cs:13:10:13:11 | enter M2 | ExitMethods.cs:13:10:13:11 | exit M2 | 7 |
 | ExitMethods.cs:19:10:19:11 | enter M3 | ExitMethods.cs:19:10:19:11 | exit M3 | 6 |

--- a/csharp/ql/test/library-tests/controlflow/graph/BasicBlockDominance.expected
+++ b/csharp/ql/test/library-tests/controlflow/graph/BasicBlockDominance.expected
@@ -381,6 +381,9 @@
 | post | Conditions.cs:117:9:123:9 | {...} | Conditions.cs:117:9:123:9 | {...} |
 | post | Conditions.cs:120:17:120:23 | [last (line 118): false] ...; | Conditions.cs:120:17:120:23 | [last (line 118): false] ...; |
 | post | Conditions.cs:121:13:122:25 | [last (line 118): true] if (...) ... | Conditions.cs:121:13:122:25 | [last (line 118): true] if (...) ... |
+| post | Conditions.cs:129:10:129:12 | enter M10 | Conditions.cs:129:10:129:12 | enter M10 |
+| post | Conditions.cs:131:16:131:19 | [Field1 (line 129): false] true | Conditions.cs:131:16:131:19 | [Field1 (line 129): false] true |
+| post | Conditions.cs:134:13:139:13 | [Field1 (line 129): true] {...} | Conditions.cs:134:13:139:13 | [Field1 (line 129): true] {...} |
 | post | ExitMethods.cs:7:10:7:11 | enter M1 | ExitMethods.cs:7:10:7:11 | enter M1 |
 | post | ExitMethods.cs:13:10:13:11 | enter M2 | ExitMethods.cs:13:10:13:11 | enter M2 |
 | post | ExitMethods.cs:19:10:19:11 | enter M3 | ExitMethods.cs:19:10:19:11 | enter M3 |
@@ -1747,6 +1750,11 @@
 | pre | Conditions.cs:117:9:123:9 | {...} | Conditions.cs:121:13:122:25 | [last (line 118): true] if (...) ... |
 | pre | Conditions.cs:120:17:120:23 | [last (line 118): false] ...; | Conditions.cs:120:17:120:23 | [last (line 118): false] ...; |
 | pre | Conditions.cs:121:13:122:25 | [last (line 118): true] if (...) ... | Conditions.cs:121:13:122:25 | [last (line 118): true] if (...) ... |
+| pre | Conditions.cs:129:10:129:12 | enter M10 | Conditions.cs:129:10:129:12 | enter M10 |
+| pre | Conditions.cs:129:10:129:12 | enter M10 | Conditions.cs:131:16:131:19 | [Field1 (line 129): false] true |
+| pre | Conditions.cs:129:10:129:12 | enter M10 | Conditions.cs:134:13:139:13 | [Field1 (line 129): true] {...} |
+| pre | Conditions.cs:131:16:131:19 | [Field1 (line 129): false] true | Conditions.cs:131:16:131:19 | [Field1 (line 129): false] true |
+| pre | Conditions.cs:134:13:139:13 | [Field1 (line 129): true] {...} | Conditions.cs:134:13:139:13 | [Field1 (line 129): true] {...} |
 | pre | ExitMethods.cs:7:10:7:11 | enter M1 | ExitMethods.cs:7:10:7:11 | enter M1 |
 | pre | ExitMethods.cs:13:10:13:11 | enter M2 | ExitMethods.cs:13:10:13:11 | enter M2 |
 | pre | ExitMethods.cs:19:10:19:11 | enter M3 | ExitMethods.cs:19:10:19:11 | enter M3 |

--- a/csharp/ql/test/library-tests/controlflow/graph/BasicBlockDominance.expected
+++ b/csharp/ql/test/library-tests/controlflow/graph/BasicBlockDominance.expected
@@ -383,7 +383,9 @@
 | post | Conditions.cs:121:13:122:25 | [last (line 118): true] if (...) ... | Conditions.cs:121:13:122:25 | [last (line 118): true] if (...) ... |
 | post | Conditions.cs:129:10:129:12 | enter M10 | Conditions.cs:129:10:129:12 | enter M10 |
 | post | Conditions.cs:131:16:131:19 | [Field1 (line 129): false] true | Conditions.cs:131:16:131:19 | [Field1 (line 129): false] true |
+| post | Conditions.cs:131:16:131:19 | [Field1 (line 129): true, Field2 (line 129): false] true | Conditions.cs:131:16:131:19 | [Field1 (line 129): true, Field2 (line 129): false] true |
 | post | Conditions.cs:134:13:139:13 | [Field1 (line 129): true] {...} | Conditions.cs:134:13:139:13 | [Field1 (line 129): true] {...} |
+| post | Conditions.cs:136:17:138:17 | [Field1 (line 129): true, Field2 (line 129): true] {...} | Conditions.cs:136:17:138:17 | [Field1 (line 129): true, Field2 (line 129): true] {...} |
 | post | ExitMethods.cs:7:10:7:11 | enter M1 | ExitMethods.cs:7:10:7:11 | enter M1 |
 | post | ExitMethods.cs:13:10:13:11 | enter M2 | ExitMethods.cs:13:10:13:11 | enter M2 |
 | post | ExitMethods.cs:19:10:19:11 | enter M3 | ExitMethods.cs:19:10:19:11 | enter M3 |
@@ -1752,9 +1754,15 @@
 | pre | Conditions.cs:121:13:122:25 | [last (line 118): true] if (...) ... | Conditions.cs:121:13:122:25 | [last (line 118): true] if (...) ... |
 | pre | Conditions.cs:129:10:129:12 | enter M10 | Conditions.cs:129:10:129:12 | enter M10 |
 | pre | Conditions.cs:129:10:129:12 | enter M10 | Conditions.cs:131:16:131:19 | [Field1 (line 129): false] true |
+| pre | Conditions.cs:129:10:129:12 | enter M10 | Conditions.cs:131:16:131:19 | [Field1 (line 129): true, Field2 (line 129): false] true |
 | pre | Conditions.cs:129:10:129:12 | enter M10 | Conditions.cs:134:13:139:13 | [Field1 (line 129): true] {...} |
+| pre | Conditions.cs:129:10:129:12 | enter M10 | Conditions.cs:136:17:138:17 | [Field1 (line 129): true, Field2 (line 129): true] {...} |
 | pre | Conditions.cs:131:16:131:19 | [Field1 (line 129): false] true | Conditions.cs:131:16:131:19 | [Field1 (line 129): false] true |
+| pre | Conditions.cs:131:16:131:19 | [Field1 (line 129): true, Field2 (line 129): false] true | Conditions.cs:131:16:131:19 | [Field1 (line 129): true, Field2 (line 129): false] true |
+| pre | Conditions.cs:134:13:139:13 | [Field1 (line 129): true] {...} | Conditions.cs:131:16:131:19 | [Field1 (line 129): true, Field2 (line 129): false] true |
 | pre | Conditions.cs:134:13:139:13 | [Field1 (line 129): true] {...} | Conditions.cs:134:13:139:13 | [Field1 (line 129): true] {...} |
+| pre | Conditions.cs:134:13:139:13 | [Field1 (line 129): true] {...} | Conditions.cs:136:17:138:17 | [Field1 (line 129): true, Field2 (line 129): true] {...} |
+| pre | Conditions.cs:136:17:138:17 | [Field1 (line 129): true, Field2 (line 129): true] {...} | Conditions.cs:136:17:138:17 | [Field1 (line 129): true, Field2 (line 129): true] {...} |
 | pre | ExitMethods.cs:7:10:7:11 | enter M1 | ExitMethods.cs:7:10:7:11 | enter M1 |
 | pre | ExitMethods.cs:13:10:13:11 | enter M2 | ExitMethods.cs:13:10:13:11 | enter M2 |
 | pre | ExitMethods.cs:19:10:19:11 | enter M3 | ExitMethods.cs:19:10:19:11 | enter M3 |

--- a/csharp/ql/test/library-tests/controlflow/graph/BooleanNode.expected
+++ b/csharp/ql/test/library-tests/controlflow/graph/BooleanNode.expected
@@ -1,3 +1,12 @@
+| Field1 (line 129): false | Conditions.cs:131:16:131:19 | [Field1 (line 129): false] true |
+| Field1 (line 129): false | Conditions.cs:132:9:140:9 | [Field1 (line 129): false] {...} |
+| Field1 (line 129): false | Conditions.cs:133:13:139:13 | [Field1 (line 129): false] if (...) ... |
+| Field1 (line 129): false | Conditions.cs:133:17:133:22 | [Field1 (line 129): false] access to field Field1 |
+| Field1 (line 129): false | Conditions.cs:133:17:133:22 | [Field1 (line 129): false] this access |
+| Field1 (line 129): true | Conditions.cs:134:13:139:13 | [Field1 (line 129): true] {...} |
+| Field1 (line 129): true | Conditions.cs:135:17:138:17 | [Field1 (line 129): true] if (...) ... |
+| Field1 (line 129): true | Conditions.cs:135:21:135:26 | [Field1 (line 129): true] access to field Field2 |
+| Field1 (line 129): true | Conditions.cs:135:21:135:26 | [Field1 (line 129): true] this access |
 | b2 (line 22): false | Conditions.cs:28:9:29:16 | [b2 (line 22): false] if (...) ... |
 | b2 (line 22): false | Conditions.cs:28:13:28:14 | [b2 (line 22): false] access to parameter b2 |
 | b2 (line 22): true | Conditions.cs:27:17:27:17 | [b2 (line 22): true] access to local variable x |

--- a/csharp/ql/test/library-tests/controlflow/graph/BooleanNode.expected
+++ b/csharp/ql/test/library-tests/controlflow/graph/BooleanNode.expected
@@ -3,10 +3,56 @@
 | Field1 (line 129): false | Conditions.cs:133:13:139:13 | [Field1 (line 129): false] if (...) ... |
 | Field1 (line 129): false | Conditions.cs:133:17:133:22 | [Field1 (line 129): false] access to field Field1 |
 | Field1 (line 129): false | Conditions.cs:133:17:133:22 | [Field1 (line 129): false] this access |
+| Field1 (line 129): true | Conditions.cs:131:16:131:19 | [Field1 (line 129): true, Field2 (line 129): false] true |
+| Field1 (line 129): true | Conditions.cs:131:16:131:19 | [Field1 (line 129): true, Field2 (line 129): true] true |
+| Field1 (line 129): true | Conditions.cs:132:9:140:9 | [Field1 (line 129): true, Field2 (line 129): false] {...} |
+| Field1 (line 129): true | Conditions.cs:132:9:140:9 | [Field1 (line 129): true, Field2 (line 129): true] {...} |
+| Field1 (line 129): true | Conditions.cs:133:13:139:13 | [Field1 (line 129): true, Field2 (line 129): false] if (...) ... |
+| Field1 (line 129): true | Conditions.cs:133:13:139:13 | [Field1 (line 129): true, Field2 (line 129): true] if (...) ... |
+| Field1 (line 129): true | Conditions.cs:133:17:133:22 | [Field1 (line 129): true, Field2 (line 129): false] access to field Field1 |
+| Field1 (line 129): true | Conditions.cs:133:17:133:22 | [Field1 (line 129): true, Field2 (line 129): false] this access |
+| Field1 (line 129): true | Conditions.cs:133:17:133:22 | [Field1 (line 129): true, Field2 (line 129): true] access to field Field1 |
+| Field1 (line 129): true | Conditions.cs:133:17:133:22 | [Field1 (line 129): true, Field2 (line 129): true] this access |
+| Field1 (line 129): true | Conditions.cs:134:13:139:13 | [Field1 (line 129): true, Field2 (line 129): false] {...} |
+| Field1 (line 129): true | Conditions.cs:134:13:139:13 | [Field1 (line 129): true, Field2 (line 129): true] {...} |
 | Field1 (line 129): true | Conditions.cs:134:13:139:13 | [Field1 (line 129): true] {...} |
+| Field1 (line 129): true | Conditions.cs:135:17:138:17 | [Field1 (line 129): true, Field2 (line 129): false] if (...) ... |
+| Field1 (line 129): true | Conditions.cs:135:17:138:17 | [Field1 (line 129): true, Field2 (line 129): true] if (...) ... |
 | Field1 (line 129): true | Conditions.cs:135:17:138:17 | [Field1 (line 129): true] if (...) ... |
+| Field1 (line 129): true | Conditions.cs:135:21:135:26 | [Field1 (line 129): true, Field2 (line 129): false] access to field Field2 |
+| Field1 (line 129): true | Conditions.cs:135:21:135:26 | [Field1 (line 129): true, Field2 (line 129): false] this access |
+| Field1 (line 129): true | Conditions.cs:135:21:135:26 | [Field1 (line 129): true, Field2 (line 129): true] access to field Field2 |
+| Field1 (line 129): true | Conditions.cs:135:21:135:26 | [Field1 (line 129): true, Field2 (line 129): true] this access |
 | Field1 (line 129): true | Conditions.cs:135:21:135:26 | [Field1 (line 129): true] access to field Field2 |
 | Field1 (line 129): true | Conditions.cs:135:21:135:26 | [Field1 (line 129): true] this access |
+| Field1 (line 129): true | Conditions.cs:136:17:138:17 | [Field1 (line 129): true, Field2 (line 129): true] {...} |
+| Field1 (line 129): true | Conditions.cs:137:21:137:26 | [Field1 (line 129): true, Field2 (line 129): true] access to field Field1 |
+| Field1 (line 129): true | Conditions.cs:137:21:137:26 | [Field1 (line 129): true, Field2 (line 129): true] this access |
+| Field1 (line 129): true | Conditions.cs:137:21:137:37 | [Field1 (line 129): true, Field2 (line 129): true] call to method ToString |
+| Field1 (line 129): true | Conditions.cs:137:21:137:38 | [Field1 (line 129): true, Field2 (line 129): true] ...; |
+| Field2 (line 129): false | Conditions.cs:131:16:131:19 | [Field1 (line 129): true, Field2 (line 129): false] true |
+| Field2 (line 129): false | Conditions.cs:132:9:140:9 | [Field1 (line 129): true, Field2 (line 129): false] {...} |
+| Field2 (line 129): false | Conditions.cs:133:13:139:13 | [Field1 (line 129): true, Field2 (line 129): false] if (...) ... |
+| Field2 (line 129): false | Conditions.cs:133:17:133:22 | [Field1 (line 129): true, Field2 (line 129): false] access to field Field1 |
+| Field2 (line 129): false | Conditions.cs:133:17:133:22 | [Field1 (line 129): true, Field2 (line 129): false] this access |
+| Field2 (line 129): false | Conditions.cs:134:13:139:13 | [Field1 (line 129): true, Field2 (line 129): false] {...} |
+| Field2 (line 129): false | Conditions.cs:135:17:138:17 | [Field1 (line 129): true, Field2 (line 129): false] if (...) ... |
+| Field2 (line 129): false | Conditions.cs:135:21:135:26 | [Field1 (line 129): true, Field2 (line 129): false] access to field Field2 |
+| Field2 (line 129): false | Conditions.cs:135:21:135:26 | [Field1 (line 129): true, Field2 (line 129): false] this access |
+| Field2 (line 129): true | Conditions.cs:131:16:131:19 | [Field1 (line 129): true, Field2 (line 129): true] true |
+| Field2 (line 129): true | Conditions.cs:132:9:140:9 | [Field1 (line 129): true, Field2 (line 129): true] {...} |
+| Field2 (line 129): true | Conditions.cs:133:13:139:13 | [Field1 (line 129): true, Field2 (line 129): true] if (...) ... |
+| Field2 (line 129): true | Conditions.cs:133:17:133:22 | [Field1 (line 129): true, Field2 (line 129): true] access to field Field1 |
+| Field2 (line 129): true | Conditions.cs:133:17:133:22 | [Field1 (line 129): true, Field2 (line 129): true] this access |
+| Field2 (line 129): true | Conditions.cs:134:13:139:13 | [Field1 (line 129): true, Field2 (line 129): true] {...} |
+| Field2 (line 129): true | Conditions.cs:135:17:138:17 | [Field1 (line 129): true, Field2 (line 129): true] if (...) ... |
+| Field2 (line 129): true | Conditions.cs:135:21:135:26 | [Field1 (line 129): true, Field2 (line 129): true] access to field Field2 |
+| Field2 (line 129): true | Conditions.cs:135:21:135:26 | [Field1 (line 129): true, Field2 (line 129): true] this access |
+| Field2 (line 129): true | Conditions.cs:136:17:138:17 | [Field1 (line 129): true, Field2 (line 129): true] {...} |
+| Field2 (line 129): true | Conditions.cs:137:21:137:26 | [Field1 (line 129): true, Field2 (line 129): true] access to field Field1 |
+| Field2 (line 129): true | Conditions.cs:137:21:137:26 | [Field1 (line 129): true, Field2 (line 129): true] this access |
+| Field2 (line 129): true | Conditions.cs:137:21:137:37 | [Field1 (line 129): true, Field2 (line 129): true] call to method ToString |
+| Field2 (line 129): true | Conditions.cs:137:21:137:38 | [Field1 (line 129): true, Field2 (line 129): true] ...; |
 | b2 (line 22): false | Conditions.cs:28:9:29:16 | [b2 (line 22): false] if (...) ... |
 | b2 (line 22): false | Conditions.cs:28:13:28:14 | [b2 (line 22): false] access to parameter b2 |
 | b2 (line 22): true | Conditions.cs:27:17:27:17 | [b2 (line 22): true] access to local variable x |

--- a/csharp/ql/test/library-tests/controlflow/graph/ConditionBlock.expected
+++ b/csharp/ql/test/library-tests/controlflow/graph/ConditionBlock.expected
@@ -162,6 +162,8 @@
 | Conditions.cs:116:24:116:38 | ... < ... | Conditions.cs:121:13:122:25 | [last (line 118): true] if (...) ... | true |
 | Conditions.cs:119:18:119:21 | access to local variable last | Conditions.cs:120:17:120:23 | [last (line 118): false] ...; | false |
 | Conditions.cs:119:18:119:21 | access to local variable last | Conditions.cs:121:13:122:25 | [last (line 118): true] if (...) ... | true |
+| Conditions.cs:133:17:133:22 | access to field Field1 | Conditions.cs:131:16:131:19 | [Field1 (line 129): false] true | false |
+| Conditions.cs:133:17:133:22 | access to field Field1 | Conditions.cs:134:13:139:13 | [Field1 (line 129): true] {...} | true |
 | ExitMethods.cs:43:9:46:9 | [exception: Exception] catch (...) {...} | ExitMethods.cs:47:9:50:9 | [exception: Exception] catch (...) {...} | false |
 | ExitMethods.cs:55:13:55:13 | access to parameter b | ExitMethods.cs:56:19:56:33 | object creation of type Exception | true |
 | ExitMethods.cs:61:13:61:13 | access to parameter b | ExitMethods.cs:62:19:62:33 | object creation of type Exception | true |

--- a/csharp/ql/test/library-tests/controlflow/graph/ConditionBlock.expected
+++ b/csharp/ql/test/library-tests/controlflow/graph/ConditionBlock.expected
@@ -163,7 +163,11 @@
 | Conditions.cs:119:18:119:21 | access to local variable last | Conditions.cs:120:17:120:23 | [last (line 118): false] ...; | false |
 | Conditions.cs:119:18:119:21 | access to local variable last | Conditions.cs:121:13:122:25 | [last (line 118): true] if (...) ... | true |
 | Conditions.cs:133:17:133:22 | access to field Field1 | Conditions.cs:131:16:131:19 | [Field1 (line 129): false] true | false |
+| Conditions.cs:133:17:133:22 | access to field Field1 | Conditions.cs:131:16:131:19 | [Field1 (line 129): true, Field2 (line 129): false] true | true |
 | Conditions.cs:133:17:133:22 | access to field Field1 | Conditions.cs:134:13:139:13 | [Field1 (line 129): true] {...} | true |
+| Conditions.cs:133:17:133:22 | access to field Field1 | Conditions.cs:136:17:138:17 | [Field1 (line 129): true, Field2 (line 129): true] {...} | true |
+| Conditions.cs:135:21:135:26 | [Field1 (line 129): true] access to field Field2 | Conditions.cs:131:16:131:19 | [Field1 (line 129): true, Field2 (line 129): false] true | false |
+| Conditions.cs:135:21:135:26 | [Field1 (line 129): true] access to field Field2 | Conditions.cs:136:17:138:17 | [Field1 (line 129): true, Field2 (line 129): true] {...} | true |
 | ExitMethods.cs:43:9:46:9 | [exception: Exception] catch (...) {...} | ExitMethods.cs:47:9:50:9 | [exception: Exception] catch (...) {...} | false |
 | ExitMethods.cs:55:13:55:13 | access to parameter b | ExitMethods.cs:56:19:56:33 | object creation of type Exception | true |
 | ExitMethods.cs:61:13:61:13 | access to parameter b | ExitMethods.cs:62:19:62:33 | object creation of type Exception | true |

--- a/csharp/ql/test/library-tests/controlflow/graph/ConditionalFlow.expected
+++ b/csharp/ql/test/library-tests/controlflow/graph/ConditionalFlow.expected
@@ -199,6 +199,11 @@
 | 121 | 17 | Conditions.cs:121:17:121:20 | [last (line 118): true] access to local variable last | true | 122 | 17 | Conditions.cs:122:17:122:25 | ...; |
 | 127 | 32 | cflow.cs:127:32:127:44 | ... == ... | false | 127 | 53 | cflow.cs:127:53:127:57 | this access |
 | 127 | 32 | cflow.cs:127:32:127:44 | ... == ... | true | 127 | 48 | cflow.cs:127:48:127:49 | "" |
+| 131 | 16 | Conditions.cs:131:16:131:19 | [Field1 (line 129): false] true | true | 132 | 9 | Conditions.cs:132:9:140:9 | [Field1 (line 129): false] {...} |
+| 131 | 16 | Conditions.cs:131:16:131:19 | true | true | 132 | 9 | Conditions.cs:132:9:140:9 | {...} |
+| 133 | 17 | Conditions.cs:133:17:133:22 | [Field1 (line 129): false] access to field Field1 | false | 131 | 16 | Conditions.cs:131:16:131:19 | [Field1 (line 129): false] true |
+| 133 | 17 | Conditions.cs:133:17:133:22 | access to field Field1 | false | 131 | 16 | Conditions.cs:131:16:131:19 | [Field1 (line 129): false] true |
+| 133 | 17 | Conditions.cs:133:17:133:22 | access to field Field1 | true | 134 | 13 | Conditions.cs:134:13:139:13 | [Field1 (line 129): true] {...} |
 | 162 | 48 | cflow.cs:162:48:162:51 | [exception: Exception] true | true | 163 | 9 | cflow.cs:163:9:165:9 | {...} |
 | 170 | 21 | cflow.cs:170:21:170:24 | true | true | 170 | 27 | cflow.cs:170:27:170:32 | throw ...; |
 | 194 | 48 | cflow.cs:194:48:194:51 | [exception: Exception] true | true | 195 | 9 | cflow.cs:195:9:197:9 | {...} |

--- a/csharp/ql/test/library-tests/controlflow/graph/ConditionalFlow.expected
+++ b/csharp/ql/test/library-tests/controlflow/graph/ConditionalFlow.expected
@@ -200,10 +200,18 @@
 | 127 | 32 | cflow.cs:127:32:127:44 | ... == ... | false | 127 | 53 | cflow.cs:127:53:127:57 | this access |
 | 127 | 32 | cflow.cs:127:32:127:44 | ... == ... | true | 127 | 48 | cflow.cs:127:48:127:49 | "" |
 | 131 | 16 | Conditions.cs:131:16:131:19 | [Field1 (line 129): false] true | true | 132 | 9 | Conditions.cs:132:9:140:9 | [Field1 (line 129): false] {...} |
+| 131 | 16 | Conditions.cs:131:16:131:19 | [Field1 (line 129): true, Field2 (line 129): false] true | true | 132 | 9 | Conditions.cs:132:9:140:9 | [Field1 (line 129): true, Field2 (line 129): false] {...} |
+| 131 | 16 | Conditions.cs:131:16:131:19 | [Field1 (line 129): true, Field2 (line 129): true] true | true | 132 | 9 | Conditions.cs:132:9:140:9 | [Field1 (line 129): true, Field2 (line 129): true] {...} |
 | 131 | 16 | Conditions.cs:131:16:131:19 | true | true | 132 | 9 | Conditions.cs:132:9:140:9 | {...} |
 | 133 | 17 | Conditions.cs:133:17:133:22 | [Field1 (line 129): false] access to field Field1 | false | 131 | 16 | Conditions.cs:131:16:131:19 | [Field1 (line 129): false] true |
+| 133 | 17 | Conditions.cs:133:17:133:22 | [Field1 (line 129): true, Field2 (line 129): false] access to field Field1 | true | 134 | 13 | Conditions.cs:134:13:139:13 | [Field1 (line 129): true, Field2 (line 129): false] {...} |
+| 133 | 17 | Conditions.cs:133:17:133:22 | [Field1 (line 129): true, Field2 (line 129): true] access to field Field1 | true | 134 | 13 | Conditions.cs:134:13:139:13 | [Field1 (line 129): true, Field2 (line 129): true] {...} |
 | 133 | 17 | Conditions.cs:133:17:133:22 | access to field Field1 | false | 131 | 16 | Conditions.cs:131:16:131:19 | [Field1 (line 129): false] true |
 | 133 | 17 | Conditions.cs:133:17:133:22 | access to field Field1 | true | 134 | 13 | Conditions.cs:134:13:139:13 | [Field1 (line 129): true] {...} |
+| 135 | 21 | Conditions.cs:135:21:135:26 | [Field1 (line 129): true, Field2 (line 129): false] access to field Field2 | false | 131 | 16 | Conditions.cs:131:16:131:19 | [Field1 (line 129): true, Field2 (line 129): false] true |
+| 135 | 21 | Conditions.cs:135:21:135:26 | [Field1 (line 129): true, Field2 (line 129): true] access to field Field2 | true | 136 | 17 | Conditions.cs:136:17:138:17 | [Field1 (line 129): true, Field2 (line 129): true] {...} |
+| 135 | 21 | Conditions.cs:135:21:135:26 | [Field1 (line 129): true] access to field Field2 | false | 131 | 16 | Conditions.cs:131:16:131:19 | [Field1 (line 129): true, Field2 (line 129): false] true |
+| 135 | 21 | Conditions.cs:135:21:135:26 | [Field1 (line 129): true] access to field Field2 | true | 136 | 17 | Conditions.cs:136:17:138:17 | [Field1 (line 129): true, Field2 (line 129): true] {...} |
 | 162 | 48 | cflow.cs:162:48:162:51 | [exception: Exception] true | true | 163 | 9 | cflow.cs:163:9:165:9 | {...} |
 | 170 | 21 | cflow.cs:170:21:170:24 | true | true | 170 | 27 | cflow.cs:170:27:170:32 | throw ...; |
 | 194 | 48 | cflow.cs:194:48:194:51 | [exception: Exception] true | true | 195 | 9 | cflow.cs:195:9:197:9 | {...} |

--- a/csharp/ql/test/library-tests/controlflow/graph/Conditions.cs
+++ b/csharp/ql/test/library-tests/controlflow/graph/Conditions.cs
@@ -122,4 +122,21 @@ class Conditions
                 s = null;
         }
     }
+
+    private bool Field1;
+    private bool Field2;
+
+    void M10()
+    {
+        while (true)
+        {
+            if (Field1)
+            {
+                if (Field2)
+                {
+                    Field1.ToString();
+                }
+            }
+        }
+    }
 }

--- a/csharp/ql/test/library-tests/controlflow/graph/Dominance.expected
+++ b/csharp/ql/test/library-tests/controlflow/graph/Dominance.expected
@@ -663,18 +663,39 @@
 | post | Conditions.cs:122:21:122:24 | null | Conditions.cs:122:17:122:17 | access to local variable s |
 | post | Conditions.cs:130:5:141:5 | {...} | Conditions.cs:129:10:129:12 | enter M10 |
 | post | Conditions.cs:131:9:140:9 | while (...) ... | Conditions.cs:130:5:141:5 | {...} |
+| post | Conditions.cs:131:16:131:19 | [Field1 (line 129): true, Field2 (line 129): true] true | Conditions.cs:137:21:137:37 | [Field1 (line 129): true, Field2 (line 129): true] call to method ToString |
 | post | Conditions.cs:131:16:131:19 | true | Conditions.cs:131:9:140:9 | while (...) ... |
 | post | Conditions.cs:132:9:140:9 | [Field1 (line 129): false] {...} | Conditions.cs:131:16:131:19 | [Field1 (line 129): false] true |
+| post | Conditions.cs:132:9:140:9 | [Field1 (line 129): true, Field2 (line 129): false] {...} | Conditions.cs:131:16:131:19 | [Field1 (line 129): true, Field2 (line 129): false] true |
+| post | Conditions.cs:132:9:140:9 | [Field1 (line 129): true, Field2 (line 129): true] {...} | Conditions.cs:131:16:131:19 | [Field1 (line 129): true, Field2 (line 129): true] true |
 | post | Conditions.cs:132:9:140:9 | {...} | Conditions.cs:131:16:131:19 | true |
 | post | Conditions.cs:133:13:139:13 | [Field1 (line 129): false] if (...) ... | Conditions.cs:132:9:140:9 | [Field1 (line 129): false] {...} |
+| post | Conditions.cs:133:13:139:13 | [Field1 (line 129): true, Field2 (line 129): false] if (...) ... | Conditions.cs:132:9:140:9 | [Field1 (line 129): true, Field2 (line 129): false] {...} |
+| post | Conditions.cs:133:13:139:13 | [Field1 (line 129): true, Field2 (line 129): true] if (...) ... | Conditions.cs:132:9:140:9 | [Field1 (line 129): true, Field2 (line 129): true] {...} |
 | post | Conditions.cs:133:13:139:13 | if (...) ... | Conditions.cs:132:9:140:9 | {...} |
 | post | Conditions.cs:133:17:133:22 | [Field1 (line 129): false] access to field Field1 | Conditions.cs:133:17:133:22 | [Field1 (line 129): false] this access |
 | post | Conditions.cs:133:17:133:22 | [Field1 (line 129): false] this access | Conditions.cs:133:13:139:13 | [Field1 (line 129): false] if (...) ... |
+| post | Conditions.cs:133:17:133:22 | [Field1 (line 129): true, Field2 (line 129): false] access to field Field1 | Conditions.cs:133:17:133:22 | [Field1 (line 129): true, Field2 (line 129): false] this access |
+| post | Conditions.cs:133:17:133:22 | [Field1 (line 129): true, Field2 (line 129): false] this access | Conditions.cs:133:13:139:13 | [Field1 (line 129): true, Field2 (line 129): false] if (...) ... |
+| post | Conditions.cs:133:17:133:22 | [Field1 (line 129): true, Field2 (line 129): true] access to field Field1 | Conditions.cs:133:17:133:22 | [Field1 (line 129): true, Field2 (line 129): true] this access |
+| post | Conditions.cs:133:17:133:22 | [Field1 (line 129): true, Field2 (line 129): true] this access | Conditions.cs:133:13:139:13 | [Field1 (line 129): true, Field2 (line 129): true] if (...) ... |
 | post | Conditions.cs:133:17:133:22 | access to field Field1 | Conditions.cs:133:17:133:22 | this access |
 | post | Conditions.cs:133:17:133:22 | this access | Conditions.cs:133:13:139:13 | if (...) ... |
+| post | Conditions.cs:134:13:139:13 | [Field1 (line 129): true, Field2 (line 129): false] {...} | Conditions.cs:133:17:133:22 | [Field1 (line 129): true, Field2 (line 129): false] access to field Field1 |
+| post | Conditions.cs:134:13:139:13 | [Field1 (line 129): true, Field2 (line 129): true] {...} | Conditions.cs:133:17:133:22 | [Field1 (line 129): true, Field2 (line 129): true] access to field Field1 |
+| post | Conditions.cs:135:17:138:17 | [Field1 (line 129): true, Field2 (line 129): false] if (...) ... | Conditions.cs:134:13:139:13 | [Field1 (line 129): true, Field2 (line 129): false] {...} |
+| post | Conditions.cs:135:17:138:17 | [Field1 (line 129): true, Field2 (line 129): true] if (...) ... | Conditions.cs:134:13:139:13 | [Field1 (line 129): true, Field2 (line 129): true] {...} |
 | post | Conditions.cs:135:17:138:17 | [Field1 (line 129): true] if (...) ... | Conditions.cs:134:13:139:13 | [Field1 (line 129): true] {...} |
+| post | Conditions.cs:135:21:135:26 | [Field1 (line 129): true, Field2 (line 129): false] access to field Field2 | Conditions.cs:135:21:135:26 | [Field1 (line 129): true, Field2 (line 129): false] this access |
+| post | Conditions.cs:135:21:135:26 | [Field1 (line 129): true, Field2 (line 129): false] this access | Conditions.cs:135:17:138:17 | [Field1 (line 129): true, Field2 (line 129): false] if (...) ... |
+| post | Conditions.cs:135:21:135:26 | [Field1 (line 129): true, Field2 (line 129): true] access to field Field2 | Conditions.cs:135:21:135:26 | [Field1 (line 129): true, Field2 (line 129): true] this access |
+| post | Conditions.cs:135:21:135:26 | [Field1 (line 129): true, Field2 (line 129): true] this access | Conditions.cs:135:17:138:17 | [Field1 (line 129): true, Field2 (line 129): true] if (...) ... |
 | post | Conditions.cs:135:21:135:26 | [Field1 (line 129): true] access to field Field2 | Conditions.cs:135:21:135:26 | [Field1 (line 129): true] this access |
 | post | Conditions.cs:135:21:135:26 | [Field1 (line 129): true] this access | Conditions.cs:135:17:138:17 | [Field1 (line 129): true] if (...) ... |
+| post | Conditions.cs:137:21:137:26 | [Field1 (line 129): true, Field2 (line 129): true] access to field Field1 | Conditions.cs:137:21:137:26 | [Field1 (line 129): true, Field2 (line 129): true] this access |
+| post | Conditions.cs:137:21:137:26 | [Field1 (line 129): true, Field2 (line 129): true] this access | Conditions.cs:137:21:137:38 | [Field1 (line 129): true, Field2 (line 129): true] ...; |
+| post | Conditions.cs:137:21:137:37 | [Field1 (line 129): true, Field2 (line 129): true] call to method ToString | Conditions.cs:137:21:137:26 | [Field1 (line 129): true, Field2 (line 129): true] access to field Field1 |
+| post | Conditions.cs:137:21:137:38 | [Field1 (line 129): true, Field2 (line 129): true] ...; | Conditions.cs:136:17:138:17 | [Field1 (line 129): true, Field2 (line 129): true] {...} |
 | post | ExitMethods.cs:7:10:7:11 | exit M1 | ExitMethods.cs:10:9:10:15 | return ...; |
 | post | ExitMethods.cs:8:5:11:5 | {...} | ExitMethods.cs:7:10:7:11 | enter M1 |
 | post | ExitMethods.cs:9:9:9:24 | call to method ErrorMaybe | ExitMethods.cs:9:20:9:23 | true |
@@ -2846,18 +2867,41 @@
 | pre | Conditions.cs:130:5:141:5 | {...} | Conditions.cs:131:9:140:9 | while (...) ... |
 | pre | Conditions.cs:131:9:140:9 | while (...) ... | Conditions.cs:131:16:131:19 | true |
 | pre | Conditions.cs:131:16:131:19 | [Field1 (line 129): false] true | Conditions.cs:132:9:140:9 | [Field1 (line 129): false] {...} |
+| pre | Conditions.cs:131:16:131:19 | [Field1 (line 129): true, Field2 (line 129): false] true | Conditions.cs:132:9:140:9 | [Field1 (line 129): true, Field2 (line 129): false] {...} |
+| pre | Conditions.cs:131:16:131:19 | [Field1 (line 129): true, Field2 (line 129): true] true | Conditions.cs:132:9:140:9 | [Field1 (line 129): true, Field2 (line 129): true] {...} |
 | pre | Conditions.cs:131:16:131:19 | true | Conditions.cs:132:9:140:9 | {...} |
 | pre | Conditions.cs:132:9:140:9 | [Field1 (line 129): false] {...} | Conditions.cs:133:13:139:13 | [Field1 (line 129): false] if (...) ... |
+| pre | Conditions.cs:132:9:140:9 | [Field1 (line 129): true, Field2 (line 129): false] {...} | Conditions.cs:133:13:139:13 | [Field1 (line 129): true, Field2 (line 129): false] if (...) ... |
+| pre | Conditions.cs:132:9:140:9 | [Field1 (line 129): true, Field2 (line 129): true] {...} | Conditions.cs:133:13:139:13 | [Field1 (line 129): true, Field2 (line 129): true] if (...) ... |
 | pre | Conditions.cs:132:9:140:9 | {...} | Conditions.cs:133:13:139:13 | if (...) ... |
 | pre | Conditions.cs:133:13:139:13 | [Field1 (line 129): false] if (...) ... | Conditions.cs:133:17:133:22 | [Field1 (line 129): false] this access |
+| pre | Conditions.cs:133:13:139:13 | [Field1 (line 129): true, Field2 (line 129): false] if (...) ... | Conditions.cs:133:17:133:22 | [Field1 (line 129): true, Field2 (line 129): false] this access |
+| pre | Conditions.cs:133:13:139:13 | [Field1 (line 129): true, Field2 (line 129): true] if (...) ... | Conditions.cs:133:17:133:22 | [Field1 (line 129): true, Field2 (line 129): true] this access |
 | pre | Conditions.cs:133:13:139:13 | if (...) ... | Conditions.cs:133:17:133:22 | this access |
 | pre | Conditions.cs:133:17:133:22 | [Field1 (line 129): false] this access | Conditions.cs:133:17:133:22 | [Field1 (line 129): false] access to field Field1 |
+| pre | Conditions.cs:133:17:133:22 | [Field1 (line 129): true, Field2 (line 129): false] access to field Field1 | Conditions.cs:134:13:139:13 | [Field1 (line 129): true, Field2 (line 129): false] {...} |
+| pre | Conditions.cs:133:17:133:22 | [Field1 (line 129): true, Field2 (line 129): false] this access | Conditions.cs:133:17:133:22 | [Field1 (line 129): true, Field2 (line 129): false] access to field Field1 |
+| pre | Conditions.cs:133:17:133:22 | [Field1 (line 129): true, Field2 (line 129): true] access to field Field1 | Conditions.cs:134:13:139:13 | [Field1 (line 129): true, Field2 (line 129): true] {...} |
+| pre | Conditions.cs:133:17:133:22 | [Field1 (line 129): true, Field2 (line 129): true] this access | Conditions.cs:133:17:133:22 | [Field1 (line 129): true, Field2 (line 129): true] access to field Field1 |
 | pre | Conditions.cs:133:17:133:22 | access to field Field1 | Conditions.cs:131:16:131:19 | [Field1 (line 129): false] true |
 | pre | Conditions.cs:133:17:133:22 | access to field Field1 | Conditions.cs:134:13:139:13 | [Field1 (line 129): true] {...} |
 | pre | Conditions.cs:133:17:133:22 | this access | Conditions.cs:133:17:133:22 | access to field Field1 |
+| pre | Conditions.cs:134:13:139:13 | [Field1 (line 129): true, Field2 (line 129): false] {...} | Conditions.cs:135:17:138:17 | [Field1 (line 129): true, Field2 (line 129): false] if (...) ... |
+| pre | Conditions.cs:134:13:139:13 | [Field1 (line 129): true, Field2 (line 129): true] {...} | Conditions.cs:135:17:138:17 | [Field1 (line 129): true, Field2 (line 129): true] if (...) ... |
 | pre | Conditions.cs:134:13:139:13 | [Field1 (line 129): true] {...} | Conditions.cs:135:17:138:17 | [Field1 (line 129): true] if (...) ... |
+| pre | Conditions.cs:135:17:138:17 | [Field1 (line 129): true, Field2 (line 129): false] if (...) ... | Conditions.cs:135:21:135:26 | [Field1 (line 129): true, Field2 (line 129): false] this access |
+| pre | Conditions.cs:135:17:138:17 | [Field1 (line 129): true, Field2 (line 129): true] if (...) ... | Conditions.cs:135:21:135:26 | [Field1 (line 129): true, Field2 (line 129): true] this access |
 | pre | Conditions.cs:135:17:138:17 | [Field1 (line 129): true] if (...) ... | Conditions.cs:135:21:135:26 | [Field1 (line 129): true] this access |
+| pre | Conditions.cs:135:21:135:26 | [Field1 (line 129): true, Field2 (line 129): false] this access | Conditions.cs:135:21:135:26 | [Field1 (line 129): true, Field2 (line 129): false] access to field Field2 |
+| pre | Conditions.cs:135:21:135:26 | [Field1 (line 129): true, Field2 (line 129): true] this access | Conditions.cs:135:21:135:26 | [Field1 (line 129): true, Field2 (line 129): true] access to field Field2 |
+| pre | Conditions.cs:135:21:135:26 | [Field1 (line 129): true] access to field Field2 | Conditions.cs:131:16:131:19 | [Field1 (line 129): true, Field2 (line 129): false] true |
+| pre | Conditions.cs:135:21:135:26 | [Field1 (line 129): true] access to field Field2 | Conditions.cs:136:17:138:17 | [Field1 (line 129): true, Field2 (line 129): true] {...} |
 | pre | Conditions.cs:135:21:135:26 | [Field1 (line 129): true] this access | Conditions.cs:135:21:135:26 | [Field1 (line 129): true] access to field Field2 |
+| pre | Conditions.cs:136:17:138:17 | [Field1 (line 129): true, Field2 (line 129): true] {...} | Conditions.cs:137:21:137:38 | [Field1 (line 129): true, Field2 (line 129): true] ...; |
+| pre | Conditions.cs:137:21:137:26 | [Field1 (line 129): true, Field2 (line 129): true] access to field Field1 | Conditions.cs:137:21:137:37 | [Field1 (line 129): true, Field2 (line 129): true] call to method ToString |
+| pre | Conditions.cs:137:21:137:26 | [Field1 (line 129): true, Field2 (line 129): true] this access | Conditions.cs:137:21:137:26 | [Field1 (line 129): true, Field2 (line 129): true] access to field Field1 |
+| pre | Conditions.cs:137:21:137:37 | [Field1 (line 129): true, Field2 (line 129): true] call to method ToString | Conditions.cs:131:16:131:19 | [Field1 (line 129): true, Field2 (line 129): true] true |
+| pre | Conditions.cs:137:21:137:38 | [Field1 (line 129): true, Field2 (line 129): true] ...; | Conditions.cs:137:21:137:26 | [Field1 (line 129): true, Field2 (line 129): true] this access |
 | pre | ExitMethods.cs:7:10:7:11 | enter M1 | ExitMethods.cs:8:5:11:5 | {...} |
 | pre | ExitMethods.cs:8:5:11:5 | {...} | ExitMethods.cs:9:9:9:25 | ...; |
 | pre | ExitMethods.cs:9:9:9:24 | call to method ErrorMaybe | ExitMethods.cs:10:9:10:15 | return ...; |

--- a/csharp/ql/test/library-tests/controlflow/graph/Dominance.expected
+++ b/csharp/ql/test/library-tests/controlflow/graph/Dominance.expected
@@ -661,6 +661,20 @@
 | post | Conditions.cs:122:17:122:24 | ... = ... | Conditions.cs:122:21:122:24 | null |
 | post | Conditions.cs:122:17:122:25 | ...; | Conditions.cs:121:17:121:20 | [last (line 118): true] access to local variable last |
 | post | Conditions.cs:122:21:122:24 | null | Conditions.cs:122:17:122:17 | access to local variable s |
+| post | Conditions.cs:130:5:141:5 | {...} | Conditions.cs:129:10:129:12 | enter M10 |
+| post | Conditions.cs:131:9:140:9 | while (...) ... | Conditions.cs:130:5:141:5 | {...} |
+| post | Conditions.cs:131:16:131:19 | true | Conditions.cs:131:9:140:9 | while (...) ... |
+| post | Conditions.cs:132:9:140:9 | [Field1 (line 129): false] {...} | Conditions.cs:131:16:131:19 | [Field1 (line 129): false] true |
+| post | Conditions.cs:132:9:140:9 | {...} | Conditions.cs:131:16:131:19 | true |
+| post | Conditions.cs:133:13:139:13 | [Field1 (line 129): false] if (...) ... | Conditions.cs:132:9:140:9 | [Field1 (line 129): false] {...} |
+| post | Conditions.cs:133:13:139:13 | if (...) ... | Conditions.cs:132:9:140:9 | {...} |
+| post | Conditions.cs:133:17:133:22 | [Field1 (line 129): false] access to field Field1 | Conditions.cs:133:17:133:22 | [Field1 (line 129): false] this access |
+| post | Conditions.cs:133:17:133:22 | [Field1 (line 129): false] this access | Conditions.cs:133:13:139:13 | [Field1 (line 129): false] if (...) ... |
+| post | Conditions.cs:133:17:133:22 | access to field Field1 | Conditions.cs:133:17:133:22 | this access |
+| post | Conditions.cs:133:17:133:22 | this access | Conditions.cs:133:13:139:13 | if (...) ... |
+| post | Conditions.cs:135:17:138:17 | [Field1 (line 129): true] if (...) ... | Conditions.cs:134:13:139:13 | [Field1 (line 129): true] {...} |
+| post | Conditions.cs:135:21:135:26 | [Field1 (line 129): true] access to field Field2 | Conditions.cs:135:21:135:26 | [Field1 (line 129): true] this access |
+| post | Conditions.cs:135:21:135:26 | [Field1 (line 129): true] this access | Conditions.cs:135:17:138:17 | [Field1 (line 129): true] if (...) ... |
 | post | ExitMethods.cs:7:10:7:11 | exit M1 | ExitMethods.cs:10:9:10:15 | return ...; |
 | post | ExitMethods.cs:8:5:11:5 | {...} | ExitMethods.cs:7:10:7:11 | enter M1 |
 | post | ExitMethods.cs:9:9:9:24 | call to method ErrorMaybe | ExitMethods.cs:9:20:9:23 | true |
@@ -2828,6 +2842,22 @@
 | pre | Conditions.cs:122:17:122:17 | access to local variable s | Conditions.cs:122:21:122:24 | null |
 | pre | Conditions.cs:122:17:122:25 | ...; | Conditions.cs:122:17:122:17 | access to local variable s |
 | pre | Conditions.cs:122:21:122:24 | null | Conditions.cs:122:17:122:24 | ... = ... |
+| pre | Conditions.cs:129:10:129:12 | enter M10 | Conditions.cs:130:5:141:5 | {...} |
+| pre | Conditions.cs:130:5:141:5 | {...} | Conditions.cs:131:9:140:9 | while (...) ... |
+| pre | Conditions.cs:131:9:140:9 | while (...) ... | Conditions.cs:131:16:131:19 | true |
+| pre | Conditions.cs:131:16:131:19 | [Field1 (line 129): false] true | Conditions.cs:132:9:140:9 | [Field1 (line 129): false] {...} |
+| pre | Conditions.cs:131:16:131:19 | true | Conditions.cs:132:9:140:9 | {...} |
+| pre | Conditions.cs:132:9:140:9 | [Field1 (line 129): false] {...} | Conditions.cs:133:13:139:13 | [Field1 (line 129): false] if (...) ... |
+| pre | Conditions.cs:132:9:140:9 | {...} | Conditions.cs:133:13:139:13 | if (...) ... |
+| pre | Conditions.cs:133:13:139:13 | [Field1 (line 129): false] if (...) ... | Conditions.cs:133:17:133:22 | [Field1 (line 129): false] this access |
+| pre | Conditions.cs:133:13:139:13 | if (...) ... | Conditions.cs:133:17:133:22 | this access |
+| pre | Conditions.cs:133:17:133:22 | [Field1 (line 129): false] this access | Conditions.cs:133:17:133:22 | [Field1 (line 129): false] access to field Field1 |
+| pre | Conditions.cs:133:17:133:22 | access to field Field1 | Conditions.cs:131:16:131:19 | [Field1 (line 129): false] true |
+| pre | Conditions.cs:133:17:133:22 | access to field Field1 | Conditions.cs:134:13:139:13 | [Field1 (line 129): true] {...} |
+| pre | Conditions.cs:133:17:133:22 | this access | Conditions.cs:133:17:133:22 | access to field Field1 |
+| pre | Conditions.cs:134:13:139:13 | [Field1 (line 129): true] {...} | Conditions.cs:135:17:138:17 | [Field1 (line 129): true] if (...) ... |
+| pre | Conditions.cs:135:17:138:17 | [Field1 (line 129): true] if (...) ... | Conditions.cs:135:21:135:26 | [Field1 (line 129): true] this access |
+| pre | Conditions.cs:135:21:135:26 | [Field1 (line 129): true] this access | Conditions.cs:135:21:135:26 | [Field1 (line 129): true] access to field Field2 |
 | pre | ExitMethods.cs:7:10:7:11 | enter M1 | ExitMethods.cs:8:5:11:5 | {...} |
 | pre | ExitMethods.cs:8:5:11:5 | {...} | ExitMethods.cs:9:9:9:25 | ...; |
 | pre | ExitMethods.cs:9:9:9:24 | call to method ErrorMaybe | ExitMethods.cs:10:9:10:15 | return ...; |

--- a/csharp/ql/test/library-tests/controlflow/graph/ElementGraph.expected
+++ b/csharp/ql/test/library-tests/controlflow/graph/ElementGraph.expected
@@ -524,7 +524,14 @@
 | Conditions.cs:133:17:133:22 | this access | Conditions.cs:133:17:133:22 | access to field Field1 | semmle.label | successor |
 | Conditions.cs:134:13:139:13 | {...} | Conditions.cs:135:17:138:17 | if (...) ... | semmle.label | successor |
 | Conditions.cs:135:17:138:17 | if (...) ... | Conditions.cs:135:21:135:26 | this access | semmle.label | successor |
+| Conditions.cs:135:21:135:26 | access to field Field2 | Conditions.cs:131:16:131:19 | true | semmle.label | false |
+| Conditions.cs:135:21:135:26 | access to field Field2 | Conditions.cs:136:17:138:17 | {...} | semmle.label | true |
 | Conditions.cs:135:21:135:26 | this access | Conditions.cs:135:21:135:26 | access to field Field2 | semmle.label | successor |
+| Conditions.cs:136:17:138:17 | {...} | Conditions.cs:137:21:137:38 | ...; | semmle.label | successor |
+| Conditions.cs:137:21:137:26 | access to field Field1 | Conditions.cs:137:21:137:37 | call to method ToString | semmle.label | successor |
+| Conditions.cs:137:21:137:26 | this access | Conditions.cs:137:21:137:26 | access to field Field1 | semmle.label | successor |
+| Conditions.cs:137:21:137:37 | call to method ToString | Conditions.cs:131:16:131:19 | true | semmle.label | successor |
+| Conditions.cs:137:21:137:38 | ...; | Conditions.cs:137:21:137:26 | this access | semmle.label | successor |
 | ExitMethods.cs:8:5:11:5 | {...} | ExitMethods.cs:9:9:9:25 | ...; | semmle.label | successor |
 | ExitMethods.cs:9:9:9:24 | call to method ErrorMaybe | ExitMethods.cs:10:9:10:15 | return ...; | semmle.label | successor |
 | ExitMethods.cs:9:9:9:25 | ...; | ExitMethods.cs:9:20:9:23 | true | semmle.label | successor |

--- a/csharp/ql/test/library-tests/controlflow/graph/ElementGraph.expected
+++ b/csharp/ql/test/library-tests/controlflow/graph/ElementGraph.expected
@@ -514,6 +514,17 @@
 | Conditions.cs:122:17:122:24 | ... = ... | Conditions.cs:116:41:116:41 | access to local variable i | semmle.label | successor |
 | Conditions.cs:122:17:122:25 | ...; | Conditions.cs:122:17:122:17 | access to local variable s | semmle.label | successor |
 | Conditions.cs:122:21:122:24 | null | Conditions.cs:122:17:122:24 | ... = ... | semmle.label | successor |
+| Conditions.cs:130:5:141:5 | {...} | Conditions.cs:131:9:140:9 | while (...) ... | semmle.label | successor |
+| Conditions.cs:131:9:140:9 | while (...) ... | Conditions.cs:131:16:131:19 | true | semmle.label | successor |
+| Conditions.cs:131:16:131:19 | true | Conditions.cs:132:9:140:9 | {...} | semmle.label | true |
+| Conditions.cs:132:9:140:9 | {...} | Conditions.cs:133:13:139:13 | if (...) ... | semmle.label | successor |
+| Conditions.cs:133:13:139:13 | if (...) ... | Conditions.cs:133:17:133:22 | this access | semmle.label | successor |
+| Conditions.cs:133:17:133:22 | access to field Field1 | Conditions.cs:131:16:131:19 | true | semmle.label | false |
+| Conditions.cs:133:17:133:22 | access to field Field1 | Conditions.cs:134:13:139:13 | {...} | semmle.label | true |
+| Conditions.cs:133:17:133:22 | this access | Conditions.cs:133:17:133:22 | access to field Field1 | semmle.label | successor |
+| Conditions.cs:134:13:139:13 | {...} | Conditions.cs:135:17:138:17 | if (...) ... | semmle.label | successor |
+| Conditions.cs:135:17:138:17 | if (...) ... | Conditions.cs:135:21:135:26 | this access | semmle.label | successor |
+| Conditions.cs:135:21:135:26 | this access | Conditions.cs:135:21:135:26 | access to field Field2 | semmle.label | successor |
 | ExitMethods.cs:8:5:11:5 | {...} | ExitMethods.cs:9:9:9:25 | ...; | semmle.label | successor |
 | ExitMethods.cs:9:9:9:24 | call to method ErrorMaybe | ExitMethods.cs:10:9:10:15 | return ...; | semmle.label | successor |
 | ExitMethods.cs:9:9:9:25 | ...; | ExitMethods.cs:9:20:9:23 | true | semmle.label | successor |

--- a/csharp/ql/test/library-tests/controlflow/graph/EntryElement.expected
+++ b/csharp/ql/test/library-tests/controlflow/graph/EntryElement.expected
@@ -516,6 +516,22 @@
 | Conditions.cs:122:17:122:24 | ... = ... | Conditions.cs:122:17:122:17 | access to local variable s |
 | Conditions.cs:122:17:122:25 | ...; | Conditions.cs:122:17:122:25 | ...; |
 | Conditions.cs:122:21:122:24 | null | Conditions.cs:122:21:122:24 | null |
+| Conditions.cs:130:5:141:5 | {...} | Conditions.cs:130:5:141:5 | {...} |
+| Conditions.cs:131:9:140:9 | while (...) ... | Conditions.cs:131:9:140:9 | while (...) ... |
+| Conditions.cs:131:16:131:19 | true | Conditions.cs:131:16:131:19 | true |
+| Conditions.cs:132:9:140:9 | {...} | Conditions.cs:132:9:140:9 | {...} |
+| Conditions.cs:133:13:139:13 | if (...) ... | Conditions.cs:133:13:139:13 | if (...) ... |
+| Conditions.cs:133:17:133:22 | access to field Field1 | Conditions.cs:133:17:133:22 | this access |
+| Conditions.cs:133:17:133:22 | this access | Conditions.cs:133:17:133:22 | this access |
+| Conditions.cs:134:13:139:13 | {...} | Conditions.cs:134:13:139:13 | {...} |
+| Conditions.cs:135:17:138:17 | if (...) ... | Conditions.cs:135:17:138:17 | if (...) ... |
+| Conditions.cs:135:21:135:26 | access to field Field2 | Conditions.cs:135:21:135:26 | this access |
+| Conditions.cs:135:21:135:26 | this access | Conditions.cs:135:21:135:26 | this access |
+| Conditions.cs:136:17:138:17 | {...} | Conditions.cs:136:17:138:17 | {...} |
+| Conditions.cs:137:21:137:26 | access to field Field1 | Conditions.cs:137:21:137:26 | this access |
+| Conditions.cs:137:21:137:26 | this access | Conditions.cs:137:21:137:26 | this access |
+| Conditions.cs:137:21:137:37 | call to method ToString | Conditions.cs:137:21:137:26 | this access |
+| Conditions.cs:137:21:137:38 | ...; | Conditions.cs:137:21:137:38 | ...; |
 | ExitMethods.cs:8:5:11:5 | {...} | ExitMethods.cs:8:5:11:5 | {...} |
 | ExitMethods.cs:9:9:9:24 | call to method ErrorMaybe | ExitMethods.cs:9:20:9:23 | true |
 | ExitMethods.cs:9:9:9:25 | ...; | ExitMethods.cs:9:9:9:25 | ...; |

--- a/csharp/ql/test/library-tests/controlflow/graph/EntryPoint.expected
+++ b/csharp/ql/test/library-tests/controlflow/graph/EntryPoint.expected
@@ -33,6 +33,7 @@
 | Conditions.cs:86:9:86:10 | M7 | Conditions.cs:87:5:100:5 | {...} |
 | Conditions.cs:102:12:102:13 | M8 | Conditions.cs:103:5:111:5 | {...} |
 | Conditions.cs:113:10:113:11 | M9 | Conditions.cs:114:5:124:5 | {...} |
+| Conditions.cs:129:10:129:12 | M10 | Conditions.cs:130:5:141:5 | {...} |
 | ExitMethods.cs:7:10:7:11 | M1 | ExitMethods.cs:8:5:11:5 | {...} |
 | ExitMethods.cs:13:10:13:11 | M2 | ExitMethods.cs:14:5:17:5 | {...} |
 | ExitMethods.cs:19:10:19:11 | M3 | ExitMethods.cs:20:5:23:5 | {...} |

--- a/csharp/ql/test/library-tests/controlflow/graph/ExitElement.expected
+++ b/csharp/ql/test/library-tests/controlflow/graph/ExitElement.expected
@@ -717,6 +717,28 @@
 | Conditions.cs:122:17:122:24 | ... = ... | Conditions.cs:122:17:122:24 | ... = ... | normal |
 | Conditions.cs:122:17:122:25 | ...; | Conditions.cs:122:17:122:24 | ... = ... | normal |
 | Conditions.cs:122:21:122:24 | null | Conditions.cs:122:21:122:24 | null | normal |
+| Conditions.cs:131:16:131:19 | true | Conditions.cs:131:16:131:19 | true | true/true |
+| Conditions.cs:132:9:140:9 | {...} | Conditions.cs:133:17:133:22 | access to field Field1 | false/false |
+| Conditions.cs:132:9:140:9 | {...} | Conditions.cs:135:21:135:26 | access to field Field2 | false/false |
+| Conditions.cs:132:9:140:9 | {...} | Conditions.cs:137:21:137:37 | call to method ToString | normal |
+| Conditions.cs:133:13:139:13 | if (...) ... | Conditions.cs:133:17:133:22 | access to field Field1 | false/false |
+| Conditions.cs:133:13:139:13 | if (...) ... | Conditions.cs:135:21:135:26 | access to field Field2 | false/false |
+| Conditions.cs:133:13:139:13 | if (...) ... | Conditions.cs:137:21:137:37 | call to method ToString | normal |
+| Conditions.cs:133:17:133:22 | access to field Field1 | Conditions.cs:133:17:133:22 | access to field Field1 | false/false |
+| Conditions.cs:133:17:133:22 | access to field Field1 | Conditions.cs:133:17:133:22 | access to field Field1 | true/true |
+| Conditions.cs:133:17:133:22 | this access | Conditions.cs:133:17:133:22 | this access | normal |
+| Conditions.cs:134:13:139:13 | {...} | Conditions.cs:135:21:135:26 | access to field Field2 | false/false |
+| Conditions.cs:134:13:139:13 | {...} | Conditions.cs:137:21:137:37 | call to method ToString | normal |
+| Conditions.cs:135:17:138:17 | if (...) ... | Conditions.cs:135:21:135:26 | access to field Field2 | false/false |
+| Conditions.cs:135:17:138:17 | if (...) ... | Conditions.cs:137:21:137:37 | call to method ToString | normal |
+| Conditions.cs:135:21:135:26 | access to field Field2 | Conditions.cs:135:21:135:26 | access to field Field2 | false/false |
+| Conditions.cs:135:21:135:26 | access to field Field2 | Conditions.cs:135:21:135:26 | access to field Field2 | true/true |
+| Conditions.cs:135:21:135:26 | this access | Conditions.cs:135:21:135:26 | this access | normal |
+| Conditions.cs:136:17:138:17 | {...} | Conditions.cs:137:21:137:37 | call to method ToString | normal |
+| Conditions.cs:137:21:137:26 | access to field Field1 | Conditions.cs:137:21:137:26 | access to field Field1 | normal |
+| Conditions.cs:137:21:137:26 | this access | Conditions.cs:137:21:137:26 | this access | normal |
+| Conditions.cs:137:21:137:37 | call to method ToString | Conditions.cs:137:21:137:37 | call to method ToString | normal |
+| Conditions.cs:137:21:137:38 | ...; | Conditions.cs:137:21:137:37 | call to method ToString | normal |
 | ExitMethods.cs:8:5:11:5 | {...} | ExitMethods.cs:10:9:10:15 | return ...; | return |
 | ExitMethods.cs:9:9:9:24 | call to method ErrorMaybe | ExitMethods.cs:9:9:9:24 | call to method ErrorMaybe | normal |
 | ExitMethods.cs:9:9:9:25 | ...; | ExitMethods.cs:9:9:9:24 | call to method ErrorMaybe | normal |

--- a/csharp/ql/test/library-tests/controlflow/graph/NodeGraph.expected
+++ b/csharp/ql/test/library-tests/controlflow/graph/NodeGraph.expected
@@ -775,19 +775,44 @@
 | Conditions.cs:130:5:141:5 | {...} | Conditions.cs:131:9:140:9 | while (...) ... | semmle.label | successor |
 | Conditions.cs:131:9:140:9 | while (...) ... | Conditions.cs:131:16:131:19 | true | semmle.label | successor |
 | Conditions.cs:131:16:131:19 | [Field1 (line 129): false] true | Conditions.cs:132:9:140:9 | [Field1 (line 129): false] {...} | semmle.label | true |
+| Conditions.cs:131:16:131:19 | [Field1 (line 129): true, Field2 (line 129): false] true | Conditions.cs:132:9:140:9 | [Field1 (line 129): true, Field2 (line 129): false] {...} | semmle.label | true |
+| Conditions.cs:131:16:131:19 | [Field1 (line 129): true, Field2 (line 129): true] true | Conditions.cs:132:9:140:9 | [Field1 (line 129): true, Field2 (line 129): true] {...} | semmle.label | true |
 | Conditions.cs:131:16:131:19 | true | Conditions.cs:132:9:140:9 | {...} | semmle.label | true |
 | Conditions.cs:132:9:140:9 | [Field1 (line 129): false] {...} | Conditions.cs:133:13:139:13 | [Field1 (line 129): false] if (...) ... | semmle.label | successor |
+| Conditions.cs:132:9:140:9 | [Field1 (line 129): true, Field2 (line 129): false] {...} | Conditions.cs:133:13:139:13 | [Field1 (line 129): true, Field2 (line 129): false] if (...) ... | semmle.label | successor |
+| Conditions.cs:132:9:140:9 | [Field1 (line 129): true, Field2 (line 129): true] {...} | Conditions.cs:133:13:139:13 | [Field1 (line 129): true, Field2 (line 129): true] if (...) ... | semmle.label | successor |
 | Conditions.cs:132:9:140:9 | {...} | Conditions.cs:133:13:139:13 | if (...) ... | semmle.label | successor |
 | Conditions.cs:133:13:139:13 | [Field1 (line 129): false] if (...) ... | Conditions.cs:133:17:133:22 | [Field1 (line 129): false] this access | semmle.label | successor |
+| Conditions.cs:133:13:139:13 | [Field1 (line 129): true, Field2 (line 129): false] if (...) ... | Conditions.cs:133:17:133:22 | [Field1 (line 129): true, Field2 (line 129): false] this access | semmle.label | successor |
+| Conditions.cs:133:13:139:13 | [Field1 (line 129): true, Field2 (line 129): true] if (...) ... | Conditions.cs:133:17:133:22 | [Field1 (line 129): true, Field2 (line 129): true] this access | semmle.label | successor |
 | Conditions.cs:133:13:139:13 | if (...) ... | Conditions.cs:133:17:133:22 | this access | semmle.label | successor |
 | Conditions.cs:133:17:133:22 | [Field1 (line 129): false] access to field Field1 | Conditions.cs:131:16:131:19 | [Field1 (line 129): false] true | semmle.label | false |
 | Conditions.cs:133:17:133:22 | [Field1 (line 129): false] this access | Conditions.cs:133:17:133:22 | [Field1 (line 129): false] access to field Field1 | semmle.label | successor |
+| Conditions.cs:133:17:133:22 | [Field1 (line 129): true, Field2 (line 129): false] access to field Field1 | Conditions.cs:134:13:139:13 | [Field1 (line 129): true, Field2 (line 129): false] {...} | semmle.label | true |
+| Conditions.cs:133:17:133:22 | [Field1 (line 129): true, Field2 (line 129): false] this access | Conditions.cs:133:17:133:22 | [Field1 (line 129): true, Field2 (line 129): false] access to field Field1 | semmle.label | successor |
+| Conditions.cs:133:17:133:22 | [Field1 (line 129): true, Field2 (line 129): true] access to field Field1 | Conditions.cs:134:13:139:13 | [Field1 (line 129): true, Field2 (line 129): true] {...} | semmle.label | true |
+| Conditions.cs:133:17:133:22 | [Field1 (line 129): true, Field2 (line 129): true] this access | Conditions.cs:133:17:133:22 | [Field1 (line 129): true, Field2 (line 129): true] access to field Field1 | semmle.label | successor |
 | Conditions.cs:133:17:133:22 | access to field Field1 | Conditions.cs:131:16:131:19 | [Field1 (line 129): false] true | semmle.label | false |
 | Conditions.cs:133:17:133:22 | access to field Field1 | Conditions.cs:134:13:139:13 | [Field1 (line 129): true] {...} | semmle.label | true |
 | Conditions.cs:133:17:133:22 | this access | Conditions.cs:133:17:133:22 | access to field Field1 | semmle.label | successor |
+| Conditions.cs:134:13:139:13 | [Field1 (line 129): true, Field2 (line 129): false] {...} | Conditions.cs:135:17:138:17 | [Field1 (line 129): true, Field2 (line 129): false] if (...) ... | semmle.label | successor |
+| Conditions.cs:134:13:139:13 | [Field1 (line 129): true, Field2 (line 129): true] {...} | Conditions.cs:135:17:138:17 | [Field1 (line 129): true, Field2 (line 129): true] if (...) ... | semmle.label | successor |
 | Conditions.cs:134:13:139:13 | [Field1 (line 129): true] {...} | Conditions.cs:135:17:138:17 | [Field1 (line 129): true] if (...) ... | semmle.label | successor |
+| Conditions.cs:135:17:138:17 | [Field1 (line 129): true, Field2 (line 129): false] if (...) ... | Conditions.cs:135:21:135:26 | [Field1 (line 129): true, Field2 (line 129): false] this access | semmle.label | successor |
+| Conditions.cs:135:17:138:17 | [Field1 (line 129): true, Field2 (line 129): true] if (...) ... | Conditions.cs:135:21:135:26 | [Field1 (line 129): true, Field2 (line 129): true] this access | semmle.label | successor |
 | Conditions.cs:135:17:138:17 | [Field1 (line 129): true] if (...) ... | Conditions.cs:135:21:135:26 | [Field1 (line 129): true] this access | semmle.label | successor |
+| Conditions.cs:135:21:135:26 | [Field1 (line 129): true, Field2 (line 129): false] access to field Field2 | Conditions.cs:131:16:131:19 | [Field1 (line 129): true, Field2 (line 129): false] true | semmle.label | false |
+| Conditions.cs:135:21:135:26 | [Field1 (line 129): true, Field2 (line 129): false] this access | Conditions.cs:135:21:135:26 | [Field1 (line 129): true, Field2 (line 129): false] access to field Field2 | semmle.label | successor |
+| Conditions.cs:135:21:135:26 | [Field1 (line 129): true, Field2 (line 129): true] access to field Field2 | Conditions.cs:136:17:138:17 | [Field1 (line 129): true, Field2 (line 129): true] {...} | semmle.label | true |
+| Conditions.cs:135:21:135:26 | [Field1 (line 129): true, Field2 (line 129): true] this access | Conditions.cs:135:21:135:26 | [Field1 (line 129): true, Field2 (line 129): true] access to field Field2 | semmle.label | successor |
+| Conditions.cs:135:21:135:26 | [Field1 (line 129): true] access to field Field2 | Conditions.cs:131:16:131:19 | [Field1 (line 129): true, Field2 (line 129): false] true | semmle.label | false |
+| Conditions.cs:135:21:135:26 | [Field1 (line 129): true] access to field Field2 | Conditions.cs:136:17:138:17 | [Field1 (line 129): true, Field2 (line 129): true] {...} | semmle.label | true |
 | Conditions.cs:135:21:135:26 | [Field1 (line 129): true] this access | Conditions.cs:135:21:135:26 | [Field1 (line 129): true] access to field Field2 | semmle.label | successor |
+| Conditions.cs:136:17:138:17 | [Field1 (line 129): true, Field2 (line 129): true] {...} | Conditions.cs:137:21:137:38 | [Field1 (line 129): true, Field2 (line 129): true] ...; | semmle.label | successor |
+| Conditions.cs:137:21:137:26 | [Field1 (line 129): true, Field2 (line 129): true] access to field Field1 | Conditions.cs:137:21:137:37 | [Field1 (line 129): true, Field2 (line 129): true] call to method ToString | semmle.label | successor |
+| Conditions.cs:137:21:137:26 | [Field1 (line 129): true, Field2 (line 129): true] this access | Conditions.cs:137:21:137:26 | [Field1 (line 129): true, Field2 (line 129): true] access to field Field1 | semmle.label | successor |
+| Conditions.cs:137:21:137:37 | [Field1 (line 129): true, Field2 (line 129): true] call to method ToString | Conditions.cs:131:16:131:19 | [Field1 (line 129): true, Field2 (line 129): true] true | semmle.label | successor |
+| Conditions.cs:137:21:137:38 | [Field1 (line 129): true, Field2 (line 129): true] ...; | Conditions.cs:137:21:137:26 | [Field1 (line 129): true, Field2 (line 129): true] this access | semmle.label | successor |
 | ExitMethods.cs:7:10:7:11 | enter M1 | ExitMethods.cs:8:5:11:5 | {...} | semmle.label | successor |
 | ExitMethods.cs:8:5:11:5 | {...} | ExitMethods.cs:9:9:9:25 | ...; | semmle.label | successor |
 | ExitMethods.cs:9:9:9:24 | call to method ErrorMaybe | ExitMethods.cs:10:9:10:15 | return ...; | semmle.label | successor |

--- a/csharp/ql/test/library-tests/controlflow/graph/NodeGraph.expected
+++ b/csharp/ql/test/library-tests/controlflow/graph/NodeGraph.expected
@@ -771,6 +771,23 @@
 | Conditions.cs:122:17:122:24 | ... = ... | Conditions.cs:116:41:116:41 | access to local variable i | semmle.label | successor |
 | Conditions.cs:122:17:122:25 | ...; | Conditions.cs:122:17:122:17 | access to local variable s | semmle.label | successor |
 | Conditions.cs:122:21:122:24 | null | Conditions.cs:122:17:122:24 | ... = ... | semmle.label | successor |
+| Conditions.cs:129:10:129:12 | enter M10 | Conditions.cs:130:5:141:5 | {...} | semmle.label | successor |
+| Conditions.cs:130:5:141:5 | {...} | Conditions.cs:131:9:140:9 | while (...) ... | semmle.label | successor |
+| Conditions.cs:131:9:140:9 | while (...) ... | Conditions.cs:131:16:131:19 | true | semmle.label | successor |
+| Conditions.cs:131:16:131:19 | [Field1 (line 129): false] true | Conditions.cs:132:9:140:9 | [Field1 (line 129): false] {...} | semmle.label | true |
+| Conditions.cs:131:16:131:19 | true | Conditions.cs:132:9:140:9 | {...} | semmle.label | true |
+| Conditions.cs:132:9:140:9 | [Field1 (line 129): false] {...} | Conditions.cs:133:13:139:13 | [Field1 (line 129): false] if (...) ... | semmle.label | successor |
+| Conditions.cs:132:9:140:9 | {...} | Conditions.cs:133:13:139:13 | if (...) ... | semmle.label | successor |
+| Conditions.cs:133:13:139:13 | [Field1 (line 129): false] if (...) ... | Conditions.cs:133:17:133:22 | [Field1 (line 129): false] this access | semmle.label | successor |
+| Conditions.cs:133:13:139:13 | if (...) ... | Conditions.cs:133:17:133:22 | this access | semmle.label | successor |
+| Conditions.cs:133:17:133:22 | [Field1 (line 129): false] access to field Field1 | Conditions.cs:131:16:131:19 | [Field1 (line 129): false] true | semmle.label | false |
+| Conditions.cs:133:17:133:22 | [Field1 (line 129): false] this access | Conditions.cs:133:17:133:22 | [Field1 (line 129): false] access to field Field1 | semmle.label | successor |
+| Conditions.cs:133:17:133:22 | access to field Field1 | Conditions.cs:131:16:131:19 | [Field1 (line 129): false] true | semmle.label | false |
+| Conditions.cs:133:17:133:22 | access to field Field1 | Conditions.cs:134:13:139:13 | [Field1 (line 129): true] {...} | semmle.label | true |
+| Conditions.cs:133:17:133:22 | this access | Conditions.cs:133:17:133:22 | access to field Field1 | semmle.label | successor |
+| Conditions.cs:134:13:139:13 | [Field1 (line 129): true] {...} | Conditions.cs:135:17:138:17 | [Field1 (line 129): true] if (...) ... | semmle.label | successor |
+| Conditions.cs:135:17:138:17 | [Field1 (line 129): true] if (...) ... | Conditions.cs:135:21:135:26 | [Field1 (line 129): true] this access | semmle.label | successor |
+| Conditions.cs:135:21:135:26 | [Field1 (line 129): true] this access | Conditions.cs:135:21:135:26 | [Field1 (line 129): true] access to field Field2 | semmle.label | successor |
 | ExitMethods.cs:7:10:7:11 | enter M1 | ExitMethods.cs:8:5:11:5 | {...} | semmle.label | successor |
 | ExitMethods.cs:8:5:11:5 | {...} | ExitMethods.cs:9:9:9:25 | ...; | semmle.label | successor |
 | ExitMethods.cs:9:9:9:24 | call to method ErrorMaybe | ExitMethods.cs:10:9:10:15 | return ...; | semmle.label | successor |


### PR DESCRIPTION
The internal pre-SSA library was extended on 3e78c26 to include fields/properties that are local-scope-like. The CFG splitting logic uses ranking of SSA definitions to define an (arbitrary) order of splits, but for fields/properties the implicit entry definition all have the same line and column. In effect, such SSA definitions incorrectly get the same rank. Adding the name of the field/property to the lexicographic ordering resolves the issue.