### PR TITLE
Python: Add query for insecure SSH host key policies in Paramiko.

### DIFF
--- a/change-notes/1.21/analysis-python.md
+++ b/change-notes/1.21/analysis-python.md
@@ -9,7 +9,7 @@
 ## New queries
   | **Query** | **Tags** | **Purpose** |
   |-----------|----------|-------------|
-  | Accepting unknown SSH host keys when using Paramiko. (`py/paramiko-missing-host-key-validation`) | security, external/cwe/cwe-295 | Finds instances where Paramiko is configured to accept unknown host keys. Results are shown on LGTM by default. |
+  | Accepting unknown SSH host keys when using Paramiko (`py/paramiko-missing-host-key-validation`) | security, external/cwe/cwe-295 | Finds instances where Paramiko is configured to accept unknown host keys. Results are shown on LGTM by default. |
 
 
 ## Changes to existing queries

--- a/change-notes/1.21/analysis-python.md
+++ b/change-notes/1.21/analysis-python.md
@@ -1,0 +1,26 @@
+# Improvements to Python analysis
+
+
+## General improvements
+
+> Changes that affect alerts in many files or from many queries
+> For example, changes to file classification
+
+## New queries
+  | **Query** | **Tags** | **Purpose** |
+  |-----------|----------|-------------|
+  | Accepting unknown SSH host keys when using Paramiko. (`py/paramiko-missing-host-key-validation`) | security, external/cwe/cwe-295 | Finds instances where Paramiko is configured to accept unknown host keys. Results are shown on LGTM by default. |
+
+
+## Changes to existing queries
+
+  | **Query** | **Expected impact** | **Change** |
+  |-----------|---------------------|------------|
+
+## Changes to code extraction
+
+* *Series of bullet points*
+
+## Changes to QL libraries
+
+* *Series of bullet points*

--- a/python/ql/src/Security/CWE-295/MissingHostKeyValidation.qhelp
+++ b/python/ql/src/Security/CWE-295/MissingHostKeyValidation.qhelp
@@ -13,20 +13,23 @@ man-in-the-middle attacks.
 
 <recommendation>
 <p>
-Do not accept unknown host keys. For the Paramiko library in particular, avoid
-setting the missing host key policy to either <code>AutoAddPolicy</code> or
-<code>WarningPolicy</code>, as both of these will continue even when the host
-key is unknown. The default <code>RejectPolicy</code> throws an exception when
-unknown host keys are encountered.
+Do not accept unknown host keys. In particular, do not set the default missing
+host key policy for the Paramiko library to either <code>AutoAddPolicy</code> or
+<code>WarningPolicy</code>. Both of these policies continue even when the host
+key is unknown. The default setting of <code>RejectPolicy</code> is secure
+because it throws an exception when it encounters an unknown host key.
 </p>
 </recommendation>
 
 <example>
 <p>
-The following example opens a connection to <code>example.com</code> with the
-missing host key policy set to <code>AutoAddPolicy</code>. If the host key
-verification fails, the client will continue to interact with the server, even
-though the connection may be compromised.
+The following example shows two ways of opening an SSH connection to
+<code>example.com</code>. The first function sets the missing host key policy to
+<code>AutoAddPolicy</code>. If the host key verification fails, the client will
+continue to interact with the server, even though the connection may be
+compromised. The second function sets the host key policy to
+<code>RejectPolicy</code>, and will throw an exception if the host key
+verification fails.
 </p>
 <sample src="examples/paramiko_host_key.py" />
 </example>

