### PR TITLE
JS: track document and DOM values with type tracking

### DIFF
--- a/javascript/ql/src/semmle/javascript/DOM.qll
+++ b/javascript/ql/src/semmle/javascript/DOM.qll
@@ -303,14 +303,14 @@ module DOM {
   /** Gets a data flow node that may refer to a value from the DOM. */
   DataFlow::SourceNode domValueRef() { result = domValueRef(DataFlow::TypeTracker::end()) }
 
-  /** Gets a data flow node that directly refers to the DOM `location` object. */
+  /** Gets a data flow node that directly refers to a DOM `location` object. */
   DataFlow::SourceNode locationSource() {
     result = domValueRef().getAPropertyRead("location")
     or
     result = DataFlow::globalVarRef("location")
   }
 
-  /** Gets a reference to the DOM `location` object. */
+  /** Gets a reference to a DOM `location` object. */
   private DataFlow::SourceNode locationRef(DataFlow::TypeTracker t) {
     t.start() and
     result = locationSource()
@@ -318,7 +318,7 @@ module DOM {
     exists(DataFlow::TypeTracker t2 | result = locationRef(t2).track(t2, t))
   }
 
-  /** Gets a reference to the DOM `location` object. */
+  /** Gets a reference to a DOM `location` object. */
   DataFlow::SourceNode locationRef() { result = locationRef(DataFlow::TypeTracker::end()) }
 
   /**

--- a/javascript/ql/src/semmle/javascript/DOM.qll
+++ b/javascript/ql/src/semmle/javascript/DOM.qll
@@ -284,7 +284,7 @@ module DOM {
     )
   }
 
-  /** Gets a data flow node that refer directly to a value from the DOM. */
+  /** Gets a data flow node that refers directly to a value from the DOM. */
   DataFlow::SourceNode domValueSource() {
     result.asExpr().(VarAccess).getVariable() instanceof DOMGlobalVariable or
     result = domValueRef().getAPropertyRead(_) or

--- a/javascript/ql/src/semmle/javascript/DOM.qll
+++ b/javascript/ql/src/semmle/javascript/DOM.qll
@@ -287,7 +287,7 @@ module DOM {
   /** Gets a data flow node that refers directly to a value from the DOM. */
   DataFlow::SourceNode domValueSource() {
     result.asExpr().(VarAccess).getVariable() instanceof DOMGlobalVariable or
-    result = domValueRef().getAPropertyRead(_) or
+    result = domValueRef().getAPropertyRead() or
     result = domElementCreationOrQuery() or
     result = domElementCollection()
   }

--- a/javascript/ql/src/semmle/javascript/DOM.qll
+++ b/javascript/ql/src/semmle/javascript/DOM.qll
@@ -322,7 +322,7 @@ module DOM {
   DataFlow::SourceNode locationRef() { result = locationRef(DataFlow::TypeTracker::end()) }
 
   /**
-   * Gets a reference to the 'document' object.
+   * Gets a reference to the `document` object.
    */
   private DataFlow::SourceNode documentRef(DataFlow::TypeTracker t) {
     t.start() and

--- a/javascript/ql/src/semmle/javascript/security/dataflow/ClientSideUrlRedirect.qll
+++ b/javascript/ql/src/semmle/javascript/security/dataflow/ClientSideUrlRedirect.qll
@@ -121,10 +121,9 @@ module ClientSideUrlRedirect {
       )
       or
       // A call to `location.replace` or `location.assign`
-      exists(MethodCallExpr locationCall, string name |
-        isLocation(locationCall.getReceiver()) and
-        name = locationCall.getMethodName() and
-        astNode = locationCall.getArgument(0)
+      exists(DataFlow::MethodCallNode locationCall, string name |
+        locationCall = DOM::locationRef().getAMethodCall(name) and
+        this = locationCall.getArgument(0)
       |
         name = "replace" or name = "assign"
       )
@@ -134,8 +133,7 @@ module ClientSideUrlRedirect {
       or
       // An assignment to `location.href`, `location.protocol` or `location.hostname`
       exists(DataFlow::PropWrite pw, string propName |
-        isLocation(pw.getBase().asExpr()) and
-        propName = pw.getPropertyName() and
+        pw = DOM::locationRef().getAPropertyWrite(propName) and
         this = pw.getRhs()
       |
         propName = "href" or propName = "protocol" or propName = "hostname"

--- a/javascript/ql/src/semmle/javascript/security/dataflow/DOM.qll
+++ b/javascript/ql/src/semmle/javascript/security/dataflow/DOM.qll
@@ -61,13 +61,13 @@ private DataFlow::SourceNode domValueSource(DataFlow::TypeTracker t) {
 }
 
 private DataFlow::SourceNode domValueSource() {
-  result = domValueSource(_)
+  result = domValueSource(DataFlow::TypeTracker::end())
 }
 
 /** Holds if `e` could hold a value that comes from the DOM. */
 predicate isDomValue(Expr e) { domValueSource().flowsToExpr(e) }
 
-/** Holds if `e` could refer to the `location` property of a DOM node. */
+/** Gets a reference to the DOM `location` object. */
 private DataFlow::SourceNode locationRef(DataFlow::TypeTracker t) {
   t.start() and
   exists(Expr e | result.asExpr() = e |
@@ -80,9 +80,14 @@ private DataFlow::SourceNode locationRef(DataFlow::TypeTracker t) {
   )
 }
 
+/** Gets a reference to the DOM `location` object. */
+private DataFlow::SourceNode locationRef() {
+  result = locationRef(DataFlow::TypeTracker::end())
+}
+
 /** Holds if `e` could refer to the `location` property of a DOM node. */
 predicate isLocation(Expr e) {
-  locationRef(_).flowsToExpr(e)
+  locationRef().flowsToExpr(e)
 }
 
 /**
@@ -100,7 +105,7 @@ private DataFlow::SourceNode document(DataFlow::TypeTracker t) {
 /**
  * Gets a reference to the 'document' object.
  */
-DataFlow::SourceNode document() { result = document(_) }
+DataFlow::SourceNode document() { result = document(DataFlow::TypeTracker::end()) }
 
 /** Holds if `e` could refer to the `document` object. */
 predicate isDocument(Expr e) { document().flowsToExpr(e) }

--- a/javascript/ql/src/semmle/javascript/security/dataflow/PropertyInjectionShared.qll
+++ b/javascript/ql/src/semmle/javascript/security/dataflow/PropertyInjectionShared.qll
@@ -14,7 +14,7 @@ module PropertyInjection {
     node = DataFlow::globalObjectRef()
     or
     // document.write can be accessed
-    isDocument(node.asExpr())
+    node = DOM::documentRef()
     or
     // 'constructor' property leads to the Function constructor.
     node.analyze().getAValue() instanceof AbstractCallable

--- a/javascript/ql/src/semmle/javascript/security/dataflow/XpathInjection.qll
+++ b/javascript/ql/src/semmle/javascript/security/dataflow/XpathInjection.qll
@@ -75,7 +75,7 @@ module XpathInjection {
   class DomXpathSink extends Sink {
     DomXpathSink() {
       exists(string m | m = "evaluate" or m = "createExpression" |
-        this = document().getAMethodCall(m).getArgument(0)
+        this = DOM::documentRef().getAMethodCall(m).getArgument(0)
       )
     }
   }


### PR DESCRIPTION
This PR does a few things:
1. Use TypeTracking to track `document` and DOM values.
2. Move some predicates into the `DOM::` namespace in order to safely introduce the `documentRef()`, `locationRef()`, etc outside the global scope.
3. Rewrite some other DOM code to use `DataFlow` library and some of the new predicates that use type tracking.

[Evaluation](https://git.semmle.com/asger/dist-compare-reports/tree/balbinus.ti.semmle.com_1553834869797) of the first commit alone shows some decent results, though the performance looks too good to be true.

I'll re-run a full evaluation over the weekend with latest changes, ideally including those from review.

There is still more modernization to be done in the DOM libraries, but I'd prefer not to do all of it in this PR.