### PR TITLE
Java: Fix FP in `UseSSL.ql`.

### DIFF
--- a/java/ql/src/Security/CWE/CWE-319/UseSSL.ql
+++ b/java/ql/src/Security/CWE/CWE-319/UseSSL.ql
@@ -10,6 +10,7 @@
  */
 
 import java
+import semmle.code.java.dataflow.TypeFlow
 import semmle.code.java.security.Encryption
 
 class URLConnection extends RefType {
@@ -27,11 +28,15 @@ from MethodAccess m, Class c, string type
 where
   m.getQualifier().getType() = c and
   (
-    (c instanceof URLConnection and type = "connection")
+    c instanceof URLConnection and type = "connection"
     or
-    (c instanceof Socket and type = "socket")
+    c instanceof Socket and type = "socket"
   ) and
   not c instanceof SSLClass and
+  not exists(RefType t |
+    exprTypeFlow(m.getQualifier(), t, _) and
+    t instanceof SSLClass
+  ) and
   (
     m.getMethod().getName() = "getInputStream" or
     m.getMethod().getName() = "getOutputStream"

--- a/java/ql/test/query-tests/security/CWE-311/CWE-319/Test.java
+++ b/java/ql/test/query-tests/security/CWE-311/CWE-319/Test.java
@@ -1,0 +1,14 @@
+import java.net.HttpURLConnection;
+import javax.net.ssl.HttpsURLConnection;
+import java.io.*;
+
+class Test {
+  public void m1(HttpURLConnection connection) {
+    InputStream input;
+    if (connection instanceof HttpsURLConnection) {
+      input = connection.getInputStream(); // OK
+    } else {
+      input = connection.getInputStream(); // BAD
+    }
+  }
+}

--- a/java/ql/test/query-tests/security/CWE-311/CWE-319/UseSSL.expected
+++ b/java/ql/test/query-tests/security/CWE-311/CWE-319/UseSSL.expected
@@ -1,0 +1,1 @@
+| Test.java:11:15:11:41 | getInputStream(...) | Stream using vulnerable non-SSL connection. |

--- a/java/ql/test/query-tests/security/CWE-311/CWE-319/UseSSL.qlref
+++ b/java/ql/test/query-tests/security/CWE-311/CWE-319/UseSSL.qlref
@@ -1,0 +1,1 @@
+Security/CWE/CWE-319/UseSSL.ql


### PR DESCRIPTION
This fixes FPs of the type where the static type is not SSL, but the runtime type is guaranteed to be SSL, e.g. due to an instanceof-check.