### PR TITLE
JS: add PropWrites cases for instance fields initialization

### DIFF
--- a/javascript/ql/src/semmle/javascript/dataflow/DataFlow.qll
+++ b/javascript/ql/src/semmle/javascript/dataflow/DataFlow.qll
@@ -532,6 +532,31 @@ module DataFlow {
   }
 
   /**
+   * An instance field with an initializer expression, seen as a property write.
+   */
+  private class InstanceFieldAsPropWrite extends PropWrite, PropNode {
+    override FieldDefinition prop;
+
+    InstanceFieldAsPropWrite() {
+      not prop.isStatic() and
+      exists(prop.getInit()) and
+      not prop instanceof ParameterField
+    }
+
+    override Node getBase() {
+      result = thisNode(prop.getDeclaringClass().getConstructor().getBody())
+    }
+
+    override Expr getPropertyNameExpr() { result = prop.getNameExpr() }
+
+    override string getPropertyName() { result = prop.getName() }
+
+    override Node getRhs() { result = valueNode(prop.getInit()) }
+
+    override ControlFlowNode getWriteNode() { result = prop }
+  }
+
+  /**
    * A data flow node that reads an object property.
    */
   abstract class PropRead extends PropRef, SourceNode { }

--- a/javascript/ql/src/semmle/javascript/dataflow/DataFlow.qll
+++ b/javascript/ql/src/semmle/javascript/dataflow/DataFlow.qll
@@ -513,6 +513,25 @@ module DataFlow {
   }
 
   /**
+   * A field induced by an initializing constructor parameter, seen as a property write (TypeScript only).
+   */
+  private class ParameterFieldAsPropWrite extends PropWrite, PropNode {
+    override ParameterField prop;
+
+    override Node getBase() {
+      result = thisNode(prop.getDeclaringClass().getConstructor().getBody())
+    }
+
+    override Expr getPropertyNameExpr() { result = prop.getNameExpr() }
+
+    override string getPropertyName() { result = prop.getName() }
+
+    override Node getRhs() { result = parameterNode(prop.getParameter()) }
+
+    override ControlFlowNode getWriteNode() { result = prop.getParameter() }
+  }
+
+  /**
    * A data flow node that reads an object property.
    */
   abstract class PropRead extends PropRef, SourceNode { }

