### PR TITLE
JS: whitelist $(location) for xss in simple cases

### DIFF
--- a/change-notes/1.20/analysis-javascript.md
+++ b/change-notes/1.20/analysis-javascript.md
@@ -24,7 +24,7 @@
 
 | **Query**                                  | **Expected impact**          | **Change**                                                                   |
 |--------------------------------------------|------------------------------|------------------------------------------------------------------------------|
-| Client-side cross-site scripting           | More results                 | This rule now recognizes WinJS functions that are vulnerable to HTML injection. |
+| Client-side cross-site scripting           | More true-positive results, fewer false-positive results.                 | This rule now recognizes WinJS functions that are vulnerable to HTML injection, and no longer flags certain safe uses of jQuery. |
 | Insecure randomness | More results | This rule now flags insecure uses of `crypto.pseudoRandomBytes`. |
 | Unused parameter                           | Fewer false-positive results | This rule no longer flags parameters with leading underscore. |
 | Unused variable, import, function or class | Fewer false-positive results | This rule now flags fewer variables that are implictly used by JSX elements, and no longer flags variables with leading underscore. |

--- a/javascript/ql/src/semmle/javascript/security/dataflow/DomBasedXss.qll
+++ b/javascript/ql/src/semmle/javascript/security/dataflow/DomBasedXss.qll
@@ -91,7 +91,8 @@ module DomBasedXss {
           isPrefixOfJQueryHtmlString(astNode, prefix) and
           strval = prefix.asExpr().getStringValue() and
           not strval.regexpMatch("\\s*<.*")
-        )
+        ) and
+        not isDocumentURL(astNode)
       )
       or
       // call to an Angular method that interprets its argument as HTML

--- a/javascript/ql/test/query-tests/Security/CWE-079/StoredXss.expected
+++ b/javascript/ql/test/query-tests/Security/CWE-079/StoredXss.expected
@@ -214,17 +214,8 @@ nodes
 | tst.js:256:7:256:17 | window.name |
 | tst.js:257:7:257:10 | name |
 | tst.js:261:11:261:21 | window.name |
-| tst.js:267:7:267:14 | location |
-| tst.js:268:7:268:21 | window.location |
-| tst.js:269:7:269:23 | document.location |
-| tst.js:270:9:270:23 | loc1 |
-| tst.js:270:16:270:23 | location |
-| tst.js:271:9:271:30 | loc2 |
-| tst.js:271:16:271:30 | window.location |
 | tst.js:272:9:272:32 | loc3 |
 | tst.js:272:16:272:32 | document.location |
-| tst.js:273:7:273:10 | loc1 |
-| tst.js:274:7:274:10 | loc2 |
 | tst.js:275:7:275:10 | loc3 |
 | winjs.js:2:7:2:53 | tainted |
 | winjs.js:2:17:2:33 | document.location |
@@ -408,10 +399,6 @@ edges
 | tst.js:238:23:238:29 | tainted | tst.js:228:32:228:49 | prevProps.tainted4 |
 | tst.js:244:39:244:55 | props.propTainted | tst.js:248:60:248:82 | this.st ... Tainted |
 | tst.js:252:23:252:29 | tainted | tst.js:244:39:244:55 | props.propTainted |
-| tst.js:270:9:270:23 | loc1 | tst.js:273:7:273:10 | loc1 |
-| tst.js:270:16:270:23 | location | tst.js:270:9:270:23 | loc1 |
-| tst.js:271:9:271:30 | loc2 | tst.js:274:7:274:10 | loc2 |
-| tst.js:271:16:271:30 | window.location | tst.js:271:9:271:30 | loc2 |
 | tst.js:272:9:272:32 | loc3 | tst.js:275:7:275:10 | loc3 |
 | tst.js:272:16:272:32 | document.location | tst.js:272:9:272:32 | loc3 |
 | winjs.js:2:7:2:53 | tainted | winjs.js:3:43:3:49 | tainted |

--- a/javascript/ql/test/query-tests/Security/CWE-079/StoredXss.expected
+++ b/javascript/ql/test/query-tests/Security/CWE-079/StoredXss.expected
@@ -214,6 +214,18 @@ nodes
 | tst.js:256:7:256:17 | window.name |
 | tst.js:257:7:257:10 | name |
 | tst.js:261:11:261:21 | window.name |
