### PR TITLE
CPP: Clean up PotentialBufferOverflow.ql, PotentiallyDangerousFunction.ql

### DIFF
--- a/change-notes/1.20/analysis-cpp.md
+++ b/change-notes/1.20/analysis-cpp.md
@@ -23,6 +23,8 @@
 | Lossy function result cast (`cpp/lossy-function-result-cast`) | Fewer false positive results | The whitelist of rounding functions built into this query has been expanded. |
 | Unused static variable (`cpp/unused-static-variable`) | Fewer false positive results | Variables with the attribute `unused` are now excluded from the query. |
 | Resource not released in destructor (`cpp/resource-not-released-in-destructor`) | Fewer false positive results | Fix false positives where a resource is released via a virtual method call, function pointer, or lambda. |
+| Use of inherently dangerous function (`cpp/potential-buffer-overflow`) | Cleaned up | This query no longer catches uses of `gets`, and has been renamed 'Potential buffer overflow'. |
+| Use of potentially dangerous function (`cpp/potentially-dangerous-function`) | More correct results | This query now catches uses of `gets`. |
 
 ## Changes to QL libraries
 

--- a/cpp/ql/src/Likely Bugs/Memory Management/PotentialBufferOverflow.qhelp
+++ b/cpp/ql/src/Likely Bugs/Memory Management/PotentialBufferOverflow.qhelp
@@ -3,13 +3,12 @@
   "qhelp.dtd">
 <qhelp>
 <overview>
-<p>This rule highlights potentially overflowing calls to the functions <code>sprintf</code>, <code>vsprintf</code>, and <code>gets</code> with a warning. 
-These functions allow unbounded writes to buffers, which may cause an overflow when used on untrusted data or without adequate checks on the size of the data. Function calls of this type constitute a security risk through buffer overflows. The <code>gets</code> function, in particular,
-is one of the vulnerabilities exploited by the Internet Worm of 1988, one of the first computer worms to spread through the Internet.</p>
+<p>This rule highlights potentially overflowing calls to the functions <code>sprintf</code> and <code>vsprintf</code> with a warning. 
+These functions allow unbounded writes to buffers, which may cause an overflow when used on untrusted data or without adequate checks on the size of the data. Function calls of this type constitute a security risk through buffer overflows.
 
 </overview>
 <recommendation>
-<p>Always control the length of buffer copy and buffer write operations. Use the safer variants <code>snprintf</code>, <code>vsnprintf</code>, and <code>fgets</code>, which include an extra buffer length argument.</p>
+<p>Always control the length of buffer copy and buffer write operations. Use the safer variants <code>snprintf</code> and <code>vsnprintf</code>, which include an extra buffer length argument.</p>
 
 </recommendation>
 <example>
@@ -18,7 +17,6 @@ is one of the vulnerabilities exploited by the Internet Worm of 1988, one of the
 <p>To improve the security of this example code, three changes should be made:</p>
 <ol>
   <li>Introduce a preprocessor define for the size of the buffer.</li>
-  <li>Replace the call to <code>gets</code> with <code>fgets</code>, specifying the define as the maximum length to copy.  This will prevent the buffer overflow.</li>
   <li>Replace both calls to <code>sprintf</code> with <code>snprintf</code>, specifying the define as the maximum length to copy.  This will prevent the buffer overflow.</li>
   <li>Consider using the %g format specifier instead of %f.</li>
 </ol>
@@ -33,8 +31,6 @@ Standard: <a href="https://www.securecoding.cert.org/confluence/display/c/STR31-
 that storage for strings has sufficient space for character data and
 the null terminator</a>.</li>
 <li>M. Howard, D. Leblanc, J. Viega, <i>19 Deadly Sins of Software Security: Programming Flaws and How to Fix Them</i>, McGraw-Hill Osborne, 2005.</li>
