### PR TITLE
C++ IR: Make instruction operand getters have only exact results

### DIFF
--- a/cpp/ql/src/semmle/code/cpp/ir/dataflow/TaintTracking.qll
+++ b/cpp/ql/src/semmle/code/cpp/ir/dataflow/TaintTracking.qll
@@ -145,6 +145,11 @@ module TaintTracking {
       nodeTo instanceof PointerArithmeticInstruction
       or
       nodeTo instanceof FieldAddressInstruction
+      or
+      // The `CopyInstruction` case is also present in non-taint data flow, but
+      // that uses `getDef` rather than `getAnyDef`. For taint, we want flow
+      // from a definition of `myStruct` to a `myStruct.myField` expression.
+      nodeTo instanceof CopyInstruction
     )
     or
     nodeTo.(LoadInstruction).getSourceAddress() = nodeFrom

--- a/cpp/ql/src/semmle/code/cpp/ir/dataflow/TaintTracking.qll
+++ b/cpp/ql/src/semmle/code/cpp/ir/dataflow/TaintTracking.qll
@@ -136,7 +136,7 @@ module TaintTracking {
     // Taint can flow through expressions that alter the value but preserve
     // more than one bit of it _or_ expressions that follow data through
     // pointer indirections.
-    nodeTo.getAnOperand().getDefinitionInstruction() = nodeFrom and
+    nodeTo.getAnOperand().getAnyDef() = nodeFrom and
     (
       nodeTo instanceof ArithmeticInstruction
       or

--- a/cpp/ql/src/semmle/code/cpp/ir/dataflow/internal/DataFlowUtil.qll
+++ b/cpp/ql/src/semmle/code/cpp/ir/dataflow/internal/DataFlowUtil.qll
@@ -143,7 +143,7 @@ UninitializedNode uninitializedNode(LocalVariable v) { result.getLocalVariable()
  */
 predicate localFlowStep(Node nodeFrom, Node nodeTo) {
   nodeTo.(CopyInstruction).getSourceValue() = nodeFrom or
-  nodeTo.(PhiInstruction).getAnOperand().getDefinitionInstruction() = nodeFrom or
+  nodeTo.(PhiInstruction).getAnOperand().getAnyDef() = nodeFrom or
   // Treat all conversions as flow, even conversions between different numeric types.
   nodeTo.(ConvertInstruction).getUnary() = nodeFrom
 }

--- a/cpp/ql/src/semmle/code/cpp/ir/dataflow/internal/DataFlowUtil.qll
+++ b/cpp/ql/src/semmle/code/cpp/ir/dataflow/internal/DataFlowUtil.qll
@@ -143,7 +143,7 @@ UninitializedNode uninitializedNode(LocalVariable v) { result.getLocalVariable()
  */
 predicate localFlowStep(Node nodeFrom, Node nodeTo) {
   nodeTo.(CopyInstruction).getSourceValue() = nodeFrom or
-  nodeTo.(PhiInstruction).getAnOperand().getAnyDef() = nodeFrom or
+  nodeTo.(PhiInstruction).getAnOperand().getDef() = nodeFrom or
   // Treat all conversions as flow, even conversions between different numeric types.
   nodeTo.(ConvertInstruction).getUnary() = nodeFrom
 }

--- a/cpp/ql/src/semmle/code/cpp/ir/implementation/aliased_ssa/Instruction.qll
+++ b/cpp/ql/src/semmle/code/cpp/ir/implementation/aliased_ssa/Instruction.qll
@@ -480,7 +480,8 @@ class Instruction extends Construction::TInstruction {
   }
 
   /**
-   * Gets all direct uses of the result of this instruction.
+   * Gets all direct uses of the result of this instruction. The result can be
+   * an `Operand` for which `isDefinitionInexact` holds.
    */
   final Operand getAUse() {
     result.getAnyDef() = this
@@ -698,7 +699,7 @@ class FieldAddressInstruction extends FieldInstruction {
   }
 
   final Instruction getObjectAddress() {
-    result = getObjectAddressOperand().getAnyDef()
+    result = getObjectAddressOperand().getDef()
   }
 }
 
@@ -747,7 +748,7 @@ class ReturnValueInstruction extends ReturnInstruction {
   }
   
   final Instruction getReturnValue() {
-    result = getReturnValueOperand().getAnyDef()
+    result = getReturnValueOperand().getDef()
   }
 }
 
@@ -761,7 +762,7 @@ class CopyInstruction extends Instruction {
   }
 
   final Instruction getSourceValue() {
-    result = getSourceValueOperand().getAnyDef()
+    result = getSourceValueOperand().getDef()
   }
 }
 
@@ -785,7 +786,7 @@ class LoadInstruction extends CopyInstruction {
   }
   
   final Instruction getSourceAddress() {
-    result = getSourceAddressOperand().getAnyDef()
+    result = getSourceAddressOperand().getDef()
   }
 
   override final LoadOperand getSourceValueOperand() {
@@ -807,7 +808,7 @@ class StoreInstruction extends CopyInstruction {
   }
   
   final Instruction getDestinationAddress() {
-    result = getDestinationAddressOperand().getAnyDef()
+    result = getDestinationAddressOperand().getDef()
   }
 
   override final StoreValueOperand getSourceValueOperand() {
@@ -825,7 +826,7 @@ class ConditionalBranchInstruction extends Instruction {
   }
 
   final Instruction getCondition() {
-    result = getConditionOperand().getAnyDef()
+    result = getConditionOperand().getDef()
   }
 
   final Instruction getTrueSuccessor() {
@@ -891,11 +892,11 @@ class BinaryInstruction extends Instruction {
   }
 
   final Instruction getLeft() {
-    result = getLeftOperand().getAnyDef()
+    result = getLeftOperand().getDef()
   }
 
   final Instruction getRight() {
-    result = getRightOperand().getAnyDef()
+    result = getRightOperand().getDef()
   }
   
   /**
@@ -1045,7 +1046,7 @@ class UnaryInstruction extends Instruction {
   }
   
   final Instruction getUnary() {
-    result = getUnaryOperand().getAnyDef()
+    result = getUnaryOperand().getDef()
   }
 }
 
@@ -1275,7 +1276,7 @@ class SwitchInstruction extends Instruction {
   }
 
   final Instruction getExpression() {
-    result = getExpressionOperand().getAnyDef()
+    result = getExpressionOperand().getDef()
   }
 
   final Instruction getACaseSuccessor() {
@@ -1310,7 +1311,7 @@ class CallInstruction extends Instruction {
    * function pointer.
    */
   final Instruction getCallTarget() {
-    result = getCallTargetOperand().getAnyDef()
+    result = getCallTargetOperand().getDef()
   }
 
   /**
@@ -1331,7 +1332,7 @@ class CallInstruction extends Instruction {
    * Gets all of the arguments of the call, including the `this` pointer, if any.
    */
   final Instruction getAnArgument() {
-    result = getAnArgumentOperand().getAnyDef()
+    result = getAnArgumentOperand().getDef()
   }
 
   /**
@@ -1345,7 +1346,7 @@ class CallInstruction extends Instruction {
    * Gets the `this` pointer argument of the call, if any.
    */
   final Instruction getThisArgument() {
-    result = getThisArgumentOperand().getAnyDef()
+    result = getThisArgumentOperand().getDef()
   }
 
   /**
@@ -1360,7 +1361,7 @@ class CallInstruction extends Instruction {
    * Gets the argument at the specified index.
    */
   final Instruction getPositionalArgument(int index) {
-    result = getPositionalArgumentOperand(index).getAnyDef()
+    result = getPositionalArgumentOperand(index).getDef()
   }
 }
 
@@ -1516,7 +1517,7 @@ class ThrowValueInstruction extends ThrowInstruction {
    * Gets the address of the exception thrown by this instruction.
    */
   final Instruction getExceptionAddress() {
-    result = getExceptionAddressOperand().getAnyDef()
+    result = getExceptionAddressOperand().getDef()
   }
 
   /**
@@ -1530,7 +1531,7 @@ class ThrowValueInstruction extends ThrowInstruction {
    * Gets the exception thrown by this instruction.
    */
   final Instruction getException() {
-    result = getExceptionOperand().getAnyDef()
+    result = getExceptionOperand().getDef()
   }
 }
 
@@ -1660,7 +1661,7 @@ class PhiInstruction extends Instruction {
    */
   pragma[noinline]
   final Instruction getAnInput() {
-    result = this.getAnInputOperand().getAnyDef()
+    result = this.getAnInputOperand().getDef()
   }
 }
 
@@ -1728,7 +1729,7 @@ class ChiInstruction extends Instruction {
    * memory write.
    */
   final Instruction getTotal() {
-    result = getTotalOperand().getAnyDef()
+    result = getTotalOperand().getDef()
   }
 
   /**
@@ -1742,7 +1743,7 @@ class ChiInstruction extends Instruction {
    * Gets the operand that represents the new value written by the memory write.
    */
   final Instruction getPartial() {
-    result = getPartialOperand().getAnyDef()
+    result = getPartialOperand().getDef()
   }
 }
 

--- a/cpp/ql/src/semmle/code/cpp/ir/implementation/aliased_ssa/Instruction.qll
+++ b/cpp/ql/src/semmle/code/cpp/ir/implementation/aliased_ssa/Instruction.qll
@@ -510,13 +510,22 @@ class Instruction extends Construction::TInstruction {
   }
 
   /**
-   * Returns the operand that holds the memory address to which the instruction stores its
+   * Gets the operand that holds the memory address to which this instruction stores its
    * result, if any. For example, in `m3 = Store r1, r2`, the result of `getResultAddressOperand()`
    * is `r1`.
    */
   final AddressOperand getResultAddressOperand() {
     getResultMemoryAccess().usesAddressOperand() and
     result.getUse() = this
+  }
+
+  /**
+   * Gets the instruction that holds the exact memory address to which this instruction stores its
+   * result, if any. For example, in `m3 = Store r1, r2`, the result of `getResultAddressOperand()`
+   * is the instruction that defines `r1`.
+   */
+  final Instruction getResultAddress() {
+    result = getResultAddressOperand().getDef()
   }
 
   /**

--- a/cpp/ql/src/semmle/code/cpp/ir/implementation/aliased_ssa/Instruction.qll
+++ b/cpp/ql/src/semmle/code/cpp/ir/implementation/aliased_ssa/Instruction.qll
@@ -103,7 +103,7 @@ module InstructionSanity {
   query predicate missingOperandType(Operand operand, string message) {
     exists(Function func |
       not exists(operand.getType()) and
-      func = operand.getUseInstruction().getEnclosingFunction() and
+      func = operand.getUse().getEnclosingFunction() and
       message = "Operand missing type in function '" + getIdentityString(func) + "'."
     )
   }
@@ -158,8 +158,8 @@ module InstructionSanity {
    * a different function.
    */
   query predicate operandAcrossFunctions(Operand operand, Instruction instr, Instruction defInstr) {
-    operand.getUseInstruction() = instr and
-    operand.getDefinitionInstruction() = defInstr and
+    operand.getUse() = instr and
+    operand.getAnyDef() = defInstr and
     instr.getEnclosingIRFunction() != defInstr.getEnclosingIRFunction()
   }
 
@@ -483,14 +483,14 @@ class Instruction extends Construction::TInstruction {
    * Gets all direct uses of the result of this instruction.
    */
   final Operand getAUse() {
-    result.getDefinitionInstruction() = this
+    result.getAnyDef() = this
   }
 
   /**
    * Gets all of this instruction's operands.
    */
   final Operand getAnOperand() {
-    result.getUseInstruction() = this
+    result.getUse() = this
   }
 
   /**
@@ -515,7 +515,7 @@ class Instruction extends Construction::TInstruction {
    */
   final AddressOperand getResultAddressOperand() {
     getResultMemoryAccess().usesAddressOperand() and
-    result.getUseInstruction() = this
+    result.getUse() = this
   }
 
   /**
@@ -698,7 +698,7 @@ class FieldAddressInstruction extends FieldInstruction {
   }
 
   final Instruction getObjectAddress() {
-    result = getObjectAddressOperand().getDefinitionInstruction()
+    result = getObjectAddressOperand().getAnyDef()
   }
 }
 
@@ -747,7 +747,7 @@ class ReturnValueInstruction extends ReturnInstruction {
   }
   
   final Instruction getReturnValue() {
-    result = getReturnValueOperand().getDefinitionInstruction()
+    result = getReturnValueOperand().getAnyDef()
   }
 }
 
@@ -761,7 +761,7 @@ class CopyInstruction extends Instruction {
   }
 
   final Instruction getSourceValue() {
-    result = getSourceValueOperand().getDefinitionInstruction()
+    result = getSourceValueOperand().getAnyDef()
   }
 }
 
@@ -785,7 +785,7 @@ class LoadInstruction extends CopyInstruction {
   }
   
   final Instruction getSourceAddress() {
-    result = getSourceAddressOperand().getDefinitionInstruction()
+    result = getSourceAddressOperand().getAnyDef()
   }
 
   override final LoadOperand getSourceValueOperand() {
@@ -807,7 +807,7 @@ class StoreInstruction extends CopyInstruction {
   }
   
   final Instruction getDestinationAddress() {
-    result = getDestinationAddressOperand().getDefinitionInstruction()
+    result = getDestinationAddressOperand().getAnyDef()
   }
 
   override final StoreValueOperand getSourceValueOperand() {
@@ -825,7 +825,7 @@ class ConditionalBranchInstruction extends Instruction {
   }
 
   final Instruction getCondition() {
-    result = getConditionOperand().getDefinitionInstruction()
+    result = getConditionOperand().getAnyDef()
   }
 
   final Instruction getTrueSuccessor() {
@@ -891,11 +891,11 @@ class BinaryInstruction extends Instruction {
   }
 
   final Instruction getLeft() {
-    result = getLeftOperand().getDefinitionInstruction()
+    result = getLeftOperand().getAnyDef()
   }
 
   final Instruction getRight() {
-    result = getRightOperand().getDefinitionInstruction()
+    result = getRightOperand().getAnyDef()
   }
   
   /**
@@ -1045,7 +1045,7 @@ class UnaryInstruction extends Instruction {
   }
   
   final Instruction getUnary() {
-    result = getUnaryOperand().getDefinitionInstruction()
+    result = getUnaryOperand().getAnyDef()
   }
 }
 
@@ -1275,7 +1275,7 @@ class SwitchInstruction extends Instruction {
   }
 
   final Instruction getExpression() {
-    result = getExpressionOperand().getDefinitionInstruction()
+    result = getExpressionOperand().getAnyDef()
   }
 
   final Instruction getACaseSuccessor() {
@@ -1310,7 +1310,7 @@ class CallInstruction extends Instruction {
    * function pointer.
    */
   final Instruction getCallTarget() {
-    result = getCallTargetOperand().getDefinitionInstruction()
+    result = getCallTargetOperand().getAnyDef()
   }
 
   /**
@@ -1331,7 +1331,7 @@ class CallInstruction extends Instruction {
    * Gets all of the arguments of the call, including the `this` pointer, if any.
    */
   final Instruction getAnArgument() {
-    result = getAnArgumentOperand().getDefinitionInstruction()
+    result = getAnArgumentOperand().getAnyDef()
   }
 
   /**
@@ -1345,7 +1345,7 @@ class CallInstruction extends Instruction {
    * Gets the `this` pointer argument of the call, if any.
    */
   final Instruction getThisArgument() {
-    result = getThisArgumentOperand().getDefinitionInstruction()
+    result = getThisArgumentOperand().getAnyDef()
   }
 
   /**
@@ -1360,7 +1360,7 @@ class CallInstruction extends Instruction {
    * Gets the argument at the specified index.
    */
   final Instruction getPositionalArgument(int index) {
-    result = getPositionalArgumentOperand(index).getDefinitionInstruction()
+    result = getPositionalArgumentOperand(index).getAnyDef()
   }
 }
 
@@ -1516,7 +1516,7 @@ class ThrowValueInstruction extends ThrowInstruction {
    * Gets the address of the exception thrown by this instruction.
    */
   final Instruction getExceptionAddress() {
-    result = getExceptionAddressOperand().getDefinitionInstruction()
+    result = getExceptionAddressOperand().getAnyDef()
   }
 
   /**
@@ -1530,7 +1530,7 @@ class ThrowValueInstruction extends ThrowInstruction {
    * Gets the exception thrown by this instruction.
    */
   final Instruction getException() {
-    result = getExceptionOperand().getDefinitionInstruction()
+    result = getExceptionOperand().getAnyDef()
   }
 }
 
@@ -1660,7 +1660,7 @@ class PhiInstruction extends Instruction {
    */
   pragma[noinline]
   final Instruction getAnInput() {
-    result = this.getAnInputOperand().getDefinitionInstruction()
+    result = this.getAnInputOperand().getAnyDef()
   }
 }
 
@@ -1728,7 +1728,7 @@ class ChiInstruction extends Instruction {
    * memory write.
    */
   final Instruction getTotal() {
-    result = getTotalOperand().getDefinitionInstruction()
+    result = getTotalOperand().getAnyDef()
   }
 
   /**
@@ -1742,7 +1742,7 @@ class ChiInstruction extends Instruction {
    * Gets the operand that represents the new value written by the memory write.
    */
   final Instruction getPartial() {
-    result = getPartialOperand().getDefinitionInstruction()
+    result = getPartialOperand().getAnyDef()
   }
 }
 

--- a/cpp/ql/src/semmle/code/cpp/ir/implementation/aliased_ssa/Operand.qll
+++ b/cpp/ql/src/semmle/code/cpp/ir/implementation/aliased_ssa/Operand.qll
@@ -26,24 +26,24 @@ class Operand extends TOperand {
   }
 
   final Location getLocation() {
-    result = getUseInstruction().getLocation()
+    result = getUse().getLocation()
   }
 
   final IRFunction getEnclosingIRFunction() {
-    result = getUseInstruction().getEnclosingIRFunction()
+    result = getUse().getEnclosingIRFunction()
   }
   
   /**
    * Gets the `Instruction` that consumes this operand.
    */
-  Instruction getUseInstruction() {
+  Instruction getUse() {
     none()
   }
 
   /**
    * Gets the `Instruction` whose result is the value of the operand.
    */
-  Instruction getDefinitionInstruction() {
+  Instruction getAnyDef() {
     none()
   }
 
@@ -76,7 +76,7 @@ class Operand extends TOperand {
    * For example: `this:r3_5`
    */
   final string getDumpString() {
-    result = getDumpLabel() + getInexactSpecifier() + getDefinitionInstruction().getResultId()
+    result = getDumpLabel() + getInexactSpecifier() + getAnyDef().getResultId()
   }
 
   /**
@@ -106,7 +106,7 @@ class Operand extends TOperand {
    * has been cast to a different type.
    */
   Type getType() {
-    result = getDefinitionInstruction().getResultType()
+    result = getAnyDef().getResultType()
   }
 
   /**
@@ -117,7 +117,7 @@ class Operand extends TOperand {
    * given by `getResultType()`.
    */
   predicate isGLValue() {
-    getDefinitionInstruction().isGLValue()
+    getAnyDef().isGLValue()
   }
 
   /**
@@ -157,7 +157,7 @@ class MemoryOperand extends Operand {
    */
   final AddressOperand getAddressOperand() {
     getMemoryAccess().usesAddressOperand() and
-    result.getUseInstruction() = getUseInstruction()
+    result.getUse() = getUse()
   }
 }
 
@@ -174,11 +174,11 @@ class NonPhiOperand extends Operand {
     this = TNonPhiMemoryOperand(useInstr, tag, defInstr, _)
   }
 
-  override final Instruction getUseInstruction() {
+  override final Instruction getUse() {
     result = useInstr
   }
 
-  override final Instruction getDefinitionInstruction() {
+  override final Instruction getAnyDef() {
     result = defInstr
   }
 
@@ -436,11 +436,11 @@ class PhiInputOperand extends MemoryOperand, TPhiOperand {
     result = "Phi"
   }
 
-  override final PhiInstruction getUseInstruction() {
+  override final PhiInstruction getUse() {
     result = useInstr
   }
 
-  override final Instruction getDefinitionInstruction() {
+  override final Instruction getAnyDef() {
     result = defInstr
   }
 

--- a/cpp/ql/src/semmle/code/cpp/ir/implementation/aliased_ssa/Operand.qll
+++ b/cpp/ql/src/semmle/code/cpp/ir/implementation/aliased_ssa/Operand.qll
@@ -32,7 +32,7 @@ class Operand extends TOperand {
   final IRFunction getEnclosingIRFunction() {
     result = getUse().getEnclosingIRFunction()
   }
-  
+
   /**
    * Gets the `Instruction` that consumes this operand.
    */
@@ -41,10 +41,46 @@ class Operand extends TOperand {
   }
 
   /**
-   * Gets the `Instruction` whose result is the value of the operand.
+   * Gets the `Instruction` whose result is the value of the operand. Unlike
+   * `getDef`, this also has a result when `isDefinitionInexact` holds, which
+   * means that the resulting instruction may only _partially_ or _potentially_
+   * be the value of this operand.
    */
   Instruction getAnyDef() {
     none()
+  }
+
+  /**
+   * Gets the `Instruction` whose result is the value of the operand. Unlike
+   * `getAnyDef`, this also has no result when `isDefinitionInexact` holds,
+   * which means that the resulting instruction must always be exactly the be
+   * the value of this operand.
+   */
+  final Instruction getDef() {
+    result = this.getAnyDef() and
+    getDefinitionOverlap() instanceof MustExactlyOverlap
+  }
+
+  /**
+   * DEPRECATED: renamed to `getUse`.
+   *
+   * Gets the `Instruction` that consumes this operand.
+   */
+  deprecated
+  final Instruction getUseInstruction() {
+    result = getUse()
+  }
+
+  /**
+   * DEPRECATED: use `getAnyDef` or `getDef`. The exact replacement for this
+   * predicate is `getAnyDef`, but most uses of this predicate should probably
+   * be replaced with `getDef`.
+   *
+   * Gets the `Instruction` whose result is the value of the operand.
+   */
+  deprecated
+  final Instruction getDefinitionInstruction() {
+    result = getAnyDef()
   }
 
   /**

--- a/cpp/ql/src/semmle/code/cpp/ir/implementation/aliased_ssa/constant/ConstantAnalysis.qll
+++ b/cpp/ql/src/semmle/code/cpp/ir/implementation/aliased_ssa/constant/ConstantAnalysis.qll
@@ -10,16 +10,8 @@ int getConstantValue(Instruction instr) {
   result = getConstantValue(instr.(CopyInstruction).getSourceValue()) or
   exists(PhiInstruction phi |
     phi = instr and
-    result = max(Instruction def | def = phi.getAnInput() | getConstantValueToPhi(def)) and
-    result = min(Instruction def | def = phi.getAnInput() | getConstantValueToPhi(def))
-  )
-}
-
-pragma[noinline]
-int getConstantValueToPhi(Instruction def) {
-  exists(PhiInstruction phi |
-    result = getConstantValue(def) and
-    def = phi.getAnInput()
+    result = max(Operand op | op = phi.getAnInputOperand() | getConstantValue(op.getDef())) and
+    result = min(Operand op | op = phi.getAnInputOperand() | getConstantValue(op.getDef()))
   )
 }
 

--- a/cpp/ql/src/semmle/code/cpp/ir/implementation/aliased_ssa/gvn/ValueNumbering.qll
+++ b/cpp/ql/src/semmle/code/cpp/ir/implementation/aliased_ssa/gvn/ValueNumbering.qll
@@ -88,7 +88,7 @@ class ValueNumber extends TValueNumber {
   }
   
   final Operand getAUse() {
-    this = valueNumber(result.getDefinitionInstruction())
+    this = valueNumber(result.getAnyDef())
   }
 }
 
@@ -230,7 +230,7 @@ cached ValueNumber valueNumber(Instruction instr) {
  * Gets the value number assigned to `instr`, if any. Returns at most one result.
  */
 ValueNumber valueNumberOfOperand(Operand op) {
-  result = valueNumber(op.getDefinitionInstruction())
+  result = valueNumber(op.getAnyDef())
 }
 
 /**

--- a/cpp/ql/src/semmle/code/cpp/ir/implementation/aliased_ssa/gvn/ValueNumbering.qll
+++ b/cpp/ql/src/semmle/code/cpp/ir/implementation/aliased_ssa/gvn/ValueNumbering.qll
@@ -86,9 +86,12 @@ class ValueNumber extends TValueNumber {
       instr order by instr.getBlock().getDisplayIndex(), instr.getDisplayIndexInBlock()
     )
   }
-  
+
+  /**
+   * Gets an `Operand` whose definition is exact and has this value number.
+   */
   final Operand getAUse() {
-    this = valueNumber(result.getAnyDef())
+    this = valueNumber(result.getDef())
   }
 }
 
@@ -227,10 +230,11 @@ cached ValueNumber valueNumber(Instruction instr) {
 }
 
 /**
- * Gets the value number assigned to `instr`, if any. Returns at most one result.
+ * Gets the value number assigned to the exact definition of `op`, if any.
+ * Returns at most one result.
  */
 ValueNumber valueNumberOfOperand(Operand op) {
-  result = valueNumber(op.getAnyDef())
+  result = valueNumber(op.getDef())
 }
 
 /**

--- a/cpp/ql/src/semmle/code/cpp/ir/implementation/aliased_ssa/internal/AliasedSSA.qll
+++ b/cpp/ql/src/semmle/code/cpp/ir/implementation/aliased_ssa/internal/AliasedSSA.qll
@@ -21,7 +21,7 @@ private predicate hasResultMemoryAccess(Instruction instr, IRVariable var, Type 
 
 private predicate hasOperandMemoryAccess(MemoryOperand operand, IRVariable var, Type type, IntValue startBitOffset,
     IntValue endBitOffset) {
-  resultPointsTo(operand.getAddress().getAnyDef(), var, startBitOffset) and
+  resultPointsTo(operand.getAddressOperand().getAnyDef(), var, startBitOffset) and
   type = operand.getType() and
   if exists(operand.getSize()) then
     endBitOffset = Ints::add(startBitOffset, Ints::mul(operand.getSize(), 8))

--- a/cpp/ql/src/semmle/code/cpp/ir/implementation/aliased_ssa/internal/AliasedSSA.qll
+++ b/cpp/ql/src/semmle/code/cpp/ir/implementation/aliased_ssa/internal/AliasedSSA.qll
@@ -11,7 +11,7 @@ private class IntValue = Ints::IntValue;
 
 private predicate hasResultMemoryAccess(Instruction instr, IRVariable var, Type type, IntValue startBitOffset,
     IntValue endBitOffset) {
-  resultPointsTo(instr.getResultAddressOperand().getDefinitionInstruction(), var, startBitOffset) and
+  resultPointsTo(instr.getResultAddressOperand().getAnyDef(), var, startBitOffset) and
   type = instr.getResultType() and
   if exists(instr.getResultSize()) then
     endBitOffset = Ints::add(startBitOffset, Ints::mul(instr.getResultSize(), 8))
@@ -21,7 +21,7 @@ private predicate hasResultMemoryAccess(Instruction instr, IRVariable var, Type 
 
 private predicate hasOperandMemoryAccess(MemoryOperand operand, IRVariable var, Type type, IntValue startBitOffset,
     IntValue endBitOffset) {
-  resultPointsTo(operand.getAddressOperand().getDefinitionInstruction(), var, startBitOffset) and
+  resultPointsTo(operand.getAddressOperand().getAnyDef(), var, startBitOffset) and
   type = operand.getType() and
   if exists(operand.getSize()) then
     endBitOffset = Ints::add(startBitOffset, Ints::mul(operand.getSize(), 8))

--- a/cpp/ql/src/semmle/code/cpp/ir/implementation/aliased_ssa/internal/AliasedSSA.qll
+++ b/cpp/ql/src/semmle/code/cpp/ir/implementation/aliased_ssa/internal/AliasedSSA.qll
@@ -11,7 +11,7 @@ private class IntValue = Ints::IntValue;
 
 private predicate hasResultMemoryAccess(Instruction instr, IRVariable var, Type type, IntValue startBitOffset,
     IntValue endBitOffset) {
-  resultPointsTo(instr.getResultAddressOperand().getAnyDef(), var, startBitOffset) and
+  resultPointsTo(instr.getResultAddress(), var, startBitOffset) and
   type = instr.getResultType() and
   if exists(instr.getResultSize()) then
     endBitOffset = Ints::add(startBitOffset, Ints::mul(instr.getResultSize(), 8))
@@ -21,7 +21,7 @@ private predicate hasResultMemoryAccess(Instruction instr, IRVariable var, Type 
 
 private predicate hasOperandMemoryAccess(MemoryOperand operand, IRVariable var, Type type, IntValue startBitOffset,
     IntValue endBitOffset) {
-  resultPointsTo(operand.getAddressOperand().getAnyDef(), var, startBitOffset) and
+  resultPointsTo(operand.getAddress().getAnyDef(), var, startBitOffset) and
   type = operand.getType() and
   if exists(operand.getSize()) then
     endBitOffset = Ints::add(startBitOffset, Ints::mul(operand.getSize(), 8))

--- a/cpp/ql/src/semmle/code/cpp/ir/implementation/aliased_ssa/internal/SSAConstruction.qll
+++ b/cpp/ql/src/semmle/code/cpp/ir/implementation/aliased_ssa/internal/SSAConstruction.qll
@@ -69,7 +69,7 @@ cached private module Cached {
       oldInstruction = getOldInstruction(instruction) and
       oldOperand = oldInstruction.getAnOperand() and
       tag = oldOperand.getOperandTag() and
-      result = getNewInstruction(oldOperand.getDefinitionInstruction())
+      result = getNewInstruction(oldOperand.getAnyDef())
     )
   }
 
@@ -101,7 +101,7 @@ cached private module Cached {
         exists(OldInstruction oldDefinition |
           instruction instanceof UnmodeledUseInstruction and
           tag instanceof UnmodeledUseOperandTag and
-          oldDefinition = oldOperand.getDefinitionInstruction() and
+          oldDefinition = oldOperand.getAnyDef() and
           not exists(Alias::getResultMemoryLocation(oldDefinition)) and
           result = getNewInstruction(oldDefinition) and
           overlap instanceof MustTotallyOverlap

--- a/cpp/ql/src/semmle/code/cpp/ir/implementation/raw/Instruction.qll
+++ b/cpp/ql/src/semmle/code/cpp/ir/implementation/raw/Instruction.qll
@@ -480,7 +480,8 @@ class Instruction extends Construction::TInstruction {
   }
 
   /**
-   * Gets all direct uses of the result of this instruction.
+   * Gets all direct uses of the result of this instruction. The result can be
+   * an `Operand` for which `isDefinitionInexact` holds.
    */
   final Operand getAUse() {
     result.getAnyDef() = this
@@ -698,7 +699,7 @@ class FieldAddressInstruction extends FieldInstruction {
   }
 
   final Instruction getObjectAddress() {
-    result = getObjectAddressOperand().getAnyDef()
+    result = getObjectAddressOperand().getDef()
   }
 }
 
@@ -747,7 +748,7 @@ class ReturnValueInstruction extends ReturnInstruction {
   }
   
   final Instruction getReturnValue() {
-    result = getReturnValueOperand().getAnyDef()
+    result = getReturnValueOperand().getDef()
   }
 }
 
@@ -761,7 +762,7 @@ class CopyInstruction extends Instruction {
   }
 
   final Instruction getSourceValue() {
-    result = getSourceValueOperand().getAnyDef()
+    result = getSourceValueOperand().getDef()
   }
 }
 
@@ -785,7 +786,7 @@ class LoadInstruction extends CopyInstruction {
   }
   
   final Instruction getSourceAddress() {
-    result = getSourceAddressOperand().getAnyDef()
+    result = getSourceAddressOperand().getDef()
   }
 
   override final LoadOperand getSourceValueOperand() {
@@ -807,7 +808,7 @@ class StoreInstruction extends CopyInstruction {
   }
   
   final Instruction getDestinationAddress() {
-    result = getDestinationAddressOperand().getAnyDef()
+    result = getDestinationAddressOperand().getDef()
   }
 
   override final StoreValueOperand getSourceValueOperand() {
@@ -825,7 +826,7 @@ class ConditionalBranchInstruction extends Instruction {
   }
 
   final Instruction getCondition() {
-    result = getConditionOperand().getAnyDef()
+    result = getConditionOperand().getDef()
   }
 
   final Instruction getTrueSuccessor() {
@@ -891,11 +892,11 @@ class BinaryInstruction extends Instruction {
   }
 
   final Instruction getLeft() {
-    result = getLeftOperand().getAnyDef()
+    result = getLeftOperand().getDef()
   }
 
   final Instruction getRight() {
-    result = getRightOperand().getAnyDef()
+    result = getRightOperand().getDef()
   }
   
   /**
@@ -1045,7 +1046,7 @@ class UnaryInstruction extends Instruction {
   }
   
   final Instruction getUnary() {
-    result = getUnaryOperand().getAnyDef()
+    result = getUnaryOperand().getDef()
   }
 }
 
@@ -1275,7 +1276,7 @@ class SwitchInstruction extends Instruction {
   }
 
   final Instruction getExpression() {
-    result = getExpressionOperand().getAnyDef()
+    result = getExpressionOperand().getDef()
   }
 
   final Instruction getACaseSuccessor() {
@@ -1310,7 +1311,7 @@ class CallInstruction extends Instruction {
    * function pointer.
    */
   final Instruction getCallTarget() {
-    result = getCallTargetOperand().getAnyDef()
+    result = getCallTargetOperand().getDef()
   }
 
   /**
@@ -1331,7 +1332,7 @@ class CallInstruction extends Instruction {
    * Gets all of the arguments of the call, including the `this` pointer, if any.
    */
   final Instruction getAnArgument() {
-    result = getAnArgumentOperand().getAnyDef()
+    result = getAnArgumentOperand().getDef()
   }
 
   /**
@@ -1345,7 +1346,7 @@ class CallInstruction extends Instruction {
    * Gets the `this` pointer argument of the call, if any.
    */
   final Instruction getThisArgument() {
-    result = getThisArgumentOperand().getAnyDef()
+    result = getThisArgumentOperand().getDef()
   }
 
   /**
@@ -1360,7 +1361,7 @@ class CallInstruction extends Instruction {
    * Gets the argument at the specified index.
    */
   final Instruction getPositionalArgument(int index) {
-    result = getPositionalArgumentOperand(index).getAnyDef()
+    result = getPositionalArgumentOperand(index).getDef()
   }
 }
 
@@ -1516,7 +1517,7 @@ class ThrowValueInstruction extends ThrowInstruction {
    * Gets the address of the exception thrown by this instruction.
    */
   final Instruction getExceptionAddress() {
-    result = getExceptionAddressOperand().getAnyDef()
+    result = getExceptionAddressOperand().getDef()
   }
 
   /**
@@ -1530,7 +1531,7 @@ class ThrowValueInstruction extends ThrowInstruction {
    * Gets the exception thrown by this instruction.
    */
   final Instruction getException() {
-    result = getExceptionOperand().getAnyDef()
+    result = getExceptionOperand().getDef()
   }
 }
 
@@ -1660,7 +1661,7 @@ class PhiInstruction extends Instruction {
    */
   pragma[noinline]
   final Instruction getAnInput() {
-    result = this.getAnInputOperand().getAnyDef()
+    result = this.getAnInputOperand().getDef()
   }
 }
 
@@ -1728,7 +1729,7 @@ class ChiInstruction extends Instruction {
    * memory write.
    */
   final Instruction getTotal() {
-    result = getTotalOperand().getAnyDef()
+    result = getTotalOperand().getDef()
   }
 
   /**
@@ -1742,7 +1743,7 @@ class ChiInstruction extends Instruction {
    * Gets the operand that represents the new value written by the memory write.
    */
   final Instruction getPartial() {
-    result = getPartialOperand().getAnyDef()
+    result = getPartialOperand().getDef()
   }
 }
 

--- a/cpp/ql/src/semmle/code/cpp/ir/implementation/raw/Instruction.qll
+++ b/cpp/ql/src/semmle/code/cpp/ir/implementation/raw/Instruction.qll
@@ -510,13 +510,22 @@ class Instruction extends Construction::TInstruction {
   }
 
   /**
-   * Returns the operand that holds the memory address to which the instruction stores its
+   * Gets the operand that holds the memory address to which this instruction stores its
    * result, if any. For example, in `m3 = Store r1, r2`, the result of `getResultAddressOperand()`
    * is `r1`.
    */
   final AddressOperand getResultAddressOperand() {
     getResultMemoryAccess().usesAddressOperand() and
     result.getUse() = this
+  }
+
+  /**
+   * Gets the instruction that holds the exact memory address to which this instruction stores its
+   * result, if any. For example, in `m3 = Store r1, r2`, the result of `getResultAddressOperand()`
+   * is the instruction that defines `r1`.
+   */
+  final Instruction getResultAddress() {
+    result = getResultAddressOperand().getDef()
   }
 
   /**

--- a/cpp/ql/src/semmle/code/cpp/ir/implementation/raw/Instruction.qll
+++ b/cpp/ql/src/semmle/code/cpp/ir/implementation/raw/Instruction.qll
@@ -103,7 +103,7 @@ module InstructionSanity {
   query predicate missingOperandType(Operand operand, string message) {
     exists(Function func |
       not exists(operand.getType()) and
-      func = operand.getUseInstruction().getEnclosingFunction() and
+      func = operand.getUse().getEnclosingFunction() and
       message = "Operand missing type in function '" + getIdentityString(func) + "'."
     )
   }
@@ -158,8 +158,8 @@ module InstructionSanity {
    * a different function.
    */
   query predicate operandAcrossFunctions(Operand operand, Instruction instr, Instruction defInstr) {
-    operand.getUseInstruction() = instr and
-    operand.getDefinitionInstruction() = defInstr and
+    operand.getUse() = instr and
+    operand.getAnyDef() = defInstr and
     instr.getEnclosingIRFunction() != defInstr.getEnclosingIRFunction()
   }
 
@@ -483,14 +483,14 @@ class Instruction extends Construction::TInstruction {
    * Gets all direct uses of the result of this instruction.
    */
   final Operand getAUse() {
-    result.getDefinitionInstruction() = this
+    result.getAnyDef() = this
   }
 
   /**
    * Gets all of this instruction's operands.
    */
   final Operand getAnOperand() {
-    result.getUseInstruction() = this
+    result.getUse() = this
   }
 
   /**
@@ -515,7 +515,7 @@ class Instruction extends Construction::TInstruction {
    */
   final AddressOperand getResultAddressOperand() {
     getResultMemoryAccess().usesAddressOperand() and
-    result.getUseInstruction() = this
+    result.getUse() = this
   }
 
   /**
@@ -698,7 +698,7 @@ class FieldAddressInstruction extends FieldInstruction {
   }
 
   final Instruction getObjectAddress() {
-    result = getObjectAddressOperand().getDefinitionInstruction()
+    result = getObjectAddressOperand().getAnyDef()
   }
 }
 
@@ -747,7 +747,7 @@ class ReturnValueInstruction extends ReturnInstruction {
   }
   
   final Instruction getReturnValue() {
-    result = getReturnValueOperand().getDefinitionInstruction()
+    result = getReturnValueOperand().getAnyDef()
   }
 }
 
@@ -761,7 +761,7 @@ class CopyInstruction extends Instruction {
   }
 
   final Instruction getSourceValue() {
-    result = getSourceValueOperand().getDefinitionInstruction()
+    result = getSourceValueOperand().getAnyDef()
   }
 }
 
@@ -785,7 +785,7 @@ class LoadInstruction extends CopyInstruction {
   }
   
   final Instruction getSourceAddress() {
-    result = getSourceAddressOperand().getDefinitionInstruction()
+    result = getSourceAddressOperand().getAnyDef()
   }
 
   override final LoadOperand getSourceValueOperand() {
@@ -807,7 +807,7 @@ class StoreInstruction extends CopyInstruction {
   }
   
   final Instruction getDestinationAddress() {
-    result = getDestinationAddressOperand().getDefinitionInstruction()
+    result = getDestinationAddressOperand().getAnyDef()
   }
 
   override final StoreValueOperand getSourceValueOperand() {
@@ -825,7 +825,7 @@ class ConditionalBranchInstruction extends Instruction {
   }
 
   final Instruction getCondition() {
-    result = getConditionOperand().getDefinitionInstruction()
+    result = getConditionOperand().getAnyDef()
   }
 
   final Instruction getTrueSuccessor() {
@@ -891,11 +891,11 @@ class BinaryInstruction extends Instruction {
   }
 
   final Instruction getLeft() {
-    result = getLeftOperand().getDefinitionInstruction()
+    result = getLeftOperand().getAnyDef()
   }
 
   final Instruction getRight() {
-    result = getRightOperand().getDefinitionInstruction()
+    result = getRightOperand().getAnyDef()
   }
   
   /**
@@ -1045,7 +1045,7 @@ class UnaryInstruction extends Instruction {
   }
   
   final Instruction getUnary() {
-    result = getUnaryOperand().getDefinitionInstruction()
+    result = getUnaryOperand().getAnyDef()
   }
 }
 
@@ -1275,7 +1275,7 @@ class SwitchInstruction extends Instruction {
   }
 
   final Instruction getExpression() {
-    result = getExpressionOperand().getDefinitionInstruction()
+    result = getExpressionOperand().getAnyDef()
   }
 
   final Instruction getACaseSuccessor() {
@@ -1310,7 +1310,7 @@ class CallInstruction extends Instruction {
    * function pointer.
    */
   final Instruction getCallTarget() {
-    result = getCallTargetOperand().getDefinitionInstruction()
+    result = getCallTargetOperand().getAnyDef()
   }
 
   /**
@@ -1331,7 +1331,7 @@ class CallInstruction extends Instruction {
    * Gets all of the arguments of the call, including the `this` pointer, if any.
    */
   final Instruction getAnArgument() {
-    result = getAnArgumentOperand().getDefinitionInstruction()
+    result = getAnArgumentOperand().getAnyDef()
   }
 
   /**
@@ -1345,7 +1345,7 @@ class CallInstruction extends Instruction {
    * Gets the `this` pointer argument of the call, if any.
    */
   final Instruction getThisArgument() {
-    result = getThisArgumentOperand().getDefinitionInstruction()
+    result = getThisArgumentOperand().getAnyDef()
   }
 
   /**
@@ -1360,7 +1360,7 @@ class CallInstruction extends Instruction {
    * Gets the argument at the specified index.
    */
   final Instruction getPositionalArgument(int index) {
-    result = getPositionalArgumentOperand(index).getDefinitionInstruction()
+    result = getPositionalArgumentOperand(index).getAnyDef()
   }
 }
 
@@ -1516,7 +1516,7 @@ class ThrowValueInstruction extends ThrowInstruction {
    * Gets the address of the exception thrown by this instruction.
    */
   final Instruction getExceptionAddress() {
-    result = getExceptionAddressOperand().getDefinitionInstruction()
+    result = getExceptionAddressOperand().getAnyDef()
   }
 
   /**
@@ -1530,7 +1530,7 @@ class ThrowValueInstruction extends ThrowInstruction {
    * Gets the exception thrown by this instruction.
    */
   final Instruction getException() {
-    result = getExceptionOperand().getDefinitionInstruction()
+    result = getExceptionOperand().getAnyDef()
   }
 }
 
@@ -1660,7 +1660,7 @@ class PhiInstruction extends Instruction {
    */
   pragma[noinline]
   final Instruction getAnInput() {
-    result = this.getAnInputOperand().getDefinitionInstruction()
+    result = this.getAnInputOperand().getAnyDef()
   }
 }
 
@@ -1728,7 +1728,7 @@ class ChiInstruction extends Instruction {
    * memory write.
    */
   final Instruction getTotal() {
-    result = getTotalOperand().getDefinitionInstruction()
+    result = getTotalOperand().getAnyDef()
   }
 
   /**
@@ -1742,7 +1742,7 @@ class ChiInstruction extends Instruction {
    * Gets the operand that represents the new value written by the memory write.
    */
   final Instruction getPartial() {
-    result = getPartialOperand().getDefinitionInstruction()
+    result = getPartialOperand().getAnyDef()
   }
 }
 

--- a/cpp/ql/src/semmle/code/cpp/ir/implementation/raw/Operand.qll
+++ b/cpp/ql/src/semmle/code/cpp/ir/implementation/raw/Operand.qll
@@ -26,24 +26,24 @@ class Operand extends TOperand {
   }
 
   final Location getLocation() {
-    result = getUseInstruction().getLocation()
+    result = getUse().getLocation()
   }
 
   final IRFunction getEnclosingIRFunction() {
-    result = getUseInstruction().getEnclosingIRFunction()
+    result = getUse().getEnclosingIRFunction()
   }
   
   /**
    * Gets the `Instruction` that consumes this operand.
    */
-  Instruction getUseInstruction() {
+  Instruction getUse() {
     none()
   }
 
   /**
    * Gets the `Instruction` whose result is the value of the operand.
    */
-  Instruction getDefinitionInstruction() {
+  Instruction getAnyDef() {
     none()
   }
 
@@ -76,7 +76,7 @@ class Operand extends TOperand {
    * For example: `this:r3_5`
    */
   final string getDumpString() {
-    result = getDumpLabel() + getInexactSpecifier() + getDefinitionInstruction().getResultId()
+    result = getDumpLabel() + getInexactSpecifier() + getAnyDef().getResultId()
   }
 
   /**
@@ -106,7 +106,7 @@ class Operand extends TOperand {
    * has been cast to a different type.
    */
   Type getType() {
-    result = getDefinitionInstruction().getResultType()
+    result = getAnyDef().getResultType()
   }
 
   /**
@@ -117,7 +117,7 @@ class Operand extends TOperand {
    * given by `getResultType()`.
    */
   predicate isGLValue() {
-    getDefinitionInstruction().isGLValue()
+    getAnyDef().isGLValue()
   }
 
   /**
@@ -157,7 +157,7 @@ class MemoryOperand extends Operand {
    */
   final AddressOperand getAddressOperand() {
     getMemoryAccess().usesAddressOperand() and
-    result.getUseInstruction() = getUseInstruction()
+    result.getUse() = getUse()
   }
 }
 
@@ -174,11 +174,11 @@ class NonPhiOperand extends Operand {
     this = TNonPhiMemoryOperand(useInstr, tag, defInstr, _)
   }
 
-  override final Instruction getUseInstruction() {
+  override final Instruction getUse() {
     result = useInstr
   }
 
-  override final Instruction getDefinitionInstruction() {
+  override final Instruction getAnyDef() {
     result = defInstr
   }
 
@@ -436,11 +436,11 @@ class PhiInputOperand extends MemoryOperand, TPhiOperand {
     result = "Phi"
   }
 
-  override final PhiInstruction getUseInstruction() {
+  override final PhiInstruction getUse() {
     result = useInstr
   }
 
-  override final Instruction getDefinitionInstruction() {
+  override final Instruction getAnyDef() {
     result = defInstr
   }
 

--- a/cpp/ql/src/semmle/code/cpp/ir/implementation/raw/Operand.qll
+++ b/cpp/ql/src/semmle/code/cpp/ir/implementation/raw/Operand.qll
@@ -32,7 +32,7 @@ class Operand extends TOperand {
   final IRFunction getEnclosingIRFunction() {
     result = getUse().getEnclosingIRFunction()
   }
-  
+
   /**
    * Gets the `Instruction` that consumes this operand.
    */
@@ -41,10 +41,46 @@ class Operand extends TOperand {
   }
 
   /**
-   * Gets the `Instruction` whose result is the value of the operand.
+   * Gets the `Instruction` whose result is the value of the operand. Unlike
+   * `getDef`, this also has a result when `isDefinitionInexact` holds, which
+   * means that the resulting instruction may only _partially_ or _potentially_
+   * be the value of this operand.
    */
   Instruction getAnyDef() {
     none()
+  }
+
+  /**
+   * Gets the `Instruction` whose result is the value of the operand. Unlike
+   * `getAnyDef`, this also has no result when `isDefinitionInexact` holds,
+   * which means that the resulting instruction must always be exactly the be
+   * the value of this operand.
+   */
+  final Instruction getDef() {
+    result = this.getAnyDef() and
+    getDefinitionOverlap() instanceof MustExactlyOverlap
+  }
+
+  /**
+   * DEPRECATED: renamed to `getUse`.
+   *
+   * Gets the `Instruction` that consumes this operand.
+   */
+  deprecated
+  final Instruction getUseInstruction() {
+    result = getUse()
+  }
+
+  /**
+   * DEPRECATED: use `getAnyDef` or `getDef`. The exact replacement for this
+   * predicate is `getAnyDef`, but most uses of this predicate should probably
+   * be replaced with `getDef`.
+   *
+   * Gets the `Instruction` whose result is the value of the operand.
+   */
+  deprecated
+  final Instruction getDefinitionInstruction() {
+    result = getAnyDef()
   }
 
   /**

--- a/cpp/ql/src/semmle/code/cpp/ir/implementation/raw/constant/ConstantAnalysis.qll
+++ b/cpp/ql/src/semmle/code/cpp/ir/implementation/raw/constant/ConstantAnalysis.qll
@@ -10,16 +10,8 @@ int getConstantValue(Instruction instr) {
   result = getConstantValue(instr.(CopyInstruction).getSourceValue()) or
   exists(PhiInstruction phi |
     phi = instr and
-    result = max(Instruction def | def = phi.getAnInput() | getConstantValueToPhi(def)) and
-    result = min(Instruction def | def = phi.getAnInput() | getConstantValueToPhi(def))
-  )
-}
-
-pragma[noinline]
-int getConstantValueToPhi(Instruction def) {
-  exists(PhiInstruction phi |
-    result = getConstantValue(def) and
-    def = phi.getAnInput()
+    result = max(Operand op | op = phi.getAnInputOperand() | getConstantValue(op.getDef())) and
+    result = min(Operand op | op = phi.getAnInputOperand() | getConstantValue(op.getDef()))
   )
 }
 

--- a/cpp/ql/src/semmle/code/cpp/ir/implementation/raw/gvn/ValueNumbering.qll
+++ b/cpp/ql/src/semmle/code/cpp/ir/implementation/raw/gvn/ValueNumbering.qll
@@ -88,7 +88,7 @@ class ValueNumber extends TValueNumber {
   }
   
   final Operand getAUse() {
-    this = valueNumber(result.getDefinitionInstruction())
+    this = valueNumber(result.getAnyDef())
   }
 }
 
@@ -230,7 +230,7 @@ cached ValueNumber valueNumber(Instruction instr) {
  * Gets the value number assigned to `instr`, if any. Returns at most one result.
  */
 ValueNumber valueNumberOfOperand(Operand op) {
-  result = valueNumber(op.getDefinitionInstruction())
+  result = valueNumber(op.getAnyDef())
 }
 
 /**

--- a/cpp/ql/src/semmle/code/cpp/ir/implementation/raw/gvn/ValueNumbering.qll
+++ b/cpp/ql/src/semmle/code/cpp/ir/implementation/raw/gvn/ValueNumbering.qll
@@ -86,9 +86,12 @@ class ValueNumber extends TValueNumber {
       instr order by instr.getBlock().getDisplayIndex(), instr.getDisplayIndexInBlock()
     )
   }
-  
+
+  /**
+   * Gets an `Operand` whose definition is exact and has this value number.
+   */
   final Operand getAUse() {
-    this = valueNumber(result.getAnyDef())
+    this = valueNumber(result.getDef())
   }
 }
 
@@ -227,10 +230,11 @@ cached ValueNumber valueNumber(Instruction instr) {
 }
 
 /**
- * Gets the value number assigned to `instr`, if any. Returns at most one result.
+ * Gets the value number assigned to the exact definition of `op`, if any.
+ * Returns at most one result.
  */
 ValueNumber valueNumberOfOperand(Operand op) {
-  result = valueNumber(op.getAnyDef())
+  result = valueNumber(op.getDef())
 }
 
 /**

--- a/cpp/ql/src/semmle/code/cpp/ir/implementation/unaliased_ssa/Instruction.qll
+++ b/cpp/ql/src/semmle/code/cpp/ir/implementation/unaliased_ssa/Instruction.qll
@@ -480,7 +480,8 @@ class Instruction extends Construction::TInstruction {
   }
 
   /**
-   * Gets all direct uses of the result of this instruction.
+   * Gets all direct uses of the result of this instruction. The result can be
+   * an `Operand` for which `isDefinitionInexact` holds.
    */
   final Operand getAUse() {
     result.getAnyDef() = this
@@ -698,7 +699,7 @@ class FieldAddressInstruction extends FieldInstruction {
   }
 
   final Instruction getObjectAddress() {
-    result = getObjectAddressOperand().getAnyDef()
+    result = getObjectAddressOperand().getDef()
   }
 }
 
@@ -747,7 +748,7 @@ class ReturnValueInstruction extends ReturnInstruction {
   }
   
   final Instruction getReturnValue() {
-    result = getReturnValueOperand().getAnyDef()
+    result = getReturnValueOperand().getDef()
   }
 }
 
@@ -761,7 +762,7 @@ class CopyInstruction extends Instruction {
   }
 
   final Instruction getSourceValue() {
-    result = getSourceValueOperand().getAnyDef()
+    result = getSourceValueOperand().getDef()
   }
 }
 
@@ -785,7 +786,7 @@ class LoadInstruction extends CopyInstruction {
   }
   
   final Instruction getSourceAddress() {
-    result = getSourceAddressOperand().getAnyDef()
+    result = getSourceAddressOperand().getDef()
   }
 
   override final LoadOperand getSourceValueOperand() {
@@ -807,7 +808,7 @@ class StoreInstruction extends CopyInstruction {
   }
   
   final Instruction getDestinationAddress() {
-    result = getDestinationAddressOperand().getAnyDef()
+    result = getDestinationAddressOperand().getDef()
   }
 
   override final StoreValueOperand getSourceValueOperand() {
@@ -825,7 +826,7 @@ class ConditionalBranchInstruction extends Instruction {
   }
 
   final Instruction getCondition() {
-    result = getConditionOperand().getAnyDef()
+    result = getConditionOperand().getDef()
   }
 
   final Instruction getTrueSuccessor() {
@@ -891,11 +892,11 @@ class BinaryInstruction extends Instruction {
   }
 
   final Instruction getLeft() {
-    result = getLeftOperand().getAnyDef()
+    result = getLeftOperand().getDef()
   }
 
   final Instruction getRight() {
-    result = getRightOperand().getAnyDef()
+    result = getRightOperand().getDef()
   }
   
   /**
@@ -1045,7 +1046,7 @@ class UnaryInstruction extends Instruction {
   }
   
   final Instruction getUnary() {
-    result = getUnaryOperand().getAnyDef()
+    result = getUnaryOperand().getDef()
   }
 }
 
@@ -1275,7 +1276,7 @@ class SwitchInstruction extends Instruction {
   }
 
   final Instruction getExpression() {
-    result = getExpressionOperand().getAnyDef()
+    result = getExpressionOperand().getDef()
   }
 
   final Instruction getACaseSuccessor() {
@@ -1310,7 +1311,7 @@ class CallInstruction extends Instruction {
    * function pointer.
    */
   final Instruction getCallTarget() {
-    result = getCallTargetOperand().getAnyDef()
+    result = getCallTargetOperand().getDef()
   }
 
   /**
@@ -1331,7 +1332,7 @@ class CallInstruction extends Instruction {
    * Gets all of the arguments of the call, including the `this` pointer, if any.
    */
   final Instruction getAnArgument() {
-    result = getAnArgumentOperand().getAnyDef()
+    result = getAnArgumentOperand().getDef()
   }
 
   /**
@@ -1345,7 +1346,7 @@ class CallInstruction extends Instruction {
    * Gets the `this` pointer argument of the call, if any.
    */
   final Instruction getThisArgument() {
-    result = getThisArgumentOperand().getAnyDef()
+    result = getThisArgumentOperand().getDef()
   }
 
   /**
@@ -1360,7 +1361,7 @@ class CallInstruction extends Instruction {
    * Gets the argument at the specified index.
    */
   final Instruction getPositionalArgument(int index) {
-    result = getPositionalArgumentOperand(index).getAnyDef()
+    result = getPositionalArgumentOperand(index).getDef()
   }
 }
 
@@ -1516,7 +1517,7 @@ class ThrowValueInstruction extends ThrowInstruction {
    * Gets the address of the exception thrown by this instruction.
    */
   final Instruction getExceptionAddress() {
-    result = getExceptionAddressOperand().getAnyDef()
+    result = getExceptionAddressOperand().getDef()
   }
 
   /**
@@ -1530,7 +1531,7 @@ class ThrowValueInstruction extends ThrowInstruction {
    * Gets the exception thrown by this instruction.
    */
   final Instruction getException() {
-    result = getExceptionOperand().getAnyDef()
+    result = getExceptionOperand().getDef()
   }
 }
 
@@ -1660,7 +1661,7 @@ class PhiInstruction extends Instruction {
    */
   pragma[noinline]
   final Instruction getAnInput() {
-    result = this.getAnInputOperand().getAnyDef()
+    result = this.getAnInputOperand().getDef()
   }
 }
 
@@ -1728,7 +1729,7 @@ class ChiInstruction extends Instruction {
    * memory write.
    */
   final Instruction getTotal() {
-    result = getTotalOperand().getAnyDef()
+    result = getTotalOperand().getDef()
   }
 
   /**
@@ -1742,7 +1743,7 @@ class ChiInstruction extends Instruction {
    * Gets the operand that represents the new value written by the memory write.
    */
   final Instruction getPartial() {
-    result = getPartialOperand().getAnyDef()
+    result = getPartialOperand().getDef()
   }
 }
 

--- a/cpp/ql/src/semmle/code/cpp/ir/implementation/unaliased_ssa/Instruction.qll
+++ b/cpp/ql/src/semmle/code/cpp/ir/implementation/unaliased_ssa/Instruction.qll
@@ -510,13 +510,22 @@ class Instruction extends Construction::TInstruction {
   }
 
   /**
-   * Returns the operand that holds the memory address to which the instruction stores its
+   * Gets the operand that holds the memory address to which this instruction stores its
    * result, if any. For example, in `m3 = Store r1, r2`, the result of `getResultAddressOperand()`
    * is `r1`.
    */
   final AddressOperand getResultAddressOperand() {
     getResultMemoryAccess().usesAddressOperand() and
     result.getUse() = this
+  }
+
+  /**
+   * Gets the instruction that holds the exact memory address to which this instruction stores its
+   * result, if any. For example, in `m3 = Store r1, r2`, the result of `getResultAddressOperand()`
+   * is the instruction that defines `r1`.
+   */
+  final Instruction getResultAddress() {
+    result = getResultAddressOperand().getDef()
   }
 
   /**

--- a/cpp/ql/src/semmle/code/cpp/ir/implementation/unaliased_ssa/Instruction.qll
+++ b/cpp/ql/src/semmle/code/cpp/ir/implementation/unaliased_ssa/Instruction.qll
@@ -103,7 +103,7 @@ module InstructionSanity {
   query predicate missingOperandType(Operand operand, string message) {
     exists(Function func |
       not exists(operand.getType()) and
-      func = operand.getUseInstruction().getEnclosingFunction() and
+      func = operand.getUse().getEnclosingFunction() and
       message = "Operand missing type in function '" + getIdentityString(func) + "'."
     )
   }
@@ -158,8 +158,8 @@ module InstructionSanity {
    * a different function.
    */
   query predicate operandAcrossFunctions(Operand operand, Instruction instr, Instruction defInstr) {
-    operand.getUseInstruction() = instr and
-    operand.getDefinitionInstruction() = defInstr and
+    operand.getUse() = instr and
+    operand.getAnyDef() = defInstr and
     instr.getEnclosingIRFunction() != defInstr.getEnclosingIRFunction()
   }
 
@@ -483,14 +483,14 @@ class Instruction extends Construction::TInstruction {
    * Gets all direct uses of the result of this instruction.
    */
   final Operand getAUse() {
-    result.getDefinitionInstruction() = this
+    result.getAnyDef() = this
   }
 
   /**
    * Gets all of this instruction's operands.
    */
   final Operand getAnOperand() {
-    result.getUseInstruction() = this
+    result.getUse() = this
   }
 
   /**
@@ -515,7 +515,7 @@ class Instruction extends Construction::TInstruction {
    */
   final AddressOperand getResultAddressOperand() {
     getResultMemoryAccess().usesAddressOperand() and
-    result.getUseInstruction() = this
+    result.getUse() = this
   }
 
   /**
@@ -698,7 +698,7 @@ class FieldAddressInstruction extends FieldInstruction {
   }
 
   final Instruction getObjectAddress() {
-    result = getObjectAddressOperand().getDefinitionInstruction()
+    result = getObjectAddressOperand().getAnyDef()
   }
 }
 
@@ -747,7 +747,7 @@ class ReturnValueInstruction extends ReturnInstruction {
   }
   
   final Instruction getReturnValue() {
-    result = getReturnValueOperand().getDefinitionInstruction()
+    result = getReturnValueOperand().getAnyDef()
   }
 }
 
@@ -761,7 +761,7 @@ class CopyInstruction extends Instruction {
   }
 
   final Instruction getSourceValue() {
-    result = getSourceValueOperand().getDefinitionInstruction()
+    result = getSourceValueOperand().getAnyDef()
   }
 }
 
@@ -785,7 +785,7 @@ class LoadInstruction extends CopyInstruction {
   }
   
   final Instruction getSourceAddress() {
-    result = getSourceAddressOperand().getDefinitionInstruction()
+    result = getSourceAddressOperand().getAnyDef()
   }
 
   override final LoadOperand getSourceValueOperand() {
@@ -807,7 +807,7 @@ class StoreInstruction extends CopyInstruction {
   }
   
   final Instruction getDestinationAddress() {
-    result = getDestinationAddressOperand().getDefinitionInstruction()
+    result = getDestinationAddressOperand().getAnyDef()
   }
 
   override final StoreValueOperand getSourceValueOperand() {
@@ -825,7 +825,7 @@ class ConditionalBranchInstruction extends Instruction {
   }
 
   final Instruction getCondition() {
-    result = getConditionOperand().getDefinitionInstruction()
+    result = getConditionOperand().getAnyDef()
   }
 
   final Instruction getTrueSuccessor() {
@@ -891,11 +891,11 @@ class BinaryInstruction extends Instruction {
   }
 
   final Instruction getLeft() {
-    result = getLeftOperand().getDefinitionInstruction()
+    result = getLeftOperand().getAnyDef()
   }
 
   final Instruction getRight() {
-    result = getRightOperand().getDefinitionInstruction()
+    result = getRightOperand().getAnyDef()
   }
   
   /**
@@ -1045,7 +1045,7 @@ class UnaryInstruction extends Instruction {
   }
   
   final Instruction getUnary() {
-    result = getUnaryOperand().getDefinitionInstruction()
+    result = getUnaryOperand().getAnyDef()
   }
 }
 
@@ -1275,7 +1275,7 @@ class SwitchInstruction extends Instruction {
   }
 
   final Instruction getExpression() {
-    result = getExpressionOperand().getDefinitionInstruction()
+    result = getExpressionOperand().getAnyDef()
   }
 
   final Instruction getACaseSuccessor() {
@@ -1310,7 +1310,7 @@ class CallInstruction extends Instruction {
    * function pointer.
    */
   final Instruction getCallTarget() {
-    result = getCallTargetOperand().getDefinitionInstruction()
+    result = getCallTargetOperand().getAnyDef()
   }
 
   /**
@@ -1331,7 +1331,7 @@ class CallInstruction extends Instruction {
    * Gets all of the arguments of the call, including the `this` pointer, if any.
    */
   final Instruction getAnArgument() {
-    result = getAnArgumentOperand().getDefinitionInstruction()
+    result = getAnArgumentOperand().getAnyDef()
   }
 
   /**
@@ -1345,7 +1345,7 @@ class CallInstruction extends Instruction {
    * Gets the `this` pointer argument of the call, if any.
    */
   final Instruction getThisArgument() {
-    result = getThisArgumentOperand().getDefinitionInstruction()
+    result = getThisArgumentOperand().getAnyDef()
   }
 
   /**
@@ -1360,7 +1360,7 @@ class CallInstruction extends Instruction {
    * Gets the argument at the specified index.
    */
   final Instruction getPositionalArgument(int index) {
-    result = getPositionalArgumentOperand(index).getDefinitionInstruction()
+    result = getPositionalArgumentOperand(index).getAnyDef()
   }
 }
 
@@ -1516,7 +1516,7 @@ class ThrowValueInstruction extends ThrowInstruction {
    * Gets the address of the exception thrown by this instruction.
    */
   final Instruction getExceptionAddress() {
-    result = getExceptionAddressOperand().getDefinitionInstruction()
+    result = getExceptionAddressOperand().getAnyDef()
   }
 
   /**
@@ -1530,7 +1530,7 @@ class ThrowValueInstruction extends ThrowInstruction {
    * Gets the exception thrown by this instruction.
    */
   final Instruction getException() {
-    result = getExceptionOperand().getDefinitionInstruction()
+    result = getExceptionOperand().getAnyDef()
   }
 }
 
@@ -1660,7 +1660,7 @@ class PhiInstruction extends Instruction {
    */
   pragma[noinline]
   final Instruction getAnInput() {
-    result = this.getAnInputOperand().getDefinitionInstruction()
+    result = this.getAnInputOperand().getAnyDef()
   }
 }
 
@@ -1728,7 +1728,7 @@ class ChiInstruction extends Instruction {
    * memory write.
    */
   final Instruction getTotal() {
-    result = getTotalOperand().getDefinitionInstruction()
+    result = getTotalOperand().getAnyDef()
   }
 
   /**
@@ -1742,7 +1742,7 @@ class ChiInstruction extends Instruction {
    * Gets the operand that represents the new value written by the memory write.
    */
   final Instruction getPartial() {
-    result = getPartialOperand().getDefinitionInstruction()
+    result = getPartialOperand().getAnyDef()
   }
 }
 

--- a/cpp/ql/src/semmle/code/cpp/ir/implementation/unaliased_ssa/Operand.qll
+++ b/cpp/ql/src/semmle/code/cpp/ir/implementation/unaliased_ssa/Operand.qll
@@ -26,24 +26,24 @@ class Operand extends TOperand {
   }
 
   final Location getLocation() {
-    result = getUseInstruction().getLocation()
+    result = getUse().getLocation()
   }
 
   final IRFunction getEnclosingIRFunction() {
-    result = getUseInstruction().getEnclosingIRFunction()
+    result = getUse().getEnclosingIRFunction()
   }
   
   /**
    * Gets the `Instruction` that consumes this operand.
    */
-  Instruction getUseInstruction() {
+  Instruction getUse() {
     none()
   }
 
   /**
    * Gets the `Instruction` whose result is the value of the operand.
    */
-  Instruction getDefinitionInstruction() {
+  Instruction getAnyDef() {
     none()
   }
 
@@ -76,7 +76,7 @@ class Operand extends TOperand {
    * For example: `this:r3_5`
    */
   final string getDumpString() {
-    result = getDumpLabel() + getInexactSpecifier() + getDefinitionInstruction().getResultId()
+    result = getDumpLabel() + getInexactSpecifier() + getAnyDef().getResultId()
   }
 
   /**
@@ -106,7 +106,7 @@ class Operand extends TOperand {
    * has been cast to a different type.
    */
   Type getType() {
-    result = getDefinitionInstruction().getResultType()
+    result = getAnyDef().getResultType()
   }
 
   /**
@@ -117,7 +117,7 @@ class Operand extends TOperand {
    * given by `getResultType()`.
    */
   predicate isGLValue() {
-    getDefinitionInstruction().isGLValue()
+    getAnyDef().isGLValue()
   }
 
   /**
@@ -157,7 +157,7 @@ class MemoryOperand extends Operand {
    */
   final AddressOperand getAddressOperand() {
     getMemoryAccess().usesAddressOperand() and
-    result.getUseInstruction() = getUseInstruction()
+    result.getUse() = getUse()
   }
 }
 
@@ -174,11 +174,11 @@ class NonPhiOperand extends Operand {
     this = TNonPhiMemoryOperand(useInstr, tag, defInstr, _)
   }
 
-  override final Instruction getUseInstruction() {
+  override final Instruction getUse() {
     result = useInstr
   }
 
-  override final Instruction getDefinitionInstruction() {
+  override final Instruction getAnyDef() {
     result = defInstr
   }
 
@@ -436,11 +436,11 @@ class PhiInputOperand extends MemoryOperand, TPhiOperand {
     result = "Phi"
   }
 
-  override final PhiInstruction getUseInstruction() {
+  override final PhiInstruction getUse() {
     result = useInstr
   }
 
-  override final Instruction getDefinitionInstruction() {
+  override final Instruction getAnyDef() {
     result = defInstr
   }
 

--- a/cpp/ql/src/semmle/code/cpp/ir/implementation/unaliased_ssa/Operand.qll
+++ b/cpp/ql/src/semmle/code/cpp/ir/implementation/unaliased_ssa/Operand.qll
@@ -32,7 +32,7 @@ class Operand extends TOperand {
   final IRFunction getEnclosingIRFunction() {
     result = getUse().getEnclosingIRFunction()
   }
-  
+
   /**
    * Gets the `Instruction` that consumes this operand.
    */
@@ -41,10 +41,46 @@ class Operand extends TOperand {
   }
 
   /**
-   * Gets the `Instruction` whose result is the value of the operand.
+   * Gets the `Instruction` whose result is the value of the operand. Unlike
+   * `getDef`, this also has a result when `isDefinitionInexact` holds, which
+   * means that the resulting instruction may only _partially_ or _potentially_
+   * be the value of this operand.
    */
   Instruction getAnyDef() {
     none()
+  }
+
+  /**
+   * Gets the `Instruction` whose result is the value of the operand. Unlike
+   * `getAnyDef`, this also has no result when `isDefinitionInexact` holds,
+   * which means that the resulting instruction must always be exactly the be
+   * the value of this operand.
+   */
+  final Instruction getDef() {
+    result = this.getAnyDef() and
+    getDefinitionOverlap() instanceof MustExactlyOverlap
+  }
+
+  /**
+   * DEPRECATED: renamed to `getUse`.
+   *
+   * Gets the `Instruction` that consumes this operand.
+   */
+  deprecated
+  final Instruction getUseInstruction() {
+    result = getUse()
+  }
+
+  /**
+   * DEPRECATED: use `getAnyDef` or `getDef`. The exact replacement for this
+   * predicate is `getAnyDef`, but most uses of this predicate should probably
+   * be replaced with `getDef`.
+   *
+   * Gets the `Instruction` whose result is the value of the operand.
+   */
+  deprecated
+  final Instruction getDefinitionInstruction() {
+    result = getAnyDef()
   }
 
   /**

--- a/cpp/ql/src/semmle/code/cpp/ir/implementation/unaliased_ssa/constant/ConstantAnalysis.qll
+++ b/cpp/ql/src/semmle/code/cpp/ir/implementation/unaliased_ssa/constant/ConstantAnalysis.qll
@@ -10,16 +10,8 @@ int getConstantValue(Instruction instr) {
   result = getConstantValue(instr.(CopyInstruction).getSourceValue()) or
   exists(PhiInstruction phi |
     phi = instr and
-    result = max(Instruction def | def = phi.getAnInput() | getConstantValueToPhi(def)) and
-    result = min(Instruction def | def = phi.getAnInput() | getConstantValueToPhi(def))
-  )
-}
-
-pragma[noinline]
-int getConstantValueToPhi(Instruction def) {
-  exists(PhiInstruction phi |
-    result = getConstantValue(def) and
-    def = phi.getAnInput()
+    result = max(Operand op | op = phi.getAnInputOperand() | getConstantValue(op.getDef())) and
+    result = min(Operand op | op = phi.getAnInputOperand() | getConstantValue(op.getDef()))
   )
 }
 

--- a/cpp/ql/src/semmle/code/cpp/ir/implementation/unaliased_ssa/gvn/ValueNumbering.qll
+++ b/cpp/ql/src/semmle/code/cpp/ir/implementation/unaliased_ssa/gvn/ValueNumbering.qll
@@ -88,7 +88,7 @@ class ValueNumber extends TValueNumber {
   }
   
   final Operand getAUse() {
-    this = valueNumber(result.getDefinitionInstruction())
+    this = valueNumber(result.getAnyDef())
   }
 }
 
@@ -230,7 +230,7 @@ cached ValueNumber valueNumber(Instruction instr) {
  * Gets the value number assigned to `instr`, if any. Returns at most one result.
  */
 ValueNumber valueNumberOfOperand(Operand op) {
-  result = valueNumber(op.getDefinitionInstruction())
+  result = valueNumber(op.getAnyDef())
 }
 
 /**

--- a/cpp/ql/src/semmle/code/cpp/ir/implementation/unaliased_ssa/gvn/ValueNumbering.qll
+++ b/cpp/ql/src/semmle/code/cpp/ir/implementation/unaliased_ssa/gvn/ValueNumbering.qll
@@ -86,9 +86,12 @@ class ValueNumber extends TValueNumber {
       instr order by instr.getBlock().getDisplayIndex(), instr.getDisplayIndexInBlock()
     )
   }
-  
+
+  /**
+   * Gets an `Operand` whose definition is exact and has this value number.
+   */
   final Operand getAUse() {
-    this = valueNumber(result.getAnyDef())
+    this = valueNumber(result.getDef())
   }
 }
 
@@ -227,10 +230,11 @@ cached ValueNumber valueNumber(Instruction instr) {
 }
 
 /**
- * Gets the value number assigned to `instr`, if any. Returns at most one result.
+ * Gets the value number assigned to the exact definition of `op`, if any.
+ * Returns at most one result.
  */
 ValueNumber valueNumberOfOperand(Operand op) {
-  result = valueNumber(op.getAnyDef())
+  result = valueNumber(op.getDef())
 }
 
 /**

--- a/cpp/ql/src/semmle/code/cpp/ir/implementation/unaliased_ssa/internal/SSAConstruction.qll
+++ b/cpp/ql/src/semmle/code/cpp/ir/implementation/unaliased_ssa/internal/SSAConstruction.qll
@@ -69,7 +69,7 @@ cached private module Cached {
       oldInstruction = getOldInstruction(instruction) and
       oldOperand = oldInstruction.getAnOperand() and
       tag = oldOperand.getOperandTag() and
-      result = getNewInstruction(oldOperand.getDefinitionInstruction())
+      result = getNewInstruction(oldOperand.getAnyDef())
     )
   }
 
@@ -101,7 +101,7 @@ cached private module Cached {
         exists(OldInstruction oldDefinition |
           instruction instanceof UnmodeledUseInstruction and
           tag instanceof UnmodeledUseOperandTag and
-          oldDefinition = oldOperand.getDefinitionInstruction() and
+          oldDefinition = oldOperand.getAnyDef() and
           not exists(Alias::getResultMemoryLocation(oldDefinition)) and
           result = getNewInstruction(oldDefinition) and
           overlap instanceof MustTotallyOverlap

--- a/cpp/ql/src/semmle/code/cpp/ir/implementation/unaliased_ssa/internal/SimpleSSA.qll
+++ b/cpp/ql/src/semmle/code/cpp/ir/implementation/unaliased_ssa/internal/SimpleSSA.qll
@@ -8,12 +8,12 @@ private import semmle.code.cpp.ir.internal.Overlap
 private class IntValue = Ints::IntValue;
 
 private predicate hasResultMemoryAccess(Instruction instr, IRVariable var, Type type, IntValue bitOffset) {
-  resultPointsTo(instr.getResultAddressOperand().getDefinitionInstruction(), var, bitOffset) and
+  resultPointsTo(instr.getResultAddressOperand().getAnyDef(), var, bitOffset) and
   type = instr.getResultType()
 }
 
 private predicate hasOperandMemoryAccess(MemoryOperand operand, IRVariable var, Type type, IntValue bitOffset) {
-  resultPointsTo(operand.getAddressOperand().getDefinitionInstruction(), var, bitOffset) and
+  resultPointsTo(operand.getAddressOperand().getAnyDef(), var, bitOffset) and
   type = operand.getType()
 }
 

--- a/cpp/ql/src/semmle/code/cpp/rangeanalysis/RangeAnalysis.qll
+++ b/cpp/ql/src/semmle/code/cpp/rangeanalysis/RangeAnalysis.qll
@@ -353,7 +353,7 @@ private predicate boundedNonPhiOperand(NonPhiOperand op, Bound b, int delta, boo
     delta = d1 + d2
   )
   or
-  boundedInstruction(op.getAnyDef(), b, delta, upper, fromBackEdge, origdelta, reason)
+  boundedInstruction(op.getDef(), b, delta, upper, fromBackEdge, origdelta, reason)
   or
   exists(int d, Reason r1, Reason r2 |
     boundedNonPhiOperand(op, b, d, upper, fromBackEdge, origdelta, r2)
@@ -379,7 +379,7 @@ private predicate boundedNonPhiOperand(NonPhiOperand op, Bound b, int delta, boo
 private predicate boundFlowStepPhi(
   PhiInputOperand op2, Operand op1, int delta, boolean upper, Reason reason
 ) {
-  op2.getAnyDef().(CopyInstruction).getSourceValueOperand() = op1 and
+  op2.getDef().(CopyInstruction).getSourceValueOperand() = op1 and
   (upper = true or upper = false) and
   reason = TNoReason() and
   delta = 0
@@ -403,10 +403,10 @@ private predicate boundedPhiOperand(
     (if r1 instanceof NoReason then reason = r2 else reason = r1)
   )
   or
-  boundedInstruction(op.getAnyDef(), b, delta, upper, fromBackEdge, origdelta, reason)
+  boundedInstruction(op.getDef(), b, delta, upper, fromBackEdge, origdelta, reason)
   or
   exists(int d, Reason r1, Reason r2 |
-    boundedInstruction(op.getAnyDef(), b, d, upper, fromBackEdge, origdelta, r2)
+    boundedInstruction(op.getDef(), b, d, upper, fromBackEdge, origdelta, r2)
   |
     unequalOperand(op, b, d, r1) and
     (
@@ -476,7 +476,7 @@ private predicate boundedPhiInp(
   exists(int d, boolean fromBackEdge0 |
     boundedPhiOperand(op, b, d, upper, fromBackEdge0, origdelta, reason)
     or
-    b.(ValueNumberBound).getInstruction() = op.getAnyDef() and
+    b.(ValueNumberBound).getInstruction() = op.getDef() and
     d = 0 and
     (upper = true or upper = false) and
     fromBackEdge0 = false and

--- a/cpp/ql/src/semmle/code/cpp/rangeanalysis/RangeAnalysis.qll
+++ b/cpp/ql/src/semmle/code/cpp/rangeanalysis/RangeAnalysis.qll
@@ -144,7 +144,7 @@ private predicate boundFlowStepSsa(
 ) {
   exists(IRGuardCondition guard, boolean testIsTrue |
     guard = boundFlowCond(valueNumberOfOperand(op2), op1, delta, upper, testIsTrue) and
-    guard.controls(op2.getUseInstruction().getBlock(), testIsTrue) and
+    guard.controls(op2.getUse().getBlock(), testIsTrue) and
     reason = TCondReason(guard)
   )
 }
@@ -269,8 +269,8 @@ private predicate boundFlowStep(Instruction i, NonPhiOperand op, int delta, bool
     i.(AddInstruction).getAnOperand() = x and
     op != x
     |
-    not exists(getValue(getConstantValue(op.getUseInstruction()))) and
-    not exists(getValue(getConstantValue(x.getUseInstruction()))) and
+    not exists(getValue(getConstantValue(op.getUse()))) and
+    not exists(getValue(getConstantValue(x.getUse()))) and
     if(strictlyPositive(x))
     then (
       upper = false and delta = 1
@@ -293,7 +293,7 @@ private predicate boundFlowStep(Instruction i, NonPhiOperand op, int delta, bool
     )
   |
     // `x` with constant value is covered by valueFlowStep
-    not exists(getValue(getConstantValue(x.getUseInstruction()))) and
+    not exists(getValue(getConstantValue(x.getUse()))) and
     if strictlyPositive(x)
     then (
       upper = true and delta = -1
@@ -353,7 +353,7 @@ private predicate boundedNonPhiOperand(NonPhiOperand op, Bound b, int delta, boo
     delta = d1 + d2
   )
   or
-  boundedInstruction(op.getDefinitionInstruction(), b, delta, upper, fromBackEdge, origdelta, reason)
+  boundedInstruction(op.getAnyDef(), b, delta, upper, fromBackEdge, origdelta, reason)
   or
   exists(int d, Reason r1, Reason r2 |
     boundedNonPhiOperand(op, b, d, upper, fromBackEdge, origdelta, r2)
@@ -379,14 +379,14 @@ private predicate boundedNonPhiOperand(NonPhiOperand op, Bound b, int delta, boo
 private predicate boundFlowStepPhi(
   PhiInputOperand op2, Operand op1, int delta, boolean upper, Reason reason
 ) {
-  op2.getDefinitionInstruction().(CopyInstruction).getSourceValueOperand() = op1 and
+  op2.getAnyDef().(CopyInstruction).getSourceValueOperand() = op1 and
   (upper = true or upper = false) and
   reason = TNoReason() and
   delta = 0
   or
   exists(IRGuardCondition guard, boolean testIsTrue |
     guard = boundFlowCond(valueNumberOfOperand(op2), op1, delta, upper, testIsTrue) and
-    guard.controlsEdge(op2.getPredecessorBlock(), op2.getUseInstruction().getBlock(), testIsTrue) and
+    guard.controlsEdge(op2.getPredecessorBlock(), op2.getUse().getBlock(), testIsTrue) and
     reason = TCondReason(guard)
   )
 }
@@ -403,10 +403,10 @@ private predicate boundedPhiOperand(
     (if r1 instanceof NoReason then reason = r2 else reason = r1)
   )
   or
-  boundedInstruction(op.getDefinitionInstruction(), b, delta, upper, fromBackEdge, origdelta, reason)
+  boundedInstruction(op.getAnyDef(), b, delta, upper, fromBackEdge, origdelta, reason)
   or
   exists(int d, Reason r1, Reason r2 |
-    boundedInstruction(op.getDefinitionInstruction(), b, d, upper, fromBackEdge, origdelta, r2)
+    boundedInstruction(op.getAnyDef(), b, d, upper, fromBackEdge, origdelta, r2)
   |
     unequalOperand(op, b, d, r1) and
     (
@@ -427,7 +427,7 @@ private predicate unequalFlowStep(
 ) {
   exists(IRGuardCondition guard, boolean testIsTrue |
     guard = eqFlowCond(valueNumberOfOperand(op2), op1, delta, false, testIsTrue) and
-    guard.controls(op2.getUseInstruction().getBlock(), testIsTrue) and
+    guard.controls(op2.getUse().getBlock(), testIsTrue) and
     reason = TCondReason(guard)
   )
 }
@@ -476,7 +476,7 @@ private predicate boundedPhiInp(
   exists(int d, boolean fromBackEdge0 |
     boundedPhiOperand(op, b, d, upper, fromBackEdge0, origdelta, reason)
     or
-    b.(ValueNumberBound).getInstruction() = op.getDefinitionInstruction() and
+    b.(ValueNumberBound).getInstruction() = op.getAnyDef() and
     d = 0 and
     (upper = true or upper = false) and
     fromBackEdge0 = false and

--- a/cpp/ql/src/semmle/code/cpp/rangeanalysis/RangeUtils.qll
+++ b/cpp/ql/src/semmle/code/cpp/rangeanalysis/RangeUtils.qll
@@ -22,8 +22,8 @@ IntValue getConstantValue(Instruction instr) {
   result = getConstantValue(instr.(CopyInstruction).getSourceValue()) or
   exists(PhiInstruction phi |
     phi = instr and
-    result = max(PhiInputOperand operand | operand = phi.getAnOperand() | getConstantValue(operand.getAnyDef())) and
-    result = min(PhiInputOperand operand | operand = phi.getAnOperand() | getConstantValue(operand.getAnyDef()))
+    result = max(PhiInputOperand operand | operand = phi.getAnOperand() | getConstantValue(operand.getDef())) and
+    result = min(PhiInputOperand operand | operand = phi.getAnOperand() | getConstantValue(operand.getDef()))
   )
 }
 
@@ -35,7 +35,7 @@ predicate valueFlowStep(Instruction i, Operand op, int delta) {
     i.(AddInstruction).getAnOperand() = x and
     op  != x
     |
-    delta = getValue(getConstantValue(x.getAnyDef()))
+    delta = getValue(getConstantValue(x.getDef()))
   )
   or
   exists(Operand x |

--- a/cpp/ql/src/semmle/code/cpp/rangeanalysis/RangeUtils.qll
+++ b/cpp/ql/src/semmle/code/cpp/rangeanalysis/RangeUtils.qll
@@ -42,7 +42,7 @@ predicate valueFlowStep(Instruction i, Operand op, int delta) {
     i.(SubInstruction).getLeftOperand() = op and
     i.(SubInstruction).getRightOperand() = x
     |
-    delta = -getValue(getConstantValue(x.getAnyDef()))
+    delta = -getValue(getConstantValue(x.getDef()))
   )
   or
   exists(Operand x |
@@ -51,7 +51,7 @@ predicate valueFlowStep(Instruction i, Operand op, int delta) {
     op  != x
     |
     delta = i.(PointerAddInstruction).getElementSize() *
-      getValue(getConstantValue(x.getAnyDef()))
+      getValue(getConstantValue(x.getDef()))
   )
   or
   exists(Operand x |
@@ -59,7 +59,7 @@ predicate valueFlowStep(Instruction i, Operand op, int delta) {
     i.(PointerSubInstruction).getRightOperand() = x
     |
     delta = i.(PointerSubInstruction).getElementSize() * 
-      -getValue(getConstantValue(x.getAnyDef()))
+      -getValue(getConstantValue(x.getDef()))
   )
 }
 

--- a/cpp/ql/src/semmle/code/cpp/rangeanalysis/RangeUtils.qll
+++ b/cpp/ql/src/semmle/code/cpp/rangeanalysis/RangeUtils.qll
@@ -22,8 +22,8 @@ IntValue getConstantValue(Instruction instr) {
   result = getConstantValue(instr.(CopyInstruction).getSourceValue()) or
   exists(PhiInstruction phi |
     phi = instr and
-    result = max(PhiInputOperand operand | operand = phi.getAnOperand() | getConstantValue(operand.getDefinitionInstruction())) and
-    result = min(PhiInputOperand operand | operand = phi.getAnOperand() | getConstantValue(operand.getDefinitionInstruction()))
+    result = max(PhiInputOperand operand | operand = phi.getAnOperand() | getConstantValue(operand.getAnyDef())) and
+    result = min(PhiInputOperand operand | operand = phi.getAnOperand() | getConstantValue(operand.getAnyDef()))
   )
 }
 
@@ -35,14 +35,14 @@ predicate valueFlowStep(Instruction i, Operand op, int delta) {
     i.(AddInstruction).getAnOperand() = x and
     op  != x
     |
-    delta = getValue(getConstantValue(x.getDefinitionInstruction()))
+    delta = getValue(getConstantValue(x.getAnyDef()))
   )
   or
   exists(Operand x |
     i.(SubInstruction).getLeftOperand() = op and
     i.(SubInstruction).getRightOperand() = x
     |
-    delta = -getValue(getConstantValue(x.getDefinitionInstruction()))
+    delta = -getValue(getConstantValue(x.getAnyDef()))
   )
   or
   exists(Operand x |
@@ -51,7 +51,7 @@ predicate valueFlowStep(Instruction i, Operand op, int delta) {
     op  != x
     |
     delta = i.(PointerAddInstruction).getElementSize() *
-      getValue(getConstantValue(x.getDefinitionInstruction()))
+      getValue(getConstantValue(x.getAnyDef()))
   )
   or
   exists(Operand x |
@@ -59,7 +59,7 @@ predicate valueFlowStep(Instruction i, Operand op, int delta) {
     i.(PointerSubInstruction).getRightOperand() = x
     |
     delta = i.(PointerSubInstruction).getElementSize() * 
-      -getValue(getConstantValue(x.getDefinitionInstruction()))
+      -getValue(getConstantValue(x.getAnyDef()))
   )
 }
 

--- a/cpp/ql/src/semmle/code/cpp/rangeanalysis/SignAnalysis.qll
+++ b/cpp/ql/src/semmle/code/cpp/rangeanalysis/SignAnalysis.qll
@@ -368,6 +368,9 @@ cached module SignAnalysisCached {
     or
     result = guardedOperandSign(operand) and
     result = guardedOperandSignOk(operand)
+    or
+    // `result` is unconstrained if the definition is inexact. Then any sign is possible.
+    operand.isDefinitionInexact()
   }
   
   cached

--- a/cpp/ql/src/semmle/code/cpp/rangeanalysis/SignAnalysis.qll
+++ b/cpp/ql/src/semmle/code/cpp/rangeanalysis/SignAnalysis.qll
@@ -331,12 +331,12 @@ private predicate binaryOpSigns(BinaryInstruction i, Sign lhs, Sign rhs) {
 }
 
 private Sign unguardedOperandSign(Operand operand) {
-  result = instructionSign(operand.getAnyDef()) and
+  result = instructionSign(operand.getDef()) and
   not hasGuard(operand, result)
 }
 
 private Sign guardedOperandSign(Operand operand) {
-  result = instructionSign(operand.getAnyDef()) and
+  result = instructionSign(operand.getDef()) and
   hasGuard(operand, result)
 }
 

--- a/cpp/ql/src/semmle/code/cpp/rangeanalysis/SignAnalysis.qll
+++ b/cpp/ql/src/semmle/code/cpp/rangeanalysis/SignAnalysis.qll
@@ -221,7 +221,7 @@ private predicate unknownSign(Instruction i) {
  */
 private predicate lowerBound(IRGuardCondition comp, Operand lowerbound, Operand bounded, boolean isStrict) {
   exists(int adjustment, Operand compared |
-    valueNumber(bounded.getDefinitionInstruction()) = valueNumber(compared.getDefinitionInstruction()) and
+    valueNumber(bounded.getAnyDef()) = valueNumber(compared.getAnyDef()) and
     (
       isStrict = true and
       adjustment = 0
@@ -229,7 +229,7 @@ private predicate lowerBound(IRGuardCondition comp, Operand lowerbound, Operand 
       isStrict = false and
       adjustment = 1
     )  and
-    comp.ensuresLt(lowerbound, compared, adjustment, bounded.getUseInstruction().getBlock(), true)
+    comp.ensuresLt(lowerbound, compared, adjustment, bounded.getUse().getBlock(), true)
   )
 }
 
@@ -240,7 +240,7 @@ private predicate lowerBound(IRGuardCondition comp, Operand lowerbound, Operand 
  */
 private predicate upperBound(IRGuardCondition comp, Operand upperbound, Operand bounded, boolean isStrict) {
   exists(int adjustment, Operand compared |
-    valueNumber(bounded.getDefinitionInstruction()) = valueNumber(compared.getDefinitionInstruction()) and
+    valueNumber(bounded.getAnyDef()) = valueNumber(compared.getAnyDef()) and
     (
       isStrict = true and
       adjustment = 0
@@ -248,7 +248,7 @@ private predicate upperBound(IRGuardCondition comp, Operand upperbound, Operand 
       isStrict = false and
       adjustment = 1
     ) and
-    comp.ensuresLt(compared, upperbound, adjustment, bounded.getUseInstruction().getBlock(), true)
+    comp.ensuresLt(compared, upperbound, adjustment, bounded.getUse().getBlock(), true)
   )
 }
 
@@ -261,8 +261,8 @@ private predicate upperBound(IRGuardCondition comp, Operand upperbound, Operand 
  */
 private predicate eqBound(IRGuardCondition guard, Operand eqbound, Operand bounded, boolean isEq) {
   exists(Operand compared |
-    valueNumber(bounded.getDefinitionInstruction()) = valueNumber(compared.getDefinitionInstruction()) and
-    guard.ensuresEq(compared, eqbound, 0, bounded.getUseInstruction().getBlock(), isEq)
+    valueNumber(bounded.getAnyDef()) = valueNumber(compared.getAnyDef()) and
+    guard.ensuresEq(compared, eqbound, 0, bounded.getUse().getBlock(), isEq)
   )
 }
 
@@ -331,12 +331,12 @@ private predicate binaryOpSigns(BinaryInstruction i, Sign lhs, Sign rhs) {
 }
 
 private Sign unguardedOperandSign(Operand operand) {
-  result = instructionSign(operand.getDefinitionInstruction()) and
+  result = instructionSign(operand.getAnyDef()) and
   not hasGuard(operand, result)
 }
 
 private Sign guardedOperandSign(Operand operand) {
-  result = instructionSign(operand.getDefinitionInstruction()) and
+  result = instructionSign(operand.getAnyDef()) and
   hasGuard(operand, result)
 }
 

--- a/cpp/ql/src/semmle/code/cpp/rangeanalysis/SignAnalysis.qll
+++ b/cpp/ql/src/semmle/code/cpp/rangeanalysis/SignAnalysis.qll
@@ -221,7 +221,7 @@ private predicate unknownSign(Instruction i) {
  */
 private predicate lowerBound(IRGuardCondition comp, Operand lowerbound, Operand bounded, boolean isStrict) {
   exists(int adjustment, Operand compared |
-    valueNumber(bounded.getAnyDef()) = valueNumber(compared.getAnyDef()) and
+    valueNumberOfOperand(bounded) = valueNumberOfOperand(compared) and
     (
       isStrict = true and
       adjustment = 0
@@ -240,7 +240,7 @@ private predicate lowerBound(IRGuardCondition comp, Operand lowerbound, Operand 
  */
 private predicate upperBound(IRGuardCondition comp, Operand upperbound, Operand bounded, boolean isStrict) {
   exists(int adjustment, Operand compared |
-    valueNumber(bounded.getAnyDef()) = valueNumber(compared.getAnyDef()) and
+    valueNumberOfOperand(bounded) = valueNumberOfOperand(compared) and
     (
       isStrict = true and
       adjustment = 0
@@ -261,7 +261,7 @@ private predicate upperBound(IRGuardCondition comp, Operand upperbound, Operand 
  */
 private predicate eqBound(IRGuardCondition guard, Operand eqbound, Operand bounded, boolean isEq) {
   exists(Operand compared |
-    valueNumber(bounded.getAnyDef()) = valueNumber(compared.getAnyDef()) and
+    valueNumberOfOperand(bounded) = valueNumberOfOperand(compared) and
     guard.ensuresEq(compared, eqbound, 0, bounded.getUse().getBlock(), isEq)
   )
 }

--- a/cpp/ql/test/library-tests/controlflow/guards-ir/tests.ql
+++ b/cpp/ql/test/library-tests/controlflow/guards-ir/tests.ql
@@ -65,7 +65,7 @@ query predicate irGuardsCompare(int startLine, string msg) {
       guard.comparesEq(left, right, k, false, sense)  and op = " != "
     )
     and startLine = guard.getLocation().getStartLine()
-    and msg = left.getDefinitionInstruction().getUnconvertedResultExpression() + op + right.getDefinitionInstruction().getUnconvertedResultExpression() + "+" + k + " when " + guard + " is " + which
+    and msg = left.getAnyDef().getUnconvertedResultExpression() + op + right.getAnyDef().getUnconvertedResultExpression() + "+" + k + " when " + guard + " is " + which
   )
 }
 query predicate irGuardsControl(IRGuardCondition guard, boolean sense, int start, int end) {

--- a/cpp/ql/test/library-tests/dataflow/dataflow-tests/test_diff.expected
+++ b/cpp/ql/test/library-tests/dataflow/dataflow-tests/test_diff.expected
@@ -1,8 +1,6 @@
 | test.cpp:89:28:89:34 | test.cpp:92:8:92:14 | IR only |
 | test.cpp:100:13:100:18 | test.cpp:103:10:103:12 | AST only |
 | test.cpp:109:9:109:14 | test.cpp:110:10:110:12 | IR only |
-| test.cpp:122:18:122:30 | test.cpp:132:22:132:23 | IR only |
-| test.cpp:122:18:122:30 | test.cpp:140:22:140:23 | IR only |
 | test.cpp:136:27:136:32 | test.cpp:137:27:137:28 | AST only |
 | test.cpp:136:27:136:32 | test.cpp:140:22:140:23 | AST only |
 | test.cpp:142:32:142:37 | test.cpp:145:10:145:11 | IR only |

--- a/cpp/ql/test/library-tests/dataflow/dataflow-tests/test_ir.expected
+++ b/cpp/ql/test/library-tests/dataflow/dataflow-tests/test_ir.expected
@@ -17,8 +17,6 @@
 | test.cpp:110:10:110:12 | Load: (reference dereference) | test.cpp:109:9:109:14 | Call: call to source |
 | test.cpp:126:8:126:19 | Convert: (const int *)... | test.cpp:120:9:120:20 | InitializeParameter: sourceArray1 |
 | test.cpp:126:8:126:19 | Load: sourceArray1 | test.cpp:120:9:120:20 | InitializeParameter: sourceArray1 |
-| test.cpp:132:22:132:23 | Load: m1 | test.cpp:122:18:122:30 | InitializeParameter: sourceStruct1 |
-| test.cpp:140:22:140:23 | Load: m1 | test.cpp:122:18:122:30 | InitializeParameter: sourceStruct1 |
 | test.cpp:145:10:145:11 | Load: m2 | test.cpp:142:32:142:37 | Call: call to source |
 | test.cpp:153:17:153:18 | Load: m2 | test.cpp:151:35:151:40 | Call: call to source |
 | test.cpp:188:8:188:8 | Load: y | test.cpp:186:27:186:32 | Call: call to source |


### PR DESCRIPTION
This is my attempt to implement the changes we [discussed on Slack](https://semmle.slack.com/archives/C7NS4H8HY/p1559242384011500), making the default memory operand getters have a result only for definitions that _must exactly overlap_. This is a breaking API change, but I think the new behaviour is what most users were expecting in the first place.

I'd like to hear @dave-bartolomeo's initial comments before I refine this further.

To do:
- Bikeshedding predicate names. I've chosen `getDef` and `getAnyDef` because they are short and because the shortest of the two is the one most people should be using.
- Documenting, and ideally also testing, what it means for a definition to be non-exact. We need some examples in the documentation of `getDef` and `getAnyDef`.
- Considering whether some `getAnyDef` should become `getDef` in the SSA construction code.
- Benchmarking.
- Writing a change note.