### PR TITLE
JS: add dataflow cookbook queries (tests only)

### DIFF
--- a/javascript/ql/test/tutorials/cookbook/BackendIdor/BackendIdor.expected
+++ b/javascript/ql/test/tutorials/cookbook/BackendIdor/BackendIdor.expected
@@ -1,0 +1,11 @@
+nodes
+| tst.js:6:9:6:34 | userId |
+| tst.js:6:18:6:34 | req.params.userId |
+| tst.js:7:61:7:68 | {userId} |
+| tst.js:7:62:7:67 | userId |
+edges
+| tst.js:6:9:6:34 | userId | tst.js:7:62:7:67 | userId |
+| tst.js:6:18:6:34 | req.params.userId | tst.js:6:9:6:34 | userId |
+| tst.js:7:62:7:67 | userId | tst.js:7:61:7:68 | {userId} |
+#select
+| tst.js:7:61:7:68 | {userId} | tst.js:6:18:6:34 | req.params.userId | tst.js:7:61:7:68 | {userId} | Unauthenticated user ID from $@. | tst.js:6:18:6:34 | req.params.userId | here |

--- a/javascript/ql/test/tutorials/cookbook/BackendIdor/BackendIdor.ql
+++ b/javascript/ql/test/tutorials/cookbook/BackendIdor/BackendIdor.ql
@@ -1,0 +1,47 @@
+/**
+ * @name IDOR through request to backend service
+ * @description Finds cases where the 'userId' field in a request to another service
+ *              is an arbitrary user-controlled value.
+ * @kind path-problem
+ * @tags security
+ * @id js/cookbook/backend-idor
+ */
+
+import javascript::DataFlow
+import DataFlow::PathGraph
+
+/**
+ * Tracks user-controlled values into a 'userId' property sent to a backend service.
+ */
+class IdorTaint extends TaintTracking::Configuration {
+  IdorTaint() { this = "IdorTaint" }
+
+  override predicate isSource(Node node) { node instanceof RemoteFlowSource }
+
+  override predicate isSink(Node node) { exists(ClientRequest req | node = req.getADataNode()) }
+
+  override predicate isAdditionalTaintStep(Node pred, Node succ) {
+    // Step from x -> { userId: x }
+    succ.(SourceNode).getAPropertyWrite("userId").getRhs() = pred
+  }
+
+  override predicate isSanitizerGuard(TaintTracking::SanitizerGuardNode node) {
+    node instanceof EqualityGuard
+  }
+}
+
+/**
+ * Sanitize values that have succesfully been compared to another value.
+ */
+class EqualityGuard extends TaintTracking::SanitizerGuardNode, ValueNode {
+  override EqualityTest astNode;
+
+  override predicate sanitizes(boolean outcome, Expr e) {
+    e = astNode.getAnOperand() and
+    outcome = astNode.getPolarity()
+  }
+}
+
+from IdorTaint cfg, PathNode source, PathNode sink
+where cfg.hasFlowPath(source, sink)
+select sink.getNode(), source, sink, "Unauthenticated user ID from $@.", source.getNode(), "here"

