### PR TITLE
C#: Cache `Call::getArgumentForParameter()`

### DIFF
--- a/csharp/ql/src/semmle/code/csharp/exprs/Call.qll
+++ b/csharp/ql/src/semmle/code/csharp/exprs/Call.qll
@@ -76,7 +76,7 @@ class Call extends DotNet::Call, Expr, @call {
    * }
    * ```
    */
-  pragma[nomagic]
+  cached
   override Expr getArgumentForParameter(DotNet::Parameter p) {
     getTarget().getAParameter() = p and
     (


### PR DESCRIPTION
This predicate can take quite a while to compute on large snapshots, so cache it.