### PR TITLE
JavaScript: Fix potential null-pointer exception in YAML extractor.

### DIFF
--- a/javascript/extractor/src/com/semmle/js/extractor/YAMLExtractor.java
+++ b/javascript/extractor/src/com/semmle/js/extractor/YAMLExtractor.java
@@ -166,8 +166,10 @@ public class YAMLExtractor implements IExtractor {
                 NodeId.scalar,
                 scalar.getValue(),
                 scalar.getImplicit().canOmitTagInPlainScalar());
+        Character style = scalar.getStyle();
+        int styleCode = style == null ? 0 : (int) style;
         trapWriter.addTuple(
-            YAMLTables.YAML_SCALARS, label, (int) scalar.getStyle(), scalar.getValue());
+            YAMLTables.YAML_SCALARS, label, styleCode, scalar.getValue());
       } else if (start.is(Event.ID.SequenceStart)) {
         kind = NodeKind.SEQUENCE;
         SequenceStartEvent sequenceStart = (SequenceStartEvent) start;


### PR DESCRIPTION
`ScalarEvent.getStyle()` is documented as returning `null` for plain scalars, so we need to handle that specially (cf https://github.com/Semmle/ql/blob/master/javascript/ql/src/semmle/javascript/YAML.qll#L100
for the corresponding code in the library, which expects plain style to be encoded as zero).