### PR TITLE
C++: Make `constructor-used-as-copy-constructor` warning/low

### DIFF
--- a/change-notes/1.21/analysis-cpp.md
+++ b/change-notes/1.21/analysis-cpp.md
@@ -30,6 +30,7 @@
 | Wrong type of arguments to formatting function (`cpp/wrong-type-format-argument`) | Fewer false positive results | Non-standard uses of %L are now understood. |
 | `()`-declared function called with too many arguments (`cpp/futile-params`) | Improved coverage | Query has been generalized to find all cases where the number of arguments exceedes the number of parameters of the function, provided the function is also properly declared/defined elsewhere. |
 | Use of potentially dangerous function (`cpp/potentially-dangerous-function`) | Fewer results | Results relating to the standard library `gets` function have been moved into a new query (`dangerous-function-overflow`). |
+| Constructor with default arguments will be used as a copy constructor (`cpp/constructor-used-as-copy-constructor`) | Lowered severity and precision | The severity and precision of this query have been reduced to "warning" and "low", respectively, due to this coding pattern being used intentionally and safely in a number of real-world projects. |
 
 ## Changes to QL libraries
 - The predicate `Declaration.hasGlobalName` now only holds for declarations that are not nested in a class. For example, it no longer holds for a member function `MyClass::myFunction` or a constructor `MyClass::MyClass`, whereas previously it would classify those two declarations as global names.

--- a/cpp/ql/src/jsf/4.10 Classes/AV Rule 77.1.qhelp
+++ b/cpp/ql/src/jsf/4.10 Classes/AV Rule 77.1.qhelp
@@ -11,8 +11,7 @@ when their default arguments are taken into account. An example would be a const
 of the form <code>X(const X&amp; rhs, int i = 0)</code>. A compiler will use such a constructor as a copy
 constructor in preference to the default member-wise copy constructor that it would otherwise generate.
 Since this is usually not what was intended, constructors of the form often do not provide the right
-semantics for copying objects of the class, making them potentially dangerous. Even when this sort of
-thing has been done intentionally, it is confusing and in bad taste, and should be avoided.
+semantics for copying objects of the class, making them potentially dangerous.
 </p>
 
 </overview>

--- a/cpp/ql/src/jsf/4.10 Classes/AV Rule 77.1.ql
+++ b/cpp/ql/src/jsf/4.10 Classes/AV Rule 77.1.ql
@@ -2,8 +2,8 @@
  * @name Constructor with default arguments will be used as a copy constructor
  * @description Constructors with default arguments should not be signature-compatible with a copy constructor when their default arguments are taken into account.
  * @kind problem
- * @problem.severity error
- * @precision high
+ * @problem.severity warning
+ * @precision low
  * @id cpp/constructor-used-as-copy-constructor
  * @tags reliability
  *       readability


### PR DESCRIPTION
This query is supposed to look for constructors that unintentionally qualify as copy constructors due to default arguments. There are quite a few real-world projects that define such constructors intentionally. I've reduced the severity to "warning" and the precision to "low" due to the high false positive rate.