### PR TITLE
Java: Fix typo in query description

### DIFF
--- a/java/ql/src/Security/CWE/CWE-614/InsecureCookie.ql
+++ b/java/ql/src/Security/CWE/CWE-614/InsecureCookie.ql
@@ -1,6 +1,6 @@
 /**
  * @name Failure to use secure cookies
- * @description Insecured cookies may be sent in cleartext, which makes them vulnerable to
+ * @description Insecure cookies may be sent in cleartext, which makes them vulnerable to
  *              interception.
  * @kind problem
  * @problem.severity error


### PR DESCRIPTION
@Semmle/java, Josh raised a docs issue for this.