### PR TITLE
JS: misc. improvements for koa

### DIFF
--- a/change-notes/1.21/analysis-javascript.md
+++ b/change-notes/1.21/analysis-javascript.md
@@ -3,6 +3,7 @@
 ## General improvements
 
 * Support for the following frameworks and libraries has been improved:
+  - [koa](https://github.com/koajs/koa)
   - [socket.io](http://socket.io)
 
 * The security queries now track data flow through Base64 decoders such as the Node.js `Buffer` class, the DOM function `atob`, and a number of npm packages intcluding [`abab`](https://www.npmjs.com/package/abab), [`atob`](https://www.npmjs.com/package/atob), [`btoa`](https://www.npmjs.com/package/btoa), [`base-64`](https://www.npmjs.com/package/base-64), [`js-base64`](https://www.npmjs.com/package/js-base64), [`Base64.js`](https://www.npmjs.com/package/Base64) and [`base64-js`](https://www.npmjs.com/package/base64-js).

--- a/javascript/ql/src/semmle/javascript/frameworks/Koa.qll
+++ b/javascript/ql/src/semmle/javascript/frameworks/Koa.qll
@@ -291,4 +291,20 @@ module Koa {
 
     override RouteHandler getRouteHandler() { result = rh }
   }
+
+  /**
+   * An invocation of the `redirect` method of an HTTP response object.
+   */
+  private class RedirectInvocation extends HTTP::RedirectInvocation, MethodCallExpr {
+    RouteHandler rh;
+
+    RedirectInvocation() {
+      this.(MethodCallExpr).calls(rh.getAResponseOrContextExpr(), "redirect")
+    }
+
+    override Expr getUrlArgument() { result = getArgument(0) }
+
+    override RouteHandler getRouteHandler() { result = rh }
+  }
+
 }

--- a/javascript/ql/src/semmle/javascript/frameworks/Koa.qll
+++ b/javascript/ql/src/semmle/javascript/frameworks/Koa.qll
@@ -1,3 +1,4 @@
+
 /**
  * Provides classes for working with [Koa](https://koajs.com) applications.
  */
@@ -63,18 +64,13 @@ module Koa {
      * Gets an expression that contains the context or response
      * object of a route handler invocation.
      */
-    Expr getAResponseOrContextExpr() {
-      result = getAResponseExpr() or result = getAContextExpr()
-    }
+    Expr getAResponseOrContextExpr() { result = getAResponseExpr() or result = getAContextExpr() }
 
     /**
      * Gets an expression that contains the context or request
      * object of a route handler invocation.
      */
-    Expr getARequestOrContextExpr() {
-      result = getARequestExpr() or result = getAContextExpr()
-    }
-
+    Expr getARequestOrContextExpr() { result = getARequestExpr() or result = getAContextExpr() }
   }
 
   /**
@@ -184,7 +180,7 @@ module Koa {
         exists(string propName |
           kind = "url" and
           this.asExpr().(PropAccess).accesses(e, propName)
-          |
+        |
           propName = "url"
           or
           propName = "originalUrl"
@@ -221,7 +217,7 @@ module Koa {
 
   private DataFlow::Node getAQueryParameterAccess(RouteHandler rh) {
     // `ctx.query.name` or `ctx.request.query.name`
-    exists (PropAccess q |
+    exists(PropAccess q |
       q.accesses(rh.getARequestOrContextExpr(), "query") and
       result = q.flow().(DataFlow::SourceNode).getAPropertyRead()
     )
@@ -288,7 +284,9 @@ module Koa {
 
     ResponseSendArgument() {
       exists(DataFlow::PropWrite pwn |
-        pwn.writes(DataFlow::valueNode(rh.getAResponseOrContextExpr()), "body", DataFlow::valueNode(this))
+        pwn
+            .writes(DataFlow::valueNode(rh.getAResponseOrContextExpr()), "body",
+              DataFlow::valueNode(this))
       )
     }
 
@@ -301,13 +299,10 @@ module Koa {
   private class RedirectInvocation extends HTTP::RedirectInvocation, MethodCallExpr {
     RouteHandler rh;
 
-    RedirectInvocation() {
-      this.(MethodCallExpr).calls(rh.getAResponseOrContextExpr(), "redirect")
-    }
+    RedirectInvocation() { this.(MethodCallExpr).calls(rh.getAResponseOrContextExpr(), "redirect") }
 
     override Expr getUrlArgument() { result = getArgument(0) }
 
     override RouteHandler getRouteHandler() { result = rh }
   }
-
 }

--- a/javascript/ql/src/semmle/javascript/frameworks/Koa.qll
+++ b/javascript/ql/src/semmle/javascript/frameworks/Koa.qll
@@ -202,7 +202,7 @@ module Koa {
           e instanceof ContextExpr and
           kind = "cookie" and
           cookies.accesses(e, "cookies") and
-          this.asExpr().(MethodCallExpr).calls(cookies, "get")
+          this = cookies.flow().(DataFlow::SourceNode).getAMethodCall("get")
         )
         or
         exists(RequestHeaderAccess access | access = this |
@@ -221,7 +221,10 @@ module Koa {
 
   private DataFlow::Node getAQueryParameterAccess(RouteHandler rh) {
     // `ctx.query.name` or `ctx.request.query.name`
-    result.asExpr().(PropAccess).getBase().(PropAccess).accesses(rh.getARequestOrContextExpr(), "query")
+    exists (PropAccess q |
+      q.accesses(rh.getARequestOrContextExpr(), "query") and
+      result = q.flow().(DataFlow::SourceNode).getAPropertyRead()
+    )
   }
 
   /**
@@ -235,7 +238,7 @@ module Koa {
         exists(string propName, PropAccess headers |
           // `ctx.request.header.<name>`, `ctx.request.headers.<name>`
           headers.accesses(e, propName) and
-          this.asExpr().(PropAccess).accesses(headers, _)
+          this = headers.flow().(DataFlow::SourceNode).getAPropertyRead()
         |
           propName = "header" or
           propName = "headers"

--- a/javascript/ql/test/library-tests/frameworks/koa/RedirectInvocation.qll
+++ b/javascript/ql/test/library-tests/frameworks/koa/RedirectInvocation.qll
@@ -1,6 +1,9 @@
+
 import javascript
 
-query predicate test_RedirectInvocation(HTTP::RedirectInvocation redirect, Expr url, HTTP::RouteHandler rh) {
+query predicate test_RedirectInvocation(
+  HTTP::RedirectInvocation redirect, Expr url, HTTP::RouteHandler rh
+) {
   redirect.getUrlArgument() = url and
   redirect.getRouteHandler() = rh
 }

--- a/javascript/ql/test/library-tests/frameworks/koa/RedirectInvocation.qll
+++ b/javascript/ql/test/library-tests/frameworks/koa/RedirectInvocation.qll
@@ -1,0 +1,6 @@
+import javascript
+
+query predicate test_RedirectInvocation(HTTP::RedirectInvocation redirect, Expr url, HTTP::RouteHandler rh) {
+  redirect.getUrlArgument() = url and
+  redirect.getRouteHandler() = rh
+}

--- a/javascript/ql/test/library-tests/frameworks/koa/src/koa.js
+++ b/javascript/ql/test/library-tests/frameworks/koa/src/koa.js
@@ -43,3 +43,14 @@ app2.use(async ctx => {
 	ctx.redirect(url);
 	ctx.response.redirect(url);
 });
+
+app2.use(async ctx => {
+	var cookies = ctx.cookies;
+	cookies.get();
+
+	var query = ctx.query;
+	query.foo;
+
+	var headers = ctx.headers;
+	headers.foo;
+});

--- a/javascript/ql/test/library-tests/frameworks/koa/src/koa.js
+++ b/javascript/ql/test/library-tests/frameworks/koa/src/koa.js
@@ -26,3 +26,20 @@ app2.use(function handler2(ctx){ // HTTP::RouteHandler
   ctx.request.get('bar');
   ctx.cookies.get('baz');
 });
+
+app2.use(async ctx => {
+	ctx.body = x;
+	ctx.body;
+	ctx.query.foo;
+	ctx.url;
+	ctx.originalUrl;
+	ctx.href;
+	ctx.header.bar;
+	ctx.headers.bar;
+	ctx.set('bar');
+	ctx.get('bar');
+
+	var url = ctx.query.target;
+	ctx.redirect(url);
+	ctx.response.redirect(url);
+});

--- a/javascript/ql/test/library-tests/frameworks/koa/tests.expected
+++ b/javascript/ql/test/library-tests/frameworks/koa/tests.expected
@@ -161,3 +161,5 @@ test_ContextExpr
 | src/koa.js:43:2:43:4 | ctx | src/koa.js:30:10:45:1 | async c ... url);\\n} |
 | src/koa.js:44:2:44:4 | ctx | src/koa.js:30:10:45:1 | async c ... url);\\n} |
 test_RedirectInvocation
+| src/koa.js:43:2:43:18 | ctx.redirect(url) | src/koa.js:43:15:43:17 | url | src/koa.js:30:10:45:1 | async c ... url);\\n} |
+| src/koa.js:44:2:44:27 | ctx.res ... ct(url) | src/koa.js:44:24:44:26 | url | src/koa.js:30:10:45:1 | async c ... url);\\n} |

--- a/javascript/ql/test/library-tests/frameworks/koa/tests.expected
+++ b/javascript/ql/test/library-tests/frameworks/koa/tests.expected
@@ -1,6 +1,7 @@
 test_RouteSetup
 | src/koa.js:8:1:8:18 | app2.use(handler1) |
 | src/koa.js:10:1:28:2 | app2.us ... z');\\n}) |
+| src/koa.js:30:1:45:2 | app2.us ... rl);\\n}) |
 test_RequestInputAccess
 | src/koa.js:19:3:19:18 | ctx.request.body | body | src/koa.js:10:10:28:1 | functio ... az');\\n} |
 | src/koa.js:20:3:20:23 | ctx.req ... ery.foo | parameter | src/koa.js:10:10:28:1 | functio ... az');\\n} |
@@ -29,6 +30,7 @@ test_ResponseExpr
 | src/koa.js:15:13:15:24 | ctx.response | src/koa.js:10:10:28:1 | functio ... az');\\n} |
 | src/koa.js:16:3:16:5 | rsp | src/koa.js:10:10:28:1 | functio ... az');\\n} |
 | src/koa.js:18:3:18:14 | ctx.response | src/koa.js:10:10:28:1 | functio ... az');\\n} |
+| src/koa.js:44:2:44:13 | ctx.response | src/koa.js:30:10:45:1 | async c ... url);\\n} |
 test_RouteHandler_getAContextExpr
 | src/koa.js:10:10:28:1 | functio ... az');\\n} | src/koa.js:11:3:11:6 | this |
 | src/koa.js:10:10:28:1 | functio ... az');\\n} | src/koa.js:12:3:12:6 | this |
@@ -45,15 +47,30 @@ test_RouteHandler_getAContextExpr
 | src/koa.js:10:10:28:1 | functio ... az');\\n} | src/koa.js:25:3:25:5 | ctx |
 | src/koa.js:10:10:28:1 | functio ... az');\\n} | src/koa.js:26:3:26:5 | ctx |
 | src/koa.js:10:10:28:1 | functio ... az');\\n} | src/koa.js:27:3:27:5 | ctx |
+| src/koa.js:30:10:45:1 | async c ... url);\\n} | src/koa.js:31:2:31:4 | ctx |
+| src/koa.js:30:10:45:1 | async c ... url);\\n} | src/koa.js:32:2:32:4 | ctx |
+| src/koa.js:30:10:45:1 | async c ... url);\\n} | src/koa.js:33:2:33:4 | ctx |
+| src/koa.js:30:10:45:1 | async c ... url);\\n} | src/koa.js:34:2:34:4 | ctx |
+| src/koa.js:30:10:45:1 | async c ... url);\\n} | src/koa.js:35:2:35:4 | ctx |
+| src/koa.js:30:10:45:1 | async c ... url);\\n} | src/koa.js:36:2:36:4 | ctx |
+| src/koa.js:30:10:45:1 | async c ... url);\\n} | src/koa.js:37:2:37:4 | ctx |
+| src/koa.js:30:10:45:1 | async c ... url);\\n} | src/koa.js:38:2:38:4 | ctx |
+| src/koa.js:30:10:45:1 | async c ... url);\\n} | src/koa.js:39:2:39:4 | ctx |
+| src/koa.js:30:10:45:1 | async c ... url);\\n} | src/koa.js:40:2:40:4 | ctx |
+| src/koa.js:30:10:45:1 | async c ... url);\\n} | src/koa.js:42:12:42:14 | ctx |
+| src/koa.js:30:10:45:1 | async c ... url);\\n} | src/koa.js:43:2:43:4 | ctx |
+| src/koa.js:30:10:45:1 | async c ... url);\\n} | src/koa.js:44:2:44:4 | ctx |
 test_HeaderDefinition
 | src/koa.js:11:3:11:25 | this.se ... 1', '') | src/koa.js:10:10:28:1 | functio ... az');\\n} |
 | src/koa.js:12:3:12:37 | this.re ... 2', '') | src/koa.js:10:10:28:1 | functio ... az');\\n} |
 | src/koa.js:13:3:13:24 | ctx.set ... 3', '') | src/koa.js:10:10:28:1 | functio ... az');\\n} |
 | src/koa.js:14:3:14:36 | ctx.res ... 4', '') | src/koa.js:10:10:28:1 | functio ... az');\\n} |
 | src/koa.js:16:3:16:27 | rsp.hea ... 5', '') | src/koa.js:10:10:28:1 | functio ... az');\\n} |
+| src/koa.js:39:2:39:15 | ctx.set('bar') | src/koa.js:30:10:45:1 | async c ... url);\\n} |
 test_RouteSetup_getServer
 | src/koa.js:8:1:8:18 | app2.use(handler1) | src/koa.js:5:12:5:20 | new Koa() |
 | src/koa.js:10:1:28:2 | app2.us ... z');\\n}) | src/koa.js:5:12:5:20 | new Koa() |
+| src/koa.js:30:1:45:2 | app2.us ... rl);\\n}) | src/koa.js:5:12:5:20 | new Koa() |
 test_HeaderDefinition_getAHeaderName
 | src/koa.js:11:3:11:25 | this.se ... 1', '') | header1 |
 | src/koa.js:12:3:12:37 | this.re ... 2', '') | header2 |
@@ -70,17 +87,20 @@ test_RouteHandler_getAResponseExpr
 | src/koa.js:10:10:28:1 | functio ... az');\\n} | src/koa.js:15:13:15:24 | ctx.response |
 | src/koa.js:10:10:28:1 | functio ... az');\\n} | src/koa.js:16:3:16:5 | rsp |
 | src/koa.js:10:10:28:1 | functio ... az');\\n} | src/koa.js:18:3:18:14 | ctx.response |
+| src/koa.js:30:10:45:1 | async c ... url);\\n} | src/koa.js:44:2:44:13 | ctx.response |
 test_ResponseSendArgument
 | src/koa.js:18:23:18:23 | x | src/koa.js:10:10:28:1 | functio ... az');\\n} |
 test_RouteSetup_getARouteHandler
 | src/koa.js:8:1:8:18 | app2.use(handler1) | src/koa.js:7:1:7:22 | functio ... r1() {} |
 | src/koa.js:10:1:28:2 | app2.us ... z');\\n}) | src/koa.js:10:10:28:1 | functio ... az');\\n} |
+| src/koa.js:30:1:45:2 | app2.us ... rl);\\n}) | src/koa.js:30:10:45:1 | async c ... url);\\n} |
 test_AppDefinition
 | src/koa.js:2:12:2:33 | new (re ... oa'))() |
 | src/koa.js:5:12:5:20 | new Koa() |
 test_RouteHandler
 | src/koa.js:7:1:7:22 | functio ... r1() {} | src/koa.js:5:12:5:20 | new Koa() |
 | src/koa.js:10:10:28:1 | functio ... az');\\n} | src/koa.js:5:12:5:20 | new Koa() |
+| src/koa.js:30:10:45:1 | async c ... url);\\n} | src/koa.js:5:12:5:20 | new Koa() |
 test_RequestExpr
 | src/koa.js:19:3:19:13 | ctx.request | src/koa.js:10:10:28:1 | functio ... az');\\n} |
 | src/koa.js:20:3:20:13 | ctx.request | src/koa.js:10:10:28:1 | functio ... az');\\n} |
@@ -115,3 +135,17 @@ test_ContextExpr
 | src/koa.js:25:3:25:5 | ctx | src/koa.js:10:10:28:1 | functio ... az');\\n} |
 | src/koa.js:26:3:26:5 | ctx | src/koa.js:10:10:28:1 | functio ... az');\\n} |
 | src/koa.js:27:3:27:5 | ctx | src/koa.js:10:10:28:1 | functio ... az');\\n} |
+| src/koa.js:31:2:31:4 | ctx | src/koa.js:30:10:45:1 | async c ... url);\\n} |
+| src/koa.js:32:2:32:4 | ctx | src/koa.js:30:10:45:1 | async c ... url);\\n} |
+| src/koa.js:33:2:33:4 | ctx | src/koa.js:30:10:45:1 | async c ... url);\\n} |
+| src/koa.js:34:2:34:4 | ctx | src/koa.js:30:10:45:1 | async c ... url);\\n} |
+| src/koa.js:35:2:35:4 | ctx | src/koa.js:30:10:45:1 | async c ... url);\\n} |
+| src/koa.js:36:2:36:4 | ctx | src/koa.js:30:10:45:1 | async c ... url);\\n} |
+| src/koa.js:37:2:37:4 | ctx | src/koa.js:30:10:45:1 | async c ... url);\\n} |
+| src/koa.js:38:2:38:4 | ctx | src/koa.js:30:10:45:1 | async c ... url);\\n} |
+| src/koa.js:39:2:39:4 | ctx | src/koa.js:30:10:45:1 | async c ... url);\\n} |
+| src/koa.js:40:2:40:4 | ctx | src/koa.js:30:10:45:1 | async c ... url);\\n} |
+| src/koa.js:42:12:42:14 | ctx | src/koa.js:30:10:45:1 | async c ... url);\\n} |
+| src/koa.js:43:2:43:4 | ctx | src/koa.js:30:10:45:1 | async c ... url);\\n} |
+| src/koa.js:44:2:44:4 | ctx | src/koa.js:30:10:45:1 | async c ... url);\\n} |
+test_RedirectInvocation

--- a/javascript/ql/test/library-tests/frameworks/koa/tests.expected
+++ b/javascript/ql/test/library-tests/frameworks/koa/tests.expected
@@ -2,6 +2,7 @@ test_RouteSetup
 | src/koa.js:8:1:8:18 | app2.use(handler1) |
 | src/koa.js:10:1:28:2 | app2.us ... z');\\n}) |
 | src/koa.js:30:1:45:2 | app2.us ... rl);\\n}) |
+| src/koa.js:47:1:56:2 | app2.us ... foo;\\n}) |
 test_RequestInputAccess
 | src/koa.js:19:3:19:18 | ctx.request.body | body | src/koa.js:10:10:28:1 | functio ... az');\\n} |
 | src/koa.js:20:3:20:23 | ctx.req ... ery.foo | parameter | src/koa.js:10:10:28:1 | functio ... az');\\n} |
@@ -68,6 +69,9 @@ test_RouteHandler_getAContextExpr
 | src/koa.js:30:10:45:1 | async c ... url);\\n} | src/koa.js:42:12:42:14 | ctx |
 | src/koa.js:30:10:45:1 | async c ... url);\\n} | src/koa.js:43:2:43:4 | ctx |
 | src/koa.js:30:10:45:1 | async c ... url);\\n} | src/koa.js:44:2:44:4 | ctx |
+| src/koa.js:47:10:56:1 | async c ... .foo;\\n} | src/koa.js:48:16:48:18 | ctx |
+| src/koa.js:47:10:56:1 | async c ... .foo;\\n} | src/koa.js:51:14:51:16 | ctx |
+| src/koa.js:47:10:56:1 | async c ... .foo;\\n} | src/koa.js:54:16:54:18 | ctx |
 test_HeaderDefinition
 | src/koa.js:11:3:11:25 | this.se ... 1', '') | src/koa.js:10:10:28:1 | functio ... az');\\n} |
 | src/koa.js:12:3:12:37 | this.re ... 2', '') | src/koa.js:10:10:28:1 | functio ... az');\\n} |
@@ -79,6 +83,7 @@ test_RouteSetup_getServer
 | src/koa.js:8:1:8:18 | app2.use(handler1) | src/koa.js:5:12:5:20 | new Koa() |
 | src/koa.js:10:1:28:2 | app2.us ... z');\\n}) | src/koa.js:5:12:5:20 | new Koa() |
 | src/koa.js:30:1:45:2 | app2.us ... rl);\\n}) | src/koa.js:5:12:5:20 | new Koa() |
+| src/koa.js:47:1:56:2 | app2.us ... foo;\\n}) | src/koa.js:5:12:5:20 | new Koa() |
 test_HeaderDefinition_getAHeaderName
 | src/koa.js:11:3:11:25 | this.se ... 1', '') | header1 |
 | src/koa.js:12:3:12:37 | this.re ... 2', '') | header2 |
@@ -106,6 +111,7 @@ test_RouteSetup_getARouteHandler
 | src/koa.js:8:1:8:18 | app2.use(handler1) | src/koa.js:7:1:7:22 | functio ... r1() {} |
 | src/koa.js:10:1:28:2 | app2.us ... z');\\n}) | src/koa.js:10:10:28:1 | functio ... az');\\n} |
 | src/koa.js:30:1:45:2 | app2.us ... rl);\\n}) | src/koa.js:30:10:45:1 | async c ... url);\\n} |
+| src/koa.js:47:1:56:2 | app2.us ... foo;\\n}) | src/koa.js:47:10:56:1 | async c ... .foo;\\n} |
 test_AppDefinition
 | src/koa.js:2:12:2:33 | new (re ... oa'))() |
 | src/koa.js:5:12:5:20 | new Koa() |
@@ -113,6 +119,7 @@ test_RouteHandler
 | src/koa.js:7:1:7:22 | functio ... r1() {} | src/koa.js:5:12:5:20 | new Koa() |
 | src/koa.js:10:10:28:1 | functio ... az');\\n} | src/koa.js:5:12:5:20 | new Koa() |
 | src/koa.js:30:10:45:1 | async c ... url);\\n} | src/koa.js:5:12:5:20 | new Koa() |
+| src/koa.js:47:10:56:1 | async c ... .foo;\\n} | src/koa.js:5:12:5:20 | new Koa() |
 test_RequestExpr
 | src/koa.js:19:3:19:13 | ctx.request | src/koa.js:10:10:28:1 | functio ... az');\\n} |
 | src/koa.js:20:3:20:13 | ctx.request | src/koa.js:10:10:28:1 | functio ... az');\\n} |
@@ -160,6 +167,9 @@ test_ContextExpr
 | src/koa.js:42:12:42:14 | ctx | src/koa.js:30:10:45:1 | async c ... url);\\n} |
 | src/koa.js:43:2:43:4 | ctx | src/koa.js:30:10:45:1 | async c ... url);\\n} |
 | src/koa.js:44:2:44:4 | ctx | src/koa.js:30:10:45:1 | async c ... url);\\n} |
+| src/koa.js:48:16:48:18 | ctx | src/koa.js:47:10:56:1 | async c ... .foo;\\n} |
+| src/koa.js:51:14:51:16 | ctx | src/koa.js:47:10:56:1 | async c ... .foo;\\n} |
+| src/koa.js:54:16:54:18 | ctx | src/koa.js:47:10:56:1 | async c ... .foo;\\n} |
 test_RedirectInvocation
 | src/koa.js:43:2:43:18 | ctx.redirect(url) | src/koa.js:43:15:43:17 | url | src/koa.js:30:10:45:1 | async c ... url);\\n} |
 | src/koa.js:44:2:44:27 | ctx.res ... ct(url) | src/koa.js:44:24:44:26 | url | src/koa.js:30:10:45:1 | async c ... url);\\n} |

--- a/javascript/ql/test/library-tests/frameworks/koa/tests.expected
+++ b/javascript/ql/test/library-tests/frameworks/koa/tests.expected
@@ -21,6 +21,9 @@ test_RequestInputAccess
 | src/koa.js:38:2:38:16 | ctx.headers.bar | header | src/koa.js:30:10:45:1 | async c ... url);\\n} |
 | src/koa.js:40:2:40:15 | ctx.get('bar') | header | src/koa.js:30:10:45:1 | async c ... url);\\n} |
 | src/koa.js:42:12:42:27 | ctx.query.target | parameter | src/koa.js:30:10:45:1 | async c ... url);\\n} |
+| src/koa.js:49:2:49:14 | cookies.get() | cookie | src/koa.js:47:10:56:1 | async c ... .foo;\\n} |
+| src/koa.js:52:2:52:10 | query.foo | parameter | src/koa.js:47:10:56:1 | async c ... .foo;\\n} |
+| src/koa.js:55:2:55:12 | headers.foo | header | src/koa.js:47:10:56:1 | async c ... .foo;\\n} |
 test_RouteHandler_getAResponseHeader
 | src/koa.js:10:10:28:1 | functio ... az');\\n} | header1 | src/koa.js:11:3:11:25 | this.se ... 1', '') |
 | src/koa.js:10:10:28:1 | functio ... az');\\n} | header2 | src/koa.js:12:3:12:37 | this.re ... 2', '') |
@@ -97,6 +100,7 @@ test_HeaderAccess
 | src/koa.js:37:2:37:15 | ctx.header.bar | bar |
 | src/koa.js:38:2:38:16 | ctx.headers.bar | bar |
 | src/koa.js:40:2:40:15 | ctx.get('bar') | bar |
+| src/koa.js:55:2:55:12 | headers.foo | foo |
 test_RouteHandler_getAResponseExpr
 | src/koa.js:10:10:28:1 | functio ... az');\\n} | src/koa.js:12:3:12:15 | this.response |
 | src/koa.js:10:10:28:1 | functio ... az');\\n} | src/koa.js:14:3:14:14 | ctx.response |

--- a/javascript/ql/test/library-tests/frameworks/koa/tests.expected
+++ b/javascript/ql/test/library-tests/frameworks/koa/tests.expected
@@ -12,6 +12,14 @@ test_RequestInputAccess
 | src/koa.js:25:3:25:25 | ctx.req ... ers.bar | header | src/koa.js:10:10:28:1 | functio ... az');\\n} |
 | src/koa.js:26:3:26:24 | ctx.req ... ('bar') | header | src/koa.js:10:10:28:1 | functio ... az');\\n} |
 | src/koa.js:27:3:27:24 | ctx.coo ... ('baz') | cookie | src/koa.js:10:10:28:1 | functio ... az');\\n} |
+| src/koa.js:33:2:33:14 | ctx.query.foo | parameter | src/koa.js:30:10:45:1 | async c ... url);\\n} |
+| src/koa.js:34:2:34:8 | ctx.url | url | src/koa.js:30:10:45:1 | async c ... url);\\n} |
+| src/koa.js:35:2:35:16 | ctx.originalUrl | url | src/koa.js:30:10:45:1 | async c ... url);\\n} |
+| src/koa.js:36:2:36:9 | ctx.href | url | src/koa.js:30:10:45:1 | async c ... url);\\n} |
+| src/koa.js:37:2:37:15 | ctx.header.bar | header | src/koa.js:30:10:45:1 | async c ... url);\\n} |
+| src/koa.js:38:2:38:16 | ctx.headers.bar | header | src/koa.js:30:10:45:1 | async c ... url);\\n} |
+| src/koa.js:40:2:40:15 | ctx.get('bar') | header | src/koa.js:30:10:45:1 | async c ... url);\\n} |
+| src/koa.js:42:12:42:27 | ctx.query.target | parameter | src/koa.js:30:10:45:1 | async c ... url);\\n} |
 test_RouteHandler_getAResponseHeader
 | src/koa.js:10:10:28:1 | functio ... az');\\n} | header1 | src/koa.js:11:3:11:25 | this.se ... 1', '') |
 | src/koa.js:10:10:28:1 | functio ... az');\\n} | header2 | src/koa.js:12:3:12:37 | this.re ... 2', '') |
@@ -81,6 +89,9 @@ test_HeaderAccess
 | src/koa.js:24:3:24:24 | ctx.req ... der.bar | bar |
 | src/koa.js:25:3:25:25 | ctx.req ... ers.bar | bar |
 | src/koa.js:26:3:26:24 | ctx.req ... ('bar') | bar |
+| src/koa.js:37:2:37:15 | ctx.header.bar | bar |
+| src/koa.js:38:2:38:16 | ctx.headers.bar | bar |
+| src/koa.js:40:2:40:15 | ctx.get('bar') | bar |
 test_RouteHandler_getAResponseExpr
 | src/koa.js:10:10:28:1 | functio ... az');\\n} | src/koa.js:12:3:12:15 | this.response |
 | src/koa.js:10:10:28:1 | functio ... az');\\n} | src/koa.js:14:3:14:14 | ctx.response |
@@ -90,6 +101,7 @@ test_RouteHandler_getAResponseExpr
 | src/koa.js:30:10:45:1 | async c ... url);\\n} | src/koa.js:44:2:44:13 | ctx.response |
 test_ResponseSendArgument
 | src/koa.js:18:23:18:23 | x | src/koa.js:10:10:28:1 | functio ... az');\\n} |
+| src/koa.js:31:13:31:13 | x | src/koa.js:30:10:45:1 | async c ... url);\\n} |
 test_RouteSetup_getARouteHandler
 | src/koa.js:8:1:8:18 | app2.use(handler1) | src/koa.js:7:1:7:22 | functio ... r1() {} |
 | src/koa.js:10:1:28:2 | app2.us ... z');\\n}) | src/koa.js:10:10:28:1 | functio ... az');\\n} |

--- a/javascript/ql/test/library-tests/frameworks/koa/tests.ql
+++ b/javascript/ql/test/library-tests/frameworks/koa/tests.ql
@@ -16,3 +16,4 @@ import RouteHandler
 import RequestExpr
 import RouteHandler_getARequestExpr
 import ContextExpr
+import RedirectInvocation

--- a/javascript/ql/test/query-tests/Security/CWE-601/ServerSideUrlRedirect/ServerSideUrlRedirect.expected
+++ b/javascript/ql/test/query-tests/Security/CWE-601/ServerSideUrlRedirect/ServerSideUrlRedirect.expected
@@ -22,6 +22,12 @@ nodes
 | express.js:135:23:135:37 | req.params.user |
 | express.js:136:16:136:36 | 'u' + r ... ms.user |
 | express.js:136:22:136:36 | req.params.user |
+| koa.js:6:6:6:27 | url |
+| koa.js:6:12:6:27 | ctx.query.target |
+| koa.js:7:15:7:17 | url |
+| koa.js:8:15:8:26 | `${url}${x}` |
+| koa.js:8:18:8:20 | url |
+| koa.js:14:16:14:18 | url |
 | node.js:6:7:6:52 | target |
 | node.js:6:16:6:39 | url.par ... , true) |
 | node.js:6:16:6:45 | url.par ... ).query |
@@ -60,6 +66,24 @@ edges
 | express.js:134:22:134:36 | req.params.user | express.js:134:16:134:36 | '/' + r ... ms.user |
 | express.js:135:23:135:37 | req.params.user | express.js:135:16:135:37 | '//' +  ... ms.user |
 | express.js:136:22:136:36 | req.params.user | express.js:136:16:136:36 | 'u' + r ... ms.user |
+| koa.js:6:6:6:27 | url | koa.js:7:15:7:17 | url |
+| koa.js:6:6:6:27 | url | koa.js:8:18:8:20 | url |
+| koa.js:6:6:6:27 | url | koa.js:10:40:10:42 | url |
+| koa.js:6:6:6:27 | url | koa.js:10:40:10:42 | url |
+| koa.js:6:6:6:27 | url | koa.js:10:51:10:51 | url |
+| koa.js:6:6:6:27 | url | koa.js:11:6:11:8 | url |
+| koa.js:6:6:6:27 | url | koa.js:14:16:14:18 | url |
+| koa.js:6:12:6:27 | ctx.query.target | koa.js:6:6:6:27 | url |
+| koa.js:8:18:8:20 | url | koa.js:8:15:8:26 | `${url}${x}` |
+| koa.js:10:40:10:42 | url | koa.js:10:51:10:51 | url |
+| koa.js:10:40:10:42 | url | koa.js:10:51:10:51 | url |
+| koa.js:10:40:10:42 | url | koa.js:11:6:11:8 | url |
+| koa.js:10:40:10:42 | url | koa.js:11:6:11:8 | url |
+| koa.js:10:40:10:42 | url | koa.js:14:16:14:18 | url |
+| koa.js:10:40:10:42 | url | koa.js:14:16:14:18 | url |
+| koa.js:10:51:10:51 | url | koa.js:11:6:11:8 | url |
+| koa.js:10:51:10:51 | url | koa.js:14:16:14:18 | url |
+| koa.js:11:6:11:8 | url | koa.js:14:16:14:18 | url |
 | node.js:6:7:6:52 | target | node.js:7:34:7:39 | target |
 | node.js:6:16:6:39 | url.par ... , true) | node.js:6:16:6:45 | url.par ... ).query |
 | node.js:6:16:6:45 | url.par ... ).query | node.js:6:16:6:52 | url.par ... .target |
@@ -95,6 +119,9 @@ edges
 | express.js:134:16:134:36 | '/' + r ... ms.user | express.js:134:22:134:36 | req.params.user | express.js:134:16:134:36 | '/' + r ... ms.user | Untrusted URL redirection due to $@. | express.js:134:22:134:36 | req.params.user | user-provided value |
 | express.js:135:16:135:37 | '//' +  ... ms.user | express.js:135:23:135:37 | req.params.user | express.js:135:16:135:37 | '//' +  ... ms.user | Untrusted URL redirection due to $@. | express.js:135:23:135:37 | req.params.user | user-provided value |
 | express.js:136:16:136:36 | 'u' + r ... ms.user | express.js:136:22:136:36 | req.params.user | express.js:136:16:136:36 | 'u' + r ... ms.user | Untrusted URL redirection due to $@. | express.js:136:22:136:36 | req.params.user | user-provided value |
+| koa.js:7:15:7:17 | url | koa.js:6:12:6:27 | ctx.query.target | koa.js:7:15:7:17 | url | Untrusted URL redirection due to $@. | koa.js:6:12:6:27 | ctx.query.target | user-provided value |
+| koa.js:8:15:8:26 | `${url}${x}` | koa.js:6:12:6:27 | ctx.query.target | koa.js:8:15:8:26 | `${url}${x}` | Untrusted URL redirection due to $@. | koa.js:6:12:6:27 | ctx.query.target | user-provided value |
+| koa.js:14:16:14:18 | url | koa.js:6:12:6:27 | ctx.query.target | koa.js:14:16:14:18 | url | Untrusted URL redirection due to $@. | koa.js:6:12:6:27 | ctx.query.target | user-provided value |
 | node.js:7:34:7:39 | target | node.js:6:26:6:32 | req.url | node.js:7:34:7:39 | target | Untrusted URL redirection due to $@. | node.js:6:26:6:32 | req.url | user-provided value |
 | node.js:15:34:15:45 | '/' + target | node.js:11:26:11:32 | req.url | node.js:15:34:15:45 | '/' + target | Untrusted URL redirection due to $@. | node.js:11:26:11:32 | req.url | user-provided value |
 | node.js:32:34:32:55 | target  ... =" + me | node.js:29:26:29:32 | req.url | node.js:32:34:32:55 | target  ... =" + me | Untrusted URL redirection due to $@. | node.js:29:26:29:32 | req.url | user-provided value |

--- a/javascript/ql/test/query-tests/Security/CWE-601/ServerSideUrlRedirect/koa.js
+++ b/javascript/ql/test/query-tests/Security/CWE-601/ServerSideUrlRedirect/koa.js
@@ -1,0 +1,24 @@
+const Koa = require('koa');
+const url = require('url');
+const app = new Koa();
+
+app.use(async ctx => {
+	var url = ctx.query.target;
+	ctx.redirect(url); // NOT OK
+	ctx.redirect(`${url}${x}`); // NOT OK
+
+	var isCrossDomainRedirect = url.parse(url || '', false, true).hostname;
+	if(!url || isCrossDomainRedirect) {
+		ctx.redirect('/'); // OK
+	} else {
+		ctx.redirect(url); // NOT OK
+	}
+
+	if(!url || isCrossDomainRedirect || ! url.match(VALID)) {
+		ctx.redirect('/'); // OK
+	} else {
+		ctx.redirect(url); // OK
+	}
+});
+
+app.listen(3000);


### PR DESCRIPTION
Three improvements for the koa model:

-   many properties of `ctx.request` and `ctx.response` are also directly available on `ctx`, we now support that
-   three additional uses of `DataFlow::SourceNode`
-   another instance of `HTTP::RedirectInvocation>`, and some tests inspired by a real world situations

Evaluation is ongoing, putting this up early to avoid conflicting too much with an upcoming `TypeTracker` refactoring.