### PR TITLE
C#: Fix a bug in `ThrowingCallable`

### DIFF
--- a/csharp/ql/test/library-tests/controlflow/graph/BasicBlock.expected
+++ b/csharp/ql/test/library-tests/controlflow/graph/BasicBlock.expected
@@ -187,28 +187,32 @@
 | ExitMethods.cs:43:9:46:9 | [exception: Exception] catch (...) {...} | ExitMethods.cs:43:9:46:9 | [exception: Exception] catch (...) {...} | 1 |
 | ExitMethods.cs:44:9:46:9 | {...} | ExitMethods.cs:45:13:45:19 | return ...; | 2 |
 | ExitMethods.cs:47:9:50:9 | [exception: Exception] catch (...) {...} | ExitMethods.cs:49:13:49:19 | return ...; | 3 |
-| ExitMethods.cs:53:17:53:26 | enter ErrorMaybe | ExitMethods.cs:55:13:55:13 | access to parameter b | 4 |
-| ExitMethods.cs:53:17:53:26 | exit ErrorMaybe | ExitMethods.cs:53:17:53:26 | exit ErrorMaybe | 1 |
-| ExitMethods.cs:56:19:56:33 | object creation of type Exception | ExitMethods.cs:56:13:56:34 | throw ...; | 2 |
-| ExitMethods.cs:59:17:59:27 | enter ErrorAlways | ExitMethods.cs:61:13:61:13 | access to parameter b | 4 |
-| ExitMethods.cs:59:17:59:27 | exit ErrorAlways | ExitMethods.cs:59:17:59:27 | exit ErrorAlways | 1 |
-| ExitMethods.cs:62:19:62:33 | object creation of type Exception | ExitMethods.cs:62:13:62:34 | throw ...; | 2 |
-| ExitMethods.cs:64:41:64:43 | "b" | ExitMethods.cs:64:13:64:45 | throw ...; | 3 |
-| ExitMethods.cs:67:10:67:13 | enter Exit | ExitMethods.cs:67:10:67:13 | exit Exit | 6 |
-| ExitMethods.cs:72:10:72:18 | enter ExitInTry | ExitMethods.cs:72:10:72:18 | exit ExitInTry | 8 |
-| ExitMethods.cs:85:10:85:24 | enter ApplicationExit | ExitMethods.cs:85:10:85:24 | exit ApplicationExit | 5 |
-| ExitMethods.cs:90:13:90:21 | enter ThrowExpr | ExitMethods.cs:92:16:92:25 | ... != ... | 7 |
-| ExitMethods.cs:90:13:90:21 | exit ThrowExpr | ExitMethods.cs:90:13:90:21 | exit ThrowExpr | 1 |
-| ExitMethods.cs:92:29:92:29 | 1 | ExitMethods.cs:92:9:92:77 | return ...; | 5 |
-| ExitMethods.cs:92:69:92:75 | "input" | ExitMethods.cs:92:41:92:76 | throw ... | 3 |
-| ExitMethods.cs:95:16:95:34 | enter ExtensionMethodCall | ExitMethods.cs:97:16:97:30 | call to method Contains | 6 |
-| ExitMethods.cs:97:9:97:39 | return ...; | ExitMethods.cs:95:16:95:34 | exit ExtensionMethodCall | 2 |
-| ExitMethods.cs:97:34:97:34 | 0 | ExitMethods.cs:97:34:97:34 | 0 | 1 |
-| ExitMethods.cs:97:38:97:38 | 1 | ExitMethods.cs:97:38:97:38 | 1 | 1 |
-| ExitMethods.cs:100:17:100:32 | enter FailingAssertion | ExitMethods.cs:100:17:100:32 | exit FailingAssertion | 6 |
-| ExitMethods.cs:106:17:106:33 | enter FailingAssertion2 | ExitMethods.cs:106:17:106:33 | exit FailingAssertion2 | 6 |
-| ExitMethods.cs:112:10:112:20 | enter AssertFalse | ExitMethods.cs:112:10:112:20 | exit AssertFalse | 4 |
-| ExitMethods.cs:114:17:114:33 | enter FailingAssertion3 | ExitMethods.cs:114:17:114:33 | exit FailingAssertion3 | 7 |
+| ExitMethods.cs:53:10:53:11 | enter M7 | ExitMethods.cs:53:10:53:11 | exit M7 | 6 |
+| ExitMethods.cs:59:10:59:11 | enter M8 | ExitMethods.cs:59:10:59:11 | exit M8 | 5 |
+| ExitMethods.cs:65:17:65:26 | enter ErrorMaybe | ExitMethods.cs:67:13:67:13 | access to parameter b | 4 |
+| ExitMethods.cs:65:17:65:26 | exit ErrorMaybe | ExitMethods.cs:65:17:65:26 | exit ErrorMaybe | 1 |
+| ExitMethods.cs:68:19:68:33 | object creation of type Exception | ExitMethods.cs:68:13:68:34 | throw ...; | 2 |
+| ExitMethods.cs:71:17:71:27 | enter ErrorAlways | ExitMethods.cs:73:13:73:13 | access to parameter b | 4 |
+| ExitMethods.cs:71:17:71:27 | exit ErrorAlways | ExitMethods.cs:71:17:71:27 | exit ErrorAlways | 1 |
+| ExitMethods.cs:74:19:74:33 | object creation of type Exception | ExitMethods.cs:74:13:74:34 | throw ...; | 2 |
+| ExitMethods.cs:76:41:76:43 | "b" | ExitMethods.cs:76:13:76:45 | throw ...; | 3 |
+| ExitMethods.cs:79:17:79:28 | enter ErrorAlways2 | ExitMethods.cs:79:17:79:28 | exit ErrorAlways2 | 5 |
+| ExitMethods.cs:84:17:84:28 | enter ErrorAlways3 | ExitMethods.cs:84:17:84:28 | exit ErrorAlways3 | 4 |
+| ExitMethods.cs:86:10:86:13 | enter Exit | ExitMethods.cs:86:10:86:13 | exit Exit | 6 |
+| ExitMethods.cs:91:10:91:18 | enter ExitInTry | ExitMethods.cs:91:10:91:18 | exit ExitInTry | 8 |
+| ExitMethods.cs:104:10:104:24 | enter ApplicationExit | ExitMethods.cs:104:10:104:24 | exit ApplicationExit | 5 |
+| ExitMethods.cs:109:13:109:21 | enter ThrowExpr | ExitMethods.cs:111:16:111:25 | ... != ... | 7 |
+| ExitMethods.cs:109:13:109:21 | exit ThrowExpr | ExitMethods.cs:109:13:109:21 | exit ThrowExpr | 1 |
+| ExitMethods.cs:111:29:111:29 | 1 | ExitMethods.cs:111:9:111:77 | return ...; | 5 |
+| ExitMethods.cs:111:69:111:75 | "input" | ExitMethods.cs:111:41:111:76 | throw ... | 3 |
+| ExitMethods.cs:114:16:114:34 | enter ExtensionMethodCall | ExitMethods.cs:116:16:116:30 | call to method Contains | 6 |
+| ExitMethods.cs:116:9:116:39 | return ...; | ExitMethods.cs:114:16:114:34 | exit ExtensionMethodCall | 2 |
+| ExitMethods.cs:116:34:116:34 | 0 | ExitMethods.cs:116:34:116:34 | 0 | 1 |
+| ExitMethods.cs:116:38:116:38 | 1 | ExitMethods.cs:116:38:116:38 | 1 | 1 |
+| ExitMethods.cs:119:17:119:32 | enter FailingAssertion | ExitMethods.cs:119:17:119:32 | exit FailingAssertion | 6 |
+| ExitMethods.cs:125:17:125:33 | enter FailingAssertion2 | ExitMethods.cs:125:17:125:33 | exit FailingAssertion2 | 6 |
+| ExitMethods.cs:131:10:131:20 | enter AssertFalse | ExitMethods.cs:131:10:131:20 | exit AssertFalse | 4 |
+| ExitMethods.cs:133:17:133:33 | enter FailingAssertion3 | ExitMethods.cs:133:17:133:33 | exit FailingAssertion3 | 7 |
 | Extensions.cs:5:23:5:29 | enter ToInt32 | Extensions.cs:5:23:5:29 | exit ToInt32 | 6 |
 | Extensions.cs:10:24:10:29 | enter ToBool | Extensions.cs:10:24:10:29 | exit ToBool | 7 |
 | Extensions.cs:15:23:15:33 | enter CallToInt32 | Extensions.cs:15:23:15:33 | exit CallToInt32 | 4 |

--- a/csharp/ql/test/library-tests/controlflow/graph/BasicBlock.expected
+++ b/csharp/ql/test/library-tests/controlflow/graph/BasicBlock.expected
@@ -187,7 +187,7 @@
 | ExitMethods.cs:43:9:46:9 | [exception: Exception] catch (...) {...} | ExitMethods.cs:43:9:46:9 | [exception: Exception] catch (...) {...} | 1 |
 | ExitMethods.cs:44:9:46:9 | {...} | ExitMethods.cs:45:13:45:19 | return ...; | 2 |
 | ExitMethods.cs:47:9:50:9 | [exception: Exception] catch (...) {...} | ExitMethods.cs:49:13:49:19 | return ...; | 3 |
-| ExitMethods.cs:53:10:53:11 | enter M7 | ExitMethods.cs:53:10:53:11 | exit M7 | 6 |
+| ExitMethods.cs:53:10:53:11 | enter M7 | ExitMethods.cs:53:10:53:11 | exit M7 | 5 |
 | ExitMethods.cs:59:10:59:11 | enter M8 | ExitMethods.cs:59:10:59:11 | exit M8 | 5 |
 | ExitMethods.cs:65:17:65:26 | enter ErrorMaybe | ExitMethods.cs:67:13:67:13 | access to parameter b | 4 |
 | ExitMethods.cs:65:17:65:26 | exit ErrorMaybe | ExitMethods.cs:65:17:65:26 | exit ErrorMaybe | 1 |

--- a/csharp/ql/test/library-tests/controlflow/graph/BasicBlockDominance.expected
+++ b/csharp/ql/test/library-tests/controlflow/graph/BasicBlockDominance.expected
@@ -403,39 +403,43 @@
 | post | ExitMethods.cs:44:9:46:9 | {...} | ExitMethods.cs:43:9:46:9 | [exception: ArgumentException] catch (...) {...} |
 | post | ExitMethods.cs:44:9:46:9 | {...} | ExitMethods.cs:44:9:46:9 | {...} |
 | post | ExitMethods.cs:47:9:50:9 | [exception: Exception] catch (...) {...} | ExitMethods.cs:47:9:50:9 | [exception: Exception] catch (...) {...} |
-| post | ExitMethods.cs:53:17:53:26 | enter ErrorMaybe | ExitMethods.cs:53:17:53:26 | enter ErrorMaybe |
-| post | ExitMethods.cs:53:17:53:26 | exit ErrorMaybe | ExitMethods.cs:53:17:53:26 | enter ErrorMaybe |
-| post | ExitMethods.cs:53:17:53:26 | exit ErrorMaybe | ExitMethods.cs:53:17:53:26 | exit ErrorMaybe |
-| post | ExitMethods.cs:53:17:53:26 | exit ErrorMaybe | ExitMethods.cs:56:19:56:33 | object creation of type Exception |
-| post | ExitMethods.cs:56:19:56:33 | object creation of type Exception | ExitMethods.cs:56:19:56:33 | object creation of type Exception |
-| post | ExitMethods.cs:59:17:59:27 | enter ErrorAlways | ExitMethods.cs:59:17:59:27 | enter ErrorAlways |
-| post | ExitMethods.cs:59:17:59:27 | exit ErrorAlways | ExitMethods.cs:59:17:59:27 | enter ErrorAlways |
-| post | ExitMethods.cs:59:17:59:27 | exit ErrorAlways | ExitMethods.cs:59:17:59:27 | exit ErrorAlways |
-| post | ExitMethods.cs:59:17:59:27 | exit ErrorAlways | ExitMethods.cs:62:19:62:33 | object creation of type Exception |
-| post | ExitMethods.cs:59:17:59:27 | exit ErrorAlways | ExitMethods.cs:64:41:64:43 | "b" |
-| post | ExitMethods.cs:62:19:62:33 | object creation of type Exception | ExitMethods.cs:62:19:62:33 | object creation of type Exception |
-| post | ExitMethods.cs:64:41:64:43 | "b" | ExitMethods.cs:64:41:64:43 | "b" |
-| post | ExitMethods.cs:67:10:67:13 | enter Exit | ExitMethods.cs:67:10:67:13 | enter Exit |
-| post | ExitMethods.cs:72:10:72:18 | enter ExitInTry | ExitMethods.cs:72:10:72:18 | enter ExitInTry |
-| post | ExitMethods.cs:85:10:85:24 | enter ApplicationExit | ExitMethods.cs:85:10:85:24 | enter ApplicationExit |
-| post | ExitMethods.cs:90:13:90:21 | enter ThrowExpr | ExitMethods.cs:90:13:90:21 | enter ThrowExpr |
-| post | ExitMethods.cs:90:13:90:21 | exit ThrowExpr | ExitMethods.cs:90:13:90:21 | enter ThrowExpr |
-| post | ExitMethods.cs:90:13:90:21 | exit ThrowExpr | ExitMethods.cs:90:13:90:21 | exit ThrowExpr |
-| post | ExitMethods.cs:90:13:90:21 | exit ThrowExpr | ExitMethods.cs:92:29:92:29 | 1 |
-| post | ExitMethods.cs:90:13:90:21 | exit ThrowExpr | ExitMethods.cs:92:69:92:75 | "input" |
-| post | ExitMethods.cs:92:29:92:29 | 1 | ExitMethods.cs:92:29:92:29 | 1 |
-| post | ExitMethods.cs:92:69:92:75 | "input" | ExitMethods.cs:92:69:92:75 | "input" |
-| post | ExitMethods.cs:95:16:95:34 | enter ExtensionMethodCall | ExitMethods.cs:95:16:95:34 | enter ExtensionMethodCall |
-| post | ExitMethods.cs:97:9:97:39 | return ...; | ExitMethods.cs:95:16:95:34 | enter ExtensionMethodCall |
-| post | ExitMethods.cs:97:9:97:39 | return ...; | ExitMethods.cs:97:9:97:39 | return ...; |
-| post | ExitMethods.cs:97:9:97:39 | return ...; | ExitMethods.cs:97:34:97:34 | 0 |
-| post | ExitMethods.cs:97:9:97:39 | return ...; | ExitMethods.cs:97:38:97:38 | 1 |
-| post | ExitMethods.cs:97:34:97:34 | 0 | ExitMethods.cs:97:34:97:34 | 0 |
-| post | ExitMethods.cs:97:38:97:38 | 1 | ExitMethods.cs:97:38:97:38 | 1 |
-| post | ExitMethods.cs:100:17:100:32 | enter FailingAssertion | ExitMethods.cs:100:17:100:32 | enter FailingAssertion |
-| post | ExitMethods.cs:106:17:106:33 | enter FailingAssertion2 | ExitMethods.cs:106:17:106:33 | enter FailingAssertion2 |
-| post | ExitMethods.cs:112:10:112:20 | enter AssertFalse | ExitMethods.cs:112:10:112:20 | enter AssertFalse |
-| post | ExitMethods.cs:114:17:114:33 | enter FailingAssertion3 | ExitMethods.cs:114:17:114:33 | enter FailingAssertion3 |
+| post | ExitMethods.cs:53:10:53:11 | enter M7 | ExitMethods.cs:53:10:53:11 | enter M7 |
+| post | ExitMethods.cs:59:10:59:11 | enter M8 | ExitMethods.cs:59:10:59:11 | enter M8 |
+| post | ExitMethods.cs:65:17:65:26 | enter ErrorMaybe | ExitMethods.cs:65:17:65:26 | enter ErrorMaybe |
+| post | ExitMethods.cs:65:17:65:26 | exit ErrorMaybe | ExitMethods.cs:65:17:65:26 | enter ErrorMaybe |
+| post | ExitMethods.cs:65:17:65:26 | exit ErrorMaybe | ExitMethods.cs:65:17:65:26 | exit ErrorMaybe |
+| post | ExitMethods.cs:65:17:65:26 | exit ErrorMaybe | ExitMethods.cs:68:19:68:33 | object creation of type Exception |
+| post | ExitMethods.cs:68:19:68:33 | object creation of type Exception | ExitMethods.cs:68:19:68:33 | object creation of type Exception |
+| post | ExitMethods.cs:71:17:71:27 | enter ErrorAlways | ExitMethods.cs:71:17:71:27 | enter ErrorAlways |
+| post | ExitMethods.cs:71:17:71:27 | exit ErrorAlways | ExitMethods.cs:71:17:71:27 | enter ErrorAlways |
+| post | ExitMethods.cs:71:17:71:27 | exit ErrorAlways | ExitMethods.cs:71:17:71:27 | exit ErrorAlways |
+| post | ExitMethods.cs:71:17:71:27 | exit ErrorAlways | ExitMethods.cs:74:19:74:33 | object creation of type Exception |
+| post | ExitMethods.cs:71:17:71:27 | exit ErrorAlways | ExitMethods.cs:76:41:76:43 | "b" |
+| post | ExitMethods.cs:74:19:74:33 | object creation of type Exception | ExitMethods.cs:74:19:74:33 | object creation of type Exception |
+| post | ExitMethods.cs:76:41:76:43 | "b" | ExitMethods.cs:76:41:76:43 | "b" |
+| post | ExitMethods.cs:79:17:79:28 | enter ErrorAlways2 | ExitMethods.cs:79:17:79:28 | enter ErrorAlways2 |
+| post | ExitMethods.cs:84:17:84:28 | enter ErrorAlways3 | ExitMethods.cs:84:17:84:28 | enter ErrorAlways3 |
+| post | ExitMethods.cs:86:10:86:13 | enter Exit | ExitMethods.cs:86:10:86:13 | enter Exit |
+| post | ExitMethods.cs:91:10:91:18 | enter ExitInTry | ExitMethods.cs:91:10:91:18 | enter ExitInTry |
+| post | ExitMethods.cs:104:10:104:24 | enter ApplicationExit | ExitMethods.cs:104:10:104:24 | enter ApplicationExit |
+| post | ExitMethods.cs:109:13:109:21 | enter ThrowExpr | ExitMethods.cs:109:13:109:21 | enter ThrowExpr |
+| post | ExitMethods.cs:109:13:109:21 | exit ThrowExpr | ExitMethods.cs:109:13:109:21 | enter ThrowExpr |
+| post | ExitMethods.cs:109:13:109:21 | exit ThrowExpr | ExitMethods.cs:109:13:109:21 | exit ThrowExpr |
+| post | ExitMethods.cs:109:13:109:21 | exit ThrowExpr | ExitMethods.cs:111:29:111:29 | 1 |
+| post | ExitMethods.cs:109:13:109:21 | exit ThrowExpr | ExitMethods.cs:111:69:111:75 | "input" |
+| post | ExitMethods.cs:111:29:111:29 | 1 | ExitMethods.cs:111:29:111:29 | 1 |
+| post | ExitMethods.cs:111:69:111:75 | "input" | ExitMethods.cs:111:69:111:75 | "input" |
+| post | ExitMethods.cs:114:16:114:34 | enter ExtensionMethodCall | ExitMethods.cs:114:16:114:34 | enter ExtensionMethodCall |
+| post | ExitMethods.cs:116:9:116:39 | return ...; | ExitMethods.cs:114:16:114:34 | enter ExtensionMethodCall |
+| post | ExitMethods.cs:116:9:116:39 | return ...; | ExitMethods.cs:116:9:116:39 | return ...; |
+| post | ExitMethods.cs:116:9:116:39 | return ...; | ExitMethods.cs:116:34:116:34 | 0 |
+| post | ExitMethods.cs:116:9:116:39 | return ...; | ExitMethods.cs:116:38:116:38 | 1 |
+| post | ExitMethods.cs:116:34:116:34 | 0 | ExitMethods.cs:116:34:116:34 | 0 |
+| post | ExitMethods.cs:116:38:116:38 | 1 | ExitMethods.cs:116:38:116:38 | 1 |
+| post | ExitMethods.cs:119:17:119:32 | enter FailingAssertion | ExitMethods.cs:119:17:119:32 | enter FailingAssertion |
+| post | ExitMethods.cs:125:17:125:33 | enter FailingAssertion2 | ExitMethods.cs:125:17:125:33 | enter FailingAssertion2 |
+| post | ExitMethods.cs:131:10:131:20 | enter AssertFalse | ExitMethods.cs:131:10:131:20 | enter AssertFalse |
+| post | ExitMethods.cs:133:17:133:33 | enter FailingAssertion3 | ExitMethods.cs:133:17:133:33 | enter FailingAssertion3 |
 | post | Extensions.cs:5:23:5:29 | enter ToInt32 | Extensions.cs:5:23:5:29 | enter ToInt32 |
 | post | Extensions.cs:10:24:10:29 | enter ToBool | Extensions.cs:10:24:10:29 | enter ToBool |
 | post | Extensions.cs:15:23:15:33 | enter CallToInt32 | Extensions.cs:15:23:15:33 | enter CallToInt32 |
@@ -1780,39 +1784,43 @@
 | pre | ExitMethods.cs:43:9:46:9 | [exception: Exception] catch (...) {...} | ExitMethods.cs:47:9:50:9 | [exception: Exception] catch (...) {...} |
 | pre | ExitMethods.cs:44:9:46:9 | {...} | ExitMethods.cs:44:9:46:9 | {...} |
 | pre | ExitMethods.cs:47:9:50:9 | [exception: Exception] catch (...) {...} | ExitMethods.cs:47:9:50:9 | [exception: Exception] catch (...) {...} |
