### PR TITLE
C++: Improve optimiser performance

### DIFF
--- a/cpp/ql/src/semmle/code/cpp/ir/implementation/raw/internal/TranslatedExpr.qll
+++ b/cpp/ql/src/semmle/code/cpp/ir/implementation/raw/internal/TranslatedExpr.qll
@@ -959,7 +959,7 @@ class TranslatedFunctionAccess extends TranslatedNonConstantExpr {
 /**
  * IR translation of an expression whose value is not known at compile time.
  */
-abstract class TranslatedNonConstantExpr extends TranslatedCoreExpr {
+abstract class TranslatedNonConstantExpr extends TranslatedCoreExpr, TTranslatedValueExpr {
   TranslatedNonConstantExpr() {
     this = TTranslatedValueExpr(expr) and
     not expr.isConstant()
@@ -971,7 +971,7 @@ abstract class TranslatedNonConstantExpr extends TranslatedCoreExpr {
  * includes not only literals, but also "integral constant expressions" (e.g.
  * `1 + 2`).
  */
-abstract class TranslatedConstantExpr extends TranslatedCoreExpr {
+abstract class TranslatedConstantExpr extends TranslatedCoreExpr, TTranslatedValueExpr {
   TranslatedConstantExpr() {
     this = TTranslatedValueExpr(expr) and
     expr.isConstant()


### PR DESCRIPTION
The IR tests are timing out optimisation tests on some of the slower workers, this improves it quite a bit by simplifying the type hierarchy by adding some extra super types (The optimiser currently doesn't look into the bodies of characteristic predicates to determine type relations so it can't work this out). 