### PR TITLE
JavaScript: Fix an auto-build test.

### DIFF
--- a/javascript/extractor/src/com/semmle/js/extractor/test/AutoBuildTests.java
+++ b/javascript/extractor/src/com/semmle/js/extractor/test/AutoBuildTests.java
@@ -497,6 +497,6 @@ public class AutoBuildTests {
     addFile(true, LGTM_SRC, "tst.yaml");
     addFile(true, LGTM_SRC, "tst.yml");
     addFile(true, LGTM_SRC, "tst.raml");
-    addFile(true, LGTM_SRC, "tst2.YML");
+    runTest();
   }
 }


### PR DESCRIPTION
This fixes what I'll just pretend is a minor glitch in one of the autobuilder tests: it wasn't run.

Invariable, running it revealed that it didn't pass: we treat file extensions case-sensitively, so `.YML` files are not actually extracted. While it might be nice to extract them anyway, this behaviour is not specific to YAML, so for the time being I simply amended the test.