### PR TITLE
Move support information to QL repository for easier maintenance

### DIFF
--- a/change-notes/1.19/support/framework-support.rst
+++ b/change-notes/1.19/support/framework-support.rst
@@ -1,0 +1,61 @@
+Frameworks and libraries
+########################
+
+The QL libraries and queries in this version have been explicitly checked against the libraries and frameworks listed below.
+
+.. pull-quote::
+
+    Tip
+    
+    If you're interested in other libraries or frameworks, you can extend the analysis to cover them. 
+    For example, by extending the data flow libraries to include data sources and sinks for additional libraries or frameworks.
+
+.. There is currently no built-in support for libraries or frameworks for C/C++.
+
+C# built-in support
+================================
+
+* ASP.Net MVC framework
+* ASP.NET Web API
+* ASP.NET Web Forms
+* ASP.NET Core
+* ASP.NET Core MVC
+* ASP.Net Core Razor
+* Razor templates
+
+
+COBOL built-in support
+===================================
+
+* Embedded SQL
+* Embedded CICS
+
+
+Java built-in support
+==================================
+
+.. csv-table:: 
+     :file: java-frameworks.csv
+     :header-rows: 1
+     :class: fullWidthTable
+     :widths: auto
+
+
+JavaScript and TypeScript built-in support
+=======================================================
+
+.. csv-table:: 
+     :file: javascript-typescript-frameworks.csv
+     :header-rows: 1
+     :class: fullWidthTable
+     :widths: auto
+
+
+Python built-in support
+====================================
+
+.. csv-table:: 
+     :file: python-frameworks.csv
+     :header-rows: 1
+     :class: fullWidthTable
+     :widths: auto

--- a/change-notes/1.19/support/java-frameworks.csv
+++ b/change-notes/1.19/support/java-frameworks.csv
@@ -1,0 +1,10 @@
+Name, Category
+Hibernate, Database
+iBatis / MyBatis, Database
+Java Persistence API (JPA), Database
+JDBC, Database
+Kryo deserialization, Serialization
+SnakeYaml, Serialization
+Spring JDBC, Database
+Spring MVC, Web application framework
+XStream, Serialization

--- a/change-notes/1.19/support/javascript-typescript-frameworks.csv
+++ b/change-notes/1.19/support/javascript-typescript-frameworks.csv
@@ -1,0 +1,22 @@
+Name, Category
+angularjs, HTML framework
+axios, Network communicator
+browser, Runtime environment
+electron, Runtime environment
+express, Server
+hapi, Server
+jquery, Utility library
+koa, Server
+lodash, Utility library
+mongodb, Database
+mssql, Database
+mysql, Database
+node, Runtime environment
+postgres, Database
+ramda, Utility library
+react, HTML framework
+request, Network communicator
+sequelize, Database
+sqlite3, Database
+superagent, Network communicator
+underscore, Utility library

--- a/change-notes/1.19/support/language-support.rst
+++ b/change-notes/1.19/support/language-support.rst
@@ -1,0 +1,19 @@
+Languages and compilers
+#######################
+
+QL and LGTM version |version| support analysis of the following languages compiled by the following compilers.
+
+Note that where there are several versions or dialects of a language, the supported variants are listed.
+
+.. csv-table::
+     :file: versions-compilers.csv
+     :header-rows: 1
+     :widths: auto
+     :stub-columns: 1
+
+.. container:: footnote-group
+
+    .. [1] The best results are achieved with COBOL code that stays close to the ANSI 85 standard.  
+    .. [2] Java 11 refers to the language features used. Builds that execute on Java 6 or higher can be analyzed.
+    .. [3] JSX and Flow code, YAML, JSON, and HTML files may also be analyzed with JavaScript files. 
+    .. [4] TypeScript analysis is performed by running the JavaScript extractor with TypeScript enabled. This is the default for LGTM.   

--- a/change-notes/1.19/support/python-frameworks.csv
+++ b/change-notes/1.19/support/python-frameworks.csv
@@ -1,0 +1,7 @@
+Name, Category
+Django, Web application framework
+Flask, Microframework
+Pyramid, Web application framework
+Tornado, Web application framework and asynchronous networking library
+Twisted, Networking engine
+WebOb, WSGI request library

