### PR TITLE
Python: Fix false positive for `py/insecure-default-protocol`.

### DIFF
--- a/python/ql/src/Security/CWE-327/InsecureDefaultProtocol.ql
+++ b/python/ql/src/Security/CWE-327/InsecureDefaultProtocol.ql
@@ -22,16 +22,17 @@ ClassObject ssl_Context_class() {
 
 CallNode unsafe_call(string method_name) {
     result = ssl_wrap_socket().getACall() and
+    not exists(result.getArgByName("ssl_version")) and
     method_name = "deprecated method ssl.wrap_socket"
     or
     result = ssl_Context_class().getACall() and
+    not exists(result.getArgByName("protocol")) and
     method_name = "ssl.SSLContext"
 }
 
 from CallNode call, string method_name
 where 
-    call = unsafe_call(method_name) and
-    not exists(call.getArgByName("ssl_version"))
+    call = unsafe_call(method_name)
 select call, "Call to " + method_name + " does not specify a protocol, which may result in an insecure default being used."
 
 

--- a/python/ql/src/Security/CWE-327/InsecureDefaultProtocol.ql
+++ b/python/ql/src/Security/CWE-327/InsecureDefaultProtocol.ql
@@ -27,6 +27,7 @@ CallNode unsafe_call(string method_name) {
     or
     result = ssl_Context_class().getACall() and
     not exists(result.getArgByName("protocol")) and
+    not exists(result.getArg(0)) and
     method_name = "ssl.SSLContext"
 }
 

--- a/python/ql/src/Security/CWE-327/InsecureProtocol.ql
+++ b/python/ql/src/Security/CWE-327/InsecureProtocol.ql
@@ -45,8 +45,12 @@ private ModuleObject the_pyOpenSSL_module() {
  * a protocol constant, e.g. if it has been removed in later versions of the `ssl`
  * library.
  */
-predicate probable_insecure_ssl_constant(CallNode call, string insecure_version) {
-    exists(ControlFlowNode arg | arg = call.getArgByName("ssl_version") |
+bindingset[named_argument]
+predicate probable_insecure_ssl_constant(CallNode call, string insecure_version, string named_argument) {
+    exists(ControlFlowNode arg |
+        arg = call.getArgByName(named_argument) or
+        arg = call.getArg(0)
+    |
         arg.(AttrNode).getObject(insecure_version).refersTo(the_ssl_module())
         or
         arg.(NameNode).getId() = insecure_version and
@@ -57,21 +61,23 @@ predicate probable_insecure_ssl_constant(CallNode call, string insecure_version)
     )
 }
 
-predicate unsafe_ssl_wrap_socket_call(CallNode call, string method_name, string insecure_version) {
+predicate unsafe_ssl_wrap_socket_call(CallNode call, string method_name, string insecure_version, string named_argument) {
     (
         call = ssl_wrap_socket().getACall() and
-        method_name = "deprecated method ssl.wrap_socket"
+        method_name = "deprecated method ssl.wrap_socket" and
+        named_argument = "ssl_version"
         or
         call = ssl_Context_class().getACall() and
+        named_argument = "protocol" and
         method_name = "ssl.SSLContext"
     )
     and
     insecure_version = insecure_version_name()
     and
     (
-        call.getArgByName("ssl_version").refersTo(the_ssl_module().attr(insecure_version))
+        call.getArgByName(named_argument).refersTo(the_ssl_module().attr(insecure_version))
         or
-        probable_insecure_ssl_constant(call, insecure_version)
+        probable_insecure_ssl_constant(call, insecure_version, named_argument)
     )
 }
 
@@ -87,7 +93,7 @@ predicate unsafe_pyOpenSSL_Context_call(CallNode call, string insecure_version) 
 
 from CallNode call, string method_name, string insecure_version
 where
-    unsafe_ssl_wrap_socket_call(call, method_name, insecure_version)
+    unsafe_ssl_wrap_socket_call(call, method_name, insecure_version, _)
 or
     unsafe_pyOpenSSL_Context_call(call, insecure_version) and method_name = "pyOpenSSL.SSL.Context"
 select call, "Insecure SSL/TLS protocol version " + insecure_version + " specified in call to " + method_name + "."

--- a/python/ql/test/query-tests/Security/CWE-327/InsecureProtocol.expected
+++ b/python/ql/test/query-tests/Security/CWE-327/InsecureProtocol.expected
@@ -11,3 +11,4 @@
 | InsecureProtocol.py:32:1:32:19 | ControlFlowNode for Attribute() | Insecure SSL/TLS protocol version SSLv2_METHOD specified in call to pyOpenSSL.SSL.Context. |
 | InsecureProtocol.py:48:1:48:43 | ControlFlowNode for Attribute() | Insecure SSL/TLS protocol version PROTOCOL_SSLv2 specified in call to deprecated method ssl.wrap_socket. |
 | InsecureProtocol.py:49:1:49:35 | ControlFlowNode for SSLContext() | Insecure SSL/TLS protocol version PROTOCOL_SSLv2 specified in call to ssl.SSLContext. |
+| InsecureProtocol.py:52:1:52:33 | ControlFlowNode for Attribute() | Insecure SSL/TLS protocol version SSLv23_METHOD specified in call to ssl.SSLContext. |

--- a/python/ql/test/query-tests/Security/CWE-327/InsecureProtocol.expected
+++ b/python/ql/test/query-tests/Security/CWE-327/InsecureProtocol.expected
@@ -1,13 +1,13 @@
 | InsecureProtocol.py:6:1:6:47 | ControlFlowNode for Attribute() | Insecure SSL/TLS protocol version PROTOCOL_SSLv2 specified in call to deprecated method ssl.wrap_socket. |
 | InsecureProtocol.py:7:1:7:47 | ControlFlowNode for Attribute() | Insecure SSL/TLS protocol version PROTOCOL_SSLv3 specified in call to deprecated method ssl.wrap_socket. |
 | InsecureProtocol.py:8:1:8:47 | ControlFlowNode for Attribute() | Insecure SSL/TLS protocol version PROTOCOL_TLSv1 specified in call to deprecated method ssl.wrap_socket. |
-| InsecureProtocol.py:10:1:10:42 | ControlFlowNode for SSLContext() | Insecure SSL/TLS protocol version PROTOCOL_SSLv2 specified in call to ssl.SSLContext. |
-| InsecureProtocol.py:11:1:11:42 | ControlFlowNode for SSLContext() | Insecure SSL/TLS protocol version PROTOCOL_SSLv3 specified in call to ssl.SSLContext. |
-| InsecureProtocol.py:12:1:12:42 | ControlFlowNode for SSLContext() | Insecure SSL/TLS protocol version PROTOCOL_TLSv1 specified in call to ssl.SSLContext. |
+| InsecureProtocol.py:10:1:10:39 | ControlFlowNode for SSLContext() | Insecure SSL/TLS protocol version PROTOCOL_SSLv2 specified in call to ssl.SSLContext. |
+| InsecureProtocol.py:11:1:11:39 | ControlFlowNode for SSLContext() | Insecure SSL/TLS protocol version PROTOCOL_SSLv3 specified in call to ssl.SSLContext. |
+| InsecureProtocol.py:12:1:12:39 | ControlFlowNode for SSLContext() | Insecure SSL/TLS protocol version PROTOCOL_TLSv1 specified in call to ssl.SSLContext. |
 | InsecureProtocol.py:14:1:14:29 | ControlFlowNode for Attribute() | Insecure SSL/TLS protocol version SSLv2_METHOD specified in call to pyOpenSSL.SSL.Context. |
 | InsecureProtocol.py:15:1:15:30 | ControlFlowNode for Attribute() | Insecure SSL/TLS protocol version SSLv23_METHOD specified in call to pyOpenSSL.SSL.Context. |
 | InsecureProtocol.py:16:1:16:29 | ControlFlowNode for Attribute() | Insecure SSL/TLS protocol version SSLv3_METHOD specified in call to pyOpenSSL.SSL.Context. |
 | InsecureProtocol.py:17:1:17:29 | ControlFlowNode for Attribute() | Insecure SSL/TLS protocol version TLSv1_METHOD specified in call to pyOpenSSL.SSL.Context. |
 | InsecureProtocol.py:32:1:32:19 | ControlFlowNode for Attribute() | Insecure SSL/TLS protocol version SSLv2_METHOD specified in call to pyOpenSSL.SSL.Context. |
 | InsecureProtocol.py:48:1:48:43 | ControlFlowNode for Attribute() | Insecure SSL/TLS protocol version PROTOCOL_SSLv2 specified in call to deprecated method ssl.wrap_socket. |
-| InsecureProtocol.py:49:1:49:38 | ControlFlowNode for SSLContext() | Insecure SSL/TLS protocol version PROTOCOL_SSLv2 specified in call to ssl.SSLContext. |
+| InsecureProtocol.py:49:1:49:35 | ControlFlowNode for SSLContext() | Insecure SSL/TLS protocol version PROTOCOL_SSLv2 specified in call to ssl.SSLContext. |

--- a/python/ql/test/query-tests/Security/CWE-327/InsecureProtocol.py
+++ b/python/ql/test/query-tests/Security/CWE-327/InsecureProtocol.py
@@ -48,3 +48,5 @@ from ssl import PROTOCOL_SSLv2
 ssl.wrap_socket(ssl_version=PROTOCOL_SSLv2)
 SSLContext(protocol=PROTOCOL_SSLv2)
 
+# FP for insecure default
+ssl.SSLContext(ssl.SSLv23_METHOD)

--- a/python/ql/test/query-tests/Security/CWE-327/InsecureProtocol.py
+++ b/python/ql/test/query-tests/Security/CWE-327/InsecureProtocol.py
@@ -7,9 +7,9 @@ ssl.wrap_socket(ssl_version=ssl.PROTOCOL_SSLv2)
 ssl.wrap_socket(ssl_version=ssl.PROTOCOL_SSLv3)
 ssl.wrap_socket(ssl_version=ssl.PROTOCOL_TLSv1)
 
-SSLContext(ssl_version=ssl.PROTOCOL_SSLv2)
-SSLContext(ssl_version=ssl.PROTOCOL_SSLv3)
-SSLContext(ssl_version=ssl.PROTOCOL_TLSv1)
+SSLContext(protocol=ssl.PROTOCOL_SSLv2)
+SSLContext(protocol=ssl.PROTOCOL_SSLv3)
+SSLContext(protocol=ssl.PROTOCOL_TLSv1)
 
 SSL.Context(SSL.SSLv2_METHOD)
 SSL.Context(SSL.SSLv23_METHOD)
@@ -34,7 +34,7 @@ SSL.Context(METHOD)
 # secure versions
 
 ssl.wrap_socket(ssl_version=ssl.PROTOCOL_TLSv1_1)
-SSLContext(ssl_version=ssl.PROTOCOL_TLSv1_1)
+SSLContext(protocol=ssl.PROTOCOL_TLSv1_1)
 SSL.Context(SSL.TLSv1_1_METHOD)
 
 # possibly insecure default
@@ -46,5 +46,5 @@ context = SSLContext()
 from ssl import PROTOCOL_SSLv2
 
 ssl.wrap_socket(ssl_version=PROTOCOL_SSLv2)
-SSLContext(ssl_version=PROTOCOL_SSLv2)
+SSLContext(protocol=PROTOCOL_SSLv2)
 


### PR DESCRIPTION
Also fixes a bit of confusion with regard to named arguments: even though they accept the same protocols, `ssl.wrap_socket` uses `ssl_version` for the named argument where `ssl.SSLContext` uses `protocol`.

These two fixes are in separate commits.