### PR TITLE
JS: add taint step through object/array spread operators

### DIFF
--- a/javascript/ql/src/semmle/javascript/dataflow/TaintTracking.qll
+++ b/javascript/ql/src/semmle/javascript/dataflow/TaintTracking.qll
@@ -185,6 +185,12 @@ module TaintTracking {
         or
         // awaiting a tainted expression gives a tainted result
         e.(AwaitExpr).getOperand() = f
+        or
+        // spreading a tainted object into an object literal gives a tainted object
+        e.(ObjectExpr).getAProperty().(SpreadProperty).getInit().(SpreadElement).getOperand() = f
+        or
+        // spreading a tainted value into an array literal gives a tainted array
+        e.(ArrayExpr).getAnElement().(SpreadElement).getOperand() = f
       )
       or
       // reading from a tainted object yields a tainted result

--- a/javascript/ql/test/library-tests/TaintTracking/BasicTaintTracking.expected
+++ b/javascript/ql/test/library-tests/TaintTracking/BasicTaintTracking.expected
@@ -27,6 +27,10 @@
 | sanitizer-guards.js:13:14:13:21 | source() | sanitizer-guards.js:15:10:15:15 | this.x |
 | sanitizer-guards.js:13:14:13:21 | source() | sanitizer-guards.js:21:14:21:19 | this.x |
 | sanitizer-guards.js:13:14:13:21 | source() | sanitizer-guards.js:26:9:26:14 | this.x |
+| spread.js:2:15:2:22 | source() | spread.js:4:8:4:19 | { ...taint } |
+| spread.js:2:15:2:22 | source() | spread.js:5:8:5:43 | { f: 'h ... orld' } |
+| spread.js:2:15:2:22 | source() | spread.js:7:8:7:19 | [ ...taint ] |
+| spread.js:2:15:2:22 | source() | spread.js:8:8:8:28 | [ 1, 2, ... nt, 3 ] |
 | thisAssignments.js:4:17:4:24 | source() | thisAssignments.js:5:10:5:18 | obj.field |
 | thisAssignments.js:7:19:7:26 | source() | thisAssignments.js:8:10:8:20 | this.field2 |
 | tst.js:2:13:2:20 | source() | tst.js:4:10:4:10 | x |

--- a/javascript/ql/test/library-tests/TaintTracking/spread.js
+++ b/javascript/ql/test/library-tests/TaintTracking/spread.js
@@ -1,0 +1,9 @@
+function test() {
+  let taint = source();
+  
+  sink({ ...taint }); // NOT OK
+  sink({ f: 'hello', ...taint, g: 'world' }); // NOT OK
+
+  sink([ ...taint ]); // NOT OK
+  sink([ 1, 2, ...taint, 3 ]); // NOT OK
+}


### PR DESCRIPTION
Evaluation underway.

Intentionally does not deal with spread operators in argument lists.

Fixes https://jira.semmle.com/browse/ODASA-7670