### PR TITLE
Java: Add configuration file library.

### DIFF
--- a/java/ql/src/semmle/code/configfiles/ConfigFiles.ql
+++ b/java/ql/src/semmle/code/configfiles/ConfigFiles.ql
@@ -1,0 +1,101 @@
+/**
+ * Provides classes and predicates for working with configuration files, such
+ * as Java .properties or .ini files.
+ */
+
+import semmle.code.Location
+
+/** Each element in a configuration file has a location. */
+abstract class ConfigLocatable extends @configLocatable {
+  /** Retrieve the source location for this element. */
+  Location getLocation() {
+    configLocations(this, result)
+  }
+
+  /** The file associated with this element. */
+  File getFile() {
+    result = getLocation().getFile()
+  }
+
+  /** Gets a textual representation of this element. */
+  abstract string toString();
+}
+
+/**
+ * A logical line (possibly spread out over multiple actual lines)
+ * containing a name-value pair.
+ */
+class ConfigLine extends @config, ConfigLocatable {
+
+  /** If this configuration has a name element, return it. */
+  ConfigName getNameElement() {
+    configNames(result, this, _)
+  }
+
+  /** If this configuration has a value element, return it. */
+  ConfigValue getValueElement() {
+    configValues(result, this, _)
+  }
+
+  /**
+   * If this configuration has a name element, return its string value.
+   * Otherwise return the empty string.
+   */
+  string getEffectiveName() {
+    if exists(getNameElement()) then
+      result = getNameElement().getName()
+    else
+      result = ""
+  }
+
+  /**
+   * If this configuration has a value element, return its string value.
+   * Otherwise return the empty string.
+   */
+  string getEffectiveValue() {
+    if exists(getValueElement()) then
+      result = getValueElement().getValue()
+    else
+      result = ""
+  }
+
+  /** A printable representation of this configuration line. */
+  override string toString() {
+    result = getEffectiveName() + "=" + getEffectiveValue()
+  }
+}
+
+/** The name element of a configuration line. */
+class ConfigName extends @configName, ConfigLocatable {
+
+  /** Returns the name as a string. */
+  string getName() {
+    configNames(this, _, result)
+  }
+
+  /** A printable representation of this ConfigName. */
+  override string toString() {
+    result = getName()
+  }
+}
+
+/** The value element of a configuration line. */
+class ConfigValue extends @configValue, ConfigLocatable {
+
+  /** Returns the value as a string. */
+  string getValue() {
+    configValues(this, _, result)
+  }
+
+  /** A printable representation of this ConfigValue. */
+  override string toString() {
+    result = getValue()
+  }
+}
+
+/** A Java property is a name-value pair in a .properties file. */
+class JavaProperty extends ConfigLine {
+  JavaProperty() {
+    getFile().getExtension() = "properties"
+  }
+}

--- a/java/ql/src/semmle/code/configfiles/ConfigFiles.qll
+++ b/java/ql/src/semmle/code/configfiles/ConfigFiles.qll
@@ -1,11 +1,11 @@
 /**
  * Provides classes and predicates for working with configuration files, such
- * as Java .properties or .ini files.
+ * as Java `.properties` or `.ini` files.
  */
 
 import semmle.code.Location
 
