### PR TITLE
C++: Support definition by reference in data flow library

### DIFF
--- a/change-notes/1.20/analysis-cpp.md
+++ b/change-notes/1.20/analysis-cpp.md
@@ -34,6 +34,10 @@
 
 ## Changes to QL libraries
 
+* The `semmle.code.cpp.dataflow.DataFlow` library now supports _definition by reference_ via output parameters of known functions.
+    * Data flows through `memcpy` and `memmove` by default.
+    * Custom flow into or out of arguments assigned by reference can be modelled with the new class `DataFlow::DefinitionByReferenceNode`.
+    * The data flow library adds flow through library functions that are modeled in `semmle.code.cpp.models.interfaces.DataFlow`. Queries can add subclasses of `DataFlowFunction` to specify additional flow.
 * There is a new `Namespace.isInline()` predicate, which holds if the namespace was declared as `inline namespace`.
 * The `Expr.isConstant()` predicate now also holds for _address constant expressions_, which are addresses that will be constant after the program has been linked. These address constants do not have a result for `Expr.getValue()`.
 * There are new `Function.isDeclaredConstexpr()` and `Function.isConstexpr()` predicates. They can be used to tell whether a function was declared as `constexpr`, and whether it actually is `constexpr`.

--- a/cpp/ql/src/semmle/code/cpp/dataflow/internal/DataFlowUtil.qll
+++ b/cpp/ql/src/semmle/code/cpp/dataflow/internal/DataFlowUtil.qll
@@ -45,11 +45,6 @@ class Node extends TNode {
   /** Gets the argument that defines this `DefinitionByReferenceNode`, if any. */
   Expr asDefiningArgument() { result = this.(DefinitionByReferenceNode).getArgument() }
 
-  /** Gets the VariableAccess that defines this `DefinitionByReferenceNode`, if any. */
-  VariableAccess asDefiningVariableAccess() {
-    result = this.(DefinitionByReferenceNode).getVariableAccess()
-  }
-
   /**
    * Gets the uninitialized local variable corresponding to this node, if
    * any.
@@ -113,8 +108,7 @@ class ParameterNode extends Node, TParameterNode {
  * A typical example would be a call `f(&x)`. Firstly, there will be flow into
  * `x` from previous definitions of `x`. Secondly, there will be a
  * `DefinitionByReferenceNode` to represent the value of `x` after the call has
- * returned. This node will have its `getArgument()` equal to `&x` and its
- * `getVariableAccess()` equal to `x`.
+ * returned. This node will have its `getArgument()` equal to `&x`.
  */
 class DefinitionByReferenceNode extends Node, TDefinitionByReferenceNode {
   VariableAccess va;
@@ -127,8 +121,6 @@ class DefinitionByReferenceNode extends Node, TDefinitionByReferenceNode {
   override Location getLocation() { result = argument.getLocation() }
   /** Gets the argument corresponding to this node. */
   Expr getArgument() { result = argument }
-  /** Gets the variable access corresponding to this node. */
-  VariableAccess getVariableAccess() { result = va }
 }
 
 /**
@@ -182,14 +174,6 @@ ParameterNode parameterNode(Parameter p) { result.getParameter() = p }
  */
 DefinitionByReferenceNode definitionByReferenceNodeFromArgument(Expr argument) {
   result.getArgument() = argument
-}
-
-/**
- * Gets the `Node` corresponding to a definition by reference of the variable
- * that is passed by reference as `va` in a call argument.
- */
-DefinitionByReferenceNode definitionByReferenceNodeFromVariableAccess(VariableAccess va) {
-  result.getVariableAccess() = va
 }
 
 /**

--- a/cpp/ql/src/semmle/code/cpp/dataflow/internal/DataFlowUtil.qll
+++ b/cpp/ql/src/semmle/code/cpp/dataflow/internal/DataFlowUtil.qll
@@ -292,10 +292,14 @@ private predicate exprToExprStep_nocfg(Expr fromExpr, Expr toExpr) {
     fromExpr = op.getOperand()
   )
   or
-  toExpr = any(FunctionCall moveCall |
-    moveCall.getTarget().getNamespace().getName() = "std" and
-    moveCall.getTarget().getName() = "move" and
-    fromExpr = moveCall.getArgument(0)
+  toExpr = any(Call call |
+    exists(DataFlowFunction f, FunctionInput inModel , FunctionOutput outModel, int iIn |
+      call.getTarget() = f and
+      f.hasDataFlow(inModel, outModel) and
+      outModel.isOutReturnValue() and
+      inModel.isInParameter(iIn) and
+      fromExpr = call.getArgument(iIn)
+    )
   )
 }
 

--- a/cpp/ql/src/semmle/code/cpp/dataflow/internal/DataFlowUtil.qll
+++ b/cpp/ql/src/semmle/code/cpp/dataflow/internal/DataFlowUtil.qll
@@ -121,6 +121,13 @@ class DefinitionByReferenceNode extends Node, TDefinitionByReferenceNode {
   override Location getLocation() { result = argument.getLocation() }
   /** Gets the argument corresponding to this node. */
   Expr getArgument() { result = argument }
+  /** Gets the parameter through which this value is assigned. */
+  Parameter getParameter() {
+    exists(FunctionCall call, int i |
+      argument = call.getArgument(i) and
+      result = call.getTarget().getParameter(i)
+    )
+  }
 }
 
 /**

--- a/cpp/ql/test/library-tests/dataflow/dataflow-tests/DataflowTestCommon.qll
+++ b/cpp/ql/test/library-tests/dataflow/dataflow-tests/DataflowTestCommon.qll
@@ -12,6 +12,8 @@ class TestAllocationConfig extends DataFlow::Configuration {
     or
     source.asParameter().getName().matches("source%")
     or
+    source.(DataFlow::DefinitionByReferenceNode).getParameter().getName().matches("ref_source%")
+    or
     // Track uninitialized variables
     exists(source.asUninitialized())
   }

--- a/cpp/ql/test/library-tests/dataflow/dataflow-tests/localFlow.expected
+++ b/cpp/ql/test/library-tests/dataflow/dataflow-tests/localFlow.expected
@@ -28,3 +28,12 @@
 | test.cpp:24:10:24:11 | t2 | test.cpp:23:23:23:24 | t1 |
 | test.cpp:24:10:24:11 | t2 | test.cpp:24:5:24:11 | ... = ... |
 | test.cpp:24:10:24:11 | t2 | test.cpp:26:8:26:9 | t1 |
+| test.cpp:430:48:430:54 | source1 | test.cpp:432:17:432:23 | source1 |
+| test.cpp:431:12:431:13 | 0 | test.cpp:432:11:432:13 | tmp |
+| test.cpp:436:53:436:59 | source1 | test.cpp:439:17:439:23 | source1 |
+| test.cpp:436:66:436:66 | b | test.cpp:441:7:441:7 | b |
+| test.cpp:437:12:437:13 | 0 | test.cpp:438:19:438:21 | tmp |
+| test.cpp:437:12:437:13 | 0 | test.cpp:439:11:439:13 | tmp |
+| test.cpp:437:12:437:13 | 0 | test.cpp:439:33:439:35 | tmp |
+| test.cpp:437:12:437:13 | 0 | test.cpp:440:8:440:10 | tmp |
+| test.cpp:437:12:437:13 | 0 | test.cpp:442:10:442:12 | tmp |

--- a/cpp/ql/test/library-tests/dataflow/dataflow-tests/localFlow.expected
+++ b/cpp/ql/test/library-tests/dataflow/dataflow-tests/localFlow.expected
@@ -5,6 +5,7 @@
 | example.c:24:13:24:30 | ... = ... | example.c:24:2:24:30 | ... = ... |
 | example.c:24:24:24:30 | ... + ... | example.c:24:13:24:30 | ... = ... |
 | example.c:26:13:26:16 | call to getX | example.c:26:2:26:25 | ... = ... |
+| example.c:26:18:26:24 | ref arg & ... | example.c:26:2:26:7 | coords |
 | test.cpp:6:12:6:17 | call to source | test.cpp:7:8:7:9 | t1 |
 | test.cpp:6:12:6:17 | call to source | test.cpp:8:8:8:9 | t1 |
 | test.cpp:6:12:6:17 | call to source | test.cpp:9:8:9:9 | t1 |
@@ -30,7 +31,13 @@
 | test.cpp:24:10:24:11 | t2 | test.cpp:26:8:26:9 | t1 |
 | test.cpp:430:48:430:54 | source1 | test.cpp:432:17:432:23 | source1 |
 | test.cpp:431:12:431:13 | 0 | test.cpp:432:11:432:13 | tmp |
+| test.cpp:432:10:432:13 | ref arg & ... | test.cpp:433:8:433:10 | tmp |
+| test.cpp:432:17:432:23 | source1 | test.cpp:432:10:432:13 | ref arg & ... |
 | test.cpp:436:53:436:59 | source1 | test.cpp:439:17:439:23 | source1 |
 | test.cpp:436:66:436:66 | b | test.cpp:441:7:441:7 | b |
 | test.cpp:437:12:437:13 | 0 | test.cpp:438:19:438:21 | tmp |
 | test.cpp:437:12:437:13 | 0 | test.cpp:439:11:439:13 | tmp |
+| test.cpp:439:10:439:13 | ref arg & ... | test.cpp:439:33:439:35 | tmp |
+| test.cpp:439:10:439:13 | ref arg & ... | test.cpp:440:8:440:10 | tmp |
+| test.cpp:439:10:439:13 | ref arg & ... | test.cpp:442:10:442:12 | tmp |
+| test.cpp:439:17:439:23 | source1 | test.cpp:439:10:439:13 | ref arg & ... |

--- a/cpp/ql/test/library-tests/dataflow/dataflow-tests/localFlow.expected
+++ b/cpp/ql/test/library-tests/dataflow/dataflow-tests/localFlow.expected
@@ -31,12 +31,14 @@
 | test.cpp:24:10:24:11 | t2 | test.cpp:26:8:26:9 | t1 |
 | test.cpp:430:48:430:54 | source1 | test.cpp:432:17:432:23 | source1 |
 | test.cpp:431:12:431:13 | 0 | test.cpp:432:11:432:13 | tmp |
+| test.cpp:432:10:432:13 | & ... | test.cpp:432:3:432:8 | call to memcpy |
 | test.cpp:432:10:432:13 | ref arg & ... | test.cpp:433:8:433:10 | tmp |
 | test.cpp:432:17:432:23 | source1 | test.cpp:432:10:432:13 | ref arg & ... |
 | test.cpp:436:53:436:59 | source1 | test.cpp:439:17:439:23 | source1 |
 | test.cpp:436:66:436:66 | b | test.cpp:441:7:441:7 | b |
 | test.cpp:437:12:437:13 | 0 | test.cpp:438:19:438:21 | tmp |
 | test.cpp:437:12:437:13 | 0 | test.cpp:439:11:439:13 | tmp |
+| test.cpp:439:10:439:13 | & ... | test.cpp:439:3:439:8 | call to memcpy |
 | test.cpp:439:10:439:13 | ref arg & ... | test.cpp:439:33:439:35 | tmp |
 | test.cpp:439:10:439:13 | ref arg & ... | test.cpp:440:8:440:10 | tmp |
 | test.cpp:439:10:439:13 | ref arg & ... | test.cpp:442:10:442:12 | tmp |

--- a/cpp/ql/test/library-tests/dataflow/dataflow-tests/localFlow.expected
+++ b/cpp/ql/test/library-tests/dataflow/dataflow-tests/localFlow.expected
@@ -34,6 +34,3 @@
 | test.cpp:436:66:436:66 | b | test.cpp:441:7:441:7 | b |
 | test.cpp:437:12:437:13 | 0 | test.cpp:438:19:438:21 | tmp |
 | test.cpp:437:12:437:13 | 0 | test.cpp:439:11:439:13 | tmp |
-| test.cpp:437:12:437:13 | 0 | test.cpp:439:33:439:35 | tmp |
-| test.cpp:437:12:437:13 | 0 | test.cpp:440:8:440:10 | tmp |
-| test.cpp:437:12:437:13 | 0 | test.cpp:442:10:442:12 | tmp |

--- a/cpp/ql/test/library-tests/dataflow/dataflow-tests/test.cpp
+++ b/cpp/ql/test/library-tests/dataflow/dataflow-tests/test.cpp
@@ -453,5 +453,5 @@ void cleanedByMemcpy_blockvar(int clean1) {
   int tmp;
   int *capture = &tmp;
   memcpy(&tmp, &clean1, sizeof tmp);
-  sink(tmp); // clean (FALSE POSITIVE)
+  sink(tmp); // clean
 }

--- a/cpp/ql/test/library-tests/dataflow/dataflow-tests/test.cpp
+++ b/cpp/ql/test/library-tests/dataflow/dataflow-tests/test.cpp
@@ -455,3 +455,39 @@ void cleanedByMemcpy_blockvar(int clean1) {
   memcpy(&tmp, &clean1, sizeof tmp);
   sink(tmp); // clean
 }
+
+void intRefSource(int &ref_source);
+void intPointerSource(int *ref_source);
+void intArraySource(int ref_source[], size_t len);
+
+void intRefSourceCaller() {
+  int local;
+  intRefSource(local);
+  sink(local); // tainted
+}
+
+void intPointerSourceCaller() {
+  int local;
+  intPointerSource(&local);
+  sink(local); // tainted
+}
+
+void intPointerSourceCaller2() {
+  int local[1];
+  intPointerSource(local);
+  sink(local); // tainted
+  sink(*local); // clean
+}
+
+void intArraySourceCaller() {
+  int local;
+  intArraySource(&local, 1);
+  sink(local); // tainted
+}
+
+void intArraySourceCaller2() {
+  int local[2];
+  intArraySource(local, 2);
+  sink(local); // tainted
+  sink(*local); // clean
+}

--- a/cpp/ql/test/library-tests/dataflow/dataflow-tests/test.cpp
+++ b/cpp/ql/test/library-tests/dataflow/dataflow-tests/test.cpp
@@ -430,16 +430,16 @@ void *memcpy(void *dest, const void *src, size_t count);
 void flowThroughMemcpy_ssa_with_local_flow(int source1) {
   int tmp = 0;
   memcpy(&tmp, &source1, sizeof tmp);
-  sink(tmp); // tainted (FALSE NEGATIVE)
+  sink(tmp); // tainted
 }
 
 void flowThroughMemcpy_blockvar_with_local_flow(int source1, int b) {
   int tmp = 0;
   int *capture = &tmp;
   memcpy(&tmp, &source1, sizeof tmp);
-  sink(tmp); // tainted (FALSE NEGATIVE)
+  sink(tmp); // tainted
   if (b) {
-    sink(tmp); // different sub-basic-block
+    sink(tmp); // tainted
   }
 }
 

--- a/cpp/ql/test/library-tests/dataflow/dataflow-tests/test.cpp
+++ b/cpp/ql/test/library-tests/dataflow/dataflow-tests/test.cpp
@@ -423,3 +423,35 @@ class FlowThroughFields {
     sink(field); // tainted
   }
 };
+
+typedef unsigned long size_t;
+void *memcpy(void *dest, const void *src, size_t count);
+
+void flowThroughMemcpy_ssa_with_local_flow(int source1) {
+  int tmp = 0;
+  memcpy(&tmp, &source1, sizeof tmp);
+  sink(tmp); // tainted (FALSE NEGATIVE)
+}
+
+void flowThroughMemcpy_blockvar_with_local_flow(int source1, int b) {
+  int tmp = 0;
+  int *capture = &tmp;
+  memcpy(&tmp, &source1, sizeof tmp);
+  sink(tmp); // tainted (FALSE NEGATIVE)
+  if (b) {
+    sink(tmp); // different sub-basic-block
+  }
+}
+
+void cleanedByMemcpy_ssa(int clean1) {
+  int tmp;
+  memcpy(&tmp, &clean1, sizeof tmp);
+  sink(tmp); // clean
+}
+
+void cleanedByMemcpy_blockvar(int clean1) {
+  int tmp;
+  int *capture = &tmp;
+  memcpy(&tmp, &clean1, sizeof tmp);
+  sink(tmp); // clean (FALSE POSITIVE)
+}

--- a/cpp/ql/test/library-tests/dataflow/dataflow-tests/test.expected
+++ b/cpp/ql/test/library-tests/dataflow/dataflow-tests/test.expected
@@ -30,6 +30,11 @@
 | test.cpp:433:8:433:10 | tmp | test.cpp:430:48:430:54 | source1 |
 | test.cpp:440:8:440:10 | tmp | test.cpp:436:53:436:59 | source1 |
 | test.cpp:442:10:442:12 | tmp | test.cpp:436:53:436:59 | source1 |
+| test.cpp:466:8:466:12 | local | test.cpp:465:16:465:20 | ref arg local |
+| test.cpp:472:8:472:12 | local | test.cpp:471:20:471:25 | ref arg & ... |
+| test.cpp:478:8:478:12 | local | test.cpp:477:20:477:24 | ref arg local |
+| test.cpp:485:8:485:12 | local | test.cpp:484:18:484:23 | ref arg & ... |
+| test.cpp:491:8:491:12 | local | test.cpp:490:18:490:22 | ref arg local |
 | true_upon_entry.cpp:21:8:21:8 | x | true_upon_entry.cpp:17:11:17:16 | call to source |
 | true_upon_entry.cpp:29:8:29:8 | x | true_upon_entry.cpp:27:9:27:14 | call to source |
 | true_upon_entry.cpp:39:8:39:8 | x | true_upon_entry.cpp:33:11:33:16 | call to source |

--- a/cpp/ql/test/library-tests/dataflow/dataflow-tests/test.expected
+++ b/cpp/ql/test/library-tests/dataflow/dataflow-tests/test.expected
@@ -27,6 +27,8 @@
 | test.cpp:366:7:366:7 | x | test.cpp:362:4:362:9 | call to source |
 | test.cpp:397:10:397:18 | globalVar | test.cpp:395:17:395:22 | call to source |
 | test.cpp:423:10:423:14 | field | test.cpp:421:13:421:18 | call to source |
+| test.cpp:449:8:449:10 | tmp | test.cpp:447:7:447:9 | tmp |
+| test.cpp:456:8:456:10 | tmp | test.cpp:453:7:453:9 | tmp |
 | true_upon_entry.cpp:21:8:21:8 | x | true_upon_entry.cpp:17:11:17:16 | call to source |
 | true_upon_entry.cpp:29:8:29:8 | x | true_upon_entry.cpp:27:9:27:14 | call to source |
 | true_upon_entry.cpp:39:8:39:8 | x | true_upon_entry.cpp:33:11:33:16 | call to source |

--- a/cpp/ql/test/library-tests/dataflow/dataflow-tests/test.expected
+++ b/cpp/ql/test/library-tests/dataflow/dataflow-tests/test.expected
@@ -27,6 +27,9 @@
 | test.cpp:366:7:366:7 | x | test.cpp:362:4:362:9 | call to source |
 | test.cpp:397:10:397:18 | globalVar | test.cpp:395:17:395:22 | call to source |
 | test.cpp:423:10:423:14 | field | test.cpp:421:13:421:18 | call to source |
+| test.cpp:433:8:433:10 | tmp | test.cpp:430:48:430:54 | source1 |
+| test.cpp:440:8:440:10 | tmp | test.cpp:436:53:436:59 | source1 |
+| test.cpp:442:10:442:12 | tmp | test.cpp:436:53:436:59 | source1 |
 | true_upon_entry.cpp:21:8:21:8 | x | true_upon_entry.cpp:17:11:17:16 | call to source |
 | true_upon_entry.cpp:29:8:29:8 | x | true_upon_entry.cpp:27:9:27:14 | call to source |
 | true_upon_entry.cpp:39:8:39:8 | x | true_upon_entry.cpp:33:11:33:16 | call to source |

--- a/cpp/ql/test/library-tests/dataflow/dataflow-tests/test.expected
+++ b/cpp/ql/test/library-tests/dataflow/dataflow-tests/test.expected
@@ -27,8 +27,6 @@
 | test.cpp:366:7:366:7 | x | test.cpp:362:4:362:9 | call to source |
 | test.cpp:397:10:397:18 | globalVar | test.cpp:395:17:395:22 | call to source |
 | test.cpp:423:10:423:14 | field | test.cpp:421:13:421:18 | call to source |
-| test.cpp:449:8:449:10 | tmp | test.cpp:447:7:447:9 | tmp |
-| test.cpp:456:8:456:10 | tmp | test.cpp:453:7:453:9 | tmp |
 | true_upon_entry.cpp:21:8:21:8 | x | true_upon_entry.cpp:17:11:17:16 | call to source |
 | true_upon_entry.cpp:29:8:29:8 | x | true_upon_entry.cpp:27:9:27:14 | call to source |
 | true_upon_entry.cpp:39:8:39:8 | x | true_upon_entry.cpp:33:11:33:16 | call to source |

--- a/cpp/ql/test/library-tests/dataflow/dataflow-tests/test_diff.expected
+++ b/cpp/ql/test/library-tests/dataflow/dataflow-tests/test_diff.expected
@@ -9,6 +9,9 @@
 | test.cpp:136:27:136:32 | test.cpp:140:22:140:23 | AST only |
 | test.cpp:395:17:395:22 | test.cpp:397:10:397:18 | AST only |
 | test.cpp:421:13:421:18 | test.cpp:423:10:423:14 | AST only |
+| test.cpp:430:48:430:54 | test.cpp:433:8:433:10 | AST only |
+| test.cpp:436:53:436:59 | test.cpp:440:8:440:10 | AST only |
+| test.cpp:436:53:436:59 | test.cpp:442:10:442:12 | AST only |
 | true_upon_entry.cpp:9:11:9:16 | true_upon_entry.cpp:13:8:13:8 | IR only |
 | true_upon_entry.cpp:62:11:62:16 | true_upon_entry.cpp:66:8:66:8 | IR only |
 | true_upon_entry.cpp:98:11:98:16 | true_upon_entry.cpp:105:8:105:8 | IR only |

--- a/cpp/ql/test/library-tests/dataflow/dataflow-tests/test_diff.expected
+++ b/cpp/ql/test/library-tests/dataflow/dataflow-tests/test_diff.expected
@@ -12,6 +12,11 @@
 | test.cpp:430:48:430:54 | test.cpp:433:8:433:10 | AST only |
 | test.cpp:436:53:436:59 | test.cpp:440:8:440:10 | AST only |
 | test.cpp:436:53:436:59 | test.cpp:442:10:442:12 | AST only |
+| test.cpp:465:16:465:20 | test.cpp:466:8:466:12 | AST only |
+| test.cpp:471:20:471:25 | test.cpp:472:8:472:12 | AST only |
+| test.cpp:477:20:477:24 | test.cpp:478:8:478:12 | AST only |
+| test.cpp:484:18:484:23 | test.cpp:485:8:485:12 | AST only |
+| test.cpp:490:18:490:22 | test.cpp:491:8:491:12 | AST only |
 | true_upon_entry.cpp:9:11:9:16 | true_upon_entry.cpp:13:8:13:8 | IR only |
 | true_upon_entry.cpp:62:11:62:16 | true_upon_entry.cpp:66:8:66:8 | IR only |
 | true_upon_entry.cpp:98:11:98:16 | true_upon_entry.cpp:105:8:105:8 | IR only |

--- a/cpp/ql/test/library-tests/dataflow/dataflow-tests/test_diff.expected
+++ b/cpp/ql/test/library-tests/dataflow/dataflow-tests/test_diff.expected
@@ -9,6 +9,8 @@
 | test.cpp:136:27:136:32 | test.cpp:140:22:140:23 | AST only |
 | test.cpp:395:17:395:22 | test.cpp:397:10:397:18 | AST only |
 | test.cpp:421:13:421:18 | test.cpp:423:10:423:14 | AST only |
+| test.cpp:447:7:447:9 | test.cpp:449:8:449:10 | AST only |
+| test.cpp:453:7:453:9 | test.cpp:456:8:456:10 | AST only |
 | true_upon_entry.cpp:9:11:9:16 | true_upon_entry.cpp:13:8:13:8 | IR only |
 | true_upon_entry.cpp:62:11:62:16 | true_upon_entry.cpp:66:8:66:8 | IR only |
 | true_upon_entry.cpp:98:11:98:16 | true_upon_entry.cpp:105:8:105:8 | IR only |

--- a/cpp/ql/test/library-tests/dataflow/dataflow-tests/test_diff.expected
+++ b/cpp/ql/test/library-tests/dataflow/dataflow-tests/test_diff.expected
@@ -9,8 +9,6 @@
 | test.cpp:136:27:136:32 | test.cpp:140:22:140:23 | AST only |
 | test.cpp:395:17:395:22 | test.cpp:397:10:397:18 | AST only |
 | test.cpp:421:13:421:18 | test.cpp:423:10:423:14 | AST only |
-| test.cpp:447:7:447:9 | test.cpp:449:8:449:10 | AST only |
-| test.cpp:453:7:453:9 | test.cpp:456:8:456:10 | AST only |
 | true_upon_entry.cpp:9:11:9:16 | true_upon_entry.cpp:13:8:13:8 | IR only |
 | true_upon_entry.cpp:62:11:62:16 | true_upon_entry.cpp:66:8:66:8 | IR only |
 | true_upon_entry.cpp:98:11:98:16 | true_upon_entry.cpp:105:8:105:8 | IR only |

--- a/cpp/ql/test/library-tests/dataflow/dataflow-tests/uninitialized.expected
+++ b/cpp/ql/test/library-tests/dataflow/dataflow-tests/uninitialized.expected
@@ -1,3 +1,8 @@
 | test.cpp:75:7:75:8 | u1 | test.cpp:76:8:76:9 | u1 |
 | test.cpp:83:7:83:8 | u2 | test.cpp:84:13:84:14 | u2 |
 | test.cpp:83:7:83:8 | u2 | test.cpp:85:8:85:9 | u2 |
+| test.cpp:447:7:447:9 | tmp | test.cpp:448:11:448:13 | tmp |
+| test.cpp:447:7:447:9 | tmp | test.cpp:449:8:449:10 | tmp |
+| test.cpp:453:7:453:9 | tmp | test.cpp:454:19:454:21 | tmp |
+| test.cpp:453:7:453:9 | tmp | test.cpp:455:11:455:13 | tmp |
+| test.cpp:453:7:453:9 | tmp | test.cpp:456:8:456:10 | tmp |

--- a/cpp/ql/test/library-tests/dataflow/dataflow-tests/uninitialized.expected
+++ b/cpp/ql/test/library-tests/dataflow/dataflow-tests/uninitialized.expected
@@ -1,8 +1,4 @@
 | test.cpp:75:7:75:8 | u1 | test.cpp:76:8:76:9 | u1 |
 | test.cpp:83:7:83:8 | u2 | test.cpp:84:13:84:14 | u2 |
 | test.cpp:83:7:83:8 | u2 | test.cpp:85:8:85:9 | u2 |
-| test.cpp:447:7:447:9 | tmp | test.cpp:448:11:448:13 | tmp |
-| test.cpp:447:7:447:9 | tmp | test.cpp:449:8:449:10 | tmp |
 | test.cpp:453:7:453:9 | tmp | test.cpp:454:19:454:21 | tmp |
-| test.cpp:453:7:453:9 | tmp | test.cpp:455:11:455:13 | tmp |
-| test.cpp:453:7:453:9 | tmp | test.cpp:456:8:456:10 | tmp |

--- a/cpp/ql/test/library-tests/dataflow/taint-tests/localTaint.expected
+++ b/cpp/ql/test/library-tests/dataflow/taint-tests/localTaint.expected
@@ -129,6 +129,9 @@
 | taint.cpp:164:19:164:24 | call to source | taint.cpp:172:18:172:24 | tainted |  |
 | taint.cpp:165:22:165:25 | {...} | taint.cpp:170:10:170:15 | buffer |  |
 | taint.cpp:165:24:165:24 | 0 | taint.cpp:165:22:165:25 | {...} | TAINT |
+| taint.cpp:170:10:170:15 | ref arg buffer | taint.cpp:171:8:171:13 | buffer |  |
+| taint.cpp:171:8:171:13 | ref arg buffer | taint.cpp:172:10:172:15 | buffer |  |
+| taint.cpp:172:10:172:15 | ref arg buffer | taint.cpp:173:8:173:13 | buffer |  |
 | taint.cpp:180:19:180:19 | p | taint.cpp:181:9:181:9 | p |  |
 | taint.cpp:181:9:181:9 | p | taint.cpp:181:8:181:9 | * ... | TAINT |
 | taint.cpp:185:11:185:16 | call to source | taint.cpp:186:11:186:11 | x |  |

--- a/cpp/ql/test/library-tests/dataflow/taint-tests/localTaint.expected
+++ b/cpp/ql/test/library-tests/dataflow/taint-tests/localTaint.expected
@@ -129,8 +129,10 @@
 | taint.cpp:164:19:164:24 | call to source | taint.cpp:172:18:172:24 | tainted |  |
 | taint.cpp:165:22:165:25 | {...} | taint.cpp:170:10:170:15 | buffer |  |
 | taint.cpp:165:24:165:24 | 0 | taint.cpp:165:22:165:25 | {...} | TAINT |
+| taint.cpp:170:10:170:15 | buffer | taint.cpp:170:3:170:8 | call to strcpy |  |
 | taint.cpp:170:10:170:15 | ref arg buffer | taint.cpp:171:8:171:13 | buffer |  |
 | taint.cpp:171:8:171:13 | ref arg buffer | taint.cpp:172:10:172:15 | buffer |  |
+| taint.cpp:172:10:172:15 | buffer | taint.cpp:172:3:172:8 | call to strcat |  |
 | taint.cpp:172:10:172:15 | ref arg buffer | taint.cpp:173:8:173:13 | buffer |  |
 | taint.cpp:180:19:180:19 | p | taint.cpp:181:9:181:9 | p |  |
 | taint.cpp:181:9:181:9 | p | taint.cpp:181:8:181:9 | * ... | TAINT |


### PR DESCRIPTION
The IR-based data flow library won’t  become the default in 1.20, so I've added support for definition by reference to the current one. This PR doesn't support flow out of callers whose body assigns to a pointer parameter; that will still have to wait for the IR. What's supported now is flow through known library functions and manual specification of flow sources as `DefinitionByReferenceNode`s. I've hooked data flow up to the `semmle.code.cpp.models.interfaces.DataFlow` library, which immediately gives us flow through `memcpy` and related functions.

We need to find out whether this interface with `DefinitionByReferenceNode` is going to be forward-compatible with whatever is coming in the IR. We can always deprecate it, but it should at least allow feature parity between the current library and the IR-based one.

Before this PR, data flow around definition by reference was different depending on whether a variable was modelled in `FlowVar.qll` as `SsaVar` or `BlockVar`. It's supposed to be an implementation detail that variables can be modelled in these two different ways. Essentially, `SsaVar`-modelled variables would stop their data flow propagation at `f(&x)`, while `BlockVar`-modelled variables wouldn't. I've changed `BlockVar` to do what `SsaVar` does.

The implementation was a bit tricky because it added cases to `FlowVar` where a control-flow node is simultaneously a definition and a use, similar to what I did in https://git.semmle.com/Semmle/code/pull/23501.