### PR TITLE
Python: "TarSlip" query

### DIFF
--- a/change-notes/1.22/analysis-python.md
+++ b/change-notes/1.22/analysis-python.md
@@ -1,0 +1,17 @@
+# Improvements to Python analysis
+
+
+## General improvements
+
+
+
+### Impact on existing queries.
+
+
+
+## New queries
+
+| **Query** | **Tags** | **Purpose** |
+|-----------|----------|-------------|
+| Arbitrary file write during tarfile extraction (`py/tarslip`) | security, external/cwe/cwe-022 | Finds instances where extracting from a tar archive can result in arbitrary file writes. Results are not shown on LGTM by default. |
+

--- a/python/ql/src/Security/CWE-022/TarSlip.qhelp
+++ b/python/ql/src/Security/CWE-022/TarSlip.qhelp
@@ -1,0 +1,75 @@
+<!DOCTYPE qhelp PUBLIC
+  "-//Semmle//qhelp//EN"
+  "qhelp.dtd">
+<qhelp>
+
+<overview>
+<p>Extracting files from a malicious tar archive without validating that the destination file path
+is within the destination directory can cause files outside the destination directory to be
+overwritten, due to the possible presence of directory traversal elements (<code>..</code>) in
+archive paths.</p>
+
+<p>Tar archives contain archive entries representing each file in the archive. These entries
+include a file path for the entry, but these file paths are not restricted and may contain
+unexpected special elements such as the directory traversal element (<code>..</code>). If these
+file paths are used to determine an output file to write the contents of the archive item to, then
+the file may be written to an unexpected location. This can result in sensitive information being
+revealed or deleted, or an attacker being able to influence behavior by modifying unexpected
+files.</p>
+
+<p>For example, if a tar archive contains a file entry <code>..\sneaky-file</code>, and the tar archive
+is extracted to the directory <code>c:\output</code>, then naively combining the paths would result
+in an output file path of <code>c:\output\..\sneaky-file</code>, which would cause the file to be
+written to <code>c:\sneaky-file</code>.</p>
+
+</overview>
+<recommendation>
+
+<p>Ensure that output paths constructed from tar archive entries are validated
+to prevent writing files to unexpected locations.</p>
+
+<p>The recommended way of writing an output file from a tar archive entry is to check that
+<code>".."</code> does not occur in the path.
+</p>
+
+</recommendation>
+
+<example>
+<p>
+In this example an archive is extracted without validating file paths.
+If <code>archive.tar</code> contained relative paths (for
+instance, if it were created by something like <code>tar -cf archive.tar
+../file.txt</code>) then executing this code could write to locations
+outside the destination directory.
+</p>
+
+<sample src="examples/tarslip_bad.py" />
+
+<p>To fix this vulnerability, we need to check that the path does not
+contain any <code>".."</code> elements in it.
+</p>
+
+<sample src="examples/tarslip_good.py" />
+
+</example>
+<references>
+
+<li>
+Snyk:
+<a href="https://snyk.io/research/zip-slip-vulnerability">Zip Slip Vulnerability</a>.
+</li>
+<li>
+OWASP:
+<a href="https://www.owasp.org/index.php/Path_traversal">Path Traversal</a>.
+</li>
+<li>
+Python Library Reference:
+< href="https://docs.python.org/3/library/tarfile.html#tarfile.TarFile.extract">TarFile.extract</a>.
+</li>
+<li>
+Python Library Reference:
+< href="https://docs.python.org/3/library/tarfile.html#tarfile.TarFile.extractall">TarFile.extractall</a>.
+</li>
+
+</references>
+</qhelp>

--- a/python/ql/src/Security/CWE-022/TarSlip.qhelp
+++ b/python/ql/src/Security/CWE-022/TarSlip.qhelp
@@ -64,11 +64,11 @@ OWASP:
 </li>
 <li>
 Python Library Reference:
-< href="https://docs.python.org/3/library/tarfile.html#tarfile.TarFile.extract">TarFile.extract</a>.
+<a href="https://docs.python.org/3/library/tarfile.html#tarfile.TarFile.extract">TarFile.extract</a>.
 </li>
 <li>
 Python Library Reference:
