### PR TITLE
C++: Speed up getAFeasiblePredecessorBlock

### DIFF
--- a/cpp/ql/src/semmle/code/cpp/ir/implementation/raw/internal/reachability/ReachableBlock.qll
+++ b/cpp/ql/src/semmle/code/cpp/ir/implementation/raw/internal/reachability/ReachableBlock.qll
@@ -13,6 +13,7 @@ predicate isInfeasibleInstructionSuccessor(Instruction instr, EdgeKind kind) {
   )
 }
 
+pragma[noinline]
 predicate isInfeasibleEdge(IRBlockBase block, EdgeKind kind) {
   isInfeasibleInstructionSuccessor(block.getLastInstruction(), kind)
 }

--- a/cpp/ql/src/semmle/code/cpp/ir/implementation/unaliased_ssa/internal/reachability/ReachableBlock.qll
+++ b/cpp/ql/src/semmle/code/cpp/ir/implementation/unaliased_ssa/internal/reachability/ReachableBlock.qll
@@ -13,6 +13,7 @@ predicate isInfeasibleInstructionSuccessor(Instruction instr, EdgeKind kind) {
   )
 }
 
+pragma[noinline]
 predicate isInfeasibleEdge(IRBlockBase block, EdgeKind kind) {
   isInfeasibleInstructionSuccessor(block.getLastInstruction(), kind)
 }


### PR DESCRIPTION
This predicate was unbearably slow on a ChakraCore snapshot (and
probably everywhere else):

    ReachableBlock::getAFeasiblePredecessorBlock#2#ff#antijoin_rhs .. 1m6s
    ReachableBlock::getAFeasiblePredecessorBlock#ff#antijoin_rhs .... 31.8s

With this change, the predicate is so fast that it doesn't even show up
in the clause timing report.

It's possible that we only tested this for performance in 1.18, and then
it has regressed in 1.19. Otherwise I can't explain how we've missed
this. I'm using QL for Eclipse 1.20.0.201901070127.