### PR TITLE
CPP: Deprecate PotentialBufferOverflow.ql

### DIFF
--- a/change-notes/1.20/analysis-cpp.md
+++ b/change-notes/1.20/analysis-cpp.md
@@ -33,6 +33,7 @@
 | Mismatching new/free or malloc/delete (`cpp/new-free-mismatch`) | More correct results | Data flow through global variables for this query has been improved. |
 | Use of inherently dangerous function (`cpp/potential-buffer-overflow`) | Cleaned up | This query no longer catches uses of `gets`, and has been renamed 'Potential buffer overflow'. |
 | Use of potentially dangerous function (`cpp/potentially-dangerous-function`) | More correct results | This query now catches uses of `gets`. |
+| Potential buffer overflow (`cpp/potential-buffer-overflow`) | Deprecated | This query has been deprecated. Use Potentially overrunning write (`cpp/overrunning-write`) and Potentially overrunning write with float to string conversion (`cpp/overrunning-write-with-float`) instead. |
 
 ## Changes to QL libraries
 

--- a/cpp/config/suites/security/cwe-242
+++ b/cpp/config/suites/security/cwe-242
@@ -1,3 +1,0 @@
-# CWE-242: Use of Inherently Dangerous Function
-+ semmlecode-cpp-queries/Likely Bugs/Memory Management/PotentialBufferOverflow.ql: /CWE/CWE-242
-    @name Use of inherently dangerous function (CWE-242)

--- a/cpp/config/suites/security/default
+++ b/cpp/config/suites/security/default
@@ -12,7 +12,6 @@
 @import "cwe-134"
 @import "cwe-170"
 @import "cwe-190"
-@import "cwe-242"
 @import "cwe-253"
 @import "cwe-290"
 @import "cwe-311"

--- a/cpp/ql/src/Likely Bugs/Memory Management/PotentialBufferOverflow.ql
+++ b/cpp/ql/src/Likely Bugs/Memory Management/PotentialBufferOverflow.ql
@@ -9,10 +9,9 @@
  * @tags reliability
  *       security
  *       external/cwe/cwe-676
- * @deprecated
- *
- * This query is deprecated, use Security/CWE/CWE-120/OverrunWrite.ql and
- * Security/CWE/CWE-120/OverrunWriteFloat.ql instead.
+ * @deprecated This query is deprecated, use
+ *             Security/CWE/CWE-120/OverrunWrite.ql and
+ *             Security/CWE/CWE-120/OverrunWriteFloat.ql instead.
  */
 import cpp
 import semmle.code.cpp.commons.Buffer

--- a/cpp/ql/src/Likely Bugs/Memory Management/PotentialBufferOverflow.ql
+++ b/cpp/ql/src/Likely Bugs/Memory Management/PotentialBufferOverflow.ql
@@ -9,6 +9,10 @@
  * @tags reliability
  *       security
  *       external/cwe/cwe-676
+ * @deprecated
+ *
+ * This query is deprecated, use Security/CWE/CWE-120/OverrunWrite.ql and
+ * Security/CWE/CWE-120/OverrunWriteFloat.ql instead.
  */
 import cpp
 import semmle.code.cpp.commons.Buffer

--- a/cpp/ql/src/Likely Bugs/OO/NonVirtualDestructor.ql
+++ b/cpp/ql/src/Likely Bugs/OO/NonVirtualDestructor.ql
@@ -7,10 +7,10 @@
  * @id cpp/non-virtual-destructor
  * @problem.severity warning
  * @tags reliability
- * @deprecated
+ * @deprecated This query is deprecated, and replaced by
+ *             jsf/4.10 Classes/AV Rule 78.ql, which has far fewer false
+ *             positives on typical code.
  */
-
-// This query is deprecated, and replaced by jsf/4.10 Classes/AV Rule 78.ql, which has far fewer false positives on typical code.
 
 import cpp
 

--- a/cpp/ql/src/PointsTo/Debug.ql
+++ b/cpp/ql/src/PointsTo/Debug.ql
@@ -3,10 +3,8 @@
  * @description Query to help investigate mysterious results with ReturnStackAllocatedObject
  * @kind table
  * @id cpp/points-to/debug
