### PR TITLE
Java: Reduce precision of java/user-controlled-bypass.

### DIFF
--- a/java/ql/src/Security/CWE/CWE-807/ConditionalBypass.ql
+++ b/java/ql/src/Security/CWE/CWE-807/ConditionalBypass.ql
@@ -4,7 +4,7 @@
  *              passing through authentication systems.
  * @kind path-problem
  * @problem.severity error
- * @precision high
+ * @precision medium
  * @id java/user-controlled-bypass
  * @tags security
  *       external/cwe/cwe-807


### PR DESCRIPTION
This query isn't very precise, so downgrading to `medium`.