-| pre | ExitMethods.cs:53:17:53:26 | enter ErrorMaybe | ExitMethods.cs:53:17:53:26 | enter ErrorMaybe |
-| pre | ExitMethods.cs:53:17:53:26 | enter ErrorMaybe | ExitMethods.cs:53:17:53:26 | exit ErrorMaybe |
-| pre | ExitMethods.cs:53:17:53:26 | enter ErrorMaybe | ExitMethods.cs:56:19:56:33 | object creation of type Exception |
-| pre | ExitMethods.cs:53:17:53:26 | exit ErrorMaybe | ExitMethods.cs:53:17:53:26 | exit ErrorMaybe |
-| pre | ExitMethods.cs:56:19:56:33 | object creation of type Exception | ExitMethods.cs:56:19:56:33 | object creation of type Exception |
-| pre | ExitMethods.cs:59:17:59:27 | enter ErrorAlways | ExitMethods.cs:59:17:59:27 | enter ErrorAlways |
-| pre | ExitMethods.cs:59:17:59:27 | enter ErrorAlways | ExitMethods.cs:59:17:59:27 | exit ErrorAlways |
-| pre | ExitMethods.cs:59:17:59:27 | enter ErrorAlways | ExitMethods.cs:62:19:62:33 | object creation of type Exception |
-| pre | ExitMethods.cs:59:17:59:27 | enter ErrorAlways | ExitMethods.cs:64:41:64:43 | "b" |
-| pre | ExitMethods.cs:59:17:59:27 | exit ErrorAlways | ExitMethods.cs:59:17:59:27 | exit ErrorAlways |
-| pre | ExitMethods.cs:62:19:62:33 | object creation of type Exception | ExitMethods.cs:62:19:62:33 | object creation of type Exception |
-| pre | ExitMethods.cs:64:41:64:43 | "b" | ExitMethods.cs:64:41:64:43 | "b" |
-| pre | ExitMethods.cs:67:10:67:13 | enter Exit | ExitMethods.cs:67:10:67:13 | enter Exit |
-| pre | ExitMethods.cs:72:10:72:18 | enter ExitInTry | ExitMethods.cs:72:10:72:18 | enter ExitInTry |
-| pre | ExitMethods.cs:85:10:85:24 | enter ApplicationExit | ExitMethods.cs:85:10:85:24 | enter ApplicationExit |
-| pre | ExitMethods.cs:90:13:90:21 | enter ThrowExpr | ExitMethods.cs:90:13:90:21 | enter ThrowExpr |
-| pre | ExitMethods.cs:90:13:90:21 | enter ThrowExpr | ExitMethods.cs:90:13:90:21 | exit ThrowExpr |
-| pre | ExitMethods.cs:90:13:90:21 | enter ThrowExpr | ExitMethods.cs:92:29:92:29 | 1 |
-| pre | ExitMethods.cs:90:13:90:21 | enter ThrowExpr | ExitMethods.cs:92:69:92:75 | "input" |
-| pre | ExitMethods.cs:90:13:90:21 | exit ThrowExpr | ExitMethods.cs:90:13:90:21 | exit ThrowExpr |
-| pre | ExitMethods.cs:92:29:92:29 | 1 | ExitMethods.cs:92:29:92:29 | 1 |
-| pre | ExitMethods.cs:92:69:92:75 | "input" | ExitMethods.cs:92:69:92:75 | "input" |
-| pre | ExitMethods.cs:95:16:95:34 | enter ExtensionMethodCall | ExitMethods.cs:95:16:95:34 | enter ExtensionMethodCall |
-| pre | ExitMethods.cs:95:16:95:34 | enter ExtensionMethodCall | ExitMethods.cs:97:9:97:39 | return ...; |
-| pre | ExitMethods.cs:95:16:95:34 | enter ExtensionMethodCall | ExitMethods.cs:97:34:97:34 | 0 |
-| pre | ExitMethods.cs:95:16:95:34 | enter ExtensionMethodCall | ExitMethods.cs:97:38:97:38 | 1 |
-| pre | ExitMethods.cs:97:9:97:39 | return ...; | ExitMethods.cs:97:9:97:39 | return ...; |
-| pre | ExitMethods.cs:97:34:97:34 | 0 | ExitMethods.cs:97:34:97:34 | 0 |
-| pre | ExitMethods.cs:97:38:97:38 | 1 | ExitMethods.cs:97:38:97:38 | 1 |
-| pre | ExitMethods.cs:100:17:100:32 | enter FailingAssertion | ExitMethods.cs:100:17:100:32 | enter FailingAssertion |
-| pre | ExitMethods.cs:106:17:106:33 | enter FailingAssertion2 | ExitMethods.cs:106:17:106:33 | enter FailingAssertion2 |
-| pre | ExitMethods.cs:112:10:112:20 | enter AssertFalse | ExitMethods.cs:112:10:112:20 | enter AssertFalse |
-| pre | ExitMethods.cs:114:17:114:33 | enter FailingAssertion3 | ExitMethods.cs:114:17:114:33 | enter FailingAssertion3 |
+| pre | ExitMethods.cs:53:10:53:11 | enter M7 | ExitMethods.cs:53:10:53:11 | enter M7 |
+| pre | ExitMethods.cs:59:10:59:11 | enter M8 | ExitMethods.cs:59:10:59:11 | enter M8 |
+| pre | ExitMethods.cs:65:17:65:26 | enter ErrorMaybe | ExitMethods.cs:65:17:65:26 | enter ErrorMaybe |
+| pre | ExitMethods.cs:65:17:65:26 | enter ErrorMaybe | ExitMethods.cs:65:17:65:26 | exit ErrorMaybe |
+| pre | ExitMethods.cs:65:17:65:26 | enter ErrorMaybe | ExitMethods.cs:68:19:68:33 | object creation of type Exception |
+| pre | ExitMethods.cs:65:17:65:26 | exit ErrorMaybe | ExitMethods.cs:65:17:65:26 | exit ErrorMaybe |
+| pre | ExitMethods.cs:68:19:68:33 | object creation of type Exception | ExitMethods.cs:68:19:68:33 | object creation of type Exception |
+| pre | ExitMethods.cs:71:17:71:27 | enter ErrorAlways | ExitMethods.cs:71:17:71:27 | enter ErrorAlways |
+| pre | ExitMethods.cs:71:17:71:27 | enter ErrorAlways | ExitMethods.cs:71:17:71:27 | exit ErrorAlways |
+| pre | ExitMethods.cs:71:17:71:27 | enter ErrorAlways | ExitMethods.cs:74:19:74:33 | object creation of type Exception |
+| pre | ExitMethods.cs:71:17:71:27 | enter ErrorAlways | ExitMethods.cs:76:41:76:43 | "b" |
+| pre | ExitMethods.cs:71:17:71:27 | exit ErrorAlways | ExitMethods.cs:71:17:71:27 | exit ErrorAlways |
+| pre | ExitMethods.cs:74:19:74:33 | object creation of type Exception | ExitMethods.cs:74:19:74:33 | object creation of type Exception |
+| pre | ExitMethods.cs:76:41:76:43 | "b" | ExitMethods.cs:76:41:76:43 | "b" |
+| pre | ExitMethods.cs:79:17:79:28 | enter ErrorAlways2 | ExitMethods.cs:79:17:79:28 | enter ErrorAlways2 |
+| pre | ExitMethods.cs:84:17:84:28 | enter ErrorAlways3 | ExitMethods.cs:84:17:84:28 | enter ErrorAlways3 |
+| pre | ExitMethods.cs:86:10:86:13 | enter Exit | ExitMethods.cs:86:10:86:13 | enter Exit |
+| pre | ExitMethods.cs:91:10:91:18 | enter ExitInTry | ExitMethods.cs:91:10:91:18 | enter ExitInTry |
+| pre | ExitMethods.cs:104:10:104:24 | enter ApplicationExit | ExitMethods.cs:104:10:104:24 | enter ApplicationExit |
+| pre | ExitMethods.cs:109:13:109:21 | enter ThrowExpr | ExitMethods.cs:109:13:109:21 | enter ThrowExpr |
+| pre | ExitMethods.cs:109:13:109:21 | enter ThrowExpr | ExitMethods.cs:109:13:109:21 | exit ThrowExpr |
+| pre | ExitMethods.cs:109:13:109:21 | enter ThrowExpr | ExitMethods.cs:111:29:111:29 | 1 |
+| pre | ExitMethods.cs:109:13:109:21 | enter ThrowExpr | ExitMethods.cs:111:69:111:75 | "input" |
+| pre | ExitMethods.cs:109:13:109:21 | exit ThrowExpr | ExitMethods.cs:109:13:109:21 | exit ThrowExpr |
+| pre | ExitMethods.cs:111:29:111:29 | 1 | ExitMethods.cs:111:29:111:29 | 1 |
+| pre | ExitMethods.cs:111:69:111:75 | "input" | ExitMethods.cs:111:69:111:75 | "input" |
+| pre | ExitMethods.cs:114:16:114:34 | enter ExtensionMethodCall | ExitMethods.cs:114:16:114:34 | enter ExtensionMethodCall |
+| pre | ExitMethods.cs:114:16:114:34 | enter ExtensionMethodCall | ExitMethods.cs:116:9:116:39 | return ...; |
+| pre | ExitMethods.cs:114:16:114:34 | enter ExtensionMethodCall | ExitMethods.cs:116:34:116:34 | 0 |
+| pre | ExitMethods.cs:114:16:114:34 | enter ExtensionMethodCall | ExitMethods.cs:116:38:116:38 | 1 |
+| pre | ExitMethods.cs:116:9:116:39 | return ...; | ExitMethods.cs:116:9:116:39 | return ...; |
+| pre | ExitMethods.cs:116:34:116:34 | 0 | ExitMethods.cs:116:34:116:34 | 0 |
+| pre | ExitMethods.cs:116:38:116:38 | 1 | ExitMethods.cs:116:38:116:38 | 1 |
+| pre | ExitMethods.cs:119:17:119:32 | enter FailingAssertion | ExitMethods.cs:119:17:119:32 | enter FailingAssertion |
+| pre | ExitMethods.cs:125:17:125:33 | enter FailingAssertion2 | ExitMethods.cs:125:17:125:33 | enter FailingAssertion2 |
+| pre | ExitMethods.cs:131:10:131:20 | enter AssertFalse | ExitMethods.cs:131:10:131:20 | enter AssertFalse |
+| pre | ExitMethods.cs:133:17:133:33 | enter FailingAssertion3 | ExitMethods.cs:133:17:133:33 | enter FailingAssertion3 |
 | pre | Extensions.cs:5:23:5:29 | enter ToInt32 | Extensions.cs:5:23:5:29 | enter ToInt32 |
 | pre | Extensions.cs:10:24:10:29 | enter ToBool | Extensions.cs:10:24:10:29 | enter ToBool |
 | pre | Extensions.cs:15:23:15:33 | enter CallToInt32 | Extensions.cs:15:23:15:33 | enter CallToInt32 |

--- a/csharp/ql/test/library-tests/controlflow/graph/ConditionBlock.expected
+++ b/csharp/ql/test/library-tests/controlflow/graph/ConditionBlock.expected
@@ -169,13 +169,13 @@
 | Conditions.cs:135:21:135:26 | [Field1 (line 129): true] access to field Field2 | Conditions.cs:131:16:131:19 | [Field1 (line 129): true, Field2 (line 129): false] true | false |
 | Conditions.cs:135:21:135:26 | [Field1 (line 129): true] access to field Field2 | Conditions.cs:136:17:138:17 | [Field1 (line 129): true, Field2 (line 129): true] {...} | true |
 | ExitMethods.cs:43:9:46:9 | [exception: Exception] catch (...) {...} | ExitMethods.cs:47:9:50:9 | [exception: Exception] catch (...) {...} | false |
-| ExitMethods.cs:55:13:55:13 | access to parameter b | ExitMethods.cs:56:19:56:33 | object creation of type Exception | true |
-| ExitMethods.cs:61:13:61:13 | access to parameter b | ExitMethods.cs:62:19:62:33 | object creation of type Exception | true |
-| ExitMethods.cs:61:13:61:13 | access to parameter b | ExitMethods.cs:64:41:64:43 | "b" | false |
-| ExitMethods.cs:92:16:92:25 | ... != ... | ExitMethods.cs:92:29:92:29 | 1 | true |
-| ExitMethods.cs:92:16:92:25 | ... != ... | ExitMethods.cs:92:69:92:75 | "input" | false |
-| ExitMethods.cs:97:16:97:30 | call to method Contains | ExitMethods.cs:97:34:97:34 | 0 | true |
-| ExitMethods.cs:97:16:97:30 | call to method Contains | ExitMethods.cs:97:38:97:38 | 1 | false |
+| ExitMethods.cs:67:13:67:13 | access to parameter b | ExitMethods.cs:68:19:68:33 | object creation of type Exception | true |
+| ExitMethods.cs:73:13:73:13 | access to parameter b | ExitMethods.cs:74:19:74:33 | object creation of type Exception | true |
+| ExitMethods.cs:73:13:73:13 | access to parameter b | ExitMethods.cs:76:41:76:43 | "b" | false |
+| ExitMethods.cs:111:16:111:25 | ... != ... | ExitMethods.cs:111:29:111:29 | 1 | true |
+| ExitMethods.cs:111:16:111:25 | ... != ... | ExitMethods.cs:111:69:111:75 | "input" | false |
+| ExitMethods.cs:116:16:116:30 | call to method Contains | ExitMethods.cs:116:34:116:34 | 0 | true |
+| ExitMethods.cs:116:16:116:30 | call to method Contains | ExitMethods.cs:116:38:116:38 | 1 | false |
 | Foreach.cs:8:9:9:13 | foreach (... ... in ...) ... | Foreach.cs:6:10:6:11 | exit M1 | true |
 | Foreach.cs:8:9:9:13 | foreach (... ... in ...) ... | Foreach.cs:8:22:8:24 | String arg | false |
 | Foreach.cs:14:9:15:13 | foreach (... ... in ...) ... | Foreach.cs:12:10:12:11 | exit M2 | true |

--- a/csharp/ql/test/library-tests/controlflow/graph/ConditionalFlow.expected
+++ b/csharp/ql/test/library-tests/controlflow/graph/ConditionalFlow.expected
@@ -116,8 +116,6 @@
 | 51 | 17 | Conditions.cs:51:17:51:17 | [b (line 46): true] access to parameter b | true | 52 | 17 | Conditions.cs:52:17:52:20 | [b (line 46): true] ...; |
 | 51 | 17 | Conditions.cs:51:17:51:17 | access to parameter b | false | 49 | 16 | Conditions.cs:49:16:49:16 | [b (line 46): false] access to parameter x |
 | 51 | 17 | Conditions.cs:51:17:51:17 | access to parameter b | true | 52 | 17 | Conditions.cs:52:17:52:20 | [b (line 46): true] ...; |
-| 55 | 13 | ExitMethods.cs:55:13:55:13 | access to parameter b | false | 53 | 17 | ExitMethods.cs:53:17:53:26 | exit ErrorMaybe |
-| 55 | 13 | ExitMethods.cs:55:13:55:13 | access to parameter b | true | 56 | 19 | ExitMethods.cs:56:19:56:33 | object creation of type Exception |
 | 60 | 16 | Conditions.cs:60:16:60:22 | ... > ... | false | 65 | 9 | Conditions.cs:65:9:66:16 | if (...) ... |
 | 60 | 16 | Conditions.cs:60:16:60:22 | ... > ... | true | 61 | 9 | Conditions.cs:61:9:64:9 | {...} |
 | 60 | 16 | Conditions.cs:60:16:60:22 | [b (line 57): false] ... > ... | false | 65 | 9 | Conditions.cs:65:9:66:16 | [b (line 57): false] if (...) ... |
@@ -126,8 +124,6 @@
 | 60 | 16 | Conditions.cs:60:16:60:22 | [b (line 57): true] ... > ... | true | 61 | 9 | Conditions.cs:61:9:64:9 | [b (line 57): true] {...} |
 | 60 | 17 | BreakInTry.cs:60:17:60:28 | ... == ... | false | 64 | 9 | BreakInTry.cs:64:9:70:9 | {...} |
 | 60 | 17 | BreakInTry.cs:60:17:60:28 | ... == ... | true | 61 | 17 | BreakInTry.cs:61:17:61:23 | return ...; |
-| 61 | 13 | ExitMethods.cs:61:13:61:13 | access to parameter b | false | 64 | 41 | ExitMethods.cs:64:41:64:43 | "b" |
-| 61 | 13 | ExitMethods.cs:61:13:61:13 | access to parameter b | true | 62 | 19 | ExitMethods.cs:62:19:62:33 | object creation of type Exception |
 | 62 | 17 | Conditions.cs:62:17:62:17 | [b (line 57): false] access to parameter b | false | 60 | 16 | Conditions.cs:60:16:60:16 | [b (line 57): false] access to parameter x |
 | 62 | 17 | Conditions.cs:62:17:62:17 | [b (line 57): true] access to parameter b | true | 63 | 17 | Conditions.cs:63:17:63:20 | [b (line 57): true] ...; |
 | 62 | 17 | Conditions.cs:62:17:62:17 | access to parameter b | false | 60 | 16 | Conditions.cs:60:16:60:16 | [b (line 57): false] access to parameter x |
@@ -138,12 +134,16 @@
 | 65 | 13 | Conditions.cs:65:13:65:13 | [b (line 57): true] access to parameter b | true | 66 | 13 | Conditions.cs:66:13:66:16 | ...; |
 | 65 | 13 | Conditions.cs:65:13:65:13 | access to parameter b | false | 67 | 16 | Conditions.cs:67:16:67:16 | access to local variable y |
 | 65 | 13 | Conditions.cs:65:13:65:13 | access to parameter b | true | 66 | 13 | Conditions.cs:66:13:66:16 | ...; |
+| 67 | 13 | ExitMethods.cs:67:13:67:13 | access to parameter b | false | 65 | 17 | ExitMethods.cs:65:17:65:26 | exit ErrorMaybe |
+| 67 | 13 | ExitMethods.cs:67:13:67:13 | access to parameter b | true | 68 | 19 | ExitMethods.cs:68:19:68:33 | object creation of type Exception |
 | 67 | 21 | BreakInTry.cs:67:21:67:31 | ... == ... | false | 65 | 13 | BreakInTry.cs:65:13:69:13 | foreach (... ... in ...) ... |
 | 67 | 21 | BreakInTry.cs:67:21:67:31 | ... == ... | true | 68 | 21 | BreakInTry.cs:68:21:68:26 | break; |
 | 67 | 21 | BreakInTry.cs:67:21:67:31 | [finally: return] ... == ... | false | 65 | 13 | BreakInTry.cs:65:13:69:13 | [finally: return] foreach (... ... in ...) ... |
 | 67 | 21 | BreakInTry.cs:67:21:67:31 | [finally: return] ... == ... | true | 68 | 21 | BreakInTry.cs:68:21:68:26 | [finally: return] break; |
 | 72 | 13 | cflow.cs:72:13:72:21 | ... == ... | false | 74 | 9 | cflow.cs:74:9:81:9 | if (...) ... |
 | 72 | 13 | cflow.cs:72:13:72:21 | ... == ... | true | 73 | 13 | cflow.cs:73:13:73:19 | return ...; |
+| 73 | 13 | ExitMethods.cs:73:13:73:13 | access to parameter b | false | 76 | 41 | ExitMethods.cs:76:41:76:43 | "b" |
+| 73 | 13 | ExitMethods.cs:73:13:73:13 | access to parameter b | true | 74 | 19 | ExitMethods.cs:74:19:74:33 | object creation of type Exception |
 | 74 | 13 | cflow.cs:74:13:74:24 | ... > ... | false | 79 | 9 | cflow.cs:79:9:81:9 | {...} |
 | 74 | 13 | cflow.cs:74:13:74:24 | ... > ... | true | 75 | 9 | cflow.cs:75:9:77:9 | {...} |
 | 76 | 17 | Conditions.cs:76:17:76:17 | access to local variable b | false | 78 | 13 | Conditions.cs:78:13:79:26 | if (...) ... |
@@ -160,8 +160,6 @@
 | 86 | 26 | cflow.cs:86:26:86:37 | ... > ... | true | 87 | 13 | cflow.cs:87:13:87:33 | ...; |
 | 92 | 13 | cflow.cs:92:13:92:27 | call to method Equals | false | 94 | 9 | cflow.cs:94:9:94:29 | ...; |
 | 92 | 13 | cflow.cs:92:13:92:27 | call to method Equals | true | 93 | 45 | cflow.cs:93:45:93:47 | "s" |
-| 92 | 16 | ExitMethods.cs:92:16:92:25 | ... != ... | false | 92 | 69 | ExitMethods.cs:92:69:92:75 | "input" |
-| 92 | 16 | ExitMethods.cs:92:16:92:25 | ... != ... | true | 92 | 29 | ExitMethods.cs:92:29:92:29 | 1 |
 | 92 | 17 | Conditions.cs:92:17:92:17 | access to local variable b | false | 94 | 13 | Conditions.cs:94:13:95:26 | if (...) ... |
 | 92 | 17 | Conditions.cs:92:17:92:17 | access to local variable b | true | 93 | 17 | Conditions.cs:93:17:93:20 | ...; |
 | 94 | 17 | Conditions.cs:94:17:94:21 | ... > ... | false | 96 | 13 | Conditions.cs:96:13:97:20 | if (...) ... |
@@ -170,8 +168,6 @@
 | 96 | 13 | cflow.cs:96:13:96:25 | ... != ... | true | 97 | 13 | cflow.cs:97:13:97:55 | ...; |
 | 96 | 17 | Conditions.cs:96:17:96:17 | access to local variable b | false | 90 | 9 | Conditions.cs:90:9:98:9 | foreach (... ... in ...) ... |
 | 96 | 17 | Conditions.cs:96:17:96:17 | access to local variable b | true | 97 | 17 | Conditions.cs:97:17:97:20 | ...; |
-| 97 | 16 | ExitMethods.cs:97:16:97:30 | call to method Contains | false | 97 | 38 | ExitMethods.cs:97:38:97:38 | 1 |
-| 97 | 16 | ExitMethods.cs:97:16:97:30 | call to method Contains | true | 97 | 34 | ExitMethods.cs:97:34:97:34 | 0 |
 | 99 | 13 | cflow.cs:99:13:99:25 | ... != ... | false | 102 | 9 | cflow.cs:102:9:103:36 | if (...) ... |
 | 99 | 13 | cflow.cs:99:13:99:25 | ... != ... | true | 100 | 13 | cflow.cs:100:13:100:42 | ...; |
 | 102 | 13 | cflow.cs:102:13:102:29 | ... != ... | false | 90 | 18 | cflow.cs:90:18:90:19 | exit M3 |
@@ -187,6 +183,10 @@
 | 108 | 18 | Conditions.cs:108:18:108:18 | [b (line 102): false] access to parameter b | false | 109 | 17 | Conditions.cs:109:17:109:24 | ...; |
 | 108 | 18 | Conditions.cs:108:18:108:18 | [b (line 102): true] access to parameter b | true | 110 | 16 | Conditions.cs:110:16:110:16 | access to local variable x |
 | 110 | 20 | cflow.cs:110:20:110:23 | true | true | 111 | 13 | cflow.cs:111:13:113:13 | {...} |
+| 111 | 16 | ExitMethods.cs:111:16:111:25 | ... != ... | false | 111 | 69 | ExitMethods.cs:111:69:111:75 | "input" |
+| 111 | 16 | ExitMethods.cs:111:16:111:25 | ... != ... | true | 111 | 29 | ExitMethods.cs:111:29:111:29 | 1 |
+| 116 | 16 | ExitMethods.cs:116:16:116:30 | call to method Contains | false | 116 | 38 | ExitMethods.cs:116:38:116:38 | 1 |
+| 116 | 16 | ExitMethods.cs:116:16:116:30 | call to method Contains | true | 116 | 34 | ExitMethods.cs:116:34:116:34 | 0 |
 | 116 | 24 | Conditions.cs:116:24:116:38 | ... < ... | false | 113 | 10 | Conditions.cs:113:10:113:11 | exit M9 |
 | 116 | 24 | Conditions.cs:116:24:116:38 | ... < ... | true | 117 | 9 | Conditions.cs:117:9:123:9 | {...} |
 | 117 | 25 | Switch.cs:117:25:117:32 | ... == ... | false | 118 | 13 | Switch.cs:118:13:118:33 | case ...: |

--- a/csharp/ql/test/library-tests/controlflow/graph/Dominance.expected
+++ b/csharp/ql/test/library-tests/controlflow/graph/Dominance.expected
@@ -735,77 +735,93 @@
 | post | ExitMethods.cs:45:13:45:19 | return ...; | ExitMethods.cs:44:9:46:9 | {...} |
 | post | ExitMethods.cs:48:9:50:9 | {...} | ExitMethods.cs:47:9:50:9 | [exception: Exception] catch (...) {...} |
 | post | ExitMethods.cs:49:13:49:19 | return ...; | ExitMethods.cs:48:9:50:9 | {...} |
