### PR TITLE
CPP: Small change to 'Resource not released in destructor'

### DIFF
--- a/cpp/ql/src/jsf/4.10 Classes/AV Rule 79.ql
+++ b/cpp/ql/src/jsf/4.10 Classes/AV Rule 79.ql
@@ -191,9 +191,7 @@ predicate freedInSameMethod(Resource r, Expr acquire) {
   exists(Expr releaseExpr, string kind |
     r.acquisitionWithRequiredKind(acquire, kind) and
     releaseExpr = r.getAReleaseExpr(kind) and
-    releaseExpr.getEnclosingFunction().getEnclosingAccessHolder*() = acquire.getEnclosingFunction()
-    	// here, `getEnclosingAccessHolder*` allows us to go from a nested function or lambda
-    	// expression to the class method enclosing it.
+    releaseExpr.getEnclosingElement*() = acquire.getEnclosingFunction()
   )
 }
 

--- a/cpp/ql/src/jsf/4.10 Classes/AV Rule 79.ql
+++ b/cpp/ql/src/jsf/4.10 Classes/AV Rule 79.ql
@@ -191,7 +191,7 @@ predicate freedInSameMethod(Resource r, Expr acquire) {
   exists(Expr releaseExpr, string kind |
     r.acquisitionWithRequiredKind(acquire, kind) and
     releaseExpr = r.getAReleaseExpr(kind) and
-    releaseExpr.getEnclosingElement*() = acquire.getEnclosingFunction()
+    releaseExpr.getEnclosingElement+() = acquire.getEnclosingFunction()
   )
 }
 


### PR DESCRIPTION
Change discussed in https://github.com/Semmle/ql/pull/672#discussion_r242134216.  @jbj is right, performance is if anything slightly better (not worse) with `getEnclosingElement`, given a warmed up cache.