### PR TITLE
JS: relax the `js/trivial-conditional` whitelist

### DIFF
--- a/change-notes/1.20/analysis-javascript.md
+++ b/change-notes/1.20/analysis-javascript.md
@@ -35,6 +35,7 @@
 | Useless assignment to property. | Fewer false-positive results | This rule now treats assignments with complex right-hand sides correctly. |
 | Unsafe dynamic method access              | Fewer false-positive results | This rule no longer flags concatenated strings as unsafe method names. |
 | Unvalidated dynamic method call           | More true-positive results | This rule now flags concatenated strings as unvalidated method names in more cases. |
+| Useless conditional | More true-positive results | More true-positive results | This rule now flags additional uses of function call values. | 
 
 ## Changes to QL libraries
 

--- a/change-notes/1.20/analysis-javascript.md
+++ b/change-notes/1.20/analysis-javascript.md
@@ -35,7 +35,7 @@
 | Useless assignment to property. | Fewer false-positive results | This rule now treats assignments with complex right-hand sides correctly. |
 | Unsafe dynamic method access              | Fewer false-positive results | This rule no longer flags concatenated strings as unsafe method names. |
 | Unvalidated dynamic method call           | More true-positive results | This rule now flags concatenated strings as unvalidated method names in more cases. |
-| Useless conditional | More true-positive results | More true-positive results | This rule now flags additional uses of function call values. | 
+| Useless conditional | More true-positive results | This rule now flags additional uses of function call values. | 
 
 ## Changes to QL libraries
 

--- a/javascript/ql/test/query-tests/Statements/UselessConditional/UselessConditional.expected
+++ b/javascript/ql/test/query-tests/Statements/UselessConditional/UselessConditional.expected
@@ -22,6 +22,9 @@
 | UselessConditional.js:102:19:102:19 | x | This use of variable 'x' always evaluates to false. |
 | UselessConditional.js:103:23:103:23 | x | This use of variable 'x' always evaluates to false. |
 | UselessConditional.js:109:15:109:16 | {} | This expression always evaluates to true. |
+| UselessConditional.js:129:6:129:24 | constantUndefined() | This call to constantUndefined always evaluates to false. |
+| UselessConditional.js:135:6:135:32 | constan ... ined1() | This call to constantFalseOrUndefined1 always evaluates to false. |
+| UselessConditional.js:139:6:139:32 | constan ... ined2() | This call to constantFalseOrUndefined2 always evaluates to false. |
 | UselessConditionalGood.js:58:12:58:13 | x2 | This use of variable 'x2' always evaluates to false. |
 | UselessConditionalGood.js:69:12:69:13 | xy | This use of variable 'xy' always evaluates to false. |
 | UselessConditionalGood.js:85:12:85:13 | xy | This use of variable 'xy' always evaluates to false. |

--- a/javascript/ql/test/query-tests/Statements/UselessConditional/UselessConditional.js
+++ b/javascript/ql/test/query-tests/Statements/UselessConditional/UselessConditional.js
@@ -109,4 +109,35 @@ async function awaitFlow(){
     if ((x && {}) || y) {} // NOT OK
 });
 
+(function(){
+    function constantFalse1() {
+        return false;
+    }
+    if (constantFalse1()) // OK
+        return;
+
+	function constantFalse2() {
+		return false;
+    }
+	let constantFalse = unknown? constantFalse1 : constantFalse2;
+    if (constantFalse2()) // OK
+        return;
+
+	function constantUndefined() {
+        return undefined;
+    }
+	if (constantUndefined()) // NOT OK
+        return;
+
+	function constantFalseOrUndefined1() {
+		return unknown? false: undefined;
+	}
+	if (constantFalseOrUndefined1()) // NOT OK
+        return;
+
+	let constantFalseOrUndefined2 = unknown? constantFalse1 : constantUndefined;
+	if (constantFalseOrUndefined2())  // NOT OK
+        return;
+
+});
 // semmle-extractor-options: --experimental


### PR DESCRIPTION
`UselessConditional::isConstantBooleanReturnValue` whitelists the results from all callsites that have at least one function that returns a definite boolean. This was done to avoid flagging results from calls to functions like:

```javascript
function isFeatureEnabled(){
  // TODO implement support for this
  return false;
}
```

This is a bit too agressive in practice. I have refined the whitelist to only consider callsites that gets their value from `true` or `false` literals.

[Results look good](https://git.semmle.com/esben/dist-compare-reports/tree/js/sharpen-cond_1548366371540), the apparent performance hit goes away when the evaluation is done with another query that use the callgraph extensively: <https://git.semmle.com/esben/dist-compare-reports/tree/js/sharpen-cond_1548430444077>.