### PR TITLE
C++: Improvements to "Declaration hides parameter"

### DIFF
--- a/cpp/ql/src/Best Practices/Hiding/DeclarationHidesParameter.ql
+++ b/cpp/ql/src/Best Practices/Hiding/DeclarationHidesParameter.ql
@@ -11,13 +11,14 @@
 
 import cpp
 
-// Names of parameters in the implementation of a function.
-// Notice that we need to exclude parameter names used in prototype
-// declarations and only include the ones from the actual definition.
-// We also exclude names from functions that have multiple definitions.
-// This should not happen in a single application but since we
-// have a system wide view it is likely to happen for instance for
-// the main function.
+/**
+ * Gets the parameter of `f` with name `name`, which has to come from the
+ * _definition_ of `f` and not a prototype declaration.
+ * We also exclude names from functions that have multiple definitions.
+ * This should not happen in a single application but since we
+ * have a system wide view it is likely to happen for instance for
+ * the main function.
+ */
 ParameterDeclarationEntry functionParameterNames(Function f, string name) {
   exists(FunctionDeclarationEntry fe |
     result.getFunctionDeclarationEntry() = fe and
@@ -29,6 +30,7 @@ ParameterDeclarationEntry functionParameterNames(Function f, string name) {
   )
 }
 
+/** Gets a local variable in `f` with name `name`. */
 pragma[nomagic]
 LocalVariable localVariableNames(Function f, string name) {
   name = result.getName() and

--- a/cpp/ql/src/Best Practices/Hiding/DeclarationHidesParameter.ql
+++ b/cpp/ql/src/Best Practices/Hiding/DeclarationHidesParameter.ql
@@ -8,29 +8,29 @@
  * @tags maintainability
  *       readability
  */
+
 import cpp
 
-
-/* Names of parameters in the implementation of a function.
-   Notice that we need to exclude parameter names used in prototype
-   declarations and only include the ones from the actual definition.
-   We also exclude names from functions that have multiple definitions.
-   This should not happen in a single application but since we
-   have a system wide view it is likely to happen for instance for
-   the main function. */
+// Names of parameters in the implementation of a function.
+// Notice that we need to exclude parameter names used in prototype
+// declarations and only include the ones from the actual definition.
+// We also exclude names from functions that have multiple definitions.
+// This should not happen in a single application but since we
+// have a system wide view it is likely to happen for instance for
+// the main function.
 ParameterDeclarationEntry functionParameterNames(Function f, string name) {
   exists(FunctionDeclarationEntry fe |
-    result.getFunctionDeclarationEntry() = fe
-    and fe.getFunction() = f
-    and fe.getLocation() = f.getDefinitionLocation()
-    and strictcount(f.getDefinitionLocation()) = 1
-    and result.getName() = name
+    result.getFunctionDeclarationEntry() = fe and
+    fe.getFunction() = f and
+    fe.getLocation() = f.getDefinitionLocation() and
+    strictcount(f.getDefinitionLocation()) = 1 and
+    result.getName() = name
   )
 }
 
 from Function f, LocalVariable lv, ParameterDeclarationEntry pde
-where f = lv.getFunction() and
-      pde = functionParameterNames(f, lv.getName()) and
-      not lv.isInMacroExpansion()
-select lv, "Local variable '"+ lv.getName() +"' hides a $@.",
-       pde, "parameter of the same name"
+where
+  f = lv.getFunction() and
+  pde = functionParameterNames(f, lv.getName()) and
+  not lv.isInMacroExpansion()
+select lv, "Local variable '" + lv.getName() + "' hides a $@.", pde, "parameter of the same name"

--- a/cpp/ql/src/Best Practices/Hiding/DeclarationHidesParameter.ql
+++ b/cpp/ql/src/Best Practices/Hiding/DeclarationHidesParameter.ql
@@ -28,9 +28,15 @@ ParameterDeclarationEntry functionParameterNames(Function f, string name) {
   )
 }
 
-from Function f, LocalVariable lv, ParameterDeclarationEntry pde
+pragma[nomagic]
+LocalVariable localVariableNames(Function f, string name) {
+  name = result.getName() and
+  f = result.getFunction()
+}
+
+from Function f, LocalVariable lv, ParameterDeclarationEntry pde, string name
 where
-  f = lv.getFunction() and
-  pde = functionParameterNames(f, lv.getName()) and
+  lv = localVariableNames(f, name) and
+  pde = functionParameterNames(f, name) and
   not lv.isInMacroExpansion()
 select lv, "Local variable '" + lv.getName() + "' hides a $@.", pde, "parameter of the same name"

--- a/cpp/ql/src/Best Practices/Hiding/DeclarationHidesParameter.ql
+++ b/cpp/ql/src/Best Practices/Hiding/DeclarationHidesParameter.ql
@@ -23,6 +23,7 @@ ParameterDeclarationEntry functionParameterNames(Function f, string name) {
     result.getFunctionDeclarationEntry() = fe and
     fe.getFunction() = f and
     fe.getLocation() = f.getDefinitionLocation() and
+    result.getFile() = fe.getFile() and // Work around CPP-331
     strictcount(f.getDefinitionLocation()) = 1 and
     result.getName() = name
   )


### PR DESCRIPTION
The forum post https://discuss.lgtm.com/t/please-help-me-understand-this-issue-local-variable-buffer-hides-a-parameter-of-the-same-name/1662 prompted me to look at this query. I auto-formatted the query and fixed a performance bug, and then I worked around the issue that was causing false positives. I think it's an extractor bug, and I've filed CPP-331 to track it.

I wasn't able to create a unit test that demonstrates the problem, but you can see how the results change on the jx_application_framework project: [before](https://lgtm.com/query/7661096896888929010/) and [after](https://lgtm.com/query/2090894019133464346/).