### PR TITLE
C#: Recognize `ref` assignments through delegate calls

### DIFF
--- a/csharp/ql/test/library-tests/assignables/AssignableAccess.expected
+++ b/csharp/ql/test/library-tests/assignables/AssignableAccess.expected
@@ -92,6 +92,7 @@
 | Assignables.cs:123:13:123:13 | access to local variable x | Assignables.cs:123:13:123:13 | x | write |
 | Assignables.cs:124:9:124:9 | access to parameter d | Assignables.cs:121:31:121:31 | d | read |
 | Assignables.cs:124:15:124:15 | access to local variable x | Assignables.cs:123:13:123:13 | x | read |
+| Assignables.cs:124:15:124:15 | access to local variable x | Assignables.cs:123:13:123:13 | x | write |
 | Assignables.cs:124:29:124:29 | String s | Assignables.cs:124:29:124:29 | s | write |
 | Discards.cs:7:9:7:9 | access to parameter x | Discards.cs:5:30:5:30 | x | write |
 | Discards.cs:20:32:20:32 | Boolean z | Discards.cs:20:32:20:32 | z | write |

--- a/csharp/ql/test/library-tests/assignables/AssignableAccess.expected
+++ b/csharp/ql/test/library-tests/assignables/AssignableAccess.expected
@@ -89,6 +89,10 @@
 | Assignables.cs:110:36:110:36 | access to local variable s | Assignables.cs:109:16:109:16 | s | write |
 | Assignables.cs:116:13:116:13 | access to local variable s | Assignables.cs:116:13:116:13 | s | write |
 | Assignables.cs:117:9:117:9 | access to local variable s | Assignables.cs:116:13:116:13 | s | write |
+| Assignables.cs:123:13:123:13 | access to local variable x | Assignables.cs:123:13:123:13 | x | write |
+| Assignables.cs:124:9:124:9 | access to parameter d | Assignables.cs:121:31:121:31 | d | read |
+| Assignables.cs:124:15:124:15 | access to local variable x | Assignables.cs:123:13:123:13 | x | read |
+| Assignables.cs:124:29:124:29 | String s | Assignables.cs:124:29:124:29 | s | write |
 | Discards.cs:7:9:7:9 | access to parameter x | Discards.cs:5:30:5:30 | x | write |
 | Discards.cs:20:32:20:32 | Boolean z | Discards.cs:20:32:20:32 | z | write |
 | Discards.cs:25:27:25:30 | access to parameter args | Discards.cs:23:27:23:30 | args | read |

--- a/csharp/ql/test/library-tests/assignables/AssignableDefinition.expected
+++ b/csharp/ql/test/library-tests/assignables/AssignableDefinition.expected
@@ -80,7 +80,7 @@
 | Assignables.cs:116:13:116:13 | s | Assignables.cs:117:9:117:30 | ... = ... | Assignables.cs:117:9:117:9 | access to local variable s | Assignables.cs:117:13:117:30 | nameof(...) | certain |
 | Assignables.cs:121:31:121:31 | d | Assignables.cs:121:31:121:31 | d | Assignables.cs:121:31:121:31 | <none> | Assignables.cs:121:31:121:31 | <none> | certain |
 | Assignables.cs:123:13:123:13 | x | Assignables.cs:123:13:123:17 | Int32 x = ... | Assignables.cs:123:13:123:13 | access to local variable x | Assignables.cs:123:17:123:17 | 0 | certain |
-| Assignables.cs:124:29:124:29 | s | Assignables.cs:124:29:124:29 | String s | Assignables.cs:124:29:124:29 | <none> | Assignables.cs:124:29:124:29 | <none> | certain |
+| Assignables.cs:123:13:123:13 | x | Assignables.cs:124:15:124:15 | access to local variable x | Assignables.cs:124:15:124:15 | access to local variable x | Assignables.cs:124:15:124:15 | <none> | certain |
 | Assignables.cs:124:29:124:29 | s | Assignables.cs:124:29:124:29 | String s | Assignables.cs:124:29:124:29 | String s | Assignables.cs:124:29:124:29 | <none> | certain |
 | Discards.cs:5:30:5:30 | x | Discards.cs:5:30:5:30 | x | Discards.cs:5:30:5:30 | <none> | Discards.cs:5:30:5:30 | <none> | certain |
 | Discards.cs:5:30:5:30 | x | Discards.cs:7:9:7:17 | ... = ... | Discards.cs:7:9:7:9 | access to parameter x | Discards.cs:7:13:7:17 | false | certain |
@@ -88,7 +88,6 @@
 | Discards.cs:19:14:19:14 | x | Discards.cs:19:14:19:14 | Int32 x | Discards.cs:19:14:19:14 | <none> | Discards.cs:19:14:19:14 | <none> | certain |
 | Discards.cs:20:17:20:17 | y | Discards.cs:20:9:20:33 | ... = ... | Discards.cs:20:9:20:33 | <none> | Discards.cs:20:9:20:33 | <none> | certain |
 | Discards.cs:20:17:20:17 | y | Discards.cs:20:17:20:17 | Double y | Discards.cs:20:17:20:17 | <none> | Discards.cs:20:17:20:17 | <none> | certain |
