### PR TITLE
C++: use shortestDistances in PrimitiveBasicBlocks

### DIFF
--- a/cpp/ql/src/semmle/code/cpp/controlflow/internal/PrimitiveBasicBlocks.qll
+++ b/cpp/ql/src/semmle/code/cpp/controlflow/internal/PrimitiveBasicBlocks.qll
@@ -60,29 +60,10 @@ private cached module Cached {
     not n2 instanceof PrimitiveBasicBlock
   }
 
-  /** Returns the index of `node` in its `PrimitiveBasicBlock`. */
-  private int getMemberIndex(Node node) {
-    primitive_basic_block_entry_node(node) and
-    result = 0
-    or
-    exists(Node prev |
-      member_step(prev, node) and
-      result = getMemberIndex(prev) + 1
-    )
-  }
-
   /** Holds if `node` is the `pos`th control-flow node in primitive basic block `bb`. */
   cached
-  predicate primitive_basic_block_member(Node node, PrimitiveBasicBlock bb, int pos) {
-    primitive_basic_block_entry_node(bb) and
-    (
-      pos = 0 and
-      node = bb
-      or
-      pos = getMemberIndex(node) and
-      member_step+(bb, node)
-    )
-  }
+  predicate primitive_basic_block_member(Node node, PrimitiveBasicBlock bb, int pos) =
+    shortestDistances(primitive_basic_block_entry_node/1, member_step/2)(bb, node, pos)
 
   /** Gets the number of control-flow nodes in the primitive basic block `bb`. */
   cached

--- a/cpp/ql/src/semmle/code/cpp/controlflow/internal/PrimitiveBasicBlocks.qll
+++ b/cpp/ql/src/semmle/code/cpp/controlflow/internal/PrimitiveBasicBlocks.qll
@@ -62,8 +62,14 @@ private cached module Cached {
 
   /** Holds if `node` is the `pos`th control-flow node in primitive basic block `bb`. */
   cached
-  predicate primitive_basic_block_member(Node node, PrimitiveBasicBlock bb, int pos) =
-    shortestDistances(primitive_basic_block_entry_node/1, member_step/2)(bb, node, pos)
+  predicate primitive_basic_block_member(Node node, PrimitiveBasicBlock bb, int pos) {
+    primitive_basic_block_entry_node(bb) and node = bb and pos = 0
+    or
+    exists(Node prev |
+      member_step(prev, node) and
+      primitive_basic_block_member(prev, bb, pos - 1)
+    )
+  }
 
   /** Gets the number of control-flow nodes in the primitive basic block `bb`. */
   cached


### PR DESCRIPTION
The use of transitive closure for BB index calculation has been the cause of an out-of-memory error. This PR switches the calculation to use the `shortestDistances` HOP, which still has the problem that the result needs to fit in RAM, but at least the RAM requirements are sure to be linear in the size of the result. The `shortestDistances` HOP is already used for BB index calculation for the C++ IR and for C#.

We could guard even better against OOM by switching the calculation to use manual recursion, but that would undo the much-needed performance improvements we got from #123.

This change improves performance on Wireshark, which is notorious for having long basic blocks. When I benchmarked `shortestDistances` for #123, it was slower than TC. With the current evaluator, it looks like `shortestDistances` is faster. Performance before was:

    PrimitiveBasicBlocks::Cached::getMemberIndex#ff ................... 9.7s (executed 8027 times)
    #PrimitiveBasicBlocks::Cached::member_step#ffPlus ................. 6.6s
    PrimitiveBasicBlocks::Cached::primitive_basic_block_entry_node#f .. 3.5s
    PrimitiveBasicBlocks::Cached::primitive_basic_block_member#fff .... 2.3s

Performance with this commit is:

    PrimitiveBasicBlocks::Cached::primitive_basic_block_entry_node#f ................................................................... 3.5s
    shortestDistances@PrimitiveBasicBlocks::Cached::primitive_basic_block_entry_node#1@PrimitiveBasicBlocks::Cached::member_step#2#fff . 3s
    PrimitiveBasicBlocks::Cached::primitive_basic_block_member#fff ..................................................................... 963ms