### PR TITLE
JS: Omit uninteresting nodes from path explanations

### DIFF
--- a/javascript/ql/test/query-tests/Security/CWE-022/TaintedPath/TaintedPath.expected
+++ b/javascript/ql/test/query-tests/Security/CWE-022/TaintedPath/TaintedPath.expected
@@ -17,14 +17,6 @@ nodes
 | TaintedPath.js:19:33:19:36 | path |
 | TaintedPath.js:23:33:23:36 | path |
 | TaintedPath.js:27:33:27:36 | path |
-| TaintedPath.js:30:7:30:24 | path |
-| TaintedPath.js:34:3:34:3 | path |
-| TaintedPath.js:34:7:34:24 | path |
-| TaintedPath.js:34:29:34:46 | path |
-| TaintedPath.js:38:3:38:3 | path |
-| TaintedPath.js:38:7:38:24 | path |
-| TaintedPath.js:38:29:38:46 | path |
-| TaintedPath.js:39:5:39:5 | path |
 | TaintedPath.js:39:31:39:34 | path |
 | TaintedPath.js:45:3:45:44 | path |
 | TaintedPath.js:45:10:45:33 | url.par ... , true) |
@@ -112,18 +104,54 @@ edges
 | TaintedPath.js:9:7:9:48 | path | TaintedPath.js:23:33:23:36 | path |
 | TaintedPath.js:9:7:9:48 | path | TaintedPath.js:27:33:27:36 | path |
 | TaintedPath.js:9:7:9:48 | path | TaintedPath.js:30:7:30:24 | path |
+| TaintedPath.js:9:7:9:48 | path | TaintedPath.js:34:3:34:3 | path |
+| TaintedPath.js:9:7:9:48 | path | TaintedPath.js:34:7:34:24 | path |
+| TaintedPath.js:9:7:9:48 | path | TaintedPath.js:34:29:34:46 | path |
+| TaintedPath.js:9:7:9:48 | path | TaintedPath.js:38:3:38:3 | path |
+| TaintedPath.js:9:7:9:48 | path | TaintedPath.js:38:7:38:24 | path |
+| TaintedPath.js:9:7:9:48 | path | TaintedPath.js:38:29:38:46 | path |
+| TaintedPath.js:9:7:9:48 | path | TaintedPath.js:39:5:39:5 | path |
+| TaintedPath.js:9:7:9:48 | path | TaintedPath.js:39:31:39:34 | path |
 | TaintedPath.js:9:14:9:37 | url.par ... , true) | TaintedPath.js:9:14:9:43 | url.par ... ).query |
 | TaintedPath.js:9:14:9:43 | url.par ... ).query | TaintedPath.js:9:14:9:48 | url.par ... ry.path |
 | TaintedPath.js:9:14:9:48 | url.par ... ry.path | TaintedPath.js:9:7:9:48 | path |
 | TaintedPath.js:9:24:9:30 | req.url | TaintedPath.js:9:14:9:37 | url.par ... , true) |
 | TaintedPath.js:15:45:15:48 | path | TaintedPath.js:15:29:15:48 | "/home/user/" + path |
 | TaintedPath.js:30:7:30:24 | path | TaintedPath.js:34:3:34:3 | path |
+| TaintedPath.js:30:7:30:24 | path | TaintedPath.js:34:7:34:24 | path |
+| TaintedPath.js:30:7:30:24 | path | TaintedPath.js:34:29:34:46 | path |
+| TaintedPath.js:30:7:30:24 | path | TaintedPath.js:38:3:38:3 | path |
+| TaintedPath.js:30:7:30:24 | path | TaintedPath.js:38:7:38:24 | path |
+| TaintedPath.js:30:7:30:24 | path | TaintedPath.js:38:29:38:46 | path |
+| TaintedPath.js:30:7:30:24 | path | TaintedPath.js:39:5:39:5 | path |
+| TaintedPath.js:30:7:30:24 | path | TaintedPath.js:39:31:39:34 | path |
 | TaintedPath.js:34:3:34:3 | path | TaintedPath.js:34:7:34:24 | path |
+| TaintedPath.js:34:3:34:3 | path | TaintedPath.js:34:29:34:46 | path |
+| TaintedPath.js:34:3:34:3 | path | TaintedPath.js:38:3:38:3 | path |
+| TaintedPath.js:34:3:34:3 | path | TaintedPath.js:38:7:38:24 | path |
+| TaintedPath.js:34:3:34:3 | path | TaintedPath.js:38:29:38:46 | path |
+| TaintedPath.js:34:3:34:3 | path | TaintedPath.js:39:5:39:5 | path |
+| TaintedPath.js:34:3:34:3 | path | TaintedPath.js:39:31:39:34 | path |
 | TaintedPath.js:34:7:34:24 | path | TaintedPath.js:34:29:34:46 | path |
+| TaintedPath.js:34:7:34:24 | path | TaintedPath.js:38:3:38:3 | path |
+| TaintedPath.js:34:7:34:24 | path | TaintedPath.js:38:7:38:24 | path |
+| TaintedPath.js:34:7:34:24 | path | TaintedPath.js:38:29:38:46 | path |
+| TaintedPath.js:34:7:34:24 | path | TaintedPath.js:39:5:39:5 | path |
+| TaintedPath.js:34:7:34:24 | path | TaintedPath.js:39:31:39:34 | path |
 | TaintedPath.js:34:29:34:46 | path | TaintedPath.js:38:3:38:3 | path |
+| TaintedPath.js:34:29:34:46 | path | TaintedPath.js:38:7:38:24 | path |
+| TaintedPath.js:34:29:34:46 | path | TaintedPath.js:38:29:38:46 | path |
+| TaintedPath.js:34:29:34:46 | path | TaintedPath.js:39:5:39:5 | path |
+| TaintedPath.js:34:29:34:46 | path | TaintedPath.js:39:31:39:34 | path |
 | TaintedPath.js:38:3:38:3 | path | TaintedPath.js:38:7:38:24 | path |
