### PR TITLE
CPP: Add a reference about include optimization for AV Rule 35

### DIFF
--- a/cpp/ql/src/jsf/4.07 Header Files/AV Rule 35.qhelp
+++ b/cpp/ql/src/jsf/4.07 Header Files/AV Rule 35.qhelp
@@ -68,6 +68,9 @@ some are after the final <code>#endif</code>. All three of these things must be 
 <li>
   <a href="http://www.cplusplus.com/forum/articles/10627/">Headers and Includes: Why and How</a>
 </li>
+<li>
+  <a href="https://gcc.gnu.org/onlinedocs/cppinternals/Guard-Macros.html">The Multiple-Include Optimization</a>
+</li>
 
 
 </references>


### PR DESCRIPTION
This came up a while ago in https://discuss.lgtm.com/t/ignore-leading-underscores-for-header-guards/1743/2 (see also https://discuss.lgtm.com/t/multiple-c-false-positives/1451/6).  We decided the query is OK, but I meant to add the reference about this to the qhelp as it isn't obvious.