-<li>Wikipedia: <a href="http://en.wikipedia.org/wiki/Morris_worm">Morris worm</a>.</li>
-<li>E. Spafford. <i>The Internet Worm Program: An Analysis</i>. Purdue Technical Report CSD-TR-823, <a href="http://www.textfiles.com/100/tr823.txt">(online)</a>, 1988.</li>
 
 
 </references>

--- a/cpp/ql/src/Likely Bugs/Memory Management/PotentialBufferOverflow.qhelp
+++ b/cpp/ql/src/Likely Bugs/Memory Management/PotentialBufferOverflow.qhelp
@@ -4,7 +4,7 @@
 <qhelp>
 <overview>
 <p>This rule highlights potentially overflowing calls to the functions <code>sprintf</code> and <code>vsprintf</code> with a warning. 
-These functions allow unbounded writes to buffers, which may cause an overflow when used on untrusted data or without adequate checks on the size of the data. Function calls of this type constitute a security risk through buffer overflows.
+These functions allow unbounded writes to buffers, which may cause an overflow when used on untrusted data or without adequate checks on the size of the data. Function calls of this type constitute a security risk through buffer overflows.</p>
 
 </overview>
 <recommendation>

--- a/cpp/ql/src/Likely Bugs/Memory Management/PotentialBufferOverflow.ql
+++ b/cpp/ql/src/Likely Bugs/Memory Management/PotentialBufferOverflow.ql
@@ -18,20 +18,6 @@ abstract class PotentiallyDangerousFunctionCall extends FunctionCall {
   abstract string getDescription();
 }
 
