### PR TITLE
C++: Use the cached getInstructionCount

### DIFF
--- a/cpp/ql/src/semmle/code/cpp/ir/implementation/aliased_ssa/IRBlock.qll
+++ b/cpp/ql/src/semmle/code/cpp/ir/implementation/aliased_ssa/IRBlock.qll
@@ -60,7 +60,7 @@ class IRBlockBase extends TIRBlock {
   }
 
   final int getInstructionCount() {
-    result = strictcount(getInstruction(_))
+    result = getInstructionCount(this)
   }
 
   final FunctionIR getEnclosingFunctionIR() {

--- a/cpp/ql/src/semmle/code/cpp/ir/implementation/raw/IRBlock.qll
+++ b/cpp/ql/src/semmle/code/cpp/ir/implementation/raw/IRBlock.qll
@@ -60,7 +60,7 @@ class IRBlockBase extends TIRBlock {
   }
 
   final int getInstructionCount() {
-    result = strictcount(getInstruction(_))
+    result = getInstructionCount(this)
   }
 
   final FunctionIR getEnclosingFunctionIR() {

--- a/cpp/ql/src/semmle/code/cpp/ir/implementation/unaliased_ssa/IRBlock.qll
+++ b/cpp/ql/src/semmle/code/cpp/ir/implementation/unaliased_ssa/IRBlock.qll
@@ -60,7 +60,7 @@ class IRBlockBase extends TIRBlock {
   }
 
   final int getInstructionCount() {
-    result = strictcount(getInstruction(_))
+    result = getInstructionCount(this)
   }
 
   final FunctionIR getEnclosingFunctionIR() {


### PR DESCRIPTION
The object-oriented `IRBlock` interface was recomputing instruction counts instead of using the cached count that had already been computed.