### PR TITLE
C#: Improve CFG for assignments

### DIFF
--- a/csharp/ql/src/semmle/code/csharp/Assignable.qll
+++ b/csharp/ql/src/semmle/code/csharp/Assignable.qll
@@ -601,20 +601,19 @@ module AssignableDefinitions {
     /** Gets the underlying call. */
     Call getCall() { result.getAnArgument() = aa }
 
+    private int getPosition() { aa = this.getCall().getArgument(result) }
+
     /**
      * Gets the index of this definition among the other definitions in the
      * `out`/`ref` assignment. For example, in `M(out x, ref y)` the index of
      * the definitions of `x` and `y` are 0 and 1, respectively.
      */
     int getIndex() {
-      exists(ControlFlow::BasicBlock bb, int i | bb.getNode(i).getElement() = aa |
-        i = rank[result + 1](int j, OutRefDefinition def |
-            bb.getNode(j).getElement() = def.getTargetAccess() and
-            this.getCall() = def.getCall()
-          |
-            j
-          )
-      )
+      this = rank[result + 1](OutRefDefinition def |
+          def.getCall() = this.getCall()
+        |
+          def order by def.getPosition()
+        )
     }
 
     override predicate isCertain() { not isUncertainRefCall(this.getTargetAccess()) }

--- a/csharp/ql/src/semmle/code/csharp/controlflow/ControlFlowGraph.qll
+++ b/csharp/ql/src/semmle/code/csharp/controlflow/ControlFlowGraph.qll
@@ -518,6 +518,7 @@ module ControlFlow {
 
       private class WriteAccessNoNodeExpr extends WriteAccess, NoNodeExpr {
         WriteAccessNoNodeExpr() {
+          // For example a write to a static field, `Foo.Bar = 0`.
           forall(Expr e | e = this.(QualifiableExpr).getQualifier() | e instanceof NoNodeExpr)
         }
       }

--- a/csharp/ql/src/semmle/code/csharp/controlflow/ControlFlowGraph.qll
+++ b/csharp/ql/src/semmle/code/csharp/controlflow/ControlFlowGraph.qll
@@ -455,6 +455,7 @@ module ControlFlow {
         }
 
         override ControlFlowElement getChildElement(int i) {
+          not this instanceof GeneralCatchClause and
           not this instanceof FixedStmt and
           not this instanceof UsingStmt and
           result = this.getChild(i)
@@ -496,8 +497,115 @@ module ControlFlow {
       }
 
       /** A conditionally qualified expression. */
-      private class ConditionalQualifiableExpr extends QualifiableExpr {
-        ConditionalQualifiableExpr() { this.isConditional() }
+      private class ConditionallyQualifiedExpr extends QualifiableExpr {
+        ConditionallyQualifiedExpr() { this.isConditional() }
+      }
+
+      /** An expression that should not be included in the control flow graph. */
+      abstract private class NoNodeExpr extends Expr { }
+
+      private class SimpleNoNodeExpr extends NoNodeExpr {
+        SimpleNoNodeExpr() { this instanceof TypeAccess }
+      }
+
+      /** A write access that is not also a read access. */
+      private class WriteAccess extends AssignableWrite {
+        WriteAccess() {
+          // `x++` is both a read and write access
+          not this instanceof AssignableRead
+        }
+      }
+
+      private class WriteAccessNoNodeExpr extends WriteAccess, NoNodeExpr {
+        WriteAccessNoNodeExpr() {
+          forall(Expr e | e = this.(QualifiableExpr).getQualifier() | e instanceof NoNodeExpr)
+        }
+      }
+
+      private ControlFlowElement getExprChildElement0(Expr e, int i) {
+        not e instanceof NameOfExpr and
+        not e instanceof QualifiableExpr and
+        not e instanceof Assignment and
+        not e instanceof AnonymousFunctionExpr and
+        result = e.getChild(i)
+        or
+        e = any(ExtensionMethodCall emc | result = emc.getArgument(i))
+        or
+        e = any(QualifiableExpr qe |
+            not qe instanceof ExtensionMethodCall and
+            not qe.isConditional() and
+            result = qe.getChild(i)
+          )
+        or
+        e = any(Assignment a |
+            // The left-hand side of an assignment is evaluated before the right-hand side
+            i = 0 and result = a.getLValue()
+            or
+            i = 1 and result = a.getRValue()
+          )
+      }
+
+      private ControlFlowElement getExprChildElement(Expr e, int i) {
+        result = rank[i + 1](ControlFlowElement cfe, int j |
+            cfe = getExprChildElement0(e, j) and
+            not cfe instanceof NoNodeExpr
+          |
+            cfe order by j
+          )
+      }
+
+      private int getFirstChildElement(Expr e) {
+        result = min(int i | exists(getExprChildElement(e, i)))
+      }
+
+      private int getLastChildElement(Expr e) {
+        result = max(int i | exists(getExprChildElement(e, i)))
+      }
+
+      /**
+       * A qualified write access. In a qualified write access, the access itself is
+       * not evaluated, only the qualifier and the indexer arguments (if any).
+       */
+      private class QualifiedWriteAccess extends WriteAccess, QualifiableExpr {
+        QualifiedWriteAccess() { this.hasQualifier() }
+      }
+
+      /**
+       * An expression that writes via an accessor call, for example `x.Prop = 0`,
+       * where `Prop` is a property.
+       *
+       * Accessor writes need special attention, because we need to model the fact
+       * that the accessor is called *after* the assigned value has been evaluated.
+       * In the example above, this means we want a CFG that looks like
+       *
+       * ```
+       * x -> 0 -> set_Prop -> x.Prop = 0
+       * ```
+       */
+      class AccessorWrite extends Expr {
+        AssignableDefinition def;
+
+        AccessorWrite() {
+          def.getExpr() = this and
+          def.getTargetAccess().(WriteAccess) instanceof AccessorCall and
+          not this instanceof AssignOperationWithExpandedAssignment
+        }
+
+        /**
+         * Gets the `i`th accessor being called in this write. More than one call
+         * can happen in tuple assignments.
+         */
+        AccessorCall getCall(int i) {
+          result = rank[i + 1](AssignableDefinitions::TupleAssignmentDefinition tdef |
+              tdef.getExpr() = this and tdef.getTargetAccess() instanceof AccessorCall
+            |
+              tdef order by tdef.getEvaluationOrder()
+            ).getTargetAccess()
+          or
+          i = 0 and
+          result = def.getTargetAccess() and
+          not def instanceof AssignableDefinitions::TupleAssignmentDefinition
+        }
       }
 
       private class StandardExpr extends StandardElement, Expr {
@@ -509,85 +617,17 @@ module ControlFlow {
           not this instanceof NullCoalescingExpr and
           not this instanceof ConditionalExpr and
           not this instanceof AssignOperationWithExpandedAssignment and
-          not this instanceof ConditionalQualifiableExpr and
+          not this instanceof ConditionallyQualifiedExpr and
           not this instanceof ThrowExpr and
           not this instanceof TypeAccess and
           not this instanceof ObjectCreation and
-          not this instanceof ArrayCreation
+          not this instanceof ArrayCreation and
+          not this instanceof QualifiedWriteAccess and
+          not this instanceof AccessorWrite and
+          not this instanceof NoNodeExpr
         }
 
-        override ControlFlowElement getChildElement(int i) {
-          not this instanceof TypeofExpr and
-          not this instanceof DefaultValueExpr and
-          not this instanceof SizeofExpr and
-          not this instanceof NameOfExpr and
-          not this instanceof QualifiableExpr and
-          not this instanceof Assignment and
-          not this instanceof IsExpr and
-          not this instanceof AsExpr and
-          not this instanceof CastExpr and
-          not this instanceof AnonymousFunctionExpr and
-          not this instanceof DelegateCall and
-          not this instanceof @unknown_expr and
-          result = this.getChild(i)
-          or
-          this = any(ExtensionMethodCall emc | result = emc.getArgument(i))
-          or
-          result = getQualifiableExprChild(this, i)
-          or
-          result = getAssignmentChild(this, i)
-          or
-          result = getIsExprChild(this, i)
-          or
-          result = getAsExprChild(this, i)
-          or
-          result = getCastExprChild(this, i)
-          or
-          result = this.(DelegateCall).getChild(i - 1)
-          or
-          result = getUnknownExprChild(this, i)
-        }
-      }
-
-      private ControlFlowElement getQualifiableExprChild(QualifiableExpr qe, int i) {
-        i >= 0 and
-        not qe instanceof ExtensionMethodCall and
-        not qe.isConditional() and
-        if exists(Expr q | q = qe.getQualifier() | not q instanceof TypeAccess)
-        then result = qe.getChild(i - 1)
-        else result = qe.getChild(i)
-      }
-
-      private ControlFlowElement getAssignmentChild(Assignment a, int i) {
-        // The left-hand side of an assignment is evaluated before the right-hand side
-        i = 0 and result = a.getLValue()
-        or
-        i = 1 and result = a.getRValue()
-      }
-
-      private ControlFlowElement getIsExprChild(IsExpr ie, int i) {
-        // The type access at index 1 is not evaluated at run-time
-        i = 0 and result = ie.getExpr()
-        or
-        i = 1 and result = ie.(IsPatternExpr).getVariableDeclExpr()
-        or
-        i = 1 and result = ie.(IsConstantExpr).getConstant()
-      }
-
-      private ControlFlowElement getAsExprChild(AsExpr ae, int i) {
-        // The type access at index 1 is not evaluated at run-time
-        i = 0 and result = ae.getExpr()
-      }
-
-      private ControlFlowElement getUnknownExprChild(@unknown_expr e, int i) {
-        exists(int c | result = e.(Expr).getChild(c) |
-          c = rank[i + 1](int j | exists(e.(Expr).getChild(j)))
-        )
-      }
-
-      private ControlFlowElement getCastExprChild(CastExpr ce, int i) {
-        // The type access at index 1 is not evaluated at run-time
-        i = 0 and result = ce.getExpr()
+        override ControlFlowElement getChildElement(int i) { result = getExprChildElement(this, i) }
       }
 
       /**
@@ -610,7 +650,7 @@ module ControlFlow {
             result = first(a.getExpandedAssignment())
           )
         or
-        cfe = any(ConditionalQualifiableExpr cqe | result = first(cqe.getChildExpr(-1)))
+        cfe = any(ConditionallyQualifiedExpr cqe | result = first(cqe.getChildExpr(-1)))
         or
         cfe = any(ArrayCreation ac |
             if ac.isImplicitlySized()
@@ -628,6 +668,12 @@ module ControlFlow {
             // emptiness test that determines whether to execute the loop body
             result = first(fs.getIterableExpr())
           )
+        or
+        cfe instanceof QualifiedWriteAccess and
+        result = first(getExprChildElement(cfe, getFirstChildElement(cfe)))
+        or
+        cfe instanceof AccessorWrite and
+        result = first(getExprChildElement(cfe, getFirstChildElement(cfe)))
       }
 
       private class PreOrderElement extends ControlFlowElement {
@@ -660,6 +706,13 @@ module ControlFlow {
         }
       }
 
+      private Expr getObjectCreationArgument(ObjectCreation oc, int i) {
+        i >= 0 and
+        if oc.hasInitializer()
+        then result = getExprChildElement(oc, i + 1)
+        else result = getExprChildElement(oc, i)
+      }
+
       private class PostOrderElement extends ControlFlowElement {
         PostOrderElement() {
           this instanceof StandardExpr or
@@ -672,7 +725,7 @@ module ControlFlow {
           result = this.(StandardExpr).getFirstChildElement() or
           result = this.(JumpStmt).getChild(0) or
           result = this.(ThrowExpr).getExpr() or
-          result = this.(ObjectCreation).getArgument(0)
+          result = getObjectCreationArgument(this, 0)
         }
       }
 
@@ -768,7 +821,7 @@ module ControlFlow {
         or
         result = lastAssignOperationWithExpandedAssignmentExpandedAssignment(cfe, c)
         or
-        cfe = any(ConditionalQualifiableExpr cqe |
+        cfe = any(ConditionallyQualifiedExpr cqe |
             // Post-order: element itself
             result = cqe and
             c.isValidFor(cqe)
@@ -1034,6 +1087,30 @@ module ControlFlow {
             result = nrc and
             c = nrc.getACompletion()
           )
+        or
+        cfe = any(QualifiedWriteAccess qwa |
+            // Skip the access in a qualified write access
+            result = lastQualifiedWriteAccessGetChildElement(qwa, getLastChildElement(qwa), c)
+            or
+            // A child exits abnormally
+            result = lastQualifiedWriteAccessGetChildElement(qwa, _, c) and
+            not c instanceof NormalCompletion
+          )
+        or
+        cfe = any(AccessorWrite aw |
+            // Post-order: element itself
+            result = aw and
+            c.isValidFor(result)
+            or
+            // A child exits abnormally
+            result = lastAccessorWriteGetChildElement(aw, _, c) and
+            not c instanceof NormalCompletion
+            or
+            // An accessor call exits abnormally
+            result = aw.getCall(_) and
+            c.isValidFor(result) and
+            not c instanceof NormalCompletion
+          )
       }
 
       private ControlFlowElement lastConstCaseNoMatch(ConstCase cc, MatchingCompletion c) {
@@ -1122,14 +1199,14 @@ module ControlFlow {
 
       pragma[nomagic]
       private ControlFlowElement lastConditionalQualifiableExprChildExpr(
-        ConditionalQualifiableExpr cqe, int i, Completion c
+        ConditionallyQualifiedExpr cqe, int i, Completion c
       ) {
         result = last(cqe.getChildExpr(i), c)
       }
 
       pragma[nomagic]
       private ControlFlowElement lastObjectCreationArgument(ObjectCreation oc, int i, Completion c) {
-        result = last(oc.getArgument(i), c)
+        result = last(getObjectCreationArgument(oc, i), c)
       }
 
       pragma[nomagic]
@@ -1272,6 +1349,20 @@ module ControlFlow {
         result = last(fs.getInitializer(i), c)
       }
 
+      pragma[nomagic]
+      private ControlFlowElement lastQualifiedWriteAccessGetChildElement(
+        QualifiedWriteAccess qwa, int i, Completion c
+      ) {
+        result = last(getExprChildElement(qwa, i), c)
+      }
+
+      pragma[nomagic]
+      private ControlFlowElement lastAccessorWriteGetChildElement(
+        AccessorWrite aw, int i, Completion c
+      ) {
+        result = last(getExprChildElement(aw, i), c)
+      }
+
       /**
        * Gets a last element from a `try` or `catch` block of this `try` statement
        * that may finish with completion `c`, such that control may be transferred
@@ -1402,7 +1493,7 @@ module ControlFlow {
           result = first(ce.getElse())
         )
         or
-        exists(ConditionalQualifiableExpr parent, int i |
+        exists(ConditionallyQualifiedExpr parent, int i |
           cfe = lastConditionalQualifiableExprChildExpr(parent, i, c) and
           c instanceof NormalCompletion and
           not c.(NullnessCompletion).isNull()
@@ -1422,12 +1513,12 @@ module ControlFlow {
         exists(ObjectCreation oc |
           // Flow from last element of argument `i` to first element of argument `i+1`
           exists(int i | cfe = lastObjectCreationArgument(oc, i, c) |
-            result = first(oc.getArgument(i + 1)) and
+            result = first(getObjectCreationArgument(oc, i + 1)) and
             c instanceof NormalCompletion
           )
           or
           // Flow from last element of last argument to self
-          exists(int last | last = max(int i | exists(oc.getArgument(i))) |
+          exists(int last | last = max(int i | exists(getObjectCreationArgument(oc, i))) |
             cfe = lastObjectCreationArgument(oc, last, c) and
             result = oc and
             c instanceof NormalCompletion
@@ -1806,6 +1897,42 @@ module ControlFlow {
             not cfe = getBlockOrCatchFinallyPred(any(TryStmt ts | ts.hasFinally()), _) and
             result = first(glc.getGotoStmt().getTarget())
           )
+        or
+        // Standard left-to-right evaluation
+        exists(QualifiedWriteAccess qwa, int i |
+          cfe = lastQualifiedWriteAccessGetChildElement(qwa, i, c) and
+          c instanceof NormalCompletion and
+          result = first(getExprChildElement(qwa, i + 1))
+        )
+        or
+        exists(AccessorWrite aw |
+          // Standard left-to-right evaluation
+          exists(int i |
+            cfe = lastAccessorWriteGetChildElement(aw, i, c) and
+            c instanceof NormalCompletion and
+            result = first(getExprChildElement(aw, i + 1))
+          )
+          or
+          // Flow from last element of last child to first accessor call
+          cfe = lastAccessorWriteGetChildElement(aw, getLastChildElement(aw), c) and
+          result = aw.getCall(0) and
+          c instanceof NormalCompletion
+          or
+          // Flow from one call to the next
+          exists(int i | cfe = aw.getCall(i) |
+            result = aw.getCall(i + 1) and
+            c.isValidFor(cfe) and
+            c instanceof NormalCompletion
+          )
+          or
+          // Post-order: flow from last call to element itself
+          exists(int last | last = max(int i | exists(aw.getCall(i))) |
+            cfe = aw.getCall(last) and
+            result = aw and
+            c.isValidFor(cfe) and
+            c instanceof NormalCompletion
+          )
+        )
       }
 
       /**

--- a/csharp/ql/src/semmle/code/csharp/dataflow/SSA.qll
+++ b/csharp/ql/src/semmle/code/csharp/dataflow/SSA.qll
@@ -244,7 +244,7 @@ module Ssa {
         def.getTarget() = lv and
         lv.isRef() and
         lv = v.getAssignable() and
-        def.getTargetAccess().getAControlFlowNode() = node and
+        node = def.getAControlFlowNode().getAPredecessor() and
         bb.getNode(i) = node
       )
     }
@@ -587,8 +587,11 @@ module Ssa {
      * (when `k` is `SsaDef()`).
      */
     private predicate ssaRef(BasicBlock bb, int i, SourceVariable v, SsaRefKind k) {
-      variableRead(bb, i, v, _, _) and
-      k = SsaRead()
+      exists(ReadKind rk |
+        variableRead(bb, i, v, _, rk) |
+        not rk instanceof RefReadBeforeWrite and
+        k = SsaRead()
+      )
       or
       exists(TrackedDefinition def | definesAt(def, bb, i, v)) and
       k = SsaDef()

--- a/csharp/ql/test/library-tests/controlflow/graph/AccessorCalls.cs
+++ b/csharp/ql/test/library-tests/controlflow/graph/AccessorCalls.cs
@@ -1,0 +1,65 @@
+class AccessorCalls
+{
+    int Field;
+    int Prop { get; set; }
+    int this[int i] { get => i; set { } }
+    public delegate void EventHandler();
+    event EventHandler Event { add { } remove { } }
+    AccessorCalls x;
+
+    void M1(EventHandler e)
+    {
+        this.Field = this.Field;
+        this.Prop = this.Prop;
+        this[0] = this[1];
+        this.Event += e;
+        this.Event -= e;
+    }
+
+    void M2(EventHandler e)
+    {
+        this.x.Field = this.x.Field;
+        this.x.Prop = this.x.Prop;
+        this.x[0] = this.x[1];
+        this.x.Event += e;
+        this.x.Event -= e;
+    }
+
+    void M3()
+    {
+        this.Field++;
+        this.Prop++;
+        this[0]++;
+    }
+
+    void M4()
+    {
+        this.x.Field++;
+        this.x.Prop++;
+        this.x[0]++;
+    }
+
+    void M5()
+    {
+        this.Field += this.Field;
+        this.Prop += this.Prop;
+        this[0] += this[0];
+    }
+
+    void M6()
+    {
+        this.x.Field += this.x.Field;
+        this.x.Prop += this.x.Prop;
+        this.x[0] += this.x[0];
+    }
+
+    void M7(int i)
+    {
+        (this.Field, this.Prop, (i, this[0])) = (this.Field, this.Prop, (0, this[1]));
+    }
+
+    void M8(int i)
+    {
+        (this.x.Field, this.x.Prop, (i, this.x[0])) = (this.x.Field, this.x.Prop, (0, this.x[1]));
+    }
+}

--- a/csharp/ql/test/library-tests/controlflow/graph/BasicBlock.expected
+++ b/csharp/ql/test/library-tests/controlflow/graph/BasicBlock.expected
@@ -1,3 +1,15 @@
+| AccessorCalls.cs:5:23:5:25 | enter get_Item | AccessorCalls.cs:5:23:5:25 | exit get_Item | 3 |
+| AccessorCalls.cs:5:33:5:35 | enter set_Item | AccessorCalls.cs:5:33:5:35 | exit set_Item | 3 |
+| AccessorCalls.cs:7:32:7:34 | enter add_Event | AccessorCalls.cs:7:32:7:34 | exit add_Event | 3 |
+| AccessorCalls.cs:7:40:7:45 | enter remove_Event | AccessorCalls.cs:7:40:7:45 | exit remove_Event | 3 |
+| AccessorCalls.cs:10:10:10:11 | enter M1 | AccessorCalls.cs:10:10:10:11 | exit M1 | 33 |
+| AccessorCalls.cs:19:10:19:11 | enter M2 | AccessorCalls.cs:19:10:19:11 | exit M2 | 41 |
+| AccessorCalls.cs:28:10:28:11 | enter M3 | AccessorCalls.cs:28:10:28:11 | exit M3 | 16 |
+| AccessorCalls.cs:35:10:35:11 | enter M4 | AccessorCalls.cs:35:10:35:11 | exit M4 | 19 |
+| AccessorCalls.cs:42:10:42:11 | enter M5 | AccessorCalls.cs:42:10:42:11 | exit M5 | 33 |
+| AccessorCalls.cs:49:10:49:11 | enter M6 | AccessorCalls.cs:49:10:49:11 | exit M6 | 42 |
+| AccessorCalls.cs:56:10:56:11 | enter M7 | AccessorCalls.cs:56:10:56:11 | exit M7 | 25 |
+| AccessorCalls.cs:61:10:61:11 | enter M8 | AccessorCalls.cs:61:10:61:11 | exit M8 | 31 |
 | ArrayCreation.cs:3:11:3:12 | enter M1 | ArrayCreation.cs:3:11:3:12 | exit M1 | 4 |
 | ArrayCreation.cs:5:12:5:13 | enter M2 | ArrayCreation.cs:5:12:5:13 | exit M2 | 5 |
 | ArrayCreation.cs:7:11:7:12 | enter M3 | ArrayCreation.cs:7:11:7:12 | exit M3 | 6 |

--- a/csharp/ql/test/library-tests/controlflow/graph/BasicBlock.expected
+++ b/csharp/ql/test/library-tests/controlflow/graph/BasicBlock.expected
@@ -2,19 +2,19 @@
 | AccessorCalls.cs:5:33:5:35 | enter set_Item | AccessorCalls.cs:5:33:5:35 | exit set_Item | 3 |
 | AccessorCalls.cs:7:32:7:34 | enter add_Event | AccessorCalls.cs:7:32:7:34 | exit add_Event | 3 |
 | AccessorCalls.cs:7:40:7:45 | enter remove_Event | AccessorCalls.cs:7:40:7:45 | exit remove_Event | 3 |
-| AccessorCalls.cs:10:10:10:11 | enter M1 | AccessorCalls.cs:10:10:10:11 | exit M1 | 33 |
-| AccessorCalls.cs:19:10:19:11 | enter M2 | AccessorCalls.cs:19:10:19:11 | exit M2 | 41 |
+| AccessorCalls.cs:10:10:10:11 | enter M1 | AccessorCalls.cs:10:10:10:11 | exit M1 | 32 |
+| AccessorCalls.cs:19:10:19:11 | enter M2 | AccessorCalls.cs:19:10:19:11 | exit M2 | 40 |
 | AccessorCalls.cs:28:10:28:11 | enter M3 | AccessorCalls.cs:28:10:28:11 | exit M3 | 16 |
 | AccessorCalls.cs:35:10:35:11 | enter M4 | AccessorCalls.cs:35:10:35:11 | exit M4 | 19 |
-| AccessorCalls.cs:42:10:42:11 | enter M5 | AccessorCalls.cs:42:10:42:11 | exit M5 | 33 |
-| AccessorCalls.cs:49:10:49:11 | enter M6 | AccessorCalls.cs:49:10:49:11 | exit M6 | 42 |
-| AccessorCalls.cs:56:10:56:11 | enter M7 | AccessorCalls.cs:56:10:56:11 | exit M7 | 25 |
-| AccessorCalls.cs:61:10:61:11 | enter M8 | AccessorCalls.cs:61:10:61:11 | exit M8 | 31 |
+| AccessorCalls.cs:42:10:42:11 | enter M5 | AccessorCalls.cs:42:10:42:11 | exit M5 | 32 |
+| AccessorCalls.cs:49:10:49:11 | enter M6 | AccessorCalls.cs:49:10:49:11 | exit M6 | 41 |
+| AccessorCalls.cs:56:10:56:11 | enter M7 | AccessorCalls.cs:56:10:56:11 | exit M7 | 23 |
+| AccessorCalls.cs:61:10:61:11 | enter M8 | AccessorCalls.cs:61:10:61:11 | exit M8 | 29 |
 | ArrayCreation.cs:3:11:3:12 | enter M1 | ArrayCreation.cs:3:11:3:12 | exit M1 | 4 |
 | ArrayCreation.cs:5:12:5:13 | enter M2 | ArrayCreation.cs:5:12:5:13 | exit M2 | 5 |
 | ArrayCreation.cs:7:11:7:12 | enter M3 | ArrayCreation.cs:7:11:7:12 | exit M3 | 6 |
 | ArrayCreation.cs:9:12:9:13 | enter M4 | ArrayCreation.cs:9:12:9:13 | exit M4 | 10 |
-| Assignments.cs:3:10:3:10 | enter M | Assignments.cs:3:10:3:10 | exit M | 39 |
+| Assignments.cs:3:10:3:10 | enter M | Assignments.cs:3:10:3:10 | exit M | 33 |
 | Assignments.cs:14:18:14:35 | enter (...) => ... | Assignments.cs:14:18:14:35 | exit (...) => ... | 3 |
 | Assignments.cs:17:40:17:40 | enter + | Assignments.cs:17:40:17:40 | exit + | 5 |
 | BreakInTry.cs:3:10:3:11 | enter M1 | BreakInTry.cs:7:33:7:36 | access to parameter args | 5 |
@@ -109,39 +109,39 @@
 | ConditionalAccess.cs:19:12:19:13 | enter M6 | ConditionalAccess.cs:19:40:19:41 | access to parameter s1 | 2 |
 | ConditionalAccess.cs:19:12:19:13 | exit M6 | ConditionalAccess.cs:19:12:19:13 | exit M6 | 1 |
 | ConditionalAccess.cs:19:58:19:59 | access to parameter s2 | ConditionalAccess.cs:19:43:19:60 | call to method CommaJoinWith | 2 |
-| ConditionalAccess.cs:21:10:21:11 | enter M7 | ConditionalAccess.cs:21:10:21:11 | exit M7 | 20 |
+| ConditionalAccess.cs:21:10:21:11 | enter M7 | ConditionalAccess.cs:21:10:21:11 | exit M7 | 17 |
 | ConditionalAccess.cs:31:26:31:38 | enter CommaJoinWith | ConditionalAccess.cs:31:26:31:38 | exit CommaJoinWith | 7 |
 | Conditions.cs:3:10:3:19 | enter IncrOrDecr | Conditions.cs:5:13:5:15 | access to parameter inc | 4 |
 | Conditions.cs:3:10:3:19 | exit IncrOrDecr | Conditions.cs:3:10:3:19 | exit IncrOrDecr | 1 |
 | Conditions.cs:6:13:6:16 | [inc (line 3): true] ...; | Conditions.cs:7:14:7:16 | [inc (line 3): true] access to parameter inc | 6 |
 | Conditions.cs:7:9:8:16 | [inc (line 3): false] if (...) ... | Conditions.cs:8:13:8:15 | ...-- | 6 |
-| Conditions.cs:11:9:11:10 | enter M1 | Conditions.cs:14:13:14:13 | access to parameter b | 8 |
+| Conditions.cs:11:9:11:10 | enter M1 | Conditions.cs:14:13:14:13 | access to parameter b | 7 |
 | Conditions.cs:15:13:15:16 | [b (line 11): true] ...; | Conditions.cs:16:13:16:17 | [b (line 11): true] ... > ... | 7 |
 | Conditions.cs:16:9:18:20 | [b (line 11): false] if (...) ... | Conditions.cs:16:13:16:17 | [b (line 11): false] ... > ... | 4 |
 | Conditions.cs:17:13:18:20 | [b (line 11): false] if (...) ... | Conditions.cs:18:17:18:19 | ...-- | 6 |
 | Conditions.cs:17:13:18:20 | [b (line 11): true] if (...) ... | Conditions.cs:17:18:17:18 | [b (line 11): true] access to parameter b | 3 |
 | Conditions.cs:19:16:19:16 | access to local variable x | Conditions.cs:11:9:11:10 | exit M1 | 3 |
-| Conditions.cs:22:9:22:10 | enter M2 | Conditions.cs:25:13:25:14 | access to parameter b1 | 8 |
+| Conditions.cs:22:9:22:10 | enter M2 | Conditions.cs:25:13:25:14 | access to parameter b1 | 7 |
 | Conditions.cs:26:13:27:20 | if (...) ... | Conditions.cs:26:17:26:18 | access to parameter b2 | 2 |
 | Conditions.cs:27:17:27:20 | [b2 (line 22): true] ...; | Conditions.cs:28:13:28:14 | [b2 (line 22): true] access to parameter b2 | 5 |
 | Conditions.cs:28:9:29:16 | [b2 (line 22): false] if (...) ... | Conditions.cs:28:13:28:14 | [b2 (line 22): false] access to parameter b2 | 2 |
 | Conditions.cs:28:9:29:16 | if (...) ... | Conditions.cs:28:13:28:14 | access to parameter b2 | 2 |
 | Conditions.cs:29:13:29:16 | ...; | Conditions.cs:29:13:29:15 | ...++ | 3 |
 | Conditions.cs:30:16:30:16 | access to local variable x | Conditions.cs:22:9:22:10 | exit M2 | 3 |
-| Conditions.cs:33:9:33:10 | enter M3 | Conditions.cs:37:13:37:14 | access to parameter b1 | 12 |
-| Conditions.cs:38:13:38:20 | ...; | Conditions.cs:38:13:38:19 | ... = ... | 4 |
+| Conditions.cs:33:9:33:10 | enter M3 | Conditions.cs:37:13:37:14 | access to parameter b1 | 10 |
+| Conditions.cs:38:13:38:20 | ...; | Conditions.cs:38:13:38:19 | ... = ... | 3 |
 | Conditions.cs:39:9:40:16 | if (...) ... | Conditions.cs:39:13:39:14 | access to local variable b2 | 2 |
 | Conditions.cs:40:13:40:16 | [b2 (line 39): true] ...; | Conditions.cs:42:13:42:15 | ...++ | 8 |
 | Conditions.cs:41:9:42:16 | [b2 (line 39): false] if (...) ... | Conditions.cs:41:13:41:14 | [b2 (line 39): false] access to local variable b2 | 2 |
 | Conditions.cs:43:16:43:16 | access to local variable x | Conditions.cs:33:9:33:10 | exit M3 | 3 |
-| Conditions.cs:46:9:46:10 | enter M4 | Conditions.cs:49:16:49:22 | ... > ... | 11 |
+| Conditions.cs:46:9:46:10 | enter M4 | Conditions.cs:49:16:49:22 | ... > ... | 10 |
 | Conditions.cs:49:16:49:16 | [b (line 46): false] access to parameter x | Conditions.cs:49:16:49:22 | [b (line 46): false] ... > ... | 4 |
 | Conditions.cs:50:9:53:9 | [b (line 46): false] {...} | Conditions.cs:51:17:51:17 | [b (line 46): false] access to parameter b | 3 |
 | Conditions.cs:50:9:53:9 | [b (line 46): true] {...} | Conditions.cs:51:17:51:17 | [b (line 46): true] access to parameter b | 3 |
 | Conditions.cs:50:9:53:9 | {...} | Conditions.cs:51:17:51:17 | access to parameter b | 3 |
 | Conditions.cs:52:17:52:20 | [b (line 46): true] ...; | Conditions.cs:49:16:49:22 | [b (line 46): true] ... > ... | 7 |
 | Conditions.cs:54:16:54:16 | access to local variable y | Conditions.cs:46:9:46:10 | exit M4 | 3 |
-| Conditions.cs:57:9:57:10 | enter M5 | Conditions.cs:60:16:60:22 | ... > ... | 11 |
+| Conditions.cs:57:9:57:10 | enter M5 | Conditions.cs:60:16:60:22 | ... > ... | 10 |
 | Conditions.cs:60:16:60:16 | [b (line 57): false] access to parameter x | Conditions.cs:60:16:60:22 | [b (line 57): false] ... > ... | 4 |
 | Conditions.cs:61:9:64:9 | [b (line 57): false] {...} | Conditions.cs:62:17:62:17 | [b (line 57): false] access to parameter b | 3 |
 | Conditions.cs:61:9:64:9 | [b (line 57): true] {...} | Conditions.cs:62:17:62:17 | [b (line 57): true] access to parameter b | 3 |
@@ -152,37 +152,37 @@
 | Conditions.cs:65:9:66:16 | if (...) ... | Conditions.cs:65:13:65:13 | access to parameter b | 2 |
 | Conditions.cs:66:13:66:16 | ...; | Conditions.cs:66:13:66:15 | ...++ | 3 |
 | Conditions.cs:67:16:67:16 | access to local variable y | Conditions.cs:57:9:57:10 | exit M5 | 3 |
-| Conditions.cs:70:9:70:10 | enter M6 | Conditions.cs:74:27:74:28 | access to parameter ss | 14 |
+| Conditions.cs:70:9:70:10 | enter M6 | Conditions.cs:74:27:74:28 | access to parameter ss | 12 |
 | Conditions.cs:74:9:80:9 | foreach (... ... in ...) ... | Conditions.cs:74:9:80:9 | foreach (... ... in ...) ... | 1 |
 | Conditions.cs:75:9:80:9 | {...} | Conditions.cs:76:17:76:17 | access to local variable b | 3 |
 | Conditions.cs:77:17:77:20 | ...; | Conditions.cs:77:17:77:19 | ...++ | 3 |
 | Conditions.cs:78:13:79:26 | if (...) ... | Conditions.cs:78:17:78:21 | ... > ... | 4 |
-| Conditions.cs:79:17:79:26 | ...; | Conditions.cs:79:17:79:25 | ... = ... | 4 |
+| Conditions.cs:79:17:79:26 | ...; | Conditions.cs:79:17:79:25 | ... = ... | 3 |
 | Conditions.cs:81:9:82:16 | if (...) ... | Conditions.cs:81:12:81:12 | access to local variable b | 2 |
 | Conditions.cs:82:13:82:16 | ...; | Conditions.cs:82:13:82:15 | ...++ | 3 |
 | Conditions.cs:83:16:83:16 | access to local variable x | Conditions.cs:70:9:70:10 | exit M6 | 3 |
-| Conditions.cs:86:9:86:10 | enter M7 | Conditions.cs:90:27:90:28 | access to parameter ss | 14 |
+| Conditions.cs:86:9:86:10 | enter M7 | Conditions.cs:90:27:90:28 | access to parameter ss | 12 |
 | Conditions.cs:90:9:98:9 | foreach (... ... in ...) ... | Conditions.cs:90:9:98:9 | foreach (... ... in ...) ... | 1 |
 | Conditions.cs:91:9:98:9 | {...} | Conditions.cs:92:17:92:17 | access to local variable b | 3 |
 | Conditions.cs:93:17:93:20 | ...; | Conditions.cs:93:17:93:19 | ...++ | 3 |
 | Conditions.cs:94:13:95:26 | if (...) ... | Conditions.cs:94:17:94:21 | ... > ... | 4 |
-| Conditions.cs:95:17:95:26 | ...; | Conditions.cs:95:17:95:25 | ... = ... | 4 |
+| Conditions.cs:95:17:95:26 | ...; | Conditions.cs:95:17:95:25 | ... = ... | 3 |
 | Conditions.cs:96:13:97:20 | if (...) ... | Conditions.cs:96:17:96:17 | access to local variable b | 2 |
 | Conditions.cs:97:17:97:20 | ...; | Conditions.cs:97:17:97:19 | ...++ | 3 |
 | Conditions.cs:99:16:99:16 | access to local variable x | Conditions.cs:86:9:86:10 | exit M7 | 3 |
-| Conditions.cs:102:12:102:13 | enter M8 | Conditions.cs:105:13:105:13 | access to parameter b | 9 |
-| Conditions.cs:106:13:106:20 | [b (line 102): true] ...; | Conditions.cs:107:13:107:24 | [b (line 102): true] ... > ... | 11 |
+| Conditions.cs:102:12:102:13 | enter M8 | Conditions.cs:105:13:105:13 | access to parameter b | 8 |
+| Conditions.cs:106:13:106:20 | [b (line 102): true] ...; | Conditions.cs:107:13:107:24 | [b (line 102): true] ... > ... | 10 |
 | Conditions.cs:107:9:109:24 | [b (line 102): false] if (...) ... | Conditions.cs:107:13:107:24 | [b (line 102): false] ... > ... | 5 |
-| Conditions.cs:108:13:109:24 | [b (line 102): false] if (...) ... | Conditions.cs:109:17:109:23 | ... = ... | 9 |
+| Conditions.cs:108:13:109:24 | [b (line 102): false] if (...) ... | Conditions.cs:109:17:109:23 | ... = ... | 8 |
 | Conditions.cs:108:13:109:24 | [b (line 102): true] if (...) ... | Conditions.cs:108:18:108:18 | [b (line 102): true] access to parameter b | 3 |
 | Conditions.cs:110:16:110:16 | access to local variable x | Conditions.cs:102:12:102:13 | exit M8 | 3 |
-| Conditions.cs:113:10:113:11 | enter M9 | Conditions.cs:116:17:116:21 | Int32 i = ... | 10 |
+| Conditions.cs:113:10:113:11 | enter M9 | Conditions.cs:116:17:116:21 | Int32 i = ... | 8 |
 | Conditions.cs:113:10:113:11 | exit M9 | Conditions.cs:113:10:113:11 | exit M9 | 1 |
 | Conditions.cs:116:24:116:24 | access to local variable i | Conditions.cs:116:24:116:38 | ... < ... | 4 |
 | Conditions.cs:116:41:116:41 | access to local variable i | Conditions.cs:116:41:116:43 | ...++ | 2 |
-| Conditions.cs:117:9:123:9 | {...} | Conditions.cs:119:18:119:21 | access to local variable last | 13 |
-| Conditions.cs:120:17:120:23 | [last (line 118): false] ...; | Conditions.cs:121:17:121:20 | [last (line 118): false] access to local variable last | 6 |
-| Conditions.cs:121:13:122:25 | [last (line 118): true] if (...) ... | Conditions.cs:122:17:122:24 | ... = ... | 6 |
+| Conditions.cs:117:9:123:9 | {...} | Conditions.cs:119:18:119:21 | access to local variable last | 12 |
+| Conditions.cs:120:17:120:23 | [last (line 118): false] ...; | Conditions.cs:121:17:121:20 | [last (line 118): false] access to local variable last | 5 |
+| Conditions.cs:121:13:122:25 | [last (line 118): true] if (...) ... | Conditions.cs:122:17:122:24 | ... = ... | 5 |
 | Conditions.cs:129:10:129:12 | enter M10 | Conditions.cs:133:17:133:22 | access to field Field1 | 8 |
 | Conditions.cs:131:16:131:19 | [Field1 (line 129): false] true | Conditions.cs:133:17:133:22 | [Field1 (line 129): false] access to field Field1 | 5 |
 | Conditions.cs:131:16:131:19 | [Field1 (line 129): true, Field2 (line 129): false] true | Conditions.cs:135:21:135:26 | [Field1 (line 129): true, Field2 (line 129): false] access to field Field2 | 9 |
@@ -258,7 +258,7 @@
 | Initializers.cs:3:13:3:13 | access to field H | Initializers.cs:3:13:3:17 | ... + ... | 3 |
 | Initializers.cs:4:27:4:27 | access to field H | Initializers.cs:4:27:4:31 | ... + ... | 3 |
 | Initializers.cs:6:5:6:16 | enter Initializers | Initializers.cs:6:5:6:16 | exit Initializers | 3 |
-| Initializers.cs:8:10:8:10 | enter M | Initializers.cs:8:10:8:10 | exit M | 23 |
+| Initializers.cs:8:10:8:10 | enter M | Initializers.cs:8:10:8:10 | exit M | 20 |
 | NullCoalescing.cs:3:9:3:10 | enter M1 | NullCoalescing.cs:3:23:3:23 | access to parameter i | 3 |
 | NullCoalescing.cs:3:9:3:10 | exit M1 | NullCoalescing.cs:3:9:3:10 | exit M1 | 1 |
 | NullCoalescing.cs:3:28:3:28 | 0 | NullCoalescing.cs:3:28:3:28 | 0 | 1 |
@@ -282,8 +282,8 @@
 | NullCoalescing.cs:11:57:11:58 | access to parameter b3 | NullCoalescing.cs:11:57:11:58 | access to parameter b3 | 1 |
 | NullCoalescing.cs:11:64:11:64 | 0 | NullCoalescing.cs:11:64:11:64 | 0 | 1 |
 | NullCoalescing.cs:11:68:11:68 | 1 | NullCoalescing.cs:11:68:11:68 | 1 | 1 |
-| NullCoalescing.cs:13:10:13:11 | enter M6 | NullCoalescing.cs:13:10:13:11 | exit M6 | 21 |
-| Patterns.cs:5:10:5:13 | enter Test | Patterns.cs:8:13:8:23 | ... is ... | 10 |
+| NullCoalescing.cs:13:10:13:11 | enter M6 | NullCoalescing.cs:13:10:13:11 | exit M6 | 18 |
+| Patterns.cs:5:10:5:13 | enter Test | Patterns.cs:8:13:8:23 | ... is ... | 9 |
 | Patterns.cs:9:9:11:9 | {...} | Patterns.cs:10:13:10:42 | call to method WriteLine | 6 |
 | Patterns.cs:12:14:18:9 | if (...) ... | Patterns.cs:12:18:12:31 | ... is ... | 4 |
 | Patterns.cs:13:9:15:9 | {...} | Patterns.cs:14:13:14:45 | call to method WriteLine | 6 |
@@ -304,7 +304,7 @@
 | Patterns.cs:40:9:42:9 | switch (...) {...} | Patterns.cs:5:10:5:13 | exit Test | 3 |
 | Qualifiers.cs:7:16:7:21 | enter Method | Qualifiers.cs:7:16:7:21 | exit Method | 3 |
 | Qualifiers.cs:8:23:8:34 | enter StaticMethod | Qualifiers.cs:8:23:8:34 | exit StaticMethod | 3 |
-| Qualifiers.cs:10:10:10:10 | enter M | Qualifiers.cs:10:10:10:10 | exit M | 72 |
+| Qualifiers.cs:10:10:10:10 | enter M | Qualifiers.cs:10:10:10:10 | exit M | 57 |
 | Switch.cs:5:10:5:11 | enter M1 | Switch.cs:5:10:5:11 | exit M1 | 5 |
 | Switch.cs:10:10:10:11 | enter M2 | Switch.cs:14:18:14:20 | "a" | 6 |
 | Switch.cs:10:10:10:11 | exit M2 | Switch.cs:10:10:10:11 | exit M2 | 1 |
@@ -364,17 +364,17 @@
 | Switch.cs:118:25:118:25 | access to parameter s | Switch.cs:118:25:118:31 | ... == ... | 3 |
 | Switch.cs:118:42:118:42 | 2 | Switch.cs:118:35:118:43 | return ...; | 2 |
 | Switch.cs:120:17:120:17 | 1 | Switch.cs:120:9:120:18 | return ...; | 3 |
-| TypeAccesses.cs:3:10:3:10 | enter M | TypeAccesses.cs:7:13:7:22 | ... is ... | 16 |
+| TypeAccesses.cs:3:10:3:10 | enter M | TypeAccesses.cs:7:13:7:22 | ... is ... | 14 |
 | TypeAccesses.cs:7:25:7:25 | ; | TypeAccesses.cs:7:25:7:25 | ; | 1 |
-| TypeAccesses.cs:8:9:8:28 | ... ...; | TypeAccesses.cs:3:10:3:10 | exit M | 5 |
-| VarDecls.cs:5:18:5:19 | enter M1 | VarDecls.cs:5:18:5:19 | exit M1 | 18 |
-| VarDecls.cs:13:12:13:13 | enter M2 | VarDecls.cs:13:12:13:13 | exit M2 | 14 |
-| VarDecls.cs:19:7:19:8 | enter M3 | VarDecls.cs:25:20:25:20 | access to parameter b | 14 |
+| TypeAccesses.cs:8:9:8:28 | ... ...; | TypeAccesses.cs:3:10:3:10 | exit M | 4 |
+| VarDecls.cs:5:18:5:19 | enter M1 | VarDecls.cs:5:18:5:19 | exit M1 | 16 |
+| VarDecls.cs:13:12:13:13 | enter M2 | VarDecls.cs:13:12:13:13 | exit M2 | 12 |
+| VarDecls.cs:19:7:19:8 | enter M3 | VarDecls.cs:25:20:25:20 | access to parameter b | 12 |
 | VarDecls.cs:25:13:25:29 | return ...; | VarDecls.cs:19:7:19:8 | exit M3 | 2 |
 | VarDecls.cs:25:24:25:24 | access to local variable x | VarDecls.cs:25:24:25:24 | access to local variable x | 1 |
 | VarDecls.cs:25:28:25:28 | access to local variable y | VarDecls.cs:25:28:25:28 | access to local variable y | 1 |
 | VarDecls.cs:28:41:28:47 | enter Dispose | VarDecls.cs:28:41:28:47 | exit Dispose | 3 |
-| cflow.cs:5:17:5:20 | enter Main | cflow.cs:11:13:11:17 | ... > ... | 17 |
+| cflow.cs:5:17:5:20 | enter Main | cflow.cs:11:13:11:17 | ... > ... | 15 |
 | cflow.cs:5:17:5:20 | exit Main | cflow.cs:5:17:5:20 | exit Main | 1 |
 | cflow.cs:12:13:12:49 | ...; | cflow.cs:12:13:12:48 | call to method WriteLine | 3 |
 | cflow.cs:14:9:17:9 | while (...) ... | cflow.cs:14:9:17:9 | while (...) ... | 1 |
@@ -382,7 +382,7 @@
 | cflow.cs:15:9:17:9 | {...} | cflow.cs:16:13:16:40 | call to method WriteLine | 7 |
 | cflow.cs:19:9:22:25 | do ... while (...); | cflow.cs:19:9:22:25 | do ... while (...); | 1 |
 | cflow.cs:20:9:22:9 | {...} | cflow.cs:22:18:22:23 | ... < ... | 9 |
-| cflow.cs:24:9:34:9 | for (...;...;...) ... | cflow.cs:24:18:24:22 | Int32 i = ... | 4 |
+| cflow.cs:24:9:34:9 | for (...;...;...) ... | cflow.cs:24:18:24:22 | Int32 i = ... | 3 |
 | cflow.cs:24:25:24:25 | access to local variable i | cflow.cs:24:25:24:31 | ... <= ... | 3 |
 | cflow.cs:24:34:24:34 | access to local variable i | cflow.cs:24:34:24:36 | ...++ | 2 |
 | cflow.cs:25:9:34:9 | {...} | cflow.cs:26:17:26:26 | ... == ... | 8 |
@@ -431,13 +431,13 @@
 | cflow.cs:109:9:115:9 | {...} | cflow.cs:110:13:113:13 | while (...) ... | 2 |
 | cflow.cs:110:20:110:23 | true | cflow.cs:112:17:112:36 | call to method WriteLine | 5 |
 | cflow.cs:116:9:116:29 | ...; | cflow.cs:106:18:106:19 | exit M4 | 4 |
-| cflow.cs:119:20:119:21 | enter M5 | cflow.cs:119:20:119:21 | exit M5 | 15 |
+| cflow.cs:119:20:119:21 | enter M5 | cflow.cs:119:20:119:21 | exit M5 | 13 |
 | cflow.cs:127:19:127:21 | enter get_Prop | cflow.cs:127:32:127:44 | ... == ... | 7 |
 | cflow.cs:127:25:127:58 | return ...; | cflow.cs:127:19:127:21 | exit get_Prop | 2 |
 | cflow.cs:127:48:127:49 | "" | cflow.cs:127:48:127:49 | "" | 1 |
 | cflow.cs:127:53:127:57 | this access | cflow.cs:127:53:127:57 | access to field Field | 2 |
-| cflow.cs:127:62:127:64 | enter set_Prop | cflow.cs:127:62:127:64 | exit set_Prop | 8 |
-| cflow.cs:129:5:129:15 | enter ControlFlow | cflow.cs:129:5:129:15 | exit ControlFlow | 8 |
+| cflow.cs:127:62:127:64 | enter set_Prop | cflow.cs:127:62:127:64 | exit set_Prop | 7 |
+| cflow.cs:129:5:129:15 | enter ControlFlow | cflow.cs:129:5:129:15 | exit ControlFlow | 7 |
 | cflow.cs:134:5:134:15 | enter ControlFlow | cflow.cs:134:5:134:15 | exit ControlFlow | 8 |
 | cflow.cs:136:12:136:22 | enter ControlFlow | cflow.cs:136:12:136:22 | exit ControlFlow | 7 |
 | cflow.cs:138:40:138:40 | enter + | cflow.cs:138:40:138:40 | exit + | 8 |
@@ -464,7 +464,7 @@
 | cflow.cs:194:9:197:9 | [exception: OutOfMemoryException] catch (...) {...} | cflow.cs:198:35:198:51 | [exception: OutOfMemoryException] ... != ... | 7 |
 | cflow.cs:194:38:194:39 | [exception: Exception] IOException ex | cflow.cs:203:13:203:40 | [finally: exception(IOException)] call to method WriteLine | 8 |
 | cflow.cs:198:9:200:9 | [exception: Exception] catch (...) {...} | cflow.cs:198:35:198:51 | [exception: Exception] ... != ... | 6 |
-| cflow.cs:199:9:200:9 | {...} | cflow.cs:207:9:230:9 | while (...) ... | 10 |
+| cflow.cs:199:9:200:9 | {...} | cflow.cs:207:9:230:9 | while (...) ... | 9 |
 | cflow.cs:202:9:204:9 | [finally: exception(Exception)] {...} | cflow.cs:203:13:203:40 | [finally: exception(Exception)] call to method WriteLine | 4 |
 | cflow.cs:202:9:204:9 | [finally: exception(OutOfMemoryException)] {...} | cflow.cs:203:13:203:40 | [finally: exception(OutOfMemoryException)] call to method WriteLine | 4 |
 | cflow.cs:207:16:207:16 | access to local variable i | cflow.cs:207:16:207:20 | ... > ... | 3 |
@@ -515,8 +515,8 @@
 | cflow.cs:244:17:244:37 | [finally: exception(NullReferenceException)] ...; | cflow.cs:244:17:244:36 | [finally: exception(NullReferenceException)] call to method WriteLine | 3 |
 | cflow.cs:244:17:244:37 | [finally: exception(OutOfMemoryException)] ...; | cflow.cs:244:17:244:36 | [finally: exception(OutOfMemoryException)] call to method WriteLine | 3 |
 | cflow.cs:244:17:244:37 | [finally: return] ...; | cflow.cs:244:17:244:36 | [finally: return] call to method WriteLine | 3 |
-| cflow.cs:247:9:254:9 | try {...} ... | cflow.cs:249:17:249:40 | Double temp = ... | 9 |
-| cflow.cs:257:10:257:12 | enter For | cflow.cs:260:9:261:33 | for (...;...;...) ... | 7 |
+| cflow.cs:247:9:254:9 | try {...} ... | cflow.cs:249:17:249:40 | Double temp = ... | 8 |
+| cflow.cs:257:10:257:12 | enter For | cflow.cs:260:9:261:33 | for (...;...;...) ... | 6 |
 | cflow.cs:257:10:257:12 | exit For | cflow.cs:257:10:257:12 | exit For | 1 |
 | cflow.cs:260:16:260:16 | access to local variable x | cflow.cs:260:16:260:21 | ... < ... | 3 |
 | cflow.cs:261:13:261:33 | ...; | cflow.cs:260:24:260:26 | ++... | 5 |
@@ -528,18 +528,18 @@
 | cflow.cs:275:17:275:22 | break; | cflow.cs:278:9:282:9 | for (...;...;...) ... | 2 |
 | cflow.cs:278:16:278:16 | access to local variable x | cflow.cs:278:16:278:21 | ... < ... | 3 |
 | cflow.cs:279:9:282:9 | {...} | cflow.cs:281:13:281:15 | ...++ | 7 |
-| cflow.cs:284:9:287:9 | for (...;...;...) ... | cflow.cs:284:25:284:29 | Int32 j = ... | 7 |
+| cflow.cs:284:9:287:9 | for (...;...;...) ... | cflow.cs:284:25:284:29 | Int32 j = ... | 5 |
 | cflow.cs:284:32:284:32 | access to local variable i | cflow.cs:284:32:284:41 | ... < ... | 5 |
 | cflow.cs:285:9:287:9 | {...} | cflow.cs:284:49:284:51 | ...++ | 10 |
-| cflow.cs:290:10:290:16 | enter Lambdas | cflow.cs:290:10:290:16 | exit Lambdas | 11 |
+| cflow.cs:290:10:290:16 | enter Lambdas | cflow.cs:290:10:290:16 | exit Lambdas | 9 |
 | cflow.cs:292:28:292:37 | enter (...) => ... | cflow.cs:292:28:292:37 | exit (...) => ... | 5 |
 | cflow.cs:293:28:293:61 | enter delegate(...) { ... } | cflow.cs:293:28:293:61 | exit delegate(...) { ... } | 7 |
 | cflow.cs:296:10:296:18 | enter LogicalOr | cflow.cs:296:10:296:18 | exit LogicalOr | 19 |
-| cflow.cs:304:10:304:17 | enter Booleans | cflow.cs:306:17:306:32 | ... > ... | 10 |
+| cflow.cs:304:10:304:17 | enter Booleans | cflow.cs:306:17:306:32 | ... > ... | 9 |
 | cflow.cs:304:10:304:17 | exit Booleans | cflow.cs:304:10:304:17 | exit Booleans | 1 |
 | cflow.cs:306:13:306:56 | Boolean b = ... | cflow.cs:308:15:308:31 | ... == ... | 9 |
 | cflow.cs:306:37:306:56 | !... | cflow.cs:306:39:306:55 | ... == ... | 6 |
-| cflow.cs:308:35:308:39 | false | cflow.cs:309:17:309:33 | ... == ... | 9 |
+| cflow.cs:308:35:308:39 | false | cflow.cs:309:17:309:33 | ... == ... | 8 |
 | cflow.cs:308:43:308:46 | true | cflow.cs:308:43:308:46 | true | 1 |
 | cflow.cs:309:13:309:48 | ... = ... | cflow.cs:309:13:309:48 | ... = ... | 1 |
 | cflow.cs:309:37:309:41 | false | cflow.cs:309:37:309:41 | false | 1 |
@@ -550,7 +550,7 @@
 | cflow.cs:312:9:316:9 | {...} | cflow.cs:314:17:314:38 | throw ...; | 4 |
 | cflow.cs:319:10:319:11 | enter Do | cflow.cs:321:9:332:36 | do ... while (...); | 3 |
 | cflow.cs:319:10:319:11 | exit Do | cflow.cs:319:10:319:11 | exit Do | 1 |
-| cflow.cs:322:9:332:9 | {...} | cflow.cs:324:17:324:32 | ... > ... | 15 |
+| cflow.cs:322:9:332:9 | {...} | cflow.cs:324:17:324:32 | ... > ... | 14 |
 | cflow.cs:325:13:327:13 | {...} | cflow.cs:326:17:326:25 | continue; | 2 |
 | cflow.cs:328:13:331:13 | if (...) ... | cflow.cs:328:17:328:32 | ... < ... | 6 |
 | cflow.cs:329:13:331:13 | {...} | cflow.cs:330:17:330:22 | break; | 2 |
@@ -558,7 +558,7 @@
 | cflow.cs:335:10:335:16 | enter Foreach | cflow.cs:337:27:337:64 | call to method Repeat | 5 |
 | cflow.cs:335:10:335:16 | exit Foreach | cflow.cs:335:10:335:16 | exit Foreach | 1 |
 | cflow.cs:337:9:348:9 | foreach (... ... in ...) ... | cflow.cs:337:9:348:9 | foreach (... ... in ...) ... | 1 |
-| cflow.cs:337:22:337:22 | String x | cflow.cs:340:17:340:32 | ... > ... | 16 |
+| cflow.cs:337:22:337:22 | String x | cflow.cs:340:17:340:32 | ... > ... | 15 |
 | cflow.cs:341:13:343:13 | {...} | cflow.cs:342:17:342:25 | continue; | 2 |
 | cflow.cs:344:13:347:13 | if (...) ... | cflow.cs:344:17:344:32 | ... < ... | 6 |
 | cflow.cs:345:13:347:13 | {...} | cflow.cs:346:17:346:22 | break; | 2 |
@@ -575,7 +575,7 @@
 | cflow.cs:364:13:364:19 | case ...: | cflow.cs:364:18:364:18 | 2 | 2 |
 | cflow.cs:365:17:365:27 | goto ...; | cflow.cs:365:17:365:27 | goto ...; | 1 |
 | cflow.cs:366:13:366:20 | default: | cflow.cs:368:17:368:22 | break; | 5 |
-| cflow.cs:372:49:372:53 | enter Yield | cflow.cs:375:18:375:22 | Int32 i = ... | 8 |
+| cflow.cs:372:49:372:53 | enter Yield | cflow.cs:375:18:375:22 | Int32 i = ... | 7 |
 | cflow.cs:375:25:375:25 | access to local variable i | cflow.cs:375:25:375:30 | ... < ... | 3 |
 | cflow.cs:376:9:378:9 | {...} | cflow.cs:375:33:375:35 | ...++ | 5 |
 | cflow.cs:379:9:387:9 | try {...} ... | cflow.cs:372:49:372:53 | exit Yield | 8 |

--- a/csharp/ql/test/library-tests/controlflow/graph/BasicBlockDominance.expected
+++ b/csharp/ql/test/library-tests/controlflow/graph/BasicBlockDominance.expected
@@ -1,3 +1,15 @@
+| post | AccessorCalls.cs:5:23:5:25 | enter get_Item | AccessorCalls.cs:5:23:5:25 | enter get_Item |
+| post | AccessorCalls.cs:5:33:5:35 | enter set_Item | AccessorCalls.cs:5:33:5:35 | enter set_Item |
+| post | AccessorCalls.cs:7:32:7:34 | enter add_Event | AccessorCalls.cs:7:32:7:34 | enter add_Event |
+| post | AccessorCalls.cs:7:40:7:45 | enter remove_Event | AccessorCalls.cs:7:40:7:45 | enter remove_Event |
+| post | AccessorCalls.cs:10:10:10:11 | enter M1 | AccessorCalls.cs:10:10:10:11 | enter M1 |
+| post | AccessorCalls.cs:19:10:19:11 | enter M2 | AccessorCalls.cs:19:10:19:11 | enter M2 |
+| post | AccessorCalls.cs:28:10:28:11 | enter M3 | AccessorCalls.cs:28:10:28:11 | enter M3 |
+| post | AccessorCalls.cs:35:10:35:11 | enter M4 | AccessorCalls.cs:35:10:35:11 | enter M4 |
+| post | AccessorCalls.cs:42:10:42:11 | enter M5 | AccessorCalls.cs:42:10:42:11 | enter M5 |
+| post | AccessorCalls.cs:49:10:49:11 | enter M6 | AccessorCalls.cs:49:10:49:11 | enter M6 |
+| post | AccessorCalls.cs:56:10:56:11 | enter M7 | AccessorCalls.cs:56:10:56:11 | enter M7 |
+| post | AccessorCalls.cs:61:10:61:11 | enter M8 | AccessorCalls.cs:61:10:61:11 | enter M8 |
 | post | ArrayCreation.cs:3:11:3:12 | enter M1 | ArrayCreation.cs:3:11:3:12 | enter M1 |
 | post | ArrayCreation.cs:5:12:5:13 | enter M2 | ArrayCreation.cs:5:12:5:13 | enter M2 |
 | post | ArrayCreation.cs:7:11:7:12 | enter M3 | ArrayCreation.cs:7:11:7:12 | enter M3 |
@@ -1322,6 +1334,18 @@
 | post | cflow.cs:428:70:428:71 | "" | cflow.cs:426:10:426:10 | enter M |
 | post | cflow.cs:428:70:428:71 | "" | cflow.cs:428:56:428:56 | access to parameter s |
 | post | cflow.cs:428:70:428:71 | "" | cflow.cs:428:70:428:71 | "" |
+| pre | AccessorCalls.cs:5:23:5:25 | enter get_Item | AccessorCalls.cs:5:23:5:25 | enter get_Item |
+| pre | AccessorCalls.cs:5:33:5:35 | enter set_Item | AccessorCalls.cs:5:33:5:35 | enter set_Item |
+| pre | AccessorCalls.cs:7:32:7:34 | enter add_Event | AccessorCalls.cs:7:32:7:34 | enter add_Event |
+| pre | AccessorCalls.cs:7:40:7:45 | enter remove_Event | AccessorCalls.cs:7:40:7:45 | enter remove_Event |
+| pre | AccessorCalls.cs:10:10:10:11 | enter M1 | AccessorCalls.cs:10:10:10:11 | enter M1 |
+| pre | AccessorCalls.cs:19:10:19:11 | enter M2 | AccessorCalls.cs:19:10:19:11 | enter M2 |
+| pre | AccessorCalls.cs:28:10:28:11 | enter M3 | AccessorCalls.cs:28:10:28:11 | enter M3 |
+| pre | AccessorCalls.cs:35:10:35:11 | enter M4 | AccessorCalls.cs:35:10:35:11 | enter M4 |
+| pre | AccessorCalls.cs:42:10:42:11 | enter M5 | AccessorCalls.cs:42:10:42:11 | enter M5 |
+| pre | AccessorCalls.cs:49:10:49:11 | enter M6 | AccessorCalls.cs:49:10:49:11 | enter M6 |
+| pre | AccessorCalls.cs:56:10:56:11 | enter M7 | AccessorCalls.cs:56:10:56:11 | enter M7 |
+| pre | AccessorCalls.cs:61:10:61:11 | enter M8 | AccessorCalls.cs:61:10:61:11 | enter M8 |
 | pre | ArrayCreation.cs:3:11:3:12 | enter M1 | ArrayCreation.cs:3:11:3:12 | enter M1 |
 | pre | ArrayCreation.cs:5:12:5:13 | enter M2 | ArrayCreation.cs:5:12:5:13 | enter M2 |
 | pre | ArrayCreation.cs:7:11:7:12 | enter M3 | ArrayCreation.cs:7:11:7:12 | enter M3 |

--- a/csharp/ql/test/library-tests/controlflow/graph/BooleanNode.expected
+++ b/csharp/ql/test/library-tests/controlflow/graph/BooleanNode.expected
@@ -131,7 +131,6 @@
 | b (line 102): false | Conditions.cs:108:17:108:18 | [b (line 102): false] !... |
 | b (line 102): false | Conditions.cs:108:18:108:18 | [b (line 102): false] access to parameter b |
 | b (line 102): true | Conditions.cs:106:13:106:13 | [b (line 102): true] access to local variable x |
-| b (line 102): true | Conditions.cs:106:13:106:13 | [b (line 102): true] access to local variable x |
 | b (line 102): true | Conditions.cs:106:13:106:19 | [b (line 102): true] ... + ... |
 | b (line 102): true | Conditions.cs:106:13:106:19 | [b (line 102): true] ... = ... |
 | b (line 102): true | Conditions.cs:106:13:106:20 | [b (line 102): true] ...; |
@@ -153,7 +152,6 @@
 | inc (line 3): true | Conditions.cs:7:9:8:16 | [inc (line 3): true] if (...) ... |
 | inc (line 3): true | Conditions.cs:7:13:7:16 | [inc (line 3): true] !... |
 | inc (line 3): true | Conditions.cs:7:14:7:16 | [inc (line 3): true] access to parameter inc |
-| last (line 118): false | Conditions.cs:120:17:120:17 | [last (line 118): false] access to local variable s |
 | last (line 118): false | Conditions.cs:120:17:120:22 | [last (line 118): false] ... = ... |
 | last (line 118): false | Conditions.cs:120:17:120:23 | [last (line 118): false] ...; |
 | last (line 118): false | Conditions.cs:120:21:120:22 | [last (line 118): false] "" |

--- a/csharp/ql/test/library-tests/controlflow/graph/Dominance.expected
+++ b/csharp/ql/test/library-tests/controlflow/graph/Dominance.expected
@@ -9,75 +9,73 @@
 | post | AccessorCalls.cs:10:10:10:11 | exit M1 | AccessorCalls.cs:16:9:16:23 | ... -= ... |
 | post | AccessorCalls.cs:11:5:17:5 | {...} | AccessorCalls.cs:10:10:10:11 | enter M1 |
 | post | AccessorCalls.cs:12:9:12:12 | this access | AccessorCalls.cs:12:9:12:32 | ...; |
-| post | AccessorCalls.cs:12:9:12:18 | access to field Field | AccessorCalls.cs:12:9:12:12 | this access |
 | post | AccessorCalls.cs:12:9:12:31 | ... = ... | AccessorCalls.cs:12:22:12:31 | access to field Field |
 | post | AccessorCalls.cs:12:9:12:32 | ...; | AccessorCalls.cs:11:5:17:5 | {...} |
-| post | AccessorCalls.cs:12:22:12:25 | this access | AccessorCalls.cs:12:9:12:18 | access to field Field |
+| post | AccessorCalls.cs:12:22:12:25 | this access | AccessorCalls.cs:12:9:12:12 | this access |
 | post | AccessorCalls.cs:12:22:12:31 | access to field Field | AccessorCalls.cs:12:22:12:25 | this access |
 | post | AccessorCalls.cs:13:9:13:12 | this access | AccessorCalls.cs:13:9:13:30 | ...; |
-| post | AccessorCalls.cs:13:9:13:17 | access to property Prop | AccessorCalls.cs:13:9:13:12 | this access |
-| post | AccessorCalls.cs:13:9:13:29 | ... = ... | AccessorCalls.cs:13:21:13:29 | access to property Prop |
+| post | AccessorCalls.cs:13:9:13:17 | access to property Prop | AccessorCalls.cs:13:21:13:29 | access to property Prop |
+| post | AccessorCalls.cs:13:9:13:29 | ... = ... | AccessorCalls.cs:13:9:13:17 | access to property Prop |
 | post | AccessorCalls.cs:13:9:13:30 | ...; | AccessorCalls.cs:12:9:12:31 | ... = ... |
-| post | AccessorCalls.cs:13:21:13:24 | this access | AccessorCalls.cs:13:9:13:17 | access to property Prop |
+| post | AccessorCalls.cs:13:21:13:24 | this access | AccessorCalls.cs:13:9:13:12 | this access |
 | post | AccessorCalls.cs:13:21:13:29 | access to property Prop | AccessorCalls.cs:13:21:13:24 | this access |
 | post | AccessorCalls.cs:14:9:14:12 | this access | AccessorCalls.cs:14:9:14:26 | ...; |
-| post | AccessorCalls.cs:14:9:14:15 | access to indexer | AccessorCalls.cs:14:14:14:14 | 0 |
-| post | AccessorCalls.cs:14:9:14:25 | ... = ... | AccessorCalls.cs:14:19:14:25 | access to indexer |
+| post | AccessorCalls.cs:14:9:14:15 | access to indexer | AccessorCalls.cs:14:19:14:25 | access to indexer |
+| post | AccessorCalls.cs:14:9:14:25 | ... = ... | AccessorCalls.cs:14:9:14:15 | access to indexer |
 | post | AccessorCalls.cs:14:9:14:26 | ...; | AccessorCalls.cs:13:9:13:29 | ... = ... |
 | post | AccessorCalls.cs:14:14:14:14 | 0 | AccessorCalls.cs:14:9:14:12 | this access |
-| post | AccessorCalls.cs:14:19:14:22 | this access | AccessorCalls.cs:14:9:14:15 | access to indexer |
+| post | AccessorCalls.cs:14:19:14:22 | this access | AccessorCalls.cs:14:14:14:14 | 0 |
 | post | AccessorCalls.cs:14:19:14:25 | access to indexer | AccessorCalls.cs:14:24:14:24 | 1 |
 | post | AccessorCalls.cs:14:24:14:24 | 1 | AccessorCalls.cs:14:19:14:22 | this access |
 | post | AccessorCalls.cs:15:9:15:12 | this access | AccessorCalls.cs:15:9:15:24 | ...; |
-| post | AccessorCalls.cs:15:9:15:18 | access to event Event | AccessorCalls.cs:15:9:15:12 | this access |
-| post | AccessorCalls.cs:15:9:15:23 | ... += ... | AccessorCalls.cs:15:23:15:23 | access to parameter e |
+| post | AccessorCalls.cs:15:9:15:18 | access to event Event | AccessorCalls.cs:15:23:15:23 | access to parameter e |
+| post | AccessorCalls.cs:15:9:15:23 | ... += ... | AccessorCalls.cs:15:9:15:18 | access to event Event |
 | post | AccessorCalls.cs:15:9:15:24 | ...; | AccessorCalls.cs:14:9:14:25 | ... = ... |
-| post | AccessorCalls.cs:15:23:15:23 | access to parameter e | AccessorCalls.cs:15:9:15:18 | access to event Event |
+| post | AccessorCalls.cs:15:23:15:23 | access to parameter e | AccessorCalls.cs:15:9:15:12 | this access |
 | post | AccessorCalls.cs:16:9:16:12 | this access | AccessorCalls.cs:16:9:16:24 | ...; |
-| post | AccessorCalls.cs:16:9:16:18 | access to event Event | AccessorCalls.cs:16:9:16:12 | this access |
-| post | AccessorCalls.cs:16:9:16:23 | ... -= ... | AccessorCalls.cs:16:23:16:23 | access to parameter e |
+| post | AccessorCalls.cs:16:9:16:18 | access to event Event | AccessorCalls.cs:16:23:16:23 | access to parameter e |
+| post | AccessorCalls.cs:16:9:16:23 | ... -= ... | AccessorCalls.cs:16:9:16:18 | access to event Event |
 | post | AccessorCalls.cs:16:9:16:24 | ...; | AccessorCalls.cs:15:9:15:23 | ... += ... |
-| post | AccessorCalls.cs:16:23:16:23 | access to parameter e | AccessorCalls.cs:16:9:16:18 | access to event Event |
+| post | AccessorCalls.cs:16:23:16:23 | access to parameter e | AccessorCalls.cs:16:9:16:12 | this access |
 | post | AccessorCalls.cs:19:10:19:11 | exit M2 | AccessorCalls.cs:25:9:25:25 | ... -= ... |
 | post | AccessorCalls.cs:20:5:26:5 | {...} | AccessorCalls.cs:19:10:19:11 | enter M2 |
 | post | AccessorCalls.cs:21:9:21:12 | this access | AccessorCalls.cs:21:9:21:36 | ...; |
 | post | AccessorCalls.cs:21:9:21:14 | access to field x | AccessorCalls.cs:21:9:21:12 | this access |
-| post | AccessorCalls.cs:21:9:21:20 | access to field Field | AccessorCalls.cs:21:9:21:14 | access to field x |
 | post | AccessorCalls.cs:21:9:21:35 | ... = ... | AccessorCalls.cs:21:24:21:35 | access to field Field |
 | post | AccessorCalls.cs:21:9:21:36 | ...; | AccessorCalls.cs:20:5:26:5 | {...} |
-| post | AccessorCalls.cs:21:24:21:27 | this access | AccessorCalls.cs:21:9:21:20 | access to field Field |
+| post | AccessorCalls.cs:21:24:21:27 | this access | AccessorCalls.cs:21:9:21:14 | access to field x |
 | post | AccessorCalls.cs:21:24:21:29 | access to field x | AccessorCalls.cs:21:24:21:27 | this access |
 | post | AccessorCalls.cs:21:24:21:35 | access to field Field | AccessorCalls.cs:21:24:21:29 | access to field x |
 | post | AccessorCalls.cs:22:9:22:12 | this access | AccessorCalls.cs:22:9:22:34 | ...; |
 | post | AccessorCalls.cs:22:9:22:14 | access to field x | AccessorCalls.cs:22:9:22:12 | this access |
-| post | AccessorCalls.cs:22:9:22:19 | access to property Prop | AccessorCalls.cs:22:9:22:14 | access to field x |
-| post | AccessorCalls.cs:22:9:22:33 | ... = ... | AccessorCalls.cs:22:23:22:33 | access to property Prop |
+| post | AccessorCalls.cs:22:9:22:19 | access to property Prop | AccessorCalls.cs:22:23:22:33 | access to property Prop |
+| post | AccessorCalls.cs:22:9:22:33 | ... = ... | AccessorCalls.cs:22:9:22:19 | access to property Prop |
 | post | AccessorCalls.cs:22:9:22:34 | ...; | AccessorCalls.cs:21:9:21:35 | ... = ... |
-| post | AccessorCalls.cs:22:23:22:26 | this access | AccessorCalls.cs:22:9:22:19 | access to property Prop |
+| post | AccessorCalls.cs:22:23:22:26 | this access | AccessorCalls.cs:22:9:22:14 | access to field x |
 | post | AccessorCalls.cs:22:23:22:28 | access to field x | AccessorCalls.cs:22:23:22:26 | this access |
 | post | AccessorCalls.cs:22:23:22:33 | access to property Prop | AccessorCalls.cs:22:23:22:28 | access to field x |
 | post | AccessorCalls.cs:23:9:23:12 | this access | AccessorCalls.cs:23:9:23:30 | ...; |
 | post | AccessorCalls.cs:23:9:23:14 | access to field x | AccessorCalls.cs:23:9:23:12 | this access |
-| post | AccessorCalls.cs:23:9:23:17 | access to indexer | AccessorCalls.cs:23:16:23:16 | 0 |
-| post | AccessorCalls.cs:23:9:23:29 | ... = ... | AccessorCalls.cs:23:21:23:29 | access to indexer |
+| post | AccessorCalls.cs:23:9:23:17 | access to indexer | AccessorCalls.cs:23:21:23:29 | access to indexer |
+| post | AccessorCalls.cs:23:9:23:29 | ... = ... | AccessorCalls.cs:23:9:23:17 | access to indexer |
 | post | AccessorCalls.cs:23:9:23:30 | ...; | AccessorCalls.cs:22:9:22:33 | ... = ... |
 | post | AccessorCalls.cs:23:16:23:16 | 0 | AccessorCalls.cs:23:9:23:14 | access to field x |
-| post | AccessorCalls.cs:23:21:23:24 | this access | AccessorCalls.cs:23:9:23:17 | access to indexer |
+| post | AccessorCalls.cs:23:21:23:24 | this access | AccessorCalls.cs:23:16:23:16 | 0 |
 | post | AccessorCalls.cs:23:21:23:26 | access to field x | AccessorCalls.cs:23:21:23:24 | this access |
 | post | AccessorCalls.cs:23:21:23:29 | access to indexer | AccessorCalls.cs:23:28:23:28 | 1 |
 | post | AccessorCalls.cs:23:28:23:28 | 1 | AccessorCalls.cs:23:21:23:26 | access to field x |
 | post | AccessorCalls.cs:24:9:24:12 | this access | AccessorCalls.cs:24:9:24:26 | ...; |
 | post | AccessorCalls.cs:24:9:24:14 | access to field x | AccessorCalls.cs:24:9:24:12 | this access |
-| post | AccessorCalls.cs:24:9:24:20 | access to event Event | AccessorCalls.cs:24:9:24:14 | access to field x |
-| post | AccessorCalls.cs:24:9:24:25 | ... += ... | AccessorCalls.cs:24:25:24:25 | access to parameter e |
+| post | AccessorCalls.cs:24:9:24:20 | access to event Event | AccessorCalls.cs:24:25:24:25 | access to parameter e |
+| post | AccessorCalls.cs:24:9:24:25 | ... += ... | AccessorCalls.cs:24:9:24:20 | access to event Event |
 | post | AccessorCalls.cs:24:9:24:26 | ...; | AccessorCalls.cs:23:9:23:29 | ... = ... |
-| post | AccessorCalls.cs:24:25:24:25 | access to parameter e | AccessorCalls.cs:24:9:24:20 | access to event Event |
+| post | AccessorCalls.cs:24:25:24:25 | access to parameter e | AccessorCalls.cs:24:9:24:14 | access to field x |
 | post | AccessorCalls.cs:25:9:25:12 | this access | AccessorCalls.cs:25:9:25:26 | ...; |
 | post | AccessorCalls.cs:25:9:25:14 | access to field x | AccessorCalls.cs:25:9:25:12 | this access |
-| post | AccessorCalls.cs:25:9:25:20 | access to event Event | AccessorCalls.cs:25:9:25:14 | access to field x |
-| post | AccessorCalls.cs:25:9:25:25 | ... -= ... | AccessorCalls.cs:25:25:25:25 | access to parameter e |
+| post | AccessorCalls.cs:25:9:25:20 | access to event Event | AccessorCalls.cs:25:25:25:25 | access to parameter e |
+| post | AccessorCalls.cs:25:9:25:25 | ... -= ... | AccessorCalls.cs:25:9:25:20 | access to event Event |
 | post | AccessorCalls.cs:25:9:25:26 | ...; | AccessorCalls.cs:24:9:24:25 | ... += ... |
-| post | AccessorCalls.cs:25:25:25:25 | access to parameter e | AccessorCalls.cs:25:9:25:20 | access to event Event |
+| post | AccessorCalls.cs:25:25:25:25 | access to parameter e | AccessorCalls.cs:25:9:25:14 | access to field x |
 | post | AccessorCalls.cs:28:10:28:11 | exit M3 | AccessorCalls.cs:32:9:32:17 | ...++ |
 | post | AccessorCalls.cs:29:5:33:5 | {...} | AccessorCalls.cs:28:10:28:11 | enter M3 |
 | post | AccessorCalls.cs:30:9:30:12 | this access | AccessorCalls.cs:30:9:30:21 | ...; |
@@ -113,30 +111,29 @@
 | post | AccessorCalls.cs:39:16:39:16 | 0 | AccessorCalls.cs:39:9:39:14 | access to field x |
 | post | AccessorCalls.cs:42:10:42:11 | exit M5 | AccessorCalls.cs:46:9:46:26 | ... = ... |
 | post | AccessorCalls.cs:43:5:47:5 | {...} | AccessorCalls.cs:42:10:42:11 | enter M5 |
-| post | AccessorCalls.cs:44:9:44:12 | this access | AccessorCalls.cs:44:9:44:18 | access to field Field |
+| post | AccessorCalls.cs:44:9:44:12 | this access | AccessorCalls.cs:44:9:44:12 | this access |
 | post | AccessorCalls.cs:44:9:44:12 | this access | AccessorCalls.cs:44:9:44:33 | ...; |
-| post | AccessorCalls.cs:44:9:44:18 | access to field Field | AccessorCalls.cs:44:9:44:12 | this access |
 | post | AccessorCalls.cs:44:9:44:18 | access to field Field | AccessorCalls.cs:44:9:44:12 | this access |
 | post | AccessorCalls.cs:44:9:44:32 | ... + ... | AccessorCalls.cs:44:23:44:32 | access to field Field |
 | post | AccessorCalls.cs:44:9:44:32 | ... = ... | AccessorCalls.cs:44:9:44:32 | ... + ... |
 | post | AccessorCalls.cs:44:9:44:33 | ...; | AccessorCalls.cs:43:5:47:5 | {...} |
 | post | AccessorCalls.cs:44:23:44:26 | this access | AccessorCalls.cs:44:9:44:18 | access to field Field |
 | post | AccessorCalls.cs:44:23:44:32 | access to field Field | AccessorCalls.cs:44:23:44:26 | this access |
-| post | AccessorCalls.cs:45:9:45:12 | this access | AccessorCalls.cs:45:9:45:17 | access to property Prop |
+| post | AccessorCalls.cs:45:9:45:12 | this access | AccessorCalls.cs:45:9:45:12 | this access |
 | post | AccessorCalls.cs:45:9:45:12 | this access | AccessorCalls.cs:45:9:45:31 | ...; |
 | post | AccessorCalls.cs:45:9:45:17 | access to property Prop | AccessorCalls.cs:45:9:45:12 | this access |
-| post | AccessorCalls.cs:45:9:45:17 | access to property Prop | AccessorCalls.cs:45:9:45:12 | this access |
+| post | AccessorCalls.cs:45:9:45:17 | access to property Prop | AccessorCalls.cs:45:9:45:30 | ... + ... |
 | post | AccessorCalls.cs:45:9:45:30 | ... + ... | AccessorCalls.cs:45:22:45:30 | access to property Prop |
-| post | AccessorCalls.cs:45:9:45:30 | ... = ... | AccessorCalls.cs:45:9:45:30 | ... + ... |
+| post | AccessorCalls.cs:45:9:45:30 | ... = ... | AccessorCalls.cs:45:9:45:17 | access to property Prop |
 | post | AccessorCalls.cs:45:9:45:31 | ...; | AccessorCalls.cs:44:9:44:32 | ... = ... |
 | post | AccessorCalls.cs:45:22:45:25 | this access | AccessorCalls.cs:45:9:45:17 | access to property Prop |
 | post | AccessorCalls.cs:45:22:45:30 | access to property Prop | AccessorCalls.cs:45:22:45:25 | this access |
-| post | AccessorCalls.cs:46:9:46:12 | this access | AccessorCalls.cs:46:9:46:15 | access to indexer |
 | post | AccessorCalls.cs:46:9:46:12 | this access | AccessorCalls.cs:46:9:46:27 | ...; |
-| post | AccessorCalls.cs:46:9:46:15 | access to indexer | AccessorCalls.cs:46:14:46:14 | 0 |
+| post | AccessorCalls.cs:46:9:46:12 | this access | AccessorCalls.cs:46:14:46:14 | 0 |
+| post | AccessorCalls.cs:46:9:46:15 | access to indexer | AccessorCalls.cs:46:9:46:26 | ... + ... |
 | post | AccessorCalls.cs:46:9:46:15 | access to indexer | AccessorCalls.cs:46:14:46:14 | 0 |
 | post | AccessorCalls.cs:46:9:46:26 | ... + ... | AccessorCalls.cs:46:20:46:26 | access to indexer |
-| post | AccessorCalls.cs:46:9:46:26 | ... = ... | AccessorCalls.cs:46:9:46:26 | ... + ... |
+| post | AccessorCalls.cs:46:9:46:26 | ... = ... | AccessorCalls.cs:46:9:46:15 | access to indexer |
 | post | AccessorCalls.cs:46:9:46:27 | ...; | AccessorCalls.cs:45:9:45:30 | ... = ... |
 | post | AccessorCalls.cs:46:14:46:14 | 0 | AccessorCalls.cs:46:9:46:12 | this access |
 | post | AccessorCalls.cs:46:14:46:14 | 0 | AccessorCalls.cs:46:9:46:12 | this access |
@@ -145,11 +142,10 @@
 | post | AccessorCalls.cs:46:25:46:25 | 0 | AccessorCalls.cs:46:20:46:23 | this access |
 | post | AccessorCalls.cs:49:10:49:11 | exit M6 | AccessorCalls.cs:53:9:53:30 | ... = ... |
 | post | AccessorCalls.cs:50:5:54:5 | {...} | AccessorCalls.cs:49:10:49:11 | enter M6 |
-| post | AccessorCalls.cs:51:9:51:12 | this access | AccessorCalls.cs:51:9:51:20 | access to field Field |
+| post | AccessorCalls.cs:51:9:51:12 | this access | AccessorCalls.cs:51:9:51:14 | access to field x |
 | post | AccessorCalls.cs:51:9:51:12 | this access | AccessorCalls.cs:51:9:51:37 | ...; |
 | post | AccessorCalls.cs:51:9:51:14 | access to field x | AccessorCalls.cs:51:9:51:12 | this access |
 | post | AccessorCalls.cs:51:9:51:14 | access to field x | AccessorCalls.cs:51:9:51:12 | this access |
-| post | AccessorCalls.cs:51:9:51:20 | access to field Field | AccessorCalls.cs:51:9:51:14 | access to field x |
 | post | AccessorCalls.cs:51:9:51:20 | access to field Field | AccessorCalls.cs:51:9:51:14 | access to field x |
 | post | AccessorCalls.cs:51:9:51:36 | ... + ... | AccessorCalls.cs:51:25:51:36 | access to field Field |
 | post | AccessorCalls.cs:51:9:51:36 | ... = ... | AccessorCalls.cs:51:9:51:36 | ... + ... |
@@ -157,26 +153,26 @@
 | post | AccessorCalls.cs:51:25:51:28 | this access | AccessorCalls.cs:51:9:51:20 | access to field Field |
 | post | AccessorCalls.cs:51:25:51:30 | access to field x | AccessorCalls.cs:51:25:51:28 | this access |
 | post | AccessorCalls.cs:51:25:51:36 | access to field Field | AccessorCalls.cs:51:25:51:30 | access to field x |
-| post | AccessorCalls.cs:52:9:52:12 | this access | AccessorCalls.cs:52:9:52:19 | access to property Prop |
+| post | AccessorCalls.cs:52:9:52:12 | this access | AccessorCalls.cs:52:9:52:14 | access to field x |
 | post | AccessorCalls.cs:52:9:52:12 | this access | AccessorCalls.cs:52:9:52:35 | ...; |
 | post | AccessorCalls.cs:52:9:52:14 | access to field x | AccessorCalls.cs:52:9:52:12 | this access |
 | post | AccessorCalls.cs:52:9:52:14 | access to field x | AccessorCalls.cs:52:9:52:12 | this access |
 | post | AccessorCalls.cs:52:9:52:19 | access to property Prop | AccessorCalls.cs:52:9:52:14 | access to field x |
-| post | AccessorCalls.cs:52:9:52:19 | access to property Prop | AccessorCalls.cs:52:9:52:14 | access to field x |
+| post | AccessorCalls.cs:52:9:52:19 | access to property Prop | AccessorCalls.cs:52:9:52:34 | ... + ... |
 | post | AccessorCalls.cs:52:9:52:34 | ... + ... | AccessorCalls.cs:52:24:52:34 | access to property Prop |
-| post | AccessorCalls.cs:52:9:52:34 | ... = ... | AccessorCalls.cs:52:9:52:34 | ... + ... |
+| post | AccessorCalls.cs:52:9:52:34 | ... = ... | AccessorCalls.cs:52:9:52:19 | access to property Prop |
 | post | AccessorCalls.cs:52:9:52:35 | ...; | AccessorCalls.cs:51:9:51:36 | ... = ... |
 | post | AccessorCalls.cs:52:24:52:27 | this access | AccessorCalls.cs:52:9:52:19 | access to property Prop |
 | post | AccessorCalls.cs:52:24:52:29 | access to field x | AccessorCalls.cs:52:24:52:27 | this access |
 | post | AccessorCalls.cs:52:24:52:34 | access to property Prop | AccessorCalls.cs:52:24:52:29 | access to field x |
-| post | AccessorCalls.cs:53:9:53:12 | this access | AccessorCalls.cs:53:9:53:17 | access to indexer |
 | post | AccessorCalls.cs:53:9:53:12 | this access | AccessorCalls.cs:53:9:53:31 | ...; |
+| post | AccessorCalls.cs:53:9:53:12 | this access | AccessorCalls.cs:53:16:53:16 | 0 |
 | post | AccessorCalls.cs:53:9:53:14 | access to field x | AccessorCalls.cs:53:9:53:12 | this access |
 | post | AccessorCalls.cs:53:9:53:14 | access to field x | AccessorCalls.cs:53:9:53:12 | this access |
-| post | AccessorCalls.cs:53:9:53:17 | access to indexer | AccessorCalls.cs:53:16:53:16 | 0 |
+| post | AccessorCalls.cs:53:9:53:17 | access to indexer | AccessorCalls.cs:53:9:53:30 | ... + ... |
 | post | AccessorCalls.cs:53:9:53:17 | access to indexer | AccessorCalls.cs:53:16:53:16 | 0 |
 | post | AccessorCalls.cs:53:9:53:30 | ... + ... | AccessorCalls.cs:53:22:53:30 | access to indexer |
-| post | AccessorCalls.cs:53:9:53:30 | ... = ... | AccessorCalls.cs:53:9:53:30 | ... + ... |
+| post | AccessorCalls.cs:53:9:53:30 | ... = ... | AccessorCalls.cs:53:9:53:17 | access to indexer |
 | post | AccessorCalls.cs:53:9:53:31 | ...; | AccessorCalls.cs:52:9:52:34 | ... = ... |
 | post | AccessorCalls.cs:53:16:53:16 | 0 | AccessorCalls.cs:53:9:53:14 | access to field x |
 | post | AccessorCalls.cs:53:16:53:16 | 0 | AccessorCalls.cs:53:9:53:14 | access to field x |
@@ -187,16 +183,14 @@
 | post | AccessorCalls.cs:56:10:56:11 | exit M7 | AccessorCalls.cs:58:9:58:85 | ... = ... |
 | post | AccessorCalls.cs:57:5:59:5 | {...} | AccessorCalls.cs:56:10:56:11 | enter M7 |
 | post | AccessorCalls.cs:58:9:58:45 | (..., ...) | AccessorCalls.cs:58:33:58:44 | (..., ...) |
-| post | AccessorCalls.cs:58:9:58:85 | ... = ... | AccessorCalls.cs:58:49:58:85 | (..., ...) |
+| post | AccessorCalls.cs:58:9:58:85 | ... = ... | AccessorCalls.cs:58:37:58:43 | access to indexer |
 | post | AccessorCalls.cs:58:9:58:86 | ...; | AccessorCalls.cs:57:5:59:5 | {...} |
 | post | AccessorCalls.cs:58:10:58:13 | this access | AccessorCalls.cs:58:9:58:86 | ...; |
-| post | AccessorCalls.cs:58:10:58:19 | access to field Field | AccessorCalls.cs:58:10:58:13 | this access |
-| post | AccessorCalls.cs:58:22:58:25 | this access | AccessorCalls.cs:58:10:58:19 | access to field Field |
-| post | AccessorCalls.cs:58:22:58:30 | access to property Prop | AccessorCalls.cs:58:22:58:25 | this access |
-| post | AccessorCalls.cs:58:33:58:44 | (..., ...) | AccessorCalls.cs:58:37:58:43 | access to indexer |
-| post | AccessorCalls.cs:58:34:58:34 | access to parameter i | AccessorCalls.cs:58:22:58:30 | access to property Prop |
-| post | AccessorCalls.cs:58:37:58:40 | this access | AccessorCalls.cs:58:34:58:34 | access to parameter i |
-| post | AccessorCalls.cs:58:37:58:43 | access to indexer | AccessorCalls.cs:58:42:58:42 | 0 |
+| post | AccessorCalls.cs:58:22:58:25 | this access | AccessorCalls.cs:58:10:58:13 | this access |
+| post | AccessorCalls.cs:58:22:58:30 | access to property Prop | AccessorCalls.cs:58:49:58:85 | (..., ...) |
+| post | AccessorCalls.cs:58:33:58:44 | (..., ...) | AccessorCalls.cs:58:42:58:42 | 0 |
+| post | AccessorCalls.cs:58:37:58:40 | this access | AccessorCalls.cs:58:22:58:25 | this access |
+| post | AccessorCalls.cs:58:37:58:43 | access to indexer | AccessorCalls.cs:58:22:58:30 | access to property Prop |
 | post | AccessorCalls.cs:58:42:58:42 | 0 | AccessorCalls.cs:58:37:58:40 | this access |
 | post | AccessorCalls.cs:58:49:58:85 | (..., ...) | AccessorCalls.cs:58:73:58:84 | (..., ...) |
 | post | AccessorCalls.cs:58:50:58:53 | this access | AccessorCalls.cs:58:9:58:45 | (..., ...) |
@@ -211,19 +205,17 @@
 | post | AccessorCalls.cs:61:10:61:11 | exit M8 | AccessorCalls.cs:63:9:63:97 | ... = ... |
 | post | AccessorCalls.cs:62:5:64:5 | {...} | AccessorCalls.cs:61:10:61:11 | enter M8 |
 | post | AccessorCalls.cs:63:9:63:51 | (..., ...) | AccessorCalls.cs:63:37:63:50 | (..., ...) |
-| post | AccessorCalls.cs:63:9:63:97 | ... = ... | AccessorCalls.cs:63:55:63:97 | (..., ...) |
+| post | AccessorCalls.cs:63:9:63:97 | ... = ... | AccessorCalls.cs:63:41:63:49 | access to indexer |
 | post | AccessorCalls.cs:63:9:63:98 | ...; | AccessorCalls.cs:62:5:64:5 | {...} |
 | post | AccessorCalls.cs:63:10:63:13 | this access | AccessorCalls.cs:63:9:63:98 | ...; |
 | post | AccessorCalls.cs:63:10:63:15 | access to field x | AccessorCalls.cs:63:10:63:13 | this access |
-| post | AccessorCalls.cs:63:10:63:21 | access to field Field | AccessorCalls.cs:63:10:63:15 | access to field x |
-| post | AccessorCalls.cs:63:24:63:27 | this access | AccessorCalls.cs:63:10:63:21 | access to field Field |
+| post | AccessorCalls.cs:63:24:63:27 | this access | AccessorCalls.cs:63:10:63:15 | access to field x |
 | post | AccessorCalls.cs:63:24:63:29 | access to field x | AccessorCalls.cs:63:24:63:27 | this access |
-| post | AccessorCalls.cs:63:24:63:34 | access to property Prop | AccessorCalls.cs:63:24:63:29 | access to field x |
-| post | AccessorCalls.cs:63:37:63:50 | (..., ...) | AccessorCalls.cs:63:41:63:49 | access to indexer |
-| post | AccessorCalls.cs:63:38:63:38 | access to parameter i | AccessorCalls.cs:63:24:63:34 | access to property Prop |
-| post | AccessorCalls.cs:63:41:63:44 | this access | AccessorCalls.cs:63:38:63:38 | access to parameter i |
+| post | AccessorCalls.cs:63:24:63:34 | access to property Prop | AccessorCalls.cs:63:55:63:97 | (..., ...) |
+| post | AccessorCalls.cs:63:37:63:50 | (..., ...) | AccessorCalls.cs:63:48:63:48 | 0 |
+| post | AccessorCalls.cs:63:41:63:44 | this access | AccessorCalls.cs:63:24:63:29 | access to field x |
 | post | AccessorCalls.cs:63:41:63:46 | access to field x | AccessorCalls.cs:63:41:63:44 | this access |
-| post | AccessorCalls.cs:63:41:63:49 | access to indexer | AccessorCalls.cs:63:48:63:48 | 0 |
+| post | AccessorCalls.cs:63:41:63:49 | access to indexer | AccessorCalls.cs:63:24:63:34 | access to property Prop |
 | post | AccessorCalls.cs:63:48:63:48 | 0 | AccessorCalls.cs:63:41:63:46 | access to field x |
 | post | AccessorCalls.cs:63:55:63:97 | (..., ...) | AccessorCalls.cs:63:83:63:96 | (..., ...) |
 | post | AccessorCalls.cs:63:56:63:59 | this access | AccessorCalls.cs:63:9:63:51 | (..., ...) |
@@ -262,41 +254,35 @@
 | post | Assignments.cs:3:10:3:10 | exit M | Assignments.cs:14:9:14:35 | ... += ... |
 | post | Assignments.cs:4:5:15:5 | {...} | Assignments.cs:3:10:3:10 | enter M |
 | post | Assignments.cs:5:9:5:18 | ... ...; | Assignments.cs:4:5:15:5 | {...} |
-| post | Assignments.cs:5:13:5:13 | access to local variable x | Assignments.cs:5:9:5:18 | ... ...; |
 | post | Assignments.cs:5:13:5:17 | Int32 x = ... | Assignments.cs:5:17:5:17 | 0 |
-| post | Assignments.cs:5:17:5:17 | 0 | Assignments.cs:5:13:5:13 | access to local variable x |
-| post | Assignments.cs:6:9:6:9 | access to local variable x | Assignments.cs:6:9:6:9 | access to local variable x |
+| post | Assignments.cs:5:17:5:17 | 0 | Assignments.cs:5:9:5:18 | ... ...; |
 | post | Assignments.cs:6:9:6:9 | access to local variable x | Assignments.cs:6:9:6:15 | ...; |
 | post | Assignments.cs:6:9:6:14 | ... + ... | Assignments.cs:6:14:6:14 | 1 |
 | post | Assignments.cs:6:9:6:14 | ... = ... | Assignments.cs:6:9:6:14 | ... + ... |
 | post | Assignments.cs:6:9:6:15 | ...; | Assignments.cs:5:13:5:17 | Int32 x = ... |
 | post | Assignments.cs:6:14:6:14 | 1 | Assignments.cs:6:9:6:9 | access to local variable x |
 | post | Assignments.cs:8:9:8:22 | ... ...; | Assignments.cs:6:9:6:14 | ... = ... |
-| post | Assignments.cs:8:17:8:17 | access to local variable d | Assignments.cs:8:9:8:22 | ... ...; |
 | post | Assignments.cs:8:17:8:21 | dynamic d = ... | Assignments.cs:8:21:8:21 | (...) ... |
-| post | Assignments.cs:8:21:8:21 | 0 | Assignments.cs:8:17:8:17 | access to local variable d |
+| post | Assignments.cs:8:21:8:21 | 0 | Assignments.cs:8:9:8:22 | ... ...; |
 | post | Assignments.cs:8:21:8:21 | (...) ... | Assignments.cs:8:21:8:21 | 0 |
-| post | Assignments.cs:9:9:9:9 | access to local variable d | Assignments.cs:9:9:9:9 | access to local variable d |
 | post | Assignments.cs:9:9:9:9 | access to local variable d | Assignments.cs:9:9:9:15 | ...; |
 | post | Assignments.cs:9:9:9:14 | ... = ... | Assignments.cs:9:9:9:14 | dynamic call to operator - |
 | post | Assignments.cs:9:9:9:14 | dynamic call to operator - | Assignments.cs:9:14:9:14 | 2 |
 | post | Assignments.cs:9:9:9:15 | ...; | Assignments.cs:8:17:8:21 | dynamic d = ... |
 | post | Assignments.cs:9:14:9:14 | 2 | Assignments.cs:9:9:9:9 | access to local variable d |
 | post | Assignments.cs:11:9:11:34 | ... ...; | Assignments.cs:9:9:9:14 | ... = ... |
-| post | Assignments.cs:11:13:11:13 | access to local variable a | Assignments.cs:11:9:11:34 | ... ...; |
 | post | Assignments.cs:11:13:11:33 | Assignments a = ... | Assignments.cs:11:17:11:33 | object creation of type Assignments |
-| post | Assignments.cs:11:17:11:33 | object creation of type Assignments | Assignments.cs:11:13:11:13 | access to local variable a |
-| post | Assignments.cs:12:9:12:9 | access to local variable a | Assignments.cs:12:9:12:9 | access to local variable a |
+| post | Assignments.cs:11:17:11:33 | object creation of type Assignments | Assignments.cs:11:9:11:34 | ... ...; |
 | post | Assignments.cs:12:9:12:9 | access to local variable a | Assignments.cs:12:9:12:18 | ...; |
 | post | Assignments.cs:12:9:12:17 | ... = ... | Assignments.cs:12:9:12:17 | call to operator + |
 | post | Assignments.cs:12:9:12:17 | call to operator + | Assignments.cs:12:14:12:17 | this access |
 | post | Assignments.cs:12:9:12:18 | ...; | Assignments.cs:11:13:11:33 | Assignments a = ... |
 | post | Assignments.cs:12:14:12:17 | this access | Assignments.cs:12:9:12:9 | access to local variable a |
-| post | Assignments.cs:14:9:14:13 | access to event Event | Assignments.cs:14:9:14:13 | this access |
+| post | Assignments.cs:14:9:14:13 | access to event Event | Assignments.cs:14:18:14:35 | (...) => ... |
 | post | Assignments.cs:14:9:14:13 | this access | Assignments.cs:14:9:14:36 | ...; |
-| post | Assignments.cs:14:9:14:35 | ... += ... | Assignments.cs:14:18:14:35 | (...) => ... |
+| post | Assignments.cs:14:9:14:35 | ... += ... | Assignments.cs:14:9:14:13 | access to event Event |
 | post | Assignments.cs:14:9:14:36 | ...; | Assignments.cs:12:9:12:17 | ... = ... |
-| post | Assignments.cs:14:18:14:35 | (...) => ... | Assignments.cs:14:9:14:13 | access to event Event |
+| post | Assignments.cs:14:18:14:35 | (...) => ... | Assignments.cs:14:9:14:13 | this access |
 | post | Assignments.cs:14:18:14:35 | exit (...) => ... | Assignments.cs:14:33:14:35 | {...} |
 | post | Assignments.cs:14:33:14:35 | {...} | Assignments.cs:14:18:14:35 | enter (...) => ... |
 | post | Assignments.cs:17:40:17:40 | exit + | Assignments.cs:19:9:19:17 | return ...; |
@@ -562,20 +548,17 @@
 | post | ConditionalAccess.cs:21:10:21:11 | exit M7 | ConditionalAccess.cs:25:9:25:32 | ... = ... |
 | post | ConditionalAccess.cs:22:5:26:5 | {...} | ConditionalAccess.cs:21:10:21:11 | enter M7 |
 | post | ConditionalAccess.cs:23:9:23:39 | ... ...; | ConditionalAccess.cs:22:5:26:5 | {...} |
-| post | ConditionalAccess.cs:23:13:23:13 | access to local variable j | ConditionalAccess.cs:23:9:23:39 | ... ...; |
 | post | ConditionalAccess.cs:23:13:23:38 | Nullable<Int32> j = ... | ConditionalAccess.cs:23:18:23:29 | (...) ... |
 | post | ConditionalAccess.cs:23:18:23:29 | (...) ... | ConditionalAccess.cs:23:26:23:29 | null |
-| post | ConditionalAccess.cs:23:26:23:29 | null | ConditionalAccess.cs:23:13:23:13 | access to local variable j |
+| post | ConditionalAccess.cs:23:26:23:29 | null | ConditionalAccess.cs:23:9:23:39 | ... ...; |
 | post | ConditionalAccess.cs:24:9:24:38 | ... ...; | ConditionalAccess.cs:23:13:23:38 | Nullable<Int32> j = ... |
-| post | ConditionalAccess.cs:24:13:24:13 | access to local variable s | ConditionalAccess.cs:24:9:24:38 | ... ...; |
 | post | ConditionalAccess.cs:24:13:24:37 | String s = ... | ConditionalAccess.cs:24:27:24:37 | call to method ToString |
 | post | ConditionalAccess.cs:24:18:24:24 | (...) ... | ConditionalAccess.cs:24:24:24:24 | access to parameter i |
-| post | ConditionalAccess.cs:24:24:24:24 | access to parameter i | ConditionalAccess.cs:24:13:24:13 | access to local variable s |
+| post | ConditionalAccess.cs:24:24:24:24 | access to parameter i | ConditionalAccess.cs:24:9:24:38 | ... ...; |
 | post | ConditionalAccess.cs:24:27:24:37 | call to method ToString | ConditionalAccess.cs:24:18:24:24 | (...) ... |
-| post | ConditionalAccess.cs:25:9:25:9 | access to local variable s | ConditionalAccess.cs:25:9:25:33 | ...; |
 | post | ConditionalAccess.cs:25:9:25:32 | ... = ... | ConditionalAccess.cs:25:16:25:32 | call to method CommaJoinWith |
 | post | ConditionalAccess.cs:25:9:25:33 | ...; | ConditionalAccess.cs:24:13:24:37 | String s = ... |
-| post | ConditionalAccess.cs:25:13:25:14 | "" | ConditionalAccess.cs:25:9:25:9 | access to local variable s |
+| post | ConditionalAccess.cs:25:13:25:14 | "" | ConditionalAccess.cs:25:9:25:33 | ...; |
 | post | ConditionalAccess.cs:25:16:25:32 | call to method CommaJoinWith | ConditionalAccess.cs:25:31:25:31 | access to local variable s |
 | post | ConditionalAccess.cs:25:31:25:31 | access to local variable s | ConditionalAccess.cs:25:13:25:14 | "" |
 | post | ConditionalAccess.cs:31:26:31:38 | exit CommaJoinWith | ConditionalAccess.cs:31:70:31:83 | ... + ... |
@@ -602,9 +585,8 @@
 | post | Conditions.cs:11:9:11:10 | exit M1 | Conditions.cs:19:9:19:17 | return ...; |
 | post | Conditions.cs:12:5:20:5 | {...} | Conditions.cs:11:9:11:10 | enter M1 |
 | post | Conditions.cs:13:9:13:18 | ... ...; | Conditions.cs:12:5:20:5 | {...} |
-| post | Conditions.cs:13:13:13:13 | access to local variable x | Conditions.cs:13:9:13:18 | ... ...; |
 | post | Conditions.cs:13:13:13:17 | Int32 x = ... | Conditions.cs:13:17:13:17 | 0 |
-| post | Conditions.cs:13:17:13:17 | 0 | Conditions.cs:13:13:13:13 | access to local variable x |
+| post | Conditions.cs:13:17:13:17 | 0 | Conditions.cs:13:9:13:18 | ... ...; |
 | post | Conditions.cs:14:9:15:16 | if (...) ... | Conditions.cs:13:13:13:17 | Int32 x = ... |
 | post | Conditions.cs:14:13:14:13 | access to parameter b | Conditions.cs:14:9:15:16 | if (...) ... |
 | post | Conditions.cs:15:13:15:13 | [b (line 11): true] access to local variable x | Conditions.cs:15:13:15:16 | [b (line 11): true] ...; |
@@ -631,9 +613,8 @@
 | post | Conditions.cs:22:9:22:10 | exit M2 | Conditions.cs:30:9:30:17 | return ...; |
 | post | Conditions.cs:23:5:31:5 | {...} | Conditions.cs:22:9:22:10 | enter M2 |
 | post | Conditions.cs:24:9:24:18 | ... ...; | Conditions.cs:23:5:31:5 | {...} |
-| post | Conditions.cs:24:13:24:13 | access to local variable x | Conditions.cs:24:9:24:18 | ... ...; |
 | post | Conditions.cs:24:13:24:17 | Int32 x = ... | Conditions.cs:24:17:24:17 | 0 |
-| post | Conditions.cs:24:17:24:17 | 0 | Conditions.cs:24:13:24:13 | access to local variable x |
+| post | Conditions.cs:24:17:24:17 | 0 | Conditions.cs:24:9:24:18 | ... ...; |
 | post | Conditions.cs:25:9:27:20 | if (...) ... | Conditions.cs:24:13:24:17 | Int32 x = ... |
 | post | Conditions.cs:25:13:25:14 | access to parameter b1 | Conditions.cs:25:9:27:20 | if (...) ... |
 | post | Conditions.cs:26:17:26:18 | access to parameter b2 | Conditions.cs:26:13:27:20 | if (...) ... |
@@ -653,18 +634,15 @@
 | post | Conditions.cs:33:9:33:10 | exit M3 | Conditions.cs:43:9:43:17 | return ...; |
 | post | Conditions.cs:34:5:44:5 | {...} | Conditions.cs:33:9:33:10 | enter M3 |
 | post | Conditions.cs:35:9:35:18 | ... ...; | Conditions.cs:34:5:44:5 | {...} |
-| post | Conditions.cs:35:13:35:13 | access to local variable x | Conditions.cs:35:9:35:18 | ... ...; |
 | post | Conditions.cs:35:13:35:17 | Int32 x = ... | Conditions.cs:35:17:35:17 | 0 |
-| post | Conditions.cs:35:17:35:17 | 0 | Conditions.cs:35:13:35:13 | access to local variable x |
+| post | Conditions.cs:35:17:35:17 | 0 | Conditions.cs:35:9:35:18 | ... ...; |
 | post | Conditions.cs:36:9:36:23 | ... ...; | Conditions.cs:35:13:35:17 | Int32 x = ... |
-| post | Conditions.cs:36:13:36:14 | access to local variable b2 | Conditions.cs:36:9:36:23 | ... ...; |
 | post | Conditions.cs:36:13:36:22 | Boolean b2 = ... | Conditions.cs:36:18:36:22 | false |
-| post | Conditions.cs:36:18:36:22 | false | Conditions.cs:36:13:36:14 | access to local variable b2 |
+| post | Conditions.cs:36:18:36:22 | false | Conditions.cs:36:9:36:23 | ... ...; |
 | post | Conditions.cs:37:9:38:20 | if (...) ... | Conditions.cs:36:13:36:22 | Boolean b2 = ... |
 | post | Conditions.cs:37:13:37:14 | access to parameter b1 | Conditions.cs:37:9:38:20 | if (...) ... |
-| post | Conditions.cs:38:13:38:14 | access to local variable b2 | Conditions.cs:38:13:38:20 | ...; |
 | post | Conditions.cs:38:13:38:19 | ... = ... | Conditions.cs:38:18:38:19 | access to parameter b1 |
-| post | Conditions.cs:38:18:38:19 | access to parameter b1 | Conditions.cs:38:13:38:14 | access to local variable b2 |
+| post | Conditions.cs:38:18:38:19 | access to parameter b1 | Conditions.cs:38:13:38:20 | ...; |
 | post | Conditions.cs:39:9:40:16 | if (...) ... | Conditions.cs:37:13:37:14 | access to parameter b1 |
 | post | Conditions.cs:39:9:40:16 | if (...) ... | Conditions.cs:38:13:38:19 | ... = ... |
 | post | Conditions.cs:39:13:39:14 | access to local variable b2 | Conditions.cs:39:9:40:16 | if (...) ... |
@@ -682,9 +660,8 @@
 | post | Conditions.cs:46:9:46:10 | exit M4 | Conditions.cs:54:9:54:17 | return ...; |
 | post | Conditions.cs:47:5:55:5 | {...} | Conditions.cs:46:9:46:10 | enter M4 |
 | post | Conditions.cs:48:9:48:18 | ... ...; | Conditions.cs:47:5:55:5 | {...} |
-| post | Conditions.cs:48:13:48:13 | access to local variable y | Conditions.cs:48:9:48:18 | ... ...; |
 | post | Conditions.cs:48:13:48:17 | Int32 y = ... | Conditions.cs:48:17:48:17 | 0 |
-| post | Conditions.cs:48:17:48:17 | 0 | Conditions.cs:48:13:48:13 | access to local variable y |
+| post | Conditions.cs:48:17:48:17 | 0 | Conditions.cs:48:9:48:18 | ... ...; |
 | post | Conditions.cs:49:9:53:9 | while (...) ... | Conditions.cs:48:13:48:17 | Int32 y = ... |
 | post | Conditions.cs:49:16:49:16 | [b (line 46): false] access to parameter x | Conditions.cs:51:17:51:17 | [b (line 46): false] access to parameter b |
 | post | Conditions.cs:49:16:49:16 | [b (line 46): true] access to parameter x | Conditions.cs:52:17:52:19 | [b (line 46): true] ...++ |
@@ -714,9 +691,8 @@
 | post | Conditions.cs:57:9:57:10 | exit M5 | Conditions.cs:67:9:67:17 | return ...; |
 | post | Conditions.cs:58:5:68:5 | {...} | Conditions.cs:57:9:57:10 | enter M5 |
 | post | Conditions.cs:59:9:59:18 | ... ...; | Conditions.cs:58:5:68:5 | {...} |
-| post | Conditions.cs:59:13:59:13 | access to local variable y | Conditions.cs:59:9:59:18 | ... ...; |
 | post | Conditions.cs:59:13:59:17 | Int32 y = ... | Conditions.cs:59:17:59:17 | 0 |
-| post | Conditions.cs:59:17:59:17 | 0 | Conditions.cs:59:13:59:13 | access to local variable y |
+| post | Conditions.cs:59:17:59:17 | 0 | Conditions.cs:59:9:59:18 | ... ...; |
 | post | Conditions.cs:60:9:64:9 | while (...) ... | Conditions.cs:59:13:59:17 | Int32 y = ... |
 | post | Conditions.cs:60:16:60:16 | [b (line 57): false] access to parameter x | Conditions.cs:62:17:62:17 | [b (line 57): false] access to parameter b |
 | post | Conditions.cs:60:16:60:16 | [b (line 57): true] access to parameter x | Conditions.cs:63:17:63:19 | [b (line 57): true] ...++ |
@@ -754,16 +730,14 @@
 | post | Conditions.cs:70:9:70:10 | exit M6 | Conditions.cs:83:9:83:17 | return ...; |
 | post | Conditions.cs:71:5:84:5 | {...} | Conditions.cs:70:9:70:10 | enter M6 |
 | post | Conditions.cs:72:9:72:30 | ... ...; | Conditions.cs:71:5:84:5 | {...} |
-| post | Conditions.cs:72:13:72:13 | access to local variable b | Conditions.cs:72:9:72:30 | ... ...; |
 | post | Conditions.cs:72:13:72:29 | Boolean b = ... | Conditions.cs:72:17:72:29 | ... > ... |
-| post | Conditions.cs:72:17:72:18 | access to parameter ss | Conditions.cs:72:13:72:13 | access to local variable b |
+| post | Conditions.cs:72:17:72:18 | access to parameter ss | Conditions.cs:72:9:72:30 | ... ...; |
 | post | Conditions.cs:72:17:72:25 | access to property Length | Conditions.cs:72:17:72:18 | access to parameter ss |
 | post | Conditions.cs:72:17:72:29 | ... > ... | Conditions.cs:72:29:72:29 | 0 |
 | post | Conditions.cs:72:29:72:29 | 0 | Conditions.cs:72:17:72:25 | access to property Length |
 | post | Conditions.cs:73:9:73:18 | ... ...; | Conditions.cs:72:13:72:29 | Boolean b = ... |
-| post | Conditions.cs:73:13:73:13 | access to local variable x | Conditions.cs:73:9:73:18 | ... ...; |
 | post | Conditions.cs:73:13:73:17 | Int32 x = ... | Conditions.cs:73:17:73:17 | 0 |
-| post | Conditions.cs:73:17:73:17 | 0 | Conditions.cs:73:13:73:13 | access to local variable x |
+| post | Conditions.cs:73:17:73:17 | 0 | Conditions.cs:73:9:73:18 | ... ...; |
 | post | Conditions.cs:74:9:80:9 | foreach (... ... in ...) ... | Conditions.cs:74:27:74:28 | access to parameter ss |
 | post | Conditions.cs:74:9:80:9 | foreach (... ... in ...) ... | Conditions.cs:78:17:78:21 | ... > ... |
 | post | Conditions.cs:74:9:80:9 | foreach (... ... in ...) ... | Conditions.cs:79:17:79:25 | ... = ... |
@@ -777,9 +751,8 @@
 | post | Conditions.cs:78:17:78:17 | access to local variable x | Conditions.cs:78:13:79:26 | if (...) ... |
 | post | Conditions.cs:78:17:78:21 | ... > ... | Conditions.cs:78:21:78:21 | 0 |
 | post | Conditions.cs:78:21:78:21 | 0 | Conditions.cs:78:17:78:17 | access to local variable x |
-| post | Conditions.cs:79:17:79:17 | access to local variable b | Conditions.cs:79:17:79:26 | ...; |
 | post | Conditions.cs:79:17:79:25 | ... = ... | Conditions.cs:79:21:79:25 | false |
-| post | Conditions.cs:79:21:79:25 | false | Conditions.cs:79:17:79:17 | access to local variable b |
+| post | Conditions.cs:79:21:79:25 | false | Conditions.cs:79:17:79:26 | ...; |
 | post | Conditions.cs:81:9:82:16 | if (...) ... | Conditions.cs:74:9:80:9 | foreach (... ... in ...) ... |
 | post | Conditions.cs:81:12:81:12 | access to local variable b | Conditions.cs:81:9:82:16 | if (...) ... |
 | post | Conditions.cs:82:13:82:13 | access to local variable x | Conditions.cs:82:13:82:16 | ...; |
@@ -790,16 +763,14 @@
 | post | Conditions.cs:86:9:86:10 | exit M7 | Conditions.cs:99:9:99:17 | return ...; |
 | post | Conditions.cs:87:5:100:5 | {...} | Conditions.cs:86:9:86:10 | enter M7 |
 | post | Conditions.cs:88:9:88:30 | ... ...; | Conditions.cs:87:5:100:5 | {...} |
-| post | Conditions.cs:88:13:88:13 | access to local variable b | Conditions.cs:88:9:88:30 | ... ...; |
 | post | Conditions.cs:88:13:88:29 | Boolean b = ... | Conditions.cs:88:17:88:29 | ... > ... |
-| post | Conditions.cs:88:17:88:18 | access to parameter ss | Conditions.cs:88:13:88:13 | access to local variable b |
+| post | Conditions.cs:88:17:88:18 | access to parameter ss | Conditions.cs:88:9:88:30 | ... ...; |
 | post | Conditions.cs:88:17:88:25 | access to property Length | Conditions.cs:88:17:88:18 | access to parameter ss |
 | post | Conditions.cs:88:17:88:29 | ... > ... | Conditions.cs:88:29:88:29 | 0 |
 | post | Conditions.cs:88:29:88:29 | 0 | Conditions.cs:88:17:88:25 | access to property Length |
 | post | Conditions.cs:89:9:89:18 | ... ...; | Conditions.cs:88:13:88:29 | Boolean b = ... |
-| post | Conditions.cs:89:13:89:13 | access to local variable x | Conditions.cs:89:9:89:18 | ... ...; |
 | post | Conditions.cs:89:13:89:17 | Int32 x = ... | Conditions.cs:89:17:89:17 | 0 |
-| post | Conditions.cs:89:17:89:17 | 0 | Conditions.cs:89:13:89:13 | access to local variable x |
+| post | Conditions.cs:89:17:89:17 | 0 | Conditions.cs:89:9:89:18 | ... ...; |
 | post | Conditions.cs:90:9:98:9 | foreach (... ... in ...) ... | Conditions.cs:90:27:90:28 | access to parameter ss |
 | post | Conditions.cs:90:9:98:9 | foreach (... ... in ...) ... | Conditions.cs:96:17:96:17 | access to local variable b |
 | post | Conditions.cs:90:9:98:9 | foreach (... ... in ...) ... | Conditions.cs:97:17:97:19 | ...++ |
@@ -813,9 +784,8 @@
 | post | Conditions.cs:94:17:94:17 | access to local variable x | Conditions.cs:94:13:95:26 | if (...) ... |
 | post | Conditions.cs:94:17:94:21 | ... > ... | Conditions.cs:94:21:94:21 | 0 |
 | post | Conditions.cs:94:21:94:21 | 0 | Conditions.cs:94:17:94:17 | access to local variable x |
-| post | Conditions.cs:95:17:95:17 | access to local variable b | Conditions.cs:95:17:95:26 | ...; |
 | post | Conditions.cs:95:17:95:25 | ... = ... | Conditions.cs:95:21:95:25 | false |
-| post | Conditions.cs:95:21:95:25 | false | Conditions.cs:95:17:95:17 | access to local variable b |
+| post | Conditions.cs:95:21:95:25 | false | Conditions.cs:95:17:95:26 | ...; |
 | post | Conditions.cs:96:13:97:20 | if (...) ... | Conditions.cs:94:17:94:21 | ... > ... |
 | post | Conditions.cs:96:13:97:20 | if (...) ... | Conditions.cs:95:17:95:25 | ... = ... |
 | post | Conditions.cs:96:17:96:17 | access to local variable b | Conditions.cs:96:13:97:20 | if (...) ... |
@@ -826,13 +796,11 @@
 | post | Conditions.cs:102:12:102:13 | exit M8 | Conditions.cs:110:9:110:17 | return ...; |
 | post | Conditions.cs:103:5:111:5 | {...} | Conditions.cs:102:12:102:13 | enter M8 |
 | post | Conditions.cs:104:9:104:29 | ... ...; | Conditions.cs:103:5:111:5 | {...} |
-| post | Conditions.cs:104:13:104:13 | access to local variable x | Conditions.cs:104:9:104:29 | ... ...; |
 | post | Conditions.cs:104:13:104:28 | String x = ... | Conditions.cs:104:17:104:28 | call to method ToString |
-| post | Conditions.cs:104:17:104:17 | access to parameter b | Conditions.cs:104:13:104:13 | access to local variable x |
+| post | Conditions.cs:104:17:104:17 | access to parameter b | Conditions.cs:104:9:104:29 | ... ...; |
 | post | Conditions.cs:104:17:104:28 | call to method ToString | Conditions.cs:104:17:104:17 | access to parameter b |
 | post | Conditions.cs:105:9:106:20 | if (...) ... | Conditions.cs:104:13:104:28 | String x = ... |
 | post | Conditions.cs:105:13:105:13 | access to parameter b | Conditions.cs:105:9:106:20 | if (...) ... |
-| post | Conditions.cs:106:13:106:13 | [b (line 102): true] access to local variable x | Conditions.cs:106:13:106:13 | [b (line 102): true] access to local variable x |
 | post | Conditions.cs:106:13:106:13 | [b (line 102): true] access to local variable x | Conditions.cs:106:13:106:20 | [b (line 102): true] ...; |
 | post | Conditions.cs:106:13:106:19 | [b (line 102): true] ... + ... | Conditions.cs:106:18:106:19 | [b (line 102): true] "" |
 | post | Conditions.cs:106:13:106:19 | [b (line 102): true] ... = ... | Conditions.cs:106:13:106:19 | [b (line 102): true] ... + ... |
@@ -850,7 +818,6 @@
 | post | Conditions.cs:108:17:108:18 | [b (line 102): true] !... | Conditions.cs:108:13:109:24 | [b (line 102): true] if (...) ... |
 | post | Conditions.cs:108:18:108:18 | [b (line 102): false] access to parameter b | Conditions.cs:108:17:108:18 | [b (line 102): false] !... |
 | post | Conditions.cs:108:18:108:18 | [b (line 102): true] access to parameter b | Conditions.cs:108:17:108:18 | [b (line 102): true] !... |
-| post | Conditions.cs:109:17:109:17 | access to local variable x | Conditions.cs:109:17:109:17 | access to local variable x |
 | post | Conditions.cs:109:17:109:17 | access to local variable x | Conditions.cs:109:17:109:24 | ...; |
 | post | Conditions.cs:109:17:109:23 | ... + ... | Conditions.cs:109:22:109:23 | "" |
 | post | Conditions.cs:109:17:109:23 | ... = ... | Conditions.cs:109:17:109:23 | ... + ... |
@@ -864,13 +831,11 @@
 | post | Conditions.cs:113:10:113:11 | exit M9 | Conditions.cs:116:24:116:38 | ... < ... |
 | post | Conditions.cs:114:5:124:5 | {...} | Conditions.cs:113:10:113:11 | enter M9 |
 | post | Conditions.cs:115:9:115:24 | ... ...; | Conditions.cs:114:5:124:5 | {...} |
-| post | Conditions.cs:115:16:115:16 | access to local variable s | Conditions.cs:115:9:115:24 | ... ...; |
 | post | Conditions.cs:115:16:115:23 | String s = ... | Conditions.cs:115:20:115:23 | null |
-| post | Conditions.cs:115:20:115:23 | null | Conditions.cs:115:16:115:16 | access to local variable s |
+| post | Conditions.cs:115:20:115:23 | null | Conditions.cs:115:9:115:24 | ... ...; |
 | post | Conditions.cs:116:9:123:9 | for (...;...;...) ... | Conditions.cs:115:16:115:23 | String s = ... |
-| post | Conditions.cs:116:17:116:17 | access to local variable i | Conditions.cs:116:9:123:9 | for (...;...;...) ... |
 | post | Conditions.cs:116:17:116:21 | Int32 i = ... | Conditions.cs:116:21:116:21 | 0 |
-| post | Conditions.cs:116:21:116:21 | 0 | Conditions.cs:116:17:116:17 | access to local variable i |
+| post | Conditions.cs:116:21:116:21 | 0 | Conditions.cs:116:9:123:9 | for (...;...;...) ... |
 | post | Conditions.cs:116:24:116:24 | access to local variable i | Conditions.cs:116:17:116:21 | Int32 i = ... |
 | post | Conditions.cs:116:24:116:24 | access to local variable i | Conditions.cs:116:41:116:43 | ...++ |
 | post | Conditions.cs:116:24:116:38 | ... < ... | Conditions.cs:116:28:116:38 | access to property Length |
@@ -880,9 +845,8 @@
 | post | Conditions.cs:116:41:116:41 | access to local variable i | Conditions.cs:122:17:122:24 | ... = ... |
 | post | Conditions.cs:116:41:116:43 | ...++ | Conditions.cs:116:41:116:41 | access to local variable i |
 | post | Conditions.cs:118:13:118:44 | ... ...; | Conditions.cs:117:9:123:9 | {...} |
-| post | Conditions.cs:118:17:118:20 | access to local variable last | Conditions.cs:118:13:118:44 | ... ...; |
 | post | Conditions.cs:118:17:118:43 | Boolean last = ... | Conditions.cs:118:24:118:43 | ... == ... |
-| post | Conditions.cs:118:24:118:24 | access to local variable i | Conditions.cs:118:17:118:20 | access to local variable last |
+| post | Conditions.cs:118:24:118:24 | access to local variable i | Conditions.cs:118:13:118:44 | ... ...; |
 | post | Conditions.cs:118:24:118:43 | ... == ... | Conditions.cs:118:29:118:43 | ... - ... |
 | post | Conditions.cs:118:29:118:32 | access to parameter args | Conditions.cs:118:24:118:24 | access to local variable i |
 | post | Conditions.cs:118:29:118:39 | access to property Length | Conditions.cs:118:29:118:32 | access to parameter args |
@@ -891,16 +855,14 @@
 | post | Conditions.cs:119:13:120:23 | if (...) ... | Conditions.cs:118:17:118:43 | Boolean last = ... |
 | post | Conditions.cs:119:17:119:21 | !... | Conditions.cs:119:13:120:23 | if (...) ... |
 | post | Conditions.cs:119:18:119:21 | access to local variable last | Conditions.cs:119:17:119:21 | !... |
-| post | Conditions.cs:120:17:120:17 | [last (line 118): false] access to local variable s | Conditions.cs:120:17:120:23 | [last (line 118): false] ...; |
 | post | Conditions.cs:120:17:120:22 | [last (line 118): false] ... = ... | Conditions.cs:120:21:120:22 | [last (line 118): false] "" |
-| post | Conditions.cs:120:21:120:22 | [last (line 118): false] "" | Conditions.cs:120:17:120:17 | [last (line 118): false] access to local variable s |
+| post | Conditions.cs:120:21:120:22 | [last (line 118): false] "" | Conditions.cs:120:17:120:23 | [last (line 118): false] ...; |
 | post | Conditions.cs:121:13:122:25 | [last (line 118): false] if (...) ... | Conditions.cs:120:17:120:22 | [last (line 118): false] ... = ... |
 | post | Conditions.cs:121:17:121:20 | [last (line 118): false] access to local variable last | Conditions.cs:121:13:122:25 | [last (line 118): false] if (...) ... |
 | post | Conditions.cs:121:17:121:20 | [last (line 118): true] access to local variable last | Conditions.cs:121:13:122:25 | [last (line 118): true] if (...) ... |
-| post | Conditions.cs:122:17:122:17 | access to local variable s | Conditions.cs:122:17:122:25 | ...; |
 | post | Conditions.cs:122:17:122:24 | ... = ... | Conditions.cs:122:21:122:24 | null |
 | post | Conditions.cs:122:17:122:25 | ...; | Conditions.cs:121:17:121:20 | [last (line 118): true] access to local variable last |
-| post | Conditions.cs:122:21:122:24 | null | Conditions.cs:122:17:122:17 | access to local variable s |
+| post | Conditions.cs:122:21:122:24 | null | Conditions.cs:122:17:122:25 | ...; |
 | post | Conditions.cs:130:5:141:5 | {...} | Conditions.cs:129:10:129:12 | enter M10 |
 | post | Conditions.cs:131:9:140:9 | while (...) ... | Conditions.cs:130:5:141:5 | {...} |
 | post | Conditions.cs:131:16:131:19 | [Field1 (line 129): true, Field2 (line 129): true] true | Conditions.cs:137:21:137:37 | [Field1 (line 129): true, Field2 (line 129): true] call to method ToString |
@@ -1145,21 +1107,18 @@
 | post | Initializers.cs:8:10:8:10 | exit M | Initializers.cs:11:13:11:63 | Initializers[] iz = ... |
 | post | Initializers.cs:9:5:12:5 | {...} | Initializers.cs:8:10:8:10 | enter M |
 | post | Initializers.cs:10:9:10:54 | ... ...; | Initializers.cs:9:5:12:5 | {...} |
-| post | Initializers.cs:10:13:10:13 | access to local variable i | Initializers.cs:10:9:10:54 | ... ...; |
 | post | Initializers.cs:10:13:10:53 | Initializers i = ... | Initializers.cs:10:38:10:53 | { ..., ... } |
 | post | Initializers.cs:10:17:10:53 | object creation of type Initializers | Initializers.cs:10:34:10:35 | "" |
-| post | Initializers.cs:10:34:10:35 | "" | Initializers.cs:10:13:10:13 | access to local variable i |
+| post | Initializers.cs:10:34:10:35 | "" | Initializers.cs:10:9:10:54 | ... ...; |
 | post | Initializers.cs:10:38:10:53 | { ..., ... } | Initializers.cs:10:47:10:51 | ... = ... |
-| post | Initializers.cs:10:40:10:40 | access to field F | Initializers.cs:10:17:10:53 | object creation of type Initializers |
 | post | Initializers.cs:10:40:10:44 | ... = ... | Initializers.cs:10:44:10:44 | 0 |
-| post | Initializers.cs:10:44:10:44 | 0 | Initializers.cs:10:40:10:40 | access to field F |
-| post | Initializers.cs:10:47:10:47 | access to property G | Initializers.cs:10:40:10:44 | ... = ... |
-| post | Initializers.cs:10:47:10:51 | ... = ... | Initializers.cs:10:51:10:51 | 1 |
-| post | Initializers.cs:10:51:10:51 | 1 | Initializers.cs:10:47:10:47 | access to property G |
+| post | Initializers.cs:10:44:10:44 | 0 | Initializers.cs:10:17:10:53 | object creation of type Initializers |
+| post | Initializers.cs:10:47:10:47 | access to property G | Initializers.cs:10:51:10:51 | 1 |
+| post | Initializers.cs:10:47:10:51 | ... = ... | Initializers.cs:10:47:10:47 | access to property G |
+| post | Initializers.cs:10:51:10:51 | 1 | Initializers.cs:10:40:10:44 | ... = ... |
 | post | Initializers.cs:11:9:11:64 | ... ...; | Initializers.cs:10:13:10:53 | Initializers i = ... |
-| post | Initializers.cs:11:13:11:14 | access to local variable iz | Initializers.cs:11:9:11:64 | ... ...; |
 | post | Initializers.cs:11:13:11:63 | Initializers[] iz = ... | Initializers.cs:11:37:11:63 | { ..., ... } |
-| post | Initializers.cs:11:18:11:63 | array creation of type Initializers[] | Initializers.cs:11:13:11:14 | access to local variable iz |
+| post | Initializers.cs:11:18:11:63 | array creation of type Initializers[] | Initializers.cs:11:9:11:64 | ... ...; |
 | post | Initializers.cs:11:37:11:63 | { ..., ... } | Initializers.cs:11:42:11:61 | object creation of type Initializers |
 | post | Initializers.cs:11:39:11:39 | access to local variable i | Initializers.cs:11:18:11:63 | array creation of type Initializers[] |
 | post | Initializers.cs:11:42:11:61 | object creation of type Initializers | Initializers.cs:11:59:11:60 | "" |
@@ -1196,29 +1155,25 @@
 | post | NullCoalescing.cs:13:10:13:11 | exit M6 | NullCoalescing.cs:17:9:17:24 | ... = ... |
 | post | NullCoalescing.cs:14:5:18:5 | {...} | NullCoalescing.cs:13:10:13:11 | enter M6 |
 | post | NullCoalescing.cs:15:9:15:32 | ... ...; | NullCoalescing.cs:14:5:18:5 | {...} |
-| post | NullCoalescing.cs:15:13:15:13 | access to local variable j | NullCoalescing.cs:15:9:15:32 | ... ...; |
 | post | NullCoalescing.cs:15:13:15:31 | Int32 j = ... | NullCoalescing.cs:15:31:15:31 | 0 |
 | post | NullCoalescing.cs:15:17:15:26 | (...) ... | NullCoalescing.cs:15:23:15:26 | null |
-| post | NullCoalescing.cs:15:17:15:31 | ... ?? ... | NullCoalescing.cs:15:13:15:13 | access to local variable j |
+| post | NullCoalescing.cs:15:17:15:31 | ... ?? ... | NullCoalescing.cs:15:9:15:32 | ... ...; |
 | post | NullCoalescing.cs:15:23:15:26 | null | NullCoalescing.cs:15:17:15:31 | ... ?? ... |
 | post | NullCoalescing.cs:15:31:15:31 | 0 | NullCoalescing.cs:15:17:15:26 | (...) ... |
 | post | NullCoalescing.cs:16:9:16:26 | ... ...; | NullCoalescing.cs:15:13:15:31 | Int32 j = ... |
-| post | NullCoalescing.cs:16:13:16:13 | access to local variable s | NullCoalescing.cs:16:9:16:26 | ... ...; |
 | post | NullCoalescing.cs:16:13:16:25 | String s = ... | NullCoalescing.cs:16:17:16:18 | "" |
 | post | NullCoalescing.cs:16:17:16:18 | "" | NullCoalescing.cs:16:17:16:25 | ... ?? ... |
-| post | NullCoalescing.cs:16:17:16:25 | ... ?? ... | NullCoalescing.cs:16:13:16:13 | access to local variable s |
-| post | NullCoalescing.cs:17:9:17:9 | access to local variable j | NullCoalescing.cs:17:9:17:25 | ...; |
+| post | NullCoalescing.cs:16:17:16:25 | ... ?? ... | NullCoalescing.cs:16:9:16:26 | ... ...; |
 | post | NullCoalescing.cs:17:9:17:24 | ... = ... | NullCoalescing.cs:17:13:17:19 | (...) ... |
 | post | NullCoalescing.cs:17:9:17:25 | ...; | NullCoalescing.cs:16:13:16:25 | String s = ... |
 | post | NullCoalescing.cs:17:13:17:19 | (...) ... | NullCoalescing.cs:17:19:17:19 | access to parameter i |
-| post | NullCoalescing.cs:17:13:17:24 | ... ?? ... | NullCoalescing.cs:17:9:17:9 | access to local variable j |
+| post | NullCoalescing.cs:17:13:17:24 | ... ?? ... | NullCoalescing.cs:17:9:17:25 | ...; |
 | post | NullCoalescing.cs:17:19:17:19 | access to parameter i | NullCoalescing.cs:17:13:17:24 | ... ?? ... |
 | post | Patterns.cs:5:10:5:13 | exit Test | Patterns.cs:40:17:40:17 | access to local variable o |
 | post | Patterns.cs:6:5:43:5 | {...} | Patterns.cs:5:10:5:13 | enter Test |
 | post | Patterns.cs:7:9:7:24 | ... ...; | Patterns.cs:6:5:43:5 | {...} |
-| post | Patterns.cs:7:16:7:16 | access to local variable o | Patterns.cs:7:9:7:24 | ... ...; |
 | post | Patterns.cs:7:16:7:23 | Object o = ... | Patterns.cs:7:20:7:23 | null |
-| post | Patterns.cs:7:20:7:23 | null | Patterns.cs:7:16:7:16 | access to local variable o |
+| post | Patterns.cs:7:20:7:23 | null | Patterns.cs:7:9:7:24 | ... ...; |
 | post | Patterns.cs:8:9:18:9 | if (...) ... | Patterns.cs:7:16:7:23 | Object o = ... |
 | post | Patterns.cs:8:13:8:13 | access to local variable o | Patterns.cs:8:9:18:9 | if (...) ... |
 | post | Patterns.cs:8:13:8:23 | ... is ... | Patterns.cs:8:18:8:23 | Int32 i1 |
@@ -1289,73 +1244,58 @@
 | post | Qualifiers.cs:10:10:10:10 | exit M | Qualifiers.cs:30:9:30:46 | ... = ... |
 | post | Qualifiers.cs:11:5:31:5 | {...} | Qualifiers.cs:10:10:10:10 | enter M |
 | post | Qualifiers.cs:12:9:12:22 | ... ...; | Qualifiers.cs:11:5:31:5 | {...} |
-| post | Qualifiers.cs:12:13:12:13 | access to local variable q | Qualifiers.cs:12:9:12:22 | ... ...; |
 | post | Qualifiers.cs:12:13:12:21 | Qualifiers q = ... | Qualifiers.cs:12:17:12:21 | access to field Field |
 | post | Qualifiers.cs:12:17:12:21 | access to field Field | Qualifiers.cs:12:17:12:21 | this access |
-| post | Qualifiers.cs:12:17:12:21 | this access | Qualifiers.cs:12:13:12:13 | access to local variable q |
-| post | Qualifiers.cs:13:9:13:9 | access to local variable q | Qualifiers.cs:13:9:13:21 | ...; |
+| post | Qualifiers.cs:12:17:12:21 | this access | Qualifiers.cs:12:9:12:22 | ... ...; |
 | post | Qualifiers.cs:13:9:13:20 | ... = ... | Qualifiers.cs:13:13:13:20 | access to property Property |
 | post | Qualifiers.cs:13:9:13:21 | ...; | Qualifiers.cs:12:13:12:21 | Qualifiers q = ... |
 | post | Qualifiers.cs:13:13:13:20 | access to property Property | Qualifiers.cs:13:13:13:20 | this access |
-| post | Qualifiers.cs:13:13:13:20 | this access | Qualifiers.cs:13:9:13:9 | access to local variable q |
-| post | Qualifiers.cs:14:9:14:9 | access to local variable q | Qualifiers.cs:14:9:14:21 | ...; |
+| post | Qualifiers.cs:13:13:13:20 | this access | Qualifiers.cs:13:9:13:21 | ...; |
 | post | Qualifiers.cs:14:9:14:20 | ... = ... | Qualifiers.cs:14:13:14:20 | call to method Method |
 | post | Qualifiers.cs:14:9:14:21 | ...; | Qualifiers.cs:13:9:13:20 | ... = ... |
 | post | Qualifiers.cs:14:13:14:20 | call to method Method | Qualifiers.cs:14:13:14:20 | this access |
-| post | Qualifiers.cs:14:13:14:20 | this access | Qualifiers.cs:14:9:14:9 | access to local variable q |
-| post | Qualifiers.cs:16:9:16:9 | access to local variable q | Qualifiers.cs:16:9:16:23 | ...; |
+| post | Qualifiers.cs:14:13:14:20 | this access | Qualifiers.cs:14:9:14:21 | ...; |
 | post | Qualifiers.cs:16:9:16:22 | ... = ... | Qualifiers.cs:16:13:16:22 | access to field Field |
 | post | Qualifiers.cs:16:9:16:23 | ...; | Qualifiers.cs:14:9:14:20 | ... = ... |
-| post | Qualifiers.cs:16:13:16:16 | this access | Qualifiers.cs:16:9:16:9 | access to local variable q |
+| post | Qualifiers.cs:16:13:16:16 | this access | Qualifiers.cs:16:9:16:23 | ...; |
 | post | Qualifiers.cs:16:13:16:22 | access to field Field | Qualifiers.cs:16:13:16:16 | this access |
-| post | Qualifiers.cs:17:9:17:9 | access to local variable q | Qualifiers.cs:17:9:17:26 | ...; |
 | post | Qualifiers.cs:17:9:17:25 | ... = ... | Qualifiers.cs:17:13:17:25 | access to property Property |
 | post | Qualifiers.cs:17:9:17:26 | ...; | Qualifiers.cs:16:9:16:22 | ... = ... |
-| post | Qualifiers.cs:17:13:17:16 | this access | Qualifiers.cs:17:9:17:9 | access to local variable q |
+| post | Qualifiers.cs:17:13:17:16 | this access | Qualifiers.cs:17:9:17:26 | ...; |
 | post | Qualifiers.cs:17:13:17:25 | access to property Property | Qualifiers.cs:17:13:17:16 | this access |
-| post | Qualifiers.cs:18:9:18:9 | access to local variable q | Qualifiers.cs:18:9:18:26 | ...; |
 | post | Qualifiers.cs:18:9:18:25 | ... = ... | Qualifiers.cs:18:13:18:25 | call to method Method |
 | post | Qualifiers.cs:18:9:18:26 | ...; | Qualifiers.cs:17:9:17:25 | ... = ... |
-| post | Qualifiers.cs:18:13:18:16 | this access | Qualifiers.cs:18:9:18:9 | access to local variable q |
+| post | Qualifiers.cs:18:13:18:16 | this access | Qualifiers.cs:18:9:18:26 | ...; |
 | post | Qualifiers.cs:18:13:18:25 | call to method Method | Qualifiers.cs:18:13:18:16 | this access |
-| post | Qualifiers.cs:20:9:20:9 | access to local variable q | Qualifiers.cs:20:9:20:24 | ...; |
 | post | Qualifiers.cs:20:9:20:23 | ... = ... | Qualifiers.cs:20:13:20:23 | access to field StaticField |
 | post | Qualifiers.cs:20:9:20:24 | ...; | Qualifiers.cs:18:9:18:25 | ... = ... |
-| post | Qualifiers.cs:20:13:20:23 | access to field StaticField | Qualifiers.cs:20:9:20:9 | access to local variable q |
-| post | Qualifiers.cs:21:9:21:9 | access to local variable q | Qualifiers.cs:21:9:21:27 | ...; |
+| post | Qualifiers.cs:20:13:20:23 | access to field StaticField | Qualifiers.cs:20:9:20:24 | ...; |
 | post | Qualifiers.cs:21:9:21:26 | ... = ... | Qualifiers.cs:21:13:21:26 | access to property StaticProperty |
 | post | Qualifiers.cs:21:9:21:27 | ...; | Qualifiers.cs:20:9:20:23 | ... = ... |
-| post | Qualifiers.cs:21:13:21:26 | access to property StaticProperty | Qualifiers.cs:21:9:21:9 | access to local variable q |
-| post | Qualifiers.cs:22:9:22:9 | access to local variable q | Qualifiers.cs:22:9:22:27 | ...; |
+| post | Qualifiers.cs:21:13:21:26 | access to property StaticProperty | Qualifiers.cs:21:9:21:27 | ...; |
 | post | Qualifiers.cs:22:9:22:26 | ... = ... | Qualifiers.cs:22:13:22:26 | call to method StaticMethod |
 | post | Qualifiers.cs:22:9:22:27 | ...; | Qualifiers.cs:21:9:21:26 | ... = ... |
-| post | Qualifiers.cs:22:13:22:26 | call to method StaticMethod | Qualifiers.cs:22:9:22:9 | access to local variable q |
-| post | Qualifiers.cs:24:9:24:9 | access to local variable q | Qualifiers.cs:24:9:24:35 | ...; |
+| post | Qualifiers.cs:22:13:22:26 | call to method StaticMethod | Qualifiers.cs:22:9:22:27 | ...; |
 | post | Qualifiers.cs:24:9:24:34 | ... = ... | Qualifiers.cs:24:13:24:34 | access to field StaticField |
 | post | Qualifiers.cs:24:9:24:35 | ...; | Qualifiers.cs:22:9:22:26 | ... = ... |
-| post | Qualifiers.cs:24:13:24:34 | access to field StaticField | Qualifiers.cs:24:9:24:9 | access to local variable q |
-| post | Qualifiers.cs:25:9:25:9 | access to local variable q | Qualifiers.cs:25:9:25:38 | ...; |
+| post | Qualifiers.cs:24:13:24:34 | access to field StaticField | Qualifiers.cs:24:9:24:35 | ...; |
 | post | Qualifiers.cs:25:9:25:37 | ... = ... | Qualifiers.cs:25:13:25:37 | access to property StaticProperty |
 | post | Qualifiers.cs:25:9:25:38 | ...; | Qualifiers.cs:24:9:24:34 | ... = ... |
-| post | Qualifiers.cs:25:13:25:37 | access to property StaticProperty | Qualifiers.cs:25:9:25:9 | access to local variable q |
-| post | Qualifiers.cs:26:9:26:9 | access to local variable q | Qualifiers.cs:26:9:26:38 | ...; |
+| post | Qualifiers.cs:25:13:25:37 | access to property StaticProperty | Qualifiers.cs:25:9:25:38 | ...; |
 | post | Qualifiers.cs:26:9:26:37 | ... = ... | Qualifiers.cs:26:13:26:37 | call to method StaticMethod |
 | post | Qualifiers.cs:26:9:26:38 | ...; | Qualifiers.cs:25:9:25:37 | ... = ... |
-| post | Qualifiers.cs:26:13:26:37 | call to method StaticMethod | Qualifiers.cs:26:9:26:9 | access to local variable q |
-| post | Qualifiers.cs:28:9:28:9 | access to local variable q | Qualifiers.cs:28:9:28:41 | ...; |
+| post | Qualifiers.cs:26:13:26:37 | call to method StaticMethod | Qualifiers.cs:26:9:26:38 | ...; |
 | post | Qualifiers.cs:28:9:28:40 | ... = ... | Qualifiers.cs:28:13:28:40 | access to field Field |
 | post | Qualifiers.cs:28:9:28:41 | ...; | Qualifiers.cs:26:9:26:37 | ... = ... |
-| post | Qualifiers.cs:28:13:28:34 | access to field StaticField | Qualifiers.cs:28:9:28:9 | access to local variable q |
+| post | Qualifiers.cs:28:13:28:34 | access to field StaticField | Qualifiers.cs:28:9:28:41 | ...; |
 | post | Qualifiers.cs:28:13:28:40 | access to field Field | Qualifiers.cs:28:13:28:34 | access to field StaticField |
-| post | Qualifiers.cs:29:9:29:9 | access to local variable q | Qualifiers.cs:29:9:29:47 | ...; |
 | post | Qualifiers.cs:29:9:29:46 | ... = ... | Qualifiers.cs:29:13:29:46 | access to property Property |
 | post | Qualifiers.cs:29:9:29:47 | ...; | Qualifiers.cs:28:9:28:40 | ... = ... |
-| post | Qualifiers.cs:29:13:29:37 | access to property StaticProperty | Qualifiers.cs:29:9:29:9 | access to local variable q |
+| post | Qualifiers.cs:29:13:29:37 | access to property StaticProperty | Qualifiers.cs:29:9:29:47 | ...; |
 | post | Qualifiers.cs:29:13:29:46 | access to property Property | Qualifiers.cs:29:13:29:37 | access to property StaticProperty |
-| post | Qualifiers.cs:30:9:30:9 | access to local variable q | Qualifiers.cs:30:9:30:47 | ...; |
 | post | Qualifiers.cs:30:9:30:46 | ... = ... | Qualifiers.cs:30:13:30:46 | call to method Method |
 | post | Qualifiers.cs:30:9:30:47 | ...; | Qualifiers.cs:29:9:29:46 | ... = ... |
-| post | Qualifiers.cs:30:13:30:37 | call to method StaticMethod | Qualifiers.cs:30:9:30:9 | access to local variable q |
+| post | Qualifiers.cs:30:13:30:37 | call to method StaticMethod | Qualifiers.cs:30:9:30:47 | ...; |
 | post | Qualifiers.cs:30:13:30:46 | call to method Method | Qualifiers.cs:30:13:30:37 | call to method StaticMethod |
 | post | Switch.cs:5:10:5:11 | exit M1 | Switch.cs:7:17:7:17 | access to parameter o |
 | post | Switch.cs:6:5:8:5 | {...} | Switch.cs:5:10:5:11 | enter M1 |
@@ -1499,14 +1439,12 @@
 | post | TypeAccesses.cs:3:10:3:10 | exit M | TypeAccesses.cs:8:13:8:27 | Type t = ... |
 | post | TypeAccesses.cs:4:5:9:5 | {...} | TypeAccesses.cs:3:10:3:10 | enter M |
 | post | TypeAccesses.cs:5:9:5:26 | ... ...; | TypeAccesses.cs:4:5:9:5 | {...} |
-| post | TypeAccesses.cs:5:13:5:13 | access to local variable s | TypeAccesses.cs:5:9:5:26 | ... ...; |
 | post | TypeAccesses.cs:5:13:5:25 | String s = ... | TypeAccesses.cs:5:17:5:25 | (...) ... |
 | post | TypeAccesses.cs:5:17:5:25 | (...) ... | TypeAccesses.cs:5:25:5:25 | access to parameter o |
-| post | TypeAccesses.cs:5:25:5:25 | access to parameter o | TypeAccesses.cs:5:13:5:13 | access to local variable s |
-| post | TypeAccesses.cs:6:9:6:9 | access to local variable s | TypeAccesses.cs:6:9:6:24 | ...; |
+| post | TypeAccesses.cs:5:25:5:25 | access to parameter o | TypeAccesses.cs:5:9:5:26 | ... ...; |
 | post | TypeAccesses.cs:6:9:6:23 | ... = ... | TypeAccesses.cs:6:13:6:23 | ... as ... |
 | post | TypeAccesses.cs:6:9:6:24 | ...; | TypeAccesses.cs:5:13:5:25 | String s = ... |
-| post | TypeAccesses.cs:6:13:6:13 | access to parameter o | TypeAccesses.cs:6:9:6:9 | access to local variable s |
+| post | TypeAccesses.cs:6:13:6:13 | access to parameter o | TypeAccesses.cs:6:9:6:24 | ...; |
 | post | TypeAccesses.cs:6:13:6:23 | ... as ... | TypeAccesses.cs:6:13:6:13 | access to parameter o |
 | post | TypeAccesses.cs:7:9:7:25 | if (...) ... | TypeAccesses.cs:6:9:6:23 | ... = ... |
 | post | TypeAccesses.cs:7:13:7:13 | access to parameter o | TypeAccesses.cs:7:9:7:25 | if (...) ... |
@@ -1514,20 +1452,17 @@
 | post | TypeAccesses.cs:7:18:7:22 | Int32 j | TypeAccesses.cs:7:13:7:13 | access to parameter o |
 | post | TypeAccesses.cs:8:9:8:28 | ... ...; | TypeAccesses.cs:7:13:7:22 | ... is ... |
 | post | TypeAccesses.cs:8:9:8:28 | ... ...; | TypeAccesses.cs:7:25:7:25 | ; |
-| post | TypeAccesses.cs:8:13:8:13 | access to local variable t | TypeAccesses.cs:8:9:8:28 | ... ...; |
 | post | TypeAccesses.cs:8:13:8:27 | Type t = ... | TypeAccesses.cs:8:17:8:27 | typeof(...) |
-| post | TypeAccesses.cs:8:17:8:27 | typeof(...) | TypeAccesses.cs:8:13:8:13 | access to local variable t |
+| post | TypeAccesses.cs:8:17:8:27 | typeof(...) | TypeAccesses.cs:8:9:8:28 | ... ...; |
 | post | VarDecls.cs:5:18:5:19 | exit M1 | VarDecls.cs:9:13:9:29 | return ...; |
 | post | VarDecls.cs:6:5:11:5 | {...} | VarDecls.cs:5:18:5:19 | enter M1 |
 | post | VarDecls.cs:7:9:10:9 | fixed(...) { ... } | VarDecls.cs:6:5:11:5 | {...} |
-| post | VarDecls.cs:7:22:7:23 | access to local variable c1 | VarDecls.cs:7:9:10:9 | fixed(...) { ... } |
 | post | VarDecls.cs:7:22:7:36 | Char* c1 = ... | VarDecls.cs:7:27:7:36 | access to array element |
-| post | VarDecls.cs:7:27:7:33 | access to parameter strings | VarDecls.cs:7:22:7:23 | access to local variable c1 |
+| post | VarDecls.cs:7:27:7:33 | access to parameter strings | VarDecls.cs:7:9:10:9 | fixed(...) { ... } |
 | post | VarDecls.cs:7:27:7:36 | access to array element | VarDecls.cs:7:35:7:35 | 0 |
 | post | VarDecls.cs:7:35:7:35 | 0 | VarDecls.cs:7:27:7:33 | access to parameter strings |
-| post | VarDecls.cs:7:39:7:40 | access to local variable c2 | VarDecls.cs:7:22:7:36 | Char* c1 = ... |
 | post | VarDecls.cs:7:39:7:53 | Char* c2 = ... | VarDecls.cs:7:44:7:53 | access to array element |
-| post | VarDecls.cs:7:44:7:50 | access to parameter strings | VarDecls.cs:7:39:7:40 | access to local variable c2 |
+| post | VarDecls.cs:7:44:7:50 | access to parameter strings | VarDecls.cs:7:22:7:36 | Char* c1 = ... |
 | post | VarDecls.cs:7:44:7:53 | access to array element | VarDecls.cs:7:52:7:52 | 1 |
 | post | VarDecls.cs:7:52:7:52 | 1 | VarDecls.cs:7:44:7:50 | access to parameter strings |
 | post | VarDecls.cs:8:9:10:9 | {...} | VarDecls.cs:7:39:7:53 | Char* c2 = ... |
@@ -1537,12 +1472,10 @@
 | post | VarDecls.cs:13:12:13:13 | exit M2 | VarDecls.cs:16:9:16:23 | return ...; |
 | post | VarDecls.cs:14:5:17:5 | {...} | VarDecls.cs:13:12:13:13 | enter M2 |
 | post | VarDecls.cs:15:9:15:30 | ... ...; | VarDecls.cs:14:5:17:5 | {...} |
-| post | VarDecls.cs:15:16:15:17 | access to local variable s1 | VarDecls.cs:15:9:15:30 | ... ...; |
 | post | VarDecls.cs:15:16:15:21 | String s1 = ... | VarDecls.cs:15:21:15:21 | access to parameter s |
-| post | VarDecls.cs:15:21:15:21 | access to parameter s | VarDecls.cs:15:16:15:17 | access to local variable s1 |
-| post | VarDecls.cs:15:24:15:25 | access to local variable s2 | VarDecls.cs:15:16:15:21 | String s1 = ... |
+| post | VarDecls.cs:15:21:15:21 | access to parameter s | VarDecls.cs:15:9:15:30 | ... ...; |
 | post | VarDecls.cs:15:24:15:29 | String s2 = ... | VarDecls.cs:15:29:15:29 | access to parameter s |
-| post | VarDecls.cs:15:29:15:29 | access to parameter s | VarDecls.cs:15:24:15:25 | access to local variable s2 |
+| post | VarDecls.cs:15:29:15:29 | access to parameter s | VarDecls.cs:15:16:15:21 | String s1 = ... |
 | post | VarDecls.cs:16:9:16:23 | return ...; | VarDecls.cs:16:16:16:22 | ... + ... |
 | post | VarDecls.cs:16:16:16:17 | access to local variable s1 | VarDecls.cs:15:24:15:29 | String s2 = ... |
 | post | VarDecls.cs:16:16:16:22 | ... + ... | VarDecls.cs:16:21:16:22 | access to local variable s2 |
@@ -1553,12 +1486,10 @@
 | post | VarDecls.cs:21:16:21:22 | object creation of type C | VarDecls.cs:21:9:22:13 | using (...) {...} |
 | post | VarDecls.cs:22:13:22:13 | ; | VarDecls.cs:21:16:21:22 | object creation of type C |
 | post | VarDecls.cs:24:9:25:29 | using (...) {...} | VarDecls.cs:22:13:22:13 | ; |
-| post | VarDecls.cs:24:18:24:18 | access to local variable x | VarDecls.cs:24:9:25:29 | using (...) {...} |
 | post | VarDecls.cs:24:18:24:28 | C x = ... | VarDecls.cs:24:22:24:28 | object creation of type C |
-| post | VarDecls.cs:24:22:24:28 | object creation of type C | VarDecls.cs:24:18:24:18 | access to local variable x |
-| post | VarDecls.cs:24:31:24:31 | access to local variable y | VarDecls.cs:24:18:24:28 | C x = ... |
+| post | VarDecls.cs:24:22:24:28 | object creation of type C | VarDecls.cs:24:9:25:29 | using (...) {...} |
 | post | VarDecls.cs:24:31:24:41 | C y = ... | VarDecls.cs:24:35:24:41 | object creation of type C |
-| post | VarDecls.cs:24:35:24:41 | object creation of type C | VarDecls.cs:24:31:24:31 | access to local variable y |
+| post | VarDecls.cs:24:35:24:41 | object creation of type C | VarDecls.cs:24:18:24:28 | C x = ... |
 | post | VarDecls.cs:25:13:25:29 | return ...; | VarDecls.cs:25:24:25:24 | access to local variable x |
 | post | VarDecls.cs:25:13:25:29 | return ...; | VarDecls.cs:25:28:25:28 | access to local variable y |
 | post | VarDecls.cs:25:20:25:20 | access to parameter b | VarDecls.cs:25:20:25:28 | ... ? ... : ... |
@@ -1568,14 +1499,12 @@
 | post | cflow.cs:5:17:5:20 | exit Main | cflow.cs:24:25:24:31 | ... <= ... |
 | post | cflow.cs:6:5:35:5 | {...} | cflow.cs:5:17:5:20 | enter Main |
 | post | cflow.cs:7:9:7:28 | ... ...; | cflow.cs:6:5:35:5 | {...} |
-| post | cflow.cs:7:13:7:13 | access to local variable a | cflow.cs:7:9:7:28 | ... ...; |
 | post | cflow.cs:7:13:7:27 | Int32 a = ... | cflow.cs:7:17:7:27 | access to property Length |
-| post | cflow.cs:7:17:7:20 | access to parameter args | cflow.cs:7:13:7:13 | access to local variable a |
+| post | cflow.cs:7:17:7:20 | access to parameter args | cflow.cs:7:9:7:28 | ... ...; |
 | post | cflow.cs:7:17:7:27 | access to property Length | cflow.cs:7:17:7:20 | access to parameter args |
-| post | cflow.cs:9:9:9:9 | access to local variable a | cflow.cs:9:9:9:40 | ...; |
 | post | cflow.cs:9:9:9:39 | ... = ... | cflow.cs:9:13:9:39 | call to method Switch |
 | post | cflow.cs:9:9:9:40 | ...; | cflow.cs:7:13:7:27 | Int32 a = ... |
-| post | cflow.cs:9:13:9:29 | object creation of type ControlFlow | cflow.cs:9:9:9:9 | access to local variable a |
+| post | cflow.cs:9:13:9:29 | object creation of type ControlFlow | cflow.cs:9:9:9:40 | ...; |
 | post | cflow.cs:9:13:9:39 | call to method Switch | cflow.cs:9:38:9:38 | access to local variable a |
 | post | cflow.cs:9:38:9:38 | access to local variable a | cflow.cs:9:13:9:29 | object creation of type ControlFlow |
 | post | cflow.cs:11:9:12:49 | if (...) ... | cflow.cs:9:9:9:39 | ... = ... |
@@ -1607,9 +1536,8 @@
 | post | cflow.cs:22:18:22:23 | ... < ... | cflow.cs:22:22:22:23 | 10 |
 | post | cflow.cs:22:22:22:23 | 10 | cflow.cs:22:18:22:18 | access to local variable a |
 | post | cflow.cs:24:9:34:9 | for (...;...;...) ... | cflow.cs:22:18:22:23 | ... < ... |
-| post | cflow.cs:24:18:24:18 | access to local variable i | cflow.cs:24:9:34:9 | for (...;...;...) ... |
 | post | cflow.cs:24:18:24:22 | Int32 i = ... | cflow.cs:24:22:24:22 | 1 |
-| post | cflow.cs:24:22:24:22 | 1 | cflow.cs:24:18:24:18 | access to local variable i |
+| post | cflow.cs:24:22:24:22 | 1 | cflow.cs:24:9:34:9 | for (...;...;...) ... |
 | post | cflow.cs:24:25:24:25 | access to local variable i | cflow.cs:24:18:24:22 | Int32 i = ... |
 | post | cflow.cs:24:25:24:25 | access to local variable i | cflow.cs:24:34:24:36 | ...++ |
 | post | cflow.cs:24:25:24:31 | ... <= ... | cflow.cs:24:30:24:31 | 20 |
@@ -1784,13 +1712,11 @@
 | post | cflow.cs:119:20:119:21 | exit M5 | cflow.cs:123:9:123:17 | return ...; |
 | post | cflow.cs:120:5:124:5 | {...} | cflow.cs:119:20:119:21 | enter M5 |
 | post | cflow.cs:121:9:121:18 | ... ...; | cflow.cs:120:5:124:5 | {...} |
-| post | cflow.cs:121:13:121:13 | access to local variable x | cflow.cs:121:9:121:18 | ... ...; |
 | post | cflow.cs:121:13:121:17 | String x = ... | cflow.cs:121:17:121:17 | access to parameter s |
-| post | cflow.cs:121:17:121:17 | access to parameter s | cflow.cs:121:13:121:13 | access to local variable x |
-| post | cflow.cs:122:9:122:9 | access to local variable x | cflow.cs:122:9:122:20 | ...; |
+| post | cflow.cs:121:17:121:17 | access to parameter s | cflow.cs:121:9:121:18 | ... ...; |
 | post | cflow.cs:122:9:122:19 | ... = ... | cflow.cs:122:13:122:19 | ... + ... |
 | post | cflow.cs:122:9:122:20 | ...; | cflow.cs:121:13:121:17 | String x = ... |
-| post | cflow.cs:122:13:122:13 | access to local variable x | cflow.cs:122:9:122:9 | access to local variable x |
+| post | cflow.cs:122:13:122:13 | access to local variable x | cflow.cs:122:9:122:20 | ...; |
 | post | cflow.cs:122:13:122:19 | ... + ... | cflow.cs:122:17:122:19 | " " |
 | post | cflow.cs:122:17:122:19 | " " | cflow.cs:122:13:122:13 | access to local variable x |
 | post | cflow.cs:123:9:123:17 | return ...; | cflow.cs:123:16:123:16 | access to local variable x |
@@ -1807,18 +1733,16 @@
 | post | cflow.cs:127:53:127:57 | access to field Field | cflow.cs:127:53:127:57 | this access |
 | post | cflow.cs:127:62:127:64 | exit set_Prop | cflow.cs:127:68:127:80 | ... = ... |
 | post | cflow.cs:127:66:127:83 | {...} | cflow.cs:127:62:127:64 | enter set_Prop |
-| post | cflow.cs:127:68:127:72 | access to field Field | cflow.cs:127:68:127:72 | this access |
 | post | cflow.cs:127:68:127:72 | this access | cflow.cs:127:68:127:81 | ...; |
 | post | cflow.cs:127:68:127:80 | ... = ... | cflow.cs:127:76:127:80 | access to parameter value |
 | post | cflow.cs:127:68:127:81 | ...; | cflow.cs:127:66:127:83 | {...} |
-| post | cflow.cs:127:76:127:80 | access to parameter value | cflow.cs:127:68:127:72 | access to field Field |
+| post | cflow.cs:127:76:127:80 | access to parameter value | cflow.cs:127:68:127:72 | this access |
 | post | cflow.cs:129:5:129:15 | exit ControlFlow | cflow.cs:131:9:131:17 | ... = ... |
 | post | cflow.cs:130:5:132:5 | {...} | cflow.cs:129:5:129:15 | enter ControlFlow |
-| post | cflow.cs:131:9:131:13 | access to field Field | cflow.cs:131:9:131:13 | this access |
 | post | cflow.cs:131:9:131:13 | this access | cflow.cs:131:9:131:18 | ...; |
 | post | cflow.cs:131:9:131:17 | ... = ... | cflow.cs:131:17:131:17 | access to parameter s |
 | post | cflow.cs:131:9:131:18 | ...; | cflow.cs:130:5:132:5 | {...} |
-| post | cflow.cs:131:17:131:17 | access to parameter s | cflow.cs:131:9:131:13 | access to field Field |
+| post | cflow.cs:131:17:131:17 | access to parameter s | cflow.cs:131:9:131:13 | this access |
 | post | cflow.cs:134:5:134:15 | exit ControlFlow | cflow.cs:134:39:134:41 | {...} |
 | post | cflow.cs:134:26:134:29 | call to constructor ControlFlow | cflow.cs:134:31:134:36 | ... + ... |
 | post | cflow.cs:134:31:134:31 | (...) ... | cflow.cs:134:31:134:31 | access to parameter i |
@@ -1956,9 +1880,8 @@
 | post | cflow.cs:203:31:203:39 | [finally: exception(OutOfMemoryException)] "Finally" | cflow.cs:203:13:203:41 | [finally: exception(OutOfMemoryException)] ...; |
 | post | cflow.cs:203:31:203:39 | [finally: return] "Finally" | cflow.cs:203:13:203:41 | [finally: return] ...; |
 | post | cflow.cs:206:9:206:19 | ... ...; | cflow.cs:203:13:203:40 | call to method WriteLine |
-| post | cflow.cs:206:13:206:13 | access to local variable i | cflow.cs:206:9:206:19 | ... ...; |
 | post | cflow.cs:206:13:206:18 | Int32 i = ... | cflow.cs:206:17:206:18 | 10 |
-| post | cflow.cs:206:17:206:18 | 10 | cflow.cs:206:13:206:13 | access to local variable i |
+| post | cflow.cs:206:17:206:18 | 10 | cflow.cs:206:9:206:19 | ... ...; |
 | post | cflow.cs:207:9:230:9 | while (...) ... | cflow.cs:206:13:206:18 | Int32 i = ... |
 | post | cflow.cs:207:16:207:16 | access to local variable i | cflow.cs:207:9:230:9 | while (...) ... |
 | post | cflow.cs:207:16:207:16 | access to local variable i | cflow.cs:227:21:227:23 | ...-- |
@@ -2137,18 +2060,16 @@
 | post | cflow.cs:247:9:254:9 | try {...} ... | cflow.cs:244:17:244:36 | call to method WriteLine |
 | post | cflow.cs:248:9:250:9 | {...} | cflow.cs:247:9:254:9 | try {...} ... |
 | post | cflow.cs:249:13:249:41 | ... ...; | cflow.cs:248:9:250:9 | {...} |
-| post | cflow.cs:249:17:249:20 | access to local variable temp | cflow.cs:249:13:249:41 | ... ...; |
 | post | cflow.cs:249:17:249:40 | Double temp = ... | cflow.cs:249:24:249:40 | ... / ... |
-| post | cflow.cs:249:24:249:24 | 0 | cflow.cs:249:17:249:20 | access to local variable temp |
+| post | cflow.cs:249:24:249:24 | 0 | cflow.cs:249:13:249:41 | ... ...; |
 | post | cflow.cs:249:24:249:24 | (...) ... | cflow.cs:249:24:249:24 | 0 |
 | post | cflow.cs:249:24:249:40 | ... / ... | cflow.cs:249:28:249:40 | access to constant E |
 | post | cflow.cs:249:28:249:40 | access to constant E | cflow.cs:249:24:249:24 | (...) ... |
 | post | cflow.cs:257:10:257:12 | exit For | cflow.cs:284:32:284:41 | ... < ... |
 | post | cflow.cs:258:5:288:5 | {...} | cflow.cs:257:10:257:12 | enter For |
 | post | cflow.cs:259:9:259:18 | ... ...; | cflow.cs:258:5:288:5 | {...} |
-| post | cflow.cs:259:13:259:13 | access to local variable x | cflow.cs:259:9:259:18 | ... ...; |
 | post | cflow.cs:259:13:259:17 | Int32 x = ... | cflow.cs:259:17:259:17 | 0 |
-| post | cflow.cs:259:17:259:17 | 0 | cflow.cs:259:13:259:13 | access to local variable x |
+| post | cflow.cs:259:17:259:17 | 0 | cflow.cs:259:9:259:18 | ... ...; |
 | post | cflow.cs:260:9:261:33 | for (...;...;...) ... | cflow.cs:259:13:259:17 | Int32 x = ... |
 | post | cflow.cs:260:16:260:16 | access to local variable x | cflow.cs:260:9:261:33 | for (...;...;...) ... |
 | post | cflow.cs:260:16:260:16 | access to local variable x | cflow.cs:260:24:260:26 | ++... |
@@ -2195,12 +2116,10 @@
 | post | cflow.cs:281:13:281:15 | ...++ | cflow.cs:281:13:281:13 | access to local variable x |
 | post | cflow.cs:281:13:281:16 | ...; | cflow.cs:280:13:280:32 | call to method WriteLine |
 | post | cflow.cs:284:9:287:9 | for (...;...;...) ... | cflow.cs:278:16:278:21 | ... < ... |
-| post | cflow.cs:284:18:284:18 | access to local variable i | cflow.cs:284:9:287:9 | for (...;...;...) ... |
 | post | cflow.cs:284:18:284:22 | Int32 i = ... | cflow.cs:284:22:284:22 | 0 |
-| post | cflow.cs:284:22:284:22 | 0 | cflow.cs:284:18:284:18 | access to local variable i |
-| post | cflow.cs:284:25:284:25 | access to local variable j | cflow.cs:284:18:284:22 | Int32 i = ... |
+| post | cflow.cs:284:22:284:22 | 0 | cflow.cs:284:9:287:9 | for (...;...;...) ... |
 | post | cflow.cs:284:25:284:29 | Int32 j = ... | cflow.cs:284:29:284:29 | 0 |
-| post | cflow.cs:284:29:284:29 | 0 | cflow.cs:284:25:284:25 | access to local variable j |
+| post | cflow.cs:284:29:284:29 | 0 | cflow.cs:284:18:284:22 | Int32 i = ... |
 | post | cflow.cs:284:32:284:32 | access to local variable i | cflow.cs:284:25:284:29 | Int32 j = ... |
 | post | cflow.cs:284:32:284:32 | access to local variable i | cflow.cs:284:49:284:51 | ...++ |
 | post | cflow.cs:284:32:284:36 | ... + ... | cflow.cs:284:36:284:36 | access to local variable j |
@@ -2219,17 +2138,15 @@
 | post | cflow.cs:290:10:290:16 | exit Lambdas | cflow.cs:293:24:293:61 | Func<Int32,Int32> z = ... |
 | post | cflow.cs:291:5:294:5 | {...} | cflow.cs:290:10:290:16 | enter Lambdas |
 | post | cflow.cs:292:9:292:38 | ... ...; | cflow.cs:291:5:294:5 | {...} |
-| post | cflow.cs:292:24:292:24 | access to local variable y | cflow.cs:292:9:292:38 | ... ...; |
 | post | cflow.cs:292:24:292:37 | Func<Int32,Int32> y = ... | cflow.cs:292:28:292:37 | (...) => ... |
-| post | cflow.cs:292:28:292:37 | (...) => ... | cflow.cs:292:24:292:24 | access to local variable y |
+| post | cflow.cs:292:28:292:37 | (...) => ... | cflow.cs:292:9:292:38 | ... ...; |
 | post | cflow.cs:292:28:292:37 | exit (...) => ... | cflow.cs:292:33:292:37 | ... + ... |
 | post | cflow.cs:292:33:292:33 | access to parameter x | cflow.cs:292:28:292:37 | enter (...) => ... |
 | post | cflow.cs:292:33:292:37 | ... + ... | cflow.cs:292:37:292:37 | 1 |
 | post | cflow.cs:292:37:292:37 | 1 | cflow.cs:292:33:292:33 | access to parameter x |
 | post | cflow.cs:293:9:293:62 | ... ...; | cflow.cs:292:24:292:37 | Func<Int32,Int32> y = ... |
-| post | cflow.cs:293:24:293:24 | access to local variable z | cflow.cs:293:9:293:62 | ... ...; |
 | post | cflow.cs:293:24:293:61 | Func<Int32,Int32> z = ... | cflow.cs:293:28:293:61 | delegate(...) { ... } |
-| post | cflow.cs:293:28:293:61 | delegate(...) { ... } | cflow.cs:293:24:293:24 | access to local variable z |
+| post | cflow.cs:293:28:293:61 | delegate(...) { ... } | cflow.cs:293:9:293:62 | ... ...; |
 | post | cflow.cs:293:28:293:61 | exit delegate(...) { ... } | cflow.cs:293:47:293:59 | return ...; |
 | post | cflow.cs:293:45:293:61 | {...} | cflow.cs:293:28:293:61 | enter delegate(...) { ... } |
 | post | cflow.cs:293:47:293:59 | return ...; | cflow.cs:293:54:293:58 | ... + ... |
@@ -2259,14 +2176,13 @@
 | post | cflow.cs:304:10:304:17 | exit Booleans | cflow.cs:314:17:314:38 | throw ...; |
 | post | cflow.cs:305:5:317:5 | {...} | cflow.cs:304:10:304:17 | enter Booleans |
 | post | cflow.cs:306:9:306:57 | ... ...; | cflow.cs:305:5:317:5 | {...} |
-| post | cflow.cs:306:13:306:13 | access to local variable b | cflow.cs:306:9:306:57 | ... ...; |
 | post | cflow.cs:306:13:306:56 | Boolean b = ... | cflow.cs:306:17:306:32 | ... > ... |
 | post | cflow.cs:306:13:306:56 | Boolean b = ... | cflow.cs:306:39:306:55 | ... == ... |
 | post | cflow.cs:306:17:306:21 | access to field Field | cflow.cs:306:17:306:21 | this access |
 | post | cflow.cs:306:17:306:21 | this access | cflow.cs:306:17:306:56 | ... && ... |
 | post | cflow.cs:306:17:306:28 | access to property Length | cflow.cs:306:17:306:21 | access to field Field |
 | post | cflow.cs:306:17:306:32 | ... > ... | cflow.cs:306:32:306:32 | 0 |
-| post | cflow.cs:306:17:306:56 | ... && ... | cflow.cs:306:13:306:13 | access to local variable b |
+| post | cflow.cs:306:17:306:56 | ... && ... | cflow.cs:306:9:306:57 | ... ...; |
 | post | cflow.cs:306:32:306:32 | 0 | cflow.cs:306:17:306:28 | access to property Length |
 | post | cflow.cs:306:39:306:43 | access to field Field | cflow.cs:306:39:306:43 | this access |
 | post | cflow.cs:306:39:306:43 | this access | cflow.cs:306:37:306:56 | !... |
@@ -2281,7 +2197,6 @@
 | post | cflow.cs:308:15:308:31 | ... == ... | cflow.cs:308:31:308:31 | 0 |
 | post | cflow.cs:308:15:308:46 | ... ? ... : ... | cflow.cs:308:13:308:47 | !... |
 | post | cflow.cs:308:31:308:31 | 0 | cflow.cs:308:15:308:26 | access to property Length |
-| post | cflow.cs:309:13:309:13 | access to local variable b | cflow.cs:309:13:309:49 | ...; |
 | post | cflow.cs:309:13:309:48 | ... = ... | cflow.cs:309:37:309:41 | false |
 | post | cflow.cs:309:13:309:48 | ... = ... | cflow.cs:309:45:309:48 | true |
 | post | cflow.cs:309:13:309:49 | ...; | cflow.cs:308:35:308:39 | false |
@@ -2289,7 +2204,7 @@
 | post | cflow.cs:309:17:309:21 | this access | cflow.cs:309:17:309:48 | ... ? ... : ... |
 | post | cflow.cs:309:17:309:28 | access to property Length | cflow.cs:309:17:309:21 | access to field Field |
 | post | cflow.cs:309:17:309:33 | ... == ... | cflow.cs:309:33:309:33 | 0 |
-| post | cflow.cs:309:17:309:48 | ... ? ... : ... | cflow.cs:309:13:309:13 | access to local variable b |
+| post | cflow.cs:309:17:309:48 | ... ? ... : ... | cflow.cs:309:13:309:49 | ...; |
 | post | cflow.cs:309:33:309:33 | 0 | cflow.cs:309:17:309:28 | access to property Length |
 | post | cflow.cs:311:9:316:9 | if (...) ... | cflow.cs:308:43:308:46 | true |
 | post | cflow.cs:311:9:316:9 | if (...) ... | cflow.cs:309:13:309:48 | ... = ... |
@@ -2316,8 +2231,7 @@
 | post | cflow.cs:321:9:332:36 | do ... while (...); | cflow.cs:320:5:333:5 | {...} |
 | post | cflow.cs:322:9:332:9 | {...} | cflow.cs:321:9:332:36 | do ... while (...); |
 | post | cflow.cs:323:13:323:17 | access to field Field | cflow.cs:323:13:323:17 | this access |
-| post | cflow.cs:323:13:323:17 | access to field Field | cflow.cs:323:13:323:17 | this access |
-| post | cflow.cs:323:13:323:17 | this access | cflow.cs:323:13:323:17 | access to field Field |
+| post | cflow.cs:323:13:323:17 | this access | cflow.cs:323:13:323:17 | this access |
 | post | cflow.cs:323:13:323:17 | this access | cflow.cs:323:13:323:25 | ...; |
 | post | cflow.cs:323:13:323:24 | ... + ... | cflow.cs:323:22:323:24 | "a" |
 | post | cflow.cs:323:13:323:24 | ... = ... | cflow.cs:323:13:323:24 | ... + ... |
@@ -2351,8 +2265,7 @@
 | post | cflow.cs:337:62:337:63 | 10 | cflow.cs:337:57:337:59 | "a" |
 | post | cflow.cs:338:9:348:9 | {...} | cflow.cs:337:22:337:22 | String x |
 | post | cflow.cs:339:13:339:17 | access to field Field | cflow.cs:339:13:339:17 | this access |
-| post | cflow.cs:339:13:339:17 | access to field Field | cflow.cs:339:13:339:17 | this access |
-| post | cflow.cs:339:13:339:17 | this access | cflow.cs:339:13:339:17 | access to field Field |
+| post | cflow.cs:339:13:339:17 | this access | cflow.cs:339:13:339:17 | this access |
 | post | cflow.cs:339:13:339:17 | this access | cflow.cs:339:13:339:23 | ...; |
 | post | cflow.cs:339:13:339:22 | ... + ... | cflow.cs:339:22:339:22 | access to local variable x |
 | post | cflow.cs:339:13:339:22 | ... = ... | cflow.cs:339:13:339:22 | ... + ... |
@@ -2415,9 +2328,8 @@
 | post | cflow.cs:374:9:374:23 | yield return ...; | cflow.cs:374:22:374:22 | 0 |
 | post | cflow.cs:374:22:374:22 | 0 | cflow.cs:373:5:388:5 | {...} |
 | post | cflow.cs:375:9:378:9 | for (...;...;...) ... | cflow.cs:374:9:374:23 | yield return ...; |
-| post | cflow.cs:375:18:375:18 | access to local variable i | cflow.cs:375:9:378:9 | for (...;...;...) ... |
 | post | cflow.cs:375:18:375:22 | Int32 i = ... | cflow.cs:375:22:375:22 | 1 |
-| post | cflow.cs:375:22:375:22 | 1 | cflow.cs:375:18:375:18 | access to local variable i |
+| post | cflow.cs:375:22:375:22 | 1 | cflow.cs:375:9:378:9 | for (...;...;...) ... |
 | post | cflow.cs:375:25:375:25 | access to local variable i | cflow.cs:375:18:375:22 | Int32 i = ... |
 | post | cflow.cs:375:25:375:25 | access to local variable i | cflow.cs:375:33:375:35 | ...++ |
 | post | cflow.cs:375:25:375:30 | ... < ... | cflow.cs:375:29:375:30 | 10 |
@@ -2491,76 +2403,74 @@
 | pre | AccessorCalls.cs:7:47:7:49 | {...} | AccessorCalls.cs:7:40:7:45 | exit remove_Event |
 | pre | AccessorCalls.cs:10:10:10:11 | enter M1 | AccessorCalls.cs:11:5:17:5 | {...} |
 | pre | AccessorCalls.cs:11:5:17:5 | {...} | AccessorCalls.cs:12:9:12:32 | ...; |
-| pre | AccessorCalls.cs:12:9:12:12 | this access | AccessorCalls.cs:12:9:12:18 | access to field Field |
-| pre | AccessorCalls.cs:12:9:12:18 | access to field Field | AccessorCalls.cs:12:22:12:25 | this access |
+| pre | AccessorCalls.cs:12:9:12:12 | this access | AccessorCalls.cs:12:22:12:25 | this access |
 | pre | AccessorCalls.cs:12:9:12:31 | ... = ... | AccessorCalls.cs:13:9:13:30 | ...; |
 | pre | AccessorCalls.cs:12:9:12:32 | ...; | AccessorCalls.cs:12:9:12:12 | this access |
 | pre | AccessorCalls.cs:12:22:12:25 | this access | AccessorCalls.cs:12:22:12:31 | access to field Field |
 | pre | AccessorCalls.cs:12:22:12:31 | access to field Field | AccessorCalls.cs:12:9:12:31 | ... = ... |
-| pre | AccessorCalls.cs:13:9:13:12 | this access | AccessorCalls.cs:13:9:13:17 | access to property Prop |
-| pre | AccessorCalls.cs:13:9:13:17 | access to property Prop | AccessorCalls.cs:13:21:13:24 | this access |
+| pre | AccessorCalls.cs:13:9:13:12 | this access | AccessorCalls.cs:13:21:13:24 | this access |
+| pre | AccessorCalls.cs:13:9:13:17 | access to property Prop | AccessorCalls.cs:13:9:13:29 | ... = ... |
 | pre | AccessorCalls.cs:13:9:13:29 | ... = ... | AccessorCalls.cs:14:9:14:26 | ...; |
 | pre | AccessorCalls.cs:13:9:13:30 | ...; | AccessorCalls.cs:13:9:13:12 | this access |
 | pre | AccessorCalls.cs:13:21:13:24 | this access | AccessorCalls.cs:13:21:13:29 | access to property Prop |
-| pre | AccessorCalls.cs:13:21:13:29 | access to property Prop | AccessorCalls.cs:13:9:13:29 | ... = ... |
+| pre | AccessorCalls.cs:13:21:13:29 | access to property Prop | AccessorCalls.cs:13:9:13:17 | access to property Prop |
 | pre | AccessorCalls.cs:14:9:14:12 | this access | AccessorCalls.cs:14:14:14:14 | 0 |
-| pre | AccessorCalls.cs:14:9:14:15 | access to indexer | AccessorCalls.cs:14:19:14:22 | this access |
+| pre | AccessorCalls.cs:14:9:14:15 | access to indexer | AccessorCalls.cs:14:9:14:25 | ... = ... |
 | pre | AccessorCalls.cs:14:9:14:25 | ... = ... | AccessorCalls.cs:15:9:15:24 | ...; |
 | pre | AccessorCalls.cs:14:9:14:26 | ...; | AccessorCalls.cs:14:9:14:12 | this access |
-| pre | AccessorCalls.cs:14:14:14:14 | 0 | AccessorCalls.cs:14:9:14:15 | access to indexer |
+| pre | AccessorCalls.cs:14:14:14:14 | 0 | AccessorCalls.cs:14:19:14:22 | this access |
 | pre | AccessorCalls.cs:14:19:14:22 | this access | AccessorCalls.cs:14:24:14:24 | 1 |
-| pre | AccessorCalls.cs:14:19:14:25 | access to indexer | AccessorCalls.cs:14:9:14:25 | ... = ... |
+| pre | AccessorCalls.cs:14:19:14:25 | access to indexer | AccessorCalls.cs:14:9:14:15 | access to indexer |
 | pre | AccessorCalls.cs:14:24:14:24 | 1 | AccessorCalls.cs:14:19:14:25 | access to indexer |
-| pre | AccessorCalls.cs:15:9:15:12 | this access | AccessorCalls.cs:15:9:15:18 | access to event Event |
-| pre | AccessorCalls.cs:15:9:15:18 | access to event Event | AccessorCalls.cs:15:23:15:23 | access to parameter e |
+| pre | AccessorCalls.cs:15:9:15:12 | this access | AccessorCalls.cs:15:23:15:23 | access to parameter e |
+| pre | AccessorCalls.cs:15:9:15:18 | access to event Event | AccessorCalls.cs:15:9:15:23 | ... += ... |
 | pre | AccessorCalls.cs:15:9:15:23 | ... += ... | AccessorCalls.cs:16:9:16:24 | ...; |
 | pre | AccessorCalls.cs:15:9:15:24 | ...; | AccessorCalls.cs:15:9:15:12 | this access |
-| pre | AccessorCalls.cs:15:23:15:23 | access to parameter e | AccessorCalls.cs:15:9:15:23 | ... += ... |
-| pre | AccessorCalls.cs:16:9:16:12 | this access | AccessorCalls.cs:16:9:16:18 | access to event Event |
-| pre | AccessorCalls.cs:16:9:16:18 | access to event Event | AccessorCalls.cs:16:23:16:23 | access to parameter e |
+| pre | AccessorCalls.cs:15:23:15:23 | access to parameter e | AccessorCalls.cs:15:9:15:18 | access to event Event |
+| pre | AccessorCalls.cs:16:9:16:12 | this access | AccessorCalls.cs:16:23:16:23 | access to parameter e |
+| pre | AccessorCalls.cs:16:9:16:18 | access to event Event | AccessorCalls.cs:16:9:16:23 | ... -= ... |
 | pre | AccessorCalls.cs:16:9:16:23 | ... -= ... | AccessorCalls.cs:10:10:10:11 | exit M1 |
 | pre | AccessorCalls.cs:16:9:16:24 | ...; | AccessorCalls.cs:16:9:16:12 | this access |
-| pre | AccessorCalls.cs:16:23:16:23 | access to parameter e | AccessorCalls.cs:16:9:16:23 | ... -= ... |
+| pre | AccessorCalls.cs:16:23:16:23 | access to parameter e | AccessorCalls.cs:16:9:16:18 | access to event Event |
 | pre | AccessorCalls.cs:19:10:19:11 | enter M2 | AccessorCalls.cs:20:5:26:5 | {...} |
 | pre | AccessorCalls.cs:20:5:26:5 | {...} | AccessorCalls.cs:21:9:21:36 | ...; |
 | pre | AccessorCalls.cs:21:9:21:12 | this access | AccessorCalls.cs:21:9:21:14 | access to field x |
-| pre | AccessorCalls.cs:21:9:21:14 | access to field x | AccessorCalls.cs:21:9:21:20 | access to field Field |
-| pre | AccessorCalls.cs:21:9:21:20 | access to field Field | AccessorCalls.cs:21:24:21:27 | this access |
+| pre | AccessorCalls.cs:21:9:21:14 | access to field x | AccessorCalls.cs:21:24:21:27 | this access |
 | pre | AccessorCalls.cs:21:9:21:35 | ... = ... | AccessorCalls.cs:22:9:22:34 | ...; |
 | pre | AccessorCalls.cs:21:9:21:36 | ...; | AccessorCalls.cs:21:9:21:12 | this access |
 | pre | AccessorCalls.cs:21:24:21:27 | this access | AccessorCalls.cs:21:24:21:29 | access to field x |
 | pre | AccessorCalls.cs:21:24:21:29 | access to field x | AccessorCalls.cs:21:24:21:35 | access to field Field |
 | pre | AccessorCalls.cs:21:24:21:35 | access to field Field | AccessorCalls.cs:21:9:21:35 | ... = ... |
 | pre | AccessorCalls.cs:22:9:22:12 | this access | AccessorCalls.cs:22:9:22:14 | access to field x |
-| pre | AccessorCalls.cs:22:9:22:14 | access to field x | AccessorCalls.cs:22:9:22:19 | access to property Prop |
-| pre | AccessorCalls.cs:22:9:22:19 | access to property Prop | AccessorCalls.cs:22:23:22:26 | this access |
+| pre | AccessorCalls.cs:22:9:22:14 | access to field x | AccessorCalls.cs:22:23:22:26 | this access |
+| pre | AccessorCalls.cs:22:9:22:19 | access to property Prop | AccessorCalls.cs:22:9:22:33 | ... = ... |
 | pre | AccessorCalls.cs:22:9:22:33 | ... = ... | AccessorCalls.cs:23:9:23:30 | ...; |
 | pre | AccessorCalls.cs:22:9:22:34 | ...; | AccessorCalls.cs:22:9:22:12 | this access |
 | pre | AccessorCalls.cs:22:23:22:26 | this access | AccessorCalls.cs:22:23:22:28 | access to field x |
 | pre | AccessorCalls.cs:22:23:22:28 | access to field x | AccessorCalls.cs:22:23:22:33 | access to property Prop |
-| pre | AccessorCalls.cs:22:23:22:33 | access to property Prop | AccessorCalls.cs:22:9:22:33 | ... = ... |
+| pre | AccessorCalls.cs:22:23:22:33 | access to property Prop | AccessorCalls.cs:22:9:22:19 | access to property Prop |
 | pre | AccessorCalls.cs:23:9:23:12 | this access | AccessorCalls.cs:23:9:23:14 | access to field x |
 | pre | AccessorCalls.cs:23:9:23:14 | access to field x | AccessorCalls.cs:23:16:23:16 | 0 |
-| pre | AccessorCalls.cs:23:9:23:17 | access to indexer | AccessorCalls.cs:23:21:23:24 | this access |
+| pre | AccessorCalls.cs:23:9:23:17 | access to indexer | AccessorCalls.cs:23:9:23:29 | ... = ... |
 | pre | AccessorCalls.cs:23:9:23:29 | ... = ... | AccessorCalls.cs:24:9:24:26 | ...; |
 | pre | AccessorCalls.cs:23:9:23:30 | ...; | AccessorCalls.cs:23:9:23:12 | this access |
-| pre | AccessorCalls.cs:23:16:23:16 | 0 | AccessorCalls.cs:23:9:23:17 | access to indexer |
+| pre | AccessorCalls.cs:23:16:23:16 | 0 | AccessorCalls.cs:23:21:23:24 | this access |
 | pre | AccessorCalls.cs:23:21:23:24 | this access | AccessorCalls.cs:23:21:23:26 | access to field x |
 | pre | AccessorCalls.cs:23:21:23:26 | access to field x | AccessorCalls.cs:23:28:23:28 | 1 |
-| pre | AccessorCalls.cs:23:21:23:29 | access to indexer | AccessorCalls.cs:23:9:23:29 | ... = ... |
+| pre | AccessorCalls.cs:23:21:23:29 | access to indexer | AccessorCalls.cs:23:9:23:17 | access to indexer |
 | pre | AccessorCalls.cs:23:28:23:28 | 1 | AccessorCalls.cs:23:21:23:29 | access to indexer |
 | pre | AccessorCalls.cs:24:9:24:12 | this access | AccessorCalls.cs:24:9:24:14 | access to field x |
-| pre | AccessorCalls.cs:24:9:24:14 | access to field x | AccessorCalls.cs:24:9:24:20 | access to event Event |
-| pre | AccessorCalls.cs:24:9:24:20 | access to event Event | AccessorCalls.cs:24:25:24:25 | access to parameter e |
+| pre | AccessorCalls.cs:24:9:24:14 | access to field x | AccessorCalls.cs:24:25:24:25 | access to parameter e |
+| pre | AccessorCalls.cs:24:9:24:20 | access to event Event | AccessorCalls.cs:24:9:24:25 | ... += ... |
 | pre | AccessorCalls.cs:24:9:24:25 | ... += ... | AccessorCalls.cs:25:9:25:26 | ...; |
 | pre | AccessorCalls.cs:24:9:24:26 | ...; | AccessorCalls.cs:24:9:24:12 | this access |
-| pre | AccessorCalls.cs:24:25:24:25 | access to parameter e | AccessorCalls.cs:24:9:24:25 | ... += ... |
+| pre | AccessorCalls.cs:24:25:24:25 | access to parameter e | AccessorCalls.cs:24:9:24:20 | access to event Event |
 | pre | AccessorCalls.cs:25:9:25:12 | this access | AccessorCalls.cs:25:9:25:14 | access to field x |
-| pre | AccessorCalls.cs:25:9:25:14 | access to field x | AccessorCalls.cs:25:9:25:20 | access to event Event |
-| pre | AccessorCalls.cs:25:9:25:20 | access to event Event | AccessorCalls.cs:25:25:25:25 | access to parameter e |
+| pre | AccessorCalls.cs:25:9:25:14 | access to field x | AccessorCalls.cs:25:25:25:25 | access to parameter e |
+| pre | AccessorCalls.cs:25:9:25:20 | access to event Event | AccessorCalls.cs:25:9:25:25 | ... -= ... |
 | pre | AccessorCalls.cs:25:9:25:25 | ... -= ... | AccessorCalls.cs:19:10:19:11 | exit M2 |
 | pre | AccessorCalls.cs:25:9:25:26 | ...; | AccessorCalls.cs:25:9:25:12 | this access |
-| pre | AccessorCalls.cs:25:25:25:25 | access to parameter e | AccessorCalls.cs:25:9:25:25 | ... -= ... |
+| pre | AccessorCalls.cs:25:25:25:25 | access to parameter e | AccessorCalls.cs:25:9:25:20 | access to event Event |
 | pre | AccessorCalls.cs:28:10:28:11 | enter M3 | AccessorCalls.cs:29:5:33:5 | {...} |
 | pre | AccessorCalls.cs:29:5:33:5 | {...} | AccessorCalls.cs:30:9:30:21 | ...; |
 | pre | AccessorCalls.cs:30:9:30:12 | this access | AccessorCalls.cs:30:9:30:18 | access to field Field |
@@ -2596,32 +2506,31 @@
 | pre | AccessorCalls.cs:39:16:39:16 | 0 | AccessorCalls.cs:39:9:39:17 | access to indexer |
 | pre | AccessorCalls.cs:42:10:42:11 | enter M5 | AccessorCalls.cs:43:5:47:5 | {...} |
 | pre | AccessorCalls.cs:43:5:47:5 | {...} | AccessorCalls.cs:44:9:44:33 | ...; |
+| pre | AccessorCalls.cs:44:9:44:12 | this access | AccessorCalls.cs:44:9:44:12 | this access |
 | pre | AccessorCalls.cs:44:9:44:12 | this access | AccessorCalls.cs:44:9:44:18 | access to field Field |
-| pre | AccessorCalls.cs:44:9:44:12 | this access | AccessorCalls.cs:44:9:44:18 | access to field Field |
-| pre | AccessorCalls.cs:44:9:44:18 | access to field Field | AccessorCalls.cs:44:9:44:12 | this access |
 | pre | AccessorCalls.cs:44:9:44:18 | access to field Field | AccessorCalls.cs:44:23:44:26 | this access |
 | pre | AccessorCalls.cs:44:9:44:32 | ... + ... | AccessorCalls.cs:44:9:44:32 | ... = ... |
 | pre | AccessorCalls.cs:44:9:44:32 | ... = ... | AccessorCalls.cs:45:9:45:31 | ...; |
 | pre | AccessorCalls.cs:44:9:44:33 | ...; | AccessorCalls.cs:44:9:44:12 | this access |
 | pre | AccessorCalls.cs:44:23:44:26 | this access | AccessorCalls.cs:44:23:44:32 | access to field Field |
 | pre | AccessorCalls.cs:44:23:44:32 | access to field Field | AccessorCalls.cs:44:9:44:32 | ... + ... |
+| pre | AccessorCalls.cs:45:9:45:12 | this access | AccessorCalls.cs:45:9:45:12 | this access |
 | pre | AccessorCalls.cs:45:9:45:12 | this access | AccessorCalls.cs:45:9:45:17 | access to property Prop |
-| pre | AccessorCalls.cs:45:9:45:12 | this access | AccessorCalls.cs:45:9:45:17 | access to property Prop |
-| pre | AccessorCalls.cs:45:9:45:17 | access to property Prop | AccessorCalls.cs:45:9:45:12 | this access |
+| pre | AccessorCalls.cs:45:9:45:17 | access to property Prop | AccessorCalls.cs:45:9:45:30 | ... = ... |
 | pre | AccessorCalls.cs:45:9:45:17 | access to property Prop | AccessorCalls.cs:45:22:45:25 | this access |
-| pre | AccessorCalls.cs:45:9:45:30 | ... + ... | AccessorCalls.cs:45:9:45:30 | ... = ... |
+| pre | AccessorCalls.cs:45:9:45:30 | ... + ... | AccessorCalls.cs:45:9:45:17 | access to property Prop |
 | pre | AccessorCalls.cs:45:9:45:30 | ... = ... | AccessorCalls.cs:46:9:46:27 | ...; |
 | pre | AccessorCalls.cs:45:9:45:31 | ...; | AccessorCalls.cs:45:9:45:12 | this access |
 | pre | AccessorCalls.cs:45:22:45:25 | this access | AccessorCalls.cs:45:22:45:30 | access to property Prop |
 | pre | AccessorCalls.cs:45:22:45:30 | access to property Prop | AccessorCalls.cs:45:9:45:30 | ... + ... |
 | pre | AccessorCalls.cs:46:9:46:12 | this access | AccessorCalls.cs:46:14:46:14 | 0 |
 | pre | AccessorCalls.cs:46:9:46:12 | this access | AccessorCalls.cs:46:14:46:14 | 0 |
-| pre | AccessorCalls.cs:46:9:46:15 | access to indexer | AccessorCalls.cs:46:9:46:12 | this access |
+| pre | AccessorCalls.cs:46:9:46:15 | access to indexer | AccessorCalls.cs:46:9:46:26 | ... = ... |
 | pre | AccessorCalls.cs:46:9:46:15 | access to indexer | AccessorCalls.cs:46:20:46:23 | this access |
-| pre | AccessorCalls.cs:46:9:46:26 | ... + ... | AccessorCalls.cs:46:9:46:26 | ... = ... |
+| pre | AccessorCalls.cs:46:9:46:26 | ... + ... | AccessorCalls.cs:46:9:46:15 | access to indexer |
 | pre | AccessorCalls.cs:46:9:46:26 | ... = ... | AccessorCalls.cs:42:10:42:11 | exit M5 |
 | pre | AccessorCalls.cs:46:9:46:27 | ...; | AccessorCalls.cs:46:9:46:12 | this access |
-| pre | AccessorCalls.cs:46:14:46:14 | 0 | AccessorCalls.cs:46:9:46:15 | access to indexer |
+| pre | AccessorCalls.cs:46:14:46:14 | 0 | AccessorCalls.cs:46:9:46:12 | this access |
 | pre | AccessorCalls.cs:46:14:46:14 | 0 | AccessorCalls.cs:46:9:46:15 | access to indexer |
 | pre | AccessorCalls.cs:46:20:46:23 | this access | AccessorCalls.cs:46:25:46:25 | 0 |
 | pre | AccessorCalls.cs:46:20:46:26 | access to indexer | AccessorCalls.cs:46:9:46:26 | ... + ... |
@@ -2630,9 +2539,8 @@
 | pre | AccessorCalls.cs:50:5:54:5 | {...} | AccessorCalls.cs:51:9:51:37 | ...; |
 | pre | AccessorCalls.cs:51:9:51:12 | this access | AccessorCalls.cs:51:9:51:14 | access to field x |
 | pre | AccessorCalls.cs:51:9:51:12 | this access | AccessorCalls.cs:51:9:51:14 | access to field x |
+| pre | AccessorCalls.cs:51:9:51:14 | access to field x | AccessorCalls.cs:51:9:51:12 | this access |
 | pre | AccessorCalls.cs:51:9:51:14 | access to field x | AccessorCalls.cs:51:9:51:20 | access to field Field |
-| pre | AccessorCalls.cs:51:9:51:14 | access to field x | AccessorCalls.cs:51:9:51:20 | access to field Field |
-| pre | AccessorCalls.cs:51:9:51:20 | access to field Field | AccessorCalls.cs:51:9:51:12 | this access |
 | pre | AccessorCalls.cs:51:9:51:20 | access to field Field | AccessorCalls.cs:51:25:51:28 | this access |
 | pre | AccessorCalls.cs:51:9:51:36 | ... + ... | AccessorCalls.cs:51:9:51:36 | ... = ... |
 | pre | AccessorCalls.cs:51:9:51:36 | ... = ... | AccessorCalls.cs:52:9:52:35 | ...; |
@@ -2642,11 +2550,11 @@
 | pre | AccessorCalls.cs:51:25:51:36 | access to field Field | AccessorCalls.cs:51:9:51:36 | ... + ... |
 | pre | AccessorCalls.cs:52:9:52:12 | this access | AccessorCalls.cs:52:9:52:14 | access to field x |
 | pre | AccessorCalls.cs:52:9:52:12 | this access | AccessorCalls.cs:52:9:52:14 | access to field x |
+| pre | AccessorCalls.cs:52:9:52:14 | access to field x | AccessorCalls.cs:52:9:52:12 | this access |
 | pre | AccessorCalls.cs:52:9:52:14 | access to field x | AccessorCalls.cs:52:9:52:19 | access to property Prop |
-| pre | AccessorCalls.cs:52:9:52:14 | access to field x | AccessorCalls.cs:52:9:52:19 | access to property Prop |
-| pre | AccessorCalls.cs:52:9:52:19 | access to property Prop | AccessorCalls.cs:52:9:52:12 | this access |
+| pre | AccessorCalls.cs:52:9:52:19 | access to property Prop | AccessorCalls.cs:52:9:52:34 | ... = ... |
 | pre | AccessorCalls.cs:52:9:52:19 | access to property Prop | AccessorCalls.cs:52:24:52:27 | this access |
-| pre | AccessorCalls.cs:52:9:52:34 | ... + ... | AccessorCalls.cs:52:9:52:34 | ... = ... |
+| pre | AccessorCalls.cs:52:9:52:34 | ... + ... | AccessorCalls.cs:52:9:52:19 | access to property Prop |
 | pre | AccessorCalls.cs:52:9:52:34 | ... = ... | AccessorCalls.cs:53:9:53:31 | ...; |
 | pre | AccessorCalls.cs:52:9:52:35 | ...; | AccessorCalls.cs:52:9:52:12 | this access |
 | pre | AccessorCalls.cs:52:24:52:27 | this access | AccessorCalls.cs:52:24:52:29 | access to field x |
@@ -2656,12 +2564,12 @@
 | pre | AccessorCalls.cs:53:9:53:12 | this access | AccessorCalls.cs:53:9:53:14 | access to field x |
 | pre | AccessorCalls.cs:53:9:53:14 | access to field x | AccessorCalls.cs:53:16:53:16 | 0 |
 | pre | AccessorCalls.cs:53:9:53:14 | access to field x | AccessorCalls.cs:53:16:53:16 | 0 |
-| pre | AccessorCalls.cs:53:9:53:17 | access to indexer | AccessorCalls.cs:53:9:53:12 | this access |
+| pre | AccessorCalls.cs:53:9:53:17 | access to indexer | AccessorCalls.cs:53:9:53:30 | ... = ... |
 | pre | AccessorCalls.cs:53:9:53:17 | access to indexer | AccessorCalls.cs:53:22:53:25 | this access |
-| pre | AccessorCalls.cs:53:9:53:30 | ... + ... | AccessorCalls.cs:53:9:53:30 | ... = ... |
+| pre | AccessorCalls.cs:53:9:53:30 | ... + ... | AccessorCalls.cs:53:9:53:17 | access to indexer |
 | pre | AccessorCalls.cs:53:9:53:30 | ... = ... | AccessorCalls.cs:49:10:49:11 | exit M6 |
 | pre | AccessorCalls.cs:53:9:53:31 | ...; | AccessorCalls.cs:53:9:53:12 | this access |
-| pre | AccessorCalls.cs:53:16:53:16 | 0 | AccessorCalls.cs:53:9:53:17 | access to indexer |
+| pre | AccessorCalls.cs:53:16:53:16 | 0 | AccessorCalls.cs:53:9:53:12 | this access |
 | pre | AccessorCalls.cs:53:16:53:16 | 0 | AccessorCalls.cs:53:9:53:17 | access to indexer |
 | pre | AccessorCalls.cs:53:22:53:25 | this access | AccessorCalls.cs:53:22:53:27 | access to field x |
 | pre | AccessorCalls.cs:53:22:53:27 | access to field x | AccessorCalls.cs:53:29:53:29 | 0 |
@@ -2672,16 +2580,14 @@
 | pre | AccessorCalls.cs:58:9:58:45 | (..., ...) | AccessorCalls.cs:58:50:58:53 | this access |
 | pre | AccessorCalls.cs:58:9:58:85 | ... = ... | AccessorCalls.cs:56:10:56:11 | exit M7 |
 | pre | AccessorCalls.cs:58:9:58:86 | ...; | AccessorCalls.cs:58:10:58:13 | this access |
-| pre | AccessorCalls.cs:58:10:58:13 | this access | AccessorCalls.cs:58:10:58:19 | access to field Field |
-| pre | AccessorCalls.cs:58:10:58:19 | access to field Field | AccessorCalls.cs:58:22:58:25 | this access |
-| pre | AccessorCalls.cs:58:22:58:25 | this access | AccessorCalls.cs:58:22:58:30 | access to property Prop |
-| pre | AccessorCalls.cs:58:22:58:30 | access to property Prop | AccessorCalls.cs:58:34:58:34 | access to parameter i |
+| pre | AccessorCalls.cs:58:10:58:13 | this access | AccessorCalls.cs:58:22:58:25 | this access |
+| pre | AccessorCalls.cs:58:22:58:25 | this access | AccessorCalls.cs:58:37:58:40 | this access |
+| pre | AccessorCalls.cs:58:22:58:30 | access to property Prop | AccessorCalls.cs:58:37:58:43 | access to indexer |
 | pre | AccessorCalls.cs:58:33:58:44 | (..., ...) | AccessorCalls.cs:58:9:58:45 | (..., ...) |
-| pre | AccessorCalls.cs:58:34:58:34 | access to parameter i | AccessorCalls.cs:58:37:58:40 | this access |
 | pre | AccessorCalls.cs:58:37:58:40 | this access | AccessorCalls.cs:58:42:58:42 | 0 |
-| pre | AccessorCalls.cs:58:37:58:43 | access to indexer | AccessorCalls.cs:58:33:58:44 | (..., ...) |
-| pre | AccessorCalls.cs:58:42:58:42 | 0 | AccessorCalls.cs:58:37:58:43 | access to indexer |
-| pre | AccessorCalls.cs:58:49:58:85 | (..., ...) | AccessorCalls.cs:58:9:58:85 | ... = ... |
+| pre | AccessorCalls.cs:58:37:58:43 | access to indexer | AccessorCalls.cs:58:9:58:85 | ... = ... |
+| pre | AccessorCalls.cs:58:42:58:42 | 0 | AccessorCalls.cs:58:33:58:44 | (..., ...) |
+| pre | AccessorCalls.cs:58:49:58:85 | (..., ...) | AccessorCalls.cs:58:22:58:30 | access to property Prop |
 | pre | AccessorCalls.cs:58:50:58:53 | this access | AccessorCalls.cs:58:50:58:59 | access to field Field |
 | pre | AccessorCalls.cs:58:50:58:59 | access to field Field | AccessorCalls.cs:58:62:58:65 | this access |
 | pre | AccessorCalls.cs:58:62:58:65 | this access | AccessorCalls.cs:58:62:58:70 | access to property Prop |
@@ -2697,18 +2603,16 @@
 | pre | AccessorCalls.cs:63:9:63:97 | ... = ... | AccessorCalls.cs:61:10:61:11 | exit M8 |
 | pre | AccessorCalls.cs:63:9:63:98 | ...; | AccessorCalls.cs:63:10:63:13 | this access |
 | pre | AccessorCalls.cs:63:10:63:13 | this access | AccessorCalls.cs:63:10:63:15 | access to field x |
-| pre | AccessorCalls.cs:63:10:63:15 | access to field x | AccessorCalls.cs:63:10:63:21 | access to field Field |
-| pre | AccessorCalls.cs:63:10:63:21 | access to field Field | AccessorCalls.cs:63:24:63:27 | this access |
+| pre | AccessorCalls.cs:63:10:63:15 | access to field x | AccessorCalls.cs:63:24:63:27 | this access |
 | pre | AccessorCalls.cs:63:24:63:27 | this access | AccessorCalls.cs:63:24:63:29 | access to field x |
-| pre | AccessorCalls.cs:63:24:63:29 | access to field x | AccessorCalls.cs:63:24:63:34 | access to property Prop |
-| pre | AccessorCalls.cs:63:24:63:34 | access to property Prop | AccessorCalls.cs:63:38:63:38 | access to parameter i |
+| pre | AccessorCalls.cs:63:24:63:29 | access to field x | AccessorCalls.cs:63:41:63:44 | this access |
+| pre | AccessorCalls.cs:63:24:63:34 | access to property Prop | AccessorCalls.cs:63:41:63:49 | access to indexer |
 | pre | AccessorCalls.cs:63:37:63:50 | (..., ...) | AccessorCalls.cs:63:9:63:51 | (..., ...) |
-| pre | AccessorCalls.cs:63:38:63:38 | access to parameter i | AccessorCalls.cs:63:41:63:44 | this access |
 | pre | AccessorCalls.cs:63:41:63:44 | this access | AccessorCalls.cs:63:41:63:46 | access to field x |
 | pre | AccessorCalls.cs:63:41:63:46 | access to field x | AccessorCalls.cs:63:48:63:48 | 0 |
-| pre | AccessorCalls.cs:63:41:63:49 | access to indexer | AccessorCalls.cs:63:37:63:50 | (..., ...) |
-| pre | AccessorCalls.cs:63:48:63:48 | 0 | AccessorCalls.cs:63:41:63:49 | access to indexer |
-| pre | AccessorCalls.cs:63:55:63:97 | (..., ...) | AccessorCalls.cs:63:9:63:97 | ... = ... |
+| pre | AccessorCalls.cs:63:41:63:49 | access to indexer | AccessorCalls.cs:63:9:63:97 | ... = ... |
+| pre | AccessorCalls.cs:63:48:63:48 | 0 | AccessorCalls.cs:63:37:63:50 | (..., ...) |
+| pre | AccessorCalls.cs:63:55:63:97 | (..., ...) | AccessorCalls.cs:63:24:63:34 | access to property Prop |
 | pre | AccessorCalls.cs:63:56:63:59 | this access | AccessorCalls.cs:63:56:63:61 | access to field x |
 | pre | AccessorCalls.cs:63:56:63:61 | access to field x | AccessorCalls.cs:63:56:63:67 | access to field Field |
 | pre | AccessorCalls.cs:63:56:63:67 | access to field Field | AccessorCalls.cs:63:70:63:73 | this access |
@@ -2744,42 +2648,36 @@
 | pre | ArrayCreation.cs:9:48:9:48 | 3 | ArrayCreation.cs:9:43:9:50 | { ..., ... } |
 | pre | Assignments.cs:3:10:3:10 | enter M | Assignments.cs:4:5:15:5 | {...} |
 | pre | Assignments.cs:4:5:15:5 | {...} | Assignments.cs:5:9:5:18 | ... ...; |
-| pre | Assignments.cs:5:9:5:18 | ... ...; | Assignments.cs:5:13:5:13 | access to local variable x |
-| pre | Assignments.cs:5:13:5:13 | access to local variable x | Assignments.cs:5:17:5:17 | 0 |
+| pre | Assignments.cs:5:9:5:18 | ... ...; | Assignments.cs:5:17:5:17 | 0 |
 | pre | Assignments.cs:5:13:5:17 | Int32 x = ... | Assignments.cs:6:9:6:15 | ...; |
 | pre | Assignments.cs:5:17:5:17 | 0 | Assignments.cs:5:13:5:17 | Int32 x = ... |
-| pre | Assignments.cs:6:9:6:9 | access to local variable x | Assignments.cs:6:9:6:9 | access to local variable x |
 | pre | Assignments.cs:6:9:6:9 | access to local variable x | Assignments.cs:6:14:6:14 | 1 |
 | pre | Assignments.cs:6:9:6:14 | ... + ... | Assignments.cs:6:9:6:14 | ... = ... |
 | pre | Assignments.cs:6:9:6:14 | ... = ... | Assignments.cs:8:9:8:22 | ... ...; |
 | pre | Assignments.cs:6:9:6:15 | ...; | Assignments.cs:6:9:6:9 | access to local variable x |
 | pre | Assignments.cs:6:14:6:14 | 1 | Assignments.cs:6:9:6:14 | ... + ... |
-| pre | Assignments.cs:8:9:8:22 | ... ...; | Assignments.cs:8:17:8:17 | access to local variable d |
-| pre | Assignments.cs:8:17:8:17 | access to local variable d | Assignments.cs:8:21:8:21 | 0 |
+| pre | Assignments.cs:8:9:8:22 | ... ...; | Assignments.cs:8:21:8:21 | 0 |
 | pre | Assignments.cs:8:17:8:21 | dynamic d = ... | Assignments.cs:9:9:9:15 | ...; |
 | pre | Assignments.cs:8:21:8:21 | 0 | Assignments.cs:8:21:8:21 | (...) ... |
 | pre | Assignments.cs:8:21:8:21 | (...) ... | Assignments.cs:8:17:8:21 | dynamic d = ... |
-| pre | Assignments.cs:9:9:9:9 | access to local variable d | Assignments.cs:9:9:9:9 | access to local variable d |
 | pre | Assignments.cs:9:9:9:9 | access to local variable d | Assignments.cs:9:14:9:14 | 2 |
 | pre | Assignments.cs:9:9:9:14 | ... = ... | Assignments.cs:11:9:11:34 | ... ...; |
 | pre | Assignments.cs:9:9:9:14 | dynamic call to operator - | Assignments.cs:9:9:9:14 | ... = ... |
 | pre | Assignments.cs:9:9:9:15 | ...; | Assignments.cs:9:9:9:9 | access to local variable d |
 | pre | Assignments.cs:9:14:9:14 | 2 | Assignments.cs:9:9:9:14 | dynamic call to operator - |
-| pre | Assignments.cs:11:9:11:34 | ... ...; | Assignments.cs:11:13:11:13 | access to local variable a |
-| pre | Assignments.cs:11:13:11:13 | access to local variable a | Assignments.cs:11:17:11:33 | object creation of type Assignments |
+| pre | Assignments.cs:11:9:11:34 | ... ...; | Assignments.cs:11:17:11:33 | object creation of type Assignments |
 | pre | Assignments.cs:11:13:11:33 | Assignments a = ... | Assignments.cs:12:9:12:18 | ...; |
 | pre | Assignments.cs:11:17:11:33 | object creation of type Assignments | Assignments.cs:11:13:11:33 | Assignments a = ... |
-| pre | Assignments.cs:12:9:12:9 | access to local variable a | Assignments.cs:12:9:12:9 | access to local variable a |
 | pre | Assignments.cs:12:9:12:9 | access to local variable a | Assignments.cs:12:14:12:17 | this access |
 | pre | Assignments.cs:12:9:12:17 | ... = ... | Assignments.cs:14:9:14:36 | ...; |
 | pre | Assignments.cs:12:9:12:17 | call to operator + | Assignments.cs:12:9:12:17 | ... = ... |
 | pre | Assignments.cs:12:9:12:18 | ...; | Assignments.cs:12:9:12:9 | access to local variable a |
 | pre | Assignments.cs:12:14:12:17 | this access | Assignments.cs:12:9:12:17 | call to operator + |
-| pre | Assignments.cs:14:9:14:13 | access to event Event | Assignments.cs:14:18:14:35 | (...) => ... |
-| pre | Assignments.cs:14:9:14:13 | this access | Assignments.cs:14:9:14:13 | access to event Event |
+| pre | Assignments.cs:14:9:14:13 | access to event Event | Assignments.cs:14:9:14:35 | ... += ... |
+| pre | Assignments.cs:14:9:14:13 | this access | Assignments.cs:14:18:14:35 | (...) => ... |
 | pre | Assignments.cs:14:9:14:35 | ... += ... | Assignments.cs:3:10:3:10 | exit M |
 | pre | Assignments.cs:14:9:14:36 | ...; | Assignments.cs:14:9:14:13 | this access |
-| pre | Assignments.cs:14:18:14:35 | (...) => ... | Assignments.cs:14:9:14:35 | ... += ... |
+| pre | Assignments.cs:14:18:14:35 | (...) => ... | Assignments.cs:14:9:14:13 | access to event Event |
 | pre | Assignments.cs:14:18:14:35 | enter (...) => ... | Assignments.cs:14:33:14:35 | {...} |
 | pre | Assignments.cs:14:33:14:35 | {...} | Assignments.cs:14:18:14:35 | exit (...) => ... |
 | pre | Assignments.cs:17:40:17:40 | enter + | Assignments.cs:18:5:20:5 | {...} |
@@ -3054,20 +2952,17 @@
 | pre | ConditionalAccess.cs:19:58:19:59 | access to parameter s2 | ConditionalAccess.cs:19:43:19:60 | call to method CommaJoinWith |
 | pre | ConditionalAccess.cs:21:10:21:11 | enter M7 | ConditionalAccess.cs:22:5:26:5 | {...} |
 | pre | ConditionalAccess.cs:22:5:26:5 | {...} | ConditionalAccess.cs:23:9:23:39 | ... ...; |
-| pre | ConditionalAccess.cs:23:9:23:39 | ... ...; | ConditionalAccess.cs:23:13:23:13 | access to local variable j |
-| pre | ConditionalAccess.cs:23:13:23:13 | access to local variable j | ConditionalAccess.cs:23:26:23:29 | null |
+| pre | ConditionalAccess.cs:23:9:23:39 | ... ...; | ConditionalAccess.cs:23:26:23:29 | null |
 | pre | ConditionalAccess.cs:23:13:23:38 | Nullable<Int32> j = ... | ConditionalAccess.cs:24:9:24:38 | ... ...; |
 | pre | ConditionalAccess.cs:23:18:23:29 | (...) ... | ConditionalAccess.cs:23:13:23:38 | Nullable<Int32> j = ... |
 | pre | ConditionalAccess.cs:23:26:23:29 | null | ConditionalAccess.cs:23:18:23:29 | (...) ... |
-| pre | ConditionalAccess.cs:24:9:24:38 | ... ...; | ConditionalAccess.cs:24:13:24:13 | access to local variable s |
-| pre | ConditionalAccess.cs:24:13:24:13 | access to local variable s | ConditionalAccess.cs:24:24:24:24 | access to parameter i |
+| pre | ConditionalAccess.cs:24:9:24:38 | ... ...; | ConditionalAccess.cs:24:24:24:24 | access to parameter i |
 | pre | ConditionalAccess.cs:24:13:24:37 | String s = ... | ConditionalAccess.cs:25:9:25:33 | ...; |
 | pre | ConditionalAccess.cs:24:18:24:24 | (...) ... | ConditionalAccess.cs:24:27:24:37 | call to method ToString |
 | pre | ConditionalAccess.cs:24:24:24:24 | access to parameter i | ConditionalAccess.cs:24:18:24:24 | (...) ... |
 | pre | ConditionalAccess.cs:24:27:24:37 | call to method ToString | ConditionalAccess.cs:24:13:24:37 | String s = ... |
-| pre | ConditionalAccess.cs:25:9:25:9 | access to local variable s | ConditionalAccess.cs:25:13:25:14 | "" |
 | pre | ConditionalAccess.cs:25:9:25:32 | ... = ... | ConditionalAccess.cs:21:10:21:11 | exit M7 |
-| pre | ConditionalAccess.cs:25:9:25:33 | ...; | ConditionalAccess.cs:25:9:25:9 | access to local variable s |
+| pre | ConditionalAccess.cs:25:9:25:33 | ...; | ConditionalAccess.cs:25:13:25:14 | "" |
 | pre | ConditionalAccess.cs:25:13:25:14 | "" | ConditionalAccess.cs:25:31:25:31 | access to local variable s |
 | pre | ConditionalAccess.cs:25:16:25:32 | call to method CommaJoinWith | ConditionalAccess.cs:25:9:25:32 | ... = ... |
 | pre | ConditionalAccess.cs:25:31:25:31 | access to local variable s | ConditionalAccess.cs:25:16:25:32 | call to method CommaJoinWith |
@@ -3094,8 +2989,7 @@
 | pre | Conditions.cs:8:13:8:16 | ...; | Conditions.cs:8:13:8:13 | access to parameter x |
 | pre | Conditions.cs:11:9:11:10 | enter M1 | Conditions.cs:12:5:20:5 | {...} |
 | pre | Conditions.cs:12:5:20:5 | {...} | Conditions.cs:13:9:13:18 | ... ...; |
-| pre | Conditions.cs:13:9:13:18 | ... ...; | Conditions.cs:13:13:13:13 | access to local variable x |
-| pre | Conditions.cs:13:13:13:13 | access to local variable x | Conditions.cs:13:17:13:17 | 0 |
+| pre | Conditions.cs:13:9:13:18 | ... ...; | Conditions.cs:13:17:13:17 | 0 |
 | pre | Conditions.cs:13:13:13:17 | Int32 x = ... | Conditions.cs:14:9:15:16 | if (...) ... |
 | pre | Conditions.cs:13:17:13:17 | 0 | Conditions.cs:13:13:13:17 | Int32 x = ... |
 | pre | Conditions.cs:14:9:15:16 | if (...) ... | Conditions.cs:14:13:14:13 | access to parameter b |
@@ -3123,8 +3017,7 @@
 | pre | Conditions.cs:19:16:19:16 | access to local variable x | Conditions.cs:19:9:19:17 | return ...; |
 | pre | Conditions.cs:22:9:22:10 | enter M2 | Conditions.cs:23:5:31:5 | {...} |
 | pre | Conditions.cs:23:5:31:5 | {...} | Conditions.cs:24:9:24:18 | ... ...; |
-| pre | Conditions.cs:24:9:24:18 | ... ...; | Conditions.cs:24:13:24:13 | access to local variable x |
-| pre | Conditions.cs:24:13:24:13 | access to local variable x | Conditions.cs:24:17:24:17 | 0 |
+| pre | Conditions.cs:24:9:24:18 | ... ...; | Conditions.cs:24:17:24:17 | 0 |
 | pre | Conditions.cs:24:13:24:17 | Int32 x = ... | Conditions.cs:25:9:27:20 | if (...) ... |
 | pre | Conditions.cs:24:17:24:17 | 0 | Conditions.cs:24:13:24:17 | Int32 x = ... |
 | pre | Conditions.cs:25:9:27:20 | if (...) ... | Conditions.cs:25:13:25:14 | access to parameter b1 |
@@ -3145,19 +3038,16 @@
 | pre | Conditions.cs:30:16:30:16 | access to local variable x | Conditions.cs:30:9:30:17 | return ...; |
 | pre | Conditions.cs:33:9:33:10 | enter M3 | Conditions.cs:34:5:44:5 | {...} |
 | pre | Conditions.cs:34:5:44:5 | {...} | Conditions.cs:35:9:35:18 | ... ...; |
-| pre | Conditions.cs:35:9:35:18 | ... ...; | Conditions.cs:35:13:35:13 | access to local variable x |
-| pre | Conditions.cs:35:13:35:13 | access to local variable x | Conditions.cs:35:17:35:17 | 0 |
+| pre | Conditions.cs:35:9:35:18 | ... ...; | Conditions.cs:35:17:35:17 | 0 |
 | pre | Conditions.cs:35:13:35:17 | Int32 x = ... | Conditions.cs:36:9:36:23 | ... ...; |
 | pre | Conditions.cs:35:17:35:17 | 0 | Conditions.cs:35:13:35:17 | Int32 x = ... |
-| pre | Conditions.cs:36:9:36:23 | ... ...; | Conditions.cs:36:13:36:14 | access to local variable b2 |
-| pre | Conditions.cs:36:13:36:14 | access to local variable b2 | Conditions.cs:36:18:36:22 | false |
+| pre | Conditions.cs:36:9:36:23 | ... ...; | Conditions.cs:36:18:36:22 | false |
 | pre | Conditions.cs:36:13:36:22 | Boolean b2 = ... | Conditions.cs:37:9:38:20 | if (...) ... |
 | pre | Conditions.cs:36:18:36:22 | false | Conditions.cs:36:13:36:22 | Boolean b2 = ... |
 | pre | Conditions.cs:37:9:38:20 | if (...) ... | Conditions.cs:37:13:37:14 | access to parameter b1 |
 | pre | Conditions.cs:37:13:37:14 | access to parameter b1 | Conditions.cs:38:13:38:20 | ...; |
 | pre | Conditions.cs:37:13:37:14 | access to parameter b1 | Conditions.cs:39:9:40:16 | if (...) ... |
-| pre | Conditions.cs:38:13:38:14 | access to local variable b2 | Conditions.cs:38:18:38:19 | access to parameter b1 |
-| pre | Conditions.cs:38:13:38:20 | ...; | Conditions.cs:38:13:38:14 | access to local variable b2 |
+| pre | Conditions.cs:38:13:38:20 | ...; | Conditions.cs:38:18:38:19 | access to parameter b1 |
 | pre | Conditions.cs:38:18:38:19 | access to parameter b1 | Conditions.cs:38:13:38:19 | ... = ... |
 | pre | Conditions.cs:39:9:40:16 | if (...) ... | Conditions.cs:39:13:39:14 | access to local variable b2 |
 | pre | Conditions.cs:39:13:39:14 | access to local variable b2 | Conditions.cs:40:13:40:16 | [b2 (line 39): true] ...; |
@@ -3174,8 +3064,7 @@
 | pre | Conditions.cs:43:16:43:16 | access to local variable x | Conditions.cs:43:9:43:17 | return ...; |
 | pre | Conditions.cs:46:9:46:10 | enter M4 | Conditions.cs:47:5:55:5 | {...} |
 | pre | Conditions.cs:47:5:55:5 | {...} | Conditions.cs:48:9:48:18 | ... ...; |
-| pre | Conditions.cs:48:9:48:18 | ... ...; | Conditions.cs:48:13:48:13 | access to local variable y |
-| pre | Conditions.cs:48:13:48:13 | access to local variable y | Conditions.cs:48:17:48:17 | 0 |
+| pre | Conditions.cs:48:9:48:18 | ... ...; | Conditions.cs:48:17:48:17 | 0 |
 | pre | Conditions.cs:48:13:48:17 | Int32 y = ... | Conditions.cs:49:9:53:9 | while (...) ... |
 | pre | Conditions.cs:48:17:48:17 | 0 | Conditions.cs:48:13:48:17 | Int32 y = ... |
 | pre | Conditions.cs:49:9:53:9 | while (...) ... | Conditions.cs:49:16:49:16 | access to parameter x |
@@ -3207,8 +3096,7 @@
 | pre | Conditions.cs:54:16:54:16 | access to local variable y | Conditions.cs:54:9:54:17 | return ...; |
 | pre | Conditions.cs:57:9:57:10 | enter M5 | Conditions.cs:58:5:68:5 | {...} |
 | pre | Conditions.cs:58:5:68:5 | {...} | Conditions.cs:59:9:59:18 | ... ...; |
-| pre | Conditions.cs:59:9:59:18 | ... ...; | Conditions.cs:59:13:59:13 | access to local variable y |
-| pre | Conditions.cs:59:13:59:13 | access to local variable y | Conditions.cs:59:17:59:17 | 0 |
+| pre | Conditions.cs:59:9:59:18 | ... ...; | Conditions.cs:59:17:59:17 | 0 |
 | pre | Conditions.cs:59:13:59:17 | Int32 y = ... | Conditions.cs:60:9:64:9 | while (...) ... |
 | pre | Conditions.cs:59:17:59:17 | 0 | Conditions.cs:59:13:59:17 | Int32 y = ... |
 | pre | Conditions.cs:60:9:64:9 | while (...) ... | Conditions.cs:60:16:60:16 | access to parameter x |
@@ -3247,15 +3135,13 @@
 | pre | Conditions.cs:67:16:67:16 | access to local variable y | Conditions.cs:67:9:67:17 | return ...; |
 | pre | Conditions.cs:70:9:70:10 | enter M6 | Conditions.cs:71:5:84:5 | {...} |
 | pre | Conditions.cs:71:5:84:5 | {...} | Conditions.cs:72:9:72:30 | ... ...; |
-| pre | Conditions.cs:72:9:72:30 | ... ...; | Conditions.cs:72:13:72:13 | access to local variable b |
-| pre | Conditions.cs:72:13:72:13 | access to local variable b | Conditions.cs:72:17:72:18 | access to parameter ss |
+| pre | Conditions.cs:72:9:72:30 | ... ...; | Conditions.cs:72:17:72:18 | access to parameter ss |
 | pre | Conditions.cs:72:13:72:29 | Boolean b = ... | Conditions.cs:73:9:73:18 | ... ...; |
 | pre | Conditions.cs:72:17:72:18 | access to parameter ss | Conditions.cs:72:17:72:25 | access to property Length |
 | pre | Conditions.cs:72:17:72:25 | access to property Length | Conditions.cs:72:29:72:29 | 0 |
 | pre | Conditions.cs:72:17:72:29 | ... > ... | Conditions.cs:72:13:72:29 | Boolean b = ... |
 | pre | Conditions.cs:72:29:72:29 | 0 | Conditions.cs:72:17:72:29 | ... > ... |
-| pre | Conditions.cs:73:9:73:18 | ... ...; | Conditions.cs:73:13:73:13 | access to local variable x |
-| pre | Conditions.cs:73:13:73:13 | access to local variable x | Conditions.cs:73:17:73:17 | 0 |
+| pre | Conditions.cs:73:9:73:18 | ... ...; | Conditions.cs:73:17:73:17 | 0 |
 | pre | Conditions.cs:73:13:73:17 | Int32 x = ... | Conditions.cs:74:27:74:28 | access to parameter ss |
 | pre | Conditions.cs:73:17:73:17 | 0 | Conditions.cs:73:13:73:17 | Int32 x = ... |
 | pre | Conditions.cs:74:9:80:9 | foreach (... ... in ...) ... | Conditions.cs:75:9:80:9 | {...} |
@@ -3271,8 +3157,7 @@
 | pre | Conditions.cs:78:17:78:17 | access to local variable x | Conditions.cs:78:21:78:21 | 0 |
 | pre | Conditions.cs:78:17:78:21 | ... > ... | Conditions.cs:79:17:79:26 | ...; |
 | pre | Conditions.cs:78:21:78:21 | 0 | Conditions.cs:78:17:78:21 | ... > ... |
-| pre | Conditions.cs:79:17:79:17 | access to local variable b | Conditions.cs:79:21:79:25 | false |
-| pre | Conditions.cs:79:17:79:26 | ...; | Conditions.cs:79:17:79:17 | access to local variable b |
+| pre | Conditions.cs:79:17:79:26 | ...; | Conditions.cs:79:21:79:25 | false |
 | pre | Conditions.cs:79:21:79:25 | false | Conditions.cs:79:17:79:25 | ... = ... |
 | pre | Conditions.cs:81:9:82:16 | if (...) ... | Conditions.cs:81:12:81:12 | access to local variable b |
 | pre | Conditions.cs:81:12:81:12 | access to local variable b | Conditions.cs:82:13:82:16 | ...; |
@@ -3283,15 +3168,13 @@
 | pre | Conditions.cs:83:16:83:16 | access to local variable x | Conditions.cs:83:9:83:17 | return ...; |
 | pre | Conditions.cs:86:9:86:10 | enter M7 | Conditions.cs:87:5:100:5 | {...} |
 | pre | Conditions.cs:87:5:100:5 | {...} | Conditions.cs:88:9:88:30 | ... ...; |
-| pre | Conditions.cs:88:9:88:30 | ... ...; | Conditions.cs:88:13:88:13 | access to local variable b |
-| pre | Conditions.cs:88:13:88:13 | access to local variable b | Conditions.cs:88:17:88:18 | access to parameter ss |
+| pre | Conditions.cs:88:9:88:30 | ... ...; | Conditions.cs:88:17:88:18 | access to parameter ss |
 | pre | Conditions.cs:88:13:88:29 | Boolean b = ... | Conditions.cs:89:9:89:18 | ... ...; |
 | pre | Conditions.cs:88:17:88:18 | access to parameter ss | Conditions.cs:88:17:88:25 | access to property Length |
 | pre | Conditions.cs:88:17:88:25 | access to property Length | Conditions.cs:88:29:88:29 | 0 |
 | pre | Conditions.cs:88:17:88:29 | ... > ... | Conditions.cs:88:13:88:29 | Boolean b = ... |
 | pre | Conditions.cs:88:29:88:29 | 0 | Conditions.cs:88:17:88:29 | ... > ... |
-| pre | Conditions.cs:89:9:89:18 | ... ...; | Conditions.cs:89:13:89:13 | access to local variable x |
-| pre | Conditions.cs:89:13:89:13 | access to local variable x | Conditions.cs:89:17:89:17 | 0 |
+| pre | Conditions.cs:89:9:89:18 | ... ...; | Conditions.cs:89:17:89:17 | 0 |
 | pre | Conditions.cs:89:13:89:17 | Int32 x = ... | Conditions.cs:90:27:90:28 | access to parameter ss |
 | pre | Conditions.cs:89:17:89:17 | 0 | Conditions.cs:89:13:89:17 | Int32 x = ... |
 | pre | Conditions.cs:90:9:98:9 | foreach (... ... in ...) ... | Conditions.cs:91:9:98:9 | {...} |
@@ -3308,8 +3191,7 @@
 | pre | Conditions.cs:94:17:94:21 | ... > ... | Conditions.cs:95:17:95:26 | ...; |
 | pre | Conditions.cs:94:17:94:21 | ... > ... | Conditions.cs:96:13:97:20 | if (...) ... |
 | pre | Conditions.cs:94:21:94:21 | 0 | Conditions.cs:94:17:94:21 | ... > ... |
-| pre | Conditions.cs:95:17:95:17 | access to local variable b | Conditions.cs:95:21:95:25 | false |
-| pre | Conditions.cs:95:17:95:26 | ...; | Conditions.cs:95:17:95:17 | access to local variable b |
+| pre | Conditions.cs:95:17:95:26 | ...; | Conditions.cs:95:21:95:25 | false |
 | pre | Conditions.cs:95:21:95:25 | false | Conditions.cs:95:17:95:25 | ... = ... |
 | pre | Conditions.cs:96:13:97:20 | if (...) ... | Conditions.cs:96:17:96:17 | access to local variable b |
 | pre | Conditions.cs:96:17:96:17 | access to local variable b | Conditions.cs:97:17:97:20 | ...; |
@@ -3319,15 +3201,13 @@
 | pre | Conditions.cs:99:16:99:16 | access to local variable x | Conditions.cs:99:9:99:17 | return ...; |
 | pre | Conditions.cs:102:12:102:13 | enter M8 | Conditions.cs:103:5:111:5 | {...} |
 | pre | Conditions.cs:103:5:111:5 | {...} | Conditions.cs:104:9:104:29 | ... ...; |
-| pre | Conditions.cs:104:9:104:29 | ... ...; | Conditions.cs:104:13:104:13 | access to local variable x |
-| pre | Conditions.cs:104:13:104:13 | access to local variable x | Conditions.cs:104:17:104:17 | access to parameter b |
+| pre | Conditions.cs:104:9:104:29 | ... ...; | Conditions.cs:104:17:104:17 | access to parameter b |
 | pre | Conditions.cs:104:13:104:28 | String x = ... | Conditions.cs:105:9:106:20 | if (...) ... |
 | pre | Conditions.cs:104:17:104:17 | access to parameter b | Conditions.cs:104:17:104:28 | call to method ToString |
 | pre | Conditions.cs:104:17:104:28 | call to method ToString | Conditions.cs:104:13:104:28 | String x = ... |
 | pre | Conditions.cs:105:9:106:20 | if (...) ... | Conditions.cs:105:13:105:13 | access to parameter b |
 | pre | Conditions.cs:105:13:105:13 | access to parameter b | Conditions.cs:106:13:106:20 | [b (line 102): true] ...; |
 | pre | Conditions.cs:105:13:105:13 | access to parameter b | Conditions.cs:107:9:109:24 | [b (line 102): false] if (...) ... |
-| pre | Conditions.cs:106:13:106:13 | [b (line 102): true] access to local variable x | Conditions.cs:106:13:106:13 | [b (line 102): true] access to local variable x |
 | pre | Conditions.cs:106:13:106:13 | [b (line 102): true] access to local variable x | Conditions.cs:106:18:106:19 | [b (line 102): true] "" |
 | pre | Conditions.cs:106:13:106:19 | [b (line 102): true] ... + ... | Conditions.cs:106:13:106:19 | [b (line 102): true] ... = ... |
 | pre | Conditions.cs:106:13:106:19 | [b (line 102): true] ... = ... | Conditions.cs:107:9:109:24 | [b (line 102): true] if (...) ... |
@@ -3348,7 +3228,6 @@
 | pre | Conditions.cs:108:17:108:18 | [b (line 102): false] !... | Conditions.cs:108:18:108:18 | [b (line 102): false] access to parameter b |
 | pre | Conditions.cs:108:17:108:18 | [b (line 102): true] !... | Conditions.cs:108:18:108:18 | [b (line 102): true] access to parameter b |
 | pre | Conditions.cs:108:18:108:18 | [b (line 102): false] access to parameter b | Conditions.cs:109:17:109:24 | ...; |
-| pre | Conditions.cs:109:17:109:17 | access to local variable x | Conditions.cs:109:17:109:17 | access to local variable x |
 | pre | Conditions.cs:109:17:109:17 | access to local variable x | Conditions.cs:109:22:109:23 | "" |
 | pre | Conditions.cs:109:17:109:23 | ... + ... | Conditions.cs:109:17:109:23 | ... = ... |
 | pre | Conditions.cs:109:17:109:24 | ...; | Conditions.cs:109:17:109:17 | access to local variable x |
@@ -3357,12 +3236,10 @@
 | pre | Conditions.cs:110:16:110:16 | access to local variable x | Conditions.cs:110:9:110:17 | return ...; |
 | pre | Conditions.cs:113:10:113:11 | enter M9 | Conditions.cs:114:5:124:5 | {...} |
 | pre | Conditions.cs:114:5:124:5 | {...} | Conditions.cs:115:9:115:24 | ... ...; |
-| pre | Conditions.cs:115:9:115:24 | ... ...; | Conditions.cs:115:16:115:16 | access to local variable s |
-| pre | Conditions.cs:115:16:115:16 | access to local variable s | Conditions.cs:115:20:115:23 | null |
+| pre | Conditions.cs:115:9:115:24 | ... ...; | Conditions.cs:115:20:115:23 | null |
 | pre | Conditions.cs:115:16:115:23 | String s = ... | Conditions.cs:116:9:123:9 | for (...;...;...) ... |
 | pre | Conditions.cs:115:20:115:23 | null | Conditions.cs:115:16:115:23 | String s = ... |
-| pre | Conditions.cs:116:9:123:9 | for (...;...;...) ... | Conditions.cs:116:17:116:17 | access to local variable i |
-| pre | Conditions.cs:116:17:116:17 | access to local variable i | Conditions.cs:116:21:116:21 | 0 |
+| pre | Conditions.cs:116:9:123:9 | for (...;...;...) ... | Conditions.cs:116:21:116:21 | 0 |
 | pre | Conditions.cs:116:17:116:21 | Int32 i = ... | Conditions.cs:116:24:116:24 | access to local variable i |
 | pre | Conditions.cs:116:21:116:21 | 0 | Conditions.cs:116:17:116:21 | Int32 i = ... |
 | pre | Conditions.cs:116:24:116:24 | access to local variable i | Conditions.cs:116:28:116:31 | access to parameter args |
@@ -3372,8 +3249,7 @@
 | pre | Conditions.cs:116:28:116:38 | access to property Length | Conditions.cs:116:24:116:38 | ... < ... |
 | pre | Conditions.cs:116:41:116:41 | access to local variable i | Conditions.cs:116:41:116:43 | ...++ |
 | pre | Conditions.cs:117:9:123:9 | {...} | Conditions.cs:118:13:118:44 | ... ...; |
-| pre | Conditions.cs:118:13:118:44 | ... ...; | Conditions.cs:118:17:118:20 | access to local variable last |
-| pre | Conditions.cs:118:17:118:20 | access to local variable last | Conditions.cs:118:24:118:24 | access to local variable i |
+| pre | Conditions.cs:118:13:118:44 | ... ...; | Conditions.cs:118:24:118:24 | access to local variable i |
 | pre | Conditions.cs:118:17:118:43 | Boolean last = ... | Conditions.cs:119:13:120:23 | if (...) ... |
 | pre | Conditions.cs:118:24:118:24 | access to local variable i | Conditions.cs:118:29:118:32 | access to parameter args |
 | pre | Conditions.cs:118:24:118:43 | ... == ... | Conditions.cs:118:17:118:43 | Boolean last = ... |
@@ -3385,15 +3261,13 @@
 | pre | Conditions.cs:119:17:119:21 | !... | Conditions.cs:119:18:119:21 | access to local variable last |
 | pre | Conditions.cs:119:18:119:21 | access to local variable last | Conditions.cs:120:17:120:23 | [last (line 118): false] ...; |
 | pre | Conditions.cs:119:18:119:21 | access to local variable last | Conditions.cs:121:13:122:25 | [last (line 118): true] if (...) ... |
-| pre | Conditions.cs:120:17:120:17 | [last (line 118): false] access to local variable s | Conditions.cs:120:21:120:22 | [last (line 118): false] "" |
 | pre | Conditions.cs:120:17:120:22 | [last (line 118): false] ... = ... | Conditions.cs:121:13:122:25 | [last (line 118): false] if (...) ... |
-| pre | Conditions.cs:120:17:120:23 | [last (line 118): false] ...; | Conditions.cs:120:17:120:17 | [last (line 118): false] access to local variable s |
+| pre | Conditions.cs:120:17:120:23 | [last (line 118): false] ...; | Conditions.cs:120:21:120:22 | [last (line 118): false] "" |
 | pre | Conditions.cs:120:21:120:22 | [last (line 118): false] "" | Conditions.cs:120:17:120:22 | [last (line 118): false] ... = ... |
 | pre | Conditions.cs:121:13:122:25 | [last (line 118): false] if (...) ... | Conditions.cs:121:17:121:20 | [last (line 118): false] access to local variable last |
 | pre | Conditions.cs:121:13:122:25 | [last (line 118): true] if (...) ... | Conditions.cs:121:17:121:20 | [last (line 118): true] access to local variable last |
 | pre | Conditions.cs:121:17:121:20 | [last (line 118): true] access to local variable last | Conditions.cs:122:17:122:25 | ...; |
-| pre | Conditions.cs:122:17:122:17 | access to local variable s | Conditions.cs:122:21:122:24 | null |
-| pre | Conditions.cs:122:17:122:25 | ...; | Conditions.cs:122:17:122:17 | access to local variable s |
+| pre | Conditions.cs:122:17:122:25 | ...; | Conditions.cs:122:21:122:24 | null |
 | pre | Conditions.cs:122:21:122:24 | null | Conditions.cs:122:17:122:24 | ... = ... |
 | pre | Conditions.cs:129:10:129:12 | enter M10 | Conditions.cs:130:5:141:5 | {...} |
 | pre | Conditions.cs:130:5:141:5 | {...} | Conditions.cs:131:9:140:9 | while (...) ... |
@@ -3642,20 +3516,17 @@
 | pre | Initializers.cs:6:28:6:30 | {...} | Initializers.cs:6:5:6:16 | exit Initializers |
 | pre | Initializers.cs:8:10:8:10 | enter M | Initializers.cs:9:5:12:5 | {...} |
 | pre | Initializers.cs:9:5:12:5 | {...} | Initializers.cs:10:9:10:54 | ... ...; |
-| pre | Initializers.cs:10:9:10:54 | ... ...; | Initializers.cs:10:13:10:13 | access to local variable i |
-| pre | Initializers.cs:10:13:10:13 | access to local variable i | Initializers.cs:10:34:10:35 | "" |
+| pre | Initializers.cs:10:9:10:54 | ... ...; | Initializers.cs:10:34:10:35 | "" |
 | pre | Initializers.cs:10:13:10:53 | Initializers i = ... | Initializers.cs:11:9:11:64 | ... ...; |
-| pre | Initializers.cs:10:17:10:53 | object creation of type Initializers | Initializers.cs:10:40:10:40 | access to field F |
+| pre | Initializers.cs:10:17:10:53 | object creation of type Initializers | Initializers.cs:10:44:10:44 | 0 |
 | pre | Initializers.cs:10:34:10:35 | "" | Initializers.cs:10:17:10:53 | object creation of type Initializers |
 | pre | Initializers.cs:10:38:10:53 | { ..., ... } | Initializers.cs:10:13:10:53 | Initializers i = ... |
-| pre | Initializers.cs:10:40:10:40 | access to field F | Initializers.cs:10:44:10:44 | 0 |
-| pre | Initializers.cs:10:40:10:44 | ... = ... | Initializers.cs:10:47:10:47 | access to property G |
+| pre | Initializers.cs:10:40:10:44 | ... = ... | Initializers.cs:10:51:10:51 | 1 |
 | pre | Initializers.cs:10:44:10:44 | 0 | Initializers.cs:10:40:10:44 | ... = ... |
-| pre | Initializers.cs:10:47:10:47 | access to property G | Initializers.cs:10:51:10:51 | 1 |
+| pre | Initializers.cs:10:47:10:47 | access to property G | Initializers.cs:10:47:10:51 | ... = ... |
 | pre | Initializers.cs:10:47:10:51 | ... = ... | Initializers.cs:10:38:10:53 | { ..., ... } |
-| pre | Initializers.cs:10:51:10:51 | 1 | Initializers.cs:10:47:10:51 | ... = ... |
-| pre | Initializers.cs:11:9:11:64 | ... ...; | Initializers.cs:11:13:11:14 | access to local variable iz |
-| pre | Initializers.cs:11:13:11:14 | access to local variable iz | Initializers.cs:11:18:11:63 | array creation of type Initializers[] |
+| pre | Initializers.cs:10:51:10:51 | 1 | Initializers.cs:10:47:10:47 | access to property G |
+| pre | Initializers.cs:11:9:11:64 | ... ...; | Initializers.cs:11:18:11:63 | array creation of type Initializers[] |
 | pre | Initializers.cs:11:13:11:63 | Initializers[] iz = ... | Initializers.cs:8:10:8:10 | exit M |
 | pre | Initializers.cs:11:18:11:63 | array creation of type Initializers[] | Initializers.cs:11:39:11:39 | access to local variable i |
 | pre | Initializers.cs:11:37:11:63 | { ..., ... } | Initializers.cs:11:13:11:63 | Initializers[] iz = ... |
@@ -3694,28 +3565,24 @@
 | pre | NullCoalescing.cs:11:51:11:58 | ... && ... | NullCoalescing.cs:11:51:11:52 | access to parameter b2 |
 | pre | NullCoalescing.cs:13:10:13:11 | enter M6 | NullCoalescing.cs:14:5:18:5 | {...} |
 | pre | NullCoalescing.cs:14:5:18:5 | {...} | NullCoalescing.cs:15:9:15:32 | ... ...; |
-| pre | NullCoalescing.cs:15:9:15:32 | ... ...; | NullCoalescing.cs:15:13:15:13 | access to local variable j |
-| pre | NullCoalescing.cs:15:13:15:13 | access to local variable j | NullCoalescing.cs:15:17:15:31 | ... ?? ... |
+| pre | NullCoalescing.cs:15:9:15:32 | ... ...; | NullCoalescing.cs:15:17:15:31 | ... ?? ... |
 | pre | NullCoalescing.cs:15:13:15:31 | Int32 j = ... | NullCoalescing.cs:16:9:16:26 | ... ...; |
 | pre | NullCoalescing.cs:15:17:15:26 | (...) ... | NullCoalescing.cs:15:31:15:31 | 0 |
 | pre | NullCoalescing.cs:15:17:15:31 | ... ?? ... | NullCoalescing.cs:15:23:15:26 | null |
 | pre | NullCoalescing.cs:15:23:15:26 | null | NullCoalescing.cs:15:17:15:26 | (...) ... |
 | pre | NullCoalescing.cs:15:31:15:31 | 0 | NullCoalescing.cs:15:13:15:31 | Int32 j = ... |
-| pre | NullCoalescing.cs:16:9:16:26 | ... ...; | NullCoalescing.cs:16:13:16:13 | access to local variable s |
-| pre | NullCoalescing.cs:16:13:16:13 | access to local variable s | NullCoalescing.cs:16:17:16:25 | ... ?? ... |
+| pre | NullCoalescing.cs:16:9:16:26 | ... ...; | NullCoalescing.cs:16:17:16:25 | ... ?? ... |
 | pre | NullCoalescing.cs:16:13:16:25 | String s = ... | NullCoalescing.cs:17:9:17:25 | ...; |
 | pre | NullCoalescing.cs:16:17:16:18 | "" | NullCoalescing.cs:16:13:16:25 | String s = ... |
 | pre | NullCoalescing.cs:16:17:16:25 | ... ?? ... | NullCoalescing.cs:16:17:16:18 | "" |
-| pre | NullCoalescing.cs:17:9:17:9 | access to local variable j | NullCoalescing.cs:17:13:17:24 | ... ?? ... |
 | pre | NullCoalescing.cs:17:9:17:24 | ... = ... | NullCoalescing.cs:13:10:13:11 | exit M6 |
-| pre | NullCoalescing.cs:17:9:17:25 | ...; | NullCoalescing.cs:17:9:17:9 | access to local variable j |
+| pre | NullCoalescing.cs:17:9:17:25 | ...; | NullCoalescing.cs:17:13:17:24 | ... ?? ... |
 | pre | NullCoalescing.cs:17:13:17:19 | (...) ... | NullCoalescing.cs:17:9:17:24 | ... = ... |
 | pre | NullCoalescing.cs:17:13:17:24 | ... ?? ... | NullCoalescing.cs:17:19:17:19 | access to parameter i |
 | pre | NullCoalescing.cs:17:19:17:19 | access to parameter i | NullCoalescing.cs:17:13:17:19 | (...) ... |
 | pre | Patterns.cs:5:10:5:13 | enter Test | Patterns.cs:6:5:43:5 | {...} |
 | pre | Patterns.cs:6:5:43:5 | {...} | Patterns.cs:7:9:7:24 | ... ...; |
-| pre | Patterns.cs:7:9:7:24 | ... ...; | Patterns.cs:7:16:7:16 | access to local variable o |
-| pre | Patterns.cs:7:16:7:16 | access to local variable o | Patterns.cs:7:20:7:23 | null |
+| pre | Patterns.cs:7:9:7:24 | ... ...; | Patterns.cs:7:20:7:23 | null |
 | pre | Patterns.cs:7:16:7:23 | Object o = ... | Patterns.cs:8:9:18:9 | if (...) ... |
 | pre | Patterns.cs:7:20:7:23 | null | Patterns.cs:7:16:7:23 | Object o = ... |
 | pre | Patterns.cs:8:9:18:9 | if (...) ... | Patterns.cs:8:13:8:13 | access to local variable o |
@@ -3793,73 +3660,58 @@
 | pre | Qualifiers.cs:8:41:8:44 | null | Qualifiers.cs:8:23:8:34 | exit StaticMethod |
 | pre | Qualifiers.cs:10:10:10:10 | enter M | Qualifiers.cs:11:5:31:5 | {...} |
 | pre | Qualifiers.cs:11:5:31:5 | {...} | Qualifiers.cs:12:9:12:22 | ... ...; |
-| pre | Qualifiers.cs:12:9:12:22 | ... ...; | Qualifiers.cs:12:13:12:13 | access to local variable q |
-| pre | Qualifiers.cs:12:13:12:13 | access to local variable q | Qualifiers.cs:12:17:12:21 | this access |
+| pre | Qualifiers.cs:12:9:12:22 | ... ...; | Qualifiers.cs:12:17:12:21 | this access |
 | pre | Qualifiers.cs:12:13:12:21 | Qualifiers q = ... | Qualifiers.cs:13:9:13:21 | ...; |
 | pre | Qualifiers.cs:12:17:12:21 | access to field Field | Qualifiers.cs:12:13:12:21 | Qualifiers q = ... |
 | pre | Qualifiers.cs:12:17:12:21 | this access | Qualifiers.cs:12:17:12:21 | access to field Field |
-| pre | Qualifiers.cs:13:9:13:9 | access to local variable q | Qualifiers.cs:13:13:13:20 | this access |
 | pre | Qualifiers.cs:13:9:13:20 | ... = ... | Qualifiers.cs:14:9:14:21 | ...; |
-| pre | Qualifiers.cs:13:9:13:21 | ...; | Qualifiers.cs:13:9:13:9 | access to local variable q |
+| pre | Qualifiers.cs:13:9:13:21 | ...; | Qualifiers.cs:13:13:13:20 | this access |
 | pre | Qualifiers.cs:13:13:13:20 | access to property Property | Qualifiers.cs:13:9:13:20 | ... = ... |
 | pre | Qualifiers.cs:13:13:13:20 | this access | Qualifiers.cs:13:13:13:20 | access to property Property |
-| pre | Qualifiers.cs:14:9:14:9 | access to local variable q | Qualifiers.cs:14:13:14:20 | this access |
 | pre | Qualifiers.cs:14:9:14:20 | ... = ... | Qualifiers.cs:16:9:16:23 | ...; |
-| pre | Qualifiers.cs:14:9:14:21 | ...; | Qualifiers.cs:14:9:14:9 | access to local variable q |
+| pre | Qualifiers.cs:14:9:14:21 | ...; | Qualifiers.cs:14:13:14:20 | this access |
 | pre | Qualifiers.cs:14:13:14:20 | call to method Method | Qualifiers.cs:14:9:14:20 | ... = ... |
 | pre | Qualifiers.cs:14:13:14:20 | this access | Qualifiers.cs:14:13:14:20 | call to method Method |
-| pre | Qualifiers.cs:16:9:16:9 | access to local variable q | Qualifiers.cs:16:13:16:16 | this access |
 | pre | Qualifiers.cs:16:9:16:22 | ... = ... | Qualifiers.cs:17:9:17:26 | ...; |
-| pre | Qualifiers.cs:16:9:16:23 | ...; | Qualifiers.cs:16:9:16:9 | access to local variable q |
+| pre | Qualifiers.cs:16:9:16:23 | ...; | Qualifiers.cs:16:13:16:16 | this access |
 | pre | Qualifiers.cs:16:13:16:16 | this access | Qualifiers.cs:16:13:16:22 | access to field Field |
 | pre | Qualifiers.cs:16:13:16:22 | access to field Field | Qualifiers.cs:16:9:16:22 | ... = ... |
-| pre | Qualifiers.cs:17:9:17:9 | access to local variable q | Qualifiers.cs:17:13:17:16 | this access |
 | pre | Qualifiers.cs:17:9:17:25 | ... = ... | Qualifiers.cs:18:9:18:26 | ...; |
-| pre | Qualifiers.cs:17:9:17:26 | ...; | Qualifiers.cs:17:9:17:9 | access to local variable q |
+| pre | Qualifiers.cs:17:9:17:26 | ...; | Qualifiers.cs:17:13:17:16 | this access |
 | pre | Qualifiers.cs:17:13:17:16 | this access | Qualifiers.cs:17:13:17:25 | access to property Property |
 | pre | Qualifiers.cs:17:13:17:25 | access to property Property | Qualifiers.cs:17:9:17:25 | ... = ... |
-| pre | Qualifiers.cs:18:9:18:9 | access to local variable q | Qualifiers.cs:18:13:18:16 | this access |
 | pre | Qualifiers.cs:18:9:18:25 | ... = ... | Qualifiers.cs:20:9:20:24 | ...; |
-| pre | Qualifiers.cs:18:9:18:26 | ...; | Qualifiers.cs:18:9:18:9 | access to local variable q |
+| pre | Qualifiers.cs:18:9:18:26 | ...; | Qualifiers.cs:18:13:18:16 | this access |
 | pre | Qualifiers.cs:18:13:18:16 | this access | Qualifiers.cs:18:13:18:25 | call to method Method |
 | pre | Qualifiers.cs:18:13:18:25 | call to method Method | Qualifiers.cs:18:9:18:25 | ... = ... |
-| pre | Qualifiers.cs:20:9:20:9 | access to local variable q | Qualifiers.cs:20:13:20:23 | access to field StaticField |
 | pre | Qualifiers.cs:20:9:20:23 | ... = ... | Qualifiers.cs:21:9:21:27 | ...; |
-| pre | Qualifiers.cs:20:9:20:24 | ...; | Qualifiers.cs:20:9:20:9 | access to local variable q |
+| pre | Qualifiers.cs:20:9:20:24 | ...; | Qualifiers.cs:20:13:20:23 | access to field StaticField |
 | pre | Qualifiers.cs:20:13:20:23 | access to field StaticField | Qualifiers.cs:20:9:20:23 | ... = ... |
-| pre | Qualifiers.cs:21:9:21:9 | access to local variable q | Qualifiers.cs:21:13:21:26 | access to property StaticProperty |
 | pre | Qualifiers.cs:21:9:21:26 | ... = ... | Qualifiers.cs:22:9:22:27 | ...; |
-| pre | Qualifiers.cs:21:9:21:27 | ...; | Qualifiers.cs:21:9:21:9 | access to local variable q |
+| pre | Qualifiers.cs:21:9:21:27 | ...; | Qualifiers.cs:21:13:21:26 | access to property StaticProperty |
 | pre | Qualifiers.cs:21:13:21:26 | access to property StaticProperty | Qualifiers.cs:21:9:21:26 | ... = ... |
-| pre | Qualifiers.cs:22:9:22:9 | access to local variable q | Qualifiers.cs:22:13:22:26 | call to method StaticMethod |
 | pre | Qualifiers.cs:22:9:22:26 | ... = ... | Qualifiers.cs:24:9:24:35 | ...; |
-| pre | Qualifiers.cs:22:9:22:27 | ...; | Qualifiers.cs:22:9:22:9 | access to local variable q |
+| pre | Qualifiers.cs:22:9:22:27 | ...; | Qualifiers.cs:22:13:22:26 | call to method StaticMethod |
 | pre | Qualifiers.cs:22:13:22:26 | call to method StaticMethod | Qualifiers.cs:22:9:22:26 | ... = ... |
-| pre | Qualifiers.cs:24:9:24:9 | access to local variable q | Qualifiers.cs:24:13:24:34 | access to field StaticField |
 | pre | Qualifiers.cs:24:9:24:34 | ... = ... | Qualifiers.cs:25:9:25:38 | ...; |
-| pre | Qualifiers.cs:24:9:24:35 | ...; | Qualifiers.cs:24:9:24:9 | access to local variable q |
+| pre | Qualifiers.cs:24:9:24:35 | ...; | Qualifiers.cs:24:13:24:34 | access to field StaticField |
 | pre | Qualifiers.cs:24:13:24:34 | access to field StaticField | Qualifiers.cs:24:9:24:34 | ... = ... |
-| pre | Qualifiers.cs:25:9:25:9 | access to local variable q | Qualifiers.cs:25:13:25:37 | access to property StaticProperty |
 | pre | Qualifiers.cs:25:9:25:37 | ... = ... | Qualifiers.cs:26:9:26:38 | ...; |
-| pre | Qualifiers.cs:25:9:25:38 | ...; | Qualifiers.cs:25:9:25:9 | access to local variable q |
+| pre | Qualifiers.cs:25:9:25:38 | ...; | Qualifiers.cs:25:13:25:37 | access to property StaticProperty |
 | pre | Qualifiers.cs:25:13:25:37 | access to property StaticProperty | Qualifiers.cs:25:9:25:37 | ... = ... |
-| pre | Qualifiers.cs:26:9:26:9 | access to local variable q | Qualifiers.cs:26:13:26:37 | call to method StaticMethod |
 | pre | Qualifiers.cs:26:9:26:37 | ... = ... | Qualifiers.cs:28:9:28:41 | ...; |
-| pre | Qualifiers.cs:26:9:26:38 | ...; | Qualifiers.cs:26:9:26:9 | access to local variable q |
+| pre | Qualifiers.cs:26:9:26:38 | ...; | Qualifiers.cs:26:13:26:37 | call to method StaticMethod |
 | pre | Qualifiers.cs:26:13:26:37 | call to method StaticMethod | Qualifiers.cs:26:9:26:37 | ... = ... |
-| pre | Qualifiers.cs:28:9:28:9 | access to local variable q | Qualifiers.cs:28:13:28:34 | access to field StaticField |
 | pre | Qualifiers.cs:28:9:28:40 | ... = ... | Qualifiers.cs:29:9:29:47 | ...; |
-| pre | Qualifiers.cs:28:9:28:41 | ...; | Qualifiers.cs:28:9:28:9 | access to local variable q |
+| pre | Qualifiers.cs:28:9:28:41 | ...; | Qualifiers.cs:28:13:28:34 | access to field StaticField |
 | pre | Qualifiers.cs:28:13:28:34 | access to field StaticField | Qualifiers.cs:28:13:28:40 | access to field Field |
 | pre | Qualifiers.cs:28:13:28:40 | access to field Field | Qualifiers.cs:28:9:28:40 | ... = ... |
-| pre | Qualifiers.cs:29:9:29:9 | access to local variable q | Qualifiers.cs:29:13:29:37 | access to property StaticProperty |
 | pre | Qualifiers.cs:29:9:29:46 | ... = ... | Qualifiers.cs:30:9:30:47 | ...; |
-| pre | Qualifiers.cs:29:9:29:47 | ...; | Qualifiers.cs:29:9:29:9 | access to local variable q |
+| pre | Qualifiers.cs:29:9:29:47 | ...; | Qualifiers.cs:29:13:29:37 | access to property StaticProperty |
 | pre | Qualifiers.cs:29:13:29:37 | access to property StaticProperty | Qualifiers.cs:29:13:29:46 | access to property Property |
 | pre | Qualifiers.cs:29:13:29:46 | access to property Property | Qualifiers.cs:29:9:29:46 | ... = ... |
-| pre | Qualifiers.cs:30:9:30:9 | access to local variable q | Qualifiers.cs:30:13:30:37 | call to method StaticMethod |
 | pre | Qualifiers.cs:30:9:30:46 | ... = ... | Qualifiers.cs:10:10:10:10 | exit M |
-| pre | Qualifiers.cs:30:9:30:47 | ...; | Qualifiers.cs:30:9:30:9 | access to local variable q |
+| pre | Qualifiers.cs:30:9:30:47 | ...; | Qualifiers.cs:30:13:30:37 | call to method StaticMethod |
 | pre | Qualifiers.cs:30:13:30:37 | call to method StaticMethod | Qualifiers.cs:30:13:30:46 | call to method Method |
 | pre | Qualifiers.cs:30:13:30:46 | call to method Method | Qualifiers.cs:30:9:30:46 | ... = ... |
 | pre | Switch.cs:5:10:5:11 | enter M1 | Switch.cs:6:5:8:5 | {...} |
@@ -4016,14 +3868,12 @@
 | pre | Switch.cs:120:17:120:17 | 1 | Switch.cs:120:16:120:17 | -... |
 | pre | TypeAccesses.cs:3:10:3:10 | enter M | TypeAccesses.cs:4:5:9:5 | {...} |
 | pre | TypeAccesses.cs:4:5:9:5 | {...} | TypeAccesses.cs:5:9:5:26 | ... ...; |
-| pre | TypeAccesses.cs:5:9:5:26 | ... ...; | TypeAccesses.cs:5:13:5:13 | access to local variable s |
-| pre | TypeAccesses.cs:5:13:5:13 | access to local variable s | TypeAccesses.cs:5:25:5:25 | access to parameter o |
+| pre | TypeAccesses.cs:5:9:5:26 | ... ...; | TypeAccesses.cs:5:25:5:25 | access to parameter o |
 | pre | TypeAccesses.cs:5:13:5:25 | String s = ... | TypeAccesses.cs:6:9:6:24 | ...; |
 | pre | TypeAccesses.cs:5:17:5:25 | (...) ... | TypeAccesses.cs:5:13:5:25 | String s = ... |
 | pre | TypeAccesses.cs:5:25:5:25 | access to parameter o | TypeAccesses.cs:5:17:5:25 | (...) ... |
-| pre | TypeAccesses.cs:6:9:6:9 | access to local variable s | TypeAccesses.cs:6:13:6:13 | access to parameter o |
 | pre | TypeAccesses.cs:6:9:6:23 | ... = ... | TypeAccesses.cs:7:9:7:25 | if (...) ... |
-| pre | TypeAccesses.cs:6:9:6:24 | ...; | TypeAccesses.cs:6:9:6:9 | access to local variable s |
+| pre | TypeAccesses.cs:6:9:6:24 | ...; | TypeAccesses.cs:6:13:6:13 | access to parameter o |
 | pre | TypeAccesses.cs:6:13:6:13 | access to parameter o | TypeAccesses.cs:6:13:6:23 | ... as ... |
 | pre | TypeAccesses.cs:6:13:6:23 | ... as ... | TypeAccesses.cs:6:9:6:23 | ... = ... |
 | pre | TypeAccesses.cs:7:9:7:25 | if (...) ... | TypeAccesses.cs:7:13:7:13 | access to parameter o |
@@ -4031,19 +3881,16 @@
 | pre | TypeAccesses.cs:7:13:7:22 | ... is ... | TypeAccesses.cs:7:25:7:25 | ; |
 | pre | TypeAccesses.cs:7:13:7:22 | ... is ... | TypeAccesses.cs:8:9:8:28 | ... ...; |
 | pre | TypeAccesses.cs:7:18:7:22 | Int32 j | TypeAccesses.cs:7:13:7:22 | ... is ... |
-| pre | TypeAccesses.cs:8:9:8:28 | ... ...; | TypeAccesses.cs:8:13:8:13 | access to local variable t |
-| pre | TypeAccesses.cs:8:13:8:13 | access to local variable t | TypeAccesses.cs:8:17:8:27 | typeof(...) |
+| pre | TypeAccesses.cs:8:9:8:28 | ... ...; | TypeAccesses.cs:8:17:8:27 | typeof(...) |
 | pre | TypeAccesses.cs:8:13:8:27 | Type t = ... | TypeAccesses.cs:3:10:3:10 | exit M |
 | pre | TypeAccesses.cs:8:17:8:27 | typeof(...) | TypeAccesses.cs:8:13:8:27 | Type t = ... |
 | pre | VarDecls.cs:5:18:5:19 | enter M1 | VarDecls.cs:6:5:11:5 | {...} |
 | pre | VarDecls.cs:6:5:11:5 | {...} | VarDecls.cs:7:9:10:9 | fixed(...) { ... } |
-| pre | VarDecls.cs:7:9:10:9 | fixed(...) { ... } | VarDecls.cs:7:22:7:23 | access to local variable c1 |
-| pre | VarDecls.cs:7:22:7:23 | access to local variable c1 | VarDecls.cs:7:27:7:33 | access to parameter strings |
-| pre | VarDecls.cs:7:22:7:36 | Char* c1 = ... | VarDecls.cs:7:39:7:40 | access to local variable c2 |
+| pre | VarDecls.cs:7:9:10:9 | fixed(...) { ... } | VarDecls.cs:7:27:7:33 | access to parameter strings |
+| pre | VarDecls.cs:7:22:7:36 | Char* c1 = ... | VarDecls.cs:7:44:7:50 | access to parameter strings |
 | pre | VarDecls.cs:7:27:7:33 | access to parameter strings | VarDecls.cs:7:35:7:35 | 0 |
 | pre | VarDecls.cs:7:27:7:36 | access to array element | VarDecls.cs:7:22:7:36 | Char* c1 = ... |
 | pre | VarDecls.cs:7:35:7:35 | 0 | VarDecls.cs:7:27:7:36 | access to array element |
-| pre | VarDecls.cs:7:39:7:40 | access to local variable c2 | VarDecls.cs:7:44:7:50 | access to parameter strings |
 | pre | VarDecls.cs:7:39:7:53 | Char* c2 = ... | VarDecls.cs:8:9:10:9 | {...} |
 | pre | VarDecls.cs:7:44:7:50 | access to parameter strings | VarDecls.cs:7:52:7:52 | 1 |
 | pre | VarDecls.cs:7:44:7:53 | access to array element | VarDecls.cs:7:39:7:53 | Char* c2 = ... |
@@ -4054,11 +3901,9 @@
 | pre | VarDecls.cs:9:27:9:28 | access to local variable c1 | VarDecls.cs:9:20:9:28 | (...) ... |
 | pre | VarDecls.cs:13:12:13:13 | enter M2 | VarDecls.cs:14:5:17:5 | {...} |
 | pre | VarDecls.cs:14:5:17:5 | {...} | VarDecls.cs:15:9:15:30 | ... ...; |
-| pre | VarDecls.cs:15:9:15:30 | ... ...; | VarDecls.cs:15:16:15:17 | access to local variable s1 |
-| pre | VarDecls.cs:15:16:15:17 | access to local variable s1 | VarDecls.cs:15:21:15:21 | access to parameter s |
-| pre | VarDecls.cs:15:16:15:21 | String s1 = ... | VarDecls.cs:15:24:15:25 | access to local variable s2 |
+| pre | VarDecls.cs:15:9:15:30 | ... ...; | VarDecls.cs:15:21:15:21 | access to parameter s |
+| pre | VarDecls.cs:15:16:15:21 | String s1 = ... | VarDecls.cs:15:29:15:29 | access to parameter s |
 | pre | VarDecls.cs:15:21:15:21 | access to parameter s | VarDecls.cs:15:16:15:21 | String s1 = ... |
-| pre | VarDecls.cs:15:24:15:25 | access to local variable s2 | VarDecls.cs:15:29:15:29 | access to parameter s |
 | pre | VarDecls.cs:15:24:15:29 | String s2 = ... | VarDecls.cs:16:16:16:17 | access to local variable s1 |
 | pre | VarDecls.cs:15:29:15:29 | access to parameter s | VarDecls.cs:15:24:15:29 | String s2 = ... |
 | pre | VarDecls.cs:16:9:16:23 | return ...; | VarDecls.cs:13:12:13:13 | exit M2 |
@@ -4070,11 +3915,9 @@
 | pre | VarDecls.cs:21:9:22:13 | using (...) {...} | VarDecls.cs:21:16:21:22 | object creation of type C |
 | pre | VarDecls.cs:21:16:21:22 | object creation of type C | VarDecls.cs:22:13:22:13 | ; |
 | pre | VarDecls.cs:22:13:22:13 | ; | VarDecls.cs:24:9:25:29 | using (...) {...} |
-| pre | VarDecls.cs:24:9:25:29 | using (...) {...} | VarDecls.cs:24:18:24:18 | access to local variable x |
-| pre | VarDecls.cs:24:18:24:18 | access to local variable x | VarDecls.cs:24:22:24:28 | object creation of type C |
-| pre | VarDecls.cs:24:18:24:28 | C x = ... | VarDecls.cs:24:31:24:31 | access to local variable y |
+| pre | VarDecls.cs:24:9:25:29 | using (...) {...} | VarDecls.cs:24:22:24:28 | object creation of type C |
+| pre | VarDecls.cs:24:18:24:28 | C x = ... | VarDecls.cs:24:35:24:41 | object creation of type C |
 | pre | VarDecls.cs:24:22:24:28 | object creation of type C | VarDecls.cs:24:18:24:28 | C x = ... |
-| pre | VarDecls.cs:24:31:24:31 | access to local variable y | VarDecls.cs:24:35:24:41 | object creation of type C |
 | pre | VarDecls.cs:24:31:24:41 | C y = ... | VarDecls.cs:25:20:25:28 | ... ? ... : ... |
 | pre | VarDecls.cs:24:35:24:41 | object creation of type C | VarDecls.cs:24:31:24:41 | C y = ... |
 | pre | VarDecls.cs:25:13:25:29 | return ...; | VarDecls.cs:19:7:19:8 | exit M3 |
@@ -4085,14 +3928,12 @@
 | pre | VarDecls.cs:28:51:28:53 | {...} | VarDecls.cs:28:41:28:47 | exit Dispose |
 | pre | cflow.cs:5:17:5:20 | enter Main | cflow.cs:6:5:35:5 | {...} |
 | pre | cflow.cs:6:5:35:5 | {...} | cflow.cs:7:9:7:28 | ... ...; |
-| pre | cflow.cs:7:9:7:28 | ... ...; | cflow.cs:7:13:7:13 | access to local variable a |
-| pre | cflow.cs:7:13:7:13 | access to local variable a | cflow.cs:7:17:7:20 | access to parameter args |
+| pre | cflow.cs:7:9:7:28 | ... ...; | cflow.cs:7:17:7:20 | access to parameter args |
 | pre | cflow.cs:7:13:7:27 | Int32 a = ... | cflow.cs:9:9:9:40 | ...; |
 | pre | cflow.cs:7:17:7:20 | access to parameter args | cflow.cs:7:17:7:27 | access to property Length |
 | pre | cflow.cs:7:17:7:27 | access to property Length | cflow.cs:7:13:7:27 | Int32 a = ... |
-| pre | cflow.cs:9:9:9:9 | access to local variable a | cflow.cs:9:13:9:29 | object creation of type ControlFlow |
 | pre | cflow.cs:9:9:9:39 | ... = ... | cflow.cs:11:9:12:49 | if (...) ... |
-| pre | cflow.cs:9:9:9:40 | ...; | cflow.cs:9:9:9:9 | access to local variable a |
+| pre | cflow.cs:9:9:9:40 | ...; | cflow.cs:9:13:9:29 | object creation of type ControlFlow |
 | pre | cflow.cs:9:13:9:29 | object creation of type ControlFlow | cflow.cs:9:38:9:38 | access to local variable a |
 | pre | cflow.cs:9:13:9:39 | call to method Switch | cflow.cs:9:9:9:39 | ... = ... |
 | pre | cflow.cs:9:38:9:38 | access to local variable a | cflow.cs:9:13:9:39 | call to method Switch |
@@ -4124,8 +3965,7 @@
 | pre | cflow.cs:22:18:22:18 | access to local variable a | cflow.cs:22:22:22:23 | 10 |
 | pre | cflow.cs:22:18:22:23 | ... < ... | cflow.cs:24:9:34:9 | for (...;...;...) ... |
 | pre | cflow.cs:22:22:22:23 | 10 | cflow.cs:22:18:22:23 | ... < ... |
-| pre | cflow.cs:24:9:34:9 | for (...;...;...) ... | cflow.cs:24:18:24:18 | access to local variable i |
-| pre | cflow.cs:24:18:24:18 | access to local variable i | cflow.cs:24:22:24:22 | 1 |
+| pre | cflow.cs:24:9:34:9 | for (...;...;...) ... | cflow.cs:24:22:24:22 | 1 |
 | pre | cflow.cs:24:18:24:22 | Int32 i = ... | cflow.cs:24:25:24:25 | access to local variable i |
 | pre | cflow.cs:24:22:24:22 | 1 | cflow.cs:24:18:24:22 | Int32 i = ... |
 | pre | cflow.cs:24:25:24:25 | access to local variable i | cflow.cs:24:30:24:31 | 20 |
@@ -4309,13 +4149,11 @@
 | pre | cflow.cs:116:27:116:27 | access to parameter s | cflow.cs:116:9:116:28 | call to method WriteLine |
 | pre | cflow.cs:119:20:119:21 | enter M5 | cflow.cs:120:5:124:5 | {...} |
 | pre | cflow.cs:120:5:124:5 | {...} | cflow.cs:121:9:121:18 | ... ...; |
-| pre | cflow.cs:121:9:121:18 | ... ...; | cflow.cs:121:13:121:13 | access to local variable x |
-| pre | cflow.cs:121:13:121:13 | access to local variable x | cflow.cs:121:17:121:17 | access to parameter s |
+| pre | cflow.cs:121:9:121:18 | ... ...; | cflow.cs:121:17:121:17 | access to parameter s |
 | pre | cflow.cs:121:13:121:17 | String x = ... | cflow.cs:122:9:122:20 | ...; |
 | pre | cflow.cs:121:17:121:17 | access to parameter s | cflow.cs:121:13:121:17 | String x = ... |
-| pre | cflow.cs:122:9:122:9 | access to local variable x | cflow.cs:122:13:122:13 | access to local variable x |
 | pre | cflow.cs:122:9:122:19 | ... = ... | cflow.cs:123:16:123:16 | access to local variable x |
-| pre | cflow.cs:122:9:122:20 | ...; | cflow.cs:122:9:122:9 | access to local variable x |
+| pre | cflow.cs:122:9:122:20 | ...; | cflow.cs:122:13:122:13 | access to local variable x |
 | pre | cflow.cs:122:13:122:13 | access to local variable x | cflow.cs:122:17:122:19 | " " |
 | pre | cflow.cs:122:13:122:19 | ... + ... | cflow.cs:122:9:122:19 | ... = ... |
 | pre | cflow.cs:122:17:122:19 | " " | cflow.cs:122:13:122:19 | ... + ... |
@@ -4333,15 +4171,13 @@
 | pre | cflow.cs:127:53:127:57 | this access | cflow.cs:127:53:127:57 | access to field Field |
 | pre | cflow.cs:127:62:127:64 | enter set_Prop | cflow.cs:127:66:127:83 | {...} |
 | pre | cflow.cs:127:66:127:83 | {...} | cflow.cs:127:68:127:81 | ...; |
-| pre | cflow.cs:127:68:127:72 | access to field Field | cflow.cs:127:76:127:80 | access to parameter value |
-| pre | cflow.cs:127:68:127:72 | this access | cflow.cs:127:68:127:72 | access to field Field |
+| pre | cflow.cs:127:68:127:72 | this access | cflow.cs:127:76:127:80 | access to parameter value |
 | pre | cflow.cs:127:68:127:80 | ... = ... | cflow.cs:127:62:127:64 | exit set_Prop |
 | pre | cflow.cs:127:68:127:81 | ...; | cflow.cs:127:68:127:72 | this access |
 | pre | cflow.cs:127:76:127:80 | access to parameter value | cflow.cs:127:68:127:80 | ... = ... |
 | pre | cflow.cs:129:5:129:15 | enter ControlFlow | cflow.cs:130:5:132:5 | {...} |
 | pre | cflow.cs:130:5:132:5 | {...} | cflow.cs:131:9:131:18 | ...; |
-| pre | cflow.cs:131:9:131:13 | access to field Field | cflow.cs:131:17:131:17 | access to parameter s |
-| pre | cflow.cs:131:9:131:13 | this access | cflow.cs:131:9:131:13 | access to field Field |
+| pre | cflow.cs:131:9:131:13 | this access | cflow.cs:131:17:131:17 | access to parameter s |
 | pre | cflow.cs:131:9:131:17 | ... = ... | cflow.cs:129:5:129:15 | exit ControlFlow |
 | pre | cflow.cs:131:9:131:18 | ...; | cflow.cs:131:9:131:13 | this access |
 | pre | cflow.cs:131:17:131:17 | access to parameter s | cflow.cs:131:9:131:17 | ... = ... |
@@ -4480,8 +4316,7 @@
 | pre | cflow.cs:203:31:203:39 | [finally: exception(IOException)] "Finally" | cflow.cs:203:13:203:40 | [finally: exception(IOException)] call to method WriteLine |
 | pre | cflow.cs:203:31:203:39 | [finally: exception(OutOfMemoryException)] "Finally" | cflow.cs:203:13:203:40 | [finally: exception(OutOfMemoryException)] call to method WriteLine |
 | pre | cflow.cs:203:31:203:39 | [finally: return] "Finally" | cflow.cs:203:13:203:40 | [finally: return] call to method WriteLine |
-| pre | cflow.cs:206:9:206:19 | ... ...; | cflow.cs:206:13:206:13 | access to local variable i |
-| pre | cflow.cs:206:13:206:13 | access to local variable i | cflow.cs:206:17:206:18 | 10 |
+| pre | cflow.cs:206:9:206:19 | ... ...; | cflow.cs:206:17:206:18 | 10 |
 | pre | cflow.cs:206:13:206:18 | Int32 i = ... | cflow.cs:207:9:230:9 | while (...) ... |
 | pre | cflow.cs:206:17:206:18 | 10 | cflow.cs:206:13:206:18 | Int32 i = ... |
 | pre | cflow.cs:207:9:230:9 | while (...) ... | cflow.cs:207:16:207:16 | access to local variable i |
@@ -4685,16 +4520,14 @@
 | pre | cflow.cs:244:35:244:35 | [finally: return] 1 | cflow.cs:244:17:244:36 | [finally: return] call to method WriteLine |
 | pre | cflow.cs:247:9:254:9 | try {...} ... | cflow.cs:248:9:250:9 | {...} |
 | pre | cflow.cs:248:9:250:9 | {...} | cflow.cs:249:13:249:41 | ... ...; |
-| pre | cflow.cs:249:13:249:41 | ... ...; | cflow.cs:249:17:249:20 | access to local variable temp |
-| pre | cflow.cs:249:17:249:20 | access to local variable temp | cflow.cs:249:24:249:24 | 0 |
+| pre | cflow.cs:249:13:249:41 | ... ...; | cflow.cs:249:24:249:24 | 0 |
 | pre | cflow.cs:249:24:249:24 | 0 | cflow.cs:249:24:249:24 | (...) ... |
 | pre | cflow.cs:249:24:249:24 | (...) ... | cflow.cs:249:28:249:40 | access to constant E |
 | pre | cflow.cs:249:24:249:40 | ... / ... | cflow.cs:249:17:249:40 | Double temp = ... |
 | pre | cflow.cs:249:28:249:40 | access to constant E | cflow.cs:249:24:249:40 | ... / ... |
 | pre | cflow.cs:257:10:257:12 | enter For | cflow.cs:258:5:288:5 | {...} |
 | pre | cflow.cs:258:5:288:5 | {...} | cflow.cs:259:9:259:18 | ... ...; |
-| pre | cflow.cs:259:9:259:18 | ... ...; | cflow.cs:259:13:259:13 | access to local variable x |
-| pre | cflow.cs:259:13:259:13 | access to local variable x | cflow.cs:259:17:259:17 | 0 |
+| pre | cflow.cs:259:9:259:18 | ... ...; | cflow.cs:259:17:259:17 | 0 |
 | pre | cflow.cs:259:13:259:17 | Int32 x = ... | cflow.cs:260:9:261:33 | for (...;...;...) ... |
 | pre | cflow.cs:259:17:259:17 | 0 | cflow.cs:259:13:259:17 | Int32 x = ... |
 | pre | cflow.cs:260:9:261:33 | for (...;...;...) ... | cflow.cs:260:16:260:16 | access to local variable x |
@@ -4742,11 +4575,9 @@
 | pre | cflow.cs:280:31:280:31 | access to local variable x | cflow.cs:280:13:280:32 | call to method WriteLine |
 | pre | cflow.cs:281:13:281:13 | access to local variable x | cflow.cs:281:13:281:15 | ...++ |
 | pre | cflow.cs:281:13:281:16 | ...; | cflow.cs:281:13:281:13 | access to local variable x |
-| pre | cflow.cs:284:9:287:9 | for (...;...;...) ... | cflow.cs:284:18:284:18 | access to local variable i |
-| pre | cflow.cs:284:18:284:18 | access to local variable i | cflow.cs:284:22:284:22 | 0 |
-| pre | cflow.cs:284:18:284:22 | Int32 i = ... | cflow.cs:284:25:284:25 | access to local variable j |
+| pre | cflow.cs:284:9:287:9 | for (...;...;...) ... | cflow.cs:284:22:284:22 | 0 |
+| pre | cflow.cs:284:18:284:22 | Int32 i = ... | cflow.cs:284:29:284:29 | 0 |
 | pre | cflow.cs:284:22:284:22 | 0 | cflow.cs:284:18:284:22 | Int32 i = ... |
-| pre | cflow.cs:284:25:284:25 | access to local variable j | cflow.cs:284:29:284:29 | 0 |
 | pre | cflow.cs:284:25:284:29 | Int32 j = ... | cflow.cs:284:32:284:32 | access to local variable i |
 | pre | cflow.cs:284:29:284:29 | 0 | cflow.cs:284:25:284:29 | Int32 j = ... |
 | pre | cflow.cs:284:32:284:32 | access to local variable i | cflow.cs:284:36:284:36 | access to local variable j |
@@ -4766,16 +4597,14 @@
 | pre | cflow.cs:286:35:286:35 | access to local variable j | cflow.cs:286:31:286:35 | ... + ... |
 | pre | cflow.cs:290:10:290:16 | enter Lambdas | cflow.cs:291:5:294:5 | {...} |
 | pre | cflow.cs:291:5:294:5 | {...} | cflow.cs:292:9:292:38 | ... ...; |
-| pre | cflow.cs:292:9:292:38 | ... ...; | cflow.cs:292:24:292:24 | access to local variable y |
-| pre | cflow.cs:292:24:292:24 | access to local variable y | cflow.cs:292:28:292:37 | (...) => ... |
+| pre | cflow.cs:292:9:292:38 | ... ...; | cflow.cs:292:28:292:37 | (...) => ... |
 | pre | cflow.cs:292:24:292:37 | Func<Int32,Int32> y = ... | cflow.cs:293:9:293:62 | ... ...; |
 | pre | cflow.cs:292:28:292:37 | (...) => ... | cflow.cs:292:24:292:37 | Func<Int32,Int32> y = ... |
 | pre | cflow.cs:292:28:292:37 | enter (...) => ... | cflow.cs:292:33:292:33 | access to parameter x |
 | pre | cflow.cs:292:33:292:33 | access to parameter x | cflow.cs:292:37:292:37 | 1 |
 | pre | cflow.cs:292:33:292:37 | ... + ... | cflow.cs:292:28:292:37 | exit (...) => ... |
 | pre | cflow.cs:292:37:292:37 | 1 | cflow.cs:292:33:292:37 | ... + ... |
-| pre | cflow.cs:293:9:293:62 | ... ...; | cflow.cs:293:24:293:24 | access to local variable z |
-| pre | cflow.cs:293:24:293:24 | access to local variable z | cflow.cs:293:28:293:61 | delegate(...) { ... } |
+| pre | cflow.cs:293:9:293:62 | ... ...; | cflow.cs:293:28:293:61 | delegate(...) { ... } |
 | pre | cflow.cs:293:24:293:61 | Func<Int32,Int32> z = ... | cflow.cs:290:10:290:16 | exit Lambdas |
 | pre | cflow.cs:293:28:293:61 | delegate(...) { ... } | cflow.cs:293:24:293:61 | Func<Int32,Int32> z = ... |
 | pre | cflow.cs:293:28:293:61 | enter delegate(...) { ... } | cflow.cs:293:45:293:61 | {...} |
@@ -4804,8 +4633,7 @@
 | pre | cflow.cs:301:31:301:50 | "This should happen" | cflow.cs:301:13:301:51 | call to method WriteLine |
 | pre | cflow.cs:304:10:304:17 | enter Booleans | cflow.cs:305:5:317:5 | {...} |
 | pre | cflow.cs:305:5:317:5 | {...} | cflow.cs:306:9:306:57 | ... ...; |
-| pre | cflow.cs:306:9:306:57 | ... ...; | cflow.cs:306:13:306:13 | access to local variable b |
-| pre | cflow.cs:306:13:306:13 | access to local variable b | cflow.cs:306:17:306:56 | ... && ... |
+| pre | cflow.cs:306:9:306:57 | ... ...; | cflow.cs:306:17:306:56 | ... && ... |
 | pre | cflow.cs:306:13:306:56 | Boolean b = ... | cflow.cs:308:9:309:49 | if (...) ... |
 | pre | cflow.cs:306:17:306:21 | access to field Field | cflow.cs:306:17:306:28 | access to property Length |
 | pre | cflow.cs:306:17:306:21 | this access | cflow.cs:306:17:306:21 | access to field Field |
@@ -4829,8 +4657,7 @@
 | pre | cflow.cs:308:15:308:46 | ... ? ... : ... | cflow.cs:308:15:308:19 | this access |
 | pre | cflow.cs:308:31:308:31 | 0 | cflow.cs:308:15:308:31 | ... == ... |
 | pre | cflow.cs:308:35:308:39 | false | cflow.cs:309:13:309:49 | ...; |
-| pre | cflow.cs:309:13:309:13 | access to local variable b | cflow.cs:309:17:309:48 | ... ? ... : ... |
-| pre | cflow.cs:309:13:309:49 | ...; | cflow.cs:309:13:309:13 | access to local variable b |
+| pre | cflow.cs:309:13:309:49 | ...; | cflow.cs:309:17:309:48 | ... ? ... : ... |
 | pre | cflow.cs:309:17:309:21 | access to field Field | cflow.cs:309:17:309:28 | access to property Length |
 | pre | cflow.cs:309:17:309:21 | this access | cflow.cs:309:17:309:21 | access to field Field |
 | pre | cflow.cs:309:17:309:28 | access to property Length | cflow.cs:309:33:309:33 | 0 |
@@ -4862,10 +4689,9 @@
 | pre | cflow.cs:320:5:333:5 | {...} | cflow.cs:321:9:332:36 | do ... while (...); |
 | pre | cflow.cs:321:9:332:36 | do ... while (...); | cflow.cs:322:9:332:9 | {...} |
 | pre | cflow.cs:322:9:332:9 | {...} | cflow.cs:323:13:323:25 | ...; |
-| pre | cflow.cs:323:13:323:17 | access to field Field | cflow.cs:323:13:323:17 | this access |
 | pre | cflow.cs:323:13:323:17 | access to field Field | cflow.cs:323:22:323:24 | "a" |
 | pre | cflow.cs:323:13:323:17 | this access | cflow.cs:323:13:323:17 | access to field Field |
-| pre | cflow.cs:323:13:323:17 | this access | cflow.cs:323:13:323:17 | access to field Field |
+| pre | cflow.cs:323:13:323:17 | this access | cflow.cs:323:13:323:17 | this access |
 | pre | cflow.cs:323:13:323:24 | ... + ... | cflow.cs:323:13:323:24 | ... = ... |
 | pre | cflow.cs:323:13:323:24 | ... = ... | cflow.cs:324:13:327:13 | if (...) ... |
 | pre | cflow.cs:323:13:323:25 | ...; | cflow.cs:323:13:323:17 | this access |
@@ -4898,10 +4724,9 @@
 | pre | cflow.cs:337:57:337:59 | "a" | cflow.cs:337:62:337:63 | 10 |
 | pre | cflow.cs:337:62:337:63 | 10 | cflow.cs:337:27:337:64 | call to method Repeat |
 | pre | cflow.cs:338:9:348:9 | {...} | cflow.cs:339:13:339:23 | ...; |
-| pre | cflow.cs:339:13:339:17 | access to field Field | cflow.cs:339:13:339:17 | this access |
 | pre | cflow.cs:339:13:339:17 | access to field Field | cflow.cs:339:22:339:22 | access to local variable x |
 | pre | cflow.cs:339:13:339:17 | this access | cflow.cs:339:13:339:17 | access to field Field |
-| pre | cflow.cs:339:13:339:17 | this access | cflow.cs:339:13:339:17 | access to field Field |
+| pre | cflow.cs:339:13:339:17 | this access | cflow.cs:339:13:339:17 | this access |
 | pre | cflow.cs:339:13:339:22 | ... + ... | cflow.cs:339:13:339:22 | ... = ... |
 | pre | cflow.cs:339:13:339:22 | ... = ... | cflow.cs:340:13:343:13 | if (...) ... |
 | pre | cflow.cs:339:13:339:23 | ...; | cflow.cs:339:13:339:17 | this access |
@@ -4965,8 +4790,7 @@
 | pre | cflow.cs:373:5:388:5 | {...} | cflow.cs:374:22:374:22 | 0 |
 | pre | cflow.cs:374:9:374:23 | yield return ...; | cflow.cs:375:9:378:9 | for (...;...;...) ... |
 | pre | cflow.cs:374:22:374:22 | 0 | cflow.cs:374:9:374:23 | yield return ...; |
-| pre | cflow.cs:375:9:378:9 | for (...;...;...) ... | cflow.cs:375:18:375:18 | access to local variable i |
-| pre | cflow.cs:375:18:375:18 | access to local variable i | cflow.cs:375:22:375:22 | 1 |
+| pre | cflow.cs:375:9:378:9 | for (...;...;...) ... | cflow.cs:375:22:375:22 | 1 |
 | pre | cflow.cs:375:18:375:22 | Int32 i = ... | cflow.cs:375:25:375:25 | access to local variable i |
 | pre | cflow.cs:375:22:375:22 | 1 | cflow.cs:375:18:375:22 | Int32 i = ... |
 | pre | cflow.cs:375:25:375:25 | access to local variable i | cflow.cs:375:29:375:30 | 10 |

--- a/csharp/ql/test/library-tests/controlflow/graph/Dominance.expected
+++ b/csharp/ql/test/library-tests/controlflow/graph/Dominance.expected
@@ -1,3 +1,243 @@
+| post | AccessorCalls.cs:5:23:5:25 | exit get_Item | AccessorCalls.cs:5:30:5:30 | access to parameter i |
+| post | AccessorCalls.cs:5:30:5:30 | access to parameter i | AccessorCalls.cs:5:23:5:25 | enter get_Item |
+| post | AccessorCalls.cs:5:33:5:35 | exit set_Item | AccessorCalls.cs:5:37:5:39 | {...} |
+| post | AccessorCalls.cs:5:37:5:39 | {...} | AccessorCalls.cs:5:33:5:35 | enter set_Item |
+| post | AccessorCalls.cs:7:32:7:34 | exit add_Event | AccessorCalls.cs:7:36:7:38 | {...} |
+| post | AccessorCalls.cs:7:36:7:38 | {...} | AccessorCalls.cs:7:32:7:34 | enter add_Event |
+| post | AccessorCalls.cs:7:40:7:45 | exit remove_Event | AccessorCalls.cs:7:47:7:49 | {...} |
+| post | AccessorCalls.cs:7:47:7:49 | {...} | AccessorCalls.cs:7:40:7:45 | enter remove_Event |
+| post | AccessorCalls.cs:10:10:10:11 | exit M1 | AccessorCalls.cs:16:9:16:23 | ... -= ... |
+| post | AccessorCalls.cs:11:5:17:5 | {...} | AccessorCalls.cs:10:10:10:11 | enter M1 |
+| post | AccessorCalls.cs:12:9:12:12 | this access | AccessorCalls.cs:12:9:12:32 | ...; |
+| post | AccessorCalls.cs:12:9:12:18 | access to field Field | AccessorCalls.cs:12:9:12:12 | this access |
+| post | AccessorCalls.cs:12:9:12:31 | ... = ... | AccessorCalls.cs:12:22:12:31 | access to field Field |
+| post | AccessorCalls.cs:12:9:12:32 | ...; | AccessorCalls.cs:11:5:17:5 | {...} |
+| post | AccessorCalls.cs:12:22:12:25 | this access | AccessorCalls.cs:12:9:12:18 | access to field Field |
+| post | AccessorCalls.cs:12:22:12:31 | access to field Field | AccessorCalls.cs:12:22:12:25 | this access |
+| post | AccessorCalls.cs:13:9:13:12 | this access | AccessorCalls.cs:13:9:13:30 | ...; |
+| post | AccessorCalls.cs:13:9:13:17 | access to property Prop | AccessorCalls.cs:13:9:13:12 | this access |
+| post | AccessorCalls.cs:13:9:13:29 | ... = ... | AccessorCalls.cs:13:21:13:29 | access to property Prop |
+| post | AccessorCalls.cs:13:9:13:30 | ...; | AccessorCalls.cs:12:9:12:31 | ... = ... |
+| post | AccessorCalls.cs:13:21:13:24 | this access | AccessorCalls.cs:13:9:13:17 | access to property Prop |
+| post | AccessorCalls.cs:13:21:13:29 | access to property Prop | AccessorCalls.cs:13:21:13:24 | this access |
+| post | AccessorCalls.cs:14:9:14:12 | this access | AccessorCalls.cs:14:9:14:26 | ...; |
+| post | AccessorCalls.cs:14:9:14:15 | access to indexer | AccessorCalls.cs:14:14:14:14 | 0 |
+| post | AccessorCalls.cs:14:9:14:25 | ... = ... | AccessorCalls.cs:14:19:14:25 | access to indexer |
+| post | AccessorCalls.cs:14:9:14:26 | ...; | AccessorCalls.cs:13:9:13:29 | ... = ... |
+| post | AccessorCalls.cs:14:14:14:14 | 0 | AccessorCalls.cs:14:9:14:12 | this access |
+| post | AccessorCalls.cs:14:19:14:22 | this access | AccessorCalls.cs:14:9:14:15 | access to indexer |
+| post | AccessorCalls.cs:14:19:14:25 | access to indexer | AccessorCalls.cs:14:24:14:24 | 1 |
+| post | AccessorCalls.cs:14:24:14:24 | 1 | AccessorCalls.cs:14:19:14:22 | this access |
+| post | AccessorCalls.cs:15:9:15:12 | this access | AccessorCalls.cs:15:9:15:24 | ...; |
+| post | AccessorCalls.cs:15:9:15:18 | access to event Event | AccessorCalls.cs:15:9:15:12 | this access |
+| post | AccessorCalls.cs:15:9:15:23 | ... += ... | AccessorCalls.cs:15:23:15:23 | access to parameter e |
+| post | AccessorCalls.cs:15:9:15:24 | ...; | AccessorCalls.cs:14:9:14:25 | ... = ... |
+| post | AccessorCalls.cs:15:23:15:23 | access to parameter e | AccessorCalls.cs:15:9:15:18 | access to event Event |
+| post | AccessorCalls.cs:16:9:16:12 | this access | AccessorCalls.cs:16:9:16:24 | ...; |
+| post | AccessorCalls.cs:16:9:16:18 | access to event Event | AccessorCalls.cs:16:9:16:12 | this access |
+| post | AccessorCalls.cs:16:9:16:23 | ... -= ... | AccessorCalls.cs:16:23:16:23 | access to parameter e |
+| post | AccessorCalls.cs:16:9:16:24 | ...; | AccessorCalls.cs:15:9:15:23 | ... += ... |
+| post | AccessorCalls.cs:16:23:16:23 | access to parameter e | AccessorCalls.cs:16:9:16:18 | access to event Event |
+| post | AccessorCalls.cs:19:10:19:11 | exit M2 | AccessorCalls.cs:25:9:25:25 | ... -= ... |
+| post | AccessorCalls.cs:20:5:26:5 | {...} | AccessorCalls.cs:19:10:19:11 | enter M2 |
+| post | AccessorCalls.cs:21:9:21:12 | this access | AccessorCalls.cs:21:9:21:36 | ...; |
+| post | AccessorCalls.cs:21:9:21:14 | access to field x | AccessorCalls.cs:21:9:21:12 | this access |
+| post | AccessorCalls.cs:21:9:21:20 | access to field Field | AccessorCalls.cs:21:9:21:14 | access to field x |
+| post | AccessorCalls.cs:21:9:21:35 | ... = ... | AccessorCalls.cs:21:24:21:35 | access to field Field |
+| post | AccessorCalls.cs:21:9:21:36 | ...; | AccessorCalls.cs:20:5:26:5 | {...} |
+| post | AccessorCalls.cs:21:24:21:27 | this access | AccessorCalls.cs:21:9:21:20 | access to field Field |
+| post | AccessorCalls.cs:21:24:21:29 | access to field x | AccessorCalls.cs:21:24:21:27 | this access |
+| post | AccessorCalls.cs:21:24:21:35 | access to field Field | AccessorCalls.cs:21:24:21:29 | access to field x |
+| post | AccessorCalls.cs:22:9:22:12 | this access | AccessorCalls.cs:22:9:22:34 | ...; |
+| post | AccessorCalls.cs:22:9:22:14 | access to field x | AccessorCalls.cs:22:9:22:12 | this access |
+| post | AccessorCalls.cs:22:9:22:19 | access to property Prop | AccessorCalls.cs:22:9:22:14 | access to field x |
+| post | AccessorCalls.cs:22:9:22:33 | ... = ... | AccessorCalls.cs:22:23:22:33 | access to property Prop |
+| post | AccessorCalls.cs:22:9:22:34 | ...; | AccessorCalls.cs:21:9:21:35 | ... = ... |
+| post | AccessorCalls.cs:22:23:22:26 | this access | AccessorCalls.cs:22:9:22:19 | access to property Prop |
+| post | AccessorCalls.cs:22:23:22:28 | access to field x | AccessorCalls.cs:22:23:22:26 | this access |
+| post | AccessorCalls.cs:22:23:22:33 | access to property Prop | AccessorCalls.cs:22:23:22:28 | access to field x |
+| post | AccessorCalls.cs:23:9:23:12 | this access | AccessorCalls.cs:23:9:23:30 | ...; |
+| post | AccessorCalls.cs:23:9:23:14 | access to field x | AccessorCalls.cs:23:9:23:12 | this access |
+| post | AccessorCalls.cs:23:9:23:17 | access to indexer | AccessorCalls.cs:23:16:23:16 | 0 |
+| post | AccessorCalls.cs:23:9:23:29 | ... = ... | AccessorCalls.cs:23:21:23:29 | access to indexer |
+| post | AccessorCalls.cs:23:9:23:30 | ...; | AccessorCalls.cs:22:9:22:33 | ... = ... |
+| post | AccessorCalls.cs:23:16:23:16 | 0 | AccessorCalls.cs:23:9:23:14 | access to field x |
+| post | AccessorCalls.cs:23:21:23:24 | this access | AccessorCalls.cs:23:9:23:17 | access to indexer |
+| post | AccessorCalls.cs:23:21:23:26 | access to field x | AccessorCalls.cs:23:21:23:24 | this access |
+| post | AccessorCalls.cs:23:21:23:29 | access to indexer | AccessorCalls.cs:23:28:23:28 | 1 |
+| post | AccessorCalls.cs:23:28:23:28 | 1 | AccessorCalls.cs:23:21:23:26 | access to field x |
+| post | AccessorCalls.cs:24:9:24:12 | this access | AccessorCalls.cs:24:9:24:26 | ...; |
+| post | AccessorCalls.cs:24:9:24:14 | access to field x | AccessorCalls.cs:24:9:24:12 | this access |
+| post | AccessorCalls.cs:24:9:24:20 | access to event Event | AccessorCalls.cs:24:9:24:14 | access to field x |
+| post | AccessorCalls.cs:24:9:24:25 | ... += ... | AccessorCalls.cs:24:25:24:25 | access to parameter e |
+| post | AccessorCalls.cs:24:9:24:26 | ...; | AccessorCalls.cs:23:9:23:29 | ... = ... |
+| post | AccessorCalls.cs:24:25:24:25 | access to parameter e | AccessorCalls.cs:24:9:24:20 | access to event Event |
+| post | AccessorCalls.cs:25:9:25:12 | this access | AccessorCalls.cs:25:9:25:26 | ...; |
+| post | AccessorCalls.cs:25:9:25:14 | access to field x | AccessorCalls.cs:25:9:25:12 | this access |
+| post | AccessorCalls.cs:25:9:25:20 | access to event Event | AccessorCalls.cs:25:9:25:14 | access to field x |
+| post | AccessorCalls.cs:25:9:25:25 | ... -= ... | AccessorCalls.cs:25:25:25:25 | access to parameter e |
+| post | AccessorCalls.cs:25:9:25:26 | ...; | AccessorCalls.cs:24:9:24:25 | ... += ... |
+| post | AccessorCalls.cs:25:25:25:25 | access to parameter e | AccessorCalls.cs:25:9:25:20 | access to event Event |
+| post | AccessorCalls.cs:28:10:28:11 | exit M3 | AccessorCalls.cs:32:9:32:17 | ...++ |
+| post | AccessorCalls.cs:29:5:33:5 | {...} | AccessorCalls.cs:28:10:28:11 | enter M3 |
+| post | AccessorCalls.cs:30:9:30:12 | this access | AccessorCalls.cs:30:9:30:21 | ...; |
+| post | AccessorCalls.cs:30:9:30:18 | access to field Field | AccessorCalls.cs:30:9:30:12 | this access |
+| post | AccessorCalls.cs:30:9:30:20 | ...++ | AccessorCalls.cs:30:9:30:18 | access to field Field |
+| post | AccessorCalls.cs:30:9:30:21 | ...; | AccessorCalls.cs:29:5:33:5 | {...} |
+| post | AccessorCalls.cs:31:9:31:12 | this access | AccessorCalls.cs:31:9:31:20 | ...; |
+| post | AccessorCalls.cs:31:9:31:17 | access to property Prop | AccessorCalls.cs:31:9:31:12 | this access |
+| post | AccessorCalls.cs:31:9:31:19 | ...++ | AccessorCalls.cs:31:9:31:17 | access to property Prop |
+| post | AccessorCalls.cs:31:9:31:20 | ...; | AccessorCalls.cs:30:9:30:20 | ...++ |
+| post | AccessorCalls.cs:32:9:32:12 | this access | AccessorCalls.cs:32:9:32:18 | ...; |
+| post | AccessorCalls.cs:32:9:32:15 | access to indexer | AccessorCalls.cs:32:14:32:14 | 0 |
+| post | AccessorCalls.cs:32:9:32:17 | ...++ | AccessorCalls.cs:32:9:32:15 | access to indexer |
+| post | AccessorCalls.cs:32:9:32:18 | ...; | AccessorCalls.cs:31:9:31:19 | ...++ |
+| post | AccessorCalls.cs:32:14:32:14 | 0 | AccessorCalls.cs:32:9:32:12 | this access |
+| post | AccessorCalls.cs:35:10:35:11 | exit M4 | AccessorCalls.cs:39:9:39:19 | ...++ |
+| post | AccessorCalls.cs:36:5:40:5 | {...} | AccessorCalls.cs:35:10:35:11 | enter M4 |
+| post | AccessorCalls.cs:37:9:37:12 | this access | AccessorCalls.cs:37:9:37:23 | ...; |
+| post | AccessorCalls.cs:37:9:37:14 | access to field x | AccessorCalls.cs:37:9:37:12 | this access |
+| post | AccessorCalls.cs:37:9:37:20 | access to field Field | AccessorCalls.cs:37:9:37:14 | access to field x |
+| post | AccessorCalls.cs:37:9:37:22 | ...++ | AccessorCalls.cs:37:9:37:20 | access to field Field |
+| post | AccessorCalls.cs:37:9:37:23 | ...; | AccessorCalls.cs:36:5:40:5 | {...} |
+| post | AccessorCalls.cs:38:9:38:12 | this access | AccessorCalls.cs:38:9:38:22 | ...; |
+| post | AccessorCalls.cs:38:9:38:14 | access to field x | AccessorCalls.cs:38:9:38:12 | this access |
+| post | AccessorCalls.cs:38:9:38:19 | access to property Prop | AccessorCalls.cs:38:9:38:14 | access to field x |
+| post | AccessorCalls.cs:38:9:38:21 | ...++ | AccessorCalls.cs:38:9:38:19 | access to property Prop |
+| post | AccessorCalls.cs:38:9:38:22 | ...; | AccessorCalls.cs:37:9:37:22 | ...++ |
+| post | AccessorCalls.cs:39:9:39:12 | this access | AccessorCalls.cs:39:9:39:20 | ...; |
+| post | AccessorCalls.cs:39:9:39:14 | access to field x | AccessorCalls.cs:39:9:39:12 | this access |
+| post | AccessorCalls.cs:39:9:39:17 | access to indexer | AccessorCalls.cs:39:16:39:16 | 0 |
+| post | AccessorCalls.cs:39:9:39:19 | ...++ | AccessorCalls.cs:39:9:39:17 | access to indexer |
+| post | AccessorCalls.cs:39:9:39:20 | ...; | AccessorCalls.cs:38:9:38:21 | ...++ |
+| post | AccessorCalls.cs:39:16:39:16 | 0 | AccessorCalls.cs:39:9:39:14 | access to field x |
+| post | AccessorCalls.cs:42:10:42:11 | exit M5 | AccessorCalls.cs:46:9:46:26 | ... = ... |
+| post | AccessorCalls.cs:43:5:47:5 | {...} | AccessorCalls.cs:42:10:42:11 | enter M5 |
+| post | AccessorCalls.cs:44:9:44:12 | this access | AccessorCalls.cs:44:9:44:18 | access to field Field |
+| post | AccessorCalls.cs:44:9:44:12 | this access | AccessorCalls.cs:44:9:44:33 | ...; |
+| post | AccessorCalls.cs:44:9:44:18 | access to field Field | AccessorCalls.cs:44:9:44:12 | this access |
+| post | AccessorCalls.cs:44:9:44:18 | access to field Field | AccessorCalls.cs:44:9:44:12 | this access |
+| post | AccessorCalls.cs:44:9:44:32 | ... + ... | AccessorCalls.cs:44:23:44:32 | access to field Field |
+| post | AccessorCalls.cs:44:9:44:32 | ... = ... | AccessorCalls.cs:44:9:44:32 | ... + ... |
+| post | AccessorCalls.cs:44:9:44:33 | ...; | AccessorCalls.cs:43:5:47:5 | {...} |
+| post | AccessorCalls.cs:44:23:44:26 | this access | AccessorCalls.cs:44:9:44:18 | access to field Field |
+| post | AccessorCalls.cs:44:23:44:32 | access to field Field | AccessorCalls.cs:44:23:44:26 | this access |
+| post | AccessorCalls.cs:45:9:45:12 | this access | AccessorCalls.cs:45:9:45:17 | access to property Prop |
+| post | AccessorCalls.cs:45:9:45:12 | this access | AccessorCalls.cs:45:9:45:31 | ...; |
+| post | AccessorCalls.cs:45:9:45:17 | access to property Prop | AccessorCalls.cs:45:9:45:12 | this access |
+| post | AccessorCalls.cs:45:9:45:17 | access to property Prop | AccessorCalls.cs:45:9:45:12 | this access |
+| post | AccessorCalls.cs:45:9:45:30 | ... + ... | AccessorCalls.cs:45:22:45:30 | access to property Prop |
+| post | AccessorCalls.cs:45:9:45:30 | ... = ... | AccessorCalls.cs:45:9:45:30 | ... + ... |
+| post | AccessorCalls.cs:45:9:45:31 | ...; | AccessorCalls.cs:44:9:44:32 | ... = ... |
+| post | AccessorCalls.cs:45:22:45:25 | this access | AccessorCalls.cs:45:9:45:17 | access to property Prop |
+| post | AccessorCalls.cs:45:22:45:30 | access to property Prop | AccessorCalls.cs:45:22:45:25 | this access |
+| post | AccessorCalls.cs:46:9:46:12 | this access | AccessorCalls.cs:46:9:46:15 | access to indexer |
+| post | AccessorCalls.cs:46:9:46:12 | this access | AccessorCalls.cs:46:9:46:27 | ...; |
+| post | AccessorCalls.cs:46:9:46:15 | access to indexer | AccessorCalls.cs:46:14:46:14 | 0 |
+| post | AccessorCalls.cs:46:9:46:15 | access to indexer | AccessorCalls.cs:46:14:46:14 | 0 |
+| post | AccessorCalls.cs:46:9:46:26 | ... + ... | AccessorCalls.cs:46:20:46:26 | access to indexer |
+| post | AccessorCalls.cs:46:9:46:26 | ... = ... | AccessorCalls.cs:46:9:46:26 | ... + ... |
+| post | AccessorCalls.cs:46:9:46:27 | ...; | AccessorCalls.cs:45:9:45:30 | ... = ... |
+| post | AccessorCalls.cs:46:14:46:14 | 0 | AccessorCalls.cs:46:9:46:12 | this access |
+| post | AccessorCalls.cs:46:14:46:14 | 0 | AccessorCalls.cs:46:9:46:12 | this access |
+| post | AccessorCalls.cs:46:20:46:23 | this access | AccessorCalls.cs:46:9:46:15 | access to indexer |
+| post | AccessorCalls.cs:46:20:46:26 | access to indexer | AccessorCalls.cs:46:25:46:25 | 0 |
+| post | AccessorCalls.cs:46:25:46:25 | 0 | AccessorCalls.cs:46:20:46:23 | this access |
+| post | AccessorCalls.cs:49:10:49:11 | exit M6 | AccessorCalls.cs:53:9:53:30 | ... = ... |
+| post | AccessorCalls.cs:50:5:54:5 | {...} | AccessorCalls.cs:49:10:49:11 | enter M6 |
+| post | AccessorCalls.cs:51:9:51:12 | this access | AccessorCalls.cs:51:9:51:20 | access to field Field |
+| post | AccessorCalls.cs:51:9:51:12 | this access | AccessorCalls.cs:51:9:51:37 | ...; |
+| post | AccessorCalls.cs:51:9:51:14 | access to field x | AccessorCalls.cs:51:9:51:12 | this access |
+| post | AccessorCalls.cs:51:9:51:14 | access to field x | AccessorCalls.cs:51:9:51:12 | this access |
+| post | AccessorCalls.cs:51:9:51:20 | access to field Field | AccessorCalls.cs:51:9:51:14 | access to field x |
+| post | AccessorCalls.cs:51:9:51:20 | access to field Field | AccessorCalls.cs:51:9:51:14 | access to field x |
+| post | AccessorCalls.cs:51:9:51:36 | ... + ... | AccessorCalls.cs:51:25:51:36 | access to field Field |
+| post | AccessorCalls.cs:51:9:51:36 | ... = ... | AccessorCalls.cs:51:9:51:36 | ... + ... |
+| post | AccessorCalls.cs:51:9:51:37 | ...; | AccessorCalls.cs:50:5:54:5 | {...} |
+| post | AccessorCalls.cs:51:25:51:28 | this access | AccessorCalls.cs:51:9:51:20 | access to field Field |
+| post | AccessorCalls.cs:51:25:51:30 | access to field x | AccessorCalls.cs:51:25:51:28 | this access |
+| post | AccessorCalls.cs:51:25:51:36 | access to field Field | AccessorCalls.cs:51:25:51:30 | access to field x |
+| post | AccessorCalls.cs:52:9:52:12 | this access | AccessorCalls.cs:52:9:52:19 | access to property Prop |
+| post | AccessorCalls.cs:52:9:52:12 | this access | AccessorCalls.cs:52:9:52:35 | ...; |
+| post | AccessorCalls.cs:52:9:52:14 | access to field x | AccessorCalls.cs:52:9:52:12 | this access |
+| post | AccessorCalls.cs:52:9:52:14 | access to field x | AccessorCalls.cs:52:9:52:12 | this access |
+| post | AccessorCalls.cs:52:9:52:19 | access to property Prop | AccessorCalls.cs:52:9:52:14 | access to field x |
+| post | AccessorCalls.cs:52:9:52:19 | access to property Prop | AccessorCalls.cs:52:9:52:14 | access to field x |
+| post | AccessorCalls.cs:52:9:52:34 | ... + ... | AccessorCalls.cs:52:24:52:34 | access to property Prop |
+| post | AccessorCalls.cs:52:9:52:34 | ... = ... | AccessorCalls.cs:52:9:52:34 | ... + ... |
+| post | AccessorCalls.cs:52:9:52:35 | ...; | AccessorCalls.cs:51:9:51:36 | ... = ... |
+| post | AccessorCalls.cs:52:24:52:27 | this access | AccessorCalls.cs:52:9:52:19 | access to property Prop |
+| post | AccessorCalls.cs:52:24:52:29 | access to field x | AccessorCalls.cs:52:24:52:27 | this access |
+| post | AccessorCalls.cs:52:24:52:34 | access to property Prop | AccessorCalls.cs:52:24:52:29 | access to field x |
+| post | AccessorCalls.cs:53:9:53:12 | this access | AccessorCalls.cs:53:9:53:17 | access to indexer |
+| post | AccessorCalls.cs:53:9:53:12 | this access | AccessorCalls.cs:53:9:53:31 | ...; |
+| post | AccessorCalls.cs:53:9:53:14 | access to field x | AccessorCalls.cs:53:9:53:12 | this access |
+| post | AccessorCalls.cs:53:9:53:14 | access to field x | AccessorCalls.cs:53:9:53:12 | this access |
+| post | AccessorCalls.cs:53:9:53:17 | access to indexer | AccessorCalls.cs:53:16:53:16 | 0 |
+| post | AccessorCalls.cs:53:9:53:17 | access to indexer | AccessorCalls.cs:53:16:53:16 | 0 |
+| post | AccessorCalls.cs:53:9:53:30 | ... + ... | AccessorCalls.cs:53:22:53:30 | access to indexer |
+| post | AccessorCalls.cs:53:9:53:30 | ... = ... | AccessorCalls.cs:53:9:53:30 | ... + ... |
+| post | AccessorCalls.cs:53:9:53:31 | ...; | AccessorCalls.cs:52:9:52:34 | ... = ... |
+| post | AccessorCalls.cs:53:16:53:16 | 0 | AccessorCalls.cs:53:9:53:14 | access to field x |
+| post | AccessorCalls.cs:53:16:53:16 | 0 | AccessorCalls.cs:53:9:53:14 | access to field x |
+| post | AccessorCalls.cs:53:22:53:25 | this access | AccessorCalls.cs:53:9:53:17 | access to indexer |
+| post | AccessorCalls.cs:53:22:53:27 | access to field x | AccessorCalls.cs:53:22:53:25 | this access |
+| post | AccessorCalls.cs:53:22:53:30 | access to indexer | AccessorCalls.cs:53:29:53:29 | 0 |
+| post | AccessorCalls.cs:53:29:53:29 | 0 | AccessorCalls.cs:53:22:53:27 | access to field x |
+| post | AccessorCalls.cs:56:10:56:11 | exit M7 | AccessorCalls.cs:58:9:58:85 | ... = ... |
+| post | AccessorCalls.cs:57:5:59:5 | {...} | AccessorCalls.cs:56:10:56:11 | enter M7 |
+| post | AccessorCalls.cs:58:9:58:45 | (..., ...) | AccessorCalls.cs:58:33:58:44 | (..., ...) |
+| post | AccessorCalls.cs:58:9:58:85 | ... = ... | AccessorCalls.cs:58:49:58:85 | (..., ...) |
+| post | AccessorCalls.cs:58:9:58:86 | ...; | AccessorCalls.cs:57:5:59:5 | {...} |
+| post | AccessorCalls.cs:58:10:58:13 | this access | AccessorCalls.cs:58:9:58:86 | ...; |
+| post | AccessorCalls.cs:58:10:58:19 | access to field Field | AccessorCalls.cs:58:10:58:13 | this access |
+| post | AccessorCalls.cs:58:22:58:25 | this access | AccessorCalls.cs:58:10:58:19 | access to field Field |
+| post | AccessorCalls.cs:58:22:58:30 | access to property Prop | AccessorCalls.cs:58:22:58:25 | this access |
+| post | AccessorCalls.cs:58:33:58:44 | (..., ...) | AccessorCalls.cs:58:37:58:43 | access to indexer |
+| post | AccessorCalls.cs:58:34:58:34 | access to parameter i | AccessorCalls.cs:58:22:58:30 | access to property Prop |
+| post | AccessorCalls.cs:58:37:58:40 | this access | AccessorCalls.cs:58:34:58:34 | access to parameter i |
+| post | AccessorCalls.cs:58:37:58:43 | access to indexer | AccessorCalls.cs:58:42:58:42 | 0 |
+| post | AccessorCalls.cs:58:42:58:42 | 0 | AccessorCalls.cs:58:37:58:40 | this access |
+| post | AccessorCalls.cs:58:49:58:85 | (..., ...) | AccessorCalls.cs:58:73:58:84 | (..., ...) |
+| post | AccessorCalls.cs:58:50:58:53 | this access | AccessorCalls.cs:58:9:58:45 | (..., ...) |
+| post | AccessorCalls.cs:58:50:58:59 | access to field Field | AccessorCalls.cs:58:50:58:53 | this access |
+| post | AccessorCalls.cs:58:62:58:65 | this access | AccessorCalls.cs:58:50:58:59 | access to field Field |
+| post | AccessorCalls.cs:58:62:58:70 | access to property Prop | AccessorCalls.cs:58:62:58:65 | this access |
+| post | AccessorCalls.cs:58:73:58:84 | (..., ...) | AccessorCalls.cs:58:77:58:83 | access to indexer |
+| post | AccessorCalls.cs:58:74:58:74 | 0 | AccessorCalls.cs:58:62:58:70 | access to property Prop |
+| post | AccessorCalls.cs:58:77:58:80 | this access | AccessorCalls.cs:58:74:58:74 | 0 |
+| post | AccessorCalls.cs:58:77:58:83 | access to indexer | AccessorCalls.cs:58:82:58:82 | 1 |
+| post | AccessorCalls.cs:58:82:58:82 | 1 | AccessorCalls.cs:58:77:58:80 | this access |
+| post | AccessorCalls.cs:61:10:61:11 | exit M8 | AccessorCalls.cs:63:9:63:97 | ... = ... |
+| post | AccessorCalls.cs:62:5:64:5 | {...} | AccessorCalls.cs:61:10:61:11 | enter M8 |
+| post | AccessorCalls.cs:63:9:63:51 | (..., ...) | AccessorCalls.cs:63:37:63:50 | (..., ...) |
+| post | AccessorCalls.cs:63:9:63:97 | ... = ... | AccessorCalls.cs:63:55:63:97 | (..., ...) |
+| post | AccessorCalls.cs:63:9:63:98 | ...; | AccessorCalls.cs:62:5:64:5 | {...} |
+| post | AccessorCalls.cs:63:10:63:13 | this access | AccessorCalls.cs:63:9:63:98 | ...; |
+| post | AccessorCalls.cs:63:10:63:15 | access to field x | AccessorCalls.cs:63:10:63:13 | this access |
+| post | AccessorCalls.cs:63:10:63:21 | access to field Field | AccessorCalls.cs:63:10:63:15 | access to field x |
+| post | AccessorCalls.cs:63:24:63:27 | this access | AccessorCalls.cs:63:10:63:21 | access to field Field |
+| post | AccessorCalls.cs:63:24:63:29 | access to field x | AccessorCalls.cs:63:24:63:27 | this access |
+| post | AccessorCalls.cs:63:24:63:34 | access to property Prop | AccessorCalls.cs:63:24:63:29 | access to field x |
+| post | AccessorCalls.cs:63:37:63:50 | (..., ...) | AccessorCalls.cs:63:41:63:49 | access to indexer |
+| post | AccessorCalls.cs:63:38:63:38 | access to parameter i | AccessorCalls.cs:63:24:63:34 | access to property Prop |
+| post | AccessorCalls.cs:63:41:63:44 | this access | AccessorCalls.cs:63:38:63:38 | access to parameter i |
+| post | AccessorCalls.cs:63:41:63:46 | access to field x | AccessorCalls.cs:63:41:63:44 | this access |
+| post | AccessorCalls.cs:63:41:63:49 | access to indexer | AccessorCalls.cs:63:48:63:48 | 0 |
+| post | AccessorCalls.cs:63:48:63:48 | 0 | AccessorCalls.cs:63:41:63:46 | access to field x |
+| post | AccessorCalls.cs:63:55:63:97 | (..., ...) | AccessorCalls.cs:63:83:63:96 | (..., ...) |
+| post | AccessorCalls.cs:63:56:63:59 | this access | AccessorCalls.cs:63:9:63:51 | (..., ...) |
+| post | AccessorCalls.cs:63:56:63:61 | access to field x | AccessorCalls.cs:63:56:63:59 | this access |
+| post | AccessorCalls.cs:63:56:63:67 | access to field Field | AccessorCalls.cs:63:56:63:61 | access to field x |
+| post | AccessorCalls.cs:63:70:63:73 | this access | AccessorCalls.cs:63:56:63:67 | access to field Field |
+| post | AccessorCalls.cs:63:70:63:75 | access to field x | AccessorCalls.cs:63:70:63:73 | this access |
+| post | AccessorCalls.cs:63:70:63:80 | access to property Prop | AccessorCalls.cs:63:70:63:75 | access to field x |
+| post | AccessorCalls.cs:63:83:63:96 | (..., ...) | AccessorCalls.cs:63:87:63:95 | access to indexer |
+| post | AccessorCalls.cs:63:84:63:84 | 0 | AccessorCalls.cs:63:70:63:80 | access to property Prop |
+| post | AccessorCalls.cs:63:87:63:90 | this access | AccessorCalls.cs:63:84:63:84 | 0 |
+| post | AccessorCalls.cs:63:87:63:92 | access to field x | AccessorCalls.cs:63:87:63:90 | this access |
+| post | AccessorCalls.cs:63:87:63:95 | access to indexer | AccessorCalls.cs:63:94:63:94 | 1 |
+| post | AccessorCalls.cs:63:94:63:94 | 1 | AccessorCalls.cs:63:87:63:92 | access to field x |
 | post | ArrayCreation.cs:3:11:3:12 | exit M1 | ArrayCreation.cs:3:19:3:28 | array creation of type Int32[] |
 | post | ArrayCreation.cs:3:19:3:28 | array creation of type Int32[] | ArrayCreation.cs:3:27:3:27 | 0 |
 | post | ArrayCreation.cs:3:27:3:27 | 0 | ArrayCreation.cs:3:11:3:12 | enter M1 |
@@ -2241,6 +2481,246 @@
 | post | cflow.cs:428:61:428:64 | null | cflow.cs:428:56:428:56 | access to parameter s |
 | post | cflow.cs:428:70:428:71 | "" | cflow.cs:428:46:428:50 | ... > ... |
 | post | cflow.cs:428:70:428:71 | "" | cflow.cs:428:56:428:64 | ... != ... |
+| pre | AccessorCalls.cs:5:23:5:25 | enter get_Item | AccessorCalls.cs:5:30:5:30 | access to parameter i |
+| pre | AccessorCalls.cs:5:30:5:30 | access to parameter i | AccessorCalls.cs:5:23:5:25 | exit get_Item |
+| pre | AccessorCalls.cs:5:33:5:35 | enter set_Item | AccessorCalls.cs:5:37:5:39 | {...} |
+| pre | AccessorCalls.cs:5:37:5:39 | {...} | AccessorCalls.cs:5:33:5:35 | exit set_Item |
+| pre | AccessorCalls.cs:7:32:7:34 | enter add_Event | AccessorCalls.cs:7:36:7:38 | {...} |
+| pre | AccessorCalls.cs:7:36:7:38 | {...} | AccessorCalls.cs:7:32:7:34 | exit add_Event |
+| pre | AccessorCalls.cs:7:40:7:45 | enter remove_Event | AccessorCalls.cs:7:47:7:49 | {...} |
+| pre | AccessorCalls.cs:7:47:7:49 | {...} | AccessorCalls.cs:7:40:7:45 | exit remove_Event |
+| pre | AccessorCalls.cs:10:10:10:11 | enter M1 | AccessorCalls.cs:11:5:17:5 | {...} |
+| pre | AccessorCalls.cs:11:5:17:5 | {...} | AccessorCalls.cs:12:9:12:32 | ...; |
+| pre | AccessorCalls.cs:12:9:12:12 | this access | AccessorCalls.cs:12:9:12:18 | access to field Field |
+| pre | AccessorCalls.cs:12:9:12:18 | access to field Field | AccessorCalls.cs:12:22:12:25 | this access |
+| pre | AccessorCalls.cs:12:9:12:31 | ... = ... | AccessorCalls.cs:13:9:13:30 | ...; |
+| pre | AccessorCalls.cs:12:9:12:32 | ...; | AccessorCalls.cs:12:9:12:12 | this access |
+| pre | AccessorCalls.cs:12:22:12:25 | this access | AccessorCalls.cs:12:22:12:31 | access to field Field |
+| pre | AccessorCalls.cs:12:22:12:31 | access to field Field | AccessorCalls.cs:12:9:12:31 | ... = ... |
+| pre | AccessorCalls.cs:13:9:13:12 | this access | AccessorCalls.cs:13:9:13:17 | access to property Prop |
+| pre | AccessorCalls.cs:13:9:13:17 | access to property Prop | AccessorCalls.cs:13:21:13:24 | this access |
+| pre | AccessorCalls.cs:13:9:13:29 | ... = ... | AccessorCalls.cs:14:9:14:26 | ...; |
+| pre | AccessorCalls.cs:13:9:13:30 | ...; | AccessorCalls.cs:13:9:13:12 | this access |
+| pre | AccessorCalls.cs:13:21:13:24 | this access | AccessorCalls.cs:13:21:13:29 | access to property Prop |
+| pre | AccessorCalls.cs:13:21:13:29 | access to property Prop | AccessorCalls.cs:13:9:13:29 | ... = ... |
+| pre | AccessorCalls.cs:14:9:14:12 | this access | AccessorCalls.cs:14:14:14:14 | 0 |
+| pre | AccessorCalls.cs:14:9:14:15 | access to indexer | AccessorCalls.cs:14:19:14:22 | this access |
+| pre | AccessorCalls.cs:14:9:14:25 | ... = ... | AccessorCalls.cs:15:9:15:24 | ...; |
+| pre | AccessorCalls.cs:14:9:14:26 | ...; | AccessorCalls.cs:14:9:14:12 | this access |
+| pre | AccessorCalls.cs:14:14:14:14 | 0 | AccessorCalls.cs:14:9:14:15 | access to indexer |
+| pre | AccessorCalls.cs:14:19:14:22 | this access | AccessorCalls.cs:14:24:14:24 | 1 |
+| pre | AccessorCalls.cs:14:19:14:25 | access to indexer | AccessorCalls.cs:14:9:14:25 | ... = ... |
+| pre | AccessorCalls.cs:14:24:14:24 | 1 | AccessorCalls.cs:14:19:14:25 | access to indexer |
+| pre | AccessorCalls.cs:15:9:15:12 | this access | AccessorCalls.cs:15:9:15:18 | access to event Event |
+| pre | AccessorCalls.cs:15:9:15:18 | access to event Event | AccessorCalls.cs:15:23:15:23 | access to parameter e |
+| pre | AccessorCalls.cs:15:9:15:23 | ... += ... | AccessorCalls.cs:16:9:16:24 | ...; |
+| pre | AccessorCalls.cs:15:9:15:24 | ...; | AccessorCalls.cs:15:9:15:12 | this access |
+| pre | AccessorCalls.cs:15:23:15:23 | access to parameter e | AccessorCalls.cs:15:9:15:23 | ... += ... |
+| pre | AccessorCalls.cs:16:9:16:12 | this access | AccessorCalls.cs:16:9:16:18 | access to event Event |
+| pre | AccessorCalls.cs:16:9:16:18 | access to event Event | AccessorCalls.cs:16:23:16:23 | access to parameter e |
+| pre | AccessorCalls.cs:16:9:16:23 | ... -= ... | AccessorCalls.cs:10:10:10:11 | exit M1 |
+| pre | AccessorCalls.cs:16:9:16:24 | ...; | AccessorCalls.cs:16:9:16:12 | this access |
+| pre | AccessorCalls.cs:16:23:16:23 | access to parameter e | AccessorCalls.cs:16:9:16:23 | ... -= ... |
+| pre | AccessorCalls.cs:19:10:19:11 | enter M2 | AccessorCalls.cs:20:5:26:5 | {...} |
+| pre | AccessorCalls.cs:20:5:26:5 | {...} | AccessorCalls.cs:21:9:21:36 | ...; |
+| pre | AccessorCalls.cs:21:9:21:12 | this access | AccessorCalls.cs:21:9:21:14 | access to field x |
+| pre | AccessorCalls.cs:21:9:21:14 | access to field x | AccessorCalls.cs:21:9:21:20 | access to field Field |
+| pre | AccessorCalls.cs:21:9:21:20 | access to field Field | AccessorCalls.cs:21:24:21:27 | this access |
+| pre | AccessorCalls.cs:21:9:21:35 | ... = ... | AccessorCalls.cs:22:9:22:34 | ...; |
+| pre | AccessorCalls.cs:21:9:21:36 | ...; | AccessorCalls.cs:21:9:21:12 | this access |
+| pre | AccessorCalls.cs:21:24:21:27 | this access | AccessorCalls.cs:21:24:21:29 | access to field x |
+| pre | AccessorCalls.cs:21:24:21:29 | access to field x | AccessorCalls.cs:21:24:21:35 | access to field Field |
+| pre | AccessorCalls.cs:21:24:21:35 | access to field Field | AccessorCalls.cs:21:9:21:35 | ... = ... |
+| pre | AccessorCalls.cs:22:9:22:12 | this access | AccessorCalls.cs:22:9:22:14 | access to field x |
+| pre | AccessorCalls.cs:22:9:22:14 | access to field x | AccessorCalls.cs:22:9:22:19 | access to property Prop |
+| pre | AccessorCalls.cs:22:9:22:19 | access to property Prop | AccessorCalls.cs:22:23:22:26 | this access |
+| pre | AccessorCalls.cs:22:9:22:33 | ... = ... | AccessorCalls.cs:23:9:23:30 | ...; |
+| pre | AccessorCalls.cs:22:9:22:34 | ...; | AccessorCalls.cs:22:9:22:12 | this access |
+| pre | AccessorCalls.cs:22:23:22:26 | this access | AccessorCalls.cs:22:23:22:28 | access to field x |
+| pre | AccessorCalls.cs:22:23:22:28 | access to field x | AccessorCalls.cs:22:23:22:33 | access to property Prop |
+| pre | AccessorCalls.cs:22:23:22:33 | access to property Prop | AccessorCalls.cs:22:9:22:33 | ... = ... |
+| pre | AccessorCalls.cs:23:9:23:12 | this access | AccessorCalls.cs:23:9:23:14 | access to field x |
+| pre | AccessorCalls.cs:23:9:23:14 | access to field x | AccessorCalls.cs:23:16:23:16 | 0 |
+| pre | AccessorCalls.cs:23:9:23:17 | access to indexer | AccessorCalls.cs:23:21:23:24 | this access |
+| pre | AccessorCalls.cs:23:9:23:29 | ... = ... | AccessorCalls.cs:24:9:24:26 | ...; |
+| pre | AccessorCalls.cs:23:9:23:30 | ...; | AccessorCalls.cs:23:9:23:12 | this access |
+| pre | AccessorCalls.cs:23:16:23:16 | 0 | AccessorCalls.cs:23:9:23:17 | access to indexer |
+| pre | AccessorCalls.cs:23:21:23:24 | this access | AccessorCalls.cs:23:21:23:26 | access to field x |
+| pre | AccessorCalls.cs:23:21:23:26 | access to field x | AccessorCalls.cs:23:28:23:28 | 1 |
+| pre | AccessorCalls.cs:23:21:23:29 | access to indexer | AccessorCalls.cs:23:9:23:29 | ... = ... |
+| pre | AccessorCalls.cs:23:28:23:28 | 1 | AccessorCalls.cs:23:21:23:29 | access to indexer |
+| pre | AccessorCalls.cs:24:9:24:12 | this access | AccessorCalls.cs:24:9:24:14 | access to field x |
+| pre | AccessorCalls.cs:24:9:24:14 | access to field x | AccessorCalls.cs:24:9:24:20 | access to event Event |
+| pre | AccessorCalls.cs:24:9:24:20 | access to event Event | AccessorCalls.cs:24:25:24:25 | access to parameter e |
+| pre | AccessorCalls.cs:24:9:24:25 | ... += ... | AccessorCalls.cs:25:9:25:26 | ...; |
+| pre | AccessorCalls.cs:24:9:24:26 | ...; | AccessorCalls.cs:24:9:24:12 | this access |
+| pre | AccessorCalls.cs:24:25:24:25 | access to parameter e | AccessorCalls.cs:24:9:24:25 | ... += ... |
+| pre | AccessorCalls.cs:25:9:25:12 | this access | AccessorCalls.cs:25:9:25:14 | access to field x |
+| pre | AccessorCalls.cs:25:9:25:14 | access to field x | AccessorCalls.cs:25:9:25:20 | access to event Event |
+| pre | AccessorCalls.cs:25:9:25:20 | access to event Event | AccessorCalls.cs:25:25:25:25 | access to parameter e |
+| pre | AccessorCalls.cs:25:9:25:25 | ... -= ... | AccessorCalls.cs:19:10:19:11 | exit M2 |
+| pre | AccessorCalls.cs:25:9:25:26 | ...; | AccessorCalls.cs:25:9:25:12 | this access |
+| pre | AccessorCalls.cs:25:25:25:25 | access to parameter e | AccessorCalls.cs:25:9:25:25 | ... -= ... |
+| pre | AccessorCalls.cs:28:10:28:11 | enter M3 | AccessorCalls.cs:29:5:33:5 | {...} |
+| pre | AccessorCalls.cs:29:5:33:5 | {...} | AccessorCalls.cs:30:9:30:21 | ...; |
+| pre | AccessorCalls.cs:30:9:30:12 | this access | AccessorCalls.cs:30:9:30:18 | access to field Field |
+| pre | AccessorCalls.cs:30:9:30:18 | access to field Field | AccessorCalls.cs:30:9:30:20 | ...++ |
+| pre | AccessorCalls.cs:30:9:30:20 | ...++ | AccessorCalls.cs:31:9:31:20 | ...; |
+| pre | AccessorCalls.cs:30:9:30:21 | ...; | AccessorCalls.cs:30:9:30:12 | this access |
+| pre | AccessorCalls.cs:31:9:31:12 | this access | AccessorCalls.cs:31:9:31:17 | access to property Prop |
+| pre | AccessorCalls.cs:31:9:31:17 | access to property Prop | AccessorCalls.cs:31:9:31:19 | ...++ |
+| pre | AccessorCalls.cs:31:9:31:19 | ...++ | AccessorCalls.cs:32:9:32:18 | ...; |
+| pre | AccessorCalls.cs:31:9:31:20 | ...; | AccessorCalls.cs:31:9:31:12 | this access |
+| pre | AccessorCalls.cs:32:9:32:12 | this access | AccessorCalls.cs:32:14:32:14 | 0 |
+| pre | AccessorCalls.cs:32:9:32:15 | access to indexer | AccessorCalls.cs:32:9:32:17 | ...++ |
+| pre | AccessorCalls.cs:32:9:32:17 | ...++ | AccessorCalls.cs:28:10:28:11 | exit M3 |
+| pre | AccessorCalls.cs:32:9:32:18 | ...; | AccessorCalls.cs:32:9:32:12 | this access |
+| pre | AccessorCalls.cs:32:14:32:14 | 0 | AccessorCalls.cs:32:9:32:15 | access to indexer |
+| pre | AccessorCalls.cs:35:10:35:11 | enter M4 | AccessorCalls.cs:36:5:40:5 | {...} |
+| pre | AccessorCalls.cs:36:5:40:5 | {...} | AccessorCalls.cs:37:9:37:23 | ...; |
+| pre | AccessorCalls.cs:37:9:37:12 | this access | AccessorCalls.cs:37:9:37:14 | access to field x |
+| pre | AccessorCalls.cs:37:9:37:14 | access to field x | AccessorCalls.cs:37:9:37:20 | access to field Field |
+| pre | AccessorCalls.cs:37:9:37:20 | access to field Field | AccessorCalls.cs:37:9:37:22 | ...++ |
+| pre | AccessorCalls.cs:37:9:37:22 | ...++ | AccessorCalls.cs:38:9:38:22 | ...; |
+| pre | AccessorCalls.cs:37:9:37:23 | ...; | AccessorCalls.cs:37:9:37:12 | this access |
+| pre | AccessorCalls.cs:38:9:38:12 | this access | AccessorCalls.cs:38:9:38:14 | access to field x |
+| pre | AccessorCalls.cs:38:9:38:14 | access to field x | AccessorCalls.cs:38:9:38:19 | access to property Prop |
+| pre | AccessorCalls.cs:38:9:38:19 | access to property Prop | AccessorCalls.cs:38:9:38:21 | ...++ |
+| pre | AccessorCalls.cs:38:9:38:21 | ...++ | AccessorCalls.cs:39:9:39:20 | ...; |
+| pre | AccessorCalls.cs:38:9:38:22 | ...; | AccessorCalls.cs:38:9:38:12 | this access |
+| pre | AccessorCalls.cs:39:9:39:12 | this access | AccessorCalls.cs:39:9:39:14 | access to field x |
+| pre | AccessorCalls.cs:39:9:39:14 | access to field x | AccessorCalls.cs:39:16:39:16 | 0 |
+| pre | AccessorCalls.cs:39:9:39:17 | access to indexer | AccessorCalls.cs:39:9:39:19 | ...++ |
+| pre | AccessorCalls.cs:39:9:39:19 | ...++ | AccessorCalls.cs:35:10:35:11 | exit M4 |
+| pre | AccessorCalls.cs:39:9:39:20 | ...; | AccessorCalls.cs:39:9:39:12 | this access |
+| pre | AccessorCalls.cs:39:16:39:16 | 0 | AccessorCalls.cs:39:9:39:17 | access to indexer |
+| pre | AccessorCalls.cs:42:10:42:11 | enter M5 | AccessorCalls.cs:43:5:47:5 | {...} |
+| pre | AccessorCalls.cs:43:5:47:5 | {...} | AccessorCalls.cs:44:9:44:33 | ...; |
+| pre | AccessorCalls.cs:44:9:44:12 | this access | AccessorCalls.cs:44:9:44:18 | access to field Field |
+| pre | AccessorCalls.cs:44:9:44:12 | this access | AccessorCalls.cs:44:9:44:18 | access to field Field |
+| pre | AccessorCalls.cs:44:9:44:18 | access to field Field | AccessorCalls.cs:44:9:44:12 | this access |
+| pre | AccessorCalls.cs:44:9:44:18 | access to field Field | AccessorCalls.cs:44:23:44:26 | this access |
+| pre | AccessorCalls.cs:44:9:44:32 | ... + ... | AccessorCalls.cs:44:9:44:32 | ... = ... |
+| pre | AccessorCalls.cs:44:9:44:32 | ... = ... | AccessorCalls.cs:45:9:45:31 | ...; |
+| pre | AccessorCalls.cs:44:9:44:33 | ...; | AccessorCalls.cs:44:9:44:12 | this access |
+| pre | AccessorCalls.cs:44:23:44:26 | this access | AccessorCalls.cs:44:23:44:32 | access to field Field |
+| pre | AccessorCalls.cs:44:23:44:32 | access to field Field | AccessorCalls.cs:44:9:44:32 | ... + ... |
+| pre | AccessorCalls.cs:45:9:45:12 | this access | AccessorCalls.cs:45:9:45:17 | access to property Prop |
+| pre | AccessorCalls.cs:45:9:45:12 | this access | AccessorCalls.cs:45:9:45:17 | access to property Prop |
+| pre | AccessorCalls.cs:45:9:45:17 | access to property Prop | AccessorCalls.cs:45:9:45:12 | this access |
+| pre | AccessorCalls.cs:45:9:45:17 | access to property Prop | AccessorCalls.cs:45:22:45:25 | this access |
+| pre | AccessorCalls.cs:45:9:45:30 | ... + ... | AccessorCalls.cs:45:9:45:30 | ... = ... |
+| pre | AccessorCalls.cs:45:9:45:30 | ... = ... | AccessorCalls.cs:46:9:46:27 | ...; |
+| pre | AccessorCalls.cs:45:9:45:31 | ...; | AccessorCalls.cs:45:9:45:12 | this access |
+| pre | AccessorCalls.cs:45:22:45:25 | this access | AccessorCalls.cs:45:22:45:30 | access to property Prop |
+| pre | AccessorCalls.cs:45:22:45:30 | access to property Prop | AccessorCalls.cs:45:9:45:30 | ... + ... |
+| pre | AccessorCalls.cs:46:9:46:12 | this access | AccessorCalls.cs:46:14:46:14 | 0 |
+| pre | AccessorCalls.cs:46:9:46:12 | this access | AccessorCalls.cs:46:14:46:14 | 0 |
+| pre | AccessorCalls.cs:46:9:46:15 | access to indexer | AccessorCalls.cs:46:9:46:12 | this access |
+| pre | AccessorCalls.cs:46:9:46:15 | access to indexer | AccessorCalls.cs:46:20:46:23 | this access |
+| pre | AccessorCalls.cs:46:9:46:26 | ... + ... | AccessorCalls.cs:46:9:46:26 | ... = ... |
+| pre | AccessorCalls.cs:46:9:46:26 | ... = ... | AccessorCalls.cs:42:10:42:11 | exit M5 |
+| pre | AccessorCalls.cs:46:9:46:27 | ...; | AccessorCalls.cs:46:9:46:12 | this access |
+| pre | AccessorCalls.cs:46:14:46:14 | 0 | AccessorCalls.cs:46:9:46:15 | access to indexer |
+| pre | AccessorCalls.cs:46:14:46:14 | 0 | AccessorCalls.cs:46:9:46:15 | access to indexer |
+| pre | AccessorCalls.cs:46:20:46:23 | this access | AccessorCalls.cs:46:25:46:25 | 0 |
+| pre | AccessorCalls.cs:46:20:46:26 | access to indexer | AccessorCalls.cs:46:9:46:26 | ... + ... |
+| pre | AccessorCalls.cs:46:25:46:25 | 0 | AccessorCalls.cs:46:20:46:26 | access to indexer |
+| pre | AccessorCalls.cs:49:10:49:11 | enter M6 | AccessorCalls.cs:50:5:54:5 | {...} |
+| pre | AccessorCalls.cs:50:5:54:5 | {...} | AccessorCalls.cs:51:9:51:37 | ...; |
+| pre | AccessorCalls.cs:51:9:51:12 | this access | AccessorCalls.cs:51:9:51:14 | access to field x |
+| pre | AccessorCalls.cs:51:9:51:12 | this access | AccessorCalls.cs:51:9:51:14 | access to field x |
+| pre | AccessorCalls.cs:51:9:51:14 | access to field x | AccessorCalls.cs:51:9:51:20 | access to field Field |
+| pre | AccessorCalls.cs:51:9:51:14 | access to field x | AccessorCalls.cs:51:9:51:20 | access to field Field |
+| pre | AccessorCalls.cs:51:9:51:20 | access to field Field | AccessorCalls.cs:51:9:51:12 | this access |
+| pre | AccessorCalls.cs:51:9:51:20 | access to field Field | AccessorCalls.cs:51:25:51:28 | this access |
+| pre | AccessorCalls.cs:51:9:51:36 | ... + ... | AccessorCalls.cs:51:9:51:36 | ... = ... |
+| pre | AccessorCalls.cs:51:9:51:36 | ... = ... | AccessorCalls.cs:52:9:52:35 | ...; |
+| pre | AccessorCalls.cs:51:9:51:37 | ...; | AccessorCalls.cs:51:9:51:12 | this access |
+| pre | AccessorCalls.cs:51:25:51:28 | this access | AccessorCalls.cs:51:25:51:30 | access to field x |
+| pre | AccessorCalls.cs:51:25:51:30 | access to field x | AccessorCalls.cs:51:25:51:36 | access to field Field |
+| pre | AccessorCalls.cs:51:25:51:36 | access to field Field | AccessorCalls.cs:51:9:51:36 | ... + ... |
+| pre | AccessorCalls.cs:52:9:52:12 | this access | AccessorCalls.cs:52:9:52:14 | access to field x |
+| pre | AccessorCalls.cs:52:9:52:12 | this access | AccessorCalls.cs:52:9:52:14 | access to field x |
+| pre | AccessorCalls.cs:52:9:52:14 | access to field x | AccessorCalls.cs:52:9:52:19 | access to property Prop |
+| pre | AccessorCalls.cs:52:9:52:14 | access to field x | AccessorCalls.cs:52:9:52:19 | access to property Prop |
+| pre | AccessorCalls.cs:52:9:52:19 | access to property Prop | AccessorCalls.cs:52:9:52:12 | this access |
+| pre | AccessorCalls.cs:52:9:52:19 | access to property Prop | AccessorCalls.cs:52:24:52:27 | this access |
+| pre | AccessorCalls.cs:52:9:52:34 | ... + ... | AccessorCalls.cs:52:9:52:34 | ... = ... |
+| pre | AccessorCalls.cs:52:9:52:34 | ... = ... | AccessorCalls.cs:53:9:53:31 | ...; |
+| pre | AccessorCalls.cs:52:9:52:35 | ...; | AccessorCalls.cs:52:9:52:12 | this access |
+| pre | AccessorCalls.cs:52:24:52:27 | this access | AccessorCalls.cs:52:24:52:29 | access to field x |
+| pre | AccessorCalls.cs:52:24:52:29 | access to field x | AccessorCalls.cs:52:24:52:34 | access to property Prop |
+| pre | AccessorCalls.cs:52:24:52:34 | access to property Prop | AccessorCalls.cs:52:9:52:34 | ... + ... |
+| pre | AccessorCalls.cs:53:9:53:12 | this access | AccessorCalls.cs:53:9:53:14 | access to field x |
+| pre | AccessorCalls.cs:53:9:53:12 | this access | AccessorCalls.cs:53:9:53:14 | access to field x |
+| pre | AccessorCalls.cs:53:9:53:14 | access to field x | AccessorCalls.cs:53:16:53:16 | 0 |
+| pre | AccessorCalls.cs:53:9:53:14 | access to field x | AccessorCalls.cs:53:16:53:16 | 0 |
+| pre | AccessorCalls.cs:53:9:53:17 | access to indexer | AccessorCalls.cs:53:9:53:12 | this access |
+| pre | AccessorCalls.cs:53:9:53:17 | access to indexer | AccessorCalls.cs:53:22:53:25 | this access |
+| pre | AccessorCalls.cs:53:9:53:30 | ... + ... | AccessorCalls.cs:53:9:53:30 | ... = ... |
+| pre | AccessorCalls.cs:53:9:53:30 | ... = ... | AccessorCalls.cs:49:10:49:11 | exit M6 |
+| pre | AccessorCalls.cs:53:9:53:31 | ...; | AccessorCalls.cs:53:9:53:12 | this access |
+| pre | AccessorCalls.cs:53:16:53:16 | 0 | AccessorCalls.cs:53:9:53:17 | access to indexer |
+| pre | AccessorCalls.cs:53:16:53:16 | 0 | AccessorCalls.cs:53:9:53:17 | access to indexer |
+| pre | AccessorCalls.cs:53:22:53:25 | this access | AccessorCalls.cs:53:22:53:27 | access to field x |
+| pre | AccessorCalls.cs:53:22:53:27 | access to field x | AccessorCalls.cs:53:29:53:29 | 0 |
+| pre | AccessorCalls.cs:53:22:53:30 | access to indexer | AccessorCalls.cs:53:9:53:30 | ... + ... |
+| pre | AccessorCalls.cs:53:29:53:29 | 0 | AccessorCalls.cs:53:22:53:30 | access to indexer |
+| pre | AccessorCalls.cs:56:10:56:11 | enter M7 | AccessorCalls.cs:57:5:59:5 | {...} |
+| pre | AccessorCalls.cs:57:5:59:5 | {...} | AccessorCalls.cs:58:9:58:86 | ...; |
+| pre | AccessorCalls.cs:58:9:58:45 | (..., ...) | AccessorCalls.cs:58:50:58:53 | this access |
+| pre | AccessorCalls.cs:58:9:58:85 | ... = ... | AccessorCalls.cs:56:10:56:11 | exit M7 |
+| pre | AccessorCalls.cs:58:9:58:86 | ...; | AccessorCalls.cs:58:10:58:13 | this access |
+| pre | AccessorCalls.cs:58:10:58:13 | this access | AccessorCalls.cs:58:10:58:19 | access to field Field |
+| pre | AccessorCalls.cs:58:10:58:19 | access to field Field | AccessorCalls.cs:58:22:58:25 | this access |
+| pre | AccessorCalls.cs:58:22:58:25 | this access | AccessorCalls.cs:58:22:58:30 | access to property Prop |
+| pre | AccessorCalls.cs:58:22:58:30 | access to property Prop | AccessorCalls.cs:58:34:58:34 | access to parameter i |
+| pre | AccessorCalls.cs:58:33:58:44 | (..., ...) | AccessorCalls.cs:58:9:58:45 | (..., ...) |
+| pre | AccessorCalls.cs:58:34:58:34 | access to parameter i | AccessorCalls.cs:58:37:58:40 | this access |
+| pre | AccessorCalls.cs:58:37:58:40 | this access | AccessorCalls.cs:58:42:58:42 | 0 |
+| pre | AccessorCalls.cs:58:37:58:43 | access to indexer | AccessorCalls.cs:58:33:58:44 | (..., ...) |
+| pre | AccessorCalls.cs:58:42:58:42 | 0 | AccessorCalls.cs:58:37:58:43 | access to indexer |
+| pre | AccessorCalls.cs:58:49:58:85 | (..., ...) | AccessorCalls.cs:58:9:58:85 | ... = ... |
+| pre | AccessorCalls.cs:58:50:58:53 | this access | AccessorCalls.cs:58:50:58:59 | access to field Field |
+| pre | AccessorCalls.cs:58:50:58:59 | access to field Field | AccessorCalls.cs:58:62:58:65 | this access |
+| pre | AccessorCalls.cs:58:62:58:65 | this access | AccessorCalls.cs:58:62:58:70 | access to property Prop |
+| pre | AccessorCalls.cs:58:62:58:70 | access to property Prop | AccessorCalls.cs:58:74:58:74 | 0 |
+| pre | AccessorCalls.cs:58:73:58:84 | (..., ...) | AccessorCalls.cs:58:49:58:85 | (..., ...) |
+| pre | AccessorCalls.cs:58:74:58:74 | 0 | AccessorCalls.cs:58:77:58:80 | this access |
+| pre | AccessorCalls.cs:58:77:58:80 | this access | AccessorCalls.cs:58:82:58:82 | 1 |
+| pre | AccessorCalls.cs:58:77:58:83 | access to indexer | AccessorCalls.cs:58:73:58:84 | (..., ...) |
+| pre | AccessorCalls.cs:58:82:58:82 | 1 | AccessorCalls.cs:58:77:58:83 | access to indexer |
+| pre | AccessorCalls.cs:61:10:61:11 | enter M8 | AccessorCalls.cs:62:5:64:5 | {...} |
+| pre | AccessorCalls.cs:62:5:64:5 | {...} | AccessorCalls.cs:63:9:63:98 | ...; |
+| pre | AccessorCalls.cs:63:9:63:51 | (..., ...) | AccessorCalls.cs:63:56:63:59 | this access |
+| pre | AccessorCalls.cs:63:9:63:97 | ... = ... | AccessorCalls.cs:61:10:61:11 | exit M8 |
+| pre | AccessorCalls.cs:63:9:63:98 | ...; | AccessorCalls.cs:63:10:63:13 | this access |
+| pre | AccessorCalls.cs:63:10:63:13 | this access | AccessorCalls.cs:63:10:63:15 | access to field x |
+| pre | AccessorCalls.cs:63:10:63:15 | access to field x | AccessorCalls.cs:63:10:63:21 | access to field Field |
+| pre | AccessorCalls.cs:63:10:63:21 | access to field Field | AccessorCalls.cs:63:24:63:27 | this access |
+| pre | AccessorCalls.cs:63:24:63:27 | this access | AccessorCalls.cs:63:24:63:29 | access to field x |
+| pre | AccessorCalls.cs:63:24:63:29 | access to field x | AccessorCalls.cs:63:24:63:34 | access to property Prop |
+| pre | AccessorCalls.cs:63:24:63:34 | access to property Prop | AccessorCalls.cs:63:38:63:38 | access to parameter i |
+| pre | AccessorCalls.cs:63:37:63:50 | (..., ...) | AccessorCalls.cs:63:9:63:51 | (..., ...) |
+| pre | AccessorCalls.cs:63:38:63:38 | access to parameter i | AccessorCalls.cs:63:41:63:44 | this access |
+| pre | AccessorCalls.cs:63:41:63:44 | this access | AccessorCalls.cs:63:41:63:46 | access to field x |
+| pre | AccessorCalls.cs:63:41:63:46 | access to field x | AccessorCalls.cs:63:48:63:48 | 0 |
+| pre | AccessorCalls.cs:63:41:63:49 | access to indexer | AccessorCalls.cs:63:37:63:50 | (..., ...) |
+| pre | AccessorCalls.cs:63:48:63:48 | 0 | AccessorCalls.cs:63:41:63:49 | access to indexer |
+| pre | AccessorCalls.cs:63:55:63:97 | (..., ...) | AccessorCalls.cs:63:9:63:97 | ... = ... |
+| pre | AccessorCalls.cs:63:56:63:59 | this access | AccessorCalls.cs:63:56:63:61 | access to field x |
+| pre | AccessorCalls.cs:63:56:63:61 | access to field x | AccessorCalls.cs:63:56:63:67 | access to field Field |
+| pre | AccessorCalls.cs:63:56:63:67 | access to field Field | AccessorCalls.cs:63:70:63:73 | this access |
+| pre | AccessorCalls.cs:63:70:63:73 | this access | AccessorCalls.cs:63:70:63:75 | access to field x |
+| pre | AccessorCalls.cs:63:70:63:75 | access to field x | AccessorCalls.cs:63:70:63:80 | access to property Prop |
+| pre | AccessorCalls.cs:63:70:63:80 | access to property Prop | AccessorCalls.cs:63:84:63:84 | 0 |
+| pre | AccessorCalls.cs:63:83:63:96 | (..., ...) | AccessorCalls.cs:63:55:63:97 | (..., ...) |
+| pre | AccessorCalls.cs:63:84:63:84 | 0 | AccessorCalls.cs:63:87:63:90 | this access |
+| pre | AccessorCalls.cs:63:87:63:90 | this access | AccessorCalls.cs:63:87:63:92 | access to field x |
+| pre | AccessorCalls.cs:63:87:63:92 | access to field x | AccessorCalls.cs:63:94:63:94 | 1 |
+| pre | AccessorCalls.cs:63:87:63:95 | access to indexer | AccessorCalls.cs:63:83:63:96 | (..., ...) |
+| pre | AccessorCalls.cs:63:94:63:94 | 1 | AccessorCalls.cs:63:87:63:95 | access to indexer |
 | pre | ArrayCreation.cs:3:11:3:12 | enter M1 | ArrayCreation.cs:3:27:3:27 | 0 |
 | pre | ArrayCreation.cs:3:19:3:28 | array creation of type Int32[] | ArrayCreation.cs:3:11:3:12 | exit M1 |
 | pre | ArrayCreation.cs:3:27:3:27 | 0 | ArrayCreation.cs:3:19:3:28 | array creation of type Int32[] |

--- a/csharp/ql/test/library-tests/controlflow/graph/ElementGraph.expected
+++ b/csharp/ql/test/library-tests/controlflow/graph/ElementGraph.expected
@@ -1,71 +1,69 @@
 | AccessorCalls.cs:11:5:17:5 | {...} | AccessorCalls.cs:12:9:12:32 | ...; | semmle.label | successor |
-| AccessorCalls.cs:12:9:12:12 | this access | AccessorCalls.cs:12:9:12:18 | access to field Field | semmle.label | successor |
-| AccessorCalls.cs:12:9:12:18 | access to field Field | AccessorCalls.cs:12:22:12:25 | this access | semmle.label | successor |
+| AccessorCalls.cs:12:9:12:12 | this access | AccessorCalls.cs:12:22:12:25 | this access | semmle.label | successor |
 | AccessorCalls.cs:12:9:12:31 | ... = ... | AccessorCalls.cs:13:9:13:30 | ...; | semmle.label | successor |
 | AccessorCalls.cs:12:9:12:32 | ...; | AccessorCalls.cs:12:9:12:12 | this access | semmle.label | successor |
 | AccessorCalls.cs:12:22:12:25 | this access | AccessorCalls.cs:12:22:12:31 | access to field Field | semmle.label | successor |
 | AccessorCalls.cs:12:22:12:31 | access to field Field | AccessorCalls.cs:12:9:12:31 | ... = ... | semmle.label | successor |
-| AccessorCalls.cs:13:9:13:12 | this access | AccessorCalls.cs:13:9:13:17 | access to property Prop | semmle.label | successor |
-| AccessorCalls.cs:13:9:13:17 | access to property Prop | AccessorCalls.cs:13:21:13:24 | this access | semmle.label | successor |
+| AccessorCalls.cs:13:9:13:12 | this access | AccessorCalls.cs:13:21:13:24 | this access | semmle.label | successor |
+| AccessorCalls.cs:13:9:13:17 | access to property Prop | AccessorCalls.cs:13:9:13:29 | ... = ... | semmle.label | successor |
 | AccessorCalls.cs:13:9:13:29 | ... = ... | AccessorCalls.cs:14:9:14:26 | ...; | semmle.label | successor |
 | AccessorCalls.cs:13:9:13:30 | ...; | AccessorCalls.cs:13:9:13:12 | this access | semmle.label | successor |
 | AccessorCalls.cs:13:21:13:24 | this access | AccessorCalls.cs:13:21:13:29 | access to property Prop | semmle.label | successor |
-| AccessorCalls.cs:13:21:13:29 | access to property Prop | AccessorCalls.cs:13:9:13:29 | ... = ... | semmle.label | successor |
+| AccessorCalls.cs:13:21:13:29 | access to property Prop | AccessorCalls.cs:13:9:13:17 | access to property Prop | semmle.label | successor |
 | AccessorCalls.cs:14:9:14:12 | this access | AccessorCalls.cs:14:14:14:14 | 0 | semmle.label | successor |
-| AccessorCalls.cs:14:9:14:15 | access to indexer | AccessorCalls.cs:14:19:14:22 | this access | semmle.label | successor |
+| AccessorCalls.cs:14:9:14:15 | access to indexer | AccessorCalls.cs:14:9:14:25 | ... = ... | semmle.label | successor |
 | AccessorCalls.cs:14:9:14:25 | ... = ... | AccessorCalls.cs:15:9:15:24 | ...; | semmle.label | successor |
 | AccessorCalls.cs:14:9:14:26 | ...; | AccessorCalls.cs:14:9:14:12 | this access | semmle.label | successor |
-| AccessorCalls.cs:14:14:14:14 | 0 | AccessorCalls.cs:14:9:14:15 | access to indexer | semmle.label | successor |
+| AccessorCalls.cs:14:14:14:14 | 0 | AccessorCalls.cs:14:19:14:22 | this access | semmle.label | successor |
 | AccessorCalls.cs:14:19:14:22 | this access | AccessorCalls.cs:14:24:14:24 | 1 | semmle.label | successor |
-| AccessorCalls.cs:14:19:14:25 | access to indexer | AccessorCalls.cs:14:9:14:25 | ... = ... | semmle.label | successor |
+| AccessorCalls.cs:14:19:14:25 | access to indexer | AccessorCalls.cs:14:9:14:15 | access to indexer | semmle.label | successor |
 | AccessorCalls.cs:14:24:14:24 | 1 | AccessorCalls.cs:14:19:14:25 | access to indexer | semmle.label | successor |
-| AccessorCalls.cs:15:9:15:12 | this access | AccessorCalls.cs:15:9:15:18 | access to event Event | semmle.label | successor |
-| AccessorCalls.cs:15:9:15:18 | access to event Event | AccessorCalls.cs:15:23:15:23 | access to parameter e | semmle.label | successor |
+| AccessorCalls.cs:15:9:15:12 | this access | AccessorCalls.cs:15:23:15:23 | access to parameter e | semmle.label | successor |
+| AccessorCalls.cs:15:9:15:18 | access to event Event | AccessorCalls.cs:15:9:15:23 | ... += ... | semmle.label | successor |
 | AccessorCalls.cs:15:9:15:23 | ... += ... | AccessorCalls.cs:16:9:16:24 | ...; | semmle.label | successor |
 | AccessorCalls.cs:15:9:15:24 | ...; | AccessorCalls.cs:15:9:15:12 | this access | semmle.label | successor |
-| AccessorCalls.cs:15:23:15:23 | access to parameter e | AccessorCalls.cs:15:9:15:23 | ... += ... | semmle.label | successor |
-| AccessorCalls.cs:16:9:16:12 | this access | AccessorCalls.cs:16:9:16:18 | access to event Event | semmle.label | successor |
-| AccessorCalls.cs:16:9:16:18 | access to event Event | AccessorCalls.cs:16:23:16:23 | access to parameter e | semmle.label | successor |
+| AccessorCalls.cs:15:23:15:23 | access to parameter e | AccessorCalls.cs:15:9:15:18 | access to event Event | semmle.label | successor |
+| AccessorCalls.cs:16:9:16:12 | this access | AccessorCalls.cs:16:23:16:23 | access to parameter e | semmle.label | successor |
+| AccessorCalls.cs:16:9:16:18 | access to event Event | AccessorCalls.cs:16:9:16:23 | ... -= ... | semmle.label | successor |
 | AccessorCalls.cs:16:9:16:24 | ...; | AccessorCalls.cs:16:9:16:12 | this access | semmle.label | successor |
-| AccessorCalls.cs:16:23:16:23 | access to parameter e | AccessorCalls.cs:16:9:16:23 | ... -= ... | semmle.label | successor |
+| AccessorCalls.cs:16:23:16:23 | access to parameter e | AccessorCalls.cs:16:9:16:18 | access to event Event | semmle.label | successor |
 | AccessorCalls.cs:20:5:26:5 | {...} | AccessorCalls.cs:21:9:21:36 | ...; | semmle.label | successor |
 | AccessorCalls.cs:21:9:21:12 | this access | AccessorCalls.cs:21:9:21:14 | access to field x | semmle.label | successor |
-| AccessorCalls.cs:21:9:21:14 | access to field x | AccessorCalls.cs:21:9:21:20 | access to field Field | semmle.label | successor |
-| AccessorCalls.cs:21:9:21:20 | access to field Field | AccessorCalls.cs:21:24:21:27 | this access | semmle.label | successor |
+| AccessorCalls.cs:21:9:21:14 | access to field x | AccessorCalls.cs:21:24:21:27 | this access | semmle.label | successor |
 | AccessorCalls.cs:21:9:21:35 | ... = ... | AccessorCalls.cs:22:9:22:34 | ...; | semmle.label | successor |
 | AccessorCalls.cs:21:9:21:36 | ...; | AccessorCalls.cs:21:9:21:12 | this access | semmle.label | successor |
 | AccessorCalls.cs:21:24:21:27 | this access | AccessorCalls.cs:21:24:21:29 | access to field x | semmle.label | successor |
 | AccessorCalls.cs:21:24:21:29 | access to field x | AccessorCalls.cs:21:24:21:35 | access to field Field | semmle.label | successor |
 | AccessorCalls.cs:21:24:21:35 | access to field Field | AccessorCalls.cs:21:9:21:35 | ... = ... | semmle.label | successor |
 | AccessorCalls.cs:22:9:22:12 | this access | AccessorCalls.cs:22:9:22:14 | access to field x | semmle.label | successor |
-| AccessorCalls.cs:22:9:22:14 | access to field x | AccessorCalls.cs:22:9:22:19 | access to property Prop | semmle.label | successor |
-| AccessorCalls.cs:22:9:22:19 | access to property Prop | AccessorCalls.cs:22:23:22:26 | this access | semmle.label | successor |
+| AccessorCalls.cs:22:9:22:14 | access to field x | AccessorCalls.cs:22:23:22:26 | this access | semmle.label | successor |
+| AccessorCalls.cs:22:9:22:19 | access to property Prop | AccessorCalls.cs:22:9:22:33 | ... = ... | semmle.label | successor |
 | AccessorCalls.cs:22:9:22:33 | ... = ... | AccessorCalls.cs:23:9:23:30 | ...; | semmle.label | successor |
 | AccessorCalls.cs:22:9:22:34 | ...; | AccessorCalls.cs:22:9:22:12 | this access | semmle.label | successor |
 | AccessorCalls.cs:22:23:22:26 | this access | AccessorCalls.cs:22:23:22:28 | access to field x | semmle.label | successor |
 | AccessorCalls.cs:22:23:22:28 | access to field x | AccessorCalls.cs:22:23:22:33 | access to property Prop | semmle.label | successor |
-| AccessorCalls.cs:22:23:22:33 | access to property Prop | AccessorCalls.cs:22:9:22:33 | ... = ... | semmle.label | successor |
+| AccessorCalls.cs:22:23:22:33 | access to property Prop | AccessorCalls.cs:22:9:22:19 | access to property Prop | semmle.label | successor |
 | AccessorCalls.cs:23:9:23:12 | this access | AccessorCalls.cs:23:9:23:14 | access to field x | semmle.label | successor |
 | AccessorCalls.cs:23:9:23:14 | access to field x | AccessorCalls.cs:23:16:23:16 | 0 | semmle.label | successor |
-| AccessorCalls.cs:23:9:23:17 | access to indexer | AccessorCalls.cs:23:21:23:24 | this access | semmle.label | successor |
+| AccessorCalls.cs:23:9:23:17 | access to indexer | AccessorCalls.cs:23:9:23:29 | ... = ... | semmle.label | successor |
 | AccessorCalls.cs:23:9:23:29 | ... = ... | AccessorCalls.cs:24:9:24:26 | ...; | semmle.label | successor |
 | AccessorCalls.cs:23:9:23:30 | ...; | AccessorCalls.cs:23:9:23:12 | this access | semmle.label | successor |
-| AccessorCalls.cs:23:16:23:16 | 0 | AccessorCalls.cs:23:9:23:17 | access to indexer | semmle.label | successor |
+| AccessorCalls.cs:23:16:23:16 | 0 | AccessorCalls.cs:23:21:23:24 | this access | semmle.label | successor |
 | AccessorCalls.cs:23:21:23:24 | this access | AccessorCalls.cs:23:21:23:26 | access to field x | semmle.label | successor |
 | AccessorCalls.cs:23:21:23:26 | access to field x | AccessorCalls.cs:23:28:23:28 | 1 | semmle.label | successor |
-| AccessorCalls.cs:23:21:23:29 | access to indexer | AccessorCalls.cs:23:9:23:29 | ... = ... | semmle.label | successor |
+| AccessorCalls.cs:23:21:23:29 | access to indexer | AccessorCalls.cs:23:9:23:17 | access to indexer | semmle.label | successor |
 | AccessorCalls.cs:23:28:23:28 | 1 | AccessorCalls.cs:23:21:23:29 | access to indexer | semmle.label | successor |
 | AccessorCalls.cs:24:9:24:12 | this access | AccessorCalls.cs:24:9:24:14 | access to field x | semmle.label | successor |
-| AccessorCalls.cs:24:9:24:14 | access to field x | AccessorCalls.cs:24:9:24:20 | access to event Event | semmle.label | successor |
-| AccessorCalls.cs:24:9:24:20 | access to event Event | AccessorCalls.cs:24:25:24:25 | access to parameter e | semmle.label | successor |
+| AccessorCalls.cs:24:9:24:14 | access to field x | AccessorCalls.cs:24:25:24:25 | access to parameter e | semmle.label | successor |
+| AccessorCalls.cs:24:9:24:20 | access to event Event | AccessorCalls.cs:24:9:24:25 | ... += ... | semmle.label | successor |
 | AccessorCalls.cs:24:9:24:25 | ... += ... | AccessorCalls.cs:25:9:25:26 | ...; | semmle.label | successor |
 | AccessorCalls.cs:24:9:24:26 | ...; | AccessorCalls.cs:24:9:24:12 | this access | semmle.label | successor |
-| AccessorCalls.cs:24:25:24:25 | access to parameter e | AccessorCalls.cs:24:9:24:25 | ... += ... | semmle.label | successor |
+| AccessorCalls.cs:24:25:24:25 | access to parameter e | AccessorCalls.cs:24:9:24:20 | access to event Event | semmle.label | successor |
 | AccessorCalls.cs:25:9:25:12 | this access | AccessorCalls.cs:25:9:25:14 | access to field x | semmle.label | successor |
-| AccessorCalls.cs:25:9:25:14 | access to field x | AccessorCalls.cs:25:9:25:20 | access to event Event | semmle.label | successor |
-| AccessorCalls.cs:25:9:25:20 | access to event Event | AccessorCalls.cs:25:25:25:25 | access to parameter e | semmle.label | successor |
+| AccessorCalls.cs:25:9:25:14 | access to field x | AccessorCalls.cs:25:25:25:25 | access to parameter e | semmle.label | successor |
+| AccessorCalls.cs:25:9:25:20 | access to event Event | AccessorCalls.cs:25:9:25:25 | ... -= ... | semmle.label | successor |
 | AccessorCalls.cs:25:9:25:26 | ...; | AccessorCalls.cs:25:9:25:12 | this access | semmle.label | successor |
-| AccessorCalls.cs:25:25:25:25 | access to parameter e | AccessorCalls.cs:25:9:25:25 | ... -= ... | semmle.label | successor |
+| AccessorCalls.cs:25:25:25:25 | access to parameter e | AccessorCalls.cs:25:9:25:20 | access to event Event | semmle.label | successor |
 | AccessorCalls.cs:29:5:33:5 | {...} | AccessorCalls.cs:30:9:30:21 | ...; | semmle.label | successor |
 | AccessorCalls.cs:30:9:30:12 | this access | AccessorCalls.cs:30:9:30:18 | access to field Field | semmle.label | successor |
 | AccessorCalls.cs:30:9:30:18 | access to field Field | AccessorCalls.cs:30:9:30:20 | ...++ | semmle.label | successor |
@@ -96,31 +94,30 @@
 | AccessorCalls.cs:39:9:39:20 | ...; | AccessorCalls.cs:39:9:39:12 | this access | semmle.label | successor |
 | AccessorCalls.cs:39:16:39:16 | 0 | AccessorCalls.cs:39:9:39:17 | access to indexer | semmle.label | successor |
 | AccessorCalls.cs:43:5:47:5 | {...} | AccessorCalls.cs:44:9:44:33 | ...; | semmle.label | successor |
+| AccessorCalls.cs:44:9:44:12 | this access | AccessorCalls.cs:44:9:44:12 | this access | semmle.label | successor |
 | AccessorCalls.cs:44:9:44:12 | this access | AccessorCalls.cs:44:9:44:18 | access to field Field | semmle.label | successor |
-| AccessorCalls.cs:44:9:44:12 | this access | AccessorCalls.cs:44:9:44:18 | access to field Field | semmle.label | successor |
-| AccessorCalls.cs:44:9:44:18 | access to field Field | AccessorCalls.cs:44:9:44:12 | this access | semmle.label | successor |
 | AccessorCalls.cs:44:9:44:18 | access to field Field | AccessorCalls.cs:44:23:44:26 | this access | semmle.label | successor |
 | AccessorCalls.cs:44:9:44:32 | ... + ... | AccessorCalls.cs:44:9:44:32 | ... = ... | semmle.label | successor |
 | AccessorCalls.cs:44:9:44:32 | ... = ... | AccessorCalls.cs:45:9:45:31 | ...; | semmle.label | successor |
 | AccessorCalls.cs:44:9:44:33 | ...; | AccessorCalls.cs:44:9:44:12 | this access | semmle.label | successor |
 | AccessorCalls.cs:44:23:44:26 | this access | AccessorCalls.cs:44:23:44:32 | access to field Field | semmle.label | successor |
 | AccessorCalls.cs:44:23:44:32 | access to field Field | AccessorCalls.cs:44:9:44:32 | ... + ... | semmle.label | successor |
+| AccessorCalls.cs:45:9:45:12 | this access | AccessorCalls.cs:45:9:45:12 | this access | semmle.label | successor |
 | AccessorCalls.cs:45:9:45:12 | this access | AccessorCalls.cs:45:9:45:17 | access to property Prop | semmle.label | successor |
-| AccessorCalls.cs:45:9:45:12 | this access | AccessorCalls.cs:45:9:45:17 | access to property Prop | semmle.label | successor |
-| AccessorCalls.cs:45:9:45:17 | access to property Prop | AccessorCalls.cs:45:9:45:12 | this access | semmle.label | successor |
+| AccessorCalls.cs:45:9:45:17 | access to property Prop | AccessorCalls.cs:45:9:45:30 | ... = ... | semmle.label | successor |
 | AccessorCalls.cs:45:9:45:17 | access to property Prop | AccessorCalls.cs:45:22:45:25 | this access | semmle.label | successor |
-| AccessorCalls.cs:45:9:45:30 | ... + ... | AccessorCalls.cs:45:9:45:30 | ... = ... | semmle.label | successor |
+| AccessorCalls.cs:45:9:45:30 | ... + ... | AccessorCalls.cs:45:9:45:17 | access to property Prop | semmle.label | successor |
 | AccessorCalls.cs:45:9:45:30 | ... = ... | AccessorCalls.cs:46:9:46:27 | ...; | semmle.label | successor |
 | AccessorCalls.cs:45:9:45:31 | ...; | AccessorCalls.cs:45:9:45:12 | this access | semmle.label | successor |
 | AccessorCalls.cs:45:22:45:25 | this access | AccessorCalls.cs:45:22:45:30 | access to property Prop | semmle.label | successor |
 | AccessorCalls.cs:45:22:45:30 | access to property Prop | AccessorCalls.cs:45:9:45:30 | ... + ... | semmle.label | successor |
 | AccessorCalls.cs:46:9:46:12 | this access | AccessorCalls.cs:46:14:46:14 | 0 | semmle.label | successor |
 | AccessorCalls.cs:46:9:46:12 | this access | AccessorCalls.cs:46:14:46:14 | 0 | semmle.label | successor |
-| AccessorCalls.cs:46:9:46:15 | access to indexer | AccessorCalls.cs:46:9:46:12 | this access | semmle.label | successor |
+| AccessorCalls.cs:46:9:46:15 | access to indexer | AccessorCalls.cs:46:9:46:26 | ... = ... | semmle.label | successor |
 | AccessorCalls.cs:46:9:46:15 | access to indexer | AccessorCalls.cs:46:20:46:23 | this access | semmle.label | successor |
-| AccessorCalls.cs:46:9:46:26 | ... + ... | AccessorCalls.cs:46:9:46:26 | ... = ... | semmle.label | successor |
+| AccessorCalls.cs:46:9:46:26 | ... + ... | AccessorCalls.cs:46:9:46:15 | access to indexer | semmle.label | successor |
 | AccessorCalls.cs:46:9:46:27 | ...; | AccessorCalls.cs:46:9:46:12 | this access | semmle.label | successor |
-| AccessorCalls.cs:46:14:46:14 | 0 | AccessorCalls.cs:46:9:46:15 | access to indexer | semmle.label | successor |
+| AccessorCalls.cs:46:14:46:14 | 0 | AccessorCalls.cs:46:9:46:12 | this access | semmle.label | successor |
 | AccessorCalls.cs:46:14:46:14 | 0 | AccessorCalls.cs:46:9:46:15 | access to indexer | semmle.label | successor |
 | AccessorCalls.cs:46:20:46:23 | this access | AccessorCalls.cs:46:25:46:25 | 0 | semmle.label | successor |
 | AccessorCalls.cs:46:20:46:26 | access to indexer | AccessorCalls.cs:46:9:46:26 | ... + ... | semmle.label | successor |
@@ -128,9 +125,8 @@
 | AccessorCalls.cs:50:5:54:5 | {...} | AccessorCalls.cs:51:9:51:37 | ...; | semmle.label | successor |
 | AccessorCalls.cs:51:9:51:12 | this access | AccessorCalls.cs:51:9:51:14 | access to field x | semmle.label | successor |
 | AccessorCalls.cs:51:9:51:12 | this access | AccessorCalls.cs:51:9:51:14 | access to field x | semmle.label | successor |
+| AccessorCalls.cs:51:9:51:14 | access to field x | AccessorCalls.cs:51:9:51:12 | this access | semmle.label | successor |
 | AccessorCalls.cs:51:9:51:14 | access to field x | AccessorCalls.cs:51:9:51:20 | access to field Field | semmle.label | successor |
-| AccessorCalls.cs:51:9:51:14 | access to field x | AccessorCalls.cs:51:9:51:20 | access to field Field | semmle.label | successor |
-| AccessorCalls.cs:51:9:51:20 | access to field Field | AccessorCalls.cs:51:9:51:12 | this access | semmle.label | successor |
 | AccessorCalls.cs:51:9:51:20 | access to field Field | AccessorCalls.cs:51:25:51:28 | this access | semmle.label | successor |
 | AccessorCalls.cs:51:9:51:36 | ... + ... | AccessorCalls.cs:51:9:51:36 | ... = ... | semmle.label | successor |
 | AccessorCalls.cs:51:9:51:36 | ... = ... | AccessorCalls.cs:52:9:52:35 | ...; | semmle.label | successor |
@@ -140,11 +136,11 @@
 | AccessorCalls.cs:51:25:51:36 | access to field Field | AccessorCalls.cs:51:9:51:36 | ... + ... | semmle.label | successor |
 | AccessorCalls.cs:52:9:52:12 | this access | AccessorCalls.cs:52:9:52:14 | access to field x | semmle.label | successor |
 | AccessorCalls.cs:52:9:52:12 | this access | AccessorCalls.cs:52:9:52:14 | access to field x | semmle.label | successor |
+| AccessorCalls.cs:52:9:52:14 | access to field x | AccessorCalls.cs:52:9:52:12 | this access | semmle.label | successor |
 | AccessorCalls.cs:52:9:52:14 | access to field x | AccessorCalls.cs:52:9:52:19 | access to property Prop | semmle.label | successor |
-| AccessorCalls.cs:52:9:52:14 | access to field x | AccessorCalls.cs:52:9:52:19 | access to property Prop | semmle.label | successor |
-| AccessorCalls.cs:52:9:52:19 | access to property Prop | AccessorCalls.cs:52:9:52:12 | this access | semmle.label | successor |
+| AccessorCalls.cs:52:9:52:19 | access to property Prop | AccessorCalls.cs:52:9:52:34 | ... = ... | semmle.label | successor |
 | AccessorCalls.cs:52:9:52:19 | access to property Prop | AccessorCalls.cs:52:24:52:27 | this access | semmle.label | successor |
-| AccessorCalls.cs:52:9:52:34 | ... + ... | AccessorCalls.cs:52:9:52:34 | ... = ... | semmle.label | successor |
+| AccessorCalls.cs:52:9:52:34 | ... + ... | AccessorCalls.cs:52:9:52:19 | access to property Prop | semmle.label | successor |
 | AccessorCalls.cs:52:9:52:34 | ... = ... | AccessorCalls.cs:53:9:53:31 | ...; | semmle.label | successor |
 | AccessorCalls.cs:52:9:52:35 | ...; | AccessorCalls.cs:52:9:52:12 | this access | semmle.label | successor |
 | AccessorCalls.cs:52:24:52:27 | this access | AccessorCalls.cs:52:24:52:29 | access to field x | semmle.label | successor |
@@ -154,11 +150,11 @@
 | AccessorCalls.cs:53:9:53:12 | this access | AccessorCalls.cs:53:9:53:14 | access to field x | semmle.label | successor |
 | AccessorCalls.cs:53:9:53:14 | access to field x | AccessorCalls.cs:53:16:53:16 | 0 | semmle.label | successor |
 | AccessorCalls.cs:53:9:53:14 | access to field x | AccessorCalls.cs:53:16:53:16 | 0 | semmle.label | successor |
-| AccessorCalls.cs:53:9:53:17 | access to indexer | AccessorCalls.cs:53:9:53:12 | this access | semmle.label | successor |
+| AccessorCalls.cs:53:9:53:17 | access to indexer | AccessorCalls.cs:53:9:53:30 | ... = ... | semmle.label | successor |
 | AccessorCalls.cs:53:9:53:17 | access to indexer | AccessorCalls.cs:53:22:53:25 | this access | semmle.label | successor |
-| AccessorCalls.cs:53:9:53:30 | ... + ... | AccessorCalls.cs:53:9:53:30 | ... = ... | semmle.label | successor |
+| AccessorCalls.cs:53:9:53:30 | ... + ... | AccessorCalls.cs:53:9:53:17 | access to indexer | semmle.label | successor |
 | AccessorCalls.cs:53:9:53:31 | ...; | AccessorCalls.cs:53:9:53:12 | this access | semmle.label | successor |
-| AccessorCalls.cs:53:16:53:16 | 0 | AccessorCalls.cs:53:9:53:17 | access to indexer | semmle.label | successor |
+| AccessorCalls.cs:53:16:53:16 | 0 | AccessorCalls.cs:53:9:53:12 | this access | semmle.label | successor |
 | AccessorCalls.cs:53:16:53:16 | 0 | AccessorCalls.cs:53:9:53:17 | access to indexer | semmle.label | successor |
 | AccessorCalls.cs:53:22:53:25 | this access | AccessorCalls.cs:53:22:53:27 | access to field x | semmle.label | successor |
 | AccessorCalls.cs:53:22:53:27 | access to field x | AccessorCalls.cs:53:29:53:29 | 0 | semmle.label | successor |
@@ -167,16 +163,14 @@
 | AccessorCalls.cs:57:5:59:5 | {...} | AccessorCalls.cs:58:9:58:86 | ...; | semmle.label | successor |
 | AccessorCalls.cs:58:9:58:45 | (..., ...) | AccessorCalls.cs:58:50:58:53 | this access | semmle.label | successor |
 | AccessorCalls.cs:58:9:58:86 | ...; | AccessorCalls.cs:58:10:58:13 | this access | semmle.label | successor |
-| AccessorCalls.cs:58:10:58:13 | this access | AccessorCalls.cs:58:10:58:19 | access to field Field | semmle.label | successor |
-| AccessorCalls.cs:58:10:58:19 | access to field Field | AccessorCalls.cs:58:22:58:25 | this access | semmle.label | successor |
-| AccessorCalls.cs:58:22:58:25 | this access | AccessorCalls.cs:58:22:58:30 | access to property Prop | semmle.label | successor |
-| AccessorCalls.cs:58:22:58:30 | access to property Prop | AccessorCalls.cs:58:34:58:34 | access to parameter i | semmle.label | successor |
+| AccessorCalls.cs:58:10:58:13 | this access | AccessorCalls.cs:58:22:58:25 | this access | semmle.label | successor |
+| AccessorCalls.cs:58:22:58:25 | this access | AccessorCalls.cs:58:37:58:40 | this access | semmle.label | successor |
+| AccessorCalls.cs:58:22:58:30 | access to property Prop | AccessorCalls.cs:58:37:58:43 | access to indexer | semmle.label | successor |
 | AccessorCalls.cs:58:33:58:44 | (..., ...) | AccessorCalls.cs:58:9:58:45 | (..., ...) | semmle.label | successor |
-| AccessorCalls.cs:58:34:58:34 | access to parameter i | AccessorCalls.cs:58:37:58:40 | this access | semmle.label | successor |
 | AccessorCalls.cs:58:37:58:40 | this access | AccessorCalls.cs:58:42:58:42 | 0 | semmle.label | successor |
-| AccessorCalls.cs:58:37:58:43 | access to indexer | AccessorCalls.cs:58:33:58:44 | (..., ...) | semmle.label | successor |
-| AccessorCalls.cs:58:42:58:42 | 0 | AccessorCalls.cs:58:37:58:43 | access to indexer | semmle.label | successor |
-| AccessorCalls.cs:58:49:58:85 | (..., ...) | AccessorCalls.cs:58:9:58:85 | ... = ... | semmle.label | successor |
+| AccessorCalls.cs:58:37:58:43 | access to indexer | AccessorCalls.cs:58:9:58:85 | ... = ... | semmle.label | successor |
+| AccessorCalls.cs:58:42:58:42 | 0 | AccessorCalls.cs:58:33:58:44 | (..., ...) | semmle.label | successor |
+| AccessorCalls.cs:58:49:58:85 | (..., ...) | AccessorCalls.cs:58:22:58:30 | access to property Prop | semmle.label | successor |
 | AccessorCalls.cs:58:50:58:53 | this access | AccessorCalls.cs:58:50:58:59 | access to field Field | semmle.label | successor |
 | AccessorCalls.cs:58:50:58:59 | access to field Field | AccessorCalls.cs:58:62:58:65 | this access | semmle.label | successor |
 | AccessorCalls.cs:58:62:58:65 | this access | AccessorCalls.cs:58:62:58:70 | access to property Prop | semmle.label | successor |
@@ -190,18 +184,16 @@
 | AccessorCalls.cs:63:9:63:51 | (..., ...) | AccessorCalls.cs:63:56:63:59 | this access | semmle.label | successor |
 | AccessorCalls.cs:63:9:63:98 | ...; | AccessorCalls.cs:63:10:63:13 | this access | semmle.label | successor |
 | AccessorCalls.cs:63:10:63:13 | this access | AccessorCalls.cs:63:10:63:15 | access to field x | semmle.label | successor |
-| AccessorCalls.cs:63:10:63:15 | access to field x | AccessorCalls.cs:63:10:63:21 | access to field Field | semmle.label | successor |
-| AccessorCalls.cs:63:10:63:21 | access to field Field | AccessorCalls.cs:63:24:63:27 | this access | semmle.label | successor |
+| AccessorCalls.cs:63:10:63:15 | access to field x | AccessorCalls.cs:63:24:63:27 | this access | semmle.label | successor |
 | AccessorCalls.cs:63:24:63:27 | this access | AccessorCalls.cs:63:24:63:29 | access to field x | semmle.label | successor |
-| AccessorCalls.cs:63:24:63:29 | access to field x | AccessorCalls.cs:63:24:63:34 | access to property Prop | semmle.label | successor |
-| AccessorCalls.cs:63:24:63:34 | access to property Prop | AccessorCalls.cs:63:38:63:38 | access to parameter i | semmle.label | successor |
+| AccessorCalls.cs:63:24:63:29 | access to field x | AccessorCalls.cs:63:41:63:44 | this access | semmle.label | successor |
+| AccessorCalls.cs:63:24:63:34 | access to property Prop | AccessorCalls.cs:63:41:63:49 | access to indexer | semmle.label | successor |
 | AccessorCalls.cs:63:37:63:50 | (..., ...) | AccessorCalls.cs:63:9:63:51 | (..., ...) | semmle.label | successor |
-| AccessorCalls.cs:63:38:63:38 | access to parameter i | AccessorCalls.cs:63:41:63:44 | this access | semmle.label | successor |
 | AccessorCalls.cs:63:41:63:44 | this access | AccessorCalls.cs:63:41:63:46 | access to field x | semmle.label | successor |
 | AccessorCalls.cs:63:41:63:46 | access to field x | AccessorCalls.cs:63:48:63:48 | 0 | semmle.label | successor |
-| AccessorCalls.cs:63:41:63:49 | access to indexer | AccessorCalls.cs:63:37:63:50 | (..., ...) | semmle.label | successor |
-| AccessorCalls.cs:63:48:63:48 | 0 | AccessorCalls.cs:63:41:63:49 | access to indexer | semmle.label | successor |
-| AccessorCalls.cs:63:55:63:97 | (..., ...) | AccessorCalls.cs:63:9:63:97 | ... = ... | semmle.label | successor |
+| AccessorCalls.cs:63:41:63:49 | access to indexer | AccessorCalls.cs:63:9:63:97 | ... = ... | semmle.label | successor |
+| AccessorCalls.cs:63:48:63:48 | 0 | AccessorCalls.cs:63:37:63:50 | (..., ...) | semmle.label | successor |
+| AccessorCalls.cs:63:55:63:97 | (..., ...) | AccessorCalls.cs:63:24:63:34 | access to property Prop | semmle.label | successor |
 | AccessorCalls.cs:63:56:63:59 | this access | AccessorCalls.cs:63:56:63:61 | access to field x | semmle.label | successor |
 | AccessorCalls.cs:63:56:63:61 | access to field x | AccessorCalls.cs:63:56:63:67 | access to field Field | semmle.label | successor |
 | AccessorCalls.cs:63:56:63:67 | access to field Field | AccessorCalls.cs:63:70:63:73 | this access | semmle.label | successor |
@@ -228,41 +220,35 @@
 | ArrayCreation.cs:9:45:9:45 | 2 | ArrayCreation.cs:9:48:9:48 | 3 | semmle.label | successor |
 | ArrayCreation.cs:9:48:9:48 | 3 | ArrayCreation.cs:9:43:9:50 | { ..., ... } | semmle.label | successor |
 | Assignments.cs:4:5:15:5 | {...} | Assignments.cs:5:9:5:18 | ... ...; | semmle.label | successor |
-| Assignments.cs:5:9:5:18 | ... ...; | Assignments.cs:5:13:5:13 | access to local variable x | semmle.label | successor |
-| Assignments.cs:5:13:5:13 | access to local variable x | Assignments.cs:5:17:5:17 | 0 | semmle.label | successor |
+| Assignments.cs:5:9:5:18 | ... ...; | Assignments.cs:5:17:5:17 | 0 | semmle.label | successor |
 | Assignments.cs:5:13:5:17 | Int32 x = ... | Assignments.cs:6:9:6:15 | ...; | semmle.label | successor |
 | Assignments.cs:5:17:5:17 | 0 | Assignments.cs:5:13:5:17 | Int32 x = ... | semmle.label | successor |
-| Assignments.cs:6:9:6:9 | access to local variable x | Assignments.cs:6:9:6:9 | access to local variable x | semmle.label | successor |
 | Assignments.cs:6:9:6:9 | access to local variable x | Assignments.cs:6:14:6:14 | 1 | semmle.label | successor |
 | Assignments.cs:6:9:6:14 | ... + ... | Assignments.cs:6:9:6:14 | ... = ... | semmle.label | successor |
 | Assignments.cs:6:9:6:14 | ... = ... | Assignments.cs:8:9:8:22 | ... ...; | semmle.label | successor |
 | Assignments.cs:6:9:6:15 | ...; | Assignments.cs:6:9:6:9 | access to local variable x | semmle.label | successor |
 | Assignments.cs:6:14:6:14 | 1 | Assignments.cs:6:9:6:14 | ... + ... | semmle.label | successor |
-| Assignments.cs:8:9:8:22 | ... ...; | Assignments.cs:8:17:8:17 | access to local variable d | semmle.label | successor |
-| Assignments.cs:8:17:8:17 | access to local variable d | Assignments.cs:8:21:8:21 | 0 | semmle.label | successor |
+| Assignments.cs:8:9:8:22 | ... ...; | Assignments.cs:8:21:8:21 | 0 | semmle.label | successor |
 | Assignments.cs:8:17:8:21 | dynamic d = ... | Assignments.cs:9:9:9:15 | ...; | semmle.label | successor |
 | Assignments.cs:8:21:8:21 | 0 | Assignments.cs:8:21:8:21 | (...) ... | semmle.label | successor |
 | Assignments.cs:8:21:8:21 | (...) ... | Assignments.cs:8:17:8:21 | dynamic d = ... | semmle.label | successor |
-| Assignments.cs:9:9:9:9 | access to local variable d | Assignments.cs:9:9:9:9 | access to local variable d | semmle.label | successor |
 | Assignments.cs:9:9:9:9 | access to local variable d | Assignments.cs:9:14:9:14 | 2 | semmle.label | successor |
 | Assignments.cs:9:9:9:14 | ... = ... | Assignments.cs:11:9:11:34 | ... ...; | semmle.label | successor |
 | Assignments.cs:9:9:9:14 | dynamic call to operator - | Assignments.cs:9:9:9:14 | ... = ... | semmle.label | successor |
 | Assignments.cs:9:9:9:15 | ...; | Assignments.cs:9:9:9:9 | access to local variable d | semmle.label | successor |
 | Assignments.cs:9:14:9:14 | 2 | Assignments.cs:9:9:9:14 | dynamic call to operator - | semmle.label | successor |
-| Assignments.cs:11:9:11:34 | ... ...; | Assignments.cs:11:13:11:13 | access to local variable a | semmle.label | successor |
-| Assignments.cs:11:13:11:13 | access to local variable a | Assignments.cs:11:17:11:33 | object creation of type Assignments | semmle.label | successor |
+| Assignments.cs:11:9:11:34 | ... ...; | Assignments.cs:11:17:11:33 | object creation of type Assignments | semmle.label | successor |
 | Assignments.cs:11:13:11:33 | Assignments a = ... | Assignments.cs:12:9:12:18 | ...; | semmle.label | successor |
 | Assignments.cs:11:17:11:33 | object creation of type Assignments | Assignments.cs:11:13:11:33 | Assignments a = ... | semmle.label | successor |
-| Assignments.cs:12:9:12:9 | access to local variable a | Assignments.cs:12:9:12:9 | access to local variable a | semmle.label | successor |
 | Assignments.cs:12:9:12:9 | access to local variable a | Assignments.cs:12:14:12:17 | this access | semmle.label | successor |
 | Assignments.cs:12:9:12:17 | ... = ... | Assignments.cs:14:9:14:36 | ...; | semmle.label | successor |
 | Assignments.cs:12:9:12:17 | call to operator + | Assignments.cs:12:9:12:17 | ... = ... | semmle.label | successor |
 | Assignments.cs:12:9:12:18 | ...; | Assignments.cs:12:9:12:9 | access to local variable a | semmle.label | successor |
 | Assignments.cs:12:14:12:17 | this access | Assignments.cs:12:9:12:17 | call to operator + | semmle.label | successor |
-| Assignments.cs:14:9:14:13 | access to event Event | Assignments.cs:14:18:14:35 | (...) => ... | semmle.label | successor |
-| Assignments.cs:14:9:14:13 | this access | Assignments.cs:14:9:14:13 | access to event Event | semmle.label | successor |
+| Assignments.cs:14:9:14:13 | access to event Event | Assignments.cs:14:9:14:35 | ... += ... | semmle.label | successor |
+| Assignments.cs:14:9:14:13 | this access | Assignments.cs:14:18:14:35 | (...) => ... | semmle.label | successor |
 | Assignments.cs:14:9:14:36 | ...; | Assignments.cs:14:9:14:13 | this access | semmle.label | successor |
-| Assignments.cs:14:18:14:35 | (...) => ... | Assignments.cs:14:9:14:35 | ... += ... | semmle.label | successor |
+| Assignments.cs:14:18:14:35 | (...) => ... | Assignments.cs:14:9:14:13 | access to event Event | semmle.label | successor |
 | Assignments.cs:18:5:20:5 | {...} | Assignments.cs:19:16:19:16 | access to parameter x | semmle.label | successor |
 | Assignments.cs:19:16:19:16 | access to parameter x | Assignments.cs:19:9:19:17 | return ...; | semmle.label | successor |
 | BreakInTry.cs:4:5:18:5 | {...} | BreakInTry.cs:5:9:17:9 | try {...} ... | semmle.label | successor |
@@ -432,19 +418,16 @@
 | ConditionalAccess.cs:19:40:19:41 | access to parameter s1 | ConditionalAccess.cs:19:58:19:59 | access to parameter s2 | semmle.label | non-null |
 | ConditionalAccess.cs:19:58:19:59 | access to parameter s2 | ConditionalAccess.cs:19:43:19:60 | call to method CommaJoinWith | semmle.label | successor |
 | ConditionalAccess.cs:22:5:26:5 | {...} | ConditionalAccess.cs:23:9:23:39 | ... ...; | semmle.label | successor |
-| ConditionalAccess.cs:23:9:23:39 | ... ...; | ConditionalAccess.cs:23:13:23:13 | access to local variable j | semmle.label | successor |
-| ConditionalAccess.cs:23:13:23:13 | access to local variable j | ConditionalAccess.cs:23:26:23:29 | null | semmle.label | successor |
+| ConditionalAccess.cs:23:9:23:39 | ... ...; | ConditionalAccess.cs:23:26:23:29 | null | semmle.label | successor |
 | ConditionalAccess.cs:23:13:23:38 | Nullable<Int32> j = ... | ConditionalAccess.cs:24:9:24:38 | ... ...; | semmle.label | successor |
 | ConditionalAccess.cs:23:18:23:29 | (...) ... | ConditionalAccess.cs:23:13:23:38 | Nullable<Int32> j = ... | semmle.label | null |
 | ConditionalAccess.cs:23:26:23:29 | null | ConditionalAccess.cs:23:18:23:29 | (...) ... | semmle.label | successor |
-| ConditionalAccess.cs:24:9:24:38 | ... ...; | ConditionalAccess.cs:24:13:24:13 | access to local variable s | semmle.label | successor |
-| ConditionalAccess.cs:24:13:24:13 | access to local variable s | ConditionalAccess.cs:24:24:24:24 | access to parameter i | semmle.label | successor |
+| ConditionalAccess.cs:24:9:24:38 | ... ...; | ConditionalAccess.cs:24:24:24:24 | access to parameter i | semmle.label | successor |
 | ConditionalAccess.cs:24:13:24:37 | String s = ... | ConditionalAccess.cs:25:9:25:33 | ...; | semmle.label | successor |
 | ConditionalAccess.cs:24:18:24:24 | (...) ... | ConditionalAccess.cs:24:27:24:37 | call to method ToString | semmle.label | non-null |
 | ConditionalAccess.cs:24:24:24:24 | access to parameter i | ConditionalAccess.cs:24:18:24:24 | (...) ... | semmle.label | successor |
 | ConditionalAccess.cs:24:27:24:37 | call to method ToString | ConditionalAccess.cs:24:13:24:37 | String s = ... | semmle.label | successor |
-| ConditionalAccess.cs:25:9:25:9 | access to local variable s | ConditionalAccess.cs:25:13:25:14 | "" | semmle.label | successor |
-| ConditionalAccess.cs:25:9:25:33 | ...; | ConditionalAccess.cs:25:9:25:9 | access to local variable s | semmle.label | successor |
+| ConditionalAccess.cs:25:9:25:33 | ...; | ConditionalAccess.cs:25:13:25:14 | "" | semmle.label | successor |
 | ConditionalAccess.cs:25:13:25:14 | "" | ConditionalAccess.cs:25:31:25:31 | access to local variable s | semmle.label | non-null |
 | ConditionalAccess.cs:25:16:25:32 | call to method CommaJoinWith | ConditionalAccess.cs:25:9:25:32 | ... = ... | semmle.label | successor |
 | ConditionalAccess.cs:25:31:25:31 | access to local variable s | ConditionalAccess.cs:25:16:25:32 | call to method CommaJoinWith | semmle.label | successor |
@@ -465,8 +448,7 @@
 | Conditions.cs:8:13:8:13 | access to parameter x | Conditions.cs:8:13:8:15 | ...-- | semmle.label | successor |
 | Conditions.cs:8:13:8:16 | ...; | Conditions.cs:8:13:8:13 | access to parameter x | semmle.label | successor |
 | Conditions.cs:12:5:20:5 | {...} | Conditions.cs:13:9:13:18 | ... ...; | semmle.label | successor |
-| Conditions.cs:13:9:13:18 | ... ...; | Conditions.cs:13:13:13:13 | access to local variable x | semmle.label | successor |
-| Conditions.cs:13:13:13:13 | access to local variable x | Conditions.cs:13:17:13:17 | 0 | semmle.label | successor |
+| Conditions.cs:13:9:13:18 | ... ...; | Conditions.cs:13:17:13:17 | 0 | semmle.label | successor |
 | Conditions.cs:13:13:13:17 | Int32 x = ... | Conditions.cs:14:9:15:16 | if (...) ... | semmle.label | successor |
 | Conditions.cs:13:17:13:17 | 0 | Conditions.cs:13:13:13:17 | Int32 x = ... | semmle.label | successor |
 | Conditions.cs:14:9:15:16 | if (...) ... | Conditions.cs:14:13:14:13 | access to parameter b | semmle.label | successor |
@@ -489,8 +471,7 @@
 | Conditions.cs:18:17:18:20 | ...; | Conditions.cs:18:17:18:17 | access to local variable x | semmle.label | successor |
 | Conditions.cs:19:16:19:16 | access to local variable x | Conditions.cs:19:9:19:17 | return ...; | semmle.label | successor |
 | Conditions.cs:23:5:31:5 | {...} | Conditions.cs:24:9:24:18 | ... ...; | semmle.label | successor |
-| Conditions.cs:24:9:24:18 | ... ...; | Conditions.cs:24:13:24:13 | access to local variable x | semmle.label | successor |
-| Conditions.cs:24:13:24:13 | access to local variable x | Conditions.cs:24:17:24:17 | 0 | semmle.label | successor |
+| Conditions.cs:24:9:24:18 | ... ...; | Conditions.cs:24:17:24:17 | 0 | semmle.label | successor |
 | Conditions.cs:24:13:24:17 | Int32 x = ... | Conditions.cs:25:9:27:20 | if (...) ... | semmle.label | successor |
 | Conditions.cs:24:17:24:17 | 0 | Conditions.cs:24:13:24:17 | Int32 x = ... | semmle.label | successor |
 | Conditions.cs:25:9:27:20 | if (...) ... | Conditions.cs:25:13:25:14 | access to parameter b1 | semmle.label | successor |
@@ -510,20 +491,17 @@
 | Conditions.cs:29:13:29:16 | ...; | Conditions.cs:29:13:29:13 | access to local variable x | semmle.label | successor |
 | Conditions.cs:30:16:30:16 | access to local variable x | Conditions.cs:30:9:30:17 | return ...; | semmle.label | successor |
 | Conditions.cs:34:5:44:5 | {...} | Conditions.cs:35:9:35:18 | ... ...; | semmle.label | successor |
-| Conditions.cs:35:9:35:18 | ... ...; | Conditions.cs:35:13:35:13 | access to local variable x | semmle.label | successor |
-| Conditions.cs:35:13:35:13 | access to local variable x | Conditions.cs:35:17:35:17 | 0 | semmle.label | successor |
+| Conditions.cs:35:9:35:18 | ... ...; | Conditions.cs:35:17:35:17 | 0 | semmle.label | successor |
 | Conditions.cs:35:13:35:17 | Int32 x = ... | Conditions.cs:36:9:36:23 | ... ...; | semmle.label | successor |
 | Conditions.cs:35:17:35:17 | 0 | Conditions.cs:35:13:35:17 | Int32 x = ... | semmle.label | successor |
-| Conditions.cs:36:9:36:23 | ... ...; | Conditions.cs:36:13:36:14 | access to local variable b2 | semmle.label | successor |
-| Conditions.cs:36:13:36:14 | access to local variable b2 | Conditions.cs:36:18:36:22 | false | semmle.label | successor |
+| Conditions.cs:36:9:36:23 | ... ...; | Conditions.cs:36:18:36:22 | false | semmle.label | successor |
 | Conditions.cs:36:13:36:22 | Boolean b2 = ... | Conditions.cs:37:9:38:20 | if (...) ... | semmle.label | successor |
 | Conditions.cs:36:18:36:22 | false | Conditions.cs:36:13:36:22 | Boolean b2 = ... | semmle.label | successor |
 | Conditions.cs:37:9:38:20 | if (...) ... | Conditions.cs:37:13:37:14 | access to parameter b1 | semmle.label | successor |
 | Conditions.cs:37:13:37:14 | access to parameter b1 | Conditions.cs:38:13:38:20 | ...; | semmle.label | true |
 | Conditions.cs:37:13:37:14 | access to parameter b1 | Conditions.cs:39:9:40:16 | if (...) ... | semmle.label | false |
-| Conditions.cs:38:13:38:14 | access to local variable b2 | Conditions.cs:38:18:38:19 | access to parameter b1 | semmle.label | successor |
 | Conditions.cs:38:13:38:19 | ... = ... | Conditions.cs:39:9:40:16 | if (...) ... | semmle.label | successor |
-| Conditions.cs:38:13:38:20 | ...; | Conditions.cs:38:13:38:14 | access to local variable b2 | semmle.label | successor |
+| Conditions.cs:38:13:38:20 | ...; | Conditions.cs:38:18:38:19 | access to parameter b1 | semmle.label | successor |
 | Conditions.cs:38:18:38:19 | access to parameter b1 | Conditions.cs:38:13:38:19 | ... = ... | semmle.label | successor |
 | Conditions.cs:39:9:40:16 | if (...) ... | Conditions.cs:39:13:39:14 | access to local variable b2 | semmle.label | successor |
 | Conditions.cs:39:13:39:14 | access to local variable b2 | Conditions.cs:40:13:40:16 | ...; | semmle.label | true |
@@ -539,8 +517,7 @@
 | Conditions.cs:42:13:42:16 | ...; | Conditions.cs:42:13:42:13 | access to local variable x | semmle.label | successor |
 | Conditions.cs:43:16:43:16 | access to local variable x | Conditions.cs:43:9:43:17 | return ...; | semmle.label | successor |
 | Conditions.cs:47:5:55:5 | {...} | Conditions.cs:48:9:48:18 | ... ...; | semmle.label | successor |
-| Conditions.cs:48:9:48:18 | ... ...; | Conditions.cs:48:13:48:13 | access to local variable y | semmle.label | successor |
-| Conditions.cs:48:13:48:13 | access to local variable y | Conditions.cs:48:17:48:17 | 0 | semmle.label | successor |
+| Conditions.cs:48:9:48:18 | ... ...; | Conditions.cs:48:17:48:17 | 0 | semmle.label | successor |
 | Conditions.cs:48:13:48:17 | Int32 y = ... | Conditions.cs:49:9:53:9 | while (...) ... | semmle.label | successor |
 | Conditions.cs:48:17:48:17 | 0 | Conditions.cs:48:13:48:17 | Int32 y = ... | semmle.label | successor |
 | Conditions.cs:49:9:53:9 | while (...) ... | Conditions.cs:49:16:49:16 | access to parameter x | semmle.label | successor |
@@ -558,8 +535,7 @@
 | Conditions.cs:52:17:52:20 | ...; | Conditions.cs:52:17:52:17 | access to local variable y | semmle.label | successor |
 | Conditions.cs:54:16:54:16 | access to local variable y | Conditions.cs:54:9:54:17 | return ...; | semmle.label | successor |
 | Conditions.cs:58:5:68:5 | {...} | Conditions.cs:59:9:59:18 | ... ...; | semmle.label | successor |
-| Conditions.cs:59:9:59:18 | ... ...; | Conditions.cs:59:13:59:13 | access to local variable y | semmle.label | successor |
-| Conditions.cs:59:13:59:13 | access to local variable y | Conditions.cs:59:17:59:17 | 0 | semmle.label | successor |
+| Conditions.cs:59:9:59:18 | ... ...; | Conditions.cs:59:17:59:17 | 0 | semmle.label | successor |
 | Conditions.cs:59:13:59:17 | Int32 y = ... | Conditions.cs:60:9:64:9 | while (...) ... | semmle.label | successor |
 | Conditions.cs:59:17:59:17 | 0 | Conditions.cs:59:13:59:17 | Int32 y = ... | semmle.label | successor |
 | Conditions.cs:60:9:64:9 | while (...) ... | Conditions.cs:60:16:60:16 | access to parameter x | semmle.label | successor |
@@ -583,15 +559,13 @@
 | Conditions.cs:66:13:66:16 | ...; | Conditions.cs:66:13:66:13 | access to local variable y | semmle.label | successor |
 | Conditions.cs:67:16:67:16 | access to local variable y | Conditions.cs:67:9:67:17 | return ...; | semmle.label | successor |
 | Conditions.cs:71:5:84:5 | {...} | Conditions.cs:72:9:72:30 | ... ...; | semmle.label | successor |
-| Conditions.cs:72:9:72:30 | ... ...; | Conditions.cs:72:13:72:13 | access to local variable b | semmle.label | successor |
-| Conditions.cs:72:13:72:13 | access to local variable b | Conditions.cs:72:17:72:18 | access to parameter ss | semmle.label | successor |
+| Conditions.cs:72:9:72:30 | ... ...; | Conditions.cs:72:17:72:18 | access to parameter ss | semmle.label | successor |
 | Conditions.cs:72:13:72:29 | Boolean b = ... | Conditions.cs:73:9:73:18 | ... ...; | semmle.label | successor |
 | Conditions.cs:72:17:72:18 | access to parameter ss | Conditions.cs:72:17:72:25 | access to property Length | semmle.label | successor |
 | Conditions.cs:72:17:72:25 | access to property Length | Conditions.cs:72:29:72:29 | 0 | semmle.label | successor |
 | Conditions.cs:72:17:72:29 | ... > ... | Conditions.cs:72:13:72:29 | Boolean b = ... | semmle.label | successor |
 | Conditions.cs:72:29:72:29 | 0 | Conditions.cs:72:17:72:29 | ... > ... | semmle.label | successor |
-| Conditions.cs:73:9:73:18 | ... ...; | Conditions.cs:73:13:73:13 | access to local variable x | semmle.label | successor |
-| Conditions.cs:73:13:73:13 | access to local variable x | Conditions.cs:73:17:73:17 | 0 | semmle.label | successor |
+| Conditions.cs:73:9:73:18 | ... ...; | Conditions.cs:73:17:73:17 | 0 | semmle.label | successor |
 | Conditions.cs:73:13:73:17 | Int32 x = ... | Conditions.cs:74:27:74:28 | access to parameter ss | semmle.label | successor |
 | Conditions.cs:73:17:73:17 | 0 | Conditions.cs:73:13:73:17 | Int32 x = ... | semmle.label | successor |
 | Conditions.cs:74:9:80:9 | foreach (... ... in ...) ... | Conditions.cs:75:9:80:9 | {...} | semmle.label | non-empty |
@@ -609,9 +583,8 @@
 | Conditions.cs:78:17:78:21 | ... > ... | Conditions.cs:74:9:80:9 | foreach (... ... in ...) ... | semmle.label | false |
 | Conditions.cs:78:17:78:21 | ... > ... | Conditions.cs:79:17:79:26 | ...; | semmle.label | true |
 | Conditions.cs:78:21:78:21 | 0 | Conditions.cs:78:17:78:21 | ... > ... | semmle.label | successor |
-| Conditions.cs:79:17:79:17 | access to local variable b | Conditions.cs:79:21:79:25 | false | semmle.label | successor |
 | Conditions.cs:79:17:79:25 | ... = ... | Conditions.cs:74:9:80:9 | foreach (... ... in ...) ... | semmle.label | successor |
-| Conditions.cs:79:17:79:26 | ...; | Conditions.cs:79:17:79:17 | access to local variable b | semmle.label | successor |
+| Conditions.cs:79:17:79:26 | ...; | Conditions.cs:79:21:79:25 | false | semmle.label | successor |
 | Conditions.cs:79:21:79:25 | false | Conditions.cs:79:17:79:25 | ... = ... | semmle.label | successor |
 | Conditions.cs:81:9:82:16 | if (...) ... | Conditions.cs:81:12:81:12 | access to local variable b | semmle.label | successor |
 | Conditions.cs:81:12:81:12 | access to local variable b | Conditions.cs:82:13:82:16 | ...; | semmle.label | true |
@@ -621,15 +594,13 @@
 | Conditions.cs:82:13:82:16 | ...; | Conditions.cs:82:13:82:13 | access to local variable x | semmle.label | successor |
 | Conditions.cs:83:16:83:16 | access to local variable x | Conditions.cs:83:9:83:17 | return ...; | semmle.label | successor |
 | Conditions.cs:87:5:100:5 | {...} | Conditions.cs:88:9:88:30 | ... ...; | semmle.label | successor |
-| Conditions.cs:88:9:88:30 | ... ...; | Conditions.cs:88:13:88:13 | access to local variable b | semmle.label | successor |
-| Conditions.cs:88:13:88:13 | access to local variable b | Conditions.cs:88:17:88:18 | access to parameter ss | semmle.label | successor |
+| Conditions.cs:88:9:88:30 | ... ...; | Conditions.cs:88:17:88:18 | access to parameter ss | semmle.label | successor |
 | Conditions.cs:88:13:88:29 | Boolean b = ... | Conditions.cs:89:9:89:18 | ... ...; | semmle.label | successor |
 | Conditions.cs:88:17:88:18 | access to parameter ss | Conditions.cs:88:17:88:25 | access to property Length | semmle.label | successor |
 | Conditions.cs:88:17:88:25 | access to property Length | Conditions.cs:88:29:88:29 | 0 | semmle.label | successor |
 | Conditions.cs:88:17:88:29 | ... > ... | Conditions.cs:88:13:88:29 | Boolean b = ... | semmle.label | successor |
 | Conditions.cs:88:29:88:29 | 0 | Conditions.cs:88:17:88:29 | ... > ... | semmle.label | successor |
-| Conditions.cs:89:9:89:18 | ... ...; | Conditions.cs:89:13:89:13 | access to local variable x | semmle.label | successor |
-| Conditions.cs:89:13:89:13 | access to local variable x | Conditions.cs:89:17:89:17 | 0 | semmle.label | successor |
+| Conditions.cs:89:9:89:18 | ... ...; | Conditions.cs:89:17:89:17 | 0 | semmle.label | successor |
 | Conditions.cs:89:13:89:17 | Int32 x = ... | Conditions.cs:90:27:90:28 | access to parameter ss | semmle.label | successor |
 | Conditions.cs:89:17:89:17 | 0 | Conditions.cs:89:13:89:17 | Int32 x = ... | semmle.label | successor |
 | Conditions.cs:90:9:98:9 | foreach (... ... in ...) ... | Conditions.cs:91:9:98:9 | {...} | semmle.label | non-empty |
@@ -647,9 +618,8 @@
 | Conditions.cs:94:17:94:21 | ... > ... | Conditions.cs:95:17:95:26 | ...; | semmle.label | true |
 | Conditions.cs:94:17:94:21 | ... > ... | Conditions.cs:96:13:97:20 | if (...) ... | semmle.label | false |
 | Conditions.cs:94:21:94:21 | 0 | Conditions.cs:94:17:94:21 | ... > ... | semmle.label | successor |
-| Conditions.cs:95:17:95:17 | access to local variable b | Conditions.cs:95:21:95:25 | false | semmle.label | successor |
 | Conditions.cs:95:17:95:25 | ... = ... | Conditions.cs:96:13:97:20 | if (...) ... | semmle.label | successor |
-| Conditions.cs:95:17:95:26 | ...; | Conditions.cs:95:17:95:17 | access to local variable b | semmle.label | successor |
+| Conditions.cs:95:17:95:26 | ...; | Conditions.cs:95:21:95:25 | false | semmle.label | successor |
 | Conditions.cs:95:21:95:25 | false | Conditions.cs:95:17:95:25 | ... = ... | semmle.label | successor |
 | Conditions.cs:96:13:97:20 | if (...) ... | Conditions.cs:96:17:96:17 | access to local variable b | semmle.label | successor |
 | Conditions.cs:96:17:96:17 | access to local variable b | Conditions.cs:90:9:98:9 | foreach (... ... in ...) ... | semmle.label | false |
@@ -659,15 +629,13 @@
 | Conditions.cs:97:17:97:20 | ...; | Conditions.cs:97:17:97:17 | access to local variable x | semmle.label | successor |
 | Conditions.cs:99:16:99:16 | access to local variable x | Conditions.cs:99:9:99:17 | return ...; | semmle.label | successor |
 | Conditions.cs:103:5:111:5 | {...} | Conditions.cs:104:9:104:29 | ... ...; | semmle.label | successor |
-| Conditions.cs:104:9:104:29 | ... ...; | Conditions.cs:104:13:104:13 | access to local variable x | semmle.label | successor |
-| Conditions.cs:104:13:104:13 | access to local variable x | Conditions.cs:104:17:104:17 | access to parameter b | semmle.label | successor |
+| Conditions.cs:104:9:104:29 | ... ...; | Conditions.cs:104:17:104:17 | access to parameter b | semmle.label | successor |
 | Conditions.cs:104:13:104:28 | String x = ... | Conditions.cs:105:9:106:20 | if (...) ... | semmle.label | successor |
 | Conditions.cs:104:17:104:17 | access to parameter b | Conditions.cs:104:17:104:28 | call to method ToString | semmle.label | successor |
 | Conditions.cs:104:17:104:28 | call to method ToString | Conditions.cs:104:13:104:28 | String x = ... | semmle.label | successor |
 | Conditions.cs:105:9:106:20 | if (...) ... | Conditions.cs:105:13:105:13 | access to parameter b | semmle.label | successor |
 | Conditions.cs:105:13:105:13 | access to parameter b | Conditions.cs:106:13:106:20 | ...; | semmle.label | true |
 | Conditions.cs:105:13:105:13 | access to parameter b | Conditions.cs:107:9:109:24 | if (...) ... | semmle.label | false |
-| Conditions.cs:106:13:106:13 | access to local variable x | Conditions.cs:106:13:106:13 | access to local variable x | semmle.label | successor |
 | Conditions.cs:106:13:106:13 | access to local variable x | Conditions.cs:106:18:106:19 | "" | semmle.label | successor |
 | Conditions.cs:106:13:106:19 | ... + ... | Conditions.cs:106:13:106:19 | ... = ... | semmle.label | successor |
 | Conditions.cs:106:13:106:19 | ... = ... | Conditions.cs:107:9:109:24 | if (...) ... | semmle.label | successor |
@@ -683,7 +651,6 @@
 | Conditions.cs:108:17:108:18 | !... | Conditions.cs:108:18:108:18 | access to parameter b | semmle.label | successor |
 | Conditions.cs:108:18:108:18 | access to parameter b | Conditions.cs:109:17:109:24 | ...; | semmle.label | false |
 | Conditions.cs:108:18:108:18 | access to parameter b | Conditions.cs:110:16:110:16 | access to local variable x | semmle.label | true |
-| Conditions.cs:109:17:109:17 | access to local variable x | Conditions.cs:109:17:109:17 | access to local variable x | semmle.label | successor |
 | Conditions.cs:109:17:109:17 | access to local variable x | Conditions.cs:109:22:109:23 | "" | semmle.label | successor |
 | Conditions.cs:109:17:109:23 | ... + ... | Conditions.cs:109:17:109:23 | ... = ... | semmle.label | successor |
 | Conditions.cs:109:17:109:23 | ... = ... | Conditions.cs:110:16:110:16 | access to local variable x | semmle.label | successor |
@@ -691,12 +658,10 @@
 | Conditions.cs:109:22:109:23 | "" | Conditions.cs:109:17:109:23 | ... + ... | semmle.label | successor |
 | Conditions.cs:110:16:110:16 | access to local variable x | Conditions.cs:110:9:110:17 | return ...; | semmle.label | successor |
 | Conditions.cs:114:5:124:5 | {...} | Conditions.cs:115:9:115:24 | ... ...; | semmle.label | successor |
-| Conditions.cs:115:9:115:24 | ... ...; | Conditions.cs:115:16:115:16 | access to local variable s | semmle.label | successor |
-| Conditions.cs:115:16:115:16 | access to local variable s | Conditions.cs:115:20:115:23 | null | semmle.label | successor |
+| Conditions.cs:115:9:115:24 | ... ...; | Conditions.cs:115:20:115:23 | null | semmle.label | successor |
 | Conditions.cs:115:16:115:23 | String s = ... | Conditions.cs:116:9:123:9 | for (...;...;...) ... | semmle.label | successor |
 | Conditions.cs:115:20:115:23 | null | Conditions.cs:115:16:115:23 | String s = ... | semmle.label | successor |
-| Conditions.cs:116:9:123:9 | for (...;...;...) ... | Conditions.cs:116:17:116:17 | access to local variable i | semmle.label | successor |
-| Conditions.cs:116:17:116:17 | access to local variable i | Conditions.cs:116:21:116:21 | 0 | semmle.label | successor |
+| Conditions.cs:116:9:123:9 | for (...;...;...) ... | Conditions.cs:116:21:116:21 | 0 | semmle.label | successor |
 | Conditions.cs:116:17:116:21 | Int32 i = ... | Conditions.cs:116:24:116:24 | access to local variable i | semmle.label | successor |
 | Conditions.cs:116:21:116:21 | 0 | Conditions.cs:116:17:116:21 | Int32 i = ... | semmle.label | successor |
 | Conditions.cs:116:24:116:24 | access to local variable i | Conditions.cs:116:28:116:31 | access to parameter args | semmle.label | successor |
@@ -706,8 +671,7 @@
 | Conditions.cs:116:41:116:41 | access to local variable i | Conditions.cs:116:41:116:43 | ...++ | semmle.label | successor |
 | Conditions.cs:116:41:116:43 | ...++ | Conditions.cs:116:24:116:24 | access to local variable i | semmle.label | successor |
 | Conditions.cs:117:9:123:9 | {...} | Conditions.cs:118:13:118:44 | ... ...; | semmle.label | successor |
-| Conditions.cs:118:13:118:44 | ... ...; | Conditions.cs:118:17:118:20 | access to local variable last | semmle.label | successor |
-| Conditions.cs:118:17:118:20 | access to local variable last | Conditions.cs:118:24:118:24 | access to local variable i | semmle.label | successor |
+| Conditions.cs:118:13:118:44 | ... ...; | Conditions.cs:118:24:118:24 | access to local variable i | semmle.label | successor |
 | Conditions.cs:118:17:118:43 | Boolean last = ... | Conditions.cs:119:13:120:23 | if (...) ... | semmle.label | successor |
 | Conditions.cs:118:24:118:24 | access to local variable i | Conditions.cs:118:29:118:32 | access to parameter args | semmle.label | successor |
 | Conditions.cs:118:24:118:43 | ... == ... | Conditions.cs:118:17:118:43 | Boolean last = ... | semmle.label | successor |
@@ -719,16 +683,14 @@
 | Conditions.cs:119:17:119:21 | !... | Conditions.cs:119:18:119:21 | access to local variable last | semmle.label | successor |
 | Conditions.cs:119:18:119:21 | access to local variable last | Conditions.cs:120:17:120:23 | ...; | semmle.label | false |
 | Conditions.cs:119:18:119:21 | access to local variable last | Conditions.cs:121:13:122:25 | if (...) ... | semmle.label | true |
-| Conditions.cs:120:17:120:17 | access to local variable s | Conditions.cs:120:21:120:22 | "" | semmle.label | successor |
 | Conditions.cs:120:17:120:22 | ... = ... | Conditions.cs:121:13:122:25 | if (...) ... | semmle.label | successor |
-| Conditions.cs:120:17:120:23 | ...; | Conditions.cs:120:17:120:17 | access to local variable s | semmle.label | successor |
+| Conditions.cs:120:17:120:23 | ...; | Conditions.cs:120:21:120:22 | "" | semmle.label | successor |
 | Conditions.cs:120:21:120:22 | "" | Conditions.cs:120:17:120:22 | ... = ... | semmle.label | successor |
 | Conditions.cs:121:13:122:25 | if (...) ... | Conditions.cs:121:17:121:20 | access to local variable last | semmle.label | successor |
 | Conditions.cs:121:17:121:20 | access to local variable last | Conditions.cs:116:41:116:41 | access to local variable i | semmle.label | false |
 | Conditions.cs:121:17:121:20 | access to local variable last | Conditions.cs:122:17:122:25 | ...; | semmle.label | true |
-| Conditions.cs:122:17:122:17 | access to local variable s | Conditions.cs:122:21:122:24 | null | semmle.label | successor |
 | Conditions.cs:122:17:122:24 | ... = ... | Conditions.cs:116:41:116:41 | access to local variable i | semmle.label | successor |
-| Conditions.cs:122:17:122:25 | ...; | Conditions.cs:122:17:122:17 | access to local variable s | semmle.label | successor |
+| Conditions.cs:122:17:122:25 | ...; | Conditions.cs:122:21:122:24 | null | semmle.label | successor |
 | Conditions.cs:122:21:122:24 | null | Conditions.cs:122:17:122:24 | ... = ... | semmle.label | successor |
 | Conditions.cs:130:5:141:5 | {...} | Conditions.cs:131:9:140:9 | while (...) ... | semmle.label | successor |
 | Conditions.cs:131:9:140:9 | while (...) ... | Conditions.cs:131:16:131:19 | true | semmle.label | successor |
@@ -906,20 +868,17 @@
 | Initializers.cs:4:27:4:27 | access to field H | Initializers.cs:4:31:4:31 | 2 | semmle.label | successor |
 | Initializers.cs:4:31:4:31 | 2 | Initializers.cs:4:27:4:31 | ... + ... | semmle.label | successor |
 | Initializers.cs:9:5:12:5 | {...} | Initializers.cs:10:9:10:54 | ... ...; | semmle.label | successor |
-| Initializers.cs:10:9:10:54 | ... ...; | Initializers.cs:10:13:10:13 | access to local variable i | semmle.label | successor |
-| Initializers.cs:10:13:10:13 | access to local variable i | Initializers.cs:10:34:10:35 | "" | semmle.label | successor |
+| Initializers.cs:10:9:10:54 | ... ...; | Initializers.cs:10:34:10:35 | "" | semmle.label | successor |
 | Initializers.cs:10:13:10:53 | Initializers i = ... | Initializers.cs:11:9:11:64 | ... ...; | semmle.label | successor |
-| Initializers.cs:10:17:10:53 | object creation of type Initializers | Initializers.cs:10:40:10:40 | access to field F | semmle.label | successor |
+| Initializers.cs:10:17:10:53 | object creation of type Initializers | Initializers.cs:10:44:10:44 | 0 | semmle.label | successor |
 | Initializers.cs:10:34:10:35 | "" | Initializers.cs:10:17:10:53 | object creation of type Initializers | semmle.label | successor |
 | Initializers.cs:10:38:10:53 | { ..., ... } | Initializers.cs:10:13:10:53 | Initializers i = ... | semmle.label | successor |
-| Initializers.cs:10:40:10:40 | access to field F | Initializers.cs:10:44:10:44 | 0 | semmle.label | successor |
-| Initializers.cs:10:40:10:44 | ... = ... | Initializers.cs:10:47:10:47 | access to property G | semmle.label | successor |
+| Initializers.cs:10:40:10:44 | ... = ... | Initializers.cs:10:51:10:51 | 1 | semmle.label | successor |
 | Initializers.cs:10:44:10:44 | 0 | Initializers.cs:10:40:10:44 | ... = ... | semmle.label | successor |
-| Initializers.cs:10:47:10:47 | access to property G | Initializers.cs:10:51:10:51 | 1 | semmle.label | successor |
+| Initializers.cs:10:47:10:47 | access to property G | Initializers.cs:10:47:10:51 | ... = ... | semmle.label | successor |
 | Initializers.cs:10:47:10:51 | ... = ... | Initializers.cs:10:38:10:53 | { ..., ... } | semmle.label | successor |
-| Initializers.cs:10:51:10:51 | 1 | Initializers.cs:10:47:10:51 | ... = ... | semmle.label | successor |
-| Initializers.cs:11:9:11:64 | ... ...; | Initializers.cs:11:13:11:14 | access to local variable iz | semmle.label | successor |
-| Initializers.cs:11:13:11:14 | access to local variable iz | Initializers.cs:11:18:11:63 | array creation of type Initializers[] | semmle.label | successor |
+| Initializers.cs:10:51:10:51 | 1 | Initializers.cs:10:47:10:47 | access to property G | semmle.label | successor |
+| Initializers.cs:11:9:11:64 | ... ...; | Initializers.cs:11:18:11:63 | array creation of type Initializers[] | semmle.label | successor |
 | Initializers.cs:11:18:11:63 | array creation of type Initializers[] | Initializers.cs:11:39:11:39 | access to local variable i | semmle.label | successor |
 | Initializers.cs:11:37:11:63 | { ..., ... } | Initializers.cs:11:13:11:63 | Initializers[] iz = ... | semmle.label | successor |
 | Initializers.cs:11:39:11:39 | access to local variable i | Initializers.cs:11:59:11:60 | "" | semmle.label | successor |
@@ -955,26 +914,22 @@
 | NullCoalescing.cs:11:57:11:58 | access to parameter b3 | NullCoalescing.cs:11:64:11:64 | 0 | semmle.label | true |
 | NullCoalescing.cs:11:57:11:58 | access to parameter b3 | NullCoalescing.cs:11:68:11:68 | 1 | semmle.label | false |
 | NullCoalescing.cs:14:5:18:5 | {...} | NullCoalescing.cs:15:9:15:32 | ... ...; | semmle.label | successor |
-| NullCoalescing.cs:15:9:15:32 | ... ...; | NullCoalescing.cs:15:13:15:13 | access to local variable j | semmle.label | successor |
-| NullCoalescing.cs:15:13:15:13 | access to local variable j | NullCoalescing.cs:15:17:15:31 | ... ?? ... | semmle.label | successor |
+| NullCoalescing.cs:15:9:15:32 | ... ...; | NullCoalescing.cs:15:17:15:31 | ... ?? ... | semmle.label | successor |
 | NullCoalescing.cs:15:13:15:31 | Int32 j = ... | NullCoalescing.cs:16:9:16:26 | ... ...; | semmle.label | successor |
 | NullCoalescing.cs:15:17:15:26 | (...) ... | NullCoalescing.cs:15:31:15:31 | 0 | semmle.label | null |
 | NullCoalescing.cs:15:17:15:31 | ... ?? ... | NullCoalescing.cs:15:23:15:26 | null | semmle.label | successor |
 | NullCoalescing.cs:15:23:15:26 | null | NullCoalescing.cs:15:17:15:26 | (...) ... | semmle.label | successor |
 | NullCoalescing.cs:15:31:15:31 | 0 | NullCoalescing.cs:15:13:15:31 | Int32 j = ... | semmle.label | successor |
-| NullCoalescing.cs:16:9:16:26 | ... ...; | NullCoalescing.cs:16:13:16:13 | access to local variable s | semmle.label | successor |
-| NullCoalescing.cs:16:13:16:13 | access to local variable s | NullCoalescing.cs:16:17:16:25 | ... ?? ... | semmle.label | successor |
+| NullCoalescing.cs:16:9:16:26 | ... ...; | NullCoalescing.cs:16:17:16:25 | ... ?? ... | semmle.label | successor |
 | NullCoalescing.cs:16:13:16:25 | String s = ... | NullCoalescing.cs:17:9:17:25 | ...; | semmle.label | successor |
 | NullCoalescing.cs:16:17:16:18 | "" | NullCoalescing.cs:16:13:16:25 | String s = ... | semmle.label | non-null |
 | NullCoalescing.cs:16:17:16:25 | ... ?? ... | NullCoalescing.cs:16:17:16:18 | "" | semmle.label | successor |
-| NullCoalescing.cs:17:9:17:9 | access to local variable j | NullCoalescing.cs:17:13:17:24 | ... ?? ... | semmle.label | successor |
-| NullCoalescing.cs:17:9:17:25 | ...; | NullCoalescing.cs:17:9:17:9 | access to local variable j | semmle.label | successor |
+| NullCoalescing.cs:17:9:17:25 | ...; | NullCoalescing.cs:17:13:17:24 | ... ?? ... | semmle.label | successor |
 | NullCoalescing.cs:17:13:17:19 | (...) ... | NullCoalescing.cs:17:9:17:24 | ... = ... | semmle.label | non-null |
 | NullCoalescing.cs:17:13:17:24 | ... ?? ... | NullCoalescing.cs:17:19:17:19 | access to parameter i | semmle.label | successor |
 | NullCoalescing.cs:17:19:17:19 | access to parameter i | NullCoalescing.cs:17:13:17:19 | (...) ... | semmle.label | successor |
 | Patterns.cs:6:5:43:5 | {...} | Patterns.cs:7:9:7:24 | ... ...; | semmle.label | successor |
-| Patterns.cs:7:9:7:24 | ... ...; | Patterns.cs:7:16:7:16 | access to local variable o | semmle.label | successor |
-| Patterns.cs:7:16:7:16 | access to local variable o | Patterns.cs:7:20:7:23 | null | semmle.label | successor |
+| Patterns.cs:7:9:7:24 | ... ...; | Patterns.cs:7:20:7:23 | null | semmle.label | successor |
 | Patterns.cs:7:16:7:23 | Object o = ... | Patterns.cs:8:9:18:9 | if (...) ... | semmle.label | successor |
 | Patterns.cs:7:20:7:23 | null | Patterns.cs:7:16:7:23 | Object o = ... | semmle.label | successor |
 | Patterns.cs:8:9:18:9 | if (...) ... | Patterns.cs:8:13:8:13 | access to local variable o | semmle.label | successor |
@@ -1057,72 +1012,57 @@
 | Patterns.cs:37:17:37:22 | break; | Patterns.cs:40:9:42:9 | switch (...) {...} | semmle.label | break |
 | Patterns.cs:40:9:42:9 | switch (...) {...} | Patterns.cs:40:17:40:17 | access to local variable o | semmle.label | successor |
 | Qualifiers.cs:11:5:31:5 | {...} | Qualifiers.cs:12:9:12:22 | ... ...; | semmle.label | successor |
-| Qualifiers.cs:12:9:12:22 | ... ...; | Qualifiers.cs:12:13:12:13 | access to local variable q | semmle.label | successor |
-| Qualifiers.cs:12:13:12:13 | access to local variable q | Qualifiers.cs:12:17:12:21 | this access | semmle.label | successor |
+| Qualifiers.cs:12:9:12:22 | ... ...; | Qualifiers.cs:12:17:12:21 | this access | semmle.label | successor |
 | Qualifiers.cs:12:13:12:21 | Qualifiers q = ... | Qualifiers.cs:13:9:13:21 | ...; | semmle.label | successor |
 | Qualifiers.cs:12:17:12:21 | access to field Field | Qualifiers.cs:12:13:12:21 | Qualifiers q = ... | semmle.label | successor |
 | Qualifiers.cs:12:17:12:21 | this access | Qualifiers.cs:12:17:12:21 | access to field Field | semmle.label | successor |
-| Qualifiers.cs:13:9:13:9 | access to local variable q | Qualifiers.cs:13:13:13:20 | this access | semmle.label | successor |
 | Qualifiers.cs:13:9:13:20 | ... = ... | Qualifiers.cs:14:9:14:21 | ...; | semmle.label | successor |
-| Qualifiers.cs:13:9:13:21 | ...; | Qualifiers.cs:13:9:13:9 | access to local variable q | semmle.label | successor |
+| Qualifiers.cs:13:9:13:21 | ...; | Qualifiers.cs:13:13:13:20 | this access | semmle.label | successor |
 | Qualifiers.cs:13:13:13:20 | access to property Property | Qualifiers.cs:13:9:13:20 | ... = ... | semmle.label | successor |
 | Qualifiers.cs:13:13:13:20 | this access | Qualifiers.cs:13:13:13:20 | access to property Property | semmle.label | successor |
-| Qualifiers.cs:14:9:14:9 | access to local variable q | Qualifiers.cs:14:13:14:20 | this access | semmle.label | successor |
 | Qualifiers.cs:14:9:14:20 | ... = ... | Qualifiers.cs:16:9:16:23 | ...; | semmle.label | successor |
-| Qualifiers.cs:14:9:14:21 | ...; | Qualifiers.cs:14:9:14:9 | access to local variable q | semmle.label | successor |
+| Qualifiers.cs:14:9:14:21 | ...; | Qualifiers.cs:14:13:14:20 | this access | semmle.label | successor |
 | Qualifiers.cs:14:13:14:20 | call to method Method | Qualifiers.cs:14:9:14:20 | ... = ... | semmle.label | successor |
 | Qualifiers.cs:14:13:14:20 | this access | Qualifiers.cs:14:13:14:20 | call to method Method | semmle.label | successor |
-| Qualifiers.cs:16:9:16:9 | access to local variable q | Qualifiers.cs:16:13:16:16 | this access | semmle.label | successor |
 | Qualifiers.cs:16:9:16:22 | ... = ... | Qualifiers.cs:17:9:17:26 | ...; | semmle.label | successor |
-| Qualifiers.cs:16:9:16:23 | ...; | Qualifiers.cs:16:9:16:9 | access to local variable q | semmle.label | successor |
+| Qualifiers.cs:16:9:16:23 | ...; | Qualifiers.cs:16:13:16:16 | this access | semmle.label | successor |
 | Qualifiers.cs:16:13:16:16 | this access | Qualifiers.cs:16:13:16:22 | access to field Field | semmle.label | successor |
 | Qualifiers.cs:16:13:16:22 | access to field Field | Qualifiers.cs:16:9:16:22 | ... = ... | semmle.label | successor |
-| Qualifiers.cs:17:9:17:9 | access to local variable q | Qualifiers.cs:17:13:17:16 | this access | semmle.label | successor |
 | Qualifiers.cs:17:9:17:25 | ... = ... | Qualifiers.cs:18:9:18:26 | ...; | semmle.label | successor |
-| Qualifiers.cs:17:9:17:26 | ...; | Qualifiers.cs:17:9:17:9 | access to local variable q | semmle.label | successor |
+| Qualifiers.cs:17:9:17:26 | ...; | Qualifiers.cs:17:13:17:16 | this access | semmle.label | successor |
 | Qualifiers.cs:17:13:17:16 | this access | Qualifiers.cs:17:13:17:25 | access to property Property | semmle.label | successor |
 | Qualifiers.cs:17:13:17:25 | access to property Property | Qualifiers.cs:17:9:17:25 | ... = ... | semmle.label | successor |
-| Qualifiers.cs:18:9:18:9 | access to local variable q | Qualifiers.cs:18:13:18:16 | this access | semmle.label | successor |
 | Qualifiers.cs:18:9:18:25 | ... = ... | Qualifiers.cs:20:9:20:24 | ...; | semmle.label | successor |
-| Qualifiers.cs:18:9:18:26 | ...; | Qualifiers.cs:18:9:18:9 | access to local variable q | semmle.label | successor |
+| Qualifiers.cs:18:9:18:26 | ...; | Qualifiers.cs:18:13:18:16 | this access | semmle.label | successor |
 | Qualifiers.cs:18:13:18:16 | this access | Qualifiers.cs:18:13:18:25 | call to method Method | semmle.label | successor |
 | Qualifiers.cs:18:13:18:25 | call to method Method | Qualifiers.cs:18:9:18:25 | ... = ... | semmle.label | successor |
-| Qualifiers.cs:20:9:20:9 | access to local variable q | Qualifiers.cs:20:13:20:23 | access to field StaticField | semmle.label | successor |
 | Qualifiers.cs:20:9:20:23 | ... = ... | Qualifiers.cs:21:9:21:27 | ...; | semmle.label | successor |
-| Qualifiers.cs:20:9:20:24 | ...; | Qualifiers.cs:20:9:20:9 | access to local variable q | semmle.label | successor |
+| Qualifiers.cs:20:9:20:24 | ...; | Qualifiers.cs:20:13:20:23 | access to field StaticField | semmle.label | successor |
 | Qualifiers.cs:20:13:20:23 | access to field StaticField | Qualifiers.cs:20:9:20:23 | ... = ... | semmle.label | successor |
-| Qualifiers.cs:21:9:21:9 | access to local variable q | Qualifiers.cs:21:13:21:26 | access to property StaticProperty | semmle.label | successor |
 | Qualifiers.cs:21:9:21:26 | ... = ... | Qualifiers.cs:22:9:22:27 | ...; | semmle.label | successor |
-| Qualifiers.cs:21:9:21:27 | ...; | Qualifiers.cs:21:9:21:9 | access to local variable q | semmle.label | successor |
+| Qualifiers.cs:21:9:21:27 | ...; | Qualifiers.cs:21:13:21:26 | access to property StaticProperty | semmle.label | successor |
 | Qualifiers.cs:21:13:21:26 | access to property StaticProperty | Qualifiers.cs:21:9:21:26 | ... = ... | semmle.label | successor |
-| Qualifiers.cs:22:9:22:9 | access to local variable q | Qualifiers.cs:22:13:22:26 | call to method StaticMethod | semmle.label | successor |
 | Qualifiers.cs:22:9:22:26 | ... = ... | Qualifiers.cs:24:9:24:35 | ...; | semmle.label | successor |
-| Qualifiers.cs:22:9:22:27 | ...; | Qualifiers.cs:22:9:22:9 | access to local variable q | semmle.label | successor |
+| Qualifiers.cs:22:9:22:27 | ...; | Qualifiers.cs:22:13:22:26 | call to method StaticMethod | semmle.label | successor |
 | Qualifiers.cs:22:13:22:26 | call to method StaticMethod | Qualifiers.cs:22:9:22:26 | ... = ... | semmle.label | successor |
-| Qualifiers.cs:24:9:24:9 | access to local variable q | Qualifiers.cs:24:13:24:34 | access to field StaticField | semmle.label | successor |
 | Qualifiers.cs:24:9:24:34 | ... = ... | Qualifiers.cs:25:9:25:38 | ...; | semmle.label | successor |
-| Qualifiers.cs:24:9:24:35 | ...; | Qualifiers.cs:24:9:24:9 | access to local variable q | semmle.label | successor |
+| Qualifiers.cs:24:9:24:35 | ...; | Qualifiers.cs:24:13:24:34 | access to field StaticField | semmle.label | successor |
 | Qualifiers.cs:24:13:24:34 | access to field StaticField | Qualifiers.cs:24:9:24:34 | ... = ... | semmle.label | successor |
-| Qualifiers.cs:25:9:25:9 | access to local variable q | Qualifiers.cs:25:13:25:37 | access to property StaticProperty | semmle.label | successor |
 | Qualifiers.cs:25:9:25:37 | ... = ... | Qualifiers.cs:26:9:26:38 | ...; | semmle.label | successor |
-| Qualifiers.cs:25:9:25:38 | ...; | Qualifiers.cs:25:9:25:9 | access to local variable q | semmle.label | successor |
+| Qualifiers.cs:25:9:25:38 | ...; | Qualifiers.cs:25:13:25:37 | access to property StaticProperty | semmle.label | successor |
 | Qualifiers.cs:25:13:25:37 | access to property StaticProperty | Qualifiers.cs:25:9:25:37 | ... = ... | semmle.label | successor |
-| Qualifiers.cs:26:9:26:9 | access to local variable q | Qualifiers.cs:26:13:26:37 | call to method StaticMethod | semmle.label | successor |
 | Qualifiers.cs:26:9:26:37 | ... = ... | Qualifiers.cs:28:9:28:41 | ...; | semmle.label | successor |
-| Qualifiers.cs:26:9:26:38 | ...; | Qualifiers.cs:26:9:26:9 | access to local variable q | semmle.label | successor |
+| Qualifiers.cs:26:9:26:38 | ...; | Qualifiers.cs:26:13:26:37 | call to method StaticMethod | semmle.label | successor |
 | Qualifiers.cs:26:13:26:37 | call to method StaticMethod | Qualifiers.cs:26:9:26:37 | ... = ... | semmle.label | successor |
-| Qualifiers.cs:28:9:28:9 | access to local variable q | Qualifiers.cs:28:13:28:34 | access to field StaticField | semmle.label | successor |
 | Qualifiers.cs:28:9:28:40 | ... = ... | Qualifiers.cs:29:9:29:47 | ...; | semmle.label | successor |
-| Qualifiers.cs:28:9:28:41 | ...; | Qualifiers.cs:28:9:28:9 | access to local variable q | semmle.label | successor |
+| Qualifiers.cs:28:9:28:41 | ...; | Qualifiers.cs:28:13:28:34 | access to field StaticField | semmle.label | successor |
 | Qualifiers.cs:28:13:28:34 | access to field StaticField | Qualifiers.cs:28:13:28:40 | access to field Field | semmle.label | successor |
 | Qualifiers.cs:28:13:28:40 | access to field Field | Qualifiers.cs:28:9:28:40 | ... = ... | semmle.label | successor |
-| Qualifiers.cs:29:9:29:9 | access to local variable q | Qualifiers.cs:29:13:29:37 | access to property StaticProperty | semmle.label | successor |
 | Qualifiers.cs:29:9:29:46 | ... = ... | Qualifiers.cs:30:9:30:47 | ...; | semmle.label | successor |
-| Qualifiers.cs:29:9:29:47 | ...; | Qualifiers.cs:29:9:29:9 | access to local variable q | semmle.label | successor |
+| Qualifiers.cs:29:9:29:47 | ...; | Qualifiers.cs:29:13:29:37 | access to property StaticProperty | semmle.label | successor |
 | Qualifiers.cs:29:13:29:37 | access to property StaticProperty | Qualifiers.cs:29:13:29:46 | access to property Property | semmle.label | successor |
 | Qualifiers.cs:29:13:29:46 | access to property Property | Qualifiers.cs:29:9:29:46 | ... = ... | semmle.label | successor |
-| Qualifiers.cs:30:9:30:9 | access to local variable q | Qualifiers.cs:30:13:30:37 | call to method StaticMethod | semmle.label | successor |
-| Qualifiers.cs:30:9:30:47 | ...; | Qualifiers.cs:30:9:30:9 | access to local variable q | semmle.label | successor |
+| Qualifiers.cs:30:9:30:47 | ...; | Qualifiers.cs:30:13:30:37 | call to method StaticMethod | semmle.label | successor |
 | Qualifiers.cs:30:13:30:37 | call to method StaticMethod | Qualifiers.cs:30:13:30:46 | call to method Method | semmle.label | successor |
 | Qualifiers.cs:30:13:30:46 | call to method Method | Qualifiers.cs:30:9:30:46 | ... = ... | semmle.label | successor |
 | Switch.cs:6:5:8:5 | {...} | Switch.cs:7:9:7:22 | switch (...) {...} | semmle.label | successor |
@@ -1271,14 +1211,12 @@
 | Switch.cs:120:16:120:17 | -... | Switch.cs:120:9:120:18 | return ...; | semmle.label | successor |
 | Switch.cs:120:17:120:17 | 1 | Switch.cs:120:16:120:17 | -... | semmle.label | successor |
 | TypeAccesses.cs:4:5:9:5 | {...} | TypeAccesses.cs:5:9:5:26 | ... ...; | semmle.label | successor |
-| TypeAccesses.cs:5:9:5:26 | ... ...; | TypeAccesses.cs:5:13:5:13 | access to local variable s | semmle.label | successor |
-| TypeAccesses.cs:5:13:5:13 | access to local variable s | TypeAccesses.cs:5:25:5:25 | access to parameter o | semmle.label | successor |
+| TypeAccesses.cs:5:9:5:26 | ... ...; | TypeAccesses.cs:5:25:5:25 | access to parameter o | semmle.label | successor |
 | TypeAccesses.cs:5:13:5:25 | String s = ... | TypeAccesses.cs:6:9:6:24 | ...; | semmle.label | successor |
 | TypeAccesses.cs:5:17:5:25 | (...) ... | TypeAccesses.cs:5:13:5:25 | String s = ... | semmle.label | successor |
 | TypeAccesses.cs:5:25:5:25 | access to parameter o | TypeAccesses.cs:5:17:5:25 | (...) ... | semmle.label | successor |
-| TypeAccesses.cs:6:9:6:9 | access to local variable s | TypeAccesses.cs:6:13:6:13 | access to parameter o | semmle.label | successor |
 | TypeAccesses.cs:6:9:6:23 | ... = ... | TypeAccesses.cs:7:9:7:25 | if (...) ... | semmle.label | successor |
-| TypeAccesses.cs:6:9:6:24 | ...; | TypeAccesses.cs:6:9:6:9 | access to local variable s | semmle.label | successor |
+| TypeAccesses.cs:6:9:6:24 | ...; | TypeAccesses.cs:6:13:6:13 | access to parameter o | semmle.label | successor |
 | TypeAccesses.cs:6:13:6:13 | access to parameter o | TypeAccesses.cs:6:13:6:23 | ... as ... | semmle.label | successor |
 | TypeAccesses.cs:6:13:6:23 | ... as ... | TypeAccesses.cs:6:9:6:23 | ... = ... | semmle.label | successor |
 | TypeAccesses.cs:7:9:7:25 | if (...) ... | TypeAccesses.cs:7:13:7:13 | access to parameter o | semmle.label | successor |
@@ -1287,17 +1225,14 @@
 | TypeAccesses.cs:7:13:7:22 | ... is ... | TypeAccesses.cs:8:9:8:28 | ... ...; | semmle.label | false |
 | TypeAccesses.cs:7:18:7:22 | Int32 j | TypeAccesses.cs:7:13:7:22 | ... is ... | semmle.label | successor |
 | TypeAccesses.cs:7:25:7:25 | ; | TypeAccesses.cs:8:9:8:28 | ... ...; | semmle.label | successor |
-| TypeAccesses.cs:8:9:8:28 | ... ...; | TypeAccesses.cs:8:13:8:13 | access to local variable t | semmle.label | successor |
-| TypeAccesses.cs:8:13:8:13 | access to local variable t | TypeAccesses.cs:8:17:8:27 | typeof(...) | semmle.label | successor |
+| TypeAccesses.cs:8:9:8:28 | ... ...; | TypeAccesses.cs:8:17:8:27 | typeof(...) | semmle.label | successor |
 | TypeAccesses.cs:8:17:8:27 | typeof(...) | TypeAccesses.cs:8:13:8:27 | Type t = ... | semmle.label | successor |
 | VarDecls.cs:6:5:11:5 | {...} | VarDecls.cs:7:9:10:9 | fixed(...) { ... } | semmle.label | successor |
-| VarDecls.cs:7:9:10:9 | fixed(...) { ... } | VarDecls.cs:7:22:7:23 | access to local variable c1 | semmle.label | successor |
-| VarDecls.cs:7:22:7:23 | access to local variable c1 | VarDecls.cs:7:27:7:33 | access to parameter strings | semmle.label | successor |
-| VarDecls.cs:7:22:7:36 | Char* c1 = ... | VarDecls.cs:7:39:7:40 | access to local variable c2 | semmle.label | successor |
+| VarDecls.cs:7:9:10:9 | fixed(...) { ... } | VarDecls.cs:7:27:7:33 | access to parameter strings | semmle.label | successor |
+| VarDecls.cs:7:22:7:36 | Char* c1 = ... | VarDecls.cs:7:44:7:50 | access to parameter strings | semmle.label | successor |
 | VarDecls.cs:7:27:7:33 | access to parameter strings | VarDecls.cs:7:35:7:35 | 0 | semmle.label | successor |
 | VarDecls.cs:7:27:7:36 | access to array element | VarDecls.cs:7:22:7:36 | Char* c1 = ... | semmle.label | successor |
 | VarDecls.cs:7:35:7:35 | 0 | VarDecls.cs:7:27:7:36 | access to array element | semmle.label | successor |
-| VarDecls.cs:7:39:7:40 | access to local variable c2 | VarDecls.cs:7:44:7:50 | access to parameter strings | semmle.label | successor |
 | VarDecls.cs:7:39:7:53 | Char* c2 = ... | VarDecls.cs:8:9:10:9 | {...} | semmle.label | successor |
 | VarDecls.cs:7:44:7:50 | access to parameter strings | VarDecls.cs:7:52:7:52 | 1 | semmle.label | successor |
 | VarDecls.cs:7:44:7:53 | access to array element | VarDecls.cs:7:39:7:53 | Char* c2 = ... | semmle.label | successor |
@@ -1306,11 +1241,9 @@
 | VarDecls.cs:9:20:9:28 | (...) ... | VarDecls.cs:9:13:9:29 | return ...; | semmle.label | successor |
 | VarDecls.cs:9:27:9:28 | access to local variable c1 | VarDecls.cs:9:20:9:28 | (...) ... | semmle.label | successor |
 | VarDecls.cs:14:5:17:5 | {...} | VarDecls.cs:15:9:15:30 | ... ...; | semmle.label | successor |
-| VarDecls.cs:15:9:15:30 | ... ...; | VarDecls.cs:15:16:15:17 | access to local variable s1 | semmle.label | successor |
-| VarDecls.cs:15:16:15:17 | access to local variable s1 | VarDecls.cs:15:21:15:21 | access to parameter s | semmle.label | successor |
-| VarDecls.cs:15:16:15:21 | String s1 = ... | VarDecls.cs:15:24:15:25 | access to local variable s2 | semmle.label | successor |
+| VarDecls.cs:15:9:15:30 | ... ...; | VarDecls.cs:15:21:15:21 | access to parameter s | semmle.label | successor |
+| VarDecls.cs:15:16:15:21 | String s1 = ... | VarDecls.cs:15:29:15:29 | access to parameter s | semmle.label | successor |
 | VarDecls.cs:15:21:15:21 | access to parameter s | VarDecls.cs:15:16:15:21 | String s1 = ... | semmle.label | successor |
-| VarDecls.cs:15:24:15:25 | access to local variable s2 | VarDecls.cs:15:29:15:29 | access to parameter s | semmle.label | successor |
 | VarDecls.cs:15:24:15:29 | String s2 = ... | VarDecls.cs:16:16:16:17 | access to local variable s1 | semmle.label | successor |
 | VarDecls.cs:15:29:15:29 | access to parameter s | VarDecls.cs:15:24:15:29 | String s2 = ... | semmle.label | successor |
 | VarDecls.cs:16:16:16:17 | access to local variable s1 | VarDecls.cs:16:21:16:22 | access to local variable s2 | semmle.label | successor |
@@ -1320,11 +1253,9 @@
 | VarDecls.cs:21:9:22:13 | using (...) {...} | VarDecls.cs:21:16:21:22 | object creation of type C | semmle.label | successor |
 | VarDecls.cs:21:16:21:22 | object creation of type C | VarDecls.cs:22:13:22:13 | ; | semmle.label | successor |
 | VarDecls.cs:22:13:22:13 | ; | VarDecls.cs:24:9:25:29 | using (...) {...} | semmle.label | successor |
-| VarDecls.cs:24:9:25:29 | using (...) {...} | VarDecls.cs:24:18:24:18 | access to local variable x | semmle.label | successor |
-| VarDecls.cs:24:18:24:18 | access to local variable x | VarDecls.cs:24:22:24:28 | object creation of type C | semmle.label | successor |
-| VarDecls.cs:24:18:24:28 | C x = ... | VarDecls.cs:24:31:24:31 | access to local variable y | semmle.label | successor |
+| VarDecls.cs:24:9:25:29 | using (...) {...} | VarDecls.cs:24:22:24:28 | object creation of type C | semmle.label | successor |
+| VarDecls.cs:24:18:24:28 | C x = ... | VarDecls.cs:24:35:24:41 | object creation of type C | semmle.label | successor |
 | VarDecls.cs:24:22:24:28 | object creation of type C | VarDecls.cs:24:18:24:28 | C x = ... | semmle.label | successor |
-| VarDecls.cs:24:31:24:31 | access to local variable y | VarDecls.cs:24:35:24:41 | object creation of type C | semmle.label | successor |
 | VarDecls.cs:24:31:24:41 | C y = ... | VarDecls.cs:25:20:25:28 | ... ? ... : ... | semmle.label | successor |
 | VarDecls.cs:24:35:24:41 | object creation of type C | VarDecls.cs:24:31:24:41 | C y = ... | semmle.label | successor |
 | VarDecls.cs:25:20:25:20 | access to parameter b | VarDecls.cs:25:24:25:24 | access to local variable x | semmle.label | true |
@@ -1333,14 +1264,12 @@
 | VarDecls.cs:25:24:25:24 | access to local variable x | VarDecls.cs:25:13:25:29 | return ...; | semmle.label | successor |
 | VarDecls.cs:25:28:25:28 | access to local variable y | VarDecls.cs:25:13:25:29 | return ...; | semmle.label | successor |
 | cflow.cs:6:5:35:5 | {...} | cflow.cs:7:9:7:28 | ... ...; | semmle.label | successor |
-| cflow.cs:7:9:7:28 | ... ...; | cflow.cs:7:13:7:13 | access to local variable a | semmle.label | successor |
-| cflow.cs:7:13:7:13 | access to local variable a | cflow.cs:7:17:7:20 | access to parameter args | semmle.label | successor |
+| cflow.cs:7:9:7:28 | ... ...; | cflow.cs:7:17:7:20 | access to parameter args | semmle.label | successor |
 | cflow.cs:7:13:7:27 | Int32 a = ... | cflow.cs:9:9:9:40 | ...; | semmle.label | successor |
 | cflow.cs:7:17:7:20 | access to parameter args | cflow.cs:7:17:7:27 | access to property Length | semmle.label | successor |
 | cflow.cs:7:17:7:27 | access to property Length | cflow.cs:7:13:7:27 | Int32 a = ... | semmle.label | successor |
-| cflow.cs:9:9:9:9 | access to local variable a | cflow.cs:9:13:9:29 | object creation of type ControlFlow | semmle.label | successor |
 | cflow.cs:9:9:9:39 | ... = ... | cflow.cs:11:9:12:49 | if (...) ... | semmle.label | successor |
-| cflow.cs:9:9:9:40 | ...; | cflow.cs:9:9:9:9 | access to local variable a | semmle.label | successor |
+| cflow.cs:9:9:9:40 | ...; | cflow.cs:9:13:9:29 | object creation of type ControlFlow | semmle.label | successor |
 | cflow.cs:9:13:9:29 | object creation of type ControlFlow | cflow.cs:9:38:9:38 | access to local variable a | semmle.label | successor |
 | cflow.cs:9:13:9:39 | call to method Switch | cflow.cs:9:9:9:39 | ... = ... | semmle.label | successor |
 | cflow.cs:9:38:9:38 | access to local variable a | cflow.cs:9:13:9:39 | call to method Switch | semmle.label | successor |
@@ -1375,8 +1304,7 @@
 | cflow.cs:22:18:22:23 | ... < ... | cflow.cs:20:9:22:9 | {...} | semmle.label | true |
 | cflow.cs:22:18:22:23 | ... < ... | cflow.cs:24:9:34:9 | for (...;...;...) ... | semmle.label | false |
 | cflow.cs:22:22:22:23 | 10 | cflow.cs:22:18:22:23 | ... < ... | semmle.label | successor |
-| cflow.cs:24:9:34:9 | for (...;...;...) ... | cflow.cs:24:18:24:18 | access to local variable i | semmle.label | successor |
-| cflow.cs:24:18:24:18 | access to local variable i | cflow.cs:24:22:24:22 | 1 | semmle.label | successor |
+| cflow.cs:24:9:34:9 | for (...;...;...) ... | cflow.cs:24:22:24:22 | 1 | semmle.label | successor |
 | cflow.cs:24:18:24:22 | Int32 i = ... | cflow.cs:24:25:24:25 | access to local variable i | semmle.label | successor |
 | cflow.cs:24:22:24:22 | 1 | cflow.cs:24:18:24:22 | Int32 i = ... | semmle.label | successor |
 | cflow.cs:24:25:24:25 | access to local variable i | cflow.cs:24:30:24:31 | 20 | semmle.label | successor |
@@ -1567,13 +1495,11 @@
 | cflow.cs:116:9:116:29 | ...; | cflow.cs:116:27:116:27 | access to parameter s | semmle.label | successor |
 | cflow.cs:116:27:116:27 | access to parameter s | cflow.cs:116:9:116:28 | call to method WriteLine | semmle.label | successor |
 | cflow.cs:120:5:124:5 | {...} | cflow.cs:121:9:121:18 | ... ...; | semmle.label | successor |
-| cflow.cs:121:9:121:18 | ... ...; | cflow.cs:121:13:121:13 | access to local variable x | semmle.label | successor |
-| cflow.cs:121:13:121:13 | access to local variable x | cflow.cs:121:17:121:17 | access to parameter s | semmle.label | successor |
+| cflow.cs:121:9:121:18 | ... ...; | cflow.cs:121:17:121:17 | access to parameter s | semmle.label | successor |
 | cflow.cs:121:13:121:17 | String x = ... | cflow.cs:122:9:122:20 | ...; | semmle.label | successor |
 | cflow.cs:121:17:121:17 | access to parameter s | cflow.cs:121:13:121:17 | String x = ... | semmle.label | successor |
-| cflow.cs:122:9:122:9 | access to local variable x | cflow.cs:122:13:122:13 | access to local variable x | semmle.label | successor |
 | cflow.cs:122:9:122:19 | ... = ... | cflow.cs:123:16:123:16 | access to local variable x | semmle.label | successor |
-| cflow.cs:122:9:122:20 | ...; | cflow.cs:122:9:122:9 | access to local variable x | semmle.label | successor |
+| cflow.cs:122:9:122:20 | ...; | cflow.cs:122:13:122:13 | access to local variable x | semmle.label | successor |
 | cflow.cs:122:13:122:13 | access to local variable x | cflow.cs:122:17:122:19 | " " | semmle.label | successor |
 | cflow.cs:122:13:122:19 | ... + ... | cflow.cs:122:9:122:19 | ... = ... | semmle.label | successor |
 | cflow.cs:122:17:122:19 | " " | cflow.cs:122:13:122:19 | ... + ... | semmle.label | successor |
@@ -1589,13 +1515,11 @@
 | cflow.cs:127:53:127:57 | access to field Field | cflow.cs:127:25:127:58 | return ...; | semmle.label | successor |
 | cflow.cs:127:53:127:57 | this access | cflow.cs:127:53:127:57 | access to field Field | semmle.label | successor |
 | cflow.cs:127:66:127:83 | {...} | cflow.cs:127:68:127:81 | ...; | semmle.label | successor |
-| cflow.cs:127:68:127:72 | access to field Field | cflow.cs:127:76:127:80 | access to parameter value | semmle.label | successor |
-| cflow.cs:127:68:127:72 | this access | cflow.cs:127:68:127:72 | access to field Field | semmle.label | successor |
+| cflow.cs:127:68:127:72 | this access | cflow.cs:127:76:127:80 | access to parameter value | semmle.label | successor |
 | cflow.cs:127:68:127:81 | ...; | cflow.cs:127:68:127:72 | this access | semmle.label | successor |
 | cflow.cs:127:76:127:80 | access to parameter value | cflow.cs:127:68:127:80 | ... = ... | semmle.label | successor |
 | cflow.cs:130:5:132:5 | {...} | cflow.cs:131:9:131:18 | ...; | semmle.label | successor |
-| cflow.cs:131:9:131:13 | access to field Field | cflow.cs:131:17:131:17 | access to parameter s | semmle.label | successor |
-| cflow.cs:131:9:131:13 | this access | cflow.cs:131:9:131:13 | access to field Field | semmle.label | successor |
+| cflow.cs:131:9:131:13 | this access | cflow.cs:131:17:131:17 | access to parameter s | semmle.label | successor |
 | cflow.cs:131:9:131:18 | ...; | cflow.cs:131:9:131:13 | this access | semmle.label | successor |
 | cflow.cs:131:17:131:17 | access to parameter s | cflow.cs:131:9:131:17 | ... = ... | semmle.label | successor |
 | cflow.cs:134:26:134:29 | call to constructor ControlFlow | cflow.cs:134:39:134:41 | {...} | semmle.label | successor |
@@ -1689,8 +1613,7 @@
 | cflow.cs:203:13:203:40 | call to method WriteLine | cflow.cs:206:9:206:19 | ... ...; | semmle.label | successor |
 | cflow.cs:203:13:203:41 | ...; | cflow.cs:203:31:203:39 | "Finally" | semmle.label | successor |
 | cflow.cs:203:31:203:39 | "Finally" | cflow.cs:203:13:203:40 | call to method WriteLine | semmle.label | successor |
-| cflow.cs:206:9:206:19 | ... ...; | cflow.cs:206:13:206:13 | access to local variable i | semmle.label | successor |
-| cflow.cs:206:13:206:13 | access to local variable i | cflow.cs:206:17:206:18 | 10 | semmle.label | successor |
+| cflow.cs:206:9:206:19 | ... ...; | cflow.cs:206:17:206:18 | 10 | semmle.label | successor |
 | cflow.cs:206:13:206:18 | Int32 i = ... | cflow.cs:207:9:230:9 | while (...) ... | semmle.label | successor |
 | cflow.cs:206:17:206:18 | 10 | cflow.cs:206:13:206:18 | Int32 i = ... | semmle.label | successor |
 | cflow.cs:207:9:230:9 | while (...) ... | cflow.cs:207:16:207:16 | access to local variable i | semmle.label | successor |
@@ -1787,15 +1710,13 @@
 | cflow.cs:244:35:244:35 | 1 | cflow.cs:244:17:244:36 | call to method WriteLine | semmle.label | successor |
 | cflow.cs:247:9:254:9 | try {...} ... | cflow.cs:248:9:250:9 | {...} | semmle.label | successor |
 | cflow.cs:248:9:250:9 | {...} | cflow.cs:249:13:249:41 | ... ...; | semmle.label | successor |
-| cflow.cs:249:13:249:41 | ... ...; | cflow.cs:249:17:249:20 | access to local variable temp | semmle.label | successor |
-| cflow.cs:249:17:249:20 | access to local variable temp | cflow.cs:249:24:249:24 | 0 | semmle.label | successor |
+| cflow.cs:249:13:249:41 | ... ...; | cflow.cs:249:24:249:24 | 0 | semmle.label | successor |
 | cflow.cs:249:24:249:24 | 0 | cflow.cs:249:24:249:24 | (...) ... | semmle.label | successor |
 | cflow.cs:249:24:249:24 | (...) ... | cflow.cs:249:28:249:40 | access to constant E | semmle.label | successor |
 | cflow.cs:249:24:249:40 | ... / ... | cflow.cs:249:17:249:40 | Double temp = ... | semmle.label | successor |
 | cflow.cs:249:28:249:40 | access to constant E | cflow.cs:249:24:249:40 | ... / ... | semmle.label | successor |
 | cflow.cs:258:5:288:5 | {...} | cflow.cs:259:9:259:18 | ... ...; | semmle.label | successor |
-| cflow.cs:259:9:259:18 | ... ...; | cflow.cs:259:13:259:13 | access to local variable x | semmle.label | successor |
-| cflow.cs:259:13:259:13 | access to local variable x | cflow.cs:259:17:259:17 | 0 | semmle.label | successor |
+| cflow.cs:259:9:259:18 | ... ...; | cflow.cs:259:17:259:17 | 0 | semmle.label | successor |
 | cflow.cs:259:13:259:17 | Int32 x = ... | cflow.cs:260:9:261:33 | for (...;...;...) ... | semmle.label | successor |
 | cflow.cs:259:17:259:17 | 0 | cflow.cs:259:13:259:17 | Int32 x = ... | semmle.label | successor |
 | cflow.cs:260:9:261:33 | for (...;...;...) ... | cflow.cs:260:16:260:16 | access to local variable x | semmle.label | successor |
@@ -1847,11 +1768,9 @@
 | cflow.cs:281:13:281:13 | access to local variable x | cflow.cs:281:13:281:15 | ...++ | semmle.label | successor |
 | cflow.cs:281:13:281:15 | ...++ | cflow.cs:278:16:278:16 | access to local variable x | semmle.label | successor |
 | cflow.cs:281:13:281:16 | ...; | cflow.cs:281:13:281:13 | access to local variable x | semmle.label | successor |
-| cflow.cs:284:9:287:9 | for (...;...;...) ... | cflow.cs:284:18:284:18 | access to local variable i | semmle.label | successor |
-| cflow.cs:284:18:284:18 | access to local variable i | cflow.cs:284:22:284:22 | 0 | semmle.label | successor |
-| cflow.cs:284:18:284:22 | Int32 i = ... | cflow.cs:284:25:284:25 | access to local variable j | semmle.label | successor |
+| cflow.cs:284:9:287:9 | for (...;...;...) ... | cflow.cs:284:22:284:22 | 0 | semmle.label | successor |
+| cflow.cs:284:18:284:22 | Int32 i = ... | cflow.cs:284:29:284:29 | 0 | semmle.label | successor |
 | cflow.cs:284:22:284:22 | 0 | cflow.cs:284:18:284:22 | Int32 i = ... | semmle.label | successor |
-| cflow.cs:284:25:284:25 | access to local variable j | cflow.cs:284:29:284:29 | 0 | semmle.label | successor |
 | cflow.cs:284:25:284:29 | Int32 j = ... | cflow.cs:284:32:284:32 | access to local variable i | semmle.label | successor |
 | cflow.cs:284:29:284:29 | 0 | cflow.cs:284:25:284:29 | Int32 j = ... | semmle.label | successor |
 | cflow.cs:284:32:284:32 | access to local variable i | cflow.cs:284:36:284:36 | access to local variable j | semmle.label | successor |
@@ -1870,14 +1789,12 @@
 | cflow.cs:286:31:286:35 | ... + ... | cflow.cs:286:13:286:36 | call to method WriteLine | semmle.label | successor |
 | cflow.cs:286:35:286:35 | access to local variable j | cflow.cs:286:31:286:35 | ... + ... | semmle.label | successor |
 | cflow.cs:291:5:294:5 | {...} | cflow.cs:292:9:292:38 | ... ...; | semmle.label | successor |
-| cflow.cs:292:9:292:38 | ... ...; | cflow.cs:292:24:292:24 | access to local variable y | semmle.label | successor |
-| cflow.cs:292:24:292:24 | access to local variable y | cflow.cs:292:28:292:37 | (...) => ... | semmle.label | successor |
+| cflow.cs:292:9:292:38 | ... ...; | cflow.cs:292:28:292:37 | (...) => ... | semmle.label | successor |
 | cflow.cs:292:24:292:37 | Func<Int32,Int32> y = ... | cflow.cs:293:9:293:62 | ... ...; | semmle.label | successor |
 | cflow.cs:292:28:292:37 | (...) => ... | cflow.cs:292:24:292:37 | Func<Int32,Int32> y = ... | semmle.label | successor |
 | cflow.cs:292:33:292:33 | access to parameter x | cflow.cs:292:37:292:37 | 1 | semmle.label | successor |
 | cflow.cs:292:37:292:37 | 1 | cflow.cs:292:33:292:37 | ... + ... | semmle.label | successor |
-| cflow.cs:293:9:293:62 | ... ...; | cflow.cs:293:24:293:24 | access to local variable z | semmle.label | successor |
-| cflow.cs:293:24:293:24 | access to local variable z | cflow.cs:293:28:293:61 | delegate(...) { ... } | semmle.label | successor |
+| cflow.cs:293:9:293:62 | ... ...; | cflow.cs:293:28:293:61 | delegate(...) { ... } | semmle.label | successor |
 | cflow.cs:293:28:293:61 | delegate(...) { ... } | cflow.cs:293:24:293:61 | Func<Int32,Int32> z = ... | semmle.label | successor |
 | cflow.cs:293:45:293:61 | {...} | cflow.cs:293:54:293:54 | access to parameter x | semmle.label | successor |
 | cflow.cs:293:54:293:54 | access to parameter x | cflow.cs:293:58:293:58 | 1 | semmle.label | successor |
@@ -1900,8 +1817,7 @@
 | cflow.cs:301:13:301:52 | ...; | cflow.cs:301:31:301:50 | "This should happen" | semmle.label | successor |
 | cflow.cs:301:31:301:50 | "This should happen" | cflow.cs:301:13:301:51 | call to method WriteLine | semmle.label | successor |
 | cflow.cs:305:5:317:5 | {...} | cflow.cs:306:9:306:57 | ... ...; | semmle.label | successor |
-| cflow.cs:306:9:306:57 | ... ...; | cflow.cs:306:13:306:13 | access to local variable b | semmle.label | successor |
-| cflow.cs:306:13:306:13 | access to local variable b | cflow.cs:306:17:306:56 | ... && ... | semmle.label | successor |
+| cflow.cs:306:9:306:57 | ... ...; | cflow.cs:306:17:306:56 | ... && ... | semmle.label | successor |
 | cflow.cs:306:13:306:56 | Boolean b = ... | cflow.cs:308:9:309:49 | if (...) ... | semmle.label | successor |
 | cflow.cs:306:17:306:21 | access to field Field | cflow.cs:306:17:306:28 | access to property Length | semmle.label | successor |
 | cflow.cs:306:17:306:21 | this access | cflow.cs:306:17:306:21 | access to field Field | semmle.label | successor |
@@ -1927,9 +1843,8 @@
 | cflow.cs:308:31:308:31 | 0 | cflow.cs:308:15:308:31 | ... == ... | semmle.label | successor |
 | cflow.cs:308:35:308:39 | false | cflow.cs:309:13:309:49 | ...; | semmle.label | false |
 | cflow.cs:308:43:308:46 | true | cflow.cs:311:9:316:9 | if (...) ... | semmle.label | true |
-| cflow.cs:309:13:309:13 | access to local variable b | cflow.cs:309:17:309:48 | ... ? ... : ... | semmle.label | successor |
 | cflow.cs:309:13:309:48 | ... = ... | cflow.cs:311:9:316:9 | if (...) ... | semmle.label | successor |
-| cflow.cs:309:13:309:49 | ...; | cflow.cs:309:13:309:13 | access to local variable b | semmle.label | successor |
+| cflow.cs:309:13:309:49 | ...; | cflow.cs:309:17:309:48 | ... ? ... : ... | semmle.label | successor |
 | cflow.cs:309:17:309:21 | access to field Field | cflow.cs:309:17:309:28 | access to property Length | semmle.label | successor |
 | cflow.cs:309:17:309:21 | this access | cflow.cs:309:17:309:21 | access to field Field | semmle.label | successor |
 | cflow.cs:309:17:309:28 | access to property Length | cflow.cs:309:33:309:33 | 0 | semmle.label | successor |
@@ -1963,10 +1878,9 @@
 | cflow.cs:320:5:333:5 | {...} | cflow.cs:321:9:332:36 | do ... while (...); | semmle.label | successor |
 | cflow.cs:321:9:332:36 | do ... while (...); | cflow.cs:322:9:332:9 | {...} | semmle.label | successor |
 | cflow.cs:322:9:332:9 | {...} | cflow.cs:323:13:323:25 | ...; | semmle.label | successor |
-| cflow.cs:323:13:323:17 | access to field Field | cflow.cs:323:13:323:17 | this access | semmle.label | successor |
 | cflow.cs:323:13:323:17 | access to field Field | cflow.cs:323:22:323:24 | "a" | semmle.label | successor |
 | cflow.cs:323:13:323:17 | this access | cflow.cs:323:13:323:17 | access to field Field | semmle.label | successor |
-| cflow.cs:323:13:323:17 | this access | cflow.cs:323:13:323:17 | access to field Field | semmle.label | successor |
+| cflow.cs:323:13:323:17 | this access | cflow.cs:323:13:323:17 | this access | semmle.label | successor |
 | cflow.cs:323:13:323:24 | ... + ... | cflow.cs:323:13:323:24 | ... = ... | semmle.label | successor |
 | cflow.cs:323:13:323:24 | ... = ... | cflow.cs:324:13:327:13 | if (...) ... | semmle.label | successor |
 | cflow.cs:323:13:323:25 | ...; | cflow.cs:323:13:323:17 | this access | semmle.label | successor |
@@ -2000,10 +1914,9 @@
 | cflow.cs:337:57:337:59 | "a" | cflow.cs:337:62:337:63 | 10 | semmle.label | successor |
 | cflow.cs:337:62:337:63 | 10 | cflow.cs:337:27:337:64 | call to method Repeat | semmle.label | successor |
 | cflow.cs:338:9:348:9 | {...} | cflow.cs:339:13:339:23 | ...; | semmle.label | successor |
-| cflow.cs:339:13:339:17 | access to field Field | cflow.cs:339:13:339:17 | this access | semmle.label | successor |
 | cflow.cs:339:13:339:17 | access to field Field | cflow.cs:339:22:339:22 | access to local variable x | semmle.label | successor |
 | cflow.cs:339:13:339:17 | this access | cflow.cs:339:13:339:17 | access to field Field | semmle.label | successor |
-| cflow.cs:339:13:339:17 | this access | cflow.cs:339:13:339:17 | access to field Field | semmle.label | successor |
+| cflow.cs:339:13:339:17 | this access | cflow.cs:339:13:339:17 | this access | semmle.label | successor |
 | cflow.cs:339:13:339:22 | ... + ... | cflow.cs:339:13:339:22 | ... = ... | semmle.label | successor |
 | cflow.cs:339:13:339:22 | ... = ... | cflow.cs:340:13:343:13 | if (...) ... | semmle.label | successor |
 | cflow.cs:339:13:339:23 | ...; | cflow.cs:339:13:339:17 | this access | semmle.label | successor |
@@ -2072,8 +1985,7 @@
 | cflow.cs:373:5:388:5 | {...} | cflow.cs:374:22:374:22 | 0 | semmle.label | successor |
 | cflow.cs:374:9:374:23 | yield return ...; | cflow.cs:375:9:378:9 | for (...;...;...) ... | semmle.label | successor |
 | cflow.cs:374:22:374:22 | 0 | cflow.cs:374:9:374:23 | yield return ...; | semmle.label | successor |
-| cflow.cs:375:9:378:9 | for (...;...;...) ... | cflow.cs:375:18:375:18 | access to local variable i | semmle.label | successor |
-| cflow.cs:375:18:375:18 | access to local variable i | cflow.cs:375:22:375:22 | 1 | semmle.label | successor |
+| cflow.cs:375:9:378:9 | for (...;...;...) ... | cflow.cs:375:22:375:22 | 1 | semmle.label | successor |
 | cflow.cs:375:18:375:22 | Int32 i = ... | cflow.cs:375:25:375:25 | access to local variable i | semmle.label | successor |
 | cflow.cs:375:22:375:22 | 1 | cflow.cs:375:18:375:22 | Int32 i = ... | semmle.label | successor |
 | cflow.cs:375:25:375:25 | access to local variable i | cflow.cs:375:29:375:30 | 10 | semmle.label | successor |

--- a/csharp/ql/test/library-tests/controlflow/graph/ElementGraph.expected
+++ b/csharp/ql/test/library-tests/controlflow/graph/ElementGraph.expected
@@ -1,3 +1,219 @@
+| AccessorCalls.cs:11:5:17:5 | {...} | AccessorCalls.cs:12:9:12:32 | ...; | semmle.label | successor |
+| AccessorCalls.cs:12:9:12:12 | this access | AccessorCalls.cs:12:9:12:18 | access to field Field | semmle.label | successor |
+| AccessorCalls.cs:12:9:12:18 | access to field Field | AccessorCalls.cs:12:22:12:25 | this access | semmle.label | successor |
+| AccessorCalls.cs:12:9:12:31 | ... = ... | AccessorCalls.cs:13:9:13:30 | ...; | semmle.label | successor |
+| AccessorCalls.cs:12:9:12:32 | ...; | AccessorCalls.cs:12:9:12:12 | this access | semmle.label | successor |
+| AccessorCalls.cs:12:22:12:25 | this access | AccessorCalls.cs:12:22:12:31 | access to field Field | semmle.label | successor |
+| AccessorCalls.cs:12:22:12:31 | access to field Field | AccessorCalls.cs:12:9:12:31 | ... = ... | semmle.label | successor |
+| AccessorCalls.cs:13:9:13:12 | this access | AccessorCalls.cs:13:9:13:17 | access to property Prop | semmle.label | successor |
+| AccessorCalls.cs:13:9:13:17 | access to property Prop | AccessorCalls.cs:13:21:13:24 | this access | semmle.label | successor |
+| AccessorCalls.cs:13:9:13:29 | ... = ... | AccessorCalls.cs:14:9:14:26 | ...; | semmle.label | successor |
+| AccessorCalls.cs:13:9:13:30 | ...; | AccessorCalls.cs:13:9:13:12 | this access | semmle.label | successor |
+| AccessorCalls.cs:13:21:13:24 | this access | AccessorCalls.cs:13:21:13:29 | access to property Prop | semmle.label | successor |
+| AccessorCalls.cs:13:21:13:29 | access to property Prop | AccessorCalls.cs:13:9:13:29 | ... = ... | semmle.label | successor |
+| AccessorCalls.cs:14:9:14:12 | this access | AccessorCalls.cs:14:14:14:14 | 0 | semmle.label | successor |
+| AccessorCalls.cs:14:9:14:15 | access to indexer | AccessorCalls.cs:14:19:14:22 | this access | semmle.label | successor |
+| AccessorCalls.cs:14:9:14:25 | ... = ... | AccessorCalls.cs:15:9:15:24 | ...; | semmle.label | successor |
+| AccessorCalls.cs:14:9:14:26 | ...; | AccessorCalls.cs:14:9:14:12 | this access | semmle.label | successor |
+| AccessorCalls.cs:14:14:14:14 | 0 | AccessorCalls.cs:14:9:14:15 | access to indexer | semmle.label | successor |
+| AccessorCalls.cs:14:19:14:22 | this access | AccessorCalls.cs:14:24:14:24 | 1 | semmle.label | successor |
+| AccessorCalls.cs:14:19:14:25 | access to indexer | AccessorCalls.cs:14:9:14:25 | ... = ... | semmle.label | successor |
+| AccessorCalls.cs:14:24:14:24 | 1 | AccessorCalls.cs:14:19:14:25 | access to indexer | semmle.label | successor |
+| AccessorCalls.cs:15:9:15:12 | this access | AccessorCalls.cs:15:9:15:18 | access to event Event | semmle.label | successor |
+| AccessorCalls.cs:15:9:15:18 | access to event Event | AccessorCalls.cs:15:23:15:23 | access to parameter e | semmle.label | successor |
+| AccessorCalls.cs:15:9:15:23 | ... += ... | AccessorCalls.cs:16:9:16:24 | ...; | semmle.label | successor |
+| AccessorCalls.cs:15:9:15:24 | ...; | AccessorCalls.cs:15:9:15:12 | this access | semmle.label | successor |
+| AccessorCalls.cs:15:23:15:23 | access to parameter e | AccessorCalls.cs:15:9:15:23 | ... += ... | semmle.label | successor |
+| AccessorCalls.cs:16:9:16:12 | this access | AccessorCalls.cs:16:9:16:18 | access to event Event | semmle.label | successor |
+| AccessorCalls.cs:16:9:16:18 | access to event Event | AccessorCalls.cs:16:23:16:23 | access to parameter e | semmle.label | successor |
+| AccessorCalls.cs:16:9:16:24 | ...; | AccessorCalls.cs:16:9:16:12 | this access | semmle.label | successor |
+| AccessorCalls.cs:16:23:16:23 | access to parameter e | AccessorCalls.cs:16:9:16:23 | ... -= ... | semmle.label | successor |
+| AccessorCalls.cs:20:5:26:5 | {...} | AccessorCalls.cs:21:9:21:36 | ...; | semmle.label | successor |
+| AccessorCalls.cs:21:9:21:12 | this access | AccessorCalls.cs:21:9:21:14 | access to field x | semmle.label | successor |
+| AccessorCalls.cs:21:9:21:14 | access to field x | AccessorCalls.cs:21:9:21:20 | access to field Field | semmle.label | successor |
+| AccessorCalls.cs:21:9:21:20 | access to field Field | AccessorCalls.cs:21:24:21:27 | this access | semmle.label | successor |
+| AccessorCalls.cs:21:9:21:35 | ... = ... | AccessorCalls.cs:22:9:22:34 | ...; | semmle.label | successor |
+| AccessorCalls.cs:21:9:21:36 | ...; | AccessorCalls.cs:21:9:21:12 | this access | semmle.label | successor |
+| AccessorCalls.cs:21:24:21:27 | this access | AccessorCalls.cs:21:24:21:29 | access to field x | semmle.label | successor |
+| AccessorCalls.cs:21:24:21:29 | access to field x | AccessorCalls.cs:21:24:21:35 | access to field Field | semmle.label | successor |
+| AccessorCalls.cs:21:24:21:35 | access to field Field | AccessorCalls.cs:21:9:21:35 | ... = ... | semmle.label | successor |
+| AccessorCalls.cs:22:9:22:12 | this access | AccessorCalls.cs:22:9:22:14 | access to field x | semmle.label | successor |
+| AccessorCalls.cs:22:9:22:14 | access to field x | AccessorCalls.cs:22:9:22:19 | access to property Prop | semmle.label | successor |
+| AccessorCalls.cs:22:9:22:19 | access to property Prop | AccessorCalls.cs:22:23:22:26 | this access | semmle.label | successor |
+| AccessorCalls.cs:22:9:22:33 | ... = ... | AccessorCalls.cs:23:9:23:30 | ...; | semmle.label | successor |
+| AccessorCalls.cs:22:9:22:34 | ...; | AccessorCalls.cs:22:9:22:12 | this access | semmle.label | successor |
+| AccessorCalls.cs:22:23:22:26 | this access | AccessorCalls.cs:22:23:22:28 | access to field x | semmle.label | successor |
+| AccessorCalls.cs:22:23:22:28 | access to field x | AccessorCalls.cs:22:23:22:33 | access to property Prop | semmle.label | successor |
+| AccessorCalls.cs:22:23:22:33 | access to property Prop | AccessorCalls.cs:22:9:22:33 | ... = ... | semmle.label | successor |
+| AccessorCalls.cs:23:9:23:12 | this access | AccessorCalls.cs:23:9:23:14 | access to field x | semmle.label | successor |
+| AccessorCalls.cs:23:9:23:14 | access to field x | AccessorCalls.cs:23:16:23:16 | 0 | semmle.label | successor |
+| AccessorCalls.cs:23:9:23:17 | access to indexer | AccessorCalls.cs:23:21:23:24 | this access | semmle.label | successor |
+| AccessorCalls.cs:23:9:23:29 | ... = ... | AccessorCalls.cs:24:9:24:26 | ...; | semmle.label | successor |
+| AccessorCalls.cs:23:9:23:30 | ...; | AccessorCalls.cs:23:9:23:12 | this access | semmle.label | successor |
+| AccessorCalls.cs:23:16:23:16 | 0 | AccessorCalls.cs:23:9:23:17 | access to indexer | semmle.label | successor |
+| AccessorCalls.cs:23:21:23:24 | this access | AccessorCalls.cs:23:21:23:26 | access to field x | semmle.label | successor |
+| AccessorCalls.cs:23:21:23:26 | access to field x | AccessorCalls.cs:23:28:23:28 | 1 | semmle.label | successor |
+| AccessorCalls.cs:23:21:23:29 | access to indexer | AccessorCalls.cs:23:9:23:29 | ... = ... | semmle.label | successor |
+| AccessorCalls.cs:23:28:23:28 | 1 | AccessorCalls.cs:23:21:23:29 | access to indexer | semmle.label | successor |
+| AccessorCalls.cs:24:9:24:12 | this access | AccessorCalls.cs:24:9:24:14 | access to field x | semmle.label | successor |
+| AccessorCalls.cs:24:9:24:14 | access to field x | AccessorCalls.cs:24:9:24:20 | access to event Event | semmle.label | successor |
+| AccessorCalls.cs:24:9:24:20 | access to event Event | AccessorCalls.cs:24:25:24:25 | access to parameter e | semmle.label | successor |
+| AccessorCalls.cs:24:9:24:25 | ... += ... | AccessorCalls.cs:25:9:25:26 | ...; | semmle.label | successor |
+| AccessorCalls.cs:24:9:24:26 | ...; | AccessorCalls.cs:24:9:24:12 | this access | semmle.label | successor |
+| AccessorCalls.cs:24:25:24:25 | access to parameter e | AccessorCalls.cs:24:9:24:25 | ... += ... | semmle.label | successor |
+| AccessorCalls.cs:25:9:25:12 | this access | AccessorCalls.cs:25:9:25:14 | access to field x | semmle.label | successor |
+| AccessorCalls.cs:25:9:25:14 | access to field x | AccessorCalls.cs:25:9:25:20 | access to event Event | semmle.label | successor |
+| AccessorCalls.cs:25:9:25:20 | access to event Event | AccessorCalls.cs:25:25:25:25 | access to parameter e | semmle.label | successor |
+| AccessorCalls.cs:25:9:25:26 | ...; | AccessorCalls.cs:25:9:25:12 | this access | semmle.label | successor |
+| AccessorCalls.cs:25:25:25:25 | access to parameter e | AccessorCalls.cs:25:9:25:25 | ... -= ... | semmle.label | successor |
+| AccessorCalls.cs:29:5:33:5 | {...} | AccessorCalls.cs:30:9:30:21 | ...; | semmle.label | successor |
+| AccessorCalls.cs:30:9:30:12 | this access | AccessorCalls.cs:30:9:30:18 | access to field Field | semmle.label | successor |
+| AccessorCalls.cs:30:9:30:18 | access to field Field | AccessorCalls.cs:30:9:30:20 | ...++ | semmle.label | successor |
+| AccessorCalls.cs:30:9:30:20 | ...++ | AccessorCalls.cs:31:9:31:20 | ...; | semmle.label | successor |
+| AccessorCalls.cs:30:9:30:21 | ...; | AccessorCalls.cs:30:9:30:12 | this access | semmle.label | successor |
+| AccessorCalls.cs:31:9:31:12 | this access | AccessorCalls.cs:31:9:31:17 | access to property Prop | semmle.label | successor |
+| AccessorCalls.cs:31:9:31:17 | access to property Prop | AccessorCalls.cs:31:9:31:19 | ...++ | semmle.label | successor |
+| AccessorCalls.cs:31:9:31:19 | ...++ | AccessorCalls.cs:32:9:32:18 | ...; | semmle.label | successor |
+| AccessorCalls.cs:31:9:31:20 | ...; | AccessorCalls.cs:31:9:31:12 | this access | semmle.label | successor |
+| AccessorCalls.cs:32:9:32:12 | this access | AccessorCalls.cs:32:14:32:14 | 0 | semmle.label | successor |
+| AccessorCalls.cs:32:9:32:15 | access to indexer | AccessorCalls.cs:32:9:32:17 | ...++ | semmle.label | successor |
+| AccessorCalls.cs:32:9:32:18 | ...; | AccessorCalls.cs:32:9:32:12 | this access | semmle.label | successor |
+| AccessorCalls.cs:32:14:32:14 | 0 | AccessorCalls.cs:32:9:32:15 | access to indexer | semmle.label | successor |
+| AccessorCalls.cs:36:5:40:5 | {...} | AccessorCalls.cs:37:9:37:23 | ...; | semmle.label | successor |
+| AccessorCalls.cs:37:9:37:12 | this access | AccessorCalls.cs:37:9:37:14 | access to field x | semmle.label | successor |
+| AccessorCalls.cs:37:9:37:14 | access to field x | AccessorCalls.cs:37:9:37:20 | access to field Field | semmle.label | successor |
+| AccessorCalls.cs:37:9:37:20 | access to field Field | AccessorCalls.cs:37:9:37:22 | ...++ | semmle.label | successor |
+| AccessorCalls.cs:37:9:37:22 | ...++ | AccessorCalls.cs:38:9:38:22 | ...; | semmle.label | successor |
+| AccessorCalls.cs:37:9:37:23 | ...; | AccessorCalls.cs:37:9:37:12 | this access | semmle.label | successor |
+| AccessorCalls.cs:38:9:38:12 | this access | AccessorCalls.cs:38:9:38:14 | access to field x | semmle.label | successor |
+| AccessorCalls.cs:38:9:38:14 | access to field x | AccessorCalls.cs:38:9:38:19 | access to property Prop | semmle.label | successor |
+| AccessorCalls.cs:38:9:38:19 | access to property Prop | AccessorCalls.cs:38:9:38:21 | ...++ | semmle.label | successor |
+| AccessorCalls.cs:38:9:38:21 | ...++ | AccessorCalls.cs:39:9:39:20 | ...; | semmle.label | successor |
+| AccessorCalls.cs:38:9:38:22 | ...; | AccessorCalls.cs:38:9:38:12 | this access | semmle.label | successor |
+| AccessorCalls.cs:39:9:39:12 | this access | AccessorCalls.cs:39:9:39:14 | access to field x | semmle.label | successor |
+| AccessorCalls.cs:39:9:39:14 | access to field x | AccessorCalls.cs:39:16:39:16 | 0 | semmle.label | successor |
+| AccessorCalls.cs:39:9:39:17 | access to indexer | AccessorCalls.cs:39:9:39:19 | ...++ | semmle.label | successor |
+| AccessorCalls.cs:39:9:39:20 | ...; | AccessorCalls.cs:39:9:39:12 | this access | semmle.label | successor |
+| AccessorCalls.cs:39:16:39:16 | 0 | AccessorCalls.cs:39:9:39:17 | access to indexer | semmle.label | successor |
+| AccessorCalls.cs:43:5:47:5 | {...} | AccessorCalls.cs:44:9:44:33 | ...; | semmle.label | successor |
+| AccessorCalls.cs:44:9:44:12 | this access | AccessorCalls.cs:44:9:44:18 | access to field Field | semmle.label | successor |
+| AccessorCalls.cs:44:9:44:12 | this access | AccessorCalls.cs:44:9:44:18 | access to field Field | semmle.label | successor |
+| AccessorCalls.cs:44:9:44:18 | access to field Field | AccessorCalls.cs:44:9:44:12 | this access | semmle.label | successor |
+| AccessorCalls.cs:44:9:44:18 | access to field Field | AccessorCalls.cs:44:23:44:26 | this access | semmle.label | successor |
+| AccessorCalls.cs:44:9:44:32 | ... + ... | AccessorCalls.cs:44:9:44:32 | ... = ... | semmle.label | successor |
+| AccessorCalls.cs:44:9:44:32 | ... = ... | AccessorCalls.cs:45:9:45:31 | ...; | semmle.label | successor |
+| AccessorCalls.cs:44:9:44:33 | ...; | AccessorCalls.cs:44:9:44:12 | this access | semmle.label | successor |
+| AccessorCalls.cs:44:23:44:26 | this access | AccessorCalls.cs:44:23:44:32 | access to field Field | semmle.label | successor |
+| AccessorCalls.cs:44:23:44:32 | access to field Field | AccessorCalls.cs:44:9:44:32 | ... + ... | semmle.label | successor |
+| AccessorCalls.cs:45:9:45:12 | this access | AccessorCalls.cs:45:9:45:17 | access to property Prop | semmle.label | successor |
+| AccessorCalls.cs:45:9:45:12 | this access | AccessorCalls.cs:45:9:45:17 | access to property Prop | semmle.label | successor |
+| AccessorCalls.cs:45:9:45:17 | access to property Prop | AccessorCalls.cs:45:9:45:12 | this access | semmle.label | successor |
+| AccessorCalls.cs:45:9:45:17 | access to property Prop | AccessorCalls.cs:45:22:45:25 | this access | semmle.label | successor |
+| AccessorCalls.cs:45:9:45:30 | ... + ... | AccessorCalls.cs:45:9:45:30 | ... = ... | semmle.label | successor |
+| AccessorCalls.cs:45:9:45:30 | ... = ... | AccessorCalls.cs:46:9:46:27 | ...; | semmle.label | successor |
+| AccessorCalls.cs:45:9:45:31 | ...; | AccessorCalls.cs:45:9:45:12 | this access | semmle.label | successor |
+| AccessorCalls.cs:45:22:45:25 | this access | AccessorCalls.cs:45:22:45:30 | access to property Prop | semmle.label | successor |
+| AccessorCalls.cs:45:22:45:30 | access to property Prop | AccessorCalls.cs:45:9:45:30 | ... + ... | semmle.label | successor |
+| AccessorCalls.cs:46:9:46:12 | this access | AccessorCalls.cs:46:14:46:14 | 0 | semmle.label | successor |
+| AccessorCalls.cs:46:9:46:12 | this access | AccessorCalls.cs:46:14:46:14 | 0 | semmle.label | successor |
+| AccessorCalls.cs:46:9:46:15 | access to indexer | AccessorCalls.cs:46:9:46:12 | this access | semmle.label | successor |
+| AccessorCalls.cs:46:9:46:15 | access to indexer | AccessorCalls.cs:46:20:46:23 | this access | semmle.label | successor |
+| AccessorCalls.cs:46:9:46:26 | ... + ... | AccessorCalls.cs:46:9:46:26 | ... = ... | semmle.label | successor |
+| AccessorCalls.cs:46:9:46:27 | ...; | AccessorCalls.cs:46:9:46:12 | this access | semmle.label | successor |
+| AccessorCalls.cs:46:14:46:14 | 0 | AccessorCalls.cs:46:9:46:15 | access to indexer | semmle.label | successor |
+| AccessorCalls.cs:46:14:46:14 | 0 | AccessorCalls.cs:46:9:46:15 | access to indexer | semmle.label | successor |
+| AccessorCalls.cs:46:20:46:23 | this access | AccessorCalls.cs:46:25:46:25 | 0 | semmle.label | successor |
+| AccessorCalls.cs:46:20:46:26 | access to indexer | AccessorCalls.cs:46:9:46:26 | ... + ... | semmle.label | successor |
+| AccessorCalls.cs:46:25:46:25 | 0 | AccessorCalls.cs:46:20:46:26 | access to indexer | semmle.label | successor |
+| AccessorCalls.cs:50:5:54:5 | {...} | AccessorCalls.cs:51:9:51:37 | ...; | semmle.label | successor |
+| AccessorCalls.cs:51:9:51:12 | this access | AccessorCalls.cs:51:9:51:14 | access to field x | semmle.label | successor |
+| AccessorCalls.cs:51:9:51:12 | this access | AccessorCalls.cs:51:9:51:14 | access to field x | semmle.label | successor |
+| AccessorCalls.cs:51:9:51:14 | access to field x | AccessorCalls.cs:51:9:51:20 | access to field Field | semmle.label | successor |
+| AccessorCalls.cs:51:9:51:14 | access to field x | AccessorCalls.cs:51:9:51:20 | access to field Field | semmle.label | successor |
+| AccessorCalls.cs:51:9:51:20 | access to field Field | AccessorCalls.cs:51:9:51:12 | this access | semmle.label | successor |
+| AccessorCalls.cs:51:9:51:20 | access to field Field | AccessorCalls.cs:51:25:51:28 | this access | semmle.label | successor |
+| AccessorCalls.cs:51:9:51:36 | ... + ... | AccessorCalls.cs:51:9:51:36 | ... = ... | semmle.label | successor |
+| AccessorCalls.cs:51:9:51:36 | ... = ... | AccessorCalls.cs:52:9:52:35 | ...; | semmle.label | successor |
+| AccessorCalls.cs:51:9:51:37 | ...; | AccessorCalls.cs:51:9:51:12 | this access | semmle.label | successor |
+| AccessorCalls.cs:51:25:51:28 | this access | AccessorCalls.cs:51:25:51:30 | access to field x | semmle.label | successor |
+| AccessorCalls.cs:51:25:51:30 | access to field x | AccessorCalls.cs:51:25:51:36 | access to field Field | semmle.label | successor |
+| AccessorCalls.cs:51:25:51:36 | access to field Field | AccessorCalls.cs:51:9:51:36 | ... + ... | semmle.label | successor |
+| AccessorCalls.cs:52:9:52:12 | this access | AccessorCalls.cs:52:9:52:14 | access to field x | semmle.label | successor |
+| AccessorCalls.cs:52:9:52:12 | this access | AccessorCalls.cs:52:9:52:14 | access to field x | semmle.label | successor |
+| AccessorCalls.cs:52:9:52:14 | access to field x | AccessorCalls.cs:52:9:52:19 | access to property Prop | semmle.label | successor |
+| AccessorCalls.cs:52:9:52:14 | access to field x | AccessorCalls.cs:52:9:52:19 | access to property Prop | semmle.label | successor |
+| AccessorCalls.cs:52:9:52:19 | access to property Prop | AccessorCalls.cs:52:9:52:12 | this access | semmle.label | successor |
+| AccessorCalls.cs:52:9:52:19 | access to property Prop | AccessorCalls.cs:52:24:52:27 | this access | semmle.label | successor |
+| AccessorCalls.cs:52:9:52:34 | ... + ... | AccessorCalls.cs:52:9:52:34 | ... = ... | semmle.label | successor |
+| AccessorCalls.cs:52:9:52:34 | ... = ... | AccessorCalls.cs:53:9:53:31 | ...; | semmle.label | successor |
+| AccessorCalls.cs:52:9:52:35 | ...; | AccessorCalls.cs:52:9:52:12 | this access | semmle.label | successor |
+| AccessorCalls.cs:52:24:52:27 | this access | AccessorCalls.cs:52:24:52:29 | access to field x | semmle.label | successor |
+| AccessorCalls.cs:52:24:52:29 | access to field x | AccessorCalls.cs:52:24:52:34 | access to property Prop | semmle.label | successor |
+| AccessorCalls.cs:52:24:52:34 | access to property Prop | AccessorCalls.cs:52:9:52:34 | ... + ... | semmle.label | successor |
+| AccessorCalls.cs:53:9:53:12 | this access | AccessorCalls.cs:53:9:53:14 | access to field x | semmle.label | successor |
+| AccessorCalls.cs:53:9:53:12 | this access | AccessorCalls.cs:53:9:53:14 | access to field x | semmle.label | successor |
+| AccessorCalls.cs:53:9:53:14 | access to field x | AccessorCalls.cs:53:16:53:16 | 0 | semmle.label | successor |
+| AccessorCalls.cs:53:9:53:14 | access to field x | AccessorCalls.cs:53:16:53:16 | 0 | semmle.label | successor |
+| AccessorCalls.cs:53:9:53:17 | access to indexer | AccessorCalls.cs:53:9:53:12 | this access | semmle.label | successor |
+| AccessorCalls.cs:53:9:53:17 | access to indexer | AccessorCalls.cs:53:22:53:25 | this access | semmle.label | successor |
+| AccessorCalls.cs:53:9:53:30 | ... + ... | AccessorCalls.cs:53:9:53:30 | ... = ... | semmle.label | successor |
+| AccessorCalls.cs:53:9:53:31 | ...; | AccessorCalls.cs:53:9:53:12 | this access | semmle.label | successor |
+| AccessorCalls.cs:53:16:53:16 | 0 | AccessorCalls.cs:53:9:53:17 | access to indexer | semmle.label | successor |
+| AccessorCalls.cs:53:16:53:16 | 0 | AccessorCalls.cs:53:9:53:17 | access to indexer | semmle.label | successor |
+| AccessorCalls.cs:53:22:53:25 | this access | AccessorCalls.cs:53:22:53:27 | access to field x | semmle.label | successor |
+| AccessorCalls.cs:53:22:53:27 | access to field x | AccessorCalls.cs:53:29:53:29 | 0 | semmle.label | successor |
+| AccessorCalls.cs:53:22:53:30 | access to indexer | AccessorCalls.cs:53:9:53:30 | ... + ... | semmle.label | successor |
+| AccessorCalls.cs:53:29:53:29 | 0 | AccessorCalls.cs:53:22:53:30 | access to indexer | semmle.label | successor |
+| AccessorCalls.cs:57:5:59:5 | {...} | AccessorCalls.cs:58:9:58:86 | ...; | semmle.label | successor |
+| AccessorCalls.cs:58:9:58:45 | (..., ...) | AccessorCalls.cs:58:50:58:53 | this access | semmle.label | successor |
+| AccessorCalls.cs:58:9:58:86 | ...; | AccessorCalls.cs:58:10:58:13 | this access | semmle.label | successor |
+| AccessorCalls.cs:58:10:58:13 | this access | AccessorCalls.cs:58:10:58:19 | access to field Field | semmle.label | successor |
+| AccessorCalls.cs:58:10:58:19 | access to field Field | AccessorCalls.cs:58:22:58:25 | this access | semmle.label | successor |
+| AccessorCalls.cs:58:22:58:25 | this access | AccessorCalls.cs:58:22:58:30 | access to property Prop | semmle.label | successor |
+| AccessorCalls.cs:58:22:58:30 | access to property Prop | AccessorCalls.cs:58:34:58:34 | access to parameter i | semmle.label | successor |
+| AccessorCalls.cs:58:33:58:44 | (..., ...) | AccessorCalls.cs:58:9:58:45 | (..., ...) | semmle.label | successor |
+| AccessorCalls.cs:58:34:58:34 | access to parameter i | AccessorCalls.cs:58:37:58:40 | this access | semmle.label | successor |
+| AccessorCalls.cs:58:37:58:40 | this access | AccessorCalls.cs:58:42:58:42 | 0 | semmle.label | successor |
+| AccessorCalls.cs:58:37:58:43 | access to indexer | AccessorCalls.cs:58:33:58:44 | (..., ...) | semmle.label | successor |
+| AccessorCalls.cs:58:42:58:42 | 0 | AccessorCalls.cs:58:37:58:43 | access to indexer | semmle.label | successor |
+| AccessorCalls.cs:58:49:58:85 | (..., ...) | AccessorCalls.cs:58:9:58:85 | ... = ... | semmle.label | successor |
+| AccessorCalls.cs:58:50:58:53 | this access | AccessorCalls.cs:58:50:58:59 | access to field Field | semmle.label | successor |
+| AccessorCalls.cs:58:50:58:59 | access to field Field | AccessorCalls.cs:58:62:58:65 | this access | semmle.label | successor |
+| AccessorCalls.cs:58:62:58:65 | this access | AccessorCalls.cs:58:62:58:70 | access to property Prop | semmle.label | successor |
+| AccessorCalls.cs:58:62:58:70 | access to property Prop | AccessorCalls.cs:58:74:58:74 | 0 | semmle.label | successor |
+| AccessorCalls.cs:58:73:58:84 | (..., ...) | AccessorCalls.cs:58:49:58:85 | (..., ...) | semmle.label | successor |
+| AccessorCalls.cs:58:74:58:74 | 0 | AccessorCalls.cs:58:77:58:80 | this access | semmle.label | successor |
+| AccessorCalls.cs:58:77:58:80 | this access | AccessorCalls.cs:58:82:58:82 | 1 | semmle.label | successor |
+| AccessorCalls.cs:58:77:58:83 | access to indexer | AccessorCalls.cs:58:73:58:84 | (..., ...) | semmle.label | successor |
+| AccessorCalls.cs:58:82:58:82 | 1 | AccessorCalls.cs:58:77:58:83 | access to indexer | semmle.label | successor |
+| AccessorCalls.cs:62:5:64:5 | {...} | AccessorCalls.cs:63:9:63:98 | ...; | semmle.label | successor |
+| AccessorCalls.cs:63:9:63:51 | (..., ...) | AccessorCalls.cs:63:56:63:59 | this access | semmle.label | successor |
+| AccessorCalls.cs:63:9:63:98 | ...; | AccessorCalls.cs:63:10:63:13 | this access | semmle.label | successor |
+| AccessorCalls.cs:63:10:63:13 | this access | AccessorCalls.cs:63:10:63:15 | access to field x | semmle.label | successor |
+| AccessorCalls.cs:63:10:63:15 | access to field x | AccessorCalls.cs:63:10:63:21 | access to field Field | semmle.label | successor |
+| AccessorCalls.cs:63:10:63:21 | access to field Field | AccessorCalls.cs:63:24:63:27 | this access | semmle.label | successor |
+| AccessorCalls.cs:63:24:63:27 | this access | AccessorCalls.cs:63:24:63:29 | access to field x | semmle.label | successor |
+| AccessorCalls.cs:63:24:63:29 | access to field x | AccessorCalls.cs:63:24:63:34 | access to property Prop | semmle.label | successor |
+| AccessorCalls.cs:63:24:63:34 | access to property Prop | AccessorCalls.cs:63:38:63:38 | access to parameter i | semmle.label | successor |
+| AccessorCalls.cs:63:37:63:50 | (..., ...) | AccessorCalls.cs:63:9:63:51 | (..., ...) | semmle.label | successor |
+| AccessorCalls.cs:63:38:63:38 | access to parameter i | AccessorCalls.cs:63:41:63:44 | this access | semmle.label | successor |
+| AccessorCalls.cs:63:41:63:44 | this access | AccessorCalls.cs:63:41:63:46 | access to field x | semmle.label | successor |
+| AccessorCalls.cs:63:41:63:46 | access to field x | AccessorCalls.cs:63:48:63:48 | 0 | semmle.label | successor |
+| AccessorCalls.cs:63:41:63:49 | access to indexer | AccessorCalls.cs:63:37:63:50 | (..., ...) | semmle.label | successor |
+| AccessorCalls.cs:63:48:63:48 | 0 | AccessorCalls.cs:63:41:63:49 | access to indexer | semmle.label | successor |
+| AccessorCalls.cs:63:55:63:97 | (..., ...) | AccessorCalls.cs:63:9:63:97 | ... = ... | semmle.label | successor |
+| AccessorCalls.cs:63:56:63:59 | this access | AccessorCalls.cs:63:56:63:61 | access to field x | semmle.label | successor |
+| AccessorCalls.cs:63:56:63:61 | access to field x | AccessorCalls.cs:63:56:63:67 | access to field Field | semmle.label | successor |
+| AccessorCalls.cs:63:56:63:67 | access to field Field | AccessorCalls.cs:63:70:63:73 | this access | semmle.label | successor |
+| AccessorCalls.cs:63:70:63:73 | this access | AccessorCalls.cs:63:70:63:75 | access to field x | semmle.label | successor |
+| AccessorCalls.cs:63:70:63:75 | access to field x | AccessorCalls.cs:63:70:63:80 | access to property Prop | semmle.label | successor |
+| AccessorCalls.cs:63:70:63:80 | access to property Prop | AccessorCalls.cs:63:84:63:84 | 0 | semmle.label | successor |
+| AccessorCalls.cs:63:83:63:96 | (..., ...) | AccessorCalls.cs:63:55:63:97 | (..., ...) | semmle.label | successor |
+| AccessorCalls.cs:63:84:63:84 | 0 | AccessorCalls.cs:63:87:63:90 | this access | semmle.label | successor |
+| AccessorCalls.cs:63:87:63:90 | this access | AccessorCalls.cs:63:87:63:92 | access to field x | semmle.label | successor |
+| AccessorCalls.cs:63:87:63:92 | access to field x | AccessorCalls.cs:63:94:63:94 | 1 | semmle.label | successor |
+| AccessorCalls.cs:63:87:63:95 | access to indexer | AccessorCalls.cs:63:83:63:96 | (..., ...) | semmle.label | successor |
+| AccessorCalls.cs:63:94:63:94 | 1 | AccessorCalls.cs:63:87:63:95 | access to indexer | semmle.label | successor |
 | ArrayCreation.cs:3:27:3:27 | 0 | ArrayCreation.cs:3:19:3:28 | array creation of type Int32[] | semmle.label | successor |
 | ArrayCreation.cs:5:28:5:28 | 0 | ArrayCreation.cs:5:31:5:31 | 1 | semmle.label | successor |
 | ArrayCreation.cs:5:31:5:31 | 1 | ArrayCreation.cs:5:20:5:32 | array creation of type Int32[,] | semmle.label | successor |

--- a/csharp/ql/test/library-tests/controlflow/graph/EntryElement.expected
+++ b/csharp/ql/test/library-tests/controlflow/graph/EntryElement.expected
@@ -188,8 +188,7 @@
 | AccessorCalls.cs:58:10:58:19 | access to field Field | AccessorCalls.cs:58:10:58:13 | this access |
 | AccessorCalls.cs:58:22:58:25 | this access | AccessorCalls.cs:58:22:58:25 | this access |
 | AccessorCalls.cs:58:22:58:30 | access to property Prop | AccessorCalls.cs:58:22:58:25 | this access |
-| AccessorCalls.cs:58:33:58:44 | (..., ...) | AccessorCalls.cs:58:34:58:34 | access to parameter i |
-| AccessorCalls.cs:58:34:58:34 | access to parameter i | AccessorCalls.cs:58:34:58:34 | access to parameter i |
+| AccessorCalls.cs:58:33:58:44 | (..., ...) | AccessorCalls.cs:58:37:58:40 | this access |
 | AccessorCalls.cs:58:37:58:40 | this access | AccessorCalls.cs:58:37:58:40 | this access |
 | AccessorCalls.cs:58:37:58:43 | access to indexer | AccessorCalls.cs:58:37:58:40 | this access |
 | AccessorCalls.cs:58:42:58:42 | 0 | AccessorCalls.cs:58:42:58:42 | 0 |
@@ -213,8 +212,7 @@
 | AccessorCalls.cs:63:24:63:27 | this access | AccessorCalls.cs:63:24:63:27 | this access |
 | AccessorCalls.cs:63:24:63:29 | access to field x | AccessorCalls.cs:63:24:63:27 | this access |
 | AccessorCalls.cs:63:24:63:34 | access to property Prop | AccessorCalls.cs:63:24:63:27 | this access |
-| AccessorCalls.cs:63:37:63:50 | (..., ...) | AccessorCalls.cs:63:38:63:38 | access to parameter i |
-| AccessorCalls.cs:63:38:63:38 | access to parameter i | AccessorCalls.cs:63:38:63:38 | access to parameter i |
+| AccessorCalls.cs:63:37:63:50 | (..., ...) | AccessorCalls.cs:63:41:63:44 | this access |
 | AccessorCalls.cs:63:41:63:44 | this access | AccessorCalls.cs:63:41:63:44 | this access |
 | AccessorCalls.cs:63:41:63:46 | access to field x | AccessorCalls.cs:63:41:63:44 | this access |
 | AccessorCalls.cs:63:41:63:49 | access to indexer | AccessorCalls.cs:63:41:63:44 | this access |
@@ -254,10 +252,8 @@
 | ArrayCreation.cs:9:48:9:48 | 3 | ArrayCreation.cs:9:48:9:48 | 3 |
 | Assignments.cs:4:5:15:5 | {...} | Assignments.cs:4:5:15:5 | {...} |
 | Assignments.cs:5:9:5:18 | ... ...; | Assignments.cs:5:9:5:18 | ... ...; |
-| Assignments.cs:5:13:5:13 | access to local variable x | Assignments.cs:5:13:5:13 | access to local variable x |
-| Assignments.cs:5:13:5:17 | Int32 x = ... | Assignments.cs:5:13:5:13 | access to local variable x |
+| Assignments.cs:5:13:5:17 | Int32 x = ... | Assignments.cs:5:17:5:17 | 0 |
 | Assignments.cs:5:17:5:17 | 0 | Assignments.cs:5:17:5:17 | 0 |
-| Assignments.cs:6:9:6:9 | access to local variable x | Assignments.cs:6:9:6:9 | access to local variable x |
 | Assignments.cs:6:9:6:9 | access to local variable x | Assignments.cs:6:9:6:9 | access to local variable x |
 | Assignments.cs:6:9:6:14 | ... + ... | Assignments.cs:6:9:6:9 | access to local variable x |
 | Assignments.cs:6:9:6:14 | ... += ... | Assignments.cs:6:9:6:9 | access to local variable x |
@@ -265,11 +261,9 @@
 | Assignments.cs:6:9:6:15 | ...; | Assignments.cs:6:9:6:15 | ...; |
 | Assignments.cs:6:14:6:14 | 1 | Assignments.cs:6:14:6:14 | 1 |
 | Assignments.cs:8:9:8:22 | ... ...; | Assignments.cs:8:9:8:22 | ... ...; |
-| Assignments.cs:8:17:8:17 | access to local variable d | Assignments.cs:8:17:8:17 | access to local variable d |
-| Assignments.cs:8:17:8:21 | dynamic d = ... | Assignments.cs:8:17:8:17 | access to local variable d |
+| Assignments.cs:8:17:8:21 | dynamic d = ... | Assignments.cs:8:21:8:21 | 0 |
 | Assignments.cs:8:21:8:21 | 0 | Assignments.cs:8:21:8:21 | 0 |
 | Assignments.cs:8:21:8:21 | (...) ... | Assignments.cs:8:21:8:21 | 0 |
-| Assignments.cs:9:9:9:9 | access to local variable d | Assignments.cs:9:9:9:9 | access to local variable d |
 | Assignments.cs:9:9:9:9 | access to local variable d | Assignments.cs:9:9:9:9 | access to local variable d |
 | Assignments.cs:9:9:9:14 | ... -= ... | Assignments.cs:9:9:9:9 | access to local variable d |
 | Assignments.cs:9:9:9:14 | ... = ... | Assignments.cs:9:9:9:9 | access to local variable d |
@@ -277,10 +271,8 @@
 | Assignments.cs:9:9:9:15 | ...; | Assignments.cs:9:9:9:15 | ...; |
 | Assignments.cs:9:14:9:14 | 2 | Assignments.cs:9:14:9:14 | 2 |
 | Assignments.cs:11:9:11:34 | ... ...; | Assignments.cs:11:9:11:34 | ... ...; |
-| Assignments.cs:11:13:11:13 | access to local variable a | Assignments.cs:11:13:11:13 | access to local variable a |
-| Assignments.cs:11:13:11:33 | Assignments a = ... | Assignments.cs:11:13:11:13 | access to local variable a |
+| Assignments.cs:11:13:11:33 | Assignments a = ... | Assignments.cs:11:17:11:33 | object creation of type Assignments |
 | Assignments.cs:11:17:11:33 | object creation of type Assignments | Assignments.cs:11:17:11:33 | object creation of type Assignments |
-| Assignments.cs:12:9:12:9 | access to local variable a | Assignments.cs:12:9:12:9 | access to local variable a |
 | Assignments.cs:12:9:12:9 | access to local variable a | Assignments.cs:12:9:12:9 | access to local variable a |
 | Assignments.cs:12:9:12:17 | ... += ... | Assignments.cs:12:9:12:9 | access to local variable a |
 | Assignments.cs:12:9:12:17 | ... = ... | Assignments.cs:12:9:12:9 | access to local variable a |
@@ -467,19 +459,16 @@
 | ConditionalAccess.cs:19:58:19:59 | access to parameter s2 | ConditionalAccess.cs:19:58:19:59 | access to parameter s2 |
 | ConditionalAccess.cs:22:5:26:5 | {...} | ConditionalAccess.cs:22:5:26:5 | {...} |
 | ConditionalAccess.cs:23:9:23:39 | ... ...; | ConditionalAccess.cs:23:9:23:39 | ... ...; |
-| ConditionalAccess.cs:23:13:23:13 | access to local variable j | ConditionalAccess.cs:23:13:23:13 | access to local variable j |
-| ConditionalAccess.cs:23:13:23:38 | Nullable<Int32> j = ... | ConditionalAccess.cs:23:13:23:13 | access to local variable j |
+| ConditionalAccess.cs:23:13:23:38 | Nullable<Int32> j = ... | ConditionalAccess.cs:23:26:23:29 | null |
 | ConditionalAccess.cs:23:18:23:29 | (...) ... | ConditionalAccess.cs:23:26:23:29 | null |
 | ConditionalAccess.cs:23:26:23:29 | null | ConditionalAccess.cs:23:26:23:29 | null |
 | ConditionalAccess.cs:23:32:23:38 | access to property Length | ConditionalAccess.cs:23:26:23:29 | null |
 | ConditionalAccess.cs:24:9:24:38 | ... ...; | ConditionalAccess.cs:24:9:24:38 | ... ...; |
-| ConditionalAccess.cs:24:13:24:13 | access to local variable s | ConditionalAccess.cs:24:13:24:13 | access to local variable s |
-| ConditionalAccess.cs:24:13:24:37 | String s = ... | ConditionalAccess.cs:24:13:24:13 | access to local variable s |
+| ConditionalAccess.cs:24:13:24:37 | String s = ... | ConditionalAccess.cs:24:24:24:24 | access to parameter i |
 | ConditionalAccess.cs:24:18:24:24 | (...) ... | ConditionalAccess.cs:24:24:24:24 | access to parameter i |
 | ConditionalAccess.cs:24:24:24:24 | access to parameter i | ConditionalAccess.cs:24:24:24:24 | access to parameter i |
 | ConditionalAccess.cs:24:27:24:37 | call to method ToString | ConditionalAccess.cs:24:24:24:24 | access to parameter i |
-| ConditionalAccess.cs:25:9:25:9 | access to local variable s | ConditionalAccess.cs:25:9:25:9 | access to local variable s |
-| ConditionalAccess.cs:25:9:25:32 | ... = ... | ConditionalAccess.cs:25:9:25:9 | access to local variable s |
+| ConditionalAccess.cs:25:9:25:32 | ... = ... | ConditionalAccess.cs:25:13:25:14 | "" |
 | ConditionalAccess.cs:25:9:25:33 | ...; | ConditionalAccess.cs:25:9:25:33 | ...; |
 | ConditionalAccess.cs:25:13:25:14 | "" | ConditionalAccess.cs:25:13:25:14 | "" |
 | ConditionalAccess.cs:25:16:25:32 | call to method CommaJoinWith | ConditionalAccess.cs:25:13:25:14 | "" |
@@ -503,8 +492,7 @@
 | Conditions.cs:8:13:8:16 | ...; | Conditions.cs:8:13:8:16 | ...; |
 | Conditions.cs:12:5:20:5 | {...} | Conditions.cs:12:5:20:5 | {...} |
 | Conditions.cs:13:9:13:18 | ... ...; | Conditions.cs:13:9:13:18 | ... ...; |
-| Conditions.cs:13:13:13:13 | access to local variable x | Conditions.cs:13:13:13:13 | access to local variable x |
-| Conditions.cs:13:13:13:17 | Int32 x = ... | Conditions.cs:13:13:13:13 | access to local variable x |
+| Conditions.cs:13:13:13:17 | Int32 x = ... | Conditions.cs:13:17:13:17 | 0 |
 | Conditions.cs:13:17:13:17 | 0 | Conditions.cs:13:17:13:17 | 0 |
 | Conditions.cs:14:9:15:16 | if (...) ... | Conditions.cs:14:9:15:16 | if (...) ... |
 | Conditions.cs:14:13:14:13 | access to parameter b | Conditions.cs:14:13:14:13 | access to parameter b |
@@ -525,8 +513,7 @@
 | Conditions.cs:19:16:19:16 | access to local variable x | Conditions.cs:19:16:19:16 | access to local variable x |
 | Conditions.cs:23:5:31:5 | {...} | Conditions.cs:23:5:31:5 | {...} |
 | Conditions.cs:24:9:24:18 | ... ...; | Conditions.cs:24:9:24:18 | ... ...; |
-| Conditions.cs:24:13:24:13 | access to local variable x | Conditions.cs:24:13:24:13 | access to local variable x |
-| Conditions.cs:24:13:24:17 | Int32 x = ... | Conditions.cs:24:13:24:13 | access to local variable x |
+| Conditions.cs:24:13:24:17 | Int32 x = ... | Conditions.cs:24:17:24:17 | 0 |
 | Conditions.cs:24:17:24:17 | 0 | Conditions.cs:24:17:24:17 | 0 |
 | Conditions.cs:25:9:27:20 | if (...) ... | Conditions.cs:25:9:27:20 | if (...) ... |
 | Conditions.cs:25:13:25:14 | access to parameter b1 | Conditions.cs:25:13:25:14 | access to parameter b1 |
@@ -544,17 +531,14 @@
 | Conditions.cs:30:16:30:16 | access to local variable x | Conditions.cs:30:16:30:16 | access to local variable x |
 | Conditions.cs:34:5:44:5 | {...} | Conditions.cs:34:5:44:5 | {...} |
 | Conditions.cs:35:9:35:18 | ... ...; | Conditions.cs:35:9:35:18 | ... ...; |
-| Conditions.cs:35:13:35:13 | access to local variable x | Conditions.cs:35:13:35:13 | access to local variable x |
-| Conditions.cs:35:13:35:17 | Int32 x = ... | Conditions.cs:35:13:35:13 | access to local variable x |
+| Conditions.cs:35:13:35:17 | Int32 x = ... | Conditions.cs:35:17:35:17 | 0 |
 | Conditions.cs:35:17:35:17 | 0 | Conditions.cs:35:17:35:17 | 0 |
 | Conditions.cs:36:9:36:23 | ... ...; | Conditions.cs:36:9:36:23 | ... ...; |
-| Conditions.cs:36:13:36:14 | access to local variable b2 | Conditions.cs:36:13:36:14 | access to local variable b2 |
-| Conditions.cs:36:13:36:22 | Boolean b2 = ... | Conditions.cs:36:13:36:14 | access to local variable b2 |
+| Conditions.cs:36:13:36:22 | Boolean b2 = ... | Conditions.cs:36:18:36:22 | false |
 | Conditions.cs:36:18:36:22 | false | Conditions.cs:36:18:36:22 | false |
 | Conditions.cs:37:9:38:20 | if (...) ... | Conditions.cs:37:9:38:20 | if (...) ... |
 | Conditions.cs:37:13:37:14 | access to parameter b1 | Conditions.cs:37:13:37:14 | access to parameter b1 |
-| Conditions.cs:38:13:38:14 | access to local variable b2 | Conditions.cs:38:13:38:14 | access to local variable b2 |
-| Conditions.cs:38:13:38:19 | ... = ... | Conditions.cs:38:13:38:14 | access to local variable b2 |
+| Conditions.cs:38:13:38:19 | ... = ... | Conditions.cs:38:18:38:19 | access to parameter b1 |
 | Conditions.cs:38:13:38:20 | ...; | Conditions.cs:38:13:38:20 | ...; |
 | Conditions.cs:38:18:38:19 | access to parameter b1 | Conditions.cs:38:18:38:19 | access to parameter b1 |
 | Conditions.cs:39:9:40:16 | if (...) ... | Conditions.cs:39:9:40:16 | if (...) ... |
@@ -571,8 +555,7 @@
 | Conditions.cs:43:16:43:16 | access to local variable x | Conditions.cs:43:16:43:16 | access to local variable x |
 | Conditions.cs:47:5:55:5 | {...} | Conditions.cs:47:5:55:5 | {...} |
 | Conditions.cs:48:9:48:18 | ... ...; | Conditions.cs:48:9:48:18 | ... ...; |
-| Conditions.cs:48:13:48:13 | access to local variable y | Conditions.cs:48:13:48:13 | access to local variable y |
-| Conditions.cs:48:13:48:17 | Int32 y = ... | Conditions.cs:48:13:48:13 | access to local variable y |
+| Conditions.cs:48:13:48:17 | Int32 y = ... | Conditions.cs:48:17:48:17 | 0 |
 | Conditions.cs:48:17:48:17 | 0 | Conditions.cs:48:17:48:17 | 0 |
 | Conditions.cs:49:9:53:9 | while (...) ... | Conditions.cs:49:9:53:9 | while (...) ... |
 | Conditions.cs:49:16:49:16 | access to parameter x | Conditions.cs:49:16:49:16 | access to parameter x |
@@ -589,8 +572,7 @@
 | Conditions.cs:54:16:54:16 | access to local variable y | Conditions.cs:54:16:54:16 | access to local variable y |
 | Conditions.cs:58:5:68:5 | {...} | Conditions.cs:58:5:68:5 | {...} |
 | Conditions.cs:59:9:59:18 | ... ...; | Conditions.cs:59:9:59:18 | ... ...; |
-| Conditions.cs:59:13:59:13 | access to local variable y | Conditions.cs:59:13:59:13 | access to local variable y |
-| Conditions.cs:59:13:59:17 | Int32 y = ... | Conditions.cs:59:13:59:13 | access to local variable y |
+| Conditions.cs:59:13:59:17 | Int32 y = ... | Conditions.cs:59:17:59:17 | 0 |
 | Conditions.cs:59:17:59:17 | 0 | Conditions.cs:59:17:59:17 | 0 |
 | Conditions.cs:60:9:64:9 | while (...) ... | Conditions.cs:60:9:64:9 | while (...) ... |
 | Conditions.cs:60:16:60:16 | access to parameter x | Conditions.cs:60:16:60:16 | access to parameter x |
@@ -612,15 +594,13 @@
 | Conditions.cs:67:16:67:16 | access to local variable y | Conditions.cs:67:16:67:16 | access to local variable y |
 | Conditions.cs:71:5:84:5 | {...} | Conditions.cs:71:5:84:5 | {...} |
 | Conditions.cs:72:9:72:30 | ... ...; | Conditions.cs:72:9:72:30 | ... ...; |
-| Conditions.cs:72:13:72:13 | access to local variable b | Conditions.cs:72:13:72:13 | access to local variable b |
-| Conditions.cs:72:13:72:29 | Boolean b = ... | Conditions.cs:72:13:72:13 | access to local variable b |
+| Conditions.cs:72:13:72:29 | Boolean b = ... | Conditions.cs:72:17:72:18 | access to parameter ss |
 | Conditions.cs:72:17:72:18 | access to parameter ss | Conditions.cs:72:17:72:18 | access to parameter ss |
 | Conditions.cs:72:17:72:25 | access to property Length | Conditions.cs:72:17:72:18 | access to parameter ss |
 | Conditions.cs:72:17:72:29 | ... > ... | Conditions.cs:72:17:72:18 | access to parameter ss |
 | Conditions.cs:72:29:72:29 | 0 | Conditions.cs:72:29:72:29 | 0 |
 | Conditions.cs:73:9:73:18 | ... ...; | Conditions.cs:73:9:73:18 | ... ...; |
-| Conditions.cs:73:13:73:13 | access to local variable x | Conditions.cs:73:13:73:13 | access to local variable x |
-| Conditions.cs:73:13:73:17 | Int32 x = ... | Conditions.cs:73:13:73:13 | access to local variable x |
+| Conditions.cs:73:13:73:17 | Int32 x = ... | Conditions.cs:73:17:73:17 | 0 |
 | Conditions.cs:73:17:73:17 | 0 | Conditions.cs:73:17:73:17 | 0 |
 | Conditions.cs:74:9:80:9 | foreach (... ... in ...) ... | Conditions.cs:74:27:74:28 | access to parameter ss |
 | Conditions.cs:74:27:74:28 | access to parameter ss | Conditions.cs:74:27:74:28 | access to parameter ss |
@@ -634,8 +614,7 @@
 | Conditions.cs:78:17:78:17 | access to local variable x | Conditions.cs:78:17:78:17 | access to local variable x |
 | Conditions.cs:78:17:78:21 | ... > ... | Conditions.cs:78:17:78:17 | access to local variable x |
 | Conditions.cs:78:21:78:21 | 0 | Conditions.cs:78:21:78:21 | 0 |
-| Conditions.cs:79:17:79:17 | access to local variable b | Conditions.cs:79:17:79:17 | access to local variable b |
-| Conditions.cs:79:17:79:25 | ... = ... | Conditions.cs:79:17:79:17 | access to local variable b |
+| Conditions.cs:79:17:79:25 | ... = ... | Conditions.cs:79:21:79:25 | false |
 | Conditions.cs:79:17:79:26 | ...; | Conditions.cs:79:17:79:26 | ...; |
 | Conditions.cs:79:21:79:25 | false | Conditions.cs:79:21:79:25 | false |
 | Conditions.cs:81:9:82:16 | if (...) ... | Conditions.cs:81:9:82:16 | if (...) ... |
@@ -647,15 +626,13 @@
 | Conditions.cs:83:16:83:16 | access to local variable x | Conditions.cs:83:16:83:16 | access to local variable x |
 | Conditions.cs:87:5:100:5 | {...} | Conditions.cs:87:5:100:5 | {...} |
 | Conditions.cs:88:9:88:30 | ... ...; | Conditions.cs:88:9:88:30 | ... ...; |
-| Conditions.cs:88:13:88:13 | access to local variable b | Conditions.cs:88:13:88:13 | access to local variable b |
-| Conditions.cs:88:13:88:29 | Boolean b = ... | Conditions.cs:88:13:88:13 | access to local variable b |
+| Conditions.cs:88:13:88:29 | Boolean b = ... | Conditions.cs:88:17:88:18 | access to parameter ss |
 | Conditions.cs:88:17:88:18 | access to parameter ss | Conditions.cs:88:17:88:18 | access to parameter ss |
 | Conditions.cs:88:17:88:25 | access to property Length | Conditions.cs:88:17:88:18 | access to parameter ss |
 | Conditions.cs:88:17:88:29 | ... > ... | Conditions.cs:88:17:88:18 | access to parameter ss |
 | Conditions.cs:88:29:88:29 | 0 | Conditions.cs:88:29:88:29 | 0 |
 | Conditions.cs:89:9:89:18 | ... ...; | Conditions.cs:89:9:89:18 | ... ...; |
-| Conditions.cs:89:13:89:13 | access to local variable x | Conditions.cs:89:13:89:13 | access to local variable x |
-| Conditions.cs:89:13:89:17 | Int32 x = ... | Conditions.cs:89:13:89:13 | access to local variable x |
+| Conditions.cs:89:13:89:17 | Int32 x = ... | Conditions.cs:89:17:89:17 | 0 |
 | Conditions.cs:89:17:89:17 | 0 | Conditions.cs:89:17:89:17 | 0 |
 | Conditions.cs:90:9:98:9 | foreach (... ... in ...) ... | Conditions.cs:90:27:90:28 | access to parameter ss |
 | Conditions.cs:90:27:90:28 | access to parameter ss | Conditions.cs:90:27:90:28 | access to parameter ss |
@@ -669,8 +646,7 @@
 | Conditions.cs:94:17:94:17 | access to local variable x | Conditions.cs:94:17:94:17 | access to local variable x |
 | Conditions.cs:94:17:94:21 | ... > ... | Conditions.cs:94:17:94:17 | access to local variable x |
 | Conditions.cs:94:21:94:21 | 0 | Conditions.cs:94:21:94:21 | 0 |
-| Conditions.cs:95:17:95:17 | access to local variable b | Conditions.cs:95:17:95:17 | access to local variable b |
-| Conditions.cs:95:17:95:25 | ... = ... | Conditions.cs:95:17:95:17 | access to local variable b |
+| Conditions.cs:95:17:95:25 | ... = ... | Conditions.cs:95:21:95:25 | false |
 | Conditions.cs:95:17:95:26 | ...; | Conditions.cs:95:17:95:26 | ...; |
 | Conditions.cs:95:21:95:25 | false | Conditions.cs:95:21:95:25 | false |
 | Conditions.cs:96:13:97:20 | if (...) ... | Conditions.cs:96:13:97:20 | if (...) ... |
@@ -682,13 +658,11 @@
 | Conditions.cs:99:16:99:16 | access to local variable x | Conditions.cs:99:16:99:16 | access to local variable x |
 | Conditions.cs:103:5:111:5 | {...} | Conditions.cs:103:5:111:5 | {...} |
 | Conditions.cs:104:9:104:29 | ... ...; | Conditions.cs:104:9:104:29 | ... ...; |
-| Conditions.cs:104:13:104:13 | access to local variable x | Conditions.cs:104:13:104:13 | access to local variable x |
-| Conditions.cs:104:13:104:28 | String x = ... | Conditions.cs:104:13:104:13 | access to local variable x |
+| Conditions.cs:104:13:104:28 | String x = ... | Conditions.cs:104:17:104:17 | access to parameter b |
 | Conditions.cs:104:17:104:17 | access to parameter b | Conditions.cs:104:17:104:17 | access to parameter b |
 | Conditions.cs:104:17:104:28 | call to method ToString | Conditions.cs:104:17:104:17 | access to parameter b |
 | Conditions.cs:105:9:106:20 | if (...) ... | Conditions.cs:105:9:106:20 | if (...) ... |
 | Conditions.cs:105:13:105:13 | access to parameter b | Conditions.cs:105:13:105:13 | access to parameter b |
-| Conditions.cs:106:13:106:13 | access to local variable x | Conditions.cs:106:13:106:13 | access to local variable x |
 | Conditions.cs:106:13:106:13 | access to local variable x | Conditions.cs:106:13:106:13 | access to local variable x |
 | Conditions.cs:106:13:106:19 | ... + ... | Conditions.cs:106:13:106:13 | access to local variable x |
 | Conditions.cs:106:13:106:19 | ... += ... | Conditions.cs:106:13:106:13 | access to local variable x |
@@ -704,7 +678,6 @@
 | Conditions.cs:108:17:108:18 | !... | Conditions.cs:108:17:108:18 | !... |
 | Conditions.cs:108:18:108:18 | access to parameter b | Conditions.cs:108:18:108:18 | access to parameter b |
 | Conditions.cs:109:17:109:17 | access to local variable x | Conditions.cs:109:17:109:17 | access to local variable x |
-| Conditions.cs:109:17:109:17 | access to local variable x | Conditions.cs:109:17:109:17 | access to local variable x |
 | Conditions.cs:109:17:109:23 | ... + ... | Conditions.cs:109:17:109:17 | access to local variable x |
 | Conditions.cs:109:17:109:23 | ... += ... | Conditions.cs:109:17:109:17 | access to local variable x |
 | Conditions.cs:109:17:109:23 | ... = ... | Conditions.cs:109:17:109:17 | access to local variable x |
@@ -714,12 +687,10 @@
 | Conditions.cs:110:16:110:16 | access to local variable x | Conditions.cs:110:16:110:16 | access to local variable x |
 | Conditions.cs:114:5:124:5 | {...} | Conditions.cs:114:5:124:5 | {...} |
 | Conditions.cs:115:9:115:24 | ... ...; | Conditions.cs:115:9:115:24 | ... ...; |
-| Conditions.cs:115:16:115:16 | access to local variable s | Conditions.cs:115:16:115:16 | access to local variable s |
-| Conditions.cs:115:16:115:23 | String s = ... | Conditions.cs:115:16:115:16 | access to local variable s |
+| Conditions.cs:115:16:115:23 | String s = ... | Conditions.cs:115:20:115:23 | null |
 | Conditions.cs:115:20:115:23 | null | Conditions.cs:115:20:115:23 | null |
 | Conditions.cs:116:9:123:9 | for (...;...;...) ... | Conditions.cs:116:9:123:9 | for (...;...;...) ... |
-| Conditions.cs:116:17:116:17 | access to local variable i | Conditions.cs:116:17:116:17 | access to local variable i |
-| Conditions.cs:116:17:116:21 | Int32 i = ... | Conditions.cs:116:17:116:17 | access to local variable i |
+| Conditions.cs:116:17:116:21 | Int32 i = ... | Conditions.cs:116:21:116:21 | 0 |
 | Conditions.cs:116:21:116:21 | 0 | Conditions.cs:116:21:116:21 | 0 |
 | Conditions.cs:116:24:116:24 | access to local variable i | Conditions.cs:116:24:116:24 | access to local variable i |
 | Conditions.cs:116:24:116:38 | ... < ... | Conditions.cs:116:24:116:24 | access to local variable i |
@@ -729,8 +700,7 @@
 | Conditions.cs:116:41:116:43 | ...++ | Conditions.cs:116:41:116:41 | access to local variable i |
 | Conditions.cs:117:9:123:9 | {...} | Conditions.cs:117:9:123:9 | {...} |
 | Conditions.cs:118:13:118:44 | ... ...; | Conditions.cs:118:13:118:44 | ... ...; |
-| Conditions.cs:118:17:118:20 | access to local variable last | Conditions.cs:118:17:118:20 | access to local variable last |
-| Conditions.cs:118:17:118:43 | Boolean last = ... | Conditions.cs:118:17:118:20 | access to local variable last |
+| Conditions.cs:118:17:118:43 | Boolean last = ... | Conditions.cs:118:24:118:24 | access to local variable i |
 | Conditions.cs:118:24:118:24 | access to local variable i | Conditions.cs:118:24:118:24 | access to local variable i |
 | Conditions.cs:118:24:118:43 | ... == ... | Conditions.cs:118:24:118:24 | access to local variable i |
 | Conditions.cs:118:29:118:32 | access to parameter args | Conditions.cs:118:29:118:32 | access to parameter args |
@@ -740,14 +710,12 @@
 | Conditions.cs:119:13:120:23 | if (...) ... | Conditions.cs:119:13:120:23 | if (...) ... |
 | Conditions.cs:119:17:119:21 | !... | Conditions.cs:119:17:119:21 | !... |
 | Conditions.cs:119:18:119:21 | access to local variable last | Conditions.cs:119:18:119:21 | access to local variable last |
-| Conditions.cs:120:17:120:17 | access to local variable s | Conditions.cs:120:17:120:17 | access to local variable s |
-| Conditions.cs:120:17:120:22 | ... = ... | Conditions.cs:120:17:120:17 | access to local variable s |
+| Conditions.cs:120:17:120:22 | ... = ... | Conditions.cs:120:21:120:22 | "" |
 | Conditions.cs:120:17:120:23 | ...; | Conditions.cs:120:17:120:23 | ...; |
 | Conditions.cs:120:21:120:22 | "" | Conditions.cs:120:21:120:22 | "" |
 | Conditions.cs:121:13:122:25 | if (...) ... | Conditions.cs:121:13:122:25 | if (...) ... |
 | Conditions.cs:121:17:121:20 | access to local variable last | Conditions.cs:121:17:121:20 | access to local variable last |
-| Conditions.cs:122:17:122:17 | access to local variable s | Conditions.cs:122:17:122:17 | access to local variable s |
-| Conditions.cs:122:17:122:24 | ... = ... | Conditions.cs:122:17:122:17 | access to local variable s |
+| Conditions.cs:122:17:122:24 | ... = ... | Conditions.cs:122:21:122:24 | null |
 | Conditions.cs:122:17:122:25 | ...; | Conditions.cs:122:17:122:25 | ...; |
 | Conditions.cs:122:21:122:24 | null | Conditions.cs:122:21:122:24 | null |
 | Conditions.cs:130:5:141:5 | {...} | Conditions.cs:130:5:141:5 | {...} |
@@ -873,16 +841,14 @@
 | ExitMethods.cs:121:9:121:29 | ...; | ExitMethods.cs:121:9:121:29 | ...; |
 | ExitMethods.cs:121:23:121:27 | false | ExitMethods.cs:121:23:121:27 | false |
 | ExitMethods.cs:122:9:122:18 | ... ...; | ExitMethods.cs:122:9:122:18 | ... ...; |
-| ExitMethods.cs:122:13:122:13 | access to local variable x | ExitMethods.cs:122:13:122:13 | access to local variable x |
-| ExitMethods.cs:122:13:122:17 | Int32 x = ... | ExitMethods.cs:122:13:122:13 | access to local variable x |
+| ExitMethods.cs:122:13:122:17 | Int32 x = ... | ExitMethods.cs:122:17:122:17 | 0 |
 | ExitMethods.cs:122:17:122:17 | 0 | ExitMethods.cs:122:17:122:17 | 0 |
 | ExitMethods.cs:126:5:129:5 | {...} | ExitMethods.cs:126:5:129:5 | {...} |
 | ExitMethods.cs:127:9:127:26 | call to method FailingAssertion | ExitMethods.cs:127:9:127:26 | this access |
 | ExitMethods.cs:127:9:127:26 | this access | ExitMethods.cs:127:9:127:26 | this access |
 | ExitMethods.cs:127:9:127:27 | ...; | ExitMethods.cs:127:9:127:27 | ...; |
 | ExitMethods.cs:128:9:128:18 | ... ...; | ExitMethods.cs:128:9:128:18 | ... ...; |
-| ExitMethods.cs:128:13:128:13 | access to local variable x | ExitMethods.cs:128:13:128:13 | access to local variable x |
-| ExitMethods.cs:128:13:128:17 | Int32 x = ... | ExitMethods.cs:128:13:128:13 | access to local variable x |
+| ExitMethods.cs:128:13:128:17 | Int32 x = ... | ExitMethods.cs:128:17:128:17 | 0 |
 | ExitMethods.cs:128:17:128:17 | 0 | ExitMethods.cs:128:17:128:17 | 0 |
 | ExitMethods.cs:131:33:131:49 | call to method IsFalse | ExitMethods.cs:131:48:131:48 | access to parameter b |
 | ExitMethods.cs:131:48:131:48 | access to parameter b | ExitMethods.cs:131:48:131:48 | access to parameter b |
@@ -892,8 +858,7 @@
 | ExitMethods.cs:135:9:135:26 | ...; | ExitMethods.cs:135:9:135:26 | ...; |
 | ExitMethods.cs:135:21:135:24 | true | ExitMethods.cs:135:21:135:24 | true |
 | ExitMethods.cs:136:9:136:18 | ... ...; | ExitMethods.cs:136:9:136:18 | ... ...; |
-| ExitMethods.cs:136:13:136:13 | access to local variable x | ExitMethods.cs:136:13:136:13 | access to local variable x |
-| ExitMethods.cs:136:13:136:17 | Int32 x = ... | ExitMethods.cs:136:13:136:13 | access to local variable x |
+| ExitMethods.cs:136:13:136:17 | Int32 x = ... | ExitMethods.cs:136:17:136:17 | 0 |
 | ExitMethods.cs:136:17:136:17 | 0 | ExitMethods.cs:136:17:136:17 | 0 |
 | Extensions.cs:6:5:8:5 | {...} | Extensions.cs:6:5:8:5 | {...} |
 | Extensions.cs:7:9:7:30 | return ...; | Extensions.cs:7:28:7:28 | access to parameter s |
@@ -970,20 +935,16 @@
 | Initializers.cs:6:28:6:30 | {...} | Initializers.cs:6:28:6:30 | {...} |
 | Initializers.cs:9:5:12:5 | {...} | Initializers.cs:9:5:12:5 | {...} |
 | Initializers.cs:10:9:10:54 | ... ...; | Initializers.cs:10:9:10:54 | ... ...; |
-| Initializers.cs:10:13:10:13 | access to local variable i | Initializers.cs:10:13:10:13 | access to local variable i |
-| Initializers.cs:10:13:10:53 | Initializers i = ... | Initializers.cs:10:13:10:13 | access to local variable i |
+| Initializers.cs:10:13:10:53 | Initializers i = ... | Initializers.cs:10:34:10:35 | "" |
 | Initializers.cs:10:17:10:53 | object creation of type Initializers | Initializers.cs:10:34:10:35 | "" |
 | Initializers.cs:10:34:10:35 | "" | Initializers.cs:10:34:10:35 | "" |
-| Initializers.cs:10:38:10:53 | { ..., ... } | Initializers.cs:10:40:10:40 | access to field F |
-| Initializers.cs:10:40:10:40 | access to field F | Initializers.cs:10:40:10:40 | access to field F |
-| Initializers.cs:10:40:10:44 | ... = ... | Initializers.cs:10:40:10:40 | access to field F |
+| Initializers.cs:10:38:10:53 | { ..., ... } | Initializers.cs:10:44:10:44 | 0 |
+| Initializers.cs:10:40:10:44 | ... = ... | Initializers.cs:10:44:10:44 | 0 |
 | Initializers.cs:10:44:10:44 | 0 | Initializers.cs:10:44:10:44 | 0 |
-| Initializers.cs:10:47:10:47 | access to property G | Initializers.cs:10:47:10:47 | access to property G |
-| Initializers.cs:10:47:10:51 | ... = ... | Initializers.cs:10:47:10:47 | access to property G |
+| Initializers.cs:10:47:10:51 | ... = ... | Initializers.cs:10:51:10:51 | 1 |
 | Initializers.cs:10:51:10:51 | 1 | Initializers.cs:10:51:10:51 | 1 |
 | Initializers.cs:11:9:11:64 | ... ...; | Initializers.cs:11:9:11:64 | ... ...; |
-| Initializers.cs:11:13:11:14 | access to local variable iz | Initializers.cs:11:13:11:14 | access to local variable iz |
-| Initializers.cs:11:13:11:63 | Initializers[] iz = ... | Initializers.cs:11:13:11:14 | access to local variable iz |
+| Initializers.cs:11:13:11:63 | Initializers[] iz = ... | Initializers.cs:11:18:11:63 | array creation of type Initializers[] |
 | Initializers.cs:11:18:11:63 | 2 | Initializers.cs:11:18:11:63 | 2 |
 | Initializers.cs:11:18:11:63 | array creation of type Initializers[] | Initializers.cs:11:18:11:63 | array creation of type Initializers[] |
 | Initializers.cs:11:37:11:63 | { ..., ... } | Initializers.cs:11:39:11:39 | access to local variable i |
@@ -1023,20 +984,17 @@
 | NullCoalescing.cs:11:68:11:68 | 1 | NullCoalescing.cs:11:68:11:68 | 1 |
 | NullCoalescing.cs:14:5:18:5 | {...} | NullCoalescing.cs:14:5:18:5 | {...} |
 | NullCoalescing.cs:15:9:15:32 | ... ...; | NullCoalescing.cs:15:9:15:32 | ... ...; |
-| NullCoalescing.cs:15:13:15:13 | access to local variable j | NullCoalescing.cs:15:13:15:13 | access to local variable j |
-| NullCoalescing.cs:15:13:15:31 | Int32 j = ... | NullCoalescing.cs:15:13:15:13 | access to local variable j |
+| NullCoalescing.cs:15:13:15:31 | Int32 j = ... | NullCoalescing.cs:15:17:15:31 | ... ?? ... |
 | NullCoalescing.cs:15:17:15:26 | (...) ... | NullCoalescing.cs:15:23:15:26 | null |
 | NullCoalescing.cs:15:17:15:31 | ... ?? ... | NullCoalescing.cs:15:17:15:31 | ... ?? ... |
 | NullCoalescing.cs:15:23:15:26 | null | NullCoalescing.cs:15:23:15:26 | null |
 | NullCoalescing.cs:15:31:15:31 | 0 | NullCoalescing.cs:15:31:15:31 | 0 |
 | NullCoalescing.cs:16:9:16:26 | ... ...; | NullCoalescing.cs:16:9:16:26 | ... ...; |
-| NullCoalescing.cs:16:13:16:13 | access to local variable s | NullCoalescing.cs:16:13:16:13 | access to local variable s |
-| NullCoalescing.cs:16:13:16:25 | String s = ... | NullCoalescing.cs:16:13:16:13 | access to local variable s |
+| NullCoalescing.cs:16:13:16:25 | String s = ... | NullCoalescing.cs:16:17:16:25 | ... ?? ... |
 | NullCoalescing.cs:16:17:16:18 | "" | NullCoalescing.cs:16:17:16:18 | "" |
 | NullCoalescing.cs:16:17:16:25 | ... ?? ... | NullCoalescing.cs:16:17:16:25 | ... ?? ... |
 | NullCoalescing.cs:16:23:16:25 | "a" | NullCoalescing.cs:16:23:16:25 | "a" |
-| NullCoalescing.cs:17:9:17:9 | access to local variable j | NullCoalescing.cs:17:9:17:9 | access to local variable j |
-| NullCoalescing.cs:17:9:17:24 | ... = ... | NullCoalescing.cs:17:9:17:9 | access to local variable j |
+| NullCoalescing.cs:17:9:17:24 | ... = ... | NullCoalescing.cs:17:13:17:24 | ... ?? ... |
 | NullCoalescing.cs:17:9:17:25 | ...; | NullCoalescing.cs:17:9:17:25 | ...; |
 | NullCoalescing.cs:17:13:17:19 | (...) ... | NullCoalescing.cs:17:19:17:19 | access to parameter i |
 | NullCoalescing.cs:17:13:17:24 | ... ?? ... | NullCoalescing.cs:17:13:17:24 | ... ?? ... |
@@ -1044,8 +1002,7 @@
 | NullCoalescing.cs:17:24:17:24 | 1 | NullCoalescing.cs:17:24:17:24 | 1 |
 | Patterns.cs:6:5:43:5 | {...} | Patterns.cs:6:5:43:5 | {...} |
 | Patterns.cs:7:9:7:24 | ... ...; | Patterns.cs:7:9:7:24 | ... ...; |
-| Patterns.cs:7:16:7:16 | access to local variable o | Patterns.cs:7:16:7:16 | access to local variable o |
-| Patterns.cs:7:16:7:23 | Object o = ... | Patterns.cs:7:16:7:16 | access to local variable o |
+| Patterns.cs:7:16:7:23 | Object o = ... | Patterns.cs:7:20:7:23 | null |
 | Patterns.cs:7:20:7:23 | null | Patterns.cs:7:20:7:23 | null |
 | Patterns.cs:8:9:18:9 | if (...) ... | Patterns.cs:8:9:18:9 | if (...) ... |
 | Patterns.cs:8:13:8:13 | access to local variable o | Patterns.cs:8:13:8:13 | access to local variable o |
@@ -1118,71 +1075,56 @@
 | Qualifiers.cs:8:41:8:44 | null | Qualifiers.cs:8:41:8:44 | null |
 | Qualifiers.cs:11:5:31:5 | {...} | Qualifiers.cs:11:5:31:5 | {...} |
 | Qualifiers.cs:12:9:12:22 | ... ...; | Qualifiers.cs:12:9:12:22 | ... ...; |
-| Qualifiers.cs:12:13:12:13 | access to local variable q | Qualifiers.cs:12:13:12:13 | access to local variable q |
-| Qualifiers.cs:12:13:12:21 | Qualifiers q = ... | Qualifiers.cs:12:13:12:13 | access to local variable q |
+| Qualifiers.cs:12:13:12:21 | Qualifiers q = ... | Qualifiers.cs:12:17:12:21 | this access |
 | Qualifiers.cs:12:17:12:21 | access to field Field | Qualifiers.cs:12:17:12:21 | this access |
 | Qualifiers.cs:12:17:12:21 | this access | Qualifiers.cs:12:17:12:21 | this access |
-| Qualifiers.cs:13:9:13:9 | access to local variable q | Qualifiers.cs:13:9:13:9 | access to local variable q |
-| Qualifiers.cs:13:9:13:20 | ... = ... | Qualifiers.cs:13:9:13:9 | access to local variable q |
+| Qualifiers.cs:13:9:13:20 | ... = ... | Qualifiers.cs:13:13:13:20 | this access |
 | Qualifiers.cs:13:9:13:21 | ...; | Qualifiers.cs:13:9:13:21 | ...; |
 | Qualifiers.cs:13:13:13:20 | access to property Property | Qualifiers.cs:13:13:13:20 | this access |
 | Qualifiers.cs:13:13:13:20 | this access | Qualifiers.cs:13:13:13:20 | this access |
-| Qualifiers.cs:14:9:14:9 | access to local variable q | Qualifiers.cs:14:9:14:9 | access to local variable q |
-| Qualifiers.cs:14:9:14:20 | ... = ... | Qualifiers.cs:14:9:14:9 | access to local variable q |
+| Qualifiers.cs:14:9:14:20 | ... = ... | Qualifiers.cs:14:13:14:20 | this access |
 | Qualifiers.cs:14:9:14:21 | ...; | Qualifiers.cs:14:9:14:21 | ...; |
 | Qualifiers.cs:14:13:14:20 | call to method Method | Qualifiers.cs:14:13:14:20 | this access |
 | Qualifiers.cs:14:13:14:20 | this access | Qualifiers.cs:14:13:14:20 | this access |
-| Qualifiers.cs:16:9:16:9 | access to local variable q | Qualifiers.cs:16:9:16:9 | access to local variable q |
-| Qualifiers.cs:16:9:16:22 | ... = ... | Qualifiers.cs:16:9:16:9 | access to local variable q |
+| Qualifiers.cs:16:9:16:22 | ... = ... | Qualifiers.cs:16:13:16:16 | this access |
 | Qualifiers.cs:16:9:16:23 | ...; | Qualifiers.cs:16:9:16:23 | ...; |
 | Qualifiers.cs:16:13:16:16 | this access | Qualifiers.cs:16:13:16:16 | this access |
 | Qualifiers.cs:16:13:16:22 | access to field Field | Qualifiers.cs:16:13:16:16 | this access |
-| Qualifiers.cs:17:9:17:9 | access to local variable q | Qualifiers.cs:17:9:17:9 | access to local variable q |
-| Qualifiers.cs:17:9:17:25 | ... = ... | Qualifiers.cs:17:9:17:9 | access to local variable q |
+| Qualifiers.cs:17:9:17:25 | ... = ... | Qualifiers.cs:17:13:17:16 | this access |
 | Qualifiers.cs:17:9:17:26 | ...; | Qualifiers.cs:17:9:17:26 | ...; |
 | Qualifiers.cs:17:13:17:16 | this access | Qualifiers.cs:17:13:17:16 | this access |
 | Qualifiers.cs:17:13:17:25 | access to property Property | Qualifiers.cs:17:13:17:16 | this access |
-| Qualifiers.cs:18:9:18:9 | access to local variable q | Qualifiers.cs:18:9:18:9 | access to local variable q |
-| Qualifiers.cs:18:9:18:25 | ... = ... | Qualifiers.cs:18:9:18:9 | access to local variable q |
+| Qualifiers.cs:18:9:18:25 | ... = ... | Qualifiers.cs:18:13:18:16 | this access |
 | Qualifiers.cs:18:9:18:26 | ...; | Qualifiers.cs:18:9:18:26 | ...; |
 | Qualifiers.cs:18:13:18:16 | this access | Qualifiers.cs:18:13:18:16 | this access |
 | Qualifiers.cs:18:13:18:25 | call to method Method | Qualifiers.cs:18:13:18:16 | this access |
-| Qualifiers.cs:20:9:20:9 | access to local variable q | Qualifiers.cs:20:9:20:9 | access to local variable q |
-| Qualifiers.cs:20:9:20:23 | ... = ... | Qualifiers.cs:20:9:20:9 | access to local variable q |
+| Qualifiers.cs:20:9:20:23 | ... = ... | Qualifiers.cs:20:13:20:23 | access to field StaticField |
 | Qualifiers.cs:20:9:20:24 | ...; | Qualifiers.cs:20:9:20:24 | ...; |
 | Qualifiers.cs:20:13:20:23 | access to field StaticField | Qualifiers.cs:20:13:20:23 | access to field StaticField |
-| Qualifiers.cs:21:9:21:9 | access to local variable q | Qualifiers.cs:21:9:21:9 | access to local variable q |
-| Qualifiers.cs:21:9:21:26 | ... = ... | Qualifiers.cs:21:9:21:9 | access to local variable q |
+| Qualifiers.cs:21:9:21:26 | ... = ... | Qualifiers.cs:21:13:21:26 | access to property StaticProperty |
 | Qualifiers.cs:21:9:21:27 | ...; | Qualifiers.cs:21:9:21:27 | ...; |
 | Qualifiers.cs:21:13:21:26 | access to property StaticProperty | Qualifiers.cs:21:13:21:26 | access to property StaticProperty |
-| Qualifiers.cs:22:9:22:9 | access to local variable q | Qualifiers.cs:22:9:22:9 | access to local variable q |
-| Qualifiers.cs:22:9:22:26 | ... = ... | Qualifiers.cs:22:9:22:9 | access to local variable q |
+| Qualifiers.cs:22:9:22:26 | ... = ... | Qualifiers.cs:22:13:22:26 | call to method StaticMethod |
 | Qualifiers.cs:22:9:22:27 | ...; | Qualifiers.cs:22:9:22:27 | ...; |
 | Qualifiers.cs:22:13:22:26 | call to method StaticMethod | Qualifiers.cs:22:13:22:26 | call to method StaticMethod |
-| Qualifiers.cs:24:9:24:9 | access to local variable q | Qualifiers.cs:24:9:24:9 | access to local variable q |
-| Qualifiers.cs:24:9:24:34 | ... = ... | Qualifiers.cs:24:9:24:9 | access to local variable q |
+| Qualifiers.cs:24:9:24:34 | ... = ... | Qualifiers.cs:24:13:24:34 | access to field StaticField |
 | Qualifiers.cs:24:9:24:35 | ...; | Qualifiers.cs:24:9:24:35 | ...; |
 | Qualifiers.cs:24:13:24:34 | access to field StaticField | Qualifiers.cs:24:13:24:34 | access to field StaticField |
-| Qualifiers.cs:25:9:25:9 | access to local variable q | Qualifiers.cs:25:9:25:9 | access to local variable q |
-| Qualifiers.cs:25:9:25:37 | ... = ... | Qualifiers.cs:25:9:25:9 | access to local variable q |
+| Qualifiers.cs:25:9:25:37 | ... = ... | Qualifiers.cs:25:13:25:37 | access to property StaticProperty |
 | Qualifiers.cs:25:9:25:38 | ...; | Qualifiers.cs:25:9:25:38 | ...; |
 | Qualifiers.cs:25:13:25:37 | access to property StaticProperty | Qualifiers.cs:25:13:25:37 | access to property StaticProperty |
-| Qualifiers.cs:26:9:26:9 | access to local variable q | Qualifiers.cs:26:9:26:9 | access to local variable q |
-| Qualifiers.cs:26:9:26:37 | ... = ... | Qualifiers.cs:26:9:26:9 | access to local variable q |
+| Qualifiers.cs:26:9:26:37 | ... = ... | Qualifiers.cs:26:13:26:37 | call to method StaticMethod |
 | Qualifiers.cs:26:9:26:38 | ...; | Qualifiers.cs:26:9:26:38 | ...; |
 | Qualifiers.cs:26:13:26:37 | call to method StaticMethod | Qualifiers.cs:26:13:26:37 | call to method StaticMethod |
-| Qualifiers.cs:28:9:28:9 | access to local variable q | Qualifiers.cs:28:9:28:9 | access to local variable q |
-| Qualifiers.cs:28:9:28:40 | ... = ... | Qualifiers.cs:28:9:28:9 | access to local variable q |
+| Qualifiers.cs:28:9:28:40 | ... = ... | Qualifiers.cs:28:13:28:34 | access to field StaticField |
 | Qualifiers.cs:28:9:28:41 | ...; | Qualifiers.cs:28:9:28:41 | ...; |
 | Qualifiers.cs:28:13:28:34 | access to field StaticField | Qualifiers.cs:28:13:28:34 | access to field StaticField |
 | Qualifiers.cs:28:13:28:40 | access to field Field | Qualifiers.cs:28:13:28:34 | access to field StaticField |
-| Qualifiers.cs:29:9:29:9 | access to local variable q | Qualifiers.cs:29:9:29:9 | access to local variable q |
-| Qualifiers.cs:29:9:29:46 | ... = ... | Qualifiers.cs:29:9:29:9 | access to local variable q |
+| Qualifiers.cs:29:9:29:46 | ... = ... | Qualifiers.cs:29:13:29:37 | access to property StaticProperty |
 | Qualifiers.cs:29:9:29:47 | ...; | Qualifiers.cs:29:9:29:47 | ...; |
 | Qualifiers.cs:29:13:29:37 | access to property StaticProperty | Qualifiers.cs:29:13:29:37 | access to property StaticProperty |
 | Qualifiers.cs:29:13:29:46 | access to property Property | Qualifiers.cs:29:13:29:37 | access to property StaticProperty |
-| Qualifiers.cs:30:9:30:9 | access to local variable q | Qualifiers.cs:30:9:30:9 | access to local variable q |
-| Qualifiers.cs:30:9:30:46 | ... = ... | Qualifiers.cs:30:9:30:9 | access to local variable q |
+| Qualifiers.cs:30:9:30:46 | ... = ... | Qualifiers.cs:30:13:30:37 | call to method StaticMethod |
 | Qualifiers.cs:30:9:30:47 | ...; | Qualifiers.cs:30:9:30:47 | ...; |
 | Qualifiers.cs:30:13:30:37 | call to method StaticMethod | Qualifiers.cs:30:13:30:37 | call to method StaticMethod |
 | Qualifiers.cs:30:13:30:46 | call to method Method | Qualifiers.cs:30:13:30:37 | call to method StaticMethod |
@@ -1333,12 +1275,10 @@
 | Switch.cs:120:17:120:17 | 1 | Switch.cs:120:17:120:17 | 1 |
 | TypeAccesses.cs:4:5:9:5 | {...} | TypeAccesses.cs:4:5:9:5 | {...} |
 | TypeAccesses.cs:5:9:5:26 | ... ...; | TypeAccesses.cs:5:9:5:26 | ... ...; |
-| TypeAccesses.cs:5:13:5:13 | access to local variable s | TypeAccesses.cs:5:13:5:13 | access to local variable s |
-| TypeAccesses.cs:5:13:5:25 | String s = ... | TypeAccesses.cs:5:13:5:13 | access to local variable s |
+| TypeAccesses.cs:5:13:5:25 | String s = ... | TypeAccesses.cs:5:25:5:25 | access to parameter o |
 | TypeAccesses.cs:5:17:5:25 | (...) ... | TypeAccesses.cs:5:25:5:25 | access to parameter o |
 | TypeAccesses.cs:5:25:5:25 | access to parameter o | TypeAccesses.cs:5:25:5:25 | access to parameter o |
-| TypeAccesses.cs:6:9:6:9 | access to local variable s | TypeAccesses.cs:6:9:6:9 | access to local variable s |
-| TypeAccesses.cs:6:9:6:23 | ... = ... | TypeAccesses.cs:6:9:6:9 | access to local variable s |
+| TypeAccesses.cs:6:9:6:23 | ... = ... | TypeAccesses.cs:6:13:6:13 | access to parameter o |
 | TypeAccesses.cs:6:9:6:24 | ...; | TypeAccesses.cs:6:9:6:24 | ...; |
 | TypeAccesses.cs:6:13:6:13 | access to parameter o | TypeAccesses.cs:6:13:6:13 | access to parameter o |
 | TypeAccesses.cs:6:13:6:23 | ... as ... | TypeAccesses.cs:6:13:6:13 | access to parameter o |
@@ -1348,18 +1288,15 @@
 | TypeAccesses.cs:7:18:7:22 | Int32 j | TypeAccesses.cs:7:18:7:22 | Int32 j |
 | TypeAccesses.cs:7:25:7:25 | ; | TypeAccesses.cs:7:25:7:25 | ; |
 | TypeAccesses.cs:8:9:8:28 | ... ...; | TypeAccesses.cs:8:9:8:28 | ... ...; |
-| TypeAccesses.cs:8:13:8:13 | access to local variable t | TypeAccesses.cs:8:13:8:13 | access to local variable t |
-| TypeAccesses.cs:8:13:8:27 | Type t = ... | TypeAccesses.cs:8:13:8:13 | access to local variable t |
+| TypeAccesses.cs:8:13:8:27 | Type t = ... | TypeAccesses.cs:8:17:8:27 | typeof(...) |
 | TypeAccesses.cs:8:17:8:27 | typeof(...) | TypeAccesses.cs:8:17:8:27 | typeof(...) |
 | VarDecls.cs:6:5:11:5 | {...} | VarDecls.cs:6:5:11:5 | {...} |
 | VarDecls.cs:7:9:10:9 | fixed(...) { ... } | VarDecls.cs:7:9:10:9 | fixed(...) { ... } |
-| VarDecls.cs:7:22:7:23 | access to local variable c1 | VarDecls.cs:7:22:7:23 | access to local variable c1 |
-| VarDecls.cs:7:22:7:36 | Char* c1 = ... | VarDecls.cs:7:22:7:23 | access to local variable c1 |
+| VarDecls.cs:7:22:7:36 | Char* c1 = ... | VarDecls.cs:7:27:7:33 | access to parameter strings |
 | VarDecls.cs:7:27:7:33 | access to parameter strings | VarDecls.cs:7:27:7:33 | access to parameter strings |
 | VarDecls.cs:7:27:7:36 | access to array element | VarDecls.cs:7:27:7:33 | access to parameter strings |
 | VarDecls.cs:7:35:7:35 | 0 | VarDecls.cs:7:35:7:35 | 0 |
-| VarDecls.cs:7:39:7:40 | access to local variable c2 | VarDecls.cs:7:39:7:40 | access to local variable c2 |
-| VarDecls.cs:7:39:7:53 | Char* c2 = ... | VarDecls.cs:7:39:7:40 | access to local variable c2 |
+| VarDecls.cs:7:39:7:53 | Char* c2 = ... | VarDecls.cs:7:44:7:50 | access to parameter strings |
 | VarDecls.cs:7:44:7:50 | access to parameter strings | VarDecls.cs:7:44:7:50 | access to parameter strings |
 | VarDecls.cs:7:44:7:53 | access to array element | VarDecls.cs:7:44:7:50 | access to parameter strings |
 | VarDecls.cs:7:52:7:52 | 1 | VarDecls.cs:7:52:7:52 | 1 |
@@ -1369,11 +1306,9 @@
 | VarDecls.cs:9:27:9:28 | access to local variable c1 | VarDecls.cs:9:27:9:28 | access to local variable c1 |
 | VarDecls.cs:14:5:17:5 | {...} | VarDecls.cs:14:5:17:5 | {...} |
 | VarDecls.cs:15:9:15:30 | ... ...; | VarDecls.cs:15:9:15:30 | ... ...; |
-| VarDecls.cs:15:16:15:17 | access to local variable s1 | VarDecls.cs:15:16:15:17 | access to local variable s1 |
-| VarDecls.cs:15:16:15:21 | String s1 = ... | VarDecls.cs:15:16:15:17 | access to local variable s1 |
+| VarDecls.cs:15:16:15:21 | String s1 = ... | VarDecls.cs:15:21:15:21 | access to parameter s |
 | VarDecls.cs:15:21:15:21 | access to parameter s | VarDecls.cs:15:21:15:21 | access to parameter s |
-| VarDecls.cs:15:24:15:25 | access to local variable s2 | VarDecls.cs:15:24:15:25 | access to local variable s2 |
-| VarDecls.cs:15:24:15:29 | String s2 = ... | VarDecls.cs:15:24:15:25 | access to local variable s2 |
+| VarDecls.cs:15:24:15:29 | String s2 = ... | VarDecls.cs:15:29:15:29 | access to parameter s |
 | VarDecls.cs:15:29:15:29 | access to parameter s | VarDecls.cs:15:29:15:29 | access to parameter s |
 | VarDecls.cs:16:9:16:23 | return ...; | VarDecls.cs:16:16:16:17 | access to local variable s1 |
 | VarDecls.cs:16:16:16:17 | access to local variable s1 | VarDecls.cs:16:16:16:17 | access to local variable s1 |
@@ -1384,11 +1319,9 @@
 | VarDecls.cs:21:16:21:22 | object creation of type C | VarDecls.cs:21:16:21:22 | object creation of type C |
 | VarDecls.cs:22:13:22:13 | ; | VarDecls.cs:22:13:22:13 | ; |
 | VarDecls.cs:24:9:25:29 | using (...) {...} | VarDecls.cs:24:9:25:29 | using (...) {...} |
-| VarDecls.cs:24:18:24:18 | access to local variable x | VarDecls.cs:24:18:24:18 | access to local variable x |
-| VarDecls.cs:24:18:24:28 | C x = ... | VarDecls.cs:24:18:24:18 | access to local variable x |
+| VarDecls.cs:24:18:24:28 | C x = ... | VarDecls.cs:24:22:24:28 | object creation of type C |
 | VarDecls.cs:24:22:24:28 | object creation of type C | VarDecls.cs:24:22:24:28 | object creation of type C |
-| VarDecls.cs:24:31:24:31 | access to local variable y | VarDecls.cs:24:31:24:31 | access to local variable y |
-| VarDecls.cs:24:31:24:41 | C y = ... | VarDecls.cs:24:31:24:31 | access to local variable y |
+| VarDecls.cs:24:31:24:41 | C y = ... | VarDecls.cs:24:35:24:41 | object creation of type C |
 | VarDecls.cs:24:35:24:41 | object creation of type C | VarDecls.cs:24:35:24:41 | object creation of type C |
 | VarDecls.cs:25:13:25:29 | return ...; | VarDecls.cs:25:20:25:28 | ... ? ... : ... |
 | VarDecls.cs:25:20:25:20 | access to parameter b | VarDecls.cs:25:20:25:20 | access to parameter b |
@@ -1398,12 +1331,10 @@
 | VarDecls.cs:28:51:28:53 | {...} | VarDecls.cs:28:51:28:53 | {...} |
 | cflow.cs:6:5:35:5 | {...} | cflow.cs:6:5:35:5 | {...} |
 | cflow.cs:7:9:7:28 | ... ...; | cflow.cs:7:9:7:28 | ... ...; |
-| cflow.cs:7:13:7:13 | access to local variable a | cflow.cs:7:13:7:13 | access to local variable a |
-| cflow.cs:7:13:7:27 | Int32 a = ... | cflow.cs:7:13:7:13 | access to local variable a |
+| cflow.cs:7:13:7:27 | Int32 a = ... | cflow.cs:7:17:7:20 | access to parameter args |
 | cflow.cs:7:17:7:20 | access to parameter args | cflow.cs:7:17:7:20 | access to parameter args |
 | cflow.cs:7:17:7:27 | access to property Length | cflow.cs:7:17:7:20 | access to parameter args |
-| cflow.cs:9:9:9:9 | access to local variable a | cflow.cs:9:9:9:9 | access to local variable a |
-| cflow.cs:9:9:9:39 | ... = ... | cflow.cs:9:9:9:9 | access to local variable a |
+| cflow.cs:9:9:9:39 | ... = ... | cflow.cs:9:13:9:29 | object creation of type ControlFlow |
 | cflow.cs:9:9:9:40 | ...; | cflow.cs:9:9:9:40 | ...; |
 | cflow.cs:9:13:9:29 | object creation of type ControlFlow | cflow.cs:9:13:9:29 | object creation of type ControlFlow |
 | cflow.cs:9:13:9:39 | call to method Switch | cflow.cs:9:13:9:29 | object creation of type ControlFlow |
@@ -1437,8 +1368,7 @@
 | cflow.cs:22:18:22:23 | ... < ... | cflow.cs:22:18:22:18 | access to local variable a |
 | cflow.cs:22:22:22:23 | 10 | cflow.cs:22:22:22:23 | 10 |
 | cflow.cs:24:9:34:9 | for (...;...;...) ... | cflow.cs:24:9:34:9 | for (...;...;...) ... |
-| cflow.cs:24:18:24:18 | access to local variable i | cflow.cs:24:18:24:18 | access to local variable i |
-| cflow.cs:24:18:24:22 | Int32 i = ... | cflow.cs:24:18:24:18 | access to local variable i |
+| cflow.cs:24:18:24:22 | Int32 i = ... | cflow.cs:24:22:24:22 | 1 |
 | cflow.cs:24:22:24:22 | 1 | cflow.cs:24:22:24:22 | 1 |
 | cflow.cs:24:25:24:25 | access to local variable i | cflow.cs:24:25:24:25 | access to local variable i |
 | cflow.cs:24:25:24:31 | ... <= ... | cflow.cs:24:25:24:25 | access to local variable i |
@@ -1625,11 +1555,9 @@
 | cflow.cs:116:27:116:27 | access to parameter s | cflow.cs:116:27:116:27 | access to parameter s |
 | cflow.cs:120:5:124:5 | {...} | cflow.cs:120:5:124:5 | {...} |
 | cflow.cs:121:9:121:18 | ... ...; | cflow.cs:121:9:121:18 | ... ...; |
-| cflow.cs:121:13:121:13 | access to local variable x | cflow.cs:121:13:121:13 | access to local variable x |
-| cflow.cs:121:13:121:17 | String x = ... | cflow.cs:121:13:121:13 | access to local variable x |
+| cflow.cs:121:13:121:17 | String x = ... | cflow.cs:121:17:121:17 | access to parameter s |
 | cflow.cs:121:17:121:17 | access to parameter s | cflow.cs:121:17:121:17 | access to parameter s |
-| cflow.cs:122:9:122:9 | access to local variable x | cflow.cs:122:9:122:9 | access to local variable x |
-| cflow.cs:122:9:122:19 | ... = ... | cflow.cs:122:9:122:9 | access to local variable x |
+| cflow.cs:122:9:122:19 | ... = ... | cflow.cs:122:13:122:13 | access to local variable x |
 | cflow.cs:122:9:122:20 | ...; | cflow.cs:122:9:122:20 | ...; |
 | cflow.cs:122:13:122:13 | access to local variable x | cflow.cs:122:13:122:13 | access to local variable x |
 | cflow.cs:122:13:122:19 | ... + ... | cflow.cs:122:13:122:13 | access to local variable x |
@@ -1747,8 +1675,7 @@
 | cflow.cs:203:13:203:41 | ...; | cflow.cs:203:13:203:41 | ...; |
 | cflow.cs:203:31:203:39 | "Finally" | cflow.cs:203:31:203:39 | "Finally" |
 | cflow.cs:206:9:206:19 | ... ...; | cflow.cs:206:9:206:19 | ... ...; |
-| cflow.cs:206:13:206:13 | access to local variable i | cflow.cs:206:13:206:13 | access to local variable i |
-| cflow.cs:206:13:206:18 | Int32 i = ... | cflow.cs:206:13:206:13 | access to local variable i |
+| cflow.cs:206:13:206:18 | Int32 i = ... | cflow.cs:206:17:206:18 | 10 |
 | cflow.cs:206:17:206:18 | 10 | cflow.cs:206:17:206:18 | 10 |
 | cflow.cs:207:9:230:9 | while (...) ... | cflow.cs:207:9:230:9 | while (...) ... |
 | cflow.cs:207:16:207:16 | access to local variable i | cflow.cs:207:16:207:16 | access to local variable i |
@@ -1826,8 +1753,7 @@
 | cflow.cs:247:9:254:9 | try {...} ... | cflow.cs:247:9:254:9 | try {...} ... |
 | cflow.cs:248:9:250:9 | {...} | cflow.cs:248:9:250:9 | {...} |
 | cflow.cs:249:13:249:41 | ... ...; | cflow.cs:249:13:249:41 | ... ...; |
-| cflow.cs:249:17:249:20 | access to local variable temp | cflow.cs:249:17:249:20 | access to local variable temp |
-| cflow.cs:249:17:249:40 | Double temp = ... | cflow.cs:249:17:249:20 | access to local variable temp |
+| cflow.cs:249:17:249:40 | Double temp = ... | cflow.cs:249:24:249:24 | 0 |
 | cflow.cs:249:24:249:24 | 0 | cflow.cs:249:24:249:24 | 0 |
 | cflow.cs:249:24:249:24 | (...) ... | cflow.cs:249:24:249:24 | 0 |
 | cflow.cs:249:24:249:40 | ... / ... | cflow.cs:249:24:249:24 | 0 |
@@ -1837,8 +1763,7 @@
 | cflow.cs:253:13:253:13 | ; | cflow.cs:253:13:253:13 | ; |
 | cflow.cs:258:5:288:5 | {...} | cflow.cs:258:5:288:5 | {...} |
 | cflow.cs:259:9:259:18 | ... ...; | cflow.cs:259:9:259:18 | ... ...; |
-| cflow.cs:259:13:259:13 | access to local variable x | cflow.cs:259:13:259:13 | access to local variable x |
-| cflow.cs:259:13:259:17 | Int32 x = ... | cflow.cs:259:13:259:13 | access to local variable x |
+| cflow.cs:259:13:259:17 | Int32 x = ... | cflow.cs:259:17:259:17 | 0 |
 | cflow.cs:259:17:259:17 | 0 | cflow.cs:259:17:259:17 | 0 |
 | cflow.cs:260:9:261:33 | for (...;...;...) ... | cflow.cs:260:9:261:33 | for (...;...;...) ... |
 | cflow.cs:260:16:260:16 | access to local variable x | cflow.cs:260:16:260:16 | access to local variable x |
@@ -1886,11 +1811,9 @@
 | cflow.cs:281:13:281:15 | ...++ | cflow.cs:281:13:281:13 | access to local variable x |
 | cflow.cs:281:13:281:16 | ...; | cflow.cs:281:13:281:16 | ...; |
 | cflow.cs:284:9:287:9 | for (...;...;...) ... | cflow.cs:284:9:287:9 | for (...;...;...) ... |
-| cflow.cs:284:18:284:18 | access to local variable i | cflow.cs:284:18:284:18 | access to local variable i |
-| cflow.cs:284:18:284:22 | Int32 i = ... | cflow.cs:284:18:284:18 | access to local variable i |
+| cflow.cs:284:18:284:22 | Int32 i = ... | cflow.cs:284:22:284:22 | 0 |
 | cflow.cs:284:22:284:22 | 0 | cflow.cs:284:22:284:22 | 0 |
-| cflow.cs:284:25:284:25 | access to local variable j | cflow.cs:284:25:284:25 | access to local variable j |
-| cflow.cs:284:25:284:29 | Int32 j = ... | cflow.cs:284:25:284:25 | access to local variable j |
+| cflow.cs:284:25:284:29 | Int32 j = ... | cflow.cs:284:29:284:29 | 0 |
 | cflow.cs:284:29:284:29 | 0 | cflow.cs:284:29:284:29 | 0 |
 | cflow.cs:284:32:284:32 | access to local variable i | cflow.cs:284:32:284:32 | access to local variable i |
 | cflow.cs:284:32:284:36 | ... + ... | cflow.cs:284:32:284:32 | access to local variable i |
@@ -1909,15 +1832,13 @@
 | cflow.cs:286:35:286:35 | access to local variable j | cflow.cs:286:35:286:35 | access to local variable j |
 | cflow.cs:291:5:294:5 | {...} | cflow.cs:291:5:294:5 | {...} |
 | cflow.cs:292:9:292:38 | ... ...; | cflow.cs:292:9:292:38 | ... ...; |
-| cflow.cs:292:24:292:24 | access to local variable y | cflow.cs:292:24:292:24 | access to local variable y |
-| cflow.cs:292:24:292:37 | Func<Int32,Int32> y = ... | cflow.cs:292:24:292:24 | access to local variable y |
+| cflow.cs:292:24:292:37 | Func<Int32,Int32> y = ... | cflow.cs:292:28:292:37 | (...) => ... |
 | cflow.cs:292:28:292:37 | (...) => ... | cflow.cs:292:28:292:37 | (...) => ... |
 | cflow.cs:292:33:292:33 | access to parameter x | cflow.cs:292:33:292:33 | access to parameter x |
 | cflow.cs:292:33:292:37 | ... + ... | cflow.cs:292:33:292:33 | access to parameter x |
 | cflow.cs:292:37:292:37 | 1 | cflow.cs:292:37:292:37 | 1 |
 | cflow.cs:293:9:293:62 | ... ...; | cflow.cs:293:9:293:62 | ... ...; |
-| cflow.cs:293:24:293:24 | access to local variable z | cflow.cs:293:24:293:24 | access to local variable z |
-| cflow.cs:293:24:293:61 | Func<Int32,Int32> z = ... | cflow.cs:293:24:293:24 | access to local variable z |
+| cflow.cs:293:24:293:61 | Func<Int32,Int32> z = ... | cflow.cs:293:28:293:61 | delegate(...) { ... } |
 | cflow.cs:293:28:293:61 | delegate(...) { ... } | cflow.cs:293:28:293:61 | delegate(...) { ... } |
 | cflow.cs:293:45:293:61 | {...} | cflow.cs:293:45:293:61 | {...} |
 | cflow.cs:293:47:293:59 | return ...; | cflow.cs:293:54:293:54 | access to parameter x |
@@ -1949,8 +1870,7 @@
 | cflow.cs:301:31:301:50 | "This should happen" | cflow.cs:301:31:301:50 | "This should happen" |
 | cflow.cs:305:5:317:5 | {...} | cflow.cs:305:5:317:5 | {...} |
 | cflow.cs:306:9:306:57 | ... ...; | cflow.cs:306:9:306:57 | ... ...; |
-| cflow.cs:306:13:306:13 | access to local variable b | cflow.cs:306:13:306:13 | access to local variable b |
-| cflow.cs:306:13:306:56 | Boolean b = ... | cflow.cs:306:13:306:13 | access to local variable b |
+| cflow.cs:306:13:306:56 | Boolean b = ... | cflow.cs:306:17:306:56 | ... && ... |
 | cflow.cs:306:17:306:21 | access to field Field | cflow.cs:306:17:306:21 | this access |
 | cflow.cs:306:17:306:21 | this access | cflow.cs:306:17:306:21 | this access |
 | cflow.cs:306:17:306:28 | access to property Length | cflow.cs:306:17:306:21 | this access |
@@ -1973,8 +1893,7 @@
 | cflow.cs:308:31:308:31 | 0 | cflow.cs:308:31:308:31 | 0 |
 | cflow.cs:308:35:308:39 | false | cflow.cs:308:35:308:39 | false |
 | cflow.cs:308:43:308:46 | true | cflow.cs:308:43:308:46 | true |
-| cflow.cs:309:13:309:13 | access to local variable b | cflow.cs:309:13:309:13 | access to local variable b |
-| cflow.cs:309:13:309:48 | ... = ... | cflow.cs:309:13:309:13 | access to local variable b |
+| cflow.cs:309:13:309:48 | ... = ... | cflow.cs:309:17:309:48 | ... ? ... : ... |
 | cflow.cs:309:13:309:49 | ...; | cflow.cs:309:13:309:49 | ...; |
 | cflow.cs:309:17:309:21 | access to field Field | cflow.cs:309:17:309:21 | this access |
 | cflow.cs:309:17:309:21 | this access | cflow.cs:309:17:309:21 | this access |
@@ -2115,8 +2034,7 @@
 | cflow.cs:374:9:374:23 | yield return ...; | cflow.cs:374:22:374:22 | 0 |
 | cflow.cs:374:22:374:22 | 0 | cflow.cs:374:22:374:22 | 0 |
 | cflow.cs:375:9:378:9 | for (...;...;...) ... | cflow.cs:375:9:378:9 | for (...;...;...) ... |
-| cflow.cs:375:18:375:18 | access to local variable i | cflow.cs:375:18:375:18 | access to local variable i |
-| cflow.cs:375:18:375:22 | Int32 i = ... | cflow.cs:375:18:375:18 | access to local variable i |
+| cflow.cs:375:18:375:22 | Int32 i = ... | cflow.cs:375:22:375:22 | 1 |
 | cflow.cs:375:22:375:22 | 1 | cflow.cs:375:22:375:22 | 1 |
 | cflow.cs:375:25:375:25 | access to local variable i | cflow.cs:375:25:375:25 | access to local variable i |
 | cflow.cs:375:25:375:30 | ... < ... | cflow.cs:375:25:375:25 | access to local variable i |

--- a/csharp/ql/test/library-tests/controlflow/graph/EntryElement.expected
+++ b/csharp/ql/test/library-tests/controlflow/graph/EntryElement.expected
@@ -1,3 +1,237 @@
+| AccessorCalls.cs:5:30:5:30 | access to parameter i | AccessorCalls.cs:5:30:5:30 | access to parameter i |
+| AccessorCalls.cs:5:37:5:39 | {...} | AccessorCalls.cs:5:37:5:39 | {...} |
+| AccessorCalls.cs:7:36:7:38 | {...} | AccessorCalls.cs:7:36:7:38 | {...} |
+| AccessorCalls.cs:7:47:7:49 | {...} | AccessorCalls.cs:7:47:7:49 | {...} |
+| AccessorCalls.cs:11:5:17:5 | {...} | AccessorCalls.cs:11:5:17:5 | {...} |
+| AccessorCalls.cs:12:9:12:12 | this access | AccessorCalls.cs:12:9:12:12 | this access |
+| AccessorCalls.cs:12:9:12:18 | access to field Field | AccessorCalls.cs:12:9:12:12 | this access |
+| AccessorCalls.cs:12:9:12:31 | ... = ... | AccessorCalls.cs:12:9:12:12 | this access |
+| AccessorCalls.cs:12:9:12:32 | ...; | AccessorCalls.cs:12:9:12:32 | ...; |
+| AccessorCalls.cs:12:22:12:25 | this access | AccessorCalls.cs:12:22:12:25 | this access |
+| AccessorCalls.cs:12:22:12:31 | access to field Field | AccessorCalls.cs:12:22:12:25 | this access |
+| AccessorCalls.cs:13:9:13:12 | this access | AccessorCalls.cs:13:9:13:12 | this access |
+| AccessorCalls.cs:13:9:13:17 | access to property Prop | AccessorCalls.cs:13:9:13:12 | this access |
+| AccessorCalls.cs:13:9:13:29 | ... = ... | AccessorCalls.cs:13:9:13:12 | this access |
+| AccessorCalls.cs:13:9:13:30 | ...; | AccessorCalls.cs:13:9:13:30 | ...; |
+| AccessorCalls.cs:13:21:13:24 | this access | AccessorCalls.cs:13:21:13:24 | this access |
+| AccessorCalls.cs:13:21:13:29 | access to property Prop | AccessorCalls.cs:13:21:13:24 | this access |
+| AccessorCalls.cs:14:9:14:12 | this access | AccessorCalls.cs:14:9:14:12 | this access |
+| AccessorCalls.cs:14:9:14:15 | access to indexer | AccessorCalls.cs:14:9:14:12 | this access |
+| AccessorCalls.cs:14:9:14:25 | ... = ... | AccessorCalls.cs:14:9:14:12 | this access |
+| AccessorCalls.cs:14:9:14:26 | ...; | AccessorCalls.cs:14:9:14:26 | ...; |
+| AccessorCalls.cs:14:14:14:14 | 0 | AccessorCalls.cs:14:14:14:14 | 0 |
+| AccessorCalls.cs:14:19:14:22 | this access | AccessorCalls.cs:14:19:14:22 | this access |
+| AccessorCalls.cs:14:19:14:25 | access to indexer | AccessorCalls.cs:14:19:14:22 | this access |
+| AccessorCalls.cs:14:24:14:24 | 1 | AccessorCalls.cs:14:24:14:24 | 1 |
+| AccessorCalls.cs:15:9:15:12 | this access | AccessorCalls.cs:15:9:15:12 | this access |
+| AccessorCalls.cs:15:9:15:18 | access to event Event | AccessorCalls.cs:15:9:15:12 | this access |
+| AccessorCalls.cs:15:9:15:23 | ... += ... | AccessorCalls.cs:15:9:15:12 | this access |
+| AccessorCalls.cs:15:9:15:24 | ...; | AccessorCalls.cs:15:9:15:24 | ...; |
+| AccessorCalls.cs:15:23:15:23 | access to parameter e | AccessorCalls.cs:15:23:15:23 | access to parameter e |
+| AccessorCalls.cs:16:9:16:12 | this access | AccessorCalls.cs:16:9:16:12 | this access |
+| AccessorCalls.cs:16:9:16:18 | access to event Event | AccessorCalls.cs:16:9:16:12 | this access |
+| AccessorCalls.cs:16:9:16:23 | ... -= ... | AccessorCalls.cs:16:9:16:12 | this access |
+| AccessorCalls.cs:16:9:16:24 | ...; | AccessorCalls.cs:16:9:16:24 | ...; |
+| AccessorCalls.cs:16:23:16:23 | access to parameter e | AccessorCalls.cs:16:23:16:23 | access to parameter e |
+| AccessorCalls.cs:20:5:26:5 | {...} | AccessorCalls.cs:20:5:26:5 | {...} |
+| AccessorCalls.cs:21:9:21:12 | this access | AccessorCalls.cs:21:9:21:12 | this access |
+| AccessorCalls.cs:21:9:21:14 | access to field x | AccessorCalls.cs:21:9:21:12 | this access |
+| AccessorCalls.cs:21:9:21:20 | access to field Field | AccessorCalls.cs:21:9:21:12 | this access |
+| AccessorCalls.cs:21:9:21:35 | ... = ... | AccessorCalls.cs:21:9:21:12 | this access |
+| AccessorCalls.cs:21:9:21:36 | ...; | AccessorCalls.cs:21:9:21:36 | ...; |
+| AccessorCalls.cs:21:24:21:27 | this access | AccessorCalls.cs:21:24:21:27 | this access |
+| AccessorCalls.cs:21:24:21:29 | access to field x | AccessorCalls.cs:21:24:21:27 | this access |
+| AccessorCalls.cs:21:24:21:35 | access to field Field | AccessorCalls.cs:21:24:21:27 | this access |
+| AccessorCalls.cs:22:9:22:12 | this access | AccessorCalls.cs:22:9:22:12 | this access |
+| AccessorCalls.cs:22:9:22:14 | access to field x | AccessorCalls.cs:22:9:22:12 | this access |
+| AccessorCalls.cs:22:9:22:19 | access to property Prop | AccessorCalls.cs:22:9:22:12 | this access |
+| AccessorCalls.cs:22:9:22:33 | ... = ... | AccessorCalls.cs:22:9:22:12 | this access |
+| AccessorCalls.cs:22:9:22:34 | ...; | AccessorCalls.cs:22:9:22:34 | ...; |
+| AccessorCalls.cs:22:23:22:26 | this access | AccessorCalls.cs:22:23:22:26 | this access |
+| AccessorCalls.cs:22:23:22:28 | access to field x | AccessorCalls.cs:22:23:22:26 | this access |
+| AccessorCalls.cs:22:23:22:33 | access to property Prop | AccessorCalls.cs:22:23:22:26 | this access |
+| AccessorCalls.cs:23:9:23:12 | this access | AccessorCalls.cs:23:9:23:12 | this access |
+| AccessorCalls.cs:23:9:23:14 | access to field x | AccessorCalls.cs:23:9:23:12 | this access |
+| AccessorCalls.cs:23:9:23:17 | access to indexer | AccessorCalls.cs:23:9:23:12 | this access |
+| AccessorCalls.cs:23:9:23:29 | ... = ... | AccessorCalls.cs:23:9:23:12 | this access |
+| AccessorCalls.cs:23:9:23:30 | ...; | AccessorCalls.cs:23:9:23:30 | ...; |
+| AccessorCalls.cs:23:16:23:16 | 0 | AccessorCalls.cs:23:16:23:16 | 0 |
+| AccessorCalls.cs:23:21:23:24 | this access | AccessorCalls.cs:23:21:23:24 | this access |
+| AccessorCalls.cs:23:21:23:26 | access to field x | AccessorCalls.cs:23:21:23:24 | this access |
+| AccessorCalls.cs:23:21:23:29 | access to indexer | AccessorCalls.cs:23:21:23:24 | this access |
+| AccessorCalls.cs:23:28:23:28 | 1 | AccessorCalls.cs:23:28:23:28 | 1 |
+| AccessorCalls.cs:24:9:24:12 | this access | AccessorCalls.cs:24:9:24:12 | this access |
+| AccessorCalls.cs:24:9:24:14 | access to field x | AccessorCalls.cs:24:9:24:12 | this access |
+| AccessorCalls.cs:24:9:24:20 | access to event Event | AccessorCalls.cs:24:9:24:12 | this access |
+| AccessorCalls.cs:24:9:24:25 | ... += ... | AccessorCalls.cs:24:9:24:12 | this access |
+| AccessorCalls.cs:24:9:24:26 | ...; | AccessorCalls.cs:24:9:24:26 | ...; |
+| AccessorCalls.cs:24:25:24:25 | access to parameter e | AccessorCalls.cs:24:25:24:25 | access to parameter e |
+| AccessorCalls.cs:25:9:25:12 | this access | AccessorCalls.cs:25:9:25:12 | this access |
+| AccessorCalls.cs:25:9:25:14 | access to field x | AccessorCalls.cs:25:9:25:12 | this access |
+| AccessorCalls.cs:25:9:25:20 | access to event Event | AccessorCalls.cs:25:9:25:12 | this access |
+| AccessorCalls.cs:25:9:25:25 | ... -= ... | AccessorCalls.cs:25:9:25:12 | this access |
+| AccessorCalls.cs:25:9:25:26 | ...; | AccessorCalls.cs:25:9:25:26 | ...; |
+| AccessorCalls.cs:25:25:25:25 | access to parameter e | AccessorCalls.cs:25:25:25:25 | access to parameter e |
+| AccessorCalls.cs:29:5:33:5 | {...} | AccessorCalls.cs:29:5:33:5 | {...} |
+| AccessorCalls.cs:30:9:30:12 | this access | AccessorCalls.cs:30:9:30:12 | this access |
+| AccessorCalls.cs:30:9:30:18 | access to field Field | AccessorCalls.cs:30:9:30:12 | this access |
+| AccessorCalls.cs:30:9:30:20 | ...++ | AccessorCalls.cs:30:9:30:12 | this access |
+| AccessorCalls.cs:30:9:30:21 | ...; | AccessorCalls.cs:30:9:30:21 | ...; |
+| AccessorCalls.cs:31:9:31:12 | this access | AccessorCalls.cs:31:9:31:12 | this access |
+| AccessorCalls.cs:31:9:31:17 | access to property Prop | AccessorCalls.cs:31:9:31:12 | this access |
+| AccessorCalls.cs:31:9:31:19 | ...++ | AccessorCalls.cs:31:9:31:12 | this access |
+| AccessorCalls.cs:31:9:31:20 | ...; | AccessorCalls.cs:31:9:31:20 | ...; |
+| AccessorCalls.cs:32:9:32:12 | this access | AccessorCalls.cs:32:9:32:12 | this access |
+| AccessorCalls.cs:32:9:32:15 | access to indexer | AccessorCalls.cs:32:9:32:12 | this access |
+| AccessorCalls.cs:32:9:32:17 | ...++ | AccessorCalls.cs:32:9:32:12 | this access |
+| AccessorCalls.cs:32:9:32:18 | ...; | AccessorCalls.cs:32:9:32:18 | ...; |
+| AccessorCalls.cs:32:14:32:14 | 0 | AccessorCalls.cs:32:14:32:14 | 0 |
+| AccessorCalls.cs:36:5:40:5 | {...} | AccessorCalls.cs:36:5:40:5 | {...} |
+| AccessorCalls.cs:37:9:37:12 | this access | AccessorCalls.cs:37:9:37:12 | this access |
+| AccessorCalls.cs:37:9:37:14 | access to field x | AccessorCalls.cs:37:9:37:12 | this access |
+| AccessorCalls.cs:37:9:37:20 | access to field Field | AccessorCalls.cs:37:9:37:12 | this access |
+| AccessorCalls.cs:37:9:37:22 | ...++ | AccessorCalls.cs:37:9:37:12 | this access |
+| AccessorCalls.cs:37:9:37:23 | ...; | AccessorCalls.cs:37:9:37:23 | ...; |
+| AccessorCalls.cs:38:9:38:12 | this access | AccessorCalls.cs:38:9:38:12 | this access |
+| AccessorCalls.cs:38:9:38:14 | access to field x | AccessorCalls.cs:38:9:38:12 | this access |
+| AccessorCalls.cs:38:9:38:19 | access to property Prop | AccessorCalls.cs:38:9:38:12 | this access |
+| AccessorCalls.cs:38:9:38:21 | ...++ | AccessorCalls.cs:38:9:38:12 | this access |
+| AccessorCalls.cs:38:9:38:22 | ...; | AccessorCalls.cs:38:9:38:22 | ...; |
+| AccessorCalls.cs:39:9:39:12 | this access | AccessorCalls.cs:39:9:39:12 | this access |
+| AccessorCalls.cs:39:9:39:14 | access to field x | AccessorCalls.cs:39:9:39:12 | this access |
+| AccessorCalls.cs:39:9:39:17 | access to indexer | AccessorCalls.cs:39:9:39:12 | this access |
+| AccessorCalls.cs:39:9:39:19 | ...++ | AccessorCalls.cs:39:9:39:12 | this access |
+| AccessorCalls.cs:39:9:39:20 | ...; | AccessorCalls.cs:39:9:39:20 | ...; |
+| AccessorCalls.cs:39:16:39:16 | 0 | AccessorCalls.cs:39:16:39:16 | 0 |
+| AccessorCalls.cs:43:5:47:5 | {...} | AccessorCalls.cs:43:5:47:5 | {...} |
+| AccessorCalls.cs:44:9:44:12 | this access | AccessorCalls.cs:44:9:44:12 | this access |
+| AccessorCalls.cs:44:9:44:12 | this access | AccessorCalls.cs:44:9:44:12 | this access |
+| AccessorCalls.cs:44:9:44:18 | access to field Field | AccessorCalls.cs:44:9:44:12 | this access |
+| AccessorCalls.cs:44:9:44:18 | access to field Field | AccessorCalls.cs:44:9:44:12 | this access |
+| AccessorCalls.cs:44:9:44:32 | ... + ... | AccessorCalls.cs:44:9:44:12 | this access |
+| AccessorCalls.cs:44:9:44:32 | ... += ... | AccessorCalls.cs:44:9:44:12 | this access |
+| AccessorCalls.cs:44:9:44:32 | ... = ... | AccessorCalls.cs:44:9:44:12 | this access |
+| AccessorCalls.cs:44:9:44:33 | ...; | AccessorCalls.cs:44:9:44:33 | ...; |
+| AccessorCalls.cs:44:23:44:26 | this access | AccessorCalls.cs:44:23:44:26 | this access |
+| AccessorCalls.cs:44:23:44:32 | access to field Field | AccessorCalls.cs:44:23:44:26 | this access |
+| AccessorCalls.cs:45:9:45:12 | this access | AccessorCalls.cs:45:9:45:12 | this access |
+| AccessorCalls.cs:45:9:45:12 | this access | AccessorCalls.cs:45:9:45:12 | this access |
+| AccessorCalls.cs:45:9:45:17 | access to property Prop | AccessorCalls.cs:45:9:45:12 | this access |
+| AccessorCalls.cs:45:9:45:17 | access to property Prop | AccessorCalls.cs:45:9:45:12 | this access |
+| AccessorCalls.cs:45:9:45:30 | ... + ... | AccessorCalls.cs:45:9:45:12 | this access |
+| AccessorCalls.cs:45:9:45:30 | ... += ... | AccessorCalls.cs:45:9:45:12 | this access |
+| AccessorCalls.cs:45:9:45:30 | ... = ... | AccessorCalls.cs:45:9:45:12 | this access |
+| AccessorCalls.cs:45:9:45:31 | ...; | AccessorCalls.cs:45:9:45:31 | ...; |
+| AccessorCalls.cs:45:22:45:25 | this access | AccessorCalls.cs:45:22:45:25 | this access |
+| AccessorCalls.cs:45:22:45:30 | access to property Prop | AccessorCalls.cs:45:22:45:25 | this access |
+| AccessorCalls.cs:46:9:46:12 | this access | AccessorCalls.cs:46:9:46:12 | this access |
+| AccessorCalls.cs:46:9:46:12 | this access | AccessorCalls.cs:46:9:46:12 | this access |
+| AccessorCalls.cs:46:9:46:15 | access to indexer | AccessorCalls.cs:46:9:46:12 | this access |
+| AccessorCalls.cs:46:9:46:15 | access to indexer | AccessorCalls.cs:46:9:46:12 | this access |
+| AccessorCalls.cs:46:9:46:26 | ... + ... | AccessorCalls.cs:46:9:46:12 | this access |
+| AccessorCalls.cs:46:9:46:26 | ... += ... | AccessorCalls.cs:46:9:46:12 | this access |
+| AccessorCalls.cs:46:9:46:26 | ... = ... | AccessorCalls.cs:46:9:46:12 | this access |
+| AccessorCalls.cs:46:9:46:27 | ...; | AccessorCalls.cs:46:9:46:27 | ...; |
+| AccessorCalls.cs:46:14:46:14 | 0 | AccessorCalls.cs:46:14:46:14 | 0 |
+| AccessorCalls.cs:46:14:46:14 | 0 | AccessorCalls.cs:46:14:46:14 | 0 |
+| AccessorCalls.cs:46:20:46:23 | this access | AccessorCalls.cs:46:20:46:23 | this access |
+| AccessorCalls.cs:46:20:46:26 | access to indexer | AccessorCalls.cs:46:20:46:23 | this access |
+| AccessorCalls.cs:46:25:46:25 | 0 | AccessorCalls.cs:46:25:46:25 | 0 |
+| AccessorCalls.cs:50:5:54:5 | {...} | AccessorCalls.cs:50:5:54:5 | {...} |
+| AccessorCalls.cs:51:9:51:12 | this access | AccessorCalls.cs:51:9:51:12 | this access |
+| AccessorCalls.cs:51:9:51:12 | this access | AccessorCalls.cs:51:9:51:12 | this access |
+| AccessorCalls.cs:51:9:51:14 | access to field x | AccessorCalls.cs:51:9:51:12 | this access |
+| AccessorCalls.cs:51:9:51:14 | access to field x | AccessorCalls.cs:51:9:51:12 | this access |
+| AccessorCalls.cs:51:9:51:20 | access to field Field | AccessorCalls.cs:51:9:51:12 | this access |
+| AccessorCalls.cs:51:9:51:20 | access to field Field | AccessorCalls.cs:51:9:51:12 | this access |
+| AccessorCalls.cs:51:9:51:36 | ... + ... | AccessorCalls.cs:51:9:51:12 | this access |
+| AccessorCalls.cs:51:9:51:36 | ... += ... | AccessorCalls.cs:51:9:51:12 | this access |
+| AccessorCalls.cs:51:9:51:36 | ... = ... | AccessorCalls.cs:51:9:51:12 | this access |
+| AccessorCalls.cs:51:9:51:37 | ...; | AccessorCalls.cs:51:9:51:37 | ...; |
+| AccessorCalls.cs:51:25:51:28 | this access | AccessorCalls.cs:51:25:51:28 | this access |
+| AccessorCalls.cs:51:25:51:30 | access to field x | AccessorCalls.cs:51:25:51:28 | this access |
+| AccessorCalls.cs:51:25:51:36 | access to field Field | AccessorCalls.cs:51:25:51:28 | this access |
+| AccessorCalls.cs:52:9:52:12 | this access | AccessorCalls.cs:52:9:52:12 | this access |
+| AccessorCalls.cs:52:9:52:12 | this access | AccessorCalls.cs:52:9:52:12 | this access |
+| AccessorCalls.cs:52:9:52:14 | access to field x | AccessorCalls.cs:52:9:52:12 | this access |
+| AccessorCalls.cs:52:9:52:14 | access to field x | AccessorCalls.cs:52:9:52:12 | this access |
+| AccessorCalls.cs:52:9:52:19 | access to property Prop | AccessorCalls.cs:52:9:52:12 | this access |
+| AccessorCalls.cs:52:9:52:19 | access to property Prop | AccessorCalls.cs:52:9:52:12 | this access |
+| AccessorCalls.cs:52:9:52:34 | ... + ... | AccessorCalls.cs:52:9:52:12 | this access |
+| AccessorCalls.cs:52:9:52:34 | ... += ... | AccessorCalls.cs:52:9:52:12 | this access |
+| AccessorCalls.cs:52:9:52:34 | ... = ... | AccessorCalls.cs:52:9:52:12 | this access |
+| AccessorCalls.cs:52:9:52:35 | ...; | AccessorCalls.cs:52:9:52:35 | ...; |
+| AccessorCalls.cs:52:24:52:27 | this access | AccessorCalls.cs:52:24:52:27 | this access |
+| AccessorCalls.cs:52:24:52:29 | access to field x | AccessorCalls.cs:52:24:52:27 | this access |
+| AccessorCalls.cs:52:24:52:34 | access to property Prop | AccessorCalls.cs:52:24:52:27 | this access |
+| AccessorCalls.cs:53:9:53:12 | this access | AccessorCalls.cs:53:9:53:12 | this access |
+| AccessorCalls.cs:53:9:53:12 | this access | AccessorCalls.cs:53:9:53:12 | this access |
+| AccessorCalls.cs:53:9:53:14 | access to field x | AccessorCalls.cs:53:9:53:12 | this access |
+| AccessorCalls.cs:53:9:53:14 | access to field x | AccessorCalls.cs:53:9:53:12 | this access |
+| AccessorCalls.cs:53:9:53:17 | access to indexer | AccessorCalls.cs:53:9:53:12 | this access |
+| AccessorCalls.cs:53:9:53:17 | access to indexer | AccessorCalls.cs:53:9:53:12 | this access |
+| AccessorCalls.cs:53:9:53:30 | ... + ... | AccessorCalls.cs:53:9:53:12 | this access |
+| AccessorCalls.cs:53:9:53:30 | ... += ... | AccessorCalls.cs:53:9:53:12 | this access |
+| AccessorCalls.cs:53:9:53:30 | ... = ... | AccessorCalls.cs:53:9:53:12 | this access |
+| AccessorCalls.cs:53:9:53:31 | ...; | AccessorCalls.cs:53:9:53:31 | ...; |
+| AccessorCalls.cs:53:16:53:16 | 0 | AccessorCalls.cs:53:16:53:16 | 0 |
+| AccessorCalls.cs:53:16:53:16 | 0 | AccessorCalls.cs:53:16:53:16 | 0 |
+| AccessorCalls.cs:53:22:53:25 | this access | AccessorCalls.cs:53:22:53:25 | this access |
+| AccessorCalls.cs:53:22:53:27 | access to field x | AccessorCalls.cs:53:22:53:25 | this access |
+| AccessorCalls.cs:53:22:53:30 | access to indexer | AccessorCalls.cs:53:22:53:25 | this access |
+| AccessorCalls.cs:53:29:53:29 | 0 | AccessorCalls.cs:53:29:53:29 | 0 |
+| AccessorCalls.cs:57:5:59:5 | {...} | AccessorCalls.cs:57:5:59:5 | {...} |
+| AccessorCalls.cs:58:9:58:45 | (..., ...) | AccessorCalls.cs:58:10:58:13 | this access |
+| AccessorCalls.cs:58:9:58:85 | ... = ... | AccessorCalls.cs:58:10:58:13 | this access |
+| AccessorCalls.cs:58:9:58:86 | ...; | AccessorCalls.cs:58:9:58:86 | ...; |
+| AccessorCalls.cs:58:10:58:13 | this access | AccessorCalls.cs:58:10:58:13 | this access |
+| AccessorCalls.cs:58:10:58:19 | access to field Field | AccessorCalls.cs:58:10:58:13 | this access |
+| AccessorCalls.cs:58:22:58:25 | this access | AccessorCalls.cs:58:22:58:25 | this access |
+| AccessorCalls.cs:58:22:58:30 | access to property Prop | AccessorCalls.cs:58:22:58:25 | this access |
+| AccessorCalls.cs:58:33:58:44 | (..., ...) | AccessorCalls.cs:58:34:58:34 | access to parameter i |
+| AccessorCalls.cs:58:34:58:34 | access to parameter i | AccessorCalls.cs:58:34:58:34 | access to parameter i |
+| AccessorCalls.cs:58:37:58:40 | this access | AccessorCalls.cs:58:37:58:40 | this access |
+| AccessorCalls.cs:58:37:58:43 | access to indexer | AccessorCalls.cs:58:37:58:40 | this access |
+| AccessorCalls.cs:58:42:58:42 | 0 | AccessorCalls.cs:58:42:58:42 | 0 |
+| AccessorCalls.cs:58:49:58:85 | (..., ...) | AccessorCalls.cs:58:50:58:53 | this access |
+| AccessorCalls.cs:58:50:58:53 | this access | AccessorCalls.cs:58:50:58:53 | this access |
+| AccessorCalls.cs:58:50:58:59 | access to field Field | AccessorCalls.cs:58:50:58:53 | this access |
+| AccessorCalls.cs:58:62:58:65 | this access | AccessorCalls.cs:58:62:58:65 | this access |
+| AccessorCalls.cs:58:62:58:70 | access to property Prop | AccessorCalls.cs:58:62:58:65 | this access |
+| AccessorCalls.cs:58:73:58:84 | (..., ...) | AccessorCalls.cs:58:74:58:74 | 0 |
+| AccessorCalls.cs:58:74:58:74 | 0 | AccessorCalls.cs:58:74:58:74 | 0 |
+| AccessorCalls.cs:58:77:58:80 | this access | AccessorCalls.cs:58:77:58:80 | this access |
+| AccessorCalls.cs:58:77:58:83 | access to indexer | AccessorCalls.cs:58:77:58:80 | this access |
+| AccessorCalls.cs:58:82:58:82 | 1 | AccessorCalls.cs:58:82:58:82 | 1 |
+| AccessorCalls.cs:62:5:64:5 | {...} | AccessorCalls.cs:62:5:64:5 | {...} |
+| AccessorCalls.cs:63:9:63:51 | (..., ...) | AccessorCalls.cs:63:10:63:13 | this access |
+| AccessorCalls.cs:63:9:63:97 | ... = ... | AccessorCalls.cs:63:10:63:13 | this access |
+| AccessorCalls.cs:63:9:63:98 | ...; | AccessorCalls.cs:63:9:63:98 | ...; |
+| AccessorCalls.cs:63:10:63:13 | this access | AccessorCalls.cs:63:10:63:13 | this access |
+| AccessorCalls.cs:63:10:63:15 | access to field x | AccessorCalls.cs:63:10:63:13 | this access |
+| AccessorCalls.cs:63:10:63:21 | access to field Field | AccessorCalls.cs:63:10:63:13 | this access |
+| AccessorCalls.cs:63:24:63:27 | this access | AccessorCalls.cs:63:24:63:27 | this access |
+| AccessorCalls.cs:63:24:63:29 | access to field x | AccessorCalls.cs:63:24:63:27 | this access |
+| AccessorCalls.cs:63:24:63:34 | access to property Prop | AccessorCalls.cs:63:24:63:27 | this access |
+| AccessorCalls.cs:63:37:63:50 | (..., ...) | AccessorCalls.cs:63:38:63:38 | access to parameter i |
+| AccessorCalls.cs:63:38:63:38 | access to parameter i | AccessorCalls.cs:63:38:63:38 | access to parameter i |
+| AccessorCalls.cs:63:41:63:44 | this access | AccessorCalls.cs:63:41:63:44 | this access |
+| AccessorCalls.cs:63:41:63:46 | access to field x | AccessorCalls.cs:63:41:63:44 | this access |
+| AccessorCalls.cs:63:41:63:49 | access to indexer | AccessorCalls.cs:63:41:63:44 | this access |
+| AccessorCalls.cs:63:48:63:48 | 0 | AccessorCalls.cs:63:48:63:48 | 0 |
+| AccessorCalls.cs:63:55:63:97 | (..., ...) | AccessorCalls.cs:63:56:63:59 | this access |
+| AccessorCalls.cs:63:56:63:59 | this access | AccessorCalls.cs:63:56:63:59 | this access |
+| AccessorCalls.cs:63:56:63:61 | access to field x | AccessorCalls.cs:63:56:63:59 | this access |
+| AccessorCalls.cs:63:56:63:67 | access to field Field | AccessorCalls.cs:63:56:63:59 | this access |
+| AccessorCalls.cs:63:70:63:73 | this access | AccessorCalls.cs:63:70:63:73 | this access |
+| AccessorCalls.cs:63:70:63:75 | access to field x | AccessorCalls.cs:63:70:63:73 | this access |
+| AccessorCalls.cs:63:70:63:80 | access to property Prop | AccessorCalls.cs:63:70:63:73 | this access |
+| AccessorCalls.cs:63:83:63:96 | (..., ...) | AccessorCalls.cs:63:84:63:84 | 0 |
+| AccessorCalls.cs:63:84:63:84 | 0 | AccessorCalls.cs:63:84:63:84 | 0 |
+| AccessorCalls.cs:63:87:63:90 | this access | AccessorCalls.cs:63:87:63:90 | this access |
+| AccessorCalls.cs:63:87:63:92 | access to field x | AccessorCalls.cs:63:87:63:90 | this access |
+| AccessorCalls.cs:63:87:63:95 | access to indexer | AccessorCalls.cs:63:87:63:90 | this access |
+| AccessorCalls.cs:63:94:63:94 | 1 | AccessorCalls.cs:63:94:63:94 | 1 |
 | ArrayCreation.cs:3:19:3:28 | array creation of type Int32[] | ArrayCreation.cs:3:27:3:27 | 0 |
 | ArrayCreation.cs:3:27:3:27 | 0 | ArrayCreation.cs:3:27:3:27 | 0 |
 | ArrayCreation.cs:5:20:5:32 | array creation of type Int32[,] | ArrayCreation.cs:5:28:5:28 | 0 |

--- a/csharp/ql/test/library-tests/controlflow/graph/EntryPoint.expected
+++ b/csharp/ql/test/library-tests/controlflow/graph/EntryPoint.expected
@@ -1,3 +1,15 @@
+| AccessorCalls.cs:5:23:5:25 | get_Item | AccessorCalls.cs:5:30:5:30 | access to parameter i |
+| AccessorCalls.cs:5:33:5:35 | set_Item | AccessorCalls.cs:5:37:5:39 | {...} |
+| AccessorCalls.cs:7:32:7:34 | add_Event | AccessorCalls.cs:7:36:7:38 | {...} |
+| AccessorCalls.cs:7:40:7:45 | remove_Event | AccessorCalls.cs:7:47:7:49 | {...} |
+| AccessorCalls.cs:10:10:10:11 | M1 | AccessorCalls.cs:11:5:17:5 | {...} |
+| AccessorCalls.cs:19:10:19:11 | M2 | AccessorCalls.cs:20:5:26:5 | {...} |
+| AccessorCalls.cs:28:10:28:11 | M3 | AccessorCalls.cs:29:5:33:5 | {...} |
+| AccessorCalls.cs:35:10:35:11 | M4 | AccessorCalls.cs:36:5:40:5 | {...} |
+| AccessorCalls.cs:42:10:42:11 | M5 | AccessorCalls.cs:43:5:47:5 | {...} |
+| AccessorCalls.cs:49:10:49:11 | M6 | AccessorCalls.cs:50:5:54:5 | {...} |
+| AccessorCalls.cs:56:10:56:11 | M7 | AccessorCalls.cs:57:5:59:5 | {...} |
+| AccessorCalls.cs:61:10:61:11 | M8 | AccessorCalls.cs:62:5:64:5 | {...} |
 | ArrayCreation.cs:3:11:3:12 | M1 | ArrayCreation.cs:3:27:3:27 | 0 |
 | ArrayCreation.cs:5:12:5:13 | M2 | ArrayCreation.cs:5:28:5:28 | 0 |
 | ArrayCreation.cs:7:11:7:12 | M3 | ArrayCreation.cs:7:19:7:36 | array creation of type Int32[] |

--- a/csharp/ql/test/library-tests/controlflow/graph/ExitElement.expected
+++ b/csharp/ql/test/library-tests/controlflow/graph/ExitElement.expected
@@ -1,3 +1,237 @@
+| AccessorCalls.cs:5:30:5:30 | access to parameter i | AccessorCalls.cs:5:30:5:30 | access to parameter i | normal |
+| AccessorCalls.cs:5:37:5:39 | {...} | AccessorCalls.cs:5:37:5:39 | {...} | normal |
+| AccessorCalls.cs:7:36:7:38 | {...} | AccessorCalls.cs:7:36:7:38 | {...} | normal |
+| AccessorCalls.cs:7:47:7:49 | {...} | AccessorCalls.cs:7:47:7:49 | {...} | normal |
+| AccessorCalls.cs:11:5:17:5 | {...} | AccessorCalls.cs:16:9:16:23 | ... -= ... | normal |
+| AccessorCalls.cs:12:9:12:12 | this access | AccessorCalls.cs:12:9:12:12 | this access | normal |
+| AccessorCalls.cs:12:9:12:18 | access to field Field | AccessorCalls.cs:12:9:12:18 | access to field Field | normal |
+| AccessorCalls.cs:12:9:12:31 | ... = ... | AccessorCalls.cs:12:9:12:31 | ... = ... | normal |
+| AccessorCalls.cs:12:9:12:32 | ...; | AccessorCalls.cs:12:9:12:31 | ... = ... | normal |
+| AccessorCalls.cs:12:22:12:25 | this access | AccessorCalls.cs:12:22:12:25 | this access | normal |
+| AccessorCalls.cs:12:22:12:31 | access to field Field | AccessorCalls.cs:12:22:12:31 | access to field Field | normal |
+| AccessorCalls.cs:13:9:13:12 | this access | AccessorCalls.cs:13:9:13:12 | this access | normal |
+| AccessorCalls.cs:13:9:13:17 | access to property Prop | AccessorCalls.cs:13:9:13:17 | access to property Prop | normal |
+| AccessorCalls.cs:13:9:13:29 | ... = ... | AccessorCalls.cs:13:9:13:29 | ... = ... | normal |
+| AccessorCalls.cs:13:9:13:30 | ...; | AccessorCalls.cs:13:9:13:29 | ... = ... | normal |
+| AccessorCalls.cs:13:21:13:24 | this access | AccessorCalls.cs:13:21:13:24 | this access | normal |
+| AccessorCalls.cs:13:21:13:29 | access to property Prop | AccessorCalls.cs:13:21:13:29 | access to property Prop | normal |
+| AccessorCalls.cs:14:9:14:12 | this access | AccessorCalls.cs:14:9:14:12 | this access | normal |
+| AccessorCalls.cs:14:9:14:15 | access to indexer | AccessorCalls.cs:14:9:14:15 | access to indexer | normal |
+| AccessorCalls.cs:14:9:14:25 | ... = ... | AccessorCalls.cs:14:9:14:25 | ... = ... | normal |
+| AccessorCalls.cs:14:9:14:26 | ...; | AccessorCalls.cs:14:9:14:25 | ... = ... | normal |
+| AccessorCalls.cs:14:14:14:14 | 0 | AccessorCalls.cs:14:14:14:14 | 0 | normal |
+| AccessorCalls.cs:14:19:14:22 | this access | AccessorCalls.cs:14:19:14:22 | this access | normal |
+| AccessorCalls.cs:14:19:14:25 | access to indexer | AccessorCalls.cs:14:19:14:25 | access to indexer | normal |
+| AccessorCalls.cs:14:24:14:24 | 1 | AccessorCalls.cs:14:24:14:24 | 1 | normal |
+| AccessorCalls.cs:15:9:15:12 | this access | AccessorCalls.cs:15:9:15:12 | this access | normal |
+| AccessorCalls.cs:15:9:15:18 | access to event Event | AccessorCalls.cs:15:9:15:18 | access to event Event | normal |
+| AccessorCalls.cs:15:9:15:23 | ... += ... | AccessorCalls.cs:15:9:15:23 | ... += ... | normal |
+| AccessorCalls.cs:15:9:15:24 | ...; | AccessorCalls.cs:15:9:15:23 | ... += ... | normal |
+| AccessorCalls.cs:15:23:15:23 | access to parameter e | AccessorCalls.cs:15:23:15:23 | access to parameter e | normal |
+| AccessorCalls.cs:16:9:16:12 | this access | AccessorCalls.cs:16:9:16:12 | this access | normal |
+| AccessorCalls.cs:16:9:16:18 | access to event Event | AccessorCalls.cs:16:9:16:18 | access to event Event | normal |
+| AccessorCalls.cs:16:9:16:23 | ... -= ... | AccessorCalls.cs:16:9:16:23 | ... -= ... | normal |
+| AccessorCalls.cs:16:9:16:24 | ...; | AccessorCalls.cs:16:9:16:23 | ... -= ... | normal |
+| AccessorCalls.cs:16:23:16:23 | access to parameter e | AccessorCalls.cs:16:23:16:23 | access to parameter e | normal |
+| AccessorCalls.cs:20:5:26:5 | {...} | AccessorCalls.cs:25:9:25:25 | ... -= ... | normal |
+| AccessorCalls.cs:21:9:21:12 | this access | AccessorCalls.cs:21:9:21:12 | this access | normal |
+| AccessorCalls.cs:21:9:21:14 | access to field x | AccessorCalls.cs:21:9:21:14 | access to field x | normal |
+| AccessorCalls.cs:21:9:21:20 | access to field Field | AccessorCalls.cs:21:9:21:20 | access to field Field | normal |
+| AccessorCalls.cs:21:9:21:35 | ... = ... | AccessorCalls.cs:21:9:21:35 | ... = ... | normal |
+| AccessorCalls.cs:21:9:21:36 | ...; | AccessorCalls.cs:21:9:21:35 | ... = ... | normal |
+| AccessorCalls.cs:21:24:21:27 | this access | AccessorCalls.cs:21:24:21:27 | this access | normal |
+| AccessorCalls.cs:21:24:21:29 | access to field x | AccessorCalls.cs:21:24:21:29 | access to field x | normal |
+| AccessorCalls.cs:21:24:21:35 | access to field Field | AccessorCalls.cs:21:24:21:35 | access to field Field | normal |
+| AccessorCalls.cs:22:9:22:12 | this access | AccessorCalls.cs:22:9:22:12 | this access | normal |
+| AccessorCalls.cs:22:9:22:14 | access to field x | AccessorCalls.cs:22:9:22:14 | access to field x | normal |
+| AccessorCalls.cs:22:9:22:19 | access to property Prop | AccessorCalls.cs:22:9:22:19 | access to property Prop | normal |
+| AccessorCalls.cs:22:9:22:33 | ... = ... | AccessorCalls.cs:22:9:22:33 | ... = ... | normal |
+| AccessorCalls.cs:22:9:22:34 | ...; | AccessorCalls.cs:22:9:22:33 | ... = ... | normal |
+| AccessorCalls.cs:22:23:22:26 | this access | AccessorCalls.cs:22:23:22:26 | this access | normal |
+| AccessorCalls.cs:22:23:22:28 | access to field x | AccessorCalls.cs:22:23:22:28 | access to field x | normal |
+| AccessorCalls.cs:22:23:22:33 | access to property Prop | AccessorCalls.cs:22:23:22:33 | access to property Prop | normal |
+| AccessorCalls.cs:23:9:23:12 | this access | AccessorCalls.cs:23:9:23:12 | this access | normal |
+| AccessorCalls.cs:23:9:23:14 | access to field x | AccessorCalls.cs:23:9:23:14 | access to field x | normal |
+| AccessorCalls.cs:23:9:23:17 | access to indexer | AccessorCalls.cs:23:9:23:17 | access to indexer | normal |
+| AccessorCalls.cs:23:9:23:29 | ... = ... | AccessorCalls.cs:23:9:23:29 | ... = ... | normal |
+| AccessorCalls.cs:23:9:23:30 | ...; | AccessorCalls.cs:23:9:23:29 | ... = ... | normal |
+| AccessorCalls.cs:23:16:23:16 | 0 | AccessorCalls.cs:23:16:23:16 | 0 | normal |
+| AccessorCalls.cs:23:21:23:24 | this access | AccessorCalls.cs:23:21:23:24 | this access | normal |
+| AccessorCalls.cs:23:21:23:26 | access to field x | AccessorCalls.cs:23:21:23:26 | access to field x | normal |
+| AccessorCalls.cs:23:21:23:29 | access to indexer | AccessorCalls.cs:23:21:23:29 | access to indexer | normal |
+| AccessorCalls.cs:23:28:23:28 | 1 | AccessorCalls.cs:23:28:23:28 | 1 | normal |
+| AccessorCalls.cs:24:9:24:12 | this access | AccessorCalls.cs:24:9:24:12 | this access | normal |
+| AccessorCalls.cs:24:9:24:14 | access to field x | AccessorCalls.cs:24:9:24:14 | access to field x | normal |
+| AccessorCalls.cs:24:9:24:20 | access to event Event | AccessorCalls.cs:24:9:24:20 | access to event Event | normal |
+| AccessorCalls.cs:24:9:24:25 | ... += ... | AccessorCalls.cs:24:9:24:25 | ... += ... | normal |
+| AccessorCalls.cs:24:9:24:26 | ...; | AccessorCalls.cs:24:9:24:25 | ... += ... | normal |
+| AccessorCalls.cs:24:25:24:25 | access to parameter e | AccessorCalls.cs:24:25:24:25 | access to parameter e | normal |
+| AccessorCalls.cs:25:9:25:12 | this access | AccessorCalls.cs:25:9:25:12 | this access | normal |
+| AccessorCalls.cs:25:9:25:14 | access to field x | AccessorCalls.cs:25:9:25:14 | access to field x | normal |
+| AccessorCalls.cs:25:9:25:20 | access to event Event | AccessorCalls.cs:25:9:25:20 | access to event Event | normal |
+| AccessorCalls.cs:25:9:25:25 | ... -= ... | AccessorCalls.cs:25:9:25:25 | ... -= ... | normal |
+| AccessorCalls.cs:25:9:25:26 | ...; | AccessorCalls.cs:25:9:25:25 | ... -= ... | normal |
+| AccessorCalls.cs:25:25:25:25 | access to parameter e | AccessorCalls.cs:25:25:25:25 | access to parameter e | normal |
+| AccessorCalls.cs:29:5:33:5 | {...} | AccessorCalls.cs:32:9:32:17 | ...++ | normal |
+| AccessorCalls.cs:30:9:30:12 | this access | AccessorCalls.cs:30:9:30:12 | this access | normal |
+| AccessorCalls.cs:30:9:30:18 | access to field Field | AccessorCalls.cs:30:9:30:18 | access to field Field | normal |
+| AccessorCalls.cs:30:9:30:20 | ...++ | AccessorCalls.cs:30:9:30:20 | ...++ | normal |
+| AccessorCalls.cs:30:9:30:21 | ...; | AccessorCalls.cs:30:9:30:20 | ...++ | normal |
+| AccessorCalls.cs:31:9:31:12 | this access | AccessorCalls.cs:31:9:31:12 | this access | normal |
+| AccessorCalls.cs:31:9:31:17 | access to property Prop | AccessorCalls.cs:31:9:31:17 | access to property Prop | normal |
+| AccessorCalls.cs:31:9:31:19 | ...++ | AccessorCalls.cs:31:9:31:19 | ...++ | normal |
+| AccessorCalls.cs:31:9:31:20 | ...; | AccessorCalls.cs:31:9:31:19 | ...++ | normal |
+| AccessorCalls.cs:32:9:32:12 | this access | AccessorCalls.cs:32:9:32:12 | this access | normal |
+| AccessorCalls.cs:32:9:32:15 | access to indexer | AccessorCalls.cs:32:9:32:15 | access to indexer | normal |
+| AccessorCalls.cs:32:9:32:17 | ...++ | AccessorCalls.cs:32:9:32:17 | ...++ | normal |
+| AccessorCalls.cs:32:9:32:18 | ...; | AccessorCalls.cs:32:9:32:17 | ...++ | normal |
+| AccessorCalls.cs:32:14:32:14 | 0 | AccessorCalls.cs:32:14:32:14 | 0 | normal |
+| AccessorCalls.cs:36:5:40:5 | {...} | AccessorCalls.cs:39:9:39:19 | ...++ | normal |
+| AccessorCalls.cs:37:9:37:12 | this access | AccessorCalls.cs:37:9:37:12 | this access | normal |
+| AccessorCalls.cs:37:9:37:14 | access to field x | AccessorCalls.cs:37:9:37:14 | access to field x | normal |
+| AccessorCalls.cs:37:9:37:20 | access to field Field | AccessorCalls.cs:37:9:37:20 | access to field Field | normal |
+| AccessorCalls.cs:37:9:37:22 | ...++ | AccessorCalls.cs:37:9:37:22 | ...++ | normal |
+| AccessorCalls.cs:37:9:37:23 | ...; | AccessorCalls.cs:37:9:37:22 | ...++ | normal |
+| AccessorCalls.cs:38:9:38:12 | this access | AccessorCalls.cs:38:9:38:12 | this access | normal |
+| AccessorCalls.cs:38:9:38:14 | access to field x | AccessorCalls.cs:38:9:38:14 | access to field x | normal |
+| AccessorCalls.cs:38:9:38:19 | access to property Prop | AccessorCalls.cs:38:9:38:19 | access to property Prop | normal |
+| AccessorCalls.cs:38:9:38:21 | ...++ | AccessorCalls.cs:38:9:38:21 | ...++ | normal |
+| AccessorCalls.cs:38:9:38:22 | ...; | AccessorCalls.cs:38:9:38:21 | ...++ | normal |
+| AccessorCalls.cs:39:9:39:12 | this access | AccessorCalls.cs:39:9:39:12 | this access | normal |
+| AccessorCalls.cs:39:9:39:14 | access to field x | AccessorCalls.cs:39:9:39:14 | access to field x | normal |
+| AccessorCalls.cs:39:9:39:17 | access to indexer | AccessorCalls.cs:39:9:39:17 | access to indexer | normal |
+| AccessorCalls.cs:39:9:39:19 | ...++ | AccessorCalls.cs:39:9:39:19 | ...++ | normal |
+| AccessorCalls.cs:39:9:39:20 | ...; | AccessorCalls.cs:39:9:39:19 | ...++ | normal |
+| AccessorCalls.cs:39:16:39:16 | 0 | AccessorCalls.cs:39:16:39:16 | 0 | normal |
+| AccessorCalls.cs:43:5:47:5 | {...} | AccessorCalls.cs:46:9:46:26 | ... = ... | normal |
+| AccessorCalls.cs:44:9:44:12 | this access | AccessorCalls.cs:44:9:44:12 | this access | normal |
+| AccessorCalls.cs:44:9:44:12 | this access | AccessorCalls.cs:44:9:44:12 | this access | normal |
+| AccessorCalls.cs:44:9:44:18 | access to field Field | AccessorCalls.cs:44:9:44:18 | access to field Field | normal |
+| AccessorCalls.cs:44:9:44:18 | access to field Field | AccessorCalls.cs:44:9:44:18 | access to field Field | normal |
+| AccessorCalls.cs:44:9:44:32 | ... + ... | AccessorCalls.cs:44:9:44:32 | ... + ... | normal |
+| AccessorCalls.cs:44:9:44:32 | ... += ... | AccessorCalls.cs:44:9:44:32 | ... = ... | normal |
+| AccessorCalls.cs:44:9:44:32 | ... = ... | AccessorCalls.cs:44:9:44:32 | ... = ... | normal |
+| AccessorCalls.cs:44:9:44:33 | ...; | AccessorCalls.cs:44:9:44:32 | ... = ... | normal |
+| AccessorCalls.cs:44:23:44:26 | this access | AccessorCalls.cs:44:23:44:26 | this access | normal |
+| AccessorCalls.cs:44:23:44:32 | access to field Field | AccessorCalls.cs:44:23:44:32 | access to field Field | normal |
+| AccessorCalls.cs:45:9:45:12 | this access | AccessorCalls.cs:45:9:45:12 | this access | normal |
+| AccessorCalls.cs:45:9:45:12 | this access | AccessorCalls.cs:45:9:45:12 | this access | normal |
+| AccessorCalls.cs:45:9:45:17 | access to property Prop | AccessorCalls.cs:45:9:45:17 | access to property Prop | normal |
+| AccessorCalls.cs:45:9:45:17 | access to property Prop | AccessorCalls.cs:45:9:45:17 | access to property Prop | normal |
+| AccessorCalls.cs:45:9:45:30 | ... + ... | AccessorCalls.cs:45:9:45:30 | ... + ... | normal |
+| AccessorCalls.cs:45:9:45:30 | ... += ... | AccessorCalls.cs:45:9:45:30 | ... = ... | normal |
+| AccessorCalls.cs:45:9:45:30 | ... = ... | AccessorCalls.cs:45:9:45:30 | ... = ... | normal |
+| AccessorCalls.cs:45:9:45:31 | ...; | AccessorCalls.cs:45:9:45:30 | ... = ... | normal |
+| AccessorCalls.cs:45:22:45:25 | this access | AccessorCalls.cs:45:22:45:25 | this access | normal |
+| AccessorCalls.cs:45:22:45:30 | access to property Prop | AccessorCalls.cs:45:22:45:30 | access to property Prop | normal |
+| AccessorCalls.cs:46:9:46:12 | this access | AccessorCalls.cs:46:9:46:12 | this access | normal |
+| AccessorCalls.cs:46:9:46:12 | this access | AccessorCalls.cs:46:9:46:12 | this access | normal |
+| AccessorCalls.cs:46:9:46:15 | access to indexer | AccessorCalls.cs:46:9:46:15 | access to indexer | normal |
+| AccessorCalls.cs:46:9:46:15 | access to indexer | AccessorCalls.cs:46:9:46:15 | access to indexer | normal |
+| AccessorCalls.cs:46:9:46:26 | ... + ... | AccessorCalls.cs:46:9:46:26 | ... + ... | normal |
+| AccessorCalls.cs:46:9:46:26 | ... += ... | AccessorCalls.cs:46:9:46:26 | ... = ... | normal |
+| AccessorCalls.cs:46:9:46:26 | ... = ... | AccessorCalls.cs:46:9:46:26 | ... = ... | normal |
+| AccessorCalls.cs:46:9:46:27 | ...; | AccessorCalls.cs:46:9:46:26 | ... = ... | normal |
+| AccessorCalls.cs:46:14:46:14 | 0 | AccessorCalls.cs:46:14:46:14 | 0 | normal |
+| AccessorCalls.cs:46:14:46:14 | 0 | AccessorCalls.cs:46:14:46:14 | 0 | normal |
+| AccessorCalls.cs:46:20:46:23 | this access | AccessorCalls.cs:46:20:46:23 | this access | normal |
+| AccessorCalls.cs:46:20:46:26 | access to indexer | AccessorCalls.cs:46:20:46:26 | access to indexer | normal |
+| AccessorCalls.cs:46:25:46:25 | 0 | AccessorCalls.cs:46:25:46:25 | 0 | normal |
+| AccessorCalls.cs:50:5:54:5 | {...} | AccessorCalls.cs:53:9:53:30 | ... = ... | normal |
+| AccessorCalls.cs:51:9:51:12 | this access | AccessorCalls.cs:51:9:51:12 | this access | normal |
+| AccessorCalls.cs:51:9:51:12 | this access | AccessorCalls.cs:51:9:51:12 | this access | normal |
+| AccessorCalls.cs:51:9:51:14 | access to field x | AccessorCalls.cs:51:9:51:14 | access to field x | normal |
+| AccessorCalls.cs:51:9:51:14 | access to field x | AccessorCalls.cs:51:9:51:14 | access to field x | normal |
+| AccessorCalls.cs:51:9:51:20 | access to field Field | AccessorCalls.cs:51:9:51:20 | access to field Field | normal |
+| AccessorCalls.cs:51:9:51:20 | access to field Field | AccessorCalls.cs:51:9:51:20 | access to field Field | normal |
+| AccessorCalls.cs:51:9:51:36 | ... + ... | AccessorCalls.cs:51:9:51:36 | ... + ... | normal |
+| AccessorCalls.cs:51:9:51:36 | ... += ... | AccessorCalls.cs:51:9:51:36 | ... = ... | normal |
+| AccessorCalls.cs:51:9:51:36 | ... = ... | AccessorCalls.cs:51:9:51:36 | ... = ... | normal |
+| AccessorCalls.cs:51:9:51:37 | ...; | AccessorCalls.cs:51:9:51:36 | ... = ... | normal |
+| AccessorCalls.cs:51:25:51:28 | this access | AccessorCalls.cs:51:25:51:28 | this access | normal |
+| AccessorCalls.cs:51:25:51:30 | access to field x | AccessorCalls.cs:51:25:51:30 | access to field x | normal |
+| AccessorCalls.cs:51:25:51:36 | access to field Field | AccessorCalls.cs:51:25:51:36 | access to field Field | normal |
+| AccessorCalls.cs:52:9:52:12 | this access | AccessorCalls.cs:52:9:52:12 | this access | normal |
+| AccessorCalls.cs:52:9:52:12 | this access | AccessorCalls.cs:52:9:52:12 | this access | normal |
+| AccessorCalls.cs:52:9:52:14 | access to field x | AccessorCalls.cs:52:9:52:14 | access to field x | normal |
+| AccessorCalls.cs:52:9:52:14 | access to field x | AccessorCalls.cs:52:9:52:14 | access to field x | normal |
+| AccessorCalls.cs:52:9:52:19 | access to property Prop | AccessorCalls.cs:52:9:52:19 | access to property Prop | normal |
+| AccessorCalls.cs:52:9:52:19 | access to property Prop | AccessorCalls.cs:52:9:52:19 | access to property Prop | normal |
+| AccessorCalls.cs:52:9:52:34 | ... + ... | AccessorCalls.cs:52:9:52:34 | ... + ... | normal |
+| AccessorCalls.cs:52:9:52:34 | ... += ... | AccessorCalls.cs:52:9:52:34 | ... = ... | normal |
+| AccessorCalls.cs:52:9:52:34 | ... = ... | AccessorCalls.cs:52:9:52:34 | ... = ... | normal |
+| AccessorCalls.cs:52:9:52:35 | ...; | AccessorCalls.cs:52:9:52:34 | ... = ... | normal |
+| AccessorCalls.cs:52:24:52:27 | this access | AccessorCalls.cs:52:24:52:27 | this access | normal |
+| AccessorCalls.cs:52:24:52:29 | access to field x | AccessorCalls.cs:52:24:52:29 | access to field x | normal |
+| AccessorCalls.cs:52:24:52:34 | access to property Prop | AccessorCalls.cs:52:24:52:34 | access to property Prop | normal |
+| AccessorCalls.cs:53:9:53:12 | this access | AccessorCalls.cs:53:9:53:12 | this access | normal |
+| AccessorCalls.cs:53:9:53:12 | this access | AccessorCalls.cs:53:9:53:12 | this access | normal |
+| AccessorCalls.cs:53:9:53:14 | access to field x | AccessorCalls.cs:53:9:53:14 | access to field x | normal |
+| AccessorCalls.cs:53:9:53:14 | access to field x | AccessorCalls.cs:53:9:53:14 | access to field x | normal |
+| AccessorCalls.cs:53:9:53:17 | access to indexer | AccessorCalls.cs:53:9:53:17 | access to indexer | normal |
+| AccessorCalls.cs:53:9:53:17 | access to indexer | AccessorCalls.cs:53:9:53:17 | access to indexer | normal |
+| AccessorCalls.cs:53:9:53:30 | ... + ... | AccessorCalls.cs:53:9:53:30 | ... + ... | normal |
+| AccessorCalls.cs:53:9:53:30 | ... += ... | AccessorCalls.cs:53:9:53:30 | ... = ... | normal |
+| AccessorCalls.cs:53:9:53:30 | ... = ... | AccessorCalls.cs:53:9:53:30 | ... = ... | normal |
+| AccessorCalls.cs:53:9:53:31 | ...; | AccessorCalls.cs:53:9:53:30 | ... = ... | normal |
+| AccessorCalls.cs:53:16:53:16 | 0 | AccessorCalls.cs:53:16:53:16 | 0 | normal |
+| AccessorCalls.cs:53:16:53:16 | 0 | AccessorCalls.cs:53:16:53:16 | 0 | normal |
+| AccessorCalls.cs:53:22:53:25 | this access | AccessorCalls.cs:53:22:53:25 | this access | normal |
+| AccessorCalls.cs:53:22:53:27 | access to field x | AccessorCalls.cs:53:22:53:27 | access to field x | normal |
+| AccessorCalls.cs:53:22:53:30 | access to indexer | AccessorCalls.cs:53:22:53:30 | access to indexer | normal |
+| AccessorCalls.cs:53:29:53:29 | 0 | AccessorCalls.cs:53:29:53:29 | 0 | normal |
+| AccessorCalls.cs:57:5:59:5 | {...} | AccessorCalls.cs:58:9:58:85 | ... = ... | normal |
+| AccessorCalls.cs:58:9:58:45 | (..., ...) | AccessorCalls.cs:58:9:58:45 | (..., ...) | normal |
+| AccessorCalls.cs:58:9:58:85 | ... = ... | AccessorCalls.cs:58:9:58:85 | ... = ... | normal |
+| AccessorCalls.cs:58:9:58:86 | ...; | AccessorCalls.cs:58:9:58:85 | ... = ... | normal |
+| AccessorCalls.cs:58:10:58:13 | this access | AccessorCalls.cs:58:10:58:13 | this access | normal |
+| AccessorCalls.cs:58:10:58:19 | access to field Field | AccessorCalls.cs:58:10:58:19 | access to field Field | normal |
+| AccessorCalls.cs:58:22:58:25 | this access | AccessorCalls.cs:58:22:58:25 | this access | normal |
+| AccessorCalls.cs:58:22:58:30 | access to property Prop | AccessorCalls.cs:58:22:58:30 | access to property Prop | normal |
+| AccessorCalls.cs:58:33:58:44 | (..., ...) | AccessorCalls.cs:58:33:58:44 | (..., ...) | normal |
+| AccessorCalls.cs:58:34:58:34 | access to parameter i | AccessorCalls.cs:58:34:58:34 | access to parameter i | normal |
+| AccessorCalls.cs:58:37:58:40 | this access | AccessorCalls.cs:58:37:58:40 | this access | normal |
+| AccessorCalls.cs:58:37:58:43 | access to indexer | AccessorCalls.cs:58:37:58:43 | access to indexer | normal |
+| AccessorCalls.cs:58:42:58:42 | 0 | AccessorCalls.cs:58:42:58:42 | 0 | normal |
+| AccessorCalls.cs:58:49:58:85 | (..., ...) | AccessorCalls.cs:58:49:58:85 | (..., ...) | normal |
+| AccessorCalls.cs:58:50:58:53 | this access | AccessorCalls.cs:58:50:58:53 | this access | normal |
+| AccessorCalls.cs:58:50:58:59 | access to field Field | AccessorCalls.cs:58:50:58:59 | access to field Field | normal |
+| AccessorCalls.cs:58:62:58:65 | this access | AccessorCalls.cs:58:62:58:65 | this access | normal |
+| AccessorCalls.cs:58:62:58:70 | access to property Prop | AccessorCalls.cs:58:62:58:70 | access to property Prop | normal |
+| AccessorCalls.cs:58:73:58:84 | (..., ...) | AccessorCalls.cs:58:73:58:84 | (..., ...) | normal |
+| AccessorCalls.cs:58:74:58:74 | 0 | AccessorCalls.cs:58:74:58:74 | 0 | normal |
+| AccessorCalls.cs:58:77:58:80 | this access | AccessorCalls.cs:58:77:58:80 | this access | normal |
+| AccessorCalls.cs:58:77:58:83 | access to indexer | AccessorCalls.cs:58:77:58:83 | access to indexer | normal |
+| AccessorCalls.cs:58:82:58:82 | 1 | AccessorCalls.cs:58:82:58:82 | 1 | normal |
+| AccessorCalls.cs:62:5:64:5 | {...} | AccessorCalls.cs:63:9:63:97 | ... = ... | normal |
+| AccessorCalls.cs:63:9:63:51 | (..., ...) | AccessorCalls.cs:63:9:63:51 | (..., ...) | normal |
+| AccessorCalls.cs:63:9:63:97 | ... = ... | AccessorCalls.cs:63:9:63:97 | ... = ... | normal |
+| AccessorCalls.cs:63:9:63:98 | ...; | AccessorCalls.cs:63:9:63:97 | ... = ... | normal |
+| AccessorCalls.cs:63:10:63:13 | this access | AccessorCalls.cs:63:10:63:13 | this access | normal |
+| AccessorCalls.cs:63:10:63:15 | access to field x | AccessorCalls.cs:63:10:63:15 | access to field x | normal |
+| AccessorCalls.cs:63:10:63:21 | access to field Field | AccessorCalls.cs:63:10:63:21 | access to field Field | normal |
+| AccessorCalls.cs:63:24:63:27 | this access | AccessorCalls.cs:63:24:63:27 | this access | normal |
+| AccessorCalls.cs:63:24:63:29 | access to field x | AccessorCalls.cs:63:24:63:29 | access to field x | normal |
+| AccessorCalls.cs:63:24:63:34 | access to property Prop | AccessorCalls.cs:63:24:63:34 | access to property Prop | normal |
+| AccessorCalls.cs:63:37:63:50 | (..., ...) | AccessorCalls.cs:63:37:63:50 | (..., ...) | normal |
+| AccessorCalls.cs:63:38:63:38 | access to parameter i | AccessorCalls.cs:63:38:63:38 | access to parameter i | normal |
+| AccessorCalls.cs:63:41:63:44 | this access | AccessorCalls.cs:63:41:63:44 | this access | normal |
+| AccessorCalls.cs:63:41:63:46 | access to field x | AccessorCalls.cs:63:41:63:46 | access to field x | normal |
+| AccessorCalls.cs:63:41:63:49 | access to indexer | AccessorCalls.cs:63:41:63:49 | access to indexer | normal |
+| AccessorCalls.cs:63:48:63:48 | 0 | AccessorCalls.cs:63:48:63:48 | 0 | normal |
+| AccessorCalls.cs:63:55:63:97 | (..., ...) | AccessorCalls.cs:63:55:63:97 | (..., ...) | normal |
+| AccessorCalls.cs:63:56:63:59 | this access | AccessorCalls.cs:63:56:63:59 | this access | normal |
+| AccessorCalls.cs:63:56:63:61 | access to field x | AccessorCalls.cs:63:56:63:61 | access to field x | normal |
+| AccessorCalls.cs:63:56:63:67 | access to field Field | AccessorCalls.cs:63:56:63:67 | access to field Field | normal |
+| AccessorCalls.cs:63:70:63:73 | this access | AccessorCalls.cs:63:70:63:73 | this access | normal |
+| AccessorCalls.cs:63:70:63:75 | access to field x | AccessorCalls.cs:63:70:63:75 | access to field x | normal |
+| AccessorCalls.cs:63:70:63:80 | access to property Prop | AccessorCalls.cs:63:70:63:80 | access to property Prop | normal |
+| AccessorCalls.cs:63:83:63:96 | (..., ...) | AccessorCalls.cs:63:83:63:96 | (..., ...) | normal |
+| AccessorCalls.cs:63:84:63:84 | 0 | AccessorCalls.cs:63:84:63:84 | 0 | normal |
+| AccessorCalls.cs:63:87:63:90 | this access | AccessorCalls.cs:63:87:63:90 | this access | normal |
+| AccessorCalls.cs:63:87:63:92 | access to field x | AccessorCalls.cs:63:87:63:92 | access to field x | normal |
+| AccessorCalls.cs:63:87:63:95 | access to indexer | AccessorCalls.cs:63:87:63:95 | access to indexer | normal |
+| AccessorCalls.cs:63:94:63:94 | 1 | AccessorCalls.cs:63:94:63:94 | 1 | normal |
 | ArrayCreation.cs:3:19:3:28 | array creation of type Int32[] | ArrayCreation.cs:3:19:3:28 | array creation of type Int32[] | normal |
 | ArrayCreation.cs:3:27:3:27 | 0 | ArrayCreation.cs:3:27:3:27 | 0 | normal |
 | ArrayCreation.cs:5:20:5:32 | array creation of type Int32[,] | ArrayCreation.cs:5:20:5:32 | array creation of type Int32[,] | normal |

--- a/csharp/ql/test/library-tests/controlflow/graph/ExitElement.expected
+++ b/csharp/ql/test/library-tests/controlflow/graph/ExitElement.expected
@@ -4,19 +4,19 @@
 | AccessorCalls.cs:7:47:7:49 | {...} | AccessorCalls.cs:7:47:7:49 | {...} | normal |
 | AccessorCalls.cs:11:5:17:5 | {...} | AccessorCalls.cs:16:9:16:23 | ... -= ... | normal |
 | AccessorCalls.cs:12:9:12:12 | this access | AccessorCalls.cs:12:9:12:12 | this access | normal |
-| AccessorCalls.cs:12:9:12:18 | access to field Field | AccessorCalls.cs:12:9:12:18 | access to field Field | normal |
+| AccessorCalls.cs:12:9:12:18 | access to field Field | AccessorCalls.cs:12:9:12:12 | this access | normal |
 | AccessorCalls.cs:12:9:12:31 | ... = ... | AccessorCalls.cs:12:9:12:31 | ... = ... | normal |
 | AccessorCalls.cs:12:9:12:32 | ...; | AccessorCalls.cs:12:9:12:31 | ... = ... | normal |
 | AccessorCalls.cs:12:22:12:25 | this access | AccessorCalls.cs:12:22:12:25 | this access | normal |
 | AccessorCalls.cs:12:22:12:31 | access to field Field | AccessorCalls.cs:12:22:12:31 | access to field Field | normal |
 | AccessorCalls.cs:13:9:13:12 | this access | AccessorCalls.cs:13:9:13:12 | this access | normal |
-| AccessorCalls.cs:13:9:13:17 | access to property Prop | AccessorCalls.cs:13:9:13:17 | access to property Prop | normal |
+| AccessorCalls.cs:13:9:13:17 | access to property Prop | AccessorCalls.cs:13:9:13:12 | this access | normal |
 | AccessorCalls.cs:13:9:13:29 | ... = ... | AccessorCalls.cs:13:9:13:29 | ... = ... | normal |
 | AccessorCalls.cs:13:9:13:30 | ...; | AccessorCalls.cs:13:9:13:29 | ... = ... | normal |
 | AccessorCalls.cs:13:21:13:24 | this access | AccessorCalls.cs:13:21:13:24 | this access | normal |
 | AccessorCalls.cs:13:21:13:29 | access to property Prop | AccessorCalls.cs:13:21:13:29 | access to property Prop | normal |
 | AccessorCalls.cs:14:9:14:12 | this access | AccessorCalls.cs:14:9:14:12 | this access | normal |
-| AccessorCalls.cs:14:9:14:15 | access to indexer | AccessorCalls.cs:14:9:14:15 | access to indexer | normal |
+| AccessorCalls.cs:14:9:14:15 | access to indexer | AccessorCalls.cs:14:14:14:14 | 0 | normal |
 | AccessorCalls.cs:14:9:14:25 | ... = ... | AccessorCalls.cs:14:9:14:25 | ... = ... | normal |
 | AccessorCalls.cs:14:9:14:26 | ...; | AccessorCalls.cs:14:9:14:25 | ... = ... | normal |
 | AccessorCalls.cs:14:14:14:14 | 0 | AccessorCalls.cs:14:14:14:14 | 0 | normal |
@@ -24,19 +24,19 @@
 | AccessorCalls.cs:14:19:14:25 | access to indexer | AccessorCalls.cs:14:19:14:25 | access to indexer | normal |
 | AccessorCalls.cs:14:24:14:24 | 1 | AccessorCalls.cs:14:24:14:24 | 1 | normal |
 | AccessorCalls.cs:15:9:15:12 | this access | AccessorCalls.cs:15:9:15:12 | this access | normal |
-| AccessorCalls.cs:15:9:15:18 | access to event Event | AccessorCalls.cs:15:9:15:18 | access to event Event | normal |
+| AccessorCalls.cs:15:9:15:18 | access to event Event | AccessorCalls.cs:15:9:15:12 | this access | normal |
 | AccessorCalls.cs:15:9:15:23 | ... += ... | AccessorCalls.cs:15:9:15:23 | ... += ... | normal |
 | AccessorCalls.cs:15:9:15:24 | ...; | AccessorCalls.cs:15:9:15:23 | ... += ... | normal |
 | AccessorCalls.cs:15:23:15:23 | access to parameter e | AccessorCalls.cs:15:23:15:23 | access to parameter e | normal |
 | AccessorCalls.cs:16:9:16:12 | this access | AccessorCalls.cs:16:9:16:12 | this access | normal |
-| AccessorCalls.cs:16:9:16:18 | access to event Event | AccessorCalls.cs:16:9:16:18 | access to event Event | normal |
+| AccessorCalls.cs:16:9:16:18 | access to event Event | AccessorCalls.cs:16:9:16:12 | this access | normal |
 | AccessorCalls.cs:16:9:16:23 | ... -= ... | AccessorCalls.cs:16:9:16:23 | ... -= ... | normal |
 | AccessorCalls.cs:16:9:16:24 | ...; | AccessorCalls.cs:16:9:16:23 | ... -= ... | normal |
 | AccessorCalls.cs:16:23:16:23 | access to parameter e | AccessorCalls.cs:16:23:16:23 | access to parameter e | normal |
 | AccessorCalls.cs:20:5:26:5 | {...} | AccessorCalls.cs:25:9:25:25 | ... -= ... | normal |
 | AccessorCalls.cs:21:9:21:12 | this access | AccessorCalls.cs:21:9:21:12 | this access | normal |
 | AccessorCalls.cs:21:9:21:14 | access to field x | AccessorCalls.cs:21:9:21:14 | access to field x | normal |
-| AccessorCalls.cs:21:9:21:20 | access to field Field | AccessorCalls.cs:21:9:21:20 | access to field Field | normal |
+| AccessorCalls.cs:21:9:21:20 | access to field Field | AccessorCalls.cs:21:9:21:14 | access to field x | normal |
 | AccessorCalls.cs:21:9:21:35 | ... = ... | AccessorCalls.cs:21:9:21:35 | ... = ... | normal |
 | AccessorCalls.cs:21:9:21:36 | ...; | AccessorCalls.cs:21:9:21:35 | ... = ... | normal |
 | AccessorCalls.cs:21:24:21:27 | this access | AccessorCalls.cs:21:24:21:27 | this access | normal |
@@ -44,7 +44,7 @@
 | AccessorCalls.cs:21:24:21:35 | access to field Field | AccessorCalls.cs:21:24:21:35 | access to field Field | normal |
 | AccessorCalls.cs:22:9:22:12 | this access | AccessorCalls.cs:22:9:22:12 | this access | normal |
 | AccessorCalls.cs:22:9:22:14 | access to field x | AccessorCalls.cs:22:9:22:14 | access to field x | normal |
-| AccessorCalls.cs:22:9:22:19 | access to property Prop | AccessorCalls.cs:22:9:22:19 | access to property Prop | normal |
+| AccessorCalls.cs:22:9:22:19 | access to property Prop | AccessorCalls.cs:22:9:22:14 | access to field x | normal |
 | AccessorCalls.cs:22:9:22:33 | ... = ... | AccessorCalls.cs:22:9:22:33 | ... = ... | normal |
 | AccessorCalls.cs:22:9:22:34 | ...; | AccessorCalls.cs:22:9:22:33 | ... = ... | normal |
 | AccessorCalls.cs:22:23:22:26 | this access | AccessorCalls.cs:22:23:22:26 | this access | normal |
@@ -52,7 +52,7 @@
 | AccessorCalls.cs:22:23:22:33 | access to property Prop | AccessorCalls.cs:22:23:22:33 | access to property Prop | normal |
 | AccessorCalls.cs:23:9:23:12 | this access | AccessorCalls.cs:23:9:23:12 | this access | normal |
 | AccessorCalls.cs:23:9:23:14 | access to field x | AccessorCalls.cs:23:9:23:14 | access to field x | normal |
-| AccessorCalls.cs:23:9:23:17 | access to indexer | AccessorCalls.cs:23:9:23:17 | access to indexer | normal |
+| AccessorCalls.cs:23:9:23:17 | access to indexer | AccessorCalls.cs:23:16:23:16 | 0 | normal |
 | AccessorCalls.cs:23:9:23:29 | ... = ... | AccessorCalls.cs:23:9:23:29 | ... = ... | normal |
 | AccessorCalls.cs:23:9:23:30 | ...; | AccessorCalls.cs:23:9:23:29 | ... = ... | normal |
 | AccessorCalls.cs:23:16:23:16 | 0 | AccessorCalls.cs:23:16:23:16 | 0 | normal |
@@ -62,13 +62,13 @@
 | AccessorCalls.cs:23:28:23:28 | 1 | AccessorCalls.cs:23:28:23:28 | 1 | normal |
 | AccessorCalls.cs:24:9:24:12 | this access | AccessorCalls.cs:24:9:24:12 | this access | normal |
 | AccessorCalls.cs:24:9:24:14 | access to field x | AccessorCalls.cs:24:9:24:14 | access to field x | normal |
-| AccessorCalls.cs:24:9:24:20 | access to event Event | AccessorCalls.cs:24:9:24:20 | access to event Event | normal |
+| AccessorCalls.cs:24:9:24:20 | access to event Event | AccessorCalls.cs:24:9:24:14 | access to field x | normal |
 | AccessorCalls.cs:24:9:24:25 | ... += ... | AccessorCalls.cs:24:9:24:25 | ... += ... | normal |
 | AccessorCalls.cs:24:9:24:26 | ...; | AccessorCalls.cs:24:9:24:25 | ... += ... | normal |
 | AccessorCalls.cs:24:25:24:25 | access to parameter e | AccessorCalls.cs:24:25:24:25 | access to parameter e | normal |
 | AccessorCalls.cs:25:9:25:12 | this access | AccessorCalls.cs:25:9:25:12 | this access | normal |
 | AccessorCalls.cs:25:9:25:14 | access to field x | AccessorCalls.cs:25:9:25:14 | access to field x | normal |
-| AccessorCalls.cs:25:9:25:20 | access to event Event | AccessorCalls.cs:25:9:25:20 | access to event Event | normal |
+| AccessorCalls.cs:25:9:25:20 | access to event Event | AccessorCalls.cs:25:9:25:14 | access to field x | normal |
 | AccessorCalls.cs:25:9:25:25 | ... -= ... | AccessorCalls.cs:25:9:25:25 | ... -= ... | normal |
 | AccessorCalls.cs:25:9:25:26 | ...; | AccessorCalls.cs:25:9:25:25 | ... -= ... | normal |
 | AccessorCalls.cs:25:25:25:25 | access to parameter e | AccessorCalls.cs:25:25:25:25 | access to parameter e | normal |
@@ -106,7 +106,7 @@
 | AccessorCalls.cs:43:5:47:5 | {...} | AccessorCalls.cs:46:9:46:26 | ... = ... | normal |
 | AccessorCalls.cs:44:9:44:12 | this access | AccessorCalls.cs:44:9:44:12 | this access | normal |
 | AccessorCalls.cs:44:9:44:12 | this access | AccessorCalls.cs:44:9:44:12 | this access | normal |
-| AccessorCalls.cs:44:9:44:18 | access to field Field | AccessorCalls.cs:44:9:44:18 | access to field Field | normal |
+| AccessorCalls.cs:44:9:44:18 | access to field Field | AccessorCalls.cs:44:9:44:12 | this access | normal |
 | AccessorCalls.cs:44:9:44:18 | access to field Field | AccessorCalls.cs:44:9:44:18 | access to field Field | normal |
 | AccessorCalls.cs:44:9:44:32 | ... + ... | AccessorCalls.cs:44:9:44:32 | ... + ... | normal |
 | AccessorCalls.cs:44:9:44:32 | ... += ... | AccessorCalls.cs:44:9:44:32 | ... = ... | normal |
@@ -116,7 +116,7 @@
 | AccessorCalls.cs:44:23:44:32 | access to field Field | AccessorCalls.cs:44:23:44:32 | access to field Field | normal |
 | AccessorCalls.cs:45:9:45:12 | this access | AccessorCalls.cs:45:9:45:12 | this access | normal |
 | AccessorCalls.cs:45:9:45:12 | this access | AccessorCalls.cs:45:9:45:12 | this access | normal |
-| AccessorCalls.cs:45:9:45:17 | access to property Prop | AccessorCalls.cs:45:9:45:17 | access to property Prop | normal |
+| AccessorCalls.cs:45:9:45:17 | access to property Prop | AccessorCalls.cs:45:9:45:12 | this access | normal |
 | AccessorCalls.cs:45:9:45:17 | access to property Prop | AccessorCalls.cs:45:9:45:17 | access to property Prop | normal |
 | AccessorCalls.cs:45:9:45:30 | ... + ... | AccessorCalls.cs:45:9:45:30 | ... + ... | normal |
 | AccessorCalls.cs:45:9:45:30 | ... += ... | AccessorCalls.cs:45:9:45:30 | ... = ... | normal |
@@ -127,7 +127,7 @@
 | AccessorCalls.cs:46:9:46:12 | this access | AccessorCalls.cs:46:9:46:12 | this access | normal |
 | AccessorCalls.cs:46:9:46:12 | this access | AccessorCalls.cs:46:9:46:12 | this access | normal |
 | AccessorCalls.cs:46:9:46:15 | access to indexer | AccessorCalls.cs:46:9:46:15 | access to indexer | normal |
-| AccessorCalls.cs:46:9:46:15 | access to indexer | AccessorCalls.cs:46:9:46:15 | access to indexer | normal |
+| AccessorCalls.cs:46:9:46:15 | access to indexer | AccessorCalls.cs:46:14:46:14 | 0 | normal |
 | AccessorCalls.cs:46:9:46:26 | ... + ... | AccessorCalls.cs:46:9:46:26 | ... + ... | normal |
 | AccessorCalls.cs:46:9:46:26 | ... += ... | AccessorCalls.cs:46:9:46:26 | ... = ... | normal |
 | AccessorCalls.cs:46:9:46:26 | ... = ... | AccessorCalls.cs:46:9:46:26 | ... = ... | normal |
@@ -142,7 +142,7 @@
 | AccessorCalls.cs:51:9:51:12 | this access | AccessorCalls.cs:51:9:51:12 | this access | normal |
 | AccessorCalls.cs:51:9:51:14 | access to field x | AccessorCalls.cs:51:9:51:14 | access to field x | normal |
 | AccessorCalls.cs:51:9:51:14 | access to field x | AccessorCalls.cs:51:9:51:14 | access to field x | normal |
-| AccessorCalls.cs:51:9:51:20 | access to field Field | AccessorCalls.cs:51:9:51:20 | access to field Field | normal |
+| AccessorCalls.cs:51:9:51:20 | access to field Field | AccessorCalls.cs:51:9:51:14 | access to field x | normal |
 | AccessorCalls.cs:51:9:51:20 | access to field Field | AccessorCalls.cs:51:9:51:20 | access to field Field | normal |
 | AccessorCalls.cs:51:9:51:36 | ... + ... | AccessorCalls.cs:51:9:51:36 | ... + ... | normal |
 | AccessorCalls.cs:51:9:51:36 | ... += ... | AccessorCalls.cs:51:9:51:36 | ... = ... | normal |
@@ -155,7 +155,7 @@
 | AccessorCalls.cs:52:9:52:12 | this access | AccessorCalls.cs:52:9:52:12 | this access | normal |
 | AccessorCalls.cs:52:9:52:14 | access to field x | AccessorCalls.cs:52:9:52:14 | access to field x | normal |
 | AccessorCalls.cs:52:9:52:14 | access to field x | AccessorCalls.cs:52:9:52:14 | access to field x | normal |
-| AccessorCalls.cs:52:9:52:19 | access to property Prop | AccessorCalls.cs:52:9:52:19 | access to property Prop | normal |
+| AccessorCalls.cs:52:9:52:19 | access to property Prop | AccessorCalls.cs:52:9:52:14 | access to field x | normal |
 | AccessorCalls.cs:52:9:52:19 | access to property Prop | AccessorCalls.cs:52:9:52:19 | access to property Prop | normal |
 | AccessorCalls.cs:52:9:52:34 | ... + ... | AccessorCalls.cs:52:9:52:34 | ... + ... | normal |
 | AccessorCalls.cs:52:9:52:34 | ... += ... | AccessorCalls.cs:52:9:52:34 | ... = ... | normal |
@@ -169,7 +169,7 @@
 | AccessorCalls.cs:53:9:53:14 | access to field x | AccessorCalls.cs:53:9:53:14 | access to field x | normal |
 | AccessorCalls.cs:53:9:53:14 | access to field x | AccessorCalls.cs:53:9:53:14 | access to field x | normal |
 | AccessorCalls.cs:53:9:53:17 | access to indexer | AccessorCalls.cs:53:9:53:17 | access to indexer | normal |
-| AccessorCalls.cs:53:9:53:17 | access to indexer | AccessorCalls.cs:53:9:53:17 | access to indexer | normal |
+| AccessorCalls.cs:53:9:53:17 | access to indexer | AccessorCalls.cs:53:16:53:16 | 0 | normal |
 | AccessorCalls.cs:53:9:53:30 | ... + ... | AccessorCalls.cs:53:9:53:30 | ... + ... | normal |
 | AccessorCalls.cs:53:9:53:30 | ... += ... | AccessorCalls.cs:53:9:53:30 | ... = ... | normal |
 | AccessorCalls.cs:53:9:53:30 | ... = ... | AccessorCalls.cs:53:9:53:30 | ... = ... | normal |
@@ -185,13 +185,12 @@
 | AccessorCalls.cs:58:9:58:85 | ... = ... | AccessorCalls.cs:58:9:58:85 | ... = ... | normal |
 | AccessorCalls.cs:58:9:58:86 | ...; | AccessorCalls.cs:58:9:58:85 | ... = ... | normal |
 | AccessorCalls.cs:58:10:58:13 | this access | AccessorCalls.cs:58:10:58:13 | this access | normal |
-| AccessorCalls.cs:58:10:58:19 | access to field Field | AccessorCalls.cs:58:10:58:19 | access to field Field | normal |
+| AccessorCalls.cs:58:10:58:19 | access to field Field | AccessorCalls.cs:58:10:58:13 | this access | normal |
 | AccessorCalls.cs:58:22:58:25 | this access | AccessorCalls.cs:58:22:58:25 | this access | normal |
-| AccessorCalls.cs:58:22:58:30 | access to property Prop | AccessorCalls.cs:58:22:58:30 | access to property Prop | normal |
+| AccessorCalls.cs:58:22:58:30 | access to property Prop | AccessorCalls.cs:58:22:58:25 | this access | normal |
 | AccessorCalls.cs:58:33:58:44 | (..., ...) | AccessorCalls.cs:58:33:58:44 | (..., ...) | normal |
-| AccessorCalls.cs:58:34:58:34 | access to parameter i | AccessorCalls.cs:58:34:58:34 | access to parameter i | normal |
 | AccessorCalls.cs:58:37:58:40 | this access | AccessorCalls.cs:58:37:58:40 | this access | normal |
-| AccessorCalls.cs:58:37:58:43 | access to indexer | AccessorCalls.cs:58:37:58:43 | access to indexer | normal |
+| AccessorCalls.cs:58:37:58:43 | access to indexer | AccessorCalls.cs:58:42:58:42 | 0 | normal |
 | AccessorCalls.cs:58:42:58:42 | 0 | AccessorCalls.cs:58:42:58:42 | 0 | normal |
 | AccessorCalls.cs:58:49:58:85 | (..., ...) | AccessorCalls.cs:58:49:58:85 | (..., ...) | normal |
 | AccessorCalls.cs:58:50:58:53 | this access | AccessorCalls.cs:58:50:58:53 | this access | normal |
@@ -209,15 +208,14 @@
 | AccessorCalls.cs:63:9:63:98 | ...; | AccessorCalls.cs:63:9:63:97 | ... = ... | normal |
 | AccessorCalls.cs:63:10:63:13 | this access | AccessorCalls.cs:63:10:63:13 | this access | normal |
 | AccessorCalls.cs:63:10:63:15 | access to field x | AccessorCalls.cs:63:10:63:15 | access to field x | normal |
-| AccessorCalls.cs:63:10:63:21 | access to field Field | AccessorCalls.cs:63:10:63:21 | access to field Field | normal |
+| AccessorCalls.cs:63:10:63:21 | access to field Field | AccessorCalls.cs:63:10:63:15 | access to field x | normal |
 | AccessorCalls.cs:63:24:63:27 | this access | AccessorCalls.cs:63:24:63:27 | this access | normal |
 | AccessorCalls.cs:63:24:63:29 | access to field x | AccessorCalls.cs:63:24:63:29 | access to field x | normal |
-| AccessorCalls.cs:63:24:63:34 | access to property Prop | AccessorCalls.cs:63:24:63:34 | access to property Prop | normal |
+| AccessorCalls.cs:63:24:63:34 | access to property Prop | AccessorCalls.cs:63:24:63:29 | access to field x | normal |
 | AccessorCalls.cs:63:37:63:50 | (..., ...) | AccessorCalls.cs:63:37:63:50 | (..., ...) | normal |
-| AccessorCalls.cs:63:38:63:38 | access to parameter i | AccessorCalls.cs:63:38:63:38 | access to parameter i | normal |
 | AccessorCalls.cs:63:41:63:44 | this access | AccessorCalls.cs:63:41:63:44 | this access | normal |
 | AccessorCalls.cs:63:41:63:46 | access to field x | AccessorCalls.cs:63:41:63:46 | access to field x | normal |
-| AccessorCalls.cs:63:41:63:49 | access to indexer | AccessorCalls.cs:63:41:63:49 | access to indexer | normal |
+| AccessorCalls.cs:63:41:63:49 | access to indexer | AccessorCalls.cs:63:48:63:48 | 0 | normal |
 | AccessorCalls.cs:63:48:63:48 | 0 | AccessorCalls.cs:63:48:63:48 | 0 | normal |
 | AccessorCalls.cs:63:55:63:97 | (..., ...) | AccessorCalls.cs:63:55:63:97 | (..., ...) | normal |
 | AccessorCalls.cs:63:56:63:59 | this access | AccessorCalls.cs:63:56:63:59 | this access | normal |
@@ -254,10 +252,8 @@
 | ArrayCreation.cs:9:48:9:48 | 3 | ArrayCreation.cs:9:48:9:48 | 3 | normal |
 | Assignments.cs:4:5:15:5 | {...} | Assignments.cs:14:9:14:35 | ... += ... | normal |
 | Assignments.cs:5:9:5:18 | ... ...; | Assignments.cs:5:13:5:17 | Int32 x = ... | normal |
-| Assignments.cs:5:13:5:13 | access to local variable x | Assignments.cs:5:13:5:13 | access to local variable x | normal |
 | Assignments.cs:5:13:5:17 | Int32 x = ... | Assignments.cs:5:13:5:17 | Int32 x = ... | normal |
 | Assignments.cs:5:17:5:17 | 0 | Assignments.cs:5:17:5:17 | 0 | normal |
-| Assignments.cs:6:9:6:9 | access to local variable x | Assignments.cs:6:9:6:9 | access to local variable x | normal |
 | Assignments.cs:6:9:6:9 | access to local variable x | Assignments.cs:6:9:6:9 | access to local variable x | normal |
 | Assignments.cs:6:9:6:14 | ... + ... | Assignments.cs:6:9:6:14 | ... + ... | normal |
 | Assignments.cs:6:9:6:14 | ... += ... | Assignments.cs:6:9:6:14 | ... = ... | normal |
@@ -265,11 +261,9 @@
 | Assignments.cs:6:9:6:15 | ...; | Assignments.cs:6:9:6:14 | ... = ... | normal |
 | Assignments.cs:6:14:6:14 | 1 | Assignments.cs:6:14:6:14 | 1 | normal |
 | Assignments.cs:8:9:8:22 | ... ...; | Assignments.cs:8:17:8:21 | dynamic d = ... | normal |
-| Assignments.cs:8:17:8:17 | access to local variable d | Assignments.cs:8:17:8:17 | access to local variable d | normal |
 | Assignments.cs:8:17:8:21 | dynamic d = ... | Assignments.cs:8:17:8:21 | dynamic d = ... | normal |
 | Assignments.cs:8:21:8:21 | 0 | Assignments.cs:8:21:8:21 | 0 | normal |
 | Assignments.cs:8:21:8:21 | (...) ... | Assignments.cs:8:21:8:21 | (...) ... | normal |
-| Assignments.cs:9:9:9:9 | access to local variable d | Assignments.cs:9:9:9:9 | access to local variable d | normal |
 | Assignments.cs:9:9:9:9 | access to local variable d | Assignments.cs:9:9:9:9 | access to local variable d | normal |
 | Assignments.cs:9:9:9:14 | ... -= ... | Assignments.cs:9:9:9:14 | ... = ... | normal |
 | Assignments.cs:9:9:9:14 | ... = ... | Assignments.cs:9:9:9:14 | ... = ... | normal |
@@ -277,17 +271,15 @@
 | Assignments.cs:9:9:9:15 | ...; | Assignments.cs:9:9:9:14 | ... = ... | normal |
 | Assignments.cs:9:14:9:14 | 2 | Assignments.cs:9:14:9:14 | 2 | normal |
 | Assignments.cs:11:9:11:34 | ... ...; | Assignments.cs:11:13:11:33 | Assignments a = ... | normal |
-| Assignments.cs:11:13:11:13 | access to local variable a | Assignments.cs:11:13:11:13 | access to local variable a | normal |
 | Assignments.cs:11:13:11:33 | Assignments a = ... | Assignments.cs:11:13:11:33 | Assignments a = ... | normal |
 | Assignments.cs:11:17:11:33 | object creation of type Assignments | Assignments.cs:11:17:11:33 | object creation of type Assignments | normal |
-| Assignments.cs:12:9:12:9 | access to local variable a | Assignments.cs:12:9:12:9 | access to local variable a | normal |
 | Assignments.cs:12:9:12:9 | access to local variable a | Assignments.cs:12:9:12:9 | access to local variable a | normal |
 | Assignments.cs:12:9:12:17 | ... += ... | Assignments.cs:12:9:12:17 | ... = ... | normal |
 | Assignments.cs:12:9:12:17 | ... = ... | Assignments.cs:12:9:12:17 | ... = ... | normal |
 | Assignments.cs:12:9:12:17 | call to operator + | Assignments.cs:12:9:12:17 | call to operator + | normal |
 | Assignments.cs:12:9:12:18 | ...; | Assignments.cs:12:9:12:17 | ... = ... | normal |
 | Assignments.cs:12:14:12:17 | this access | Assignments.cs:12:14:12:17 | this access | normal |
-| Assignments.cs:14:9:14:13 | access to event Event | Assignments.cs:14:9:14:13 | access to event Event | normal |
+| Assignments.cs:14:9:14:13 | access to event Event | Assignments.cs:14:9:14:13 | this access | normal |
 | Assignments.cs:14:9:14:13 | this access | Assignments.cs:14:9:14:13 | this access | normal |
 | Assignments.cs:14:9:14:35 | ... += ... | Assignments.cs:14:9:14:35 | ... += ... | normal |
 | Assignments.cs:14:9:14:36 | ...; | Assignments.cs:14:9:14:35 | ... += ... | normal |
@@ -601,19 +593,16 @@
 | ConditionalAccess.cs:19:58:19:59 | access to parameter s2 | ConditionalAccess.cs:19:58:19:59 | access to parameter s2 | normal |
 | ConditionalAccess.cs:22:5:26:5 | {...} | ConditionalAccess.cs:25:9:25:32 | ... = ... | normal |
 | ConditionalAccess.cs:23:9:23:39 | ... ...; | ConditionalAccess.cs:23:13:23:38 | Nullable<Int32> j = ... | normal |
-| ConditionalAccess.cs:23:13:23:13 | access to local variable j | ConditionalAccess.cs:23:13:23:13 | access to local variable j | normal |
 | ConditionalAccess.cs:23:13:23:38 | Nullable<Int32> j = ... | ConditionalAccess.cs:23:13:23:38 | Nullable<Int32> j = ... | normal |
 | ConditionalAccess.cs:23:18:23:29 | (...) ... | ConditionalAccess.cs:23:18:23:29 | (...) ... | null |
 | ConditionalAccess.cs:23:26:23:29 | null | ConditionalAccess.cs:23:26:23:29 | null | normal |
 | ConditionalAccess.cs:23:32:23:38 | access to property Length | ConditionalAccess.cs:23:18:23:29 | (...) ... | null |
 | ConditionalAccess.cs:23:32:23:38 | access to property Length | ConditionalAccess.cs:23:32:23:38 | access to property Length | normal |
 | ConditionalAccess.cs:24:9:24:38 | ... ...; | ConditionalAccess.cs:24:13:24:37 | String s = ... | normal |
-| ConditionalAccess.cs:24:13:24:13 | access to local variable s | ConditionalAccess.cs:24:13:24:13 | access to local variable s | normal |
 | ConditionalAccess.cs:24:13:24:37 | String s = ... | ConditionalAccess.cs:24:13:24:37 | String s = ... | normal |
 | ConditionalAccess.cs:24:18:24:24 | (...) ... | ConditionalAccess.cs:24:18:24:24 | (...) ... | non-null |
 | ConditionalAccess.cs:24:24:24:24 | access to parameter i | ConditionalAccess.cs:24:24:24:24 | access to parameter i | normal |
 | ConditionalAccess.cs:24:27:24:37 | call to method ToString | ConditionalAccess.cs:24:27:24:37 | call to method ToString | normal |
-| ConditionalAccess.cs:25:9:25:9 | access to local variable s | ConditionalAccess.cs:25:9:25:9 | access to local variable s | normal |
 | ConditionalAccess.cs:25:9:25:32 | ... = ... | ConditionalAccess.cs:25:9:25:32 | ... = ... | normal |
 | ConditionalAccess.cs:25:9:25:33 | ...; | ConditionalAccess.cs:25:9:25:32 | ... = ... | normal |
 | ConditionalAccess.cs:25:13:25:14 | "" | ConditionalAccess.cs:25:13:25:14 | "" | non-null |
@@ -644,7 +633,6 @@
 | Conditions.cs:8:13:8:16 | ...; | Conditions.cs:8:13:8:15 | ...-- | normal |
 | Conditions.cs:12:5:20:5 | {...} | Conditions.cs:19:9:19:17 | return ...; | return |
 | Conditions.cs:13:9:13:18 | ... ...; | Conditions.cs:13:13:13:17 | Int32 x = ... | normal |
-| Conditions.cs:13:13:13:13 | access to local variable x | Conditions.cs:13:13:13:13 | access to local variable x | normal |
 | Conditions.cs:13:13:13:17 | Int32 x = ... | Conditions.cs:13:13:13:17 | Int32 x = ... | normal |
 | Conditions.cs:13:17:13:17 | 0 | Conditions.cs:13:17:13:17 | 0 | normal |
 | Conditions.cs:14:9:15:16 | if (...) ... | Conditions.cs:14:13:14:13 | access to parameter b | false/false |
@@ -674,7 +662,6 @@
 | Conditions.cs:19:16:19:16 | access to local variable x | Conditions.cs:19:16:19:16 | access to local variable x | normal |
 | Conditions.cs:23:5:31:5 | {...} | Conditions.cs:30:9:30:17 | return ...; | return |
 | Conditions.cs:24:9:24:18 | ... ...; | Conditions.cs:24:13:24:17 | Int32 x = ... | normal |
-| Conditions.cs:24:13:24:13 | access to local variable x | Conditions.cs:24:13:24:13 | access to local variable x | normal |
 | Conditions.cs:24:13:24:17 | Int32 x = ... | Conditions.cs:24:13:24:17 | Int32 x = ... | normal |
 | Conditions.cs:24:17:24:17 | 0 | Conditions.cs:24:17:24:17 | 0 | normal |
 | Conditions.cs:25:9:27:20 | if (...) ... | Conditions.cs:25:13:25:14 | access to parameter b1 | false/false |
@@ -700,18 +687,15 @@
 | Conditions.cs:30:16:30:16 | access to local variable x | Conditions.cs:30:16:30:16 | access to local variable x | normal |
 | Conditions.cs:34:5:44:5 | {...} | Conditions.cs:43:9:43:17 | return ...; | return |
 | Conditions.cs:35:9:35:18 | ... ...; | Conditions.cs:35:13:35:17 | Int32 x = ... | normal |
-| Conditions.cs:35:13:35:13 | access to local variable x | Conditions.cs:35:13:35:13 | access to local variable x | normal |
 | Conditions.cs:35:13:35:17 | Int32 x = ... | Conditions.cs:35:13:35:17 | Int32 x = ... | normal |
 | Conditions.cs:35:17:35:17 | 0 | Conditions.cs:35:17:35:17 | 0 | normal |
 | Conditions.cs:36:9:36:23 | ... ...; | Conditions.cs:36:13:36:22 | Boolean b2 = ... | normal |
-| Conditions.cs:36:13:36:14 | access to local variable b2 | Conditions.cs:36:13:36:14 | access to local variable b2 | normal |
 | Conditions.cs:36:13:36:22 | Boolean b2 = ... | Conditions.cs:36:13:36:22 | Boolean b2 = ... | normal |
 | Conditions.cs:36:18:36:22 | false | Conditions.cs:36:18:36:22 | false | normal |
 | Conditions.cs:37:9:38:20 | if (...) ... | Conditions.cs:37:13:37:14 | access to parameter b1 | false/false |
 | Conditions.cs:37:9:38:20 | if (...) ... | Conditions.cs:38:13:38:19 | ... = ... | normal |
 | Conditions.cs:37:13:37:14 | access to parameter b1 | Conditions.cs:37:13:37:14 | access to parameter b1 | false/false |
 | Conditions.cs:37:13:37:14 | access to parameter b1 | Conditions.cs:37:13:37:14 | access to parameter b1 | true/true |
-| Conditions.cs:38:13:38:14 | access to local variable b2 | Conditions.cs:38:13:38:14 | access to local variable b2 | normal |
 | Conditions.cs:38:13:38:19 | ... = ... | Conditions.cs:38:13:38:19 | ... = ... | normal |
 | Conditions.cs:38:13:38:20 | ...; | Conditions.cs:38:13:38:19 | ... = ... | normal |
 | Conditions.cs:38:18:38:19 | access to parameter b1 | Conditions.cs:38:18:38:19 | access to parameter b1 | normal |
@@ -733,7 +717,6 @@
 | Conditions.cs:43:16:43:16 | access to local variable x | Conditions.cs:43:16:43:16 | access to local variable x | normal |
 | Conditions.cs:47:5:55:5 | {...} | Conditions.cs:54:9:54:17 | return ...; | return |
 | Conditions.cs:48:9:48:18 | ... ...; | Conditions.cs:48:13:48:17 | Int32 y = ... | normal |
-| Conditions.cs:48:13:48:13 | access to local variable y | Conditions.cs:48:13:48:13 | access to local variable y | normal |
 | Conditions.cs:48:13:48:17 | Int32 y = ... | Conditions.cs:48:13:48:17 | Int32 y = ... | normal |
 | Conditions.cs:48:17:48:17 | 0 | Conditions.cs:48:17:48:17 | 0 | normal |
 | Conditions.cs:49:9:53:9 | while (...) ... | Conditions.cs:49:16:49:22 | ... > ... | false/false |
@@ -755,7 +738,6 @@
 | Conditions.cs:54:16:54:16 | access to local variable y | Conditions.cs:54:16:54:16 | access to local variable y | normal |
 | Conditions.cs:58:5:68:5 | {...} | Conditions.cs:67:9:67:17 | return ...; | return |
 | Conditions.cs:59:9:59:18 | ... ...; | Conditions.cs:59:13:59:17 | Int32 y = ... | normal |
-| Conditions.cs:59:13:59:13 | access to local variable y | Conditions.cs:59:13:59:13 | access to local variable y | normal |
 | Conditions.cs:59:13:59:17 | Int32 y = ... | Conditions.cs:59:13:59:17 | Int32 y = ... | normal |
 | Conditions.cs:59:17:59:17 | 0 | Conditions.cs:59:17:59:17 | 0 | normal |
 | Conditions.cs:60:9:64:9 | while (...) ... | Conditions.cs:60:16:60:22 | ... > ... | false/false |
@@ -784,14 +766,12 @@
 | Conditions.cs:67:16:67:16 | access to local variable y | Conditions.cs:67:16:67:16 | access to local variable y | normal |
 | Conditions.cs:71:5:84:5 | {...} | Conditions.cs:83:9:83:17 | return ...; | return |
 | Conditions.cs:72:9:72:30 | ... ...; | Conditions.cs:72:13:72:29 | Boolean b = ... | normal |
-| Conditions.cs:72:13:72:13 | access to local variable b | Conditions.cs:72:13:72:13 | access to local variable b | normal |
 | Conditions.cs:72:13:72:29 | Boolean b = ... | Conditions.cs:72:13:72:29 | Boolean b = ... | normal |
 | Conditions.cs:72:17:72:18 | access to parameter ss | Conditions.cs:72:17:72:18 | access to parameter ss | normal |
 | Conditions.cs:72:17:72:25 | access to property Length | Conditions.cs:72:17:72:25 | access to property Length | normal |
 | Conditions.cs:72:17:72:29 | ... > ... | Conditions.cs:72:17:72:29 | ... > ... | normal |
 | Conditions.cs:72:29:72:29 | 0 | Conditions.cs:72:29:72:29 | 0 | normal |
 | Conditions.cs:73:9:73:18 | ... ...; | Conditions.cs:73:13:73:17 | Int32 x = ... | normal |
-| Conditions.cs:73:13:73:13 | access to local variable x | Conditions.cs:73:13:73:13 | access to local variable x | normal |
 | Conditions.cs:73:13:73:17 | Int32 x = ... | Conditions.cs:73:13:73:17 | Int32 x = ... | normal |
 | Conditions.cs:73:17:73:17 | 0 | Conditions.cs:73:17:73:17 | 0 | normal |
 | Conditions.cs:74:9:80:9 | foreach (... ... in ...) ... | Conditions.cs:74:9:80:9 | foreach (... ... in ...) ... | empty |
@@ -811,7 +791,6 @@
 | Conditions.cs:78:17:78:21 | ... > ... | Conditions.cs:78:17:78:21 | ... > ... | false/false |
 | Conditions.cs:78:17:78:21 | ... > ... | Conditions.cs:78:17:78:21 | ... > ... | true/true |
 | Conditions.cs:78:21:78:21 | 0 | Conditions.cs:78:21:78:21 | 0 | normal |
-| Conditions.cs:79:17:79:17 | access to local variable b | Conditions.cs:79:17:79:17 | access to local variable b | normal |
 | Conditions.cs:79:17:79:25 | ... = ... | Conditions.cs:79:17:79:25 | ... = ... | normal |
 | Conditions.cs:79:17:79:26 | ...; | Conditions.cs:79:17:79:25 | ... = ... | normal |
 | Conditions.cs:79:21:79:25 | false | Conditions.cs:79:21:79:25 | false | normal |
@@ -826,14 +805,12 @@
 | Conditions.cs:83:16:83:16 | access to local variable x | Conditions.cs:83:16:83:16 | access to local variable x | normal |
 | Conditions.cs:87:5:100:5 | {...} | Conditions.cs:99:9:99:17 | return ...; | return |
 | Conditions.cs:88:9:88:30 | ... ...; | Conditions.cs:88:13:88:29 | Boolean b = ... | normal |
-| Conditions.cs:88:13:88:13 | access to local variable b | Conditions.cs:88:13:88:13 | access to local variable b | normal |
 | Conditions.cs:88:13:88:29 | Boolean b = ... | Conditions.cs:88:13:88:29 | Boolean b = ... | normal |
 | Conditions.cs:88:17:88:18 | access to parameter ss | Conditions.cs:88:17:88:18 | access to parameter ss | normal |
 | Conditions.cs:88:17:88:25 | access to property Length | Conditions.cs:88:17:88:25 | access to property Length | normal |
 | Conditions.cs:88:17:88:29 | ... > ... | Conditions.cs:88:17:88:29 | ... > ... | normal |
 | Conditions.cs:88:29:88:29 | 0 | Conditions.cs:88:29:88:29 | 0 | normal |
 | Conditions.cs:89:9:89:18 | ... ...; | Conditions.cs:89:13:89:17 | Int32 x = ... | normal |
-| Conditions.cs:89:13:89:13 | access to local variable x | Conditions.cs:89:13:89:13 | access to local variable x | normal |
 | Conditions.cs:89:13:89:17 | Int32 x = ... | Conditions.cs:89:13:89:17 | Int32 x = ... | normal |
 | Conditions.cs:89:17:89:17 | 0 | Conditions.cs:89:17:89:17 | 0 | normal |
 | Conditions.cs:90:9:98:9 | foreach (... ... in ...) ... | Conditions.cs:90:9:98:9 | foreach (... ... in ...) ... | empty |
@@ -853,7 +830,6 @@
 | Conditions.cs:94:17:94:21 | ... > ... | Conditions.cs:94:17:94:21 | ... > ... | false/false |
 | Conditions.cs:94:17:94:21 | ... > ... | Conditions.cs:94:17:94:21 | ... > ... | true/true |
 | Conditions.cs:94:21:94:21 | 0 | Conditions.cs:94:21:94:21 | 0 | normal |
-| Conditions.cs:95:17:95:17 | access to local variable b | Conditions.cs:95:17:95:17 | access to local variable b | normal |
 | Conditions.cs:95:17:95:25 | ... = ... | Conditions.cs:95:17:95:25 | ... = ... | normal |
 | Conditions.cs:95:17:95:26 | ...; | Conditions.cs:95:17:95:25 | ... = ... | normal |
 | Conditions.cs:95:21:95:25 | false | Conditions.cs:95:21:95:25 | false | normal |
@@ -868,7 +844,6 @@
 | Conditions.cs:99:16:99:16 | access to local variable x | Conditions.cs:99:16:99:16 | access to local variable x | normal |
 | Conditions.cs:103:5:111:5 | {...} | Conditions.cs:110:9:110:17 | return ...; | return |
 | Conditions.cs:104:9:104:29 | ... ...; | Conditions.cs:104:13:104:28 | String x = ... | normal |
-| Conditions.cs:104:13:104:13 | access to local variable x | Conditions.cs:104:13:104:13 | access to local variable x | normal |
 | Conditions.cs:104:13:104:28 | String x = ... | Conditions.cs:104:13:104:28 | String x = ... | normal |
 | Conditions.cs:104:17:104:17 | access to parameter b | Conditions.cs:104:17:104:17 | access to parameter b | normal |
 | Conditions.cs:104:17:104:28 | call to method ToString | Conditions.cs:104:17:104:28 | call to method ToString | normal |
@@ -876,7 +851,6 @@
 | Conditions.cs:105:9:106:20 | if (...) ... | Conditions.cs:106:13:106:19 | ... = ... | normal |
 | Conditions.cs:105:13:105:13 | access to parameter b | Conditions.cs:105:13:105:13 | access to parameter b | false/false |
 | Conditions.cs:105:13:105:13 | access to parameter b | Conditions.cs:105:13:105:13 | access to parameter b | true/true |
-| Conditions.cs:106:13:106:13 | access to local variable x | Conditions.cs:106:13:106:13 | access to local variable x | normal |
 | Conditions.cs:106:13:106:13 | access to local variable x | Conditions.cs:106:13:106:13 | access to local variable x | normal |
 | Conditions.cs:106:13:106:19 | ... + ... | Conditions.cs:106:13:106:19 | ... + ... | normal |
 | Conditions.cs:106:13:106:19 | ... += ... | Conditions.cs:106:13:106:19 | ... = ... | normal |
@@ -898,7 +872,6 @@
 | Conditions.cs:108:18:108:18 | access to parameter b | Conditions.cs:108:18:108:18 | access to parameter b | false/false |
 | Conditions.cs:108:18:108:18 | access to parameter b | Conditions.cs:108:18:108:18 | access to parameter b | true/true |
 | Conditions.cs:109:17:109:17 | access to local variable x | Conditions.cs:109:17:109:17 | access to local variable x | normal |
-| Conditions.cs:109:17:109:17 | access to local variable x | Conditions.cs:109:17:109:17 | access to local variable x | normal |
 | Conditions.cs:109:17:109:23 | ... + ... | Conditions.cs:109:17:109:23 | ... + ... | normal |
 | Conditions.cs:109:17:109:23 | ... += ... | Conditions.cs:109:17:109:23 | ... = ... | normal |
 | Conditions.cs:109:17:109:23 | ... = ... | Conditions.cs:109:17:109:23 | ... = ... | normal |
@@ -908,11 +881,9 @@
 | Conditions.cs:110:16:110:16 | access to local variable x | Conditions.cs:110:16:110:16 | access to local variable x | normal |
 | Conditions.cs:114:5:124:5 | {...} | Conditions.cs:116:24:116:38 | ... < ... | false/false |
 | Conditions.cs:115:9:115:24 | ... ...; | Conditions.cs:115:16:115:23 | String s = ... | normal |
-| Conditions.cs:115:16:115:16 | access to local variable s | Conditions.cs:115:16:115:16 | access to local variable s | normal |
 | Conditions.cs:115:16:115:23 | String s = ... | Conditions.cs:115:16:115:23 | String s = ... | normal |
 | Conditions.cs:115:20:115:23 | null | Conditions.cs:115:20:115:23 | null | normal |
 | Conditions.cs:116:9:123:9 | for (...;...;...) ... | Conditions.cs:116:24:116:38 | ... < ... | false/false |
-| Conditions.cs:116:17:116:17 | access to local variable i | Conditions.cs:116:17:116:17 | access to local variable i | normal |
 | Conditions.cs:116:17:116:21 | Int32 i = ... | Conditions.cs:116:17:116:21 | Int32 i = ... | normal |
 | Conditions.cs:116:21:116:21 | 0 | Conditions.cs:116:21:116:21 | 0 | normal |
 | Conditions.cs:116:24:116:24 | access to local variable i | Conditions.cs:116:24:116:24 | access to local variable i | normal |
@@ -925,7 +896,6 @@
 | Conditions.cs:117:9:123:9 | {...} | Conditions.cs:121:17:121:20 | access to local variable last | false/false |
 | Conditions.cs:117:9:123:9 | {...} | Conditions.cs:122:17:122:24 | ... = ... | normal |
 | Conditions.cs:118:13:118:44 | ... ...; | Conditions.cs:118:17:118:43 | Boolean last = ... | normal |
-| Conditions.cs:118:17:118:20 | access to local variable last | Conditions.cs:118:17:118:20 | access to local variable last | normal |
 | Conditions.cs:118:17:118:43 | Boolean last = ... | Conditions.cs:118:17:118:43 | Boolean last = ... | normal |
 | Conditions.cs:118:24:118:24 | access to local variable i | Conditions.cs:118:24:118:24 | access to local variable i | normal |
 | Conditions.cs:118:24:118:43 | ... == ... | Conditions.cs:118:24:118:43 | ... == ... | normal |
@@ -939,7 +909,6 @@
 | Conditions.cs:119:17:119:21 | !... | Conditions.cs:119:18:119:21 | access to local variable last | true/false |
 | Conditions.cs:119:18:119:21 | access to local variable last | Conditions.cs:119:18:119:21 | access to local variable last | false/false |
 | Conditions.cs:119:18:119:21 | access to local variable last | Conditions.cs:119:18:119:21 | access to local variable last | true/true |
-| Conditions.cs:120:17:120:17 | access to local variable s | Conditions.cs:120:17:120:17 | access to local variable s | normal |
 | Conditions.cs:120:17:120:22 | ... = ... | Conditions.cs:120:17:120:22 | ... = ... | normal |
 | Conditions.cs:120:17:120:23 | ...; | Conditions.cs:120:17:120:22 | ... = ... | normal |
 | Conditions.cs:120:21:120:22 | "" | Conditions.cs:120:21:120:22 | "" | normal |
@@ -947,7 +916,6 @@
 | Conditions.cs:121:13:122:25 | if (...) ... | Conditions.cs:122:17:122:24 | ... = ... | normal |
 | Conditions.cs:121:17:121:20 | access to local variable last | Conditions.cs:121:17:121:20 | access to local variable last | false/false |
 | Conditions.cs:121:17:121:20 | access to local variable last | Conditions.cs:121:17:121:20 | access to local variable last | true/true |
-| Conditions.cs:122:17:122:17 | access to local variable s | Conditions.cs:122:17:122:17 | access to local variable s | normal |
 | Conditions.cs:122:17:122:24 | ... = ... | Conditions.cs:122:17:122:24 | ... = ... | normal |
 | Conditions.cs:122:17:122:25 | ...; | Conditions.cs:122:17:122:24 | ... = ... | normal |
 | Conditions.cs:122:21:122:24 | null | Conditions.cs:122:21:122:24 | null | normal |
@@ -1109,7 +1077,6 @@
 | ExitMethods.cs:121:9:121:29 | ...; | ExitMethods.cs:121:9:121:28 | call to method IsTrue | throw(AssertFailedException) |
 | ExitMethods.cs:121:23:121:27 | false | ExitMethods.cs:121:23:121:27 | false | normal |
 | ExitMethods.cs:122:9:122:18 | ... ...; | ExitMethods.cs:122:13:122:17 | Int32 x = ... | normal |
-| ExitMethods.cs:122:13:122:13 | access to local variable x | ExitMethods.cs:122:13:122:13 | access to local variable x | normal |
 | ExitMethods.cs:122:13:122:17 | Int32 x = ... | ExitMethods.cs:122:13:122:17 | Int32 x = ... | normal |
 | ExitMethods.cs:122:17:122:17 | 0 | ExitMethods.cs:122:17:122:17 | 0 | normal |
 | ExitMethods.cs:126:5:129:5 | {...} | ExitMethods.cs:127:9:127:26 | call to method FailingAssertion | throw(AssertFailedException) |
@@ -1118,7 +1085,6 @@
 | ExitMethods.cs:127:9:127:26 | this access | ExitMethods.cs:127:9:127:26 | this access | normal |
 | ExitMethods.cs:127:9:127:27 | ...; | ExitMethods.cs:127:9:127:26 | call to method FailingAssertion | throw(AssertFailedException) |
 | ExitMethods.cs:128:9:128:18 | ... ...; | ExitMethods.cs:128:13:128:17 | Int32 x = ... | normal |
-| ExitMethods.cs:128:13:128:13 | access to local variable x | ExitMethods.cs:128:13:128:13 | access to local variable x | normal |
 | ExitMethods.cs:128:13:128:17 | Int32 x = ... | ExitMethods.cs:128:13:128:17 | Int32 x = ... | normal |
 | ExitMethods.cs:128:17:128:17 | 0 | ExitMethods.cs:128:17:128:17 | 0 | normal |
 | ExitMethods.cs:131:33:131:49 | call to method IsFalse | ExitMethods.cs:131:33:131:49 | call to method IsFalse | normal |
@@ -1130,7 +1096,6 @@
 | ExitMethods.cs:135:9:135:26 | ...; | ExitMethods.cs:135:9:135:25 | call to method AssertFalse | throw(AssertFailedException) |
 | ExitMethods.cs:135:21:135:24 | true | ExitMethods.cs:135:21:135:24 | true | normal |
 | ExitMethods.cs:136:9:136:18 | ... ...; | ExitMethods.cs:136:13:136:17 | Int32 x = ... | normal |
-| ExitMethods.cs:136:13:136:13 | access to local variable x | ExitMethods.cs:136:13:136:13 | access to local variable x | normal |
 | ExitMethods.cs:136:13:136:17 | Int32 x = ... | ExitMethods.cs:136:13:136:17 | Int32 x = ... | normal |
 | ExitMethods.cs:136:17:136:17 | 0 | ExitMethods.cs:136:17:136:17 | 0 | normal |
 | Extensions.cs:6:5:8:5 | {...} | Extensions.cs:7:9:7:30 | return ...; | return |
@@ -1212,19 +1177,15 @@
 | Initializers.cs:6:28:6:30 | {...} | Initializers.cs:6:28:6:30 | {...} | normal |
 | Initializers.cs:9:5:12:5 | {...} | Initializers.cs:11:13:11:63 | Initializers[] iz = ... | normal |
 | Initializers.cs:10:9:10:54 | ... ...; | Initializers.cs:10:13:10:53 | Initializers i = ... | normal |
-| Initializers.cs:10:13:10:13 | access to local variable i | Initializers.cs:10:13:10:13 | access to local variable i | normal |
 | Initializers.cs:10:13:10:53 | Initializers i = ... | Initializers.cs:10:13:10:53 | Initializers i = ... | normal |
 | Initializers.cs:10:17:10:53 | object creation of type Initializers | Initializers.cs:10:38:10:53 | { ..., ... } | normal |
 | Initializers.cs:10:34:10:35 | "" | Initializers.cs:10:34:10:35 | "" | normal |
 | Initializers.cs:10:38:10:53 | { ..., ... } | Initializers.cs:10:38:10:53 | { ..., ... } | normal |
-| Initializers.cs:10:40:10:40 | access to field F | Initializers.cs:10:40:10:40 | access to field F | normal |
 | Initializers.cs:10:40:10:44 | ... = ... | Initializers.cs:10:40:10:44 | ... = ... | normal |
 | Initializers.cs:10:44:10:44 | 0 | Initializers.cs:10:44:10:44 | 0 | normal |
-| Initializers.cs:10:47:10:47 | access to property G | Initializers.cs:10:47:10:47 | access to property G | normal |
 | Initializers.cs:10:47:10:51 | ... = ... | Initializers.cs:10:47:10:51 | ... = ... | normal |
 | Initializers.cs:10:51:10:51 | 1 | Initializers.cs:10:51:10:51 | 1 | normal |
 | Initializers.cs:11:9:11:64 | ... ...; | Initializers.cs:11:13:11:63 | Initializers[] iz = ... | normal |
-| Initializers.cs:11:13:11:14 | access to local variable iz | Initializers.cs:11:13:11:14 | access to local variable iz | normal |
 | Initializers.cs:11:13:11:63 | Initializers[] iz = ... | Initializers.cs:11:13:11:63 | Initializers[] iz = ... | normal |
 | Initializers.cs:11:18:11:63 | 2 | Initializers.cs:11:18:11:63 | 2 | normal |
 | Initializers.cs:11:18:11:63 | array creation of type Initializers[] | Initializers.cs:11:37:11:63 | { ..., ... } | normal |
@@ -1298,20 +1259,17 @@
 | NullCoalescing.cs:11:68:11:68 | 1 | NullCoalescing.cs:11:68:11:68 | 1 | normal |
 | NullCoalescing.cs:14:5:18:5 | {...} | NullCoalescing.cs:17:9:17:24 | ... = ... | normal |
 | NullCoalescing.cs:15:9:15:32 | ... ...; | NullCoalescing.cs:15:13:15:31 | Int32 j = ... | normal |
-| NullCoalescing.cs:15:13:15:13 | access to local variable j | NullCoalescing.cs:15:13:15:13 | access to local variable j | normal |
 | NullCoalescing.cs:15:13:15:31 | Int32 j = ... | NullCoalescing.cs:15:13:15:31 | Int32 j = ... | normal |
 | NullCoalescing.cs:15:17:15:26 | (...) ... | NullCoalescing.cs:15:17:15:26 | (...) ... | null |
 | NullCoalescing.cs:15:17:15:31 | ... ?? ... | NullCoalescing.cs:15:31:15:31 | 0 | normal |
 | NullCoalescing.cs:15:23:15:26 | null | NullCoalescing.cs:15:23:15:26 | null | normal |
 | NullCoalescing.cs:15:31:15:31 | 0 | NullCoalescing.cs:15:31:15:31 | 0 | normal |
 | NullCoalescing.cs:16:9:16:26 | ... ...; | NullCoalescing.cs:16:13:16:25 | String s = ... | normal |
-| NullCoalescing.cs:16:13:16:13 | access to local variable s | NullCoalescing.cs:16:13:16:13 | access to local variable s | normal |
 | NullCoalescing.cs:16:13:16:25 | String s = ... | NullCoalescing.cs:16:13:16:25 | String s = ... | normal |
 | NullCoalescing.cs:16:17:16:18 | "" | NullCoalescing.cs:16:17:16:18 | "" | non-null |
 | NullCoalescing.cs:16:17:16:25 | ... ?? ... | NullCoalescing.cs:16:17:16:18 | "" | non-null |
 | NullCoalescing.cs:16:17:16:25 | ... ?? ... | NullCoalescing.cs:16:23:16:25 | "a" | normal |
 | NullCoalescing.cs:16:23:16:25 | "a" | NullCoalescing.cs:16:23:16:25 | "a" | normal |
-| NullCoalescing.cs:17:9:17:9 | access to local variable j | NullCoalescing.cs:17:9:17:9 | access to local variable j | normal |
 | NullCoalescing.cs:17:9:17:24 | ... = ... | NullCoalescing.cs:17:9:17:24 | ... = ... | normal |
 | NullCoalescing.cs:17:9:17:25 | ...; | NullCoalescing.cs:17:9:17:24 | ... = ... | normal |
 | NullCoalescing.cs:17:13:17:19 | (...) ... | NullCoalescing.cs:17:13:17:19 | (...) ... | non-null |
@@ -1321,7 +1279,6 @@
 | NullCoalescing.cs:17:24:17:24 | 1 | NullCoalescing.cs:17:24:17:24 | 1 | normal |
 | Patterns.cs:6:5:43:5 | {...} | Patterns.cs:40:17:40:17 | access to local variable o | normal |
 | Patterns.cs:7:9:7:24 | ... ...; | Patterns.cs:7:16:7:23 | Object o = ... | normal |
-| Patterns.cs:7:16:7:16 | access to local variable o | Patterns.cs:7:16:7:16 | access to local variable o | normal |
 | Patterns.cs:7:16:7:23 | Object o = ... | Patterns.cs:7:16:7:23 | Object o = ... | normal |
 | Patterns.cs:7:20:7:23 | null | Patterns.cs:7:20:7:23 | null | normal |
 | Patterns.cs:8:9:18:9 | if (...) ... | Patterns.cs:10:13:10:42 | call to method WriteLine | normal |
@@ -1417,70 +1374,55 @@
 | Qualifiers.cs:8:41:8:44 | null | Qualifiers.cs:8:41:8:44 | null | normal |
 | Qualifiers.cs:11:5:31:5 | {...} | Qualifiers.cs:30:9:30:46 | ... = ... | normal |
 | Qualifiers.cs:12:9:12:22 | ... ...; | Qualifiers.cs:12:13:12:21 | Qualifiers q = ... | normal |
-| Qualifiers.cs:12:13:12:13 | access to local variable q | Qualifiers.cs:12:13:12:13 | access to local variable q | normal |
 | Qualifiers.cs:12:13:12:21 | Qualifiers q = ... | Qualifiers.cs:12:13:12:21 | Qualifiers q = ... | normal |
 | Qualifiers.cs:12:17:12:21 | access to field Field | Qualifiers.cs:12:17:12:21 | access to field Field | normal |
 | Qualifiers.cs:12:17:12:21 | this access | Qualifiers.cs:12:17:12:21 | this access | normal |
-| Qualifiers.cs:13:9:13:9 | access to local variable q | Qualifiers.cs:13:9:13:9 | access to local variable q | normal |
 | Qualifiers.cs:13:9:13:20 | ... = ... | Qualifiers.cs:13:9:13:20 | ... = ... | normal |
 | Qualifiers.cs:13:9:13:21 | ...; | Qualifiers.cs:13:9:13:20 | ... = ... | normal |
 | Qualifiers.cs:13:13:13:20 | access to property Property | Qualifiers.cs:13:13:13:20 | access to property Property | normal |
 | Qualifiers.cs:13:13:13:20 | this access | Qualifiers.cs:13:13:13:20 | this access | normal |
-| Qualifiers.cs:14:9:14:9 | access to local variable q | Qualifiers.cs:14:9:14:9 | access to local variable q | normal |
 | Qualifiers.cs:14:9:14:20 | ... = ... | Qualifiers.cs:14:9:14:20 | ... = ... | normal |
 | Qualifiers.cs:14:9:14:21 | ...; | Qualifiers.cs:14:9:14:20 | ... = ... | normal |
 | Qualifiers.cs:14:13:14:20 | call to method Method | Qualifiers.cs:14:13:14:20 | call to method Method | normal |
 | Qualifiers.cs:14:13:14:20 | this access | Qualifiers.cs:14:13:14:20 | this access | normal |
-| Qualifiers.cs:16:9:16:9 | access to local variable q | Qualifiers.cs:16:9:16:9 | access to local variable q | normal |
 | Qualifiers.cs:16:9:16:22 | ... = ... | Qualifiers.cs:16:9:16:22 | ... = ... | normal |
 | Qualifiers.cs:16:9:16:23 | ...; | Qualifiers.cs:16:9:16:22 | ... = ... | normal |
 | Qualifiers.cs:16:13:16:16 | this access | Qualifiers.cs:16:13:16:16 | this access | normal |
 | Qualifiers.cs:16:13:16:22 | access to field Field | Qualifiers.cs:16:13:16:22 | access to field Field | normal |
-| Qualifiers.cs:17:9:17:9 | access to local variable q | Qualifiers.cs:17:9:17:9 | access to local variable q | normal |
 | Qualifiers.cs:17:9:17:25 | ... = ... | Qualifiers.cs:17:9:17:25 | ... = ... | normal |
 | Qualifiers.cs:17:9:17:26 | ...; | Qualifiers.cs:17:9:17:25 | ... = ... | normal |
 | Qualifiers.cs:17:13:17:16 | this access | Qualifiers.cs:17:13:17:16 | this access | normal |
 | Qualifiers.cs:17:13:17:25 | access to property Property | Qualifiers.cs:17:13:17:25 | access to property Property | normal |
-| Qualifiers.cs:18:9:18:9 | access to local variable q | Qualifiers.cs:18:9:18:9 | access to local variable q | normal |
 | Qualifiers.cs:18:9:18:25 | ... = ... | Qualifiers.cs:18:9:18:25 | ... = ... | normal |
 | Qualifiers.cs:18:9:18:26 | ...; | Qualifiers.cs:18:9:18:25 | ... = ... | normal |
 | Qualifiers.cs:18:13:18:16 | this access | Qualifiers.cs:18:13:18:16 | this access | normal |
 | Qualifiers.cs:18:13:18:25 | call to method Method | Qualifiers.cs:18:13:18:25 | call to method Method | normal |
-| Qualifiers.cs:20:9:20:9 | access to local variable q | Qualifiers.cs:20:9:20:9 | access to local variable q | normal |
 | Qualifiers.cs:20:9:20:23 | ... = ... | Qualifiers.cs:20:9:20:23 | ... = ... | normal |
 | Qualifiers.cs:20:9:20:24 | ...; | Qualifiers.cs:20:9:20:23 | ... = ... | normal |
 | Qualifiers.cs:20:13:20:23 | access to field StaticField | Qualifiers.cs:20:13:20:23 | access to field StaticField | normal |
-| Qualifiers.cs:21:9:21:9 | access to local variable q | Qualifiers.cs:21:9:21:9 | access to local variable q | normal |
 | Qualifiers.cs:21:9:21:26 | ... = ... | Qualifiers.cs:21:9:21:26 | ... = ... | normal |
 | Qualifiers.cs:21:9:21:27 | ...; | Qualifiers.cs:21:9:21:26 | ... = ... | normal |
 | Qualifiers.cs:21:13:21:26 | access to property StaticProperty | Qualifiers.cs:21:13:21:26 | access to property StaticProperty | normal |
-| Qualifiers.cs:22:9:22:9 | access to local variable q | Qualifiers.cs:22:9:22:9 | access to local variable q | normal |
 | Qualifiers.cs:22:9:22:26 | ... = ... | Qualifiers.cs:22:9:22:26 | ... = ... | normal |
 | Qualifiers.cs:22:9:22:27 | ...; | Qualifiers.cs:22:9:22:26 | ... = ... | normal |
 | Qualifiers.cs:22:13:22:26 | call to method StaticMethod | Qualifiers.cs:22:13:22:26 | call to method StaticMethod | normal |
-| Qualifiers.cs:24:9:24:9 | access to local variable q | Qualifiers.cs:24:9:24:9 | access to local variable q | normal |
 | Qualifiers.cs:24:9:24:34 | ... = ... | Qualifiers.cs:24:9:24:34 | ... = ... | normal |
 | Qualifiers.cs:24:9:24:35 | ...; | Qualifiers.cs:24:9:24:34 | ... = ... | normal |
 | Qualifiers.cs:24:13:24:34 | access to field StaticField | Qualifiers.cs:24:13:24:34 | access to field StaticField | normal |
-| Qualifiers.cs:25:9:25:9 | access to local variable q | Qualifiers.cs:25:9:25:9 | access to local variable q | normal |
 | Qualifiers.cs:25:9:25:37 | ... = ... | Qualifiers.cs:25:9:25:37 | ... = ... | normal |
 | Qualifiers.cs:25:9:25:38 | ...; | Qualifiers.cs:25:9:25:37 | ... = ... | normal |
 | Qualifiers.cs:25:13:25:37 | access to property StaticProperty | Qualifiers.cs:25:13:25:37 | access to property StaticProperty | normal |
-| Qualifiers.cs:26:9:26:9 | access to local variable q | Qualifiers.cs:26:9:26:9 | access to local variable q | normal |
 | Qualifiers.cs:26:9:26:37 | ... = ... | Qualifiers.cs:26:9:26:37 | ... = ... | normal |
 | Qualifiers.cs:26:9:26:38 | ...; | Qualifiers.cs:26:9:26:37 | ... = ... | normal |
 | Qualifiers.cs:26:13:26:37 | call to method StaticMethod | Qualifiers.cs:26:13:26:37 | call to method StaticMethod | normal |
-| Qualifiers.cs:28:9:28:9 | access to local variable q | Qualifiers.cs:28:9:28:9 | access to local variable q | normal |
 | Qualifiers.cs:28:9:28:40 | ... = ... | Qualifiers.cs:28:9:28:40 | ... = ... | normal |
 | Qualifiers.cs:28:9:28:41 | ...; | Qualifiers.cs:28:9:28:40 | ... = ... | normal |
 | Qualifiers.cs:28:13:28:34 | access to field StaticField | Qualifiers.cs:28:13:28:34 | access to field StaticField | normal |
 | Qualifiers.cs:28:13:28:40 | access to field Field | Qualifiers.cs:28:13:28:40 | access to field Field | normal |
-| Qualifiers.cs:29:9:29:9 | access to local variable q | Qualifiers.cs:29:9:29:9 | access to local variable q | normal |
 | Qualifiers.cs:29:9:29:46 | ... = ... | Qualifiers.cs:29:9:29:46 | ... = ... | normal |
 | Qualifiers.cs:29:9:29:47 | ...; | Qualifiers.cs:29:9:29:46 | ... = ... | normal |
 | Qualifiers.cs:29:13:29:37 | access to property StaticProperty | Qualifiers.cs:29:13:29:37 | access to property StaticProperty | normal |
 | Qualifiers.cs:29:13:29:46 | access to property Property | Qualifiers.cs:29:13:29:46 | access to property Property | normal |
-| Qualifiers.cs:30:9:30:9 | access to local variable q | Qualifiers.cs:30:9:30:9 | access to local variable q | normal |
 | Qualifiers.cs:30:9:30:46 | ... = ... | Qualifiers.cs:30:9:30:46 | ... = ... | normal |
 | Qualifiers.cs:30:9:30:47 | ...; | Qualifiers.cs:30:9:30:46 | ... = ... | normal |
 | Qualifiers.cs:30:13:30:37 | call to method StaticMethod | Qualifiers.cs:30:13:30:37 | call to method StaticMethod | normal |
@@ -1723,11 +1665,9 @@
 | Switch.cs:120:17:120:17 | 1 | Switch.cs:120:17:120:17 | 1 | normal |
 | TypeAccesses.cs:4:5:9:5 | {...} | TypeAccesses.cs:8:13:8:27 | Type t = ... | normal |
 | TypeAccesses.cs:5:9:5:26 | ... ...; | TypeAccesses.cs:5:13:5:25 | String s = ... | normal |
-| TypeAccesses.cs:5:13:5:13 | access to local variable s | TypeAccesses.cs:5:13:5:13 | access to local variable s | normal |
 | TypeAccesses.cs:5:13:5:25 | String s = ... | TypeAccesses.cs:5:13:5:25 | String s = ... | normal |
 | TypeAccesses.cs:5:17:5:25 | (...) ... | TypeAccesses.cs:5:17:5:25 | (...) ... | normal |
 | TypeAccesses.cs:5:25:5:25 | access to parameter o | TypeAccesses.cs:5:25:5:25 | access to parameter o | normal |
-| TypeAccesses.cs:6:9:6:9 | access to local variable s | TypeAccesses.cs:6:9:6:9 | access to local variable s | normal |
 | TypeAccesses.cs:6:9:6:23 | ... = ... | TypeAccesses.cs:6:9:6:23 | ... = ... | normal |
 | TypeAccesses.cs:6:9:6:24 | ...; | TypeAccesses.cs:6:9:6:23 | ... = ... | normal |
 | TypeAccesses.cs:6:13:6:13 | access to parameter o | TypeAccesses.cs:6:13:6:13 | access to parameter o | normal |
@@ -1740,17 +1680,14 @@
 | TypeAccesses.cs:7:18:7:22 | Int32 j | TypeAccesses.cs:7:18:7:22 | Int32 j | normal |
 | TypeAccesses.cs:7:25:7:25 | ; | TypeAccesses.cs:7:25:7:25 | ; | normal |
 | TypeAccesses.cs:8:9:8:28 | ... ...; | TypeAccesses.cs:8:13:8:27 | Type t = ... | normal |
-| TypeAccesses.cs:8:13:8:13 | access to local variable t | TypeAccesses.cs:8:13:8:13 | access to local variable t | normal |
 | TypeAccesses.cs:8:13:8:27 | Type t = ... | TypeAccesses.cs:8:13:8:27 | Type t = ... | normal |
 | TypeAccesses.cs:8:17:8:27 | typeof(...) | TypeAccesses.cs:8:17:8:27 | typeof(...) | normal |
 | VarDecls.cs:6:5:11:5 | {...} | VarDecls.cs:9:13:9:29 | return ...; | return |
 | VarDecls.cs:7:9:10:9 | fixed(...) { ... } | VarDecls.cs:9:13:9:29 | return ...; | return |
-| VarDecls.cs:7:22:7:23 | access to local variable c1 | VarDecls.cs:7:22:7:23 | access to local variable c1 | normal |
 | VarDecls.cs:7:22:7:36 | Char* c1 = ... | VarDecls.cs:7:22:7:36 | Char* c1 = ... | normal |
 | VarDecls.cs:7:27:7:33 | access to parameter strings | VarDecls.cs:7:27:7:33 | access to parameter strings | normal |
 | VarDecls.cs:7:27:7:36 | access to array element | VarDecls.cs:7:27:7:36 | access to array element | normal |
 | VarDecls.cs:7:35:7:35 | 0 | VarDecls.cs:7:35:7:35 | 0 | normal |
-| VarDecls.cs:7:39:7:40 | access to local variable c2 | VarDecls.cs:7:39:7:40 | access to local variable c2 | normal |
 | VarDecls.cs:7:39:7:53 | Char* c2 = ... | VarDecls.cs:7:39:7:53 | Char* c2 = ... | normal |
 | VarDecls.cs:7:44:7:50 | access to parameter strings | VarDecls.cs:7:44:7:50 | access to parameter strings | normal |
 | VarDecls.cs:7:44:7:53 | access to array element | VarDecls.cs:7:44:7:53 | access to array element | normal |
@@ -1761,10 +1698,8 @@
 | VarDecls.cs:9:27:9:28 | access to local variable c1 | VarDecls.cs:9:27:9:28 | access to local variable c1 | normal |
 | VarDecls.cs:14:5:17:5 | {...} | VarDecls.cs:16:9:16:23 | return ...; | return |
 | VarDecls.cs:15:9:15:30 | ... ...; | VarDecls.cs:15:24:15:29 | String s2 = ... | normal |
-| VarDecls.cs:15:16:15:17 | access to local variable s1 | VarDecls.cs:15:16:15:17 | access to local variable s1 | normal |
 | VarDecls.cs:15:16:15:21 | String s1 = ... | VarDecls.cs:15:16:15:21 | String s1 = ... | normal |
 | VarDecls.cs:15:21:15:21 | access to parameter s | VarDecls.cs:15:21:15:21 | access to parameter s | normal |
-| VarDecls.cs:15:24:15:25 | access to local variable s2 | VarDecls.cs:15:24:15:25 | access to local variable s2 | normal |
 | VarDecls.cs:15:24:15:29 | String s2 = ... | VarDecls.cs:15:24:15:29 | String s2 = ... | normal |
 | VarDecls.cs:15:29:15:29 | access to parameter s | VarDecls.cs:15:29:15:29 | access to parameter s | normal |
 | VarDecls.cs:16:9:16:23 | return ...; | VarDecls.cs:16:9:16:23 | return ...; | return |
@@ -1776,10 +1711,8 @@
 | VarDecls.cs:21:16:21:22 | object creation of type C | VarDecls.cs:21:16:21:22 | object creation of type C | normal |
 | VarDecls.cs:22:13:22:13 | ; | VarDecls.cs:22:13:22:13 | ; | normal |
 | VarDecls.cs:24:9:25:29 | using (...) {...} | VarDecls.cs:25:13:25:29 | return ...; | return |
-| VarDecls.cs:24:18:24:18 | access to local variable x | VarDecls.cs:24:18:24:18 | access to local variable x | normal |
 | VarDecls.cs:24:18:24:28 | C x = ... | VarDecls.cs:24:18:24:28 | C x = ... | normal |
 | VarDecls.cs:24:22:24:28 | object creation of type C | VarDecls.cs:24:22:24:28 | object creation of type C | normal |
-| VarDecls.cs:24:31:24:31 | access to local variable y | VarDecls.cs:24:31:24:31 | access to local variable y | normal |
 | VarDecls.cs:24:31:24:41 | C y = ... | VarDecls.cs:24:31:24:41 | C y = ... | normal |
 | VarDecls.cs:24:35:24:41 | object creation of type C | VarDecls.cs:24:35:24:41 | object creation of type C | normal |
 | VarDecls.cs:25:13:25:29 | return ...; | VarDecls.cs:25:13:25:29 | return ...; | return |
@@ -1792,11 +1725,9 @@
 | VarDecls.cs:28:51:28:53 | {...} | VarDecls.cs:28:51:28:53 | {...} | normal |
 | cflow.cs:6:5:35:5 | {...} | cflow.cs:24:25:24:31 | ... <= ... | false/false |
 | cflow.cs:7:9:7:28 | ... ...; | cflow.cs:7:13:7:27 | Int32 a = ... | normal |
-| cflow.cs:7:13:7:13 | access to local variable a | cflow.cs:7:13:7:13 | access to local variable a | normal |
 | cflow.cs:7:13:7:27 | Int32 a = ... | cflow.cs:7:13:7:27 | Int32 a = ... | normal |
 | cflow.cs:7:17:7:20 | access to parameter args | cflow.cs:7:17:7:20 | access to parameter args | normal |
 | cflow.cs:7:17:7:27 | access to property Length | cflow.cs:7:17:7:27 | access to property Length | normal |
-| cflow.cs:9:9:9:9 | access to local variable a | cflow.cs:9:9:9:9 | access to local variable a | normal |
 | cflow.cs:9:9:9:39 | ... = ... | cflow.cs:9:9:9:39 | ... = ... | normal |
 | cflow.cs:9:9:9:40 | ...; | cflow.cs:9:9:9:39 | ... = ... | normal |
 | cflow.cs:9:13:9:29 | object creation of type ControlFlow | cflow.cs:9:13:9:29 | object creation of type ControlFlow | normal |
@@ -1835,7 +1766,6 @@
 | cflow.cs:22:18:22:23 | ... < ... | cflow.cs:22:18:22:23 | ... < ... | true/true |
 | cflow.cs:22:22:22:23 | 10 | cflow.cs:22:22:22:23 | 10 | normal |
 | cflow.cs:24:9:34:9 | for (...;...;...) ... | cflow.cs:24:25:24:31 | ... <= ... | false/false |
-| cflow.cs:24:18:24:18 | access to local variable i | cflow.cs:24:18:24:18 | access to local variable i | normal |
 | cflow.cs:24:18:24:22 | Int32 i = ... | cflow.cs:24:18:24:22 | Int32 i = ... | normal |
 | cflow.cs:24:22:24:22 | 1 | cflow.cs:24:22:24:22 | 1 | normal |
 | cflow.cs:24:25:24:25 | access to local variable i | cflow.cs:24:25:24:25 | access to local variable i | normal |
@@ -2083,10 +2013,8 @@
 | cflow.cs:116:27:116:27 | access to parameter s | cflow.cs:116:27:116:27 | access to parameter s | normal |
 | cflow.cs:120:5:124:5 | {...} | cflow.cs:123:9:123:17 | return ...; | return |
 | cflow.cs:121:9:121:18 | ... ...; | cflow.cs:121:13:121:17 | String x = ... | normal |
-| cflow.cs:121:13:121:13 | access to local variable x | cflow.cs:121:13:121:13 | access to local variable x | normal |
 | cflow.cs:121:13:121:17 | String x = ... | cflow.cs:121:13:121:17 | String x = ... | normal |
 | cflow.cs:121:17:121:17 | access to parameter s | cflow.cs:121:17:121:17 | access to parameter s | normal |
-| cflow.cs:122:9:122:9 | access to local variable x | cflow.cs:122:9:122:9 | access to local variable x | normal |
 | cflow.cs:122:9:122:19 | ... = ... | cflow.cs:122:9:122:19 | ... = ... | normal |
 | cflow.cs:122:9:122:20 | ...; | cflow.cs:122:9:122:19 | ... = ... | normal |
 | cflow.cs:122:13:122:13 | access to local variable x | cflow.cs:122:13:122:13 | access to local variable x | normal |
@@ -2107,13 +2035,13 @@
 | cflow.cs:127:53:127:57 | access to field Field | cflow.cs:127:53:127:57 | access to field Field | normal |
 | cflow.cs:127:53:127:57 | this access | cflow.cs:127:53:127:57 | this access | normal |
 | cflow.cs:127:66:127:83 | {...} | cflow.cs:127:68:127:80 | ... = ... | normal |
-| cflow.cs:127:68:127:72 | access to field Field | cflow.cs:127:68:127:72 | access to field Field | normal |
+| cflow.cs:127:68:127:72 | access to field Field | cflow.cs:127:68:127:72 | this access | normal |
 | cflow.cs:127:68:127:72 | this access | cflow.cs:127:68:127:72 | this access | normal |
 | cflow.cs:127:68:127:80 | ... = ... | cflow.cs:127:68:127:80 | ... = ... | normal |
 | cflow.cs:127:68:127:81 | ...; | cflow.cs:127:68:127:80 | ... = ... | normal |
 | cflow.cs:127:76:127:80 | access to parameter value | cflow.cs:127:76:127:80 | access to parameter value | normal |
 | cflow.cs:130:5:132:5 | {...} | cflow.cs:131:9:131:17 | ... = ... | normal |
-| cflow.cs:131:9:131:13 | access to field Field | cflow.cs:131:9:131:13 | access to field Field | normal |
+| cflow.cs:131:9:131:13 | access to field Field | cflow.cs:131:9:131:13 | this access | normal |
 | cflow.cs:131:9:131:13 | this access | cflow.cs:131:9:131:13 | this access | normal |
 | cflow.cs:131:9:131:17 | ... = ... | cflow.cs:131:9:131:17 | ... = ... | normal |
 | cflow.cs:131:9:131:18 | ...; | cflow.cs:131:9:131:17 | ... = ... | normal |
@@ -2266,7 +2194,6 @@
 | cflow.cs:203:13:203:41 | ...; | cflow.cs:203:13:203:40 | call to method WriteLine | normal |
 | cflow.cs:203:31:203:39 | "Finally" | cflow.cs:203:31:203:39 | "Finally" | normal |
 | cflow.cs:206:9:206:19 | ... ...; | cflow.cs:206:13:206:18 | Int32 i = ... | normal |
-| cflow.cs:206:13:206:13 | access to local variable i | cflow.cs:206:13:206:13 | access to local variable i | normal |
 | cflow.cs:206:13:206:18 | Int32 i = ... | cflow.cs:206:13:206:18 | Int32 i = ... | normal |
 | cflow.cs:206:17:206:18 | 10 | cflow.cs:206:17:206:18 | 10 | normal |
 | cflow.cs:207:9:230:9 | while (...) ... | cflow.cs:207:16:207:20 | ... > ... | false/false |
@@ -2427,7 +2354,6 @@
 | cflow.cs:247:9:254:9 | try {...} ... | cflow.cs:253:13:253:13 | ; | normal |
 | cflow.cs:248:9:250:9 | {...} | cflow.cs:249:17:249:40 | Double temp = ... | normal |
 | cflow.cs:249:13:249:41 | ... ...; | cflow.cs:249:17:249:40 | Double temp = ... | normal |
-| cflow.cs:249:17:249:20 | access to local variable temp | cflow.cs:249:17:249:20 | access to local variable temp | normal |
 | cflow.cs:249:17:249:40 | Double temp = ... | cflow.cs:249:17:249:40 | Double temp = ... | normal |
 | cflow.cs:249:24:249:24 | 0 | cflow.cs:249:24:249:24 | 0 | normal |
 | cflow.cs:249:24:249:24 | (...) ... | cflow.cs:249:24:249:24 | (...) ... | normal |
@@ -2438,7 +2364,6 @@
 | cflow.cs:253:13:253:13 | ; | cflow.cs:253:13:253:13 | ; | normal |
 | cflow.cs:258:5:288:5 | {...} | cflow.cs:284:32:284:41 | ... < ... | false/false |
 | cflow.cs:259:9:259:18 | ... ...; | cflow.cs:259:13:259:17 | Int32 x = ... | normal |
-| cflow.cs:259:13:259:13 | access to local variable x | cflow.cs:259:13:259:13 | access to local variable x | normal |
 | cflow.cs:259:13:259:17 | Int32 x = ... | cflow.cs:259:13:259:17 | Int32 x = ... | normal |
 | cflow.cs:259:17:259:17 | 0 | cflow.cs:259:17:259:17 | 0 | normal |
 | cflow.cs:260:9:261:33 | for (...;...;...) ... | cflow.cs:260:16:260:21 | ... < ... | false/false |
@@ -2495,10 +2420,8 @@
 | cflow.cs:281:13:281:15 | ...++ | cflow.cs:281:13:281:15 | ...++ | normal |
 | cflow.cs:281:13:281:16 | ...; | cflow.cs:281:13:281:15 | ...++ | normal |
 | cflow.cs:284:9:287:9 | for (...;...;...) ... | cflow.cs:284:32:284:41 | ... < ... | false/false |
-| cflow.cs:284:18:284:18 | access to local variable i | cflow.cs:284:18:284:18 | access to local variable i | normal |
 | cflow.cs:284:18:284:22 | Int32 i = ... | cflow.cs:284:18:284:22 | Int32 i = ... | normal |
 | cflow.cs:284:22:284:22 | 0 | cflow.cs:284:22:284:22 | 0 | normal |
-| cflow.cs:284:25:284:25 | access to local variable j | cflow.cs:284:25:284:25 | access to local variable j | normal |
 | cflow.cs:284:25:284:29 | Int32 j = ... | cflow.cs:284:25:284:29 | Int32 j = ... | normal |
 | cflow.cs:284:29:284:29 | 0 | cflow.cs:284:29:284:29 | 0 | normal |
 | cflow.cs:284:32:284:32 | access to local variable i | cflow.cs:284:32:284:32 | access to local variable i | normal |
@@ -2519,14 +2442,12 @@
 | cflow.cs:286:35:286:35 | access to local variable j | cflow.cs:286:35:286:35 | access to local variable j | normal |
 | cflow.cs:291:5:294:5 | {...} | cflow.cs:293:24:293:61 | Func<Int32,Int32> z = ... | normal |
 | cflow.cs:292:9:292:38 | ... ...; | cflow.cs:292:24:292:37 | Func<Int32,Int32> y = ... | normal |
-| cflow.cs:292:24:292:24 | access to local variable y | cflow.cs:292:24:292:24 | access to local variable y | normal |
 | cflow.cs:292:24:292:37 | Func<Int32,Int32> y = ... | cflow.cs:292:24:292:37 | Func<Int32,Int32> y = ... | normal |
 | cflow.cs:292:28:292:37 | (...) => ... | cflow.cs:292:28:292:37 | (...) => ... | normal |
 | cflow.cs:292:33:292:33 | access to parameter x | cflow.cs:292:33:292:33 | access to parameter x | normal |
 | cflow.cs:292:33:292:37 | ... + ... | cflow.cs:292:33:292:37 | ... + ... | normal |
 | cflow.cs:292:37:292:37 | 1 | cflow.cs:292:37:292:37 | 1 | normal |
 | cflow.cs:293:9:293:62 | ... ...; | cflow.cs:293:24:293:61 | Func<Int32,Int32> z = ... | normal |
-| cflow.cs:293:24:293:24 | access to local variable z | cflow.cs:293:24:293:24 | access to local variable z | normal |
 | cflow.cs:293:24:293:61 | Func<Int32,Int32> z = ... | cflow.cs:293:24:293:61 | Func<Int32,Int32> z = ... | normal |
 | cflow.cs:293:28:293:61 | delegate(...) { ... } | cflow.cs:293:28:293:61 | delegate(...) { ... } | normal |
 | cflow.cs:293:45:293:61 | {...} | cflow.cs:293:47:293:59 | return ...; | return |
@@ -2565,7 +2486,6 @@
 | cflow.cs:305:5:317:5 | {...} | cflow.cs:311:61:311:61 | access to local variable b | false/false |
 | cflow.cs:305:5:317:5 | {...} | cflow.cs:314:17:314:38 | throw ...; | throw(Exception) |
 | cflow.cs:306:9:306:57 | ... ...; | cflow.cs:306:13:306:56 | Boolean b = ... | normal |
-| cflow.cs:306:13:306:13 | access to local variable b | cflow.cs:306:13:306:13 | access to local variable b | normal |
 | cflow.cs:306:13:306:56 | Boolean b = ... | cflow.cs:306:13:306:56 | Boolean b = ... | normal |
 | cflow.cs:306:17:306:21 | access to field Field | cflow.cs:306:17:306:21 | access to field Field | normal |
 | cflow.cs:306:17:306:21 | this access | cflow.cs:306:17:306:21 | this access | normal |
@@ -2595,7 +2515,6 @@
 | cflow.cs:308:31:308:31 | 0 | cflow.cs:308:31:308:31 | 0 | normal |
 | cflow.cs:308:35:308:39 | false | cflow.cs:308:35:308:39 | false | false/false |
 | cflow.cs:308:43:308:46 | true | cflow.cs:308:43:308:46 | true | true/true |
-| cflow.cs:309:13:309:13 | access to local variable b | cflow.cs:309:13:309:13 | access to local variable b | normal |
 | cflow.cs:309:13:309:48 | ... = ... | cflow.cs:309:13:309:48 | ... = ... | normal |
 | cflow.cs:309:13:309:49 | ...; | cflow.cs:309:13:309:48 | ... = ... | normal |
 | cflow.cs:309:17:309:21 | access to field Field | cflow.cs:309:17:309:21 | access to field Field | normal |
@@ -2652,7 +2571,7 @@
 | cflow.cs:322:9:332:9 | {...} | cflow.cs:328:17:328:32 | ... < ... | false/false |
 | cflow.cs:322:9:332:9 | {...} | cflow.cs:330:17:330:22 | break; | break |
 | cflow.cs:323:13:323:17 | access to field Field | cflow.cs:323:13:323:17 | access to field Field | normal |
-| cflow.cs:323:13:323:17 | access to field Field | cflow.cs:323:13:323:17 | access to field Field | normal |
+| cflow.cs:323:13:323:17 | access to field Field | cflow.cs:323:13:323:17 | this access | normal |
 | cflow.cs:323:13:323:17 | this access | cflow.cs:323:13:323:17 | this access | normal |
 | cflow.cs:323:13:323:17 | this access | cflow.cs:323:13:323:17 | this access | normal |
 | cflow.cs:323:13:323:24 | ... + ... | cflow.cs:323:13:323:24 | ... + ... | normal |
@@ -2698,7 +2617,7 @@
 | cflow.cs:338:9:348:9 | {...} | cflow.cs:344:17:344:32 | ... < ... | false/false |
 | cflow.cs:338:9:348:9 | {...} | cflow.cs:346:17:346:22 | break; | break |
 | cflow.cs:339:13:339:17 | access to field Field | cflow.cs:339:13:339:17 | access to field Field | normal |
-| cflow.cs:339:13:339:17 | access to field Field | cflow.cs:339:13:339:17 | access to field Field | normal |
+| cflow.cs:339:13:339:17 | access to field Field | cflow.cs:339:13:339:17 | this access | normal |
 | cflow.cs:339:13:339:17 | this access | cflow.cs:339:13:339:17 | this access | normal |
 | cflow.cs:339:13:339:17 | this access | cflow.cs:339:13:339:17 | this access | normal |
 | cflow.cs:339:13:339:22 | ... + ... | cflow.cs:339:13:339:22 | ... + ... | normal |
@@ -2791,7 +2710,6 @@
 | cflow.cs:374:9:374:23 | yield return ...; | cflow.cs:374:9:374:23 | yield return ...; | normal |
 | cflow.cs:374:22:374:22 | 0 | cflow.cs:374:22:374:22 | 0 | normal |
 | cflow.cs:375:9:378:9 | for (...;...;...) ... | cflow.cs:375:25:375:30 | ... < ... | false/false |
-| cflow.cs:375:18:375:18 | access to local variable i | cflow.cs:375:18:375:18 | access to local variable i | normal |
 | cflow.cs:375:18:375:22 | Int32 i = ... | cflow.cs:375:18:375:22 | Int32 i = ... | normal |
 | cflow.cs:375:22:375:22 | 1 | cflow.cs:375:22:375:22 | 1 | normal |
 | cflow.cs:375:25:375:25 | access to local variable i | cflow.cs:375:25:375:25 | access to local variable i | normal |

--- a/csharp/ql/test/library-tests/controlflow/graph/NodeGraph.expected
+++ b/csharp/ql/test/library-tests/controlflow/graph/NodeGraph.expected
@@ -1,3 +1,243 @@
+| AccessorCalls.cs:5:23:5:25 | enter get_Item | AccessorCalls.cs:5:30:5:30 | access to parameter i | semmle.label | successor |
+| AccessorCalls.cs:5:30:5:30 | access to parameter i | AccessorCalls.cs:5:23:5:25 | exit get_Item | semmle.label | successor |
+| AccessorCalls.cs:5:33:5:35 | enter set_Item | AccessorCalls.cs:5:37:5:39 | {...} | semmle.label | successor |
+| AccessorCalls.cs:5:37:5:39 | {...} | AccessorCalls.cs:5:33:5:35 | exit set_Item | semmle.label | successor |
+| AccessorCalls.cs:7:32:7:34 | enter add_Event | AccessorCalls.cs:7:36:7:38 | {...} | semmle.label | successor |
+| AccessorCalls.cs:7:36:7:38 | {...} | AccessorCalls.cs:7:32:7:34 | exit add_Event | semmle.label | successor |
+| AccessorCalls.cs:7:40:7:45 | enter remove_Event | AccessorCalls.cs:7:47:7:49 | {...} | semmle.label | successor |
+| AccessorCalls.cs:7:47:7:49 | {...} | AccessorCalls.cs:7:40:7:45 | exit remove_Event | semmle.label | successor |
+| AccessorCalls.cs:10:10:10:11 | enter M1 | AccessorCalls.cs:11:5:17:5 | {...} | semmle.label | successor |
+| AccessorCalls.cs:11:5:17:5 | {...} | AccessorCalls.cs:12:9:12:32 | ...; | semmle.label | successor |
+| AccessorCalls.cs:12:9:12:12 | this access | AccessorCalls.cs:12:9:12:18 | access to field Field | semmle.label | successor |
+| AccessorCalls.cs:12:9:12:18 | access to field Field | AccessorCalls.cs:12:22:12:25 | this access | semmle.label | successor |
+| AccessorCalls.cs:12:9:12:31 | ... = ... | AccessorCalls.cs:13:9:13:30 | ...; | semmle.label | successor |
+| AccessorCalls.cs:12:9:12:32 | ...; | AccessorCalls.cs:12:9:12:12 | this access | semmle.label | successor |
+| AccessorCalls.cs:12:22:12:25 | this access | AccessorCalls.cs:12:22:12:31 | access to field Field | semmle.label | successor |
+| AccessorCalls.cs:12:22:12:31 | access to field Field | AccessorCalls.cs:12:9:12:31 | ... = ... | semmle.label | successor |
+| AccessorCalls.cs:13:9:13:12 | this access | AccessorCalls.cs:13:9:13:17 | access to property Prop | semmle.label | successor |
+| AccessorCalls.cs:13:9:13:17 | access to property Prop | AccessorCalls.cs:13:21:13:24 | this access | semmle.label | successor |
+| AccessorCalls.cs:13:9:13:29 | ... = ... | AccessorCalls.cs:14:9:14:26 | ...; | semmle.label | successor |
+| AccessorCalls.cs:13:9:13:30 | ...; | AccessorCalls.cs:13:9:13:12 | this access | semmle.label | successor |
+| AccessorCalls.cs:13:21:13:24 | this access | AccessorCalls.cs:13:21:13:29 | access to property Prop | semmle.label | successor |
+| AccessorCalls.cs:13:21:13:29 | access to property Prop | AccessorCalls.cs:13:9:13:29 | ... = ... | semmle.label | successor |
+| AccessorCalls.cs:14:9:14:12 | this access | AccessorCalls.cs:14:14:14:14 | 0 | semmle.label | successor |
+| AccessorCalls.cs:14:9:14:15 | access to indexer | AccessorCalls.cs:14:19:14:22 | this access | semmle.label | successor |
+| AccessorCalls.cs:14:9:14:25 | ... = ... | AccessorCalls.cs:15:9:15:24 | ...; | semmle.label | successor |
+| AccessorCalls.cs:14:9:14:26 | ...; | AccessorCalls.cs:14:9:14:12 | this access | semmle.label | successor |
+| AccessorCalls.cs:14:14:14:14 | 0 | AccessorCalls.cs:14:9:14:15 | access to indexer | semmle.label | successor |
+| AccessorCalls.cs:14:19:14:22 | this access | AccessorCalls.cs:14:24:14:24 | 1 | semmle.label | successor |
+| AccessorCalls.cs:14:19:14:25 | access to indexer | AccessorCalls.cs:14:9:14:25 | ... = ... | semmle.label | successor |
+| AccessorCalls.cs:14:24:14:24 | 1 | AccessorCalls.cs:14:19:14:25 | access to indexer | semmle.label | successor |
+| AccessorCalls.cs:15:9:15:12 | this access | AccessorCalls.cs:15:9:15:18 | access to event Event | semmle.label | successor |
+| AccessorCalls.cs:15:9:15:18 | access to event Event | AccessorCalls.cs:15:23:15:23 | access to parameter e | semmle.label | successor |
+| AccessorCalls.cs:15:9:15:23 | ... += ... | AccessorCalls.cs:16:9:16:24 | ...; | semmle.label | successor |
+| AccessorCalls.cs:15:9:15:24 | ...; | AccessorCalls.cs:15:9:15:12 | this access | semmle.label | successor |
+| AccessorCalls.cs:15:23:15:23 | access to parameter e | AccessorCalls.cs:15:9:15:23 | ... += ... | semmle.label | successor |
+| AccessorCalls.cs:16:9:16:12 | this access | AccessorCalls.cs:16:9:16:18 | access to event Event | semmle.label | successor |
+| AccessorCalls.cs:16:9:16:18 | access to event Event | AccessorCalls.cs:16:23:16:23 | access to parameter e | semmle.label | successor |
+| AccessorCalls.cs:16:9:16:23 | ... -= ... | AccessorCalls.cs:10:10:10:11 | exit M1 | semmle.label | successor |
+| AccessorCalls.cs:16:9:16:24 | ...; | AccessorCalls.cs:16:9:16:12 | this access | semmle.label | successor |
+| AccessorCalls.cs:16:23:16:23 | access to parameter e | AccessorCalls.cs:16:9:16:23 | ... -= ... | semmle.label | successor |
+| AccessorCalls.cs:19:10:19:11 | enter M2 | AccessorCalls.cs:20:5:26:5 | {...} | semmle.label | successor |
+| AccessorCalls.cs:20:5:26:5 | {...} | AccessorCalls.cs:21:9:21:36 | ...; | semmle.label | successor |
+| AccessorCalls.cs:21:9:21:12 | this access | AccessorCalls.cs:21:9:21:14 | access to field x | semmle.label | successor |
+| AccessorCalls.cs:21:9:21:14 | access to field x | AccessorCalls.cs:21:9:21:20 | access to field Field | semmle.label | successor |
+| AccessorCalls.cs:21:9:21:20 | access to field Field | AccessorCalls.cs:21:24:21:27 | this access | semmle.label | successor |
+| AccessorCalls.cs:21:9:21:35 | ... = ... | AccessorCalls.cs:22:9:22:34 | ...; | semmle.label | successor |
+| AccessorCalls.cs:21:9:21:36 | ...; | AccessorCalls.cs:21:9:21:12 | this access | semmle.label | successor |
+| AccessorCalls.cs:21:24:21:27 | this access | AccessorCalls.cs:21:24:21:29 | access to field x | semmle.label | successor |
+| AccessorCalls.cs:21:24:21:29 | access to field x | AccessorCalls.cs:21:24:21:35 | access to field Field | semmle.label | successor |
+| AccessorCalls.cs:21:24:21:35 | access to field Field | AccessorCalls.cs:21:9:21:35 | ... = ... | semmle.label | successor |
+| AccessorCalls.cs:22:9:22:12 | this access | AccessorCalls.cs:22:9:22:14 | access to field x | semmle.label | successor |
+| AccessorCalls.cs:22:9:22:14 | access to field x | AccessorCalls.cs:22:9:22:19 | access to property Prop | semmle.label | successor |
+| AccessorCalls.cs:22:9:22:19 | access to property Prop | AccessorCalls.cs:22:23:22:26 | this access | semmle.label | successor |
+| AccessorCalls.cs:22:9:22:33 | ... = ... | AccessorCalls.cs:23:9:23:30 | ...; | semmle.label | successor |
+| AccessorCalls.cs:22:9:22:34 | ...; | AccessorCalls.cs:22:9:22:12 | this access | semmle.label | successor |
+| AccessorCalls.cs:22:23:22:26 | this access | AccessorCalls.cs:22:23:22:28 | access to field x | semmle.label | successor |
+| AccessorCalls.cs:22:23:22:28 | access to field x | AccessorCalls.cs:22:23:22:33 | access to property Prop | semmle.label | successor |
+| AccessorCalls.cs:22:23:22:33 | access to property Prop | AccessorCalls.cs:22:9:22:33 | ... = ... | semmle.label | successor |
+| AccessorCalls.cs:23:9:23:12 | this access | AccessorCalls.cs:23:9:23:14 | access to field x | semmle.label | successor |
+| AccessorCalls.cs:23:9:23:14 | access to field x | AccessorCalls.cs:23:16:23:16 | 0 | semmle.label | successor |
+| AccessorCalls.cs:23:9:23:17 | access to indexer | AccessorCalls.cs:23:21:23:24 | this access | semmle.label | successor |
+| AccessorCalls.cs:23:9:23:29 | ... = ... | AccessorCalls.cs:24:9:24:26 | ...; | semmle.label | successor |
+| AccessorCalls.cs:23:9:23:30 | ...; | AccessorCalls.cs:23:9:23:12 | this access | semmle.label | successor |
+| AccessorCalls.cs:23:16:23:16 | 0 | AccessorCalls.cs:23:9:23:17 | access to indexer | semmle.label | successor |
+| AccessorCalls.cs:23:21:23:24 | this access | AccessorCalls.cs:23:21:23:26 | access to field x | semmle.label | successor |
+| AccessorCalls.cs:23:21:23:26 | access to field x | AccessorCalls.cs:23:28:23:28 | 1 | semmle.label | successor |
+| AccessorCalls.cs:23:21:23:29 | access to indexer | AccessorCalls.cs:23:9:23:29 | ... = ... | semmle.label | successor |
+| AccessorCalls.cs:23:28:23:28 | 1 | AccessorCalls.cs:23:21:23:29 | access to indexer | semmle.label | successor |
+| AccessorCalls.cs:24:9:24:12 | this access | AccessorCalls.cs:24:9:24:14 | access to field x | semmle.label | successor |
+| AccessorCalls.cs:24:9:24:14 | access to field x | AccessorCalls.cs:24:9:24:20 | access to event Event | semmle.label | successor |
+| AccessorCalls.cs:24:9:24:20 | access to event Event | AccessorCalls.cs:24:25:24:25 | access to parameter e | semmle.label | successor |
+| AccessorCalls.cs:24:9:24:25 | ... += ... | AccessorCalls.cs:25:9:25:26 | ...; | semmle.label | successor |
+| AccessorCalls.cs:24:9:24:26 | ...; | AccessorCalls.cs:24:9:24:12 | this access | semmle.label | successor |
+| AccessorCalls.cs:24:25:24:25 | access to parameter e | AccessorCalls.cs:24:9:24:25 | ... += ... | semmle.label | successor |
+| AccessorCalls.cs:25:9:25:12 | this access | AccessorCalls.cs:25:9:25:14 | access to field x | semmle.label | successor |
+| AccessorCalls.cs:25:9:25:14 | access to field x | AccessorCalls.cs:25:9:25:20 | access to event Event | semmle.label | successor |
+| AccessorCalls.cs:25:9:25:20 | access to event Event | AccessorCalls.cs:25:25:25:25 | access to parameter e | semmle.label | successor |
+| AccessorCalls.cs:25:9:25:25 | ... -= ... | AccessorCalls.cs:19:10:19:11 | exit M2 | semmle.label | successor |
+| AccessorCalls.cs:25:9:25:26 | ...; | AccessorCalls.cs:25:9:25:12 | this access | semmle.label | successor |
+| AccessorCalls.cs:25:25:25:25 | access to parameter e | AccessorCalls.cs:25:9:25:25 | ... -= ... | semmle.label | successor |
+| AccessorCalls.cs:28:10:28:11 | enter M3 | AccessorCalls.cs:29:5:33:5 | {...} | semmle.label | successor |
+| AccessorCalls.cs:29:5:33:5 | {...} | AccessorCalls.cs:30:9:30:21 | ...; | semmle.label | successor |
+| AccessorCalls.cs:30:9:30:12 | this access | AccessorCalls.cs:30:9:30:18 | access to field Field | semmle.label | successor |
+| AccessorCalls.cs:30:9:30:18 | access to field Field | AccessorCalls.cs:30:9:30:20 | ...++ | semmle.label | successor |
+| AccessorCalls.cs:30:9:30:20 | ...++ | AccessorCalls.cs:31:9:31:20 | ...; | semmle.label | successor |
+| AccessorCalls.cs:30:9:30:21 | ...; | AccessorCalls.cs:30:9:30:12 | this access | semmle.label | successor |
+| AccessorCalls.cs:31:9:31:12 | this access | AccessorCalls.cs:31:9:31:17 | access to property Prop | semmle.label | successor |
+| AccessorCalls.cs:31:9:31:17 | access to property Prop | AccessorCalls.cs:31:9:31:19 | ...++ | semmle.label | successor |
+| AccessorCalls.cs:31:9:31:19 | ...++ | AccessorCalls.cs:32:9:32:18 | ...; | semmle.label | successor |
+| AccessorCalls.cs:31:9:31:20 | ...; | AccessorCalls.cs:31:9:31:12 | this access | semmle.label | successor |
+| AccessorCalls.cs:32:9:32:12 | this access | AccessorCalls.cs:32:14:32:14 | 0 | semmle.label | successor |
+| AccessorCalls.cs:32:9:32:15 | access to indexer | AccessorCalls.cs:32:9:32:17 | ...++ | semmle.label | successor |
+| AccessorCalls.cs:32:9:32:17 | ...++ | AccessorCalls.cs:28:10:28:11 | exit M3 | semmle.label | successor |
+| AccessorCalls.cs:32:9:32:18 | ...; | AccessorCalls.cs:32:9:32:12 | this access | semmle.label | successor |
+| AccessorCalls.cs:32:14:32:14 | 0 | AccessorCalls.cs:32:9:32:15 | access to indexer | semmle.label | successor |
+| AccessorCalls.cs:35:10:35:11 | enter M4 | AccessorCalls.cs:36:5:40:5 | {...} | semmle.label | successor |
+| AccessorCalls.cs:36:5:40:5 | {...} | AccessorCalls.cs:37:9:37:23 | ...; | semmle.label | successor |
+| AccessorCalls.cs:37:9:37:12 | this access | AccessorCalls.cs:37:9:37:14 | access to field x | semmle.label | successor |
+| AccessorCalls.cs:37:9:37:14 | access to field x | AccessorCalls.cs:37:9:37:20 | access to field Field | semmle.label | successor |
+| AccessorCalls.cs:37:9:37:20 | access to field Field | AccessorCalls.cs:37:9:37:22 | ...++ | semmle.label | successor |
+| AccessorCalls.cs:37:9:37:22 | ...++ | AccessorCalls.cs:38:9:38:22 | ...; | semmle.label | successor |
+| AccessorCalls.cs:37:9:37:23 | ...; | AccessorCalls.cs:37:9:37:12 | this access | semmle.label | successor |
+| AccessorCalls.cs:38:9:38:12 | this access | AccessorCalls.cs:38:9:38:14 | access to field x | semmle.label | successor |
+| AccessorCalls.cs:38:9:38:14 | access to field x | AccessorCalls.cs:38:9:38:19 | access to property Prop | semmle.label | successor |
+| AccessorCalls.cs:38:9:38:19 | access to property Prop | AccessorCalls.cs:38:9:38:21 | ...++ | semmle.label | successor |
+| AccessorCalls.cs:38:9:38:21 | ...++ | AccessorCalls.cs:39:9:39:20 | ...; | semmle.label | successor |
+| AccessorCalls.cs:38:9:38:22 | ...; | AccessorCalls.cs:38:9:38:12 | this access | semmle.label | successor |
+| AccessorCalls.cs:39:9:39:12 | this access | AccessorCalls.cs:39:9:39:14 | access to field x | semmle.label | successor |
+| AccessorCalls.cs:39:9:39:14 | access to field x | AccessorCalls.cs:39:16:39:16 | 0 | semmle.label | successor |
+| AccessorCalls.cs:39:9:39:17 | access to indexer | AccessorCalls.cs:39:9:39:19 | ...++ | semmle.label | successor |
+| AccessorCalls.cs:39:9:39:19 | ...++ | AccessorCalls.cs:35:10:35:11 | exit M4 | semmle.label | successor |
+| AccessorCalls.cs:39:9:39:20 | ...; | AccessorCalls.cs:39:9:39:12 | this access | semmle.label | successor |
+| AccessorCalls.cs:39:16:39:16 | 0 | AccessorCalls.cs:39:9:39:17 | access to indexer | semmle.label | successor |
+| AccessorCalls.cs:42:10:42:11 | enter M5 | AccessorCalls.cs:43:5:47:5 | {...} | semmle.label | successor |
+| AccessorCalls.cs:43:5:47:5 | {...} | AccessorCalls.cs:44:9:44:33 | ...; | semmle.label | successor |
+| AccessorCalls.cs:44:9:44:12 | this access | AccessorCalls.cs:44:9:44:18 | access to field Field | semmle.label | successor |
+| AccessorCalls.cs:44:9:44:12 | this access | AccessorCalls.cs:44:9:44:18 | access to field Field | semmle.label | successor |
+| AccessorCalls.cs:44:9:44:18 | access to field Field | AccessorCalls.cs:44:9:44:12 | this access | semmle.label | successor |
+| AccessorCalls.cs:44:9:44:18 | access to field Field | AccessorCalls.cs:44:23:44:26 | this access | semmle.label | successor |
+| AccessorCalls.cs:44:9:44:32 | ... + ... | AccessorCalls.cs:44:9:44:32 | ... = ... | semmle.label | successor |
+| AccessorCalls.cs:44:9:44:32 | ... = ... | AccessorCalls.cs:45:9:45:31 | ...; | semmle.label | successor |
+| AccessorCalls.cs:44:9:44:33 | ...; | AccessorCalls.cs:44:9:44:12 | this access | semmle.label | successor |
+| AccessorCalls.cs:44:23:44:26 | this access | AccessorCalls.cs:44:23:44:32 | access to field Field | semmle.label | successor |
+| AccessorCalls.cs:44:23:44:32 | access to field Field | AccessorCalls.cs:44:9:44:32 | ... + ... | semmle.label | successor |
+| AccessorCalls.cs:45:9:45:12 | this access | AccessorCalls.cs:45:9:45:17 | access to property Prop | semmle.label | successor |
+| AccessorCalls.cs:45:9:45:12 | this access | AccessorCalls.cs:45:9:45:17 | access to property Prop | semmle.label | successor |
+| AccessorCalls.cs:45:9:45:17 | access to property Prop | AccessorCalls.cs:45:9:45:12 | this access | semmle.label | successor |
+| AccessorCalls.cs:45:9:45:17 | access to property Prop | AccessorCalls.cs:45:22:45:25 | this access | semmle.label | successor |
+| AccessorCalls.cs:45:9:45:30 | ... + ... | AccessorCalls.cs:45:9:45:30 | ... = ... | semmle.label | successor |
+| AccessorCalls.cs:45:9:45:30 | ... = ... | AccessorCalls.cs:46:9:46:27 | ...; | semmle.label | successor |
+| AccessorCalls.cs:45:9:45:31 | ...; | AccessorCalls.cs:45:9:45:12 | this access | semmle.label | successor |
+| AccessorCalls.cs:45:22:45:25 | this access | AccessorCalls.cs:45:22:45:30 | access to property Prop | semmle.label | successor |
+| AccessorCalls.cs:45:22:45:30 | access to property Prop | AccessorCalls.cs:45:9:45:30 | ... + ... | semmle.label | successor |
+| AccessorCalls.cs:46:9:46:12 | this access | AccessorCalls.cs:46:14:46:14 | 0 | semmle.label | successor |
+| AccessorCalls.cs:46:9:46:12 | this access | AccessorCalls.cs:46:14:46:14 | 0 | semmle.label | successor |
+| AccessorCalls.cs:46:9:46:15 | access to indexer | AccessorCalls.cs:46:9:46:12 | this access | semmle.label | successor |
+| AccessorCalls.cs:46:9:46:15 | access to indexer | AccessorCalls.cs:46:20:46:23 | this access | semmle.label | successor |
+| AccessorCalls.cs:46:9:46:26 | ... + ... | AccessorCalls.cs:46:9:46:26 | ... = ... | semmle.label | successor |
+| AccessorCalls.cs:46:9:46:26 | ... = ... | AccessorCalls.cs:42:10:42:11 | exit M5 | semmle.label | successor |
+| AccessorCalls.cs:46:9:46:27 | ...; | AccessorCalls.cs:46:9:46:12 | this access | semmle.label | successor |
+| AccessorCalls.cs:46:14:46:14 | 0 | AccessorCalls.cs:46:9:46:15 | access to indexer | semmle.label | successor |
+| AccessorCalls.cs:46:14:46:14 | 0 | AccessorCalls.cs:46:9:46:15 | access to indexer | semmle.label | successor |
+| AccessorCalls.cs:46:20:46:23 | this access | AccessorCalls.cs:46:25:46:25 | 0 | semmle.label | successor |
+| AccessorCalls.cs:46:20:46:26 | access to indexer | AccessorCalls.cs:46:9:46:26 | ... + ... | semmle.label | successor |
+| AccessorCalls.cs:46:25:46:25 | 0 | AccessorCalls.cs:46:20:46:26 | access to indexer | semmle.label | successor |
+| AccessorCalls.cs:49:10:49:11 | enter M6 | AccessorCalls.cs:50:5:54:5 | {...} | semmle.label | successor |
+| AccessorCalls.cs:50:5:54:5 | {...} | AccessorCalls.cs:51:9:51:37 | ...; | semmle.label | successor |
+| AccessorCalls.cs:51:9:51:12 | this access | AccessorCalls.cs:51:9:51:14 | access to field x | semmle.label | successor |
+| AccessorCalls.cs:51:9:51:12 | this access | AccessorCalls.cs:51:9:51:14 | access to field x | semmle.label | successor |
+| AccessorCalls.cs:51:9:51:14 | access to field x | AccessorCalls.cs:51:9:51:20 | access to field Field | semmle.label | successor |
+| AccessorCalls.cs:51:9:51:14 | access to field x | AccessorCalls.cs:51:9:51:20 | access to field Field | semmle.label | successor |
+| AccessorCalls.cs:51:9:51:20 | access to field Field | AccessorCalls.cs:51:9:51:12 | this access | semmle.label | successor |
+| AccessorCalls.cs:51:9:51:20 | access to field Field | AccessorCalls.cs:51:25:51:28 | this access | semmle.label | successor |
+| AccessorCalls.cs:51:9:51:36 | ... + ... | AccessorCalls.cs:51:9:51:36 | ... = ... | semmle.label | successor |
+| AccessorCalls.cs:51:9:51:36 | ... = ... | AccessorCalls.cs:52:9:52:35 | ...; | semmle.label | successor |
+| AccessorCalls.cs:51:9:51:37 | ...; | AccessorCalls.cs:51:9:51:12 | this access | semmle.label | successor |
+| AccessorCalls.cs:51:25:51:28 | this access | AccessorCalls.cs:51:25:51:30 | access to field x | semmle.label | successor |
+| AccessorCalls.cs:51:25:51:30 | access to field x | AccessorCalls.cs:51:25:51:36 | access to field Field | semmle.label | successor |
+| AccessorCalls.cs:51:25:51:36 | access to field Field | AccessorCalls.cs:51:9:51:36 | ... + ... | semmle.label | successor |
+| AccessorCalls.cs:52:9:52:12 | this access | AccessorCalls.cs:52:9:52:14 | access to field x | semmle.label | successor |
+| AccessorCalls.cs:52:9:52:12 | this access | AccessorCalls.cs:52:9:52:14 | access to field x | semmle.label | successor |
+| AccessorCalls.cs:52:9:52:14 | access to field x | AccessorCalls.cs:52:9:52:19 | access to property Prop | semmle.label | successor |
+| AccessorCalls.cs:52:9:52:14 | access to field x | AccessorCalls.cs:52:9:52:19 | access to property Prop | semmle.label | successor |
+| AccessorCalls.cs:52:9:52:19 | access to property Prop | AccessorCalls.cs:52:9:52:12 | this access | semmle.label | successor |
+| AccessorCalls.cs:52:9:52:19 | access to property Prop | AccessorCalls.cs:52:24:52:27 | this access | semmle.label | successor |
+| AccessorCalls.cs:52:9:52:34 | ... + ... | AccessorCalls.cs:52:9:52:34 | ... = ... | semmle.label | successor |
+| AccessorCalls.cs:52:9:52:34 | ... = ... | AccessorCalls.cs:53:9:53:31 | ...; | semmle.label | successor |
+| AccessorCalls.cs:52:9:52:35 | ...; | AccessorCalls.cs:52:9:52:12 | this access | semmle.label | successor |
+| AccessorCalls.cs:52:24:52:27 | this access | AccessorCalls.cs:52:24:52:29 | access to field x | semmle.label | successor |
+| AccessorCalls.cs:52:24:52:29 | access to field x | AccessorCalls.cs:52:24:52:34 | access to property Prop | semmle.label | successor |
+| AccessorCalls.cs:52:24:52:34 | access to property Prop | AccessorCalls.cs:52:9:52:34 | ... + ... | semmle.label | successor |
+| AccessorCalls.cs:53:9:53:12 | this access | AccessorCalls.cs:53:9:53:14 | access to field x | semmle.label | successor |
+| AccessorCalls.cs:53:9:53:12 | this access | AccessorCalls.cs:53:9:53:14 | access to field x | semmle.label | successor |
+| AccessorCalls.cs:53:9:53:14 | access to field x | AccessorCalls.cs:53:16:53:16 | 0 | semmle.label | successor |
+| AccessorCalls.cs:53:9:53:14 | access to field x | AccessorCalls.cs:53:16:53:16 | 0 | semmle.label | successor |
+| AccessorCalls.cs:53:9:53:17 | access to indexer | AccessorCalls.cs:53:9:53:12 | this access | semmle.label | successor |
+| AccessorCalls.cs:53:9:53:17 | access to indexer | AccessorCalls.cs:53:22:53:25 | this access | semmle.label | successor |
+| AccessorCalls.cs:53:9:53:30 | ... + ... | AccessorCalls.cs:53:9:53:30 | ... = ... | semmle.label | successor |
+| AccessorCalls.cs:53:9:53:30 | ... = ... | AccessorCalls.cs:49:10:49:11 | exit M6 | semmle.label | successor |
+| AccessorCalls.cs:53:9:53:31 | ...; | AccessorCalls.cs:53:9:53:12 | this access | semmle.label | successor |
+| AccessorCalls.cs:53:16:53:16 | 0 | AccessorCalls.cs:53:9:53:17 | access to indexer | semmle.label | successor |
+| AccessorCalls.cs:53:16:53:16 | 0 | AccessorCalls.cs:53:9:53:17 | access to indexer | semmle.label | successor |
+| AccessorCalls.cs:53:22:53:25 | this access | AccessorCalls.cs:53:22:53:27 | access to field x | semmle.label | successor |
+| AccessorCalls.cs:53:22:53:27 | access to field x | AccessorCalls.cs:53:29:53:29 | 0 | semmle.label | successor |
+| AccessorCalls.cs:53:22:53:30 | access to indexer | AccessorCalls.cs:53:9:53:30 | ... + ... | semmle.label | successor |
+| AccessorCalls.cs:53:29:53:29 | 0 | AccessorCalls.cs:53:22:53:30 | access to indexer | semmle.label | successor |
+| AccessorCalls.cs:56:10:56:11 | enter M7 | AccessorCalls.cs:57:5:59:5 | {...} | semmle.label | successor |
+| AccessorCalls.cs:57:5:59:5 | {...} | AccessorCalls.cs:58:9:58:86 | ...; | semmle.label | successor |
+| AccessorCalls.cs:58:9:58:45 | (..., ...) | AccessorCalls.cs:58:50:58:53 | this access | semmle.label | successor |
+| AccessorCalls.cs:58:9:58:85 | ... = ... | AccessorCalls.cs:56:10:56:11 | exit M7 | semmle.label | successor |
+| AccessorCalls.cs:58:9:58:86 | ...; | AccessorCalls.cs:58:10:58:13 | this access | semmle.label | successor |
+| AccessorCalls.cs:58:10:58:13 | this access | AccessorCalls.cs:58:10:58:19 | access to field Field | semmle.label | successor |
+| AccessorCalls.cs:58:10:58:19 | access to field Field | AccessorCalls.cs:58:22:58:25 | this access | semmle.label | successor |
+| AccessorCalls.cs:58:22:58:25 | this access | AccessorCalls.cs:58:22:58:30 | access to property Prop | semmle.label | successor |
+| AccessorCalls.cs:58:22:58:30 | access to property Prop | AccessorCalls.cs:58:34:58:34 | access to parameter i | semmle.label | successor |
+| AccessorCalls.cs:58:33:58:44 | (..., ...) | AccessorCalls.cs:58:9:58:45 | (..., ...) | semmle.label | successor |
+| AccessorCalls.cs:58:34:58:34 | access to parameter i | AccessorCalls.cs:58:37:58:40 | this access | semmle.label | successor |
+| AccessorCalls.cs:58:37:58:40 | this access | AccessorCalls.cs:58:42:58:42 | 0 | semmle.label | successor |
+| AccessorCalls.cs:58:37:58:43 | access to indexer | AccessorCalls.cs:58:33:58:44 | (..., ...) | semmle.label | successor |
+| AccessorCalls.cs:58:42:58:42 | 0 | AccessorCalls.cs:58:37:58:43 | access to indexer | semmle.label | successor |
+| AccessorCalls.cs:58:49:58:85 | (..., ...) | AccessorCalls.cs:58:9:58:85 | ... = ... | semmle.label | successor |
+| AccessorCalls.cs:58:50:58:53 | this access | AccessorCalls.cs:58:50:58:59 | access to field Field | semmle.label | successor |
+| AccessorCalls.cs:58:50:58:59 | access to field Field | AccessorCalls.cs:58:62:58:65 | this access | semmle.label | successor |
+| AccessorCalls.cs:58:62:58:65 | this access | AccessorCalls.cs:58:62:58:70 | access to property Prop | semmle.label | successor |
+| AccessorCalls.cs:58:62:58:70 | access to property Prop | AccessorCalls.cs:58:74:58:74 | 0 | semmle.label | successor |
+| AccessorCalls.cs:58:73:58:84 | (..., ...) | AccessorCalls.cs:58:49:58:85 | (..., ...) | semmle.label | successor |
+| AccessorCalls.cs:58:74:58:74 | 0 | AccessorCalls.cs:58:77:58:80 | this access | semmle.label | successor |
+| AccessorCalls.cs:58:77:58:80 | this access | AccessorCalls.cs:58:82:58:82 | 1 | semmle.label | successor |
+| AccessorCalls.cs:58:77:58:83 | access to indexer | AccessorCalls.cs:58:73:58:84 | (..., ...) | semmle.label | successor |
+| AccessorCalls.cs:58:82:58:82 | 1 | AccessorCalls.cs:58:77:58:83 | access to indexer | semmle.label | successor |
+| AccessorCalls.cs:61:10:61:11 | enter M8 | AccessorCalls.cs:62:5:64:5 | {...} | semmle.label | successor |
+| AccessorCalls.cs:62:5:64:5 | {...} | AccessorCalls.cs:63:9:63:98 | ...; | semmle.label | successor |
+| AccessorCalls.cs:63:9:63:51 | (..., ...) | AccessorCalls.cs:63:56:63:59 | this access | semmle.label | successor |
+| AccessorCalls.cs:63:9:63:97 | ... = ... | AccessorCalls.cs:61:10:61:11 | exit M8 | semmle.label | successor |
+| AccessorCalls.cs:63:9:63:98 | ...; | AccessorCalls.cs:63:10:63:13 | this access | semmle.label | successor |
+| AccessorCalls.cs:63:10:63:13 | this access | AccessorCalls.cs:63:10:63:15 | access to field x | semmle.label | successor |
+| AccessorCalls.cs:63:10:63:15 | access to field x | AccessorCalls.cs:63:10:63:21 | access to field Field | semmle.label | successor |
+| AccessorCalls.cs:63:10:63:21 | access to field Field | AccessorCalls.cs:63:24:63:27 | this access | semmle.label | successor |
+| AccessorCalls.cs:63:24:63:27 | this access | AccessorCalls.cs:63:24:63:29 | access to field x | semmle.label | successor |
+| AccessorCalls.cs:63:24:63:29 | access to field x | AccessorCalls.cs:63:24:63:34 | access to property Prop | semmle.label | successor |
+| AccessorCalls.cs:63:24:63:34 | access to property Prop | AccessorCalls.cs:63:38:63:38 | access to parameter i | semmle.label | successor |
+| AccessorCalls.cs:63:37:63:50 | (..., ...) | AccessorCalls.cs:63:9:63:51 | (..., ...) | semmle.label | successor |
+| AccessorCalls.cs:63:38:63:38 | access to parameter i | AccessorCalls.cs:63:41:63:44 | this access | semmle.label | successor |
+| AccessorCalls.cs:63:41:63:44 | this access | AccessorCalls.cs:63:41:63:46 | access to field x | semmle.label | successor |
+| AccessorCalls.cs:63:41:63:46 | access to field x | AccessorCalls.cs:63:48:63:48 | 0 | semmle.label | successor |
+| AccessorCalls.cs:63:41:63:49 | access to indexer | AccessorCalls.cs:63:37:63:50 | (..., ...) | semmle.label | successor |
+| AccessorCalls.cs:63:48:63:48 | 0 | AccessorCalls.cs:63:41:63:49 | access to indexer | semmle.label | successor |
+| AccessorCalls.cs:63:55:63:97 | (..., ...) | AccessorCalls.cs:63:9:63:97 | ... = ... | semmle.label | successor |
+| AccessorCalls.cs:63:56:63:59 | this access | AccessorCalls.cs:63:56:63:61 | access to field x | semmle.label | successor |
+| AccessorCalls.cs:63:56:63:61 | access to field x | AccessorCalls.cs:63:56:63:67 | access to field Field | semmle.label | successor |
+| AccessorCalls.cs:63:56:63:67 | access to field Field | AccessorCalls.cs:63:70:63:73 | this access | semmle.label | successor |
+| AccessorCalls.cs:63:70:63:73 | this access | AccessorCalls.cs:63:70:63:75 | access to field x | semmle.label | successor |
+| AccessorCalls.cs:63:70:63:75 | access to field x | AccessorCalls.cs:63:70:63:80 | access to property Prop | semmle.label | successor |
+| AccessorCalls.cs:63:70:63:80 | access to property Prop | AccessorCalls.cs:63:84:63:84 | 0 | semmle.label | successor |
+| AccessorCalls.cs:63:83:63:96 | (..., ...) | AccessorCalls.cs:63:55:63:97 | (..., ...) | semmle.label | successor |
+| AccessorCalls.cs:63:84:63:84 | 0 | AccessorCalls.cs:63:87:63:90 | this access | semmle.label | successor |
+| AccessorCalls.cs:63:87:63:90 | this access | AccessorCalls.cs:63:87:63:92 | access to field x | semmle.label | successor |
+| AccessorCalls.cs:63:87:63:92 | access to field x | AccessorCalls.cs:63:94:63:94 | 1 | semmle.label | successor |
+| AccessorCalls.cs:63:87:63:95 | access to indexer | AccessorCalls.cs:63:83:63:96 | (..., ...) | semmle.label | successor |
+| AccessorCalls.cs:63:94:63:94 | 1 | AccessorCalls.cs:63:87:63:95 | access to indexer | semmle.label | successor |
 | ArrayCreation.cs:3:11:3:12 | enter M1 | ArrayCreation.cs:3:27:3:27 | 0 | semmle.label | successor |
 | ArrayCreation.cs:3:19:3:28 | array creation of type Int32[] | ArrayCreation.cs:3:11:3:12 | exit M1 | semmle.label | successor |
 | ArrayCreation.cs:3:27:3:27 | 0 | ArrayCreation.cs:3:19:3:28 | array creation of type Int32[] | semmle.label | successor |

--- a/csharp/ql/test/library-tests/controlflow/graph/NodeGraph.expected
+++ b/csharp/ql/test/library-tests/controlflow/graph/NodeGraph.expected
@@ -8,76 +8,74 @@
 | AccessorCalls.cs:7:47:7:49 | {...} | AccessorCalls.cs:7:40:7:45 | exit remove_Event | semmle.label | successor |
 | AccessorCalls.cs:10:10:10:11 | enter M1 | AccessorCalls.cs:11:5:17:5 | {...} | semmle.label | successor |
 | AccessorCalls.cs:11:5:17:5 | {...} | AccessorCalls.cs:12:9:12:32 | ...; | semmle.label | successor |
-| AccessorCalls.cs:12:9:12:12 | this access | AccessorCalls.cs:12:9:12:18 | access to field Field | semmle.label | successor |
-| AccessorCalls.cs:12:9:12:18 | access to field Field | AccessorCalls.cs:12:22:12:25 | this access | semmle.label | successor |
+| AccessorCalls.cs:12:9:12:12 | this access | AccessorCalls.cs:12:22:12:25 | this access | semmle.label | successor |
 | AccessorCalls.cs:12:9:12:31 | ... = ... | AccessorCalls.cs:13:9:13:30 | ...; | semmle.label | successor |
 | AccessorCalls.cs:12:9:12:32 | ...; | AccessorCalls.cs:12:9:12:12 | this access | semmle.label | successor |
 | AccessorCalls.cs:12:22:12:25 | this access | AccessorCalls.cs:12:22:12:31 | access to field Field | semmle.label | successor |
 | AccessorCalls.cs:12:22:12:31 | access to field Field | AccessorCalls.cs:12:9:12:31 | ... = ... | semmle.label | successor |
-| AccessorCalls.cs:13:9:13:12 | this access | AccessorCalls.cs:13:9:13:17 | access to property Prop | semmle.label | successor |
-| AccessorCalls.cs:13:9:13:17 | access to property Prop | AccessorCalls.cs:13:21:13:24 | this access | semmle.label | successor |
+| AccessorCalls.cs:13:9:13:12 | this access | AccessorCalls.cs:13:21:13:24 | this access | semmle.label | successor |
+| AccessorCalls.cs:13:9:13:17 | access to property Prop | AccessorCalls.cs:13:9:13:29 | ... = ... | semmle.label | successor |
 | AccessorCalls.cs:13:9:13:29 | ... = ... | AccessorCalls.cs:14:9:14:26 | ...; | semmle.label | successor |
 | AccessorCalls.cs:13:9:13:30 | ...; | AccessorCalls.cs:13:9:13:12 | this access | semmle.label | successor |
 | AccessorCalls.cs:13:21:13:24 | this access | AccessorCalls.cs:13:21:13:29 | access to property Prop | semmle.label | successor |
-| AccessorCalls.cs:13:21:13:29 | access to property Prop | AccessorCalls.cs:13:9:13:29 | ... = ... | semmle.label | successor |
+| AccessorCalls.cs:13:21:13:29 | access to property Prop | AccessorCalls.cs:13:9:13:17 | access to property Prop | semmle.label | successor |
 | AccessorCalls.cs:14:9:14:12 | this access | AccessorCalls.cs:14:14:14:14 | 0 | semmle.label | successor |
-| AccessorCalls.cs:14:9:14:15 | access to indexer | AccessorCalls.cs:14:19:14:22 | this access | semmle.label | successor |
+| AccessorCalls.cs:14:9:14:15 | access to indexer | AccessorCalls.cs:14:9:14:25 | ... = ... | semmle.label | successor |
 | AccessorCalls.cs:14:9:14:25 | ... = ... | AccessorCalls.cs:15:9:15:24 | ...; | semmle.label | successor |
 | AccessorCalls.cs:14:9:14:26 | ...; | AccessorCalls.cs:14:9:14:12 | this access | semmle.label | successor |
-| AccessorCalls.cs:14:14:14:14 | 0 | AccessorCalls.cs:14:9:14:15 | access to indexer | semmle.label | successor |
+| AccessorCalls.cs:14:14:14:14 | 0 | AccessorCalls.cs:14:19:14:22 | this access | semmle.label | successor |
 | AccessorCalls.cs:14:19:14:22 | this access | AccessorCalls.cs:14:24:14:24 | 1 | semmle.label | successor |
-| AccessorCalls.cs:14:19:14:25 | access to indexer | AccessorCalls.cs:14:9:14:25 | ... = ... | semmle.label | successor |
+| AccessorCalls.cs:14:19:14:25 | access to indexer | AccessorCalls.cs:14:9:14:15 | access to indexer | semmle.label | successor |
 | AccessorCalls.cs:14:24:14:24 | 1 | AccessorCalls.cs:14:19:14:25 | access to indexer | semmle.label | successor |
-| AccessorCalls.cs:15:9:15:12 | this access | AccessorCalls.cs:15:9:15:18 | access to event Event | semmle.label | successor |
-| AccessorCalls.cs:15:9:15:18 | access to event Event | AccessorCalls.cs:15:23:15:23 | access to parameter e | semmle.label | successor |
+| AccessorCalls.cs:15:9:15:12 | this access | AccessorCalls.cs:15:23:15:23 | access to parameter e | semmle.label | successor |
+| AccessorCalls.cs:15:9:15:18 | access to event Event | AccessorCalls.cs:15:9:15:23 | ... += ... | semmle.label | successor |
 | AccessorCalls.cs:15:9:15:23 | ... += ... | AccessorCalls.cs:16:9:16:24 | ...; | semmle.label | successor |
 | AccessorCalls.cs:15:9:15:24 | ...; | AccessorCalls.cs:15:9:15:12 | this access | semmle.label | successor |
-| AccessorCalls.cs:15:23:15:23 | access to parameter e | AccessorCalls.cs:15:9:15:23 | ... += ... | semmle.label | successor |
-| AccessorCalls.cs:16:9:16:12 | this access | AccessorCalls.cs:16:9:16:18 | access to event Event | semmle.label | successor |
-| AccessorCalls.cs:16:9:16:18 | access to event Event | AccessorCalls.cs:16:23:16:23 | access to parameter e | semmle.label | successor |
+| AccessorCalls.cs:15:23:15:23 | access to parameter e | AccessorCalls.cs:15:9:15:18 | access to event Event | semmle.label | successor |
+| AccessorCalls.cs:16:9:16:12 | this access | AccessorCalls.cs:16:23:16:23 | access to parameter e | semmle.label | successor |
+| AccessorCalls.cs:16:9:16:18 | access to event Event | AccessorCalls.cs:16:9:16:23 | ... -= ... | semmle.label | successor |
 | AccessorCalls.cs:16:9:16:23 | ... -= ... | AccessorCalls.cs:10:10:10:11 | exit M1 | semmle.label | successor |
 | AccessorCalls.cs:16:9:16:24 | ...; | AccessorCalls.cs:16:9:16:12 | this access | semmle.label | successor |
-| AccessorCalls.cs:16:23:16:23 | access to parameter e | AccessorCalls.cs:16:9:16:23 | ... -= ... | semmle.label | successor |
+| AccessorCalls.cs:16:23:16:23 | access to parameter e | AccessorCalls.cs:16:9:16:18 | access to event Event | semmle.label | successor |
 | AccessorCalls.cs:19:10:19:11 | enter M2 | AccessorCalls.cs:20:5:26:5 | {...} | semmle.label | successor |
 | AccessorCalls.cs:20:5:26:5 | {...} | AccessorCalls.cs:21:9:21:36 | ...; | semmle.label | successor |
 | AccessorCalls.cs:21:9:21:12 | this access | AccessorCalls.cs:21:9:21:14 | access to field x | semmle.label | successor |
-| AccessorCalls.cs:21:9:21:14 | access to field x | AccessorCalls.cs:21:9:21:20 | access to field Field | semmle.label | successor |
-| AccessorCalls.cs:21:9:21:20 | access to field Field | AccessorCalls.cs:21:24:21:27 | this access | semmle.label | successor |
+| AccessorCalls.cs:21:9:21:14 | access to field x | AccessorCalls.cs:21:24:21:27 | this access | semmle.label | successor |
 | AccessorCalls.cs:21:9:21:35 | ... = ... | AccessorCalls.cs:22:9:22:34 | ...; | semmle.label | successor |
 | AccessorCalls.cs:21:9:21:36 | ...; | AccessorCalls.cs:21:9:21:12 | this access | semmle.label | successor |
 | AccessorCalls.cs:21:24:21:27 | this access | AccessorCalls.cs:21:24:21:29 | access to field x | semmle.label | successor |
 | AccessorCalls.cs:21:24:21:29 | access to field x | AccessorCalls.cs:21:24:21:35 | access to field Field | semmle.label | successor |
 | AccessorCalls.cs:21:24:21:35 | access to field Field | AccessorCalls.cs:21:9:21:35 | ... = ... | semmle.label | successor |
 | AccessorCalls.cs:22:9:22:12 | this access | AccessorCalls.cs:22:9:22:14 | access to field x | semmle.label | successor |
-| AccessorCalls.cs:22:9:22:14 | access to field x | AccessorCalls.cs:22:9:22:19 | access to property Prop | semmle.label | successor |
-| AccessorCalls.cs:22:9:22:19 | access to property Prop | AccessorCalls.cs:22:23:22:26 | this access | semmle.label | successor |
+| AccessorCalls.cs:22:9:22:14 | access to field x | AccessorCalls.cs:22:23:22:26 | this access | semmle.label | successor |
+| AccessorCalls.cs:22:9:22:19 | access to property Prop | AccessorCalls.cs:22:9:22:33 | ... = ... | semmle.label | successor |
 | AccessorCalls.cs:22:9:22:33 | ... = ... | AccessorCalls.cs:23:9:23:30 | ...; | semmle.label | successor |
 | AccessorCalls.cs:22:9:22:34 | ...; | AccessorCalls.cs:22:9:22:12 | this access | semmle.label | successor |
 | AccessorCalls.cs:22:23:22:26 | this access | AccessorCalls.cs:22:23:22:28 | access to field x | semmle.label | successor |
 | AccessorCalls.cs:22:23:22:28 | access to field x | AccessorCalls.cs:22:23:22:33 | access to property Prop | semmle.label | successor |
-| AccessorCalls.cs:22:23:22:33 | access to property Prop | AccessorCalls.cs:22:9:22:33 | ... = ... | semmle.label | successor |
+| AccessorCalls.cs:22:23:22:33 | access to property Prop | AccessorCalls.cs:22:9:22:19 | access to property Prop | semmle.label | successor |
 | AccessorCalls.cs:23:9:23:12 | this access | AccessorCalls.cs:23:9:23:14 | access to field x | semmle.label | successor |
 | AccessorCalls.cs:23:9:23:14 | access to field x | AccessorCalls.cs:23:16:23:16 | 0 | semmle.label | successor |
-| AccessorCalls.cs:23:9:23:17 | access to indexer | AccessorCalls.cs:23:21:23:24 | this access | semmle.label | successor |
+| AccessorCalls.cs:23:9:23:17 | access to indexer | AccessorCalls.cs:23:9:23:29 | ... = ... | semmle.label | successor |
 | AccessorCalls.cs:23:9:23:29 | ... = ... | AccessorCalls.cs:24:9:24:26 | ...; | semmle.label | successor |
 | AccessorCalls.cs:23:9:23:30 | ...; | AccessorCalls.cs:23:9:23:12 | this access | semmle.label | successor |
-| AccessorCalls.cs:23:16:23:16 | 0 | AccessorCalls.cs:23:9:23:17 | access to indexer | semmle.label | successor |
+| AccessorCalls.cs:23:16:23:16 | 0 | AccessorCalls.cs:23:21:23:24 | this access | semmle.label | successor |
 | AccessorCalls.cs:23:21:23:24 | this access | AccessorCalls.cs:23:21:23:26 | access to field x | semmle.label | successor |
 | AccessorCalls.cs:23:21:23:26 | access to field x | AccessorCalls.cs:23:28:23:28 | 1 | semmle.label | successor |
-| AccessorCalls.cs:23:21:23:29 | access to indexer | AccessorCalls.cs:23:9:23:29 | ... = ... | semmle.label | successor |
+| AccessorCalls.cs:23:21:23:29 | access to indexer | AccessorCalls.cs:23:9:23:17 | access to indexer | semmle.label | successor |
 | AccessorCalls.cs:23:28:23:28 | 1 | AccessorCalls.cs:23:21:23:29 | access to indexer | semmle.label | successor |
 | AccessorCalls.cs:24:9:24:12 | this access | AccessorCalls.cs:24:9:24:14 | access to field x | semmle.label | successor |
-| AccessorCalls.cs:24:9:24:14 | access to field x | AccessorCalls.cs:24:9:24:20 | access to event Event | semmle.label | successor |
-| AccessorCalls.cs:24:9:24:20 | access to event Event | AccessorCalls.cs:24:25:24:25 | access to parameter e | semmle.label | successor |
+| AccessorCalls.cs:24:9:24:14 | access to field x | AccessorCalls.cs:24:25:24:25 | access to parameter e | semmle.label | successor |
+| AccessorCalls.cs:24:9:24:20 | access to event Event | AccessorCalls.cs:24:9:24:25 | ... += ... | semmle.label | successor |
 | AccessorCalls.cs:24:9:24:25 | ... += ... | AccessorCalls.cs:25:9:25:26 | ...; | semmle.label | successor |
 | AccessorCalls.cs:24:9:24:26 | ...; | AccessorCalls.cs:24:9:24:12 | this access | semmle.label | successor |
-| AccessorCalls.cs:24:25:24:25 | access to parameter e | AccessorCalls.cs:24:9:24:25 | ... += ... | semmle.label | successor |
+| AccessorCalls.cs:24:25:24:25 | access to parameter e | AccessorCalls.cs:24:9:24:20 | access to event Event | semmle.label | successor |
 | AccessorCalls.cs:25:9:25:12 | this access | AccessorCalls.cs:25:9:25:14 | access to field x | semmle.label | successor |
-| AccessorCalls.cs:25:9:25:14 | access to field x | AccessorCalls.cs:25:9:25:20 | access to event Event | semmle.label | successor |
-| AccessorCalls.cs:25:9:25:20 | access to event Event | AccessorCalls.cs:25:25:25:25 | access to parameter e | semmle.label | successor |
+| AccessorCalls.cs:25:9:25:14 | access to field x | AccessorCalls.cs:25:25:25:25 | access to parameter e | semmle.label | successor |
+| AccessorCalls.cs:25:9:25:20 | access to event Event | AccessorCalls.cs:25:9:25:25 | ... -= ... | semmle.label | successor |
 | AccessorCalls.cs:25:9:25:25 | ... -= ... | AccessorCalls.cs:19:10:19:11 | exit M2 | semmle.label | successor |
 | AccessorCalls.cs:25:9:25:26 | ...; | AccessorCalls.cs:25:9:25:12 | this access | semmle.label | successor |
-| AccessorCalls.cs:25:25:25:25 | access to parameter e | AccessorCalls.cs:25:9:25:25 | ... -= ... | semmle.label | successor |
+| AccessorCalls.cs:25:25:25:25 | access to parameter e | AccessorCalls.cs:25:9:25:20 | access to event Event | semmle.label | successor |
 | AccessorCalls.cs:28:10:28:11 | enter M3 | AccessorCalls.cs:29:5:33:5 | {...} | semmle.label | successor |
 | AccessorCalls.cs:29:5:33:5 | {...} | AccessorCalls.cs:30:9:30:21 | ...; | semmle.label | successor |
 | AccessorCalls.cs:30:9:30:12 | this access | AccessorCalls.cs:30:9:30:18 | access to field Field | semmle.label | successor |
@@ -113,32 +111,31 @@
 | AccessorCalls.cs:39:16:39:16 | 0 | AccessorCalls.cs:39:9:39:17 | access to indexer | semmle.label | successor |
 | AccessorCalls.cs:42:10:42:11 | enter M5 | AccessorCalls.cs:43:5:47:5 | {...} | semmle.label | successor |
 | AccessorCalls.cs:43:5:47:5 | {...} | AccessorCalls.cs:44:9:44:33 | ...; | semmle.label | successor |
+| AccessorCalls.cs:44:9:44:12 | this access | AccessorCalls.cs:44:9:44:12 | this access | semmle.label | successor |
 | AccessorCalls.cs:44:9:44:12 | this access | AccessorCalls.cs:44:9:44:18 | access to field Field | semmle.label | successor |
-| AccessorCalls.cs:44:9:44:12 | this access | AccessorCalls.cs:44:9:44:18 | access to field Field | semmle.label | successor |
-| AccessorCalls.cs:44:9:44:18 | access to field Field | AccessorCalls.cs:44:9:44:12 | this access | semmle.label | successor |
 | AccessorCalls.cs:44:9:44:18 | access to field Field | AccessorCalls.cs:44:23:44:26 | this access | semmle.label | successor |
 | AccessorCalls.cs:44:9:44:32 | ... + ... | AccessorCalls.cs:44:9:44:32 | ... = ... | semmle.label | successor |
 | AccessorCalls.cs:44:9:44:32 | ... = ... | AccessorCalls.cs:45:9:45:31 | ...; | semmle.label | successor |
 | AccessorCalls.cs:44:9:44:33 | ...; | AccessorCalls.cs:44:9:44:12 | this access | semmle.label | successor |
 | AccessorCalls.cs:44:23:44:26 | this access | AccessorCalls.cs:44:23:44:32 | access to field Field | semmle.label | successor |
 | AccessorCalls.cs:44:23:44:32 | access to field Field | AccessorCalls.cs:44:9:44:32 | ... + ... | semmle.label | successor |
+| AccessorCalls.cs:45:9:45:12 | this access | AccessorCalls.cs:45:9:45:12 | this access | semmle.label | successor |
 | AccessorCalls.cs:45:9:45:12 | this access | AccessorCalls.cs:45:9:45:17 | access to property Prop | semmle.label | successor |
-| AccessorCalls.cs:45:9:45:12 | this access | AccessorCalls.cs:45:9:45:17 | access to property Prop | semmle.label | successor |
-| AccessorCalls.cs:45:9:45:17 | access to property Prop | AccessorCalls.cs:45:9:45:12 | this access | semmle.label | successor |
+| AccessorCalls.cs:45:9:45:17 | access to property Prop | AccessorCalls.cs:45:9:45:30 | ... = ... | semmle.label | successor |
 | AccessorCalls.cs:45:9:45:17 | access to property Prop | AccessorCalls.cs:45:22:45:25 | this access | semmle.label | successor |
-| AccessorCalls.cs:45:9:45:30 | ... + ... | AccessorCalls.cs:45:9:45:30 | ... = ... | semmle.label | successor |
+| AccessorCalls.cs:45:9:45:30 | ... + ... | AccessorCalls.cs:45:9:45:17 | access to property Prop | semmle.label | successor |
 | AccessorCalls.cs:45:9:45:30 | ... = ... | AccessorCalls.cs:46:9:46:27 | ...; | semmle.label | successor |
 | AccessorCalls.cs:45:9:45:31 | ...; | AccessorCalls.cs:45:9:45:12 | this access | semmle.label | successor |
 | AccessorCalls.cs:45:22:45:25 | this access | AccessorCalls.cs:45:22:45:30 | access to property Prop | semmle.label | successor |
 | AccessorCalls.cs:45:22:45:30 | access to property Prop | AccessorCalls.cs:45:9:45:30 | ... + ... | semmle.label | successor |
 | AccessorCalls.cs:46:9:46:12 | this access | AccessorCalls.cs:46:14:46:14 | 0 | semmle.label | successor |
 | AccessorCalls.cs:46:9:46:12 | this access | AccessorCalls.cs:46:14:46:14 | 0 | semmle.label | successor |
-| AccessorCalls.cs:46:9:46:15 | access to indexer | AccessorCalls.cs:46:9:46:12 | this access | semmle.label | successor |
+| AccessorCalls.cs:46:9:46:15 | access to indexer | AccessorCalls.cs:46:9:46:26 | ... = ... | semmle.label | successor |
 | AccessorCalls.cs:46:9:46:15 | access to indexer | AccessorCalls.cs:46:20:46:23 | this access | semmle.label | successor |
-| AccessorCalls.cs:46:9:46:26 | ... + ... | AccessorCalls.cs:46:9:46:26 | ... = ... | semmle.label | successor |
+| AccessorCalls.cs:46:9:46:26 | ... + ... | AccessorCalls.cs:46:9:46:15 | access to indexer | semmle.label | successor |
 | AccessorCalls.cs:46:9:46:26 | ... = ... | AccessorCalls.cs:42:10:42:11 | exit M5 | semmle.label | successor |
 | AccessorCalls.cs:46:9:46:27 | ...; | AccessorCalls.cs:46:9:46:12 | this access | semmle.label | successor |
-| AccessorCalls.cs:46:14:46:14 | 0 | AccessorCalls.cs:46:9:46:15 | access to indexer | semmle.label | successor |
+| AccessorCalls.cs:46:14:46:14 | 0 | AccessorCalls.cs:46:9:46:12 | this access | semmle.label | successor |
 | AccessorCalls.cs:46:14:46:14 | 0 | AccessorCalls.cs:46:9:46:15 | access to indexer | semmle.label | successor |
 | AccessorCalls.cs:46:20:46:23 | this access | AccessorCalls.cs:46:25:46:25 | 0 | semmle.label | successor |
 | AccessorCalls.cs:46:20:46:26 | access to indexer | AccessorCalls.cs:46:9:46:26 | ... + ... | semmle.label | successor |
@@ -147,9 +144,8 @@
 | AccessorCalls.cs:50:5:54:5 | {...} | AccessorCalls.cs:51:9:51:37 | ...; | semmle.label | successor |
 | AccessorCalls.cs:51:9:51:12 | this access | AccessorCalls.cs:51:9:51:14 | access to field x | semmle.label | successor |
 | AccessorCalls.cs:51:9:51:12 | this access | AccessorCalls.cs:51:9:51:14 | access to field x | semmle.label | successor |
+| AccessorCalls.cs:51:9:51:14 | access to field x | AccessorCalls.cs:51:9:51:12 | this access | semmle.label | successor |
 | AccessorCalls.cs:51:9:51:14 | access to field x | AccessorCalls.cs:51:9:51:20 | access to field Field | semmle.label | successor |
-| AccessorCalls.cs:51:9:51:14 | access to field x | AccessorCalls.cs:51:9:51:20 | access to field Field | semmle.label | successor |
-| AccessorCalls.cs:51:9:51:20 | access to field Field | AccessorCalls.cs:51:9:51:12 | this access | semmle.label | successor |
 | AccessorCalls.cs:51:9:51:20 | access to field Field | AccessorCalls.cs:51:25:51:28 | this access | semmle.label | successor |
 | AccessorCalls.cs:51:9:51:36 | ... + ... | AccessorCalls.cs:51:9:51:36 | ... = ... | semmle.label | successor |
 | AccessorCalls.cs:51:9:51:36 | ... = ... | AccessorCalls.cs:52:9:52:35 | ...; | semmle.label | successor |
@@ -159,11 +155,11 @@
 | AccessorCalls.cs:51:25:51:36 | access to field Field | AccessorCalls.cs:51:9:51:36 | ... + ... | semmle.label | successor |
 | AccessorCalls.cs:52:9:52:12 | this access | AccessorCalls.cs:52:9:52:14 | access to field x | semmle.label | successor |
 | AccessorCalls.cs:52:9:52:12 | this access | AccessorCalls.cs:52:9:52:14 | access to field x | semmle.label | successor |
+| AccessorCalls.cs:52:9:52:14 | access to field x | AccessorCalls.cs:52:9:52:12 | this access | semmle.label | successor |
 | AccessorCalls.cs:52:9:52:14 | access to field x | AccessorCalls.cs:52:9:52:19 | access to property Prop | semmle.label | successor |
-| AccessorCalls.cs:52:9:52:14 | access to field x | AccessorCalls.cs:52:9:52:19 | access to property Prop | semmle.label | successor |
-| AccessorCalls.cs:52:9:52:19 | access to property Prop | AccessorCalls.cs:52:9:52:12 | this access | semmle.label | successor |
+| AccessorCalls.cs:52:9:52:19 | access to property Prop | AccessorCalls.cs:52:9:52:34 | ... = ... | semmle.label | successor |
 | AccessorCalls.cs:52:9:52:19 | access to property Prop | AccessorCalls.cs:52:24:52:27 | this access | semmle.label | successor |
-| AccessorCalls.cs:52:9:52:34 | ... + ... | AccessorCalls.cs:52:9:52:34 | ... = ... | semmle.label | successor |
+| AccessorCalls.cs:52:9:52:34 | ... + ... | AccessorCalls.cs:52:9:52:19 | access to property Prop | semmle.label | successor |
 | AccessorCalls.cs:52:9:52:34 | ... = ... | AccessorCalls.cs:53:9:53:31 | ...; | semmle.label | successor |
 | AccessorCalls.cs:52:9:52:35 | ...; | AccessorCalls.cs:52:9:52:12 | this access | semmle.label | successor |
 | AccessorCalls.cs:52:24:52:27 | this access | AccessorCalls.cs:52:24:52:29 | access to field x | semmle.label | successor |
@@ -173,12 +169,12 @@
 | AccessorCalls.cs:53:9:53:12 | this access | AccessorCalls.cs:53:9:53:14 | access to field x | semmle.label | successor |
 | AccessorCalls.cs:53:9:53:14 | access to field x | AccessorCalls.cs:53:16:53:16 | 0 | semmle.label | successor |
 | AccessorCalls.cs:53:9:53:14 | access to field x | AccessorCalls.cs:53:16:53:16 | 0 | semmle.label | successor |
-| AccessorCalls.cs:53:9:53:17 | access to indexer | AccessorCalls.cs:53:9:53:12 | this access | semmle.label | successor |
+| AccessorCalls.cs:53:9:53:17 | access to indexer | AccessorCalls.cs:53:9:53:30 | ... = ... | semmle.label | successor |
 | AccessorCalls.cs:53:9:53:17 | access to indexer | AccessorCalls.cs:53:22:53:25 | this access | semmle.label | successor |
-| AccessorCalls.cs:53:9:53:30 | ... + ... | AccessorCalls.cs:53:9:53:30 | ... = ... | semmle.label | successor |
+| AccessorCalls.cs:53:9:53:30 | ... + ... | AccessorCalls.cs:53:9:53:17 | access to indexer | semmle.label | successor |
 | AccessorCalls.cs:53:9:53:30 | ... = ... | AccessorCalls.cs:49:10:49:11 | exit M6 | semmle.label | successor |
 | AccessorCalls.cs:53:9:53:31 | ...; | AccessorCalls.cs:53:9:53:12 | this access | semmle.label | successor |
-| AccessorCalls.cs:53:16:53:16 | 0 | AccessorCalls.cs:53:9:53:17 | access to indexer | semmle.label | successor |
+| AccessorCalls.cs:53:16:53:16 | 0 | AccessorCalls.cs:53:9:53:12 | this access | semmle.label | successor |
 | AccessorCalls.cs:53:16:53:16 | 0 | AccessorCalls.cs:53:9:53:17 | access to indexer | semmle.label | successor |
 | AccessorCalls.cs:53:22:53:25 | this access | AccessorCalls.cs:53:22:53:27 | access to field x | semmle.label | successor |
 | AccessorCalls.cs:53:22:53:27 | access to field x | AccessorCalls.cs:53:29:53:29 | 0 | semmle.label | successor |
@@ -189,16 +185,14 @@
 | AccessorCalls.cs:58:9:58:45 | (..., ...) | AccessorCalls.cs:58:50:58:53 | this access | semmle.label | successor |
 | AccessorCalls.cs:58:9:58:85 | ... = ... | AccessorCalls.cs:56:10:56:11 | exit M7 | semmle.label | successor |
 | AccessorCalls.cs:58:9:58:86 | ...; | AccessorCalls.cs:58:10:58:13 | this access | semmle.label | successor |
-| AccessorCalls.cs:58:10:58:13 | this access | AccessorCalls.cs:58:10:58:19 | access to field Field | semmle.label | successor |
-| AccessorCalls.cs:58:10:58:19 | access to field Field | AccessorCalls.cs:58:22:58:25 | this access | semmle.label | successor |
-| AccessorCalls.cs:58:22:58:25 | this access | AccessorCalls.cs:58:22:58:30 | access to property Prop | semmle.label | successor |
-| AccessorCalls.cs:58:22:58:30 | access to property Prop | AccessorCalls.cs:58:34:58:34 | access to parameter i | semmle.label | successor |
+| AccessorCalls.cs:58:10:58:13 | this access | AccessorCalls.cs:58:22:58:25 | this access | semmle.label | successor |
+| AccessorCalls.cs:58:22:58:25 | this access | AccessorCalls.cs:58:37:58:40 | this access | semmle.label | successor |
+| AccessorCalls.cs:58:22:58:30 | access to property Prop | AccessorCalls.cs:58:37:58:43 | access to indexer | semmle.label | successor |
 | AccessorCalls.cs:58:33:58:44 | (..., ...) | AccessorCalls.cs:58:9:58:45 | (..., ...) | semmle.label | successor |
-| AccessorCalls.cs:58:34:58:34 | access to parameter i | AccessorCalls.cs:58:37:58:40 | this access | semmle.label | successor |
 | AccessorCalls.cs:58:37:58:40 | this access | AccessorCalls.cs:58:42:58:42 | 0 | semmle.label | successor |
-| AccessorCalls.cs:58:37:58:43 | access to indexer | AccessorCalls.cs:58:33:58:44 | (..., ...) | semmle.label | successor |
-| AccessorCalls.cs:58:42:58:42 | 0 | AccessorCalls.cs:58:37:58:43 | access to indexer | semmle.label | successor |
-| AccessorCalls.cs:58:49:58:85 | (..., ...) | AccessorCalls.cs:58:9:58:85 | ... = ... | semmle.label | successor |
+| AccessorCalls.cs:58:37:58:43 | access to indexer | AccessorCalls.cs:58:9:58:85 | ... = ... | semmle.label | successor |
+| AccessorCalls.cs:58:42:58:42 | 0 | AccessorCalls.cs:58:33:58:44 | (..., ...) | semmle.label | successor |
+| AccessorCalls.cs:58:49:58:85 | (..., ...) | AccessorCalls.cs:58:22:58:30 | access to property Prop | semmle.label | successor |
 | AccessorCalls.cs:58:50:58:53 | this access | AccessorCalls.cs:58:50:58:59 | access to field Field | semmle.label | successor |
 | AccessorCalls.cs:58:50:58:59 | access to field Field | AccessorCalls.cs:58:62:58:65 | this access | semmle.label | successor |
 | AccessorCalls.cs:58:62:58:65 | this access | AccessorCalls.cs:58:62:58:70 | access to property Prop | semmle.label | successor |
@@ -214,18 +208,16 @@
 | AccessorCalls.cs:63:9:63:97 | ... = ... | AccessorCalls.cs:61:10:61:11 | exit M8 | semmle.label | successor |
 | AccessorCalls.cs:63:9:63:98 | ...; | AccessorCalls.cs:63:10:63:13 | this access | semmle.label | successor |
 | AccessorCalls.cs:63:10:63:13 | this access | AccessorCalls.cs:63:10:63:15 | access to field x | semmle.label | successor |
-| AccessorCalls.cs:63:10:63:15 | access to field x | AccessorCalls.cs:63:10:63:21 | access to field Field | semmle.label | successor |
-| AccessorCalls.cs:63:10:63:21 | access to field Field | AccessorCalls.cs:63:24:63:27 | this access | semmle.label | successor |
+| AccessorCalls.cs:63:10:63:15 | access to field x | AccessorCalls.cs:63:24:63:27 | this access | semmle.label | successor |
 | AccessorCalls.cs:63:24:63:27 | this access | AccessorCalls.cs:63:24:63:29 | access to field x | semmle.label | successor |
-| AccessorCalls.cs:63:24:63:29 | access to field x | AccessorCalls.cs:63:24:63:34 | access to property Prop | semmle.label | successor |
-| AccessorCalls.cs:63:24:63:34 | access to property Prop | AccessorCalls.cs:63:38:63:38 | access to parameter i | semmle.label | successor |
+| AccessorCalls.cs:63:24:63:29 | access to field x | AccessorCalls.cs:63:41:63:44 | this access | semmle.label | successor |
+| AccessorCalls.cs:63:24:63:34 | access to property Prop | AccessorCalls.cs:63:41:63:49 | access to indexer | semmle.label | successor |
 | AccessorCalls.cs:63:37:63:50 | (..., ...) | AccessorCalls.cs:63:9:63:51 | (..., ...) | semmle.label | successor |
-| AccessorCalls.cs:63:38:63:38 | access to parameter i | AccessorCalls.cs:63:41:63:44 | this access | semmle.label | successor |
 | AccessorCalls.cs:63:41:63:44 | this access | AccessorCalls.cs:63:41:63:46 | access to field x | semmle.label | successor |
 | AccessorCalls.cs:63:41:63:46 | access to field x | AccessorCalls.cs:63:48:63:48 | 0 | semmle.label | successor |
-| AccessorCalls.cs:63:41:63:49 | access to indexer | AccessorCalls.cs:63:37:63:50 | (..., ...) | semmle.label | successor |
-| AccessorCalls.cs:63:48:63:48 | 0 | AccessorCalls.cs:63:41:63:49 | access to indexer | semmle.label | successor |
-| AccessorCalls.cs:63:55:63:97 | (..., ...) | AccessorCalls.cs:63:9:63:97 | ... = ... | semmle.label | successor |
+| AccessorCalls.cs:63:41:63:49 | access to indexer | AccessorCalls.cs:63:9:63:97 | ... = ... | semmle.label | successor |
+| AccessorCalls.cs:63:48:63:48 | 0 | AccessorCalls.cs:63:37:63:50 | (..., ...) | semmle.label | successor |
+| AccessorCalls.cs:63:55:63:97 | (..., ...) | AccessorCalls.cs:63:24:63:34 | access to property Prop | semmle.label | successor |
 | AccessorCalls.cs:63:56:63:59 | this access | AccessorCalls.cs:63:56:63:61 | access to field x | semmle.label | successor |
 | AccessorCalls.cs:63:56:63:61 | access to field x | AccessorCalls.cs:63:56:63:67 | access to field Field | semmle.label | successor |
 | AccessorCalls.cs:63:56:63:67 | access to field Field | AccessorCalls.cs:63:70:63:73 | this access | semmle.label | successor |
@@ -261,42 +253,36 @@
 | ArrayCreation.cs:9:48:9:48 | 3 | ArrayCreation.cs:9:43:9:50 | { ..., ... } | semmle.label | successor |
 | Assignments.cs:3:10:3:10 | enter M | Assignments.cs:4:5:15:5 | {...} | semmle.label | successor |
 | Assignments.cs:4:5:15:5 | {...} | Assignments.cs:5:9:5:18 | ... ...; | semmle.label | successor |
-| Assignments.cs:5:9:5:18 | ... ...; | Assignments.cs:5:13:5:13 | access to local variable x | semmle.label | successor |
-| Assignments.cs:5:13:5:13 | access to local variable x | Assignments.cs:5:17:5:17 | 0 | semmle.label | successor |
+| Assignments.cs:5:9:5:18 | ... ...; | Assignments.cs:5:17:5:17 | 0 | semmle.label | successor |
 | Assignments.cs:5:13:5:17 | Int32 x = ... | Assignments.cs:6:9:6:15 | ...; | semmle.label | successor |
 | Assignments.cs:5:17:5:17 | 0 | Assignments.cs:5:13:5:17 | Int32 x = ... | semmle.label | successor |
-| Assignments.cs:6:9:6:9 | access to local variable x | Assignments.cs:6:9:6:9 | access to local variable x | semmle.label | successor |
 | Assignments.cs:6:9:6:9 | access to local variable x | Assignments.cs:6:14:6:14 | 1 | semmle.label | successor |
 | Assignments.cs:6:9:6:14 | ... + ... | Assignments.cs:6:9:6:14 | ... = ... | semmle.label | successor |
 | Assignments.cs:6:9:6:14 | ... = ... | Assignments.cs:8:9:8:22 | ... ...; | semmle.label | successor |
 | Assignments.cs:6:9:6:15 | ...; | Assignments.cs:6:9:6:9 | access to local variable x | semmle.label | successor |
 | Assignments.cs:6:14:6:14 | 1 | Assignments.cs:6:9:6:14 | ... + ... | semmle.label | successor |
-| Assignments.cs:8:9:8:22 | ... ...; | Assignments.cs:8:17:8:17 | access to local variable d | semmle.label | successor |
-| Assignments.cs:8:17:8:17 | access to local variable d | Assignments.cs:8:21:8:21 | 0 | semmle.label | successor |
+| Assignments.cs:8:9:8:22 | ... ...; | Assignments.cs:8:21:8:21 | 0 | semmle.label | successor |
 | Assignments.cs:8:17:8:21 | dynamic d = ... | Assignments.cs:9:9:9:15 | ...; | semmle.label | successor |
 | Assignments.cs:8:21:8:21 | 0 | Assignments.cs:8:21:8:21 | (...) ... | semmle.label | successor |
 | Assignments.cs:8:21:8:21 | (...) ... | Assignments.cs:8:17:8:21 | dynamic d = ... | semmle.label | successor |
-| Assignments.cs:9:9:9:9 | access to local variable d | Assignments.cs:9:9:9:9 | access to local variable d | semmle.label | successor |
 | Assignments.cs:9:9:9:9 | access to local variable d | Assignments.cs:9:14:9:14 | 2 | semmle.label | successor |
 | Assignments.cs:9:9:9:14 | ... = ... | Assignments.cs:11:9:11:34 | ... ...; | semmle.label | successor |
 | Assignments.cs:9:9:9:14 | dynamic call to operator - | Assignments.cs:9:9:9:14 | ... = ... | semmle.label | successor |
 | Assignments.cs:9:9:9:15 | ...; | Assignments.cs:9:9:9:9 | access to local variable d | semmle.label | successor |
 | Assignments.cs:9:14:9:14 | 2 | Assignments.cs:9:9:9:14 | dynamic call to operator - | semmle.label | successor |
-| Assignments.cs:11:9:11:34 | ... ...; | Assignments.cs:11:13:11:13 | access to local variable a | semmle.label | successor |
-| Assignments.cs:11:13:11:13 | access to local variable a | Assignments.cs:11:17:11:33 | object creation of type Assignments | semmle.label | successor |
+| Assignments.cs:11:9:11:34 | ... ...; | Assignments.cs:11:17:11:33 | object creation of type Assignments | semmle.label | successor |
 | Assignments.cs:11:13:11:33 | Assignments a = ... | Assignments.cs:12:9:12:18 | ...; | semmle.label | successor |
 | Assignments.cs:11:17:11:33 | object creation of type Assignments | Assignments.cs:11:13:11:33 | Assignments a = ... | semmle.label | successor |
-| Assignments.cs:12:9:12:9 | access to local variable a | Assignments.cs:12:9:12:9 | access to local variable a | semmle.label | successor |
 | Assignments.cs:12:9:12:9 | access to local variable a | Assignments.cs:12:14:12:17 | this access | semmle.label | successor |
 | Assignments.cs:12:9:12:17 | ... = ... | Assignments.cs:14:9:14:36 | ...; | semmle.label | successor |
 | Assignments.cs:12:9:12:17 | call to operator + | Assignments.cs:12:9:12:17 | ... = ... | semmle.label | successor |
 | Assignments.cs:12:9:12:18 | ...; | Assignments.cs:12:9:12:9 | access to local variable a | semmle.label | successor |
 | Assignments.cs:12:14:12:17 | this access | Assignments.cs:12:9:12:17 | call to operator + | semmle.label | successor |
-| Assignments.cs:14:9:14:13 | access to event Event | Assignments.cs:14:18:14:35 | (...) => ... | semmle.label | successor |
-| Assignments.cs:14:9:14:13 | this access | Assignments.cs:14:9:14:13 | access to event Event | semmle.label | successor |
+| Assignments.cs:14:9:14:13 | access to event Event | Assignments.cs:14:9:14:35 | ... += ... | semmle.label | successor |
+| Assignments.cs:14:9:14:13 | this access | Assignments.cs:14:18:14:35 | (...) => ... | semmle.label | successor |
 | Assignments.cs:14:9:14:35 | ... += ... | Assignments.cs:3:10:3:10 | exit M | semmle.label | successor |
 | Assignments.cs:14:9:14:36 | ...; | Assignments.cs:14:9:14:13 | this access | semmle.label | successor |
-| Assignments.cs:14:18:14:35 | (...) => ... | Assignments.cs:14:9:14:35 | ... += ... | semmle.label | successor |
+| Assignments.cs:14:18:14:35 | (...) => ... | Assignments.cs:14:9:14:13 | access to event Event | semmle.label | successor |
 | Assignments.cs:14:18:14:35 | enter (...) => ... | Assignments.cs:14:33:14:35 | {...} | semmle.label | successor |
 | Assignments.cs:14:33:14:35 | {...} | Assignments.cs:14:18:14:35 | exit (...) => ... | semmle.label | successor |
 | Assignments.cs:17:40:17:40 | enter + | Assignments.cs:18:5:20:5 | {...} | semmle.label | successor |
@@ -630,20 +616,17 @@
 | ConditionalAccess.cs:19:58:19:59 | access to parameter s2 | ConditionalAccess.cs:19:43:19:60 | call to method CommaJoinWith | semmle.label | successor |
 | ConditionalAccess.cs:21:10:21:11 | enter M7 | ConditionalAccess.cs:22:5:26:5 | {...} | semmle.label | successor |
 | ConditionalAccess.cs:22:5:26:5 | {...} | ConditionalAccess.cs:23:9:23:39 | ... ...; | semmle.label | successor |
-| ConditionalAccess.cs:23:9:23:39 | ... ...; | ConditionalAccess.cs:23:13:23:13 | access to local variable j | semmle.label | successor |
-| ConditionalAccess.cs:23:13:23:13 | access to local variable j | ConditionalAccess.cs:23:26:23:29 | null | semmle.label | successor |
+| ConditionalAccess.cs:23:9:23:39 | ... ...; | ConditionalAccess.cs:23:26:23:29 | null | semmle.label | successor |
 | ConditionalAccess.cs:23:13:23:38 | Nullable<Int32> j = ... | ConditionalAccess.cs:24:9:24:38 | ... ...; | semmle.label | successor |
 | ConditionalAccess.cs:23:18:23:29 | (...) ... | ConditionalAccess.cs:23:13:23:38 | Nullable<Int32> j = ... | semmle.label | null |
 | ConditionalAccess.cs:23:26:23:29 | null | ConditionalAccess.cs:23:18:23:29 | (...) ... | semmle.label | successor |
-| ConditionalAccess.cs:24:9:24:38 | ... ...; | ConditionalAccess.cs:24:13:24:13 | access to local variable s | semmle.label | successor |
-| ConditionalAccess.cs:24:13:24:13 | access to local variable s | ConditionalAccess.cs:24:24:24:24 | access to parameter i | semmle.label | successor |
+| ConditionalAccess.cs:24:9:24:38 | ... ...; | ConditionalAccess.cs:24:24:24:24 | access to parameter i | semmle.label | successor |
 | ConditionalAccess.cs:24:13:24:37 | String s = ... | ConditionalAccess.cs:25:9:25:33 | ...; | semmle.label | successor |
 | ConditionalAccess.cs:24:18:24:24 | (...) ... | ConditionalAccess.cs:24:27:24:37 | call to method ToString | semmle.label | non-null |
 | ConditionalAccess.cs:24:24:24:24 | access to parameter i | ConditionalAccess.cs:24:18:24:24 | (...) ... | semmle.label | successor |
 | ConditionalAccess.cs:24:27:24:37 | call to method ToString | ConditionalAccess.cs:24:13:24:37 | String s = ... | semmle.label | successor |
-| ConditionalAccess.cs:25:9:25:9 | access to local variable s | ConditionalAccess.cs:25:13:25:14 | "" | semmle.label | successor |
 | ConditionalAccess.cs:25:9:25:32 | ... = ... | ConditionalAccess.cs:21:10:21:11 | exit M7 | semmle.label | successor |
-| ConditionalAccess.cs:25:9:25:33 | ...; | ConditionalAccess.cs:25:9:25:9 | access to local variable s | semmle.label | successor |
+| ConditionalAccess.cs:25:9:25:33 | ...; | ConditionalAccess.cs:25:13:25:14 | "" | semmle.label | successor |
 | ConditionalAccess.cs:25:13:25:14 | "" | ConditionalAccess.cs:25:31:25:31 | access to local variable s | semmle.label | non-null |
 | ConditionalAccess.cs:25:16:25:32 | call to method CommaJoinWith | ConditionalAccess.cs:25:9:25:32 | ... = ... | semmle.label | successor |
 | ConditionalAccess.cs:25:31:25:31 | access to local variable s | ConditionalAccess.cs:25:16:25:32 | call to method CommaJoinWith | semmle.label | successor |
@@ -672,8 +655,7 @@
 | Conditions.cs:8:13:8:16 | ...; | Conditions.cs:8:13:8:13 | access to parameter x | semmle.label | successor |
 | Conditions.cs:11:9:11:10 | enter M1 | Conditions.cs:12:5:20:5 | {...} | semmle.label | successor |
 | Conditions.cs:12:5:20:5 | {...} | Conditions.cs:13:9:13:18 | ... ...; | semmle.label | successor |
-| Conditions.cs:13:9:13:18 | ... ...; | Conditions.cs:13:13:13:13 | access to local variable x | semmle.label | successor |
-| Conditions.cs:13:13:13:13 | access to local variable x | Conditions.cs:13:17:13:17 | 0 | semmle.label | successor |
+| Conditions.cs:13:9:13:18 | ... ...; | Conditions.cs:13:17:13:17 | 0 | semmle.label | successor |
 | Conditions.cs:13:13:13:17 | Int32 x = ... | Conditions.cs:14:9:15:16 | if (...) ... | semmle.label | successor |
 | Conditions.cs:13:17:13:17 | 0 | Conditions.cs:13:13:13:17 | Int32 x = ... | semmle.label | successor |
 | Conditions.cs:14:9:15:16 | if (...) ... | Conditions.cs:14:13:14:13 | access to parameter b | semmle.label | successor |
@@ -705,8 +687,7 @@
 | Conditions.cs:19:16:19:16 | access to local variable x | Conditions.cs:19:9:19:17 | return ...; | semmle.label | successor |
 | Conditions.cs:22:9:22:10 | enter M2 | Conditions.cs:23:5:31:5 | {...} | semmle.label | successor |
 | Conditions.cs:23:5:31:5 | {...} | Conditions.cs:24:9:24:18 | ... ...; | semmle.label | successor |
-| Conditions.cs:24:9:24:18 | ... ...; | Conditions.cs:24:13:24:13 | access to local variable x | semmle.label | successor |
-| Conditions.cs:24:13:24:13 | access to local variable x | Conditions.cs:24:17:24:17 | 0 | semmle.label | successor |
+| Conditions.cs:24:9:24:18 | ... ...; | Conditions.cs:24:17:24:17 | 0 | semmle.label | successor |
 | Conditions.cs:24:13:24:17 | Int32 x = ... | Conditions.cs:25:9:27:20 | if (...) ... | semmle.label | successor |
 | Conditions.cs:24:17:24:17 | 0 | Conditions.cs:24:13:24:17 | Int32 x = ... | semmle.label | successor |
 | Conditions.cs:25:9:27:20 | if (...) ... | Conditions.cs:25:13:25:14 | access to parameter b1 | semmle.label | successor |
@@ -732,20 +713,17 @@
 | Conditions.cs:30:16:30:16 | access to local variable x | Conditions.cs:30:9:30:17 | return ...; | semmle.label | successor |
 | Conditions.cs:33:9:33:10 | enter M3 | Conditions.cs:34:5:44:5 | {...} | semmle.label | successor |
 | Conditions.cs:34:5:44:5 | {...} | Conditions.cs:35:9:35:18 | ... ...; | semmle.label | successor |
-| Conditions.cs:35:9:35:18 | ... ...; | Conditions.cs:35:13:35:13 | access to local variable x | semmle.label | successor |
-| Conditions.cs:35:13:35:13 | access to local variable x | Conditions.cs:35:17:35:17 | 0 | semmle.label | successor |
+| Conditions.cs:35:9:35:18 | ... ...; | Conditions.cs:35:17:35:17 | 0 | semmle.label | successor |
 | Conditions.cs:35:13:35:17 | Int32 x = ... | Conditions.cs:36:9:36:23 | ... ...; | semmle.label | successor |
 | Conditions.cs:35:17:35:17 | 0 | Conditions.cs:35:13:35:17 | Int32 x = ... | semmle.label | successor |
-| Conditions.cs:36:9:36:23 | ... ...; | Conditions.cs:36:13:36:14 | access to local variable b2 | semmle.label | successor |
-| Conditions.cs:36:13:36:14 | access to local variable b2 | Conditions.cs:36:18:36:22 | false | semmle.label | successor |
+| Conditions.cs:36:9:36:23 | ... ...; | Conditions.cs:36:18:36:22 | false | semmle.label | successor |
 | Conditions.cs:36:13:36:22 | Boolean b2 = ... | Conditions.cs:37:9:38:20 | if (...) ... | semmle.label | successor |
 | Conditions.cs:36:18:36:22 | false | Conditions.cs:36:13:36:22 | Boolean b2 = ... | semmle.label | successor |
 | Conditions.cs:37:9:38:20 | if (...) ... | Conditions.cs:37:13:37:14 | access to parameter b1 | semmle.label | successor |
 | Conditions.cs:37:13:37:14 | access to parameter b1 | Conditions.cs:38:13:38:20 | ...; | semmle.label | true |
 | Conditions.cs:37:13:37:14 | access to parameter b1 | Conditions.cs:39:9:40:16 | if (...) ... | semmle.label | false |
-| Conditions.cs:38:13:38:14 | access to local variable b2 | Conditions.cs:38:18:38:19 | access to parameter b1 | semmle.label | successor |
 | Conditions.cs:38:13:38:19 | ... = ... | Conditions.cs:39:9:40:16 | if (...) ... | semmle.label | successor |
-| Conditions.cs:38:13:38:20 | ...; | Conditions.cs:38:13:38:14 | access to local variable b2 | semmle.label | successor |
+| Conditions.cs:38:13:38:20 | ...; | Conditions.cs:38:18:38:19 | access to parameter b1 | semmle.label | successor |
 | Conditions.cs:38:18:38:19 | access to parameter b1 | Conditions.cs:38:13:38:19 | ... = ... | semmle.label | successor |
 | Conditions.cs:39:9:40:16 | if (...) ... | Conditions.cs:39:13:39:14 | access to local variable b2 | semmle.label | successor |
 | Conditions.cs:39:13:39:14 | access to local variable b2 | Conditions.cs:40:13:40:16 | [b2 (line 39): true] ...; | semmle.label | true |
@@ -764,8 +742,7 @@
 | Conditions.cs:43:16:43:16 | access to local variable x | Conditions.cs:43:9:43:17 | return ...; | semmle.label | successor |
 | Conditions.cs:46:9:46:10 | enter M4 | Conditions.cs:47:5:55:5 | {...} | semmle.label | successor |
 | Conditions.cs:47:5:55:5 | {...} | Conditions.cs:48:9:48:18 | ... ...; | semmle.label | successor |
-| Conditions.cs:48:9:48:18 | ... ...; | Conditions.cs:48:13:48:13 | access to local variable y | semmle.label | successor |
-| Conditions.cs:48:13:48:13 | access to local variable y | Conditions.cs:48:17:48:17 | 0 | semmle.label | successor |
+| Conditions.cs:48:9:48:18 | ... ...; | Conditions.cs:48:17:48:17 | 0 | semmle.label | successor |
 | Conditions.cs:48:13:48:17 | Int32 y = ... | Conditions.cs:49:9:53:9 | while (...) ... | semmle.label | successor |
 | Conditions.cs:48:17:48:17 | 0 | Conditions.cs:48:13:48:17 | Int32 y = ... | semmle.label | successor |
 | Conditions.cs:49:9:53:9 | while (...) ... | Conditions.cs:49:16:49:16 | access to parameter x | semmle.label | successor |
@@ -801,8 +778,7 @@
 | Conditions.cs:54:16:54:16 | access to local variable y | Conditions.cs:54:9:54:17 | return ...; | semmle.label | successor |
 | Conditions.cs:57:9:57:10 | enter M5 | Conditions.cs:58:5:68:5 | {...} | semmle.label | successor |
 | Conditions.cs:58:5:68:5 | {...} | Conditions.cs:59:9:59:18 | ... ...; | semmle.label | successor |
-| Conditions.cs:59:9:59:18 | ... ...; | Conditions.cs:59:13:59:13 | access to local variable y | semmle.label | successor |
-| Conditions.cs:59:13:59:13 | access to local variable y | Conditions.cs:59:17:59:17 | 0 | semmle.label | successor |
+| Conditions.cs:59:9:59:18 | ... ...; | Conditions.cs:59:17:59:17 | 0 | semmle.label | successor |
 | Conditions.cs:59:13:59:17 | Int32 y = ... | Conditions.cs:60:9:64:9 | while (...) ... | semmle.label | successor |
 | Conditions.cs:59:17:59:17 | 0 | Conditions.cs:59:13:59:17 | Int32 y = ... | semmle.label | successor |
 | Conditions.cs:60:9:64:9 | while (...) ... | Conditions.cs:60:16:60:16 | access to parameter x | semmle.label | successor |
@@ -848,15 +824,13 @@
 | Conditions.cs:67:16:67:16 | access to local variable y | Conditions.cs:67:9:67:17 | return ...; | semmle.label | successor |
 | Conditions.cs:70:9:70:10 | enter M6 | Conditions.cs:71:5:84:5 | {...} | semmle.label | successor |
 | Conditions.cs:71:5:84:5 | {...} | Conditions.cs:72:9:72:30 | ... ...; | semmle.label | successor |
-| Conditions.cs:72:9:72:30 | ... ...; | Conditions.cs:72:13:72:13 | access to local variable b | semmle.label | successor |
-| Conditions.cs:72:13:72:13 | access to local variable b | Conditions.cs:72:17:72:18 | access to parameter ss | semmle.label | successor |
+| Conditions.cs:72:9:72:30 | ... ...; | Conditions.cs:72:17:72:18 | access to parameter ss | semmle.label | successor |
 | Conditions.cs:72:13:72:29 | Boolean b = ... | Conditions.cs:73:9:73:18 | ... ...; | semmle.label | successor |
 | Conditions.cs:72:17:72:18 | access to parameter ss | Conditions.cs:72:17:72:25 | access to property Length | semmle.label | successor |
 | Conditions.cs:72:17:72:25 | access to property Length | Conditions.cs:72:29:72:29 | 0 | semmle.label | successor |
 | Conditions.cs:72:17:72:29 | ... > ... | Conditions.cs:72:13:72:29 | Boolean b = ... | semmle.label | successor |
 | Conditions.cs:72:29:72:29 | 0 | Conditions.cs:72:17:72:29 | ... > ... | semmle.label | successor |
-| Conditions.cs:73:9:73:18 | ... ...; | Conditions.cs:73:13:73:13 | access to local variable x | semmle.label | successor |
-| Conditions.cs:73:13:73:13 | access to local variable x | Conditions.cs:73:17:73:17 | 0 | semmle.label | successor |
+| Conditions.cs:73:9:73:18 | ... ...; | Conditions.cs:73:17:73:17 | 0 | semmle.label | successor |
 | Conditions.cs:73:13:73:17 | Int32 x = ... | Conditions.cs:74:27:74:28 | access to parameter ss | semmle.label | successor |
 | Conditions.cs:73:17:73:17 | 0 | Conditions.cs:73:13:73:17 | Int32 x = ... | semmle.label | successor |
 | Conditions.cs:74:9:80:9 | foreach (... ... in ...) ... | Conditions.cs:75:9:80:9 | {...} | semmle.label | non-empty |
@@ -874,9 +848,8 @@
 | Conditions.cs:78:17:78:21 | ... > ... | Conditions.cs:74:9:80:9 | foreach (... ... in ...) ... | semmle.label | false |
 | Conditions.cs:78:17:78:21 | ... > ... | Conditions.cs:79:17:79:26 | ...; | semmle.label | true |
 | Conditions.cs:78:21:78:21 | 0 | Conditions.cs:78:17:78:21 | ... > ... | semmle.label | successor |
-| Conditions.cs:79:17:79:17 | access to local variable b | Conditions.cs:79:21:79:25 | false | semmle.label | successor |
 | Conditions.cs:79:17:79:25 | ... = ... | Conditions.cs:74:9:80:9 | foreach (... ... in ...) ... | semmle.label | successor |
-| Conditions.cs:79:17:79:26 | ...; | Conditions.cs:79:17:79:17 | access to local variable b | semmle.label | successor |
+| Conditions.cs:79:17:79:26 | ...; | Conditions.cs:79:21:79:25 | false | semmle.label | successor |
 | Conditions.cs:79:21:79:25 | false | Conditions.cs:79:17:79:25 | ... = ... | semmle.label | successor |
 | Conditions.cs:81:9:82:16 | if (...) ... | Conditions.cs:81:12:81:12 | access to local variable b | semmle.label | successor |
 | Conditions.cs:81:12:81:12 | access to local variable b | Conditions.cs:82:13:82:16 | ...; | semmle.label | true |
@@ -888,15 +861,13 @@
 | Conditions.cs:83:16:83:16 | access to local variable x | Conditions.cs:83:9:83:17 | return ...; | semmle.label | successor |
 | Conditions.cs:86:9:86:10 | enter M7 | Conditions.cs:87:5:100:5 | {...} | semmle.label | successor |
 | Conditions.cs:87:5:100:5 | {...} | Conditions.cs:88:9:88:30 | ... ...; | semmle.label | successor |
-| Conditions.cs:88:9:88:30 | ... ...; | Conditions.cs:88:13:88:13 | access to local variable b | semmle.label | successor |
-| Conditions.cs:88:13:88:13 | access to local variable b | Conditions.cs:88:17:88:18 | access to parameter ss | semmle.label | successor |
+| Conditions.cs:88:9:88:30 | ... ...; | Conditions.cs:88:17:88:18 | access to parameter ss | semmle.label | successor |
 | Conditions.cs:88:13:88:29 | Boolean b = ... | Conditions.cs:89:9:89:18 | ... ...; | semmle.label | successor |
 | Conditions.cs:88:17:88:18 | access to parameter ss | Conditions.cs:88:17:88:25 | access to property Length | semmle.label | successor |
 | Conditions.cs:88:17:88:25 | access to property Length | Conditions.cs:88:29:88:29 | 0 | semmle.label | successor |
 | Conditions.cs:88:17:88:29 | ... > ... | Conditions.cs:88:13:88:29 | Boolean b = ... | semmle.label | successor |
 | Conditions.cs:88:29:88:29 | 0 | Conditions.cs:88:17:88:29 | ... > ... | semmle.label | successor |
-| Conditions.cs:89:9:89:18 | ... ...; | Conditions.cs:89:13:89:13 | access to local variable x | semmle.label | successor |
-| Conditions.cs:89:13:89:13 | access to local variable x | Conditions.cs:89:17:89:17 | 0 | semmle.label | successor |
+| Conditions.cs:89:9:89:18 | ... ...; | Conditions.cs:89:17:89:17 | 0 | semmle.label | successor |
 | Conditions.cs:89:13:89:17 | Int32 x = ... | Conditions.cs:90:27:90:28 | access to parameter ss | semmle.label | successor |
 | Conditions.cs:89:17:89:17 | 0 | Conditions.cs:89:13:89:17 | Int32 x = ... | semmle.label | successor |
 | Conditions.cs:90:9:98:9 | foreach (... ... in ...) ... | Conditions.cs:91:9:98:9 | {...} | semmle.label | non-empty |
@@ -914,9 +885,8 @@
 | Conditions.cs:94:17:94:21 | ... > ... | Conditions.cs:95:17:95:26 | ...; | semmle.label | true |
 | Conditions.cs:94:17:94:21 | ... > ... | Conditions.cs:96:13:97:20 | if (...) ... | semmle.label | false |
 | Conditions.cs:94:21:94:21 | 0 | Conditions.cs:94:17:94:21 | ... > ... | semmle.label | successor |
-| Conditions.cs:95:17:95:17 | access to local variable b | Conditions.cs:95:21:95:25 | false | semmle.label | successor |
 | Conditions.cs:95:17:95:25 | ... = ... | Conditions.cs:96:13:97:20 | if (...) ... | semmle.label | successor |
-| Conditions.cs:95:17:95:26 | ...; | Conditions.cs:95:17:95:17 | access to local variable b | semmle.label | successor |
+| Conditions.cs:95:17:95:26 | ...; | Conditions.cs:95:21:95:25 | false | semmle.label | successor |
 | Conditions.cs:95:21:95:25 | false | Conditions.cs:95:17:95:25 | ... = ... | semmle.label | successor |
 | Conditions.cs:96:13:97:20 | if (...) ... | Conditions.cs:96:17:96:17 | access to local variable b | semmle.label | successor |
 | Conditions.cs:96:17:96:17 | access to local variable b | Conditions.cs:90:9:98:9 | foreach (... ... in ...) ... | semmle.label | false |
@@ -928,15 +898,13 @@
 | Conditions.cs:99:16:99:16 | access to local variable x | Conditions.cs:99:9:99:17 | return ...; | semmle.label | successor |
 | Conditions.cs:102:12:102:13 | enter M8 | Conditions.cs:103:5:111:5 | {...} | semmle.label | successor |
 | Conditions.cs:103:5:111:5 | {...} | Conditions.cs:104:9:104:29 | ... ...; | semmle.label | successor |
-| Conditions.cs:104:9:104:29 | ... ...; | Conditions.cs:104:13:104:13 | access to local variable x | semmle.label | successor |
-| Conditions.cs:104:13:104:13 | access to local variable x | Conditions.cs:104:17:104:17 | access to parameter b | semmle.label | successor |
+| Conditions.cs:104:9:104:29 | ... ...; | Conditions.cs:104:17:104:17 | access to parameter b | semmle.label | successor |
 | Conditions.cs:104:13:104:28 | String x = ... | Conditions.cs:105:9:106:20 | if (...) ... | semmle.label | successor |
 | Conditions.cs:104:17:104:17 | access to parameter b | Conditions.cs:104:17:104:28 | call to method ToString | semmle.label | successor |
 | Conditions.cs:104:17:104:28 | call to method ToString | Conditions.cs:104:13:104:28 | String x = ... | semmle.label | successor |
 | Conditions.cs:105:9:106:20 | if (...) ... | Conditions.cs:105:13:105:13 | access to parameter b | semmle.label | successor |
 | Conditions.cs:105:13:105:13 | access to parameter b | Conditions.cs:106:13:106:20 | [b (line 102): true] ...; | semmle.label | true |
 | Conditions.cs:105:13:105:13 | access to parameter b | Conditions.cs:107:9:109:24 | [b (line 102): false] if (...) ... | semmle.label | false |
-| Conditions.cs:106:13:106:13 | [b (line 102): true] access to local variable x | Conditions.cs:106:13:106:13 | [b (line 102): true] access to local variable x | semmle.label | successor |
 | Conditions.cs:106:13:106:13 | [b (line 102): true] access to local variable x | Conditions.cs:106:18:106:19 | [b (line 102): true] "" | semmle.label | successor |
 | Conditions.cs:106:13:106:19 | [b (line 102): true] ... + ... | Conditions.cs:106:13:106:19 | [b (line 102): true] ... = ... | semmle.label | successor |
 | Conditions.cs:106:13:106:19 | [b (line 102): true] ... = ... | Conditions.cs:107:9:109:24 | [b (line 102): true] if (...) ... | semmle.label | successor |
@@ -960,7 +928,6 @@
 | Conditions.cs:108:17:108:18 | [b (line 102): true] !... | Conditions.cs:108:18:108:18 | [b (line 102): true] access to parameter b | semmle.label | successor |
 | Conditions.cs:108:18:108:18 | [b (line 102): false] access to parameter b | Conditions.cs:109:17:109:24 | ...; | semmle.label | false |
 | Conditions.cs:108:18:108:18 | [b (line 102): true] access to parameter b | Conditions.cs:110:16:110:16 | access to local variable x | semmle.label | true |
-| Conditions.cs:109:17:109:17 | access to local variable x | Conditions.cs:109:17:109:17 | access to local variable x | semmle.label | successor |
 | Conditions.cs:109:17:109:17 | access to local variable x | Conditions.cs:109:22:109:23 | "" | semmle.label | successor |
 | Conditions.cs:109:17:109:23 | ... + ... | Conditions.cs:109:17:109:23 | ... = ... | semmle.label | successor |
 | Conditions.cs:109:17:109:23 | ... = ... | Conditions.cs:110:16:110:16 | access to local variable x | semmle.label | successor |
@@ -970,12 +937,10 @@
 | Conditions.cs:110:16:110:16 | access to local variable x | Conditions.cs:110:9:110:17 | return ...; | semmle.label | successor |
 | Conditions.cs:113:10:113:11 | enter M9 | Conditions.cs:114:5:124:5 | {...} | semmle.label | successor |
 | Conditions.cs:114:5:124:5 | {...} | Conditions.cs:115:9:115:24 | ... ...; | semmle.label | successor |
-| Conditions.cs:115:9:115:24 | ... ...; | Conditions.cs:115:16:115:16 | access to local variable s | semmle.label | successor |
-| Conditions.cs:115:16:115:16 | access to local variable s | Conditions.cs:115:20:115:23 | null | semmle.label | successor |
+| Conditions.cs:115:9:115:24 | ... ...; | Conditions.cs:115:20:115:23 | null | semmle.label | successor |
 | Conditions.cs:115:16:115:23 | String s = ... | Conditions.cs:116:9:123:9 | for (...;...;...) ... | semmle.label | successor |
 | Conditions.cs:115:20:115:23 | null | Conditions.cs:115:16:115:23 | String s = ... | semmle.label | successor |
-| Conditions.cs:116:9:123:9 | for (...;...;...) ... | Conditions.cs:116:17:116:17 | access to local variable i | semmle.label | successor |
-| Conditions.cs:116:17:116:17 | access to local variable i | Conditions.cs:116:21:116:21 | 0 | semmle.label | successor |
+| Conditions.cs:116:9:123:9 | for (...;...;...) ... | Conditions.cs:116:21:116:21 | 0 | semmle.label | successor |
 | Conditions.cs:116:17:116:21 | Int32 i = ... | Conditions.cs:116:24:116:24 | access to local variable i | semmle.label | successor |
 | Conditions.cs:116:21:116:21 | 0 | Conditions.cs:116:17:116:21 | Int32 i = ... | semmle.label | successor |
 | Conditions.cs:116:24:116:24 | access to local variable i | Conditions.cs:116:28:116:31 | access to parameter args | semmle.label | successor |
@@ -986,8 +951,7 @@
 | Conditions.cs:116:41:116:41 | access to local variable i | Conditions.cs:116:41:116:43 | ...++ | semmle.label | successor |
 | Conditions.cs:116:41:116:43 | ...++ | Conditions.cs:116:24:116:24 | access to local variable i | semmle.label | successor |
 | Conditions.cs:117:9:123:9 | {...} | Conditions.cs:118:13:118:44 | ... ...; | semmle.label | successor |
-| Conditions.cs:118:13:118:44 | ... ...; | Conditions.cs:118:17:118:20 | access to local variable last | semmle.label | successor |
-| Conditions.cs:118:17:118:20 | access to local variable last | Conditions.cs:118:24:118:24 | access to local variable i | semmle.label | successor |
+| Conditions.cs:118:13:118:44 | ... ...; | Conditions.cs:118:24:118:24 | access to local variable i | semmle.label | successor |
 | Conditions.cs:118:17:118:43 | Boolean last = ... | Conditions.cs:119:13:120:23 | if (...) ... | semmle.label | successor |
 | Conditions.cs:118:24:118:24 | access to local variable i | Conditions.cs:118:29:118:32 | access to parameter args | semmle.label | successor |
 | Conditions.cs:118:24:118:43 | ... == ... | Conditions.cs:118:17:118:43 | Boolean last = ... | semmle.label | successor |
@@ -999,17 +963,15 @@
 | Conditions.cs:119:17:119:21 | !... | Conditions.cs:119:18:119:21 | access to local variable last | semmle.label | successor |
 | Conditions.cs:119:18:119:21 | access to local variable last | Conditions.cs:120:17:120:23 | [last (line 118): false] ...; | semmle.label | false |
 | Conditions.cs:119:18:119:21 | access to local variable last | Conditions.cs:121:13:122:25 | [last (line 118): true] if (...) ... | semmle.label | true |
-| Conditions.cs:120:17:120:17 | [last (line 118): false] access to local variable s | Conditions.cs:120:21:120:22 | [last (line 118): false] "" | semmle.label | successor |
 | Conditions.cs:120:17:120:22 | [last (line 118): false] ... = ... | Conditions.cs:121:13:122:25 | [last (line 118): false] if (...) ... | semmle.label | successor |
-| Conditions.cs:120:17:120:23 | [last (line 118): false] ...; | Conditions.cs:120:17:120:17 | [last (line 118): false] access to local variable s | semmle.label | successor |
+| Conditions.cs:120:17:120:23 | [last (line 118): false] ...; | Conditions.cs:120:21:120:22 | [last (line 118): false] "" | semmle.label | successor |
 | Conditions.cs:120:21:120:22 | [last (line 118): false] "" | Conditions.cs:120:17:120:22 | [last (line 118): false] ... = ... | semmle.label | successor |
 | Conditions.cs:121:13:122:25 | [last (line 118): false] if (...) ... | Conditions.cs:121:17:121:20 | [last (line 118): false] access to local variable last | semmle.label | successor |
 | Conditions.cs:121:13:122:25 | [last (line 118): true] if (...) ... | Conditions.cs:121:17:121:20 | [last (line 118): true] access to local variable last | semmle.label | successor |
 | Conditions.cs:121:17:121:20 | [last (line 118): false] access to local variable last | Conditions.cs:116:41:116:41 | access to local variable i | semmle.label | false |
 | Conditions.cs:121:17:121:20 | [last (line 118): true] access to local variable last | Conditions.cs:122:17:122:25 | ...; | semmle.label | true |
-| Conditions.cs:122:17:122:17 | access to local variable s | Conditions.cs:122:21:122:24 | null | semmle.label | successor |
 | Conditions.cs:122:17:122:24 | ... = ... | Conditions.cs:116:41:116:41 | access to local variable i | semmle.label | successor |
-| Conditions.cs:122:17:122:25 | ...; | Conditions.cs:122:17:122:17 | access to local variable s | semmle.label | successor |
+| Conditions.cs:122:17:122:25 | ...; | Conditions.cs:122:21:122:24 | null | semmle.label | successor |
 | Conditions.cs:122:21:122:24 | null | Conditions.cs:122:17:122:24 | ... = ... | semmle.label | successor |
 | Conditions.cs:129:10:129:12 | enter M10 | Conditions.cs:130:5:141:5 | {...} | semmle.label | successor |
 | Conditions.cs:130:5:141:5 | {...} | Conditions.cs:131:9:140:9 | while (...) ... | semmle.label | successor |
@@ -1282,20 +1244,17 @@
 | Initializers.cs:6:28:6:30 | {...} | Initializers.cs:6:5:6:16 | exit Initializers | semmle.label | successor |
 | Initializers.cs:8:10:8:10 | enter M | Initializers.cs:9:5:12:5 | {...} | semmle.label | successor |
 | Initializers.cs:9:5:12:5 | {...} | Initializers.cs:10:9:10:54 | ... ...; | semmle.label | successor |
-| Initializers.cs:10:9:10:54 | ... ...; | Initializers.cs:10:13:10:13 | access to local variable i | semmle.label | successor |
-| Initializers.cs:10:13:10:13 | access to local variable i | Initializers.cs:10:34:10:35 | "" | semmle.label | successor |
+| Initializers.cs:10:9:10:54 | ... ...; | Initializers.cs:10:34:10:35 | "" | semmle.label | successor |
 | Initializers.cs:10:13:10:53 | Initializers i = ... | Initializers.cs:11:9:11:64 | ... ...; | semmle.label | successor |
-| Initializers.cs:10:17:10:53 | object creation of type Initializers | Initializers.cs:10:40:10:40 | access to field F | semmle.label | successor |
+| Initializers.cs:10:17:10:53 | object creation of type Initializers | Initializers.cs:10:44:10:44 | 0 | semmle.label | successor |
 | Initializers.cs:10:34:10:35 | "" | Initializers.cs:10:17:10:53 | object creation of type Initializers | semmle.label | successor |
 | Initializers.cs:10:38:10:53 | { ..., ... } | Initializers.cs:10:13:10:53 | Initializers i = ... | semmle.label | successor |
-| Initializers.cs:10:40:10:40 | access to field F | Initializers.cs:10:44:10:44 | 0 | semmle.label | successor |
-| Initializers.cs:10:40:10:44 | ... = ... | Initializers.cs:10:47:10:47 | access to property G | semmle.label | successor |
+| Initializers.cs:10:40:10:44 | ... = ... | Initializers.cs:10:51:10:51 | 1 | semmle.label | successor |
 | Initializers.cs:10:44:10:44 | 0 | Initializers.cs:10:40:10:44 | ... = ... | semmle.label | successor |
-| Initializers.cs:10:47:10:47 | access to property G | Initializers.cs:10:51:10:51 | 1 | semmle.label | successor |
+| Initializers.cs:10:47:10:47 | access to property G | Initializers.cs:10:47:10:51 | ... = ... | semmle.label | successor |
 | Initializers.cs:10:47:10:51 | ... = ... | Initializers.cs:10:38:10:53 | { ..., ... } | semmle.label | successor |
-| Initializers.cs:10:51:10:51 | 1 | Initializers.cs:10:47:10:51 | ... = ... | semmle.label | successor |
-| Initializers.cs:11:9:11:64 | ... ...; | Initializers.cs:11:13:11:14 | access to local variable iz | semmle.label | successor |
-| Initializers.cs:11:13:11:14 | access to local variable iz | Initializers.cs:11:18:11:63 | array creation of type Initializers[] | semmle.label | successor |
+| Initializers.cs:10:51:10:51 | 1 | Initializers.cs:10:47:10:47 | access to property G | semmle.label | successor |
+| Initializers.cs:11:9:11:64 | ... ...; | Initializers.cs:11:18:11:63 | array creation of type Initializers[] | semmle.label | successor |
 | Initializers.cs:11:13:11:63 | Initializers[] iz = ... | Initializers.cs:8:10:8:10 | exit M | semmle.label | successor |
 | Initializers.cs:11:18:11:63 | array creation of type Initializers[] | Initializers.cs:11:39:11:39 | access to local variable i | semmle.label | successor |
 | Initializers.cs:11:37:11:63 | { ..., ... } | Initializers.cs:11:13:11:63 | Initializers[] iz = ... | semmle.label | successor |
@@ -1350,28 +1309,24 @@
 | NullCoalescing.cs:11:68:11:68 | 1 | NullCoalescing.cs:11:9:11:10 | exit M5 | semmle.label | successor |
 | NullCoalescing.cs:13:10:13:11 | enter M6 | NullCoalescing.cs:14:5:18:5 | {...} | semmle.label | successor |
 | NullCoalescing.cs:14:5:18:5 | {...} | NullCoalescing.cs:15:9:15:32 | ... ...; | semmle.label | successor |
-| NullCoalescing.cs:15:9:15:32 | ... ...; | NullCoalescing.cs:15:13:15:13 | access to local variable j | semmle.label | successor |
-| NullCoalescing.cs:15:13:15:13 | access to local variable j | NullCoalescing.cs:15:17:15:31 | ... ?? ... | semmle.label | successor |
+| NullCoalescing.cs:15:9:15:32 | ... ...; | NullCoalescing.cs:15:17:15:31 | ... ?? ... | semmle.label | successor |
 | NullCoalescing.cs:15:13:15:31 | Int32 j = ... | NullCoalescing.cs:16:9:16:26 | ... ...; | semmle.label | successor |
 | NullCoalescing.cs:15:17:15:26 | (...) ... | NullCoalescing.cs:15:31:15:31 | 0 | semmle.label | null |
 | NullCoalescing.cs:15:17:15:31 | ... ?? ... | NullCoalescing.cs:15:23:15:26 | null | semmle.label | successor |
 | NullCoalescing.cs:15:23:15:26 | null | NullCoalescing.cs:15:17:15:26 | (...) ... | semmle.label | successor |
 | NullCoalescing.cs:15:31:15:31 | 0 | NullCoalescing.cs:15:13:15:31 | Int32 j = ... | semmle.label | successor |
-| NullCoalescing.cs:16:9:16:26 | ... ...; | NullCoalescing.cs:16:13:16:13 | access to local variable s | semmle.label | successor |
-| NullCoalescing.cs:16:13:16:13 | access to local variable s | NullCoalescing.cs:16:17:16:25 | ... ?? ... | semmle.label | successor |
+| NullCoalescing.cs:16:9:16:26 | ... ...; | NullCoalescing.cs:16:17:16:25 | ... ?? ... | semmle.label | successor |
 | NullCoalescing.cs:16:13:16:25 | String s = ... | NullCoalescing.cs:17:9:17:25 | ...; | semmle.label | successor |
 | NullCoalescing.cs:16:17:16:18 | "" | NullCoalescing.cs:16:13:16:25 | String s = ... | semmle.label | non-null |
 | NullCoalescing.cs:16:17:16:25 | ... ?? ... | NullCoalescing.cs:16:17:16:18 | "" | semmle.label | successor |
-| NullCoalescing.cs:17:9:17:9 | access to local variable j | NullCoalescing.cs:17:13:17:24 | ... ?? ... | semmle.label | successor |
 | NullCoalescing.cs:17:9:17:24 | ... = ... | NullCoalescing.cs:13:10:13:11 | exit M6 | semmle.label | successor |
-| NullCoalescing.cs:17:9:17:25 | ...; | NullCoalescing.cs:17:9:17:9 | access to local variable j | semmle.label | successor |
+| NullCoalescing.cs:17:9:17:25 | ...; | NullCoalescing.cs:17:13:17:24 | ... ?? ... | semmle.label | successor |
 | NullCoalescing.cs:17:13:17:19 | (...) ... | NullCoalescing.cs:17:9:17:24 | ... = ... | semmle.label | non-null |
 | NullCoalescing.cs:17:13:17:24 | ... ?? ... | NullCoalescing.cs:17:19:17:19 | access to parameter i | semmle.label | successor |
 | NullCoalescing.cs:17:19:17:19 | access to parameter i | NullCoalescing.cs:17:13:17:19 | (...) ... | semmle.label | successor |
 | Patterns.cs:5:10:5:13 | enter Test | Patterns.cs:6:5:43:5 | {...} | semmle.label | successor |
 | Patterns.cs:6:5:43:5 | {...} | Patterns.cs:7:9:7:24 | ... ...; | semmle.label | successor |
-| Patterns.cs:7:9:7:24 | ... ...; | Patterns.cs:7:16:7:16 | access to local variable o | semmle.label | successor |
-| Patterns.cs:7:16:7:16 | access to local variable o | Patterns.cs:7:20:7:23 | null | semmle.label | successor |
+| Patterns.cs:7:9:7:24 | ... ...; | Patterns.cs:7:20:7:23 | null | semmle.label | successor |
 | Patterns.cs:7:16:7:23 | Object o = ... | Patterns.cs:8:9:18:9 | if (...) ... | semmle.label | successor |
 | Patterns.cs:7:20:7:23 | null | Patterns.cs:7:16:7:23 | Object o = ... | semmle.label | successor |
 | Patterns.cs:8:9:18:9 | if (...) ... | Patterns.cs:8:13:8:13 | access to local variable o | semmle.label | successor |
@@ -1460,73 +1415,58 @@
 | Qualifiers.cs:8:41:8:44 | null | Qualifiers.cs:8:23:8:34 | exit StaticMethod | semmle.label | successor |
 | Qualifiers.cs:10:10:10:10 | enter M | Qualifiers.cs:11:5:31:5 | {...} | semmle.label | successor |
 | Qualifiers.cs:11:5:31:5 | {...} | Qualifiers.cs:12:9:12:22 | ... ...; | semmle.label | successor |
-| Qualifiers.cs:12:9:12:22 | ... ...; | Qualifiers.cs:12:13:12:13 | access to local variable q | semmle.label | successor |
-| Qualifiers.cs:12:13:12:13 | access to local variable q | Qualifiers.cs:12:17:12:21 | this access | semmle.label | successor |
+| Qualifiers.cs:12:9:12:22 | ... ...; | Qualifiers.cs:12:17:12:21 | this access | semmle.label | successor |
 | Qualifiers.cs:12:13:12:21 | Qualifiers q = ... | Qualifiers.cs:13:9:13:21 | ...; | semmle.label | successor |
 | Qualifiers.cs:12:17:12:21 | access to field Field | Qualifiers.cs:12:13:12:21 | Qualifiers q = ... | semmle.label | successor |
 | Qualifiers.cs:12:17:12:21 | this access | Qualifiers.cs:12:17:12:21 | access to field Field | semmle.label | successor |
-| Qualifiers.cs:13:9:13:9 | access to local variable q | Qualifiers.cs:13:13:13:20 | this access | semmle.label | successor |
 | Qualifiers.cs:13:9:13:20 | ... = ... | Qualifiers.cs:14:9:14:21 | ...; | semmle.label | successor |
-| Qualifiers.cs:13:9:13:21 | ...; | Qualifiers.cs:13:9:13:9 | access to local variable q | semmle.label | successor |
+| Qualifiers.cs:13:9:13:21 | ...; | Qualifiers.cs:13:13:13:20 | this access | semmle.label | successor |
 | Qualifiers.cs:13:13:13:20 | access to property Property | Qualifiers.cs:13:9:13:20 | ... = ... | semmle.label | successor |
 | Qualifiers.cs:13:13:13:20 | this access | Qualifiers.cs:13:13:13:20 | access to property Property | semmle.label | successor |
-| Qualifiers.cs:14:9:14:9 | access to local variable q | Qualifiers.cs:14:13:14:20 | this access | semmle.label | successor |
 | Qualifiers.cs:14:9:14:20 | ... = ... | Qualifiers.cs:16:9:16:23 | ...; | semmle.label | successor |
-| Qualifiers.cs:14:9:14:21 | ...; | Qualifiers.cs:14:9:14:9 | access to local variable q | semmle.label | successor |
+| Qualifiers.cs:14:9:14:21 | ...; | Qualifiers.cs:14:13:14:20 | this access | semmle.label | successor |
 | Qualifiers.cs:14:13:14:20 | call to method Method | Qualifiers.cs:14:9:14:20 | ... = ... | semmle.label | successor |
 | Qualifiers.cs:14:13:14:20 | this access | Qualifiers.cs:14:13:14:20 | call to method Method | semmle.label | successor |
-| Qualifiers.cs:16:9:16:9 | access to local variable q | Qualifiers.cs:16:13:16:16 | this access | semmle.label | successor |
 | Qualifiers.cs:16:9:16:22 | ... = ... | Qualifiers.cs:17:9:17:26 | ...; | semmle.label | successor |
-| Qualifiers.cs:16:9:16:23 | ...; | Qualifiers.cs:16:9:16:9 | access to local variable q | semmle.label | successor |
+| Qualifiers.cs:16:9:16:23 | ...; | Qualifiers.cs:16:13:16:16 | this access | semmle.label | successor |
 | Qualifiers.cs:16:13:16:16 | this access | Qualifiers.cs:16:13:16:22 | access to field Field | semmle.label | successor |
 | Qualifiers.cs:16:13:16:22 | access to field Field | Qualifiers.cs:16:9:16:22 | ... = ... | semmle.label | successor |
-| Qualifiers.cs:17:9:17:9 | access to local variable q | Qualifiers.cs:17:13:17:16 | this access | semmle.label | successor |
 | Qualifiers.cs:17:9:17:25 | ... = ... | Qualifiers.cs:18:9:18:26 | ...; | semmle.label | successor |
-| Qualifiers.cs:17:9:17:26 | ...; | Qualifiers.cs:17:9:17:9 | access to local variable q | semmle.label | successor |
+| Qualifiers.cs:17:9:17:26 | ...; | Qualifiers.cs:17:13:17:16 | this access | semmle.label | successor |
 | Qualifiers.cs:17:13:17:16 | this access | Qualifiers.cs:17:13:17:25 | access to property Property | semmle.label | successor |
 | Qualifiers.cs:17:13:17:25 | access to property Property | Qualifiers.cs:17:9:17:25 | ... = ... | semmle.label | successor |
-| Qualifiers.cs:18:9:18:9 | access to local variable q | Qualifiers.cs:18:13:18:16 | this access | semmle.label | successor |
 | Qualifiers.cs:18:9:18:25 | ... = ... | Qualifiers.cs:20:9:20:24 | ...; | semmle.label | successor |
-| Qualifiers.cs:18:9:18:26 | ...; | Qualifiers.cs:18:9:18:9 | access to local variable q | semmle.label | successor |
+| Qualifiers.cs:18:9:18:26 | ...; | Qualifiers.cs:18:13:18:16 | this access | semmle.label | successor |
 | Qualifiers.cs:18:13:18:16 | this access | Qualifiers.cs:18:13:18:25 | call to method Method | semmle.label | successor |
 | Qualifiers.cs:18:13:18:25 | call to method Method | Qualifiers.cs:18:9:18:25 | ... = ... | semmle.label | successor |
-| Qualifiers.cs:20:9:20:9 | access to local variable q | Qualifiers.cs:20:13:20:23 | access to field StaticField | semmle.label | successor |
 | Qualifiers.cs:20:9:20:23 | ... = ... | Qualifiers.cs:21:9:21:27 | ...; | semmle.label | successor |
-| Qualifiers.cs:20:9:20:24 | ...; | Qualifiers.cs:20:9:20:9 | access to local variable q | semmle.label | successor |
+| Qualifiers.cs:20:9:20:24 | ...; | Qualifiers.cs:20:13:20:23 | access to field StaticField | semmle.label | successor |
 | Qualifiers.cs:20:13:20:23 | access to field StaticField | Qualifiers.cs:20:9:20:23 | ... = ... | semmle.label | successor |
-| Qualifiers.cs:21:9:21:9 | access to local variable q | Qualifiers.cs:21:13:21:26 | access to property StaticProperty | semmle.label | successor |
 | Qualifiers.cs:21:9:21:26 | ... = ... | Qualifiers.cs:22:9:22:27 | ...; | semmle.label | successor |
-| Qualifiers.cs:21:9:21:27 | ...; | Qualifiers.cs:21:9:21:9 | access to local variable q | semmle.label | successor |
+| Qualifiers.cs:21:9:21:27 | ...; | Qualifiers.cs:21:13:21:26 | access to property StaticProperty | semmle.label | successor |
 | Qualifiers.cs:21:13:21:26 | access to property StaticProperty | Qualifiers.cs:21:9:21:26 | ... = ... | semmle.label | successor |
-| Qualifiers.cs:22:9:22:9 | access to local variable q | Qualifiers.cs:22:13:22:26 | call to method StaticMethod | semmle.label | successor |
 | Qualifiers.cs:22:9:22:26 | ... = ... | Qualifiers.cs:24:9:24:35 | ...; | semmle.label | successor |
-| Qualifiers.cs:22:9:22:27 | ...; | Qualifiers.cs:22:9:22:9 | access to local variable q | semmle.label | successor |
+| Qualifiers.cs:22:9:22:27 | ...; | Qualifiers.cs:22:13:22:26 | call to method StaticMethod | semmle.label | successor |
 | Qualifiers.cs:22:13:22:26 | call to method StaticMethod | Qualifiers.cs:22:9:22:26 | ... = ... | semmle.label | successor |
-| Qualifiers.cs:24:9:24:9 | access to local variable q | Qualifiers.cs:24:13:24:34 | access to field StaticField | semmle.label | successor |
 | Qualifiers.cs:24:9:24:34 | ... = ... | Qualifiers.cs:25:9:25:38 | ...; | semmle.label | successor |
-| Qualifiers.cs:24:9:24:35 | ...; | Qualifiers.cs:24:9:24:9 | access to local variable q | semmle.label | successor |
+| Qualifiers.cs:24:9:24:35 | ...; | Qualifiers.cs:24:13:24:34 | access to field StaticField | semmle.label | successor |
 | Qualifiers.cs:24:13:24:34 | access to field StaticField | Qualifiers.cs:24:9:24:34 | ... = ... | semmle.label | successor |
-| Qualifiers.cs:25:9:25:9 | access to local variable q | Qualifiers.cs:25:13:25:37 | access to property StaticProperty | semmle.label | successor |
 | Qualifiers.cs:25:9:25:37 | ... = ... | Qualifiers.cs:26:9:26:38 | ...; | semmle.label | successor |
-| Qualifiers.cs:25:9:25:38 | ...; | Qualifiers.cs:25:9:25:9 | access to local variable q | semmle.label | successor |
+| Qualifiers.cs:25:9:25:38 | ...; | Qualifiers.cs:25:13:25:37 | access to property StaticProperty | semmle.label | successor |
 | Qualifiers.cs:25:13:25:37 | access to property StaticProperty | Qualifiers.cs:25:9:25:37 | ... = ... | semmle.label | successor |
-| Qualifiers.cs:26:9:26:9 | access to local variable q | Qualifiers.cs:26:13:26:37 | call to method StaticMethod | semmle.label | successor |
 | Qualifiers.cs:26:9:26:37 | ... = ... | Qualifiers.cs:28:9:28:41 | ...; | semmle.label | successor |
-| Qualifiers.cs:26:9:26:38 | ...; | Qualifiers.cs:26:9:26:9 | access to local variable q | semmle.label | successor |
+| Qualifiers.cs:26:9:26:38 | ...; | Qualifiers.cs:26:13:26:37 | call to method StaticMethod | semmle.label | successor |
 | Qualifiers.cs:26:13:26:37 | call to method StaticMethod | Qualifiers.cs:26:9:26:37 | ... = ... | semmle.label | successor |
-| Qualifiers.cs:28:9:28:9 | access to local variable q | Qualifiers.cs:28:13:28:34 | access to field StaticField | semmle.label | successor |
 | Qualifiers.cs:28:9:28:40 | ... = ... | Qualifiers.cs:29:9:29:47 | ...; | semmle.label | successor |
-| Qualifiers.cs:28:9:28:41 | ...; | Qualifiers.cs:28:9:28:9 | access to local variable q | semmle.label | successor |
+| Qualifiers.cs:28:9:28:41 | ...; | Qualifiers.cs:28:13:28:34 | access to field StaticField | semmle.label | successor |
 | Qualifiers.cs:28:13:28:34 | access to field StaticField | Qualifiers.cs:28:13:28:40 | access to field Field | semmle.label | successor |
 | Qualifiers.cs:28:13:28:40 | access to field Field | Qualifiers.cs:28:9:28:40 | ... = ... | semmle.label | successor |
-| Qualifiers.cs:29:9:29:9 | access to local variable q | Qualifiers.cs:29:13:29:37 | access to property StaticProperty | semmle.label | successor |
 | Qualifiers.cs:29:9:29:46 | ... = ... | Qualifiers.cs:30:9:30:47 | ...; | semmle.label | successor |
-| Qualifiers.cs:29:9:29:47 | ...; | Qualifiers.cs:29:9:29:9 | access to local variable q | semmle.label | successor |
+| Qualifiers.cs:29:9:29:47 | ...; | Qualifiers.cs:29:13:29:37 | access to property StaticProperty | semmle.label | successor |
 | Qualifiers.cs:29:13:29:37 | access to property StaticProperty | Qualifiers.cs:29:13:29:46 | access to property Property | semmle.label | successor |
 | Qualifiers.cs:29:13:29:46 | access to property Property | Qualifiers.cs:29:9:29:46 | ... = ... | semmle.label | successor |
-| Qualifiers.cs:30:9:30:9 | access to local variable q | Qualifiers.cs:30:13:30:37 | call to method StaticMethod | semmle.label | successor |
 | Qualifiers.cs:30:9:30:46 | ... = ... | Qualifiers.cs:10:10:10:10 | exit M | semmle.label | successor |
-| Qualifiers.cs:30:9:30:47 | ...; | Qualifiers.cs:30:9:30:9 | access to local variable q | semmle.label | successor |
+| Qualifiers.cs:30:9:30:47 | ...; | Qualifiers.cs:30:13:30:37 | call to method StaticMethod | semmle.label | successor |
 | Qualifiers.cs:30:13:30:37 | call to method StaticMethod | Qualifiers.cs:30:13:30:46 | call to method Method | semmle.label | successor |
 | Qualifiers.cs:30:13:30:46 | call to method Method | Qualifiers.cs:30:9:30:46 | ... = ... | semmle.label | successor |
 | Switch.cs:5:10:5:11 | enter M1 | Switch.cs:6:5:8:5 | {...} | semmle.label | successor |
@@ -1714,14 +1654,12 @@
 | Switch.cs:120:17:120:17 | 1 | Switch.cs:120:16:120:17 | -... | semmle.label | successor |
 | TypeAccesses.cs:3:10:3:10 | enter M | TypeAccesses.cs:4:5:9:5 | {...} | semmle.label | successor |
 | TypeAccesses.cs:4:5:9:5 | {...} | TypeAccesses.cs:5:9:5:26 | ... ...; | semmle.label | successor |
-| TypeAccesses.cs:5:9:5:26 | ... ...; | TypeAccesses.cs:5:13:5:13 | access to local variable s | semmle.label | successor |
-| TypeAccesses.cs:5:13:5:13 | access to local variable s | TypeAccesses.cs:5:25:5:25 | access to parameter o | semmle.label | successor |
+| TypeAccesses.cs:5:9:5:26 | ... ...; | TypeAccesses.cs:5:25:5:25 | access to parameter o | semmle.label | successor |
 | TypeAccesses.cs:5:13:5:25 | String s = ... | TypeAccesses.cs:6:9:6:24 | ...; | semmle.label | successor |
 | TypeAccesses.cs:5:17:5:25 | (...) ... | TypeAccesses.cs:5:13:5:25 | String s = ... | semmle.label | successor |
 | TypeAccesses.cs:5:25:5:25 | access to parameter o | TypeAccesses.cs:5:17:5:25 | (...) ... | semmle.label | successor |
-| TypeAccesses.cs:6:9:6:9 | access to local variable s | TypeAccesses.cs:6:13:6:13 | access to parameter o | semmle.label | successor |
 | TypeAccesses.cs:6:9:6:23 | ... = ... | TypeAccesses.cs:7:9:7:25 | if (...) ... | semmle.label | successor |
-| TypeAccesses.cs:6:9:6:24 | ...; | TypeAccesses.cs:6:9:6:9 | access to local variable s | semmle.label | successor |
+| TypeAccesses.cs:6:9:6:24 | ...; | TypeAccesses.cs:6:13:6:13 | access to parameter o | semmle.label | successor |
 | TypeAccesses.cs:6:13:6:13 | access to parameter o | TypeAccesses.cs:6:13:6:23 | ... as ... | semmle.label | successor |
 | TypeAccesses.cs:6:13:6:23 | ... as ... | TypeAccesses.cs:6:9:6:23 | ... = ... | semmle.label | successor |
 | TypeAccesses.cs:7:9:7:25 | if (...) ... | TypeAccesses.cs:7:13:7:13 | access to parameter o | semmle.label | successor |
@@ -1730,19 +1668,16 @@
 | TypeAccesses.cs:7:13:7:22 | ... is ... | TypeAccesses.cs:8:9:8:28 | ... ...; | semmle.label | false |
 | TypeAccesses.cs:7:18:7:22 | Int32 j | TypeAccesses.cs:7:13:7:22 | ... is ... | semmle.label | successor |
 | TypeAccesses.cs:7:25:7:25 | ; | TypeAccesses.cs:8:9:8:28 | ... ...; | semmle.label | successor |
-| TypeAccesses.cs:8:9:8:28 | ... ...; | TypeAccesses.cs:8:13:8:13 | access to local variable t | semmle.label | successor |
-| TypeAccesses.cs:8:13:8:13 | access to local variable t | TypeAccesses.cs:8:17:8:27 | typeof(...) | semmle.label | successor |
+| TypeAccesses.cs:8:9:8:28 | ... ...; | TypeAccesses.cs:8:17:8:27 | typeof(...) | semmle.label | successor |
 | TypeAccesses.cs:8:13:8:27 | Type t = ... | TypeAccesses.cs:3:10:3:10 | exit M | semmle.label | successor |
 | TypeAccesses.cs:8:17:8:27 | typeof(...) | TypeAccesses.cs:8:13:8:27 | Type t = ... | semmle.label | successor |
 | VarDecls.cs:5:18:5:19 | enter M1 | VarDecls.cs:6:5:11:5 | {...} | semmle.label | successor |
 | VarDecls.cs:6:5:11:5 | {...} | VarDecls.cs:7:9:10:9 | fixed(...) { ... } | semmle.label | successor |
-| VarDecls.cs:7:9:10:9 | fixed(...) { ... } | VarDecls.cs:7:22:7:23 | access to local variable c1 | semmle.label | successor |
-| VarDecls.cs:7:22:7:23 | access to local variable c1 | VarDecls.cs:7:27:7:33 | access to parameter strings | semmle.label | successor |
-| VarDecls.cs:7:22:7:36 | Char* c1 = ... | VarDecls.cs:7:39:7:40 | access to local variable c2 | semmle.label | successor |
+| VarDecls.cs:7:9:10:9 | fixed(...) { ... } | VarDecls.cs:7:27:7:33 | access to parameter strings | semmle.label | successor |
+| VarDecls.cs:7:22:7:36 | Char* c1 = ... | VarDecls.cs:7:44:7:50 | access to parameter strings | semmle.label | successor |
 | VarDecls.cs:7:27:7:33 | access to parameter strings | VarDecls.cs:7:35:7:35 | 0 | semmle.label | successor |
 | VarDecls.cs:7:27:7:36 | access to array element | VarDecls.cs:7:22:7:36 | Char* c1 = ... | semmle.label | successor |
 | VarDecls.cs:7:35:7:35 | 0 | VarDecls.cs:7:27:7:36 | access to array element | semmle.label | successor |
-| VarDecls.cs:7:39:7:40 | access to local variable c2 | VarDecls.cs:7:44:7:50 | access to parameter strings | semmle.label | successor |
 | VarDecls.cs:7:39:7:53 | Char* c2 = ... | VarDecls.cs:8:9:10:9 | {...} | semmle.label | successor |
 | VarDecls.cs:7:44:7:50 | access to parameter strings | VarDecls.cs:7:52:7:52 | 1 | semmle.label | successor |
 | VarDecls.cs:7:44:7:53 | access to array element | VarDecls.cs:7:39:7:53 | Char* c2 = ... | semmle.label | successor |
@@ -1753,11 +1688,9 @@
 | VarDecls.cs:9:27:9:28 | access to local variable c1 | VarDecls.cs:9:20:9:28 | (...) ... | semmle.label | successor |
 | VarDecls.cs:13:12:13:13 | enter M2 | VarDecls.cs:14:5:17:5 | {...} | semmle.label | successor |
 | VarDecls.cs:14:5:17:5 | {...} | VarDecls.cs:15:9:15:30 | ... ...; | semmle.label | successor |
-| VarDecls.cs:15:9:15:30 | ... ...; | VarDecls.cs:15:16:15:17 | access to local variable s1 | semmle.label | successor |
-| VarDecls.cs:15:16:15:17 | access to local variable s1 | VarDecls.cs:15:21:15:21 | access to parameter s | semmle.label | successor |
-| VarDecls.cs:15:16:15:21 | String s1 = ... | VarDecls.cs:15:24:15:25 | access to local variable s2 | semmle.label | successor |
+| VarDecls.cs:15:9:15:30 | ... ...; | VarDecls.cs:15:21:15:21 | access to parameter s | semmle.label | successor |
+| VarDecls.cs:15:16:15:21 | String s1 = ... | VarDecls.cs:15:29:15:29 | access to parameter s | semmle.label | successor |
 | VarDecls.cs:15:21:15:21 | access to parameter s | VarDecls.cs:15:16:15:21 | String s1 = ... | semmle.label | successor |
-| VarDecls.cs:15:24:15:25 | access to local variable s2 | VarDecls.cs:15:29:15:29 | access to parameter s | semmle.label | successor |
 | VarDecls.cs:15:24:15:29 | String s2 = ... | VarDecls.cs:16:16:16:17 | access to local variable s1 | semmle.label | successor |
 | VarDecls.cs:15:29:15:29 | access to parameter s | VarDecls.cs:15:24:15:29 | String s2 = ... | semmle.label | successor |
 | VarDecls.cs:16:9:16:23 | return ...; | VarDecls.cs:13:12:13:13 | exit M2 | semmle.label | return |
@@ -1769,11 +1702,9 @@
 | VarDecls.cs:21:9:22:13 | using (...) {...} | VarDecls.cs:21:16:21:22 | object creation of type C | semmle.label | successor |
 | VarDecls.cs:21:16:21:22 | object creation of type C | VarDecls.cs:22:13:22:13 | ; | semmle.label | successor |
 | VarDecls.cs:22:13:22:13 | ; | VarDecls.cs:24:9:25:29 | using (...) {...} | semmle.label | successor |
-| VarDecls.cs:24:9:25:29 | using (...) {...} | VarDecls.cs:24:18:24:18 | access to local variable x | semmle.label | successor |
-| VarDecls.cs:24:18:24:18 | access to local variable x | VarDecls.cs:24:22:24:28 | object creation of type C | semmle.label | successor |
-| VarDecls.cs:24:18:24:28 | C x = ... | VarDecls.cs:24:31:24:31 | access to local variable y | semmle.label | successor |
+| VarDecls.cs:24:9:25:29 | using (...) {...} | VarDecls.cs:24:22:24:28 | object creation of type C | semmle.label | successor |
+| VarDecls.cs:24:18:24:28 | C x = ... | VarDecls.cs:24:35:24:41 | object creation of type C | semmle.label | successor |
 | VarDecls.cs:24:22:24:28 | object creation of type C | VarDecls.cs:24:18:24:28 | C x = ... | semmle.label | successor |
-| VarDecls.cs:24:31:24:31 | access to local variable y | VarDecls.cs:24:35:24:41 | object creation of type C | semmle.label | successor |
 | VarDecls.cs:24:31:24:41 | C y = ... | VarDecls.cs:25:20:25:28 | ... ? ... : ... | semmle.label | successor |
 | VarDecls.cs:24:35:24:41 | object creation of type C | VarDecls.cs:24:31:24:41 | C y = ... | semmle.label | successor |
 | VarDecls.cs:25:13:25:29 | return ...; | VarDecls.cs:19:7:19:8 | exit M3 | semmle.label | return |
@@ -1786,14 +1717,12 @@
 | VarDecls.cs:28:51:28:53 | {...} | VarDecls.cs:28:41:28:47 | exit Dispose | semmle.label | successor |
 | cflow.cs:5:17:5:20 | enter Main | cflow.cs:6:5:35:5 | {...} | semmle.label | successor |
 | cflow.cs:6:5:35:5 | {...} | cflow.cs:7:9:7:28 | ... ...; | semmle.label | successor |
-| cflow.cs:7:9:7:28 | ... ...; | cflow.cs:7:13:7:13 | access to local variable a | semmle.label | successor |
-| cflow.cs:7:13:7:13 | access to local variable a | cflow.cs:7:17:7:20 | access to parameter args | semmle.label | successor |
+| cflow.cs:7:9:7:28 | ... ...; | cflow.cs:7:17:7:20 | access to parameter args | semmle.label | successor |
 | cflow.cs:7:13:7:27 | Int32 a = ... | cflow.cs:9:9:9:40 | ...; | semmle.label | successor |
 | cflow.cs:7:17:7:20 | access to parameter args | cflow.cs:7:17:7:27 | access to property Length | semmle.label | successor |
 | cflow.cs:7:17:7:27 | access to property Length | cflow.cs:7:13:7:27 | Int32 a = ... | semmle.label | successor |
-| cflow.cs:9:9:9:9 | access to local variable a | cflow.cs:9:13:9:29 | object creation of type ControlFlow | semmle.label | successor |
 | cflow.cs:9:9:9:39 | ... = ... | cflow.cs:11:9:12:49 | if (...) ... | semmle.label | successor |
-| cflow.cs:9:9:9:40 | ...; | cflow.cs:9:9:9:9 | access to local variable a | semmle.label | successor |
+| cflow.cs:9:9:9:40 | ...; | cflow.cs:9:13:9:29 | object creation of type ControlFlow | semmle.label | successor |
 | cflow.cs:9:13:9:29 | object creation of type ControlFlow | cflow.cs:9:38:9:38 | access to local variable a | semmle.label | successor |
 | cflow.cs:9:13:9:39 | call to method Switch | cflow.cs:9:9:9:39 | ... = ... | semmle.label | successor |
 | cflow.cs:9:38:9:38 | access to local variable a | cflow.cs:9:13:9:39 | call to method Switch | semmle.label | successor |
@@ -1828,8 +1757,7 @@
 | cflow.cs:22:18:22:23 | ... < ... | cflow.cs:20:9:22:9 | {...} | semmle.label | true |
 | cflow.cs:22:18:22:23 | ... < ... | cflow.cs:24:9:34:9 | for (...;...;...) ... | semmle.label | false |
 | cflow.cs:22:22:22:23 | 10 | cflow.cs:22:18:22:23 | ... < ... | semmle.label | successor |
-| cflow.cs:24:9:34:9 | for (...;...;...) ... | cflow.cs:24:18:24:18 | access to local variable i | semmle.label | successor |
-| cflow.cs:24:18:24:18 | access to local variable i | cflow.cs:24:22:24:22 | 1 | semmle.label | successor |
+| cflow.cs:24:9:34:9 | for (...;...;...) ... | cflow.cs:24:22:24:22 | 1 | semmle.label | successor |
 | cflow.cs:24:18:24:22 | Int32 i = ... | cflow.cs:24:25:24:25 | access to local variable i | semmle.label | successor |
 | cflow.cs:24:22:24:22 | 1 | cflow.cs:24:18:24:22 | Int32 i = ... | semmle.label | successor |
 | cflow.cs:24:25:24:25 | access to local variable i | cflow.cs:24:30:24:31 | 20 | semmle.label | successor |
@@ -2039,13 +1967,11 @@
 | cflow.cs:116:27:116:27 | access to parameter s | cflow.cs:116:9:116:28 | call to method WriteLine | semmle.label | successor |
 | cflow.cs:119:20:119:21 | enter M5 | cflow.cs:120:5:124:5 | {...} | semmle.label | successor |
 | cflow.cs:120:5:124:5 | {...} | cflow.cs:121:9:121:18 | ... ...; | semmle.label | successor |
-| cflow.cs:121:9:121:18 | ... ...; | cflow.cs:121:13:121:13 | access to local variable x | semmle.label | successor |
-| cflow.cs:121:13:121:13 | access to local variable x | cflow.cs:121:17:121:17 | access to parameter s | semmle.label | successor |
+| cflow.cs:121:9:121:18 | ... ...; | cflow.cs:121:17:121:17 | access to parameter s | semmle.label | successor |
 | cflow.cs:121:13:121:17 | String x = ... | cflow.cs:122:9:122:20 | ...; | semmle.label | successor |
 | cflow.cs:121:17:121:17 | access to parameter s | cflow.cs:121:13:121:17 | String x = ... | semmle.label | successor |
-| cflow.cs:122:9:122:9 | access to local variable x | cflow.cs:122:13:122:13 | access to local variable x | semmle.label | successor |
 | cflow.cs:122:9:122:19 | ... = ... | cflow.cs:123:16:123:16 | access to local variable x | semmle.label | successor |
-| cflow.cs:122:9:122:20 | ...; | cflow.cs:122:9:122:9 | access to local variable x | semmle.label | successor |
+| cflow.cs:122:9:122:20 | ...; | cflow.cs:122:13:122:13 | access to local variable x | semmle.label | successor |
 | cflow.cs:122:13:122:13 | access to local variable x | cflow.cs:122:17:122:19 | " " | semmle.label | successor |
 | cflow.cs:122:13:122:19 | ... + ... | cflow.cs:122:9:122:19 | ... = ... | semmle.label | successor |
 | cflow.cs:122:17:122:19 | " " | cflow.cs:122:13:122:19 | ... + ... | semmle.label | successor |
@@ -2065,15 +1991,13 @@
 | cflow.cs:127:53:127:57 | this access | cflow.cs:127:53:127:57 | access to field Field | semmle.label | successor |
 | cflow.cs:127:62:127:64 | enter set_Prop | cflow.cs:127:66:127:83 | {...} | semmle.label | successor |
 | cflow.cs:127:66:127:83 | {...} | cflow.cs:127:68:127:81 | ...; | semmle.label | successor |
-| cflow.cs:127:68:127:72 | access to field Field | cflow.cs:127:76:127:80 | access to parameter value | semmle.label | successor |
-| cflow.cs:127:68:127:72 | this access | cflow.cs:127:68:127:72 | access to field Field | semmle.label | successor |
+| cflow.cs:127:68:127:72 | this access | cflow.cs:127:76:127:80 | access to parameter value | semmle.label | successor |
 | cflow.cs:127:68:127:80 | ... = ... | cflow.cs:127:62:127:64 | exit set_Prop | semmle.label | successor |
 | cflow.cs:127:68:127:81 | ...; | cflow.cs:127:68:127:72 | this access | semmle.label | successor |
 | cflow.cs:127:76:127:80 | access to parameter value | cflow.cs:127:68:127:80 | ... = ... | semmle.label | successor |
 | cflow.cs:129:5:129:15 | enter ControlFlow | cflow.cs:130:5:132:5 | {...} | semmle.label | successor |
 | cflow.cs:130:5:132:5 | {...} | cflow.cs:131:9:131:18 | ...; | semmle.label | successor |
-| cflow.cs:131:9:131:13 | access to field Field | cflow.cs:131:17:131:17 | access to parameter s | semmle.label | successor |
-| cflow.cs:131:9:131:13 | this access | cflow.cs:131:9:131:13 | access to field Field | semmle.label | successor |
+| cflow.cs:131:9:131:13 | this access | cflow.cs:131:17:131:17 | access to parameter s | semmle.label | successor |
 | cflow.cs:131:9:131:17 | ... = ... | cflow.cs:129:5:129:15 | exit ControlFlow | semmle.label | successor |
 | cflow.cs:131:9:131:18 | ...; | cflow.cs:131:9:131:13 | this access | semmle.label | successor |
 | cflow.cs:131:17:131:17 | access to parameter s | cflow.cs:131:9:131:17 | ... = ... | semmle.label | successor |
@@ -2225,8 +2149,7 @@
 | cflow.cs:203:31:203:39 | [finally: exception(IOException)] "Finally" | cflow.cs:203:13:203:40 | [finally: exception(IOException)] call to method WriteLine | semmle.label | successor |
 | cflow.cs:203:31:203:39 | [finally: exception(OutOfMemoryException)] "Finally" | cflow.cs:203:13:203:40 | [finally: exception(OutOfMemoryException)] call to method WriteLine | semmle.label | successor |
 | cflow.cs:203:31:203:39 | [finally: return] "Finally" | cflow.cs:203:13:203:40 | [finally: return] call to method WriteLine | semmle.label | successor |
-| cflow.cs:206:9:206:19 | ... ...; | cflow.cs:206:13:206:13 | access to local variable i | semmle.label | successor |
-| cflow.cs:206:13:206:13 | access to local variable i | cflow.cs:206:17:206:18 | 10 | semmle.label | successor |
+| cflow.cs:206:9:206:19 | ... ...; | cflow.cs:206:17:206:18 | 10 | semmle.label | successor |
 | cflow.cs:206:13:206:18 | Int32 i = ... | cflow.cs:207:9:230:9 | while (...) ... | semmle.label | successor |
 | cflow.cs:206:17:206:18 | 10 | cflow.cs:206:13:206:18 | Int32 i = ... | semmle.label | successor |
 | cflow.cs:207:9:230:9 | while (...) ... | cflow.cs:207:16:207:16 | access to local variable i | semmle.label | successor |
@@ -2462,8 +2385,7 @@
 | cflow.cs:244:35:244:35 | [finally: return] 1 | cflow.cs:244:17:244:36 | [finally: return] call to method WriteLine | semmle.label | successor |
 | cflow.cs:247:9:254:9 | try {...} ... | cflow.cs:248:9:250:9 | {...} | semmle.label | successor |
 | cflow.cs:248:9:250:9 | {...} | cflow.cs:249:13:249:41 | ... ...; | semmle.label | successor |
-| cflow.cs:249:13:249:41 | ... ...; | cflow.cs:249:17:249:20 | access to local variable temp | semmle.label | successor |
-| cflow.cs:249:17:249:20 | access to local variable temp | cflow.cs:249:24:249:24 | 0 | semmle.label | successor |
+| cflow.cs:249:13:249:41 | ... ...; | cflow.cs:249:24:249:24 | 0 | semmle.label | successor |
 | cflow.cs:249:17:249:40 | Double temp = ... | cflow.cs:146:10:146:19 | exit TryFinally | semmle.label | successor |
 | cflow.cs:249:24:249:24 | 0 | cflow.cs:249:24:249:24 | (...) ... | semmle.label | successor |
 | cflow.cs:249:24:249:24 | (...) ... | cflow.cs:249:28:249:40 | access to constant E | semmle.label | successor |
@@ -2471,8 +2393,7 @@
 | cflow.cs:249:28:249:40 | access to constant E | cflow.cs:249:24:249:40 | ... / ... | semmle.label | successor |
 | cflow.cs:257:10:257:12 | enter For | cflow.cs:258:5:288:5 | {...} | semmle.label | successor |
 | cflow.cs:258:5:288:5 | {...} | cflow.cs:259:9:259:18 | ... ...; | semmle.label | successor |
-| cflow.cs:259:9:259:18 | ... ...; | cflow.cs:259:13:259:13 | access to local variable x | semmle.label | successor |
-| cflow.cs:259:13:259:13 | access to local variable x | cflow.cs:259:17:259:17 | 0 | semmle.label | successor |
+| cflow.cs:259:9:259:18 | ... ...; | cflow.cs:259:17:259:17 | 0 | semmle.label | successor |
 | cflow.cs:259:13:259:17 | Int32 x = ... | cflow.cs:260:9:261:33 | for (...;...;...) ... | semmle.label | successor |
 | cflow.cs:259:17:259:17 | 0 | cflow.cs:259:13:259:17 | Int32 x = ... | semmle.label | successor |
 | cflow.cs:260:9:261:33 | for (...;...;...) ... | cflow.cs:260:16:260:16 | access to local variable x | semmle.label | successor |
@@ -2524,11 +2445,9 @@
 | cflow.cs:281:13:281:13 | access to local variable x | cflow.cs:281:13:281:15 | ...++ | semmle.label | successor |
 | cflow.cs:281:13:281:15 | ...++ | cflow.cs:278:16:278:16 | access to local variable x | semmle.label | successor |
 | cflow.cs:281:13:281:16 | ...; | cflow.cs:281:13:281:13 | access to local variable x | semmle.label | successor |
-| cflow.cs:284:9:287:9 | for (...;...;...) ... | cflow.cs:284:18:284:18 | access to local variable i | semmle.label | successor |
-| cflow.cs:284:18:284:18 | access to local variable i | cflow.cs:284:22:284:22 | 0 | semmle.label | successor |
-| cflow.cs:284:18:284:22 | Int32 i = ... | cflow.cs:284:25:284:25 | access to local variable j | semmle.label | successor |
+| cflow.cs:284:9:287:9 | for (...;...;...) ... | cflow.cs:284:22:284:22 | 0 | semmle.label | successor |
+| cflow.cs:284:18:284:22 | Int32 i = ... | cflow.cs:284:29:284:29 | 0 | semmle.label | successor |
 | cflow.cs:284:22:284:22 | 0 | cflow.cs:284:18:284:22 | Int32 i = ... | semmle.label | successor |
-| cflow.cs:284:25:284:25 | access to local variable j | cflow.cs:284:29:284:29 | 0 | semmle.label | successor |
 | cflow.cs:284:25:284:29 | Int32 j = ... | cflow.cs:284:32:284:32 | access to local variable i | semmle.label | successor |
 | cflow.cs:284:29:284:29 | 0 | cflow.cs:284:25:284:29 | Int32 j = ... | semmle.label | successor |
 | cflow.cs:284:32:284:32 | access to local variable i | cflow.cs:284:36:284:36 | access to local variable j | semmle.label | successor |
@@ -2549,16 +2468,14 @@
 | cflow.cs:286:35:286:35 | access to local variable j | cflow.cs:286:31:286:35 | ... + ... | semmle.label | successor |
 | cflow.cs:290:10:290:16 | enter Lambdas | cflow.cs:291:5:294:5 | {...} | semmle.label | successor |
 | cflow.cs:291:5:294:5 | {...} | cflow.cs:292:9:292:38 | ... ...; | semmle.label | successor |
-| cflow.cs:292:9:292:38 | ... ...; | cflow.cs:292:24:292:24 | access to local variable y | semmle.label | successor |
-| cflow.cs:292:24:292:24 | access to local variable y | cflow.cs:292:28:292:37 | (...) => ... | semmle.label | successor |
+| cflow.cs:292:9:292:38 | ... ...; | cflow.cs:292:28:292:37 | (...) => ... | semmle.label | successor |
 | cflow.cs:292:24:292:37 | Func<Int32,Int32> y = ... | cflow.cs:293:9:293:62 | ... ...; | semmle.label | successor |
 | cflow.cs:292:28:292:37 | (...) => ... | cflow.cs:292:24:292:37 | Func<Int32,Int32> y = ... | semmle.label | successor |
 | cflow.cs:292:28:292:37 | enter (...) => ... | cflow.cs:292:33:292:33 | access to parameter x | semmle.label | successor |
 | cflow.cs:292:33:292:33 | access to parameter x | cflow.cs:292:37:292:37 | 1 | semmle.label | successor |
 | cflow.cs:292:33:292:37 | ... + ... | cflow.cs:292:28:292:37 | exit (...) => ... | semmle.label | successor |
 | cflow.cs:292:37:292:37 | 1 | cflow.cs:292:33:292:37 | ... + ... | semmle.label | successor |
-| cflow.cs:293:9:293:62 | ... ...; | cflow.cs:293:24:293:24 | access to local variable z | semmle.label | successor |
-| cflow.cs:293:24:293:24 | access to local variable z | cflow.cs:293:28:293:61 | delegate(...) { ... } | semmle.label | successor |
+| cflow.cs:293:9:293:62 | ... ...; | cflow.cs:293:28:293:61 | delegate(...) { ... } | semmle.label | successor |
 | cflow.cs:293:24:293:61 | Func<Int32,Int32> z = ... | cflow.cs:290:10:290:16 | exit Lambdas | semmle.label | successor |
 | cflow.cs:293:28:293:61 | delegate(...) { ... } | cflow.cs:293:24:293:61 | Func<Int32,Int32> z = ... | semmle.label | successor |
 | cflow.cs:293:28:293:61 | enter delegate(...) { ... } | cflow.cs:293:45:293:61 | {...} | semmle.label | successor |
@@ -2587,8 +2504,7 @@
 | cflow.cs:301:31:301:50 | "This should happen" | cflow.cs:301:13:301:51 | call to method WriteLine | semmle.label | successor |
 | cflow.cs:304:10:304:17 | enter Booleans | cflow.cs:305:5:317:5 | {...} | semmle.label | successor |
 | cflow.cs:305:5:317:5 | {...} | cflow.cs:306:9:306:57 | ... ...; | semmle.label | successor |
-| cflow.cs:306:9:306:57 | ... ...; | cflow.cs:306:13:306:13 | access to local variable b | semmle.label | successor |
-| cflow.cs:306:13:306:13 | access to local variable b | cflow.cs:306:17:306:56 | ... && ... | semmle.label | successor |
+| cflow.cs:306:9:306:57 | ... ...; | cflow.cs:306:17:306:56 | ... && ... | semmle.label | successor |
 | cflow.cs:306:13:306:56 | Boolean b = ... | cflow.cs:308:9:309:49 | if (...) ... | semmle.label | successor |
 | cflow.cs:306:17:306:21 | access to field Field | cflow.cs:306:17:306:28 | access to property Length | semmle.label | successor |
 | cflow.cs:306:17:306:21 | this access | cflow.cs:306:17:306:21 | access to field Field | semmle.label | successor |
@@ -2614,9 +2530,8 @@
 | cflow.cs:308:31:308:31 | 0 | cflow.cs:308:15:308:31 | ... == ... | semmle.label | successor |
 | cflow.cs:308:35:308:39 | false | cflow.cs:309:13:309:49 | ...; | semmle.label | false |
 | cflow.cs:308:43:308:46 | true | cflow.cs:311:9:316:9 | if (...) ... | semmle.label | true |
-| cflow.cs:309:13:309:13 | access to local variable b | cflow.cs:309:17:309:48 | ... ? ... : ... | semmle.label | successor |
 | cflow.cs:309:13:309:48 | ... = ... | cflow.cs:311:9:316:9 | if (...) ... | semmle.label | successor |
-| cflow.cs:309:13:309:49 | ...; | cflow.cs:309:13:309:13 | access to local variable b | semmle.label | successor |
+| cflow.cs:309:13:309:49 | ...; | cflow.cs:309:17:309:48 | ... ? ... : ... | semmle.label | successor |
 | cflow.cs:309:17:309:21 | access to field Field | cflow.cs:309:17:309:28 | access to property Length | semmle.label | successor |
 | cflow.cs:309:17:309:21 | this access | cflow.cs:309:17:309:21 | access to field Field | semmle.label | successor |
 | cflow.cs:309:17:309:28 | access to property Length | cflow.cs:309:33:309:33 | 0 | semmle.label | successor |
@@ -2654,10 +2569,9 @@
 | cflow.cs:320:5:333:5 | {...} | cflow.cs:321:9:332:36 | do ... while (...); | semmle.label | successor |
 | cflow.cs:321:9:332:36 | do ... while (...); | cflow.cs:322:9:332:9 | {...} | semmle.label | successor |
 | cflow.cs:322:9:332:9 | {...} | cflow.cs:323:13:323:25 | ...; | semmle.label | successor |
-| cflow.cs:323:13:323:17 | access to field Field | cflow.cs:323:13:323:17 | this access | semmle.label | successor |
 | cflow.cs:323:13:323:17 | access to field Field | cflow.cs:323:22:323:24 | "a" | semmle.label | successor |
 | cflow.cs:323:13:323:17 | this access | cflow.cs:323:13:323:17 | access to field Field | semmle.label | successor |
-| cflow.cs:323:13:323:17 | this access | cflow.cs:323:13:323:17 | access to field Field | semmle.label | successor |
+| cflow.cs:323:13:323:17 | this access | cflow.cs:323:13:323:17 | this access | semmle.label | successor |
 | cflow.cs:323:13:323:24 | ... + ... | cflow.cs:323:13:323:24 | ... = ... | semmle.label | successor |
 | cflow.cs:323:13:323:24 | ... = ... | cflow.cs:324:13:327:13 | if (...) ... | semmle.label | successor |
 | cflow.cs:323:13:323:25 | ...; | cflow.cs:323:13:323:17 | this access | semmle.label | successor |
@@ -2695,10 +2609,9 @@
 | cflow.cs:337:57:337:59 | "a" | cflow.cs:337:62:337:63 | 10 | semmle.label | successor |
 | cflow.cs:337:62:337:63 | 10 | cflow.cs:337:27:337:64 | call to method Repeat | semmle.label | successor |
 | cflow.cs:338:9:348:9 | {...} | cflow.cs:339:13:339:23 | ...; | semmle.label | successor |
-| cflow.cs:339:13:339:17 | access to field Field | cflow.cs:339:13:339:17 | this access | semmle.label | successor |
 | cflow.cs:339:13:339:17 | access to field Field | cflow.cs:339:22:339:22 | access to local variable x | semmle.label | successor |
 | cflow.cs:339:13:339:17 | this access | cflow.cs:339:13:339:17 | access to field Field | semmle.label | successor |
-| cflow.cs:339:13:339:17 | this access | cflow.cs:339:13:339:17 | access to field Field | semmle.label | successor |
+| cflow.cs:339:13:339:17 | this access | cflow.cs:339:13:339:17 | this access | semmle.label | successor |
 | cflow.cs:339:13:339:22 | ... + ... | cflow.cs:339:13:339:22 | ... = ... | semmle.label | successor |
 | cflow.cs:339:13:339:22 | ... = ... | cflow.cs:340:13:343:13 | if (...) ... | semmle.label | successor |
 | cflow.cs:339:13:339:23 | ...; | cflow.cs:339:13:339:17 | this access | semmle.label | successor |
@@ -2772,8 +2685,7 @@
 | cflow.cs:373:5:388:5 | {...} | cflow.cs:374:22:374:22 | 0 | semmle.label | successor |
 | cflow.cs:374:9:374:23 | yield return ...; | cflow.cs:375:9:378:9 | for (...;...;...) ... | semmle.label | successor |
 | cflow.cs:374:22:374:22 | 0 | cflow.cs:374:9:374:23 | yield return ...; | semmle.label | successor |
-| cflow.cs:375:9:378:9 | for (...;...;...) ... | cflow.cs:375:18:375:18 | access to local variable i | semmle.label | successor |
-| cflow.cs:375:18:375:18 | access to local variable i | cflow.cs:375:22:375:22 | 1 | semmle.label | successor |
+| cflow.cs:375:9:378:9 | for (...;...;...) ... | cflow.cs:375:22:375:22 | 1 | semmle.label | successor |
 | cflow.cs:375:18:375:22 | Int32 i = ... | cflow.cs:375:25:375:25 | access to local variable i | semmle.label | successor |
 | cflow.cs:375:22:375:22 | 1 | cflow.cs:375:18:375:22 | Int32 i = ... | semmle.label | successor |
 | cflow.cs:375:25:375:25 | access to local variable i | cflow.cs:375:29:375:30 | 10 | semmle.label | successor |

--- a/csharp/ql/test/library-tests/csharp7/LocalTaintFlow.expected
+++ b/csharp/ql/test/library-tests/csharp7/LocalTaintFlow.expected
@@ -17,7 +17,6 @@
 | CSharp7.cs:72:13:72:19 | SSA def(z) | CSharp7.cs:75:16:75:16 | access to local variable z |
 | CSharp7.cs:72:17:72:19 | call to method F | CSharp7.cs:72:13:72:19 | SSA def(z) |
 | CSharp7.cs:74:13:74:15 | call to method F | CSharp7.cs:74:13:74:21 | access to field Item1 |
-| CSharp7.cs:75:16:75:16 | access to local variable z | CSharp7.cs:75:16:75:22 | access to field Item1 |
 | CSharp7.cs:75:16:75:16 | access to local variable z | CSharp7.cs:77:39:77:39 | access to local variable z |
 | CSharp7.cs:75:28:75:28 | 1 | CSharp7.cs:75:27:75:35 | (..., ...) |
 | CSharp7.cs:75:31:75:31 | 2 | CSharp7.cs:75:27:75:35 | (..., ...) |
@@ -82,7 +81,6 @@
 | CSharp7.cs:114:61:114:66 | (..., ...) | CSharp7.cs:114:49:114:67 | (..., ...) |
 | CSharp7.cs:114:62:114:62 | 0 | CSharp7.cs:114:61:114:66 | (..., ...) |
 | CSharp7.cs:114:65:114:65 | 1 | CSharp7.cs:114:61:114:66 | (..., ...) |
-| CSharp7.cs:118:9:118:10 | access to local variable m2 | CSharp7.cs:118:9:118:16 | access to field Item2 |
 | CSharp7.cs:118:9:118:10 | access to local variable m2 | CSharp7.cs:119:19:119:20 | access to local variable m2 |
 | CSharp7.cs:119:19:119:20 | access to local variable m2 | CSharp7.cs:119:19:119:26 | access to field Item1 |
 | CSharp7.cs:123:28:123:36 | "DefUse3" | CSharp7.cs:123:22:123:36 | ... = ... |

--- a/csharp/ql/test/library-tests/dataflow/local/TaintTrackingStep.expected
+++ b/csharp/ql/test/library-tests/dataflow/local/TaintTrackingStep.expected
@@ -38,7 +38,6 @@
 | LocalDataFlow.cs:69:21:69:51 | object creation of type Dictionary<Int32,String[]> | LocalDataFlow.cs:69:13:69:51 | SSA def(sink2) |
 | LocalDataFlow.cs:70:9:70:13 | access to local variable sink2 | LocalDataFlow.cs:70:9:70:16 | access to indexer |
 | LocalDataFlow.cs:70:9:70:13 | access to local variable sink2 | LocalDataFlow.cs:71:15:71:19 | access to local variable sink2 |
-| LocalDataFlow.cs:70:9:70:16 | access to indexer | LocalDataFlow.cs:70:9:70:19 | access to array element |
 | LocalDataFlow.cs:70:23:70:27 | access to local variable sink1 | LocalDataFlow.cs:70:9:70:13 | access to local variable sink2 |
 | LocalDataFlow.cs:70:23:70:27 | access to local variable sink1 | LocalDataFlow.cs:70:9:70:16 | access to indexer |
 | LocalDataFlow.cs:70:23:70:27 | access to local variable sink1 | LocalDataFlow.cs:76:18:76:22 | access to local variable sink1 |
@@ -861,9 +860,7 @@
 | Splitting.cs:51:17:51:36 | [b (line 46): true] array creation of type String[] | Splitting.cs:51:13:51:36 | [b (line 46): true] SSA def(y) |
 | Splitting.cs:51:32:51:34 | [b (line 46): false] "a" | Splitting.cs:51:17:51:36 | [b (line 46): false] array creation of type String[] |
 | Splitting.cs:51:32:51:34 | [b (line 46): true] "a" | Splitting.cs:51:17:51:36 | [b (line 46): true] array creation of type String[] |
-| Splitting.cs:52:9:52:9 | [b (line 46): false] access to local variable y | Splitting.cs:52:9:52:12 | [b (line 46): false] access to array element |
 | Splitting.cs:52:9:52:9 | [b (line 46): false] access to local variable y | Splitting.cs:53:17:53:17 | [b (line 46): false] access to local variable y |
-| Splitting.cs:52:9:52:9 | [b (line 46): true] access to local variable y | Splitting.cs:52:9:52:12 | [b (line 46): true] access to array element |
 | Splitting.cs:52:9:52:9 | [b (line 46): true] access to local variable y | Splitting.cs:53:17:53:17 | [b (line 46): true] access to local variable y |
 | Splitting.cs:52:16:52:18 | [b (line 46): false] "b" | Splitting.cs:52:9:52:9 | [b (line 46): false] access to local variable y |
 | Splitting.cs:52:16:52:18 | [b (line 46): true] "b" | Splitting.cs:52:9:52:9 | [b (line 46): true] access to local variable y |

--- a/csharp/ql/test/library-tests/goto/Goto1.expected
+++ b/csharp/ql/test/library-tests/goto/Goto1.expected
@@ -4,8 +4,7 @@
 | goto.cs:7:13:7:14 | s1: | goto.cs:7:17:7:24 | goto ...; | semmle.label | successor |
 | goto.cs:7:17:7:24 | goto ...; | goto.cs:9:9:9:10 | s2: | semmle.label | goto(s2) |
 | goto.cs:9:9:9:10 | s2: | goto.cs:9:13:9:27 | ... ...; | semmle.label | successor |
-| goto.cs:9:13:9:27 | ... ...; | goto.cs:9:20:9:20 | access to local variable s | semmle.label | successor |
-| goto.cs:9:20:9:20 | access to local variable s | goto.cs:9:24:9:26 | "5" | semmle.label | successor |
+| goto.cs:9:13:9:27 | ... ...; | goto.cs:9:24:9:26 | "5" | semmle.label | successor |
 | goto.cs:9:20:9:26 | String s = ... | goto.cs:10:9:18:9 | switch (...) {...} | semmle.label | successor |
 | goto.cs:9:24:9:26 | "5" | goto.cs:9:20:9:26 | String s = ... | semmle.label | successor |
 | goto.cs:10:9:18:9 | switch (...) {...} | goto.cs:10:17:10:17 | access to local variable s | semmle.label | successor |

--- a/csharp/ql/test/library-tests/security/dataflow/flowsources/StoredFlowSources.expected
+++ b/csharp/ql/test/library-tests/security/dataflow/flowsources/StoredFlowSources.expected
@@ -1,4 +1,3 @@
-| data.cs:22:29:22:42 | access to local variable customerReader |
 | data.cs:22:29:22:76 | OleDbDataReader customerReader = ... |
 | data.cs:22:46:22:76 | call to method ExecuteReader |
 | data.cs:25:20:25:33 | access to local variable customerReader |
@@ -11,13 +10,11 @@
 | data.cs:29:51:29:71 | access to indexer |
 | data.cs:31:13:31:26 | access to local variable customerReader |
 | data.cs:31:13:31:34 | call to method Close |
-| entity.cs:32:29:32:33 | access to local variable blogs |
 | entity.cs:32:29:32:82 | DbRawSqlQuery<Blog> blogs = ... |
 | entity.cs:32:37:32:82 | call to method SqlQuery |
 | entity.cs:33:30:33:34 | access to local variable blogs |
 | entity.cs:36:31:36:34 | access to local variable blog |
 | entity.cs:36:31:36:39 | access to property Name |
-| entity.cs:39:31:39:39 | access to local variable blogNames |
 | entity.cs:39:31:39:93 | DbRawSqlQuery<String> blogNames = ... |
 | entity.cs:39:43:39:93 | call to method SqlQuery |
 | entity.cs:40:34:40:42 | access to local variable blogNames |

--- a/csharp/ql/test/library-tests/standalone/controlflow/cfg.expected
+++ b/csharp/ql/test/library-tests/standalone/controlflow/cfg.expected
@@ -1,13 +1,17 @@
 | ControlFlow.cs:7:10:7:10 | enter F | ControlFlow.cs:8:5:13:5 | {...} |
 | ControlFlow.cs:8:5:13:5 | {...} | ControlFlow.cs:9:9:9:34 | ... ...; |
-| ControlFlow.cs:9:9:9:34 | ... ...; | ControlFlow.cs:9:13:9:13 | access to local variable v |
+| ControlFlow.cs:9:9:9:34 | ... ...; | ControlFlow.cs:9:17:9:33 | Call (unknown target) |
+| ControlFlow.cs:9:13:9:33 | (unknown type) v | ControlFlow.cs:10:9:10:44 | ...; |
+| ControlFlow.cs:9:17:9:33 | Call (unknown target) | ControlFlow.cs:9:13:9:33 | (unknown type) v |
 | ControlFlow.cs:10:9:10:13 | Expression | ControlFlow.cs:10:22:10:22 | access to local variable v |
-| ControlFlow.cs:10:9:10:43 | Call to unknown method | ControlFlow.cs:12:9:12:87 | ...; |
+| ControlFlow.cs:10:9:10:43 | Call (unknown target) | ControlFlow.cs:12:9:12:87 | ...; |
 | ControlFlow.cs:10:9:10:44 | ...; | ControlFlow.cs:10:9:10:13 | Expression |
 | ControlFlow.cs:10:22:10:22 | access to local variable v | ControlFlow.cs:10:22:10:24 | Expression |
 | ControlFlow.cs:10:22:10:24 | Expression | ControlFlow.cs:10:22:10:26 | Expression |
 | ControlFlow.cs:10:22:10:26 | Expression | ControlFlow.cs:10:29:10:42 | "This is true" |
-| ControlFlow.cs:10:29:10:42 | "This is true" | ControlFlow.cs:10:9:10:43 | Call to unknown method |
+| ControlFlow.cs:10:29:10:42 | "This is true" | ControlFlow.cs:10:9:10:43 | Call (unknown target) |
+| ControlFlow.cs:12:9:12:86 | Call (unknown target) | ControlFlow.cs:12:37:12:47 | Expression |
+| ControlFlow.cs:12:9:12:87 | ...; | ControlFlow.cs:12:9:12:86 | Call (unknown target) |
 | ControlFlow.cs:12:35:12:86 | { ..., ... } | ControlFlow.cs:7:10:7:10 | exit F |
 | ControlFlow.cs:12:37:12:47 | Expression | ControlFlow.cs:12:51:12:62 | access to field Empty |
 | ControlFlow.cs:12:37:12:62 | ... = ... | ControlFlow.cs:12:65:12:75 | Expression |

--- a/csharp/ql/test/library-tests/standalone/controlflow/cfg.ql
+++ b/csharp/ql/test/library-tests/standalone/controlflow/cfg.ql
@@ -6,10 +6,17 @@ import semmle.code.csharp.controlflow.ControlFlowGraph
  * The purpose of this is to ensure that all MethodCall expressions
  * have a valid `toString()`.
  */
-class UnknownCall extends MethodCall {
+class UnknownCall extends Call {
   UnknownCall() { not exists(this.getTarget()) }
 
-  override string toString() { result = "Call to unknown method" }
+  override string toString() { result = "Call (unknown target)" }
 }
+
+class UnknownLocalVariableDeclExpr extends LocalVariableDeclAndInitExpr {
+  UnknownLocalVariableDeclExpr() { not exists(this.getVariable().getType().getName()) }
+
+  override string toString() { result = "(unknown type) " + this.getName() }
+}
+
 
 query predicate edges(ControlFlow::Node n1, ControlFlow::Node n2) { n2 = n1.getASuccessor() }

--- a/csharp/ql/test/query-tests/Nullness/E.cs
+++ b/csharp/ql/test/query-tests/Nullness/E.cs
@@ -308,7 +308,7 @@ public class E
     {
         if (l.HasValue)
         {
-            e.Long = l.Value; // GOOD (false positive)
+            e.Long = l.Value; // GOOD
         }
         return;
     }

--- a/csharp/ql/test/query-tests/Nullness/NullMaybe.expected
+++ b/csharp/ql/test/query-tests/Nullness/NullMaybe.expected
@@ -348,8 +348,6 @@ nodes
 | E.cs:285:9:285:9 | access to local variable o |
 | E.cs:301:13:301:27 | SSA def(s) |
 | E.cs:302:9:302:9 | access to local variable s |
-| E.cs:311:13:311:18 | SSA call def(this.l) |
-| E.cs:311:22:311:22 | access to field l |
 | Forwarding.cs:7:16:7:23 | SSA def(s) |
 | Forwarding.cs:14:9:17:9 | if (...) ... |
 | Forwarding.cs:19:9:22:9 | if (...) ... |
@@ -680,7 +678,6 @@ edges
 | E.cs:283:13:283:22 | [b (line 279): false] SSA def(o) | E.cs:285:9:285:9 | access to local variable o |
 | E.cs:283:13:283:22 | [b (line 279): true] SSA def(o) | E.cs:285:9:285:9 | access to local variable o |
 | E.cs:301:13:301:27 | SSA def(s) | E.cs:302:9:302:9 | access to local variable s |
-| E.cs:311:13:311:18 | SSA call def(this.l) | E.cs:311:22:311:22 | access to field l |
 | Forwarding.cs:7:16:7:23 | SSA def(s) | Forwarding.cs:14:9:17:9 | if (...) ... |
 | Forwarding.cs:14:9:17:9 | if (...) ... | Forwarding.cs:19:9:22:9 | if (...) ... |
 | Forwarding.cs:19:9:22:9 | if (...) ... | Forwarding.cs:24:9:27:9 | if (...) ... |
@@ -781,7 +778,6 @@ edges
 | E.cs:285:9:285:9 | access to local variable o | E.cs:283:13:283:22 | [b (line 279): false] SSA def(o) | E.cs:285:9:285:9 | access to local variable o | Variable $@ may be null here as suggested by $@ null check. | E.cs:283:13:283:13 | o | o | E.cs:284:9:284:9 | access to local variable o | this |
 | E.cs:285:9:285:9 | access to local variable o | E.cs:283:13:283:22 | [b (line 279): true] SSA def(o) | E.cs:285:9:285:9 | access to local variable o | Variable $@ may be null here as suggested by $@ null check. | E.cs:283:13:283:13 | o | o | E.cs:284:9:284:9 | access to local variable o | this |
 | E.cs:302:9:302:9 | access to local variable s | E.cs:301:13:301:27 | SSA def(s) | E.cs:302:9:302:9 | access to local variable s | Variable $@ may be null here because of $@ assignment. | E.cs:301:13:301:13 | s | s | E.cs:301:13:301:27 | String s = ... | this |
-| E.cs:311:22:311:22 | access to field l | E.cs:311:13:311:18 | SSA call def(this.l) | E.cs:311:22:311:22 | access to field l | Variable $@ may be null here because it has a nullable type. | E.cs:309:13:309:13 | this.l | this.l | E.cs:305:19:305:19 | l | this |
 | GuardedString.cs:35:31:35:31 | access to local variable s | GuardedString.cs:7:16:7:32 | SSA def(s) | GuardedString.cs:35:31:35:31 | access to local variable s | Variable $@ may be null here because of $@ assignment. | GuardedString.cs:7:16:7:16 | s | s | GuardedString.cs:7:16:7:32 | String s = ... | this |
 | NullMaybeBad.cs:7:27:7:27 | access to parameter o | NullMaybeBad.cs:13:17:13:20 | null | NullMaybeBad.cs:7:27:7:27 | access to parameter o | Variable $@ may be null here because of $@ null argument. | NullMaybeBad.cs:5:25:5:25 | o | o | NullMaybeBad.cs:13:17:13:20 | null | this |
 | StringConcatenation.cs:16:17:16:17 | access to local variable s | StringConcatenation.cs:14:16:14:23 | SSA def(s) | StringConcatenation.cs:16:17:16:17 | access to local variable s | Variable $@ may be null here because of $@ assignment. | StringConcatenation.cs:14:16:14:16 | s | s | StringConcatenation.cs:14:16:14:23 | String s = ... | this |


### PR DESCRIPTION
Write accesses in assignments, such as the access to `x` in `x = 0` are not
evaluated, so they should not have entries in the control flow graph. However,
qualifiers (and indexer arguments) should still be evaluated, for example in

```
x.Foo.Bar = 0;
```

the CFG should be `x --> x.Foo --> 0 --> x.Foo.Bar = 0` (as opposed to
`x --> x.Foo --> x.Foo.Bar --> 0 --> x.Foo.Bar = 0`, prior to this change).

A special case is assignments via acessors (properties, indexers, and event
adders), where we do want to include the access in the control flow graph,
as it represents the accessor call:

```
x.Prop = 0;
```

But instead of `x --> x.set_Prop --> 0 --> x.Prop = 0` the CFG should be
`x --> 0 --> x.set_Prop --> x.Prop = 0`, as the setter is called *after* the
assigned value has been evaluated.

An even more special case is tuple assignments via accessors:

```
(x.Prop1, y.Prop2) = (0, 1);
```

Here the CFG should be
`x --> y --> 0 --> 1 --> x.set_Prop1 --> y.set_Prop2 --> (x.Prop1, y.Prop2) = (0, 1)`.

---

I have kicked off a dist comparison to check for performance regressions, and will report the numbers as soon as they are ready.