### PR TITLE
C#: Speedup `cs/missed-readonly-modifier`

### DIFF
--- a/csharp/ql/src/Language Abuse/MissedReadonlyOpportunity.ql
+++ b/csharp/ql/src/Language Abuse/MissedReadonlyOpportunity.ql
@@ -12,8 +12,12 @@
 
 import csharp
 
+predicate defTargetsField(AssignableDefinition def, Field f) {
+  def.getTarget().getSourceDeclaration() = f
+}
+
 predicate isReadonlyCompatibleDefinition(AssignableDefinition def, Field f) {
-  def.getTarget().getSourceDeclaration() = f and
+  defTargetsField(def, f) and
   (
     def.getEnclosingCallable().(Constructor).getDeclaringType() = f.getDeclaringType()
     or
@@ -22,7 +26,7 @@ predicate isReadonlyCompatibleDefinition(AssignableDefinition def, Field f) {
 }
 
 predicate canBeReadonly(Field f) {
-  forex(AssignableDefinition def | def.getTarget().getSourceDeclaration() = f |
+  forex(AssignableDefinition def | defTargetsField(def, f) |
     isReadonlyCompatibleDefinition(def, f)
   )
 }


### PR DESCRIPTION
This rewrite brings the query execution time on `mcintyre321/OneOf` down from ~4400s (on a warm cache, see https://lgtm.com/projects/g/mcintyre321/OneOf/logs/rev/06622f689625181f1800c8242690814dcd96c697/lang:csharp/stage:Build%20child%20(06622f6)) to ~100s (on a clean cache, locally on my machine).

DIL before:
```
MissedReadonlyOpportunity::canBeReadonly#f(pure unique Variable::Field f) :-
  exists(cached TAssignableDefinition def |
    exists(pure Assignable::Assignable receiver |
      Declaration::Declaration::getSourceDeclaration_dispred#ff(receiver, f),
      not(
        exists(cached TAssignableDefinition def1 |
          exists(pure Assignable::Assignable call_result#4 |
            Declaration::Declaration::getSourceDeclaration_dispred#ff(call_result#4,
                                                                      f),
            Assignable::AssignableInternal::Cached::getTarget(def1,
                                                              call_result#4)
          ),
          not(
            MissedReadonlyOpportunity::isReadonlyCompatibleDefinition#ff(def1, f)
          )
        )
      ),
      Assignable::AssignableInternal::Cached::getTarget(def, receiver)
    ),
    MissedReadonlyOpportunity::isReadonlyCompatibleDefinition#ff(def, f)
  )
.
```

DIL after:
```
MissedReadonlyOpportunity::canBeReadonly#f(pure unique Variable::Field f) :-
  exists(cached TAssignableDefinition def |
    MissedReadonlyOpportunity::defTargetsField#ff(def, f),
    MissedReadonlyOpportunity::isReadonlyCompatibleDefinition#ff(def, f)
  ),
  not(
    exists(cached TAssignableDefinition def1 |
      MissedReadonlyOpportunity::defTargetsField#ff(def1, f),
      not(MissedReadonlyOpportunity::isReadonlyCompatibleDefinition#ff(def1, f))
    )
  )
.
```