### PR TITLE
C++: IR back-edge detection based on TranslatedStmt

### DIFF
--- a/cpp/ql/src/semmle/code/cpp/ir/implementation/aliased_ssa/IRBlock.qll
+++ b/cpp/ql/src/semmle/code/cpp/ir/implementation/aliased_ssa/IRBlock.qll
@@ -90,6 +90,10 @@ class IRBlock extends IRBlockBase {
     blockSuccessor(this, result, kind)
   }
 
+  final IRBlock getBackEdgeSuccessor(EdgeKind kind) {
+    backEdgeSuccessor(this, result, kind)
+  }
+
   final predicate immediatelyDominates(IRBlock block) {
     blockImmediatelyDominates(this, block)
   }
@@ -132,7 +136,10 @@ private predicate startsBasicBlock(Instruction instr) {
     exists(Instruction predecessor, EdgeKind kind |
       instr = predecessor.getSuccessor(kind) and
       not kind instanceof GotoEdge
-    )  // Incoming edge is not a GotoEdge
+    ) or  // Incoming edge is not a GotoEdge
+    exists(Instruction predecessor |
+      instr = predecessor.getBackEdgeSuccessor(_)
+    )  // A back edge enters this instruction
   )
 }
 
@@ -180,6 +187,14 @@ private cached module Cached {
     exists(Instruction predLast, Instruction succFirst |
       predLast = getInstruction(pred, getInstructionCount(pred) - 1) and
       succFirst = predLast.getSuccessor(kind) and
+      succ = MkIRBlock(succFirst)
+    )
+  }
+
+  cached predicate backEdgeSuccessor(TIRBlock pred, TIRBlock succ, EdgeKind kind) {
+    exists(Instruction predLast, Instruction succFirst |
+      predLast = getInstruction(pred, getInstructionCount(pred) - 1) and
+      succFirst = predLast.getBackEdgeSuccessor(kind) and
       succ = MkIRBlock(succFirst)
     )
   }

--- a/cpp/ql/src/semmle/code/cpp/ir/implementation/aliased_ssa/Instruction.qll
+++ b/cpp/ql/src/semmle/code/cpp/ir/implementation/aliased_ssa/Instruction.qll
@@ -464,6 +464,16 @@ class Instruction extends Construction::TInstruction {
   }
 
   /**
+   * Gets the a _back-edge successor_ of this instruction along the control
+   * flow edge specified by `kind`. A back edge in the control-flow graph is
+   * intuitively the edge that goes back around a loop. If all back edges are
+   * removed from the control-flow graph, it becomes acyclic.
+   */
+  final Instruction getBackEdgeSuccessor(EdgeKind kind) {
+    result = Construction::getInstructionBackEdgeSuccessor(this, kind)
+  }
+
+  /**
    * Gets all direct successors of this instruction.
    */
   final Instruction getASuccessor() {

--- a/cpp/ql/src/semmle/code/cpp/ir/implementation/aliased_ssa/internal/SSAConstruction.qll
+++ b/cpp/ql/src/semmle/code/cpp/ir/implementation/aliased_ssa/internal/SSAConstruction.qll
@@ -278,6 +278,14 @@ cached private module Cached {
     )
   }
 
+  cached Instruction getInstructionBackEdgeSuccessor(Instruction instruction, EdgeKind kind) {
+    exists(OldInstruction oldInstruction |
+      oldInstruction = getOldInstruction(instruction) and
+      result = getNewInstruction(oldInstruction.getBackEdgeSuccessor(kind)) and
+      not Reachability::isInfeasibleInstructionSuccessor(oldInstruction, kind)
+    )
+  }
+
   cached IRVariable getInstructionVariable(Instruction instruction) {
     result = getNewIRVariable(getOldInstruction(instruction).(OldIR::VariableInstruction).getVariable())
   }

--- a/cpp/ql/src/semmle/code/cpp/ir/implementation/raw/IRBlock.qll
+++ b/cpp/ql/src/semmle/code/cpp/ir/implementation/raw/IRBlock.qll
@@ -90,6 +90,10 @@ class IRBlock extends IRBlockBase {
     blockSuccessor(this, result, kind)
   }
 
+  final IRBlock getBackEdgeSuccessor(EdgeKind kind) {
+    backEdgeSuccessor(this, result, kind)
+  }
+
   final predicate immediatelyDominates(IRBlock block) {
     blockImmediatelyDominates(this, block)
   }
@@ -132,7 +136,10 @@ private predicate startsBasicBlock(Instruction instr) {
     exists(Instruction predecessor, EdgeKind kind |
       instr = predecessor.getSuccessor(kind) and
       not kind instanceof GotoEdge
-    )  // Incoming edge is not a GotoEdge
+    ) or  // Incoming edge is not a GotoEdge
+    exists(Instruction predecessor |
+      instr = predecessor.getBackEdgeSuccessor(_)
+    )  // A back edge enters this instruction
   )
 }
 
