### PR TITLE
JS: remove slow test Security/heuristics/AdditionalCommandInjections

### DIFF
--- a/javascript/ql/test/library-tests/Security/heuristics/AdditionalCommandInjections.expected
+++ b/javascript/ql/test/library-tests/Security/heuristics/AdditionalCommandInjections.expected
@@ -1,1 +1,0 @@
-| additionalCommandInjections.js:2:11:2:45 | "prgm - ... place() | additionalCommandInjections.js:2:28:2:35 | password |

--- a/javascript/ql/test/library-tests/Security/heuristics/AdditionalCommandInjections.ql
+++ b/javascript/ql/test/library-tests/Security/heuristics/AdditionalCommandInjections.ql
@@ -1,9 +1,0 @@
-import javascript
-import semmle.javascript.security.dataflow.CommandInjection::CommandInjection
-
-private import semmle.javascript.heuristics.all
-// tests that the imports above changes the behavior of the standard taint tracking query
-
-from Configuration cfg, Source source, Sink sink
-where cfg.hasFlow(source, sink)
-select sink, source

--- a/javascript/ql/test/library-tests/Security/heuristics/HeuristicSink.expected
+++ b/javascript/ql/test/library-tests/Security/heuristics/HeuristicSink.expected
@@ -1,4 +1,3 @@
-| additionalCommandInjections.js:2:11:2:45 | "prgm - ... place() |
 | sinks.js:2:14:2:17 | sink |
 | sinks.js:3:5:3:17 | script + sink |
 | sinks.js:4:9:4:12 | sink |

--- a/javascript/ql/test/library-tests/Security/heuristics/HeuristicSource.expected
+++ b/javascript/ql/test/library-tests/Security/heuristics/HeuristicSource.expected
@@ -1,3 +1,2 @@
-| additionalCommandInjections.js:2:28:2:35 | password |
 | sources.js:2:5:2:12 | password |
 | sources.js:3:5:3:20 | JSON.stringify() |

--- a/javascript/ql/test/library-tests/Security/heuristics/additionalCommandInjections.js
+++ b/javascript/ql/test/library-tests/Security/heuristics/additionalCommandInjections.js
@@ -1,3 +1,0 @@
-(function() {
-    o.run("prgm --pass " + password.replace())
-})();


### PR DESCRIPTION
This change simply removes an unimportant test that may take a very long time to compile. (c.f. <https://semmle.slack.com/archives/C6XSL9C4U/p1544698798119300>)