### PR TITLE
Python: Remove Value.getSource(). It has no use.

### DIFF
--- a/python/ql/src/semmle/python/Module.qll
+++ b/python/ql/src/semmle/python/Module.qll
@@ -67,9 +67,9 @@ class Module extends Module_, Scope, AstNode {
     string getAnExport() {
         py_exports(this, result)
         or
-        exists(ModuleValue mod |
+        exists(ModuleObjectInternal mod |
             mod.getSource() = this.getEntryNode() |
-            mod.exports(result)
+            mod.(ModuleValue).exports(result)
         )
     }
 

--- a/python/ql/src/semmle/python/objects/ObjectAPI.qll
+++ b/python/ql/src/semmle/python/objects/ObjectAPI.qll
@@ -71,13 +71,6 @@ class Value extends TObject {
         this.(ObjectInternal).attribute(name, result, _)
     }
 
-    /** DEPRECATED: For backwards compatibility with old API
-     * Use `Value` instead of `ObjectSource`.
-     */
-    deprecated ObjectSource getSource() {
-        result = this.(ObjectInternal).getSource()
-    }
-
     /** Holds if this value is builtin. Applies to built-in functions and methods,
      * but also integers and strings.
      */

--- a/python/ql/src/semmle/python/pointsto/PointsTo.qll
+++ b/python/ql/src/semmle/python/pointsto/PointsTo.qll
@@ -141,7 +141,7 @@ module PointsTo {
         )
         or
         not f.isParameter() and
-        exists(Value value |
+        exists(ObjectInternal value |
             PointsToInternal::pointsTo(f.(DefinitionNode).getValue(), context, value, origin) and
             cls = value.getClass().getSource() |
             obj = value.getSource() or
@@ -151,7 +151,7 @@ module PointsTo {
 
     deprecated predicate
     ssa_variable_points_to(EssaVariable var, PointsToContext context, Object obj, ClassObject cls, CfgOrigin origin) {
-        exists(Value value |
+        exists(ObjectInternal value |
             PointsToInternal::variablePointsTo(var, context, value, origin) and
             cls = value.getClass().getSource() |
             obj = value.getSource()
@@ -160,8 +160,8 @@ module PointsTo {
 
     deprecated
     CallNode get_a_call(Object func, PointsToContext context) {
-        exists(Value value |
-            result = value.getACall(context) and
+        exists(ObjectInternal value |
+            result = value.(Value).getACall(context) and
             func = value.getSource()
         )
     }

--- a/python/ql/src/semmle/python/security/TaintTracking.qll
+++ b/python/ql/src/semmle/python/security/TaintTracking.qll
@@ -144,7 +144,7 @@ abstract class TaintKind extends string {
      * the `result` would be `theStrType()`.
      */
     ClassValue getType() {
-        result.getSource() = this.getClass()
+        result.(ClassObjectInternal).getSource() = this.getClass()
     }
 
     /** Gets the boolean values (may be one, neither, or both) that

--- a/python/ql/src/semmle/python/types/ClassObject.qll
+++ b/python/ql/src/semmle/python/types/ClassObject.qll
@@ -4,6 +4,7 @@ private import semmle.python.objects.Instances
 private import semmle.python.pointsto.PointsTo
 private import semmle.python.pointsto.MRO
 private import semmle.python.types.Builtins
+private import semmle.python.objects.ObjectInternal
 
 
 /** A class whose instances represents Python classes.
@@ -99,7 +100,7 @@ class ClassObject extends Object {
 
     /** Returns an attribute declared on this class (not on a super-class) */
     Object declaredAttribute(string name) {
-        exists(Value val |
+        exists(ObjectInternal val |
             Types::declaredAttribute(theClass(), name, val, _) and
             result = val.getSource()
         )
@@ -113,7 +114,7 @@ class ClassObject extends Object {
     /** Returns an attribute as it would be when looked up at runtime on this class.
       Will include attributes of super-classes */
     Object lookupAttribute(string name) {
-        exists(Value val |
+        exists(ObjectInternal val |
             theClass().lookup(name, val, _) and
             result = val.getSource()
         )
@@ -125,7 +126,7 @@ class ClassObject extends Object {
 
     /** Looks up an attribute by searching this class' MRO starting at `start` */
     Object lookupMro(ClassObject start, string name) {
-        exists(ClassObjectInternal other, ClassObjectInternal decl, Value val |
+        exists(ClassObjectInternal other, ClassObjectInternal decl, ObjectInternal val |
             other.getSource() = start and
             decl = Types::getMro(theClass()).startingAt(other).findDeclaringClass(name) and
             Types::declaredAttribute(decl, name, val, _) and
@@ -140,7 +141,7 @@ class ClassObject extends Object {
 
     /** Whether the named attribute refers to the object, class and origin */
     predicate attributeRefersTo(string name, Object obj, ClassObject cls, ControlFlowNode origin) {
-        exists(Value val, CfgOrigin valorig |
+        exists(ObjectInternal val, CfgOrigin valorig |
             theClass().lookup(name, val, valorig) and
             obj = val.getSource() and
             cls = val.getClass().getSource() and

--- a/python/ql/src/semmle/python/types/FunctionObject.qll
+++ b/python/ql/src/semmle/python/types/FunctionObject.qll
@@ -4,13 +4,14 @@ private import semmle.python.pointsto.PointsTo
 private import semmle.python.objects.Callables
 private import semmle.python.libraries.Zope
 private import semmle.python.pointsto.Base
+private import semmle.python.objects.ObjectInternal
 private import semmle.python.types.Builtins
 
 /** A function object, whether written in Python or builtin */
 abstract class FunctionObject extends Object {
 
     CallableValue theCallable() {
-        result.getSource() = this
+        result.(ObjectInternal).getSource() = this
     }
 
     predicate isOverridingMethod() {

--- a/python/ql/src/semmle/python/types/ModuleObject.qll
+++ b/python/ql/src/semmle/python/types/ModuleObject.qll
@@ -1,6 +1,6 @@
 import python
 private import semmle.python.pointsto.PointsTo
-private import semmle.python.objects.Modules
+private import semmle.python.objects.ObjectInternal
 private import semmle.python.types.ModuleKind
 
 abstract class ModuleObject extends Object {
@@ -54,7 +54,7 @@ abstract class ModuleObject extends Object {
     }
 
     predicate attributeRefersTo(string name, Object obj, ControlFlowNode origin) {
-        exists(Value val, CfgOrigin valorig |
+        exists(ObjectInternal val, CfgOrigin valorig |
             theModule().(ModuleObjectInternal).attribute(name, val, valorig) and
             obj = val.getSource() and
             origin = valorig.toCfgNode()
@@ -62,7 +62,7 @@ abstract class ModuleObject extends Object {
     }
 
     predicate attributeRefersTo(string name, Object obj, ClassObject cls, ControlFlowNode origin) {
-        exists(Value val, CfgOrigin valorig |
+        exists(ObjectInternal val, CfgOrigin valorig |
             theModule().(ModuleObjectInternal).attribute(name, val, valorig) and
             obj = val.getSource() and
             cls = val.getClass().getSource() and
@@ -223,7 +223,7 @@ class PackageObject extends ModuleObject {
     }
 
     override Object getAttribute(string name) {
-        exists(Value val |
+        exists(ObjectInternal val |
             theModule().(PackageObjectInternal).attribute(name, val, _) and
             result = val.getSource()
         )

--- a/python/ql/test/3/library-tests/PointsTo/attributes/Test.expected
+++ b/python/ql/test/3/library-tests/PointsTo/attributes/Test.expected
@@ -1,3 +1,4 @@
+| 1 | ControlFlowNode for unicode_literals | ImportMember | 1 |
 | 2 | ControlFlowNode for C | class C | 2 |
 | 2 | ControlFlowNode for ClassExpr | class C | 2 |
 | 2 | ControlFlowNode for object | builtin-class object | 2 |

--- a/python/ql/test/library-tests/PointsTo/general/GlobalPointsTo.expected
+++ b/python/ql/test/library-tests/PointsTo/general/GlobalPointsTo.expected
@@ -98,6 +98,7 @@
 | Module pointsto_test | 76 | ControlFlowNode for sys | Module sys |
 | Module pointsto_test | 76 | ControlFlowNode for type | builtin-class type |
 | Module pointsto_test | 76 | ControlFlowNode for type() | builtin-class module |
+| Module pointsto_test | 77 | ControlFlowNode for unknown | ImportMember |
 | Module pointsto_test | 78 | ControlFlowNode for type | builtin-class type |
 | Module pointsto_test | 79 | ControlFlowNode for Dict | Dict |
 | Module pointsto_test | 79 | ControlFlowNode for Tuple | Tuple |

--- a/python/ql/test/library-tests/PointsTo/general/LocalPointsTo.expected
+++ b/python/ql/test/library-tests/PointsTo/general/LocalPointsTo.expected
@@ -106,6 +106,7 @@
 | 76 | ControlFlowNode for sys | Module sys |
 | 76 | ControlFlowNode for type | builtin-class type |
 | 76 | ControlFlowNode for type() | builtin-class module |
+| 77 | ControlFlowNode for unknown | ImportMember |
 | 78 | ControlFlowNode for type | builtin-class type |
 | 79 | ControlFlowNode for Dict | Dict |
 | 79 | ControlFlowNode for Tuple | Tuple |

--- a/python/ql/test/library-tests/PointsTo/new/PointsToWithContext.expected
+++ b/python/ql/test/library-tests/PointsTo/new/PointsToWithContext.expected
@@ -1142,6 +1142,7 @@ WARNING: Predicate points_to has been deprecated and may be removed in future (P
 | t_type.py:7 | ControlFlowNode for sys | Module sys | builtin-class module | 1 | import |
 | t_type.py:7 | ControlFlowNode for type | builtin-class type | builtin-class type | 7 | import |
 | t_type.py:7 | ControlFlowNode for type() | builtin-class module | builtin-class type | 7 | import |
+| t_type.py:8 | ControlFlowNode for unknown | ImportMember | *UNKNOWN TYPE* | 8 | import |
 | t_type.py:9 | ControlFlowNode for type | builtin-class type | builtin-class type | 9 | import |
 | t_type.py:9 | ControlFlowNode for type() | *UNKNOWN TYPE* | *UNKNOWN TYPE* | 9 | import |
 | t_type.py:10 | ControlFlowNode for Dict | Dict | builtin-class dict | 10 | import |

--- a/python/ql/test/library-tests/PointsTo/new/TestEvaluate.expected
+++ b/python/ql/test/library-tests/PointsTo/new/TestEvaluate.expected
@@ -1,5 +1,3 @@
-WARNING: Predicate getSource has been deprecated and may be removed in future (TestEvaluate.ql:14,16-25)
-WARNING: Predicate getSource has been deprecated and may be removed in future (TestEvaluate.ql:16,20-29)
 | b_condition.py:7 | Compare | true | x | NoneType None |
 | b_condition.py:13 | Compare | false | x | NoneType None |
 | b_condition.py:19 | UnaryExpr | true | x | NoneType None |

--- a/python/ql/test/library-tests/PointsTo/new/TestEvaluate.ql
+++ b/python/ql/test/library-tests/PointsTo/new/TestEvaluate.ql
@@ -5,13 +5,13 @@ import semmle.python.pointsto.PointsToContext
 import Util
 
 
-from ControlFlowNode test, ControlFlowNode use, Value val, boolean eval, PointsToContext ctx, ControlFlowNode origin, string what
+from ControlFlowNode test, ControlFlowNode use, ObjectInternal val, boolean eval, PointsToContext ctx, ControlFlowNode origin, string what
 where 
 not use instanceof NameConstantNode and
 not use.getNode() instanceof ImmutableLiteral and
 eval = Conditionals::testEvaluates(test, use, ctx, val, origin) and
 (
-    what = val.getSource().toString()
+    what = val.getSource().(Object).toString()
     or
     not exists(val.getSource()) and what = origin.getNode().toString()
 )


### PR DESCRIPTION
Removes the `Value.getSource()` predicate. We added it for 1.21, but it has no real use, so we should remove it before the release.