### PR TITLE
Fix queries with inconsistent `@kind` and `select` statements

### DIFF
--- a/cpp/ql/src/Architecture/General Class-Level Information/HubClasses.ql
+++ b/cpp/ql/src/Architecture/General Class-Level Information/HubClasses.ql
@@ -2,7 +2,7 @@
  * @name Hub classes
  * @description Shows coupling between classes. Large, red, boxes are hub types that depend on many other classes
  *              and are depended on by many other classes.
- * @kind treemap
+ * @kind table
  * @id cpp/architecture/hub-classes
  * @treemap.warnOn highValues
  * @tags maintainability

--- a/cpp/ql/src/jsf/3.02 Code Size and Complexity/AV Rule 3.ql
+++ b/cpp/ql/src/jsf/3.02 Code Size and Complexity/AV Rule 3.ql
@@ -12,5 +12,4 @@ import cpp
 from Function f, int c
 where c = f.getMetrics().getCyclomaticComplexity() and
       c > 20
-select f, c as CyclomaticComplexity,
-       "AV Rule 3: All functions shall have a cyclomatic complexity number of 20 or less."
+select f, "AV Rule 3: All functions shall have a cyclomatic complexity number of 20 or less."

--- a/cpp/ql/src/jsf/4.10 Classes/AV Rule 81.ql
+++ b/cpp/ql/src/jsf/4.10 Classes/AV Rule 81.ql
@@ -3,6 +3,7 @@
  * @description The assignment operator shall handle self-assignment correctly.
  * @kind problem
  * @id cpp/jsf/av-rule-81
+ * @precision low
  * @problem.severity error
  * @tags correctness
  *       external/jsf
@@ -77,4 +78,4 @@ where hasResource(op.getDeclaringType())
       and not exists(op.getASelfEqualityTest())
       and not exists(op.getASwapCall())
       and exists(op.getADeleteExpr())
-select op
+select op, "AV Rule 81: The assignment operator shall handle self-assignment correctly."

--- a/cpp/ql/src/semmle/code/cpp/ASTSanity.ql
+++ b/cpp/ql/src/semmle/code/cpp/ASTSanity.ql
@@ -1,7 +1,7 @@
 /**
  * @name AST Sanity Check
  * @description Performs sanity checks on the Abstract Syntax Tree. This query should have no results. 
- * @kind problem
+ * @kind table
  * @id cpp/ast-sanity-check
  */
 

--- a/cpp/ql/src/semmle/code/cpp/ir/IRSanity.ql
+++ b/cpp/ql/src/semmle/code/cpp/ir/IRSanity.ql
@@ -1,7 +1,7 @@
 /**
  * @name IR Sanity Check
  * @description Performs sanity checks on the Intermediate Representation. This query should have no results. 
- * @kind problem
+ * @kind table
  * @id cpp/ir-sanity-check
  */
 

--- a/cpp/ql/src/semmle/code/cpp/ir/implementation/aliased_ssa/IRSanity.ql
+++ b/cpp/ql/src/semmle/code/cpp/ir/implementation/aliased_ssa/IRSanity.ql
@@ -1,7 +1,7 @@
 /**
  * @name Aliased SSA IR Sanity Check
  * @description Performs sanity checks on the Intermediate Representation. This query should have no results. 
- * @kind problem
+ * @kind table
  * @id cpp/aliased-ssa-ir-sanity-check
  */
 

--- a/cpp/ql/src/semmle/code/cpp/ir/implementation/raw/IRSanity.ql
+++ b/cpp/ql/src/semmle/code/cpp/ir/implementation/raw/IRSanity.ql
@@ -1,7 +1,7 @@
 /**
  * @name Raw IR Sanity Check
  * @description Performs sanity checks on the Intermediate Representation. This query should have no results. 
- * @kind problem
+ * @kind table
  * @id cpp/raw-ir-sanity-check
  */
 

