### PR TITLE
CPP: De-duplicate the PointerScaling queries.

### DIFF
--- a/cpp/ql/src/Security/CWE/CWE-468/IncorrectPointerScaling.ql
+++ b/cpp/ql/src/Security/CWE/CWE-468/IncorrectPointerScaling.ql
@@ -13,11 +13,6 @@ import cpp
 import semmle.code.cpp.controlflow.SSA
 import IncorrectPointerScalingCommon
 
-private predicate isPointerType(Type t) {
-  t instanceof PointerType or
-  t instanceof ArrayType
-}
-
 private Type baseType(Type t) {
   (
     exists (PointerType dt
@@ -34,84 +29,6 @@ private Type baseType(Type t) {
   )
   // Make sure that the type has a size and that it isn't ambiguous.  
   and strictcount(result.getSize()) = 1
-}
-
-/**
- * Holds if there is a pointer expression with type `sourceType` at
- * location `sourceLoc` which might be the source expression for `use`.
- *
- * For example, with
- * ```
- * int intArray[5] = { 1, 2, 3, 4, 5 };
- * char *charPointer = (char *)intArray;
- * return *(charPointer + i);
- * ```
- * the array initializer on the first line is a source expression
- * for the use of `charPointer` on the third line.
- *
- * The source will either be an `Expr` or a `Parameter`.
- */
-private
-predicate exprSourceType(Expr use, Type sourceType, Location sourceLoc) {
-  // Reaching definitions.
-  if exists (SsaDefinition def, LocalScopeVariable v | use = def.getAUse(v)) then
-    exists (SsaDefinition def, LocalScopeVariable v
-    | use = def.getAUse(v)
-    | defSourceType(def, v, sourceType, sourceLoc))
-
-  // Pointer arithmetic
-  else if use instanceof PointerAddExpr then
-    exprSourceType(use.(PointerAddExpr).getLeftOperand(), sourceType, sourceLoc)
-  else if use instanceof PointerSubExpr then
-    exprSourceType(use.(PointerSubExpr).getLeftOperand(), sourceType, sourceLoc)
-  else if use instanceof AddExpr then
-    exprSourceType(use.(AddExpr).getAnOperand(), sourceType, sourceLoc)
-  else if use instanceof SubExpr then
-    exprSourceType(use.(SubExpr).getAnOperand(), sourceType, sourceLoc)
-  else if use instanceof CrementOperation then
-    exprSourceType(use.(CrementOperation).getOperand(), sourceType, sourceLoc)
-
-  // Conversions are not in the AST, so ignore them.
-  else if use instanceof Conversion then
-    none()
-
-  // Source expressions
-  else
-    (sourceType = use.getType().getUnspecifiedType() and
-     isPointerType(sourceType) and
-     sourceLoc = use.getLocation())
-}
-
-/**
- * Holds if there is a pointer expression with type `sourceType` at
- * location `sourceLoc` which might define the value of `v` at `def`.
- */
-private
-predicate defSourceType(SsaDefinition def, LocalScopeVariable v,
-                        Type sourceType, Location sourceLoc) {
-  exprSourceType(def.getDefiningValue(v), sourceType, sourceLoc)
-  or
-  defSourceType(def.getAPhiInput(v), v, sourceType, sourceLoc)
-  or
-  exists (Parameter p
-  | p = v and
-    def.definedByParameter(p) and
-    sourceType = p.getType().getUnspecifiedType() and
-    strictcount(p.getType()) = 1 and
-    isPointerType(sourceType) and
-    sourceLoc = p.getLocation())
-}
-
-/**
- * Gets the pointer arithmetic expression that `e` is (directly) used
- * in, if any.
- *
- * For example, in `(char*)(p + 1)`, for `p`, ths result is `p + 1`.
- */
-private Expr pointerArithmeticParent(Expr e) {
-  e = result.(PointerAddExpr).getLeftOperand() or
-  e = result.(PointerSubExpr).getLeftOperand() or
-  e = result.(PointerDiffExpr).getAnOperand()
 }
 
 from Expr dest, Type destType, Type sourceType, Type sourceBase,

--- a/cpp/ql/src/Security/CWE/CWE-468/IncorrectPointerScaling.ql
+++ b/cpp/ql/src/Security/CWE/CWE-468/IncorrectPointerScaling.ql
@@ -13,24 +13,6 @@ import cpp
 import semmle.code.cpp.controlflow.SSA
 import IncorrectPointerScalingCommon
 
-private Type baseType(Type t) {
-  (
-    exists (PointerType dt
-    | dt = t.getUnspecifiedType() and
-      result = dt.getBaseType().getUnspecifiedType()) or
-    exists (ArrayType at
-    | at = t.getUnspecifiedType() and
-      (not at.getBaseType().getUnspecifiedType() instanceof ArrayType) and
-      result = at.getBaseType().getUnspecifiedType()) or
-    exists (ArrayType at, ArrayType at2
-    | at = t.getUnspecifiedType() and
-      at2 = at.getBaseType().getUnspecifiedType() and
-      result = baseType(at2))
-  )
-  // Make sure that the type has a size and that it isn't ambiguous.  
-  and strictcount(result.getSize()) = 1
-}
-
 from Expr dest, Type destType, Type sourceType, Type sourceBase,
      Type destBase, Location sourceLoc
 where exists(pointerArithmeticParent(dest))

--- a/cpp/ql/src/Security/CWE/CWE-468/IncorrectPointerScaling.ql
+++ b/cpp/ql/src/Security/CWE/CWE-468/IncorrectPointerScaling.ql
@@ -9,8 +9,6 @@
  * @tags security
  *       external/cwe/cwe-468
  */
-import cpp
-import semmle.code.cpp.controlflow.SSA
 import IncorrectPointerScalingCommon
 
 from Expr dest, Type destType, Type sourceType, Type sourceBase,

--- a/cpp/ql/src/Security/CWE/CWE-468/IncorrectPointerScalingChar.ql
+++ b/cpp/ql/src/Security/CWE/CWE-468/IncorrectPointerScalingChar.ql
@@ -14,12 +14,20 @@ import semmle.code.cpp.controlflow.SSA
 import IncorrectPointerScalingCommon
 
 private Type baseType(Type t) {
-  exists (DerivedType dt
-  | dt = t.getUnspecifiedType() and
-    isPointerType(dt) and
-    result = dt.getBaseType().getUnspecifiedType())
-
-  // Make sure that the type has a size and that it isn't ambiguous.
+  (
+    exists (PointerType dt
+    | dt = t.getUnspecifiedType() and
+      result = dt.getBaseType().getUnspecifiedType()) or
+    exists (ArrayType at
+    | at = t.getUnspecifiedType() and
+      (not at.getBaseType().getUnspecifiedType() instanceof ArrayType) and
+      result = at.getBaseType().getUnspecifiedType()) or
+    exists (ArrayType at, ArrayType at2
+    | at = t.getUnspecifiedType() and
+      at2 = at.getBaseType().getUnspecifiedType() and
+      result = baseType(at2))
+  )
+  // Make sure that the type has a size and that it isn't ambiguous.  
   and strictcount(result.getSize()) = 1
 }
 

--- a/cpp/ql/src/Security/CWE/CWE-468/IncorrectPointerScalingChar.ql
+++ b/cpp/ql/src/Security/CWE/CWE-468/IncorrectPointerScalingChar.ql
@@ -13,24 +13,6 @@ import cpp
 import semmle.code.cpp.controlflow.SSA
 import IncorrectPointerScalingCommon
 
-private Type baseType(Type t) {
-  (
-    exists (PointerType dt
-    | dt = t.getUnspecifiedType() and
-      result = dt.getBaseType().getUnspecifiedType()) or
-    exists (ArrayType at
-    | at = t.getUnspecifiedType() and
-      (not at.getBaseType().getUnspecifiedType() instanceof ArrayType) and
-      result = at.getBaseType().getUnspecifiedType()) or
-    exists (ArrayType at, ArrayType at2
-    | at = t.getUnspecifiedType() and
-      at2 = at.getBaseType().getUnspecifiedType() and
-      result = baseType(at2))
-  )
-  // Make sure that the type has a size and that it isn't ambiguous.  
-  and strictcount(result.getSize()) = 1
-}
-
 from Expr dest, Type destType, Type sourceType, Type sourceBase,
      Type destBase, Location sourceLoc
 where exists(pointerArithmeticParent(dest))

--- a/cpp/ql/src/Security/CWE/CWE-468/IncorrectPointerScalingChar.ql
+++ b/cpp/ql/src/Security/CWE/CWE-468/IncorrectPointerScalingChar.ql
@@ -9,8 +9,6 @@
  * @tags security
  *       external/cwe/cwe-468
  */
-import cpp
-import semmle.code.cpp.controlflow.SSA
 import IncorrectPointerScalingCommon
 
 from Expr dest, Type destType, Type sourceType, Type sourceBase,

--- a/cpp/ql/src/Security/CWE/CWE-468/IncorrectPointerScalingChar.ql
+++ b/cpp/ql/src/Security/CWE/CWE-468/IncorrectPointerScalingChar.ql
@@ -13,11 +13,6 @@ import cpp
 import semmle.code.cpp.controlflow.SSA
 import IncorrectPointerScalingCommon
 
-private predicate isPointerType(Type t) {
-  t instanceof PointerType or
-  t instanceof ArrayType
-}
-
 private Type baseType(Type t) {
   exists (DerivedType dt
   | dt = t.getUnspecifiedType() and
@@ -26,84 +21,6 @@ private Type baseType(Type t) {
 
   // Make sure that the type has a size and that it isn't ambiguous.
   and strictcount(result.getSize()) = 1
-}
-
-/**
- * Holds if there is a pointer expression with type `sourceType` at
- * location `sourceLoc` which might be the source expression for `use`.
- *
- * For example, with
- * ```
- * int intArray[5] = { 1, 2, 3, 4, 5 };
- * char *charPointer = (char *)intArray;
- * return *(charPointer + i);
- * ```
- * the array initializer on the first line is a source expression
- * for the use of `charPointer` on the third line.
- *
- * The source will either be an `Expr` or a `Parameter`.
- */
-private
-predicate exprSourceType(Expr use, Type sourceType, Location sourceLoc) {
-  // Reaching definitions.
-  if exists (SsaDefinition def, LocalScopeVariable v | use = def.getAUse(v)) then
-    exists (SsaDefinition def, LocalScopeVariable v
-    | use = def.getAUse(v)
-    | defSourceType(def, v, sourceType, sourceLoc))
-
-  // Pointer arithmetic
-  else if use instanceof PointerAddExpr then
-    exprSourceType(use.(PointerAddExpr).getLeftOperand(), sourceType, sourceLoc)
-  else if use instanceof PointerSubExpr then
-    exprSourceType(use.(PointerSubExpr).getLeftOperand(), sourceType, sourceLoc)
-  else if use instanceof AddExpr then
-    exprSourceType(use.(AddExpr).getAnOperand(), sourceType, sourceLoc)
-  else if use instanceof SubExpr then
-    exprSourceType(use.(SubExpr).getAnOperand(), sourceType, sourceLoc)
-  else if use instanceof CrementOperation then
-    exprSourceType(use.(CrementOperation).getOperand(), sourceType, sourceLoc)
-
-  // Conversions are not in the AST, so ignore them.
-  else if use instanceof Conversion then
-    none()
-
-  // Source expressions
-  else
-    (sourceType = use.getType().getUnspecifiedType() and
-     isPointerType(sourceType) and
-     sourceLoc = use.getLocation())
-}
-
-/**
- * Holds if there is a pointer expression with type `sourceType` at
- * location `sourceLoc` which might define the value of `v` at `def`.
- */
-private
-predicate defSourceType(SsaDefinition def, LocalScopeVariable v,
-                        Type sourceType, Location sourceLoc) {
-  exprSourceType(def.getDefiningValue(v), sourceType, sourceLoc)
-  or
-  defSourceType(def.getAPhiInput(v), v, sourceType, sourceLoc)
-  or
-  exists (Parameter p
-  | p = v and
-    def.definedByParameter(p) and
-    sourceType = p.getType().getUnspecifiedType() and
-    strictcount(p.getType()) = 1 and
-    isPointerType(sourceType) and
-    sourceLoc = p.getLocation())
-}
-
-/**
- * Gets the pointer arithmetic expression that `e` is (directly) used
- * in, if any.
- *
- * For example, in `(char*)(p + 1)`, for `p`, ths result is `p + 1`.
- */
-private Expr pointerArithmeticParent(Expr e) {
-  e = result.(PointerAddExpr).getLeftOperand() or
-  e = result.(PointerSubExpr).getLeftOperand() or
-  e = result.(PointerDiffExpr).getAnOperand()
 }
 
 from Expr dest, Type destType, Type sourceType, Type sourceBase,

--- a/cpp/ql/src/Security/CWE/CWE-468/IncorrectPointerScalingCommon.qll
+++ b/cpp/ql/src/Security/CWE/CWE-468/IncorrectPointerScalingCommon.qll
@@ -56,6 +56,28 @@ predicate isPointerType(Type t) {
 }
 
 /**
+ * Gets the base type of a pointer or array type.  In the case of an array of
+ * arrays, the inner base type is returned.
+ */
+Type baseType(Type t) {
+  (
+    exists (PointerType dt
+    | dt = t.getUnspecifiedType() and
+      result = dt.getBaseType().getUnspecifiedType()) or
+    exists (ArrayType at
+    | at = t.getUnspecifiedType() and
+      (not at.getBaseType().getUnspecifiedType() instanceof ArrayType) and
+      result = at.getBaseType().getUnspecifiedType()) or
+    exists (ArrayType at, ArrayType at2
+    | at = t.getUnspecifiedType() and
+      at2 = at.getBaseType().getUnspecifiedType() and
+      result = baseType(at2))
+  )
+  // Make sure that the type has a size and that it isn't ambiguous.  
+  and strictcount(result.getSize()) = 1
+}
+
+/**
  * Holds if there is a pointer expression with type `sourceType` at
  * location `sourceLoc` which might be the source expression for `use`.
  *

--- a/cpp/ql/src/Security/CWE/CWE-468/IncorrectPointerScalingVoid.ql
+++ b/cpp/ql/src/Security/CWE/CWE-468/IncorrectPointerScalingVoid.ql
@@ -14,12 +14,20 @@ import semmle.code.cpp.controlflow.SSA
 import IncorrectPointerScalingCommon
 
 private Type baseType(Type t) {
-  exists (DerivedType dt
-  | dt = t.getUnspecifiedType() and
-    isPointerType(dt) and
-    result = dt.getBaseType().getUnspecifiedType())
-
-  // Make sure that the type has a size and that it isn't ambiguous.
+  (
+    exists (PointerType dt
+    | dt = t.getUnspecifiedType() and
+      result = dt.getBaseType().getUnspecifiedType()) or
+    exists (ArrayType at
+    | at = t.getUnspecifiedType() and
+      (not at.getBaseType().getUnspecifiedType() instanceof ArrayType) and
+      result = at.getBaseType().getUnspecifiedType()) or
+    exists (ArrayType at, ArrayType at2
+    | at = t.getUnspecifiedType() and
+      at2 = at.getBaseType().getUnspecifiedType() and
+      result = baseType(at2))
+  )
+  // Make sure that the type has a size and that it isn't ambiguous.  
   and strictcount(result.getSize()) = 1
 }
 

--- a/cpp/ql/src/Security/CWE/CWE-468/IncorrectPointerScalingVoid.ql
+++ b/cpp/ql/src/Security/CWE/CWE-468/IncorrectPointerScalingVoid.ql
@@ -13,24 +13,6 @@ import cpp
 import semmle.code.cpp.controlflow.SSA
 import IncorrectPointerScalingCommon
 
-private Type baseType(Type t) {
-  (
-    exists (PointerType dt
-    | dt = t.getUnspecifiedType() and
-      result = dt.getBaseType().getUnspecifiedType()) or
-    exists (ArrayType at
-    | at = t.getUnspecifiedType() and
-      (not at.getBaseType().getUnspecifiedType() instanceof ArrayType) and
-      result = at.getBaseType().getUnspecifiedType()) or
-    exists (ArrayType at, ArrayType at2
-    | at = t.getUnspecifiedType() and
-      at2 = at.getBaseType().getUnspecifiedType() and
-      result = baseType(at2))
-  )
-  // Make sure that the type has a size and that it isn't ambiguous.  
-  and strictcount(result.getSize()) = 1
-}
-
 from Expr dest, Type destType, Type sourceType, Type sourceBase,
      Type destBase, Location sourceLoc
 where exists(pointerArithmeticParent(dest))

--- a/cpp/ql/src/Security/CWE/CWE-468/IncorrectPointerScalingVoid.ql
+++ b/cpp/ql/src/Security/CWE/CWE-468/IncorrectPointerScalingVoid.ql
@@ -9,8 +9,6 @@
  * @tags security
  *       external/cwe/cwe-468
  */
-import cpp
-import semmle.code.cpp.controlflow.SSA
 import IncorrectPointerScalingCommon
 
 from Expr dest, Type destType, Type sourceType, Type sourceBase,

--- a/cpp/ql/src/Security/CWE/CWE-468/IncorrectPointerScalingVoid.ql
+++ b/cpp/ql/src/Security/CWE/CWE-468/IncorrectPointerScalingVoid.ql
@@ -13,11 +13,6 @@ import cpp
 import semmle.code.cpp.controlflow.SSA
 import IncorrectPointerScalingCommon
 
-private predicate isPointerType(Type t) {
-  t instanceof PointerType or
-  t instanceof ArrayType
-}
-
 private Type baseType(Type t) {
   exists (DerivedType dt
   | dt = t.getUnspecifiedType() and
@@ -26,84 +21,6 @@ private Type baseType(Type t) {
 
   // Make sure that the type has a size and that it isn't ambiguous.
   and strictcount(result.getSize()) = 1
-}
-
-/**
- * Holds if there is a pointer expression with type `sourceType` at
- * location `sourceLoc` which might be the source expression for `use`.
- *
- * For example, with
- * ```
- * int intArray[5] = { 1, 2, 3, 4, 5 };
- * char *charPointer = (char *)intArray;
- * return *(charPointer + i);
- * ```
- * the array initializer on the first line is a source expression
- * for the use of `charPointer` on the third line.
- *
- * The source will either be an `Expr` or a `Parameter`.
- */
-private
-predicate exprSourceType(Expr use, Type sourceType, Location sourceLoc) {
-  // Reaching definitions.
-  if exists (SsaDefinition def, LocalScopeVariable v | use = def.getAUse(v)) then
-    exists (SsaDefinition def, LocalScopeVariable v
-    | use = def.getAUse(v)
-    | defSourceType(def, v, sourceType, sourceLoc))
-
-  // Pointer arithmetic
-  else if use instanceof PointerAddExpr then
-    exprSourceType(use.(PointerAddExpr).getLeftOperand(), sourceType, sourceLoc)
-  else if use instanceof PointerSubExpr then
-    exprSourceType(use.(PointerSubExpr).getLeftOperand(), sourceType, sourceLoc)
-  else if use instanceof AddExpr then
-    exprSourceType(use.(AddExpr).getAnOperand(), sourceType, sourceLoc)
-  else if use instanceof SubExpr then
-    exprSourceType(use.(SubExpr).getAnOperand(), sourceType, sourceLoc)
-  else if use instanceof CrementOperation then
-    exprSourceType(use.(CrementOperation).getOperand(), sourceType, sourceLoc)
-
-  // Conversions are not in the AST, so ignore them.
-  else if use instanceof Conversion then
-    none()
-
-  // Source expressions
-  else
-    (sourceType = use.getType().getUnspecifiedType() and
-     isPointerType(sourceType) and
-     sourceLoc = use.getLocation())
-}
-
-/**
- * Holds if there is a pointer expression with type `sourceType` at
- * location `sourceLoc` which might define the value of `v` at `def`.
- */
-private
-predicate defSourceType(SsaDefinition def, LocalScopeVariable v,
-                        Type sourceType, Location sourceLoc) {
-  exprSourceType(def.getDefiningValue(v), sourceType, sourceLoc)
-  or
-  defSourceType(def.getAPhiInput(v), v, sourceType, sourceLoc)
-  or
-  exists (Parameter p
-  | p = v and
-    def.definedByParameter(p) and
-    sourceType = p.getType().getUnspecifiedType() and
-    strictcount(p.getType()) = 1 and
-    isPointerType(sourceType) and
-    sourceLoc = p.getLocation())
-}
-
-/**
- * Gets the pointer arithmetic expression that `e` is (directly) used
- * in, if any.
- *
- * For example, in `(char*)(p + 1)`, for `p`, ths result is `p + 1`.
- */
-private Expr pointerArithmeticParent(Expr e) {
-  e = result.(PointerAddExpr).getLeftOperand() or
-  e = result.(PointerSubExpr).getLeftOperand() or
-  e = result.(PointerDiffExpr).getAnOperand()
 }
 
 from Expr dest, Type destType, Type sourceType, Type sourceBase,

--- a/cpp/ql/test/query-tests/Security/CWE/CWE-468/semmle/IncorrectPointerScaling/IncorrectPointerScalingChar.expected
+++ b/cpp/ql/test/query-tests/Security/CWE/CWE-468/semmle/IncorrectPointerScaling/IncorrectPointerScalingChar.expected
@@ -1,3 +1,4 @@
 | test.cpp:13:19:13:29 | charPointer | This pointer might have type $@ (size 4), but the pointer arithmetic here is done with type char * (size 1). | test.cpp:10:31:10:38 | test.cpp:10:31:10:38 | int |
 | test.cpp:77:17:77:17 | x | This pointer might have type $@ (size 4), but the pointer arithmetic here is done with type char * (size 1). | test.cpp:72:19:72:19 | test.cpp:72:19:72:19 | int |
 | test.cpp:119:26:119:26 | p | This pointer might have type $@ (size 8), but the pointer arithmetic here is done with type char * (size 1). | test.cpp:114:22:114:22 | test.cpp:114:22:114:22 | mystruct |
+| test.cpp:147:19:147:29 | charPointer | This pointer might have type $@ (size 8), but the pointer arithmetic here is done with type char * (size 1). | test.cpp:145:31:145:38 | test.cpp:145:31:145:38 | int[2] |

--- a/cpp/ql/test/query-tests/Security/CWE/CWE-468/semmle/IncorrectPointerScaling/IncorrectPointerScalingChar.expected
+++ b/cpp/ql/test/query-tests/Security/CWE/CWE-468/semmle/IncorrectPointerScaling/IncorrectPointerScalingChar.expected
@@ -1,4 +1,4 @@
 | test.cpp:13:19:13:29 | charPointer | This pointer might have type $@ (size 4), but the pointer arithmetic here is done with type char * (size 1). | test.cpp:10:31:10:38 | test.cpp:10:31:10:38 | int |
 | test.cpp:77:17:77:17 | x | This pointer might have type $@ (size 4), but the pointer arithmetic here is done with type char * (size 1). | test.cpp:72:19:72:19 | test.cpp:72:19:72:19 | int |
 | test.cpp:119:26:119:26 | p | This pointer might have type $@ (size 8), but the pointer arithmetic here is done with type char * (size 1). | test.cpp:114:22:114:22 | test.cpp:114:22:114:22 | mystruct |
-| test.cpp:147:19:147:29 | charPointer | This pointer might have type $@ (size 8), but the pointer arithmetic here is done with type char * (size 1). | test.cpp:145:31:145:38 | test.cpp:145:31:145:38 | int[2] |
+| test.cpp:147:19:147:29 | charPointer | This pointer might have type $@ (size 4), but the pointer arithmetic here is done with type char * (size 1). | test.cpp:145:31:145:38 | test.cpp:145:31:145:38 | int |

--- a/cpp/ql/test/query-tests/Security/CWE/CWE-468/semmle/IncorrectPointerScaling/test.cpp
+++ b/cpp/ql/test/query-tests/Security/CWE/CWE-468/semmle/IncorrectPointerScaling/test.cpp
@@ -139,3 +139,10 @@ void* test17(int* x) {
   // BAD: void pointer arithmetic is not portable across compilers
   return (void*)x + sizeof(int);
 }
+
+int test18(int i) {
+  int intArray[2][2] = { {1, 2}, {3, 4} };
+  char *charPointer = (char *)intArray;
+  // BAD: the pointer arithmetic uses type char*, so the offset is not scaled by sizeof(int).
+  return *(int *)(charPointer + i);
+}


### PR DESCRIPTION
Duplication makes maintenance difficult.  A difference in the `baseType` predicate had already snuck in between these three queries.

Note the copy-pasting is not exact, I have removed `private` and added qldoc comments as appropriate.

(promised in https://github.com/Semmle/ql/pull/644, except that it turns out a shared library already existed it just didn't have everything in it)