### PR TITLE
C++: data flow AlwaysTrueUponEntryLoop perf fix

### DIFF
--- a/cpp/ql/src/semmle/code/cpp/dataflow/internal/FlowVar.qll
+++ b/cpp/ql/src/semmle/code/cpp/dataflow/internal/FlowVar.qll
@@ -292,14 +292,20 @@ module FlowVar_internal {
      * Gets a variable that is assigned in this loop and read outside the loop.
      */
     private Variable getARelevantVariable() {
-      exists(BasicBlock bbAssign |
-        assignmentLikeOperation(bbAssign.getANode(), result, _) and
-        this.bbInLoop(bbAssign)
-      ) and
+      result = this.getAVariableAssignedInLoop() and
       exists(VariableAccess va |
         va.getTarget() = result and
         readAccess(va) and
         bbNotInLoop(va.getBasicBlock())
+      )
+    }
+
+    /** Gets a variable that is assigned in this loop. */
+    pragma[noinline]
+    private Variable getAVariableAssignedInLoop() {
+      exists(BasicBlock bbAssign |
+        assignmentLikeOperation(bbAssign.getANode(), result, _) and
+        this.bbInLoop(bbAssign)
       )
     }
 


### PR DESCRIPTION
The predicate `AlwaysTrueUponEntryLoop.getARelevantVariable` was very sensitive to join ordering, and with the 1.19 QL engine it got an unfortunate join order that made it explode on certain snapshots. With this change, it goes from taking minutes to taking less than a second on a libretro-uae snapshot.

This should fix the problem noticed by @geoffw0 in #403. Please test.