### PR TITLE
JS: sharpen js/incomplete-hostname-regexp: ignore unlikely sources

### DIFF
--- a/javascript/ql/src/Security/CWE-020/IncompleteHostnameRegExp.ql
+++ b/javascript/ql/src/Security/CWE-020/IncompleteHostnameRegExp.ql
@@ -46,7 +46,12 @@ where
     or
     exists(Configuration cfg |
       cfg.hasFlow(e.flow(), _) and
-      e.mayHaveStringValue(pattern)
+      e.mayHaveStringValue(pattern) and
+      // ignore strings that are unlikely to be regular expressions for URLs
+      not (
+        pattern.length() > 50 or
+        pattern.regexpMatch(".*\\s.*")
+      )
     )
   ) and
   isIncompleteHostNameRegExpPattern(pattern, hostPart) and

--- a/javascript/ql/test/query-tests/Security/CWE-020/tst-IncompleteHostnameRegExp.js
+++ b/javascript/ql/test/query-tests/Security/CWE-020/tst-IncompleteHostnameRegExp.js
@@ -44,4 +44,7 @@
 	RegExp('protos?://(localhost|.+.example.net|.+.example-a.com|.+.example-b.com|.+.example.internal)'); // NOT OK
 
 	/example.dev|example.com/; // OK, but still flagged
+
+	new RegExp(`test.example.com is my home page`); // OK
+	new RegExp(`test.example.com/foo/bar/baz/foo/bar/baz/foo/bar/baz/foo/bar/baz/foo/bar/baz/foo/bar/baz/foo/bar/baz`); // OK
 });


### PR DESCRIPTION
This is inspired by ODASA-7638. This PR restricts the sources of the taint tracking part of `js/incomplete-hostname-regexp` by eliminating strings that are unlikely to result in true positives later. The change eliminates 3000 false positive sources in `proexpressjs`.

Surprisingly, [performance is unchanged](https://git.semmle.com/esben/dist-compare-reports/tree/js/sharpen-incomplete-hostname-regex_1547758156717), but 13 false positives have been eliminated from test code.

The query is still new, so no change note is required.