### PR TITLE
 Python tests: Further hiding of special ESSA variables in tests

### DIFF
--- a/python/ql/test/library-tests/PointsTo/new/Definitions.ql
+++ b/python/ql/test/library-tests/PointsTo/new/Definitions.ql
@@ -4,5 +4,5 @@ import python
 import Util
 
 from EssaDefinition def, Variable v
-where v = def.getSourceVariable()
+where v = def.getSourceVariable() and not v instanceof SpecialSsaSourceVariable
 select locate(def.getLocation(), "abdgk"), v.toString(), def.getAQlClass()

--- a/python/ql/test/library-tests/PointsTo/new/SSA.ql
+++ b/python/ql/test/library-tests/PointsTo/new/SSA.ql
@@ -5,6 +5,7 @@ private import semmle.python.pointsto.PointsToContext
 import Util
 
 from EssaVariable v, EssaDefinition def, Object o, ClassObject cls
-where def = v.getDefinition() and
+where def = v.getDefinition() and 
+not v.getSourceVariable() instanceof SpecialSsaSourceVariable and
 PointsTo::ssa_variable_points_to(v, _, o, cls, _)
 select locate(def.getLocation(), "abcdegjqmns_"), v.getRepresentation() + " = " + def.getRepresentation(), repr(o), repr(cls)

--- a/python/ql/test/library-tests/PointsTo/new/SourceEdgeDefinitions.ql
+++ b/python/ql/test/library-tests/PointsTo/new/SourceEdgeDefinitions.ql
@@ -6,5 +6,5 @@ import semmle.python.pointsto.PointsTo
 import Util
 
 from SsaSourceVariable var, ControlFlowNode use, BasicBlock pred
-where var.hasRefinementEdge(use, pred, _)
+where var.hasRefinementEdge(use, pred, _) and not var instanceof SpecialSsaSourceVariable
 select locate(pred.getLastNode().getLocation(), "ab"), var.(Variable), use.toString()

--- a/python/ql/test/library-tests/PointsTo/new/SourceNodeDefinitions.ql
+++ b/python/ql/test/library-tests/PointsTo/new/SourceNodeDefinitions.ql
@@ -6,8 +6,10 @@ import semmle.python.pointsto.PointsTo
 import Util
 
 from SsaSourceVariable var, ControlFlowNode defn, string kind
-where 
-var.hasDefiningNode(defn) and kind = "definition"
-or
-var.hasRefinement(_, defn) and kind = "refinement"
+where not var instanceof SpecialSsaSourceVariable and
+(
+    var.hasDefiningNode(defn) and kind = "definition"
+    or
+    var.hasRefinement(_, defn) and kind = "refinement"
+)
 select locate(defn.getLocation(), "ab"), var.(Variable), defn.toString(), kind

--- a/python/ql/test/library-tests/PointsTo/new/VarUses.ql
+++ b/python/ql/test/library-tests/PointsTo/new/VarUses.ql
@@ -5,5 +5,5 @@ import semmle.python.pointsto.PointsTo
 import Util
 
 from SsaSourceVariable var, ControlFlowNode use
-where use = var.getAUse() or var.hasRefinement(use, _)
+where (use = var.getAUse() or var.hasRefinement(use, _)) and not var instanceof SpecialSsaSourceVariable
 select locate(use.getLocation(), "abd"), var.getName(), use.toString()


### PR DESCRIPTION
More of same: https://github.com/Semmle/ql/pull/810
To ease transition from '*' to '$' variable.