### PR TITLE
JS: support 'this' as the root of an access path

### DIFF
--- a/javascript/ql/test/library-tests/TaintTracking/BasicTaintTracking.expected
+++ b/javascript/ql/test/library-tests/TaintTracking/BasicTaintTracking.expected
@@ -14,6 +14,8 @@
 | promise.js:5:25:5:32 | source() | promise.js:5:8:5:33 | bluebir ... urce()) |
 | sanitizer-guards.js:2:11:2:18 | source() | sanitizer-guards.js:4:8:4:8 | x |
 | sanitizer-guards.js:13:14:13:21 | source() | sanitizer-guards.js:15:10:15:15 | this.x |
+| sanitizer-guards.js:13:14:13:21 | source() | sanitizer-guards.js:21:14:21:19 | this.x |
+| sanitizer-guards.js:13:14:13:21 | source() | sanitizer-guards.js:26:9:26:14 | this.x |
 | thisAssignments.js:4:17:4:24 | source() | thisAssignments.js:5:10:5:18 | obj.field |
 | thisAssignments.js:7:19:7:26 | source() | thisAssignments.js:8:10:8:20 | this.field2 |
 | tst.js:2:13:2:20 | source() | tst.js:4:10:4:10 | x |

--- a/javascript/ql/test/library-tests/TaintTracking/BasicTaintTracking.expected
+++ b/javascript/ql/test/library-tests/TaintTracking/BasicTaintTracking.expected
@@ -12,6 +12,8 @@
 | partialCalls.js:4:17:4:24 | source() | partialCalls.js:51:14:51:14 | x |
 | promise.js:4:24:4:31 | source() | promise.js:4:8:4:32 | Promise ... urce()) |
 | promise.js:5:25:5:32 | source() | promise.js:5:8:5:33 | bluebir ... urce()) |
+| sanitizer-guards.js:2:11:2:18 | source() | sanitizer-guards.js:4:8:4:8 | x |
+| sanitizer-guards.js:13:14:13:21 | source() | sanitizer-guards.js:15:10:15:15 | this.x |
 | thisAssignments.js:4:17:4:24 | source() | thisAssignments.js:5:10:5:18 | obj.field |
 | thisAssignments.js:7:19:7:26 | source() | thisAssignments.js:8:10:8:20 | this.field2 |
 | tst.js:2:13:2:20 | source() | tst.js:4:10:4:10 | x |

--- a/javascript/ql/test/library-tests/TaintTracking/BasicTaintTracking.ql
+++ b/javascript/ql/test/library-tests/TaintTracking/BasicTaintTracking.ql
@@ -8,6 +8,18 @@ class BasicConfig extends TaintTracking::Configuration {
   override predicate isSource(DataFlow::Node node) { node = getACall("source") }
 
   override predicate isSink(DataFlow::Node node) { node = getACall("sink").getAnArgument() }
+
+  override predicate isSanitizerGuard(TaintTracking::SanitizerGuardNode node) {
+    node instanceof BasicSanitizerGuard
+  }
+}
+
+class BasicSanitizerGuard extends TaintTracking::SanitizerGuardNode, DataFlow::CallNode {
+  BasicSanitizerGuard() { this = getACall("isSafe") }
+
+  override predicate sanitizes(boolean outcome, Expr e) {
+    outcome = true and e = getArgument(0).asExpr()
+  }
 }
 
 from BasicConfig cfg, DataFlow::Node src, DataFlow::Node sink

--- a/javascript/ql/test/library-tests/TaintTracking/sanitizer-guards.js
+++ b/javascript/ql/test/library-tests/TaintTracking/sanitizer-guards.js
@@ -25,5 +25,16 @@ class C {
     addEventListener('hey', () => {
 	  sink(this.x); // NOT OK
 	});
+
+	let self = this;
+	if (isSafe(self.x)) {
+	  sink(self.x); // OK
+	}
+
+	addEventListener('hey', function() {
+	  if (isSafe(self.x)) {
+	    sink(self.x); // OK
+	  }
+	});
   }
 }

--- a/javascript/ql/test/library-tests/TaintTracking/sanitizer-guards.js
+++ b/javascript/ql/test/library-tests/TaintTracking/sanitizer-guards.js
@@ -1,0 +1,21 @@
+function test() {
+  let x = source();
+  
+  sink(x); // NOT OK
+  
+  if (isSafe(x)) {
+    sink(x); // OK
+  }
+}
+
+class C {
+  method() {
+    this.x = source();
+
+    sink(this.x); // NOT OK
+
+    if (isSafe(this.x)) {
+      sink(this.x); // OK
+    }
+  }
+}

--- a/javascript/ql/test/library-tests/TaintTracking/sanitizer-guards.js
+++ b/javascript/ql/test/library-tests/TaintTracking/sanitizer-guards.js
@@ -16,6 +16,14 @@ class C {
 
     if (isSafe(this.x)) {
       sink(this.x); // OK
+
+      addEventListener('hey', () => {
+        sink(this.x); // OK - but still flagged
+      });
     }
+
+    addEventListener('hey', () => {
+	  sink(this.x); // NOT OK
+	});
   }
 }


### PR DESCRIPTION
Allows for sanitizers of form
```javascript
if (isSafe(this.foo.bar)) {
  let value = this.foo.bar;
}
```
Will start an evaluation when workers are ready again.