### PR TITLE
C#: Revert recent change to `AccessorCall`

### DIFF
--- a/change-notes/1.20/analysis-csharp.md
+++ b/change-notes/1.20/analysis-csharp.md
@@ -25,6 +25,4 @@
 
 ## Changes to QL libraries
 
-* The class `AccessorCall` (and subclasses `PropertyCall`, `IndexerCall`, and `EventCall`) have been redefined, so the expressions they represent are not necessarily the accesses themselves, but rather the expressions that give rise to the accessor calls. For example, in the property assignment `x.Prop = 0`, the call to the setter for `Prop` is no longer represented by the access `x.Prop`, but instead the whole assignment. Consequently, it is no longer safe to cast directly between `AccessorCall`s and `Access`es, and the predicate `AccessorCall::getAccess()` should be used instead.
-
 ## Changes to the autobuilder

--- a/csharp/ql/src/semmle/code/csharp/Assignable.qll
+++ b/csharp/ql/src/semmle/code/csharp/Assignable.qll
@@ -402,17 +402,14 @@ module AssignableInternal {
      * `a`, if any.
      */
     cached
-    Expr getAccessorCallValueArgument(Access a) {
-      a.getTarget() instanceof DeclarationWithAccessors and
-      (
-        exists(AssignExpr ae | tupleAssignmentDefinition(ae, a) |
-          tupleAssignmentPair(ae, a, result)
-        )
-        or
-        exists(Assignment ass | a = ass.getLValue() |
-          result = ass.getRValue() and
-          not ass.(AssignOperation).hasExpandedAssignment()
-        )
+    Expr getAccessorCallValueArgument(AccessorCall ac) {
+      exists(AssignExpr ae | tupleAssignmentDefinition(ae, ac) |
+        tupleAssignmentPair(ae, ac, result)
+      )
+      or
+      exists(Assignment ass | ac = ass.getLValue() |
+        result = ass.getRValue() and
+        not ass.(AssignOperation).hasExpandedAssignment()
       )
     }
   }

--- a/csharp/ql/src/semmle/code/csharp/Property.qll
+++ b/csharp/ql/src/semmle/code/csharp/Property.qll
@@ -513,7 +513,7 @@ class IndexerProperty extends Property {
   IndexerCall getAnIndexerCall() {
     result = getType().(RefType).getAnIndexer().getAnAccessor().getACall() and
     // The qualifier of this indexer call should be a value returned from an access of this property
-    exists(Expr qualifier | qualifier = result.getAccess().getQualifier() |
+    exists(Expr qualifier | qualifier = result.(IndexerAccess).getQualifier() |
       DataFlow::localFlow(DataFlow::exprNode(this.getAnAccess()), DataFlow::exprNode(qualifier))
     )
   }

--- a/csharp/ql/src/semmle/code/csharp/dispatch/Dispatch.qll
+++ b/csharp/ql/src/semmle/code/csharp/dispatch/Dispatch.qll
@@ -477,7 +477,7 @@ private module Internal {
 
     override Expr getArgument(int i) { result = getCall().getArgument(i) }
 
-    override Expr getQualifier() { result = getCall().getAccess().getQualifier() }
+    override Expr getQualifier() { result = getCall().(MemberAccess).getQualifier() }
 
     override Accessor getAStaticTarget() { result = getCall().getTarget() }
 

--- a/csharp/ql/src/semmle/code/csharp/exprs/Access.qll
+++ b/csharp/ql/src/semmle/code/csharp/exprs/Access.qll
@@ -381,6 +381,17 @@ class MemberConstantAccess extends FieldAccess {
 }
 
 /**
+ * An internal helper class to share logic between `PropertyAccess` and
+ * `PropertyCall`.
+ */
+library class PropertyAccessExpr extends Expr, @property_access_expr {
+  /** Gets the target of this property access. */
+  Property getProperty() { expr_access(this, result) }
+
+  override string toString() { result = "access to property " + this.getProperty().getName() }
+}
+
+/**
  * An access to a property, for example the access to `P` on line 5 in
  *
  * ```
@@ -393,13 +404,8 @@ class MemberConstantAccess extends FieldAccess {
  * }
  * ```
  */
-class PropertyAccess extends AssignableMemberAccess, @property_access_expr {
-  /** Gets the target of this property access. */
-  Property getProperty() { expr_access(this, result) }
-
+class PropertyAccess extends AssignableMemberAccess, PropertyAccessExpr {
   override Property getTarget() { result = this.getProperty() }
-
-  override string toString() { result = "access to property " + this.getProperty().getName() }
 }
 
 /**
@@ -510,6 +516,17 @@ class ElementRead extends ElementAccess, AssignableRead { }
 class ElementWrite extends ElementAccess, AssignableWrite { }
 
 /**
+ * An internal helper class to share logic between `IndexerAccess` and
+ * `IndexerCall`.
+ */
+library class IndexerAccessExpr extends Expr, @indexer_access_expr {
+  /** Gets the target of this indexer access. */
+  Indexer getIndexer() { expr_access(this, result) }
+
+  override string toString() { result = "access to indexer" }
+}
+
+/**
  * An access to an indexer, for example the access to `c` on line 5 in
  *
  * ```
@@ -522,17 +539,12 @@ class ElementWrite extends ElementAccess, AssignableWrite { }
  * }
  * ```
  */
-class IndexerAccess extends AssignableMemberAccess, ElementAccess, @indexer_access_expr {
-  /** Gets the target of this indexer access. */
-  Indexer getIndexer() { expr_access(this, result) }
-
+class IndexerAccess extends AssignableMemberAccess, ElementAccess, IndexerAccessExpr {
   override Indexer getTarget() { result = this.getIndexer() }
 
   override Indexer getQualifiedDeclaration() {
     result = ElementAccess.super.getQualifiedDeclaration()
   }
-
-  override string toString() { result = "access to indexer" }
 }
 
 /**
@@ -589,6 +601,17 @@ class VirtualIndexerAccess extends IndexerAccess {
 }
 
 /**
+ * An internal helper class to share logic between `EventAccess` and
+ * `EventCall`.
+ */
+library class EventAccessExpr extends Expr, @event_access_expr {
+  /** Gets the target of this event access. */
+  Event getEvent() { expr_access(this, result) }
+
+  override string toString() { result = "access to event " + this.getEvent().getName() }
+}
+
+/**
  * An access to an event, for example the accesses to `Click` on lines
  * 7 and 8 in
  *
@@ -605,13 +628,8 @@ class VirtualIndexerAccess extends IndexerAccess {
  * }
  * ```
  */
-class EventAccess extends AssignableMemberAccess, @event_access_expr {
-  /** Gets the target of this event access. */
-  Event getEvent() { expr_access(this, result) }
-
+class EventAccess extends AssignableMemberAccess, EventAccessExpr {
   override Event getTarget() { result = getEvent() }
-
-  override string toString() { result = "access to event " + this.getEvent().getName() }
 }
 
 /**

--- a/csharp/ql/src/semmle/code/csharp/exprs/Call.qll
+++ b/csharp/ql/src/semmle/code/csharp/exprs/Call.qll
@@ -11,24 +11,13 @@ private import semmle.code.csharp.dataflow.DelegateDataFlow
 private import semmle.code.csharp.dispatch.Dispatch
 private import dotnet
 
-/** INTERNAL: Do not use. */
-library class CallImpl extends Expr {
-  cached
-  CallImpl() {
-    this instanceof @call and
-    not this instanceof @call_access_expr
-    or
-    this instanceof AccessorCallImpl::AccessorCallImpl
-  }
-}
-
 /**
  * A call. Either a method call (`MethodCall`), a constructor initializer call
  * (`ConstructorInitializer`), a call to a user-defined operator (`OperatorCall`),
  * a delegate call (`DelegateCall`), an accessor call (`AccessorCall`), a
  * constructor call (`ObjectCreation`), or a local function call (`LocalFunctionCall`).
  */
-class Call extends DotNet::Call, CallImpl {
+class Call extends DotNet::Call, Expr, @call {
   /**
    * Gets the static (compile-time) target of this call. For example, the
    * static target of `x.M()` on line 9 is `A.M` in
@@ -566,158 +555,14 @@ class DelegateCall extends Call, @delegate_invocation_expr {
 }
 
 /**
- * Provides logic for determining the syntactic nodes associated with calls
- * to accessors. Example:
- *
- * ```
- * int Prop { get; set; }
- * public int GetProp() => Prop;
- * public void SetProp(int i) { Prop = i + 1; }
- * ```
- *
- * In the body of `GetProp()`, the call to the accessor `get_Prop()` is simply
- * the access `Prop`. However, in the body of `SetProp()`, the call to the accessor
- * `set_Prop()` is not the access `Prop`, but rather the assignment `Prop = i + 1`.
- * (Using `Prop` as the call to `set_Prop()` will yield an incorrect control flow
- * graph, where `set_Prop()` is called before `i + 1` is evaluated.)
- */
-private module AccessorCallImpl {
-  /**
-   * Holds if `e` is a tuple assignment with multiple setter assignments,
-   * for example `(Prop1, Prop2) = (0, 1)`, where both `Prop1` and `Prop2`
-   * are properties.
-   *
-   * In such cases, we cannot associate the compound assignment with the
-   * setter calls, so we instead revert to representing the calls via the
-   * individual accesses on the left hand side.
-   */
-  private predicate multiTupleSetter(Expr e) {
-    strictcount(AssignableDefinitions::TupleAssignmentDefinition def |
-      def.getExpr() = e and
-      def.getTargetAccess().getTarget() instanceof DeclarationWithGetSetAccessors
-    ) > 1
-  }
-
-  abstract class AccessorCallImpl extends Expr {
-    abstract Access getAccess();
-
-    abstract Accessor getTarget();
-
-    abstract Expr getArgument(int i);
-  }
-
-  abstract class PropertyCallImpl extends AccessorCallImpl {
-    PropertyAccess pa;
-
-    override PropertyAccess getAccess() { result = pa }
-
-    abstract override Accessor getTarget();
-
-    abstract override Expr getArgument(int i);
-  }
-
-  class PropertyGetterCall extends PropertyCallImpl, @property_access_expr {
-    PropertyGetterCall() {
-      this instanceof AssignableRead and
-      pa = this
-    }
-
-    override Getter getTarget() { result = pa.getProperty().getGetter() }
-
-    override Expr getArgument(int i) { none() }
-  }
-
-  class PropertySetterCall extends PropertyCallImpl {
-    PropertySetterCall() {
-      exists(AssignableDefinition def | pa = def.getTargetAccess() |
-        (if multiTupleSetter(def.getExpr()) then this = pa else this = def.getExpr()) and
-        not def.getExpr().(AssignOperation).hasExpandedAssignment()
-      )
-    }
-
-    override Expr getArgument(int i) {
-      i = 0 and
-      result = AssignableInternal::getAccessorCallValueArgument(pa)
-    }
-
-    override Setter getTarget() { result = pa.getProperty().getSetter() }
-  }
-
-  abstract class IndexerCallImpl extends AccessorCallImpl {
-    IndexerAccess ia;
-
-    override IndexerAccess getAccess() { result = ia }
-
-    abstract override Accessor getTarget();
-
-    abstract override Expr getArgument(int i);
-  }
-
-  class IndexerGetterCall extends IndexerCallImpl, @indexer_access_expr {
-    IndexerGetterCall() {
-      this instanceof AssignableRead and
-      ia = this
-    }
-
-    override Getter getTarget() { result = ia.getIndexer().getGetter() }
-
-    override Expr getArgument(int i) { result = ia.getIndex(i) }
-  }
-
-  class IndexerSetterCall extends IndexerCallImpl {
-    IndexerSetterCall() {
-      exists(AssignableDefinition def | ia = def.getTargetAccess() |
-        (if multiTupleSetter(def.getExpr()) then this = ia else this = def.getExpr()) and
-        not def.getExpr().(AssignOperation).hasExpandedAssignment()
-      )
-    }
-
-    override Setter getTarget() { result = ia.getIndexer().getSetter() }
-
-    override Expr getArgument(int i) {
-      result = ia.getIndex(i)
-      or
-      i = count(ia.getAnIndex()) and
-      result = AssignableInternal::getAccessorCallValueArgument(ia)
-    }
-  }
-
-  class EventCallImpl extends AccessorCallImpl, @assign_event_expr {
-    override EventAccess getAccess() { result = this.(AddOrRemoveEventExpr).getLValue() }
-
-    override EventAccessor getTarget() {
-      exists(Event e | e = this.getAccess().getEvent() |
-        this instanceof AddEventExpr and result = e.getAddEventAccessor()
-        or
-        this instanceof RemoveEventExpr and result = e.getRemoveEventAccessor()
-      )
-    }
-
-    override Expr getArgument(int i) {
-      i = 0 and
-      result = this.(AddOrRemoveEventExpr).getRValue()
-    }
-  }
-}
-
-/**
  * A call to an accessor. Either a property accessor call (`PropertyCall`),
  * an indexer accessor call (`IndexerCall`), or an event accessor call
  * (`EventCall`).
  */
-class AccessorCall extends Call {
-  private AccessorCallImpl::AccessorCallImpl impl;
+class AccessorCall extends Call, QualifiableExpr, @call_access_expr {
+  override Accessor getTarget() { none() }
 
-  AccessorCall() { this = impl }
-
-  /** Gets the underlying access. */
-  MemberAccess getAccess() { result = impl.getAccess() }
-
-  override Accessor getTarget() { result = impl.getTarget() }
-
-  override Expr getArgument(int i) { result = impl.getArgument(i) }
-
-  override string toString() { none() } // avoid multiple `toString()`s
+  override Expr getArgument(int i) { none() }
 
   override Accessor getARuntimeTarget() { result = Call.super.getARuntimeTarget() }
 }
@@ -736,15 +581,21 @@ class AccessorCall extends Call {
  * }
  * ```
  */
-class PropertyCall extends AccessorCall {
-  private AccessorCallImpl::PropertyCallImpl impl;
+class PropertyCall extends AccessorCall, PropertyAccessExpr {
+  override Accessor getTarget() {
+    exists(PropertyAccess pa, Property p | pa = this and p = getProperty() |
+      pa instanceof AssignableRead and result = p.getGetter()
+      or
+      pa instanceof AssignableWrite and result = p.getSetter()
+    )
+  }
 
-  PropertyCall() { this = impl }
+  override Expr getArgument(int i) {
+    i = 0 and
+    result = AssignableInternal::getAccessorCallValueArgument(this)
+  }
 
-  override PropertyAccess getAccess() { result = impl.getAccess() }
-
-  /** Gets property targeted by this property call. */
-  Property getProperty() { result = this.getAccess().getTarget() }
+  override string toString() { result = PropertyAccessExpr.super.toString() }
 }
 
 /**
@@ -763,15 +614,23 @@ class PropertyCall extends AccessorCall {
  * }
  * ```
  */
-class IndexerCall extends AccessorCall {
-  private AccessorCallImpl::IndexerCallImpl impl;
+class IndexerCall extends AccessorCall, IndexerAccessExpr {
+  override Accessor getTarget() {
+    exists(IndexerAccess ia, Indexer i | ia = this and i = getIndexer() |
+      ia instanceof AssignableRead and result = i.getGetter()
+      or
+      ia instanceof AssignableWrite and result = i.getSetter()
+    )
+  }
 
-  IndexerCall() { this = impl }
+  override Expr getArgument(int i) {
+    result = this.(ElementAccess).getIndex(i)
+    or
+    i = count(this.(ElementAccess).getAnIndex()) and
+    result = AssignableInternal::getAccessorCallValueArgument(this)
+  }
 
-  override IndexerAccess getAccess() { result = impl.getAccess() }
-
-  /** Gets indexer targeted by this index call. */
-  Indexer getIndexer() { result = this.getAccess().getTarget() }
+  override string toString() { result = IndexerAccessExpr.super.toString() }
 }
 
 /**
@@ -795,15 +654,27 @@ class IndexerCall extends AccessorCall {
  * }
  * ```
  */
-class EventCall extends AccessorCall, @assign_event_expr {
-  private AccessorCallImpl::EventCallImpl impl;
+class EventCall extends AccessorCall, EventAccessExpr {
+  override EventAccessor getTarget() {
+    exists(Event e, AddOrRemoveEventExpr aoree |
+      e = getEvent() and
+      aoree.getLValue() = this
+    |
+      aoree instanceof AddEventExpr and result = e.getAddEventAccessor()
+      or
+      aoree instanceof RemoveEventExpr and result = e.getRemoveEventAccessor()
+    )
+  }
 
-  EventCall() { this = impl }
+  override Expr getArgument(int i) {
+    i = 0 and
+    exists(AddOrRemoveEventExpr aoree |
+      aoree.getLValue() = this and
+      result = aoree.getRValue()
+    )
+  }
 
-  override EventAccess getAccess() { result = impl.getAccess() }
-
-  /** Gets event targeted by this event call. */
-  Event getEvent() { result = this.getAccess().getTarget() }
+  override string toString() { result = EventAccessExpr.super.toString() }
 }
 
 /**

--- a/csharp/ql/src/semmle/code/csharp/frameworks/system/Xml.qll
+++ b/csharp/ql/src/semmle/code/csharp/frameworks/system/Xml.qll
@@ -155,7 +155,7 @@ class XmlReaderSettingsCreation extends ObjectCreation {
     p = this.getType().(RefType).getAProperty() and
     exists(PropertyCall set, Expr arg |
       set.getTarget() = p.getSetter() and
-      DataFlow::localFlow(DataFlow::exprNode(this), DataFlow::exprNode(set.getAccess().getQualifier())) and
+      DataFlow::localFlow(DataFlow::exprNode(this), DataFlow::exprNode(set.getQualifier())) and
       arg = set.getAnArgument() and
       result = getBitwiseOrOperand*(arg)
     )

--- a/csharp/ql/src/semmle/code/dotnet/Expr.qll
+++ b/csharp/ql/src/semmle/code/dotnet/Expr.qll
@@ -5,7 +5,6 @@
 import Expr
 import Type
 import Callable
-private import csharp as CS
 
 /** An expression. */
 class Expr extends Element, @dotnet_expr {
@@ -26,9 +25,7 @@ class Expr extends Element, @dotnet_expr {
 }
 
 /** A call. */
-class Call extends Expr {
-  Call() { this instanceof @cil_call_any or this instanceof CS::CallImpl }
-
+class Call extends Expr, @dotnet_call {
   /** Gets the target of this call. */
   Callable getTarget() { none() }
 

--- a/csharp/ql/test/library-tests/arguments/argumentByName.expected
+++ b/csharp/ql/test/library-tests/arguments/argumentByName.expected
@@ -17,23 +17,21 @@
 | arguments.cs:39:9:39:28 | call to method f3 | arguments.cs:39:27:39:27 | 0 | o |
 | arguments.cs:40:9:40:42 | call to method f3 | arguments.cs:40:18:40:35 | array creation of type Int32[] | args |
 | arguments.cs:40:9:40:42 | call to method f3 | arguments.cs:40:41:40:41 | 0 | o |
-| arguments.cs:54:9:54:16 | ... = ... | arguments.cs:54:16:54:16 | 0 | value |
-| arguments.cs:55:9:55:25 | ... = ... | arguments.cs:55:16:55:25 | access to indexer | value |
+| arguments.cs:54:9:54:12 | access to property Prop | arguments.cs:54:16:54:16 | 0 | value |
+| arguments.cs:55:9:55:12 | access to property Prop | arguments.cs:55:16:55:25 | access to indexer | value |
 | arguments.cs:55:16:55:25 | access to indexer | arguments.cs:55:21:55:21 | 1 | a |
 | arguments.cs:55:16:55:25 | access to indexer | arguments.cs:55:24:55:24 | 2 | b |
 | arguments.cs:56:10:56:13 | access to property Prop | arguments.cs:56:31:56:31 | 5 | value |
 | arguments.cs:56:16:56:25 | access to indexer | arguments.cs:56:21:56:21 | 3 | a |
 | arguments.cs:56:16:56:25 | access to indexer | arguments.cs:56:24:56:24 | 4 | b |
 | arguments.cs:56:16:56:25 | access to indexer | arguments.cs:56:34:56:34 | 6 | value |
-| arguments.cs:58:9:58:17 | ... = ... | arguments.cs:58:9:58:17 | ... + ... | value |
+| arguments.cs:58:9:58:12 | access to property Prop | arguments.cs:58:9:58:17 | ... + ... | value |
 | arguments.cs:59:9:59:18 | access to indexer | arguments.cs:59:14:59:14 | 8 | a |
 | arguments.cs:59:9:59:18 | access to indexer | arguments.cs:59:17:59:17 | 9 | b |
-| arguments.cs:59:9:59:20 | ...++ | arguments.cs:59:14:59:14 | 8 | a |
-| arguments.cs:59:9:59:20 | ...++ | arguments.cs:59:17:59:17 | 9 | b |
+| arguments.cs:60:9:60:20 | access to indexer | arguments.cs:60:9:60:26 | ... + ... | value |
+| arguments.cs:60:9:60:20 | access to indexer | arguments.cs:60:14:60:15 | 10 | a |
 | arguments.cs:60:9:60:20 | access to indexer | arguments.cs:60:14:60:15 | 10 | a |
 | arguments.cs:60:9:60:20 | access to indexer | arguments.cs:60:18:60:19 | 11 | b |
-| arguments.cs:60:9:60:26 | ... = ... | arguments.cs:60:9:60:26 | ... + ... | value |
-| arguments.cs:60:9:60:26 | ... = ... | arguments.cs:60:14:60:15 | 10 | a |
-| arguments.cs:60:9:60:26 | ... = ... | arguments.cs:60:18:60:19 | 11 | b |
+| arguments.cs:60:9:60:20 | access to indexer | arguments.cs:60:18:60:19 | 11 | b |
 | arguments.cs:62:16:62:27 | access to indexer | arguments.cs:62:21:62:22 | 15 | a |
 | arguments.cs:62:16:62:27 | access to indexer | arguments.cs:62:25:62:26 | 16 | b |

--- a/csharp/ql/test/library-tests/arguments/argumentByParameter.expected
+++ b/csharp/ql/test/library-tests/arguments/argumentByParameter.expected
@@ -17,23 +17,23 @@
 | arguments.cs:39:9:39:28 | call to method f3 | arguments.cs:39:27:39:27 | 0 | arguments.cs:33:17:33:17 | o |
 | arguments.cs:40:9:40:42 | call to method f3 | arguments.cs:40:18:40:35 | array creation of type Int32[] | arguments.cs:33:33:33:36 | args |
 | arguments.cs:40:9:40:42 | call to method f3 | arguments.cs:40:41:40:41 | 0 | arguments.cs:33:17:33:17 | o |
-| arguments.cs:54:9:54:16 | ... = ... | arguments.cs:54:16:54:16 | 0 | arguments.cs:48:21:48:23 | value |
-| arguments.cs:55:9:55:25 | ... = ... | arguments.cs:55:16:55:25 | access to indexer | arguments.cs:48:21:48:23 | value |
+| arguments.cs:54:9:54:12 | access to property Prop | arguments.cs:54:16:54:16 | 0 | arguments.cs:48:21:48:23 | value |
+| arguments.cs:55:9:55:12 | access to property Prop | arguments.cs:55:16:55:25 | access to indexer | arguments.cs:48:21:48:23 | value |
 | arguments.cs:55:16:55:25 | access to indexer | arguments.cs:55:21:55:21 | 1 | arguments.cs:50:18:50:18 | a |
 | arguments.cs:55:16:55:25 | access to indexer | arguments.cs:55:24:55:24 | 2 | arguments.cs:50:25:50:25 | b |
 | arguments.cs:56:10:56:13 | access to property Prop | arguments.cs:56:31:56:31 | 5 | arguments.cs:48:21:48:23 | value |
 | arguments.cs:56:16:56:25 | access to indexer | arguments.cs:56:21:56:21 | 3 | arguments.cs:50:18:50:18 | a |
 | arguments.cs:56:16:56:25 | access to indexer | arguments.cs:56:24:56:24 | 4 | arguments.cs:50:25:50:25 | b |
 | arguments.cs:56:16:56:25 | access to indexer | arguments.cs:56:34:56:34 | 6 | arguments.cs:50:44:50:46 | value |
-| arguments.cs:58:9:58:17 | ... = ... | arguments.cs:58:9:58:17 | ... + ... | arguments.cs:48:21:48:23 | value |
+| arguments.cs:58:9:58:12 | access to property Prop | arguments.cs:58:9:58:17 | ... + ... | arguments.cs:48:21:48:23 | value |
+| arguments.cs:59:9:59:18 | access to indexer | arguments.cs:59:14:59:14 | 8 | arguments.cs:50:18:50:18 | a |
 | arguments.cs:59:9:59:18 | access to indexer | arguments.cs:59:14:59:14 | 8 | arguments.cs:50:18:50:18 | a |
 | arguments.cs:59:9:59:18 | access to indexer | arguments.cs:59:17:59:17 | 9 | arguments.cs:50:25:50:25 | b |
-| arguments.cs:59:9:59:20 | ...++ | arguments.cs:59:14:59:14 | 8 | arguments.cs:50:18:50:18 | a |
-| arguments.cs:59:9:59:20 | ...++ | arguments.cs:59:17:59:17 | 9 | arguments.cs:50:25:50:25 | b |
+| arguments.cs:59:9:59:18 | access to indexer | arguments.cs:59:17:59:17 | 9 | arguments.cs:50:25:50:25 | b |
+| arguments.cs:60:9:60:20 | access to indexer | arguments.cs:60:9:60:26 | ... + ... | arguments.cs:50:44:50:46 | value |
+| arguments.cs:60:9:60:20 | access to indexer | arguments.cs:60:14:60:15 | 10 | arguments.cs:50:18:50:18 | a |
 | arguments.cs:60:9:60:20 | access to indexer | arguments.cs:60:14:60:15 | 10 | arguments.cs:50:18:50:18 | a |
 | arguments.cs:60:9:60:20 | access to indexer | arguments.cs:60:18:60:19 | 11 | arguments.cs:50:25:50:25 | b |
-| arguments.cs:60:9:60:26 | ... = ... | arguments.cs:60:9:60:26 | ... + ... | arguments.cs:50:44:50:46 | value |
-| arguments.cs:60:9:60:26 | ... = ... | arguments.cs:60:14:60:15 | 10 | arguments.cs:50:18:50:18 | a |
-| arguments.cs:60:9:60:26 | ... = ... | arguments.cs:60:18:60:19 | 11 | arguments.cs:50:25:50:25 | b |
+| arguments.cs:60:9:60:20 | access to indexer | arguments.cs:60:18:60:19 | 11 | arguments.cs:50:25:50:25 | b |
 | arguments.cs:62:16:62:27 | access to indexer | arguments.cs:62:21:62:22 | 15 | arguments.cs:50:18:50:18 | a |
 | arguments.cs:62:16:62:27 | access to indexer | arguments.cs:62:25:62:26 | 16 | arguments.cs:50:25:50:25 | b |

--- a/csharp/ql/test/library-tests/dataflow/ssa/SsaCapturedVariableDef.expected
+++ b/csharp/ql/test/library-tests/dataflow/ssa/SsaCapturedVariableDef.expected
@@ -16,7 +16,7 @@
 | in | Capture.cs:182:17:182:17 | i | Capture.cs:188:13:188:17 | SSA def(i) | Capture.cs:183:13:186:13 | SSA capture def(i) | Capture.cs:189:13:189:17 | call to local function M11 |
 | in | Capture.cs:197:17:197:17 | i | Capture.cs:197:17:197:21 | SSA def(i) | Capture.cs:198:33:198:44 | SSA capture def(i) | Capture.cs:200:13:200:19 | delegate call |
 | in | Capture.cs:197:17:197:17 | i | Capture.cs:197:17:197:21 | SSA def(i) | Capture.cs:203:34:203:45 | SSA capture def(i) | Capture.cs:200:13:200:19 | delegate call |
-| in | Capture.cs:209:17:209:17 | i | Capture.cs:209:17:209:21 | SSA def(i) | Capture.cs:212:39:212:71 | SSA capture def(i) | Capture.cs:213:17:213:34 | ... += ... |
+| in | Capture.cs:209:17:209:17 | i | Capture.cs:209:17:209:21 | SSA def(i) | Capture.cs:212:39:212:71 | SSA capture def(i) | Capture.cs:213:17:213:24 | access to event Exited |
 | in | Capture.cs:229:13:229:13 | i | Capture.cs:232:9:232:13 | SSA def(i) | Capture.cs:231:9:231:49 | SSA capture def(i) | Capture.cs:233:9:233:12 | call to local function M2 |
 | in | Fields.cs:77:13:77:13 | f | Fields.cs:77:13:77:45 | SSA def(f) | Fields.cs:78:27:78:54 | SSA capture def(f) | Fields.cs:81:9:81:11 | delegate call |
 | in | Fields.cs:77:13:77:13 | f | Fields.cs:77:13:77:45 | SSA def(f) | Fields.cs:78:27:78:54 | SSA capture def(f) | Fields.cs:86:9:86:47 | call to method Select |

--- a/csharp/ql/test/library-tests/definitions/definitions.expected
+++ b/csharp/ql/test/library-tests/definitions/definitions.expected
@@ -30,7 +30,7 @@
 | definitions.cs:57:13:57:23 | Enumeration | definitions.cs:13:10:13:20 | Enumeration | T |
 | definitions.cs:57:29:57:39 | Enumeration | definitions.cs:13:10:13:20 | Enumeration | T |
 | definitions.cs:57:41:57:42 | access to constant e1 | definitions.cs:15:9:15:10 | e1 | V |
-| definitions.cs:60:13:60:21 | access to property property1 | definitions.cs:24:20:24:28 | property1 | V |
+| definitions.cs:60:13:60:21 | access to property property1 | definitions.cs:24:20:24:28 | property1 | M |
 | definitions.cs:60:25:60:33 | access to property property1 | definitions.cs:24:20:24:28 | property1 | M |
 | definitions.cs:63:13:63:14 | C1 | definitions.cs:18:11:18:12 | C1 | T |
 | definitions.cs:64:13:64:14 | S1 | definitions.cs:78:12:78:13 | S1 | T |
@@ -45,11 +45,11 @@
 | definitions.cs:92:31:92:32 | S1 | definitions.cs:78:12:78:13 | S1 | T |
 | definitions.cs:93:24:93:25 | S1 | definitions.cs:78:12:78:13 | S1 | M |
 | definitions.cs:101:22:101:33 | EventHandler | definitions.cs:99:30:99:41 | EventHandler | T |
-| definitions.cs:105:13:105:17 | access to event Click | definitions.cs:101:35:101:39 | Click | V |
+| definitions.cs:105:13:105:17 | access to event Click | definitions.cs:101:35:101:39 | Click | M |
 | definitions.cs:105:22:105:22 | access to method M | definitions.cs:103:32:103:32 | M | M |
-| definitions.cs:107:13:107:17 | access to event Click | definitions.cs:101:35:101:39 | Click | V |
+| definitions.cs:107:13:107:17 | access to event Click | definitions.cs:101:35:101:39 | Click | M |
 | definitions.cs:107:22:107:34 | access to local function LocalFunction | definitions.cs:106:13:106:36 | LocalFunction | M |
-| definitions.cs:108:13:108:17 | access to event Click | definitions.cs:101:35:101:39 | Click | V |
+| definitions.cs:108:13:108:17 | access to event Click | definitions.cs:101:35:101:39 | Click | M |
 | definitions.cs:114:28:114:28 | T | definitions.cs:114:17:114:17 | T | T |
 | definitions.cs:114:32:114:32 | A | definitions.cs:97:11:97:11 | A | T |
 | definitions.cs:117:27:117:27 | T | definitions.cs:117:18:117:18 | T | T |
@@ -109,7 +109,7 @@
 | definitions.cs:171:13:171:17 | C1 | definitions.cs:18:11:18:12 | C1 | T |
 | definitions.cs:171:27:171:31 | C1 | definitions.cs:18:11:18:12 | C1 | M |
 | definitions.cs:172:13:172:13 | access to local variable c | definitions.cs:171:19:171:19 | c | V |
-| definitions.cs:172:15:172:23 | access to property property1 | definitions.cs:24:20:24:28 | property1 | V |
+| definitions.cs:172:15:172:23 | access to property property1 | definitions.cs:24:20:24:28 | property1 | M |
 | definitions.cs:172:27:172:27 | access to local variable c | definitions.cs:171:19:171:19 | c | V |
 | definitions.cs:172:29:172:37 | access to property property1 | definitions.cs:24:20:24:28 | property1 | M |
 | definitions.cs:173:13:173:15 | C5 | definitions.cs:164:11:164:12 | C5 | T |
@@ -117,7 +117,7 @@
 | definitions.cs:173:34:173:35 | C5 | definitions.cs:164:11:164:12 | C5 | T |
 | definitions.cs:174:13:174:14 | access to local variable c5 | definitions.cs:173:17:173:18 | c5 | V |
 | definitions.cs:174:16:174:17 | access to field c1 | definitions.cs:167:12:167:13 | c1 | V |
-| definitions.cs:174:19:174:27 | access to property property1 | definitions.cs:24:20:24:28 | property1 | V |
+| definitions.cs:174:19:174:27 | access to property property1 | definitions.cs:24:20:24:28 | property1 | M |
 | definitions.cs:175:24:175:25 | access to local variable c5 | definitions.cs:173:17:173:18 | c5 | V |
 | definitions.cs:175:30:175:34 | C4 | definitions.cs:151:11:151:12 | C4 | T |
 | definitions.cs:175:36:175:41 | Nested<I4> | definitions.cs:158:22:158:30 | Nested<> | T |

--- a/csharp/ql/test/library-tests/dispatch/GetADynamicTarget.expected
+++ b/csharp/ql/test/library-tests/dispatch/GetADynamicTarget.expected
@@ -77,18 +77,18 @@
 | ViableCallable.cs:12:9:12:28 | call to method M | C6<String,Decimal>.M<T3>(string, T3) |
 | ViableCallable.cs:12:9:12:28 | call to method M | C6<String,Int32>.M<T3>(string, T3) |
 | ViableCallable.cs:12:9:12:28 | call to method M | C7<Boolean>.M<T3>(bool, T3) |
-| ViableCallable.cs:14:9:14:25 | ... = ... | C2<Boolean>.set_Prop(string) |
-| ViableCallable.cs:14:9:14:25 | ... = ... | C2<Decimal>.set_Prop(string) |
-| ViableCallable.cs:14:9:14:25 | ... = ... | C2<Int32>.set_Prop(string) |
-| ViableCallable.cs:14:9:14:25 | ... = ... | C3.set_Prop(string) |
-| ViableCallable.cs:14:9:14:25 | ... = ... | C4<Int32>.set_Prop(int[]) |
-| ViableCallable.cs:14:9:14:25 | ... = ... | C5.set_Prop(string) |
-| ViableCallable.cs:14:9:14:25 | ... = ... | C6<Boolean,Byte>.set_Prop(bool) |
-| ViableCallable.cs:14:9:14:25 | ... = ... | C6<Int32[],Boolean>.set_Prop(int[]) |
-| ViableCallable.cs:14:9:14:25 | ... = ... | C6<String,Boolean>.set_Prop(string) |
-| ViableCallable.cs:14:9:14:25 | ... = ... | C6<String,Decimal>.set_Prop(string) |
-| ViableCallable.cs:14:9:14:25 | ... = ... | C6<String,Int32>.set_Prop(string) |
-| ViableCallable.cs:14:9:14:25 | ... = ... | C7<Boolean>.set_Prop(bool) |
+| ViableCallable.cs:14:9:14:15 | access to property Prop | C2<Boolean>.set_Prop(string) |
+| ViableCallable.cs:14:9:14:15 | access to property Prop | C2<Decimal>.set_Prop(string) |
+| ViableCallable.cs:14:9:14:15 | access to property Prop | C2<Int32>.set_Prop(string) |
+| ViableCallable.cs:14:9:14:15 | access to property Prop | C3.set_Prop(string) |
+| ViableCallable.cs:14:9:14:15 | access to property Prop | C4<Int32>.set_Prop(int[]) |
+| ViableCallable.cs:14:9:14:15 | access to property Prop | C5.set_Prop(string) |
+| ViableCallable.cs:14:9:14:15 | access to property Prop | C6<Boolean,Byte>.set_Prop(bool) |
+| ViableCallable.cs:14:9:14:15 | access to property Prop | C6<Int32[],Boolean>.set_Prop(int[]) |
+| ViableCallable.cs:14:9:14:15 | access to property Prop | C6<String,Boolean>.set_Prop(string) |
+| ViableCallable.cs:14:9:14:15 | access to property Prop | C6<String,Decimal>.set_Prop(string) |
+| ViableCallable.cs:14:9:14:15 | access to property Prop | C6<String,Int32>.set_Prop(string) |
+| ViableCallable.cs:14:9:14:15 | access to property Prop | C7<Boolean>.set_Prop(bool) |
 | ViableCallable.cs:14:19:14:25 | access to property Prop | C2<Boolean>.get_Prop() |
 | ViableCallable.cs:14:19:14:25 | access to property Prop | C2<Decimal>.get_Prop() |
 | ViableCallable.cs:14:19:14:25 | access to property Prop | C2<Int32>.get_Prop() |
@@ -101,18 +101,18 @@
 | ViableCallable.cs:14:19:14:25 | access to property Prop | C6<String,Decimal>.get_Prop() |
 | ViableCallable.cs:14:19:14:25 | access to property Prop | C6<String,Int32>.get_Prop() |
 | ViableCallable.cs:14:19:14:25 | access to property Prop | C7<Boolean>.get_Prop() |
-| ViableCallable.cs:16:9:16:41 | ... = ... | C2<Boolean>.set_Item(bool, string) |
-| ViableCallable.cs:16:9:16:41 | ... = ... | C2<Decimal>.set_Item(decimal, string) |
-| ViableCallable.cs:16:9:16:41 | ... = ... | C2<Int32>.set_Item(int, string) |
-| ViableCallable.cs:16:9:16:41 | ... = ... | C3.set_Item(decimal, string) |
-| ViableCallable.cs:16:9:16:41 | ... = ... | C4<Int32>.set_Item(bool, int[]) |
-| ViableCallable.cs:16:9:16:41 | ... = ... | C5.set_Item(bool, string) |
-| ViableCallable.cs:16:9:16:41 | ... = ... | C6<Boolean,Byte>.set_Item(byte, bool) |
-| ViableCallable.cs:16:9:16:41 | ... = ... | C6<Int32[],Boolean>.set_Item(bool, int[]) |
-| ViableCallable.cs:16:9:16:41 | ... = ... | C6<String,Boolean>.set_Item(bool, string) |
-| ViableCallable.cs:16:9:16:41 | ... = ... | C6<String,Decimal>.set_Item(decimal, string) |
-| ViableCallable.cs:16:9:16:41 | ... = ... | C6<String,Int32>.set_Item(int, string) |
-| ViableCallable.cs:16:9:16:41 | ... = ... | C7<Boolean>.set_Item(byte, bool) |
+| ViableCallable.cs:16:9:16:23 | access to indexer | C2<Boolean>.set_Item(bool, string) |
+| ViableCallable.cs:16:9:16:23 | access to indexer | C2<Decimal>.set_Item(decimal, string) |
+| ViableCallable.cs:16:9:16:23 | access to indexer | C2<Int32>.set_Item(int, string) |
+| ViableCallable.cs:16:9:16:23 | access to indexer | C3.set_Item(decimal, string) |
+| ViableCallable.cs:16:9:16:23 | access to indexer | C4<Int32>.set_Item(bool, int[]) |
+| ViableCallable.cs:16:9:16:23 | access to indexer | C5.set_Item(bool, string) |
+| ViableCallable.cs:16:9:16:23 | access to indexer | C6<Boolean,Byte>.set_Item(byte, bool) |
+| ViableCallable.cs:16:9:16:23 | access to indexer | C6<Int32[],Boolean>.set_Item(bool, int[]) |
+| ViableCallable.cs:16:9:16:23 | access to indexer | C6<String,Boolean>.set_Item(bool, string) |
+| ViableCallable.cs:16:9:16:23 | access to indexer | C6<String,Decimal>.set_Item(decimal, string) |
+| ViableCallable.cs:16:9:16:23 | access to indexer | C6<String,Int32>.set_Item(int, string) |
+| ViableCallable.cs:16:9:16:23 | access to indexer | C7<Boolean>.set_Item(byte, bool) |
 | ViableCallable.cs:16:27:16:41 | access to indexer | C2<Boolean>.get_Item(bool) |
 | ViableCallable.cs:16:27:16:41 | access to indexer | C2<Decimal>.get_Item(decimal) |
 | ViableCallable.cs:16:27:16:41 | access to indexer | C2<Int32>.get_Item(int) |
@@ -125,125 +125,125 @@
 | ViableCallable.cs:16:27:16:41 | access to indexer | C6<String,Decimal>.get_Item(decimal) |
 | ViableCallable.cs:16:27:16:41 | access to indexer | C6<String,Int32>.get_Item(int) |
 | ViableCallable.cs:16:27:16:41 | access to indexer | C7<Boolean>.get_Item(byte) |
-| ViableCallable.cs:18:9:18:29 | ... += ... | C2<Boolean>.add_Event(EventHandler<string>) |
-| ViableCallable.cs:18:9:18:29 | ... += ... | C2<Decimal>.add_Event(EventHandler<string>) |
-| ViableCallable.cs:18:9:18:29 | ... += ... | C2<Int32>.add_Event(EventHandler<string>) |
-| ViableCallable.cs:18:9:18:29 | ... += ... | C3.add_Event(EventHandler<string>) |
-| ViableCallable.cs:18:9:18:29 | ... += ... | C4<Int32>.add_Event(EventHandler<int[]>) |
-| ViableCallable.cs:18:9:18:29 | ... += ... | C5.add_Event(EventHandler<string>) |
-| ViableCallable.cs:18:9:18:29 | ... += ... | C6<Boolean,Byte>.add_Event(EventHandler<bool>) |
-| ViableCallable.cs:18:9:18:29 | ... += ... | C6<Int32[],Boolean>.add_Event(EventHandler<int[]>) |
-| ViableCallable.cs:18:9:18:29 | ... += ... | C6<String,Boolean>.add_Event(EventHandler<string>) |
-| ViableCallable.cs:18:9:18:29 | ... += ... | C6<String,Decimal>.add_Event(EventHandler<string>) |
-| ViableCallable.cs:18:9:18:29 | ... += ... | C6<String,Int32>.add_Event(EventHandler<string>) |
-| ViableCallable.cs:18:9:18:29 | ... += ... | C7<Boolean>.add_Event(EventHandler<bool>) |
-| ViableCallable.cs:19:9:19:29 | ... -= ... | C2<Boolean>.remove_Event(EventHandler<string>) |
-| ViableCallable.cs:19:9:19:29 | ... -= ... | C2<Decimal>.remove_Event(EventHandler<string>) |
-| ViableCallable.cs:19:9:19:29 | ... -= ... | C2<Int32>.remove_Event(EventHandler<string>) |
-| ViableCallable.cs:19:9:19:29 | ... -= ... | C3.remove_Event(EventHandler<string>) |
-| ViableCallable.cs:19:9:19:29 | ... -= ... | C4<Int32>.remove_Event(EventHandler<int[]>) |
-| ViableCallable.cs:19:9:19:29 | ... -= ... | C5.remove_Event(EventHandler<string>) |
-| ViableCallable.cs:19:9:19:29 | ... -= ... | C6<Boolean,Byte>.remove_Event(EventHandler<bool>) |
-| ViableCallable.cs:19:9:19:29 | ... -= ... | C6<Int32[],Boolean>.remove_Event(EventHandler<int[]>) |
-| ViableCallable.cs:19:9:19:29 | ... -= ... | C6<String,Boolean>.remove_Event(EventHandler<string>) |
-| ViableCallable.cs:19:9:19:29 | ... -= ... | C6<String,Decimal>.remove_Event(EventHandler<string>) |
-| ViableCallable.cs:19:9:19:29 | ... -= ... | C6<String,Int32>.remove_Event(EventHandler<string>) |
-| ViableCallable.cs:19:9:19:29 | ... -= ... | C7<Boolean>.remove_Event(EventHandler<bool>) |
+| ViableCallable.cs:18:9:18:16 | access to event Event | C2<Boolean>.add_Event(EventHandler<string>) |
+| ViableCallable.cs:18:9:18:16 | access to event Event | C2<Decimal>.add_Event(EventHandler<string>) |
+| ViableCallable.cs:18:9:18:16 | access to event Event | C2<Int32>.add_Event(EventHandler<string>) |
+| ViableCallable.cs:18:9:18:16 | access to event Event | C3.add_Event(EventHandler<string>) |
+| ViableCallable.cs:18:9:18:16 | access to event Event | C4<Int32>.add_Event(EventHandler<int[]>) |
+| ViableCallable.cs:18:9:18:16 | access to event Event | C5.add_Event(EventHandler<string>) |
+| ViableCallable.cs:18:9:18:16 | access to event Event | C6<Boolean,Byte>.add_Event(EventHandler<bool>) |
+| ViableCallable.cs:18:9:18:16 | access to event Event | C6<Int32[],Boolean>.add_Event(EventHandler<int[]>) |
+| ViableCallable.cs:18:9:18:16 | access to event Event | C6<String,Boolean>.add_Event(EventHandler<string>) |
+| ViableCallable.cs:18:9:18:16 | access to event Event | C6<String,Decimal>.add_Event(EventHandler<string>) |
+| ViableCallable.cs:18:9:18:16 | access to event Event | C6<String,Int32>.add_Event(EventHandler<string>) |
+| ViableCallable.cs:18:9:18:16 | access to event Event | C7<Boolean>.add_Event(EventHandler<bool>) |
+| ViableCallable.cs:19:9:19:16 | access to event Event | C2<Boolean>.remove_Event(EventHandler<string>) |
+| ViableCallable.cs:19:9:19:16 | access to event Event | C2<Decimal>.remove_Event(EventHandler<string>) |
+| ViableCallable.cs:19:9:19:16 | access to event Event | C2<Int32>.remove_Event(EventHandler<string>) |
+| ViableCallable.cs:19:9:19:16 | access to event Event | C3.remove_Event(EventHandler<string>) |
+| ViableCallable.cs:19:9:19:16 | access to event Event | C4<Int32>.remove_Event(EventHandler<int[]>) |
+| ViableCallable.cs:19:9:19:16 | access to event Event | C5.remove_Event(EventHandler<string>) |
+| ViableCallable.cs:19:9:19:16 | access to event Event | C6<Boolean,Byte>.remove_Event(EventHandler<bool>) |
+| ViableCallable.cs:19:9:19:16 | access to event Event | C6<Int32[],Boolean>.remove_Event(EventHandler<int[]>) |
+| ViableCallable.cs:19:9:19:16 | access to event Event | C6<String,Boolean>.remove_Event(EventHandler<string>) |
+| ViableCallable.cs:19:9:19:16 | access to event Event | C6<String,Decimal>.remove_Event(EventHandler<string>) |
+| ViableCallable.cs:19:9:19:16 | access to event Event | C6<String,Int32>.remove_Event(EventHandler<string>) |
+| ViableCallable.cs:19:9:19:16 | access to event Event | C7<Boolean>.remove_Event(EventHandler<bool>) |
 | ViableCallable.cs:22:9:22:30 | call to method M | C4<Int32>.M<T3>(int[], T3) |
 | ViableCallable.cs:22:9:22:30 | call to method M | C6<Int32[],Boolean>.M<T3>(int[], T3) |
-| ViableCallable.cs:24:9:24:25 | ... = ... | C4<Int32>.set_Prop(int[]) |
-| ViableCallable.cs:24:9:24:25 | ... = ... | C6<Int32[],Boolean>.set_Prop(int[]) |
+| ViableCallable.cs:24:9:24:15 | access to property Prop | C4<Int32>.set_Prop(int[]) |
+| ViableCallable.cs:24:9:24:15 | access to property Prop | C6<Int32[],Boolean>.set_Prop(int[]) |
 | ViableCallable.cs:24:19:24:25 | access to property Prop | C4<Int32>.get_Prop() |
 | ViableCallable.cs:24:19:24:25 | access to property Prop | C6<Int32[],Boolean>.get_Prop() |
-| ViableCallable.cs:26:9:26:41 | ... = ... | C4<Int32>.set_Item(bool, int[]) |
-| ViableCallable.cs:26:9:26:41 | ... = ... | C6<Int32[],Boolean>.set_Item(bool, int[]) |
+| ViableCallable.cs:26:9:26:23 | access to indexer | C4<Int32>.set_Item(bool, int[]) |
+| ViableCallable.cs:26:9:26:23 | access to indexer | C6<Int32[],Boolean>.set_Item(bool, int[]) |
 | ViableCallable.cs:26:27:26:41 | access to indexer | C4<Int32>.get_Item(bool) |
 | ViableCallable.cs:26:27:26:41 | access to indexer | C6<Int32[],Boolean>.get_Item(bool) |
-| ViableCallable.cs:28:9:28:29 | ... += ... | C4<Int32>.add_Event(EventHandler<int[]>) |
-| ViableCallable.cs:28:9:28:29 | ... += ... | C6<Int32[],Boolean>.add_Event(EventHandler<int[]>) |
-| ViableCallable.cs:29:9:29:29 | ... -= ... | C4<Int32>.remove_Event(EventHandler<int[]>) |
-| ViableCallable.cs:29:9:29:29 | ... -= ... | C6<Int32[],Boolean>.remove_Event(EventHandler<int[]>) |
+| ViableCallable.cs:28:9:28:16 | access to event Event | C4<Int32>.add_Event(EventHandler<int[]>) |
+| ViableCallable.cs:28:9:28:16 | access to event Event | C6<Int32[],Boolean>.add_Event(EventHandler<int[]>) |
+| ViableCallable.cs:29:9:29:16 | access to event Event | C4<Int32>.remove_Event(EventHandler<int[]>) |
+| ViableCallable.cs:29:9:29:16 | access to event Event | C6<Int32[],Boolean>.remove_Event(EventHandler<int[]>) |
 | ViableCallable.cs:32:30:32:52 | call to method Mock | ViableCallable.Mock<C1<string, int>>() |
 | ViableCallable.cs:33:9:33:23 | call to method M | C2<Int32>.M<T3>(string, T3) |
 | ViableCallable.cs:33:9:33:23 | call to method M | C6<String,Int32>.M<T3>(string, T3) |
-| ViableCallable.cs:35:9:35:25 | ... = ... | C2<Int32>.set_Prop(string) |
-| ViableCallable.cs:35:9:35:25 | ... = ... | C6<String,Int32>.set_Prop(string) |
+| ViableCallable.cs:35:9:35:15 | access to property Prop | C2<Int32>.set_Prop(string) |
+| ViableCallable.cs:35:9:35:15 | access to property Prop | C6<String,Int32>.set_Prop(string) |
 | ViableCallable.cs:35:19:35:25 | access to property Prop | C2<Int32>.get_Prop() |
 | ViableCallable.cs:35:19:35:25 | access to property Prop | C6<String,Int32>.get_Prop() |
-| ViableCallable.cs:37:9:37:21 | ... = ... | C2<Int32>.set_Item(int, string) |
-| ViableCallable.cs:37:9:37:21 | ... = ... | C6<String,Int32>.set_Item(int, string) |
+| ViableCallable.cs:37:9:37:13 | access to indexer | C2<Int32>.set_Item(int, string) |
+| ViableCallable.cs:37:9:37:13 | access to indexer | C6<String,Int32>.set_Item(int, string) |
 | ViableCallable.cs:37:17:37:21 | access to indexer | C2<Int32>.get_Item(int) |
 | ViableCallable.cs:37:17:37:21 | access to indexer | C6<String,Int32>.get_Item(int) |
-| ViableCallable.cs:39:9:39:29 | ... += ... | C2<Int32>.add_Event(EventHandler<string>) |
-| ViableCallable.cs:39:9:39:29 | ... += ... | C6<String,Int32>.add_Event(EventHandler<string>) |
-| ViableCallable.cs:40:9:40:29 | ... -= ... | C2<Int32>.remove_Event(EventHandler<string>) |
-| ViableCallable.cs:40:9:40:29 | ... -= ... | C6<String,Int32>.remove_Event(EventHandler<string>) |
+| ViableCallable.cs:39:9:39:16 | access to event Event | C2<Int32>.add_Event(EventHandler<string>) |
+| ViableCallable.cs:39:9:39:16 | access to event Event | C6<String,Int32>.add_Event(EventHandler<string>) |
+| ViableCallable.cs:40:9:40:16 | access to event Event | C2<Int32>.remove_Event(EventHandler<string>) |
+| ViableCallable.cs:40:9:40:16 | access to event Event | C6<String,Int32>.remove_Event(EventHandler<string>) |
 | ViableCallable.cs:43:34:43:60 | call to method Mock | ViableCallable.Mock<C1<string, decimal>>() |
 | ViableCallable.cs:44:9:44:24 | call to method M | C2<Decimal>.M<T3>(string, T3) |
 | ViableCallable.cs:44:9:44:24 | call to method M | C3.M<T3>(string, T3) |
 | ViableCallable.cs:44:9:44:24 | call to method M | C6<String,Decimal>.M<T3>(string, T3) |
-| ViableCallable.cs:46:9:46:25 | ... = ... | C2<Decimal>.set_Prop(string) |
-| ViableCallable.cs:46:9:46:25 | ... = ... | C3.set_Prop(string) |
-| ViableCallable.cs:46:9:46:25 | ... = ... | C6<String,Decimal>.set_Prop(string) |
+| ViableCallable.cs:46:9:46:15 | access to property Prop | C2<Decimal>.set_Prop(string) |
+| ViableCallable.cs:46:9:46:15 | access to property Prop | C3.set_Prop(string) |
+| ViableCallable.cs:46:9:46:15 | access to property Prop | C6<String,Decimal>.set_Prop(string) |
 | ViableCallable.cs:46:19:46:25 | access to property Prop | C2<Decimal>.get_Prop() |
 | ViableCallable.cs:46:19:46:25 | access to property Prop | C3.get_Prop() |
 | ViableCallable.cs:46:19:46:25 | access to property Prop | C6<String,Decimal>.get_Prop() |
-| ViableCallable.cs:48:9:48:23 | ... = ... | C2<Decimal>.set_Item(decimal, string) |
-| ViableCallable.cs:48:9:48:23 | ... = ... | C3.set_Item(decimal, string) |
-| ViableCallable.cs:48:9:48:23 | ... = ... | C6<String,Decimal>.set_Item(decimal, string) |
+| ViableCallable.cs:48:9:48:14 | access to indexer | C2<Decimal>.set_Item(decimal, string) |
+| ViableCallable.cs:48:9:48:14 | access to indexer | C3.set_Item(decimal, string) |
+| ViableCallable.cs:48:9:48:14 | access to indexer | C6<String,Decimal>.set_Item(decimal, string) |
 | ViableCallable.cs:48:18:48:23 | access to indexer | C2<Decimal>.get_Item(decimal) |
 | ViableCallable.cs:48:18:48:23 | access to indexer | C3.get_Item(decimal) |
 | ViableCallable.cs:48:18:48:23 | access to indexer | C6<String,Decimal>.get_Item(decimal) |
-| ViableCallable.cs:50:9:50:29 | ... += ... | C2<Decimal>.add_Event(EventHandler<string>) |
-| ViableCallable.cs:50:9:50:29 | ... += ... | C3.add_Event(EventHandler<string>) |
-| ViableCallable.cs:50:9:50:29 | ... += ... | C6<String,Decimal>.add_Event(EventHandler<string>) |
-| ViableCallable.cs:51:9:51:29 | ... -= ... | C2<Decimal>.remove_Event(EventHandler<string>) |
-| ViableCallable.cs:51:9:51:29 | ... -= ... | C3.remove_Event(EventHandler<string>) |
-| ViableCallable.cs:51:9:51:29 | ... -= ... | C6<String,Decimal>.remove_Event(EventHandler<string>) |
+| ViableCallable.cs:50:9:50:16 | access to event Event | C2<Decimal>.add_Event(EventHandler<string>) |
+| ViableCallable.cs:50:9:50:16 | access to event Event | C3.add_Event(EventHandler<string>) |
+| ViableCallable.cs:50:9:50:16 | access to event Event | C6<String,Decimal>.add_Event(EventHandler<string>) |
+| ViableCallable.cs:51:9:51:16 | access to event Event | C2<Decimal>.remove_Event(EventHandler<string>) |
+| ViableCallable.cs:51:9:51:16 | access to event Event | C3.remove_Event(EventHandler<string>) |
+| ViableCallable.cs:51:9:51:16 | access to event Event | C6<String,Decimal>.remove_Event(EventHandler<string>) |
 | ViableCallable.cs:54:30:54:52 | call to method Mock | ViableCallable.Mock<C1<int[], bool>>() |
 | ViableCallable.cs:55:9:55:44 | call to method M | C4<Int32>.M<T3>(int[], T3) |
 | ViableCallable.cs:55:9:55:44 | call to method M | C6<Int32[],Boolean>.M<T3>(int[], T3) |
-| ViableCallable.cs:57:9:57:25 | ... = ... | C4<Int32>.set_Prop(int[]) |
-| ViableCallable.cs:57:9:57:25 | ... = ... | C6<Int32[],Boolean>.set_Prop(int[]) |
+| ViableCallable.cs:57:9:57:15 | access to property Prop | C4<Int32>.set_Prop(int[]) |
+| ViableCallable.cs:57:9:57:15 | access to property Prop | C6<Int32[],Boolean>.set_Prop(int[]) |
 | ViableCallable.cs:57:19:57:25 | access to property Prop | C4<Int32>.get_Prop() |
 | ViableCallable.cs:57:19:57:25 | access to property Prop | C6<Int32[],Boolean>.get_Prop() |
-| ViableCallable.cs:59:9:59:29 | ... = ... | C4<Int32>.set_Item(bool, int[]) |
-| ViableCallable.cs:59:9:59:29 | ... = ... | C6<Int32[],Boolean>.set_Item(bool, int[]) |
+| ViableCallable.cs:59:9:59:17 | access to indexer | C4<Int32>.set_Item(bool, int[]) |
+| ViableCallable.cs:59:9:59:17 | access to indexer | C6<Int32[],Boolean>.set_Item(bool, int[]) |
 | ViableCallable.cs:59:21:59:29 | access to indexer | C4<Int32>.get_Item(bool) |
 | ViableCallable.cs:59:21:59:29 | access to indexer | C6<Int32[],Boolean>.get_Item(bool) |
-| ViableCallable.cs:61:9:61:29 | ... += ... | C4<Int32>.add_Event(EventHandler<int[]>) |
-| ViableCallable.cs:61:9:61:29 | ... += ... | C6<Int32[],Boolean>.add_Event(EventHandler<int[]>) |
-| ViableCallable.cs:62:9:62:29 | ... -= ... | C4<Int32>.remove_Event(EventHandler<int[]>) |
-| ViableCallable.cs:62:9:62:29 | ... -= ... | C6<Int32[],Boolean>.remove_Event(EventHandler<int[]>) |
+| ViableCallable.cs:61:9:61:16 | access to event Event | C4<Int32>.add_Event(EventHandler<int[]>) |
+| ViableCallable.cs:61:9:61:16 | access to event Event | C6<Int32[],Boolean>.add_Event(EventHandler<int[]>) |
+| ViableCallable.cs:62:9:62:16 | access to event Event | C4<Int32>.remove_Event(EventHandler<int[]>) |
+| ViableCallable.cs:62:9:62:16 | access to event Event | C6<Int32[],Boolean>.remove_Event(EventHandler<int[]>) |
 | ViableCallable.cs:65:31:65:54 | call to method Mock | ViableCallable.Mock<C1<string, bool>>() |
 | ViableCallable.cs:66:9:66:30 | call to method M | C2<Boolean>.M<T3>(string, T3) |
 | ViableCallable.cs:66:9:66:30 | call to method M | C5.M<T3>(string, T3) |
 | ViableCallable.cs:66:9:66:30 | call to method M | C6<String,Boolean>.M<T3>(string, T3) |
-| ViableCallable.cs:68:9:68:25 | ... = ... | C2<Boolean>.set_Prop(string) |
-| ViableCallable.cs:68:9:68:25 | ... = ... | C5.set_Prop(string) |
-| ViableCallable.cs:68:9:68:25 | ... = ... | C6<String,Boolean>.set_Prop(string) |
+| ViableCallable.cs:68:9:68:15 | access to property Prop | C2<Boolean>.set_Prop(string) |
+| ViableCallable.cs:68:9:68:15 | access to property Prop | C5.set_Prop(string) |
+| ViableCallable.cs:68:9:68:15 | access to property Prop | C6<String,Boolean>.set_Prop(string) |
 | ViableCallable.cs:68:19:68:25 | access to property Prop | C2<Boolean>.get_Prop() |
 | ViableCallable.cs:68:19:68:25 | access to property Prop | C5.get_Prop() |
 | ViableCallable.cs:68:19:68:25 | access to property Prop | C6<String,Boolean>.get_Prop() |
-| ViableCallable.cs:70:9:70:29 | ... = ... | C2<Boolean>.set_Item(bool, string) |
-| ViableCallable.cs:70:9:70:29 | ... = ... | C5.set_Item(bool, string) |
-| ViableCallable.cs:70:9:70:29 | ... = ... | C6<String,Boolean>.set_Item(bool, string) |
+| ViableCallable.cs:70:9:70:17 | access to indexer | C2<Boolean>.set_Item(bool, string) |
+| ViableCallable.cs:70:9:70:17 | access to indexer | C5.set_Item(bool, string) |
+| ViableCallable.cs:70:9:70:17 | access to indexer | C6<String,Boolean>.set_Item(bool, string) |
 | ViableCallable.cs:70:21:70:29 | access to indexer | C2<Boolean>.get_Item(bool) |
 | ViableCallable.cs:70:21:70:29 | access to indexer | C5.get_Item(bool) |
 | ViableCallable.cs:70:21:70:29 | access to indexer | C6<String,Boolean>.get_Item(bool) |
-| ViableCallable.cs:72:9:72:29 | ... += ... | C2<Boolean>.add_Event(EventHandler<string>) |
-| ViableCallable.cs:72:9:72:29 | ... += ... | C5.add_Event(EventHandler<string>) |
-| ViableCallable.cs:72:9:72:29 | ... += ... | C6<String,Boolean>.add_Event(EventHandler<string>) |
-| ViableCallable.cs:73:9:73:29 | ... -= ... | C2<Boolean>.remove_Event(EventHandler<string>) |
-| ViableCallable.cs:73:9:73:29 | ... -= ... | C5.remove_Event(EventHandler<string>) |
-| ViableCallable.cs:73:9:73:29 | ... -= ... | C6<String,Boolean>.remove_Event(EventHandler<string>) |
+| ViableCallable.cs:72:9:72:16 | access to event Event | C2<Boolean>.add_Event(EventHandler<string>) |
+| ViableCallable.cs:72:9:72:16 | access to event Event | C5.add_Event(EventHandler<string>) |
+| ViableCallable.cs:72:9:72:16 | access to event Event | C6<String,Boolean>.add_Event(EventHandler<string>) |
+| ViableCallable.cs:73:9:73:16 | access to event Event | C2<Boolean>.remove_Event(EventHandler<string>) |
+| ViableCallable.cs:73:9:73:16 | access to event Event | C5.remove_Event(EventHandler<string>) |
+| ViableCallable.cs:73:9:73:16 | access to event Event | C6<String,Boolean>.remove_Event(EventHandler<string>) |
 | ViableCallable.cs:77:9:77:29 | call to method M | C6<T1,Boolean>.M<T3>(T1, T3) |
-| ViableCallable.cs:79:9:79:25 | ... = ... | C6<T1,Boolean>.set_Prop(T1) |
+| ViableCallable.cs:79:9:79:15 | access to property Prop | C6<T1,Boolean>.set_Prop(T1) |
 | ViableCallable.cs:79:19:79:25 | access to property Prop | C6<T1,Boolean>.get_Prop() |
-| ViableCallable.cs:81:9:81:29 | ... = ... | C6<T1,Boolean>.set_Item(bool, T1) |
+| ViableCallable.cs:81:9:81:17 | access to indexer | C6<T1,Boolean>.set_Item(bool, T1) |
 | ViableCallable.cs:81:21:81:29 | access to indexer | C6<T1,Boolean>.get_Item(bool) |
-| ViableCallable.cs:83:9:83:29 | ... += ... | C6<T1,Boolean>.add_Event(EventHandler<T1>) |
-| ViableCallable.cs:84:9:84:29 | ... -= ... | C6<T1,Boolean>.remove_Event(EventHandler<T1>) |
+| ViableCallable.cs:83:9:83:16 | access to event Event | C6<T1,Boolean>.add_Event(EventHandler<T1>) |
+| ViableCallable.cs:84:9:84:16 | access to event Event | C6<T1,Boolean>.remove_Event(EventHandler<T1>) |
 | ViableCallable.cs:87:21:87:30 | call to method Mock | ViableCallable.Mock<C8>() |
 | ViableCallable.cs:88:9:88:44 | dynamic call to method M | C8.M(IEnumerable<C1<string[], bool>>) |
 | ViableCallable.cs:88:9:88:44 | dynamic call to method M | C9<>.M(IEnumerable<C1<string[], bool>>) |
@@ -258,9 +258,9 @@
 | ViableCallable.cs:92:16:92:19 | dynamic access to element | C9<>.get_Item(int) |
 | ViableCallable.cs:95:13:95:40 | call to method Mock | ViableCallable.Mock<IEnumerable<C4<int>>>() |
 | ViableCallable.cs:99:9:99:15 | dynamic call to method M | C5.M(int) |
-| ViableCallable.cs:102:9:102:20 | ... = ... | C5.set_Prop2(string) |
-| ViableCallable.cs:105:9:105:22 | ... += ... | C5.add_Event2(EventHandler<string>) |
-| ViableCallable.cs:106:9:106:22 | ... -= ... | C5.remove_Event2(EventHandler<string>) |
+| ViableCallable.cs:102:9:102:16 | access to property Prop2 | C5.set_Prop2(string) |
+| ViableCallable.cs:105:9:105:17 | access to event Event2 | C5.add_Event2(EventHandler<string>) |
+| ViableCallable.cs:106:9:106:17 | access to event Event2 | C5.remove_Event2(EventHandler<string>) |
 | ViableCallable.cs:120:9:120:25 | dynamic call to method M2 | C8.M2<decimal>(decimal[]) |
 | ViableCallable.cs:124:9:124:24 | dynamic call to method M2 | C8.M2<string>(string[]) |
 | ViableCallable.cs:132:9:132:28 | dynamic call to method M | C6<T1,Byte>.M<T3>(T1, T3) |

--- a/csharp/ql/test/library-tests/dispatch/viableCallable.expected
+++ b/csharp/ql/test/library-tests/dispatch/viableCallable.expected
@@ -4,134 +4,134 @@
 | ViableCallable.cs:12:9:12:28 | call to method M | M | C5 |
 | ViableCallable.cs:12:9:12:28 | call to method M | M | C6<,> |
 | ViableCallable.cs:12:9:12:28 | call to method M | M | C7<> |
-| ViableCallable.cs:14:9:14:25 | ... = ... | set_Prop | C2<> |
-| ViableCallable.cs:14:9:14:25 | ... = ... | set_Prop | C3 |
-| ViableCallable.cs:14:9:14:25 | ... = ... | set_Prop | C4<> |
-| ViableCallable.cs:14:9:14:25 | ... = ... | set_Prop | C5 |
-| ViableCallable.cs:14:9:14:25 | ... = ... | set_Prop | C6<,> |
-| ViableCallable.cs:14:9:14:25 | ... = ... | set_Prop | C7<> |
+| ViableCallable.cs:14:9:14:15 | access to property Prop | set_Prop | C2<> |
+| ViableCallable.cs:14:9:14:15 | access to property Prop | set_Prop | C3 |
+| ViableCallable.cs:14:9:14:15 | access to property Prop | set_Prop | C4<> |
+| ViableCallable.cs:14:9:14:15 | access to property Prop | set_Prop | C5 |
+| ViableCallable.cs:14:9:14:15 | access to property Prop | set_Prop | C6<,> |
+| ViableCallable.cs:14:9:14:15 | access to property Prop | set_Prop | C7<> |
 | ViableCallable.cs:14:19:14:25 | access to property Prop | get_Prop | C2<> |
 | ViableCallable.cs:14:19:14:25 | access to property Prop | get_Prop | C3 |
 | ViableCallable.cs:14:19:14:25 | access to property Prop | get_Prop | C4<> |
 | ViableCallable.cs:14:19:14:25 | access to property Prop | get_Prop | C5 |
 | ViableCallable.cs:14:19:14:25 | access to property Prop | get_Prop | C6<,> |
 | ViableCallable.cs:14:19:14:25 | access to property Prop | get_Prop | C7<> |
-| ViableCallable.cs:16:9:16:41 | ... = ... | set_Item | C2<> |
-| ViableCallable.cs:16:9:16:41 | ... = ... | set_Item | C3 |
-| ViableCallable.cs:16:9:16:41 | ... = ... | set_Item | C4<> |
-| ViableCallable.cs:16:9:16:41 | ... = ... | set_Item | C5 |
-| ViableCallable.cs:16:9:16:41 | ... = ... | set_Item | C6<,> |
-| ViableCallable.cs:16:9:16:41 | ... = ... | set_Item | C7<> |
+| ViableCallable.cs:16:9:16:23 | access to indexer | set_Item | C2<> |
+| ViableCallable.cs:16:9:16:23 | access to indexer | set_Item | C3 |
+| ViableCallable.cs:16:9:16:23 | access to indexer | set_Item | C4<> |
+| ViableCallable.cs:16:9:16:23 | access to indexer | set_Item | C5 |
+| ViableCallable.cs:16:9:16:23 | access to indexer | set_Item | C6<,> |
+| ViableCallable.cs:16:9:16:23 | access to indexer | set_Item | C7<> |
 | ViableCallable.cs:16:27:16:41 | access to indexer | get_Item | C2<> |
 | ViableCallable.cs:16:27:16:41 | access to indexer | get_Item | C3 |
 | ViableCallable.cs:16:27:16:41 | access to indexer | get_Item | C4<> |
 | ViableCallable.cs:16:27:16:41 | access to indexer | get_Item | C5 |
 | ViableCallable.cs:16:27:16:41 | access to indexer | get_Item | C6<,> |
 | ViableCallable.cs:16:27:16:41 | access to indexer | get_Item | C7<> |
-| ViableCallable.cs:18:9:18:29 | ... += ... | add_Event | C2<> |
-| ViableCallable.cs:18:9:18:29 | ... += ... | add_Event | C3 |
-| ViableCallable.cs:18:9:18:29 | ... += ... | add_Event | C4<> |
-| ViableCallable.cs:18:9:18:29 | ... += ... | add_Event | C5 |
-| ViableCallable.cs:18:9:18:29 | ... += ... | add_Event | C6<,> |
-| ViableCallable.cs:18:9:18:29 | ... += ... | add_Event | C7<> |
-| ViableCallable.cs:19:9:19:29 | ... -= ... | remove_Event | C2<> |
-| ViableCallable.cs:19:9:19:29 | ... -= ... | remove_Event | C3 |
-| ViableCallable.cs:19:9:19:29 | ... -= ... | remove_Event | C4<> |
-| ViableCallable.cs:19:9:19:29 | ... -= ... | remove_Event | C5 |
-| ViableCallable.cs:19:9:19:29 | ... -= ... | remove_Event | C6<,> |
-| ViableCallable.cs:19:9:19:29 | ... -= ... | remove_Event | C7<> |
+| ViableCallable.cs:18:9:18:16 | access to event Event | add_Event | C2<> |
+| ViableCallable.cs:18:9:18:16 | access to event Event | add_Event | C3 |
+| ViableCallable.cs:18:9:18:16 | access to event Event | add_Event | C4<> |
+| ViableCallable.cs:18:9:18:16 | access to event Event | add_Event | C5 |
+| ViableCallable.cs:18:9:18:16 | access to event Event | add_Event | C6<,> |
+| ViableCallable.cs:18:9:18:16 | access to event Event | add_Event | C7<> |
+| ViableCallable.cs:19:9:19:16 | access to event Event | remove_Event | C2<> |
+| ViableCallable.cs:19:9:19:16 | access to event Event | remove_Event | C3 |
+| ViableCallable.cs:19:9:19:16 | access to event Event | remove_Event | C4<> |
+| ViableCallable.cs:19:9:19:16 | access to event Event | remove_Event | C5 |
+| ViableCallable.cs:19:9:19:16 | access to event Event | remove_Event | C6<,> |
+| ViableCallable.cs:19:9:19:16 | access to event Event | remove_Event | C7<> |
 | ViableCallable.cs:22:9:22:30 | call to method M | M | C4<> |
 | ViableCallable.cs:22:9:22:30 | call to method M | M | C6<,> |
-| ViableCallable.cs:24:9:24:25 | ... = ... | set_Prop | C4<> |
-| ViableCallable.cs:24:9:24:25 | ... = ... | set_Prop | C6<,> |
+| ViableCallable.cs:24:9:24:15 | access to property Prop | set_Prop | C4<> |
+| ViableCallable.cs:24:9:24:15 | access to property Prop | set_Prop | C6<,> |
 | ViableCallable.cs:24:19:24:25 | access to property Prop | get_Prop | C4<> |
 | ViableCallable.cs:24:19:24:25 | access to property Prop | get_Prop | C6<,> |
-| ViableCallable.cs:26:9:26:41 | ... = ... | set_Item | C4<> |
-| ViableCallable.cs:26:9:26:41 | ... = ... | set_Item | C6<,> |
+| ViableCallable.cs:26:9:26:23 | access to indexer | set_Item | C4<> |
+| ViableCallable.cs:26:9:26:23 | access to indexer | set_Item | C6<,> |
 | ViableCallable.cs:26:27:26:41 | access to indexer | get_Item | C4<> |
 | ViableCallable.cs:26:27:26:41 | access to indexer | get_Item | C6<,> |
-| ViableCallable.cs:28:9:28:29 | ... += ... | add_Event | C4<> |
-| ViableCallable.cs:28:9:28:29 | ... += ... | add_Event | C6<,> |
-| ViableCallable.cs:29:9:29:29 | ... -= ... | remove_Event | C4<> |
-| ViableCallable.cs:29:9:29:29 | ... -= ... | remove_Event | C6<,> |
+| ViableCallable.cs:28:9:28:16 | access to event Event | add_Event | C4<> |
+| ViableCallable.cs:28:9:28:16 | access to event Event | add_Event | C6<,> |
+| ViableCallable.cs:29:9:29:16 | access to event Event | remove_Event | C4<> |
+| ViableCallable.cs:29:9:29:16 | access to event Event | remove_Event | C6<,> |
 | ViableCallable.cs:33:9:33:23 | call to method M | M | C2<> |
 | ViableCallable.cs:33:9:33:23 | call to method M | M | C6<,> |
-| ViableCallable.cs:35:9:35:25 | ... = ... | set_Prop | C2<> |
-| ViableCallable.cs:35:9:35:25 | ... = ... | set_Prop | C6<,> |
+| ViableCallable.cs:35:9:35:15 | access to property Prop | set_Prop | C2<> |
+| ViableCallable.cs:35:9:35:15 | access to property Prop | set_Prop | C6<,> |
 | ViableCallable.cs:35:19:35:25 | access to property Prop | get_Prop | C2<> |
 | ViableCallable.cs:35:19:35:25 | access to property Prop | get_Prop | C6<,> |
-| ViableCallable.cs:37:9:37:21 | ... = ... | set_Item | C2<> |
-| ViableCallable.cs:37:9:37:21 | ... = ... | set_Item | C6<,> |
+| ViableCallable.cs:37:9:37:13 | access to indexer | set_Item | C2<> |
+| ViableCallable.cs:37:9:37:13 | access to indexer | set_Item | C6<,> |
 | ViableCallable.cs:37:17:37:21 | access to indexer | get_Item | C2<> |
 | ViableCallable.cs:37:17:37:21 | access to indexer | get_Item | C6<,> |
-| ViableCallable.cs:39:9:39:29 | ... += ... | add_Event | C2<> |
-| ViableCallable.cs:39:9:39:29 | ... += ... | add_Event | C6<,> |
-| ViableCallable.cs:40:9:40:29 | ... -= ... | remove_Event | C2<> |
-| ViableCallable.cs:40:9:40:29 | ... -= ... | remove_Event | C6<,> |
+| ViableCallable.cs:39:9:39:16 | access to event Event | add_Event | C2<> |
+| ViableCallable.cs:39:9:39:16 | access to event Event | add_Event | C6<,> |
+| ViableCallable.cs:40:9:40:16 | access to event Event | remove_Event | C2<> |
+| ViableCallable.cs:40:9:40:16 | access to event Event | remove_Event | C6<,> |
 | ViableCallable.cs:44:9:44:24 | call to method M | M | C2<> |
 | ViableCallable.cs:44:9:44:24 | call to method M | M | C3 |
 | ViableCallable.cs:44:9:44:24 | call to method M | M | C6<,> |
-| ViableCallable.cs:46:9:46:25 | ... = ... | set_Prop | C2<> |
-| ViableCallable.cs:46:9:46:25 | ... = ... | set_Prop | C3 |
-| ViableCallable.cs:46:9:46:25 | ... = ... | set_Prop | C6<,> |
+| ViableCallable.cs:46:9:46:15 | access to property Prop | set_Prop | C2<> |
+| ViableCallable.cs:46:9:46:15 | access to property Prop | set_Prop | C3 |
+| ViableCallable.cs:46:9:46:15 | access to property Prop | set_Prop | C6<,> |
 | ViableCallable.cs:46:19:46:25 | access to property Prop | get_Prop | C2<> |
 | ViableCallable.cs:46:19:46:25 | access to property Prop | get_Prop | C3 |
 | ViableCallable.cs:46:19:46:25 | access to property Prop | get_Prop | C6<,> |
-| ViableCallable.cs:48:9:48:23 | ... = ... | set_Item | C2<> |
-| ViableCallable.cs:48:9:48:23 | ... = ... | set_Item | C3 |
-| ViableCallable.cs:48:9:48:23 | ... = ... | set_Item | C6<,> |
+| ViableCallable.cs:48:9:48:14 | access to indexer | set_Item | C2<> |
+| ViableCallable.cs:48:9:48:14 | access to indexer | set_Item | C3 |
+| ViableCallable.cs:48:9:48:14 | access to indexer | set_Item | C6<,> |
 | ViableCallable.cs:48:18:48:23 | access to indexer | get_Item | C2<> |
 | ViableCallable.cs:48:18:48:23 | access to indexer | get_Item | C3 |
 | ViableCallable.cs:48:18:48:23 | access to indexer | get_Item | C6<,> |
-| ViableCallable.cs:50:9:50:29 | ... += ... | add_Event | C2<> |
-| ViableCallable.cs:50:9:50:29 | ... += ... | add_Event | C3 |
-| ViableCallable.cs:50:9:50:29 | ... += ... | add_Event | C6<,> |
-| ViableCallable.cs:51:9:51:29 | ... -= ... | remove_Event | C2<> |
-| ViableCallable.cs:51:9:51:29 | ... -= ... | remove_Event | C3 |
-| ViableCallable.cs:51:9:51:29 | ... -= ... | remove_Event | C6<,> |
+| ViableCallable.cs:50:9:50:16 | access to event Event | add_Event | C2<> |
+| ViableCallable.cs:50:9:50:16 | access to event Event | add_Event | C3 |
+| ViableCallable.cs:50:9:50:16 | access to event Event | add_Event | C6<,> |
+| ViableCallable.cs:51:9:51:16 | access to event Event | remove_Event | C2<> |
+| ViableCallable.cs:51:9:51:16 | access to event Event | remove_Event | C3 |
+| ViableCallable.cs:51:9:51:16 | access to event Event | remove_Event | C6<,> |
 | ViableCallable.cs:55:9:55:44 | call to method M | M | C4<> |
 | ViableCallable.cs:55:9:55:44 | call to method M | M | C6<,> |
-| ViableCallable.cs:57:9:57:25 | ... = ... | set_Prop | C4<> |
-| ViableCallable.cs:57:9:57:25 | ... = ... | set_Prop | C6<,> |
+| ViableCallable.cs:57:9:57:15 | access to property Prop | set_Prop | C4<> |
+| ViableCallable.cs:57:9:57:15 | access to property Prop | set_Prop | C6<,> |
 | ViableCallable.cs:57:19:57:25 | access to property Prop | get_Prop | C4<> |
 | ViableCallable.cs:57:19:57:25 | access to property Prop | get_Prop | C6<,> |
-| ViableCallable.cs:59:9:59:29 | ... = ... | set_Item | C4<> |
-| ViableCallable.cs:59:9:59:29 | ... = ... | set_Item | C6<,> |
+| ViableCallable.cs:59:9:59:17 | access to indexer | set_Item | C4<> |
+| ViableCallable.cs:59:9:59:17 | access to indexer | set_Item | C6<,> |
 | ViableCallable.cs:59:21:59:29 | access to indexer | get_Item | C4<> |
 | ViableCallable.cs:59:21:59:29 | access to indexer | get_Item | C6<,> |
-| ViableCallable.cs:61:9:61:29 | ... += ... | add_Event | C4<> |
-| ViableCallable.cs:61:9:61:29 | ... += ... | add_Event | C6<,> |
-| ViableCallable.cs:62:9:62:29 | ... -= ... | remove_Event | C4<> |
-| ViableCallable.cs:62:9:62:29 | ... -= ... | remove_Event | C6<,> |
+| ViableCallable.cs:61:9:61:16 | access to event Event | add_Event | C4<> |
+| ViableCallable.cs:61:9:61:16 | access to event Event | add_Event | C6<,> |
+| ViableCallable.cs:62:9:62:16 | access to event Event | remove_Event | C4<> |
+| ViableCallable.cs:62:9:62:16 | access to event Event | remove_Event | C6<,> |
 | ViableCallable.cs:66:9:66:30 | call to method M | M | C2<> |
 | ViableCallable.cs:66:9:66:30 | call to method M | M | C5 |
 | ViableCallable.cs:66:9:66:30 | call to method M | M | C6<,> |
-| ViableCallable.cs:68:9:68:25 | ... = ... | set_Prop | C2<> |
-| ViableCallable.cs:68:9:68:25 | ... = ... | set_Prop | C5 |
-| ViableCallable.cs:68:9:68:25 | ... = ... | set_Prop | C6<,> |
+| ViableCallable.cs:68:9:68:15 | access to property Prop | set_Prop | C2<> |
+| ViableCallable.cs:68:9:68:15 | access to property Prop | set_Prop | C5 |
+| ViableCallable.cs:68:9:68:15 | access to property Prop | set_Prop | C6<,> |
 | ViableCallable.cs:68:19:68:25 | access to property Prop | get_Prop | C2<> |
 | ViableCallable.cs:68:19:68:25 | access to property Prop | get_Prop | C5 |
 | ViableCallable.cs:68:19:68:25 | access to property Prop | get_Prop | C6<,> |
-| ViableCallable.cs:70:9:70:29 | ... = ... | set_Item | C2<> |
-| ViableCallable.cs:70:9:70:29 | ... = ... | set_Item | C5 |
-| ViableCallable.cs:70:9:70:29 | ... = ... | set_Item | C6<,> |
+| ViableCallable.cs:70:9:70:17 | access to indexer | set_Item | C2<> |
+| ViableCallable.cs:70:9:70:17 | access to indexer | set_Item | C5 |
+| ViableCallable.cs:70:9:70:17 | access to indexer | set_Item | C6<,> |
 | ViableCallable.cs:70:21:70:29 | access to indexer | get_Item | C2<> |
 | ViableCallable.cs:70:21:70:29 | access to indexer | get_Item | C5 |
 | ViableCallable.cs:70:21:70:29 | access to indexer | get_Item | C6<,> |
-| ViableCallable.cs:72:9:72:29 | ... += ... | add_Event | C2<> |
-| ViableCallable.cs:72:9:72:29 | ... += ... | add_Event | C5 |
-| ViableCallable.cs:72:9:72:29 | ... += ... | add_Event | C6<,> |
-| ViableCallable.cs:73:9:73:29 | ... -= ... | remove_Event | C2<> |
-| ViableCallable.cs:73:9:73:29 | ... -= ... | remove_Event | C5 |
-| ViableCallable.cs:73:9:73:29 | ... -= ... | remove_Event | C6<,> |
+| ViableCallable.cs:72:9:72:16 | access to event Event | add_Event | C2<> |
+| ViableCallable.cs:72:9:72:16 | access to event Event | add_Event | C5 |
+| ViableCallable.cs:72:9:72:16 | access to event Event | add_Event | C6<,> |
+| ViableCallable.cs:73:9:73:16 | access to event Event | remove_Event | C2<> |
+| ViableCallable.cs:73:9:73:16 | access to event Event | remove_Event | C5 |
+| ViableCallable.cs:73:9:73:16 | access to event Event | remove_Event | C6<,> |
 | ViableCallable.cs:76:27:76:44 | object creation of type C6<T1,Boolean> | C6 | C6<,> |
 | ViableCallable.cs:77:9:77:29 | call to method M | M | C6<,> |
-| ViableCallable.cs:79:9:79:25 | ... = ... | set_Prop | C6<,> |
+| ViableCallable.cs:79:9:79:15 | access to property Prop | set_Prop | C6<,> |
 | ViableCallable.cs:79:19:79:25 | access to property Prop | get_Prop | C6<,> |
-| ViableCallable.cs:81:9:81:29 | ... = ... | set_Item | C6<,> |
+| ViableCallable.cs:81:9:81:17 | access to indexer | set_Item | C6<,> |
 | ViableCallable.cs:81:21:81:29 | access to indexer | get_Item | C6<,> |
-| ViableCallable.cs:83:9:83:29 | ... += ... | add_Event | C6<,> |
-| ViableCallable.cs:84:9:84:29 | ... -= ... | remove_Event | C6<,> |
+| ViableCallable.cs:83:9:83:16 | access to event Event | add_Event | C6<,> |
+| ViableCallable.cs:84:9:84:16 | access to event Event | remove_Event | C6<,> |
 | ViableCallable.cs:88:9:88:44 | dynamic call to method M | M | C8 |
 | ViableCallable.cs:88:9:88:44 | dynamic call to method M | M | C9<> |
 | ViableCallable.cs:90:9:90:15 | dynamic access to member Prop1 | set_Prop1 | C8 |
@@ -143,9 +143,9 @@
 | ViableCallable.cs:92:16:92:19 | dynamic access to element | get_Item | C8 |
 | ViableCallable.cs:92:16:92:19 | dynamic access to element | get_Item | C9<> |
 | ViableCallable.cs:99:9:99:15 | dynamic call to method M | M | C5 |
-| ViableCallable.cs:102:9:102:20 | ... = ... | set_Prop2 | C5 |
-| ViableCallable.cs:105:9:105:22 | ... += ... | add_Event2 | C5 |
-| ViableCallable.cs:106:9:106:22 | ... -= ... | remove_Event2 | C5 |
+| ViableCallable.cs:102:9:102:16 | access to property Prop2 | set_Prop2 | C5 |
+| ViableCallable.cs:105:9:105:17 | access to event Event2 | add_Event2 | C5 |
+| ViableCallable.cs:106:9:106:17 | access to event Event2 | remove_Event2 | C5 |
 | ViableCallable.cs:120:9:120:25 | dynamic call to method M2 | M2 | C8 |
 | ViableCallable.cs:124:9:124:24 | dynamic call to method M2 | M2 | C8 |
 | ViableCallable.cs:131:13:131:30 | object creation of type C6<T1,Byte> | C6 | C6<,> |

--- a/csharp/ql/test/query-tests/Nullness/E.cs
+++ b/csharp/ql/test/query-tests/Nullness/E.cs
@@ -308,7 +308,7 @@ public class E
     {
         if (l.HasValue)
         {
-            e.Long = l.Value; // GOOD
+            e.Long = l.Value; // GOOD (false positive)
         }
         return;
     }

--- a/csharp/ql/test/query-tests/Nullness/NullMaybe.expected
+++ b/csharp/ql/test/query-tests/Nullness/NullMaybe.expected
@@ -348,6 +348,8 @@ nodes
 | E.cs:285:9:285:9 | access to local variable o |
 | E.cs:301:13:301:27 | SSA def(s) |
 | E.cs:302:9:302:9 | access to local variable s |
+| E.cs:311:13:311:18 | SSA call def(this.l) |
+| E.cs:311:22:311:22 | access to field l |
 | Forwarding.cs:7:16:7:23 | SSA def(s) |
 | Forwarding.cs:14:9:17:9 | if (...) ... |
 | Forwarding.cs:19:9:22:9 | if (...) ... |
@@ -678,6 +680,7 @@ edges
 | E.cs:283:13:283:22 | [b (line 279): false] SSA def(o) | E.cs:285:9:285:9 | access to local variable o |
 | E.cs:283:13:283:22 | [b (line 279): true] SSA def(o) | E.cs:285:9:285:9 | access to local variable o |
 | E.cs:301:13:301:27 | SSA def(s) | E.cs:302:9:302:9 | access to local variable s |
+| E.cs:311:13:311:18 | SSA call def(this.l) | E.cs:311:22:311:22 | access to field l |
 | Forwarding.cs:7:16:7:23 | SSA def(s) | Forwarding.cs:14:9:17:9 | if (...) ... |
 | Forwarding.cs:14:9:17:9 | if (...) ... | Forwarding.cs:19:9:22:9 | if (...) ... |
 | Forwarding.cs:19:9:22:9 | if (...) ... | Forwarding.cs:24:9:27:9 | if (...) ... |
@@ -778,6 +781,7 @@ edges
 | E.cs:285:9:285:9 | access to local variable o | E.cs:283:13:283:22 | [b (line 279): false] SSA def(o) | E.cs:285:9:285:9 | access to local variable o | Variable $@ may be null here as suggested by $@ null check. | E.cs:283:13:283:13 | o | o | E.cs:284:9:284:9 | access to local variable o | this |
 | E.cs:285:9:285:9 | access to local variable o | E.cs:283:13:283:22 | [b (line 279): true] SSA def(o) | E.cs:285:9:285:9 | access to local variable o | Variable $@ may be null here as suggested by $@ null check. | E.cs:283:13:283:13 | o | o | E.cs:284:9:284:9 | access to local variable o | this |
 | E.cs:302:9:302:9 | access to local variable s | E.cs:301:13:301:27 | SSA def(s) | E.cs:302:9:302:9 | access to local variable s | Variable $@ may be null here because of $@ assignment. | E.cs:301:13:301:13 | s | s | E.cs:301:13:301:27 | String s = ... | this |
+| E.cs:311:22:311:22 | access to field l | E.cs:311:13:311:18 | SSA call def(this.l) | E.cs:311:22:311:22 | access to field l | Variable $@ may be null here because it has a nullable type. | E.cs:309:13:309:13 | this.l | this.l | E.cs:305:19:305:19 | l | this |
 | GuardedString.cs:35:31:35:31 | access to local variable s | GuardedString.cs:7:16:7:32 | SSA def(s) | GuardedString.cs:35:31:35:31 | access to local variable s | Variable $@ may be null here because of $@ assignment. | GuardedString.cs:7:16:7:16 | s | s | GuardedString.cs:7:16:7:32 | String s = ... | this |
 | NullMaybeBad.cs:7:27:7:27 | access to parameter o | NullMaybeBad.cs:13:17:13:20 | null | NullMaybeBad.cs:7:27:7:27 | access to parameter o | Variable $@ may be null here because of $@ null argument. | NullMaybeBad.cs:5:25:5:25 | o | o | NullMaybeBad.cs:13:17:13:20 | null | this |
 | StringConcatenation.cs:16:17:16:17 | access to local variable s | StringConcatenation.cs:14:16:14:23 | SSA def(s) | StringConcatenation.cs:16:17:16:17 | access to local variable s | Variable $@ may be null here because of $@ assignment. | StringConcatenation.cs:14:16:14:16 | s | s | StringConcatenation.cs:14:16:14:23 | String s = ... | this |


### PR DESCRIPTION
The recent change to `AccessorCall` on dd9952556624571c4f66a5e4ffe5a5155cf772e6 resulted in some bad join-orders, so I have (partly) reverted it. This means that the issues originally addressed by that change are now reintroduced, and I plan to instead apply a fix to the CFG, which--unlike the original fix--should be able to handle multi-property-tuple assignments.