### PR TITLE
C#: Improve logic for looking up .NET runtime in standalone mode

### DIFF
--- a/csharp/extractor/Semmle.Extraction.CSharp.Standalone/Runtime.cs
+++ b/csharp/extractor/Semmle.Extraction.CSharp.Standalone/Runtime.cs
@@ -21,7 +21,7 @@ namespace Semmle.Extraction.CSharp.Standalone
         {
             get
             {
-                var dotnetPath = FileUtils.FindExecutableOnPath(Win32.IsWindows() ? "dotnet.exe" : "dotnet");
+                var dotnetPath = FileUtils.FindProgramOnPath(Win32.IsWindows() ? "dotnet.exe" : "dotnet");
                 var dotnetDirs = dotnetPath != null
                     ? new[] { dotnetPath }
                     : new[] { "/usr/share/dotnet", @"C:\Program Files\dotnet" };
@@ -41,7 +41,7 @@ namespace Semmle.Extraction.CSharp.Standalone
         {
             get
             {
-                var monoPath = FileUtils.FindExecutableOnPath(Win32.IsWindows() ? "mono.exe" : "mono");
+                var monoPath = FileUtils.FindProgramOnPath(Win32.IsWindows() ? "mono.exe" : "mono");
                 var monoDirs = monoPath != null
                     ? new[] { monoPath }
                     : new[] { "/usr/lib/mono", @"C:\Program Files\Mono\lib\mono" };

--- a/csharp/extractor/Semmle.Extraction.CSharp.Standalone/Runtime.cs
+++ b/csharp/extractor/Semmle.Extraction.CSharp.Standalone/Runtime.cs
@@ -21,7 +21,7 @@ namespace Semmle.Extraction.CSharp.Standalone
         {
             get
             {
-                var dotnetPath = FileUtils.FindExecutableOnPath("dotnet");
+                var dotnetPath = FileUtils.FindExecutableOnPath(Win32.IsWindows() ? "dotnet.exe" : "dotnet");
                 var dotnetDirs = dotnetPath != null
                     ? new[] { dotnetPath }
                     : new[] { "/usr/share/dotnet", @"C:\Program Files\dotnet" };
@@ -41,7 +41,7 @@ namespace Semmle.Extraction.CSharp.Standalone
         {
             get
             {
-                var monoPath = FileUtils.FindExecutableOnPath("mono");
+                var monoPath = FileUtils.FindExecutableOnPath(Win32.IsWindows() ? "mono.exe" : "mono");
                 var monoDirs = monoPath != null
                     ? new[] { monoPath }
                     : new[] { "/usr/lib/mono", @"C:\Program Files\Mono\lib\mono" };

--- a/csharp/extractor/Semmle.Util/FileUtils.cs
+++ b/csharp/extractor/Semmle.Util/FileUtils.cs
@@ -54,27 +54,29 @@ namespace Semmle.Util
         }
 
         /// <summary>
-        /// Finds the path for the executable <paramref name="exe"/> based on the
+        /// Finds the path for the program <paramref name="prog"/> based on the
         /// <code>PATH</code> environment variable, and in the case of Windows the
         /// <code>PATHEXT</code> environment variable.
         /// 
         /// Returns <code>null</code> of no path can be found.
         /// </summary>
-        public static string FindExecutableOnPath(string exe)
+        public static string FindProgramOnPath(string prog)
         {
-            var paths = Environment.GetEnvironmentVariable("PATH").Split(Path.PathSeparator);
+            var paths = Environment.GetEnvironmentVariable("PATH")?.Split(Path.PathSeparator);
             string[] exes;
             if (Win32.IsWindows())
             {
-                var extensions = Environment.GetEnvironmentVariable("PATHEXT").Split(';').ToArray();
-                exes = extensions.Any(exe.EndsWith) ? new[] { exe } : extensions.Select(ext => exe + ext).ToArray();
+                var extensions = Environment.GetEnvironmentVariable("PATHEXT")?.Split(';')?.ToArray();
+                exes = extensions == null || extensions.Any(prog.EndsWith)
+                    ? new[] { prog }
+                    : extensions.Select(ext => prog + ext).ToArray();
             }
             else
             {
-                exes = new[] { exe };
+                exes = new[] { prog };
             }
-            var candidates = paths.Where(path => exes.Any(exe0 => File.Exists(Path.Combine(path, exe0))));
-            return candidates.FirstOrDefault();
+            var candidates = paths?.Where(path => exes.Any(exe0 => File.Exists(Path.Combine(path, exe0))));
+            return candidates?.FirstOrDefault();
         }
     }
 }

--- a/csharp/extractor/Semmle.Util/FileUtils.cs
+++ b/csharp/extractor/Semmle.Util/FileUtils.cs
@@ -1,4 +1,6 @@
+using System;
 using System.IO;
+using System.Linq;
 
 namespace Semmle.Util
 {
@@ -49,6 +51,24 @@ namespace Semmle.Util
             {
                 // Ignore
             }
+        }
+
+        /// <summary>
+        /// Finds the path for the executable <paramref name="exe"/> based on the
+        /// <code>PATH</code> environment variable, and in the case of Windows the
+        /// <code>PATHEXT</code> environment variable.
+        /// 
+        /// Returns <code>null</code> of no path can be found.
+        /// </summary>
+        public static string FindExecutableOnPath(string exe)
+        {
+            var isWindows = Win32.IsWindows();
+            var paths = Environment.GetEnvironmentVariable("PATH").Split(isWindows ? ';' : ':');
+            var exes = isWindows
+                ? Environment.GetEnvironmentVariable("PATHEXT").Split(';').Select(ext => exe + ext)
+                : new[] { exe };
+            var candidates = paths.Where(path => exes.Any(exe0 => File.Exists(Path.Combine(path, exe0))));
+            return candidates.FirstOrDefault();
         }
     }
 }

--- a/csharp/extractor/Semmle.Util/FileUtils.cs
+++ b/csharp/extractor/Semmle.Util/FileUtils.cs
@@ -62,11 +62,17 @@ namespace Semmle.Util
         /// </summary>
         public static string FindExecutableOnPath(string exe)
         {
-            var isWindows = Win32.IsWindows();
-            var paths = Environment.GetEnvironmentVariable("PATH").Split(isWindows ? ';' : ':');
-            var exes = isWindows
-                ? Environment.GetEnvironmentVariable("PATHEXT").Split(';').Select(ext => exe + ext)
-                : new[] { exe };
+            var paths = Environment.GetEnvironmentVariable("PATH").Split(Path.PathSeparator);
+            string[] exes;
+            if (Win32.IsWindows())
+            {
+                var extensions = Environment.GetEnvironmentVariable("PATHEXT").Split(';').ToArray();
+                exes = extensions.Any(exe.EndsWith) ? new[] { exe } : extensions.Select(ext => exe + ext).ToArray();
+            }
+            else
+            {
+                exes = new[] { exe };
+            }
             var candidates = paths.Where(path => exes.Any(exe0 => File.Exists(Path.Combine(path, exe0))));
             return candidates.FirstOrDefault();
         }


### PR DESCRIPTION
Instead of only considering a fixed set of paths for `dotnet` and `mono`,
first attempt to lookup the paths based on the `PATH` environment variable.
This change also fixes a potential `System.IO.DirectoryNotFoundException` exception,
which could be thrown when the `shared/Microsoft.NETCore.App` folder was not
present.