### PR TITLE
Parameters annotated with Spring's @RequestBody and @PathVariable are remote input sources.

### DIFF
--- a/change-notes/1.21/analysis-java.md
+++ b/change-notes/1.21/analysis-java.md
@@ -22,5 +22,6 @@
   methods. This means that more guards are recognized yielding precision
   improvements in a number of queries including `java/index-out-of-bounds`,
   `java/dereferenced-value-may-be-null`, and `java/useless-null-check`.
-
-
+* Spring framework support is enhanced by taking into account additional
+  annotations that indicate remote user input. This affects all security
+  queries, which may yield additional results.

--- a/java/ql/src/semmle/code/java/frameworks/SpringWeb.qll
+++ b/java/ql/src/semmle/code/java/frameworks/SpringWeb.qll
@@ -11,7 +11,9 @@ class SpringServletInputAnnotation extends Annotation {
       a.hasName("RequestParam") or
       a.hasName("RequestHeader") or
       a.hasName("CookieValue") or
-      a.hasName("RequestPart")
+      a.hasName("RequestPart") or
+      a.hasName("PathVariable") or
+      a.hasName("RequestBody")
     )
   }
 }


### PR DESCRIPTION
@aschackmull I have seen parameters with those annotations in several commercial code bases.

A parameter annotated with [@RequestBody](https://docs.spring.io/spring-framework/docs/current/javadoc-api/org/springframework/web/bind/annotation/RequestBody.html) will often be a class object with multiple user-controlled member variables. From what I have seen it might make sense to add additional logic to track those as well, which, however, would involve two dataflow steps. I will have a look whether I can add those in a separate PR.