### PR TITLE
JavaScript: Restructure implementation of `DataFlow::SourceNode`.

### DIFF
--- a/change-notes/1.20/analysis-javascript.md
+++ b/change-notes/1.20/analysis-javascript.md
@@ -33,3 +33,6 @@
 | Uncontrolled data used in path expression | Fewer false-positive results | This rule now recognizes the Express `root` option, which prevents path traversal. |
 
 ## Changes to QL libraries
+
+* `DataFlow::SourceNode` is no longer an abstract class; to add new source nodes, extend `DataFlow::SourceNode::Range` instead.
+* Subclasses of `DataFlow::PropRead` are no longer automatically made source nodes; you now need to additionally define a corresponding subclass of `DataFlow::SourceNode::Range` to achieve this.

--- a/javascript/ql/src/semmle/javascript/EmailClients.qll
+++ b/javascript/ql/src/semmle/javascript/EmailClients.qll
@@ -3,7 +3,7 @@ import javascript
 /**
  * An operation that sends an email.
  */
-abstract class EmailSender extends DataFlow::DefaultSourceNode {
+abstract class EmailSender extends DataFlow::SourceNode {
   /**
    * Gets a data flow node holding the plaintext version of the email body.
    */

--- a/javascript/ql/src/semmle/javascript/StandardLibrary.qll
+++ b/javascript/ql/src/semmle/javascript/StandardLibrary.qll
@@ -76,7 +76,7 @@ private class AnalyzedThisInArrayIterationFunction extends AnalyzedNode, DataFlo
 /**
  * A definition of a `Promise` object.
  */
-abstract class PromiseDefinition extends DataFlow::DefaultSourceNode {
+abstract class PromiseDefinition extends DataFlow::SourceNode {
   /** Gets the executor function of this promise object. */
   abstract DataFlow::FunctionNode getExecutor();
 

--- a/javascript/ql/src/semmle/javascript/dataflow/DataFlow.qll
+++ b/javascript/ql/src/semmle/javascript/dataflow/DataFlow.qll
@@ -516,6 +516,20 @@ module DataFlow {
   abstract class PropRead extends PropRef, SourceNode { }
 
   /**
+   * A property read, considered as a source node.
+   *
+   * Note that we cannot simplify the characteristic predicate to `this instanceof PropRead`,
+   * since `PropRead` is itself a subclass of `SourceNode`.
+   */
+  private class PropReadAsSourceNode extends SourceNode::Range {
+    PropReadAsSourceNode() {
+      this = TPropNode(any(PropertyPattern p)) or
+      this instanceof RestPatternNode or
+      this instanceof ElementPatternNode
+    }
+  }
+
+  /**
    * A property access in rvalue position.
    */
   private class PropRValueAsPropRead extends PropRead, ValueNode {

--- a/javascript/ql/src/semmle/javascript/frameworks/AngularJS/AngularJSCore.qll
+++ b/javascript/ql/src/semmle/javascript/frameworks/AngularJS/AngularJSCore.qll
@@ -45,7 +45,7 @@ private predicate isAngularString(Expr s) {
  * String literals in Angular code are often used as identifiers or references, so we
  * want to track them.
  */
-private class TrackStringsInAngularCode extends DataFlow::SourceNode, DataFlow::ValueNode {
+private class TrackStringsInAngularCode extends DataFlow::SourceNode::Range, DataFlow::ValueNode {
   TrackStringsInAngularCode() { isAngularString(astNode) }
 }
 

--- a/javascript/ql/src/semmle/javascript/frameworks/HTTP.qll
+++ b/javascript/ql/src/semmle/javascript/frameworks/HTTP.qll
@@ -435,6 +435,10 @@ module HTTP {
     abstract DataFlow::Node getASecretKey();
   }
 
+  private class CookieMiddlewareInstanceAsSourceNode extends DataFlow::SourceNode::Range {
+    CookieMiddlewareInstanceAsSourceNode() { this instanceof CookieMiddlewareInstance }
+  }
+
   /**
    * A key used for signed cookies, viewed as a `CryptographicKey`.
    */

--- a/javascript/ql/src/semmle/javascript/frameworks/LodashUnderscore.qll
+++ b/javascript/ql/src/semmle/javascript/frameworks/LodashUnderscore.qll
@@ -14,6 +14,10 @@ module LodashUnderscore {
     abstract string getName();
   }
 
+  private class MemberAsSourceNode extends DataFlow::SourceNode::Range {
+    MemberAsSourceNode() { this instanceof Member }
+  }
+
   /**
    * An import of `lodash` or `underscore` accessing a given member of that package.
    */

--- a/javascript/ql/src/semmle/javascript/frameworks/ReactNative.qll
+++ b/javascript/ql/src/semmle/javascript/frameworks/ReactNative.qll
@@ -6,7 +6,7 @@ import javascript
 
 module ReactNative {
   /** A `WebView` JSX element. */
-  class WebViewElement extends DataFlow::ValueNode, DataFlow::DefaultSourceNode {
+  class WebViewElement extends DataFlow::ValueNode, DataFlow::SourceNode {
     override JSXElement astNode;
 
     WebViewElement() {


### PR DESCRIPTION
It now uses a facade pattern similar to `InvokeNode`: the range of the class is defined by an abstract class `DataFlow::SourceNode::Range`, while the actual behaviour is defined by the (no longer abstract) `SourceNode` class itself.

Clients that want to add new source nodes need to extend `DataFlow::SourceNode::Range`, those that want to refine the behaviour of existing source nodes should extend `DataFlow::SourceNode` itself.

While this is technically a breaking API change, I think separating the two aspects in this way is cleaner and makes it easier to use, and improves [performance](https://git.semmle.com/gist/max/032a0aa577e8f6d9b5a488981cc4f6a3) (internal link) as well.