### PR TITLE
JS: fix FPs in UselessConditional

### DIFF
--- a/javascript/ql/src/Statements/UselessConditional.ql
+++ b/javascript/ql/src/Statements/UselessConditional.ql
@@ -124,7 +124,7 @@ predicate isExplicitConditional(ASTNode cond, Expr e) {
  * `e` and checks its value for truthiness.
  *
  * The return value of `e` may have other uses besides the truthiness check,
- * but if the truthiness check is always goes one way, it still indicates an error.
+ * but if the truthiness check always goes one way, it still indicates an error.
  */
 predicate isConditional(ASTNode cond, Expr e) {
   isExplicitConditional(cond, e) or

--- a/javascript/ql/test/query-tests/Statements/UselessConditional/UselessConditional.expected
+++ b/javascript/ql/test/query-tests/Statements/UselessConditional/UselessConditional.expected
@@ -21,6 +21,7 @@
 | UselessConditional.js:101:18:101:18 | x | This use of variable 'x' always evaluates to false. |
 | UselessConditional.js:102:19:102:19 | x | This use of variable 'x' always evaluates to false. |
 | UselessConditional.js:103:23:103:23 | x | This use of variable 'x' always evaluates to false. |
+| UselessConditional.js:109:15:109:16 | {} | This expression always evaluates to true. |
 | UselessConditionalGood.js:58:12:58:13 | x2 | This use of variable 'x2' always evaluates to false. |
 | UselessConditionalGood.js:69:12:69:13 | xy | This use of variable 'xy' always evaluates to false. |
 | UselessConditionalGood.js:85:12:85:13 | xy | This use of variable 'xy' always evaluates to false. |

--- a/javascript/ql/test/query-tests/Statements/UselessConditional/UselessConditional.js
+++ b/javascript/ql/test/query-tests/Statements/UselessConditional/UselessConditional.js
@@ -104,4 +104,9 @@ async function awaitFlow(){
     }
 });
 
+(function(x,y) {
+    let obj = (x && {}) || y; // OK
+    if ((x && {}) || y) {} // NOT OK
+});
+
 // semmle-extractor-options: --experimental


### PR DESCRIPTION
Fixes [these false positives](https://lgtm.com/projects/g/devhubapp/devhub/alerts/?mode=tree&ruleFocus=7860090).

For a code snippet like this,
```javascript
let obj = (x && {}) || y;
```
we would report that `{}` always evaluates to `true`, but `{}` also gets stored in `obj`, so the alert is moot.

We now distinguish between conditionals that *only* use the expression for the purpose of a branch from those that also use it for something else.