### PR TITLE
C++: IR sanity queries for outgoing edges

### DIFF
--- a/cpp/ql/src/semmle/code/cpp/ir/implementation/aliased_ssa/Instruction.qll
+++ b/cpp/ql/src/semmle/code/cpp/ir/implementation/aliased_ssa/Instruction.qll
@@ -107,6 +107,32 @@ module InstructionSanity {
   }
 
   /**
+   * Holds if there are multiple (`n`) edges of kind `kind` from `source`,
+   * where `target` is among the targets of those edges.
+   */
+  query predicate ambiguousSuccessors(
+    Instruction source, EdgeKind kind, int n, Instruction target
+  ) {
+    n = strictcount(Instruction t | source.getSuccessor(kind) = t) and
+    n > 1 and
+    source.getSuccessor(kind) = target
+  }
+
+  /**
+   * Holds if `instr` in `f` is part of a loop even though the AST of `f`
+   * contains no element that can cause loops.
+   */
+  query predicate unexplainedLoop(Function f, Instruction instr) {
+    exists(IRBlock block |
+      instr.getBlock() = block and
+      block.getFunction() = f and
+      block.getASuccessor+() = block
+    ) and
+    not exists(Loop l | l.getEnclosingFunction() = f) and
+    not exists(GotoStmt s | s.getEnclosingFunction() = f)
+  }
+
+  /**
    * Holds if a `Phi` instruction is present in a block with fewer than two
    * predecessors.
    */

--- a/cpp/ql/src/semmle/code/cpp/ir/implementation/raw/Instruction.qll
+++ b/cpp/ql/src/semmle/code/cpp/ir/implementation/raw/Instruction.qll
@@ -107,6 +107,32 @@ module InstructionSanity {
   }
 
   /**
+   * Holds if there are multiple (`n`) edges of kind `kind` from `source`,
+   * where `target` is among the targets of those edges.
+   */
+  query predicate ambiguousSuccessors(
+    Instruction source, EdgeKind kind, int n, Instruction target
+  ) {
+    n = strictcount(Instruction t | source.getSuccessor(kind) = t) and
+    n > 1 and
+    source.getSuccessor(kind) = target
+  }
+
+  /**
+   * Holds if `instr` in `f` is part of a loop even though the AST of `f`
+   * contains no element that can cause loops.
+   */
+  query predicate unexplainedLoop(Function f, Instruction instr) {
+    exists(IRBlock block |
+      instr.getBlock() = block and
+      block.getFunction() = f and
+      block.getASuccessor+() = block
+    ) and
+    not exists(Loop l | l.getEnclosingFunction() = f) and
+    not exists(GotoStmt s | s.getEnclosingFunction() = f)
+  }
+
+  /**
    * Holds if a `Phi` instruction is present in a block with fewer than two
    * predecessors.
    */

--- a/cpp/ql/src/semmle/code/cpp/ir/implementation/unaliased_ssa/Instruction.qll
+++ b/cpp/ql/src/semmle/code/cpp/ir/implementation/unaliased_ssa/Instruction.qll
@@ -107,6 +107,32 @@ module InstructionSanity {
   }
 
   /**
+   * Holds if there are multiple (`n`) edges of kind `kind` from `source`,
+   * where `target` is among the targets of those edges.
+   */
+  query predicate ambiguousSuccessors(
+    Instruction source, EdgeKind kind, int n, Instruction target
+  ) {
+    n = strictcount(Instruction t | source.getSuccessor(kind) = t) and
+    n > 1 and
+    source.getSuccessor(kind) = target
+  }
+
+  /**
+   * Holds if `instr` in `f` is part of a loop even though the AST of `f`
+   * contains no element that can cause loops.
+   */
+  query predicate unexplainedLoop(Function f, Instruction instr) {
+    exists(IRBlock block |
+      instr.getBlock() = block and
+      block.getFunction() = f and
+      block.getASuccessor+() = block
+    ) and
+    not exists(Loop l | l.getEnclosingFunction() = f) and
+    not exists(GotoStmt s | s.getEnclosingFunction() = f)
+  }
+
+  /**
    * Holds if a `Phi` instruction is present in a block with fewer than two
    * predecessors.
    */

--- a/cpp/ql/test/library-tests/ir/ir/aliased_ssa_sanity.expected
+++ b/cpp/ql/test/library-tests/ir/ir/aliased_ssa_sanity.expected
@@ -3,6 +3,8 @@ unexpectedOperand
 duplicateOperand
 missingPhiOperand
 instructionWithoutSuccessor
+ambiguousSuccessors
+unexplainedLoop
 unnecessaryPhiInstruction
 operandAcrossFunctions
 instructionWithoutUniqueBlock

--- a/cpp/ql/test/library-tests/ir/ir/raw_sanity.expected
+++ b/cpp/ql/test/library-tests/ir/ir/raw_sanity.expected
@@ -3,6 +3,8 @@ unexpectedOperand
 duplicateOperand
 missingPhiOperand
 instructionWithoutSuccessor
+ambiguousSuccessors
+unexplainedLoop
 unnecessaryPhiInstruction
 operandAcrossFunctions
 instructionWithoutUniqueBlock

--- a/cpp/ql/test/library-tests/ir/ir/unaliased_ssa_sanity.expected
+++ b/cpp/ql/test/library-tests/ir/ir/unaliased_ssa_sanity.expected
@@ -3,6 +3,8 @@ unexpectedOperand
 duplicateOperand
 missingPhiOperand
 instructionWithoutSuccessor
+ambiguousSuccessors
+unexplainedLoop
 unnecessaryPhiInstruction
 operandAcrossFunctions
 instructionWithoutUniqueBlock


### PR DESCRIPTION
These queries have no results on our test cases in the repo, but `ambiguousSuccessors` has results on any large C++ code base, and `unexplainedLoop` has results on Windows builds of ChakraCore. I haven't been able to replicate these problems in qltest, so I think they have to do with linker awareness or with how declarations of similar names show up in different files.

Given the vast number of results for `ambiguousSuccessors`, fixing these problems could be necessary not just for correctness but also for performance. Here is a screenshot of `raw/PrintIR.ql` for a function that comes up in both of these new sanity queries.

<img width="1056" alt="unexplainedloop" src="https://user-images.githubusercontent.com/308293/51599649-7252c980-1f00-11e9-9c43-86f06e1ba91b.png">

This is the source of that function: https://github.com/Microsoft/ChakraCore/blob/08161b0b4110e3888f77632a9f40a2229884bbe7/lib/Runtime/Base/Entropy.cpp#L14-L21.