--- a/javascript/ql/src/semmle/javascript/dataflow/DataFlow.qll
+++ b/javascript/ql/src/semmle/javascript/dataflow/DataFlow.qll
@@ -478,10 +478,9 @@ module DataFlow {
   private class ClassMemberAsPropWrite extends PropWrite, PropNode {
     override MemberDefinition prop;
 
-    override Node getBase() {
-      prop.isStatic() and
-      result = valueNode(prop.getDeclaringClass())
-    }
+    ClassMemberAsPropWrite() { prop.isStatic() }
+
+    override Node getBase() { result = valueNode(prop.getDeclaringClass()) }
 
     override Expr getPropertyNameExpr() { result = prop.getNameExpr() }
 

--- a/javascript/ql/src/semmle/javascript/dataflow/DataFlow.qll
+++ b/javascript/ql/src/semmle/javascript/dataflow/DataFlow.qll
@@ -495,6 +495,29 @@ module DataFlow {
   }
 
   /**
+   * An instance method definition, viewed as a data flow node that adds
+   * a property to an unseen value.
+   */
+  private class InstanceMethodAsPropWrite extends PropWrite, PropNode {
+    override MethodDefinition prop;
+
+    InstanceMethodAsPropWrite() { not prop.isStatic() }
+
+    override Node getBase() { none() } // The prototype has no DataFlow node
+
+    override Expr getPropertyNameExpr() { result = prop.getNameExpr() }
+
+    override string getPropertyName() { result = prop.getName() }
+
+    override Node getRhs() {
+      not prop instanceof AccessorMethodDefinition and
+      result = valueNode(prop.getInit())
+    }
+
+    override ControlFlowNode getWriteNode() { result = prop }
+  }
+
+  /**
    * A JSX attribute definition, viewed as a data flow node that writes properties to
    * the JSX element it is in.
    */
@@ -532,14 +555,13 @@ module DataFlow {
   }
 
   /**
-   * An instance field with an initializer expression, seen as a property write.
+   * An instance field, seen as a property write.
    */
   private class InstanceFieldAsPropWrite extends PropWrite, PropNode {
     override FieldDefinition prop;
 
     InstanceFieldAsPropWrite() {
       not prop.isStatic() and
-      exists(prop.getInit()) and
       not prop instanceof ParameterField
     }
 

--- a/javascript/ql/src/semmle/javascript/dataflow/DataFlow.qll
+++ b/javascript/ql/src/semmle/javascript/dataflow/DataFlow.qll
@@ -475,10 +475,10 @@ module DataFlow {
    * A static member definition, viewed as a data flow node that adds
    * a property to the class.
    */
-  private class ClassMemberAsPropWrite extends PropWrite, PropNode {
+  private class StaticClassMemberAsPropWrite extends PropWrite, PropNode {
     override MemberDefinition prop;
 
-    ClassMemberAsPropWrite() { prop.isStatic() }
+    StaticClassMemberAsPropWrite() { prop.isStatic() }
 
     override Node getBase() { result = valueNode(prop.getDeclaringClass()) }
 

--- a/javascript/ql/test/library-tests/PropWrite/PropWrite.expected
+++ b/javascript/ql/test/library-tests/PropWrite/PropWrite.expected
@@ -1,3 +1,5 @@
+| classes.ts:4:3:4:24 | instanc ...  foo(); |
+| classes.ts:8:15:8:35 | public  ... erField |
 | tst.js:3:5:3:8 | x: 4 |
 | tst.js:4:5:6:5 | func: f ... ;\\n    } |
 | tst.js:7:5:9:5 | f() {\\n  ... ;\\n    } |

--- a/javascript/ql/test/library-tests/PropWrite/PropWrite.expected
+++ b/javascript/ql/test/library-tests/PropWrite/PropWrite.expected
@@ -1,9 +1,7 @@
 | tst.js:3:5:3:8 | x: 4 |
 | tst.js:4:5:6:5 | func: f ... ;\\n    } |
 | tst.js:7:5:9:5 | f() {\\n  ... ;\\n    } |
-| tst.js:12:9:12:8 | constructor() {} |
 | tst.js:13:3:15:3 | static  ... x);\\n  } |
-| tst.js:16:3:18:3 | f(x) {\\n ... x);\\n  } |
 | tst.js:21:1:21:6 | C.prop |
 | tst.js:24:13:24:27 | onClick={click} |
 | tst.js:27:3:27:26 | get x() ... null; } |

--- a/javascript/ql/test/library-tests/PropWrite/PropWrite.expected
+++ b/javascript/ql/test/library-tests/PropWrite/PropWrite.expected
@@ -1,9 +1,13 @@
+| classes.ts:3:21:3:20 | constructor() {} |
 | classes.ts:4:3:4:24 | instanc ...  foo(); |
+| classes.ts:8:3:8:39 | constru ... eld) {} |
 | classes.ts:8:15:8:35 | public  ... erField |
 | tst.js:3:5:3:8 | x: 4 |
 | tst.js:4:5:6:5 | func: f ... ;\\n    } |
 | tst.js:7:5:9:5 | f() {\\n  ... ;\\n    } |
+| tst.js:12:9:12:8 | constructor() {} |
 | tst.js:13:3:15:3 | static  ... x);\\n  } |
+| tst.js:16:3:18:3 | f(x) {\\n ... x);\\n  } |
 | tst.js:21:1:21:6 | C.prop |
 | tst.js:24:13:24:27 | onClick={click} |
 | tst.js:27:3:27:26 | get x() ... null; } |

--- a/javascript/ql/test/library-tests/PropWrite/PropWriteBase.expected
+++ b/javascript/ql/test/library-tests/PropWrite/PropWriteBase.expected
@@ -1,3 +1,5 @@
+| classes.ts:4:3:4:24 | instanc ...  foo(); | classes.ts:3:21:3:20 | this |
+| classes.ts:8:15:8:35 | public  ... erField | classes.ts:8:3:8:2 | this |
 | tst.js:3:5:3:8 | x: 4 | tst.js:2:11:10:1 | {\\n    x ...     }\\n} |
 | tst.js:4:5:6:5 | func: f ... ;\\n    } | tst.js:2:11:10:1 | {\\n    x ...     }\\n} |
 | tst.js:7:5:9:5 | f() {\\n  ... ;\\n    } | tst.js:2:11:10:1 | {\\n    x ...     }\\n} |

