### PR TITLE
CPP: add a query for catching alloca in a loop

### DIFF
--- a/cpp/ql/src/Likely Bugs/Memory Management/AllocaInLoop.ql
+++ b/cpp/ql/src/Likely Bugs/Memory Management/AllocaInLoop.ql
@@ -1,0 +1,28 @@
+/**
+ * @name alloca in a loop
+ * @description Using alloca in a loop can lead to a stack overflow
+ * @kind problem
+ * @problem.severity warning
+ * @precision medium
+ * @id cpp/alloca-in-loop
+ * @tags reliability
+ *       correctness
+ *       external/cwe/cwe-770
+ */
+import cpp
+
+Loop getAnEnclosingLoopOfExpr(Expr e) {
+  result = e.getEnclosingStmt().getParent*() or
+  result = getAnEnclosingLoopOfStmt(e.getEnclosingStmt())
+}
+
+Loop getAnEnclosingLoopOfStmt(Stmt s) {
+  result = s.getParent*() or
+  result = getAnEnclosingLoopOfExpr(s.getParent*())
+}
+
+from Loop l, FunctionCall fc
+where getAnEnclosingLoopOfExpr(fc) = l
+  and fc.getTarget().getName() = "__builtin_alloca"
+  and not l.(DoStmt).getCondition().getValue() = "0"
+select fc, "Stack allocation is inside a $@ and could lead to overflow.", l, l.toString()


### PR DESCRIPTION
Thanks to Sam Lanning (@samlanning) and Robert Marsh (@rdmarsh2) for taking the time to help
to make it possible. In fact, it was Robert Marsh who effectively
wrote the query and figured out that __builtin_alloca should be
used to also take functions like strdupa into account. I just
filled out the metadata :-)

@samlanning is my understanding correct that we kind of agreed that the query is perfect and self-documenting so there's no need for me to add tests or documentation? :-)