### PR TITLE
doc: remove - from command arguments

### DIFF
--- a/java/ql/src/Security/CWE/CWE-078/ExecUnescaped.java
+++ b/java/ql/src/Security/CWE/CWE-078/ExecUnescaped.java
@@ -4,7 +4,7 @@ class Test {
         {
             String latlonCoords = args[1];
             Runtime rt = Runtime.getRuntime();
-            Process exec = rt.exec("cmd.exe /C latlon2utm.exe -" + latlonCoords);
+            Process exec = rt.exec("cmd.exe /C latlon2utm.exe " + latlonCoords);
         }
 
         // GOOD: use an array of arguments instead of executing a string


### PR DESCRIPTION
The bad examples for this code would prepend a `-` to the latlonCoords on the command-line, but the good example would not. I'm guessing this isn't an intentional divergence, and I found it a bit confusing.

@aschackmull 
@felicity-semmle 