### PR TITLE
JS: Vue security improvements

### DIFF
--- a/javascript/ql/src/semmle/javascript/dataflow/DataFlow.qll
+++ b/javascript/ql/src/semmle/javascript/dataflow/DataFlow.qll
@@ -116,7 +116,9 @@ module DataFlow {
     int getIntValue() { result = asExpr().getIntValue() }
 
     /** Gets a function value that may reach this node. */
-    FunctionNode getAFunctionValue() { result.getAstNode() = analyze().getAValue().(AbstractCallable).getFunction() }
+    FunctionNode getAFunctionValue() {
+      result.getAstNode() = analyze().getAValue().(AbstractCallable).getFunction()
+    }
 
     /**
      * Holds if this expression may refer to the initial value of parameter `p`.
@@ -1155,7 +1157,7 @@ module DataFlow {
     nd.asExpr() instanceof ExternalModuleReference and
     cause = "import"
     or
-    exists (Expr e | e = nd.asExpr() and cause = "heap" |
+    exists(Expr e | e = nd.asExpr() and cause = "heap" |
       e instanceof PropAccess or
       e instanceof E4X::XMLAnyName or
       e instanceof E4X::XMLAttributeSelector or

--- a/javascript/ql/src/semmle/javascript/dataflow/DataFlow.qll
+++ b/javascript/ql/src/semmle/javascript/dataflow/DataFlow.qll
@@ -742,22 +742,21 @@ module DataFlow {
   /**
    * A data flow node representing an HTML attribute.
    */
-  private class HtmlAttributeNode extends DataFlow::Node, THtmlAttributeNode {
+  class HtmlAttributeNode extends DataFlow::Node, THtmlAttributeNode {
     HTML::Attribute attr;
 
     HtmlAttributeNode() { this = THtmlAttributeNode(attr) }
 
     override string toString() { result = attr.toString() }
 
-    override ASTNode getAstNode() { none() }
-
-    override BasicBlock getBasicBlock() { none() }
-
     override predicate hasLocationInfo(
       string filepath, int startline, int startcolumn, int endline, int endcolumn
     ) {
       attr.getLocation().hasLocationInfo(filepath, startline, startcolumn, endline, endcolumn)
     }
+
+    /** Gets the attribute corresponding to this data flow node. */
+    HTML::Attribute getAttribute() { result = attr }
   }
 
   /**

--- a/javascript/ql/src/semmle/javascript/dataflow/DataFlow.qll
+++ b/javascript/ql/src/semmle/javascript/dataflow/DataFlow.qll
@@ -40,7 +40,8 @@ module DataFlow {
     } or
     TDestructuredModuleImportNode(ImportDeclaration decl) {
       exists(decl.getASpecifier().getImportedName())
-    }
+    } or
+    THtmlAttributeNode(HTML::Attribute attr)
 
   /**
    * A node in the data flow graph.
@@ -735,6 +736,27 @@ module DataFlow {
       string filepath, int startline, int startcolumn, int endline, int endcolumn
     ) {
       p.getLocation().hasLocationInfo(filepath, startline, startcolumn, endline, endcolumn)
+    }
+  }
+
+  /**
+   * A data flow node representing an HTML attribute.
+   */
+  private class HtmlAttributeNode extends DataFlow::Node, THtmlAttributeNode {
+    HTML::Attribute attr;
+
+    HtmlAttributeNode() { this = THtmlAttributeNode(attr) }
+
+    override string toString() { result = attr.toString() }
+
+    override ASTNode getAstNode() { none() }
+
+    override BasicBlock getBasicBlock() { none() }
+
+    override predicate hasLocationInfo(
+      string filepath, int startline, int startcolumn, int endline, int endcolumn
+    ) {
+      attr.getLocation().hasLocationInfo(filepath, startline, startcolumn, endline, endcolumn)
     }
   }
 

--- a/javascript/ql/src/semmle/javascript/frameworks/Vue.qll
+++ b/javascript/ql/src/semmle/javascript/frameworks/Vue.qll
@@ -392,7 +392,6 @@ module Vue {
    * A taint propagating data flow edge through a Vue instance property.
    */
   class InstanceHeapStep extends TaintTracking::AdditionalTaintStep {
-
     DataFlow::Node src;
 
     InstanceHeapStep() {
@@ -404,19 +403,16 @@ module Vue {
       )
     }
 
-    override predicate step(DataFlow::Node pred, DataFlow::Node succ) {
-      pred = src and succ = this
-    }
-
+    override predicate step(DataFlow::Node pred, DataFlow::Node succ) { pred = src and succ = this }
   }
 
   /*
    * Provides classes for working with Vue templates.
    */
+
   module Template {
     // Currently only supports HTML elements, but it may be possible to parse simple string templates later
-    private newtype TElement =
-      MkHtmlElement(HTML::Element e) { e.getFile() instanceof VueFile }
+    private newtype TElement = MkHtmlElement(HTML::Element e) { e.getFile() instanceof VueFile }
 
     /**
      * An element of a template.
@@ -472,5 +468,4 @@ module Vue {
       HTML::Element getElement() { result = elem }
     }
   }
-
 }

--- a/javascript/ql/src/semmle/javascript/frameworks/Vue.qll
+++ b/javascript/ql/src/semmle/javascript/frameworks/Vue.qll
@@ -366,4 +366,26 @@ module Vue {
   class VueFile extends File {
     VueFile() { getExtension() = "vue" }
   }
+
+  /**
+   * A taint propagating data flow edge through a Vue instance property.
+   */
+  class InstanceHeapStep extends TaintTracking::AdditionalTaintStep {
+
+    DataFlow::Node src;
+
+    InstanceHeapStep() {
+      exists(Instance i, string name, DataFlow::FunctionNode bound |
+        bound.flowsTo(i.getABoundFunction()) and
+        not bound.getFunction() instanceof ArrowFunctionExpr and
+        bound.getReceiver().getAPropertyRead(name) = this and
+        src = i.getAPropertyValue(name)
+      )
+    }
+
+    override predicate step(DataFlow::Node pred, DataFlow::Node succ) {
+      pred = src and succ = this
+    }
+  }
+
 }

--- a/javascript/ql/src/semmle/javascript/frameworks/Vue.qll
+++ b/javascript/ql/src/semmle/javascript/frameworks/Vue.qll
@@ -416,7 +416,7 @@ module Vue {
   module Template {
     // Currently only supports HTML elements, but it may be possible to parse simple string templates later
     private newtype TElement =
-      MkHtmlElement(HTML::Element e) { exists(VueFile f | e.getFile() = f) }
+      MkHtmlElement(HTML::Element e) { e.getFile() instanceof VueFile }
 
     /**
      * An element of a template.
@@ -430,7 +430,7 @@ module Vue {
        * The location spans column `startcolumn` of line `startline` to
        * column `endcolumn` of line `endline` in file `filepath`.
        * For more information, see
-       * [LGTM locations](https://lgtm.com/help/ql/locations).
+       * [locations](https://help.semmle.com/QL/learn-ql/ql/locations.html).
        */
       predicate hasLocationInfo(
         string filepath, int startline, int startcolumn, int endline, int endcolumn
@@ -442,6 +442,11 @@ module Vue {
         endcolumn = 0
       }
 
+      /**
+       * Gets the name of this element.
+       *
+       * For example, the name of `<br>` is `br`.
+       */
       abstract string getName();
     }
 
@@ -461,6 +466,9 @@ module Vue {
 
       override string getName() { result = elem.getName() }
 
+      /**
+       * Gets the HTML element of this element.
+       */
       HTML::Element getElement() { result = elem }
     }
   }

--- a/javascript/ql/src/semmle/javascript/security/dataflow/Xss.qll
+++ b/javascript/ql/src/semmle/javascript/security/dataflow/Xss.qll
@@ -203,14 +203,15 @@ module DomBasedXss {
    */
   class VHtmlSink extends DomBasedXss::Sink {
     HTML::Attribute attr;
-    VHtmlSink() { this.(DataFlow::HtmlAttributeNode).getAttribute() = attr and attr.getName() = "v-html" }
+
+    VHtmlSink() {
+      this.(DataFlow::HtmlAttributeNode).getAttribute() = attr and attr.getName() = "v-html"
+    }
 
     /**
      * Gets the HTML attribute of this sink.
      */
-    HTML::Attribute getAttr() {
-      result = attr
-    }
+    HTML::Attribute getAttr() { result = attr }
   }
 
   /**
@@ -226,7 +227,10 @@ module DomBasedXss {
 
     VHtmlSourceWrite() {
       exists(Vue::Instance instance, string expr |
-        attr.getAttr().getRoot() = instance.getTemplateElement().(Vue::Template::HtmlElement).getElement() and
+        attr.getAttr().getRoot() = instance
+              .getTemplateElement()
+              .(Vue::Template::HtmlElement)
+              .getElement() and
         expr = attr.getAttr().getValue() and
         // only support for simple identifier expressions
         expr.regexpMatch("(?i)[a-z0-9_]+") and

--- a/javascript/ql/src/semmle/javascript/security/dataflow/Xss.qll
+++ b/javascript/ql/src/semmle/javascript/security/dataflow/Xss.qll
@@ -204,6 +204,10 @@ module DomBasedXss {
   class VHtmlSink extends DomBasedXss::Sink {
     HTML::Attribute attr;
     VHtmlSink() { this.(DataFlow::HtmlAttributeNode).getAttribute() = attr and attr.getName() = "v-html" }
+
+    /**
+     * Gets the HTML attribute of this sink.
+     */
     HTML::Attribute getAttr() {
       result = attr
     }
@@ -212,6 +216,10 @@ module DomBasedXss {
   /**
    * A taint propagating data flow edge through a string interpolation of a
    * Vue instance property to a `v-html` attribute.
+   *
+   * As an example, `<div v-html="prop"/>` reads the `prop` property
+   * of `inst = new Vue({ ..., data: { prop: source } })`, if the
+   * `div` element is part of the template for `inst`.
    */
   class VHtmlSourceWrite extends TaintTracking::AdditionalTaintStep {
     VHtmlSink attr;

--- a/javascript/ql/src/semmle/javascript/security/dataflow/Xss.qll
+++ b/javascript/ql/src/semmle/javascript/security/dataflow/Xss.qll
@@ -203,7 +203,7 @@ module DomBasedXss {
    */
   class VHtmlSink extends DomBasedXss::Sink {
     HTML::Attribute attr;
-    VHtmlSink() { this = DataFlow::THtmlAttributeNode(attr) and attr.getName() = "v-html" }
+    VHtmlSink() { this.(DataFlow::HtmlAttributeNode).getAttribute() = attr and attr.getName() = "v-html" }
     HTML::Attribute getAttr() {
       result = attr
     }

--- a/javascript/ql/test/library-tests/frameworks/Vue/Instance.expected
+++ b/javascript/ql/test/library-tests/frameworks/Vue/Instance.expected
@@ -15,3 +15,4 @@
 | tst.js:77:20:83:2 | Vue.ext ... \\n  }\\n}) |
 | tst.js:85:1:87:2 | new Vue ... e; }\\n}) |
 | tst.js:94:2:96:3 | new Vue ...  f,\\n\\t}) |
+| tst.js:99:2:104:3 | new Vue ... \\t\\t}\\n\\t}) |

