### PR TITLE
CPP: Work on Lossy function result cast query

### DIFF
--- a/change-notes/1.20/analysis-cpp.md
+++ b/change-notes/1.20/analysis-cpp.md
@@ -8,12 +8,14 @@
 
 | **Query**                   | **Tags**  | **Purpose**                                                        |
 |-----------------------------|-----------|--------------------------------------------------------------------|
+| Lossy function result cast (`cpp/lossy-function-result-cast`) | correctness | Finds function calls whose result type is a floating point type, which are implicitly cast to an integral type.  Newly available but not displayed by default on LGTM. |
 
 ## Changes to existing queries
 
 | **Query**                  | **Expected impact**    | **Change**                                                       |
 |----------------------------|------------------------|------------------------------------------------------------------|
 | Suspicious pointer scaling (`cpp/suspicious-pointer-scaling`) | Fewer false positives | False positives involving types that are not uniquely named in the snapshot have been fixed. |
+| Lossy function result cast (`cpp/lossy-function-result-cast`) | Fewer false positive results | The whitelist of rounding functions built into this query has been expanded. |
 | Unused static variable (`cpp/unused-static-variable`) | Fewer false positive results | Variables with the attribute `unused` are now excluded from the query. |
 | Resource not released in destructor (`cpp/resource-not-released-in-destructor`) | Fewer false positive results | Fix false positives where a resource is released via a virtual method call. |
 

--- a/cpp/ql/src/Likely Bugs/Conversion/LossyFunctionResultCast.cpp
+++ b/cpp/ql/src/Likely Bugs/Conversion/LossyFunctionResultCast.cpp
@@ -1,0 +1,7 @@
+double getWidth();
+
+void f() {
+	int width = getWidth();
+	
+	// ...
+}

--- a/cpp/ql/src/Likely Bugs/Conversion/LossyFunctionResultCast.qhelp
+++ b/cpp/ql/src/Likely Bugs/Conversion/LossyFunctionResultCast.qhelp
@@ -1,0 +1,28 @@
+<!DOCTYPE qhelp PUBLIC
+  "-//Semmle//qhelp//EN"
+  "qhelp.dtd">
+<qhelp>
+
+<overview>
+<p>This rule finds function calls whose result type is a floating point type, which are implicitly cast to an integral type. Such code may not behave as intended when the floating point return value has a fractional part, or takes an extreme value outside the range that can be represented by the integer type.</p>
+
+</overview>
+<recommendation>
+<p>Consider changing the surrounding expression to match the floating point type. If rounding is intended, explicitly round using a standard function such as `trunc`, `floor` or `round`.</p>
+
+</recommendation>
+<example><sample src="LossyFunctionResultCast.cpp" />
+<p>In this example, the result of the call to <code>getWidth()</code> is implicitly cast to <code>int</code>, resulting in an unintended loss of accuracy. To fix this, the type of variable <code>width</code> could be changed from <code>int</code> to <code>double</code>.</p>
+
+</example>
+<references>
+
+<li>
+  Microsoft Visual C++ Documentation: <a href="https://docs.microsoft.com/en-us/cpp/cpp/type-conversions-and-type-safety-modern-cpp?view=vs-2017">Type Conversions and Type Safety (Modern C++)</a>.
+</li>
+<li>
+  Cplusplus.com: <a href="http://www.cplusplus.com/doc/tutorial/typecasting/">Type conversions</a>.
+</li>
+
+</references>
+</qhelp>

--- a/cpp/ql/src/Likely Bugs/Conversion/LossyFunctionResultCast.ql
+++ b/cpp/ql/src/Likely Bugs/Conversion/LossyFunctionResultCast.ql
@@ -10,6 +10,7 @@
  */
 
 import cpp
