### PR TITLE
JS: optimistic tracking of Hapi route handlers

### DIFF
--- a/change-notes/1.20/analysis-javascript.md
+++ b/change-notes/1.20/analysis-javascript.md
@@ -2,6 +2,9 @@
 
 ## General improvements
 
+* Support for popular libraries has been improved. Consequently, queries may produce more results on code bases that use the following features:
+  - servers, for example [hapi](https://hapijs.com/)
+
 ## New queries
 
 | **Query**                                     | **Tags**                                             | **Purpose**                                                                                                                                                                 |

--- a/javascript/ql/src/semmle/javascript/frameworks/ConnectExpressShared.qll
+++ b/javascript/ql/src/semmle/javascript/frameworks/ConnectExpressShared.qll
@@ -32,9 +32,7 @@ module ConnectExpressShared {
    *
    * For example, this could be the function `function(req, res, next){...}`.
    */
-  class RouteHandlerCandidate extends HTTP::RouteHandlerCandidate, DataFlow::FunctionNode {
-
-    override Function astNode;
+  class RouteHandlerCandidate extends HTTP::RouteHandlerCandidate {
 
     RouteHandlerCandidate() {
       exists (string request, string response, string next, string error |

--- a/javascript/ql/src/semmle/javascript/frameworks/Hapi.qll
+++ b/javascript/ql/src/semmle/javascript/frameworks/Hapi.qll
@@ -228,9 +228,7 @@ module Hapi {
    *
    * For example, this could be the function `function(request, h){...}`.
    */
-  class RouteHandlerCandidate extends HTTP::RouteHandlerCandidate, DataFlow::FunctionNode {
-
-    override Function astNode;
+  class RouteHandlerCandidate extends HTTP::RouteHandlerCandidate {
 
     RouteHandlerCandidate() {
       exists (string request, string responseToolkit |

--- a/javascript/ql/src/semmle/javascript/frameworks/NodeJSLib.qll
+++ b/javascript/ql/src/semmle/javascript/frameworks/NodeJSLib.qll
@@ -597,9 +597,7 @@ module NodeJSLib {
    *
    * For example, this could be the function `function(req, res){...}`.
    */
-  class RouteHandlerCandidate extends HTTP::RouteHandlerCandidate, DataFlow::FunctionNode {
-
-    override Function astNode;
+  class RouteHandlerCandidate extends HTTP::RouteHandlerCandidate {
 
     RouteHandlerCandidate() {
       exists (string request, string response |

--- a/javascript/ql/src/semmle/javascript/heuristics/AdditionalRouteHandlers.qll
+++ b/javascript/ql/src/semmle/javascript/heuristics/AdditionalRouteHandlers.qll
@@ -8,7 +8,7 @@ import javascript
 private import semmle.javascript.frameworks.ConnectExpressShared
 
 /**
- * Adds `NodeJSLib::RouteHandlerCandidate` to the extent of `NodeJSLib::RouteHandler`.
+ * Add `NodeJSLib::RouteHandlerCandidate` to the extent of `NodeJSLib::RouteHandler`.
  */
 private class PromotedNodeJSLibCandidate extends NodeJSLib::RouteHandler, HTTP::Servers::StandardRouteHandler {
 
@@ -19,7 +19,7 @@ private class PromotedNodeJSLibCandidate extends NodeJSLib::RouteHandler, HTTP::
 }
 
 /**
- * Adds `Hapi::RouteHandlerCandidate` to the extent of `Hapi::RouteHandler`.
+ * Add `Hapi::RouteHandlerCandidate` to the extent of `Hapi::RouteHandler`.
  */
 private class PromotedHapiCandidate extends Hapi::RouteHandler, HTTP::Servers::StandardRouteHandler {
 
@@ -30,7 +30,7 @@ private class PromotedHapiCandidate extends Hapi::RouteHandler, HTTP::Servers::S
 }
 
 /**
- * Adds `ConnectExpressShared::RouteHandlerCandidate` to the extent of `Express::RouteHandler`.
+ * Add `ConnectExpressShared::RouteHandlerCandidate` to the extent of `Express::RouteHandler`.
  */
 private class PromotedExpressCandidate extends Express::RouteHandler, HTTP::Servers::StandardRouteHandler {
 
@@ -45,7 +45,7 @@ private class PromotedExpressCandidate extends Express::RouteHandler, HTTP::Serv
 }
 
 /**
- * Adds `ConnectExpressShared::RouteHandlerCandidate` to the extent of `Connect::RouteHandler`.
+ * Add `ConnectExpressShared::RouteHandlerCandidate` to the extent of `Connect::RouteHandler`.
  */
 private class PromotedConnectCandidate extends Connect::RouteHandler, HTTP::Servers::StandardRouteHandler {
 

--- a/javascript/ql/src/semmle/javascript/heuristics/AdditionalRouteHandlers.qll
+++ b/javascript/ql/src/semmle/javascript/heuristics/AdditionalRouteHandlers.qll
@@ -19,6 +19,17 @@ private class PromotedNodeJSLibCandidate extends NodeJSLib::RouteHandler, HTTP::
 }
 
 /**
+ * Adds `Hapi::RouteHandlerCandidate` to the extent of `Hapi::RouteHandler`.
+ */
+private class PromotedHapiCandidate extends Hapi::RouteHandler, HTTP::Servers::StandardRouteHandler {
+
+    PromotedHapiCandidate() {
+      this instanceof Hapi::RouteHandlerCandidate
+    }
+
+}
+
+/**
  * Adds `ConnectExpressShared::RouteHandlerCandidate` to the extent of `Express::RouteHandler`.
  */
 private class PromotedExpressCandidate extends Express::RouteHandler, HTTP::Servers::StandardRouteHandler {

--- a/javascript/ql/test/library-tests/frameworks/HTTP-heuristics/RouteHandlerCandidate.expected
+++ b/javascript/ql/test/library-tests/frameworks/HTTP-heuristics/RouteHandlerCandidate.expected
@@ -15,6 +15,7 @@
 | src/exported-middleware-attacher.js:2:13:2:32 | function(req, res){} |
 | src/handler-in-property.js:5:14:5:33 | function(req, res){} |
 | src/handler-in-property.js:12:18:12:37 | function(req, res){} |
+| src/hapi.js:1:1:1:30 | functio ... t, h){} |
 | src/iterated-handlers.js:4:2:4:22 | functio ...  res){} |
 | src/middleware-attacher-getter.js:4:17:4:36 | function(req, res){} |
 | src/middleware-attacher-getter.js:19:19:19:38 | function(req, res){} |

--- a/javascript/ql/test/library-tests/frameworks/HTTP-heuristics/UnpromotedRouteHandlerCandidate.expected
+++ b/javascript/ql/test/library-tests/frameworks/HTTP-heuristics/UnpromotedRouteHandlerCandidate.expected
@@ -1,5 +1,6 @@
 | src/bound-handler.js:4:1:4:28 | functio ...  res){} | A `RouteHandlerCandidate` that did not get promoted to `RouteHandler`, and it is not used in a `RouteSetupCandidate`. |
 | src/bound-handler.js:9:12:9:31 | function(req, res){} | A `RouteHandlerCandidate` that did not get promoted to `RouteHandler`, and it is not used in a `RouteSetupCandidate`. |
+| src/hapi.js:1:1:1:30 | functio ... t, h){} | A `RouteHandlerCandidate` that did not get promoted to `RouteHandler`, and it is not used in a `RouteSetupCandidate`. |
 | src/iterated-handlers.js:4:2:4:22 | functio ...  res){} | A `RouteHandlerCandidate` that did not get promoted to `RouteHandler`, and it is not used in a `RouteSetupCandidate`. |
 | src/middleware-attacher-getter.js:29:32:29:51 | function(req, res){} | A `RouteHandlerCandidate` that did not get promoted to `RouteHandler`, and it is not used in a `RouteSetupCandidate`. |
 | src/route-objects.js:7:19:7:38 | function(req, res){} | A `RouteHandlerCandidate` that did not get promoted to `RouteHandler`, and it is not used in a `RouteSetupCandidate`. |

--- a/javascript/ql/test/library-tests/frameworks/HTTP-heuristics/src/hapi.js
+++ b/javascript/ql/test/library-tests/frameworks/HTTP-heuristics/src/hapi.js
@@ -1,0 +1,1 @@
+function handler(request, h){}

--- a/javascript/ql/test/library-tests/frameworks/hapi/RouteHandler.expected
+++ b/javascript/ql/test/library-tests/frameworks/hapi/RouteHandler.expected
@@ -2,3 +2,4 @@
 | src/hapi.js:13:14:15:5 | functio ... n\\n    } | src/hapi.js:4:15:4:31 | new Hapi.Server() |
 | src/hapi.js:17:30:18:1 | functio ... ndler\\n} | src/hapi.js:4:15:4:31 | new Hapi.Server() |
 | src/hapi.js:20:1:27:1 | functio ... oken;\\n} | src/hapi.js:4:15:4:31 | new Hapi.Server() |
+| src/hapi.js:34:12:34:30 | function (req, h){} | src/hapi.js:4:15:4:31 | new Hapi.Server() |

--- a/javascript/ql/test/library-tests/frameworks/hapi/RouteSetup.expected
+++ b/javascript/ql/test/library-tests/frameworks/hapi/RouteSetup.expected
@@ -2,3 +2,4 @@
 | src/hapi.js:12:1:15:7 | server2 ...     }}) |
 | src/hapi.js:17:1:18:2 | server2 ... dler\\n}) |
 | src/hapi.js:29:1:29:20 | server2.route(route) |
+| src/hapi.js:36:1:36:38 | server2 ... ler()}) |

--- a/javascript/ql/test/library-tests/frameworks/hapi/RouteSetup_getARouteHandler.expected
+++ b/javascript/ql/test/library-tests/frameworks/hapi/RouteSetup_getARouteHandler.expected
@@ -2,3 +2,5 @@
 | src/hapi.js:12:1:15:7 | server2 ...     }}) | src/hapi.js:13:14:15:5 | functio ... n\\n    } |
 | src/hapi.js:17:1:18:2 | server2 ... dler\\n}) | src/hapi.js:17:30:18:1 | functio ... ndler\\n} |
 | src/hapi.js:29:1:29:20 | server2.route(route) | src/hapi.js:20:1:27:1 | functio ... oken;\\n} |
