### PR TITLE
TS: update TypeScript compiler version

### DIFF
--- a/javascript/extractor/lib/typescript/package.json
+++ b/javascript/extractor/lib/typescript/package.json
@@ -2,7 +2,7 @@
     "name": "typescript-parser-wrapper",
     "private": true,
     "dependencies": {
-        "typescript": "3.2.1"
+        "typescript": "3.3.3333"
     },
     "scripts": {
         "build": "tsc --project tsconfig.json && rollup -c",

--- a/javascript/extractor/lib/typescript/yarn.lock
+++ b/javascript/extractor/lib/typescript/yarn.lock
@@ -509,9 +509,9 @@ tsutils@^2.12.1:
   dependencies:
     tslib "^1.8.1"
 
-typescript@3.2.1:
-  version "3.2.1"
-  resolved "typescript-3.2.1.tgz#0b7a04b8cf3868188de914d9568bd030f0c56192"
+typescript@3.3.3333:
+  version "3.3.3333"
+  resolved "typescript-3.3.3333.tgz#171b2c5af66c59e9431199117a3bcadc66fdcfd6"
 
 wrappy@1:
   version "1.0.2"


### PR DESCRIPTION
Updating to TypeScript 3.3.3333. There are no new features in TypeScript 3.3 that affects us, but it fixes a compiler crash when extracting vscode in full mode.

[Evaluation](https://git.semmle.com/asger/dist-compare-reports/tree/balbinus.ti.semmle.com_1552394759278) as a sanity check shows no changes, though the report looks confusing at first due to vscode failing in the previous version.