### PR TITLE
JS: whitelilist delimiter unwrapping for js/incomplete-sanitization

### DIFF
--- a/javascript/ql/test/query-tests/Security/CWE-116/IncompleteSanitization/IncompleteSanitization.expected
+++ b/javascript/ql/test/query-tests/Security/CWE-116/IncompleteSanitization/IncompleteSanitization.expected
@@ -15,3 +15,19 @@
 | tst.js:61:10:61:18 | s.replace | This replaces only the first occurrence of "'" + "". |
 | tst.js:65:10:65:18 | s.replace | This replaces only the first occurrence of "'". |
 | tst.js:69:10:69:18 | s.replace | This replaces only the first occurrence of "'" + "". |
+| tst.js:130:2:130:10 | s.replace | This replaces only the first occurrence of '['. |
+| tst.js:130:2:130:27 | s.repla ... replace | This replaces only the first occurrence of ']'. |
+| tst.js:132:2:132:10 | s.replace | This replaces only the first occurrence of '{'. |
+| tst.js:132:2:132:27 | s.repla ... replace | This replaces only the first occurrence of '}'. |
+| tst.js:133:2:133:10 | s.replace | This replaces only the first occurrence of '<'. |
+| tst.js:133:2:133:27 | s.repla ... replace | This replaces only the first occurrence of '>'. |
+| tst.js:135:2:135:10 | s.replace | This replaces only the first occurrence of '['. |
+| tst.js:135:2:135:30 | s.repla ... replace | This replaces only the first occurrence of ']'. |
+| tst.js:136:2:136:10 | s.replace | This replaces only the first occurrence of '{'. |
+| tst.js:136:2:136:30 | s.repla ... replace | This replaces only the first occurrence of '}'. |
+| tst.js:138:6:138:14 | s.replace | This replaces only the first occurrence of '['. |
+| tst.js:139:6:139:14 | s.replace | This replaces only the first occurrence of ']'. |
+| tst.js:140:2:140:10 | s.replace | This replaces only the first occurrence of /{/. |
+| tst.js:140:2:140:27 | s.repla ... replace | This replaces only the first occurrence of /}/. |
+| tst.js:141:2:141:10 | s.replace | This replaces only the first occurrence of ']'. |
+| tst.js:141:2:141:27 | s.repla ... replace | This replaces only the first occurrence of '['. |

--- a/javascript/ql/test/query-tests/Security/CWE-116/IncompleteSanitization/IncompleteSanitization.expected
+++ b/javascript/ql/test/query-tests/Security/CWE-116/IncompleteSanitization/IncompleteSanitization.expected
@@ -15,18 +15,12 @@
 | tst.js:61:10:61:18 | s.replace | This replaces only the first occurrence of "'" + "". |
 | tst.js:65:10:65:18 | s.replace | This replaces only the first occurrence of "'". |
 | tst.js:69:10:69:18 | s.replace | This replaces only the first occurrence of "'" + "". |
-| tst.js:130:2:130:10 | s.replace | This replaces only the first occurrence of '['. |
-| tst.js:130:2:130:27 | s.repla ... replace | This replaces only the first occurrence of ']'. |
-| tst.js:132:2:132:10 | s.replace | This replaces only the first occurrence of '{'. |
-| tst.js:132:2:132:27 | s.repla ... replace | This replaces only the first occurrence of '}'. |
 | tst.js:133:2:133:10 | s.replace | This replaces only the first occurrence of '<'. |
 | tst.js:133:2:133:27 | s.repla ... replace | This replaces only the first occurrence of '>'. |
 | tst.js:135:2:135:10 | s.replace | This replaces only the first occurrence of '['. |
 | tst.js:135:2:135:30 | s.repla ... replace | This replaces only the first occurrence of ']'. |
 | tst.js:136:2:136:10 | s.replace | This replaces only the first occurrence of '{'. |
 | tst.js:136:2:136:30 | s.repla ... replace | This replaces only the first occurrence of '}'. |
-| tst.js:138:6:138:14 | s.replace | This replaces only the first occurrence of '['. |
-| tst.js:139:6:139:14 | s.replace | This replaces only the first occurrence of ']'. |
 | tst.js:140:2:140:10 | s.replace | This replaces only the first occurrence of /{/. |
 | tst.js:140:2:140:27 | s.repla ... replace | This replaces only the first occurrence of /}/. |
 | tst.js:141:2:141:10 | s.replace | This replaces only the first occurrence of ']'. |

--- a/javascript/ql/test/query-tests/Security/CWE-116/IncompleteSanitization/tst.js
+++ b/javascript/ql/test/query-tests/Security/CWE-116/IncompleteSanitization/tst.js
@@ -126,6 +126,21 @@ function good11(s) {
   return s.replace("%d", "42");
 }
 
+function good12(s) {
+	s.replace('[', '').replace(']', ''); // OK
+	s.replace('(', '').replace(')', ''); // OK
+	s.replace('{', '').replace('}', ''); // OK
+	s.replace('<', '').replace('>', ''); // NOT OK: too common as a bad HTML sanitizer
+
+	s.replace('[', '\\[').replace(']', '\\]'); // NOT OK
+	s.replace('{', '\\{').replace('}', '\\}'); // NOT OK
+
+	s = s.replace('[', ''); // OK
+	s = s.replace(']', ''); // OK
+	s.replace(/{/, '').replace(/}/, ''); // NOT OK: should have used a string literal if a single replacement was intended
+	s.replace(']', '').replace('[', ''); // probably OK, but still flagged
+}
+
 app.get('/some/path', function(req, res) {
   let untrusted = req.param("p");
 
@@ -162,4 +177,5 @@ app.get('/some/path', function(req, res) {
   good10(untrusted);
   flowifyComments(untrusted);
   good11(untrusted);
+  good12(untrusted);
 });


### PR DESCRIPTION
Addresses a part of <https://jira.semmle.com/browse/ODASA-7891>. Unwrapper-calls like `var unwrapped = str.replace('{', '').replace('}', '')` are no longer flagged.

Evaluation is ongoing. This is being considered for the 1.20.1 patch release.