### PR TITLE
C++: Suspicious pointer scaling: @precision medium

### DIFF
--- a/change-notes/1.22/analysis-cpp.md
+++ b/change-notes/1.22/analysis-cpp.md
@@ -11,6 +11,7 @@
 
 | **Query**                  | **Expected impact**    | **Change**                                                       |
 |----------------------------|------------------------|------------------------------------------------------------------|
+| Suspicious pointer scaling (`cpp/suspicious-pointer-scaling`) | Lower precision | The precision of this query has been reduced to "medium". This coding pattern is used intentionally and safely in a number of real-world projects. Results are no longer displayed on LGTM unless you choose to display them. |
 
 ## Changes to QL libraries
 

--- a/cpp/ql/src/Security/CWE/CWE-468/IncorrectPointerScaling.ql
+++ b/cpp/ql/src/Security/CWE/CWE-468/IncorrectPointerScaling.ql
@@ -4,7 +4,7 @@
  *              can cause buffer overflow conditions.
  * @kind problem
  * @problem.severity warning
- * @precision high
+ * @precision medium
  * @id cpp/suspicious-pointer-scaling
  * @tags security
  *       external/cwe/cwe-468


### PR DESCRIPTION
This query is not producing good enough results to justify `@precision high`. It fundamentally looks for a pattern that should correlate with memory management errors, but it doesn't look for the errors themselves.

I've wanted to take this query off LGTM for a long time. [This forum post](https://discuss.lgtm.com/t/this-pointer-might-have-type-unsigned-long-size-8-but-the-pointer-arithmetic-here-is-done-with-type-const-m128i-size-16/2123) and [the following Slack discussion](https://semmle.slack.com/archives/C7NS4H8HY/p1559628168009800) is the occasion for doing it now.