### PR TITLE
JS: Use captured variables as access path root

### DIFF
--- a/javascript/ql/src/semmle/javascript/dataflow/internal/AccessPaths.qll
+++ b/javascript/ql/src/semmle/javascript/dataflow/internal/AccessPaths.qll
@@ -53,7 +53,12 @@ private SsaVariable getARefinementOf(SsaVariable variable) {
  */
 private newtype TAccessPath =
   MkSsaRoot(SsaVariable var) {
-    not exists(getRefinedVariable(var))
+    not exists(getRefinedVariable(var)) and
+    not var.getSourceVariable().isCaptured()
+  }
+  or
+  MkCapturedRoot(LocalVariable var) {
+    var.isCaptured()
   }
   or
   MkThisRoot(Function function) { function.getThisBinder() = function } or
@@ -76,6 +81,12 @@ class AccessPath extends TAccessPath {
     exists(SsaVariable var |
       this = MkSsaRoot(var) and
       result = getARefinementOf*(var).getAUseIn(bb)
+    )
+    or
+    exists(Variable var |
+      this = MkCapturedRoot(var) and
+      result = var.getAnAccess() and
+      result.getBasicBlock() = bb
     )
     or
     exists(ThisExpr this_ |

--- a/javascript/ql/test/library-tests/TaintTracking/BasicTaintTracking.expected
+++ b/javascript/ql/test/library-tests/TaintTracking/BasicTaintTracking.expected
@@ -12,7 +12,6 @@
 | callbacks.js:44:17:44:24 | source() | callbacks.js:41:10:41:10 | x |
 | callbacks.js:50:18:50:25 | source() | callbacks.js:30:29:30:29 | y |
 | callbacks.js:51:18:51:25 | source() | callbacks.js:30:29:30:29 | y |
-| captured-sanitizer.js:25:3:25:10 | source() | captured-sanitizer.js:13:12:13:12 | x |
 | captured-sanitizer.js:25:3:25:10 | source() | captured-sanitizer.js:15:10:15:10 | x |
 | closure.js:6:15:6:22 | source() | closure.js:8:8:8:31 | string. ... (taint) |
 | closure.js:6:15:6:22 | source() | closure.js:9:8:9:25 | string.trim(taint) |

--- a/javascript/ql/test/library-tests/TaintTracking/BasicTaintTracking.expected
+++ b/javascript/ql/test/library-tests/TaintTracking/BasicTaintTracking.expected
@@ -12,6 +12,8 @@
 | callbacks.js:44:17:44:24 | source() | callbacks.js:41:10:41:10 | x |
 | callbacks.js:50:18:50:25 | source() | callbacks.js:30:29:30:29 | y |
 | callbacks.js:51:18:51:25 | source() | callbacks.js:30:29:30:29 | y |
+| captured-sanitizer.js:25:3:25:10 | source() | captured-sanitizer.js:13:12:13:12 | x |
+| captured-sanitizer.js:25:3:25:10 | source() | captured-sanitizer.js:15:10:15:10 | x |
 | closure.js:6:15:6:22 | source() | closure.js:8:8:8:31 | string. ... (taint) |
 | closure.js:6:15:6:22 | source() | closure.js:9:8:9:25 | string.trim(taint) |
 | closure.js:6:15:6:22 | source() | closure.js:10:8:10:33 | string. ... nt, 50) |

--- a/javascript/ql/test/library-tests/TaintTracking/captured-sanitizer.js
+++ b/javascript/ql/test/library-tests/TaintTracking/captured-sanitizer.js
@@ -1,0 +1,25 @@
+import * as dummy from 'dummy';
+
+function f(x) {
+  useVar();
+  useVar();
+  mutateVar();
+  mutateVar();
+
+  function useVar() {
+    if (isSafe(x)) {
+      causeReCapture();
+      causeReCapture();
+      sink(x); // OK
+    }
+    sink(x); // NOT OK
+  }
+
+  function causeReCapture() {}
+
+  function mutateVar() {
+    x = null;
+  }
+}
+
+f(source());


### PR DESCRIPTION
Previously we would use re-capture nodes as the root of an access path; now we use the captured variable itself as the root. This means more expressions now share the same access path.

The test case is there to verify the expected behavior for sanitization purposes, though sanitization is not the motivation. As mentioned in the meeting, it's a small step on the way to using access paths in call graph construction.

[Evaluation](https://git.semmle.com/asger/dist-compare-reports/tree/augustus.ti.semmle.com_1555587925060) of security suite on security.slugs.