### PR TITLE
C#: Improvement to cs/dispose-not-called-on-throw

### DIFF
--- a/change-notes/1.22/analysis-csharp.md
+++ b/change-notes/1.22/analysis-csharp.md
@@ -1,0 +1,13 @@
+# Improvements to C# analysis
+
+## Changes to existing queries
+
+| **Query**                    | **Expected impact**    | **Change**                        |
+|------------------------------|------------------------|-----------------------------------|
+| Dispose may not be called if an exception is thrown during execution (`cs/dispose-not-called-on-throw`) | Fewer false positive results | Results have been removed where an object is disposed both by a `using` statement and a `Dispose` call. |
+
+## Changes to code extraction
+
+## Changes to QL libraries
+
+## Changes to autobuilder

--- a/csharp/ql/src/API Abuse/DisposeNotCalledOnException.ql
+++ b/csharp/ql/src/API Abuse/DisposeNotCalledOnException.ql
@@ -54,9 +54,9 @@ private class DisposeCall extends MethodCall {
 
 private predicate localFlowStep(DataFlow::Node nodeFrom, DataFlow::Node nodeTo) {
   DataFlow::localFlowStep(nodeFrom, nodeTo) and
-  not exists(AssignableDefinition def, UsingStmt uds |
+  not exists(AssignableDefinition def, UsingStmt us |
     nodeTo.asExpr() = def.getAReachableRead() and
-    def.getTargetAccess() = uds.getAVariableDeclExpr().getAccess()
+    def.getTargetAccess() = us.getAVariableDeclExpr().getAccess()
   )
 }
 

--- a/csharp/ql/src/API Abuse/DisposeNotCalledOnException.ql
+++ b/csharp/ql/src/API Abuse/DisposeNotCalledOnException.ql
@@ -52,11 +52,19 @@ private class DisposeCall extends MethodCall {
   DisposeCall() { this.getTarget() instanceof DisposeMethod }
 }
 
+private predicate localFlowStep(DataFlow::Node nodeFrom, DataFlow::Node nodeTo) {
+  DataFlow::localFlowStep(nodeFrom, nodeTo) and
+  not exists(AssignableDefinition def, UsingStmt uds |
+    nodeTo.asExpr() = def.getAReachableRead() and
+    def.getTargetAccess() = uds.getAVariableDeclExpr().getAccess()
+  )
+}
+
 private predicate reachesDisposeCall(DisposeCall disposeCall, DataFlow::Node node) {
-  DataFlow::localFlowStep(node, DataFlow::exprNode(disposeCall.getQualifier()))
+  localFlowStep(node, DataFlow::exprNode(disposeCall.getQualifier()))
   or
   exists(DataFlow::Node mid | reachesDisposeCall(disposeCall, mid) |
-    DataFlow::localFlowStep(node, mid)
+    localFlowStep(node, mid)
   )
 }
 

--- a/csharp/ql/test/query-tests/API Abuse/DisposeNotCalledOnException/DisposeNotCalledOnException.cs
+++ b/csharp/ql/test/query-tests/API Abuse/DisposeNotCalledOnException/DisposeNotCalledOnException.cs
@@ -62,6 +62,18 @@ class Test
         // GOOD: using declaration
         using SqlConnection c2 = new SqlConnection("");
         c2.Open();
+
+        // GOOD: Always disposed
+        using SqlConnection c3 = new SqlConnection("");
+        Throw2(c3);
+        c3.Dispose();
+
+        // GOOD: Disposed automatically
+        using (SqlConnection c4 = new SqlConnection(""))
+        {
+            Throw2(c4);
+            c4.Dispose();
+        }
     }
 
     void Throw1(SqlConnection sc)


### PR DESCRIPTION
~~Only the last 2 commits need reviewing.~~

Handle additional cases where an object is disposed both implicitly and explicitly, for example
```
using(var x = ...)
{
   throw ...;
   x.Dispose();
}
```