-| post | ExitMethods.cs:53:17:53:26 | exit ErrorMaybe | ExitMethods.cs:55:13:55:13 | access to parameter b |
-| post | ExitMethods.cs:53:17:53:26 | exit ErrorMaybe | ExitMethods.cs:56:13:56:34 | throw ...; |
-| post | ExitMethods.cs:54:5:57:5 | {...} | ExitMethods.cs:53:17:53:26 | enter ErrorMaybe |
-| post | ExitMethods.cs:55:9:56:34 | if (...) ... | ExitMethods.cs:54:5:57:5 | {...} |
-| post | ExitMethods.cs:55:13:55:13 | access to parameter b | ExitMethods.cs:55:9:56:34 | if (...) ... |
-| post | ExitMethods.cs:56:13:56:34 | throw ...; | ExitMethods.cs:56:19:56:33 | object creation of type Exception |
-| post | ExitMethods.cs:59:17:59:27 | exit ErrorAlways | ExitMethods.cs:62:13:62:34 | throw ...; |
-| post | ExitMethods.cs:59:17:59:27 | exit ErrorAlways | ExitMethods.cs:64:13:64:45 | throw ...; |
-| post | ExitMethods.cs:60:5:65:5 | {...} | ExitMethods.cs:59:17:59:27 | enter ErrorAlways |
-| post | ExitMethods.cs:61:9:64:45 | if (...) ... | ExitMethods.cs:60:5:65:5 | {...} |
-| post | ExitMethods.cs:61:13:61:13 | access to parameter b | ExitMethods.cs:61:9:64:45 | if (...) ... |
-| post | ExitMethods.cs:62:13:62:34 | throw ...; | ExitMethods.cs:62:19:62:33 | object creation of type Exception |
-| post | ExitMethods.cs:64:13:64:45 | throw ...; | ExitMethods.cs:64:19:64:44 | object creation of type ArgumentException |
-| post | ExitMethods.cs:64:19:64:44 | object creation of type ArgumentException | ExitMethods.cs:64:41:64:43 | "b" |
-| post | ExitMethods.cs:67:10:67:13 | exit Exit | ExitMethods.cs:69:9:69:27 | call to method Exit |
-| post | ExitMethods.cs:68:5:70:5 | {...} | ExitMethods.cs:67:10:67:13 | enter Exit |
-| post | ExitMethods.cs:69:9:69:27 | call to method Exit | ExitMethods.cs:69:26:69:26 | 0 |
-| post | ExitMethods.cs:69:9:69:28 | ...; | ExitMethods.cs:68:5:70:5 | {...} |
-| post | ExitMethods.cs:69:26:69:26 | 0 | ExitMethods.cs:69:9:69:28 | ...; |
-| post | ExitMethods.cs:72:10:72:18 | exit ExitInTry | ExitMethods.cs:76:13:76:18 | call to method Exit |
-| post | ExitMethods.cs:73:5:83:5 | {...} | ExitMethods.cs:72:10:72:18 | enter ExitInTry |
-| post | ExitMethods.cs:74:9:82:9 | try {...} ... | ExitMethods.cs:73:5:83:5 | {...} |
-| post | ExitMethods.cs:75:9:77:9 | {...} | ExitMethods.cs:74:9:82:9 | try {...} ... |
-| post | ExitMethods.cs:76:13:76:18 | call to method Exit | ExitMethods.cs:76:13:76:18 | this access |
-| post | ExitMethods.cs:76:13:76:18 | this access | ExitMethods.cs:76:13:76:19 | ...; |
-| post | ExitMethods.cs:76:13:76:19 | ...; | ExitMethods.cs:75:9:77:9 | {...} |
-| post | ExitMethods.cs:85:10:85:24 | exit ApplicationExit | ExitMethods.cs:87:9:87:47 | call to method Exit |
-| post | ExitMethods.cs:86:5:88:5 | {...} | ExitMethods.cs:85:10:85:24 | enter ApplicationExit |
-| post | ExitMethods.cs:87:9:87:47 | call to method Exit | ExitMethods.cs:87:9:87:48 | ...; |
-| post | ExitMethods.cs:87:9:87:48 | ...; | ExitMethods.cs:86:5:88:5 | {...} |
-| post | ExitMethods.cs:90:13:90:21 | exit ThrowExpr | ExitMethods.cs:92:9:92:77 | return ...; |
-| post | ExitMethods.cs:90:13:90:21 | exit ThrowExpr | ExitMethods.cs:92:41:92:76 | throw ... |
-| post | ExitMethods.cs:91:5:93:5 | {...} | ExitMethods.cs:90:13:90:21 | enter ThrowExpr |
-| post | ExitMethods.cs:92:9:92:77 | return ...; | ExitMethods.cs:92:29:92:37 | ... / ... |
-| post | ExitMethods.cs:92:16:92:20 | access to parameter input | ExitMethods.cs:92:16:92:76 | ... ? ... : ... |
-| post | ExitMethods.cs:92:16:92:25 | ... != ... | ExitMethods.cs:92:25:92:25 | (...) ... |
-| post | ExitMethods.cs:92:16:92:76 | ... ? ... : ... | ExitMethods.cs:91:5:93:5 | {...} |
-| post | ExitMethods.cs:92:25:92:25 | 0 | ExitMethods.cs:92:16:92:20 | access to parameter input |
-| post | ExitMethods.cs:92:25:92:25 | (...) ... | ExitMethods.cs:92:25:92:25 | 0 |
-| post | ExitMethods.cs:92:29:92:29 | (...) ... | ExitMethods.cs:92:29:92:29 | 1 |
-| post | ExitMethods.cs:92:29:92:37 | ... / ... | ExitMethods.cs:92:33:92:37 | access to parameter input |
-| post | ExitMethods.cs:92:33:92:37 | access to parameter input | ExitMethods.cs:92:29:92:29 | (...) ... |
-| post | ExitMethods.cs:92:41:92:76 | throw ... | ExitMethods.cs:92:47:92:76 | object creation of type ArgumentException |
-| post | ExitMethods.cs:92:47:92:76 | object creation of type ArgumentException | ExitMethods.cs:92:69:92:75 | "input" |
-| post | ExitMethods.cs:95:16:95:34 | exit ExtensionMethodCall | ExitMethods.cs:97:9:97:39 | return ...; |
-| post | ExitMethods.cs:96:5:98:5 | {...} | ExitMethods.cs:95:16:95:34 | enter ExtensionMethodCall |
-| post | ExitMethods.cs:97:9:97:39 | return ...; | ExitMethods.cs:97:34:97:34 | 0 |
-| post | ExitMethods.cs:97:9:97:39 | return ...; | ExitMethods.cs:97:38:97:38 | 1 |
-| post | ExitMethods.cs:97:16:97:16 | access to parameter s | ExitMethods.cs:97:16:97:38 | ... ? ... : ... |
-| post | ExitMethods.cs:97:16:97:30 | call to method Contains | ExitMethods.cs:97:27:97:29 | - |
-| post | ExitMethods.cs:97:16:97:38 | ... ? ... : ... | ExitMethods.cs:96:5:98:5 | {...} |
-| post | ExitMethods.cs:97:27:97:29 | - | ExitMethods.cs:97:16:97:16 | access to parameter s |
-| post | ExitMethods.cs:100:17:100:32 | exit FailingAssertion | ExitMethods.cs:102:9:102:28 | call to method IsTrue |
-| post | ExitMethods.cs:101:5:104:5 | {...} | ExitMethods.cs:100:17:100:32 | enter FailingAssertion |
-| post | ExitMethods.cs:102:9:102:28 | call to method IsTrue | ExitMethods.cs:102:23:102:27 | false |
-| post | ExitMethods.cs:102:9:102:29 | ...; | ExitMethods.cs:101:5:104:5 | {...} |
-| post | ExitMethods.cs:102:23:102:27 | false | ExitMethods.cs:102:9:102:29 | ...; |
-| post | ExitMethods.cs:106:17:106:33 | exit FailingAssertion2 | ExitMethods.cs:108:9:108:26 | call to method FailingAssertion |
-| post | ExitMethods.cs:107:5:110:5 | {...} | ExitMethods.cs:106:17:106:33 | enter FailingAssertion2 |
-| post | ExitMethods.cs:108:9:108:26 | call to method FailingAssertion | ExitMethods.cs:108:9:108:26 | this access |
-| post | ExitMethods.cs:108:9:108:26 | this access | ExitMethods.cs:108:9:108:27 | ...; |
-| post | ExitMethods.cs:108:9:108:27 | ...; | ExitMethods.cs:107:5:110:5 | {...} |
-| post | ExitMethods.cs:112:10:112:20 | exit AssertFalse | ExitMethods.cs:112:33:112:49 | call to method IsFalse |
-| post | ExitMethods.cs:112:33:112:49 | call to method IsFalse | ExitMethods.cs:112:48:112:48 | access to parameter b |
-| post | ExitMethods.cs:112:48:112:48 | access to parameter b | ExitMethods.cs:112:10:112:20 | enter AssertFalse |
-| post | ExitMethods.cs:114:17:114:33 | exit FailingAssertion3 | ExitMethods.cs:116:9:116:25 | call to method AssertFalse |
-| post | ExitMethods.cs:115:5:118:5 | {...} | ExitMethods.cs:114:17:114:33 | enter FailingAssertion3 |
-| post | ExitMethods.cs:116:9:116:25 | call to method AssertFalse | ExitMethods.cs:116:21:116:24 | true |
-| post | ExitMethods.cs:116:9:116:25 | this access | ExitMethods.cs:116:9:116:26 | ...; |
-| post | ExitMethods.cs:116:9:116:26 | ...; | ExitMethods.cs:115:5:118:5 | {...} |
-| post | ExitMethods.cs:116:21:116:24 | true | ExitMethods.cs:116:9:116:25 | this access |
+| post | ExitMethods.cs:53:10:53:11 | exit M7 | ExitMethods.cs:56:9:56:15 | return ...; |
+| post | ExitMethods.cs:54:5:57:5 | {...} | ExitMethods.cs:53:10:53:11 | enter M7 |
+| post | ExitMethods.cs:55:9:55:22 | call to method ErrorAlways2 | ExitMethods.cs:55:9:55:23 | ...; |
+| post | ExitMethods.cs:55:9:55:23 | ...; | ExitMethods.cs:54:5:57:5 | {...} |
+| post | ExitMethods.cs:56:9:56:15 | return ...; | ExitMethods.cs:55:9:55:22 | call to method ErrorAlways2 |
+| post | ExitMethods.cs:59:10:59:11 | exit M8 | ExitMethods.cs:61:9:61:22 | call to method ErrorAlways3 |
+| post | ExitMethods.cs:60:5:63:5 | {...} | ExitMethods.cs:59:10:59:11 | enter M8 |
+| post | ExitMethods.cs:61:9:61:22 | call to method ErrorAlways3 | ExitMethods.cs:61:9:61:23 | ...; |
+| post | ExitMethods.cs:61:9:61:23 | ...; | ExitMethods.cs:60:5:63:5 | {...} |
+| post | ExitMethods.cs:65:17:65:26 | exit ErrorMaybe | ExitMethods.cs:67:13:67:13 | access to parameter b |
+| post | ExitMethods.cs:65:17:65:26 | exit ErrorMaybe | ExitMethods.cs:68:13:68:34 | throw ...; |
+| post | ExitMethods.cs:66:5:69:5 | {...} | ExitMethods.cs:65:17:65:26 | enter ErrorMaybe |
+| post | ExitMethods.cs:67:9:68:34 | if (...) ... | ExitMethods.cs:66:5:69:5 | {...} |
+| post | ExitMethods.cs:67:13:67:13 | access to parameter b | ExitMethods.cs:67:9:68:34 | if (...) ... |
+| post | ExitMethods.cs:68:13:68:34 | throw ...; | ExitMethods.cs:68:19:68:33 | object creation of type Exception |
+| post | ExitMethods.cs:71:17:71:27 | exit ErrorAlways | ExitMethods.cs:74:13:74:34 | throw ...; |
+| post | ExitMethods.cs:71:17:71:27 | exit ErrorAlways | ExitMethods.cs:76:13:76:45 | throw ...; |
+| post | ExitMethods.cs:72:5:77:5 | {...} | ExitMethods.cs:71:17:71:27 | enter ErrorAlways |
+| post | ExitMethods.cs:73:9:76:45 | if (...) ... | ExitMethods.cs:72:5:77:5 | {...} |
+| post | ExitMethods.cs:73:13:73:13 | access to parameter b | ExitMethods.cs:73:9:76:45 | if (...) ... |
+| post | ExitMethods.cs:74:13:74:34 | throw ...; | ExitMethods.cs:74:19:74:33 | object creation of type Exception |
+| post | ExitMethods.cs:76:13:76:45 | throw ...; | ExitMethods.cs:76:19:76:44 | object creation of type ArgumentException |
+| post | ExitMethods.cs:76:19:76:44 | object creation of type ArgumentException | ExitMethods.cs:76:41:76:43 | "b" |
+| post | ExitMethods.cs:79:17:79:28 | exit ErrorAlways2 | ExitMethods.cs:81:9:81:30 | throw ...; |
+| post | ExitMethods.cs:80:5:82:5 | {...} | ExitMethods.cs:79:17:79:28 | enter ErrorAlways2 |
+| post | ExitMethods.cs:81:9:81:30 | throw ...; | ExitMethods.cs:81:15:81:29 | object creation of type Exception |
+| post | ExitMethods.cs:81:15:81:29 | object creation of type Exception | ExitMethods.cs:80:5:82:5 | {...} |
+| post | ExitMethods.cs:84:17:84:28 | exit ErrorAlways3 | ExitMethods.cs:84:35:84:55 | throw ... |
+| post | ExitMethods.cs:84:35:84:55 | throw ... | ExitMethods.cs:84:41:84:55 | object creation of type Exception |
+| post | ExitMethods.cs:84:41:84:55 | object creation of type Exception | ExitMethods.cs:84:17:84:28 | enter ErrorAlways3 |
+| post | ExitMethods.cs:86:10:86:13 | exit Exit | ExitMethods.cs:88:9:88:27 | call to method Exit |
+| post | ExitMethods.cs:87:5:89:5 | {...} | ExitMethods.cs:86:10:86:13 | enter Exit |
+| post | ExitMethods.cs:88:9:88:27 | call to method Exit | ExitMethods.cs:88:26:88:26 | 0 |
+| post | ExitMethods.cs:88:9:88:28 | ...; | ExitMethods.cs:87:5:89:5 | {...} |
+| post | ExitMethods.cs:88:26:88:26 | 0 | ExitMethods.cs:88:9:88:28 | ...; |
+| post | ExitMethods.cs:91:10:91:18 | exit ExitInTry | ExitMethods.cs:95:13:95:18 | call to method Exit |
+| post | ExitMethods.cs:92:5:102:5 | {...} | ExitMethods.cs:91:10:91:18 | enter ExitInTry |
+| post | ExitMethods.cs:93:9:101:9 | try {...} ... | ExitMethods.cs:92:5:102:5 | {...} |
+| post | ExitMethods.cs:94:9:96:9 | {...} | ExitMethods.cs:93:9:101:9 | try {...} ... |
+| post | ExitMethods.cs:95:13:95:18 | call to method Exit | ExitMethods.cs:95:13:95:18 | this access |
+| post | ExitMethods.cs:95:13:95:18 | this access | ExitMethods.cs:95:13:95:19 | ...; |
+| post | ExitMethods.cs:95:13:95:19 | ...; | ExitMethods.cs:94:9:96:9 | {...} |
+| post | ExitMethods.cs:104:10:104:24 | exit ApplicationExit | ExitMethods.cs:106:9:106:47 | call to method Exit |
+| post | ExitMethods.cs:105:5:107:5 | {...} | ExitMethods.cs:104:10:104:24 | enter ApplicationExit |
+| post | ExitMethods.cs:106:9:106:47 | call to method Exit | ExitMethods.cs:106:9:106:48 | ...; |
+| post | ExitMethods.cs:106:9:106:48 | ...; | ExitMethods.cs:105:5:107:5 | {...} |
+| post | ExitMethods.cs:109:13:109:21 | exit ThrowExpr | ExitMethods.cs:111:9:111:77 | return ...; |
+| post | ExitMethods.cs:109:13:109:21 | exit ThrowExpr | ExitMethods.cs:111:41:111:76 | throw ... |
+| post | ExitMethods.cs:110:5:112:5 | {...} | ExitMethods.cs:109:13:109:21 | enter ThrowExpr |
+| post | ExitMethods.cs:111:9:111:77 | return ...; | ExitMethods.cs:111:29:111:37 | ... / ... |
+| post | ExitMethods.cs:111:16:111:20 | access to parameter input | ExitMethods.cs:111:16:111:76 | ... ? ... : ... |
+| post | ExitMethods.cs:111:16:111:25 | ... != ... | ExitMethods.cs:111:25:111:25 | (...) ... |
+| post | ExitMethods.cs:111:16:111:76 | ... ? ... : ... | ExitMethods.cs:110:5:112:5 | {...} |
+| post | ExitMethods.cs:111:25:111:25 | 0 | ExitMethods.cs:111:16:111:20 | access to parameter input |
+| post | ExitMethods.cs:111:25:111:25 | (...) ... | ExitMethods.cs:111:25:111:25 | 0 |
+| post | ExitMethods.cs:111:29:111:29 | (...) ... | ExitMethods.cs:111:29:111:29 | 1 |
+| post | ExitMethods.cs:111:29:111:37 | ... / ... | ExitMethods.cs:111:33:111:37 | access to parameter input |
+| post | ExitMethods.cs:111:33:111:37 | access to parameter input | ExitMethods.cs:111:29:111:29 | (...) ... |
+| post | ExitMethods.cs:111:41:111:76 | throw ... | ExitMethods.cs:111:47:111:76 | object creation of type ArgumentException |
+| post | ExitMethods.cs:111:47:111:76 | object creation of type ArgumentException | ExitMethods.cs:111:69:111:75 | "input" |
+| post | ExitMethods.cs:114:16:114:34 | exit ExtensionMethodCall | ExitMethods.cs:116:9:116:39 | return ...; |
+| post | ExitMethods.cs:115:5:117:5 | {...} | ExitMethods.cs:114:16:114:34 | enter ExtensionMethodCall |
+| post | ExitMethods.cs:116:9:116:39 | return ...; | ExitMethods.cs:116:34:116:34 | 0 |
+| post | ExitMethods.cs:116:9:116:39 | return ...; | ExitMethods.cs:116:38:116:38 | 1 |
+| post | ExitMethods.cs:116:16:116:16 | access to parameter s | ExitMethods.cs:116:16:116:38 | ... ? ... : ... |
+| post | ExitMethods.cs:116:16:116:30 | call to method Contains | ExitMethods.cs:116:27:116:29 | - |
+| post | ExitMethods.cs:116:16:116:38 | ... ? ... : ... | ExitMethods.cs:115:5:117:5 | {...} |
+| post | ExitMethods.cs:116:27:116:29 | - | ExitMethods.cs:116:16:116:16 | access to parameter s |
+| post | ExitMethods.cs:119:17:119:32 | exit FailingAssertion | ExitMethods.cs:121:9:121:28 | call to method IsTrue |
+| post | ExitMethods.cs:120:5:123:5 | {...} | ExitMethods.cs:119:17:119:32 | enter FailingAssertion |
+| post | ExitMethods.cs:121:9:121:28 | call to method IsTrue | ExitMethods.cs:121:23:121:27 | false |
+| post | ExitMethods.cs:121:9:121:29 | ...; | ExitMethods.cs:120:5:123:5 | {...} |
+| post | ExitMethods.cs:121:23:121:27 | false | ExitMethods.cs:121:9:121:29 | ...; |
+| post | ExitMethods.cs:125:17:125:33 | exit FailingAssertion2 | ExitMethods.cs:127:9:127:26 | call to method FailingAssertion |
+| post | ExitMethods.cs:126:5:129:5 | {...} | ExitMethods.cs:125:17:125:33 | enter FailingAssertion2 |
+| post | ExitMethods.cs:127:9:127:26 | call to method FailingAssertion | ExitMethods.cs:127:9:127:26 | this access |
+| post | ExitMethods.cs:127:9:127:26 | this access | ExitMethods.cs:127:9:127:27 | ...; |
+| post | ExitMethods.cs:127:9:127:27 | ...; | ExitMethods.cs:126:5:129:5 | {...} |
+| post | ExitMethods.cs:131:10:131:20 | exit AssertFalse | ExitMethods.cs:131:33:131:49 | call to method IsFalse |
+| post | ExitMethods.cs:131:33:131:49 | call to method IsFalse | ExitMethods.cs:131:48:131:48 | access to parameter b |
+| post | ExitMethods.cs:131:48:131:48 | access to parameter b | ExitMethods.cs:131:10:131:20 | enter AssertFalse |
+| post | ExitMethods.cs:133:17:133:33 | exit FailingAssertion3 | ExitMethods.cs:135:9:135:25 | call to method AssertFalse |
+| post | ExitMethods.cs:134:5:137:5 | {...} | ExitMethods.cs:133:17:133:33 | enter FailingAssertion3 |
+| post | ExitMethods.cs:135:9:135:25 | call to method AssertFalse | ExitMethods.cs:135:21:135:24 | true |
+| post | ExitMethods.cs:135:9:135:25 | this access | ExitMethods.cs:135:9:135:26 | ...; |
+| post | ExitMethods.cs:135:9:135:26 | ...; | ExitMethods.cs:134:5:137:5 | {...} |
+| post | ExitMethods.cs:135:21:135:24 | true | ExitMethods.cs:135:9:135:25 | this access |
 | post | Extensions.cs:5:23:5:29 | exit ToInt32 | Extensions.cs:7:9:7:30 | return ...; |
 | post | Extensions.cs:6:5:8:5 | {...} | Extensions.cs:5:23:5:29 | enter ToInt32 |
 | post | Extensions.cs:7:9:7:30 | return ...; | Extensions.cs:7:16:7:29 | call to method Parse |
@@ -2941,77 +2957,93 @@
 | pre | ExitMethods.cs:44:9:46:9 | {...} | ExitMethods.cs:45:13:45:19 | return ...; |
 | pre | ExitMethods.cs:47:9:50:9 | [exception: Exception] catch (...) {...} | ExitMethods.cs:48:9:50:9 | {...} |
 | pre | ExitMethods.cs:48:9:50:9 | {...} | ExitMethods.cs:49:13:49:19 | return ...; |
