### PR TITLE
C++: Fix "Overloaded assignment does not return 'this'" for templates

### DIFF
--- a/cpp/ql/src/jsf/4.10 Classes/AV Rule 82.ql
+++ b/cpp/ql/src/jsf/4.10 Classes/AV Rule 82.ql
@@ -76,7 +76,7 @@ predicate assignOperatorWithWrongType(Operator op, string msg) {
   and exists(op.getBlock())
   and exists(Class c |
         c = op.getDeclaringType()
-    and op.getType() = c
+    and op.getType().getUnspecifiedType() = c
     and msg = "Assignment operator in class " + c.getName() + " should have return type " + c.getName() + "&. Otherwise a copy is created at each call."
   )
 }

--- a/cpp/ql/src/jsf/4.10 Classes/AV Rule 82.ql
+++ b/cpp/ql/src/jsf/4.10 Classes/AV Rule 82.ql
@@ -51,7 +51,6 @@ predicate dereferenceThis(Expr e) {
  * This includes functions whose body is not in the database.
  */
 predicate returnsPointerThis(Function f) {
-  f.getType().getUnspecifiedType() instanceof PointerType and
   forall(ReturnStmt s | s.getEnclosingFunction() = f and reachable(s) |
     // `return this`
     pointerThis(s.getExpr())
@@ -64,7 +63,6 @@ predicate returnsPointerThis(Function f) {
  * database.
  */
 predicate returnsDereferenceThis(Function f) {
-  f.getType().getUnspecifiedType() instanceof ReferenceType and
   forall(ReturnStmt s | s.getEnclosingFunction() = f and reachable(s) |
     // `return *this`
     dereferenceThis(s.getExpr())

--- a/cpp/ql/test/query-tests/jsf/4.10 Classes/AV Rule 82/AV Rule 82.cpp
+++ b/cpp/ql/test/query-tests/jsf/4.10 Classes/AV Rule 82/AV Rule 82.cpp
@@ -181,11 +181,35 @@ private:
   Forgivable operator=(int *_val);
 };
 
+// This template has structure similar to `std::enable_if`.
+template<typename S, typename T>
+struct second {
+  typedef T type;
+};
+
+struct TemplatedAssignmentGood {
+  template<typename T>
+  typename second<T, TemplatedAssignmentGood &>::type operator=(T val) { // GOOD [FALSE POSITIVE]
+    return *this;
+  }
+};
+
+struct TemplatedAssignmentBad {
+  template<typename T>
+  typename second<T, TemplatedAssignmentBad>::type operator=(T val) { // BAD (missing &)
+    return *this;
+  }
+};
+
 int main() {
   Container c;
   c = c;
   TemplateReturnAssignment<int> tra(1);
   tra = 2;
   tra = true;
+  TemplatedAssignmentGood taGood;
+  taGood = 3;
+  TemplatedAssignmentBad taBad;
+  taBad = 4;
   return 0;
 }

--- a/cpp/ql/test/query-tests/jsf/4.10 Classes/AV Rule 82/AV Rule 82.cpp
+++ b/cpp/ql/test/query-tests/jsf/4.10 Classes/AV Rule 82/AV Rule 82.cpp
@@ -189,7 +189,7 @@ struct second {
 
 struct TemplatedAssignmentGood {
   template<typename T>
-  typename second<T, TemplatedAssignmentGood &>::type operator=(T val) { // GOOD [FALSE POSITIVE]
+  typename second<T, TemplatedAssignmentGood &>::type operator=(T val) { // GOOD
     return *this;
   }
 };

--- a/cpp/ql/test/query-tests/jsf/4.10 Classes/AV Rule 82/AV Rule 82.expected
+++ b/cpp/ql/test/query-tests/jsf/4.10 Classes/AV Rule 82/AV Rule 82.expected
@@ -3,5 +3,5 @@
 | AV Rule 82.cpp:63:29:63:29 | operator= | Assignment operator in class TemplateReturnAssignment<int> does not return a reference to *this. |
 | AV Rule 82.cpp:63:29:63:37 | operator= | Assignment operator in class TemplateReturnAssignment<T> does not return a reference to *this. |
 | AV Rule 82.cpp:192:55:192:63 | operator= | Assignment operator in class TemplatedAssignmentGood does not return a reference to *this. |
-| AV Rule 82.cpp:199:52:199:52 | operator= | Assignment operator in class TemplatedAssignmentBad does not return a reference to *this. |
+| AV Rule 82.cpp:199:52:199:52 | operator= | Assignment operator in class TemplatedAssignmentBad should have return type TemplatedAssignmentBad&. Otherwise a copy is created at each call. |
 | AV Rule 82.cpp:199:52:199:60 | operator= | Assignment operator in class TemplatedAssignmentBad does not return a reference to *this. |

--- a/cpp/ql/test/query-tests/jsf/4.10 Classes/AV Rule 82/AV Rule 82.expected
+++ b/cpp/ql/test/query-tests/jsf/4.10 Classes/AV Rule 82/AV Rule 82.expected
@@ -2,3 +2,6 @@
 | AV Rule 82.cpp:24:8:24:16 | operator= | Assignment operator in class Bad2 should have return type Bad2&. Otherwise a copy is created at each call. |
 | AV Rule 82.cpp:63:29:63:29 | operator= | Assignment operator in class TemplateReturnAssignment<int> does not return a reference to *this. |
 | AV Rule 82.cpp:63:29:63:37 | operator= | Assignment operator in class TemplateReturnAssignment<T> does not return a reference to *this. |
+| AV Rule 82.cpp:192:55:192:63 | operator= | Assignment operator in class TemplatedAssignmentGood does not return a reference to *this. |
+| AV Rule 82.cpp:199:52:199:52 | operator= | Assignment operator in class TemplatedAssignmentBad does not return a reference to *this. |
+| AV Rule 82.cpp:199:52:199:60 | operator= | Assignment operator in class TemplatedAssignmentBad does not return a reference to *this. |

--- a/cpp/ql/test/query-tests/jsf/4.10 Classes/AV Rule 82/AV Rule 82.expected
+++ b/cpp/ql/test/query-tests/jsf/4.10 Classes/AV Rule 82/AV Rule 82.expected
@@ -2,6 +2,4 @@
 | AV Rule 82.cpp:24:8:24:16 | operator= | Assignment operator in class Bad2 should have return type Bad2&. Otherwise a copy is created at each call. |
 | AV Rule 82.cpp:63:29:63:29 | operator= | Assignment operator in class TemplateReturnAssignment<int> does not return a reference to *this. |
 | AV Rule 82.cpp:63:29:63:37 | operator= | Assignment operator in class TemplateReturnAssignment<T> does not return a reference to *this. |
-| AV Rule 82.cpp:192:55:192:63 | operator= | Assignment operator in class TemplatedAssignmentGood does not return a reference to *this. |
 | AV Rule 82.cpp:199:52:199:52 | operator= | Assignment operator in class TemplatedAssignmentBad should have return type TemplatedAssignmentBad&. Otherwise a copy is created at each call. |
-| AV Rule 82.cpp:199:52:199:60 | operator= | Assignment operator in class TemplatedAssignmentBad does not return a reference to *this. |


### PR DESCRIPTION
My last commit in #362 introduced FPs in code where `operator=` is a template with a dependent return type.

I've tested for performance and correctness on Boost and Blender.