### PR TITLE
C++: Add addresses to `Expr.isConstant`

### DIFF
--- a/change-notes/1.20/analysis-cpp.md
+++ b/change-notes/1.20/analysis-cpp.md
@@ -19,4 +19,5 @@
 
 ## Changes to QL libraries
 
-There is a new `Namespace.isInline()` predicate, which holds if the namespace was declared as `inline namespace`.
+* There is a new `Namespace.isInline()` predicate, which holds if the namespace was declared as `inline namespace`.
+* The `Expr.isConstant()` predicate now also holds for _address constant expressions_, which are addresses that will be constant after the program has been linked. These address constants do not have a result for `Expr.getValue()`.

--- a/cpp/ql/src/Likely Bugs/Likely Typos/LogicalExprCouldBeSimplified.ql
+++ b/cpp/ql/src/Likely Bugs/Likely Typos/LogicalExprCouldBeSimplified.ql
@@ -43,7 +43,7 @@ string comparisonOnLiterals(ComparisonOperation op) {
   simple(op.getLeftOperand()) and
   simple(op.getRightOperand()) and
   not op.getAnOperand().isInMacroExpansion() and
-  if op.isConstant()
+  if exists(op.getValue())
   then result = "This comparison involves two literals and is always " + op.getValue() + "."
   else result = "This comparison involves two literals and should be simplified."
 }

