### PR TITLE
[CPP-370] Non-const format strings: Add change note for the 1.22 release.

### DIFF
--- a/change-notes/1.22/analysis-cpp.md
+++ b/change-notes/1.22/analysis-cpp.md
@@ -13,7 +13,7 @@
 |----------------------------|------------------------|------------------------------------------------------------------|
 | Expression has no effect (`cpp/useless-expression`) | Fewer false positive results | Calls to functions with the `weak` attribute are no longer considered to be side effect free, because they could be overridden with a different implementation at link time. |
 | Suspicious pointer scaling (`cpp/suspicious-pointer-scaling`) | Lower precision | The precision of this query has been reduced to "medium". This coding pattern is used intentionally and safely in a number of real-world projects. Results are no longer displayed on LGTM unless you choose to display them. |
-| Non-constant format string (`cpp/non-constant-format`) | Higher precision | Rewritten using the taint-tracking library; should also improve performance in batched runs. |
+| Non-constant format string (`cpp/non-constant-format`) | Fewer false positive results | Rewritten using the taint-tracking library. |
 
 ## Changes to QL libraries
 

--- a/change-notes/1.22/analysis-cpp.md
+++ b/change-notes/1.22/analysis-cpp.md
@@ -13,6 +13,7 @@
 |----------------------------|------------------------|------------------------------------------------------------------|
 | Expression has no effect (`cpp/useless-expression`) | Fewer false positive results | Calls to functions with the `weak` attribute are no longer considered to be side effect free, because they could be overridden with a different implementation at link time. |
 | Suspicious pointer scaling (`cpp/suspicious-pointer-scaling`) | Lower precision | The precision of this query has been reduced to "medium". This coding pattern is used intentionally and safely in a number of real-world projects. Results are no longer displayed on LGTM unless you choose to display them. |
+| Non-constant format string (`cpp/non-constant-format`) | Higher precision | Rewritten using the taint-tracking library; should also improve performance in batched runs. |
 
 ## Changes to QL libraries
 


### PR DESCRIPTION
This PR is a companion to https://github.com/Semmle/ql/pull/1251 and deals strictly with the changelog entry for the 1.22 release.  I've added a note about the increased precision of the new `cpp/non-constant-format` query.  

Please let me know if the wording is incorrect or if this PR is unnecessary altogether.