### PR TITLE
C++: Recognize more function decls as code

### DIFF
--- a/cpp/ql/src/Documentation/CommentedOutCode.qll
+++ b/cpp/ql/src/Documentation/CommentedOutCode.qll
@@ -25,12 +25,12 @@ private predicate looksLikeCode(string line) {
               // brace that's preceded by something other than whitespace ...
               trimmed.regexpMatch(".*.\\}")
               implies
-              // ... then there has to be ") {" (with some variation of
-              // whitespace) on the line, suggesting it's a statement like `if`
+              // ... then there has to be ") {" (or some variation)
+              // on the line, suggesting it's a statement like `if`
               // or a function declaration. Otherwise it's likely to be a
               // benign use of braces such as a JSON example or explanatory
               // pseudocode.
-              trimmed.regexpMatch(".*\\)\\s*\\{.*")
+              trimmed.regexpMatch(".*(\\)|const|volatile|override|final|noexcept|&)\\s*\\{.*")
            )
            and not trimmed.regexpMatch("(>.*|.*[\\\\@][{}].*|(optional|repeated) .*;|.*(\\{\\{\\{|\\}\\}\\}).*|\\{[-0-9a-zA-Z]+\\})"))
 }

--- a/cpp/ql/test/query-tests/Documentation/CommentedOutCode/CommentedOutCode.expected
+++ b/cpp/ql/test/query-tests/Documentation/CommentedOutCode/CommentedOutCode.expected
@@ -1,4 +1,6 @@
 | test2.cpp:37:1:37:39 | // int myFunction() { return myValue; } | This comment appears to contain commented-out code |
+| test2.cpp:39:1:39:45 | // int myFunction() const { return myValue; } | This comment appears to contain commented-out code |
+| test2.cpp:41:1:41:54 | // int myFunction() const noexcept { return myValue; } | This comment appears to contain commented-out code |
 | test.c:2:1:2:22 | // commented out code; | This comment appears to contain commented-out code |
 | test.c:4:1:7:8 | // some; | This comment appears to contain commented-out code |
 | test.c:9:1:13:8 | // also; | This comment appears to contain commented-out code |

--- a/cpp/ql/test/query-tests/Documentation/CommentedOutCode/test2.cpp
+++ b/cpp/ql/test/query-tests/Documentation/CommentedOutCode/test2.cpp
@@ -35,3 +35,7 @@
 // Example: { 1, 2, 3, 4 }
 
 // int myFunction() { return myValue; }
+
+// int myFunction() const { return myValue; }
+
+// int myFunction() const noexcept { return myValue; }


### PR DESCRIPTION
This follows up on the discussion in #779.