### PR TITLE
JS: Reorganize Closure module

### DIFF
--- a/javascript/ql/src/semmle/javascript/Closure.qll
+++ b/javascript/ql/src/semmle/javascript/Closure.qll
@@ -38,9 +38,7 @@ module Closure {
     Expr getAnArgument() { result = getArgument(_) }
   }
 
-  abstract private class GoogNamespaceRef extends ExprOrStmt {
-    abstract string getNamespaceId();
-  }
+  abstract private class GoogNamespaceRef extends ExprOrStmt { abstract string getClosureNamespace(); }
 
   /**
    * A call to `goog.provide`.
@@ -49,7 +47,7 @@ module Closure {
     GoogProvide() { getFunctionName() = "provide" }
 
     /** Gets the identifier of the namespace created by this call. */
-    override string getNamespaceId() { result = getArgument(0).getStringValue() }
+    override string getClosureNamespace() { result = getArgument(0).getStringValue() }
   }
 
   /**
@@ -59,7 +57,7 @@ module Closure {
     GoogRequire() { getFunctionName() = "require" }
 
     /** Gets the identifier of the namespace imported by this call. */
-    override string getNamespaceId() { result = getArgument(0).getStringValue() }
+    override string getClosureNamespace() { result = getArgument(0).getStringValue() }
   }
 
   private class GoogRequireImport extends GoogRequire, Import {
@@ -80,7 +78,7 @@ module Closure {
     }
 
     /** Gets the identifier of the namespace imported by this call. */
-    override string getNamespaceId() { result = getArgument(0).getStringValue() }
+    override string getClosureNamespace() { result = getArgument(0).getStringValue() }
   }
 
   /**
@@ -97,12 +95,12 @@ module Closure {
     /**
      * Gets the namespace of this module.
      */
-    string getNamespaceId() { result = getModuleDeclaration().getNamespaceId() }
+    string getClosureNamespace() { result = getModuleDeclaration().getClosureNamespace() }
 
     override Module getAnImportedModule() {
       exists(GoogRequireImport imprt |
         imprt.getEnclosingModule() = this and
-        result.(ClosureModule).getNamespaceId() = imprt.getNamespaceId()
+        result.(ClosureModule).getClosureNamespace() = imprt.getClosureNamespace()
       )
     }
 