+| tst.js:267:7:267:14 | location |
+| tst.js:268:7:268:21 | window.location |
+| tst.js:269:7:269:23 | document.location |
+| tst.js:270:9:270:23 | loc1 |
+| tst.js:270:16:270:23 | location |
+| tst.js:271:9:271:30 | loc2 |
+| tst.js:271:16:271:30 | window.location |
+| tst.js:272:9:272:32 | loc3 |
+| tst.js:272:16:272:32 | document.location |
+| tst.js:273:7:273:10 | loc1 |
+| tst.js:274:7:274:10 | loc2 |
+| tst.js:275:7:275:10 | loc3 |
 | winjs.js:2:7:2:53 | tainted |
 | winjs.js:2:17:2:33 | document.location |
 | winjs.js:2:17:2:40 | documen ... .search |
@@ -396,6 +408,12 @@ edges
 | tst.js:238:23:238:29 | tainted | tst.js:228:32:228:49 | prevProps.tainted4 |
 | tst.js:244:39:244:55 | props.propTainted | tst.js:248:60:248:82 | this.st ... Tainted |
 | tst.js:252:23:252:29 | tainted | tst.js:244:39:244:55 | props.propTainted |
+| tst.js:270:9:270:23 | loc1 | tst.js:273:7:273:10 | loc1 |
+| tst.js:270:16:270:23 | location | tst.js:270:9:270:23 | loc1 |
+| tst.js:271:9:271:30 | loc2 | tst.js:274:7:274:10 | loc2 |
+| tst.js:271:16:271:30 | window.location | tst.js:271:9:271:30 | loc2 |
+| tst.js:272:9:272:32 | loc3 | tst.js:275:7:275:10 | loc3 |
+| tst.js:272:16:272:32 | document.location | tst.js:272:9:272:32 | loc3 |
 | winjs.js:2:7:2:53 | tainted | winjs.js:3:43:3:49 | tainted |
 | winjs.js:2:7:2:53 | tainted | winjs.js:4:43:4:49 | tainted |
 | winjs.js:2:17:2:33 | document.location | winjs.js:2:17:2:40 | documen ... .search |

--- a/javascript/ql/test/query-tests/Security/CWE-079/StoredXss.expected
+++ b/javascript/ql/test/query-tests/Security/CWE-079/StoredXss.expected
@@ -217,6 +217,7 @@ nodes
 | tst.js:272:9:272:32 | loc3 |
 | tst.js:272:16:272:32 | document.location |
 | tst.js:275:7:275:10 | loc3 |
+| tst.js:277:22:277:29 | location |
 | winjs.js:2:7:2:53 | tainted |
 | winjs.js:2:17:2:33 | document.location |
 | winjs.js:2:17:2:40 | documen ... .search |

--- a/javascript/ql/test/query-tests/Security/CWE-079/Xss.expected
+++ b/javascript/ql/test/query-tests/Security/CWE-079/Xss.expected
@@ -171,6 +171,18 @@ nodes
 | tst.js:256:7:256:17 | window.name |
 | tst.js:257:7:257:10 | name |
 | tst.js:261:11:261:21 | window.name |
+| tst.js:267:7:267:14 | location |
+| tst.js:268:7:268:21 | window.location |
+| tst.js:269:7:269:23 | document.location |
+| tst.js:270:9:270:23 | loc1 |
+| tst.js:270:16:270:23 | location |
+| tst.js:271:9:271:30 | loc2 |
+| tst.js:271:16:271:30 | window.location |
+| tst.js:272:9:272:32 | loc3 |
+| tst.js:272:16:272:32 | document.location |
+| tst.js:273:7:273:10 | loc1 |
+| tst.js:274:7:274:10 | loc2 |
+| tst.js:275:7:275:10 | loc3 |
 | winjs.js:2:7:2:53 | tainted |
 | winjs.js:2:17:2:33 | document.location |
 | winjs.js:2:17:2:40 | documen ... .search |
@@ -307,6 +319,12 @@ edges
 | tst.js:238:23:238:29 | tainted | tst.js:228:32:228:49 | prevProps.tainted4 |
 | tst.js:244:39:244:55 | props.propTainted | tst.js:248:60:248:82 | this.st ... Tainted |
 | tst.js:252:23:252:29 | tainted | tst.js:244:39:244:55 | props.propTainted |
