### PR TITLE
CPP: Add 'fread' to BufferAccess.qll

### DIFF
--- a/change-notes/1.20/analysis-cpp.md
+++ b/change-notes/1.20/analysis-cpp.md
@@ -17,6 +17,7 @@
 |----------------------------|------------------------|------------------------------------------------------------------|
 | Suspicious add with sizeof (`cpp/suspicious-add-sizeof`) | Fewer false positives | Pointer arithmetic on `char * const` expressions (and other variations of `char *`) are now correctly excluded from the results. |
 | Suspicious pointer scaling (`cpp/suspicious-pointer-scaling`) | Fewer false positives | False positives involving types that are not uniquely named in the snapshot have been fixed. |
+| Call to memory access function may overflow buffer | More correct results | Calls to `fread` are now examined by this query. |
 | Lossy function result cast (`cpp/lossy-function-result-cast`) | Fewer false positive results | The whitelist of rounding functions built into this query has been expanded. |
 | Unused static variable (`cpp/unused-static-variable`) | Fewer false positive results | Variables with the attribute `unused` are now excluded from the query. |
 | Resource not released in destructor (`cpp/resource-not-released-in-destructor`) | Fewer false positive results | Fix false positives where a resource is released via a virtual method call, function pointer, or lambda. |

--- a/change-notes/1.20/analysis-cpp.md
+++ b/change-notes/1.20/analysis-cpp.md
@@ -17,7 +17,7 @@
 |----------------------------|------------------------|------------------------------------------------------------------|
 | Suspicious add with sizeof (`cpp/suspicious-add-sizeof`) | Fewer false positives | Pointer arithmetic on `char * const` expressions (and other variations of `char *`) are now correctly excluded from the results. |
 | Suspicious pointer scaling (`cpp/suspicious-pointer-scaling`) | Fewer false positives | False positives involving types that are not uniquely named in the snapshot have been fixed. |
-| Call to memory access function may overflow buffer | More correct results | Calls to `fread` are now examined by this query. |
+| Call to memory access function may overflow buffer (`cpp/overflow-buffer`) | More correct results | Calls to `fread` are now examined by this query. |
 | Lossy function result cast (`cpp/lossy-function-result-cast`) | Fewer false positive results | The whitelist of rounding functions built into this query has been expanded. |
 | Unused static variable (`cpp/unused-static-variable`) | Fewer false positive results | Variables with the attribute `unused` are now excluded from the query. |
 | Resource not released in destructor (`cpp/resource-not-released-in-destructor`) | Fewer false positive results | Fix false positives where a resource is released via a virtual method call, function pointer, or lambda. |

