### PR TITLE
QL 1.20 docs: Be more explicit about Java versions supported

### DIFF
--- a/change-notes/1.20/support/framework-support.rst
+++ b/change-notes/1.20/support/framework-support.rst
@@ -1,7 +1,7 @@
 Frameworks and libraries
 ########################
 
-The QL libraries and queries in this version have been explicitly checked against the libraries and frameworks listed below.
+The QL libraries and queries in version |version| have been explicitly checked against the libraries and frameworks listed below.
 
 .. pull-quote::
 

--- a/change-notes/1.20/support/language-support.rst
+++ b/change-notes/1.20/support/language-support.rst
@@ -14,6 +14,6 @@ Note that where there are several versions or dialects of a language, the suppor
 .. container:: footnote-group
 
     .. [1] The best results are achieved with COBOL code that stays close to the ANSI 85 standard.  
-    .. [2] Builds that execute on Java 6 or higher can be analyzed. The analysis understands Java 11 language features.
+    .. [2] Builds that execute on Java 6 to 11 can be analyzed. The analysis understands Java 11 language features.
     .. [3] JSX and Flow code, YAML, JSON, and HTML files may also be analyzed with JavaScript files. 
     .. [4] TypeScript analysis is performed by running the JavaScript extractor with TypeScript enabled. This is the default for LGTM.   

--- a/change-notes/1.20/support/language-support.rst
+++ b/change-notes/1.20/support/language-support.rst
@@ -14,6 +14,6 @@ Note that where there are several versions or dialects of a language, the suppor
 .. container:: footnote-group
 
     .. [1] The best results are achieved with COBOL code that stays close to the ANSI 85 standard.  
-    .. [2] Java 11 refers to the language features used. Builds that execute on Java 6 or higher can be analyzed.
+    .. [2] Builds that execute on Java 6 or higher can be analyzed. The analysis understands Java 11 language features.
     .. [3] JSX and Flow code, YAML, JSON, and HTML files may also be analyzed with JavaScript files. 
     .. [4] TypeScript analysis is performed by running the JavaScript extractor with TypeScript enabled. This is the default for LGTM.   

--- a/change-notes/1.20/support/versions-compilers.csv
+++ b/change-notes/1.20/support/versions-compilers.csv
@@ -8,7 +8,7 @@ C#,C# up to 7.2 together with .NET versions up to 4.7.1,"Microsoft Visual Studio
 
 .NET Core up to 2.1","``.sln``, ``.csproj``, ``.cs``, ``.cshtml``, ``.xaml``"
 COBOL,ANSI 85 or newer [1]_.,Not applicable,"``.cbl``, ``.CBL``, ``.cpy``, ``.CPY``, ``.copy``, ``.COPY``"
-Java,"Java 11 [2]_. or lower","javac (OpenJDK and Oracle JDK)
+Java,"Java 6 to 11 [2]_.","javac (OpenJDK and Oracle JDK)
 
 Eclipse compiler for Java (ECJ) batch compiler",``.java``
 JavaScript,ECMAScript 2018 or lower,Not applicable,"``.js``, ``.jsx``, ``.mjs``, ``.es``, ``.es6``, ``.htm``, ``.html``, ``.xhm``, ``.xhtml``, ``.vue``, ``.json`` [3]_."


### PR DESCRIPTION
This small text change makes the documentation more explicit about which Java versions are supported. This was triggered by a discussion on Slack. 

@aschackmull or @yh-semmle - can you check this is clear and correct?