### PR TITLE
CPP: Fix function pointer/lambda related false positives in 'Resource not released in destructor'

### DIFF
--- a/change-notes/1.20/analysis-cpp.md
+++ b/change-notes/1.20/analysis-cpp.md
@@ -15,6 +15,6 @@
 |----------------------------|------------------------|------------------------------------------------------------------|
 | Suspicious pointer scaling (`cpp/suspicious-pointer-scaling`) | Fewer false positives | False positives involving types that are not uniquely named in the snapshot have been fixed. |
 | Unused static variable (`cpp/unused-static-variable`) | Fewer false positive results | Variables with the attribute `unused` are now excluded from the query. |
-| Resource not released in destructor (`cpp/resource-not-released-in-destructor`) | Fewer false positive results | Fix false positives where a resource is released via a virtual method call. |
+| Resource not released in destructor (`cpp/resource-not-released-in-destructor`) | Fewer false positive results | Fix false positives where a resource is released via a virtual method call, function pointer, or lambda. |
 
 ## Changes to QL libraries

--- a/cpp/ql/src/jsf/4.10 Classes/AV Rule 79.ql
+++ b/cpp/ql/src/jsf/4.10 Classes/AV Rule 79.ql
@@ -167,6 +167,13 @@ predicate unreleasedResource(Resource r, Expr acquire, File f, int acquireLine) 
     and f = acquire.getFile()
     and acquireLine = acquire.getLocation().getStartLine()
 
+    and not exists(ExprCall exprCall |
+      // expression call (function pointer or lambda) with `r` as an
+      // argument, which could release it.
+      exprCall.getAnArgument() = r.getAnAccess() and
+      r.inDestructor(exprCall)
+    )
+
     // check that any destructor for this class has a block; if it doesn't,
     // we must be missing information.
     and forall(Class c, Destructor d |

--- a/cpp/ql/src/jsf/4.10 Classes/AV Rule 79.ql
+++ b/cpp/ql/src/jsf/4.10 Classes/AV Rule 79.ql
@@ -227,6 +227,11 @@ predicate leakedInSameMethod(Resource r, Expr acquire) {
         fc.getQualifier() = r.getAnAccess() or // e.g. `r->setOwner(this)`
         fc = acquire.getAChild*() // e.g. `r = new MyClass(this)`
       )
+    ) or exists(FunctionAccess fa, string kind |
+      // the address of a function that releases `r` is taken (and likely
+      // used to release `r` at some point).
+      r.acquisitionWithRequiredKind(acquire, kind) and
+      fa.getTarget() = r.getAReleaseExpr(kind).getEnclosingFunction()
     )
   )
 }

--- a/cpp/ql/src/jsf/4.10 Classes/AV Rule 79.ql
+++ b/cpp/ql/src/jsf/4.10 Classes/AV Rule 79.ql
@@ -184,7 +184,9 @@ predicate freedInSameMethod(Resource r, Expr acquire) {
   exists(Expr releaseExpr, string kind |
     r.acquisitionWithRequiredKind(acquire, kind) and
     releaseExpr = r.getAReleaseExpr(kind) and
-    releaseExpr.getEnclosingFunction() = acquire.getEnclosingFunction()
+    releaseExpr.getEnclosingFunction().getEnclosingAccessHolder*() = acquire.getEnclosingFunction()
+    	// here, `getEnclosingAccessHolder*` allows us to go from a nested function or lambda
+    	// expression to the class method enclosing it.
   )
 }
 

--- a/cpp/ql/test/query-tests/jsf/4.10 Classes/AV Rule 79/AV Rule 79.expected
+++ b/cpp/ql/test/query-tests/jsf/4.10 Classes/AV Rule 79/AV Rule 79.expected
@@ -10,9 +10,7 @@
 | DeleteThis.cpp:60:3:60:24 | ... = ... | Resource ptr14 is acquired by class MyClass3 but not released anywhere in this class. |
 | DeleteThis.cpp:127:3:127:20 | ... = ... | Resource d is acquired by class MyClass9 but not released anywhere in this class. |
 | ExternalOwners.cpp:49:3:49:20 | ... = ... | Resource a is acquired by class MyScreen but not released anywhere in this class. |
