### PR TITLE
CPP: Add to UnusedStaticVariables tests.

### DIFF
--- a/cpp/ql/test/query-tests/Best Practices/Unused Entities/UnusedStaticVariables/UnusedStaticVariables.expected
+++ b/cpp/ql/test/query-tests/Best Practices/Unused Entities/UnusedStaticVariables/UnusedStaticVariables.expected
@@ -1,2 +1,4 @@
 | test.cpp:7:12:7:21 | staticVar5 | Static variable staticVar5 is never read |
 | test.cpp:8:12:8:21 | staticVar6 | Static variable staticVar6 is never read |
+| test.cpp:10:11:10:19 | constVar8 | Static variable constVar8 is never read |
+| test.cpp:12:12:12:22 | staticVar10 | Static variable staticVar10 is never read |

--- a/cpp/ql/test/query-tests/Best Practices/Unused Entities/UnusedStaticVariables/test.cpp
+++ b/cpp/ql/test/query-tests/Best Practices/Unused Entities/UnusedStaticVariables/test.cpp
@@ -7,6 +7,9 @@ static int staticVar4 = staticVar3; // GOOD (used)
 static int staticVar5; // BAD (unused)
 static int staticVar6 = 6; // BAD (unused)
 static __attribute__((__unused__)) int staticVar7; // GOOD (unused but this is expected)
+const int constVar8 = 8; // BAD (const defaults to static)
+extern const int constVar9 = 9; // GOOD
+static int staticVar10 = 10; // GOOD [FALSE POSITIVE] (referenced in a never instantiated template)
 
 void f()
 {
@@ -16,3 +19,12 @@ void f()
 	(*ptr) = 0;
 }
 
+template<class T>
+class MyTemplateClass // never instantiated
+{
+public:
+	MyTemplateClass(int param = staticVar10)
+	{
+		// ...
+	}
+};


### PR DESCRIPTION
Add some test cases for UnusedStaticVariables.ql, inspired by query differences on 13/03/19 for boost/boost/iostreams/filter/bzip2.hpp.  The false positive may be a result of recent extractor changes.