--- a/javascript/ql/test/library-tests/frameworks/Vue/InstanceHeapStep.expected
+++ b/javascript/ql/test/library-tests/frameworks/Vue/InstanceHeapStep.expected
@@ -1,0 +1,2 @@
+| tst.js:102:20:102:29 | this.dataA | tst.js:100:18:100:19 | 42 | tst.js:102:20:102:29 | this.dataA |
+| tst.js:102:20:102:29 | this.dataA | tst.js:102:20:102:23 | this | tst.js:102:20:102:29 | this.dataA |

--- a/javascript/ql/test/library-tests/frameworks/Vue/InstanceHeapStep.ql
+++ b/javascript/ql/test/library-tests/frameworks/Vue/InstanceHeapStep.ql
@@ -1,0 +1,5 @@
+import javascript
+
+from Vue::InstanceHeapStep step, DataFlow::Node pred, DataFlow::Node succ
+where step.step(pred, succ)
+select step, pred, succ

--- a/javascript/ql/test/library-tests/frameworks/Vue/Instance_getAPropertyValue.expected
+++ b/javascript/ql/test/library-tests/frameworks/Vue/Instance_getAPropertyValue.expected
@@ -20,3 +20,4 @@
 | tst.js:77:20:83:2 | Vue.ext ... \\n  }\\n}) | deadExtended | tst.js:80:21:80:22 | 42 |
 | tst.js:85:1:87:2 | new Vue ... e; }\\n}) | created | tst.js:86:38:86:41 | true |
 | tst.js:94:2:96:3 | new Vue ...  f,\\n\\t}) | dataA | tst.js:89:22:89:23 | 42 |
