### PR TITLE
Python: dill pickle support.

### DIFF
--- a/change-notes/1.20/analysis-python.md
+++ b/change-notes/1.20/analysis-python.md
@@ -23,4 +23,4 @@
 
  ## Changes to QL libraries
 
- * *Series of bullet points*
+ * Added support for the `dill` pickle library.

--- a/python/ql/src/semmle/python/security/injection/Pickle.qll
+++ b/python/ql/src/semmle/python/security/injection/Pickle.qll
@@ -15,6 +15,8 @@ private ModuleObject pickleModule() {
     result.getName() = "pickle"
     or
     result.getName() = "cPickle"
+    or
+    result.getName() = "dill"
 }
 
 private FunctionObject pickleLoads() {

--- a/python/ql/test/query-tests/Security/CWE-502/UnsafeDeserialization.expected
+++ b/python/ql/test/query-tests/Security/CWE-502/UnsafeDeserialization.expected
@@ -3,6 +3,7 @@ edges
 | test.py:11:15:11:41 | externally controlled string | test.py:12:18:12:24 | externally controlled string |
 | test.py:11:15:11:41 | externally controlled string | test.py:13:15:13:21 | externally controlled string |
 | test.py:11:15:11:41 | externally controlled string | test.py:14:19:14:25 | externally controlled string |
+| test.py:11:15:11:41 | externally controlled string | test.py:16:16:16:22 | externally controlled string |
 | test.py:13:15:13:21 | externally controlled string | ../lib/yaml.py:1:10:1:10 | externally controlled string |
 parents
 | ../lib/yaml.py:1:10:1:10 | externally controlled string | test.py:13:15:13:21 | externally controlled string |
@@ -10,3 +11,4 @@ parents
 | test.py:12:18:12:24 | unpickling untrusted data | test.py:11:15:11:26 | dict of externally controlled string | test.py:12:18:12:24 | externally controlled string | Deserializing of $@. | test.py:11:15:11:26 | flask.request.args | untrusted input |
 | test.py:13:15:13:21 | yaml.load vulnerability | test.py:11:15:11:26 | dict of externally controlled string | test.py:13:15:13:21 | externally controlled string | Deserializing of $@. | test.py:11:15:11:26 | flask.request.args | untrusted input |
 | test.py:14:19:14:25 | unmarshaling vulnerability | test.py:11:15:11:26 | dict of externally controlled string | test.py:14:19:14:25 | externally controlled string | Deserializing of $@. | test.py:11:15:11:26 | flask.request.args | untrusted input |
+| test.py:16:16:16:22 | unpickling untrusted data | test.py:11:15:11:26 | dict of externally controlled string | test.py:16:16:16:22 | externally controlled string | Deserializing of $@. | test.py:11:15:11:26 | flask.request.args | untrusted input |

--- a/python/ql/test/query-tests/Security/CWE-502/test.py
+++ b/python/ql/test/query-tests/Security/CWE-502/test.py
@@ -12,5 +12,7 @@ def hello():
     pickle.loads(payload)
     yaml.load(payload)
     marshal.loads(payload)
+    import dill
+    dill.loads(payload)
 
 

--- a/python/ql/test/query-tests/Security/lib/dill.py
+++ b/python/ql/test/query-tests/Security/lib/dill.py
@@ -1,0 +1,2 @@
+def loads(*args, **kwargs):
+    return None


### PR DESCRIPTION
We currently only support `pickle` and `cPickle` for our security queries. This PR adds support for `dill` as well.

A change note has been added @Semmle/doc 