### PR TITLE
JavaScript: Update UnreachableStmt, now unreachable throws don't give an alert

### DIFF
--- a/change-notes/1.21/analysis-javascript.md
+++ b/change-notes/1.21/analysis-javascript.md
@@ -38,7 +38,7 @@
 | Server-side URL redirect       | Fewer false-positive results | This rule now treats URLs as safe in more cases where the hostname cannot be tampered with. |
 | Type confusion through parameter tampering | Fewer false-positive results | This rule now recognizes additional emptiness checks. |
 | Useless assignment to property | Fewer false-positive results | This rule now ignore reads of additional getters. |
-| Unreachable statement | Unreachable throws no longer give an alert | This ignores unreachable throws, as they could be intentional (for eg. to placate the TS compiler). |
+| Unreachable statement | Unreachable throws no longer give an alert | This ignores unreachable throws, as they could be intentional (for example, to placate the TS compiler). |
 
 ## Changes to QL libraries
 

--- a/change-notes/1.21/analysis-javascript.md
+++ b/change-notes/1.21/analysis-javascript.md
@@ -38,6 +38,7 @@
 | Server-side URL redirect       | Fewer false-positive results | This rule now treats URLs as safe in more cases where the hostname cannot be tampered with. |
 | Type confusion through parameter tampering | Fewer false-positive results | This rule now recognizes additional emptiness checks. |
 | Useless assignment to property | Fewer false-positive results | This rule now ignore reads of additional getters. |
+| Unreachable statement | Unreachable throws no longer give an alert | This ignores unreachable throws, as they could be intentional (for eg. to placate the TS compiler). |
 
 ## Changes to QL libraries
 

--- a/javascript/ql/src/Statements/UnreachableStatement.ql
+++ b/javascript/ql/src/Statements/UnreachableStatement.ql
@@ -26,5 +26,7 @@ where
   // ignore ambient statements
   not s.isAmbient() and
   // ignore empty statements
-  not s instanceof EmptyStmt
+  not s instanceof EmptyStmt and 
+  // ignore unreachable throws
+  not s instanceof ThrowStmt
 select s.(FirstLineOf), "This statement is unreachable."

--- a/javascript/ql/test/query-tests/Statements/UnreachableStatement/tst.js
+++ b/javascript/ql/test/query-tests/Statements/UnreachableStatement/tst.js
@@ -73,3 +73,9 @@ function f(){
 		return z;
 	}; // ';' is unreachable, but alert is squelched
 }
+
+// test for unreachable throws
+function z() {
+	return 10;
+	throw new Error(); // this throws is unreachable, but alert should not be produced
+}


### PR DESCRIPTION
Small change to the UnreachableStmt query, so unreachable throws don't give an alert any more. This style could be intentional and shouldn't be flagged as an error, as per https://jira.semmle.com/browse/ODASA-7935

@xiemaisi 