+| TaintedPath.js:38:3:38:3 | path | TaintedPath.js:38:29:38:46 | path |
+| TaintedPath.js:38:3:38:3 | path | TaintedPath.js:39:5:39:5 | path |
+| TaintedPath.js:38:3:38:3 | path | TaintedPath.js:39:31:39:34 | path |
 | TaintedPath.js:38:7:38:24 | path | TaintedPath.js:38:29:38:46 | path |
+| TaintedPath.js:38:7:38:24 | path | TaintedPath.js:39:5:39:5 | path |
+| TaintedPath.js:38:7:38:24 | path | TaintedPath.js:39:31:39:34 | path |
 | TaintedPath.js:38:29:38:46 | path | TaintedPath.js:39:5:39:5 | path |
+| TaintedPath.js:38:29:38:46 | path | TaintedPath.js:39:31:39:34 | path |
 | TaintedPath.js:39:5:39:5 | path | TaintedPath.js:39:31:39:34 | path |
 | TaintedPath.js:45:3:45:44 | path | TaintedPath.js:47:49:47:52 | path |
 | TaintedPath.js:45:3:45:44 | path | TaintedPath.js:49:48:49:51 | path |

--- a/javascript/ql/test/query-tests/Security/CWE-078/CommandInjection.expected
+++ b/javascript/ql/test/query-tests/Security/CWE-078/CommandInjection.expected
@@ -11,14 +11,12 @@ nodes
 | child_process-test.js:21:14:21:16 | cmd |
 | child_process-test.js:22:18:22:20 | cmd |
 | child_process-test.js:23:13:23:15 | cmd |
-| child_process-test.js:25:13:25:23 | "foo" + cmd |
 | child_process-test.js:25:13:25:31 | "foo" + cmd + "bar" |
 | child_process-test.js:25:21:25:23 | cmd |
 | child_process-test.js:36:7:36:20 | sh |
 | child_process-test.js:36:12:36:20 | 'cmd.exe' |
 | child_process-test.js:38:7:38:20 | sh |
 | child_process-test.js:38:12:38:20 | '/bin/sh' |
-| child_process-test.js:39:5:39:5 | sh |
 | child_process-test.js:39:14:39:15 | sh |
 | child_process-test.js:39:18:39:30 | [ flag, cmd ] |
 | child_process-test.js:39:26:39:28 | cmd |
@@ -39,7 +37,6 @@ nodes
 | child_process-test.js:56:12:56:14 | cmd |
 | child_process-test.js:56:17:56:20 | args |
 | execSeries.js:3:20:3:22 | arr |
-| execSeries.js:5:4:5:3 | arr |
 | execSeries.js:6:14:6:16 | arr |
 | execSeries.js:6:14:6:21 | arr[i++] |
 | execSeries.js:13:19:13:26 | commands |
@@ -71,9 +68,12 @@ edges
 | child_process-test.js:6:25:6:31 | req.url | child_process-test.js:6:15:6:38 | url.par ... , true) |
 | child_process-test.js:25:13:25:23 | "foo" + cmd | child_process-test.js:25:13:25:31 | "foo" + cmd + "bar" |
 | child_process-test.js:25:21:25:23 | cmd | child_process-test.js:25:13:25:23 | "foo" + cmd |
+| child_process-test.js:25:21:25:23 | cmd | child_process-test.js:25:13:25:31 | "foo" + cmd + "bar" |
 | child_process-test.js:36:7:36:20 | sh | child_process-test.js:39:5:39:5 | sh |
+| child_process-test.js:36:7:36:20 | sh | child_process-test.js:39:14:39:15 | sh |
 | child_process-test.js:36:12:36:20 | 'cmd.exe' | child_process-test.js:36:7:36:20 | sh |
 | child_process-test.js:38:7:38:20 | sh | child_process-test.js:39:5:39:5 | sh |
+| child_process-test.js:38:7:38:20 | sh | child_process-test.js:39:14:39:15 | sh |
 | child_process-test.js:38:12:38:20 | '/bin/sh' | child_process-test.js:38:7:38:20 | sh |
 | child_process-test.js:39:5:39:5 | sh | child_process-test.js:39:14:39:15 | sh |
 | child_process-test.js:41:9:41:17 | args | child_process-test.js:44:30:44:33 | args |
@@ -86,6 +86,7 @@ edges
 | child_process-test.js:55:14:55:16 | cmd | child_process-test.js:56:12:56:14 | cmd |
 | child_process-test.js:55:19:55:22 | args | child_process-test.js:56:17:56:20 | args |
 | execSeries.js:3:20:3:22 | arr | execSeries.js:5:4:5:3 | arr |
+| execSeries.js:3:20:3:22 | arr | execSeries.js:6:14:6:16 | arr |
 | execSeries.js:5:4:5:3 | arr | execSeries.js:6:14:6:16 | arr |
 | execSeries.js:6:14:6:16 | arr | execSeries.js:6:14:6:21 | arr[i++] |
 | execSeries.js:6:14:6:21 | arr[i++] | execSeries.js:14:24:14:30 | command |

--- a/javascript/ql/test/query-tests/Security/CWE-079/ReflectedXss.expected
+++ b/javascript/ql/test/query-tests/Security/CWE-079/ReflectedXss.expected
@@ -3,10 +3,7 @@ nodes
 | ReflectedXss.js:8:33:8:45 | req.params.id |
 | etherpad.js:9:5:9:53 | response |
 | etherpad.js:9:16:9:30 | req.query.jsonp |
-| etherpad.js:9:16:9:36 | req.que ... p + "(" |
-| etherpad.js:9:16:9:47 | req.que ... esponse |
 | etherpad.js:9:16:9:53 | req.que ... e + ")" |
-| etherpad.js:11:3:11:3 | response |
 | etherpad.js:11:12:11:19 | response |
 | formatting.js:4:9:4:29 | evil |
 | formatting.js:4:16:4:29 | req.query.evil |
@@ -45,8 +42,12 @@ nodes
 edges
 | ReflectedXss.js:8:33:8:45 | req.params.id | ReflectedXss.js:8:14:8:45 | "Unknow ... rams.id |
 | etherpad.js:9:5:9:53 | response | etherpad.js:11:3:11:3 | response |
