### PR TITLE
[CPP-80] Make query message and qlhelp more user-friendly.

### DIFF
--- a/cpp/ql/src/Architecture/Refactoring Opportunities/ClassesWithManyFields.qhelp
+++ b/cpp/ql/src/Architecture/Refactoring Opportunities/ClassesWithManyFields.qhelp
@@ -6,7 +6,7 @@
 
 <overview>
 <p>This rule finds classes with more than 15 instance (i.e., non-<code>static</code>) fields. Library classes
-are not shown. Having too many fields in one class is a sign that the class lacks cohesion (i.e. lacks a single purpose).
+are not shown. Having too many fields in one class is a sign that the class may lack cohesion (i.e. lack a single purpose).
 These classes can be split into smaller, more cohesive classes. Alternatively, the related fields can be grouped 
 into <code>struct</code>s.</p>
 

--- a/cpp/ql/src/Architecture/Refactoring Opportunities/ClassesWithManyFields.qhelp
+++ b/cpp/ql/src/Architecture/Refactoring Opportunities/ClassesWithManyFields.qhelp
@@ -4,53 +4,33 @@
 <qhelp>
 
 
-	<overview>
-		<p>
-			This rule finds classes with more than 15 instance (i.e., non-
-			<code>static</code>
-			) fields. Library classes
-			are not shown. Having too many fields in one class is a sign that the
-			class may lack cohesion (i.e. lack a single purpose).
-			These classes can be split into smaller, more cohesive classes.
-			Alternatively, the related fields can be grouped
-			into
-			<code>struct</code>
-			s.
-		</p>
+<overview>
+<p>This rule finds classes with more than 15 instance (i.e., non-<code>static</code>) fields. Library classes
+are not shown. Having too many fields in one class is a sign that the class lacks cohesion (i.e. lacks a single purpose).
+These classes can be split into smaller, more cohesive classes. Alternatively, the related fields can be grouped 
+into <code>struct</code>s.</p>
 
-	</overview>
-	<recommendation>
-		<p>Classes with many fields may be hard to maintain. They could
-			probably be refactored by breaking them down into smaller classes
-			and using composition.
-		</p>
+</overview>
+<recommendation>
+<p>Classes with many fields may be hard to maintain. They could probably be refactored by breaking them down into smaller classes
+and using composition.</p>
 
-	</recommendation>
-	<example>
-		<sample src="ClassesWithManyFields.cpp" />
+</recommendation>
+<example>
+<sample src="ClassesWithManyFields.cpp" />
 
 
-	</example>
-	<references>
+</example>
+<references>
 
-		<li>
-			W. Stevens, G. Myers, L. Constantine,
-			<em>Structured Design</em>
-			. IBM Systems Journal, 13 (2), 115-139, 1974.
-		</li>
-		<li>
-			Microsoft Patterns &amp; Practices Team,
-			<em>Microsoft Application Architecture Guide (2nd Edition), Chapter
-				3: Architectural Patterns and Styles.</em>
-			Microsoft Press, 2009 (
-			<a href="http://msdn.microsoft.com/en-us/library/ee658117.aspx">available online</a>
-			).
-		</li>
-		<li>
-			Wikipedia:
-			<a href="https://en.wikipedia.org/wiki/Code_refactoring">Code refactoring</a>
-		</li>
+<li>W. Stevens, G. Myers, L. Constantine, <em>Structured Design</em>. IBM Systems Journal, 13 (2), 115-139, 1974.</li>
+<li>
+Microsoft Patterns &amp; Practices Team, <em>Microsoft Application Architecture Guide (2nd Edition), Chapter 3: Architectural Patterns and Styles.</em> Microsoft Press, 2009 (<a href="http://msdn.microsoft.com/en-us/library/ee658117.aspx">available online</a>).
+</li>
+<li>
+  Wikipedia: <a href="https://en.wikipedia.org/wiki/Code_refactoring">Code refactoring</a>
+</li>
 
 
-	</references>
+</references>
 </qhelp>

--- a/cpp/ql/src/Architecture/Refactoring Opportunities/ClassesWithManyFields.qhelp
+++ b/cpp/ql/src/Architecture/Refactoring Opportunities/ClassesWithManyFields.qhelp
@@ -4,58 +4,53 @@
 <qhelp>
 
 
