### PR TITLE
C#: Break up a big cached stage into multiple stages

### DIFF
--- a/csharp/ql/src/semmle/code/cil/BasicBlock.qll
+++ b/csharp/ql/src/semmle/code/cil/BasicBlock.qll
@@ -8,7 +8,7 @@ private import CIL
  * A basic block, that is, a maximal straight-line sequence of control flow nodes
  * without branches or joins.
  */
-class BasicBlock extends Internal::TBasicBlockStart {
+class BasicBlock extends Cached::TBasicBlockStart {
   /** Gets an immediate successor of this basic block, if any. */
   BasicBlock getASuccessor() { result.getFirstNode() = getLastNode().getASuccessor() }
 
@@ -52,13 +52,13 @@ class BasicBlock extends Internal::TBasicBlockStart {
   BasicBlock getAFalseSuccessor() { result.getFirstNode() = getLastNode().getFalseSuccessor() }
 
   /** Gets the control flow node at a specific (zero-indexed) position in this basic block. */
-  ControlFlowNode getNode(int pos) { Internal::bbIndex(getFirstNode(), result, pos) }
+  ControlFlowNode getNode(int pos) { Cached::bbIndex(getFirstNode(), result, pos) }
 
   /** Gets a control flow node in this basic block. */
   ControlFlowNode getANode() { result = getNode(_) }
 
   /** Gets the first control flow node in this basic block. */
-  ControlFlowNode getFirstNode() { this = Internal::TBasicBlockStart(result) }
+  ControlFlowNode getFirstNode() { this = Cached::TBasicBlockStart(result) }
 
   /** Gets the last control flow node in this basic block. */
   ControlFlowNode getLastNode() { result = getNode(length() - 1) }
@@ -246,7 +246,7 @@ class BasicBlock extends Internal::TBasicBlockStart {
  * Internal implementation details.
  */
 cached
-private module Internal {
+private module Cached {
   /** Internal representation of basic blocks. */
   cached
   newtype TBasicBlock = TBasicBlockStart(ControlFlowNode cfn) { startsBB(cfn) }

--- a/csharp/ql/src/semmle/code/cil/CallableReturns.qll
+++ b/csharp/ql/src/semmle/code/cil/CallableReturns.qll
@@ -41,9 +41,7 @@ private predicate alwaysNullExpr(Expr expr) {
   or
   alwaysNullMethod(expr.(StaticCall).getTarget())
   or
-  forex(VariableUpdate vu | DefUse::variableUpdateUse(_, vu, expr) |
-    alwaysNullVariableUpdate(vu)
-  )
+  forex(VariableUpdate vu | DefUse::variableUpdateUse(_, vu, expr) | alwaysNullVariableUpdate(vu))
 }
 
 pragma[noinline]

--- a/csharp/ql/src/semmle/code/csharp/Caching.qll
+++ b/csharp/ql/src/semmle/code/csharp/Caching.qll
@@ -1,0 +1,81 @@
+private import csharp
+
+/**
+ * INTERNAL: Do not use.
+ *
+ * Provides modules and predicates for enforcing evaluation of cached predicates
+ * in the same stage across different files.
+ */
+module Stages {
+  cached
+  module ControlFlowStage {
+    private import semmle.code.csharp.controlflow.internal.Splitting
+    private import semmle.code.csharp.controlflow.internal.SuccessorType
+    private import semmle.code.csharp.controlflow.Guards as Guards
+
+    cached
+    predicate forceCachingInSameStage() { any() }
+
+    cached
+    private predicate forceCachingInSameStageRev() {
+      exists(SplitImpl si)
+      or
+      exists(SuccessorType st)
+      or
+      exists(ControlFlow::Node n)
+      or
+      Guards::Internal::isCustomNullCheck(_, _, _, _)
+      or
+      forceCachingInSameStageRev()
+    }
+  }
+
+  cached
+  module GuardsStage {
+    private import semmle.code.csharp.controlflow.Guards
+
+    cached
+    predicate forceCachingInSameStage() { any() }
+
+    cached
+    private predicate forceCachingInSameStageRev() {
+      any(ControlFlowElement cfe).controlsBlock(_, _)
+      or
+      exists(GuardedExpr ge)
+      or
+      forceCachingInSameStageRev()
+    }
+  }
+
+  cached
+  module DataFlowStage {
+    private import semmle.code.csharp.dataflow.internal.DataFlowPrivate
+    private import semmle.code.csharp.dataflow.internal.DataFlowImplCommon
+
+    cached
+    predicate forceCachingInSameStage() { any() }
+
+    cached
+    private predicate forceCachingInSameStageRev() {
+      TaintTracking::localTaintStep(_, _)
+      or
+      any(ArgumentNode n).argumentOf(_, _)
+      or
+      exists(any(DataFlow::Node n).getEnclosingCallable())
+      or
+      exists(any(DataFlow::Node n).getControlFlowNode())
+      or
+      exists(any(DataFlow::Node n).getType())
+      or
+      exists(any(DataFlow::Node n).getLocation())
+      or
+      exists(any(DataFlow::Node n).toString())
+      or
+      exists(any(OutNode n).getCall())
+      or
+      exists(CallContext cc)
+      or
+      forceCachingInSameStageRev()
+    }
+  }
+}

--- a/csharp/ql/src/semmle/code/csharp/Element.qll
+++ b/csharp/ql/src/semmle/code/csharp/Element.qll
@@ -18,11 +18,11 @@ class Element extends DotNet::Element, @element {
   override string toStringWithTypes() { result = this.toString() }
 
   /**
-   * Gets the location of this element, if any.
-   * Where an element has multiple locations (for example a source file and an assembly),
-   * gets only the source location.
+   * Gets the location of this element. Where an element has locations in
+   * source and assemblies, choose the source location. If there are multiple
+   * assembly locations, choose only one.
    */
-  final override Location getLocation() { result = ExprOrStmtParentCached::bestLocation(this) }
+  final override Location getLocation() { result = bestLocation(this) }
 
   /** Gets a location of this element, including sources and assemblies. */
   override Location getALocation() { none() }

--- a/csharp/ql/src/semmle/code/csharp/ExprOrStmtParent.qll
+++ b/csharp/ql/src/semmle/code/csharp/ExprOrStmtParent.qll
@@ -241,24 +241,6 @@ class MultiImplementationsParent extends ExprOrStmtParent {
   }
 }
 
-/**
- * INTERNAL: Do not use.
- *
- * Holds if accessor `a` has an auto-implementation in file `f`.
- */
-predicate hasAccessorAutoImplementation(Accessor a, File f) {
-  exists(SourceLocation sl | sl = a.getALocation() |
-    f = sl.getFile() and
-    not exists(ControlFlowElement cfe, Location l | sl.getFile() = l.getFile() |
-      stmt_parent_top_level(cfe, _, a) and
-      stmt_location(cfe, l)
-      or
-      expr_parent_top_level_adjusted(cfe, 0, a) and
-      expr_location(cfe, l)
-    )
-  )
-}
-
 /** Gets the top-level type containing declaration `d`. */
 private ValueOrRefType getTopLevelDeclaringType(Declaration d) {
   result = getDeclaringType+(d) and
@@ -332,8 +314,24 @@ private int getImplementationSize(ValueOrRefType t, File f) {
   else result = getImplementationSize1(t, f)
 }
 
+/**
+ * Holds if declaration `d` should have a location in file `f`, because it is part of a
+ * type with multiple implementations, where the most likely run-time implementation is
+ * in `f`.
+ */
+private predicate mustHaveLocationInFile(Declaration d, File f) {
+  exists(MultiImplementationsParent p, ValueOrRefType t |
+    t = getTopLevelDeclaringType(p) and
+    f = p.getBestFile()
+  |
+    t = getTopLevelDeclaringType(d) or d = t or d = p
+  )
+}
+
+private predicate hasNoSourceLocation(Element e) { not e.getALocation() instanceof SourceLocation }
+
 cached
-module ExprOrStmtParentCached {
+private module Cached {
   cached
   ControlFlowElement getTopLevelChild(ExprOrStmtParent p, int i) {
     result = p.(MultiImplementationsParent).getBestChild(i)
@@ -342,32 +340,6 @@ module ExprOrStmtParentCached {
     (stmt_parent_top_level(result, i, p) or expr_parent_top_level_adjusted(result, i, p))
   }
 
-  /**
-   * INTERNAL: Do not use.
-   *
-   * Holds if declaration `d` should have a location in file `f`, because it is part of a
-   * type with multiple implementations, where the most likely run-time implementation is
-   * in `f`.
-   */
-  cached
-  predicate mustHaveLocationInFile(Declaration d, File f) {
-    exists(MultiImplementationsParent p, ValueOrRefType t |
-      t = getTopLevelDeclaringType(p) and
-      f = p.getBestFile()
-    |
-      t = getTopLevelDeclaringType(d) or d = t or d = p
-    )
-  }
-
-  private predicate hasNoSourceLocation(Element e) {
-    not e.getALocation() instanceof SourceLocation
-  }
-
-  /**
-   * Gets the "best" location for element `e`. Where an element has locations in
-   * source and assemblies, choose the source location. If there are multiple assembly
-   * locations, choose only one.
-   */
   cached
   Location bestLocation(Element e) {
     result = e.getALocation().(SourceLocation) and
@@ -379,5 +351,24 @@ module ExprOrStmtParentCached {
     not exists(e.getALocation()) and
     result instanceof EmptyLocation
   }
+
+  /**
+   * INTERNAL: Do not use.
+   *
+   * Holds if accessor `a` has an auto-implementation in file `f`.
+   */
+  cached
+  predicate hasAccessorAutoImplementation(Accessor a, File f) {
+    exists(SourceLocation sl | sl = a.getALocation() |
+      f = sl.getFile() and
+      not exists(ControlFlowElement cfe, Location l | sl.getFile() = l.getFile() |
+        stmt_parent_top_level(cfe, _, a) and
+        stmt_location(cfe, l)
+        or
+        expr_parent_top_level_adjusted(cfe, 0, a) and
+        expr_location(cfe, l)
+      )
+    )
+  }
 }
-private import ExprOrStmtParentCached
+import Cached

--- a/csharp/ql/src/semmle/code/csharp/Implements.qll
+++ b/csharp/ql/src/semmle/code/csharp/Implements.qll
@@ -9,7 +9,6 @@
 
 import csharp
 private import Conversion
-private import dispatch.Dispatch
 
 /**
  * INTERNAL: Do not use.

--- a/csharp/ql/src/semmle/code/csharp/Stmt.qll
+++ b/csharp/ql/src/semmle/code/csharp/Stmt.qll
@@ -1303,9 +1303,7 @@ class UsingDeclStmt extends LocalVariableDeclStmt, UsingStmt, @using_decl_stmt {
     result = LocalVariableDeclStmt.super.getVariableDeclExpr(n)
   }
 
-  override Expr getAnExpr() {
-    result = this.getAVariableDeclExpr().getInitializer()
-  }
+  override Expr getAnExpr() { result = this.getAVariableDeclExpr().getInitializer() }
 }
 
 /**

--- a/csharp/ql/src/semmle/code/csharp/controlflow/ControlFlowElement.qll
+++ b/csharp/ql/src/semmle/code/csharp/controlflow/ControlFlowElement.qll
@@ -5,6 +5,7 @@ private import semmle.code.csharp.ExprOrStmtParent
 private import ControlFlow
 private import ControlFlow::BasicBlocks
 private import SuccessorTypes
+private import semmle.code.csharp.Caching
 
 /**
  * A program element that can possess control flow. That is, either a statement or
@@ -156,6 +157,7 @@ class ControlFlowElement extends ExprOrStmtParent, @control_flow_element {
 
   cached
   private predicate controlsBlockSplit(BasicBlock controlled, ConditionalSuccessor s) {
+    Stages::GuardsStage::forceCachingInSameStage() and
     this.immediatelyControlsBlockSplit(controlled, s)
     or
     // Equivalent with

--- a/csharp/ql/src/semmle/code/csharp/controlflow/ControlFlowGraph.qll
+++ b/csharp/ql/src/semmle/code/csharp/controlflow/ControlFlowGraph.qll
@@ -1972,8 +1972,7 @@ module ControlFlow {
 
     cached
     private module Cached {
-      cached
-      predicate forceCachingInSameStage() { any() }
+      private import semmle.code.csharp.Caching
 
       /**
        * Internal representation of control flow nodes in the control flow graph.
@@ -1981,7 +1980,10 @@ module ControlFlow {
        */
       cached
       newtype TNode =
-        TEntryNode(Callable c) { succEntrySplits(c, _, _, _) } or
+        TEntryNode(Callable c) {
+          Stages::ControlFlowStage::forceCachingInSameStage() and
+          succEntrySplits(c, _, _, _)
+        } or
         TExitNode(Callable c) {
           exists(Reachability::SameSplitsBlock b | b.isReachable(_) |
             succExitSplits(b.getAnElement(), _, c, _)

--- a/csharp/ql/src/semmle/code/csharp/controlflow/internal/PreSsa.qll
+++ b/csharp/ql/src/semmle/code/csharp/controlflow/internal/PreSsa.qll
@@ -50,11 +50,8 @@ private predicate phiNodeMaybeLive(PreBasicBlock bb, SimpleAssignable a) {
   exists(PreBasicBlock def | defAt(def, _, _, a) | def.inDominanceFrontier(bb))
 }
 
-cached
 private newtype TPreSsaDef =
   TExplicitPreSsaDef(PreBasicBlock bb, int i, AssignableDefinition def, SimpleAssignable a) {
-    Guards::Internal::CachedWithCFG::forceCachingInSameStage() and
-    ControlFlow::Internal::forceCachingInSameStage() and
     assignableDefAtLive(bb, i, def, a)
   } or
   TImplicitEntryPreSsaDef(Callable c, PreBasicBlock bb, Assignable a) {
@@ -124,6 +121,11 @@ class Definition extends TPreSsaDef {
       bb.getAPredecessor() = phiPred and
       ssaDefReachesEndOfBlock(phiPred, result, a)
     )
+  }
+
+  Definition getAnUltimateDefinition() {
+    result = this.getAPhiInput*() and
+    not this = TPhiPreSsaDef(_, _)
   }
 }
 

--- a/csharp/ql/src/semmle/code/csharp/controlflow/internal/Splitting.qll
+++ b/csharp/ql/src/semmle/code/csharp/controlflow/internal/Splitting.qll
@@ -18,10 +18,12 @@ private int maxSplits() { result = 7 }
 
 cached
 private module Cached {
+  private import semmle.code.csharp.Caching
+
   cached
   newtype TBooleanSplitSubKind =
     TSsaBooleanSplitSubKind(PreSsa::Definition def) {
-      ControlFlow::Internal::forceCachingInSameStage()
+      Stages::ControlFlowStage::forceCachingInSameStage()
     }
 
   cached

--- a/csharp/ql/src/semmle/code/csharp/controlflow/internal/SuccessorType.qll
+++ b/csharp/ql/src/semmle/code/csharp/controlflow/internal/SuccessorType.qll
@@ -6,10 +6,11 @@
 
 import csharp
 private import semmle.code.csharp.controlflow.internal.Completion
+private import semmle.code.csharp.Caching
 
 cached
 private newtype TSuccessorType =
-  TSuccessorSuccessor() { ControlFlow::Internal::forceCachingInSameStage() } or
+  TSuccessorSuccessor() { Stages::ControlFlowStage::forceCachingInSameStage() } or
   TBooleanSuccessor(boolean b) { b = true or b = false } or
   TNullnessSuccessor(boolean isNull) { isNull = true or isNull = false } or
   TMatchingSuccessor(boolean isMatch) { isMatch = true or isMatch = false } or

--- a/csharp/ql/src/semmle/code/csharp/dataflow/Nullness.qll
+++ b/csharp/ql/src/semmle/code/csharp/dataflow/Nullness.qll
@@ -35,11 +35,17 @@ class MaybeNullExpr extends Expr {
     or
     this instanceof AsExpr
     or
-    exists(MaybeNullExpr e | G::Internal::nullValueImpliedUnary(e, this))
+    this.(AssignExpr).getRValue() instanceof MaybeNullExpr
     or
-    exists(MaybeNullExpr e | G::Internal::nullValueImpliedBinary(e, _, this))
+    this.(Cast).getExpr() instanceof MaybeNullExpr
     or
-    exists(MaybeNullExpr e | G::Internal::nullValueImpliedBinary(_, e, this))
+    this = any(ConditionalExpr ce |
+        ce.getThen() instanceof MaybeNullExpr
+        or
+        ce.getElse() instanceof MaybeNullExpr
+      )
+    or
+    this.(NullCoalescingExpr).getRightOperand() instanceof MaybeNullExpr
   }
 }
 

--- a/csharp/ql/src/semmle/code/csharp/dataflow/Nullness.qll
+++ b/csharp/ql/src/semmle/code/csharp/dataflow/Nullness.qll
@@ -31,35 +31,26 @@ private import semmle.code.csharp.frameworks.Test
 /** An expression that may be `null`. */
 class MaybeNullExpr extends Expr {
   MaybeNullExpr() {
-    this instanceof NullLiteral
-    or
-    this.(ConditionalExpr).getThen() instanceof MaybeNullExpr
-    or
-    this.(ConditionalExpr).getElse() instanceof MaybeNullExpr
-    or
-    this.(AssignExpr).getRValue() instanceof MaybeNullExpr
-    or
-    this.(Cast).getExpr() instanceof MaybeNullExpr
+    G::Internal::nullValue(this)
     or
     this instanceof AsExpr
+    or
+    exists(MaybeNullExpr e | G::Internal::nullValueImpliedUnary(e, this))
+    or
+    exists(MaybeNullExpr e | G::Internal::nullValueImpliedBinary(e, _, this))
+    or
+    exists(MaybeNullExpr e | G::Internal::nullValueImpliedBinary(_, e, this))
   }
 }
 
 /** An expression that is always `null`. */
 class AlwaysNullExpr extends Expr {
   AlwaysNullExpr() {
-    this instanceof NullLiteral
+    G::Internal::nullValue(this)
     or
-    this = any(ConditionalExpr ce |
-        ce.getThen() instanceof AlwaysNullExpr and
-        ce.getElse() instanceof AlwaysNullExpr
-      )
+    exists(AlwaysNullExpr e | G::Internal::nullValueImpliedUnary(e, this))
     or
-    this.(AssignExpr).getRValue() instanceof AlwaysNullExpr
-    or
-    this.(Cast).getExpr() instanceof AlwaysNullExpr
-    or
-    this instanceof DefaultValueExpr and this.getType().isRefType()
+    exists(AlwaysNullExpr e1, AlwaysNullExpr e2 | G::Internal::nullValueImpliedBinary(e1, e2, this))
     or
     this = any(Ssa::Definition def |
         forex(Ssa::Definition u | u = def.getAnUltimateDefinition() | nullDef(u))
@@ -83,7 +74,7 @@ class NonNullExpr extends Expr {
   NonNullExpr() {
     G::Internal::nonNullValue(this)
     or
-    exists(NonNullExpr mid | G::Internal::nonNullValueImplied(mid, this))
+    exists(NonNullExpr mid | G::Internal::nonNullValueImpliedUnary(mid, this))
     or
     this instanceof G::NullGuardedExpr
     or

--- a/csharp/ql/src/semmle/code/csharp/dataflow/TaintTracking.qll
+++ b/csharp/ql/src/semmle/code/csharp/dataflow/TaintTracking.qll
@@ -221,11 +221,11 @@ module TaintTracking {
 
     cached
     module Cached {
-      cached
-      predicate forceCachingInSameStage() { DataFlowPrivateCached::forceCachingInSameStage() }
+      private import semmle.code.csharp.Caching
 
       cached
       predicate localAdditionalTaintStep(DataFlow::Node nodeFrom, DataFlow::Node nodeTo) {
+        Stages::DataFlowStage::forceCachingInSameStage() and
         any(LocalTaintExprStepConfiguration x).hasNodePath(nodeFrom, nodeTo)
         or
         nodeTo = nodeFrom.(TaintedParameterNode).getUnderlyingNode()

--- a/csharp/ql/src/semmle/code/csharp/dataflow/internal/DataFlowDispatch.qll
+++ b/csharp/ql/src/semmle/code/csharp/dataflow/internal/DataFlowDispatch.qll
@@ -68,16 +68,11 @@ private predicate transitiveCapturedCallTarget(ControlFlow::Nodes::ElementNode c
 cached
 private module Cached {
   private import CallContext
-
-  cached
-  module DataFlowDispatchCached {
-    cached
-    predicate forceCachingInSameStage() { DataFlowPrivateCached::forceCachingInSameStage() }
-  }
+  private import semmle.code.csharp.Caching
 
   cached
   newtype TReturnKind =
-    TNormalReturnKind() or
+    TNormalReturnKind() { Stages::DataFlowStage::forceCachingInSameStage() } or
     TYieldReturnKind() or
     TOutReturnKind(int i) {
       exists(Parameter p | callableReturnsOutOrRef(_, p, _) and p.isOut() | i = p.getPosition())

--- a/csharp/ql/test/library-tests/cil/dataflow/Nullness.expected
+++ b/csharp/ql/test/library-tests/cil/dataflow/Nullness.expected
@@ -1,6 +1,7 @@
 alwaysNull
 | dataflow.cs:70:21:70:35 | default(...) |
 | dataflow.cs:74:21:74:34 | call to method NullFunction |
+| dataflow.cs:74:21:74:52 | ... ?? ... |
 | dataflow.cs:74:39:74:52 | call to method IndirectNull |
 | dataflow.cs:78:21:78:45 | call to method ReturnsNull |
 | dataflow.cs:79:21:79:46 | call to method ReturnsNull2 |

--- a/csharp/ql/test/library-tests/controlflow/guards/Implications.expected
+++ b/csharp/ql/test/library-tests/controlflow/guards/Implications.expected
@@ -257,10 +257,14 @@
 | Guards.cs:108:27:108:36 | access to property Property | null | Guards.cs:106:22:106:25 | null | null |
 | Guards.cs:113:13:114:38 | String dummy = ... | non-null | Guards.cs:113:13:113:17 | access to local variable dummy | non-null |
 | Guards.cs:113:13:114:38 | String dummy = ... | null | Guards.cs:113:13:113:17 | access to local variable dummy | null |
+| Guards.cs:113:21:114:38 | ... ?? ... | null | Guards.cs:113:21:113:45 | access to field Field | null |
+| Guards.cs:113:21:114:38 | ... ?? ... | null | Guards.cs:114:14:114:38 | access to field Field | null |
 | Guards.cs:115:9:115:55 | ... = ... | non-null | Guards.cs:115:9:115:13 | access to local variable dummy | non-null |
 | Guards.cs:115:9:115:55 | ... = ... | non-null | Guards.cs:115:17:115:55 | ... ?? ... | non-null |
 | Guards.cs:115:9:115:55 | ... = ... | null | Guards.cs:115:9:115:13 | access to local variable dummy | null |
 | Guards.cs:115:9:115:55 | ... = ... | null | Guards.cs:115:17:115:55 | ... ?? ... | null |
+| Guards.cs:115:17:115:55 | ... ?? ... | null | Guards.cs:115:17:115:41 | access to field Field | null |
+| Guards.cs:115:17:115:55 | ... ?? ... | null | Guards.cs:115:46:115:55 | throw ... | null |
 | Guards.cs:117:9:117:25 | ... = ... | non-null | Guards.cs:117:9:117:18 | access to property Property | non-null |
 | Guards.cs:117:9:117:25 | ... = ... | non-null | Guards.cs:117:22:117:25 | null | non-null |
 | Guards.cs:117:9:117:25 | ... = ... | null | Guards.cs:117:9:117:18 | access to property Property | null |

--- a/csharp/ql/test/library-tests/dataflow/local/Common.qll
+++ b/csharp/ql/test/library-tests/dataflow/local/Common.qll
@@ -13,7 +13,7 @@ class MyFlowSource extends DataFlow::Node {
     this.asParameter().hasName("tainted")
     or
     exists(Expr e |
-      this = DataFlowPrivateCached::TImplicitDelegateOutNode(e.getAControlFlowNode(), _)
+      this = TImplicitDelegateOutNode(e.getAControlFlowNode(), _)
     |
       e.(DelegateCreation).getArgument().(MethodAccess).getTarget().hasName("TaintedMethod") or
       e.(LambdaExpr).getExpressionBody().(StringLiteral).getValue() = "taint source"

--- a/csharp/ql/test/query-tests/Nullness/E.cs
+++ b/csharp/ql/test/query-tests/Nullness/E.cs
@@ -315,6 +315,33 @@ public class E
 
     public bool Field;
     string Make() => Field ? null : "";
+
+    static void Ex27(string s1, string s2)
+    {
+        if ((s1 ?? s2) is null)
+        {
+            s1.ToString(); // BAD (always)
+            s2.ToString(); // BAD (always)
+        }
+    }
+
+    static void Ex28()
+    {
+        var x = (string)null ?? null;
+        x.ToString(); // BAD (always)
+    }
+
+    static void Ex29(string s)
+    {
+        var x = s ?? "";
+        x.ToString(); // GOOD
+    }
+
+    static void Ex30(string s, object o)
+    {
+        var x = s ?? o as string;
+        x.ToString(); // BAD (maybe)
+    }
 }
 
 public static class Extensions

--- a/csharp/ql/test/query-tests/Nullness/EqualityCheck.expected
+++ b/csharp/ql/test/query-tests/Nullness/EqualityCheck.expected
@@ -215,6 +215,7 @@
 | E.cs:274:17:274:25 | ... != ... | false | E.cs:274:22:274:25 | null | E.cs:274:17:274:17 | access to local variable o |
 | E.cs:293:13:293:24 | ... == ... | true | E.cs:293:15:293:19 | call to method M2 | E.cs:293:24:293:24 | (...) ... |
 | E.cs:293:13:293:24 | ... == ... | true | E.cs:293:24:293:24 | (...) ... | E.cs:293:15:293:19 | call to method M2 |
+| E.cs:321:13:321:30 | ... is ... | true | E.cs:321:14:321:21 | ... ?? ... | E.cs:321:27:321:30 | null |
 | Forwarding.cs:59:13:59:21 | ... == ... | true | Forwarding.cs:59:13:59:13 | access to parameter o | Forwarding.cs:59:18:59:21 | null |
 | Forwarding.cs:59:13:59:21 | ... == ... | true | Forwarding.cs:59:18:59:21 | null | Forwarding.cs:59:13:59:13 | access to parameter o |
 | Forwarding.cs:78:16:78:39 | call to method ReferenceEquals | true | Forwarding.cs:78:32:78:32 | access to parameter o | Forwarding.cs:78:35:78:38 | null |

--- a/csharp/ql/test/query-tests/Nullness/Implications.expected
+++ b/csharp/ql/test/query-tests/Nullness/Implications.expected
@@ -1488,6 +1488,30 @@
 | E.cs:317:22:317:38 | ... ? ... : ... | non-null | E.cs:317:37:317:38 | "" | non-null |
 | E.cs:317:22:317:38 | ... ? ... : ... | null | E.cs:317:22:317:26 | access to field Field | true |
 | E.cs:317:22:317:38 | ... ? ... : ... | null | E.cs:317:30:317:33 | null | null |
+| E.cs:321:13:321:30 | ... is ... | false | E.cs:321:14:321:21 | ... ?? ... | non-null |
+| E.cs:321:13:321:30 | ... is ... | true | E.cs:321:14:321:21 | ... ?? ... | null |
+| E.cs:321:14:321:21 | ... ?? ... | null | E.cs:321:14:321:15 | access to parameter s1 | null |
+| E.cs:321:14:321:21 | ... ?? ... | null | E.cs:321:20:321:21 | access to parameter s2 | null |
+| E.cs:330:13:330:36 | String x = ... | non-null | E.cs:330:13:330:13 | access to local variable x | non-null |
+| E.cs:330:13:330:36 | String x = ... | null | E.cs:330:13:330:13 | access to local variable x | null |
+| E.cs:330:17:330:28 | (...) ... | non-null | E.cs:330:25:330:28 | null | non-null |
+| E.cs:330:17:330:28 | (...) ... | null | E.cs:330:25:330:28 | null | null |
+| E.cs:330:17:330:36 | ... ?? ... | null | E.cs:330:17:330:28 | (...) ... | null |
+| E.cs:330:17:330:36 | ... ?? ... | null | E.cs:330:33:330:36 | null | null |
+| E.cs:331:9:331:9 | access to local variable x | non-null | E.cs:330:17:330:36 | ... ?? ... | non-null |
+| E.cs:331:9:331:9 | access to local variable x | null | E.cs:330:17:330:36 | ... ?? ... | null |
+| E.cs:336:13:336:23 | String x = ... | non-null | E.cs:336:13:336:13 | access to local variable x | non-null |
+| E.cs:336:13:336:23 | String x = ... | null | E.cs:336:13:336:13 | access to local variable x | null |
+| E.cs:336:17:336:23 | ... ?? ... | null | E.cs:336:17:336:17 | access to parameter s | null |
+| E.cs:336:17:336:23 | ... ?? ... | null | E.cs:336:22:336:23 | "" | null |
+| E.cs:337:9:337:9 | access to local variable x | non-null | E.cs:336:17:336:23 | ... ?? ... | non-null |
+| E.cs:337:9:337:9 | access to local variable x | null | E.cs:336:17:336:23 | ... ?? ... | null |
+| E.cs:342:13:342:32 | String x = ... | non-null | E.cs:342:13:342:13 | access to local variable x | non-null |
+| E.cs:342:13:342:32 | String x = ... | null | E.cs:342:13:342:13 | access to local variable x | null |
+| E.cs:342:17:342:32 | ... ?? ... | null | E.cs:342:17:342:17 | access to parameter s | null |
+| E.cs:342:17:342:32 | ... ?? ... | null | E.cs:342:22:342:32 | ... as ... | null |
+| E.cs:343:9:343:9 | access to local variable x | non-null | E.cs:342:17:342:32 | ... ?? ... | non-null |
+| E.cs:343:9:343:9 | access to local variable x | null | E.cs:342:17:342:32 | ... ?? ... | null |
 | Forwarding.cs:7:16:7:23 | String s = ... | non-null | Forwarding.cs:7:16:7:16 | access to local variable s | non-null |
 | Forwarding.cs:7:16:7:23 | String s = ... | null | Forwarding.cs:7:16:7:16 | access to local variable s | null |
 | Forwarding.cs:9:13:9:30 | !... | false | Forwarding.cs:9:14:9:30 | call to method IsNullOrEmpty | true |

--- a/csharp/ql/test/query-tests/Nullness/Implications.expected
+++ b/csharp/ql/test/query-tests/Nullness/Implications.expected
@@ -611,6 +611,7 @@
 | C.cs:222:13:222:13 | access to local variable s | non-null | C.cs:221:13:221:14 | "" | non-null |
 | C.cs:222:13:222:13 | access to local variable s | null | C.cs:221:13:221:14 | "" | null |
 | C.cs:222:13:222:21 | ... != ... | false | C.cs:222:13:222:13 | access to local variable s | null |
+| C.cs:222:13:222:21 | ... != ... | false | C.cs:222:18:222:21 | null | non-null |
 | C.cs:222:13:222:21 | ... != ... | true | C.cs:222:13:222:13 | access to local variable s | non-null |
 | C.cs:222:13:222:42 | ... && ... | true | C.cs:222:13:222:21 | ... != ... | true |
 | C.cs:222:13:222:42 | ... && ... | true | C.cs:222:26:222:42 | ... == ... | true |
@@ -938,6 +939,7 @@
 | D.cs:196:13:196:13 | access to local variable o | null | D.cs:195:17:195:28 | object creation of type Object | null |
 | D.cs:196:13:196:21 | ... == ... | false | D.cs:196:13:196:13 | access to local variable o | non-null |
 | D.cs:196:13:196:21 | ... == ... | true | D.cs:196:13:196:13 | access to local variable o | null |
+| D.cs:196:13:196:21 | ... == ... | true | D.cs:196:18:196:21 | null | non-null |
 | D.cs:197:13:197:13 | access to local variable o | non-null | D.cs:195:17:195:28 | object creation of type Object | non-null |
 | D.cs:197:13:197:13 | access to local variable o | null | D.cs:195:17:195:28 | object creation of type Object | null |
 | D.cs:198:9:198:9 | access to local variable o | non-null | D.cs:195:17:195:28 | object creation of type Object | non-null |
@@ -966,6 +968,7 @@
 | D.cs:216:13:216:14 | access to local variable o3 | null | D.cs:215:18:215:22 | "abc" | null |
 | D.cs:216:13:216:22 | ... == ... | false | D.cs:216:13:216:14 | access to local variable o3 | non-null |
 | D.cs:216:13:216:22 | ... == ... | true | D.cs:216:13:216:14 | access to local variable o3 | null |
+| D.cs:216:13:216:22 | ... == ... | true | D.cs:216:19:216:22 | null | non-null |
 | D.cs:217:13:217:14 | access to local variable o3 | non-null | D.cs:215:18:215:22 | "abc" | non-null |
 | D.cs:217:13:217:14 | access to local variable o3 | null | D.cs:215:18:215:22 | "abc" | null |
 | D.cs:218:9:218:10 | access to local variable o3 | non-null | D.cs:215:18:215:22 | "abc" | non-null |
@@ -979,6 +982,7 @@
 | D.cs:221:13:221:14 | access to local variable o4 | null | D.cs:220:18:220:26 | ... + ... | null |
 | D.cs:221:13:221:22 | ... == ... | false | D.cs:221:13:221:14 | access to local variable o4 | non-null |
 | D.cs:221:13:221:22 | ... == ... | true | D.cs:221:13:221:14 | access to local variable o4 | null |
+| D.cs:221:13:221:22 | ... == ... | true | D.cs:221:19:221:22 | null | non-null |
 | D.cs:222:13:222:14 | access to local variable o4 | non-null | D.cs:220:18:220:26 | ... + ... | non-null |
 | D.cs:222:13:222:14 | access to local variable o4 | null | D.cs:220:18:220:26 | ... + ... | null |
 | D.cs:223:9:223:10 | access to local variable o4 | non-null | D.cs:220:18:220:26 | ... + ... | non-null |
@@ -1688,6 +1692,7 @@
 | StringConcatenation.cs:30:9:30:9 | access to local variable s | null | StringConcatenation.cs:29:20:29:24 | "abc" | null |
 | StringConcatenation.cs:30:9:30:17 | ... + ... | non-null | StringConcatenation.cs:30:9:30:9 | access to local variable s | non-null |
 | StringConcatenation.cs:30:9:30:17 | ... + ... | non-null | StringConcatenation.cs:30:14:30:17 | null | non-null |
+| StringConcatenation.cs:30:9:30:17 | ... + ... | null | StringConcatenation.cs:30:14:30:17 | null | null |
 | StringConcatenation.cs:30:9:30:17 | ... += ... | non-null | StringConcatenation.cs:30:9:30:9 | access to local variable s | non-null |
 | StringConcatenation.cs:30:9:30:17 | ... += ... | null | StringConcatenation.cs:30:9:30:9 | access to local variable s | null |
 | StringConcatenation.cs:30:9:30:17 | ... = ... | non-null | StringConcatenation.cs:30:9:30:9 | access to local variable s | non-null |

--- a/csharp/ql/test/query-tests/Nullness/NullAlways.expected
+++ b/csharp/ql/test/query-tests/Nullness/NullAlways.expected
@@ -33,6 +33,9 @@
 | E.cs:210:16:210:16 | access to parameter s | Variable $@ is always null here. | E.cs:206:28:206:28 | s | s |
 | E.cs:220:13:220:13 | access to local variable x | Variable $@ is always null here. | E.cs:215:13:215:13 | x | x |
 | E.cs:229:13:229:13 | access to local variable x | Variable $@ is always null here. | E.cs:225:13:225:13 | x | x |
+| E.cs:323:13:323:14 | access to parameter s1 | Variable $@ is always null here. | E.cs:319:29:319:30 | s1 | s1 |
+| E.cs:324:13:324:14 | access to parameter s2 | Variable $@ is always null here. | E.cs:319:40:319:41 | s2 | s2 |
+| E.cs:331:9:331:9 | access to local variable x | Variable $@ is always null here. | E.cs:330:13:330:13 | x | x |
 | Forwarding.cs:36:31:36:31 | access to local variable s | Variable $@ is always null here. | Forwarding.cs:7:16:7:16 | s | s |
 | Forwarding.cs:40:27:40:27 | access to local variable s | Variable $@ is always null here. | Forwarding.cs:7:16:7:16 | s | s |
 | NullAlwaysBad.cs:9:30:9:30 | access to parameter s | Variable $@ is always null here. | NullAlwaysBad.cs:7:29:7:29 | s | s |

--- a/csharp/ql/test/query-tests/Nullness/NullCheck.expected
+++ b/csharp/ql/test/query-tests/Nullness/NullCheck.expected
@@ -69,6 +69,7 @@
 | C.cs:218:13:218:21 | ... == ... | C.cs:218:13:218:13 | access to local variable s | true | true |
 | C.cs:222:13:222:21 | ... != ... | C.cs:222:13:222:13 | access to local variable s | false | true |
 | C.cs:222:13:222:21 | ... != ... | C.cs:222:13:222:13 | access to local variable s | true | false |
+| C.cs:222:13:222:21 | ... != ... | C.cs:222:18:222:21 | null | false | false |
 | C.cs:230:22:230:30 | ... != ... | C.cs:230:22:230:22 | access to local variable s | false | true |
 | C.cs:230:22:230:30 | ... != ... | C.cs:230:22:230:22 | access to local variable s | true | false |
 | C.cs:236:24:236:32 | ... == ... | C.cs:236:24:236:24 | access to local variable s | false | false |
@@ -116,14 +117,17 @@
 | D.cs:152:17:152:27 | ... != ... | D.cs:152:17:152:19 | access to parameter obj | true | false |
 | D.cs:196:13:196:21 | ... == ... | D.cs:196:13:196:13 | access to local variable o | false | false |
 | D.cs:196:13:196:21 | ... == ... | D.cs:196:13:196:13 | access to local variable o | true | true |
+| D.cs:196:13:196:21 | ... == ... | D.cs:196:18:196:21 | null | true | false |
 | D.cs:206:17:206:25 | ... == ... | D.cs:206:17:206:17 | access to local variable e | false | false |
 | D.cs:206:17:206:25 | ... == ... | D.cs:206:17:206:17 | access to local variable e | true | true |
 | D.cs:212:18:212:26 | ... == ... | D.cs:212:18:212:18 | access to local variable n | false | false |
 | D.cs:212:18:212:26 | ... == ... | D.cs:212:18:212:18 | access to local variable n | true | true |
 | D.cs:216:13:216:22 | ... == ... | D.cs:216:13:216:14 | access to local variable o3 | false | false |
 | D.cs:216:13:216:22 | ... == ... | D.cs:216:13:216:14 | access to local variable o3 | true | true |
+| D.cs:216:13:216:22 | ... == ... | D.cs:216:19:216:22 | null | true | false |
 | D.cs:221:13:221:22 | ... == ... | D.cs:221:13:221:14 | access to local variable o4 | false | false |
 | D.cs:221:13:221:22 | ... == ... | D.cs:221:13:221:14 | access to local variable o4 | true | true |
+| D.cs:221:13:221:22 | ... == ... | D.cs:221:19:221:22 | null | true | false |
 | D.cs:242:13:242:25 | ... == ... | D.cs:242:13:242:17 | access to local variable other | false | false |
 | D.cs:242:13:242:25 | ... == ... | D.cs:242:13:242:17 | access to local variable other | true | true |
 | D.cs:244:13:244:25 | ... != ... | D.cs:244:13:244:17 | access to local variable other | false | true |

--- a/csharp/ql/test/query-tests/Nullness/NullCheck.expected
+++ b/csharp/ql/test/query-tests/Nullness/NullCheck.expected
@@ -208,6 +208,15 @@
 | E.cs:306:31:306:31 | access to field l | E.cs:306:31:306:31 | access to field l | null | true |
 | E.cs:309:13:309:22 | access to property HasValue | E.cs:309:13:309:13 | access to field l | false | true |
 | E.cs:309:13:309:22 | access to property HasValue | E.cs:309:13:309:13 | access to field l | true | false |
+| E.cs:321:13:321:30 | ... is ... | E.cs:321:14:321:21 | ... ?? ... | false | false |
+| E.cs:321:13:321:30 | ... is ... | E.cs:321:14:321:21 | ... ?? ... | true | true |
+| E.cs:321:14:321:15 | access to parameter s1 | E.cs:321:14:321:15 | access to parameter s1 | non-null | false |
+| E.cs:321:14:321:15 | access to parameter s1 | E.cs:321:14:321:15 | access to parameter s1 | null | true |
+| E.cs:330:17:330:28 | (...) ... | E.cs:330:17:330:28 | (...) ... | null | true |
+| E.cs:336:17:336:17 | access to parameter s | E.cs:336:17:336:17 | access to parameter s | non-null | false |
+| E.cs:336:17:336:17 | access to parameter s | E.cs:336:17:336:17 | access to parameter s | null | true |
+| E.cs:342:17:342:17 | access to parameter s | E.cs:342:17:342:17 | access to parameter s | non-null | false |
+| E.cs:342:17:342:17 | access to parameter s | E.cs:342:17:342:17 | access to parameter s | null | true |
 | Forwarding.cs:9:14:9:30 | call to method IsNullOrEmpty | Forwarding.cs:9:14:9:14 | access to local variable s | false | false |
 | Forwarding.cs:14:13:14:32 | call to method IsNotNullOrEmpty | Forwarding.cs:14:13:14:13 | access to local variable s | true | false |
 | Forwarding.cs:19:14:19:23 | call to method IsNull | Forwarding.cs:19:14:19:14 | access to local variable s | false | false |

--- a/csharp/ql/test/query-tests/Nullness/NullMaybe.expected
+++ b/csharp/ql/test/query-tests/Nullness/NullMaybe.expected
@@ -348,6 +348,14 @@ nodes
 | E.cs:285:9:285:9 | access to local variable o |
 | E.cs:301:13:301:27 | SSA def(s) |
 | E.cs:302:9:302:9 | access to local variable s |
+| E.cs:319:29:319:30 | SSA param(s1) |
+| E.cs:321:20:321:21 | access to parameter s2 |
+| E.cs:321:27:321:30 | null |
+| E.cs:323:13:323:14 | access to parameter s1 |
+| E.cs:330:13:330:36 | SSA def(x) |
+| E.cs:331:9:331:9 | access to local variable x |
+| E.cs:342:13:342:32 | SSA def(x) |
+| E.cs:343:9:343:9 | access to local variable x |
 | Forwarding.cs:7:16:7:23 | SSA def(s) |
 | Forwarding.cs:14:9:17:9 | if (...) ... |
 | Forwarding.cs:19:9:22:9 | if (...) ... |
@@ -678,6 +686,11 @@ edges
 | E.cs:283:13:283:22 | [b (line 279): false] SSA def(o) | E.cs:285:9:285:9 | access to local variable o |
 | E.cs:283:13:283:22 | [b (line 279): true] SSA def(o) | E.cs:285:9:285:9 | access to local variable o |
 | E.cs:301:13:301:27 | SSA def(s) | E.cs:302:9:302:9 | access to local variable s |
+| E.cs:319:29:319:30 | SSA param(s1) | E.cs:321:20:321:21 | access to parameter s2 |
+| E.cs:321:20:321:21 | access to parameter s2 | E.cs:321:27:321:30 | null |
+| E.cs:321:27:321:30 | null | E.cs:323:13:323:14 | access to parameter s1 |
+| E.cs:330:13:330:36 | SSA def(x) | E.cs:331:9:331:9 | access to local variable x |
+| E.cs:342:13:342:32 | SSA def(x) | E.cs:343:9:343:9 | access to local variable x |
 | Forwarding.cs:7:16:7:23 | SSA def(s) | Forwarding.cs:14:9:17:9 | if (...) ... |
 | Forwarding.cs:14:9:17:9 | if (...) ... | Forwarding.cs:19:9:22:9 | if (...) ... |
 | Forwarding.cs:19:9:22:9 | if (...) ... | Forwarding.cs:24:9:27:9 | if (...) ... |
@@ -778,6 +791,7 @@ edges
 | E.cs:285:9:285:9 | access to local variable o | E.cs:283:13:283:22 | [b (line 279): false] SSA def(o) | E.cs:285:9:285:9 | access to local variable o | Variable $@ may be null here as suggested by $@ null check. | E.cs:283:13:283:13 | o | o | E.cs:284:9:284:9 | access to local variable o | this |
 | E.cs:285:9:285:9 | access to local variable o | E.cs:283:13:283:22 | [b (line 279): true] SSA def(o) | E.cs:285:9:285:9 | access to local variable o | Variable $@ may be null here as suggested by $@ null check. | E.cs:283:13:283:13 | o | o | E.cs:284:9:284:9 | access to local variable o | this |
 | E.cs:302:9:302:9 | access to local variable s | E.cs:301:13:301:27 | SSA def(s) | E.cs:302:9:302:9 | access to local variable s | Variable $@ may be null here because of $@ assignment. | E.cs:301:13:301:13 | s | s | E.cs:301:13:301:27 | String s = ... | this |
+| E.cs:343:9:343:9 | access to local variable x | E.cs:342:13:342:32 | SSA def(x) | E.cs:343:9:343:9 | access to local variable x | Variable $@ may be null here because of $@ assignment. | E.cs:342:13:342:13 | x | x | E.cs:342:13:342:32 | String x = ... | this |
 | GuardedString.cs:35:31:35:31 | access to local variable s | GuardedString.cs:7:16:7:32 | SSA def(s) | GuardedString.cs:35:31:35:31 | access to local variable s | Variable $@ may be null here because of $@ assignment. | GuardedString.cs:7:16:7:16 | s | s | GuardedString.cs:7:16:7:32 | String s = ... | this |
 | NullMaybeBad.cs:7:27:7:27 | access to parameter o | NullMaybeBad.cs:13:17:13:20 | null | NullMaybeBad.cs:7:27:7:27 | access to parameter o | Variable $@ may be null here because of $@ null argument. | NullMaybeBad.cs:5:25:5:25 | o | o | NullMaybeBad.cs:13:17:13:20 | null | this |
 | StringConcatenation.cs:16:17:16:17 | access to local variable s | StringConcatenation.cs:14:16:14:23 | SSA def(s) | StringConcatenation.cs:16:17:16:17 | access to local variable s | Variable $@ may be null here because of $@ assignment. | StringConcatenation.cs:14:16:14:16 | s | s | StringConcatenation.cs:14:16:14:23 | String s = ... | this |


### PR DESCRIPTION
- Add `Caching.qll` for controlling caching across multiple files.
- Move `isUncertainRefCall()` out of cached module in `Assignable.qll` to avoid
  collapsing with CFG stage.
- Remove dependency on `AlwaysNullExpr` in `NullValue::getAnExpr()` to avoid
  collapsing with CFG stage.
- Avoid caching pre-SSA library as it should only be used during the CFG construction
  stage.

Profiling report: https://git.semmle.com/gist/tom/95dbc1efebfbb3c29e4d91b1abb7809d (internal link).