### PR TITLE
JavaScript: Refine `PasswordInConfigurationFile` to avoid FPs.

### DIFF
--- a/change-notes/1.21/analysis-javascript.md
+++ b/change-notes/1.21/analysis-javascript.md
@@ -30,6 +30,7 @@
 | Double escaping or unescaping | More results | This rule now considers the flow of regular expressions literals. |
 | Expression has no effect       | Fewer false-positive results | This rule now treats uses of `Object.defineProperty` more conservatively. |
 | Incomplete string escaping or encoding | More results | This rule now considers the flow of regular expressions literals. |
+| Password in configuration file | Fewer false positive results | This query now excludes passwords that are inserted into the configuration file using a templating mechanism. |
 | Replacement of a substring with itself | More results | This rule now considers the flow of regular expressions literals. |
 | Server-side URL redirect       | Fewer false-positive results | This rule now treats URLs as safe in more cases where the hostname cannot be tampered with. |
 | Type confusion through parameter tampering | Fewer false-positive results | This rule now recognizes additional emptiness checks. |

--- a/javascript/ql/src/Security/CWE-313/PasswordInConfigurationFile.ql
+++ b/javascript/ql/src/Security/CWE-313/PasswordInConfigurationFile.ql
@@ -45,11 +45,14 @@ from string key, string val, Locatable valElement
 where
   config(key, val, valElement) and
   val != "" and
+  // exclude possible templates
+  not val.regexpMatch(Templating::getDelimiterMatchingRegexp()) and
   (
     key.toLowerCase() = "password"
     or
     key.toLowerCase() != "readme" and
-    val.regexpMatch("(?is).*password\\s*=(?!\\s*;).*")
+    // look for `password=...`, but exclude `password=;` and `password="$(...)"`
+    val.regexpMatch("(?is).*password\\s*=(?!\\s*;)(?!\"?[$`]).*")
   ) and
   not exclude(valElement.getFile())
 select valElement, "Avoid plaintext passwords in configuration files."

--- a/javascript/ql/test/query-tests/Security/CWE-313/tst.yml
+++ b/javascript/ql/test/query-tests/Security/CWE-313/tst.yml
@@ -1,0 +1,6 @@
+steps:
+- script: |
+    PASSWORD="$(PASSWORD)" npm install
+    OTHER_PASSWORD=`get password` yarn install
+username: <%= ENV['USERNAME'] %>
+password: <%= ENV['PASSWORD'] %>


### PR DESCRIPTION
We now exclude passwords that look like they might be filled in via templating or shell substitution.

Fixes false positives on vscode and reactjs-by-example introduced by #1235, without losing the true (seeded) results on juice-shop.