### PR TITLE
JS: exclude field initializers in dead-store

### DIFF
--- a/javascript/ql/src/Declarations/DeadStoreOfProperty.ql
+++ b/javascript/ql/src/Declarations/DeadStoreOfProperty.ql
@@ -154,6 +154,12 @@ where
     or
     // exclude result from js/overwritten-property
     assign2.getBase() instanceof DataFlow::ObjectLiteralNode
+    or
+    // exclude the implicit initialization of fields
+    exists (FieldDeclaration field |
+      assign1.getWriteNode() = field and
+      not exists(field.getInit())
+    )
   )
 select assign1.getWriteNode(),
   "This write to property '" + name + "' is useless, since $@ always overrides it.",

--- a/javascript/ql/test/query-tests/Declarations/DeadStoreOfProperty/DeadStoreOfProperty.expected
+++ b/javascript/ql/test/query-tests/Declarations/DeadStoreOfProperty/DeadStoreOfProperty.expected
@@ -1,3 +1,4 @@
+| fieldInit.ts:10:3:10:8 | f = 4; | This write to property 'f' is useless, since $@ always overrides it. | fieldInit.ts:13:5:13:14 | this.f = 5 | another property write |
 | real-world-examples.js:5:4:5:11 | o.p = 42 | This write to property 'p' is useless, since $@ always overrides it. | real-world-examples.js:10:2:10:9 | o.p = 42 | another property write |
 | real-world-examples.js:15:9:15:18 | o.p1 += 42 | This write to property 'p1' is useless, since $@ always overrides it. | real-world-examples.js:15:2:15:18 | o.p1 = o.p1 += 42 | another property write |
 | real-world-examples.js:16:11:16:20 | o.p2 *= 42 | This write to property 'p2' is useless, since $@ always overrides it. | real-world-examples.js:16:2:16:21 | o.p2 -= (o.p2 *= 42) | another property write |

--- a/javascript/ql/test/query-tests/Declarations/DeadStoreOfProperty/fieldInit.ts
+++ b/javascript/ql/test/query-tests/Declarations/DeadStoreOfProperty/fieldInit.ts
@@ -1,0 +1,15 @@
+class C {
+  f; // OK
+  
+  constructor() {
+    this.f = 5;
+  }
+}
+
+class D {
+  f = 4; // NOT OK
+  
+  constructor() {
+    this.f = 5;
+  }
+}


### PR DESCRIPTION
Should fix some [false positives](https://lgtm.com/projects/g/synesthesia-project/core/alerts/?mode=tree&ruleFocus=1506738031393) that were introduced with the recent change to `PropWrite` in class constructors.