### PR TITLE
C++: Set cpp/command-line-injection precision=low

### DIFF
--- a/cpp/ql/src/Security/CWE/CWE-078/ExecTainted.ql
+++ b/cpp/ql/src/Security/CWE/CWE-078/ExecTainted.ql
@@ -5,7 +5,7 @@
  *              to command injection.
  * @kind problem
  * @problem.severity error
- * @precision high
+ * @precision low
  * @id cpp/command-line-injection
  * @tags security
  *       external/cwe/cwe-078


### PR DESCRIPTION
This query is only appropriate for setuid programs. Since such programs are at most 0.1% of all code we analyse, I would say this query has a precision of at most 0.1%.

We can talk about raising the precision to medium if someone can find at least one true positive on https://lgtm.com/rules/2152620561/alerts/.
