### PR TITLE
JavaScript: Remove a `@link` in Javadoc.

### DIFF
--- a/javascript/extractor/src/com/semmle/js/extractor/test/AutoBuildTests.java
+++ b/javascript/extractor/src/com/semmle/js/extractor/test/AutoBuildTests.java
@@ -85,7 +85,7 @@ public class AutoBuildTests {
   }
 
   /**
-   * Add a file with default file type; see {@link #addFile(boolean, FileType, Path, String...)}.
+   * Add a file with default file type.
    */
   private Path addFile(boolean extracted, Path root, String... components) throws IOException {
     return addFile(extracted, null, root, components);


### PR DESCRIPTION
Javadoc claims not to be able to resolve this link, while Eclipse manages to do so without any problems, failing an internal PR check.

It's only in a test, though, so I just removed it.