### PR TITLE
C#: Fix performance regression in `cs/user-controlled-bypass`

### DIFF
--- a/csharp/ql/src/semmle/code/csharp/security/dataflow/ConditionalBypass.qll
+++ b/csharp/ql/src/semmle/code/csharp/security/dataflow/ConditionalBypass.qll
@@ -57,11 +57,18 @@ module UserControlledBypassOfSensitiveMethod {
     }
   }
 
+  pragma[noinline]
+  private predicate conditionControlsCall0(
+    SensitiveExecutionMethodCall call, Expr e, ControlFlow::SuccessorTypes::BooleanSuccessor s
+  ) {
+    forex(BasicBlock bb | bb = call.getAControlFlowNode().getBasicBlock() | e.controlsBlock(bb, s))
+  }
+
   private predicate conditionControlsCall(
     SensitiveExecutionMethodCall call, SensitiveExecutionMethod def, Expr e, boolean cond
   ) {
     exists(ControlFlow::SuccessorTypes::BooleanSuccessor s | cond = s.getValue() |
-      e.controlsElement(call, s)
+      conditionControlsCall0(call, e, s)
     ) and
     def = call.getTarget()
   }


### PR DESCRIPTION
This PR addresses a regression the the query `cs/user-controlled-bypass`, as witnessed by the [performance report](https://git.semmle.com/gist/tom/b44db9de7aa73c4131681a2f878f7b65) (internal link).