### PR TITLE
Java: Change alert location for ConstantLoopCondition.

### DIFF
--- a/java/ql/src/Likely Bugs/Termination/ConstantLoopCondition.ql
+++ b/java/ql/src/Likely Bugs/Termination/ConstantLoopCondition.ql
@@ -81,5 +81,5 @@ where
   not exists(MethodAccess ma | ma.getParent*() = cond) and
   not exists(FieldRead fa | fa.getParent*() = cond) and
   not exists(ArrayAccess aa | aa.getParent*() = cond)
-select loop, "Loop might not terminate, as this $@ is constant within the loop.", cond,
-  "loop condition"
+select cond, "$@ might not terminate, as this loop condition is constant within the loop.", loop,
+  "Loop"

--- a/java/ql/test/query-tests/ConstantLoopCondition/ConstantLoopCondition.expected
+++ b/java/ql/test/query-tests/ConstantLoopCondition/ConstantLoopCondition.expected
@@ -1,3 +1,3 @@
-| A.java:6:5:6:16 | stmt | Loop might not terminate, as this $@ is constant within the loop. | A.java:6:11:6:15 | !... | loop condition |
-| A.java:12:5:12:19 | stmt | Loop might not terminate, as this $@ is constant within the loop. | A.java:13:11:13:15 | ... > ... | loop condition |
-| A.java:27:5:27:38 | stmt | Loop might not terminate, as this $@ is constant within the loop. | A.java:27:20:27:32 | ... < ... | loop condition |
+| A.java:6:11:6:15 | !... | $@ might not terminate, as this loop condition is constant within the loop. | A.java:6:5:6:16 | stmt | Loop |
+| A.java:13:11:13:15 | ... > ... | $@ might not terminate, as this loop condition is constant within the loop. | A.java:12:5:12:19 | stmt | Loop |
+| A.java:27:20:27:32 | ... < ... | $@ might not terminate, as this loop condition is constant within the loop. | A.java:27:5:27:38 | stmt | Loop |


### PR DESCRIPTION
The interesting location for this query is at the constant condition, so this updates the message to point there, instead of at the loop, which might just be `while (true)`.