### PR TITLE
JS: Augment call graph with instance type tracking

### DIFF
--- a/javascript/ql/src/semmle/javascript/dataflow/Nodes.qll
+++ b/javascript/ql/src/semmle/javascript/dataflow/Nodes.qll
@@ -879,10 +879,10 @@ module ClassNode {
 
     override FunctionNode getAnInstanceMember(MemberKind kind) {
       kind = MemberKind::method() and
-      result = getAPrototypeReference().getAPropertyWrite().getRhs().getALocalSource()
+      result = getAPrototypeReference().getAPropertySource()
       or
       kind = MemberKind::method() and
-      result = getConstructor().getReceiver().getAPropertyWrite().getRhs().getALocalSource()
+      result = getConstructor().getReceiver().getAPropertySource()
       or
       exists(PropertyAccessor accessor |
         accessor = getAnAccessor(kind) and
@@ -893,7 +893,7 @@ module ClassNode {
     override FunctionNode getStaticMethod(string name) { result = getAPropertySource(name) }
 
     override FunctionNode getAStaticMethod() {
-      result = getAPropertyWrite().getRhs().getALocalSource()
+      result = getAPropertySource()
     }
 
     /**

--- a/javascript/ql/src/semmle/javascript/dataflow/Nodes.qll
+++ b/javascript/ql/src/semmle/javascript/dataflow/Nodes.qll
@@ -868,7 +868,7 @@ module ClassNode {
       result = getAPrototypeReference().getAPropertySource(name)
       or
       kind = MemberKind::method() and
-      result = getConstructor().getReceiver().getAPropertyWrite(name).getRhs().getALocalSource()
+      result = getConstructor().getReceiver().getAPropertySource(name)
       or
       exists(PropertyAccessor accessor |
         accessor = getAnAccessor(kind) and

--- a/javascript/ql/src/semmle/javascript/dataflow/Sources.qll
+++ b/javascript/ql/src/semmle/javascript/dataflow/Sources.qll
@@ -156,6 +156,13 @@ class SourceNode extends DataFlow::Node {
   }
 
   /**
+   * Gets a source node whose value is stored in a property of this node.
+   */
+  DataFlow::SourceNode getAPropertySource() {
+    result.flowsTo(getAPropertyWrite().getRhs())
+  }
+
+  /**
    * EXPERIMENTAL.
    *
    * Gets a node that this node may flow to using one heap and/or interprocedural step.

--- a/javascript/ql/src/semmle/javascript/dataflow/internal/FlowSteps.qll
+++ b/javascript/ql/src/semmle/javascript/dataflow/internal/FlowSteps.qll
@@ -102,11 +102,11 @@ private module CachedSteps {
    * or one of its super classes.
    */
   cached
-  predicate callResolvesToClass(DataFlow::InvokeNode invoke, DataFlow::ClassNode cls, string name) {
+  predicate callResolvesToMember(DataFlow::InvokeNode invoke, DataFlow::ClassNode cls, string name) {
     invoke = cls.getAnInstanceReference().getAMethodCall(name)
     or
     exists(DataFlow::ClassNode subclass |
-      callResolvesToClass(invoke, subclass, name) and
+      callResolvesToMember(invoke, subclass, name) and
       not exists(subclass.getAnInstanceMember(name)) and
       cls = subclass.getADirectSuperClass()
     )
@@ -120,7 +120,7 @@ private module CachedSteps {
     f = invk.getACallee(0)
     or
     exists(DataFlow::ClassNode cls, string name |
-      callResolvesToClass(invk, cls, name) and
+      callResolvesToMember(invk, cls, name) and
       f = cls.getInstanceMethod(name).getFunction()
     )
   }

--- a/javascript/ql/src/semmle/javascript/dataflow/internal/FlowSteps.qll
+++ b/javascript/ql/src/semmle/javascript/dataflow/internal/FlowSteps.qll
@@ -98,10 +98,32 @@ private module CachedSteps {
   }
 
   /**
+   * Holds if the method invoked by `invoke` resolved to a member named `name` in `cls`
+   * or one of its super classes.
+   */
+  cached
+  predicate callResolvesToClass(DataFlow::InvokeNode invoke, DataFlow::ClassNode cls, string name) {
+    invoke = cls.getAnInstanceReference().getAMethodCall(name)
+    or
+    exists(DataFlow::ClassNode subclass |
+      callResolvesToClass(invoke, subclass, name) and
+      not exists(subclass.getAnInstanceMember(name)) and
+      cls = subclass.getADirectSuperClass()
+    )
+  }
+
+  /**
    * Holds if `invk` may invoke `f`.
    */
   cached
-  predicate calls(DataFlow::InvokeNode invk, Function f) { f = invk.getACallee(0) }
+  predicate calls(DataFlow::InvokeNode invk, Function f) {
+    f = invk.getACallee(0)
+    or
+    exists(DataFlow::ClassNode cls, string name |
+      callResolvesToClass(invk, cls, name) and
+      f = cls.getInstanceMethod(name).getFunction()
+    )
+  }
 
   /**
    * Holds if `invk` may invoke `f` indirectly through the given `callback` argument.


### PR DESCRIPTION
Uses type tracking to track instances of classes in order to resolve method calls and add these to the call graph.

Evaluation on [big-apps](https://git.semmle.com/asger/dist-compare-reports/tree/instance-type-tracking-final_1561628353443) and [nightly](https://git.semmle.com/asger/dist-compare-reports/tree/instance-type-tracking-final_1561605603875) suggest that quite a few new calls could be resolved, at a fairly modest cost. The two failures in big-apps were due to a bad join ordering in the call graph metric which I've "fixed" in https://github.com/Semmle/ql/commit/8f4228b7c3359c5fdc1de0934641690eacb55818. The metrics are computed after the security suite, so the timings should be trustworthy.

The intent is to take advantage of JSDoc types in `ClassNode.getAnInstanceReference` - initial experiments shows good results there as well, but my name resolution of JSDoc types was a bit half-assed so I've left that out for now, to revisit in a later PR.

There's also a fix for a bad join ordering in `LocalObject.hasOwnProperty` which for some reason manifested after this change.

The first 3 commits are from the call graph metric PR https://github.com/Semmle/ql/pull/1488.