### PR TITLE
C++: Function `error` doesn't always exit

### DIFF
--- a/cpp/ql/src/DefaultOptions.qll
+++ b/cpp/ql/src/DefaultOptions.qll
@@ -56,7 +56,7 @@ class Options extends string
    * Holds if a call to this function will never return.
    *
    * By default, this holds for `exit`, `_exit`, `abort`, `__assert_fail`,
-   * `longjmp`, `error`, `__builtin_unreachable` and any function with a
+   * `longjmp`, `__builtin_unreachable` and any function with a
    * `noreturn` attribute.
    */
   predicate exits(Function f) {
@@ -67,7 +67,6 @@ class Options extends string
       name = "abort" or
       name = "__assert_fail" or
       name = "longjmp" or
-      name = "error" or
       name = "__builtin_unreachable"
     ) or
     CustomOptions::exits(f) // old Options.qll

--- a/cpp/ql/test/library-tests/controlflow/exits/exits.expected
+++ b/cpp/ql/test/library-tests/controlflow/exits/exits.expected
@@ -3,7 +3,7 @@
 | test.cpp:1:6:1:9 | exit | exit | exits |
 | test.cpp:2:6:2:10 | _exit | _exit | exits |
 | test.cpp:3:6:3:10 | abort | abort | exits |
-| test.cpp:4:6:4:10 | error | error | exits |
+| test.cpp:4:6:4:10 | error | error | returns |
 | test.cpp:5:6:5:18 | __assert_fail | __assert_fail | exits |
 | test.cpp:7:6:7:12 | longjmp | longjmp | exits |
 | test.cpp:8:6:8:15 | DoesReturn | DoesReturn | returns |


### PR DESCRIPTION
The configuration in `DefaultOptions.qll` assumed that a call to any top-level function named `error` would exit the program. This is not true.

The assumption was probably about `error(3)`, which is a GNU extension. It only exits if its first argument it not 0. Furthermore, projects such as openssh may define their own function named `error` with different behaviour. Because the GNU `error` function is non-standard, it's perfectly fine to shadow it with a project-specific definition.

This change removes two FPs from `PointlessComparison.qll` on https://github.com/openssh/openssh-portable.