### PR TITLE
C++: Fix all prepareQueries errors and warnings

### DIFF
--- a/cpp/ql/src/Metrics/queries.xml
+++ b/cpp/ql/src/Metrics/queries.xml
@@ -1,1 +1,0 @@
-<queries language="cpp"/>

--- a/cpp/ql/src/semmle/code/cpp/commons/Environment.qll
+++ b/cpp/ql/src/semmle/code/cpp/commons/Environment.qll
@@ -34,11 +34,5 @@ private predicate readsEnvironment(Expr read, string sourceDescription) {
     read = call and
     call.getTarget().hasGlobalName(name) and
     (name = "getenv" or name = "secure_getenv" or name = "_wgetenv") and
-    sourceDescription = name) or
-  exists(MessageExpr getObjectKey, MessageExpr getEnviron |
-    read = getObjectKey and
-    getObjectKey.getTarget().getQualifiedName().matches("NSDictionary%::-objectForKey:") and
-    getObjectKey.getQualifier() = getEnviron and
-    getEnviron.getTarget().getQualifiedName().matches("NSProcessInfo%:-environment") and
-    sourceDescription = "NSProcessInfo")
+    sourceDescription = name)
 }

--- a/cpp/ql/src/semmle/code/cpp/security/CommandExecution.qll
+++ b/cpp/ql/src/semmle/code/cpp/security/CommandExecution.qll
@@ -203,18 +203,5 @@ predicate shellCommand(Expr command, string callChain) {
     and arrayInitializer.getChild(idx) = command
     and shellCommandPreface(commandInterpreter.getValue(), flag.getValue())
     and idx > 1)
-      
-  // Creation of NSTask
-  or exists(
-    MessageExpr launchedTaskCall, TextLiteral commandInterpreter,
-    Expr arrayLiteral, TextLiteral flag
-  |
-    launchedTaskCall.getStaticTarget().getQualifiedName().matches("NSTask%::+launchedTaskWithLaunchPath:arguments:")
-    and commandInterpreter = launchedTaskCall.getArgument(0)
-    and arrayLiteral = launchedTaskCall.getArgument(1)
-    and arrayElement(arrayLiteral, 0, flag)
-    and arrayElement(arrayLiteral, 1, command)
-    and shellCommandPreface(commandInterpreter.getValue(), flag.getValue())
-    and callChain = "NSTask")
 }
 

--- a/cpp/ql/src/semmle/code/cpp/security/SensitiveExprs.qll
+++ b/cpp/ql/src/semmle/code/cpp/security/SensitiveExprs.qll
@@ -35,25 +35,3 @@ class SensitiveCall extends SensitiveExpr {
     )
   } 
 }
-
-class SensitivePropAccess extends SensitiveExpr {
-  SensitivePropAccess() {
-    exists (PropertyAccess acc, string name |
-      acc = this and
-      name = acc.getProperty().getName().toLowerCase() and
-      name.matches(suspicious()) and
-      not name.matches(nonSuspicious()))
-  }
-}
-
-/**
- * A read from the value of a text widget.
- */
-class SensitiveTextRead extends SensitiveExpr {
-  SensitiveTextRead() {
-    exists (PropertyAccess facc |
-      facc = this and
-      facc.getReceiver() instanceof SensitiveExpr and
-      facc.getProperty().getName() = "text")
-  }
-}

--- a/cpp/ql/src/semmle/code/cpp/security/TaintTracking.qll
+++ b/cpp/ql/src/semmle/code/cpp/security/TaintTracking.qll
@@ -238,21 +238,12 @@ predicate insideFunctionValueMoveTo(Element src, Element dest)
       returnArgument(c.getTarget(), sourceArg)
       and src = c.getArgument(sourceArg)
       and dest = c)
-    or exists (MessageExpr send |
-      methodReturningAnyArgument(send.getStaticTarget())
-      and not send instanceof FormattingFunctionCall
-      and src = send.getAnArgument()
-      and dest = send)
     or exists(FormattingFunctionCall formattingSend, int arg, FormatLiteral format, string argFormat |
       dest = formattingSend
       and formattingSend.getArgument(arg) = src
       and format = formattingSend.getFormat()
       and format.getConversionChar(arg - formattingSend.getTarget().getNumberOfParameters()) = argFormat
       and (argFormat = "s" or argFormat = "S" or argFormat = "@"))