+import semmle.code.cpp.dataflow.DataFlow
 
 predicate whitelist(Function f) {
   exists(string fName |
@@ -52,14 +53,10 @@ predicate whitelistPow(FunctionCall fc) {
 predicate whiteListWrapped(FunctionCall fc) {
   whitelist(fc.getTarget()) or
   whitelistPow(fc) or
-  exists(ReturnStmt rs |
-    rs.getEnclosingFunction() = fc.getTarget() and
-    whiteListWrapped(rs.getExpr())
-  ) or
-  exists(ReturnStmt rs, Variable v |
-    rs.getEnclosingFunction() = fc.getTarget() and
-    rs.getExpr().(VariableAccess).getTarget() = v and
-    whiteListWrapped(v.getAnAssignedValue())
+  exists(Expr e, ReturnStmt rs |
+    whiteListWrapped(e) and
+    DataFlow::localFlow(DataFlow::exprNode(e), DataFlow::exprNode(rs.getExpr())) and
+    fc.getTarget() = rs.getEnclosingFunction()
   )
 }
 

--- a/cpp/ql/src/Likely Bugs/Conversion/LossyFunctionResultCast.ql
+++ b/cpp/ql/src/Likely Bugs/Conversion/LossyFunctionResultCast.ql
@@ -10,11 +10,30 @@
  */
 import cpp
 
+predicate whitelist(string fName) {
+  fName = "ceil" or
+  fName = "ceilf" or
+  fName = "ceill" or
+  fName = "floor" or
+  fName = "floorf" or
+  fName = "floorl" or
+  fName = "nearbyint" or
+  fName = "nearbyintf" or
+  fName = "nearbyintl" or
+  fName = "rint" or
+  fName = "rintf" or
+  fName = "rintl" or
+  fName = "round" or
+  fName = "roundf" or
+  fName = "roundl" or
+  fName = "trunc" or
+  fName = "truncf" or
+  fName = "truncl"
+}
+
 from FunctionCall c, FloatingPointType t1, IntegralType t2
 where t1 = c.getTarget().getType().getUnderlyingType() and
       t2 = c.getActualType() and
       c.hasImplicitConversion() and
-      not c.getTarget().getName() = "ceil" and
-      not c.getTarget().getName() = "floor" and
-      not c.getTarget().getName() = "round"
+      not whitelist(c.getTarget().getName())
 select c, "Return value of type " + t1.toString() + " is implicitly converted to " + t2.toString() + " here."

--- a/cpp/ql/src/Likely Bugs/Conversion/LossyFunctionResultCast.ql
+++ b/cpp/ql/src/Likely Bugs/Conversion/LossyFunctionResultCast.ql
@@ -11,25 +11,31 @@
 
 import cpp
 
-predicate whitelist(string fName) {
-  fName = "ceil" or
-  fName = "ceilf" or
-  fName = "ceill" or
-  fName = "floor" or
-  fName = "floorf" or
-  fName = "floorl" or
-  fName = "nearbyint" or
-  fName = "nearbyintf" or
-  fName = "nearbyintl" or
-  fName = "rint" or
-  fName = "rintf" or
-  fName = "rintl" or
-  fName = "round" or
-  fName = "roundf" or
-  fName = "roundl" or
-  fName = "trunc" or
-  fName = "truncf" or
-  fName = "truncl"
+predicate whitelist(Function f) {
+  exists(string fName |
+    fName = f.getName() and
+    (
+      fName = "ceil" or
+      fName = "ceilf" or
+      fName = "ceill" or
+      fName = "floor" or
+      fName = "floorf" or
+      fName = "floorl" or
+      fName = "nearbyint" or
+      fName = "nearbyintf" or
+      fName = "nearbyintl" or
+      fName = "rint" or
+      fName = "rintf" or
+      fName = "rintl" or
+      fName = "round" or
+      fName = "roundf" or
+      fName = "roundl" or
+      fName = "trunc" or
+      fName = "truncf" or
+      fName = "truncl" or
+      fName.matches("__builtin_%")
+    )
+  )
 }
 
 predicate whitelistPow(FunctionCall fc) {
@@ -44,7 +50,7 @@ predicate whitelistPow(FunctionCall fc) {
 }
 
 predicate whiteListWrapped(FunctionCall fc) {
-  whitelist(fc.getTarget().getName()) or
+  whitelist(fc.getTarget()) or
   whitelistPow(fc) or
   exists(ReturnStmt rs |
     rs.getEnclosingFunction() = fc.getTarget() and

--- a/cpp/ql/src/Likely Bugs/Conversion/LossyFunctionResultCast.ql
+++ b/cpp/ql/src/Likely Bugs/Conversion/LossyFunctionResultCast.ql
@@ -31,9 +31,21 @@ predicate whitelist(string fName) {
   fName = "truncl"
 }
 
+predicate whitelistPow(FunctionCall fc) {
+  (
+    fc.getTarget().getName() = "pow" or
+    fc.getTarget().getName() = "powf" or
+    fc.getTarget().getName() = "powl"
+  ) and exists(float value |
+    value = fc.getArgument(0).getValue().toFloat() and
+    (value.floor() - value).abs() < 0.001
+  )
+}
+
 from FunctionCall c, FloatingPointType t1, IntegralType t2
 where t1 = c.getTarget().getType().getUnderlyingType() and
       t2 = c.getActualType() and
       c.hasImplicitConversion() and
-      not whitelist(c.getTarget().getName())
+      not whitelist(c.getTarget().getName()) and
+      not whitelistPow(c)
 select c, "Return value of type " + t1.toString() + " is implicitly converted to " + t2.toString() + " here."

--- a/cpp/ql/src/Likely Bugs/Conversion/LossyFunctionResultCast.ql
+++ b/cpp/ql/src/Likely Bugs/Conversion/LossyFunctionResultCast.ql
@@ -1,10 +1,12 @@
 /**
  * @name Lossy function result cast
  * @description Finds function calls whose result type is a floating point type, and which are casted to an integral type.
- *              Includes only expressions with implicit cast and excludes function calls to ceil, floor and round. {This is a gcc check; doesn't seem wildly useful.}
+ *              Includes only expressions with implicit cast and excludes function calls to ceil, floor and round.
  * @kind problem
  * @id cpp/lossy-function-result-cast
  * @problem.severity warning
+ * @precision medium
+ * @tags correctness
  */
 import cpp
 
@@ -15,4 +17,4 @@ where t1 = c.getTarget().getType().getUnderlyingType() and
       not c.getTarget().getName() = "ceil" and
       not c.getTarget().getName() = "floor" and
       not c.getTarget().getName() = "round"
-select c
+select c, "Return value of type " + t1.toString() + " is implicitly converted to " + t2.toString() + " here."

--- a/cpp/ql/test/query-tests/Likely Bugs/Conversion/LossyFunctionResultCast/ImplicitDowncastFromBitfield.expected
+++ b/cpp/ql/test/query-tests/Likely Bugs/Conversion/LossyFunctionResultCast/ImplicitDowncastFromBitfield.expected
@@ -4,3 +4,9 @@
 | test.cpp:40:13:40:21 | call to getDouble | Return value of type double is implicitly converted to int here. |
 | test.cpp:43:6:43:12 | call to getMyLD | Return value of type long double is implicitly converted to bool here. |
 | test.cpp:45:13:45:19 | call to getMyLD | Return value of type long double is implicitly converted to int here. |
+| test.cpp:97:10:97:12 | call to pow | Return value of type double is implicitly converted to int here. |
+| test.cpp:99:10:99:12 | call to pow | Return value of type double is implicitly converted to int here. |
+| test.cpp:101:10:101:12 | call to pow | Return value of type double is implicitly converted to int here. |
+| test.cpp:103:10:103:12 | call to pow | Return value of type double is implicitly converted to int here. |
+| test.cpp:105:10:105:12 | call to pow | Return value of type double is implicitly converted to int here. |
+| test.cpp:118:10:118:16 | call to myRound | Return value of type double is implicitly converted to int here. |

--- a/cpp/ql/test/query-tests/Likely Bugs/Conversion/LossyFunctionResultCast/ImplicitDowncastFromBitfield.expected
+++ b/cpp/ql/test/query-tests/Likely Bugs/Conversion/LossyFunctionResultCast/ImplicitDowncastFromBitfield.expected
@@ -7,4 +7,3 @@
 | test.cpp:101:10:101:12 | call to pow | Return value of type double is implicitly converted to int here. |
 | test.cpp:103:10:103:12 | call to pow | Return value of type double is implicitly converted to int here. |
 | test.cpp:105:10:105:12 | call to pow | Return value of type double is implicitly converted to int here. |
-| test.cpp:118:10:118:16 | call to myRound | Return value of type double is implicitly converted to int here. |

--- a/cpp/ql/test/query-tests/Likely Bugs/Conversion/LossyFunctionResultCast/ImplicitDowncastFromBitfield.expected
+++ b/cpp/ql/test/query-tests/Likely Bugs/Conversion/LossyFunctionResultCast/ImplicitDowncastFromBitfield.expected
@@ -7,3 +7,4 @@
 | test.cpp:101:10:101:12 | call to pow | Return value of type double is implicitly converted to int here. |
 | test.cpp:103:10:103:12 | call to pow | Return value of type double is implicitly converted to int here. |
 | test.cpp:105:10:105:12 | call to pow | Return value of type double is implicitly converted to int here. |
+| test.cpp:130:10:130:17 | call to myRound3 | Return value of type double is implicitly converted to int here. |

--- a/cpp/ql/test/query-tests/Likely Bugs/Conversion/LossyFunctionResultCast/ImplicitDowncastFromBitfield.expected
+++ b/cpp/ql/test/query-tests/Likely Bugs/Conversion/LossyFunctionResultCast/ImplicitDowncastFromBitfield.expected
@@ -1,0 +1,8 @@
+| test.cpp:33:6:33:13 | call to getFloat | Return value of type float is implicitly converted to bool here. |
+| test.cpp:35:13:35:20 | call to getFloat | Return value of type float is implicitly converted to int here. |
+| test.cpp:38:6:38:14 | call to getDouble | Return value of type double is implicitly converted to bool here. |
+| test.cpp:40:13:40:21 | call to getDouble | Return value of type double is implicitly converted to int here. |
+| test.cpp:43:6:43:12 | call to getMyLD | Return value of type long double is implicitly converted to bool here. |
+| test.cpp:45:13:45:19 | call to getMyLD | Return value of type long double is implicitly converted to int here. |
+| test.cpp:78:6:78:11 | call to roundf | Return value of type float is implicitly converted to bool here. |
+| test.cpp:80:13:80:18 | call to roundf | Return value of type float is implicitly converted to int here. |

--- a/cpp/ql/test/query-tests/Likely Bugs/Conversion/LossyFunctionResultCast/ImplicitDowncastFromBitfield.expected
+++ b/cpp/ql/test/query-tests/Likely Bugs/Conversion/LossyFunctionResultCast/ImplicitDowncastFromBitfield.expected
@@ -4,5 +4,3 @@
 | test.cpp:40:13:40:21 | call to getDouble | Return value of type double is implicitly converted to int here. |
 | test.cpp:43:6:43:12 | call to getMyLD | Return value of type long double is implicitly converted to bool here. |
 | test.cpp:45:13:45:19 | call to getMyLD | Return value of type long double is implicitly converted to int here. |
-| test.cpp:78:6:78:11 | call to roundf | Return value of type float is implicitly converted to bool here. |
-| test.cpp:80:13:80:18 | call to roundf | Return value of type float is implicitly converted to int here. |

--- a/cpp/ql/test/query-tests/Likely Bugs/Conversion/LossyFunctionResultCast/ImplicitDowncastFromBitfield.expected
+++ b/cpp/ql/test/query-tests/Likely Bugs/Conversion/LossyFunctionResultCast/ImplicitDowncastFromBitfield.expected
@@ -7,4 +7,3 @@
 | test.cpp:101:10:101:12 | call to pow | Return value of type double is implicitly converted to int here. |
 | test.cpp:103:10:103:12 | call to pow | Return value of type double is implicitly converted to int here. |
 | test.cpp:105:10:105:12 | call to pow | Return value of type double is implicitly converted to int here. |
-| test.cpp:130:10:130:17 | call to myRound3 | Return value of type double is implicitly converted to int here. |

--- a/cpp/ql/test/query-tests/Likely Bugs/Conversion/LossyFunctionResultCast/ImplicitDowncastFromBitfield.expected
+++ b/cpp/ql/test/query-tests/Likely Bugs/Conversion/LossyFunctionResultCast/ImplicitDowncastFromBitfield.expected
@@ -4,8 +4,6 @@
 | test.cpp:40:13:40:21 | call to getDouble | Return value of type double is implicitly converted to int here. |
 | test.cpp:43:6:43:12 | call to getMyLD | Return value of type long double is implicitly converted to bool here. |
 | test.cpp:45:13:45:19 | call to getMyLD | Return value of type long double is implicitly converted to int here. |
-| test.cpp:97:10:97:12 | call to pow | Return value of type double is implicitly converted to int here. |
-| test.cpp:99:10:99:12 | call to pow | Return value of type double is implicitly converted to int here. |
 | test.cpp:101:10:101:12 | call to pow | Return value of type double is implicitly converted to int here. |
 | test.cpp:103:10:103:12 | call to pow | Return value of type double is implicitly converted to int here. |
 | test.cpp:105:10:105:12 | call to pow | Return value of type double is implicitly converted to int here. |

--- a/cpp/ql/test/query-tests/Likely Bugs/Conversion/LossyFunctionResultCast/ImplicitDowncastFromBitfield.qlref
+++ b/cpp/ql/test/query-tests/Likely Bugs/Conversion/LossyFunctionResultCast/ImplicitDowncastFromBitfield.qlref
@@ -1,0 +1,1 @@
+Likely Bugs/Conversion/LossyFunctionResultCast.ql

--- a/cpp/ql/test/query-tests/Likely Bugs/Conversion/LossyFunctionResultCast/test.cpp
+++ b/cpp/ql/test/query-tests/Likely Bugs/Conversion/LossyFunctionResultCast/test.cpp
@@ -86,3 +86,34 @@ void test1()
 		setPosFloat(round(getDouble()));
 	}
 }
+
+double pow(double x, double y);
+
+int test2(double v, double w, int n)
+{
+	switch (n)
+	{
+	case 1:
+		return pow(2, v); // GOOD [FALSE POSITIVE]
+	case 2:
+		return pow(10, v); // GOOD [FALSE POSITIVE]
+	case 3:
+		return pow(2.5, v); // BAD
+	case 4:
+		return pow(v, 2); // BAD
+	case 5:
+		return pow(v, w); // BAD
+	};
+}
+
+double myRound(double v)
+{
+	double result = round(v);
+
+	return result;
+}
+
+void test3()
+{
+	int i = myRound(1.5); // GOOD [FALSE POSITIVE]
+}

--- a/cpp/ql/test/query-tests/Likely Bugs/Conversion/LossyFunctionResultCast/test.cpp
+++ b/cpp/ql/test/query-tests/Likely Bugs/Conversion/LossyFunctionResultCast/test.cpp
@@ -1,0 +1,88 @@
+
+typedef long double MYLD;
+
+bool getBool();
+int getInt();
+float getFloat();
+double getDouble();
+MYLD getMyLD();
+float *getFloatPtr();
+float &getFloatRef();
+const float &getConstFloatRef();
+
+void setPosInt(int x);
+void setPosFloat(float x);
+
+double round(double x);
+float roundf(float x);
+
+void test1()
+{
+	// simple
+
+	if (getBool())
+	{
+		setPosInt(getBool());
+		setPosFloat(getBool());
+	}
+	if (getInt())
+	{
+		setPosInt(getInt());
+		setPosFloat(getInt());
+	}
+	if (getFloat()) // BAD
+	{
+		setPosInt(getFloat()); // BAD
+		setPosFloat(getFloat());
+	}
+	if (getDouble()) // BAD
+	{
+		setPosInt(getDouble()); // BAD
+		setPosFloat(getDouble());
+	}
+	if (getMyLD()) // BAD
+	{
+		setPosInt(getMyLD()); // BAD
+		setPosFloat(getMyLD());
+	}
+	if (getFloatPtr())
+	{
+		// ...
+	}
+	if (getFloatRef()) // BAD [NOT DETECTED]
+	{
+		setPosInt(getFloatRef()); // BAD [NOT DETECTED]
+		setPosFloat(getFloatRef());
+	}
+	if (getConstFloatRef()) // BAD [NOT DETECTED]
+	{
+		setPosInt(getConstFloatRef()); // BAD [NOT DETECTED]
+		setPosFloat(getConstFloatRef());
+	}
+
+	// explicit cast
+
+	if ((bool)getInt())
+	{
+		setPosInt(getInt());
+		setPosFloat((float)getInt());
+	}
+	if ((bool)getFloat())
+	{
+		setPosInt((int)getFloat());
+		setPosFloat(getFloat());
+	}
+
+	// explicit rounding
+
+	if (roundf(getFloat())) // [FALSE POSITIVE]
+	{
+		setPosInt(roundf(getFloat())); // [FALSE POSITIVE]
+		setPosFloat(roundf(getFloat()));
+	}
+	if (round(getDouble()))
+	{
+		setPosInt(round(getDouble()));
+		setPosFloat(round(getDouble()));
+	}
+}

--- a/cpp/ql/test/query-tests/Likely Bugs/Conversion/LossyFunctionResultCast/test.cpp
+++ b/cpp/ql/test/query-tests/Likely Bugs/Conversion/LossyFunctionResultCast/test.cpp
@@ -106,14 +106,26 @@ int test2(double v, double w, int n)
 	};
 }
 
-double myRound(double v)
+double myRound1(double v)
+{
+	return round(v);
+}
+
+double myRound2(double v)
 {
 	double result = round(v);
 
 	return result;
 }
 
+double myRound3(double v)
+{
+	return (v > 0) ? round(v) : 0;
+}
+
 void test3()
 {
-	int i = myRound(1.5); // GOOD
+	int i = myRound1(1.5); // GOOD
+	int j = myRound2(2.5); // GOOD
+	int k = myRound3(3.5); // GOOD [FALSE POSITIVE]
 }

--- a/cpp/ql/test/query-tests/Likely Bugs/Conversion/LossyFunctionResultCast/test.cpp
+++ b/cpp/ql/test/query-tests/Likely Bugs/Conversion/LossyFunctionResultCast/test.cpp
@@ -94,9 +94,9 @@ int test2(double v, double w, int n)
 	switch (n)
 	{
 	case 1:
-		return pow(2, v); // GOOD [FALSE POSITIVE]
+		return pow(2, v); // GOOD
 	case 2:
-		return pow(10, v); // GOOD [FALSE POSITIVE]
+		return pow(10, v); // GOOD
 	case 3:
 		return pow(2.5, v); // BAD
 	case 4:

--- a/cpp/ql/test/query-tests/Likely Bugs/Conversion/LossyFunctionResultCast/test.cpp
+++ b/cpp/ql/test/query-tests/Likely Bugs/Conversion/LossyFunctionResultCast/test.cpp
@@ -75,9 +75,9 @@ void test1()
 
 	// explicit rounding
 
-	if (roundf(getFloat())) // [FALSE POSITIVE]
+	if (roundf(getFloat()))
 	{
-		setPosInt(roundf(getFloat())); // [FALSE POSITIVE]
+		setPosInt(roundf(getFloat()));
 		setPosFloat(roundf(getFloat()));
 	}
 	if (round(getDouble()))

--- a/cpp/ql/test/query-tests/Likely Bugs/Conversion/LossyFunctionResultCast/test.cpp
+++ b/cpp/ql/test/query-tests/Likely Bugs/Conversion/LossyFunctionResultCast/test.cpp
@@ -127,5 +127,5 @@ void test3()
 {
 	int i = myRound1(1.5); // GOOD
 	int j = myRound2(2.5); // GOOD
-	int k = myRound3(3.5); // GOOD [FALSE POSITIVE]
+	int k = myRound3(3.5); // GOOD
 }

--- a/cpp/ql/test/query-tests/Likely Bugs/Conversion/LossyFunctionResultCast/test.cpp
+++ b/cpp/ql/test/query-tests/Likely Bugs/Conversion/LossyFunctionResultCast/test.cpp
@@ -115,5 +115,5 @@ double myRound(double v)
 
 void test3()
 {
-	int i = myRound(1.5); // GOOD [FALSE POSITIVE]
+	int i = myRound(1.5); // GOOD
 }


### PR DESCRIPTION
Added test, qhelp and tags to this query.  Fixed some false positives.  It appears to produce generally good results (despite the comment that was in the `@description`), so I've given it a `medium` precision - which will result on it being run on LGTM but not displayed by default.  If this part turns out to be controversial I can reduce the precision to `low` or delete it.

@jbj - I'd like your opinion on the precision tag.
@Semmle/doc - please review and make suggestions on the new `qhelp`.