### PR TITLE
C++: fix cartesian product in IRGuards.qll

### DIFF
--- a/cpp/ql/src/semmle/code/cpp/controlflow/IRGuards.qll
+++ b/cpp/ql/src/semmle/code/cpp/controlflow/IRGuards.qll
@@ -381,9 +381,7 @@ cached class IRGuardCondition extends Instruction {
 }
 
 private ConditionalBranchInstruction get_branch_for_condition(Instruction guard) {
-  exists(ConditionalBranchInstruction branch|
-    branch.getCondition() = guard
-  )
+  result.getCondition() = guard
   or
   exists(LogicalNotInstruction cond | result = get_branch_for_condition(cond) and cond.getUnary() = guard)
 }


### PR DESCRIPTION
I've had this change locally for a while and didn't realize it wasn't in master. I've opened this as a hotfix against r/1.20 because it's likely a blocker for use of the IR guards library on nontrivial codebases.