### PR TITLE
JS: use type inference to back up function-style classes

### DIFF
--- a/javascript/ql/test/library-tests/ClassNode/InstanceMember.expected
+++ b/javascript/ql/test/library-tests/ClassNode/InstanceMember.expected
@@ -1,3 +1,4 @@
+| namespace.js:5:32:5:44 | function() {} | Baz.method | method |
 | tst.js:4:17:4:21 | () {} | A.instanceMethod | method |
 | tst.js:7:6:7:10 | () {} | A.bar | method |
 | tst.js:9:10:9:14 | () {} | A.baz | getter |

--- a/javascript/ql/test/library-tests/ClassNode/InstanceMethod.expected
+++ b/javascript/ql/test/library-tests/ClassNode/InstanceMethod.expected
@@ -1,3 +1,4 @@
+| namespace.js:5:32:5:44 | function() {} | Baz.method |
 | tst.js:4:17:4:21 | () {} | A.instanceMethod |
 | tst.js:7:6:7:10 | () {} | A.bar |
 | tst.js:17:19:17:31 | function() {} | B.foo |

--- a/javascript/ql/test/library-tests/ClassNode/namespace.js
+++ b/javascript/ql/test/library-tests/ClassNode/namespace.js
@@ -1,0 +1,5 @@
+goog.provide('foo.bar.baz');
+
+foo.bar.baz = function Baz() {};
+
+foo.bar.baz.prototype.method = function() {};


### PR DESCRIPTION
This makes `ClassNode` take advantage of type inference to recognize function-style classes in more cases.

[Evaluation](https://git.semmle.com/asger/dist-compare-reports/tree/domitian.ti.semmle.com_1549778481053) (internal link). Currently re-running on rhino.