--- a/javascript/ql/test/tutorials/cookbook/BackendIdor/BackendIdor.ql
+++ b/javascript/ql/test/tutorials/cookbook/BackendIdor/BackendIdor.ql
@@ -1,7 +1,7 @@
 /**
  * @name IDOR through request to backend service
  * @description Finds cases where the 'userId' field in a request to another service
- *              is an arbitrary user-controlled value.
+ *              is an arbitrary user-controlled value, indicating lack of authentication.
  * @kind path-problem
  * @tags security
  * @id js/cookbook/backend-idor
@@ -26,6 +26,7 @@ class IdorTaint extends TaintTracking::Configuration {
   }
 
   override predicate isSanitizerGuard(TaintTracking::SanitizerGuardNode node) {
+    // After a check like `if (userId === session.user.id)`, the userId is considered safe.
     node instanceof EqualityGuard
   }
 }

--- a/javascript/ql/test/tutorials/cookbook/BackendIdor/tst.js
+++ b/javascript/ql/test/tutorials/cookbook/BackendIdor/tst.js
@@ -1,0 +1,12 @@
+let express = require('express');
+let request = require('request');
+
+let app = express();
+app.get('/messages/{userId}', (req, res) => {
+    let userId = req.params.userId;
+    request.post('https://backend.example.com/getMessages', {userId})
+        .on('response', (resp) => res.end(resp))
+        .on('error', (err) => res.status(500));
+});
+
+// semmle-extractor-options: --experimental

--- a/javascript/ql/test/tutorials/cookbook/DecodingAfterSanitization/DecodingAfterSanitization.expected
+++ b/javascript/ql/test/tutorials/cookbook/DecodingAfterSanitization/DecodingAfterSanitization.expected
@@ -1,0 +1,7 @@
+nodes
+| tst.js:3:11:3:23 | escapeHtml(x) |
+| tst.js:4:20:4:32 | escapeHtml(x) |
+edges
+#select
+| tst.js:3:11:3:23 | escapeHtml(x) | tst.js:3:11:3:23 | escapeHtml(x) | tst.js:3:11:3:23 | escapeHtml(x) | URI decoding invalidates the HTML sanitization performed $@. | tst.js:3:11:3:23 | escapeHtml(x) | here |
+| tst.js:4:20:4:32 | escapeHtml(x) | tst.js:4:20:4:32 | escapeHtml(x) | tst.js:4:20:4:32 | escapeHtml(x) | URI decoding invalidates the HTML sanitization performed $@. | tst.js:4:20:4:32 | escapeHtml(x) | here |

--- a/javascript/ql/test/tutorials/cookbook/DecodingAfterSanitization/DecodingAfterSanitization.ql
+++ b/javascript/ql/test/tutorials/cookbook/DecodingAfterSanitization/DecodingAfterSanitization.ql
@@ -1,6 +1,7 @@
 /**
  * @name Decoding after sanitization
- * @description Tracks the return value of 'escapeHtml' into 'decodeURI'.
+ * @description Tracks the return value of 'escapeHtml' into 'decodeURI', indicating
+                an ineffective sanitization attempt.
  * @kind path-problem
  * @tags security
  * @id js/cookbook/decoding-after-sanitization

--- a/javascript/ql/test/tutorials/cookbook/DecodingAfterSanitization/DecodingAfterSanitization.ql
+++ b/javascript/ql/test/tutorials/cookbook/DecodingAfterSanitization/DecodingAfterSanitization.ql
@@ -1,0 +1,28 @@
+/**
+ * @name Decoding after sanitization
+ * @description Tracks the return value of 'escapeHtml' into 'decodeURI'.
+ * @kind path-problem
+ * @tags security
+ * @id js/cookbook/decoding-after-sanitization
+ */
+
+import javascript::DataFlow
+import DataFlow::PathGraph
+
+class DecodingAfterSanitization extends TaintTracking::Configuration {
+  DecodingAfterSanitization() { this = "DecodingAfterSanitization" }
+
+  override predicate isSource(Node node) { node.(CallNode).getCalleeName() = "escapeHtml" }
+
+  override predicate isSink(Node node) {
+    exists(CallNode call |
+      call.getCalleeName().matches("decodeURI%") and
+      node = call.getArgument(0)
+    )
+  }
+}
+
+from DecodingAfterSanitization cfg, PathNode source, PathNode sink
+where cfg.hasFlowPath(source, sink)
+select sink.getNode(), source, sink, "URI decoding invalidates the HTML sanitization performed $@.",
+  source.getNode(), "here"