+| etherpad.js:9:5:9:53 | response | etherpad.js:11:12:11:19 | response |
 | etherpad.js:9:16:9:30 | req.query.jsonp | etherpad.js:9:16:9:36 | req.que ... p + "(" |
+| etherpad.js:9:16:9:30 | req.query.jsonp | etherpad.js:9:16:9:47 | req.que ... esponse |
+| etherpad.js:9:16:9:30 | req.query.jsonp | etherpad.js:9:16:9:53 | req.que ... e + ")" |
 | etherpad.js:9:16:9:36 | req.que ... p + "(" | etherpad.js:9:16:9:47 | req.que ... esponse |
+| etherpad.js:9:16:9:36 | req.que ... p + "(" | etherpad.js:9:16:9:53 | req.que ... e + ")" |
 | etherpad.js:9:16:9:47 | req.que ... esponse | etherpad.js:9:16:9:53 | req.que ... e + ")" |
 | etherpad.js:9:16:9:53 | req.que ... e + ")" | etherpad.js:9:5:9:53 | response |
 | etherpad.js:11:3:11:3 | response | etherpad.js:11:12:11:19 | response |

--- a/javascript/ql/test/query-tests/Security/CWE-079/Xss.expected
+++ b/javascript/ql/test/query-tests/Security/CWE-079/Xss.expected
@@ -6,7 +6,6 @@ nodes
 | jquery.js:2:17:2:33 | document.location |
 | jquery.js:2:17:2:40 | documen ... .search |
 | jquery.js:4:5:4:11 | tainted |
-| jquery.js:7:5:7:26 | "<div i ... tainted |
 | jquery.js:7:5:7:34 | "<div i ... + "\\">" |
 | jquery.js:7:20:7:26 | tainted |
 | jquery.js:8:18:8:34 | "XSS: " + tainted |
@@ -54,12 +53,10 @@ nodes
 | tst.js:2:16:2:32 | document.location |
 | tst.js:2:16:2:39 | documen ... .search |
 | tst.js:5:18:5:23 | target |
-| tst.js:8:18:8:114 | "<OPTIO ... t=")+8) |
 | tst.js:8:18:8:126 | "<OPTIO ... PTION>" |
 | tst.js:8:37:8:53 | document.location |
 | tst.js:8:37:8:58 | documen ... on.href |
 | tst.js:8:37:8:114 | documen ... t=")+8) |
-| tst.js:12:5:12:33 | '<div s ...  target |
 | tst.js:12:5:12:42 | '<div s ...  'px">' |
 | tst.js:12:28:12:33 | target |
 | tst.js:19:25:19:41 | document.location |
@@ -100,7 +97,6 @@ nodes
 | tst.js:73:3:73:19 | document.location |
 | tst.js:73:3:73:26 | documen ... .search |
 | tst.js:73:46:73:46 | x |
-| tst.js:74:7:74:7 | x |
 | tst.js:76:20:76:20 | x |
 | tst.js:80:49:80:65 | document.location |
 | tst.js:80:49:80:72 | documen ... .search |
@@ -147,9 +143,7 @@ nodes
 | tst.js:194:19:194:42 | documen ... .search |
 | tst.js:196:67:196:73 | tainted |
 | tst.js:197:67:197:73 | tainted |
-| tst.js:200:20:200:19 | tainted |
 | tst.js:201:35:201:41 | tainted |
-| tst.js:203:27:203:26 | tainted |
 | tst.js:203:46:203:52 | tainted |
 | tst.js:204:38:204:44 | tainted |
 | tst.js:205:35:205:41 | tainted |
@@ -196,6 +190,7 @@ edges
 | jquery.js:2:17:2:40 | documen ... .search | jquery.js:2:7:2:40 | tainted |
 | jquery.js:7:5:7:26 | "<div i ... tainted | jquery.js:7:5:7:34 | "<div i ... + "\\">" |
 | jquery.js:7:20:7:26 | tainted | jquery.js:7:5:7:26 | "<div i ... tainted |
+| jquery.js:7:20:7:26 | tainted | jquery.js:7:5:7:34 | "<div i ... + "\\">" |
 | jquery.js:8:28:8:34 | tainted | jquery.js:8:18:8:34 | "XSS: " + tainted |
 | nodemailer.js:13:50:13:66 | req.query.message | nodemailer.js:13:11:13:69 | `Hi, yo ... sage}.` |
 | react-native.js:7:7:7:33 | tainted | react-native.js:8:18:8:24 | tainted |
@@ -232,8 +227,10 @@ edges
 | tst.js:8:37:8:53 | document.location | tst.js:8:37:8:58 | documen ... on.href |
 | tst.js:8:37:8:58 | documen ... on.href | tst.js:8:37:8:114 | documen ... t=")+8) |
 | tst.js:8:37:8:114 | documen ... t=")+8) | tst.js:8:18:8:114 | "<OPTIO ... t=")+8) |
+| tst.js:8:37:8:114 | documen ... t=")+8) | tst.js:8:18:8:126 | "<OPTIO ... PTION>" |
 | tst.js:12:5:12:33 | '<div s ...  target | tst.js:12:5:12:42 | '<div s ...  'px">' |
 | tst.js:12:28:12:33 | target | tst.js:12:5:12:33 | '<div s ...  target |
+| tst.js:12:28:12:33 | target | tst.js:12:5:12:42 | '<div s ...  'px">' |
 | tst.js:19:25:19:41 | document.location | tst.js:20:18:20:35 | params.get('name') |
 | tst.js:23:42:23:47 | target | tst.js:23:42:23:60 | target.substring(1) |
 | tst.js:23:42:23:60 | target.substring(1) | tst.js:24:18:24:41 | searchP ... 'name') |
@@ -263,6 +260,7 @@ edges
 | tst.js:73:3:73:19 | document.location | tst.js:73:3:73:26 | documen ... .search |
 | tst.js:73:3:73:26 | documen ... .search | tst.js:73:1:73:27 | [,docum ... search] |
 | tst.js:73:46:73:46 | x | tst.js:74:7:74:7 | x |
