### PR TITLE
Python: Copy query suites from `python2` to `python`.

### DIFF
--- a/python/config/suites/lgtm/python-alerts-lgtm
+++ b/python/config/suites/lgtm/python-alerts-lgtm
@@ -1,0 +1,3 @@
+# DO NOT EDIT
+# This is a stub file. The actual suite of queries to run is generated
+# automatically based on query precision and severity.

--- a/python/config/suites/lgtm/python-lgtm
+++ b/python/config/suites/lgtm/python-lgtm
@@ -1,0 +1,2 @@
+@import "python-queries-lgtm"
+@import "python-metrics-lgtm"

--- a/python/config/suites/lgtm/python-metrics-lgtm
+++ b/python/config/suites/lgtm/python-metrics-lgtm
@@ -1,0 +1,17 @@
++ semmlecode-python-queries/Lexical/FCommentedOutCode.ql: /Metrics/Files
+    @_namespace com.lgtm/python-queries
++ semmlecode-python-queries/Metrics/FLinesOfCode.ql: /Metrics/Files
+    @_namespace com.lgtm/python-queries
++ semmlecode-python-queries/Metrics/FLinesOfComments.ql: /Metrics/Files
+    @_namespace com.lgtm/python-queries
++ semmlecode-python-queries/Metrics/FLinesOfDuplicatedCode.ql: /Metrics/Duplication
+    @_namespace com.lgtm/python-queries
++ semmlecode-python-queries/Metrics/FLinesOfSimilarCode.ql: /Metrics/Duplication
+    @_namespace com.lgtm/python-queries
++ semmlecode-python-queries/Metrics/FNumberOfTests.ql: /Metrics/Functions
+    @_namespace com.lgtm/python-queries
+
++ semmlecode-python-queries/Metrics/Dependencies/ExternalDependencies.ql
+    @_namespace com.lgtm/python-queries
++ semmlecode-python-queries/Metrics/Dependencies/ExternalDependenciesSourceLinks.ql
+    @_namespace com.lgtm/python-queries

--- a/python/config/suites/lgtm/python-queries-lgtm
+++ b/python/config/suites/lgtm/python-queries-lgtm
@@ -1,0 +1,10 @@
++ semmlecode-python-queries/analysis/Definitions.ql
+    @_namespace com.lgtm/python-queries
++ semmlecode-python-queries/analysis/AlertSuppression.ql
+    @_namespace com.lgtm/python-queries
++ semmlecode-python-queries/Filters/ClassifyFiles.ql
+    @_namespace com.lgtm/python-queries
++ semmlecode-python-queries/Filters/ImportAdditionalLibraries.ql
+    @_namespace com.lgtm/python-queries
+
+@import "python-alerts-lgtm"


### PR DESCRIPTION
... to make the naming scheme more consistent.

This could have been done in a single step, by simply renaming the files (and the imports contained therein), but the corresponding internal PR would have to bump the submodule pointer. In order to avoid contention on this pointer, I thought it simpler to just create copies of these files now, and then remove the `python2` files in a later PR, once the internal references have been removed. (This does of course make the history of these files more difficult to follow, but in this case it makes no difference, as the files have not been changed since they were added two months ago.)