### PR TITLE
JavaScript: Remove dependency of module import on `globalVarRef`.

### DIFF
--- a/javascript/ql/src/semmle/javascript/frameworks/NodeJSLib.qll
+++ b/javascript/ql/src/semmle/javascript/frameworks/NodeJSLib.qll
@@ -13,7 +13,10 @@ module NodeJSLib {
    */
   private class ImplicitProcessImport extends DataFlow::ModuleImportNode::Range {
     ImplicitProcessImport() {
-      this = DataFlow::globalVarRef("process") and
+      exists(GlobalVariable process |
+        process.getName() = "process" and
+        this = DataFlow::exprNode(process.getAnAccess())
+      ) and
       getTopLevel() instanceof NodeModule
     }
 
@@ -24,7 +27,15 @@ module NodeJSLib {
    * Gets a reference to the 'process' object.
    */
   DataFlow::SourceNode process() {
+    result = DataFlow::globalVarRef("process") or
     result = DataFlow::moduleImport("process")
+  }
+
+  /**
+   * Gets a reference to a member of the 'process' object.
+   */
+  private DataFlow::SourceNode processMember(string member) {
+    result = process().getAPropertyRead(member)
   }
 
   /**
@@ -365,7 +376,7 @@ module NodeJSLib {
     ProcessTermination() {
       this = DataFlow::moduleImport("exit").getAnInvocation()
       or
-      this = DataFlow::moduleMember("process", "exit").getACall()
+      this = processMember("exit").getACall()
     }
   }
 

--- a/javascript/ql/test/library-tests/ModuleImportNodes/TSGlobalImport.expected
+++ b/javascript/ql/test/library-tests/ModuleImportNodes/TSGlobalImport.expected
@@ -16,4 +16,3 @@
 | process2.js:1:1:1:13 | require('fs') | fs |
 | process2.js:2:10:2:16 | process | process |
 | process.js:1:10:1:27 | require('process') | process |
-| process.js:2:10:2:23 | global.process | process |

--- a/javascript/ql/test/library-tests/ModuleImportNodes/process.js
+++ b/javascript/ql/test/library-tests/ModuleImportNodes/process.js
@@ -1,2 +1,2 @@
 var p1 = require('process');
-var p2 = global.process;
+var p2 = global.process; // not detected yet

--- a/javascript/ql/test/library-tests/ModuleImportNodes/tests.expected
+++ b/javascript/ql/test/library-tests/ModuleImportNodes/tests.expected
@@ -44,7 +44,6 @@ test_moduleImport
 | net | client1.ts:6:9:6:11 | net |
 | process | process2.js:2:10:2:16 | process |
 | process | process.js:1:10:1:27 | require('process') |
-| process | process.js:2:10:2:23 | global.process |
 test_moduleMember
 | electron | BrowserWindow | destructuringES6.js:1:10:1:22 | BrowserWindow |
 | electron | BrowserWindow | destructuringRequire.js:1:9:1:21 | BrowserWindow |
@@ -78,7 +77,6 @@ test_ModuleImportNode_getPath
 | process2.js:1:1:1:13 | require('fs') | fs |
 | process2.js:2:10:2:16 | process | process |
 | process.js:1:10:1:27 | require('process') | process |
-| process.js:2:10:2:23 | global.process | process |
 test_ModuleImportNode_getAMethodCall
 | amd1.js:1:25:1:26 | fs | amd1.js:2:3:2:29 | fs.read ... a.txt") |
 | amd2.js:2:12:2:24 | require('fs') | amd2.js:3:3:3:29 | fs.read ... a.txt") |


### PR DESCRIPTION
As @asger-semmle pointed out in https://github.com/Semmle/ql/pull/1455, this introduces a circularity that may lead to unpleasant surprises further down the line, so it's probably best to avoid it until we have a compelling reason for it.