### PR TITLE
Python tests: Increase import depth to ensure sre_constants module is imported.

### DIFF
--- a/python/ql/test/library-tests/regex/options
+++ b/python/ql/test/library-tests/regex/options
@@ -1,1 +1,1 @@
-semmle-extractor-options: --max-import-depth=2
+semmle-extractor-options: --max-import-depth=3


### PR DESCRIPTION
Required to ensure that `sre_constants` is imported along the chain `test` -> `re` -> `sre_compile` -> `sre_constants`. Necessary for stricter enforcement of import depth in the extractor.