--- a/cpp/ql/src/semmle/code/cpp/controlflow/internal/CFG.qll
+++ b/cpp/ql/src/semmle/code/cpp/controlflow/internal/CFG.qll
@@ -461,38 +461,16 @@ private predicate skipInitializer(Initializer init) {
  */
 private predicate runtimeExprInStaticInitializer(Expr e) {
   inStaticInitializer(e) and
-  if
-    e instanceof AggregateLiteral
-    or
-    e instanceof PointerArithmeticOperation
-    or
-    // Extractor doesn't populate this specifier at the time of writing, so
-    // this case has not been tested. See CPP-314.
-    e.(FunctionCall).getTarget().hasSpecifier("constexpr")
+  if e instanceof AggregateLiteral
   then runtimeExprInStaticInitializer(e.getAChild())
-  else (
-    // Not constant
-    not e.isConstant() and
-    // Not a function address
-    not e instanceof FunctionAccess and
-    // Not a function address-of (same as above)
-    not e.(AddressOfExpr).getOperand() instanceof FunctionAccess and
-    // Not the address of a global variable
-    not exists(Variable v |
-      v.isStatic()
-      or
-      v instanceof GlobalOrNamespaceVariable
-    |
-      e.(AddressOfExpr).getOperand() = v.getAnAccess()
-    )
-  )
+  else not e.getFullyConverted().isConstant()
 }
 
 /** Holds if `e` is part of the initializer of a local static variable. */
 private predicate inStaticInitializer(Expr e) {
   exists(LocalVariable local |
     local.isStatic() and
-    e.(Node).getParentNode*() = local.getInitializer()
+    e.getParent+() = local.getInitializer()
   )
 }
 

--- a/cpp/ql/src/semmle/code/cpp/exprs/Expr.qll
+++ b/cpp/ql/src/semmle/code/cpp/exprs/Expr.qll
@@ -2,6 +2,7 @@
 import semmle.code.cpp.Element
 private import semmle.code.cpp.Enclosing
 private import semmle.code.cpp.internal.ResolveClass
+private import semmle.code.cpp.internal.AddressConstantExpression
 
 /**
  * A C/C++ expression.
@@ -84,7 +85,12 @@ class Expr extends StmtParent, @expr {
   string getValueText() { exists(@value v | values(v,_,result) and valuebind(v,underlyingElement(this))) }
   
   /** Holds if this expression has a value that can be determined at compile time. */
-  predicate isConstant() { valuebind(_,underlyingElement(this)) }
+  cached
+  predicate isConstant() {
+    valuebind(_,underlyingElement(this))
+    or
+    addressConstantExpression(this)
+  }
 
   /**
    * Holds if this expression is side-effect free (conservative

--- a/cpp/ql/src/semmle/code/cpp/internal/AddressConstantExpression.qll
+++ b/cpp/ql/src/semmle/code/cpp/internal/AddressConstantExpression.qll
@@ -16,15 +16,8 @@ private predicate addressConstantVariable(Variable v) {
   addressConstantExpression(v.getInitializer().getExpr().getFullyConverted()) and
   // Here we should also require that `v` is constexpr, but we don't have that
   // information in the db. See CPP-314. Instead, we require that the variable
-  // is not assigned to.
-  not exists(VariableAccess va | va.getTarget() = v |
-    // `v` may be assigned to, completely or partially
-    exists(Expr lvalue | variableAccessedAsValue(va, lvalue) |
-      lvalue = any(Assignment a).getLValue().getFullyConverted()
-      or
-      lvalue = any(CrementOperation c).getOperand().getFullyConverted()
-    )
-  )
+  // is never defined except in its initializer.
+  forall(Expr def | definition(v, def) | def = any(Initializer init).getExpr())
 }
 
 /**

--- a/cpp/ql/src/semmle/code/cpp/internal/AddressConstantExpression.qll
+++ b/cpp/ql/src/semmle/code/cpp/internal/AddressConstantExpression.qll
@@ -1,0 +1,191 @@
+private import cpp
+private import semmle.code.cpp.dataflow.EscapesTree
+
+predicate addressConstantExpression(Expr e) {
+  constantAddressPointer(e)
+  or
+  constantAddressReference(e)
+  or
+  // Special case for function pointers, where `fp == *fp`.
+  constantAddressLValue(e) and
+  e.getType() instanceof FunctionPointerType
+}
+
+/** Holds if `v` is a constexpr variable initialized to a constant address. */
+private predicate addressConstantVariable(Variable v) {
+  addressConstantExpression(v.getInitializer().getExpr().getFullyConverted()) and
+  // Here we should also require that `v` is constexpr, but we don't have that
+  // information in the db. See CPP-314. Instead, we require that the variable
+  // is not assigned to.
+  not exists(VariableAccess va | va.getTarget() = v |
+    // `v` may be assigned to, completely or partially
+    exists(Expr lvalue | variableAccessedAsValue(va, lvalue) |
+      lvalue = any(Assignment a).getLValue().getFullyConverted()
+      or
+      lvalue = any(CrementOperation c).getOperand().getFullyConverted()
+    )
+  )
+}
+
+/**
+ * Holds if `lvalue` is an lvalue whose address is an _address constant
+ * expression_.
+ */
+private predicate constantAddressLValue(Expr lvalue) {
+  lvalue.(VariableAccess).getTarget() = any(Variable v |
+      v.(Variable).isStatic()
+      or
+      v instanceof GlobalOrNamespaceVariable
+    )
+  or
+  // There is no `Conversion` for the implicit conversion from a function type
+  // to a function _pointer_ type. Instead, the type of a `FunctionAccess`
+  // tells us how it's going to be used.
+  lvalue.(FunctionAccess).getType() instanceof RoutineType
+  or
+  // String literals have array types and undergo array-to-pointer conversion.
+  lvalue instanceof StringLiteral
+  or
+  // lvalue -> lvalue
+  exists(Expr prev |
+    constantAddressLValue(prev) and
+    lvalueToLvalueStep(prev, lvalue)
+  )
+  or
+  // pointer -> lvalue
+  exists(Expr prev |
+    constantAddressPointer(prev) and
+    pointerToLvalueStep(prev, lvalue)
+  )
+  or
+  // reference -> lvalue
+  exists(Expr prev |
+    constantAddressReference(prev) and
+    referenceToLvalueStep(prev, lvalue)
+  )
+}
+
+/** Holds if `pointer` is an _address constant expression_ of pointer type. */
+private predicate constantAddressPointer(Expr pointer) {
+  // There is no `Conversion` for the implicit conversion from a function type
+  // to a function _pointer_ type. Instead, the type of a `FunctionAccess`
+  // tells us how it's going to be used.
+  pointer.(FunctionAccess).getType() instanceof FunctionPointerType
+  or
+  addressConstantVariable(pointer.(VariableAccess).getTarget()) and
+  pointer.getType().getUnderlyingType() instanceof PointerType
+  or
+  // pointer -> pointer
+  exists(Expr prev |
+    constantAddressPointer(prev) and
+    pointerToPointerStep(prev, pointer)
+  )
+  or
+  // lvalue -> pointer
+  exists(Expr prev |
+    constantAddressLValue(prev) and
+    lvalueToPointerStep(prev, pointer)
+  )
+}
+
+/** Holds if `reference` is an _address constant expression_ of reference type. */
+private predicate constantAddressReference(Expr reference) {
+  addressConstantVariable(reference.(VariableAccess).getTarget()) and
+  reference.getType().getUnderlyingType() instanceof ReferenceType
+  or
+  addressConstantVariable(reference.(VariableAccess).getTarget()) and
+  reference.getType().getUnderlyingType() instanceof FunctionReferenceType // not a ReferenceType
+  or
+  // reference -> reference
+  exists(Expr prev |
+    constantAddressReference(prev) and
+    referenceToReferenceStep(prev, reference)
+  )
+  or
+  // lvalue -> reference
+  exists(Expr prev |
+    constantAddressLValue(prev) and
+    lvalueToReferenceStep(prev, reference)
+  )
+}
+
+private predicate lvalueToLvalueStep(Expr lvalueIn, Expr lvalueOut) {
+  lvalueIn = lvalueOut.(DotFieldAccess).getQualifier().getFullyConverted()
+  or
+  lvalueIn.getConversion() = lvalueOut.(ParenthesisExpr)
+  or
+  // Special case for function pointers, where `fp == *fp`.
+  lvalueIn = lvalueOut.(PointerDereferenceExpr).getOperand().getFullyConverted() and
+  lvalueIn.getType() instanceof FunctionPointerType
+}
+
+private predicate pointerToLvalueStep(Expr pointerIn, Expr lvalueOut) {
+  lvalueOut = any(ArrayExpr ae |
+      pointerIn = ae.getArrayBase().getFullyConverted() and
+      hasConstantValue(ae.getArrayOffset().getFullyConverted())
+    )
+  or
+  pointerIn = lvalueOut.(PointerDereferenceExpr).getOperand().getFullyConverted()
+  or
+  pointerIn = lvalueOut.(PointerFieldAccess).getQualifier().getFullyConverted()
+}
+
+private predicate lvalueToPointerStep(Expr lvalueIn, Expr pointerOut) {
+  lvalueIn.getConversion() = pointerOut.(ArrayToPointerConversion)
+  or
+  lvalueIn = pointerOut.(AddressOfExpr).getOperand().getFullyConverted()
+}
+
+private predicate pointerToPointerStep(Expr pointerIn, Expr pointerOut) {
+  (
+    pointerOut instanceof PointerAddExpr
+    or
+    pointerOut instanceof PointerSubExpr
+  ) and
+  pointerIn = pointerOut.getAChild().getFullyConverted() and
+  pointerIn.getType().getUnspecifiedType() instanceof PointerType and
+  // The pointer arg won't be constant in the sense of `hasConstantValue`, so
+  // this will have to match the integer argument.
+  hasConstantValue(pointerOut.getAChild().getFullyConverted())
+  or
+  pointerIn = pointerOut.(UnaryPlusExpr).getOperand().getFullyConverted()
+  or
+  pointerIn.getConversion() = pointerOut.(Cast)
+  or
+  pointerIn.getConversion() = pointerOut.(ParenthesisExpr)
+  or
+  pointerOut = any(ConditionalExpr cond |
+      cond.getCondition().getFullyConverted().getValue().toInt() != 0 and
+      pointerIn = cond.getThen().getFullyConverted()
+      or
+      cond.getCondition().getFullyConverted().getValue().toInt() = 0 and
+      pointerIn = cond.getElse().getFullyConverted()
+    )
+  or
+  // The comma operator is allowed by C++17 but disallowed by C99. This
+  // disjunct is a compromise that's chosen for being easy to implement.
+  pointerOut = any(CommaExpr comma |
+      hasConstantValue(comma.getLeftOperand()) and
+      pointerIn = comma.getRightOperand().getFullyConverted()
+    )
+}
+
+private predicate lvalueToReferenceStep(Expr lvalueIn, Expr referenceOut) {
+  lvalueIn.getConversion() = referenceOut.(ReferenceToExpr)
+}
+
+private predicate referenceToLvalueStep(Expr referenceIn, Expr lvalueOut) {
+  // This probably cannot happen. It would require an expression to be
+  // converted to a reference and back again without an intermediate variable
+  // assignment.
+  referenceIn.getConversion() = lvalueOut.(ReferenceDereferenceExpr)
+}
+
+private predicate referenceToReferenceStep(Expr referenceIn, Expr referenceOut) {
+  referenceIn.getConversion() = referenceOut.(Cast)
+  or
+  referenceIn.getConversion() = referenceOut.(ParenthesisExpr)
+}
+
+/** Holds if `e` is constant according to the database. */
+private predicate hasConstantValue(Expr e) { valuebind(_, underlyingElement(e)) }

--- a/cpp/ql/src/semmle/code/cpp/ir/implementation/raw/internal/TranslatedElement.qll
+++ b/cpp/ql/src/semmle/code/cpp/ir/implementation/raw/internal/TranslatedElement.qll
@@ -50,6 +50,13 @@ private Element getRealParent(Expr expr) {
 }
 
 /**
+ * Holds if `expr` is a constant of a type that can be replaced directly with
+ * its value in the IR. This does not include address constants as we have no
+ * means to express those as QL values.
+ */
+predicate isIRConstant(Expr expr) { exists(expr.getValue()) }
+
+/**
  * Holds if `expr` and all of its descendants should be ignored for the purposes
  * of IR generation due to some property of `expr` itself. Unlike
  * `ignoreExpr()`, this predicate does not ignore an expression solely because
@@ -63,7 +70,7 @@ private predicate ignoreExprAndDescendants(Expr expr) {
   getRealParent(expr) instanceof SwitchCase or
   // Ignore descendants of constant expressions, since we'll just substitute the
   // constant value.
-  getRealParent(expr).(Expr).isConstant() or
+  isIRConstant(getRealParent(expr)) or
   // The `DestructorCall` node for a `DestructorFieldDestruction` has a `FieldAccess`
   // node as its qualifier, but that `FieldAccess` does not have a child of its own.
   // We'll ignore that `FieldAccess`, and supply the receiver as part of the calling
@@ -146,7 +153,7 @@ private predicate translateStmt(Stmt stmt) {
  */
 private predicate isNativeCondition(Expr expr) {
   expr instanceof BinaryLogicalOperation and
-  not expr.isConstant()
+  not isIRConstant(expr)
 }
 
 /**
@@ -159,7 +166,7 @@ private predicate isFlexibleCondition(Expr expr) {
     expr instanceof NotExpr
   ) and
   usedAsCondition(expr) and
-  not expr.isConstant()
+  not isIRConstant(expr)
 }
 
 /**

--- a/cpp/ql/src/semmle/code/cpp/ir/implementation/raw/internal/TranslatedExpr.qll
+++ b/cpp/ql/src/semmle/code/cpp/ir/implementation/raw/internal/TranslatedExpr.qll
@@ -962,7 +962,7 @@ class TranslatedFunctionAccess extends TranslatedNonConstantExpr {
 abstract class TranslatedNonConstantExpr extends TranslatedCoreExpr {
   TranslatedNonConstantExpr() {
     this = TTranslatedValueExpr(expr) and
-    not expr.isConstant()
+    not isIRConstant(expr)
   }
 }
 
@@ -974,7 +974,7 @@ abstract class TranslatedNonConstantExpr extends TranslatedCoreExpr {
 abstract class TranslatedConstantExpr extends TranslatedCoreExpr {
   TranslatedConstantExpr() {
     this = TTranslatedValueExpr(expr) and
-    expr.isConstant()
+    isIRConstant(expr)
   }
 
   override final Instruction getFirstInstruction() {

--- a/cpp/ql/test/library-tests/constants/addresses/addresses.cpp
+++ b/cpp/ql/test/library-tests/constants/addresses/addresses.cpp
@@ -1,0 +1,86 @@
+// semmle-extractor-options: --c++14
+
+const int int_const = 1;
+extern const int extern_int_const = 1;
+extern const int extern_int_const_noinit;
+
+int int_var;
+int int_arr[4];
+int int_arr_arr[4][4];
+
+int *const const_ptr = &int_var;
+
+void sideEffect();
+using fptr = void (*)();
+using fref = void (&)();
+
+
+
+// All variables in this function are initialized to constants, as witnessed by
+// the `constexpr` annotation that compiles under C++14.
+void constantAddresses(int param) {
+    constexpr int *ptr_int = &int_var;
+    constexpr int *ptr_deref_chain = &*&int_var;
+    constexpr int *ptr_array = &int_arr[1] + 1;
+    constexpr int (*ptr_to_array)[4] = &int_arr_arr[1] + 1;
+    constexpr int *array2d = &int_arr_arr[1][1] + 1;
+    constexpr int *const_ints = &int_arr_arr[int_const][extern_int_const];
+
+    // Commented out because clang and EDG disagree on whether this is
+    // constant.
+    //constexpr int *stmtexpr_int = &int_arr[ ({ 1; }) ];
+
+    constexpr int *comma_int = &int_arr[ ((void)0, 1) ];
+    constexpr int *comma_addr = ((void)0, &int_var);
+    constexpr int *ternary_true = int_const ? &int_var : &param;
+    constexpr int *ternary_false = !int_const ? &param : &int_var;
+    constexpr int *ternary_overflow = (unsigned char)256 ? &param : &int_var;
+    constexpr int *ternary_ptr_cond = (&int_arr+1) ? &int_var : &param;;
+    constexpr int *ptr_subtract = &int_arr[&int_arr[1] - &int_arr[0]];
+
+    constexpr int *constexpr_va = ptr_subtract + 1;
+
+    constexpr int &ref_int = int_var;
+    constexpr int &ref_array2d = int_arr_arr[1][1];
+    constexpr int &ref_va = ref_array2d;
+    constexpr int &ref_va_arith = *(&ref_array2d + 1);
+
+    constexpr fptr fp_implicit = sideEffect;
+    constexpr fptr fp_explicit = &sideEffect;
+    constexpr fptr fp_chain_addressof = &**&**sideEffect;
+    constexpr fptr fp_chain_deref = **&**&**sideEffect;
+    constexpr fptr fp_shortchain_deref = *&sideEffect;
+
+    constexpr fref fr_int = sideEffect;
+    constexpr fref fr_deref = *&sideEffect;
+    constexpr fref fr_2deref = **sideEffect;
+    constexpr fref fr_va = fr_int;
+
+    constexpr const char *char_ptr = "str";
+    constexpr const char *char_ptr_1 = "str" + 1;
+    constexpr char char_arr[] = "str";
+}
+
+
+
+
+// All variables in this function are initialized to non-const values. Writing
+// `constexpr` in front of any of the variables will be a compile error
+// (C++14).
+void nonConstantAddresses(const int param, int *const pparam, int &rparam, fref frparam) {
+    int *int_param = &int_arr[param];
+    int *int_noinit = &int_arr[extern_int_const_noinit];
+
+    int *side_effect_stmtexpr = &int_arr[ ({ sideEffect(); 1; }) ];
+    int *side_effect_comma_int = &int_arr[ (sideEffect(), 1) ];
+    int *side_effect_comma_addr = (sideEffect(), &int_var);
+    int *side_effect_comma_addr2 = ((void)(sideEffect(), 1), &int_var);
+    int *ternary_int = &int_arr[int_const ? param : 1];
+    const int *ternary_addr = int_const ? &param : &int_var;
+    int *va_non_constexpr = pparam;
+
+    int *&&ref_to_temporary = &int_var; // reference to temporary is not a const
+    int &ref_param = rparam;
+
+    fref fr_param = frparam;
+}

--- a/cpp/ql/test/library-tests/constants/addresses/addresses.ql
+++ b/cpp/ql/test/library-tests/constants/addresses/addresses.ql
@@ -1,0 +1,16 @@
+import cpp
+
+from Expr e, string msg, LocalVariable var, Function f
+where
+  e = var.getInitializer().getExpr().getFullyConverted() and
+  var.getFunction() = f and
+  (
+    e.isConstant() and
+    f.getName() = "nonConstantAddresses" and
+    msg = "misclassified as constant"
+    or
+    not e.isConstant() and
+    f.getName() = "constantAddresses" and
+    msg = "misclassified as NOT constant"
+  )
+select e, var.getName(), msg

--- a/cpp/ql/test/library-tests/qlcfg/cpp11.cpp
+++ b/cpp/ql/test/library-tests/qlcfg/cpp11.cpp
@@ -54,6 +54,9 @@ void skip_init() {
 void run_init() {
   int nonstatic;
   static int x1 = global_int;
+
+  // It makes no sense to initialize a static variable to the address of a
+  // non-static variable, but in principle it can be done:
   static int *x2 = &nonstatic;
 }
 


### PR DESCRIPTION
Better modelling of constants was needed to get parity between the QL and extractor CFG wrt. static initialisers. Since I decided to put that functionality into `Expr.isConstant`, I thought it was worth spending some time to get it (mostly) right.