### PR TITLE
Python: Fix up OsGuard class.

### DIFF
--- a/python/ql/src/semmle/python/types/Version.qll
+++ b/python/ql/src/semmle/python/types/Version.qll
@@ -91,15 +91,15 @@ class VersionGuard extends ConditionBlock {
 }
 
 string os_name(StrConst s) {
-    exists(string t | 
+    exists(string t |
         t = s.getText() |
-        t = "Darwin" and result = "darwin"
+        (t = "linux" or t = "linux2") and result = "Linux"
         or
-        t = "Windows" and result = "win32"
+        t = "win32" and result = "Windows"
         or
-        t = "Linux" and result = "linux"
+        t = "darwin" and result = "Darwin"
         or
-        not t = "Darwin" and not t = "Windows" and not t = "Linux" and result = t
+        not t  = "linux" and not t = "linux2" and not t = "win32" and not t = "darwin" and result = t
     )
 }
 
@@ -154,13 +154,13 @@ class OsGuard extends ConditionBlock {
 
     OsGuard() {
         exists(OsTest t |
-            PointsTo::points_to(this.getLastNode(), _, theBoolType(), t, _)
+            PointsTo::points_to(this.getLastNode(), _, _, theBoolType(), t)
         )
     }
 
     string getOs() {
         exists(OsTest t |
-            PointsTo::points_to(this.getLastNode(), _, theBoolType(), t, _) and result = t.getOs()
+            PointsTo::points_to(this.getLastNode(), _, _, theBoolType(), t) and result = t.getOs()
         )
     }
 

--- a/python/ql/test/library-tests/PointsTo/version/OSGuard.expected
+++ b/python/ql/test/library-tests/PointsTo/version/OSGuard.expected
@@ -1,0 +1,2 @@
+| 34 | BasicBlock | Linux |
+| 68 | BasicBlock | Windows |

--- a/python/ql/test/library-tests/PointsTo/version/OSGuard.ql
+++ b/python/ql/test/library-tests/PointsTo/version/OSGuard.ql
@@ -1,0 +1,8 @@
+
+import python
+import semmle.python.types.Version
+
+from OsGuard og, Location l 
+where l = og.getLastNode().getLocation() and
+l.getFile().getName().matches("%test.py")
+select l.getStartLine(), og.toString(), og.getOs()

--- a/python/ql/test/library-tests/PointsTo/version/test.py
+++ b/python/ql/test/library-tests/PointsTo/version/test.py
@@ -11,7 +11,7 @@ import sys
 
 
 
-os_test = sys.platform == "linux"
+os_test = sys.platform == "win32"
 version_test = sys.version_info < (3,)
 
 from module import os_test as t2
@@ -64,3 +64,7 @@ Py2f = sys.version_info[:2] < (2,7)
 #From problem_report
 Py2g = sys.version[0] < '3'
 Py3h = sys.version[0] >= '3'
+
+if os_test:
+    pass
+


### PR DESCRIPTION
This class is unused in the library or any queries, but it is part of the historic API and should work.
This PR gets it back to a working state.