### PR TITLE
CPP: Speed up StructWithExactEraDate.ql

### DIFF
--- a/cpp/ql/src/Likely Bugs/JapaneseEra/StructWithExactEraDate.ql
+++ b/cpp/ql/src/Likely Bugs/JapaneseEra/StructWithExactEraDate.ql
@@ -4,6 +4,7 @@
  * @kind problem
  * @problem.severity warning
  * @id cpp/japanese-era/struct-with-exact-era-date
+ * @precision medium
  * @tags reliability
  *       japanese-era
  */

--- a/cpp/ql/src/Likely Bugs/JapaneseEra/StructWithExactEraDate.ql
+++ b/cpp/ql/src/Likely Bugs/JapaneseEra/StructWithExactEraDate.ql
@@ -11,17 +11,37 @@
 import cpp
 import semmle.code.cpp.commons.DateTime
 
+predicate assignedYear(Struct s, YearFieldAccess year, int value)
+{
+  exists(Operation yearAssignment |
+    s.getAField().getAnAccess() = year and
+    yearAssignment.getAnOperand() = year and
+    yearAssignment.getAnOperand().getValue().toInt() = value
+  )
+}
+
+predicate assignedMonth(Struct s, MonthFieldAccess month, int value)
+{
+  exists(Operation monthAssignment |
+    s.getAField().getAnAccess() = month and
+    monthAssignment.getAnOperand() = month and
+    monthAssignment.getAnOperand().getValue().toInt() = value
+  )
+}
+
+predicate assignedDay(Struct s, DayFieldAccess day, int value)
+{
+  exists(Operation dayAssignment |
+    s.getAField().getAnAccess() = day and
+    dayAssignment.getAnOperand() = day and
+    dayAssignment.getAnOperand().getValue().toInt() = value
+  )
+}
+
 from
-  StructLikeClass s, YearFieldAccess year, MonthFieldAccess month, DayFieldAccess day,
-  Operation yearAssignment, Operation monthAssignment, Operation dayAssignment
+  StructLikeClass s, YearFieldAccess year, MonthFieldAccess month, DayFieldAccess day
 where
-  s.getAField().getAnAccess() = year and
-  yearAssignment.getAnOperand() = year and
-  yearAssignment.getAnOperand().getValue().toInt() = 1989 and
-  s.getAField().getAnAccess() = month and
-  monthAssignment.getAnOperand() = month and
-  monthAssignment.getAnOperand().getValue().toInt() = 1 and
-  s.getAField().getAnAccess() = day and
-  dayAssignment.getAnOperand() = day and
-  dayAssignment.getAnOperand().getValue().toInt() = 8
+  assignedYear(s, year, 1989) and
+  assignedMonth(s, month, 1) and
+  assignedDay(s, day, 8)
 select year, "A time struct that is initialized with exact Japanese calendar era start date."


### PR DESCRIPTION
This had been timing out on wireshark, and performing slowly on other projects.

I've also restored the query precision since this should now be good for running on LGTM.