### PR TITLE
C++: Exclude copy assignment in LargeParameter.ql

### DIFF
--- a/cpp/ql/src/Critical/LargeParameter.ql
+++ b/cpp/ql/src/Critical/LargeParameter.ql
@@ -18,6 +18,7 @@ where f.getAParameter() = p
   and t.getSize() = size
   and size > 64
   and not t.getUnderlyingType() instanceof ArrayType
+  and not f instanceof CopyAssignmentOperator
 select
   p, "This parameter of type $@ is " + size.toString() + " bytes - consider passing a pointer/reference instead.",
   t, t.toString()

--- a/cpp/ql/test/query-tests/Critical/LargeParameter/LargeParameter.expected
+++ b/cpp/ql/test/query-tests/Critical/LargeParameter/LargeParameter.expected
@@ -1,4 +1,3 @@
 | test.cpp:16:13:16:14 | _t | This parameter of type $@ is 4096 bytes - consider passing a pointer/reference instead. | test.cpp:6:8:6:20 | myLargeStruct | myLargeStruct |
 | test.cpp:24:44:24:48 | mtc_t | This parameter of type $@ is 4096 bytes - consider passing a pointer/reference instead. | test.cpp:11:7:11:21 | myTemplateClass<myLargeStruct> | myTemplateClass<myLargeStruct> |
 | test.cpp:28:49:28:49 | b | This parameter of type $@ is 4096 bytes - consider passing a pointer/reference instead. | test.cpp:6:8:6:20 | myLargeStruct | myLargeStruct |
-| test.cpp:52:52:52:54 | rhs | This parameter of type $@ is 4096 bytes - consider passing a pointer/reference instead. | test.cpp:48:8:48:25 | CustomAssignmentOp | CustomAssignmentOp |

--- a/cpp/ql/test/query-tests/Critical/LargeParameter/LargeParameter.expected
+++ b/cpp/ql/test/query-tests/Critical/LargeParameter/LargeParameter.expected
@@ -1,3 +1,4 @@
 | test.cpp:16:13:16:14 | _t | This parameter of type $@ is 4096 bytes - consider passing a pointer/reference instead. | test.cpp:6:8:6:20 | myLargeStruct | myLargeStruct |
 | test.cpp:24:44:24:48 | mtc_t | This parameter of type $@ is 4096 bytes - consider passing a pointer/reference instead. | test.cpp:11:7:11:21 | myTemplateClass<myLargeStruct> | myTemplateClass<myLargeStruct> |
 | test.cpp:28:49:28:49 | b | This parameter of type $@ is 4096 bytes - consider passing a pointer/reference instead. | test.cpp:6:8:6:20 | myLargeStruct | myLargeStruct |
+| test.cpp:52:52:52:54 | rhs | This parameter of type $@ is 4096 bytes - consider passing a pointer/reference instead. | test.cpp:48:8:48:25 | CustomAssignmentOp | CustomAssignmentOp |

--- a/cpp/ql/test/query-tests/Critical/LargeParameter/test.cpp
+++ b/cpp/ql/test/query-tests/Critical/LargeParameter/test.cpp
@@ -44,3 +44,11 @@ void myFunction2(mySmallStruct *a, myLargeStruct *b) // GOOD
 void myFunction3(mySmallStruct &a, myLargeStruct &b) // GOOD
 {
 }
+
+struct CustomAssignmentOp {
+  // GOOD: it's an accepted pattern to implement copy assignment via copy and
+  // swap. This delegates the resource management involved in copying to the
+  // copy constructor so that logic only has to be written once.
+  CustomAssignmentOp &operator=(CustomAssignmentOp rhs); // FALSE POSITIVE
+  char data[4096];
+};

--- a/cpp/ql/test/query-tests/Critical/LargeParameter/test.cpp
+++ b/cpp/ql/test/query-tests/Critical/LargeParameter/test.cpp
@@ -49,6 +49,6 @@ struct CustomAssignmentOp {
   // GOOD: it's an accepted pattern to implement copy assignment via copy and
   // swap. This delegates the resource management involved in copying to the
   // copy constructor so that logic only has to be written once.
-  CustomAssignmentOp &operator=(CustomAssignmentOp rhs); // FALSE POSITIVE
+  CustomAssignmentOp &operator=(CustomAssignmentOp rhs);
   char data[4096];
 };


### PR DESCRIPTION
This addresses https://discuss.lgtm.com/t/c-consider-passing-a-pointer-to-unifying-assignment-operator/1664. I've checked that the new version of the query makes the alert go away on the affected project: https://lgtm.com/query/5725802104708838857/