### PR TITLE
Java: Improve precision of java/unchecked-cast-in-equals

### DIFF
--- a/change-notes/1.22/analysis-java.md
+++ b/change-notes/1.22/analysis-java.md
@@ -1,0 +1,10 @@
+# Improvements to Java analysis
+
+## Changes to existing queries
+
+| **Query**                  | **Expected impact**    | **Change**                                                       |
+|----------------------------|------------------------|------------------------------------------------------------------|
+| Equals method does not inspect argument type (`java/unchecked-cast-in-equals`) | Fewer false positive and more true positive results | Precision has been improved by doing a bit of inter-procedural analysis and relying less on ad-hoc method names. |
+
+## Changes to QL libraries
+


### PR DESCRIPTION
As discussed on slack. See https://lgtm.com/query/6961820689409815191/ for a comparison of the 3 versions.