### PR TITLE
JS: Handler deeper access paths in Closure::moduleImport

### DIFF
--- a/javascript/ql/src/semmle/javascript/Closure.qll
+++ b/javascript/ql/src/semmle/javascript/Closure.qll
@@ -223,9 +223,15 @@ module Closure {
     or
     exists(DataFlow::SourceNode base, string basePath, string prop |
       basePath = getClosureNamespaceFromSourceNode(base) and
-      isClosureNamespace(basePath) and
       node = base.getAPropertyRead(prop) and
-      result = basePath + "." + prop
+      result = basePath + "." + prop and
+      // ensure finiteness
+      (
+        isClosureNamespace(basePath)
+        or
+        // direct access, no indirection
+        node.(DataFlow::PropRead).getBase() = base
+      )
     )
     or
     // Associate an access path with the immediate RHS of a store on a closure namespace.

--- a/javascript/ql/test/library-tests/Closure/NestedAccess.expected
+++ b/javascript/ql/test/library-tests/Closure/NestedAccess.expected
@@ -1,0 +1,1 @@
+| tests/nestedAccess.js:5:1:5:12 | fooBar.x.y.z |

--- a/javascript/ql/test/library-tests/Closure/NestedAccess.ql
+++ b/javascript/ql/test/library-tests/Closure/NestedAccess.ql
@@ -1,0 +1,3 @@
+import javascript
+
+select Closure::moduleImport("foo.bar.x.y.z")

--- a/javascript/ql/test/library-tests/Closure/moduleImport.expected
+++ b/javascript/ql/test/library-tests/Closure/moduleImport.expected
@@ -1,9 +1,16 @@
+| foo.bar | tests/nestedAccess.js:3:14:3:36 | goog.re ... o.bar') |
+| foo.bar.x | tests/nestedAccess.js:5:1:5:8 | fooBar.x |
+| foo.bar.x | tests/nestedAccess.js:10:9:10:11 | z.x |
+| foo.bar.x.y | tests/nestedAccess.js:5:1:5:10 | fooBar.x.y |
+| foo.bar.x.y.z | tests/nestedAccess.js:5:1:5:12 | fooBar.x.y.z |
 | goog | tests/es6Module.js:1:1:1:4 | goog |
 | goog | tests/es6ModuleDefault.js:1:1:1:4 | goog |
 | goog | tests/globalModule.js:1:1:1:4 | goog |
 | goog | tests/globalModuleDefault.js:1:1:1:4 | goog |
 | goog | tests/googModule.js:1:1:1:4 | goog |
 | goog | tests/googModuleDefault.js:1:1:1:4 | goog |
+| goog | tests/nestedAccess.js:1:1:1:4 | goog |
+| goog | tests/nestedAccess.js:3:14:3:17 | goog |
 | goog | tests/requireFromEs6.js:3:20:3:23 | goog |
 | goog | tests/requireFromEs6.js:4:27:4:30 | goog |
 | goog | tests/requireFromEs6.js:6:17:6:20 | goog |
@@ -29,12 +36,14 @@
 | goog.declareModuleId | tests/es6ModuleDefault.js:1:1:1:20 | goog.declareModuleId |
 | goog.module | tests/googModule.js:1:1:1:11 | goog.module |
 | goog.module | tests/googModuleDefault.js:1:1:1:11 | goog.module |
+| goog.module | tests/nestedAccess.js:1:1:1:11 | goog.module |
 | goog.module | tests/requireFromGoogModule.js:1:1:1:11 | goog.module |
 | goog.module | tests/uri.js:1:1:1:11 | goog.module |
 | goog.net | tests/uri.js:3:11:3:34 | goog.re ... g.net') |
 | goog.net.Uri | tests/uri.js:5:5:5:11 | net.Uri |
 | goog.provide | tests/globalModule.js:1:1:1:12 | goog.provide |
 | goog.provide | tests/globalModuleDefault.js:1:1:1:12 | goog.provide |
+| goog.require | tests/nestedAccess.js:3:14:3:25 | goog.require |
 | goog.require | tests/requireFromEs6.js:3:20:3:31 | goog.require |
 | goog.require | tests/requireFromEs6.js:4:27:4:38 | goog.require |
 | goog.require | tests/requireFromEs6.js:6:17:6:28 | goog.require |

--- a/javascript/ql/test/library-tests/Closure/tests/nestedAccess.js
+++ b/javascript/ql/test/library-tests/Closure/tests/nestedAccess.js
@@ -1,0 +1,12 @@
+goog.module('enumuse');
+
+let fooBar = goog.require('foo.bar');
+
+fooBar.x.y.z;
+
+function infinite() {
+  let z = fooBar;
+  while (z) {
+    z = z.x;
+  }
+}


### PR DESCRIPTION
Ensures that `Closure::moduleImport()` handles access paths that are longer than those explicitly declared in the snapshot. Previously it was restricted to access paths that were up to one property access longer than a declared access path.

"Declared" means that there exists a call to `goog.require` or similar with that access path as argument, and was a way to ensure finiteness.

Evaluation underway.