### PR TITLE
Python: Make old query suites point to new query suites.

### DIFF
--- a/python/config/suites/lgtm/python2-alerts-lgtm
+++ b/python/config/suites/lgtm/python2-alerts-lgtm
@@ -1,1 +1,0 @@
-@import "python-alerts-lgtm"

--- a/python/config/suites/lgtm/python2-alerts-lgtm
+++ b/python/config/suites/lgtm/python2-alerts-lgtm
@@ -1,3 +1,1 @@
-# DO NOT EDIT
-# This is a stub file. The actual suite of queries to run is generated
-# automatically based on query precision and severity.
+@import "python-alerts-lgtm"

--- a/python/config/suites/lgtm/python2-lgtm
+++ b/python/config/suites/lgtm/python2-lgtm
@@ -1,2 +1,1 @@
-@import "python2-queries-lgtm"
-@import "python2-metrics-lgtm"
+@import "python-lgtm"

--- a/python/config/suites/lgtm/python2-lgtm
+++ b/python/config/suites/lgtm/python2-lgtm
@@ -1,1 +1,4 @@
+# This file (and the other python2- files in this directory) is present for
+# backwards compatibility, and can be removed once we reach version 1.23.
+
 @import "python-lgtm"

--- a/python/config/suites/lgtm/python2-metrics-lgtm
+++ b/python/config/suites/lgtm/python2-metrics-lgtm
@@ -1,17 +1,1 @@
-+ semmlecode-python-queries/Lexical/FCommentedOutCode.ql: /Metrics/Files
-    @_namespace com.lgtm/python-queries
-+ semmlecode-python-queries/Metrics/FLinesOfCode.ql: /Metrics/Files
-    @_namespace com.lgtm/python-queries
-+ semmlecode-python-queries/Metrics/FLinesOfComments.ql: /Metrics/Files
-    @_namespace com.lgtm/python-queries
-+ semmlecode-python-queries/Metrics/FLinesOfDuplicatedCode.ql: /Metrics/Duplication
-    @_namespace com.lgtm/python-queries
-+ semmlecode-python-queries/Metrics/FLinesOfSimilarCode.ql: /Metrics/Duplication
-    @_namespace com.lgtm/python-queries
-+ semmlecode-python-queries/Metrics/FNumberOfTests.ql: /Metrics/Functions
-    @_namespace com.lgtm/python-queries
-
-+ semmlecode-python-queries/Metrics/Dependencies/ExternalDependencies.ql
-    @_namespace com.lgtm/python-queries
-+ semmlecode-python-queries/Metrics/Dependencies/ExternalDependenciesSourceLinks.ql
-    @_namespace com.lgtm/python-queries
+@import "python-metrics-lgtm"

--- a/python/config/suites/lgtm/python2-metrics-lgtm
+++ b/python/config/suites/lgtm/python2-metrics-lgtm
@@ -1,1 +1,0 @@
-@import "python-metrics-lgtm"

--- a/python/config/suites/lgtm/python2-queries-lgtm
+++ b/python/config/suites/lgtm/python2-queries-lgtm
@@ -1,1 +1,0 @@
-@import "python-queries-lgtm"

--- a/python/config/suites/lgtm/python2-queries-lgtm
+++ b/python/config/suites/lgtm/python2-queries-lgtm
@@ -1,10 +1,1 @@
-+ semmlecode-python-queries/analysis/Definitions.ql
-    @_namespace com.lgtm/python-queries
-+ semmlecode-python-queries/analysis/AlertSuppression.ql
-    @_namespace com.lgtm/python-queries
-+ semmlecode-python-queries/Filters/ClassifyFiles.ql
-    @_namespace com.lgtm/python-queries
-+ semmlecode-python-queries/Filters/ImportAdditionalLibraries.ql
-    @_namespace com.lgtm/python-queries
-
-@import "python2-alerts-lgtm"
+@import "python-queries-lgtm"


### PR DESCRIPTION
As per the suggestion of @aibaars, we'll leave the `python2-*` query suites for the time being, but point them to the new files. 

I believe that this should be safe to merge now, and does not require a synchronised submodule bump. (Until the internal renaming PR is merged, `python2-alerts-lgtm` will simply be overwritten with the autogenerated query suite. After the merge, `python-alerts-lgtm` will be generated instead, and will then simply be imported into `python2-alerts-lgtm`. Either way, nothing should break.)