### PR TITLE
JS: fix azure performance

### DIFF
--- a/javascript/ql/src/semmle/javascript/frameworks/SocketIO.qll
+++ b/javascript/ql/src/semmle/javascript/frameworks/SocketIO.qll
@@ -412,7 +412,7 @@ module SocketIOClient {
   }
 
   /**
-   * Gets the NPM package that countains `nd`.
+   * Gets the NPM package that contains `nd`.
    */
   private NPMPackage getPackage(DataFlow::SourceNode nd) { result.getAFile() = nd.getFile() }
 

--- a/javascript/ql/src/semmle/javascript/frameworks/SocketIO.qll
+++ b/javascript/ql/src/semmle/javascript/frameworks/SocketIO.qll
@@ -411,6 +411,11 @@ module SocketIOClient {
     exists(DataFlow::TypeTracker t2 | result = socket(invk, t2).track(t2, t))
   }
 
+  /**
+   * Gets the NPM package that countains `nd`.
+   */
+  private NPMPackage getPackage(DataFlow::SourceNode nd) { result.getAFile() = nd.getFile() }
+
   /** A data flow node that may produce a socket object. */
   class SocketNode extends DataFlow::SourceNode {
     DataFlow::InvokeNode invk;
@@ -445,10 +450,8 @@ module SocketIOClient {
      * it can be determined.
      */
     SocketIO::ServerObject getATargetServer() {
-      exists(NPMPackage pkg |
-        result.getOrigin().getFile() = pkg.getAFile() and
-        this.getFile() = pkg.getAFile()
-      |
+      getPackage(result.getOrigin()) = getPackage(this) and
+      (
         not exists(getNamespacePath()) or
         exists(result.getNamespace(getNamespacePath()))
       )


### PR DESCRIPTION
I enountered reproducible timeouts for `azure-sdk-for-node` on master, this change seems to fix it ([small evaluation](https://git.semmle.com/esben/dist-compare-reports/tree/js/semver-lib_1556263742267)). I am currently doing a full run on a clean master ([sneak peek](https://git.semmle.com/esben/dist-compare-reports/tree/js/fix-azure-performance_1556309687861)).