### PR TITLE
Data flow: performance improvements

### DIFF
--- a/cpp/ql/src/semmle/code/cpp/dataflow/internal/DataFlowImpl.qll
+++ b/cpp/ql/src/semmle/code/cpp/dataflow/internal/DataFlowImpl.qll
@@ -836,7 +836,11 @@ private predicate flowCandFwd(Node node, boolean fromArg, AccessPathFront apf, C
   if node instanceof CastingNode then compatibleTypes(node.getType(), apf.getType()) else any()
 }
 
-/** A node that should have a `nil` access path front. */
+/**
+ * A node that requires an empty access path and should have its tracked type
+ * (re-)computed. This is either a source or a node reached through an
+ * additional step.
+ */
 private class AccessPathFrontNilNode extends Node {
   AccessPathFrontNilNode() {
     nodeCand(this, _) and
@@ -1101,7 +1105,11 @@ private predicate popWithFront(AccessPath ap0, Content f, AccessPathFront apf, A
 /** Holds if `ap` corresponds to the cons of `f` and `ap0`. */
 private predicate push(AccessPath ap0, Content f, AccessPath ap) { pop(ap, f, ap0) }
 
-/** A node that should have a `nil` access path. */
+/**
+ * A node that requires an empty access path and should have its tracked type
+ * (re-)computed. This is either a source or a node reached through an
+ * additional step.
+ */
 private class AccessPathNilNode extends Node {
   AccessPathNilNode() { flowCand(this.(AccessPathFrontNilNode), _, _, _) }
 

--- a/cpp/ql/src/semmle/code/cpp/dataflow/internal/DataFlowImpl.qll
+++ b/cpp/ql/src/semmle/code/cpp/dataflow/internal/DataFlowImpl.qll
@@ -683,6 +683,7 @@ private predicate readCand2(Content f, Configuration config) {
   )
 }
 
+pragma[nomagic]
 private predicate storeCand(Content f, Configuration conf) {
   exists(Node n1, Node n2 |
     store(n1, f, n2) and

--- a/cpp/ql/src/semmle/code/cpp/dataflow/internal/DataFlowImpl2.qll
+++ b/cpp/ql/src/semmle/code/cpp/dataflow/internal/DataFlowImpl2.qll
@@ -836,7 +836,11 @@ private predicate flowCandFwd(Node node, boolean fromArg, AccessPathFront apf, C
   if node instanceof CastingNode then compatibleTypes(node.getType(), apf.getType()) else any()
 }
 
-/** A node that should have a `nil` access path front. */
+/**
+ * A node that requires an empty access path and should have its tracked type
+ * (re-)computed. This is either a source or a node reached through an
+ * additional step.
+ */
 private class AccessPathFrontNilNode extends Node {
   AccessPathFrontNilNode() {
     nodeCand(this, _) and
@@ -1101,7 +1105,11 @@ private predicate popWithFront(AccessPath ap0, Content f, AccessPathFront apf, A
 /** Holds if `ap` corresponds to the cons of `f` and `ap0`. */
 private predicate push(AccessPath ap0, Content f, AccessPath ap) { pop(ap, f, ap0) }
 
-/** A node that should have a `nil` access path. */
+/**
+ * A node that requires an empty access path and should have its tracked type
+ * (re-)computed. This is either a source or a node reached through an
+ * additional step.
+ */
 private class AccessPathNilNode extends Node {
   AccessPathNilNode() { flowCand(this.(AccessPathFrontNilNode), _, _, _) }
 

--- a/cpp/ql/src/semmle/code/cpp/dataflow/internal/DataFlowImpl2.qll
+++ b/cpp/ql/src/semmle/code/cpp/dataflow/internal/DataFlowImpl2.qll
@@ -683,6 +683,7 @@ private predicate readCand2(Content f, Configuration config) {
   )
 }
 
+pragma[nomagic]
 private predicate storeCand(Content f, Configuration conf) {
   exists(Node n1, Node n2 |
     store(n1, f, n2) and

--- a/cpp/ql/src/semmle/code/cpp/dataflow/internal/DataFlowImpl3.qll
+++ b/cpp/ql/src/semmle/code/cpp/dataflow/internal/DataFlowImpl3.qll
@@ -836,7 +836,11 @@ private predicate flowCandFwd(Node node, boolean fromArg, AccessPathFront apf, C
   if node instanceof CastingNode then compatibleTypes(node.getType(), apf.getType()) else any()
 }
 
-/** A node that should have a `nil` access path front. */
+/**
+ * A node that requires an empty access path and should have its tracked type
+ * (re-)computed. This is either a source or a node reached through an
+ * additional step.
+ */
 private class AccessPathFrontNilNode extends Node {
   AccessPathFrontNilNode() {
     nodeCand(this, _) and
@@ -1101,7 +1105,11 @@ private predicate popWithFront(AccessPath ap0, Content f, AccessPathFront apf, A
 /** Holds if `ap` corresponds to the cons of `f` and `ap0`. */
 private predicate push(AccessPath ap0, Content f, AccessPath ap) { pop(ap, f, ap0) }
 
-/** A node that should have a `nil` access path. */
+/**
+ * A node that requires an empty access path and should have its tracked type
+ * (re-)computed. This is either a source or a node reached through an
+ * additional step.
+ */
 private class AccessPathNilNode extends Node {
   AccessPathNilNode() { flowCand(this.(AccessPathFrontNilNode), _, _, _) }
 

--- a/cpp/ql/src/semmle/code/cpp/dataflow/internal/DataFlowImpl3.qll
+++ b/cpp/ql/src/semmle/code/cpp/dataflow/internal/DataFlowImpl3.qll
@@ -683,6 +683,7 @@ private predicate readCand2(Content f, Configuration config) {
   )
 }
 
+pragma[nomagic]
 private predicate storeCand(Content f, Configuration conf) {
   exists(Node n1, Node n2 |
     store(n1, f, n2) and

--- a/cpp/ql/src/semmle/code/cpp/dataflow/internal/DataFlowImpl4.qll
+++ b/cpp/ql/src/semmle/code/cpp/dataflow/internal/DataFlowImpl4.qll
@@ -836,7 +836,11 @@ private predicate flowCandFwd(Node node, boolean fromArg, AccessPathFront apf, C
   if node instanceof CastingNode then compatibleTypes(node.getType(), apf.getType()) else any()
 }
 
-/** A node that should have a `nil` access path front. */
+/**
+ * A node that requires an empty access path and should have its tracked type
+ * (re-)computed. This is either a source or a node reached through an
+ * additional step.
+ */
 private class AccessPathFrontNilNode extends Node {
   AccessPathFrontNilNode() {
     nodeCand(this, _) and
@@ -1101,7 +1105,11 @@ private predicate popWithFront(AccessPath ap0, Content f, AccessPathFront apf, A
 /** Holds if `ap` corresponds to the cons of `f` and `ap0`. */
 private predicate push(AccessPath ap0, Content f, AccessPath ap) { pop(ap, f, ap0) }
 
-/** A node that should have a `nil` access path. */
+/**
+ * A node that requires an empty access path and should have its tracked type
+ * (re-)computed. This is either a source or a node reached through an
+ * additional step.
+ */
 private class AccessPathNilNode extends Node {
   AccessPathNilNode() { flowCand(this.(AccessPathFrontNilNode), _, _, _) }
 

--- a/cpp/ql/src/semmle/code/cpp/dataflow/internal/DataFlowImpl4.qll
+++ b/cpp/ql/src/semmle/code/cpp/dataflow/internal/DataFlowImpl4.qll
@@ -683,6 +683,7 @@ private predicate readCand2(Content f, Configuration config) {
   )
 }
 
+pragma[nomagic]
 private predicate storeCand(Content f, Configuration conf) {
   exists(Node n1, Node n2 |
     store(n1, f, n2) and

--- a/cpp/ql/src/semmle/code/cpp/dataflow/internal/DataFlowImplCommon.qll
+++ b/cpp/ql/src/semmle/code/cpp/dataflow/internal/DataFlowImplCommon.qll
@@ -90,11 +90,14 @@ private module ImplCommon {
   }
 
   pragma[noinline]
+  private ParameterNode getAParameter(DataFlowCallable c) { result.getEnclosingCallable() = c }
+
+  pragma[noinline]
   private predicate viableParamArg0(int i, ArgumentNode arg, CallContext outercc, DataFlowCall call) {
     exists(DataFlowCallable c | argumentOf(call, i, arg, c) |
       outercc = TAnyCallContext()
       or
-      exists(ParameterNode p | outercc = TSomeCall(p, _) | c = p.getEnclosingCallable())
+      outercc = TSomeCall(getAParameter(c), _)
       or
       exists(DataFlowCall other | outercc = TSpecificCall(other, _, _) |
         reducedViableImplInCallContext(_, c, other)

--- a/cpp/ql/src/semmle/code/cpp/ir/dataflow/internal/DataFlowImpl.qll
+++ b/cpp/ql/src/semmle/code/cpp/ir/dataflow/internal/DataFlowImpl.qll
@@ -836,7 +836,11 @@ private predicate flowCandFwd(Node node, boolean fromArg, AccessPathFront apf, C
   if node instanceof CastingNode then compatibleTypes(node.getType(), apf.getType()) else any()
 }
 
-/** A node that should have a `nil` access path front. */
+/**
+ * A node that requires an empty access path and should have its tracked type
+ * (re-)computed. This is either a source or a node reached through an
+ * additional step.
+ */
 private class AccessPathFrontNilNode extends Node {
   AccessPathFrontNilNode() {
     nodeCand(this, _) and
@@ -1101,7 +1105,11 @@ private predicate popWithFront(AccessPath ap0, Content f, AccessPathFront apf, A
 /** Holds if `ap` corresponds to the cons of `f` and `ap0`. */
 private predicate push(AccessPath ap0, Content f, AccessPath ap) { pop(ap, f, ap0) }
 
-/** A node that should have a `nil` access path. */
+/**
+ * A node that requires an empty access path and should have its tracked type
+ * (re-)computed. This is either a source or a node reached through an
+ * additional step.
+ */
 private class AccessPathNilNode extends Node {
   AccessPathNilNode() { flowCand(this.(AccessPathFrontNilNode), _, _, _) }
 

--- a/cpp/ql/src/semmle/code/cpp/ir/dataflow/internal/DataFlowImpl.qll
+++ b/cpp/ql/src/semmle/code/cpp/ir/dataflow/internal/DataFlowImpl.qll
@@ -683,6 +683,7 @@ private predicate readCand2(Content f, Configuration config) {
   )
 }
 
+pragma[nomagic]
 private predicate storeCand(Content f, Configuration conf) {
   exists(Node n1, Node n2 |
     store(n1, f, n2) and

--- a/cpp/ql/src/semmle/code/cpp/ir/dataflow/internal/DataFlowImpl2.qll
+++ b/cpp/ql/src/semmle/code/cpp/ir/dataflow/internal/DataFlowImpl2.qll
@@ -836,7 +836,11 @@ private predicate flowCandFwd(Node node, boolean fromArg, AccessPathFront apf, C
   if node instanceof CastingNode then compatibleTypes(node.getType(), apf.getType()) else any()
 }
 
-/** A node that should have a `nil` access path front. */
+/**
+ * A node that requires an empty access path and should have its tracked type
+ * (re-)computed. This is either a source or a node reached through an
+ * additional step.
+ */
 private class AccessPathFrontNilNode extends Node {
   AccessPathFrontNilNode() {
     nodeCand(this, _) and
@@ -1101,7 +1105,11 @@ private predicate popWithFront(AccessPath ap0, Content f, AccessPathFront apf, A
 /** Holds if `ap` corresponds to the cons of `f` and `ap0`. */
 private predicate push(AccessPath ap0, Content f, AccessPath ap) { pop(ap, f, ap0) }
 
-/** A node that should have a `nil` access path. */
+/**
+ * A node that requires an empty access path and should have its tracked type
+ * (re-)computed. This is either a source or a node reached through an
+ * additional step.
+ */
 private class AccessPathNilNode extends Node {
   AccessPathNilNode() { flowCand(this.(AccessPathFrontNilNode), _, _, _) }
 

--- a/cpp/ql/src/semmle/code/cpp/ir/dataflow/internal/DataFlowImpl2.qll
+++ b/cpp/ql/src/semmle/code/cpp/ir/dataflow/internal/DataFlowImpl2.qll
@@ -683,6 +683,7 @@ private predicate readCand2(Content f, Configuration config) {
   )
 }
 
+pragma[nomagic]
 private predicate storeCand(Content f, Configuration conf) {
   exists(Node n1, Node n2 |
     store(n1, f, n2) and

--- a/cpp/ql/src/semmle/code/cpp/ir/dataflow/internal/DataFlowImpl3.qll
+++ b/cpp/ql/src/semmle/code/cpp/ir/dataflow/internal/DataFlowImpl3.qll
@@ -836,7 +836,11 @@ private predicate flowCandFwd(Node node, boolean fromArg, AccessPathFront apf, C
   if node instanceof CastingNode then compatibleTypes(node.getType(), apf.getType()) else any()
 }
 
-/** A node that should have a `nil` access path front. */
+/**
+ * A node that requires an empty access path and should have its tracked type
+ * (re-)computed. This is either a source or a node reached through an
+ * additional step.
+ */
 private class AccessPathFrontNilNode extends Node {
   AccessPathFrontNilNode() {
     nodeCand(this, _) and
@@ -1101,7 +1105,11 @@ private predicate popWithFront(AccessPath ap0, Content f, AccessPathFront apf, A
 /** Holds if `ap` corresponds to the cons of `f` and `ap0`. */
 private predicate push(AccessPath ap0, Content f, AccessPath ap) { pop(ap, f, ap0) }
 
-/** A node that should have a `nil` access path. */
+/**
+ * A node that requires an empty access path and should have its tracked type
+ * (re-)computed. This is either a source or a node reached through an
+ * additional step.
+ */
 private class AccessPathNilNode extends Node {
   AccessPathNilNode() { flowCand(this.(AccessPathFrontNilNode), _, _, _) }
 

--- a/cpp/ql/src/semmle/code/cpp/ir/dataflow/internal/DataFlowImpl3.qll
+++ b/cpp/ql/src/semmle/code/cpp/ir/dataflow/internal/DataFlowImpl3.qll
@@ -683,6 +683,7 @@ private predicate readCand2(Content f, Configuration config) {
   )
 }
 
+pragma[nomagic]
 private predicate storeCand(Content f, Configuration conf) {
   exists(Node n1, Node n2 |
     store(n1, f, n2) and

--- a/cpp/ql/src/semmle/code/cpp/ir/dataflow/internal/DataFlowImpl4.qll
+++ b/cpp/ql/src/semmle/code/cpp/ir/dataflow/internal/DataFlowImpl4.qll
@@ -836,7 +836,11 @@ private predicate flowCandFwd(Node node, boolean fromArg, AccessPathFront apf, C
   if node instanceof CastingNode then compatibleTypes(node.getType(), apf.getType()) else any()
 }
 
-/** A node that should have a `nil` access path front. */
+/**
+ * A node that requires an empty access path and should have its tracked type
+ * (re-)computed. This is either a source or a node reached through an
+ * additional step.
+ */
 private class AccessPathFrontNilNode extends Node {
   AccessPathFrontNilNode() {
     nodeCand(this, _) and
@@ -1101,7 +1105,11 @@ private predicate popWithFront(AccessPath ap0, Content f, AccessPathFront apf, A
 /** Holds if `ap` corresponds to the cons of `f` and `ap0`. */
 private predicate push(AccessPath ap0, Content f, AccessPath ap) { pop(ap, f, ap0) }
 
-/** A node that should have a `nil` access path. */
+/**
+ * A node that requires an empty access path and should have its tracked type
+ * (re-)computed. This is either a source or a node reached through an
+ * additional step.
+ */
 private class AccessPathNilNode extends Node {
   AccessPathNilNode() { flowCand(this.(AccessPathFrontNilNode), _, _, _) }
 

--- a/cpp/ql/src/semmle/code/cpp/ir/dataflow/internal/DataFlowImpl4.qll
+++ b/cpp/ql/src/semmle/code/cpp/ir/dataflow/internal/DataFlowImpl4.qll
@@ -683,6 +683,7 @@ private predicate readCand2(Content f, Configuration config) {
   )
 }
 
+pragma[nomagic]
 private predicate storeCand(Content f, Configuration conf) {
   exists(Node n1, Node n2 |
     store(n1, f, n2) and

--- a/cpp/ql/src/semmle/code/cpp/ir/dataflow/internal/DataFlowImplCommon.qll
+++ b/cpp/ql/src/semmle/code/cpp/ir/dataflow/internal/DataFlowImplCommon.qll
@@ -90,11 +90,14 @@ private module ImplCommon {
   }
 
   pragma[noinline]
+  private ParameterNode getAParameter(DataFlowCallable c) { result.getEnclosingCallable() = c }
+
+  pragma[noinline]
   private predicate viableParamArg0(int i, ArgumentNode arg, CallContext outercc, DataFlowCall call) {
     exists(DataFlowCallable c | argumentOf(call, i, arg, c) |
       outercc = TAnyCallContext()
       or
-      exists(ParameterNode p | outercc = TSomeCall(p, _) | c = p.getEnclosingCallable())
+      outercc = TSomeCall(getAParameter(c), _)
       or
       exists(DataFlowCall other | outercc = TSpecificCall(other, _, _) |
         reducedViableImplInCallContext(_, c, other)

--- a/csharp/ql/src/semmle/code/csharp/dataflow/internal/DataFlowImpl.qll
+++ b/csharp/ql/src/semmle/code/csharp/dataflow/internal/DataFlowImpl.qll
@@ -836,7 +836,11 @@ private predicate flowCandFwd(Node node, boolean fromArg, AccessPathFront apf, C
   if node instanceof CastingNode then compatibleTypes(node.getType(), apf.getType()) else any()
 }
 
-/** A node that should have a `nil` access path front. */
+/**
+ * A node that requires an empty access path and should have its tracked type
+ * (re-)computed. This is either a source or a node reached through an
+ * additional step.
+ */
 private class AccessPathFrontNilNode extends Node {
   AccessPathFrontNilNode() {
     nodeCand(this, _) and
@@ -1101,7 +1105,11 @@ private predicate popWithFront(AccessPath ap0, Content f, AccessPathFront apf, A
 /** Holds if `ap` corresponds to the cons of `f` and `ap0`. */
 private predicate push(AccessPath ap0, Content f, AccessPath ap) { pop(ap, f, ap0) }
 
-/** A node that should have a `nil` access path. */
+/**
+ * A node that requires an empty access path and should have its tracked type
+ * (re-)computed. This is either a source or a node reached through an
+ * additional step.
+ */
 private class AccessPathNilNode extends Node {
   AccessPathNilNode() { flowCand(this.(AccessPathFrontNilNode), _, _, _) }
 

--- a/csharp/ql/src/semmle/code/csharp/dataflow/internal/DataFlowImpl.qll
+++ b/csharp/ql/src/semmle/code/csharp/dataflow/internal/DataFlowImpl.qll
@@ -683,6 +683,7 @@ private predicate readCand2(Content f, Configuration config) {
   )
 }
 
+pragma[nomagic]
 private predicate storeCand(Content f, Configuration conf) {
   exists(Node n1, Node n2 |
     store(n1, f, n2) and

--- a/csharp/ql/src/semmle/code/csharp/dataflow/internal/DataFlowImplCommon.qll
+++ b/csharp/ql/src/semmle/code/csharp/dataflow/internal/DataFlowImplCommon.qll
@@ -90,11 +90,14 @@ private module ImplCommon {
   }
 
   pragma[noinline]
+  private ParameterNode getAParameter(DataFlowCallable c) { result.getEnclosingCallable() = c }
+
+  pragma[noinline]
   private predicate viableParamArg0(int i, ArgumentNode arg, CallContext outercc, DataFlowCall call) {
     exists(DataFlowCallable c | argumentOf(call, i, arg, c) |
       outercc = TAnyCallContext()
       or
-      exists(ParameterNode p | outercc = TSomeCall(p, _) | c = p.getEnclosingCallable())
+      outercc = TSomeCall(getAParameter(c), _)
       or
       exists(DataFlowCall other | outercc = TSpecificCall(other, _, _) |
         reducedViableImplInCallContext(_, c, other)

--- a/java/ql/src/semmle/code/java/dataflow/internal/DataFlowImpl.qll
+++ b/java/ql/src/semmle/code/java/dataflow/internal/DataFlowImpl.qll
@@ -836,7 +836,11 @@ private predicate flowCandFwd(Node node, boolean fromArg, AccessPathFront apf, C
   if node instanceof CastingNode then compatibleTypes(node.getType(), apf.getType()) else any()
 }
 
-/** A node that should have a `nil` access path front. */
+/**
+ * A node that requires an empty access path and should have its tracked type
+ * (re-)computed. This is either a source or a node reached through an
+ * additional step.
+ */
 private class AccessPathFrontNilNode extends Node {
   AccessPathFrontNilNode() {
     nodeCand(this, _) and
@@ -1101,7 +1105,11 @@ private predicate popWithFront(AccessPath ap0, Content f, AccessPathFront apf, A
 /** Holds if `ap` corresponds to the cons of `f` and `ap0`. */
 private predicate push(AccessPath ap0, Content f, AccessPath ap) { pop(ap, f, ap0) }
 
-/** A node that should have a `nil` access path. */
+/**
+ * A node that requires an empty access path and should have its tracked type
+ * (re-)computed. This is either a source or a node reached through an
+ * additional step.
+ */
 private class AccessPathNilNode extends Node {
   AccessPathNilNode() { flowCand(this.(AccessPathFrontNilNode), _, _, _) }
 

--- a/java/ql/src/semmle/code/java/dataflow/internal/DataFlowImpl.qll
+++ b/java/ql/src/semmle/code/java/dataflow/internal/DataFlowImpl.qll
@@ -683,6 +683,7 @@ private predicate readCand2(Content f, Configuration config) {
   )
 }
 
+pragma[nomagic]
 private predicate storeCand(Content f, Configuration conf) {
   exists(Node n1, Node n2 |
     store(n1, f, n2) and

--- a/java/ql/src/semmle/code/java/dataflow/internal/DataFlowImpl2.qll
+++ b/java/ql/src/semmle/code/java/dataflow/internal/DataFlowImpl2.qll
@@ -836,7 +836,11 @@ private predicate flowCandFwd(Node node, boolean fromArg, AccessPathFront apf, C
   if node instanceof CastingNode then compatibleTypes(node.getType(), apf.getType()) else any()
 }
 
-/** A node that should have a `nil` access path front. */
+/**
+ * A node that requires an empty access path and should have its tracked type
+ * (re-)computed. This is either a source or a node reached through an
+ * additional step.
+ */
 private class AccessPathFrontNilNode extends Node {
   AccessPathFrontNilNode() {
     nodeCand(this, _) and
@@ -1101,7 +1105,11 @@ private predicate popWithFront(AccessPath ap0, Content f, AccessPathFront apf, A
 /** Holds if `ap` corresponds to the cons of `f` and `ap0`. */
 private predicate push(AccessPath ap0, Content f, AccessPath ap) { pop(ap, f, ap0) }
 
-/** A node that should have a `nil` access path. */
+/**
+ * A node that requires an empty access path and should have its tracked type
+ * (re-)computed. This is either a source or a node reached through an
+ * additional step.
+ */
 private class AccessPathNilNode extends Node {
   AccessPathNilNode() { flowCand(this.(AccessPathFrontNilNode), _, _, _) }
 

--- a/java/ql/src/semmle/code/java/dataflow/internal/DataFlowImpl2.qll
+++ b/java/ql/src/semmle/code/java/dataflow/internal/DataFlowImpl2.qll
@@ -683,6 +683,7 @@ private predicate readCand2(Content f, Configuration config) {
   )
 }
 
+pragma[nomagic]
 private predicate storeCand(Content f, Configuration conf) {
   exists(Node n1, Node n2 |
     store(n1, f, n2) and

--- a/java/ql/src/semmle/code/java/dataflow/internal/DataFlowImpl3.qll
+++ b/java/ql/src/semmle/code/java/dataflow/internal/DataFlowImpl3.qll
@@ -836,7 +836,11 @@ private predicate flowCandFwd(Node node, boolean fromArg, AccessPathFront apf, C
   if node instanceof CastingNode then compatibleTypes(node.getType(), apf.getType()) else any()
 }
 
-/** A node that should have a `nil` access path front. */
+/**
+ * A node that requires an empty access path and should have its tracked type
+ * (re-)computed. This is either a source or a node reached through an
+ * additional step.
+ */
 private class AccessPathFrontNilNode extends Node {
   AccessPathFrontNilNode() {
     nodeCand(this, _) and
@@ -1101,7 +1105,11 @@ private predicate popWithFront(AccessPath ap0, Content f, AccessPathFront apf, A
 /** Holds if `ap` corresponds to the cons of `f` and `ap0`. */
 private predicate push(AccessPath ap0, Content f, AccessPath ap) { pop(ap, f, ap0) }
 
-/** A node that should have a `nil` access path. */
+/**
+ * A node that requires an empty access path and should have its tracked type
+ * (re-)computed. This is either a source or a node reached through an
+ * additional step.
+ */
 private class AccessPathNilNode extends Node {
   AccessPathNilNode() { flowCand(this.(AccessPathFrontNilNode), _, _, _) }
 

--- a/java/ql/src/semmle/code/java/dataflow/internal/DataFlowImpl3.qll
+++ b/java/ql/src/semmle/code/java/dataflow/internal/DataFlowImpl3.qll
@@ -683,6 +683,7 @@ private predicate readCand2(Content f, Configuration config) {
   )
 }
 
+pragma[nomagic]
 private predicate storeCand(Content f, Configuration conf) {
   exists(Node n1, Node n2 |
     store(n1, f, n2) and

--- a/java/ql/src/semmle/code/java/dataflow/internal/DataFlowImpl4.qll
+++ b/java/ql/src/semmle/code/java/dataflow/internal/DataFlowImpl4.qll
@@ -836,7 +836,11 @@ private predicate flowCandFwd(Node node, boolean fromArg, AccessPathFront apf, C
   if node instanceof CastingNode then compatibleTypes(node.getType(), apf.getType()) else any()
 }
 
-/** A node that should have a `nil` access path front. */
+/**
+ * A node that requires an empty access path and should have its tracked type
+ * (re-)computed. This is either a source or a node reached through an
+ * additional step.
+ */
 private class AccessPathFrontNilNode extends Node {
   AccessPathFrontNilNode() {
     nodeCand(this, _) and
@@ -1101,7 +1105,11 @@ private predicate popWithFront(AccessPath ap0, Content f, AccessPathFront apf, A
 /** Holds if `ap` corresponds to the cons of `f` and `ap0`. */
 private predicate push(AccessPath ap0, Content f, AccessPath ap) { pop(ap, f, ap0) }
 
-/** A node that should have a `nil` access path. */
+/**
+ * A node that requires an empty access path and should have its tracked type
+ * (re-)computed. This is either a source or a node reached through an
+ * additional step.
+ */
 private class AccessPathNilNode extends Node {
   AccessPathNilNode() { flowCand(this.(AccessPathFrontNilNode), _, _, _) }
 

--- a/java/ql/src/semmle/code/java/dataflow/internal/DataFlowImpl4.qll
+++ b/java/ql/src/semmle/code/java/dataflow/internal/DataFlowImpl4.qll
@@ -683,6 +683,7 @@ private predicate readCand2(Content f, Configuration config) {
   )
 }
 
+pragma[nomagic]
 private predicate storeCand(Content f, Configuration conf) {
   exists(Node n1, Node n2 |
     store(n1, f, n2) and

--- a/java/ql/src/semmle/code/java/dataflow/internal/DataFlowImpl5.qll
+++ b/java/ql/src/semmle/code/java/dataflow/internal/DataFlowImpl5.qll
@@ -836,7 +836,11 @@ private predicate flowCandFwd(Node node, boolean fromArg, AccessPathFront apf, C
   if node instanceof CastingNode then compatibleTypes(node.getType(), apf.getType()) else any()
 }
 
-/** A node that should have a `nil` access path front. */
+/**
+ * A node that requires an empty access path and should have its tracked type
+ * (re-)computed. This is either a source or a node reached through an
+ * additional step.
+ */
 private class AccessPathFrontNilNode extends Node {
   AccessPathFrontNilNode() {
     nodeCand(this, _) and
@@ -1101,7 +1105,11 @@ private predicate popWithFront(AccessPath ap0, Content f, AccessPathFront apf, A
 /** Holds if `ap` corresponds to the cons of `f` and `ap0`. */
 private predicate push(AccessPath ap0, Content f, AccessPath ap) { pop(ap, f, ap0) }
 
-/** A node that should have a `nil` access path. */
+/**
+ * A node that requires an empty access path and should have its tracked type
+ * (re-)computed. This is either a source or a node reached through an
+ * additional step.
+ */
 private class AccessPathNilNode extends Node {
   AccessPathNilNode() { flowCand(this.(AccessPathFrontNilNode), _, _, _) }
 

--- a/java/ql/src/semmle/code/java/dataflow/internal/DataFlowImpl5.qll
+++ b/java/ql/src/semmle/code/java/dataflow/internal/DataFlowImpl5.qll
@@ -683,6 +683,7 @@ private predicate readCand2(Content f, Configuration config) {
   )
 }
 
+pragma[nomagic]
 private predicate storeCand(Content f, Configuration conf) {
   exists(Node n1, Node n2 |
     store(n1, f, n2) and

--- a/java/ql/src/semmle/code/java/dataflow/internal/DataFlowImplCommon.qll
+++ b/java/ql/src/semmle/code/java/dataflow/internal/DataFlowImplCommon.qll
@@ -90,11 +90,14 @@ private module ImplCommon {
   }
 
   pragma[noinline]
+  private ParameterNode getAParameter(DataFlowCallable c) { result.getEnclosingCallable() = c }
+
+  pragma[noinline]
   private predicate viableParamArg0(int i, ArgumentNode arg, CallContext outercc, DataFlowCall call) {
     exists(DataFlowCallable c | argumentOf(call, i, arg, c) |
       outercc = TAnyCallContext()
       or
-      exists(ParameterNode p | outercc = TSomeCall(p, _) | c = p.getEnclosingCallable())
+      outercc = TSomeCall(getAParameter(c), _)
       or
       exists(DataFlowCall other | outercc = TSpecificCall(other, _, _) |
         reducedViableImplInCallContext(_, c, other)

--- a/java/ql/src/semmle/code/java/dataflow/internal/DataFlowImplDepr.qll
+++ b/java/ql/src/semmle/code/java/dataflow/internal/DataFlowImplDepr.qll
@@ -836,7 +836,11 @@ private predicate flowCandFwd(Node node, boolean fromArg, AccessPathFront apf, C
   if node instanceof CastingNode then compatibleTypes(node.getType(), apf.getType()) else any()
 }
 
-/** A node that should have a `nil` access path front. */
+/**
+ * A node that requires an empty access path and should have its tracked type
+ * (re-)computed. This is either a source or a node reached through an
+ * additional step.
+ */
 private class AccessPathFrontNilNode extends Node {
   AccessPathFrontNilNode() {
     nodeCand(this, _) and
@@ -1101,7 +1105,11 @@ private predicate popWithFront(AccessPath ap0, Content f, AccessPathFront apf, A
 /** Holds if `ap` corresponds to the cons of `f` and `ap0`. */
 private predicate push(AccessPath ap0, Content f, AccessPath ap) { pop(ap, f, ap0) }
 
-/** A node that should have a `nil` access path. */
+/**
+ * A node that requires an empty access path and should have its tracked type
+ * (re-)computed. This is either a source or a node reached through an
+ * additional step.
+ */
 private class AccessPathNilNode extends Node {
   AccessPathNilNode() { flowCand(this.(AccessPathFrontNilNode), _, _, _) }
 

--- a/java/ql/src/semmle/code/java/dataflow/internal/DataFlowImplDepr.qll
+++ b/java/ql/src/semmle/code/java/dataflow/internal/DataFlowImplDepr.qll
@@ -683,6 +683,7 @@ private predicate readCand2(Content f, Configuration config) {
   )
 }
 
+pragma[nomagic]
 private predicate storeCand(Content f, Configuration conf) {
   exists(Node n1, Node n2 |
     store(n1, f, n2) and


### PR DESCRIPTION
This PR is about restoring performance for C# data flow queries following the adoption of the shared implementation. All changes are in the shared code, so hopefully C++ and Java should also benefit from these changes as well.

Here are the numbers from the PR that [adopted the shared implementation](https://github.com/Semmle/ql/pull/1306), which show a significant slowdown:

```
Project              23faa942ced@639d715d0  23faa942ced@949b3601d
pythonnet            101                    115                    1.13861
OneOf                773                    908                    1.17464
corefx               2195                   2621                   1.19408
nhibernate-core      2841                   3451                   1.21471
roslyn               2653                   3282                   1.23709
monodevelop          3487                   4388                   1.25839
PowerShell           838                    1094                   1.30549
OrchardCore          1000                   1307                   1.307
EntityFrameworkCore  2023                   2745                   1.3569
coreclr              287                    393                    1.36934
ql                   285                    417                    1.46316
runuo                670                    1040                   1.55224
mono                 1893                   3584                   1.89329
```

Here are the numbers for this PR (full report [here](https://git.semmle.com/gist/tom/a5c03c1b2d2d57e6cc103a3cca71dba4), internal link):

```
Project              23faa942ced@949b3601d  23faa942ced@02ca09aa4
mono                 3584                   1957                   0.546038
ql                   417                    305                    0.731415
runuo                1040                   783                    0.752885
monodevelop          4388                   3348                   0.76299
OrchardCore          1307                   1044                   0.798776
coreclr              393                    315                    0.801527
corefx               2621                   2121                   0.809233
roslyn               3282                   2701                   0.822974
EntityFrameworkCore  2745                   2263                   0.824408
nhibernate-core      3451                   2869                   0.831353
PowerShell           1094                   979                    0.894881
pythonnet            115                    109                    0.947826
OneOf                908                    884                    0.973568
```

And combined:

```
Project              23faa942ced@639d715d0  23faa942ced@02ca09aa4
monodevelop          3487                   3348                   0.960138
corefx               2195                   2121                   0.966287
nhibernate-core      2841                   2869                   1.00986
roslyn               2653                   2701                   1.01809
mono                 1893                   1957                   1.03381
OrchardCore          1000                   1044                   1.044
ql                   285                    305                    1.07018
pythonnet            101                    109                    1.07921
coreclr              287                    315                    1.09756
EntityFrameworkCore  2023                   2263                   1.11864
OneOf                773                    884                    1.1436
PowerShell           838                    979                    1.16826
runuo                670                    783                    1.16866
```

I have started a [query changes job](https://jenkins.internal.semmle.com/job/Query-Changes/job/Java-Differences/284/) (internal link) for Java (@aschackmull); @jbj will you help me with performance testing for C++?