### PR TITLE
C++: Revert doc-related changes to dbscheme

### DIFF
--- a/cpp/ql/src/semmlecode.cpp.dbscheme
+++ b/cpp/ql/src/semmlecode.cpp.dbscheme
@@ -233,7 +233,7 @@ svnchurn(
  * The location spans column `startcolumn` of line `startline` to
  * column `endcolumn` of line `endline` in file `file`.
  * For more information, see
- * [Locations](https://help.semmle.com/QL/learn-ql/ql/locations.html).
+ * [LGTM locations](https://lgtm.com/docs/ql/locations).
  */
 locations_default(
     /** The location of an element that is not an expression or a statement. */
@@ -250,7 +250,7 @@ locations_default(
  * The location spans column `startcolumn` of line `startline` to
  * column `endcolumn` of line `endline` in file `file`.
  * For more information, see
- * [Locations](https://help.semmle.com/QL/learn-ql/ql/locations.html).
+ * [LGTM locations](https://lgtm.com/docs/ql/locations).
  */
 locations_stmt(
     /** The location of a statement. */
@@ -267,7 +267,7 @@ locations_stmt(
  * The location spans column `startcolumn` of line `startline` to
  * column `endcolumn` of line `endline` in file `file`.
  * For more information, see
- * [Locations](https://help.semmle.com/QL/learn-ql/ql/locations.html).
+ * [LGTM locations](https://lgtm.com/docs/ql/locations).
  */
 locations_expr(
     /** The location of an expression. */


### PR DESCRIPTION
These changes to the dbscheme were made in #849 without a corresponding upgrade script in the internal repo. That's now preventing me from bumping the submodule pointer in the internal repo.