### PR TITLE
JS: track dataflow sources out of callbacks

### DIFF
--- a/javascript/ql/src/semmle/javascript/dataflow/Configuration.qll
+++ b/javascript/ql/src/semmle/javascript/dataflow/Configuration.qll
@@ -712,7 +712,7 @@ predicate higherOrderCall(
     summary = PathSummary::call()
   )
   or
-  // Forwarding of the callback parameter  (but not the argument).
+  // Forwarding of the callback parameter (but not the argument).
   // We use a return summary since flow moves back towards the call site.
   // This ensures that an argument that is only tainted in some contexts cannot flow
   // out to every callback.

--- a/javascript/ql/src/semmle/javascript/dataflow/Configuration.qll
+++ b/javascript/ql/src/semmle/javascript/dataflow/Configuration.qll
@@ -663,18 +663,21 @@ private predicate flowThroughProperty(
 private predicate summarizedHigherOrderCall(
   DataFlow::Node arg, DataFlow::Node cb, int i, DataFlow::Configuration cfg, PathSummary summary
 ) {
-  exists (Function f, DataFlow::InvokeNode outer, DataFlow::InvokeNode inner, int j,
-    DataFlow::Node innerArg, DataFlow::ParameterNode cbParm, PathSummary oldSummary |
+  exists(
+    Function f, DataFlow::InvokeNode outer, DataFlow::InvokeNode inner, int j,
+    DataFlow::Node innerArg, DataFlow::ParameterNode cbParm, PathSummary oldSummary
+  |
     reachableFromInput(f, outer, arg, innerArg, cfg, oldSummary) and
     argumentPassing(outer, cb, f, cbParm) and
-    innerArg = inner.getArgument(j) |
+    innerArg = inner.getArgument(j)
+  |
     // direct higher-order call
     cbParm.flowsTo(inner.getCalleeNode()) and
     i = j and
     summary = oldSummary
     or
     // indirect higher-order call
-    exists (DataFlow::Node cbArg, PathSummary newSummary |
+    exists(DataFlow::Node cbArg, PathSummary newSummary |
       cbParm.flowsTo(cbArg) and
       summarizedHigherOrderCall(innerArg, cbArg, i, cfg, newSummary) and
       summary = oldSummary.append(PathSummary::call()).append(newSummary)
@@ -696,14 +699,14 @@ predicate higherOrderCall(
   PathSummary summary
 ) {
   // Summarized call
-  exists (DataFlow::Node cb |
+  exists(DataFlow::Node cb |
     summarizedHigherOrderCall(arg, cb, i, cfg, summary) and
     callback.flowsTo(cb)
   )
   or
   // Local invocation of a parameter
   isRelevant(arg, cfg) and
-  exists (DataFlow::InvokeNode invoke |
+  exists(DataFlow::InvokeNode invoke |
     arg = invoke.getArgument(i) and
     invoke = callback.(DataFlow::ParameterNode).getACall() and
     summary = PathSummary::call()
@@ -720,7 +723,6 @@ predicate higherOrderCall(
     summary = PathSummary::return().append(oldSummary)
   )
 }
-
 
 /**
  * Holds if `pred` is passed as an argument to a function `f` which also takes a

--- a/javascript/ql/src/semmle/javascript/dataflow/TrackedNodes.qll
+++ b/javascript/ql/src/semmle/javascript/dataflow/TrackedNodes.qll
@@ -251,8 +251,7 @@ private module NodeTracking {
    * That is, `arg` refers to a value defined in `f` or one of its callees.
    */
   predicate higherOrderCall(
-    DataFlow::Node arg, DataFlow::SourceNode callback, int i,
-    PathSummary summary
+    DataFlow::Node arg, DataFlow::SourceNode callback, int i, PathSummary summary
   ) {
     // Summarized call
     exists(DataFlow::Node cb |
@@ -287,7 +286,7 @@ private module NodeTracking {
    * locally.
    */
   private predicate flowIntoHigherOrderCall(
-    DataFlow::Node pred, DataFlow::Node succ,  PathSummary summary
+    DataFlow::Node pred, DataFlow::Node succ, PathSummary summary
   ) {
     exists(DataFlow::FunctionNode cb, int i, PathSummary oldSummary |
       higherOrderCall(pred, cb, i, oldSummary) and

--- a/javascript/ql/src/semmle/javascript/dataflow/TrackedNodes.qll
+++ b/javascript/ql/src/semmle/javascript/dataflow/TrackedNodes.qll
@@ -216,25 +216,67 @@ private module NodeTracking {
    * invokes `cb`, passing `arg` as its `i`th argument. `arg` flows along a path summarized
    * by `summary`, while `cb` is only tracked locally.
    */
-  private predicate higherOrderCall(
+  private predicate summarizedHigherOrderCall(
     DataFlow::Node arg, DataFlow::Node cb, int i, PathSummary summary
   ) {
-    exists (Function f, DataFlow::InvokeNode outer, DataFlow::InvokeNode inner, int j,
-      DataFlow::Node innerArg, DataFlow::ParameterNode cbParm, PathSummary oldSummary |
+    exists(
+      Function f, DataFlow::InvokeNode outer, DataFlow::InvokeNode inner, int j,
+      DataFlow::Node innerArg, DataFlow::ParameterNode cbParm, PathSummary oldSummary
+    |
       reachableFromInput(f, outer, arg, innerArg, oldSummary) and
       argumentPassing(outer, cb, f, cbParm) and
-      innerArg = inner.getArgument(j) |
+      innerArg = inner.getArgument(j)
+    |
       // direct higher-order call
       cbParm.flowsTo(inner.getCalleeNode()) and
       i = j and
       summary = oldSummary
       or
       // indirect higher-order call
-      exists (DataFlow::Node cbArg, PathSummary newSummary |
+      exists(DataFlow::Node cbArg, PathSummary newSummary |
         cbParm.flowsTo(cbArg) and
-        higherOrderCall(innerArg, cbArg, i, newSummary) and
+        summarizedHigherOrderCall(innerArg, cbArg, i, newSummary) and
         summary = oldSummary.append(PathSummary::call()).append(newSummary)
       )
+    )
+  }
+
+  /**
+   * Holds if `arg` is passed as the `i`th argument to `callback` through a callback invocation.
+   *
+   * This can be a summarized call, that is, `arg` and `callback` flow into a call,
+   * `f(arg, callback)`, which  performs the invocation.
+   *
+   * Alternatively, the callback can flow into a call `f(callback)` which itself provides the `arg`.
+   * That is, `arg` refers to a value defined in `f` or one of its callees.
+   */
+  predicate higherOrderCall(
+    DataFlow::Node arg, DataFlow::SourceNode callback, int i,
+    PathSummary summary
+  ) {
+    // Summarized call
+    exists(DataFlow::Node cb |
+      summarizedHigherOrderCall(arg, cb, i, summary) and
+      callback.flowsTo(cb)
+    )
+    or
+    // Local invocation of a parameter
+    isRelevant(arg) and
+    exists(DataFlow::InvokeNode invoke |
+      arg = invoke.getArgument(i) and
+      invoke = callback.(DataFlow::ParameterNode).getACall() and
+      summary = PathSummary::call()
+    )
+    or
+    // Forwarding of the callback parameter  (but not the argument).
+    // We use a return summary since flow moves back towards the call site.
+    // This ensures that an argument that is only tainted in some contexts cannot flow
+    // out to every callback.
+    exists(DataFlow::Node cbArg, DataFlow::SourceNode innerCb, PathSummary oldSummary |
+      higherOrderCall(arg, innerCb, i, oldSummary) and
+      callStep(cbArg, innerCb) and
+      callback.flowsTo(cbArg) and
+      summary = PathSummary::return().append(oldSummary)
     )
   }
 
@@ -245,14 +287,10 @@ private module NodeTracking {
    * locally.
    */
   private predicate flowIntoHigherOrderCall(
-    DataFlow::Node pred, DataFlow::Node succ, PathSummary summary
+    DataFlow::Node pred, DataFlow::Node succ,  PathSummary summary
   ) {
-    exists(
-      DataFlow::Node fArg, DataFlow::FunctionNode cb,
-      int i, PathSummary oldSummary
-    |
-      higherOrderCall(pred, fArg, i, oldSummary) and
-      cb = fArg.getALocalSource() and
+    exists(DataFlow::FunctionNode cb, int i, PathSummary oldSummary |
+      higherOrderCall(pred, cb, i, oldSummary) and
       succ = cb.getParameter(i) and
       summary = oldSummary.append(PathSummary::call())
     )

--- a/javascript/ql/src/semmle/javascript/dataflow/internal/FlowSteps.qll
+++ b/javascript/ql/src/semmle/javascript/dataflow/internal/FlowSteps.qll
@@ -264,6 +264,12 @@ predicate callback(DataFlow::Node arg, DataFlow::SourceNode cb) {
     callStep(cbArg, cbParm) and
     cb.flowsTo(cbArg)
   )
+  or
+  exists (DataFlow::ParameterNode cbParm, DataFlow::Node cbArg |
+    callback(arg, cbParm) and
+    callStep(cbArg, cbParm) and
+    cb.flowsTo(cbArg)
+  )
 }
 
 /**

--- a/javascript/ql/src/semmle/javascript/dataflow/internal/FlowSteps.qll
+++ b/javascript/ql/src/semmle/javascript/dataflow/internal/FlowSteps.qll
@@ -109,9 +109,7 @@ predicate argumentPassing(
  * Holds if there is a flow step from `pred` to `succ` through parameter passing
  * to a function call.
  */
-predicate callStep(DataFlow::Node pred, DataFlow::Node succ) {
-  argumentPassing(_, pred, _, succ)
-}
+predicate callStep(DataFlow::Node pred, DataFlow::Node succ) { argumentPassing(_, pred, _, succ) }
 
 /**
  * Holds if there is a flow step from `pred` to `succ` through returning
@@ -258,14 +256,14 @@ predicate loadStep(DataFlow::Node pred, DataFlow::PropRead succ, string prop) {
  * invocation.
  */
 predicate callback(DataFlow::Node arg, DataFlow::SourceNode cb) {
-  exists (DataFlow::InvokeNode invk, DataFlow::ParameterNode cbParm, DataFlow::Node cbArg |
+  exists(DataFlow::InvokeNode invk, DataFlow::ParameterNode cbParm, DataFlow::Node cbArg |
     arg = invk.getAnArgument() and
     cbParm.flowsTo(invk.getCalleeNode()) and
     callStep(cbArg, cbParm) and
     cb.flowsTo(cbArg)
   )
   or
-  exists (DataFlow::ParameterNode cbParm, DataFlow::Node cbArg |
+  exists(DataFlow::ParameterNode cbParm, DataFlow::Node cbArg |
     callback(arg, cbParm) and
     callStep(cbArg, cbParm) and
     cb.flowsTo(cbArg)

--- a/javascript/ql/test/library-tests/TaintTracking/BasicTaintTracking.expected
+++ b/javascript/ql/test/library-tests/TaintTracking/BasicTaintTracking.expected
@@ -1,4 +1,14 @@
 | advanced-callgraph.js:2:13:2:20 | source() | advanced-callgraph.js:6:22:6:22 | v |
+| callbacks.js:4:6:4:13 | source() | callbacks.js:34:27:34:27 | x |
+| callbacks.js:4:6:4:13 | source() | callbacks.js:35:27:35:27 | x |
+| callbacks.js:5:6:5:13 | source() | callbacks.js:34:27:34:27 | x |
+| callbacks.js:5:6:5:13 | source() | callbacks.js:35:27:35:27 | x |
+| callbacks.js:25:16:25:23 | source() | callbacks.js:47:26:47:26 | x |
+| callbacks.js:25:16:25:23 | source() | callbacks.js:48:26:48:26 | x |
+| callbacks.js:37:17:37:24 | source() | callbacks.js:37:37:37:37 | x |
+| callbacks.js:44:17:44:24 | source() | callbacks.js:41:10:41:10 | x |
+| callbacks.js:50:18:50:25 | source() | callbacks.js:30:29:30:29 | y |
+| callbacks.js:51:18:51:25 | source() | callbacks.js:30:29:30:29 | y |
 | constructor-calls.js:4:18:4:25 | source() | constructor-calls.js:18:8:18:14 | c.taint |
 | constructor-calls.js:4:18:4:25 | source() | constructor-calls.js:22:8:22:19 | c_safe.taint |
 | constructor-calls.js:10:16:10:23 | source() | constructor-calls.js:26:8:26:14 | d.taint |

--- a/javascript/ql/test/library-tests/TaintTracking/callbacks.js
+++ b/javascript/ql/test/library-tests/TaintTracking/callbacks.js
@@ -1,0 +1,52 @@
+import * as dummy from 'dummy'; // treat as module
+
+function provideTaint(cb) {
+  cb(source());
+  cb(source());
+}
+
+function provideTaint2(cb) {
+  provideTaint(cb);
+  provideTaint(cb); // suppress precision gains from functions with unique call site
+}
+
+function forwardTaint(x, cb) {
+  cb(x);
+  cb(x);
+}
+
+function forwardTaint2(x, cb) {
+  forwardTaint(x, cb);
+  forwardTaint(x, cb);
+}
+
+function middleSource(cb) {
+  // The source occurs in-between the callback definition and the callback invocation.
+  forwardTaint(source(), cb);
+}
+
+function middleCallback(x) {
+  // The callback definition occurs in-between the source and the callback invocation.
+  forwardTaint(x, y => sink(y)); // NOT OK
+}
+
+function test() {
+  provideTaint2(x => sink(x)); // NOT OK
+  provideTaint2(x => sink(x)); // NOT OK
+
+  forwardTaint2(source(), x => sink(x)); // NOT OK
+  forwardTaint2("safe", x => sink(x)); // OK
+  
+  function helper1(x) {
+    sink(x); // NOT OK
+    return x;
+  }
+  forwardTaint2(source(), helper1);
+  sink(helper1("safe")); // OK
+
+  middleSource(x => sink(x)); // NOT OK
+  middleSource(x => sink(x)); // NOT OK
+
+  middleCallback(source());
+  middleCallback(source());
+}


### PR DESCRIPTION
This tracks flow out of callbacks in cases where the source occurs in the function performing the callback invocation.

For example:
```javascript
function f(callback) {
  callback(arg)
}
function test() {
  f(x => sink(x))
}
```
In the above case, we would add a step from `arg` to `x` with the summary `return;call`, that is, a return followed by a call.

Why `return`? Intuitively, the flow goes back towards the caller. More concretely, it ensures that the source actually came from `f` itself (since prior call steps are blocked by the return) and so the taintedness of `arg` does not depend on the calling context, and we can safely propagate it to all callbacks passed into the function.

[Evaluation](https://git.semmle.com/asger/dist-compare-reports/tree/callback-taint-source_1547955565784) looks mostly good, but I had initially forgotten to update `TrackedNode` so I'm running another evaluation on just big-apps and the two slowest slugs from before.

