### PR TITLE
CPP: Tweak tags for consistency

### DIFF
--- a/cpp/ql/src/jsf/4.05 Libraries/AV Rule 20.ql
+++ b/cpp/ql/src/jsf/4.05 Libraries/AV Rule 20.ql
@@ -3,7 +3,7 @@
  * @description The setjmp macro and the longjmp function shall not be used.
  * @kind problem
  * @id cpp/jsf/av-rule-20
- * @problem.severity error
+ * @problem.severity warning
  * @tags correctness
  *       portability
  *       readability


### PR DESCRIPTION
We have many versions of 'use of goto' and 'use of setjmp / longjmp'.  This PR makes the query tagging more consistent between them (though there are still differences; e.g. some of the MISRA versions have higher severity to reflect the need for strict aherence to the MISRA standard in projects that intend to do so).