### PR TITLE
CPP: NewDelete.qll performance

### DIFF
--- a/cpp/ql/src/Critical/NewDelete.qll
+++ b/cpp/ql/src/Critical/NewDelete.qll
@@ -55,7 +55,7 @@ predicate allocExprOrIndirect(Expr alloc, string kind) {
  * Holds if `v` is a non-local variable which is assigned with allocations of
  * type `kind`.
  */
-private cached predicate allocReachesVariable(Variable v, Expr alloc, string kind) {
+private pragma[nomagic] predicate allocReachesVariable(Variable v, Expr alloc, string kind) {
   exists(Expr mid |
     not v instanceof LocalScopeVariable and
     v.getAnAssignedValue() = mid and

--- a/cpp/ql/src/Critical/NewDelete.qll
+++ b/cpp/ql/src/Critical/NewDelete.qll
@@ -52,22 +52,13 @@ predicate allocExprOrIndirect(Expr alloc, string kind) {
 }
 
 /**
- * Holds if `v` is a global variable assigned value `e`, and `e` is not known
- * to be `0`.
- */
-private predicate nonNullGlobalAssignment(Variable v, Expr e) {
-  not v instanceof LocalScopeVariable and
-  v.getAnAssignedValue() = e and
-  not e.getValue().toInt() = 0
-}
-
-/**
  * Holds if `v` is a non-local variable which is assigned with allocations of
  * type `kind`.
  */
 private cached predicate allocReachesVariable(Variable v, Expr alloc, string kind) {
   exists(Expr mid |
-    nonNullGlobalAssignment(v, mid) and
+    not v instanceof LocalScopeVariable and
+    v.getAnAssignedValue() = mid and
     allocReaches0(mid, alloc, kind)
   )
 }

--- a/cpp/ql/test/query-tests/Critical/NewFree/NewFreeMismatch.expected
+++ b/cpp/ql/test/query-tests/Critical/NewFree/NewFreeMismatch.expected
@@ -12,3 +12,5 @@
 | test.cpp:235:2:235:5 | call to free | There is a new/free mismatch between this free and the corresponding $@. | test.cpp:227:7:227:13 | new | new |
 | test.cpp:239:2:239:5 | call to free | There is a new/free mismatch between this free and the corresponding $@. | test.cpp:228:7:228:17 | new[] | new[] |
 | test.cpp:272:3:272:6 | call to free | There is a new/free mismatch between this free and the corresponding $@. | test.cpp:265:7:265:13 | new | new |
+| test.cpp:367:3:367:10 | delete | There is a malloc/delete mismatch between this delete and the corresponding $@. | test.cpp:359:14:359:19 | call to malloc | malloc |
+| test.cpp:370:3:370:6 | call to free | There is a new/free mismatch between this free and the corresponding $@. | test.cpp:356:7:356:15 | new | new |

--- a/cpp/ql/test/query-tests/Critical/NewFree/NewFreeMismatch.expected
+++ b/cpp/ql/test/query-tests/Critical/NewFree/NewFreeMismatch.expected
@@ -12,5 +12,3 @@
 | test.cpp:235:2:235:5 | call to free | There is a new/free mismatch between this free and the corresponding $@. | test.cpp:227:7:227:13 | new | new |
 | test.cpp:239:2:239:5 | call to free | There is a new/free mismatch between this free and the corresponding $@. | test.cpp:228:7:228:17 | new[] | new[] |
 | test.cpp:272:3:272:6 | call to free | There is a new/free mismatch between this free and the corresponding $@. | test.cpp:265:7:265:13 | new | new |
-| test.cpp:367:3:367:10 | delete | There is a malloc/delete mismatch between this delete and the corresponding $@. | test.cpp:359:14:359:19 | call to malloc | malloc |
-| test.cpp:370:3:370:6 | call to free | There is a new/free mismatch between this free and the corresponding $@. | test.cpp:356:7:356:15 | new | new |

--- a/cpp/ql/test/query-tests/Critical/NewFree/test.cpp
+++ b/cpp/ql/test/query-tests/Critical/NewFree/test.cpp
@@ -364,10 +364,10 @@ void test12(bool cond)
 
 	if (cond)
 	{
-		delete y; // GOOD [FALSE POSITIVE]
+		delete y; // GOOD
 		delete z; // GOOD
 	} else {
-		free(y); // GOOD [FALSE POSITIVE]
+		free(y); // GOOD
 		free(z); // GOOD
 	}
 }

--- a/cpp/ql/test/query-tests/Critical/NewFree/test.cpp
+++ b/cpp/ql/test/query-tests/Critical/NewFree/test.cpp
@@ -337,3 +337,37 @@ public:
 
 	char *data;
 };
+
+// ---
+
+int *z;
+
+void test12(bool cond)
+{
+	int *x, *y;
+
+	x = new int();
+	delete x; // GOOD
+	x = (int *)malloc(sizeof(int));
+	free(x); // GOOD
+
+	if (cond)
+	{
+		y = new int();
+		z = new int();
+	} else {
+		y = (int *)malloc(sizeof(int));
+		z = (int *)malloc(sizeof(int));
+	}
+
+	// ...
+
+	if (cond)
+	{
+		delete y; // GOOD [FALSE POSITIVE]
+		delete z; // GOOD
+	} else {
+		free(y); // GOOD [FALSE POSITIVE]
+		free(z); // GOOD
+	}
+}


### PR DESCRIPTION
This PR rearranges some of the logic in `NewDelete.qll` to obtain better performance.  Correctness is also slightly better (in obscure cases).

@jbj @nickrolfe 