### PR TITLE
Python: typesafe origin for points-to

### DIFF
--- a/python/ql/src/semmle/python/pointsto/PointsTo.qll
+++ b/python/ql/src/semmle/python/pointsto/PointsTo.qll
@@ -31,14 +31,27 @@ private import Filters as BaseFilters
 import semmle.dataflow.SSA
 private import MRO
 
-/** Get a `ControlFlowNode` from an object or `here`.
- * If the object is a ControlFlowNode then use that, otherwise fall back on `here`
- */
-pragma[inline]
-private ControlFlowNode origin_from_object_or_here(ObjectOrCfg object, ControlFlowNode here) {
-    result = object
-    or
-    not object instanceof ControlFlowNode and result = here
+library class ObjectOrCfg extends @py_object {
+
+    string toString() {
+        /* Not to be displayed */
+        none()
+    }
+
+    ControlFlowNode getOrigin() {
+        result = this
+    }
+
+    /** Get a `ControlFlowNode` from `this` or `here`.
+     * If `this` is a ControlFlowNode then use that, otherwise fall back on `here`
+     */
+    pragma[inline]
+    ControlFlowNode fromObjectOrHere(ControlFlowNode here) {
+        result = this
+        or
+        not this instanceof ControlFlowNode and result = here
+    }
+
 }
 
 module PointsTo {
@@ -144,7 +157,7 @@ module PointsTo {
                 ssa_variable_points_to(var, imp, obj, cls, orig) and
                 imp.isImport() and
                 obj != undefinedVariable() |
-                origin = origin_from_object_or_here(orig, exit)
+                origin = orig.fromObjectOrHere(exit)
             )
             or
             not exists(EssaVariable var | var.getAUse() = m.getANormalExit() and var.getSourceVariable().getName() = name) and
@@ -563,7 +576,7 @@ module PointsTo {
         exists(ObjectOrCfg origin_or_obj |
             value != undefinedVariable() and
             use_points_to_maybe_origin(f, context, value, cls, origin_or_obj) |
-            origin = origin_from_object_or_here(origin_or_obj, f)
+            origin = origin_or_obj.fromObjectOrHere(f)
         )
     }
 
@@ -637,7 +650,7 @@ module PointsTo {
         exists(Object cls_or_mod, string name, ObjectOrCfg orig |
             receiver_object(f, context, cls_or_mod, name) and
             class_or_module_attribute(cls_or_mod, name, value, cls, orig) and
-            origin = origin_from_object_or_here(orig, f)
+            origin = orig.fromObjectOrHere(f)
         )
         or
         points_to(f.getObject(), context, unknownValue(), theUnknownType(), origin) and value = unknownValue() and cls = theUnknownType()
@@ -667,7 +680,7 @@ module PointsTo {
     private predicate from_import_points_to(ImportMemberNode f, PointsToContext context, Object value, ClassObject cls, ControlFlowNode origin) {
         exists(string name, ModuleObject mod, ObjectOrCfg orig |
             points_to(f.getModule(name), context, mod, _, _) and
-            origin = origin_from_object_or_here(orig, f)
+            origin = orig.fromObjectOrHere(f)
             |
             mod.getSourceModule() = f.getEnclosingModule() and
             exists(EssaVariable var |
@@ -2014,7 +2027,7 @@ module PointsTo {
                 exists(ObjectOrCfg obj |
                     Layer::module_attribute_points_to(mod, name, value, cls, obj) and
                     not exists(Variable v | v.getId() = name and v.getScope() = imp.getScope()) and
-                    origin = origin_from_object_or_here(obj, imp)
+                    origin = obj.fromObjectOrHere(imp)
                 )
                 or
                 /* Retain value held before import */

--- a/python/ql/src/semmle/python/types/ClassObject.qll
+++ b/python/ql/src/semmle/python/types/ClassObject.qll
@@ -10,19 +10,6 @@ predicate is_c_metaclass(Object o) {
 }
 
 
-library class ObjectOrCfg extends @py_object {
-
-    string toString() {
-        /* Not to be displayed */
-        none()
-    }
-
-    ControlFlowNode getOrigin() {
-        result = this
-    }
-
-}
-
 /** A class whose instances represents Python classes.
  *  Instances of this class represent either builtin classes 
  *  such as `list` or `str`, or program-defined Python classes 

--- a/python/ql/src/semmle/python/types/ClassObject.qll
+++ b/python/ql/src/semmle/python/types/ClassObject.qll
@@ -134,13 +134,19 @@ class ClassObject extends Object {
 
     /** Whether the named attribute refers to the object and origin */
     predicate attributeRefersTo(string name, Object obj, ControlFlowNode origin) {
-        PointsTo::Types::class_attribute_lookup(this, name, obj, _, origin)
+        exists(ObjectOrCfg orig |
+            origin = orig.toCfgNode() and
+            PointsTo::Types::class_attribute_lookup(this, name, obj, _, orig)
+        )
     }
 
     /** Whether the named attribute refers to the object, class and origin */
     predicate attributeRefersTo(string name, Object obj, ClassObject cls, ControlFlowNode origin) {
         not obj = unknownValue() and
-        PointsTo::Types::class_attribute_lookup(this, name, obj, cls, origin)
+        exists(ObjectOrCfg orig |
+            origin = orig.toCfgNode() and
+            PointsTo::Types::class_attribute_lookup(this, name, obj, cls, orig)
+        )
     }
 
     /** Whether this class has a attribute named `name`, either declared or inherited.*/

--- a/python/ql/src/semmle/python/types/ClassObject.qll
+++ b/python/ql/src/semmle/python/types/ClassObject.qll
@@ -134,7 +134,7 @@ class ClassObject extends Object {
 
     /** Whether the named attribute refers to the object and origin */
     predicate attributeRefersTo(string name, Object obj, ControlFlowNode origin) {
-        exists(ObjectOrCfg orig |
+        exists(CfgOrigin orig |
             origin = orig.toCfgNode() and
             PointsTo::Types::class_attribute_lookup(this, name, obj, _, orig)
         )
@@ -143,7 +143,7 @@ class ClassObject extends Object {
     /** Whether the named attribute refers to the object, class and origin */
     predicate attributeRefersTo(string name, Object obj, ClassObject cls, ControlFlowNode origin) {
         not obj = unknownValue() and
-        exists(ObjectOrCfg orig |
+        exists(CfgOrigin orig |
             origin = orig.toCfgNode() and
             PointsTo::Types::class_attribute_lookup(this, name, obj, cls, orig)
         )

--- a/python/ql/src/semmle/python/types/ModuleObject.qll
+++ b/python/ql/src/semmle/python/types/ModuleObject.qll
@@ -174,14 +174,14 @@ class PythonModuleObject extends ModuleObject {
     }
 
     override predicate attributeRefersTo(string name, Object value, ControlFlowNode origin) {
-        exists(ObjectOrCfg orig |
+        exists(CfgOrigin orig |
             origin = orig.toCfgNode() and
             PointsTo::py_module_attributes(this.getModule(), name, value, _, orig)
         )
     }
 
     override predicate attributeRefersTo(string name, Object value, ClassObject cls, ControlFlowNode origin) {
-        exists(ObjectOrCfg orig |
+        exists(CfgOrigin orig |
             origin = orig.toCfgNode() and
             PointsTo::py_module_attributes(this.getModule(), name, value, cls, orig)
         )
@@ -266,14 +266,14 @@ class PackageObject extends ModuleObject {
     }
 
     override predicate attributeRefersTo(string name, Object value, ControlFlowNode origin) {
-        exists(ObjectOrCfg orig |
+        exists(CfgOrigin orig |
             origin = orig.toCfgNode() and
             PointsTo::package_attribute_points_to(this, name, value, _, orig)
         )
     }
 
     override predicate attributeRefersTo(string name, Object value, ClassObject cls, ControlFlowNode origin) {
-        exists(ObjectOrCfg orig |
+        exists(CfgOrigin orig |
             origin = orig.toCfgNode() and
             PointsTo::package_attribute_points_to(this, name, value, cls, orig)
         )

--- a/python/ql/src/semmle/python/types/ModuleObject.qll
+++ b/python/ql/src/semmle/python/types/ModuleObject.qll
@@ -174,11 +174,17 @@ class PythonModuleObject extends ModuleObject {
     }
 
     override predicate attributeRefersTo(string name, Object value, ControlFlowNode origin) {
-         PointsTo::py_module_attributes(this.getModule(), name, value, _, origin)
+        exists(ObjectOrCfg orig |
+            origin = orig.toCfgNode() and
+            PointsTo::py_module_attributes(this.getModule(), name, value, _, orig)
+        )
     }
 
     override predicate attributeRefersTo(string name, Object value, ClassObject cls, ControlFlowNode origin) {
-         PointsTo::py_module_attributes(this.getModule(), name, value, cls, origin)
+        exists(ObjectOrCfg orig |
+            origin = orig.toCfgNode() and
+            PointsTo::py_module_attributes(this.getModule(), name, value, cls, orig)
+        )
     }
 
 }
@@ -260,11 +266,17 @@ class PackageObject extends ModuleObject {
     }
 
     override predicate attributeRefersTo(string name, Object value, ControlFlowNode origin) {
-        PointsTo::package_attribute_points_to(this, name, value, _, origin)
+        exists(ObjectOrCfg orig |
+            origin = orig.toCfgNode() and
+            PointsTo::package_attribute_points_to(this, name, value, _, orig)
+        )
     }
 
     override predicate attributeRefersTo(string name, Object value, ClassObject cls, ControlFlowNode origin) {
-        PointsTo::package_attribute_points_to(this, name, value, cls, origin)
+        exists(ObjectOrCfg orig |
+            origin = orig.toCfgNode() and
+            PointsTo::package_attribute_points_to(this, name, value, cls, orig)
+        )
     }
 
     Location getLocation() {

--- a/python/ql/test/library-tests/PointsTo/imports/Runtime.expected
+++ b/python/ql/test/library-tests/PointsTo/imports/Runtime.expected
@@ -51,5 +51,5 @@
 | test.py | 24 | ControlFlowNode for IntegerLiteral | int 0 | ControlFlowNode for IntegerLiteral |
 | test.py | 24 | ControlFlowNode for argv | int 0 | ControlFlowNode for IntegerLiteral |
 | test.py | 27 | ControlFlowNode for ImportExpr | Module sys | ControlFlowNode for ImportExpr |
-| test.py | 31 | ControlFlowNode for argv | list object | ControlFlowNode for argv |
+| test.py | 31 | ControlFlowNode for argv | list object | ControlFlowNode for from sys import * |
 | x.py | 2 | ControlFlowNode for ImportExpr | Module sys | ControlFlowNode for ImportExpr |

--- a/python/ql/test/library-tests/PointsTo/imports/RuntimeWithType.expected
+++ b/python/ql/test/library-tests/PointsTo/imports/RuntimeWithType.expected
@@ -51,5 +51,5 @@
 | test.py | 24 | ControlFlowNode for IntegerLiteral | int 0 | builtin-class int | ControlFlowNode for IntegerLiteral |
 | test.py | 24 | ControlFlowNode for argv | int 0 | builtin-class int | ControlFlowNode for IntegerLiteral |
 | test.py | 27 | ControlFlowNode for ImportExpr | Module sys | builtin-class module | ControlFlowNode for ImportExpr |
-| test.py | 31 | ControlFlowNode for argv | list object | builtin-class list | ControlFlowNode for argv |
+| test.py | 31 | ControlFlowNode for argv | list object | builtin-class list | ControlFlowNode for from sys import * |
 | x.py | 2 | ControlFlowNode for ImportExpr | Module sys | builtin-class module | ControlFlowNode for ImportExpr |


### PR DESCRIPTION
Use ADTs for stronger typechecking, then revert to extensionals for performance.