--- a/javascript/ql/test/tutorials/cookbook/DecodingAfterSanitization/DecodingAfterSanitizationGeneralized.expected
+++ b/javascript/ql/test/tutorials/cookbook/DecodingAfterSanitization/DecodingAfterSanitizationGeneralized.expected
@@ -1,0 +1,9 @@
+nodes
+| tst.js:3:11:3:23 | escapeHtml(x) |
+| tst.js:4:20:4:32 | escapeHtml(x) |
+| tst.js:6:12:6:23 | he.encode(x) |
+edges
+#select
+| tst.js:3:11:3:23 | escapeHtml(x) | tst.js:3:11:3:23 | escapeHtml(x) | tst.js:3:11:3:23 | escapeHtml(x) | URI decoding invalidates the HTML sanitization performed $@. | tst.js:3:11:3:23 | escapeHtml(x) | here |
+| tst.js:4:20:4:32 | escapeHtml(x) | tst.js:4:20:4:32 | escapeHtml(x) | tst.js:4:20:4:32 | escapeHtml(x) | URI decoding invalidates the HTML sanitization performed $@. | tst.js:4:20:4:32 | escapeHtml(x) | here |
+| tst.js:6:12:6:23 | he.encode(x) | tst.js:6:12:6:23 | he.encode(x) | tst.js:6:12:6:23 | he.encode(x) | JSON parsing invalidates the HTML sanitization performed $@. | tst.js:6:12:6:23 | he.encode(x) | here |

--- a/javascript/ql/test/tutorials/cookbook/DecodingAfterSanitization/DecodingAfterSanitizationGeneralized.ql
+++ b/javascript/ql/test/tutorials/cookbook/DecodingAfterSanitization/DecodingAfterSanitizationGeneralized.ql
@@ -1,6 +1,7 @@
 /**
  * @name Decoding after sanitization (generalized)
- * @description Tracks the return value of an HTML sanitizer into a escape-sequence decoder.
+ * @description Tracks the return value of an HTML sanitizer into an escape-sequence decoder,
+                indicating an ineffective sanitization attempt.
  * @kind path-problem
  * @tags security
  * @id js/cookbook/decoding-after-sanitization-generalized

--- a/javascript/ql/test/tutorials/cookbook/DecodingAfterSanitization/DecodingAfterSanitizationGeneralized.ql
+++ b/javascript/ql/test/tutorials/cookbook/DecodingAfterSanitization/DecodingAfterSanitizationGeneralized.ql
@@ -1,0 +1,50 @@
+/**
+ * @name Decoding after sanitization (generalized)
+ * @description Tracks the return value of an HTML sanitizer into a escape-sequence decoder.
+ * @kind path-problem
+ * @tags security
+ * @id js/cookbook/decoding-after-sanitization-generalized
+ */
+
+import javascript::DataFlow
+import DataFlow::PathGraph
+
+/**
+ * A call to a function that may introduce HTML meta-characters by
+ * replacing `%3C` or `\u003C` with `<`.
+ */
+class DecodingCall extends CallNode {
+  string kind;
+
+  Node input;
+
+  DecodingCall() {
+    getCalleeName().matches("decodeURI%") and
+    input = getArgument(0) and
+    kind = "URI decoding"
+    or
+    input = this.(JsonParserCall).getInput() and
+    kind = "JSON parsing"
+  }
+
+  /** Gets the decoder kind, to be used in the alert message. */
+  string getKind() { result = kind }
+
+  /** Gets the input being decoded. */
+  Node getInput() { result = input }
+}
+
+class DecodingAfterSanitization extends TaintTracking::Configuration {
+  DecodingAfterSanitization() { this = "DecodingAfterSanitization" }
+
+  override predicate isSource(Node node) { node instanceof HtmlSanitizerCall }
+
+  override predicate isSink(Node node) { node = any(DecodingCall c).getInput() }
+}
+
+from DecodingAfterSanitization cfg, PathNode source, PathNode sink, DecodingCall decoder
+where
+  cfg.hasFlowPath(source, sink) and
+  decoder.getInput() = sink.getNode()
+select sink.getNode(), source, sink,
+  decoder.getKind() + " invalidates the HTML sanitization performed $@.", source.getNode(), "here"

