### PR TITLE
1.20 release: Update supported versions for C#

### DIFF
--- a/change-notes/1.20/support/versions-compilers.csv
+++ b/change-notes/1.20/support/versions-compilers.csv
@@ -4,9 +4,9 @@ C/C++,"C89, C99, C11, C++98, C++03, C++11, C++14, C++17","Clang extensions (up t
 GNU extensions (up to GCC 7.3), 
 
 Microsoft extensions (up to VS 2017)","``.cpp``, ``.c++``, ``.cxx``, ``.hpp``, ``.hh``, ``.h++``, ``.hxx``, ``.c``, ``.cc``, ``.h``"
-C#,C# up to 7.2 together with .NET versions up to 4.7.1,"Microsoft Visual Studio up to 2017, 
+C#,C# up to 7.3 together with .NET versions up to 4.7.1,"Microsoft Visual Studio up to 2017, 
 
-.NET Core up to 2.1","``.sln``, ``.csproj``, ``.cs``, ``.cshtml``, ``.xaml``"
+.NET Core up to 2.2","``.sln``, ``.csproj``, ``.cs``, ``.cshtml``, ``.xaml``"
 COBOL,ANSI 85 or newer [1]_.,Not applicable,"``.cbl``, ``.CBL``, ``.cpy``, ``.CPY``, ``.copy``, ``.COPY``"
 Java,"Java 6 to 11 [2]_.","javac (OpenJDK and Oracle JDK)
 


### PR DESCRIPTION
@calum - as discussed. This corrects the information about supported versions for 1.20.