### PR TITLE
C#: Extract stackalloc initializers

### DIFF
--- a/change-notes/1.20/analysis-csharp.md
+++ b/change-notes/1.20/analysis-csharp.md
@@ -17,6 +17,8 @@
 
 ## Changes to code extraction
 
+* Initializers of `stackalloc` arrays are now extracted.
+
 ## Changes to QL libraries
 
 ## Changes to the autobuilder

--- a/csharp/extractor/Semmle.Extraction.CSharp/Entities/Expressions/ArrayCreation.cs
+++ b/csharp/extractor/Semmle.Extraction.CSharp/Entities/Expressions/ArrayCreation.cs
@@ -9,7 +9,7 @@ namespace Semmle.Extraction.CSharp.Entities.Expressions
         protected ArrayCreation(ExpressionNodeInfo info) : base(info) { }
     }
 
-    abstract class ExplicitArrayCreation<T> : ArrayCreation<T> where T:ExpressionSyntax
+    abstract class ExplicitArrayCreation<SyntaxNode> : ArrayCreation<SyntaxNode> where SyntaxNode : ExpressionSyntax
     {
         protected ExplicitArrayCreation(ExpressionNodeInfo info) : base(info.SetKind(ExprKind.ARRAY_CREATION)) { }
 

--- a/csharp/extractor/Semmle.Extraction.CSharp/Entities/Expressions/ArrayCreation.cs
+++ b/csharp/extractor/Semmle.Extraction.CSharp/Entities/Expressions/ArrayCreation.cs
@@ -13,16 +13,16 @@ namespace Semmle.Extraction.CSharp.Entities.Expressions
     {
         protected ExplicitArrayCreation(ExpressionNodeInfo info) : base(info.SetKind(ExprKind.ARRAY_CREATION)) { }
 
-        public abstract ArrayTypeSyntax TypeSyntax { get; }
+        protected abstract ArrayTypeSyntax TypeSyntax { get; }
 
         public abstract InitializerExpressionSyntax  Initializer { get;  }
 
         protected override void Populate()
         {
             var child = 0;
-            bool explicitlySized = false;
+            var explicitlySized = false;
 
-            if(TypeSyntax is null)
+            if (TypeSyntax is null)
             {
                 cx.ModelError(Syntax, "Array has unexpected type syntax");
             }
@@ -33,7 +33,7 @@ namespace Semmle.Extraction.CSharp.Entities.Expressions
                 {
                     // Create an expression which simulates the explicit size of the array
 
-                    if (Initializer != null)
+                    if (!(Initializer is null))
                     {
                         // An implicitly-sized array must have an initializer.
                         // Guard it just in case.
@@ -59,7 +59,7 @@ namespace Semmle.Extraction.CSharp.Entities.Expressions
                 }
                 child++;
             }
-            if (Initializer != null)
+            if (!(Initializer is null))
             {
                 ArrayInitializer.Create(new ExpressionNodeInfo(cx, Initializer, this, -1));
             }
@@ -73,7 +73,7 @@ namespace Semmle.Extraction.CSharp.Entities.Expressions
     {
         private NormalArrayCreation(ExpressionNodeInfo info) : base(info) { }
 
-        public override ArrayTypeSyntax TypeSyntax => Syntax.Type;
+        protected override ArrayTypeSyntax TypeSyntax => Syntax.Type;
 
         public override InitializerExpressionSyntax Initializer => Syntax.Initializer;
 
@@ -84,7 +84,7 @@ namespace Semmle.Extraction.CSharp.Entities.Expressions
     {
         StackAllocArrayCreation(ExpressionNodeInfo info) : base(info) { }
 
-        public override ArrayTypeSyntax TypeSyntax => Syntax.Type as ArrayTypeSyntax;
+        protected override ArrayTypeSyntax TypeSyntax => Syntax.Type as ArrayTypeSyntax;
 
         public override InitializerExpressionSyntax Initializer => Syntax.Initializer;
 

--- a/csharp/extractor/Semmle.Extraction.CSharp/Entities/Expressions/Factory.cs
+++ b/csharp/extractor/Semmle.Extraction.CSharp/Entities/Expressions/Factory.cs
@@ -86,7 +86,7 @@ namespace Semmle.Extraction.CSharp.Entities.Expressions
                         return ExplicitObjectCreation.Create(info);
 
                     case SyntaxKind.ArrayCreationExpression:
-                        return ExplicitArrayCreation.Create(info);
+                        return NormalArrayCreation.Create(info);
 
                     case SyntaxKind.ObjectInitializerExpression:
                         return ObjectInitializer.Create(info);

--- a/csharp/ql/test/library-tests/csharp7.3/ArrayCreations.expected
+++ b/csharp/ql/test/library-tests/csharp7.3/ArrayCreations.expected
@@ -1,0 +1,6 @@
+| csharp73.cs:9:20:9:49 | array creation of type Char* | 0 | csharp73.cs:9:20:9:49 | 2 |
+| csharp73.cs:10:20:10:45 | array creation of type Char* | 0 | csharp73.cs:10:36:10:36 | 1 |
+| csharp73.cs:11:20:11:37 | array creation of type Char[] | 0 | csharp73.cs:11:20:11:37 | 1 |
+| csharp73.cs:12:20:12:38 | array creation of type Char* | 0 | csharp73.cs:12:36:12:37 | 10 |
+| csharp73.cs:13:20:13:31 | array creation of type Char[] | 0 | csharp73.cs:13:29:13:30 | 10 |
+| csharp73.cs:21:23:21:33 | array creation of type Int32[] | 0 | csharp73.cs:21:31:21:32 | 10 |

--- a/csharp/ql/test/library-tests/csharp7.3/ArrayCreations.ql
+++ b/csharp/ql/test/library-tests/csharp7.3/ArrayCreations.ql
@@ -1,0 +1,4 @@
+import csharp
+
+from ArrayCreation creation, int i
+select creation, i, creation.getLengthArgument(i)

--- a/csharp/ql/test/library-tests/csharp7.3/ArrayElements.expected
+++ b/csharp/ql/test/library-tests/csharp7.3/ArrayElements.expected
@@ -1,0 +1,4 @@
+| csharp73.cs:9:20:9:49 | array creation of type Char* | 0 | csharp73.cs:9:40:9:42 | x |
+| csharp73.cs:9:20:9:49 | array creation of type Char* | 1 | csharp73.cs:9:45:9:47 | y |
+| csharp73.cs:10:20:10:45 | array creation of type Char* | 0 | csharp73.cs:10:41:10:43 | x |
+| csharp73.cs:11:20:11:37 | array creation of type Char[] | 0 | csharp73.cs:11:33:11:35 | x |

--- a/csharp/ql/test/library-tests/csharp7.3/ArrayElements.ql
+++ b/csharp/ql/test/library-tests/csharp7.3/ArrayElements.ql
@@ -1,0 +1,4 @@
+import csharp
+
+from ArrayCreation array, int i
+select array, i, array.getInitializer().getElement(i)

--- a/csharp/ql/test/library-tests/csharp7.3/csharp73.cs
+++ b/csharp/ql/test/library-tests/csharp7.3/csharp73.cs
@@ -1,0 +1,52 @@
+// semmle-extractor-options: /langversion:latest
+
+using System;
+
+class StackAllocs
+{
+    unsafe void Fn()
+    {
+        var arr1 = stackalloc char[] { 'x', 'y' };
+        var arr2 = stackalloc char[1] { 'x' };
+        var arr3 = new char[] { 'x' };
+        var arr4 = stackalloc char[10];
+        var arr5 = new char[10];
+    }
+}
+
+class PinnedReference
+{
+    unsafe void F()
+    {
+        Span<int> t = new int[10];
+        // This line should compile and generate a call to t.GetPinnableReference()
+        // fixed (int * p = t)
+        {
+        }
+    }
+}
+
+class UnmanagedConstraint<T> where T : unmanaged
+{
+}
+
+class EnumConstraint<T> where T : System.Enum
+{
+}
+
+class DelegateConstraint<T> where T : System.Delegate
+{
+}
+
+class ExpressionVariables
+{
+    ExpressionVariables(out int x)
+    {
+        x = 5;
+    }
+
+    public ExpressionVariables() : this(out int x)
+    {
+        Console.WriteLine($"x is {x}");
+    }
+}


### PR DESCRIPTION
Extracts expressions of the form
```
stackalloc int[] { 1, 2, 3 }
```
This is a C# 7.3 feature.

Previously, the extractor failed since it didn't handle the implicit size `[]`, and it didn't extract the initializer list `{ 1, 2, 3 }`.

The dbscheme doesn't currently distinguish between `new` arrays and `stackalloc` arrays - this is work for the future. The test code covers some additional 7.3 features which currently just check that the extractor doesn't fail.