### PR TITLE
removed extra parenthesis around argument for set state arrow function

### DIFF
--- a/javascript/ql/src/React/InconsistentStateUpdate.qhelp
+++ b/javascript/ql/src/React/InconsistentStateUpdate.qhelp
@@ -36,7 +36,7 @@ Instead, the callback form of <code>setState</code> should be used:
 </p>
 
 <sample language="javascript">
-this.setState((prevState) => ({
+this.setState(prevState => ({
   counter: prevState.counter + 1
 }));
 </sample>


### PR DESCRIPTION
This came up in a discussion with @samlanning . We both think it looks cleaner when there is only one parameter.