### PR TITLE
JavaScript: Avoid more unhelpful magic.

### DIFF
--- a/javascript/ql/src/semmle/javascript/dataflow/Configuration.qll
+++ b/javascript/ql/src/semmle/javascript/dataflow/Configuration.qll
@@ -687,6 +687,7 @@ private predicate flowsTo(PathNode flowsource, DataFlow::Node source,
  * Holds if `nd` is reachable from a source under `cfg` along a path summarized by
  * `summary`.
  */
+pragma[nomagic]
 private predicate reachableFromSource(DataFlow::Node nd, DataFlow::Configuration cfg,
                                       PathSummary summary) {
   exists (FlowLabel lbl |


### PR DESCRIPTION
Helps `CommandInjection` on `node` (312s -> 68s) and `angular-webpack-starter` (266s -> 77s), otherwise no changes to performance.