### PR TITLE
CPP: Fix a bug in NewFree.qll

### DIFF
--- a/change-notes/1.21/analysis-cpp.md
+++ b/change-notes/1.21/analysis-cpp.md
@@ -1,0 +1,15 @@
+# Improvements to C/C++ analysis
+
+## General improvements
+
+## New queries
+
+| **Query**                   | **Tags**  | **Purpose**                                                        |
+|-----------------------------|-----------|--------------------------------------------------------------------|
+
+## Changes to existing queries
+
+| **Query**                  | **Expected impact**    | **Change**                                                       |
+|----------------------------|------------------------|------------------------------------------------------------------|
+
+## Changes to QL libraries

--- a/change-notes/1.21/analysis-cpp.md
+++ b/change-notes/1.21/analysis-cpp.md
@@ -11,5 +11,6 @@
 
 | **Query**                  | **Expected impact**    | **Change**                                                       |
 |----------------------------|------------------------|------------------------------------------------------------------|
+| Mismatching new/free or malloc/delete (`cpp/new-free-mismatch`) | Fewer false positive results | Fixed an issue where functions were being identified as allocation functions inappropriately.  Also affects `cpp/new-array-delete-mismatch` and `cpp/new-delete-array-mismatch`. |
 
 ## Changes to QL libraries

--- a/cpp/ql/src/Critical/NewDelete.qll
+++ b/cpp/ql/src/Critical/NewDelete.qll
@@ -3,6 +3,7 @@
  */
 import cpp
 import semmle.code.cpp.controlflow.SSA
