### PR TITLE
CPP: Add support for the Rtl* functions in BufferAccess.ql

### DIFF
--- a/change-notes/1.20/analysis-cpp.md
+++ b/change-notes/1.20/analysis-cpp.md
@@ -18,6 +18,7 @@
 | **Query**                  | **Expected impact**    | **Change**                                                       |
 |----------------------------|------------------------|------------------------------------------------------------------|
 | Array argument size mismatch (`cpp/array-arg-size-mismatch`) | Fewer false positives | An exception has been added to this query for variable sized arrays. |
+| Call to memory access function may overflow buffer (`cpp/overflow-buffer`) | More correct results | This query now recognizes calls to `RtlCopyMemoryNonTemporal` and `RtlSecureZeroMemory`. |
 | Returning stack-allocated memory (`cpp/return-stack-allocated-memory`) | More correct results | Many more stack allocated expressions are now recognized. |
 | Suspicious add with sizeof (`cpp/suspicious-add-sizeof`) | Fewer false positives | Pointer arithmetic on `char * const` expressions (and other variations of `char *`) are now correctly excluded from the results. |
 | Suspicious pointer scaling (`cpp/suspicious-pointer-scaling`) | Fewer false positives | False positives involving types that are not uniquely named in the snapshot have been fixed. |

--- a/cpp/ql/src/semmle/code/cpp/security/BufferAccess.qll
+++ b/cpp/ql/src/semmle/code/cpp/security/BufferAccess.qll
@@ -32,8 +32,9 @@ abstract class BufferAccess extends Expr {
  *  wmemcpy(dest, src, num)
  *  memmove(dest, src, num)
  *  wmemmove(dest, src, num)
- *  mempcpy(dest, src, num);
- *  wmempcpy(dest, src, num);
+ *  mempcpy(dest, src, num)
+ *  wmempcpy(dest, src, num)
+ *  RtlCopyMemoryNonTemporal(dest, src, num)
  */
 class MemcpyBA extends BufferAccess {
   MemcpyBA() {
@@ -42,7 +43,8 @@ class MemcpyBA extends BufferAccess {
     this.(FunctionCall).getTarget().getName() = "memmove" or
     this.(FunctionCall).getTarget().getName() = "wmemmove" or
     this.(FunctionCall).getTarget().getName() = "mempcpy" or
-    this.(FunctionCall).getTarget().getName() = "wmempcpy"
+    this.(FunctionCall).getTarget().getName() = "wmempcpy" or
+    this.(FunctionCall).getTarget().getName() = "RtlCopyMemoryNonTemporal"
   }
   
   override string getName() {
@@ -261,6 +263,30 @@ class MemsetBA extends BufferAccess {
     result =
       this.(FunctionCall).getArgument(2).getValue().toInt() *
       getPointedSize(this.(FunctionCall).getTarget().getParameter(0).getType())
+  }
+}
+
+/**
+ * Calls to `RtlSecureZeroMemory`.
+ *  RtlSecureZeroMemory(ptr, cnt)
+ */
+class ZeroMemoryBA extends BufferAccess {
+  ZeroMemoryBA() {
+    this.(FunctionCall).getTarget().getName() = "RtlSecureZeroMemory"
+  }
+  
+  override string getName() {
+    result = this.(FunctionCall).getTarget().getName()
+  }
+
+  override Expr getBuffer(string bufferDesc, int accessType) {
+    result = this.(FunctionCall).getArgument(0) and
+    bufferDesc = "destination buffer" and
+    accessType = 1
+  }
+
+  override int getSize() {
+    result = this.(FunctionCall).getArgument(1).getValue().toInt()
   }
 }
 


### PR DESCRIPTION
Add support for the Microsoft `Rtl*` functions in BufferAccess.ql, used by OverflowBuffer.ql.

@lukecartey this is a start on improving our buffer overflow detection on code for Microsoft platforms.  More to follow soon.