### PR TITLE
CPP: Fix false positive in SuspiciousAddWithSizeof.ql

### DIFF
--- a/change-notes/1.20/analysis-cpp.md
+++ b/change-notes/1.20/analysis-cpp.md
@@ -13,6 +13,7 @@
 
 | **Query**                  | **Expected impact**    | **Change**                                                       |
 |----------------------------|------------------------|------------------------------------------------------------------|
+| Suspicious add with sizeof (`cpp/suspicious-add-sizeof`) | Fewer false positives | Pointer arithmetic on `char * const` expressions (and other variations of `char *`) are now correctly excluded from the results. |
 | Suspicious pointer scaling (`cpp/suspicious-pointer-scaling`) | Fewer false positives | False positives involving types that are not uniquely named in the snapshot have been fixed. |
 | Unused static variable (`cpp/unused-static-variable`) | Fewer false positive results | Variables with the attribute `unused` are now excluded from the query. |
 | Resource not released in destructor (`cpp/resource-not-released-in-destructor`) | Fewer false positive results | Fix false positives where a resource is released via a virtual method call. |

--- a/cpp/ql/src/Security/CWE/CWE-468/SuspiciousAddWithSizeof.ql
+++ b/cpp/ql/src/Security/CWE/CWE-468/SuspiciousAddWithSizeof.ql
@@ -15,9 +15,9 @@ import IncorrectPointerScalingCommon
 
 private predicate isCharSzPtrExpr(Expr e) {
   exists (PointerType pt
-  | pt = e.getFullyConverted().getUnderlyingType()
-  | pt.getBaseType().getUnspecifiedType() instanceof CharType
-  or pt.getBaseType().getUnspecifiedType() instanceof VoidType)
+  | pt = e.getFullyConverted().getType().getUnspecifiedType()
+  | pt.getBaseType() instanceof CharType
+  or pt.getBaseType() instanceof VoidType)
 }
 
 from Expr sizeofExpr, Expr e

--- a/cpp/ql/test/query-tests/Security/CWE/CWE-468/semmle/SuspiciousAddWithSizeof/SuspiciousAddWithSizeof.expected
+++ b/cpp/ql/test/query-tests/Security/CWE/CWE-468/semmle/SuspiciousAddWithSizeof/SuspiciousAddWithSizeof.expected
@@ -4,5 +4,4 @@
 | test.cpp:30:25:30:35 | sizeof(int) | Suspicious sizeof offset in a pointer arithmetic expression. The type of the pointer is int *. |
 | test.cpp:38:30:38:40 | sizeof(int) | Suspicious sizeof offset in a pointer arithmetic expression. The type of the pointer is int *. |
 | test.cpp:61:27:61:37 | sizeof(int) | Suspicious sizeof offset in a pointer arithmetic expression. The type of the pointer is int *. |
-| test.cpp:88:35:88:47 | sizeof(MyABC) | Suspicious sizeof offset in a pointer arithmetic expression. The type of the pointer is myChar *const. |
 | test.cpp:89:40:89:52 | sizeof(MyABC) | Suspicious sizeof offset in a pointer arithmetic expression. The type of the pointer is myInt *const. |

--- a/cpp/ql/test/query-tests/Security/CWE/CWE-468/semmle/SuspiciousAddWithSizeof/SuspiciousAddWithSizeof.expected
+++ b/cpp/ql/test/query-tests/Security/CWE/CWE-468/semmle/SuspiciousAddWithSizeof/SuspiciousAddWithSizeof.expected
@@ -4,4 +4,4 @@
 | test.cpp:30:25:30:35 | sizeof(int) | Suspicious sizeof offset in a pointer arithmetic expression. The type of the pointer is int *. |
 | test.cpp:38:30:38:40 | sizeof(int) | Suspicious sizeof offset in a pointer arithmetic expression. The type of the pointer is int *. |
 | test.cpp:61:27:61:37 | sizeof(int) | Suspicious sizeof offset in a pointer arithmetic expression. The type of the pointer is int *. |
-| test.cpp:89:40:89:52 | sizeof(MyABC) | Suspicious sizeof offset in a pointer arithmetic expression. The type of the pointer is myInt *const. |
+| test.cpp:89:43:89:55 | sizeof(MyABC) | Suspicious sizeof offset in a pointer arithmetic expression. The type of the pointer is myInt *const. |