+| tst.js:99:2:104:3 | new Vue ... \\t\\t}\\n\\t}) | dataA | tst.js:100:18:100:19 | 42 |

--- a/javascript/ql/test/library-tests/frameworks/Vue/Instance_getOption.expected
+++ b/javascript/ql/test/library-tests/frameworks/Vue/Instance_getOption.expected
@@ -23,3 +23,5 @@
 | tst.js:77:20:83:2 | Vue.ext ... \\n  }\\n}) | data | tst.js:78:9:82:3 | functio ...  };\\n  } |
 | tst.js:85:1:87:2 | new Vue ... e; }\\n}) | created | tst.js:86:11:86:44 | functio ... true; } |
 | tst.js:94:2:96:3 | new Vue ...  f,\\n\\t}) | data | tst.js:95:9:95:9 | f |
+| tst.js:99:2:104:3 | new Vue ... \\t\\t}\\n\\t}) | data | tst.js:100:9:100:21 | { dataA: 42 } |
+| tst.js:99:2:104:3 | new Vue ... \\t\\t}\\n\\t}) | methods | tst.js:101:12:103:3 | {\\n\\t\\t\\tm: ... ; }\\n\\t\\t} |

--- a/javascript/ql/test/library-tests/frameworks/Vue/TemplateElement.expected
+++ b/javascript/ql/test/library-tests/frameworks/Vue/TemplateElement.expected
@@ -1,0 +1,12 @@
+| single-component-file-1.vue:1:1:3:11 | <template>...</> |
+| single-component-file-1.vue:2:5:10:8 | <p>...</> |
+| single-component-file-1.vue:4:1:8:9 | <script>...</> |
+| single-component-file-1.vue:9:1:10:8 | <style>...</> |
+| single-file-component-2.vue:1:1:3:11 | <template>...</> |
+| single-file-component-2.vue:2:5:11:8 | <p>...</> |
+| single-file-component-2.vue:4:1:9:9 | <script>...</> |
+| single-file-component-2.vue:10:1:11:8 | <style>...</> |
+| single-file-component-3.vue:1:1:3:11 | <template>...</> |
+| single-file-component-3.vue:2:5:7:8 | <p>...</> |
+| single-file-component-3.vue:4:1:5:9 | <script>...</> |
+| single-file-component-3.vue:6:1:7:8 | <style>...</> |

