### PR TITLE
C#: Reduce size of `getAThrownException()`

### DIFF
--- a/csharp/ql/src/semmle/code/csharp/controlflow/ControlFlowElement.qll
+++ b/csharp/ql/src/semmle/code/csharp/controlflow/ControlFlowElement.qll
@@ -19,6 +19,11 @@ class ControlFlowElement extends ExprOrStmtParent, @control_flow_element {
   /** Gets the enclosing callable of this element, if any. */
   Callable getEnclosingCallable() { none() }
 
+  /** Gets the assembly that this element was compiled into. */
+  Assembly getAssembly() {
+    result = this.getEnclosingCallable().getDeclaringType().getALocation()
+  }
+
   /**
    * Gets a control flow node for this element. That is, a node in the
    * control flow graph that corresponds to this element.

--- a/csharp/ql/src/semmle/code/csharp/controlflow/internal/Completion.qll
+++ b/csharp/ql/src/semmle/code/csharp/controlflow/internal/Completion.qll
@@ -194,7 +194,7 @@ private class CoreLib extends Assembly {
  */
 pragma[noinline]
 private predicate assemblyCompiledWithCoreLib(Assembly a, CoreLib core) {
-  a.getAnAttribute().getType().getABaseType*().getALocation() = core
+  a.getAnAttribute().getType().getBaseClass*().(SystemAttributeClass).getALocation() = core
 }
 
 /** A control flow element that is inside a `try` block. */
@@ -266,7 +266,7 @@ private class TriedControlFlowElement extends ControlFlowElement {
 
   private CoreLib getCoreLibFromACatchClause() {
     exists(SpecificCatchClause scc | scc = try.getACatchClause() |
-      result = scc.getCaughtExceptionType().getABaseType*().getALocation()
+      result = scc.getCaughtExceptionType().getBaseClass*().(SystemExceptionClass).getALocation()
     )
   }
 
@@ -289,12 +289,12 @@ private class TriedControlFlowElement extends ControlFlowElement {
   }
 
   Class getAThrownException() {
-    exists(string name |
-      result = this.getAThrownExceptionFromPlausibleCoreLib(name) |
+    exists(string name | result = this.getAThrownExceptionFromPlausibleCoreLib(name) |
       result = min(Class c |
-        c = this.getAThrownExceptionFromPlausibleCoreLib(name) |
-        c order by c.getLocation().(Assembly).getFullName()
-      )
+          c = this.getAThrownExceptionFromPlausibleCoreLib(name)
+        |
+          c order by c.getLocation().(Assembly).getFullName()
+        )
     )
   }
 }

--- a/csharp/ql/src/semmle/code/csharp/frameworks/System.qll
+++ b/csharp/ql/src/semmle/code/csharp/frameworks/System.qll
@@ -56,6 +56,11 @@ class SystemArrayClass extends SystemClass {
   SystemArrayClass() { this.hasName("Array") }
 }
 
+/** `System.Attribute` class. */
+class SystemAttributeClass extends SystemClass {
+  SystemAttributeClass() { this.hasName("Attribute") }
+}
+
 /** The `System.Boolean` structure. */
 class SystemBooleanStruct extends BoolType {
   /** Gets the `Parse(string)` method. */


### PR DESCRIPTION
In the precense of multiple core libraries, `getAThrownException()` would return
multiple copies of the same exception, say `System.OverflowException`, one for each
core library. With this change we try to identify which core library a given control
flow element was compiled against, and only return the corresponding version.