### PR TITLE
Java: Restrict attention to integral types in IntMultToLong.

### DIFF
--- a/change-notes/1.20/analysis-java.md
+++ b/change-notes/1.20/analysis-java.md
@@ -14,6 +14,7 @@
 
 | **Query**                  | **Expected impact**    | **Change**                                                       |
 |----------------------------|------------------------|------------------------------------------------------------------|
+| Result of multiplication cast to wider type (`java/integer-multiplication-cast-to-long`) | Fewer results | Results involving conversions to `float` or `double` are no longer reported, as they were almost exclusively false positives. |
 
 ## Changes to QL libraries
 

--- a/java/ql/src/Likely Bugs/Arithmetic/IntMultToLong.ql
+++ b/java/ql/src/Likely Bugs/Arithmetic/IntMultToLong.ql
@@ -47,6 +47,8 @@ where
   e.getType() = sourceType and
   c.getConversionTarget() = destType and
   destType.widerThan(sourceType) and
+  // restrict attention to integral types
+  destType instanceof IntegralType and
   // not a trivial conversion
   not c.isTrivial() and
   // not an explicit conversion, which is probably intended by a user

--- a/java/ql/test/query-tests/security/CWE-190/semmle/tests/IntMultToLong.expected
+++ b/java/ql/test/query-tests/security/CWE-190/semmle/tests/IntMultToLong.expected
@@ -1,4 +1,3 @@
 | Test.java:20:23:20:48 | ... * ... | Potential overflow in $@ before it is converted to long by use in an assignment context. | Test.java:20:23:20:48 | ... * ... | int multiplication |
 | Test.java:27:23:27:52 | ... + ... | Potential overflow in $@ before it is converted to long by use in an assignment context. | Test.java:27:23:27:48 | ... * ... | int multiplication |
 | Test.java:34:23:34:63 | ...?...:... | Potential overflow in $@ before it is converted to long by use in an assignment context. | Test.java:34:30:34:55 | ... * ... | int multiplication |
-| Test.java:41:25:41:49 | ... * ... | Potential overflow in $@ before it is converted to double by use in an assignment context. | Test.java:41:25:41:49 | ... * ... | long multiplication |

--- a/java/ql/test/query-tests/security/CWE-190/semmle/tests/Test.java
+++ b/java/ql/test/query-tests/security/CWE-190/semmle/tests/Test.java
@@ -37,7 +37,7 @@ class Test {
 		{
 			long timeInSeconds = 10000000L;
 
-			// BAD: same problem, but with longs
+			// same problem, but with longs; not reported as the conversion to double is not sufficient indication of a large number
 			double timeInNanos = timeInSeconds * 10000000L;
 		}
 


### PR DESCRIPTION
Looking at the results of this query, the results involving conversions to floating point types have considerably lower precision than the integral type results.