### PR TITLE
C++: Speed up Expr.getFullyConverted slightly

### DIFF
--- a/cpp/ql/src/semmle/code/cpp/exprs/Expr.qll
+++ b/cpp/ql/src/semmle/code/cpp/exprs/Expr.qll
@@ -335,10 +335,10 @@ class Expr extends StmtParent, @expr {
   /** Gets the fully converted form of this expression, including all type casts and other conversions. */
   cached
   Expr getFullyConverted() {
-    if this.hasConversion() then
-      result = this.getConversion().getFullyConverted()
-    else
-      result = this
+    hasNoConversions(this) and
+    result = this
+    or
+    result = this.getConversion().getFullyConverted()
   }
 
   /**
@@ -977,3 +977,6 @@ private predicate isStandardPlacementNewAllocator(Function operatorNew) {
   operatorNew.getNumberOfParameters() = 2 and
   operatorNew.getParameter(1).getType() instanceof VoidPointerType
 }
+
+// Pulled out for performance. See QL-796.
+private predicate hasNoConversions(Expr e) { not e.hasConversion() }


### PR DESCRIPTION
This is another workaround for QL-796. This change cuts around 15% of the run time off this predicate, which previously took around 7 seconds on Wireshark.

The performance gains do not obviously outweigh the added complexity, but I could only measure the speed-up after writing the code, and I thought it was better to make a PR from it than to throw it away.