--- a/javascript/ql/test/library-tests/PropWrite/PropWritePropName.expected
+++ b/javascript/ql/test/library-tests/PropWrite/PropWritePropName.expected
@@ -1,9 +1,7 @@
 | tst.js:3:5:3:8 | x: 4 | x |
 | tst.js:4:5:6:5 | func: f ... ;\\n    } | func |
 | tst.js:7:5:9:5 | f() {\\n  ... ;\\n    } | f |
-| tst.js:12:9:12:8 | constructor() {} | constructor |
 | tst.js:13:3:15:3 | static  ... x);\\n  } | func |
-| tst.js:16:3:18:3 | f(x) {\\n ... x);\\n  } | f |
 | tst.js:21:1:21:6 | C.prop | prop |
 | tst.js:24:13:24:27 | onClick={click} | onClick |
 | tst.js:27:3:27:26 | get x() ... null; } | x |

--- a/javascript/ql/test/library-tests/PropWrite/PropWritePropName.expected
+++ b/javascript/ql/test/library-tests/PropWrite/PropWritePropName.expected
@@ -1,3 +1,5 @@
+| classes.ts:4:3:4:24 | instanc ...  foo(); | instanceField |
+| classes.ts:8:15:8:35 | public  ... erField | parameterField |
 | tst.js:3:5:3:8 | x: 4 | x |
 | tst.js:4:5:6:5 | func: f ... ;\\n    } | func |
 | tst.js:7:5:9:5 | f() {\\n  ... ;\\n    } | f |

--- a/javascript/ql/test/library-tests/PropWrite/PropWritePropName.expected
+++ b/javascript/ql/test/library-tests/PropWrite/PropWritePropName.expected
@@ -1,9 +1,13 @@
+| classes.ts:3:21:3:20 | constructor() {} | constructor |
 | classes.ts:4:3:4:24 | instanc ...  foo(); | instanceField |
+| classes.ts:8:3:8:39 | constru ... eld) {} | constructor |
 | classes.ts:8:15:8:35 | public  ... erField | parameterField |
 | tst.js:3:5:3:8 | x: 4 | x |
 | tst.js:4:5:6:5 | func: f ... ;\\n    } | func |
 | tst.js:7:5:9:5 | f() {\\n  ... ;\\n    } | f |
+| tst.js:12:9:12:8 | constructor() {} | constructor |
 | tst.js:13:3:15:3 | static  ... x);\\n  } | func |
+| tst.js:16:3:18:3 | f(x) {\\n ... x);\\n  } | f |
 | tst.js:21:1:21:6 | C.prop | prop |
 | tst.js:24:13:24:27 | onClick={click} | onClick |
 | tst.js:27:3:27:26 | get x() ... null; } | x |

--- a/javascript/ql/test/library-tests/PropWrite/PropWriteRhs.expected
+++ b/javascript/ql/test/library-tests/PropWrite/PropWriteRhs.expected
@@ -1,3 +1,5 @@
+| classes.ts:4:3:4:24 | instanc ...  foo(); | classes.ts:4:19:4:23 | foo() |
+| classes.ts:8:15:8:35 | public  ... erField | classes.ts:8:22:8:35 | parameterField |
 | tst.js:3:5:3:8 | x: 4 | tst.js:3:8:3:8 | 4 |
 | tst.js:4:5:6:5 | func: f ... ;\\n    } | tst.js:4:11:6:5 | functio ... ;\\n    } |
 | tst.js:7:5:9:5 | f() {\\n  ... ;\\n    } | tst.js:7:6:9:5 | () {\\n   ... ;\\n    } |

--- a/javascript/ql/test/library-tests/PropWrite/PropWriteRhs.expected
+++ b/javascript/ql/test/library-tests/PropWrite/PropWriteRhs.expected
@@ -1,9 +1,7 @@
 | tst.js:3:5:3:8 | x: 4 | tst.js:3:8:3:8 | 4 |
 | tst.js:4:5:6:5 | func: f ... ;\\n    } | tst.js:4:11:6:5 | functio ... ;\\n    } |
 | tst.js:7:5:9:5 | f() {\\n  ... ;\\n    } | tst.js:7:6:9:5 | () {\\n   ... ;\\n    } |
-| tst.js:12:9:12:8 | constructor() {} | tst.js:12:9:12:8 | () {} |
 | tst.js:13:3:15:3 | static  ... x);\\n  } | tst.js:13:14:15:3 | (x) {\\n  ... x);\\n  } |
