### PR TITLE
CPP: Fix performance issues in ClassesWithManyFields.ql

### DIFF
--- a/cpp/ql/src/Architecture/Refactoring Opportunities/ClassesWithManyFields.ql
+++ b/cpp/ql/src/Architecture/Refactoring Opportunities/ClassesWithManyFields.ql
@@ -9,51 +9,41 @@
  *       statistical
  *       non-attributable
  */
-
 import cpp
 
-string kindstr(Class c) {
+string kindstr(Class c)
+{
   exists(int kind | usertypes(unresolveElement(c), _, kind) |
-    kind = 1 and result = "Struct"
-    or
-    kind = 2 and result = "Class"
-    or
-    kind = 6 and result = "Template class"
+    (kind = 1 and result = "Struct") or
+    (kind = 2 and result = "Class") or
+    (kind = 6 and result = "Template class")
   )
 }
 
-predicate vdeInfo(VariableDeclarationEntry vde, Class c, File f, int line) {
+predicate vdeInfo(VariableDeclarationEntry vde, Class c, File f, int line)
+{
   c = vde.getVariable().getDeclaringType() and
   f = vde.getLocation().getFile() and
   line = vde.getLocation().getStartLine()
 }
 
-predicate previousVde(VariableDeclarationEntry previous, VariableDeclarationEntry vde) {
+predicate previousVde(VariableDeclarationEntry previous, VariableDeclarationEntry vde)
+{
   exists(Class c, File f, int line | vdeInfo(vde, c, f, line) |
-    vdeInfo(previous, c, f, line - 3)
-    or
-    vdeInfo(previous, c, f, line - 2)
-    or
-    vdeInfo(previous, c, f, line - 1)
-    or
-    vdeInfo(previous, c, f, line) and
-    exists(int prevCol, int vdeCol |
-      prevCol = previous.getLocation().getStartColumn() and
-      vdeCol = vde.getLocation().getStartColumn()
-    |
-      prevCol < vdeCol
-      or
-      prevCol = vdeCol and previous.getName() < vde.getName()
-    )
+    vdeInfo(previous, c, f, line - 3) or
+    vdeInfo(previous, c, f, line - 2) or
+    vdeInfo(previous, c, f, line - 1) or
+    (vdeInfo(previous, c, f, line) and exists(int prevCol, int vdeCol |
+      prevCol = previous.getLocation().getStartColumn() and vdeCol = vde.getLocation().getStartColumn() |
+      prevCol < vdeCol or (prevCol = vdeCol and previous.getName() < vde.getName())
+    ))
   )
 }
 
-predicate masterVde(VariableDeclarationEntry master, VariableDeclarationEntry vde) {
-  not previousVde(_, vde) and master = vde
-  or
-  exists(VariableDeclarationEntry previous |
-    previousVde(previous, vde) and masterVde(master, previous)
-  )
+predicate masterVde(VariableDeclarationEntry master, VariableDeclarationEntry vde)
+{
+  (not previousVde(_, vde) and master = vde) or
+  exists(VariableDeclarationEntry previous | previousVde(previous, vde) and masterVde(master, previous))
 }
 
 class VariableDeclarationGroup extends ElementBase {
@@ -61,8 +51,9 @@ class VariableDeclarationGroup extends ElementBase {
     this instanceof VariableDeclarationEntry and
     not previousVde(_, this)
   }
-
-  Class getClass() { vdeInfo(this, result, _, _) }
+  Class getClass() {
+    vdeInfo(this, result, _, _)
+  }
 
   // pragma[noopt] since otherwise the two locationInfo relations get join-ordered
   // after each other
@@ -72,9 +63,7 @@ class VariableDeclarationGroup extends ElementBase {
       masterVde(this, last) and
       this instanceof VariableDeclarationGroup and
       not previousVde(last, _) and
-      exists(VariableDeclarationEntry vde |
-        vde = this and vde instanceof VariableDeclarationEntry and vde.getLocation() = lstart
-      ) and
+      exists(VariableDeclarationEntry vde | vde=this and vde instanceof VariableDeclarationEntry and vde.getLocation() = lstart) and
       last.getLocation() = lend and
       lstart.hasLocationInfo(path, startline, startcol, _, _) and
       lend.hasLocationInfo(path, _, _, endline, endcol)
@@ -82,16 +71,15 @@ class VariableDeclarationGroup extends ElementBase {
   }
 
   string describeGroup() {
-    if previousVde(this, _)
-    then
-      result = "group of " +
-          strictcount(string name |
-            exists(VariableDeclarationEntry vde |
-              masterVde(this, vde) and
-              name = vde.getName()
-            )
-          ) + " fields here"
-    else result = "declaration of " + this.(VariableDeclarationEntry).getVariable().getName()
+    if previousVde(this, _) then
+      result = "group of "
+             + strictcount(string name
+                         | exists(VariableDeclarationEntry vde
+                                | masterVde(this, vde) and
+                                  name = vde.getName()))
+             + " fields here"
+    else
+      result = "declaration of " + this.(VariableDeclarationEntry).getVariable().getName()
   }
 }
 
@@ -101,32 +89,26 @@ class ExtClass extends Class {
   }
 
   predicate hasLocationInfo(string path, int startline, int startcol, int endline, int endcol) {
-    if hasOneVariableGroup()
-    then
-      exists(VariableDeclarationGroup vdg | vdg.getClass() = this |
-        vdg.hasLocationInfo(path, startline, startcol, endline, endcol)
-      )
-    else getLocation().hasLocationInfo(path, startline, startcol, endline, endcol)
+    if hasOneVariableGroup() then
+      exists(VariableDeclarationGroup vdg | vdg.getClass() = this | vdg.hasLocationInfo(path, startline, startcol, endline, endcol))
+    else
+      getLocation().hasLocationInfo(path, startline, startcol, endline, endcol)
   }
 }
 
 from ExtClass c, int n, VariableDeclarationGroup vdg, string suffix
-where
-  n = strictcount(string fieldName |
-      exists(Field f |
-        f.getDeclaringType() = c and
-        fieldName = f.getName() and
-        // IBOutlet's are a way of building GUIs
-        // automatically out of ObjC properties.
-        // We don't want to count those for the
-        // purposes of this query.
-        not f.getType().getAnAttribute().hasName("iboutlet")
-      )
-    ) and
-  n > 15 and
-  not c.isConstructedFrom(_) and
-  c = vdg.getClass() and
-  if c.hasOneVariableGroup() then suffix = "" else suffix = " - see $@"
-select c,
-  kindstr(c) + " " + c.getName() + " has " + n +
-    " fields; we suggest refactoring to 15 fields or fewer" + suffix + ".", vdg, vdg.describeGroup()
+where n = strictcount(string fieldName
+                    | exists(Field f
+                           | f.getDeclaringType() = c and
+                             fieldName = f.getName() and
+                             // IBOutlet's are a way of building GUIs
+                             // automatically out of ObjC properties.
+                             // We don't want to count those for the
+                             // purposes of this query.
+                             not (f.getType().getAnAttribute().hasName("iboutlet")))) and
+      n > 15 and
+      not c.isConstructedFrom(_) and
+      c = vdg.getClass() and
+      if c.hasOneVariableGroup() then suffix = "" else suffix = " - see $@"
+select c, kindstr(c) + " " + c.getName() + " has " + n + " fields; we suggest refactoring to 15 fields or fewer" + suffix + ".",
+       vdg, vdg.describeGroup()

--- a/cpp/ql/src/Architecture/Refactoring Opportunities/ClassesWithManyFields.ql
+++ b/cpp/ql/src/Architecture/Refactoring Opportunities/ClassesWithManyFields.ql
@@ -9,42 +9,42 @@
  *       statistical
  *       non-attributable
  */
+
 import cpp
 
 /**
  * Gets a string describing the kind of a `Class`.
  */
-string kindstr(Class c)
-{
+string kindstr(Class c) {
   exists(int kind | usertypes(unresolveElement(c), _, kind) |
-    (kind = 1 and result = "Struct") or
-    (kind = 2 and result = "Class") or
-    (kind = 6 and result = "Template class")
+    kind = 1 and result = "Struct"
+    or
+    kind = 2 and result = "Class"
+    or
+    kind = 6 and result = "Template class"
   )
 }
 
 /**
  * Holds if the arguments correspond to information about a `VariableDeclarationEntry`.
  */
-predicate vdeInfo(VariableDeclarationEntry vde, Class c, File f, int line)
-{
+predicate vdeInfo(VariableDeclarationEntry vde, Class c, File f, int line) {
   c = vde.getVariable().getDeclaringType() and
   f = vde.getLocation().getFile() and
   line = vde.getLocation().getStartLine()
 }
 
 newtype TVariableDeclarationInfo =
-  TVariableDeclarationLine(Class c, File f, int line) {
-  	vdeInfo(_, c, f, line)
-  }
+  TVariableDeclarationLine(Class c, File f, int line) { vdeInfo(_, c, f, line) }
 
 /**
  * A line that contains one or more `VariableDeclarationEntry`s (in the same class).
  */
-class VariableDeclarationLine extends TVariableDeclarationInfo
-{
+class VariableDeclarationLine extends TVariableDeclarationInfo {
   Class c;
+
   File f;
+
   int line;
 
   VariableDeclarationLine() {
@@ -55,38 +55,27 @@ class VariableDeclarationLine extends TVariableDeclarationInfo
   /**
    * Gets the class associated with this `VariableDeclarationLine`.
    */
-  Class getClass() {
-    result = c
-  }
+  Class getClass() { result = c }
 
   /**
    * Gets the line of this `VariableDeclarationLine`.
    */
-  int getLine() {
-    result = line
-  }
+  int getLine() { result = line }
 
   /**
    * Gets a `VariableDeclarationEntry` on this line.
    */
-  VariableDeclarationEntry getAVDE()
-  {
-    vdeInfo(result, c, f, line)
-  }
+  VariableDeclarationEntry getAVDE() { vdeInfo(result, c, f, line) }
 
   /**
    * Gets the start column of the first `VariableDeclarationEntry` on this line.
    */
-  int getStartColumn() {
-    result = min(getAVDE().getLocation().getStartColumn())
-  }
+  int getStartColumn() { result = min(getAVDE().getLocation().getStartColumn()) }
 
   /**
    * Gets the end column of the last `VariableDeclarationEntry` on this line.
    */
-  int getEndColumn() {
-    result = max(getAVDE().getLocation().getEndColumn())
-  }
+  int getEndColumn() { result = max(getAVDE().getLocation().getEndColumn()) }
 
   /**
    * Gets the rank of this `VariableDeclarationLine` in its file and class
@@ -94,9 +83,10 @@ class VariableDeclarationLine extends TVariableDeclarationInfo
    */
   private int getRank() {
     line = rank[result](VariableDeclarationLine vdl, int l |
-      vdl = TVariableDeclarationLine(c, f, l) |
-      l
-    )
+        vdl = TVariableDeclarationLine(c, f, l)
+      |
+        l
+      )
   }
 
   /**
@@ -115,23 +105,19 @@ class VariableDeclarationLine extends TVariableDeclarationInfo
     result.getLine() <= this.getLine() + 3
   }
 
-  string toString() {
-    result = "VariableDeclarationLine"
-  }
+  string toString() { result = "VariableDeclarationLine" }
 }
 
 /**
  * A group of `VariableDeclarationEntry`s in the same class that are approximately
  * contiguous.
  */
-class VariableDeclarationGroup extends VariableDeclarationLine
-{
+class VariableDeclarationGroup extends VariableDeclarationLine {
   VariableDeclarationLine end;
 
   VariableDeclarationGroup() {
     // there is no `VariableDeclarationLine` within three lines previously
     not any(VariableDeclarationLine prev).getProximateNext() = this and
-
     // `end` is the last transitively proximate line
     end = getProximateNext*() and
     not exists(end.getProximateNext())
@@ -149,17 +135,19 @@ class VariableDeclarationGroup extends VariableDeclarationLine
    * Gets the number of uniquely named `VariableDeclarationEntry`s in this group.
    */
   int getCount() {
-    result = count(VariableDeclarationLine l | l = getProximateNext*() | l.getAVDE().getVariable().getName())
+    result = count(VariableDeclarationLine l |
+        l = getProximateNext*()
+      |
+        l.getAVDE().getVariable().getName()
+      )
   }
 
   override string toString() {
-    (
-      getCount() = 1 and
-      result = "declaration of " + getAVDE().getVariable().getName()
-    ) or (
-      getCount() > 1 and
-      result = "group of " + getCount() + " fields here"
-    )
+    getCount() = 1 and
+    result = "declaration of " + getAVDE().getVariable().getName()
+    or
+    getCount() > 1 and
+    result = "group of " + getCount() + " fields here"
   }
 }
 
@@ -169,26 +157,32 @@ class ExtClass extends Class {
   }
 
   predicate hasLocationInfo(string path, int startline, int startcol, int endline, int endcol) {
-    if hasOneVariableGroup() then
-      exists(VariableDeclarationGroup vdg | vdg.getClass() = this | vdg.hasLocationInfo(path, startline, startcol, endline, endcol))
-    else
-      getLocation().hasLocationInfo(path, startline, startcol, endline, endcol)
+    if hasOneVariableGroup()
+    then
+      exists(VariableDeclarationGroup vdg | vdg.getClass() = this |
+        vdg.hasLocationInfo(path, startline, startcol, endline, endcol)
+      )
+    else getLocation().hasLocationInfo(path, startline, startcol, endline, endcol)
   }
 }
 
 from ExtClass c, int n, VariableDeclarationGroup vdg, string suffix
-where n = strictcount(string fieldName
-                    | exists(Field f
-                           | f.getDeclaringType() = c and
-                             fieldName = f.getName() and
-                             // IBOutlet's are a way of building GUIs
-                             // automatically out of ObjC properties.
-                             // We don't want to count those for the
-                             // purposes of this query.
-                             not (f.getType().getAnAttribute().hasName("iboutlet")))) and
-      n > 15 and
-      not c.isConstructedFrom(_) and
-      c = vdg.getClass() and
-      if c.hasOneVariableGroup() then suffix = "" else suffix = " - see $@"
-select c, kindstr(c) + " " + c.getName() + " has " + n + " fields; we suggest refactoring to 15 fields or fewer" + suffix + ".",
-       vdg, vdg.toString()
+where
+  n = strictcount(string fieldName |
+      exists(Field f |
+        f.getDeclaringType() = c and
+        fieldName = f.getName() and
+        // IBOutlet's are a way of building GUIs
+        // automatically out of ObjC properties.
+        // We don't want to count those for the
+        // purposes of this query.
+        not f.getType().getAnAttribute().hasName("iboutlet")
+      )
+    ) and
+  n > 15 and
+  not c.isConstructedFrom(_) and
+  c = vdg.getClass() and
+  if c.hasOneVariableGroup() then suffix = "" else suffix = " - see $@"
+select c,
+  kindstr(c) + " " + c.getName() + " has " + n +
+    " fields; we suggest refactoring to 15 fields or fewer" + suffix + ".", vdg, vdg.toString()

--- a/cpp/ql/src/Architecture/Refactoring Opportunities/ClassesWithManyFields.ql
+++ b/cpp/ql/src/Architecture/Refactoring Opportunities/ClassesWithManyFields.ql
@@ -11,6 +11,9 @@
  */
 import cpp
 
+/**
+ * Gets a string describing the kind of a `Class`.
+ */
 string kindstr(Class c)
 {
   exists(int kind | usertypes(unresolveElement(c), _, kind) |
@@ -20,6 +23,9 @@ string kindstr(Class c)
   )
 }
 
+/**
+ * Holds if the arguments correspond to information about a `VariableDeclarationEntry`.
+ */
 predicate vdeInfo(VariableDeclarationEntry vde, Class c, File f, int line)
 {
   c = vde.getVariable().getDeclaringType() and
@@ -27,6 +33,10 @@ predicate vdeInfo(VariableDeclarationEntry vde, Class c, File f, int line)
   line = vde.getLocation().getStartLine()
 }
 
+/**
+ * Holds if `previous` describes a `VariableDeclarationEntry` occurring soon before
+ * `vde` (this may have many results).
+ */
 predicate previousVde(VariableDeclarationEntry previous, VariableDeclarationEntry vde)
 {
   exists(Class c, File f, int line | vdeInfo(vde, c, f, line) |
@@ -40,12 +50,19 @@ predicate previousVde(VariableDeclarationEntry previous, VariableDeclarationEntr
   )
 }
 
+/**
+ * The first `VariableDeclarationEntry` in a group.
+ */
 predicate masterVde(VariableDeclarationEntry master, VariableDeclarationEntry vde)
 {
   (not previousVde(_, vde) and master = vde) or
   exists(VariableDeclarationEntry previous | previousVde(previous, vde) and masterVde(master, previous))
 }
 
+/**
+ * A group of `VariableDeclaratinEntry`'s in the same class and in close proximity
+ * to each other.
+ */
 class VariableDeclarationGroup extends ElementBase {
   VariableDeclarationGroup() {
     this instanceof VariableDeclarationEntry and

--- a/cpp/ql/src/Architecture/Refactoring Opportunities/ClassesWithManyFields.ql
+++ b/cpp/ql/src/Architecture/Refactoring Opportunities/ClassesWithManyFields.ql
@@ -89,7 +89,7 @@ class VariableDeclarationLine extends TVariableDeclarationInfo
   }
 
   /**
-   * Gets the rank of this `VariableDeclarationLine` in it's file and class
+   * Gets the rank of this `VariableDeclarationLine` in its file and class
    * (that is, the first is 0, the second is 1 and so on).
    */
   private int getRank() {

--- a/cpp/ql/test/query-tests/Architecture/Refactoring Opportunities/ClassesWithManyFields/cwmf.cpp
+++ b/cpp/ql/test/query-tests/Architecture/Refactoring Opportunities/ClassesWithManyFields/cwmf.cpp
@@ -56,3 +56,29 @@ struct MyParticle {
   class texture *tex;
   float u1, v1, u2, v2;
 };
+
+struct MyAlphaClass1 {
+  int a1, b1, c1, d1, e1, f1, g1, h1, i1, j1;
+  int k1, l1, m1, n1, o1, p1, q1, r1, s1, t1;
+  int u1, v1, w1, x1, y1, z1;
+
+  // ...
+  // ...
+  // ...
+
+  int a2, b2, c2, d2, e2, f2, g2, h2, i2, j2;
+  int k2, l2, m2, n2, o2, p2, q2, r2, s2, t2;
+  int u2, v2, w2, x2, y2, z2;
+};
+
+struct MyAlphaClass2 {
+  int x;
+
+  // ...
+  // ...
+  // ...
+
+  int a1, b1, c1, d1, e1, f1, g1, h1, i1, j1;
+  int k1, l1, m1, n1, o1, p1, q1, r1, s1, t1;
+  int u1, v1, w1, x1, y1, z1;
+};

--- a/cpp/ql/test/query-tests/Architecture/Refactoring Opportunities/ClassesWithManyFields/cwmf.expected
+++ b/cpp/ql/test/query-tests/Architecture/Refactoring Opportunities/ClassesWithManyFields/cwmf.expected
@@ -1,7 +1,7 @@
-| cwmf.cpp:8:3:9:12 | aa | Struct aa has 20 fields; we suggest refactoring to 15 fields or fewer. | cwmf.cpp:8:3:9:12 | definition of f1 | group of 20 fields here |
-| cwmf.cpp:13:3:14:12 | bb | Class bb has 20 fields; we suggest refactoring to 15 fields or fewer. | cwmf.cpp:13:3:14:12 | definition of f1 | group of 20 fields here |
-| cwmf.cpp:24:3:25:12 | dd<T> | Template class dd<T> has 20 fields; we suggest refactoring to 15 fields or fewer. | cwmf.cpp:24:3:25:12 | definition of f1 | group of 20 fields here |
-| cwmf.cpp:30:3:31:12 | ee<U> | Template class ee<U> has 20 fields; we suggest refactoring to 15 fields or fewer. | cwmf.cpp:30:3:31:12 | definition of f1 | group of 20 fields here |
-| cwmf.cpp:41:8:57:22 | MyParticle | Struct MyParticle has 30 fields; we suggest refactoring to 15 fields or fewer. | cwmf.cpp:41:8:57:22 | definition of isActive | group of 30 fields here |
-| different_types.h:15:15:33:10 | DifferentTypes2 | Class DifferentTypes2 has 18 fields; we suggest refactoring to 15 fields or fewer. | different_types.h:15:15:33:10 | definition of i1 | group of 18 fields here |
-| different_types.h:15:15:33:10 | DifferentTypes2 | Class DifferentTypes2 has 18 fields; we suggest refactoring to 15 fields or fewer. | different_types.h:15:15:33:10 | definition of i1 | group of 18 fields here |
+| cwmf.cpp:8:3:9:12 | aa | Struct aa has 20 fields; we suggest refactoring to 15 fields or fewer. | cwmf.cpp:8:3:9:12 | group of 20 fields here | group of 20 fields here |
+| cwmf.cpp:13:3:14:12 | bb | Class bb has 20 fields; we suggest refactoring to 15 fields or fewer. | cwmf.cpp:13:3:14:12 | group of 20 fields here | group of 20 fields here |
+| cwmf.cpp:24:3:25:12 | dd<T> | Template class dd<T> has 20 fields; we suggest refactoring to 15 fields or fewer. | cwmf.cpp:24:3:25:12 | group of 20 fields here | group of 20 fields here |
+| cwmf.cpp:30:3:31:12 | ee<U> | Template class ee<U> has 20 fields; we suggest refactoring to 15 fields or fewer. | cwmf.cpp:30:3:31:12 | group of 20 fields here | group of 20 fields here |
+| cwmf.cpp:41:8:57:22 | MyParticle | Struct MyParticle has 30 fields; we suggest refactoring to 15 fields or fewer. | cwmf.cpp:41:8:57:22 | group of 30 fields here | group of 30 fields here |
+| different_types.h:15:15:33:10 | DifferentTypes2 | Class DifferentTypes2 has 18 fields; we suggest refactoring to 15 fields or fewer. | different_types.h:15:15:33:10 | group of 18 fields here | group of 18 fields here |
+| different_types.h:15:15:33:10 | DifferentTypes2 | Class DifferentTypes2 has 18 fields; we suggest refactoring to 15 fields or fewer. | different_types.h:15:15:33:10 | group of 18 fields here | group of 18 fields here |

--- a/cpp/ql/test/query-tests/Architecture/Refactoring Opportunities/ClassesWithManyFields/cwmf.expected
+++ b/cpp/ql/test/query-tests/Architecture/Refactoring Opportunities/ClassesWithManyFields/cwmf.expected
@@ -3,5 +3,9 @@
 | cwmf.cpp:24:3:25:12 | dd<T> | Template class dd<T> has 20 fields; we suggest refactoring to 15 fields or fewer. | cwmf.cpp:24:3:25:12 | group of 20 fields here | group of 20 fields here |
 | cwmf.cpp:30:3:31:12 | ee<U> | Template class ee<U> has 20 fields; we suggest refactoring to 15 fields or fewer. | cwmf.cpp:30:3:31:12 | group of 20 fields here | group of 20 fields here |
 | cwmf.cpp:41:8:57:22 | MyParticle | Struct MyParticle has 30 fields; we suggest refactoring to 15 fields or fewer. | cwmf.cpp:41:8:57:22 | group of 30 fields here | group of 30 fields here |
+| cwmf.cpp:60:8:60:20 | MyAlphaClass1 | Struct MyAlphaClass1 has 52 fields; we suggest refactoring to 15 fields or fewer - see $@. | cwmf.cpp:61:7:63:28 | group of 26 fields here | group of 26 fields here |
+| cwmf.cpp:60:8:60:20 | MyAlphaClass1 | Struct MyAlphaClass1 has 52 fields; we suggest refactoring to 15 fields or fewer - see $@. | cwmf.cpp:69:7:71:28 | group of 26 fields here | group of 26 fields here |
+| cwmf.cpp:74:8:74:20 | MyAlphaClass2 | Struct MyAlphaClass2 has 27 fields; we suggest refactoring to 15 fields or fewer - see $@. | cwmf.cpp:75:7:75:7 | declaration of x | declaration of x |
+| cwmf.cpp:74:8:74:20 | MyAlphaClass2 | Struct MyAlphaClass2 has 27 fields; we suggest refactoring to 15 fields or fewer - see $@. | cwmf.cpp:81:7:83:28 | group of 26 fields here | group of 26 fields here |
 | different_types.h:15:15:33:10 | DifferentTypes2 | Class DifferentTypes2 has 18 fields; we suggest refactoring to 15 fields or fewer. | different_types.h:15:15:33:10 | group of 18 fields here | group of 18 fields here |
 | different_types.h:15:15:33:10 | DifferentTypes2 | Class DifferentTypes2 has 18 fields; we suggest refactoring to 15 fields or fewer. | different_types.h:15:15:33:10 | group of 18 fields here | group of 18 fields here |


### PR DESCRIPTION
As noted in the weekly meeting, this query performed extremely poorly (timed out on my machine) on Chromium due to it's complex logic for blaming particular groups of member variables in the violation message.  It turns out this logic was full of cartesian products on the number of variable declarations on one line or nearby - a problem that is particularly pronounced on Chrome (but most projects exhibit a lesser version of this issue e.g. in template / macro logic or line 0 of file `""`).

The new version makes use of modern QL features to make an abstraction for a line containing one or more variable declaration entries - quickly forgetting about those individual VDEs themselves, resulting in good performance.