### PR TITLE
Python: Fix 'unused import' for doctests and typehints.

### DIFF
--- a/change-notes/1.20/analysis-python.md
+++ b/change-notes/1.20/analysis-python.md
@@ -17,6 +17,7 @@
  | **Query**                  | **Expected impact**    | **Change**                                                       |
 |----------------------------|------------------------|------------------------------------------------------------------|
 | Unused import (`py/unused-import`) | Fewer false positive results | Results where the imported module is used in a `doctest` string are no longer reported. |
+| Unused import (`py/unused-import`) | Fewer false positive results | Results where the imported module is used in a type-hint comment are no longer reported. |
 
  ## Changes to code extraction
 

--- a/change-notes/1.20/analysis-python.md
+++ b/change-notes/1.20/analysis-python.md
@@ -16,7 +16,7 @@
 
  | **Query**                  | **Expected impact**    | **Change**                                                       |
 |----------------------------|------------------------|------------------------------------------------------------------|
-| Unused import (`py/unused-import`) | Fewer false positive results | Results where the imported module is used in a doctest string are no longer reported |
+| Unused import (`py/unused-import`) | Fewer false positive results | Results where the imported module is used in a `doctest` string are no longer reported. |
 
  ## Changes to code extraction
 

--- a/change-notes/1.20/analysis-python.md
+++ b/change-notes/1.20/analysis-python.md
@@ -16,6 +16,7 @@
 
  | **Query**                  | **Expected impact**    | **Change**                                                       |
 |----------------------------|------------------------|------------------------------------------------------------------|
+| Unused import (`py/unused-import`) | Fewer false positive results | Results where the imported module is used in a doctest string are no longer reported |
 
  ## Changes to code extraction
 

--- a/python/ql/src/Imports/UnusedImport.ql
+++ b/python/ql/src/Imports/UnusedImport.ql
@@ -43,7 +43,7 @@ predicate all_not_understood(Module m) {
 
 predicate imported_module_used_in_doctest(Import imp) {
     exists(string modname |
-        ((Name)imp.getAName().getAsname()).getId() = modname
+        imp.getAName().getAsname().(Name).getId() = modname
         and
         /* Look for doctests containing the patterns:
          * >>> …name…
@@ -59,14 +59,14 @@ predicate imported_module_used_in_doctest(Import imp) {
 
 predicate imported_module_used_in_typehint(Import imp) {
     exists(string modname |
-        ((Name)imp.getAName().getAsname()).getId() = modname
+        imp.getAName().getAsname().(Name).getId() = modname
         and
         /* Look for typehints containing the patterns:
          * # type: …name…
          */
-        exists(Comment tyephint |
-            tyephint.getLocation().getFile() = imp.getScope().(Module).getFile() and
-            tyephint.getText().regexpMatch("# type:.*" + modname + ".*")
+        exists(Comment typehint |
+            typehint.getLocation().getFile() = imp.getScope().(Module).getFile() and
+            typehint.getText().regexpMatch("# type:.*" + modname + ".*")
         )
     )
 }

--- a/python/ql/src/Imports/UnusedImport.ql
+++ b/python/ql/src/Imports/UnusedImport.ql
@@ -57,6 +57,21 @@ predicate imported_module_used_in_doctest(Import imp) {
     )
 }
 
+predicate imported_module_used_in_typehint(Import imp) {
+    exists(string modname |
+        ((Name)imp.getAName().getAsname()).getId() = modname
+        and
+        /* Look for typehints containing the patterns:
+         * # type: …name…
+         */
+        exists(Comment tyephint |
+            tyephint.getLocation().getFile() = imp.getScope().(Module).getFile() and
+            tyephint.getText().regexpMatch("# type:.*" + modname + ".*")
+        )
+    )
+}
+
+
 predicate unused_import(Import imp, Variable name) {
     ((Name)imp.getAName().getAsname()).getVariable() = name
     and
@@ -83,6 +98,8 @@ predicate unused_import(Import imp, Variable name) {
     not all_not_understood(imp.getEnclosingModule())
     and
     not imported_module_used_in_doctest(imp)
+    and
+    not imported_module_used_in_typehint(imp)
 }
 
 

--- a/python/ql/src/Imports/UnusedImport.ql
+++ b/python/ql/src/Imports/UnusedImport.ql
@@ -41,6 +41,22 @@ predicate all_not_understood(Module m) {
     )
 }
 
+predicate imported_module_used_in_doctest(Import imp) {
+    exists(string modname |
+        ((Name)imp.getAName().getAsname()).getId() = modname
+        and
+        /* Look for doctests containing the patterns:
+         * >>> …name…
+         * ... …name…
+         */
+        exists(StrConst doc |
+            doc.getEnclosingModule() = imp.getScope() and
+            doc.isDocString() and
+            doc.getText().regexpMatch("[\\s\\S]*(>>>|\\.\\.\\.).*" + modname + "[\\s\\S]*")
+        )
+    )
+}
+
 predicate unused_import(Import imp, Variable name) {
     ((Name)imp.getAName().getAsname()).getVariable() = name
     and
@@ -65,6 +81,8 @@ predicate unused_import(Import imp, Variable name) {
     and
     /* Assume that opaque `__all__` includes imported module */
     not all_not_understood(imp.getEnclosingModule())
+    and
+    not imported_module_used_in_doctest(imp)
 }
 
 

--- a/python/ql/src/semmle/python/strings.qll
+++ b/python/ql/src/semmle/python/strings.qll
@@ -57,3 +57,4 @@ string repr(Expr e) {
    else
        result = e.toString()
 }
+

--- a/python/ql/test/query-tests/Imports/unused/imports_test.py
+++ b/python/ql/test/query-tests/Imports/unused/imports_test.py
@@ -61,3 +61,12 @@ import module1 as different
 #Use it
 different
 
+import used_in_doctest
+
+def f():
+    '''
+    >>> unrelated
+    >>> used_in_doctest.thing() == f()
+    True
+    '''
+    return 5

--- a/python/ql/test/query-tests/Imports/unused/imports_test.py
+++ b/python/ql/test/query-tests/Imports/unused/imports_test.py
@@ -70,3 +70,9 @@ def f():
     True
     '''
     return 5
+
+#Used in Python2 type hint
+import typing
+
+foo = None # type: typing.Optional[int]
+


### PR DESCRIPTION
Don't give alerts for 'unused import' when the imported module is used in either a doctest or a typehint.