-| Lambda.cpp:7:3:7:21 | ... = ... | Resource r1 is acquired by class testLambda but not released anywhere in this class. |
 | Lambda.cpp:24:3:24:21 | ... = ... | Resource r4 is acquired by class testLambda but not released anywhere in this class. |
-| Lambda.cpp:26:3:26:21 | ... = ... | Resource r5 is acquired by class testLambda but not released anywhere in this class. |
 | Lambda.cpp:29:3:29:21 | ... = ... | Resource r6 is acquired by class testLambda but not released in the destructor. It is released from deleter_for_r6 on line 40, so this function may need to be called from the destructor. |
 | ListDelete.cpp:21:3:21:21 | ... = ... | Resource first is acquired by class MyThingColection but not released anywhere in this class. |
 | NoDestructor.cpp:23:3:23:20 | ... = ... | Resource n is acquired by class MyClass5 but not released anywhere in this class. |

--- a/cpp/ql/test/query-tests/jsf/4.10 Classes/AV Rule 79/AV Rule 79.expected
+++ b/cpp/ql/test/query-tests/jsf/4.10 Classes/AV Rule 79/AV Rule 79.expected
@@ -13,6 +13,8 @@
 | Lambda.cpp:7:3:7:21 | ... = ... | Resource r1 is acquired by class testLambda but not released anywhere in this class. |
 | Lambda.cpp:12:3:12:21 | ... = ... | Resource r2 is acquired by class testLambda but not released anywhere in this class. |
 | Lambda.cpp:24:3:24:21 | ... = ... | Resource r4 is acquired by class testLambda but not released anywhere in this class. |
+| Lambda.cpp:26:3:26:21 | ... = ... | Resource r5 is acquired by class testLambda but not released anywhere in this class. |
+| Lambda.cpp:29:3:29:21 | ... = ... | Resource r6 is acquired by class testLambda but not released in the destructor. It is released from deleter_for_r6 on line 40, so this function may need to be called from the destructor. |
 | ListDelete.cpp:21:3:21:21 | ... = ... | Resource first is acquired by class MyThingColection but not released anywhere in this class. |
 | NoDestructor.cpp:23:3:23:20 | ... = ... | Resource n is acquired by class MyClass5 but not released anywhere in this class. |
 | PlacementNew.cpp:36:3:36:36 | ... = ... | Resource p1 is acquired by class MyTestForPlacementNew but not released anywhere in this class. |

--- a/cpp/ql/test/query-tests/jsf/4.10 Classes/AV Rule 79/AV Rule 79.expected
+++ b/cpp/ql/test/query-tests/jsf/4.10 Classes/AV Rule 79/AV Rule 79.expected
@@ -11,7 +11,6 @@
 | DeleteThis.cpp:127:3:127:20 | ... = ... | Resource d is acquired by class MyClass9 but not released anywhere in this class. |
 | ExternalOwners.cpp:49:3:49:20 | ... = ... | Resource a is acquired by class MyScreen but not released anywhere in this class. |
 | Lambda.cpp:24:3:24:21 | ... = ... | Resource r4 is acquired by class testLambda but not released anywhere in this class. |
-| Lambda.cpp:29:3:29:21 | ... = ... | Resource r6 is acquired by class testLambda but not released in the destructor. It is released from deleter_for_r6 on line 40, so this function may need to be called from the destructor. |
 | ListDelete.cpp:21:3:21:21 | ... = ... | Resource first is acquired by class MyThingColection but not released anywhere in this class. |
 | NoDestructor.cpp:23:3:23:20 | ... = ... | Resource n is acquired by class MyClass5 but not released anywhere in this class. |
 | PlacementNew.cpp:36:3:36:36 | ... = ... | Resource p1 is acquired by class MyTestForPlacementNew but not released anywhere in this class. |

