### PR TITLE
JS: exclude accessor definitions from DeadStoreOfProperty

### DIFF
--- a/javascript/ql/src/Declarations/DeadStoreOfProperty.ql
+++ b/javascript/ql/src/Declarations/DeadStoreOfProperty.ql
@@ -154,6 +154,9 @@ where
     or
     // exclude result from js/overwritten-property
     assign2.getBase() instanceof DataFlow::ObjectLiteralNode
+    or
+    // exclude result from accessor declarations
+    assign1.getWriteNode() instanceof AccessorMethodDeclaration
   )
 select assign1.getWriteNode(),
   "This write to property '" + name + "' is useless, since $@ always overrides it.",

--- a/javascript/ql/test/query-tests/Declarations/DeadStoreOfProperty/DeadStoreOfProperty.expected
+++ b/javascript/ql/test/query-tests/Declarations/DeadStoreOfProperty/DeadStoreOfProperty.expected
@@ -1,4 +1,3 @@
-| accessors.js:2:3:2:21 | static get foo() {} | This write to property 'foo' is useless, since $@ always overrides it. | accessors.js:3:3:3:22 | static set foo(v) {} | another property write |
 | fieldInit.ts:10:3:10:8 | f = 4; | This write to property 'f' is useless, since $@ always overrides it. | fieldInit.ts:13:5:13:14 | this.f = 5 | another property write |
 | real-world-examples.js:5:4:5:11 | o.p = 42 | This write to property 'p' is useless, since $@ always overrides it. | real-world-examples.js:10:2:10:9 | o.p = 42 | another property write |
 | real-world-examples.js:15:9:15:18 | o.p1 += 42 | This write to property 'p1' is useless, since $@ always overrides it. | real-world-examples.js:15:2:15:18 | o.p1 = o.p1 += 42 | another property write |

--- a/javascript/ql/test/query-tests/Declarations/DeadStoreOfProperty/DeadStoreOfProperty.expected
+++ b/javascript/ql/test/query-tests/Declarations/DeadStoreOfProperty/DeadStoreOfProperty.expected
@@ -1,3 +1,4 @@
+| accessors.js:2:3:2:21 | static get foo() {} | This write to property 'foo' is useless, since $@ always overrides it. | accessors.js:3:3:3:22 | static set foo(v) {} | another property write |
 | fieldInit.ts:10:3:10:8 | f = 4; | This write to property 'f' is useless, since $@ always overrides it. | fieldInit.ts:13:5:13:14 | this.f = 5 | another property write |
 | real-world-examples.js:5:4:5:11 | o.p = 42 | This write to property 'p' is useless, since $@ always overrides it. | real-world-examples.js:10:2:10:9 | o.p = 42 | another property write |
 | real-world-examples.js:15:9:15:18 | o.p1 += 42 | This write to property 'p1' is useless, since $@ always overrides it. | real-world-examples.js:15:2:15:18 | o.p1 = o.p1 += 42 | another property write |

--- a/javascript/ql/test/query-tests/Declarations/DeadStoreOfProperty/accessors.js
+++ b/javascript/ql/test/query-tests/Declarations/DeadStoreOfProperty/accessors.js
@@ -1,0 +1,7 @@
+class C {
+  static get foo() {} // OK
+  static set foo(v) {} // OK
+  
+  get bar() {} // OK
+  set bar(v) {} // OK
+}


### PR DESCRIPTION
Fixes a FP in DeadStoreOfProperty resulting from static accessor declarations on classes.