### PR TITLE
JavaScript: Fix uses of `TypeTracker` with custom flow steps.

### DIFF
--- a/javascript/ql/src/semmle/javascript/dataflow/TypeTracking.qll
+++ b/javascript/ql/src/semmle/javascript/dataflow/TypeTracking.qll
@@ -168,10 +168,12 @@ class TypeTracker extends TTypeTracker {
   boolean hasCall() { result = hasCall }
 
   /**
-   * Gets the property this type has been tracked into, or the empty string if
-   * it has not been tracked into a property.
+   * Gets a type tracker that starts where this one has left off to allow continued
+   * tracking.
+   *
+   * This predicate is only defined if the type has not been tracked into a property.
    */
-  string getProp() { result = prop }
+  TypeTracker continue() { prop = "" and result = this }
 }
 
 module TypeTracker {
@@ -257,10 +259,12 @@ class TypeBackTracker extends TTypeBackTracker {
   boolean hasReturn() { result = hasReturn }
 
   /**
-   * Gets the property this type has been tracked into, or the empty string if
-   * it has not been tracked into a property.
+   * Gets a type tracker that starts where this one has left off to allow continued
+   * tracking.
+   *
+   * This predicate is only defined if the type has not been tracked into a property.
    */
-  string getProp() { result = prop }
+  TypeBackTracker continue() { prop = "" and result = this }
 }
 
 module TypeBackTracker {

--- a/javascript/ql/src/semmle/javascript/dataflow/TypeTracking.qll
+++ b/javascript/ql/src/semmle/javascript/dataflow/TypeTracking.qll
@@ -126,6 +126,7 @@ class TypeTracker extends TTypeTracker {
 
   TypeTracker() { this = MkTypeTracker(hasCall, prop) }
 
+  /** Gets the summary resulting from appending `step` to this type-tracking summary. */
   TypeTracker append(StepSummary step) {
     step = LevelStep() and result = this
     or
@@ -140,6 +141,7 @@ class TypeTracker extends TTypeTracker {
     )
   }
 
+  /** Gets a textual representation of this summary. */
   string toString() {
     exists(string withCall, string withProp |
       (if hasCall = true then withCall = "with" else withCall = "without") and
@@ -153,6 +155,9 @@ class TypeTracker extends TTypeTracker {
    */
   predicate start() { hasCall = false and prop = "" }
 
+  /**
+   * Holds if this is the end point of type tracking.
+   */
   predicate end() { prop = "" }
 
   /**
@@ -162,6 +167,10 @@ class TypeTracker extends TTypeTracker {
    */
   boolean hasCall() { result = hasCall }
 
+  /**
+   * Gets the property this type has been tracked into, or the empty string if
+   * it has not been tracked into a property.
+   */
   string getProp() { result = prop }
 }
 
@@ -206,6 +215,7 @@ class TypeBackTracker extends TTypeBackTracker {
 
   TypeBackTracker() { this = MkTypeBackTracker(hasReturn, prop) }
 
+  /** Gets the summary resulting from prepending `step` to this type-tracking summary. */
   TypeBackTracker prepend(StepSummary step) {
     step = LevelStep() and result = this
     or
@@ -220,6 +230,7 @@ class TypeBackTracker extends TTypeBackTracker {
     step = StoreStep(prop) and result = MkTypeBackTracker(hasReturn, "")
   }
 
+  /** Gets a textual representation of this summary. */
   string toString() {
     exists(string withReturn, string withProp |
       (if hasReturn = true then withReturn = "with" else withReturn = "without") and
@@ -233,6 +244,9 @@ class TypeBackTracker extends TTypeBackTracker {
    */
   predicate start() { hasReturn = false and prop = "" }
 
+  /**
+   * Holds if this is the end point of type tracking.
+   */
   predicate end() { prop = "" }
 
   /**
@@ -242,6 +256,10 @@ class TypeBackTracker extends TTypeBackTracker {
    */
   boolean hasReturn() { result = hasReturn }
 
+  /**
+   * Gets the property this type has been tracked into, or the empty string if
+   * it has not been tracked into a property.
+   */
   string getProp() { result = prop }
 }
 

--- a/javascript/ql/src/semmle/javascript/frameworks/SocketIO.qll
+++ b/javascript/ql/src/semmle/javascript/frameworks/SocketIO.qll
@@ -51,6 +51,7 @@ module SocketIO {
         // exclude getter versions
         exists(mcn.getAnArgument()) and
         result = mcn and
+        t2.getProp() = "" and
         t = t2
       )
     )
@@ -110,6 +111,7 @@ module SocketIO {
       or
       // invocation of a chainable method
       result = pred.getAMethodCall(namespaceChainableMethod()) and
+      t2.getProp() = "" and
       t = t2
       or
       // invocation of chainable getter method
@@ -119,6 +121,7 @@ module SocketIO {
         m = "volatile"
       |
         result = pred.getAPropertyRead(m) and
+        t2.getProp() = "" and
         t = t2
       )
     )
@@ -171,6 +174,7 @@ module SocketIO {
         m = EventEmitter::chainableMethod()
       |
         result = pred.getAMethodCall(m) and
+        t2.getProp() = "" and
         t = t2
       )
       or
@@ -182,6 +186,7 @@ module SocketIO {
         m = "volatile"
       |
         result = pred.getAPropertyRead(m) and
+        t2.getProp() = "" and
         t = t2
       )
     )

--- a/javascript/ql/src/semmle/javascript/frameworks/SocketIO.qll
+++ b/javascript/ql/src/semmle/javascript/frameworks/SocketIO.qll
@@ -51,8 +51,7 @@ module SocketIO {
         // exclude getter versions
         exists(mcn.getAnArgument()) and
         result = mcn and
-        t2.getProp() = "" and
-        t = t2
+        t = t2.continue()
       )
     )
   }
@@ -111,8 +110,7 @@ module SocketIO {
       or
       // invocation of a chainable method
       result = pred.getAMethodCall(namespaceChainableMethod()) and
-      t2.getProp() = "" and
-      t = t2
+      t = t2.continue()
       or
       // invocation of chainable getter method
       exists(string m |
@@ -121,8 +119,7 @@ module SocketIO {
         m = "volatile"
       |
         result = pred.getAPropertyRead(m) and
-        t2.getProp() = "" and
-        t = t2
+        t = t2.continue()
       )
     )
   }
@@ -174,8 +171,7 @@ module SocketIO {
         m = EventEmitter::chainableMethod()
       |
         result = pred.getAMethodCall(m) and
-        t2.getProp() = "" and
-        t = t2
+        t = t2.continue()
       )
       or
       // invocation of a chainable getter method
@@ -186,8 +182,7 @@ module SocketIO {
         m = "volatile"
       |
         result = pred.getAPropertyRead(m) and
-        t2.getProp() = "" and
-        t = t2
+        t = t2.continue()
       )
     )
   }

--- a/javascript/ql/test/library-tests/frameworks/SocketIO/tests.expected
+++ b/javascript/ql/test/library-tests/frameworks/SocketIO/tests.expected
@@ -149,6 +149,7 @@ test_ServerNode
 | tst.js:15:1:15:15 | io.attach(http) | tst.js:1:12:1:33 | socket.io server |
 | tst.js:16:1:16:15 | io.bind(engine) | tst.js:1:12:1:33 | socket.io server |
 | tst.js:17:1:17:23 | io.onco ... socket) | tst.js:1:12:1:33 | socket.io server |
+| tst.js:79:1:79:10 | obj.server | tst.js:1:12:1:33 | socket.io server |
 test_ClientSendNode_getAReceiver
 | client2.js:14:1:14:32 | sock.em ... there") | tst.js:72:3:72:43 | socket. ...  => {}) |
 | client2.js:16:1:16:36 | sock.wr ...  => {}) | tst.js:70:3:70:35 | socket. ...  => {}) |

--- a/javascript/ql/test/library-tests/frameworks/SocketIO/tst.js
+++ b/javascript/ql/test/library-tests/frameworks/SocketIO/tst.js
@@ -71,3 +71,11 @@ ns.on('connection', (socket) => {
   socket.once('message', (data1, data2) => {});
   socket.addListener(eventName(), () => {});
 });
+
+var obj = {
+  server: io,
+  serveClient: function() { return null; }
+};
+obj.server;                    // SocketIO::ServerNode
+obj.serveClient(false);        // not a SocketIO::ServerNode
+obj.serveClient(false).server; // not a SocketIO::ServerNode


### PR DESCRIPTION
These steps need to check that the type hasn't been tracked into a property.

Before I start testing this, I'd like some feedback on the API. Checking for the property name explicitly is awkward and easy to forget and should probably be encapsulated in an auxiliary predicate, but I'm struggling to come up with an intuitive name and would be grateful for suggestions. Or maybe there is another way to ensure this?