### PR TITLE
C++: Quick fix for CP in TranslatedExpr#class#ff

### DIFF
--- a/cpp/ql/src/semmle/code/cpp/ir/implementation/raw/internal/TranslatedCall.qll
+++ b/cpp/ql/src/semmle/code/cpp/ir/implementation/raw/internal/TranslatedCall.qll
@@ -255,22 +255,20 @@ abstract class TranslatedDirectCall extends TranslatedCall {
  */
 abstract class TranslatedCallExpr extends TranslatedNonConstantExpr,
     TranslatedCall {
-  override Call expr;
-
   override final Type getCallResultType() {
     result = getResultType()
   }
 
   override final predicate hasArguments() {
-    exists(expr.getArgument(0))
+    exists(expr.(Call).getArgument(0))
   }
 
   override final TranslatedExpr getQualifier() {
-    result = getTranslatedExpr(expr.getQualifier().getFullyConverted())
+    result = getTranslatedExpr(expr.(Call).getQualifier().getFullyConverted())
   }
 
   override final TranslatedExpr getArgument(int index) {
-    result = getTranslatedExpr(expr.getArgument(index).getFullyConverted())
+    result = getTranslatedExpr(expr.(Call).getArgument(index).getFullyConverted())
   }
 }
 
@@ -290,18 +288,20 @@ class TranslatedExprCall extends TranslatedCallExpr {
  * Represents the IR translation of a direct function call.
  */
 class TranslatedFunctionCall extends TranslatedCallExpr, TranslatedDirectCall {
-  override FunctionCall expr;
+  Function target;
+
+  TranslatedFunctionCall() { target = expr.(FunctionCall).getTarget() }
 
   override Function getInstructionFunction(InstructionTag tag) {
-    tag = CallTargetTag() and result = expr.getTarget()
+    tag = CallTargetTag() and result = target
   }
 
   override predicate hasReadSideEffect() {
-    not expr.getTarget().(SideEffectFunction).neverReadsMemory()
+    not target.(SideEffectFunction).neverReadsMemory()
   }
 
   override predicate hasWriteSideEffect() {
-    not expr.getTarget().(SideEffectFunction).neverWritesMemory()
+    not target.(SideEffectFunction).neverWritesMemory()
   }
 }
 

--- a/cpp/ql/src/semmle/code/cpp/ir/implementation/raw/internal/TranslatedExpr.qll
+++ b/cpp/ql/src/semmle/code/cpp/ir/implementation/raw/internal/TranslatedExpr.qll
@@ -1725,8 +1725,6 @@ class TranslatedAssignOperation extends TranslatedAssignment {
  */
 abstract class TranslatedAllocationSize extends TranslatedExpr,
     TTranslatedAllocationSize {
-  override NewOrNewArrayExpr expr;
-  
   TranslatedAllocationSize() {
     this = TTranslatedAllocationSize(expr)
   }
@@ -1768,7 +1766,7 @@ class TranslatedConstantAllocationSize extends TranslatedAllocationSize {
       Type resultType, boolean isGLValue) {
     tag = AllocationSizeTag() and
     opcode instanceof Opcode::Constant and
-    resultType = expr.getAllocator().getParameter(0).getType().getUnspecifiedType() and
+    resultType = expr.(NewOrNewArrayExpr).getAllocator().getParameter(0).getType().getUnspecifiedType() and
     isGLValue = false
   }
 
@@ -1789,7 +1787,7 @@ class TranslatedConstantAllocationSize extends TranslatedAllocationSize {
 
   override final string getInstructionConstantValue(InstructionTag tag) {
     tag = AllocationSizeTag() and
-    result = expr.getAllocatedType().getSize().toString()
+    result = expr.(NewOrNewArrayExpr).getAllocatedType().getSize().toString()
   }
 }
 
@@ -1883,8 +1881,6 @@ class TranslatedNonConstantAllocationSize extends TranslatedAllocationSize {
  */
 class TranslatedAllocatorCall extends TTranslatedAllocatorCall,
     TranslatedDirectCall {
-  override NewOrNewArrayExpr expr;
-
   TranslatedAllocatorCall() {
     this = TTranslatedAllocatorCall(expr)
   }
@@ -1898,11 +1894,11 @@ class TranslatedAllocatorCall extends TTranslatedAllocatorCall,
   }
 
   override Function getInstructionFunction(InstructionTag tag) {
-    tag = CallTargetTag() and result = expr.getAllocator()
+    tag = CallTargetTag() and result = expr.(NewOrNewArrayExpr).getAllocator()
   }
 
   override final Type getCallResultType() {
-    result = expr.getAllocator().getType().getUnspecifiedType()
+    result = expr.(NewOrNewArrayExpr).getAllocator().getType().getUnspecifiedType()
   }
 
   override final TranslatedExpr getQualifier() {
@@ -1923,10 +1919,10 @@ class TranslatedAllocatorCall extends TTranslatedAllocatorCall,
     // case.
     if index = 0 then
       result = getTranslatedAllocationSize(expr)
-    else if(index = 1 and expr.hasAlignedAllocation()) then
-      result = getTranslatedExpr(expr.getAlignmentArgument())
+    else if(index = 1 and expr.(NewOrNewArrayExpr).hasAlignedAllocation()) then
+      result = getTranslatedExpr(expr.(NewOrNewArrayExpr).getAlignmentArgument())
     else
-      result = getTranslatedExpr(expr.getAllocatorCall().getArgument(index))
+      result = getTranslatedExpr(expr.(NewOrNewArrayExpr).getAllocatorCall().getArgument(index))
   }
 }
 


### PR DESCRIPTION
The recent change (#859) to use `override` on the `expr` field somehow introduced a Cartesian product. This commit removes the override from code that seemed to be associated with the problem, and the CP is now gone.

I hope we can find a better solution soon.