### PR TITLE
 CPP: Fix AV Rule 95 performance issue.

### DIFF
--- a/cpp/ql/src/jsf/4.10 Classes/AV Rule 95.ql
+++ b/cpp/ql/src/jsf/4.10 Classes/AV Rule 95.ql
@@ -11,17 +11,16 @@
  */
 import cpp
 
-predicate parameterWithDefault(MemberFunction f, int ix, Parameter p, Expr initExpr, string initValue) {
+predicate memberParameterWithDefault(MemberFunction f, int ix, Parameter p, Expr initExpr, string initValue) {
   f.getParameter(ix) = p and
-  p.hasInitializer() and
   initExpr = p.getInitializer().getExpr() and
   initValue = initExpr.getValue()
 }
 
 from Parameter p, Parameter superP, MemberFunction subF, MemberFunction superF, int i, Expr subExpr, string subValue, string superValue
-where parameterWithDefault(subF, i, p, subExpr, subValue)
+where memberParameterWithDefault(subF, i, p, subExpr, subValue)
    and subF.overrides(superF)
-   and parameterWithDefault(superF, i, superP, _, superValue)
+   and memberParameterWithDefault(superF, i, superP, _, superValue)
    and subValue != superValue
 select subExpr,
    "Parameter " + p.getName() +

--- a/cpp/ql/src/jsf/4.10 Classes/AV Rule 95.ql
+++ b/cpp/ql/src/jsf/4.10 Classes/AV Rule 95.ql
@@ -11,16 +11,19 @@
  */
 import cpp
 
-from Parameter p, Parameter superP, MemberFunction subF, MemberFunction superF, int i, string subValue, string superValue
-where p.hasInitializer()
-  and subF.getParameter(i) = p
-   and superP.hasInitializer()
+predicate parameterWithDefault(MemberFunction f, int ix, Parameter p, Expr initExpr, string initValue) {
+  f.getParameter(ix) = p and
+  p.hasInitializer() and
+  initExpr = p.getInitializer().getExpr() and
+  initValue = initExpr.getValue()
+}
+
+from Parameter p, Parameter superP, MemberFunction subF, MemberFunction superF, int i, Expr subExpr, string subValue, string superValue
+where parameterWithDefault(subF, i, p, subExpr, subValue)
    and subF.overrides(superF)
-   and superF.getParameter(i) = superP
-   and subValue = p.getInitializer().getExpr().getValue()
-   and superValue = superP.getInitializer().getExpr().getValue()
+   and parameterWithDefault(superF, i, superP, _, superValue)
    and subValue != superValue
-select p.getInitializer().getExpr(),
+select subExpr,
    "Parameter " + p.getName() +
    " redefines its default value to " + subValue +
    " from the inherited default value " + superValue +

--- a/cpp/ql/src/jsf/4.10 Classes/AV Rule 95.ql
+++ b/cpp/ql/src/jsf/4.10 Classes/AV Rule 95.ql
@@ -9,22 +9,27 @@
  *       readability
  *       external/jsf
  */
+
 import cpp
 
-predicate memberParameterWithDefault(MemberFunction f, int ix, Parameter p, Expr initExpr, string initValue) {
+predicate memberParameterWithDefault(
+  MemberFunction f, int ix, Parameter p, Expr initExpr, string initValue
+) {
   f.getParameter(ix) = p and
   initExpr = p.getInitializer().getExpr() and
   initValue = initExpr.getValue()
 }
 
-from Parameter p, Parameter superP, MemberFunction subF, MemberFunction superF, int i, Expr subExpr, string subValue, string superValue
-where memberParameterWithDefault(subF, i, p, subExpr, subValue)
-   and subF.overrides(superF)
-   and memberParameterWithDefault(superF, i, superP, _, superValue)
-   and subValue != superValue
+from
+  Parameter p, Parameter superP, MemberFunction subF, MemberFunction superF, int i, Expr subExpr,
+  string subValue, string superValue
+where
+  memberParameterWithDefault(subF, i, p, subExpr, subValue) and
+  subF.overrides(superF) and
+  memberParameterWithDefault(superF, i, superP, _, superValue) and
+  subValue != superValue
 select subExpr,
-   "Parameter " + p.getName() +
-   " redefines its default value to " + subValue +
-   " from the inherited default value " + superValue +
-   " (in " + superF.getDeclaringType().getName() +
-   ").\nThe default value will be resolved statically, not by dispatch, so this can cause confusion."
+  "Parameter " + p.getName() + " redefines its default value to " + subValue +
+    " from the inherited default value " + superValue + " (in " +
+    superF.getDeclaringType().getName() +
+    ").\nThe default value will be resolved statically, not by dispatch, so this can cause confusion."


### PR DESCRIPTION
There was an explosion of rows around one of the calls to `getInitializer()` (probably because `subF.overrides(superF)` wasn't being evaluated early enough ... but I didn't do a lot of investigation).  I pulled out a nice linear part of the query into a predicate, reused it in a second place, and by the time I'd done that the issue had gone away.  And the QL is cleaner now, which is nice.