### PR TITLE
JS: Recognize '+' in suffix check

### DIFF
--- a/javascript/ql/src/Security/CWE-020/IncorrectSuffixCheck.ql
+++ b/javascript/ql/src/Security/CWE-020/IncorrectSuffixCheck.ql
@@ -95,9 +95,9 @@ predicate isDerivedFromLength(DataFlow::Node length, DataFlow::Node operand) {
   or
   isDerivedFromLength(length.getAPredecessor(), operand)
   or
-  exists(SubExpr sub |
-    isDerivedFromLength(sub.getAnOperand().flow(), operand) and
-    length = sub.flow()
+  exists(BinaryExpr expr | expr instanceof SubExpr or expr instanceof AddExpr |
+    isDerivedFromLength(expr.getAnOperand().flow(), operand) and
+    length = expr.flow()
   )
 }
 

--- a/javascript/ql/test/query-tests/Security/CWE-020/IncorrectSuffixCheck.expected
+++ b/javascript/ql/test/query-tests/Security/CWE-020/IncorrectSuffixCheck.expected
@@ -8,3 +8,4 @@
 | tst.js:55:32:55:71 | x.index ... gth - 1 | This suffix check is missing a length comparison to correctly handle indexOf returning -1. |
 | tst.js:67:32:67:71 | x.index ... gth - 1 | This suffix check is missing a length comparison to correctly handle indexOf returning -1. |
 | tst.js:76:25:76:57 | index = ... gth - 1 | This suffix check is missing a length comparison to correctly handle indexOf returning -1. |
+| tst.js:80:10:80:57 | x.index ... th + 1) | This suffix check is missing a length comparison to correctly handle indexOf returning -1. |

--- a/javascript/ql/test/query-tests/Security/CWE-020/tst.js
+++ b/javascript/ql/test/query-tests/Security/CWE-020/tst.js
@@ -75,3 +75,7 @@ function withIndexOfCheckBad(x, y) {
   let index = x.indexOf(y);
   return index !== 0 && index === x.length - y.length - 1; // NOT OK
 }
+
+function plus(x, y) {
+  return x.indexOf("." + y) === x.length - (y.length + 1); // NOT OK
+}


### PR DESCRIPTION
I spotted a false negative due to not recognizing `.length + 1`.

[Evaluation](https://git.semmle.com/asger/dist-compare-reports/tree/florian.ti.semmle.com_1551304139197).