-/** Each element in a configuration file has a location. */
+/** An element in a configuration file has a location. */
 abstract class ConfigLocatable extends @configLocatable {
   /** Gets the source location for this element. */
   Location getLocation() { configLocations(this, result) }
@@ -22,14 +22,14 @@ abstract class ConfigLocatable extends @configLocatable {
  * for applications, such as the port, name or address of a database.
  */
 class ConfigPair extends @config, ConfigLocatable {
-  /** Gets the name of this ConfigPair, if any. */
+  /** Gets the name of this `ConfigPair`, if any. */
   ConfigName getNameElement() { configNames(result, this, _) }
 
-  /** Gets the value of this ConfigPair, if any. */
+  /** Gets the value of this `ConfigPair`, if any. */
   ConfigValue getValueElement() { configValues(result, this, _) }
 
   /**
-   * Gets the string value of the name of this ConfigPair if
+   * Gets the string value of the name of this `ConfigPair` if
    * it exists and the empty string if it doesn't.
    */
   string getEffectiveName() {
@@ -37,34 +37,34 @@ class ConfigPair extends @config, ConfigLocatable {
   }
 
   /**
-   * Gets the string value of the value of this ConfigPair if
+   * Gets the string value of the value of this `ConfigPair` if
    * it exists and the empty string if it doesn't.
    */
   string getEffectiveValue() {
     if exists(getValueElement()) then result = getValueElement().getValue() else result = ""
   }
 
-  /** Gets a printable representation of this ConfigPair. */
+  /** Gets a printable representation of this `ConfigPair`. */
   override string toString() { result = getEffectiveName() + "=" + getEffectiveValue() }
 }
 
-/** The name element of a ConfigPair. */
+/** The name element of a `ConfigPair`. */
 class ConfigName extends @configName, ConfigLocatable {
   /** Gets the name as a string. */
   string getName() { configNames(this, _, result) }
 
-  /** Gets a printable representation of this ConfigName. */
+  /** Gets a printable representation of this `ConfigName`. */
   override string toString() { result = getName() }
 }
 
-/** The value element of a ConfigPair. */
+/** The value element of a `ConfigPair`. */
 class ConfigValue extends @configValue, ConfigLocatable {
   /** Gets the value as a string. */
   string getValue() { configValues(this, _, result) }
 
-  /** Gets a printable representation of this ConfigValue. */
+  /** Gets a printable representation of this `ConfigValue`. */
   override string toString() { result = getValue() }
 }
 
-/** A Java property is a name-value pair in a .properties file. */
+/** A Java property is a name-value pair in a `.properties` file. */
 class JavaProperty extends ConfigPair { JavaProperty() { getFile().getExtension() = "properties" } }

--- a/java/ql/src/semmle/code/configfiles/ConfigFiles.qll
+++ b/java/ql/src/semmle/code/configfiles/ConfigFiles.qll
@@ -22,23 +22,23 @@ abstract class ConfigLocatable extends @configLocatable {
 }
 
 /**
- * A logical line (possibly spread out over multiple actual lines)
- * containing a name-value pair.
+ * A name-value pair often used to store configuration properties
+ * for applications, such as the port, name or address of a database.
  */
-class ConfigLine extends @config, ConfigLocatable {
+class ConfigPair extends @config, ConfigLocatable {
 
-  /** If this configuration has a name element, return it. */
+  /** If this ConfigPair has a name element, return it. */
   ConfigName getNameElement() {
     configNames(result, this, _)
   }
 
-  /** If this configuration has a value element, return it. */
+  /** If this ConfigPair has a value element, return it. */
   ConfigValue getValueElement() {
     configValues(result, this, _)
   }
 
   /**
-   * If this configuration has a name element, return its string value.
+   * If this ConfigPair has a name element, return its string value.
    * Otherwise return the empty string.
    */
   string getEffectiveName() {
@@ -49,7 +49,7 @@ class ConfigLine extends @config, ConfigLocatable {
   }
 
   /**
-   * If this configuration has a value element, return its string value.
+   * If this ConfigPair has a value element, return its string value.
    * Otherwise return the empty string.
    */
   string getEffectiveValue() {
@@ -59,13 +59,13 @@ class ConfigLine extends @config, ConfigLocatable {
       result = ""
   }
 
-  /** A printable representation of this configuration line. */
+  /** A printable representation of this ConfigPair. */
   override string toString() {
     result = getEffectiveName() + "=" + getEffectiveValue()
   }
 }
 
-/** The name element of a configuration line. */
+/** The name element of a ConfigPair. */
 class ConfigName extends @configName, ConfigLocatable {
 
   /** Returns the name as a string. */
@@ -79,7 +79,7 @@ class ConfigName extends @configName, ConfigLocatable {
   }
 }
 
-/** The value element of a configuration line. */
+/** The value element of a ConfigPair. */
 class ConfigValue extends @configValue, ConfigLocatable {
 
   /** Returns the value as a string. */
@@ -94,7 +94,7 @@ class ConfigValue extends @configValue, ConfigLocatable {
 }
 
 /** A Java property is a name-value pair in a .properties file. */
-class JavaProperty extends ConfigLine {
+class JavaProperty extends ConfigPair {
   JavaProperty() {
     getFile().getExtension() = "properties"
   }

--- a/java/ql/src/semmle/code/configfiles/ConfigFiles.qll
+++ b/java/ql/src/semmle/code/configfiles/ConfigFiles.qll
@@ -7,15 +7,11 @@ import semmle.code.Location
 
 /** Each element in a configuration file has a location. */
 abstract class ConfigLocatable extends @configLocatable {
-  /** Retrieve the source location for this element. */
-  Location getLocation() {
-    configLocations(this, result)
-  }
+  /** Gets the source location for this element. */
+  Location getLocation() { configLocations(this, result) }
 
-  /** The file associated with this element. */
-  File getFile() {
-    result = getLocation().getFile()
-  }
+  /** Gets the file associated with this element. */
+  File getFile() { result = getLocation().getFile() }
 
   /** Gets a textual representation of this element. */
   abstract string toString();
@@ -26,76 +22,49 @@ abstract class ConfigLocatable extends @configLocatable {
  * for applications, such as the port, name or address of a database.
  */
 class ConfigPair extends @config, ConfigLocatable {
+  /** Gets the name of this ConfigPair, if any. */
+  ConfigName getNameElement() { configNames(result, this, _) }
 
-  /** If this ConfigPair has a name element, return it. */
-  ConfigName getNameElement() {
-    configNames(result, this, _)
-  }
-
-  /** If this ConfigPair has a value element, return it. */
-  ConfigValue getValueElement() {
-    configValues(result, this, _)
-  }
+  /** Gets the value of this ConfigPair, if any. */
+  ConfigValue getValueElement() { configValues(result, this, _) }
 
   /**
-   * If this ConfigPair has a name element, return its string value.
-   * Otherwise return the empty string.
+   * Gets the string value of the name of this ConfigPair if
+   * it exists and the empty string if it doesn't.
    */
   string getEffectiveName() {
-    if exists(getNameElement()) then
-      result = getNameElement().getName()
-    else
-      result = ""
+    if exists(getNameElement()) then result = getNameElement().getName() else result = ""
   }
 
   /**
-   * If this ConfigPair has a value element, return its string value.
-   * Otherwise return the empty string.
+   * Gets the string value of the value of this ConfigPair if
+   * it exists and the empty string if it doesn't.
    */
   string getEffectiveValue() {
-    if exists(getValueElement()) then
-      result = getValueElement().getValue()
-    else
-      result = ""
+    if exists(getValueElement()) then result = getValueElement().getValue() else result = ""
   }
 
-  /** A printable representation of this ConfigPair. */
-  override string toString() {
-    result = getEffectiveName() + "=" + getEffectiveValue()
-  }
+  /** Gets a printable representation of this ConfigPair. */
+  override string toString() { result = getEffectiveName() + "=" + getEffectiveValue() }
 }
 
 /** The name element of a ConfigPair. */
 class ConfigName extends @configName, ConfigLocatable {
+  /** Gets the name as a string. */
+  string getName() { configNames(this, _, result) }
 
-  /** Returns the name as a string. */
-  string getName() {
-    configNames(this, _, result)
-  }
-
-  /** A printable representation of this ConfigName. */
-  override string toString() {
-    result = getName()
-  }
+  /** Gets a printable representation of this ConfigName. */
+  override string toString() { result = getName() }
 }
 
 /** The value element of a ConfigPair. */
 class ConfigValue extends @configValue, ConfigLocatable {
+  /** Gets the value as a string. */
+  string getValue() { configValues(this, _, result) }
 
-  /** Returns the value as a string. */
-  string getValue() {
-    configValues(this, _, result)
-  }
-
-  /** A printable representation of this ConfigValue. */
-  override string toString() {
-    result = getValue()
-  }
+  /** Gets a printable representation of this ConfigValue. */
+  override string toString() { result = getValue() }
 }
 
 /** A Java property is a name-value pair in a .properties file. */
-class JavaProperty extends ConfigPair {
-  JavaProperty() {
-    getFile().getExtension() = "properties"
-  }
-}
+class JavaProperty extends ConfigPair { JavaProperty() { getFile().getExtension() = "properties" } }

--- a/java/ql/test/library-tests/properties/Properties.expected
+++ b/java/ql/test/library-tests/properties/Properties.expected
@@ -1,0 +1,25 @@
+|  |  |
+|  | separatorAndValue1 |
+|  | separatorAndValue2 |
+| Can:you=spot theactual=separator? | I betitwill=take:you a moment! |
+| a | unicode value |
+| co | lon |
+| duplicate | value1 |
+| duplicate | value2 |
+| indented | value |
+| multilinename | value |
+| name with spaces | value   with  spaces      |
+| nameAndSeparator1 |  |
+| nameAndSeparator2 |  |
+| nameAndSeparator3? |  |
+| nameOnly |  |
+| property1 | value |
+| property2 | value |
+| property3 | value |
+| property4 | valueWithTrailingSpaces     |
+| property5 | multi  linevalue     |
+| sortOfEmptyButNotReally |   |
+| space | separator    |
+| this | is a new property because the previous line has spaces after the backslash |
+| thisIsANameNotAValue! |  |
+| with | line\nbreak |

--- a/java/ql/test/library-tests/properties/Properties.ql
+++ b/java/ql/test/library-tests/properties/Properties.ql
@@ -1,0 +1,5 @@
+import default
+import semmle.code.configfiles.ConfigFiles
+
+from ConfigPair cp
+select cp.getEffectiveName(), cp.getEffectiveValue()

--- a/java/ql/test/library-tests/properties/Test.java
+++ b/java/ql/test/library-tests/properties/Test.java
@@ -1,0 +1,1 @@
+public class Test { }

--- a/java/ql/test/library-tests/properties/test.properties
+++ b/java/ql/test/library-tests/properties/test.properties
@@ -1,0 +1,53 @@
+property1=value
+property2 =value
+property3 = value
+property4 = valueWithTrailingSpaces    
+name\ with\ spaces = value   with  spaces     
+space    separator   
+co:lon
+property5 = \
+            \
+            multi  \
+            line\
+            value\    
+            this is a new property because the previous line has spaces after the backslash
+with=line\nbreak
+a=unicode\u0020value
+    indented=value
+
+multi\
+line\
+name=value
+
+duplicate=value1
+nameOnly
+# this and the following lines
+   # are comments or are empty  \
+      ! and should thus be ignored   
+         !
+
+   
+nameAndSeparator1=
+nameAndSeparator2:
+nameAndSeparator3? 
+=
+:
+ :
+ : 
+=separatorAndValue1
+:separatorAndValue2
+ thisIsANameNotAValue!
+sortOfEmptyButNotReally=\
+\
+\
+\u0020
+
+duplicate=value2
+
+Can\:you\=spot\ the\
+                actual\
+                \=separator? I bet\
+                it\
+                will=\
+                take:\
+                you a moment!


### PR DESCRIPTION
@yh-semmle This is a small library to work with the extracted properties (and possibly other configuration) files. I cannot easily add tests for this code yet, as we don't extract properties by default, but I plan to enable the extraction in the auto-builder and will then add test cases in a separate PR.