### PR TITLE
Python: fix nested import stars

### DIFF
--- a/python/ql/src/semmle/python/objects/Modules.qll
+++ b/python/ql/src/semmle/python/objects/Modules.qll
@@ -177,13 +177,8 @@ class PackageObjectInternal extends ModuleObjectInternal, TPackageObject {
         or
         exists(Module init |
             init = this.getSourceModule() and
-            (
-                /* There is no variable shadowing the name of the child module */
-                not exists(EssaVariable var | var.getAUse() = init.getANormalExit() and var.getSourceVariable().getName() = name)
-                or
-                /* The variable shadowing the name of the child module is undefined at exit */
-                ModuleAttributes::pointsToAtExit(init, name, ObjectInternal::undefined(), _)
-            ) and
+            /* The variable shadowing the name of the child module is undefined at exit */
+            ModuleAttributes::pointsToAtExit(init, name, ObjectInternal::undefined(), _) and
             not name = "__init__" and
             value = this.submodule(name) and
             origin = CfgOrigin::fromObject(value)
@@ -249,6 +244,7 @@ class PythonModuleObjectInternal extends ModuleObjectInternal, TPythonModule {
     }
 
     pragma [noinline] override predicate attribute(string name, ObjectInternal value, CfgOrigin origin) {
+        value != ObjectInternal::undefined() and
         ModuleAttributes::pointsToAtExit(this.getSourceModule(), name, value, origin)
     }
 

--- a/python/ql/test/library-tests/PointsTo/import_star/Values.expected
+++ b/python/ql/test/library-tests/PointsTo/import_star/Values.expected
@@ -1,0 +1,4 @@
+| nested/__init__.py:1:6:1:12 | ControlFlowNode for ImportExpr | import | nested/nested.py:0:0:0:0 | Module nested.nested |
+| nested/nested.py:1:1:1:13 | ControlFlowNode for FunctionExpr | import | nested/nested.py:1:1:1:13 | Function nested |
+| test.py:1:6:1:11 | ControlFlowNode for ImportExpr | import | file://:0:0:0:0 | Package nested |
+| test.py:2:1:2:6 | ControlFlowNode for nested | import | nested/nested.py:1:1:1:13 | Function nested |

--- a/python/ql/test/library-tests/PointsTo/import_star/Values.ql
+++ b/python/ql/test/library-tests/PointsTo/import_star/Values.ql
@@ -1,0 +1,7 @@
+
+import python
+
+from ControlFlowNode f, Context ctx, Value v, ControlFlowNode origin
+where
+  f.pointsTo(ctx, v, origin)
+select f, ctx, v

--- a/python/ql/test/library-tests/PointsTo/import_star/nested/__init__.py
+++ b/python/ql/test/library-tests/PointsTo/import_star/nested/__init__.py
@@ -1,0 +1,1 @@
+from .nested import *

--- a/python/ql/test/library-tests/PointsTo/import_star/nested/nested.py
+++ b/python/ql/test/library-tests/PointsTo/import_star/nested/nested.py
@@ -1,0 +1,2 @@
+def nested():
+    pass

--- a/python/ql/test/library-tests/PointsTo/import_star/test.py
+++ b/python/ql/test/library-tests/PointsTo/import_star/test.py
@@ -1,0 +1,2 @@
+from nested import *
+nested

--- a/python/ql/test/library-tests/PointsTo/new/Sanity.ql
+++ b/python/ql/test/library-tests/PointsTo/new/Sanity.ql
@@ -109,7 +109,17 @@ predicate ssa_sanity(string clsname, string problem, string what) {
     )
 }
 
+predicate undefined_sanity(string clsname, string problem, string what) {
+    /* Variables may be undefined, but values cannot be */
+    exists(ControlFlowNode f |
+        PointsToInternal::pointsTo(f, _, ObjectInternal::undefined(), _) and
+        clsname = f.getAQlClass() and not clsname = "AnyNode" and
+        problem = " points-to an undefined variable" and
+        what = f.toString()
+    )
+}
+
 from string clsname, string problem, string what
-where ssa_sanity(clsname, problem, what)
+where ssa_sanity(clsname, problem, what) or undefined_sanity(clsname, problem, what)
 select clsname, what, problem
 


### PR DESCRIPTION
Suppose the have a package `foo` containing `foo/__init__.py` and `foo/foo.py` where 
`foo/__init__.py` contains of `from .foo import *` and
`foo/foo.py` contains `def foo(): pass`.
Then, when we  analyse the code `from foo import *; foo` we get both the module `foo.foo` and the function `foo` for `foo`.

This PR fixes that so that we only get the function `foo`.
