### PR TITLE
C++: Use shortestDistances HOP for IR BB indexes

### DIFF
--- a/cpp/ql/src/semmle/code/cpp/ir/implementation/aliased_ssa/IRBlock.qll
+++ b/cpp/ql/src/semmle/code/cpp/ir/implementation/aliased_ssa/IRBlock.qll
@@ -159,24 +159,13 @@ private cached module Cached {
     not startsBasicBlock(i2)
   }
 
-  /** Gets the index of `i` in its `IRBlock`. */
-  private int getMemberIndex(Instruction i) {
-    startsBasicBlock(i) and
-    result = 0
-    or
-    exists(Instruction iPrev |
-      adjacentInBlock(iPrev, i) and
-      result = getMemberIndex(iPrev) + 1
-    )
-  }
+  /** Holds if `i` is the `index`th instruction the block starting with `first`. */
+  private Instruction getInstructionFromFirst(Instruction first, int index) =
+    shortestDistances(startsBasicBlock/1, adjacentInBlock/2)(first, result, index)
 
   /** Holds if `i` is the `index`th instruction in `block`. */
   cached Instruction getInstruction(TIRBlock block, int index) {
-    exists(Instruction first |
-      block = MkIRBlock(first) and
-      index = getMemberIndex(result) and
-      adjacentInBlock*(first, result)
-    )
+    result = getInstructionFromFirst(getFirstInstruction(block), index)
   }
 
   cached int getInstructionCount(TIRBlock block) {

--- a/cpp/ql/src/semmle/code/cpp/ir/implementation/raw/IRBlock.qll
+++ b/cpp/ql/src/semmle/code/cpp/ir/implementation/raw/IRBlock.qll
@@ -159,24 +159,13 @@ private cached module Cached {
     not startsBasicBlock(i2)
   }
 
-  /** Gets the index of `i` in its `IRBlock`. */
-  private int getMemberIndex(Instruction i) {
-    startsBasicBlock(i) and
-    result = 0
-    or
-    exists(Instruction iPrev |
-      adjacentInBlock(iPrev, i) and
-      result = getMemberIndex(iPrev) + 1
-    )
-  }
+  /** Holds if `i` is the `index`th instruction the block starting with `first`. */
+  private Instruction getInstructionFromFirst(Instruction first, int index) =
+    shortestDistances(startsBasicBlock/1, adjacentInBlock/2)(first, result, index)
 
   /** Holds if `i` is the `index`th instruction in `block`. */
   cached Instruction getInstruction(TIRBlock block, int index) {
-    exists(Instruction first |
-      block = MkIRBlock(first) and
-      index = getMemberIndex(result) and
-      adjacentInBlock*(first, result)
-    )
+    result = getInstructionFromFirst(getFirstInstruction(block), index)
   }
 
   cached int getInstructionCount(TIRBlock block) {

--- a/cpp/ql/src/semmle/code/cpp/ir/implementation/unaliased_ssa/IRBlock.qll
+++ b/cpp/ql/src/semmle/code/cpp/ir/implementation/unaliased_ssa/IRBlock.qll
@@ -159,24 +159,13 @@ private cached module Cached {
     not startsBasicBlock(i2)
   }
 
-  /** Gets the index of `i` in its `IRBlock`. */
-  private int getMemberIndex(Instruction i) {
-    startsBasicBlock(i) and
-    result = 0
-    or
-    exists(Instruction iPrev |
-      adjacentInBlock(iPrev, i) and
-      result = getMemberIndex(iPrev) + 1
-    )
-  }
+  /** Holds if `i` is the `index`th instruction the block starting with `first`. */
+  private Instruction getInstructionFromFirst(Instruction first, int index) =
+    shortestDistances(startsBasicBlock/1, adjacentInBlock/2)(first, result, index)
 
   /** Holds if `i` is the `index`th instruction in `block`. */
   cached Instruction getInstruction(TIRBlock block, int index) {
-    exists(Instruction first |
-      block = MkIRBlock(first) and
-      index = getMemberIndex(result) and
-      adjacentInBlock*(first, result)
-    )
+    result = getInstructionFromFirst(getFirstInstruction(block), index)
   }
 
   cached int getInstructionCount(TIRBlock block) {


### PR DESCRIPTION
This doesn't make it much faster, but it reduces the debug output volume. It also simplifies the code.

I've found this change necessary when I compute the full IR on a Wireshark snapshot in QL4E. Without it, Eclipse runs out of memory because the console log is too large.