### PR TITLE
Python: Add taint tracking guard for truthiness.

### DIFF
--- a/python/ql/test/library-tests/taint/general/TestNode.expected
+++ b/python/ql/test/library-tests/taint/general/TestNode.expected
@@ -215,6 +215,11 @@
 | Taint simple.test | test.py:169 | SOURCE |  |
 | Taint simple.test | test.py:172 | Subscript |  |
 | Taint simple.test | test.py:173 | Subscript |  |
+| Taint simple.test | test.py:178 | SOURCE |  |
+| Taint simple.test | test.py:179 | t |  |
+| Taint simple.test | test.py:180 | t |  |
+| Taint simple.test | test.py:183 | t |  |
+| Taint simple.test | test.py:186 | t |  |
 | Taint {simple.test} | test.py:169 | Dict |  |
 | Taint {simple.test} | test.py:171 | d |  |
 | Taint {simple.test} | test.py:173 | y |  |

--- a/python/ql/test/library-tests/taint/general/TestSink.expected
+++ b/python/ql/test/library-tests/taint/general/TestSink.expected
@@ -32,3 +32,5 @@
 | simple.test | test.py:159 | 160 | t | simple.test |
 | simple.test | test.py:168 | 172 | Subscript | simple.test |
 | simple.test | test.py:169 | 173 | Subscript | simple.test |
+| simple.test | test.py:178 | 180 | t | simple.test |
+| simple.test | test.py:178 | 186 | t | simple.test |

--- a/python/ql/test/library-tests/taint/general/TestSource.expected
+++ b/python/ql/test/library-tests/taint/general/TestSource.expected
@@ -40,3 +40,4 @@
 | test.py:163 | SOURCE | simple.test |
 | test.py:168 | SOURCE | simple.test |
 | test.py:169 | SOURCE | simple.test |
+| test.py:178 | SOURCE | simple.test |

--- a/python/ql/test/library-tests/taint/general/TestStep.expected
+++ b/python/ql/test/library-tests/taint/general/TestStep.expected
@@ -173,6 +173,10 @@
 | Taint simple.test | test.py:163 | SOURCE |  |  -->  | Taint simple.test | test.py:164 | s |  |
 | Taint simple.test | test.py:168 | SOURCE |  |  -->  | Taint [simple.test] | test.py:168 | List |  |
 | Taint simple.test | test.py:169 | SOURCE |  |  -->  | Taint {simple.test} | test.py:169 | Dict |  |
+| Taint simple.test | test.py:178 | SOURCE |  |  -->  | Taint simple.test | test.py:179 | t |  |
+| Taint simple.test | test.py:178 | SOURCE |  |  -->  | Taint simple.test | test.py:180 | t |  |
+| Taint simple.test | test.py:178 | SOURCE |  |  -->  | Taint simple.test | test.py:183 | t |  |
+| Taint simple.test | test.py:178 | SOURCE |  |  -->  | Taint simple.test | test.py:186 | t |  |
 | Taint {simple.test} | test.py:169 | Dict |  |  -->  | Taint {simple.test} | test.py:171 | d |  |
 | Taint {simple.test} | test.py:169 | Dict |  |  -->  | Taint {simple.test} | test.py:175 | d |  |
 | Taint {simple.test} | test.py:171 | d |  |  -->  | Taint {simple.test} | test.py:173 | y |  |

--- a/python/ql/test/library-tests/taint/general/TestVar.expected
+++ b/python/ql/test/library-tests/taint/general/TestVar.expected
@@ -177,3 +177,8 @@
 | test.py:174 | l_2 | test.py:168 | Taint [simple.test] | List |
 | test.py:175 | d2_0 | test.py:175 | Taint {simple.test} | dict() |
 | test.py:175 | d_2 | test.py:169 | Taint {simple.test} | Dict |
+| test.py:178 | t_0 | test.py:178 | Taint simple.test | SOURCE |
+| test.py:180 | t_1 | test.py:178 | Taint simple.test | SOURCE |
+| test.py:180 | t_2 | test.py:178 | Taint simple.test | SOURCE |
+| test.py:183 | t_3 | test.py:178 | Taint simple.test | SOURCE |
+| test.py:186 | t_4 | test.py:178 | Taint simple.test | SOURCE |

--- a/python/ql/test/library-tests/taint/general/test.py
+++ b/python/ql/test/library-tests/taint/general/test.py
@@ -173,3 +173,14 @@ def test_update_extend(x, y):
     SINK(y["key"])
     l2 = list(l)
     d2 = dict(d)
+
+def test_truth():
+    t = SOURCE
+    if t:
+        SINK(t)
+    else:
+        SINK(t)
+    if not t:
+        SINK(t)
+    else:
+        SINK(t)

--- a/python/ql/test/query-tests/Functions/general/ModificationOfParameterWithDefault.expected
+++ b/python/ql/test/query-tests/Functions/general/ModificationOfParameterWithDefault.expected
@@ -1,20 +1,22 @@
 edges
