### PR TITLE
TS: disable deep type extraction by default

### DIFF
--- a/javascript/extractor/lib/typescript/src/main.ts
+++ b/javascript/extractor/lib/typescript/src/main.ts
@@ -409,7 +409,7 @@ function handlePrepareFilesCommand(command: PrepareFilesCommand) {
 
 function reset() {
     state = new State();
-    state.typeTable.restrictedExpansion = getEnvironmentVariable("SEMMLE_TYPESCRIPT_NO_EXPANSION", Boolean, false);
+    state.typeTable.restrictedExpansion = getEnvironmentVariable("SEMMLE_TYPESCRIPT_NO_EXPANSION", Boolean, true);
 }
 
 function getEnvironmentVariable<T>(name: string, parse: (x: string) => T, defaultValue: T) {

--- a/javascript/ql/test/library-tests/TypeScript/ArrayTypes/ArrayTypes.expected
+++ b/javascript/ql/test/library-tests/TypeScript/ArrayTypes/ArrayTypes.expected
@@ -1,35 +1,15 @@
-| (ConcatArray<T> \| ConcatArray<ConcatArray<T>>)[] | `ConcatArray<T> \| ConcatArray<ConcatArray<T>>` |
-| (ConcatArray<number> \| ConcatArray<ConcatArray<... | `ConcatArray<number> \| ConcatArray<ConcatArray<n...` |
-| (ConcatArray<string \| number> \| ConcatArray<Con... | `ConcatArray<string \| number> \| ConcatArray<Conc...` |
-| (S \| ConcatArray<S>)[] | `S \| ConcatArray<S>` |
-| (T \| ConcatArray<T> \| ConcatArray<T \| ConcatArr... | `T \| ConcatArray<T> \| ConcatArray<T \| ConcatArra...` |
 | (T \| ConcatArray<T>)[] | `T \| ConcatArray<T>` |
-| (T \| ConcatArray<T>)[] | `T \| ConcatArray<T>` |
-| (U \| ConcatArray<U>)[] | `U \| ConcatArray<U>` |
-| (number \| ConcatArray<number> \| ConcatArray<num... | `number \| ConcatArray<number> \| ConcatArray<numb...` |
 | (number \| ConcatArray<number>)[] | `number \| ConcatArray<number>` |
 | (string \| ConcatArray<string>)[] | `string \| ConcatArray<string>` |
 | (string \| number \| ConcatArray<string \| number>)[] | `string \| number \| ConcatArray<string \| number>` |
-| (string \| number \| ConcatArray<string \| number>... | `string \| number \| ConcatArray<string \| number> ...` |
 | (string \| number)[] | `string \| number` |
-| ConcatArray<ConcatArray<T>>[] | `ConcatArray<ConcatArray<T>>` |
-| ConcatArray<ConcatArray<number>>[] | `ConcatArray<ConcatArray<number>>` |
-| ConcatArray<ConcatArray<string \| number>>[] | `ConcatArray<ConcatArray<string \| number>>` |
-| ConcatArray<S>[] | `ConcatArray<S>` |
-| ConcatArray<T \| ConcatArray<T>>[] | `ConcatArray<T \| ConcatArray<T>>` |
 | ConcatArray<T>[] | `ConcatArray<T>` |
-| ConcatArray<T>[] | `ConcatArray<T>` |
-| ConcatArray<U>[] | `ConcatArray<U>` |
-| ConcatArray<number \| ConcatArray<number>>[] | `ConcatArray<number \| ConcatArray<number>>` |
 | ConcatArray<number>[] | `ConcatArray<number>` |
-| ConcatArray<string \| number \| ConcatArray<strin... | `ConcatArray<string \| number \| ConcatArray<strin...` |
 | ConcatArray<string \| number>[] | `ConcatArray<string \| number>` |
 | ConcatArray<string>[] | `ConcatArray<string>` |
 | ReadonlyArray<T> | `T` |
 | ReadonlyArray<number> | `number` |
 | S[] | `S` |
-| T[] | `T` |
-| T[] | `T` |
 | T[] | `T` |
 | U[] | `U` |
 | [number, string] | `string \| number` |

--- a/javascript/ql/test/library-tests/TypeScript/ArrayTypes/NumberIndexTypes.expected
+++ b/javascript/ql/test/library-tests/TypeScript/ArrayTypes/NumberIndexTypes.expected
@@ -1,36 +1,10 @@
-| (ConcatArray<T> \| ConcatArray<ConcatArray<T>>)[] | ConcatArray<T> \| ConcatArray<ConcatArray<T>> |
-| (ConcatArray<number> \| ConcatArray<ConcatArray<... | ConcatArray<number> \| ConcatArray<ConcatArray<n... |
-| (ConcatArray<string \| number> \| ConcatArray<Con... | ConcatArray<string \| number> \| ConcatArray<Conc... |
-| (S \| ConcatArray<S>)[] | S \| ConcatArray<S> |
-| (T \| ConcatArray<T> \| ConcatArray<T \| ConcatArr... | T \| ConcatArray<T> \| ConcatArray<T \| ConcatArra... |
 | (T \| ConcatArray<T>)[] | T \| ConcatArray<T> |
-| (T \| ConcatArray<T>)[] | T \| ConcatArray<T> |
-| (U \| ConcatArray<U>)[] | U \| ConcatArray<U> |
-| (number \| ConcatArray<number> \| ConcatArray<num... | number \| ConcatArray<number> \| ConcatArray<numb... |
 | (number \| ConcatArray<number>)[] | number \| ConcatArray<number> |
 | (string \| ConcatArray<string>)[] | string \| ConcatArray<string> |
 | (string \| number \| ConcatArray<string \| number>)[] | string \| number \| ConcatArray<string \| number> |
-| (string \| number \| ConcatArray<string \| number>... | string \| number \| ConcatArray<string \| number> ... |
 | (string \| number)[] | string \| number |
-| (string \| number)[] \| ConcatArray<string \| numb... | string \| number \| ConcatArray<string \| number> |
-| ConcatArray<ConcatArray<T>>[] | ConcatArray<ConcatArray<T>> |
-| ConcatArray<ConcatArray<number>>[] | ConcatArray<ConcatArray<number>> |
-| ConcatArray<ConcatArray<string \| number>>[] | ConcatArray<ConcatArray<string \| number>> |
-| ConcatArray<S>[] | ConcatArray<S> |
-| ConcatArray<T \| ConcatArray<T>>[] | ConcatArray<T \| ConcatArray<T>> |
-| ConcatArray<T> | T |
-| ConcatArray<T> | T |
-| ConcatArray<T> \| ConcatArray<ConcatArray<T>> | T \| ConcatArray<T> |
 | ConcatArray<T>[] | ConcatArray<T> |
-| ConcatArray<T>[] | ConcatArray<T> |
-| ConcatArray<U>[] | ConcatArray<U> |
-| ConcatArray<number \| ConcatArray<number>>[] | ConcatArray<number \| ConcatArray<number>> |
-| ConcatArray<number> | number |
-| ConcatArray<number> \| ConcatArray<ConcatArray<n... | number \| ConcatArray<number> |
 | ConcatArray<number>[] | ConcatArray<number> |
-| ConcatArray<string \| number \| ConcatArray<strin... | ConcatArray<string \| number \| ConcatArray<strin... |
-| ConcatArray<string \| number> | string \| number |
-| ConcatArray<string \| number> \| ConcatArray<Conc... | string \| number \| ConcatArray<string \| number> |
 | ConcatArray<string \| number>[] | ConcatArray<string \| number> |
 | ConcatArray<string>[] | ConcatArray<string> |
 | NumberIndexable | object |
@@ -38,14 +12,10 @@
 | ReadonlyArray<number> | number |
 | S[] | S |
 | T[] | T |
-| T[] | T |
-| T[] | T |
-| T[] \| ConcatArray<T>[] | T \| ConcatArray<T> |
 | U[] | U |
 | [number, string] | string \| number |
 | any[] | any |
 | number[] | number |
-| number[] \| ConcatArray<number>[] | number \| ConcatArray<number> |
 | string | string |
 | string \| ConcatArray<string> | string |
 | string \| string[] | string |

--- a/javascript/ql/test/library-tests/TypeScript/BaseTypes/BaseTypes.expected
+++ b/javascript/ql/test/library-tests/TypeScript/BaseTypes/BaseTypes.expected
@@ -13,5 +13,4 @@
 | IMulti | IGenericBase |
 | IStringSub | IGenericBase |
 | ISub | IBase |
-| RegExpExecArray | Array |
 | RegExpMatchArray | Array |

--- a/javascript/ql/test/library-tests/TypeScript/BaseTypes/SelfTypes.expected
+++ b/javascript/ql/test/library-tests/TypeScript/BaseTypes/SelfTypes.expected
@@ -1,4 +1,3 @@
-| Array | T[] |
 | CBase | CBase |
 | CEverything | CEverything<S, T> |
 | CGenericBase | CGenericBase<T> |
@@ -9,7 +8,6 @@
 | CStringSub | CStringSub |
 | CSub | CSub |
 | CollatorOptions | CollatorOptions |
-| ConcatArray | ConcatArray<T> |
 | Function | Function |
 | IBase | IBase |
 | IEmpty | IEmpty |
@@ -22,5 +20,4 @@
 | NumberFormatOptions | NumberFormatOptions |
 | Object | Object |
 | RegExp | RegExp |
-| RegExpExecArray | RegExpExecArray |
 | RegExpMatchArray | RegExpMatchArray |

--- a/javascript/ql/test/library-tests/TypeScript/ExpansiveTypes/ExpansiveTypes.expected
+++ b/javascript/ql/test/library-tests/TypeScript/ExpansiveTypes/ExpansiveTypes.expected
@@ -1,3 +1,4 @@
+| Box in shared_non_expansive.ts | has no properties |
 | Box in through_non_expansive.ts | has no properties |
 | C in expansive_class.ts | has no properties |
 | Expand in through_non_expansive.ts | has no properties |

--- a/javascript/ql/test/library-tests/TypeScript/ExpansiveTypes/NonExpansiveTypes.expected
+++ b/javascript/ql/test/library-tests/TypeScript/ExpansiveTypes/NonExpansiveTypes.expected
@@ -6,7 +6,6 @@
 | Box in shared_non_expansive.ts | has properties |
 | Box in through_non_expansive.ts | has properties |
 | C in expansive_class.ts | has properties |
-| ConcatArray in global scope | has properties |
 | Expand in through_non_expansive.ts | has properties |
 | ExpandUsingObjectLiteral in expansive_object_literal.ts | has properties |
 | Expansive in leading_into_expansion.ts | has properties |
@@ -32,6 +31,3 @@
 | Intl.NumberFormatOptions in global scope | has properties |
 | NonExpansive in shared_non_expansive.ts | has properties |
 | Object in global scope | has properties |
-| RegExp in global scope | has properties |
-| RegExpExecArray in global scope | has properties |
-| RegExpMatchArray in global scope | has properties |

--- a/javascript/ql/test/library-tests/TypeScript/ExternalTypes/GlobalQualifiedNames.expected
+++ b/javascript/ql/test/library-tests/TypeScript/ExternalTypes/GlobalQualifiedNames.expected
@@ -6,6 +6,5 @@
 | ModernGlobals.ModernSubclass | ModernSubclass |
 | Object | Object |
 | RegExp | RegExp |
-| RegExpExecArray | RegExpExecArray |
 | RegExpMatchArray | RegExpMatchArray |
 | __Legacy.LegacyClass | LegacyClass |

--- a/javascript/ql/test/library-tests/TypeScript/ExternalTypes/Types.expected
+++ b/javascript/ql/test/library-tests/TypeScript/ExternalTypes/Types.expected
@@ -12,7 +12,6 @@
 | Object | has no definition |
 | OtherClass | has no definition |
 | RegExp | has no definition |
-| RegExpExecArray | has no definition |
 | RegExpMatchArray | has no definition |
 | UtilClass | has no definition |
 | UtilExtraClass | has no definition |

--- a/javascript/ql/test/library-tests/TypeScript/TypeVariableTypes/CanonicalTypeVariables.expected
+++ b/javascript/ql/test/library-tests/TypeScript/TypeVariableTypes/CanonicalTypeVariables.expected
@@ -1,4 +1,2 @@
-| T | Array.T in global scope |
-| T | ConcatArray.T in global scope |
 | T | GenericMethods.T in global scope |
 | T | Repeated.T in global scope |

--- a/javascript/ql/test/library-tests/TypeScript/TypeVariableTypes/SignatureTypeParameters.expected
+++ b/javascript/ql/test/library-tests/TypeScript/TypeVariableTypes/SignatureTypeParameters.expected
@@ -1,36 +1,18 @@
 | <D>(x: D): D | 1 | 0 | D | no bound |
 | <E>(x: () => E): E | 1 | 0 | E | no bound |
 | <E>(x: E[]): E | 1 | 0 | E | no bound |
-| <S extends ConcatArray<T \| S>>(callbackfn: (value: ConcatArray<T \| S>... | 1 | 0 | S | ConcatArray<T \| S> |
 | <S extends E>(callbackfn: (value: E, index: number, array: E[]) => va... | 1 | 0 | S | no bound |
-| <S extends S>(callbackfn: (value: S, index: number, array: S[]) => va... | 1 | 0 | S | no bound |
-| <S extends T \| S \| ConcatArray<T \| S>>(callbackfn: (value: T \| S \| Co... | 1 | 0 | S | no bound |
 | <S extends T \| S>(callbackfn: (value: T \| S, index: number, array: (T... | 1 | 0 | S | no bound |
 | <S extends T>(callbackfn: (value: T, index: number, array: T[]) => va... | 1 | 0 | S | no bound |
-| <S extends T>(callbackfn: (value: T, index: number, array: T[]) => va... | 1 | 0 | S | no bound |
-| <S extends U>(callbackfn: (value: U, index: number, array: U[]) => va... | 1 | 0 | S | no bound |
 | <S extends any>(callbackfn: (value: any, index: number, array: any[])... | 1 | 0 | S | any |
 | <S extends any[]>(x: S, y: T[]): S | 1 | 0 | S | any[] |
-| <S extends string>(callbackfn: (value: string, index: number, array: ... | 1 | 0 | S | string |
 | <S>(x: S, y: S): S | 1 | 0 | S | no bound |
 | <S>(x: S, y: T): [S, T] | 1 | 0 | S | no bound |
-| <U>(callbackfn: (previousValue: U, currentValue: ConcatArray<T \| S>, ... | 1 | 0 | U | no bound |
 | <U>(callbackfn: (previousValue: U, currentValue: E, currentIndex: num... | 1 | 0 | U | no bound |
-| <U>(callbackfn: (previousValue: U, currentValue: S, currentIndex: num... | 1 | 0 | U | no bound |
-| <U>(callbackfn: (previousValue: U, currentValue: T \| S \| ConcatArray<... | 1 | 0 | U | no bound |
 | <U>(callbackfn: (previousValue: U, currentValue: T \| S, currentIndex:... | 1 | 0 | U | no bound |
 | <U>(callbackfn: (previousValue: U, currentValue: T, currentIndex: num... | 1 | 0 | U | no bound |
-| <U>(callbackfn: (previousValue: U, currentValue: T, currentIndex: num... | 1 | 0 | U | no bound |
-| <U>(callbackfn: (previousValue: U, currentValue: U, currentIndex: num... | 1 | 0 | U | no bound |
 | <U>(callbackfn: (previousValue: U, currentValue: any, currentIndex: n... | 1 | 0 | U | no bound |
-| <U>(callbackfn: (previousValue: U, currentValue: string, currentIndex... | 1 | 0 | U | no bound |
-| <U>(callbackfn: (value: ConcatArray<T \| S>, index: number, array: Con... | 1 | 0 | U | no bound |
 | <U>(callbackfn: (value: E, index: number, array: E[]) => U, thisArg?:... | 1 | 0 | U | no bound |
-| <U>(callbackfn: (value: S, index: number, array: S[]) => U, thisArg?:... | 1 | 0 | U | no bound |
-| <U>(callbackfn: (value: T \| S \| ConcatArray<T \| S>, index: number, ar... | 1 | 0 | U | no bound |
 | <U>(callbackfn: (value: T \| S, index: number, array: (T \| S)[]) => U,... | 1 | 0 | U | no bound |
 | <U>(callbackfn: (value: T, index: number, array: T[]) => U, thisArg?:... | 1 | 0 | U | no bound |
-| <U>(callbackfn: (value: T, index: number, array: T[]) => U, thisArg?:... | 1 | 0 | U | no bound |
-| <U>(callbackfn: (value: U, index: number, array: U[]) => U, thisArg?:... | 1 | 0 | U | no bound |
 | <U>(callbackfn: (value: any, index: number, array: any[]) => U, thisA... | 1 | 0 | U | no bound |
-| <U>(callbackfn: (value: string, index: number, array: string[]) => U,... | 1 | 0 | U | no bound |

--- a/javascript/ql/test/library-tests/TypeScript/TypeVariableTypes/TypeVariableCanonicalNames.expected
+++ b/javascript/ql/test/library-tests/TypeScript/TypeVariableTypes/TypeVariableCanonicalNames.expected
@@ -1,4 +1,2 @@
-| T | Array.T in global scope |
-| T | ConcatArray.T in global scope |
 | T | GenericMethods.T in global scope |
 | T | Repeated.T in global scope |

--- a/javascript/ql/test/library-tests/TypeScript/TypeVariableTypes/TypeVariableHost.expected
+++ b/javascript/ql/test/library-tests/TypeScript/TypeVariableTypes/TypeVariableHost.expected
@@ -1,4 +1,2 @@
-| T | Array.T in global scope | Array in global scope |
-| T | ConcatArray.T in global scope | ConcatArray in global scope |
 | T | GenericMethods.T in global scope | GenericMethods in global scope |
 | T | Repeated.T in global scope | Repeated in global scope |


### PR DESCRIPTION
Disables TypeScript type expansion by default. Previously, non-expansive types were fully extracted, which was mostly fine, but could in a few cases lead to a huge blow-up.

Now, only types that are directly referenced from the AST or is the type of an expression will have their properties extracted.

The main use-case for "deep" type information was a type-based taint tracking experiment that never really manifested to anything. The information we get now should still let us recognize expressions by their type and augment the call graph a bit.