--- a/javascript/ql/test/library-tests/frameworks/Vue/TemplateElement.ql
+++ b/javascript/ql/test/library-tests/frameworks/Vue/TemplateElement.ql
@@ -1,0 +1,3 @@
+import javascript
+
+select any(Vue::Template::Element e)

--- a/javascript/ql/test/library-tests/frameworks/Vue/VHtmlSourceWrite.expected
+++ b/javascript/ql/test/library-tests/frameworks/Vue/VHtmlSourceWrite.expected
@@ -1,0 +1,2 @@
+| single-component-file-1.vue:6:40:6:41 | 42 | single-component-file-1.vue:6:40:6:41 | 42 | single-component-file-1.vue:2:8:2:21 | v-html=dataA |
+| single-file-component-3-script.js:4:37:4:38 | 42 | single-file-component-3-script.js:4:37:4:38 | 42 | single-file-component-3.vue:2:8:2:21 | v-html=dataA |

--- a/javascript/ql/test/library-tests/frameworks/Vue/VHtmlSourceWrite.ql
+++ b/javascript/ql/test/library-tests/frameworks/Vue/VHtmlSourceWrite.ql
@@ -1,0 +1,6 @@
+import javascript
+import semmle.javascript.security.dataflow.DomBasedXss
+
+from DomBasedXss::VHtmlSourceWrite w, DataFlow::Node pred, DataFlow::Node succ
+where w.step(pred, succ)
+select w, pred, succ

--- a/javascript/ql/test/library-tests/frameworks/Vue/XssSink.expected
+++ b/javascript/ql/test/library-tests/frameworks/Vue/XssSink.expected
@@ -1,2 +1,5 @@
+| single-component-file-1.vue:2:8:2:21 | v-html=dataA |
+| single-file-component-2.vue:2:8:2:21 | v-html=dataA |
+| single-file-component-3.vue:2:8:2:21 | v-html=dataA |
 | tst.js:5:13:5:13 | a |
 | tst.js:38:12:38:17 | danger |

