### PR TITLE
C#: Fix performance issue in `isValidExplicitParamsType()`

### DIFF
--- a/csharp/ql/src/semmle/code/csharp/exprs/Call.qll
+++ b/csharp/ql/src/semmle/code/csharp/exprs/Call.qll
@@ -287,6 +287,7 @@ class Call extends DotNet::Call, Expr, @call {
  * }
  * ```
  */
+pragma[nomagic]
 private predicate isValidExplicitParamsType(Parameter p, Type t) {
   p.isParams() and
   t.isImplicitlyConvertibleTo(p.getType())


### PR DESCRIPTION
Joining on `.isParams()` first is important, as can be seen from this (interrupted) execution:
```
[2019-01-10 21:12:37] (213s) Starting to evaluate predicate Call::isValidExplicitParamsType#fb
[2019-01-10 21:15:11] Received message for service 7
[2019-01-10 21:15:11] Running message for service 7
[2019-01-10 21:15:11] Received cancellation request for job 3
[2019-01-10 21:15:11] (367s) Tuple counts:
                      283187    ~3%     {2} r1 = JOIN m#Call::isValidExplicitParamsType#fb WITH Conversion::implicitConversion#ff@staged_ext ON m#Call::isValidExplicitParamsType#fb.<0>=Conversion::implicitConversion#ff@staged_ext.<0> OUTPUT FIELDS {Conversion::implicitConversion#ff@staged_ext.<1>,m#Call::isValidExplicitParamsType#fb.<0>}
                      906452622 ~5%     {3} r2 = JOIN r1 WITH Variable::Parameter::getType_dispred#ff_10#join_rhs ON r1.<0>=Variable::Parameter::getType_dispred#ff_10#join_rhs.<0> OUTPUT FIELDS {Variable::Parameter::getType_dispred#ff_10#join_rhs.<1>,3,r1.<1>}
                      522       ~1%     {2} r3 = JOIN r2 WITH params_04#join_rhs ON r2.<0>=params_04#join_rhs.<0> AND r2.<1>=params_04#join_rhs.<1> OUTPUT FIELDS {r2.<0>,r2.<2>}
                                        return r3
```