### PR TITLE
Python: Fix false positive in 'Incomplete URL substring sanitization' query

### DIFF
--- a/python/ql/src/Security/CWE-020/IncompleteUrlSubstringSanitization.ql
+++ b/python/ql/src/Security/CWE-020/IncompleteUrlSubstringSanitization.ql
@@ -35,16 +35,18 @@ predicate incomplete_sanitization(Expr sanitizer, StrConst url) {
     (
         sanitizer.(Compare).compares(url, any(In i), _)
         or
-        call_to_startswith(sanitizer, url)
+        unsafe_call_to_startswith(sanitizer, url)
         or
         unsafe_call_to_endswith(sanitizer, url)
     )
 }
 
-predicate call_to_startswith(Call sanitizer, StrConst url) {
+predicate unsafe_call_to_startswith(Call sanitizer, StrConst url) {
     sanitizer.getFunc().(Attribute).getName() = "startswith"
     and
     sanitizer.getArg(0) = url
+    and
+    not url.getText().regexpMatch("(?i)https?://[\\.a-z0-9-]+/.*")
 }
 
 predicate unsafe_call_to_endswith(Call sanitizer, StrConst url) {

--- a/python/ql/test/query-tests/Security/CWE-020/urltest.py
+++ b/python/ql/test/query-tests/Security/CWE-020/urltest.py
@@ -39,3 +39,12 @@ def safe2(request):
     if host and host.endswith(".example.com"):
         return redirect(target)
 
+
+@app.route('/some/path/good3')
+def safe3(request):
+    target = request.args.get('target', '')
+    target = urlparse(target)
+    #Start url with https:// and ends with a / so must match the correct domain.
+    if target and target.startswith("https://example.com/"):
+        return redirect(target)
+


### PR DESCRIPTION
Although this is vulnerable:
`url.startswith("https://mydomain.com")`
this is OK:
`url.startswith("https://mydomain.com/")`
as the trailing `/` prevents substituting `mydomain.com.hijack.org` or similar.