--- a/javascript/ql/test/library-tests/frameworks/Vue/tst.js
+++ b/javascript/ql/test/library-tests/frameworks/Vue/tst.js
@@ -95,3 +95,11 @@ new Vue({
 		data: f,
 	});
 });
+(function() {
+	new Vue({
+		data: { dataA: 42 },
+		methods: {
+			m: function() { this.dataA; }
+		}
+	});
+});

--- a/javascript/ql/test/query-tests/Security/CWE-079/Xss.expected
+++ b/javascript/ql/test/query-tests/Security/CWE-079/Xss.expected
@@ -178,6 +178,8 @@ nodes
 | tst.js:282:9:282:29 | tainted |
 | tst.js:282:19:282:29 | window.name |
 | tst.js:285:59:285:65 | tainted |
+| v-html.vue:2:8:2:23 | v-html=tainted |
+| v-html.vue:6:42:6:58 | document.location |
 | winjs.js:2:7:2:53 | tainted |
 | winjs.js:2:17:2:33 | document.location |
 | winjs.js:2:17:2:40 | documen ... .search |
@@ -318,6 +320,7 @@ edges
 | tst.js:272:16:272:32 | document.location | tst.js:272:9:272:32 | loc3 |
 | tst.js:282:9:282:29 | tainted | tst.js:285:59:285:65 | tainted |
 | tst.js:282:19:282:29 | window.name | tst.js:282:9:282:29 | tainted |
+| v-html.vue:6:42:6:58 | document.location | v-html.vue:2:8:2:23 | v-html=tainted |
 | winjs.js:2:7:2:53 | tainted | winjs.js:3:43:3:49 | tainted |
 | winjs.js:2:7:2:53 | tainted | winjs.js:4:43:4:49 | tainted |
 | winjs.js:2:17:2:33 | document.location | winjs.js:2:17:2:40 | documen ... .search |
@@ -394,5 +397,6 @@ edges
 | tst.js:285:59:285:65 | tainted | tst.js:282:9:282:29 | tainted | tst.js:285:59:285:65 | tainted | Cross-site scripting vulnerability due to $@. | tst.js:282:9:282:29 | tainted | user-provided value |
 | tst.js:285:59:285:65 | tainted | tst.js:282:19:282:29 | window.name | tst.js:285:59:285:65 | tainted | Cross-site scripting vulnerability due to $@. | tst.js:282:19:282:29 | window.name | user-provided value |
 | tst.js:285:59:285:65 | tainted | tst.js:285:59:285:65 | tainted | tst.js:285:59:285:65 | tainted | Cross-site scripting vulnerability due to $@. | tst.js:285:59:285:65 | tainted | user-provided value |
+| v-html.vue:2:8:2:23 | v-html=tainted | v-html.vue:6:42:6:58 | document.location | v-html.vue:2:8:2:23 | v-html=tainted | Cross-site scripting vulnerability due to $@. | v-html.vue:6:42:6:58 | document.location | user-provided value |
 | winjs.js:3:43:3:49 | tainted | winjs.js:2:17:2:33 | document.location | winjs.js:3:43:3:49 | tainted | Cross-site scripting vulnerability due to $@. | winjs.js:2:17:2:33 | document.location | user-provided value |
 | winjs.js:4:43:4:49 | tainted | winjs.js:2:17:2:33 | document.location | winjs.js:4:43:4:49 | tainted | Cross-site scripting vulnerability due to $@. | winjs.js:2:17:2:33 | document.location | user-provided value |

--- a/javascript/ql/test/query-tests/Security/CWE-079/v-html.vue
+++ b/javascript/ql/test/query-tests/Security/CWE-079/v-html.vue
@@ -1,0 +1,10 @@
+<template>
+    <p v-html="tainted"/>
+</template>
+<script>
+  export default {
+    data: function() { return { tainted: document.location } }
+  }
+</script>
+<style>
+</style>


### PR DESCRIPTION
This adds two security related improvements for Vue:

An additional taint step through the instance fields of vue objects

XSS injection into the `v-html` Vue template property. This is the motivation for boldly adding `DataFlow:HtmlAttributeNode`, which scales surprisingly well (do we want to measure explicitly how many new nodes we get?).

The evaluation is boring. The two most recent evalutions show no new results or changes to performance: [gecko](https://git.semmle.com/esben/dist-compare-reports/tree/js/vue_1550061482993), [vue-projects](https://git.semmle.com/esben/dist-compare-reports/tree/js/vue_1550069331971).