### PR TITLE
Python points-to: Make sure that builtin-classes inherit attributes.

### DIFF
--- a/python/ql/src/analysis/Sanity.ql
+++ b/python/ql/src/analysis/Sanity.ql
@@ -212,6 +212,15 @@ predicate file_sanity(string clsname, string problem, string what) {
     )
 }
 
+predicate class_value_sanity(string clsname, string problem, string what) {
+    exists(ClassValue value |
+        exists(value.getASuperType().lookup(what)) and
+        not exists(value.lookup(what)) and
+        clsname = value.getAQlClass() and
+        problem = "is missing attribute that superclass has"
+    )
+}
+
 from string clsname, string problem, string what
 where 
 ast_sanity(clsname, problem, what) or
@@ -224,5 +233,6 @@ source_object_sanity(clsname, problem, what) or
 function_object_sanity(clsname, problem, what) or
 points_to_sanity(clsname, problem, what) or
 jump_to_definition_sanity(clsname, problem, what) or
-file_sanity(clsname, problem, what)
+file_sanity(clsname, problem, what) or
+class_value_sanity(clsname, problem, what)
 select clsname + " " + what + " has " + problem

--- a/python/ql/src/semmle/python/objects/Classes.qll
+++ b/python/ql/src/semmle/python/objects/Classes.qll
@@ -191,8 +191,7 @@ class BuiltinClassObjectInternal extends ClassObjectInternal, TBuiltinClassObjec
     }
 
     override predicate lookup(string name, ObjectInternal value, CfgOrigin origin) {
-        value = ObjectInternal::fromBuiltin(this.getBuiltin().getMember(name)) and
-        origin = CfgOrigin::unknown()
+        Types::getMro(this).lookup(name, value, origin)
     }
 
     pragma [noinline] override predicate attributesUnknown() { none() }
@@ -301,8 +300,7 @@ class TypeInternal extends ClassObjectInternal, TType {
     }
 
     override predicate lookup(string name, ObjectInternal value, CfgOrigin origin) {
-        value = ObjectInternal::fromBuiltin(Builtin::special("type").getMember(name)) and
-        origin = CfgOrigin::unknown()
+        Types::getMro(this).lookup(name, value, origin)
     }
 
     pragma [noinline] override predicate attributesUnknown() { any() }


### PR DESCRIPTION
Previously builtin classes like `_ctypes.PyCSimpleType` and `type` weren't inheriting attributes properly.
This PR fixes that and adds a sanity check.