### PR TITLE
JS: additional propagation in the global type inference layer

### DIFF
--- a/change-notes/1.20/analysis-javascript.md
+++ b/change-notes/1.20/analysis-javascript.md
@@ -10,6 +10,8 @@
 
 * The taint tracking library now recognizes flow through persistent storage, class fields, and callbacks in certain cases. This may give more results for the security queries.
 
+* Type inference for function calls has been improved. This may give additional results for queries that rely on type inference.
+
 ## New queries
 
 | **Query**                                     | **Tags**                                             | **Purpose**                                                                                                                                                                 |

--- a/javascript/ql/src/semmle/javascript/dataflow/internal/VariableTypeInference.qll
+++ b/javascript/ql/src/semmle/javascript/dataflow/internal/VariableTypeInference.qll
@@ -42,6 +42,27 @@ private class SsaVarAccessAnalysis extends DataFlow::AnalyzedValueNode {
 }
 
 /**
+ * Flow analysis for accesses to SSA variables.
+ *
+ * Unlike `SsaVarAccessAnalysis`, this only contributes to `getAValue()`, not `getALocalValue()`.
+ */
+private class SsaVarAccessWithNonLocalAnalysis extends SsaVarAccessAnalysis {
+  DataFlow::AnalyzedValueNode src;
+
+  SsaVarAccessWithNonLocalAnalysis() {
+    exists(VarDef varDef |
+      varDef = def.(SsaExplicitDefinition).getDef() and
+      varDef.getSource().flow() = src and
+      src instanceof CallWithNonLocalAnalyzedReturnFlow and
+      // avoid relating `v` and `f()` in `var {v} = f();`
+      not varDef.getTarget() instanceof DestructuringPattern
+    )
+  }
+
+  override AbstractValue getAValue() { result = src.getAValue() }
+}
+
+/**
  * Flow analysis for `VarDef`s.
  */
 class AnalyzedVarDef extends VarDef {

--- a/javascript/ql/test/query-tests/Statements/UselessConditional/UselessConditional.expected
+++ b/javascript/ql/test/query-tests/Statements/UselessConditional/UselessConditional.expected
@@ -25,6 +25,8 @@
 | UselessConditional.js:129:6:129:24 | constantUndefined() | This call to constantUndefined always evaluates to false. |
 | UselessConditional.js:135:6:135:32 | constan ... ined1() | This call to constantFalseOrUndefined1 always evaluates to false. |
 | UselessConditional.js:139:6:139:32 | constan ... ined2() | This call to constantFalseOrUndefined2 always evaluates to false. |
+| UselessConditional.js:148:6:148:8 | p() | This call to p always evaluates to true. |
+| UselessConditional.js:163:5:163:17 | findOrThrow() | This call to findOrThrow always evaluates to true. |
 | UselessConditionalGood.js:58:12:58:13 | x2 | This use of variable 'x2' always evaluates to false. |
 | UselessConditionalGood.js:69:12:69:13 | xy | This use of variable 'xy' always evaluates to false. |
 | UselessConditionalGood.js:85:12:85:13 | xy | This use of variable 'xy' always evaluates to false. |

--- a/javascript/ql/test/query-tests/Statements/UselessConditional/UselessConditional.expected
+++ b/javascript/ql/test/query-tests/Statements/UselessConditional/UselessConditional.expected
@@ -26,7 +26,9 @@
 | UselessConditional.js:135:6:135:32 | constan ... ined1() | This call to constantFalseOrUndefined1 always evaluates to false. |
 | UselessConditional.js:139:6:139:32 | constan ... ined2() | This call to constantFalseOrUndefined2 always evaluates to false. |
 | UselessConditional.js:148:6:148:8 | p() | This call to p always evaluates to true. |
+| UselessConditional.js:151:6:151:6 | v | This use of variable 'v' always evaluates to true. |
 | UselessConditional.js:163:5:163:17 | findOrThrow() | This call to findOrThrow always evaluates to true. |
+| UselessConditional.js:166:6:166:6 | v | This use of variable 'v' always evaluates to true. |
 | UselessConditionalGood.js:58:12:58:13 | x2 | This use of variable 'x2' always evaluates to false. |
 | UselessConditionalGood.js:69:12:69:13 | xy | This use of variable 'xy' always evaluates to false. |
 | UselessConditionalGood.js:85:12:85:13 | xy | This use of variable 'xy' always evaluates to false. |

--- a/javascript/ql/test/query-tests/Statements/UselessConditional/UselessConditional.js
+++ b/javascript/ql/test/query-tests/Statements/UselessConditional/UselessConditional.js
@@ -140,4 +140,41 @@ async function awaitFlow(){
         return;
 
 });
+
+(function () {
+	function p() {
+		return {};
+	}
+	if (p()) { // NOT OK
+	}
+	var v = p();
+	if (v) { // NOT OK
+	}
+	if (v) { // NOT OK, but not detected due to SSA limitations
+	}
+});
+
+(function() {
+	function findOrThrow() {
+		var e = find();
+		if (e) return e;
+		throw new Error();
+	}
+	if(findOrThrow()){ // NOT OK
+	}
+	var v = findOrThrow();
+	if (v) { // NOT OK
+	}
+	if (v) { // NOT OK, but not detected due to SSA limitations
+	}
+});
+
+(function () {
+	function f(){ return { v: unkown };}
+	f();
+	var { v } = f();
+	if (v) { // OK
+	}
+});
+
 // semmle-extractor-options: --experimental


### PR DESCRIPTION
A minor change with a relatively big impact on the results.

Consider:

```javascript
function p() {
    return {};
}
if (p()) { // NOT OK
}
var v = p();
if (v) { // NOT OK
}
```

Both conditionals ought to be flagged by `js/trivial-conditional`, but only the first one is. This change enables us to flag both by propagating some ****overriding**** information one extra step in the global type inference layer. I expect to extend the character of the newly introduced `SsaVarAccessWithNonLocalAnalysis` soon.

[Performance is unchanged](https://git.semmle.com/esben/dist-compare-reports/tree/js/propagate-sound-avalue_1548669501105). The new alert for `js/remote-property-injection` is probably a FP, but it is an interesting showcase for the usefulness of this PR: the indirection through a variable is required for the code to work. [This is another nice alert](https://github.com/eclipse/orion.client/blob/fe3fa593f673425ae2d57af4e833afac23fa3b65/bundles/org.eclipse.orion.client.javascript/web/tern/lib/tern.js#L1146): expr is always truthy!