@@ -146,11 +144,11 @@ module Closure {
 
     /** Gets the identifier of a namespace required by this module. */
     string getARequiredNamespace() {
-      result = getAChildStmt().(ExprStmt).getExpr().(GoogRequire).getNamespaceId()
+      result = getAChildStmt().(ExprStmt).getExpr().(GoogRequire).getClosureNamespace()
     }
 
     /** Gets the identifer of a namespace provided by this module. */
-    string getAProvidedNamespace() { result = getAChildStmt().(GoogProvide).getNamespaceId() }
+    string getAProvidedNamespace() { result = getAChildStmt().(GoogProvide).getClosureNamespace() }
   }
 
   /**
@@ -158,7 +156,7 @@ module Closure {
    */
   pragma[noinline]
   predicate isLibraryNamespacePath(string name) {
-    exists(string namespace | namespace = any(GoogNamespaceRef provide).getNamespaceId() |
+    exists(string namespace | namespace = any(GoogNamespaceRef provide).getClosureNamespace() |
       name = namespace.substring(0, namespace.indexOf("."))
       or
       name = namespace
@@ -187,7 +185,7 @@ module Closure {
       result = getWrittenLibraryAccessPath(write)
     )
     or
-    result = node.asExpr().(GoogRequire).getNamespaceId()
+    result = node.asExpr().(GoogRequire).getClosureNamespace()
   }
 
   /**

--- a/javascript/ql/src/semmle/javascript/Closure.qll
+++ b/javascript/ql/src/semmle/javascript/Closure.qll
@@ -30,7 +30,8 @@ module Closure {
   }
 
   /**
-   * Holds if `node` is the data flow node for a top-level expression.
+   * Holds if `node` is the data flow node corresponding to the expression in
+   * a top-level expression statement.
    */
   private predicate isTopLevelExpr(DataFlow::Node node) {
     node.getTopLevel().getAChildStmt().(ExprStmt).getExpr().flow() = node

--- a/javascript/ql/src/semmle/javascript/Closure.qll
+++ b/javascript/ql/src/semmle/javascript/Closure.qll
@@ -16,6 +16,11 @@ module Closure {
   }
 
   /**
+   * A dataflow node that returns the value of a closure namespace.
+   */
+  abstract class ClosureNamespaceAccess extends ClosureNamespaceRef, DataFlow::SourceNode { }
+
+  /**
    * A call to a method on the `goog.` namespace, as a closure reference.
    */
   abstract private class DefaultNamespaceRef extends DataFlow::MethodCallNode, ClosureNamespaceRef {
@@ -44,7 +49,7 @@ module Closure {
   /**
    * A call to `goog.require`.
    */
-  class ClosureRequireCall extends DefaultNamespaceRef {
+  class ClosureRequireCall extends DefaultNamespaceRef, ClosureNamespaceAccess {
     ClosureRequireCall() { getMethodName() = "require" }
   }
 
@@ -172,7 +177,7 @@ module Closure {
       result = getWrittenLibraryAccessPath(write)
     )
     or
-    result = node.(ClosureRequireCall).getClosureNamespace()
+    result = node.(ClosureNamespaceAccess).getClosureNamespace()
   }
 
   /**

--- a/javascript/ql/src/semmle/javascript/Closure.qll
+++ b/javascript/ql/src/semmle/javascript/Closure.qll
@@ -16,7 +16,7 @@ module Closure {
   }
 
   /**
-   * A dataflow node that returns the value of a closure namespace.
+   * A data flow node that returns the value of a closure namespace.
    */
   abstract class ClosureNamespaceAccess extends ClosureNamespaceRef, DataFlow::SourceNode { }
 
@@ -30,7 +30,7 @@ module Closure {
   }
 
   /**
-   * Holds if `node` is the dataflow node for a top-level expression.
+   * Holds if `node` is the data flow node for a top-level expression.
    */
   private predicate isTopLevelExpr(DataFlow::Node node) {
     node.getTopLevel().getAChildStmt().(ExprStmt).getExpr().flow() = node
@@ -156,7 +156,7 @@ module Closure {
   }
 
   /**
-   * Gets the closure namespace path addressed by the given dataflow node, if any.
+   * Gets the closure namespace path addressed by the given data flow node, if any.
    */
   string getClosureNamespaceFromSourceNode(DataFlow::SourceNode node) {
     isClosureNamespace(result) and
@@ -188,7 +188,7 @@ module Closure {
   }
 
   /**
-   * Gets a dataflow node that refers to the given value exported from a Closure module.
+   * Gets a data flow node that refers to the given value exported from a Closure module.
    */
   DataFlow::SourceNode moduleImport(string moduleName) { getClosureNamespaceFromSourceNode(result) = moduleName }
 }

--- a/javascript/ql/src/semmle/javascript/Closure.qll
+++ b/javascript/ql/src/semmle/javascript/Closure.qll
@@ -18,7 +18,7 @@ module Closure {
   /**
    * A data flow node that returns the value of a closure namespace.
    */
-  abstract class ClosureNamespaceAccess extends ClosureNamespaceRef, DataFlow::SourceNode { }
+  abstract class ClosureNamespaceAccess extends ClosureNamespaceRef { }
 
   /**
    * A call to a method on the `goog.` namespace, as a closure reference.

--- a/javascript/ql/src/semmle/javascript/Closure.qll
+++ b/javascript/ql/src/semmle/javascript/Closure.qll
@@ -68,7 +68,14 @@ module Closure {
    * A module using the Closure module system, declared using `goog.module()` or `goog.declareModuleId()`.
    */
   class ClosureModule extends Module {
-    ClosureModule() { any(ClosureModuleDeclaration decl).getTopLevel() = this }
+    ClosureModule() {
+      // Use AST-based predicate to cut recursive dependencies.
+      exists(MethodCallExpr call |
+        getAStmt().(ExprStmt).getExpr() = call and
+        call.getReceiver().(GlobalVarAccess).getName() = "goog" and
+        (call.getMethodName() = "module" or call.getMethodName() = "declareModuleId")
+      )
+    }
 
     /**
      * Gets the call to `goog.module` or `goog.declareModuleId` in this module.

--- a/javascript/ql/src/semmle/javascript/dataflow/DataFlow.qll
+++ b/javascript/ql/src/semmle/javascript/dataflow/DataFlow.qll
@@ -1057,7 +1057,7 @@ module DataFlow {
     or
     exists(GlobalVarAccess va |
       nd = valueNode(va.(VarUse)) and
-      if Closure::isLibraryNamespacePath(va.getName()) then cause = "heap" else cause = "global"
+      if Closure::isClosureNamespace(va.getName()) then cause = "heap" else cause = "global"
     )
     or
     exists(Expr e | e = nd.asExpr() and cause = "call" |

--- a/javascript/ql/src/semmle/javascript/dataflow/internal/InterModuleTypeInference.qll
+++ b/javascript/ql/src/semmle/javascript/dataflow/internal/InterModuleTypeInference.qll
@@ -358,11 +358,11 @@ private class AnalyzedClosureExportAssign extends AnalyzedPropertyWrite, DataFlo
 private class AnalyzedClosureGlobalAccessPath extends AnalyzedNode, AnalyzedPropertyRead {
   string accessPath;
 
-  AnalyzedClosureGlobalAccessPath() { accessPath = Closure::getLibraryAccessPath(this) }
+  AnalyzedClosureGlobalAccessPath() { accessPath = Closure::getClosureNamespaceFromSourceNode(this) }
 
   override AnalyzedNode localFlowPred() {
     exists(DataFlow::PropWrite write |
-      Closure::getWrittenLibraryAccessPath(write) = accessPath and
+      Closure::getWrittenClosureNamespace(write) = accessPath and
       result = write.getRhs()
     )
     or

--- a/javascript/ql/src/semmle/javascript/dataflow/internal/InterModuleTypeInference.qll
+++ b/javascript/ql/src/semmle/javascript/dataflow/internal/InterModuleTypeInference.qll
@@ -371,7 +371,7 @@ private class AnalyzedClosureGlobalAccessPath extends AnalyzedNode, AnalyzedProp
 
   override predicate reads(AbstractValue base, string propName) {
     exists(Closure::ClosureModule mod |
-      mod.getNamespaceId() = accessPath and
+      mod.getClosureNamespace() = accessPath and
       base = TAbstractModuleObject(mod) and
       propName = "exports"
     )

--- a/javascript/ql/src/semmle/javascript/dataflow/internal/InterModuleTypeInference.qll
+++ b/javascript/ql/src/semmle/javascript/dataflow/internal/InterModuleTypeInference.qll
@@ -358,7 +358,9 @@ private class AnalyzedClosureExportAssign extends AnalyzedPropertyWrite, DataFlo
 private class AnalyzedClosureGlobalAccessPath extends AnalyzedNode, AnalyzedPropertyRead {
   string accessPath;
 
-  AnalyzedClosureGlobalAccessPath() { accessPath = Closure::getClosureNamespaceFromSourceNode(this) }
+  AnalyzedClosureGlobalAccessPath() {
+    accessPath = Closure::getClosureNamespaceFromSourceNode(this)
+  }
 
   override AnalyzedNode localFlowPred() {
     exists(DataFlow::PropWrite write |


### PR DESCRIPTION
First of all, sorry for the horrendous diff in the second commit.

The class for `goog.require` calls needs to be extensible and can't be based on the AST, as it must be possible to use an `import` node here. The refactoring in commit nr 2 leads up to the commit that makes this possible.

To contribute to the confusing mess that is commit nr 2, I opted for a midway renaming of most of the classes to be more consistent. We now consistently use the term "closure namespace" instead of "library access path" and "namespace id".

Currently running evaluation on closure.slugs