### PR TITLE
Polish StringOps module

### DIFF
--- a/javascript/ql/src/semmle/javascript/StringOps.qll
+++ b/javascript/ql/src/semmle/javascript/StringOps.qll
@@ -5,6 +5,9 @@
 import javascript
 
 module StringOps {
+  /**
+   * A expression that is equivalent to `A.startsWith(B)` or `!A.startsWith(B)`.
+   */
   class StartsWith extends DataFlow::Node {
     StartsWith::Range range;
 

--- a/javascript/ql/src/semmle/javascript/StringOps.qll
+++ b/javascript/ql/src/semmle/javascript/StringOps.qll
@@ -343,16 +343,20 @@ module StringOps {
   /**
    * An expression that is equivalent to `A.endsWith(B)` or `!A.endsWith(B)`.
    */
-  abstract class EndsWith extends DataFlow::Node {
+  class EndsWith extends DataFlow::Node {
+    EndsWith::Range range;
+
+    EndsWith() { this = range }
+
     /**
      * Gets the `A` in `A.startsWith(B)`.
      */
-    abstract DataFlow::Node getBaseString();
+    DataFlow::Node getBaseString() { result = range.getBaseString() }
 
     /**
      * Gets the `B` in `A.startsWith(B)`.
      */
-    abstract DataFlow::Node getSubstring();
+    DataFlow::Node getSubstring() { result = range.getSubstring() }
 
     /**
      * Gets the polarity if the check.
@@ -360,37 +364,62 @@ module StringOps {
      * If the polarity is `false` the check returns `true` if the string does not end
      * with the given substring.
      */
-    boolean getPolarity() { result = true }
+    boolean getPolarity() { result = range.getPolarity() }
   }
 
-  /**
-   * A call of form `A.endsWith(B)`.
-   */
-  private class EndsWith_Native extends EndsWith, DataFlow::MethodCallNode {
-    EndsWith_Native() {
-      getMethodName() = "endsWith" and
-      getNumArgument() = 1
+  module EndsWith {
+    /**
+     * An expression that is equivalent to `A.endsWith(B)` or `!A.endsWith(B)`.
+     */
+    abstract class Range extends DataFlow::Node {
+      /**
+       * Gets the `A` in `A.startsWith(B)`.
+       */
+      abstract DataFlow::Node getBaseString();
+
+      /**
+       * Gets the `B` in `A.startsWith(B)`.
+       */
+      abstract DataFlow::Node getSubstring();
+
+      /**
+       * Gets the polarity if the check.
+       *
+       * If the polarity is `false` the check returns `true` if the string does not end
+       * with the given substring.
+       */
+      boolean getPolarity() { result = true }
     }
 
-    override DataFlow::Node getBaseString() { result = getReceiver() }
+    /**
+     * A call of form `A.endsWith(B)`.
+     */
+    private class EndsWith_Native extends Range, DataFlow::MethodCallNode {
+      EndsWith_Native() {
+        getMethodName() = "endsWith" and
+        getNumArgument() = 1
+      }
 
-    override DataFlow::Node getSubstring() { result = getArgument(0) }
-  }
+      override DataFlow::Node getBaseString() { result = getReceiver() }
 
-  /**
-   * A call of form `_.endsWith(A, B)` or `ramda.endsWith(A, B)`.
-   */
-  private class EndsWith_Library extends StartsWith, DataFlow::CallNode {
-    EndsWith_Library() {
-      getNumArgument() = 2 and
-      exists(DataFlow::SourceNode callee | this = callee.getACall() |
-        callee = LodashUnderscore::member("endsWith") or
-        callee = DataFlow::moduleMember("ramda", "endsWith")
-      )
+      override DataFlow::Node getSubstring() { result = getArgument(0) }
     }
 
-    override DataFlow::Node getBaseString() { result = getArgument(0) }
+    /**
+     * A call of form `_.endsWith(A, B)` or `ramda.endsWith(A, B)`.
+     */
+    private class EndsWith_Library extends StartsWith, DataFlow::CallNode {
+      EndsWith_Library() {
+        getNumArgument() = 2 and
+        exists(DataFlow::SourceNode callee | this = callee.getACall() |
+          callee = LodashUnderscore::member("endsWith") or
+          callee = DataFlow::moduleMember("ramda", "endsWith")
+        )
+      }
 
-    override DataFlow::Node getSubstring() { result = getArgument(1) }
+      override DataFlow::Node getBaseString() { result = getArgument(0) }
+
+      override DataFlow::Node getSubstring() { result = getArgument(1) }
+    }
   }
 }

--- a/javascript/ql/src/semmle/javascript/StringOps.qll
+++ b/javascript/ql/src/semmle/javascript/StringOps.qll
@@ -408,7 +408,7 @@ module StringOps {
     /**
      * A call of form `_.endsWith(A, B)` or `ramda.endsWith(A, B)`.
      */
-    private class EndsWith_Library extends StartsWith, DataFlow::CallNode {
+    private class EndsWith_Library extends Range, DataFlow::CallNode {
       EndsWith_Library() {
         getNumArgument() = 2 and
         exists(DataFlow::SourceNode callee | this = callee.getACall() |

--- a/javascript/ql/src/semmle/javascript/StringOps.qll
+++ b/javascript/ql/src/semmle/javascript/StringOps.qll
@@ -422,4 +422,71 @@ module StringOps {
       override DataFlow::Node getSubstring() { result = getArgument(1) }
     }
   }
+
+  /**
+   * A data flow node that concatenates strings and returns the result.
+   */
+  class Concatenation extends DataFlow::Node {
+    Concatenation() {
+      exists(StringConcatenation::getAnOperand(this))
+    }
+
+    /**
+     * Gets the `n`th operand of this string concatenation.
+     */
+    DataFlow::Node getOperand(int n) {
+      result = StringConcatenation::getOperand(this, n)
+    }
+
+    /**
+     * Gets an operand of this string concatenation.
+     */
+    DataFlow::Node getAnOperand() {
+      result = StringConcatenation::getAnOperand(this)
+    }
+
+    /**
+     * Gets the number of operands of this string concatenation.
+     */
+    int getNumOperand() {
+      result = StringConcatenation::getNumOperand(this)
+    }
+
+    /**
+     * Gets the first operand of this string concatenation.
+     */
+    DataFlow::Node getFirstOperand() {
+      result = StringConcatenation::getFirstOperand(this)
+    }
+
+    /**
+     * Gets the last operand of this string concatenation
+     */
+    DataFlow::Node getLastOperand() {
+      result = StringConcatenation::getLastOperand(this)
+    }
+
+    /**
+     * Holds if this only acts as a string coercion, such as `"" + x`.
+     */
+    predicate isCoercion() {
+      StringConcatenation::isCoercion(this)
+    }
+
+    /**
+     * Holds if this is the root of a concatenation tree, that is,
+     * it is a concatenation operator that is not itself the immediate operand to
+     * another concatenation operator.
+     */
+    predicate isRoot() {
+      StringConcatenation::isRoot(this)
+    }
+
+    /**
+     * Gets the root of the concatenation tree in which this is an operator.
+     */
+    Concatenation getRoot() {
+      result = StringConcatenation::getRoot(this)
+    }
+  }
 }

--- a/javascript/ql/src/semmle/javascript/StringOps.qll
+++ b/javascript/ql/src/semmle/javascript/StringOps.qll
@@ -183,12 +183,16 @@ module StringOps {
    *
    * Note that this also includes calls to the array method named `includes`.
    */
-  abstract class Includes extends DataFlow::Node {
+  class Includes extends DataFlow::Node {
+    Includes::Range range;
+
+    Includes() { this = range }
+
     /** Gets the `A` in `A.includes(B)`. */
-    abstract DataFlow::Node getBaseString();
+    DataFlow::Node getBaseString() { result = range.getBaseString() }
 
     /** Gets the `B` in `A.includes(B)`. */
-    abstract DataFlow::Node getSubstring();
+    DataFlow::Node getSubstring() { result = range.getSubstring() }
 
     /**
      * Gets the polarity of the check.
@@ -196,121 +200,144 @@ module StringOps {
      * If the polarity is `false` the check returns `true` if the string does not contain
      * the given substring.
      */
-    boolean getPolarity() { result = true }
+    boolean getPolarity() { result = range.getPolarity() }
   }
 
-  /**
-   * A call to a method named `includes`, assumed to refer to `String.prototype.includes`.
-   */
-  private class Includes_Native extends Includes, DataFlow::MethodCallNode {
-    Includes_Native() {
-      getMethodName() = "includes" and
-      getNumArgument() = 1
+  module Includes {
+    /**
+     * A expression that is equivalent to `A.includes(B)` or `!A.includes(B)`.
+     *
+     * Note that this also includes calls to the array method named `includes`.
+     */
+    abstract class Range extends DataFlow::Node {
+      /** Gets the `A` in `A.includes(B)`. */
+      abstract DataFlow::Node getBaseString();
+
+      /** Gets the `B` in `A.includes(B)`. */
+      abstract DataFlow::Node getSubstring();
+
+      /**
+       * Gets the polarity of the check.
+       *
+       * If the polarity is `false` the check returns `true` if the string does not contain
+       * the given substring.
+       */
+      boolean getPolarity() { result = true }
     }
 
-    override DataFlow::Node getBaseString() { result = getReceiver() }
+    /**
+     * A call to a method named `includes`, assumed to refer to `String.prototype.includes`.
+     */
+    private class Includes_Native extends Range, DataFlow::MethodCallNode {
+      Includes_Native() {
+        getMethodName() = "includes" and
+        getNumArgument() = 1
+      }
 
-    override DataFlow::Node getSubstring() { result = getArgument(0) }
-  }
+      override DataFlow::Node getBaseString() { result = getReceiver() }
 
-  /**
-   * A call to `_.includes` or similar, assumed to operate on strings.
-   */
-  private class Includes_Library extends Includes, DataFlow::CallNode {
-    Includes_Library() {
-      exists(string name |
-        this = LodashUnderscore::member(name).getACall() and
-        (name = "includes" or name = "include" or name = "contains")
-      )
+      override DataFlow::Node getSubstring() { result = getArgument(0) }
     }
 
-    override DataFlow::Node getBaseString() { result = getArgument(0) }
-
-    override DataFlow::Node getSubstring() { result = getArgument(1) }
-  }
-
-  /**
-   * A check of form `A.indexOf(B) !== -1` or similar.
-   */
-  private class Includes_IndexOfEquals extends Includes, DataFlow::ValueNode {
-    MethodCallExpr indexOf;
-
-    override EqualityTest astNode;
-
-    Includes_IndexOfEquals() {
-      exists(Expr index | astNode.hasOperands(indexOf, index) |
-        // one operand is of the form `whitelist.indexOf(x)`
-        indexOf.getMethodName() = "indexOf" and
-        // and the other one is -1
-        index.getIntValue() = -1
-      )
-    }
-
-    override DataFlow::Node getBaseString() { result = indexOf.getReceiver().flow() }
-
-    override DataFlow::Node getSubstring() { result = indexOf.getArgument(0).flow() }
-
-    override boolean getPolarity() { result = astNode.getPolarity().booleanNot() }
-  }
-
-  /**
-   * A check of form `A.indexOf(B) >= 0` or similar.
-   */
-  private class Includes_IndexOfRelational extends Includes, DataFlow::ValueNode {
-    MethodCallExpr indexOf;
-
-    override RelationalComparison astNode;
-
-    boolean polarity;
-
-    Includes_IndexOfRelational() {
-      exists(Expr lesser, Expr greater |
-        astNode.getLesserOperand() = lesser and
-        astNode.getGreaterOperand() = greater and
-        indexOf.getMethodName() = "indexOf" and
-        indexOf.getNumArgument() = 1
-      |
-        polarity = true and
-        greater = indexOf and
-        (
-          lesser.getIntValue() = 0 and astNode.isInclusive()
-          or
-          lesser.getIntValue() = -1 and not astNode.isInclusive()
+    /**
+     * A call to `_.includes` or similar, assumed to operate on strings.
+     */
+    private class Includes_Library extends Range, DataFlow::CallNode {
+      Includes_Library() {
+        exists(string name |
+          this = LodashUnderscore::member(name).getACall() and
+          (name = "includes" or name = "include" or name = "contains")
         )
-        or
-        polarity = false and
-        lesser = indexOf and
-        (
-          greater.getIntValue() = -1 and astNode.isInclusive()
-          or
-          greater.getIntValue() = 0 and not astNode.isInclusive()
+      }
+
+      override DataFlow::Node getBaseString() { result = getArgument(0) }
+
+      override DataFlow::Node getSubstring() { result = getArgument(1) }
+    }
+
+    /**
+     * A check of form `A.indexOf(B) !== -1` or similar.
+     */
+    private class Includes_IndexOfEquals extends Range, DataFlow::ValueNode {
+      MethodCallExpr indexOf;
+
+      override EqualityTest astNode;
+
+      Includes_IndexOfEquals() {
+        exists(Expr index | astNode.hasOperands(indexOf, index) |
+          // one operand is of the form `whitelist.indexOf(x)`
+          indexOf.getMethodName() = "indexOf" and
+          // and the other one is -1
+          index.getIntValue() = -1
         )
-      )
+      }
+
+      override DataFlow::Node getBaseString() { result = indexOf.getReceiver().flow() }
+
+      override DataFlow::Node getSubstring() { result = indexOf.getArgument(0).flow() }
+
+      override boolean getPolarity() { result = astNode.getPolarity().booleanNot() }
     }
 
-    override DataFlow::Node getBaseString() { result = indexOf.getReceiver().flow() }
+    /**
+     * A check of form `A.indexOf(B) >= 0` or similar.
+     */
+    private class Includes_IndexOfRelational extends Range, DataFlow::ValueNode {
+      MethodCallExpr indexOf;
 
-    override DataFlow::Node getSubstring() { result = indexOf.getArgument(0).flow() }
+      override RelationalComparison astNode;
 
-    override boolean getPolarity() { result = polarity }
-  }
+      boolean polarity;
 
-  /**
-   * An expression of form `~A.indexOf(B)` which, when coerced to a boolean, is equivalent to `A.includes(B)`.
-   */
-  private class Includes_IndexOfBitwise extends Includes, DataFlow::ValueNode {
-    MethodCallExpr indexOf;
+      Includes_IndexOfRelational() {
+        exists(Expr lesser, Expr greater |
+          astNode.getLesserOperand() = lesser and
+          astNode.getGreaterOperand() = greater and
+          indexOf.getMethodName() = "indexOf" and
+          indexOf.getNumArgument() = 1
+        |
+          polarity = true and
+          greater = indexOf and
+          (
+            lesser.getIntValue() = 0 and astNode.isInclusive()
+            or
+            lesser.getIntValue() = -1 and not astNode.isInclusive()
+          )
+          or
+          polarity = false and
+          lesser = indexOf and
+          (
+            greater.getIntValue() = -1 and astNode.isInclusive()
+            or
+            greater.getIntValue() = 0 and not astNode.isInclusive()
+          )
+        )
+      }
 
-    override BitNotExpr astNode;
+      override DataFlow::Node getBaseString() { result = indexOf.getReceiver().flow() }
 
-    Includes_IndexOfBitwise() {
-      astNode.getOperand() = indexOf and
-      indexOf.getMethodName() = "indexOf"
+      override DataFlow::Node getSubstring() { result = indexOf.getArgument(0).flow() }
+
+      override boolean getPolarity() { result = polarity }
     }
 
-    override DataFlow::Node getBaseString() { result = indexOf.getReceiver().flow() }
+    /**
+     * An expression of form `~A.indexOf(B)` which, when coerced to a boolean, is equivalent to `A.includes(B)`.
+     */
+    private class Includes_IndexOfBitwise extends Range, DataFlow::ValueNode {
+      MethodCallExpr indexOf;
 
-    override DataFlow::Node getSubstring() { result = indexOf.getArgument(0).flow() }
+      override BitNotExpr astNode;
+
+      Includes_IndexOfBitwise() {
+        astNode.getOperand() = indexOf and
+        indexOf.getMethodName() = "indexOf"
+      }
+
+      override DataFlow::Node getBaseString() { result = indexOf.getReceiver().flow() }
+
+      override DataFlow::Node getSubstring() { result = indexOf.getArgument(0).flow() }
+    }
   }
 
   /**

--- a/javascript/ql/test/library-tests/StringConcatenation/ClassContainsTwo.expected
+++ b/javascript/ql/test/library-tests/StringConcatenation/ClassContainsTwo.expected
@@ -1,0 +1,31 @@
+| tst.js:3:3:3:12 | x += "two" |
+| tst.js:3:8:3:12 | "two" |
+| tst.js:4:3:4:3 | x |
+| tst.js:4:3:4:14 | x += "three" |
+| tst.js:5:3:5:3 | x |
+| tst.js:5:3:5:13 | x += "four" |
+| tst.js:6:10:6:10 | x |
+| tst.js:12:5:12:26 | x += "o ... + "two" |
+| tst.js:12:10:12:26 | "one" + y + "two" |
+| tst.js:12:22:12:26 | "two" |
+| tst.js:19:11:19:23 | "one" + "two" |
+| tst.js:19:19:19:23 | "two" |
+| tst.js:20:3:20:3 | x |
+| tst.js:20:3:20:25 | x += (" ... "four") |
+| tst.js:21:10:21:10 | x |
+| tst.js:21:10:21:19 | x + "five" |
+| tst.js:25:10:25:32 | ["one", ... three"] |
+| tst.js:25:10:25:41 | ["one", ... oin("") |
+| tst.js:25:18:25:22 | "two" |
+| tst.js:29:10:29:37 | Array(" ... three") |
+| tst.js:29:10:29:46 | Array(" ... oin("") |
+| tst.js:29:23:29:27 | "two" |
+| tst.js:33:10:33:41 | new Arr ... three") |
+| tst.js:33:10:33:50 | new Arr ... oin("") |
+| tst.js:33:27:33:31 | "two" |
+| tst.js:38:11:38:15 | "two" |
+| tst.js:46:23:46:27 | "two" |
+| tst.js:53:10:53:34 | `one ${ ...  three` |
+| tst.js:53:19:53:23 |  two  |
+| tst.js:71:14:71:18 | "two" |
+| tst.js:77:23:77:27 | "two" |

--- a/javascript/ql/test/library-tests/StringConcatenation/ClassContainsTwo.ql
+++ b/javascript/ql/test/library-tests/StringConcatenation/ClassContainsTwo.ql
@@ -1,0 +1,14 @@
+import javascript
+
+// Select all expressions whose string value contains the word "two"
+predicate containsTwo(DataFlow::Node node) {
+  node.getStringValue().regexpMatch(".*two.*")
+  or
+  containsTwo(node.getAPredecessor())
+  or
+  containsTwo(node.(StringOps::Concatenation).getAnOperand())
+}
+
+from Expr e
+where containsTwo(e.flow())
+select e

--- a/javascript/ql/test/library-tests/StringOps/EndsWith/EndsWith.expected
+++ b/javascript/ql/test/library-tests/StringOps/EndsWith/EndsWith.expected
@@ -1,1 +1,3 @@
 | tst.js:5:7:5:19 | A.endsWith(B) | tst.js:5:7:5:7 | A | tst.js:5:18:5:18 | B | true |
+| tst.js:6:7:6:22 | _.endsWith(A, B) | tst.js:6:18:6:18 | A | tst.js:6:21:6:21 | B | true |
+| tst.js:7:7:7:22 | R.endsWith(A, B) | tst.js:7:18:7:18 | A | tst.js:7:21:7:21 | B | true |


### PR DESCRIPTION
- Adds the `::Range` pattern to the classes in `StringOps`.
- Fixes a bug in an `EndsWith` class
- Adds `StringOps::Concatenation` as a forwarder to `StringConcatenation` for now.
