### PR TITLE
JS: add closure library in globalObjectRef

### DIFF
--- a/javascript/ql/src/semmle/javascript/dataflow/Nodes.qll
+++ b/javascript/ql/src/semmle/javascript/dataflow/Nodes.qll
@@ -286,7 +286,7 @@ DataFlow::SourceNode globalObjectRef() {
   result = moduleImport("global")
   or
   // Closure library - based on AST to avoid recursion with Closure library model
-  result.asExpr().(DotExpr).getQualifiedName() = "goog.global"
+  result = globalVarRef("goog").getAPropertyRead("global")
 }
 
 /**

--- a/javascript/ql/src/semmle/javascript/dataflow/Nodes.qll
+++ b/javascript/ql/src/semmle/javascript/dataflow/Nodes.qll
@@ -284,6 +284,9 @@ DataFlow::SourceNode globalObjectRef() {
   or
   // `require("global")`
   result = moduleImport("global")
+  or
+  // Closure library - based on AST to avoid recursion with Closure library model
+  result.asExpr().(DotExpr).getQualifiedName() = "goog.global"
 }
 
 /**

--- a/javascript/ql/test/library-tests/Nodes/globalObjectRef.expected
+++ b/javascript/ql/test/library-tests/Nodes/globalObjectRef.expected
@@ -3,6 +3,8 @@
 | tst2.js:3:1:3:24 | require ... indow") |
 | tst2.js:7:1:7:6 | global |
 | tst2.js:8:1:8:6 | global |
+| tst3.js:1:1:1:0 | this |
+| tst3.js:3:9:3:19 | goog.global |
 | tst.js:1:1:1:0 | this |
 | tst.js:1:1:1:6 | window |
 | tst.js:3:1:3:6 | window |

--- a/javascript/ql/test/library-tests/Nodes/globalVarRef.expected
+++ b/javascript/ql/test/library-tests/Nodes/globalVarRef.expected
@@ -3,8 +3,11 @@
 | document | tst2.js:2:1:2:26 | require ... ument") |
 | document | tst.js:3:1:3:15 | window.document |
 | document | tst.js:4:1:4:22 | window. ... ocument |
+| foo | tst3.js:4:1:4:5 | w.foo |
 | global | tst2.js:7:1:7:6 | global |
 | global | tst2.js:8:1:8:6 | global |
+| goog | tst3.js:1:1:1:4 | goog |
+| goog | tst3.js:3:9:3:12 | goog |
 | setTimeout | tst2.js:5:1:5:12 | g.setTimeout |
 | window | tst2.js:3:1:3:24 | require ... indow") |
 | window | tst.js:1:1:1:6 | window |

--- a/javascript/ql/test/library-tests/Nodes/tst3.js
+++ b/javascript/ql/test/library-tests/Nodes/tst3.js
@@ -1,0 +1,4 @@
+goog.module('test');
+
+let w = goog.global;
+w.foo;


### PR DESCRIPTION
Recognizes [goog.global](https://google.github.io/closure-library/api/goog.html#global) as an alias for the global object.