### PR TITLE
JS: Fix syntax error in js/react/inconsistent-state-update example

### DIFF
--- a/javascript/ql/src/React/InconsistentStateUpdate.qhelp
+++ b/javascript/ql/src/React/InconsistentStateUpdate.qhelp
@@ -36,9 +36,9 @@ Instead, the callback form of <code>setState</code> should be used:
 </p>
 
 <sample language="javascript">
-this.setState((prevState) => {
+this.setState((prevState) => ({
   counter: prevState.counter + 1
-});
+}));
 </sample>
 </example>
 


### PR DESCRIPTION
Trivial syntax error in example code for rule help.