### PR TITLE
JavaScript: Add model of `adm-zip` library for ZipSlip query.

### DIFF
--- a/javascript/ql/src/semmle/javascript/security/dataflow/ZipSlip.qll
+++ b/javascript/ql/src/semmle/javascript/security/dataflow/ZipSlip.qll
@@ -91,6 +91,26 @@ module ZipSlip {
     }
   }
 
+  /** An archive entry path access using the `adm-zip` package. */
+  class AdmZipEntrySource extends Source {
+    AdmZipEntrySource() {
+      exists(DataFlow::SourceNode admZip, DataFlow::SourceNode entry |
+        admZip = DataFlow::moduleImport("adm-zip").getAnInstantiation() and
+        this = entry.getAPropertyRead("entryName")
+      |
+        entry = admZip.getAMethodCall("getEntry")
+        or
+        exists(DataFlow::SourceNode entries | entries = admZip.getAMethodCall("getEntries") |
+          entry = entries.getAPropertyRead()
+          or
+          exists(string map | map = "map" or map = "forEach" |
+            entry = entries.getAMethodCall(map).getCallback(0).getParameter(0)
+          )
+        )
+      )
+    }
+  }
+
   /** A call to `fs.createWriteStream`, as a sink for unsafe archive extraction. */
   class CreateWriteStreamSink extends Sink {
     CreateWriteStreamSink() {

--- a/javascript/ql/test/query-tests/Security/CWE-022/ZipSlip/AdmZipBad.js
+++ b/javascript/ql/test/query-tests/Security/CWE-022/ZipSlip/AdmZipBad.js
@@ -1,0 +1,7 @@
+const fs = require('fs');
+var AdmZip = require('adm-zip');
+var zip = new AdmZip("archive.zip");
+var zipEntries = zip.getEntries();
+zipEntries.forEach(function(zipEntry) {
+  fs.createWriteStream(zipEntry.entryName);
+});

--- a/javascript/ql/test/query-tests/Security/CWE-022/ZipSlip/ZipSlip.expected
+++ b/javascript/ql/test/query-tests/Security/CWE-022/ZipSlip/ZipSlip.expected
@@ -1,4 +1,5 @@
 nodes
+| AdmZipBad.js:6:24:6:41 | zipEntry.entryName |
 | TarSlipBad.js:6:36:6:46 | header.name |
 | ZipSlipBad2.js:5:9:5:46 | fileName |
 | ZipSlipBad2.js:5:20:5:46 | 'output ... ry.path |
@@ -19,6 +20,7 @@ edges
 | ZipSlipBadUnzipper.js:7:9:7:29 | fileName | ZipSlipBadUnzipper.js:8:37:8:44 | fileName |
 | ZipSlipBadUnzipper.js:7:20:7:29 | entry.path | ZipSlipBadUnzipper.js:7:9:7:29 | fileName |
 #select
+| AdmZipBad.js:6:24:6:41 | zipEntry.entryName | AdmZipBad.js:6:24:6:41 | zipEntry.entryName | AdmZipBad.js:6:24:6:41 | zipEntry.entryName | Unsanitized zip archive $@, which may contain '..', is used in a file system operation. | AdmZipBad.js:6:24:6:41 | zipEntry.entryName | item path |
 | TarSlipBad.js:6:36:6:46 | header.name | TarSlipBad.js:6:36:6:46 | header.name | TarSlipBad.js:6:36:6:46 | header.name | Unsanitized zip archive $@, which may contain '..', is used in a file system operation. | TarSlipBad.js:6:36:6:46 | header.name | item path |
 | ZipSlipBad2.js:6:22:6:29 | fileName | ZipSlipBad2.js:5:37:5:46 | entry.path | ZipSlipBad2.js:6:22:6:29 | fileName | Unsanitized zip archive $@, which may contain '..', is used in a file system operation. | ZipSlipBad2.js:5:37:5:46 | entry.path | item path |
 | ZipSlipBad.js:8:37:8:44 | fileName | ZipSlipBad.js:7:22:7:31 | entry.path | ZipSlipBad.js:8:37:8:44 | fileName | Unsanitized zip archive $@, which may contain '..', is used in a file system operation. | ZipSlipBad.js:7:22:7:31 | entry.path | item path |


### PR DESCRIPTION
`adm-zip` is a popular (1.5M weekly downloads) npm package that is vulnerable to zip slip, so seems worth looking for. The API is slightly more challenging to model since it involves flow through an array. I've taken the easy route and just added support for likely common patterns of using the array; perhaps this is something we could support better in general, though.

Evaluation on a handful of projects that depend on `adm-zip` showed no new results and no performance regressions.

The existing ZipSlip change note should cover this change.