### PR TITLE
C++: Exclude assignment operator in ExprHasNoEffect

### DIFF
--- a/cpp/ql/src/Likely Bugs/Likely Typos/ExprHasNoEffect.ql
+++ b/cpp/ql/src/Likely Bugs/Likely Typos/ExprHasNoEffect.ql
@@ -97,6 +97,10 @@ where // EQExprs are covered by CompareWhereAssignMeant.ql
       not peivc instanceof EQExpr and
       // as is operator==
       not peivc.(FunctionCall).getTarget().hasName("operator==") and
+      // An assignment operator may have no side effects in its current
+      // implementation, but we should not advise callers to rely on this. That
+      // would break encapsulation.
+      not peivc.(FunctionCall).getTarget().hasName("operator=") and
       not accessInInitOfForStmt(peivc) and
       not peivc.isCompilerGenerated() and
       not exists(Macro m | peivc = m.getAnInvocation().getAnExpandedElement()) and

--- a/cpp/ql/src/semmle/code/cpp/NameQualifiers.qll
+++ b/cpp/ql/src/semmle/code/cpp/NameQualifiers.qll
@@ -67,7 +67,10 @@ class NameQualifier extends NameQualifiableElement, @namequalifier {
  * the latter is qualified by `N1`.
  */
 class NameQualifiableElement extends Element, @namequalifiableelement {
-  /** Gets the name qualifier associated with this element. */
+  /**
+   * Gets the name qualifier associated with this element. For example, the
+   * name qualifier of `N::f()` is `N`.
+   */
   NameQualifier getNameQualifier() {
     namequalifiers(unresolveElement(result),underlyingElement(this),_,_)
   }

--- a/cpp/ql/test/query-tests/Likely Bugs/Likely Typos/ExprHasNoEffect/ExprHasNoEffect.expected
+++ b/cpp/ql/test/query-tests/Likely Bugs/Likely Typos/ExprHasNoEffect/ExprHasNoEffect.expected
@@ -27,9 +27,6 @@
 | test.c:27:9:27:10 | 33 | This expression has no effect. | test.c:27:9:27:10 | 33 |  |
 | test.cpp:24:3:24:3 | call to operator++ | This expression has no effect (because $@ has no external side effects). | test.cpp:9:14:9:23 | operator++ | operator++ |
 | test.cpp:25:3:25:3 | call to operator++ | This expression has no effect (because $@ has no external side effects). | test.cpp:9:14:9:23 | operator++ | operator++ |
-| test.cpp:62:5:62:5 | call to operator= | This expression has no effect (because $@ has no external side effects). | test.cpp:47:14:47:22 | operator= | operator= |
-| test.cpp:65:5:65:5 | call to operator= | This expression has no effect (because $@ has no external side effects). | test.cpp:55:7:55:7 | operator= | operator= |
-| test.cpp:91:5:91:19 | call to operator= | This expression has no effect (because $@ has no external side effects). | test.cpp:77:9:77:17 | operator= | operator= |
 | volatile.c:9:5:9:5 | c | This expression has no effect. | volatile.c:9:5:9:5 | c |  |
 | volatile.c:12:5:12:9 | access to array | This expression has no effect. | volatile.c:12:5:12:9 | access to array |  |
 | volatile.c:16:5:16:7 | * ... | This expression has no effect. | volatile.c:16:5:16:7 | * ... |  |

--- a/cpp/ql/test/query-tests/Likely Bugs/Likely Typos/ExprHasNoEffect/ExprHasNoEffect.expected
+++ b/cpp/ql/test/query-tests/Likely Bugs/Likely Typos/ExprHasNoEffect/ExprHasNoEffect.expected
@@ -29,6 +29,7 @@
 | test.cpp:25:3:25:3 | call to operator++ | This expression has no effect (because $@ has no external side effects). | test.cpp:9:14:9:23 | operator++ | operator++ |
 | test.cpp:62:5:62:5 | call to operator= | This expression has no effect (because $@ has no external side effects). | test.cpp:47:14:47:22 | operator= | operator= |
 | test.cpp:65:5:65:5 | call to operator= | This expression has no effect (because $@ has no external side effects). | test.cpp:55:7:55:7 | operator= | operator= |
+| test.cpp:91:5:91:19 | call to operator= | This expression has no effect (because $@ has no external side effects). | test.cpp:77:9:77:17 | operator= | operator= |
 | volatile.c:9:5:9:5 | c | This expression has no effect. | volatile.c:9:5:9:5 | c |  |
 | volatile.c:12:5:12:9 | access to array | This expression has no effect. | volatile.c:12:5:12:9 | access to array |  |
 | volatile.c:16:5:16:7 | * ... | This expression has no effect. | volatile.c:16:5:16:7 | * ... |  |

--- a/cpp/ql/test/query-tests/Likely Bugs/Likely Typos/ExprHasNoEffect/ExprHasNoEffect.expected
+++ b/cpp/ql/test/query-tests/Likely Bugs/Likely Typos/ExprHasNoEffect/ExprHasNoEffect.expected
@@ -27,6 +27,8 @@
 | test.c:27:9:27:10 | 33 | This expression has no effect. | test.c:27:9:27:10 | 33 |  |
 | test.cpp:24:3:24:3 | call to operator++ | This expression has no effect (because $@ has no external side effects). | test.cpp:9:14:9:23 | operator++ | operator++ |
 | test.cpp:25:3:25:3 | call to operator++ | This expression has no effect (because $@ has no external side effects). | test.cpp:9:14:9:23 | operator++ | operator++ |
+| test.cpp:62:5:62:5 | call to operator= | This expression has no effect (because $@ has no external side effects). | test.cpp:47:14:47:22 | operator= | operator= |
+| test.cpp:65:5:65:5 | call to operator= | This expression has no effect (because $@ has no external side effects). | test.cpp:55:7:55:7 | operator= | operator= |
 | volatile.c:9:5:9:5 | c | This expression has no effect. | volatile.c:9:5:9:5 | c |  |
 | volatile.c:12:5:12:9 | access to array | This expression has no effect. | volatile.c:12:5:12:9 | access to array |  |
 | volatile.c:16:5:16:7 | * ... | This expression has no effect. | volatile.c:16:5:16:7 | * ... |  |

--- a/cpp/ql/test/query-tests/Likely Bugs/Likely Typos/ExprHasNoEffect/test.cpp
+++ b/cpp/ql/test/query-tests/Likely Bugs/Likely Typos/ExprHasNoEffect/test.cpp
@@ -88,7 +88,7 @@ struct Derived : Base {
     }
 
     // In case base class has data, now or in the future, copy that first.
-    Base::operator=(rhs); // GOOD [FALSE POSITIVE]
+    Base::operator=(rhs); // GOOD
 
     this->m_x = rhs.m_x;
     return *this;

--- a/cpp/ql/test/query-tests/Likely Bugs/Likely Typos/ExprHasNoEffect/test.cpp
+++ b/cpp/ql/test/query-tests/Likely Bugs/Likely Typos/ExprHasNoEffect/test.cpp
@@ -64,3 +64,45 @@ void testFunc2()
 	MyAssignable v1, v2;
 	v2 = v1;
 }
+
+namespace std {
+  typedef unsigned long size_t;
+}
+
+void* operator new  (std::size_t size, void* ptr) noexcept;
+
+struct Base {
+  Base() { }
+
+  Base &operator=(const Base &rhs) {
+    return *this;
+  }
+
+  virtual ~Base() { }
+};
+
+struct Derived : Base {
+  Derived &operator=(const Derived &rhs) {
+    if (&rhs == this) {
+      return *this;
+    }
+
+    // In case base class has data, now or in the future, copy that first.
+    Base::operator=(rhs); // GOOD [FALSE POSITIVE]
+
+    this->m_x = rhs.m_x;
+    return *this;
+  }
+
+  int m_x;
+};
+
+void use_Base() {
+  Base base_buffer[1];
+  Base *base = new(&base_buffer[0]) Base();
+
+  // In case the destructor does something, now or in the future, call it. It
+  // won't get called automatically because the object was allocated with
+  // placement new.
+  base->~Base(); // GOOD (because the call has void type)
+}


### PR DESCRIPTION
Fixes https://discuss.lgtm.com/t/incorrect-application-of-this-expression-has-no-effect-because-operator-has-no-external-side-effects/1660