### PR TITLE
JavaScript: Make autobuilder fail if no JS/TS code was seen.

### DIFF
--- a/change-notes/1.21/extractor-javascript.md
+++ b/change-notes/1.21/extractor-javascript.md
@@ -5,5 +5,5 @@
 ## Changes to code extraction
 
 * ECMAScript 2019 support is now enabled by default.
-
+* On LGTM, JavaScript extraction for projects that do not contain any JavaScript or TypeScript code will now fail, even if the project contains other file types (such as HTML or YAML) recognized by the JavaScript extractor.
 * YAML files are now extracted by default on LGTM. You can specify exclusion filters in your `lgtm.yml` file to override this behavior.


### PR DESCRIPTION
In particular, the autobuilder will no longer succeed for projects that contain HTML or YAML files but no JS/TS code. Further down the line, this prevents LGTM.com from classifying such projects as "JavaScript"
projects.

When TRAP caching is turned on, we can't easily tell whether a file contained code or not, so we conservatively assume that it did. This only affects dist-compare (not LGTM), and only to the extent that extraction may trivially succeed.