### PR TITLE
JS: classify more HTML as generated

### DIFF
--- a/javascript/ql/src/semmle/javascript/GeneratedCode.qll
+++ b/javascript/ql/src/semmle/javascript/GeneratedCode.qll
@@ -134,7 +134,7 @@ private HTML::Element getAStartingElement(File f, int l) {
 
 
 /**
- * Gets the number of HTML elements that starts at line `l` in file `f`.
+ * Gets the number of HTML elements that start at line `l` in file `f`.
  */
 private int countStartingHtmlElements(File f, int l) {
   result = strictcount(getAStartingElement(f, l))

--- a/javascript/ql/src/semmle/javascript/GeneratedCode.qll
+++ b/javascript/ql/src/semmle/javascript/GeneratedCode.qll
@@ -121,6 +121,23 @@ private predicate isGeneratedHtml(File f) {
     e.getName() = "meta" and
     e.getAttributeByName("name").getValue() = "generator"
   )
+  or
+  20 < countStartingHtmlElements(f, _)
+}
+
+/**
+ * Gets an element that starts at line `l` in file `f`.
+ */
+private HTML::Element getAStartingElement(File f, int l) {
+  result.getFile() = f and result.getLocation().getStartLine() = l
+}
+
+
+/**
+ * Gets the number of HTML elements that starts at line `l` in file `f`.
+ */
+private int countStartingHtmlElements(File f, int l) {
+  result = strictcount(getAStartingElement(f, l))
 }
 
 /**

--- a/javascript/ql/test/query-tests/filters/ClassifyFiles/AlmostManyElementsOnLine.html
+++ b/javascript/ql/test/query-tests/filters/ClassifyFiles/AlmostManyElementsOnLine.html
@@ -1,0 +1,4 @@
+<html>
+  <div><div><div><div><div><div><div><div><div><div><div><div><div><div><div><div><div><div><div></div></div></div></div></div></div></div></div></div></div></div></div></div></div></div></div></div></div></div>
+  <script>42</script>
+</html>

--- a/javascript/ql/test/query-tests/filters/ClassifyFiles/ClassifyFiles.expected
+++ b/javascript/ql/test/query-tests/filters/ClassifyFiles/ClassifyFiles.expected
@@ -1,4 +1,5 @@
 | AutoRest.js:0:0:0:0 | AutoRest.js | generated |
+| ManyElementsOnLine.html:0:0:0:0 | ManyElementsOnLine.html | generated |
 | ai.1.2.3-build0123.js:0:0:0:0 | ai.1.2.3-build0123.js | library |
 | bundle-directive.js:0:0:0:0 | bundle-directive.js | generated |
 | data.js:0:0:0:0 | data.js | generated |

--- a/javascript/ql/test/query-tests/filters/ClassifyFiles/ManyElementsOnLine.html
+++ b/javascript/ql/test/query-tests/filters/ClassifyFiles/ManyElementsOnLine.html
@@ -1,0 +1,4 @@
+<html>
+  <div><div><div><div><div><div><div><div><div><div><div><div><div><div><div><div><div><div><div><div><div></div></div></div></div></div></div></div></div></div></div></div></div></div></div></div></div></div></div></div></div></div>
+  <script>42</script>
+</html>


### PR DESCRIPTION
This change is motivated by the query `js/duplicate-html-id` being prone to flagging generated HTML.

The added heuristic for identifying generated HTML is that there are "many" HTML elements that start on the same line.

For now, I have selected `"many" > 20` as the limit, and I have not seen any FPs with that. See <https://lgtm.com/query/7721678073770499188/>, <https://lgtm.com/query/613928986248972020/> for exploratory use of this classifier.

Some examples of files that are classified by this change that are not classified otherwise:

-   <https://lgtm.com/projects/g/rapidpro/rapidpro/snapshot/417239731f0afc3f2017d6b8e8407cb427f91413/files/static/bower/jquery/speed/index.html?sort=name&dir=ASC&mode=list#L0>
-   <https://lgtm.com/projects/g/ckeditor/ckeditor-dev/snapshot/fb1ba41c8a4313ba2d9651b453b4c48b252fb502/files/plugins/magicline/dev/magicline.html?sort=name&dir=ASC&mode=list#L0>
-   <https://lgtm.com/projects/g/alibaba/ice/snapshot/aba04b6a5a5ee0c811f054294e46beef4e2e4e14/files/react-materials/scaffolds/ice-opensource-site/en-us/blog/blog1.html?sort=name&dir=ASC&mode=list#L0>
-   <https://lgtm.com/projects/g/Plateful/plateful-mobile/snapshot/5e819126d8882a5f5191e7b5af58452155b5a11e/files/coverage/Chrome%2036.0.1985%20>(Mac%20OS%20X%2010.9.4)/js/vendor.js.html?sort=name&dir=ASC&mode=list#L0
-   <https://lgtm.com/projects/g/capnmidnight/Primrose/snapshot/12920ddbe9f0c6a9f6076c63bc0bd9bb1840b4fb/files/demos/calendar.html?sort=name&dir=ASC&mode=list#L0>
-   <https://lgtm.com/projects/g/capnmidnight/Primrose/snapshot/12920ddbe9f0c6a9f6076c63bc0bd9bb1840b4fb/files/index.html?sort=name&dir=ASC&mode=list#L0>
-   <https://lgtm.com/projects/g/pomber/code-surfer/snapshot/d0cce0ec43f177a15c7d8d414ffac52bd5cef7fb/files/website/public/index.html?sort=name&dir=ASC&mode=list>
-   <https://lgtm.com/projects/g/Tencent/omi/snapshot/9ec05902485f1df96977236f3ee714ef508363e8/files/packages/omi-snap/build/index.html?sort=name&dir=ASC&mode=list#L0>
-   <https://lgtm.com/projects/g/ampproject/amphtml/snapshot/7bc3fed814940e6d9df6b4638f9a87a27c9a9cb5/files/spec/amp-cache-modifications.everything.cache.html?sort=name&dir=ASC&mode=list#L0>