### PR TITLE
JS: Improve performance of type inference in closure code

### DIFF
--- a/javascript/ql/src/semmle/javascript/dataflow/TypeInference.qll
+++ b/javascript/ql/src/semmle/javascript/dataflow/TypeInference.qll
@@ -48,6 +48,8 @@ class AnalyzedNode extends DataFlow::Node {
   AnalyzedNode localFlowPred() { result = getAPredecessor() }
 
   /**
+   * INTERNAL. DO NOT USE.
+   *
    * Gets another data flow node whose value flows into this node in a global step
    * (this is, involving global variables).
    */

--- a/javascript/ql/src/semmle/javascript/dataflow/TypeInference.qll
+++ b/javascript/ql/src/semmle/javascript/dataflow/TypeInference.qll
@@ -48,7 +48,7 @@ class AnalyzedNode extends DataFlow::Node {
   AnalyzedNode localFlowPred() { result = getAPredecessor() }
 
   /**
-   * INTERNAL. DO NOT USE.
+   * INTERNAL. Do not use.
    *
    * Gets another data flow node whose value flows into this node in a global step
    * (this is, involving global variables).

--- a/javascript/ql/src/semmle/javascript/dataflow/TypeInference.qll
+++ b/javascript/ql/src/semmle/javascript/dataflow/TypeInference.qll
@@ -49,7 +49,7 @@ class AnalyzedNode extends DataFlow::Node {
 
   /**
    * Gets another data flow node whose value flows into this node in a global step
-   * (this is, involvign global variables).
+   * (this is, involving global variables).
    */
   AnalyzedNode globalFlowPred() { none() }
 
@@ -76,7 +76,7 @@ class AnalyzedNode extends DataFlow::Node {
    * and global), IIFEs, ES6-style imports that can be resolved uniquely, and
    * the properties of CommonJS `module` and `exports` objects. No
    * tracking through the properties of object literals and function/class
-   * instances is performed.
+   * instances is performed, other than those accounted for by `globalFlowPred`.
    */
   cached
   AbstractValue getALocalValue() {

--- a/javascript/ql/src/semmle/javascript/dataflow/TypeInference.qll
+++ b/javascript/ql/src/semmle/javascript/dataflow/TypeInference.qll
@@ -48,6 +48,12 @@ class AnalyzedNode extends DataFlow::Node {
   AnalyzedNode localFlowPred() { result = getAPredecessor() }
 
   /**
+   * Gets another data flow node whose value flows into this node in a global step
+   * (this is, involvign global variables).
+   */
+  AnalyzedNode globalFlowPred() { none() }
+
+  /**
    * Gets an abstract value that this node may evaluate to at runtime.
    *
    * This predicate tracks flow through expressions, variables (both local
@@ -57,7 +63,9 @@ class AnalyzedNode extends DataFlow::Node {
    * instances is also performed.
    */
   cached
-  AbstractValue getAValue() { result = getALocalValue() }
+  AbstractValue getAValue() {
+    result = getALocalValue()
+  }
 
   /**
    * INTERNAL: Do not use.
@@ -82,6 +90,9 @@ class AnalyzedNode extends DataFlow::Node {
     exists(DataFlow::Incompleteness cause |
       isIncomplete(cause) and result = TIndefiniteAbstractValue(cause)
     )
+    or
+    result = globalFlowPred().getALocalValue() and
+    shouldTrackGlobally(result)
   }
 
   /** Gets a type inferred for this node. */
@@ -282,3 +293,8 @@ private class AnalyzedAsyncFunction extends AnalyzedFunction {
 
   override AbstractValue getAReturnValue() { result = TAbstractOtherObject() }
 }
+
+/**
+ * Holds if the given value should be propagated along `globalFlowPred()` edges.
+ */
+private predicate shouldTrackGlobally(AbstractValue value) { value instanceof AbstractCallable }

--- a/javascript/ql/src/semmle/javascript/dataflow/internal/InterModuleTypeInference.qll
+++ b/javascript/ql/src/semmle/javascript/dataflow/internal/InterModuleTypeInference.qll
@@ -360,13 +360,11 @@ private class AnalyzedClosureGlobalAccessPath extends AnalyzedNode, AnalyzedProp
 
   AnalyzedClosureGlobalAccessPath() { accessPath = Closure::getLibraryAccessPath(this) }
 
-  override AnalyzedNode localFlowPred() {
+  override AnalyzedNode globalFlowPred() {
     exists(DataFlow::PropWrite write |
       Closure::getWrittenLibraryAccessPath(write) = accessPath and
       result = write.getRhs()
     )
-    or
-    result = AnalyzedNode.super.localFlowPred()
   }
 
   override predicate reads(AbstractValue base, string propName) {


### PR DESCRIPTION
Improves performance of global type inference in closure code.

Concretely it ensures that only function values can be propagated along "global" dataflow edges, which is currently defined to be the edges added by the closure model.

[Evaluation](https://git.semmle.com/asger/dist-compare-reports/tree/augustus.ti.semmle.com_1550268747793)

@esben-semmle I believe this fixes the issue you reported earlier. Could you test it on an Azure worker?