### PR TITLE
JS: split CodeInjection.qll into three parts

### DIFF
--- a/javascript/ql/src/semmle/javascript/heuristics/AdditionalSinks.qll
+++ b/javascript/ql/src/semmle/javascript/heuristics/AdditionalSinks.qll
@@ -6,7 +6,7 @@
 
 import javascript
 private import SyntacticHeuristics
-private import semmle.javascript.security.dataflow.CodeInjection
+private import semmle.javascript.security.dataflow.CodeInjectionCustomizations
 private import semmle.javascript.security.dataflow.CommandInjection
 private import semmle.javascript.security.dataflow.DomBasedXss as DomBasedXss
 private import semmle.javascript.security.dataflow.ReflectedXss as ReflectedXss

--- a/javascript/ql/src/semmle/javascript/security/dataflow/CodeInjection.qll
+++ b/javascript/ql/src/semmle/javascript/security/dataflow/CodeInjection.qll
@@ -1,25 +1,16 @@
 /**
- * Provides a taint-tracking configuration for reasoning about code injection.
+ * Provides a taint-tracking configuration for reasoning about code
+ * injection vulnerabilities.
+ *
+ * Note, for performance reasons: only import this file if
+ * `CodeInjection::Configuration` is needed, otherwise
+ * `CodeInjectionCustomizations` should be imported instead.
  */
 
 import javascript
-import semmle.javascript.security.dataflow.RemoteFlowSources
 
 module CodeInjection {
-  /**
-   * A data flow source for code injection vulnerabilities.
-   */
-  abstract class Source extends DataFlow::Node { }
-
-  /**
-   * A data flow sink for code injection vulnerabilities.
-   */
-  abstract class Sink extends DataFlow::Node { }
-
-  /**
-   * A sanitizer for code injection vulnerabilities.
-   */
-  abstract class Sanitizer extends DataFlow::Node { }
+  import CodeInjectionCustomizations::CodeInjection
 
   /**
    * A taint-tracking configuration for reasoning about code injection vulnerabilities.
@@ -40,86 +31,6 @@ module CodeInjection {
     override predicate isAdditionalTaintStep(DataFlow::Node src, DataFlow::Node trg) {
       // HTML sanitizers are insufficient protection against code injection
       src = trg.(HtmlSanitizerCall).getInput()
-    }
-  }
-
-  /** A source of remote user input, considered as a flow source for code injection. */
-  class RemoteFlowSourceAsSource extends Source {
-    RemoteFlowSourceAsSource() { this instanceof RemoteFlowSource }
-  }
-
-  /**
-   * An access to a property that may hold (parts of) the document URL.
-   */
-  class LocationSource extends Source {
-    LocationSource() { this = DOM::locationSource() }
-  }
-
-  /**
-   * An expression which may be interpreted as an AngularJS expression.
-   */
-  class AngularJSExpressionSink extends Sink, DataFlow::ValueNode {
-    AngularJSExpressionSink() {
-      any(AngularJS::AngularJSCall call).interpretsArgumentAsCode(this.asExpr())
-    }
-  }
-
-  /**
-   * An expression which may be evaluated as JavaScript in NodeJS using the
-   * `vm` module.
-   */
-  class NodeJSVmSink extends Sink, DataFlow::ValueNode {
-    NodeJSVmSink() { exists(NodeJSLib::VmModuleMethodCall call | this = call.getACodeArgument()) }
-  }
-
-  /**
-   * An expression which may be evaluated as JavaScript.
-   */
-  class EvalJavaScriptSink extends Sink, DataFlow::ValueNode {
-    EvalJavaScriptSink() {
-      exists(DataFlow::InvokeNode c, int index |
-        exists(string callName | c = DataFlow::globalVarRef(callName).getAnInvocation() |
-          callName = "eval" and index = 0
-          or
-          callName = "Function"
-          or
-          callName = "execScript" and index = 0
-          or
-          callName = "executeJavaScript" and index = 0
-          or
-          callName = "execCommand" and index = 0
-          or
-          callName = "setTimeout" and index = 0
-          or
-          callName = "setInterval" and index = 0
-          or
-          callName = "setImmediate" and index = 0
-        )
-        or
-        exists(DataFlow::GlobalVarRefNode wasm, string methodName |
-          wasm.getName() = "WebAssembly" and c = wasm.getAMemberCall(methodName)
-        |
-          methodName = "compile" or
-          methodName = "compileStreaming"
-        )
-      |
-        this = c.getArgument(index)
-      )
-    }
-  }
-
-  /**
-   * An expression which is injected as JavaScript into a React Native `WebView`.
-   */
-  class WebViewInjectedJavaScriptSink extends Sink {
-    WebViewInjectedJavaScriptSink() {
-      exists(ReactNative::WebViewElement webView |
-        // `injectedJavaScript` property of React Native `WebView`
-        this = webView.getAPropertyWrite("injectedJavaScript").getRhs()
-        or
-        // argument to `injectJavascript` method of React Native `WebView`
-        this = webView.getAMethodCall("injectJavaScript").getArgument(0)
-      )
     }
   }
 }

