### PR TITLE
CPP: Fix NewDelete.qll performance.

### DIFF
--- a/cpp/ql/src/Critical/NewDelete.qll
+++ b/cpp/ql/src/Critical/NewDelete.qll
@@ -80,6 +80,7 @@ private predicate allocReaches0(Expr e, Expr alloc, string kind) {
   ) or exists(Variable v |
     // alloc via a global
     allocReachesVariable(v, alloc, kind) and
+    strictcount(VariableAccess va | va.getTarget() = v) <= 50 and // avoid very expensive cases 
     e.(VariableAccess).getTarget() = v
   )
 }


### PR DESCRIPTION
There's a cartesian product in `NewDelete.qll` between places where `malloc` is called and `VariableAccess`es those allocations might reach.  In practice this is rarely a problem - allocations for one thing are generally done in one place or a very small number of places, and often only accessed in a relatively small number of places as well.

This could be solved by not tracking the source `malloc`, only it's `kind`.  Results would be the same but it would impact the quality of our query message, as the user would no longer see 'proof' when [for example] a `malloc` is released with `delete`.

Instead I have simply excluded the largest cases from analysis.  This is done on the number of accesses to the variable, rather than the number of allocations that reach it, because the latter in nontrivial to calculate without negative recursion.

@jbj This fixes the timeouts on 'qtbindings' and 'singular', whilst having no measurable effect on performance for the four other projects I tested.

I welcome discussion of better solutions to this issue, perhaps for implementation next quarter.