--- a/cpp/ql/src/semmle/code/cpp/security/BufferAccess.qll
+++ b/cpp/ql/src/semmle/code/cpp/security/BufferAccess.qll
@@ -293,6 +293,32 @@ class MemchrBA extends BufferAccess {
 }
 
 /**
+ * Calls to fread.
+ *  fread(buffer, size, number, file)
+ */
+class FreadBA extends BufferAccess {
+  FreadBA() {
+    this.(FunctionCall).getTarget().getName() = "fread"
+  }
+  
+  override string getName() {
+    result = this.(FunctionCall).getTarget().getName()
+  }
+
+  override Expr getBuffer(string bufferDesc, int accessType) {
+    result = this.(FunctionCall).getArgument(0) and
+    bufferDesc = "destination buffer" and
+    accessType = 2
+  }
+
+  override int getSize() {
+    result =
+      this.(FunctionCall).getArgument(1).getValue().toInt() *
+      this.(FunctionCall).getArgument(2).getValue().toInt()
+  }
+}
+
+/**
  * A array access on a buffer:
  *  buffer[ix]
  * but not:

--- a/cpp/ql/test/query-tests/Security/CWE/CWE-119/semmle/tests/OverflowBuffer.expected
+++ b/cpp/ql/test/query-tests/Security/CWE/CWE-119/semmle/tests/OverflowBuffer.expected
@@ -54,6 +54,8 @@
 | tests.cpp:491:2:491:7 | access to array | This array indexing operation accesses a negative index -1 on the $@. | tests.cpp:474:21:474:26 | call to malloc | array |
 | tests.cpp:519:3:519:8 | call to memset | This 'memset' operation accesses 20 bytes but the $@ is only 10 bytes. | tests.cpp:502:15:502:20 | call to malloc | destination buffer |
 | tests.cpp:519:3:519:8 | call to memset | This 'memset' operation accesses 20 bytes but the $@ is only 10 bytes. | tests.cpp:510:16:510:21 | call to malloc | destination buffer |
+| tests.cpp:541:6:541:10 | call to fread | This 'fread' operation may access 101 bytes but the $@ is only 100 bytes. | tests.cpp:532:7:532:16 | charBuffer | destination buffer |
+| tests.cpp:546:6:546:10 | call to fread | This 'fread' operation may access 400 bytes but the $@ is only 100 bytes. | tests.cpp:532:7:532:16 | charBuffer | destination buffer |
 | tests_restrict.c:12:2:12:7 | call to memcpy | This 'memcpy' operation accesses 2 bytes but the $@ is only 1 byte. | tests_restrict.c:7:6:7:13 | smallbuf | source buffer |
 | unions.cpp:26:2:26:7 | call to memset | This 'memset' operation accesses 200 bytes but the $@ is only 100 bytes. | unions.cpp:21:10:21:11 | mu | destination buffer |
 | unions.cpp:30:2:30:7 | call to memset | This 'memset' operation accesses 200 bytes but the $@ is only 100 bytes. | unions.cpp:15:7:15:11 | small | destination buffer |

--- a/cpp/ql/test/query-tests/Security/CWE/CWE-119/semmle/tests/tests.cpp
+++ b/cpp/ql/test/query-tests/Security/CWE/CWE-119/semmle/tests/tests.cpp
@@ -522,6 +522,44 @@ void test19(bool b)
 	}
 }
 
+typedef struct {} FILE;
+FILE *fileSource;
+
+size_t fread(void *ptr, size_t size, size_t nmemb, FILE *stream);
+
+void test20()
+{
+	char charBuffer[100];
+	int intBuffer[100];
+	int num;
+
+	if (fread(charBuffer, sizeof(char), 100, fileSource) > 0) // GOOD
+	{
+		// ...
+	}
+
+	if (fread(charBuffer, sizeof(char), 101, fileSource) > 0) // BAD [NOT DETECTED]
+	{
+		// ...
+	}
+
+	if (fread(charBuffer, sizeof(int), 100, fileSource) > 0) // BAD [NOT DETECTED]
+	{
+		// ...
+	}
+
+	if (fread(intBuffer, sizeof(int), 100, fileSource) > 0) // GOOD
+	{
+		// ...
+	}
+
+	num = 101;
+	if (fread(intBuffer, sizeof(int), num, fileSource) > 0) // BAD [NOT DETECTED]
+	{
+		// ...
+	}
+}
+
 int main(int argc, char *argv[])
 {
 	long long arr17[19];
@@ -543,6 +581,7 @@ int main(int argc, char *argv[])
 	test17(arr17);
 	test18();
 	test19(argc == 0);
+	test20();
 
 	return 0;
 }

--- a/cpp/ql/test/query-tests/Security/CWE/CWE-119/semmle/tests/tests.cpp
+++ b/cpp/ql/test/query-tests/Security/CWE/CWE-119/semmle/tests/tests.cpp
@@ -538,12 +538,12 @@ void test20()
 		// ...
 	}
 
-	if (fread(charBuffer, sizeof(char), 101, fileSource) > 0) // BAD [NOT DETECTED]
+	if (fread(charBuffer, sizeof(char), 101, fileSource) > 0) // BAD
 	{
 		// ...
 	}
 
-	if (fread(charBuffer, sizeof(int), 100, fileSource) > 0) // BAD [NOT DETECTED]
+	if (fread(charBuffer, sizeof(int), 100, fileSource) > 0) // BAD
 	{
 		// ...
 	}


### PR DESCRIPTION
Add 'fread' support to `BufferAccess.qll`, which is used by `OverflowBuffer.ql` ('Call to memory access function may overflow buffer').

Note that the query understands fairly minimal data flow at present.  I have a [provisional] OKR to make various improvements to the buffer overflow queries - which may include data flow, and resolving the overlap between this query and [one of the cases in] `OverflowStatic.ql`.  Please let me know if you have any preference as to what my priorities should be.

@pavgust 