### PR TITLE
CPP: Improvements to ContinueInFalseLoop.ql

### DIFF
--- a/change-notes/1.22/analysis-cpp.md
+++ b/change-notes/1.22/analysis-cpp.md
@@ -11,6 +11,7 @@
 
 | **Query**                  | **Expected impact**    | **Change**                                                       |
 |----------------------------|------------------------|------------------------------------------------------------------|
+| Continue statement that does not continue (`cpp/continue-in-false-loop`) | Fewer false positive results | Analysis is now restricted to `do`-`while` loops. |
 | Expression has no effect (`cpp/useless-expression`) | Fewer false positive results | Calls to functions with the `weak` attribute are no longer considered to be side effect free, because they could be overridden with a different implementation at link time. |
 | No space for zero terminator (`cpp/no-space-for-terminator`) | Fewer false positive results | False positives involving strings that are not null-terminated have been excluded. |
 | Suspicious pointer scaling (`cpp/suspicious-pointer-scaling`) | Lower precision | The precision of this query has been reduced to "medium". This coding pattern is used intentionally and safely in a number of real-world projects. Results are no longer displayed on LGTM unless you choose to display them. |

--- a/change-notes/1.22/analysis-cpp.md
+++ b/change-notes/1.22/analysis-cpp.md
@@ -11,7 +11,7 @@
 
 | **Query**                  | **Expected impact**    | **Change**                                                       |
 |----------------------------|------------------------|------------------------------------------------------------------|
-| Continue statement that does not continue (`cpp/continue-in-false-loop`) | Fewer false positive results | Analysis is now restricted to `do`-`while` loops. |
+| Continue statement that does not continue (`cpp/continue-in-false-loop`) | Fewer false positive results | Analysis is now restricted to `do`-`while` loops. This query is now run and displayed by default on LGTM. |
 | Expression has no effect (`cpp/useless-expression`) | Fewer false positive results | Calls to functions with the `weak` attribute are no longer considered to be side effect free, because they could be overridden with a different implementation at link time. |
 | No space for zero terminator (`cpp/no-space-for-terminator`) | Fewer false positive results | False positives involving strings that are not null-terminated have been excluded. |
 | Suspicious pointer scaling (`cpp/suspicious-pointer-scaling`) | Lower precision | The precision of this query has been reduced to "medium". This coding pattern is used intentionally and safely in a number of real-world projects. Results are no longer displayed on LGTM unless you choose to display them. |

--- a/cpp/ql/src/Likely Bugs/ContinueInFalseLoop.qhelp
+++ b/cpp/ql/src/Likely Bugs/ContinueInFalseLoop.qhelp
@@ -1,0 +1,24 @@
+<!DOCTYPE qhelp PUBLIC
+  "-//Semmle//qhelp//EN"
+  "qhelp.dtd">
+<qhelp>
+
+
+<overview>
+<p>A <code>continue</code> statement only re-runs the loop if the loop-condition is true. Therefore using <code>continue</code> in a loop with a constant false condition will never cause the loop body to be re-run, which is is misleading.
+</p>
+
+</overview>
+<recommendation>
+
+<p>Replace the <code>continue</code> statement with a <code>break</code> statement if the intent is to break from the loop.
+</p>
+
+</recommendation>
+
+<references>
+<li>
+  Tutorialspoint - C Programming Language: <a href="https://www.tutorialspoint.com/cprogramming/c_continue_statement.htm">Continue Statement in C</a>
+</li>
+</references>
+</qhelp>

--- a/cpp/ql/src/Likely Bugs/ContinueInFalseLoop.qhelp
+++ b/cpp/ql/src/Likely Bugs/ContinueInFalseLoop.qhelp
@@ -5,7 +5,7 @@
 
 
 <overview>
-<p>A <code>continue</code> statement only re-runs the loop if the loop-condition is true. Therefore using <code>continue</code> in a loop with a constant false condition will never cause the loop body to be re-run, which is is misleading.
+<p>A <code>continue</code> statement only re-runs the loop if the loop condition is true. Therefore using <code>continue</code> in a loop with a constant false condition will never cause the loop body to be re-run, which is misleading.
 </p>
 
 </overview>