-    or exists (ExprMessageExpr send |
-      methodReturningReceiver(send.getStaticTarget())
-      and src = send.getReceiver()
-      and dest = send)
     // Expressions computed from tainted data are also tainted
     or (exists (FunctionCall call | dest = call and isPureFunction(call.getTarget().getName()) |
       call.getAnArgument() = src
@@ -455,60 +446,6 @@ private predicate returnArgument(Function f, int sourceArg)
   or (f.hasGlobalName("inet_netof") and sourceArg = 0)
   or (f.hasGlobalName("gethostbyname") and sourceArg = 0)
   or (f.hasGlobalName("gethostbyaddr") and sourceArg = 0)
-}
-
-/** A method where if any argument is tainted, the return value should be, too */
-private predicate methodReturningAnyArgument(MemberFunction method) {
-  method.getQualifiedName().matches("NS%Array%::+array%") or
-  method.getQualifiedName().matches("NS%Array%::-arrayBy%") or
-  method.getQualifiedName().matches("NS%Array%::-componentsJoinedByString:") or
-  method.getQualifiedName().matches("NS%Array%::-init%") or
-  method.getQualifiedName().matches("NS%Data%::+dataWith%") or
-  method.getQualifiedName().matches("NS%Data%::-initWith%") or
-  method.getQualifiedName().matches("NS%String%::+pathWithComponents:") or
-  method.getQualifiedName().matches("NS%String%::+stringWith%") or
-  method.getQualifiedName().matches("NS%String%::-initWithCString:") or
-  method.getQualifiedName().matches("NS%String%::-initWithCString:length:") or
-  method.getQualifiedName().matches("NS%String%::-initWithCStringNoCopy:length:") or
-  method.getQualifiedName().matches("NS%String%::-initWithCharacters:length:") or
-  method.getQualifiedName().matches("NS%String%::-initWithCharactersNoCopy:length:freeWhenDone:") or
-  method.getQualifiedName().matches("NS%String%::-initWithFormat:") or
-  method.getQualifiedName().matches("NS%String%::-initWithFormat:arguments:") or
-  method.getQualifiedName().matches("NS%String%::-initWithString:") or
-  method.getQualifiedName().matches("NS%String%::-initWithUTF8String:") or
-  method.getQualifiedName().matches("NS%String%::-stringByAppendingFormat:") or
-  method.getQualifiedName().matches("NS%String%::-stringByAppendingString:") or
-  method.getQualifiedName().matches("NS%String%::-stringByPaddingToLength:withString:startingAtIndex:") or
-  method.getQualifiedName().matches("NS%String%::-stringByReplacing%") or
-  method.getQualifiedName().matches("NS%String%::-stringsByAppendingPaths:")
-}
-
-/** A method where if the receiver is tainted, the return value should be, too */
-private predicate methodReturningReceiver(MemberFunction method) {
-  method.getQualifiedName().matches("NS%Array%::-arrayBy%") or
-  method.getQualifiedName().matches("NS%Array%::-componentsJoinedByString:") or
-  method.getQualifiedName().matches("NS%Array%::-firstObject") or
-  method.getQualifiedName().matches("NS%Array%::-lastObject") or
-  method.getQualifiedName().matches("NS%Array%::-objectAt%") or
-  method.getQualifiedName().matches("NS%Array%::-pathsMatchingExtensions:") or
-  method.getQualifiedName().matches("NS%Array%::-sortedArray%") or
-  method.getQualifiedName().matches("NS%Array%::-subarrayWithRange:") or
-  method.getQualifiedName().matches("NS%Data%::-bytes") or
-  method.getQualifiedName().matches("NS%Data%::-subdataWithRange:") or
-  method.getQualifiedName().matches("NS%String%::-capitalizedString%") or
-  method.getQualifiedName().matches("NS%String%::-componentsSeparatedByCharactersInSet:") or
-  method.getQualifiedName().matches("NS%String%::-componentsSeparatedByString:") or
-  method.getQualifiedName().matches("NS%String%::-cStringUsingEncoding:") or
-  method.getQualifiedName().matches("NS%String%::-dataUsingEncoding:%") or
-  method.getQualifiedName().matches("NS%String%::-lowercaseString%") or
-  method.getQualifiedName().matches("NS%String%::-pathComponents") or
-  method.getQualifiedName().matches("NS%String%::-stringBy%") or
-  method.getQualifiedName().matches("NS%String%::-stringsByAppendingPaths:") or
-  method.getQualifiedName().matches("NS%String%::-substringFromIndex:") or
-  method.getQualifiedName().matches("NS%String%::-substringToIndex:") or
-  method.getQualifiedName().matches("NS%String%::-substringWithRange:") or
-  method.getQualifiedName().matches("NS%String%::-uppercaseString%") or
-  method.getQualifiedName().matches("NS%String%::-UTF8String")
 }
 
 /**


### PR DESCRIPTION
With these changes we can run `odasa prepareQueries --check-only
--fail-on-warnings` on the C++ query directory. Two changes were needed:

1. The `Metrics/queries.xml` file had to be deleted. It existed because
   the built distribution has a different file layout, where `Metrics`
   is moved to the top-level query dir `odasa-cpp-metrics`. Since
   internal PR 28230 this file is created as needed as part of the dist
   build process, so it doesn't need to be checked in with the sources.
2. All uses of the `deprecated` and stubbed-out Objective C classes were
   removed.