### PR TITLE
Python: Don't record taint past sinks.

### DIFF
--- a/python/ql/src/semmle/python/security/Paths.qll
+++ b/python/ql/src/semmle/python/security/Paths.qll
@@ -3,16 +3,18 @@ import python
 import semmle.python.security.TaintTracking
 
 query predicate edges(TaintedNode fromnode, TaintedNode tonode) {
-    fromnode.getASuccessor() = tonode
+    fromnode.getASuccessor() = tonode and
+    /* Don't record flow past sinks */
+    not fromnode.isVulnerableSink()
 }
 
 private TaintedNode first_child(TaintedNode parent) {
     result.getContext().getCaller() = parent.getContext() and
-    parent.getASuccessor() = result
+    edges(parent, result)
 }
 
 private TaintedNode next_sibling(TaintedNode child) {
-    child.getASuccessor() = result and
+    edges(child, result) and
     child.getContext() = result.getContext()
 }
 

--- a/python/ql/test/query-tests/Security/CWE-078/CommandInjection.expected
+++ b/python/ql/test/query-tests/Security/CWE-078/CommandInjection.expected
@@ -1,7 +1,6 @@
 edges
 | command_injection.py:10:13:10:24 | dict of externally controlled string | command_injection.py:10:13:10:41 | externally controlled string |
 | command_injection.py:10:13:10:41 | externally controlled string | command_injection.py:12:23:12:27 | externally controlled string |
-| command_injection.py:12:15:12:27 | externally controlled string | ../lib/os/__init__.py:1:12:1:14 | externally controlled string |
 | command_injection.py:12:23:12:27 | externally controlled string | command_injection.py:12:15:12:27 | externally controlled string |
 | command_injection.py:17:13:17:24 | dict of externally controlled string | command_injection.py:17:13:17:41 | externally controlled string |
 | command_injection.py:17:13:17:41 | externally controlled string | command_injection.py:19:29:19:33 | externally controlled string |
@@ -12,11 +11,8 @@ edges
 | command_injection.py:25:23:25:25 | externally controlled string | command_injection.py:25:22:25:36 | sequence of externally controlled string |
 | command_injection.py:30:13:30:24 | dict of externally controlled string | command_injection.py:30:13:30:41 | externally controlled string |
 | command_injection.py:30:13:30:41 | externally controlled string | command_injection.py:32:22:32:26 | externally controlled string |
-| command_injection.py:32:14:32:26 | externally controlled string | ../lib/os/__init__.py:4:11:4:13 | externally controlled string |
 | command_injection.py:32:22:32:26 | externally controlled string | command_injection.py:32:14:32:26 | externally controlled string |
 parents
-| ../lib/os/__init__.py:1:12:1:14 | externally controlled string | command_injection.py:12:15:12:27 | externally controlled string |
-| ../lib/os/__init__.py:4:11:4:13 | externally controlled string | command_injection.py:32:14:32:26 | externally controlled string |
 #select
 | command_injection.py:12:15:12:27 | shell command | command_injection.py:10:13:10:24 | dict of externally controlled string | command_injection.py:12:15:12:27 | externally controlled string | This command depends on $@. | command_injection.py:10:13:10:24 | flask.request.args | a user-provided value |
 | command_injection.py:19:22:19:34 | shell command | command_injection.py:17:13:17:24 | dict of externally controlled string | command_injection.py:19:22:19:34 | sequence of externally controlled string | This command depends on $@. | command_injection.py:17:13:17:24 | flask.request.args | a user-provided value |

--- a/python/ql/test/query-tests/Security/CWE-502/UnsafeDeserialization.expected
+++ b/python/ql/test/query-tests/Security/CWE-502/UnsafeDeserialization.expected
@@ -4,9 +4,7 @@ edges
 | test.py:11:15:11:41 | externally controlled string | test.py:13:15:13:21 | externally controlled string |
 | test.py:11:15:11:41 | externally controlled string | test.py:14:19:14:25 | externally controlled string |
 | test.py:11:15:11:41 | externally controlled string | test.py:16:16:16:22 | externally controlled string |
-| test.py:13:15:13:21 | externally controlled string | ../lib/yaml.py:1:10:1:10 | externally controlled string |
 parents
-| ../lib/yaml.py:1:10:1:10 | externally controlled string | test.py:13:15:13:21 | externally controlled string |
 #select
 | test.py:12:18:12:24 | unpickling untrusted data | test.py:11:15:11:26 | dict of externally controlled string | test.py:12:18:12:24 | externally controlled string | Deserializing of $@. | test.py:11:15:11:26 | flask.request.args | untrusted input |
 | test.py:13:15:13:21 | yaml.load vulnerability | test.py:11:15:11:26 | dict of externally controlled string | test.py:13:15:13:21 | externally controlled string | Deserializing of $@. | test.py:11:15:11:26 | flask.request.args | untrusted input |

--- a/python/ql/test/query-tests/Security/CWE-601/UrlRedirect.expected
+++ b/python/ql/test/query-tests/Security/CWE-601/UrlRedirect.expected
@@ -1,10 +1,8 @@
 edges
 | test.py:7:22:7:33 | dict of externally controlled string | test.py:7:22:7:51 | externally controlled string |
 | test.py:7:22:7:51 | externally controlled string | test.py:8:21:8:26 | externally controlled string |
-| test.py:8:21:8:26 | externally controlled string | ../lib/flask/__init__.py:11:14:11:21 | externally controlled string |
 | test.py:15:17:15:28 | dict of externally controlled string | test.py:15:17:15:42 | externally controlled string |
 | test.py:15:17:15:42 | externally controlled string | test.py:17:13:17:21 | externally controlled string |
 parents
-| ../lib/flask/__init__.py:11:14:11:21 | externally controlled string | test.py:8:21:8:26 | externally controlled string |
 #select
 | test.py:8:21:8:26 | flask.redirect | test.py:7:22:7:33 | dict of externally controlled string | test.py:8:21:8:26 | externally controlled string | Untrusted URL redirection due to $@. | test.py:7:22:7:33 | flask.request.args | a user-provided value |


### PR DESCRIPTION
Don't add edges past sinks to the `edges` relation.
Reduces the size of results and simplifies writing test cases.