### PR TITLE
C++: we now process operands for vacuous destructor calls through pointers

### DIFF
--- a/cpp/ql/test/examples/expressions/PrintAST.expected
+++ b/cpp/ql/test/examples/expressions/PrintAST.expected
@@ -886,6 +886,9 @@ VacuousDestructorCall.cpp:
 #    4|       0: (vacuous destructor call)
 #    4|           Type = void
 #    4|           ValueCategory = prvalue
+#    4|         0: y
+#    4|             Type = int *
+#    4|             ValueCategory = prvalue(load)
 #    5|     2: return ...
 #    7| Vacuous(int) -> void
 #    7|   params: 


### PR DESCRIPTION
Just an update to the expected test output, to match extractor changes.