### PR TITLE
Docs: mention lgtm in qhelp style guide

### DIFF
--- a/docs/query-help-style-guide.md
+++ b/docs/query-help-style-guide.md
@@ -2,7 +2,7 @@
 
 ## Introduction
 
-When you contribute a new query to Semmle/ql for inclusion in the standard queries, you should also write a query help file. This file provides detailed information about the purpose and use of the query, which is available to users in LGTM (for example [here](https://lgtm.com/rules/1506093386171/)) and on the query homepages:
+When you contribute a new query to Semmle/ql for inclusion in the standard queries, or add a custom query to your project on LGTM, you should also write a query help file. This file provides detailed information about the purpose and use of the query, which is available to users in LGTM (for example [here](https://lgtm.com/rules/1506093386171/)) and on the query homepages:
 
 *   [C/C++ queries](https://help.semmle.com/wiki/display/CCPPOBJ/)
 *   [C# queries](https://help.semmle.com/wiki/display/CSHARP/)

--- a/docs/query-help-style-guide.md
+++ b/docs/query-help-style-guide.md
@@ -2,7 +2,7 @@
 
 ## Introduction
 
-When you contribute a new query to Semmle/ql for inclusion in the standard queries, or add a custom query to your project on LGTM, you should also write a query help file. This file provides detailed information about the purpose and use of the query, which is available to users in LGTM (for example [here](https://lgtm.com/rules/1506093386171/)) and on the query homepages:
+When you contribute a new query to Semmle/ql for inclusion in the standard queries, or add a custom query for analysis in LGTM, you should also write a query help file. This file provides detailed information about the purpose and use of the query, which is available to users in LGTM (for example [here](https://lgtm.com/rules/1506093386171/)) and on the query homepages:
 
 *   [C/C++ queries](https://help.semmle.com/wiki/display/CCPPOBJ/)
 *   [C# queries](https://help.semmle.com/wiki/display/CSHARP/)


### PR DESCRIPTION
I guess we can mention LGTM in the Qhelp style guide here now.
@rneatherway and @mc-semmle, this relates to https://git.semmle.com/Semmle/code/pull/31056/