--- a/cpp/ql/test/query-tests/jsf/4.10 Classes/AV Rule 79/AV Rule 79.expected
+++ b/cpp/ql/test/query-tests/jsf/4.10 Classes/AV Rule 79/AV Rule 79.expected
@@ -10,6 +10,9 @@
 | DeleteThis.cpp:60:3:60:24 | ... = ... | Resource ptr14 is acquired by class MyClass3 but not released anywhere in this class. |
 | DeleteThis.cpp:127:3:127:20 | ... = ... | Resource d is acquired by class MyClass9 but not released anywhere in this class. |
 | ExternalOwners.cpp:49:3:49:20 | ... = ... | Resource a is acquired by class MyScreen but not released anywhere in this class. |
+| Lambda.cpp:7:3:7:21 | ... = ... | Resource r1 is acquired by class testLambda but not released anywhere in this class. |
+| Lambda.cpp:12:3:12:21 | ... = ... | Resource r2 is acquired by class testLambda but not released anywhere in this class. |
+| Lambda.cpp:24:3:24:21 | ... = ... | Resource r4 is acquired by class testLambda but not released anywhere in this class. |
 | ListDelete.cpp:21:3:21:21 | ... = ... | Resource first is acquired by class MyThingColection but not released anywhere in this class. |
 | NoDestructor.cpp:23:3:23:20 | ... = ... | Resource n is acquired by class MyClass5 but not released anywhere in this class. |
 | PlacementNew.cpp:36:3:36:36 | ... = ... | Resource p1 is acquired by class MyTestForPlacementNew but not released anywhere in this class. |

--- a/cpp/ql/test/query-tests/jsf/4.10 Classes/AV Rule 79/AV Rule 79.expected
+++ b/cpp/ql/test/query-tests/jsf/4.10 Classes/AV Rule 79/AV Rule 79.expected
@@ -11,7 +11,6 @@
 | DeleteThis.cpp:127:3:127:20 | ... = ... | Resource d is acquired by class MyClass9 but not released anywhere in this class. |
 | ExternalOwners.cpp:49:3:49:20 | ... = ... | Resource a is acquired by class MyScreen but not released anywhere in this class. |
 | Lambda.cpp:7:3:7:21 | ... = ... | Resource r1 is acquired by class testLambda but not released anywhere in this class. |
-| Lambda.cpp:12:3:12:21 | ... = ... | Resource r2 is acquired by class testLambda but not released anywhere in this class. |
 | Lambda.cpp:24:3:24:21 | ... = ... | Resource r4 is acquired by class testLambda but not released anywhere in this class. |
 | Lambda.cpp:26:3:26:21 | ... = ... | Resource r5 is acquired by class testLambda but not released anywhere in this class. |
 | Lambda.cpp:29:3:29:21 | ... = ... | Resource r6 is acquired by class testLambda but not released in the destructor. It is released from deleter_for_r6 on line 40, so this function may need to be called from the destructor. |

--- a/cpp/ql/test/query-tests/jsf/4.10 Classes/AV Rule 79/Lambda.cpp
+++ b/cpp/ql/test/query-tests/jsf/4.10 Classes/AV Rule 79/Lambda.cpp
@@ -26,7 +26,7 @@ public:
 		r5 = new char[4096]; // GOOD
 		deleter5 = &deleter_for_r5;
 
-		r6 = new char[4096]; // GOOD [FALSE POSITIVE]
+		r6 = new char[4096]; // GOOD
 		deleter6 = &testLambda::deleter_for_r6;
 	}
 

