### PR TITLE
JS: Treat res.end() as alias for res.send() in Express

### DIFF
--- a/change-notes/1.20/analysis-javascript.md
+++ b/change-notes/1.20/analysis-javascript.md
@@ -5,6 +5,7 @@
 * Support for many frameworks and libraries has been improved, in particular including the following:
   - [a-sync-waterfall](https://www.npmjs.com/package/a-sync-waterfall)
   - [Electron](https://electronjs.org)
+  - [Express](https://npmjs.org/express)
   - [hapi](https://hapijs.com/)
   - [js-cookie](https://github.com/js-cookie/js-cookie)
   - [React](https://reactjs.org/)

--- a/javascript/ql/src/semmle/javascript/frameworks/Express.qll
+++ b/javascript/ql/src/semmle/javascript/frameworks/Express.qll
@@ -604,14 +604,15 @@ module Express {
   }
 
   /**
-   * An argument passed to the `send` method of an HTTP response object.
+   * An argument passed to the `send` or `end` method of an HTTP response object.
    */
   private class ResponseSendArgument extends HTTP::ResponseSendArgument {
     RouteHandler rh;
 
     ResponseSendArgument() {
-      exists(MethodCallExpr mce |
-        mce.calls(rh.getAResponseExpr(), "send") and
+      exists(MethodCallExpr mce, string name |
+        mce.calls(rh.getAResponseExpr(), name) and
+        (name = "send" or name = "end") and
         this = mce.getArgument(0)
       )
     }


### PR DESCRIPTION
[res.end](https://expressjs.com/en/api.html#res.end) works like res.send since it actually forwards to NodeJS's [response.end](https://nodejs.org/api/http.html#http_response_end_data_encoding_callback) method.

An alternative way to implement this would be to treat Express response objects as a subtype of NodeJS's HTTP response objects, since those already recognize the `end` method. I'm not sure what the longterm benefits of that might be so I just took the easy way for now.

Running evaluation on express.slugs.