-    <overview>
-        <p>
-            This rule finds classes with more than 15 instance (i.e., non-
-            <code>static</code>
-            ) fields. Library classes
-            are not shown. Having too many fields in one
-            class is a sign that the
-            class may lack cohesion (i.e. lack a single
-            purpose).
-            These classes can be split into smaller, more cohesive
-            classes.
-            Alternatively, the related fields can be grouped
-            into
-            <code>struct</code>
-            s.
-        </p>
+	<overview>
+		<p>
+			This rule finds classes with more than 15 instance (i.e., non-
+			<code>static</code>
+			) fields. Library classes
+			are not shown. Having too many fields in one class is a sign that the
+			class may lack cohesion (i.e. lack a single purpose).
+			These classes can be split into smaller, more cohesive classes.
+			Alternatively, the related fields can be grouped
+			into
+			<code>struct</code>
+			s.
+		</p>
 
-    </overview>
-    <recommendation>
-        <p>Classes with many fields may be hard to maintain. They could
-            probably be refactored by breaking them down into smaller classes
-            and
-            using composition.
-        </p>
+	</overview>
+	<recommendation>
+		<p>Classes with many fields may be hard to maintain. They could
+			probably be refactored by breaking them down into smaller classes
+			and using composition.
+		</p>
 
-    </recommendation>
-    <example>
-        <sample src="ClassesWithManyFields.cpp" />
+	</recommendation>
+	<example>
+		<sample src="ClassesWithManyFields.cpp" />
 
 
-    </example>
-    <references>
+	</example>
+	<references>
 
-        <li>
-            W. Stevens, G. Myers, L. Constantine,
-            <em>Structured Design</em>
-            . IBM Systems Journal, 13 (2), 115-139, 1974.
-        </li>
-        <li>
-            Microsoft Patterns &amp; Practices Team,
-            <em>Microsoft Application Architecture Guide (2nd Edition), Chapter
-                3: Architectural Patterns and Styles.
-            </em>
-            Microsoft Press, 2009 (
-            <a href="http://msdn.microsoft.com/en-us/library/ee658117.aspx">available online</a>
-            ).
-        </li>
-        <li>
-            Wikipedia:
-            <a href="https://en.wikipedia.org/wiki/Code_refactoring">Code refactoring</a>
-        </li>
+		<li>
+			W. Stevens, G. Myers, L. Constantine,
+			<em>Structured Design</em>
+			. IBM Systems Journal, 13 (2), 115-139, 1974.
+		</li>
+		<li>
+			Microsoft Patterns &amp; Practices Team,
+			<em>Microsoft Application Architecture Guide (2nd Edition), Chapter
+				3: Architectural Patterns and Styles.</em>
+			Microsoft Press, 2009 (
+			<a href="http://msdn.microsoft.com/en-us/library/ee658117.aspx">available online</a>
+			).
+		</li>
+		<li>
+			Wikipedia:
+			<a href="https://en.wikipedia.org/wiki/Code_refactoring">Code refactoring</a>
+		</li>
 
 
-    </references>
+	</references>
 </qhelp>

--- a/cpp/ql/src/Architecture/Refactoring Opportunities/ClassesWithManyFields.qhelp
+++ b/cpp/ql/src/Architecture/Refactoring Opportunities/ClassesWithManyFields.qhelp
@@ -4,33 +4,53 @@
 <qhelp>
 
 
-<overview>
-<p>This rule finds classes with more than 15 instance (i.e., non-<code>static</code>) fields. Library classes
-are not shown. Having too many fields in one class is a sign that the class lacks cohesion (i.e. lacks a single purpose).
-These classes can be split into smaller, more cohesive classes. Alternatively, the related fields can be grouped 
-into <code>struct</code>s.</p>
+	<overview>
+		<p>
+			This rule finds classes with more than 15 instance (i.e., non-
+			<code>static</code>
+			) fields. Library classes
+			are not shown. Having too many fields in one class is a sign that the
+			class may lack cohesion (i.e. lack a single purpose).
+			These classes can be split into smaller, more cohesive classes.
+			Alternatively, the related fields can be grouped
+			into
+			<code>struct</code>
+			s.
+		</p>
 
-</overview>
-<recommendation>
-<p>Classes with many fields may be hard to maintain. They could probably be refactored by breaking them down into smaller classes
-and using composition.</p>
+	</overview>
+	<recommendation>
+		<p>Classes with many fields may be hard to maintain. They could
+			probably be refactored by breaking them down into smaller classes
+			and using composition.
+		</p>
 
