### PR TITLE
Python: Remove fragile and unnecessary test.

### DIFF
--- a/python/ql/test/library-tests/classes/builtin_classes/options
+++ b/python/ql/test/library-tests/classes/builtin_classes/options
@@ -1,2 +1,0 @@
-semmle-extractor-options: --max-import-depth=2 -j
-optimize: true

--- a/python/ql/test/library-tests/classes/builtin_classes/test.expected
+++ b/python/ql/test/library-tests/classes/builtin_classes/test.expected
@@ -1,1 +1,0 @@
-| builtin-class _ctypes._Pointer | builtin-class _ctypes.PyCPointerType |

--- a/python/ql/test/library-tests/classes/builtin_classes/test.py
+++ b/python/ql/test/library-tests/classes/builtin_classes/test.py
@@ -1,1 +1,0 @@
-from ctypes import *

--- a/python/ql/test/library-tests/classes/builtin_classes/test.ql
+++ b/python/ql/test/library-tests/classes/builtin_classes/test.ql
@@ -1,5 +1,0 @@
-import python
-
-from ClassObject c
-where c.getName() = "_ctypes._Pointer"
-select c.toString(), c.getAnInferredType().toString()


### PR DESCRIPTION
Causes test failure on Windows and seems to have no purpose.
Given we are planning on switching to using stub files, rather than relying on interpreter internals, it makes sense to just remove this test.