### PR TITLE
C#: Cache `NamedElement::getLabel()`

### DIFF
--- a/csharp/ql/src/Likely Bugs/Collections/ContainerLengthCmpOffByOne.ql
+++ b/csharp/ql/src/Likely Bugs/Collections/ContainerLengthCmpOffByOne.ql
@@ -20,10 +20,10 @@ import semmle.code.csharp.commons.ComparisonTest
 class IndexGuard extends ComparisonTest {
   VariableAccess indexAccess;
   Variable array;
-  
+
   IndexGuard() {
     this.getFirstArgument() = indexAccess and
-    this.getSecondArgument() = any(PropertyAccess lengthAccess | 
+    this.getSecondArgument() = any(PropertyAccess lengthAccess |
       lengthAccess.getQualifier() = array.getAnAccess() and
       lengthAccess.getTarget().hasName("Length")
     )
@@ -50,7 +50,7 @@ from IndexGuard incorrectGuard, Variable array, Variable index, ElementAccess ea
 where
   // Look for `index <= array.Length` or `array.Length >= index`
   incorrectGuard.controls(array, index) and
-  incorrectGuard.isIncorrect() and 
+  incorrectGuard.isIncorrect() and
   // Look for `array[index]`
   ea.getQualifier() = array.getAnAccess() and
   ea.getIndex(0) = indexAccess and

--- a/csharp/ql/src/Security Features/CWE-730/ReDoS.ql
+++ b/csharp/ql/src/Security Features/CWE-730/ReDoS.ql
@@ -19,7 +19,7 @@ from TaintTrackingConfiguration c, DataFlow::PathNode source, DataFlow::PathNode
 where
   c.hasFlowPath(source, sink) and
   // No global timeout set
-  not exists(RegexGlobalTimeout r) and 
+  not exists(RegexGlobalTimeout r) and
   (
     sink.getNode() instanceof Sink
     or

--- a/csharp/ql/src/Security Features/CWE-937/Vulnerabilities.qll
+++ b/csharp/ql/src/Security Features/CWE-937/Vulnerabilities.qll
@@ -1,6 +1,6 @@
 /**
  * Provides a list of NuGet packages with known vulnerabilities.
- * 
+ *
  * To add a new vulnerability follow the existing pattern.
  * Create a new class that extends the abstract class `Vulnerability`,
  * supplying the name and the URL, and override one (or both) of
@@ -73,9 +73,9 @@ class MicrosoftAdvisory4021279 extends Vulnerability {
 
 class CVE_2017_8700 extends Vulnerability {
   CVE_2017_8700() { this = "CVE-2017-8700" }
-  
+
   override string getUrl() { result = "https://github.com/aspnet/Announcements/issues/279" }
-  
+
   override predicate matchesRange(string name, Version affected, Version fixed) {
     (
       name = "Microsoft.AspNetCore.Mvc.Core"
@@ -91,9 +91,9 @@ class CVE_2017_8700 extends Vulnerability {
 
 class CVE_2018_0765 extends Vulnerability {
   CVE_2018_0765() { this = "CVE-2018-0765" }
-  
+
   override string getUrl() { result = "https://github.com/dotnet/announcements/issues/67" }
-  
+
   override predicate matchesRange(string name, Version affected, Version fixed) {
     name = "System.Security.Cryptography.Xml" and
     affected = "0.0.0" and
@@ -103,7 +103,7 @@ class CVE_2018_0765 extends Vulnerability {
 
 class AspNetCore_Mar18 extends Vulnerability {
   AspNetCore_Mar18() { this = "ASPNETCore-Mar18" }
-  
+
   override string getUrl() { result = "https://github.com/aspnet/Announcements/issues/300" }
 
   override predicate matchesRange(string name, Version affected, Version fixed) {
@@ -125,9 +125,9 @@ class AspNetCore_Mar18 extends Vulnerability {
 
 class CVE_2018_8409 extends Vulnerability {
   CVE_2018_8409() { this = "CVE-2018-8409" }
-  
+
   override string getUrl() { result = "https://github.com/aspnet/Announcements/issues/316" }
-  
+
   override predicate matchesRange(string name, Version affected, Version fixed) {
     name = "System.IO.Pipelines" and affected = "4.5.0" and fixed = "4.5.1"
     or
@@ -138,9 +138,9 @@ class CVE_2018_8409 extends Vulnerability {
 
 class CVE_2018_8171 extends Vulnerability {
   CVE_2018_8171() { this = "CVE-2018-8171" }
-  
+
   override string getUrl() { result = "https://github.com/aspnet/Announcements/issues/310" }
-  
+
   override predicate matchesRange(string name, Version affected, Version fixed) {
     name = "Microsoft.AspNetCore.Identity" and (
       affected = "1.0.0" and fixed = "1.0.6"
@@ -204,7 +204,7 @@ class CVE_2018_8356 extends Vulnerability {
 
 class ASPNETCore_Jul18 extends Vulnerability {
   ASPNETCore_Jul18() { this = "ASPNETCore-July18" }
-  
+
   override string getUrl() { result = "https://github.com/aspnet/Announcements/issues/311" }
 
   override predicate matchesRange(string name, Version affected, Version fixed) {

--- a/csharp/ql/src/semmle/code/csharp/controlflow/Guards.qll
+++ b/csharp/ql/src/semmle/code/csharp/controlflow/Guards.qll
@@ -286,7 +286,7 @@ class DereferenceableExpr extends Expr {
           ie = any(IsTypeExpr ite | ite.getCheckedType() = ite.getExpr().getType()) and
           branch = false and
           isNull = true
-        ) 
+        )
       )
       or
       this.hasNullableType() and
@@ -1189,7 +1189,7 @@ module Internal {
         g1 = cond and
         v1 = v.getDualValue() and
         (
-          // g1 === g2 ? e : ...; 
+          // g1 === g2 ? e : ...;
           g2 = cond.getCondition() and
           v2 = TBooleanValue(branch.booleanNot())
           or

--- a/csharp/ql/src/semmle/code/dotnet/Element.qll
+++ b/csharp/ql/src/semmle/code/dotnet/Element.qll
@@ -80,6 +80,7 @@ class NamedElement extends Element, @dotnet_named_element {
   }
 
   /** Gets a unique string label for this element. */
+  cached
   string getLabel() { none() }
 
   /**

--- a/csharp/ql/test/library-tests/cil/regressions/Methods.cs
+++ b/csharp/ql/test/library-tests/cil/regressions/Methods.cs
@@ -3,7 +3,7 @@
  * This tests the correct extraction of F<T>, and we should end up with
  * 2 constructed methods of F<T>.
  */
- 
+
 // semmle-extractor-options: --cil
 
 namespace Methods

--- a/csharp/ql/test/query-tests/Likely Bugs/Collections/ContainerLengthCmpOffByOne/ContainerLengthCmpOffByOne.cs
+++ b/csharp/ql/test/query-tests/Likely Bugs/Collections/ContainerLengthCmpOffByOne/ContainerLengthCmpOffByOne.cs
@@ -48,7 +48,7 @@ class Test
     }
 
     void Test3(string[] args)
-    {    
+    {
         // GOOD: Guarded by ternary operator.
         for (int i = 0; i <= args.Length; i++)
         {
@@ -68,7 +68,7 @@ class Test
     }
 
     void Test5(string[] args)
-    {  
+    {
         // GOOD: A valid test of Length.
         for (int i = 0; i != args.Length; i++)
         {
@@ -94,6 +94,6 @@ class Test
         for (int i = 0; i <= args.Length; i++)
         {
             bool b = i == args.Length || args[i] == "x";
-        }        
+        }
     }
 }

--- a/csharp/ql/test/query-tests/Security Features/CWE-937/csproj.config
+++ b/csharp/ql/test/query-tests/Security Features/CWE-937/csproj.config
@@ -5,12 +5,12 @@
     <PackageReference Include="System.Net.Http" Version="4.3.4" />
     <PackageReference Include="System.Text.Encodings.Web" Version="4.2.9" />
     <PackageReference Include="System.Text.Encodings.Web" Version="4.3.1" />
-    
+
     <!-- These are BAD -->
     <PackageReference Include="System.Text.Encodings.Web" Version="4.3.0" />
     <PackageReference Include="system.text.encodings.web" Version="4.3" />
     <PackageReference Include="System.Net.Http" Version="4.1.1" />
     <PackageReference Include="System.Net.Http" Version="4.1.2" />
-    
+
   </ItemGroup>
 </Project>

--- a/csharp/ql/test/query-tests/Security Features/CWE-937/packages.config
+++ b/csharp/ql/test/query-tests/Security Features/CWE-937/packages.config
@@ -4,7 +4,7 @@
   <package id="System.IO.Pipelines" version="4.5.1" targetFramework="net45" />
   <package id="System.IO.Pipelines" version="4.5.1.0" targetFramework="net45" />
   <package id="Microsoft.AspNetCore.All" version="2.0.9" targetFramework="net45" />
-  
+
   <!-- These are BAD -->
   <package id="System.IO.Pipelines" version="4.5.0" targetFramework="net45" />
   <package id="System.IO.Pipelines" version="4.5.0.0" targetFramework="net45" />


### PR DESCRIPTION
Also includes two other minor changes.

The reason for caching `getLabel()` is that it can take quite a while to compute, and it may be recomputed between query runs. Once we have https://github.com/Semmle/ql/pull/590 in (for the 1.20 release), this change will be redundant, but there there is no harm in caching `getLabel()` for future uses.