-| pre | ExitMethods.cs:53:17:53:26 | enter ErrorMaybe | ExitMethods.cs:54:5:57:5 | {...} |
-| pre | ExitMethods.cs:54:5:57:5 | {...} | ExitMethods.cs:55:9:56:34 | if (...) ... |
-| pre | ExitMethods.cs:55:9:56:34 | if (...) ... | ExitMethods.cs:55:13:55:13 | access to parameter b |
-| pre | ExitMethods.cs:55:13:55:13 | access to parameter b | ExitMethods.cs:53:17:53:26 | exit ErrorMaybe |
-| pre | ExitMethods.cs:55:13:55:13 | access to parameter b | ExitMethods.cs:56:19:56:33 | object creation of type Exception |
-| pre | ExitMethods.cs:56:19:56:33 | object creation of type Exception | ExitMethods.cs:56:13:56:34 | throw ...; |
-| pre | ExitMethods.cs:59:17:59:27 | enter ErrorAlways | ExitMethods.cs:60:5:65:5 | {...} |
-| pre | ExitMethods.cs:60:5:65:5 | {...} | ExitMethods.cs:61:9:64:45 | if (...) ... |
-| pre | ExitMethods.cs:61:9:64:45 | if (...) ... | ExitMethods.cs:61:13:61:13 | access to parameter b |
-| pre | ExitMethods.cs:61:13:61:13 | access to parameter b | ExitMethods.cs:62:19:62:33 | object creation of type Exception |
-| pre | ExitMethods.cs:61:13:61:13 | access to parameter b | ExitMethods.cs:64:41:64:43 | "b" |
-| pre | ExitMethods.cs:62:19:62:33 | object creation of type Exception | ExitMethods.cs:62:13:62:34 | throw ...; |
-| pre | ExitMethods.cs:64:19:64:44 | object creation of type ArgumentException | ExitMethods.cs:64:13:64:45 | throw ...; |
-| pre | ExitMethods.cs:64:41:64:43 | "b" | ExitMethods.cs:64:19:64:44 | object creation of type ArgumentException |
-| pre | ExitMethods.cs:67:10:67:13 | enter Exit | ExitMethods.cs:68:5:70:5 | {...} |
-| pre | ExitMethods.cs:68:5:70:5 | {...} | ExitMethods.cs:69:9:69:28 | ...; |
-| pre | ExitMethods.cs:69:9:69:27 | call to method Exit | ExitMethods.cs:67:10:67:13 | exit Exit |
-| pre | ExitMethods.cs:69:9:69:28 | ...; | ExitMethods.cs:69:26:69:26 | 0 |
-| pre | ExitMethods.cs:69:26:69:26 | 0 | ExitMethods.cs:69:9:69:27 | call to method Exit |
-| pre | ExitMethods.cs:72:10:72:18 | enter ExitInTry | ExitMethods.cs:73:5:83:5 | {...} |
-| pre | ExitMethods.cs:73:5:83:5 | {...} | ExitMethods.cs:74:9:82:9 | try {...} ... |
-| pre | ExitMethods.cs:74:9:82:9 | try {...} ... | ExitMethods.cs:75:9:77:9 | {...} |
-| pre | ExitMethods.cs:75:9:77:9 | {...} | ExitMethods.cs:76:13:76:19 | ...; |
-| pre | ExitMethods.cs:76:13:76:18 | call to method Exit | ExitMethods.cs:72:10:72:18 | exit ExitInTry |
-| pre | ExitMethods.cs:76:13:76:18 | this access | ExitMethods.cs:76:13:76:18 | call to method Exit |
-| pre | ExitMethods.cs:76:13:76:19 | ...; | ExitMethods.cs:76:13:76:18 | this access |
-| pre | ExitMethods.cs:85:10:85:24 | enter ApplicationExit | ExitMethods.cs:86:5:88:5 | {...} |
-| pre | ExitMethods.cs:86:5:88:5 | {...} | ExitMethods.cs:87:9:87:48 | ...; |
-| pre | ExitMethods.cs:87:9:87:47 | call to method Exit | ExitMethods.cs:85:10:85:24 | exit ApplicationExit |
-| pre | ExitMethods.cs:87:9:87:48 | ...; | ExitMethods.cs:87:9:87:47 | call to method Exit |
-| pre | ExitMethods.cs:90:13:90:21 | enter ThrowExpr | ExitMethods.cs:91:5:93:5 | {...} |
-| pre | ExitMethods.cs:91:5:93:5 | {...} | ExitMethods.cs:92:16:92:76 | ... ? ... : ... |
-| pre | ExitMethods.cs:92:16:92:20 | access to parameter input | ExitMethods.cs:92:25:92:25 | 0 |
-| pre | ExitMethods.cs:92:16:92:25 | ... != ... | ExitMethods.cs:92:29:92:29 | 1 |
-| pre | ExitMethods.cs:92:16:92:25 | ... != ... | ExitMethods.cs:92:69:92:75 | "input" |
-| pre | ExitMethods.cs:92:16:92:76 | ... ? ... : ... | ExitMethods.cs:92:16:92:20 | access to parameter input |
-| pre | ExitMethods.cs:92:25:92:25 | 0 | ExitMethods.cs:92:25:92:25 | (...) ... |
-| pre | ExitMethods.cs:92:25:92:25 | (...) ... | ExitMethods.cs:92:16:92:25 | ... != ... |
-| pre | ExitMethods.cs:92:29:92:29 | 1 | ExitMethods.cs:92:29:92:29 | (...) ... |
-| pre | ExitMethods.cs:92:29:92:29 | (...) ... | ExitMethods.cs:92:33:92:37 | access to parameter input |
-| pre | ExitMethods.cs:92:29:92:37 | ... / ... | ExitMethods.cs:92:9:92:77 | return ...; |
-| pre | ExitMethods.cs:92:33:92:37 | access to parameter input | ExitMethods.cs:92:29:92:37 | ... / ... |
-| pre | ExitMethods.cs:92:47:92:76 | object creation of type ArgumentException | ExitMethods.cs:92:41:92:76 | throw ... |
-| pre | ExitMethods.cs:92:69:92:75 | "input" | ExitMethods.cs:92:47:92:76 | object creation of type ArgumentException |
-| pre | ExitMethods.cs:95:16:95:34 | enter ExtensionMethodCall | ExitMethods.cs:96:5:98:5 | {...} |
-| pre | ExitMethods.cs:96:5:98:5 | {...} | ExitMethods.cs:97:16:97:38 | ... ? ... : ... |
-| pre | ExitMethods.cs:97:9:97:39 | return ...; | ExitMethods.cs:95:16:95:34 | exit ExtensionMethodCall |
-| pre | ExitMethods.cs:97:16:97:16 | access to parameter s | ExitMethods.cs:97:27:97:29 | - |
-| pre | ExitMethods.cs:97:16:97:30 | call to method Contains | ExitMethods.cs:97:34:97:34 | 0 |
-| pre | ExitMethods.cs:97:16:97:30 | call to method Contains | ExitMethods.cs:97:38:97:38 | 1 |
-| pre | ExitMethods.cs:97:16:97:38 | ... ? ... : ... | ExitMethods.cs:97:16:97:16 | access to parameter s |
-| pre | ExitMethods.cs:97:27:97:29 | - | ExitMethods.cs:97:16:97:30 | call to method Contains |
-| pre | ExitMethods.cs:100:17:100:32 | enter FailingAssertion | ExitMethods.cs:101:5:104:5 | {...} |
-| pre | ExitMethods.cs:101:5:104:5 | {...} | ExitMethods.cs:102:9:102:29 | ...; |
-| pre | ExitMethods.cs:102:9:102:28 | call to method IsTrue | ExitMethods.cs:100:17:100:32 | exit FailingAssertion |
-| pre | ExitMethods.cs:102:9:102:29 | ...; | ExitMethods.cs:102:23:102:27 | false |
-| pre | ExitMethods.cs:102:23:102:27 | false | ExitMethods.cs:102:9:102:28 | call to method IsTrue |
-| pre | ExitMethods.cs:106:17:106:33 | enter FailingAssertion2 | ExitMethods.cs:107:5:110:5 | {...} |
-| pre | ExitMethods.cs:107:5:110:5 | {...} | ExitMethods.cs:108:9:108:27 | ...; |
-| pre | ExitMethods.cs:108:9:108:26 | call to method FailingAssertion | ExitMethods.cs:106:17:106:33 | exit FailingAssertion2 |
-| pre | ExitMethods.cs:108:9:108:26 | this access | ExitMethods.cs:108:9:108:26 | call to method FailingAssertion |
-| pre | ExitMethods.cs:108:9:108:27 | ...; | ExitMethods.cs:108:9:108:26 | this access |
-| pre | ExitMethods.cs:112:10:112:20 | enter AssertFalse | ExitMethods.cs:112:48:112:48 | access to parameter b |
-| pre | ExitMethods.cs:112:33:112:49 | call to method IsFalse | ExitMethods.cs:112:10:112:20 | exit AssertFalse |
-| pre | ExitMethods.cs:112:48:112:48 | access to parameter b | ExitMethods.cs:112:33:112:49 | call to method IsFalse |
-| pre | ExitMethods.cs:114:17:114:33 | enter FailingAssertion3 | ExitMethods.cs:115:5:118:5 | {...} |
-| pre | ExitMethods.cs:115:5:118:5 | {...} | ExitMethods.cs:116:9:116:26 | ...; |
-| pre | ExitMethods.cs:116:9:116:25 | call to method AssertFalse | ExitMethods.cs:114:17:114:33 | exit FailingAssertion3 |
-| pre | ExitMethods.cs:116:9:116:25 | this access | ExitMethods.cs:116:21:116:24 | true |
-| pre | ExitMethods.cs:116:9:116:26 | ...; | ExitMethods.cs:116:9:116:25 | this access |
-| pre | ExitMethods.cs:116:21:116:24 | true | ExitMethods.cs:116:9:116:25 | call to method AssertFalse |
+| pre | ExitMethods.cs:53:10:53:11 | enter M7 | ExitMethods.cs:54:5:57:5 | {...} |
+| pre | ExitMethods.cs:54:5:57:5 | {...} | ExitMethods.cs:55:9:55:23 | ...; |
+| pre | ExitMethods.cs:55:9:55:22 | call to method ErrorAlways2 | ExitMethods.cs:56:9:56:15 | return ...; |
+| pre | ExitMethods.cs:55:9:55:23 | ...; | ExitMethods.cs:55:9:55:22 | call to method ErrorAlways2 |
+| pre | ExitMethods.cs:56:9:56:15 | return ...; | ExitMethods.cs:53:10:53:11 | exit M7 |
+| pre | ExitMethods.cs:59:10:59:11 | enter M8 | ExitMethods.cs:60:5:63:5 | {...} |
+| pre | ExitMethods.cs:60:5:63:5 | {...} | ExitMethods.cs:61:9:61:23 | ...; |
+| pre | ExitMethods.cs:61:9:61:22 | call to method ErrorAlways3 | ExitMethods.cs:59:10:59:11 | exit M8 |
+| pre | ExitMethods.cs:61:9:61:23 | ...; | ExitMethods.cs:61:9:61:22 | call to method ErrorAlways3 |
+| pre | ExitMethods.cs:65:17:65:26 | enter ErrorMaybe | ExitMethods.cs:66:5:69:5 | {...} |
+| pre | ExitMethods.cs:66:5:69:5 | {...} | ExitMethods.cs:67:9:68:34 | if (...) ... |
+| pre | ExitMethods.cs:67:9:68:34 | if (...) ... | ExitMethods.cs:67:13:67:13 | access to parameter b |
+| pre | ExitMethods.cs:67:13:67:13 | access to parameter b | ExitMethods.cs:65:17:65:26 | exit ErrorMaybe |
+| pre | ExitMethods.cs:67:13:67:13 | access to parameter b | ExitMethods.cs:68:19:68:33 | object creation of type Exception |
+| pre | ExitMethods.cs:68:19:68:33 | object creation of type Exception | ExitMethods.cs:68:13:68:34 | throw ...; |
+| pre | ExitMethods.cs:71:17:71:27 | enter ErrorAlways | ExitMethods.cs:72:5:77:5 | {...} |
+| pre | ExitMethods.cs:72:5:77:5 | {...} | ExitMethods.cs:73:9:76:45 | if (...) ... |
+| pre | ExitMethods.cs:73:9:76:45 | if (...) ... | ExitMethods.cs:73:13:73:13 | access to parameter b |
+| pre | ExitMethods.cs:73:13:73:13 | access to parameter b | ExitMethods.cs:74:19:74:33 | object creation of type Exception |
+| pre | ExitMethods.cs:73:13:73:13 | access to parameter b | ExitMethods.cs:76:41:76:43 | "b" |
+| pre | ExitMethods.cs:74:19:74:33 | object creation of type Exception | ExitMethods.cs:74:13:74:34 | throw ...; |
+| pre | ExitMethods.cs:76:19:76:44 | object creation of type ArgumentException | ExitMethods.cs:76:13:76:45 | throw ...; |
+| pre | ExitMethods.cs:76:41:76:43 | "b" | ExitMethods.cs:76:19:76:44 | object creation of type ArgumentException |
+| pre | ExitMethods.cs:79:17:79:28 | enter ErrorAlways2 | ExitMethods.cs:80:5:82:5 | {...} |
+| pre | ExitMethods.cs:80:5:82:5 | {...} | ExitMethods.cs:81:15:81:29 | object creation of type Exception |
+| pre | ExitMethods.cs:81:9:81:30 | throw ...; | ExitMethods.cs:79:17:79:28 | exit ErrorAlways2 |
+| pre | ExitMethods.cs:81:15:81:29 | object creation of type Exception | ExitMethods.cs:81:9:81:30 | throw ...; |
+| pre | ExitMethods.cs:84:17:84:28 | enter ErrorAlways3 | ExitMethods.cs:84:41:84:55 | object creation of type Exception |
+| pre | ExitMethods.cs:84:35:84:55 | throw ... | ExitMethods.cs:84:17:84:28 | exit ErrorAlways3 |
+| pre | ExitMethods.cs:84:41:84:55 | object creation of type Exception | ExitMethods.cs:84:35:84:55 | throw ... |
+| pre | ExitMethods.cs:86:10:86:13 | enter Exit | ExitMethods.cs:87:5:89:5 | {...} |
+| pre | ExitMethods.cs:87:5:89:5 | {...} | ExitMethods.cs:88:9:88:28 | ...; |
+| pre | ExitMethods.cs:88:9:88:27 | call to method Exit | ExitMethods.cs:86:10:86:13 | exit Exit |
+| pre | ExitMethods.cs:88:9:88:28 | ...; | ExitMethods.cs:88:26:88:26 | 0 |
+| pre | ExitMethods.cs:88:26:88:26 | 0 | ExitMethods.cs:88:9:88:27 | call to method Exit |
+| pre | ExitMethods.cs:91:10:91:18 | enter ExitInTry | ExitMethods.cs:92:5:102:5 | {...} |
+| pre | ExitMethods.cs:92:5:102:5 | {...} | ExitMethods.cs:93:9:101:9 | try {...} ... |
+| pre | ExitMethods.cs:93:9:101:9 | try {...} ... | ExitMethods.cs:94:9:96:9 | {...} |
+| pre | ExitMethods.cs:94:9:96:9 | {...} | ExitMethods.cs:95:13:95:19 | ...; |
+| pre | ExitMethods.cs:95:13:95:18 | call to method Exit | ExitMethods.cs:91:10:91:18 | exit ExitInTry |
+| pre | ExitMethods.cs:95:13:95:18 | this access | ExitMethods.cs:95:13:95:18 | call to method Exit |
+| pre | ExitMethods.cs:95:13:95:19 | ...; | ExitMethods.cs:95:13:95:18 | this access |
+| pre | ExitMethods.cs:104:10:104:24 | enter ApplicationExit | ExitMethods.cs:105:5:107:5 | {...} |
+| pre | ExitMethods.cs:105:5:107:5 | {...} | ExitMethods.cs:106:9:106:48 | ...; |
+| pre | ExitMethods.cs:106:9:106:47 | call to method Exit | ExitMethods.cs:104:10:104:24 | exit ApplicationExit |
+| pre | ExitMethods.cs:106:9:106:48 | ...; | ExitMethods.cs:106:9:106:47 | call to method Exit |
+| pre | ExitMethods.cs:109:13:109:21 | enter ThrowExpr | ExitMethods.cs:110:5:112:5 | {...} |
+| pre | ExitMethods.cs:110:5:112:5 | {...} | ExitMethods.cs:111:16:111:76 | ... ? ... : ... |
+| pre | ExitMethods.cs:111:16:111:20 | access to parameter input | ExitMethods.cs:111:25:111:25 | 0 |
+| pre | ExitMethods.cs:111:16:111:25 | ... != ... | ExitMethods.cs:111:29:111:29 | 1 |
+| pre | ExitMethods.cs:111:16:111:25 | ... != ... | ExitMethods.cs:111:69:111:75 | "input" |
+| pre | ExitMethods.cs:111:16:111:76 | ... ? ... : ... | ExitMethods.cs:111:16:111:20 | access to parameter input |
+| pre | ExitMethods.cs:111:25:111:25 | 0 | ExitMethods.cs:111:25:111:25 | (...) ... |
+| pre | ExitMethods.cs:111:25:111:25 | (...) ... | ExitMethods.cs:111:16:111:25 | ... != ... |
+| pre | ExitMethods.cs:111:29:111:29 | 1 | ExitMethods.cs:111:29:111:29 | (...) ... |
+| pre | ExitMethods.cs:111:29:111:29 | (...) ... | ExitMethods.cs:111:33:111:37 | access to parameter input |
+| pre | ExitMethods.cs:111:29:111:37 | ... / ... | ExitMethods.cs:111:9:111:77 | return ...; |
+| pre | ExitMethods.cs:111:33:111:37 | access to parameter input | ExitMethods.cs:111:29:111:37 | ... / ... |
+| pre | ExitMethods.cs:111:47:111:76 | object creation of type ArgumentException | ExitMethods.cs:111:41:111:76 | throw ... |
+| pre | ExitMethods.cs:111:69:111:75 | "input" | ExitMethods.cs:111:47:111:76 | object creation of type ArgumentException |
+| pre | ExitMethods.cs:114:16:114:34 | enter ExtensionMethodCall | ExitMethods.cs:115:5:117:5 | {...} |
+| pre | ExitMethods.cs:115:5:117:5 | {...} | ExitMethods.cs:116:16:116:38 | ... ? ... : ... |
+| pre | ExitMethods.cs:116:9:116:39 | return ...; | ExitMethods.cs:114:16:114:34 | exit ExtensionMethodCall |
+| pre | ExitMethods.cs:116:16:116:16 | access to parameter s | ExitMethods.cs:116:27:116:29 | - |
+| pre | ExitMethods.cs:116:16:116:30 | call to method Contains | ExitMethods.cs:116:34:116:34 | 0 |
+| pre | ExitMethods.cs:116:16:116:30 | call to method Contains | ExitMethods.cs:116:38:116:38 | 1 |
+| pre | ExitMethods.cs:116:16:116:38 | ... ? ... : ... | ExitMethods.cs:116:16:116:16 | access to parameter s |
+| pre | ExitMethods.cs:116:27:116:29 | - | ExitMethods.cs:116:16:116:30 | call to method Contains |
+| pre | ExitMethods.cs:119:17:119:32 | enter FailingAssertion | ExitMethods.cs:120:5:123:5 | {...} |
+| pre | ExitMethods.cs:120:5:123:5 | {...} | ExitMethods.cs:121:9:121:29 | ...; |
+| pre | ExitMethods.cs:121:9:121:28 | call to method IsTrue | ExitMethods.cs:119:17:119:32 | exit FailingAssertion |
+| pre | ExitMethods.cs:121:9:121:29 | ...; | ExitMethods.cs:121:23:121:27 | false |
+| pre | ExitMethods.cs:121:23:121:27 | false | ExitMethods.cs:121:9:121:28 | call to method IsTrue |
+| pre | ExitMethods.cs:125:17:125:33 | enter FailingAssertion2 | ExitMethods.cs:126:5:129:5 | {...} |
+| pre | ExitMethods.cs:126:5:129:5 | {...} | ExitMethods.cs:127:9:127:27 | ...; |
+| pre | ExitMethods.cs:127:9:127:26 | call to method FailingAssertion | ExitMethods.cs:125:17:125:33 | exit FailingAssertion2 |
+| pre | ExitMethods.cs:127:9:127:26 | this access | ExitMethods.cs:127:9:127:26 | call to method FailingAssertion |
+| pre | ExitMethods.cs:127:9:127:27 | ...; | ExitMethods.cs:127:9:127:26 | this access |
+| pre | ExitMethods.cs:131:10:131:20 | enter AssertFalse | ExitMethods.cs:131:48:131:48 | access to parameter b |
+| pre | ExitMethods.cs:131:33:131:49 | call to method IsFalse | ExitMethods.cs:131:10:131:20 | exit AssertFalse |
+| pre | ExitMethods.cs:131:48:131:48 | access to parameter b | ExitMethods.cs:131:33:131:49 | call to method IsFalse |
+| pre | ExitMethods.cs:133:17:133:33 | enter FailingAssertion3 | ExitMethods.cs:134:5:137:5 | {...} |
+| pre | ExitMethods.cs:134:5:137:5 | {...} | ExitMethods.cs:135:9:135:26 | ...; |
+| pre | ExitMethods.cs:135:9:135:25 | call to method AssertFalse | ExitMethods.cs:133:17:133:33 | exit FailingAssertion3 |
+| pre | ExitMethods.cs:135:9:135:25 | this access | ExitMethods.cs:135:21:135:24 | true |
+| pre | ExitMethods.cs:135:9:135:26 | ...; | ExitMethods.cs:135:9:135:25 | this access |
+| pre | ExitMethods.cs:135:21:135:24 | true | ExitMethods.cs:135:9:135:25 | call to method AssertFalse |
 | pre | Extensions.cs:5:23:5:29 | enter ToInt32 | Extensions.cs:6:5:8:5 | {...} |
 | pre | Extensions.cs:6:5:8:5 | {...} | Extensions.cs:7:28:7:28 | access to parameter s |
 | pre | Extensions.cs:7:9:7:30 | return ...; | Extensions.cs:5:23:5:29 | exit ToInt32 |

--- a/csharp/ql/test/library-tests/controlflow/graph/Dominance.expected
+++ b/csharp/ql/test/library-tests/controlflow/graph/Dominance.expected
@@ -735,11 +735,10 @@
 | post | ExitMethods.cs:45:13:45:19 | return ...; | ExitMethods.cs:44:9:46:9 | {...} |
 | post | ExitMethods.cs:48:9:50:9 | {...} | ExitMethods.cs:47:9:50:9 | [exception: Exception] catch (...) {...} |
 | post | ExitMethods.cs:49:13:49:19 | return ...; | ExitMethods.cs:48:9:50:9 | {...} |
-| post | ExitMethods.cs:53:10:53:11 | exit M7 | ExitMethods.cs:56:9:56:15 | return ...; |
+| post | ExitMethods.cs:53:10:53:11 | exit M7 | ExitMethods.cs:55:9:55:22 | call to method ErrorAlways2 |
 | post | ExitMethods.cs:54:5:57:5 | {...} | ExitMethods.cs:53:10:53:11 | enter M7 |
 | post | ExitMethods.cs:55:9:55:22 | call to method ErrorAlways2 | ExitMethods.cs:55:9:55:23 | ...; |
 | post | ExitMethods.cs:55:9:55:23 | ...; | ExitMethods.cs:54:5:57:5 | {...} |
-| post | ExitMethods.cs:56:9:56:15 | return ...; | ExitMethods.cs:55:9:55:22 | call to method ErrorAlways2 |
 | post | ExitMethods.cs:59:10:59:11 | exit M8 | ExitMethods.cs:61:9:61:22 | call to method ErrorAlways3 |
 | post | ExitMethods.cs:60:5:63:5 | {...} | ExitMethods.cs:59:10:59:11 | enter M8 |
 | post | ExitMethods.cs:61:9:61:22 | call to method ErrorAlways3 | ExitMethods.cs:61:9:61:23 | ...; |
@@ -2959,9 +2958,8 @@
 | pre | ExitMethods.cs:48:9:50:9 | {...} | ExitMethods.cs:49:13:49:19 | return ...; |
 | pre | ExitMethods.cs:53:10:53:11 | enter M7 | ExitMethods.cs:54:5:57:5 | {...} |
 | pre | ExitMethods.cs:54:5:57:5 | {...} | ExitMethods.cs:55:9:55:23 | ...; |
-| pre | ExitMethods.cs:55:9:55:22 | call to method ErrorAlways2 | ExitMethods.cs:56:9:56:15 | return ...; |
+| pre | ExitMethods.cs:55:9:55:22 | call to method ErrorAlways2 | ExitMethods.cs:53:10:53:11 | exit M7 |
 | pre | ExitMethods.cs:55:9:55:23 | ...; | ExitMethods.cs:55:9:55:22 | call to method ErrorAlways2 |
-| pre | ExitMethods.cs:56:9:56:15 | return ...; | ExitMethods.cs:53:10:53:11 | exit M7 |
 | pre | ExitMethods.cs:59:10:59:11 | enter M8 | ExitMethods.cs:60:5:63:5 | {...} |
 | pre | ExitMethods.cs:60:5:63:5 | {...} | ExitMethods.cs:61:9:61:23 | ...; |
 | pre | ExitMethods.cs:61:9:61:22 | call to method ErrorAlways3 | ExitMethods.cs:59:10:59:11 | exit M8 |

--- a/csharp/ql/test/library-tests/controlflow/graph/ElementGraph.expected
+++ b/csharp/ql/test/library-tests/controlflow/graph/ElementGraph.expected
@@ -561,59 +561,67 @@
 | ExitMethods.cs:44:9:46:9 | {...} | ExitMethods.cs:45:13:45:19 | return ...; | semmle.label | successor |
 | ExitMethods.cs:47:9:50:9 | catch (...) {...} | ExitMethods.cs:48:9:50:9 | {...} | semmle.label | match |
 | ExitMethods.cs:48:9:50:9 | {...} | ExitMethods.cs:49:13:49:19 | return ...; | semmle.label | successor |
