### PR TITLE
JS: whitelist another emptiness check for the type-confusion query

### DIFF
--- a/change-notes/1.21/analysis-javascript.md
+++ b/change-notes/1.21/analysis-javascript.md
@@ -29,6 +29,7 @@
 | Incomplete string escaping or encoding | More results | This rule now considers the flow of regular expressions literals. |
 | Replacement of a substring with itself | More results | This rule now considers the flow of regular expressions literals. |
 | Server-side URL redirect       | Fewer false-positive results | This rule now treats URLs as safe in more cases where the hostname cannot be tampered with. |
+| Type confusion through parameter tampering | Fewer false-positive results | This rule now recognizes additional emptiness checks. |
 | Useless assignment to property | Fewer false-positive results | This rule now ignore reads of additional getters. |
 
 ## Changes to QL libraries

--- a/javascript/ql/test/query-tests/Security/CWE-843/tst.js
+++ b/javascript/ql/test/query-tests/Security/CWE-843/tst.js
@@ -68,4 +68,6 @@ express().get('/some/path/:foo', function(req, res) {
     while (p.length) { // OK
       p = p.substr(1);
     }
+
+    p.length < 1; // OK
 });


### PR DESCRIPTION
Fixes some this week's [anomalous query results](https://lgtm.com/projects/g/Swiftam/book-node-mongodb-backbone/alerts?rule=js%252Ftype-confusion-through-parameter-tampering&mode=tree&ruleFocus=1506301137371).

A sanity check evaluation is ongoing.