### PR TITLE
CPP: Revert recent microsoft detection change

### DIFF
--- a/cpp/ql/src/semmle/code/cpp/File.qll
+++ b/cpp/ql/src/semmle/code/cpp/File.qll
@@ -313,8 +313,6 @@ class File extends Container, @file {
       getAbsolutePath().charAt(1) = ":"
       	// this is not ideal, it detects compilation on a Windows file system
       	// as a heuristic approximation to compilation with a Microsoft compiler.
-    ) or (
-      getAbsolutePath().charAt(1) = "/"
     )
   }
 

--- a/cpp/ql/src/semmle/code/cpp/File.qll
+++ b/cpp/ql/src/semmle/code/cpp/File.qll
@@ -309,10 +309,6 @@ class File extends Container, @file {
     ) or exists(File parent |
       parent.compiledAsMicrosoft() and
       parent.getAnIncludedFile() = this
-    ) or (
-      getAbsolutePath().charAt(1) = ":"
-      	// this is not ideal, it detects compilation on a Windows file system
-      	// as a heuristic approximation to compilation with a Microsoft compiler.
     )
   }
 


### PR DESCRIPTION
Reverts https://github.com/Semmle/ql/pull/1191.

This will re-introduce the 239 WrongTypeFormatArgument FPs on ChakraCore on the differences job - but fix the Windows tests.

Annoyingly I can't actually find a snapshot where the original problem (failing to detect that files in a ChakraCore snapshot are built as Microsoft) actually occurs.  With such a snapshot I could analyse exactly the clues that are present and possibly develop a better solution.