### PR TITLE
Python: Fix up computation of import root path

### DIFF
--- a/python/ql/src/semmle/python/Files.qll
+++ b/python/ql/src/semmle/python/Files.qll
@@ -339,9 +339,21 @@ abstract class Container extends @container {
 
     /** Holds if this folder is the root folder for the standard library. */
     predicate isStdLibRoot(int major, int minor) {
-        allowable_version(major, minor) and
-        this.isImportRoot() and
-        this.getBaseName().regexpMatch("python" + major + "." + minor)
+        major = major_version() and minor = minor_version() and
+        this.isStdLibRoot()
+    }
+
+    /** Holds if this folder is the root folder for the standard library. */
+    predicate isStdLibRoot() {
+        /* Look for a standard lib module and find its import path
+         * We use `os` as it is the most likely to be imported and
+         * `tty` because it is small for testing.
+         */
+        exists(Module m |
+            m.getName() = "os" or m.getName() = "tty"
+            |
+            m.getFile().getImportRoot() = this
+        )
     }
 
     /** Gets the path element from which this container would be loaded. */
@@ -373,12 +385,6 @@ private string import_path_element(int n) {
 
 private string get_path(string name) {
     py_flags_versioned(name, result, _)
-}
-
-private predicate allowable_version(int major, int minor) {
-    major = 2 and minor in [6..7]
-    or
-    major = 3 and minor in [3..6]
 }
 
 class Location extends @location {

--- a/python/ql/src/semmle/python/Module.qll
+++ b/python/ql/src/semmle/python/Module.qll
@@ -158,7 +158,7 @@ class Module extends Module_, Scope, AstNode {
 
     /** Holds if this module is in the standard library */
     predicate inStdLib() {
-        this.inStdLib(_, _)
+        this.getLoadPath().isStdLibRoot()
     }
 
     override

--- a/python/ql/src/semmle/python/dependencies/TechInventory.qll
+++ b/python/ql/src/semmle/python/dependencies/TechInventory.qll
@@ -50,7 +50,7 @@ class DistPackage extends ExternalPackage {
             parent = this.(ModuleObject).getPath().getParent() and
             parent.isImportRoot() and
             /* Not in standard library */
-            not parent.isStdLibRoot(_, _) and
+            not parent.isStdLibRoot() and
             /* Not in the source */
             not exists(parent.getRelativePath())
         )

--- a/python/ql/test/library-tests/taint/exception_traceback/test.py
+++ b/python/ql/test/library-tests/taint/exception_traceback/test.py
@@ -28,3 +28,7 @@ def foo():
 
 
 foo()
+
+
+#For test to find stdlib
+import os


### PR DESCRIPTION
Fixes path computation for 3.7 upwards, Windows and other OSes.
Instead of attempting to guess which path contains the standard library, we do what the interpreter does and look for the `os` module.

The only potential problem is that some tiny projects may not import `os` and thus be unable to tell whether something is in the standard library or not. In practice this is unlikely to matter, as `inStdLib()` is not used in any of our queries and only a handful of projects do not import `os`.