### PR TITLE
JavaScript: Remove redundant conjunct in `MixedStaticInstanceThisAccess`.

### DIFF
--- a/javascript/ql/src/Declarations/MixedStaticInstanceThisAccess.ql
+++ b/javascript/ql/src/Declarations/MixedStaticInstanceThisAccess.ql
@@ -35,7 +35,6 @@ where
     fromKind = getKind(fromMethod) and
     toKind = getKind(toMethod) and
     toKind != fromKind and
-    not toKind = fromKind and
 
     // exceptions
     not (


### PR DESCRIPTION
Minor cleanup, but might as well go into the release.