### PR TITLE
C#: Fix FP in cs/call-to-object-tostring

### DIFF
--- a/change-notes/1.20/analysis-csharp.md
+++ b/change-notes/1.20/analysis-csharp.md
@@ -15,7 +15,8 @@
 | Dereferenced variable is always null (cs/dereferenced-value-is-always-null) | Improved results | The query has been rewritten from scratch, and the analysis is now based on static single assignment (SSA) forms. The query is now enabled by default in LGTM. |
 | Dereferenced variable may be null (cs/dereferenced-value-may-be-null) | Improved results | The query has been rewritten from scratch, and the analysis is now based on static single assignment (SSA) forms. The query is now enabled by default in LGTM. |
 | SQL query built from user-controlled sources (cs/sql-injection), Improper control of generation of code (cs/code-injection), Uncontrolled format string (cs/uncontrolled-format-string), Clear text storage of sensitive information (cs/cleartext-storage-of-sensitive-information), Exposure of private information (cs/exposure-of-sensitive-information) | More results | Data sources have been added from user controls in `System.Windows.Forms`. |
- 
+| Use of default ToString() (cs/call-to-object-tostring) | Fewer false positives | Results have been removed for `char` arrays passed to `StringBuilder.Append()`, which were incorrectly marked as using `ToString`. |
+
 ## Changes to code extraction
 
 * Fix extraction of `for` statements where the condition declares new variables using `is`.

--- a/csharp/ql/src/semmle/code/csharp/commons/Strings.qll
+++ b/csharp/ql/src/semmle/code/csharp/commons/Strings.qll
@@ -28,7 +28,8 @@ class ImplicitToStringExpr extends Expr {
       m = p.getCallable()
     |
       m = any(SystemTextStringBuilderClass c).getAMethod() and
-      m.getName().regexpMatch("Append(Line)?")
+      m.getName().regexpMatch("Append(Line)?") and
+      not p.getType() instanceof ArrayType
       or
       p instanceof StringFormatItemParameter and
       not p.getType() = any(ArrayType at |

--- a/csharp/ql/test/query-tests/Useless Code/DefaultToString/DefaultToString.cs
+++ b/csharp/ql/test/query-tests/Useless Code/DefaultToString/DefaultToString.cs
@@ -26,6 +26,9 @@ class DefaultToString
 
         C c = new D();
         Console.WriteLine(c); // GOOD
+
+        var sb = new StringBuilder();
+        sb.Append(new char[] { 'a', 'b', 'c' }, 0, 3); // GOOD
     }
 
     class A


### PR DESCRIPTION
Fixes false-positives such as [this one](https://lgtm.com/projects/g/dotnet/coreclr/snapshot/dist-1506404356478-1548102280670/files/src/System.Private.CoreLib/shared/System/IO/TextReader.cs?sort=name&dir=ASC&mode=heatmap#x1a7e8a5843affad7:1), where a `char[]` passed to `StringBuilder.Append()` is correctly formatted.