--- a/javascript/ql/test/tutorials/cookbook/DecodingAfterSanitization/tst.js
+++ b/javascript/ql/test/tutorials/cookbook/DecodingAfterSanitization/tst.js
@@ -1,0 +1,6 @@
+const he = require('he');
+
+decodeURI(escapeHtml(x));
+decodeURIComponent(escapeHtml(x));
+
+JSON.parse(he.encode(x));

--- a/javascript/ql/test/tutorials/cookbook/EvalTaint/EvalTaint.expected
+++ b/javascript/ql/test/tutorials/cookbook/EvalTaint/EvalTaint.expected
@@ -1,0 +1,1 @@
+| tst.js:1:6:1:16 | window.name | Eval with user-controlled input from $@. | tst.js:1:6:1:16 | window.name | here |

--- a/javascript/ql/test/tutorials/cookbook/EvalTaint/EvalTaint.ql
+++ b/javascript/ql/test/tutorials/cookbook/EvalTaint/EvalTaint.ql
@@ -1,0 +1,20 @@
+/**
+ * @name Taint-tracking to 'eval' calls
+ * @description Tracks user-controlled values into 'eval' calls.
+ * @tags security
+ * @id js/cookbook/eval-taint
+ */
+
+import javascript::DataFlow
+
+class EvalTaint extends TaintTracking::Configuration {
+  EvalTaint() { this = "EvalTaint" }
+
+  override predicate isSource(Node node) { node instanceof RemoteFlowSource }
+
+  override predicate isSink(Node node) { node = globalVarRef("eval").getACall().getArgument(0) }
+}
+
+from EvalTaint cfg, Node source, Node sink
+where cfg.hasFlow(source, sink)
+select sink, "Eval with user-controlled input from $@.", source, "here"

--- a/javascript/ql/test/tutorials/cookbook/EvalTaint/EvalTaint.ql
+++ b/javascript/ql/test/tutorials/cookbook/EvalTaint/EvalTaint.ql
@@ -1,6 +1,6 @@
 /**
  * @name Taint-tracking to 'eval' calls
- * @description Tracks user-controlled values into 'eval' calls.
+ * @description Tracks user-controlled values into 'eval' calls (special case of js/code-injection).
  * @tags security
  * @id js/cookbook/eval-taint
  */

--- a/javascript/ql/test/tutorials/cookbook/EvalTaint/EvalTaintPath.expected
+++ b/javascript/ql/test/tutorials/cookbook/EvalTaint/EvalTaintPath.expected
@@ -1,0 +1,5 @@
+nodes
+| tst.js:1:6:1:16 | window.name |
+edges
+#select
+| tst.js:1:6:1:16 | window.name | tst.js:1:6:1:16 | window.name | tst.js:1:6:1:16 | window.name | Eval with user-controlled input from $@. | tst.js:1:6:1:16 | window.name | here |

--- a/javascript/ql/test/tutorials/cookbook/EvalTaint/EvalTaintPath.ql
+++ b/javascript/ql/test/tutorials/cookbook/EvalTaint/EvalTaintPath.ql
@@ -1,0 +1,24 @@
+/**
+ * @name Taint-tracking to 'eval' calls (with path visualization)
+ * @description Tracks user-controlled values into 'eval' calls,
+ *              and generates a visualizable path from the source to the sink.
+ * @kind path-problem
+ * @tags security
+ * @id js/cookbook/eval-taint-path
+ */
+
+import javascript::DataFlow
+import DataFlow::PathGraph
+
+class EvalTaint extends TaintTracking::Configuration {
+  EvalTaint() { this = "EvalTaint" }
+
+  override predicate isSource(Node node) { node instanceof RemoteFlowSource }
+
+  override predicate isSink(Node node) { node = globalVarRef("eval").getACall().getArgument(0) }
+}
+
+from EvalTaint cfg, PathNode source, PathNode sink
+where cfg.hasFlowPath(source, sink)
+select sink.getNode(), source, sink, "Eval with user-controlled input from $@.", source.getNode(),
+  "here"

