### PR TITLE
CPP: More tests of isSideEffectFree() / ExprHasNoEffect.ql

### DIFF
--- a/cpp/ql/test/library-tests/sideEffects/functions/error.cpp
+++ b/cpp/ql/test/library-tests/sideEffects/functions/error.cpp
@@ -1,0 +1,19 @@
+// semmle-extractor-options: --expect_errors
+
+void functionBeforeError()
+{
+}
+
+void functionWithError1()
+{
+	aaaaaaaaaa(); // error
+}
+
+void functionWithError2()
+{
+	int i = aaaaaaaaaa(); // error
+}
+
+void functionAfterError()
+{
+}

--- a/cpp/ql/test/library-tests/sideEffects/functions/sideEffects.expected
+++ b/cpp/ql/test/library-tests/sideEffects/functions/sideEffects.expected
@@ -43,6 +43,10 @@
 | cpp.cpp:87:5:87:26 | functionAccessesStatic | int | false |
 | cpp.cpp:93:6:93:14 | increment | int & -> void | false |
 | cpp.cpp:97:6:97:16 | doIncrement | void | false |
+| error.cpp:3:6:3:24 | functionBeforeError | void | true |
+| error.cpp:7:6:7:23 | functionWithError1 | void | false |
+| error.cpp:12:6:12:23 | functionWithError2 | void | false |
+| error.cpp:17:6:17:23 | functionAfterError | void | true |
 | file://:0:0:0:0 | operator= | __va_list_tag & | false |
 | file://:0:0:0:0 | operator= | __va_list_tag & | false |
 | sideEffects.c:4:5:4:6 | f1 | int | true |

--- a/cpp/ql/test/query-tests/Likely Bugs/Likely Typos/ExprHasNoEffect/ExprHasNoEffect.expected
+++ b/cpp/ql/test/query-tests/Likely Bugs/Likely Typos/ExprHasNoEffect/ExprHasNoEffect.expected
@@ -1,5 +1,8 @@
 | calls.cpp:8:5:8:5 | 1 | This expression has no effect. | calls.cpp:8:5:8:5 | 1 |  |
 | calls.cpp:12:5:12:16 | call to thingy | This expression has no effect (because $@ has no external side effects). | calls.cpp:7:15:7:20 | thingy | thingy |
+| expr.cpp:8:2:8:2 | 0 | This expression has no effect. | expr.cpp:8:2:8:2 | 0 |  |
+| expr.cpp:9:7:9:7 | 0 | This expression has no effect. | expr.cpp:9:7:9:7 | 0 |  |
+| expr.cpp:10:2:10:5 | ... , ... | This expression has no effect. | expr.cpp:10:2:10:5 | ... , ... |  |
 | preproc.c:89:2:89:4 | call to fn4 | This expression has no effect (because $@ has no external side effects). | preproc.c:33:5:33:7 | fn4 | fn4 |
 | preproc.c:94:2:94:4 | call to fn9 | This expression has no effect (because $@ has no external side effects). | preproc.c:78:5:78:7 | fn9 | fn9 |
 | template.cpp:19:3:19:3 | call to operator++ | This expression has no effect (because $@ has no external side effects). | template.cpp:9:10:9:19 | operator++ | operator++ |

--- a/cpp/ql/test/query-tests/Likely Bugs/Likely Typos/ExprHasNoEffect/expr.cpp
+++ b/cpp/ql/test/query-tests/Likely Bugs/Likely Typos/ExprHasNoEffect/expr.cpp
@@ -1,0 +1,13 @@
+namespace Expr {
+
+int i;
+
+void comma_expr_test()
+{
+	i++, i++; // GOOD
+	0, i++; // BAD (first part)
+	i++, 0; // BAD (second part)
+	0, 0; // BAD (whole)
+}
+
+}


### PR DESCRIPTION
The first part of this is a test case from https://git.semmle.com/Semmle/code/pull/19744/commits/c7f56d2588bf00060e2969050a493e3c8f4b144c (never merged) about how `isSideEffectFree()` handles the presence of an `ErrorExpr`.  The test now produces the results I'd expect (in particular the third case, which like the second contains an `ErrorExpr` so cannot be assumed to be side-effect free).

The second part of this PR is a simple test case for 'Expression has no effect' on `CommaExpr`, a subject that's been discussed lately.  In fact we already had some test cases but the new ones are clearer.

@rdmarsh2 