### PR TITLE
C++: Improve Element::toString() performance

### DIFF
--- a/change-notes/1.21/analysis-cpp.md
+++ b/change-notes/1.21/analysis-cpp.md
@@ -40,3 +40,4 @@
     - The taint tracking library adds flow through library functions that are modeled in `semmle.code.cpp.models.interfaces.Taint`. Queries can add subclasses of `TaintFunction` to specify additional flow.
 - There is a new `FoldExpr` class, representing C++17 fold expressions.
 - The member predicates `DeclarationEntry.getUnspecifiedType`, `Expr.getUnspecifiedType`, and `Variable.getUnspecifiedType` have been added. These should be preferred over the existing `getUnderlyingType` predicates.
+- The predicate `TypeMention.toString()` has been simplified to always return the string "`type mention`".  This may improve performance when using `Element.toString()` or its descendants.

--- a/cpp/ql/src/semmle/code/cpp/Type.qll
+++ b/cpp/ql/src/semmle/code/cpp/Type.qll
@@ -1276,7 +1276,7 @@ private predicate suppressUnusedThis(Type t) { any() }
 
 /** A source code location referring to a type */
 class TypeMention extends Locatable, @type_mention {
-  override string toString() {result = "mention of " + getMentionedType()}
+  override string toString() {result = "type mention"}
   
   /**
    * Gets the type being referenced by this type mention.

--- a/cpp/ql/test/library-tests/templates/CPP-204/element.expected
+++ b/cpp/ql/test/library-tests/templates/CPP-204/element.expected
@@ -28,7 +28,7 @@
 | test.cpp:2:12:2:13 | EC |
 | test.cpp:2:12:2:13 | definition of EC |
 | test.cpp:3:5:3:5 | V |
-| test.cpp:6:10:6:11 | mention of EC |
+| test.cpp:6:10:6:11 | type mention |
 | test.cpp:7:8:7:10 | IsX<X> |
 | test.cpp:7:8:7:10 | IsX<X> |
 | test.cpp:7:8:7:10 | definition of IsX<X> |
@@ -36,13 +36,13 @@
 | test.cpp:8:23:8:27 | definition of Value |
 | test.cpp:8:31:8:35 | 0 |
 | test.cpp:8:31:8:35 | initializer for Value |
-| test.cpp:11:10:11:11 | mention of EC |
-| test.cpp:11:25:11:27 | mention of IsX<X> |
+| test.cpp:11:10:11:11 | type mention |
+| test.cpp:11:25:11:27 | type mention |
 | test.cpp:12:8:12:9 | DX<X, B> |
 | test.cpp:12:8:12:9 | definition of DX<X, B> |
 | test.cpp:13:17:13:20 | Type |
 | test.cpp:13:17:13:20 | declaration of Type |
-| test.cpp:16:10:16:11 | mention of EC |
+| test.cpp:16:10:16:11 | type mention |
 | test.cpp:17:8:17:9 | IX<X> |
 | test.cpp:17:8:17:9 | definition of IX<X> |
 | test.cpp:18:21:18:25 | Value |
@@ -50,6 +50,6 @@
 | test.cpp:18:29:18:32 | EC:: |
 | test.cpp:18:29:18:33 | V |
 | test.cpp:18:29:18:33 | initializer for Value |
-| test.cpp:21:10:21:11 | mention of EC |
+| test.cpp:21:10:21:11 | type mention |
 | test.cpp:22:6:22:8 | definition of run |
 | test.cpp:22:6:22:8 | run |

--- a/cpp/ql/test/library-tests/templates/instantiations_functions/elements.expected
+++ b/cpp/ql/test/library-tests/templates/instantiations_functions/elements.expected
@@ -362,15 +362,15 @@
 | test.cpp:34:6:34:11 | define |
 | test.cpp:34:6:34:11 | definition of define |
 | test.cpp:34:15:37:1 | { ... } |
-| test.cpp:35:5:35:10 | mention of action<actor1<composite<int>>> |
+| test.cpp:35:5:35:10 | type mention |
 | test.cpp:35:5:35:37 | declaration |
-| test.cpp:35:12:35:17 | mention of actor1<composite<int>> |
-| test.cpp:35:19:35:27 | mention of composite<int> |
+| test.cpp:35:12:35:17 | type mention |
+| test.cpp:35:19:35:27 | type mention |
 | test.cpp:35:36:35:36 | call to action |
 | test.cpp:35:36:35:36 | definition of z |
 | test.cpp:35:36:35:36 | initializer for z |
 | test.cpp:35:36:35:36 | z |
-| test.cpp:36:5:36:8 | mention of rule |
+| test.cpp:36:5:36:8 | type mention |
 | test.cpp:36:5:36:27 | declaration |
 | test.cpp:36:10:36:22 | definition of pp_expression |
 | test.cpp:36:10:36:22 | pp_expression |

--- a/cpp/ql/test/query-tests/definitions/definitions.expected
+++ b/cpp/ql/test/query-tests/definitions/definitions.expected
@@ -1,4 +1,4 @@
-| access.c:11:3:11:3 | mention of s | access.c:7:3:7:3 | s | T |
+| access.c:11:3:11:3 | type mention | access.c:7:3:7:3 | s | T |
 | access.c:13:3:13:8 | global | access.c:2:5:2:10 | global | V |
 | access.c:15:3:15:6 | my_s | access.c:11:5:11:8 | my_s | V |
 | access.c:15:8:15:8 | x | access.c:6:8:6:8 | x | V |
@@ -7,49 +7,49 @@
 | access.c:17:3:17:8 | call to access | access.c:9:6:9:11 | access | M |
 | access.c:17:10:17:14 | param | access.c:9:17:9:21 | param | V |
 | access.c:26:23:26:35 | more_accesses | access.c:24:6:24:18 | more_accesses | V |
-| access.c:27:3:27:8 | mention of myEnum | access.c:22:3:22:8 | myEnum | T |
+| access.c:27:3:27:8 | type mention | access.c:22:3:22:8 | myEnum | T |
 | access.c:27:15:27:25 | MYENUMCONST | access.c:21:3:21:13 | MYENUMCONST | V |
 | call.c:12:3:12:8 | call to call_f | call.c:4:6:4:11 | call_f | M |
 | call.c:14:3:14:7 | f_ptr | call.c:10:10:10:14 | f_ptr | V |
 | call.c:14:12:14:17 | call_f | call.c:4:6:4:11 | call_f | V |
 | call.c:15:3:15:7 | f_ptr | call.c:10:10:10:14 | f_ptr | V |
 | class.cpp:13:33:13:36 | _val | class.cpp:13:21:13:24 | _val | V |
-| class.cpp:16:16:16:22 | mention of myClass | class.cpp:2:7:2:13 | myClass | T |
+| class.cpp:16:16:16:22 | type mention | class.cpp:2:7:2:13 | myClass | T |
 | class.cpp:26:29:26:32 | _val | class.cpp:26:17:26:20 | _val | V |
-| class.cpp:35:1:35:14 | mention of myIntContainer | class.cpp:9:7:9:20 | myIntContainer | T |
-| class.cpp:36:1:36:12 | mention of myTContainer<char> | class.cpp:23:7:23:18 | myTContainer<char> | T |
-| class.cpp:38:30:38:36 | mention of myClass | class.cpp:2:7:2:13 | myClass | T |
-| class.cpp:45:2:45:8 | mention of myClass | class.cpp:2:7:2:13 | myClass | T |
-| class.cpp:51:2:51:8 | mention of myClass | class.cpp:2:7:2:13 | myClass | T |
-| class.cpp:59:2:59:24 | mention of implicitDestructorClass | class.cpp:48:7:48:29 | implicitDestructorClass | T |
-| class.cpp:66:2:66:8 | mention of myClass | class.cpp:2:7:2:13 | myClass | T |
+| class.cpp:35:1:35:14 | type mention | class.cpp:9:7:9:20 | myIntContainer | T |
+| class.cpp:36:1:36:12 | type mention | class.cpp:23:7:23:18 | myTContainer<char> | T |
+| class.cpp:38:30:38:36 | type mention | class.cpp:2:7:2:13 | myClass | T |
+| class.cpp:45:2:45:8 | type mention | class.cpp:2:7:2:13 | myClass | T |
+| class.cpp:51:2:51:8 | type mention | class.cpp:2:7:2:13 | myClass | T |
+| class.cpp:59:2:59:24 | type mention | class.cpp:48:7:48:29 | implicitDestructorClass | T |
+| class.cpp:66:2:66:8 | type mention | class.cpp:2:7:2:13 | myClass | T |
 | class.cpp:68:2:68:3 | mc | class.cpp:66:11:66:12 | mc | V |
-| class.cpp:68:11:68:17 | mention of myClass | class.cpp:2:7:2:13 | myClass | T |
+| class.cpp:68:11:68:17 | type mention | class.cpp:2:7:2:13 | myClass | T |
 | class.cpp:70:9:70:10 | mc | class.cpp:66:11:66:12 | mc | V |
 | class.cpp:75:26:75:29 | _num | class.cpp:75:14:75:17 | _num | V |
-| class.cpp:77:3:77:8 | mention of Number | class.cpp:73:7:73:12 | Number | T |
-| class.cpp:77:26:77:31 | mention of Number | class.cpp:73:7:73:12 | Number | T |
-| class.cpp:78:5:78:10 | mention of Number | class.cpp:73:7:73:12 | Number | T |
+| class.cpp:77:3:77:8 | type mention | class.cpp:73:7:73:12 | Number | T |
+| class.cpp:77:26:77:31 | type mention | class.cpp:73:7:73:12 | Number | T |
+| class.cpp:78:5:78:10 | type mention | class.cpp:73:7:73:12 | Number | T |
 | class.cpp:78:19:78:21 | num | class.cpp:84:7:84:9 | num | V |
 | class.cpp:78:25:78:29 | other | class.cpp:77:34:77:38 | other | V |
 | class.cpp:78:31:78:33 | num | class.cpp:84:7:84:9 | num | V |
 | class.cpp:80:12:80:17 | result | class.cpp:78:12:78:17 | result | V |
-| class.cpp:87:1:87:6 | mention of Number | class.cpp:73:7:73:12 | Number | T |
-| class.cpp:89:3:89:8 | mention of Number | class.cpp:73:7:73:12 | Number | T |
+| class.cpp:87:1:87:6 | type mention | class.cpp:73:7:73:12 | Number | T |
+| class.cpp:89:3:89:8 | type mention | class.cpp:73:7:73:12 | Number | T |
 | class.cpp:91:10:91:15 | result | class.cpp:89:10:89:15 | result | V |
 | class.cpp:91:17:91:17 | call to operator/ | class.cpp:77:10:77:18 | operator/ | M |
-| class.cpp:91:20:91:25 | mention of Number | class.cpp:73:7:73:12 | Number | T |
+| class.cpp:91:20:91:25 | type mention | class.cpp:73:7:73:12 | Number | T |
 | class.cpp:91:27:91:29 | num | class.cpp:87:17:87:19 | num | V |
-| class.cpp:100:24:100:34 | mention of string_type | class.cpp:94:18:94:28 | string_type | T |
-| class.cpp:105:1:105:15 | mention of StringContainer | class.cpp:97:7:97:21 | StringContainer | T |
-| class.cpp:106:9:106:23 | mention of StringContainer | class.cpp:100:2:100:16 | StringContainer | M |
+| class.cpp:100:24:100:34 | type mention | class.cpp:94:18:94:28 | string_type | T |
+| class.cpp:105:1:105:15 | type mention | class.cpp:97:7:97:21 | StringContainer | T |
+| class.cpp:106:9:106:23 | type mention | class.cpp:100:2:100:16 | StringContainer | M |
 | class.cpp:106:25:106:27 | STR(x) | class.cpp:95:1:95:18 | #define STR(x) L ## x | X |
-| class.cpp:117:2:117:29 | mention of myClassWithConstructorParams | class.cpp:109:7:109:34 | myClassWithConstructorParams | T |
+| class.cpp:117:2:117:29 | type mention | class.cpp:109:7:109:34 | myClassWithConstructorParams | T |
 | class.cpp:117:37:117:37 | a | class.cpp:115:27:115:27 | a | V |
 | class.cpp:117:40:117:40 | b | class.cpp:115:34:115:34 | b | V |
-| class.cpp:118:2:118:29 | mention of myClassWithConstructorParams | class.cpp:109:7:109:34 | myClassWithConstructorParams | T |
+| class.cpp:118:2:118:29 | type mention | class.cpp:109:7:109:34 | myClassWithConstructorParams | T |
 | class.cpp:119:2:119:4 | ptr | class.cpp:118:32:118:34 | ptr | V |
-| class.cpp:119:12:119:39 | mention of myClassWithConstructorParams | class.cpp:109:7:109:34 | myClassWithConstructorParams | T |
+| class.cpp:119:12:119:39 | type mention | class.cpp:109:7:109:34 | myClassWithConstructorParams | T |
 | class.cpp:119:41:119:41 | a | class.cpp:115:27:115:27 | a | V |
 | class.cpp:119:44:119:44 | b | class.cpp:115:34:115:34 | b | V |
 | include.c:2:10:2:20 | #include "include.h" | include.h:0:0:0:0 | include.h | I |
@@ -59,56 +59,56 @@
 | macros.c:11:5:11:11 | fgmacro(x) | macros.c:9:1:9:29 | #define fgmacro(x) f(x); g(x) | X |
 | macros.c:15:1:15:2 | MM(name) | macros.c:14:1:14:38 | #define MM(name) extern int name (int) | X |
 | overload.cpp:5:22:5:23 | _v | overload.cpp:5:14:5:15 | _v | V |
-| overload.cpp:6:16:6:22 | mention of MyValue | overload.cpp:2:7:2:13 | MyValue | T |
+| overload.cpp:6:16:6:22 | type mention | overload.cpp:2:7:2:13 | MyValue | T |
 | overload.cpp:6:36:6:40 | other | overload.cpp:6:25:6:29 | other | V |
 | overload.cpp:6:42:6:42 | v | overload.cpp:22:6:22:6 | v | V |
-| overload.cpp:8:2:8:8 | mention of MyValue | overload.cpp:2:7:2:13 | MyValue | T |
-| overload.cpp:8:27:8:33 | mention of MyValue | overload.cpp:2:7:2:13 | MyValue | T |
+| overload.cpp:8:2:8:8 | type mention | overload.cpp:2:7:2:13 | MyValue | T |
+| overload.cpp:8:27:8:33 | type mention | overload.cpp:2:7:2:13 | MyValue | T |
 | overload.cpp:10:3:10:3 | v | overload.cpp:22:6:22:6 | v | V |
 | overload.cpp:10:7:10:11 | other | overload.cpp:8:36:8:40 | other | V |
 | overload.cpp:10:13:10:13 | v | overload.cpp:22:6:22:6 | v | V |
-| overload.cpp:15:2:15:8 | mention of MyValue | overload.cpp:2:7:2:13 | MyValue | T |
-| overload.cpp:17:3:17:9 | mention of MyValue | overload.cpp:2:7:2:13 | MyValue | T |
+| overload.cpp:15:2:15:8 | type mention | overload.cpp:2:7:2:13 | MyValue | T |
+| overload.cpp:17:3:17:9 | type mention | overload.cpp:2:7:2:13 | MyValue | T |
 | overload.cpp:18:3:18:3 | v | overload.cpp:22:6:22:6 | v | V |
 | overload.cpp:19:10:19:13 | temp | overload.cpp:17:11:17:14 | temp | V |
-| overload.cpp:27:2:27:8 | mention of MyValue | overload.cpp:2:7:2:13 | MyValue | T |
+| overload.cpp:27:2:27:8 | type mention | overload.cpp:2:7:2:13 | MyValue | T |
 | overload.cpp:27:20:27:20 | x | overload.cpp:27:10:27:10 | x | V |
-| overload.cpp:28:2:28:8 | mention of MyValue | overload.cpp:2:7:2:13 | MyValue | T |
-| overload.cpp:28:12:28:18 | mention of MyValue | overload.cpp:2:7:2:13 | MyValue | T |
+| overload.cpp:28:2:28:8 | type mention | overload.cpp:2:7:2:13 | MyValue | T |
+| overload.cpp:28:12:28:18 | type mention | overload.cpp:2:7:2:13 | MyValue | T |
 | overload.cpp:30:2:30:2 | y | overload.cpp:27:16:27:16 | y | V |
 | overload.cpp:30:4:30:4 | call to operator= | overload.cpp:8:11:8:19 | operator= | M |
 | overload.cpp:30:6:30:6 | call to operator* | overload.cpp:15:10:15:18 | operator* | M |
 | overload.cpp:30:7:30:7 | call to operator* | overload.cpp:15:10:15:18 | operator* | M |
 | overload.cpp:30:8:30:8 | call to operator* | overload.cpp:15:10:15:18 | operator* | M |
 | overload.cpp:30:9:30:9 | x | overload.cpp:27:10:27:10 | x | V |
-| type_mentions.cpp:2:9:2:16 | mention of MyClass1 | type_mentions.cpp:1:7:1:14 | MyClass1 | T |
-| type_mentions.cpp:7:2:7:9 | mention of MyClass1 | type_mentions.cpp:1:7:1:14 | MyClass1 | T |
-| type_mentions.cpp:8:2:8:8 | mention of MyType1 | type_mentions.cpp:2:18:2:24 | MyType1 | T |
+| type_mentions.cpp:2:9:2:16 | type mention | type_mentions.cpp:1:7:1:14 | MyClass1 | T |
+| type_mentions.cpp:7:2:7:9 | type mention | type_mentions.cpp:1:7:1:14 | MyClass1 | T |
+| type_mentions.cpp:8:2:8:8 | type mention | type_mentions.cpp:2:18:2:24 | MyType1 | T |
 | type_mentions.cpp:9:2:9:7 | MYTYPE | type_mentions.cpp:3:1:3:22 | #define MYTYPE MyType1 | X |
-| type_mentions.cpp:18:8:18:15 | mention of MyClass2<1> | type_mentions.cpp:14:7:14:14 | MyClass2<1> | T |
-| type_mentions.cpp:18:24:18:31 | mention of MyClass1 | type_mentions.cpp:1:7:1:14 | MyClass1 | T |
-| type_mentions.cpp:27:3:27:11 | mention of MyStruct1 | type_mentions.cpp:21:10:21:18 | MyStruct1 | T |
-| type_mentions.cpp:35:1:35:14 | mention of BinaryTemplate<MyClass1, MyStruct1> | type_mentions.cpp:31:7:31:20 | BinaryTemplate<MyClass1, MyStruct1> | T |
-| type_mentions.cpp:35:16:35:23 | mention of MyClass1 | type_mentions.cpp:1:7:1:14 | MyClass1 | T |
-| type_mentions.cpp:35:40:35:48 | mention of MyStruct1 | type_mentions.cpp:21:10:21:18 | MyStruct1 | T |
-| type_mentions.cpp:39:24:39:32 | mention of MyStruct1 | type_mentions.cpp:21:10:21:18 | MyStruct1 | T |
-| type_mentions.cpp:43:8:43:15 | mention of MyClass3 | type_mentions.cpp:37:7:37:14 | MyClass3 | T |
-| type_mentions.cpp:43:18:43:33 | mention of MyTypedefStruct1 | type_mentions.cpp:39:34:39:49 | MyTypedefStruct1 | T |
-| type_mentions.cpp:45:18:45:25 | mention of MyClass3 | type_mentions.cpp:37:7:37:14 | MyClass3 | T |
-| type_mentions.cpp:52:2:52:9 | mention of MyClass1 | type_mentions.cpp:1:7:1:14 | MyClass1 | T |
-| type_mentions.cpp:53:2:53:9 | mention of MyClass3 | type_mentions.cpp:37:7:37:14 | MyClass3 | T |
-| type_mentions.cpp:57:2:57:8 | mention of MyUnion | type_mentions.cpp:51:7:51:13 | MyUnion | T |
+| type_mentions.cpp:18:8:18:15 | type mention | type_mentions.cpp:14:7:14:14 | MyClass2<1> | T |
+| type_mentions.cpp:18:24:18:31 | type mention | type_mentions.cpp:1:7:1:14 | MyClass1 | T |
+| type_mentions.cpp:27:3:27:11 | type mention | type_mentions.cpp:21:10:21:18 | MyStruct1 | T |
+| type_mentions.cpp:35:1:35:14 | type mention | type_mentions.cpp:31:7:31:20 | BinaryTemplate<MyClass1, MyStruct1> | T |
+| type_mentions.cpp:35:16:35:23 | type mention | type_mentions.cpp:1:7:1:14 | MyClass1 | T |
+| type_mentions.cpp:35:40:35:48 | type mention | type_mentions.cpp:21:10:21:18 | MyStruct1 | T |
+| type_mentions.cpp:39:24:39:32 | type mention | type_mentions.cpp:21:10:21:18 | MyStruct1 | T |
+| type_mentions.cpp:43:8:43:15 | type mention | type_mentions.cpp:37:7:37:14 | MyClass3 | T |
+| type_mentions.cpp:43:18:43:33 | type mention | type_mentions.cpp:39:34:39:49 | MyTypedefStruct1 | T |
+| type_mentions.cpp:45:18:45:25 | type mention | type_mentions.cpp:37:7:37:14 | MyClass3 | T |
+| type_mentions.cpp:52:2:52:9 | type mention | type_mentions.cpp:1:7:1:14 | MyClass1 | T |
+| type_mentions.cpp:53:2:53:9 | type mention | type_mentions.cpp:37:7:37:14 | MyClass3 | T |
+| type_mentions.cpp:57:2:57:8 | type mention | type_mentions.cpp:51:7:51:13 | MyUnion | T |
 | type_mentions.cpp:58:2:58:3 | un | type_mentions.cpp:57:10:57:11 | un | V |
 | type_mentions.cpp:58:5:58:10 | myVal1 | type_mentions.cpp:52:11:52:16 | myVal1 | V |
 | type_mentions.cpp:58:14:58:15 | un | type_mentions.cpp:57:10:57:11 | un | V |
 | type_mentions.cpp:58:17:58:22 | myVal1 | type_mentions.cpp:52:11:52:16 | myVal1 | V |
-| type_mentions.cpp:60:2:60:7 | mention of MyEnum | type_mentions.cpp:47:6:47:11 | MyEnum | T |
+| type_mentions.cpp:60:2:60:7 | type mention | type_mentions.cpp:47:6:47:11 | MyEnum | T |
 | type_mentions.cpp:60:14:60:22 | myEnumVal | type_mentions.cpp:48:2:48:10 | myEnumVal | V |
-| type_mentions.cpp:62:2:62:8 | mention of MyType1 | type_mentions.cpp:2:18:2:24 | MyType1 | T |
-| type_mentions.cpp:62:19:62:25 | mention of MyType1 | type_mentions.cpp:2:18:2:24 | MyType1 | T |
-| type_mentions.cpp:63:2:63:8 | mention of MyType1 | type_mentions.cpp:2:18:2:24 | MyType1 | T |
-| type_mentions.cpp:63:22:63:28 | mention of MyType1 | type_mentions.cpp:2:18:2:24 | MyType1 | T |
+| type_mentions.cpp:62:2:62:8 | type mention | type_mentions.cpp:2:18:2:24 | MyType1 | T |
+| type_mentions.cpp:62:19:62:25 | type mention | type_mentions.cpp:2:18:2:24 | MyType1 | T |
+| type_mentions.cpp:63:2:63:8 | type mention | type_mentions.cpp:2:18:2:24 | MyType1 | T |
+| type_mentions.cpp:63:22:63:28 | type mention | type_mentions.cpp:2:18:2:24 | MyType1 | T |
 | type_mentions.cpp:65:2:65:3 | en | type_mentions.cpp:60:9:60:10 | en | V |
-| type_mentions.cpp:65:8:65:13 | mention of MyEnum | type_mentions.cpp:47:6:47:11 | MyEnum | T |
-| type_mentions.cpp:74:25:74:31 | mention of MyType1 | type_mentions.cpp:2:18:2:24 | MyType1 | T |
-| type_mentions.cpp:78:1:78:7 | mention of MyType1 | type_mentions.cpp:2:18:2:24 | MyType1 | T |
+| type_mentions.cpp:65:8:65:13 | type mention | type_mentions.cpp:47:6:47:11 | MyEnum | T |
+| type_mentions.cpp:74:25:74:31 | type mention | type_mentions.cpp:2:18:2:24 | MyType1 | T |
+| type_mentions.cpp:78:1:78:7 | type mention | type_mentions.cpp:2:18:2:24 | MyType1 | T |


### PR DESCRIPTION
 by removing recursion in TypeMention::toString().