+| tst.js:73:46:73:46 | x | tst.js:76:20:76:20 | x |
 | tst.js:74:7:74:7 | x | tst.js:76:20:76:20 | x |
 | tst.js:80:49:80:65 | document.location | tst.js:80:49:80:72 | documen ... .search |
 | tst.js:84:26:84:42 | document.location | tst.js:84:26:84:49 | documen ... .search |
@@ -294,7 +292,11 @@ edges
 | tst.js:194:9:194:42 | tainted | tst.js:196:67:196:73 | tainted |
 | tst.js:194:9:194:42 | tainted | tst.js:197:67:197:73 | tainted |
 | tst.js:194:9:194:42 | tainted | tst.js:200:20:200:19 | tainted |
+| tst.js:194:9:194:42 | tainted | tst.js:201:35:201:41 | tainted |
 | tst.js:194:9:194:42 | tainted | tst.js:203:27:203:26 | tainted |
+| tst.js:194:9:194:42 | tainted | tst.js:203:46:203:52 | tainted |
+| tst.js:194:9:194:42 | tainted | tst.js:204:38:204:44 | tainted |
+| tst.js:194:9:194:42 | tainted | tst.js:205:35:205:41 | tainted |
 | tst.js:194:9:194:42 | tainted | tst.js:233:35:233:41 | tainted |
 | tst.js:194:9:194:42 | tainted | tst.js:235:20:235:26 | tainted |
 | tst.js:194:9:194:42 | tainted | tst.js:237:23:237:29 | tainted |

--- a/javascript/ql/test/query-tests/Security/CWE-089/SqlInjection.expected
+++ b/javascript/ql/test/query-tests/Security/CWE-089/SqlInjection.expected
@@ -3,24 +3,20 @@ nodes
 | mongodb.js:12:19:12:20 | {} |
 | mongodb.js:13:19:13:26 | req.body |
 | mongodb.js:13:19:13:32 | req.body.title |
-| mongodb.js:14:59:14:58 | query |
 | mongodb.js:18:16:18:20 | query |
 | mongodb.js:26:11:26:32 | title |
 | mongodb.js:26:19:26:26 | req.body |
 | mongodb.js:26:19:26:32 | req.body.title |
-| mongodb.js:27:11:27:35 | title |
 | mongodb.js:32:18:32:45 | { title ... itle) } |
 | mongodb.js:32:27:32:43 | JSON.parse(title) |
 | mongodb.js:32:38:32:42 | title |
 | mongodb.js:48:11:48:20 | query |
 | mongodb.js:48:19:48:20 | {} |
 | mongodb.js:49:19:49:33 | req.query.title |
-| mongodb.js:50:59:50:58 | query |
 | mongodb.js:54:16:54:20 | query |
 | mongodb_bodySafe.js:23:11:23:20 | query |
 | mongodb_bodySafe.js:23:19:23:20 | {} |
 | mongodb_bodySafe.js:24:19:24:33 | req.query.title |
-| mongodb_bodySafe.js:25:59:25:58 | query |
 | mongodb_bodySafe.js:29:16:29:20 | query |
 | mongoose.js:20:11:20:20 | query |
 | mongoose.js:20:19:20:20 | {} |
@@ -48,22 +44,19 @@ nodes
 | socketio.js:10:25:10:30 | handle |
 | socketio.js:11:12:11:53 | `INSERT ... andle}` |
 | socketio.js:11:46:11:51 | handle |
-| tst2.js:9:27:9:78 | "select ... rams.id |
 | tst2.js:9:27:9:84 | "select ... d + "'" |
 | tst2.js:9:66:9:78 | req.params.id |
 | tst3.js:8:7:9:55 | query1 |
-| tst3.js:8:16:9:34 | "SELECT ... ategory |
 | tst3.js:8:16:9:55 | "SELECT ...  PRICE" |
 | tst3.js:9:16:9:34 | req.params.category |
 | tst3.js:10:14:10:19 | query1 |
-| tst4.js:8:10:8:60 | 'SELECT ... rams.id |
 | tst4.js:8:10:8:66 | 'SELECT ... d + '"' |
 | tst4.js:8:46:8:60 | $routeParams.id |
-| tst.js:10:10:10:58 | 'SELECT ... rams.id |
 | tst.js:10:10:10:64 | 'SELECT ... d + '"' |
 | tst.js:10:46:10:58 | req.params.id |
 edges
 | mongodb.js:12:11:12:20 | query | mongodb.js:14:59:14:58 | query |
+| mongodb.js:12:11:12:20 | query | mongodb.js:18:16:18:20 | query |
 | mongodb.js:12:19:12:20 | {} | mongodb.js:12:11:12:20 | query |
 | mongodb.js:13:19:13:26 | req.body | mongodb.js:13:19:13:32 | req.body.title |
 | mongodb.js:13:19:13:32 | req.body.title | mongodb.js:12:11:12:20 | query |
@@ -72,12 +65,14 @@ edges
 | mongodb.js:13:19:13:32 | req.body.title | mongodb.js:18:16:18:20 | query |
 | mongodb.js:14:59:14:58 | query | mongodb.js:18:16:18:20 | query |
 | mongodb.js:26:11:26:32 | title | mongodb.js:27:11:27:35 | title |
+| mongodb.js:26:11:26:32 | title | mongodb.js:32:38:32:42 | title |
 | mongodb.js:26:19:26:26 | req.body | mongodb.js:26:19:26:32 | req.body.title |
 | mongodb.js:26:19:26:32 | req.body.title | mongodb.js:26:11:26:32 | title |
 | mongodb.js:27:11:27:35 | title | mongodb.js:32:38:32:42 | title |
 | mongodb.js:32:27:32:43 | JSON.parse(title) | mongodb.js:32:18:32:45 | { title ... itle) } |
 | mongodb.js:32:38:32:42 | title | mongodb.js:32:27:32:43 | JSON.parse(title) |
 | mongodb.js:48:11:48:20 | query | mongodb.js:50:59:50:58 | query |
