### PR TITLE
C++: Fix name clash in data flow imports

### DIFF
--- a/cpp/ql/src/filters/ImportAdditionalLibraries.ql
+++ b/cpp/ql/src/filters/ImportAdditionalLibraries.ql
@@ -9,15 +9,21 @@
 
 import cpp
 
-import semmle.code.cpp.dataflow.DataFlow
-import semmle.code.cpp.dataflow.DataFlow2
-import semmle.code.cpp.dataflow.DataFlow3
-import semmle.code.cpp.dataflow.DataFlow4
-import semmle.code.cpp.dataflow.TaintTracking
-import semmle.code.cpp.ir.dataflow.DataFlow
-import semmle.code.cpp.ir.dataflow.DataFlow2
-import semmle.code.cpp.ir.dataflow.DataFlow3
-import semmle.code.cpp.ir.dataflow.DataFlow4
+module ASTDataFlow {
+  import semmle.code.cpp.dataflow.DataFlow
+  import semmle.code.cpp.dataflow.DataFlow2
+  import semmle.code.cpp.dataflow.DataFlow3
+  import semmle.code.cpp.dataflow.DataFlow4
+  import semmle.code.cpp.dataflow.TaintTracking
+}
+
+module IRDataFlow {
+  import semmle.code.cpp.ir.dataflow.DataFlow
+  import semmle.code.cpp.ir.dataflow.DataFlow2
+  import semmle.code.cpp.ir.dataflow.DataFlow3
+  import semmle.code.cpp.ir.dataflow.DataFlow4
+}
+
 import semmle.code.cpp.valuenumbering.HashCons
 
 from File f, string tag


### PR DESCRIPTION
The AST-based data flow libraries and the IR-based ones both define modules `DataFlow`, `DataFlow2`, etc. This caused `ImportAdditionalLibraries.ql` to fail in compilation.