@@ -18,7 +18,7 @@
 
 <references>
 <li>
-  Tutorialspoint - C Programming Language: <a href="https://www.tutorialspoint.com/cprogramming/c_continue_statement.htm">Continue Statement in C</a>
+  Tutorialspoint - C Programming Language: <a href="https://www.tutorialspoint.com/cprogramming/c_continue_statement.htm">Continue Statement in C</a>.
 </li>
 </references>
 </qhelp>

--- a/cpp/ql/src/Likely Bugs/ContinueInFalseLoop.ql
+++ b/cpp/ql/src/Likely Bugs/ContinueInFalseLoop.ql
@@ -5,8 +5,8 @@
  *              a bug.
  * @kind problem
  * @id cpp/continue-in-false-loop
- * @problem.severity recommendation
- * @precision medium
+ * @problem.severity warning
+ * @precision high
  * @tags correctness
  */
 

--- a/cpp/ql/src/Likely Bugs/ContinueInFalseLoop.ql
+++ b/cpp/ql/src/Likely Bugs/ContinueInFalseLoop.ql
@@ -21,15 +21,25 @@ DoStmt getAFalseLoop() {
 }
 
 /**
- * Gets a `do` ... `while` loop surrounding a statement.
+ * Gets a `do` ... `while` loop surrounding a statement.  This is blocked by a
+ * `switch` statement, since a `continue` inside a `switch` inside a loop may be
+ * jusitifed (`continue` breaks out of the loop whereas `break` only escapes the
+ * `switch`).
  */
 DoStmt enclosingLoop(Stmt s) {
   exists(Stmt parent |
     parent = s.getParent() and
-    if parent instanceof Loop then
-      result = parent
-    else
-      result = enclosingLoop(parent))
+    (
+      (
+        parent instanceof Loop and
+        result = parent
+      ) or (
+        not parent instanceof Loop and
+        not parent instanceof SwitchStmt and
+        result = enclosingLoop(parent)
+      )
+    )
+  )
 }
 
 from DoStmt loop, ContinueStmt continue

--- a/cpp/ql/src/Likely Bugs/ContinueInFalseLoop.ql
+++ b/cpp/ql/src/Likely Bugs/ContinueInFalseLoop.ql
@@ -5,7 +5,9 @@
  *              a bug.
  * @kind problem
  * @id cpp/continue-in-false-loop
- * @problem.severity warning
+ * @problem.severity recommendation
+ * @precision medium
+ * @tags correctness
  */
 
 import cpp

--- a/cpp/ql/src/Likely Bugs/ContinueInFalseLoop.ql
+++ b/cpp/ql/src/Likely Bugs/ContinueInFalseLoop.ql
@@ -10,12 +10,12 @@
 
 import cpp
 
