### PR TITLE
CPP: Deprecate FunctionPointerVariable and FunctionPointerMemberVariable

### DIFF
--- a/cpp/ql/src/semmle/code/cpp/Variable.qll
+++ b/cpp/ql/src/semmle/code/cpp/Variable.qll
@@ -377,8 +377,10 @@ class MemberVariable extends Variable, @membervariable {
 
 /**
  * A C/C++ function pointer variable.
+ *
+ * DEPRECATED: use `Variable.getType() instanceof FunctionPointerType` instead. 
  */
-class FunctionPointerVariable extends Variable {
+deprecated class FunctionPointerVariable extends Variable {
   FunctionPointerVariable() {
     this.getType() instanceof FunctionPointerType
   }
@@ -386,8 +388,10 @@ class FunctionPointerVariable extends Variable {
 
 /**
  * A C/C++ function pointer member variable.
+ *
+ * DEPRECATED: use `MemberVariable.getType() instanceof FunctionPointerType` instead.
  */
-class FunctionPointerMemberVariable extends MemberVariable {
+deprecated class FunctionPointerMemberVariable extends MemberVariable {
   FunctionPointerMemberVariable() {
     this instanceof FunctionPointerVariable
   }


### PR DESCRIPTION
They seem arbitrary and not very helpful.  I haven't found any uses of either.

Briefly discussed on https://github.com/Semmle/ql/pull/816.