### PR TITLE
CPP: Support for aggregate initializers in getAnAssignedValue()

### DIFF
--- a/change-notes/1.22/analysis-cpp.md
+++ b/change-notes/1.22/analysis-cpp.md
@@ -15,4 +15,5 @@
 
 ## Changes to QL libraries
 
+- The predicate `Variable.getAnAssignedValue()` now reports assignments to fields resulting from aggregate initialization (` = {...}`).
 - The predicate `TypeMention.toString()` has been simplified to always return the string "`type mention`".  This may improve performance when using `Element.toString()` or its descendants.

--- a/cpp/ql/src/jsf/4.10 Classes/AV Rule 71.ql
+++ b/cpp/ql/src/jsf/4.10 Classes/AV Rule 71.ql
@@ -55,6 +55,7 @@ predicate memberDirectlyInitialisesVariable(MemberFunction mf, Class c, MemberVa
 predicate memberInitialisesVariable(MemberFunction mf, Class c, MemberVariable mv) {
   memberDirectlyInitialisesVariable(mf, c, mv) or
   exists(MemberFunction mf2 |
+    memberDirectlyInitialisesVariable(_, c, mv) and // (optimizer hint)
     memberInitialisesVariable(mf2, c, mv) and
     mf.getDeclaringType() = c and
     mf.calls(mf2)

--- a/cpp/ql/src/semmle/code/cpp/Field.qll
+++ b/cpp/ql/src/semmle/code/cpp/Field.qll
@@ -54,7 +54,7 @@ class Field extends MemberVariable {
    * which the field will be initialized, whether by an initializer list or in a
    * constructor.
    */
-  final int getInitializationOrder() {
+  final pragma[nomagic] int getInitializationOrder() {
     exists(Class cls, int memberIndex | 
       this = cls.getCanonicalMember(memberIndex) and
       memberIndex = rank[result + 1](int index |

--- a/cpp/ql/src/semmle/code/cpp/Variable.qll
+++ b/cpp/ql/src/semmle/code/cpp/Variable.qll
@@ -163,6 +163,14 @@ class Variable extends Declaration, @variable {
   predicate isCompilerGenerated() { compgenerated(underlyingElement(this)) }
 }
 
+class ExtendedField extends Field {
+  override Expr getAnAssignedValue() {
+    exists(AggregateLiteral l |
+      this.getDeclaringType() = l.getType() and result = l.getChild(this.getInitializationOrder())
+    )
+  }
+}
+
 /**
  * A particular declaration or definition of a C/C++ variable.
  */

--- a/cpp/ql/src/semmle/code/cpp/Variable.qll
+++ b/cpp/ql/src/semmle/code/cpp/Variable.qll
@@ -117,6 +117,11 @@ class Variable extends Declaration, @variable {
     or
     exists (AssignExpr ae
     | ae.getLValue().(Access).getTarget() = this and result = ae.getRValue())
+    or
+    exists(AggregateLiteral l |
+      this.getDeclaringType() = l.getType() and
+      result = l.getChild(this.(Field).getInitializationOrder())
+    )
   }
 
   /**
@@ -161,14 +166,6 @@ class Variable extends Declaration, @variable {
    *    `for (char c : str) { ... }`
    */
   predicate isCompilerGenerated() { compgenerated(underlyingElement(this)) }
-}
-
-class ExtendedField extends Field {
-  override Expr getAnAssignedValue() {
-    exists(AggregateLiteral l |
-      this.getDeclaringType() = l.getType() and result = l.getChild(this.getInitializationOrder())
-    )
-  }
 }
 
 /**

--- a/cpp/ql/test/library-tests/variables/getanassignedvalue/getanassignedvalue.expected
+++ b/cpp/ql/test/library-tests/variables/getanassignedvalue/getanassignedvalue.expected
@@ -1,3 +1,5 @@
+| file://:0:0:0:0 | abc | test.cpp:53:6:53:11 | chars1 |
+| file://:0:0:0:0 | {...} | test.cpp:38:22:38:22 | v |
 | test.cpp:4:9:4:11 | 10 | test.cpp:4:6:4:6 | v |
 | test.cpp:5:15:5:16 | & ... | test.cpp:5:7:5:11 | ptr_v |
 | test.cpp:6:15:6:15 | v | test.cpp:6:7:6:11 | ref_v |
@@ -8,3 +10,9 @@
 | test.cpp:19:42:19:43 | _x | test.cpp:24:8:24:8 | x |
 | test.cpp:19:49:19:50 | _y | test.cpp:24:11:24:11 | y |
 | test.cpp:19:54:19:60 | 0.0 | test.cpp:24:14:24:14 | z |
+| test.cpp:35:16:35:25 | {...} | test.cpp:35:11:35:12 | v1 |
+| test.cpp:36:16:36:39 | {...} | test.cpp:36:11:36:12 | v2 |
+| test.cpp:48:16:48:28 | {...} | test.cpp:48:11:48:12 | v3 |
+| test.cpp:52:19:52:27 | {...} | test.cpp:52:5:52:11 | myArray |
+| test.cpp:54:17:54:31 | {...} | test.cpp:54:6:54:11 | chars2 |
+| test.cpp:55:16:55:20 | abc | test.cpp:55:7:55:12 | chars3 |

--- a/cpp/ql/test/library-tests/variables/getanassignedvalue/getanassignedvalue.expected
+++ b/cpp/ql/test/library-tests/variables/getanassignedvalue/getanassignedvalue.expected
@@ -7,6 +7,9 @@
 | test.cpp:10:10:10:11 | 13 | test.cpp:6:7:6:11 | ref_v |
 | test.cpp:11:6:11:10 | ... + ... | test.cpp:4:6:4:6 | v |
 | test.cpp:19:32:19:35 | 0.0 | test.cpp:19:27:19:28 | _y |
+| test.cpp:19:42:19:43 | _x | test.cpp:24:8:24:8 | x |
+| test.cpp:19:49:19:50 | _y | test.cpp:24:11:24:11 | y |
+| test.cpp:19:54:19:60 | 0.0 | test.cpp:24:14:24:14 | z |
 | test.cpp:35:16:35:25 | {...} | test.cpp:35:11:35:12 | v1 |
 | test.cpp:35:17:35:17 | 1 | test.cpp:31:6:31:8 | num |
 | test.cpp:35:20:35:24 | One | test.cpp:32:14:32:16 | str |

--- a/cpp/ql/test/library-tests/variables/getanassignedvalue/getanassignedvalue.expected
+++ b/cpp/ql/test/library-tests/variables/getanassignedvalue/getanassignedvalue.expected
@@ -7,12 +7,18 @@
 | test.cpp:10:10:10:11 | 13 | test.cpp:6:7:6:11 | ref_v |
 | test.cpp:11:6:11:10 | ... + ... | test.cpp:4:6:4:6 | v |
 | test.cpp:19:32:19:35 | 0.0 | test.cpp:19:27:19:28 | _y |
-| test.cpp:19:42:19:43 | _x | test.cpp:24:8:24:8 | x |
-| test.cpp:19:49:19:50 | _y | test.cpp:24:11:24:11 | y |
-| test.cpp:19:54:19:60 | 0.0 | test.cpp:24:14:24:14 | z |
 | test.cpp:35:16:35:25 | {...} | test.cpp:35:11:35:12 | v1 |
+| test.cpp:35:17:35:17 | 1 | test.cpp:31:6:31:8 | num |
+| test.cpp:35:20:35:24 | One | test.cpp:32:14:32:16 | str |
 | test.cpp:36:16:36:39 | {...} | test.cpp:36:11:36:12 | v2 |
+| test.cpp:36:24:36:24 | 2 | test.cpp:31:6:31:8 | num |
+| test.cpp:36:34:36:38 | Two | test.cpp:32:14:32:16 | str |
+| test.cpp:38:27:38:27 | 3 | test.cpp:31:6:31:8 | num |
+| test.cpp:38:30:38:36 | Three | test.cpp:32:14:32:16 | str |
 | test.cpp:48:16:48:28 | {...} | test.cpp:48:11:48:12 | v3 |
+| test.cpp:48:17:48:27 | {...} | test.cpp:45:12:45:14 | ms2 |
+| test.cpp:48:18:48:18 | 4 | test.cpp:31:6:31:8 | num |
+| test.cpp:48:21:48:26 | Four | test.cpp:32:14:32:16 | str |
 | test.cpp:52:19:52:27 | {...} | test.cpp:52:5:52:11 | myArray |
 | test.cpp:54:17:54:31 | {...} | test.cpp:54:6:54:11 | chars2 |
 | test.cpp:55:16:55:20 | abc | test.cpp:55:7:55:12 | chars3 |

--- a/cpp/ql/test/library-tests/variables/getanassignedvalue/getanassignedvalue.expected
+++ b/cpp/ql/test/library-tests/variables/getanassignedvalue/getanassignedvalue.expected
@@ -1,0 +1,10 @@
+| test.cpp:4:9:4:11 | 10 | test.cpp:4:6:4:6 | v |
+| test.cpp:5:15:5:16 | & ... | test.cpp:5:7:5:11 | ptr_v |
+| test.cpp:6:15:6:15 | v | test.cpp:6:7:6:11 | ref_v |
+| test.cpp:8:6:8:7 | 11 | test.cpp:4:6:4:6 | v |
+| test.cpp:10:10:10:11 | 13 | test.cpp:6:7:6:11 | ref_v |
+| test.cpp:11:6:11:10 | ... + ... | test.cpp:4:6:4:6 | v |
+| test.cpp:19:32:19:35 | 0.0 | test.cpp:19:27:19:28 | _y |
+| test.cpp:19:42:19:43 | _x | test.cpp:24:8:24:8 | x |
+| test.cpp:19:49:19:50 | _y | test.cpp:24:11:24:11 | y |
+| test.cpp:19:54:19:60 | 0.0 | test.cpp:24:14:24:14 | z |

--- a/cpp/ql/test/library-tests/variables/getanassignedvalue/getanassignedvalue.ql
+++ b/cpp/ql/test/library-tests/variables/getanassignedvalue/getanassignedvalue.ql
@@ -1,0 +1,4 @@
+import cpp
+
+from Variable v
+select v.getAnAssignedValue(), v

--- a/cpp/ql/test/library-tests/variables/getanassignedvalue/test.cpp
+++ b/cpp/ql/test/library-tests/variables/getanassignedvalue/test.cpp
@@ -23,3 +23,33 @@ public:
 private:
 	float x, y, z;
 };
+
+// ---
+
+struct myStruct1
+{
+	int num;
+	const char *str;
+};
+
+myStruct1 v1 = {1, "One"}; // assigment to `v1`
+myStruct1 v2 = {.num = 2, .str = "Two"}; // assigment to `v2`
+
+void test2(myStruct1 v = {3, "Three"}) // assignment to `v` (literal `{...}` has no location)
+{
+	// ...
+}
+
+struct myStruct2
+{
+	myStruct1 ms2;
+};
+
+myStruct2 v3 = {{4, "Four"}}; // assigment to `v3`
+
+// ---
+
+int myArray[10] = {1, 2, 3}; // assigment to `myArray`
+char chars1[] = "abc"; // assignment to `chars1` (literal "abc" has no location)
+char chars2[] = {'a', 'b', 'c'}; // assigment to `chars2`
+char *chars3 = "abc"; // assigment to `chars3`

--- a/cpp/ql/test/library-tests/variables/getanassignedvalue/test.cpp
+++ b/cpp/ql/test/library-tests/variables/getanassignedvalue/test.cpp
@@ -1,0 +1,25 @@
+
+void test1()
+{
+	int v = 10; // assignment to `v`
+	int *ptr_v = &v; // assignment to `ptr_v`
+	int &ref_v = v; // assignment to `ref_v`
+
+	v = 11; // assignment to `v`
+	*ptr_v = 12;
+	ref_v = 13; // assignment to `ref_v`
+	v = v + 1; // assignment to `v`
+	v += 1;
+	v++;
+}
+
+class myClass1
+{
+public:
+	myClass1(float _x, float _y = 0.0f) : x(_x), y(_y), z(0.0f) { // assignments to `_y`, `x`, `y`, `z`
+		// ...
+	}
+
+private:
+	float x, y, z;
+};

--- a/cpp/ql/test/library-tests/variables/getanassignedvalue/test.cpp
+++ b/cpp/ql/test/library-tests/variables/getanassignedvalue/test.cpp
@@ -32,10 +32,10 @@ struct myStruct1
 	const char *str;
 };
 
-myStruct1 v1 = {1, "One"}; // assigment to `v1`
-myStruct1 v2 = {.num = 2, .str = "Two"}; // assigment to `v2`
+myStruct1 v1 = {1, "One"}; // assigments to `v1`, `num`, `str`
+myStruct1 v2 = {.num = 2, .str = "Two"}; // assigments to `v2`, `num`, `str`
 
-void test2(myStruct1 v = {3, "Three"}) // assignment to `v` (literal `{...}` has no location)
+void test2(myStruct1 v = {3, "Three"}) // assignments to `v` (literal `{...}` has no location), `num`, `str`
 {
 	// ...
 }
@@ -45,7 +45,7 @@ struct myStruct2
 	myStruct1 ms2;
 };
 
-myStruct2 v3 = {{4, "Four"}}; // assigment to `v3`
+myStruct2 v3 = {{4, "Four"}}; // assigments to `v3`, `ms2`, `num`, `str`
 
 // ---
 


### PR DESCRIPTION
This is a small tweak of @pavgust's solution that was discussed on Slack.

I added a test, integrated the change into `Variable.getAnAssignedValue()`, and added a `pragma[nomagic]` on `Field.getInitializationOrder`.  This was because some queries such as 'FileMayNotBeClosed.ql' that use `getAnAssignedValue()` are now using `getInitializationOrder()` for the first time and this exposed performance issues including query timeouts.

I plan to a query differences job for this but I haven't yet got one to complete successfully.