### PR TITLE
JS: fix getAPropertyAttribute timeouts 

### DIFF
--- a/javascript/ql/src/semmle/javascript/dataflow/DataFlow.qll
+++ b/javascript/ql/src/semmle/javascript/dataflow/DataFlow.qll
@@ -496,7 +496,11 @@ module DataFlow {
     override string getPropertyName() { result = odp.getPropertyName() }
 
     override Node getRhs() {
-      odp.getAPropertyAttribute().writes(_, "value", result)
+      // not using `CallToObjectDefineProperty::getAPropertyAttribute` for performance reasons
+      exists(ObjectLiteralNode propdesc |
+        propdesc.flowsTo(odp.getPropertyDescriptor()) and
+        propdesc.hasPropertyWrite("value", result)
+      )
     }
 
     override ControlFlowNode getWriteNode() { result = odp.getAstNode() }


### PR DESCRIPTION
Fixes the recent timeouts by reverting the dataflow change of #1113.

I will run a slightly larger evaluation, but the problematic project no longer hits a timeout (https://git.semmle.com/esben/dist-compare-reports/tree/js/fix-define-property-regression_1553252658109).