### PR TITLE
C#: Use explict recursion in `blockPrecedesVar()`

### DIFF
--- a/csharp/ql/src/semmle/code/csharp/dataflow/SSA.qll
+++ b/csharp/ql/src/semmle/code/csharp/dataflow/SSA.qll
@@ -670,7 +670,9 @@ module Ssa {
 
     /** Holds if `v` occurs in `bb` or one of `bb`'s transitive successors. */
     private predicate blockPrecedesVar(TrackedVar v, BasicBlock bb) {
-      varOccursInBlock(v, bb.getASuccessor*())
+      varOccursInBlock(v, bb)
+      or
+      blockPrecedesVar(v, bb.getASuccessor())
     }
 
     /**


### PR DESCRIPTION
A small change which may improve performance on some snapshots (in particular seen at a customer). The [performance report](https://git.semmle.com/gist/tom/189ab23465fe6fbd66eb21561ad44f82) for this change (internal link) reveals no big change in performance for our set of sample projects.