--- a/javascript/ql/test/tutorials/cookbook/EvalTaint/EvalTaintPath.ql
+++ b/javascript/ql/test/tutorials/cookbook/EvalTaint/EvalTaintPath.ql
@@ -1,6 +1,6 @@
 /**
  * @name Taint-tracking to 'eval' calls (with path visualization)
- * @description Tracks user-controlled values into 'eval' calls,
+ * @description Tracks user-controlled values into 'eval' calls (special case of js/code-injection),
  *              and generates a visualizable path from the source to the sink.
  * @kind path-problem
  * @tags security

--- a/javascript/ql/test/tutorials/cookbook/EvalTaint/tst.js
+++ b/javascript/ql/test/tutorials/cookbook/EvalTaint/tst.js
@@ -1,0 +1,1 @@
+eval(window.name);

--- a/javascript/ql/test/tutorials/cookbook/InformationDisclosure/InformationDisclosure.expected
+++ b/javascript/ql/test/tutorials/cookbook/InformationDisclosure/InformationDisclosure.expected
@@ -1,0 +1,11 @@
+nodes
+| tst.js:1:17:6:2 | JSON.st ... y\\n }\\n}) |
+| tst.js:1:32:6:1 | {\\n acti ... ey\\n }\\n} |
+| tst.js:3:8:5:2 | {\\n   ke ... hKey\\n } |
+| tst.js:4:9:4:28 | window.state.authKey |
+edges
+| tst.js:1:32:6:1 | {\\n acti ... ey\\n }\\n} | tst.js:1:17:6:2 | JSON.st ... y\\n }\\n}) |
+| tst.js:3:8:5:2 | {\\n   ke ... hKey\\n } | tst.js:1:32:6:1 | {\\n acti ... ey\\n }\\n} |
+| tst.js:4:9:4:28 | window.state.authKey | tst.js:3:8:5:2 | {\\n   ke ... hKey\\n } |
+#select
+| tst.js:1:17:6:2 | JSON.st ... y\\n }\\n}) | tst.js:4:9:4:28 | window.state.authKey | tst.js:1:17:6:2 | JSON.st ... y\\n }\\n}) | Message leaks the authKey from $@. | tst.js:4:9:4:28 | window.state.authKey | here |

--- a/javascript/ql/test/tutorials/cookbook/InformationDisclosure/InformationDisclosure.ql
+++ b/javascript/ql/test/tutorials/cookbook/InformationDisclosure/InformationDisclosure.ql
@@ -1,6 +1,7 @@
 /**
  * @name Information disclosure through postMessage
- * @description Tracks values from an 'authKey' property into a postMessage call with unrestricted origin.
+ * @description Tracks values from an 'authKey' property into a postMessage call with unrestricted origin,
+                indicating a leak of sensitive information.
  * @kind path-problem
  * @tags security
  * @id js/cookbook/information-disclosure

--- a/javascript/ql/test/tutorials/cookbook/InformationDisclosure/InformationDisclosure.ql
+++ b/javascript/ql/test/tutorials/cookbook/InformationDisclosure/InformationDisclosure.ql
@@ -1,0 +1,54 @@
+/**
+ * @name Information disclosure through postMessage
+ * @description Tracks values from an 'authKey' property into a postMessage call with unrestricted origin.
+ * @kind path-problem
+ * @tags security
+ * @id js/cookbook/information-disclosure
+ */
+
+import javascript::DataFlow
+import DataFlow::PathGraph
+
+/**
+ * Tracks authentication tokens ("authKey") to a postMessage call with unrestricted target origin.
+ *
+ * For example:
+ * ```
+ * win.postMessage(JSON.stringify({
+ *  action: 'pause',
+ *  auth: {
+ *    key: window.state.authKey
+ *  }
+ * }), '*');
+ * ```
+ */
+class AuthKeyTracking extends DataFlow::Configuration {
+  AuthKeyTracking() { this = "AuthKeyTracking" }
+
+  override predicate isSource(Node node) { node.(PropRead).getPropertyName() = "authKey" }
+
+  override predicate isSink(Node node) {
+    exists(MethodCallNode call |
+      call.getMethodName() = "postMessage" and
+      call.getArgument(1).getStringValue() = "*" and // no restriction on target origin
+      call.getArgument(0) = node
+    )
+  }
+
+  override predicate isAdditionalFlowStep(Node pred, Node succ) {
+    // Step into objects: x -> { f: x }
+    succ.(SourceNode).getAPropertyWrite().getRhs() = pred
+    or
+    // Step through JSON serialization: x -> JSON.stringify(x)
+    // Note: TaintTracking::Configuration includes this step by default, but not DataFlow::Configuration
+    exists(CallNode call |
+      call = globalVarRef("JSON").getAMethodCall("stringify") and
+      pred = call.getArgument(0) and
+      succ = call
+    )
+  }
+}
+
+from AuthKeyTracking cfg, PathNode source, PathNode sink
+where cfg.hasFlowPath(source, sink)
+select sink.getNode(), source, sink, "Message leaks the authKey from $@.", source.getNode(), "here"

