### PR TITLE
JavaScript: Fix two performance regressions in rc/1.20

### DIFF
--- a/javascript/ql/src/semmle/javascript/dataflow/Configuration.qll
+++ b/javascript/ql/src/semmle/javascript/dataflow/Configuration.qll
@@ -570,10 +570,24 @@ private predicate reachableFromInput(
   callInputStep(f, invk, input, nd, cfg) and
   summary = PathSummary::level()
   or
-  exists(DataFlow::Node mid, PathSummary oldSummary, PathSummary newSummary |
+  exists(DataFlow::Node mid, PathSummary oldSummary |
     reachableFromInput(f, invk, input, mid, cfg, oldSummary) and
-    flowStep(mid, cfg, nd, newSummary) and
-    summary = oldSummary.append(newSummary)
+    appendStep(mid, cfg, oldSummary, nd, summary)
+  )
+}
+
+/**
+ * Holds if there is a step from `pred` to `succ` under `cfg` that can be appended
+ * to a path represented by `oldSummary` yielding a path represented by `newSummary`.
+ */
+pragma[noinline]
+private predicate appendStep(
+  DataFlow::Node pred, DataFlow::Configuration cfg, PathSummary oldSummary, DataFlow::Node succ,
+  PathSummary newSummary
+) {
+  exists(PathSummary stepSummary |
+    flowStep(pred, cfg, succ, stepSummary) and
+    newSummary = oldSummary.append(stepSummary)
   )
 }
 

--- a/javascript/ql/src/semmle/javascript/frameworks/Electron.qll
+++ b/javascript/ql/src/semmle/javascript/frameworks/Electron.qll
@@ -16,7 +16,7 @@ module Electron {
   /**
    * An instantiation of `BrowserWindow` or `BrowserView`.
    */
-  abstract private class NewBrowserObject extends BrowserObject, DataFlow::TrackedNode {
+  abstract private class NewBrowserObject extends BrowserObject, DataFlow::SourceNode {
     DataFlow::NewNode self;
 
     NewBrowserObject() { this = self }
@@ -250,10 +250,10 @@ module Electron {
     /**
      * An additional flow step  via an Electron IPC message.
      */
-    private class IPCAdditionalFlowStep extends DataFlow::Configuration {
-      IPCAdditionalFlowStep() { this instanceof DataFlow::Configuration }
+    private class IPCAdditionalFlowStep extends DataFlow::AdditionalFlowStep {
+      IPCAdditionalFlowStep() { ipcFlowStep(this, _) }
 
-      override predicate isAdditionalFlowStep(DataFlow::Node pred, DataFlow::Node succ) {
+      override predicate step(DataFlow::Node pred, DataFlow::Node succ) {
         ipcFlowStep(pred, succ)
       }
     }

--- a/javascript/ql/test/library-tests/frameworks/Electron/BrowserObject.expected
+++ b/javascript/ql/test/library-tests/frameworks/Electron/BrowserObject.expected
@@ -4,11 +4,7 @@
 | electron.js:3:10:3:48 | new Bro ... s: {}}) |
 | electron.js:4:5:4:46 | bv |
 | electron.js:4:10:4:46 | new Bro ... s: {}}) |
-| electron.js:35:14:35:14 | x |
-| electron.js:36:12:36:12 | x |
-| electron.js:39:1:39:7 | foo(bw) |
 | electron.js:39:5:39:6 | bw |
-| electron.js:40:1:40:7 | foo(bv) |
 | electron.js:40:5:40:6 | bv |
 | electron.ts:3:12:3:13 | bw |
 | electron.ts:3:40:3:41 | bv |

--- a/javascript/ql/test/library-tests/frameworks/Electron/IpcFlow.ql
+++ b/javascript/ql/test/library-tests/frameworks/Electron/IpcFlow.ql
@@ -1,9 +1,5 @@
 import javascript
 
-class TestConfig extends DataFlow::Configuration {
-  TestConfig() { this = "TestConfig" }
-}
-
-from TestConfig cfg, DataFlow::Node pred, DataFlow::Node succ
-where cfg.isAdditionalFlowStep(pred, succ)
+from DataFlow::AdditionalFlowStep afs, DataFlow::Node pred, DataFlow::Node succ
+where afs.step(pred, succ)
 select pred, succ

--- a/javascript/ql/test/library-tests/frameworks/Electron/WebContents.expected
+++ b/javascript/ql/test/library-tests/frameworks/Electron/WebContents.expected
@@ -1,4 +1,2 @@
-| electron.js:39:1:39:19 | foo(bw).webContents |
-| electron.js:40:1:40:19 | foo(bv).webContents |
 | electron.ts:4:3:4:16 | bw.webContents |
 | electron.ts:5:3:5:16 | bv.webContents |


### PR DESCRIPTION
Two independent fixes for mild regressions I spotted in the comparison run last weekend: the first commit downgrades `NewBrowserObject` from `TrackedNode` to `SourceNode`, thereby restricting it to local flow tracking only. This, in turn, allows us to model Electron IPC as a normal `AdditionalFlowStep`, which is cached (unlike the `Configuration`-subclassing solution).

While it's unfortunate to lose inter-procedural tracking, it hasn't found anything yet, and we'll soon be switching it to type tracking anyway, thereby regaining most of the global tracking. In the meantime it seems easier to push this out as a hotfix, since this part of the Electron library is new in 1.20.

The second commit is a refactoring in the data flow library that enables a better join order; it is entirely behaviour-preserving.

[Evaluation](https://git.semmle.com/max/dist-compare-reports/blob/master/js/performance-fiddling/report.md) (internal link) against rc/1.20 from a few days ago on `big-apps` looks promising. I'd like to do another large-scale evaluation against 1.19 over the weekend, ideally including this fix.