--- a/javascript/ql/src/semmle/javascript/security/dataflow/CodeInjectionCustomizations.qll
+++ b/javascript/ql/src/semmle/javascript/security/dataflow/CodeInjectionCustomizations.qll
@@ -1,0 +1,104 @@
+/**
+ * Provides default sources, sinks and sanitisers for reasoning about
+ * code injection vulnerabilities, as well as extension points for
+ * adding your own.
+ */
+
+import javascript
+
+module CodeInjection {
+  /**
+   * A data flow source for code injection vulnerabilities.
+   */
+  abstract class Source extends DataFlow::Node { }
+
+  /**
+   * A data flow sink for code injection vulnerabilities.
+   */
+  abstract class Sink extends DataFlow::Node { }
+
+  /**
+   * A sanitizer for code injection vulnerabilities.
+   */
+  abstract class Sanitizer extends DataFlow::Node { }
+
+  /** A source of remote user input, considered as a flow source for code injection. */
+  class RemoteFlowSourceAsSource extends Source {
+    RemoteFlowSourceAsSource() { this instanceof RemoteFlowSource }
+  }
+
+  /**
+   * An access to a property that may hold (parts of) the document URL.
+   */
+  class LocationSource extends Source {
+    LocationSource() { this = DOM::locationSource() }
+  }
+
+  /**
+   * An expression which may be interpreted as an AngularJS expression.
+   */
+  class AngularJSExpressionSink extends Sink, DataFlow::ValueNode {
+    AngularJSExpressionSink() {
+      any(AngularJS::AngularJSCall call).interpretsArgumentAsCode(this.asExpr())
+    }
+  }
+
+  /**
+   * An expression which may be evaluated as JavaScript in NodeJS using the
+   * `vm` module.
+   */
+  class NodeJSVmSink extends Sink, DataFlow::ValueNode {
+    NodeJSVmSink() { exists(NodeJSLib::VmModuleMethodCall call | this = call.getACodeArgument()) }
+  }
+
+  /**
+   * An expression which may be evaluated as JavaScript.
+   */
+  class EvalJavaScriptSink extends Sink, DataFlow::ValueNode {
+    EvalJavaScriptSink() {
+      exists(DataFlow::InvokeNode c, int index |
+        exists(string callName | c = DataFlow::globalVarRef(callName).getAnInvocation() |
+          callName = "eval" and index = 0
+          or
+          callName = "Function"
+          or
+          callName = "execScript" and index = 0
+          or
+          callName = "executeJavaScript" and index = 0
+          or
+          callName = "execCommand" and index = 0
+          or
+          callName = "setTimeout" and index = 0
+          or
+          callName = "setInterval" and index = 0
+          or
+          callName = "setImmediate" and index = 0
+        )
+        or
+        exists(DataFlow::GlobalVarRefNode wasm, string methodName |
+          wasm.getName() = "WebAssembly" and c = wasm.getAMemberCall(methodName)
+        |
+          methodName = "compile" or
+          methodName = "compileStreaming"
+        )
+      |
+        this = c.getArgument(index)
+      )
+    }
+  }
+
+  /**
+   * An expression which is injected as JavaScript into a React Native `WebView`.
+   */
+  class WebViewInjectedJavaScriptSink extends Sink {
+    WebViewInjectedJavaScriptSink() {
+      exists(ReactNative::WebViewElement webView |
+        // `injectedJavaScript` property of React Native `WebView`
+        this = webView.getAPropertyWrite("injectedJavaScript").getRhs()
+        or
+        // argument to `injectJavascript` method of React Native `WebView`
+        this = webView.getAMethodCall("injectJavaScript").getArgument(0)
+      )
+    }
+  }
+}


### PR DESCRIPTION
Splits `CodeInjection.qll` into three parts, primarily to allow for avoiding module activation of file modules that contain `Configuration` classes. This allows us to extend the sinks and sources of a `Configuration` without causing a serious compilation speed or query speed degradation. That is the motivation for introducing `CodeInjection/Configration.qll` and `CodeInjection/Interface.qll`.

The related, but less important, introduction of `CodeInjection/Implementation.qll` allows reusing the `Configuration` in queries with a specialized set of sinks and sources.

The `CodeInjection/Implementation.qll` design is not yet optimal, since it introduces sources and sinks when it is imported. This makes it slightly tricky to make a query that reuses all of the default sources, but none of the default sinks (this design is useful to avoid double flagging with similar queries). If we find the need, we can introduce yet another layer of abstract classes to support that use case, the current design does not prevent us from doing that later.

If you agree with this design and naming scheme. Then I will apply similar transformations to at least the queries that `javascript/heuristics/all.qll` improve.