+| mongodb.js:48:11:48:20 | query | mongodb.js:54:16:54:20 | query |
 | mongodb.js:48:19:48:20 | {} | mongodb.js:48:11:48:20 | query |
 | mongodb.js:49:19:49:33 | req.query.title | mongodb.js:48:11:48:20 | query |
 | mongodb.js:49:19:49:33 | req.query.title | mongodb.js:48:19:48:20 | {} |
@@ -85,6 +80,7 @@ edges
 | mongodb.js:49:19:49:33 | req.query.title | mongodb.js:54:16:54:20 | query |
 | mongodb.js:50:59:50:58 | query | mongodb.js:54:16:54:20 | query |
 | mongodb_bodySafe.js:23:11:23:20 | query | mongodb_bodySafe.js:25:59:25:58 | query |
+| mongodb_bodySafe.js:23:11:23:20 | query | mongodb_bodySafe.js:29:16:29:20 | query |
 | mongodb_bodySafe.js:23:19:23:20 | {} | mongodb_bodySafe.js:23:11:23:20 | query |
 | mongodb_bodySafe.js:24:19:24:33 | req.query.title | mongodb_bodySafe.js:23:11:23:20 | query |
 | mongodb_bodySafe.js:24:19:24:33 | req.query.title | mongodb_bodySafe.js:23:19:23:20 | {} |
@@ -132,14 +128,18 @@ edges
 | socketio.js:11:46:11:51 | handle | socketio.js:11:12:11:53 | `INSERT ... andle}` |
 | tst2.js:9:27:9:78 | "select ... rams.id | tst2.js:9:27:9:84 | "select ... d + "'" |
 | tst2.js:9:66:9:78 | req.params.id | tst2.js:9:27:9:78 | "select ... rams.id |
+| tst2.js:9:66:9:78 | req.params.id | tst2.js:9:27:9:84 | "select ... d + "'" |
 | tst3.js:8:7:9:55 | query1 | tst3.js:10:14:10:19 | query1 |
 | tst3.js:8:16:9:34 | "SELECT ... ategory | tst3.js:8:16:9:55 | "SELECT ...  PRICE" |
 | tst3.js:8:16:9:55 | "SELECT ...  PRICE" | tst3.js:8:7:9:55 | query1 |
 | tst3.js:9:16:9:34 | req.params.category | tst3.js:8:16:9:34 | "SELECT ... ategory |
+| tst3.js:9:16:9:34 | req.params.category | tst3.js:8:16:9:55 | "SELECT ...  PRICE" |
 | tst4.js:8:10:8:60 | 'SELECT ... rams.id | tst4.js:8:10:8:66 | 'SELECT ... d + '"' |
 | tst4.js:8:46:8:60 | $routeParams.id | tst4.js:8:10:8:60 | 'SELECT ... rams.id |
+| tst4.js:8:46:8:60 | $routeParams.id | tst4.js:8:10:8:66 | 'SELECT ... d + '"' |
 | tst.js:10:10:10:58 | 'SELECT ... rams.id | tst.js:10:10:10:64 | 'SELECT ... d + '"' |
 | tst.js:10:46:10:58 | req.params.id | tst.js:10:10:10:58 | 'SELECT ... rams.id |
+| tst.js:10:46:10:58 | req.params.id | tst.js:10:10:10:64 | 'SELECT ... d + '"' |
 #select
 | mongodb.js:18:16:18:20 | query | mongodb.js:13:19:13:26 | req.body | mongodb.js:18:16:18:20 | query | This query depends on $@. | mongodb.js:13:19:13:26 | req.body | a user-provided value |
 | mongodb.js:32:18:32:45 | { title ... itle) } | mongodb.js:26:19:26:26 | req.body | mongodb.js:32:18:32:45 | { title ... itle) } | This query depends on $@. | mongodb.js:26:19:26:26 | req.body | a user-provided value |

--- a/javascript/ql/test/query-tests/Security/CWE-094/CodeInjection/CodeInjection.expected
+++ b/javascript/ql/test/query-tests/Security/CWE-094/CodeInjection/CodeInjection.expected
@@ -29,13 +29,10 @@ nodes
 | angularjs.js:53:32:53:46 | location.search |
 | eslint-escope-build.js:20:22:20:22 | c |
 | eslint-escope-build.js:21:16:21:16 | c |
-| express.js:7:24:7:62 | "return ... obble") |
 | express.js:7:24:7:69 | "return ...  + "];" |
 | express.js:7:44:7:62 | req.param("wobble") |
-| express.js:9:34:9:72 | "return ... obble") |
 | express.js:9:34:9:79 | "return ...  + "];" |
 | express.js:9:54:9:72 | req.param("wobble") |
-| express.js:12:8:12:46 | "return ... obble") |
 | express.js:12:8:12:53 | "return ...  + "];" |
 | express.js:12:28:12:46 | req.param("wobble") |
 | react-native.js:7:7:7:33 | tainted |
@@ -72,10 +69,13 @@ edges
 | eslint-escope-build.js:20:22:20:22 | c | eslint-escope-build.js:21:16:21:16 | c |
 | express.js:7:24:7:62 | "return ... obble") | express.js:7:24:7:69 | "return ...  + "];" |
 | express.js:7:44:7:62 | req.param("wobble") | express.js:7:24:7:62 | "return ... obble") |
+| express.js:7:44:7:62 | req.param("wobble") | express.js:7:24:7:69 | "return ...  + "];" |
 | express.js:9:34:9:72 | "return ... obble") | express.js:9:34:9:79 | "return ...  + "];" |
 | express.js:9:54:9:72 | req.param("wobble") | express.js:9:34:9:72 | "return ... obble") |
+| express.js:9:54:9:72 | req.param("wobble") | express.js:9:34:9:79 | "return ...  + "];" |
 | express.js:12:8:12:46 | "return ... obble") | express.js:12:8:12:53 | "return ...  + "];" |
 | express.js:12:28:12:46 | req.param("wobble") | express.js:12:8:12:46 | "return ... obble") |
