### PR TITLE
JS: Make some DOM concepts customizable

### DIFF
--- a/javascript/ql/src/semmle/javascript/DOM.qll
+++ b/javascript/ql/src/semmle/javascript/DOM.qll
@@ -326,7 +326,15 @@ module DOM {
 
     private class DefaultRange extends Range {
       DefaultRange() {
-        this = domValueRef().getAPropertyRead("location")
+        exists(string propName | this = documentRef().getAPropertyRead(propName) |
+          propName = "documentURI" or
+          propName = "documentURIObject" or
+          propName = "location" or
+          propName = "referrer" or
+          propName = "URL"
+        )
+        or
+        this = DOM::domValueRef().getAPropertyRead("baseUri")
         or
         this = DataFlow::globalVarRef("location")
       }

--- a/javascript/ql/src/semmle/javascript/DOM.qll
+++ b/javascript/ql/src/semmle/javascript/DOM.qll
@@ -284,12 +284,25 @@ module DOM {
     )
   }
 
+  module DomValueSource {
+    /**
+     * A data flow node that should be considered a source of DOM values.
+     */
+    abstract class Range extends DataFlow::Node {}
+
+    private class DefaultRange extends Range {
+      DefaultRange() {
+        this.asExpr().(VarAccess).getVariable() instanceof DOMGlobalVariable or
+        this = domValueRef().getAPropertyRead() or
+        this = domElementCreationOrQuery() or
+        this = domElementCollection()
+      }
+    }
+  }
+
   /** Gets a data flow node that refers directly to a value from the DOM. */
   DataFlow::SourceNode domValueSource() {
-    result.asExpr().(VarAccess).getVariable() instanceof DOMGlobalVariable or
-    result = domValueRef().getAPropertyRead() or
-    result = domElementCreationOrQuery() or
-    result = domElementCollection()
+    result instanceof DomValueSource::Range
   }
 
   /** Gets a data flow node that may refer to a value from the DOM. */
@@ -303,11 +316,26 @@ module DOM {
   /** Gets a data flow node that may refer to a value from the DOM. */
   DataFlow::SourceNode domValueRef() { result = domValueRef(DataFlow::TypeTracker::end()) }
 
+  module LocationSource {
+    /**
+     * A data flow node that should be considered a source of the DOM `location` object.
+     *
+     * Can be subclassed to add additional such nodes.
+     */
+    abstract class Range extends DataFlow::Node {}
+
+    private class DefaultRange extends Range {
+      DefaultRange() {
+        this = domValueRef().getAPropertyRead("location")
+        or
+        this = DataFlow::globalVarRef("location")
+      }
+    }
+  }
+
   /** Gets a data flow node that directly refers to a DOM `location` object. */
   DataFlow::SourceNode locationSource() {
-    result = domValueRef().getAPropertyRead("location")
-    or
-    result = DataFlow::globalVarRef("location")
+    result instanceof LocationSource::Range
   }
 
   /** Gets a reference to a DOM `location` object. */
@@ -321,12 +349,32 @@ module DOM {
   /** Gets a reference to a DOM `location` object. */
   DataFlow::SourceNode locationRef() { result = locationRef(DataFlow::TypeTracker::end()) }
 
+  module DocumentSource {
+    /**
+     * A data flow node that should be considered a source of the `document` object.
+     *
+     * Can be subclassed to add additional such nodes.
+     */
+    abstract class Range extends DataFlow::Node {}
+
+    private class DefaultRange extends Range {
+      DefaultRange() { this = DataFlow::globalVarRef("document") }
+    }
+  }
+
+  /**
+   * Gets a direct reference to the `document` object.
+   */
+  DataFlow::SourceNode documentSource() {
+    result instanceof DocumentSource::Range
+  }
+
   /**
    * Gets a reference to the `document` object.
    */
   private DataFlow::SourceNode documentRef(DataFlow::TypeTracker t) {
     t.start() and
-    result = DataFlow::globalVarRef("document")
+    result instanceof DocumentSource::Range
     or
     exists(DataFlow::TypeTracker t2 | result = documentRef(t2).track(t2, t))
   }

--- a/javascript/ql/src/semmle/javascript/security/dataflow/ClientSideUrlRedirect.qll
+++ b/javascript/ql/src/semmle/javascript/security/dataflow/ClientSideUrlRedirect.qll
@@ -40,7 +40,7 @@ module ClientSideUrlRedirect {
     override predicate isSource(DataFlow::Node source) { source instanceof Source }
 
     override predicate isSource(DataFlow::Node source, DataFlow::FlowLabel lbl) {
-      isDocumentURL(source.asExpr()) and
+      source = DOM::locationSource() and
       lbl instanceof DocumentUrl
     }
 

--- a/javascript/ql/src/semmle/javascript/security/dataflow/CodeInjection.qll
+++ b/javascript/ql/src/semmle/javascript/security/dataflow/CodeInjection.qll
@@ -51,8 +51,8 @@ module CodeInjection {
   /**
    * An access to a property that may hold (parts of) the document URL.
    */
-  class LocationSource extends Source, DataFlow::ValueNode {
-    LocationSource() { isDocumentURL(astNode) }
+  class LocationSource extends Source {
+    LocationSource() { this = DOM::locationSource() }
   }
 
   /**

--- a/javascript/ql/src/semmle/javascript/security/dataflow/DOM.qll
+++ b/javascript/ql/src/semmle/javascript/security/dataflow/DOM.qll
@@ -38,7 +38,7 @@ predicate isDocument(Expr e) { DOM::documentRef().flowsToExpr(e) }
 
 /** Holds if `e` could refer to the document URL. */
 predicate isDocumentURL(Expr e) {
-  DOM::locationRef().flowsToExpr(e)
+  e.flow() = DOM::locationSource()
 }
 
 /**

--- a/javascript/ql/src/semmle/javascript/security/dataflow/DOM.qll
+++ b/javascript/ql/src/semmle/javascript/security/dataflow/DOM.qll
@@ -38,17 +38,7 @@ predicate isDocument(Expr e) { DOM::documentRef().flowsToExpr(e) }
 
 /** Holds if `e` could refer to the document URL. */
 predicate isDocumentURL(Expr e) {
-  exists(string propName | e = DOM::documentRef().getAPropertyRead(propName).asExpr() |
-    propName = "documentURI" or
-    propName = "documentURIObject" or
-    propName = "location" or
-    propName = "referrer" or
-    propName = "URL"
-  )
-  or
-  e = DOM::domValueRef().getAPropertyRead("baseUri").asExpr()
-  or
-  e.accessesGlobal("location")
+  DOM::locationRef().flowsToExpr(e)
 }
 
 /**

--- a/javascript/ql/src/semmle/javascript/security/dataflow/DomBasedXss.qll
+++ b/javascript/ql/src/semmle/javascript/security/dataflow/DomBasedXss.qll
@@ -42,7 +42,7 @@ module DomBasedXss {
   /**
    * An access of the URL of this page, or of the referrer to this page.
    */
-  class LocationSource extends Source, DataFlow::ValueNode {
-    LocationSource() { isDocumentURL(astNode) }
+  class LocationSource extends Source {
+    LocationSource() { this = DOM::locationSource() }
   }
 }

--- a/javascript/ql/src/semmle/javascript/security/dataflow/UnsafeDynamicMethodAccess.qll
+++ b/javascript/ql/src/semmle/javascript/security/dataflow/UnsafeDynamicMethodAccess.qll
@@ -110,7 +110,7 @@ module UnsafeDynamicMethodAccess {
    * The page URL considered as a flow source for unsafe dynamic method access.
    */
   class DocumentUrlAsSource extends Source {
-    DocumentUrlAsSource() { isDocumentURL(asExpr()) }
+    DocumentUrlAsSource() { this = DOM::locationSource() }
   }
 
   /**

--- a/javascript/ql/src/semmle/javascript/security/dataflow/UnvalidatedDynamicMethodCall.qll
+++ b/javascript/ql/src/semmle/javascript/security/dataflow/UnvalidatedDynamicMethodCall.qll
@@ -102,7 +102,7 @@ module UnvalidatedDynamicMethodCall {
    * The page URL considered as a flow source for unvalidated dynamic method calls.
    */
   class DocumentUrlAsSource extends Source {
-    DocumentUrlAsSource() { isDocumentURL(asExpr()) }
+    DocumentUrlAsSource() { this = DOM::locationSource() }
   }
 
   /**

--- a/javascript/ql/src/semmle/javascript/security/dataflow/XpathInjection.qll
+++ b/javascript/ql/src/semmle/javascript/security/dataflow/XpathInjection.qll
@@ -64,8 +64,8 @@ module XpathInjection {
   }
 
   /** A part of the document URL, considered as a flow source for XPath injection. */
-  class DocumentUrlSource extends Source, DataFlow::ValueNode {
-    DocumentUrlSource() { isDocumentURL(astNode) }
+  class DocumentUrlSource extends Source {
+    DocumentUrlSource() { this = DOM::locationSource() }
   }
 
   /**

--- a/javascript/ql/src/semmle/javascript/security/dataflow/Xss.qll
+++ b/javascript/ql/src/semmle/javascript/security/dataflow/Xss.qll
@@ -70,7 +70,7 @@ module DomBasedXss {
           strval = prefix.getStringValue() and
           not strval.regexpMatch("\\s*<.*")
         ) and
-        not isDocumentURL(astNode)
+        not DOM::locationRef().flowsTo(this)
       )
       or
       // call to an Angular method that interprets its argument as HTML

--- a/javascript/ql/test/library-tests/DOM/Customizations.expected
+++ b/javascript/ql/test/library-tests/DOM/Customizations.expected
@@ -1,0 +1,5 @@
+test_documentRef
+| customization.js:2:13:2:31 | customGetDocument() |
+test_locationRef
+test_domValueRef
+| customization.js:4:3:4:28 | doc.get ... 'test') |

--- a/javascript/ql/test/library-tests/DOM/Customizations.expected
+++ b/javascript/ql/test/library-tests/DOM/Customizations.expected
@@ -1,5 +1,6 @@
 test_documentRef
 | customization.js:2:13:2:31 | customGetDocument() |
 test_locationRef
+| customization.js:3:3:3:14 | doc.location |
 test_domValueRef
 | customization.js:4:3:4:28 | doc.get ... 'test') |

--- a/javascript/ql/test/library-tests/DOM/Customizations.ql
+++ b/javascript/ql/test/library-tests/DOM/Customizations.ql
@@ -1,0 +1,19 @@
+import javascript
+
+class CustomDocument extends DOM::DocumentSource::Range, DataFlow::CallNode {
+  CustomDocument() {
+    getCalleeName() = "customGetDocument"
+  }
+}
+
+query DataFlow::Node test_documentRef() {
+  result = DOM::documentRef()
+}
+
+query DataFlow::Node test_locationRef() {
+  result = DOM::locationRef()
+}
+
+query DataFlow::Node test_domValueRef() {
+  result = DOM::domValueRef()
+}

--- a/javascript/ql/test/library-tests/DOM/customization.js
+++ b/javascript/ql/test/library-tests/DOM/customization.js
@@ -1,0 +1,5 @@
+function test() {
+  let doc = customGetDocument();
+  doc.location;
+  doc.getElementById('test');
+}

--- a/javascript/ql/test/query-tests/Security/CWE-079/Xss.expected
+++ b/javascript/ql/test/query-tests/Security/CWE-079/Xss.expected
@@ -165,9 +165,6 @@ nodes
 | tst.js:256:7:256:17 | window.name |
 | tst.js:257:7:257:10 | name |
 | tst.js:261:11:261:21 | window.name |
-| tst.js:272:9:272:32 | loc3 |
-| tst.js:272:16:272:32 | document.location |
-| tst.js:275:7:275:10 | loc3 |
 | tst.js:277:22:277:29 | location |
 | tst.js:282:9:282:29 | tainted |
 | tst.js:282:19:282:29 | window.name |
@@ -318,8 +315,6 @@ edges
 | tst.js:238:23:238:29 | tainted | tst.js:228:32:228:49 | prevProps.tainted4 |
 | tst.js:244:39:244:55 | props.propTainted | tst.js:248:60:248:82 | this.st ... Tainted |
 | tst.js:252:23:252:29 | tainted | tst.js:244:39:244:55 | props.propTainted |
-| tst.js:272:9:272:32 | loc3 | tst.js:275:7:275:10 | loc3 |
-| tst.js:272:16:272:32 | document.location | tst.js:272:9:272:32 | loc3 |
 | tst.js:282:9:282:29 | tainted | tst.js:285:59:285:65 | tainted |
 | tst.js:282:19:282:29 | window.name | tst.js:282:9:282:29 | tainted |
 | v-html.vue:6:42:6:58 | document.location | v-html.vue:2:8:2:23 | v-html=tainted |
@@ -394,7 +389,6 @@ edges
 | tst.js:256:7:256:17 | window.name | tst.js:256:7:256:17 | window.name | tst.js:256:7:256:17 | window.name | Cross-site scripting vulnerability due to $@. | tst.js:256:7:256:17 | window.name | user-provided value |
 | tst.js:257:7:257:10 | name | tst.js:257:7:257:10 | name | tst.js:257:7:257:10 | name | Cross-site scripting vulnerability due to $@. | tst.js:257:7:257:10 | name | user-provided value |
 | tst.js:261:11:261:21 | window.name | tst.js:261:11:261:21 | window.name | tst.js:261:11:261:21 | window.name | Cross-site scripting vulnerability due to $@. | tst.js:261:11:261:21 | window.name | user-provided value |
-| tst.js:275:7:275:10 | loc3 | tst.js:272:16:272:32 | document.location | tst.js:275:7:275:10 | loc3 | Cross-site scripting vulnerability due to $@. | tst.js:272:16:272:32 | document.location | user-provided value |
 | tst.js:277:22:277:29 | location | tst.js:277:22:277:29 | location | tst.js:277:22:277:29 | location | Cross-site scripting vulnerability due to $@. | tst.js:277:22:277:29 | location | user-provided value |
 | tst.js:285:59:285:65 | tainted | tst.js:282:9:282:29 | tainted | tst.js:285:59:285:65 | tainted | Cross-site scripting vulnerability due to $@. | tst.js:282:9:282:29 | tainted | user-provided value |
 | tst.js:285:59:285:65 | tainted | tst.js:282:19:282:29 | window.name | tst.js:285:59:285:65 | tainted | Cross-site scripting vulnerability due to $@. | tst.js:282:19:282:29 | window.name | user-provided value |

--- a/javascript/ql/test/query-tests/Security/CWE-079/tst.js
+++ b/javascript/ql/test/query-tests/Security/CWE-079/tst.js
@@ -272,7 +272,7 @@ function jqueryLocation() {
     var loc3 = document.location;
     $(loc1); // OK
     $(loc2); // OK
-    $(loc3); // OK - but still flagged
+    $(loc3); // OK
 
     $("body").append(location); // NOT OK
 }


### PR DESCRIPTION
Makes `document`, `location` and DOM value sources customizable by extending one of:
- `DOM::DocumentSource::Range`
- `DOM::LocationSource::Range`
- `DOM::DomValueSource::Range`

[Evaluation](https://git.semmle.com/asger/dist-compare-reports/tree/florian.ti.semmle.com_1558610526281) had unexpected results, will need to investigate.