### PR TITLE
JavaScript: Assign `FileAccessToHttp` and `HttpToFileAccess` a precision.

### DIFF
--- a/javascript/ql/src/Security/CWE-200/FileAccessToHttp.ql
+++ b/javascript/ql/src/Security/CWE-200/FileAccessToHttp.ql
@@ -3,6 +3,7 @@
  * @description Directly sending file data in an outbound network request can indicate unauthorized information disclosure.
  * @kind path-problem
  * @problem.severity warning
+ * @precision medium
  * @id js/file-access-to-http
  * @tags security
  *       external/cwe/cwe-200

--- a/javascript/ql/src/Security/CWE-912/HttpToFileAccess.ql
+++ b/javascript/ql/src/Security/CWE-912/HttpToFileAccess.ql
@@ -3,6 +3,7 @@
  * @description Writing user-controlled data directly to the file system allows arbitrary file upload and might indicate a backdoor.
  * @kind path-problem
  * @problem.severity warning
+ * @precision medium
  * @id js/http-to-file-access
  * @tags security
  *       external/cwe/cwe-912


### PR DESCRIPTION
They will now be run on LGTM, but their results won't be displayed by default.

An [evaluation](https://git.semmle.com/gist/max/87df05e15bad52d7062efe3b409536f3) (internal link) suggests that their performance is roughly what you'd expect from inter-procedural queries, and at least on our default projects the number of results is manageable. Still, they aren't results we'd want to show by default, hence precision `medium`.

After the next dist upgrade I plan to look over a few more results on lgtm.com and then decide what to do about these queries.