+| src/hapi.js:36:1:36:38 | server2 ... ler()}) | src/hapi.js:34:12:34:30 | function (req, h){} |
+| src/hapi.js:36:1:36:38 | server2 ... ler()}) | src/hapi.js:36:25:36:36 | getHandler() |

--- a/javascript/ql/test/library-tests/frameworks/hapi/RouteSetup_getServer.expected
+++ b/javascript/ql/test/library-tests/frameworks/hapi/RouteSetup_getServer.expected
@@ -2,3 +2,4 @@
 | src/hapi.js:12:1:15:7 | server2 ...     }}) | src/hapi.js:4:15:4:31 | new Hapi.Server() |
 | src/hapi.js:17:1:18:2 | server2 ... dler\\n}) | src/hapi.js:4:15:4:31 | new Hapi.Server() |
 | src/hapi.js:29:1:29:20 | server2.route(route) | src/hapi.js:4:15:4:31 | new Hapi.Server() |
+| src/hapi.js:36:1:36:38 | server2 ... ler()}) | src/hapi.js:4:15:4:31 | new Hapi.Server() |

--- a/javascript/ql/test/library-tests/frameworks/hapi/src/hapi.js
+++ b/javascript/ql/test/library-tests/frameworks/hapi/src/hapi.js
@@ -29,3 +29,8 @@ var route = {handler: handler4};
 server2.route(route);
 
 server2.cache({ segment: 'countries', expiresIn: 60*60*1000 });
+
+function getHandler() {
+    return function (req, h){}
+}
+server2.route({handler: getHandler()});


### PR DESCRIPTION
This change extends the optimistic forwards tracking of potential routehandlers to also track Hapi route handlers.

This resolves <https://jira.semmle.com/browse/ODASA-7489> using a more standard approach than the ticket suggested.

The [performance](https://git.semmle.com/esben/dist-compare-reports/tree/js/additional-route-handlers-from-context_1543681523037) is flaky, but generally seems safe. I am currently re-running a few of the bigger slowdowns.