- * @deprecated
+ * @deprecated This query is not suitable for production use and has been deprecated.
  */
-
-// This query is not suitable for production use and has been deprecated.
 
 import cpp
 import semmle.code.cpp.pointsto.PointsTo

--- a/cpp/ql/src/PointsTo/PreparedStagedPointsTo.ql
+++ b/cpp/ql/src/PointsTo/PreparedStagedPointsTo.ql
@@ -3,10 +3,8 @@
  * @description Query to force evaluation of staged points-to predicates
  * @kind table
  * @id cpp/points-to/prepared-staged-points-to
- * @deprecated
+ * @deprecated This query is not suitable for production use and has been deprecated.
  */
-
-// This query is not suitable for production use and has been deprecated.
 
  import semmle.code.cpp.pointsto.PointsTo
 

--- a/cpp/ql/src/PointsTo/Stats.ql
+++ b/cpp/ql/src/PointsTo/Stats.ql
@@ -3,10 +3,8 @@
  * @description Count the number points-to sets with 0 or 1 incoming flow edges, and the total number of points-to sets
  * @kind table
  * @id cpp/points-to/stats
- * @deprecated
+ * @deprecated This query is not suitable for production use and has been deprecated.
  */
-
-// This query is not suitable for production use and has been deprecated.
 
 import cpp
 import semmle.code.cpp.pointsto.PointsTo

--- a/cpp/ql/src/PointsTo/TaintedFormatStrings.ql
+++ b/cpp/ql/src/PointsTo/TaintedFormatStrings.ql
@@ -2,10 +2,8 @@
  * @name Taint test
  * @kind table
  * @id cpp/points-to/tainted-format-strings
- * @deprecated
+ * @deprecated This query is not suitable for production use and has been deprecated.
  */
-
-// This query is not suitable for production use and has been deprecated.
 
 import cpp
 import semmle.code.cpp.pointsto.PointsTo

--- a/cpp/ql/test/query-tests/Security/CWE/CWE-242/semmle/tests/OverrunWrite.expected
+++ b/cpp/ql/test/query-tests/Security/CWE/CWE-242/semmle/tests/OverrunWrite.expected
@@ -1,0 +1,4 @@
+| tests.cpp:258:2:258:8 | call to sprintf | This 'call to sprintf' operation requires 17 bytes but the destination is only 10 bytes. |
+| tests.cpp:259:2:259:8 | call to sprintf | This 'call to sprintf' operation requires 17 bytes but the destination is only 10 bytes. |
+| tests.cpp:272:2:272:8 | call to sprintf | This 'call to sprintf' operation requires 9 bytes but the destination is only 8 bytes. |
+| tests.cpp:273:2:273:8 | call to sprintf | This 'call to sprintf' operation requires 9 bytes but the destination is only 8 bytes. |

--- a/cpp/ql/test/query-tests/Security/CWE/CWE-242/semmle/tests/OverrunWrite.qlref
+++ b/cpp/ql/test/query-tests/Security/CWE/CWE-242/semmle/tests/OverrunWrite.qlref
@@ -1,0 +1,1 @@
+Security/CWE/CWE-120/OverrunWrite.ql

--- a/cpp/ql/test/query-tests/Security/CWE/CWE-242/semmle/tests/OverrunWriteFloat.expected
+++ b/cpp/ql/test/query-tests/Security/CWE/CWE-242/semmle/tests/OverrunWriteFloat.expected
@@ -1,0 +1,1 @@
+| tests.cpp:287:2:287:8 | call to sprintf | This 'call to sprintf' operation may require 318 bytes because of float conversions, but the target is only 64 bytes. |

--- a/cpp/ql/test/query-tests/Security/CWE/CWE-242/semmle/tests/OverrunWriteFloat.qlref
+++ b/cpp/ql/test/query-tests/Security/CWE/CWE-242/semmle/tests/OverrunWriteFloat.qlref
@@ -1,0 +1,1 @@
+Security/CWE/CWE-120/OverrunWriteFloat.ql

