### PR TITLE
 C++: Use isConstexpr instead of workaround in AddressConstantExpr

### DIFF
--- a/cpp/ql/src/semmle/code/cpp/internal/AddressConstantExpression.qll
+++ b/cpp/ql/src/semmle/code/cpp/internal/AddressConstantExpression.qll
@@ -13,10 +13,7 @@ predicate addressConstantExpression(Expr e) {
 /** Holds if `v` is a constexpr variable initialized to a constant address. */
 private predicate addressConstantVariable(Variable v) {
   addressConstantExpression(v.getInitializer().getExpr().getFullyConverted()) and
-  // Here we should also require that `v` is constexpr, but we don't have that
-  // information in the db. See CPP-314. Instead, we require that the variable
-  // is never defined except in its initializer.
-  forall(Expr def | definition(v, def) | def = any(Initializer init).getExpr())
+  v.isConstexpr()
 }
 
 /**

--- a/cpp/ql/src/semmle/code/cpp/internal/AddressConstantExpression.qll
+++ b/cpp/ql/src/semmle/code/cpp/internal/AddressConstantExpression.qll
@@ -1,5 +1,4 @@
 private import cpp
-private import semmle.code.cpp.dataflow.EscapesTree
 
 predicate addressConstantExpression(Expr e) {
   constantAddressPointer(e)


### PR DESCRIPTION
The `addressConstantVariable` predicate [was the slowest single predicate](https://docs.google.com/spreadsheets/d/1T3944Ig2U2wPQewWNbAa7kCoKKwYlCq49uOpHKwIiyI/edit#gid=2015539348) when running the full LGTM suite on Chromium. Fortunately it's only executed once, but it could be easily made faster by using the new `Variable.isConstexpr` predicate instead of the slow workaround that was in its place.