### PR TITLE
C#: Remove `@precision` for new date queries

### DIFF
--- a/csharp/ql/src/Likely Bugs/LeapYear/UnsafeYearConstruction.ql
+++ b/csharp/ql/src/Likely Bugs/LeapYear/UnsafeYearConstruction.ql
@@ -4,7 +4,6 @@
  * @kind path-problem
  * @problem.severity error
  * @id cs/unsafe-year-construction
- * @precision high
  * @tags security
  *       date-time
  *       reliability

--- a/csharp/ql/src/Likely Bugs/MishandlingJapaneseEra.ql
+++ b/csharp/ql/src/Likely Bugs/MishandlingJapaneseEra.ql
@@ -4,7 +4,6 @@
  * @id cs/mishandling-japanese-era
  * @kind problem
  * @problem.severity warning
- * @precision medium
  * @tags reliability
  *       date-time
  */


### PR DESCRIPTION
Removing the `@precision` annotation until we know how precise these queries actually are for projects on LGTM.com.