### PR TITLE
CPP: %@ in format strings

### DIFF
--- a/cpp/ql/src/semmle/code/cpp/commons/Printf.qll
+++ b/cpp/ql/src/semmle/code/cpp/commons/Printf.qll
@@ -256,7 +256,7 @@ class FormatLiteral extends Literal {
   }
 
   /**
-   * Gets the format string, with '%%' adn '%@' replaced by '_' (to avoid processing
+   * Gets the format string, with '%%' and '%@' replaced by '_' (to avoid processing
    * them as format specifiers).
    */
   string getFormat() {

--- a/cpp/ql/src/semmle/code/cpp/commons/Printf.qll
+++ b/cpp/ql/src/semmle/code/cpp/commons/Printf.qll
@@ -256,11 +256,11 @@ class FormatLiteral extends Literal {
   }
 
   /**
-   * Gets the format string, with '%%' replaced by '_' (to avoid processing
-   * '%%' as a format specifier).
+   * Gets the format string, with '%%' adn '%@' replaced by '_' (to avoid processing
+   * them as format specifiers).
    */
   string getFormat() {
-    result = this.getValue().replaceAll("%%", "_")
+    result = this.getValue().replaceAll("%%", "_").replaceAll("%@", "_")
   }
 
   /**

--- a/cpp/ql/test/query-tests/Likely Bugs/Format/WrongNumberOfFormatArguments/WrongNumberOfFormatArguments.expected
+++ b/cpp/ql/test/query-tests/Likely Bugs/Format/WrongNumberOfFormatArguments/WrongNumberOfFormatArguments.expected
@@ -6,3 +6,4 @@
 | test.c:15:2:15:7 | call to printf | Format expects 3 arguments but given 2 |
 | test.c:19:2:19:7 | call to printf | Format expects 2 arguments but given 1 |
 | test.c:29:3:29:8 | call to printf | Format expects 2 arguments but given 1 |
+| test.c:44:2:44:7 | call to printf | Format expects 3 arguments but given 2 |

--- a/cpp/ql/test/query-tests/Likely Bugs/Format/WrongNumberOfFormatArguments/WrongNumberOfFormatArguments.expected
+++ b/cpp/ql/test/query-tests/Likely Bugs/Format/WrongNumberOfFormatArguments/WrongNumberOfFormatArguments.expected
@@ -6,4 +6,3 @@
 | test.c:15:2:15:7 | call to printf | Format expects 3 arguments but given 2 |
 | test.c:19:2:19:7 | call to printf | Format expects 2 arguments but given 1 |
 | test.c:29:3:29:8 | call to printf | Format expects 2 arguments but given 1 |
-| test.c:44:2:44:7 | call to printf | Format expects 3 arguments but given 2 |

--- a/cpp/ql/test/query-tests/Likely Bugs/Format/WrongNumberOfFormatArguments/test.c
+++ b/cpp/ql/test/query-tests/Likely Bugs/Format/WrongNumberOfFormatArguments/test.c
@@ -40,4 +40,6 @@ void test(int i, const char *str)
 		printf("%2$.*4$f", 0, num, 0, precision); // GOOD [FALSE POSITIVE]
 		printf("%2$.*4$f", num, 0, precision); // BAD (too few format arguments) [INCORRECT MESSAGE]
 	}
+
+	printf("%@ %i %i", 1, 2); // GOOD [FALSE POSITIVE]
 }

--- a/cpp/ql/test/query-tests/Likely Bugs/Format/WrongNumberOfFormatArguments/test.c
+++ b/cpp/ql/test/query-tests/Likely Bugs/Format/WrongNumberOfFormatArguments/test.c
@@ -41,5 +41,5 @@ void test(int i, const char *str)
 		printf("%2$.*4$f", num, 0, precision); // BAD (too few format arguments) [INCORRECT MESSAGE]
 	}
 
-	printf("%@ %i %i", 1, 2); // GOOD [FALSE POSITIVE]
+	printf("%@ %i %i", 1, 2); // GOOD
 }


### PR DESCRIPTION
This PR fixes an [old issue](https://jira.semmle.com/browse/ODASA-3654) with a non-standard `%@` in format strings being handled incorrectly.  There were two obvious routes to fix this:
 - by recognizing that the custom `printf` function isn't a standard `printf` (strictly speaking it isn't); this is actually a bit tricky because it *does* pass it's format argument `fmt` into `vsnprintf`, but having offset the pointer first.
 - by excluding `%@` from being counted as a format specifier

It turns out that both g++ and the Microsoft compiler don't count `%@` as a format specifier and just output either `@` or `%@` without consuming a format argument - which is compatible with what redis does, so I'm going with the second solution.