### PR TITLE
CPP: Deprecate Expr.getKind() and Stmt.getKind().

### DIFF
--- a/cpp/ql/src/semmle/code/cpp/exprs/Expr.qll
+++ b/cpp/ql/src/semmle/code/cpp/exprs/Expr.qll
@@ -76,10 +76,10 @@ class Expr extends StmtParent, @expr {
 
   /**
    * Gets an integer indicating the type of expression that this represents.
-   * 
-   * Consider using subclasses of `Expr` rather than relying on this predicate. 
+   *
+   * DEPRECATED: use the subclasses of `Expr` rather than relying on this predicate.
    */
-  int getKind() { exprs(underlyingElement(this),result,_) }
+  deprecated int getKind() { exprs(underlyingElement(this),result,_) }
 
   /** Gets a textual representation of this expression. */
   override string toString() { none() }

--- a/cpp/ql/src/semmle/code/cpp/stmts/Stmt.qll
+++ b/cpp/ql/src/semmle/code/cpp/stmts/Stmt.qll
@@ -57,8 +57,12 @@ class Stmt extends StmtParent, @stmt {
 
   override Location getLocation() { stmts(underlyingElement(this),_,result) }
 
-  /** Gets an int indicating the type of statement that this represents. */
-  int getKind() { stmts(underlyingElement(this),result,_) }
+  /**
+   * Gets an int indicating the type of statement that this represents.
+   *
+   * DEPRECATED: use the subclasses of `Stmt` rather than relying on this predicate.
+   */
+  deprecated int getKind() { stmts(underlyingElement(this),result,_) }
 
   override string toString() { none() }
 


### PR DESCRIPTION
These predicates expose details of our dbscheme that no user should have to care about.  I don't *think* these are used in our libraries or queries any more, and I hope none of our users have gravitated towards using them.

Discussion welcome.