### PR TITLE
CPP: Workaround improvement for File.compiledAsMicrosoft.

### DIFF
--- a/cpp/ql/src/semmle/code/cpp/File.qll
+++ b/cpp/ql/src/semmle/code/cpp/File.qll
@@ -309,6 +309,10 @@ class File extends Container, @file {
     ) or exists(File parent |
       parent.compiledAsMicrosoft() and
       parent.getAnIncludedFile() = this
+    ) or (
+      getAbsolutePath().charAt(1) = ":"
+      	// this is not ideal, it detects compilation on a Windows file system
+      	// as a heuristic approximation to compilation with a Microsoft compiler.
     )
   }
 

--- a/cpp/ql/src/semmle/code/cpp/File.qll
+++ b/cpp/ql/src/semmle/code/cpp/File.qll
@@ -313,6 +313,8 @@ class File extends Container, @file {
       getAbsolutePath().charAt(1) = ":"
       	// this is not ideal, it detects compilation on a Windows file system
       	// as a heuristic approximation to compilation with a Microsoft compiler.
+    ) or (
+      getAbsolutePath().charAt(1) = "/"
     )
   }
 


### PR DESCRIPTION
This will fix the 239 new results (in chakracore) on the internal CPP differences dashboard that showed up due to failing to correctly identify a Microsoft context.  The fix is a heuristic, in the long run we need to make the extractor changes that were talked about a week or so ago.

Does not affect LGTM.