### PR TITLE
C++: Use GVN in RedundantNullCheckSimple

### DIFF
--- a/cpp/ql/src/semmle/code/cpp/ir/implementation/aliased_ssa/gvn/ValueNumbering.qll
+++ b/cpp/ql/src/semmle/code/cpp/ir/implementation/aliased_ssa/gvn/ValueNumbering.qll
@@ -105,19 +105,10 @@ class ValueNumber extends TValueNumber {
  * definition because it accesses the exact same memory.
  * The use of `p.x` on line 3 is linked to the definition of `p` on line 1 as well, but is not
  * congruent to that definition because `p.x` accesses only a subset of the memory defined by `p`.
- *
- * This concept should probably be exposed in the public IR API.
  */
 private class CongruentCopyInstruction extends CopyInstruction {
   CongruentCopyInstruction() {
-    exists(Instruction def |
-      def = this.getSourceValue() and
-      (
-        def.getResultMemoryAccess() instanceof IndirectMemoryAccess or
-        def.getResultMemoryAccess() instanceof PhiMemoryAccess or
-        not def.hasMemoryResult()
-      )
-    )
+    this.getSourceValueOperand().getDefinitionOverlap() instanceof MustExactlyOverlap
   }
 }
 

--- a/cpp/ql/src/semmle/code/cpp/ir/implementation/raw/gvn/ValueNumbering.qll
+++ b/cpp/ql/src/semmle/code/cpp/ir/implementation/raw/gvn/ValueNumbering.qll
@@ -105,19 +105,10 @@ class ValueNumber extends TValueNumber {
  * definition because it accesses the exact same memory.
  * The use of `p.x` on line 3 is linked to the definition of `p` on line 1 as well, but is not
  * congruent to that definition because `p.x` accesses only a subset of the memory defined by `p`.
- *
- * This concept should probably be exposed in the public IR API.
  */
 private class CongruentCopyInstruction extends CopyInstruction {
   CongruentCopyInstruction() {
-    exists(Instruction def |
-      def = this.getSourceValue() and
-      (
-        def.getResultMemoryAccess() instanceof IndirectMemoryAccess or
-        def.getResultMemoryAccess() instanceof PhiMemoryAccess or
-        not def.hasMemoryResult()
-      )
-    )
+    this.getSourceValueOperand().getDefinitionOverlap() instanceof MustExactlyOverlap
   }
 }
 

--- a/cpp/ql/src/semmle/code/cpp/ir/implementation/unaliased_ssa/gvn/ValueNumbering.qll
+++ b/cpp/ql/src/semmle/code/cpp/ir/implementation/unaliased_ssa/gvn/ValueNumbering.qll
@@ -105,19 +105,10 @@ class ValueNumber extends TValueNumber {
  * definition because it accesses the exact same memory.
  * The use of `p.x` on line 3 is linked to the definition of `p` on line 1 as well, but is not
  * congruent to that definition because `p.x` accesses only a subset of the memory defined by `p`.
- *
- * This concept should probably be exposed in the public IR API.
  */
 private class CongruentCopyInstruction extends CopyInstruction {
   CongruentCopyInstruction() {
-    exists(Instruction def |
-      def = this.getSourceValue() and
-      (
-        def.getResultMemoryAccess() instanceof IndirectMemoryAccess or
-        def.getResultMemoryAccess() instanceof PhiMemoryAccess or
-        not def.hasMemoryResult()
-      )
-    )
+    this.getSourceValueOperand().getDefinitionOverlap() instanceof MustExactlyOverlap
   }
 }
 

--- a/cpp/ql/test/query-tests/Likely Bugs/RedundantNullCheckSimple/RedundantNullCheckSimple.cpp
+++ b/cpp/ql/test/query-tests/Likely Bugs/RedundantNullCheckSimple/RedundantNullCheckSimple.cpp
@@ -105,7 +105,7 @@ struct S {
   long **pplong;
 
   void test_phi() {
-    while (*pplong != nullptr) { // GOOD [FALSE POSITIVE]
+    while (*pplong != nullptr) { // GOOD
       pplong++;
     }
   }

--- a/cpp/ql/test/query-tests/Likely Bugs/RedundantNullCheckSimple/RedundantNullCheckSimple.cpp
+++ b/cpp/ql/test/query-tests/Likely Bugs/RedundantNullCheckSimple/RedundantNullCheckSimple.cpp
@@ -69,3 +69,34 @@ int test_inverted_logic(int *p) {
     return 0;
   }
 }
+
+void test_indirect_local() {
+  int a = 0;
+  int *p = &a;
+  int **pp = &p;
+  int x;
+  x = **pp;
+  if (*pp == nullptr) { // BAD
+    return;
+  }
+}
+
+void test_field_local(bool boolvar) {
+  int a = 0;
+  struct {
+    int *p;
+  } s = { &a };
+  auto sp = &s;
+
+  if (boolvar) {
+    int x = *sp->p;
+    if (sp->p == nullptr) { // BAD
+      return;
+    }
+  } else {
+    int *x = sp->p;
+    if (sp == nullptr) { // BAD [NOT DETECTED]
+      return;
+    }
+  }
+}

--- a/cpp/ql/test/query-tests/Likely Bugs/RedundantNullCheckSimple/RedundantNullCheckSimple.cpp
+++ b/cpp/ql/test/query-tests/Likely Bugs/RedundantNullCheckSimple/RedundantNullCheckSimple.cpp
@@ -100,3 +100,13 @@ void test_field_local(bool boolvar) {
     }
   }
 }
+
+struct S {
+  long **pplong;
+
+  void test_phi() {
+    while (*pplong != nullptr) { // GOOD [FALSE POSITIVE]
+      pplong++;
+    }
+  }
+};

--- a/cpp/ql/test/query-tests/Likely Bugs/RedundantNullCheckSimple/RedundantNullCheckSimple.expected
+++ b/cpp/ql/test/query-tests/Likely Bugs/RedundantNullCheckSimple/RedundantNullCheckSimple.expected
@@ -3,3 +3,4 @@
 | RedundantNullCheckSimple.cpp:48:12:48:12 | Load: p | This null check is redundant because the value is $@ in any case | RedundantNullCheckSimple.cpp:51:10:51:11 | Load: * ... | dereferenced here |
 | RedundantNullCheckSimple.cpp:79:7:79:9 | Load: * ... | This null check is redundant because the value is $@ in any case | RedundantNullCheckSimple.cpp:78:7:78:10 | Load: * ... | dereferenced here |
 | RedundantNullCheckSimple.cpp:93:13:93:13 | Load: p | This null check is redundant because the value is $@ in any case | RedundantNullCheckSimple.cpp:92:13:92:18 | Load: * ... | dereferenced here |
+| RedundantNullCheckSimple.cpp:108:12:108:18 | Load: * ... | This null check is redundant because the value is $@ in any case | RedundantNullCheckSimple.cpp:108:12:108:18 | Load: * ... | dereferenced here |

--- a/cpp/ql/test/query-tests/Likely Bugs/RedundantNullCheckSimple/RedundantNullCheckSimple.expected
+++ b/cpp/ql/test/query-tests/Likely Bugs/RedundantNullCheckSimple/RedundantNullCheckSimple.expected
@@ -1,3 +1,5 @@
 | RedundantNullCheckSimple.cpp:4:7:4:7 | Load: p | This null check is redundant because the value is $@ in any case | RedundantNullCheckSimple.cpp:3:7:3:8 | Load: * ... | dereferenced here |
 | RedundantNullCheckSimple.cpp:13:8:13:8 | Load: p | This null check is redundant because the value is $@ in any case | RedundantNullCheckSimple.cpp:10:11:10:12 | Load: * ... | dereferenced here |
 | RedundantNullCheckSimple.cpp:48:12:48:12 | Load: p | This null check is redundant because the value is $@ in any case | RedundantNullCheckSimple.cpp:51:10:51:11 | Load: * ... | dereferenced here |
+| RedundantNullCheckSimple.cpp:79:7:79:9 | Load: * ... | This null check is redundant because the value is $@ in any case | RedundantNullCheckSimple.cpp:78:7:78:10 | Load: * ... | dereferenced here |
+| RedundantNullCheckSimple.cpp:93:13:93:13 | Load: p | This null check is redundant because the value is $@ in any case | RedundantNullCheckSimple.cpp:92:13:92:18 | Load: * ... | dereferenced here |

--- a/cpp/ql/test/query-tests/Likely Bugs/RedundantNullCheckSimple/RedundantNullCheckSimple.expected
+++ b/cpp/ql/test/query-tests/Likely Bugs/RedundantNullCheckSimple/RedundantNullCheckSimple.expected
@@ -3,4 +3,3 @@
 | RedundantNullCheckSimple.cpp:48:12:48:12 | Load: p | This null check is redundant because the value is $@ in any case | RedundantNullCheckSimple.cpp:51:10:51:11 | Load: * ... | dereferenced here |
 | RedundantNullCheckSimple.cpp:79:7:79:9 | Load: * ... | This null check is redundant because the value is $@ in any case | RedundantNullCheckSimple.cpp:78:7:78:10 | Load: * ... | dereferenced here |
 | RedundantNullCheckSimple.cpp:93:13:93:13 | Load: p | This null check is redundant because the value is $@ in any case | RedundantNullCheckSimple.cpp:92:13:92:18 | Load: * ... | dereferenced here |
-| RedundantNullCheckSimple.cpp:108:12:108:18 | Load: * ... | This null check is redundant because the value is $@ in any case | RedundantNullCheckSimple.cpp:108:12:108:18 | Load: * ... | dereferenced here |


### PR DESCRIPTION
This PR extends `RedundantNullCheckSimple.ql`, our dummy IR query, to use GVN. This uncovered what I think is a bug in the GVN library, where the same value number was seemingly assigned to `e` and `*e`. I've added a test case that shows how this bug affects `RedundantNullCheckSimple.ql` and how it's fixed by making use of the new `Operand.getDefinitionOverlap` predicate.