### PR TITLE
JavaScript: Make file types customisable in AutoBuild.

### DIFF
--- a/javascript/extractor/src/com/semmle/js/extractor/AutoBuild.java
+++ b/javascript/extractor/src/com/semmle/js/extractor/AutoBuild.java
@@ -58,6 +58,23 @@ import com.semmle.util.trap.TrapWriter;
  * </ul>
  *
  * <p>
+ * Additionally, the following environment variables may be set to customise extraction
+ * (explained in more detail below):
+ * </p>
+ *
+ * <ul>
+ * <li><code>LGTM_INDEX_INCLUDE</code>: a newline-separated list of paths to include</li>
+ * <li><code>LGTM_INDEX_EXCLUDE</code>: a newline-separated list of paths to exclude</li>
+ * <li><code>LGTM_REPOSITORY_FOLDERS_CSV</code>: the path of a CSV file containing file classifications</li>
+ * <li><code>LGTM_INDEX_FILTERS</code>: a newline-separated list of {@link ProjectLayout}-style
+ * patterns that can be used to refine the list of files to include and exclude</li>
+ * <li><code>LGTM_INDEX_TYPESCRIPT</code>: whether to extract TypeScript</li>
+ * <li><code>LGTM_INDEX_THREADS</code>: the maximum number of files to extract in parallel</li>
+ * <li><code>LGTM_TRAP_CACHE</code>: the path of a directory to use for trap caching</li>
+ * <li><code>LGTM_TRAP_CACHE_BOUND</code>: the size to bound the trap cache to</li>
+ </ul>
+ *
+ * <p>
  * It extracts the following:
  * </p>
  *


### PR DESCRIPTION
Every once in a while we encounter projects using some custom file extension for files that we could in principle extract, but since the extractor doesn't know about the extension the files are skipped.

To handle this, the legacy extractor has a `--file-type` option that one can use to specify a file type to use for all files in that particular extraction. So far, `AutoBuild` has nothing of the sort.

This PR proposes to introduce an environment variable `LGTM_INDEX_FILETYPES` to allow a similar customisation. In the fullness of time, this variable would be set through `lgtm.yml` in the usual way, but for now it is undocumented and for internal use only.

Specifically, `LGTM_INDEX_FILETYPES` is a newline-separated list of ".extension:filetype" pairs, specifying that files with the given `.extension` should be extracted as type `filetype`, where `filetype` is one of `js`, `html`, `json`, `typescript` or `yaml`.

For example, `.jsm:js` causes all `.jsm` files to be extracted as JavaScript.

This can also be used to override default file types: for example, by specifying `.js:typescript` all JavaScript files will be extracted as TypeScript.