--- a/cpp/ql/test/query-tests/Security/CWE/CWE-242/semmle/tests/PotentialBufferOverflow.expected
+++ b/cpp/ql/test/query-tests/Security/CWE/CWE-242/semmle/tests/PotentialBufferOverflow.expected
@@ -1,5 +1,0 @@
-| tests.cpp:258:2:258:8 | call to sprintf | This conversion may yield a string of length 17, which exceeds the allocated buffer size of 10 |
-| tests.cpp:259:2:259:8 | call to sprintf | This conversion may yield a string of length 17, which exceeds the allocated buffer size of 10 |
-| tests.cpp:272:2:272:8 | call to sprintf | This conversion may yield a string of length 9, which exceeds the allocated buffer size of 8 |
-| tests.cpp:273:2:273:8 | call to sprintf | This conversion may yield a string of length 9, which exceeds the allocated buffer size of 8 |
-| tests.cpp:287:2:287:8 | call to sprintf | This conversion may yield a string of length 318, which exceeds the allocated buffer size of 64 |

--- a/cpp/ql/test/query-tests/Security/CWE/CWE-242/semmle/tests/PotentialBufferOverflow.expected
+++ b/cpp/ql/test/query-tests/Security/CWE/CWE-242/semmle/tests/PotentialBufferOverflow.expected
@@ -2,3 +2,4 @@
 | tests.cpp:259:2:259:8 | call to sprintf | This conversion may yield a string of length 17, which exceeds the allocated buffer size of 10 |
 | tests.cpp:272:2:272:8 | call to sprintf | This conversion may yield a string of length 9, which exceeds the allocated buffer size of 8 |
 | tests.cpp:273:2:273:8 | call to sprintf | This conversion may yield a string of length 9, which exceeds the allocated buffer size of 8 |
+| tests.cpp:287:2:287:8 | call to sprintf | This conversion may yield a string of length 318, which exceeds the allocated buffer size of 64 |

--- a/cpp/ql/test/query-tests/Security/CWE/CWE-242/semmle/tests/PotentialBufferOverflow.qlref
+++ b/cpp/ql/test/query-tests/Security/CWE/CWE-242/semmle/tests/PotentialBufferOverflow.qlref
@@ -1,1 +1,0 @@
-Likely Bugs/Memory Management/PotentialBufferOverflow.ql

--- a/cpp/ql/test/query-tests/Security/CWE/CWE-242/semmle/tests/tests.cpp
+++ b/cpp/ql/test/query-tests/Security/CWE/CWE-242/semmle/tests/tests.cpp
@@ -272,3 +272,20 @@ void test4()
 	sprintf(buffer8, "12345678"); // BAD: buffer overflow
 	sprintf(buffer8_ptr, "12345678"); // BAD: buffer overflow
 }
+
+typedef void *va_list;
+int vsprintf(char *s, const char *format, va_list arg);
+
+void test5(va_list args, float f)
+{
+	char buffer10[10], buffer64[64];
+	char *buffer4 = new char[4 * sizeof(char)];
+
+	vsprintf(buffer10, "123456789", args); // GOOD
+	vsprintf(buffer10, "1234567890", args); // BAD: buffer overflow [NOT DETECTED]
+
+	sprintf(buffer64, "%f", f); // BAD: potential buffer overflow
+
+	vsprintf(buffer4, "123", args); // GOOD
+	vsprintf(buffer4, "1234", args); // BAD: buffer overflow [NOT DETECTED]
+}


### PR DESCRIPTION
Deprecate `PotentialBufferOverflow.ql`.  Everything it does is done by `OverrunWrite.ql` and `OverrunWriteFloat.ql` together, and the latter support a much wider variety of functions.  I can't find any real world results unique to `PotentialBufferOverflow.ql` (https://lgtm.com/query/1401438515475863559/).

In addition, despite appearances, the claim in the qhelp that `PotentialBufferOverflow.ql` covers uses of `vsprintf` is false (because they're outside the scope of `FormattingFunctionCall`).  I may at some point get around to making `OverrunWrite.ql` support that, but we're not losing anything right now.