### PR TITLE
C++: Cache TNode and localFlowStep

### DIFF
--- a/cpp/ql/src/semmle/code/cpp/dataflow/internal/DataFlowUtil.qll
+++ b/cpp/ql/src/semmle/code/cpp/dataflow/internal/DataFlowUtil.qll
@@ -4,6 +4,7 @@
 import cpp
 private import semmle.code.cpp.dataflow.internal.FlowVar
 
+cached
 private newtype TNode =
   TExprNode(Expr e) or
   TParameterNode(Parameter p) { exists(p.getFunction().getBlock()) } or
@@ -161,6 +162,7 @@ private Variable asVariable(Node node) {
  * Holds if data flows from `nodeFrom` to `nodeTo` in exactly one local
  * (intra-procedural) step.
  */
+cached
 predicate localFlowStep(Node nodeFrom, Node nodeTo) {
   // Expr -> Expr
   exprToExprStep_nocfg(nodeFrom.asExpr(), nodeTo.asExpr())


### PR DESCRIPTION
These two elements weren't cached, which meant that local data flow was recalculated in every query that used data flow. They are also cached in the Java version of `DataFlowUtil.qll`.

I didn't make them cached in the IR data flow because I the IR data flow does less work in `localFlowStep`.