### PR TITLE
CPP: Fix false positives from NoSpaceForZeroTerminator.ql

### DIFF
--- a/change-notes/1.22/analysis-cpp.md
+++ b/change-notes/1.22/analysis-cpp.md
@@ -12,6 +12,7 @@
 | **Query**                  | **Expected impact**    | **Change**                                                       |
 |----------------------------|------------------------|------------------------------------------------------------------|
 | Expression has no effect (`cpp/useless-expression`) | Fewer false positive results | Calls to functions with the `weak` attribute are no longer considered to be side effect free, because they could be overridden with a different implementation at link time. |
+| No space for zero terminator (`cpp/no-space-for-terminator`) | Fewer false positive results | False positives involving strings that are not null-terminated have been excluded. |
 | Suspicious pointer scaling (`cpp/suspicious-pointer-scaling`) | Lower precision | The precision of this query has been reduced to "medium". This coding pattern is used intentionally and safely in a number of real-world projects. Results are no longer displayed on LGTM unless you choose to display them. |
 
 ## Changes to QL libraries

--- a/cpp/ql/src/Security/CWE/CWE-131/NoSpaceForZeroTerminator.ql
+++ b/cpp/ql/src/Security/CWE/CWE-131/NoSpaceForZeroTerminator.ql
@@ -14,6 +14,7 @@
  *       external/cwe/cwe-122
  */
 import cpp
+import semmle.code.cpp.dataflow.DataFlow
 
 class MallocCall extends FunctionCall
 {
@@ -34,6 +35,12 @@ class MallocCall extends FunctionCall
 
 predicate terminationProblem(MallocCall malloc, string msg) {
   malloc.getAllocatedSize() instanceof StrlenCall and
+  not exists(DataFlow::Node def, DataFlow::Node use, FunctionCall fc |
+    DataFlow::localFlow(def, use) and
+    def.asExpr() = malloc and
+    use.asExpr() = fc.getArgument(0) and
+    fc.getTarget().hasName("memcpy")
+  ) and
   msg = "This allocation does not include space to null-terminate the string."
 }
 

--- a/cpp/ql/src/Security/CWE/CWE-131/NoSpaceForZeroTerminator.ql
+++ b/cpp/ql/src/Security/CWE/CWE-131/NoSpaceForZeroTerminator.ql
@@ -15,6 +15,7 @@
  */
 import cpp
 import semmle.code.cpp.dataflow.DataFlow
+import semmle.code.cpp.models.implementations.Memcpy
 
 class MallocCall extends FunctionCall
 {
@@ -35,11 +36,12 @@ class MallocCall extends FunctionCall
 
 predicate terminationProblem(MallocCall malloc, string msg) {
   malloc.getAllocatedSize() instanceof StrlenCall and
-  not exists(DataFlow::Node def, DataFlow::Node use, FunctionCall fc |
+  not exists(DataFlow::Node def, DataFlow::Node use, FunctionCall fc, MemcpyFunction memcpy, int ix |
     DataFlow::localFlow(def, use) and
     def.asExpr() = malloc and
-    use.asExpr() = fc.getArgument(0) and
-    fc.getTarget().hasName("memcpy")
+    fc.getTarget() = memcpy and
+    memcpy.hasArrayOutput(ix) and
+    use.asExpr() = fc.getArgument(ix)
   ) and
   msg = "This allocation does not include space to null-terminate the string."
 }

--- a/cpp/ql/test/query-tests/Security/CWE/CWE-131/semmle/NoSpaceForZeroTerminator/NoSpaceForZeroTerminator.expected
+++ b/cpp/ql/test/query-tests/Security/CWE/CWE-131/semmle/NoSpaceForZeroTerminator/NoSpaceForZeroTerminator.expected
@@ -1,4 +1,5 @@
 | test.c:15:20:15:25 | call to malloc | This allocation does not include space to null-terminate the string. |
 | test.c:29:20:29:25 | call to malloc | This allocation does not include space to null-terminate the string. |
 | test.c:44:20:44:25 | call to malloc | This allocation does not include space to null-terminate the string. |
+| test.c:72:17:72:22 | call to malloc | This allocation does not include space to null-terminate the string. |
 | test.cpp:18:35:18:40 | call to malloc | This allocation does not include space to null-terminate the string. |

--- a/cpp/ql/test/query-tests/Security/CWE/CWE-131/semmle/NoSpaceForZeroTerminator/NoSpaceForZeroTerminator.expected
+++ b/cpp/ql/test/query-tests/Security/CWE/CWE-131/semmle/NoSpaceForZeroTerminator/NoSpaceForZeroTerminator.expected
@@ -1,5 +1,4 @@
 | test.c:15:20:15:25 | call to malloc | This allocation does not include space to null-terminate the string. |
 | test.c:29:20:29:25 | call to malloc | This allocation does not include space to null-terminate the string. |
 | test.c:44:20:44:25 | call to malloc | This allocation does not include space to null-terminate the string. |
-| test.c:72:17:72:22 | call to malloc | This allocation does not include space to null-terminate the string. |
 | test.cpp:18:35:18:40 | call to malloc | This allocation does not include space to null-terminate the string. |

--- a/cpp/ql/test/query-tests/Security/CWE/CWE-131/semmle/NoSpaceForZeroTerminator/test.c
+++ b/cpp/ql/test/query-tests/Security/CWE/CWE-131/semmle/NoSpaceForZeroTerminator/test.c
@@ -63,3 +63,15 @@ void good3(char *str) {
     char *buffer = malloc((strlen(str) + 1) * sizeof(char));
     free(buffer);
 }
+
+void *memcpy(void *s1, const void *s2, size_t n);
+
+void good4(char *str) {
+	// GOOD -- allocating a non zero-terminated string [FALSE POSITIVE]
+	int len = strlen(str);
+	char *buffer = malloc(len);
+
+	memcpy(buffer, str, len);
+
+	free(buffer);
+}

--- a/cpp/ql/test/query-tests/Security/CWE/CWE-131/semmle/NoSpaceForZeroTerminator/test.c
+++ b/cpp/ql/test/query-tests/Security/CWE/CWE-131/semmle/NoSpaceForZeroTerminator/test.c
@@ -67,7 +67,7 @@ void good3(char *str) {
 void *memcpy(void *s1, const void *s2, size_t n);
 
 void good4(char *str) {
-	// GOOD -- allocating a non zero-terminated string [FALSE POSITIVE]
+	// GOOD -- allocating a non zero-terminated string
 	int len = strlen(str);
 	char *buffer = malloc(len);
 


### PR DESCRIPTION
I've seen false positives from 'NoSpaceForZeroTerminator.ql' on several projects where the query is trying to reason about buffers that are not actually intended to be null terminated.  The typical pattern is to allocate the length of a string (without `+ 1`), `memcpy` the contents of the string into it, and then store the length alongside.

This change excludes results where the buffer is the destination of a `memcpy` or similar operation, which is taken as a hint that the buffer isn't null terminated.