-| tst.js:16:3:18:3 | f(x) {\\n ... x);\\n  } | tst.js:16:4:18:3 | (x) {\\n  ... x);\\n  } |
 | tst.js:21:1:21:6 | C.prop | tst.js:21:10:21:11 | 56 |
 | tst.js:24:13:24:27 | onClick={click} | tst.js:24:22:24:26 | click |
 | tst.js:32:5:32:8 | n: 1 | tst.js:32:8:32:8 | 1 |

--- a/javascript/ql/test/library-tests/PropWrite/PropWriteRhs.expected
+++ b/javascript/ql/test/library-tests/PropWrite/PropWriteRhs.expected
@@ -1,9 +1,13 @@
+| classes.ts:3:21:3:20 | constructor() {} | classes.ts:3:21:3:20 | () {} |
 | classes.ts:4:3:4:24 | instanc ...  foo(); | classes.ts:4:19:4:23 | foo() |
+| classes.ts:8:3:8:39 | constru ... eld) {} | classes.ts:8:3:8:39 | constru ... eld) {} |
 | classes.ts:8:15:8:35 | public  ... erField | classes.ts:8:22:8:35 | parameterField |
 | tst.js:3:5:3:8 | x: 4 | tst.js:3:8:3:8 | 4 |
 | tst.js:4:5:6:5 | func: f ... ;\\n    } | tst.js:4:11:6:5 | functio ... ;\\n    } |
 | tst.js:7:5:9:5 | f() {\\n  ... ;\\n    } | tst.js:7:6:9:5 | () {\\n   ... ;\\n    } |
+| tst.js:12:9:12:8 | constructor() {} | tst.js:12:9:12:8 | () {} |
 | tst.js:13:3:15:3 | static  ... x);\\n  } | tst.js:13:14:15:3 | (x) {\\n  ... x);\\n  } |
+| tst.js:16:3:18:3 | f(x) {\\n ... x);\\n  } | tst.js:16:4:18:3 | (x) {\\n  ... x);\\n  } |
 | tst.js:21:1:21:6 | C.prop | tst.js:21:10:21:11 | 56 |
 | tst.js:24:13:24:27 | onClick={click} | tst.js:24:22:24:26 | click |
 | tst.js:32:5:32:8 | n: 1 | tst.js:32:8:32:8 | 1 |

--- a/javascript/ql/test/library-tests/PropWrite/classes.ts
+++ b/javascript/ql/test/library-tests/PropWrite/classes.ts
@@ -1,0 +1,9 @@
+import * as dummy from 'dummy';
+
+class InstanceField {
+  instanceField = foo();
+}
+
+class ParameterField {
+  constructor(public parameterField) {}
+}

--- a/javascript/ql/test/library-tests/PropWrite/getAPropertyReference.expected
+++ b/javascript/ql/test/library-tests/PropWrite/getAPropertyReference.expected
@@ -1,3 +1,5 @@
+| classes.ts:3:21:3:20 | this | classes.ts:4:3:4:24 | instanc ...  foo(); |
+| classes.ts:8:3:8:2 | this | classes.ts:8:15:8:35 | public  ... erField |
 | tst.js:1:1:1:0 | this | tst.js:23:15:23:29 | this.someMethod |
 | tst.js:1:1:1:0 | this | tst.js:24:36:24:45 | this.state |
 | tst.js:2:11:10:1 | {\\n    x ...     }\\n} | tst.js:3:5:3:8 | x: 4 |

--- a/javascript/ql/test/library-tests/PropWrite/getAPropertyReference2.expected
+++ b/javascript/ql/test/library-tests/PropWrite/getAPropertyReference2.expected
@@ -1,3 +1,5 @@
+| classes.ts:3:21:3:20 | this | instanceField | classes.ts:4:3:4:24 | instanc ...  foo(); |
+| classes.ts:8:3:8:2 | this | parameterField | classes.ts:8:15:8:35 | public  ... erField |
 | tst.js:1:1:1:0 | this | someMethod | tst.js:23:15:23:29 | this.someMethod |
 | tst.js:1:1:1:0 | this | state | tst.js:24:36:24:45 | this.state |
 | tst.js:2:11:10:1 | {\\n    x ...     }\\n} | f | tst.js:7:5:9:5 | f() {\\n  ... ;\\n    } |

