### PR TITLE
CPP: Re-enable OverflowDestination.ql on the security dashboard.

### DIFF
--- a/cpp/config/suites/security/cwe-119
+++ b/cpp/config/suites/security/cwe-119
@@ -3,8 +3,8 @@
     @name Call to memory access function may overflow buffer (CWE-119)
 + semmlecode-cpp-queries/Critical/OverflowStatic.ql: /CWE/CWE-119
     @name Static array access may cause overflow (CWE-119)
-# + semmlecode-cpp-queries/Critical/OverflowDestination.ql: /CWE/CWE-119
-#    ^ disabled due to timeout issue
++ semmlecode-cpp-queries/Critical/OverflowDestination.ql: /CWE/CWE-119
+    @name Copy function using source size (CWE-119)
 + semmlecode-cpp-queries/Likely Bugs/Memory Management/SuspiciousCallToStrncat.ql: /CWE/CWE-119
     @name Potentially unsafe call to strncat (CWE-119)
 + semmlecode-cpp-queries/Likely Bugs/Memory Management/StrncpyFlippedArgs.ql: /CWE/CWE-119


### PR DESCRIPTION
`OverflowDestination.ql` was disabled on the security dashboard a while ago due to performance issues (before https://github.com/Semmle/ql/pull/329 it used PointsTo...), with the intent to re-enable it when they were solved.  It's now running fine, the `security.TaintTracking` stuff isn't super-quick but it's used in many other queries on the same dashboard (some of which are slower than `OverflowDestination.ql`).