### PR TITLE
Python: Fix compilation warnings.

### DIFF
--- a/python/ql/src/semmle/python/Exprs.qll
+++ b/python/ql/src/semmle/python/Exprs.qll
@@ -502,7 +502,7 @@ class Dict extends Dict_ {
         result = this.getAValue() or result = this.getAKey()
     }
 
-    AstNode getAChildNode() {
+    override AstNode getAChildNode() {
         result = this.getAnItem()
     }
 

--- a/python/ql/src/semmle/python/pointsto/PointsTo.qll
+++ b/python/ql/src/semmle/python/pointsto/PointsTo.qll
@@ -1625,7 +1625,7 @@ module PointsTo {
             context.isRuntime() and
             exists(ControlFlowNode param |
                 param = def.getDefiningNode() |
-                varargs_points_to(param, cls) and value = theEmptyTupleObject() and origin = param
+                varargs_points_to(param, cls) and value = TupleObject::empty() and origin = param
                 or
                 varargs_points_to(param, cls) and value = param and origin = param
                 or

--- a/python/ql/src/semmle/python/types/ClassObject.qll
+++ b/python/ql/src/semmle/python/types/ClassObject.qll
@@ -385,7 +385,7 @@ class ClassObject extends Object {
         result.getFunction().refersTo(this)
     }
 
-    predicate notClass() {
+    override predicate notClass() {
         none()
     }
 

--- a/python/ql/src/semmle/python/types/Object.qll
+++ b/python/ql/src/semmle/python/types/Object.qll
@@ -130,7 +130,7 @@ class Object extends @py_object {
         or
         this = theFalseObject() and result = false 
         or
-        this = theEmptyTupleObject() and result = false 
+        this = TupleObject::empty() and result = false 
         or
         exists(Tuple t | t = this.getOrigin() |
             exists(t.getAnElt()) and result = true


### PR DESCRIPTION
Fixes four warnings that are produced when compiling the standard LGTM queries.