+import semmle.code.cpp.dataflow.DataFlow
 
 /**
  * Holds if `alloc` is a use of `malloc` or `new`.  `kind` is
@@ -46,10 +47,9 @@ predicate allocExprOrIndirect(Expr alloc, string kind) {
     alloc.(FunctionCall).getTarget() = rtn.getEnclosingFunction() and
     (
       allocExprOrIndirect(rtn.getExpr(), kind) or
-      exists(SsaDefinition def, LocalScopeVariable v |
-        // alloc via SSA
-        allocExprOrIndirect(def.getAnUltimateDefiningValue(v), kind) and
-        rtn.getExpr() = def.getAUse(v)
+      exists(Expr e |
+        allocExprOrIndirect(e, kind) and
+        DataFlow::localFlow(DataFlow::exprNode(e), DataFlow::exprNode(rtn.getExpr()))
       )
     )
   )

--- a/cpp/ql/src/Critical/NewDelete.qll
+++ b/cpp/ql/src/Critical/NewDelete.qll
@@ -46,7 +46,11 @@ predicate allocExprOrIndirect(Expr alloc, string kind) {
     alloc.(FunctionCall).getTarget() = rtn.getEnclosingFunction() and
     (
       allocExprOrIndirect(rtn.getExpr(), kind) or
-      allocReaches0(rtn.getExpr(), _, kind)
+      exists(SsaDefinition def, LocalScopeVariable v |
+        // alloc via SSA
+        allocExprOrIndirect(def.getAnUltimateDefiningValue(v), kind) and
+        rtn.getExpr() = def.getAUse(v)
+      )
     )
   )
 }

--- a/cpp/ql/test/query-tests/Critical/NewFree/NewFreeMismatch.expected
+++ b/cpp/ql/test/query-tests/Critical/NewFree/NewFreeMismatch.expected
@@ -12,3 +12,4 @@
 | test.cpp:235:2:235:5 | call to free | There is a new/free mismatch between this free and the corresponding $@. | test.cpp:227:7:227:13 | new | new |
 | test.cpp:239:2:239:5 | call to free | There is a new/free mismatch between this free and the corresponding $@. | test.cpp:228:7:228:17 | new[] | new[] |
 | test.cpp:272:3:272:6 | call to free | There is a new/free mismatch between this free and the corresponding $@. | test.cpp:265:7:265:13 | new | new |
+| test.cpp:425:2:425:31 | delete | There is a malloc/delete mismatch between this delete and the corresponding $@. | test.cpp:425:20:425:29 | call to getPointer | malloc |

--- a/cpp/ql/test/query-tests/Critical/NewFree/NewFreeMismatch.expected
+++ b/cpp/ql/test/query-tests/Critical/NewFree/NewFreeMismatch.expected
@@ -6,10 +6,8 @@
 | test.cpp:91:3:91:11 | delete | There is a malloc/delete mismatch between this delete and the corresponding $@. | test.cpp:88:28:88:36 | call to my_malloc | malloc |
 | test.cpp:99:3:99:11 | call to my_delete | There is a malloc/delete mismatch between this delete and the corresponding $@. | test.cpp:96:28:96:33 | call to malloc | malloc |
 | test.cpp:138:2:138:9 | delete | There is a malloc/delete mismatch between this delete and the corresponding $@. | test.cpp:135:12:135:22 | call to my_malloc_2 | malloc |
-| test.cpp:155:2:155:9 | delete | There is a malloc/delete mismatch between this delete and the corresponding $@. | test.cpp:152:12:152:22 | call to my_malloc_3 | malloc |
 | test.cpp:232:2:232:9 | delete | There is a malloc/delete mismatch between this delete and the corresponding $@. | test.cpp:226:7:226:12 | call to malloc | malloc |
 | test.cpp:233:2:233:12 | delete[] | There is a malloc/delete mismatch between this delete[] and the corresponding $@. | test.cpp:226:7:226:12 | call to malloc | malloc |
 | test.cpp:235:2:235:5 | call to free | There is a new/free mismatch between this free and the corresponding $@. | test.cpp:227:7:227:13 | new | new |
 | test.cpp:239:2:239:5 | call to free | There is a new/free mismatch between this free and the corresponding $@. | test.cpp:228:7:228:17 | new[] | new[] |
 | test.cpp:272:3:272:6 | call to free | There is a new/free mismatch between this free and the corresponding $@. | test.cpp:265:7:265:13 | new | new |
-| test.cpp:425:2:425:31 | delete | There is a malloc/delete mismatch between this delete and the corresponding $@. | test.cpp:425:20:425:29 | call to getPointer | malloc |

--- a/cpp/ql/test/query-tests/Critical/NewFree/NewFreeMismatch.expected
+++ b/cpp/ql/test/query-tests/Critical/NewFree/NewFreeMismatch.expected
@@ -6,6 +6,7 @@
 | test.cpp:91:3:91:11 | delete | There is a malloc/delete mismatch between this delete and the corresponding $@. | test.cpp:88:28:88:36 | call to my_malloc | malloc |
 | test.cpp:99:3:99:11 | call to my_delete | There is a malloc/delete mismatch between this delete and the corresponding $@. | test.cpp:96:28:96:33 | call to malloc | malloc |
 | test.cpp:138:2:138:9 | delete | There is a malloc/delete mismatch between this delete and the corresponding $@. | test.cpp:135:12:135:22 | call to my_malloc_2 | malloc |
+| test.cpp:155:2:155:9 | delete | There is a malloc/delete mismatch between this delete and the corresponding $@. | test.cpp:152:12:152:22 | call to my_malloc_3 | malloc |
 | test.cpp:232:2:232:9 | delete | There is a malloc/delete mismatch between this delete and the corresponding $@. | test.cpp:226:7:226:12 | call to malloc | malloc |
 | test.cpp:233:2:233:12 | delete[] | There is a malloc/delete mismatch between this delete[] and the corresponding $@. | test.cpp:226:7:226:12 | call to malloc | malloc |
 | test.cpp:235:2:235:5 | call to free | There is a new/free mismatch between this free and the corresponding $@. | test.cpp:227:7:227:13 | new | new |

--- a/cpp/ql/test/query-tests/Critical/NewFree/test.cpp
+++ b/cpp/ql/test/query-tests/Critical/NewFree/test.cpp
@@ -152,7 +152,7 @@ void test3()
 	void *b = my_malloc_3(10);
 	
 	free(a); // GOOD
-	delete b; // BAD: malloc -> delete
+	delete b; // BAD: malloc -> delete [NOT DETECTED]
 }
 
 void test4(bool do_array_delete)
@@ -422,5 +422,5 @@ void test13()
 	MyPointer13 myPointer2(myBuffer);
 	MyPointer13 myPointer3(new char[100]);
 
-	delete myPointer2.getPointer(); // GOOD [FALSE POSITIVE]
+	delete myPointer2.getPointer(); // GOOD
 }

--- a/cpp/ql/test/query-tests/Critical/NewFree/test.cpp
+++ b/cpp/ql/test/query-tests/Critical/NewFree/test.cpp
@@ -371,3 +371,56 @@ void test12(bool cond)
 		free(z); // GOOD
 	}
 }
+
+// ---
+
+class MyBuffer13
+{
+public:
+	MyBuffer13(int size)
+	{
+		buffer = (char *)malloc(size * sizeof(char));
+	}
+
+	~MyBuffer13()
+	{
+		free(buffer); // GOOD
+	}
+
+	char *getBuffer() // note: this should not be considered an allocation function
+	{
+		return buffer;
+	}
+
+private:
+	char *buffer;
+};
+
+class MyPointer13
+{
+public:
+	MyPointer13(char *_pointer) : pointer(_pointer)
+	{
+	}
+
+	MyPointer13(MyBuffer13 &buffer) : pointer(buffer.getBuffer())
+	{
+	}
+
+	char *getPointer() // note: this should not be considered an allocation function
+	{
+		return pointer;
+	}
+
+private:
+	char *pointer;
+};
+
+void test13()
+{
+	MyBuffer13 myBuffer(100);
+	MyPointer13 myPointer2(myBuffer);
+	MyPointer13 myPointer3(new char[100]);
+
+	delete myPointer2.getPointer(); // GOOD [FALSE POSITIVE]
+}

--- a/cpp/ql/test/query-tests/Critical/NewFree/test.cpp
+++ b/cpp/ql/test/query-tests/Critical/NewFree/test.cpp
@@ -422,5 +422,5 @@ void test13()
 	MyPointer13 myPointer2(myBuffer);
 	MyPointer13 myPointer3(new char[100]);
 
-	delete myPointer2.getPointer(); // GOOD
+	delete myPointer3.getPointer(); // GOOD
 }

--- a/cpp/ql/test/query-tests/Critical/NewFree/test.cpp
+++ b/cpp/ql/test/query-tests/Critical/NewFree/test.cpp
@@ -152,7 +152,7 @@ void test3()
 	void *b = my_malloc_3(10);
 	
 	free(a); // GOOD
-	delete b; // BAD: malloc -> delete [NOT DETECTED]
+	delete b; // BAD: malloc -> delete
 }
 
 void test4(bool do_array_delete)


### PR DESCRIPTION
See https://discuss.lgtm.com/t/malloc-delete-mismatch-false-positive/1914.

The issue was that the call to `tmp.data()` was being misrecognized as an allocation call, due to over-enthusiastic data-flow tracking.  The fix is to only use local data flow for the purposes of identifying `malloc`-like functions (whereas global flow is still used to track between the `malloc` and `free`).

Diff query: https://lgtm.com/query/3658696700719411428/