+| tst.js:270:9:270:23 | loc1 | tst.js:273:7:273:10 | loc1 |
+| tst.js:270:16:270:23 | location | tst.js:270:9:270:23 | loc1 |
+| tst.js:271:9:271:30 | loc2 | tst.js:274:7:274:10 | loc2 |
+| tst.js:271:16:271:30 | window.location | tst.js:271:9:271:30 | loc2 |
+| tst.js:272:9:272:32 | loc3 | tst.js:275:7:275:10 | loc3 |
+| tst.js:272:16:272:32 | document.location | tst.js:272:9:272:32 | loc3 |
 | winjs.js:2:7:2:53 | tainted | winjs.js:3:43:3:49 | tainted |
 | winjs.js:2:7:2:53 | tainted | winjs.js:4:43:4:49 | tainted |
 | winjs.js:2:17:2:33 | document.location | winjs.js:2:17:2:40 | documen ... .search |
@@ -378,5 +396,14 @@ edges
 | tst.js:256:7:256:17 | window.name | tst.js:256:7:256:17 | window.name | tst.js:256:7:256:17 | window.name | Cross-site scripting vulnerability due to $@. | tst.js:256:7:256:17 | window.name | user-provided value |
 | tst.js:257:7:257:10 | name | tst.js:257:7:257:10 | name | tst.js:257:7:257:10 | name | Cross-site scripting vulnerability due to $@. | tst.js:257:7:257:10 | name | user-provided value |
 | tst.js:261:11:261:21 | window.name | tst.js:261:11:261:21 | window.name | tst.js:261:11:261:21 | window.name | Cross-site scripting vulnerability due to $@. | tst.js:261:11:261:21 | window.name | user-provided value |
+| tst.js:267:7:267:14 | location | tst.js:267:7:267:14 | location | tst.js:267:7:267:14 | location | Cross-site scripting vulnerability due to $@. | tst.js:267:7:267:14 | location | user-provided value |
+| tst.js:268:7:268:21 | window.location | tst.js:268:7:268:21 | window.location | tst.js:268:7:268:21 | window.location | Cross-site scripting vulnerability due to $@. | tst.js:268:7:268:21 | window.location | user-provided value |
+| tst.js:269:7:269:23 | document.location | tst.js:269:7:269:23 | document.location | tst.js:269:7:269:23 | document.location | Cross-site scripting vulnerability due to $@. | tst.js:269:7:269:23 | document.location | user-provided value |
+| tst.js:273:7:273:10 | loc1 | tst.js:270:16:270:23 | location | tst.js:273:7:273:10 | loc1 | Cross-site scripting vulnerability due to $@. | tst.js:270:16:270:23 | location | user-provided value |
+| tst.js:273:7:273:10 | loc1 | tst.js:273:7:273:10 | loc1 | tst.js:273:7:273:10 | loc1 | Cross-site scripting vulnerability due to $@. | tst.js:273:7:273:10 | loc1 | user-provided value |
+| tst.js:274:7:274:10 | loc2 | tst.js:271:16:271:30 | window.location | tst.js:274:7:274:10 | loc2 | Cross-site scripting vulnerability due to $@. | tst.js:271:16:271:30 | window.location | user-provided value |
+| tst.js:274:7:274:10 | loc2 | tst.js:274:7:274:10 | loc2 | tst.js:274:7:274:10 | loc2 | Cross-site scripting vulnerability due to $@. | tst.js:274:7:274:10 | loc2 | user-provided value |
+| tst.js:275:7:275:10 | loc3 | tst.js:272:16:272:32 | document.location | tst.js:275:7:275:10 | loc3 | Cross-site scripting vulnerability due to $@. | tst.js:272:16:272:32 | document.location | user-provided value |
+| tst.js:275:7:275:10 | loc3 | tst.js:275:7:275:10 | loc3 | tst.js:275:7:275:10 | loc3 | Cross-site scripting vulnerability due to $@. | tst.js:275:7:275:10 | loc3 | user-provided value |
 | winjs.js:3:43:3:49 | tainted | winjs.js:2:17:2:33 | document.location | winjs.js:3:43:3:49 | tainted | Cross-site scripting vulnerability due to $@. | winjs.js:2:17:2:33 | document.location | user-provided value |
 | winjs.js:4:43:4:49 | tainted | winjs.js:2:17:2:33 | document.location | winjs.js:4:43:4:49 | tainted | Cross-site scripting vulnerability due to $@. | winjs.js:2:17:2:33 | document.location | user-provided value |

--- a/javascript/ql/test/query-tests/Security/CWE-079/Xss.expected
+++ b/javascript/ql/test/query-tests/Security/CWE-079/Xss.expected
@@ -171,17 +171,8 @@ nodes
 | tst.js:256:7:256:17 | window.name |
 | tst.js:257:7:257:10 | name |
 | tst.js:261:11:261:21 | window.name |