--- a/python/ql/src/Security/CWE-295/MissingHostKeyValidation.qhelp
+++ b/python/ql/src/Security/CWE-295/MissingHostKeyValidation.qhelp
@@ -1,0 +1,40 @@
+<!DOCTYPE qhelp PUBLIC
+  "-//Semmle//qhelp//EN"
+  "qhelp.dtd">
+<qhelp>
+
+<overview>
+  <p>
+In the Secure Shell (SSH) protocol, host keys are used to verify the identity of
+remote hosts. Accepting unknown host keys may leave the connection open to
+man-in-the-middle attacks.
+</p>
+</overview>
+
+<recommendation>
+<p>
+Do not accept unknown host keys. For the Paramiko library in particular, avoid
+setting the missing host key policy to either <code>AutoAddPolicy</code> or
+<code>WarningPolicy</code>, as both of these will continue even when the host
+key is unknown. The default <code>RejectPolicy</code> throws an exception when
+unknown host keys are encountered.
+</p>
+</recommendation>
+
+<example>
+<p>
+The following example opens a connection to <code>example.com</code> with the
+missing host key policy set to <code>AutoAddPolicy</code>. If the host key
+verification fails, the client will continue to interact with the server, even
+though the connection may be compromised.
+</p>
+<sample src="examples/paramiko_host_key.py" />
+</example>
+
+<references>
+<li>
+Paramiko documentation: <a href="http://docs.paramiko.org/en/2.4/api/client.html?highlight=set_missing_host_key_policy#paramiko.client.SSHClient.set_missing_host_key_policy">set_missing_host_key_policy</a>.
+</li>
+</references>
+</qhelp>
+

--- a/python/ql/src/Security/CWE-295/MissingHostKeyValidation.ql
+++ b/python/ql/src/Security/CWE-295/MissingHostKeyValidation.ql
@@ -1,0 +1,32 @@
+/**
+ * @name Accepting unknown host keys.
+ * @description Accepting unknown host keys can allow man-in-the-middle attacks.
+ * @kind problem
+ * @problem.severity error
+ * @precision high
+ * @id py/missing-host-key-validation
+ * @tags security
+ *       external/cwe/cwe-295
+ */
+
+import python
+
+private ModuleObject theParamikoClientModule() { result = ModuleObject::named("paramiko.client") }
+
+private ClassObject theParamikoSSHClientClass() {
+    result = theParamikoClientModule().attr("SSHClient")
+}
+
+private ClassObject unsafe_paramiko_policy(string name) {
+    (name = "AutoAddPolicy" or name = "WarningPolicy") and
+    result = theParamikoClientModule().attr(name)
+}
+
+from CallNode call, string name
+where
+    call = theParamikoSSHClientClass()
+        .declaredAttribute("set_missing_host_key_policy")
+        .(FunctionObject)
+        .getACall() and
+    call.getAnArg().refersTo(unsafe_paramiko_policy(name))
+select call, "Setting missing host key policy to " + name + " may be unsafe."

--- a/python/ql/src/Security/CWE-295/examples/paramiko_host_key.py
+++ b/python/ql/src/Security/CWE-295/examples/paramiko_host_key.py
@@ -1,9 +1,19 @@
-from paramiko.client import SSHClient, AutoAddPolicy
+from paramiko.client import SSHClient, AutoAddPolicy, RejectPolicy
 
-client = SSHClient()
-client.set_missing_host_key_policy(AutoAddPolicy)
-client.connect("example.com")
+def unsafe_connect():
+    client = SSHClient()
+    client.set_missing_host_key_policy(AutoAddPolicy)
+    client.connect("example.com")
 
-# ... interaction with server
+    # ... interaction with server
 
-client.close()
+    client.close()
+
+def safe_connect():
+    client = SSHClient()
+    client.set_missing_host_key_policy(RejectPolicy)
+    client.connect("example.com")
+
+    # ... interaction with server
+
+    client.close()

--- a/python/ql/src/Security/CWE-295/examples/paramiko_host_key.py
+++ b/python/ql/src/Security/CWE-295/examples/paramiko_host_key.py
@@ -1,0 +1,9 @@
+from paramiko.client import SSHClient, AutoAddPolicy
+
+client = SSHClient()
+client.set_missing_host_key_policy(AutoAddPolicy)
+client.connect("example.com")
+
+# ... interaction with server
+
+client.close()

