### PR TITLE
Java: Use range analysis in IntMultToLong (ODASA-7836).

### DIFF
--- a/change-notes/1.21/analysis-java.md
+++ b/change-notes/1.21/analysis-java.md
@@ -10,6 +10,7 @@
 | **Query**                  | **Expected impact**    | **Change**                                                       |
 |----------------------------|------------------------|------------------------------------------------------------------|
 | Implicit conversion from array to string (`java/print-array`) | Fewer false positive results | Results in slf4j logging calls are no longer reported as slf4j supports array printing. |
+| Result of multiplication cast to wider type (`java/integer-multiplication-cast-to-long`) | Fewer false positive results | Range analysis is now used to exclude results involving multiplication of small values that cannot overflow. |
 
 ## Changes to QL libraries
 

--- a/java/ql/src/Likely Bugs/Arithmetic/IntMultToLong.ql
+++ b/java/ql/src/Likely Bugs/Arithmetic/IntMultToLong.ql
@@ -18,15 +18,26 @@
 
 import java
 import semmle.code.java.dataflow.RangeUtils
+import semmle.code.java.dataflow.RangeAnalysis
 import semmle.code.java.Conversions
 
-/** An multiplication that does not overflow. */
+/** Gets an upper bound on the absolute value of `e`. */
+float exprBound(Expr e) {
+  result = e.(ConstantIntegerExpr).getIntValue().(float).abs()
+  or
+  exists(float lower, float upper |
+    bounded(e, any(ZeroBound zb), lower, false, _) and
+    bounded(e, any(ZeroBound zb), upper, true, _) and
+    result = upper.abs().maximum(lower.abs())
+  )
+}
+
+/** A multiplication that does not overflow. */
 predicate small(MulExpr e) {
   exists(NumType t, float lhs, float rhs, float res | t = e.getType() |
-    lhs = e.getLeftOperand().getProperExpr().(ConstantIntegerExpr).getIntValue() and
-    rhs = e.getRightOperand().getProperExpr().(ConstantIntegerExpr).getIntValue() and
+    lhs = exprBound(e.getLeftOperand().getProperExpr()) and
+    rhs = exprBound(e.getRightOperand().getProperExpr()) and
     lhs * rhs = res and
-    t.getOrdPrimitiveType().getMinValue() <= res and
     res <= t.getOrdPrimitiveType().getMaxValue()
   )
 }

--- a/java/ql/test/query-tests/security/CWE-190/semmle/tests/Test2.java
+++ b/java/ql/test/query-tests/security/CWE-190/semmle/tests/Test2.java
@@ -1,0 +1,8 @@
+public class Test2 {
+  // IntMultToLong
+  void foo() {
+    for (int k = 1; k < 10; k++) {
+      long res = k * 1000; // OK
+    }
+  }
+}


### PR DESCRIPTION
Fixes https://github.com/Semmle/ql/issues/1062.

This detects safe multiplication using range analysis, as opposed to merely looking at constant values.