-| Discards.cs:20:32:20:32 | z | Discards.cs:20:32:20:32 | Boolean z | Discards.cs:20:32:20:32 | <none> | Discards.cs:20:32:20:32 | <none> | certain |
 | Discards.cs:20:32:20:32 | z | Discards.cs:20:32:20:32 | Boolean z | Discards.cs:20:32:20:32 | Boolean z | Discards.cs:20:32:20:32 | <none> | certain |
 | Discards.cs:23:27:23:30 | args | Discards.cs:23:27:23:30 | args | Discards.cs:23:27:23:30 | <none> | Discards.cs:23:27:23:30 | <none> | certain |
 | Discards.cs:30:24:30:24 | o | Discards.cs:30:24:30:24 | o | Discards.cs:30:24:30:24 | <none> | Discards.cs:30:24:30:24 | <none> | certain |

--- a/csharp/ql/test/library-tests/assignables/AssignableDefinition.expected
+++ b/csharp/ql/test/library-tests/assignables/AssignableDefinition.expected
@@ -78,6 +78,10 @@
 | Assignables.cs:115:13:115:13 | i | Assignables.cs:115:13:115:13 | Int32 i | Assignables.cs:115:13:115:13 | <none> | Assignables.cs:115:13:115:13 | <none> | certain |
 | Assignables.cs:116:13:116:13 | s | Assignables.cs:116:13:116:25 | String s = ... | Assignables.cs:116:13:116:13 | access to local variable s | Assignables.cs:116:17:116:25 | nameof(...) | certain |
 | Assignables.cs:116:13:116:13 | s | Assignables.cs:117:9:117:30 | ... = ... | Assignables.cs:117:9:117:9 | access to local variable s | Assignables.cs:117:13:117:30 | nameof(...) | certain |
+| Assignables.cs:121:31:121:31 | d | Assignables.cs:121:31:121:31 | d | Assignables.cs:121:31:121:31 | <none> | Assignables.cs:121:31:121:31 | <none> | certain |
+| Assignables.cs:123:13:123:13 | x | Assignables.cs:123:13:123:17 | Int32 x = ... | Assignables.cs:123:13:123:13 | access to local variable x | Assignables.cs:123:17:123:17 | 0 | certain |
+| Assignables.cs:124:29:124:29 | s | Assignables.cs:124:29:124:29 | String s | Assignables.cs:124:29:124:29 | <none> | Assignables.cs:124:29:124:29 | <none> | certain |
+| Assignables.cs:124:29:124:29 | s | Assignables.cs:124:29:124:29 | String s | Assignables.cs:124:29:124:29 | String s | Assignables.cs:124:29:124:29 | <none> | certain |
 | Discards.cs:5:30:5:30 | x | Discards.cs:5:30:5:30 | x | Discards.cs:5:30:5:30 | <none> | Discards.cs:5:30:5:30 | <none> | certain |
 | Discards.cs:5:30:5:30 | x | Discards.cs:7:9:7:17 | ... = ... | Discards.cs:7:9:7:9 | access to parameter x | Discards.cs:7:13:7:17 | false | certain |
 | Discards.cs:19:14:19:14 | x | Discards.cs:19:9:19:29 | ... = ... | Discards.cs:19:9:19:29 | <none> | Discards.cs:19:9:19:29 | <none> | certain |

--- a/csharp/ql/test/library-tests/assignables/AssignableDefinitionNode.expected
+++ b/csharp/ql/test/library-tests/assignables/AssignableDefinitionNode.expected
@@ -79,8 +79,8 @@
 | Assignables.cs:117:9:117:30 | ... = ... | Assignables.cs:117:9:117:30 | ... = ... |
 | Assignables.cs:121:31:121:31 | d | Assignables.cs:121:10:121:20 | enter DelegateRef |
 | Assignables.cs:123:13:123:17 | Int32 x = ... | Assignables.cs:123:13:123:17 | Int32 x = ... |
+| Assignables.cs:124:15:124:15 | access to local variable x | Assignables.cs:124:9:124:30 | delegate call |
 | Assignables.cs:124:29:124:29 | String s | Assignables.cs:124:9:124:30 | delegate call |
-| Assignables.cs:124:29:124:29 | String s | Assignables.cs:124:29:124:29 | String s |
 | Discards.cs:5:30:5:30 | x | Discards.cs:5:19:5:19 | enter f |
 | Discards.cs:7:9:7:17 | ... = ... | Discards.cs:7:9:7:17 | ... = ... |
 | Discards.cs:13:9:13:20 | ... = ... | Discards.cs:13:9:13:20 | ... = ... |
