### PR TITLE
C#: Teach `cs/useless-upcast` about disambiguating constructor calls

### DIFF
--- a/change-notes/1.21/analysis-csharp.md
+++ b/change-notes/1.21/analysis-csharp.md
@@ -6,6 +6,7 @@
 |------------------------------|------------------------|-----------------------------------|
 | Class defines a field that uses an ICryptoTransform class in a way that would be unsafe for concurrent threads (`cs/thread-unsafe-icryptotransform-field-in-class`) | Fewer false positive results | The criteria for a result has changed to include nested properties, nested fields and collections. The format of the alert message has changed to highlight the static field. |
 | Constant condition (`cs/constant-condition`) | Fewer false positive results | Results have been removed where the `null` value is in a conditional expression on the left hand side of a null-coalescing expression. For example, in `(a ? b : null) ?? c`, `null` is not considered to be a constant condition. |
+| Useless upcast (`cs/useless-upcast`) | Fewer false positive results | Results have been removed where the upcast is used to disambiguate the target of a constructor call. |
 
 ## Changes to code extraction
 

--- a/csharp/ql/test/query-tests/Language Abuse/UselessUpcast/UselessUpcast.cs
+++ b/csharp/ql/test/query-tests/Language Abuse/UselessUpcast/UselessUpcast.cs
@@ -132,3 +132,36 @@ static class StaticMethods
    public static void M1(B _) { }
    public static void M2(B _) { }
 }
+
+class Constructors : I2
+{
+    Constructors(I1 i) { }
+    Constructors(I2 i) { }
+    Constructors(Constructors c) : this((I1)c) { } // GOOD
+    Constructors(Sub s) : this((I2)s) { } // GOOD
+
+    void M(Constructors c)
+    {
+        new Constructors((I1)c); // GOOD
+        new Constructors((I2)c); // GOOD
+    }
+
+    public int Foo() => 0;
+
+    float I2.Foo() => 0;
+
+    class Sub : Constructors
+    {
+        public Sub(Sub s) : base((I1)s) { } // GOOD
+    }
+
+    class SubSub : Sub
+    {
+        SubSub(SubSub ss) : base((Sub)ss) { } // BAD
+
+        void M(SubSub ss)
+        {
+            new Sub((Sub)ss); // BAD
+        }
+    }
+}

--- a/csharp/ql/test/query-tests/Language Abuse/UselessUpcast/UselessUpcast.expected
+++ b/csharp/ql/test/query-tests/Language Abuse/UselessUpcast/UselessUpcast.expected
@@ -4,4 +4,8 @@
 | UselessUpcast.cs:85:12:85:15 | (...) ... | There is no need to upcast from $@ to $@ - the conversion can be done implicitly. | UselessUpcast.cs:20:7:20:7 | B | B | UselessUpcast.cs:13:7:13:7 | A | A |
 | UselessUpcast.cs:94:12:94:15 | (...) ... | There is no need to upcast from $@ to $@ - the conversion can be done implicitly. | UselessUpcast.cs:20:7:20:7 | B | B | UselessUpcast.cs:13:7:13:7 | A | A |
 | UselessUpcast.cs:105:16:105:19 | (...) ... | There is no need to upcast from $@ to $@ - the conversion can be done implicitly. | UselessUpcast.cs:27:7:27:7 | C | C | UselessUpcast.cs:20:7:20:7 | B | B |
