### PR TITLE
Python: Improve performance of submodule name computation.

### DIFF
--- a/python/ql/src/semmle/python/objects/Modules.qll
+++ b/python/ql/src/semmle/python/objects/Modules.qll
@@ -155,7 +155,12 @@ class PackageObjectInternal extends ModuleObjectInternal, TPackageObject {
 
     /** Gets the submodule `name` of this package */
     ModuleObjectInternal submodule(string name) {
-        result.getName() = this.getName() + "." + name
+        exists(string fullName, int lastDotIndex |
+            fullName = result.getName() and
+            lastDotIndex = max(fullName.indexOf(".")) and
+            name = fullName.substring(lastDotIndex + 1, fullName.length()) and
+            this.getName() = fullName.substring(0, lastDotIndex)
+        )
     }
 
     override int intValue() {


### PR DESCRIPTION
The current method requires the evaluator to compute a Cartesian product between `ModuleObjectInternal`s and `PackageObjectInternal`s.

This change as written is currently a semantic change as we split the string on the last ".". I can change this back but I think this is more what was intended by the original predicate anyway.