### PR TITLE
Java 1.21: clarify ECJ support

### DIFF
--- a/change-notes/support/language-support.rst
+++ b/change-notes/support/language-support.rst
@@ -17,5 +17,6 @@ Note that where there are several versions or dialects of a language, the suppor
     .. [2] In addition, support is included for the preview features of C# 8.0 and .NET Core 3.0.
     .. [3] The best results are achieved with COBOL code that stays close to the ANSI 85 standard.  
     .. [4] Builds that execute on Java 6 to 12 can be analyzed. The analysis understands Java 12 language features.
-    .. [5] JSX and Flow code, YAML, JSON, HTML, and XML files may also be analyzed with JavaScript files. 
-    .. [6] TypeScript analysis is performed by running the JavaScript extractor with TypeScript enabled. This is the default for LGTM.   
+    .. [5] ECJ is supported when the build invokes it via the Maven Compiler plugin or the Takari Lifecycle plugin.
+    .. [6] JSX and Flow code, YAML, JSON, HTML, and XML files may also be analyzed with JavaScript files. 
+    .. [7] TypeScript analysis is performed by running the JavaScript extractor with TypeScript enabled. This is the default for LGTM.   

--- a/change-notes/support/versions-compilers.csv
+++ b/change-notes/support/versions-compilers.csv
@@ -1,5 +1,5 @@
 Language,Variants,Compilers,Extensions
-C/C++,"C89, C99, C11, C++98, C++03, C++11, C++14, C++17","Clang extensions (up to Clang 8.0)
+C/C++,"C89, C99, C11, C++98, C++03, C++11, C++14, C++17","Clang extensions (up to Clang 8.0),
 
 GNU extensions (up to GCC 8.3), 
 
@@ -10,9 +10,9 @@ C#,C# up to 7.3. with .NET up to 4.8 [2]_.,"Microsoft Visual Studio up to 2019,
 
 .NET Core up to 2.2","``.sln``, ``.csproj``, ``.cs``, ``.cshtml``, ``.xaml``"
 COBOL,ANSI 85 or newer [3]_.,Not applicable,"``.cbl``, ``.CBL``, ``.cpy``, ``.CPY``, ``.copy``, ``.COPY``"
-Java,"Java 6 to 12 [4]_.","javac (OpenJDK and Oracle JDK)
+Java,"Java 6 to 12 [4]_.","javac (OpenJDK and Oracle JDK),
 
-Eclipse compiler for Java (ECJ) batch compiler",``.java``
-JavaScript,ECMAScript 2019 or lower,Not applicable,"``.js``, ``.jsx``, ``.mjs``, ``.es``, ``.es6``, ``.htm``, ``.html``, ``.xhm``, ``.xhtml``, ``.vue``, ``.json``, ``.yaml``, ``.yml``, ``.raml``, ``.xml`` [5]_."
+Eclipse compiler for Java (ECJ) [5]_.",``.java``
+JavaScript,ECMAScript 2019 or lower,Not applicable,"``.js``, ``.jsx``, ``.mjs``, ``.es``, ``.es6``, ``.htm``, ``.html``, ``.xhm``, ``.xhtml``, ``.vue``, ``.json``, ``.yaml``, ``.yml``, ``.raml``, ``.xml`` [6]_."
 Python,"2.7, 3.5, 3.6, 3.7",Not applicable,``.py``
-TypeScript [6]_.,"2.6-3.5",Standard TypeScript compiler,"``.ts``, ``.tsx``"
+TypeScript [7]_.,"2.6-3.5",Standard TypeScript compiler,"``.ts``, ``.tsx``"


### PR DESCRIPTION
@yh-semmle, as discussed, this PR updates the supported languages and compilers page to include the Takari Lifecycle plugin that's mentioned in the Java change notes for 1.21.

Preview: http://docteam.internal.semmle.com/felicity/test-Java-ECJ/language-support.html