+| express.js:12:28:12:46 | req.param("wobble") | express.js:12:8:12:53 | "return ...  + "];" |
 | react-native.js:7:7:7:33 | tainted | react-native.js:8:32:8:38 | tainted |
 | react-native.js:7:7:7:33 | tainted | react-native.js:10:23:10:29 | tainted |
 | react-native.js:7:17:7:33 | req.param("code") | react-native.js:7:7:7:33 | tainted |

--- a/javascript/ql/test/query-tests/Security/CWE-200/FileAccessToHttp.expected
+++ b/javascript/ql/test/query-tests/Security/CWE-200/FileAccessToHttp.expected
@@ -6,7 +6,6 @@ nodes
 | FileAccessToHttp.js:9:23:9:29 | content |
 | bufferRead.js:12:13:12:43 | buffer |
 | bufferRead.js:12:22:12:43 | new Buf ... s.size) |
-| bufferRead.js:13:53:13:52 | buffer |
 | bufferRead.js:15:15:15:62 | postData |
 | bufferRead.js:15:26:15:31 | buffer |
 | bufferRead.js:15:26:15:62 | buffer. ... esRead) |
@@ -18,7 +17,6 @@ nodes
 | googlecompiler.js:14:21:14:30 | codestring |
 | googlecompiler.js:38:18:38:26 | post_data |
 | googlecompiler.js:44:54:44:57 | data |
-| googlecompiler.js:55:6:55:9 | data |
 | googlecompiler.js:56:14:56:17 | data |
 | readFileSync.js:5:5:5:39 | data |
 | readFileSync.js:5:12:5:39 | fs.read ... t.txt") |
@@ -36,10 +34,8 @@ nodes
 | request.js:16:11:23:3 | {\\n    u ... ody\\n  } |
 | request.js:22:11:22:17 | xmlData |
 | request.js:28:52:28:55 | data |
-| request.js:34:6:34:9 | data |
 | request.js:35:14:35:17 | data |
 | request.js:43:51:43:54 | data |
-| request.js:49:6:49:9 | data |
 | request.js:50:13:50:16 | data |
 | sentAsHeaders.js:10:79:10:84 | buffer |
 | sentAsHeaders.js:11:13:11:59 | content |
@@ -63,6 +59,7 @@ edges
 | FileAccessToHttp.js:9:12:9:31 | { Referer: content } | FileAccessToHttp.js:5:11:10:1 | {\\n  hos ... ent }\\n} |
 | FileAccessToHttp.js:9:23:9:29 | content | FileAccessToHttp.js:9:12:9:31 | { Referer: content } |
 | bufferRead.js:12:13:12:43 | buffer | bufferRead.js:13:53:13:52 | buffer |
+| bufferRead.js:12:13:12:43 | buffer | bufferRead.js:15:26:15:31 | buffer |
 | bufferRead.js:12:22:12:43 | new Buf ... s.size) | bufferRead.js:12:13:12:43 | buffer |
 | bufferRead.js:13:53:13:52 | buffer | bufferRead.js:15:26:15:31 | buffer |
 | bufferRead.js:15:15:15:62 | postData | bufferRead.js:33:21:33:28 | postData |
@@ -74,6 +71,7 @@ edges
 | googlecompiler.js:9:41:15:3 | {\\n      ... ody\\n  } | googlecompiler.js:9:19:15:4 | queryst ... dy\\n  }) |
 | googlecompiler.js:14:21:14:30 | codestring | googlecompiler.js:9:41:15:3 | {\\n      ... ody\\n  } |
 | googlecompiler.js:44:54:44:57 | data | googlecompiler.js:55:6:55:9 | data |
+| googlecompiler.js:44:54:44:57 | data | googlecompiler.js:56:14:56:17 | data |
 | googlecompiler.js:55:6:55:9 | data | googlecompiler.js:56:14:56:17 | data |
 | googlecompiler.js:56:14:56:17 | data | googlecompiler.js:7:19:7:28 | codestring |
 | readFileSync.js:5:5:5:39 | data | readFileSync.js:7:11:7:14 | data |
@@ -88,9 +86,11 @@ edges
 | request.js:13:18:13:24 | xmlData | request.js:22:11:22:17 | xmlData |
 | request.js:22:11:22:17 | xmlData | request.js:16:11:23:3 | {\\n    u ... ody\\n  } |
 | request.js:28:52:28:55 | data | request.js:34:6:34:9 | data |
+| request.js:28:52:28:55 | data | request.js:35:14:35:17 | data |
 | request.js:34:6:34:9 | data | request.js:35:14:35:17 | data |
 | request.js:35:14:35:17 | data | request.js:6:19:6:26 | jsonData |
 | request.js:43:51:43:54 | data | request.js:49:6:49:9 | data |
+| request.js:43:51:43:54 | data | request.js:50:13:50:16 | data |
 | request.js:49:6:49:9 | data | request.js:50:13:50:16 | data |
 | request.js:50:13:50:16 | data | request.js:13:18:13:24 | xmlData |
 | sentAsHeaders.js:10:79:10:84 | buffer | sentAsHeaders.js:11:23:11:28 | buffer |

--- a/javascript/ql/test/query-tests/Security/CWE-601/ServerSideUrlRedirect/ServerSideUrlRedirect.expected
+++ b/javascript/ql/test/query-tests/Security/CWE-601/ServerSideUrlRedirect/ServerSideUrlRedirect.expected
@@ -47,7 +47,6 @@ nodes
 | node.js:29:16:29:52 | url.par ... .target |
 | node.js:29:26:29:32 | req.url |
 | node.js:32:34:32:39 | target |
-| node.js:32:34:32:50 | target + "?from=" |
 | node.js:32:34:32:55 | target  ... =" + me |
 | react-native.js:7:7:7:33 | tainted |
 | react-native.js:7:17:7:33 | req.param("code") |
@@ -88,6 +87,7 @@ edges
 | node.js:29:16:29:52 | url.par ... .target | node.js:29:7:29:52 | target |
 | node.js:29:26:29:32 | req.url | node.js:29:16:29:39 | url.par ... , true) |
 | node.js:32:34:32:39 | target | node.js:32:34:32:50 | target + "?from=" |
