### PR TITLE
Python tests: Increase import depth to ensure sre_constants module is imported

### DIFF
--- a/python/ql/test/query-tests/Expressions/Regex/options
+++ b/python/ql/test/query-tests/Expressions/Regex/options
@@ -1,1 +1,1 @@
-semmle-extractor-options: --max-import-depth=2
+semmle-extractor-options: --max-import-depth=3


### PR DESCRIPTION
Same as https://github.com/Semmle/ql/pull/753, but for the query tests.