### PR TITLE
CPP: Fix false positives in UnusedStaticVariables.ql

### DIFF
--- a/change-notes/1.20/analysis-cpp.md
+++ b/change-notes/1.20/analysis-cpp.md
@@ -11,6 +11,6 @@
 
 | **Query**                  | **Expected impact**    | **Change**                                                       |
 |----------------------------|------------------------|------------------------------------------------------------------|
-| Unused static variable | Fewer false positive results | Variables with the attribute `unused` are now excluded from the query. |
+| Unused static variable (`cpp/unused-static-variable`) | Fewer false positive results | Variables with the attribute `unused` are now excluded from the query. |
 
 ## Changes to QL libraries

--- a/change-notes/1.20/analysis-cpp.md
+++ b/change-notes/1.20/analysis-cpp.md
@@ -1,0 +1,16 @@
+# Improvements to C/C++ analysis
+
+## General improvements
+
+## New queries
+
+| **Query**                   | **Tags**  | **Purpose**                                                        |
+|-----------------------------|-----------|--------------------------------------------------------------------|
+
+## Changes to existing queries
+
+| **Query**                  | **Expected impact**    | **Change**                                                       |
+|----------------------------|------------------------|------------------------------------------------------------------|
+| Unused static variable | Fewer false positive results | Variables with the attribute `unused` are now excluded from the query. |
+
+## Changes to QL libraries

--- a/cpp/ql/src/Best Practices/Unused Entities/UnusedStaticVariables.ql
+++ b/cpp/ql/src/Best Practices/Unused Entities/UnusedStaticVariables.ql
@@ -25,4 +25,5 @@ where v.isStatic()
   and not v instanceof MemberVariable
   and not declarationHasSideEffects(v)
   and not v.getAnAttribute().hasName("used")
+  and not v.getAnAttribute().hasName("unused")
 select v, "Static variable " + v.getName() + " is never read"

--- a/cpp/ql/test/query-tests/Best Practices/Unused Entities/UnusedStaticVariables/UnusedStaticVariables.expected
+++ b/cpp/ql/test/query-tests/Best Practices/Unused Entities/UnusedStaticVariables/UnusedStaticVariables.expected
@@ -1,3 +1,2 @@
 | test.cpp:7:12:7:21 | staticVar5 | Static variable staticVar5 is never read |
 | test.cpp:8:12:8:21 | staticVar6 | Static variable staticVar6 is never read |
-| test.cpp:9:40:9:49 | staticVar7 | Static variable staticVar7 is never read |

--- a/cpp/ql/test/query-tests/Best Practices/Unused Entities/UnusedStaticVariables/UnusedStaticVariables.expected
+++ b/cpp/ql/test/query-tests/Best Practices/Unused Entities/UnusedStaticVariables/UnusedStaticVariables.expected
@@ -1,0 +1,3 @@
+| test.cpp:7:12:7:21 | staticVar5 | Static variable staticVar5 is never read |
+| test.cpp:8:12:8:21 | staticVar6 | Static variable staticVar6 is never read |
+| test.cpp:9:40:9:49 | staticVar7 | Static variable staticVar7 is never read |

--- a/cpp/ql/test/query-tests/Best Practices/Unused Entities/UnusedStaticVariables/UnusedStaticVariables.qlref
+++ b/cpp/ql/test/query-tests/Best Practices/Unused Entities/UnusedStaticVariables/UnusedStaticVariables.qlref
@@ -1,0 +1,1 @@
+Best Practices/Unused Entities/UnusedStaticVariables.ql

--- a/cpp/ql/test/query-tests/Best Practices/Unused Entities/UnusedStaticVariables/test.cpp
+++ b/cpp/ql/test/query-tests/Best Practices/Unused Entities/UnusedStaticVariables/test.cpp
@@ -1,0 +1,18 @@
+
+int globalVar; // GOOD (not static)
+static int staticVar1; // GOOD (used)
+static int staticVar2; // GOOD (used)
+static int staticVar3 = 3; // GOOD (used)
+static int staticVar4 = staticVar3; // GOOD (used)
+static int staticVar5; // BAD (unused)
+static int staticVar6 = 6; // BAD (unused)
+static __attribute__((__unused__)) int staticVar7; // GOOD (unused but this is expected) [FALSE POSITIVE]
+
+void f()
+{
+	int *ptr = &staticVar4;
+
+	staticVar1 = staticVar2;
+	(*ptr) = 0;
+}
+

--- a/cpp/ql/test/query-tests/Best Practices/Unused Entities/UnusedStaticVariables/test.cpp
+++ b/cpp/ql/test/query-tests/Best Practices/Unused Entities/UnusedStaticVariables/test.cpp
@@ -6,7 +6,7 @@ static int staticVar3 = 3; // GOOD (used)
 static int staticVar4 = staticVar3; // GOOD (used)
 static int staticVar5; // BAD (unused)
 static int staticVar6 = 6; // BAD (unused)
-static __attribute__((__unused__)) int staticVar7; // GOOD (unused but this is expected) [FALSE POSITIVE]
+static __attribute__((__unused__)) int staticVar7; // GOOD (unused but this is expected)
 
 void f()
 {


### PR DESCRIPTION
The query was recognizing attribute `used` but not attribute `unused` on variables (e.g. in boost, wireshark).  Both [exist](https://lgtm.com/query/3432375821388887707/) and as far as I can tell have subtly different meanings, but both should be excluded from this query.

Also added a test.