### PR TITLE
CPP: Add lots more allocation functions to Alloc.qll

### DIFF
--- a/change-notes/1.20/analysis-cpp.md
+++ b/change-notes/1.20/analysis-cpp.md
@@ -23,6 +23,8 @@
 | Suspicious pointer scaling (`cpp/suspicious-pointer-scaling`) | Fewer false positives | False positives involving types that are not uniquely named in the snapshot have been fixed. |
 | Call to memory access function may overflow buffer (`cpp/overflow-buffer`) | More correct results | Calls to `fread` are now examined by this query. |
 | Lossy function result cast (`cpp/lossy-function-result-cast`) | Fewer false positive results | The whitelist of rounding functions built into this query has been expanded. |
+| Memory is never freed (`cpp/memory-never-freed`) | More correct results | Support for more Microsoft-specific memory allocation/de-allocation functions has been added. |
+| Memory may not be freed (`cpp/memory-may-not-be-freed`) | More correct results | Support for more Microsoft-specific memory allocation/de-allocation functions has been added. |
 | Unused static variable (`cpp/unused-static-variable`) | Fewer false positive results | Variables with the attribute `unused` are now excluded from the query. |
 | Resource not released in destructor (`cpp/resource-not-released-in-destructor`) | Fewer false positive results | Fix false positives where a resource is released via a virtual method call, function pointer, or lambda. |
 | 'new[]' array freed with 'delete' (`cpp/new-array-delete-mismatch`) | More correct results | Data flow through global variables for this query has been improved. |

--- a/cpp/ql/src/semmle/code/cpp/commons/Alloc.qll
+++ b/cpp/ql/src/semmle/code/cpp/commons/Alloc.qll
@@ -15,7 +15,31 @@ predicate allocationFunction(Function f)
       name = "wcsdup" or
       name = "_strdup" or
       name = "_wcsdup" or
-      name = "_mbsdup"
+      name = "_mbsdup" or
+      name = "ExAllocatePool" or
+      name = "ExAllocatePoolWithTag" or
+      name = "ExAllocatePoolWithTagPriority" or
+      name = "ExAllocatePoolWithQuota" or
+      name = "ExAllocatePoolWithQuotaTag" or
+      name = "ExAllocateFromLookasideListEx" or
+      name = "ExAllocateFromPagedLookasideList" or
+      name = "ExAllocateFromNPagedLookasideList" or
+      name = "ExAllocateTimer" or
+      name = "IoAllocateMdl" or
+      name = "IoAllocateWorkItem" or
+      name = "IoAllocateErrorLogEntry" or
+      name = "MmAllocateContiguousMemory" or
+      name = "MmAllocateContiguousNodeMemory" or
+      name = "MmAllocateContiguousMemorySpecifyCache" or
+      name = "MmAllocateContiguousMemorySpecifyCacheNode" or
+      name = "MmAllocateNonCachedMemory" or
+      name = "MmAllocateMappingAddress" or
+      name = "MmAllocatePagesForMdl" or
+      name = "MmAllocatePagesForMdlEx" or
+      name = "MmAllocateNodePagesForMdlEx" or
+      name = "MmMapLockedPagesWithReservedMapping" or
+      name = "MmMapLockedPages" or
+      name = "MmMapLockedPagesSpecifyCache"
     )
   )
 }
@@ -42,7 +66,22 @@ predicate freeFunction(Function f, int argNum)
     f.hasQualifiedName(name) and
     (
       (name = "free" and argNum = 0) or
-      (name = "realloc" and argNum = 0)
+      (name = "realloc" and argNum = 0) or
+      (name = "ExFreePoolWithTag" and argNum = 0) or
+      (name = "ExFreeToLookasideListEx" and argNum = 1) or
+      (name = "ExFreeToPagedLookasideList" and argNum = 1) or
+      (name = "ExFreeToNPagedLookasideList" and argNum = 1) or
+      (name = "ExDeleteTimer" and argNum = 0) or
+      (name = "IoFreeMdl" and argNum = 0) or
+      (name = "IoFreeWorkItem" and argNum = 0) or
+      (name = "IoFreeErrorLogEntry" and argNum = 0) or
+      (name = "MmFreeContiguousMemory" and argNum = 0) or
+      (name = "MmFreeContiguousMemorySpecifyCache" and argNum = 0) or
+      (name = "MmFreeNonCachedMemory" and argNum = 0) or
+      (name = "MmFreeMappingAddress" and argNum = 0) or
+      (name = "MmFreePagesFromMdl" and argNum = 0) or
+      (name = "MmUnmapReservedMapping" and argNum = 0) or
+      (name = "MmUnmapLockedPages" and argNum = 0)
     )
   )
 }


### PR DESCRIPTION
On certain Microsoft-heavy code bases, these changes may result in many new results for the 'Memory is never freed' and 'Memory may not be freed' queries.

@lukecartey