-</recommendation>
-<example>
-<sample src="ClassesWithManyFields.cpp" />
-
-
-</example>
-<references>
-
-<li>W. Stevens, G. Myers, L. Constantine, <em>Structured Design</em>. IBM Systems Journal, 13 (2), 115-139, 1974.</li>
-<li>
-Microsoft Patterns &amp; Practices Team, <em>Microsoft Application Architecture Guide (2nd Edition), Chapter 3: Architectural Patterns and Styles.</em> Microsoft Press, 2009 (<a href="http://msdn.microsoft.com/en-us/library/ee658117.aspx">available online</a>).
-</li>
-<li>
-  Wikipedia: <a href="https://en.wikipedia.org/wiki/Code_refactoring">Code refactoring</a>
-</li>
+	</recommendation>
+	<example>
+		<sample src="ClassesWithManyFields.cpp" />
 
 
-</references>
+	</example>
+	<references>
+
+		<li>
+			W. Stevens, G. Myers, L. Constantine,
+			<em>Structured Design</em>
+			. IBM Systems Journal, 13 (2), 115-139, 1974.
+		</li>
+		<li>
+			Microsoft Patterns &amp; Practices Team,
+			<em>Microsoft Application Architecture Guide (2nd Edition), Chapter
+				3: Architectural Patterns and Styles.</em>
+			Microsoft Press, 2009 (
+			<a href="http://msdn.microsoft.com/en-us/library/ee658117.aspx">available online</a>
+			).
+		</li>
+		<li>
+			Wikipedia:
+			<a href="https://en.wikipedia.org/wiki/Code_refactoring">Code refactoring</a>
+		</li>
+
+
+	</references>
 </qhelp>

--- a/cpp/ql/src/Architecture/Refactoring Opportunities/ClassesWithManyFields.qhelp
+++ b/cpp/ql/src/Architecture/Refactoring Opportunities/ClassesWithManyFields.qhelp
@@ -4,53 +4,58 @@
 <qhelp>
 
 
-	<overview>
-		<p>
-			This rule finds classes with more than 15 instance (i.e., non-
-			<code>static</code>
-			) fields. Library classes
-			are not shown. Having too many fields in one class is a sign that the
-			class may lack cohesion (i.e. lack a single purpose).
-			These classes can be split into smaller, more cohesive classes.
-			Alternatively, the related fields can be grouped
-			into
-			<code>struct</code>
-			s.
-		</p>
+    <overview>
+        <p>
+            This rule finds classes with more than 15 instance (i.e., non-
+            <code>static</code>
+            ) fields. Library classes
+            are not shown. Having too many fields in one
+            class is a sign that the
+            class may lack cohesion (i.e. lack a single
+            purpose).
+            These classes can be split into smaller, more cohesive
+            classes.
+            Alternatively, the related fields can be grouped
+            into
+            <code>struct</code>
+            s.
+        </p>
 
-	</overview>
-	<recommendation>
-		<p>Classes with many fields may be hard to maintain. They could
-			probably be refactored by breaking them down into smaller classes
-			and using composition.
-		</p>
+    </overview>
+    <recommendation>
+        <p>Classes with many fields may be hard to maintain. They could
+            probably be refactored by breaking them down into smaller classes
+            and
+            using composition.
+        </p>
 
-	</recommendation>
-	<example>
-		<sample src="ClassesWithManyFields.cpp" />
-
-
-	</example>
-	<references>
-
-		<li>
-			W. Stevens, G. Myers, L. Constantine,
-			<em>Structured Design</em>
-			. IBM Systems Journal, 13 (2), 115-139, 1974.
-		</li>
-		<li>
-			Microsoft Patterns &amp; Practices Team,
-			<em>Microsoft Application Architecture Guide (2nd Edition), Chapter
-				3: Architectural Patterns and Styles.</em>
-			Microsoft Press, 2009 (
-			<a href="http://msdn.microsoft.com/en-us/library/ee658117.aspx">available online</a>
-			).
-		</li>
-		<li>
-			Wikipedia:
-			<a href="https://en.wikipedia.org/wiki/Code_refactoring">Code refactoring</a>
-		</li>
+    </recommendation>
+    <example>
+        <sample src="ClassesWithManyFields.cpp" />
 
 
-	</references>
+    </example>
+    <references>
+
+        <li>
+            W. Stevens, G. Myers, L. Constantine,
+            <em>Structured Design</em>
+            . IBM Systems Journal, 13 (2), 115-139, 1974.
+        </li>
+        <li>
+            Microsoft Patterns &amp; Practices Team,
+            <em>Microsoft Application Architecture Guide (2nd Edition), Chapter
+                3: Architectural Patterns and Styles.
+            </em>
+            Microsoft Press, 2009 (
+            <a href="http://msdn.microsoft.com/en-us/library/ee658117.aspx">available online</a>
+            ).
+        </li>
+        <li>
+            Wikipedia:
+            <a href="https://en.wikipedia.org/wiki/Code_refactoring">Code refactoring</a>
+        </li>
+
+
+    </references>
 </qhelp>

