### PR TITLE
Python taint-tracking: Better flow for "generic" taint.

### DIFF
--- a/python/ql/src/semmle/python/security/TaintTracking.qll
+++ b/python/ql/src/semmle/python/security/TaintTracking.qll
@@ -1267,6 +1267,8 @@ library module TaintFlowImplementation {
                 Filters::isinstance(test.getTest(), c, var.getSourceVariable().getAUse())
                 and c.refersTo(cls)
                 |
+                test.getSense() = true and not exists(kind.getClass())
+                or
                 test.getSense() = true and kind.getClass().getAnImproperSuperType() = cls
                 or
                 test.getSense() = false and not kind.getClass().getAnImproperSuperType() = cls

--- a/python/ql/test/library-tests/taint/general/TestDefn.expected
+++ b/python/ql/test/library-tests/taint/general/TestDefn.expected
@@ -182,3 +182,10 @@
 | test.py:186 | ArgumentRefinement(t_3) | test.py:178 | Taint simple.test | SOURCE |
 | test.py:189 | FALSEY | test.py:189 | Taint falsey | FALSEY |
 | test.py:191 | Pi(t_0) [true] | test.py:189 | Taint falsey | FALSEY |
+| test.py:194 | phi(t_3, t_5) | test.py:195 | Taint simple.test | SOURCE |
+| test.py:195 | SOURCE | test.py:195 | Taint simple.test | SOURCE |
+| test.py:196 | ArgumentRefinement(t_0) | test.py:195 | Taint simple.test | SOURCE |
+| test.py:197 | ArgumentRefinement(t_2) | test.py:195 | Taint simple.test | SOURCE |
+| test.py:197 | Pi(t_1) [true] | test.py:195 | Taint simple.test | SOURCE |
+| test.py:199 | ArgumentRefinement(t_4) | test.py:195 | Taint simple.test | SOURCE |
+| test.py:199 | Pi(t_1) [false] | test.py:195 | Taint simple.test | SOURCE |

--- a/python/ql/test/library-tests/taint/general/TestNode.expected
+++ b/python/ql/test/library-tests/taint/general/TestNode.expected
@@ -222,6 +222,10 @@
 | Taint simple.test | test.py:180 | t |  |
 | Taint simple.test | test.py:183 | t |  |
 | Taint simple.test | test.py:186 | t |  |
+| Taint simple.test | test.py:195 | SOURCE |  |
+| Taint simple.test | test.py:196 | t |  |
+| Taint simple.test | test.py:197 | t |  |
+| Taint simple.test | test.py:199 | t |  |
 | Taint {simple.test} | test.py:169 | Dict |  |
 | Taint {simple.test} | test.py:171 | d |  |
 | Taint {simple.test} | test.py:173 | y |  |

--- a/python/ql/test/library-tests/taint/general/TestSink.expected
+++ b/python/ql/test/library-tests/taint/general/TestSink.expected
@@ -34,3 +34,5 @@
 | simple.test | test.py:169 | 173 | Subscript | simple.test |
 | simple.test | test.py:178 | 180 | t | simple.test |
 | simple.test | test.py:178 | 186 | t | simple.test |
+| simple.test | test.py:195 | 197 | t | simple.test |
+| simple.test | test.py:195 | 199 | t | simple.test |

--- a/python/ql/test/library-tests/taint/general/TestSource.expected
+++ b/python/ql/test/library-tests/taint/general/TestSource.expected
@@ -42,3 +42,4 @@
 | test.py:169 | SOURCE | simple.test |
 | test.py:178 | SOURCE | simple.test |
 | test.py:189 | FALSEY | falsey |
+| test.py:195 | SOURCE | simple.test |

--- a/python/ql/test/library-tests/taint/general/TestStep.expected
+++ b/python/ql/test/library-tests/taint/general/TestStep.expected
@@ -178,6 +178,9 @@
 | Taint simple.test | test.py:178 | SOURCE |  |  -->  | Taint simple.test | test.py:180 | t |  |
 | Taint simple.test | test.py:178 | SOURCE |  |  -->  | Taint simple.test | test.py:183 | t |  |
 | Taint simple.test | test.py:178 | SOURCE |  |  -->  | Taint simple.test | test.py:186 | t |  |
+| Taint simple.test | test.py:195 | SOURCE |  |  -->  | Taint simple.test | test.py:196 | t |  |
+| Taint simple.test | test.py:195 | SOURCE |  |  -->  | Taint simple.test | test.py:197 | t |  |
+| Taint simple.test | test.py:195 | SOURCE |  |  -->  | Taint simple.test | test.py:199 | t |  |
 | Taint {simple.test} | test.py:169 | Dict |  |  -->  | Taint {simple.test} | test.py:171 | d |  |
 | Taint {simple.test} | test.py:169 | Dict |  |  -->  | Taint {simple.test} | test.py:175 | d |  |
 | Taint {simple.test} | test.py:171 | d |  |  -->  | Taint {simple.test} | test.py:173 | y |  |

--- a/python/ql/test/library-tests/taint/general/TestVar.expected
+++ b/python/ql/test/library-tests/taint/general/TestVar.expected
@@ -184,3 +184,10 @@
 | test.py:186 | t_4 | test.py:178 | Taint simple.test | SOURCE |
 | test.py:189 | t_0 | test.py:189 | Taint falsey | FALSEY |
 | test.py:191 | t_1 | test.py:189 | Taint falsey | FALSEY |
+| test.py:194 | t_6 | test.py:195 | Taint simple.test | SOURCE |
+| test.py:195 | t_0 | test.py:195 | Taint simple.test | SOURCE |
+| test.py:196 | t_1 | test.py:195 | Taint simple.test | SOURCE |
+| test.py:197 | t_2 | test.py:195 | Taint simple.test | SOURCE |
+| test.py:197 | t_3 | test.py:195 | Taint simple.test | SOURCE |
+| test.py:199 | t_4 | test.py:195 | Taint simple.test | SOURCE |
+| test.py:199 | t_5 | test.py:195 | Taint simple.test | SOURCE |

--- a/python/ql/test/library-tests/taint/general/test.py
+++ b/python/ql/test/library-tests/taint/general/test.py
@@ -190,3 +190,11 @@ def test_early_exit():
     if not t:
         return
     t
+
+def flow_through_type_test_if_no_class():
+    t = SOURCE
+    if isinstance(t, str):
+        SINK(t)
+    else:
+        SINK(t)
+


### PR DESCRIPTION
If taint has no result for `getClass()` then allow it flow through both branches of isinstance test.

This is a fairly obscure change, so shouldn't need a change note.