### PR TITLE
Update support info for 1.21

### DIFF
--- a/change-notes/support/language-support.rst
+++ b/change-notes/support/language-support.rst
@@ -13,7 +13,9 @@ Note that where there are several versions or dialects of a language, the suppor
 
 .. container:: footnote-group
 
-    .. [1] The best results are achieved with COBOL code that stays close to the ANSI 85 standard.  
-    .. [2] Builds that execute on Java 6 to 11 can be analyzed. The analysis understands Java 11 language features.
-    .. [3] JSX and Flow code, YAML, JSON, and HTML files may also be analyzed with JavaScript files. 
-    .. [4] TypeScript analysis is performed by running the JavaScript extractor with TypeScript enabled. This is the default for LGTM.   
+    .. [1] Support for the Arm Compiler (armcc) is preliminary.
+    .. [2] In addition, support for the preview features of C#8 and .NET Core 3.0.
+    .. [3] The best results are achieved with COBOL code that stays close to the ANSI 85 standard.  
+    .. [4] Builds that execute on Java 6 to 12 can be analyzed. The analysis understands Java 12 language features.
+    .. [5] JSX and Flow code, YAML, JSON, HTML, and XML files may also be analyzed with JavaScript files. 
+    .. [6] TypeScript analysis is performed by running the JavaScript extractor with TypeScript enabled. This is the default for LGTM.   

--- a/change-notes/support/language-support.rst
+++ b/change-notes/support/language-support.rst
@@ -14,7 +14,7 @@ Note that where there are several versions or dialects of a language, the suppor
 .. container:: footnote-group
 
     .. [1] Support for the Arm Compiler (armcc) is preliminary.
-    .. [2] In addition, support for the preview features of C#8 and .NET Core 3.0.
+    .. [2] In addition, support is included for the preview features of C# 8.0 and .NET Core 3.0.
     .. [3] The best results are achieved with COBOL code that stays close to the ANSI 85 standard.  
     .. [4] Builds that execute on Java 6 to 12 can be analyzed. The analysis understands Java 12 language features.
     .. [5] JSX and Flow code, YAML, JSON, HTML, and XML files may also be analyzed with JavaScript files. 

--- a/change-notes/support/versions-compilers.csv
+++ b/change-notes/support/versions-compilers.csv
@@ -1,16 +1,18 @@
 Language,Variants,Compilers,Extensions
-C/C++,"C89, C99, C11, C++98, C++03, C++11, C++14, C++17","Clang extensions (up to Clang 6.0)
+C/C++,"C89, C99, C11, C++98, C++03, C++11, C++14, C++17","Clang extensions (up to Clang 8.0)
 
-GNU extensions (up to GCC 7.3), 
+GNU extensions (up to GCC 8.3), 
 
-Microsoft extensions (up to VS 2017)","``.cpp``, ``.c++``, ``.cxx``, ``.hpp``, ``.hh``, ``.h++``, ``.hxx``, ``.c``, ``.cc``, ``.h``"
-C#,C# up to 7.2 together with .NET versions up to 4.7.1,"Microsoft Visual Studio up to 2017, 
+Microsoft extensions (up to VS 2019),
 
-.NET Core up to 2.1","``.sln``, ``.csproj``, ``.cs``, ``.cshtml``, ``.xaml``"
-COBOL,ANSI 85 or newer [1]_.,Not applicable,"``.cbl``, ``.CBL``, ``.cpy``, ``.CPY``, ``.copy``, ``.COPY``"
-Java,"Java 6 to 11 [2]_.","javac (OpenJDK and Oracle JDK)
+Arm Compiler 5.0 [1]_.","``.cpp``, ``.c++``, ``.cxx``, ``.hpp``, ``.hh``, ``.h++``, ``.hxx``, ``.c``, ``.cc``, ``.h``"
+C#,C# up to 7.3. with .NET up to 4.8 [2]_.,"Microsoft Visual Studio up to 2019, 
+
+.NET Core up to 2.2","``.sln``, ``.csproj``, ``.cs``, ``.cshtml``, ``.xaml``"
+COBOL,ANSI 85 or newer [3]_.,Not applicable,"``.cbl``, ``.CBL``, ``.cpy``, ``.CPY``, ``.copy``, ``.COPY``"
+Java,"Java 6 to 12 [4]_.","javac (OpenJDK and Oracle JDK)
 
 Eclipse compiler for Java (ECJ) batch compiler",``.java``
-JavaScript,ECMAScript 2019 or lower,Not applicable,"``.js``, ``.jsx``, ``.mjs``, ``.es``, ``.es6``, ``.htm``, ``.html``, ``.xhm``, ``.xhtml``, ``.vue``, ``.json``, ``.yaml``, ``.yml``, ``.raml`` [3]_."
+JavaScript,ECMAScript 2019 or lower,Not applicable,"``.js``, ``.jsx``, ``.mjs``, ``.es``, ``.es6``, ``.htm``, ``.html``, ``.xhm``, ``.xhtml``, ``.vue``, ``.json``, ``.yaml``, ``.yml``, ``.raml``, ``.xml`` [5]_."
 Python,"2.7, 3.5, 3.6, 3.7",Not applicable,``.py``
-TypeScript [4]_.,"2.6-3.5",Standard TypeScript compiler,"``.ts``, ``.tsx``"
+TypeScript [6]_.,"2.6-3.5",Standard TypeScript compiler,"``.ts``, ``.tsx``"


### PR DESCRIPTION
This PR updates the support information based on the analysis change notes for 1.21.

The changes I'm aware of are:
* C/C++ - support for clang 8, gcc 8.3, and VS 2019, and preliminary support for armcc
* C# - support for C# up to 7.3. with .NET up to 4.8, Microsoft Visual Studio up to 2019, .NET Core up to 2.2, and support for C# 8.0 with .NET 3.0 preview features
* Java - support for Java 12

Preview: http://docteam.internal.semmle.com/felicity/sphinx-support-3/language-support.html

@Semmle/cpp, @Semmle/cs and @Semmle/java - please check that you're happy with these changes.