### PR TITLE
Update link to QL documentation in vue.qll

### DIFF
--- a/javascript/ql/src/semmle/javascript/frameworks/Vue.qll
+++ b/javascript/ql/src/semmle/javascript/frameworks/Vue.qll
@@ -53,7 +53,7 @@ module Vue {
      * The location spans column `startcolumn` of line `startline` to
      * column `endcolumn` of line `endline` in file `filepath`.
      * For more information, see
-     * [LGTM locations](https://lgtm.com/help/ql/locations).
+     * [locations](https://help.semmle.com/QL/learn-ql/ql/locations.html).
      */
     predicate hasLocationInfo(
       string filepath, int startline, int startcolumn, int endline, int endcolumn


### PR DESCRIPTION
Small update to a link to some documentation in `vue.qll`. Required due to upcoming QL documentation consolidation.