--- a/cpp/ql/src/Architecture/Refactoring Opportunities/ClassesWithManyFields.ql
+++ b/cpp/ql/src/Architecture/Refactoring Opportunities/ClassesWithManyFields.ql
@@ -9,53 +9,41 @@
  *       statistical
  *       non-attributable
  */
-
 import cpp
 
-string kindstr(Class c) {
+string kindstr(Class c)
+{
   exists(int kind | usertypes(unresolveElement(c), _, kind) |
-    (kind = 1 and result = "Struct")
-    or
-    (kind = 2 and result = "Class")
-    or
+    (kind = 1 and result = "Struct") or
+    (kind = 2 and result = "Class") or
     (kind = 6 and result = "Template class")
   )
 }
 
-predicate vdeInfo(VariableDeclarationEntry vde, Class c, File f, int line) {
+predicate vdeInfo(VariableDeclarationEntry vde, Class c, File f, int line)
+{
   c = vde.getVariable().getDeclaringType() and
   f = vde.getLocation().getFile() and
   line = vde.getLocation().getStartLine()
 }
 
-predicate previousVde(VariableDeclarationEntry previous, VariableDeclarationEntry vde) {
+predicate previousVde(VariableDeclarationEntry previous, VariableDeclarationEntry vde)
+{
   exists(Class c, File f, int line | vdeInfo(vde, c, f, line) |
-    vdeInfo(previous, c, f, line - 3)
-    or
-    vdeInfo(previous, c, f, line - 2)
-    or
-    vdeInfo(previous, c, f, line - 1)
-    or
-    (
-      vdeInfo(previous, c, f, line) and
-      exists(int prevCol, int vdeCol |
-        prevCol = previous.getLocation().getStartColumn() and
-        vdeCol = vde.getLocation().getStartColumn()
-      |
-        prevCol < vdeCol
-        or
-        (prevCol = vdeCol and previous.getName() < vde.getName())
-      )
-    )
+    vdeInfo(previous, c, f, line - 3) or
+    vdeInfo(previous, c, f, line - 2) or
+    vdeInfo(previous, c, f, line - 1) or
+    (vdeInfo(previous, c, f, line) and exists(int prevCol, int vdeCol |
+      prevCol = previous.getLocation().getStartColumn() and vdeCol = vde.getLocation().getStartColumn() |
+      prevCol < vdeCol or (prevCol = vdeCol and previous.getName() < vde.getName())
+    ))
   )
 }
 
-predicate masterVde(VariableDeclarationEntry master, VariableDeclarationEntry vde) {
-  (not previousVde(_, vde) and master = vde)
-  or
-  exists(VariableDeclarationEntry previous |
-    previousVde(previous, vde) and masterVde(master, previous)
-  )
+predicate masterVde(VariableDeclarationEntry master, VariableDeclarationEntry vde)
+{
+  (not previousVde(_, vde) and master = vde) or
+  exists(VariableDeclarationEntry previous | previousVde(previous, vde) and masterVde(master, previous))
 }
 
 class VariableDeclarationGroup extends ElementBase {
@@ -63,8 +51,9 @@ class VariableDeclarationGroup extends ElementBase {
     this instanceof VariableDeclarationEntry and
     not previousVde(_, this)
   }
-
-  Class getClass() { vdeInfo(this, result, _, _) }
+  Class getClass() {
+    vdeInfo(this, result, _, _)
+  }
 
   // pragma[noopt] since otherwise the two locationInfo relations get join-ordered
   // after each other
@@ -74,9 +63,7 @@ class VariableDeclarationGroup extends ElementBase {
       masterVde(this, last) and
       this instanceof VariableDeclarationGroup and
       not previousVde(last, _) and
-      exists(VariableDeclarationEntry vde |
-        vde = this and vde instanceof VariableDeclarationEntry and vde.getLocation() = lstart
-      ) and
+      exists(VariableDeclarationEntry vde | vde=this and vde instanceof VariableDeclarationEntry and vde.getLocation() = lstart) and
       last.getLocation() = lend and
       lstart.hasLocationInfo(path, startline, startcol, _, _) and
       lend.hasLocationInfo(path, _, _, endline, endcol)
@@ -84,16 +71,15 @@ class VariableDeclarationGroup extends ElementBase {
   }
 
   string describeGroup() {
-    if previousVde(this, _)
-    then
-      result = "group of " +
-          strictcount(string name |
-            exists(VariableDeclarationEntry vde |
-              masterVde(this, vde) and
-              name = vde.getName()
-            )
-          ) + " fields here"
-    else result = "declaration of " + this.(VariableDeclarationEntry).getVariable().getName()
+    if previousVde(this, _) then
+      result = "group of "
+             + strictcount(string name
+                         | exists(VariableDeclarationEntry vde
+                                | masterVde(this, vde) and
+                                  name = vde.getName()))
+             + " fields here"
+    else
+      result = "declaration of " + this.(VariableDeclarationEntry).getVariable().getName()
   }
 }
 
@@ -103,33 +89,26 @@ class ExtClass extends Class {
   }
 
   predicate hasLocationInfo(string path, int startline, int startcol, int endline, int endcol) {
-    if hasOneVariableGroup()
-    then
-      exists(VariableDeclarationGroup vdg | vdg.getClass() = this |
-        vdg.hasLocationInfo(path, startline, startcol, endline, endcol)
-      )
-    else getLocation().hasLocationInfo(path, startline, startcol, endline, endcol)
+    if hasOneVariableGroup() then
+      exists(VariableDeclarationGroup vdg | vdg.getClass() = this | vdg.hasLocationInfo(path, startline, startcol, endline, endcol))
+    else
+      getLocation().hasLocationInfo(path, startline, startcol, endline, endcol)
   }
 }
 
 from ExtClass c, int n, VariableDeclarationGroup vdg, string suffix
-where
-  n = strictcount(string fieldName |
-      exists(Field f |
-        f.getDeclaringType() = c and
-        fieldName = f.getName() and
-        // IBOutlet's are a way of building GUIs
-        // automatically out of ObjC properties.
-        // We don't want to count those for the
-        // purposes of this query.
-        not (f.getType().getAnAttribute().hasName("iboutlet"))
-      )
-    ) and
-  n > 15 and
-  not c.isConstructedFrom(_) and
-  c = vdg.getClass() and
-  if c.hasOneVariableGroup() then suffix = "" else suffix = " - see $@"
-select c,
-  kindstr(c) + " '" + c.getName() + "' has " + n +
-    " fields; we recommend refactoring to 15 fields or fewer" + suffix + ".", vdg,
-  vdg.describeGroup()
+where n = strictcount(string fieldName
+                    | exists(Field f
+                           | f.getDeclaringType() = c and
+                             fieldName = f.getName() and
+                             // IBOutlet's are a way of building GUIs
+                             // automatically out of ObjC properties.
+                             // We don't want to count those for the
+                             // purposes of this query.
+                             not (f.getType().getAnAttribute().hasName("iboutlet")))) and
+      n > 15 and
+      not c.isConstructedFrom(_) and
+      c = vdg.getClass() and
+      if c.hasOneVariableGroup() then suffix = "" else suffix = " - see $@"
+select c, kindstr(c) + " " + c.getName() + " has " + n + " fields, which is too many" + suffix + ".",
+       vdg, vdg.describeGroup()

--- a/cpp/ql/src/Architecture/Refactoring Opportunities/ClassesWithManyFields.ql
+++ b/cpp/ql/src/Architecture/Refactoring Opportunities/ClassesWithManyFields.ql
@@ -110,5 +110,5 @@ where n = strictcount(string fieldName
       not c.isConstructedFrom(_) and
       c = vdg.getClass() and
       if c.hasOneVariableGroup() then suffix = "" else suffix = " - see $@"
-select c, kindstr(c) + " " + c.getName() + " has " + n + " fields, which is too many" + suffix + ".",
+select c, kindstr(c) + " " + c.getName() + " has " + n + " fields; we recommend refactoring to 15 fields or fewer" + suffix + ".",
        vdg, vdg.describeGroup()

--- a/cpp/ql/src/Architecture/Refactoring Opportunities/ClassesWithManyFields.ql
+++ b/cpp/ql/src/Architecture/Refactoring Opportunities/ClassesWithManyFields.ql
@@ -9,41 +9,53 @@
  *       statistical
  *       non-attributable
  */
+
 import cpp
 
-string kindstr(Class c)
-{
+string kindstr(Class c) {
   exists(int kind | usertypes(unresolveElement(c), _, kind) |
-    (kind = 1 and result = "Struct") or
-    (kind = 2 and result = "Class") or
+    (kind = 1 and result = "Struct")
+    or
+    (kind = 2 and result = "Class")
+    or
     (kind = 6 and result = "Template class")
   )
 }
 
-predicate vdeInfo(VariableDeclarationEntry vde, Class c, File f, int line)
-{
+predicate vdeInfo(VariableDeclarationEntry vde, Class c, File f, int line) {
   c = vde.getVariable().getDeclaringType() and
   f = vde.getLocation().getFile() and
   line = vde.getLocation().getStartLine()
 }
 
-predicate previousVde(VariableDeclarationEntry previous, VariableDeclarationEntry vde)
-{
+predicate previousVde(VariableDeclarationEntry previous, VariableDeclarationEntry vde) {
   exists(Class c, File f, int line | vdeInfo(vde, c, f, line) |
-    vdeInfo(previous, c, f, line - 3) or
-    vdeInfo(previous, c, f, line - 2) or
-    vdeInfo(previous, c, f, line - 1) or
-    (vdeInfo(previous, c, f, line) and exists(int prevCol, int vdeCol |
-      prevCol = previous.getLocation().getStartColumn() and vdeCol = vde.getLocation().getStartColumn() |
-      prevCol < vdeCol or (prevCol = vdeCol and previous.getName() < vde.getName())
-    ))
+    vdeInfo(previous, c, f, line - 3)
+    or
+    vdeInfo(previous, c, f, line - 2)
+    or
+    vdeInfo(previous, c, f, line - 1)
+    or
+    (
+      vdeInfo(previous, c, f, line) and
+      exists(int prevCol, int vdeCol |
+        prevCol = previous.getLocation().getStartColumn() and
+        vdeCol = vde.getLocation().getStartColumn()
+      |
+        prevCol < vdeCol
+        or
+        (prevCol = vdeCol and previous.getName() < vde.getName())
+      )
+    )
   )
 }
 
-predicate masterVde(VariableDeclarationEntry master, VariableDeclarationEntry vde)
-{
-  (not previousVde(_, vde) and master = vde) or
-  exists(VariableDeclarationEntry previous | previousVde(previous, vde) and masterVde(master, previous))
+predicate masterVde(VariableDeclarationEntry master, VariableDeclarationEntry vde) {
+  (not previousVde(_, vde) and master = vde)
+  or
+  exists(VariableDeclarationEntry previous |
+    previousVde(previous, vde) and masterVde(master, previous)
+  )
 }
 
 class VariableDeclarationGroup extends ElementBase {
@@ -51,9 +63,8 @@ class VariableDeclarationGroup extends ElementBase {
     this instanceof VariableDeclarationEntry and
     not previousVde(_, this)
   }
-  Class getClass() {
-    vdeInfo(this, result, _, _)
-  }
+
+  Class getClass() { vdeInfo(this, result, _, _) }
 
   // pragma[noopt] since otherwise the two locationInfo relations get join-ordered
   // after each other
@@ -63,7 +74,9 @@ class VariableDeclarationGroup extends ElementBase {
       masterVde(this, last) and
       this instanceof VariableDeclarationGroup and
       not previousVde(last, _) and
-      exists(VariableDeclarationEntry vde | vde=this and vde instanceof VariableDeclarationEntry and vde.getLocation() = lstart) and
+      exists(VariableDeclarationEntry vde |
+        vde = this and vde instanceof VariableDeclarationEntry and vde.getLocation() = lstart
+      ) and
       last.getLocation() = lend and
       lstart.hasLocationInfo(path, startline, startcol, _, _) and
       lend.hasLocationInfo(path, _, _, endline, endcol)
@@ -71,15 +84,16 @@ class VariableDeclarationGroup extends ElementBase {
   }
 
   string describeGroup() {
-    if previousVde(this, _) then
-      result = "group of "
-             + strictcount(string name
-                         | exists(VariableDeclarationEntry vde
-                                | masterVde(this, vde) and
-                                  name = vde.getName()))
-             + " fields here"
-    else
-      result = "declaration of " + this.(VariableDeclarationEntry).getVariable().getName()
+    if previousVde(this, _)
+    then
+      result = "group of " +
+          strictcount(string name |
+            exists(VariableDeclarationEntry vde |
+              masterVde(this, vde) and
+              name = vde.getName()
+            )
+          ) + " fields here"
+    else result = "declaration of " + this.(VariableDeclarationEntry).getVariable().getName()
   }
 }
 
@@ -89,26 +103,33 @@ class ExtClass extends Class {
   }
 
   predicate hasLocationInfo(string path, int startline, int startcol, int endline, int endcol) {
-    if hasOneVariableGroup() then
-      exists(VariableDeclarationGroup vdg | vdg.getClass() = this | vdg.hasLocationInfo(path, startline, startcol, endline, endcol))
-    else
-      getLocation().hasLocationInfo(path, startline, startcol, endline, endcol)
+    if hasOneVariableGroup()
+    then
+      exists(VariableDeclarationGroup vdg | vdg.getClass() = this |
+        vdg.hasLocationInfo(path, startline, startcol, endline, endcol)
+      )
+    else getLocation().hasLocationInfo(path, startline, startcol, endline, endcol)
   }
 }
 
 from ExtClass c, int n, VariableDeclarationGroup vdg, string suffix
-where n = strictcount(string fieldName
-                    | exists(Field f
-                           | f.getDeclaringType() = c and
-                             fieldName = f.getName() and
-                             // IBOutlet's are a way of building GUIs
-                             // automatically out of ObjC properties.
-                             // We don't want to count those for the
-                             // purposes of this query.
-                             not (f.getType().getAnAttribute().hasName("iboutlet")))) and
-      n > 15 and
-      not c.isConstructedFrom(_) and
-      c = vdg.getClass() and
-      if c.hasOneVariableGroup() then suffix = "" else suffix = " - see $@"
-select c, kindstr(c) + " " + c.getName() + " has " + n + " fields, which is too many" + suffix + ".",
-       vdg, vdg.describeGroup()
+where
+  n = strictcount(string fieldName |
+      exists(Field f |
+        f.getDeclaringType() = c and
+        fieldName = f.getName() and
+        // IBOutlet's are a way of building GUIs
+        // automatically out of ObjC properties.
+        // We don't want to count those for the
+        // purposes of this query.
+        not (f.getType().getAnAttribute().hasName("iboutlet"))
+      )
+    ) and
+  n > 15 and
+  not c.isConstructedFrom(_) and
+  c = vdg.getClass() and
+  if c.hasOneVariableGroup() then suffix = "" else suffix = " - see $@"
+select c,
+  kindstr(c) + " '" + c.getName() + "' has " + n +
+    " fields; we recommend refactoring to 15 fields or fewer" + suffix + ".", vdg,
+  vdg.describeGroup()

--- a/cpp/ql/test/query-tests/Architecture/Refactoring Opportunities/ClassesWithManyFields/cwmf.expected
+++ b/cpp/ql/test/query-tests/Architecture/Refactoring Opportunities/ClassesWithManyFields/cwmf.expected
@@ -1,7 +1,7 @@
-| cwmf.cpp:8:3:9:12 | aa | Struct aa has 20 fields, which is too many. | cwmf.cpp:8:3:9:12 | definition of f1 | group of 20 fields here |
-| cwmf.cpp:13:3:14:12 | bb | Class bb has 20 fields, which is too many. | cwmf.cpp:13:3:14:12 | definition of f1 | group of 20 fields here |
-| cwmf.cpp:24:3:25:12 | dd<T> | Template class dd<T> has 20 fields, which is too many. | cwmf.cpp:24:3:25:12 | definition of f1 | group of 20 fields here |
-| cwmf.cpp:30:3:31:12 | ee<U> | Template class ee<U> has 20 fields, which is too many. | cwmf.cpp:30:3:31:12 | definition of f1 | group of 20 fields here |
-| cwmf.cpp:41:8:57:22 | MyParticle | Struct MyParticle has 30 fields, which is too many. | cwmf.cpp:41:8:57:22 | definition of isActive | group of 30 fields here |
-| different_types.h:15:15:33:10 | DifferentTypes2 | Class DifferentTypes2 has 18 fields, which is too many. | different_types.h:15:15:33:10 | definition of i1 | group of 18 fields here |
-| different_types.h:15:15:33:10 | DifferentTypes2 | Class DifferentTypes2 has 18 fields, which is too many. | different_types.h:15:15:33:10 | definition of i1 | group of 18 fields here |
+| cwmf.cpp:8:3:9:12 | aa | Struct 'aa' has 20 fields; we recommend refactoring to 15 fields or fewer. | cwmf.cpp:8:3:9:12 | definition of f1 | group of 20 fields here |
+| cwmf.cpp:13:3:14:12 | bb | Class 'bb' has 20 fields; we recommend refactoring to 15 fields or fewer. | cwmf.cpp:13:3:14:12 | definition of f1 | group of 20 fields here |
+| cwmf.cpp:24:3:25:12 | dd<T> | Template class 'dd<T>' has 20 fields; we recommend refactoring to 15 fields or fewer. | cwmf.cpp:24:3:25:12 | definition of f1 | group of 20 fields here |
+| cwmf.cpp:30:3:31:12 | ee<U> | Template class 'ee<U>' has 20 fields; we recommend refactoring to 15 fields or fewer. | cwmf.cpp:30:3:31:12 | definition of f1 | group of 20 fields here |
+| cwmf.cpp:41:8:57:22 | MyParticle | Struct 'MyParticle' has 30 fields; we recommend refactoring to 15 fields or fewer. | cwmf.cpp:41:8:57:22 | definition of isActive | group of 30 fields here |
+| different_types.h:15:15:33:10 | DifferentTypes2 | Class 'DifferentTypes2' has 18 fields; we recommend refactoring to 15 fields or fewer. | different_types.h:15:15:33:10 | definition of i1 | group of 18 fields here |
+| different_types.h:15:15:33:10 | DifferentTypes2 | Class 'DifferentTypes2' has 18 fields; we recommend refactoring to 15 fields or fewer. | different_types.h:15:15:33:10 | definition of i1 | group of 18 fields here |

--- a/cpp/ql/test/query-tests/Architecture/Refactoring Opportunities/ClassesWithManyFields/cwmf.expected
+++ b/cpp/ql/test/query-tests/Architecture/Refactoring Opportunities/ClassesWithManyFields/cwmf.expected
@@ -1,7 +1,7 @@
-| cwmf.cpp:8:3:9:12 | aa | Struct 'aa' has 20 fields; we recommend refactoring to 15 fields or fewer. | cwmf.cpp:8:3:9:12 | definition of f1 | group of 20 fields here |
-| cwmf.cpp:13:3:14:12 | bb | Class 'bb' has 20 fields; we recommend refactoring to 15 fields or fewer. | cwmf.cpp:13:3:14:12 | definition of f1 | group of 20 fields here |
-| cwmf.cpp:24:3:25:12 | dd<T> | Template class 'dd<T>' has 20 fields; we recommend refactoring to 15 fields or fewer. | cwmf.cpp:24:3:25:12 | definition of f1 | group of 20 fields here |
-| cwmf.cpp:30:3:31:12 | ee<U> | Template class 'ee<U>' has 20 fields; we recommend refactoring to 15 fields or fewer. | cwmf.cpp:30:3:31:12 | definition of f1 | group of 20 fields here |
-| cwmf.cpp:41:8:57:22 | MyParticle | Struct 'MyParticle' has 30 fields; we recommend refactoring to 15 fields or fewer. | cwmf.cpp:41:8:57:22 | definition of isActive | group of 30 fields here |
-| different_types.h:15:15:33:10 | DifferentTypes2 | Class 'DifferentTypes2' has 18 fields; we recommend refactoring to 15 fields or fewer. | different_types.h:15:15:33:10 | definition of i1 | group of 18 fields here |
-| different_types.h:15:15:33:10 | DifferentTypes2 | Class 'DifferentTypes2' has 18 fields; we recommend refactoring to 15 fields or fewer. | different_types.h:15:15:33:10 | definition of i1 | group of 18 fields here |
+| cwmf.cpp:8:3:9:12 | aa | Struct aa has 20 fields, which is too many. | cwmf.cpp:8:3:9:12 | definition of f1 | group of 20 fields here |
+| cwmf.cpp:13:3:14:12 | bb | Class bb has 20 fields, which is too many. | cwmf.cpp:13:3:14:12 | definition of f1 | group of 20 fields here |
+| cwmf.cpp:24:3:25:12 | dd<T> | Template class dd<T> has 20 fields, which is too many. | cwmf.cpp:24:3:25:12 | definition of f1 | group of 20 fields here |
+| cwmf.cpp:30:3:31:12 | ee<U> | Template class ee<U> has 20 fields, which is too many. | cwmf.cpp:30:3:31:12 | definition of f1 | group of 20 fields here |
+| cwmf.cpp:41:8:57:22 | MyParticle | Struct MyParticle has 30 fields, which is too many. | cwmf.cpp:41:8:57:22 | definition of isActive | group of 30 fields here |
+| different_types.h:15:15:33:10 | DifferentTypes2 | Class DifferentTypes2 has 18 fields, which is too many. | different_types.h:15:15:33:10 | definition of i1 | group of 18 fields here |
+| different_types.h:15:15:33:10 | DifferentTypes2 | Class DifferentTypes2 has 18 fields, which is too many. | different_types.h:15:15:33:10 | definition of i1 | group of 18 fields here |


### PR DESCRIPTION
ql:   "struct aa has 28 fields, which is too many" becomes
       "struct 'aa' has 28 fields; we suggest refactoring to 15 fields or fewer"

qhelp "...is a sign that the class lacks cohesion (i.e., lacks a single purpose)" becomes
          "...is a sign that the class may lack cohesion (i.e., lack a single purpose)"

Both the .ql and .qhelp have been reformatted in Eclipse via  ctrl+shift+F.

NB: I'm getting 'Pending — Contributor License Agreement is not signed yet.' below, even though I did sign it (and am not allowed to sign it again)...