### PR TITLE
Java: Add a flow step for `Path::toFile` in ZipSlip

### DIFF
--- a/change-notes/1.20/analysis-java.md
+++ b/change-notes/1.20/analysis-java.md
@@ -14,6 +14,7 @@
 
 | **Query**                  | **Expected impact**    | **Change**                                                       |
 |----------------------------|------------------------|------------------------------------------------------------------|
+| Arbitrary file write during archive extraction ("Zip Slip") (`java/zipslip`) | Fewer false positive results | Results involving a sanitization step that converts a destination `Path` to a `File` are no longer reported. |
 | Double-checked locking is not thread-safe (`java/unsafe-double-checked-locking`) | Fewer false positive results and more true positive results | Results that use safe publication through a `final` field are no longer reported. Results that initialize immutable types like `String` incorrectly are now reported. |
 | Result of multiplication cast to wider type (`java/integer-multiplication-cast-to-long`) | Fewer results | Results involving conversions to `float` or `double` are no longer reported, as they were almost exclusively false positives. |
 

--- a/java/ql/src/Security/CWE/CWE-022/ZipSlip.ql
+++ b/java/ql/src/Security/CWE/CWE-022/ZipSlip.ql
@@ -79,6 +79,8 @@ predicate filePathStep(ExprNode n1, ExprNode n2) {
     m.getDeclaringType() instanceof TypeFile and m.hasName("toPath")
     or
     m.getDeclaringType() instanceof TypePath and m.hasName("toAbsolutePath")
+    or
+    m.getDeclaringType() instanceof TypePath and m.hasName("toFile")
   )
 }
 

--- a/java/ql/test/query-tests/security/CWE-022/semmle/tests/ZipTest.java
+++ b/java/ql/test/query-tests/security/CWE-022/semmle/tests/ZipTest.java
@@ -51,4 +51,13 @@ public class ZipTest {
       throw new Exception();
     FileOutputStream os = new FileOutputStream(file); // OK
   }
+
+  public void m6(ZipEntry entry, Path dir) {
+    String canonicalDest = dir.toFile().getCanonicalPath();
+    Path target = dir.resolve(entry.getName());
+    String canonicalTarget = target.toFile().getCanonicalPath();
+    if (!canonicalTarget.startsWith(canonicalDest + File.separator))
+      throw new Exception();
+    OutputStream os = Files.newOutputStream(target); // OK
+  }
 }


### PR DESCRIPTION
This fixes this false positive: https://lgtm.com/projects/g/GoogleContainerTools/jib/snapshot/83d33f2b220d3d8183028ddaaa15cf84255ddc9f/files/jib-plugins-common/src/main/java/com/google/cloud/tools/jib/plugins/common/ZipUtil.java?sort=name&dir=ASC&mode=heatmap#x89296eae147d2e8:1