### PR TITLE
C#: More performance tweaks

### DIFF
--- a/csharp/ql/src/semmle/code/csharp/commons/Constants.qll
+++ b/csharp/ql/src/semmle/code/csharp/commons/Constants.qll
@@ -4,18 +4,20 @@ import csharp
 private import semmle.code.csharp.commons.ComparisonTest
 private import semmle.code.csharp.commons.StructuralComparison as StructuralComparison
 
+pragma[noinline]
+private predicate isConstantCondition0(ControlFlow::Node cfn, boolean b) {
+  exists(
+    cfn.getASuccessorByType(any(ControlFlow::SuccessorTypes::BooleanSuccessor t | t.getValue() = b))
+  ) and
+  strictcount(ControlFlow::SuccessorType t | exists(cfn.getASuccessorByType(t))) = 1
+}
+
 /**
  * Holds if `e` is a condition that always evaluates to Boolean value `b`.
  */
 predicate isConstantCondition(Expr e, boolean b) {
   forex(ControlFlow::Node cfn | cfn = e.getAControlFlowNode() |
-    exists(
-      cfn
-          .getASuccessorByType(any(ControlFlow::SuccessorTypes::BooleanSuccessor t |
-              t.getValue() = b
-            ))
-    ) and
-    strictcount(ControlFlow::SuccessorType t | exists(cfn.getASuccessorByType(t))) = 1
+    isConstantCondition0(cfn, b)
   )
 }
 

--- a/csharp/ql/src/semmle/code/csharp/controlflow/ControlFlowElement.qll
+++ b/csharp/ql/src/semmle/code/csharp/controlflow/ControlFlowElement.qll
@@ -75,6 +75,40 @@ class ControlFlowElement extends ExprOrStmtParent, @control_flow_element {
     getAControlFlowNode().getBasicBlock().getASuccessor+().getANode() = result.getAControlFlowNode()
   }
 
+  pragma[noinline]
+  private predicate immediatelyControlsBlockSplit0(
+    ConditionBlock cb, BasicBlock succ, ConditionalSuccessor s
+  ) {
+    // Only calculate dominance by explicit recursion for split nodes;
+    // all other nodes can use regular CFG dominance
+    this instanceof ControlFlow::Internal::SplitControlFlowElement and
+    cb.getLastNode() = this.getAControlFlowNode() and
+    succ = cb.getASuccessorByType(s)
+  }
+
+  pragma[noinline]
+  private predicate immediatelyControlsBlockSplit1(
+    ConditionBlock cb, BasicBlock succ, ConditionalSuccessor s, BasicBlock pred, SuccessorType t
+  ) {
+    this.immediatelyControlsBlockSplit0(cb, succ, s) and
+    pred = succ.getAPredecessorByType(t) and
+    pred != cb
+  }
+
+  pragma[noinline]
+  private predicate immediatelyControlsBlockSplit2(
+    ConditionBlock cb, BasicBlock succ, ConditionalSuccessor s, BasicBlock pred, SuccessorType t
+  ) {
+    this.immediatelyControlsBlockSplit1(cb, succ, s, pred, t) and
+    (
+      succ.dominates(pred)
+      or
+      // `pred` might be another split of this element
+      pred.getLastNode().getElement() = this and
+      t = s
+    )
+  }
+
   /**
    * Holds if basic block `succ` is immediately controlled by this control flow
    * element with conditional value `s`. That is, `succ` can only be reached from
@@ -96,19 +130,11 @@ class ControlFlowElement extends ExprOrStmtParent, @control_flow_element {
    */
   pragma[nomagic]
   private predicate immediatelyControlsBlockSplit(BasicBlock succ, ConditionalSuccessor s) {
-    // Only calculate dominance by explicit recursion for split nodes;
-    // all other nodes can use regular CFG dominance
-    this instanceof ControlFlow::Internal::SplitControlFlowElement and
-    exists(ConditionBlock cb | cb.getLastNode() = this.getAControlFlowNode() |
-      succ = cb.getASuccessorByType(s) and
+    exists(ConditionBlock cb | this.immediatelyControlsBlockSplit0(cb, succ, s) |
       forall(BasicBlock pred, SuccessorType t |
-        pred = succ.getAPredecessorByType(t) and pred != cb
+        this.immediatelyControlsBlockSplit1(cb, succ, s, pred, t)
       |
-        succ.dominates(pred)
-        or
-        // `pred` might be another split of this element
-        pred.getLastNode().getElement() = this and
-        t = s
+        this.immediatelyControlsBlockSplit2(cb, succ, s, pred, t)
       )
     )
   }


### PR DESCRIPTION
This PR improves performance of predicates introduced with 1.20 (CFG-split-aware guards library & new nullness queries), as well as `isConstantCondition()`, which I consider safe to target for 1.20 as well. The profiling report is [here](https://git.semmle.com/gist/tom/7511c28ed0005dcf667ccc93234d032e) (internal link).