### PR TITLE
CPP: Improve performance of RedundantNullCheckSimple.ql

### DIFF
--- a/cpp/ql/src/Likely Bugs/RedundantNullCheckSimple.ql
+++ b/cpp/ql/src/Likely Bugs/RedundantNullCheckSimple.ql
@@ -56,17 +56,22 @@ predicate explicitNullTestOfInstruction(Instruction checked, Instruction bool) {
     )
 }
 
+predicate candidateResult(LoadInstruction checked, SingleValuedInstruction sourceValue)
+{
+  explicitNullTestOfInstruction(checked, _) and
+  not checked.getAST().isInMacroExpansion() and
+  sourceValue = checked.getSourceValue()
+}
+
 from LoadInstruction checked, LoadInstruction deref, SingleValuedInstruction sourceValue
 where
-  explicitNullTestOfInstruction(checked, _) and
+  candidateResult(checked, sourceValue) and
   sourceValue = deref.getSourceAddress().(LoadInstruction).getSourceValue() and
-  sourceValue = checked.getSourceValue() and
   // This also holds if the blocks are equal, meaning that the check could come
   // before the deref. That's still not okay because when they're in the same
   // basic block then the deref is unavoidable even if the check concluded that
   // the pointer was null. To follow this idea to its full generality, we
   // should also give an alert when `check` post-dominates `deref`.
-  deref.getBlock().dominates(checked.getBlock()) and
-  not checked.getAST().isInMacroExpansion()
+  deref.getBlock().dominates(checked.getBlock())
 select checked, "This null check is redundant because the value is $@ in any case", deref,
   "dereferenced here"


### PR DESCRIPTION
On a small proportion of the projects I ran this on (notably including wireshark), a lot of time is spent evaluating the predicate itself:
```
	RedundantNullCheckSimple.ql-9:#select#cpe#13#ff ................................................................................ 7m56s
	RedundantNullCheckSimple.ql-9:#select#cpe#13#ff#antijoin_rhs ................................................................... 6m56s
	RedundantNullCheckSimple.ql-9:#select#cpe#13#ff#shared ......................................................................... 4m22s
```
This PR resolves this problem.