### PR TITLE
C++: Reduce the IRGuards to two cached stages

### DIFF
--- a/cpp/ql/src/semmle/code/cpp/controlflow/IRGuards.qll
+++ b/cpp/ql/src/semmle/code/cpp/controlflow/IRGuards.qll
@@ -16,8 +16,8 @@ private predicate isUnreachedBlock(IRBlock block) {
  * A Boolean condition in the AST that guards one or more basic blocks. This includes
  * operands of logical operators but not switch statements.
  */
-class GuardCondition extends Expr {
-  GuardCondition() {
+cached class GuardCondition extends Expr {
+  cached GuardCondition() {
     exists(IRGuardCondition ir | this = ir.getUnconvertedResultExpression())
     or
     // no binary operators in the IR
@@ -238,10 +238,10 @@ private class GuardConditionFromIR extends GuardCondition {
  * don't have an explicit representation in the IR, and therefore will not appear as
  * IRGuardConditions.
  */
-class IRGuardCondition extends Instruction {
+cached class IRGuardCondition extends Instruction {
     ConditionalBranchInstruction branch;
     
-    IRGuardCondition() {
+    cached IRGuardCondition() {
         branch = get_branch_for_condition(this)
     }
 
@@ -281,7 +281,7 @@ class IRGuardCondition extends Instruction {
           ne.controls(controlled, testIsTrue.booleanNot())) 
     }
 
-    predicate controlsEdge(IRBlock pred, IRBlock succ, boolean testIsTrue) {
+    cached predicate controlsEdge(IRBlock pred, IRBlock succ, boolean testIsTrue) {
       pred.getASuccessor() = succ and
       controls(pred, testIsTrue)
       or


### PR DESCRIPTION
Before this change, all the cached predicates in `IRGuards.qll` were in separate cached stages, resulting in recomputation of most of the library for each stage. This change groups the cached predicates in two cached classes. A better grouping may be possible, but this grouping was easy to do and seems to solve the problem.

Before this change, the `IRGuards` library accounted for five cached stages when using the `RangeAnalysis` library. After this change, it only accounts for one. On a sample query using IR data flow and range analysis, the total pretty-printed DIL went from 98,670 lines to 93,164 lines.