### PR TITLE
CPP: Fix FormatLiteral.isMicrosoft

### DIFF
--- a/cpp/ql/src/semmle/code/cpp/File.qll
+++ b/cpp/ql/src/semmle/code/cpp/File.qll
@@ -298,7 +298,12 @@ class File extends Container, @file {
     none()
   }
 
-  /** Holds if this file was compiled by a Microsoft compiler (at any point). */
+  /**
+   * Holds if this file was compiled by a Microsoft compiler (at any point).
+   *
+   * Note: currently unreliable - on some projects only some of the files that
+   * are compiled by a Microsoft compiler are detected by this predicate.
+   */
   predicate compiledAsMicrosoft() {
     exists(Compilation c |
       c.getAFileCompiled() = this and

--- a/cpp/ql/src/semmle/code/cpp/commons/Printf.qll
+++ b/cpp/ql/src/semmle/code/cpp/commons/Printf.qll
@@ -250,7 +250,7 @@ class FormatLiteral extends Literal {
    * Microsoft rules and extensions.
    */
   predicate isMicrosoft() {
-    getFile().compiledAsMicrosoft()
+    any(File f).compiledAsMicrosoft()
   }
 
   /**

--- a/cpp/ql/src/semmle/code/cpp/models/interfaces/FormattingFunction.qll
+++ b/cpp/ql/src/semmle/code/cpp/models/interfaces/FormattingFunction.qll
@@ -51,7 +51,7 @@ abstract class FormattingFunction extends Function {
    * Microsoft rules and extensions.
    */
   predicate isMicrosoft() {
-    getFile().compiledAsMicrosoft()
+    any(File f).compiledAsMicrosoft()
   }
 
   /**


### PR DESCRIPTION
It turns out `File.compiledAsMicrosoft()` is missing a lot of Microsoft compiled files that are built with `extractor.exe --mimic @-`.  As a quick fix, have the string formatting functions look for *any* Microsoft compiled file in the snapshot (i.e. assume a mix of compilers is not being used).  This should produce good reliability in practice.