### PR TITLE
Add Alistair as code owner for *.qhelp within cpp

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -2,3 +2,4 @@
 /java/ @Semmle/java
 /javascript/ @Semmle/js
 /cpp/ @Semmle/cpp-analysis
+/cpp/**/*.qhelp @semmledocs-ac


### PR DESCRIPTION
This should ensure that Alistair (@semmledocs-ac) is notified on every PR that changes a `*.qhelp` file within the `cpp` top-level directory.

I don't know how to test this before merging it. I tried to follow https://help.github.com/en/articles/about-code-owners, which refers to https://git-scm.com/docs/gitignore#_pattern_format.