### PR TITLE
JS: Refactor LabelledBarrierGuard

### DIFF
--- a/change-notes/1.21/analysis-javascript.md
+++ b/change-notes/1.21/analysis-javascript.md
@@ -48,4 +48,7 @@
 * `RegExpLiteral` is now a `DataFlow::SourceNode`.
 * `JSDocTypeExpr` now has source locations and is a subclass of `Locatable` and `TypeAnnotation`.
 * Various predicates named `getTypeAnnotation()` now return `TypeAnnotation` instead of `TypeExpr`.
-  In rare cases, this may cause compilation errors. Cast the result to `TypeExpr` if this happens.
+  In rare cases, this may cause compilation errors in existing code. Cast the result to `TypeExpr` if this happens.
+* The `getALabel` predicate in `LabeledBarrierGuardNode` and `LabeledSanitizerGuardNode`
+  has been deprecated and overriding it no longer has any effect.
+  Instead use the 3-parameter version of `blocks` or `sanitizes`.

--- a/javascript/ql/src/semmle/javascript/dataflow/Configuration.qll
+++ b/javascript/ql/src/semmle/javascript/dataflow/Configuration.qll
@@ -320,6 +320,13 @@ abstract class BarrierGuardNode extends DataFlow::Node {
  */
 abstract class LabeledBarrierGuardNode extends BarrierGuardNode {
   override predicate blocks(boolean outcome, Expr e) { none() }
+
+  /**
+   * DEPRECATED: Use `blocks(outcome, e, label)` or `sanitizes(outcome, e, label)` instead.
+   *
+   * Overriding this predicate has no effect.
+   */
+  deprecated FlowLabel getALabel() { none() }
 }
 
 /**

--- a/javascript/ql/src/semmle/javascript/dataflow/TaintTracking.qll
+++ b/javascript/ql/src/semmle/javascript/dataflow/TaintTracking.qll
@@ -129,20 +129,35 @@ module TaintTracking {
    * A node that can act as a sanitizer when appearing in a condition.
    */
   abstract class SanitizerGuardNode extends DataFlow::BarrierGuardNode {
-    final override predicate blocks(boolean outcome, Expr e) { sanitizes(outcome, e) }
+    override predicate blocks(boolean outcome, Expr e) { sanitizes(outcome, e) }
 
     /**
      * Holds if this node sanitizes expression `e`, provided it evaluates
      * to `outcome`.
      */
     abstract predicate sanitizes(boolean outcome, Expr e);
+
+    override predicate blocks(boolean outcome, Expr e, DataFlow::FlowLabel label) {
+      sanitizes(outcome, e, label)
+    }
+
+    /**
+     * Holds if this node sanitizes expression `e`, provided it evaluates
+     * to `outcome`.
+     */
+    predicate sanitizes(boolean outcome, Expr e, DataFlow::FlowLabel label) { none() }
   }
 
   /**
    * A sanitizer guard node that only blocks specific flow labels.
    */
-  abstract class LabeledSanitizerGuardNode extends SanitizerGuardNode,
-    DataFlow::LabeledBarrierGuardNode { }
+  abstract class LabeledSanitizerGuardNode extends SanitizerGuardNode, DataFlow::BarrierGuardNode {
+    final override predicate blocks(boolean outcome, Expr e, DataFlow::FlowLabel label) {
+      sanitizes(outcome, e, label)
+    }
+
+    override predicate sanitizes(boolean outcome, Expr e) { none() }
+  }
 
   /**
    * A taint-propagating data flow edge that should be added to all taint tracking

--- a/javascript/ql/src/semmle/javascript/security/TaintedObject.qll
+++ b/javascript/ql/src/semmle/javascript/security/TaintedObject.qll
@@ -84,7 +84,6 @@ module TaintedObject {
    * Sanitizer guard that blocks deep object taint.
    */
   abstract class SanitizerGuard extends TaintTracking::LabeledSanitizerGuardNode {
-    override FlowLabel getALabel() { result = label() }
   }
 
   /**
@@ -110,9 +109,10 @@ module TaintedObject {
       )
     }
 
-    override predicate sanitizes(boolean outcome, Expr e) {
+    override predicate sanitizes(boolean outcome, Expr e, FlowLabel label) {
       polarity = outcome and
-      e = typeof.getOperand()
+      e = typeof.getOperand() and
+      label = label()
     }
   }
 }

--- a/javascript/ql/src/semmle/javascript/security/dataflow/UnvalidatedDynamicMethodCall.qll
+++ b/javascript/ql/src/semmle/javascript/security/dataflow/UnvalidatedDynamicMethodCall.qll
@@ -142,11 +142,10 @@ module UnvalidatedDynamicMethodCall {
       astNode.getAnOperand().getUnderlyingValue() = t
     }
 
-    override predicate sanitizes(boolean outcome, Expr e) {
+    override predicate sanitizes(boolean outcome, Expr e, DataFlow::FlowLabel label) {
       outcome = astNode.getPolarity() and
-      e = t.getOperand().getUnderlyingValue()
+      e = t.getOperand().getUnderlyingValue() and
+      label instanceof MaybeNonFunction
     }
-
-    override DataFlow::FlowLabel getALabel() { result instanceof MaybeNonFunction }
   }
 }

--- a/javascript/ql/test/library-tests/LabelledBarrierGuards/LabelledBarrierGuards.expected
+++ b/javascript/ql/test/library-tests/LabelledBarrierGuards/LabelledBarrierGuards.expected
@@ -1,0 +1,6 @@
+| tst.js:2:11:2:18 | source() | tst.js:8:12:8:12 | x |
+| tst.js:2:11:2:18 | source() | tst.js:12:12:12:12 | x |
+| tst.js:2:11:2:18 | source() | tst.js:14:12:14:12 | x |
+| tst.js:2:11:2:18 | source() | tst.js:18:12:18:12 | x |
+| tst.js:2:11:2:18 | source() | tst.js:20:12:20:12 | x |
+| tst.js:2:11:2:18 | source() | tst.js:26:12:26:12 | x |

--- a/javascript/ql/test/library-tests/LabelledBarrierGuards/LabelledBarrierGuards.ql
+++ b/javascript/ql/test/library-tests/LabelledBarrierGuards/LabelledBarrierGuards.ql
@@ -1,0 +1,68 @@
+import javascript
+
+class CustomFlowLabel extends DataFlow::FlowLabel {
+  CustomFlowLabel() {
+    this = "A" or this = "B"
+  }
+}
+
+class Config extends TaintTracking::Configuration {
+  Config() { this = "Config" }
+
+  override predicate isSource(DataFlow::Node node, DataFlow::FlowLabel lbl) {
+    node.(DataFlow::CallNode).getCalleeName() = "source" and
+    lbl instanceof CustomFlowLabel
+  }
+
+  override predicate isSink(DataFlow::Node node, DataFlow::FlowLabel lbl) {
+    exists(DataFlow::CallNode call |
+      call.getCalleeName() = "sink" and
+      node = call.getAnArgument() and
+      lbl instanceof CustomFlowLabel
+    )
+  }
+
+  override predicate isSanitizerGuard(TaintTracking::SanitizerGuardNode node) {
+    node instanceof IsTypeAGuard or
+    node instanceof IsSanitizedGuard
+  }
+}
+
+/**
+ * A condition that checks what kind of value the input is. Not enough to
+ * sanitize the value, but later sanitizers only need to handle the relevant case.
+ */
+class IsTypeAGuard extends TaintTracking::LabeledSanitizerGuardNode, DataFlow::CallNode {
+  IsTypeAGuard() {
+    getCalleeName() = "isTypeA"
+  }
+
+  override predicate sanitizes(boolean outcome, Expr e, DataFlow::FlowLabel lbl) {
+    e = getArgument(0).asExpr() and
+    (
+      outcome = true and lbl = "B"
+      or
+      outcome = false and lbl = "A"
+    )
+  }
+}
+
+class IsSanitizedGuard extends TaintTracking::LabeledSanitizerGuardNode, DataFlow::CallNode {
+  IsSanitizedGuard() {
+    getCalleeName() = "sanitizeA" or getCalleeName() = "sanitizeB"
+  }
+
+  override predicate sanitizes(boolean outcome, Expr e, DataFlow::FlowLabel lbl) {
+    e = getArgument(0).asExpr() and
+    outcome = true and
+    (
+      getCalleeName() = "sanitizeA" and lbl = "A"
+      or
+      getCalleeName() = "sanitizeB" and lbl = "B"
+    )
+  }
+}
+
+from Config cfg, DataFlow::Node source, DataFlow::Node sink
+where cfg.hasFlow(source, sink)
+select source, sink

--- a/javascript/ql/test/library-tests/LabelledBarrierGuards/tst.js
+++ b/javascript/ql/test/library-tests/LabelledBarrierGuards/tst.js
@@ -1,0 +1,33 @@
+function test() {
+  let x = source();
+
+  if (isTypeA(x)) {
+    if (sanitizeA(x)) {
+      sink(x); // OK
+    } else {
+      sink(x); // NOT OK
+    }
+
+    if (sanitizeB(x)) {
+      sink(x); // NOT OK
+    } else {
+      sink(x); // NOT OK
+    }
+  } else {
+    if (sanitizeA(x)) {
+      sink(x); // NOT OK
+    } else {
+      sink(x); // NOT OK
+    }
+
+    if (sanitizeB(x)) {
+      sink(x); // OK
+    } else {
+      sink(x); // NOT OK
+    }
+  }
+
+  if (sanitizeA(x) && sanitizeB(x)) {
+    sink(x); // OK
+  }
+}


### PR DESCRIPTION
This cherry-picks a small part of https://github.com/Semmle/ql/pull/1180, to fix an issue with labelled barrier guards

Previously we had two separate predicates, `getALabel()` and `blocks(boolean outcome, Expr e)`, so there was no way for the outcome to depend on the label.

This can lead to some surprising gotchas when two guard node classes overlap, and the combination of `getALabel()` from one subclass and `blocks()` from the other subclass ends up blocking flow that neither of guard node was intended to block.

[Smoke test](https://git.semmle.com/asger/dist-compare-reports/tree/balbinus.ti.semmle.com_1558528877152) looks ok and so does a [larger evaluation](https://git.semmle.com/asger/dist-compare-reports/tree/balbinus.ti.semmle.com_1558591777115).