### PR TITLE
CPP: Add a test of common mistakes using locking classes.

### DIFF
--- a/cpp/ql/test/examples/BadLocking/AV Rule 107.expected
+++ b/cpp/ql/test/examples/BadLocking/AV Rule 107.expected
@@ -1,2 +1,2 @@
-| UnintendedDeclaration.cpp:48:2:48:22 | declaration | Functions should be declared at file scope, not inside blocks. |
-| UnintendedDeclaration.cpp:69:2:69:27 | declaration | Functions should be declared at file scope, not inside blocks. |
+| UnintendedDeclaration.cpp:51:2:51:22 | declaration | Functions should be declared at file scope, not inside blocks. |
+| UnintendedDeclaration.cpp:72:2:72:27 | declaration | Functions should be declared at file scope, not inside blocks. |

--- a/cpp/ql/test/examples/BadLocking/AV Rule 107.expected
+++ b/cpp/ql/test/examples/BadLocking/AV Rule 107.expected
@@ -1,0 +1,2 @@
+| UnintendedDeclaration.cpp:48:2:48:22 | declaration | Functions should be declared at file scope, not inside blocks. |
+| UnintendedDeclaration.cpp:69:2:69:27 | declaration | Functions should be declared at file scope, not inside blocks. |

--- a/cpp/ql/test/examples/BadLocking/AV Rule 107.qlref
+++ b/cpp/ql/test/examples/BadLocking/AV Rule 107.qlref
@@ -1,0 +1,1 @@
+jsf/4.13 Functions/AV Rule 107.ql

--- a/cpp/ql/test/examples/BadLocking/DeclStmts.expected
+++ b/cpp/ql/test/examples/BadLocking/DeclStmts.expected
@@ -1,7 +1,7 @@
-| UnintendedDeclaration.cpp:41:2:41:29 | declaration | myLock | Variable |
-| UnintendedDeclaration.cpp:48:2:48:22 | declaration | myLock | Function |
-| UnintendedDeclaration.cpp:55:2:55:20 | declaration | myLock | Variable |
-| UnintendedDeclaration.cpp:62:2:62:22 | declaration | myMutex | Variable |
-| UnintendedDeclaration.cpp:69:2:69:27 | declaration | myLock | Function |
-| UnintendedDeclaration.cpp:79:3:79:34 | declaration | myLock | Variable |
-| UnintendedDeclaration.cpp:86:3:86:27 | declaration | memberMutex | Variable |
+| UnintendedDeclaration.cpp:44:2:44:29 | declaration | myLock | Variable |
+| UnintendedDeclaration.cpp:51:2:51:22 | declaration | myLock | Function |
+| UnintendedDeclaration.cpp:58:2:58:20 | declaration | myLock | Variable |
+| UnintendedDeclaration.cpp:65:2:65:22 | declaration | myMutex | Variable |
+| UnintendedDeclaration.cpp:72:2:72:27 | declaration | myLock | Function |
+| UnintendedDeclaration.cpp:82:3:82:34 | declaration | myLock | Variable |
+| UnintendedDeclaration.cpp:89:3:89:27 | declaration | memberMutex | Variable |

--- a/cpp/ql/test/examples/BadLocking/DeclStmts.expected
+++ b/cpp/ql/test/examples/BadLocking/DeclStmts.expected
@@ -1,0 +1,7 @@
+| UnintendedDeclaration.cpp:41:2:41:29 | declaration | myLock | Variable |
+| UnintendedDeclaration.cpp:48:2:48:22 | declaration | myLock | Function |
+| UnintendedDeclaration.cpp:55:2:55:20 | declaration | myLock | Variable |
+| UnintendedDeclaration.cpp:62:2:62:22 | declaration | myMutex | Variable |
+| UnintendedDeclaration.cpp:69:2:69:27 | declaration | myLock | Function |
+| UnintendedDeclaration.cpp:79:3:79:34 | declaration | myLock | Variable |
+| UnintendedDeclaration.cpp:86:3:86:27 | declaration | memberMutex | Variable |

--- a/cpp/ql/test/examples/BadLocking/DeclStmts.ql
+++ b/cpp/ql/test/examples/BadLocking/DeclStmts.ql
@@ -1,0 +1,18 @@
+import cpp
+
+string describe(Declaration d)
+{
+	(
+		d instanceof Variable and
+		result = "Variable"
+	) or (
+		d instanceof Function and
+		result = "Function"
+	)
+}
+
+from DeclStmt ds, Declaration d
+where
+	ds.getADeclaration() = d
+select
+	ds, concat(d.getName(), ", "), concat(describe(d), ", ")

