### PR TITLE
C++: Fix special-casing of Qt library in resource-not-released-in-destructor

### DIFF
--- a/cpp/ql/src/jsf/4.10 Classes/AV Rule 79.ql
+++ b/cpp/ql/src/jsf/4.10 Classes/AV Rule 79.ql
@@ -267,7 +267,7 @@ predicate automaticallyReleased(Assignment acquire)
 {
   // sub-types of the Qt type QObject are released by their parent (if they have one)
   exists(NewExpr alloc |
-    alloc.getType() = qtObject() and
+    alloc.getAllocatedType() = qtObject() and
     acquire.getRValue() = alloc and
     alloc.getInitializer() = qtParentConstructor().getACallToThisFunction()
   )

--- a/cpp/ql/test/query-tests/jsf/4.10 Classes/AV Rule 79/AV Rule 79.expected
+++ b/cpp/ql/test/query-tests/jsf/4.10 Classes/AV Rule 79/AV Rule 79.expected
@@ -14,6 +14,9 @@
 | ListDelete.cpp:21:3:21:21 | ... = ... | Resource first is acquired by class MyThingColection but not released anywhere in this class. |
 | NoDestructor.cpp:23:3:23:20 | ... = ... | Resource n is acquired by class MyClass5 but not released anywhere in this class. |
 | PlacementNew.cpp:36:3:36:36 | ... = ... | Resource p1 is acquired by class MyTestForPlacementNew but not released anywhere in this class. |
+| QObject.cpp:16:5:16:46 | ... = ... | Resource noParent is acquired by class MyQtUser but not released anywhere in this class. |
+| QObject.cpp:20:5:20:54 | ... = ... | Resource constructorParent is acquired by class MyQtUser but not released anywhere in this class. |
+| QObject.cpp:22:5:22:49 | ... = ... | Resource laterParent is acquired by class MyQtUser but not released anywhere in this class. |
 | SelfRegistering.cpp:25:3:25:24 | ... = ... | Resource side is acquired by class MyOwner but not released anywhere in this class. |
 | Variants.cpp:25:3:25:13 | ... = ... | Resource f is acquired by class MyClass4 but not released anywhere in this class. |
 | Variants.cpp:65:3:65:17 | ... = ... | Resource a is acquired by class MyClass6 but not released anywhere in this class. |

--- a/cpp/ql/test/query-tests/jsf/4.10 Classes/AV Rule 79/AV Rule 79.expected
+++ b/cpp/ql/test/query-tests/jsf/4.10 Classes/AV Rule 79/AV Rule 79.expected
@@ -14,9 +14,6 @@
 | ListDelete.cpp:21:3:21:21 | ... = ... | Resource first is acquired by class MyThingColection but not released anywhere in this class. |
 | NoDestructor.cpp:23:3:23:20 | ... = ... | Resource n is acquired by class MyClass5 but not released anywhere in this class. |
 | PlacementNew.cpp:36:3:36:36 | ... = ... | Resource p1 is acquired by class MyTestForPlacementNew but not released anywhere in this class. |
-| QObject.cpp:16:5:16:46 | ... = ... | Resource noParent is acquired by class MyQtUser but not released anywhere in this class. |
-| QObject.cpp:20:5:20:54 | ... = ... | Resource constructorParent is acquired by class MyQtUser but not released anywhere in this class. |
-| QObject.cpp:22:5:22:49 | ... = ... | Resource laterParent is acquired by class MyQtUser but not released anywhere in this class. |
 | SelfRegistering.cpp:25:3:25:24 | ... = ... | Resource side is acquired by class MyOwner but not released anywhere in this class. |
 | Variants.cpp:25:3:25:13 | ... = ... | Resource f is acquired by class MyClass4 but not released anywhere in this class. |
 | Variants.cpp:65:3:65:17 | ... = ... | Resource a is acquired by class MyClass6 but not released anywhere in this class. |

--- a/cpp/ql/test/query-tests/jsf/4.10 Classes/AV Rule 79/QObject.cpp
+++ b/cpp/ql/test/query-tests/jsf/4.10 Classes/AV Rule 79/QObject.cpp
@@ -1,0 +1,25 @@
+struct QObject {
+  QObject(QObject *parent);
+  void setParent(QObject *parent);
+};
+
+struct DerivedFromQObject : public QObject {
+  DerivedFromQObject(QObject *parent);
+};
+
+class MyQtUser {
+  DerivedFromQObject *noParent, *constructorParent, *laterParent;
+
+  MyQtUser(QObject *parent) {
+    // This object sets its parent pointer to null and thus must be deleted
+    // manually.
+    noParent = new DerivedFromQObject(nullptr); // BAD
+
+    // This object does not need to be deleted because it will be deleted by
+    // its parent object when the time is right.
+    constructorParent = new DerivedFromQObject(parent); // GOOD [FALSE POSITIVE]
+
+    laterParent = new DerivedFromQObject(nullptr); // GOOD [FALSE POSITIVE]
+    laterParent->setParent(parent);
+  }
+};

--- a/cpp/ql/test/query-tests/jsf/4.10 Classes/AV Rule 79/QObject.cpp
+++ b/cpp/ql/test/query-tests/jsf/4.10 Classes/AV Rule 79/QObject.cpp
@@ -13,13 +13,13 @@ class MyQtUser {
   MyQtUser(QObject *parent) {
     // This object sets its parent pointer to null and thus must be deleted
     // manually.
-    noParent = new DerivedFromQObject(nullptr); // BAD
+    noParent = new DerivedFromQObject(nullptr); // BAD [NOT DETECTED]
 
     // This object does not need to be deleted because it will be deleted by
     // its parent object when the time is right.
-    constructorParent = new DerivedFromQObject(parent); // GOOD [FALSE POSITIVE]
+    constructorParent = new DerivedFromQObject(parent); // GOOD
 
-    laterParent = new DerivedFromQObject(nullptr); // GOOD [FALSE POSITIVE]
+    laterParent = new DerivedFromQObject(nullptr); // GOOD
     laterParent->setParent(parent);
   }
 };


### PR DESCRIPTION
This should address the false positives reported at https://discuss.lgtm.com/t/false-positive-for-qt-object-hierarchy/1922. It turns out we had support for Qt all along, but it was one typo away from working.