### PR TITLE
Python: Further performance improvements on large databases.

### DIFF
--- a/python/ql/src/semmle/python/Flow.qll
+++ b/python/ql/src/semmle/python/Flow.qll
@@ -956,6 +956,7 @@ class BasicBlock extends @py_flow_node {
 
     /** Dominance frontier of a node x is the set of all nodes `other` such that `this` dominates a predecessor 
      * of `other` but does not strictly dominate `other` */ 
+    pragma[noinline]
     predicate dominanceFrontier(BasicBlock other) {
         this.dominates(other.getAPredecessor()) and not this.strictlyDominates(other)
     }

--- a/python/ql/src/semmle/python/objects/Constants.qll
+++ b/python/ql/src/semmle/python/objects/Constants.qll
@@ -73,11 +73,6 @@ abstract class ConstantObjectInternal extends ObjectInternal {
 
 private abstract class BooleanObjectInternal extends ConstantObjectInternal {
 
-    BooleanObjectInternal() {
-        this = TTrue() or this = TFalse()
-    }
-
-
     override ObjectInternal getClass() {
         result = TBuiltinClassObject(Builtin::special("bool"))
     }


### PR DESCRIPTION
This shaves 3 minutes off the time to evaluate points-to on cinder.