### PR TITLE
JavaScript: Further broaden the whitelist in `PasswordInConfigurationFile`.

### DIFF
--- a/javascript/ql/src/Security/CWE-313/PasswordInConfigurationFile.ql
+++ b/javascript/ql/src/Security/CWE-313/PasswordInConfigurationFile.ql
@@ -54,7 +54,7 @@ where
   (
     key.toLowerCase() = "password" and
     // exclude interpolations of environment variables
-    not val.regexpMatch("\\$\\w+|\\$[{(].+[)}]|%.*%")
+    not val.regexpMatch("\\$.*|%.*%")
     or
     key.toLowerCase() != "readme" and
     // look for `password=...`, but exclude `password=;`, `password="$(...)"`,

--- a/javascript/ql/test/query-tests/Security/CWE-313/tst7.yml
+++ b/javascript/ql/test/query-tests/Security/CWE-313/tst7.yml
@@ -1,0 +1,1 @@
+password: $$SOME_VAR


### PR DESCRIPTION
Fixes the FP reported [here](https://discuss.lgtm.com/t/possible-false-positive-in-variable-definition/2077).