### PR TITLE
C++: Remove @precision of AllocaInLoop.ql

### DIFF
--- a/cpp/ql/src/Likely Bugs/Memory Management/AllocaInLoop.ql
+++ b/cpp/ql/src/Likely Bugs/Memory Management/AllocaInLoop.ql
@@ -3,7 +3,6 @@
  * @description Using alloca in a loop can lead to a stack overflow
  * @kind problem
  * @problem.severity warning
- * @precision medium
  * @id cpp/alloca-in-loop
  * @tags reliability
  *       correctness


### PR DESCRIPTION
A PR check was failing because this query was enabled on LGTM but had no qhelp. I'm removing the `@precision` for now to take it off LGTM, and then we can add it back when it has qhelp, tests, and change note.