### PR TITLE
Java: Add SwitchExpr to Nullness::dereference.

### DIFF
--- a/java/ql/src/semmle/code/java/dataflow/Nullness.qll
+++ b/java/ql/src/semmle/code/java/dataflow/Nullness.qll
@@ -104,6 +104,8 @@ predicate dereference(Expr e) {
   or
   exists(SwitchStmt switch | switch.getExpr() = e)
   or
+  exists(SwitchExpr switch | switch.getExpr() = e)
+  or
   exists(FieldAccess fa, Field f | fa.getQualifier() = e and fa.getField() = f and not f.isStatic())
   or
   exists(MethodAccess ma, Method m |


### PR DESCRIPTION
Account for the java 12 switch expression in the nullness queries.