### PR TITLE
CPP: Add references section to cpp/return-stack-allocated-memory

### DIFF
--- a/cpp/ql/src/Likely Bugs/Memory Management/ReturnStackAllocatedMemory.qhelp
+++ b/cpp/ql/src/Likely Bugs/Memory Management/ReturnStackAllocatedMemory.qhelp
@@ -22,4 +22,7 @@ memory after the function has already returned will have undefined results. </p>
 
 
 </example>
+
+<references>
+</references>
 </qhelp>


### PR DESCRIPTION
Add a references section to `cpp/return-stack-allocated-memory`, so that the query help generator will be able to add a reference from the CWE tag.

@felicity-semmle 