### PR TITLE
C#: Improve performance of `cs/useless-upcast`

### DIFF
--- a/csharp/ql/src/Language Abuse/UselessUpcast.ql
+++ b/csharp/ql/src/Language Abuse/UselessUpcast.ql
@@ -118,8 +118,9 @@ class ExplicitUpcast extends ExplicitCast {
   }
 
   pragma [nomagic]
-  private predicate isDisambiguatingStaticCall0(StaticCall c, StaticCallable target, ValueOrRefType t) {
+  private predicate isDisambiguatingStaticCall0(StaticCall c, StaticCallable target, string name, ValueOrRefType t) {
     this.isArgument(c, target) and
+    name = target.getName() and
     (
       t = c.(QualifiableExpr).getQualifier().getType()
       or
@@ -131,9 +132,9 @@ class ExplicitUpcast extends ExplicitCast {
   /** Holds if this upcast may be used to disambiguate the target of a static call. */
   pragma [nomagic]
   private predicate isDisambiguatingStaticCall(StaticCallable other, int args) {
-    exists(StaticCall c, StaticCallable target, ValueOrRefType t |
-      this.isDisambiguatingStaticCall0(c, target, t) |
-      hasStaticCallable(t, other, target.getName()) and
+    exists(StaticCall c, StaticCallable target, ValueOrRefType t, string name |
+      this.isDisambiguatingStaticCall0(c, target, name, t) |
+      hasStaticCallable(t, other, name) and
       args = c.getNumberOfArguments() and
       other != target
     )


### PR DESCRIPTION
Before (on `monodevelop`):
```
[2018-12-11 16:51:48] (37s) Starting to evaluate predicate UselessUpcast::ExplicitUpcast::isDisambiguatingStaticCall#fff
[2018-12-11 16:51:48] (37s) Evaluating to sink of kind 
[2018-12-11 17:01:41] (630s) Tuple counts:
                      3313790    ~0%     {3} r1 = SCAN UselessUpcast::hasStaticCallable#fff OUTPUT FIELDS {UselessUpcast::hasStaticCallable#fff.<2>,UselessUpcast::hasStaticCallable#fff.<0>,UselessUpcast::hasStaticCallable#fff.<1>}
                      5855238615 ~3%     {4} r2 = JOIN r1 WITH Element::NamedElement::getName_dispred#ff_10#join_rhs ON r1.<0>=Element::NamedElement::getName_dispred#ff_10#join_rhs.<0> OUTPUT FIELDS {r1.<1>,r1.<2>,r1.<0>,Element::NamedElement::getName_dispred#ff_10#join_rhs.<1>}
                      5851924825 ~3%     {4} r3 = SELECT r2 ON r2.<3> != r2.<1>
                      5851924825 ~0%     {3} r4 = SCAN r3 OUTPUT FIELDS {r3.<3>,r3.<0>,r3.<1>}
                      2385       ~0%     {3} r5 = JOIN r4 WITH UselessUpcast::ExplicitUpcast::isDisambiguatingStaticCall0#ffff_2301#join_rhs ON r4.<0>=UselessUpcast::ExplicitUpcast::isDisambiguatingStaticCall0#ffff_2301#join_rhs.<0> AND r4.<1>=UselessUpcast::ExplicitUpcast::isDisambiguatingStaticCall0#ffff_2301#join_rhs.<1> OUTPUT FIELDS {UselessUpcast::ExplicitUpcast::isDisambiguatingStaticCall0#ffff_2301#join_rhs.<3>,r4.<2>,UselessUpcast::ExplicitUpcast::isDisambiguatingStaticCall0#ffff_2301#join_rhs.<2>}
                      2385       ~6%     {3} r6 = JOIN r5 WITH Call::Call::getNumberOfArguments_dispred#ff ON r5.<0>=Call::Call::getNumberOfArguments_dispred#ff.<0> OUTPUT FIELDS {r5.<2>,r5.<1>,Call::Call::getNumberOfArguments_dispred#ff.<1>}
                                         return r6
```
After:
```
[2018-12-11 17:23:10] (725s) Starting to evaluate predicate UselessUpcast::ExplicitUpcast::isDisambiguatingStaticCall#fff
[2018-12-11 17:23:10] (725s) Evaluating to sink of kind 
[2018-12-11 17:23:10] (725s) Tuple counts:
                      73      ~1%     {5} r1 = SCAN UselessUpcast::ExplicitUpcast::isDisambiguatingStaticCall0#fffff OUTPUT FIELDS {UselessUpcast::ExplicitUpcast::isDisambiguatingStaticCall0#fffff.<1>,UselessUpcast::ExplicitUpcast::isDisambiguatingStaticCall0#fffff.<0>,UselessUpcast::ExplicitUpcast::isDisambiguatingStaticCall0#fffff.<2>,UselessUpcast::ExplicitUpcast::isDisambiguatingStaticCall0#fffff.<3>,UselessUpcast::ExplicitUpcast::isDisambiguatingStaticCall0#fffff.<4>}
                      73      ~0%     {5} r2 = JOIN r1 WITH Call::Call::getNumberOfArguments_dispred#ff ON r1.<0>=Call::Call::getNumberOfArguments_dispred#ff.<0> OUTPUT FIELDS {r1.<4>,r1.<3>,Call::Call::getNumberOfArguments_dispred#ff.<1>,r1.<1>,r1.<2>}
                      2458    ~6%     {6} r3 = JOIN r2 WITH UselessUpcast::hasStaticCallable#fff_021#join_rhs ON r2.<0>=UselessUpcast::hasStaticCallable#fff_021#join_rhs.<0> AND r2.<1>=UselessUpcast::hasStaticCallable#fff_021#join_rhs.<1> OUTPUT FIELDS {r2.<2>,r2.<3>,r2.<4>,r2.<1>,r2.<0>,UselessUpcast::hasStaticCallable#fff_021#join_rhs.<2>}
                      2385    ~8%     {6} r4 = SELECT r3 ON r3.<2> != r3.<5>
                      2385    ~6%     {3} r5 = SCAN r4 OUTPUT FIELDS {r4.<1>,r4.<5>,r4.<0>}
                                      return r5
```