### PR TITLE
JS: bump vulnerable lodash version for prototype pollution

### DIFF
--- a/javascript/ql/src/semmle/javascript/security/dataflow/PrototypePollution.qll
+++ b/javascript/ql/src/semmle/javascript/security/dataflow/PrototypePollution.qll
@@ -162,7 +162,7 @@ module PrototypePollution {
       version.maybeBefore("4.0.1")
       or
       id = "lodash" + any(string s) and
-      version.maybeBefore("4.17.11")
+      version.maybeBefore("4.17.12")
       or
       id = "merge" and
       version.maybeBefore("1.2.1")


### PR DESCRIPTION
See https://github.com/lodash/lodash/pull/4336