### PR TITLE
Java: Check compilation unit of the same element in both disjuncts.

### DIFF
--- a/java/ql/src/semmle/code/java/Annotation.qll
+++ b/java/ql/src/semmle/code/java/Annotation.qll
@@ -27,7 +27,11 @@ class Annotation extends @annotation, Expr {
   Element getAnnotatedElement() {
     exists(Element e | e = this.getParent() |
       if e.(Field).getCompilationUnit().fromSource()
-      then result = e.(Field).getDeclaration().getAField()
+      then
+        exists(FieldDeclaration decl |
+          decl.getField(0) = e and
+          result = decl.getAField()
+        )
       else result = e
     )
   }

--- a/java/ql/src/semmle/code/java/Annotation.qll
+++ b/java/ql/src/semmle/code/java/Annotation.qll
@@ -25,11 +25,11 @@ class Annotation extends @annotation, Expr {
 
   /** Gets the element being annotated. */
   Element getAnnotatedElement() {
-    this.getParent().(Field).getDeclaration().getAField() = result and
-    this.getCompilationUnit().fromSource()
-    or
-    not result.(Field).getCompilationUnit().fromSource() and
-    this.getParent() = result
+    exists(Element e | e = this.getParent() |
+      if e.(Field).getCompilationUnit().fromSource()
+      then result = e.(Field).getDeclaration().getAField()
+      else result = e
+    )
   }
 
   /** Gets the annotation type declaration for this annotation. */


### PR DESCRIPTION
It can happen that an annotation on a field and the field originate from separate compilation units in which case `getAnnotatedElement` could end up missing come cases.