### PR TITLE
JavaScript: Update link to the OWASP XSS prevetion cheat sheet.

### DIFF
--- a/javascript/ql/src/Security/CWE-079/Xss.qhelp
+++ b/javascript/ql/src/Security/CWE-079/Xss.qhelp
@@ -38,7 +38,7 @@ XSS Prevention Cheat Sheet</a>.
 </li>
 <li>
 OWASP:
-<a href="https://www.owasp.org/index.php/XSS_%28Cross_Site_Scripting%29_Prevention_Cheat_Sheet">XSS
+<a href="https://github.com/OWASP/CheatSheetSeries/blob/master/cheatsheets/Cross_Site_Scripting_Prevention_Cheat_Sheet.md">XSS
 (Cross Site Scripting) Prevention Cheat Sheet</a>.
 </li>
 <li>


### PR DESCRIPTION
The cheat sheet has now been moved to GitHub, as mentioned on [the old page](https://www.owasp.org/index.php/XSS_%28Cross_Site_Scripting%29_Prevention_Cheat_Sheet).