### PR TITLE
CPP: Speed up AV Rule 35.ql

### DIFF
--- a/cpp/ql/src/jsf/4.07 Header Files/AV Rule 35.ql
+++ b/cpp/ql/src/jsf/4.07 Header Files/AV Rule 35.ql
@@ -88,6 +88,7 @@ string extraDetail(HeaderFile hf, SomePreprocessorDirective detail1, SomePreproc
  * Header file `hf` uses a macro called `macroName`.
  */
 predicate usesMacro(HeaderFile hf, string macroName) {
+  not hf instanceof IncludeGuardedHeader and // restrict to cases the query looks at
   exists(MacroAccess ma |
     ma.getFile() = hf and
     ma.getMacro().getName() = macroName


### PR DESCRIPTION
Yields a little over a 10% speedup (I'd hoped for more) in AV Rule 35.ql, for most medium to large projects.