### PR TITLE
JS: More improvements to access paths

### DIFF
--- a/javascript/ql/src/semmle/javascript/SSA.qll
+++ b/javascript/ql/src/semmle/javascript/SSA.qll
@@ -521,6 +521,22 @@ class SsaExplicitDefinition extends SsaDefinition, TExplicitDef {
   ) {
     getDef().getLocation().hasLocationInfo(filepath, startline, startcolumn, endline, endcolumn)
   }
+
+  /**
+   * Gets the data flow node representing the incoming value assigned at this definition,
+   * if any.
+   */
+  DataFlow::Node getRhsNode() {
+    exists(VarDef def | def = getDef() |
+      result = def.getSource().flow()
+      or
+      exists(VarRef ref |
+        ref = getSourceVariable().getAReference() and
+        def.getTarget().(BindingPattern).getABindingVarRef() = ref and
+        result = DataFlow::patternPropRead(ref)
+      )
+    )
+  }
 }
 
 /**

--- a/javascript/ql/src/semmle/javascript/dataflow/Configuration.qll
+++ b/javascript/ql/src/semmle/javascript/dataflow/Configuration.qll
@@ -268,9 +268,9 @@ abstract class BarrierGuardNode extends DataFlow::Node {
     or
     // 2) `nd` is an instance of an access path `p`, and dominated by a barrier for `p`
     exists(AccessPath p, BasicBlock bb, ConditionGuardNode cond |
-      nd = DataFlow::valueNode(p.getAnInstanceIn(bb)) and
+      nd = p.getAnInstanceIn(bb) and
       asExpr() = cond.getTest() and
-      blocks(cond.getOutcome(), p.getAnInstance()) and
+      blocks(cond.getOutcome(), p.getAnInstanceExpr()) and
       cond.dominates(bb)
     )
   }

--- a/javascript/ql/src/semmle/javascript/dataflow/DataFlow.qll
+++ b/javascript/ql/src/semmle/javascript/dataflow/DataFlow.qll
@@ -978,6 +978,27 @@ module DataFlow {
   }
 
   /**
+   * INTERNAL. DO NOT USE.
+   *
+   * Gets the `PropRead` node corresponding to the value stored in the given
+   * binding pattern due to destructuring.
+   *
+   * For example, in `let { p: value } = f()`, the `value` pattern maps to a `PropRead`
+   * extracting the `p` property.
+   */
+  DataFlow::PropRead patternPropRead(BindingPattern value) {
+    exists(PropertyPattern prop |
+      value = prop.getValuePattern() and
+      result = TPropNode(prop)
+    )
+    or
+    exists(ArrayPattern array |
+      value = array.getAnElement() and
+      result = TElementPatternNode(array, value)
+    )
+  }
+
+  /**
    * A classification of flows that are not modeled, or only modeled incompletely, by
    * `DataFlowNode`:
    *

--- a/javascript/ql/src/semmle/javascript/dataflow/internal/AccessPaths.qll
+++ b/javascript/ql/src/semmle/javascript/dataflow/internal/AccessPaths.qll
@@ -140,6 +140,8 @@ class AccessPath extends TAccessPath {
   string toString() {
     exists(SsaVariable var | this = MkSsaRoot(var) | result = var.getSourceVariable().getName())
     or
+    exists(Variable var | this = MkCapturedRoot(var) | result = var.getName())
+    or
     this = MkThisRoot(_) and result = "this"
     or
     exists(AccessPath base, PropertyName name, string rest |

--- a/javascript/ql/test/library-tests/AccessPaths/AccessPaths.expected
+++ b/javascript/ql/test/library-tests/AccessPaths/AccessPaths.expected
@@ -1,0 +1,11 @@
+| a | a |
+| b | b |
+| c | c, c |
+| c.z | c.z |
+| this |  |
+| x | x, x, x, x, x |
+| x.y | x.y, x.y, x.y |
+| x.y.z | x.y.z, x.y.z |
+| y | y, y |
+| y.z | y.z |
+| z | z |

--- a/javascript/ql/test/library-tests/AccessPaths/AccessPaths.ql
+++ b/javascript/ql/test/library-tests/AccessPaths/AccessPaths.ql
@@ -1,0 +1,5 @@
+import javascript
+import semmle.javascript.dataflow.internal.AccessPaths
+
+from AccessPath path
+select path, concat(DataFlow::Node node | node = path.getAnInstance() | node.toString(), ", ")

--- a/javascript/ql/test/library-tests/AccessPaths/tst.js
+++ b/javascript/ql/test/library-tests/AccessPaths/tst.js
@@ -1,0 +1,17 @@
+function f(x) {
+  let a = x.y.z;
+  let b = x.y.z;
+  let { y: c } = x;
+  
+  let y = x.y;
+  let z = y.z;
+
+  a;
+  b;
+  c;
+  x;
+  y;
+  z;
+
+  c.z;
+}

--- a/javascript/ql/test/library-tests/SSA/GetRhsNode/GetRhsNode.expected
+++ b/javascript/ql/test/library-tests/SSA/GetRhsNode/GetRhsNode.expected
@@ -1,0 +1,14 @@
+| tst.js:2:7:2:13 | a = g() | a | tst.js:2:11:2:13 | g() |
+| tst.js:4:7:4:24 | { propB: b } = g() | b | tst.js:4:9:4:16 | propB: b |
+| tst.js:6:7:6:34 | { propC ... } = g() | c | tst.js:6:9:6:16 | propC: c |
+| tst.js:6:7:6:34 | { propC ... } = g() | d | tst.js:6:19:6:26 | propD: d |
+| tst.js:8:7:8:41 | { array ... } = g() | elm1 | tst.js:8:22:8:25 | elm1 |
+| tst.js:8:7:8:41 | { array ... } = g() | elm2 | tst.js:8:28:8:31 | elm2 |
+| tst.js:17:3:17:22 | ({ propB: b }) = g() | b | tst.js:17:6:17:13 | propB: b |
+| tst.js:19:3:19:32 | ({ prop ... ) = g() | c | tst.js:19:6:19:13 | propC: c |
+| tst.js:19:3:19:32 | ({ prop ... ) = g() | d | tst.js:19:16:19:23 | propD: d |
+| tst.js:21:3:21:22 | [ elm1, elm2 ] = g() | elm1 | tst.js:21:5:21:8 | elm1 |
+| tst.js:21:3:21:22 | [ elm1, elm2 ] = g() | elm2 | tst.js:21:11:21:14 | elm2 |
+| tst.js:31:12:31:23 | [elm1, elm2] | elm1 | tst.js:31:13:31:16 | elm1 |
+| tst.js:31:12:31:23 | [elm1, elm2] | elm2 | tst.js:31:19:31:22 | elm2 |
+| tst.js:31:26:31:40 | { prop: value } | value | tst.js:31:28:31:38 | prop: value |

--- a/javascript/ql/test/library-tests/SSA/GetRhsNode/GetRhsNode.ql
+++ b/javascript/ql/test/library-tests/SSA/GetRhsNode/GetRhsNode.ql
@@ -1,0 +1,4 @@
+import javascript
+
+from SsaExplicitDefinition def
+select def, def.getSourceVariable(), def.getRhsNode()

--- a/javascript/ql/test/library-tests/SSA/GetRhsNode/tst.js
+++ b/javascript/ql/test/library-tests/SSA/GetRhsNode/tst.js
@@ -1,0 +1,35 @@
+function f() {
+  let a = g();
+  
+  let { propB: b } = g();
+
+  let { propC: c, propD: d } = g();
+  
+  let { arrayProp: [ elm1, elm2 ] } = g();
+  
+  a; // Ensure variables are live.
+  b;
+  c;
+  d;
+  elm1;
+  elm2;
+
+  ({ propB: b }) = g();
+  
+  ({ propC: c, propD: d }) = g();
+  
+  [ elm1, elm2 ] = g();
+  
+  a;
+  b;
+  c;
+  d;
+  elm1;
+  elm2;
+}
+
+function h([elm1, elm2], { prop: value }) {
+  elm1;
+  elm2;
+  value;
+}


### PR DESCRIPTION
Commit-by-commit review encouraged.

Improvements to access paths:
- Rely on data flow nodes instead of expressions
- ~~Handle destructuring assignments, that is, for `let { y } = x`, let `y` be an alias for `x.y` instead of being the root of its own access path.~~
- ~~Handle local aliasing in some cases, that is, for `let y = x.y`, let `y` be an alias for `x.y`.~~

Also adds `SsaExplicitDefinition.getRhsNode()` which is something I've often been missing even if not all definitions have a RHS node. In the future, we could possibly add more cases here, such as for postfix update expressions.

[Evaluation](https://git.semmle.com/asger/dist-compare-reports/tree/domitian.ti.semmle.com_1557973546377) is uneventful but as usual this is a stepping stone towards making access paths usable for call graph construction.