### PR TITLE
C#: No qualified names for local scope variables

### DIFF
--- a/csharp/ql/src/semmle/code/cil/Variable.qll
+++ b/csharp/ql/src/semmle/code/cil/Variable.qll
@@ -28,7 +28,9 @@ class Variable extends DotNet::Variable, Declaration, DataFlowNode, @cil_variabl
 }
 
 /** A stack variable. Either a local variable (`LocalVariable`) or a parameter (`Parameter`). */
-class StackVariable extends Variable, @cil_stack_variable { }
+class StackVariable extends Variable, @cil_stack_variable {
+  override predicate hasQualifiedName(string qualifier, string name) { none() }
+}
 
 /**
  * A local variable.

--- a/csharp/ql/src/semmle/code/csharp/Variable.qll
+++ b/csharp/ql/src/semmle/code/csharp/Variable.qll
@@ -111,6 +111,8 @@ class LocalScopeVariable extends Variable, @local_scope_variable {
    * Holds if this local variable or parameter is a `ref`.
    */
   predicate isRef() { none() }
+
+  override predicate hasQualifiedName(string qualifier, string name) { none() }
 }
 
 /**


### PR DESCRIPTION
Qualified names are meant to uniquely identify public elements, and therefor do not make sense for local scope variables. [Performance report](https://git.semmle.com/gist/tom/d9719302cbaf0ebe8f6c9dffde65ac74) (internal link) reveals that performance is mostly unchanged.