### PR TITLE
CPP: Fix type confusion in IncorrectPointerscaling.ql

### DIFF
--- a/change-notes/1.20/analysis-cpp.md
+++ b/change-notes/1.20/analysis-cpp.md
@@ -11,6 +11,7 @@
 
 | **Query**                  | **Expected impact**    | **Change**                                                       |
 |----------------------------|------------------------|------------------------------------------------------------------|
+| Suspicious pointer scaling (`cpp/suspicious-pointer-scaling`) | Fewer false positives | False positives involving types that are not uniquely named in the snapshot have been fixed. |
 | Unused static variable (`cpp/unused-static-variable`) | Fewer false positive results | Variables with the attribute `unused` are now excluded from the query. |
 
 ## Changes to QL libraries

--- a/cpp/ql/src/Security/CWE/CWE-468/IncorrectPointerScaling.ql
+++ b/cpp/ql/src/Security/CWE/CWE-468/IncorrectPointerScaling.ql
@@ -34,7 +34,6 @@ private Type baseType(Type t) {
   )
   // Make sure that the type has a size and that it isn't ambiguous.  
   and strictcount(result.getSize()) = 1
-    
 }
 
 /**
@@ -98,6 +97,7 @@ predicate defSourceType(SsaDefinition def, LocalScopeVariable v,
   | p = v and
     def.definedByParameter(p) and
     sourceType = p.getType().getUnspecifiedType() and
+    strictcount(p.getType()) = 1 and
     isPointerType(sourceType) and
     sourceLoc = p.getLocation())
 }

--- a/cpp/ql/src/Security/CWE/CWE-468/IncorrectPointerScalingChar.ql
+++ b/cpp/ql/src/Security/CWE/CWE-468/IncorrectPointerScalingChar.ql
@@ -89,6 +89,7 @@ predicate defSourceType(SsaDefinition def, LocalScopeVariable v,
   | p = v and
     def.definedByParameter(p) and
     sourceType = p.getType().getUnspecifiedType() and
+    strictcount(p.getType()) = 1 and
     isPointerType(sourceType) and
     sourceLoc = p.getLocation())
 }

--- a/cpp/ql/src/Security/CWE/CWE-468/IncorrectPointerScalingVoid.ql
+++ b/cpp/ql/src/Security/CWE/CWE-468/IncorrectPointerScalingVoid.ql
@@ -89,6 +89,7 @@ predicate defSourceType(SsaDefinition def, LocalScopeVariable v,
   | p = v and
     def.definedByParameter(p) and
     sourceType = p.getType().getUnspecifiedType() and
+    strictcount(p.getType()) = 1 and
     isPointerType(sourceType) and
     sourceLoc = p.getLocation())
 }

--- a/cpp/ql/test/query-tests/Security/CWE/CWE-468/semmle/IncorrectPointerScaling/IncorrectPointerScaling.expected
+++ b/cpp/ql/test/query-tests/Security/CWE/CWE-468/semmle/IncorrectPointerScaling/IncorrectPointerScaling.expected
@@ -1,3 +1,7 @@
 | test.cpp:50:19:50:19 | p | This pointer might have type $@ (size 8), but the pointer arithmetic here is done with type int * (size 4). | test.cpp:45:11:45:11 | test.cpp:45:11:45:11 | double |
 | test.cpp:94:18:94:18 | x | This pointer might have type $@ (size 4), but the pointer arithmetic here is done with type short * (size 2). | test.cpp:88:21:88:21 | test.cpp:88:21:88:21 | int |
 | test.cpp:130:27:130:29 | arr | This pointer might have type $@ (size 4), but the pointer arithmetic here is done with type short * (size 2). | test.cpp:128:16:128:18 | test.cpp:128:16:128:18 | int |
+| test_large.cpp:9:22:9:24 | ptr | This pointer might have type $@ (size 8), but the pointer arithmetic here is done with type MyStruct * (size 16). | test_large.cpp:7:21:7:23 | test_large.cpp:7:21:7:23 | MyStruct |
+| test_large.cpp:9:22:9:24 | ptr | This pointer might have type $@ (size 8), but the pointer arithmetic here is done with type MyStruct * (size 16). | test_small.cpp:10:21:10:23 | test_small.cpp:10:21:10:23 | MyStruct |
+| test_small.cpp:12:22:12:24 | ptr | This pointer might have type $@ (size 16), but the pointer arithmetic here is done with type MyStruct * (size 8). | test_large.cpp:7:21:7:23 | test_large.cpp:7:21:7:23 | MyStruct |
+| test_small.cpp:12:22:12:24 | ptr | This pointer might have type $@ (size 16), but the pointer arithmetic here is done with type MyStruct * (size 8). | test_small.cpp:10:21:10:23 | test_small.cpp:10:21:10:23 | MyStruct |

--- a/cpp/ql/test/query-tests/Security/CWE/CWE-468/semmle/IncorrectPointerScaling/IncorrectPointerScaling.expected
+++ b/cpp/ql/test/query-tests/Security/CWE/CWE-468/semmle/IncorrectPointerScaling/IncorrectPointerScaling.expected
@@ -1,7 +1,3 @@
 | test.cpp:50:19:50:19 | p | This pointer might have type $@ (size 8), but the pointer arithmetic here is done with type int * (size 4). | test.cpp:45:11:45:11 | test.cpp:45:11:45:11 | double |
 | test.cpp:94:18:94:18 | x | This pointer might have type $@ (size 4), but the pointer arithmetic here is done with type short * (size 2). | test.cpp:88:21:88:21 | test.cpp:88:21:88:21 | int |
 | test.cpp:130:27:130:29 | arr | This pointer might have type $@ (size 4), but the pointer arithmetic here is done with type short * (size 2). | test.cpp:128:16:128:18 | test.cpp:128:16:128:18 | int |
-| test_large.cpp:9:22:9:24 | ptr | This pointer might have type $@ (size 8), but the pointer arithmetic here is done with type MyStruct * (size 16). | test_large.cpp:7:21:7:23 | test_large.cpp:7:21:7:23 | MyStruct |
-| test_large.cpp:9:22:9:24 | ptr | This pointer might have type $@ (size 8), but the pointer arithmetic here is done with type MyStruct * (size 16). | test_small.cpp:10:21:10:23 | test_small.cpp:10:21:10:23 | MyStruct |
-| test_small.cpp:12:22:12:24 | ptr | This pointer might have type $@ (size 16), but the pointer arithmetic here is done with type MyStruct * (size 8). | test_large.cpp:7:21:7:23 | test_large.cpp:7:21:7:23 | MyStruct |
-| test_small.cpp:12:22:12:24 | ptr | This pointer might have type $@ (size 16), but the pointer arithmetic here is done with type MyStruct * (size 8). | test_small.cpp:10:21:10:23 | test_small.cpp:10:21:10:23 | MyStruct |

--- a/cpp/ql/test/query-tests/Security/CWE/CWE-468/semmle/IncorrectPointerScaling/test_large.cpp
+++ b/cpp/ql/test/query-tests/Security/CWE/CWE-468/semmle/IncorrectPointerScaling/test_large.cpp
@@ -1,0 +1,10 @@
+
+struct MyStruct
+{
+	int x, y, z, w;
+};
+
+void test(MyStruct *ptr)
+{
+	MyStruct *new_ptr = ptr + 1; // GOOD [FALSE POSITIVE]
+}

--- a/cpp/ql/test/query-tests/Security/CWE/CWE-468/semmle/IncorrectPointerScaling/test_large.cpp
+++ b/cpp/ql/test/query-tests/Security/CWE/CWE-468/semmle/IncorrectPointerScaling/test_large.cpp
@@ -6,5 +6,5 @@ struct MyStruct
 
 void test(MyStruct *ptr)
 {
-	MyStruct *new_ptr = ptr + 1; // GOOD [FALSE POSITIVE]
+	MyStruct *new_ptr = ptr + 1; // GOOD
 }

--- a/cpp/ql/test/query-tests/Security/CWE/CWE-468/semmle/IncorrectPointerScaling/test_small.cpp
+++ b/cpp/ql/test/query-tests/Security/CWE/CWE-468/semmle/IncorrectPointerScaling/test_small.cpp
@@ -1,0 +1,13 @@
+// note the two different `MyStruct` definitions, in test_small.cpp and test_large.cpp.  These are
+// in different translation units and we assume they are never linked into the same program (which
+// would result in undefined behaviour).
+
+struct MyStruct
+{
+	int x, y;
+};
+
+void test(MyStruct *ptr)
+{
+	MyStruct *new_ptr = ptr + 1; // GOOD [FALSE POSITIVE]
+}

--- a/cpp/ql/test/query-tests/Security/CWE/CWE-468/semmle/IncorrectPointerScaling/test_small.cpp
+++ b/cpp/ql/test/query-tests/Security/CWE/CWE-468/semmle/IncorrectPointerScaling/test_small.cpp
@@ -9,5 +9,5 @@ struct MyStruct
 
 void test(MyStruct *ptr)
 {
-	MyStruct *new_ptr = ptr + 1; // GOOD [FALSE POSITIVE]
+	MyStruct *new_ptr = ptr + 1; // GOOD
 }


### PR DESCRIPTION
Fix false positives in IncorrectPointerscaling.ql caused by type confusion in pointer parameters, such as this case:

https://lgtm.com/projects/g/NVIDIAGameWorks/PhysX-3.4/snapshot/7824041cdbe617fcb8d905c36bdb0db06c77a75c/files/PhysX_3.4/Source/SceneQuery/src/SqBucketPruner.cpp?sort=name&dir=ASC&mode=heatmap#L343

After this is merged I plan to create an `IncorrectPointerScaling.qll` library to remove some of the code duplication you can see in the three similar queries.