### PR TITLE
C++: Manual CSE optimisation

### DIFF
--- a/cpp/ql/src/semmle/code/cpp/Preprocessor.qll
+++ b/cpp/ql/src/semmle/code/cpp/Preprocessor.qll
@@ -73,13 +73,24 @@ abstract class PreprocessorBranchDirective extends PreprocessorDirective {
    * `somePreprocessorBranchDirective`.
    */
   PreprocessorBranchDirective getNext() {
-    getIf() = result.getIf() and
-    getLocation().getStartLine() < result.getLocation().getStartLine() and
+    result = getAfter() and
     not exists(PreprocessorBranchDirective other |
-      getIf() = other.getIf() and
-      getLocation().getStartLine() < other.getLocation().getStartLine() and
+      other = getAfter() and
       other.getLocation().getStartLine() < result.getLocation().getStartLine()
     )
+  }
+  
+  /**
+   * Gets all the following `#elif`, `#else` or `#endif` matching this branching
+   * directive.
+   *
+   * For example `somePreprocessorBranchDirective.getIf().getNext().getAfter()`
+   * gets the third, fourth, fifth, etc. directives in the same construct as
+   * `somePreprocessorBranchDirective`.
+   */
+  PreprocessorBranchDirective getAfter() {
+    getIf() = result.getIf() and
+    getLocation().getStartLine() < result.getLocation().getStartLine()
   }
 }
 


### PR DESCRIPTION
This pulls out two identical parts of the `getNext` predicate in `PreprocessorBranchDirective` to their own predicate. Currently, this is done automatically by the CSE pass in the optimiser. However, a potential upcoming change means this may no longer be the case in future. This change ensures there won't be a performance regression when this happens.