### PR TITLE
JavaScript: Round down percentage in `DuplicateToplevel.ql`.

### DIFF
--- a/javascript/ql/src/external/DuplicateToplevel.ql
+++ b/javascript/ql/src/external/DuplicateToplevel.ql
@@ -22,5 +22,5 @@ from TopLevel one, TopLevel another, float percent
 where
   duplicateContainers(one, another, percent) and
   one.getNumLines() > 5
-select one.(FirstLineOf), percent + "% of statements in this script are duplicated in $@.",
+select one.(FirstLineOf), percent.floor() + "% of statements in this script are duplicated in $@.",
   another.(FirstLineOf), "another script"

--- a/javascript/ql/test/query-tests/external/DuplicateToplevel/DuplicateToplevel.expected
+++ b/javascript/ql/test/query-tests/external/DuplicateToplevel/DuplicateToplevel.expected
@@ -1,2 +1,6 @@
+| a.js:1:1:1:1 | <toplevel> | 90% of statements in this script are duplicated in $@. | e.js:1:1:1:1 | <toplevel> | another script |
 | a.js:1:1:1:1 | <toplevel> | 100% of statements in this script are duplicated in $@. | b.js:1:1:1:1 | <toplevel> | another script |
+| b.js:1:1:1:1 | <toplevel> | 90% of statements in this script are duplicated in $@. | e.js:1:1:1:1 | <toplevel> | another script |
 | b.js:1:1:1:1 | <toplevel> | 100% of statements in this script are duplicated in $@. | a.js:1:1:1:1 | <toplevel> | another script |
+| e.js:1:1:1:1 | <toplevel> | 90% of statements in this script are duplicated in $@. | a.js:1:1:1:1 | <toplevel> | another script |
+| e.js:1:1:1:1 | <toplevel> | 90% of statements in this script are duplicated in $@. | b.js:1:1:1:1 | <toplevel> | another script |

--- a/javascript/ql/test/query-tests/external/DuplicateToplevel/a.js
+++ b/javascript/ql/test/query-tests/external/DuplicateToplevel/a.js
@@ -7,4 +7,7 @@
 	arguments[0]--;
 	arguments[1] += 19;
 	arguments[0] * arguments[1];
+	arguments[2] / arguments[3];
+	arguments[4] % arguments[5];
+	arguments[6] % arguments[7];
 }

--- a/javascript/ql/test/query-tests/external/DuplicateToplevel/b.js
+++ b/javascript/ql/test/query-tests/external/DuplicateToplevel/b.js
@@ -7,4 +7,7 @@
 	arguments[0]--;
 	arguments[1] += 19;
 	arguments[0] * arguments[1];
+	arguments[2] / arguments[3];
+	arguments[4] % arguments[5];
+	arguments[6] % arguments[7];
 }

--- a/javascript/ql/test/query-tests/external/DuplicateToplevel/e.js
+++ b/javascript/ql/test/query-tests/external/DuplicateToplevel/e.js
@@ -1,0 +1,13 @@
+{
+	if (arguments.length == 0)
+		23;
+	if (arguments.length % 2 != 0)
+		42;
+	console.log(arguments[0]);
+	arguments[0]--;
+	arguments[1] += 19;
+	arguments[0] * arguments[1];
+	arguments[2] / arguments[3];
+	arguments[4] % arguments[5];
+	/*arguments[6] % arguments[7]*/;
+}


### PR DESCRIPTION
All the other duplicate-code queries already do this.