### PR TITLE
JavaScript: Restrict `InstanceFieldAsPropWrite` to fields with initializers.

### DIFF
--- a/javascript/ql/src/semmle/javascript/dataflow/DataFlow.qll
+++ b/javascript/ql/src/semmle/javascript/dataflow/DataFlow.qll
@@ -555,14 +555,15 @@ module DataFlow {
   }
 
   /**
-   * An instance field, seen as a property write.
+   * An instance field with an initializer, seen as a property write.
    */
   private class InstanceFieldAsPropWrite extends PropWrite, PropNode {
     override FieldDefinition prop;
 
     InstanceFieldAsPropWrite() {
       not prop.isStatic() and
-      not prop instanceof ParameterField
+      not prop instanceof ParameterField and
+      exists(prop.getInit())
     }
 
     override Node getBase() {

--- a/javascript/ql/test/query-tests/Declarations/DeadStoreOfProperty/DeadStoreOfProperty.expected
+++ b/javascript/ql/test/query-tests/Declarations/DeadStoreOfProperty/DeadStoreOfProperty.expected
@@ -1,3 +1,4 @@
+| fieldInit.ts:10:3:10:8 | f = 4; | This write to property 'f' is useless, since $@ always overrides it. | fieldInit.ts:13:5:13:14 | this.f = 5 | another property write |
 | real-world-examples.js:5:4:5:11 | o.p = 42 | This write to property 'p' is useless, since $@ always overrides it. | real-world-examples.js:10:2:10:9 | o.p = 42 | another property write |
 | real-world-examples.js:15:9:15:18 | o.p1 += 42 | This write to property 'p1' is useless, since $@ always overrides it. | real-world-examples.js:15:2:15:18 | o.p1 = o.p1 += 42 | another property write |
 | real-world-examples.js:16:11:16:20 | o.p2 *= 42 | This write to property 'p2' is useless, since $@ always overrides it. | real-world-examples.js:16:2:16:21 | o.p2 -= (o.p2 *= 42) | another property write |

--- a/javascript/ql/test/query-tests/Declarations/DeadStoreOfProperty/fieldInit.ts
+++ b/javascript/ql/test/query-tests/Declarations/DeadStoreOfProperty/fieldInit.ts
@@ -1,0 +1,15 @@
+class C {
+  f; // OK
+  
+  constructor() {
+    this.f = 5;
+  }
+}
+
+class D {
+  f = 4; // NOT OK
+  
+  constructor() {
+    this.f = 5;
+  }
+}


### PR DESCRIPTION
As an alternative to https://github.com/Semmle/ql/pull/918, we could consider this (partial) revert of https://github.com/Semmle/ql/pull/839/commits/60cef60c1d534e1b48d19b37ba7489c2f03626bb (which was added to the PR at my unwise suggestion).

Both in Flow and in TypeScript, a field declaration does not give rise to any actual JavaScript code (in particular, the corresponding property is not initialised to `undefined` or anything), so there is no reason to model such declarations as `PropWrite`s.

I have verified that this fixes all five dead-store-of-property alerts on `g/wabilin/MumiGiveP` and `g/ionjs-dev/ionjs` (the projects we've had reports about on discuss.lgtm.com). A full evaluation is ongoing, but performance looks unaffected so far.