### PR TITLE
C++: Sync files that should be identical

### DIFF
--- a/cpp/ql/src/semmle/code/cpp/ir/implementation/raw/Instruction.qll
+++ b/cpp/ql/src/semmle/code/cpp/ir/implementation/raw/Instruction.qll
@@ -751,6 +751,9 @@ class BinaryInstruction extends Instruction {
     result = getAnOperand().(RightOperand).getDefinitionInstruction()
   }
   
+  /**
+   * Holds if this instruction's operands are `op1` and `op2`, in either order.
+   */
   final predicate hasOperands(Operand op1, Operand op2) {
     op1 = getAnOperand().(LeftOperand) and op2 = getAnOperand().(RightOperand)
     or

--- a/cpp/ql/src/semmle/code/cpp/ir/implementation/raw/gvn/ValueNumbering.qll
+++ b/cpp/ql/src/semmle/code/cpp/ir/implementation/raw/gvn/ValueNumbering.qll
@@ -83,6 +83,10 @@ class ValueNumber extends TValueNumber {
       instr order by instr.getBlock().getDisplayIndex(), instr.getDisplayIndexInBlock()
     )
   }
+  
+  final Operand getAUse() {
+    this = valueNumber(result.getDefinitionInstruction())
+  }
 }
 
 /**
@@ -212,12 +216,19 @@ private predicate uniqueValueNumber(Instruction instr, FunctionIR funcIR) {
 /**
  * Gets the value number assigned to `instr`, if any. Returns at most one result.
  */
-ValueNumber valueNumber(Instruction instr) {
+cached ValueNumber valueNumber(Instruction instr) {
   result = nonUniqueValueNumber(instr) or
   exists(FunctionIR funcIR |
     uniqueValueNumber(instr, funcIR) and
     result = TUniqueValueNumber(funcIR, instr)
   )
+}
+
+/**
+ * Gets the value number assigned to `instr`, if any. Returns at most one result.
+ */
+ValueNumber valueNumberOfOperand(Operand op) {
+  result = valueNumber(op.getDefinitionInstruction())
 }
 
 /**

--- a/cpp/ql/src/semmle/code/cpp/ir/implementation/unaliased_ssa/Instruction.qll
+++ b/cpp/ql/src/semmle/code/cpp/ir/implementation/unaliased_ssa/Instruction.qll
@@ -751,6 +751,9 @@ class BinaryInstruction extends Instruction {
     result = getAnOperand().(RightOperand).getDefinitionInstruction()
   }
   
+  /**
+   * Holds if this instruction's operands are `op1` and `op2`, in either order.
+   */
   final predicate hasOperands(Operand op1, Operand op2) {
     op1 = getAnOperand().(LeftOperand) and op2 = getAnOperand().(RightOperand)
     or

--- a/cpp/ql/src/semmle/code/cpp/ir/implementation/unaliased_ssa/gvn/ValueNumbering.qll
+++ b/cpp/ql/src/semmle/code/cpp/ir/implementation/unaliased_ssa/gvn/ValueNumbering.qll
@@ -83,6 +83,10 @@ class ValueNumber extends TValueNumber {
       instr order by instr.getBlock().getDisplayIndex(), instr.getDisplayIndexInBlock()
     )
   }
+  
+  final Operand getAUse() {
+    this = valueNumber(result.getDefinitionInstruction())
+  }
 }
 
 /**
@@ -212,12 +216,19 @@ private predicate uniqueValueNumber(Instruction instr, FunctionIR funcIR) {
 /**
  * Gets the value number assigned to `instr`, if any. Returns at most one result.
  */
-ValueNumber valueNumber(Instruction instr) {
+cached ValueNumber valueNumber(Instruction instr) {
   result = nonUniqueValueNumber(instr) or
   exists(FunctionIR funcIR |
     uniqueValueNumber(instr, funcIR) and
     result = TUniqueValueNumber(funcIR, instr)
   )
+}
+
+/**
+ * Gets the value number assigned to `instr`, if any. Returns at most one result.
+ */
+ValueNumber valueNumberOfOperand(Operand op) {
+  result = valueNumber(op.getDefinitionInstruction())
 }
 
 /**


### PR DESCRIPTION
These files had come out of sync due to 89148a9ec7 and 8c9c316e1b. I synced the files by replaying the changes that those commits made in `aliased_ssa/` to the two other copies.

Cc @rdmarsh2: the files got out of sync due to some late changes in #633.
Cc @dave-bartolomeo: can we make the sync script part of PR checks for this repo?