### PR TITLE
Fix reccomendation for LargeParameter (C++)

### DIFF
--- a/cpp/ql/src/Critical/LargeParameter.cpp
+++ b/cpp/ql/src/Critical/LargeParameter.cpp
@@ -8,6 +8,6 @@ int doFoo(Names n) { //wrong: n is passed by value (meaning the entire structure
     ...
 }
 
-int doBar(Names &n) { //better, only a reference is passed
+int doBar(const Names &n) { //better, only a reference is passed
     ...
 }

--- a/cpp/ql/src/Critical/LargeParameter.ql
+++ b/cpp/ql/src/Critical/LargeParameter.ql
@@ -1,6 +1,6 @@
 /**
  * @name Large object passed by value
- * @description An object larger than 64 bytes is passed by value to a function. Passing large objects by value unnecessarily use up scarce stack space, increase the cost of calling a function and can be a security risk. Use a pointer to the object instead.
+ * @description An object larger than 64 bytes is passed by value to a function. Passing large objects by value unnecessarily use up scarce stack space, increase the cost of calling a function and can be a security risk. Use a const pointer to the object instead.
  * @kind problem
  * @problem.severity warning
  * @precision high
@@ -20,5 +20,5 @@ where f.getAParameter() = p
   and not t.getUnderlyingType() instanceof ArrayType
   and not f instanceof CopyAssignmentOperator
 select
-  p, "This parameter of type $@ is " + size.toString() + " bytes - consider passing a pointer/reference instead.",
+  p, "This parameter of type $@ is " + size.toString() + " bytes - consider passing a const pointer/reference instead.",
   t, t.toString()

--- a/cpp/ql/test/query-tests/Critical/LargeParameter/LargeParameter.expected
+++ b/cpp/ql/test/query-tests/Critical/LargeParameter/LargeParameter.expected
@@ -1,3 +1,3 @@
-| test.cpp:16:13:16:14 | _t | This parameter of type $@ is 4096 bytes - consider passing a pointer/reference instead. | test.cpp:6:8:6:20 | myLargeStruct | myLargeStruct |
-| test.cpp:24:44:24:48 | mtc_t | This parameter of type $@ is 4096 bytes - consider passing a pointer/reference instead. | test.cpp:11:7:11:21 | myTemplateClass<myLargeStruct> | myTemplateClass<myLargeStruct> |
-| test.cpp:28:49:28:49 | b | This parameter of type $@ is 4096 bytes - consider passing a pointer/reference instead. | test.cpp:6:8:6:20 | myLargeStruct | myLargeStruct |
+| test.cpp:16:13:16:14 | _t | This parameter of type $@ is 4096 bytes - consider passing a const pointer/reference instead. | test.cpp:6:8:6:20 | myLargeStruct | myLargeStruct |
+| test.cpp:24:44:24:48 | mtc_t | This parameter of type $@ is 4096 bytes - consider passing a const pointer/reference instead. | test.cpp:11:7:11:21 | myTemplateClass<myLargeStruct> | myTemplateClass<myLargeStruct> |
+| test.cpp:28:49:28:49 | b | This parameter of type $@ is 4096 bytes - consider passing a const pointer/reference instead. | test.cpp:6:8:6:20 | myLargeStruct | myLargeStruct |


### PR DESCRIPTION
The previous reccomentation changed the behaviour of the code.
A user following the advice might have broken her/his code:
With call-by-value, the original parameter is not changed.
With a call-by-reference, however, it may be changed. To be sure,
nothing breaks by blindly following the advice, suggest to pass a
const reference.