### PR TITLE
C++: Make IR TaintTracking available on LGTM

### DIFF
--- a/cpp/ql/src/filters/ImportAdditionalLibraries.ql
+++ b/cpp/ql/src/filters/ImportAdditionalLibraries.ql
@@ -22,6 +22,7 @@ module IRDataFlow {
   import semmle.code.cpp.ir.dataflow.DataFlow2
   import semmle.code.cpp.ir.dataflow.DataFlow3
   import semmle.code.cpp.ir.dataflow.DataFlow4
+  import semmle.code.cpp.ir.dataflow.TaintTracking
 }
 
 import semmle.code.cpp.valuenumbering.HashCons


### PR DESCRIPTION
Because this new library is not used in a default query, it needs to be imported here in order to be available in the LGTM query console.

We forgot to add this in #966.