-Loop getAFalseLoop() {
+DoStmt getAFalseLoop() {
   result.getControllingExpr().getValue() = "0"
   and not result.getControllingExpr().isAffectedByMacro()
 }
 
-Loop enclosingLoop(Stmt s) {
+DoStmt enclosingLoop(Stmt s) {
   exists(Stmt parent |
     parent = s.getParent() and
     if parent instanceof Loop then
@@ -24,7 +24,7 @@ Loop enclosingLoop(Stmt s) {
       result = enclosingLoop(parent))
 }
 
-from Loop loop, ContinueStmt continue
+from DoStmt loop, ContinueStmt continue
 where loop = getAFalseLoop()
   and loop = enclosingLoop(continue)
 select continue,

--- a/cpp/ql/src/Likely Bugs/ContinueInFalseLoop.ql
+++ b/cpp/ql/src/Likely Bugs/ContinueInFalseLoop.ql
@@ -12,11 +12,17 @@
 
 import cpp
 
+/**
+ * Gets a `do` ... `while` loop with a constant false condition.
+ */
 DoStmt getAFalseLoop() {
   result.getControllingExpr().getValue() = "0"
   and not result.getControllingExpr().isAffectedByMacro()
 }
 
+/**
+ * Gets a `do` ... `while` loop surrounding a statement.
+ */
 DoStmt enclosingLoop(Stmt s) {
   exists(Stmt parent |
     parent = s.getParent() and

--- a/cpp/ql/test/query-tests/Likely Bugs/ContinueInFalseLoop/ContinueInFalseLoop.expected
+++ b/cpp/ql/test/query-tests/Likely Bugs/ContinueInFalseLoop/ContinueInFalseLoop.expected
@@ -1,0 +1,4 @@
+| test.cpp:13:4:13:12 | continue; | This 'continue' never re-runs the loop - the $@ is always false. | test.cpp:16:11:16:15 | 0 | loop condition |
+| test.cpp:39:4:39:12 | continue; | This 'continue' never re-runs the loop - the $@ is always false. | test.cpp:36:9:36:13 | 0 | loop condition |
+| test.cpp:47:4:47:12 | continue; | This 'continue' never re-runs the loop - the $@ is always false. | test.cpp:44:14:44:18 | 0 | loop condition |
+| test.cpp:59:5:59:13 | continue; | This 'continue' never re-runs the loop - the $@ is always false. | test.cpp:62:12:62:16 | 0 | loop condition |

--- a/cpp/ql/test/query-tests/Likely Bugs/ContinueInFalseLoop/ContinueInFalseLoop.expected
+++ b/cpp/ql/test/query-tests/Likely Bugs/ContinueInFalseLoop/ContinueInFalseLoop.expected
@@ -1,2 +1,3 @@
 | test.cpp:13:4:13:12 | continue; | This 'continue' never re-runs the loop - the $@ is always false. | test.cpp:16:11:16:15 | 0 | loop condition |
 | test.cpp:59:5:59:13 | continue; | This 'continue' never re-runs the loop - the $@ is always false. | test.cpp:62:12:62:16 | 0 | loop condition |
+| test.cpp:88:4:88:12 | continue; | This 'continue' never re-runs the loop - the $@ is always false. | test.cpp:93:11:93:11 | 0 | loop condition |

--- a/cpp/ql/test/query-tests/Likely Bugs/ContinueInFalseLoop/ContinueInFalseLoop.expected
+++ b/cpp/ql/test/query-tests/Likely Bugs/ContinueInFalseLoop/ContinueInFalseLoop.expected
@@ -1,4 +1,2 @@
 | test.cpp:13:4:13:12 | continue; | This 'continue' never re-runs the loop - the $@ is always false. | test.cpp:16:11:16:15 | 0 | loop condition |
-| test.cpp:39:4:39:12 | continue; | This 'continue' never re-runs the loop - the $@ is always false. | test.cpp:36:9:36:13 | 0 | loop condition |
-| test.cpp:47:4:47:12 | continue; | This 'continue' never re-runs the loop - the $@ is always false. | test.cpp:44:14:44:18 | 0 | loop condition |
 | test.cpp:59:5:59:13 | continue; | This 'continue' never re-runs the loop - the $@ is always false. | test.cpp:62:12:62:16 | 0 | loop condition |

--- a/cpp/ql/test/query-tests/Likely Bugs/ContinueInFalseLoop/ContinueInFalseLoop.expected
+++ b/cpp/ql/test/query-tests/Likely Bugs/ContinueInFalseLoop/ContinueInFalseLoop.expected
@@ -1,3 +1,2 @@
 | test.cpp:13:4:13:12 | continue; | This 'continue' never re-runs the loop - the $@ is always false. | test.cpp:16:11:16:15 | 0 | loop condition |
 | test.cpp:59:5:59:13 | continue; | This 'continue' never re-runs the loop - the $@ is always false. | test.cpp:62:12:62:16 | 0 | loop condition |
-| test.cpp:88:4:88:12 | continue; | This 'continue' never re-runs the loop - the $@ is always false. | test.cpp:93:11:93:11 | 0 | loop condition |

--- a/cpp/ql/test/query-tests/Likely Bugs/ContinueInFalseLoop/ContinueInFalseLoop.qlref
+++ b/cpp/ql/test/query-tests/Likely Bugs/ContinueInFalseLoop/ContinueInFalseLoop.qlref
@@ -1,0 +1,1 @@
+Likely Bugs/ContinueInFalseLoop.ql

--- a/cpp/ql/test/query-tests/Likely Bugs/ContinueInFalseLoop/test.cpp
+++ b/cpp/ql/test/query-tests/Likely Bugs/ContinueInFalseLoop/test.cpp
@@ -1,0 +1,75 @@
+
+bool cond();
+
+void test1()
+{
+	int i;
+
+	// --- do loops ---
+
+	do
+	{
+		if (cond())
+			continue; // BAD
+		if (cond())
+			break;
+	} while (false);
+
+	do
+	{
+		if (cond())
+			continue;
+		if (cond())
+			break;
+	} while (true);
+
+	do
+	{
+		if (cond())
+			continue;
+		if (cond())
+			break;
+	} while (cond());
+
+	// --- while, for loops ---
+
+	while (false)
+	{
+		if (cond())
+			continue; // GOOD [never reached, if the condition changed so it was then the result would no longer apply] [FALSE POSITIVE]
+		if (cond())
+			break;
+	}
+
+	for (i = 0; false; i++)
+	{
+		if (cond())
+			continue; // GOOD [never reached, if the condition changed so it was then the result would no longer apply] [FALSE POSITIVE]
+		if (cond())
+			break;
+	}
+
+	// --- nested loops ---
+
+	do
+	{
+		do
+		{
+			if (cond())
+				continue; // BAD
+			if (cond())
+				break;
+		} while (false);
+	} while (true);
+
+	do
+	{
+		do
+		{
+			if (cond())
+				continue; // GOOD
+			if (cond())
+				break;
+		} while (true);
+	} while (false);
+}

--- a/cpp/ql/test/query-tests/Likely Bugs/ContinueInFalseLoop/test.cpp
+++ b/cpp/ql/test/query-tests/Likely Bugs/ContinueInFalseLoop/test.cpp
@@ -36,7 +36,7 @@ void test1()
 	while (false)
 	{
 		if (cond())
-			continue; // GOOD [never reached, if the condition changed so it was then the result would no longer apply] [FALSE POSITIVE]
+			continue; // GOOD [never reached, if the condition changed so it was then the result would no longer apply]
 		if (cond())
 			break;
 	}
@@ -44,7 +44,7 @@ void test1()
 	for (i = 0; false; i++)
 	{
 		if (cond())
-			continue; // GOOD [never reached, if the condition changed so it was then the result would no longer apply] [FALSE POSITIVE]
+			continue; // GOOD [never reached, if the condition changed so it was then the result would no longer apply]
 		if (cond())
 			break;
 	}

--- a/cpp/ql/test/query-tests/Likely Bugs/ContinueInFalseLoop/test.cpp
+++ b/cpp/ql/test/query-tests/Likely Bugs/ContinueInFalseLoop/test.cpp
@@ -1,7 +1,7 @@
 
 bool cond();
 
-void test1()
+void test1(int x)
 {
 	int i;
 
@@ -72,4 +72,23 @@ void test1()
 				break;
 		} while (true);
 	} while (false);
+
+	do
+	{
+		switch (x)
+		{
+		case 1:
+			// do [1]
+
+			break; // break out of the switch
+
+		default:
+			// do [2]
+
+			continue; // break out of the loop entirely, skipping [3] [FALSE POSITIVE]
+		};
+
+		// do [3]
+
+	} while (0);
 }

--- a/cpp/ql/test/query-tests/Likely Bugs/ContinueInFalseLoop/test.cpp
+++ b/cpp/ql/test/query-tests/Likely Bugs/ContinueInFalseLoop/test.cpp
@@ -85,7 +85,7 @@ void test1(int x)
 		default:
 			// do [2]
 
-			continue; // break out of the loop entirely, skipping [3] [FALSE POSITIVE]
+			continue; // GOOD; break out of the loop entirely, skipping [3]
 		};
 
 		// do [3]


### PR DESCRIPTION
Improvements for 'ContinueInFalseLoop.ql', which has somehow flown under the radar w.r.t. tests, qhelp and tagging.  When I started these changes I had also hoped to add the query to LGTM - however in [73 projects](https://lgtm.com/query/1514281852921565823/) I found a lot of weird constructs but nothing I'm convinced is actually wrong.
 - adds a test
 - adds basic qhelp
 - adds tags
 - fixes false positives