### PR TITLE
TS: cache type IDs on type objects

### DIFF
--- a/javascript/extractor/lib/typescript/src/type_table.ts
+++ b/javascript/extractor/lib/typescript/src/type_table.ts
@@ -971,8 +971,12 @@ export class TypeTable {
     }
     let selfType = this.getSelfType(type);
     if (selfType != null) {
-      this.checkExpansiveness(selfType);
       let id = this.getId(selfType);
+      let expansiveness = this.expansiveTypes.get(id);
+      if (expansiveness != null) {
+        return expansiveness;
+      }
+      this.checkExpansiveness(selfType);
       return this.expansiveTypes.get(id);
     }
     return false;


### PR DESCRIPTION
This speeds up full-mode extraction by caching the ID of a type on TypeScript type object, and checking the expansiveness cache a bit earlier. Type objects do not survive across different compiler instances, so the cache really is temporary and is not a replacement for any of the `Map` instances stored on the type table.

|            | before | after | difference
|------------|--------|-------|--------------
| vscode     |  334s | 334s | 0s (0%)
| TypeScript | 440s       | 350s      | 90s (20%)
| angular    | 224s       | 208     | 16s (7%)

The benchmark for https://github.com/Semmle/ql/pull/479 showed TypeScript to be an outlier, in that full-mode had a 10X overhead on TypeScript, whereas other projects are closer to 2X. The larger impact on TypeScript is expected as a larger fraction of its time is spent extracting types.