@@ -93,7 +93,6 @@
 | Discards.cs:20:9:20:33 | ... = ... | Discards.cs:20:9:20:33 | ... = ... |
 | Discards.cs:20:17:20:17 | Double y | Discards.cs:20:17:20:17 | Double y |
 | Discards.cs:20:32:20:32 | Boolean z | Discards.cs:20:22:20:33 | call to method f |
-| Discards.cs:20:32:20:32 | Boolean z | Discards.cs:20:32:20:32 | Boolean z |
 | Discards.cs:23:27:23:30 | args | Discards.cs:23:10:23:16 | enter Foreach |
 | Discards.cs:30:24:30:24 | o | Discards.cs:30:10:30:15 | enter Switch |
 | Finally.cs:5:16:5:16 | b | Finally.cs:5:9:5:9 | enter M |

--- a/csharp/ql/test/library-tests/assignables/AssignableDefinitionNode.expected
+++ b/csharp/ql/test/library-tests/assignables/AssignableDefinitionNode.expected
@@ -77,6 +77,10 @@
 | Assignables.cs:115:13:115:13 | Int32 i | Assignables.cs:115:13:115:13 | Int32 i |
 | Assignables.cs:116:13:116:25 | String s = ... | Assignables.cs:116:13:116:25 | String s = ... |
 | Assignables.cs:117:9:117:30 | ... = ... | Assignables.cs:117:9:117:30 | ... = ... |
+| Assignables.cs:121:31:121:31 | d | Assignables.cs:121:10:121:20 | enter DelegateRef |
+| Assignables.cs:123:13:123:17 | Int32 x = ... | Assignables.cs:123:13:123:17 | Int32 x = ... |
+| Assignables.cs:124:29:124:29 | String s | Assignables.cs:124:9:124:30 | delegate call |
+| Assignables.cs:124:29:124:29 | String s | Assignables.cs:124:29:124:29 | String s |
 | Discards.cs:5:30:5:30 | x | Discards.cs:5:19:5:19 | enter f |
 | Discards.cs:7:9:7:17 | ... = ... | Discards.cs:7:9:7:17 | ... = ... |
 | Discards.cs:13:9:13:20 | ... = ... | Discards.cs:13:9:13:20 | ... = ... |

--- a/csharp/ql/test/library-tests/assignables/Assignables.cs
+++ b/csharp/ql/test/library-tests/assignables/Assignables.cs
@@ -116,4 +116,11 @@ class Assignables
         var s = nameof(i); // not a read of `i`
         s = nameof(this.Field); // not a read of `this.Field`
     }
+
+    delegate void Delegate(ref int i, out string s);
+    void DelegateRef(Delegate d)
+    {
+        var x = 0;
+        d(ref x, out string s);
+    }
 }

--- a/csharp/ql/test/library-tests/assignables/Assignables.expected
+++ b/csharp/ql/test/library-tests/assignables/Assignables.expected
@@ -82,6 +82,17 @@
 | Assignables.cs:109:16:109:16 | s |
 | Assignables.cs:115:13:115:13 | i |
 | Assignables.cs:116:13:116:13 | s |
+| Assignables.cs:120:36:120:36 | i |
+| Assignables.cs:120:36:120:36 | i |
+| Assignables.cs:120:36:120:36 | i |
+| Assignables.cs:120:36:120:36 | i |
+| Assignables.cs:120:50:120:50 | s |
+| Assignables.cs:120:50:120:50 | s |
+| Assignables.cs:120:50:120:50 | s |
+| Assignables.cs:120:50:120:50 | s |
+| Assignables.cs:121:31:121:31 | d |
+| Assignables.cs:123:13:123:13 | x |
+| Assignables.cs:124:29:124:29 | s |
 | Discards.cs:5:6:5:8 | Item1 |
 | Discards.cs:5:11:5:16 | Item2 |
 | Discards.cs:5:30:5:30 | x |

--- a/csharp/ql/test/library-tests/assignables/GetAnAssignedValue.expected
+++ b/csharp/ql/test/library-tests/assignables/GetAnAssignedValue.expected
@@ -35,6 +35,7 @@
 | Assignables.cs:109:16:109:16 | s | Assignables.cs:109:20:109:21 | "" |
 | Assignables.cs:116:13:116:13 | s | Assignables.cs:116:17:116:25 | nameof(...) |
 | Assignables.cs:116:13:116:13 | s | Assignables.cs:117:13:117:30 | nameof(...) |
+| Assignables.cs:123:13:123:13 | x | Assignables.cs:123:17:123:17 | 0 |
 | Discards.cs:5:30:5:30 | x | Discards.cs:7:13:7:17 | false |
 | Finally.cs:7:13:7:13 | i | Finally.cs:7:17:7:17 | 0 |
 | Finally.cs:7:13:7:13 | i | Finally.cs:15:17:15:17 | 1 |


### PR DESCRIPTION
This change removes these FPs: https://lgtm.com/projects/g/dotnet/machinelearning/alerts/?mode=tree&lang=csharp&ruleFocus=1506094316834.