### PR TITLE
Python: Don't report uninitialized locals in unreachable code.

### DIFF
--- a/python/ql/src/Variables/UninitializedLocal.ql
+++ b/python/ql/src/Variables/UninitializedLocal.ql
@@ -12,7 +12,7 @@
 
 import python
 import Undefined
-
+import semmle.python.pointsto.PointsTo
 
 predicate uninitialized_local(NameNode use) {
     exists(FastLocalVariable local |
@@ -21,7 +21,7 @@ predicate uninitialized_local(NameNode use) {
     )
     and
     (
-        any(Uninitialized uninit).taints(use)
+        any(Uninitialized uninit).taints(use) and PointsToInternal::reachableBlock(use.getBasicBlock(), _)
         or
         not exists(EssaVariable var | var.getASourceUse() = use)
     )


### PR DESCRIPTION
No tests as it is tricky to produce any error without the combination of library code (which is more often "unreachable" according to points-to) and loop unrolling.
This change cannot add any false positives and any potential additional false negatives should be in library code.