-| ExitMethods.cs:54:5:57:5 | {...} | ExitMethods.cs:55:9:56:34 | if (...) ... | semmle.label | successor |
-| ExitMethods.cs:55:9:56:34 | if (...) ... | ExitMethods.cs:55:13:55:13 | access to parameter b | semmle.label | successor |
-| ExitMethods.cs:55:13:55:13 | access to parameter b | ExitMethods.cs:56:19:56:33 | object creation of type Exception | semmle.label | true |
-| ExitMethods.cs:56:19:56:33 | object creation of type Exception | ExitMethods.cs:56:13:56:34 | throw ...; | semmle.label | successor |
-| ExitMethods.cs:60:5:65:5 | {...} | ExitMethods.cs:61:9:64:45 | if (...) ... | semmle.label | successor |
-| ExitMethods.cs:61:9:64:45 | if (...) ... | ExitMethods.cs:61:13:61:13 | access to parameter b | semmle.label | successor |
-| ExitMethods.cs:61:13:61:13 | access to parameter b | ExitMethods.cs:62:19:62:33 | object creation of type Exception | semmle.label | true |
-| ExitMethods.cs:61:13:61:13 | access to parameter b | ExitMethods.cs:64:41:64:43 | "b" | semmle.label | false |
-| ExitMethods.cs:62:19:62:33 | object creation of type Exception | ExitMethods.cs:62:13:62:34 | throw ...; | semmle.label | successor |
-| ExitMethods.cs:64:19:64:44 | object creation of type ArgumentException | ExitMethods.cs:64:13:64:45 | throw ...; | semmle.label | successor |
-| ExitMethods.cs:64:41:64:43 | "b" | ExitMethods.cs:64:19:64:44 | object creation of type ArgumentException | semmle.label | successor |
-| ExitMethods.cs:68:5:70:5 | {...} | ExitMethods.cs:69:9:69:28 | ...; | semmle.label | successor |
-| ExitMethods.cs:69:9:69:28 | ...; | ExitMethods.cs:69:26:69:26 | 0 | semmle.label | successor |
-| ExitMethods.cs:69:26:69:26 | 0 | ExitMethods.cs:69:9:69:27 | call to method Exit | semmle.label | successor |
-| ExitMethods.cs:73:5:83:5 | {...} | ExitMethods.cs:74:9:82:9 | try {...} ... | semmle.label | successor |
-| ExitMethods.cs:74:9:82:9 | try {...} ... | ExitMethods.cs:75:9:77:9 | {...} | semmle.label | successor |
-| ExitMethods.cs:75:9:77:9 | {...} | ExitMethods.cs:76:13:76:19 | ...; | semmle.label | successor |
-| ExitMethods.cs:76:13:76:18 | this access | ExitMethods.cs:76:13:76:18 | call to method Exit | semmle.label | successor |
-| ExitMethods.cs:76:13:76:19 | ...; | ExitMethods.cs:76:13:76:18 | this access | semmle.label | successor |
-| ExitMethods.cs:86:5:88:5 | {...} | ExitMethods.cs:87:9:87:48 | ...; | semmle.label | successor |
-| ExitMethods.cs:87:9:87:48 | ...; | ExitMethods.cs:87:9:87:47 | call to method Exit | semmle.label | successor |
-| ExitMethods.cs:91:5:93:5 | {...} | ExitMethods.cs:92:16:92:76 | ... ? ... : ... | semmle.label | successor |
-| ExitMethods.cs:92:16:92:20 | access to parameter input | ExitMethods.cs:92:25:92:25 | 0 | semmle.label | successor |
-| ExitMethods.cs:92:16:92:25 | ... != ... | ExitMethods.cs:92:29:92:29 | 1 | semmle.label | true |
-| ExitMethods.cs:92:16:92:25 | ... != ... | ExitMethods.cs:92:69:92:75 | "input" | semmle.label | false |
-| ExitMethods.cs:92:16:92:76 | ... ? ... : ... | ExitMethods.cs:92:16:92:20 | access to parameter input | semmle.label | successor |
-| ExitMethods.cs:92:25:92:25 | 0 | ExitMethods.cs:92:25:92:25 | (...) ... | semmle.label | successor |
-| ExitMethods.cs:92:25:92:25 | (...) ... | ExitMethods.cs:92:16:92:25 | ... != ... | semmle.label | successor |
-| ExitMethods.cs:92:29:92:29 | 1 | ExitMethods.cs:92:29:92:29 | (...) ... | semmle.label | successor |
-| ExitMethods.cs:92:29:92:29 | (...) ... | ExitMethods.cs:92:33:92:37 | access to parameter input | semmle.label | successor |
-| ExitMethods.cs:92:29:92:37 | ... / ... | ExitMethods.cs:92:9:92:77 | return ...; | semmle.label | successor |
-| ExitMethods.cs:92:33:92:37 | access to parameter input | ExitMethods.cs:92:29:92:37 | ... / ... | semmle.label | successor |
-| ExitMethods.cs:92:47:92:76 | object creation of type ArgumentException | ExitMethods.cs:92:41:92:76 | throw ... | semmle.label | successor |
-| ExitMethods.cs:92:69:92:75 | "input" | ExitMethods.cs:92:47:92:76 | object creation of type ArgumentException | semmle.label | successor |
-| ExitMethods.cs:96:5:98:5 | {...} | ExitMethods.cs:97:16:97:38 | ... ? ... : ... | semmle.label | successor |
-| ExitMethods.cs:97:16:97:16 | access to parameter s | ExitMethods.cs:97:27:97:29 | - | semmle.label | successor |
-| ExitMethods.cs:97:16:97:30 | call to method Contains | ExitMethods.cs:97:34:97:34 | 0 | semmle.label | true |
-| ExitMethods.cs:97:16:97:30 | call to method Contains | ExitMethods.cs:97:38:97:38 | 1 | semmle.label | false |
-| ExitMethods.cs:97:16:97:38 | ... ? ... : ... | ExitMethods.cs:97:16:97:16 | access to parameter s | semmle.label | successor |
-| ExitMethods.cs:97:27:97:29 | - | ExitMethods.cs:97:16:97:30 | call to method Contains | semmle.label | successor |
-| ExitMethods.cs:97:34:97:34 | 0 | ExitMethods.cs:97:9:97:39 | return ...; | semmle.label | successor |
-| ExitMethods.cs:97:38:97:38 | 1 | ExitMethods.cs:97:9:97:39 | return ...; | semmle.label | successor |
-| ExitMethods.cs:101:5:104:5 | {...} | ExitMethods.cs:102:9:102:29 | ...; | semmle.label | successor |
-| ExitMethods.cs:102:9:102:29 | ...; | ExitMethods.cs:102:23:102:27 | false | semmle.label | successor |
-| ExitMethods.cs:102:23:102:27 | false | ExitMethods.cs:102:9:102:28 | call to method IsTrue | semmle.label | successor |
-| ExitMethods.cs:107:5:110:5 | {...} | ExitMethods.cs:108:9:108:27 | ...; | semmle.label | successor |
-| ExitMethods.cs:108:9:108:26 | this access | ExitMethods.cs:108:9:108:26 | call to method FailingAssertion | semmle.label | successor |
-| ExitMethods.cs:108:9:108:27 | ...; | ExitMethods.cs:108:9:108:26 | this access | semmle.label | successor |
-| ExitMethods.cs:112:48:112:48 | access to parameter b | ExitMethods.cs:112:33:112:49 | call to method IsFalse | semmle.label | successor |
-| ExitMethods.cs:115:5:118:5 | {...} | ExitMethods.cs:116:9:116:26 | ...; | semmle.label | successor |
-| ExitMethods.cs:116:9:116:25 | this access | ExitMethods.cs:116:21:116:24 | true | semmle.label | successor |
-| ExitMethods.cs:116:9:116:26 | ...; | ExitMethods.cs:116:9:116:25 | this access | semmle.label | successor |
-| ExitMethods.cs:116:21:116:24 | true | ExitMethods.cs:116:9:116:25 | call to method AssertFalse | semmle.label | successor |
+| ExitMethods.cs:54:5:57:5 | {...} | ExitMethods.cs:55:9:55:23 | ...; | semmle.label | successor |
+| ExitMethods.cs:55:9:55:22 | call to method ErrorAlways2 | ExitMethods.cs:56:9:56:15 | return ...; | semmle.label | successor |
+| ExitMethods.cs:55:9:55:23 | ...; | ExitMethods.cs:55:9:55:22 | call to method ErrorAlways2 | semmle.label | successor |
+| ExitMethods.cs:60:5:63:5 | {...} | ExitMethods.cs:61:9:61:23 | ...; | semmle.label | successor |
+| ExitMethods.cs:61:9:61:23 | ...; | ExitMethods.cs:61:9:61:22 | call to method ErrorAlways3 | semmle.label | successor |
+| ExitMethods.cs:66:5:69:5 | {...} | ExitMethods.cs:67:9:68:34 | if (...) ... | semmle.label | successor |
+| ExitMethods.cs:67:9:68:34 | if (...) ... | ExitMethods.cs:67:13:67:13 | access to parameter b | semmle.label | successor |
+| ExitMethods.cs:67:13:67:13 | access to parameter b | ExitMethods.cs:68:19:68:33 | object creation of type Exception | semmle.label | true |
+| ExitMethods.cs:68:19:68:33 | object creation of type Exception | ExitMethods.cs:68:13:68:34 | throw ...; | semmle.label | successor |
+| ExitMethods.cs:72:5:77:5 | {...} | ExitMethods.cs:73:9:76:45 | if (...) ... | semmle.label | successor |
+| ExitMethods.cs:73:9:76:45 | if (...) ... | ExitMethods.cs:73:13:73:13 | access to parameter b | semmle.label | successor |
+| ExitMethods.cs:73:13:73:13 | access to parameter b | ExitMethods.cs:74:19:74:33 | object creation of type Exception | semmle.label | true |
+| ExitMethods.cs:73:13:73:13 | access to parameter b | ExitMethods.cs:76:41:76:43 | "b" | semmle.label | false |
+| ExitMethods.cs:74:19:74:33 | object creation of type Exception | ExitMethods.cs:74:13:74:34 | throw ...; | semmle.label | successor |
+| ExitMethods.cs:76:19:76:44 | object creation of type ArgumentException | ExitMethods.cs:76:13:76:45 | throw ...; | semmle.label | successor |
+| ExitMethods.cs:76:41:76:43 | "b" | ExitMethods.cs:76:19:76:44 | object creation of type ArgumentException | semmle.label | successor |
+| ExitMethods.cs:80:5:82:5 | {...} | ExitMethods.cs:81:15:81:29 | object creation of type Exception | semmle.label | successor |
+| ExitMethods.cs:81:15:81:29 | object creation of type Exception | ExitMethods.cs:81:9:81:30 | throw ...; | semmle.label | successor |
+| ExitMethods.cs:84:41:84:55 | object creation of type Exception | ExitMethods.cs:84:35:84:55 | throw ... | semmle.label | successor |
+| ExitMethods.cs:87:5:89:5 | {...} | ExitMethods.cs:88:9:88:28 | ...; | semmle.label | successor |
+| ExitMethods.cs:88:9:88:28 | ...; | ExitMethods.cs:88:26:88:26 | 0 | semmle.label | successor |
+| ExitMethods.cs:88:26:88:26 | 0 | ExitMethods.cs:88:9:88:27 | call to method Exit | semmle.label | successor |
+| ExitMethods.cs:92:5:102:5 | {...} | ExitMethods.cs:93:9:101:9 | try {...} ... | semmle.label | successor |
+| ExitMethods.cs:93:9:101:9 | try {...} ... | ExitMethods.cs:94:9:96:9 | {...} | semmle.label | successor |
+| ExitMethods.cs:94:9:96:9 | {...} | ExitMethods.cs:95:13:95:19 | ...; | semmle.label | successor |
+| ExitMethods.cs:95:13:95:18 | this access | ExitMethods.cs:95:13:95:18 | call to method Exit | semmle.label | successor |
+| ExitMethods.cs:95:13:95:19 | ...; | ExitMethods.cs:95:13:95:18 | this access | semmle.label | successor |
+| ExitMethods.cs:105:5:107:5 | {...} | ExitMethods.cs:106:9:106:48 | ...; | semmle.label | successor |
+| ExitMethods.cs:106:9:106:48 | ...; | ExitMethods.cs:106:9:106:47 | call to method Exit | semmle.label | successor |
+| ExitMethods.cs:110:5:112:5 | {...} | ExitMethods.cs:111:16:111:76 | ... ? ... : ... | semmle.label | successor |
+| ExitMethods.cs:111:16:111:20 | access to parameter input | ExitMethods.cs:111:25:111:25 | 0 | semmle.label | successor |
+| ExitMethods.cs:111:16:111:25 | ... != ... | ExitMethods.cs:111:29:111:29 | 1 | semmle.label | true |
+| ExitMethods.cs:111:16:111:25 | ... != ... | ExitMethods.cs:111:69:111:75 | "input" | semmle.label | false |
+| ExitMethods.cs:111:16:111:76 | ... ? ... : ... | ExitMethods.cs:111:16:111:20 | access to parameter input | semmle.label | successor |
+| ExitMethods.cs:111:25:111:25 | 0 | ExitMethods.cs:111:25:111:25 | (...) ... | semmle.label | successor |
+| ExitMethods.cs:111:25:111:25 | (...) ... | ExitMethods.cs:111:16:111:25 | ... != ... | semmle.label | successor |
+| ExitMethods.cs:111:29:111:29 | 1 | ExitMethods.cs:111:29:111:29 | (...) ... | semmle.label | successor |
+| ExitMethods.cs:111:29:111:29 | (...) ... | ExitMethods.cs:111:33:111:37 | access to parameter input | semmle.label | successor |
+| ExitMethods.cs:111:29:111:37 | ... / ... | ExitMethods.cs:111:9:111:77 | return ...; | semmle.label | successor |
+| ExitMethods.cs:111:33:111:37 | access to parameter input | ExitMethods.cs:111:29:111:37 | ... / ... | semmle.label | successor |
+| ExitMethods.cs:111:47:111:76 | object creation of type ArgumentException | ExitMethods.cs:111:41:111:76 | throw ... | semmle.label | successor |
+| ExitMethods.cs:111:69:111:75 | "input" | ExitMethods.cs:111:47:111:76 | object creation of type ArgumentException | semmle.label | successor |
+| ExitMethods.cs:115:5:117:5 | {...} | ExitMethods.cs:116:16:116:38 | ... ? ... : ... | semmle.label | successor |
+| ExitMethods.cs:116:16:116:16 | access to parameter s | ExitMethods.cs:116:27:116:29 | - | semmle.label | successor |
+| ExitMethods.cs:116:16:116:30 | call to method Contains | ExitMethods.cs:116:34:116:34 | 0 | semmle.label | true |
+| ExitMethods.cs:116:16:116:30 | call to method Contains | ExitMethods.cs:116:38:116:38 | 1 | semmle.label | false |
+| ExitMethods.cs:116:16:116:38 | ... ? ... : ... | ExitMethods.cs:116:16:116:16 | access to parameter s | semmle.label | successor |
+| ExitMethods.cs:116:27:116:29 | - | ExitMethods.cs:116:16:116:30 | call to method Contains | semmle.label | successor |
+| ExitMethods.cs:116:34:116:34 | 0 | ExitMethods.cs:116:9:116:39 | return ...; | semmle.label | successor |
+| ExitMethods.cs:116:38:116:38 | 1 | ExitMethods.cs:116:9:116:39 | return ...; | semmle.label | successor |
+| ExitMethods.cs:120:5:123:5 | {...} | ExitMethods.cs:121:9:121:29 | ...; | semmle.label | successor |
+| ExitMethods.cs:121:9:121:29 | ...; | ExitMethods.cs:121:23:121:27 | false | semmle.label | successor |
+| ExitMethods.cs:121:23:121:27 | false | ExitMethods.cs:121:9:121:28 | call to method IsTrue | semmle.label | successor |
+| ExitMethods.cs:126:5:129:5 | {...} | ExitMethods.cs:127:9:127:27 | ...; | semmle.label | successor |
+| ExitMethods.cs:127:9:127:26 | this access | ExitMethods.cs:127:9:127:26 | call to method FailingAssertion | semmle.label | successor |
+| ExitMethods.cs:127:9:127:27 | ...; | ExitMethods.cs:127:9:127:26 | this access | semmle.label | successor |
+| ExitMethods.cs:131:48:131:48 | access to parameter b | ExitMethods.cs:131:33:131:49 | call to method IsFalse | semmle.label | successor |
+| ExitMethods.cs:134:5:137:5 | {...} | ExitMethods.cs:135:9:135:26 | ...; | semmle.label | successor |
+| ExitMethods.cs:135:9:135:25 | this access | ExitMethods.cs:135:21:135:24 | true | semmle.label | successor |
+| ExitMethods.cs:135:9:135:26 | ...; | ExitMethods.cs:135:9:135:25 | this access | semmle.label | successor |
+| ExitMethods.cs:135:21:135:24 | true | ExitMethods.cs:135:9:135:25 | call to method AssertFalse | semmle.label | successor |
 | Extensions.cs:6:5:8:5 | {...} | Extensions.cs:7:28:7:28 | access to parameter s | semmle.label | successor |
 | Extensions.cs:7:16:7:29 | call to method Parse | Extensions.cs:7:9:7:30 | return ...; | semmle.label | successor |
 | Extensions.cs:7:28:7:28 | access to parameter s | Extensions.cs:7:16:7:29 | call to method Parse | semmle.label | successor |

--- a/csharp/ql/test/library-tests/controlflow/graph/ElementGraph.expected
+++ b/csharp/ql/test/library-tests/controlflow/graph/ElementGraph.expected
@@ -562,7 +562,6 @@
 | ExitMethods.cs:47:9:50:9 | catch (...) {...} | ExitMethods.cs:48:9:50:9 | {...} | semmle.label | match |
 | ExitMethods.cs:48:9:50:9 | {...} | ExitMethods.cs:49:13:49:19 | return ...; | semmle.label | successor |
 | ExitMethods.cs:54:5:57:5 | {...} | ExitMethods.cs:55:9:55:23 | ...; | semmle.label | successor |
-| ExitMethods.cs:55:9:55:22 | call to method ErrorAlways2 | ExitMethods.cs:56:9:56:15 | return ...; | semmle.label | successor |
 | ExitMethods.cs:55:9:55:23 | ...; | ExitMethods.cs:55:9:55:22 | call to method ErrorAlways2 | semmle.label | successor |
 | ExitMethods.cs:60:5:63:5 | {...} | ExitMethods.cs:61:9:61:23 | ...; | semmle.label | successor |
 | ExitMethods.cs:61:9:61:23 | ...; | ExitMethods.cs:61:9:61:22 | call to method ErrorAlways3 | semmle.label | successor |

--- a/csharp/ql/test/library-tests/controlflow/graph/EntryElement.expected
+++ b/csharp/ql/test/library-tests/controlflow/graph/EntryElement.expected
@@ -570,84 +570,97 @@
 | ExitMethods.cs:48:9:50:9 | {...} | ExitMethods.cs:48:9:50:9 | {...} |
 | ExitMethods.cs:49:13:49:19 | return ...; | ExitMethods.cs:49:13:49:19 | return ...; |
 | ExitMethods.cs:54:5:57:5 | {...} | ExitMethods.cs:54:5:57:5 | {...} |
-| ExitMethods.cs:55:9:56:34 | if (...) ... | ExitMethods.cs:55:9:56:34 | if (...) ... |
-| ExitMethods.cs:55:13:55:13 | access to parameter b | ExitMethods.cs:55:13:55:13 | access to parameter b |
-| ExitMethods.cs:56:13:56:34 | throw ...; | ExitMethods.cs:56:19:56:33 | object creation of type Exception |
-| ExitMethods.cs:56:19:56:33 | object creation of type Exception | ExitMethods.cs:56:19:56:33 | object creation of type Exception |
-| ExitMethods.cs:60:5:65:5 | {...} | ExitMethods.cs:60:5:65:5 | {...} |
-| ExitMethods.cs:61:9:64:45 | if (...) ... | ExitMethods.cs:61:9:64:45 | if (...) ... |
-| ExitMethods.cs:61:13:61:13 | access to parameter b | ExitMethods.cs:61:13:61:13 | access to parameter b |
-| ExitMethods.cs:62:13:62:34 | throw ...; | ExitMethods.cs:62:19:62:33 | object creation of type Exception |
-| ExitMethods.cs:62:19:62:33 | object creation of type Exception | ExitMethods.cs:62:19:62:33 | object creation of type Exception |
-| ExitMethods.cs:64:13:64:45 | throw ...; | ExitMethods.cs:64:41:64:43 | "b" |
-| ExitMethods.cs:64:19:64:44 | object creation of type ArgumentException | ExitMethods.cs:64:41:64:43 | "b" |
-| ExitMethods.cs:64:41:64:43 | "b" | ExitMethods.cs:64:41:64:43 | "b" |
-| ExitMethods.cs:68:5:70:5 | {...} | ExitMethods.cs:68:5:70:5 | {...} |
-| ExitMethods.cs:69:9:69:27 | call to method Exit | ExitMethods.cs:69:26:69:26 | 0 |
-| ExitMethods.cs:69:9:69:28 | ...; | ExitMethods.cs:69:9:69:28 | ...; |
-| ExitMethods.cs:69:26:69:26 | 0 | ExitMethods.cs:69:26:69:26 | 0 |
-| ExitMethods.cs:73:5:83:5 | {...} | ExitMethods.cs:73:5:83:5 | {...} |
-| ExitMethods.cs:74:9:82:9 | try {...} ... | ExitMethods.cs:74:9:82:9 | try {...} ... |
-| ExitMethods.cs:75:9:77:9 | {...} | ExitMethods.cs:75:9:77:9 | {...} |
-| ExitMethods.cs:76:13:76:18 | call to method Exit | ExitMethods.cs:76:13:76:18 | this access |
-| ExitMethods.cs:76:13:76:18 | this access | ExitMethods.cs:76:13:76:18 | this access |
-| ExitMethods.cs:76:13:76:19 | ...; | ExitMethods.cs:76:13:76:19 | ...; |
-| ExitMethods.cs:79:9:82:9 | {...} | ExitMethods.cs:79:9:82:9 | {...} |
-| ExitMethods.cs:81:13:81:40 | call to method WriteLine | ExitMethods.cs:81:38:81:39 | "" |
-| ExitMethods.cs:81:13:81:41 | ...; | ExitMethods.cs:81:13:81:41 | ...; |
-| ExitMethods.cs:81:38:81:39 | "" | ExitMethods.cs:81:38:81:39 | "" |
-| ExitMethods.cs:86:5:88:5 | {...} | ExitMethods.cs:86:5:88:5 | {...} |
-| ExitMethods.cs:87:9:87:47 | call to method Exit | ExitMethods.cs:87:9:87:47 | call to method Exit |
-| ExitMethods.cs:87:9:87:48 | ...; | ExitMethods.cs:87:9:87:48 | ...; |
-| ExitMethods.cs:91:5:93:5 | {...} | ExitMethods.cs:91:5:93:5 | {...} |
-| ExitMethods.cs:92:9:92:77 | return ...; | ExitMethods.cs:92:16:92:76 | ... ? ... : ... |
-| ExitMethods.cs:92:16:92:20 | access to parameter input | ExitMethods.cs:92:16:92:20 | access to parameter input |
-| ExitMethods.cs:92:16:92:25 | ... != ... | ExitMethods.cs:92:16:92:20 | access to parameter input |
-| ExitMethods.cs:92:16:92:76 | ... ? ... : ... | ExitMethods.cs:92:16:92:76 | ... ? ... : ... |
-| ExitMethods.cs:92:25:92:25 | 0 | ExitMethods.cs:92:25:92:25 | 0 |
-| ExitMethods.cs:92:25:92:25 | (...) ... | ExitMethods.cs:92:25:92:25 | 0 |
-| ExitMethods.cs:92:29:92:29 | 1 | ExitMethods.cs:92:29:92:29 | 1 |
-| ExitMethods.cs:92:29:92:29 | (...) ... | ExitMethods.cs:92:29:92:29 | 1 |
-| ExitMethods.cs:92:29:92:37 | ... / ... | ExitMethods.cs:92:29:92:29 | 1 |
-| ExitMethods.cs:92:33:92:37 | access to parameter input | ExitMethods.cs:92:33:92:37 | access to parameter input |
-| ExitMethods.cs:92:41:92:76 | throw ... | ExitMethods.cs:92:69:92:75 | "input" |
-| ExitMethods.cs:92:47:92:76 | object creation of type ArgumentException | ExitMethods.cs:92:69:92:75 | "input" |
-| ExitMethods.cs:92:69:92:75 | "input" | ExitMethods.cs:92:69:92:75 | "input" |
-| ExitMethods.cs:96:5:98:5 | {...} | ExitMethods.cs:96:5:98:5 | {...} |
-| ExitMethods.cs:97:9:97:39 | return ...; | ExitMethods.cs:97:16:97:38 | ... ? ... : ... |
-| ExitMethods.cs:97:16:97:16 | access to parameter s | ExitMethods.cs:97:16:97:16 | access to parameter s |
-| ExitMethods.cs:97:16:97:30 | call to method Contains | ExitMethods.cs:97:16:97:16 | access to parameter s |
-| ExitMethods.cs:97:16:97:38 | ... ? ... : ... | ExitMethods.cs:97:16:97:38 | ... ? ... : ... |
-| ExitMethods.cs:97:27:97:29 | - | ExitMethods.cs:97:27:97:29 | - |
-| ExitMethods.cs:97:34:97:34 | 0 | ExitMethods.cs:97:34:97:34 | 0 |
-| ExitMethods.cs:97:38:97:38 | 1 | ExitMethods.cs:97:38:97:38 | 1 |
-| ExitMethods.cs:101:5:104:5 | {...} | ExitMethods.cs:101:5:104:5 | {...} |
-| ExitMethods.cs:102:9:102:28 | call to method IsTrue | ExitMethods.cs:102:23:102:27 | false |
-| ExitMethods.cs:102:9:102:29 | ...; | ExitMethods.cs:102:9:102:29 | ...; |
-| ExitMethods.cs:102:23:102:27 | false | ExitMethods.cs:102:23:102:27 | false |
-| ExitMethods.cs:103:9:103:18 | ... ...; | ExitMethods.cs:103:9:103:18 | ... ...; |
-| ExitMethods.cs:103:13:103:13 | access to local variable x | ExitMethods.cs:103:13:103:13 | access to local variable x |
-| ExitMethods.cs:103:13:103:17 | Int32 x = ... | ExitMethods.cs:103:13:103:13 | access to local variable x |
-| ExitMethods.cs:103:17:103:17 | 0 | ExitMethods.cs:103:17:103:17 | 0 |
-| ExitMethods.cs:107:5:110:5 | {...} | ExitMethods.cs:107:5:110:5 | {...} |
-| ExitMethods.cs:108:9:108:26 | call to method FailingAssertion | ExitMethods.cs:108:9:108:26 | this access |
-| ExitMethods.cs:108:9:108:26 | this access | ExitMethods.cs:108:9:108:26 | this access |
-| ExitMethods.cs:108:9:108:27 | ...; | ExitMethods.cs:108:9:108:27 | ...; |
-| ExitMethods.cs:109:9:109:18 | ... ...; | ExitMethods.cs:109:9:109:18 | ... ...; |
-| ExitMethods.cs:109:13:109:13 | access to local variable x | ExitMethods.cs:109:13:109:13 | access to local variable x |
-| ExitMethods.cs:109:13:109:17 | Int32 x = ... | ExitMethods.cs:109:13:109:13 | access to local variable x |
-| ExitMethods.cs:109:17:109:17 | 0 | ExitMethods.cs:109:17:109:17 | 0 |
-| ExitMethods.cs:112:33:112:49 | call to method IsFalse | ExitMethods.cs:112:48:112:48 | access to parameter b |
-| ExitMethods.cs:112:48:112:48 | access to parameter b | ExitMethods.cs:112:48:112:48 | access to parameter b |
-| ExitMethods.cs:115:5:118:5 | {...} | ExitMethods.cs:115:5:118:5 | {...} |
-| ExitMethods.cs:116:9:116:25 | call to method AssertFalse | ExitMethods.cs:116:9:116:25 | this access |
-| ExitMethods.cs:116:9:116:25 | this access | ExitMethods.cs:116:9:116:25 | this access |
-| ExitMethods.cs:116:9:116:26 | ...; | ExitMethods.cs:116:9:116:26 | ...; |
-| ExitMethods.cs:116:21:116:24 | true | ExitMethods.cs:116:21:116:24 | true |
-| ExitMethods.cs:117:9:117:18 | ... ...; | ExitMethods.cs:117:9:117:18 | ... ...; |
-| ExitMethods.cs:117:13:117:13 | access to local variable x | ExitMethods.cs:117:13:117:13 | access to local variable x |
-| ExitMethods.cs:117:13:117:17 | Int32 x = ... | ExitMethods.cs:117:13:117:13 | access to local variable x |
-| ExitMethods.cs:117:17:117:17 | 0 | ExitMethods.cs:117:17:117:17 | 0 |
+| ExitMethods.cs:55:9:55:22 | call to method ErrorAlways2 | ExitMethods.cs:55:9:55:22 | call to method ErrorAlways2 |
+| ExitMethods.cs:55:9:55:23 | ...; | ExitMethods.cs:55:9:55:23 | ...; |
+| ExitMethods.cs:56:9:56:15 | return ...; | ExitMethods.cs:56:9:56:15 | return ...; |
+| ExitMethods.cs:60:5:63:5 | {...} | ExitMethods.cs:60:5:63:5 | {...} |
+| ExitMethods.cs:61:9:61:22 | call to method ErrorAlways3 | ExitMethods.cs:61:9:61:22 | call to method ErrorAlways3 |
+| ExitMethods.cs:61:9:61:23 | ...; | ExitMethods.cs:61:9:61:23 | ...; |
+| ExitMethods.cs:62:9:62:15 | return ...; | ExitMethods.cs:62:9:62:15 | return ...; |
+| ExitMethods.cs:66:5:69:5 | {...} | ExitMethods.cs:66:5:69:5 | {...} |
+| ExitMethods.cs:67:9:68:34 | if (...) ... | ExitMethods.cs:67:9:68:34 | if (...) ... |
+| ExitMethods.cs:67:13:67:13 | access to parameter b | ExitMethods.cs:67:13:67:13 | access to parameter b |
+| ExitMethods.cs:68:13:68:34 | throw ...; | ExitMethods.cs:68:19:68:33 | object creation of type Exception |
+| ExitMethods.cs:68:19:68:33 | object creation of type Exception | ExitMethods.cs:68:19:68:33 | object creation of type Exception |
+| ExitMethods.cs:72:5:77:5 | {...} | ExitMethods.cs:72:5:77:5 | {...} |
+| ExitMethods.cs:73:9:76:45 | if (...) ... | ExitMethods.cs:73:9:76:45 | if (...) ... |
+| ExitMethods.cs:73:13:73:13 | access to parameter b | ExitMethods.cs:73:13:73:13 | access to parameter b |
+| ExitMethods.cs:74:13:74:34 | throw ...; | ExitMethods.cs:74:19:74:33 | object creation of type Exception |
+| ExitMethods.cs:74:19:74:33 | object creation of type Exception | ExitMethods.cs:74:19:74:33 | object creation of type Exception |
+| ExitMethods.cs:76:13:76:45 | throw ...; | ExitMethods.cs:76:41:76:43 | "b" |
+| ExitMethods.cs:76:19:76:44 | object creation of type ArgumentException | ExitMethods.cs:76:41:76:43 | "b" |
+| ExitMethods.cs:76:41:76:43 | "b" | ExitMethods.cs:76:41:76:43 | "b" |
+| ExitMethods.cs:80:5:82:5 | {...} | ExitMethods.cs:80:5:82:5 | {...} |
+| ExitMethods.cs:81:9:81:30 | throw ...; | ExitMethods.cs:81:15:81:29 | object creation of type Exception |
+| ExitMethods.cs:81:15:81:29 | object creation of type Exception | ExitMethods.cs:81:15:81:29 | object creation of type Exception |
+| ExitMethods.cs:84:35:84:55 | throw ... | ExitMethods.cs:84:41:84:55 | object creation of type Exception |
+| ExitMethods.cs:84:41:84:55 | object creation of type Exception | ExitMethods.cs:84:41:84:55 | object creation of type Exception |
+| ExitMethods.cs:87:5:89:5 | {...} | ExitMethods.cs:87:5:89:5 | {...} |
+| ExitMethods.cs:88:9:88:27 | call to method Exit | ExitMethods.cs:88:26:88:26 | 0 |
+| ExitMethods.cs:88:9:88:28 | ...; | ExitMethods.cs:88:9:88:28 | ...; |
+| ExitMethods.cs:88:26:88:26 | 0 | ExitMethods.cs:88:26:88:26 | 0 |
+| ExitMethods.cs:92:5:102:5 | {...} | ExitMethods.cs:92:5:102:5 | {...} |
+| ExitMethods.cs:93:9:101:9 | try {...} ... | ExitMethods.cs:93:9:101:9 | try {...} ... |
+| ExitMethods.cs:94:9:96:9 | {...} | ExitMethods.cs:94:9:96:9 | {...} |
+| ExitMethods.cs:95:13:95:18 | call to method Exit | ExitMethods.cs:95:13:95:18 | this access |
+| ExitMethods.cs:95:13:95:18 | this access | ExitMethods.cs:95:13:95:18 | this access |
+| ExitMethods.cs:95:13:95:19 | ...; | ExitMethods.cs:95:13:95:19 | ...; |
+| ExitMethods.cs:98:9:101:9 | {...} | ExitMethods.cs:98:9:101:9 | {...} |
+| ExitMethods.cs:100:13:100:40 | call to method WriteLine | ExitMethods.cs:100:38:100:39 | "" |
+| ExitMethods.cs:100:13:100:41 | ...; | ExitMethods.cs:100:13:100:41 | ...; |
+| ExitMethods.cs:100:38:100:39 | "" | ExitMethods.cs:100:38:100:39 | "" |
+| ExitMethods.cs:105:5:107:5 | {...} | ExitMethods.cs:105:5:107:5 | {...} |
+| ExitMethods.cs:106:9:106:47 | call to method Exit | ExitMethods.cs:106:9:106:47 | call to method Exit |
+| ExitMethods.cs:106:9:106:48 | ...; | ExitMethods.cs:106:9:106:48 | ...; |
+| ExitMethods.cs:110:5:112:5 | {...} | ExitMethods.cs:110:5:112:5 | {...} |
+| ExitMethods.cs:111:9:111:77 | return ...; | ExitMethods.cs:111:16:111:76 | ... ? ... : ... |
+| ExitMethods.cs:111:16:111:20 | access to parameter input | ExitMethods.cs:111:16:111:20 | access to parameter input |
+| ExitMethods.cs:111:16:111:25 | ... != ... | ExitMethods.cs:111:16:111:20 | access to parameter input |
+| ExitMethods.cs:111:16:111:76 | ... ? ... : ... | ExitMethods.cs:111:16:111:76 | ... ? ... : ... |
+| ExitMethods.cs:111:25:111:25 | 0 | ExitMethods.cs:111:25:111:25 | 0 |
+| ExitMethods.cs:111:25:111:25 | (...) ... | ExitMethods.cs:111:25:111:25 | 0 |
+| ExitMethods.cs:111:29:111:29 | 1 | ExitMethods.cs:111:29:111:29 | 1 |
+| ExitMethods.cs:111:29:111:29 | (...) ... | ExitMethods.cs:111:29:111:29 | 1 |
+| ExitMethods.cs:111:29:111:37 | ... / ... | ExitMethods.cs:111:29:111:29 | 1 |
+| ExitMethods.cs:111:33:111:37 | access to parameter input | ExitMethods.cs:111:33:111:37 | access to parameter input |
+| ExitMethods.cs:111:41:111:76 | throw ... | ExitMethods.cs:111:69:111:75 | "input" |
+| ExitMethods.cs:111:47:111:76 | object creation of type ArgumentException | ExitMethods.cs:111:69:111:75 | "input" |
+| ExitMethods.cs:111:69:111:75 | "input" | ExitMethods.cs:111:69:111:75 | "input" |
+| ExitMethods.cs:115:5:117:5 | {...} | ExitMethods.cs:115:5:117:5 | {...} |
+| ExitMethods.cs:116:9:116:39 | return ...; | ExitMethods.cs:116:16:116:38 | ... ? ... : ... |
+| ExitMethods.cs:116:16:116:16 | access to parameter s | ExitMethods.cs:116:16:116:16 | access to parameter s |
+| ExitMethods.cs:116:16:116:30 | call to method Contains | ExitMethods.cs:116:16:116:16 | access to parameter s |
+| ExitMethods.cs:116:16:116:38 | ... ? ... : ... | ExitMethods.cs:116:16:116:38 | ... ? ... : ... |
+| ExitMethods.cs:116:27:116:29 | - | ExitMethods.cs:116:27:116:29 | - |
+| ExitMethods.cs:116:34:116:34 | 0 | ExitMethods.cs:116:34:116:34 | 0 |
+| ExitMethods.cs:116:38:116:38 | 1 | ExitMethods.cs:116:38:116:38 | 1 |
+| ExitMethods.cs:120:5:123:5 | {...} | ExitMethods.cs:120:5:123:5 | {...} |
+| ExitMethods.cs:121:9:121:28 | call to method IsTrue | ExitMethods.cs:121:23:121:27 | false |
+| ExitMethods.cs:121:9:121:29 | ...; | ExitMethods.cs:121:9:121:29 | ...; |
+| ExitMethods.cs:121:23:121:27 | false | ExitMethods.cs:121:23:121:27 | false |
+| ExitMethods.cs:122:9:122:18 | ... ...; | ExitMethods.cs:122:9:122:18 | ... ...; |
+| ExitMethods.cs:122:13:122:13 | access to local variable x | ExitMethods.cs:122:13:122:13 | access to local variable x |
+| ExitMethods.cs:122:13:122:17 | Int32 x = ... | ExitMethods.cs:122:13:122:13 | access to local variable x |
+| ExitMethods.cs:122:17:122:17 | 0 | ExitMethods.cs:122:17:122:17 | 0 |
+| ExitMethods.cs:126:5:129:5 | {...} | ExitMethods.cs:126:5:129:5 | {...} |
+| ExitMethods.cs:127:9:127:26 | call to method FailingAssertion | ExitMethods.cs:127:9:127:26 | this access |
+| ExitMethods.cs:127:9:127:26 | this access | ExitMethods.cs:127:9:127:26 | this access |
+| ExitMethods.cs:127:9:127:27 | ...; | ExitMethods.cs:127:9:127:27 | ...; |
+| ExitMethods.cs:128:9:128:18 | ... ...; | ExitMethods.cs:128:9:128:18 | ... ...; |
+| ExitMethods.cs:128:13:128:13 | access to local variable x | ExitMethods.cs:128:13:128:13 | access to local variable x |
+| ExitMethods.cs:128:13:128:17 | Int32 x = ... | ExitMethods.cs:128:13:128:13 | access to local variable x |
+| ExitMethods.cs:128:17:128:17 | 0 | ExitMethods.cs:128:17:128:17 | 0 |
+| ExitMethods.cs:131:33:131:49 | call to method IsFalse | ExitMethods.cs:131:48:131:48 | access to parameter b |
+| ExitMethods.cs:131:48:131:48 | access to parameter b | ExitMethods.cs:131:48:131:48 | access to parameter b |
+| ExitMethods.cs:134:5:137:5 | {...} | ExitMethods.cs:134:5:137:5 | {...} |
+| ExitMethods.cs:135:9:135:25 | call to method AssertFalse | ExitMethods.cs:135:9:135:25 | this access |
+| ExitMethods.cs:135:9:135:25 | this access | ExitMethods.cs:135:9:135:25 | this access |
+| ExitMethods.cs:135:9:135:26 | ...; | ExitMethods.cs:135:9:135:26 | ...; |
+| ExitMethods.cs:135:21:135:24 | true | ExitMethods.cs:135:21:135:24 | true |
+| ExitMethods.cs:136:9:136:18 | ... ...; | ExitMethods.cs:136:9:136:18 | ... ...; |
+| ExitMethods.cs:136:13:136:13 | access to local variable x | ExitMethods.cs:136:13:136:13 | access to local variable x |
+| ExitMethods.cs:136:13:136:17 | Int32 x = ... | ExitMethods.cs:136:13:136:13 | access to local variable x |
+| ExitMethods.cs:136:17:136:17 | 0 | ExitMethods.cs:136:17:136:17 | 0 |
 | Extensions.cs:6:5:8:5 | {...} | Extensions.cs:6:5:8:5 | {...} |
 | Extensions.cs:7:9:7:30 | return ...; | Extensions.cs:7:28:7:28 | access to parameter s |
 | Extensions.cs:7:16:7:29 | call to method Parse | Extensions.cs:7:28:7:28 | access to parameter s |

