### PR TITLE
JavaScript: Teach AutoBuilder to extract YAML files by default.

### DIFF
--- a/change-notes/1.21/extractor-javascript.md
+++ b/change-notes/1.21/extractor-javascript.md
@@ -1,0 +1,7 @@
+[[ condition: enterprise-only ]]
+
+# Improvements to JavaScript analysis
+
+## Changes to code extraction
+
+* YAML files are now extracted by default on LGTM. You can specify exclusion filters in your `lgtm.yml` file to override this behavior.

--- a/javascript/extractor/src/com/semmle/js/extractor/AutoBuild.java
+++ b/javascript/extractor/src/com/semmle/js/extractor/AutoBuild.java
@@ -128,6 +128,8 @@ import java.util.stream.Stream;
  *       FileType#JS} (currently ".js", ".jsx", ".mjs", ".es6", ".es").
  *   <li>All HTML files, that is, files with with one of the extensions supported by {@link
  *       FileType#HTML} (currently ".htm", ".html", ".xhtm", ".xhtml", ".vue").
+ *   <li>All YAML files, that is, files with one of the extensions supported by {@link
+ *       FileType#YAML} (currently ".raml", ".yaml", ".yml").
  *   <li>Files with base name "package.json".
  *   <li>JavaScript, JSON or YAML files whose base name starts with ".eslintrc".
  *   <li>All extension-less files.
@@ -338,10 +340,11 @@ public class AutoBuild {
     // exclude all files with extensions
     patterns.add("-**/*.*");
 
-    // but include HTML, JavaScript and (optionally) TypeScript
+    // but include HTML, JavaScript, YAML and (optionally) TypeScript
     Set<FileType> defaultExtract = new LinkedHashSet<FileType>();
     defaultExtract.add(FileType.HTML);
     defaultExtract.add(FileType.JS);
+    defaultExtract.add(FileType.YAML);
     if (typeScriptMode != TypeScriptMode.NONE) defaultExtract.add(FileType.TYPESCRIPT);
     for (FileType filetype : defaultExtract)
       for (String extension : filetype.getExtensions()) patterns.add("**/*" + extension);

--- a/javascript/extractor/src/com/semmle/js/extractor/test/AutoBuildTests.java
+++ b/javascript/extractor/src/com/semmle/js/extractor/test/AutoBuildTests.java
@@ -491,4 +491,12 @@ public class AutoBuildTests {
       Assert.assertEquals("Invalid file type 'javascript'.", ue.getMessage());
     }
   }
+
+  @Test
+  public void includeYaml() throws IOException {
+    addFile(true, LGTM_SRC, "tst.yaml");
+    addFile(true, LGTM_SRC, "tst.yml");
+    addFile(true, LGTM_SRC, "tst.raml");
+    addFile(true, LGTM_SRC, "tst2.YML");
+  }
 }


### PR DESCRIPTION
Our default benchmark projects only contain a little more than 200 KLoC of YAML overall, so it seems pretty safe to just extract it all by default. (For comparison, there are over 4.6 MLoC of JSON in the same projects.)

This won't affect our default analysis very much, but could be useful for custom queries.

I've added a change note and will file an issue ticket to update the LGTM documentation once this is merged.