### PR TITLE
Java: Add simple sanitizer for java/http-response-splitting.

### DIFF
--- a/java/ql/src/Security/CWE/CWE-113/ResponseSplitting.ql
+++ b/java/ql/src/Security/CWE/CWE-113/ResponseSplitting.ql
@@ -23,6 +23,11 @@ class ResponseSplittingConfig extends TaintTracking::Configuration {
   }
 
   override predicate isSink(DataFlow::Node sink) { sink instanceof HeaderSplittingSink }
+
+  override predicate isSanitizer(DataFlow::Node node) {
+    node.getType() instanceof PrimitiveType or
+    node.getType() instanceof BoxedType
+  }
 }
 
 from DataFlow::PathNode source, DataFlow::PathNode sink, ResponseSplittingConfig conf

--- a/java/ql/src/Security/CWE/CWE-113/ResponseSplittingLocal.ql
+++ b/java/ql/src/Security/CWE/CWE-113/ResponseSplittingLocal.ql
@@ -21,6 +21,11 @@ class ResponseSplittingLocalConfig extends TaintTracking::Configuration {
   override predicate isSource(DataFlow::Node source) { source instanceof LocalUserInput }
 
   override predicate isSink(DataFlow::Node sink) { sink instanceof HeaderSplittingSink }
+
+  override predicate isSanitizer(DataFlow::Node node) {
+    node.getType() instanceof PrimitiveType or
+    node.getType() instanceof BoxedType
+  }
 }
 
 from DataFlow::PathNode source, DataFlow::PathNode sink, ResponseSplittingLocalConfig conf


### PR DESCRIPTION
This fixes a FP observed during a POC.