### PR TITLE
Python: Fix 'comparison using is' query to account for enum members.

### DIFF
--- a/change-notes/1.20/analysis-python.md
+++ b/change-notes/1.20/analysis-python.md
@@ -20,6 +20,7 @@ Removes false positives seen when using Python 3.6, but not when using earlier v
 
  | **Query**                  | **Expected impact**    | **Change**                                                       |
 |----------------------------|------------------------|------------------------------------------------------------------|
+| Comparison using is when operands support \_\_eq\_\_ (`py/comparison-using-is`) | Fewer false positive results | Results where one of the objects being compared is an enum member are no longer reported. |
 | Unused import (`py/unused-import`) | Fewer false positive results | Results where the imported module is used in a `doctest` string are no longer reported. |
 | Unused import (`py/unused-import`) | Fewer false positive results | Results where the imported module is used in a type-hint comment are no longer reported. |
 

--- a/python/ql/src/Expressions/IsComparisons.qll
+++ b/python/ql/src/Expressions/IsComparisons.qll
@@ -107,6 +107,20 @@ predicate invalid_portable_is_comparison(Compare comp, Cmpop op, ClassObject cls
         left.refersTo(obj) and right.refersTo(obj) and
         exists(ImmutableLiteral il | il.getLiteralObject() = obj)
     )
+    and
+    /* OK to use 'is' when comparing with a member of an enum */
+    not exists(Expr left, Expr right, AstNode origin |
+        comp.compares(left, op, right) and
+        enum_member(origin) |
+        left.refersTo(_, origin) or right.refersTo(_, origin)
+    )
 }
 
+private predicate enum_member(AstNode obj) {
+    exists(ClassObject cls, AssignStmt asgn |
+        cls.getASuperType().getName() = "Enum" |
+        cls.getPyClass() = asgn.getScope() and
+        asgn.getValue() = obj
+    )
+}
 

--- a/python/ql/test/query-tests/Expressions/eq/expressions_test.py
+++ b/python/ql/test/query-tests/Expressions/eq/expressions_test.py
@@ -24,7 +24,7 @@
 
 
 
-#ODASA-4519
+
 #OK as we are using identity tests for unique objects
 V2 = "v2"
 V3 = "v3"
@@ -84,4 +84,22 @@ def both_sides_known(zero_based="auto", query_id=False):
         zero_based = True
     if zero_based is False: # False positive here
         pass
+
+#Avoid depending on enum back port for Python 2 tests:
+class Enum(object):
+    pass
+
+class MyEnum(Enum):
+
+    memberA = None
+    memberB = 10
+    memberC = ("Hello", "World")
+
+def comp_enum(x):
+    if x is MyEnum.memberA:
+        return
+    if x is MyEnum.memberB:
+        return
+    if x is MyEnum.memberC:
+        return
 


### PR DESCRIPTION
Fixes this false positive:
https://lgtm.com/projects/g/aws/aws-encryption-sdk-python/snapshot/1098f2ce68ad337a25ab07d73083c3ca6c7f3603/files/src/aws_encryption_sdk/identifiers.py?sort=name&dir=ASC&mode=heatmap#x90c48e8124a0715f:1