### PR TITLE
Update logging information based on 'extractor-python.md'

### DIFF
--- a/change-notes/1.19/analysis-python.md
+++ b/change-notes/1.19/analysis-python.md
@@ -70,10 +70,16 @@ Most security alerts are now visible on LGTM by default. This means that you may
 
 ## Changes to code extraction
 
-* Improved scalability: Scaling is near linear to at least 20 CPU cores.
-* Five levels of logging can be selected: `ERROR`, `WARN`, `INFO`, `DEBUG` and `TRACE`. LGTM uses `INFO` level logging. QL tools use `WARN` level logging by default.
-* The `-v` flag can be specified multiple times to increase logging level by one per `-v`.
-* The `-q` flag has been added and can be specified multiple times to reduce the logging level by one per `-q`.
+### Improved scalability
+
+Scaling is near linear to at least 20 CPU cores.
+
+### Improved logging
+
+* Five levels of logging are available: `CRITICAL`, `ERROR`, `WARN`, `INFO` and `DEBUG`. `WARN` is the default.
+* LGTM uses `INFO` level logging. QL tools use `WARN` level logging by default.
+* The `--verbose` flag can be specified specified multiple times to increase the logging level once per flag added.
+* The `--quiet` flag can be specified multiple times to reduce the logging level once per flag added.
 * Log lines are now in the `[SEVERITY] message` style and never overlap.
 * The extractor now outputs the location of the first character that triggers an EncodingError.
 

--- a/change-notes/1.19/analysis-python.md
+++ b/change-notes/1.19/analysis-python.md
@@ -70,6 +70,11 @@ Most security alerts are now visible on LGTM by default. This means that you may
 
 ## Changes to code extraction
 
+## Improved reporting of encoding errors
+
+The extractor now outputs the location of the first character that triggers an `EncodingError`. 
+Any queries that report encoding errors will now show results at the location of the character that caused the error.
+
 ### Improved scalability
 
 Scaling is near linear to at least 20 CPU cores.
@@ -81,7 +86,6 @@ Scaling is near linear to at least 20 CPU cores.
 * The `--verbose` flag can be specified specified multiple times to increase the logging level once per flag added.
 * The `--quiet` flag can be specified multiple times to reduce the logging level once per flag added.
 * Log lines are now in the `[SEVERITY] message` style and never overlap.
-* The extractor now outputs the location of the first character that triggers an EncodingError.
 
 ## Changes to QL libraries
 


### PR DESCRIPTION
This PR updates the information on logging based on the near duplicate content of `extractor-python.md`.

@taus-semmle - as discussed, I'll also raise a PR to delete the other file. I wasn't entirely sure whether the final bullet point about `EncodingError` was part of the logging improvements or not.