--- a/cpp/ql/src/semmle/code/cpp/ir/implementation/unaliased_ssa/IRSanity.ql
+++ b/cpp/ql/src/semmle/code/cpp/ir/implementation/unaliased_ssa/IRSanity.ql
@@ -1,7 +1,7 @@
 /**
  * @name SSA IR Sanity Check
  * @description Performs sanity checks on the Intermediate Representation. This query should have no results. 
- * @kind problem
+ * @kind table
  * @id cpp/ssa-ir-sanity-check
  */
 

--- a/cpp/ql/src/semmle/code/cpp/padding/SanityCheck.ql
+++ b/cpp/ql/src/semmle/code/cpp/padding/SanityCheck.ql
@@ -1,7 +1,7 @@
 /**
  * @name Padding Sanity Check
  * @description Performs sanity checks for the padding library. This query should have no results. 
- * @kind problem
+ * @kind table
  * @id cpp/padding-sanity-check
  */
 

--- a/python/ql/test/2/library-tests/locations/general/AllLocations.ql
+++ b/python/ql/test/2/library-tests/locations/general/AllLocations.ql
@@ -1,7 +1,7 @@
 /**
  * @name All must have locations
  * @description
- * @kind problem
+ * @kind table
  * @problem.severity error
  */
 

--- a/python/ql/test/3/library-tests/PointsTo/import_time/Pruned.ql
+++ b/python/ql/test/3/library-tests/PointsTo/import_time/Pruned.ql
@@ -1,7 +1,7 @@
 /**
  * @name Naive
  * @description Insert description here...
- * @kind problem
+ * @kind table
  * @problem.severity warning
  */
 

--- a/python/ql/test/3/library-tests/locations/general/AllLocations.ql
+++ b/python/ql/test/3/library-tests/locations/general/AllLocations.ql
@@ -1,7 +1,7 @@
 /**
  * @name All must have locations
  * @description
- * @kind problem
+ * @kind table
  * @problem.severity error
  */
 

--- a/python/ql/test/3/library-tests/types/namespaces/NameSpace.ql
+++ b/python/ql/test/3/library-tests/types/namespaces/NameSpace.ql
@@ -1,7 +1,7 @@
 /**
  * @name ImportTimeScope
  * @description ImportTimeScope Test
- * @kind problem
+ * @kind table
  * @problem.severity warning
  */
 

--- a/python/ql/test/library-tests/ControlFlow/PointsToSupport/UseFromDefinition.ql
+++ b/python/ql/test/library-tests/ControlFlow/PointsToSupport/UseFromDefinition.ql
@@ -1,7 +1,7 @@
 /**
  * @name UseFromDefinition
  * @description Insert description here...
- * @kind problem
+ * @kind table
  * @problem.severity warning
  */
 

--- a/python/ql/test/library-tests/ControlFlow/augassign/SSA.ql
+++ b/python/ql/test/library-tests/ControlFlow/augassign/SSA.ql
@@ -1,7 +1,7 @@
 /**
  * @name SSA
  * @description Insert description here...
- * @kind problem
+ * @kind table
  * @problem.severity warning
  */
 

--- a/python/ql/test/library-tests/ControlFlow/comparison/Compare.ql
+++ b/python/ql/test/library-tests/ControlFlow/comparison/Compare.ql
@@ -1,7 +1,7 @@
 /**
  * @name CompareTest
  * @description CompareTest
- * @kind problem
+ * @kind table
  * @problem.severity warning
  */
 

--- a/python/ql/test/library-tests/ControlFlow/dominators/idom.ql
+++ b/python/ql/test/library-tests/ControlFlow/dominators/idom.ql
@@ -1,7 +1,7 @@
 /**
  * @name Check all non-scope nodes have an immediate dominator
  * @description Check all non-scope nodes have an immediate dominator
- * @kind problem
+ * @kind table
  * @problem.severity warning
  */
 

