### PR TITLE
Python ESSA: Fix definition of ESSA non-local variables.

### DIFF
--- a/python/ql/test/library-tests/PointsTo/new/Dataflow.expected
+++ b/python/ql/test/library-tests/PointsTo/new/Dataflow.expected
@@ -698,10 +698,8 @@
 | r_regressions.py:61 | obj_0 = ParameterDefinition |
 | r_regressions.py:61 | obj_3 = phi(obj_1, obj_2) |
 | r_regressions.py:62 | is_class_0 = isinstance() |
-| r_regressions.py:62 | name_2 = CallsiteRefinement(name_1) |
 | r_regressions.py:62 | obj_1 = ArgumentRefinement(obj_0) |
 | r_regressions.py:64 | is_class_1 = Pi(is_class_0) [true] |
-| r_regressions.py:64 | name_3 = CallsiteRefinement(name_2) |
 | r_regressions.py:66 | func_1 = obj |
 | r_regressions.py:66 | is_class_2 = Pi(is_class_0) [false] |
 | r_regressions.py:68 | _wrapper_0 = FunctionExpr |
@@ -709,7 +707,6 @@
 | r_regressions.py:68 | func_2 = phi(func_0, func_1) |
 | r_regressions.py:68 | is_class_3 = phi(is_class_1, is_class_2) |
 | r_regressions.py:68 | kwargs_0 = ParameterDefinition |
-| r_regressions.py:68 | name_4 = phi(name_2, name_3) |
 | r_regressions.py:68 | self_0 = ParameterDefinition |
 | r_regressions.py:73 | is_class_4 = Pi(is_class_3) [true] |
 | r_regressions.py:73 | obj_2 = ArgumentRefinement(obj_1) |

--- a/python/ql/test/library-tests/PointsTo/new/SourceNodeDefinitions.expected
+++ b/python/ql/test/library-tests/PointsTo/new/SourceNodeDefinitions.expected
@@ -103,7 +103,6 @@
 | b_condition.py:82 | Local Variable foo | ControlFlowNode for callable() | refinement |
 | b_condition.py:83 | Local Variable bar | ControlFlowNode for bar | definition |
 | b_condition.py:83 | Local Variable foo | Entry node for Function bar | definition |
-| b_condition.py:84 | Local Variable foo | ControlFlowNode for foo() | refinement |
 | b_condition.py:87 | Global Variable split_bool1 | ControlFlowNode for split_bool1 | definition |
 | b_condition.py:87 | Local Variable x | ControlFlowNode for x | definition |
 | b_condition.py:87 | Local Variable y | ControlFlowNode for y | definition |

--- a/python/ql/test/library-tests/PointsTo/new/SsaUses.expected
+++ b/python/ql/test/library-tests/PointsTo/new/SsaUses.expected
@@ -148,10 +148,8 @@
 | b_condition.py:79 | t_3 | ControlFlowNode for t |
 | b_condition.py:81 | bar_2 | Exit node for Function odasa6261 |
 | b_condition.py:81 | foo_5 | Exit node for Function odasa6261 |
-| b_condition.py:82 | foo_0 | ControlFlowNode for callable() |
 | b_condition.py:82 | foo_0 | ControlFlowNode for foo |
 | b_condition.py:84 | foo_3 | ControlFlowNode for foo |
-| b_condition.py:84 | foo_3 | ControlFlowNode for foo() |
 | b_condition.py:87 | x_3 | Exit node for Function split_bool1 |
 | b_condition.py:87 | x_8 | Exit node for Function split_bool1 |
 | b_condition.py:87 | y_3 | Exit node for Function split_bool1 |

--- a/python/ql/test/library-tests/PointsTo/new/VarUses.expected
+++ b/python/ql/test/library-tests/PointsTo/new/VarUses.expected
@@ -175,10 +175,8 @@
 | b_condition.py:81 | bar | Exit node for Function odasa6261 |
 | b_condition.py:81 | foo | Exit node for Function odasa6261 |
 | b_condition.py:82 | callable | ControlFlowNode for callable |
-| b_condition.py:82 | foo | ControlFlowNode for callable() |
 | b_condition.py:82 | foo | ControlFlowNode for foo |
 | b_condition.py:84 | foo | ControlFlowNode for foo |
-| b_condition.py:84 | foo | ControlFlowNode for foo() |
 | b_condition.py:87 | x | Exit node for Function split_bool1 |
 | b_condition.py:87 | y | Exit node for Function split_bool1 |
 | b_condition.py:88 | x | ControlFlowNode for x |


### PR DESCRIPTION
Previously, any variable used an inner function was given an ESSA definition for each call in that function, even if it was not defined out of scope.
This resulted in gigantic numbers of definitions. For example [this function](https://github.com/sympy/sympy/blob/master/sympy/integrals/rubi/rules/trinomial_products.py#L139) had over 3 million spurious "definitions".

This PR fixes that.