+| UselessUpcast.cs:141:32:141:36 | (...) ... | There is no need to upcast from $@ to $@ - the conversion can be done implicitly. | UselessUpcast.cs:153:11:153:13 | Sub | Sub | UselessUpcast.cs:9:11:9:12 | I2 | I2 |
+| UselessUpcast.cs:146:26:146:30 | (...) ... | There is no need to upcast from $@ to $@ - the conversion can be done implicitly. | UselessUpcast.cs:136:7:136:18 | Constructors | Constructors | UselessUpcast.cs:9:11:9:12 | I2 | I2 |
+| UselessUpcast.cs:160:34:160:40 | (...) ... | There is no need to upcast from $@ to $@ - the conversion can be done implicitly. | UselessUpcast.cs:158:11:158:16 | SubSub | SubSub | UselessUpcast.cs:153:11:153:13 | Sub | Sub |
+| UselessUpcast.cs:164:21:164:27 | (...) ... | There is no need to upcast from $@ to $@ - the conversion can be done implicitly. | UselessUpcast.cs:158:11:158:16 | SubSub | SubSub | UselessUpcast.cs:153:11:153:13 | Sub | Sub |
 | UselessUpcastBad.cs:9:23:9:32 | (...) ... | There is no need to upcast from $@ to $@ - the conversion can be done implicitly. | UselessUpcastBad.cs:4:11:4:13 | Sub | Sub | UselessUpcastBad.cs:3:11:3:15 | Super | Super |

--- a/csharp/ql/test/query-tests/Language Abuse/UselessUpcast/UselessUpcast.expected
+++ b/csharp/ql/test/query-tests/Language Abuse/UselessUpcast/UselessUpcast.expected
@@ -4,8 +4,6 @@
 | UselessUpcast.cs:85:12:85:15 | (...) ... | There is no need to upcast from $@ to $@ - the conversion can be done implicitly. | UselessUpcast.cs:20:7:20:7 | B | B | UselessUpcast.cs:13:7:13:7 | A | A |
 | UselessUpcast.cs:94:12:94:15 | (...) ... | There is no need to upcast from $@ to $@ - the conversion can be done implicitly. | UselessUpcast.cs:20:7:20:7 | B | B | UselessUpcast.cs:13:7:13:7 | A | A |
 | UselessUpcast.cs:105:16:105:19 | (...) ... | There is no need to upcast from $@ to $@ - the conversion can be done implicitly. | UselessUpcast.cs:27:7:27:7 | C | C | UselessUpcast.cs:20:7:20:7 | B | B |
-| UselessUpcast.cs:141:32:141:36 | (...) ... | There is no need to upcast from $@ to $@ - the conversion can be done implicitly. | UselessUpcast.cs:153:11:153:13 | Sub | Sub | UselessUpcast.cs:9:11:9:12 | I2 | I2 |
-| UselessUpcast.cs:146:26:146:30 | (...) ... | There is no need to upcast from $@ to $@ - the conversion can be done implicitly. | UselessUpcast.cs:136:7:136:18 | Constructors | Constructors | UselessUpcast.cs:9:11:9:12 | I2 | I2 |
 | UselessUpcast.cs:160:34:160:40 | (...) ... | There is no need to upcast from $@ to $@ - the conversion can be done implicitly. | UselessUpcast.cs:158:11:158:16 | SubSub | SubSub | UselessUpcast.cs:153:11:153:13 | Sub | Sub |
 | UselessUpcast.cs:164:21:164:27 | (...) ... | There is no need to upcast from $@ to $@ - the conversion can be done implicitly. | UselessUpcast.cs:158:11:158:16 | SubSub | SubSub | UselessUpcast.cs:153:11:153:13 | Sub | Sub |
 | UselessUpcastBad.cs:9:23:9:32 | (...) ... | There is no need to upcast from $@ to $@ - the conversion can be done implicitly. | UselessUpcastBad.cs:4:11:4:13 | Sub | Sub | UselessUpcastBad.cs:3:11:3:15 | Super | Super |


### PR DESCRIPTION
This PR eliminates false positives similar to ones on our own [Semmle/ql](https://lgtm.com/projects/g/Semmle/ql/snapshot/d3483d37b4b2bc58b5dad7bb32cc65177b2447f7/files/csharp/extractor/Semmle.Extraction.CSharp/Entities/Expressions/Discard.cs?sort=name&dir=ASC&mode=heatmap#x886a98fe18724cc1:1) repo.