### PR TITLE
C#: Use `matchesHandle()` instead of `getLabel()`

### DIFF
--- a/csharp/ql/src/semmle/code/cil/Declaration.qll
+++ b/csharp/ql/src/semmle/code/cil/Declaration.qll
@@ -28,13 +28,13 @@ class Declaration extends DotNet::Declaration, Element, @cil_declaration {
   final predicate isSourceDeclaration() { this = getSourceDeclaration() }
 }
 
-private CS::Declaration toCSharpNonTypeParameter(Declaration d) { result.getLabel() = d.getLabel() }
+private CS::Declaration toCSharpNonTypeParameter(Declaration d) { result.matchesHandle(d) }
 
 private CS::TypeParameter toCSharpTypeParameter(TypeParameter tp) {
   toCSharpTypeParameterJoin(tp, result.getIndex(), result.getGeneric())
 }
 
-pragma[noinline, nomagic]
+pragma[nomagic]
 private predicate toCSharpTypeParameterJoin(TypeParameter tp, int i, CS::UnboundGeneric ug) {
   exists(TypeContainer tc |
     tp.getIndex() = i and

--- a/csharp/ql/src/semmle/code/dotnet/Element.qll
+++ b/csharp/ql/src/semmle/code/dotnet/Element.qll
@@ -93,7 +93,7 @@ class NamedElement extends Element, @dotnet_named_element {
   predicate compiledFromSource() {
     not this.fromSource() and
     exists(NamedElement other | other != this |
-      other.getLabel() = this.getLabel() and
+      this.matchesHandle(other) and
       other.fromSource()
     )
   }


### PR DESCRIPTION
We are still calculating the expensive `getLabel()` predicate because of its use in `compiledFromSource()`. This PR removes that use (as well as another one, which is only used in tests).