### PR TITLE
C++: Fix typo in ReturnStackAllocatedMemory.ql

### DIFF
--- a/cpp/ql/src/Likely Bugs/Memory Management/ReturnStackAllocatedMemory.ql
+++ b/cpp/ql/src/Likely Bugs/Memory Management/ReturnStackAllocatedMemory.ql
@@ -56,7 +56,7 @@ where
     or
     // The data flow library doesn't support conversions, so here we check that
     // the address escapes into some expression `pointerToLocal`, which flows
-    // in a one or more steps to a returned expression.
+    // in one or more steps to a returned expression.
     exists(Expr pointerToLocal |
       variableAddressEscapesTree(va, pointerToLocal.getFullyConverted()) and
       not hasNontrivialConversion(pointerToLocal) and


### PR DESCRIPTION
From https://github.com/Semmle/ql/pull/1121#discussion_r266818822.