### PR TITLE
JS: model one more 'autobind' for js/unbound-event-handler-receiver

### DIFF
--- a/javascript/ql/src/Expressions/UnboundEventHandlerReceiver.ql
+++ b/javascript/ql/src/Expressions/UnboundEventHandlerReceiver.ql
@@ -28,7 +28,11 @@ private predicate isBoundInMethod(MethodDeclaration method) {
     )
     or
     // require("auto-bind")(this)
-    thiz.flowsTo(DataFlow::moduleImport("auto-bind").getACall().getArgument(0))
+    exists (string mod |
+      mod = "auto-bind" or
+      mod = "react-autobind" |
+      thiz.flowsTo(DataFlow::moduleImport(mod).getACall().getArgument(0))
+    )
     or
     exists(string name | name = method.getName() |
       exists(DataFlow::MethodCallNode bind |

--- a/javascript/ql/test/query-tests/Expressions/UnboundEventHandlerReceiver/tst.js
+++ b/javascript/ql/test/query-tests/Expressions/UnboundEventHandlerReceiver/tst.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import autoBind from 'auto-bind';
-
+import reactAutobind from 'react-autobind';
 class Component0 extends React.Component {
 
     render() {
@@ -151,6 +151,24 @@ class Component3 extends React.Component {
     }
 
     bound_throughIterator() {
+        this.setState({ });
+    }
+}
+
+class Component4 extends React.Component {
+
+    render() {
+        return <div>
+            <div onClick={this.bound_throughReactAutobind}/> // OK
+            </div>
+    }
+
+    constructor(props) {
+        super(props);
+        reactAutobind(this);
+    }
+
+    bound_throughReactAutobind() {
         this.setState({ });
     }
 }


### PR DESCRIPTION
Fixes <https://github.com/Semmle/ql/issues/955>. Skipping evaluation.