### PR TITLE
Python: Add taint-tracking configuration.

### DIFF
--- a/python/ql/src/semmle/python/dataflow/TaintTracking.qll
+++ b/python/ql/src/semmle/python/dataflow/TaintTracking.qll
@@ -1,0 +1,3 @@
+/* For compatibility with other language implementations */
+
+import semmle.python.security.TaintTracking

--- a/python/ql/src/semmle/python/security/TaintTracking.qll
+++ b/python/ql/src/semmle/python/security/TaintTracking.qll
@@ -323,7 +323,9 @@ abstract class Sanitizer extends string {
  * there are no `TaintTracking::Configuration`s.
  */
 private predicate valid_sanitizer(Sanitizer sanitizer) {
-    forall (TaintTracking::Configuration c | c.isSanitizer(sanitizer))
+    not exists(TaintTracking::Configuration c)
+    or
+    exists(TaintTracking::Configuration c | c.isSanitizer(sanitizer))
 }
 
 /** DEPRECATED -- Use DataFlowExtension instead.
@@ -850,7 +852,11 @@ library module TaintFlowImplementation {
         or
         exists(DataFlowNode fromnodenode |
             fromnodenode = fromnode.getNode() and
-            forall(TaintTracking::Configuration c | c.isExtension(fromnodenode))
+            (
+                not exists(TaintTracking::Configuration c)
+                or
+                exists(TaintTracking::Configuration c | c.isExtension(fromnodenode))
+            )
             |
             fromnodenode.getASuccessorNode() = tonode and
             fromnode.getContext() = tocontext and


### PR DESCRIPTION
New configuration based interface for 1.20. 

Should help avoid accidentally using extra sources and sinks via import, and brings the interface closer to that of the other languages.

It is unused for 1.20, to avoid risk of breakage.
However, it will be available for customers, will allow documentation to match code on master, and means that the documentation for writing taint-tracking queries will not need to change from 1.20 to 1.21.

This PR on master demonstrates it use:
https://github.com/Semmle/ql/pull/1051