### PR TITLE
Python: fix false positive result.

### DIFF
--- a/python/ql/src/Expressions/HashedButNoHash.ql
+++ b/python/ql/src/Expressions/HashedButNoHash.ql
@@ -16,7 +16,7 @@ import python
  * For sequences, the index must be an int, which are hashable, so we don't need to treat them specially.
  * For numpy arrays, the index may be a list, which are not hashable and needs to be treated specially.
  */
- 
+
 predicate numpy_array_type(ClassObject na) {
     exists(ModuleObject np | np.getName() = "numpy" or np.getName() = "numpy.core" |
         na.getAnImproperSuperType() = np.getAttribute("ndarray")
@@ -51,9 +51,31 @@ predicate is_unhashable(ControlFlowNode f, ClassObject cls, ControlFlowNode orig
     )
 }
 
+/**
+ * Holds if `f` is inside a `try` that catches `TypeError`. For example:
+ *
+ *    try:
+ *       ... f ...
+ *    except TypeError:
+ *       ...
+ *
+ * This predicate is used to eliminate false positive results. If `hash`
+ * is called on an unhashable object then a `TypeError` will be thrown.
+ * But this is not a bug if the code catches the `TypeError` and handles
+ * it.
+ */
+predicate typeerror_is_caught(ControlFlowNode f) {
+    exists (Try try, CheckClass c |
+        try.getBody().contains(f.getNode()) and
+        c.getName() = "TypeError" and
+        try.getAHandler().getType().refersTo(c))
+}
+
 from ControlFlowNode f, ClassObject c, ControlFlowNode origin
-where 
-explicitly_hashed(f) and is_unhashable(f, c, origin)
-or
-unhashable_subscript(f, c, origin)
+where
+not typeerror_is_caught(f)
+and
+(explicitly_hashed(f) and is_unhashable(f, c, origin)
+ or
+ unhashable_subscript(f, c, origin))
 select f.getNode(), "This $@ of $@ is unhashable.", origin, "instance", c, c.getQualifiedName()

--- a/python/ql/src/Expressions/HashedButNoHash.ql
+++ b/python/ql/src/Expressions/HashedButNoHash.ql
@@ -65,10 +65,9 @@ predicate is_unhashable(ControlFlowNode f, ClassObject cls, ControlFlowNode orig
  * it.
  */
 predicate typeerror_is_caught(ControlFlowNode f) {
-    exists (Try try, CheckClass c |
+    exists (Try try |
         try.getBody().contains(f.getNode()) and
-        c.getName() = "TypeError" and
-        try.getAHandler().getType().refersTo(c))
+        try.getAHandler().getType().refersTo(theTypeErrorType()))
 }
 
 from ControlFlowNode f, ClassObject c, ControlFlowNode origin

--- a/python/ql/test/query-tests/Expressions/general/expressions_test.py
+++ b/python/ql/test/query-tests/Expressions/general/expressions_test.py
@@ -216,3 +216,21 @@ def not_dup_key():
             u"😆" : 3
             }
 
+# Lookup of unhashable object triggers TypeError, but the
+# exception is caught, so it's not a bug. This used to be
+# a false positive of the HashedButNoHash query.
+def func():
+    unhash = list()
+    try:
+      hash(unhash)
+    except TypeError:
+      return 1
+    return 0
+
+def func():
+    mapping = dict(); unhash = list()
+    try:
+      mapping[unhash]
+    except TypeError:
+      return 1
+    return 0


### PR DESCRIPTION
I noticed a [false positive](https://lgtm.com/projects/g/django/django/snapshot/27f531b5dc462884491f8034cd5508d03a0205be/files/django/utils/hashable.py?sort=name&dir=ASC&mode=heatmap#x17e51c9af0d866e1:1) in django. It's a false positive because the code contains an explicit try-catch to handle the `TypeError` that might get thrown. This fixes the query.