### PR TITLE
JS: remove React library improvements from the change notes

### DIFF
--- a/change-notes/1.20/analysis-javascript.md
+++ b/change-notes/1.20/analysis-javascript.md
@@ -7,7 +7,6 @@
   - [Electron](https://electronjs.org)
   - [hapi](https://hapijs.com/)
   - [js-cookie](https://github.com/js-cookie/js-cookie)
-  - [React](https://reactjs.org/)
   - [Vue](https://vuejs.org/)
 
 * File classification has been improved to recognize additional generated files, for example files from [HTML Tidy](html-tidy.org).


### PR DESCRIPTION
According to git blame, the only 1.20 changes for React are
query-specific improvements, which are mentioned elsewhere in the
change notes.