### PR TITLE
C++: string pooling in IR value numbering

### DIFF
--- a/cpp/ql/src/semmle/code/cpp/ir/implementation/aliased_ssa/gvn/ValueNumbering.qll
+++ b/cpp/ql/src/semmle/code/cpp/ir/implementation/aliased_ssa/gvn/ValueNumbering.qll
@@ -31,6 +31,9 @@ newtype TValueNumber =
   TConstantValueNumber(IRFunction irFunc, Type type, string value) {
     constantValueNumber(_, irFunc, type, value)
   } or
+  TStringConstantValueNumber(IRFunction irFunc, Type type, string value) {
+    stringConstantValueNumber(_, irFunc, type, value)
+  } or
   TFieldAddressValueNumber(IRFunction irFunc, Field field, ValueNumber objectAddress) {
     fieldAddressValueNumber(_, irFunc, field, objectAddress)
   } or
@@ -127,6 +130,7 @@ private predicate numberableInstruction(Instruction instr) {
   instr instanceof InitializeParameterInstruction or
   instr instanceof InitializeThisInstruction or
   instr instanceof ConstantInstruction or
+  instr instanceof StringConstantInstruction or
   instr instanceof FieldAddressInstruction or
   instr instanceof BinaryInstruction or
   instr instanceof UnaryInstruction or
@@ -155,6 +159,13 @@ private predicate constantValueNumber(ConstantInstruction instr, IRFunction irFu
   instr.getEnclosingIRFunction() = irFunc and
   instr.getResultType() = type and
   instr.getValue() = value
+}
+
+private predicate stringConstantValueNumber(StringConstantInstruction instr, IRFunction irFunc, Type type,
+    string value) {
+  instr.getEnclosingIRFunction() = irFunc and
+  instr.getResultType() = type and
+  instr.getValue().getValue() = value
 }
 
 private predicate fieldAddressValueNumber(FieldAddressInstruction instr, IRFunction irFunc,
@@ -254,6 +265,10 @@ private ValueNumber nonUniqueValueNumber(Instruction instr) {
       exists(Type type, string value |
         constantValueNumber(instr, irFunc, type, value) and
         result = TConstantValueNumber(irFunc, type, value)
+      ) or
+      exists(Type type, string value |
+        stringConstantValueNumber(instr, irFunc, type, value) and
+        result = TStringConstantValueNumber(irFunc, type, value)
       ) or
       exists(Field field, ValueNumber objectAddress |
         fieldAddressValueNumber(instr, irFunc, field, objectAddress) and

--- a/cpp/ql/src/semmle/code/cpp/ir/implementation/raw/gvn/ValueNumbering.qll
+++ b/cpp/ql/src/semmle/code/cpp/ir/implementation/raw/gvn/ValueNumbering.qll
@@ -31,6 +31,9 @@ newtype TValueNumber =
   TConstantValueNumber(IRFunction irFunc, Type type, string value) {
     constantValueNumber(_, irFunc, type, value)
   } or
+  TStringConstantValueNumber(IRFunction irFunc, Type type, string value) {
+    stringConstantValueNumber(_, irFunc, type, value)
+  } or
   TFieldAddressValueNumber(IRFunction irFunc, Field field, ValueNumber objectAddress) {
     fieldAddressValueNumber(_, irFunc, field, objectAddress)
   } or
@@ -127,6 +130,7 @@ private predicate numberableInstruction(Instruction instr) {
   instr instanceof InitializeParameterInstruction or
   instr instanceof InitializeThisInstruction or
   instr instanceof ConstantInstruction or
+  instr instanceof StringConstantInstruction or
   instr instanceof FieldAddressInstruction or
   instr instanceof BinaryInstruction or
   instr instanceof UnaryInstruction or
@@ -155,6 +159,13 @@ private predicate constantValueNumber(ConstantInstruction instr, IRFunction irFu
   instr.getEnclosingIRFunction() = irFunc and
   instr.getResultType() = type and
   instr.getValue() = value
+}
+
+private predicate stringConstantValueNumber(StringConstantInstruction instr, IRFunction irFunc, Type type,
+    string value) {
+  instr.getEnclosingIRFunction() = irFunc and
+  instr.getResultType() = type and
+  instr.getValue().getValue() = value
 }
 
 private predicate fieldAddressValueNumber(FieldAddressInstruction instr, IRFunction irFunc,
@@ -254,6 +265,10 @@ private ValueNumber nonUniqueValueNumber(Instruction instr) {
       exists(Type type, string value |
         constantValueNumber(instr, irFunc, type, value) and
         result = TConstantValueNumber(irFunc, type, value)
+      ) or
+      exists(Type type, string value |
+        stringConstantValueNumber(instr, irFunc, type, value) and
+        result = TStringConstantValueNumber(irFunc, type, value)
       ) or
       exists(Field field, ValueNumber objectAddress |
         fieldAddressValueNumber(instr, irFunc, field, objectAddress) and

--- a/cpp/ql/src/semmle/code/cpp/ir/implementation/unaliased_ssa/gvn/ValueNumbering.qll
+++ b/cpp/ql/src/semmle/code/cpp/ir/implementation/unaliased_ssa/gvn/ValueNumbering.qll
@@ -31,6 +31,9 @@ newtype TValueNumber =
   TConstantValueNumber(IRFunction irFunc, Type type, string value) {
     constantValueNumber(_, irFunc, type, value)
   } or
+  TStringConstantValueNumber(IRFunction irFunc, Type type, string value) {
+    stringConstantValueNumber(_, irFunc, type, value)
+  } or
   TFieldAddressValueNumber(IRFunction irFunc, Field field, ValueNumber objectAddress) {
     fieldAddressValueNumber(_, irFunc, field, objectAddress)
   } or
@@ -127,6 +130,7 @@ private predicate numberableInstruction(Instruction instr) {
   instr instanceof InitializeParameterInstruction or
   instr instanceof InitializeThisInstruction or
   instr instanceof ConstantInstruction or
+  instr instanceof StringConstantInstruction or
   instr instanceof FieldAddressInstruction or
   instr instanceof BinaryInstruction or
   instr instanceof UnaryInstruction or
@@ -155,6 +159,13 @@ private predicate constantValueNumber(ConstantInstruction instr, IRFunction irFu
   instr.getEnclosingIRFunction() = irFunc and
   instr.getResultType() = type and
   instr.getValue() = value
+}
+
+private predicate stringConstantValueNumber(StringConstantInstruction instr, IRFunction irFunc, Type type,
+    string value) {
+  instr.getEnclosingIRFunction() = irFunc and
+  instr.getResultType() = type and
+  instr.getValue().getValue() = value
 }
 
 private predicate fieldAddressValueNumber(FieldAddressInstruction instr, IRFunction irFunc,
@@ -254,6 +265,10 @@ private ValueNumber nonUniqueValueNumber(Instruction instr) {
       exists(Type type, string value |
         constantValueNumber(instr, irFunc, type, value) and
         result = TConstantValueNumber(irFunc, type, value)
+      ) or
+      exists(Type type, string value |
+        stringConstantValueNumber(instr, irFunc, type, value) and
+        result = TStringConstantValueNumber(irFunc, type, value)
       ) or
       exists(Field field, ValueNumber objectAddress |
         fieldAddressValueNumber(instr, irFunc, field, objectAddress) and

--- a/cpp/ql/test/library-tests/valuenumbering/GlobalValueNumbering/ir_gvn.expected
+++ b/cpp/ql/test/library-tests/valuenumbering/GlobalValueNumbering/ir_gvn.expected
@@ -744,3 +744,23 @@ test.cpp:
 #  104|     v0_28(void)             = ReturnValue                   : r0_27, m0_26
 #  104|     v0_29(void)             = UnmodeledUse                  : mu*
 #  104|     v0_30(void)             = ExitFunction                  : 
+
+#  112| void test06()
+#  112|   Block 0
+#  112|     v0_0(void)           = EnterFunction       : 
+#  112|     m0_1(unknown)        = AliasedDefinition   : 
+#  112|         valnum = unique
+#  112|     mu0_2(unknown)       = UnmodeledDefinition : 
+#  112|         valnum = unique
+#  113|     r0_3(glval<char[2]>) = StringConstant["a"] : 
+#  113|         valnum = r0_3
+#  114|     r0_4(glval<char[2]>) = StringConstant["b"] : 
+#  114|         valnum = unique
+#  115|     r0_5(glval<char[2]>) = StringConstant["a"] : 
+#  115|         valnum = r0_3
+#  116|     r0_6(glval<char[2]>) = StringConstant["c"] : 
+#  116|         valnum = unique
+#  117|     v0_7(void)           = NoOp                : 
+#  112|     v0_8(void)           = ReturnVoid          : 
+#  112|     v0_9(void)           = UnmodeledUse        : mu*
+#  112|     v0_10(void)          = ExitFunction        : 

--- a/cpp/ql/test/library-tests/valuenumbering/GlobalValueNumbering/test.cpp
+++ b/cpp/ql/test/library-tests/valuenumbering/GlobalValueNumbering/test.cpp
@@ -108,3 +108,10 @@ int inheritanceConversions(Derived* pd) {
 
   return y;
 }
+
+void test06() {
+  "a";
+  "b";
+  "a";
+  "c";
+}


### PR DESCRIPTION
This PR adds IR value numbering support for string literals under the assumption that they are pooled. The spec says that whether string literals are pooled is unspecified, but I think this is a good assumption in practice: GCC pools string literals unconditionally, while Clang and MSVC have switches to enable/disable string pooling, but enable it by default at O1 and above. I'd expect embedded compilers to do the same,