### PR TITLE
Java: Add SwitchExpr support in Guards.qll

### DIFF
--- a/java/ql/src/semmle/code/java/Statement.qll
+++ b/java/ql/src/semmle/code/java/Statement.qll
@@ -427,7 +427,7 @@ class SwitchCase extends Stmt, @case {
    * Gets the expression of the surrounding switch that this case is compared
    * against.
    */
-  Expr getTestExpr() {
+  Expr getSelectorExpr() {
     result = this.getSwitch().getExpr() or result = this.getSwitchExpr().getExpr()
   }
 

--- a/java/ql/src/semmle/code/java/Statement.qll
+++ b/java/ql/src/semmle/code/java/Statement.qll
@@ -424,6 +424,14 @@ class SwitchCase extends Stmt, @case {
   SwitchExpr getSwitchExpr() { result.getACase() = this }
 
   /**
+   * Gets the expression of the surrounding switch that this case is compared
+   * against.
+   */
+  Expr getTestExpr() {
+    result = this.getSwitch().getExpr() or result = this.getSwitchExpr().getExpr()
+  }
+
+  /**
    * PREVIEW FEATURE in Java 12. Subject to removal in a future release.
    *
    * Holds if this `case` is a switch labeled rule of the form `... -> ...`.
@@ -625,7 +633,10 @@ class BreakStmt extends Stmt, @breakstmt {
   override string pp() {
     if this.hasLabel()
     then result = "break " + this.getLabel()
-    else if this.hasValue() then result = "break ..." else result = "break"
+    else
+      if this.hasValue()
+      then result = "break ..."
+      else result = "break"
   }
 
   /** This statement's Halstead ID (used to compute Halstead metrics). */

--- a/java/ql/src/semmle/code/java/controlflow/Guards.qll
+++ b/java/ql/src/semmle/code/java/controlflow/Guards.qll
@@ -93,7 +93,8 @@ class Guard extends ExprParent {
   /** Gets the statement containing this guard. */
   Stmt getEnclosingStmt() {
     result = this.(Expr).getEnclosingStmt() or
-    result = this.(SwitchCase).getSwitch()
+    result = this.(SwitchCase).getSwitch() or
+    result = this.(SwitchCase).getSwitchExpr().getEnclosingStmt()
   }
 
   /**
@@ -126,7 +127,7 @@ class Guard extends ExprParent {
       branch = true and
       bb2.getFirstNode() = sc.getControlFlowNode() and
       pred = sc.getControlFlowNode().getAPredecessor() and
-      pred.(Expr).getParent*() = sc.getSwitch().getExpr() and
+      pred.(Expr).getParent*() = sc.getTestExpr() and
       bb1 = pred.getBasicBlock()
     )
     or
@@ -160,12 +161,12 @@ class Guard extends ExprParent {
 }
 
 private predicate switchCaseControls(SwitchCase sc, BasicBlock bb) {
-  exists(BasicBlock caseblock, SwitchStmt ss |
-    ss.getACase() = sc and
+  exists(BasicBlock caseblock, Expr switchTest |
+    switchTest = sc.getTestExpr() and
     caseblock.getFirstNode() = sc.getControlFlowNode() and
     caseblock.bbDominates(bb) and
     forall(ControlFlowNode pred | pred = sc.getControlFlowNode().getAPredecessor() |
-      pred.(Expr).getParent*() = ss.getExpr()
+      pred.(Expr).getParent*() = switchTest
     )
   )
 }
@@ -254,7 +255,8 @@ private predicate equalityGuard(Guard g, Expr e1, Expr e2, boolean polarity) {
   exists(ConstCase cc |
     cc = g and
     polarity = true and
-    cc.getSwitch().getExpr().getProperExpr() = e1 and
-    cc.getValue() = e2
+    cc.getTestExpr().getProperExpr() = e1 and
+    cc.getValue() = e2 and
+    strictcount(cc.getValue(_)) = 1
   )
 }

--- a/java/ql/src/semmle/code/java/controlflow/Guards.qll
+++ b/java/ql/src/semmle/code/java/controlflow/Guards.qll
@@ -127,7 +127,7 @@ class Guard extends ExprParent {
       branch = true and
       bb2.getFirstNode() = sc.getControlFlowNode() and
       pred = sc.getControlFlowNode().getAPredecessor() and
-      pred.(Expr).getParent*() = sc.getTestExpr() and
+      pred.(Expr).getParent*() = sc.getSelectorExpr() and
       bb1 = pred.getBasicBlock()
     )
     or
@@ -161,12 +161,12 @@ class Guard extends ExprParent {
 }
 
 private predicate switchCaseControls(SwitchCase sc, BasicBlock bb) {
-  exists(BasicBlock caseblock, Expr switchTest |
-    switchTest = sc.getTestExpr() and
+  exists(BasicBlock caseblock, Expr selector |
+    selector = sc.getSelectorExpr() and
     caseblock.getFirstNode() = sc.getControlFlowNode() and
     caseblock.bbDominates(bb) and
     forall(ControlFlowNode pred | pred = sc.getControlFlowNode().getAPredecessor() |
-      pred.(Expr).getParent*() = switchTest
+      pred.(Expr).getParent*() = selector
     )
   )
 }
@@ -255,7 +255,7 @@ private predicate equalityGuard(Guard g, Expr e1, Expr e2, boolean polarity) {
   exists(ConstCase cc |
     cc = g and
     polarity = true and
-    cc.getTestExpr().getProperExpr() = e1 and
+    cc.getSelectorExpr().getProperExpr() = e1 and
     cc.getValue() = e2 and
     strictcount(cc.getValue(_)) = 1
   )

--- a/java/ql/test/library-tests/guards12/Test.java
+++ b/java/ql/test/library-tests/guards12/Test.java
@@ -1,0 +1,9 @@
+class Test {
+  void foo(String s) {
+    int x = switch(s) {
+      case "a", "b" -> 1;
+      case "c" -> 2;
+      default -> 3;
+    };
+  }
+}

--- a/java/ql/test/library-tests/guards12/guard.expected
+++ b/java/ql/test/library-tests/guards12/guard.expected
@@ -1,0 +1,1 @@
+| Test.java:5:7:5:17 | stmt | Test.java:3:20:3:20 | s | Test.java:5:12:5:14 | "c" | true | true | Test.java:5:7:5:17 | stmt |

--- a/java/ql/test/library-tests/guards12/guard.ql
+++ b/java/ql/test/library-tests/guards12/guard.ql
@@ -1,0 +1,8 @@
+import java
+import semmle.code.java.controlflow.Guards
+
+from Guard g, BasicBlock bb, boolean branch, VarAccess e1, Expr e2, boolean pol
+where
+  g.controls(bb, branch) and
+  g.isEquality(e1, e2, pol)
+select g, e1, e2, pol, branch, bb

--- a/java/ql/test/library-tests/guards12/options
+++ b/java/ql/test/library-tests/guards12/options
@@ -1,0 +1,1 @@
+//semmle-extractor-options: --javac-args --enable-preview -source 12 -target 12


### PR DESCRIPTION
Adds support for java 12 switch expressions in Guards.qll.