### PR TITLE
JS: Fix performance regression of query.

### DIFF
--- a/javascript/ql/src/semmle/javascript/frameworks/Vue.qll
+++ b/javascript/ql/src/semmle/javascript/frameworks/Vue.qll
@@ -139,7 +139,7 @@ module Vue {
      */
     pragma[noinline]
     private DataFlow::Node getAMethod() {
-      exists(DataFlow::SourceNode methods |
+      exists(DataFlow::ObjectLiteralNode methods |
         methods.flowsTo(getMethods()) and
         result = methods.getAPropertyWrite().getRhs()
       )
@@ -150,13 +150,13 @@ module Vue {
      */
     pragma[noinline]
     private DataFlow::Node getAnAccessor(string kind) {
-      exists(DataFlow::SourceNode computedObj, DataFlow::Node accessorObjOrGetter |
+      exists(DataFlow::ObjectLiteralNode computedObj, DataFlow::Node accessorObjOrGetter |
         computedObj.flowsTo(getComputed()) and
         computedObj.getAPropertyWrite().getRhs() = accessorObjOrGetter
       |
         result = accessorObjOrGetter and kind = "get"
         or
-        exists(DataFlow::SourceNode accessorObj |
+        exists(DataFlow::ObjectLiteralNode accessorObj |
           accessorObj.flowsTo(accessorObjOrGetter) and
           result = accessorObj.getAPropertyWrite(kind).getRhs()
         )
@@ -167,13 +167,13 @@ module Vue {
      * Gets a node for a member `name` of the `computed` option of this instance that matches `kind` ("get" or "set").
      */
     private DataFlow::Node getAccessor(string name, string kind) {
-      exists(DataFlow::SourceNode computedObj, DataFlow::SourceNode accessorObjOrGetter |
+      exists(DataFlow::ObjectLiteralNode computedObj, DataFlow::SourceNode accessorObjOrGetter |
         computedObj.flowsTo(getComputed()) and
         accessorObjOrGetter.flowsTo(computedObj.getAPropertyWrite(name).getRhs())
       |
         result = accessorObjOrGetter and kind = "get"
         or
-        exists(DataFlow::SourceNode accessorObj |
+        exists(DataFlow::ObjectLiteralNode accessorObj |
           accessorObj.flowsTo(accessorObjOrGetter) and
           result = accessorObj.getAPropertyWrite(kind).getRhs()
         )


### PR DESCRIPTION
This fixes a performance regression in the JavaScript library that may be caused by an upcoming optimiser change. In particular, due to a change in how the `getAMethod` predicate is compiled, parts of it that were previously not evaluated on certain databases (due to sentinels) may now be, causing bad performance on these databases. This change mitigates this issue.

@xiemaisi 