### PR TITLE
JavaScript: Avoid unhelpful magic.

### DIFF
--- a/javascript/ql/src/Expressions/DOMProperties.qll
+++ b/javascript/ql/src/Expressions/DOMProperties.qll
@@ -12,6 +12,7 @@ predicate isDOMRootType(ExternalType et) {
 }
 
 /** Holds if `p` is declared as a property of a DOM class or interface. */
+pragma[nomagic]
 predicate isDOMProperty(string p) {
   exists (ExternalMemberDecl emd | emd.getName() = p |
     isDOMRootType(emd.getDeclaringType().getASupertype*())


### PR DESCRIPTION
This was causing `SelfAssignment` to go wild on `anusaaraka` (4s -> 693s), and also didn't help on other snapshots.

It's a regression from 1.18, so I'd like to get it in as a (very late) hotfix.

Evaluation on big-apps suggests the fix is otherwise barely noticeable:

```
azure-sdk-for-node            3808         3606                  0.946954
gecko-dev                     18266        17711                 0.969616
TypeScript                    426          416                   0.976526
mxnet.js                      1280         1261                  0.985156
any-balance-providers         2331         2299                  0.986272
descartes                     2596         2578                  0.993066
angular-gulp-webpack-starter  5079         5095                  1.00315
A2Z-F15                       7009         7056                  1.00671
tatami                        1740         1755                  1.00862
ChakraCore                    4501         4586                  1.01888
node                          6379         6537                  1.02477
```
