### PR TITLE
C#: Avoid using `ExceptionClass` in deliberate Cartesian products

### DIFF
--- a/csharp/ql/src/API Abuse/DisposeNotCalledOnException.ql
+++ b/csharp/ql/src/API Abuse/DisposeNotCalledOnException.ql
@@ -23,7 +23,7 @@ import semmle.code.csharp.frameworks.System
  * Gets an exception type that may be thrown during the execution of method `m`.
  * Assumes any exception may be thrown by library types.
  */
-ExceptionClass getAThrownException(Method m) {
+Class getAThrownException(Method m) {
   m.fromLibrary() and
   result = any(SystemExceptionClass sc)
   or

--- a/csharp/ql/src/semmle/code/csharp/commons/Assertions.qll
+++ b/csharp/ql/src/semmle/code/csharp/commons/Assertions.qll
@@ -15,7 +15,7 @@ abstract class AssertMethod extends Method {
   final Parameter getAssertedParameter() { result = this.getParameter(this.getAssertionIndex()) }
 
   /** Gets the exception being thrown if the assertion fails, if any. */
-  abstract ExceptionClass getExceptionClass();
+  abstract Class getExceptionClass();
 }
 
 /** A positive assertion method. */
@@ -122,7 +122,7 @@ class SystemDiagnosticsDebugAssertTrueMethod extends AssertTrueMethod {
 
   override int getAssertionIndex() { result = 0 }
 
-  override ExceptionClass getExceptionClass() {
+  override Class getExceptionClass() {
     // A failing assertion generates a message box, see
     // https://docs.microsoft.com/en-us/dotnet/api/system.diagnostics.debug.assert
     none()
@@ -182,7 +182,7 @@ class ForwarderAssertMethod extends AssertMethod {
 
   override int getAssertionIndex() { result = p.getPosition() }
 
-  override ExceptionClass getExceptionClass() {
+  override Class getExceptionClass() {
     result = this.getUnderlyingAssertMethod().getExceptionClass()
   }
 

--- a/csharp/ql/src/semmle/code/csharp/controlflow/internal/Completion.qll
+++ b/csharp/ql/src/semmle/code/csharp/controlflow/internal/Completion.qll
@@ -178,6 +178,13 @@ private predicate isMatchingConstant(Expr e, boolean value) {
   )
 }
 
+private class Overflowable extends UnaryOperation {
+  Overflowable() {
+    not this instanceof UnaryBitwiseOperation and
+    this.getType() instanceof IntegralType
+  }
+}
+
 /** A control flow element that is inside a `try` block. */
 private class TriedControlFlowElement extends ControlFlowElement {
   TriedControlFlowElement() { this = any(TryStmt try).getATriedElement() }
@@ -185,20 +192,15 @@ private class TriedControlFlowElement extends ControlFlowElement {
   /**
    * Gets an exception class that is potentially thrown by this element, if any.
    */
-  ExceptionClass getAThrownException() {
-    this = any(UnaryOperation uo |
-        not uo instanceof UnaryBitwiseOperation and
-        uo.getType() instanceof IntegralType and
-        result instanceof SystemOverflowExceptionClass
-      )
+  Class getAThrownException() {
+    this instanceof Overflowable and
+    result instanceof SystemOverflowExceptionClass
     or
-    this = any(CastExpr ce |
-        ce.getType() instanceof IntegralType and
-        result instanceof SystemOverflowExceptionClass
-        or
-        invalidCastCandidate(ce) and
-        result instanceof SystemInvalidCastExceptionClass
-      )
+    this.(CastExpr).getType() instanceof IntegralType and
+    result instanceof SystemOverflowExceptionClass
+    or
+    invalidCastCandidate(this) and
+    result instanceof SystemInvalidCastExceptionClass
     or
     this instanceof Call and
     result instanceof SystemExceptionClass

--- a/csharp/ql/src/semmle/code/csharp/exprs/Expr.qll
+++ b/csharp/ql/src/semmle/code/csharp/exprs/Expr.qll
@@ -558,7 +558,7 @@ class ThrowElement extends ControlFlowElement, DotNet::Throw, @throw_element {
   override Expr getExpr() { result = this.getChild(0) }
 
   /** Gets the type of exception being thrown. */
-  ExceptionClass getThrownExceptionType() {
+  Class getThrownExceptionType() {
     result = getExpr().getType()
     or
     // Corner case: `throw null`

--- a/csharp/ql/src/semmle/code/csharp/frameworks/test/VisualStudio.qll
+++ b/csharp/ql/src/semmle/code/csharp/frameworks/test/VisualStudio.qll
@@ -89,7 +89,7 @@ class VSTestAssertClass extends Class {
 }
 
 /** The `Microsoft.VisualStudio.TestTools.UnitTesting.AssertFailedException` class. */
-class AssertFailedExceptionClass extends ExceptionClass {
+class AssertFailedExceptionClass extends Class {
   AssertFailedExceptionClass() {
     this.getNamespace() instanceof VSTestNamespace and
     this.hasName("AssertFailedException")


### PR DESCRIPTION
~This PR builds on top of https://github.com/Semmle/ql/pull/886, so only the last commit needs reviewing here.~ Update: rebased, now that https://github.com/Semmle/ql/pull/886 has been merged.

---

Using the class `ExceptionClass` in combination with a deliberate Cartesian product can lead to bad join orders, for example

```
EVALUATE NONRECURSIVE RELATION:
  Completion::TriedControlFlowElement::getAThrownException_dispred#ff(int this, int result) :-
    {1} r1 = JOIN Expr::Expr::getType_dispred#ff_10#join_rhs WITH @integral_type#f ON Expr::Expr::getType_dispred#ff_10#join_rhs.<0>=@integral_type#f.<0> OUTPUT FIELDS {Expr::Expr::getType_dispred#ff_10#join_rhs.<1>}
    {1} r2 = JOIN r1 WITH @un_op#f ON r1.<0>=@un_op#f.<0> OUTPUT FIELDS {r1.<0>}
    {1} r3 = JOIN r2 WITH Stmt::TryStmt::getATriedElement#ff_1#join_rhs ON r2.<0>=Stmt::TryStmt::getATriedElement#ff_1#join_rhs.<0> OUTPUT FIELDS {r2.<0>}
    {2} r4 = JOIN r3 WITH Stmt::ExceptionClass#f CARTESIAN PRODUCT OUTPUT FIELDS {Stmt::ExceptionClass#f.<0>,r3.<0>}
    {2} r5 = JOIN r4 WITH System::SystemOverflowExceptionClass#class#f ON r4.<0>=System::SystemOverflowExceptionClass#class#f.<0> OUTPUT FIELDS {r4.<1>,r4.<0>}
```

where the CP is made with `ExceptionClass` rather than `SystemOverflowExceptionClass` directly.

This can make a big difference if there are many exception classes, as in this example:

Before:
```

[2019-02-05 09:48:02] (2167s) Starting to evaluate predicate Completion::TriedControlFlowElement::getAThrownException_dispred#ff
[2019-02-05 09:51:04] (2349s) Tuple counts:
                      1760039    ~0%       {1} r1 = JOIN @integral_type#f WITH Expr::Expr::getType_dispred#ff_10#join_rhs ON @integral_type#f.<0>=Expr::Expr::getType_dispred#ff_10#join_rhs.<0> OUTPUT FIELDS {Expr::Expr::getType_dispred#ff_10#join_rhs.<1>}
                      44110      ~1%       {1} r2 = JOIN r1 WITH @un_op#f ON r1.<0>=@un_op#f.<0> OUTPUT FIELDS {r1.<0>}
                      2221       ~0%       {1} r3 = JOIN r2 WITH Stmt::TryStmt::getATriedElement#ff_1#join_rhs ON r2.<0>=Stmt::TryStmt::getATriedElement#ff_1#join_rhs.<0> OUTPUT FIELDS {r2.<0>}
                      22698620   ~0%       {2} r4 = JOIN r3 WITH Stmt::ExceptionClass#f CARTESIAN PRODUCT OUTPUT FIELDS {Stmt::ExceptionClass#f.<0>,r3.<0>}
                      6663       ~0%       {2} r5 = JOIN r4 WITH System::SystemOverflowExceptionClass#class#f ON r4.<0>=System::SystemOverflowExceptionClass#class#f.<0> OUTPUT FIELDS {r4.<1>,r4.<0>}
                      77350      ~0%       {1} r6 = JOIN r1 WITH Expr::CastExpr#class#f ON r1.<0>=Expr::CastExpr#class#f.<0> OUTPUT FIELDS {r1.<0>}
                      4384       ~0%       {1} r7 = JOIN r6 WITH Stmt::TryStmt::getATriedElement#ff_1#join_rhs ON r6.<0>=Stmt::TryStmt::getATriedElement#ff_1#join_rhs.<0> OUTPUT FIELDS {r6.<0>}
                      44804480   ~4%       {2} r8 = JOIN r7 WITH Stmt::ExceptionClass#f CARTESIAN PRODUCT OUTPUT FIELDS {Stmt::ExceptionClass#f.<0>,r7.<0>}
                      13152      ~3%       {2} r9 = JOIN r8 WITH System::SystemOverflowExceptionClass#class#f ON r8.<0>=System::SystemOverflowExceptionClass#class#f.<0> OUTPUT FIELDS {r8.<1>,r8.<0>}
                      19815      ~1%       {2} r10 = r5 \/ r9
                      161        ~1%       {2} r11 = JOIN System::SystemClass#f WITH Stmt::ExceptionClass#f ON System::SystemClass#f.<0>=Stmt::ExceptionClass#f.<0> OUTPUT FIELDS {Stmt::ExceptionClass#f.<0>,"InvalidCastException"}
                      3          ~0%       {1} r12 = JOIN r11 WITH Element::NamedElement::getName_dispred#ff ON r11.<0>=Element::NamedElement::getName_dispred#ff.<0> AND r11.<1>=Element::NamedElement::getName_dispred#ff.<1> OUTPUT FIELDS {r11.<0>}
                      106911     ~1%       {2} r13 = JOIN r12 WITH Completion::invalidCastCandidate#f CARTESIAN PRODUCT OUTPUT FIELDS {Completion::invalidCastCandidate#f.<0>,r12.<0>}
                      11004      ~3%       {2} r14 = JOIN r13 WITH Stmt::TryStmt::getATriedElement#ff_1#join_rhs ON r13.<0>=Stmt::TryStmt::getATriedElement#ff_1#join_rhs.<0> OUTPUT FIELDS {r13.<0>,r13.<1>}
                      30819      ~4%       {2} r15 = r10 \/ r14
                      3          ~0%       {1} r16 = JOIN System::SystemExceptionClass#class#f WITH Stmt::ExceptionClass#f ON System::SystemExceptionClass#class#f.<0>=Stmt::ExceptionClass#f.<0> OUTPUT FIELDS {Stmt::ExceptionClass#f.<0>}
                      16611066   ~0%       {2} r17 = JOIN r16 WITH Call::Call#class#f CARTESIAN PRODUCT OUTPUT FIELDS {Call::Call#class#f.<0>,r16.<0>}
                      1057272    ~0%       {2} r18 = JOIN r17 WITH Stmt::TryStmt::getATriedElement#ff_1#join_rhs ON r17.<0>=Stmt::TryStmt::getATriedElement#ff_1#join_rhs.<0> OUTPUT FIELDS {r17.<0>,r17.<1>}
                      1088091    ~0%       {2} r19 = r15 \/ r18
                      234408     ~5%       {1} r20 = Completion::TriedControlFlowElement::getAThrownException_dispred#ff#shared AND NOT Completion::TriedControlFlowElement::getAThrownException_dispred#ff#antijoin_rhs(Completion::TriedControlFlowElement::getAThrownException_dispred#ff#shared.<0>)
                      2395649760 ~4%       {2} r21 = JOIN r20 WITH Stmt::ExceptionClass#f CARTESIAN PRODUCT OUTPUT FIELDS {Stmt::ExceptionClass#f.<0>,r20.<0>}
                      703224     ~5%       {2} r22 = JOIN r21 WITH System::SystemNullReferenceExceptionClass#class#f ON r21.<0>=System::SystemNullReferenceExceptionClass#class#f.<0> OUTPUT FIELDS {r21.<1>,r21.<0>}
                      1791315    ~0%       {2} r23 = r19 \/ r22
                      1080       ~0%       {1} r24 = JOIN Creation::DelegateCreation#class#f WITH Stmt::TryStmt::getATriedElement#ff_1#join_rhs ON Creation::DelegateCreation#class#f.<0>=Stmt::TryStmt::getATriedElement#ff_1#join_rhs.<0> OUTPUT FIELDS {Creation::DelegateCreation#class#f.<0>}
                      11037600   ~0%       {2} r25 = JOIN r24 WITH Stmt::ExceptionClass#f CARTESIAN PRODUCT OUTPUT FIELDS {Stmt::ExceptionClass#f.<0>,r24.<0>}
                      3240       ~1%       {2} r26 = JOIN r25 WITH System::SystemOutOfMemoryExceptionClass#class#f ON r25.<0>=System::SystemOutOfMemoryExceptionClass#class#f.<0> OUTPUT FIELDS {r25.<1>,r25.<0>}
                      1794555    ~0%       {2} r27 = r23 \/ r26
                      1898       ~1%       {1} r28 = JOIN ControlFlowGraph::ControlFlow::Internal::Successor::StandardExpr#class#f#antijoin_rhs WITH Stmt::TryStmt::getATriedElement#ff_1#join_rhs ON ControlFlowGraph::ControlFlow::Internal::Successor::StandardExpr#class#f#antijoin_rhs.<0>=Stmt::TryStmt::getATriedElement#ff_1#join_rhs.<0> OUTPUT FIELDS {ControlFlowGraph::ControlFlow::Internal::Successor::StandardExpr#class#f#antijoin_rhs.<0>}
                      19397560   ~0%       {2} r29 = JOIN r28 WITH Stmt::ExceptionClass#f CARTESIAN PRODUCT OUTPUT FIELDS {Stmt::ExceptionClass#f.<0>,r28.<0>}
                      5694       ~0%       {2} r30 = JOIN r29 WITH System::SystemOutOfMemoryExceptionClass#class#f ON r29.<0>=System::SystemOutOfMemoryExceptionClass#class#f.<0> OUTPUT FIELDS {r29.<1>,r29.<0>}
                      1800249    ~0%       {2} r31 = r27 \/ r30
                      1          ~0%       {1} r32 = CONSTANT(unique int)[44]
                      107673     ~4%       {1} r33 = JOIN r32 WITH expressions_10#join_rhs ON r32.<0>=expressions_10#join_rhs.<0> OUTPUT FIELDS {expressions_10#join_rhs.<1>}
                      3709       ~0%       {1} r34 = JOIN r33 WITH Stmt::TryStmt::getATriedElement#ff_1#join_rhs ON r33.<0>=Stmt::TryStmt::getATriedElement#ff_1#join_rhs.<0> OUTPUT FIELDS {r33.<0>}
                      3709       ~0%       {2} r35 = JOIN r34 WITH Expr::Expr::getType_dispred#ff ON r34.<0>=Expr::Expr::getType_dispred#ff.<0> OUTPUT FIELDS {Expr::Expr::getType_dispred#ff.<1>,r34.<0>}
                      2800       ~0%       {1} r36 = JOIN r35 WITH Type::StringType#f ON r35.<0>=Type::StringType#f.<0> OUTPUT FIELDS {r35.<1>}
                      28616000   ~1%       {2} r37 = JOIN r36 WITH Stmt::ExceptionClass#f CARTESIAN PRODUCT OUTPUT FIELDS {Stmt::ExceptionClass#f.<0>,r36.<0>}
                      8400       ~0%       {2} r38 = JOIN r37 WITH System::SystemOutOfMemoryExceptionClass#class#f ON r37.<0>=System::SystemOutOfMemoryExceptionClass#class#f.<0> OUTPUT FIELDS {r37.<1>,r37.<0>}
                      1808649    ~0%       {2} r39 = r31 \/ r38
                      1760039    ~2%       {2} r40 = JOIN @integral_type#f WITH Expr::Expr::getType_dispred#ff_10#join_rhs ON @integral_type#f.<0>=Expr::Expr::getType_dispred#ff_10#join_rhs.<0> OUTPUT FIELDS {Expr::Expr::getType_dispred#ff_10#join_rhs.<1>,44}
                      26824      ~0%       {1} r41 = JOIN r40 WITH expressions ON r40.<0>=expressions.<0> AND r40.<1>=expressions.<1> OUTPUT FIELDS {r40.<0>}
                      849        ~3%       {1} r42 = JOIN r41 WITH Stmt::TryStmt::getATriedElement#ff_1#join_rhs ON r41.<0>=Stmt::TryStmt::getATriedElement#ff_1#join_rhs.<0> OUTPUT FIELDS {r41.<0>}
                      8676780    ~0%       {2} r43 = JOIN r42 WITH Stmt::ExceptionClass#f CARTESIAN PRODUCT OUTPUT FIELDS {Stmt::ExceptionClass#f.<0>,r42.<0>}
                      2547       ~0%       {2} r44 = JOIN r43 WITH System::SystemOverflowExceptionClass#class#f ON r43.<0>=System::SystemOverflowExceptionClass#class#f.<0> OUTPUT FIELDS {r43.<1>,r43.<0>}
                      1811196    ~0%       {2} r45 = r39 \/ r44
                      1760039    ~3%       {2} r46 = JOIN @integral_type#f WITH Expr::Expr::getType_dispred#ff_10#join_rhs ON @integral_type#f.<0>=Expr::Expr::getType_dispred#ff_10#join_rhs.<0> OUTPUT FIELDS {Expr::Expr::getType_dispred#ff_10#join_rhs.<1>,45}
                      11564      ~5%       {1} r47 = JOIN r46 WITH expressions ON r46.<0>=expressions.<0> AND r46.<1>=expressions.<1> OUTPUT FIELDS {r46.<0>}
                      878        ~2%       {1} r48 = JOIN r47 WITH Stmt::TryStmt::getATriedElement#ff_1#join_rhs ON r47.<0>=Stmt::TryStmt::getATriedElement#ff_1#join_rhs.<0> OUTPUT FIELDS {r47.<0>}
                      8973160    ~0%       {2} r49 = JOIN r48 WITH Stmt::ExceptionClass#f CARTESIAN PRODUCT OUTPUT FIELDS {Stmt::ExceptionClass#f.<0>,r48.<0>}
                      2634       ~0%       {2} r50 = JOIN r49 WITH System::SystemOverflowExceptionClass#class#f ON r49.<0>=System::SystemOverflowExceptionClass#class#f.<0> OUTPUT FIELDS {r49.<1>,r49.<0>}
                      1813830    ~0%       {2} r51 = r45 \/ r50
                      1760039    ~2%       {2} r52 = JOIN @integral_type#f WITH Expr::Expr::getType_dispred#ff_10#join_rhs ON @integral_type#f.<0>=Expr::Expr::getType_dispred#ff_10#join_rhs.<0> OUTPUT FIELDS {Expr::Expr::getType_dispred#ff_10#join_rhs.<1>,41}
                      8971       ~6%       {1} r53 = JOIN r52 WITH expressions ON r52.<0>=expressions.<0> AND r52.<1>=expressions.<1> OUTPUT FIELDS {r52.<0>}
                      318        ~0%       {1} r54 = JOIN r53 WITH Stmt::TryStmt::getATriedElement#ff_1#join_rhs ON r53.<0>=Stmt::TryStmt::getATriedElement#ff_1#join_rhs.<0> OUTPUT FIELDS {r53.<0>}
                      3249960    ~0%       {2} r55 = JOIN r54 WITH Stmt::ExceptionClass#f CARTESIAN PRODUCT OUTPUT FIELDS {Stmt::ExceptionClass#f.<0>,r54.<0>}
                      954        ~0%       {2} r56 = JOIN r55 WITH System::SystemOverflowExceptionClass#class#f ON r55.<0>=System::SystemOverflowExceptionClass#class#f.<0> OUTPUT FIELDS {r55.<1>,r55.<0>}
                      1814784    ~0%       {2} r57 = r51 \/ r56
                      56         ~0%       {1} r58 = Completion::TriedControlFlowElement::getAThrownException_dispred#ff#shared#1 AND NOT Completion::TriedControlFlowElement::getAThrownException_dispred#ff#antijoin_rhs#1(Completion::TriedControlFlowElement::getAThrownException_dispred#ff#shared#1.<0>)
                      572320     ~3%       {2} r59 = JOIN r58 WITH Stmt::ExceptionClass#f CARTESIAN PRODUCT OUTPUT FIELDS {Stmt::ExceptionClass#f.<0>,r58.<0>}
                      168        ~0%       {2} r60 = JOIN r59 WITH System::SystemDivideByZeroExceptionClass#class#f ON r59.<0>=System::SystemDivideByZeroExceptionClass#class#f.<0> OUTPUT FIELDS {r59.<1>,r59.<0>}
                      1814952    ~0%       {2} r61 = r57 \/ r60
                      1          ~0%       {1} r62 = CONSTANT(unique int)[43]
                      970        ~0%       {1} r63 = JOIN r62 WITH expressions_10#join_rhs ON r62.<0>=expressions_10#join_rhs.<0> OUTPUT FIELDS {expressions_10#join_rhs.<1>}
                      59         ~1%       {1} r64 = JOIN r63 WITH Stmt::TryStmt::getATriedElement#ff_1#join_rhs ON r63.<0>=Stmt::TryStmt::getATriedElement#ff_1#join_rhs.<0> OUTPUT FIELDS {r63.<0>}
                      602980     ~1%       {2} r65 = JOIN r64 WITH Stmt::ExceptionClass#f CARTESIAN PRODUCT OUTPUT FIELDS {Stmt::ExceptionClass#f.<0>,r64.<0>}
                      177        ~5%       {2} r66 = JOIN r65 WITH System::SystemDivideByZeroExceptionClass#class#f ON r65.<0>=System::SystemDivideByZeroExceptionClass#class#f.<0> OUTPUT FIELDS {r65.<1>,r65.<0>}
                      1815129    ~0%       {2} r67 = r61 \/ r66
                      172        ~3%       {1} r68 = JOIN Dynamic::DynamicExpr#f WITH Stmt::TryStmt::getATriedElement#ff_1#join_rhs ON Dynamic::DynamicExpr#f.<0>=Stmt::TryStmt::getATriedElement#ff_1#join_rhs.<0> OUTPUT FIELDS {Dynamic::DynamicExpr#f.<0>}
                      1757840    ~0%       {2} r69 = JOIN r68 WITH Stmt::ExceptionClass#f CARTESIAN PRODUCT OUTPUT FIELDS {Stmt::ExceptionClass#f.<0>,r68.<0>}
                      516        ~1%       {2} r70 = JOIN r69 WITH System::SystemExceptionClass#class#f ON r69.<0>=System::SystemExceptionClass#class#f.<0> OUTPUT FIELDS {r69.<1>,r69.<0>}
                      1815645    ~0%       {2} r71 = r67 \/ r70
                      3          ~0%       {2} r72 = JOIN System::SystemOutOfMemoryExceptionClass#class#f WITH Stmt::ExceptionClass#f ON System::SystemOutOfMemoryExceptionClass#class#f.<0>=Stmt::ExceptionClass#f.<0> OUTPUT FIELDS {10,Stmt::ExceptionClass#f.<0>}
                      3844605    ~2%       {2} r73 = JOIN r72 WITH expressions_10#join_rhs ON r72.<0>=expressions_10#join_rhs.<0> OUTPUT FIELDS {expressions_10#join_rhs.<1>,r72.<1>}
                      130110     ~0%       {2} r74 = JOIN r73 WITH Stmt::TryStmt::getATriedElement#ff_1#join_rhs ON r73.<0>=Stmt::TryStmt::getATriedElement#ff_1#join_rhs.<0> OUTPUT FIELDS {r73.<0>,r73.<1>}
                      1945755    ~0%       {2} r75 = r71 \/ r74
                                           return r75
```

After:
```
[2019-02-06 06:05:54] (116s) Starting to evaluate predicate Completion::TriedControlFlowElement::getAThrownException_dispred#ff
[2019-02-06 06:06:02] (124s) Tuple counts:
                      136178   ~3%       {2} r1 = JOIN @un_op#f WITH Expr::Expr::getType_dispred#ff ON @un_op#f.<0>=Expr::Expr::getType_dispred#ff.<0> OUTPUT FIELDS {Expr::Expr::getType_dispred#ff.<1>,@un_op#f.<0>}
                      44110    ~1%       {1} r2 = JOIN r1 WITH @integral_type#f ON r1.<0>=@integral_type#f.<0> OUTPUT FIELDS {r1.<1>}
                      2221     ~0%       {1} r3 = JOIN r2 WITH Stmt::TryStmt::getATriedElement#ff_1#join_rhs ON r2.<0>=Stmt::TryStmt::getATriedElement#ff_1#join_rhs.<0> OUTPUT FIELDS {r2.<0>}
                      6663     ~0%       {2} r4 = JOIN r3 WITH System::SystemOverflowExceptionClass#class#f CARTESIAN PRODUCT OUTPUT FIELDS {r3.<0>,System::SystemOverflowExceptionClass#class#f.<0>}
                      1760039  ~0%       {1} r5 = JOIN @integral_type#f WITH Expr::Expr::getType_dispred#ff_10#join_rhs ON @integral_type#f.<0>=Expr::Expr::getType_dispred#ff_10#join_rhs.<0> OUTPUT FIELDS {Expr::Expr::getType_dispred#ff_10#join_rhs.<1>}
                      77350    ~0%       {1} r6 = JOIN r5 WITH Expr::CastExpr#class#f ON r5.<0>=Expr::CastExpr#class#f.<0> OUTPUT FIELDS {r5.<0>}
                      4384     ~0%       {1} r7 = JOIN r6 WITH Stmt::TryStmt::getATriedElement#ff_1#join_rhs ON r6.<0>=Stmt::TryStmt::getATriedElement#ff_1#join_rhs.<0> OUTPUT FIELDS {r6.<0>}
                      13152    ~3%       {2} r8 = JOIN r7 WITH System::SystemOverflowExceptionClass#class#f CARTESIAN PRODUCT OUTPUT FIELDS {r7.<0>,System::SystemOverflowExceptionClass#class#f.<0>}
                      19815    ~1%       {2} r9 = r4 \/ r8
                      3668     ~3%       {1} r10 = JOIN Completion::invalidCastCandidate#f WITH Stmt::TryStmt::getATriedElement#ff_1#join_rhs ON Completion::invalidCastCandidate#f.<0>=Stmt::TryStmt::getATriedElement#ff_1#join_rhs.<0> OUTPUT FIELDS {Completion::invalidCastCandidate#f.<0>}
                      9701860  ~0%       {3} r11 = JOIN r10 WITH System::SystemClass#f CARTESIAN PRODUCT OUTPUT FIELDS {System::SystemClass#f.<0>,"InvalidCastException",r10.<0>}
                      11004    ~3%       {2} r12 = JOIN r11 WITH Element::NamedElement::getName_dispred#ff ON r11.<0>=Element::NamedElement::getName_dispred#ff.<0> AND r11.<1>=Element::NamedElement::getName_dispred#ff.<1> OUTPUT FIELDS {r11.<2>,r11.<0>}
                      30819    ~4%       {2} r13 = r9 \/ r12
                      352424   ~1%       {1} r14 = JOIN Stmt::TryStmt::getATriedElement#ff_1#join_rhs WITH Call::Call#class#f ON Stmt::TryStmt::getATriedElement#ff_1#join_rhs.<0>=Call::Call#class#f.<0> OUTPUT FIELDS {Call::Call#class#f.<0>}
                      1057272  ~0%       {2} r15 = JOIN r14 WITH System::SystemExceptionClass#class#f CARTESIAN PRODUCT OUTPUT FIELDS {r14.<0>,System::SystemExceptionClass#class#f.<0>}
                      1088091  ~0%       {2} r16 = r13 \/ r15
                      234408   ~5%       {1} r17 = Completion::TriedControlFlowElement::getAThrownException_dispred#ff#shared AND NOT Completion::TriedControlFlowElement::getAThrownException_dispred#ff#antijoin_rhs(Completion::TriedControlFlowElement::getAThrownException_dispred#ff#shared.<0>)
                      703224   ~5%       {2} r18 = JOIN r17 WITH System::SystemNullReferenceExceptionClass#class#f CARTESIAN PRODUCT OUTPUT FIELDS {r17.<0>,System::SystemNullReferenceExceptionClass#class#f.<0>}
                      1791315  ~0%       {2} r19 = r16 \/ r18
                      1080     ~0%       {1} r20 = JOIN Creation::DelegateCreation#class#f WITH Stmt::TryStmt::getATriedElement#ff_1#join_rhs ON Creation::DelegateCreation#class#f.<0>=Stmt::TryStmt::getATriedElement#ff_1#join_rhs.<0> OUTPUT FIELDS {Creation::DelegateCreation#class#f.<0>}
                      3240     ~1%       {2} r21 = JOIN r20 WITH System::SystemOutOfMemoryExceptionClass#class#f CARTESIAN PRODUCT OUTPUT FIELDS {r20.<0>,System::SystemOutOfMemoryExceptionClass#class#f.<0>}
                      1794555  ~0%       {2} r22 = r19 \/ r21
                      1898     ~1%       {1} r23 = JOIN ControlFlowGraph::ControlFlow::Internal::Successor::StandardExpr#class#f#antijoin_rhs WITH Stmt::TryStmt::getATriedElement#ff_1#join_rhs ON ControlFlowGraph::ControlFlow::Internal::Successor::StandardExpr#class#f#antijoin_rhs.<0>=Stmt::TryStmt::getATriedElement#ff_1#join_rhs.<0> OUTPUT FIELDS {ControlFlowGraph::ControlFlow::Internal::Successor::StandardExpr#class#f#antijoin_rhs.<0>}
                      5694     ~0%       {2} r24 = JOIN r23 WITH System::SystemOutOfMemoryExceptionClass#class#f CARTESIAN PRODUCT OUTPUT FIELDS {r23.<0>,System::SystemOutOfMemoryExceptionClass#class#f.<0>}
                      1800249  ~0%       {2} r25 = r22 \/ r24
                      1        ~0%       {1} r26 = CONSTANT(unique int)[44]
                      107673   ~4%       {1} r27 = JOIN r26 WITH expressions_10#join_rhs ON r26.<0>=expressions_10#join_rhs.<0> OUTPUT FIELDS {expressions_10#join_rhs.<1>}
                      3709     ~0%       {1} r28 = JOIN r27 WITH Stmt::TryStmt::getATriedElement#ff_1#join_rhs ON r27.<0>=Stmt::TryStmt::getATriedElement#ff_1#join_rhs.<0> OUTPUT FIELDS {r27.<0>}
                      3709     ~0%       {2} r29 = JOIN r28 WITH Expr::Expr::getType_dispred#ff ON r28.<0>=Expr::Expr::getType_dispred#ff.<0> OUTPUT FIELDS {Expr::Expr::getType_dispred#ff.<1>,r28.<0>}
                      2800     ~0%       {1} r30 = JOIN r29 WITH Type::StringType#f ON r29.<0>=Type::StringType#f.<0> OUTPUT FIELDS {r29.<1>}
                      8400     ~0%       {2} r31 = JOIN r30 WITH System::SystemOutOfMemoryExceptionClass#class#f CARTESIAN PRODUCT OUTPUT FIELDS {r30.<0>,System::SystemOutOfMemoryExceptionClass#class#f.<0>}
                      1808649  ~0%       {2} r32 = r25 \/ r31
                      1760039  ~2%       {2} r33 = JOIN @integral_type#f WITH Expr::Expr::getType_dispred#ff_10#join_rhs ON @integral_type#f.<0>=Expr::Expr::getType_dispred#ff_10#join_rhs.<0> OUTPUT FIELDS {Expr::Expr::getType_dispred#ff_10#join_rhs.<1>,44}
                      26824    ~0%       {1} r34 = JOIN r33 WITH expressions ON r33.<0>=expressions.<0> AND r33.<1>=expressions.<1> OUTPUT FIELDS {r33.<0>}
                      849      ~3%       {1} r35 = JOIN r34 WITH Stmt::TryStmt::getATriedElement#ff_1#join_rhs ON r34.<0>=Stmt::TryStmt::getATriedElement#ff_1#join_rhs.<0> OUTPUT FIELDS {r34.<0>}
                      2547     ~0%       {2} r36 = JOIN r35 WITH System::SystemOverflowExceptionClass#class#f CARTESIAN PRODUCT OUTPUT FIELDS {r35.<0>,System::SystemOverflowExceptionClass#class#f.<0>}
                      1811196  ~0%       {2} r37 = r32 \/ r36
                      1760039  ~3%       {2} r38 = JOIN @integral_type#f WITH Expr::Expr::getType_dispred#ff_10#join_rhs ON @integral_type#f.<0>=Expr::Expr::getType_dispred#ff_10#join_rhs.<0> OUTPUT FIELDS {Expr::Expr::getType_dispred#ff_10#join_rhs.<1>,45}
                      11564    ~5%       {1} r39 = JOIN r38 WITH expressions ON r38.<0>=expressions.<0> AND r38.<1>=expressions.<1> OUTPUT FIELDS {r38.<0>}
                      878      ~2%       {1} r40 = JOIN r39 WITH Stmt::TryStmt::getATriedElement#ff_1#join_rhs ON r39.<0>=Stmt::TryStmt::getATriedElement#ff_1#join_rhs.<0> OUTPUT FIELDS {r39.<0>}
                      2634     ~0%       {2} r41 = JOIN r40 WITH System::SystemOverflowExceptionClass#class#f CARTESIAN PRODUCT OUTPUT FIELDS {r40.<0>,System::SystemOverflowExceptionClass#class#f.<0>}
                      1813830  ~0%       {2} r42 = r37 \/ r41
                      1760039  ~2%       {2} r43 = JOIN @integral_type#f WITH Expr::Expr::getType_dispred#ff_10#join_rhs ON @integral_type#f.<0>=Expr::Expr::getType_dispred#ff_10#join_rhs.<0> OUTPUT FIELDS {Expr::Expr::getType_dispred#ff_10#join_rhs.<1>,41}
                      8971     ~6%       {1} r44 = JOIN r43 WITH expressions ON r43.<0>=expressions.<0> AND r43.<1>=expressions.<1> OUTPUT FIELDS {r43.<0>}
                      318      ~0%       {1} r45 = JOIN r44 WITH Stmt::TryStmt::getATriedElement#ff_1#join_rhs ON r44.<0>=Stmt::TryStmt::getATriedElement#ff_1#join_rhs.<0> OUTPUT FIELDS {r44.<0>}
                      954      ~0%       {2} r46 = JOIN r45 WITH System::SystemOverflowExceptionClass#class#f CARTESIAN PRODUCT OUTPUT FIELDS {r45.<0>,System::SystemOverflowExceptionClass#class#f.<0>}
                      1814784  ~0%       {2} r47 = r42 \/ r46
                      56       ~0%       {1} r48 = Completion::TriedControlFlowElement::getAThrownException_dispred#ff#shared#1 AND NOT Completion::TriedControlFlowElement::getAThrownException_dispred#ff#antijoin_rhs#1(Completion::TriedControlFlowElement::getAThrownException_dispred#ff#shared#1.<0>)
                      168      ~0%       {2} r49 = JOIN r48 WITH System::SystemDivideByZeroExceptionClass#class#f CARTESIAN PRODUCT OUTPUT FIELDS {r48.<0>,System::SystemDivideByZeroExceptionClass#class#f.<0>}
                      1814952  ~0%       {2} r50 = r47 \/ r49
                      1        ~0%       {1} r51 = CONSTANT(unique int)[43]
                      970      ~0%       {1} r52 = JOIN r51 WITH expressions_10#join_rhs ON r51.<0>=expressions_10#join_rhs.<0> OUTPUT FIELDS {expressions_10#join_rhs.<1>}
                      59       ~1%       {1} r53 = JOIN r52 WITH Stmt::TryStmt::getATriedElement#ff_1#join_rhs ON r52.<0>=Stmt::TryStmt::getATriedElement#ff_1#join_rhs.<0> OUTPUT FIELDS {r52.<0>}
                      177      ~5%       {2} r54 = JOIN r53 WITH System::SystemDivideByZeroExceptionClass#class#f CARTESIAN PRODUCT OUTPUT FIELDS {r53.<0>,System::SystemDivideByZeroExceptionClass#class#f.<0>}
                      1815129  ~0%       {2} r55 = r50 \/ r54
                      172      ~3%       {1} r56 = JOIN Dynamic::DynamicExpr#f WITH Stmt::TryStmt::getATriedElement#ff_1#join_rhs ON Dynamic::DynamicExpr#f.<0>=Stmt::TryStmt::getATriedElement#ff_1#join_rhs.<0> OUTPUT FIELDS {Dynamic::DynamicExpr#f.<0>}
                      516      ~1%       {2} r57 = JOIN r56 WITH System::SystemExceptionClass#class#f CARTESIAN PRODUCT OUTPUT FIELDS {r56.<0>,System::SystemExceptionClass#class#f.<0>}
                      1815645  ~0%       {2} r58 = r55 \/ r57
                      1        ~0%       {1} r59 = CONSTANT(unique int)[10]
                      1281535  ~0%       {1} r60 = JOIN r59 WITH expressions_10#join_rhs ON r59.<0>=expressions_10#join_rhs.<0> OUTPUT FIELDS {expressions_10#join_rhs.<1>}
                      43370    ~0%       {1} r61 = JOIN r60 WITH Stmt::TryStmt::getATriedElement#ff_1#join_rhs ON r60.<0>=Stmt::TryStmt::getATriedElement#ff_1#join_rhs.<0> OUTPUT FIELDS {r60.<0>}
                      130110   ~0%       {2} r62 = JOIN r61 WITH System::SystemOutOfMemoryExceptionClass#class#f CARTESIAN PRODUCT OUTPUT FIELDS {r61.<0>,System::SystemOutOfMemoryExceptionClass#class#f.<0>}
                      1945755  ~0%       {2} r63 = r58 \/ r62
                                         return r63
```