### PR TITLE
JS: Don't use refinement nodes as root of an access path

### DIFF
--- a/javascript/ql/test/library-tests/TaintBarriers/isBarrier.expected
+++ b/javascript/ql/test/library-tests/TaintBarriers/isBarrier.expected
@@ -17,7 +17,9 @@
 | tst.js:134:14:134:16 | v.p | ExampleConfiguration |
 | tst.js:136:14:136:18 | v.p.q | ExampleConfiguration |
 | tst.js:148:9:148:27 | v | ExampleConfiguration |
+| tst.js:149:14:149:14 | v | ExampleConfiguration |
 | tst.js:154:9:154:27 | v | ExampleConfiguration |
+| tst.js:157:14:157:14 | v | ExampleConfiguration |
 | tst.js:160:9:160:30 | v | ExampleConfiguration |
 | tst.js:160:35:160:56 | v | ExampleConfiguration |
 | tst.js:167:14:167:14 | v | ExampleConfiguration |
@@ -36,6 +38,7 @@
 | tst.js:284:14:284:14 | v | ExampleConfiguration |
 | tst.js:331:14:331:14 | v | ExampleConfiguration |
 | tst.js:356:16:356:27 | x10 | ExampleConfiguration |
+| tst.js:356:32:356:34 | x10 | ExampleConfiguration |
 | tst.js:361:14:361:14 | v | ExampleConfiguration |
 | tst.js:371:14:371:16 | o.p | ExampleConfiguration |
 | tst.js:378:14:378:17 | o[p] | ExampleConfiguration |

--- a/javascript/ql/test/library-tests/TaintTracking/BasicTaintTracking.expected
+++ b/javascript/ql/test/library-tests/TaintTracking/BasicTaintTracking.expected
@@ -1,5 +1,4 @@
 | access-path-sanitizer.js:2:18:2:25 | source() | access-path-sanitizer.js:4:8:4:12 | obj.x |
-| access-path-sanitizer.js:2:18:2:25 | source() | access-path-sanitizer.js:15:10:15:14 | obj.x |
 | addexpr.js:4:10:4:17 | source() | addexpr.js:7:8:7:8 | x |
 | addexpr.js:11:15:11:22 | source() | addexpr.js:21:8:21:12 | value |
 | advanced-callgraph.js:2:13:2:20 | source() | advanced-callgraph.js:6:22:6:22 | v |

--- a/javascript/ql/test/library-tests/TaintTracking/BasicTaintTracking.expected
+++ b/javascript/ql/test/library-tests/TaintTracking/BasicTaintTracking.expected
@@ -1,3 +1,5 @@
+| access-path-sanitizer.js:2:18:2:25 | source() | access-path-sanitizer.js:4:8:4:12 | obj.x |
+| access-path-sanitizer.js:2:18:2:25 | source() | access-path-sanitizer.js:15:10:15:14 | obj.x |
 | addexpr.js:4:10:4:17 | source() | addexpr.js:7:8:7:8 | x |
 | addexpr.js:11:15:11:22 | source() | addexpr.js:21:8:21:12 | value |
 | advanced-callgraph.js:2:13:2:20 | source() | advanced-callgraph.js:6:22:6:22 | v |

--- a/javascript/ql/test/library-tests/TaintTracking/access-path-sanitizer.js
+++ b/javascript/ql/test/library-tests/TaintTracking/access-path-sanitizer.js
@@ -1,0 +1,17 @@
+function foo() {
+  let obj = { x: source() };
+  
+  sink(obj.x); // NOT OK
+
+  if (isSafe(obj.x)) {
+    sink(obj.x); // OK
+  }
+
+  if (typeof obj === "object" && isSafe(obj.x)) {
+    sink(obj.x); // OK
+  }
+
+  if (isSafe(obj.x) && typeof obj === "object") {
+    sink(obj.x); // OK - but flagged anyway
+  }
+}

--- a/javascript/ql/test/library-tests/TaintTracking/access-path-sanitizer.js
+++ b/javascript/ql/test/library-tests/TaintTracking/access-path-sanitizer.js
@@ -12,6 +12,6 @@ function foo() {
   }
 
   if (isSafe(obj.x) && typeof obj === "object") {
-    sink(obj.x); // OK - but flagged anyway
+    sink(obj.x); // OK
   }
 }


### PR DESCRIPTION
When constructing access paths, we now step through refinement nodes to get to the root. The effect is that more nodes have the same access path.

For example, we failed to sanitize `obj.x` below, since the use at the sink used a different access path than at the sanitizer:
```javascript
  if (isSafe(obj.x) && typeof obj === "object") {
    sink(obj.x); // OK
  }
```

[Evaluation](https://git.semmle.com/asger/dist-compare-reports/tree/balbinus.ti.semmle.com_1555034197406) has two minor outliers but their absolute numbers aren't very high. No change in results on default.slug.

I haven't seen any real-world FPs from this, but it came up when experimenting with other uses of AccessPaths. I'm considering if something similar should be done for capture nodes, but if so I'll do that in a separate PR.