### PR TITLE
JS: improve use of attributes from ~Object.defineProperty~

### DIFF
--- a/change-notes/1.21/analysis-javascript.md
+++ b/change-notes/1.21/analysis-javascript.md
@@ -12,7 +12,9 @@
 
 ## Changes to existing queries
 
-| **Query**                                  | **Expected impact**          | **Change**                                                                   |
-|--------------------------------------------|------------------------------|------------------------------------------------------------------------------|
+| **Query**                      | **Expected impact**          | **Change**                                                                |
+|--------------------------------|------------------------------|---------------------------------------------------------------------------|
+| Expression has no effect       | Fewer false-positive results | This rule now treats uses of `Object.defineProperty` more conservatively. |
+| Useless assignment to property | Fewer false-positive results | This rule now ignore reads of additional getters. |
 
 ## Changes to QL libraries

--- a/javascript/ql/src/Declarations/DeadStoreOfProperty.ql
+++ b/javascript/ql/src/Declarations/DeadStoreOfProperty.ql
@@ -157,6 +157,11 @@ where
     or
     // exclude result from accessor declarations
     assign1.getWriteNode() instanceof AccessorMethodDeclaration
+  ) and
+  // exclude results from non-value definitions from `Object.defineProperty`
+  (
+    assign1 instanceof CallToObjectDefineProperty implies
+    assign1.(CallToObjectDefineProperty).getAPropertyAttribute().getPropertyName() = "value"
   )
 select assign1.getWriteNode(),
   "This write to property '" + name + "' is useless, since $@ always overrides it.",

