### PR TITLE
CPP: Improve ArrayArgSizeMismatch.ql

### DIFF
--- a/change-notes/1.20/analysis-cpp.md
+++ b/change-notes/1.20/analysis-cpp.md
@@ -14,7 +14,7 @@
 
 | **Query**                  | **Expected impact**    | **Change**                                                       |
 |----------------------------|------------------------|------------------------------------------------------------------|
-| Array argument size mismatch | Fewer false positives | An exception has been added to this query for variable sized arrays. |
+| Array argument size mismatch (`cpp/array-arg-size-mismatch`) | Fewer false positives | An exception has been added to this query for variable sized arrays. |
 | Suspicious add with sizeof (`cpp/suspicious-add-sizeof`) | Fewer false positives | Pointer arithmetic on `char * const` expressions (and other variations of `char *`) are now correctly excluded from the results. |
 | Suspicious pointer scaling (`cpp/suspicious-pointer-scaling`) | Fewer false positives | False positives involving types that are not uniquely named in the snapshot have been fixed. |
 | Lossy function result cast (`cpp/lossy-function-result-cast`) | Fewer false positive results | The whitelist of rounding functions built into this query has been expanded. |

--- a/change-notes/1.20/analysis-cpp.md
+++ b/change-notes/1.20/analysis-cpp.md
@@ -9,6 +9,7 @@
 | **Query**                   | **Tags**  | **Purpose**                                                        |
 |-----------------------------|-----------|--------------------------------------------------------------------|
 | Lossy function result cast (`cpp/lossy-function-result-cast`) | correctness | Finds function calls whose result type is a floating point type, which are implicitly cast to an integral type.  Newly available but not displayed by default on LGTM. |
+| Array argument size mismatch (`cpp/array-arg-size-mismatch`) | reliability | Finds function calls where the size of an array being passed is smaller than the array size of the declared parameter.  Newly displayed on LGTM. |
 
 ## Changes to existing queries
 

--- a/change-notes/1.20/analysis-cpp.md
+++ b/change-notes/1.20/analysis-cpp.md
@@ -14,6 +14,7 @@
 
 | **Query**                  | **Expected impact**    | **Change**                                                       |
 |----------------------------|------------------------|------------------------------------------------------------------|
+| Array argument size mismatch | Fewer false positives | An exception has been added to this query for variable sized arrays. |
 | Suspicious add with sizeof (`cpp/suspicious-add-sizeof`) | Fewer false positives | Pointer arithmetic on `char * const` expressions (and other variations of `char *`) are now correctly excluded from the results. |
 | Suspicious pointer scaling (`cpp/suspicious-pointer-scaling`) | Fewer false positives | False positives involving types that are not uniquely named in the snapshot have been fixed. |
 | Lossy function result cast (`cpp/lossy-function-result-cast`) | Fewer false positive results | The whitelist of rounding functions built into this query has been expanded. |

--- a/cpp/ql/src/Likely Bugs/Conversion/ArrayArgSizeMismatch.ql
+++ b/cpp/ql/src/Likely Bugs/Conversion/ArrayArgSizeMismatch.ql
@@ -5,7 +5,7 @@
  * @kind problem
  * @id cpp/array-arg-size-mismatch
  * @problem.severity warning
- * @precision medium
+ * @precision high
  * @tags reliability
  */
 import cpp

--- a/cpp/ql/src/Likely Bugs/Conversion/ArrayArgSizeMismatch.ql
+++ b/cpp/ql/src/Likely Bugs/Conversion/ArrayArgSizeMismatch.ql
@@ -9,6 +9,7 @@
  * @tags reliability
  */
 import cpp
+import semmle.code.cpp.commons.Buffer
 
 from Function f, FunctionCall c, int i, ArrayType argType, ArrayType paramType, int a, int b
 where f = c.getTarget() and
@@ -18,7 +19,7 @@ where f = c.getTarget() and
         b = paramType.getArraySize() and
         argType.getBaseType().getSize() = paramType.getBaseType().getSize() and
         a < b and
-        a > 0 and
+        not memberMayBeVarSize(_, c.getArgument(i).(VariableAccess).getTarget()) and
         // filter out results for inconsistent declarations
         strictcount(f.getParameter(i).getType().getSize()) = 1
 select c.getArgument(i), "Array of size " + a +

--- a/cpp/ql/src/Likely Bugs/Conversion/ArrayArgSizeMismatch.ql
+++ b/cpp/ql/src/Likely Bugs/Conversion/ArrayArgSizeMismatch.ql
@@ -5,6 +5,7 @@
  * @kind problem
  * @id cpp/array-arg-size-mismatch
  * @problem.severity warning
+ * @precision medium
  * @tags reliability
  */
 import cpp

