### PR TITLE
JavaScript: Make configuration of parallel extraction consistent with parallel evaluation.

### DIFF
--- a/change-notes/1.20/extractor-javascript.md
+++ b/change-notes/1.20/extractor-javascript.md
@@ -18,7 +18,7 @@
 
 ## Changes to code extraction
 
-* Extraction of JavaScript files (but not TypeScript files) on LGTM is now parallelized. By default, the extractor uses as many threads as there are processors, but this can be overridden by setting the `LGTM_INDEX_THREADS` environment variable. In particular, setting `LGTM_INDEX_THREADS` to 1 disables parallel extraction.
+* Parallel extraction of JavaScript files (but not TypeScript files) on LGTM is now supported. The `LGTM_THREADS` environment variable can be set to indicate how many files should be extracted in parallel. If this variable is not set, parallel extraction is disabled.
 * The extractor now offers experimental support for [E4X](https://developer.mozilla.org/en-US/docs/Archive/Web/E4X), a legacy language extension developed by Mozilla.
 * The extractor now supports additional [Flow](https://flow.org/) syntax.
 * The extractor now supports [Nullish Coalescing](https://github.com/tc39/proposal-nullish-coalescing) expressions.

--- a/javascript/extractor/src/com/semmle/js/extractor/AutoBuild.java
+++ b/javascript/extractor/src/com/semmle/js/extractor/AutoBuild.java
@@ -69,7 +69,7 @@ import java.util.stream.Stream;
  *   <li><code>LGTM_INDEX_TYPESCRIPT</code>: whether to extract TypeScript
  *   <li><code>LGTM_INDEX_FILETYPES</code>: a newline-separated list of ".extension:filetype" pairs
  *       specifying which {@link FileType} to use for the given extension
- *   <li><code>LGTM_INDEX_THREADS</code>: the maximum number of files to extract in parallel
+ *   <li><code>LGTM_THREADS</code>: the maximum number of files to extract in parallel
  *   <li><code>LGTM_TRAP_CACHE</code>: the path of a directory to use for trap caching
  *   <li><code>LGTM_TRAP_CACHE_BOUND</code>: the size to bound the trap cache to
  * </ul>
@@ -163,9 +163,9 @@ import java.util.stream.Stream;
  * following environment variables are available:
  *
  * <ul>
- *   <li><code>LGTM_INDEX_THREADS</code> determines how many threads are used for parallel
+ *   <li><code>LGTM_THREADS</code> determines how many threads are used for parallel
  *       extraction of JavaScript files (TypeScript files cannot currently be extracted in
- *       parallel). If left unspecified, the extractor uses as many threads as there are cores.
+ *       parallel). If left unspecified, the extractor uses a single thread.
  *   <li><code>LGTM_TRAP_CACHE</code> and <code>LGTM_TRAP_CACHE_BOUND</code> can be used to specify
  *       the location and size of a trap cache to be used during extraction.
  * </ul>
@@ -405,8 +405,8 @@ public class AutoBuild {
   }
 
   private void startThreadPool() {
-    int defaultNumThreads = Runtime.getRuntime().availableProcessors();
-    int numThreads = Env.systemEnv().getInt("LGTM_INDEX_THREADS", defaultNumThreads);
+    int defaultNumThreads = 1;
+    int numThreads = Env.systemEnv().getInt("LGTM_THREADS", defaultNumThreads);
     if (numThreads > 1) {
       System.out.println("Parallel extraction with " + numThreads + " threads.");
       threadPool = Executors.newFixedThreadPool(numThreads);


### PR DESCRIPTION
Just like parallel evaluation, the number of extractor threads is now determined by the `LGTM_THREADS` environment variable, and defaults to one.

cc @rneatherway 