-| tst.js:267:7:267:14 | location |
-| tst.js:268:7:268:21 | window.location |
-| tst.js:269:7:269:23 | document.location |
-| tst.js:270:9:270:23 | loc1 |
-| tst.js:270:16:270:23 | location |
-| tst.js:271:9:271:30 | loc2 |
-| tst.js:271:16:271:30 | window.location |
 | tst.js:272:9:272:32 | loc3 |
 | tst.js:272:16:272:32 | document.location |
-| tst.js:273:7:273:10 | loc1 |
-| tst.js:274:7:274:10 | loc2 |
 | tst.js:275:7:275:10 | loc3 |
 | winjs.js:2:7:2:53 | tainted |
 | winjs.js:2:17:2:33 | document.location |
@@ -319,10 +310,6 @@ edges
 | tst.js:238:23:238:29 | tainted | tst.js:228:32:228:49 | prevProps.tainted4 |
 | tst.js:244:39:244:55 | props.propTainted | tst.js:248:60:248:82 | this.st ... Tainted |
 | tst.js:252:23:252:29 | tainted | tst.js:244:39:244:55 | props.propTainted |
-| tst.js:270:9:270:23 | loc1 | tst.js:273:7:273:10 | loc1 |
-| tst.js:270:16:270:23 | location | tst.js:270:9:270:23 | loc1 |
-| tst.js:271:9:271:30 | loc2 | tst.js:274:7:274:10 | loc2 |
-| tst.js:271:16:271:30 | window.location | tst.js:271:9:271:30 | loc2 |
 | tst.js:272:9:272:32 | loc3 | tst.js:275:7:275:10 | loc3 |
 | tst.js:272:16:272:32 | document.location | tst.js:272:9:272:32 | loc3 |
 | winjs.js:2:7:2:53 | tainted | winjs.js:3:43:3:49 | tainted |
@@ -396,14 +383,6 @@ edges
 | tst.js:256:7:256:17 | window.name | tst.js:256:7:256:17 | window.name | tst.js:256:7:256:17 | window.name | Cross-site scripting vulnerability due to $@. | tst.js:256:7:256:17 | window.name | user-provided value |
 | tst.js:257:7:257:10 | name | tst.js:257:7:257:10 | name | tst.js:257:7:257:10 | name | Cross-site scripting vulnerability due to $@. | tst.js:257:7:257:10 | name | user-provided value |
 | tst.js:261:11:261:21 | window.name | tst.js:261:11:261:21 | window.name | tst.js:261:11:261:21 | window.name | Cross-site scripting vulnerability due to $@. | tst.js:261:11:261:21 | window.name | user-provided value |
-| tst.js:267:7:267:14 | location | tst.js:267:7:267:14 | location | tst.js:267:7:267:14 | location | Cross-site scripting vulnerability due to $@. | tst.js:267:7:267:14 | location | user-provided value |
-| tst.js:268:7:268:21 | window.location | tst.js:268:7:268:21 | window.location | tst.js:268:7:268:21 | window.location | Cross-site scripting vulnerability due to $@. | tst.js:268:7:268:21 | window.location | user-provided value |
-| tst.js:269:7:269:23 | document.location | tst.js:269:7:269:23 | document.location | tst.js:269:7:269:23 | document.location | Cross-site scripting vulnerability due to $@. | tst.js:269:7:269:23 | document.location | user-provided value |
-| tst.js:273:7:273:10 | loc1 | tst.js:270:16:270:23 | location | tst.js:273:7:273:10 | loc1 | Cross-site scripting vulnerability due to $@. | tst.js:270:16:270:23 | location | user-provided value |
-| tst.js:273:7:273:10 | loc1 | tst.js:273:7:273:10 | loc1 | tst.js:273:7:273:10 | loc1 | Cross-site scripting vulnerability due to $@. | tst.js:273:7:273:10 | loc1 | user-provided value |
-| tst.js:274:7:274:10 | loc2 | tst.js:271:16:271:30 | window.location | tst.js:274:7:274:10 | loc2 | Cross-site scripting vulnerability due to $@. | tst.js:271:16:271:30 | window.location | user-provided value |
-| tst.js:274:7:274:10 | loc2 | tst.js:274:7:274:10 | loc2 | tst.js:274:7:274:10 | loc2 | Cross-site scripting vulnerability due to $@. | tst.js:274:7:274:10 | loc2 | user-provided value |
 | tst.js:275:7:275:10 | loc3 | tst.js:272:16:272:32 | document.location | tst.js:275:7:275:10 | loc3 | Cross-site scripting vulnerability due to $@. | tst.js:272:16:272:32 | document.location | user-provided value |