--- a/javascript/ql/test/tutorials/cookbook/InformationDisclosure/tst.js
+++ b/javascript/ql/test/tutorials/cookbook/InformationDisclosure/tst.js
@@ -1,0 +1,6 @@
+win.postMessage(JSON.stringify({
+ action: 'pause',
+ auth: {
+   key: window.state.authKey
+ }
+}), '*');

--- a/javascript/ql/test/tutorials/cookbook/StoredXss/StoredXss.expected
+++ b/javascript/ql/test/tutorials/cookbook/StoredXss/StoredXss.expected
@@ -1,0 +1,7 @@
+nodes
+| tst.js:9:49:9:52 | data |
+| tst.js:10:15:10:18 | data |
+edges
+| tst.js:9:49:9:52 | data | tst.js:10:15:10:18 | data |
+#select
+| tst.js:10:15:10:18 | data | tst.js:9:49:9:52 | data | tst.js:10:15:10:18 | data | Stored XSS from $@. | tst.js:9:49:9:52 | data | database value. |

--- a/javascript/ql/test/tutorials/cookbook/StoredXss/StoredXss.ql
+++ b/javascript/ql/test/tutorials/cookbook/StoredXss/StoredXss.ql
@@ -1,0 +1,34 @@
+/**
+ * @name Extension of standard query: Stored XSS
+ * @description Extends the standard Stored XSS query with an additional source.
+ * @kind path-problem
+ * @tags security
+ * @id js/cookbook/stored-xss
+ */
+
+import javascript::DataFlow
+import semmle.javascript.security.dataflow.StoredXss
+import DataFlow::PathGraph
+
+/**
+ * Data returned from a MySQL query, such as the `data` parameter in this example:
+ * ```
+ * let mysql = require('mysql');
+ * let connection = mysql.createConnection();
+ *
+ * connection.query(..., (e, data) => { ... });
+ * ```
+ */
+class MysqlSource extends StoredXss::Source {
+  MysqlSource() {
+    this = moduleImport("mysql")
+          .getAMemberCall("createConnection")
+          .getAMethodCall("query")
+          .getCallback(1)
+          .getParameter(1)
+  }
+}
+
+from StoredXss::Configuration cfg, PathNode source, PathNode sink
+where cfg.hasFlowPath(source, sink)
+select sink.getNode(), source, sink, "Stored XSS from $@.", source.getNode(), "database value."

