### PR TITLE
JavaScript: Fix `InconsistentNew` performance regression.

### DIFF
--- a/change-notes/1.19/analysis-javascript.md
+++ b/change-notes/1.19/analysis-javascript.md
@@ -44,6 +44,7 @@
 | Conflicting HTML element attributes | Lower severity | The severity of this rule has been revised to "warning". |
 | Duplicate 'if' condition | Lower severity | The severity of this rule has been revised to "warning". |
 | Duplicate switch case | Lower severity | The severity of this rule has been revised to "warning". |
+| Inconsistent use of 'new' | Simpler result presentation | This rule now only shows one call with `new` and one without. |
 | Information exposure through a stack trace | More results | This rule now also flags cases where the entire exception object (including the stack trace) may be exposed. |
 | Missing 'this' qualifier | Fewer false-positive results | This rule now recognizes additional intentional calls to global functions. | 
 | Missing CSRF middleware | Fewer false-positive results | This rule now recognizes additional CSRF protection middlewares. |

--- a/javascript/ql/src/LanguageFeatures/InconsistentNew.ql
+++ b/javascript/ql/src/LanguageFeatures/InconsistentNew.ql
@@ -110,5 +110,6 @@ DataFlow::InvokeNode getFirstInvocation(Function f, boolean isNew) {
 from Function f, DataFlow::NewNode new, DataFlow::CallNode call
 where new = getFirstInvocation(f, true) and
       call = getFirstInvocation(f, false)
-select (FirstLineOf)f, capitalize(f.describe()) + " is invoked as a constructor $@, " +
-      "and as a normal function $@.", new, "here", call, "here"
+select (FirstLineOf)f, capitalize(f.describe()) + " is sometimes invoked as a constructor " +
+      "(for example $@), and sometimes as a normal function (for example $@).",
+      new, "here", call, "here"

--- a/javascript/ql/test/query-tests/LanguageFeatures/InconsistentNew/InconsistentNew.expected
+++ b/javascript/ql/test/query-tests/LanguageFeatures/InconsistentNew/InconsistentNew.expected
@@ -1,2 +1,2 @@
-| m.js:1:8:1:22 | functio ...  = x;\\n} | Function A is invoked as a constructor $@, and as a normal function $@. | c1.js:2:1:2:9 | new A(42) | here | c2.js:2:1:2:5 | A(23) | here |
-| tst.js:1:1:1:22 | functio ...  = y;\\n} | Function Point is invoked as a constructor $@, and as a normal function $@. | tst.js:6:1:6:17 | new Point(23, 42) | here | tst.js:7:1:7:13 | Point(56, 72) | here |
+| m.js:1:8:1:22 | functio ...  = x;\\n} | Function A is sometimes invoked as a constructor (for example $@), and sometimes as a normal function (for example $@). | c1.js:2:1:2:9 | new A(42) | here | c2.js:2:1:2:5 | A(23) | here |
+| tst.js:1:1:1:22 | functio ...  = y;\\n} | Function Point is sometimes invoked as a constructor (for example $@), and sometimes as a normal function (for example $@). | tst.js:6:1:6:17 | new Point(23, 42) | here | tst.js:7:1:7:13 | Point(56, 72) | here |

--- a/javascript/ql/test/query-tests/LanguageFeatures/InconsistentNew/InconsistentNew.expected
+++ b/javascript/ql/test/query-tests/LanguageFeatures/InconsistentNew/InconsistentNew.expected
@@ -1,2 +1,2 @@
-| m.js:1:8:1:22 | functio ...  = x;\\n} | Function A is invoked as a constructor here $@, and as a normal function here $@. | c1.js:2:1:2:9 | new A(42) | new A(42) | c2.js:2:1:2:5 | A(23) | A(23) |
-| tst.js:1:1:1:22 | functio ...  = y;\\n} | Function Point is invoked as a constructor here $@, and as a normal function here $@. | tst.js:6:1:6:17 | new Point(23, 42) | new Point(23, 42) | tst.js:7:1:7:13 | Point(56, 72) | Point(56, 72) |
+| m.js:1:8:1:22 | functio ...  = x;\\n} | Function A is invoked as a constructor $@, and as a normal function $@. | c1.js:2:1:2:9 | new A(42) | here | c2.js:2:1:2:5 | A(23) | here |
+| tst.js:1:1:1:22 | functio ...  = y;\\n} | Function Point is invoked as a constructor $@, and as a normal function $@. | tst.js:6:1:6:17 | new Point(23, 42) | here | tst.js:7:1:7:13 | Point(56, 72) | here |

--- a/javascript/ql/test/query-tests/LanguageFeatures/InconsistentNew/tst.js
+++ b/javascript/ql/test/query-tests/LanguageFeatures/InconsistentNew/tst.js
@@ -63,3 +63,6 @@ C(); // NOT OK, but flagged by IllegalInvocation
 	new A(42);
 	A.call({}, 23);
 })();
+
+new Point(42, 23); // NOT OK, but not flagged since line 6 above was already flagged
+Point(56, 72);     // NOT OK, but not flagged since line 7 above was already flagged


### PR DESCRIPTION
As noted by Alex ET, this query has significantly regressed in performance from 1.18 on `rhino`. I can't immediately see any query or library changes that would have caused it, but it's not difficult to fix by refactoring the query; see first commit.

Looking at the results on `rhino`, I then noticed that the query was producing a humongous number of result links since it listed all calls to the function with `new` and all without, ballooning 17 alerts on `rhino` into >80K result tuples. The second commit fixes this by only showing one call with `new` and one without, picking the first one when sorted lexicographically by file name, line and column.

Comparing three versions of the query (before this PR, after the first commit, and after the second commit) shows no changes in alerts, and [reasonable performance](https://git.semmle.com/gist/max/9a4426944a04499c653d54a986debeb6) (internal link). Note that the table shows only the runtimes for the query itself, but I ran `definitions.ql` before to warm the cache. While some projects exhibit a slowdown of ten seconds or more, these are outliers, and worth the improved quality of results, I think.

Since this is a regression from 1.18, I'm proposing this as a hotfix.