### PR TITLE
Java: Add missing override annotations.

### DIFF
--- a/java/ql/src/Metrics/Internal/Extents.qll
+++ b/java/ql/src/Metrics/Internal/Extents.qll
@@ -15,7 +15,7 @@ import java
  * including the body (if any), as opposed to the location of its name only.
  */
 class RangeCallable extends Callable {
-  predicate hasLocationInfo(string path, int sl, int sc, int el, int ec) {
+  override predicate hasLocationInfo(string path, int sl, int sc, int el, int ec) {
     exists(int elSuper, int ecSuper | super.hasLocationInfo(path, sl, sc, elSuper, ecSuper) |
       this.getBody().hasLocationInfo(path, _, _, el, ec)
       or
@@ -39,7 +39,7 @@ class RangeCallable extends Callable {
  * including the range of its members (if any), as opposed to the location of its name only.
  */
 class RangeRefType extends RefType {
-  predicate hasLocationInfo(string path, int sl, int sc, int el, int ec) {
+  override predicate hasLocationInfo(string path, int sl, int sc, int el, int ec) {
     exists(int elSuper, int ecSuper | super.hasLocationInfo(path, sl, sc, elSuper, ecSuper) |
       lastMember().hasLocationInfo(path, _, _, el, ec)
       or

--- a/java/ql/src/external/CodeDuplication.qll
+++ b/java/ql/src/external/CodeDuplication.qll
@@ -51,11 +51,13 @@ class Copy extends @duplication_or_similarity {
 }
 
 class DuplicateBlock extends Copy, @duplication {
-  string toString() { result = "Duplicate code: " + sourceLines() + " duplicated lines." }
+  override string toString() { result = "Duplicate code: " + sourceLines() + " duplicated lines." }
 }
 
 class SimilarBlock extends Copy, @similarity {
-  string toString() { result = "Similar code: " + sourceLines() + " almost duplicated lines." }
+  override string toString() {
+    result = "Similar code: " + sourceLines() + " almost duplicated lines."
+  }
 }
 
 Method sourceMethod() { hasLocation(result, _) and numlines(result, _, _, _) }


### PR DESCRIPTION
A few files had slipped through the cracks when this was originally turned into a warning.