### PR TITLE
Python: Update filter queries to have appropriate kind

### DIFF
--- a/python/ql/src/Filters/NotGenerated.ql
+++ b/python/ql/src/Filters/NotGenerated.ql
@@ -1,7 +1,7 @@
 /**
  * @name Filter: non-generated files
  * @description Only keep results that aren't (or don't appear to be) generated.
- * @kind file-classifier
+ * @kind problem
  * @id py/not-generated-file-filter
  */
 import external.DefectFilter

--- a/python/ql/src/Filters/NotTest.ql
+++ b/python/ql/src/Filters/NotTest.ql
@@ -1,7 +1,7 @@
 /**
  * @name Filter: non-test files
  * @description Only keep results that aren't in tests
- * @kind file-classifier
+ * @kind problem
  * @id py/not-test-file-filter
  */
 import external.DefectFilter


### PR DESCRIPTION
The `Filters` directory contains two different types of query:
 * file classifier queries, used on LGTM to classify files. These should have `@kind file-classifier`
 * filter queries, used by the Semmle command line tools to filter results. These should have `@kind problem`.

The `NotGenerated.ql` and `NotTest.ql` claim to be `file-classifier` queries, but are actually filter queries, as they report `DefectResult`s rather than files. I've therefore update the `@kind` properties to be `problem`.