--- a/csharp/ql/test/library-tests/controlflow/graph/EntryPoint.expected
+++ b/csharp/ql/test/library-tests/controlflow/graph/EntryPoint.expected
@@ -40,17 +40,21 @@
 | ExitMethods.cs:25:10:25:11 | M4 | ExitMethods.cs:26:5:29:5 | {...} |
 | ExitMethods.cs:31:10:31:11 | M5 | ExitMethods.cs:32:5:35:5 | {...} |
 | ExitMethods.cs:37:10:37:11 | M6 | ExitMethods.cs:38:5:51:5 | {...} |
-| ExitMethods.cs:53:17:53:26 | ErrorMaybe | ExitMethods.cs:54:5:57:5 | {...} |
-| ExitMethods.cs:59:17:59:27 | ErrorAlways | ExitMethods.cs:60:5:65:5 | {...} |
-| ExitMethods.cs:67:10:67:13 | Exit | ExitMethods.cs:68:5:70:5 | {...} |
-| ExitMethods.cs:72:10:72:18 | ExitInTry | ExitMethods.cs:73:5:83:5 | {...} |
-| ExitMethods.cs:85:10:85:24 | ApplicationExit | ExitMethods.cs:86:5:88:5 | {...} |
-| ExitMethods.cs:90:13:90:21 | ThrowExpr | ExitMethods.cs:91:5:93:5 | {...} |
-| ExitMethods.cs:95:16:95:34 | ExtensionMethodCall | ExitMethods.cs:96:5:98:5 | {...} |
-| ExitMethods.cs:100:17:100:32 | FailingAssertion | ExitMethods.cs:101:5:104:5 | {...} |
-| ExitMethods.cs:106:17:106:33 | FailingAssertion2 | ExitMethods.cs:107:5:110:5 | {...} |
-| ExitMethods.cs:112:10:112:20 | AssertFalse | ExitMethods.cs:112:48:112:48 | access to parameter b |
-| ExitMethods.cs:114:17:114:33 | FailingAssertion3 | ExitMethods.cs:115:5:118:5 | {...} |
+| ExitMethods.cs:53:10:53:11 | M7 | ExitMethods.cs:54:5:57:5 | {...} |
+| ExitMethods.cs:59:10:59:11 | M8 | ExitMethods.cs:60:5:63:5 | {...} |
+| ExitMethods.cs:65:17:65:26 | ErrorMaybe | ExitMethods.cs:66:5:69:5 | {...} |
+| ExitMethods.cs:71:17:71:27 | ErrorAlways | ExitMethods.cs:72:5:77:5 | {...} |
+| ExitMethods.cs:79:17:79:28 | ErrorAlways2 | ExitMethods.cs:80:5:82:5 | {...} |
+| ExitMethods.cs:84:17:84:28 | ErrorAlways3 | ExitMethods.cs:84:41:84:55 | object creation of type Exception |
+| ExitMethods.cs:86:10:86:13 | Exit | ExitMethods.cs:87:5:89:5 | {...} |
+| ExitMethods.cs:91:10:91:18 | ExitInTry | ExitMethods.cs:92:5:102:5 | {...} |
+| ExitMethods.cs:104:10:104:24 | ApplicationExit | ExitMethods.cs:105:5:107:5 | {...} |
+| ExitMethods.cs:109:13:109:21 | ThrowExpr | ExitMethods.cs:110:5:112:5 | {...} |
+| ExitMethods.cs:114:16:114:34 | ExtensionMethodCall | ExitMethods.cs:115:5:117:5 | {...} |
+| ExitMethods.cs:119:17:119:32 | FailingAssertion | ExitMethods.cs:120:5:123:5 | {...} |
+| ExitMethods.cs:125:17:125:33 | FailingAssertion2 | ExitMethods.cs:126:5:129:5 | {...} |
+| ExitMethods.cs:131:10:131:20 | AssertFalse | ExitMethods.cs:131:48:131:48 | access to parameter b |
+| ExitMethods.cs:133:17:133:33 | FailingAssertion3 | ExitMethods.cs:134:5:137:5 | {...} |
 | Extensions.cs:5:23:5:29 | ToInt32 | Extensions.cs:6:5:8:5 | {...} |
 | Extensions.cs:10:24:10:29 | ToBool | Extensions.cs:11:5:13:5 | {...} |
 | Extensions.cs:15:23:15:33 | CallToInt32 | Extensions.cs:15:48:15:50 | "0" |

--- a/csharp/ql/test/library-tests/controlflow/graph/ExitElement.expected
+++ b/csharp/ql/test/library-tests/controlflow/graph/ExitElement.expected
@@ -788,102 +788,116 @@
 | ExitMethods.cs:47:9:50:9 | catch (...) {...} | ExitMethods.cs:49:13:49:19 | return ...; | return |
 | ExitMethods.cs:48:9:50:9 | {...} | ExitMethods.cs:49:13:49:19 | return ...; | return |
 | ExitMethods.cs:49:13:49:19 | return ...; | ExitMethods.cs:49:13:49:19 | return ...; | return |
