### PR TITLE
C++: iterated dominance frontier algorithm for IR

### DIFF
--- a/cpp/ql/src/semmle/code/cpp/ir/implementation/raw/internal/reachability/Dominance.qll
+++ b/cpp/ql/src/semmle/code/cpp/ir/implementation/raw/internal/reachability/Dominance.qll
@@ -11,11 +11,12 @@ predicate blockDominates(Graph::Block dominator, Graph::Block block) {
   blockStrictlyDominates(dominator, block) or dominator = block
 }
 
-pragma[noinline]
 Graph::Block getDominanceFrontier(Graph::Block dominator) {
-  exists(Graph::Block pred |
-    Graph::blockSuccessor(pred, result) and
-    blockDominates(dominator, pred) and
-    not blockStrictlyDominates(dominator, result)
+  Graph::blockSuccessor(dominator, result) and
+  not blockImmediatelyDominates(dominator, result)
+  or
+  exists(Graph::Block prev | result = getDominanceFrontier(prev) |
+    blockImmediatelyDominates(dominator, prev) and
+    not blockImmediatelyDominates(dominator, result)
   )
 }

--- a/cpp/ql/src/semmle/code/cpp/ir/implementation/unaliased_ssa/internal/reachability/Dominance.qll
+++ b/cpp/ql/src/semmle/code/cpp/ir/implementation/unaliased_ssa/internal/reachability/Dominance.qll
@@ -11,11 +11,12 @@ predicate blockDominates(Graph::Block dominator, Graph::Block block) {
   blockStrictlyDominates(dominator, block) or dominator = block
 }
 
-pragma[noinline]
 Graph::Block getDominanceFrontier(Graph::Block dominator) {
-  exists(Graph::Block pred |
-    Graph::blockSuccessor(pred, result) and
-    blockDominates(dominator, pred) and
-    not blockStrictlyDominates(dominator, result)
+  Graph::blockSuccessor(dominator, result) and
+  not blockImmediatelyDominates(dominator, result)
+  or
+  exists(Graph::Block prev | result = getDominanceFrontier(prev) |
+    blockImmediatelyDominates(dominator, prev) and
+    not blockImmediatelyDominates(dominator, result)
   )
 }


### PR DESCRIPTION
I couldn't observe a slowdown for the IR dominance frontier calculation in #1040, so I left the IR using the slow algorithm. I can now observe that it's slow, so here's a fix. From the commit message:

> Use the iterated dominance frontier algorithm to speed up dominance frontier calculations. The implementation is copied from d310338c9b.
> 
> Before this change, the SSA calculations for unaliased and aliased SSA used 169.9 seconds in total on these predicates:
> 
>     7:Dominance::getDominanceFrontier#2#ff .. 49s
>     7:Dominance::blockDominates#2#ff ........ 47.5s
>     8:Dominance::getDominanceFrontier#ff .... 44.4s
>     8:Dominance::blockDominates#ff .......... 29s
> 
> After this change, the above predicates are replaced by two copies of `getDominanceFrontier`, each of which takes less than a second.