### PR TITLE
 C++: Speed up variableLiveOnEntryToBlock in IR

### DIFF
--- a/cpp/ql/src/semmle/code/cpp/ir/implementation/aliased_ssa/internal/SSAConstruction.qll
+++ b/cpp/ql/src/semmle/code/cpp/ir/implementation/aliased_ssa/internal/SSAConstruction.qll
@@ -392,9 +392,15 @@ cached private module Cached {
   }
 
   private predicate variableLiveOnEntryToBlock(Alias::VirtualVariable vvar, OldBlock block) {
-    exists (int index | hasUse(vvar, _, block, index) |
-      not exists (int j | ssa_variableUpdate(vvar, _, block, j) | j < index)
-    ) or
+    exists(int firstAccess |
+      hasUse(vvar, _, block, firstAccess) and
+      firstAccess = min(int index |
+          hasUse(vvar, _, block, index)
+          or
+          ssa_variableUpdate(vvar, _, block, index)
+        )
+    )
+    or
     (variableLiveOnExitFromBlock(vvar, block) and not ssa_variableUpdate(vvar, _, block, _))
   }
 

--- a/cpp/ql/src/semmle/code/cpp/ir/implementation/unaliased_ssa/internal/SSAConstruction.qll
+++ b/cpp/ql/src/semmle/code/cpp/ir/implementation/unaliased_ssa/internal/SSAConstruction.qll
@@ -392,9 +392,15 @@ cached private module Cached {
   }
 
   private predicate variableLiveOnEntryToBlock(Alias::VirtualVariable vvar, OldBlock block) {
-    exists (int index | hasUse(vvar, _, block, index) |
-      not exists (int j | ssa_variableUpdate(vvar, _, block, j) | j < index)
-    ) or
+    exists(int firstAccess |
+      hasUse(vvar, _, block, firstAccess) and
+      firstAccess = min(int index |
+          hasUse(vvar, _, block, index)
+          or
+          ssa_variableUpdate(vvar, _, block, index)
+        )
+    )
+    or
     (variableLiveOnExitFromBlock(vvar, block) and not ssa_variableUpdate(vvar, _, block, _))
   }
 


### PR DESCRIPTION
This predicate computed a local CP between all defs and uses of the same virtual variable in a basic block. This wasn't a problem in `unaliased_ssa`, but it became a huge problem in `aliased_ssa`, probably because many variables can be modelled with a single virtual variable there.

Before this commit, evaluation of `aliased_ssa`'s `variableLiveOnEntryToBlock#ff#antijoin_rhs` on Wireshark took 80 _minutes_. After this commit, that predicate and its immediate dependencies take around 5 _seconds_.