### PR TITLE
C++: Use getQualifiedName() = "gets", not hasName

### DIFF
--- a/cpp/ql/src/Security/CWE/CWE-676/PotentiallyDangerousFunction.ql
+++ b/cpp/ql/src/Security/CWE/CWE-676/PotentiallyDangerousFunction.ql
@@ -16,7 +16,7 @@ predicate potentiallyDangerousFunction(Function f, string message) {
     f.getQualifiedName() = "gmtime" and
     message = "Call to gmtime is potentially dangerous"
   ) or (
-    f.hasName("gets") and
+    f.getQualifiedName() = "gets" and
     message = "gets does not guard against buffer overflow"
   )
 }


### PR DESCRIPTION
This fixes false positives on https://lgtm.com/projects/g/brandonpelfrey/Construct caused by a member function named `gets` -- probably short for "get s".

I've opened this as a hotfix: the problematic code existed before 1.20, but it's only becoming part of a standard query in 1.20 (#842).