--- a/change-notes/1.19/support/versions-compilers.csv
+++ b/change-notes/1.19/support/versions-compilers.csv
@@ -1,0 +1,16 @@
+Language,Variants,Compilers,Extensions
+C/C++,"C89, C99, C11, C++98, C++03, C++11, C++14, C++17","Clang extensions (up to Clang 6.0)
+
+GNU extensions (up to GCC 7.3), 
+
+Microsoft extensions (up to VS 2017)","``.cpp``, ``.c++``, ``.cxx``, ``.hpp``, ``.hh``, ``.h++``, ``.hxx``, ``.c``, ``.cc``, ``.h``"
+C#,C# up to 7.2 together with .NET versions up to 4.7.1,"Microsoft Visual Studio up to 2017, 
+
+.NET Core up to 2.1","``.sln``, ``.csproj``, ``.cs``, ``.cshtml``, ``.xaml``"
+COBOL,ANSI 85 or newer [1]_.,Not applicable,"``.cbl``, ``.CBL``, ``.cpy``, ``.CPY``, ``.copy``, ``.COPY``"
+Java,"Java 11 [2]_. or lower","javac (OpenJDK and Oracle JDK)
+
+Eclipse compiler for Java (ECJ) batch compiler",``.java``
+JavaScript,ECMAScript 2018 or lower,Not applicable,"``.js``, ``.jsx``, ``.mjs``, ``.es``, ``.es6``, ``.htm``, ``.html``, ``.xhm``, ``.xhtml``, ``.vue``, ``.json`` [3]_."
+Python,"2.7, 3.5, 3.6, 3.7",Not applicable,``.py``
+TypeScript [4]_.,"2.6, 2.7, 2.8, 2.9, 3.0, 3.1",Standard TypeScript compiler,"``.ts``, ``.tsx``"

--- a/change-notes/1.20/support/framework-support.rst
+++ b/change-notes/1.20/support/framework-support.rst
@@ -1,0 +1,61 @@
+Frameworks and libraries
+########################
+
+The QL libraries and queries in this version have been explicitly checked against the libraries and frameworks listed below.
+
+.. pull-quote::
+
+    Tip
+    
+    If you're interested in other libraries or frameworks, you can extend the analysis to cover them. 
+    For example, by extending the data flow libraries to include data sources and sinks for additional libraries or frameworks.
+
+.. There is currently no built-in support for libraries or frameworks for C/C++.
+
+C# built-in support
+================================
+
+* ASP.Net MVC framework
+* ASP.NET Web API
+* ASP.NET Web Forms
+* ASP.NET Core
+* ASP.NET Core MVC
+* ASP.Net Core Razor
+* Razor templates
+
+
+COBOL built-in support
+===================================
+
+* Embedded SQL
+* Embedded CICS
+
+
+Java built-in support
+==================================
+
+.. csv-table:: 
+     :file: java-frameworks.csv
+     :header-rows: 1
+     :class: fullWidthTable
+     :widths: auto
+
+
+JavaScript and TypeScript built-in support
+=======================================================
+
+.. csv-table:: 
+     :file: javascript-typescript-frameworks.csv
+     :header-rows: 1
+     :class: fullWidthTable
+     :widths: auto
+
+
+Python built-in support
+====================================
+
+.. csv-table:: 
+     :file: python-frameworks.csv
+     :header-rows: 1
+     :class: fullWidthTable
+     :widths: auto

--- a/change-notes/1.20/support/java-frameworks.csv
+++ b/change-notes/1.20/support/java-frameworks.csv
@@ -1,0 +1,10 @@
+Name, Category
+Hibernate, Database
+iBatis / MyBatis, Database
+Java Persistence API (JPA), Database
+JDBC, Database
+Kryo deserialization, Serialization
+SnakeYaml, Serialization
+Spring JDBC, Database
+Spring MVC, Web application framework
+XStream, Serialization

