### PR TITLE
JS: Remove jump-to-namespace prefix

### DIFF
--- a/javascript/ql/src/definitions.ql
+++ b/javascript/ql/src/definitions.ql
@@ -123,18 +123,12 @@ predicate propertyLookup(Expr prop, ASTNode write, string kind) {
 }
 
 /**
- * Holds if `ref` is an identifier that refers to a type or namespace declared at `decl`.
+ * Holds if `ref` is an identifier that refers to a type declared at `decl`.
  */
 predicate typeLookup(ASTNode ref, ASTNode decl, string kind) {
   exists(TypeAccess typeAccess |
     ref = typeAccess.getIdentifier() and
     decl = typeAccess.getTypeName().getADefinition() and
-    kind = "T"
-  )
-  or
-  exists(NamespaceAccess namespaceAccess |
-    ref = namespaceAccess.getIdentifier() and
-    decl = namespaceAccess.getNamespace().getADefinition() and
     kind = "T"
   )
 }

--- a/javascript/ql/test/query-tests/definitions/definitions.expected
+++ b/javascript/ql/test/query-tests/definitions/definitions.expected
@@ -5,11 +5,9 @@
 | client.ts:7:19:7:19 | C | tslib.ts:1:8:3:1 | class C {\\n  m() {}\\n} | T |
 | client.ts:8:10:8:10 | C | client.ts:3:1:5:1 | class C {\\n  m() {}\\n} | T |
 | client.ts:9:16:9:16 | C | client.ts:3:1:5:1 | class C {\\n  m() {}\\n} | T |
-| client.ts:10:14:10:14 | N | tslib.ts:5:8:9:1 | namespa ... }\\n  }\\n} | T |
 | client.ts:10:16:10:16 | C | tslib.ts:6:10:8:3 | class C ...  {}\\n  } | T |
 | client.ts:13:25:13:25 | C | client.ts:3:1:5:1 | class C {\\n  m() {}\\n} | T |
 | client.ts:13:35:13:35 | C | tslib.ts:1:8:3:1 | class C {\\n  m() {}\\n} | T |
-| client.ts:13:45:13:45 | N | tslib.ts:5:8:9:1 | namespa ... }\\n  }\\n} | T |
 | client.ts:13:47:13:47 | C | tslib.ts:6:10:8:3 | class C ...  {}\\n  } | T |
 | client.ts:14:3:14:3 | x | client.ts:13:22:13:22 | x | V |
 | client.ts:14:5:14:5 | m | client.ts:4:3:4:8 | m() {} | M |


### PR DESCRIPTION
This removes a performance-problematic feature that I think was of little use in the first place.

It was previously possible to jump from the prefix qualifier in a type access to the definition of the namespace it came from. For example:
```typescript
namespace foo {
  export interface T {}
}
let x: foo.T; // jump from 'foo' here to 'namespace foo' above
```

Namespaces can have multiple definitions though. In a large application where every single file wraps its contents in `namespace foo`, there are many definitions of `foo` and also many references to `foo`. This had N^2 cost in `definitions.ql`.

We could restrict it to only emit single-target definitions, but I'm not sure jumping from a type prefix is all that useful (you're more likely to follow the link from `T` to `interface T`), so I've just removed that feature.

Note that this change does not affect a value-reference to a namespace, such as `var x = foo;`. It's only when it's used as the prefix of a type name.