### PR TITLE
Java: add Java 12 support

### DIFF
--- a/java/ql/src/Likely Bugs/Comparison/MissingInstanceofInEquals.ql
+++ b/java/ql/src/Likely Bugs/Comparison/MissingInstanceofInEquals.ql
@@ -17,7 +17,7 @@ import semmle.code.java.JDK
 class CheckedCast extends CastExpr {
   CheckedCast() {
     exists(TryStmt try, RefType cce |
-      this.getEnclosingStmt().getParent+() = try and
+      this.getEnclosingStmt().getEnclosingStmt+() = try and
       try.getACatchClause().getVariable().getType() = cce and
       cce.getQualifiedName() = "java.lang.ClassCastException"
     )

--- a/java/ql/src/Likely Bugs/Concurrency/BusyWait.ql
+++ b/java/ql/src/Likely Bugs/Concurrency/BusyWait.ql
@@ -69,8 +69,8 @@ class DangerStmt extends Stmt {
 
 from WhileStmt s, DangerStmt d
 where
-  d.getParent+() = s and
+  d.getEnclosingStmt+() = s and
   not exists(MethodAccess call | callsCommunicationMethod(call.getMethod()) |
-    call.getEnclosingStmt().getParent*() = s
+    call.getEnclosingStmt().getEnclosingStmt*() = s
   )
 select d, "Prefer wait/notify or java.util.concurrent to communicate between threads."

--- a/java/ql/src/Likely Bugs/Concurrency/DoubleCheckedLocking.ql
+++ b/java/ql/src/Likely Bugs/Concurrency/DoubleCheckedLocking.ql
@@ -33,7 +33,7 @@ where
     1 = strictcount(FieldAccess fa |
         fa.getField() = f and
         fa.getEnclosingCallable() = sync.getEnclosingCallable() and
-        not fa.getEnclosingStmt().getParent*() = sync.getBlock()
+        not fa.getEnclosingStmt().getEnclosingStmt*() = sync.getBlock()
       )
   )
 select sync, "Double-checked locking on the non-volatile field $@ is not thread-safe.", f,

--- a/java/ql/src/Likely Bugs/Concurrency/DoubleCheckedLocking.qll
+++ b/java/ql/src/Likely Bugs/Concurrency/DoubleCheckedLocking.qll
@@ -35,8 +35,8 @@ private Expr getANullCheck(Field f) {
  * as they are always safe to initialize with double-checked locking.
  */
 predicate doubleCheckedLocking(IfStmt if1, IfStmt if2, SynchronizedStmt sync, Field f) {
-  if1.getThen() = sync.getParent*() and
-  sync.getBlock() = if2.getParent*() and
+  if1.getThen() = sync.getEnclosingStmt*() and
+  sync.getBlock() = if2.getEnclosingStmt*() and
   if1.getCondition() = getANullCheck(f) and
   if2.getCondition() = getANullCheck(f)
 }

--- a/java/ql/src/Likely Bugs/Concurrency/DoubleCheckedLockingWithInitRace.ql
+++ b/java/ql/src/Likely Bugs/Concurrency/DoubleCheckedLockingWithInitRace.ql
@@ -34,8 +34,8 @@ class SideEffect extends Expr {
 from IfStmt if1, IfStmt if2, SynchronizedStmt sync, Field f, AssignExpr a, SideEffect se
 where
   doubleCheckedLocking(if1, if2, sync, f) and
-  a.getEnclosingStmt().getParent*() = if2.getThen() and
-  se.getEnclosingStmt().getParent*() = sync.getBlock() and
+  a.getEnclosingStmt().getEnclosingStmt*() = if2.getThen() and
+  se.getEnclosingStmt().getEnclosingStmt*() = sync.getBlock() and
   a.(ControlFlowNode).getASuccessor+() = se and
   a.getDest().(FieldAccess).getField() = f
 select a,

--- a/java/ql/src/Likely Bugs/Concurrency/FutileSynchOnField.ql
+++ b/java/ql/src/Likely Bugs/Concurrency/FutileSynchOnField.ql
@@ -23,6 +23,6 @@ from SynchronizedStmt s, Field f, Assignment a
 where
   synchField(s) = f and
   assignmentToField(a) = f and
-  a.getEnclosingStmt().getParent*() = s
+  a.getEnclosingStmt().getEnclosingStmt*() = s
 select a, "Synchronization on field $@ in futile attempt to guard that field.", f,
   f.getDeclaringType().getName() + "." + f.getName()

--- a/java/ql/src/Likely Bugs/Concurrency/InconsistentAccess.ql
+++ b/java/ql/src/Likely Bugs/Concurrency/InconsistentAccess.ql
@@ -24,7 +24,7 @@ predicate withinInitializer(Expr e) {
 }
 
 predicate locallySynchronized(MethodAccess ma) {
-  ma.getEnclosingStmt().getParent+() instanceof SynchronizedStmt
+  ma.getEnclosingStmt().getEnclosingStmt+() instanceof SynchronizedStmt
 }
 
 predicate hasUnsynchronizedCall(Method m) {
@@ -41,7 +41,7 @@ predicate hasUnsynchronizedCall(Method m) {
 
 predicate withinLocalSynchronization(Expr e) {
   e.getEnclosingCallable().isSynchronized() or
-  e.getEnclosingStmt().getParent+() instanceof SynchronizedStmt
+  e.getEnclosingStmt().getEnclosingStmt+() instanceof SynchronizedStmt
 }
 
 class MyField extends Field {

--- a/java/ql/src/Likely Bugs/Concurrency/LazyInitStaticField.ql
+++ b/java/ql/src/Likely Bugs/Concurrency/LazyInitStaticField.ql
@@ -94,14 +94,14 @@ where
   not method instanceof StaticInitializer and
   // There must be an unsynchronized read.
   exists(IfStmt unsyncNullCheck | unsyncNullCheck = init.getAnEnclosingNullCheck() |
-    not unsyncNullCheck.getParent+() instanceof ValidSynchStmt
+    not unsyncNullCheck.getEnclosingStmt+() instanceof ValidSynchStmt
   ) and
-  if i.getParent+() instanceof ValidSynchStmt
+  if i.getEnclosingStmt+() instanceof ValidSynchStmt
   then (
     not init.getField().isVolatile() and
     message = "The field must be volatile."
   ) else (
-    if i.getParent+() instanceof SynchronizedStmt
+    if i.getEnclosingStmt+() instanceof SynchronizedStmt
     then message = "Bad synchronization."
     else message = "Missing synchronization."
   )

--- a/java/ql/src/Likely Bugs/Concurrency/SleepWithLock.ql
+++ b/java/ql/src/Likely Bugs/Concurrency/SleepWithLock.ql
@@ -20,7 +20,7 @@ where
   sleep.hasName("sleep") and
   sleep.getDeclaringType().hasQualifiedName("java.lang", "Thread") and
   (
-    ma.getEnclosingStmt().getParent*() instanceof SynchronizedStmt or
+    ma.getEnclosingStmt().getEnclosingStmt*() instanceof SynchronizedStmt or
     ma.getEnclosingCallable().isSynchronized()
   )
 select ma, "sleep() with lock held."

--- a/java/ql/src/Likely Bugs/Concurrency/WaitOutsideLoop.ql
+++ b/java/ql/src/Likely Bugs/Concurrency/WaitOutsideLoop.ql
@@ -23,5 +23,5 @@ class WaitMethod extends Method {
 from MethodAccess ma
 where
   ma.getMethod() instanceof WaitMethod and
-  not exists(LoopStmt s | ma.getEnclosingStmt().getParent*() = s)
+  not exists(LoopStmt s | ma.getEnclosingStmt().getEnclosingStmt*() = s)
 select ma, "To avoid spurious wake-ups, 'wait' should only be called inside a loop."

--- a/java/ql/src/Likely Bugs/Concurrency/WaitWithTwoLocks.ql
+++ b/java/ql/src/Likely Bugs/Concurrency/WaitWithTwoLocks.ql
@@ -13,10 +13,10 @@
 
 import java
 
-/** A `synchronized` method or statement. */
-class Synched extends StmtParent {
+/** A `synchronized` method body or statement. */
+class Synched extends Stmt {
   Synched() {
-    this.(Method).isSynchronized() or
+    this.getParent().(Method).isSynchronized() or
     this instanceof SynchronizedStmt
   }
 }

--- a/java/ql/src/Likely Bugs/Concurrency/WaitWithTwoLocks.ql
+++ b/java/ql/src/Likely Bugs/Concurrency/WaitWithTwoLocks.ql
@@ -25,6 +25,6 @@ from MethodAccess ma, SynchronizedStmt synch
 where
   ma.getMethod().hasName("wait") and
   ma.getMethod().getDeclaringType().hasQualifiedName("java.lang", "Object") and
-  ma.getEnclosingStmt().getParent*() = synch and
-  synch.getParent+() instanceof Synched
+  ma.getEnclosingStmt().getEnclosingStmt*() = synch and
+  synch.getEnclosingStmt+() instanceof Synched
 select ma, "wait() with two locks held."

--- a/java/ql/src/Likely Bugs/Likely Typos/NestedLoopsSameVariable.ql
+++ b/java/ql/src/Likely Bugs/Likely Typos/NestedLoopsSameVariable.ql
@@ -17,7 +17,7 @@ from ForStmt inner, Variable iteration, ForStmt outer
 where
   iteration = inner.getAnIterationVariable() and
   iteration = outer.getAnIterationVariable() and
-  inner.getParent+() = outer and
+  inner.getEnclosingStmt+() = outer and
   inner.getBasicBlock().getABBSuccessor+() = outer.getCondition().getBasicBlock()
 select inner.getCondition(), "Nested for statement uses loop variable $@ of enclosing $@.",
   iteration, iteration.getName(), outer, "for statement"

--- a/java/ql/src/Likely Bugs/Statements/PartiallyMaskedCatch.ql
+++ b/java/ql/src/Likely Bugs/Statements/PartiallyMaskedCatch.ql
@@ -19,8 +19,8 @@ import java
  * and are therefore not propagated to the outer try block `t`.
  */
 private predicate caughtInside(TryStmt t, Stmt s, RefType rt) {
-  exists(TryStmt innerTry | innerTry.getParent+() = t.getBlock() |
-    s.getParent+() = innerTry.getBlock() and
+  exists(TryStmt innerTry | innerTry.getEnclosingStmt+() = t.getBlock() |
+    s.getEnclosingStmt+() = innerTry.getBlock() and
     caughtType(innerTry, _).hasSubtype*(rt)
   )
 }
@@ -43,7 +43,7 @@ private RefType getAThrownExceptionType(TryStmt t) {
   )
   or
   exists(Call call, Exception e |
-    t.getBlock() = call.getEnclosingStmt().getParent*() or
+    t.getBlock() = call.getEnclosingStmt().getEnclosingStmt*() or
     t.getAResourceDecl() = call.getEnclosingStmt()
   |
     (
@@ -55,7 +55,7 @@ private RefType getAThrownExceptionType(TryStmt t) {
   )
   or
   exists(ThrowStmt ts |
-    t.getBlock() = ts.getParent*() and
+    t.getBlock() = ts.getEnclosingStmt*() and
     not caughtInside(t, ts, ts.getExpr().getType()) and
     result = ts.getExpr().getType()
   )

--- a/java/ql/src/Likely Bugs/Termination/ConstantLoopCondition.ql
+++ b/java/ql/src/Likely Bugs/Termination/ConstantLoopCondition.ql
@@ -29,10 +29,10 @@ predicate loopWhileTrue(LoopStmt loop) {
  * is worth flagging even if it has a reachable exceptional loop exit.
  */
 predicate loopExit(LoopStmt loop, Stmt exit) {
-  exit.getParent*() = loop.getBody() and
+  exit.getEnclosingStmt*() = loop.getBody() and
   (
     exit instanceof ReturnStmt or
-    exit.(BreakStmt).(JumpStmt).getTarget() = loop.getParent*()
+    exit.(BreakStmt).(JumpStmt).getTarget() = loop.getEnclosingStmt*()
   )
 }
 
@@ -43,7 +43,7 @@ predicate loopExit(LoopStmt loop, Stmt exit) {
 predicate loopExitGuard(LoopStmt loop, Expr cond) {
   exists(ConditionBlock cb, boolean branch |
     cond = cb.getCondition() and
-    cond.getEnclosingStmt().getParent*() = loop.getBody() and
+    cond.getEnclosingStmt().getEnclosingStmt*() = loop.getBody() and
     forex(Stmt exit | loopExit(loop, exit) | cb.controls(exit.getBasicBlock(), branch))
   )
 }
@@ -60,7 +60,7 @@ predicate mainLoopCondition(LoopStmt loop, Expr cond) {
     then loopReentry = loop.(ForStmt).getUpdate(0)
     else loopReentry = cond
   |
-    last.getEnclosingStmt().getParent*() = loop.getBody() and
+    last.getEnclosingStmt().getEnclosingStmt*() = loop.getBody() and
     last.getASuccessor().(Expr).getParent*() = loopReentry
   )
 }
@@ -74,7 +74,7 @@ where
   ) and
   // None of the ssa variables in `cond` are updated inside the loop.
   forex(SsaVariable ssa, RValue use | ssa.getAUse() = use and use.getParent*() = cond |
-    not ssa.getCFGNode().getEnclosingStmt().getParent*() = loop or
+    not ssa.getCFGNode().getEnclosingStmt().getEnclosingStmt*() = loop or
     ssa.getCFGNode().(Expr).getParent*() = loop.(ForStmt).getAnInit()
   ) and
   // And `cond` does not use method calls, field reads, or array reads.

--- a/java/ql/src/Performance/ConcatenationInLoops.ql
+++ b/java/ql/src/Performance/ConcatenationInLoops.ql
@@ -48,7 +48,7 @@ predicate useAndDef(Assignment a, Variable v) {
 predicate declaredInLoop(LocalVariableDecl v, LoopStmt loop) {
   exists(LocalVariableDeclExpr e |
     e.getVariable() = v and
-    e.getEnclosingStmt().getParent*() = loop.getBody()
+    e.getEnclosingStmt().getEnclosingStmt*() = loop.getBody()
   )
   or
   exists(EnhancedForStmt for | for = loop | for.getVariable().getVariable() = v)
@@ -57,5 +57,5 @@ predicate declaredInLoop(LocalVariableDecl v, LoopStmt loop) {
 from Assignment a, Variable v
 where
   useAndDef(a, v) and
-  exists(LoopStmt loop | a.getEnclosingStmt().getParent*() = loop | not declaredInLoop(v, loop))
+  exists(LoopStmt loop | a.getEnclosingStmt().getEnclosingStmt*() = loop | not declaredInLoop(v, loop))
 select a, "The string " + v.getName() + " is built-up in a loop: use string buffer."

--- a/java/ql/src/Security/CWE/CWE-833/LockOrderInconsistency.ql
+++ b/java/ql/src/Security/CWE/CWE-833/LockOrderInconsistency.ql
@@ -46,7 +46,9 @@ class Synched extends Top {
     or
     result = this.(SynchronizedStmt).getAChild+()
     or
-    exists(MethodAccess ma | ma = result | ma.getEnclosingStmt().getEnclosingStmt*() = this)
+    exists(MethodAccess ma | ma = result |
+      ma.getEnclosingStmt().getEnclosingStmt*() = this or ma.getEnclosingCallable() = this
+    )
   }
 
   /** The variable on which synchronization is performed, provided this element is a `SynchronizedStmt`. */

--- a/java/ql/src/Security/CWE/CWE-833/LockOrderInconsistency.ql
+++ b/java/ql/src/Security/CWE/CWE-833/LockOrderInconsistency.ql
@@ -46,7 +46,7 @@ class Synched extends Top {
     or
     result = this.(SynchronizedStmt).getAChild+()
     or
-    exists(MethodAccess ma | ma = result | ma.getEnclosingStmt().getParent*() = this)
+    exists(MethodAccess ma | ma = result | ma.getEnclosingStmt().getEnclosingStmt*() = this)
   }
 
   /** The variable on which synchronization is performed, provided this element is a `SynchronizedStmt`. */

--- a/java/ql/src/Security/CWE/CWE-835/InfiniteLoop.ql
+++ b/java/ql/src/Security/CWE/CWE-835/InfiniteLoop.ql
@@ -22,16 +22,16 @@ predicate loopCondition(LoopStmt loop, Expr cond, boolean polarity) {
   polarity = true and cond = loop.getCondition()
   or
   exists(IfStmt ifstmt, Stmt exit |
-    ifstmt.getParent*() = loop.getBody() and
+    ifstmt.getEnclosingStmt*() = loop.getBody() and
     ifstmt.getCondition() = cond and
     (
       exit.(BreakStmt).(JumpStmt).getTarget() = loop or
-      exit.(ReturnStmt).getParent*() = loop.getBody()
+      exit.(ReturnStmt).getEnclosingStmt*() = loop.getBody()
     ) and
     (
-      polarity = false and exit.getParent*() = ifstmt.getThen()
+      polarity = false and exit.getEnclosingStmt*() = ifstmt.getThen()
       or
-      polarity = true and exit.getParent*() = ifstmt.getElse()
+      polarity = true and exit.getEnclosingStmt*() = ifstmt.getElse()
     )
   )
 }

--- a/java/ql/src/Violations of Best Practice/Exception Handling/ExceptionCatch.ql
+++ b/java/ql/src/Violations of Best Practice/Exception Handling/ExceptionCatch.ql
@@ -22,19 +22,19 @@ private predicate relevantTypeNames(string typeName, string message) {
 
 private Type getAThrownExceptionType(TryStmt t) {
   exists(MethodAccess ma, Exception e |
-    t.getBlock() = ma.getEnclosingStmt().getParent*() and
+    t.getBlock() = ma.getEnclosingStmt().getEnclosingStmt*() and
     ma.getMethod().getAnException() = e and
     result = e.getType()
   )
   or
   exists(ClassInstanceExpr cie, Exception e |
-    t.getBlock() = cie.getEnclosingStmt().getParent*() and
+    t.getBlock() = cie.getEnclosingStmt().getEnclosingStmt*() and
     cie.getConstructor().getAnException() = e and
     result = e.getType()
   )
   or
   exists(ThrowStmt ts |
-    t.getBlock() = ts.getParent*() and
+    t.getBlock() = ts.getEnclosingStmt*() and
     result = ts.getExpr().getType()
   )
 }

--- a/java/ql/src/Violations of Best Practice/Exception Handling/NumberFormatException.ql
+++ b/java/ql/src/Violations of Best Practice/Exception Handling/NumberFormatException.ql
@@ -81,7 +81,7 @@ from Expr e
 where
   throwsNFE(e) and
   not exists(TryStmt t |
-    t.getBlock() = e.getEnclosingStmt().getParent*() and
+    t.getBlock() = e.getEnclosingStmt().getEnclosingStmt*() and
     catchesNFE(t)
   ) and
   not exists(Callable c |

--- a/java/ql/src/Violations of Best Practice/Implementation Hiding/AbstractToConcreteCollection.ql
+++ b/java/ql/src/Violations of Best Practice/Implementation Hiding/AbstractToConcreteCollection.ql
@@ -28,7 +28,7 @@ predicate guardedByInstanceOf(VarAccess e, RefType t) {
     // The expression appears in one of the branches.
     // (We do not verify here whether the guard is correctly implemented.)
     exists(Stmt branch | branch = s.getThen() or branch = s.getElse() |
-      branch = e.getEnclosingStmt().getParent+()
+      branch = e.getEnclosingStmt().getEnclosingStmt+()
     )
   )
 }

--- a/java/ql/src/config/semmlecode.dbscheme
+++ b/java/ql/src/config/semmlecode.dbscheme
@@ -371,7 +371,7 @@ stmts(
   int bodydecl: @callable ref
 );
 
-@stmtparent = @callable | @stmt;
+@stmtparent = @callable | @stmt | @switchexpr;
 
 case @stmt.kind of
   0 = @block
@@ -491,6 +491,7 @@ case @expr.kind of
 | 70  = @annotatedtypeaccess
 | 71  = @typeannotation
 | 72  = @intersectiontypeaccess
+| 73  = @switchexpr
 ;
 
 @classinstancexpr = @newexpr | @lambdaexpr | @memberref

--- a/java/ql/src/config/semmlecode.dbscheme.stats
+++ b/java/ql/src/config/semmlecode.dbscheme.stats
@@ -444,6 +444,10 @@
 <v>277067</v>
 </e>
 <e>
+<k>@switchexpr</k>
+<v>4</v>
+</e>
+<e>
 <k>@uniontypeaccess</k>
 <v>158</v>
 </e>

--- a/java/ql/src/semmle/code/java/Completion.qll
+++ b/java/ql/src/semmle/code/java/Completion.qll
@@ -52,9 +52,13 @@ newtype Completion =
     (innerValue = true or innerValue = false)
   } or
   /**
-   * The expression or statement completes via a `break` statement.
+   * The expression or statement completes via a `break` statement without a value.
    */
   BreakCompletion(MaybeLabel l) or
+  /**
+   * The expression or statement completes via a value `break` statement.
+   */
+  ValueBreakCompletion(NormalOrBooleanCompletion c) or
   /**
    * The expression or statement completes via a `continue` statement.
    */
@@ -63,6 +67,14 @@ newtype Completion =
    * The expression or statement completes by throwing a `ThrowableType`.
    */
   ThrowCompletion(ThrowableType tt)
+
+class NormalOrBooleanCompletion extends Completion {
+  NormalOrBooleanCompletion() {
+    this instanceof NormalCompletion or this instanceof BooleanCompletion
+  }
+
+  string toString() { result = "completion" }
+}
 
 ContinueCompletion anonymousContinueCompletion() { result = ContinueCompletion(NoLabel()) }
 

--- a/java/ql/src/semmle/code/java/Concurrency.qll
+++ b/java/ql/src/semmle/code/java/Concurrency.qll
@@ -4,7 +4,7 @@ import java
  * Holds if `e` is synchronized by a local synchronized statement `sync` on the variable `v`.
  */
 predicate locallySynchronizedOn(Expr e, SynchronizedStmt sync, Variable v) {
-  e.getEnclosingStmt().getParent+() = sync and
+  e.getEnclosingStmt().getEnclosingStmt+() = sync and
   sync.getExpr().(VarAccess).getVariable() = v
 }
 
@@ -13,7 +13,7 @@ predicate locallySynchronizedOn(Expr e, SynchronizedStmt sync, Variable v) {
  * modifier on the enclosing (non-static) method.
  */
 predicate locallySynchronizedOnThis(Expr e, RefType thisType) {
-  exists(SynchronizedStmt sync | e.getEnclosingStmt().getParent+() = sync |
+  exists(SynchronizedStmt sync | e.getEnclosingStmt().getEnclosingStmt+() = sync |
     sync.getExpr().getProperExpr().(ThisAccess).getType().(RefType).getSourceDeclaration() = thisType
   )
   or

--- a/java/ql/src/semmle/code/java/Expr.qll
+++ b/java/ql/src/semmle/code/java/Expr.qll
@@ -1093,6 +1093,33 @@ class ConditionalExpr extends Expr, @conditionalexpr {
   override string toString() { result = "...?...:..." }
 }
 
+/** A `switch` expression. */
+class SwitchExpr extends Expr, @switchexpr {
+  /** Gets an immediate child statement of this `switch` expression. */
+  Stmt getAStmt() { result.getParent() = this }
+
+  /**
+   * Gets the immediate child statement of this `switch` expression
+   * that occurs at the specified (zero-based) position.
+   */
+  Stmt getStmt(int index) { result = this.getAStmt() and result.getIndex() = index }
+
+  /**
+   * Gets a case of this `switch` expression,
+   * which may be either a normal `case` or a `default`.
+   */
+  SwitchCase getACase() { result = getAConstCase() or result = getDefaultCase() }
+
+  /** Gets a (non-default) `case` of this `switch` expression. */
+  ConstCase getAConstCase() { result.getParent() = this }
+
+  /** Gets the `default` case of this switch expression, if any. */
+  DefaultCase getDefaultCase() { result.getParent() = this }
+
+  /** Gets the expression of this `switch` expression. */
+  Expr getExpr() { result.getParent() = this }
+}
+
 /** A parenthesised expression. */
 class ParExpr extends Expr, @parexpr {
   /** Gets the expression inside the parentheses. */

--- a/java/ql/src/semmle/code/java/Expr.qll
+++ b/java/ql/src/semmle/code/java/Expr.qll
@@ -1122,6 +1122,15 @@ deprecated class SwitchExpr extends Expr, @switchexpr {
 
   /** Gets the expression of this `switch` expression. */
   Expr getExpr() { result.getParent() = this }
+
+  /** Gets a result expression of this `switch` expression. */
+  deprecated Expr getAResult() {
+    result = getACase().getRuleExpression()
+    or
+    exists(BreakStmt break |
+      break.(JumpStmt).getTarget() = this and result = break.getValue()
+    )
+  }
 }
 
 /** A parenthesised expression. */

--- a/java/ql/src/semmle/code/java/Expr.qll
+++ b/java/ql/src/semmle/code/java/Expr.qll
@@ -1094,7 +1094,7 @@ class ConditionalExpr extends Expr, @conditionalexpr {
 }
 
 /** A `switch` expression. */
-class SwitchExpr extends Expr, @switchexpr {
+deprecated class SwitchExpr extends Expr, @switchexpr {
   /** Gets an immediate child statement of this `switch` expression. */
   Stmt getAStmt() { result.getParent() = this }
 

--- a/java/ql/src/semmle/code/java/Expr.qll
+++ b/java/ql/src/semmle/code/java/Expr.qll
@@ -1094,37 +1094,37 @@ class ConditionalExpr extends Expr, @conditionalexpr {
 }
 
 /**
- * DEPRECATED: Preview feature in Java 12. Subject to removal in a future release.
+ * PREVIEW FEATURE in Java 12. Subject to removal in a future release.
  *
  * A `switch` expression.
  */
-deprecated class SwitchExpr extends Expr, @switchexpr {
+class SwitchExpr extends Expr, @switchexpr {
   /** Gets an immediate child statement of this `switch` expression. */
-  deprecated Stmt getAStmt() { result.getParent() = this }
+  Stmt getAStmt() { result.getParent() = this }
 
   /**
    * Gets the immediate child statement of this `switch` expression
    * that occurs at the specified (zero-based) position.
    */
-  deprecated Stmt getStmt(int index) { result = this.getAStmt() and result.getIndex() = index }
+  Stmt getStmt(int index) { result = this.getAStmt() and result.getIndex() = index }
 
   /**
    * Gets a case of this `switch` expression,
    * which may be either a normal `case` or a `default`.
    */
-  deprecated SwitchCase getACase() { result = getAConstCase() or result = getDefaultCase() }
+  SwitchCase getACase() { result = getAConstCase() or result = getDefaultCase() }
 
   /** Gets a (non-default) `case` of this `switch` expression. */
-  deprecated ConstCase getAConstCase() { result.getParent() = this }
+  ConstCase getAConstCase() { result.getParent() = this }
 
   /** Gets the `default` case of this switch expression, if any. */
-  deprecated DefaultCase getDefaultCase() { result.getParent() = this }
+  DefaultCase getDefaultCase() { result.getParent() = this }
 
   /** Gets the expression of this `switch` expression. */
-  deprecated Expr getExpr() { result.getParent() = this }
+  Expr getExpr() { result.getParent() = this }
 
   /** Gets a result expression of this `switch` expression. */
-  deprecated Expr getAResult() {
+  Expr getAResult() {
     result = getACase().getRuleExpression()
     or
     exists(BreakStmt break |

--- a/java/ql/src/semmle/code/java/Expr.qll
+++ b/java/ql/src/semmle/code/java/Expr.qll
@@ -1100,28 +1100,28 @@ class ConditionalExpr extends Expr, @conditionalexpr {
  */
 deprecated class SwitchExpr extends Expr, @switchexpr {
   /** Gets an immediate child statement of this `switch` expression. */
-  Stmt getAStmt() { result.getParent() = this }
+  deprecated Stmt getAStmt() { result.getParent() = this }
 
   /**
    * Gets the immediate child statement of this `switch` expression
    * that occurs at the specified (zero-based) position.
    */
-  Stmt getStmt(int index) { result = this.getAStmt() and result.getIndex() = index }
+  deprecated Stmt getStmt(int index) { result = this.getAStmt() and result.getIndex() = index }
 
   /**
    * Gets a case of this `switch` expression,
    * which may be either a normal `case` or a `default`.
    */
-  SwitchCase getACase() { result = getAConstCase() or result = getDefaultCase() }
+  deprecated SwitchCase getACase() { result = getAConstCase() or result = getDefaultCase() }
 
   /** Gets a (non-default) `case` of this `switch` expression. */
-  ConstCase getAConstCase() { result.getParent() = this }
+  deprecated ConstCase getAConstCase() { result.getParent() = this }
 
   /** Gets the `default` case of this switch expression, if any. */
-  DefaultCase getDefaultCase() { result.getParent() = this }
+  deprecated DefaultCase getDefaultCase() { result.getParent() = this }
 
   /** Gets the expression of this `switch` expression. */
-  Expr getExpr() { result.getParent() = this }
+  deprecated Expr getExpr() { result.getParent() = this }
 
   /** Gets a result expression of this `switch` expression. */
   deprecated Expr getAResult() {

--- a/java/ql/src/semmle/code/java/Expr.qll
+++ b/java/ql/src/semmle/code/java/Expr.qll
@@ -1093,7 +1093,11 @@ class ConditionalExpr extends Expr, @conditionalexpr {
   override string toString() { result = "...?...:..." }
 }
 
-/** A `switch` expression. */
+/**
+ * DEPRECATED: Preview feature in Java 12. Subject to removal in a future release.
+ *
+ * A `switch` expression.
+ */
 deprecated class SwitchExpr extends Expr, @switchexpr {
   /** Gets an immediate child statement of this `switch` expression. */
   Stmt getAStmt() { result.getParent() = this }

--- a/java/ql/src/semmle/code/java/Statement.qll
+++ b/java/ql/src/semmle/code/java/Statement.qll
@@ -535,12 +535,12 @@ class ThrowStmt extends Stmt, @throwstmt {
   }
 
   private Stmt findEnclosing() {
-    result = getParent()
+    result = getEnclosingStmt()
     or
     exists(Stmt mid |
       mid = findEnclosing() and
       not exists(this.catchClauseForThis(mid.(TryStmt))) and
-      result = mid.getParent()
+      result = mid.getEnclosingStmt()
     )
   }
 
@@ -548,7 +548,7 @@ class ThrowStmt extends Stmt, @throwstmt {
     result = try.getACatchClause() and
     result.getEnclosingCallable() = this.getEnclosingCallable() and
     getExpr().getType().(RefType).hasSupertype*(result.getVariable().getType().(RefType)) and
-    not this.getParent+() = result
+    not this.getEnclosingStmt+() = result
   }
 }
 
@@ -588,7 +588,7 @@ class JumpStmt extends Stmt {
     or
     not exists(getSwitchExprTarget()) and
     result = getAPotentialTarget() and
-    not exists(Stmt other | other = getAPotentialTarget() | other.getParent+() = result)
+    not exists(Stmt other | other = getAPotentialTarget() | other.getEnclosingStmt+() = result)
   }
 
   /**

--- a/java/ql/src/semmle/code/java/Statement.qll
+++ b/java/ql/src/semmle/code/java/Statement.qll
@@ -408,10 +408,18 @@ class SwitchCase extends Stmt, @case {
   /** Gets the switch statement to which this case belongs, if any. */
   SwitchStmt getSwitch() { result.getACase() = this }
 
-  /** Gets the switch expression to which this case belongs, if any. */
+  /**
+   * DEPRECATED: Preview feature in Java 12. Subject to removal in a future release.
+   *
+   * Gets the switch expression to which this case belongs, if any.
+   */
   deprecated SwitchExpr getSwitchExpr() { result.getACase() = this }
 
-  /** Holds if this `case` is a switch labeled rule of the form `... -> ...`. */
+  /**
+   * DEPRECATED: Preview feature in Java 12. Subject to removal in a future release.
+   *
+   * Holds if this `case` is a switch labeled rule of the form `... -> ...`.
+   */
   deprecated predicate isRule() {
     exists(Expr e | e.getParent() = this | e.getIndex() = -1)
     or
@@ -426,13 +434,25 @@ class ConstCase extends SwitchCase {
   /** Gets the `case` constant at index 0. */
   Expr getValue() { result.getParent() = this and result.getIndex() = 0 }
 
-  /** Gets the `case` constant at the specified index. */
+  /**
+   * DEPRECATED: Preview feature in Java 12. Subject to removal in a future release.
+   *
+   * Gets the `case` constant at the specified index.
+   */
   deprecated Expr getValue(int i) { result.getParent() = this and result.getIndex() = i and i >= 0 }
 
-  /** Gets the expression on the right-hand side of the arrow, if any. */
+  /**
+   * DEPRECATED: Preview feature in Java 12. Subject to removal in a future release.
+   *
+   * Gets the expression on the right-hand side of the arrow, if any.
+   */
   deprecated Expr getRuleExpression() { result.getParent() = this and result.getIndex() = -1 }
 
-  /** Gets the statement on the right-hand side of the arrow, if any. */
+  /**
+   * DEPRECATED: Preview feature in Java 12. Subject to removal in a future release.
+   *
+   * Gets the statement on the right-hand side of the arrow, if any.
+   */
   deprecated Stmt getRuleStatement() { result.getParent() = this and result.getIndex() = -1 }
 
   /** Gets a printable representation of this statement. May include more detail than `toString()`. */
@@ -572,10 +592,18 @@ class BreakStmt extends Stmt, @breakstmt {
   /** Holds if this `break` statement has an explicit label. */
   predicate hasLabel() { exists(string s | s = this.getLabel()) }
 
-  /** Gets the value of this `break` statement, if any. */
+  /**
+   * DEPRECATED: Preview feature in Java 12. Subject to removal in a future release.
+   *
+   * Gets the value of this `break` statement, if any.
+   */
   deprecated Expr getValue() { result.getParent() = this }
 
-  /** Holds if this `break` statement has a value. */
+  /**
+   * DEPRECATED: Preview feature in Java 12. Subject to removal in a future release.
+   *
+   * Holds if this `break` statement has a value.
+   */
   deprecated predicate hasValue() { exists(Expr e | e.getParent() = this) }
 
   /** Gets a printable representation of this statement. May include more detail than `toString()`. */

--- a/java/ql/src/semmle/code/java/Statement.qll
+++ b/java/ql/src/semmle/code/java/Statement.qll
@@ -409,10 +409,10 @@ class SwitchCase extends Stmt, @case {
   SwitchStmt getSwitch() { result.getACase() = this }
 
   /** Gets the switch expression to which this case belongs, if any. */
-  SwitchExpr getSwitchExpr() { result.getACase() = this }
+  deprecated SwitchExpr getSwitchExpr() { result.getACase() = this }
 
   /** Holds if this `case` is a switch labeled rule of the form `... -> ...`. */
-  predicate isRule() {
+  deprecated predicate isRule() {
     exists(Expr e | e.getParent() = this | e.getIndex() = -1)
     or
     exists(Stmt s | s.getParent() = this | s.getIndex() = -1)
@@ -427,13 +427,13 @@ class ConstCase extends SwitchCase {
   Expr getValue() { result.getParent() = this and result.getIndex() = 0 }
 
   /** Gets the `case` constant at the specified index. */
-  Expr getValue(int i) { result.getParent() = this and result.getIndex() = i and i >= 0 }
+  deprecated Expr getValue(int i) { result.getParent() = this and result.getIndex() = i and i >= 0 }
 
   /** Gets the expression on the right-hand side of the arrow, if any. */
-  Expr getRuleExpression() { result.getParent() = this and result.getIndex() = -1 }
+  deprecated Expr getRuleExpression() { result.getParent() = this and result.getIndex() = -1 }
 
   /** Gets the statement on the right-hand side of the arrow, if any. */
-  Stmt getRuleStatement() { result.getParent() = this and result.getIndex() = -1 }
+  deprecated Stmt getRuleStatement() { result.getParent() = this and result.getIndex() = -1 }
 
   /** Gets a printable representation of this statement. May include more detail than `toString()`. */
   override string pp() { result = "case ..." }
@@ -573,10 +573,10 @@ class BreakStmt extends Stmt, @breakstmt {
   predicate hasLabel() { exists(string s | s = this.getLabel()) }
 
   /** Gets the value of this `break` statement, if any. */
-  Expr getValue() { result.getParent() = this }
+  deprecated Expr getValue() { result.getParent() = this }
 
   /** Holds if this `break` statement has a value. */
-  predicate hasValue() { exists(Expr e | e.getParent() = this) }
+  deprecated predicate hasValue() { exists(Expr e | e.getParent() = this) }
 
   /** Gets a printable representation of this statement. May include more detail than `toString()`. */
   override string pp() {

--- a/java/ql/src/semmle/code/java/Statement.qll
+++ b/java/ql/src/semmle/code/java/Statement.qll
@@ -417,36 +417,36 @@ class SwitchCase extends Stmt, @case {
   SwitchStmt getSwitch() { result.getACase() = this }
 
   /**
-   * DEPRECATED: Preview feature in Java 12. Subject to removal in a future release.
+   * PREVIEW FEATURE in Java 12. Subject to removal in a future release.
    *
    * Gets the switch expression to which this case belongs, if any.
    */
-  deprecated SwitchExpr getSwitchExpr() { result.getACase() = this }
+  SwitchExpr getSwitchExpr() { result.getACase() = this }
 
   /**
-   * DEPRECATED: Preview feature in Java 12. Subject to removal in a future release.
+   * PREVIEW FEATURE in Java 12. Subject to removal in a future release.
    *
    * Holds if this `case` is a switch labeled rule of the form `... -> ...`.
    */
-  deprecated predicate isRule() {
+  predicate isRule() {
     exists(Expr e | e.getParent() = this | e.getIndex() = -1)
     or
     exists(Stmt s | s.getParent() = this | s.getIndex() = -1)
   }
 
   /**
-   * DEPRECATED: Preview feature in Java 12. Subject to removal in a future release.
+   * PREVIEW FEATURE in Java 12. Subject to removal in a future release.
    *
    * Gets the expression on the right-hand side of the arrow, if any.
    */
-  deprecated Expr getRuleExpression() { result.getParent() = this and result.getIndex() = -1 }
+  Expr getRuleExpression() { result.getParent() = this and result.getIndex() = -1 }
 
   /**
-   * DEPRECATED: Preview feature in Java 12. Subject to removal in a future release.
+   * PREVIEW FEATURE in Java 12. Subject to removal in a future release.
    *
    * Gets the statement on the right-hand side of the arrow, if any.
    */
-  deprecated Stmt getRuleStatement() { result.getParent() = this and result.getIndex() = -1 }
+  Stmt getRuleStatement() { result.getParent() = this and result.getIndex() = -1 }
 }
 
 /** A constant `case` of a switch statement. */
@@ -457,11 +457,11 @@ class ConstCase extends SwitchCase {
   Expr getValue() { result.getParent() = this and result.getIndex() = 0 }
 
   /**
-   * DEPRECATED: Preview feature in Java 12. Subject to removal in a future release.
+   * PREVIEW FEATURE in Java 12. Subject to removal in a future release.
    *
    * Gets the `case` constant at the specified index.
    */
-  deprecated Expr getValue(int i) { result.getParent() = this and result.getIndex() = i and i >= 0 }
+  Expr getValue(int i) { result.getParent() = this and result.getIndex() = i and i >= 0 }
 
   /** Gets a printable representation of this statement. May include more detail than `toString()`. */
   override string pp() { result = "case ..." }
@@ -608,18 +608,18 @@ class BreakStmt extends Stmt, @breakstmt {
   predicate hasLabel() { exists(string s | s = this.getLabel()) }
 
   /**
-   * DEPRECATED: Preview feature in Java 12. Subject to removal in a future release.
+   * PREVIEW FEATURE in Java 12. Subject to removal in a future release.
    *
    * Gets the value of this `break` statement, if any.
    */
-  deprecated Expr getValue() { result.getParent() = this }
+  Expr getValue() { result.getParent() = this }
 
   /**
-   * DEPRECATED: Preview feature in Java 12. Subject to removal in a future release.
+   * PREVIEW FEATURE in Java 12. Subject to removal in a future release.
    *
    * Holds if this `break` statement has a value.
    */
-  deprecated predicate hasValue() { exists(Expr e | e.getParent() = this) }
+  predicate hasValue() { exists(Expr e | e.getParent() = this) }
 
   /** Gets a printable representation of this statement. May include more detail than `toString()`. */
   override string pp() {

--- a/java/ql/src/semmle/code/java/Statement.qll
+++ b/java/ql/src/semmle/code/java/Statement.qll
@@ -410,10 +410,10 @@ class SwitchCase extends Stmt, @case {
 
 /** A constant `case` of a switch statement. */
 class ConstCase extends SwitchCase {
-  ConstCase() { exists(Expr e | e.getParent() = this) }
+  ConstCase() { exists(Expr e | e.getParent() = this | e.getIndex() >= 0) }
 
   /** Gets the expression of this `case`. */
-  Expr getValue() { result.getParent() = this }
+  Expr getValue() { result.getParent() = this and result.getIndex() = 0 }
 
   /** Gets a printable representation of this statement. May include more detail than `toString()`. */
   override string pp() { result = "case ...:" }
@@ -424,7 +424,7 @@ class ConstCase extends SwitchCase {
 
 /** A `default` case of a `switch` statement */
 class DefaultCase extends SwitchCase {
-  DefaultCase() { not exists(Expr e | e.getParent() = this) }
+  DefaultCase() { not exists(Expr e | e.getParent() = this | e.getIndex() >= 0) }
 
   /** Gets a printable representation of this statement. May include more detail than `toString()`. */
   override string pp() { result = "default" }

--- a/java/ql/src/semmle/code/java/Statement.qll
+++ b/java/ql/src/semmle/code/java/Statement.qll
@@ -25,11 +25,9 @@ class Stmt extends StmtParent, ExprParent, @stmt {
   StmtParent getParent() { stmts(this, _, result, _, _) }
 
   /**
-   * DEPRECATED: Preview feature in Java 12. Subject to removal in a future release.
-   *
    * Gets the statement containing this statement, if any.
    */
-  deprecated Stmt getEnclosingStmt() {
+  Stmt getEnclosingStmt() {
     result = this.getParent() or
     result = this.getParent().(SwitchExpr).getEnclosingStmt()
   }

--- a/java/ql/src/semmle/code/java/dataflow/Nullness.qll
+++ b/java/ql/src/semmle/code/java/dataflow/Nullness.qll
@@ -184,7 +184,7 @@ private predicate varMaybeNull(SsaVariable v, string msg, Expr reason) {
     not v instanceof SsaPhiNode and
     not clearlyNotNull(v) and
     // Comparisons in finally blocks are excluded since missing exception edges in the CFG could otherwise yield FPs.
-    not exists(TryStmt try | try.getFinally() = e.getEnclosingStmt().getParent*()) and
+    not exists(TryStmt try | try.getFinally() = e.getEnclosingStmt().getEnclosingStmt*()) and
     (
       exists(ConditionalExpr c | c.getCondition().getAChildExpr*() = e) or
       not exists(MethodAccess ma | ma.getAnArgument().getAChildExpr*() = e)
@@ -291,8 +291,8 @@ private predicate leavingFinally(BasicBlock bb1, BasicBlock bb2, boolean normale
   exists(TryStmt try, Block finally |
     try.getFinally() = finally and
     bb1.getABBSuccessor() = bb2 and
-    bb1.getEnclosingStmt().getParent*() = finally and
-    not bb2.getEnclosingStmt().getParent*() = finally and
+    bb1.getEnclosingStmt().getEnclosingStmt*() = finally and
+    not bb2.getEnclosingStmt().getEnclosingStmt*() = finally and
     if bb1.getLastNode().getANormalSuccessor() = bb2.getFirstNode()
     then normaledge = true
     else normaledge = false

--- a/java/ql/src/semmle/code/java/dataflow/SSA.qll
+++ b/java/ql/src/semmle/code/java/dataflow/SSA.qll
@@ -166,7 +166,7 @@ private module TrackedVariablesImpl {
   /** Holds if `f` is accessed inside a loop. */
   private predicate loopAccessed(SsaSourceField f) {
     exists(LoopStmt l, FieldRead fr | fr = f.getAnAccess() |
-      l.getBody() = fr.getEnclosingStmt().getParent*() or
+      l.getBody() = fr.getEnclosingStmt().getEnclosingStmt*() or
       l.getCondition() = fr.getParent*() or
       l.(ForStmt).getAnUpdate() = fr.getParent*()
     )


### PR DESCRIPTION
Adds support for switch expressions, a preview feature in Java 12.

This needs to be merged along with the corresponding internal PR containing the extractor changes.