### PR TITLE
1.20: Update JavaScript extraction notes and supported versions

### DIFF
--- a/change-notes/1.20/extractor-javascript.md
+++ b/change-notes/1.20/extractor-javascript.md
@@ -2,25 +2,11 @@
 
 # Improvements to JavaScript analysis
 
-> NOTES
->
-> Please describe your changes in terms that are suitable for
-> customers to read. These notes will have only minor tidying up
-> before they are published as part of the release notes.
->
-> This file is written for lgtm users and should contain *only*
-> notes about changes that affect lgtm enterprise users. Add
-> any other customer-facing changes to the `studio-java.md`
-> file.
->
-
-## General improvements
-
 ## Changes to code extraction
 
 * Parallel extraction of JavaScript files (but not TypeScript files) on LGTM is now supported. The `LGTM_THREADS` environment variable can be set to indicate how many files should be extracted in parallel. If this variable is not set, parallel extraction is disabled.
-* The extractor now offers experimental support for [E4X](https://developer.mozilla.org/en-US/docs/Archive/Web/E4X), a legacy language extension developed by Mozilla.
-* The extractor now supports additional [Flow](https://flow.org/) syntax.
-* The extractor now supports [Nullish Coalescing](https://github.com/tc39/proposal-nullish-coalescing) expressions.
-* The extractor now supports [TypeScript 3.2](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-3-2.html).
-* The TypeScript extractor now handles the control-flow of logical operators and destructuring assignments more accurately.
+* Experimental support for [E4X](https://developer.mozilla.org/en-US/docs/Archive/Web/E4X), a legacy language extension developed by Mozilla, is available.
+* Additional [Flow](https://flow.org/) syntax is now supported.
+* [Nullish Coalescing](https://github.com/tc39/proposal-nullish-coalescing) expressions are now supported.
+* [TypeScript 3.2](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-3-2.html) is now supported.
+* The TypeScript extractor now handles the control flow of logical operators and destructuring assignments more accurately.

--- a/change-notes/1.20/extractor-javascript.md
+++ b/change-notes/1.20/extractor-javascript.md
@@ -4,7 +4,7 @@
 
 ## Changes to code extraction
 
-* Parallel extraction of JavaScript files (but not TypeScript files) on LGTM is now supported. The `LGTM_THREADS` environment variable can be set to indicate how many files should be extracted in parallel. If this variable is not set, parallel extraction is disabled.
+* Parallel extraction of JavaScript files (but not TypeScript files) on LGTM is now supported. If LGTM is configured to evaluate queries using multiple threads, then JavaScript files are also extracted using multiple threads.
 * Experimental support for [E4X](https://developer.mozilla.org/en-US/docs/Archive/Web/E4X), a legacy language extension developed by Mozilla, is available.
 * Additional [Flow](https://flow.org/) syntax is now supported.
 * [Nullish Coalescing](https://github.com/tc39/proposal-nullish-coalescing) expressions are now supported.

--- a/change-notes/1.20/support/versions-compilers.csv
+++ b/change-notes/1.20/support/versions-compilers.csv
@@ -13,4 +13,4 @@ Java,"Java 11 [2]_. or lower","javac (OpenJDK and Oracle JDK)
 Eclipse compiler for Java (ECJ) batch compiler",``.java``
 JavaScript,ECMAScript 2018 or lower,Not applicable,"``.js``, ``.jsx``, ``.mjs``, ``.es``, ``.es6``, ``.htm``, ``.html``, ``.xhm``, ``.xhtml``, ``.vue``, ``.json`` [3]_."
 Python,"2.7, 3.5, 3.6, 3.7",Not applicable,``.py``
-TypeScript [4]_.,"2.6, 2.7, 2.8, 2.9, 3.0, 3.1",Standard TypeScript compiler,"``.ts``, ``.tsx``"
+TypeScript [4]_.,"2.6, 2.7, 2.8, 2.9, 3.0, 3.1, 3.2",Standard TypeScript compiler,"``.ts``, ``.tsx``"


### PR DESCRIPTION
My apologies, I entirely missed this file when I raised #1097.

Once this is merged, I'll add the information to the analysis changes topic in the LGTM help and wiki page.

@max - as discussed, I've changed the description of parallel extraction. At the same time I've updated the support information for TypeScript.