### PR TITLE
QL 1.21: Finalize Java change notes

### DIFF
--- a/change-notes/1.21/analysis-java.md
+++ b/change-notes/1.21/analysis-java.md
@@ -1,10 +1,5 @@
 # Improvements to Java analysis
 
-## New queries
-
-| **Query**                   | **Tags**  | **Purpose**                                                        |
-|-----------------------------|-----------|--------------------------------------------------------------------|
-
 ## Changes to existing queries
 
 | **Query**                  | **Expected impact**    | **Change**                                                       |
@@ -19,14 +14,13 @@
   `checkArgument` and `checkState` methods in
   `com.google.common.base.Preconditions`, the `isTrue` and `validState` methods
   in `org.apache.commons.lang3.Validate`, as well as any similar custom
-  methods. This means that more guards are recognized yielding precision
-  improvements in a number of queries including `java/index-out-of-bounds`,
+  methods. This means that more guards are recognized which improves the precision of a number of queries including `java/index-out-of-bounds`,
   `java/dereferenced-value-may-be-null`, and `java/useless-null-check`.
 * The default sanitizer in taint tracking has been made more precise. The
-  sanitizer works by looking for guards that inspect tainted strings, and it
-  used to work at the level of individual variables. This has been changed to
-  use the `Guards` library, such that only guarded variable accesses are
-  sanitized. This may give additional results in the security queries.
-* Spring framework support is enhanced by taking into account additional
+  sanitizer works by looking for guards that inspect tainted strings. It
+  previously worked at the level of individual variables. Now it
+  uses the `Guards` library, such that only guarded variable accesses are
+  sanitized. This may give additional results for security queries.
+* Spring framework support now takes into account additional
   annotations that indicate remote user input. This affects all security
-  queries, which may yield additional results.
+  queries, which may give additional results.


### PR DESCRIPTION
This PR tidies up the Java change notes ready for the release of 1.21.

@Semmle/java 