-< href="https://docs.python.org/3/library/tarfile.html#tarfile.TarFile.extractall">TarFile.extractall</a>.
+<a href="https://docs.python.org/3/library/tarfile.html#tarfile.TarFile.extractall">TarFile.extractall</a>.
 </li>
 
 </references>

--- a/python/ql/src/Security/CWE-022/TarSlip.ql
+++ b/python/ql/src/Security/CWE-022/TarSlip.ql
@@ -15,12 +15,28 @@ import python
 import semmle.python.security.Paths
 
 import semmle.python.security.TaintTracking
+import semmle.python.security.strings.Basic
 
 /** A TaintKind to represent open tarfile objects. That is, the result of calling `tarfile.open(...)` */
 class OpenTarFile extends TaintKind {
     OpenTarFile() {
         this = "tarfile.open"
     }
+
+    override TaintKind getTaintOfMethodResult(string name) {
+        name = "getmember" and result instanceof TarFileInfo
+        or
+        name = "getmembers" and result.(SequenceKind).getItem() instanceof TarFileInfo
+    }
+
+    override ClassValue getType() {
+        result = Module::named("tarfile").attr("TarFile")
+    }
+
+    override TaintKind getTaintForIteration() {
+        result instanceof TarFileInfo
+    }
+
 }
 
 /** The source of open tarfile objects. That is, any call to `tarfile.open(...)` */
@@ -41,13 +57,29 @@ class TarfileOpen extends TaintSource {
 
 }
 
