### PR TITLE
CPP: Update severity/precision of LargeParameter.ql.

### DIFF
--- a/cpp/ql/src/Critical/LargeParameter.ql
+++ b/cpp/ql/src/Critical/LargeParameter.ql
@@ -2,8 +2,8 @@
  * @name Large object passed by value
  * @description An object larger than 64 bytes is passed by value to a function. Passing large objects by value unnecessarily use up scarce stack space, increase the cost of calling a function and can be a security risk. Use a const pointer to the object instead.
  * @kind problem
- * @problem.severity warning
- * @precision high
+ * @problem.severity recommendation
+ * @precision very-high
  * @id cpp/large-parameter
  * @tags efficiency
  *       readability


### PR DESCRIPTION
Many projects I've looked at on LGTM have their 'warning' tab dominated by large numbers of (correct) results for this query.  But it feels more like a recommendation to me, and as a warning it's potentially crowding out more interesting results.

I've also increased it's precision to `very-high`, this is defensible but mostly just to make sure it still gets displayed by default on LGTM.

As an aside, we don't tend to produce many CPP recommendations on LGTM because we have very few queries at `very-high`.  Perhaps this is something we should address at some point?