--- a/javascript/ql/src/semmle/javascript/StandardLibrary.qll
+++ b/javascript/ql/src/semmle/javascript/StandardLibrary.qll
@@ -21,6 +21,15 @@ class CallToObjectDefineProperty extends DataFlow::MethodCallNode {
 
   /** Gets the data flow node denoting the descriptor of the property being defined. */
   DataFlow::Node getPropertyDescriptor() { result = getArgument(2) }
+
+  /** Gets a data flow node defining a descriptor attribute of the property being defined. */
+  DataFlow::PropWrite getAPropertyAttribute() {
+    exists (DataFlow::SourceNode descriptor |
+      descriptor.flowsTo(getPropertyDescriptor()) and
+      result = descriptor.getAPropertyWrite()
+    )
+  }
+
 }
 
 /**

--- a/javascript/ql/src/semmle/javascript/dataflow/DataFlow.qll
+++ b/javascript/ql/src/semmle/javascript/dataflow/DataFlow.qll
@@ -496,10 +496,7 @@ module DataFlow {
     override string getPropertyName() { result = odp.getPropertyName() }
 
     override Node getRhs() {
-      exists(ObjectLiteralNode propdesc |
-        propdesc.flowsTo(odp.getPropertyDescriptor()) and
-        propdesc.hasPropertyWrite("value", result)
-      )
+      odp.getAPropertyAttribute().writes(_, "value", result)
     }
 
     override ControlFlowNode getWriteNode() { result = odp.getAstNode() }

--- a/javascript/ql/test/query-tests/Declarations/DeadStoreOfProperty/DeadStoreOfProperty.expected
+++ b/javascript/ql/test/query-tests/Declarations/DeadStoreOfProperty/DeadStoreOfProperty.expected
@@ -12,3 +12,6 @@
 | tst.js:76:5:76:34 | o.pure1 ... te = 42 | This write to property 'pure16_simpleAliasWrite' is useless, since $@ always overrides it. | tst.js:77:5:77:36 | o16.pur ... te = 42 | another property write |
 | tst.js:95:5:95:17 | o.pure18 = 42 | This write to property 'pure18' is useless, since $@ always overrides it. | tst.js:96:5:96:17 | o.pure18 = 42 | another property write |
 | tst.js:96:5:96:17 | o.pure18 = 42 | This write to property 'pure18' is useless, since $@ always overrides it. | tst.js:97:5:97:17 | o.pure18 = 42 | another property write |
+| tst.js:100:2:102:3 | Object. ... { }\\n\\t}) | This write to property 'setter' is useless, since $@ always overrides it. | tst.js:103:2:103:14 | o.setter = "" | another property write |
+| tst.js:114:2:114:14 | o.setter = 42 | This write to property 'setter' is useless, since $@ always overrides it. | tst.js:115:2:115:14 | o.setter = 87 | another property write |
+| tst.js:122:2:122:78 | Object. ... le:!1}) | This write to property 'prop' is useless, since $@ always overrides it. | tst.js:123:2:123:12 | o.prop = 42 | another property write |

--- a/javascript/ql/test/query-tests/Declarations/DeadStoreOfProperty/DeadStoreOfProperty.expected
+++ b/javascript/ql/test/query-tests/Declarations/DeadStoreOfProperty/DeadStoreOfProperty.expected
@@ -12,6 +12,5 @@
 | tst.js:76:5:76:34 | o.pure1 ... te = 42 | This write to property 'pure16_simpleAliasWrite' is useless, since $@ always overrides it. | tst.js:77:5:77:36 | o16.pur ... te = 42 | another property write |
 | tst.js:95:5:95:17 | o.pure18 = 42 | This write to property 'pure18' is useless, since $@ always overrides it. | tst.js:96:5:96:17 | o.pure18 = 42 | another property write |
 | tst.js:96:5:96:17 | o.pure18 = 42 | This write to property 'pure18' is useless, since $@ always overrides it. | tst.js:97:5:97:17 | o.pure18 = 42 | another property write |
-| tst.js:100:2:102:3 | Object. ... { }\\n\\t}) | This write to property 'setter' is useless, since $@ always overrides it. | tst.js:103:2:103:14 | o.setter = "" | another property write |
 | tst.js:114:2:114:14 | o.setter = 42 | This write to property 'setter' is useless, since $@ always overrides it. | tst.js:115:2:115:14 | o.setter = 87 | another property write |
-| tst.js:122:2:122:78 | Object. ... le:!1}) | This write to property 'prop' is useless, since $@ always overrides it. | tst.js:123:2:123:12 | o.prop = 42 | another property write |
+| tst.js:118:2:118:104 | Object. ... lue()}) | This write to property 'prop' is useless, since $@ always overrides it. | tst.js:119:2:119:12 | o.prop = 42 | another property write |

--- a/javascript/ql/test/query-tests/Declarations/DeadStoreOfProperty/tst.js
+++ b/javascript/ql/test/query-tests/Declarations/DeadStoreOfProperty/tst.js
@@ -82,17 +82,47 @@
     }
 
     // DOM
-    o.clientTop = 42;
+    o.clientTop = 42; // OK
     o.clientTop = 42;
 
-    o.defaulted1 = null;
+    o.defaulted1 = null; // OK
     o.defaulted1 = 42;
 
-    o.defaulted2 = -1;
+    o.defaulted2 = -1; // OK
     o.defaulted2 = 42;
 
     var o = {};
     o.pure18 = 42; // NOT OK
     o.pure18 = 42; // NOT OK
     o.pure18 = 42;
+
+	var o = {};
+	Object.defineProperty(o, "setter", { // OK
+		set: function (value) { }
+	});
+	o.setter = "";
+
+	var o = { set setter(value) { } }; // OK
+	o.setter = "";
+
+	var o = {
+		set accessor(value) { }, // OK
+		get accessor() { }
+	};
+
+	var o = { set setter(value) { } };
+	o.setter = 42; // probably OK, but still flagged - it seems fishy
+	o.setter = 87;
+
+	var o = {};
+	Object.defineProperty(o, "prop", {writable:!0,configurable:!0,enumerable:!1, value: getInitialValue()}) // NOT OK
+	o.prop = 42;
+
+	var o = {};
+	Object.defineProperty(o, "prop", {writable:!0,configurable:!0,enumerable:!1, value: undefined}) // OK, default value
+	o.prop = 42;
+
+	var o = {};
+	Object.defineProperty(o, "prop", {writable:!0,configurable:!0,enumerable:!1}) // OK
+	o.prop = 42;
 });

--- a/javascript/ql/test/query-tests/Expressions/ExprHasNoEffect/ExprHasNoEffect.expected
+++ b/javascript/ql/test/query-tests/Expressions/ExprHasNoEffect/ExprHasNoEffect.expected
@@ -8,4 +8,5 @@
 | tst.js:49:3:49:26 | new Err ... ou so") | This expression has no effect. |
 | tst.js:50:3:50:49 | new Syn ... o me?") | This expression has no effect. |
 | tst.js:51:3:51:36 | new Err ... age(e)) | This expression has no effect. |
+| tst.js:62:2:62:20 | o.trivialNonGetter1 | This expression has no effect. |
 | uselessfn.js:1:1:1:15 | (functi ... .");\\n}) | This expression has no effect. |

--- a/javascript/ql/test/query-tests/Expressions/ExprHasNoEffect/tst.js
+++ b/javascript/ql/test/query-tests/Expressions/ExprHasNoEffect/tst.js
@@ -51,3 +51,25 @@ try {
   new Error(computeSnarkyMessage(e)); // NOT OK
   new UnknownError(); // OK
 }
+
+function g() {
+	var o = {};
+
+	Object.defineProperty(o, "trivialGetter1", { get: function(){} });
+	o.trivialGetter1; // OK
+
+	Object.defineProperty(o, "trivialNonGetter1", "foo");
+	o.trivialNonGetter1; // NOT OK
+
+	var getterDef1 = { get: function(){} };
+	Object.defineProperty(o, "nonTrivialGetter1", getterDef1);
+	o.nonTrivialGetter1; // OK
+
+	var getterDef2 = { };
+	unknownPrepareGetter(getterDef2);
+	Object.defineProperty(o, "nonTrivialNonGetter1", getterDef2);
+	o.nonTrivialNonGetter1; // OK
+
+	Object.defineProperty(o, "nonTrivialGetter2", unknownGetterDef());
+	o.nonTrivialGetter2; // OK
+};


### PR DESCRIPTION
Add a getter for the attributes of `Object.defineProperty`, and use it in three places:

-   `DataFlow::ObjectDefinePropertyAsPropWrite::getRhs`: improve dataflow expressivity (does not impact performance: [definitions](https://git.semmle.com/esben/dist-compare-reports/tree/js/unsafe-jquery_1552427200212), [XSS/gecko](https://git.semmle.com/esben/dist-compare-reports/tree/js/useless-property-assign-setter_1552569480457))
-   `ExprHasNoEffect::isGetterProperty`: sharpen whitelist (no changes)
-   `DeadStoreOfProperty`: only flag a call to `Object.defineProperty` if it includes a value ([eliminates some FPs](https://git.semmle.com/esben/dist-compare-reports/tree/js/useless-property-assign-setter_1552394111970), the new result has been eliminated now)