--- a/cpp/ql/src/Likely Bugs/Conversion/ArrayArgSizeMismatch.ql
+++ b/cpp/ql/src/Likely Bugs/Conversion/ArrayArgSizeMismatch.ql
@@ -17,6 +17,7 @@ where f = c.getTarget() and
         b = paramType.getArraySize() and
         argType.getBaseType().getSize() = paramType.getBaseType().getSize() and
         a < b and
+        a > 0 and
         // filter out results for inconsistent declarations
         strictcount(f.getParameter(i).getType().getSize()) = 1
 select c.getArgument(i), "Array of size " + a +

--- a/cpp/ql/test/query-tests/Likely Bugs/Conversion/ArrayArgSizeMismatch/ArrayArgSizeMismatch.expected
+++ b/cpp/ql/test/query-tests/Likely Bugs/Conversion/ArrayArgSizeMismatch/ArrayArgSizeMismatch.expected
@@ -1,2 +1,1 @@
 | test.cpp:24:4:24:7 | arr3 | Array of size 3 passed to $@ which expects an array of size 4. | test.cpp:8:6:8:6 | g | g |
-| test.cpp:40:9:40:12 | data | Array of size 0 passed to $@ which expects an array of size 4. | test.cpp:9:6:9:6 | h | h |

--- a/cpp/ql/test/query-tests/Likely Bugs/Conversion/ArrayArgSizeMismatch/ArrayArgSizeMismatch.expected
+++ b/cpp/ql/test/query-tests/Likely Bugs/Conversion/ArrayArgSizeMismatch/ArrayArgSizeMismatch.expected
@@ -1,0 +1,2 @@
+| test.cpp:24:4:24:7 | arr3 | Array of size 3 passed to $@ which expects an array of size 4. | test.cpp:8:6:8:6 | g | g |
+| test.cpp:40:9:40:12 | data | Array of size 0 passed to $@ which expects an array of size 4. | test.cpp:9:6:9:6 | h | h |

--- a/cpp/ql/test/query-tests/Likely Bugs/Conversion/ArrayArgSizeMismatch/ArrayArgSizeMismatch.qlref
+++ b/cpp/ql/test/query-tests/Likely Bugs/Conversion/ArrayArgSizeMismatch/ArrayArgSizeMismatch.qlref
@@ -1,0 +1,1 @@
+Likely Bugs/Conversion/ArrayArgSizeMismatch.ql

--- a/cpp/ql/test/query-tests/Likely Bugs/Conversion/ArrayArgSizeMismatch/test.cpp
+++ b/cpp/ql/test/query-tests/Likely Bugs/Conversion/ArrayArgSizeMismatch/test.cpp
@@ -1,0 +1,49 @@
+
+typedef unsigned long size_t;
+void *malloc(size_t size);
+
+#define NUM (4)
+
+void f(int *vs);
+void g(int vs[4]);
+void h(float fs[NUM]);
+
+struct myStruct
+{
+	unsigned int num;
+	float data[0];
+};
+
+void test(float f3[3], float f4[4], float f5[5], float *fp)
+{
+	int arr3[3], arr4[4], arr5[5];
+
+	f(arr3); // GOOD
+	f(arr4); // GOOD
+	f(arr5); // GOOD
+	g(arr3); // BAD
+	g(arr4); // GOOD
+	g(arr5); // GOOD
+
+	h(f3); // BAD [NOT DETECTED]
+	h(f4); // GOOD
+	h(f5); // GOOD
+	h(fp); // GOOD
+
+	{
+		// variable size struct
+		myStruct *ms;
+
+		ms = (myStruct *)malloc(sizeof(myStruct) + (4 * sizeof(float)));
+		ms->num  = 4;
+		ms->data[0] = ms->data[1] = ms->data[2] = ms->data[3] = 0;
+		h(ms->data); // GOOD [FALSE POSITIVE]
+	}
+	
+	{
+		// char array
+		char ca[4 * sizeof(int)];
+		
+		g((int *)ca); // GOOD
+	}
+};

--- a/cpp/ql/test/query-tests/Likely Bugs/Conversion/ArrayArgSizeMismatch/test.cpp
+++ b/cpp/ql/test/query-tests/Likely Bugs/Conversion/ArrayArgSizeMismatch/test.cpp
@@ -37,7 +37,7 @@ void test(float f3[3], float f4[4], float f5[5], float *fp)
 		ms = (myStruct *)malloc(sizeof(myStruct) + (4 * sizeof(float)));
 		ms->num  = 4;
 		ms->data[0] = ms->data[1] = ms->data[2] = ms->data[3] = 0;
-		h(ms->data); // GOOD [FALSE POSITIVE]
+		h(ms->data); // GOOD
 	}
 	
 	{


### PR DESCRIPTION
Add a test for `ArrayArgSizeMismatch.ql`, fix a false positive, and give the query a precision tag.  This means that the query will be run on LGTM (but not displayed by default).

I suspect this query is going to draw criticism for being 'something a compiler warning should report'.  Nevertheless, we have it, and there's no tag to tell LGTM that it isn't very exciting.