--- a/javascript/ql/test/tutorials/cookbook/StoredXss/StoredXssTrackedNode.expected
+++ b/javascript/ql/test/tutorials/cookbook/StoredXss/StoredXssTrackedNode.expected
@@ -1,0 +1,11 @@
+nodes
+| tst.js:9:49:9:52 | data |
+| tst.js:10:15:10:18 | data |
+| tst.js:16:41:16:44 | data |
+| tst.js:17:19:17:22 | data |
+edges
+| tst.js:9:49:9:52 | data | tst.js:10:15:10:18 | data |
+| tst.js:16:41:16:44 | data | tst.js:17:19:17:22 | data |
+#select
+| tst.js:10:15:10:18 | data | tst.js:9:49:9:52 | data | tst.js:10:15:10:18 | data | Stored XSS from $@. | tst.js:9:49:9:52 | data | database value. |
+| tst.js:17:19:17:22 | data | tst.js:16:41:16:44 | data | tst.js:17:19:17:22 | data | Stored XSS from $@. | tst.js:16:41:16:44 | data | database value. |

--- a/javascript/ql/test/tutorials/cookbook/StoredXss/StoredXssTrackedNode.ql
+++ b/javascript/ql/test/tutorials/cookbook/StoredXss/StoredXssTrackedNode.ql
@@ -1,0 +1,49 @@
+/**
+ * @name Extension of standard query: Stored XSS (with TrackedNode)
+ * @description Extends the standard Stored XSS query with an additional source,
+ *              using TrackedNode to track MySQL connections globally.
+ * @kind path-problem
+ * @tags security
+ * @id js/cookbook/stored-xss
+ */
+
+import javascript::DataFlow
+import semmle.javascript.security.dataflow.StoredXss
+import DataFlow::PathGraph
+
+/**
+ * An instance of `mysql.createConnection()`, tracked globally.
+ */
+class MysqlConnection extends TrackedNode {
+  MysqlConnection() { this = moduleImport("mysql").getAMemberCall("createConnection") }
+
+  /**
+   * Gets a call to the `query` method on this connection object.
+   */
+  MethodCallNode getAQueryCall() {
+    this.flowsTo(result.getReceiver()) and
+    result.getMethodName() = "query"
+  }
+}
+
+/**
+ * Data returned from a MySQL query.
+ *
+ * For example:
+ * ```
+ * let mysql = require('mysql');
+ *
+ * getData(mysql.createConnection());
+ *
+ * function getData(c) {
+ *   c.query(..., (e, data) => { ... });
+ * }
+ * ```
+ */
+class MysqlSource extends StoredXss::Source {
+  MysqlSource() { this = any(MysqlConnection con).getAQueryCall().getCallback(1).getParameter(1) }
+}
+
+from StoredXss::Configuration cfg, PathNode source, PathNode sink
+where cfg.hasFlowPath(source, sink)
+select sink.getNode(), source, sink, "Stored XSS from $@.", source.getNode(), "database value."

--- a/javascript/ql/test/tutorials/cookbook/StoredXss/tst.js
+++ b/javascript/ql/test/tutorials/cookbook/StoredXss/tst.js
@@ -1,0 +1,22 @@
+let mysql = require('mysql');
+let express = require('express');
+
+let connection = mysql.createConnection();
+
+let app = express();
+
+app.get('/data', (req, res) => {
+    connection.query('SELECT * FROM posts', (e, data) => {
+	    res.send(data);
+    });
+});
+
+function setup(c) {
+    app.get('/data', (req, res) => {
+	    c.query('SELECT * FROM posts', (e, data) => {
+	        res.send(data);
+	    });
+	});
+}
+
+setup(connection);

--- a/javascript/ql/test/tutorials/cookbook/TemplateInjection/TemplateInjection.expected
+++ b/javascript/ql/test/tutorials/cookbook/TemplateInjection/TemplateInjection.expected
@@ -1,0 +1,5 @@
+nodes
+| tst.js:8:48:8:62 | req.query.title |
+edges
+#select
+| tst.js:8:48:8:62 | req.query.title | tst.js:8:48:8:62 | req.query.title | tst.js:8:48:8:62 | req.query.title | User-controlled value from $@ occurs unescaped in a lodash template. | tst.js:8:48:8:62 | req.query.title | here. |

