### PR TITLE
Java: respect override annotations in `java/unused-parameter`

### DIFF
--- a/java/ql/src/semmle/code/java/deadcode/DeadCode.qll
+++ b/java/ql/src/semmle/code/java/deadcode/DeadCode.qll
@@ -296,6 +296,8 @@ class RootdefCallable extends Callable {
     // Methods that are the target of a member reference need to implement
     // the exact signature of the resulting functional interface.
     exists(MemberRefExpr mre | mre.getReferencedCallable() = this)
+    or
+    this.getAnAnnotation() instanceof OverrideAnnotation
   }
 }
 


### PR DESCRIPTION
This is normally redundant, but guards against some unusual situations involving potentially inconsistent or incomplete databases that might result from two incompatible versions of the same class being extracted in different compiler invocations of the same project, as recently observed on a customer snapshot.