### PR TITLE
CPP: Resolve performance issue in CastArrayPointerArithmetic.ql

### DIFF
--- a/cpp/ql/src/Likely Bugs/Conversion/CastArrayPointerArithmetic.ql
+++ b/cpp/ql/src/Likely Bugs/Conversion/CastArrayPointerArithmetic.ql
@@ -44,8 +44,8 @@ class CastToPointerArithFlow extends DataFlow::Configuration {
 }
 
 /**
- * `derived` has a (possibly indirect) base class of `base`, and `derived`
- * introduces at least one new field that isn't in a base class.
+ * `derived` has a (possibly indirect) base class of `base`, and at least one new
+ * field has been introduced in the inheritance chain after `base`.
  */
 predicate introducesNewField(Class derived, Class base) {
   (

--- a/cpp/ql/src/Likely Bugs/Conversion/CastArrayPointerArithmetic.ql
+++ b/cpp/ql/src/Likely Bugs/Conversion/CastArrayPointerArithmetic.ql
@@ -43,11 +43,15 @@ class CastToPointerArithFlow extends DataFlow::Configuration {
   }
 }
 
+/**
+ * `derived` has a (possibly indirect) base class of `base`, and `derived`
+ * introduces at least one new field that isn't in a base class.
+ */
 predicate introducesNewField(Class derived, Class base) {
-  derived.getABaseClass+() = base and
   (
     exists(Field f |
-      f.getDeclaringType() = derived
+      f.getDeclaringType() = derived and
+      derived.getABaseClass+() = base
     ) or
     introducesNewField(derived.getABaseClass(), base)
   )


### PR DESCRIPTION
This problem (discussed on Slack this morning) was quite straightforward.  There was an unnecessary explosion of tuples when the evaluator explored `getABaseClass+()` on each recursive step.

The change reduces the code of this predicate to almost zero and saves more than 200s overall on UnrealEngine; has little effect on anything else I tried.