### PR TITLE
JavaScript: Teach `Function.isGenerator` to check for `yield`.

### DIFF
--- a/javascript/ql/src/LanguageFeatures/YieldInNonGenerator.ql
+++ b/javascript/ql/src/LanguageFeatures/YieldInNonGenerator.ql
@@ -15,6 +15,6 @@ import javascript
 from YieldExpr yield, Function f
 where
   f = yield.getEnclosingFunction() and
-  not f.isGenerator()
+  not isGenerator(f)
 select yield, "This yield expression is contained in $@ which is not marked as a generator.",
   f.getFirstToken(), f.describe()

--- a/javascript/ql/src/semmle/javascript/Functions.qll
+++ b/javascript/ql/src/semmle/javascript/Functions.qll
@@ -79,7 +79,12 @@ class Function extends @function, Parameterized, TypeParameterized, StmtContaine
   TypeExpr getReturnTypeAnnotation() { typeexprs(result, _, this, -3, _) }
 
   /** Holds if this function is a generator function. */
-  predicate isGenerator() { isGenerator(this) }
+  predicate isGenerator() {
+    isGenerator(this)
+    or
+    // we also support `yield` in non-generator functions
+    exists(YieldExpr yield | this = yield.getEnclosingFunction())
+  }
 
   /** Holds if the last parameter of this function is a rest parameter. */
   predicate hasRestParameter() { hasRestParameter(this) }

--- a/javascript/ql/test/query-tests/Expressions/SuspiciousPropAccess/yield_in_non_generator.js
+++ b/javascript/ql/test/query-tests/Expressions/SuspiciousPropAccess/yield_in_non_generator.js
@@ -1,0 +1,8 @@
+function outer() {
+  function inner() {
+    yield 1;
+  }
+  inner().next()
+}
+
+// semmle-extractor-options: --experimental


### PR DESCRIPTION
We support `yield` in non-generator functions (a legacy Mozilla feature), which leads to false positives from some of our type-inference based queries as shown in the attached test: the type inference thinks `inner` returns `undefined`, and hence flags the property access on its result. In fact, `inner` is (implicitly) a generator, so it doesn't return `undefined` at all.

Fixed by extending `Function::isGenerator` to check for this case. While that's technically a breaking API change it can only affect custom queries for projects using legacy Mozilla features, of which there are none, as far as I know.

I've tested this on `rhino`, where it fixes 56 FPs at no performance cost.