-/* Any call to an extract method */
-class ExtractionSink extends TaintSink {
+class TarFileInfo extends TaintKind {
+
+    TarFileInfo() {
+        this = "tarfile.entry"
+    }
+
+    override TaintKind getTaintOfMethodResult(string name) {
+        name = "next" and result = this
+    }
+
+    override TaintKind getTaintOfAttribute(string name) {
+        name = "name" and result instanceof TarFileInfo
+    }
+}
+
+
+/* Any call to an extractall method */
+class ExtractAllSink extends TaintSink {
 
     CallNode call;
 
-    ExtractionSink() {
-        this = call.getFunction().(AttrNode).getObject(extract())
+    ExtractAllSink() {
+        this = call.getFunction().(AttrNode).getObject("extractall")
     }
 
     override predicate sinks(TaintKind kind) {
@@ -56,12 +88,45 @@ class ExtractionSink extends TaintSink {
 
 }
 
-private string extract() {
-    result = "extract" or result = "extractall"
+/* Argument to extract method */
+class ExtractSink extends TaintSink {
+
+    CallNode call;
+
+    ExtractSink() {
+        call.getFunction().(AttrNode).getName() = "extract" and
+        this = call.getArg(0)
+    }
+
+    override predicate sinks(TaintKind kind) {
+        kind instanceof TarFileInfo
+    }
+
 }
 
+class TarFileInfoSanitizer extends Sanitizer {
 
-//evil = [e for e in members if os.path.relpath(e).startswith(('/', '..'))]
+    TarFileInfoSanitizer() {
+        this = "TarInfo sanitizer"
+    }
+
+    override predicate sanitizingEdge(TaintKind taint, PyEdgeRefinement test) {
+        path_sanitizing_test(test.getTest()) and
+        taint instanceof TarFileInfo
+    }
+}
+
+private predicate path_sanitizing_test(ControlFlowNode test) {
+    checks_not_absolute(test) and
+    test.getAChild+().getNode().(StrConst).getText() = ".."
+}
+
+private predicate checks_not_absolute(ControlFlowNode test) {
+    test.getAChild+().(CallNode).getFunction().pointsTo(Module::named("os.path").attr("absfile"))
+    or
+    test.getAChild+().getNode().(StrConst).getText() = "/"
+}
+
 
 class TarSlipConfiguration extends TaintTracking::Configuration {
 
@@ -69,8 +134,13 @@ class TarSlipConfiguration extends TaintTracking::Configuration {
 
     override predicate isSource(TaintTracking::Source source) { source instanceof TarfileOpen }
 
-    override predicate isSink(TaintTracking::Sink sink) { sink instanceof ExtractionSink }
+    override predicate isSink(TaintTracking::Sink sink) { 
+        sink instanceof ExtractSink or sink instanceof ExtractAllSink
+    }
 
+    override predicate isSanitizer(Sanitizer sanitizer) {
+        sanitizer instanceof TarFileInfoSanitizer
+    }
 }
 
 

--- a/python/ql/src/Security/CWE-022/TarSlip.ql
+++ b/python/ql/src/Security/CWE-022/TarSlip.ql
@@ -90,6 +90,8 @@ class ExcludeTarFilePy extends Sanitizer {
             taint instanceof OpenTarFile
             or
             taint instanceof TarFileInfo
+            or
+            taint.(SequenceKind).getItem() instanceof TarFileInfo
         )
     }
 
@@ -162,9 +164,9 @@ class TarFileInfoSanitizer extends Sanitizer {
 
 private predicate path_sanitizing_test(ControlFlowNode test) {
     /* Assume that any test with "path" in it is a sanitizer */
-    test.getAChild+().(AttrNode).getName() = "path"
+    test.getAChild+().(AttrNode).getName().matches("%path")
     or
-    test.getAChild+().(NameNode).getId() = "path"
+    test.getAChild+().(NameNode).getId().matches("%path")
 }
 
 class TarSlipConfiguration extends TaintTracking::Configuration {

--- a/python/ql/src/Security/CWE-022/TarSlip.ql
+++ b/python/ql/src/Security/CWE-022/TarSlip.ql
@@ -1,0 +1,81 @@
+/**
+ * @name Arbitrary file write during tarfile extraction
+ * @description Extracting files from a malicious tar archive without validating that the
+ *              destination file path is within the destination directory can cause files outside
+ *              the destination directory to be overwritten.
+* @kind path-problem
+ * @id py/tarslip
+ * @problem.severity error
+ * @precision medium
+ * @tags security
+ *       external/cwe/cwe-022
+ */
+
+import python
+import semmle.python.security.Paths
+
+import semmle.python.security.TaintTracking
+
+/** A TaintKind to represent open tarfile objects. That is, the result of calling `tarfile.open(...)` */
+class OpenTarFile extends TaintKind {
+    OpenTarFile() {
+        this = "tarfile.open"
+    }
+}
+
+/** The source of open tarfile objects. That is, any call to `tarfile.open(...)` */
+class TarfileOpen extends TaintSource {
+
+    TarfileOpen() {
+        Module::named("tarfile").attr("open").getACall() = this
+        and
+        /* If argument refers to a string object, then it's a hardcoded path and
+         * this tarfile is safe.
+         */
+        not this.(CallNode).getAnArg().refersTo(any(StringObject str))
+    }
+
+    override predicate isSourceOf(TaintKind kind) {
+        kind instanceof OpenTarFile
+    }
+
+}
+
+/* Any call to an extract method */
+class ExtractionSink extends TaintSink {
+
+    CallNode call;
+
+    ExtractionSink() {
+        this = call.getFunction().(AttrNode).getObject(extract())
+    }
+
+    override predicate sinks(TaintKind kind) {
+        kind instanceof OpenTarFile
+    }
+
+}
+
+private string extract() {
+    result = "extract" or result = "extractall"
+}
+
+
+//evil = [e for e in members if os.path.relpath(e).startswith(('/', '..'))]
+
+class TarSlipConfiguration extends TaintTracking::Configuration {
+
+    TarSlipConfiguration() { this = "TarSlip configuration" }
+
+    override predicate isSource(TaintTracking::Source source) { source instanceof TarfileOpen }
+
+    override predicate isSink(TaintTracking::Sink sink) { sink instanceof ExtractionSink }
+
+}
+
+
+from TarSlipConfiguration config, TaintedPathSource src, TaintedPathSink sink
+where config.hasFlowPath(src, sink)
+select sink.getSink(), src, sink, "Extraction of tarfile from $@", src.getSource(), "a potentially untrusted source"
+
+

--- a/python/ql/src/Security/CWE-022/examples/tarslip_bad.py
+++ b/python/ql/src/Security/CWE-022/examples/tarslip_bad.py
@@ -1,0 +1,7 @@
+
+import tarfile
+
+with tarfile.open('archive.zip') as tar:
+    #BAD : This could write any file on the filesystem.
+    for entry in tar:
+        tar.extract(entry, "/tmp/unpack/")

--- a/python/ql/src/Security/CWE-022/examples/tarslip_good.py
+++ b/python/ql/src/Security/CWE-022/examples/tarslip_good.py
@@ -1,0 +1,10 @@
+
+import tarfile
+import os.path
+
+with tarfile.open('archive.zip') as tar:
+    for entry in tar:
+        #GOOD: Check that entry is safe
+        if os.path.isabs(entry.name) or ".." in entry.name:
+            raise ValueError("Illegal tar archive entry")
+        tar.extract(entry, "/tmp/unpack/")

--- a/python/ql/src/semmle/python/security/Paths.qll
+++ b/python/ql/src/semmle/python/security/Paths.qll
@@ -5,7 +5,7 @@ import semmle.python.security.TaintTracking
 query predicate edges(TaintedNode fromnode, TaintedNode tonode) {
     fromnode.getASuccessor() = tonode and
     /* Don't record flow past sinks */
-    not fromnode.isVulnerableSink()
+    not fromnode.isSink()
 }
 
 private TaintedNode first_child(TaintedNode parent) {

--- a/python/ql/src/semmle/python/security/TaintTracking.qll
+++ b/python/ql/src/semmle/python/security/TaintTracking.qll
@@ -703,13 +703,20 @@ class TaintedNode extends TTaintedNode {
     /** Holds if the underlying CFG node for this node is a vulnerable node
      * and is vulnerable to this node's taint.
      */
-    predicate isVulnerableSink() {
+    predicate isSink() {
         exists(TaintedNode src, TaintSink vuln |
             src.isSource() and
             src.getASuccessor*() = this and
             vuln = this.getNode() and
             vuln.sinks(this.getTaintKind())
         )
+    }
+
+    /** DEPRECATED -- Use `TaintedNode.isSink()` instead
+     * Sinks are not necessarily vulnerable
+     * For removal 2020-07-01 */
+    deprecated predicate isVulnerableSink() {
+        this.isSink()
     }
 
     TaintFlowImplementation::TrackedTaint fromAttribute(string name) {

--- a/python/ql/test/query-tests/Security/CWE-022/TarSlip.expected
+++ b/python/ql/test/query-tests/Security/CWE-022/TarSlip.expected
@@ -1,9 +1,13 @@
 edges
 | tarslip.py:12:7:12:39 | tarfile.open | tarslip.py:13:1:13:3 | tarfile.open |
-| tarslip.py:12:7:12:39 | tarfile.open | tarslip.py:14:1:14:3 | tarfile.open |
 | tarslip.py:16:7:16:39 | tarfile.open | tarslip.py:17:14:17:16 | tarfile.open |
-| tarslip.py:16:7:16:39 | tarfile.open | tarslip.py:18:5:18:7 | tarfile.open |
+| tarslip.py:17:5:17:9 | tarfile.entry | tarslip.py:18:17:18:21 | tarfile.entry |
+| tarslip.py:17:14:17:16 | tarfile.open | tarslip.py:17:5:17:9 | tarfile.entry |
+| tarslip.py:33:7:33:39 | tarfile.open | tarslip.py:34:14:34:16 | tarfile.open |
+| tarslip.py:34:5:34:9 | tarfile.entry | tarslip.py:37:17:37:21 | tarfile.entry |
+| tarslip.py:34:14:34:16 | tarfile.open | tarslip.py:34:5:34:9 | tarfile.entry |
 parents
 #select
 | tarslip.py:13:1:13:3 | Taint sink | tarslip.py:12:7:12:39 | tarfile.open | tarslip.py:13:1:13:3 | tarfile.open | Extraction of tarfile from $@ | tarslip.py:12:7:12:39 | Taint source | a potentially untrusted source |
-| tarslip.py:18:5:18:7 | Taint sink | tarslip.py:16:7:16:39 | tarfile.open | tarslip.py:18:5:18:7 | tarfile.open | Extraction of tarfile from $@ | tarslip.py:16:7:16:39 | Taint source | a potentially untrusted source |
+| tarslip.py:18:17:18:21 | Taint sink | tarslip.py:16:7:16:39 | tarfile.open | tarslip.py:18:17:18:21 | tarfile.entry | Extraction of tarfile from $@ | tarslip.py:16:7:16:39 | Taint source | a potentially untrusted source |
+| tarslip.py:37:17:37:21 | Taint sink | tarslip.py:33:7:33:39 | tarfile.open | tarslip.py:37:17:37:21 | tarfile.entry | Extraction of tarfile from $@ | tarslip.py:33:7:33:39 | Taint source | a potentially untrusted source |

--- a/python/ql/test/query-tests/Security/CWE-022/TarSlip.expected
+++ b/python/ql/test/query-tests/Security/CWE-022/TarSlip.expected
@@ -1,0 +1,9 @@
+edges
+| tarslip.py:12:7:12:39 | tarfile.open | tarslip.py:13:1:13:3 | tarfile.open |
+| tarslip.py:12:7:12:39 | tarfile.open | tarslip.py:14:1:14:3 | tarfile.open |
+| tarslip.py:16:7:16:39 | tarfile.open | tarslip.py:17:14:17:16 | tarfile.open |
+| tarslip.py:16:7:16:39 | tarfile.open | tarslip.py:18:5:18:7 | tarfile.open |
+parents
+#select
+| tarslip.py:13:1:13:3 | Taint sink | tarslip.py:12:7:12:39 | tarfile.open | tarslip.py:13:1:13:3 | tarfile.open | Extraction of tarfile from $@ | tarslip.py:12:7:12:39 | Taint source | a potentially untrusted source |
+| tarslip.py:18:5:18:7 | Taint sink | tarslip.py:16:7:16:39 | tarfile.open | tarslip.py:18:5:18:7 | tarfile.open | Extraction of tarfile from $@ | tarslip.py:16:7:16:39 | Taint source | a potentially untrusted source |

--- a/python/ql/test/query-tests/Security/CWE-022/TarSlip.expected
+++ b/python/ql/test/query-tests/Security/CWE-022/TarSlip.expected
@@ -20,7 +20,6 @@ edges
 | tarslip.py:40:7:40:39 | tarfile.open | tarslip.py:41:24:41:26 | tarfile.open |
 | tarslip.py:45:17:45:23 | tarfile.open | tarslip.py:46:17:46:23 | tarfile.open |
 | tarslip.py:46:9:46:12 | tarfile.entry | tarslip.py:47:20:47:23 | tarfile.entry |
-| tarslip.py:46:9:46:12 | tarfile.entry | tarslip.py:49:15:49:18 | tarfile.entry |
 | tarslip.py:46:17:46:23 | tarfile.open | tarslip.py:46:9:46:12 | tarfile.entry |
 | tarslip.py:51:7:51:39 | tarfile.open | tarslip.py:52:1:52:3 | tarfile.open |
 | tarslip.py:51:7:51:39 | tarfile.open | tarslip.py:52:36:52:38 | tarfile.open |
@@ -30,7 +29,6 @@ parents
 | tarslip.py:46:9:46:12 | tarfile.entry | tarslip.py:52:36:52:38 | tarfile.open |
 | tarslip.py:46:17:46:23 | tarfile.open | tarslip.py:52:36:52:38 | tarfile.open |
 | tarslip.py:47:20:47:23 | tarfile.entry | tarslip.py:52:36:52:38 | tarfile.open |
-| tarslip.py:49:15:49:18 | tarfile.entry | tarslip.py:52:36:52:38 | tarfile.open |
 #select
 | tarslip.py:13:1:13:3 | Taint sink | tarslip.py:12:7:12:39 | tarfile.open | tarslip.py:13:1:13:3 | tarfile.open | Extraction of tarfile from $@ | tarslip.py:12:7:12:39 | Taint source | a potentially untrusted source |
 | tarslip.py:18:17:18:21 | Taint sink | tarslip.py:16:7:16:39 | tarfile.open | tarslip.py:18:17:18:21 | tarfile.entry | Extraction of tarfile from $@ | tarslip.py:16:7:16:39 | Taint source | a potentially untrusted source |

--- a/python/ql/test/query-tests/Security/CWE-022/TarSlip.expected
+++ b/python/ql/test/query-tests/Security/CWE-022/TarSlip.expected
@@ -1,13 +1,38 @@
 edges
 | tarslip.py:12:7:12:39 | tarfile.open | tarslip.py:13:1:13:3 | tarfile.open |
+| tarslip.py:12:7:12:39 | tarfile.open | tarslip.py:14:1:14:3 | tarfile.open |
 | tarslip.py:16:7:16:39 | tarfile.open | tarslip.py:17:14:17:16 | tarfile.open |
+| tarslip.py:16:7:16:39 | tarfile.open | tarslip.py:18:5:18:7 | tarfile.open |
 | tarslip.py:17:5:17:9 | tarfile.entry | tarslip.py:18:17:18:21 | tarfile.entry |
 | tarslip.py:17:14:17:16 | tarfile.open | tarslip.py:17:5:17:9 | tarfile.entry |
+| tarslip.py:26:7:26:39 | tarfile.open | tarslip.py:27:14:27:16 | tarfile.open |
+| tarslip.py:26:7:26:39 | tarfile.open | tarslip.py:30:5:30:7 | tarfile.open |
+| tarslip.py:27:5:27:9 | tarfile.entry | tarslip.py:28:22:28:26 | tarfile.entry |
+| tarslip.py:27:14:27:16 | tarfile.open | tarslip.py:27:5:27:9 | tarfile.entry |
+| tarslip.py:28:22:28:26 | tarfile.entry | tarslip.py:28:22:28:31 | tarfile.entry |
 | tarslip.py:33:7:33:39 | tarfile.open | tarslip.py:34:14:34:16 | tarfile.open |
+| tarslip.py:33:7:33:39 | tarfile.open | tarslip.py:37:5:37:7 | tarfile.open |
+| tarslip.py:34:5:34:9 | tarfile.entry | tarslip.py:35:16:35:20 | tarfile.entry |
 | tarslip.py:34:5:34:9 | tarfile.entry | tarslip.py:37:17:37:21 | tarfile.entry |
 | tarslip.py:34:14:34:16 | tarfile.open | tarslip.py:34:5:34:9 | tarfile.entry |
+| tarslip.py:35:16:35:20 | tarfile.entry | tarslip.py:35:16:35:25 | tarfile.entry |
+| tarslip.py:40:7:40:39 | tarfile.open | tarslip.py:41:1:41:3 | tarfile.open |
+| tarslip.py:40:7:40:39 | tarfile.open | tarslip.py:41:24:41:26 | tarfile.open |
+| tarslip.py:45:17:45:23 | tarfile.open | tarslip.py:46:17:46:23 | tarfile.open |
+| tarslip.py:46:9:46:12 | tarfile.entry | tarslip.py:47:20:47:23 | tarfile.entry |
+| tarslip.py:46:9:46:12 | tarfile.entry | tarslip.py:49:15:49:18 | tarfile.entry |
+| tarslip.py:46:17:46:23 | tarfile.open | tarslip.py:46:9:46:12 | tarfile.entry |
+| tarslip.py:51:7:51:39 | tarfile.open | tarslip.py:52:1:52:3 | tarfile.open |
+| tarslip.py:51:7:51:39 | tarfile.open | tarslip.py:52:36:52:38 | tarfile.open |
+| tarslip.py:52:36:52:38 | tarfile.open | tarslip.py:45:17:45:23 | tarfile.open |
 parents
+| tarslip.py:45:17:45:23 | tarfile.open | tarslip.py:52:36:52:38 | tarfile.open |
+| tarslip.py:46:9:46:12 | tarfile.entry | tarslip.py:52:36:52:38 | tarfile.open |
+| tarslip.py:46:17:46:23 | tarfile.open | tarslip.py:52:36:52:38 | tarfile.open |
+| tarslip.py:47:20:47:23 | tarfile.entry | tarslip.py:52:36:52:38 | tarfile.open |
+| tarslip.py:49:15:49:18 | tarfile.entry | tarslip.py:52:36:52:38 | tarfile.open |
 #select
 | tarslip.py:13:1:13:3 | Taint sink | tarslip.py:12:7:12:39 | tarfile.open | tarslip.py:13:1:13:3 | tarfile.open | Extraction of tarfile from $@ | tarslip.py:12:7:12:39 | Taint source | a potentially untrusted source |
 | tarslip.py:18:17:18:21 | Taint sink | tarslip.py:16:7:16:39 | tarfile.open | tarslip.py:18:17:18:21 | tarfile.entry | Extraction of tarfile from $@ | tarslip.py:16:7:16:39 | Taint source | a potentially untrusted source |
 | tarslip.py:37:17:37:21 | Taint sink | tarslip.py:33:7:33:39 | tarfile.open | tarslip.py:37:17:37:21 | tarfile.entry | Extraction of tarfile from $@ | tarslip.py:33:7:33:39 | Taint source | a potentially untrusted source |
+| tarslip.py:41:24:41:26 | Taint sink | tarslip.py:40:7:40:39 | tarfile.open | tarslip.py:41:24:41:26 | tarfile.open | Extraction of tarfile from $@ | tarslip.py:40:7:40:39 | Taint source | a potentially untrusted source |

--- a/python/ql/test/query-tests/Security/CWE-022/TarSlip.qlref
+++ b/python/ql/test/query-tests/Security/CWE-022/TarSlip.qlref
@@ -1,0 +1,1 @@
+Security/CWE-022/TarSlip.ql

--- a/python/ql/test/query-tests/Security/CWE-022/tarslip.py
+++ b/python/ql/test/query-tests/Security/CWE-022/tarslip.py
@@ -1,0 +1,22 @@
+#!/usr/bin/python
+import tarfile
+
+unsafe_filename_tar = sys.argv[1]
+safe_filename_tar = "safe_path.tar"
+
+
+tar = tarfile.open(safe_filename_tar)
+for entry in tar:
+    tar.extract(entry)
+
+tar = tarfile.open(unsafe_filename_tar)
+tar.extractall()
+tar.close()
+
+tar = tarfile.open(unsafe_filename_tar)
+for entry in tar:
+    tar.extract(entry)
+
+tar = tarfile.open(safe_filename_tar)
+tar.extractall()
+tar.close()

--- a/python/ql/test/query-tests/Security/CWE-022/tarslip.py
+++ b/python/ql/test/query-tests/Security/CWE-022/tarslip.py
@@ -20,3 +20,18 @@ for entry in tar:
 tar = tarfile.open(safe_filename_tar)
 tar.extractall()
 tar.close()
+
+
+#Sanitized
+tar = tarfile.open(unsafe_filename_tar)
+for entry in tar:
+    if os.path.isabs(entry.name) or ".." in entry.name:
+        raise ValueError("Illegal tar archive entry")
+    tar.extract(entry, "/tmp/unpack/")
+
+#Part Sanitized
+tar = tarfile.open(unsafe_filename_tar)
+for entry in tar:
+    if ".." in entry.name:
+        raise ValueError("Illegal tar archive entry")
+    tar.extract(entry, "/tmp/unpack/")

--- a/python/ql/test/query-tests/Security/CWE-022/tarslip.py
+++ b/python/ql/test/query-tests/Security/CWE-022/tarslip.py
@@ -35,3 +35,18 @@ for entry in tar:
     if ".." in entry.name:
         raise ValueError("Illegal tar archive entry")
     tar.extract(entry, "/tmp/unpack/")
+
+#Unsanitized members
+tar = tarfile.open(unsafe_filename_tar)
+tar.extractall(members=tar)
+
+
+#Sanitize members
+def safemembers(members):
+    for info in members:
+        if badpath(info):
+            raise
+        yield info
+
+tar = tarfile.open(unsafe_filename_tar)
+tar.extractall(members=safemembers(tar))


### PR DESCRIPTION
TarSlip is a variant of the ZipSlip query.
In the Python standard library, Zip files can be safely extracted, but Tar files need to be checked.
This PR adds a query to check for "TarSlip" vulnerabilities.