+| node.js:32:34:32:39 | target | node.js:32:34:32:55 | target  ... =" + me |
 | node.js:32:34:32:50 | target + "?from=" | node.js:32:34:32:55 | target  ... =" + me |
 | react-native.js:7:7:7:33 | tainted | react-native.js:8:17:8:23 | tainted |
 | react-native.js:7:7:7:33 | tainted | react-native.js:9:26:9:32 | tainted |

--- a/javascript/ql/test/query-tests/Security/CWE-643/XpathInjection.expected
+++ b/javascript/ql/test/query-tests/Security/CWE-643/XpathInjection.expected
@@ -1,7 +1,6 @@
 nodes
 | XpathInjectionBad.js:6:7:6:38 | userName |
 | XpathInjectionBad.js:6:18:6:38 | req.par ... rName") |
-| XpathInjectionBad.js:9:34:9:73 | "//user ... serName |
 | XpathInjectionBad.js:9:34:9:96 | "//user ... text()" |
 | XpathInjectionBad.js:9:66:9:73 | userName |
 | tst2.js:1:13:1:29 | document.location |
@@ -20,6 +19,7 @@ edges
 | XpathInjectionBad.js:6:18:6:38 | req.par ... rName") | XpathInjectionBad.js:6:7:6:38 | userName |
 | XpathInjectionBad.js:9:34:9:73 | "//user ... serName | XpathInjectionBad.js:9:34:9:96 | "//user ... text()" |
 | XpathInjectionBad.js:9:66:9:73 | userName | XpathInjectionBad.js:9:34:9:73 | "//user ... serName |
+| XpathInjectionBad.js:9:66:9:73 | userName | XpathInjectionBad.js:9:34:9:96 | "//user ... text()" |
 | tst2.js:1:13:1:29 | document.location | tst2.js:1:13:1:34 | documen ... on.hash |
 | tst2.js:1:13:1:34 | documen ... on.hash | tst2.js:1:13:1:47 | documen ... ring(1) |
 | tst2.js:1:13:1:47 | documen ... ring(1) | tst2.js:2:27:2:31 | query |

--- a/javascript/ql/test/query-tests/Security/CWE-730/RegExpInjection.expected
+++ b/javascript/ql/test/query-tests/Security/CWE-730/RegExpInjection.expected
@@ -3,7 +3,6 @@ nodes
 | RegExpInjection.js:5:13:5:28 | req.param("key") |
 | RegExpInjection.js:5:31:5:56 | input |
 | RegExpInjection.js:5:39:5:56 | req.param("input") |
-| RegExpInjection.js:8:23:8:33 | "\\\\b" + key |
 | RegExpInjection.js:8:23:8:45 | "\\\\b" + ... (.*)\\n" |
 | RegExpInjection.js:8:31:8:33 | key |
 | RegExpInjection.js:19:14:19:22 | wrap(key) |
@@ -29,7 +28,6 @@ nodes
 | tst.js:2:9:2:21 | data |
 | tst.js:2:16:2:16 | e |
 | tst.js:2:16:2:21 | e.data |
-| tst.js:3:16:3:29 | "^"+ data.name |
 | tst.js:3:16:3:35 | "^"+ data.name + "$" |
 | tst.js:3:21:3:24 | data |
 | tst.js:3:21:3:29 | data.name |
@@ -49,6 +47,7 @@ edges
 | RegExpInjection.js:5:39:5:56 | req.param("input") | RegExpInjection.js:5:31:5:56 | input |
 | RegExpInjection.js:8:23:8:33 | "\\\\b" + key | RegExpInjection.js:8:23:8:45 | "\\\\b" + ... (.*)\\n" |
 | RegExpInjection.js:8:31:8:33 | key | RegExpInjection.js:8:23:8:33 | "\\\\b" + key |
+| RegExpInjection.js:8:31:8:33 | key | RegExpInjection.js:8:23:8:45 | "\\\\b" + ... (.*)\\n" |
 | RegExpInjection.js:19:19:19:21 | key | RegExpInjection.js:19:14:19:22 | wrap(key) |
 | RegExpInjection.js:21:19:21:21 | key | RegExpInjection.js:21:14:21:22 | wrap(key) |
 | RegExpInjection.js:24:12:24:27 | req.param("key") | RegExpInjection.js:27:14:27:21 | getKey() |
@@ -64,6 +63,7 @@ edges
 | tst.js:3:16:3:29 | "^"+ data.name | tst.js:3:16:3:35 | "^"+ data.name + "$" |
 | tst.js:3:21:3:24 | data | tst.js:3:21:3:29 | data.name |
 | tst.js:3:21:3:29 | data.name | tst.js:3:16:3:29 | "^"+ data.name |
+| tst.js:3:21:3:29 | data.name | tst.js:3:16:3:35 | "^"+ data.name + "$" |
 #select
 | RegExpInjection.js:8:23:8:45 | "\\\\b" + ... (.*)\\n" | RegExpInjection.js:5:13:5:28 | req.param("key") | RegExpInjection.js:8:23:8:45 | "\\\\b" + ... (.*)\\n" | This regular expression is constructed from a $@. | RegExpInjection.js:5:13:5:28 | req.param("key") | user-provided value |
 | RegExpInjection.js:19:14:19:22 | wrap(key) | RegExpInjection.js:5:13:5:28 | req.param("key") | RegExpInjection.js:19:14:19:22 | wrap(key) | This regular expression is constructed from a $@. | RegExpInjection.js:5:13:5:28 | req.param("key") | user-provided value |

--- a/javascript/ql/test/query-tests/Security/CWE-754/UnvalidatedDynamicMethodCall.expected
+++ b/javascript/ql/test/query-tests/Security/CWE-754/UnvalidatedDynamicMethodCall.expected
@@ -35,7 +35,6 @@ nodes
 | tst.js:17:18:17:21 | name |
 | tst.js:18:5:18:6 | fn |
 | tst.js:18:5:18:6 | fn |