-| tst.js:275:7:275:10 | loc3 | tst.js:275:7:275:10 | loc3 | tst.js:275:7:275:10 | loc3 | Cross-site scripting vulnerability due to $@. | tst.js:275:7:275:10 | loc3 | user-provided value |
 | winjs.js:3:43:3:49 | tainted | winjs.js:2:17:2:33 | document.location | winjs.js:3:43:3:49 | tainted | Cross-site scripting vulnerability due to $@. | winjs.js:2:17:2:33 | document.location | user-provided value |
 | winjs.js:4:43:4:49 | tainted | winjs.js:2:17:2:33 | document.location | winjs.js:4:43:4:49 | tainted | Cross-site scripting vulnerability due to $@. | winjs.js:2:17:2:33 | document.location | user-provided value |

--- a/javascript/ql/test/query-tests/Security/CWE-079/Xss.expected
+++ b/javascript/ql/test/query-tests/Security/CWE-079/Xss.expected
@@ -174,6 +174,7 @@ nodes
 | tst.js:272:9:272:32 | loc3 |
 | tst.js:272:16:272:32 | document.location |
 | tst.js:275:7:275:10 | loc3 |
+| tst.js:277:22:277:29 | location |
 | winjs.js:2:7:2:53 | tainted |
 | winjs.js:2:17:2:33 | document.location |
 | winjs.js:2:17:2:40 | documen ... .search |
@@ -384,5 +385,6 @@ edges
 | tst.js:257:7:257:10 | name | tst.js:257:7:257:10 | name | tst.js:257:7:257:10 | name | Cross-site scripting vulnerability due to $@. | tst.js:257:7:257:10 | name | user-provided value |
 | tst.js:261:11:261:21 | window.name | tst.js:261:11:261:21 | window.name | tst.js:261:11:261:21 | window.name | Cross-site scripting vulnerability due to $@. | tst.js:261:11:261:21 | window.name | user-provided value |
 | tst.js:275:7:275:10 | loc3 | tst.js:272:16:272:32 | document.location | tst.js:275:7:275:10 | loc3 | Cross-site scripting vulnerability due to $@. | tst.js:272:16:272:32 | document.location | user-provided value |
+| tst.js:277:22:277:29 | location | tst.js:277:22:277:29 | location | tst.js:277:22:277:29 | location | Cross-site scripting vulnerability due to $@. | tst.js:277:22:277:29 | location | user-provided value |
 | winjs.js:3:43:3:49 | tainted | winjs.js:2:17:2:33 | document.location | winjs.js:3:43:3:49 | tainted | Cross-site scripting vulnerability due to $@. | winjs.js:2:17:2:33 | document.location | user-provided value |
 | winjs.js:4:43:4:49 | tainted | winjs.js:2:17:2:33 | document.location | winjs.js:4:43:4:49 | tainted | Cross-site scripting vulnerability due to $@. | winjs.js:2:17:2:33 | document.location | user-provided value |

--- a/javascript/ql/test/query-tests/Security/CWE-079/tst.js
+++ b/javascript/ql/test/query-tests/Security/CWE-079/tst.js
@@ -262,3 +262,15 @@ function windowNameAssigned() {
         $(name); // OK
     }
 }
+
+function jqueryLocation() {
+    $(location); // OK
+    $(window.location); // OK
+    $(document.location); // OK
+    var loc1 = location;
+    var loc2 = window.location;
+    var loc3 = document.location;
+    $(loc1); // OK
+    $(loc2); // OK
+    $(loc3); // OK
+}

--- a/javascript/ql/test/query-tests/Security/CWE-079/tst.js
+++ b/javascript/ql/test/query-tests/Security/CWE-079/tst.js
@@ -272,5 +272,5 @@ function jqueryLocation() {
     var loc3 = document.location;
     $(loc1); // OK
     $(loc2); // OK
-    $(loc3); // OK
+    $(loc3); // OK - but still flagged
 }

--- a/javascript/ql/test/query-tests/Security/CWE-079/tst.js
+++ b/javascript/ql/test/query-tests/Security/CWE-079/tst.js
@@ -273,4 +273,6 @@ function jqueryLocation() {
     $(loc1); // OK
     $(loc2); // OK
     $(loc3); // OK - but still flagged
+
+    $("body").append(location); // NOT OK
 }


### PR DESCRIPTION
This could be solved more generally with flow labels, but for now I'd like to ensure that this FP goes away in the common case.