-| ExitMethods.cs:54:5:57:5 | {...} | ExitMethods.cs:55:13:55:13 | access to parameter b | false/false |
-| ExitMethods.cs:54:5:57:5 | {...} | ExitMethods.cs:56:13:56:34 | throw ...; | throw(Exception) |
-| ExitMethods.cs:55:9:56:34 | if (...) ... | ExitMethods.cs:55:13:55:13 | access to parameter b | false/false |
-| ExitMethods.cs:55:9:56:34 | if (...) ... | ExitMethods.cs:56:13:56:34 | throw ...; | throw(Exception) |
-| ExitMethods.cs:55:13:55:13 | access to parameter b | ExitMethods.cs:55:13:55:13 | access to parameter b | false/false |
-| ExitMethods.cs:55:13:55:13 | access to parameter b | ExitMethods.cs:55:13:55:13 | access to parameter b | true/true |
-| ExitMethods.cs:56:13:56:34 | throw ...; | ExitMethods.cs:56:13:56:34 | throw ...; | throw(Exception) |
-| ExitMethods.cs:56:19:56:33 | object creation of type Exception | ExitMethods.cs:56:19:56:33 | object creation of type Exception | normal |
-| ExitMethods.cs:60:5:65:5 | {...} | ExitMethods.cs:62:13:62:34 | throw ...; | throw(Exception) |
-| ExitMethods.cs:60:5:65:5 | {...} | ExitMethods.cs:64:13:64:45 | throw ...; | throw(ArgumentException) |
-| ExitMethods.cs:61:9:64:45 | if (...) ... | ExitMethods.cs:62:13:62:34 | throw ...; | throw(Exception) |
-| ExitMethods.cs:61:9:64:45 | if (...) ... | ExitMethods.cs:64:13:64:45 | throw ...; | throw(ArgumentException) |
-| ExitMethods.cs:61:13:61:13 | access to parameter b | ExitMethods.cs:61:13:61:13 | access to parameter b | false/false |
-| ExitMethods.cs:61:13:61:13 | access to parameter b | ExitMethods.cs:61:13:61:13 | access to parameter b | true/true |
-| ExitMethods.cs:62:13:62:34 | throw ...; | ExitMethods.cs:62:13:62:34 | throw ...; | throw(Exception) |
-| ExitMethods.cs:62:19:62:33 | object creation of type Exception | ExitMethods.cs:62:19:62:33 | object creation of type Exception | normal |
-| ExitMethods.cs:64:13:64:45 | throw ...; | ExitMethods.cs:64:13:64:45 | throw ...; | throw(ArgumentException) |
-| ExitMethods.cs:64:19:64:44 | object creation of type ArgumentException | ExitMethods.cs:64:19:64:44 | object creation of type ArgumentException | normal |
-| ExitMethods.cs:64:41:64:43 | "b" | ExitMethods.cs:64:41:64:43 | "b" | normal |
-| ExitMethods.cs:68:5:70:5 | {...} | ExitMethods.cs:69:9:69:27 | call to method Exit | exit |
-| ExitMethods.cs:69:9:69:27 | call to method Exit | ExitMethods.cs:69:9:69:27 | call to method Exit | exit |
-| ExitMethods.cs:69:9:69:28 | ...; | ExitMethods.cs:69:9:69:27 | call to method Exit | exit |
-| ExitMethods.cs:69:26:69:26 | 0 | ExitMethods.cs:69:26:69:26 | 0 | normal |
-| ExitMethods.cs:73:5:83:5 | {...} | ExitMethods.cs:76:13:76:18 | call to method Exit | exit |
-| ExitMethods.cs:73:5:83:5 | {...} | ExitMethods.cs:81:13:81:40 | call to method WriteLine | exit |
-| ExitMethods.cs:74:9:82:9 | try {...} ... | ExitMethods.cs:76:13:76:18 | call to method Exit | exit |
-| ExitMethods.cs:74:9:82:9 | try {...} ... | ExitMethods.cs:81:13:81:40 | call to method WriteLine | exit |
-| ExitMethods.cs:75:9:77:9 | {...} | ExitMethods.cs:76:13:76:18 | call to method Exit | exit |
-| ExitMethods.cs:76:13:76:18 | call to method Exit | ExitMethods.cs:76:13:76:18 | call to method Exit | exit |
-| ExitMethods.cs:76:13:76:18 | this access | ExitMethods.cs:76:13:76:18 | this access | normal |
-| ExitMethods.cs:76:13:76:19 | ...; | ExitMethods.cs:76:13:76:18 | call to method Exit | exit |
-| ExitMethods.cs:79:9:82:9 | {...} | ExitMethods.cs:81:13:81:40 | call to method WriteLine | normal |
-| ExitMethods.cs:81:13:81:40 | call to method WriteLine | ExitMethods.cs:81:13:81:40 | call to method WriteLine | normal |
-| ExitMethods.cs:81:13:81:41 | ...; | ExitMethods.cs:81:13:81:40 | call to method WriteLine | normal |
-| ExitMethods.cs:81:38:81:39 | "" | ExitMethods.cs:81:38:81:39 | "" | normal |
-| ExitMethods.cs:86:5:88:5 | {...} | ExitMethods.cs:87:9:87:47 | call to method Exit | exit |
-| ExitMethods.cs:87:9:87:47 | call to method Exit | ExitMethods.cs:87:9:87:47 | call to method Exit | exit |
-| ExitMethods.cs:87:9:87:48 | ...; | ExitMethods.cs:87:9:87:47 | call to method Exit | exit |
-| ExitMethods.cs:91:5:93:5 | {...} | ExitMethods.cs:92:9:92:77 | return ...; | return |
-| ExitMethods.cs:91:5:93:5 | {...} | ExitMethods.cs:92:41:92:76 | throw ... | throw(ArgumentException) |
-| ExitMethods.cs:92:9:92:77 | return ...; | ExitMethods.cs:92:9:92:77 | return ...; | return |
-| ExitMethods.cs:92:9:92:77 | return ...; | ExitMethods.cs:92:41:92:76 | throw ... | throw(ArgumentException) |
-| ExitMethods.cs:92:16:92:20 | access to parameter input | ExitMethods.cs:92:16:92:20 | access to parameter input | normal |
-| ExitMethods.cs:92:16:92:25 | ... != ... | ExitMethods.cs:92:16:92:25 | ... != ... | false/false |
-| ExitMethods.cs:92:16:92:25 | ... != ... | ExitMethods.cs:92:16:92:25 | ... != ... | true/true |
-| ExitMethods.cs:92:16:92:76 | ... ? ... : ... | ExitMethods.cs:92:29:92:37 | ... / ... | normal |
-| ExitMethods.cs:92:16:92:76 | ... ? ... : ... | ExitMethods.cs:92:41:92:76 | throw ... | throw(ArgumentException) |
-| ExitMethods.cs:92:25:92:25 | 0 | ExitMethods.cs:92:25:92:25 | 0 | normal |
-| ExitMethods.cs:92:25:92:25 | (...) ... | ExitMethods.cs:92:25:92:25 | (...) ... | normal |
-| ExitMethods.cs:92:29:92:29 | 1 | ExitMethods.cs:92:29:92:29 | 1 | normal |
-| ExitMethods.cs:92:29:92:29 | (...) ... | ExitMethods.cs:92:29:92:29 | (...) ... | normal |
-| ExitMethods.cs:92:29:92:37 | ... / ... | ExitMethods.cs:92:29:92:37 | ... / ... | normal |
-| ExitMethods.cs:92:33:92:37 | access to parameter input | ExitMethods.cs:92:33:92:37 | access to parameter input | normal |
-| ExitMethods.cs:92:41:92:76 | throw ... | ExitMethods.cs:92:41:92:76 | throw ... | throw(ArgumentException) |
-| ExitMethods.cs:92:47:92:76 | object creation of type ArgumentException | ExitMethods.cs:92:47:92:76 | object creation of type ArgumentException | normal |
-| ExitMethods.cs:92:69:92:75 | "input" | ExitMethods.cs:92:69:92:75 | "input" | normal |
-| ExitMethods.cs:96:5:98:5 | {...} | ExitMethods.cs:97:9:97:39 | return ...; | return |
-| ExitMethods.cs:97:9:97:39 | return ...; | ExitMethods.cs:97:9:97:39 | return ...; | return |
-| ExitMethods.cs:97:16:97:16 | access to parameter s | ExitMethods.cs:97:16:97:16 | access to parameter s | normal |
-| ExitMethods.cs:97:16:97:30 | call to method Contains | ExitMethods.cs:97:16:97:30 | call to method Contains | false/false |
-| ExitMethods.cs:97:16:97:30 | call to method Contains | ExitMethods.cs:97:16:97:30 | call to method Contains | true/true |
-| ExitMethods.cs:97:16:97:38 | ... ? ... : ... | ExitMethods.cs:97:34:97:34 | 0 | normal |
-| ExitMethods.cs:97:16:97:38 | ... ? ... : ... | ExitMethods.cs:97:38:97:38 | 1 | normal |
-| ExitMethods.cs:97:27:97:29 | - | ExitMethods.cs:97:27:97:29 | - | normal |
-| ExitMethods.cs:97:34:97:34 | 0 | ExitMethods.cs:97:34:97:34 | 0 | normal |
-| ExitMethods.cs:97:38:97:38 | 1 | ExitMethods.cs:97:38:97:38 | 1 | normal |
-| ExitMethods.cs:101:5:104:5 | {...} | ExitMethods.cs:102:9:102:28 | call to method IsTrue | throw(AssertFailedException) |
-| ExitMethods.cs:101:5:104:5 | {...} | ExitMethods.cs:103:13:103:17 | Int32 x = ... | normal |
-| ExitMethods.cs:102:9:102:28 | call to method IsTrue | ExitMethods.cs:102:9:102:28 | call to method IsTrue | throw(AssertFailedException) |
-| ExitMethods.cs:102:9:102:29 | ...; | ExitMethods.cs:102:9:102:28 | call to method IsTrue | throw(AssertFailedException) |
-| ExitMethods.cs:102:23:102:27 | false | ExitMethods.cs:102:23:102:27 | false | normal |
-| ExitMethods.cs:103:9:103:18 | ... ...; | ExitMethods.cs:103:13:103:17 | Int32 x = ... | normal |
-| ExitMethods.cs:103:13:103:13 | access to local variable x | ExitMethods.cs:103:13:103:13 | access to local variable x | normal |
-| ExitMethods.cs:103:13:103:17 | Int32 x = ... | ExitMethods.cs:103:13:103:17 | Int32 x = ... | normal |
-| ExitMethods.cs:103:17:103:17 | 0 | ExitMethods.cs:103:17:103:17 | 0 | normal |
-| ExitMethods.cs:107:5:110:5 | {...} | ExitMethods.cs:108:9:108:26 | call to method FailingAssertion | throw(AssertFailedException) |
-| ExitMethods.cs:107:5:110:5 | {...} | ExitMethods.cs:109:13:109:17 | Int32 x = ... | normal |
-| ExitMethods.cs:108:9:108:26 | call to method FailingAssertion | ExitMethods.cs:108:9:108:26 | call to method FailingAssertion | throw(AssertFailedException) |
-| ExitMethods.cs:108:9:108:26 | this access | ExitMethods.cs:108:9:108:26 | this access | normal |
-| ExitMethods.cs:108:9:108:27 | ...; | ExitMethods.cs:108:9:108:26 | call to method FailingAssertion | throw(AssertFailedException) |
-| ExitMethods.cs:109:9:109:18 | ... ...; | ExitMethods.cs:109:13:109:17 | Int32 x = ... | normal |
-| ExitMethods.cs:109:13:109:13 | access to local variable x | ExitMethods.cs:109:13:109:13 | access to local variable x | normal |
-| ExitMethods.cs:109:13:109:17 | Int32 x = ... | ExitMethods.cs:109:13:109:17 | Int32 x = ... | normal |
-| ExitMethods.cs:109:17:109:17 | 0 | ExitMethods.cs:109:17:109:17 | 0 | normal |
-| ExitMethods.cs:112:33:112:49 | call to method IsFalse | ExitMethods.cs:112:33:112:49 | call to method IsFalse | normal |
-| ExitMethods.cs:112:48:112:48 | access to parameter b | ExitMethods.cs:112:48:112:48 | access to parameter b | normal |
-| ExitMethods.cs:115:5:118:5 | {...} | ExitMethods.cs:116:9:116:25 | call to method AssertFalse | throw(AssertFailedException) |
-| ExitMethods.cs:115:5:118:5 | {...} | ExitMethods.cs:117:13:117:17 | Int32 x = ... | normal |
-| ExitMethods.cs:116:9:116:25 | call to method AssertFalse | ExitMethods.cs:116:9:116:25 | call to method AssertFalse | throw(AssertFailedException) |
-| ExitMethods.cs:116:9:116:25 | this access | ExitMethods.cs:116:9:116:25 | this access | normal |
-| ExitMethods.cs:116:9:116:26 | ...; | ExitMethods.cs:116:9:116:25 | call to method AssertFalse | throw(AssertFailedException) |
-| ExitMethods.cs:116:21:116:24 | true | ExitMethods.cs:116:21:116:24 | true | normal |
-| ExitMethods.cs:117:9:117:18 | ... ...; | ExitMethods.cs:117:13:117:17 | Int32 x = ... | normal |
-| ExitMethods.cs:117:13:117:13 | access to local variable x | ExitMethods.cs:117:13:117:13 | access to local variable x | normal |
-| ExitMethods.cs:117:13:117:17 | Int32 x = ... | ExitMethods.cs:117:13:117:17 | Int32 x = ... | normal |
-| ExitMethods.cs:117:17:117:17 | 0 | ExitMethods.cs:117:17:117:17 | 0 | normal |
+| ExitMethods.cs:54:5:57:5 | {...} | ExitMethods.cs:56:9:56:15 | return ...; | return |
+| ExitMethods.cs:55:9:55:22 | call to method ErrorAlways2 | ExitMethods.cs:55:9:55:22 | call to method ErrorAlways2 | normal |
+| ExitMethods.cs:55:9:55:23 | ...; | ExitMethods.cs:55:9:55:22 | call to method ErrorAlways2 | normal |
+| ExitMethods.cs:56:9:56:15 | return ...; | ExitMethods.cs:56:9:56:15 | return ...; | return |
+| ExitMethods.cs:60:5:63:5 | {...} | ExitMethods.cs:61:9:61:22 | call to method ErrorAlways3 | throw(Exception) |
+| ExitMethods.cs:60:5:63:5 | {...} | ExitMethods.cs:62:9:62:15 | return ...; | return |
+| ExitMethods.cs:61:9:61:22 | call to method ErrorAlways3 | ExitMethods.cs:61:9:61:22 | call to method ErrorAlways3 | throw(Exception) |
+| ExitMethods.cs:61:9:61:23 | ...; | ExitMethods.cs:61:9:61:22 | call to method ErrorAlways3 | throw(Exception) |
+| ExitMethods.cs:62:9:62:15 | return ...; | ExitMethods.cs:62:9:62:15 | return ...; | return |
+| ExitMethods.cs:66:5:69:5 | {...} | ExitMethods.cs:67:13:67:13 | access to parameter b | false/false |
+| ExitMethods.cs:66:5:69:5 | {...} | ExitMethods.cs:68:13:68:34 | throw ...; | throw(Exception) |
+| ExitMethods.cs:67:9:68:34 | if (...) ... | ExitMethods.cs:67:13:67:13 | access to parameter b | false/false |
+| ExitMethods.cs:67:9:68:34 | if (...) ... | ExitMethods.cs:68:13:68:34 | throw ...; | throw(Exception) |
+| ExitMethods.cs:67:13:67:13 | access to parameter b | ExitMethods.cs:67:13:67:13 | access to parameter b | false/false |
+| ExitMethods.cs:67:13:67:13 | access to parameter b | ExitMethods.cs:67:13:67:13 | access to parameter b | true/true |
+| ExitMethods.cs:68:13:68:34 | throw ...; | ExitMethods.cs:68:13:68:34 | throw ...; | throw(Exception) |
+| ExitMethods.cs:68:19:68:33 | object creation of type Exception | ExitMethods.cs:68:19:68:33 | object creation of type Exception | normal |
+| ExitMethods.cs:72:5:77:5 | {...} | ExitMethods.cs:74:13:74:34 | throw ...; | throw(Exception) |
+| ExitMethods.cs:72:5:77:5 | {...} | ExitMethods.cs:76:13:76:45 | throw ...; | throw(ArgumentException) |
+| ExitMethods.cs:73:9:76:45 | if (...) ... | ExitMethods.cs:74:13:74:34 | throw ...; | throw(Exception) |
+| ExitMethods.cs:73:9:76:45 | if (...) ... | ExitMethods.cs:76:13:76:45 | throw ...; | throw(ArgumentException) |
+| ExitMethods.cs:73:13:73:13 | access to parameter b | ExitMethods.cs:73:13:73:13 | access to parameter b | false/false |
+| ExitMethods.cs:73:13:73:13 | access to parameter b | ExitMethods.cs:73:13:73:13 | access to parameter b | true/true |
+| ExitMethods.cs:74:13:74:34 | throw ...; | ExitMethods.cs:74:13:74:34 | throw ...; | throw(Exception) |
+| ExitMethods.cs:74:19:74:33 | object creation of type Exception | ExitMethods.cs:74:19:74:33 | object creation of type Exception | normal |
+| ExitMethods.cs:76:13:76:45 | throw ...; | ExitMethods.cs:76:13:76:45 | throw ...; | throw(ArgumentException) |
+| ExitMethods.cs:76:19:76:44 | object creation of type ArgumentException | ExitMethods.cs:76:19:76:44 | object creation of type ArgumentException | normal |
+| ExitMethods.cs:76:41:76:43 | "b" | ExitMethods.cs:76:41:76:43 | "b" | normal |
+| ExitMethods.cs:80:5:82:5 | {...} | ExitMethods.cs:81:9:81:30 | throw ...; | throw(Exception) |
+| ExitMethods.cs:81:9:81:30 | throw ...; | ExitMethods.cs:81:9:81:30 | throw ...; | throw(Exception) |
+| ExitMethods.cs:81:15:81:29 | object creation of type Exception | ExitMethods.cs:81:15:81:29 | object creation of type Exception | normal |
+| ExitMethods.cs:84:35:84:55 | throw ... | ExitMethods.cs:84:35:84:55 | throw ... | throw(Exception) |
+| ExitMethods.cs:84:41:84:55 | object creation of type Exception | ExitMethods.cs:84:41:84:55 | object creation of type Exception | normal |
+| ExitMethods.cs:87:5:89:5 | {...} | ExitMethods.cs:88:9:88:27 | call to method Exit | exit |
+| ExitMethods.cs:88:9:88:27 | call to method Exit | ExitMethods.cs:88:9:88:27 | call to method Exit | exit |
+| ExitMethods.cs:88:9:88:28 | ...; | ExitMethods.cs:88:9:88:27 | call to method Exit | exit |
+| ExitMethods.cs:88:26:88:26 | 0 | ExitMethods.cs:88:26:88:26 | 0 | normal |
+| ExitMethods.cs:92:5:102:5 | {...} | ExitMethods.cs:95:13:95:18 | call to method Exit | exit |
+| ExitMethods.cs:92:5:102:5 | {...} | ExitMethods.cs:100:13:100:40 | call to method WriteLine | exit |
+| ExitMethods.cs:93:9:101:9 | try {...} ... | ExitMethods.cs:95:13:95:18 | call to method Exit | exit |
+| ExitMethods.cs:93:9:101:9 | try {...} ... | ExitMethods.cs:100:13:100:40 | call to method WriteLine | exit |
+| ExitMethods.cs:94:9:96:9 | {...} | ExitMethods.cs:95:13:95:18 | call to method Exit | exit |
+| ExitMethods.cs:95:13:95:18 | call to method Exit | ExitMethods.cs:95:13:95:18 | call to method Exit | exit |
+| ExitMethods.cs:95:13:95:18 | this access | ExitMethods.cs:95:13:95:18 | this access | normal |
+| ExitMethods.cs:95:13:95:19 | ...; | ExitMethods.cs:95:13:95:18 | call to method Exit | exit |
+| ExitMethods.cs:98:9:101:9 | {...} | ExitMethods.cs:100:13:100:40 | call to method WriteLine | normal |
+| ExitMethods.cs:100:13:100:40 | call to method WriteLine | ExitMethods.cs:100:13:100:40 | call to method WriteLine | normal |
+| ExitMethods.cs:100:13:100:41 | ...; | ExitMethods.cs:100:13:100:40 | call to method WriteLine | normal |
+| ExitMethods.cs:100:38:100:39 | "" | ExitMethods.cs:100:38:100:39 | "" | normal |
+| ExitMethods.cs:105:5:107:5 | {...} | ExitMethods.cs:106:9:106:47 | call to method Exit | exit |
+| ExitMethods.cs:106:9:106:47 | call to method Exit | ExitMethods.cs:106:9:106:47 | call to method Exit | exit |
+| ExitMethods.cs:106:9:106:48 | ...; | ExitMethods.cs:106:9:106:47 | call to method Exit | exit |
+| ExitMethods.cs:110:5:112:5 | {...} | ExitMethods.cs:111:9:111:77 | return ...; | return |
+| ExitMethods.cs:110:5:112:5 | {...} | ExitMethods.cs:111:41:111:76 | throw ... | throw(ArgumentException) |
+| ExitMethods.cs:111:9:111:77 | return ...; | ExitMethods.cs:111:9:111:77 | return ...; | return |
+| ExitMethods.cs:111:9:111:77 | return ...; | ExitMethods.cs:111:41:111:76 | throw ... | throw(ArgumentException) |
+| ExitMethods.cs:111:16:111:20 | access to parameter input | ExitMethods.cs:111:16:111:20 | access to parameter input | normal |
+| ExitMethods.cs:111:16:111:25 | ... != ... | ExitMethods.cs:111:16:111:25 | ... != ... | false/false |
+| ExitMethods.cs:111:16:111:25 | ... != ... | ExitMethods.cs:111:16:111:25 | ... != ... | true/true |
+| ExitMethods.cs:111:16:111:76 | ... ? ... : ... | ExitMethods.cs:111:29:111:37 | ... / ... | normal |
+| ExitMethods.cs:111:16:111:76 | ... ? ... : ... | ExitMethods.cs:111:41:111:76 | throw ... | throw(ArgumentException) |
+| ExitMethods.cs:111:25:111:25 | 0 | ExitMethods.cs:111:25:111:25 | 0 | normal |
+| ExitMethods.cs:111:25:111:25 | (...) ... | ExitMethods.cs:111:25:111:25 | (...) ... | normal |
+| ExitMethods.cs:111:29:111:29 | 1 | ExitMethods.cs:111:29:111:29 | 1 | normal |
+| ExitMethods.cs:111:29:111:29 | (...) ... | ExitMethods.cs:111:29:111:29 | (...) ... | normal |
+| ExitMethods.cs:111:29:111:37 | ... / ... | ExitMethods.cs:111:29:111:37 | ... / ... | normal |
+| ExitMethods.cs:111:33:111:37 | access to parameter input | ExitMethods.cs:111:33:111:37 | access to parameter input | normal |
+| ExitMethods.cs:111:41:111:76 | throw ... | ExitMethods.cs:111:41:111:76 | throw ... | throw(ArgumentException) |
+| ExitMethods.cs:111:47:111:76 | object creation of type ArgumentException | ExitMethods.cs:111:47:111:76 | object creation of type ArgumentException | normal |
+| ExitMethods.cs:111:69:111:75 | "input" | ExitMethods.cs:111:69:111:75 | "input" | normal |
+| ExitMethods.cs:115:5:117:5 | {...} | ExitMethods.cs:116:9:116:39 | return ...; | return |
+| ExitMethods.cs:116:9:116:39 | return ...; | ExitMethods.cs:116:9:116:39 | return ...; | return |
+| ExitMethods.cs:116:16:116:16 | access to parameter s | ExitMethods.cs:116:16:116:16 | access to parameter s | normal |
+| ExitMethods.cs:116:16:116:30 | call to method Contains | ExitMethods.cs:116:16:116:30 | call to method Contains | false/false |
+| ExitMethods.cs:116:16:116:30 | call to method Contains | ExitMethods.cs:116:16:116:30 | call to method Contains | true/true |
+| ExitMethods.cs:116:16:116:38 | ... ? ... : ... | ExitMethods.cs:116:34:116:34 | 0 | normal |
+| ExitMethods.cs:116:16:116:38 | ... ? ... : ... | ExitMethods.cs:116:38:116:38 | 1 | normal |
+| ExitMethods.cs:116:27:116:29 | - | ExitMethods.cs:116:27:116:29 | - | normal |
+| ExitMethods.cs:116:34:116:34 | 0 | ExitMethods.cs:116:34:116:34 | 0 | normal |
+| ExitMethods.cs:116:38:116:38 | 1 | ExitMethods.cs:116:38:116:38 | 1 | normal |
+| ExitMethods.cs:120:5:123:5 | {...} | ExitMethods.cs:121:9:121:28 | call to method IsTrue | throw(AssertFailedException) |
+| ExitMethods.cs:120:5:123:5 | {...} | ExitMethods.cs:122:13:122:17 | Int32 x = ... | normal |
+| ExitMethods.cs:121:9:121:28 | call to method IsTrue | ExitMethods.cs:121:9:121:28 | call to method IsTrue | throw(AssertFailedException) |
+| ExitMethods.cs:121:9:121:29 | ...; | ExitMethods.cs:121:9:121:28 | call to method IsTrue | throw(AssertFailedException) |
+| ExitMethods.cs:121:23:121:27 | false | ExitMethods.cs:121:23:121:27 | false | normal |
+| ExitMethods.cs:122:9:122:18 | ... ...; | ExitMethods.cs:122:13:122:17 | Int32 x = ... | normal |
+| ExitMethods.cs:122:13:122:13 | access to local variable x | ExitMethods.cs:122:13:122:13 | access to local variable x | normal |
+| ExitMethods.cs:122:13:122:17 | Int32 x = ... | ExitMethods.cs:122:13:122:17 | Int32 x = ... | normal |
+| ExitMethods.cs:122:17:122:17 | 0 | ExitMethods.cs:122:17:122:17 | 0 | normal |
+| ExitMethods.cs:126:5:129:5 | {...} | ExitMethods.cs:127:9:127:26 | call to method FailingAssertion | throw(AssertFailedException) |
+| ExitMethods.cs:126:5:129:5 | {...} | ExitMethods.cs:128:13:128:17 | Int32 x = ... | normal |
+| ExitMethods.cs:127:9:127:26 | call to method FailingAssertion | ExitMethods.cs:127:9:127:26 | call to method FailingAssertion | throw(AssertFailedException) |
+| ExitMethods.cs:127:9:127:26 | this access | ExitMethods.cs:127:9:127:26 | this access | normal |
+| ExitMethods.cs:127:9:127:27 | ...; | ExitMethods.cs:127:9:127:26 | call to method FailingAssertion | throw(AssertFailedException) |
+| ExitMethods.cs:128:9:128:18 | ... ...; | ExitMethods.cs:128:13:128:17 | Int32 x = ... | normal |
+| ExitMethods.cs:128:13:128:13 | access to local variable x | ExitMethods.cs:128:13:128:13 | access to local variable x | normal |
+| ExitMethods.cs:128:13:128:17 | Int32 x = ... | ExitMethods.cs:128:13:128:17 | Int32 x = ... | normal |
+| ExitMethods.cs:128:17:128:17 | 0 | ExitMethods.cs:128:17:128:17 | 0 | normal |
+| ExitMethods.cs:131:33:131:49 | call to method IsFalse | ExitMethods.cs:131:33:131:49 | call to method IsFalse | normal |
+| ExitMethods.cs:131:48:131:48 | access to parameter b | ExitMethods.cs:131:48:131:48 | access to parameter b | normal |
+| ExitMethods.cs:134:5:137:5 | {...} | ExitMethods.cs:135:9:135:25 | call to method AssertFalse | throw(AssertFailedException) |
+| ExitMethods.cs:134:5:137:5 | {...} | ExitMethods.cs:136:13:136:17 | Int32 x = ... | normal |
+| ExitMethods.cs:135:9:135:25 | call to method AssertFalse | ExitMethods.cs:135:9:135:25 | call to method AssertFalse | throw(AssertFailedException) |
+| ExitMethods.cs:135:9:135:25 | this access | ExitMethods.cs:135:9:135:25 | this access | normal |
+| ExitMethods.cs:135:9:135:26 | ...; | ExitMethods.cs:135:9:135:25 | call to method AssertFalse | throw(AssertFailedException) |
+| ExitMethods.cs:135:21:135:24 | true | ExitMethods.cs:135:21:135:24 | true | normal |
+| ExitMethods.cs:136:9:136:18 | ... ...; | ExitMethods.cs:136:13:136:17 | Int32 x = ... | normal |
+| ExitMethods.cs:136:13:136:13 | access to local variable x | ExitMethods.cs:136:13:136:13 | access to local variable x | normal |
+| ExitMethods.cs:136:13:136:17 | Int32 x = ... | ExitMethods.cs:136:13:136:17 | Int32 x = ... | normal |
+| ExitMethods.cs:136:17:136:17 | 0 | ExitMethods.cs:136:17:136:17 | 0 | normal |
 | Extensions.cs:6:5:8:5 | {...} | Extensions.cs:7:9:7:30 | return ...; | return |
 | Extensions.cs:7:9:7:30 | return ...; | Extensions.cs:7:9:7:30 | return ...; | return |
 | Extensions.cs:7:16:7:29 | call to method Parse | Extensions.cs:7:16:7:29 | call to method Parse | normal |

--- a/csharp/ql/test/library-tests/controlflow/graph/ExitElement.expected
+++ b/csharp/ql/test/library-tests/controlflow/graph/ExitElement.expected
@@ -788,9 +788,10 @@
 | ExitMethods.cs:47:9:50:9 | catch (...) {...} | ExitMethods.cs:49:13:49:19 | return ...; | return |
 | ExitMethods.cs:48:9:50:9 | {...} | ExitMethods.cs:49:13:49:19 | return ...; | return |
 | ExitMethods.cs:49:13:49:19 | return ...; | ExitMethods.cs:49:13:49:19 | return ...; | return |
+| ExitMethods.cs:54:5:57:5 | {...} | ExitMethods.cs:55:9:55:22 | call to method ErrorAlways2 | throw(Exception) |
 | ExitMethods.cs:54:5:57:5 | {...} | ExitMethods.cs:56:9:56:15 | return ...; | return |
-| ExitMethods.cs:55:9:55:22 | call to method ErrorAlways2 | ExitMethods.cs:55:9:55:22 | call to method ErrorAlways2 | normal |
-| ExitMethods.cs:55:9:55:23 | ...; | ExitMethods.cs:55:9:55:22 | call to method ErrorAlways2 | normal |
+| ExitMethods.cs:55:9:55:22 | call to method ErrorAlways2 | ExitMethods.cs:55:9:55:22 | call to method ErrorAlways2 | throw(Exception) |
+| ExitMethods.cs:55:9:55:23 | ...; | ExitMethods.cs:55:9:55:22 | call to method ErrorAlways2 | throw(Exception) |
 | ExitMethods.cs:56:9:56:15 | return ...; | ExitMethods.cs:56:9:56:15 | return ...; | return |
 | ExitMethods.cs:60:5:63:5 | {...} | ExitMethods.cs:61:9:61:22 | call to method ErrorAlways3 | throw(Exception) |
 | ExitMethods.cs:60:5:63:5 | {...} | ExitMethods.cs:62:9:62:15 | return ...; | return |

--- a/csharp/ql/test/library-tests/controlflow/graph/ExitMethods.cs
+++ b/csharp/ql/test/library-tests/controlflow/graph/ExitMethods.cs
@@ -50,6 +50,18 @@ class ExitMethods
         }
     }
 
+    void M7()
+    {
+        ErrorAlways2();
+        return; // dead
+    }
+
+    void M8()
+    {
+        ErrorAlways3();
+        return; // dead
+    }
+
     static void ErrorMaybe(bool b)
     {
         if (b)
@@ -63,6 +75,13 @@ class ExitMethods
         else
             throw new ArgumentException("b");
     }
