### PR TITLE
TS: Bump to TypeScript 3.5.1

### DIFF
--- a/change-notes/1.21/analysis-javascript.md
+++ b/change-notes/1.21/analysis-javascript.md
@@ -17,7 +17,7 @@
 
 * The security queries now treat comparisons with symbolic constants as sanitizers, resulting in fewer false positives.
 
-* TypeScript 3.4 features are now supported.
+* TypeScript 3.5 is now supported.
 
 * On LGTM, TypeScript projects now have static type information extracted by default, resulting in more security results.
   Users of the command-line tools must still pass `--typescript-full` to the extractor to enable this.

--- a/change-notes/support/versions-compilers.csv
+++ b/change-notes/support/versions-compilers.csv
@@ -13,4 +13,4 @@ Java,"Java 6 to 11 [2]_.","javac (OpenJDK and Oracle JDK)
 Eclipse compiler for Java (ECJ) batch compiler",``.java``
 JavaScript,ECMAScript 2019 or lower,Not applicable,"``.js``, ``.jsx``, ``.mjs``, ``.es``, ``.es6``, ``.htm``, ``.html``, ``.xhm``, ``.xhtml``, ``.vue``, ``.json``, ``.yaml``, ``.yml``, ``.raml`` [3]_."
 Python,"2.7, 3.5, 3.6, 3.7",Not applicable,``.py``
-TypeScript [4]_.,"2.6-3.4",Standard TypeScript compiler,"``.ts``, ``.tsx``"
+TypeScript [4]_.,"2.6-3.5",Standard TypeScript compiler,"``.ts``, ``.tsx``"

--- a/javascript/extractor/lib/typescript/package.json
+++ b/javascript/extractor/lib/typescript/package.json
@@ -2,7 +2,7 @@
     "name": "typescript-parser-wrapper",
     "private": true,
     "dependencies": {
-        "typescript": "3.4.5"
+        "typescript": "3.5.1"
     },
     "scripts": {
         "build": "tsc --project tsconfig.json && rollup -c",

--- a/javascript/extractor/lib/typescript/yarn.lock
+++ b/javascript/extractor/lib/typescript/yarn.lock
@@ -509,9 +509,9 @@ tsutils@^2.12.1:
   dependencies:
     tslib "^1.8.1"
 
-typescript@3.4.5:
-  version "3.4.5"
-  resolved "typescript-3.4.5.tgz#2d2618d10bb566572b8d7aad5180d84257d70a99"
+typescript@3.5.1:
+  version "3.5.1"
+  resolved "typescript-3.5.1.tgz#ba72a6a600b2158139c5dd8850f700e231464202"
 
 wrappy@1:
   version "1.0.2"


### PR DESCRIPTION
It seems there are no new features we need to support on our end. Running an evaluation just in case.

The release notes mention some perf improvements though I haven't been able to observe any change in extraction time.