### PR TITLE
Python: Extend the object API.

### DIFF
--- a/python/ql/src/semmle/python/objects/Callables.qll
+++ b/python/ql/src/semmle/python/objects/Callables.qll
@@ -270,7 +270,10 @@ class BuiltinFunctionObjectInternal extends CallableObjectInternal, TBuiltinFunc
     }
 
     override predicate neverReturns() {
-        this = Module::named("sys").attr("exit")
+        exists(ModuleObjectInternal sys |
+            sys.getName() = "sys" and
+            sys.attribute("exit", this, _)
+        )
     }
 
     override predicate functionAndOffset(CallableObjectInternal function, int offset) {

--- a/python/ql/src/semmle/python/objects/Classes.qll
+++ b/python/ql/src/semmle/python/objects/Classes.qll
@@ -11,7 +11,7 @@ private import semmle.python.types.Builtins
 /** Class representing classes */
 abstract class ClassObjectInternal extends ObjectInternal {
 
-    string getName() {
+    override string getName() {
         result = this.getClassDeclaration().getName()
     }
 

--- a/python/ql/src/semmle/python/objects/Constants.qll
+++ b/python/ql/src/semmle/python/objects/Constants.qll
@@ -67,6 +67,8 @@ abstract class ConstantObjectInternal extends ObjectInternal {
         this = instance
     }
 
+    override string getName() { none() }
+
 }
 
 private abstract class BooleanObjectInternal extends ConstantObjectInternal {

--- a/python/ql/src/semmle/python/objects/Descriptors.qll
+++ b/python/ql/src/semmle/python/objects/Descriptors.qll
@@ -11,7 +11,7 @@ private import semmle.python.types.Builtins
 class PropertyInternal extends ObjectInternal, TProperty {
 
     /** Gets the name of this property */
-    string getName() {
+    override string getName() {
         result = this.getGetter().getName()
     }
 
@@ -172,6 +172,10 @@ class ClassMethodObjectInternal extends ObjectInternal, TClassMethod {
 
     override int length() { none() }
 
+    override string getName() {
+        result = this.getFunction().getName()
+    }
+
 }
 
 class StaticMethodObjectInternal extends ObjectInternal, TStaticMethod {
@@ -238,5 +242,9 @@ class StaticMethodObjectInternal extends ObjectInternal, TStaticMethod {
     pragma [noinline] override predicate binds(ObjectInternal instance, string name, ObjectInternal descriptor) { none() }
 
     override int length() { none() }
+
+    override string getName() {
+        result = this.getFunction().getName()
+    }
 
 }

--- a/python/ql/src/semmle/python/objects/Instances.qll
+++ b/python/ql/src/semmle/python/objects/Instances.qll
@@ -49,6 +49,8 @@ abstract class InstanceObject extends ObjectInternal {
     /** Holds if `init` in the context `callee` is the initializer of this instance */
     abstract predicate initializer(PythonFunctionObjectInternal init, Context callee);
 
+    override string getName() { none() }
+
 }
 
 private predicate self_variable_reaching_init_exit(EssaVariable self) {
@@ -362,6 +364,8 @@ class UnknownInstanceInternal extends TUnknownInstance, ObjectInternal {
         result = lengthFromClass(this.getClass())
     }
 
+    override string getName() { none() }
+
 }
 
 private int lengthFromClass(ClassObjectInternal cls) {
@@ -460,6 +464,8 @@ class SuperInstance extends TSuperInstance, ObjectInternal {
     override int length() {
         none()
     }
+
+    override string getName() { none() }
 
 }
 

--- a/python/ql/src/semmle/python/objects/Modules.qll
+++ b/python/ql/src/semmle/python/objects/Modules.qll
@@ -10,9 +10,6 @@ private import semmle.python.types.Builtins
 /** A class representing modules */
 abstract class ModuleObjectInternal extends ObjectInternal {
 
-    /** Gets the name of this module */
-    abstract string getName();
-
     /** Gets the source scope of this module, if it has one. */
     abstract Module getSourceModule();
 
@@ -407,6 +404,9 @@ class AbsentModuleAttributeObjectInternal extends ObjectInternal, TAbsentModuleA
     override predicate isMissing() {
         any()
     }
+
+    /* We know what this is called, but not its innate name */
+    override string getName() { none() }
 
 }
 

--- a/python/ql/src/semmle/python/objects/ObjectInternal.qll
+++ b/python/ql/src/semmle/python/objects/ObjectInternal.qll
@@ -161,6 +161,12 @@ class ObjectInternal extends TObject {
         none()
     }
 
+    /** Gets the name of this of this object if it has a meaningful name.
+     * Note that the name of an object is not necessarily the name by which it is called
+     * For example the function named `posixpath.join` will be called `os.path.join`.
+     */
+    abstract string getName();
+
 }
 
 
@@ -240,6 +246,9 @@ class BuiltinOpaqueObjectInternal extends ObjectInternal, TBuiltinOpaqueObject {
 
     override int length() { none() }
 
+    override string getName() {
+        result = this.getBuiltin().getName()
+    }
 }
 
 
@@ -314,6 +323,8 @@ class UnknownInternal extends ObjectInternal, TUnknown {
     pragma [noinline] override predicate binds(ObjectInternal instance, string name, ObjectInternal descriptor) { none() }
 
     override int length() { result = -1 }
+
+    override string getName() { none() }
 
 }
 
@@ -390,6 +401,8 @@ class UndefinedInternal extends ObjectInternal, TUndefined {
     pragma [noinline] override predicate binds(ObjectInternal instance, string name, ObjectInternal descriptor) { none() }
 
     override int length() { none() }
+
+    override string getName() { none() }
 
 }
 

--- a/python/ql/src/semmle/python/objects/Sequences.qll
+++ b/python/ql/src/semmle/python/objects/Sequences.qll
@@ -30,6 +30,8 @@ abstract class SequenceObjectInternal extends ObjectInternal {
 
     pragma [noinline] override predicate binds(ObjectInternal instance, string name, ObjectInternal descriptor) { none() }
 
+    override string getName() { none() }
+
 }
 
 abstract class TupleObjectInternal extends SequenceObjectInternal {

--- a/python/ql/src/semmle/python/pointsto/MRO.qll
+++ b/python/ql/src/semmle/python/pointsto/MRO.qll
@@ -25,7 +25,7 @@ private import semmle.python.pointsto.PointsToContext
 private import semmle.python.types.Builtins
 
 
-cached private newtype TClassList = Empty()
+cached newtype TClassList = Empty()
     or
     Cons(ClassObjectInternal head, TClassList tail) {
         required_cons(head, tail)

--- a/python/ql/src/semmle/python/pointsto/MRO.qll
+++ b/python/ql/src/semmle/python/pointsto/MRO.qll
@@ -80,10 +80,16 @@ class ClassList extends TClassList {
         or
         exists(ClassObjectInternal head |
             head = this.getHead() |
-            this.getTail() = Empty() and result = head.getName()
+            this.getTail() = Empty() and result = className(head)
             or
-            this.getTail() != Empty() and result = head.getName() + ", " + this.getTail().contents()
+            this.getTail() != Empty() and result = className(head) + ", " + this.getTail().contents()
         )
+    }
+
+    private string className(ClassObjectInternal cls) {
+        result = cls.getName()
+        or
+        cls = ObjectInternal::unknownClass() and result = "??"
     }
 
     int length() {

--- a/python/ql/src/semmle/python/security/TaintTracking.qll
+++ b/python/ql/src/semmle/python/security/TaintTracking.qll
@@ -88,6 +88,7 @@
 
 import python
 private import semmle.python.pointsto.Filters as Filters
+private import semmle.python.objects.ObjectInternal
 
 /** A 'kind' of taint. This may be almost anything,
  * but it is typically something like a "user-defined string".
@@ -199,7 +200,7 @@ class SequenceKind extends CollectionKind {
             mod.getOp() instanceof Mod and
             mod.getAnOperand() = fromnode and
             result = this.getItem() and
-            result.getType() = Value::named("str")
+            result.getType() = ObjectInternal::builtin("str")
         )
     }
 
@@ -284,7 +285,7 @@ module DictKind {
     predicate flowStep(ControlFlowNode fromnode, ControlFlowNode tonode) {
         TaintFlowImplementation::copyCall(fromnode, tonode)
         or
-        tonode.(CallNode).getFunction().pointsTo(Value::named("dict")) and
+        tonode.(CallNode).getFunction().pointsTo(ObjectInternal::builtin("dict")) and
         tonode.(CallNode).getArg(0) = fromnode
     }
 
@@ -982,7 +983,7 @@ library module TaintFlowImplementation {
     pragma [noinline]
     predicate getattr_step(TaintedNode fromnode, TrackedValue totaint, CallContext tocontext, CallNode tonode) {
         exists(ControlFlowNode arg, string name |
-            tonode.getFunction().pointsTo(Value::named("getattr")) and
+            tonode.getFunction().pointsTo(ObjectInternal::builtin("getattr")) and
             arg = tonode.getArg(0) and
             name = tonode.getArg(1).getNode().(StrConst).getText() and
             arg = fromnode.getNode() and
@@ -1372,7 +1373,7 @@ library module TaintFlowImplementation {
             tonode.getArg(0) = fromnode
         )
         or
-        tonode.getFunction().pointsTo(Value::named("reversed")) and
+        tonode.getFunction().pointsTo(ObjectInternal::builtin("reversed")) and
         tonode.getArg(0) = fromnode
     }
 
@@ -1635,7 +1636,7 @@ pragma [noinline]
 private predicate dict_construct(ControlFlowNode itemnode, ControlFlowNode dictnode) {
     dictnode.(DictNode).getAValue() = itemnode
     or
-    dictnode.(CallNode).getFunction().pointsTo(Value::named("dict")) and
+    dictnode.(CallNode).getFunction().pointsTo(ObjectInternal::builtin("dict")) and
     dictnode.(CallNode).getArgByName(_) = itemnode
 }
 
@@ -1658,11 +1659,11 @@ private predicate sequence_call(ControlFlowNode fromnode, CallNode tonode) {
     tonode.getArg(0) = fromnode and
     exists(ControlFlowNode cls |
         cls = tonode.getFunction() |
-        cls.pointsTo(Value::named("list"))
+        cls.pointsTo(ObjectInternal::builtin("list"))
         or
-        cls.pointsTo(Value::named("tuple"))
+        cls.pointsTo(ObjectInternal::builtin("tuple"))
         or
-        cls.pointsTo(Value::named("set"))
+        cls.pointsTo(ObjectInternal::builtin("set"))
     )
 }
 

--- a/python/ql/src/semmle/python/types/Version.qll
+++ b/python/ql/src/semmle/python/types/Version.qll
@@ -12,7 +12,7 @@ class Version extends int {
     predicate includes(int major, int minor) {
         this = 2 and major = 2 and minor = 7
         or
-        this = 3 and major = 3 and minor in [4..7]
+        this = 3 and major = 3 and minor in [4..8]
     }
 
 }

--- a/python/ql/test/library-tests/PointsTo/absent/Absent.expected
+++ b/python/ql/test/library-tests/PointsTo/absent/Absent.expected
@@ -1,7 +1,7 @@
-| absent.py:3:8:3:11 | ControlFlowNode for ImportExpr | Missing module xxxx |
-| absent.py:4:1:4:4 | ControlFlowNode for xxxx | Missing module xxxx |
-| absent.py:6:6:6:9 | ControlFlowNode for ImportExpr | Missing module xxxx |
-| absent.py:6:18:6:21 | ControlFlowNode for ImportMember | Missing module attribute xxxx.open |
-| absent.py:8:1:8:4 | ControlFlowNode for open | Missing module attribute xxxx.open |
-| absent.py:12:8:12:13 | ControlFlowNode for ImportExpr | Module module |
-| absent.py:14:1:14:6 | ControlFlowNode for module | Module module |
+| absent.py:3:8:3:11 | ControlFlowNode for ImportExpr | file://:0:0:0:0 | Missing module xxxx |
+| absent.py:4:1:4:4 | ControlFlowNode for xxxx | file://:0:0:0:0 | Missing module xxxx |
+| absent.py:6:6:6:9 | ControlFlowNode for ImportExpr | file://:0:0:0:0 | Missing module xxxx |
+| absent.py:6:18:6:21 | ControlFlowNode for ImportMember | file://:0:0:0:0 | Missing module attribute xxxx.open |
+| absent.py:8:1:8:4 | ControlFlowNode for open | file://:0:0:0:0 | Missing module attribute xxxx.open |
+| absent.py:12:8:12:13 | ControlFlowNode for ImportExpr | module.py:0:0:0:0 | Module module |
+| absent.py:14:1:14:6 | ControlFlowNode for module | module.py:0:0:0:0 | Module module |

--- a/python/ql/test/library-tests/PointsTo/absent/Absent.ql
+++ b/python/ql/test/library-tests/PointsTo/absent/Absent.ql
@@ -3,7 +3,6 @@ import python
 import semmle.python.objects.Modules
 
 from Value val, ControlFlowNode f
-where //val = Value::named(name) and
-f.pointsTo(val)
+where f.pointsTo(val)
 select f, val
 

--- a/python/ql/test/library-tests/PointsTo/comparisons/PointsTo.expected
+++ b/python/ql/test/library-tests/PointsTo/comparisons/PointsTo.expected
@@ -1,26 +1,26 @@
-| 2 | bool True |
-| 3 | bool False |
-| 6 | bool True |
-| 7 | bool True |
-| 8 | bool True |
-| 9 | bool False |
-| 19 | bool False |
-| 19 | bool True |
-| 20 | bool False |
-| 20 | bool True |
-| 21 | bool False |
-| 21 | bool True |
-| 22 | bool False |
-| 22 | bool True |
-| 25 | bool False |
-| 26 | bool False |
-| 27 | bool True |
-| 28 | bool True |
-| 29 | bool False |
-| 30 | bool True |
-| 33 | bool False |
-| 34 | bool True |
-| 35 | bool False |
-| 36 | bool False |
-| 37 | bool True |
-| 38 | bool True |
+| 2 | file://:0:0:0:0 | bool True |
+| 3 | file://:0:0:0:0 | bool False |
+| 6 | file://:0:0:0:0 | bool True |
+| 7 | file://:0:0:0:0 | bool True |
+| 8 | file://:0:0:0:0 | bool True |
+| 9 | file://:0:0:0:0 | bool False |
+| 19 | file://:0:0:0:0 | bool False |
+| 19 | file://:0:0:0:0 | bool True |
+| 20 | file://:0:0:0:0 | bool False |
+| 20 | file://:0:0:0:0 | bool True |
+| 21 | file://:0:0:0:0 | bool False |
+| 21 | file://:0:0:0:0 | bool True |
+| 22 | file://:0:0:0:0 | bool False |
+| 22 | file://:0:0:0:0 | bool True |
+| 25 | file://:0:0:0:0 | bool False |
+| 26 | file://:0:0:0:0 | bool False |
+| 27 | file://:0:0:0:0 | bool True |
+| 28 | file://:0:0:0:0 | bool True |
+| 29 | file://:0:0:0:0 | bool False |
+| 30 | file://:0:0:0:0 | bool True |
+| 33 | file://:0:0:0:0 | bool False |
+| 34 | file://:0:0:0:0 | bool True |
+| 35 | file://:0:0:0:0 | bool False |
+| 36 | file://:0:0:0:0 | bool False |
+| 37 | file://:0:0:0:0 | bool True |
+| 38 | file://:0:0:0:0 | bool True |

--- a/python/ql/test/library-tests/PointsTo/inheritance/Mro.expected
+++ b/python/ql/test/library-tests/PointsTo/inheritance/Mro.expected
@@ -5,8 +5,8 @@
 | class Derived4 | [Derived4, Derived3, Derived2, Derived1, Base, object] |
 | class Derived5 | [Derived5, Derived1, Base, object] |
 | class Derived6 | [Derived6, Derived5, Derived2, Derived1, Base, object] |
-| class Missing1 | [Missing1, UNKNOWN, object] |
-| class Missing2 | [Missing2, Base, UNKNOWN, object] |
-| class Missing3 | [Missing3, UNKNOWN, Base, object] |
+| class Missing1 | [Missing1, ??, object] |
+| class Missing2 | [Missing2, Base, ??, object] |
+| class Missing3 | [Missing3, ??, Base, object] |
 | class Wrong1 | [Wrong1, Derived5, Derived2, Derived1, Base, object] |
 | class Wrong2 | [Wrong2, Derived3, Derived2, Derived1, Base, object] |

--- a/python/ql/test/library-tests/PointsTo/inheritance/Mro.ql
+++ b/python/ql/test/library-tests/PointsTo/inheritance/Mro.ql
@@ -9,8 +9,6 @@ class UnknownType extends UnknownClassInternal {
 
     override string toString() { result = "*UNKNOWN TYPE" }
 
-    override string getName() { result = "UNKNOWN" }
-
 }
 
 from ClassObjectInternal c

--- a/python/ql/test/library-tests/PointsTo/metaclass/Mro.ql
+++ b/python/ql/test/library-tests/PointsTo/metaclass/Mro.ql
@@ -9,8 +9,6 @@ class UnknownType extends UnknownClassInternal {
 
     override string toString() { result = "*UNKNOWN TYPE" }
 
-    override string getName() { result = "UNKNOWN" }
-
 }
 
 from PythonClassObjectInternal cls

--- a/python/ql/test/library-tests/PointsTo/metaclass/test.ql
+++ b/python/ql/test/library-tests/PointsTo/metaclass/test.ql
@@ -7,8 +7,6 @@ class UnknownType extends UnknownClassInternal {
 
     override string toString() { result = "*UNKNOWN TYPE" }
 
-    override string getName() { result = "UNKNOWN" }
-
 }
 
 from ClassObject cls

--- a/python/ql/test/library-tests/PointsTo/subclass/Checks.expected
+++ b/python/ql/test/library-tests/PointsTo/subclass/Checks.expected
@@ -1,13 +1,13 @@
-| builtin-class dict | builtin-class dict |
-| builtin-class dict | builtin-class list |
-| builtin-class int | (builtin-class float, builtin-class dict, ) |
-| builtin-class int | (builtin-class list, builtin-class int, ) |
-| builtin-class int | (builtin-class list, builtin-class int, ) |
-| builtin-class int | builtin-class dict |
-| builtin-class int | builtin-class float |
-| builtin-class int | builtin-class int |
-| builtin-class int | builtin-class list |
-| builtin-class int | builtin-class object |
-| builtin-class int | builtin-class tuple |
-| builtin-class tuple | builtin-class int |
-| builtin-class tuple | builtin-class tuple |
+| file://:0:0:0:0 | builtin-class dict | file://:0:0:0:0 | builtin-class dict |
+| file://:0:0:0:0 | builtin-class dict | file://:0:0:0:0 | builtin-class list |
+| file://:0:0:0:0 | builtin-class int | file://:0:0:0:0 | builtin-class dict |
+| file://:0:0:0:0 | builtin-class int | file://:0:0:0:0 | builtin-class float |
+| file://:0:0:0:0 | builtin-class int | file://:0:0:0:0 | builtin-class int |
+| file://:0:0:0:0 | builtin-class int | file://:0:0:0:0 | builtin-class list |
+| file://:0:0:0:0 | builtin-class int | file://:0:0:0:0 | builtin-class object |
+| file://:0:0:0:0 | builtin-class int | file://:0:0:0:0 | builtin-class tuple |
+| file://:0:0:0:0 | builtin-class int | test.py:14:23:14:31 | (builtin-class list, builtin-class int, ) |
+| file://:0:0:0:0 | builtin-class int | test.py:15:29:15:37 | (builtin-class list, builtin-class int, ) |
+| file://:0:0:0:0 | builtin-class int | test.py:16:25:16:35 | (builtin-class float, builtin-class dict, ) |
+| file://:0:0:0:0 | builtin-class tuple | file://:0:0:0:0 | builtin-class int |
+| file://:0:0:0:0 | builtin-class tuple | file://:0:0:0:0 | builtin-class tuple |

--- a/python/ql/test/library-tests/types/classes/FailedInference.expected
+++ b/python/ql/test/library-tests/types/classes/FailedInference.expected
@@ -1,14 +1,14 @@
-| class A | Missing base 0 |
-| class B | Failed inference for base class at position 0 |
-| class C | Failed inference for base class at position 0 |
-| class D | Duplicate bases classes |
-| class E | Duplicate bases classes |
-| class G | Failed inference for base class at position 0 |
-| class H | Failed inference for base class at position 0 |
-| class J | Missing base 0 |
-| class L | Failed inference for base class at position 0 |
-| class M | Failed inference for base class at position 0 |
-| class N | Failed inference for base class at position 0 |
-| class R | Failed inference for base class at position 0 |
-| class S | Failed inference for base class at position 0 |
-| class T | Failed inference for base class at position 0 |
+| circular_inheritance.py:33:1:33:11 | class A | Missing base 0 |
+| circular_inheritance.py:37:1:37:11 | class B | Failed inference for base class at position 0 |
+| circular_inheritance.py:40:1:40:72 | class D | Duplicate bases classes |
+| circular_inheritance.py:43:1:43:41 | class E | Duplicate bases classes |
+| circular_inheritance.py:47:1:47:19 | class G | Failed inference for base class at position 0 |
+| circular_inheritance.py:50:1:50:19 | class J | Missing base 0 |
+| circular_inheritance.py:54:1:54:11 | class M | Failed inference for base class at position 0 |
+| circular_inheritance.py:57:1:57:11 | class L | Failed inference for base class at position 0 |
+| circular_inheritance.py:61:1:61:19 | class S | Failed inference for base class at position 0 |
+| circular_inheritance.py:64:1:64:19 | class R | Failed inference for base class at position 0 |
+| mutual_inheritance.py:4:1:4:11 | class C | Failed inference for base class at position 0 |
+| mutual_inheritance.py:8:1:8:19 | class H | Failed inference for base class at position 0 |
+| mutual_inheritance.py:12:1:12:11 | class N | Failed inference for base class at position 0 |
+| mutual_inheritance.py:15:1:15:19 | class T | Failed inference for base class at position 0 |


### PR DESCRIPTION
Improves the usability of the new object API, by:

1. Adding `getName()` to `Value` to avoid having to cast to `ClassValue`, etc.
2. Clearly differentiate between what an object is called, and what it is named.
3. Implement `hasLocationInfo()` on `Value` for ease of use.
4. Add generally useful member predicates from `ClassObject` to `ClassValue`.