-| functions_test.py:36:9:36:9 | mutable value | functions_test.py:37:16:37:16 | mutable value |
-| functions_test.py:39:9:39:9 | mutable value | functions_test.py:40:5:40:5 | mutable value |
-| functions_test.py:238:15:238:15 | mutable value | functions_test.py:239:5:239:5 | mutable value |
-| functions_test.py:290:25:290:25 | mutable value | functions_test.py:291:5:291:5 | mutable value |
-| functions_test.py:293:21:293:21 | mutable value | functions_test.py:294:5:294:5 | mutable value |
-| functions_test.py:296:27:296:27 | mutable value | functions_test.py:297:25:297:25 | mutable value |
-| functions_test.py:296:27:296:27 | mutable value | functions_test.py:298:21:298:21 | mutable value |
-| functions_test.py:297:25:297:25 | mutable value | functions_test.py:290:25:290:25 | mutable value |
-| functions_test.py:298:21:298:21 | mutable value | functions_test.py:293:21:293:21 | mutable value |
+| functions_test.py:36:9:36:9 | empty mutable value | functions_test.py:37:16:37:16 | empty mutable value |
+| functions_test.py:39:9:39:9 | empty mutable value | functions_test.py:40:5:40:5 | empty mutable value |
+| functions_test.py:238:15:238:15 | empty mutable value | functions_test.py:239:5:239:5 | empty mutable value |
+| functions_test.py:290:25:290:25 | empty mutable value | functions_test.py:291:5:291:5 | empty mutable value |
+| functions_test.py:293:21:293:21 | empty mutable value | functions_test.py:294:5:294:5 | empty mutable value |
+| functions_test.py:296:27:296:27 | empty mutable value | functions_test.py:297:25:297:25 | empty mutable value |
+| functions_test.py:296:27:296:27 | empty mutable value | functions_test.py:298:21:298:21 | empty mutable value |
+| functions_test.py:297:25:297:25 | empty mutable value | functions_test.py:290:25:290:25 | empty mutable value |
+| functions_test.py:298:21:298:21 | empty mutable value | functions_test.py:293:21:293:21 | empty mutable value |
+| functions_test.py:300:26:300:26 | empty mutable value | functions_test.py:301:8:301:8 | empty mutable value |
+| functions_test.py:300:26:300:26 | empty mutable value | functions_test.py:303:12:303:12 | empty mutable value |
 parents
-| functions_test.py:290:25:290:25 | mutable value | functions_test.py:297:25:297:25 | mutable value |
-| functions_test.py:291:5:291:5 | mutable value | functions_test.py:297:25:297:25 | mutable value |
-| functions_test.py:293:21:293:21 | mutable value | functions_test.py:298:21:298:21 | mutable value |
-| functions_test.py:294:5:294:5 | mutable value | functions_test.py:298:21:298:21 | mutable value |
+| functions_test.py:290:25:290:25 | empty mutable value | functions_test.py:297:25:297:25 | empty mutable value |
+| functions_test.py:291:5:291:5 | empty mutable value | functions_test.py:297:25:297:25 | empty mutable value |
+| functions_test.py:293:21:293:21 | empty mutable value | functions_test.py:298:21:298:21 | empty mutable value |
+| functions_test.py:294:5:294:5 | empty mutable value | functions_test.py:298:21:298:21 | empty mutable value |
 #select
-| functions_test.py:40:5:40:5 | Taint sink | functions_test.py:39:9:39:9 | mutable value | functions_test.py:40:5:40:5 | mutable value | $@ flows to here and is mutated. | functions_test.py:39:9:39:9 | mutable default value | Default value |
-| functions_test.py:239:5:239:5 | Taint sink | functions_test.py:238:15:238:15 | mutable value | functions_test.py:239:5:239:5 | mutable value | $@ flows to here and is mutated. | functions_test.py:238:15:238:15 | mutable default value | Default value |
-| functions_test.py:291:5:291:5 | Taint sink | functions_test.py:296:27:296:27 | mutable value | functions_test.py:291:5:291:5 | mutable value | $@ flows to here and is mutated. | functions_test.py:296:27:296:27 | mutable default value | Default value |
-| functions_test.py:294:5:294:5 | Taint sink | functions_test.py:296:27:296:27 | mutable value | functions_test.py:294:5:294:5 | mutable value | $@ flows to here and is mutated. | functions_test.py:296:27:296:27 | mutable default value | Default value |
+| functions_test.py:40:5:40:5 | Taint sink | functions_test.py:39:9:39:9 | empty mutable value | functions_test.py:40:5:40:5 | empty mutable value | $@ flows to here and is mutated. | functions_test.py:39:9:39:9 | mutable default value | Default value |
+| functions_test.py:239:5:239:5 | Taint sink | functions_test.py:238:15:238:15 | empty mutable value | functions_test.py:239:5:239:5 | empty mutable value | $@ flows to here and is mutated. | functions_test.py:238:15:238:15 | mutable default value | Default value |
+| functions_test.py:291:5:291:5 | Taint sink | functions_test.py:296:27:296:27 | empty mutable value | functions_test.py:291:5:291:5 | empty mutable value | $@ flows to here and is mutated. | functions_test.py:296:27:296:27 | mutable default value | Default value |
+| functions_test.py:294:5:294:5 | Taint sink | functions_test.py:296:27:296:27 | empty mutable value | functions_test.py:294:5:294:5 | empty mutable value | $@ flows to here and is mutated. | functions_test.py:296:27:296:27 | mutable default value | Default value |

--- a/python/ql/test/query-tests/Functions/general/functions_test.py
+++ b/python/ql/test/query-tests/Functions/general/functions_test.py
@@ -296,3 +296,9 @@ def mutate_argument(x):
 def indirect_modification(y = []):
     aug_assign_argument(y)
     mutate_argument(y)
+
+def guarded_modification(z=[]):
+    if z:
+        z.append(0)
+    return z
+


### PR DESCRIPTION
Handles false positive mentioned in https://github.com/Semmle/ql/pull/878.