### PR TITLE
C#: Prevent bad magic in `getArgumentForParameter()`

### DIFF
--- a/csharp/ql/src/semmle/code/csharp/exprs/Call.qll
+++ b/csharp/ql/src/semmle/code/csharp/exprs/Call.qll
@@ -76,6 +76,7 @@ class Call extends DotNet::Call, Expr, @call {
    * }
    * ```
    */
+  pragma[nomagic]
   override Expr getArgumentForParameter(DotNet::Parameter p) {
     getTarget().getAParameter() = p and
     (


### PR DESCRIPTION
This predicate had bad magic optimization at a customer:
```
[2019-02-04 09:44:49] (7821s) Starting to evaluate predicate Call::Call::getImplicitArgument#fbb
[2019-02-04 13:42:59] (22112s) Tuple counts:
                      55999       ~0%       {2} r1 = SELECT Expr::Expr::getValue_dispred#ff ON Expr::Expr::getValue_dispred#ff.<1> != "1"
                      55994       ~0%       {2} r2 = r1 AND NOT expr_argument_name_0#antijoin_rhs(r1.<0>)
                      55994       ~2%       {1} r3 = SCAN r2 OUTPUT FIELDS {r2.<0>}
                      55994       ~2%       {1} r4 = STREAM DEDUP r3
                      10190       ~0%       {3} r5 = JOIN r4 WITH Call::Call::getArgument_dispred#fff_201#join_rhs ON r4.<0>=Call::Call::getArgument_dispred#fff_201#join_rhs.<0> OUTPUT FIELDS {Call::Call::getArgument_dispred#fff_201#join_rhs.<2>,r4.<0>,Call::Call::getArgument_dispred#fff_201#join_rhs.<1>}
                      37604088801 ~0%       {5} r6 = JOIN r5 WITH params_30#join_rhs ON r5.<0>=params_30#join_rhs.<0> OUTPUT FIELDS {params_30#join_rhs.<1>,"x",r5.<1>,r5.<2>,r5.<0>}
                      19626       ~104%     {3} r7 = JOIN r6 WITH Element::NamedElement::getName_dispred#fb ON r6.<0>=Element::NamedElement::getName_dispred#fb.<0> AND r6.<1>=Element::NamedElement::getName_dispred#fb.<1> OUTPUT FIELDS {r6.<3>,r6.<4>,r6.<2>}
                      0           ~0%       {1} r8 = JOIN Call::Call::getImplicitArgument#fbb#shared WITH params ON Call::Call::getImplicitArgument#fbb#shared.<0>=params.<0> OUTPUT FIELDS {params.<3>}
                      0           ~0%       {4} r9 = JOIN r8 WITH Call::Call::getArgument_dispred#fff_102#join_rhs ON r8.<0>=Call::Call::getArgument_dispred#fff_102#join_rhs.<0> OUTPUT FIELDS {Call::Call::getArgument_dispred#fff_102#join_rhs.<2>,11,r8.<0>,Call::Call::getArgument_dispred#fff_102#join_rhs.<1>}
                      0           ~0%       {3} r10 = JOIN r9 WITH expressions ON r9.<0>=expressions.<0> AND r9.<1>=expressions.<1> OUTPUT FIELDS {r9.<2>,r9.<3>,r9.<0>}
                      0           ~0%       {3} r11 = r10 AND NOT expr_argument_name_0#antijoin_rhs(r10.<2>)
                      0           ~0%       {3} r12 = SCAN r11 OUTPUT FIELDS {r11.<1>,r11.<0>,r11.<2>}
                      19626       ~104%     {3} r13 = r7 \/ r12
                                            return r13
```