### PR TITLE
Python: Add missing `override` annotations.

### DIFF
--- a/python/ql/src/Variables/Undefined.qll
+++ b/python/ql/src/Variables/Undefined.qll
@@ -127,7 +127,7 @@ private predicate maybe_call_to_exiting_function(CallNode call) {
 /** Prune edges where the predecessor block looks like it might contain a call to an exit function. */
 class ExitFunctionGuardedEdge extends DataFlowExtension::DataFlowVariable {
 
-    predicate prunedSuccessor(EssaVariable succ) {
+    override predicate prunedSuccessor(EssaVariable succ) {
         exists(CallNode exit_call |
             succ.(PhiFunction).getInput(exit_call.getBasicBlock()) = this and
             maybe_call_to_exiting_function(exit_call)

--- a/python/ql/src/semmle/python/security/SensitiveData.qll
+++ b/python/ql/src/semmle/python/security/SensitiveData.qll
@@ -91,11 +91,11 @@ class SensitiveDataSource extends TaintSource {
         this.(ControlFlowNode).getNode() instanceof SensitiveExpr
     }
 
-    string toString() {
+    override string toString() {
         result = "sensitive.data.source"
     }
 
-    predicate isSourceOf(TaintKind kind) {
+    override predicate isSourceOf(TaintKind kind) {
         kind instanceof SensitiveData
     }
 


### PR DESCRIPTION
This should take care of the remaining compilation warnings.