### PR TITLE
C++: accept test output from extractor changes to template class decls

### DIFF
--- a/cpp/ql/test/library-tests/declarationEntry/template/declarationEntry.expected
+++ b/cpp/ql/test/library-tests/declarationEntry/template/declarationEntry.expected
@@ -14,4 +14,5 @@
 | src5.cpp:10:8:10:23 | declaration of my_istream<char> |
 | src5.fwd.hpp:6:17:6:20 | definition of elem |
 | src5.fwd.hpp:6:29:6:38 | declaration of my_istream<elem> |
+| src5.fwd.hpp:6:29:6:38 | declaration of my_istream<elem> |
 | src6.cpp:5:19:5:23 | definition of mis_c |


### PR DESCRIPTION
I've got a corresponding internal PR fixing an issue where the extraction of `src5.fwd.hpp` as included by `src6.cpp` could overwrite the extraction of the same header as included by `src5.cpp`, causing DB consistency failures.

This test change is an unfortunate side-effect that we would like to fix in the longer term. We now end up with two declarations of `my_istream<elem>`, because when we see it from `src5.cpp` it has a complete definition, and from `src6.cpp` it has an incomplete definition.