### PR TITLE
Fix typo in C/C++ QL library docs

### DIFF
--- a/cpp/ql/src/cpp.qll
+++ b/cpp/ql/src/cpp.qll
@@ -1,6 +1,5 @@
 /**
- * Provides classes and predicates for working with C/C++/ObjC/ObjC++
- * code.
+ * Provides classes and predicates for working with C/C++ code.
  *
  * Where the documentation refers to the standards, it gives
  * references to the freely-available drafts.


### PR DESCRIPTION
Fix a typo in C/C++ QL library docs.