### PR TITLE
CPP/Java: Sync Dataflow

### DIFF
--- a/cpp/ql/src/semmle/code/cpp/dataflow/internal/DataFlowImplCommon.qll
+++ b/cpp/ql/src/semmle/code/cpp/dataflow/internal/DataFlowImplCommon.qll
@@ -237,7 +237,9 @@ import ImplCommon
  *    this dispatch target of `ma` implies a reduced set of dispatch origins
  *    to which data may flow if it should reach a `return` statement.
  */
-abstract class CallContext extends TCallContext { abstract string toString(); }
+abstract class CallContext extends TCallContext {
+  abstract string toString();
+}
 
 class CallContextAny extends CallContext, TAnyCallContext {
   override string toString() { result = "CcAny" }

--- a/cpp/ql/src/semmle/code/cpp/ir/dataflow/internal/DataFlowImplCommon.qll
+++ b/cpp/ql/src/semmle/code/cpp/ir/dataflow/internal/DataFlowImplCommon.qll
@@ -237,7 +237,9 @@ import ImplCommon
  *    this dispatch target of `ma` implies a reduced set of dispatch origins
  *    to which data may flow if it should reach a `return` statement.
  */
-abstract class CallContext extends TCallContext { abstract string toString(); }
+abstract class CallContext extends TCallContext {
+  abstract string toString();
+}
 
 class CallContextAny extends CallContext, TAnyCallContext {
   override string toString() { result = "CcAny" }


### PR DESCRIPTION
Sync the autoformat change from the java dataflow lib to the C++ counterparts.