### PR TITLE
Python: Use new `ModuleObject` API more widely. 

### DIFF
--- a/python/ql/src/Security/CWE-295/RequestWithoutValidation.ql
+++ b/python/ql/src/Security/CWE-295/RequestWithoutValidation.ql
@@ -15,10 +15,7 @@ import semmle.python.web.Http
 
 
 FunctionObject requestFunction() {
-    exists(ModuleObject req |
-        req.getName() = "requests" and
-        result = req.attr(httpVerbLower())
-    )
+    result = ModuleObject::named("requests").attr(httpVerbLower())
 }
 
 /** requests treats None as the default and all other "falsey" values as False */

--- a/python/ql/src/Security/CWE-327/InsecureDefaultProtocol.ql
+++ b/python/ql/src/Security/CWE-327/InsecureDefaultProtocol.ql
@@ -13,11 +13,11 @@
 import python
 
 FunctionObject ssl_wrap_socket() {
-    result = any(ModuleObject ssl | ssl.getName() = "ssl").attr("wrap_socket")
+    result = ModuleObject::named("ssl").attr("wrap_socket")
 }
 
 ClassObject ssl_Context_class() {
-    result = any(ModuleObject ssl | ssl.getName() = "ssl").attr("SSLContext")
+    result = ModuleObject::named("ssl").attr("SSLContext")
 }
 
 CallNode unsafe_call(string method_name) {

--- a/python/ql/src/Security/CWE-327/InsecureProtocol.ql
+++ b/python/ql/src/Security/CWE-327/InsecureProtocol.ql
@@ -34,11 +34,11 @@ string insecure_version_name() {
 }
 
 private ModuleObject the_ssl_module() {
-    result = any(ModuleObject m | m.getName() = "ssl")
+    result = ModuleObject::named("ssl")
 }
 
 private ModuleObject the_pyOpenSSL_module() {
-    result = any(ModuleObject m | m.getName() = "pyOpenSSL.SSL")
+    result = ModuleObject::named("pyOpenSSL.SSL")
 }
 
 /* A syntactic check for cases where points-to analysis cannot infer the presence of
@@ -76,7 +76,7 @@ predicate unsafe_ssl_wrap_socket_call(CallNode call, string method_name, string 
 }
 
 ClassObject the_pyOpenSSL_Context_class() {
-    result = any(ModuleObject m | m.getName() = "pyOpenSSL.SSL").attr("Context")
+    result = ModuleObject::named("pyOpenSSL.SSL").attr("Context")
 }
 
 predicate unsafe_pyOpenSSL_Context_call(CallNode call, string insecure_version) {

--- a/python/ql/src/Security/CWE-377/InsecureTemporaryFile.ql
+++ b/python/ql/src/Security/CWE-377/InsecureTemporaryFile.ql
@@ -23,7 +23,7 @@ FunctionObject temporary_name_function(string mod, string function) {
             function = "tempnam"
         )
     ) and
-    result = ModuleObject::named(mod).getAttribute(function)
+    result = ModuleObject::named(mod).attr(function)
 }
 
 from Call c, string mod, string function

--- a/python/ql/src/Security/CWE-377/InsecureTemporaryFile.ql
+++ b/python/ql/src/Security/CWE-377/InsecureTemporaryFile.ql
@@ -23,7 +23,7 @@ FunctionObject temporary_name_function(string mod, string function) {
             function = "tempnam"
         )
     ) and
-    result = any(ModuleObject m | m.getName() = mod).getAttribute(function)
+    result = ModuleObject::named(mod).getAttribute(function)
 }
 
 from Call c, string mod, string function

--- a/python/ql/src/Security/CWE-732/WeakFilePermissions.ql
+++ b/python/ql/src/Security/CWE-732/WeakFilePermissions.ql
@@ -35,12 +35,12 @@ string permissive_permission(int p) {
 }
 
 predicate chmod_call(CallNode call, FunctionObject chmod, NumericObject num) {
-    any(ModuleObject os | os.getName() = "os").attr("chmod") = chmod and
+    ModuleObject::named("os").attr("chmod") = chmod and
     chmod.getACall() = call and call.getArg(1).refersTo(num)
 }
 
 predicate open_call(CallNode call, FunctionObject open, NumericObject num) {
-    any(ModuleObject os | os.getName() = "os").attr("open") = open and
+    ModuleObject::named("os").attr("open") = open and
     open.getACall() = call and call.getArg(2).refersTo(num)
 }
 

--- a/python/ql/src/Security/CWE-798/HardcodedCredentials.ql
+++ b/python/ql/src/Security/CWE-798/HardcodedCredentials.ql
@@ -40,7 +40,7 @@ predicate possible_reflective_name(string name) {
     or
     any(ClassObject c).getName() = name
     or
-    any(ModuleObject m).getName() = name
+    exists(ModuleObject::named(name))
     or
     exists(Object::builtin(name))
 }

--- a/python/ql/src/semmle/python/security/injection/Command.qll
+++ b/python/ql/src/semmle/python/security/injection/Command.qll
@@ -83,7 +83,7 @@ class ShellCommand extends TaintSink {
         or
         exists(CallNode call |
             call.getAnArg() = this and
-            call.getFunction().refersTo(any(ModuleObject commands | commands.getName() = "commands"))
+            call.getFunction().refersTo(ModuleObject::named("commands"))
         )
     }
 

--- a/python/ql/src/semmle/python/security/strings/External.qll
+++ b/python/ql/src/semmle/python/security/strings/External.qll
@@ -91,7 +91,7 @@ private predicate json_subscript_taint(SubscriptNode sub, ControlFlowNode obj, E
 
 private predicate json_load(ControlFlowNode fromnode, CallNode tonode) {
     exists(FunctionObject json_loads |
-        any(ModuleObject json | json.getName() = "json").attr("loads") = json_loads and
+        ModuleObject::named("json").attr("loads") = json_loads and
         json_loads.getACall() = tonode and tonode.getArg(0) = fromnode
     )
 }

--- a/python/ql/src/semmle/python/web/bottle/General.qll
+++ b/python/ql/src/semmle/python/web/bottle/General.qll
@@ -9,7 +9,7 @@ ModuleObject theBottleModule() {
 
 /** The bottle.Bottle class */
 ClassObject theBottleClass() {
-    result = ModuleObject::named("bottle").attr("Bottle")
+    result = theBottleModule().attr("Bottle")
 }
 
 /** Holds if `route` is routed to `func`

--- a/python/ql/src/semmle/python/web/django/Db.qll
+++ b/python/ql/src/semmle/python/web/django/Db.qll
@@ -12,7 +12,7 @@ class DjangoDbCursor extends DbCursor {
 }
 
 private Object theDjangoConnectionObject() {
-    any(ModuleObject m | m.getName() = "django.db").attr("connection") = result
+    ModuleObject::named("django.db").attr("connection") = result
 }
 
 /** A kind of taint source representing sources of django cursor objects.
@@ -38,7 +38,7 @@ class DjangoDbCursorSource extends DbConnectionSource {
 
 
 ClassObject theDjangoRawSqlClass() {
-    result = any(ModuleObject m | m.getName() = "django.db.models.expressions").attr("RawSQL")
+    result = ModuleObject::named("django.db.models.expressions").attr("RawSQL")
 }
 
 /**

--- a/python/ql/src/semmle/python/web/django/Model.qll
+++ b/python/ql/src/semmle/python/web/django/Model.qll
@@ -8,7 +8,7 @@ import semmle.python.web.Http
 class DjangoModel extends ClassObject {
 
     DjangoModel() {
-        any(ModuleObject m | m.getName() = "django.db.models").attr("Model") = this.getAnImproperSuperType()
+        ModuleObject::named("django.db.models").attr("Model") = this.getAnImproperSuperType()
     }
 
 }

--- a/python/ql/src/semmle/python/web/django/Request.qll
+++ b/python/ql/src/semmle/python/web/django/Request.qll
@@ -82,7 +82,7 @@ private class DjangoFunctionBasedViewRequestArgument extends DjangoRequestSource
 private class DjangoView extends ClassObject {
 
     DjangoView() {
-        any(ModuleObject m | m.getName() = "django.views.generic").attr("View") = this.getAnImproperSuperType()
+        ModuleObject::named("django.views.generic").attr("View") = this.getAnImproperSuperType()
     }
 }
 
@@ -109,7 +109,7 @@ class DjangoClassBasedViewRequestArgument extends DjangoRequestSource {
 /* Function based views */
 predicate url_dispatch(CallNode call, ControlFlowNode regex, FunctionObject view) {
     exists(FunctionObject url |
-        any(ModuleObject m | m.getName() = "django.conf.urls").attr("url") = url and
+        ModuleObject::named("django.conf.urls").attr("url") = url and
         url.getArgumentForCall(call, 0) = regex and
         url.getArgumentForCall(call, 1).refersTo(view)
     )

--- a/python/ql/src/semmle/python/web/django/Response.qll
+++ b/python/ql/src/semmle/python/web/django/Response.qll
@@ -44,7 +44,7 @@ class DjangoResponseWrite extends TaintSink {
     DjangoResponseWrite() {
         exists(AttrNode meth, CallNode call |
             call.getFunction() = meth and
-            any(DjangoResponse repsonse).taints(meth.getObject("write")) and
+            any(DjangoResponse response).taints(meth.getObject("write")) and
             this = call.getArg(0)
         )
     }

--- a/python/ql/src/semmle/python/web/django/Response.qll
+++ b/python/ql/src/semmle/python/web/django/Response.qll
@@ -17,7 +17,7 @@ class DjangoResponse extends TaintKind {
 }
 
 private ClassObject theDjangoHttpResponseClass() {
-    result = any(ModuleObject m | m.getName() = "django.http.response").attr("HttpResponse") and
+    result = ModuleObject::named("django.http.response").attr("HttpResponse") and
     not result = theDjangoHttpRedirectClass()
 }
 

--- a/python/ql/src/semmle/python/web/django/Shared.qll
+++ b/python/ql/src/semmle/python/web/django/Shared.qll
@@ -1,9 +1,9 @@
 import python
 
 FunctionObject redirect() {
-    result = any(ModuleObject m | m.getName() = "django.shortcuts").attr("redirect")
+    result = ModuleObject::named("django.shortcuts").attr("redirect")
 }
 
 ClassObject theDjangoHttpRedirectClass() {
-    result = any(ModuleObject m | m.getName() = "django.http.response").attr("HttpResponseRedirectBase")
+    result = ModuleObject::named("django.http.response").attr("HttpResponseRedirectBase")
 }

--- a/python/ql/src/semmle/python/web/falcon/General.qll
+++ b/python/ql/src/semmle/python/web/falcon/General.qll
@@ -4,7 +4,7 @@ import semmle.python.web.Http
 
 /** The falcon API class */
 ClassObject theFalconAPIClass() {
-    result = ModuleObject::named("falcon").getAttribute("API")
+    result = ModuleObject::named("falcon").attr("API")
 }
 
 

--- a/python/ql/src/semmle/python/web/flask/General.qll
+++ b/python/ql/src/semmle/python/web/flask/General.qll
@@ -3,7 +3,7 @@ import semmle.python.web.Http
 
 /** The flask module */
 ModuleObject theFlaskModule() {
-    result = any(ModuleObject m | m.getName() = "flask")
+    result = ModuleObject::named("flask")
 }
 
 /** The flask app class */
@@ -13,7 +13,7 @@ ClassObject theFlaskClass() {
 
 /** The flask MethodView class */
 ClassObject theFlaskMethodViewClass() {
-    result = any(ModuleObject m | m.getName() = "flask.views").attr("MethodView")
+    result = ModuleObject::named("flask.views").attr("MethodView")
 }
 
 ClassObject theFlaskReponseClass() {

--- a/python/ql/src/semmle/python/web/pyramid/Request.qll
+++ b/python/ql/src/semmle/python/web/pyramid/Request.qll
@@ -12,7 +12,7 @@ class PyramidRequest extends BaseWebobRequest {
     }
 
     override ClassObject getClass() {
-        result = any(ModuleObject m | m.getName() = "pyramid.request").attr("Request")
+        result = ModuleObject::named("pyramid.request").attr("Request")
     }
 
 }

--- a/python/ql/src/semmle/python/web/tornado/Tornado.qll
+++ b/python/ql/src/semmle/python/web/tornado/Tornado.qll
@@ -3,7 +3,7 @@ import python
 import semmle.python.security.TaintTracking
 
 private ClassObject theTornadoRequestHandlerClass() {
-    result = any(ModuleObject m | m.getName() = "tornado.web").attr("RequestHandler")
+    result = ModuleObject::named("tornado.web").attr("RequestHandler")
 }
 
 ClassObject aTornadoRequestHandlerClass() {

--- a/python/ql/src/semmle/python/web/turbogears/TurboGears.qll
+++ b/python/ql/src/semmle/python/web/turbogears/TurboGears.qll
@@ -3,7 +3,7 @@ import python
 import semmle.python.security.TaintTracking
 
 private ClassObject theTurboGearsControllerClass() {
-    result = ModuleObject::named("tg").getAttribute("TGController")
+    result = ModuleObject::named("tg").attr("TGController")
 }
 
 
@@ -23,7 +23,7 @@ class TurboGearsControllerMethod extends Function {
         (
             decorator.(CallNode).getFunction().(NameNode).getId() = "expose"
             or
-            decorator.refersTo(_, ModuleObject::named("tg").getAttribute("expose"), _)
+            decorator.refersTo(_, ModuleObject::named("tg").attr("expose"), _)
         )
     }
 

--- a/python/ql/src/semmle/python/web/twisted/Twisted.qll
+++ b/python/ql/src/semmle/python/web/twisted/Twisted.qll
@@ -3,11 +3,11 @@ import python
 import semmle.python.security.TaintTracking
 
 private ClassObject theTwistedHttpRequestClass() {
-    result = any(ModuleObject m | m.getName() = "twisted.web.http").attr("Request")
+    result = ModuleObject::named("twisted.web.http").attr("Request")
 }
 
 private ClassObject theTwistedHttpResourceClass() {
-    result = any(ModuleObject m | m.getName() = "twisted.web.resource").attr("Resource")
+    result = ModuleObject::named("twisted.web.resource").attr("Resource")
 }
 
 ClassObject aTwistedRequestHandlerClass() {

--- a/python/ql/src/semmle/python/web/webob/Request.qll
+++ b/python/ql/src/semmle/python/web/webob/Request.qll
@@ -45,7 +45,7 @@ class WebobRequest extends BaseWebobRequest {
     }
 
     override ClassObject getClass() {
-        result = any(ModuleObject m | m.getName() = "webob.request").attr("Request")
+        result = ModuleObject::named("webob.request").attr("Request")
     }
 
 }


### PR DESCRIPTION
Fixes up all of the security queries and libraries to use `ModuleObject::named` and `attr` instead of their more verbose counterparts. 

(Also fixes a small typo I came across during this process.)

Behaviour should be unchanged, so no change note is needed.