### PR TITLE
Java: Exclude slf4j calls in PrintLnArray as it supports array formatting.

### DIFF
--- a/change-notes/1.21/analysis-java.md
+++ b/change-notes/1.21/analysis-java.md
@@ -9,6 +9,7 @@
 
 | **Query**                  | **Expected impact**    | **Change**                                                       |
 |----------------------------|------------------------|------------------------------------------------------------------|
+| Implicit conversion from array to string (`java/print-array`) | Fewer false positive results | Results in slf4j logging calls are no longer reported as slf4j supports array printing. |
 
 ## Changes to QL libraries
 

--- a/java/ql/src/Violations of Best Practice/Undesirable Calls/PrintLnArray.ql
+++ b/java/ql/src/Violations of Best Practice/Undesirable Calls/PrintLnArray.ql
@@ -27,7 +27,11 @@ predicate arraysToStringArgument(Expr e) {
 from Expr arr
 where
   arr.getType() instanceof Array and
-  implicitToStringCall(arr)
+  implicitToStringCall(arr) and
+  not exists(FormattingCall fmtcall |
+    // exclude slf4j formatting as it supports array formatting
+    fmtcall.getAnArgumentToBeFormatted() = arr and fmtcall.getSyntax().isLogger()
+  )
   or
   arr.getType().(Array).getComponentType() instanceof Array and
   arraysToStringArgument(arr)

--- a/java/ql/src/semmle/code/java/StringFormat.qll
+++ b/java/ql/src/semmle/code/java/StringFormat.qll
@@ -85,6 +85,9 @@ class FmtSyntax extends TFmtSyntax {
     or
     result = "logger ({}) syntax" and this = TFmtLogger()
   }
+
+  /** Holds if this syntax is logger ({}) syntax. */
+  predicate isLogger() { this = TFmtLogger() }
 }
 
 /**


### PR DESCRIPTION
As reported [here](https://discuss.lgtm.com/t/false-positive-java-implicit-conversion-from-array-to-string/1985) slf4j logging calls shouldn't be reported.