--- a/cpp/ql/test/examples/BadLocking/LocalVariableHidesGlobalVariable.expected
+++ b/cpp/ql/test/examples/BadLocking/LocalVariableHidesGlobalVariable.expected
@@ -1,1 +1,1 @@
-| UnintendedDeclaration.cpp:62:14:62:20 | definition of myMutex | Local variable myMutex hides $@ with the same name. | UnintendedDeclaration.cpp:37:7:37:13 | myMutex | a global variable |
+| UnintendedDeclaration.cpp:65:14:65:20 | definition of myMutex | Local variable myMutex hides $@ with the same name. | UnintendedDeclaration.cpp:40:7:40:13 | myMutex | a global variable |

--- a/cpp/ql/test/examples/BadLocking/LocalVariableHidesGlobalVariable.expected
+++ b/cpp/ql/test/examples/BadLocking/LocalVariableHidesGlobalVariable.expected
@@ -1,0 +1,1 @@
+| UnintendedDeclaration.cpp:62:14:62:20 | definition of myMutex | Local variable myMutex hides $@ with the same name. | UnintendedDeclaration.cpp:37:7:37:13 | myMutex | a global variable |

--- a/cpp/ql/test/examples/BadLocking/LocalVariableHidesGlobalVariable.qlref
+++ b/cpp/ql/test/examples/BadLocking/LocalVariableHidesGlobalVariable.qlref
@@ -1,0 +1,1 @@
+Best Practices/Hiding/LocalVariableHidesGlobalVariable.ql

--- a/cpp/ql/test/examples/BadLocking/UnintendedDeclaration.cpp
+++ b/cpp/ql/test/examples/BadLocking/UnintendedDeclaration.cpp
@@ -27,7 +27,10 @@ public:
 
 	~Lock()
 	{
-		m->unlock();
+		if (m)
+		{
+			m->unlock();
+		}
 	}
 
 private:

--- a/cpp/ql/test/examples/BadLocking/UnintendedDeclaration.cpp
+++ b/cpp/ql/test/examples/BadLocking/UnintendedDeclaration.cpp
@@ -1,0 +1,93 @@
+
+class Mutex
+{
+public:
+	Mutex();
+	~Mutex();
+
+	void lock();
+	void unlock();
+
+private:
+	// ...
+};
+
+template<class T>
+class Lock
+{
+public:
+	Lock() : m(0)
+	{
+	}
+
+	Lock(T &_m) : m(&_m)
+	{
+		m->lock();
+	}
+
+	~Lock()
+	{
+		m->unlock();
+	}
+
+private:
+	T *m;
+};
+
+Mutex myMutex;
+
+void test1()
+{
+	Lock<Mutex> myLock(myMutex); // GOOD (creates `myLock` on `myMutex`)
+
+	// ...
+}
+
+void test2()
+{
+	Lock<Mutex> myLock(); // BAD (interpreted as a function declaration, this does nothing)
+
+	// ...
+}
+
+void test3()
+{
+	Lock<Mutex> myLock; // GOOD (creates an uninitialized variable called `myLock`, probably intended)
+
+	// ...
+}
+
+void test4()
+{
+	Lock<Mutex>(myMutex); // BAD (creates an uninitialized variable called `myMutex`, probably not intended)
+
+	// ...
+}
+
+void test5()
+{
+	Lock<Mutex> myLock(Mutex); // BAD (interpreted as a function declaration, this does nothing)
+
+	// ...
+}
+
+class MyTestClass
+{
+public:
+	void test6()
+	{
+		Lock<Mutex> myLock(memberMutex); // GOOD (creates `myLock` on `memberMutex`)
+
+		// ...
+	}
+
+	void test7()
+	{
+		Lock<Mutex>(memberMutex); // BAD (creates an uninitialized variable called `memberMutex`, probably not intended) [NOT DETECTED]
+
+		// ...
+	}
+
+private:
+	Mutex memberMutex;
+};


### PR DESCRIPTION
(follows on from discussion with @jbj on https://github.com/Semmle/ql/pull/1192)

Add a test showing a couple of common locking pitfalls, which we want to ensure we have good test coverage for:
 - Bug `#6` in [Curiously Recurring C++ Bugs at Facebook](https://www.youtube.com/watch?v=lkgszkPnV8g), where a variable is declared for the lock but a difficult to spot typo results in the default constructor being called rather than the intended one
 - [this bug](https://godbolt.org/z/sfThNv), where what appears to be a variable declaration is in fact a function declaration

Note that `AV Rule 107` has been downgraded to a recommendation.