### PR TITLE
JS: Tweak a taint step to not rely on predecessor being a SourceNode

### DIFF
--- a/javascript/ql/src/semmle/javascript/dataflow/TaintTracking.qll
+++ b/javascript/ql/src/semmle/javascript/dataflow/TaintTracking.qll
@@ -268,7 +268,8 @@ module TaintTracking {
         (name = "map" or name = "forEach") and
         (i = 0 or i = 2) and
         call.getArgument(0).analyze().getAValue().(AbstractFunction).getFunction() = f and
-        pred.(DataFlow::SourceNode).getAMethodCall(name) = call and
+        call.(DataFlow::MethodCallNode).getMethodName() = name and
+        pred = call.getReceiver() and
         succ = DataFlow::parameterNode(f.getParameter(i))
       )
       or

--- a/javascript/ql/test/library-tests/TaintTracking/BasicTaintTracking.expected
+++ b/javascript/ql/test/library-tests/TaintTracking/BasicTaintTracking.expected
@@ -8,6 +8,7 @@ typeInferenceMismatch
 | addexpr.js:4:10:4:17 | source() | addexpr.js:7:8:7:8 | x |
 | addexpr.js:11:15:11:22 | source() | addexpr.js:21:8:21:12 | value |
 | advanced-callgraph.js:2:13:2:20 | source() | advanced-callgraph.js:6:22:6:22 | v |
+| array-callback.js:2:23:2:30 | source() | array-callback.js:4:10:4:10 | x |
 | booleanOps.js:2:11:2:18 | source() | booleanOps.js:4:8:4:8 | x |
 | booleanOps.js:2:11:2:18 | source() | booleanOps.js:13:10:13:10 | x |
 | booleanOps.js:2:11:2:18 | source() | booleanOps.js:19:10:19:10 | x |

--- a/javascript/ql/test/library-tests/TaintTracking/array-callback.js
+++ b/javascript/ql/test/library-tests/TaintTracking/array-callback.js
@@ -1,0 +1,6 @@
+async function test() {
+  let promisedTaint = source();
+  (await promisedTaint).map(x => {
+    sink(x); // NOT OK
+  });
+}

--- a/javascript/ql/test/query-tests/Security/CWE-079/StoredXss.expected
+++ b/javascript/ql/test/query-tests/Security/CWE-079/StoredXss.expected
@@ -5,6 +5,7 @@ nodes
 | xss-through-filenames.js:26:19:26:24 | files1 |
 | xss-through-filenames.js:29:13:29:23 | files2 |
 | xss-through-filenames.js:29:22:29:23 | [] |
+| xss-through-filenames.js:30:9:30:14 | files1 |
 | xss-through-filenames.js:30:34:30:37 | file |
 | xss-through-filenames.js:31:25:31:28 | file |
 | xss-through-filenames.js:33:19:33:24 | files2 |
@@ -15,10 +16,11 @@ nodes
 edges
 | xss-through-filenames.js:7:43:7:48 | files1 | xss-through-filenames.js:8:18:8:23 | files1 |
 | xss-through-filenames.js:25:43:25:48 | files1 | xss-through-filenames.js:26:19:26:24 | files1 |
-| xss-through-filenames.js:25:43:25:48 | files1 | xss-through-filenames.js:30:34:30:37 | file |
+| xss-through-filenames.js:25:43:25:48 | files1 | xss-through-filenames.js:30:9:30:14 | files1 |
 | xss-through-filenames.js:29:13:29:23 | files2 | xss-through-filenames.js:33:19:33:24 | files2 |
 | xss-through-filenames.js:29:13:29:23 | files2 | xss-through-filenames.js:35:29:35:34 | files2 |
 | xss-through-filenames.js:29:22:29:23 | [] | xss-through-filenames.js:29:13:29:23 | files2 |
+| xss-through-filenames.js:30:9:30:14 | files1 | xss-through-filenames.js:30:34:30:37 | file |
 | xss-through-filenames.js:30:34:30:37 | file | xss-through-filenames.js:31:25:31:28 | file |
 | xss-through-filenames.js:31:25:31:28 | file | xss-through-filenames.js:29:22:29:23 | [] |
 | xss-through-filenames.js:35:13:35:35 | files3 | xss-through-filenames.js:37:19:37:24 | files3 |


### PR DESCRIPTION
One of our taint steps relied on the predecessor being a SourceNode, which meant we didn't get the step `x -> p` in `(await x).map(p => ..)`.

It also meant that sanitizers between the source node and its use could be bypasssed.

We should also consider making `await` expressions into SourceNodes, but that's a separate issue.