--- a/cpp/ql/test/query-tests/jsf/4.10 Classes/AV Rule 79/Lambda.cpp
+++ b/cpp/ql/test/query-tests/jsf/4.10 Classes/AV Rule 79/Lambda.cpp
@@ -22,15 +22,35 @@ public:
 		deleter3(); 
 
 		r4 = new char[4096]; // BAD
+
+		r5 = new char[4096]; // GOOD [FALSE POSITIVE]
+		deleter5 = &deleter_for_r5;
+
+		r6 = new char[4096]; // GOOD [FALSE POSITIVE]
+		deleter6 = &testLambda::deleter_for_r6;
+	}
+
+	static void deleter_for_r5(char *r)
+	{
+		delete [] r;
+	}
+
+	void deleter_for_r6()
+	{
+		delete [] r6;
 	}
 
 	~testLambda()
 	{
 		deleter1(r1);
+		deleter5(r5);
+		((*this).*deleter6)();
 	}
 
 private:
-	char *r1, *r2, *r3, *r4;
+	char *r1, *r2, *r3, *r4, *r5, *r6;
 
-	void (*deleter1)(char *r); 
+	void (*deleter1)(char *r);
+	void (*deleter5)(char *r);
+	void (testLambda::*deleter6)();
 };

--- a/cpp/ql/test/query-tests/jsf/4.10 Classes/AV Rule 79/Lambda.cpp
+++ b/cpp/ql/test/query-tests/jsf/4.10 Classes/AV Rule 79/Lambda.cpp
@@ -1,0 +1,36 @@
+
+class testLambda
+{
+public:
+	testLambda()
+	{
+		r1 = new char[4096]; // GOOD [FALSE POSITIVE]
+		deleter1 = [](char *r) {
+			delete [] r;
+		};
+
+		r2 = new char[4096]; // GOOD [FALSE POSITIVE]
+		auto deleter2 = [this]() {
+			delete [] r2;
+		};
+		deleter2();
+
+		r3 = new char[4096]; // GOOD
+		auto deleter3 = [&r = r3]() {
+			delete [] r;
+		};
+		deleter3(); 
+
+		r4 = new char[4096]; // BAD
+	}
+
+	~testLambda()
+	{
+		deleter1(r1);
+	}
+
+private:
+	char *r1, *r2, *r3, *r4;
+
+	void (*deleter1)(char *r); 
+};

--- a/cpp/ql/test/query-tests/jsf/4.10 Classes/AV Rule 79/Lambda.cpp
+++ b/cpp/ql/test/query-tests/jsf/4.10 Classes/AV Rule 79/Lambda.cpp
@@ -4,7 +4,7 @@ class testLambda
 public:
 	testLambda()
 	{
-		r1 = new char[4096]; // GOOD [FALSE POSITIVE]
+		r1 = new char[4096]; // GOOD
 		deleter1 = [](char *r) {
 			delete [] r;
 		};
@@ -23,7 +23,7 @@ public:
 
 		r4 = new char[4096]; // BAD
 
-		r5 = new char[4096]; // GOOD [FALSE POSITIVE]
+		r5 = new char[4096]; // GOOD
 		deleter5 = &deleter_for_r5;
 
 		r6 = new char[4096]; // GOOD [FALSE POSITIVE]

--- a/cpp/ql/test/query-tests/jsf/4.10 Classes/AV Rule 79/Lambda.cpp
+++ b/cpp/ql/test/query-tests/jsf/4.10 Classes/AV Rule 79/Lambda.cpp
@@ -9,7 +9,7 @@ public:
 			delete [] r;
 		};
 
-		r2 = new char[4096]; // GOOD [FALSE POSITIVE]
+		r2 = new char[4096]; // GOOD
 		auto deleter2 = [this]() {
 			delete [] r2;
 		};


### PR DESCRIPTION
Add some tests and fix several types of false positives in this query related to function pointers and lambdas.  I've also renamed some things in the query as the terminology used had become inconsistent.