### PR TITLE
JavaScript: Improve AMD support in type inference.

### DIFF
--- a/javascript/ql/src/semmle/javascript/dataflow/internal/InterModuleTypeInference.qll
+++ b/javascript/ql/src/semmle/javascript/dataflow/internal/InterModuleTypeInference.qll
@@ -248,10 +248,18 @@ private class AnalyzedAmdImport extends AnalyzedPropertyRead, DataFlow::Node {
   Module required;
 
   AnalyzedAmdImport() {
-    exists(AmdModule amd, PathExpr dep, Parameter p |
-      amd.getDefine().dependencyParameter(dep, p) and
-      this = DataFlow::parameterNode(p) and
-      required.getFile() = amd.resolve(dep)
+    exists(AmdModule amd, PathExpr dep |
+      exists(Parameter p |
+        amd.getDefine().dependencyParameter(dep, p) and
+        this = DataFlow::parameterNode(p)
+      )
+      or
+      exists(CallExpr requireCall |
+        requireCall = amd.getDefine().getARequireCall() and
+        dep = requireCall.getAnArgument() and
+        this = requireCall.flow()
+      ) |
+      required = dep.(Import).getImportedModule()
     )
   }
 

--- a/javascript/ql/test/library-tests/Flow/AbstractValues.expected
+++ b/javascript/ql/test/library-tests/Flow/AbstractValues.expected
@@ -19,6 +19,14 @@
 | amd3.js:1:1:5:0 | module object of module amd3 |
 | amd3.js:1:24:4:1 | anonymous function |
 | amd3.js:1:24:4:1 | instance of anonymous function |
+| amd4.js:1:1:4:0 | exports object of module amd4 |
+| amd4.js:1:1:4:0 | module object of module amd4 |
+| amd4.js:1:28:3:1 | anonymous function |
+| amd4.js:1:28:3:1 | instance of anonymous function |
+| amd5.js:1:1:4:0 | exports object of module amd5 |
+| amd5.js:1:1:4:0 | module object of module amd5 |
+| amd5.js:1:21:3:1 | anonymous function |
+| amd5.js:1:21:3:1 | instance of anonymous function |
 | amd.js:1:1:7:0 | exports object of module amd |
 | amd.js:1:1:7:0 | module object of module amd |
 | amd.js:1:31:6:1 | anonymous function |

--- a/javascript/ql/test/library-tests/Flow/abseval.expected
+++ b/javascript/ql/test/library-tests/Flow/abseval.expected
@@ -12,6 +12,12 @@
 | amd3.js:3:7:3:8 | _c | amd3.js:3:12:3:12 | c | c.js:1:1:7:0 | exports object of module c |
 | amd3.js:3:7:3:8 | _c | amd3.js:3:12:3:12 | c | c.js:1:18:1:19 | object literal |
 | amd3.js:3:7:3:8 | _c | amd3.js:3:12:3:12 | c | file://:0:0:0:0 | indefinite value (call) |
+| amd4.js:2:7:2:8 | _u | amd4.js:2:12:2:12 | u | file://:0:0:0:0 | indefinite value (call) |
+| amd4.js:2:7:2:8 | _u | amd4.js:2:12:2:12 | u | file://:0:0:0:0 | non-empty, non-numeric string |
+| amd4.js:2:7:2:8 | _u | amd4.js:2:12:2:12 | u | reexport/lib/src/utils/util.js:1:1:3:0 | exports object of module util |
+| amd5.js:2:7:2:8 | _u | amd5.js:2:12:2:32 | req('sr ... /util') | file://:0:0:0:0 | indefinite value (call) |
+| amd5.js:2:7:2:8 | _u | amd5.js:2:12:2:32 | req('sr ... /util') | file://:0:0:0:0 | non-empty, non-numeric string |
+| amd5.js:2:7:2:8 | _u | amd5.js:2:12:2:32 | req('sr ... /util') | reexport/lib/src/utils/util.js:1:1:3:0 | exports object of module util |
 | amd.js:2:7:2:7 | m | amd.js:2:11:2:13 | mod | amd.js:1:1:7:0 | module object of module amd |
 | amd.js:2:7:2:7 | m | amd.js:2:11:2:13 | mod | file://:0:0:0:0 | indefinite value (call) |
 | amd.js:3:7:3:7 | e | amd.js:3:11:3:13 | exp | amd.js:1:1:7:0 | exports object of module amd |

--- a/javascript/ql/test/library-tests/Flow/amd4.js
+++ b/javascript/ql/test/library-tests/Flow/amd4.js
@@ -1,0 +1,3 @@
+define(['src/utils/util'], function(u) {
+  var _u = u;
+});

--- a/javascript/ql/test/library-tests/Flow/amd5.js
+++ b/javascript/ql/test/library-tests/Flow/amd5.js
@@ -1,0 +1,3 @@
+define(['require'], function(req) {
+  var _u = req('src/utils/util');
+});

--- a/javascript/ql/test/library-tests/Flow/getAPrototype.expected
+++ b/javascript/ql/test/library-tests/Flow/getAPrototype.expected
@@ -3,6 +3,8 @@
 | a.js:15:1:17:1 | instance of function bump | a.js:15:1:17:1 | instance of function bump |
 | amd2.js:1:8:3:1 | instance of anonymous function | amd2.js:1:8:3:1 | instance of anonymous function |
 | amd3.js:1:24:4:1 | instance of anonymous function | amd3.js:1:24:4:1 | instance of anonymous function |
+| amd4.js:1:28:3:1 | instance of anonymous function | amd4.js:1:28:3:1 | instance of anonymous function |
+| amd5.js:1:21:3:1 | instance of anonymous function | amd5.js:1:21:3:1 | instance of anonymous function |
 | amd.js:1:31:6:1 | instance of anonymous function | amd.js:1:31:6:1 | instance of anonymous function |
 | arguments.js:1:2:3:1 | instance of anonymous function | arguments.js:1:2:3:1 | instance of anonymous function |
 | arguments.js:5:2:8:1 | instance of anonymous function | arguments.js:5:2:8:1 | instance of anonymous function |

--- a/javascript/ql/test/library-tests/Flow/types.expected
+++ b/javascript/ql/test/library-tests/Flow/types.expected
@@ -5,6 +5,8 @@
 | a.js:14:12:14:24 | notAlwaysZero | a.js:14:28:14:28 | 0 | number |
 | amd3.js:2:7:2:8 | _a | amd3.js:2:12:2:12 | a | boolean, class, date, function, null, number, object, regular expression,string or undefined |
 | amd3.js:3:7:3:8 | _c | amd3.js:3:12:3:12 | c | boolean, class, date, function, null, number, object, regular expression,string or undefined |
+| amd4.js:2:7:2:8 | _u | amd4.js:2:12:2:12 | u | boolean, class, date, function, null, number, object, regular expression,string or undefined |
+| amd5.js:2:7:2:8 | _u | amd5.js:2:12:2:32 | req('sr ... /util') | boolean, class, date, function, null, number, object, regular expression,string or undefined |
 | amd.js:2:7:2:7 | m | amd.js:2:11:2:13 | mod | boolean, class, date, function, null, number, object, regular expression,string or undefined |
 | amd.js:3:7:3:7 | e | amd.js:3:11:3:13 | exp | boolean, class, date, function, null, number, object, regular expression,string or undefined |
 | arguments.js:2:7:2:7 | y | arguments.js:2:11:2:11 | x | number |


### PR DESCRIPTION
Now leverages the recently introduced logic for resolving AMD imports based on unique matching paths.

The duplication with `AmdModuleDefinition.getADependency` is a little unfortunate, but can perhaps be addressed separately.

Full evaluation showed no performance regressions or result changes.