### PR TITLE
JS: Add model of 'cheerio'

### DIFF
--- a/change-notes/1.21/analysis-javascript.md
+++ b/change-notes/1.21/analysis-javascript.md
@@ -9,6 +9,7 @@
   - [Firebase](https://firebase.google.com/)
   - [Express](https://expressjs.com/)
   - [shelljs](https://www.npmjs.com/package/shelljs)
+  - [cheerio](https://www.npmjs.com/package/cheerio)
 
 * The security queries now track data flow through Base64 decoders such as the Node.js `Buffer` class, the DOM function `atob`, and a number of npm packages intcluding [`abab`](https://www.npmjs.com/package/abab), [`atob`](https://www.npmjs.com/package/atob), [`btoa`](https://www.npmjs.com/package/btoa), [`base-64`](https://www.npmjs.com/package/base-64), [`js-base64`](https://www.npmjs.com/package/js-base64), [`Base64.js`](https://www.npmjs.com/package/Base64) and [`base64-js`](https://www.npmjs.com/package/base64-js).
 

--- a/javascript/ql/src/javascript.qll
+++ b/javascript/ql/src/javascript.qll
@@ -60,6 +60,7 @@ import semmle.javascript.frameworks.AsyncPackage
 import semmle.javascript.frameworks.AWS
 import semmle.javascript.frameworks.Azure
 import semmle.javascript.frameworks.Babel
+import semmle.javascript.frameworks.Cheerio
 import semmle.javascript.frameworks.ComposedFunctions
 import semmle.javascript.frameworks.ClientRequests
 import semmle.javascript.frameworks.ClosureLibrary

--- a/javascript/ql/src/semmle/javascript/frameworks/Cheerio.qll
+++ b/javascript/ql/src/semmle/javascript/frameworks/Cheerio.qll
@@ -30,7 +30,7 @@ module Cheerio {
 
   /**
    * Creation of `cheerio` object, a collection of virtual DOM elements
-   * with an interface similar to jQuery objects.
+   * with an interface similar to that of a jQuery object.
    */
   class CheerioObjectCreation extends DataFlow::SourceNode {
     CheerioObjectCreation::Range range;

--- a/javascript/ql/src/semmle/javascript/frameworks/Cheerio.qll
+++ b/javascript/ql/src/semmle/javascript/frameworks/Cheerio.qll
@@ -1,0 +1,120 @@
+/**
+ * Provides a model of `cheerio`, a server-side DOM manipulation library like with a jQuery-like API.
+ */
+
+import javascript
+private import semmle.javascript.security.dataflow.Xss as Xss
+
+module Cheerio {
+  /**
+   * A reference to the `cheerio` function, possibly with a loaded DOM.
+   */
+  private DataFlow::SourceNode cheerioRef(DataFlow::TypeTracker t) {
+    t.start() and
+    (
+      result = DataFlow::moduleImport("cheerio")
+      or
+      exists(string name | result = cheerioRef().getAMemberCall(name) |
+        name = "load" or
+        name = "parseHTML"
+      )
+    )
+    or
+    exists(DataFlow::TypeTracker t2 | result = cheerioRef(t2).track(t2, t))
+  }
+
+  /**
+   * A reference to the `cheerio` function, possibly with a loaded DOM.
+   */
+  DataFlow::SourceNode cheerioRef() { result = cheerioRef(DataFlow::TypeTracker::end()) }
+
+  /**
+   * Creation of `cheerio` object, a collection of virtual DOM elements
+   * with an interface similar to jQuery objects.
+   */
+  class CheerioObjectCreation extends DataFlow::SourceNode {
+    CheerioObjectCreation::Range range;
+
+    CheerioObjectCreation() { this = range }
+  }
+
+  module CheerioObjectCreation {
+    /**
+     * Creation of a `cheerio` object.
+     */
+    abstract class Range extends DataFlow::SourceNode { }
+
+    private class DefaultRange extends Range {
+      DefaultRange() {
+        this = cheerioRef().getACall()
+        or
+        this = cheerioRef().getAMethodCall()
+      }
+    }
+  }
+
+  /**
+   * Gets a reference to a `cheerio` object, a collection of virtual DOM elements
+   * with an interface similar to jQuery objects.
+   */
+  private DataFlow::SourceNode cheerioObjectRef(DataFlow::TypeTracker t) {
+    t.start() and
+    result instanceof CheerioObjectCreation
+    or
+    // Chainable calls.
+    t.start() and
+    exists(DataFlow::MethodCallNode call, string name |
+      call = cheerioObjectRef().getAMethodCall(name) and
+      result = call
+    |
+      if name = "attr" or name = "data" or name = "prop" or name = "css"
+      then call.getNumArgument() = 2
+      else
+        if name = "val" or name = "html" or name = "text"
+        then call.getNumArgument() = 1
+        else (
+          name != "toString" and
+          name != "toArray" and
+          name != "hasClass"
+        )
+    )
+    or
+    exists(DataFlow::TypeTracker t2 | result = cheerioObjectRef(t2).track(t2, t))
+  }
+
+  /**
+   * Gets a reference to a `cheerio` object, a collection of virtual DOM elements
+   * with an interface similar to jQuery objects.
+   */
+  DataFlow::SourceNode cheerioObjectRef() {
+    result = cheerioObjectRef(DataFlow::TypeTracker::end())
+  }
+
+  /**
+   * Definition of a DOM attribute through `cheerio`.
+   */
+  class AttributeDef extends DOM::AttributeDefinition {
+    DataFlow::CallNode call;
+
+    AttributeDef() {
+      this = call.asExpr() and
+      call = cheerioObjectRef().getAMethodCall("attr") and
+      call.getNumArgument() >= 2
+    }
+
+    override string getName() { call.getArgument(0).mayHaveStringValue(result) }
+
+    override DataFlow::Node getValueNode() { result = call.getArgument(1) }
+  }
+
+  /**
+   * XSS sink through `cheerio`.
+   */
+  class XssSink extends Xss::DomBasedXss::Sink {
+    XssSink() {
+      exists(string name | this = cheerioObjectRef().getAMethodCall(name).getAnArgument() |
+        JQuery::isMethodArgumentInterpretedAsHtml(name)
+      )
+    }
+  }
+}

--- a/javascript/ql/src/semmle/javascript/frameworks/Cheerio.qll
+++ b/javascript/ql/src/semmle/javascript/frameworks/Cheerio.qll
@@ -1,5 +1,5 @@
 /**
- * Provides a model of `cheerio`, a server-side DOM manipulation library like with a jQuery-like API.
+ * Provides a model of `cheerio`, a server-side DOM manipulation library with a jQuery-like API.
  */
 
 import javascript

--- a/javascript/ql/src/semmle/javascript/frameworks/jQuery.qll
+++ b/javascript/ql/src/semmle/javascript/frameworks/jQuery.qll
@@ -289,7 +289,7 @@ private class JQueryClientRequest extends CustomClientRequest {
 
 module JQuery {
   /**
-   * Holds if the given method on a jQuery object may interpret any of its
+   * Holds if method `name` on a jQuery object may interpret any of its
    * arguments as HTML.
    */
   predicate isMethodArgumentInterpretedAsHtml(string name) {

--- a/javascript/ql/src/semmle/javascript/frameworks/jQuery.qll
+++ b/javascript/ql/src/semmle/javascript/frameworks/jQuery.qll
@@ -309,7 +309,7 @@ module JQuery {
   }
 
   /**
-   * Holds if the given method on a jQuery object may interpret any of its
+   * Holds if method `name` on a jQuery object may interpret any of its
    * arguments as a selector.
    */
   predicate isMethodArgumentInterpretedAsSelector(string name) {

--- a/javascript/ql/src/semmle/javascript/frameworks/jQuery.qll
+++ b/javascript/ql/src/semmle/javascript/frameworks/jQuery.qll
@@ -66,21 +66,7 @@ class JQueryMethodCall extends CallExpr {
    */
   predicate interpretsArgumentAsHtml(Expr e) {
     // some methods interpret all their arguments as (potential) HTML
-    (
-      name = "after" or
-      name = "append" or
-      name = "appendTo" or
-      name = "before" or
-      name = "html" or
-      name = "insertAfter" or
-      name = "insertBefore" or
-      name = "prepend" or
-      name = "prependTo" or
-      name = "replaceWith" or
-      name = "wrap" or
-      name = "wrapAll" or
-      name = "wrapInner"
-    ) and
+    JQuery::isMethodArgumentInterpretedAsHtml(name) and
     e = getAnArgument()
     or
     // for `$, it's only the first one
@@ -97,15 +83,7 @@ class JQueryMethodCall extends CallExpr {
    */
   predicate interpretsArgumentAsSelector(Expr e) {
     // some methods interpret all their arguments as (potential) selectors
-    (
-      name = "appendTo" or
-      name = "insertAfter" or
-      name = "insertBefore" or
-      name = "prependTo" or
-      name = "wrap" or
-      name = "wrapAll" or
-      name = "wrapInner"
-    ) and
+    JQuery::isMethodArgumentInterpretedAsSelector(name) and
     e = getAnArgument()
     or
     // for `$, it's only the first one
@@ -307,4 +285,40 @@ private class JQueryClientRequest extends CustomClientRequest {
   override DataFlow::Node getHost() { none() }
 
   override DataFlow::Node getADataNode() { result = getOptionArgument([0 .. 1], "data") }
+}
+
+module JQuery {
+  /**
+   * Holds if the given method on a jQuery object may interpret any of its
+   * arguments as HTML.
+   */
+  predicate isMethodArgumentInterpretedAsHtml(string name) {
+    name = "after" or
+    name = "append" or
+    name = "appendTo" or
+    name = "before" or
+    name = "html" or
+    name = "insertAfter" or
+    name = "insertBefore" or
+    name = "prepend" or
+    name = "prependTo" or
+    name = "replaceWith" or
+    name = "wrap" or
+    name = "wrapAll" or
+    name = "wrapInner"
+  }
+
+  /**
+   * Holds if the given method on a jQuery object may interpret any of its
+   * arguments as a selector.
+   */
+  predicate isMethodArgumentInterpretedAsSelector(string name) {
+    name = "appendTo" or
+    name = "insertAfter" or
+    name = "insertBefore" or
+    name = "prependTo" or
+    name = "wrap" or
+    name = "wrapAll" or
+    name = "wrapInner"
+  }
 }

--- a/javascript/ql/test/library-tests/frameworks/Cheerio/Cheerio.expected
+++ b/javascript/ql/test/library-tests/frameworks/Cheerio/Cheerio.expected
@@ -1,0 +1,18 @@
+test_CheerioRef
+| tst.js:1:1:1:30 | import  ... eerio"; |
+| tst.js:1:8:1:14 | cheerio |
+| tst.js:4:11:4:23 | getTemplate() |
+| tst.js:9:10:9:36 | cheerio ... t</b>') |
+test_CheerioObjectCreation
+| tst.js:5:3:5:18 | $.attr('foo', 5) |
+| tst.js:9:10:9:36 | cheerio ... t</b>') |
+test_AttributeDefinition
+| tst.js:5:3:5:18 | $.attr('foo', 5) |
+test_CheerioObjectRef
+| tst.js:4:11:4:23 | getTemplate() |
+| tst.js:5:3:5:18 | $.attr('foo', 5) |
+| tst.js:5:3:5:33 | $.attr( ... ar', 6) |
+| tst.js:5:3:5:41 | $.attr( ... html(x) |
+| tst.js:9:10:9:36 | cheerio ... t</b>') |
+test_XssSink
+| tst.js:5:40:5:40 | x |

--- a/javascript/ql/test/library-tests/frameworks/Cheerio/Cheerio.ql
+++ b/javascript/ql/test/library-tests/frameworks/Cheerio/Cheerio.ql
@@ -1,0 +1,11 @@
+import javascript
+
+query DataFlow::Node test_CheerioRef() { result = Cheerio::cheerioRef() }
+
+query Cheerio::CheerioObjectCreation test_CheerioObjectCreation() { any() }
+
+query DOM::AttributeDefinition test_AttributeDefinition() { any() }
+
+query DataFlow::Node test_CheerioObjectRef() { result = Cheerio::cheerioObjectRef() }
+
+query Cheerio::XssSink test_XssSink() { any() }

--- a/javascript/ql/test/library-tests/frameworks/Cheerio/tst.js
+++ b/javascript/ql/test/library-tests/frameworks/Cheerio/tst.js
@@ -1,0 +1,10 @@
+import cheerio from "cheerio";
+
+function test(x) {
+  let $ = getTemplate(); 
+  $.attr('foo', 5).data('bar', 6).html(x);
+}
+
+function getTemplate() {
+  return cheerio.load('<b>text</b>');
+}


### PR DESCRIPTION
Adds a model of [cheerio](https://www.npmjs.com/package/cheerio). I haven't found any results with it, but we might as well include it now that it's written.

Injecting HTML into the virtual DOM is treated as an XSS sink. It's not necessarily exploitable if the virtual dom is never rendered in a browser, but the same is technically true for JSX elements (also a virtual dom), so I've just given it the same treatment for now.

[Evaluation](https://git.semmle.com/asger/dist-compare-reports/tree/balbinus.ti.semmle.com_1554500806403).