### PR TITLE
Add `pragma[nomagic]` to `getExplicitArgument()`

### DIFF
--- a/csharp/ql/src/semmle/code/csharp/exprs/Call.qll
+++ b/csharp/ql/src/semmle/code/csharp/exprs/Call.qll
@@ -108,15 +108,13 @@ class Call extends DotNet::Call, Expr, @call {
     )
   }
 
-  // predicate folding to get proper join-order
   pragma[noinline]
   private Expr getImplicitArgument(int pos) {
     result = getArgument(pos) and
     not exists(result.getExplicitArgumentName())
   }
 
-  // predicate folding to get proper join-order
-  pragma[noinline]
+  pragma[nomagic]
   private Expr getExplicitArgument(string name) {
     result = getAnArgument() and
     result.getExplicitArgumentName() = name


### PR DESCRIPTION
This change has no notable impact on our test suite (full report [here](https://git.semmle.com/gist/tom/44372e32d1d6e44d3cbe260cd85ba7cd)):
```
Project              23faa942ced@19c7360e1  23faa942ced@272545a63
roslyn               568                    551                    0.97007
coreclr              100                    98                     0.98
corefx               483                    478                    0.989648
mono                 366                    364                    0.994536
EntityFrameworkCore  507                    506                    0.998028
OneOf                152                    152                    1
PowerShell           187                    187                    1
pythonnet            15                     15                     1
runuo                157                    158                    1.00637
ql                   77                     78                     1.01299
OrchardCore          230                    233                    1.01304
nhibernate-core      607                    617                    1.01647
monodevelop          800                    818                    1.0225
```

But it makes a big difference at one of our customers:

Before:
```
[2019-05-07 02:06:31] (3719s) Starting to evaluate predicate Call::Call::getExplicitArgument#bbf
[2019-05-07 02:09:37] (3905s) Tuple counts:​
                      5880556    ~0%     {2} r1 = JOIN Call::Call::getExplicitArgument#bbf#shared WITH Element::NamedElement::getName_dispred#ff ON Call::Call::getExplicitArgument#bbf#shared.<0>=Element::NamedElement::getName_dispred#ff.<0> OUTPUT FIELDS {Element::NamedElement::getName_dispred#ff.<1>,Call::Call::getExplicitArgument#bbf#shared.<1>}​
                      1767682173 ~0%     {3} r2 = JOIN r1 WITH expr_argument_name_10#join_rhs ON r1.<0>=expr_argument_name_10#join_rhs.<0> OUTPUT FIELDS {r1.<1>,expr_argument_name_10#join_rhs.<1>,r1.<0>}​
                      169410     ~0%     {3} r3 = JOIN r2 WITH project#Call::Call::getArgument_dispred#fff ON r2.<0>=project#Call::Call::getArgument_dispred#fff.<0> AND r2.<1>=project#Call::Call::getArgument_dispred#fff.<1> OUTPUT FIELDS {r2.<0>,r2.<2>,r2.<1>}​
                                         return r3​
[2019-05-07 02:09:37] (3905s)  >>> Relation Call::Call::getExplicitArgument#bbf: 169410 rows using 0 MB​
```
​
After:
```
[2019-05-07 04:15:25] (1s) Starting to evaluate predicate Call::Call::getExplicitArgument#fff​
[2019-05-07 04:15:25] (1s) Tuple counts:​
                      169747  ~0%     {3} r1 = JOIN expr_argument_name WITH project#Call::Call::getArgument_dispred#fff_10#join_rhs ON expr_argument_name.<0>=project#Call::Call::getArgument_dispred#fff_10#join_rhs.<0> OUTPUT FIELDS {project#Call::Call::getArgument_dispred#fff_10#join_rhs.<1>,expr_argument_name.<1>,expr_argument_name.<0>}​
                                      return r1​
[2019-05-07 04:15:25] (1s)  >>> Relation Call::Call::getExplicitArgument#fff: 169747 rows using 0 MB
```