### PR TITLE
C++: Fix FPs in "Returning stack-allocated memory"

### DIFF
--- a/cpp/ql/src/Likely Bugs/Memory Management/ReturnStackAllocatedMemory.ql
+++ b/cpp/ql/src/Likely Bugs/Memory Management/ReturnStackAllocatedMemory.ql
@@ -41,7 +41,7 @@ where
     // the address escapes into some expression `pointerToLocal`, which flows
     // in a non-trivial way (one or more steps) to a returned expression.
     exists(Expr pointerToLocal |
-      variableAddressEscapesTree(va, pointerToLocal.getFullyConverted()) and
+      variableAddressEscapesTree(va, pointerToLocal) and
       conservativeDataFlowStep+(
         DataFlow::exprNode(pointerToLocal),
         DataFlow::exprNode(r.getExpr())

--- a/cpp/ql/src/Likely Bugs/Memory Management/ReturnStackAllocatedMemory.ql
+++ b/cpp/ql/src/Likely Bugs/Memory Management/ReturnStackAllocatedMemory.ql
@@ -22,7 +22,24 @@ import semmle.code.cpp.dataflow.DataFlow
  */
 predicate conservativeDataFlowStep(DataFlow::Node n1, DataFlow::Node n2) {
   DataFlow::localFlowStep(n1, n2) and
-  not n2.asExpr() instanceof FieldAccess
+  not n2.asExpr() instanceof FieldAccess and
+  not hasNontrivialConversion(n2.asExpr())
+}
+
+/**
+ * Holds if `e` has a conversion that changes it from lvalue to pointer or
+ * back. As the data-flow library does not support conversions, we cannot track
+ * data flow through such expressions.
+ */
+predicate hasNontrivialConversion(Expr e) {
+  e instanceof Conversion and not
+  (
+    e instanceof Cast
+    or
+    e instanceof ParenthesisExpr
+  )
+  or
+  hasNontrivialConversion(e.getConversion())
 }
 
 from LocalScopeVariable var, VariableAccess va, ReturnStmt r
@@ -39,9 +56,10 @@ where
     or
     // The data flow library doesn't support conversions, so here we check that
     // the address escapes into some expression `pointerToLocal`, which flows
-    // in a non-trivial way (one or more steps) to a returned expression.
+    // in a one or more steps to a returned expression.
     exists(Expr pointerToLocal |
-      variableAddressEscapesTree(va, pointerToLocal) and
+      variableAddressEscapesTree(va, pointerToLocal.getFullyConverted()) and
+      not hasNontrivialConversion(pointerToLocal) and
       conservativeDataFlowStep+(
         DataFlow::exprNode(pointerToLocal),
         DataFlow::exprNode(r.getExpr())

--- a/cpp/ql/test/query-tests/Likely Bugs/Memory Management/ReturnStackAllocatedMemory/ReturnStackAllocatedMemory.expected
+++ b/cpp/ql/test/query-tests/Likely Bugs/Memory Management/ReturnStackAllocatedMemory/ReturnStackAllocatedMemory.expected
@@ -6,5 +6,3 @@
 | test.cpp:112:2:112:12 | return ... | May return stack-allocated memory from $@. | test.cpp:112:9:112:11 | arr | arr |
 | test.cpp:119:2:119:19 | return ... | May return stack-allocated memory from $@. | test.cpp:119:11:119:13 | arr | arr |
 | test.cpp:149:3:149:22 | return ... | May return stack-allocated memory from $@. | test.cpp:149:11:149:21 | threadLocal | threadLocal |
-| test.cpp:155:3:155:18 | return ... | May return stack-allocated memory from $@. | test.cpp:154:19:154:26 | localInt | localInt |
-| test.cpp:165:3:165:19 | return ... | May return stack-allocated memory from $@. | test.cpp:164:21:164:28 | localBuf | localBuf |

--- a/cpp/ql/test/query-tests/Likely Bugs/Memory Management/ReturnStackAllocatedMemory/ReturnStackAllocatedMemory.expected
+++ b/cpp/ql/test/query-tests/Likely Bugs/Memory Management/ReturnStackAllocatedMemory/ReturnStackAllocatedMemory.expected
@@ -6,3 +6,4 @@
 | test.cpp:112:2:112:12 | return ... | May return stack-allocated memory from $@. | test.cpp:112:9:112:11 | arr | arr |
 | test.cpp:119:2:119:19 | return ... | May return stack-allocated memory from $@. | test.cpp:119:11:119:13 | arr | arr |
 | test.cpp:149:3:149:22 | return ... | May return stack-allocated memory from $@. | test.cpp:149:11:149:21 | threadLocal | threadLocal |
+| test.cpp:190:3:190:14 | return ... | May return stack-allocated memory from $@. | test.cpp:188:13:188:19 | myLocal | myLocal |

--- a/cpp/ql/test/query-tests/Likely Bugs/Memory Management/ReturnStackAllocatedMemory/ReturnStackAllocatedMemory.expected
+++ b/cpp/ql/test/query-tests/Likely Bugs/Memory Management/ReturnStackAllocatedMemory/ReturnStackAllocatedMemory.expected
@@ -5,3 +5,6 @@
 | test.cpp:92:2:92:12 | return ... | May return stack-allocated memory from $@. | test.cpp:89:10:89:11 | mc | mc |
 | test.cpp:112:2:112:12 | return ... | May return stack-allocated memory from $@. | test.cpp:112:9:112:11 | arr | arr |
 | test.cpp:119:2:119:19 | return ... | May return stack-allocated memory from $@. | test.cpp:119:11:119:13 | arr | arr |
+| test.cpp:149:3:149:22 | return ... | May return stack-allocated memory from $@. | test.cpp:149:11:149:21 | threadLocal | threadLocal |
+| test.cpp:155:3:155:18 | return ... | May return stack-allocated memory from $@. | test.cpp:154:19:154:26 | localInt | localInt |
+| test.cpp:165:3:165:19 | return ... | May return stack-allocated memory from $@. | test.cpp:164:21:164:28 | localBuf | localBuf |

--- a/cpp/ql/test/query-tests/Likely Bugs/Memory Management/ReturnStackAllocatedMemory/ReturnStackAllocatedMemory.expected
+++ b/cpp/ql/test/query-tests/Likely Bugs/Memory Management/ReturnStackAllocatedMemory/ReturnStackAllocatedMemory.expected
@@ -6,4 +6,4 @@
 | test.cpp:112:2:112:12 | return ... | May return stack-allocated memory from $@. | test.cpp:112:9:112:11 | arr | arr |
 | test.cpp:119:2:119:19 | return ... | May return stack-allocated memory from $@. | test.cpp:119:11:119:13 | arr | arr |
 | test.cpp:149:3:149:22 | return ... | May return stack-allocated memory from $@. | test.cpp:149:11:149:21 | threadLocal | threadLocal |
-| test.cpp:190:3:190:14 | return ... | May return stack-allocated memory from $@. | test.cpp:188:13:188:19 | myLocal | myLocal |
+| test.cpp:171:3:171:24 | return ... | May return stack-allocated memory from $@. | test.cpp:170:35:170:41 | myLocal | myLocal |

--- a/cpp/ql/test/query-tests/Likely Bugs/Memory Management/ReturnStackAllocatedMemory/test.cpp
+++ b/cpp/ql/test/query-tests/Likely Bugs/Memory Management/ReturnStackAllocatedMemory/test.cpp
@@ -168,7 +168,7 @@ char *returnAfterCopy() {
 void *conversionBeforeDataFlow() {
   int myLocal;
   void *pointerToLocal = (void *)&myLocal; // has conversion
-  return pointerToLocal; // BAD [NOT DETECTED]
+  return pointerToLocal; // BAD
 }
 
 void *arrayConversionBeforeDataFlow() {
@@ -187,5 +187,5 @@ int *&conversionInFlow() {
   int myLocal;
   int *p = &myLocal;
   int *&pRef = p; // has conversion in the middle of data flow
-  return pRef; // BAD [MISLEADING ALERT MESSAGE]
+  return pRef; // BAD [NOT DETECTED]
 }

--- a/cpp/ql/test/query-tests/Likely Bugs/Memory Management/ReturnStackAllocatedMemory/test.cpp
+++ b/cpp/ql/test/query-tests/Likely Bugs/Memory Management/ReturnStackAllocatedMemory/test.cpp
@@ -143,3 +143,24 @@ char *testArray5()
 
 	return arr; // GOOD
 }
+
+int *returnThreadLocal() {
+  thread_local int threadLocal;
+  return &threadLocal; // GOOD [FALSE POSITIVE]
+}
+
+int returnDereferenced() {
+  int localInt = 2;
+  int &localRef = localInt;
+  return localRef; // GOOD [FALSE POSITIVE]
+}
+
+typedef unsigned long size_t;
+void *memcpy(void *s1, const void *s2, size_t n);
+
+char *returnAfterCopy() {
+  char localBuf[] = "Data";
+  static char staticBuf[sizeof(localBuf)];
+  memcpy(staticBuf, localBuf, sizeof(staticBuf));
+  return staticBuf; // GOOD [FALSE POSITIVE]
+}

--- a/cpp/ql/test/query-tests/Likely Bugs/Memory Management/ReturnStackAllocatedMemory/test.cpp
+++ b/cpp/ql/test/query-tests/Likely Bugs/Memory Management/ReturnStackAllocatedMemory/test.cpp
@@ -164,3 +164,28 @@ char *returnAfterCopy() {
   memcpy(staticBuf, localBuf, sizeof(staticBuf));
   return staticBuf; // GOOD
 }
+
+void *conversionBeforeDataFlow() {
+  int myLocal;
+  void *pointerToLocal = (void *)&myLocal; // has conversion
+  return pointerToLocal; // BAD [NOT DETECTED]
+}
+
+void *arrayConversionBeforeDataFlow() {
+  int localArray[4];
+  int *pointerToLocal = localArray; // has conversion
+  return pointerToLocal; // BAD [NOT DETECTED]
+}
+
+int &dataFlowThroughReference() {
+  int myLocal;
+  int &refToLocal = myLocal; // has conversion
+  return refToLocal; // BAD [NOT DETECTED]
+}
+
+int *&conversionInFlow() {
+  int myLocal;
+  int *p = &myLocal;
+  int *&pRef = p; // has conversion in the middle of data flow
+  return pRef; // BAD [MISLEADING ALERT MESSAGE]
+}

--- a/cpp/ql/test/query-tests/Likely Bugs/Memory Management/ReturnStackAllocatedMemory/test.cpp
+++ b/cpp/ql/test/query-tests/Likely Bugs/Memory Management/ReturnStackAllocatedMemory/test.cpp
@@ -152,7 +152,7 @@ int *returnThreadLocal() {
 int returnDereferenced() {
   int localInt = 2;
   int &localRef = localInt;
-  return localRef; // GOOD [FALSE POSITIVE]
+  return localRef; // GOOD
 }
 
 typedef unsigned long size_t;
@@ -162,5 +162,5 @@ char *returnAfterCopy() {
   char localBuf[] = "Data";
   static char staticBuf[sizeof(localBuf)];
   memcpy(staticBuf, localBuf, sizeof(staticBuf));
-  return staticBuf; // GOOD [FALSE POSITIVE]
+  return staticBuf; // GOOD
 }


### PR DESCRIPTION
This new query has too many false positives on lgtm.com. At the time of writing, they can be seen at https://lgtm.com/rules/1507923806246/alerts/.

This PR suppresses the most numerous type of FP: mishandling of implicit conversions. The new query most likely suppresses good results too, and we'll have to fix that when we put the IR-based data flow library into production since that models conversions properly.

There are still some false positives in [g/mgerhardy/simpleai](https://lgtm.com/projects/g/mgerhardy/simpleai/alerts/?mode=tree) due to `thread_local` variables, but I believe those would require an extractor fix. There's also a false positive in SQLite, and therefore all projects that contain it, but that's due to highly non-local data structure invariants.

Here are query console runs with the new query on lgtm.com [on the original set of 46 projects](https://lgtm.com/query/1450361470815744908/) and [on a sample of 7 projects with obvious FPs](https://lgtm.com/query/2445288052367671012/).