--- a/cpp/ql/test/query-tests/Security/CWE/CWE-468/semmle/SuspiciousAddWithSizeof/SuspiciousAddWithSizeof.expected
+++ b/cpp/ql/test/query-tests/Security/CWE/CWE-468/semmle/SuspiciousAddWithSizeof/SuspiciousAddWithSizeof.expected
@@ -4,3 +4,5 @@
 | test.cpp:30:25:30:35 | sizeof(int) | Suspicious sizeof offset in a pointer arithmetic expression. The type of the pointer is int *. |
 | test.cpp:38:30:38:40 | sizeof(int) | Suspicious sizeof offset in a pointer arithmetic expression. The type of the pointer is int *. |
 | test.cpp:61:27:61:37 | sizeof(int) | Suspicious sizeof offset in a pointer arithmetic expression. The type of the pointer is int *. |
+| test.cpp:88:35:88:47 | sizeof(MyABC) | Suspicious sizeof offset in a pointer arithmetic expression. The type of the pointer is myChar *const. |
+| test.cpp:89:40:89:52 | sizeof(MyABC) | Suspicious sizeof offset in a pointer arithmetic expression. The type of the pointer is myInt *const. |

--- a/cpp/ql/test/query-tests/Security/CWE/CWE-468/semmle/SuspiciousAddWithSizeof/test.cpp
+++ b/cpp/ql/test/query-tests/Security/CWE/CWE-468/semmle/SuspiciousAddWithSizeof/test.cpp
@@ -64,3 +64,32 @@ void test7(int i) {
   v = *(int *)(voidPointer + i); // GOOD (actually rather dubious, but this could be correct code)
   v = *(int *)(voidPointer + (i * sizeof(int))); // GOOD
 }
+
+typedef unsigned long size_t;
+
+void *malloc(size_t size);
+
+class MyABC
+{
+public:
+  int a, b, c;
+};
+
+typedef unsigned char myChar;
+typedef unsigned int myInt;
+
+class MyTest8Class
+{
+public:
+  MyTest8Class() :
+    pairPtr((myChar *)malloc(sizeof(MyABC) * 2)),
+    pairPtrInt((myInt *)malloc(sizeof(MyABC) * 2))
+  {
+    myChar *secondPtr = pairPtr + sizeof(MyABC); // GOOD [FALSE POSITIVE]
+    myInt *secondPtrInt = pairPtrInt + sizeof(MyABC); // BAD
+  }
+
+private:
+  myChar * const pairPtr;
+  myInt * const pairPtrInt;
+};

--- a/cpp/ql/test/query-tests/Security/CWE/CWE-468/semmle/SuspiciousAddWithSizeof/test.cpp
+++ b/cpp/ql/test/query-tests/Security/CWE/CWE-468/semmle/SuspiciousAddWithSizeof/test.cpp
@@ -85,7 +85,7 @@ public:
     pairPtr((myChar *)malloc(sizeof(MyABC) * 2)),
     pairPtrInt((myInt *)malloc(sizeof(MyABC) * 2))
   {
-    myChar *secondPtr = pairPtr + sizeof(MyABC); // GOOD [FALSE POSITIVE]
+    myChar *secondPtr = pairPtr + sizeof(MyABC); // GOOD
     myInt *secondPtrInt = pairPtrInt + sizeof(MyABC); // BAD
   }
 

--- a/cpp/ql/test/query-tests/Security/CWE/CWE-468/semmle/SuspiciousAddWithSizeof/test.cpp
+++ b/cpp/ql/test/query-tests/Security/CWE/CWE-468/semmle/SuspiciousAddWithSizeof/test.cpp
@@ -82,14 +82,14 @@ class MyTest8Class
 {
 public:
   MyTest8Class() :
-    pairPtr((myChar *)malloc(sizeof(MyABC) * 2)),
-    pairPtrInt((myInt *)malloc(sizeof(MyABC) * 2))
+    myCharsPointer((myChar *)malloc(sizeof(MyABC) * 2)),
+    myIntsPointer((myInt *)malloc(sizeof(MyABC) * 2))
   {
-    myChar *secondPtr = pairPtr + sizeof(MyABC); // GOOD
-    myInt *secondPtrInt = pairPtrInt + sizeof(MyABC); // BAD
+    myChar *secondPtr = myCharsPointer + sizeof(MyABC); // GOOD
+    myInt *secondPtrInt = myIntsPointer + sizeof(MyABC); // BAD
   }
 
 private:
-  myChar * const pairPtr;
-  myInt * const pairPtrInt;
+  myChar * const myCharsPointer;
+  myInt * const myIntsPointer;
 };


### PR DESCRIPTION
The query was not stripping types correctly when determining whether they are essentially `char *`.

Fixes this false positive: https://lgtm.com/projects/g/NVIDIAGameWorks/PhysX-3.4/snapshot/7824041cdbe617fcb8d905c36bdb0db06c77a75c/files/PhysX_3.4/Source/LowLevelCloth/src/StackAllocator.h?sort=name&dir=ASC&mode=heatmap#L112

(I haven't found any other results that are affected)