### PR TITLE
JavaScript: `PasswordInConfigurationFile` tweaks

### DIFF
--- a/change-notes/1.21/analysis-javascript.md
+++ b/change-notes/1.21/analysis-javascript.md
@@ -40,7 +40,7 @@
 | Expression has no effect       | Fewer false-positive results | This rule now treats uses of `Object.defineProperty` more conservatively. |
 | Incomplete regular expression for hostnames | More results | This rule now tracks regular expressions for host names further. |
 | Incomplete string escaping or encoding | More results | This rule now considers the flow of regular expressions literals, and it no longer flags the removal of trailing newlines. |
-| Password in configuration file | Fewer false positive results | This query now excludes passwords that are inserted into the configuration file using a templating mechanism or read from environment variables. |
+| Password in configuration file | Fewer false positive results | This query now excludes passwords that are inserted into the configuration file using a templating mechanism or read from environment variables. Results are no longer shown on LGTM by default. |
 | Replacement of a substring with itself | More results | This rule now considers the flow of regular expressions literals. |
 | Server-side URL redirect       | Fewer false-positive results | This rule now treats URLs as safe in more cases where the hostname cannot be tampered with. |
 | Type confusion through parameter tampering | Fewer false-positive results | This rule now recognizes additional emptiness checks. |

--- a/javascript/ql/src/Security/CWE-313/PasswordInConfigurationFile.ql
+++ b/javascript/ql/src/Security/CWE-313/PasswordInConfigurationFile.ql
@@ -3,7 +3,7 @@
  * @description Storing unencrypted passwords in configuration files is unsafe.
  * @kind problem
  * @problem.severity warning
- * @precision high
+ * @precision medium
  * @id js/password-in-configuration-file
  * @tags security
  *       external/cwe/cwe-256

--- a/javascript/ql/src/semmle/javascript/frameworks/Templating.qll
+++ b/javascript/ql/src/semmle/javascript/frameworks/Templating.qll
@@ -37,6 +37,6 @@ module Templating {
    * storing it in its first (and only) capture group.
    */
   string getDelimiterMatchingRegexp() {
-    result = ".*(" + concat("\\Q" + getADelimiter() + "\\E", "|") + ").*"
+    result = "(?s).*(" + concat("\\Q" + getADelimiter() + "\\E", "|") + ").*"
   }
 }

--- a/javascript/ql/test/query-tests/Security/CWE-313/PasswordInConfigurationFile.expected
+++ b/javascript/ql/test/query-tests/Security/CWE-313/PasswordInConfigurationFile.expected
@@ -1,2 +1,3 @@
-| mysql-config.json:4:16:4:23 | "secret" | Avoid plaintext passwords in configuration files. |
-| tst4.json:2:10:2:38 | "script ... ecret'" | Avoid plaintext passwords in configuration files. |
+| mysql-config.json:4:16:4:23 | "secret" | Hard-coded password 'secret' in configuration file. |
+| tst4.json:2:10:2:38 | "script ... ecret'" | Hard-coded password ''secret'' in configuration file. |
+| tst7.yml:2:9:2:6 | \| | Hard-coded password 'abc' in configuration file. |

--- a/javascript/ql/test/query-tests/Security/CWE-313/tst7.yml
+++ b/javascript/ql/test/query-tests/Security/CWE-313/tst7.yml
@@ -1,1 +1,7 @@
 password: $$SOME_VAR
+config: |
+    [mail]
+    host = smtp.mydomain.com
+    port = 25
+    username = sample_admin@mydomain.com
+    password = abc

--- a/javascript/ql/test/query-tests/Security/CWE-313/tst8.yml
+++ b/javascript/ql/test/query-tests/Security/CWE-313/tst8.yml
@@ -1,0 +1,6 @@
+config: |
+    [mail]
+    host = smtp.mydomain.com
+    port = 25
+    username = {{username}}
+    password = {{pwd}}


### PR DESCRIPTION
See individual commits for details; I think this qualifies as a hotfix, since YAML wasn't previously extracted by default, so the query had almost no results on LGTM.

No result changes on our default benchmarks.