### PR TITLE
C++: fix FP with ExprHasNoEffect in defaulted func

### DIFF
--- a/cpp/ql/src/Likely Bugs/Likely Typos/ExprHasNoEffect.ql
+++ b/cpp/ql/src/Likely Bugs/Likely Typos/ExprHasNoEffect.ql
@@ -73,6 +73,7 @@ where // EQExprs are covered by CompareWhereAssignMeant.ql
       not baseCall(peivc) and
       not accessInInitOfForStmt(peivc) and
       not peivc.isCompilerGenerated() and
+      not peivc.getEnclosingFunction().isDefaulted() and
       not exists(Macro m | peivc = m.getAnInvocation().getAnExpandedElement()) and
       not peivc.isFromTemplateInstantiation(_) and
       parent = peivc.getParent() and


### PR DESCRIPTION
This is a workaround for an extractor issue where expressions in a
defaulted function are not always marked as generated. I haven't yet been
able to reproduce the issue in a test case.