--- a/change-notes/1.20/support/javascript-typescript-frameworks.csv
+++ b/change-notes/1.20/support/javascript-typescript-frameworks.csv
@@ -1,0 +1,22 @@
+Name, Category
+angularjs, HTML framework
+axios, Network communicator
+browser, Runtime environment
+electron, Runtime environment
+express, Server
+hapi, Server
+jquery, Utility library
+koa, Server
+lodash, Utility library
+mongodb, Database
+mssql, Database
+mysql, Database
+node, Runtime environment
+postgres, Database
+ramda, Utility library
+react, HTML framework
+request, Network communicator
+sequelize, Database
+sqlite3, Database
+superagent, Network communicator
+underscore, Utility library

--- a/change-notes/1.20/support/language-support.rst
+++ b/change-notes/1.20/support/language-support.rst
@@ -1,0 +1,19 @@
+Languages and compilers
+#######################
+
+QL and LGTM version |version| support analysis of the following languages compiled by the following compilers.
+
+Note that where there are several versions or dialects of a language, the supported variants are listed.
+
+.. csv-table::
+     :file: versions-compilers.csv
+     :header-rows: 1
+     :widths: auto
+     :stub-columns: 1
+
+.. container:: footnote-group
+
+    .. [1] The best results are achieved with COBOL code that stays close to the ANSI 85 standard.  
+    .. [2] Java 11 refers to the language features used. Builds that execute on Java 6 or higher can be analyzed.
+    .. [3] JSX and Flow code, YAML, JSON, and HTML files may also be analyzed with JavaScript files. 
+    .. [4] TypeScript analysis is performed by running the JavaScript extractor with TypeScript enabled. This is the default for LGTM.   

--- a/change-notes/1.20/support/python-frameworks.csv
+++ b/change-notes/1.20/support/python-frameworks.csv
@@ -1,0 +1,7 @@
+Name, Category
+Django, Web application framework
+Flask, Microframework
+Pyramid, Web application framework
+Tornado, Web application framework and asynchronous networking library
+Twisted, Networking engine
+WebOb, WSGI request library

--- a/change-notes/1.20/support/versions-compilers.csv
+++ b/change-notes/1.20/support/versions-compilers.csv
@@ -1,0 +1,16 @@
+Language,Variants,Compilers,Extensions
+C/C++,"C89, C99, C11, C++98, C++03, C++11, C++14, C++17","Clang extensions (up to Clang 6.0)
+
+GNU extensions (up to GCC 7.3), 
+
+Microsoft extensions (up to VS 2017)","``.cpp``, ``.c++``, ``.cxx``, ``.hpp``, ``.hh``, ``.h++``, ``.hxx``, ``.c``, ``.cc``, ``.h``"
+C#,C# up to 7.2 together with .NET versions up to 4.7.1,"Microsoft Visual Studio up to 2017, 
+
+.NET Core up to 2.1","``.sln``, ``.csproj``, ``.cs``, ``.cshtml``, ``.xaml``"
+COBOL,ANSI 85 or newer [1]_.,Not applicable,"``.cbl``, ``.CBL``, ``.cpy``, ``.CPY``, ``.copy``, ``.COPY``"
+Java,"Java 11 [2]_. or lower","javac (OpenJDK and Oracle JDK)
+
+Eclipse compiler for Java (ECJ) batch compiler",``.java``
+JavaScript,ECMAScript 2018 or lower,Not applicable,"``.js``, ``.jsx``, ``.mjs``, ``.es``, ``.es6``, ``.htm``, ``.html``, ``.xhm``, ``.xhtml``, ``.vue``, ``.json`` [3]_."
+Python,"2.7, 3.5, 3.6, 3.7",Not applicable,``.py``
+TypeScript [4]_.,"2.6, 2.7, 2.8, 2.9, 3.0, 3.1",Standard TypeScript compiler,"``.ts``, ``.tsx``"


### PR DESCRIPTION
This pull request moves files defining which language versions, compilers, frameworks and libraries we support. They should be easier to maintain in this location.

As far as I know, the information is correct for 1.19 (taken from the wiki topic gathered by Niroshan and Bas, or from the 1.19 documentation). I've added a copy to the 1.20 directory too, so that they're ready to update for the next release.

Once this PR is merged, I'll raise a further PR against the internal repository to remove the files from there and update the Sphinx index file to point to the new location.

@markshannon - as discussed. Does this look sensible?
@jf205 - for information