### PR TITLE
JS: newline removal whitelist for js/incomplete-sanitization

### DIFF
--- a/change-notes/1.21/analysis-javascript.md
+++ b/change-notes/1.21/analysis-javascript.md
@@ -30,7 +30,7 @@
 | Double escaping or unescaping | More results | This rule now considers the flow of regular expressions literals. |
 | Expression has no effect       | Fewer false-positive results | This rule now treats uses of `Object.defineProperty` more conservatively. |
 | Incomplete regular expression for hostnames | More results | This rule now tracks regular expressions for host names further. |
-| Incomplete string escaping or encoding | More results | This rule now considers the flow of regular expressions literals. |
+| Incomplete string escaping or encoding | More results | This rule now considers the flow of regular expressions literals, and it no longer flags the removal of trailing newlines. |
 | Password in configuration file | Fewer false positive results | This query now excludes passwords that are inserted into the configuration file using a templating mechanism. |
 | Replacement of a substring with itself | More results | This rule now considers the flow of regular expressions literals. |
 | Server-side URL redirect       | Fewer false-positive results | This rule now treats URLs as safe in more cases where the hostname cannot be tampered with. |

--- a/javascript/ql/test/query-tests/Security/CWE-116/IncompleteSanitization/IncompleteSanitization.expected
+++ b/javascript/ql/test/query-tests/Security/CWE-116/IncompleteSanitization/IncompleteSanitization.expected
@@ -25,4 +25,7 @@
 | tst.js:140:2:140:27 | s.repla ... replace | This replaces only the first occurrence of /}/. |
 | tst.js:141:2:141:10 | s.replace | This replaces only the first occurrence of ']'. |
 | tst.js:141:2:141:27 | s.repla ... replace | This replaces only the first occurrence of '['. |
-| tst.js:185:9:185:17 | s.replace | This replaces only the first occurrence of /'/. |
+| tst.js:146:2:146:68 | require ... replace | This replaces only the first occurrence of "\\n". |
+| tst.js:148:2:148:10 | x.replace | This replaces only the first occurrence of "\\n". |
+| tst.js:149:2:149:24 | x.repla ... replace | This replaces only the first occurrence of "\\n". |
+| tst.js:193:9:193:17 | s.replace | This replaces only the first occurrence of /'/. |

--- a/javascript/ql/test/query-tests/Security/CWE-116/IncompleteSanitization/IncompleteSanitization.expected
+++ b/javascript/ql/test/query-tests/Security/CWE-116/IncompleteSanitization/IncompleteSanitization.expected
@@ -25,7 +25,6 @@
 | tst.js:140:2:140:27 | s.repla ... replace | This replaces only the first occurrence of /}/. |
 | tst.js:141:2:141:10 | s.replace | This replaces only the first occurrence of ']'. |
 | tst.js:141:2:141:27 | s.repla ... replace | This replaces only the first occurrence of '['. |
-| tst.js:146:2:146:68 | require ... replace | This replaces only the first occurrence of "\\n". |
 | tst.js:148:2:148:10 | x.replace | This replaces only the first occurrence of "\\n". |
 | tst.js:149:2:149:24 | x.repla ... replace | This replaces only the first occurrence of "\\n". |
 | tst.js:193:9:193:17 | s.replace | This replaces only the first occurrence of /'/. |

--- a/javascript/ql/test/query-tests/Security/CWE-116/IncompleteSanitization/tst.js
+++ b/javascript/ql/test/query-tests/Security/CWE-116/IncompleteSanitization/tst.js
@@ -141,6 +141,14 @@ function good12(s) {
 	s.replace(']', '').replace('[', ''); // probably OK, but still flagged
 }
 
+function newlines(s) {
+	// motivation for whitelist
+	require("child_process").execSync("which emacs").toString().replace("\n", ""); // OK
+
+	x.replace("\n", "").replace(x, y); // NOT OK
+	x.replace(x, y).replace("\n", ""); // NOT OK
+}
+
 app.get('/some/path', function(req, res) {
   let untrusted = req.param("p");
 


### PR DESCRIPTION
Addresses the newline part of <https://jira.semmle.com/browse/ODASA-7891>, we now no longer flag:

```js
require("child_process").execSync("which emacs").toString().replace("\n", "")
```

OK'ish [result changes](https://git.semmle.com/esben/dist-compare-reports/tree/js/whitelist-trailing-newline-removal_1554999967413). Eliminates least one [definite FP](https://github.com/mozilla/pdf.js/blob/9128335c4ddf91daabe1b2d4512b9bb207edc652/gulpfile.js#L473), the other eliminated alerts may be TPs if we are unlucky, but I doubt they are security related.

(This will conflict with the upcoming merge-back for #1229)