### PR TITLE
C#: Speedup `Assertions::strictlyDominates()` and `ControlFlowElement::controlsBlock()`

### DIFF
--- a/csharp/ql/src/semmle/code/csharp/controlflow/BasicBlocks.qll
+++ b/csharp/ql/src/semmle/code/csharp/controlflow/BasicBlocks.qll
@@ -473,6 +473,7 @@ class ConditionBlock extends BasicBlock {
    * successor of this block, and `succ` can only be reached from
    * the callable entry point by going via the `s` edge out of this basic block.
    */
+  pragma[nomagic]
   predicate immediatelyControls(BasicBlock succ, ConditionalSuccessor s) {
     succ = this.getASuccessorByType(s) and
     forall(BasicBlock pred |

--- a/csharp/ql/src/semmle/code/csharp/controlflow/ControlFlowElement.qll
+++ b/csharp/ql/src/semmle/code/csharp/controlflow/ControlFlowElement.qll
@@ -79,7 +79,7 @@ class ControlFlowElement extends ExprOrStmtParent, @control_flow_element {
    * `pred` ending with this element, and `pred` is an immediate predecessor
    * of `succ`.
    *
-   * Moroever, this control flow element corresponds to multiple control flow nodes,
+   * Moreover, this control flow element corresponds to multiple control flow nodes,
    * which is why
    *
    * ```

--- a/csharp/ql/src/semmle/code/csharp/controlflow/ControlFlowGraph.qll
+++ b/csharp/ql/src/semmle/code/csharp/controlflow/ControlFlowGraph.qll
@@ -4185,6 +4185,13 @@ module ControlFlow {
       }
     }
     import Cached
+
+    /** A control flow element that is split into multiple control flow nodes. */
+    class SplitControlFlowElement extends ControlFlowElement {
+      SplitControlFlowElement() {
+        strictcount(this.getAControlFlowNode()) > 1
+      }
+    }
   }
   private import Internal
 }


### PR DESCRIPTION
Only calculate dominance by explicit recursion for split nodes; all other nodes can use regular CFG dominance.