-class GetsCall extends PotentiallyDangerousFunctionCall {
-  GetsCall() {
-    this.getTarget().hasName("gets")
-  }
-
-  override predicate isDangerous() {
-    any()
-  }
-
-  override string getDescription() {
-    result = "gets does not guard against buffer overflow"
-  }
-}
-
 class SprintfCall extends PotentiallyDangerousFunctionCall {
   SprintfCall() {
     this.getTarget().hasName("sprintf") or this.getTarget().hasName("vsprintf")

--- a/cpp/ql/src/Likely Bugs/Memory Management/PotentialBufferOverflow.ql
+++ b/cpp/ql/src/Likely Bugs/Memory Management/PotentialBufferOverflow.ql
@@ -8,7 +8,7 @@
  * @problem.severity warning
  * @tags reliability
  *       security
- *       external/cwe/cwe-242
+ *       external/cwe/cwe-676
  */
 import cpp
 import semmle.code.cpp.commons.Buffer

--- a/cpp/ql/src/Likely Bugs/Memory Management/PotentialBufferOverflow.ql
+++ b/cpp/ql/src/Likely Bugs/Memory Management/PotentialBufferOverflow.ql
@@ -1,5 +1,5 @@
 /**
- * @name Use of inherently dangerous function
+ * @name Potential buffer overflow
  * @description Using a library function that does not check buffer bounds
  *              requires the surrounding program to be very carefully written
  *              to avoid buffer overflows.

--- a/cpp/ql/src/Likely Bugs/Memory Management/PotentialBufferOverflow.ql
+++ b/cpp/ql/src/Likely Bugs/Memory Management/PotentialBufferOverflow.ql
@@ -13,12 +13,7 @@
 import cpp
 import semmle.code.cpp.commons.Buffer
 
-abstract class PotentiallyDangerousFunctionCall extends FunctionCall {
-  abstract predicate isDangerous();
-  abstract string getDescription();
-}
-
-class SprintfCall extends PotentiallyDangerousFunctionCall {
+class SprintfCall extends FunctionCall {
   SprintfCall() {
     this.getTarget().hasName("sprintf") or this.getTarget().hasName("vsprintf")
   }
@@ -31,16 +26,16 @@ class SprintfCall extends PotentiallyDangerousFunctionCall {
     result = this.getArgument(1).(FormatLiteral).getMaxConvertedLength()
   }
 
-  override predicate isDangerous() {
+  predicate isDangerous() {
     this.getMaxConvertedLength() > this.getBufferSize()
   }
 
-  override string getDescription() {
+  string getDescription() {
     result = "This conversion may yield a string of length "+this.getMaxConvertedLength().toString()+
              ", which exceeds the allocated buffer size of "+this.getBufferSize().toString()
   }
 }
 
-from PotentiallyDangerousFunctionCall c
+from SprintfCall c
 where c.isDangerous()
 select c, c.getDescription()

--- a/cpp/ql/src/Security/CWE/CWE-676/DangerousUseOfCin.ql
+++ b/cpp/ql/src/Security/CWE/CWE-676/DangerousUseOfCin.ql
@@ -9,7 +9,6 @@
  * @tags reliability
  *       security
  *       external/cwe/cwe-676
- *       external/cwe/cwe-242
  */
 import cpp
 

--- a/cpp/ql/src/Security/CWE/CWE-676/PotentiallyDangerousFunction.qhelp
+++ b/cpp/ql/src/Security/CWE/CWE-676/PotentiallyDangerousFunction.qhelp
@@ -54,5 +54,6 @@ rules for the following CWEs:</p>
 <references>
 <li>Wikipedia: <a href="http://en.wikipedia.org/wiki/Morris_worm">Morris worm</a>.</li>
 <li>E. Spafford. <i>The Internet Worm Program: An Analysis</i>. Purdue Technical Report CSD-TR-823, <a href="http://www.textfiles.com/100/tr823.txt">(online)</a>, 1988.</li>
+<li>SEI CERT C Coding Standard: <a href="https://wiki.sei.cmu.edu/confluence/display/c/CON33-C.+Avoid+race+conditions+when+using+library+functions">CON33-C. Avoid race conditions when using library functions</a>.</li>
 </references>
 </qhelp>

--- a/cpp/ql/src/Security/CWE/CWE-676/PotentiallyDangerousFunction.qhelp
+++ b/cpp/ql/src/Security/CWE/CWE-676/PotentiallyDangerousFunction.qhelp
@@ -8,7 +8,7 @@ use. Currently, it checks for calls
 to <code>gets</code> and <code>gmtime</code>. See <strong>Related rules</strong>
 below for rules that identify other dangerous functions.</p>
 
-<p>The <code>gets</code> function is one of the vulnerabilities exploited by the Internet Worm of 1988, one of the first computer worms to spread through the Internet.</p>
+<p>The <code>gets</code> function is one of the vulnerabilities exploited by the Internet Worm of 1988, one of the first computer worms to spread through the Internet.  The <code>gets</code> function provides no way to limit the amount of data that is read and stored, so without prior knowledge of the input it is impossible to use it safely with any size of buffer.</p>
 
 <p>The <code>gmtime</code> function fills data into a <code>tm</code>
 struct in shared memory and then returns a pointer to that struct. If

--- a/cpp/ql/src/Security/CWE/CWE-676/PotentiallyDangerousFunction.qhelp
+++ b/cpp/ql/src/Security/CWE/CWE-676/PotentiallyDangerousFunction.qhelp
@@ -5,8 +5,10 @@
 <overview>
 <p>This rule finds calls to functions that are dangerous to
 use. Currently, it checks for calls
-to <code>gmtime</code>. See <strong>Related rules</strong>
+to <code>gets</code> and <code>gmtime</code>. See <strong>Related rules</strong>
 below for rules that identify other dangerous functions.</p>
+
+<p>The <code>gets</code> function is one of the vulnerabilities exploited by the Internet Worm of 1988, one of the first computer worms to spread through the Internet.</p>
 
 <p>The <code>gmtime</code> function fills data into a <code>tm</code>
 struct in shared memory and then returns a pointer to that struct. If
@@ -17,7 +19,9 @@ then the calls will overwrite each other's data.</p>
 </overview>
 <recommendation>
 
-<p>It is safer to use <code>gmtime_r</code>.
+<p>Replace calls to <code>gets</code> with <code>fgets</code>, specifying the maximum length to copy.  This will prevent the buffer overflow.</p>
+
+<p>Replace calls to <code>gmtime</code> with <code>gmtime_r</code>.
 With <code>gmtime_r</code>, the application code manages allocation of
 the <code>tm</code> struct. That way, separate calls to the function
 can use their own storage.</p>
@@ -48,7 +52,7 @@ rules for the following CWEs:</p>
 
 </section>
 <references>
-
-
+<li>Wikipedia: <a href="http://en.wikipedia.org/wiki/Morris_worm">Morris worm</a>.</li>
+<li>E. Spafford. <i>The Internet Worm Program: An Analysis</i>. Purdue Technical Report CSD-TR-823, <a href="http://www.textfiles.com/100/tr823.txt">(online)</a>, 1988.</li>
 </references>
 </qhelp>

--- a/cpp/ql/src/Security/CWE/CWE-676/PotentiallyDangerousFunction.ql
+++ b/cpp/ql/src/Security/CWE/CWE-676/PotentiallyDangerousFunction.ql
@@ -15,6 +15,9 @@ predicate potentiallyDangerousFunction(Function f, string message) {
   (
     f.getQualifiedName() = "gmtime" and
     message = "Call to gmtime is potentially dangerous"
+  ) or (
+    f.hasName("gets") and
+    message = "gets does not guard against buffer overflow"
   )
 }
 

--- a/cpp/ql/src/Security/CWE/CWE-676/PotentiallyDangerousFunction.ql
+++ b/cpp/ql/src/Security/CWE/CWE-676/PotentiallyDangerousFunction.ql
@@ -7,7 +7,7 @@
  * @id cpp/potentially-dangerous-function
  * @tags reliability
  *       security
- *       external/cwe/cwe-676
+ *       external/cwe/cwe-242
  */
 import cpp
 

--- a/cpp/ql/src/Security/CWE/CWE-676/PotentiallyDangerousFunction.ql
+++ b/cpp/ql/src/Security/CWE/CWE-676/PotentiallyDangerousFunction.ql
@@ -11,14 +11,16 @@
  */
 import cpp
 
-
-predicate dangerousFunction(Function function) {
-  exists (string name | name = function.getQualifiedName() |
-    name = "gmtime")
+predicate potentiallyDangerousFunction(Function f, string message) {
+  (
+    f.getQualifiedName() = "gmtime" and
+    message = "Call to gmtime is potentially dangerous"
+  )
 }
 
 
-from FunctionCall call, Function target
-where call.getTarget() = target
-  and dangerousFunction(target)
-select call, "Call to " + target.getQualifiedName() + " is potentially dangerous"
+from FunctionCall call, Function target, string message
+where
+  call.getTarget() = target and
+  potentiallyDangerousFunction(target, message)
+select call, message

--- a/cpp/ql/test/query-tests/Security/CWE/CWE-242/semmle/tests/PotentialBufferOverflow.expected
+++ b/cpp/ql/test/query-tests/Security/CWE/CWE-242/semmle/tests/PotentialBufferOverflow.expected
@@ -1,6 +1,3 @@
-| tests.cpp:112:9:112:12 | call to gets | gets does not guard against buffer overflow |
-| tests.cpp:249:2:249:5 | call to gets | gets does not guard against buffer overflow |
-| tests.cpp:250:2:250:5 | call to gets | gets does not guard against buffer overflow |
 | tests.cpp:258:2:258:8 | call to sprintf | This conversion may yield a string of length 17, which exceeds the allocated buffer size of 10 |
 | tests.cpp:259:2:259:8 | call to sprintf | This conversion may yield a string of length 17, which exceeds the allocated buffer size of 10 |
 | tests.cpp:272:2:272:8 | call to sprintf | This conversion may yield a string of length 9, which exceeds the allocated buffer size of 8 |

--- a/cpp/ql/test/query-tests/Security/CWE/CWE-242/semmle/tests/PotentiallyDangerousFunction.expected
+++ b/cpp/ql/test/query-tests/Security/CWE/CWE-242/semmle/tests/PotentiallyDangerousFunction.expected
@@ -1,0 +1,3 @@
+| tests.cpp:112:9:112:12 | call to gets | gets does not guard against buffer overflow |
+| tests.cpp:249:2:249:5 | call to gets | gets does not guard against buffer overflow |
+| tests.cpp:250:2:250:5 | call to gets | gets does not guard against buffer overflow |

--- a/cpp/ql/test/query-tests/Security/CWE/CWE-242/semmle/tests/PotentiallyDangerousFunction.qlref
+++ b/cpp/ql/test/query-tests/Security/CWE/CWE-242/semmle/tests/PotentiallyDangerousFunction.qlref
@@ -1,0 +1,1 @@
+Security/CWE/CWE-676/PotentiallyDangerousFunction.ql

--- a/cpp/ql/test/query-tests/Security/CWE/CWE-676/semmle/PotentiallyDangerousFunction/PotentiallyDangerousFunction.expected
+++ b/cpp/ql/test/query-tests/Security/CWE/CWE-676/semmle/PotentiallyDangerousFunction/PotentiallyDangerousFunction.expected
@@ -1,1 +1,3 @@
 | test.c:28:22:28:27 | call to gmtime | Call to gmtime is potentially dangerous |
+| test.c:39:2:39:5 | call to gets | gets does not guard against buffer overflow |
+| test.c:40:6:40:9 | call to gets | gets does not guard against buffer overflow |

--- a/cpp/ql/test/query-tests/Security/CWE/CWE-676/semmle/PotentiallyDangerousFunction/test.c
+++ b/cpp/ql/test/query-tests/Security/CWE/CWE-676/semmle/PotentiallyDangerousFunction/test.c
@@ -28,3 +28,14 @@ int is_morning() {
     struct tm *now = gmtime(time(NULL)); // BAD: gmtime uses shared state
     return (now->tm_hour < 12);
 }
+
+char *gets(char *s);
+
+void testGets() {
+	char buf1[1024];
+	char buf2 = malloc(1024);
+	char *s;
+
+	gets(buf1); // BAD: use of gets
+	s = gets(buf2); // BAD: use of gets
+}


### PR DESCRIPTION
Move the logic about `gets` from `PotentialBufferOverflow.ql` to `PotentiallyDangerousFunction.ql`.  One goal is to have LGTM report uses of `gets`, which would've caught one of the issues in https://github.com/gsingh93/lgtm-test/blob/master/test.cpp.  Also, this cleans up the identity of `PotentialBufferOverflow.ql` significantly.

Before:
 - PotentialBufferOverflow.ql (not on LGTM, CWE-242) - **any use of `gets`**, overflowing use of `sprintf`
 - PotentiallyDangerousFunction.ql (on LGTM, CWE-676) - any use of `gmtime`
 - ( and DangerousUseOfCin.ql (on LGTM, CWE-242 and CWE-676) - potentially overflowing use of `cin` )

After:
 - PotentialBufferOverflow.ql (not on LGTM, CWE-676) - overflowing use of `sprintf`
 - PotentiallyDangerousFunction.ql (on LGTM, CWE-242) - any use of `gmtime`, **any use of `gets`**
 - ( and DangerousUseOfCin.ql (on LGTM, CWE-676) - potentially overflowing use of `cin` )

Relevant CWEs:
 - CWE-242: Use of Inherently Dangerous Function (https://cwe.mitre.org/data/definitions/242.html)
		- the example is `gets`; the samate tests are all about `gets`
 - CWE-676: Use of Potentially Dangerous Function (https://cwe.mitre.org/data/definitions/676.html)
		- the example is `strcpy`; the samate tests are all about `cin`