--- a/python/ql/test/query-tests/Security/CWE-295/MissingHostKeyValidation.expected
+++ b/python/ql/test/query-tests/Security/CWE-295/MissingHostKeyValidation.expected
@@ -1,0 +1,2 @@
+| paramiko_host_key.py:5:1:5:49 | ControlFlowNode for Attribute() | Setting missing host key policy to AutoAddPolicy may be unsafe. |
+| paramiko_host_key.py:7:1:7:49 | ControlFlowNode for Attribute() | Setting missing host key policy to WarningPolicy may be unsafe. |

--- a/python/ql/test/query-tests/Security/CWE-295/MissingHostKeyValidation.expected
+++ b/python/ql/test/query-tests/Security/CWE-295/MissingHostKeyValidation.expected
@@ -1,2 +1,4 @@
 | paramiko_host_key.py:5:1:5:49 | ControlFlowNode for Attribute() | Setting missing host key policy to AutoAddPolicy may be unsafe. |
 | paramiko_host_key.py:7:1:7:49 | ControlFlowNode for Attribute() | Setting missing host key policy to WarningPolicy may be unsafe. |
+| paramiko_host_key.py:11:1:11:51 | ControlFlowNode for Attribute() | Setting missing host key policy to AutoAddPolicy may be unsafe. |
+| paramiko_host_key.py:13:1:13:51 | ControlFlowNode for Attribute() | Setting missing host key policy to WarningPolicy may be unsafe. |

--- a/python/ql/test/query-tests/Security/CWE-295/MissingHostKeyValidation.qlref
+++ b/python/ql/test/query-tests/Security/CWE-295/MissingHostKeyValidation.qlref
@@ -1,0 +1,1 @@
+Security/CWE-295/MissingHostKeyValidation.ql

--- a/python/ql/test/query-tests/Security/CWE-295/paramiko_host_key.py
+++ b/python/ql/test/query-tests/Security/CWE-295/paramiko_host_key.py
@@ -5,3 +5,9 @@ client = SSHClient()
 client.set_missing_host_key_policy(AutoAddPolicy) # bad
 client.set_missing_host_key_policy(RejectPolicy)  # good
 client.set_missing_host_key_policy(WarningPolicy) # bad
+
+# Using instances
+
+client.set_missing_host_key_policy(AutoAddPolicy()) # bad
+client.set_missing_host_key_policy(RejectPolicy())  # good
+client.set_missing_host_key_policy(WarningPolicy()) # bad

--- a/python/ql/test/query-tests/Security/CWE-295/paramiko_host_key.py
+++ b/python/ql/test/query-tests/Security/CWE-295/paramiko_host_key.py
@@ -1,0 +1,7 @@
+from paramiko.client import AutoAddPolicy, WarningPolicy, RejectPolicy, SSHClient
+
+client = SSHClient()
+
+client.set_missing_host_key_policy(AutoAddPolicy) # bad
+client.set_missing_host_key_policy(RejectPolicy)  # good
+client.set_missing_host_key_policy(WarningPolicy) # bad

--- a/python/ql/test/query-tests/Security/lib/paramiko/client.py
+++ b/python/ql/test/query-tests/Security/lib/paramiko/client.py
@@ -1,0 +1,15 @@
+class SSHClient(object):
+    def __init__(self, *args, **kwargs):
+        pass
+
+    def set_missing_host_key_policy(self, *args, **kwargs):
+        pass
+
+class AutoAddPolicy(object):
+    pass
+
+class WarningPolicy(object):
+    pass
+
+class RejectPolicy(object):
+    pass


### PR DESCRIPTION
Adds a query that looks for instances where the host key policy is set to `AutoAddPolicy` or `WarningPolicy` both of which are insecure, as they do not terminate the connection when the host key is unknown.

@felicity-semmle for the documentation.