### PR TITLE
C#: Generalize `mono` pattern in tracer config

### DIFF
--- a/csharp/config/tracer/linux/csharp-compiler-settings
+++ b/csharp/config/tracer/linux/csharp-compiler-settings
@@ -4,6 +4,6 @@
   prepend --compiler
   prepend "${compiler}"
   prepend --cil
-**/bin/mono*:
+**/mono*:
 **/dotnet:
   invoke ${odasa_tools}/extract-csharp.sh


### PR DESCRIPTION
Recent versions of [mono/mono](https://github.com/mono/mono) no longer extract all compiled source code, because it uses a `mono` binary at `mini/mono`:
```
[T 13:14:45 29350] ==== Candidate to intercept: /opt/work/src/mono/mini/mono (canonical: /opt/work/src/mono/mini/mono-sgen) ====
```
This PR generalizes the pattern from `**/bin/mono*` to just `**/mono*`; this should be safe, even if we match non-`mono` invocations, as the script `extract-csharp.sh` checks whether it is an actual compiler invocation.