+
+    static void ErrorAlways2()
+    {
+        throw new Exception();
+    }
+
+    static void ErrorAlways3() => throw new Exception();
 
     void Exit()
     {

--- a/csharp/ql/test/library-tests/controlflow/graph/NodeGraph.expected
+++ b/csharp/ql/test/library-tests/controlflow/graph/NodeGraph.expected
@@ -859,9 +859,8 @@
 | ExitMethods.cs:49:13:49:19 | return ...; | ExitMethods.cs:37:10:37:11 | exit M6 | semmle.label | return |
 | ExitMethods.cs:53:10:53:11 | enter M7 | ExitMethods.cs:54:5:57:5 | {...} | semmle.label | successor |
 | ExitMethods.cs:54:5:57:5 | {...} | ExitMethods.cs:55:9:55:23 | ...; | semmle.label | successor |
-| ExitMethods.cs:55:9:55:22 | call to method ErrorAlways2 | ExitMethods.cs:56:9:56:15 | return ...; | semmle.label | successor |
+| ExitMethods.cs:55:9:55:22 | call to method ErrorAlways2 | ExitMethods.cs:53:10:53:11 | exit M7 | semmle.label | exception(Exception) |
 | ExitMethods.cs:55:9:55:23 | ...; | ExitMethods.cs:55:9:55:22 | call to method ErrorAlways2 | semmle.label | successor |
-| ExitMethods.cs:56:9:56:15 | return ...; | ExitMethods.cs:53:10:53:11 | exit M7 | semmle.label | return |
 | ExitMethods.cs:59:10:59:11 | enter M8 | ExitMethods.cs:60:5:63:5 | {...} | semmle.label | successor |
 | ExitMethods.cs:60:5:63:5 | {...} | ExitMethods.cs:61:9:61:23 | ...; | semmle.label | successor |
 | ExitMethods.cs:61:9:61:22 | call to method ErrorAlways3 | ExitMethods.cs:59:10:59:11 | exit M8 | semmle.label | exception(Exception) |

--- a/csharp/ql/test/library-tests/controlflow/graph/NodeGraph.expected
+++ b/csharp/ql/test/library-tests/controlflow/graph/NodeGraph.expected
@@ -857,84 +857,100 @@
 | ExitMethods.cs:47:9:50:9 | [exception: Exception] catch (...) {...} | ExitMethods.cs:48:9:50:9 | {...} | semmle.label | match |
 | ExitMethods.cs:48:9:50:9 | {...} | ExitMethods.cs:49:13:49:19 | return ...; | semmle.label | successor |
 | ExitMethods.cs:49:13:49:19 | return ...; | ExitMethods.cs:37:10:37:11 | exit M6 | semmle.label | return |
-| ExitMethods.cs:53:17:53:26 | enter ErrorMaybe | ExitMethods.cs:54:5:57:5 | {...} | semmle.label | successor |
-| ExitMethods.cs:54:5:57:5 | {...} | ExitMethods.cs:55:9:56:34 | if (...) ... | semmle.label | successor |
-| ExitMethods.cs:55:9:56:34 | if (...) ... | ExitMethods.cs:55:13:55:13 | access to parameter b | semmle.label | successor |
-| ExitMethods.cs:55:13:55:13 | access to parameter b | ExitMethods.cs:53:17:53:26 | exit ErrorMaybe | semmle.label | false |
-| ExitMethods.cs:55:13:55:13 | access to parameter b | ExitMethods.cs:56:19:56:33 | object creation of type Exception | semmle.label | true |
-| ExitMethods.cs:56:13:56:34 | throw ...; | ExitMethods.cs:53:17:53:26 | exit ErrorMaybe | semmle.label | exception(Exception) |
-| ExitMethods.cs:56:19:56:33 | object creation of type Exception | ExitMethods.cs:56:13:56:34 | throw ...; | semmle.label | successor |
-| ExitMethods.cs:59:17:59:27 | enter ErrorAlways | ExitMethods.cs:60:5:65:5 | {...} | semmle.label | successor |
-| ExitMethods.cs:60:5:65:5 | {...} | ExitMethods.cs:61:9:64:45 | if (...) ... | semmle.label | successor |
-| ExitMethods.cs:61:9:64:45 | if (...) ... | ExitMethods.cs:61:13:61:13 | access to parameter b | semmle.label | successor |
-| ExitMethods.cs:61:13:61:13 | access to parameter b | ExitMethods.cs:62:19:62:33 | object creation of type Exception | semmle.label | true |
-| ExitMethods.cs:61:13:61:13 | access to parameter b | ExitMethods.cs:64:41:64:43 | "b" | semmle.label | false |
-| ExitMethods.cs:62:13:62:34 | throw ...; | ExitMethods.cs:59:17:59:27 | exit ErrorAlways | semmle.label | exception(Exception) |
-| ExitMethods.cs:62:19:62:33 | object creation of type Exception | ExitMethods.cs:62:13:62:34 | throw ...; | semmle.label | successor |
-| ExitMethods.cs:64:13:64:45 | throw ...; | ExitMethods.cs:59:17:59:27 | exit ErrorAlways | semmle.label | exception(ArgumentException) |
-| ExitMethods.cs:64:19:64:44 | object creation of type ArgumentException | ExitMethods.cs:64:13:64:45 | throw ...; | semmle.label | successor |
-| ExitMethods.cs:64:41:64:43 | "b" | ExitMethods.cs:64:19:64:44 | object creation of type ArgumentException | semmle.label | successor |
-| ExitMethods.cs:67:10:67:13 | enter Exit | ExitMethods.cs:68:5:70:5 | {...} | semmle.label | successor |
-| ExitMethods.cs:68:5:70:5 | {...} | ExitMethods.cs:69:9:69:28 | ...; | semmle.label | successor |
-| ExitMethods.cs:69:9:69:27 | call to method Exit | ExitMethods.cs:67:10:67:13 | exit Exit | semmle.label | exit |
-| ExitMethods.cs:69:9:69:28 | ...; | ExitMethods.cs:69:26:69:26 | 0 | semmle.label | successor |
-| ExitMethods.cs:69:26:69:26 | 0 | ExitMethods.cs:69:9:69:27 | call to method Exit | semmle.label | successor |
-| ExitMethods.cs:72:10:72:18 | enter ExitInTry | ExitMethods.cs:73:5:83:5 | {...} | semmle.label | successor |
-| ExitMethods.cs:73:5:83:5 | {...} | ExitMethods.cs:74:9:82:9 | try {...} ... | semmle.label | successor |
-| ExitMethods.cs:74:9:82:9 | try {...} ... | ExitMethods.cs:75:9:77:9 | {...} | semmle.label | successor |
-| ExitMethods.cs:75:9:77:9 | {...} | ExitMethods.cs:76:13:76:19 | ...; | semmle.label | successor |
-| ExitMethods.cs:76:13:76:18 | call to method Exit | ExitMethods.cs:72:10:72:18 | exit ExitInTry | semmle.label | exit |
-| ExitMethods.cs:76:13:76:18 | this access | ExitMethods.cs:76:13:76:18 | call to method Exit | semmle.label | successor |
-| ExitMethods.cs:76:13:76:19 | ...; | ExitMethods.cs:76:13:76:18 | this access | semmle.label | successor |
-| ExitMethods.cs:85:10:85:24 | enter ApplicationExit | ExitMethods.cs:86:5:88:5 | {...} | semmle.label | successor |
-| ExitMethods.cs:86:5:88:5 | {...} | ExitMethods.cs:87:9:87:48 | ...; | semmle.label | successor |
-| ExitMethods.cs:87:9:87:47 | call to method Exit | ExitMethods.cs:85:10:85:24 | exit ApplicationExit | semmle.label | exit |
-| ExitMethods.cs:87:9:87:48 | ...; | ExitMethods.cs:87:9:87:47 | call to method Exit | semmle.label | successor |
-| ExitMethods.cs:90:13:90:21 | enter ThrowExpr | ExitMethods.cs:91:5:93:5 | {...} | semmle.label | successor |
-| ExitMethods.cs:91:5:93:5 | {...} | ExitMethods.cs:92:16:92:76 | ... ? ... : ... | semmle.label | successor |
-| ExitMethods.cs:92:9:92:77 | return ...; | ExitMethods.cs:90:13:90:21 | exit ThrowExpr | semmle.label | return |
-| ExitMethods.cs:92:16:92:20 | access to parameter input | ExitMethods.cs:92:25:92:25 | 0 | semmle.label | successor |
-| ExitMethods.cs:92:16:92:25 | ... != ... | ExitMethods.cs:92:29:92:29 | 1 | semmle.label | true |
-| ExitMethods.cs:92:16:92:25 | ... != ... | ExitMethods.cs:92:69:92:75 | "input" | semmle.label | false |
-| ExitMethods.cs:92:16:92:76 | ... ? ... : ... | ExitMethods.cs:92:16:92:20 | access to parameter input | semmle.label | successor |
-| ExitMethods.cs:92:25:92:25 | 0 | ExitMethods.cs:92:25:92:25 | (...) ... | semmle.label | successor |
-| ExitMethods.cs:92:25:92:25 | (...) ... | ExitMethods.cs:92:16:92:25 | ... != ... | semmle.label | successor |
-| ExitMethods.cs:92:29:92:29 | 1 | ExitMethods.cs:92:29:92:29 | (...) ... | semmle.label | successor |
-| ExitMethods.cs:92:29:92:29 | (...) ... | ExitMethods.cs:92:33:92:37 | access to parameter input | semmle.label | successor |
-| ExitMethods.cs:92:29:92:37 | ... / ... | ExitMethods.cs:92:9:92:77 | return ...; | semmle.label | successor |
-| ExitMethods.cs:92:33:92:37 | access to parameter input | ExitMethods.cs:92:29:92:37 | ... / ... | semmle.label | successor |
-| ExitMethods.cs:92:41:92:76 | throw ... | ExitMethods.cs:90:13:90:21 | exit ThrowExpr | semmle.label | exception(ArgumentException) |
-| ExitMethods.cs:92:47:92:76 | object creation of type ArgumentException | ExitMethods.cs:92:41:92:76 | throw ... | semmle.label | successor |
-| ExitMethods.cs:92:69:92:75 | "input" | ExitMethods.cs:92:47:92:76 | object creation of type ArgumentException | semmle.label | successor |
-| ExitMethods.cs:95:16:95:34 | enter ExtensionMethodCall | ExitMethods.cs:96:5:98:5 | {...} | semmle.label | successor |
-| ExitMethods.cs:96:5:98:5 | {...} | ExitMethods.cs:97:16:97:38 | ... ? ... : ... | semmle.label | successor |
-| ExitMethods.cs:97:9:97:39 | return ...; | ExitMethods.cs:95:16:95:34 | exit ExtensionMethodCall | semmle.label | return |
-| ExitMethods.cs:97:16:97:16 | access to parameter s | ExitMethods.cs:97:27:97:29 | - | semmle.label | successor |
-| ExitMethods.cs:97:16:97:30 | call to method Contains | ExitMethods.cs:97:34:97:34 | 0 | semmle.label | true |
-| ExitMethods.cs:97:16:97:30 | call to method Contains | ExitMethods.cs:97:38:97:38 | 1 | semmle.label | false |
-| ExitMethods.cs:97:16:97:38 | ... ? ... : ... | ExitMethods.cs:97:16:97:16 | access to parameter s | semmle.label | successor |
-| ExitMethods.cs:97:27:97:29 | - | ExitMethods.cs:97:16:97:30 | call to method Contains | semmle.label | successor |
-| ExitMethods.cs:97:34:97:34 | 0 | ExitMethods.cs:97:9:97:39 | return ...; | semmle.label | successor |
-| ExitMethods.cs:97:38:97:38 | 1 | ExitMethods.cs:97:9:97:39 | return ...; | semmle.label | successor |
-| ExitMethods.cs:100:17:100:32 | enter FailingAssertion | ExitMethods.cs:101:5:104:5 | {...} | semmle.label | successor |
-| ExitMethods.cs:101:5:104:5 | {...} | ExitMethods.cs:102:9:102:29 | ...; | semmle.label | successor |
-| ExitMethods.cs:102:9:102:28 | call to method IsTrue | ExitMethods.cs:100:17:100:32 | exit FailingAssertion | semmle.label | exception(AssertFailedException) |
-| ExitMethods.cs:102:9:102:29 | ...; | ExitMethods.cs:102:23:102:27 | false | semmle.label | successor |
-| ExitMethods.cs:102:23:102:27 | false | ExitMethods.cs:102:9:102:28 | call to method IsTrue | semmle.label | successor |
-| ExitMethods.cs:106:17:106:33 | enter FailingAssertion2 | ExitMethods.cs:107:5:110:5 | {...} | semmle.label | successor |
-| ExitMethods.cs:107:5:110:5 | {...} | ExitMethods.cs:108:9:108:27 | ...; | semmle.label | successor |
-| ExitMethods.cs:108:9:108:26 | call to method FailingAssertion | ExitMethods.cs:106:17:106:33 | exit FailingAssertion2 | semmle.label | exception(AssertFailedException) |
-| ExitMethods.cs:108:9:108:26 | this access | ExitMethods.cs:108:9:108:26 | call to method FailingAssertion | semmle.label | successor |
-| ExitMethods.cs:108:9:108:27 | ...; | ExitMethods.cs:108:9:108:26 | this access | semmle.label | successor |
-| ExitMethods.cs:112:10:112:20 | enter AssertFalse | ExitMethods.cs:112:48:112:48 | access to parameter b | semmle.label | successor |
-| ExitMethods.cs:112:33:112:49 | call to method IsFalse | ExitMethods.cs:112:10:112:20 | exit AssertFalse | semmle.label | successor |
-| ExitMethods.cs:112:48:112:48 | access to parameter b | ExitMethods.cs:112:33:112:49 | call to method IsFalse | semmle.label | successor |
-| ExitMethods.cs:114:17:114:33 | enter FailingAssertion3 | ExitMethods.cs:115:5:118:5 | {...} | semmle.label | successor |
-| ExitMethods.cs:115:5:118:5 | {...} | ExitMethods.cs:116:9:116:26 | ...; | semmle.label | successor |
-| ExitMethods.cs:116:9:116:25 | call to method AssertFalse | ExitMethods.cs:114:17:114:33 | exit FailingAssertion3 | semmle.label | exception(AssertFailedException) |
-| ExitMethods.cs:116:9:116:25 | this access | ExitMethods.cs:116:21:116:24 | true | semmle.label | successor |
-| ExitMethods.cs:116:9:116:26 | ...; | ExitMethods.cs:116:9:116:25 | this access | semmle.label | successor |
-| ExitMethods.cs:116:21:116:24 | true | ExitMethods.cs:116:9:116:25 | call to method AssertFalse | semmle.label | successor |
+| ExitMethods.cs:53:10:53:11 | enter M7 | ExitMethods.cs:54:5:57:5 | {...} | semmle.label | successor |
+| ExitMethods.cs:54:5:57:5 | {...} | ExitMethods.cs:55:9:55:23 | ...; | semmle.label | successor |
+| ExitMethods.cs:55:9:55:22 | call to method ErrorAlways2 | ExitMethods.cs:56:9:56:15 | return ...; | semmle.label | successor |
+| ExitMethods.cs:55:9:55:23 | ...; | ExitMethods.cs:55:9:55:22 | call to method ErrorAlways2 | semmle.label | successor |
+| ExitMethods.cs:56:9:56:15 | return ...; | ExitMethods.cs:53:10:53:11 | exit M7 | semmle.label | return |
+| ExitMethods.cs:59:10:59:11 | enter M8 | ExitMethods.cs:60:5:63:5 | {...} | semmle.label | successor |
+| ExitMethods.cs:60:5:63:5 | {...} | ExitMethods.cs:61:9:61:23 | ...; | semmle.label | successor |
+| ExitMethods.cs:61:9:61:22 | call to method ErrorAlways3 | ExitMethods.cs:59:10:59:11 | exit M8 | semmle.label | exception(Exception) |
+| ExitMethods.cs:61:9:61:23 | ...; | ExitMethods.cs:61:9:61:22 | call to method ErrorAlways3 | semmle.label | successor |
+| ExitMethods.cs:65:17:65:26 | enter ErrorMaybe | ExitMethods.cs:66:5:69:5 | {...} | semmle.label | successor |
+| ExitMethods.cs:66:5:69:5 | {...} | ExitMethods.cs:67:9:68:34 | if (...) ... | semmle.label | successor |
+| ExitMethods.cs:67:9:68:34 | if (...) ... | ExitMethods.cs:67:13:67:13 | access to parameter b | semmle.label | successor |
+| ExitMethods.cs:67:13:67:13 | access to parameter b | ExitMethods.cs:65:17:65:26 | exit ErrorMaybe | semmle.label | false |
+| ExitMethods.cs:67:13:67:13 | access to parameter b | ExitMethods.cs:68:19:68:33 | object creation of type Exception | semmle.label | true |
+| ExitMethods.cs:68:13:68:34 | throw ...; | ExitMethods.cs:65:17:65:26 | exit ErrorMaybe | semmle.label | exception(Exception) |
+| ExitMethods.cs:68:19:68:33 | object creation of type Exception | ExitMethods.cs:68:13:68:34 | throw ...; | semmle.label | successor |
+| ExitMethods.cs:71:17:71:27 | enter ErrorAlways | ExitMethods.cs:72:5:77:5 | {...} | semmle.label | successor |
+| ExitMethods.cs:72:5:77:5 | {...} | ExitMethods.cs:73:9:76:45 | if (...) ... | semmle.label | successor |
+| ExitMethods.cs:73:9:76:45 | if (...) ... | ExitMethods.cs:73:13:73:13 | access to parameter b | semmle.label | successor |
+| ExitMethods.cs:73:13:73:13 | access to parameter b | ExitMethods.cs:74:19:74:33 | object creation of type Exception | semmle.label | true |
+| ExitMethods.cs:73:13:73:13 | access to parameter b | ExitMethods.cs:76:41:76:43 | "b" | semmle.label | false |
+| ExitMethods.cs:74:13:74:34 | throw ...; | ExitMethods.cs:71:17:71:27 | exit ErrorAlways | semmle.label | exception(Exception) |
+| ExitMethods.cs:74:19:74:33 | object creation of type Exception | ExitMethods.cs:74:13:74:34 | throw ...; | semmle.label | successor |
+| ExitMethods.cs:76:13:76:45 | throw ...; | ExitMethods.cs:71:17:71:27 | exit ErrorAlways | semmle.label | exception(ArgumentException) |
+| ExitMethods.cs:76:19:76:44 | object creation of type ArgumentException | ExitMethods.cs:76:13:76:45 | throw ...; | semmle.label | successor |
+| ExitMethods.cs:76:41:76:43 | "b" | ExitMethods.cs:76:19:76:44 | object creation of type ArgumentException | semmle.label | successor |
+| ExitMethods.cs:79:17:79:28 | enter ErrorAlways2 | ExitMethods.cs:80:5:82:5 | {...} | semmle.label | successor |
+| ExitMethods.cs:80:5:82:5 | {...} | ExitMethods.cs:81:15:81:29 | object creation of type Exception | semmle.label | successor |
+| ExitMethods.cs:81:9:81:30 | throw ...; | ExitMethods.cs:79:17:79:28 | exit ErrorAlways2 | semmle.label | exception(Exception) |
+| ExitMethods.cs:81:15:81:29 | object creation of type Exception | ExitMethods.cs:81:9:81:30 | throw ...; | semmle.label | successor |
+| ExitMethods.cs:84:17:84:28 | enter ErrorAlways3 | ExitMethods.cs:84:41:84:55 | object creation of type Exception | semmle.label | successor |
+| ExitMethods.cs:84:35:84:55 | throw ... | ExitMethods.cs:84:17:84:28 | exit ErrorAlways3 | semmle.label | exception(Exception) |
+| ExitMethods.cs:84:41:84:55 | object creation of type Exception | ExitMethods.cs:84:35:84:55 | throw ... | semmle.label | successor |
+| ExitMethods.cs:86:10:86:13 | enter Exit | ExitMethods.cs:87:5:89:5 | {...} | semmle.label | successor |
+| ExitMethods.cs:87:5:89:5 | {...} | ExitMethods.cs:88:9:88:28 | ...; | semmle.label | successor |
+| ExitMethods.cs:88:9:88:27 | call to method Exit | ExitMethods.cs:86:10:86:13 | exit Exit | semmle.label | exit |
+| ExitMethods.cs:88:9:88:28 | ...; | ExitMethods.cs:88:26:88:26 | 0 | semmle.label | successor |
+| ExitMethods.cs:88:26:88:26 | 0 | ExitMethods.cs:88:9:88:27 | call to method Exit | semmle.label | successor |
+| ExitMethods.cs:91:10:91:18 | enter ExitInTry | ExitMethods.cs:92:5:102:5 | {...} | semmle.label | successor |
+| ExitMethods.cs:92:5:102:5 | {...} | ExitMethods.cs:93:9:101:9 | try {...} ... | semmle.label | successor |
+| ExitMethods.cs:93:9:101:9 | try {...} ... | ExitMethods.cs:94:9:96:9 | {...} | semmle.label | successor |
+| ExitMethods.cs:94:9:96:9 | {...} | ExitMethods.cs:95:13:95:19 | ...; | semmle.label | successor |
+| ExitMethods.cs:95:13:95:18 | call to method Exit | ExitMethods.cs:91:10:91:18 | exit ExitInTry | semmle.label | exit |
+| ExitMethods.cs:95:13:95:18 | this access | ExitMethods.cs:95:13:95:18 | call to method Exit | semmle.label | successor |
+| ExitMethods.cs:95:13:95:19 | ...; | ExitMethods.cs:95:13:95:18 | this access | semmle.label | successor |
+| ExitMethods.cs:104:10:104:24 | enter ApplicationExit | ExitMethods.cs:105:5:107:5 | {...} | semmle.label | successor |
+| ExitMethods.cs:105:5:107:5 | {...} | ExitMethods.cs:106:9:106:48 | ...; | semmle.label | successor |
+| ExitMethods.cs:106:9:106:47 | call to method Exit | ExitMethods.cs:104:10:104:24 | exit ApplicationExit | semmle.label | exit |
+| ExitMethods.cs:106:9:106:48 | ...; | ExitMethods.cs:106:9:106:47 | call to method Exit | semmle.label | successor |
+| ExitMethods.cs:109:13:109:21 | enter ThrowExpr | ExitMethods.cs:110:5:112:5 | {...} | semmle.label | successor |
+| ExitMethods.cs:110:5:112:5 | {...} | ExitMethods.cs:111:16:111:76 | ... ? ... : ... | semmle.label | successor |
+| ExitMethods.cs:111:9:111:77 | return ...; | ExitMethods.cs:109:13:109:21 | exit ThrowExpr | semmle.label | return |
+| ExitMethods.cs:111:16:111:20 | access to parameter input | ExitMethods.cs:111:25:111:25 | 0 | semmle.label | successor |
+| ExitMethods.cs:111:16:111:25 | ... != ... | ExitMethods.cs:111:29:111:29 | 1 | semmle.label | true |
+| ExitMethods.cs:111:16:111:25 | ... != ... | ExitMethods.cs:111:69:111:75 | "input" | semmle.label | false |
+| ExitMethods.cs:111:16:111:76 | ... ? ... : ... | ExitMethods.cs:111:16:111:20 | access to parameter input | semmle.label | successor |
+| ExitMethods.cs:111:25:111:25 | 0 | ExitMethods.cs:111:25:111:25 | (...) ... | semmle.label | successor |
+| ExitMethods.cs:111:25:111:25 | (...) ... | ExitMethods.cs:111:16:111:25 | ... != ... | semmle.label | successor |
+| ExitMethods.cs:111:29:111:29 | 1 | ExitMethods.cs:111:29:111:29 | (...) ... | semmle.label | successor |
+| ExitMethods.cs:111:29:111:29 | (...) ... | ExitMethods.cs:111:33:111:37 | access to parameter input | semmle.label | successor |
+| ExitMethods.cs:111:29:111:37 | ... / ... | ExitMethods.cs:111:9:111:77 | return ...; | semmle.label | successor |
+| ExitMethods.cs:111:33:111:37 | access to parameter input | ExitMethods.cs:111:29:111:37 | ... / ... | semmle.label | successor |
+| ExitMethods.cs:111:41:111:76 | throw ... | ExitMethods.cs:109:13:109:21 | exit ThrowExpr | semmle.label | exception(ArgumentException) |
+| ExitMethods.cs:111:47:111:76 | object creation of type ArgumentException | ExitMethods.cs:111:41:111:76 | throw ... | semmle.label | successor |
+| ExitMethods.cs:111:69:111:75 | "input" | ExitMethods.cs:111:47:111:76 | object creation of type ArgumentException | semmle.label | successor |
+| ExitMethods.cs:114:16:114:34 | enter ExtensionMethodCall | ExitMethods.cs:115:5:117:5 | {...} | semmle.label | successor |
+| ExitMethods.cs:115:5:117:5 | {...} | ExitMethods.cs:116:16:116:38 | ... ? ... : ... | semmle.label | successor |
+| ExitMethods.cs:116:9:116:39 | return ...; | ExitMethods.cs:114:16:114:34 | exit ExtensionMethodCall | semmle.label | return |
+| ExitMethods.cs:116:16:116:16 | access to parameter s | ExitMethods.cs:116:27:116:29 | - | semmle.label | successor |
+| ExitMethods.cs:116:16:116:30 | call to method Contains | ExitMethods.cs:116:34:116:34 | 0 | semmle.label | true |
+| ExitMethods.cs:116:16:116:30 | call to method Contains | ExitMethods.cs:116:38:116:38 | 1 | semmle.label | false |
+| ExitMethods.cs:116:16:116:38 | ... ? ... : ... | ExitMethods.cs:116:16:116:16 | access to parameter s | semmle.label | successor |
+| ExitMethods.cs:116:27:116:29 | - | ExitMethods.cs:116:16:116:30 | call to method Contains | semmle.label | successor |
+| ExitMethods.cs:116:34:116:34 | 0 | ExitMethods.cs:116:9:116:39 | return ...; | semmle.label | successor |
+| ExitMethods.cs:116:38:116:38 | 1 | ExitMethods.cs:116:9:116:39 | return ...; | semmle.label | successor |
+| ExitMethods.cs:119:17:119:32 | enter FailingAssertion | ExitMethods.cs:120:5:123:5 | {...} | semmle.label | successor |
+| ExitMethods.cs:120:5:123:5 | {...} | ExitMethods.cs:121:9:121:29 | ...; | semmle.label | successor |
+| ExitMethods.cs:121:9:121:28 | call to method IsTrue | ExitMethods.cs:119:17:119:32 | exit FailingAssertion | semmle.label | exception(AssertFailedException) |
+| ExitMethods.cs:121:9:121:29 | ...; | ExitMethods.cs:121:23:121:27 | false | semmle.label | successor |
+| ExitMethods.cs:121:23:121:27 | false | ExitMethods.cs:121:9:121:28 | call to method IsTrue | semmle.label | successor |
+| ExitMethods.cs:125:17:125:33 | enter FailingAssertion2 | ExitMethods.cs:126:5:129:5 | {...} | semmle.label | successor |
+| ExitMethods.cs:126:5:129:5 | {...} | ExitMethods.cs:127:9:127:27 | ...; | semmle.label | successor |
+| ExitMethods.cs:127:9:127:26 | call to method FailingAssertion | ExitMethods.cs:125:17:125:33 | exit FailingAssertion2 | semmle.label | exception(AssertFailedException) |
+| ExitMethods.cs:127:9:127:26 | this access | ExitMethods.cs:127:9:127:26 | call to method FailingAssertion | semmle.label | successor |
+| ExitMethods.cs:127:9:127:27 | ...; | ExitMethods.cs:127:9:127:26 | this access | semmle.label | successor |
+| ExitMethods.cs:131:10:131:20 | enter AssertFalse | ExitMethods.cs:131:48:131:48 | access to parameter b | semmle.label | successor |
+| ExitMethods.cs:131:33:131:49 | call to method IsFalse | ExitMethods.cs:131:10:131:20 | exit AssertFalse | semmle.label | successor |
+| ExitMethods.cs:131:48:131:48 | access to parameter b | ExitMethods.cs:131:33:131:49 | call to method IsFalse | semmle.label | successor |
+| ExitMethods.cs:133:17:133:33 | enter FailingAssertion3 | ExitMethods.cs:134:5:137:5 | {...} | semmle.label | successor |
+| ExitMethods.cs:134:5:137:5 | {...} | ExitMethods.cs:135:9:135:26 | ...; | semmle.label | successor |
+| ExitMethods.cs:135:9:135:25 | call to method AssertFalse | ExitMethods.cs:133:17:133:33 | exit FailingAssertion3 | semmle.label | exception(AssertFailedException) |
+| ExitMethods.cs:135:9:135:25 | this access | ExitMethods.cs:135:21:135:24 | true | semmle.label | successor |
+| ExitMethods.cs:135:9:135:26 | ...; | ExitMethods.cs:135:9:135:25 | this access | semmle.label | successor |
+| ExitMethods.cs:135:21:135:24 | true | ExitMethods.cs:135:9:135:25 | call to method AssertFalse | semmle.label | successor |
 | Extensions.cs:5:23:5:29 | enter ToInt32 | Extensions.cs:6:5:8:5 | {...} | semmle.label | successor |
 | Extensions.cs:6:5:8:5 | {...} | Extensions.cs:7:28:7:28 | access to parameter s | semmle.label | successor |
 | Extensions.cs:7:9:7:30 | return ...; | Extensions.cs:5:23:5:29 | exit ToInt32 | semmle.label | return |


### PR DESCRIPTION
A method such as

```
void M()
{
    throw new Exception();
}
```

was incorrectly not categorized as a `ThrowingCallable`, that is, a callable that always throws an exception upon invocation.