--- a/javascript/ql/test/tutorials/cookbook/TemplateInjection/TemplateInjection.ql
+++ b/javascript/ql/test/tutorials/cookbook/TemplateInjection/TemplateInjection.ql
@@ -1,0 +1,42 @@
+/**
+ * @name Template injection
+ * @description Tracks user-controlled values to an unescaped lodash template placeholder.
+ * @kind path-problem
+ * @tags security
+ * @id js/cookbook/template-injection
+ */
+
+import javascript::DataFlow
+import DataFlow::PathGraph
+
+/**
+ * Gets the name of an unescaped placeholder in a lodash template.
+ *
+ * For example, the string `<h1><%= title %></h1>` contains the placeholder `title`.
+ */
+bindingset[s]
+string getAPlaceholderInString(string s) {
+  exists(string contents |
+    "<%=" + contents + "%>" = s.regexpFind("<%=\\s*[a-zA-Z0-9_]+\\s*%>", _, _) and
+    result = contents.trim()
+  )
+}
+
+class TemplateInjection extends TaintTracking::Configuration {
+  TemplateInjection() { this = "TemplateInjection" }
+
+  override predicate isSource(Node node) { node instanceof RemoteFlowSource }
+
+  override predicate isSink(Node node) {
+    exists(CallNode call, string placeholder |
+      call = LodashUnderscore::member("template").getACall() and
+      placeholder = getAPlaceholderInString(call.getArgument(0).getStringValue()) and
+      node = call.getOptionArgument(1, placeholder)
+    )
+  }
+}
+
+from TemplateInjection cfg, PathNode source, PathNode sink
+where cfg.hasFlowPath(source, sink)
+select sink.getNode(), source, sink,
+  "User-controlled value from $@ occurs unescaped in a lodash template.", source.getNode(), "here."

--- a/javascript/ql/test/tutorials/cookbook/TemplateInjection/TemplateInjection.ql
+++ b/javascript/ql/test/tutorials/cookbook/TemplateInjection/TemplateInjection.ql
@@ -16,10 +16,7 @@ import DataFlow::PathGraph
  */
 bindingset[s]
 string getAPlaceholderInString(string s) {
-  exists(string contents |
-    "<%=" + contents + "%>" = s.regexpFind("<%=\\s*[a-zA-Z0-9_]+\\s*%>", _, _) and
-    result = contents.trim()
-  )
+  result = s.regexpCapture(".*<%=\\s*([a-zA-Z0-9_]+)\\s*%>.*", 1)
 }
 
 class TemplateInjection extends TaintTracking::Configuration {

--- a/javascript/ql/test/tutorials/cookbook/TemplateInjection/tst.js
+++ b/javascript/ql/test/tutorials/cookbook/TemplateInjection/tst.js
@@ -1,0 +1,9 @@
+let _ = require('lodash');
+let fs = require('fs');
+let express = require('express');
+
+let app = express();
+
+app.get('/template', (req, res) => {
+  _.template('<h1><%= title %></h1>', { title: req.query.title });
+});


### PR DESCRIPTION
Adds 9 queries with tests, intended for use in the [JS QL cookbook](https://wiki.semmle.com/display/CBJS/JavaScript+QL+cookbook). They don't cover everything there is to cover, but it's a start.

The intended reading order is and their related concepts are:
- Eval taint (the basics, path visualization)
- Decoding after sanitization (name matching, standard lib concepts)
- Stored XSS (extending standard query, TrackedNode, getCallback, getParameter)
- TemplateInjection (regexp and string operations, lodash, getOptionArgument)
- BackendIDOR (idor, additional taint step, client request)
- Information discloure (data leak, dataflow configuration, flow steps)

The cookbook currently resides in the internal repo, but it's easier to have them reviewed here where I can update the tests more easily. Afterwards, my plan is to:
- Copy the queries to the internal repo and check that it works.
- Permanently relocate the cookbook queries to the public repo.