### PR TITLE
C++: Make FlowVar::toString not use Expr::toString

### DIFF
--- a/cpp/ql/src/semmle/code/cpp/dataflow/internal/FlowVar.qll
+++ b/cpp/ql/src/semmle/code/cpp/dataflow/internal/FlowVar.qll
@@ -269,7 +269,7 @@ module FlowVar_internal {
     override string toString() {
       exists(Expr e |
         this.definedByExpr(e, _) and
-        result = v +" := "+ e
+        result = "assignment to "+ v
       )
       or
       this.definedByInitialValue(_) and
@@ -277,7 +277,7 @@ module FlowVar_internal {
       or
       exists(Expr arg |
         this.definedByReference(arg) and
-        result = "ref def: "+ arg
+        result = "definition by reference of "+ v
       )
       or
       // impossible case


### PR DESCRIPTION
The `FlowVar::toString` predicate is purely a debugging aid, but unfortunately it has to be `cached` because it's in a `cached` class. Before this commit, it caused `Expr::toString` to be evaluated in full.