### PR TITLE
JavaScript: Two performance improvements

### DIFF
--- a/javascript/ql/src/Statements/UselessConditional.ql
+++ b/javascript/ql/src/Statements/UselessConditional.ql
@@ -18,17 +18,26 @@ import semmle.javascript.dataflow.Refinements
 import semmle.javascript.DefensiveProgramming
 
 /**
+ * Gets the unique definition of `v`.
+ *
+ * If `v` has no definitions or more than one, or if its single definition
+ * is a destructuring assignment, this predicate is undefined.
+ */
+VarDef getSingleDef(Variable v) {
+  strictcount(VarDef vd | vd.getAVariable() = v) = 1 and
+  result.getTarget() = v.getAReference()
+}
+
+/**
  * Holds if variable `v` looks like a symbolic constant, that is, it is assigned
  * exactly once, either in a `const` declaration or with a constant initializer.
  *
  * We do not consider conditionals to be useless if they check a symbolic constant.
  */
 predicate isSymbolicConstant(Variable v) {
-  // defined exactly once
-  count(VarDef vd | vd.getAVariable() = v) = 1 and
-  // the definition is either a `const` declaration or it assigns a constant to it
-  exists(VarDef vd | vd.getAVariable() = v and count(vd.getAVariable()) = 1 |
-    vd.(VariableDeclarator).getDeclStmt() instanceof ConstDeclStmt or
+  exists(VarDef vd | vd = getSingleDef(v) |
+    vd.(VariableDeclarator).getDeclStmt() instanceof ConstDeclStmt
+    or
     isConstant(vd.getSource())
   )
 }

--- a/javascript/ql/src/semmle/javascript/dataflow/internal/FlowSteps.qll
+++ b/javascript/ql/src/semmle/javascript/dataflow/internal/FlowSteps.qll
@@ -20,12 +20,7 @@ predicate shouldTrackProperties(AbstractValue obj) {
 /**
  * Holds if `invk` may invoke `f`.
  */
-predicate calls(DataFlow::InvokeNode invk, Function f) {
-  if invk.isIndefinite("global")
-  then (
-    f = invk.getACallee() and f.getFile() = invk.getFile()
-  ) else f = invk.getACallee()
-}
+predicate calls(DataFlow::InvokeNode invk, Function f) { f = invk.getACallee(0) }
 
 /**
  * Holds if `invk` may invoke `f` indirectly through the given `callback` argument.


### PR DESCRIPTION
This PR bundles two small performance improvements:

  - The first commit factors out a predicate in `UselessConditional`; for most projects this makes no difference, but the query becomes significantly faster on `codemagic` (152s vs 13s), `gecko-dev` (250s vs 132s), `rhino` (42s vs 5s) and `test262` (99s vs 40s)
  - The second commit unifies a few predicates that implement a precise subset of `getACallee` and caches them together with `getACallee` itself

Full evaluation is [here](https://git.semmle.com/gist/max/276417477b42ae8b69021bb949ef89ee) (internal link). Curiously we seem to gain three new true positives from the `js/trivial-conditional` query; not sure how.