--- a/python/ql/test/library-tests/ControlFlow/truefalse/Branch.ql
+++ b/python/ql/test/library-tests/ControlFlow/truefalse/Branch.ql
@@ -1,7 +1,7 @@
 /**
  * @name Branch
  * @description Insert description here...
- * @kind problem
+ * @kind table
  * @problem.severity warning
  */
 

--- a/python/ql/test/library-tests/ControlFlow/truefalse/ExceptionalSuccessors.ql
+++ b/python/ql/test/library-tests/ControlFlow/truefalse/ExceptionalSuccessors.ql
@@ -1,7 +1,7 @@
 /**
  * @name TrueFalseSuccessors Test
  * @description Tests true/false successors
- * @kind problem
+ * @kind table
  * @problem.severity warning
  */
 

--- a/python/ql/test/library-tests/ControlFlow/truefalse/TrueFalseSuccessors.ql
+++ b/python/ql/test/library-tests/ControlFlow/truefalse/TrueFalseSuccessors.ql
@@ -1,7 +1,7 @@
 /**
  * @name TrueFalseSuccessors Test
  * @description Tests true/false successors
- * @kind problem
+ * @kind table
  * @problem.severity warning
  */
 

--- a/python/ql/test/library-tests/DefUse/Definitions.ql
+++ b/python/ql/test/library-tests/DefUse/Definitions.ql
@@ -1,7 +1,7 @@
 /**
  * @name Definitions
  * @description Insert description here...
- * @kind problem
+ * @kind table
  * @problem.severity warning
  */
 

--- a/python/ql/test/library-tests/DefUse/Uses.ql
+++ b/python/ql/test/library-tests/DefUse/Uses.ql
@@ -1,7 +1,7 @@
 /**
  * @name Usages
  * @description Insert description here...
- * @kind problem
+ * @kind table
  * @problem.severity warning
  */
 

--- a/python/ql/test/library-tests/DuplicateCode/Duplicate.ql
+++ b/python/ql/test/library-tests/DuplicateCode/Duplicate.ql
@@ -1,7 +1,7 @@
 /**
  * @name Duplicate
  * @description Insert description here...
- * @kind problem
+ * @kind table
  * @problem.severity warning
  */
 

--- a/python/ql/test/library-tests/DuplicateCode/Similar.ql
+++ b/python/ql/test/library-tests/DuplicateCode/Similar.ql
@@ -1,7 +1,7 @@
 /**
  * @name Similar
  * @description Insert description here...
- * @kind problem
+ * @kind table
  * @problem.severity warning
  */
 

--- a/python/ql/test/library-tests/PointsTo/general/LocalPointsTo.ql
+++ b/python/ql/test/library-tests/PointsTo/general/LocalPointsTo.ql
@@ -1,7 +1,7 @@
 /**
  * @name LocalPointsTo
  * @description Insert description here...
- * @kind problem
+ * @kind table
  * @problem.severity warning
  */
 

--- a/python/ql/test/library-tests/comments/blocks.ql
+++ b/python/ql/test/library-tests/comments/blocks.ql
@@ -1,7 +1,7 @@
 /**
  * @name commented_out_code
  * @description Insert description here...
- * @kind problem
+ * @kind table
  * @problem.severity warning
  */
 

--- a/python/ql/test/library-tests/dependencies/Categories.ql
+++ b/python/ql/test/library-tests/dependencies/Categories.ql
@@ -1,7 +1,7 @@
 /**
  * @name Categories
  * @description Insert description here...
- * @kind problem
+ * @kind table
  * @problem.severity warning
  */
 


### PR DESCRIPTION
I am working on making inconsistent `select` statements and `@kind` annotations a fatal error. I'd like to ensure that all queries are healthy before making that change.

This PR changes all sanity check and test queries that were erroneously marked as `@kind problem` to use the generic `@kind table` instead.

Furthermore it updates the select statements of C++ AV Rules 3 and 81 to conform to the expected result pattern of a `problem` query.

Finally the C++ HubClasses query was selecting two metric values, which isn't allowed for a `metric` query. I changed its kind to `@table` to reflect that it isn't a proper metric.