@@ -180,6 +187,14 @@ private cached module Cached {
     exists(Instruction predLast, Instruction succFirst |
       predLast = getInstruction(pred, getInstructionCount(pred) - 1) and
       succFirst = predLast.getSuccessor(kind) and
+      succ = MkIRBlock(succFirst)
+    )
+  }
+
+  cached predicate backEdgeSuccessor(TIRBlock pred, TIRBlock succ, EdgeKind kind) {
+    exists(Instruction predLast, Instruction succFirst |
+      predLast = getInstruction(pred, getInstructionCount(pred) - 1) and
+      succFirst = predLast.getBackEdgeSuccessor(kind) and
       succ = MkIRBlock(succFirst)
     )
   }

--- a/cpp/ql/src/semmle/code/cpp/ir/implementation/raw/Instruction.qll
+++ b/cpp/ql/src/semmle/code/cpp/ir/implementation/raw/Instruction.qll
@@ -464,6 +464,16 @@ class Instruction extends Construction::TInstruction {
   }
 
   /**
+   * Gets the a _back-edge successor_ of this instruction along the control
+   * flow edge specified by `kind`. A back edge in the control-flow graph is
+   * intuitively the edge that goes back around a loop. If all back edges are
+   * removed from the control-flow graph, it becomes acyclic.
+   */
+  final Instruction getBackEdgeSuccessor(EdgeKind kind) {
+    result = Construction::getInstructionBackEdgeSuccessor(this, kind)
+  }
+
+  /**
    * Gets all direct successors of this instruction.
    */
   final Instruction getASuccessor() {

--- a/cpp/ql/src/semmle/code/cpp/ir/implementation/raw/internal/IRConstruction.qll
+++ b/cpp/ql/src/semmle/code/cpp/ir/implementation/raw/internal/IRConstruction.qll
@@ -5,6 +5,7 @@ private import semmle.code.cpp.ir.internal.TempVariableTag
 private import InstructionTag
 private import TranslatedElement
 private import TranslatedExpr
+private import TranslatedStmt
 private import TranslatedFunction
 
 class InstructionTagType extends TInstructionTag {
@@ -102,6 +103,92 @@ cached private module Cached {
   cached Instruction getInstructionSuccessor(Instruction instruction, EdgeKind kind) {
     result = getInstructionTranslatedElement(instruction).getInstructionSuccessor(
       instruction.getTag(), kind)
+  }
+
+  // This predicate has pragma[noopt] because otherwise the `getAChild*` calls
+  // get joined too early. The join order for the loop cases goes like this:
+  // - Find all loops of that type (tens of thousands).
+  // - Find all edges into the start of the loop (x 2).
+  // - Restrict to edges that originate within the loop (/ 2).
+  pragma[noopt]
+  cached Instruction getInstructionBackEdgeSuccessor(Instruction instruction, EdgeKind kind) {
+    // Any edge from within the body of the loop to the condition of the loop
+    // is a back edge. This includes edges from `continue` and the fall-through
+    // edge(s) after the last instruction(s) in the body.
+    exists(TranslatedWhileStmt s |
+      s instanceof TranslatedWhileStmt and
+      result = s.getFirstConditionInstruction() and
+      exists(TranslatedElement inBody, InstructionTag tag |
+        result = inBody.getInstructionSuccessor(tag, kind) and
+        exists(TranslatedElement body | body = s.getBody() | inBody = body.getAChild*()) and
+        instruction = inBody.getInstruction(tag)
+      )
+    )
+    or
+    // The back edge should be the (unique) edge from the condition to the
+    // body. This ensures that it's the back edge that will be pruned in a `do
+    // { ... } while (0)` statement. Note that all `continue` statements in a
+    // do-while loop produce forward edges.
+    exists(TranslatedDoStmt s |
+      s instanceof TranslatedDoStmt and
+      exists(TranslatedStmt body | body = s.getBody() | result = body.getFirstInstruction()) and
+      exists(TranslatedElement inCondition, InstructionTag tag |
+        result = inCondition.getInstructionSuccessor(tag, kind) and
+        exists(TranslatedElement condition | condition = s.getCondition() |
+          inCondition = condition.getAChild*()
+        ) and
+        instruction = inCondition.getInstruction(tag)
+      )
+    )
+    or
+    // Any edge from within the body or update of the loop to the condition of
+    // the loop is a back edge.  This includes edges from `continue` and the
+    // fall-through edge(s) after the last instruction(s) in the body. A `for`
+    // loop may not have a condition, in which case
+    // `getFirstConditionInstruction` returns the body instead.
+    exists(TranslatedForStmt s |
+      s instanceof TranslatedForStmt and
+      result = s.getFirstConditionInstruction() and
+      exists(TranslatedElement inLoop, InstructionTag tag |
+        result = inLoop.getInstructionSuccessor(tag, kind) and
+        exists(TranslatedElement bodyOrUpdate |
+          bodyOrUpdate = s.getBody()
+          or
+          bodyOrUpdate = s.getUpdate()
+        |
+          inLoop = bodyOrUpdate.getAChild*()
+        ) and
+        instruction = inLoop.getInstruction(tag)
+      )
+    )
+    or
+    // As a conservative approximation, any edge out of `goto` is a back edge
+    // unless it goes strictly forward in the program text. A `goto` whose
+    // source and target are both inside a macro will be seen as having the
+    // same location for source and target, so we conservatively assume that
+    // such a `goto` creates a back edge.
+    exists(TranslatedElement s, GotoStmt goto |
+      goto instanceof GotoStmt and
+      not isStrictlyForwardGoto(goto) and
+      goto = s.getAST() and
+      exists(InstructionTag tag |
+        result = s.getInstructionSuccessor(tag, kind) and
+        instruction = s.getInstruction(tag)
+      )
+    )
+  }
+
+  /** Holds if `goto` jumps strictly forward in the program text. */
+  private predicate isStrictlyForwardGoto(GotoStmt goto) {
+    exists(string gotoFile, int gotoLine, string targetFile, int targetLine |
+      goto.getLocation().hasLocationInfo(gotoFile, gotoLine, _, _, _) and
+      goto.getTarget().getLocation().hasLocationInfo(targetFile, targetLine, _, _, _) and
+      targetLine > gotoLine and
+      // We avoid `=` for equality here since that might tempt the join orderer
+      // into joining on the file name too early.
+      gotoFile >= targetFile and
+      gotoFile <= targetFile
+    )
   }
 
   cached IRVariable getInstructionVariable(Instruction instruction) {

--- a/cpp/ql/src/semmle/code/cpp/ir/implementation/raw/internal/TranslatedStmt.qll
+++ b/cpp/ql/src/semmle/code/cpp/ir/implementation/raw/internal/TranslatedStmt.qll
@@ -632,7 +632,7 @@ class TranslatedForStmt extends TranslatedLoop {
     exists(forStmt.getInitialization())
   }
   
-  private TranslatedExpr getUpdate() {
+  TranslatedExpr getUpdate() {
     result = getTranslatedExpr(forStmt.getUpdate().getFullyConverted())
   }
 

--- a/cpp/ql/src/semmle/code/cpp/ir/implementation/unaliased_ssa/IRBlock.qll
+++ b/cpp/ql/src/semmle/code/cpp/ir/implementation/unaliased_ssa/IRBlock.qll
@@ -90,6 +90,10 @@ class IRBlock extends IRBlockBase {
     blockSuccessor(this, result, kind)
   }
 
+  final IRBlock getBackEdgeSuccessor(EdgeKind kind) {
+    backEdgeSuccessor(this, result, kind)
+  }
+
   final predicate immediatelyDominates(IRBlock block) {
     blockImmediatelyDominates(this, block)
   }
@@ -132,7 +136,10 @@ private predicate startsBasicBlock(Instruction instr) {
     exists(Instruction predecessor, EdgeKind kind |
       instr = predecessor.getSuccessor(kind) and
       not kind instanceof GotoEdge
-    )  // Incoming edge is not a GotoEdge
+    ) or  // Incoming edge is not a GotoEdge
+    exists(Instruction predecessor |
+      instr = predecessor.getBackEdgeSuccessor(_)
+    )  // A back edge enters this instruction
   )
 }
 
@@ -180,6 +187,14 @@ private cached module Cached {
     exists(Instruction predLast, Instruction succFirst |
       predLast = getInstruction(pred, getInstructionCount(pred) - 1) and
       succFirst = predLast.getSuccessor(kind) and
+      succ = MkIRBlock(succFirst)
+    )
+  }
+
+  cached predicate backEdgeSuccessor(TIRBlock pred, TIRBlock succ, EdgeKind kind) {
+    exists(Instruction predLast, Instruction succFirst |
+      predLast = getInstruction(pred, getInstructionCount(pred) - 1) and
+      succFirst = predLast.getBackEdgeSuccessor(kind) and
       succ = MkIRBlock(succFirst)
     )
   }

--- a/cpp/ql/src/semmle/code/cpp/ir/implementation/unaliased_ssa/Instruction.qll
+++ b/cpp/ql/src/semmle/code/cpp/ir/implementation/unaliased_ssa/Instruction.qll
@@ -464,6 +464,16 @@ class Instruction extends Construction::TInstruction {
   }
 
   /**
+   * Gets the a _back-edge successor_ of this instruction along the control
+   * flow edge specified by `kind`. A back edge in the control-flow graph is
+   * intuitively the edge that goes back around a loop. If all back edges are
+   * removed from the control-flow graph, it becomes acyclic.
+   */
+  final Instruction getBackEdgeSuccessor(EdgeKind kind) {
+    result = Construction::getInstructionBackEdgeSuccessor(this, kind)
+  }
+
+  /**
    * Gets all direct successors of this instruction.
    */
   final Instruction getASuccessor() {

--- a/cpp/ql/src/semmle/code/cpp/ir/implementation/unaliased_ssa/internal/SSAConstruction.qll
+++ b/cpp/ql/src/semmle/code/cpp/ir/implementation/unaliased_ssa/internal/SSAConstruction.qll
@@ -278,6 +278,14 @@ cached private module Cached {
     )
   }
 
+  cached Instruction getInstructionBackEdgeSuccessor(Instruction instruction, EdgeKind kind) {
+    exists(OldInstruction oldInstruction |
+      oldInstruction = getOldInstruction(instruction) and
+      result = getNewInstruction(oldInstruction.getBackEdgeSuccessor(kind)) and
+      not Reachability::isInfeasibleInstructionSuccessor(oldInstruction, kind)
+    )
+  }
+
   cached IRVariable getInstructionVariable(Instruction instruction) {
     result = getNewIRVariable(getOldInstruction(instruction).(OldIR::VariableInstruction).getVariable())
   }

--- a/cpp/ql/src/semmle/code/cpp/rangeanalysis/RangeUtils.qll
+++ b/cpp/ql/src/semmle/code/cpp/rangeanalysis/RangeUtils.qll
@@ -81,6 +81,5 @@ predicate isReducibleCFG(Function f) {
 
 predicate backEdge(PhiInstruction phi, PhiOperand op) {
   phi.getAnOperand() = op and
-  phi.getBlock().dominates(op.getPredecessorBlock())
-  // TODO: identify backedges during IR construction
+  phi.getBlock() = op.getPredecessorBlock().getBackEdgeSuccessor(_)
 }

--- a/cpp/ql/test/library-tests/ir/ir/aliased_ssa_sanity.expected
+++ b/cpp/ql/test/library-tests/ir/ir/aliased_ssa_sanity.expected
@@ -6,3 +6,6 @@ instructionWithoutSuccessor
 unnecessaryPhiInstruction
 operandAcrossFunctions
 instructionWithoutUniqueBlock
+containsLoopOfForwardEdges
+lostReachability
+backEdgeCountMismatch

--- a/cpp/ql/test/library-tests/ir/ir/raw_sanity.expected
+++ b/cpp/ql/test/library-tests/ir/ir/raw_sanity.expected
@@ -6,3 +6,6 @@ instructionWithoutSuccessor
 unnecessaryPhiInstruction
 operandAcrossFunctions
 instructionWithoutUniqueBlock
+containsLoopOfForwardEdges
+lostReachability
+backEdgeCountMismatch

--- a/cpp/ql/test/library-tests/ir/ir/unaliased_ssa_sanity.expected
+++ b/cpp/ql/test/library-tests/ir/ir/unaliased_ssa_sanity.expected
@@ -6,3 +6,6 @@ instructionWithoutSuccessor
 unnecessaryPhiInstruction
 operandAcrossFunctions
 instructionWithoutUniqueBlock
+containsLoopOfForwardEdges
+lostReachability
+backEdgeCountMismatch


### PR DESCRIPTION
This PR implements detection of back edges in the IR based on translated statements, following up on https://github.com/Semmle/ql/pull/633#discussion_r239735951. Syntactic back edges are easy to propagate to `unaliased_ssa` and `aliased_ssa` since none of the introduced nodes cause any loops. Initially I tried to implement the detection with an overridable predicate on `TranslatedElement`, but it turns out the back edges aren't tied to particular element types in any useful way; for example, the back edge in `while (x) { x--; }` doesn't touch the `while`-loop at all but goes directly from `--` to `(x)`.

@rdmarsh2 or @aschackmull, are you able to write a test case that shows a difference in range analysis results with this PR? I suppose it'll involve unstructured `goto`.

I added sanity queries in `Instruction.qll` to test the two properties that I think back edges should have: the CFG should have no loops when they are removed, and removing them should not cause CFG nodes to become unreachable.

The sanity query `containsLoopOfForwardEdges` has results on seven functions in ChakraCore, but that's independent of this PR; see #811.