### PR TITLE
Python: fix stack trace exposure query.

### DIFF
--- a/python/ql/src/Security/CWE-209/StackTraceExposure.ql
+++ b/python/ql/src/Security/CWE-209/StackTraceExposure.ql
@@ -19,5 +19,5 @@ import semmle.python.security.Exceptions
 import semmle.python.web.HttpResponse
 
 from TaintedPathSource src, TaintedPathSink sink
-where src.flowsTo(sink)
+where src.flowsTo(sink) and src.getSource() instanceof ErrorInfoSource
 select sink.getSink(), src, sink, "$@ may be exposed to an external user", src.getSource(), "Error information"

--- a/python/ql/src/semmle/python/security/Exceptions.qll
+++ b/python/ql/src/semmle/python/security/Exceptions.qll
@@ -31,6 +31,10 @@ class ExceptionInfo extends StringKind {
 
 }
 
+/** A class representing sources of information about 
+ * execution state exposed in tracebacks and the like.
+ */
+abstract class ErrorInfoSource extends TaintSource {}
 
 /**
  * This kind represents exceptions themselves.
@@ -56,7 +60,7 @@ class ExceptionKind extends TaintKind {
  * A source of exception objects, either explicitly created, or captured by an
  * `except` statement.
  */
-class ExceptionSource extends TaintSource {
+class ExceptionSource extends ErrorInfoSource {
 
     ExceptionSource() {
         exists(ClassObject cls |
@@ -91,7 +95,7 @@ class ExceptionInfoSequence extends SequenceKind {
  * Represents calls to functions in the `traceback` module that return
  * sequences of exception information.
  */
-class CallToTracebackFunction extends TaintSource {
+class CallToTracebackFunction extends ErrorInfoSource {
 
     CallToTracebackFunction() {
         exists(string name |
@@ -120,7 +124,7 @@ class CallToTracebackFunction extends TaintSource {
  * Represents calls to functions in the `traceback` module that return a single
  * string of information about an exception.
  */
-class FormattedTracebackSource extends TaintSource {
+class FormattedTracebackSource extends ErrorInfoSource {
 
     FormattedTracebackSource() {
         this = traceback_function("format_exc").getACall()

--- a/python/ql/test/query-tests/Security/CWE-209/test.py
+++ b/python/ql/test/query-tests/Security/CWE-209/test.py
@@ -1,4 +1,4 @@
-from flask import Flask
+from flask import Flask, request, make_response
 app = Flask(__name__)
 
 
@@ -35,3 +35,8 @@ def server_bad_flow():
 
 def format_error(msg):
     return "[ERROR] " + msg
+
+#Unrelated error
+@app.route('/maybe_xss')
+def maybe_xss():
+    return make_response(request.args.get('name', ''))


### PR DESCRIPTION
Avoid cross-talk between sources by more tightly specifying the type of the source.

Fixes a recent regression, so no change note needed.

We will want to prevent this in general for the next release by adding some sort of configuration, so the query would become something like
```
class InformationExposureConfiguration extends TaintTracking::Configuration {
    predicate isSource(TaintTracking::Source source) { source.getNode() instanceof ErrorInfoSource }
    predicate isSink(TaintTracking::Sink sink) { sink.getNode() instanceof ErrorInfoSink }
}
from InformationExposureConfiguration config, TaintedPathSource src, TaintedPathSink sink
where config.hasFlowPath(src, sink)
select sink.getNode(), src, sink, "$@ may be exposed to an external user", src.getSource(), "Error information"
```

However, that is probably too intrusive a change this close to the release.