-| tst.js:19:9:19:31 | fn |
 | tst.js:20:7:20:8 | fn |
 | tst.js:21:7:21:15 | obj[name] |
 | tst.js:21:7:21:15 | obj[name] |
@@ -99,6 +98,8 @@ edges
 | tst.js:17:9:17:22 | fn | tst.js:18:5:18:6 | fn |
 | tst.js:17:9:17:22 | fn | tst.js:18:5:18:6 | fn |
 | tst.js:17:9:17:22 | fn | tst.js:19:9:19:31 | fn |
+| tst.js:17:9:17:22 | fn | tst.js:20:7:20:8 | fn |
+| tst.js:17:9:17:22 | fn | tst.js:22:11:22:12 | fn |
 | tst.js:17:14:17:22 | obj[name] | tst.js:17:9:17:22 | fn |
 | tst.js:17:14:17:22 | obj[name] | tst.js:17:9:17:22 | fn |
 | tst.js:17:18:17:21 | name | tst.js:17:14:17:22 | obj[name] |

--- a/javascript/ql/test/query-tests/Security/CWE-843/TypeConfusionThroughParameterTampering.expected
+++ b/javascript/ql/test/query-tests/Security/CWE-843/TypeConfusionThroughParameterTampering.expected
@@ -3,16 +3,12 @@ nodes
 | tst.js:5:15:5:27 | req.query.foo |
 | tst.js:6:5:6:7 | foo |
 | tst.js:8:5:8:7 | foo |
-| tst.js:10:5:10:4 | foo |
 | tst.js:11:9:11:11 | foo |
 | tst.js:14:16:14:18 | bar |
 | tst.js:15:9:15:11 | bar |
 | tst.js:17:7:17:9 | foo |
 | tst.js:27:5:27:7 | foo |
 | tst.js:28:5:28:7 | foo |
-| tst.js:30:9:30:31 | foo |
-| tst.js:30:9:30:31 | foo |
-| tst.js:35:5:35:5 | foo |
 | tst.js:36:9:36:11 | foo |
 | tst.js:41:5:41:7 | foo |
 | tst.js:45:9:45:35 | foo |
@@ -22,17 +18,25 @@ edges
 | tst.js:5:9:5:27 | foo | tst.js:6:5:6:7 | foo |
 | tst.js:5:9:5:27 | foo | tst.js:8:5:8:7 | foo |
 | tst.js:5:9:5:27 | foo | tst.js:10:5:10:4 | foo |
+| tst.js:5:9:5:27 | foo | tst.js:11:9:11:11 | foo |
 | tst.js:5:9:5:27 | foo | tst.js:17:7:17:9 | foo |
 | tst.js:5:9:5:27 | foo | tst.js:27:5:27:7 | foo |
 | tst.js:5:9:5:27 | foo | tst.js:28:5:28:7 | foo |
 | tst.js:5:9:5:27 | foo | tst.js:30:9:30:31 | foo |
 | tst.js:5:9:5:27 | foo | tst.js:30:9:30:31 | foo |
+| tst.js:5:9:5:27 | foo | tst.js:35:5:35:5 | foo |
+| tst.js:5:9:5:27 | foo | tst.js:36:9:36:11 | foo |
+| tst.js:5:9:5:27 | foo | tst.js:41:5:41:7 | foo |
 | tst.js:5:15:5:27 | req.query.foo | tst.js:5:9:5:27 | foo |
 | tst.js:10:5:10:4 | foo | tst.js:11:9:11:11 | foo |
 | tst.js:14:16:14:18 | bar | tst.js:15:9:15:11 | bar |
 | tst.js:17:7:17:9 | foo | tst.js:14:16:14:18 | bar |
 | tst.js:30:9:30:31 | foo | tst.js:35:5:35:5 | foo |
 | tst.js:30:9:30:31 | foo | tst.js:35:5:35:5 | foo |
+| tst.js:30:9:30:31 | foo | tst.js:36:9:36:11 | foo |
+| tst.js:30:9:30:31 | foo | tst.js:36:9:36:11 | foo |
+| tst.js:30:9:30:31 | foo | tst.js:41:5:41:7 | foo |
+| tst.js:30:9:30:31 | foo | tst.js:41:5:41:7 | foo |
 | tst.js:35:5:35:5 | foo | tst.js:36:9:36:11 | foo |
 | tst.js:35:5:35:5 | foo | tst.js:41:5:41:7 | foo |
 | tst.js:45:9:45:35 | foo | tst.js:46:5:46:7 | foo |

--- a/javascript/ql/test/query-tests/Security/CWE-912/HttpToFileAccess.expected
+++ b/javascript/ql/test/query-tests/Security/CWE-912/HttpToFileAccess.expected
@@ -4,13 +4,13 @@ nodes
 | tst.js:15:26:15:26 | c |
 | tst.js:16:33:16:33 | c |
 | tst.js:19:25:19:25 | c |
-| tst.js:23:27:23:26 | c |
 | tst.js:24:22:24:22 | c |
 edges
 | HttpToFileAccess.js:5:18:5:18 | d | HttpToFileAccess.js:6:37:6:37 | d |
 | tst.js:15:26:15:26 | c | tst.js:16:33:16:33 | c |
 | tst.js:15:26:15:26 | c | tst.js:19:25:19:25 | c |
 | tst.js:15:26:15:26 | c | tst.js:23:27:23:26 | c |
+| tst.js:15:26:15:26 | c | tst.js:24:22:24:22 | c |
 | tst.js:23:27:23:26 | c | tst.js:24:22:24:22 | c |
 #select
 | HttpToFileAccess.js:6:37:6:37 | d | HttpToFileAccess.js:5:18:5:18 | d | HttpToFileAccess.js:6:37:6:37 | d | $@ flows to file system | HttpToFileAccess.js:5:18:5:18 | d | Untrusted data |


### PR DESCRIPTION
Hides nodes from the path explanation that aren't interesting. This includes:
- Phi nodes, refinements, variable capture nodes.
- Intermediate nodes in a `+`-based concatenation tree.

Evaluation underway.