### PR TITLE
C++: Add edge-based predicates to IRGuards

### DIFF
--- a/cpp/ql/src/semmle/code/cpp/rangeanalysis/RangeAnalysis.qll
+++ b/cpp/ql/src/semmle/code/cpp/rangeanalysis/RangeAnalysis.qll
@@ -386,11 +386,7 @@ private predicate boundFlowStepPhi(
   or
   exists(IRGuardCondition guard, boolean testIsTrue |
     guard = boundFlowCond(valueNumberOfOperand(op2), op1, delta, upper, testIsTrue) and
-    (
-      guard.hasBranchEdge(op2.getPredecessorBlock().getLastInstruction(), op2.getUseInstruction().getBlock(), testIsTrue)
-      or
-      guard.controls(op2.getPredecessorBlock(), testIsTrue)
-    ) and
+    guard.controlsEdge(op2.getPredecessorBlock(), op2.getUseInstruction().getBlock(), testIsTrue) and
     reason = TCondReason(guard)
   )
 }

--- a/cpp/ql/test/library-tests/controlflow/guards-ir/test.c
+++ b/cpp/ql/test/library-tests/controlflow/guards-ir/test.c
@@ -151,4 +151,3 @@ void test5(int x) {
 void test6(int x, int y) {
   return x && y;
 }
-


### PR DESCRIPTION
This simplifies handling of phi nodes when using the IRGuards library; phi operands should always use the `ensuresLtEdge` predicate, while non-phi operands will use the `ensuresLt` predicate. Previously, to determine how a phi operand was affected by a guard condition, users had to use both `hasBranchEdge` and `controls` to determine whether the edge of the phi node was controlled by the guard, and `comparesLt` to determine what knowledge could be gained from the guard.