### PR TITLE
JS: inline CallToObjectDefineProperty::getAPropertyAttribute

### DIFF
--- a/javascript/ql/src/Declarations/DeadStoreOfProperty.ql
+++ b/javascript/ql/src/Declarations/DeadStoreOfProperty.ql
@@ -161,7 +161,7 @@ where
   // exclude results from non-value definitions from `Object.defineProperty`
   (
     assign1 instanceof CallToObjectDefineProperty implies
-    assign1.(CallToObjectDefineProperty).getAPropertyAttribute().getPropertyName() = "value"
+    assign1.(CallToObjectDefineProperty).hasPropertyAttributeWrite("value", _)
   )
 select assign1.getWriteNode(),
   "This write to property '" + name + "' is useless, since $@ always overrides it.",

--- a/javascript/ql/src/Expressions/ExprHasNoEffect.ql
+++ b/javascript/ql/src/Expressions/ExprHasNoEffect.ql
@@ -39,7 +39,7 @@ predicate isGetterProperty(string name) {
   exists(CallToObjectDefineProperty defProp |
     name = defProp.getPropertyName() |
     // ... where `descriptor` defines a getter
-    defProp.getAPropertyAttribute().getPropertyName() = "get" or
+    defProp.hasPropertyAttributeWrite("get", _) or
     // ... where `descriptor` may define a getter
     exists (DataFlow::SourceNode descriptor |
       descriptor.flowsTo(defProp.getPropertyDescriptor()) |

--- a/javascript/ql/src/semmle/javascript/StandardLibrary.qll
+++ b/javascript/ql/src/semmle/javascript/StandardLibrary.qll
@@ -22,14 +22,17 @@ class CallToObjectDefineProperty extends DataFlow::MethodCallNode {
   /** Gets the data flow node denoting the descriptor of the property being defined. */
   DataFlow::Node getPropertyDescriptor() { result = getArgument(2) }
 
-  /** Gets a data flow node defining a descriptor attribute of the property being defined. */
-  DataFlow::PropWrite getAPropertyAttribute() {
-    exists (DataFlow::SourceNode descriptor |
+  /**
+   * Holds if there is an assignment to property `name` to the
+   * attributes object on this node, and the right hand side of the
+   * assignment is `rhs`.
+   */
+  predicate hasPropertyAttributeWrite(string name, DataFlow::Node rhs) {
+    exists(DataFlow::SourceNode descriptor |
       descriptor.flowsTo(getPropertyDescriptor()) and
-      result = descriptor.getAPropertyWrite()
+      descriptor.hasPropertyWrite(name, rhs)
     )
   }
-
 }
 
 /**


### PR DESCRIPTION
This appears to restore performance for `DeadStoreOfProperty.ql` to the one we had before #1113. #1156 also attempted to restore that performance, but that was only for the more serious dataflow stage timeouts.


```
                                   PRE-1113              CURRENT-master         THIS-PR
Project                            74e701f7ebd@5441352^  74e701f7ebd@662ad4b2c  74e701f7ebd@3ea4958a9
mxnet.js                           248                   921                    253
```

I will start a larger evaluation now.