### PR TITLE
C#: Introduce `isBranch()` predicate

### DIFF
--- a/csharp/ql/src/semmle/code/cil/BasicBlock.qll
+++ b/csharp/ql/src/semmle/code/cil/BasicBlock.qll
@@ -257,9 +257,7 @@ private module Internal {
     or
     cfn.isJoin()
     or
-    exists(ControlFlowNode pred | pred = cfn.getAPredecessor() |
-      strictcount(pred.getASuccessor()) > 1
-    )
+    cfn.getAPredecessor().isBranch()
   }
 
   /**

--- a/csharp/ql/src/semmle/code/cil/ControlFlow.qll
+++ b/csharp/ql/src/semmle/code/cil/ControlFlow.qll
@@ -104,7 +104,10 @@ class ControlFlowNode extends @cil_controlflow_node {
   Type getType() { none() }
 
   /** Holds if this control flow node has more than one predecessor. */
-  predicate isJoin() { count(getAPredecessor()) > 1 }
+  predicate isJoin() { strictcount(this.getAPredecessor()) > 1 }
+
+  /** Holds if this control flow node has more than one successor. */
+  predicate isBranch() { strictcount(this.getASuccessor()) > 1 }
 }
 
 /**

--- a/csharp/ql/src/semmle/code/csharp/controlflow/BasicBlocks.qll
+++ b/csharp/ql/src/semmle/code/csharp/controlflow/BasicBlocks.qll
@@ -336,9 +336,7 @@ private module Internal {
     or
     cfn.isJoin()
     or
-    exists(ControlFlow::Node pred | pred = cfn.getAPredecessor() |
-      strictcount(pred.getASuccessor()) > 1
-    )
+    cfn.getAPredecessor().isBranch()
   }
 
   /**

--- a/csharp/ql/src/semmle/code/csharp/controlflow/ControlFlowGraph.qll
+++ b/csharp/ql/src/semmle/code/csharp/controlflow/ControlFlowGraph.qll
@@ -273,7 +273,10 @@ module ControlFlow {
     }
 
     /** Holds if this node has more than one predecessor. */
-    predicate isJoin() { strictcount(getAPredecessor()) > 1 }
+    predicate isJoin() { strictcount(this.getAPredecessor()) > 1 }
+
+    /** Holds if this node has more than one successor. */
+    predicate isBranch() { strictcount(this.getASuccessor()) > 1 }
   }
 
   /** Provides different types of control flow nodes. */


### PR DESCRIPTION
We already have `isJoin()`, so it makes sense to have `isBranch()` for symmetry.