### PR TITLE
JavaScript: Fix a few false positives in `PasswordInConfigurationFile`.

### DIFF
--- a/change-notes/1.21/analysis-javascript.md
+++ b/change-notes/1.21/analysis-javascript.md
@@ -33,7 +33,7 @@
 | Expression has no effect       | Fewer false-positive results | This rule now treats uses of `Object.defineProperty` more conservatively. |
 | Incomplete regular expression for hostnames | More results | This rule now tracks regular expressions for host names further. |
 | Incomplete string escaping or encoding | More results | This rule now considers the flow of regular expressions literals, and it no longer flags the removal of trailing newlines. |
-| Password in configuration file | Fewer false positive results | This query now excludes passwords that are inserted into the configuration file using a templating mechanism. |
+| Password in configuration file | Fewer false positive results | This query now excludes passwords that are inserted into the configuration file using a templating mechanism or read from environment variables. |
 | Replacement of a substring with itself | More results | This rule now considers the flow of regular expressions literals. |
 | Server-side URL redirect       | Fewer false-positive results | This rule now treats URLs as safe in more cases where the hostname cannot be tampered with. |
 | Type confusion through parameter tampering | Fewer false-positive results | This rule now recognizes additional emptiness checks. |

--- a/javascript/ql/test/query-tests/Security/CWE-313/PasswordInConfigurationFile.expected
+++ b/javascript/ql/test/query-tests/Security/CWE-313/PasswordInConfigurationFile.expected
@@ -1,1 +1,2 @@
 | mysql-config.json:4:16:4:23 | "secret" | Avoid plaintext passwords in configuration files. |
+| tst4.json:2:10:2:38 | "script ... ecret'" | Avoid plaintext passwords in configuration files. |

--- a/javascript/ql/test/query-tests/Security/CWE-313/i18n/de.json
+++ b/javascript/ql/test/query-tests/Security/CWE-313/i18n/de.json
@@ -1,0 +1,3 @@
+{
+  "password": "Passwort"
+}

--- a/javascript/ql/test/query-tests/Security/CWE-313/locales/de.json
+++ b/javascript/ql/test/query-tests/Security/CWE-313/locales/de.json
@@ -1,0 +1,3 @@
+{
+  "password": "Passwort"
+}

--- a/javascript/ql/test/query-tests/Security/CWE-313/tst.raml
+++ b/javascript/ql/test/query-tests/Security/CWE-313/tst.raml
@@ -1,0 +1,1 @@
+password: string

--- a/javascript/ql/test/query-tests/Security/CWE-313/tst1.json
+++ b/javascript/ql/test/query-tests/Security/CWE-313/tst1.json
@@ -1,0 +1,3 @@
+{
+  "password": "$pwd"
+}

--- a/javascript/ql/test/query-tests/Security/CWE-313/tst2.json
+++ b/javascript/ql/test/query-tests/Security/CWE-313/tst2.json
@@ -1,0 +1,3 @@
+{
+  "password": "%pwd%"
+}

--- a/javascript/ql/test/query-tests/Security/CWE-313/tst3.json
+++ b/javascript/ql/test/query-tests/Security/CWE-313/tst3.json
@@ -1,0 +1,3 @@
+{
+  "password": "${pwd:foo}"
+}

--- a/javascript/ql/test/query-tests/Security/CWE-313/tst4.json
+++ b/javascript/ql/test/query-tests/Security/CWE-313/tst4.json
@@ -1,0 +1,3 @@
+{
+  "cmd": "script.sh password='secret'"
+}

--- a/javascript/ql/test/query-tests/Security/CWE-313/tst5.json
+++ b/javascript/ql/test/query-tests/Security/CWE-313/tst5.json
@@ -1,0 +1,3 @@
+{
+  "cmd": "script.sh password=%s"
+}

--- a/javascript/ql/test/query-tests/Security/CWE-313/tst6.json
+++ b/javascript/ql/test/query-tests/Security/CWE-313/tst6.json
@@ -1,0 +1,3 @@
+{
+  "foo": "password==bar"
+}


### PR DESCRIPTION
This whitelists a number of common patterns that were causing FPs on LGTM.com. No result changes on our default benchmarks.