### PR TITLE
Python: Fix tornado and twisted request attribute tracking.

### DIFF
--- a/python/ql/src/semmle/python/web/tornado/Request.qll
+++ b/python/ql/src/semmle/python/web/tornado/Request.qll
@@ -15,15 +15,21 @@ class TornadoRequest extends TaintKind {
         result instanceof ExternalStringDictKind and
         (
             name = "headers" or
-            name = "arguments" or
             name = "cookies"
         )
         or
         result instanceof ExternalStringKind and
         (
-            name = "path" or
+            name = "uri" or
             name = "query" or
             name = "body"
+        )
+        or
+        result instanceof ExternalStringSequenceDictKind and
+        (
+            name = "arguments" or
+            name = "query_arguments" or
+            name = "body_arguments"
         )
     }
 

--- a/python/ql/src/semmle/python/web/twisted/Request.qll
+++ b/python/ql/src/semmle/python/web/twisted/Request.qll
@@ -19,8 +19,7 @@ class TwistedRequest extends TaintKind {
         or
         result instanceof ExternalStringKind and
         (
-            name = "uri" or
-            name = "path"
+            name = "uri"
         )
     }
 


### PR DESCRIPTION
The 'path' attribute can be trusted, but 'uri' and 'arguments' cannot.