### PR TITLE
Update links to QL help topics in GH repo files (SD-2999)

### DIFF
--- a/cpp/ql/src/AlertSuppression.ql
+++ b/cpp/ql/src/AlertSuppression.ql
@@ -64,7 +64,7 @@ class SuppressionScope extends ElementBase {
   * The location spans column `startcolumn` of line `startline` to
   * column `endcolumn` of line `endline` in file `filepath`.
   * For more information, see
-  * [LGTM locations](https://help.semmle.com/QL/learn-ql/ql/locations.html).
+  * [Locations](https://help.semmle.com/QL/learn-ql/ql/locations.html).
   */
   predicate hasLocationInfo(string filepath, int startline, int startcolumn, int endline, int endcolumn) {
     this.(SuppressionComment).covers(filepath, startline, startcolumn, endline, endcolumn)

--- a/cpp/ql/src/AlertSuppression.ql
+++ b/cpp/ql/src/AlertSuppression.ql
@@ -64,7 +64,7 @@ class SuppressionScope extends ElementBase {
   * The location spans column `startcolumn` of line `startline` to
   * column `endcolumn` of line `endline` in file `filepath`.
   * For more information, see
-  * [LGTM locations](https://lgtm.com/help/ql/locations).
+  * [LGTM locations](https://help.semmle.com/QL/learn-ql/ql/locations.html).
   */
   predicate hasLocationInfo(string filepath, int startline, int startcolumn, int endline, int endcolumn) {
     this.(SuppressionComment).covers(filepath, startline, startcolumn, endline, endcolumn)

--- a/cpp/ql/src/Documentation/CommentedOutCode.qll
+++ b/cpp/ql/src/Documentation/CommentedOutCode.qll
@@ -127,7 +127,7 @@ class CommentBlock extends Comment {
      * The location spans column `startcolumn` of line `startline` to
      * column `endcolumn` of line `endline` in file `filepath`.
      * For more information, see
-     * [LGTM locations](https://lgtm.com/help/ql/locations).
+     * [LGTM locations](https://help.semmle.com/QL/learn-ql/ql/locations.html).
      */
     predicate hasLocationInfo(string filepath, int startline, int startcolumn, int endline, int endcolumn) {
         this.getLocation().hasLocationInfo(filepath, startline, startcolumn, _, _) and

--- a/cpp/ql/src/Documentation/CommentedOutCode.qll
+++ b/cpp/ql/src/Documentation/CommentedOutCode.qll
@@ -127,7 +127,7 @@ class CommentBlock extends Comment {
      * The location spans column `startcolumn` of line `startline` to
      * column `endcolumn` of line `endline` in file `filepath`.
      * For more information, see
-     * [LGTM locations](https://help.semmle.com/QL/learn-ql/ql/locations.html).
+     * [Locations](https://help.semmle.com/QL/learn-ql/ql/locations.html).
      */
     predicate hasLocationInfo(string filepath, int startline, int startcolumn, int endline, int endcolumn) {
         this.getLocation().hasLocationInfo(filepath, startline, startcolumn, _, _) and

--- a/cpp/ql/src/Metrics/Internal/CallableExtents.ql
+++ b/cpp/ql/src/Metrics/Internal/CallableExtents.ql
@@ -17,7 +17,7 @@ class RangeFunction extends Function {
   * The location spans column `startcolumn` of line `startline` to
   * column `endcolumn` of line `endline` in file `filepath`.
   * For more information, see
-  * [LGTM locations](https://lgtm.com/help/ql/locations).
+  * [LGTM locations](https://help.semmle.com/QL/learn-ql/ql/locations.html).
   */
   predicate hasLocationInfo(string path, int sl, int sc, int el, int ec) {
     super.getLocation().hasLocationInfo(path, sl, sc, _, _)

--- a/cpp/ql/src/Metrics/Internal/CallableExtents.ql
+++ b/cpp/ql/src/Metrics/Internal/CallableExtents.ql
@@ -17,7 +17,7 @@ class RangeFunction extends Function {
   * The location spans column `startcolumn` of line `startline` to
   * column `endcolumn` of line `endline` in file `filepath`.
   * For more information, see
-  * [LGTM locations](https://help.semmle.com/QL/learn-ql/ql/locations.html).
+  * [Locations](https://help.semmle.com/QL/learn-ql/ql/locations.html).
   */
   predicate hasLocationInfo(string path, int sl, int sc, int el, int ec) {
     super.getLocation().hasLocationInfo(path, sl, sc, _, _)

--- a/cpp/ql/src/definitions.qll
+++ b/cpp/ql/src/definitions.qll
@@ -23,7 +23,7 @@ class Top extends Element {
    * The location spans column `startcolumn` of line `startline` to
    * column `endcolumn` of line `endline` in file `filepath`.
    * For more information, see
-   * [LGTM locations](https://lgtm.com/help/ql/locations).
+   * [LGTM locations](https://help.semmle.com/QL/learn-ql/ql/locations.html).
    */
   predicate hasLocationInfo(string filepath,
                             int startline, int startcolumn,

--- a/cpp/ql/src/definitions.qll
+++ b/cpp/ql/src/definitions.qll
@@ -23,7 +23,7 @@ class Top extends Element {
    * The location spans column `startcolumn` of line `startline` to
    * column `endcolumn` of line `endline` in file `filepath`.
    * For more information, see
-   * [LGTM locations](https://help.semmle.com/QL/learn-ql/ql/locations.html).
+   * [Locations](https://help.semmle.com/QL/learn-ql/ql/locations.html).
    */
   predicate hasLocationInfo(string filepath,
                             int startline, int startcolumn,

--- a/cpp/ql/src/semmle/code/cpp/File.qll
+++ b/cpp/ql/src/semmle/code/cpp/File.qll
@@ -34,7 +34,7 @@ abstract class Container extends Locatable, @container {
    * DEPRECATED: Use `getLocation` instead.
    * Gets a URL representing the location of this container.
    *
-   * For more information see https://help.semmle.com/QL/learn-ql/ql/locations.html#providing-urls.
+   * For more information see [Providing URLs](https://help.semmle.com/QL/learn-ql/ql/locations.html#providing-urls).
    */
   deprecated abstract string getURL();
 

--- a/cpp/ql/src/semmle/code/cpp/File.qll
+++ b/cpp/ql/src/semmle/code/cpp/File.qll
@@ -34,7 +34,7 @@ abstract class Container extends Locatable, @container {
    * DEPRECATED: Use `getLocation` instead.
    * Gets a URL representing the location of this container.
    *
-   * For more information see https://lgtm.com/help/ql/locations#providing-urls.
+   * For more information see https://help.semmle.com/QL/learn-ql/ql/locations.html#providing-urls.
    */
   deprecated abstract string getURL();
 

--- a/cpp/ql/src/semmle/code/cpp/Location.qll
+++ b/cpp/ql/src/semmle/code/cpp/Location.qll
@@ -68,7 +68,7 @@ class Location extends @location {
    * The location spans column `startcolumn` of line `startline` to
    * column `endcolumn` of line `endline` in file `filepath`.
    * For more information, see
-   * [LGTM locations](https://help.semmle.com/QL/learn-ql/ql/locations.html).
+   * [Locations](https://help.semmle.com/QL/learn-ql/ql/locations.html).
    */
   predicate hasLocationInfo(
     string filepath, int startline, int startcolumn, int endline, int endcolumn) {

--- a/cpp/ql/src/semmle/code/cpp/Location.qll
+++ b/cpp/ql/src/semmle/code/cpp/Location.qll
@@ -68,7 +68,7 @@ class Location extends @location {
    * The location spans column `startcolumn` of line `startline` to
    * column `endcolumn` of line `endline` in file `filepath`.
    * For more information, see
-   * [LGTM locations](https://lgtm.com/help/ql/locations).
+   * [LGTM locations](https://help.semmle.com/QL/learn-ql/ql/locations.html).
    */
   predicate hasLocationInfo(
     string filepath, int startline, int startcolumn, int endline, int endcolumn) {

--- a/cpp/ql/src/semmle/code/cpp/controlflow/BasicBlocks.qll
+++ b/cpp/ql/src/semmle/code/cpp/controlflow/BasicBlocks.qll
@@ -195,7 +195,7 @@ class BasicBlock extends ControlFlowNodeBase {
    * The location spans column `startcolumn` of line `startline` to
    * column `endcolumn` of line `endline` in file `filepath`.
    * For more information, see
-   * [LGTM locations](https://help.semmle.com/QL/learn-ql/ql/locations.html).
+   * [Locations](https://help.semmle.com/QL/learn-ql/ql/locations.html).
    *
    * Yields no result if this basic block spans multiple source files.
    */

--- a/cpp/ql/src/semmle/code/cpp/controlflow/BasicBlocks.qll
+++ b/cpp/ql/src/semmle/code/cpp/controlflow/BasicBlocks.qll
@@ -195,7 +195,7 @@ class BasicBlock extends ControlFlowNodeBase {
    * The location spans column `startcolumn` of line `startline` to
    * column `endcolumn` of line `endline` in file `filepath`.
    * For more information, see
-   * [LGTM locations](https://lgtm.com/help/ql/locations).
+   * [LGTM locations](https://help.semmle.com/QL/learn-ql/ql/locations.html).
    *
    * Yields no result if this basic block spans multiple source files.
    */

--- a/cpp/ql/src/semmlecode.cpp.dbscheme
+++ b/cpp/ql/src/semmlecode.cpp.dbscheme
@@ -233,7 +233,7 @@ svnchurn(
  * The location spans column `startcolumn` of line `startline` to
  * column `endcolumn` of line `endline` in file `file`.
  * For more information, see
- * [LGTM locations](https://lgtm.com/docs/ql/locations).
+ * [LGTM locations](https://help.semmle.com/QL/learn-ql/ql/locations.html).
  */
 locations_default(
     /** The location of an element that is not an expression or a statement. */
@@ -250,7 +250,7 @@ locations_default(
  * The location spans column `startcolumn` of line `startline` to
  * column `endcolumn` of line `endline` in file `file`.
  * For more information, see
- * [LGTM locations](https://lgtm.com/docs/ql/locations).
+ * [LGTM locations](https://help.semmle.com/QL/learn-ql/ql/locations.html).
  */
 locations_stmt(
     /** The location of a statement. */
@@ -267,7 +267,7 @@ locations_stmt(
  * The location spans column `startcolumn` of line `startline` to
  * column `endcolumn` of line `endline` in file `file`.
  * For more information, see
- * [LGTM locations](https://lgtm.com/docs/ql/locations).
+ * [LGTM locations](https://help.semmle.com/QL/learn-ql/ql/locations.html).
  */
 locations_expr(
     /** The location of an expression. */

--- a/cpp/ql/src/semmlecode.cpp.dbscheme
+++ b/cpp/ql/src/semmlecode.cpp.dbscheme
@@ -233,7 +233,7 @@ svnchurn(
  * The location spans column `startcolumn` of line `startline` to
  * column `endcolumn` of line `endline` in file `file`.
  * For more information, see
- * [LGTM locations](https://help.semmle.com/QL/learn-ql/ql/locations.html).
+ * [Locations](https://help.semmle.com/QL/learn-ql/ql/locations.html).
  */
 locations_default(
     /** The location of an element that is not an expression or a statement. */
@@ -250,7 +250,7 @@ locations_default(
  * The location spans column `startcolumn` of line `startline` to
  * column `endcolumn` of line `endline` in file `file`.
  * For more information, see
- * [LGTM locations](https://help.semmle.com/QL/learn-ql/ql/locations.html).
+ * [Locations](https://help.semmle.com/QL/learn-ql/ql/locations.html).
  */
 locations_stmt(
     /** The location of a statement. */
@@ -267,7 +267,7 @@ locations_stmt(
  * The location spans column `startcolumn` of line `startline` to
  * column `endcolumn` of line `endline` in file `file`.
  * For more information, see
- * [LGTM locations](https://help.semmle.com/QL/learn-ql/ql/locations.html).
+ * [Locations](https://help.semmle.com/QL/learn-ql/ql/locations.html).
  */
 locations_expr(
     /** The location of an expression. */

--- a/csharp/ql/src/AlertSuppression.ql
+++ b/csharp/ql/src/AlertSuppression.ql
@@ -53,7 +53,7 @@ class SuppressionScope extends @commentline {
    * The location spans column `startcolumn` of line `startline` to
    * column `endcolumn` of line `endline` in file `filepath`.
    * For more information, see
-   * [LGTM locations](https://lgtm.com/help/ql/locations).
+   * [LGTM locations](https://help.semmle.com/QL/learn-ql/ql/locations.html).
    */
   predicate hasLocationInfo(
     string filepath, int startline, int startcolumn, int endline, int endcolumn

--- a/csharp/ql/src/AlertSuppression.ql
+++ b/csharp/ql/src/AlertSuppression.ql
@@ -53,7 +53,7 @@ class SuppressionScope extends @commentline {
    * The location spans column `startcolumn` of line `startline` to
    * column `endcolumn` of line `endline` in file `filepath`.
    * For more information, see
-   * [LGTM locations](https://help.semmle.com/QL/learn-ql/ql/locations.html).
+   * [Locations](https://help.semmle.com/QL/learn-ql/ql/locations.html).
    */
   predicate hasLocationInfo(
     string filepath, int startline, int startcolumn, int endline, int endcolumn

--- a/csharp/ql/src/definitions.ql
+++ b/csharp/ql/src/definitions.ql
@@ -15,7 +15,7 @@ abstract class Use extends @type_mention_parent {
    * The location spans column `startcolumn` of line `startline` to
    * column `endcolumn` of line `endline` in file `filepath`.
    * For more information, see
-   * [LGTM locations](https://help.semmle.com/QL/learn-ql/ql/locations.html).
+   * [Locations](https://help.semmle.com/QL/learn-ql/ql/locations.html).
    */
   predicate hasLocationInfo(
     string filepath, int startline, int startcolumn, int endline, int endcolumn

--- a/csharp/ql/src/definitions.ql
+++ b/csharp/ql/src/definitions.ql
@@ -15,7 +15,7 @@ abstract class Use extends @type_mention_parent {
    * The location spans column `startcolumn` of line `startline` to
    * column `endcolumn` of line `endline` in file `filepath`.
    * For more information, see
-   * [LGTM locations](https://lgtm.com/help/ql/locations).
+   * [LGTM locations](https://help.semmle.com/QL/learn-ql/ql/locations.html).
    */
   predicate hasLocationInfo(
     string filepath, int startline, int startcolumn, int endline, int endcolumn

--- a/csharp/ql/src/external/CodeDuplication.qll
+++ b/csharp/ql/src/external/CodeDuplication.qll
@@ -6,7 +6,7 @@ private string relativePath(File file) { result = file.getRelativePath().replace
  * Holds if the `index`-th token of block `copy` is in file `file`, spanning
  * column `sc` of line `sl` to column `ec` of line `el`.
  *
- * For more information, see [LGTM locations](https://help.semmle.com/QL/learn-ql/ql/locations.html).
+ * For more information, see [Locations](https://help.semmle.com/QL/learn-ql/ql/locations.html).
  */
 pragma[nomagic]
 predicate tokenLocation(File file, int sl, int sc, int ec, int el, Copy copy, int index) {

--- a/csharp/ql/src/external/CodeDuplication.qll
+++ b/csharp/ql/src/external/CodeDuplication.qll
@@ -6,7 +6,7 @@ private string relativePath(File file) { result = file.getRelativePath().replace
  * Holds if the `index`-th token of block `copy` is in file `file`, spanning
  * column `sc` of line `sl` to column `ec` of line `el`.
  *
- * For more information, see [LGTM locations](https://lgtm.com/docs/ql/locations).
+ * For more information, see [LGTM locations](https://help.semmle.com/QL/learn-ql/ql/locations.html).
  */
 pragma[nomagic]
 predicate tokenLocation(File file, int sl, int sc, int ec, int el, Copy copy, int index) {

--- a/csharp/ql/src/semmle/code/csharp/File.qll
+++ b/csharp/ql/src/semmle/code/csharp/File.qll
@@ -33,7 +33,7 @@ class Container extends @container {
   /**
    * Gets a URL representing the location of this container.
    *
-   * For more information see https://lgtm.com/help/ql/locations#providing-urls.
+   * For more information see https://help.semmle.com/QL/learn-ql/ql/locations.html#providing-urls.
    */
   string getURL() { none() }
 

--- a/csharp/ql/src/semmle/code/csharp/File.qll
+++ b/csharp/ql/src/semmle/code/csharp/File.qll
@@ -33,7 +33,7 @@ class Container extends @container {
   /**
    * Gets a URL representing the location of this container.
    *
-   * For more information see https://help.semmle.com/QL/learn-ql/ql/locations.html#providing-urls.
+   * For more information see [Providing URLs](https://help.semmle.com/QL/learn-ql/ql/locations.html#providing-urls).
    */
   string getURL() { none() }
 

--- a/csharp/ql/src/semmle/code/csharp/Location.qll
+++ b/csharp/ql/src/semmle/code/csharp/Location.qll
@@ -27,7 +27,7 @@ class Location extends @location {
    * The location spans column `startcolumn` of line `startline` to
    * column `endcolumn` of line `endline` in file `filepath`.
    * For more information, see
-   * [LGTM locations](https://help.semmle.com/QL/learn-ql/ql/locations.html).
+   * [Locations](https://help.semmle.com/QL/learn-ql/ql/locations.html).
    */
   predicate hasLocationInfo(
     string filepath, int startline, int startcolumn, int endline, int endcolumn

--- a/csharp/ql/src/semmle/code/csharp/Location.qll
+++ b/csharp/ql/src/semmle/code/csharp/Location.qll
@@ -27,7 +27,7 @@ class Location extends @location {
    * The location spans column `startcolumn` of line `startline` to
    * column `endcolumn` of line `endline` in file `filepath`.
    * For more information, see
-   * [LGTM locations](https://lgtm.com/help/ql/locations).
+   * [LGTM locations](https://help.semmle.com/QL/learn-ql/ql/locations.html).
    */
   predicate hasLocationInfo(
     string filepath, int startline, int startcolumn, int endline, int endcolumn

--- a/java/ql/src/AlertSuppression.ql
+++ b/java/ql/src/AlertSuppression.ql
@@ -59,7 +59,7 @@ class SuppressionScope extends @javadoc {
    * The location spans column `startcolumn` of line `startline` to
    * column `endcolumn` of line `endline` in file `filepath`.
    * For more information, see
-   * [LGTM locations](https://lgtm.com/help/ql/locations).
+   * [LGTM locations](https://help.semmle.com/QL/learn-ql/ql/locations.html).
    */
   predicate hasLocationInfo(
     string filepath, int startline, int startcolumn, int endline, int endcolumn

--- a/java/ql/src/AlertSuppression.ql
+++ b/java/ql/src/AlertSuppression.ql
@@ -59,7 +59,7 @@ class SuppressionScope extends @javadoc {
    * The location spans column `startcolumn` of line `startline` to
    * column `endcolumn` of line `endline` in file `filepath`.
    * For more information, see
-   * [LGTM locations](https://help.semmle.com/QL/learn-ql/ql/locations.html).
+   * [Locations](https://help.semmle.com/QL/learn-ql/ql/locations.html).
    */
   predicate hasLocationInfo(
     string filepath, int startline, int startcolumn, int endline, int endcolumn

--- a/java/ql/src/external/DefectFilter.qll
+++ b/java/ql/src/external/DefectFilter.qll
@@ -8,7 +8,7 @@ import java
  * column `startcolumn` of line `startline` to column `endcolumn` of line `endline`
  * in file `filepath`.
  *
- * For more information, see [LGTM locations](https://help.semmle.com/QL/learn-ql/ql/locations.html).
+ * For more information, see [Locations](https://help.semmle.com/QL/learn-ql/ql/locations.html).
  */
 external predicate defectResults(
   int id, string queryPath, string file, int startline, int startcol, int endline, int endcol,

--- a/java/ql/src/external/DefectFilter.qll
+++ b/java/ql/src/external/DefectFilter.qll
@@ -8,7 +8,7 @@ import java
  * column `startcolumn` of line `startline` to column `endcolumn` of line `endline`
  * in file `filepath`.
  *
- * For more information, see [LGTM locations](https://lgtm.com/help/ql/locations).
+ * For more information, see [LGTM locations](https://help.semmle.com/QL/learn-ql/ql/locations.html).
  */
 external predicate defectResults(
   int id, string queryPath, string file, int startline, int startcol, int endline, int endcol,

--- a/java/ql/src/semmle/code/FileSystem.qll
+++ b/java/ql/src/semmle/code/FileSystem.qll
@@ -33,7 +33,7 @@ class Container extends @container, Top {
   /**
    * Gets a URL representing the location of this container.
    *
-   * For more information see https://lgtm.com/help/ql/locations#providing-urls.
+   * For more information see https://help.semmle.com/QL/learn-ql/ql/locations.html#providing-urls.
    */
   abstract string getURL();
 

--- a/java/ql/src/semmle/code/FileSystem.qll
+++ b/java/ql/src/semmle/code/FileSystem.qll
@@ -33,7 +33,7 @@ class Container extends @container, Top {
   /**
    * Gets a URL representing the location of this container.
    *
-   * For more information see https://help.semmle.com/QL/learn-ql/ql/locations.html#providing-urls.
+   * For more information see [Providing URLs](https://help.semmle.com/QL/learn-ql/ql/locations.html#providing-urls).
    */
   abstract string getURL();
 

--- a/java/ql/src/semmle/code/Location.qll
+++ b/java/ql/src/semmle/code/Location.qll
@@ -57,7 +57,7 @@ class Top extends @top {
    * The location spans column `startcolumn` of line `startline` to
    * column `endcolumn` of line `endline` in file `filepath`.
    * For more information, see
-   * [LGTM locations](https://help.semmle.com/QL/learn-ql/ql/locations.html).
+   * [Locations](https://help.semmle.com/QL/learn-ql/ql/locations.html).
    */
   predicate hasLocationInfo(
     string filepath, int startline, int startcolumn, int endline, int endcolumn
@@ -150,7 +150,7 @@ class Location extends @location {
    * The location spans column `startcolumn` of line `startline` to
    * column `endcolumn` of line `endline` in file `filepath`.
    * For more information, see
-   * [LGTM locations](https://help.semmle.com/QL/learn-ql/ql/locations.html).
+   * [Locations](https://help.semmle.com/QL/learn-ql/ql/locations.html).
    */
   predicate hasLocationInfo(
     string filepath, int startline, int startcolumn, int endline, int endcolumn

--- a/java/ql/src/semmle/code/Location.qll
+++ b/java/ql/src/semmle/code/Location.qll
@@ -57,7 +57,7 @@ class Top extends @top {
    * The location spans column `startcolumn` of line `startline` to
    * column `endcolumn` of line `endline` in file `filepath`.
    * For more information, see
-   * [LGTM locations](https://lgtm.com/help/ql/locations).
+   * [LGTM locations](https://help.semmle.com/QL/learn-ql/ql/locations.html).
    */
   predicate hasLocationInfo(
     string filepath, int startline, int startcolumn, int endline, int endcolumn
@@ -150,7 +150,7 @@ class Location extends @location {
    * The location spans column `startcolumn` of line `startline` to
    * column `endcolumn` of line `endline` in file `filepath`.
    * For more information, see
-   * [LGTM locations](https://lgtm.com/help/ql/locations).
+   * [LGTM locations](https://help.semmle.com/QL/learn-ql/ql/locations.html).
    */
   predicate hasLocationInfo(
     string filepath, int startline, int startcolumn, int endline, int endcolumn

--- a/java/ql/src/semmle/code/xml/XML.qll
+++ b/java/ql/src/semmle/code/xml/XML.qll
@@ -14,7 +14,7 @@ abstract class XMLLocatable extends @xmllocatable {
    * The location spans column `startcolumn` of line `startline` to
    * column `endcolumn` of line `endline` in file `filepath`.
    * For more information, see
-   * [LGTM locations](https://help.semmle.com/QL/learn-ql/ql/locations.html).
+   * [Locations](https://help.semmle.com/QL/learn-ql/ql/locations.html).
    */
   predicate hasLocationInfo(
     string filepath, int startline, int startcolumn, int endline, int endcolumn

--- a/java/ql/src/semmle/code/xml/XML.qll
+++ b/java/ql/src/semmle/code/xml/XML.qll
@@ -14,7 +14,7 @@ abstract class XMLLocatable extends @xmllocatable {
    * The location spans column `startcolumn` of line `startline` to
    * column `endcolumn` of line `endline` in file `filepath`.
    * For more information, see
-   * [LGTM locations](https://lgtm.com/help/ql/locations).
+   * [LGTM locations](https://help.semmle.com/QL/learn-ql/ql/locations.html).
    */
   predicate hasLocationInfo(
     string filepath, int startline, int startcolumn, int endline, int endcolumn

--- a/javascript/ql/src/AlertSuppression.ql
+++ b/javascript/ql/src/AlertSuppression.ql
@@ -62,7 +62,7 @@ class SuppressionScope extends @locatable {
    * The location spans column `startcolumn` of line `startline` to
    * column `endcolumn` of line `endline` in file `filepath`.
    * For more information, see
-   * [LGTM locations](https://help.semmle.com/QL/learn-ql/ql/locations.html).
+   * [Locations](https://help.semmle.com/QL/learn-ql/ql/locations.html).
    */
   predicate hasLocationInfo(
     string filepath, int startline, int startcolumn, int endline, int endcolumn

--- a/javascript/ql/src/AlertSuppression.ql
+++ b/javascript/ql/src/AlertSuppression.ql
@@ -62,7 +62,7 @@ class SuppressionScope extends @locatable {
    * The location spans column `startcolumn` of line `startline` to
    * column `endcolumn` of line `endline` in file `filepath`.
    * For more information, see
-   * [LGTM locations](https://lgtm.com/help/ql/locations).
+   * [LGTM locations](https://help.semmle.com/QL/learn-ql/ql/locations.html).
    */
   predicate hasLocationInfo(
     string filepath, int startline, int startcolumn, int endline, int endcolumn

--- a/javascript/ql/src/Comments/CommentedOut.qll
+++ b/javascript/ql/src/Comments/CommentedOut.qll
@@ -127,7 +127,7 @@ class CommentedOutCode extends Comment {
    * The location spans column `startcolumn` of line `startline` to
    * column `endcolumn` of line `endline` in file `filepath`.
    * For more information, see
-   * [LGTM locations](https://help.semmle.com/QL/learn-ql/ql/locations.html).
+   * [Locations](https://help.semmle.com/QL/learn-ql/ql/locations.html).
    */
   predicate hasLocationInfo(
     string filepath, int startline, int startcolumn, int endline, int endcolumn

--- a/javascript/ql/src/Comments/CommentedOut.qll
+++ b/javascript/ql/src/Comments/CommentedOut.qll
@@ -127,7 +127,7 @@ class CommentedOutCode extends Comment {
    * The location spans column `startcolumn` of line `startline` to
    * column `endcolumn` of line `endline` in file `filepath`.
    * For more information, see
-   * [LGTM locations](https://lgtm.com/help/ql/locations).
+   * [LGTM locations](https://help.semmle.com/QL/learn-ql/ql/locations.html).
    */
   predicate hasLocationInfo(
     string filepath, int startline, int startcolumn, int endline, int endcolumn

--- a/javascript/ql/src/Expressions/MisspelledIdentifier.ql
+++ b/javascript/ql/src/Expressions/MisspelledIdentifier.ql
@@ -22,7 +22,7 @@ class IdentifierPart extends string {
    * The location spans column `startcolumn` of line `startline` to
    * column `endcolumn` of line `endline` in file `filepath`.
    * For more information, see
-   * [LGTM locations](https://lgtm.com/help/ql/locations).
+   * [LGTM locations](https://help.semmle.com/QL/learn-ql/ql/locations.html).
    */
   predicate hasLocationInfo(
     string filepath, int startline, int startcolumn, int endline, int endcolumn

--- a/javascript/ql/src/Expressions/MisspelledIdentifier.ql
+++ b/javascript/ql/src/Expressions/MisspelledIdentifier.ql
@@ -22,7 +22,7 @@ class IdentifierPart extends string {
    * The location spans column `startcolumn` of line `startline` to
    * column `endcolumn` of line `endline` in file `filepath`.
    * For more information, see
-   * [LGTM locations](https://help.semmle.com/QL/learn-ql/ql/locations.html).
+   * [Locations](https://help.semmle.com/QL/learn-ql/ql/locations.html).
    */
   predicate hasLocationInfo(
     string filepath, int startline, int startcolumn, int endline, int endcolumn

--- a/javascript/ql/src/LanguageFeatures/EmptyArrayInit.ql
+++ b/javascript/ql/src/LanguageFeatures/EmptyArrayInit.ql
@@ -29,7 +29,7 @@ class OmittedArrayElement extends ArrayExpr {
    * The location spans column `startcolumn` of line `startline` to
    * column `endcolumn` of line `endline` in file `filepath`.
    * For more information, see
-   * [LGTM locations](https://help.semmle.com/QL/learn-ql/ql/locations.html).
+   * [Locations](https://help.semmle.com/QL/learn-ql/ql/locations.html).
    */
   predicate hasLocationInfo(
     string filepath, int startline, int startcolumn, int endline, int endcolumn

--- a/javascript/ql/src/LanguageFeatures/EmptyArrayInit.ql
+++ b/javascript/ql/src/LanguageFeatures/EmptyArrayInit.ql
@@ -29,7 +29,7 @@ class OmittedArrayElement extends ArrayExpr {
    * The location spans column `startcolumn` of line `startline` to
    * column `endcolumn` of line `endline` in file `filepath`.
    * For more information, see
-   * [LGTM locations](https://lgtm.com/help/ql/locations).
+   * [LGTM locations](https://help.semmle.com/QL/learn-ql/ql/locations.html).
    */
   predicate hasLocationInfo(
     string filepath, int startline, int startcolumn, int endline, int endcolumn

--- a/javascript/ql/src/LanguageFeatures/SpuriousArguments.ql
+++ b/javascript/ql/src/LanguageFeatures/SpuriousArguments.ql
@@ -68,7 +68,7 @@ class SpuriousArguments extends Expr {
    * The location spans column `startcolumn` of line `startline` to
    * column `endcolumn` of line `endline` in file `filepath`.
    * For more information, see
-   * [LGTM locations](https://help.semmle.com/QL/learn-ql/ql/locations.html).
+   * [Locations](https://help.semmle.com/QL/learn-ql/ql/locations.html).
    */
   predicate hasLocationInfo(
     string filepath, int startline, int startcolumn, int endline, int endcolumn

--- a/javascript/ql/src/LanguageFeatures/SpuriousArguments.ql
+++ b/javascript/ql/src/LanguageFeatures/SpuriousArguments.ql
@@ -68,7 +68,7 @@ class SpuriousArguments extends Expr {
    * The location spans column `startcolumn` of line `startline` to
    * column `endcolumn` of line `endline` in file `filepath`.
    * For more information, see
-   * [LGTM locations](https://lgtm.com/help/ql/locations).
+   * [LGTM locations](https://help.semmle.com/QL/learn-ql/ql/locations.html).
    */
   predicate hasLocationInfo(
     string filepath, int startline, int startcolumn, int endline, int endcolumn

--- a/javascript/ql/src/external/CodeDuplication.qll
+++ b/javascript/ql/src/external/CodeDuplication.qll
@@ -9,7 +9,7 @@ private string relativePath(File file) { result = file.getRelativePath().replace
  * Holds if the `index`-th token of block `copy` is in file `file`, spanning
  * column `sc` of line `sl` to column `ec` of line `el`.
  *
- * For more information, see [LGTM locations](https://help.semmle.com/QL/learn-ql/ql/locations.html).
+ * For more information, see [Locations](https://help.semmle.com/QL/learn-ql/ql/locations.html).
  */
 pragma[noinline]
 private predicate tokenLocation(File file, int sl, int sc, int ec, int el, Copy copy, int index) {
@@ -62,7 +62,7 @@ class Copy extends @duplication_or_similarity {
    * The location spans column `startcolumn` of line `startline` to
    * column `endcolumn` of line `endline` in file `filepath`.
    * For more information, see
-   * [LGTM locations](https://help.semmle.com/QL/learn-ql/ql/locations.html).
+   * [Locations](https://help.semmle.com/QL/learn-ql/ql/locations.html).
    */
   predicate hasLocationInfo(
     string filepath, int startline, int startcolumn, int endline, int endcolumn

--- a/javascript/ql/src/external/CodeDuplication.qll
+++ b/javascript/ql/src/external/CodeDuplication.qll
@@ -9,7 +9,7 @@ private string relativePath(File file) { result = file.getRelativePath().replace
  * Holds if the `index`-th token of block `copy` is in file `file`, spanning
  * column `sc` of line `sl` to column `ec` of line `el`.
  *
- * For more information, see [LGTM locations](https://lgtm.com/help/ql/locations).
+ * For more information, see [LGTM locations](https://help.semmle.com/QL/learn-ql/ql/locations.html).
  */
 pragma[noinline]
 private predicate tokenLocation(File file, int sl, int sc, int ec, int el, Copy copy, int index) {
@@ -62,7 +62,7 @@ class Copy extends @duplication_or_similarity {
    * The location spans column `startcolumn` of line `startline` to
    * column `endcolumn` of line `endline` in file `filepath`.
    * For more information, see
-   * [LGTM locations](https://lgtm.com/help/ql/locations).
+   * [LGTM locations](https://help.semmle.com/QL/learn-ql/ql/locations.html).
    */
   predicate hasLocationInfo(
     string filepath, int startline, int startcolumn, int endline, int endcolumn

--- a/javascript/ql/src/external/DefectFilter.qll
+++ b/javascript/ql/src/external/DefectFilter.qll
@@ -8,7 +8,7 @@ import semmle.javascript.Files
  * column `startcolumn` of line `startline` to column `endcolumn` of line `endline`
  * in file `filepath`.
  *
- * For more information, see [LGTM locations](https://help.semmle.com/QL/learn-ql/ql/locations.html).
+ * For more information, see [Locations](https://help.semmle.com/QL/learn-ql/ql/locations.html).
  */
 external predicate defectResults(
   int id, string queryPath, string file, int startline, int startcol, int endline, int endcol,

--- a/javascript/ql/src/external/DefectFilter.qll
+++ b/javascript/ql/src/external/DefectFilter.qll
@@ -8,7 +8,7 @@ import semmle.javascript.Files
  * column `startcolumn` of line `startline` to column `endcolumn` of line `endline`
  * in file `filepath`.
  *
- * For more information, see [LGTM locations](https://lgtm.com/help/ql/locations).
+ * For more information, see [LGTM locations](https://help.semmle.com/QL/learn-ql/ql/locations.html).
  */
 external predicate defectResults(
   int id, string queryPath, string file, int startline, int startcol, int endline, int endcol,

--- a/javascript/ql/src/external/MetricFilter.qll
+++ b/javascript/ql/src/external/MetricFilter.qll
@@ -8,7 +8,7 @@ import javascript
  * column `startcolumn` of line `startline` to column `endcolumn` of line `endline`
  * in file `filepath`.
  *
- * For more information, see [LGTM locations](https://lgtm.com/help/ql/locations).
+ * For more information, see [LGTM locations](https://help.semmle.com/QL/learn-ql/ql/locations.html).
  */
 external predicate metricResults(
   int id, string queryPath, string file, int startline, int startcol, int endline, int endcol,

--- a/javascript/ql/src/external/MetricFilter.qll
+++ b/javascript/ql/src/external/MetricFilter.qll
@@ -8,7 +8,7 @@ import javascript
  * column `startcolumn` of line `startline` to column `endcolumn` of line `endline`
  * in file `filepath`.
  *
- * For more information, see [LGTM locations](https://help.semmle.com/QL/learn-ql/ql/locations.html).
+ * For more information, see [Locations](https://help.semmle.com/QL/learn-ql/ql/locations.html).
  */
 external predicate metricResults(
   int id, string queryPath, string file, int startline, int startcol, int endline, int endcol,

--- a/javascript/ql/src/semmle/javascript/Files.qll
+++ b/javascript/ql/src/semmle/javascript/Files.qll
@@ -34,7 +34,7 @@ abstract class Container extends @container {
   /**
    * Gets a URL representing the location of this container.
    *
-   * For more information see https://help.semmle.com/QL/learn-ql/ql/locations.html#providing-urls.
+   * For more information see [Providing URLs](https://help.semmle.com/QL/learn-ql/ql/locations.html#providing-urls).
    */
   abstract string getURL();
 

--- a/javascript/ql/src/semmle/javascript/Files.qll
+++ b/javascript/ql/src/semmle/javascript/Files.qll
@@ -34,7 +34,7 @@ abstract class Container extends @container {
   /**
    * Gets a URL representing the location of this container.
    *
-   * For more information see https://lgtm.com/help/ql/locations#providing-urls.
+   * For more information see https://help.semmle.com/QL/learn-ql/ql/locations.html#providing-urls.
    */
   abstract string getURL();
 

--- a/javascript/ql/src/semmle/javascript/Locations.qll
+++ b/javascript/ql/src/semmle/javascript/Locations.qll
@@ -6,7 +6,7 @@ import javascript
  * A location as given by a file, a start line, a start column,
  * an end line, and an end column.
  *
- * For more information about locations see [LGTM locations](https://lgtm.com/help/ql/locations).
+ * For more information about locations see [LGTM locations](https://help.semmle.com/QL/learn-ql/ql/locations.html).
  */
 class Location extends @location {
   /** Gets the file for this location. */
@@ -70,7 +70,7 @@ class Location extends @location {
    * The location spans column `startcolumn` of line `startline` to
    * column `endcolumn` of line `endline` in file `filepath`.
    * For more information, see
-   * [LGTM locations](https://lgtm.com/help/ql/locations).
+   * [LGTM locations](https://help.semmle.com/QL/learn-ql/ql/locations.html).
    */
   predicate hasLocationInfo(
     string filepath, int startline, int startcolumn, int endline, int endcolumn

--- a/javascript/ql/src/semmle/javascript/Locations.qll
+++ b/javascript/ql/src/semmle/javascript/Locations.qll
@@ -6,7 +6,7 @@ import javascript
  * A location as given by a file, a start line, a start column,
  * an end line, and an end column.
  *
- * For more information about locations see [LGTM locations](https://help.semmle.com/QL/learn-ql/ql/locations.html).
+ * For more information about locations see [Locations](https://help.semmle.com/QL/learn-ql/ql/locations.html).
  */
 class Location extends @location {
   /** Gets the file for this location. */
@@ -70,7 +70,7 @@ class Location extends @location {
    * The location spans column `startcolumn` of line `startline` to
    * column `endcolumn` of line `endline` in file `filepath`.
    * For more information, see
-   * [LGTM locations](https://help.semmle.com/QL/learn-ql/ql/locations.html).
+   * [Locations](https://help.semmle.com/QL/learn-ql/ql/locations.html).
    */
   predicate hasLocationInfo(
     string filepath, int startline, int startcolumn, int endline, int endcolumn

--- a/javascript/ql/src/semmle/javascript/RestrictedLocations.qll
+++ b/javascript/ql/src/semmle/javascript/RestrictedLocations.qll
@@ -14,7 +14,7 @@ class FirstLineOf extends Locatable {
    * The location spans column `startcolumn` of line `startline` to
    * column `endcolumn` of line `endline` in file `filepath`.
    * For more information, see
-   * [LGTM locations](https://lgtm.com/help/ql/locations).
+   * [LGTM locations](https://help.semmle.com/QL/learn-ql/ql/locations.html).
    */
   predicate hasLocationInfo(
     string filepath, int startline, int startcolumn, int endline, int endcolumn
@@ -44,7 +44,7 @@ class LastLineOf extends Locatable {
    * The location spans column `startcolumn` of line `startline` to
    * column `endcolumn` of line `endline` in file `filepath`.
    * For more information, see
-   * [LGTM locations](https://lgtm.com/help/ql/locations).
+   * [LGTM locations](https://help.semmle.com/QL/learn-ql/ql/locations.html).
    */
   predicate hasLocationInfo(
     string filepath, int startline, int startcolumn, int endline, int endcolumn

--- a/javascript/ql/src/semmle/javascript/RestrictedLocations.qll
+++ b/javascript/ql/src/semmle/javascript/RestrictedLocations.qll
@@ -14,7 +14,7 @@ class FirstLineOf extends Locatable {
    * The location spans column `startcolumn` of line `startline` to
    * column `endcolumn` of line `endline` in file `filepath`.
    * For more information, see
-   * [LGTM locations](https://help.semmle.com/QL/learn-ql/ql/locations.html).
+   * [Locations](https://help.semmle.com/QL/learn-ql/ql/locations.html).
    */
   predicate hasLocationInfo(
     string filepath, int startline, int startcolumn, int endline, int endcolumn
@@ -44,7 +44,7 @@ class LastLineOf extends Locatable {
    * The location spans column `startcolumn` of line `startline` to
    * column `endcolumn` of line `endline` in file `filepath`.
    * For more information, see
-   * [LGTM locations](https://help.semmle.com/QL/learn-ql/ql/locations.html).
+   * [Locations](https://help.semmle.com/QL/learn-ql/ql/locations.html).
    */
   predicate hasLocationInfo(
     string filepath, int startline, int startcolumn, int endline, int endcolumn

--- a/javascript/ql/src/semmle/javascript/SSA.qll
+++ b/javascript/ql/src/semmle/javascript/SSA.qll
@@ -414,7 +414,7 @@ class SsaVariable extends TSsaDefinition {
    * The location spans column `startcolumn` of line `startline` to
    * column `endcolumn` of line `endline` in file `filepath`.
    * For more information, see
-   * [LGTM locations](https://help.semmle.com/QL/learn-ql/ql/locations.html).
+   * [Locations](https://help.semmle.com/QL/learn-ql/ql/locations.html).
    */
   predicate hasLocationInfo(
     string filepath, int startline, int startcolumn, int endline, int endcolumn
@@ -479,7 +479,7 @@ class SsaDefinition extends TSsaDefinition {
    * The location spans column `startcolumn` of line `startline` to
    * column `endcolumn` of line `endline` in file `filepath`.
    * For more information, see
-   * [LGTM locations](https://help.semmle.com/QL/learn-ql/ql/locations.html).
+   * [Locations](https://help.semmle.com/QL/learn-ql/ql/locations.html).
    */
   abstract predicate hasLocationInfo(
     string filepath, int startline, int startcolumn, int endline, int endcolumn

--- a/javascript/ql/src/semmle/javascript/SSA.qll
+++ b/javascript/ql/src/semmle/javascript/SSA.qll
@@ -414,7 +414,7 @@ class SsaVariable extends TSsaDefinition {
    * The location spans column `startcolumn` of line `startline` to
    * column `endcolumn` of line `endline` in file `filepath`.
    * For more information, see
-   * [LGTM locations](https://lgtm.com/help/ql/locations).
+   * [LGTM locations](https://help.semmle.com/QL/learn-ql/ql/locations.html).
    */
   predicate hasLocationInfo(
     string filepath, int startline, int startcolumn, int endline, int endcolumn
@@ -479,7 +479,7 @@ class SsaDefinition extends TSsaDefinition {
    * The location spans column `startcolumn` of line `startline` to
    * column `endcolumn` of line `endline` in file `filepath`.
    * For more information, see
-   * [LGTM locations](https://lgtm.com/help/ql/locations).
+   * [LGTM locations](https://help.semmle.com/QL/learn-ql/ql/locations.html).
    */
   abstract predicate hasLocationInfo(
     string filepath, int startline, int startcolumn, int endline, int endcolumn

--- a/javascript/ql/src/semmle/javascript/XML.qll
+++ b/javascript/ql/src/semmle/javascript/XML.qll
@@ -14,7 +14,7 @@ abstract class XMLLocatable extends @xmllocatable {
    * The location spans column `startcolumn` of line `startline` to
    * column `endcolumn` of line `endline` in file `filepath`.
    * For more information, see
-   * [LGTM locations](https://help.semmle.com/QL/learn-ql/ql/locations.html).
+   * [Locations](https://help.semmle.com/QL/learn-ql/ql/locations.html).
    */
   predicate hasLocationInfo(
     string filepath, int startline, int startcolumn, int endline, int endcolumn

--- a/javascript/ql/src/semmle/javascript/XML.qll
+++ b/javascript/ql/src/semmle/javascript/XML.qll
@@ -14,7 +14,7 @@ abstract class XMLLocatable extends @xmllocatable {
    * The location spans column `startcolumn` of line `startline` to
    * column `endcolumn` of line `endline` in file `filepath`.
    * For more information, see
-   * [LGTM locations](https://lgtm.com/help/ql/locations).
+   * [LGTM locations](https://help.semmle.com/QL/learn-ql/ql/locations.html).
    */
   predicate hasLocationInfo(
     string filepath, int startline, int startcolumn, int endline, int endcolumn

--- a/javascript/ql/src/semmle/javascript/dataflow/AbstractValues.qll
+++ b/javascript/ql/src/semmle/javascript/dataflow/AbstractValues.qll
@@ -109,7 +109,7 @@ class AbstractValue extends TAbstractValue {
    * The location spans column `startcolumn` of line `startline` to
    * column `endcolumn` of line `endline` in file `f`.
    * For more information, see
-   * [LGTM locations](https://help.semmle.com/QL/learn-ql/ql/locations.html).
+   * [Locations](https://help.semmle.com/QL/learn-ql/ql/locations.html).
    */
   predicate hasLocationInfo(string f, int startline, int startcolumn, int endline, int endcolumn) {
     f = "" and startline = 0 and startcolumn = 0 and endline = 0 and endcolumn = 0

--- a/javascript/ql/src/semmle/javascript/dataflow/AbstractValues.qll
+++ b/javascript/ql/src/semmle/javascript/dataflow/AbstractValues.qll
@@ -109,7 +109,7 @@ class AbstractValue extends TAbstractValue {
    * The location spans column `startcolumn` of line `startline` to
    * column `endcolumn` of line `endline` in file `f`.
    * For more information, see
-   * [LGTM locations](https://lgtm.com/help/ql/locations).
+   * [LGTM locations](https://help.semmle.com/QL/learn-ql/ql/locations.html).
    */
   predicate hasLocationInfo(string f, int startline, int startcolumn, int endline, int endcolumn) {
     f = "" and startline = 0 and startcolumn = 0 and endline = 0 and endcolumn = 0

--- a/javascript/ql/src/semmle/javascript/dataflow/Configuration.qll
+++ b/javascript/ql/src/semmle/javascript/dataflow/Configuration.qll
@@ -897,7 +897,7 @@ class PathNode extends TPathNode {
    * The location spans column `startcolumn` of line `startline` to
    * column `endcolumn` of line `endline` in file `filepath`.
    * For more information, see
-   * [LGTM locations](https://lgtm.com/help/ql/locations).
+   * [LGTM locations](https://help.semmle.com/QL/learn-ql/ql/locations.html).
    */
   predicate hasLocationInfo(
     string filepath, int startline, int startcolumn, int endline, int endcolumn

--- a/javascript/ql/src/semmle/javascript/dataflow/Configuration.qll
+++ b/javascript/ql/src/semmle/javascript/dataflow/Configuration.qll
@@ -897,7 +897,7 @@ class PathNode extends TPathNode {
    * The location spans column `startcolumn` of line `startline` to
    * column `endcolumn` of line `endline` in file `filepath`.
    * For more information, see
-   * [LGTM locations](https://help.semmle.com/QL/learn-ql/ql/locations.html).
+   * [Locations](https://help.semmle.com/QL/learn-ql/ql/locations.html).
    */
   predicate hasLocationInfo(
     string filepath, int startline, int startcolumn, int endline, int endcolumn

--- a/javascript/ql/src/semmle/javascript/dataflow/DataFlow.qll
+++ b/javascript/ql/src/semmle/javascript/dataflow/DataFlow.qll
@@ -115,7 +115,7 @@ module DataFlow {
      * The location spans column `startcolumn` of line `startline` to
      * column `endcolumn` of line `endline` in file `filepath`.
      * For more information, see
-     * [LGTM locations](https://help.semmle.com/QL/learn-ql/ql/locations.html).
+     * [Locations](https://help.semmle.com/QL/learn-ql/ql/locations.html).
      */
     predicate hasLocationInfo(
       string filepath, int startline, int startcolumn, int endline, int endcolumn

--- a/javascript/ql/src/semmle/javascript/dataflow/DataFlow.qll
+++ b/javascript/ql/src/semmle/javascript/dataflow/DataFlow.qll
@@ -115,7 +115,7 @@ module DataFlow {
      * The location spans column `startcolumn` of line `startline` to
      * column `endcolumn` of line `endline` in file `filepath`.
      * For more information, see
-     * [LGTM locations](https://lgtm.com/help/ql/locations).
+     * [LGTM locations](https://help.semmle.com/QL/learn-ql/ql/locations.html).
      */
     predicate hasLocationInfo(
       string filepath, int startline, int startcolumn, int endline, int endcolumn

--- a/javascript/ql/src/semmle/javascript/frameworks/xUnit.qll
+++ b/javascript/ql/src/semmle/javascript/frameworks/xUnit.qll
@@ -131,7 +131,7 @@ class XUnitAnnotation extends Expr {
    * The location spans column `startcolumn` of line `startline` to
    * column `endcolumn` of line `endline` in file `filepath`.
    * For more information, see
-   * [LGTM locations](https://help.semmle.com/QL/learn-ql/ql/locations.html).
+   * [Locations](https://help.semmle.com/QL/learn-ql/ql/locations.html).
    */
   predicate hasLocationInfo(
     string filepath, int startline, int startcolumn, int endline, int endcolumn

--- a/javascript/ql/src/semmle/javascript/frameworks/xUnit.qll
+++ b/javascript/ql/src/semmle/javascript/frameworks/xUnit.qll
@@ -131,7 +131,7 @@ class XUnitAnnotation extends Expr {
    * The location spans column `startcolumn` of line `startline` to
    * column `endcolumn` of line `endline` in file `filepath`.
    * For more information, see
-   * [LGTM locations](https://lgtm.com/help/ql/locations).
+   * [LGTM locations](https://help.semmle.com/QL/learn-ql/ql/locations.html).
    */
   predicate hasLocationInfo(
     string filepath, int startline, int startcolumn, int endline, int endcolumn

--- a/python/ql/src/analysis/AlertSuppression.ql
+++ b/python/ql/src/analysis/AlertSuppression.ql
@@ -106,7 +106,7 @@ class SuppressionScope extends @py_comment {
      * The location spans column `startcolumn` of line `startline` to
      * column `endcolumn` of line `endline` in file `filepath`.
      * For more information, see
-     * [LGTM locations](https://help.semmle.com/QL/learn-ql/ql/locations.html).
+     * [Locations](https://help.semmle.com/QL/learn-ql/ql/locations.html).
      */
      predicate hasLocationInfo(string filepath, int startline, int startcolumn, int endline, int endcolumn) {
        this.(SuppressionComment).covers(filepath, startline, startcolumn, endline, endcolumn)

--- a/python/ql/src/analysis/AlertSuppression.ql
+++ b/python/ql/src/analysis/AlertSuppression.ql
@@ -106,7 +106,7 @@ class SuppressionScope extends @py_comment {
      * The location spans column `startcolumn` of line `startline` to
      * column `endcolumn` of line `endline` in file `filepath`.
      * For more information, see
-     * [LGTM locations](https://lgtm.com/help/ql/locations).
+     * [LGTM locations](https://help.semmle.com/QL/learn-ql/ql/locations.html).
      */
      predicate hasLocationInfo(string filepath, int startline, int startcolumn, int endline, int endcolumn) {
        this.(SuppressionComment).covers(filepath, startline, startcolumn, endline, endcolumn)

--- a/python/ql/src/external/CodeDuplication.qll
+++ b/python/ql/src/external/CodeDuplication.qll
@@ -12,7 +12,7 @@ string relativePath(File file) {
  * Holds if the `index`-th token of block `copy` is in file `file`, spanning
  * column `sc` of line `sl` to column `ec` of line `el`.
  *
- * For more information, see [LGTM locations](https://lgtm.com/help/ql/locations).
+ * For more information, see [LGTM locations](https://help.semmle.com/QL/learn-ql/ql/locations.html).
  */
 pragma[noinline, nomagic]
 private predicate tokenLocation(File file, int sl, int sc, int ec, int el, Copy copy, int index) {
@@ -82,7 +82,7 @@ class Copy extends @duplication_or_similarity
      * The location spans column `startcolumn` of line `startline` to
      * column `endcolumn` of line `endline` in file `filepath`.
      * For more information, see
-     * [LGTM locations](https://lgtm.com/help/ql/locations).
+     * [LGTM locations](https://help.semmle.com/QL/learn-ql/ql/locations.html).
      */
     predicate hasLocationInfo(string filepath, int startline, int startcolumn, int endline, int endcolumn) {
         sourceFile().getName() = filepath and

--- a/python/ql/src/external/CodeDuplication.qll
+++ b/python/ql/src/external/CodeDuplication.qll
@@ -12,7 +12,7 @@ string relativePath(File file) {
  * Holds if the `index`-th token of block `copy` is in file `file`, spanning
  * column `sc` of line `sl` to column `ec` of line `el`.
  *
- * For more information, see [LGTM locations](https://help.semmle.com/QL/learn-ql/ql/locations.html).
+ * For more information, see [Locations](https://help.semmle.com/QL/learn-ql/ql/locations.html).
  */
 pragma[noinline, nomagic]
 private predicate tokenLocation(File file, int sl, int sc, int ec, int el, Copy copy, int index) {
@@ -82,7 +82,7 @@ class Copy extends @duplication_or_similarity
      * The location spans column `startcolumn` of line `startline` to
      * column `endcolumn` of line `endline` in file `filepath`.
      * For more information, see
-     * [LGTM locations](https://help.semmle.com/QL/learn-ql/ql/locations.html).
+     * [Locations](https://help.semmle.com/QL/learn-ql/ql/locations.html).
      */
     predicate hasLocationInfo(string filepath, int startline, int startcolumn, int endline, int endcolumn) {
         sourceFile().getName() = filepath and

--- a/python/ql/src/external/DefectFilter.qll
+++ b/python/ql/src/external/DefectFilter.qll
@@ -8,7 +8,7 @@ import semmle.python.Files
  * column `startcol` of line `startline` to column `endcol` of line `endline`
  * in file `filepath`.
  *
- * For more information, see [LGTM locations](https://lgtm.com/help/ql/locations).
+ * For more information, see [LGTM locations](https://help.semmle.com/QL/learn-ql/ql/locations.html).
  */
 external predicate defectResults(int id, string queryPath, string filepath, int startline,
                                  int startcol, int endline, int endcol, string message);

--- a/python/ql/src/external/DefectFilter.qll
+++ b/python/ql/src/external/DefectFilter.qll
@@ -8,7 +8,7 @@ import semmle.python.Files
  * column `startcol` of line `startline` to column `endcol` of line `endline`
  * in file `filepath`.
  *
- * For more information, see [LGTM locations](https://help.semmle.com/QL/learn-ql/ql/locations.html).
+ * For more information, see [Locations](https://help.semmle.com/QL/learn-ql/ql/locations.html).
  */
 external predicate defectResults(int id, string queryPath, string filepath, int startline,
                                  int startcol, int endline, int endcol, string message);

--- a/python/ql/src/semmle/python/Files.qll
+++ b/python/ql/src/semmle/python/Files.qll
@@ -321,7 +321,7 @@ abstract class Container extends @container {
     /**
      * Gets a URL representing the location of this container.
      *
-     * For more information see https://lgtm.com/help/ql/locations#providing-urls.
+     * For more information see https://help.semmle.com/QL/learn-ql/ql/locations.html#providing-urls.
      */
     abstract string getURL();
 

--- a/python/ql/src/semmle/python/Files.qll
+++ b/python/ql/src/semmle/python/Files.qll
@@ -321,7 +321,7 @@ abstract class Container extends @container {
     /**
      * Gets a URL representing the location of this container.
      *
-     * For more information see https://help.semmle.com/QL/learn-ql/ql/locations.html#providing-urls.
+     * For more information see [Providing URLs](https://help.semmle.com/QL/learn-ql/ql/locations.html#providing-urls).
      */
     abstract string getURL();
 


### PR DESCRIPTION
Some of the `.qll` library files contained to links to QL help topics on lgtm.com/help as described here: https://jira.semmle.com/browse/SD-2999.

These links have been changed to the equivalent topic on help.semmle.com so that they don't break when we further consolidate the QL documentation.

In separate commits, I have also done the same for `.ql` files, and in a few files where links to `lgtm.com/docs` were present.

I think this deals with all of the links. If you think think that the text should be changed (e.g. LGTM locations > query locations, or something along those lines) I'll deal with that in a separate PR.