### PR TITLE
C#: Refactor LibraryTypeDataFlow

### DIFF
--- a/csharp/ql/src/Language Abuse/ForeachCapture.ql
+++ b/csharp/ql/src/Language Abuse/ForeachCapture.ql
@@ -82,7 +82,6 @@ Element getCollectionAssignmentTarget(Expr e) {
     ief = mc.getQualifier().getType().getSourceDeclaration() and
     m = mc.getTarget().getSourceDeclaration() and
     ief.callableFlow(source, sink, m, _) and
-    source.getCallable() = m and
     source.getArgumentIndex() = i and
     e = mc.getArgument(i)
   )

--- a/csharp/ql/src/semmle/code/csharp/dataflow/LibraryTypeDataFlow.qll
+++ b/csharp/ql/src/semmle/code/csharp/dataflow/LibraryTypeDataFlow.qll
@@ -238,25 +238,25 @@ class CallableFlowSinkArg extends CallableFlowSink, TCallableFlowSinkArg {
 }
 
 /** Gets the flow source for argument `i` of callable `callable`. */
-CallableFlowSourceArg getFlowSourceArg(SourceDeclarationCallable callable, int i) {
+private CallableFlowSourceArg getFlowSourceArg(SourceDeclarationCallable callable, int i) {
   i = result.getArgumentIndex() and
   hasArgumentPosition(callable, i)
 }
 
 /** Gets the flow sink for argument `i` of callable `callable`. */
-CallableFlowSinkArg getFlowSinkArg(SourceDeclarationCallable callable, int i) {
+private CallableFlowSinkArg getFlowSinkArg(SourceDeclarationCallable callable, int i) {
   i = result.getArgumentIndex() and
   hasArgumentPosition(callable, i)
 }
 
 /** Gets the flow source for argument `i` of delegate `callable`. */
-CallableFlowSourceDelegateArg getDelegateFlowSourceArg(SourceDeclarationCallable callable, int i) {
+private CallableFlowSourceDelegateArg getDelegateFlowSourceArg(SourceDeclarationCallable callable, int i) {
   i = result.getArgumentIndex() and
   hasDelegateArgumentPosition(callable, i)
 }
 
 /** Gets the flow sink for the `j`th argument of the delegate at argument `i` of `callable`. */
-CallableFlowSinkDelegateArg getDelegateFlowSinkArg(SourceDeclarationCallable callable, int i, int j) {
+private CallableFlowSinkDelegateArg getDelegateFlowSinkArg(SourceDeclarationCallable callable, int i, int j) {
   result = TCallableFlowSinkDelegateArg(i, j) and
   hasDelegateArgumentPosition2(callable, i, j)
 }

--- a/csharp/ql/src/semmle/code/csharp/dataflow/LibraryTypeDataFlow.qll
+++ b/csharp/ql/src/semmle/code/csharp/dataflow/LibraryTypeDataFlow.qll
@@ -85,7 +85,7 @@ private module Cached {
     exists(LibraryTypeDataFlow ltdf, CallableFlowSource csource, CallableFlowSinkDelegateArg csink |
       ltdf.callableFlow(csource, csink, callable, preservesValue) and
       call.getTarget().getSourceDeclaration() = callable and
-      csink = getDelegateFlowSinkArg(callable, i, j) and
+      csink = getDelegateFlowSinkArg(callable, j, i) and
       source = csource.getSource(call)
     )
   }
@@ -107,7 +107,7 @@ private module Cached {
       ltdf.callableFlow(csource, csink, callable, preservesValue) and
       call.getTarget().getSourceDeclaration() = callable and
       csource = getDelegateFlowSourceArg(callable, i) and
-      csink = getDelegateFlowSinkArg(callable, j, k)
+      csink = getDelegateFlowSinkArg(callable, k, j)
     )
   }
 }

--- a/csharp/ql/src/semmle/code/csharp/dataflow/LibraryTypeDataFlow.qll
+++ b/csharp/ql/src/semmle/code/csharp/dataflow/LibraryTypeDataFlow.qll
@@ -184,12 +184,6 @@ class CallableFlowSourceArg extends CallableFlowSource, TCallableFlowSourceArg {
   override Expr getSource(Call c) { result = c.getArgument(getArgumentIndex()) }
 }
 
-/** Gets an argument flow source for callable `callable` with argument `i`. */
-CallableFlowSourceArg getFlowSourceArg(SourceDeclarationCallable callable, int i) {
-  i = result.getArgumentIndex() and
-  hasArgumentPosition(callable, i)
-}
-
 /** A flow source in a call to a library callable: output from delegate argument. */
 class CallableFlowSourceDelegateArg extends CallableFlowSource, TCallableFlowSourceDelegateArg {
   override string toString() { result = "output from argument " + getArgumentIndex().toString() }
@@ -243,17 +237,25 @@ class CallableFlowSinkArg extends CallableFlowSink, TCallableFlowSinkArg {
   }
 }
 
-/** Gets an argument flow sink for callable `callable` with argument `i`. */
+/** Gets the flow source for argument `i` of callable `callable`. */
+CallableFlowSourceArg getFlowSourceArg(SourceDeclarationCallable callable, int i) {
+  i = result.getArgumentIndex() and
+  hasArgumentPosition(callable, i)
+}
+
+/** Gets the flow sink for argument `i` of callable `callable`. */
 CallableFlowSinkArg getFlowSinkArg(SourceDeclarationCallable callable, int i) {
   i = result.getArgumentIndex() and
   hasArgumentPosition(callable, i)
 }
 
+/** Gets the flow source for argument `i` of delegate `callable`. */
 CallableFlowSourceDelegateArg getDelegateFlowSourceArg(SourceDeclarationCallable callable, int i) {
   i = result.getArgumentIndex() and
   hasDelegateArgumentPosition(callable, i)
 }
 
+/** Gets the flow sink for the `j`th argument of the delegate at argument `i` of `callable`. */
 CallableFlowSinkDelegateArg getDelegateFlowSinkArg(SourceDeclarationCallable callable, int i, int j) {
   result = TCallableFlowSinkDelegateArg(i, j) and
   hasDelegateArgumentPosition2(callable, i, j)


### PR DESCRIPTION
Remove the `callable` parameter from `TCallableFlowSourceArg`, `TCallableFlowSourceDelegateArg`, `TCallableFlowSinkArg`, `TCallableFlowSinkDelegateArg`.

The reason for this is that
- The parameter is always redundant. It never makes sense for a source or a sink to be in different callables.
- It makes the resulting IPA type much smaller.
- It is consistent with `TCallableFlowSourceQualifier`, `TCallableFlowSinkQualifier`,  `TCallableFlowSinkReturn`, which could in principle be tied to a callable as well, but are not.
- It reduces the risk that an implementation of `LibraryTypeDataFlow` binds the wrong callable in a source or sink.

These are internal predicates so do not require a change note.