### PR TITLE
C#: Autoformat QL files

### DIFF
--- a/csharp/ql/src/API Abuse/ClassDoesNotImplementEquals.ql
+++ b/csharp/ql/src/API Abuse/ClassDoesNotImplementEquals.ql
@@ -28,11 +28,9 @@ where
       itemText = "here"
     )
     or
-    (
-      item = c.getAnOperator().(EQOperator) and
-      message = "but it implements $@" and
-      itemText = "operator =="
-    )
+    item = c.getAnOperator().(EQOperator) and
+    message = "but it implements $@" and
+    itemText = "operator =="
     or
     exists(IEquatableEqualsMethod eq |
       item = eq and

--- a/csharp/ql/src/API Abuse/InconsistentEqualsGetHashCode.ql
+++ b/csharp/ql/src/API Abuse/InconsistentEqualsGetHashCode.ql
@@ -18,17 +18,13 @@ from Class c, Method present, string missing
 where
   c.isSourceDeclaration() and
   (
-    (
-      present = c.getAMethod().(EqualsMethod) and
-      not c.getAMethod() instanceof GetHashCodeMethod and
-      missing = "GetHashCode()"
-    )
+    present = c.getAMethod().(EqualsMethod) and
+    not c.getAMethod() instanceof GetHashCodeMethod and
+    missing = "GetHashCode()"
     or
-    (
-      present = c.getAMethod().(GetHashCodeMethod) and
-      not implementsEquals(c) and
-      missing = "Equals(object)"
-    )
+    present = c.getAMethod().(GetHashCodeMethod) and
+    not implementsEquals(c) and
+    missing = "Equals(object)"
   )
 select c, "Class '" + c.getName() + "' overrides $@, but not " + missing + ".", present,
   present.getName()

--- a/csharp/ql/src/API Abuse/IncorrectCompareToSignature.ql
+++ b/csharp/ql/src/API Abuse/IncorrectCompareToSignature.ql
@@ -20,10 +20,8 @@ predicate implementsIComparable(ValueOrRefType t, Type paramType) {
   or
   t instanceof SystemIComparableTInterface
   or
-  (
-    t.getABaseType*() instanceof SystemIComparableInterface and
-    paramType instanceof ObjectType
-  )
+  t.getABaseType*() instanceof SystemIComparableInterface and
+  paramType instanceof ObjectType
 }
 
 predicate compareToMethod(Method m, Type paramType) {

--- a/csharp/ql/src/API Abuse/UncheckedReturnValue.ql
+++ b/csharp/ql/src/API Abuse/UncheckedReturnValue.ql
@@ -99,7 +99,7 @@ class DiscardedMethodCall extends MethodCall {
       // to deliberately ignore the returned value
       not getEnclosingCallable().getStatementBody().getNumberOfStmts() = 1
     |
-      (important(m) and result = "should always be checked")
+      important(m) and result = "should always be checked"
       or
       exists(int percentage | dubious(m, percentage) |
         result = percentage.toString() + "% of calls to this method have their result used"

--- a/csharp/ql/src/Bad Practices/Naming Conventions/ConstantNaming.ql
+++ b/csharp/ql/src/Bad Practices/Naming Conventions/ConstantNaming.ql
@@ -23,12 +23,10 @@ class PublicConstantField extends Field {
 from PublicConstantField f
 where
   // The first character of the field's name is not uppercase.
-  not (f.getName().charAt(0).isUppercase())
+  not f.getName().charAt(0).isUppercase()
   or
-  (
-    // The field's name is uppercase.
-    f.getName().isUppercase() and
-    // The field's name is at least 4 characters long.
-    f.getName().length() >= 4
-  )
+  // The field's name is uppercase.
+  f.getName().isUppercase() and
+  // The field's name is at least 4 characters long.
+  f.getName().length() >= 4
 select f, "Public static read-only fields should be named in PascalCase."

--- a/csharp/ql/src/Bad Practices/Naming Conventions/ControlNamePrefixes.ql
+++ b/csharp/ql/src/Bad Practices/Naming Conventions/ControlNamePrefixes.ql
@@ -12,83 +12,83 @@
 import csharp
 
 string prefix(string typename) {
-  (typename = "System.Web.UI.WebControls.Label" and result = "lbl")
+  typename = "System.Web.UI.WebControls.Label" and result = "lbl"
   or
-  (typename = "System.Web.UI.WebControls.TextBox" and result = "txt")
+  typename = "System.Web.UI.WebControls.TextBox" and result = "txt"
   or
-  (typename = "System.Web.UI.WebControls.Button" and result = "btn")
+  typename = "System.Web.UI.WebControls.Button" and result = "btn"
   or
-  (typename = "System.Web.UI.WebControls.LinkButton" and result = "btn")
+  typename = "System.Web.UI.WebControls.LinkButton" and result = "btn"
   or
-  (typename = "System.Web.UI.WebControls.ImageButton" and result = "ibtn")
+  typename = "System.Web.UI.WebControls.ImageButton" and result = "ibtn"
   or
-  (typename = "System.Web.UI.WebControls.Hyperlink" and result = "hpl")
+  typename = "System.Web.UI.WebControls.Hyperlink" and result = "hpl"
   or
-  (typename = "System.Web.UI.WebControls.DropDownList" and result = "cmb")
+  typename = "System.Web.UI.WebControls.DropDownList" and result = "cmb"
   or
-  (typename = "System.Web.UI.WebControls.ListBox" and result = "lst")
+  typename = "System.Web.UI.WebControls.ListBox" and result = "lst"
   or
-  (typename = "System.Web.UI.WebControls.Datagrid" and result = "dgr")
+  typename = "System.Web.UI.WebControls.Datagrid" and result = "dgr"
   or
-  (typename = "System.Web.UI.WebControls.Datalist" and result = "dtl")
+  typename = "System.Web.UI.WebControls.Datalist" and result = "dtl"
   or
-  (typename = "System.Web.UI.WebControls.Repeater" and result = "rpt")
+  typename = "System.Web.UI.WebControls.Repeater" and result = "rpt"
   or
-  (typename = "System.Web.UI.WebControls.CheckBox" and result = "chk")
+  typename = "System.Web.UI.WebControls.CheckBox" and result = "chk"
   or
-  (typename = "System.Web.UI.WebControls.CheckBoxList" and result = "chklst")
+  typename = "System.Web.UI.WebControls.CheckBoxList" and result = "chklst"
   or
-  (typename = "System.Web.UI.WebControls.RadioButtonList" and result = "radlst")
+  typename = "System.Web.UI.WebControls.RadioButtonList" and result = "radlst"
   or
-  (typename = "System.Web.UI.WebControls.RadioButton" and result = "rad")
+  typename = "System.Web.UI.WebControls.RadioButton" and result = "rad"
   or
-  (typename = "System.Web.UI.WebControls.Image" and result = "img")
+  typename = "System.Web.UI.WebControls.Image" and result = "img"
   or
-  (typename = "System.Web.UI.WebControls.Panel" and result = "pnl")
+  typename = "System.Web.UI.WebControls.Panel" and result = "pnl"
   or
-  (typename = "System.Web.UI.WebControls.PlaceHolder" and result = "plh")
+  typename = "System.Web.UI.WebControls.PlaceHolder" and result = "plh"
   or
-  (typename = "System.Web.UI.WebControls.Calendar" and result = "cal")
+  typename = "System.Web.UI.WebControls.Calendar" and result = "cal"
   or
-  (typename = "System.Web.UI.WebControls.AdRotator" and result = "adr")
+  typename = "System.Web.UI.WebControls.AdRotator" and result = "adr"
   or
-  (typename = "System.Web.UI.WebControls.Table" and result = "tbl")
+  typename = "System.Web.UI.WebControls.Table" and result = "tbl"
   or
-  (typename = "System.Web.UI.WebControls.RequiredFieldValidator" and result = "rfv")
+  typename = "System.Web.UI.WebControls.RequiredFieldValidator" and result = "rfv"
   or
-  (typename = "System.Web.UI.WebControls.CompareValidator" and result = "cmv")
+  typename = "System.Web.UI.WebControls.CompareValidator" and result = "cmv"
   or
-  (typename = "System.Web.UI.WebControls.RegularExpressionValidator" and result = "rev")
+  typename = "System.Web.UI.WebControls.RegularExpressionValidator" and result = "rev"
   or
-  (typename = "System.Web.UI.WebControls.CustomValidator" and result = "csv")
+  typename = "System.Web.UI.WebControls.CustomValidator" and result = "csv"
   or
-  (typename = "System.Web.UI.WebControls.ValidationSummary" and result = "vsm")
+  typename = "System.Web.UI.WebControls.ValidationSummary" and result = "vsm"
   or
-  (typename = "System.Web.UI.WebControls.XML" and result = "xml")
+  typename = "System.Web.UI.WebControls.XML" and result = "xml"
   or
-  (typename = "System.Web.UI.WebControls.Literal" and result = "lit")
+  typename = "System.Web.UI.WebControls.Literal" and result = "lit"
   or
-  (typename = "System.Web.UI.WebControls.Form" and result = "frm")
+  typename = "System.Web.UI.WebControls.Form" and result = "frm"
   or
-  (typename = "System.Web.UI.WebControls.Frame" and result = "fra")
+  typename = "System.Web.UI.WebControls.Frame" and result = "fra"
   or
-  (typename = "System.Web.UI.WebControls.CrystalReportViewer" and result = "crvr")
+  typename = "System.Web.UI.WebControls.CrystalReportViewer" and result = "crvr"
   or
-  (typename = "System.Web.UI.HtmlControls.TextArea" and result = "txa")
+  typename = "System.Web.UI.HtmlControls.TextArea" and result = "txa"
   or
-  (typename = "System.Web.UI.HtmlControls.FileField" and result = "fle")
+  typename = "System.Web.UI.HtmlControls.FileField" and result = "fle"
   or
-  (typename = "System.Web.UI.HtmlControls.PasswordField" and result = "pwd")
+  typename = "System.Web.UI.HtmlControls.PasswordField" and result = "pwd"
   or
-  (typename = "System.Web.UI.HtmlControls.Hidden" and result = "hdn")
+  typename = "System.Web.UI.HtmlControls.Hidden" and result = "hdn"
   or
-  (typename = "System.Web.UI.HtmlControls.Table" and result = "tbl")
+  typename = "System.Web.UI.HtmlControls.Table" and result = "tbl"
   or
-  (typename = "System.Web.UI.HtmlControls.FlowLayoutPanel" and result = "flp")
+  typename = "System.Web.UI.HtmlControls.FlowLayoutPanel" and result = "flp"
   or
-  (typename = "System.Web.UI.HtmlControls.GridLayoutPanel" and result = "glp")
+  typename = "System.Web.UI.HtmlControls.GridLayoutPanel" and result = "glp"
   or
-  (typename = "System.Web.UI.HtmlControls.HorizontalRule" and result = "hr")
+  typename = "System.Web.UI.HtmlControls.HorizontalRule" and result = "hr"
 }
 
 from Field f, RefType t, string name, string prefix

--- a/csharp/ql/src/Complexity/ComplexCondition.ql
+++ b/csharp/ql/src/Complexity/ComplexCondition.ql
@@ -22,7 +22,7 @@ predicate logicalParent(LogicalOperation op, LogicalOperation parent) { parent =
 
 from Expr e, int operators
 where
-  not (e.getParent() instanceof LogicalOperation) and
+  not e.getParent() instanceof LogicalOperation and
   operators = count(BinaryLogicalOperation op |
       logicalParent*(op, e) and nontrivialLogicalOperator(op)
     ) and

--- a/csharp/ql/src/Concurrency/LockedWait.ql
+++ b/csharp/ql/src/Concurrency/LockedWait.ql
@@ -29,6 +29,6 @@ where
       lockedItem = "typeof(" + t.getName() + ")"
     )
     or
-    (l.isLockThis() and not w.isWaitThis() and lockedItem = "this")
+    l.isLockThis() and not w.isWaitThis() and lockedItem = "this"
   )
 select w, "'" + lockedItem + "' is locked during this wait."

--- a/csharp/ql/src/Dead Code/NonAssignedFields.ql
+++ b/csharp/ql/src/Dead Code/NonAssignedFields.ql
@@ -87,7 +87,7 @@ where
   not exists(Assignment ae, Field g |
     ae.getLValue().(FieldAccess).getTarget() = g and
     g.getSourceDeclaration() = f and
-    not (ae.getRValue() instanceof NullLiteral)
+    not ae.getRValue() instanceof NullLiteral
   ) and
   not exists(MethodCall mc, int i, Field g |
     exists(Parameter p | mc.getTarget().getParameter(i) = p | p.isOut() or p.isRef()) and

--- a/csharp/ql/src/Language Abuse/MissedTernaryOpportunity.ql
+++ b/csharp/ql/src/Language Abuse/MissedTernaryOpportunity.ql
@@ -36,11 +36,9 @@ class StructuralComparisonConfig extends StructuralComparisonConfiguration {
 from IfStmt is, string what
 where
   (
-    (
-      is.getThen().stripSingletonBlocks() instanceof ReturnStmt and
-      is.getElse().stripSingletonBlocks() instanceof ReturnStmt and
-      what = "return"
-    )
+    is.getThen().stripSingletonBlocks() instanceof ReturnStmt and
+    is.getElse().stripSingletonBlocks() instanceof ReturnStmt and
+    what = "return"
     or
     exists(StructuralComparisonConfig c |
       is = c.getIfStmt() and

--- a/csharp/ql/src/Likely Bugs/Collections/ContainerSizeCmpZero.ql
+++ b/csharp/ql/src/Likely Bugs/Collections/ContainerSizeCmpZero.ql
@@ -24,18 +24,16 @@ private predicate propertyOverrides(Property p, string baseClass, string propert
 
 private predicate containerSizeAccess(PropertyAccess pa, string containerKind) {
   (
-    (
-      propertyOverrides(pa.getTarget(), "System.Collections.Generic.ICollection<>", "Count") or
-      propertyOverrides(pa.getTarget(), "System.Collections.Generic.IReadOnlyCollection<>", "Count") or
-      propertyOverrides(pa.getTarget(), "System.Collections.ICollection", "Count")
-    ) and
-    containerKind = "a collection"
-  )
+    propertyOverrides(pa.getTarget(), "System.Collections.Generic.ICollection<>", "Count") or
+    propertyOverrides(pa.getTarget(), "System.Collections.Generic.IReadOnlyCollection<>", "Count") or
+    propertyOverrides(pa.getTarget(), "System.Collections.ICollection", "Count")
+  ) and
+  containerKind = "a collection"
   or
   (
-    (propertyOverrides(pa.getTarget(), "System.String", "Length") and containerKind = "a string")
+    propertyOverrides(pa.getTarget(), "System.String", "Length") and containerKind = "a string"
     or
-    (propertyOverrides(pa.getTarget(), "System.Array", "Length") and containerKind = "an array")
+    propertyOverrides(pa.getTarget(), "System.Array", "Length") and containerKind = "an array"
   )
 }
 
@@ -45,29 +43,21 @@ class ZeroLiteral extends Expr { ZeroLiteral() { getValue() = "0" } }
  * Whether `smaller` is checked to be no greater than `greater` by `e` being `trueOrFalse`
  */
 private predicate checkedLT(BinaryOperation e, Expr greater, Expr smaller, string trueOrFalse) {
-  (
-    greater = e.(GEExpr).getLeftOperand() and
-    smaller = e.(GEExpr).getRightOperand() and
-    trueOrFalse = "true"
-  )
+  greater = e.(GEExpr).getLeftOperand() and
+  smaller = e.(GEExpr).getRightOperand() and
+  trueOrFalse = "true"
   or
-  (
-    greater = e.(LEExpr).getRightOperand() and
-    smaller = e.(LEExpr).getLeftOperand() and
-    trueOrFalse = "true"
-  )
+  greater = e.(LEExpr).getRightOperand() and
+  smaller = e.(LEExpr).getLeftOperand() and
+  trueOrFalse = "true"
   or
-  (
-    greater = e.(GTExpr).getRightOperand() and
-    smaller = e.(GTExpr).getLeftOperand() and
-    trueOrFalse = "false"
-  )
+  greater = e.(GTExpr).getRightOperand() and
+  smaller = e.(GTExpr).getLeftOperand() and
+  trueOrFalse = "false"
   or
-  (
-    greater = e.(LTExpr).getLeftOperand() and
-    smaller = e.(LTExpr).getRightOperand() and
-    trueOrFalse = "false"
-  )
+  greater = e.(LTExpr).getLeftOperand() and
+  smaller = e.(LTExpr).getRightOperand() and
+  trueOrFalse = "false"
 }
 
 private predicate comparisonOfContainerSizeToZero(

--- a/csharp/ql/src/Likely Bugs/Collections/ReadOnlyContainer.ql
+++ b/csharp/ql/src/Likely Bugs/Collections/ReadOnlyContainer.ql
@@ -29,7 +29,7 @@ where
     a instanceof NoAddAccess or a instanceof EmptyInitializationAccess
   ) and
   // Attributes indicate some kind of reflection
-  (not exists(Attribute a | v = a.getTarget())) and
+  not exists(Attribute a | v = a.getTarget()) and
   // There is at least one non-assignment access
   v.getAnAccess() instanceof NoAddAccess
 select v, "The contents of this container are never initialized."

--- a/csharp/ql/src/Likely Bugs/EqualityCheckOnFloats.ql
+++ b/csharp/ql/src/Likely Bugs/EqualityCheckOnFloats.ql
@@ -21,9 +21,7 @@ class ZeroFloatLiteral extends FloatLiteral {
 from EqualityOperation e
 where
   e.getAnOperand().getType() instanceof FloatingPointType and
-  not (
-    e.getAnOperand() instanceof NullLiteral
-    //Uncomment this to exclude comparisons to 0 literals
-    //or e.getAnOperand() instanceof ZeroFloatLiteral
-  )
+  not e.getAnOperand() instanceof NullLiteral
+//Uncomment this to exclude comparisons to 0 literals
+//or e.getAnOperand() instanceof ZeroFloatLiteral
 select e, "Equality checks on floating point values can yield unexpected results."

--- a/csharp/ql/src/Likely Bugs/EqualityCheckOnFloats.ql
+++ b/csharp/ql/src/Likely Bugs/EqualityCheckOnFloats.ql
@@ -22,6 +22,4 @@ from EqualityOperation e
 where
   e.getAnOperand().getType() instanceof FloatingPointType and
   not e.getAnOperand() instanceof NullLiteral
-//Uncomment this to exclude comparisons to 0 literals
-//or e.getAnOperand() instanceof ZeroFloatLiteral
 select e, "Equality checks on floating point values can yield unexpected results."

--- a/csharp/ql/src/Likely Bugs/EqualsUsesAs.ql
+++ b/csharp/ql/src/Likely Bugs/EqualsUsesAs.ql
@@ -18,7 +18,7 @@ where
   e.getEnclosingCallable() = m and
   e.getExpr().(VariableAccess).getTarget() = m.getParameter(0) and
   asType = e.getTargetType() and
-  not (asType.isSealed()) and
+  not asType.isSealed() and
   not exists(MethodCall c, Variable v |
     c.getEnclosingCallable() = m and
     c.getTarget().getName() = "GetType" and

--- a/csharp/ql/src/Likely Bugs/EqualsUsesIs.ql
+++ b/csharp/ql/src/Likely Bugs/EqualsUsesIs.ql
@@ -18,7 +18,7 @@ where
   e.getEnclosingCallable() = m and
   e.getExpr().(VariableAccess).getTarget() = m.getParameter(0) and
   isType = e.getCheckedType() and
-  not (isType.isSealed()) and
+  not isType.isSealed() and
   not exists(MethodCall c |
     c.getEnclosingCallable() = m and
     c.getTarget().getName() = "GetType" and

--- a/csharp/ql/src/Likely Bugs/IncomparableEquals.ql
+++ b/csharp/ql/src/Likely Bugs/IncomparableEquals.ql
@@ -45,6 +45,6 @@ where
   // exclude wildcards since the check is not applicable to them
   not (i instanceof TypeParameter or j instanceof TypeParameter) and
   // exclude calls of the form x.Equals(null), since they're highlighted by a different query
-  not (i instanceof NullType)
+  not i instanceof NullType
 select ma, "Call to 'Equals()' comparing incomparable types $@ and $@.", j, j.getName(), i,
   i.getName()

--- a/csharp/ql/src/Linq/MissedSelectOpportunity.ql
+++ b/csharp/ql/src/Linq/MissedSelectOpportunity.ql
@@ -23,7 +23,7 @@ predicate oversized(LocalVariableDeclStmt s) {
 from ForeachStmt fes, LocalVariableDeclStmt s
 where
   missedSelectOpportunity(fes, s) and
-  not (oversized(s))
+  not oversized(s)
 select fes,
   "This foreach loop immediately maps its iteration variable to another variable $@ - consider mapping the sequence explicitly using '.Select(...)'.",
   s, "here"

--- a/csharp/ql/src/Metrics/Files/FCommentRatio.ql
+++ b/csharp/ql/src/Metrics/Files/FCommentRatio.ql
@@ -17,5 +17,5 @@ where
   total = f.getNumberOfLinesOfCode() + f.getNumberOfLinesOfComments() and
   if total = 0
   then ratio = 0.0
-  else ratio = 100.0 * (f.getNumberOfLinesOfComments().(float)) / (total.(float))
+  else ratio = 100.0 * f.getNumberOfLinesOfComments().(float) / total.(float)
 select f, ratio order by ratio desc

--- a/csharp/ql/src/Metrics/RefTypes/TNumberOfNonConstFields.ql
+++ b/csharp/ql/src/Metrics/RefTypes/TNumberOfNonConstFields.ql
@@ -15,6 +15,6 @@ where
   t.isSourceDeclaration() and
   n = count(Field f |
       f.getDeclaringType() = t and
-      not (f instanceof MemberConstant)
+      not f instanceof MemberConstant
     )
 select t, n order by n desc

--- a/csharp/ql/src/Security Features/CWE-134/UncontrolledFormatString.ql
+++ b/csharp/ql/src/Security Features/CWE-134/UncontrolledFormatString.ql
@@ -18,10 +18,8 @@ import DataFlow::PathGraph
 
 class FormatStringConfiguration extends TaintTracking::Configuration {
   FormatStringConfiguration() { this = "FormatStringConfiguration" }
-  
-  override predicate isSource(DataFlow::Node source) {
-    source instanceof RemoteFlowSource
-  }
+
+  override predicate isSource(DataFlow::Node source) { source instanceof RemoteFlowSource }
 
   override predicate isSink(DataFlow::Node sink) {
     sink.asExpr() = any(FormatCall call).getFormatExpr()
@@ -30,5 +28,5 @@ class FormatStringConfiguration extends TaintTracking::Configuration {
 
 from FormatStringConfiguration config, DataFlow::PathNode source, DataFlow::PathNode sink
 where config.hasFlowPath(source, sink)
-select sink.getNode(), source, sink,
-  "$@ flows to here and is used as a format string.", source.getNode(), source.getNode().toString()
+select sink.getNode(), source, sink, "$@ flows to here and is used as a format string.",
+  source.getNode(), source.getNode().toString()

--- a/csharp/ql/src/definitions.ql
+++ b/csharp/ql/src/definitions.ql
@@ -57,9 +57,11 @@ class MethodUse extends Use, QualifiableExpr {
 
   /** Gets the qualifier of this method use, if any. */
   private Expr getFormatQualifier() {
-    if this.getQualifiedDeclaration().(Method).isExtensionMethod()
-    then result = this.(MethodCall).getArgument(0)
-    else result = this.getQualifier() and
+    (
+      if this.getQualifiedDeclaration().(Method).isExtensionMethod()
+      then result = this.(MethodCall).getArgument(0)
+      else result = this.getQualifier()
+    ) and
     not result.isImplicit()
   }
 

--- a/csharp/ql/src/filters/ChangedLines.ql
+++ b/csharp/ql/src/filters/ChangedLines.ql
@@ -16,5 +16,5 @@ where
   or
   changedLine(res.getFile(), res.getEndLine())
   or
-  (res.getStartLine() = 0 and changedLine(res.getFile(), _))
+  res.getStartLine() = 0 and changedLine(res.getFile(), _)
 select res, res.getMessage()

--- a/csharp/ql/src/filters/NotInTestFile.ql
+++ b/csharp/ql/src/filters/NotInTestFile.ql
@@ -10,5 +10,5 @@ import semmle.code.csharp.frameworks.Test
 import external.DefectFilter
 
 from DefectResult res
-where not (res.getFile() instanceof TestFile)
+where not res.getFile() instanceof TestFile
 select res, res.getMessage()

--- a/csharp/ql/src/filters/NotInTestFileForMetric.ql
+++ b/csharp/ql/src/filters/NotInTestFileForMetric.ql
@@ -10,5 +10,5 @@ import semmle.code.csharp.frameworks.Test
 import external.MetricFilter
 
 from MetricResult res
-where not (res.getFile() instanceof TestFile)
+where not res.getFile() instanceof TestFile
 select res, res.getValue()

--- a/csharp/ql/src/filters/NotInTestMethod.ql
+++ b/csharp/ql/src/filters/NotInTestMethod.ql
@@ -11,7 +11,7 @@ import external.DefectFilter
 
 from DefectResult res
 where
-  not (res.getFile() instanceof TestFile)
+  not res.getFile() instanceof TestFile
   or
-  not (res.getStartLine() = res.getFile().(TestFile).lineInTestMethod())
+  not res.getStartLine() = res.getFile().(TestFile).lineInTestMethod()
 select res, res.getMessage()

--- a/csharp/ql/src/filters/NotInTestMethodExpectingException.ql
+++ b/csharp/ql/src/filters/NotInTestMethodExpectingException.ql
@@ -18,7 +18,7 @@ predicate ignoredLine(File f, int line) {
 
 from DefectResult res
 where
-  not (res.getFile() instanceof TestFile)
+  not res.getFile() instanceof TestFile
   or
   not ignoredLine(res.getFile(), res.getStartLine())
 select res, res.getMessage()

--- a/csharp/ql/src/filters/UnchangedLines.ql
+++ b/csharp/ql/src/filters/UnchangedLines.ql
@@ -17,6 +17,6 @@ where
     or
     changedLine(res.getFile(), res.getEndLine())
     or
-    (res.getStartLine() = 0 and changedLine(res.getFile(), _))
+    res.getStartLine() = 0 and changedLine(res.getFile(), _)
   )
 select res, res.getMessage()

--- a/csharp/ql/test/library-tests/cil/consistency/Handles.ql
+++ b/csharp/ql/test/library-tests/cil/consistency/Handles.ql
@@ -2,11 +2,11 @@ import csharp
 import cil
 import dotnet
 
-class MetadataEntity extends DotNet::NamedElement, @metadata_entity {  
+class MetadataEntity extends DotNet::NamedElement, @metadata_entity {
   int getHandle() { metadata_handle(this, _, result) }
-  
+
   predicate hasHandle() { exists(getHandle()) }
-  
+
   Assembly getAssembly() { metadata_handle(this, result, _) }
 }
 
@@ -28,10 +28,8 @@ query predicate missingCil(Element e) {
 }
 
 query predicate cilLocationViolation(CIL::Element e) {
-  e instanceof MetadataEntity
-  and
-  exists(e.getALocation())
-  and
+  e instanceof MetadataEntity and
+  exists(e.getALocation()) and
   not e.getALocation() = e.(MetadataEntity).getAssembly()
 }
 
@@ -43,8 +41,8 @@ query predicate csharpLocationViolation(Element e) {
 
 query predicate matchingObjectMethods(string s1, string s2) {
   exists(Callable m1, CIL::Method m2 |
-    m1.getDeclaringType().getQualifiedName() = "System.Object"
-    and m1.matchesHandle(m2) and
+    m1.getDeclaringType().getQualifiedName() = "System.Object" and
+    m1.matchesHandle(m2) and
     s1 = m1.toStringWithTypes() and
     s2 = m2.toStringWithTypes()
   )

--- a/csharp/ql/test/library-tests/controlflow/graph/ConditionalFlow.ql
+++ b/csharp/ql/test/library-tests/controlflow/graph/ConditionalFlow.ql
@@ -1,9 +1,9 @@
 import csharp
 
 ControlFlow::Node successor(ControlFlow::Node node, boolean kind) {
-  (kind = true and result = node.getATrueSuccessor())
+  kind = true and result = node.getATrueSuccessor()
   or
-  (kind = false and result = node.getAFalseSuccessor())
+  kind = false and result = node.getAFalseSuccessor()
 }
 
 from ControlFlow::Node node, ControlFlow::Node successor, Location nl, Location sl, boolean kind

--- a/csharp/ql/test/library-tests/csharp6/MemberAccess1.ql
+++ b/csharp/ql/test/library-tests/csharp6/MemberAccess1.ql
@@ -6,7 +6,7 @@ import csharp
 
 from MemberAccess ma, string conditional
 where
-  (ma.isConditional() and conditional = "Conditional")
+  ma.isConditional() and conditional = "Conditional"
   or
-  (not ma.isConditional() and conditional = "Unconditional")
+  not ma.isConditional() and conditional = "Unconditional"
 select ma, ma.getQualifier(), conditional

--- a/csharp/ql/test/library-tests/csharp6/MemberAccess2.ql
+++ b/csharp/ql/test/library-tests/csharp6/MemberAccess2.ql
@@ -6,7 +6,7 @@ import csharp
 
 from MethodCall mc, string conditional
 where
-  (mc.isConditional() and conditional = "Conditional")
+  mc.isConditional() and conditional = "Conditional"
   or
-  (not mc.isConditional() and conditional = "Unconditional")
+  not mc.isConditional() and conditional = "Unconditional"
 select mc, mc.getQualifier(), conditional

--- a/csharp/ql/test/library-tests/dataflow/defuse/defUseEquivalence.ql
+++ b/csharp/ql/test/library-tests/dataflow/defuse/defUseEquivalence.ql
@@ -28,15 +28,11 @@ private LocalScopeVariableRead getAReachableUncertainRead(AssignableDefinition d
 
 from AssignableDefinition def, LocalScopeVariableRead read, string s
 where
-  (
-    read = getAReachableUncertainRead(def) and
-    not defUsePair(def, read) and
-    s = "not a def/use pair"
-  )
+  read = getAReachableUncertainRead(def) and
+  not defUsePair(def, read) and
+  s = "not a def/use pair"
   or
-  (
-    defUsePair(def, read) and
-    not read = getAReachableUncertainRead(def) and
-    s = "missing def/use pair"
-  )
+  defUsePair(def, read) and
+  not read = getAReachableUncertainRead(def) and
+  s = "missing def/use pair"
 select def, read, s

--- a/csharp/ql/test/library-tests/dataflow/defuse/parameterUseEquivalence.ql
+++ b/csharp/ql/test/library-tests/dataflow/defuse/parameterUseEquivalence.ql
@@ -28,15 +28,11 @@ private LocalScopeVariableRead getAReachableUncertainRead(
 
 from AssignableDefinitions::ImplicitParameterDefinition p, AssignableRead read, string s
 where
-  (
-    read = getAReachableUncertainRead(p) and
-    not parameterUsePair(p.getParameter(), read) and
-    s = "not a param/use pair"
-  )
+  read = getAReachableUncertainRead(p) and
+  not parameterUsePair(p.getParameter(), read) and
+  s = "not a param/use pair"
   or
-  (
-    parameterUsePair(p.getParameter(), read) and
-    not read = getAReachableUncertainRead(p) and
-    s = "missing param/use pair"
-  )
+  parameterUsePair(p.getParameter(), read) and
+  not read = getAReachableUncertainRead(p) and
+  s = "missing param/use pair"
 select p, read, s

--- a/csharp/ql/test/library-tests/dataflow/defuse/useUseEquivalence.ql
+++ b/csharp/ql/test/library-tests/dataflow/defuse/useUseEquivalence.ql
@@ -62,7 +62,7 @@ private LocalScopeVariableRead getAReachableRead(LocalScopeVariableRead read) {
 
 from LocalScopeVariableRead read1, LocalScopeVariableRead read2, string s
 where
-  (read2 = getAReachableRead(read1) and not useUsePair(read1, read2) and s = "not a use/use pair")
+  read2 = getAReachableRead(read1) and not useUsePair(read1, read2) and s = "not a use/use pair"
   or
-  (useUsePair(read1, read2) and not read2 = getAReachableRead(read1) and s = "missing use/use pair")
+  useUsePair(read1, read2) and not read2 = getAReachableRead(read1) and s = "missing use/use pair"
 select read1, read2, s

--- a/csharp/ql/test/library-tests/dataflow/ssa/PreSsaConsistency.ql
+++ b/csharp/ql/test/library-tests/dataflow/ssa/PreSsaConsistency.ql
@@ -2,13 +2,10 @@ import csharp
 import ControlFlow::Internal
 
 class CallableWithSplitting extends Callable {
-  CallableWithSplitting() {
-    this = any(SplitControlFlowElement e).getEnclosingCallable()
-  }
+  CallableWithSplitting() { this = any(SplitControlFlowElement e).getEnclosingCallable() }
 }
 
-query
-predicate defReadInconsistency(
+query predicate defReadInconsistency(
   AssignableRead ar, Expr e, PreSsa::SimpleAssignable a, boolean b
 ) {
   // Exclude definitions in callables with CFG splitting, as SSA definitions may be
@@ -48,7 +45,8 @@ query predicate readReadInconsistency(
     b = true and
     a = read1.getTarget() and
     PreSsa::adjacentReadPairSameVar(read1, read2) and
-    not Ssa::Internal::adjacentReadPairSameVar(read1.getAControlFlowNode(), read2.getAControlFlowNode())
+    not Ssa::Internal::adjacentReadPairSameVar(read1.getAControlFlowNode(),
+      read2.getAControlFlowNode())
     or
     b = false and
     a = read1.getTarget() and

--- a/csharp/ql/test/library-tests/dataflow/ssa/SsaCapturedVariableDef.ql
+++ b/csharp/ql/test/library-tests/dataflow/ssa/SsaCapturedVariableDef.ql
@@ -2,11 +2,9 @@ import csharp
 
 from string inout, Ssa::ExplicitDefinition def, Ssa::Definition targetDef, Call c
 where
-  (inout = "in" and def.isCapturedVariableDefinitionFlowIn(targetDef, c))
+  inout = "in" and def.isCapturedVariableDefinitionFlowIn(targetDef, c)
   or
-  (
-    inout = "out" and
-    def.isCapturedVariableDefinitionFlowOut(targetDef) and
-    targetDef.(Ssa::ImplicitCallDefinition).getCall() = c
-  )
+  inout = "out" and
+  def.isCapturedVariableDefinitionFlowOut(targetDef) and
+  targetDef.(Ssa::ImplicitCallDefinition).getCall() = c
 select inout, def.getSourceVariable(), def, targetDef, c

--- a/csharp/ql/test/library-tests/generics/Generics2.ql
+++ b/csharp/ql/test/library-tests/generics/Generics2.ql
@@ -7,5 +7,5 @@ import csharp
 from Class c
 where
   c.hasName("A") and
-  not (c instanceof UnboundGenericClass)
+  not c instanceof UnboundGenericClass
 select c


### PR DESCRIPTION
Rerun the autoformatter on all `.ql` files, to remove unnecessary parentheses.