### PR TITLE
C#: Add sources from System.Windows.Forms controls

### DIFF
--- a/change-notes/1.20/analysis-csharp.md
+++ b/change-notes/1.20/analysis-csharp.md
@@ -14,7 +14,8 @@
 | Off-by-one comparison against container length (cs/index-out-of-bounds) | Fewer false positives | Results have been removed when there are additional guards on the index. |
 | Dereferenced variable is always null (cs/dereferenced-value-is-always-null) | Improved results | The query has been rewritten from scratch, and the analysis is now based on static single assignment (SSA) forms. The query is now enabled by default in LGTM. |
 | Dereferenced variable may be null (cs/dereferenced-value-may-be-null) | Improved results | The query has been rewritten from scratch, and the analysis is now based on static single assignment (SSA) forms. The query is now enabled by default in LGTM. |
-
+| SQL query built from user-controlled sources (cs/sql-injection), Improper control of generation of code (cs/code-injection), Uncontrolled format string (cs/uncontrolled-format-string), Clear text storage of sensitive information (cs/cleartext-storage-of-sensitive-information), Exposure of private information (cs/exposure-of-sensitive-information) | More results | Data sources have been added from user controls in `System.Windows.Forms`. |
+ 
 ## Changes to code extraction
 
 * Fix extraction of `for` statements where the condition declares new variables using `is`.

--- a/csharp/ql/src/Security Features/CWE-089/SqlInjection.ql
+++ b/csharp/ql/src/Security Features/CWE-089/SqlInjection.ql
@@ -14,7 +14,13 @@ import csharp
 import semmle.code.csharp.security.dataflow.SqlInjection::SqlInjection
 import semmle.code.csharp.dataflow.DataFlow::DataFlow::PathGraph
 
+string getSourceType(DataFlow::Node node) {
+  result = node.(RemoteFlowSource).getSourceType()
+  or
+  result = node.(LocalFlowSource).getSourceType()
+}
+
 from TaintTrackingConfiguration c, DataFlow::PathNode source, DataFlow::PathNode sink
 where c.hasFlowPath(source, sink)
 select sink.getNode(), source, sink, "Query might include code from $@.", source,
-  ("this " + source.getNode().(RemoteFlowSource).getSourceType())
+  ("this " + getSourceType(source.getNode()))

--- a/csharp/ql/src/Security Features/CWE-134/UncontrolledFormatString.ql
+++ b/csharp/ql/src/Security Features/CWE-134/UncontrolledFormatString.ql
@@ -12,6 +12,7 @@
 
 import csharp
 import semmle.code.csharp.dataflow.flowsources.Remote
+import semmle.code.csharp.dataflow.flowsources.Local
 import semmle.code.csharp.dataflow.TaintTracking
 import semmle.code.csharp.frameworks.Format
 import DataFlow::PathGraph
