### PR TITLE
JavaScript: Update `TypeTracker` to align with `TypeBackTracker`.

### DIFF
--- a/javascript/ql/src/semmle/javascript/dataflow/Sources.qll
+++ b/javascript/ql/src/semmle/javascript/dataflow/Sources.qll
@@ -164,10 +164,7 @@ class SourceNode extends DataFlow::Node {
    */
   pragma[inline]
   DataFlow::SourceNode track(TypeTracker t2, TypeTracker t) {
-    exists(StepSummary summary |
-      StepSummary::step(this, result, summary) and
-      t = t2.append(summary)
-    )
+    t = t2.step(this, result)
   }
 
   /**


### PR DESCRIPTION
It now also has `step` and `smallstep` predicates. In the usual case, however, I think I prefer the `SourceNode::track` API, so I left the recommended style in the qldoc alone (and reverted the one for `TypeBackTracker` to what it was before https://github.com/Semmle/ql/pull/1211). The reason is that when using the `step` predicate, the patterns for `TypeTracker` and `TypeBackTracker` become slighly asymmetric (different order of `t` and `t2`), which I think is confusing and error-prone.

A [full evaluation](https://git.semmle.com/max/dist-compare-reports/blob/master/js/odasa-7904/report.md) (internal link) shows a very slight slowdown overall, but nothing sticks out on the detailed profile.