### PR TITLE
JavaScript: Improve alert location and message for `IncompleteSanitization`.

### DIFF
--- a/javascript/ql/src/Security/CWE-116/IncompleteSanitization.ql
+++ b/javascript/ql/src/Security/CWE-116/IncompleteSanitization.ql
@@ -127,7 +127,7 @@ where
     exists(RegExpLiteral rel |
       isBackslashEscape(repl, rel) and
       not allBackslashesEscaped(DataFlow::valueNode(repl)) and
-      msg = "This does not backslash-escape the backslash character."
+      msg = "This does not escape backslash characters in the input."
     )
   )
-select old, msg
+select repl.getCallee(), msg

--- a/javascript/ql/test/query-tests/Security/CWE-116/IncompleteSanitization/IncompleteSanitization.expected
+++ b/javascript/ql/test/query-tests/Security/CWE-116/IncompleteSanitization/IncompleteSanitization.expected
@@ -1,17 +1,17 @@
-| tst.js:5:20:5:22 | "'" | This replaces only the first occurrence of "'". |
-| tst.js:9:20:9:22 | /'/ | This replaces only the first occurrence of /'/. |
-| tst.js:13:20:13:23 | /'/g | This does not backslash-escape the backslash character. |
-| tst.js:17:20:17:23 | /'/g | This does not backslash-escape the backslash character. |
-| tst.js:21:20:21:26 | /['"]/g | This does not backslash-escape the backslash character. |
-| tst.js:25:20:25:28 | /(['"])/g | This does not backslash-escape the backslash character. |
-| tst.js:29:20:29:27 | /('\|")/g | This does not backslash-escape the backslash character. |
-| tst.js:33:20:33:22 | '\|' | This replaces only the first occurrence of '\|'. |
-| tst.js:37:20:37:23 | /"/g | This does not backslash-escape the backslash character. |
-| tst.js:41:20:41:22 | "/" | This replaces only the first occurrence of "/". |
-| tst.js:45:20:45:24 | "%25" | This replaces only the first occurrence of "%25". |
-| tst.js:49:20:49:22 | `'` | This replaces only the first occurrence of `'`. |
-| tst.js:53:20:53:22 | "'" | This replaces only the first occurrence of "'". |
-| tst.js:57:20:57:22 | `'` | This replaces only the first occurrence of `'`. |
-| tst.js:61:20:61:27 | "'" + "" | This replaces only the first occurrence of "'" + "". |
-| tst.js:65:20:65:22 | "'" | This replaces only the first occurrence of "'". |
-| tst.js:69:20:69:27 | "'" + "" | This replaces only the first occurrence of "'" + "". |
+| tst.js:5:10:5:18 | s.replace | This replaces only the first occurrence of "'". |
+| tst.js:9:10:9:18 | s.replace | This replaces only the first occurrence of /'/. |
+| tst.js:13:10:13:18 | s.replace | This does not escape backslash characters in the input. |
+| tst.js:17:10:17:18 | s.replace | This does not escape backslash characters in the input. |
+| tst.js:21:10:21:18 | s.replace | This does not escape backslash characters in the input. |
+| tst.js:25:10:25:18 | s.replace | This does not escape backslash characters in the input. |
+| tst.js:29:10:29:18 | s.replace | This does not escape backslash characters in the input. |
+| tst.js:33:10:33:18 | s.replace | This replaces only the first occurrence of '\|'. |
+| tst.js:37:10:37:18 | s.replace | This does not escape backslash characters in the input. |
+| tst.js:41:10:41:18 | s.replace | This replaces only the first occurrence of "/". |
+| tst.js:45:10:45:18 | s.replace | This replaces only the first occurrence of "%25". |
+| tst.js:49:10:49:18 | s.replace | This replaces only the first occurrence of `'`. |
+| tst.js:53:10:53:18 | s.replace | This replaces only the first occurrence of "'". |
+| tst.js:57:10:57:18 | s.replace | This replaces only the first occurrence of `'`. |
+| tst.js:61:10:61:18 | s.replace | This replaces only the first occurrence of "'" + "". |
+| tst.js:65:10:65:18 | s.replace | This replaces only the first occurrence of "'". |
+| tst.js:69:10:69:18 | s.replace | This replaces only the first occurrence of "'" + "". |


### PR DESCRIPTION
We now highlight the `replace` call (instead of the regular expression), and the alert message for the case of missing backslash escapes clarifies that it is talking about failure to escape backslashes in the input, not in the replacement text. This hopefully will prevent misunderstandings like [this one](https://discuss.lgtm.com/t/javascript-false-positive-unescaped-backslash-in-regexp/1735).