### PR TITLE
JavaScript: Add `Range.prototype.createContextualFragment` as an XSS sink.

### DIFF
--- a/javascript/ql/src/semmle/javascript/security/dataflow/DOM.qll
+++ b/javascript/ql/src/semmle/javascript/security/dataflow/DOM.qll
@@ -37,6 +37,7 @@ private DataFlow::SourceNode domElementCreationOrQuery() {
   exists(string methodName |
     methodName = "createElement" or
     methodName = "createElementNS" or
+    methodName = "createRange" or
     methodName = "getElementById" or
     methodName = "querySelector"
   |

--- a/javascript/ql/src/semmle/javascript/security/dataflow/Xss.qll
+++ b/javascript/ql/src/semmle/javascript/security/dataflow/Xss.qll
@@ -127,13 +127,19 @@ module DomBasedXss {
   }
 
   /**
-   * An expression whose value is interpreted as HTML by a DOMParser.
+   * An expression whose value is interpreted as HTML.
    */
-  class DomParserSink extends Sink {
-    DomParserSink() {
+  class HtmlParserSink extends Sink {
+    HtmlParserSink() {
       exists(DataFlow::GlobalVarRefNode domParser |
         domParser.getName() = "DOMParser" and
         this = domParser.getAnInstantiation().getAMethodCall("parseFromString").getArgument(0)
+      )
+      or
+      exists(DataFlow::MethodCallNode ccf |
+        isDomValue(ccf.getReceiver().asExpr()) and
+        ccf.getMethodName() = "createContextualFragment" and
+        this = ccf.getArgument(0)
       )
     }
   }

--- a/javascript/ql/test/query-tests/Security/CWE-079/Xss.expected
+++ b/javascript/ql/test/query-tests/Security/CWE-079/Xss.expected
@@ -175,6 +175,9 @@ nodes
 | tst.js:272:16:272:32 | document.location |
 | tst.js:275:7:275:10 | loc3 |
 | tst.js:277:22:277:29 | location |
+| tst.js:282:9:282:29 | tainted |
+| tst.js:282:19:282:29 | window.name |
+| tst.js:285:59:285:65 | tainted |
 | winjs.js:2:7:2:53 | tainted |
 | winjs.js:2:17:2:33 | document.location |
 | winjs.js:2:17:2:40 | documen ... .search |
@@ -313,6 +316,8 @@ edges
 | tst.js:252:23:252:29 | tainted | tst.js:244:39:244:55 | props.propTainted |
 | tst.js:272:9:272:32 | loc3 | tst.js:275:7:275:10 | loc3 |
 | tst.js:272:16:272:32 | document.location | tst.js:272:9:272:32 | loc3 |
+| tst.js:282:9:282:29 | tainted | tst.js:285:59:285:65 | tainted |
+| tst.js:282:19:282:29 | window.name | tst.js:282:9:282:29 | tainted |
 | winjs.js:2:7:2:53 | tainted | winjs.js:3:43:3:49 | tainted |
 | winjs.js:2:7:2:53 | tainted | winjs.js:4:43:4:49 | tainted |
 | winjs.js:2:17:2:33 | document.location | winjs.js:2:17:2:40 | documen ... .search |
@@ -386,5 +391,8 @@ edges
 | tst.js:261:11:261:21 | window.name | tst.js:261:11:261:21 | window.name | tst.js:261:11:261:21 | window.name | Cross-site scripting vulnerability due to $@. | tst.js:261:11:261:21 | window.name | user-provided value |
 | tst.js:275:7:275:10 | loc3 | tst.js:272:16:272:32 | document.location | tst.js:275:7:275:10 | loc3 | Cross-site scripting vulnerability due to $@. | tst.js:272:16:272:32 | document.location | user-provided value |
 | tst.js:277:22:277:29 | location | tst.js:277:22:277:29 | location | tst.js:277:22:277:29 | location | Cross-site scripting vulnerability due to $@. | tst.js:277:22:277:29 | location | user-provided value |
+| tst.js:285:59:285:65 | tainted | tst.js:282:9:282:29 | tainted | tst.js:285:59:285:65 | tainted | Cross-site scripting vulnerability due to $@. | tst.js:282:9:282:29 | tainted | user-provided value |
+| tst.js:285:59:285:65 | tainted | tst.js:282:19:282:29 | window.name | tst.js:285:59:285:65 | tainted | Cross-site scripting vulnerability due to $@. | tst.js:282:19:282:29 | window.name | user-provided value |
+| tst.js:285:59:285:65 | tainted | tst.js:285:59:285:65 | tainted | tst.js:285:59:285:65 | tainted | Cross-site scripting vulnerability due to $@. | tst.js:285:59:285:65 | tainted | user-provided value |
 | winjs.js:3:43:3:49 | tainted | winjs.js:2:17:2:33 | document.location | winjs.js:3:43:3:49 | tainted | Cross-site scripting vulnerability due to $@. | winjs.js:2:17:2:33 | document.location | user-provided value |
 | winjs.js:4:43:4:49 | tainted | winjs.js:2:17:2:33 | document.location | winjs.js:4:43:4:49 | tainted | Cross-site scripting vulnerability due to $@. | winjs.js:2:17:2:33 | document.location | user-provided value |

--- a/javascript/ql/test/query-tests/Security/CWE-079/tst.js
+++ b/javascript/ql/test/query-tests/Security/CWE-079/tst.js
@@ -276,3 +276,12 @@ function jqueryLocation() {
 
     $("body").append(location); // NOT OK
 }
+
+
+function testCreateContextualFragment() {
+    var tainted = window.name;
+    var range = document.createRange();
+    range.selectNode(document.getElementsByTagName("div").item(0));
+    var documentFragment = range.createContextualFragment(tainted); // NOT OK
+    document.body.appendChild(documentFragment);
+}


### PR DESCRIPTION
Recently mentioned by a prospect. They didn't specifically ask us to add support, so no need for a change note.

This change was actually part of the evaluation of https://github.com/Semmle/ql/pull/910, but didn't cause any of the changes observed there.