--- a/javascript/ql/test/library-tests/PropWrite/getAPropertySource.expected
+++ b/javascript/ql/test/library-tests/PropWrite/getAPropertySource.expected
@@ -1,3 +1,5 @@
+| classes.ts:3:21:3:20 | this | instanceField | classes.ts:4:19:4:23 | foo() |
+| classes.ts:8:3:8:2 | this | parameterField | classes.ts:8:22:8:35 | parameterField |
 | tst.js:2:11:10:1 | {\\n    x ...     }\\n} | f | tst.js:7:6:9:5 | () {\\n   ... ;\\n    } |
 | tst.js:2:11:10:1 | {\\n    x ...     }\\n} | func | tst.js:4:11:6:5 | functio ... ;\\n    } |
 | tst.js:12:1:19:1 | class C ... ;\\n  }\\n} | func | tst.js:13:14:15:3 | (x) {\\n  ... x);\\n  } |

--- a/javascript/ql/test/library-tests/PropWrite/getAPropertyWrite.expected
+++ b/javascript/ql/test/library-tests/PropWrite/getAPropertyWrite.expected
@@ -1,3 +1,5 @@
+| classes.ts:3:21:3:20 | this | classes.ts:4:3:4:24 | instanc ...  foo(); |
+| classes.ts:8:3:8:2 | this | classes.ts:8:15:8:35 | public  ... erField |
 | tst.js:2:11:10:1 | {\\n    x ...     }\\n} | tst.js:3:5:3:8 | x: 4 |
 | tst.js:2:11:10:1 | {\\n    x ...     }\\n} | tst.js:4:5:6:5 | func: f ... ;\\n    } |
 | tst.js:2:11:10:1 | {\\n    x ...     }\\n} | tst.js:7:5:9:5 | f() {\\n  ... ;\\n    } |

--- a/javascript/ql/test/library-tests/PropWrite/getAPropertyWrite2.expected
+++ b/javascript/ql/test/library-tests/PropWrite/getAPropertyWrite2.expected
@@ -1,3 +1,5 @@
+| classes.ts:3:21:3:20 | this | instanceField | classes.ts:4:3:4:24 | instanc ...  foo(); |
+| classes.ts:8:3:8:2 | this | parameterField | classes.ts:8:15:8:35 | public  ... erField |
 | tst.js:2:11:10:1 | {\\n    x ...     }\\n} | f | tst.js:7:5:9:5 | f() {\\n  ... ;\\n    } |
 | tst.js:2:11:10:1 | {\\n    x ...     }\\n} | func | tst.js:4:5:6:5 | func: f ... ;\\n    } |
 | tst.js:2:11:10:1 | {\\n    x ...     }\\n} | x | tst.js:3:5:3:8 | x: 4 |

--- a/javascript/ql/test/library-tests/PropWrite/hasPropertyWrite.expected
+++ b/javascript/ql/test/library-tests/PropWrite/hasPropertyWrite.expected
@@ -1,3 +1,5 @@
+| classes.ts:3:21:3:20 | this | instanceField | classes.ts:4:19:4:23 | foo() |
+| classes.ts:8:3:8:2 | this | parameterField | classes.ts:8:22:8:35 | parameterField |
 | tst.js:2:11:10:1 | {\\n    x ...     }\\n} | f | tst.js:7:6:9:5 | () {\\n   ... ;\\n    } |
 | tst.js:2:11:10:1 | {\\n    x ...     }\\n} | func | tst.js:4:11:6:5 | functio ... ;\\n    } |
 | tst.js:2:11:10:1 | {\\n    x ...     }\\n} | x | tst.js:3:8:3:8 | 4 |


### PR DESCRIPTION
Adds a `PropWrite` instance for:
```javascript
class C {
  field = foo()
}
```
modelled as:
```javascript
class C {
  constructor() {
    this.field = foo();
  }
}
```
Note that the CFG extractor already inserts the synthetic `constructor` if needed, and the CFG for the `foo()` expression is occurs in the constructor CFG. We were just needing a `PropWrite` node for it.

Also adds a `PropWrite` for the TypeScript-specific syntax:
```typescript
class C {
  constructor(public f) {}
}
```
which is syntactic sugar for:
```javascript
class C {
  constructor(f) { this.f = f; }
}
```

Running an evaluation of security queries for now.