### PR TITLE
CPP: General clean up for the new dates queries

### DIFF
--- a/cpp/ql/src/Likely Bugs/Leap Year/Adding365DaysPerYear.ql
+++ b/cpp/ql/src/Likely Bugs/Leap Year/Adding365DaysPerYear.ql
@@ -5,8 +5,7 @@
  * @problem.severity warning
  * @id cpp/leap-year/adding-365-days-per-year
  * @precision medium
- * @tags security
- *       leap-year
+ * @tags leap-year
  */
 
 import cpp

--- a/cpp/ql/src/Likely Bugs/Leap Year/LeapYear.qll
+++ b/cpp/ql/src/Likely Bugs/Leap Year/LeapYear.qll
@@ -1,5 +1,5 @@
 /**
- * Provides a library for helping create leap year related queries
+ * Provides a library for helping create leap year related queries.
  */
 
 import cpp
@@ -8,7 +8,7 @@ import semmle.code.cpp.controlflow.Guards
 import semmle.code.cpp.commons.DateTime
 
 /**
- * Get the top-level BinaryOperation enclosing the expression e
+ * Get the top-level `BinaryOperation` enclosing the expression e.
  */
 BinaryOperation getATopLevelBinaryOperationExpression(Expr e) {
   result = e.getEnclosingElement().(BinaryOperation)
@@ -17,7 +17,7 @@ BinaryOperation getATopLevelBinaryOperationExpression(Expr e) {
 }
 
 /**
- * Holds if the top-level binary operation for expression `e` includes the operator specified in `operator` with an operand specified by `valueToCheck`
+ * Holds if the top-level binary operation for expression `e` includes the operator specified in `operator` with an operand specified by `valueToCheck`.
  */
 predicate additionalLogicalCheck(Expr e, string operation, int valueToCheck) {
   exists(BinaryLogicalOperation bo | bo = getATopLevelBinaryOperationExpression(e) |
@@ -29,7 +29,7 @@ predicate additionalLogicalCheck(Expr e, string operation, int valueToCheck) {
 }
 
 /**
- * Operation that seems to be checking for leap year
+ * An `Operation` that seems to be checking for leap year.
  */
 class CheckForLeapYearOperation extends Operation {
   CheckForLeapYearOperation() {
@@ -45,12 +45,12 @@ class CheckForLeapYearOperation extends Operation {
 }
 
 /**
- * abstract class of type YearFieldAccess that would represent an access to a year field on a struct and is used for arguing about leap year calculations
+ * A `YearFieldAccess` that would represent an access to a year field on a struct and is used for arguing about leap year calculations.
  */
 abstract class LeapYearFieldAccess extends YearFieldAccess {
   /**
    * Holds if the field access is a modification,
-   * and it involves an arithmetic operation
+   * and it involves an arithmetic operation.
    */
   predicate isModifiedByArithmeticOperation() {
     this.isModified() and
@@ -69,8 +69,8 @@ abstract class LeapYearFieldAccess extends YearFieldAccess {
    * and it involves an arithmetic operation.
    * In order to avoid false positives, the operation does not includes values that are normal for year normalization.
    *
-   * 1900 - struct tm counts years since 1900
-   * 1980/80 -  FAT32 epoch
+   * 1900 - `struct tm` counts years since 1900
+   * 1980/80 - FAT32 epoch
    */
   predicate isModifiedByArithmeticOperationNotForNormalization() {
     this.isModified() and
@@ -122,14 +122,14 @@ abstract class LeapYearFieldAccess extends YearFieldAccess {
   }
 
   /**
-   * Holds if the top-level binary operation includes a modulus operator with an operand specified by `valueToCheck`
+   * Holds if the top-level binary operation includes a modulus operator with an operand specified by `valueToCheck`.
    */
   predicate additionalModulusCheckForLeapYear(int valueToCheck) {
     additionalLogicalCheck(this, "%", valueToCheck)
   }
 
   /**
-   * Holds if the top-level binary operation includes an addition or subtraction operator with an operand specified by `valueToCheck`
+   * Holds if the top-level binary operation includes an addition or subtraction operator with an operand specified by `valueToCheck`.
    */
   predicate additionalAdditionOrSubstractionCheckForLeapYear(int valueToCheck) {
     additionalLogicalCheck(this, "+", valueToCheck) or
@@ -137,7 +137,7 @@ abstract class LeapYearFieldAccess extends YearFieldAccess {
   }
 
   /**
-   * Holds true if this object is used on a modulus 4 operation, which would likely indicate the start of a leap year check
+   * Holds if this object is used on a modulus 4 operation, which would likely indicate the start of a leap year check.
    */
   predicate isUsedInMod4Operation() {
     not this.isModified() and
@@ -149,7 +149,7 @@ abstract class LeapYearFieldAccess extends YearFieldAccess {
   }
 
   /**
-   * Holds true if this object seems to be used in a valid gregorian calendar leap year check
+   * Holds if this object seems to be used in a valid gregorian calendar leap year check.
    */
   predicate isUsedInCorrectLeapYearCheck() {
     // The Gregorian leap year rule is:
@@ -165,14 +165,14 @@ abstract class LeapYearFieldAccess extends YearFieldAccess {
 }
 
 /**
- * YearFieldAccess for SYSTEMTIME struct
+ * `YearFieldAccess` for the `SYSTEMTIME` struct.
  */
 class StructSystemTimeLeapYearFieldAccess extends LeapYearFieldAccess {
   StructSystemTimeLeapYearFieldAccess() { this.toString().matches("wYear") }
 }
 
 /**
- * YearFieldAccess for struct tm
+ * `YearFieldAccess` for `struct tm`.
  */
 class StructTmLeapYearFieldAccess extends LeapYearFieldAccess {
   StructTmLeapYearFieldAccess() { this.toString().matches("tm_year") }
@@ -195,7 +195,7 @@ class StructTmLeapYearFieldAccess extends LeapYearFieldAccess {
 }
 
 /**
- * FunctionCall that includes an operation that is checking for leap year
+ * `FunctionCall` that includes an operation that is checking for leap year.
  */
 class ChecksForLeapYearFunctionCall extends FunctionCall {
   ChecksForLeapYearFunctionCall() {
@@ -206,8 +206,8 @@ class ChecksForLeapYearFunctionCall extends FunctionCall {
 }
 
 /**
- * DataFlow::Configuration for finding a variable access that would flow into
- * a function call that includes an operation to check for leap year
+ * `DataFlow::Configuration` for finding a variable access that would flow into
+ * a function call that includes an operation to check for leap year.
  */
 class LeapYearCheckConfiguration extends DataFlow::Configuration {
   LeapYearCheckConfiguration() { this = "LeapYearCheckConfiguration" }
@@ -222,7 +222,7 @@ class LeapYearCheckConfiguration extends DataFlow::Configuration {
 }
 
 /**
- * DataFlow::Configuration for finding an operation w/hardcoded 365 that will flow into a FILEINFO field
+ * `DataFlow::Configuration` for finding an operation with hardcoded 365 that will flow into a `FILEINFO` field.
  */
 class FiletimeYearArithmeticOperationCheckConfiguration extends DataFlow::Configuration {
   FiletimeYearArithmeticOperationCheckConfiguration() {
@@ -248,7 +248,7 @@ class FiletimeYearArithmeticOperationCheckConfiguration extends DataFlow::Config
 }
 
 /**
- * DataFlow::Configuration for finding an operation w/hardcoded 365 that will flow into any known date/time field
+ * `DataFlow::Configuration` for finding an operation with hardcoded 365 that will flow into any known date/time field.
  */
 class PossibleYearArithmeticOperationCheckConfiguration extends DataFlow::Configuration {
   PossibleYearArithmeticOperationCheckConfiguration() {

--- a/cpp/ql/src/Likely Bugs/Leap Year/LeapYear.qll
+++ b/cpp/ql/src/Likely Bugs/Leap Year/LeapYear.qll
@@ -238,7 +238,7 @@ class FiletimeYearArithmeticOperationCheckConfiguration extends DataFlow::Config
 
   override predicate isSink(DataFlow::Node sink) {
     exists(StructLikeClass dds, FieldAccess fa, AssignExpr aexpr, Expr e | e = sink.asExpr() |
-      dds instanceof FileTimeStruct and
+      dds instanceof PackedTimeType and
       fa.getQualifier().getUnderlyingType() = dds and
       fa.isModified() and
       aexpr.getAChild() = fa and
@@ -269,7 +269,7 @@ class PossibleYearArithmeticOperationCheckConfiguration extends DataFlow::Config
       e = node1.asExpr() and
       aexpr = node2.asExpr()
     |
-      (dds instanceof FileTimeStruct or dds instanceof DateDataStruct) and
+      (dds instanceof PackedTimeType or dds instanceof UnpackedTimeType) and
       fa.getQualifier().getUnderlyingType() = dds and
       aexpr.getLValue() = fa and
       aexpr.getRValue().getAChild*() = e
@@ -278,7 +278,7 @@ class PossibleYearArithmeticOperationCheckConfiguration extends DataFlow::Config
 
   override predicate isSink(DataFlow::Node sink) {
     exists(StructLikeClass dds, FieldAccess fa, AssignExpr aexpr | aexpr = sink.asExpr() |
-      (dds instanceof FileTimeStruct or dds instanceof DateDataStruct) and
+      (dds instanceof PackedTimeType or dds instanceof UnpackedTimeType) and
       fa.getQualifier().getUnderlyingType() = dds and
       fa.isModified() and
       aexpr.getLValue() = fa

--- a/cpp/ql/src/Likely Bugs/Leap Year/LeapYear.qll
+++ b/cpp/ql/src/Likely Bugs/Leap Year/LeapYear.qll
@@ -35,7 +35,7 @@ class CheckForLeapYearOperation extends Operation {
   CheckForLeapYearOperation() {
     exists(BinaryArithmeticOperation bo | bo = this |
       bo.getAnOperand().getValue().toInt() = 4 and
-      bo.getOperator().toString() = "%" and
+      bo.getOperator() = "%" and
       additionalLogicalCheck(this.getEnclosingElement(), "%", 100) and
       additionalLogicalCheck(this.getEnclosingElement(), "%", 400)
     )
@@ -144,7 +144,7 @@ abstract class LeapYearFieldAccess extends YearFieldAccess {
     exists(BinaryArithmeticOperation bo |
       bo.getAnOperand() = this and
       bo.getAnOperand().getValue().toInt() = 4 and
-      bo.getOperator().toString() = "%"
+      bo.getOperator() = "%"
     )
   }
 
@@ -168,14 +168,14 @@ abstract class LeapYearFieldAccess extends YearFieldAccess {
  * `YearFieldAccess` for the `SYSTEMTIME` struct.
  */
 class StructSystemTimeLeapYearFieldAccess extends LeapYearFieldAccess {
-  StructSystemTimeLeapYearFieldAccess() { this.toString() = "wYear" }
+  StructSystemTimeLeapYearFieldAccess() { this.getTarget().getName() = "wYear" }
 }
 
 /**
  * `YearFieldAccess` for `struct tm`.
  */
 class StructTmLeapYearFieldAccess extends LeapYearFieldAccess {
-  StructTmLeapYearFieldAccess() { this.toString() = "tm_year" }
+  StructTmLeapYearFieldAccess() { this.getTarget().getName() = "tm_year" }
 
   override predicate isUsedInCorrectLeapYearCheck() {
     this.isUsedInMod4Operation() and

--- a/cpp/ql/src/Likely Bugs/Leap Year/LeapYear.qll
+++ b/cpp/ql/src/Likely Bugs/Leap Year/LeapYear.qll
@@ -168,14 +168,14 @@ abstract class LeapYearFieldAccess extends YearFieldAccess {
  * `YearFieldAccess` for the `SYSTEMTIME` struct.
  */
 class StructSystemTimeLeapYearFieldAccess extends LeapYearFieldAccess {
-  StructSystemTimeLeapYearFieldAccess() { this.toString().matches("wYear") }
+  StructSystemTimeLeapYearFieldAccess() { this.toString() = "wYear" }
 }
 
 /**
  * `YearFieldAccess` for `struct tm`.
  */
 class StructTmLeapYearFieldAccess extends LeapYearFieldAccess {
-  StructTmLeapYearFieldAccess() { this.toString().matches("tm_year") }
+  StructTmLeapYearFieldAccess() { this.toString() = "tm_year" }
 
   override predicate isUsedInCorrectLeapYearCheck() {
     this.isUsedInMod4Operation() and

--- a/cpp/ql/src/Likely Bugs/Leap Year/LeapYear.qll
+++ b/cpp/ql/src/Likely Bugs/Leap Year/LeapYear.qll
@@ -10,7 +10,7 @@ import semmle.code.cpp.commons.DateTime
 /**
  * Get the top-level `BinaryOperation` enclosing the expression e.
  */
-BinaryOperation getATopLevelBinaryOperationExpression(Expr e) {
+private BinaryOperation getATopLevelBinaryOperationExpression(Expr e) {
   result = e.getEnclosingElement().(BinaryOperation)
   or
   result = getATopLevelBinaryOperationExpression(e.getEnclosingElement())
@@ -19,7 +19,7 @@ BinaryOperation getATopLevelBinaryOperationExpression(Expr e) {
 /**
  * Holds if the top-level binary operation for expression `e` includes the operator specified in `operator` with an operand specified by `valueToCheck`.
  */
-predicate additionalLogicalCheck(Expr e, string operation, int valueToCheck) {
+private predicate additionalLogicalCheck(Expr e, string operation, int valueToCheck) {
   exists(BinaryLogicalOperation bo | bo = getATopLevelBinaryOperationExpression(e) |
     exists(BinaryArithmeticOperation bao | bao = bo.getAChild*() |
       bao.getAnOperand().getValue().toInt() = valueToCheck and

--- a/cpp/ql/src/Likely Bugs/Leap Year/LeapYear.qll
+++ b/cpp/ql/src/Likely Bugs/Leap Year/LeapYear.qll
@@ -59,8 +59,7 @@ abstract class LeapYearFieldAccess extends YearFieldAccess {
       (
         op instanceof AssignArithmeticOperation or
         exists(BinaryArithmeticOperation bao | bao = op.getAnOperand()) or
-        op instanceof PostfixCrementOperation or
-        op instanceof PrefixCrementOperation
+        op instanceof CrementOperation
       )
     )
   }
@@ -117,9 +116,7 @@ abstract class LeapYearFieldAccess extends YearFieldAccess {
           )
         )
         or
-        op instanceof PostfixCrementOperation
-        or
-        op instanceof PrefixCrementOperation
+        op instanceof CrementOperation
       )
     )
   }

--- a/cpp/ql/src/Likely Bugs/Leap Year/UncheckedLeapYearAfterYearModification.ql
+++ b/cpp/ql/src/Likely Bugs/Leap Year/UncheckedLeapYearAfterYearModification.ql
@@ -5,8 +5,7 @@
  * @problem.severity warning
  * @id cpp/leap-year/unchecked-after-arithmetic-year-modification
  * @precision medium
- * @tags security
- *       leap-year
+ * @tags leap-year
  */
 
 import cpp

--- a/cpp/ql/src/Likely Bugs/Leap Year/UncheckedLeapYearAfterYearModificationGood.c
+++ b/cpp/ql/src/Likely Bugs/Leap Year/UncheckedLeapYearAfterYearModificationGood.c
@@ -2,7 +2,7 @@ SYSTEMTIME st;
 FILETIME ft;
 GetSystemTime(&st);
 
-// Flawed logic will result in invalid date
+// Flawed logic may result in invalid date
 st.wYear++;
 
 // Check for leap year, and adjust the date accordingly

--- a/cpp/ql/src/Likely Bugs/Leap Year/UncheckedReturnValueForTimeFunctions.ql
+++ b/cpp/ql/src/Likely Bugs/Leap Year/UncheckedReturnValueForTimeFunctions.ql
@@ -26,7 +26,7 @@ class DateStructModifiedFieldAccess extends LeapYearFieldAccess {
     exists(Field f, StructLikeClass struct |
       f.getAnAccess() = this and
       struct.getAField() = f and
-      struct.getUnderlyingType() instanceof DateDataStruct and
+      struct.getUnderlyingType() instanceof UnpackedTimeType and
       this.isModifiedByArithmeticOperation()
     )
   }
@@ -64,7 +64,7 @@ from FunctionCall fcall, TimeConversionFunction trf, Variable var
 where
   fcall = trf.getACallToThisFunction() and
   fcall instanceof ExprInVoidContext and
-  var.getUnderlyingType() instanceof DateDataStruct and
+  var.getUnderlyingType() instanceof UnpackedTimeType and
   (
     exists(AddressOfExpr aoe |
       aoe = fcall.getAnArgument() and

--- a/cpp/ql/src/Likely Bugs/Leap Year/UncheckedReturnValueForTimeFunctions.ql
+++ b/cpp/ql/src/Likely Bugs/Leap Year/UncheckedReturnValueForTimeFunctions.ql
@@ -17,8 +17,8 @@ import LeapYear
  * NOTE:
  * To change this class to work for general purpose date transformations that do not check the return value,
  * make the following changes:
- *  -> extends FieldAccess (line 27)
- *  -> this.isModified (line 33)
+ *  - change `extends LeapYearFieldAccess` to `extends FieldAccess`.
+ *  - change `this.isModifiedByArithmeticOperation()` to `this.isModified()`.
  * Expect a lower precision for a general purpose version.
  */
 class DateStructModifiedFieldAccess extends LeapYearFieldAccess {

--- a/cpp/ql/src/Likely Bugs/Leap Year/UncheckedReturnValueForTimeFunctions.ql
+++ b/cpp/ql/src/Likely Bugs/Leap Year/UncheckedReturnValueForTimeFunctions.ql
@@ -37,9 +37,9 @@ class DateStructModifiedFieldAccess extends LeapYearFieldAccess {
  */
 class SafeTimeGatheringFunction extends Function {
   SafeTimeGatheringFunction() {
-    this.getQualifiedName().matches("GetFileTime") or
-    this.getQualifiedName().matches("GetSystemTime") or
-    this.getQualifiedName().matches("NtQuerySystemTime")
+    this.getQualifiedName() = "GetFileTime" or
+    this.getQualifiedName() = "GetSystemTime" or
+    this.getQualifiedName() = "NtQuerySystemTime"
   }
 }
 
@@ -48,15 +48,15 @@ class SafeTimeGatheringFunction extends Function {
  */
 class TimeConversionFunction extends Function {
   TimeConversionFunction() {
-    this.getQualifiedName().matches("FileTimeToSystemTime") or
-    this.getQualifiedName().matches("SystemTimeToFileTime") or
-    this.getQualifiedName().matches("SystemTimeToTzSpecificLocalTime") or
-    this.getQualifiedName().matches("SystemTimeToTzSpecificLocalTimeEx") or
-    this.getQualifiedName().matches("TzSpecificLocalTimeToSystemTime") or
-    this.getQualifiedName().matches("TzSpecificLocalTimeToSystemTimeEx") or
-    this.getQualifiedName().matches("RtlLocalTimeToSystemTime") or
-    this.getQualifiedName().matches("RtlTimeToSecondsSince1970") or
-    this.getQualifiedName().matches("_mkgmtime")
+    this.getQualifiedName() = "FileTimeToSystemTime" or
+    this.getQualifiedName() = "SystemTimeToFileTime" or
+    this.getQualifiedName() = "SystemTimeToTzSpecificLocalTime" or
+    this.getQualifiedName() = "SystemTimeToTzSpecificLocalTimeEx" or
+    this.getQualifiedName() = "TzSpecificLocalTimeToSystemTime" or
+    this.getQualifiedName() = "TzSpecificLocalTimeToSystemTimeEx" or
+    this.getQualifiedName() = "RtlLocalTimeToSystemTime" or
+    this.getQualifiedName() = "RtlTimeToSecondsSince1970" or
+    this.getQualifiedName() = "_mkgmtime"
   }
 }
 

--- a/cpp/ql/src/Likely Bugs/Leap Year/UncheckedReturnValueForTimeFunctions.ql
+++ b/cpp/ql/src/Likely Bugs/Leap Year/UncheckedReturnValueForTimeFunctions.ql
@@ -12,7 +12,7 @@ import cpp
 import LeapYear
 
 /**
- * A YearFieldAccess that is modifying the year by any arithmetic operation
+ * A `YearFieldAccess` that is modifying the year by any arithmetic operation.
  *
  * NOTE:
  * To change this class to work for general purpose date transformations that do not check the return value,
@@ -33,7 +33,7 @@ class DateStructModifiedFieldAccess extends LeapYearFieldAccess {
 }
 
 /**
- * This is a list of APIs that will get the system time, and therefore guarantee that the value is valid
+ * This is a list of APIs that will get the system time, and therefore guarantee that the value is valid.
  */
 class SafeTimeGatheringFunction extends Function {
   SafeTimeGatheringFunction() {
@@ -44,7 +44,7 @@ class SafeTimeGatheringFunction extends Function {
 }
 
 /**
- * This list of APIs should check for the return value to detect problems during the conversion
+ * This list of APIs should check for the return value to detect problems during the conversion.
  */
 class TimeConversionFunction extends Function {
   TimeConversionFunction() {

--- a/cpp/ql/src/Likely Bugs/Leap Year/UncheckedReturnValueForTimeFunctions.ql
+++ b/cpp/ql/src/Likely Bugs/Leap Year/UncheckedReturnValueForTimeFunctions.ql
@@ -5,8 +5,7 @@
  * @problem.severity warning
  * @id cpp/leap-year/unchecked-return-value-for-time-conversion-function
  * @precision medium
- * @tags security
- *       leap-year
+ * @tags leap-year
  */
 
 import cpp

--- a/cpp/ql/src/Likely Bugs/Leap Year/UnsafeArrayForDaysOfYear.ql
+++ b/cpp/ql/src/Likely Bugs/Leap Year/UnsafeArrayForDaysOfYear.ql
@@ -16,22 +16,26 @@ class LeapYearUnsafeDaysOfTheYearArrayType extends ArrayType {
   LeapYearUnsafeDaysOfTheYearArrayType() { this.getArraySize() = 365 }
 }
 
-from Element element
+from Element element, string allocType
 where
   exists(NewArrayExpr nae |
     element = nae and
-    nae.getAllocatedType() instanceof LeapYearUnsafeDaysOfTheYearArrayType
+    nae.getAllocatedType() instanceof LeapYearUnsafeDaysOfTheYearArrayType and
+    allocType = "an array allocation"
   )
   or
   exists(Variable var |
     var = element and
-    var.getType() instanceof LeapYearUnsafeDaysOfTheYearArrayType
+    var.getType() instanceof LeapYearUnsafeDaysOfTheYearArrayType and
+    allocType = "an array allocation"
   )
   or
   exists(ConstructorCall cc |
     element = cc and
     cc.getTarget().hasName("vector") and
-    cc.getArgument(0).getValue().toInt() = 365
+    cc.getArgument(0).getValue().toInt() = 365 and
+    allocType = "a std::vector allocation"
   )
 select element,
-  "There is an array or std::vector allocation with a hard-coded set of 365 elements, which may indicate the number of days in a year without considering leap year scenarios."
+  "There is " + allocType +
+    " with a hard-coded set of 365 elements, which may indicate the number of days in a year without considering leap year scenarios."

--- a/cpp/ql/src/semmle/code/cpp/commons/DateTime.qll
+++ b/cpp/ql/src/semmle/code/cpp/commons/DateTime.qll
@@ -9,8 +9,8 @@ import cpp
  */
 class FileTimeStruct extends Type {
   FileTimeStruct() {
-    this.toString() = "_FILETIME"
-    or this.toString().matches("_FILETIME %")
+    this.getName() = "_FILETIME"
+    or this.getName().matches("_FILETIME %")
   }
 }
 
@@ -20,12 +20,12 @@ class FileTimeStruct extends Type {
  */
 class DateDataStruct extends Type {
   DateDataStruct() {
-    this.toString() = "_SYSTEMTIME"
-    or this.toString() = "SYSTEMTIME"
-    or this.toString() = "tm"
-    or this.toString().matches("_SYSTEMTIME %")
-    or this.toString().matches("SYSTEMTIME %")
-    or this.toString().matches("tm %")
+    this.getName() = "_SYSTEMTIME"
+    or this.getName() = "SYSTEMTIME"
+    or this.getName() = "tm"
+    or this.getName().matches("_SYSTEMTIME %")
+    or this.getName().matches("SYSTEMTIME %")
+    or this.getName().matches("tm %")
   }
 }
 
@@ -61,7 +61,7 @@ abstract class YearFieldAccess extends StructFieldAccess {}
  */
 class SystemTimeDayFieldAccess extends DayFieldAccess {
   SystemTimeDayFieldAccess () {
-    this.toString() = "wDay"
+    this.getTarget().getName() = "wDay"
   }
 }
 
@@ -70,7 +70,7 @@ class SystemTimeDayFieldAccess extends DayFieldAccess {
  */
 class SystemTimeMonthFieldAccess extends MonthFieldAccess {
   SystemTimeMonthFieldAccess () {
-    this.toString() = "wMonth"
+    this.getTarget().getName() = "wMonth"
   }
 }
 
@@ -79,7 +79,7 @@ class SystemTimeMonthFieldAccess extends MonthFieldAccess {
  */
 class StructSystemTimeYearFieldAccess extends YearFieldAccess {
   StructSystemTimeYearFieldAccess() {
-    this.toString() = "wYear"
+    this.getTarget().getName() = "wYear"
   }
 }
 
@@ -88,7 +88,7 @@ class StructSystemTimeYearFieldAccess extends YearFieldAccess {
  */
 class StructTmDayFieldAccess extends DayFieldAccess {
   StructTmDayFieldAccess() {
-    this.toString() = "tm_mday"
+    this.getTarget().getName() = "tm_mday"
   }
 }
 
@@ -97,7 +97,7 @@ class StructTmDayFieldAccess extends DayFieldAccess {
  */
 class StructTmMonthFieldAccess extends MonthFieldAccess {
   StructTmMonthFieldAccess() {
-    this.toString() = "tm_mon"
+    this.getTarget().getName() = "tm_mon"
   }
 }
 
@@ -106,6 +106,6 @@ class StructTmMonthFieldAccess extends MonthFieldAccess {
  */
 class StructTmYearFieldAccess extends YearFieldAccess {
   StructTmYearFieldAccess() {
-    this.toString() = "tm_year"
+    this.getTarget().getName() = "tm_year"
   }
 }

--- a/cpp/ql/src/semmle/code/cpp/commons/DateTime.qll
+++ b/cpp/ql/src/semmle/code/cpp/commons/DateTime.qll
@@ -32,8 +32,8 @@ class DateDataStruct extends Type {
 /**
  * A `FieldAccess` that would represent an access to a field on a `struct`.
  */
-abstract class StructFieldAccess extends FieldAccess {
-    StructFieldAccess () {
+private abstract class DateStructFieldAccess extends FieldAccess {
+    DateStructFieldAccess () {
       exists(Field f, StructLikeClass struct |
         f.getAnAccess() = this
         and struct.getAField() = f
@@ -44,17 +44,17 @@ abstract class StructFieldAccess extends FieldAccess {
 /**
  * A `FieldAccess` where access is to a day of the month field of the `struct`.
  */
-abstract class DayFieldAccess extends StructFieldAccess { }
+abstract class DayFieldAccess extends DateStructFieldAccess { }
 
 /**
  * A `FieldAccess` where access is to a month field of the `struct`.
  */
-abstract class MonthFieldAccess extends StructFieldAccess {}
+abstract class MonthFieldAccess extends DateStructFieldAccess {}
 
 /**
  * A `FieldAccess` where access is to a year field of the `struct`.
  */
-abstract class YearFieldAccess extends StructFieldAccess {}
+abstract class YearFieldAccess extends DateStructFieldAccess {}
 
 /**
  * A `DayFieldAccess` for the `SYSTEMTIME` struct.

--- a/cpp/ql/src/semmle/code/cpp/commons/DateTime.qll
+++ b/cpp/ql/src/semmle/code/cpp/commons/DateTime.qll
@@ -1,9 +1,12 @@
 /**
- * Provides a library for helping working with a set of known data structures representing dates in C++
+ * Provides a library for helping working with a set of known data structures representing dates in C++.
  */
 
 import cpp
 
+/**
+ * A type that is used to represent time in a 'packed' form, such as an integer.
+ */
 class FileTimeStruct extends Type {
   FileTimeStruct() {
     this.toString().matches("_FILETIME")
@@ -12,7 +15,8 @@ class FileTimeStruct extends Type {
 }
 
 /**
- * Type of known data structures that are used for date representation.
+ * A type that is used to represent times and dates in an 'unpacked' form, that is,
+ * with separate fields for day, month, year etc.
  */
 class DateDataStruct extends Type {
   DateDataStruct() {
@@ -26,7 +30,7 @@ class DateDataStruct extends Type {
 }
 
 /**
- * abstract class of type FieldAccess that would represent an access to a field on a struct
+ * A `FieldAccess` that would represent an access to a field on a `struct`.
  */
 abstract class StructFieldAccess extends FieldAccess {
     StructFieldAccess () {
@@ -38,25 +42,22 @@ abstract class StructFieldAccess extends FieldAccess {
 }
 
 /**
- * abstract class of type FieldAccess where access is to a day of the month field of the struct
- * This is to be derived from for a specific struct's day of the month field access
+ * A `FieldAccess` where access is to a day of the month field of the `struct`.
  */
 abstract class DayFieldAccess extends StructFieldAccess { }
 
 /**
- * abstract class of type FieldAccess where access is to a month field of the struct
- * This is to be derived from for a specific struct's month field access
+ * A `FieldAccess` where access is to a month field of the `struct`.
  */
 abstract class MonthFieldAccess extends StructFieldAccess {}
 
 /**
- * abstract class of type FieldAccess where access is to a year field of the struct
- * This is to be derived from for a specific struct's year field access
+ * A `FieldAccess` where access is to a year field of the `struct`.
  */
 abstract class YearFieldAccess extends StructFieldAccess {}
 
 /**
- * DayFieldAccess for SYSTEMTIME struct
+ * A `DayFieldAccess` for the `SYSTEMTIME` struct.
  */
 class SystemTimeDayFieldAccess extends DayFieldAccess {
   SystemTimeDayFieldAccess () {
@@ -65,7 +66,7 @@ class SystemTimeDayFieldAccess extends DayFieldAccess {
 }
 
 /**
- * MonthFieldAccess for SYSTEMTIME struct
+ * A `MonthFieldAccess` for the `SYSTEMTIME` struct.
  */
 class SystemTimeMonthFieldAccess extends MonthFieldAccess {
   SystemTimeMonthFieldAccess () {
@@ -74,7 +75,7 @@ class SystemTimeMonthFieldAccess extends MonthFieldAccess {
 }
 
 /**
- * YearFieldAccess for SYSTEMTIME struct
+ * A `YearFieldAccess` for the `SYSTEMTIME` struct.
  */
 class StructSystemTimeYearFieldAccess extends YearFieldAccess {
   StructSystemTimeYearFieldAccess() {
@@ -83,7 +84,7 @@ class StructSystemTimeYearFieldAccess extends YearFieldAccess {
 }
 
 /**
- * DayFieldAccess for struct tm
+ * A `DayFieldAccess` for `struct tm`.
  */
 class StructTmDayFieldAccess extends DayFieldAccess {
   StructTmDayFieldAccess() {
@@ -92,7 +93,7 @@ class StructTmDayFieldAccess extends DayFieldAccess {
 }
 
 /**
- * MonthFieldAccess for struct tm
+ * A `MonthFieldAccess` for `struct tm`.
  */
 class StructTmMonthFieldAccess extends MonthFieldAccess {
   StructTmMonthFieldAccess() {
@@ -101,7 +102,7 @@ class StructTmMonthFieldAccess extends MonthFieldAccess {
 }
 
 /**
- * YearFieldAccess for struct tm
+ * A `YearFieldAccess` for `struct tm`.
  */
 class StructTmYearFieldAccess extends YearFieldAccess {
   StructTmYearFieldAccess() {

--- a/cpp/ql/src/semmle/code/cpp/commons/DateTime.qll
+++ b/cpp/ql/src/semmle/code/cpp/commons/DateTime.qll
@@ -9,7 +9,7 @@ import cpp
  */
 class FileTimeStruct extends Type {
   FileTimeStruct() {
-    this.toString().matches("_FILETIME")
+    this.toString() = "_FILETIME"
     or this.toString().matches("_FILETIME %")
   }
 }
@@ -20,9 +20,9 @@ class FileTimeStruct extends Type {
  */
 class DateDataStruct extends Type {
   DateDataStruct() {
-    this.toString().matches("_SYSTEMTIME")
-    or this.toString().matches("SYSTEMTIME")
-    or this.toString().matches("tm")
+    this.toString() = "_SYSTEMTIME"
+    or this.toString() = "SYSTEMTIME"
+    or this.toString() = "tm"
     or this.toString().matches("_SYSTEMTIME %")
     or this.toString().matches("SYSTEMTIME %")
     or this.toString().matches("tm %")
@@ -61,7 +61,7 @@ abstract class YearFieldAccess extends StructFieldAccess {}
  */
 class SystemTimeDayFieldAccess extends DayFieldAccess {
   SystemTimeDayFieldAccess () {
-    this.toString().matches("wDay") 
+    this.toString() = "wDay"
   }
 }
 
@@ -70,7 +70,7 @@ class SystemTimeDayFieldAccess extends DayFieldAccess {
  */
 class SystemTimeMonthFieldAccess extends MonthFieldAccess {
   SystemTimeMonthFieldAccess () {
-    this.toString().matches("wMonth") 
+    this.toString() = "wMonth"
   }
 }
 
@@ -79,7 +79,7 @@ class SystemTimeMonthFieldAccess extends MonthFieldAccess {
  */
 class StructSystemTimeYearFieldAccess extends YearFieldAccess {
   StructSystemTimeYearFieldAccess() {
-    this.toString().matches("wYear") 
+    this.toString() = "wYear"
   }
 }
 
@@ -88,7 +88,7 @@ class StructSystemTimeYearFieldAccess extends YearFieldAccess {
  */
 class StructTmDayFieldAccess extends DayFieldAccess {
   StructTmDayFieldAccess() {
-    this.toString().matches("tm_mday") 
+    this.toString() = "tm_mday"
   }
 }
 
@@ -97,7 +97,7 @@ class StructTmDayFieldAccess extends DayFieldAccess {
  */
 class StructTmMonthFieldAccess extends MonthFieldAccess {
   StructTmMonthFieldAccess() {
-    this.toString().matches("tm_mon") 
+    this.toString() = "tm_mon"
   }
 }
 
@@ -106,6 +106,6 @@ class StructTmMonthFieldAccess extends MonthFieldAccess {
  */
 class StructTmYearFieldAccess extends YearFieldAccess {
   StructTmYearFieldAccess() {
-    this.toString().matches("tm_year") 
+    this.toString() = "tm_year"
   }
 }

--- a/cpp/ql/src/semmle/code/cpp/commons/DateTime.qll
+++ b/cpp/ql/src/semmle/code/cpp/commons/DateTime.qll
@@ -7,8 +7,8 @@ import cpp
 /**
  * A type that is used to represent time in a 'packed' form, such as an integer.
  */
-class FileTimeStruct extends Type {
-  FileTimeStruct() {
+class PackedTimeType extends Type {
+  PackedTimeType() {
     this.getName() = "_FILETIME"
     or this.getName().matches("_FILETIME %")
   }
@@ -18,8 +18,8 @@ class FileTimeStruct extends Type {
  * A type that is used to represent times and dates in an 'unpacked' form, that is,
  * with separate fields for day, month, year etc.
  */
-class DateDataStruct extends Type {
-  DateDataStruct() {
+class UnpackedTimeType extends Type {
+  UnpackedTimeType() {
     this.getName() = "_SYSTEMTIME"
     or this.getName() = "SYSTEMTIME"
     or this.getName() = "tm"

--- a/cpp/ql/test/query-tests/Likely Bugs/Leap Year/UnsafeArrayForDaysOfYear/UnsafeArrayForDaysOfYear.expected
+++ b/cpp/ql/test/query-tests/Likely Bugs/Leap Year/UnsafeArrayForDaysOfYear/UnsafeArrayForDaysOfYear.expected
@@ -1,3 +1,3 @@
-| test.cpp:17:6:17:10 | items | There is an array or std::vector allocation with a hard-coded set of 365 elements, which may indicate the number of days in a year without considering leap year scenarios. |
-| test.cpp:25:15:25:26 | new[] | There is an array or std::vector allocation with a hard-coded set of 365 elements, which may indicate the number of days in a year without considering leap year scenarios. |
-| test.cpp:52:20:52:23 | call to vector | There is an array or std::vector allocation with a hard-coded set of 365 elements, which may indicate the number of days in a year without considering leap year scenarios. |
+| test.cpp:17:6:17:10 | items | There is an array allocation with a hard-coded set of 365 elements, which may indicate the number of days in a year without considering leap year scenarios. |
+| test.cpp:25:15:25:26 | new[] | There is an array allocation with a hard-coded set of 365 elements, which may indicate the number of days in a year without considering leap year scenarios. |
+| test.cpp:52:20:52:23 | call to vector | There is a std::vector allocation with a hard-coded set of 365 elements, which may indicate the number of days in a year without considering leap year scenarios. |


### PR DESCRIPTION
There are a lot of small changes here.  None should affect results.

I'm keen to get feedback on the 'Rename the classes for time structs.' commit - I think my names describe what the classes are trying to do better than the original names did, but perhaps we can do better?