### PR TITLE
TS: Don't extract "redirecting" SourceFiles

### DIFF
--- a/javascript/extractor/lib/typescript/src/ast_extractor.ts
+++ b/javascript/extractor/lib/typescript/src/ast_extractor.ts
@@ -7,6 +7,8 @@ import { Project } from "./common";
  */
 export interface AugmentedSourceFile extends ts.SourceFile {
     parseDiagnostics?: any[];
+    /** Internal property that we expose as a workaround. */
+    redirectInfo?: object | null;
     $tokens?: Token[];
     $symbol?: number;
     $lineStarts?: ReadonlyArray<number>;


### PR DESCRIPTION
Fix for [ODASA-7908](https://jira.semmle.com/browse/ODASA-7908).

Under rare circumstances the AST we get from the TypeScript API is a "redirecting" SourceFile, which can't be extracted like other SourceFiles.

I tried finding out under what circumstances this happens, but based on an [this assertion](https://github.com/Microsoft/TypeScript/blob/master/src/compiler/program.ts#L1240) in the TypeScript compiler it seems to be unintended behavior. So I've just worked around it the best we can.

I've confirmed that it works for the original project, but I haven't been able to reproduce it anywhere else. So unfortunately no regression test and no TypeScript bug report as I have no idea how it reproduce it in a small test case.