### PR TITLE
Python QL: Use Module.getPath() to implement ModuleObject.getPath()

### DIFF
--- a/python/ql/src/semmle/python/types/ModuleObject.qll
+++ b/python/ql/src/semmle/python/types/ModuleObject.qll
@@ -234,10 +234,7 @@ class PackageObject extends ModuleObject {
     }
 
     override Container getPath() {
-        exists(ModuleObject m | 
-            m.getPackage() = this |
-            result = m.getPath().getParent()
-        )
+        result = this.getModule().getPath()
     }
 
     ModuleObject submodule(string name) {


### PR DESCRIPTION
Hotfix of https://github.com/Semmle/ql/pull/1313