@@ -19,7 +20,11 @@ import DataFlow::PathGraph
 class FormatStringConfiguration extends TaintTracking::Configuration {
   FormatStringConfiguration() { this = "FormatStringConfiguration" }
 
-  override predicate isSource(DataFlow::Node source) { source instanceof RemoteFlowSource }
+  override predicate isSource(DataFlow::Node source) {
+    source instanceof RemoteFlowSource
+    or
+    source instanceof LocalFlowSource
+  }
 
   override predicate isSink(DataFlow::Node sink) {
     sink.asExpr() = any(FormatCall call).getFormatExpr()

--- a/csharp/ql/src/semmle/code/csharp/dataflow/flowsources/Local.qll
+++ b/csharp/ql/src/semmle/code/csharp/dataflow/flowsources/Local.qll
@@ -16,9 +16,7 @@ abstract class LocalUserInputSource extends LocalFlowSource { }
 
 /** The text of a `TextBox`. */
 class TextFieldSource extends LocalUserInputSource {
-  TextFieldSource() {
-    this.asExpr() = any(TextControl control).getARead()
-  }
+  TextFieldSource() { this.asExpr() = any(TextControl control).getARead() }
 
   override string getSourceType() { result = "TextBox text" }
 }

--- a/csharp/ql/src/semmle/code/csharp/dataflow/flowsources/Local.qll
+++ b/csharp/ql/src/semmle/code/csharp/dataflow/flowsources/Local.qll
@@ -1,0 +1,24 @@
+/**
+ * Provides classes representing sources of local input.
+ */
+
+import csharp
+private import semmle.code.csharp.frameworks.system.windows.Forms
+
+/** A data flow source of local data. */
+abstract class LocalFlowSource extends DataFlow::Node {
+  /** Gets a string that describes the type of this local flow source. */
+  abstract string getSourceType();
+}
+
+/** A data flow source of local user input. */
+abstract class LocalUserInputSource extends LocalFlowSource { }
+
+/** The text of a `TextBox`. */
+class TextFieldSource extends LocalUserInputSource {
+  TextFieldSource() {
+    this.asExpr() = any(TextControl control).getARead()
+  }
+
+  override string getSourceType() { result = "TextBox text" }
+}

--- a/csharp/ql/src/semmle/code/csharp/frameworks/system/windows/Forms.qll
+++ b/csharp/ql/src/semmle/code/csharp/frameworks/system/windows/Forms.qll
@@ -23,3 +23,78 @@ class SystemWindowsFormsHtmlElement extends SystemWindowsFormsClass {
   /** Gets the `SetAttribute` method. */
   Method getSetAttributeMethod() { result = this.getAMethod("SetAttribute") }
 }
+
+/** The `System.Windows.Forms.TextBoxBase` class. */
+class SystemWindowsFormsTextBoxBase extends SystemWindowsFormsClass {
+  SystemWindowsFormsTextBoxBase() {
+    this.hasName("TextBoxBase")
+  }
+
+  /** Gets the `Text` property. */
+  Property getTextProperty() { result = this.getProperty("Text") }
+}
+
+/** The `System.Windows.Forms.RichTextBox` class. */
+class SystemWindowsFormsRichTextBox extends SystemWindowsFormsClass {
+  SystemWindowsFormsRichTextBox() {
+    this.hasName("RichTextBox")
+  }
+
+  /** Gets the `Rtf` property. */
+  Property getRtfProperty() { result = this.getProperty("Rtf") }
+
+  /** Gets the `SelectedText` property. */
+  Property getSelectedTextProperty() { result = this.getProperty("SelectedText") }
+
+  /** Gets the 'SelectedRtf' property. */
+  Property getSelectedRtfProperty() { result = this.getProperty("SelectedRtf") }
+}
+
+/** The `System.Windows.Forms.HtmlDocument` class. */
+class SystemWindowsFormsHtmlDocumentClass extends SystemWindowsFormsClass {
+  SystemWindowsFormsHtmlDocumentClass() {
+    this.hasName("HtmlDocument")
+  }
+
+  /** Gets the `Write` method. */
+  Method getWriteMethod() { result = this.getAMethod() and result.hasName("Write") }  
+}
+
+/** The `System.Windows.Forms.WebBrowser` class. */
+class SystemWindowsFormsWebBrowserClass extends SystemWindowsFormsClass {
+  SystemWindowsFormsWebBrowserClass() {
+    this.hasName("WebBrowser")
+  }
+
+  /** Gets the `DocumentText` property. */
+  Property getDocumentTextProperty() { result = this.getProperty("DocumentText") }
+}
+
+private class TextProperty extends Property {
+  TextProperty() {
+    exists(SystemWindowsFormsRichTextBox c |
+      this = c.getRtfProperty() or
+      this = c.getSelectedTextProperty() or
+      this = c.getSelectedRtfProperty()
+    )
+    or
+    exists(SystemWindowsFormsTextBoxBase tb |
+      this = tb.getTextProperty().getAnOverrider*()
+    )
+  }
+}
+
+/** A field that contains a text control. */
+class TextControl extends Field
+{
+  TextControl() {
+    this.getType().(ValueOrRefType).getBaseClass*() instanceof SystemWindowsFormsTextBoxBase
+  }
+
+  /** Gets a read of the text property. */
+  PropertyRead getARead() {
+    result.getTarget() instanceof TextProperty
+    and
+    result.getQualifier() = this.getAnAccess()
+  }
+}

--- a/csharp/ql/src/semmle/code/csharp/frameworks/system/windows/Forms.qll
+++ b/csharp/ql/src/semmle/code/csharp/frameworks/system/windows/Forms.qll
@@ -26,9 +26,7 @@ class SystemWindowsFormsHtmlElement extends SystemWindowsFormsClass {
 
 /** The `System.Windows.Forms.TextBoxBase` class. */
 class SystemWindowsFormsTextBoxBase extends SystemWindowsFormsClass {
-  SystemWindowsFormsTextBoxBase() {
-    this.hasName("TextBoxBase")
-  }
+  SystemWindowsFormsTextBoxBase() { this.hasName("TextBoxBase") }
 
   /** Gets the `Text` property. */
   Property getTextProperty() { result = this.getProperty("Text") }
@@ -36,9 +34,7 @@ class SystemWindowsFormsTextBoxBase extends SystemWindowsFormsClass {
 
 /** The `System.Windows.Forms.RichTextBox` class. */
 class SystemWindowsFormsRichTextBox extends SystemWindowsFormsClass {
-  SystemWindowsFormsRichTextBox() {
-    this.hasName("RichTextBox")
-  }
+  SystemWindowsFormsRichTextBox() { this.hasName("RichTextBox") }
 
   /** Gets the `Rtf` property. */
   Property getRtfProperty() { result = this.getProperty("Rtf") }
@@ -52,19 +48,15 @@ class SystemWindowsFormsRichTextBox extends SystemWindowsFormsClass {
 
 /** The `System.Windows.Forms.HtmlDocument` class. */
 class SystemWindowsFormsHtmlDocumentClass extends SystemWindowsFormsClass {
-  SystemWindowsFormsHtmlDocumentClass() {
-    this.hasName("HtmlDocument")
-  }
+  SystemWindowsFormsHtmlDocumentClass() { this.hasName("HtmlDocument") }
 
   /** Gets the `Write` method. */
-  Method getWriteMethod() { result = this.getAMethod() and result.hasName("Write") }  
+  Method getWriteMethod() { result = this.getAMethod("Write") }
 }
 
 /** The `System.Windows.Forms.WebBrowser` class. */
 class SystemWindowsFormsWebBrowserClass extends SystemWindowsFormsClass {
-  SystemWindowsFormsWebBrowserClass() {
-    this.hasName("WebBrowser")
-  }
+  SystemWindowsFormsWebBrowserClass() { this.hasName("WebBrowser") }
 
   /** Gets the `DocumentText` property. */
   Property getDocumentTextProperty() { result = this.getProperty("DocumentText") }
@@ -78,23 +70,19 @@ private class TextProperty extends Property {
       this = c.getSelectedRtfProperty()
     )
     or
-    exists(SystemWindowsFormsTextBoxBase tb |
-      this = tb.getTextProperty().getAnOverrider*()
-    )
+    exists(SystemWindowsFormsTextBoxBase tb | this = tb.getTextProperty().getAnOverrider*())
   }
 }
 
-/** A field that contains a text control. */
-class TextControl extends Field
-{
+/** A variable that contains a text control. */
+class TextControl extends Variable {
   TextControl() {
     this.getType().(ValueOrRefType).getBaseClass*() instanceof SystemWindowsFormsTextBoxBase
   }
 
   /** Gets a read of the text property. */
   PropertyRead getARead() {
-    result.getTarget() instanceof TextProperty
-    and
+    result.getTarget() instanceof TextProperty and
     result.getQualifier() = this.getAnAccess()
   }
 }

--- a/csharp/ql/src/semmle/code/csharp/security/PrivateData.qll
+++ b/csharp/ql/src/semmle/code/csharp/security/PrivateData.qll
@@ -10,6 +10,7 @@
  */
 
 import csharp
+import semmle.code.csharp.frameworks.system.windows.Forms
 
 /** A string for `match` that identifies strings that look like they represent private data. */
 private string privateNames() {
@@ -56,5 +57,12 @@ class PrivateIndexerAccess extends PrivateDataExpr, IndexerAccess {
 class PrivateVariableAccess extends PrivateDataExpr, VariableAccess {
   PrivateVariableAccess() {
     exists(string s | this.getTarget().getName().toLowerCase() = s | s.matches(privateNames()))
+  }
+}
+
+/** Reading the text property of a control that might contain private data. */
+class PrivateControlAccess extends PrivateDataExpr {
+  PrivateControlAccess() {
+    exists(TextControl c | this = c.getARead() and c.getName().toLowerCase().matches(privateNames()))
   }
 }

--- a/csharp/ql/src/semmle/code/csharp/security/SensitiveActions.qll
+++ b/csharp/ql/src/semmle/code/csharp/security/SensitiveActions.qll
@@ -137,20 +137,17 @@ class SensitiveVariableAccess extends SensitiveExpr, VariableAccess {
 
 /** Reading the `Text` property of a password text box. */
 class PasswordTextboxText extends SensitiveExpr, PropertyRead {
-  PasswordTextboxText() {
-    this = any(PasswordField p).getARead()
-  }
+  PasswordTextboxText() { this = any(PasswordField p).getARead() }
 }
 
 /** A field containing a text box used as a password. */
-class PasswordField extends TextControl
-{
+class PasswordField extends TextControl {
   PasswordField() {
     isSuspicious(this.getName())
     or
     exists(PropertyWrite write | write.getQualifier() = this.getAnAccess() |
-        write.getTarget().getName() = "UseSystemPasswordChar" or
-        write.getTarget().getName() = "PasswordChar"
+      write.getTarget().getName() = "UseSystemPasswordChar" or
+      write.getTarget().getName() = "PasswordChar"
     )
   }
 }

--- a/csharp/ql/src/semmle/code/csharp/security/dataflow/CodeInjection.qll
+++ b/csharp/ql/src/semmle/code/csharp/security/dataflow/CodeInjection.qll
@@ -6,6 +6,7 @@ import csharp
 
 module CodeInjection {
   import semmle.code.csharp.dataflow.flowsources.Remote
+  import semmle.code.csharp.dataflow.flowsources.Local
   import semmle.code.csharp.frameworks.system.codedom.Compiler
   import semmle.code.csharp.security.Sanitizers
 
@@ -39,6 +40,9 @@ module CodeInjection {
 
   /** A source of remote user input. */
   class RemoteSource extends Source { RemoteSource() { this instanceof RemoteFlowSource } }
+
+  /** A source of local user input. */
+  class LocalSource extends Source { LocalSource() { this instanceof LocalFlowSource } }
 
   private class SimpleTypeSanitizer extends Sanitizer, SimpleTypeSanitizedExpr { }
 

--- a/csharp/ql/src/semmle/code/csharp/security/dataflow/ResourceInjection.qll
+++ b/csharp/ql/src/semmle/code/csharp/security/dataflow/ResourceInjection.qll
@@ -6,6 +6,7 @@ import csharp
 
 module ResourceInjection {
   import semmle.code.csharp.dataflow.flowsources.Remote
+  import semmle.code.csharp.dataflow.flowsources.Local
   import semmle.code.csharp.frameworks.system.Data
   import semmle.code.csharp.security.Sanitizers
 
@@ -39,6 +40,9 @@ module ResourceInjection {
 
   /** A source of remote user input. */
   class RemoteSource extends Source { RemoteSource() { this instanceof RemoteFlowSource } }
+
+  /** A source of local user input. */
+  class LocalSource extends Source { LocalSource() { this instanceof LocalFlowSource } }
 
   /** An argument to the `ConnectionString` property on a data connection class. */
   class SqlConnectionStringSink extends Sink {

--- a/csharp/ql/src/semmle/code/csharp/security/dataflow/SqlInjection.qll
+++ b/csharp/ql/src/semmle/code/csharp/security/dataflow/SqlInjection.qll
@@ -6,6 +6,7 @@ import csharp
 
 module SqlInjection {
   import semmle.code.csharp.dataflow.flowsources.Remote
+  import semmle.code.csharp.dataflow.flowsources.Local
   import semmle.code.csharp.frameworks.Sql
   import semmle.code.csharp.security.Sanitizers
 
@@ -39,6 +40,9 @@ module SqlInjection {
 
   /** A source of remote user input. */
   class RemoteSource extends Source { RemoteSource() { this instanceof RemoteFlowSource } }
+
+  /** A source of local user input. */
+  class LocalSource extends Source { LocalSource() { this instanceof LocalFlowSource } }
 
   /** An SQL expression passed to an API call that executes SQL. */
   class SqlInjectionExprSink extends Sink {

--- a/csharp/ql/src/semmle/code/csharp/security/dataflow/XSS.qll
+++ b/csharp/ql/src/semmle/code/csharp/security/dataflow/XSS.qll
@@ -572,9 +572,7 @@ module XSS {
     }
   }
 
-  /**
-   * HtmlString that may be rendered as is need to have sanitized value
-   */
+  /** `HtmlString` that may be rendered as is need to have sanitized value. */
   class MicrosoftAspNetHtmlStringSink extends AspNetCoreSink {
     MicrosoftAspNetHtmlStringSink() {
       exists(ObjectCreation c, MicrosoftAspNetCoreHttpHtmlString s |

--- a/csharp/ql/test/query-tests/Security Features/CWE-089/SqlInjection.cs
+++ b/csharp/ql/test/query-tests/Security Features/CWE-089/SqlInjection.cs
@@ -1,4 +1,4 @@
-// semmle-extractor-options: /r:System.ComponentModel.Primitives.dll /r:System.ComponentModel.TypeConverter.dll /r:System.Data.Common.dll ${testdir}/../../../resources/stubs/EntityFramework.cs ${testdir}/../../../resources/stubs/System.Data.cs
+// semmle-extractor-options: /r:System.ComponentModel.Primitives.dll /r:System.ComponentModel.TypeConverter.dll /r:System.Data.Common.dll ${testdir}/../../../resources/stubs/EntityFramework.cs ${testdir}/../../../resources/stubs/System.Data.cs ${testdir}/../../../resources/stubs/System.Windows.cs
 
 using System;
 
@@ -79,6 +79,18 @@ namespace Test
                     context.Database.ExecuteSqlCommand(query2, categoryTextBox.Text);
                 }
             }
+
+            // BAD: Text from a local textbox
+            using (var connection = new SqlConnection(connectionString))
+            {
+                var query1 = "SELECT ITEM,PRICE FROM PRODUCT WHERE ITEM_CATEGORY='"
+                  + box1.Text + "' ORDER BY PRICE";
+                var adapter = new SqlDataAdapter(query1, connection);
+                var result = new DataSet();
+                adapter.Fill(result);
+            }
         }
+
+        System.Windows.Forms.TextBox box1;
     }
 }

--- a/csharp/ql/test/query-tests/Security Features/CWE-089/SqlInjection.expected
+++ b/csharp/ql/test/query-tests/Security Features/CWE-089/SqlInjection.expected
@@ -18,6 +18,7 @@ edges
 | SqlInjection.cs:61:62:61:81 | access to property Text | SqlInjection.cs:75:55:75:60 | access to local variable query1 |
 | SqlInjection.cs:73:33:73:47 | access to field categoryTextBox | SqlInjection.cs:74:56:74:61 | access to local variable query1 |
 | SqlInjection.cs:73:33:73:47 | access to field categoryTextBox | SqlInjection.cs:75:55:75:60 | access to local variable query1 |
+| SqlInjection.cs:87:21:87:29 | access to property Text | SqlInjection.cs:88:50:88:55 | access to local variable query1 |
 nodes
 | SqlInjection.cs:38:21:38:35 | access to field categoryTextBox |
 | SqlInjection.cs:39:50:39:55 | access to local variable query1 |
@@ -28,6 +29,8 @@ nodes
 | SqlInjection.cs:73:33:73:47 | access to field categoryTextBox |
 | SqlInjection.cs:74:56:74:61 | access to local variable query1 |
 | SqlInjection.cs:75:55:75:60 | access to local variable query1 |
+| SqlInjection.cs:87:21:87:29 | access to property Text |
+| SqlInjection.cs:88:50:88:55 | access to local variable query1 |
 #select
 | SqlInjection.cs:39:50:39:55 | access to local variable query1 | SqlInjection.cs:38:21:38:35 | access to field categoryTextBox | SqlInjection.cs:39:50:39:55 | access to local variable query1 | Query might include code from $@. | SqlInjection.cs:38:21:38:35 | access to field categoryTextBox | this ASP.NET user input |
 | SqlInjection.cs:74:56:74:61 | access to local variable query1 | SqlInjection.cs:38:21:38:35 | access to field categoryTextBox | SqlInjection.cs:74:56:74:61 | access to local variable query1 | Query might include code from $@. | SqlInjection.cs:38:21:38:35 | access to field categoryTextBox | this ASP.NET user input |
@@ -38,3 +41,4 @@ nodes
 | SqlInjection.cs:75:55:75:60 | access to local variable query1 | SqlInjection.cs:49:62:49:76 | access to field categoryTextBox | SqlInjection.cs:75:55:75:60 | access to local variable query1 | Query might include code from $@. | SqlInjection.cs:49:62:49:76 | access to field categoryTextBox | this ASP.NET user input |
 | SqlInjection.cs:75:55:75:60 | access to local variable query1 | SqlInjection.cs:61:62:61:76 | access to field categoryTextBox | SqlInjection.cs:75:55:75:60 | access to local variable query1 | Query might include code from $@. | SqlInjection.cs:61:62:61:76 | access to field categoryTextBox | this ASP.NET user input |
 | SqlInjection.cs:75:55:75:60 | access to local variable query1 | SqlInjection.cs:73:33:73:47 | access to field categoryTextBox | SqlInjection.cs:75:55:75:60 | access to local variable query1 | Query might include code from $@. | SqlInjection.cs:73:33:73:47 | access to field categoryTextBox | this ASP.NET user input |
+| SqlInjection.cs:88:50:88:55 | access to local variable query1 | SqlInjection.cs:87:21:87:29 | access to property Text | SqlInjection.cs:88:50:88:55 | access to local variable query1 | Query might include code from $@. | SqlInjection.cs:87:21:87:29 | access to property Text | this TextBox text |

--- a/csharp/ql/test/query-tests/Security Features/CWE-094/CodeInjection.cs
+++ b/csharp/ql/test/query-tests/Security Features/CWE-094/CodeInjection.cs
@@ -1,4 +1,4 @@
-// semmle-extractor-options: ${testdir}/../../../resources/stubs/System.Web.cs /r:System.Collections.Specialized.dll ${testdir}/../../../resources/stubs/Microsoft.CSharp.cs /r:System.ComponentModel.Primitives.dll
+// semmle-extractor-options: ${testdir}/../../../resources/stubs/System.Web.cs /r:System.Collections.Specialized.dll ${testdir}/../../../resources/stubs/Microsoft.CSharp.cs /r:System.ComponentModel.Primitives.dll ${testdir}/../../../resources/stubs/System.Windows.cs
 
 using Microsoft.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Scripting;
@@ -48,5 +48,13 @@ public class CommandInjectionHandler : IHttpHandler
         {
             return true;
         }
+    }
+
+    System.Windows.Forms.RichTextBox box1;
+
+    void OnButtonClicked()
+    {
+        // BAD: Use the Roslyn APIs to dynamically evaluate C#
+    	CSharpScript.EvaluateAsync(box1.Text);
     }
 }

--- a/csharp/ql/test/query-tests/Security Features/CWE-094/CodeInjection.expected
+++ b/csharp/ql/test/query-tests/Security Features/CWE-094/CodeInjection.expected
@@ -5,6 +5,8 @@ nodes
 | CodeInjection.cs:25:23:25:45 | access to property QueryString |
 | CodeInjection.cs:31:64:31:67 | access to local variable code |
 | CodeInjection.cs:42:36:42:39 | access to local variable code |
+| CodeInjection.cs:58:33:58:41 | access to property Text |
 #select
 | CodeInjection.cs:31:64:31:67 | access to local variable code | CodeInjection.cs:25:23:25:45 | access to property QueryString | CodeInjection.cs:31:64:31:67 | access to local variable code | $@ flows to here and is compiled as code. | CodeInjection.cs:25:23:25:45 | access to property QueryString | User-provided value |
 | CodeInjection.cs:42:36:42:39 | access to local variable code | CodeInjection.cs:25:23:25:45 | access to property QueryString | CodeInjection.cs:42:36:42:39 | access to local variable code | $@ flows to here and is compiled as code. | CodeInjection.cs:25:23:25:45 | access to property QueryString | User-provided value |
+| CodeInjection.cs:58:33:58:41 | access to property Text | CodeInjection.cs:58:33:58:41 | access to property Text | CodeInjection.cs:58:33:58:41 | access to property Text | $@ flows to here and is compiled as code. | CodeInjection.cs:58:33:58:41 | access to property Text | User-provided value |

--- a/csharp/ql/test/query-tests/Security Features/CWE-134/UncontrolledFormatString.cs
+++ b/csharp/ql/test/query-tests/Security Features/CWE-134/UncontrolledFormatString.cs
@@ -1,4 +1,4 @@
-// semmle-extractor-options: /r:System.Runtime.Extensions.dll /r:System.Collections.Specialized.dll ${testdir}/../../../resources/stubs/System.Web.cs
+// semmle-extractor-options: /r:System.Runtime.Extensions.dll /r:System.Collections.Specialized.dll ${testdir}/../../../resources/stubs/System.Web.cs ${testdir}/../../../resources/stubs/System.Windows.cs
 
 using System;
 using System.IO;
@@ -21,5 +21,13 @@ public class TaintedPathHandler : IHttpHandler
         
         // GOOD: Not the format string.
         String.Format((IFormatProvider)null, "Do not do this", path);
+    }
+
+    System.Windows.Forms.TextBox box1;
+
+    void OnButtonClicked()
+    {
+    	// BAD: Uncontrolled format string.
+    	String.Format(box1.Text, "Do not do this");
     }
 }

--- a/csharp/ql/test/query-tests/Security Features/CWE-134/UncontrolledFormatString.expected
+++ b/csharp/ql/test/query-tests/Security Features/CWE-134/UncontrolledFormatString.expected
@@ -8,9 +8,11 @@ nodes
 | UncontrolledFormatString.cs:17:46:17:49 | access to local variable path |
 | UncontrolledFormatString.cs:20:23:20:38 | "Do not do this" |
 | UncontrolledFormatString.cs:23:46:23:61 | "Do not do this" |
+| UncontrolledFormatString.cs:31:20:31:28 | access to property Text |
 | UncontrolledFormatStringBad.cs:9:25:9:47 | access to property QueryString |
 | UncontrolledFormatStringBad.cs:12:39:12:44 | access to local variable format |
 #select
 | UncontrolledFormatString.cs:14:23:14:26 | access to local variable path | UncontrolledFormatString.cs:11:23:11:45 | access to property QueryString | UncontrolledFormatString.cs:14:23:14:26 | access to local variable path | $@ flows to here and is used as a format string. | UncontrolledFormatString.cs:11:23:11:45 | access to property QueryString | access to property QueryString |
 | UncontrolledFormatString.cs:17:46:17:49 | access to local variable path | UncontrolledFormatString.cs:11:23:11:45 | access to property QueryString | UncontrolledFormatString.cs:17:46:17:49 | access to local variable path | $@ flows to here and is used as a format string. | UncontrolledFormatString.cs:11:23:11:45 | access to property QueryString | access to property QueryString |
+| UncontrolledFormatString.cs:31:20:31:28 | access to property Text | UncontrolledFormatString.cs:31:20:31:28 | access to property Text | UncontrolledFormatString.cs:31:20:31:28 | access to property Text | $@ flows to here and is used as a format string. | UncontrolledFormatString.cs:31:20:31:28 | access to property Text | access to property Text |
 | UncontrolledFormatStringBad.cs:12:39:12:44 | access to local variable format | UncontrolledFormatStringBad.cs:9:25:9:47 | access to property QueryString | UncontrolledFormatStringBad.cs:12:39:12:44 | access to local variable format | $@ flows to here and is used as a format string. | UncontrolledFormatStringBad.cs:9:25:9:47 | access to property QueryString | access to property QueryString |

--- a/csharp/ql/test/query-tests/Security Features/CWE-312/CleartextStorage.cs
+++ b/csharp/ql/test/query-tests/Security Features/CWE-312/CleartextStorage.cs
@@ -1,8 +1,8 @@
-// semmle-extractor-options: ${testdir}/../../../resources/stubs/System.Web.cs /r:System.Collections.Specialized.dll
-
+// semmle-extractor-options: ${testdir}/../../../resources/stubs/System.Web.cs /r:System.Collections.Specialized.dll {testdir}/../../../../resources/stubs/System.Windows.cs
 using System.Text;
 using System.Web;
 using System.Web.Security;
+using System.Windows.Forms;
 
 public class ClearTextStorageHandler : IHttpHandler
 {
@@ -59,4 +59,20 @@ public class ClearTextStorageHandler : IHttpHandler
 class ILogger
 {
     public void Warn(string message) { }
+}
+
+class MyForm : Form
+{
+    TextBox password, box1, box2, box3;
+    ILogger logger;
+
+    public void OnButtonClicked()
+    {
+        box1.PasswordChar = '*';
+        box2.UseSystemPasswordChar = true;
+        logger.Warn(password.Text);  // BAD
+        logger.Warn(box1.Text);  // BAD
+        logger.Warn(box2.Text);  // BAD
+        logger.Warn(box3.Text);  // GOOD
+    }
 }

--- a/csharp/ql/test/query-tests/Security Features/CWE-312/CleartextStorage.expected
+++ b/csharp/ql/test/query-tests/Security Features/CWE-312/CleartextStorage.expected
@@ -5,9 +5,15 @@ nodes
 | CleartextStorage.cs:16:69:16:81 | call to method GetPassword |
 | CleartextStorage.cs:17:50:17:63 | call to method GetAccountID |
 | CleartextStorage.cs:25:21:25:33 | call to method GetPassword |
+| CleartextStorage.cs:73:21:73:33 | access to property Text |
+| CleartextStorage.cs:74:21:74:29 | access to property Text |
+| CleartextStorage.cs:75:21:75:29 | access to property Text |
 #select
 | CleartextStorage.cs:14:50:14:59 | access to field accountKey | CleartextStorage.cs:14:50:14:59 | access to field accountKey | CleartextStorage.cs:14:50:14:59 | access to field accountKey | Sensitive data returned by $@ is stored here. | CleartextStorage.cs:14:50:14:59 | access to field accountKey | access to field accountKey |
 | CleartextStorage.cs:15:62:15:74 | call to method GetPassword | CleartextStorage.cs:15:62:15:74 | call to method GetPassword | CleartextStorage.cs:15:62:15:74 | call to method GetPassword | Sensitive data returned by $@ is stored here. | CleartextStorage.cs:15:62:15:74 | call to method GetPassword | call to method GetPassword |
 | CleartextStorage.cs:16:69:16:81 | call to method GetPassword | CleartextStorage.cs:16:69:16:81 | call to method GetPassword | CleartextStorage.cs:16:69:16:81 | call to method GetPassword | Sensitive data returned by $@ is stored here. | CleartextStorage.cs:16:69:16:81 | call to method GetPassword | call to method GetPassword |
 | CleartextStorage.cs:17:50:17:63 | call to method GetAccountID | CleartextStorage.cs:17:50:17:63 | call to method GetAccountID | CleartextStorage.cs:17:50:17:63 | call to method GetAccountID | Sensitive data returned by $@ is stored here. | CleartextStorage.cs:17:50:17:63 | call to method GetAccountID | call to method GetAccountID |
 | CleartextStorage.cs:25:21:25:33 | call to method GetPassword | CleartextStorage.cs:25:21:25:33 | call to method GetPassword | CleartextStorage.cs:25:21:25:33 | call to method GetPassword | Sensitive data returned by $@ is stored here. | CleartextStorage.cs:25:21:25:33 | call to method GetPassword | call to method GetPassword |
+| CleartextStorage.cs:73:21:73:33 | access to property Text | CleartextStorage.cs:73:21:73:33 | access to property Text | CleartextStorage.cs:73:21:73:33 | access to property Text | Sensitive data returned by $@ is stored here. | CleartextStorage.cs:73:21:73:33 | access to property Text | access to property Text |
+| CleartextStorage.cs:74:21:74:29 | access to property Text | CleartextStorage.cs:74:21:74:29 | access to property Text | CleartextStorage.cs:74:21:74:29 | access to property Text | Sensitive data returned by $@ is stored here. | CleartextStorage.cs:74:21:74:29 | access to property Text | access to property Text |
+| CleartextStorage.cs:75:21:75:29 | access to property Text | CleartextStorage.cs:75:21:75:29 | access to property Text | CleartextStorage.cs:75:21:75:29 | access to property Text | Sensitive data returned by $@ is stored here. | CleartextStorage.cs:75:21:75:29 | access to property Text | access to property Text |

--- a/csharp/ql/test/query-tests/Security Features/CWE-359/ExposureOfPrivateInformation.cs
+++ b/csharp/ql/test/query-tests/Security Features/CWE-359/ExposureOfPrivateInformation.cs
@@ -1,4 +1,4 @@
-// semmle-extractor-options: ${testdir}/../../../resources/stubs/System.Web.cs /r:System.Collections.Specialized.dll
+// semmle-extractor-options: ${testdir}/../../../resources/stubs/System.Web.cs /r:System.Collections.Specialized.dll ${testdir}/../../../resources/stubs/System.Windows.cs
 
 using System.Web;
 
@@ -32,6 +32,14 @@ public class ExposureOfPrivateInformationHandler : IHttpHandler
         {
             return true;
         }
+    }
+
+    System.Windows.Forms.TextBox postcode;
+
+    void OnButtonClicked()
+    {
+        ILogger logger = new ILogger();
+        logger.Warn(postcode.Text);
     }
 }
 

--- a/csharp/ql/test/query-tests/Security Features/CWE-359/ExposureOfPrivateInformation.expected
+++ b/csharp/ql/test/query-tests/Security Features/CWE-359/ExposureOfPrivateInformation.expected
@@ -3,7 +3,9 @@ nodes
 | ExposureOfPrivateInformation.cs:18:50:18:84 | access to indexer |
 | ExposureOfPrivateInformation.cs:20:50:20:65 | call to method getTelephone |
 | ExposureOfPrivateInformation.cs:24:21:24:36 | call to method getTelephone |
+| ExposureOfPrivateInformation.cs:42:21:42:33 | access to property Text |
 #select
 | ExposureOfPrivateInformation.cs:18:50:18:84 | access to indexer | ExposureOfPrivateInformation.cs:18:50:18:84 | access to indexer | ExposureOfPrivateInformation.cs:18:50:18:84 | access to indexer | Private data returned by $@ is written to an external location. | ExposureOfPrivateInformation.cs:18:50:18:84 | access to indexer | access to indexer |
 | ExposureOfPrivateInformation.cs:20:50:20:65 | call to method getTelephone | ExposureOfPrivateInformation.cs:20:50:20:65 | call to method getTelephone | ExposureOfPrivateInformation.cs:20:50:20:65 | call to method getTelephone | Private data returned by $@ is written to an external location. | ExposureOfPrivateInformation.cs:20:50:20:65 | call to method getTelephone | call to method getTelephone |
 | ExposureOfPrivateInformation.cs:24:21:24:36 | call to method getTelephone | ExposureOfPrivateInformation.cs:24:21:24:36 | call to method getTelephone | ExposureOfPrivateInformation.cs:24:21:24:36 | call to method getTelephone | Private data returned by $@ is written to an external location. | ExposureOfPrivateInformation.cs:24:21:24:36 | call to method getTelephone | call to method getTelephone |
+| ExposureOfPrivateInformation.cs:42:21:42:33 | access to property Text | ExposureOfPrivateInformation.cs:42:21:42:33 | access to property Text | ExposureOfPrivateInformation.cs:42:21:42:33 | access to property Text | Private data returned by $@ is written to an external location. | ExposureOfPrivateInformation.cs:42:21:42:33 | access to property Text | access to property Text |

--- a/csharp/ql/test/resources/stubs/System.Windows.cs
+++ b/csharp/ql/test/resources/stubs/System.Windows.cs
@@ -8,11 +8,48 @@ namespace System.Windows.Forms
 
     public class MessageBox
     {
-        public static void Show(string msg, string title) { }
+        public static void Show(string msg, string title) { }
     }
 
     public class Application
     {
         public static void Exit() { }
+    }
+
+    class HtmlDocument
+    {
+        public void Write(string s) { }
+    }
+
+    class TextBoxBase
+    {
+        public string Text { get; set; }
+    }
+
+    class TextBox : TextBoxBase
+    {
+        public char PasswordChar { get; set; }
+        public bool UseSystemPasswordChar { get; set; }
+    }
+    
+    class RichTextBox : TextBoxBase
+    {
+        public string Rtf => null;
+        public string SelectedText => null;
+        public string SelectedRtf => null;
+    }
+
+    class WebBrowser
+    {
+        public string DocumentText { get; set; }
+        public HtmlDocument Document => null;
+    }
+
+    class Form
+    {
+    }
+
+    struct EventArgs
+    {
     }
 }


### PR DESCRIPTION
Reviewed the `System.Windows.Forms` API for potential data sources and sinks.

Added a new file `Local.qll` and `LocalFlowSource` to mirror `Remote.qll` and `RemoteFlowSource`, but did not put them into a single hierarchy. `LocalFlowSource` currently only considers text fields (inheriting from `TextBoxBase`) to be sources of user input.

Reviewed the security queries to see which for which queries it makes sense to add `LocalFlowSource` to.