### PR TITLE
Python: Convert objects to ADTs.

### DIFF
--- a/python/ql/src/Classes/ClassAttributes.qll
+++ b/python/ql/src/Classes/ClassAttributes.qll
@@ -130,7 +130,7 @@ class CheckClass extends ClassObject {
 
 
 private Object object_getattribute() {
-    py_cmembers_versioned(theObjectType(), "__getattribute__", result, major_version().toString())
+    py_cmembers_versioned(theObjectType().asBuiltin(), "__getattribute__", result.asBuiltin(), major_version().toString())
 }
 
 private predicate auto_name(string name) {

--- a/python/ql/src/Variables/SuspiciousUnusedLoopIterationVariable.ql
+++ b/python/ql/src/Variables/SuspiciousUnusedLoopIterationVariable.ql
@@ -51,7 +51,7 @@ predicate points_to_call_to_range(ControlFlowNode f) {
         range = builtin_object("xrange")
     |
         f.refersTo(call) and
-        call.(CallNode).getFunction().refersTo(range)
+        call.asCfgNode().(CallNode).getFunction().refersTo(range)
     )
     or
     /* In case points-to fails due to 'from six.moves import range' or similar. */
@@ -62,7 +62,7 @@ predicate points_to_call_to_range(ControlFlowNode f) {
     or
     /* If range is wrapped in a list it is still a range */
     exists(CallNode call |
-        f.refersTo(call) and
+        f.refersTo(Object::fromCfgNode(call)) and
         call = theListType().getACall() and
         points_to_call_to_range(call.getArg(0))
     )

--- a/python/ql/src/analysis/CrossProjectDefinitions.qll
+++ b/python/ql/src/analysis/CrossProjectDefinitions.qll
@@ -103,13 +103,13 @@ class Symbol extends TSymbol {
 /* Helper for `Symbol`.resolvesTo() */
 private Object attribute_in_scope(Object obj, string name) {
     exists(ClassObject cls |
-        cls = obj |
-        cls.lookupAttribute(name) = result and result.(ControlFlowNode).getScope() = cls.getPyClass()
+        cls = obj and exists(cls.getPyClass()) and
+        cls.declaredAttribute(name) = result
     )
     or
-    exists(ModuleObject mod |
+    exists(PythonModuleObject mod |
         mod = obj |
-        mod.getAttribute(name) = result and result.(ControlFlowNode).getScope() = mod.getModule()
-        and not result.(ControlFlowNode).isEntryNode()
+        mod.getAttribute(name) = result and result.asCfgNode().(ControlFlowNode).getScope() = mod.getModule()
+        and not result.asCfgNode().(ControlFlowNode).isEntryNode()
     )
 }

--- a/python/ql/src/analysis/DefinitionTracking.qll
+++ b/python/ql/src/analysis/DefinitionTracking.qll
@@ -65,7 +65,7 @@ private predicate jump_to_defn(ControlFlowNode use, Definition defn) {
         scope_jump_to_defn_attribute(package.getInitModule().getModule(), name, defn)
     )
     or
-    (use instanceof PyFunctionObject or use instanceof ClassObject) and
+    (use = any(PyFunctionObject func).asCfgNode() or use = any(ClassObject cls).asCfgNode()) and
     defn.getAstNode() = use.getNode()
 }
 

--- a/python/ql/src/analysis/Sanity.ql
+++ b/python/ql/src/analysis/Sanity.ql
@@ -75,31 +75,31 @@ string best_description_builtin_object(Object o) {
     (
         result = o.toString()
         or
-        not exists(o.toString()) and py_cobjectnames(o, result)
+        not exists(o.toString()) and result = o.getBuiltinName()
         or
-        not exists(o.toString()) and not py_cobjectnames(o, _) and result = "builtin object of type " + o.getAnInferredType().toString()
+        not exists(o.toString()) and not py_cobjectnames(o.asBuiltin(), _) and result = "builtin object of type " + o.getAnInferredType().toString()
         or
-        not exists(o.toString()) and not py_cobjectnames(o, _) and not exists(o.getAnInferredType().toString()) and result = "builtin object"
+        not exists(o.toString()) and not py_cobjectnames(o.asBuiltin(), _) and not exists(o.getAnInferredType().toString()) and result = "builtin object"
     )
 }
 
 private predicate introspected_builtin_object(Object o) {
     /* Only check objects from the extractor, missing data for objects generated from C source code analysis is OK.
      * as it will be ignored if it doesn't match up with the introspected form. */
-    py_cobject_sources(o, 0)
+    py_cobject_sources(o.asBuiltin(), 0)
 }
 
 predicate builtin_object_sanity(string clsname, string problem, string what) {
     exists(Object o |
         clsname = o.getAQlClass() and what = best_description_builtin_object(o) and introspected_builtin_object(o) |
-        not exists(o.getAnInferredType()) and not py_cobjectnames(o, _) and problem = "neither name nor type"
+        not exists(o.getAnInferredType()) and not exists(o.getBuiltinName()) and problem = "neither name nor type"
         or
-        uniqueness_error(count(string name | py_cobjectnames(o, name)), "name", problem)
+        uniqueness_error(count(string name | name = o.getBuiltinName()), "name", problem)
         or
         not exists(o.getAnInferredType()) and problem = "no results for getAnInferredType"
         or
         not exists(o.toString()) and problem = "no toString" and 
-        not exists(string name | name.prefix(7) = "_semmle" | py_special_objects(o, name)) and
+        not exists(string name | name.prefix(7) = "_semmle" | py_special_objects(o.asBuiltin(), name)) and
         not o = unknownValue()
     )
 }

--- a/python/ql/src/semmle/python/Exprs.qll
+++ b/python/ql/src/semmle/python/Exprs.qll
@@ -79,7 +79,7 @@ class Expr extends Expr_, AstNode {
      * `ControlFlowNode.refersTo(...)` instead.
      */
     predicate refersTo(Object value, ClassObject cls, AstNode origin) {
-        not py_special_objects(cls, "_semmle_unknown_type")
+        not cls = theUnknownType()
         and
         not value = unknownValue()
         and
@@ -89,7 +89,7 @@ class Expr extends Expr_, AstNode {
     /** Gets what this expression might "refer-to" in the given `context`.
      */
     predicate refersTo(Context context, Object value, ClassObject cls, AstNode origin) {
-        not py_special_objects(cls, "_semmle_unknown_type")
+        not cls = theUnknownType()
         and
         PointsTo::points_to(this.getAFlowNode(), context, value, cls, origin.getAFlowNode())
     }
@@ -308,8 +308,8 @@ class Bytes extends StrConst {
     }
 
     override Object getLiteralObject() {
-        py_cobjecttypes(result, theBytesType()) and
-        py_cobjectnames(result, this.quotedString())
+        result.getBuiltinClass() = theBytesType() and
+        result.getBuiltinName() = this.quotedString()
     }
 
     /** The extractor puts quotes into the name of each string (to prevent "0" clashing with 0).
@@ -378,9 +378,12 @@ class IntegerLiteral extends Num {
     }
 
     override Object getLiteralObject() {
-        py_cobjecttypes(result, theIntType()) and py_cobjectnames(result, this.getN())
-        or
-        py_cobjecttypes(result, theLongType()) and py_cobjectnames(result, this.getN())   
+        (
+            result.getBuiltinClass() = theIntType()
+            or
+            result.getBuiltinClass() = theLongType()
+        ) and
+        result.getBuiltinName() = this.getN()
     }
 
     override boolean booleanValue() {
@@ -408,7 +411,7 @@ class FloatLiteral extends Num {
     }
 
     override Object getLiteralObject() {
-        py_cobjecttypes(result, theFloatType()) and py_cobjectnames(result, this.getN())   
+        result.getBuiltinClass() = theFloatType() and result.getBuiltinName() = this.getN()
     }
 
     override boolean booleanValue() {
@@ -440,7 +443,7 @@ class ImaginaryLiteral extends Num {
     }
 
     override Object getLiteralObject() {
-        py_cobjecttypes(result, theComplexType()) and py_cobjectnames(result, this.getN())   
+        result.getBuiltinClass() = theComplexType() and result.getBuiltinName() = this.getN()
     }
 
     override boolean booleanValue() {
@@ -463,8 +466,8 @@ class Unicode extends StrConst {
     }
 
     override Object getLiteralObject() {
-        py_cobjecttypes(result, theUnicodeType()) and
-        py_cobjectnames(result, this.quotedString())
+        result.getBuiltinClass() = theUnicodeType() and
+        result.getBuiltinName() = this.quotedString()
     }
 
     /** The extractor puts quotes into the name of each string (to prevent "0" clashing with 0).
@@ -502,7 +505,7 @@ class Dict extends Dict_ {
         result = this.getAValue() or result = this.getAKey()
     }
 
-    AstNode getAChildNode() {
+    override AstNode getAChildNode() {
         result = this.getAnItem()
     }
 

--- a/python/ql/src/semmle/python/Flow.qll
+++ b/python/ql/src/semmle/python/Flow.qll
@@ -223,7 +223,7 @@ class ControlFlowNode extends @py_flow_node {
      *  If the class is unimportant then use `refersTo(value)` or `refersTo(value, origin)` instead.
      */
     predicate refersTo(Object value, ClassObject cls, ControlFlowNode origin) {
-        not py_special_objects(cls, "_semmle_unknown_type")
+        not cls = theUnknownType()
         and
         not value = unknownValue()
         and
@@ -233,7 +233,7 @@ class ControlFlowNode extends @py_flow_node {
     /** Gets what this expression might "refer-to" in the given `context`.
      */
     predicate refersTo(Context context, Object value, ClassObject cls, ControlFlowNode origin) {
-        not py_special_objects(cls, "_semmle_unknown_type")
+        not cls = theUnknownType()
         and
         PointsTo::points_to(this, context, value, cls, origin)
     }

--- a/python/ql/src/semmle/python/Import.qll
+++ b/python/ql/src/semmle/python/Import.qll
@@ -14,7 +14,7 @@ class Alias extends Alias_ {
 private predicate valid_module_name(string name) {
     exists(Module m | m.getName() = name)
     or
-    exists(Object cmod | py_cobjecttypes(cmod, theModuleType()) and py_cobjectnames(cmod, name))
+    exists(Object cmod | cmod.getBuiltinClass() = theModuleType() and cmod.getBuiltinName() = name)
 }
 
 /** An artificial expression representing an import */

--- a/python/ql/src/semmle/python/dependencies/Dependencies.qll
+++ b/python/ql/src/semmle/python/dependencies/Dependencies.qll
@@ -28,7 +28,7 @@ private predicate importDependency(Object target, AstNode source) {
             exists(ImportMember im | imp_stmt.contains(im) |
                 importee.importedAs(im.getModule().(ImportExpr).getImportedModuleName())  
                 and
-                defn_of_module_attribute(target, importee.getModule(), im.getName())
+                defn_of_module_attribute(target.asCfgNode(), importee.getModule(), im.getName())
             )
         )
     )
@@ -48,7 +48,7 @@ class PythonImport extends DependencyKind {
 }
 
 private predicate interesting(Object target) {
-    target.(ControlFlowNode).getNode() instanceof Scope
+    target.asCfgNode().(ControlFlowNode).getNode() instanceof Scope
     or
     target instanceof FunctionObject
     or
@@ -66,7 +66,7 @@ class PythonUse extends DependencyKind {
     override predicate isADependency(AstNode source, Object target) {
         interesting(target) and
         this = this and
-        source != target.(ControlFlowNode).getNode() and
+        source != target.asCfgNode().(ControlFlowNode).getNode() and
         exists(ControlFlowNode use, Object obj |
             use.getNode() = source and
             use.refersTo(obj) and
@@ -156,13 +156,13 @@ private predicate use_of_attribute(Attribute attr, Scope s, string name) {
 
 private predicate defn_of_attribute(Object target, Scope s, string name) {
     exists(Assign asgn |
-        target.(ControlFlowNode).getNode() = asgn |
+        target.asCfgNode().(ControlFlowNode).getNode() = asgn |
         defn_of_instance_attribute(asgn, s, name)
         or
         defn_of_class_attribute(asgn, s, name)
     )
     or
-    defn_of_module_attribute(target, s, name)
+    defn_of_module_attribute(target.asCfgNode(), s, name)
 }
 
 /* Whether asgn defines an instance attribute, that is does

--- a/python/ql/src/semmle/python/pointsto/PointsTo.qll
+++ b/python/ql/src/semmle/python/pointsto/PointsTo.qll
@@ -31,15 +31,39 @@ private import Filters as BaseFilters
 import semmle.dataflow.SSA
 private import MRO
 
-library class ObjectOrCfg extends @py_object {
+//library class ObjectOrCfg extends @py_object {
+//
+//    string toString() {
+//        /* Not to be displayed */
+//        none()
+//    }
+//
+//    ControlFlowNode getOrigin() {
+//        result = this
+//    }
+//
+//    /** Get a `ControlFlowNode` from `this` or `here`.
+//     * If `this` is a ControlFlowNode then use that, otherwise fall back on `here`
+//     */
+//    pragma[inline]
+//    ControlFlowNode fromObjectOrHere(ControlFlowNode here) {
+//        result = this
+//        or
+//        not this instanceof ControlFlowNode and result = here
+//    }
+//
+//}
+
+private newtype TObjectOrCfg =
+    TUnknownOrigin()
+    or
+    TCfgOrigin(ControlFlowNode f)
+
+library class ObjectOrCfg extends TObjectOrCfg {
 
     string toString() {
         /* Not to be displayed */
         none()
-    }
-
-    ControlFlowNode getOrigin() {
-        result = this
     }
 
     /** Get a `ControlFlowNode` from `this` or `here`.
@@ -47,9 +71,30 @@ library class ObjectOrCfg extends @py_object {
      */
     pragma[inline]
     ControlFlowNode fromObjectOrHere(ControlFlowNode here) {
-        result = this
+        this = TUnknownOrigin() and result = here
         or
-        not this instanceof ControlFlowNode and result = here
+        this = TCfgOrigin(result)
+    }
+
+    ControlFlowNode toCfgNode() {
+        this = TCfgOrigin(result)
+    }
+
+    ObjectOrCfg fix(ControlFlowNode here) {
+        this = TUnknownOrigin() and result = TCfgOrigin(here)
+        or
+        not this = TUnknownOrigin() and result = this
+    }
+}
+
+module ObjectOrCfg {
+
+    ObjectOrCfg fromCfgNode(ControlFlowNode f) {
+        result = TCfgOrigin(f)
+    }
+
+    ObjectOrCfg unknown() {
+        result = TUnknownOrigin()
     }
 
 }
@@ -127,7 +172,7 @@ module PointsTo {
         /** INTERNAL -- Do not use.
          *
          * Holds if `package.name` points to `(value, cls, origin)`, where `package` is a package object. */
-        cached predicate package_attribute_points_to(PackageObject package, string name, Object value, ClassObject cls, ControlFlowNode origin) {
+        cached predicate package_attribute_points_to(PackageObject package, string name, Object value, ClassObject cls, ObjectOrCfg origin) {
             py_module_attributes(package.getInitModule().getModule(), name, value, cls, origin)
             or
             exists(Module init |
@@ -140,20 +185,19 @@ module PointsTo {
                     imp.isImport()
                 )
             ) and explicitly_imported(value) and
-            value = package.submodule(name) and cls = theModuleType() and origin = value
+            value = package.submodule(name) and cls = theModuleType() and origin = ObjectOrCfg::fromCfgNode(value)
         }
 
         /** INTERNAL -- `Use m.attributeRefersTo(name, obj, origin)` instead.
          *
          * Holds if `m.name` points to `(value, cls, origin)`, where `m` is a (source) module. */
-        cached predicate py_module_attributes(Module m, string name, Object obj, ClassObject cls, ControlFlowNode origin) {
-            exists(EssaVariable var, ControlFlowNode exit, ObjectOrCfg orig, PointsToContext imp |
+        cached predicate py_module_attributes(Module m, string name, Object obj, ClassObject cls, ObjectOrCfg origin) {
+            exists(EssaVariable var, ControlFlowNode exit, PointsToContext imp |
                 exit =  m.getANormalExit() and var.getAUse() = exit and
                 var.getSourceVariable().getName() = name and
-                ssa_variable_points_to(var, imp, obj, cls, orig) and
+                ssa_variable_points_to(var, imp, obj, cls, origin) and
                 imp.isImport() and
-                obj != undefinedVariable() |
-                origin = orig.fromObjectOrHere(exit)
+                obj != undefinedVariable()
             )
             or
             not exists(EssaVariable var | var.getAUse() = m.getANormalExit() and var.getSourceVariable().getName() = name) and
@@ -431,7 +475,7 @@ module PointsTo {
             or
             package_attribute_points_to(mod, name, value, cls, origin)
             or
-            builtin_module_attribute(mod, name, value, cls) and origin = value
+            builtin_module_attribute(mod, name, value, cls) and origin = TUnknownOrigin()
         }
 
     }
@@ -470,7 +514,10 @@ module PointsTo {
         or
         attribute_load_points_to(f, context, value, cls, origin)
         or
-        getattr_points_to(f, context, value, cls, origin)
+        exists(ObjectOrCfg orig |
+            getattr_points_to(f, context, value, cls, orig) and
+            origin = orig.fromObjectOrHere(f)
+        )
         or
         if_exp_points_to(f, context, value, cls, origin)
         or
@@ -560,11 +607,15 @@ module PointsTo {
     private predicate global_lookup_points_to_maybe_origin(NameNode f, PointsToContext context, Object value, ClassObject cls, ObjectOrCfg origin_or_obj) {
         ssa_variable_points_to(global_variable(f), context, value, cls, origin_or_obj)
         or
-        ssa_variable_points_to(global_variable(f), context, undefinedVariable(), _, _) and
-        potential_builtin_points_to(f, value, cls, origin_or_obj)
-        or
-        not exists(global_variable(f)) and context.appliesToScope(f.getScope()) and
-        potential_builtin_points_to(f, value, cls, origin_or_obj)
+        exists(ControlFlowNode origin |
+            origin_or_obj = ObjectOrCfg::fromCfgNode(origin)
+            |
+            ssa_variable_points_to(global_variable(f), context, undefinedVariable(), _, _) and
+            potential_builtin_points_to(f, value, cls, origin)
+            or
+            not exists(global_variable(f)) and context.appliesToScope(f.getScope()) and
+            potential_builtin_points_to(f, value, cls, origin)
+        )
     }
 
     /** Gets an object pointed to by a use (of a variable). */
@@ -597,7 +648,10 @@ module PointsTo {
         Types::class_attribute_lookup(obj, name, value, cls, orig) and cls != theStaticMethodType() and cls != theClassMethodType()
         or
         /* Static methods of the class */
-        exists(CallNode sm | Types::class_attribute_lookup(obj, name, sm, theStaticMethodType(), _) and sm.getArg(0) = value and cls = thePyFunctionType() and orig = value)
+        exists(CallNode sm | 
+            Types::class_attribute_lookup(obj, name, sm, theStaticMethodType(), _) and sm.getArg(0) = value and 
+            cls = thePyFunctionType() and orig = ObjectOrCfg::fromCfgNode(sm.getArg(0))
+        )
         or
         /* Module attributes */
         Layer::module_attribute_points_to(obj, name, value, cls, orig)
@@ -608,7 +662,10 @@ module PointsTo {
     private predicate instance_attribute_load_points_to(AttrNode f, PointsToContext context, Object value, ClassObject cls, ControlFlowNode origin) {
         f.isLoad() and
         exists(string name |
-            named_attribute_points_to(f.getObject(name), context, name, value, cls, origin)
+            exists(ObjectOrCfg orig |
+                origin = orig.fromObjectOrHere(f) and
+                named_attribute_points_to(f.getObject(name), context, name, value, cls, orig)
+            )
             or
             /* Static methods on the class of the instance */
             exists(CallNode sm, ClassObject icls |
@@ -692,7 +749,7 @@ module PointsTo {
     }
 
     /** Holds if `f`  is of the form `getattr(x, "name")` and x.name points to `(value, cls, origin)`. */
-    private predicate getattr_points_to(CallNode f, PointsToContext context, Object value, ClassObject cls, ControlFlowNode origin) {
+    private predicate getattr_points_to(CallNode f, PointsToContext context, Object value, ClassObject cls, ObjectOrCfg origin) {
         exists(ControlFlowNode arg, string name |
             named_attribute_points_to(arg, context, name, value, cls, origin) and
             getattr(f, arg, name)
@@ -980,7 +1037,7 @@ module PointsTo {
         )
     }
 
-    predicate named_attribute_points_to(ControlFlowNode f, PointsToContext context, string name, Object value, ClassObject cls, ControlFlowNode origin) {
+    predicate named_attribute_points_to(ControlFlowNode f, PointsToContext context, string name, Object value, ClassObject cls, ObjectOrCfg origin) {
         exists(EssaVariable var |
             var.getAUse() = f |
             SSA::ssa_variable_named_attribute_points_to(var, context, name, value, cls, origin)
@@ -1403,7 +1460,10 @@ module PointsTo {
         predicate ssa_definition_points_to(EssaDefinition def, PointsToContext context, Object value, ClassObject cls, ObjectOrCfg origin) {
             ssa_phi_points_to(def, context, value, cls, origin)
             or
-            ssa_node_definition_points_to(def, context, value, cls, origin)
+            exists(ControlFlowNode orig |
+                ssa_node_definition_points_to(def, context, value, cls, orig) and
+                origin = ObjectOrCfg::fromCfgNode(orig)
+            )
             or
             Filters::ssa_filter_definition_points_to(def, context, value, cls, origin)
             or
@@ -1411,7 +1471,7 @@ module PointsTo {
         }
 
         pragma [nomagic]
-        private predicate ssa_node_definition_points_to_unpruned(EssaNodeDefinition def, PointsToContext context, Object value, ClassObject cls, ObjectOrCfg origin) {
+        private predicate ssa_node_definition_points_to_unpruned(EssaNodeDefinition def, PointsToContext context, Object value, ClassObject cls, ControlFlowNode origin) {
             assignment_points_to(def, context, value, cls, origin)
             or
             parameter_points_to(def, context, value, cls, origin)
@@ -1420,11 +1480,11 @@ module PointsTo {
             or
             delete_points_to(def, context, value, cls, origin)
             or
+            module_name_points_to(def, context, value, cls, origin)
+            or
             scope_entry_points_to(def, context, value, cls, origin)
             or
             implicit_submodule_points_to(def, context, value, cls, origin)
-            or
-            module_name_points_to(def, context, value, cls, origin)
             or
             iteration_definition_points_to(def, context, value, cls, origin)
             /*
@@ -1438,7 +1498,7 @@ module PointsTo {
         }
 
         pragma [noinline]
-        private predicate ssa_node_definition_points_to(EssaNodeDefinition def, PointsToContext context, Object value, ClassObject cls, ObjectOrCfg origin) {
+        private predicate ssa_node_definition_points_to(EssaNodeDefinition def, PointsToContext context, Object value, ClassObject cls, ControlFlowNode origin) {
             reachable_definitions(def) and
             ssa_node_definition_points_to_unpruned(def, context, value, cls, origin)
         }
@@ -1583,8 +1643,9 @@ module PointsTo {
                 neither_class_nor_static_method(scope)
             )
             or
-            exists(EssaVariable obj, PointsToContext caller |
-                ssa_variable_points_to(obj, caller, value, cls, origin) and
+            exists(EssaVariable obj, PointsToContext caller, ObjectOrCfg orig |
+                origin = orig.fromObjectOrHere(def.getDefiningNode()) and
+                ssa_variable_points_to(obj, caller, value, cls, orig) and
                 callsite_self_argument_transfer(obj, caller, def, context)
             )
             or
@@ -1640,7 +1701,7 @@ module PointsTo {
          * PointsTo isn't exactly how the interpreter works, but is the best approximation we can manage statically.
          */
         pragma [noinline]
-        private predicate implicit_submodule_points_to(ImplicitSubModuleDefinition def, PointsToContext context, Object value, ClassObject cls, ObjectOrCfg origin) {
+        private predicate implicit_submodule_points_to(ImplicitSubModuleDefinition def, PointsToContext context, Object value, ClassObject cls, ControlFlowNode origin) {
             exists(PackageObject package |
                 package.getInitModule().getModule() = def.getDefiningNode().getScope() |
                 value = package.submodule(def.getSourceVariable().getName()) and
@@ -1652,7 +1713,7 @@ module PointsTo {
 
         /** Implicit "definition" of `__name__` at the start of a module. */
         pragma [noinline]
-        private predicate module_name_points_to(ScopeEntryDefinition def, PointsToContext context, Object value, ClassObject cls, ObjectOrCfg origin) {
+        private predicate module_name_points_to(ScopeEntryDefinition def, PointsToContext context, Object value, ClassObject cls, ControlFlowNode origin) {
             def.getVariable().getName() = "__name__" and
             exists(Module m |
                 m = def.getScope()
@@ -1676,18 +1737,19 @@ module PointsTo {
 
         /** Definition of iteration variable in loop */
         pragma [noinline]
-        private predicate iteration_definition_points_to(IterationDefinition def, PointsToContext context, Object value, ClassObject cls, ObjectOrCfg origin) {
+        private predicate iteration_definition_points_to(IterationDefinition def, PointsToContext context, Object value, ClassObject cls, ControlFlowNode origin) {
             points_to(def.getSequence(), context, unknownValue(), _, _) and
             value = unknownValue() and cls = theUnknownType() and origin = def.getDefiningNode()
         }
 
         /** Points-to for implicit variable declarations at scope-entry. */
         pragma [noinline]
-        private predicate scope_entry_points_to(ScopeEntryDefinition def, PointsToContext context, Object value, ClassObject cls, ObjectOrCfg origin) {
+        private predicate scope_entry_points_to(ScopeEntryDefinition def, PointsToContext context, Object value, ClassObject cls, ControlFlowNode origin) {
             /* Transfer from another scope */
-            exists(EssaVariable var, PointsToContext outer |
+            exists(EssaVariable var, PointsToContext outer, ObjectOrCfg orig |
                 Flow::scope_entry_value_transfer(var, outer, def, context) and
-                ssa_variable_points_to(var, outer, value, cls, origin)
+                ssa_variable_points_to(var, outer, value, cls, orig) and
+                origin = orig.fromObjectOrHere(def.getDefiningNode())
             )
             or
             /* Undefined variable */
@@ -1707,7 +1769,7 @@ module PointsTo {
                 mod = def.getScope().getEnclosingModule() and
                 context.appliesToScope(def.getScope()) and
                 not exists(EssaVariable v | v.getSourceVariable() = var and v.getScope() = mod) and
-                builtin_name_points_to(var.getId(), value, cls) and origin = value
+                builtin_name_points_to(var.getId(), value, cls) and origin = def.getDefiningNode()
             )
         }
 
@@ -1765,17 +1827,21 @@ module PointsTo {
 
         /** Points-to for `from ... import *`. */
         private predicate import_star_points_to(ImportStarRefinement def, PointsToContext context, Object value, ClassObject cls, ObjectOrCfg origin) {
-            exists(ModuleObject mod, string name |
-                Flow::module_and_name_for_import_star(mod, name, def, context) |
-                /* Attribute from imported module */
-                module_exports(mod, name) and
-                Layer::module_attribute_points_to(mod, name, value, cls, origin)
-            )
-            or
-            exists(EssaVariable var |
-                /* Retain value held before import */
-                Flow::variable_not_redefined_by_import_star(var, context, def) and
-                ssa_variable_points_to(var, context, value, cls, origin)
+            exists(ObjectOrCfg orig |
+                origin = orig.fix(def.getDefiningNode())
+                |
+                exists(ModuleObject mod, string name |
+                    Flow::module_and_name_for_import_star(mod, name, def, context) |
+                    /* Attribute from imported module */
+                    module_exports(mod, name) and
+                    Layer::module_attribute_points_to(mod, name, value, cls, orig)
+                )
+                or
+                exists(EssaVariable var |
+                    /* Retain value held before import */
+                    Flow::variable_not_redefined_by_import_star(var, context, def) and
+                    ssa_variable_points_to(var, context, value, cls, orig)
+                )
             )
         }
 
@@ -1784,7 +1850,7 @@ module PointsTo {
         private predicate attribute_assignment_points_to(AttributeAssignment def, PointsToContext context, Object value, ClassObject cls, ObjectOrCfg origin) {
             if def.getName() = "__class__" then
                 ssa_variable_points_to(def.getInput(), context, value, _, _) and points_to(def.getValue(), _, cls, _,_) and
-                origin = def.getDefiningNode()
+                origin = ObjectOrCfg::fromCfgNode(def.getDefiningNode())
             else
                 ssa_variable_points_to(def.getInput(), context, value, cls, origin)
         }
@@ -1811,15 +1877,18 @@ module PointsTo {
          *
          * Hold if the attribute `name` of the ssa variable `var` refers to `(value, cls, origin)`.
          */
-        predicate ssa_variable_named_attribute_points_to(EssaVariable var, PointsToContext context, string name, Object value, ClassObject cls, ControlFlowNode origin) {
+        predicate ssa_variable_named_attribute_points_to(EssaVariable var, PointsToContext context, string name, Object value, ClassObject cls, ObjectOrCfg origin) {
             ssa_definition_named_attribute_points_to(var.getDefinition(), context, name, value, cls, origin)
         }
 
         /** Helper for `ssa_variable_named_attribute_points_to`. */
-        private predicate ssa_definition_named_attribute_points_to(EssaDefinition def, PointsToContext context, string name, Object value, ClassObject cls, ControlFlowNode origin) {
+        private predicate ssa_definition_named_attribute_points_to(EssaDefinition def, PointsToContext context, string name, Object value, ClassObject cls, ObjectOrCfg origin) {
             ssa_phi_named_attribute_points_to(def, context, name, value, cls, origin)
             or
-            ssa_node_definition_named_attribute_points_to(def, context, name, value, cls, origin)
+            exists(ControlFlowNode orig |
+                ssa_node_definition_named_attribute_points_to(def, context, name, value, cls, orig) and
+                origin = ObjectOrCfg::fromCfgNode(orig)
+            )
             or
             ssa_node_refinement_named_attribute_points_to(def, context, name, value, cls, origin)
             or
@@ -1828,7 +1897,7 @@ module PointsTo {
 
         /** Holds if the attribute `name` of the ssa phi-function definition `phi` refers to `(value, cls, origin)`. */
         pragma[noinline]
-        private predicate ssa_phi_named_attribute_points_to(PhiFunction phi, PointsToContext context, string name, Object value, ClassObject cls, ControlFlowNode origin) {
+        private predicate ssa_phi_named_attribute_points_to(PhiFunction phi, PointsToContext context, string name, Object value, ClassObject cls, ObjectOrCfg origin) {
             ssa_variable_named_attribute_points_to(phi.getAnInput(), context, name, value, cls, origin)
         }
 
@@ -1846,7 +1915,7 @@ module PointsTo {
 
         /** Helper for `ssa_definition_named_attribute_points_to`. */
         pragma[noinline]
-        private predicate ssa_node_refinement_named_attribute_points_to(EssaNodeRefinement def, PointsToContext context, string name, Object value, ClassObject cls, ControlFlowNode origin) {
+        private predicate ssa_node_refinement_named_attribute_points_to(EssaNodeRefinement def, PointsToContext context, string name, Object value, ClassObject cls, ObjectOrCfg origin) {
             attribute_assignment_named_attribute_points_to(def, context, name, value, cls, origin)
             or
             attribute_delete_named_attribute_points_to(def, context, name, value, cls, origin)
@@ -1860,9 +1929,10 @@ module PointsTo {
 
         pragma[noinline]
         private predicate scope_entry_named_attribute_points_to(ScopeEntryDefinition def, PointsToContext context, string name, Object value, ClassObject cls, ControlFlowNode origin) {
-            exists(EssaVariable var, PointsToContext outer |
+            exists(EssaVariable var, PointsToContext outer, ObjectOrCfg orig |
                 Flow::scope_entry_value_transfer(var, outer, def, context) and
-                ssa_variable_named_attribute_points_to(var, outer, name, value, cls, origin)
+                ssa_variable_named_attribute_points_to(var, outer, name, value, cls, orig) and
+                origin = orig.fromObjectOrHere(def.getDefiningNode())
             )
             or
             origin = def.getDefiningNode() and
@@ -1878,12 +1948,15 @@ module PointsTo {
 
         pragma[noinline]
         private predicate assignment_named_attribute_points_to(AssignmentDefinition def, PointsToContext context, string name, Object value, ClassObject cls, ControlFlowNode origin) {
-            named_attribute_points_to(def.getValue(), context, name, value, cls, origin)
+            exists(ObjectOrCfg orig |
+                named_attribute_points_to(def.getValue(), context, name, value, cls, orig) and
+                origin = orig.fromObjectOrHere(def.getDefiningNode())
+            )
         }
 
         pragma[noinline]
-        private predicate attribute_assignment_named_attribute_points_to(AttributeAssignment def, PointsToContext context, string name, Object value, ClassObject cls, ControlFlowNode origin) {
-            points_to(def.getValue(), context, value, cls, origin) and name = def.getName()
+        private predicate attribute_assignment_named_attribute_points_to(AttributeAssignment def, PointsToContext context, string name, Object value, ClassObject cls, ObjectOrCfg origin) {
+            points_to(def.getValue(), context, value, cls, origin.toCfgNode()) and name = def.getName()
             or
             ssa_variable_named_attribute_points_to(def.getInput(), context, name, value, cls, origin) and not name = def.getName()
         }
@@ -1915,7 +1988,7 @@ module PointsTo {
         private predicate argument_named_attribute_points_to(ArgumentRefinement def, PointsToContext context, string name, Object value, ClassObject cls, ObjectOrCfg origin) {
             not two_args_first_arg_string(def, _, name) and ssa_variable_named_attribute_points_to(def.getInput(), context, name, value, cls, origin)
             or
-            sets_attribute(def, name) = true and points_to(def.getDefiningNode().(CallNode).getArg(2), context, value, cls, origin)
+            sets_attribute(def, name) = true and points_to(def.getDefiningNode().(CallNode).getArg(2), context, value, cls, origin.toCfgNode())
             or
             sets_attribute(def, name) = false and ssa_variable_named_attribute_points_to(def.getInput(), context, name, value, cls, origin)
         }
@@ -1954,15 +2027,19 @@ module PointsTo {
 
         pragma [noinline]
         private predicate self_parameter_named_attribute_points_to(ParameterDefinition def, PointsToContext context, string name, Object value, ClassObject vcls, ControlFlowNode origin) {
-            context.isRuntime() and executes_in_runtime_context(def.getScope()) and
-            ssa_variable_named_attribute_points_to(preceding_self_variable(def), context, name, value, vcls, origin)
-            or
-            exists(FunctionObject meth, CallNode call, PointsToContext caller_context, ControlFlowNode obj |
-                meth.getFunction() = def.getScope() and
-                method_call(meth, caller_context, call) and
-                call.getFunction().(AttrNode).getObject() = obj and
-                context.fromCall(call, meth, caller_context) and
-                named_attribute_points_to(obj, caller_context, name, value, vcls, origin)
+            exists(ObjectOrCfg orig |
+                origin = orig.toCfgNode()
+                |
+                context.isRuntime() and executes_in_runtime_context(def.getScope()) and
+                ssa_variable_named_attribute_points_to(preceding_self_variable(def), context, name, value, vcls, orig)
+                or
+                exists(FunctionObject meth, CallNode call, PointsToContext caller_context, ControlFlowNode obj |
+                    meth.getFunction() = def.getScope() and
+                    method_call(meth, caller_context, call) and
+                    call.getFunction().(AttrNode).getObject() = obj and
+                    context.fromCall(call, meth, caller_context) and
+                    named_attribute_points_to(obj, caller_context, name, value, vcls, orig)
+                )
             )
         }
 
@@ -1970,7 +2047,7 @@ module PointsTo {
             none()
         }
 
-        private predicate attribute_delete_named_attribute_points_to(EssaAttributeDeletion def, PointsToContext context, string name, Object value, ClassObject cls, ControlFlowNode origin) {
+        private predicate attribute_delete_named_attribute_points_to(EssaAttributeDeletion def, PointsToContext context, string name, Object value, ClassObject cls, ObjectOrCfg origin) {
             none()
         }
 
@@ -1987,7 +2064,7 @@ module PointsTo {
 
         /* Helper for import_star_named_attribute_points_to */
         pragma [noinline, nomagic]
-        private predicate ssa_star_variable_input_points_to(ImportStarRefinement def, PointsToContext context, string name, Object value, ClassObject cls, ControlFlowNode origin) {
+        private predicate ssa_star_variable_input_points_to(ImportStarRefinement def, PointsToContext context, string name, Object value, ClassObject cls, ObjectOrCfg origin) {
             exists(EssaVariable var |
                 ssa_star_import_star_input(def, var) and
                 ssa_variable_named_attribute_points_to(var, context, name, value, cls, origin)
@@ -2001,20 +2078,18 @@ module PointsTo {
         }
 
         pragma [noinline]
-        private predicate import_star_named_attribute_points_to(ImportStarRefinement def, PointsToContext context, string name, Object value, ClassObject cls, ControlFlowNode origin) {
-            exists(ImportStarNode imp, ModuleObject mod |
+        private predicate import_star_named_attribute_points_to(ImportStarRefinement def, PointsToContext context, string name, Object value, ClassObject cls, ObjectOrCfg origin) {
+            exists(ImportStarNode imp, ModuleObject mod, ObjectOrCfg orig |
+                origin = orig.fix(imp) and
                 star_variable_import_star_module(def, imp, context, mod) |
                 /* Attribute from imported module */
                 module_exports_boolean(mod, name) = true and
-                exists(ObjectOrCfg obj |
-                    Layer::module_attribute_points_to(mod, name, value, cls, obj) and
-                    not exists(Variable v | v.getId() = name and v.getScope() = imp.getScope()) and
-                    origin = obj.fromObjectOrHere(imp)
-                )
+                Layer::module_attribute_points_to(mod, name, value, cls, orig) and
+                not exists(Variable v | v.getId() = name and v.getScope() = imp.getScope())
                 or
                 /* Retain value held before import */
                 module_exports_boolean(mod, name) = false and
-                ssa_star_variable_input_points_to(def, context, name, value, cls, origin)
+                ssa_star_variable_input_points_to(def, context, name, value, cls, orig)
             )
         }
 
@@ -2242,7 +2317,7 @@ module PointsTo {
         /** Holds if ESSA edge refinement, `def`, refers to `(value, cls, origin)`. */
         predicate ssa_filter_definition_points_to(PyEdgeRefinement def, PointsToContext context, Object value, ClassObject cls, ObjectOrCfg origin) {
             exists(ControlFlowNode test, ControlFlowNode use |
-                refinement_test(test, use, test_evaluates_boolean(test, use, context, value, cls, origin), def)
+                refinement_test(test, use, test_evaluates_boolean(test, use, context, value, cls, origin.toCfgNode()), def)
             )
             or
             /* If we can't understand the test, assume that value passes through.
@@ -2264,7 +2339,7 @@ module PointsTo {
                  */
                 use = uniphi.getInput().getSourceVariable().(Variable).getAUse() and
                 test = uniphi.getDefiningNode() and
-                uniphi.getSense() = test_evaluates_boolean(test, use, context, value, cls, origin)
+                uniphi.getSense() = test_evaluates_boolean(test, use, context, value, cls, origin.toCfgNode())
             )
         }
 
@@ -2273,7 +2348,7 @@ module PointsTo {
         predicate ssa_filter_definition_named_attribute_points_to(PyEdgeRefinement def, PointsToContext context, string name, Object value, ClassObject cls, ObjectOrCfg origin) {
             exists(ControlFlowNode test, AttrNode use, boolean sense |
                 edge_refinement_attr_use_sense(def, test, use, name, sense) and
-                sense = test_evaluates_boolean(test, use, context, value, cls, origin)
+                sense = test_evaluates_boolean(test, use, context, value, cls, origin.toCfgNode())
             )
             or
             exists(EssaVariable input |
@@ -2513,7 +2588,7 @@ module PointsTo {
             )
             or
             value = builtin_class_attribute(owner, name) and class_declares_attribute(owner, name) and
-            origin = value and vcls = builtin_object_type(value)
+            origin = ObjectOrCfg::unknown() and vcls = builtin_object_type(value)
         }
 
         private predicate interesting_class_attribute(ClassList mro, string name) {

--- a/python/ql/src/semmle/python/pointsto/PointsTo.qll
+++ b/python/ql/src/semmle/python/pointsto/PointsTo.qll
@@ -2051,13 +2051,20 @@ module PointsTo {
                 context.isRuntime() and executes_in_runtime_context(def.getScope()) and
                 ssa_variable_named_attribute_points_to(preceding_self_variable(def), context, name, value, vcls, orig)
                 or
-                exists(FunctionObject meth, CallNode call, PointsToContext caller_context, ControlFlowNode obj |
-                    meth.getFunction() = def.getScope() and
-                    method_call(meth, caller_context, call) and
-                    call.getFunction().(AttrNode).getObject() = obj and
-                    context.fromCall(call, meth, caller_context) and
+                exists(PointsToContext caller_context, ControlFlowNode obj |
+                    self_parameter_interprocedural_flow(obj, caller_context, def, context) and
                     named_attribute_points_to(obj, caller_context, name, value, vcls, orig)
                 )
+            )
+        }
+
+        /* Helper for self_parameter_named_attribute_points_to */
+        private predicate self_parameter_interprocedural_flow(ControlFlowNode obj, PointsToContext caller_context, ParameterDefinition def, PointsToContext context) {
+            exists(FunctionObject meth, CallNode call |
+                meth.getFunction() = def.getScope() and
+                method_call(meth, caller_context, call) and
+                call.getFunction().(AttrNode).getObject() = obj and
+                context.fromCall(call, meth, caller_context)
             )
         }
 

--- a/python/ql/src/semmle/python/pointsto/PointsTo.qll
+++ b/python/ql/src/semmle/python/pointsto/PointsTo.qll
@@ -32,7 +32,7 @@ import semmle.dataflow.SSA
 private import MRO
 
 /* Use this version for speed */
-library class ObjectOrCfg extends @py_object {
+library class CfgOrigin extends @py_object {
 
     string toString() {
         /* Not to be displayed */
@@ -54,7 +54,7 @@ library class ObjectOrCfg extends @py_object {
     }
 
     pragma[inline]
-    ObjectOrCfg fix(ControlFlowNode here) {
+    CfgOrigin fix(ControlFlowNode here) {
         if this = unknownValue() then
             result = here
         else
@@ -64,12 +64,12 @@ library class ObjectOrCfg extends @py_object {
 }
 
 /* Use this version for stronger type-checking */
-//private newtype TObjectOrCfg =
+//private newtype TCfgOrigin =
 //    TUnknownOrigin()
 //    or
 //    TCfgOrigin(ControlFlowNode f)
 //
-//library class ObjectOrCfg extends TObjectOrCfg {
+//library class CfgOrigin extends TCfgOrigin {
 //
 //    string toString() {
 //        /* Not to be displayed */
@@ -90,7 +90,7 @@ library class ObjectOrCfg extends @py_object {
 //        this = TCfgOrigin(result)
 //    }
 //
-//    ObjectOrCfg fix(ControlFlowNode here) {
+//    CfgOrigin fix(ControlFlowNode here) {
 //        this = TUnknownOrigin() and result = TCfgOrigin(here)
 //        or
 //        not this = TUnknownOrigin() and result = this
@@ -99,13 +99,13 @@ library class ObjectOrCfg extends @py_object {
 //
 
 
-module ObjectOrCfg {
+module CfgOrigin {
 
-    ObjectOrCfg fromCfgNode(ControlFlowNode f) {
+    CfgOrigin fromCfgNode(ControlFlowNode f) {
         result = f
     }
 
-    ObjectOrCfg unknown() {
+    CfgOrigin unknown() {
         result = unknownValue()
     }
 
@@ -184,7 +184,7 @@ module PointsTo {
         /** INTERNAL -- Do not use.
          *
          * Holds if `package.name` points to `(value, cls, origin)`, where `package` is a package object. */
-        cached predicate package_attribute_points_to(PackageObject package, string name, Object value, ClassObject cls, ObjectOrCfg origin) {
+        cached predicate package_attribute_points_to(PackageObject package, string name, Object value, ClassObject cls, CfgOrigin origin) {
             py_module_attributes(package.getInitModule().getModule(), name, value, cls, origin)
             or
             exists(Module init |
@@ -197,13 +197,13 @@ module PointsTo {
                     imp.isImport()
                 )
             ) and explicitly_imported(value) and
-            value = package.submodule(name) and cls = theModuleType() and origin = ObjectOrCfg::fromCfgNode(value)
+            value = package.submodule(name) and cls = theModuleType() and origin = CfgOrigin::fromCfgNode(value)
         }
 
         /** INTERNAL -- `Use m.attributeRefersTo(name, obj, origin)` instead.
          *
          * Holds if `m.name` points to `(value, cls, origin)`, where `m` is a (source) module. */
-        cached predicate py_module_attributes(Module m, string name, Object obj, ClassObject cls, ObjectOrCfg origin) {
+        cached predicate py_module_attributes(Module m, string name, Object obj, ClassObject cls, CfgOrigin origin) {
             exists(EssaVariable var, ControlFlowNode exit, PointsToContext imp |
                 exit =  m.getANormalExit() and var.getAUse() = exit and
                 var.getSourceVariable().getName() = name and
@@ -331,7 +331,7 @@ module PointsTo {
         }
 
         /** Holds if `var` refers to `(value, cls, origin)` given the context `context`. */
-        cached predicate ssa_variable_points_to(EssaVariable var, PointsToContext context, Object value, ClassObject cls, ObjectOrCfg origin) {
+        cached predicate ssa_variable_points_to(EssaVariable var, PointsToContext context, Object value, ClassObject cls, CfgOrigin origin) {
             SSA::ssa_definition_points_to(var.getDefinition(), context, value, cls, origin)
         }
 
@@ -482,12 +482,12 @@ module PointsTo {
         }
 
         /** Holds if `mod.name` points to `(value, cls, origin)`, where `mod` is a module object. */
-        predicate module_attribute_points_to(ModuleObject mod, string name, Object value, ClassObject cls, ObjectOrCfg origin) {
+        predicate module_attribute_points_to(ModuleObject mod, string name, Object value, ClassObject cls, CfgOrigin origin) {
             py_module_attributes(mod.getModule(), name, value, cls, origin)
             or
             package_attribute_points_to(mod, name, value, cls, origin)
             or
-            builtin_module_attribute(mod, name, value, cls) and origin = ObjectOrCfg::unknown()
+            builtin_module_attribute(mod, name, value, cls) and origin = CfgOrigin::unknown()
         }
 
     }
@@ -526,7 +526,7 @@ module PointsTo {
         or
         attribute_load_points_to(f, context, value, cls, origin)
         or
-        exists(ObjectOrCfg orig |
+        exists(CfgOrigin orig |
             getattr_points_to(f, context, value, cls, orig) and
             origin = orig.asCfgNodeOrHere(f)
         )
@@ -593,7 +593,7 @@ module PointsTo {
         result.getSourceVariable() instanceof GlobalVariable
     }
 
-    private predicate use_points_to_maybe_origin(NameNode f, PointsToContext context, Object value, ClassObject cls, ObjectOrCfg origin_or_obj) {
+    private predicate use_points_to_maybe_origin(NameNode f, PointsToContext context, Object value, ClassObject cls, CfgOrigin origin_or_obj) {
         ssa_variable_points_to(fast_local_variable(f), context, value, cls, origin_or_obj)
         or
         name_lookup_points_to_maybe_origin(f, context, value, cls, origin_or_obj)
@@ -607,7 +607,7 @@ module PointsTo {
         ssa_variable_points_to(name_local_variable(f), context, undefinedVariable(), _, _)
     }
 
-    private predicate name_lookup_points_to_maybe_origin(NameNode f, PointsToContext context, Object value, ClassObject cls, ObjectOrCfg origin_or_obj) {
+    private predicate name_lookup_points_to_maybe_origin(NameNode f, PointsToContext context, Object value, ClassObject cls, CfgOrigin origin_or_obj) {
         exists(EssaVariable var | var = name_local_variable(f) |
             ssa_variable_points_to(var, context, value, cls, origin_or_obj)
         )
@@ -616,11 +616,11 @@ module PointsTo {
         global_lookup_points_to_maybe_origin(f, context, value, cls, origin_or_obj)
     }
 
-    private predicate global_lookup_points_to_maybe_origin(NameNode f, PointsToContext context, Object value, ClassObject cls, ObjectOrCfg origin_or_obj) {
+    private predicate global_lookup_points_to_maybe_origin(NameNode f, PointsToContext context, Object value, ClassObject cls, CfgOrigin origin_or_obj) {
         ssa_variable_points_to(global_variable(f), context, value, cls, origin_or_obj)
         or
         exists(ControlFlowNode origin |
-            origin_or_obj = ObjectOrCfg::fromCfgNode(origin)
+            origin_or_obj = CfgOrigin::fromCfgNode(origin)
             |
             ssa_variable_points_to(global_variable(f), context, undefinedVariable(), _, _) and
             potential_builtin_points_to(f, value, cls, origin)
@@ -632,7 +632,7 @@ module PointsTo {
 
     /** Gets an object pointed to by a use (of a variable). */
     private predicate use_points_to(NameNode f, PointsToContext context, Object value, ClassObject cls, ControlFlowNode origin) {
-        exists(ObjectOrCfg origin_or_obj |
+        exists(CfgOrigin origin_or_obj |
             value != undefinedVariable() and
             use_points_to_maybe_origin(f, context, value, cls, origin_or_obj) |
             origin = origin_or_obj.asCfgNodeOrHere(f)
@@ -655,14 +655,14 @@ module PointsTo {
 
     /** Holds if `obj.name` points to `(value, cls, orig)`. */
     pragma [noinline]
-    private predicate class_or_module_attribute(Object obj, string name, Object value, ClassObject cls, ObjectOrCfg orig) {
+    private predicate class_or_module_attribute(Object obj, string name, Object value, ClassObject cls, CfgOrigin orig) {
         /* Normal class attributes */
         Types::class_attribute_lookup(obj, name, value, cls, orig) and cls != theStaticMethodType() and cls != theClassMethodType()
         or
         /* Static methods of the class */
         exists(CallNode sm | 
             Types::class_attribute_lookup(obj, name, sm, theStaticMethodType(), _) and sm.getArg(0) = value and 
-            cls = thePyFunctionType() and orig = ObjectOrCfg::fromCfgNode(sm.getArg(0))
+            cls = thePyFunctionType() and orig = CfgOrigin::fromCfgNode(sm.getArg(0))
         )
         or
         /* Module attributes */
@@ -674,7 +674,7 @@ module PointsTo {
     private predicate instance_attribute_load_points_to(AttrNode f, PointsToContext context, Object value, ClassObject cls, ControlFlowNode origin) {
         f.isLoad() and
         exists(string name |
-            exists(ObjectOrCfg orig |
+            exists(CfgOrigin orig |
                 origin = orig.asCfgNodeOrHere(f) and
                 named_attribute_points_to(f.getObject(name), context, name, value, cls, orig)
             )
@@ -713,7 +713,7 @@ module PointsTo {
     private predicate attribute_load_points_to(AttrNode f, PointsToContext context, Object value, ClassObject cls, ControlFlowNode origin) {
         instance_attribute_load_points_to(f, context, value, cls, origin)
         or
-        exists(Object cls_or_mod, string name, ObjectOrCfg orig |
+        exists(Object cls_or_mod, string name, CfgOrigin orig |
             receiver_object(f, context, cls_or_mod, name) and
             class_or_module_attribute(cls_or_mod, name, value, cls, orig) and
             origin = orig.asCfgNodeOrHere(f)
@@ -744,7 +744,7 @@ module PointsTo {
     /** Holds if `f` is a "from import" expression, `from mod import x` and points to `(value, cls, origin)`. */
     pragma [nomagic]
     private predicate from_import_points_to(ImportMemberNode f, PointsToContext context, Object value, ClassObject cls, ControlFlowNode origin) {
-        exists(EssaVariable var, ObjectOrCfg orig |
+        exists(EssaVariable var, CfgOrigin orig |
             live_import_from_dot_in_init(f, var) and
             ssa_variable_points_to(var, context, value, cls, orig) and
             origin = orig.asCfgNodeOrHere(f)
@@ -753,7 +753,7 @@ module PointsTo {
         not live_import_from_dot_in_init(f, _) and
         exists(string name, ModuleObject mod |
             points_to(f.getModule(name), context, mod, _, _) |
-            exists(ObjectOrCfg orig |
+            exists(CfgOrigin orig |
                 Layer::module_attribute_points_to(mod, name, value, cls, orig) and
                 origin = orig.asCfgNodeOrHere(f)
             )
@@ -761,7 +761,7 @@ module PointsTo {
     }
 
     /** Holds if `f`  is of the form `getattr(x, "name")` and x.name points to `(value, cls, origin)`. */
-    private predicate getattr_points_to(CallNode f, PointsToContext context, Object value, ClassObject cls, ObjectOrCfg origin) {
+    private predicate getattr_points_to(CallNode f, PointsToContext context, Object value, ClassObject cls, CfgOrigin origin) {
         exists(ControlFlowNode arg, string name |
             named_attribute_points_to(arg, context, name, value, cls, origin) and
             getattr(f, arg, name)
@@ -1049,7 +1049,7 @@ module PointsTo {
         )
     }
 
-    predicate named_attribute_points_to(ControlFlowNode f, PointsToContext context, string name, Object value, ClassObject cls, ObjectOrCfg origin) {
+    predicate named_attribute_points_to(ControlFlowNode f, PointsToContext context, string name, Object value, ClassObject cls, CfgOrigin origin) {
         exists(EssaVariable var |
             var.getAUse() = f |
             SSA::ssa_variable_named_attribute_points_to(var, context, name, value, cls, origin)
@@ -1455,7 +1455,7 @@ module PointsTo {
 
         /** Holds if the phi-function `phi` refers to `(value, cls, origin)` given the context `context`. */
         pragma [noinline]
-        private predicate ssa_phi_points_to(PhiFunction phi, PointsToContext context, Object value, ClassObject cls, ObjectOrCfg origin) {
+        private predicate ssa_phi_points_to(PhiFunction phi, PointsToContext context, Object value, ClassObject cls, CfgOrigin origin) {
             exists(EssaVariable input, BasicBlock pred |
                 input = phi.getInput(pred) and
                 ssa_variable_points_to(input, context, value, cls, origin)
@@ -1469,12 +1469,12 @@ module PointsTo {
         }
 
         /** Holds if the ESSA definition `def`  refers to `(value, cls, origin)` given the context `context`. */
-        predicate ssa_definition_points_to(EssaDefinition def, PointsToContext context, Object value, ClassObject cls, ObjectOrCfg origin) {
+        predicate ssa_definition_points_to(EssaDefinition def, PointsToContext context, Object value, ClassObject cls, CfgOrigin origin) {
             ssa_phi_points_to(def, context, value, cls, origin)
             or
             exists(ControlFlowNode orig |
                 ssa_node_definition_points_to(def, context, value, cls, orig) and
-                origin = ObjectOrCfg::fromCfgNode(orig)
+                origin = CfgOrigin::fromCfgNode(orig)
             )
             or
             Filters::ssa_filter_definition_points_to(def, context, value, cls, origin)
@@ -1516,7 +1516,7 @@ module PointsTo {
         }
 
         pragma [noinline]
-        private predicate ssa_node_refinement_points_to(EssaNodeRefinement def, PointsToContext context, Object value, ClassObject cls, ObjectOrCfg origin) {
+        private predicate ssa_node_refinement_points_to(EssaNodeRefinement def, PointsToContext context, Object value, ClassObject cls, CfgOrigin origin) {
             method_callsite_points_to(def, context, value, cls, origin)
             or
             import_star_points_to(def, context, value, cls, origin)
@@ -1655,7 +1655,7 @@ module PointsTo {
                 neither_class_nor_static_method(scope)
             )
             or
-            exists(EssaVariable obj, PointsToContext caller, ObjectOrCfg orig |
+            exists(EssaVariable obj, PointsToContext caller, CfgOrigin orig |
                 origin = orig.asCfgNodeOrHere(def.getDefiningNode()) and
                 ssa_variable_points_to(obj, caller, value, cls, orig) and
                 callsite_self_argument_transfer(obj, caller, def, context)
@@ -1758,7 +1758,7 @@ module PointsTo {
         pragma [noinline]
         private predicate scope_entry_points_to(ScopeEntryDefinition def, PointsToContext context, Object value, ClassObject cls, ControlFlowNode origin) {
             /* Transfer from another scope */
-            exists(EssaVariable var, PointsToContext outer, ObjectOrCfg orig |
+            exists(EssaVariable var, PointsToContext outer, CfgOrigin orig |
                 Flow::scope_entry_value_transfer(var, outer, def, context) and
                 ssa_variable_points_to(var, outer, value, cls, orig) and
                 origin = orig.asCfgNodeOrHere(def.getDefiningNode())
@@ -1790,7 +1790,7 @@ module PointsTo {
          * Where var may be redefined in call to `foo` if `var` escapes (is global or non-local).
          */
         pragma [noinline]
-        private predicate callsite_points_to(CallsiteRefinement def, PointsToContext context, Object value, ClassObject cls, ObjectOrCfg origin) {
+        private predicate callsite_points_to(CallsiteRefinement def, PointsToContext context, Object value, ClassObject cls, CfgOrigin origin) {
             exists(EssaVariable var, PointsToContext callee |
                 Flow::callsite_exit_value_transfer(var, callee, def, context) and
                 ssa_variable_points_to(var, callee, value, cls, origin)
@@ -1802,7 +1802,7 @@ module PointsTo {
         }
 
         pragma [noinline]
-        private predicate callsite_points_to_python(CallsiteRefinement def, PointsToContext context, Object value, ClassObject cls, ObjectOrCfg origin) {
+        private predicate callsite_points_to_python(CallsiteRefinement def, PointsToContext context, Object value, ClassObject cls, CfgOrigin origin) {
             ssa_variable_points_to(def.getInput(), context, value, cls, origin) and
             exists(CallNode call, PythonSsaSourceVariable var |
                 call = def.getCall() and
@@ -1822,7 +1822,7 @@ module PointsTo {
         }
 
         pragma [noinline]
-        private predicate callsite_points_to_builtin(CallsiteRefinement def, PointsToContext context, Object value, ClassObject cls, ObjectOrCfg origin) {
+        private predicate callsite_points_to_builtin(CallsiteRefinement def, PointsToContext context, Object value, ClassObject cls, CfgOrigin origin) {
             ssa_variable_points_to(def.getInput(), context, value, cls, origin) and
             exists(CallNode call |
                 call = def.getCall() |
@@ -1832,14 +1832,14 @@ module PointsTo {
         }
 
         /** Pass through for `self` for the implicit re-definition of `self` in `self.foo()`. */
-        private predicate method_callsite_points_to(MethodCallsiteRefinement def, PointsToContext context, Object value, ClassObject cls, ObjectOrCfg origin) {
+        private predicate method_callsite_points_to(MethodCallsiteRefinement def, PointsToContext context, Object value, ClassObject cls, CfgOrigin origin) {
             /* The value of self remains the same, only the attributes may change */
             ssa_variable_points_to(def.getInput(), context, value, cls, origin)
         }
 
         /** Points-to for `from ... import *`. */
-        private predicate import_star_points_to(ImportStarRefinement def, PointsToContext context, Object value, ClassObject cls, ObjectOrCfg origin) {
-            exists(ObjectOrCfg orig |
+        private predicate import_star_points_to(ImportStarRefinement def, PointsToContext context, Object value, ClassObject cls, CfgOrigin origin) {
+            exists(CfgOrigin orig |
                 origin = orig.fix(def.getDefiningNode())
                 |
                 exists(ModuleObject mod, string name |
@@ -1859,28 +1859,28 @@ module PointsTo {
 
         /** Attribute assignments have no effect as far as value tracking is concerned, except for `__class__`. */
         pragma [noinline]
-        private predicate attribute_assignment_points_to(AttributeAssignment def, PointsToContext context, Object value, ClassObject cls, ObjectOrCfg origin) {
+        private predicate attribute_assignment_points_to(AttributeAssignment def, PointsToContext context, Object value, ClassObject cls, CfgOrigin origin) {
             if def.getName() = "__class__" then
                 ssa_variable_points_to(def.getInput(), context, value, _, _) and points_to(def.getValue(), _, cls, _,_) and
-                origin = ObjectOrCfg::fromCfgNode(def.getDefiningNode())
+                origin = CfgOrigin::fromCfgNode(def.getDefiningNode())
             else
                 ssa_variable_points_to(def.getInput(), context, value, cls, origin)
         }
 
         /** Ignore the effects of calls on their arguments. PointsTo is an approximation, but attempting to improve accuracy would be very expensive for very little gain. */
         pragma [noinline]
-        private predicate argument_points_to(ArgumentRefinement def, PointsToContext context, Object value, ClassObject cls, ObjectOrCfg origin) {
+        private predicate argument_points_to(ArgumentRefinement def, PointsToContext context, Object value, ClassObject cls, CfgOrigin origin) {
             ssa_variable_points_to(def.getInput(), context, value, cls, origin)
         }
 
         /** Attribute deletions have no effect as far as value tracking is concerned. */
         pragma [noinline]
-        private predicate attribute_delete_points_to(EssaAttributeDeletion def, PointsToContext context, Object value, ClassObject cls, ObjectOrCfg origin) {
+        private predicate attribute_delete_points_to(EssaAttributeDeletion def, PointsToContext context, Object value, ClassObject cls, CfgOrigin origin) {
             ssa_variable_points_to(def.getInput(), context, value, cls, origin)
         }
 
         /* Data flow for attributes. These mirror the "normal" points-to predicates.
-         * For each points-to predicate `xxx_points_to(XXX def, PointsToContext context, Object value, ClassObject cls, ObjectOrCfg origin)`
+         * For each points-to predicate `xxx_points_to(XXX def, PointsToContext context, Object value, ClassObject cls, CfgOrigin origin)`
          * There is an equivalent predicate that tracks the values in attributes:
          * `xxx_named_attribute_points_to(XXX def, PointsToContext context, string name, Object value, ClassObject cls, ControlFlowNode origin)`
          *  */
@@ -1889,17 +1889,17 @@ module PointsTo {
          *
          * Hold if the attribute `name` of the ssa variable `var` refers to `(value, cls, origin)`.
          */
-        predicate ssa_variable_named_attribute_points_to(EssaVariable var, PointsToContext context, string name, Object value, ClassObject cls, ObjectOrCfg origin) {
+        predicate ssa_variable_named_attribute_points_to(EssaVariable var, PointsToContext context, string name, Object value, ClassObject cls, CfgOrigin origin) {
             ssa_definition_named_attribute_points_to(var.getDefinition(), context, name, value, cls, origin)
         }
 
         /** Helper for `ssa_variable_named_attribute_points_to`. */
-        private predicate ssa_definition_named_attribute_points_to(EssaDefinition def, PointsToContext context, string name, Object value, ClassObject cls, ObjectOrCfg origin) {
+        private predicate ssa_definition_named_attribute_points_to(EssaDefinition def, PointsToContext context, string name, Object value, ClassObject cls, CfgOrigin origin) {
             ssa_phi_named_attribute_points_to(def, context, name, value, cls, origin)
             or
             exists(ControlFlowNode orig |
                 ssa_node_definition_named_attribute_points_to(def, context, name, value, cls, orig) and
-                origin = ObjectOrCfg::fromCfgNode(orig)
+                origin = CfgOrigin::fromCfgNode(orig)
             )
             or
             ssa_node_refinement_named_attribute_points_to(def, context, name, value, cls, origin)
@@ -1909,7 +1909,7 @@ module PointsTo {
 
         /** Holds if the attribute `name` of the ssa phi-function definition `phi` refers to `(value, cls, origin)`. */
         pragma[noinline]
-        private predicate ssa_phi_named_attribute_points_to(PhiFunction phi, PointsToContext context, string name, Object value, ClassObject cls, ObjectOrCfg origin) {
+        private predicate ssa_phi_named_attribute_points_to(PhiFunction phi, PointsToContext context, string name, Object value, ClassObject cls, CfgOrigin origin) {
             ssa_variable_named_attribute_points_to(phi.getAnInput(), context, name, value, cls, origin)
         }
 
@@ -1927,7 +1927,7 @@ module PointsTo {
 
         /** Helper for `ssa_definition_named_attribute_points_to`. */
         pragma[noinline]
-        private predicate ssa_node_refinement_named_attribute_points_to(EssaNodeRefinement def, PointsToContext context, string name, Object value, ClassObject cls, ObjectOrCfg origin) {
+        private predicate ssa_node_refinement_named_attribute_points_to(EssaNodeRefinement def, PointsToContext context, string name, Object value, ClassObject cls, CfgOrigin origin) {
             attribute_assignment_named_attribute_points_to(def, context, name, value, cls, origin)
             or
             attribute_delete_named_attribute_points_to(def, context, name, value, cls, origin)
@@ -1941,7 +1941,7 @@ module PointsTo {
 
         pragma[noinline]
         private predicate scope_entry_named_attribute_points_to(ScopeEntryDefinition def, PointsToContext context, string name, Object value, ClassObject cls, ControlFlowNode origin) {
-            exists(EssaVariable var, PointsToContext outer, ObjectOrCfg orig |
+            exists(EssaVariable var, PointsToContext outer, CfgOrigin orig |
                 Flow::scope_entry_value_transfer(var, outer, def, context) and
                 ssa_variable_named_attribute_points_to(var, outer, name, value, cls, orig) and
                 origin = orig.asCfgNodeOrHere(def.getDefiningNode())
@@ -1960,14 +1960,14 @@ module PointsTo {
 
         pragma[noinline]
         private predicate assignment_named_attribute_points_to(AssignmentDefinition def, PointsToContext context, string name, Object value, ClassObject cls, ControlFlowNode origin) {
-            exists(ObjectOrCfg orig |
+            exists(CfgOrigin orig |
                 named_attribute_points_to(def.getValue(), context, name, value, cls, orig) and
                 origin = orig.asCfgNodeOrHere(def.getDefiningNode())
             )
         }
 
         pragma[noinline]
-        private predicate attribute_assignment_named_attribute_points_to(AttributeAssignment def, PointsToContext context, string name, Object value, ClassObject cls, ObjectOrCfg origin) {
+        private predicate attribute_assignment_named_attribute_points_to(AttributeAssignment def, PointsToContext context, string name, Object value, ClassObject cls, CfgOrigin origin) {
             points_to(def.getValue(), context, value, cls, origin.toCfgNode()) and name = def.getName()
             or
             ssa_variable_named_attribute_points_to(def.getInput(), context, name, value, cls, origin) and not name = def.getName()
@@ -1997,7 +1997,7 @@ module PointsTo {
         }
 
         pragma[noinline]
-        private predicate argument_named_attribute_points_to(ArgumentRefinement def, PointsToContext context, string name, Object value, ClassObject cls, ObjectOrCfg origin) {
+        private predicate argument_named_attribute_points_to(ArgumentRefinement def, PointsToContext context, string name, Object value, ClassObject cls, CfgOrigin origin) {
             not two_args_first_arg_string(def, _, name) and ssa_variable_named_attribute_points_to(def.getInput(), context, name, value, cls, origin)
             or
             sets_attribute(def, name) = true and points_to(def.getDefiningNode().(CallNode).getArg(2), context, value, cls, origin.toCfgNode())
@@ -2018,7 +2018,7 @@ module PointsTo {
         }
 
         pragma[noinline]
-        private predicate self_callsite_named_attribute_points_to(SelfCallsiteRefinement def, PointsToContext context, string name, Object value, ClassObject cls, ObjectOrCfg origin) {
+        private predicate self_callsite_named_attribute_points_to(SelfCallsiteRefinement def, PointsToContext context, string name, Object value, ClassObject cls, CfgOrigin origin) {
             exists(EssaVariable var, PointsToContext callee |
                 ssa_variable_named_attribute_points_to(var, callee, name, value, cls, origin) and
                 callee_self_variable(var, callee, def, context)
@@ -2039,7 +2039,7 @@ module PointsTo {
 
         pragma [noinline]
         private predicate self_parameter_named_attribute_points_to(ParameterDefinition def, PointsToContext context, string name, Object value, ClassObject vcls, ControlFlowNode origin) {
-            exists(ObjectOrCfg orig |
+            exists(CfgOrigin orig |
                 origin = orig.toCfgNode()
                 |
                 context.isRuntime() and executes_in_runtime_context(def.getScope()) and
@@ -2059,7 +2059,7 @@ module PointsTo {
             none()
         }
 
-        private predicate attribute_delete_named_attribute_points_to(EssaAttributeDeletion def, PointsToContext context, string name, Object value, ClassObject cls, ObjectOrCfg origin) {
+        private predicate attribute_delete_named_attribute_points_to(EssaAttributeDeletion def, PointsToContext context, string name, Object value, ClassObject cls, CfgOrigin origin) {
             none()
         }
 
@@ -2076,7 +2076,7 @@ module PointsTo {
 
         /* Helper for import_star_named_attribute_points_to */
         pragma [noinline, nomagic]
-        private predicate ssa_star_variable_input_points_to(ImportStarRefinement def, PointsToContext context, string name, Object value, ClassObject cls, ObjectOrCfg origin) {
+        private predicate ssa_star_variable_input_points_to(ImportStarRefinement def, PointsToContext context, string name, Object value, ClassObject cls, CfgOrigin origin) {
             exists(EssaVariable var |
                 ssa_star_import_star_input(def, var) and
                 ssa_variable_named_attribute_points_to(var, context, name, value, cls, origin)
@@ -2090,8 +2090,8 @@ module PointsTo {
         }
 
         pragma [noinline]
-        private predicate import_star_named_attribute_points_to(ImportStarRefinement def, PointsToContext context, string name, Object value, ClassObject cls, ObjectOrCfg origin) {
-            exists(ImportStarNode imp, ModuleObject mod, ObjectOrCfg orig |
+        private predicate import_star_named_attribute_points_to(ImportStarRefinement def, PointsToContext context, string name, Object value, ClassObject cls, CfgOrigin origin) {
+            exists(ImportStarNode imp, ModuleObject mod, CfgOrigin orig |
                 origin = orig.fix(imp) and
                 star_variable_import_star_module(def, imp, context, mod) |
                 /* Attribute from imported module */
@@ -2327,7 +2327,7 @@ module PointsTo {
         }
 
         /** Holds if ESSA edge refinement, `def`, refers to `(value, cls, origin)`. */
-        predicate ssa_filter_definition_points_to(PyEdgeRefinement def, PointsToContext context, Object value, ClassObject cls, ObjectOrCfg origin) {
+        predicate ssa_filter_definition_points_to(PyEdgeRefinement def, PointsToContext context, Object value, ClassObject cls, CfgOrigin origin) {
             exists(ControlFlowNode test, ControlFlowNode use |
                 refinement_test(test, use, test_evaluates_boolean(test, use, context, value, cls, origin.toCfgNode()), def)
             )
@@ -2344,7 +2344,7 @@ module PointsTo {
 
         /** Holds if ESSA definition, `uniphi`, refers to `(value, cls, origin)`. */
         pragma [noinline]
-        predicate uni_edged_phi_points_to(SingleSuccessorGuard uniphi, PointsToContext context, Object value, ClassObject cls, ObjectOrCfg origin) {
+        predicate uni_edged_phi_points_to(SingleSuccessorGuard uniphi, PointsToContext context, Object value, ClassObject cls, CfgOrigin origin) {
             exists(ControlFlowNode test, ControlFlowNode use |
                 /* Because calls such as `len` may create a new variable, we need to go via the source variable
                  * That is perfectly safe as we are only dealing with calls that do not mutate their arguments.
@@ -2357,7 +2357,7 @@ module PointsTo {
 
         /** Holds if the named attibute of ESSA edge refinement, `def`, refers to `(value, cls, origin)`. */
         pragma[noinline]
-        predicate ssa_filter_definition_named_attribute_points_to(PyEdgeRefinement def, PointsToContext context, string name, Object value, ClassObject cls, ObjectOrCfg origin) {
+        predicate ssa_filter_definition_named_attribute_points_to(PyEdgeRefinement def, PointsToContext context, string name, Object value, ClassObject cls, CfgOrigin origin) {
             exists(ControlFlowNode test, AttrNode use, boolean sense |
                 edge_refinement_attr_use_sense(def, test, use, name, sense) and
                 sense = test_evaluates_boolean(test, use, context, value, cls, origin.toCfgNode())
@@ -2589,7 +2589,7 @@ module PointsTo {
         }
 
         /** INTERNAL -- Use `ClassObject.declaredAttribute(name). instead. */
-        cached predicate class_declared_attribute(ClassObject owner, string name, Object value, ClassObject vcls, ObjectOrCfg origin) {
+        cached predicate class_declared_attribute(ClassObject owner, string name, Object value, ClassObject vcls, CfgOrigin origin) {
             /* Note that src_var must be a local variable, we aren't interested in the value that any global variable may hold */
              value != undefinedVariable() and
              exists(EssaVariable var, LocalVariable src_var |
@@ -2600,7 +2600,7 @@ module PointsTo {
             )
             or
             value = builtin_class_attribute(owner, name) and class_declares_attribute(owner, name) and
-            origin = ObjectOrCfg::unknown() and vcls = builtin_object_type(value)
+            origin = CfgOrigin::unknown() and vcls = builtin_object_type(value)
         }
 
         private predicate interesting_class_attribute(ClassList mro, string name) {
@@ -2651,7 +2651,7 @@ module PointsTo {
 
         /** INTERNAL -- Use `ClassObject.attributeRefersTo(name, value, vlcs, origin). instead.
          */
-        cached predicate class_attribute_lookup(ClassObject cls, string name, Object value, ClassObject vcls, ObjectOrCfg origin) {
+        cached predicate class_attribute_lookup(ClassObject cls, string name, Object value, ClassObject vcls, CfgOrigin origin) {
            exists(ClassObject defn |
                defn = get_mro(cls).findDeclaringClass(name) and
                class_declared_attribute(defn, name, value, vcls, origin)

--- a/python/ql/src/semmle/python/pointsto/PointsTo.qll
+++ b/python/ql/src/semmle/python/pointsto/PointsTo.qll
@@ -31,35 +31,8 @@ private import Filters as BaseFilters
 import semmle.dataflow.SSA
 private import MRO
 
-//library class ObjectOrCfg extends @py_object {
-//
-//    string toString() {
-//        /* Not to be displayed */
-//        none()
-//    }
-//
-//    ControlFlowNode getOrigin() {
-//        result = this
-//    }
-//
-//    /** Get a `ControlFlowNode` from `this` or `here`.
-//     * If `this` is a ControlFlowNode then use that, otherwise fall back on `here`
-//     */
-//    pragma[inline]
-//    ControlFlowNode fromObjectOrHere(ControlFlowNode here) {
-//        result = this
-//        or
-//        not this instanceof ControlFlowNode and result = here
-//    }
-//
-//}
-
-private newtype TObjectOrCfg =
-    TUnknownOrigin()
-    or
-    TCfgOrigin(ControlFlowNode f)
-
-library class ObjectOrCfg extends TObjectOrCfg {
+/* Use this version for speed */
+library class ObjectOrCfg extends @py_object {
 
     string toString() {
         /* Not to be displayed */
@@ -70,31 +43,70 @@ library class ObjectOrCfg extends TObjectOrCfg {
      * If `this` is a ControlFlowNode then use that, otherwise fall back on `here`
      */
     pragma[inline]
-    ControlFlowNode fromObjectOrHere(ControlFlowNode here) {
-        this = TUnknownOrigin() and result = here
+    ControlFlowNode asCfgNodeOrHere(ControlFlowNode here) {
+        result = this
         or
-        this = TCfgOrigin(result)
+        not this instanceof ControlFlowNode and result = here
     }
 
     ControlFlowNode toCfgNode() {
-        this = TCfgOrigin(result)
+        result = this
     }
 
+    pragma[inline]
     ObjectOrCfg fix(ControlFlowNode here) {
-        this = TUnknownOrigin() and result = TCfgOrigin(here)
-        or
-        not this = TUnknownOrigin() and result = this
+        if this = unknownValue() then
+            result = here
+        else
+            result = this
     }
+
 }
+
+/* Use this version for stronger type-checking */
+//private newtype TObjectOrCfg =
+//    TUnknownOrigin()
+//    or
+//    TCfgOrigin(ControlFlowNode f)
+//
+//library class ObjectOrCfg extends TObjectOrCfg {
+//
+//    string toString() {
+//        /* Not to be displayed */
+//        none()
+//    }
+//
+//    /** Get a `ControlFlowNode` from `this` or `here`.
+//     * If `this` is a ControlFlowNode then use that, otherwise fall back on `here`
+//     */
+//    pragma[inline]
+//    ControlFlowNode asCfgNodeOrHere(ControlFlowNode here) {
+//        this = TUnknownOrigin() and result = here
+//        or
+//        this = TCfgOrigin(result)
+//    }
+//
+//    ControlFlowNode toCfgNode() {
+//        this = TCfgOrigin(result)
+//    }
+//
+//    ObjectOrCfg fix(ControlFlowNode here) {
+//        this = TUnknownOrigin() and result = TCfgOrigin(here)
+//        or
+//        not this = TUnknownOrigin() and result = this
+//    }
+//}
+//
+
 
 module ObjectOrCfg {
 
     ObjectOrCfg fromCfgNode(ControlFlowNode f) {
-        result = TCfgOrigin(f)
+        result = f
     }
 
     ObjectOrCfg unknown() {
-        result = TUnknownOrigin()
+        result = unknownValue()
     }
 
 }
@@ -475,7 +487,7 @@ module PointsTo {
             or
             package_attribute_points_to(mod, name, value, cls, origin)
             or
-            builtin_module_attribute(mod, name, value, cls) and origin = TUnknownOrigin()
+            builtin_module_attribute(mod, name, value, cls) and origin = ObjectOrCfg::unknown()
         }
 
     }
@@ -516,7 +528,7 @@ module PointsTo {
         or
         exists(ObjectOrCfg orig |
             getattr_points_to(f, context, value, cls, orig) and
-            origin = orig.fromObjectOrHere(f)
+            origin = orig.asCfgNodeOrHere(f)
         )
         or
         if_exp_points_to(f, context, value, cls, origin)
@@ -623,7 +635,7 @@ module PointsTo {
         exists(ObjectOrCfg origin_or_obj |
             value != undefinedVariable() and
             use_points_to_maybe_origin(f, context, value, cls, origin_or_obj) |
-            origin = origin_or_obj.fromObjectOrHere(f)
+            origin = origin_or_obj.asCfgNodeOrHere(f)
         )
     }
 
@@ -663,7 +675,7 @@ module PointsTo {
         f.isLoad() and
         exists(string name |
             exists(ObjectOrCfg orig |
-                origin = orig.fromObjectOrHere(f) and
+                origin = orig.asCfgNodeOrHere(f) and
                 named_attribute_points_to(f.getObject(name), context, name, value, cls, orig)
             )
             or
@@ -704,7 +716,7 @@ module PointsTo {
         exists(Object cls_or_mod, string name, ObjectOrCfg orig |
             receiver_object(f, context, cls_or_mod, name) and
             class_or_module_attribute(cls_or_mod, name, value, cls, orig) and
-            origin = orig.fromObjectOrHere(f)
+            origin = orig.asCfgNodeOrHere(f)
         )
         or
         points_to(f.getObject(), context, unknownValue(), theUnknownType(), origin) and value = unknownValue() and cls = theUnknownType()
@@ -735,7 +747,7 @@ module PointsTo {
         exists(EssaVariable var, ObjectOrCfg orig |
             live_import_from_dot_in_init(f, var) and
             ssa_variable_points_to(var, context, value, cls, orig) and
-            origin = orig.fromObjectOrHere(f)
+            origin = orig.asCfgNodeOrHere(f)
         )
         or
         not live_import_from_dot_in_init(f, _) and
@@ -743,7 +755,7 @@ module PointsTo {
             points_to(f.getModule(name), context, mod, _, _) |
             exists(ObjectOrCfg orig |
                 Layer::module_attribute_points_to(mod, name, value, cls, orig) and
-                origin = orig.fromObjectOrHere(f)
+                origin = orig.asCfgNodeOrHere(f)
             )
         )
     }
@@ -1644,7 +1656,7 @@ module PointsTo {
             )
             or
             exists(EssaVariable obj, PointsToContext caller, ObjectOrCfg orig |
-                origin = orig.fromObjectOrHere(def.getDefiningNode()) and
+                origin = orig.asCfgNodeOrHere(def.getDefiningNode()) and
                 ssa_variable_points_to(obj, caller, value, cls, orig) and
                 callsite_self_argument_transfer(obj, caller, def, context)
             )
@@ -1749,7 +1761,7 @@ module PointsTo {
             exists(EssaVariable var, PointsToContext outer, ObjectOrCfg orig |
                 Flow::scope_entry_value_transfer(var, outer, def, context) and
                 ssa_variable_points_to(var, outer, value, cls, orig) and
-                origin = orig.fromObjectOrHere(def.getDefiningNode())
+                origin = orig.asCfgNodeOrHere(def.getDefiningNode())
             )
             or
             /* Undefined variable */
@@ -1932,7 +1944,7 @@ module PointsTo {
             exists(EssaVariable var, PointsToContext outer, ObjectOrCfg orig |
                 Flow::scope_entry_value_transfer(var, outer, def, context) and
                 ssa_variable_named_attribute_points_to(var, outer, name, value, cls, orig) and
-                origin = orig.fromObjectOrHere(def.getDefiningNode())
+                origin = orig.asCfgNodeOrHere(def.getDefiningNode())
             )
             or
             origin = def.getDefiningNode() and
@@ -1950,7 +1962,7 @@ module PointsTo {
         private predicate assignment_named_attribute_points_to(AssignmentDefinition def, PointsToContext context, string name, Object value, ClassObject cls, ControlFlowNode origin) {
             exists(ObjectOrCfg orig |
                 named_attribute_points_to(def.getValue(), context, name, value, cls, orig) and
-                origin = orig.fromObjectOrHere(def.getDefiningNode())
+                origin = orig.asCfgNodeOrHere(def.getDefiningNode())
             )
         }
 

--- a/python/ql/src/semmle/python/pointsto/PointsTo.qll.orig
+++ b/python/ql/src/semmle/python/pointsto/PointsTo.qll.orig
@@ -55,7 +55,7 @@ library class CfgOrigin extends @py_object {
 
     pragma[inline]
     CfgOrigin fix(ControlFlowNode here) {
-        if this = unknownValue().asBuiltin() then
+        if this = unknownValue() then
             result = here
         else
             result = this
@@ -105,14 +105,8 @@ module CfgOrigin {
         result = f
     }
 
-    CfgOrigin fromObject(Object obj) {
-        result = obj.asCfgNode()
-        or
-        obj.isBuiltin() and result = unknown()
-    }
-
     CfgOrigin unknown() {
-        result = unknownValue().asBuiltin()
+        result = unknownValue()
     }
 
 }
@@ -168,7 +162,7 @@ module PointsTo {
         pragma [nomagic]
         private predicate decorator_call(Object method, ClassObject decorator, FunctionObject func) {
             exists(CallNode f, PointsToContext imp |
-                method.asCfgNode() = f and imp.isImport() and
+                method = f and imp.isImport() and
                 points_to(f.getFunction(), imp, decorator, _, _) and
                 points_to(f.getArg(0), imp, func, _, _)
             )
@@ -203,7 +197,7 @@ module PointsTo {
                     imp.isImport()
                 )
             ) and explicitly_imported(value) and
-            value = package.submodule(name) and cls = theModuleType() and origin = CfgOrigin::fromObject(value)
+            value = package.submodule(name) and cls = theModuleType() and origin = CfgOrigin::fromCfgNode(value)
         }
 
         /** INTERNAL -- `Use m.attributeRefersTo(name, obj, origin)` instead.
@@ -437,7 +431,7 @@ module PointsTo {
     }
 
     private boolean module_exports_boolean(ModuleObject mod, string name) {
-        py_cmembers_versioned(mod.asBuiltin(), name, _, major_version().toString()) and
+        py_cmembers_versioned(mod, name, _, major_version().toString()) and
         name.charAt(0) != "_" and result = true
         or
         result = package_exports_boolean(mod, name)
@@ -517,7 +511,7 @@ module PointsTo {
     private predicate points_to_candidate(ControlFlowNode f, PointsToContext context, Object value, ClassObject cls, ControlFlowNode origin) {
         simple_points_to(f, value, cls, origin) and context.appliesToScope(f.getScope())
         or
-        f.isClass() and value.asCfgNode() = f  and origin = f and context.appliesToScope(f.getScope()) and
+        f.isClass() and value = f  and origin = f and context.appliesToScope(f.getScope()) and
         cls = Types::class_get_meta_class(value)
         or
         exists(boolean b |
@@ -638,8 +632,13 @@ module PointsTo {
 
     /** Gets an object pointed to by a use (of a variable). */
     private predicate use_points_to(NameNode f, PointsToContext context, Object value, ClassObject cls, ControlFlowNode origin) {
-        exists(CfgOrigin origin_or_obj |
+<<<<<<< HEAD
+        exists(ObjectOrCfg origin_or_obj |
             value != undefinedVariable() and
+=======
+        exists(CfgOrigin origin_or_obj |
+            not value = undefinedVariable() and
+>>>>>>> fe09c0d... Python: Rename class.
             use_points_to_maybe_origin(f, context, value, cls, origin_or_obj) |
             origin = origin_or_obj.asCfgNodeOrHere(f)
         )
@@ -656,7 +655,7 @@ module PointsTo {
             Types::six_add_metaclass(f, value, meta) and
             points_to(meta, context, cls, _, _)
         ) and
-        origin = CfgOrigin::fromObject(value)
+        origin = value
     }
 
     /** Holds if `obj.name` points to `(value, cls, orig)`. */
@@ -666,8 +665,8 @@ module PointsTo {
         Types::class_attribute_lookup(obj, name, value, cls, orig) and cls != theStaticMethodType() and cls != theClassMethodType()
         or
         /* Static methods of the class */
-        exists(CallNode sm |
-            Types::class_attribute_lookup(obj, name, Object::fromCfgNode(sm), theStaticMethodType(), _) and sm.getArg(0) = value.asCfgNode() and
+        exists(CallNode sm | 
+            Types::class_attribute_lookup(obj, name, sm, theStaticMethodType(), _) and sm.getArg(0) = value and 
             cls = thePyFunctionType() and orig = CfgOrigin::fromCfgNode(sm.getArg(0))
         )
         or
@@ -688,7 +687,7 @@ module PointsTo {
             /* Static methods on the class of the instance */
             exists(CallNode sm, ClassObject icls |
                 points_to(f.getObject(name), context, _, icls, _) and
-                Types::class_attribute_lookup(icls, name, Object::fromCfgNode(sm), theStaticMethodType(), _) and sm.getArg(0) = value.asCfgNode() and cls = thePyFunctionType() and origin = CfgOrigin::fromObject(value)
+                Types::class_attribute_lookup(icls, name, sm, theStaticMethodType(), _) and sm.getArg(0) = value and cls = thePyFunctionType() and origin = value
             )
             or
             /* Unknown instance attributes */
@@ -801,7 +800,7 @@ module PointsTo {
             points_to(left, context, _, cls, _) and
             points_to(right, context, _, cls, _)
         ) and
-        value = Object::fromCfgNode(origin) and origin = b
+        value = origin and origin = b
     }
 
     pragma [noinline]
@@ -975,8 +974,8 @@ module PointsTo {
 
     private predicate subscript_points_to(SubscriptNode sub, PointsToContext context, Object value, ClassObject cls, ControlFlowNode origin) {
         exists(Object unknownCollection |
-            varargs_points_to(unknownCollection.asCfgNode(), _) or
-            kwargs_points_to(unknownCollection.asCfgNode(), _)
+            varargs_points_to(unknownCollection, _) or
+            kwargs_points_to(unknownCollection, _)
             |
             sub.isLoad() and
             points_to(sub.getValue(), context, unknownCollection, _, _) and
@@ -1109,7 +1108,7 @@ module PointsTo {
              (
                 cls = theNoneType() and value = theNoneObject()
                 or
-                cls != theNoneType() and value = Object::fromCfgNode(f)
+                cls != theNoneType() and value = f
              )
          }
 
@@ -1164,7 +1163,7 @@ module PointsTo {
          predicate call_to_generator_points_to(CallNode f, PointsToContext context, Object value, ClassObject cls, ControlFlowNode origin) {
              exists(PyFunctionObject func |
                  f = get_a_call(func, context) |
-                 func.getFunction().isGenerator() and origin = f and value = Object::fromCfgNode(f) and cls = theGeneratorType()
+                 func.getFunction().isGenerator() and origin = f and value = f and cls = theGeneratorType()
              )
          }
 
@@ -1204,7 +1203,7 @@ module PointsTo {
              call_to_type_known_builtin_class_points_to(f, context, value, cls, origin)
              or
              /* Case 3 */
-             instantiation(f, context, cls) and value = Object::fromCfgNode(f) and f = origin
+             instantiation(f, context, cls) and value = f and f = origin
              or
              /* Case 4 */
              call_points_to_builtin_function(f, context, value, cls, origin)
@@ -1613,9 +1612,9 @@ module PointsTo {
                 param = def.getDefiningNode() |
                 varargs_points_to(param, cls) and value = theEmptyTupleObject() and origin = param
                 or
-                varargs_points_to(param, cls) and value = Object::fromCfgNode(param) and origin = param
+                varargs_points_to(param, cls) and value = param and origin = param
                 or
-                kwargs_points_to(param, cls) and value = Object::fromCfgNode(param) and origin = param
+                kwargs_points_to(param, cls) and value = param and origin = param
             )
             or
             exists(PointsToContext caller, CallNode call, FunctionObject func, Parameter p |
@@ -1653,7 +1652,7 @@ module PointsTo {
                 context.isRuntime() and context.appliesToScope(scope) and
                 scope.getScope() = cls.getPyClass() and
                 Types::concrete_class(cls) and
-                origin = def.getDefiningNode() and value = Object::fromCfgNode(origin) and
+                value = def.getDefiningNode() and origin = value and
                 /* We want to allow decorated functions, otherwise we lose a lot of useful information.
                  * However, we want to exclude any function whose arguments are permuted by the decorator.
                  * In general we can't do that, but we can special case the most common ones.
@@ -1724,7 +1723,7 @@ module PointsTo {
                 package.getInitModule().getModule() = def.getDefiningNode().getScope() |
                 value = package.submodule(def.getSourceVariable().getName()) and
                 cls = theModuleType() and
-                origin = CfgOrigin::fromObject(value) and
+                origin = value and
                 context.isImport()
             )
         }
@@ -2258,10 +2257,10 @@ module PointsTo {
         predicate equatable_value(Object o) {
             comparable_value(o)
             or
-            o.asCfgNode().(ControlFlowNode).getScope() instanceof Module and
+            o.(ControlFlowNode).getScope() instanceof Module and
             exists(ClassObject c |
                 c.isBuiltin() and
-                points_to(o.asCfgNode().(CallNode).getFunction(), _, c, _, _)
+                points_to(o.(CallNode).getFunction(), _, c, _, _)
             )
         }
 
@@ -2713,7 +2712,7 @@ module PointsTo {
                 obj = unknownValue() and result = theUnknownType()
             )
             or
-            result = cls.getBuiltinClass() and is_c_metaclass(result)
+            py_cobjecttypes(cls, result) and is_c_metaclass(result)
             or
             exists(ControlFlowNode meta |
                 Types::six_add_metaclass(_, cls, meta) and
@@ -2736,7 +2735,7 @@ module PointsTo {
         }
 
         private boolean has_declared_metaclass(ClassObject cls) {
-            exists(cls.getBuiltinClass()) and result = true
+            py_cobjecttypes(cls, _) and result = true
             or
             result = has_six_add_metaclass(cls).booleanOr(has_metaclass_var_metaclass(cls))
         }
@@ -2801,7 +2800,7 @@ module PointsTo {
 
         private ControlFlowNode decorator_call_callee(ClassObject cls) {
             exists(CallNode decorator_call, CallNode decorator |
-                 decorator_call.getArg(0) = cls.asCfgNode() and
+                 decorator_call.getArg(0) = cls and
                  decorator = decorator_call.getFunction() and
                  result = decorator.getFunction()
             )
@@ -2825,7 +2824,7 @@ module PointsTo {
         /** INTERNAL -- Do not use */
         cached predicate six_add_metaclass(CallNode decorator_call, ClassObject decorated, ControlFlowNode metaclass) {
             exists(CallNode decorator |
-                decorator_call.getArg(0) = decorated.asCfgNode() and
+                decorator_call.getArg(0) = decorated and
                 decorator = decorator_call.getFunction() and
                 decorator.getArg(0) = metaclass |
                 points_to(decorator.getFunction(), _, six_add_metaclass_function(), _, _)
@@ -2903,7 +2902,7 @@ class SuperCall extends Object {
 
     SuperCall() {
         exists(CallNode call, PointsToContext context |
-            call = this.asCfgNode() and
+            call = this and
             PointsTo::points_to(call.getFunction(), _, theSuperType(), _, _) |
             PointsTo::points_to(call.getArg(0), context, start, _, _) and
             self.getASourceUse() = call.getArg(1)
@@ -2930,7 +2929,7 @@ class SuperCall extends Object {
     }
 
     predicate instantiation(PointsToContext ctx, ControlFlowNode f) {
-        PointsTo::points_to(this.asCfgNode().(CallNode).getArg(0), ctx, start, _, _) and f = this.asCfgNode()
+        PointsTo::points_to(this.(CallNode).getArg(0), ctx, start, _, _) and f = this
     }
 
     EssaVariable getSelf() {
@@ -2950,7 +2949,7 @@ class SuperBoundMethod extends Object {
     cached
     SuperBoundMethod() {
         exists(ControlFlowNode object |
-            this.asCfgNode().(AttrNode).getObject(name) = object |
+            this.(AttrNode).getObject(name) = object |
             PointsTo::points_to(object, _, superObject, _, _)
         )
     }
@@ -2963,22 +2962,12 @@ class SuperBoundMethod extends Object {
     }
 
     predicate instantiation(PointsToContext ctx, ControlFlowNode f) {
-        PointsTo::points_to(this.asCfgNode().(AttrNode).getObject(name), ctx, superObject, _, _) and f = this.asCfgNode()
+        PointsTo::points_to(this.(AttrNode).getObject(name), ctx, superObject, _, _) and f = this
     }
 
     EssaVariable getSelf() {
         result = superObject.getSelf()
     }
 
-}
-
-private Object object_for_string(string text) {
-    result.getBuiltinClass() =  theStrType() and
-    exists(string repr |
-        repr = result.getBuiltinName() and
-        repr.charAt(1) = "'" |
-        /* Strip quotes off repr */
-        text = repr.substring(2, repr.length()-1)
-    )
 }
 

--- a/python/ql/src/semmle/python/security/injection/Sql.qll
+++ b/python/ql/src/semmle/python/security/injection/Sql.qll
@@ -17,12 +17,12 @@ private StringObject first_part(ControlFlowNode command) {
     or
     exists(CallNode call, SequenceObject seq |
         call = command |
-        call = theStrType().lookupAttribute("join") and
+        call.getFunction().(AttrNode).getObject("join").refersTo(_, theStrType(), _) and
         call.getArg(0).refersTo(seq) and
         seq.getInferredElement(0) = result
     )
     or
-    command.(BinaryExprNode).getOp() instanceof Mod and 
+    command.(BinaryExprNode).getOp() instanceof Mod and
     command.getNode().(StrConst).getLiteralObject() = result
 }
 

--- a/python/ql/src/semmle/python/types/ClassObject.qll
+++ b/python/ql/src/semmle/python/types/ClassObject.qll
@@ -10,19 +10,6 @@ predicate is_c_metaclass(Object o) {
 }
 
 
-library class ObjectOrCfg extends @py_object {
-
-    string toString() {
-        /* Not to be displayed */
-        none()
-    }
-
-    ControlFlowNode getOrigin() {
-        result = this
-    }
-
-}
-
 /** A class whose instances represents Python classes.
  *  Instances of this class represent either builtin classes 
  *  such as `list` or `str`, or program-defined Python classes 

--- a/python/ql/src/semmle/python/types/ClassObject.qll
+++ b/python/ql/src/semmle/python/types/ClassObject.qll
@@ -134,13 +134,19 @@ class ClassObject extends Object {
 
     /** Whether the named attribute refers to the object and origin */
     predicate attributeRefersTo(string name, Object obj, ControlFlowNode origin) {
-        PointsTo::Types::class_attribute_lookup(this, name, obj, _, origin)
+        exists(ObjectOrCfg orig |
+            origin = orig.toCfgNode() and
+            PointsTo::Types::class_attribute_lookup(this, name, obj, _, orig)
+        )
     }
 
     /** Whether the named attribute refers to the object, class and origin */
     predicate attributeRefersTo(string name, Object obj, ClassObject cls, ControlFlowNode origin) {
         not obj = unknownValue() and
-        PointsTo::Types::class_attribute_lookup(this, name, obj, cls, origin)
+        exists(ObjectOrCfg orig |
+            origin = orig.toCfgNode() and
+            PointsTo::Types::class_attribute_lookup(this, name, obj, cls, orig)
+        )
     }
 
     /** Whether this class has a attribute named `name`, either declared or inherited.*/

--- a/python/ql/src/semmle/python/types/ClassObject.qll
+++ b/python/ql/src/semmle/python/types/ClassObject.qll
@@ -134,7 +134,7 @@ class ClassObject extends Object {
 
     /** Whether the named attribute refers to the object and origin */
     predicate attributeRefersTo(string name, Object obj, ControlFlowNode origin) {
-        exists(ObjectOrCfg orig |
+        exists(CfgOrigin orig |
             origin = orig.toCfgNode() and
             PointsTo::Types::class_attribute_lookup(this, name, obj, _, orig)
         )
@@ -143,7 +143,7 @@ class ClassObject extends Object {
     /** Whether the named attribute refers to the object, class and origin */
     predicate attributeRefersTo(string name, Object obj, ClassObject cls, ControlFlowNode origin) {
         not obj = unknownValue() and
-        exists(ObjectOrCfg orig |
+        exists(CfgOrigin orig |
             origin = orig.toCfgNode() and
             PointsTo::Types::class_attribute_lookup(this, name, obj, cls, orig)
         )

--- a/python/ql/src/semmle/python/types/Descriptors.qll
+++ b/python/ql/src/semmle/python/types/Descriptors.qll
@@ -15,13 +15,13 @@ class BoundMethod extends Object {
 
 }
 
-private predicate bound_method(AttrNode binding, FunctionObject method) {
-    binding = method.getAMethodCall().getFunction()
+private predicate bound_method(Object binding, FunctionObject method) {
+    binding.asCfgNode().(AttrNode) = method.getAMethodCall().getFunction()
 }
 
 private predicate decorator_call(Object method, ClassObject decorator, FunctionObject func) {
     exists(CallNode f |
-        method = f and
+        method = Object::fromCfgNode(f) and
         f.getFunction().refersTo(decorator) and
         PointsTo::points_to(f.getArg(0), _, func, _, _)
     )

--- a/python/ql/src/semmle/python/types/Extensions.qll
+++ b/python/ql/src/semmle/python/types/Extensions.qll
@@ -56,7 +56,7 @@ class RangeIterationVariableFact extends CustomPointsToFact {
     }
 
     override predicate pointsTo(Context context, Object value, ClassObject cls, ControlFlowNode origin) {
-        value = this and 
+        value.asCfgNode() = this and 
         origin = this and
         cls = theIntType() and
         context.appliesTo(this)

--- a/python/ql/src/semmle/python/types/FunctionObject.qll
+++ b/python/ql/src/semmle/python/types/FunctionObject.qll
@@ -257,23 +257,23 @@ abstract class BuiltinCallable extends FunctionObject {
 class BuiltinMethodObject extends BuiltinCallable {
 
     BuiltinMethodObject() {
-        py_cobjecttypes(this, theMethodDescriptorType())
+        this.getBuiltinClass() = theMethodDescriptorType()
         or
-        py_cobjecttypes(this, theBuiltinFunctionType()) and exists(ClassObject c | py_cmembers_versioned(c, _, this, major_version().toString()))
+        this.getBuiltinClass() = theBuiltinFunctionType() and exists(ClassObject c | py_cmembers_versioned(c.asBuiltin(), _, this.asBuiltin(), major_version().toString()))
         or
-        exists(ClassObject wrapper_descriptor | 
-            py_cobjecttypes(this, wrapper_descriptor) and
-            py_cobjectnames(wrapper_descriptor, "wrapper_descriptor")
+        exists(ClassObject wrapper_descriptor |
+            wrapper_descriptor = this.getBuiltinClass() and
+            wrapper_descriptor.getBuiltinName() = "wrapper_descriptor"
         )
     }
 
     override string getQualifiedName() {
         exists(ClassObject cls |
-            py_cmembers_versioned(cls, _, this, major_version().toString()) |
+            py_cmembers_versioned(cls.asBuiltin(), _, this.asBuiltin(), major_version().toString()) |
             result = cls.getName() + "." + this.getName()
         )
         or
-        not exists(ClassObject cls | py_cmembers_versioned(cls, _, this, major_version().toString())) and
+        not exists(ClassObject cls | py_cmembers_versioned(cls.asBuiltin(), _, this.asBuiltin(), major_version().toString())) and
         result = this.getName()
     }
 
@@ -282,7 +282,7 @@ class BuiltinMethodObject extends BuiltinCallable {
     }
 
     override string getName() {
-        py_cobjectnames(this, result)
+        result = this.getBuiltinName()
     }
 
     override string toString() {
@@ -308,7 +308,7 @@ class BuiltinMethodObject extends BuiltinCallable {
     }
 
     override ClassObject getAReturnType() {
-        ext_rettype(this, result)
+        ext_rettype(this.asBuiltin(), result.asBuiltin())
     }
 
 }
@@ -316,11 +316,11 @@ class BuiltinMethodObject extends BuiltinCallable {
 class BuiltinFunctionObject extends BuiltinCallable {
 
     BuiltinFunctionObject() {
-        py_cobjecttypes(this, theBuiltinFunctionType()) and exists(ModuleObject m | py_cmembers_versioned(m, _, this, major_version().toString()))
+        this.getBuiltinClass() = theBuiltinFunctionType() and exists(ModuleObject m | py_cmembers_versioned(m.asBuiltin(), _, this.asBuiltin(), major_version().toString()))
     }
 
     override string getName() {
-        py_cobjectnames(this, result)
+        result = this.getBuiltinName()
     }
 
     override string getQualifiedName() {
@@ -355,7 +355,7 @@ class BuiltinFunctionObject extends BuiltinCallable {
         this = builtin_object("intern") and result = theStrType()
         or
         /* Fix a few minor inaccuracies in the CPython analysis */ 
-        ext_rettype(this, result) and not (
+        ext_rettype(this.asBuiltin(), result.asBuiltin()) and not (
             this = builtin_object("__import__") and result = theNoneType()
             or
             this = builtin_object("compile") and result = theNoneType()

--- a/python/ql/src/semmle/python/types/ModuleObject.qll
+++ b/python/ql/src/semmle/python/types/ModuleObject.qll
@@ -165,11 +165,17 @@ class PythonModuleObject extends ModuleObject {
     }
 
     override predicate attributeRefersTo(string name, Object value, ControlFlowNode origin) {
-         PointsTo::py_module_attributes(this.getModule(), name, value, _, origin)
+        exists(ObjectOrCfg orig |
+            origin = orig.toCfgNode() and
+            PointsTo::py_module_attributes(this.getModule(), name, value, _, orig)
+        )
     }
 
     override predicate attributeRefersTo(string name, Object value, ClassObject cls, ControlFlowNode origin) {
-         PointsTo::py_module_attributes(this.getModule(), name, value, cls, origin)
+        exists(ObjectOrCfg orig |
+            origin = orig.toCfgNode() and
+            PointsTo::py_module_attributes(this.getModule(), name, value, cls, orig)
+        )
     }
 
 }
@@ -247,11 +253,17 @@ class PackageObject extends ModuleObject {
     }
 
     override predicate attributeRefersTo(string name, Object value, ControlFlowNode origin) {
-        PointsTo::package_attribute_points_to(this, name, value, _, origin)
+        exists(ObjectOrCfg orig |
+            origin = orig.toCfgNode() and
+            PointsTo::package_attribute_points_to(this, name, value, _, orig)
+        )
     }
 
     override predicate attributeRefersTo(string name, Object value, ClassObject cls, ControlFlowNode origin) {
-        PointsTo::package_attribute_points_to(this, name, value, cls, origin)
+        exists(ObjectOrCfg orig |
+            origin = orig.toCfgNode() and
+            PointsTo::package_attribute_points_to(this, name, value, cls, orig)
+        )
     }
 
     Location getLocation() {

--- a/python/ql/src/semmle/python/types/ModuleObject.qll
+++ b/python/ql/src/semmle/python/types/ModuleObject.qll
@@ -165,14 +165,14 @@ class PythonModuleObject extends ModuleObject {
     }
 
     override predicate attributeRefersTo(string name, Object value, ControlFlowNode origin) {
-        exists(ObjectOrCfg orig |
+        exists(CfgOrigin orig |
             origin = orig.toCfgNode() and
             PointsTo::py_module_attributes(this.getModule(), name, value, _, orig)
         )
     }
 
     override predicate attributeRefersTo(string name, Object value, ClassObject cls, ControlFlowNode origin) {
-        exists(ObjectOrCfg orig |
+        exists(CfgOrigin orig |
             origin = orig.toCfgNode() and
             PointsTo::py_module_attributes(this.getModule(), name, value, cls, orig)
         )
@@ -253,14 +253,14 @@ class PackageObject extends ModuleObject {
     }
 
     override predicate attributeRefersTo(string name, Object value, ControlFlowNode origin) {
-        exists(ObjectOrCfg orig |
+        exists(CfgOrigin orig |
             origin = orig.toCfgNode() and
             PointsTo::package_attribute_points_to(this, name, value, _, orig)
         )
     }
 
     override predicate attributeRefersTo(string name, Object value, ClassObject cls, ControlFlowNode origin) {
-        exists(ObjectOrCfg orig |
+        exists(CfgOrigin orig |
             origin = orig.toCfgNode() and
             PointsTo::package_attribute_points_to(this, name, value, cls, orig)
         )

--- a/python/ql/src/semmle/python/types/Properties.qll
+++ b/python/ql/src/semmle/python/types/Properties.qll
@@ -8,11 +8,11 @@ import python
  *  Also any instances of types.GetSetDescriptorType (which are equivalent, but implemented in C)
  */
 abstract class PropertyObject extends Object {
-  
+
     PropertyObject() {
-        property_getter(this, _)
+        property_getter(this.asCfgNode(), _)
         or
-        py_cobjecttypes(this, theBuiltinPropertyType())
+        this.getBuiltinClass() = theBuiltinPropertyType()
     }
 
     /** Gets the name of this property */
@@ -47,7 +47,7 @@ abstract class PropertyObject extends Object {
 class PythonPropertyObject extends PropertyObject {
 
     PythonPropertyObject() {
-        property_getter(this, _)
+        property_getter(this.asCfgNode(), _)
     }
 
     override string getName() {
@@ -56,7 +56,7 @@ class PythonPropertyObject extends PropertyObject {
 
     /** Gets the getter function of this property */
     override FunctionObject getGetter() {
-         property_getter(this, result)
+         property_getter(this.asCfgNode(), result)
     }
 
     override ClassObject getInferredPropertyType() {
@@ -65,12 +65,12 @@ class PythonPropertyObject extends PropertyObject {
 
     /** Gets the setter function of this property */
     override FunctionObject getSetter() {
-         property_setter(this, result)
+         property_setter(this.asCfgNode(), result)
     }
 
     /** Gets the deleter function of this property */
     override FunctionObject getDeleter() {
-         property_deleter(this, result)
+         property_deleter(this.asCfgNode(), result)
     }
 
 }
@@ -78,16 +78,16 @@ class PythonPropertyObject extends PropertyObject {
 class BuiltinPropertyObject extends PropertyObject {
 
     BuiltinPropertyObject() {
-        py_cobjecttypes(this, theBuiltinPropertyType())
+        this.getBuiltinClass() = theBuiltinPropertyType()
     }
 
     override string getName() {
-        py_cobjectnames(this, result)
+        result = this.getBuiltinName()
     }
 
     /** Gets the getter method wrapper of this property */
     override Object getGetter() {
-         py_cmembers_versioned(this, "__get__", result, major_version().toString())
+         py_cmembers_versioned(this.asBuiltin(), "__get__", result.asBuiltin(), major_version().toString())
     }
 
     override ClassObject getInferredPropertyType() {
@@ -96,12 +96,12 @@ class BuiltinPropertyObject extends PropertyObject {
 
     /** Gets the setter method wrapper of this property */
     override Object getSetter() {
-         py_cmembers_versioned(this, "__set__", result, major_version().toString())
+         py_cmembers_versioned(this.asBuiltin(), "__set__", result.asBuiltin(), major_version().toString())
     }
 
     /** Gets the deleter method wrapper of this property */
     override Object getDeleter() {
-         py_cmembers_versioned(this, "__delete__", result, major_version().toString())
+         py_cmembers_versioned(this.asBuiltin(), "__delete__", result.asBuiltin(), major_version().toString())
     }
 
 }
@@ -116,7 +116,7 @@ private predicate property_setter(CallNode decorated, FunctionObject setter) {
     property_getter(decorated, _)
     and
     exists(CallNode setter_call, AttrNode prop_setter |
-        prop_setter.getObject("setter").refersTo((Object)decorated) |
+        prop_setter.getObject("setter").refersTo(Object::fromCfgNode(decorated)) |
         setter_call.getArg(0).refersTo(setter)
         and
         setter_call.getFunction() = prop_setter
@@ -131,7 +131,7 @@ private predicate property_deleter(CallNode decorated, FunctionObject deleter) {
     property_getter(decorated, _)
     and
     exists(CallNode deleter_call, AttrNode prop_deleter |
-        prop_deleter.getObject("deleter").refersTo((Object)decorated) |
+        prop_deleter.getObject("deleter").refersTo(Object::fromCfgNode(decorated)) |
         deleter_call.getArg(0).refersTo(deleter)
         and
         deleter_call.getFunction() = prop_deleter

--- a/python/ql/src/semmle/python/types/Version.qll
+++ b/python/ql/src/semmle/python/types/Version.qll
@@ -20,15 +20,15 @@ class Version extends int {
 }
 
 Object theSysVersionInfoTuple() {
-    py_cmembers_versioned(theSysModuleObject(), "version_info", result, major_version().toString())
+    py_cmembers_versioned(theSysModuleObject().asBuiltin(), "version_info", result.asBuiltin(), major_version().toString())
 }
 
 Object theSysHexVersionNumber() {
-    py_cmembers_versioned(theSysModuleObject(), "hexversion", result, major_version().toString())
+    py_cmembers_versioned(theSysModuleObject().asBuiltin(), "hexversion", result.asBuiltin(), major_version().toString())
 }
 
 Object theSysVersionString() {
-    py_cmembers_versioned(theSysModuleObject(), "version", result, major_version().toString())
+    py_cmembers_versioned(theSysModuleObject().asBuiltin(), "version", result.asBuiltin(), major_version().toString())
 }
 
 
@@ -75,7 +75,7 @@ class VersionGuard extends ConditionBlock {
 
     VersionGuard() {
         exists(VersionTest v |
-            PointsTo::points_to(this.getLastNode(), _, v, _, _) or
+            PointsTo::points_to(this.getLastNode(), _, Object::fromCfgNode(v), _, _) or
             PointsTo::points_to(this.getLastNode(), _, _, _, v)
         )
     }
@@ -83,7 +83,7 @@ class VersionGuard extends ConditionBlock {
     predicate isTrue() {
         exists(VersionTest v |
             v.isTrue() |
-            PointsTo::points_to(this.getLastNode(), _, v, _, _) or
+            PointsTo::points_to(this.getLastNode(), _, Object::fromCfgNode(v), _, _) or
             PointsTo::points_to(this.getLastNode(), _, _, _, v)
         )
     }
@@ -154,13 +154,13 @@ class OsGuard extends ConditionBlock {
 
     OsGuard() {
         exists(OsTest t |
-            PointsTo::points_to(this.getLastNode(), _, theBoolType(), t, _)
+            PointsTo::points_to(this.getLastNode(), _, theBoolType(), Object::fromCfgNode(t), _)
         )
     }
 
     string getOs() {
         exists(OsTest t |
-            PointsTo::points_to(this.getLastNode(), _, theBoolType(), t, _) and result = t.getOs()
+            PointsTo::points_to(this.getLastNode(), _, theBoolType(), Object::fromCfgNode(t), _) and result = t.getOs()
         )
     }
 

--- a/python/ql/test/library-tests/PointsTo/customise/test.ql
+++ b/python/ql/test/library-tests/PointsTo/customise/test.ql
@@ -22,7 +22,7 @@ class HasTypeFact extends CustomPointsToOriginFact {
             name.prefix("has_type_".length()) = "has_type_" |
             cls.getName() = name.suffix("has_type_".length())
         ) and
-        value = this
+        value = Object::fromCfgNode(this)
     }
 
 }

--- a/python/ql/test/library-tests/PointsTo/imports/Runtime.expected
+++ b/python/ql/test/library-tests/PointsTo/imports/Runtime.expected
@@ -51,5 +51,5 @@
 | test.py | 24 | ControlFlowNode for IntegerLiteral | int 0 | ControlFlowNode for IntegerLiteral |
 | test.py | 24 | ControlFlowNode for argv | int 0 | ControlFlowNode for IntegerLiteral |
 | test.py | 27 | ControlFlowNode for ImportExpr | Module sys | ControlFlowNode for ImportExpr |
-| test.py | 31 | ControlFlowNode for argv | list object | ControlFlowNode for argv |
+| test.py | 31 | ControlFlowNode for argv | list object | ControlFlowNode for from sys import * |
 | x.py | 2 | ControlFlowNode for ImportExpr | Module sys | ControlFlowNode for ImportExpr |

--- a/python/ql/test/library-tests/PointsTo/imports/RuntimeWithType.expected
+++ b/python/ql/test/library-tests/PointsTo/imports/RuntimeWithType.expected
@@ -51,5 +51,5 @@
 | test.py | 24 | ControlFlowNode for IntegerLiteral | int 0 | builtin-class int | ControlFlowNode for IntegerLiteral |
 | test.py | 24 | ControlFlowNode for argv | int 0 | builtin-class int | ControlFlowNode for IntegerLiteral |
 | test.py | 27 | ControlFlowNode for ImportExpr | Module sys | builtin-class module | ControlFlowNode for ImportExpr |
-| test.py | 31 | ControlFlowNode for argv | list object | builtin-class list | ControlFlowNode for argv |
+| test.py | 31 | ControlFlowNode for argv | list object | builtin-class list | ControlFlowNode for from sys import * |
 | x.py | 2 | ControlFlowNode for ImportExpr | Module sys | builtin-class module | ControlFlowNode for ImportExpr |

--- a/python/ql/test/library-tests/PointsTo/new/ClassMethod.ql
+++ b/python/ql/test/library-tests/PointsTo/new/ClassMethod.ql
@@ -5,5 +5,5 @@ import Util
 
 from ClassMethodObject cm, CallNode call
 where call = cm.getACall()
-select locate(call.getLocation(), "lp"), cm.getFunction().toString(), cm.(ControlFlowNode).getLocation().toString()
+select locate(call.getLocation(), "lp"), cm.getFunction().toString(), cm.asCfgNode().(ControlFlowNode).getLocation().toString()
 


### PR DESCRIPTION
This adds no new capabilities, just slows things down a bit.
However, this is a necessary step towards powerful, extensible object modelling.
