### PR TITLE
Python points-to. Improve handling of socket module.

### DIFF
--- a/python/ql/src/semmle/python/pointsto/PointsTo.qll
+++ b/python/ql/src/semmle/python/pointsto/PointsTo.qll
@@ -717,15 +717,28 @@ private module InterModulePointsTo {
             |
             src.declaredInAll(name) and result = true
             or
-            src.declaredInAll(_) and not src.declaredInAll(name) and
+            declared_all_is_simple(src) and
+            not src.declaredInAll(name) and
             ofInterestInExports(mod, name) and result = false
             or
-            not src.declaredInAll(_) and
+            (not src.declaredInAll(name) and not declared_all_is_simple(src))
+            and
             exists(ObjectInternal val |
                 ModuleAttributes::pointsToAtExit(src, name, val, _) |
                 val = ObjectInternal::undefined() and result = false
                 or
                 val != ObjectInternal::undefined() and result = true
+            )
+        )
+    }
+
+    /** Holds if __all__ is declared and not mutated */
+    private predicate declared_all_is_simple(Module m) {
+        exists(AssignStmt a, GlobalVariable all |
+            a.defines(all) and a.getScope() = m and
+            all.getId() = "__all__" and
+            not exists(Attribute attr |
+                all.getALoad() = attr.getObject()
             )
         )
     }

--- a/python/ql/test/library-tests/PointsTo/imports/Runtime.expected
+++ b/python/ql/test/library-tests/PointsTo/imports/Runtime.expected
@@ -52,4 +52,6 @@
 | test.py | 24 | ControlFlowNode for argv | int 0 | ControlFlowNode for IntegerLiteral |
 | test.py | 27 | ControlFlowNode for ImportExpr | Module sys | ControlFlowNode for ImportExpr |
 | test.py | 31 | ControlFlowNode for argv | list object | ControlFlowNode for from sys import * |
+| test.py | 33 | ControlFlowNode for ImportExpr | Module socket | ControlFlowNode for ImportExpr |
+| test.py | 34 | ControlFlowNode for timeout | builtin-class socket.timeout | ControlFlowNode for from _socket import * |
 | x.py | 2 | ControlFlowNode for ImportExpr | Module sys | ControlFlowNode for ImportExpr |

--- a/python/ql/test/library-tests/PointsTo/imports/RuntimeWithType.expected
+++ b/python/ql/test/library-tests/PointsTo/imports/RuntimeWithType.expected
@@ -52,4 +52,6 @@
 | test.py | 24 | ControlFlowNode for argv | int 0 | builtin-class int | ControlFlowNode for IntegerLiteral |
 | test.py | 27 | ControlFlowNode for ImportExpr | Module sys | builtin-class module | ControlFlowNode for ImportExpr |
 | test.py | 31 | ControlFlowNode for argv | list object | builtin-class list | ControlFlowNode for from sys import * |
+| test.py | 33 | ControlFlowNode for ImportExpr | Module socket | builtin-class module | ControlFlowNode for ImportExpr |
+| test.py | 34 | ControlFlowNode for timeout | builtin-class socket.timeout | builtin-class type | ControlFlowNode for from _socket import * |
 | x.py | 2 | ControlFlowNode for ImportExpr | Module sys | builtin-class module | ControlFlowNode for ImportExpr |

--- a/python/ql/test/library-tests/PointsTo/imports/test.py
+++ b/python/ql/test/library-tests/PointsTo/imports/test.py
@@ -29,3 +29,6 @@ except:
     pass
 
 argv
+
+from socket import *
+timeout


### PR DESCRIPTION
... or any module that dynamically generates "\_\_all\_\_".
If `__all__` is created dynamically, assume that all 'public' symbols as exported.
This means that we now recognise that `socket` and other symbols imported from `_socket` are included in `from socket import *`.
