### PR TITLE
CPP: Cache Expr.getType().

### DIFF
--- a/cpp/ql/src/semmle/code/cpp/exprs/Expr.qll
+++ b/cpp/ql/src/semmle/code/cpp/exprs/Expr.qll
@@ -57,7 +57,7 @@ class Expr extends StmtParent, @expr {
    * As the type of an expression can sometimes be a TypedefType, calling getUnderlyingType()
    * is often more useful than calling this predicate.
    */
-  pragma[nomagic] Type getType() { expr_types(underlyingElement(this),unresolveElement(result),_) }
+  pragma[nomagic] cached Type getType() { expr_types(underlyingElement(this),unresolveElement(result),_) }
 
   /**
    * Gets the type of this expression after typedefs have been resolved.


### PR DESCRIPTION
@jbj as discussed in the meeting.  I tested this with a series of five queries from a clean cache (`largeparameter.ql`, `castarraypointerarithmetic.ql`, `badlyboundedwrite.ql`, `wrongtypeformatarguments.ql`, `slicing.ql`, all of which are on LGTM), with the first run discarded.
```
Chakracore
base:
	largeparameter.ql 38s
	castarraypointerarithmetic.ql 233s
	badlyboundedwrite.ql 31s
	wrongtypeformatarguments.ql 29s
	slicing.ql 8s
	TOTAL: 339s
with cached `Expr.getType()`:
	largeparameter.ql 35s
	castarraypointerarithmetic.ql 206s
	badlyboundedwrite.ql 13s
	wrongtypeformatarguments.ql 23s
	slicing.ql 3s
	TOTAL: 280s (83%)

Qt
base:
	largeparameter.ql 79s
	castarraypointerarithmetic.ql 470s
	badlyboundedwrite.ql 31s
	wrongtypeformatarguments.ql 59s
	slicing.ql 9s
	TOTAL: 648s
with cached `Expr.getType()`:
	largeparameter.qls 79s
	castarraypointerarithmetic.ql 457s
	badlyboundedwrite.ql 27s
	wrongtypeformatarguments.ql 57s
	slicing.ql 6s
	TOTAL: 626s (97%)
```
Note that there are more queries on LGTM that use this predicate.

The worrying part is that `Expr.getType()` should be rather trivial:
```
pragma[nomagic] Type getType() { expr_types(underlyingElement(this),unresolveElement(result),_) }
```
so it's a bit surprising it showed up so high in our profiling, even being so heavily used.

Other predicates from the spreadsheet that might be in a similar situation to this one: `Element::getLocation`, `Expr::toString`, `Call::getTarget`, `Element::getFile`, `Location::hasLocationInfo`, `Access::getTarget`, `Class::getCanonicalMember`.