### PR TITLE
C++: definitions.ql performance tweaks

### DIFF
--- a/cpp/ql/src/definitions.qll
+++ b/cpp/ql/src/definitions.qll
@@ -30,7 +30,7 @@ class Top extends Element {
   predicate hasLocationInfo(string filepath,
                             int startline, int startcolumn,
                             int endline, int endcolumn) {
-    this instanceof Element and
+    interestingElement(this) and
     not this instanceof MacroAccess and
     not this instanceof Include and
     exists(Location l |
@@ -74,6 +74,13 @@ predicate hasLocationInfo_Include(Include i, string path, int sl, int sc, int el
     el = l.getEndLine() and
     ec = l.getEndColumn()
   )
+}
+
+/** Holds if `e` is a source or a target of jump-to-definition. */
+predicate interestingElement(Element e) {
+  exists(definitionOf(e, _))
+  or
+  e = definitionOf(_, _)
 }
 
 /**

--- a/cpp/ql/src/definitions.qll
+++ b/cpp/ql/src/definitions.qll
@@ -25,40 +25,37 @@ class Top extends Element {
    * For more information, see
    * [Locations](https://help.semmle.com/QL/learn-ql/ql/locations.html).
    */
+  pragma[noopt]
+  final
   predicate hasLocationInfo(string filepath,
                             int startline, int startcolumn,
                             int endline, int endcolumn) {
-    exists(Location l | l = this.getLocation()
-                    and filepath    = l.getFile().getAbsolutePath()
-                    and startline   = l.getStartLine()
-                    and startcolumn = l.getStartColumn()
-                    and endline     = l.getEndLine()
-                    and endcolumn   = l.getEndColumn())
-  }
-}
-
-/**
- * A `MacroAccess` with a `hasLocationInfo` predicate.
- *
- * This has a location that covers only the name of the accessed
- * macro, not its arguments (which are included by `MacroAccess`'s
- * `getLocation()`).
- */
-class MacroAccessWithHasLocationInfo extends Top {
-  MacroAccessWithHasLocationInfo() {
-    this instanceof MacroAccess
-  }
-
-  override
-  predicate hasLocationInfo(string path, int sl, int sc, int el, int ec) {
-    exists(MacroAccess ma, Location l |
-           ma = this
-       and l = ma.getLocation()
-       and path = l.getFile().getAbsolutePath()
-       and sl = l.getStartLine()
-       and sc = l.getStartColumn()
-       and el = sl
-       and ec = sc + ma.getMacroName().length() - 1)
+    this instanceof Element and
+    not this instanceof MacroAccess and
+    not this instanceof Include and
+    exists(Location l |
+      l = this.getLocation() and
+      l.hasLocationInfo(filepath, startline, startcolumn, endline, endcolumn)
+    )
+    or
+    // This has a location that covers only the name of the accessed
+    // macro, not its arguments (which are included by `MacroAccess`'s
+    // `getLocation()`).
+    exists(Location l, MacroAccess ma |
+      ma instanceof MacroAccess and
+      ma = this and
+      l = ma.getLocation() and
+      l.hasLocationInfo(filepath, startline, startcolumn, _, _) and
+      endline = startline and
+      exists(string macroName, int nameLength, int nameLengthMinusOne |
+        macroName = ma.getMacroName() and
+        nameLength = macroName.length() and
+        nameLengthMinusOne = nameLength - 1 and
+        endcolumn = startcolumn + nameLengthMinusOne
+      )
+    )
+    or
+    hasLocationInfo_Include(this, filepath, startline, startcolumn, endline, endcolumn)
   }
 }
 
@@ -68,23 +65,15 @@ class MacroAccessWithHasLocationInfo extends Top {
  * This has a location that covers only the name of the included
  * file, not the `#include` text or whitespace before it.
  */
-class IncludeWithHasLocationInfo extends Top {
-  IncludeWithHasLocationInfo() {
-    this instanceof Include
-  }
-
-  override
-  predicate hasLocationInfo(string path, int sl, int sc, int el, int ec) {
-    exists(Include i, Location l |
-      i = this and
-      l = i.getLocation() and
-      path = l.getFile().getAbsolutePath() and
-      sl = l.getEndLine() and
-      sc = l.getEndColumn() + 1 - i.getIncludeText().length() and
-      el = l.getEndLine() and
-      ec = l.getEndColumn()
-    )
-  }
+predicate hasLocationInfo_Include(Include i, string path, int sl, int sc, int el, int ec) {
+  exists(Location l |
+    l = i.getLocation() and
+    path = l.getFile().getAbsolutePath() and
+    sl = l.getEndLine() and
+    sc = l.getEndColumn() + 1 - i.getIncludeText().length() and
+    el = l.getEndLine() and
+    ec = l.getEndColumn()
+  )
 }
 
 /**


### PR DESCRIPTION
@pavgust, apologies for the `pragma[noopt]`. The optimiser was doing a fine job, taking about 2x the time of the hand-optimised version. It's just that in this case it's 2x of a long time.

@geoffw0 for review.