### PR TITLE
JavaScript: Fix data flow out of reflective calls.

### DIFF
--- a/javascript/ql/src/semmle/javascript/dataflow/DataFlow.qll
+++ b/javascript/ql/src/semmle/javascript/dataflow/DataFlow.qll
@@ -1163,6 +1163,9 @@ module DataFlow {
       pred = TThisNode(thiz.getBindingContainer()) and
       succ = valueNode(thiz)
     )
+    or
+    // `f.call(...)` and `f.apply(...)` evaluate to the result of the reflective call they perform
+    pred = TReflectiveCallNode(succ.asExpr(), _)
   }
 
   /**

--- a/javascript/ql/test/library-tests/DataFlow/flowStep.expected
+++ b/javascript/ql/test/library-tests/DataFlow/flowStep.expected
@@ -140,6 +140,7 @@
 | tst.js:111:23:111:25 | v2c | tst.js:111:6:111:38 | v2c |
 | tst.js:111:29:111:31 | o2c | tst.js:111:6:111:38 | v2c |
 | tst.js:111:36:111:38 | o2d | tst.js:111:6:111:32 | [v2a, v ...  = o2c] |
+| tst.js:115:1:115:12 | reflective call | tst.js:115:1:115:12 | Array.call() |
 | tst.ts:1:1:1:1 | A | tst.ts:1:11:1:11 | A |
 | tst.ts:1:1:1:1 | A | tst.ts:7:1:7:0 | A |
 | tst.ts:1:1:5:1 | A | tst.ts:7:1:7:0 | A |

--- a/javascript/ql/test/library-tests/DataFlow/incomplete.expected
+++ b/javascript/ql/test/library-tests/DataFlow/incomplete.expected
@@ -82,6 +82,11 @@
 | tst.js:111:23:111:25 | v2c | heap |
 | tst.js:111:29:111:31 | o2c | global |
 | tst.js:111:36:111:38 | o2d | global |
+| tst.js:115:1:115:5 | Array | global |
+| tst.js:115:1:115:10 | Array.call | global |
+| tst.js:115:1:115:10 | Array.call | heap |
+| tst.js:115:1:115:12 | Array.call() | call |
+| tst.js:115:1:115:12 | exceptional return of Array.call() | call |
 | tst.ts:2:14:2:19 | x | namespace |
 | tst.ts:3:3:3:8 | exceptional return of setX() | call |
 | tst.ts:3:3:3:8 | setX() | call |

--- a/javascript/ql/test/library-tests/DataFlow/sources.expected
+++ b/javascript/ql/test/library-tests/DataFlow/sources.expected
@@ -85,6 +85,10 @@
 | tst.js:111:23:111:25 | v2c |
 | tst.js:111:29:111:31 | o2c |
 | tst.js:111:36:111:38 | o2d |
+| tst.js:115:1:115:5 | Array |
+| tst.js:115:1:115:10 | Array.call |
+| tst.js:115:1:115:12 | Array.call() |
+| tst.js:115:1:115:12 | reflective call |
 | tst.ts:1:1:1:0 | this |
 | tst.ts:3:3:3:8 | setX() |
 | tst.ts:7:1:7:0 | this |

--- a/javascript/ql/test/library-tests/DataFlow/tst.js
+++ b/javascript/ql/test/library-tests/DataFlow/tst.js
@@ -111,4 +111,7 @@ x ?? y;                           // flow through short-circuiting operator
 	var [v2a, v2b = o2b, v2c = o2c] = o2d;
 	v2a + v2b + v2c;
 });
+
+Array.call()  // flow from implicit call to `Array` to `Array.call`
+
 // semmle-extractor-options: --experimental

--- a/javascript/ql/test/library-tests/InterProceduralFlow/DataFlow.expected
+++ b/javascript/ql/test/library-tests/InterProceduralFlow/DataFlow.expected
@@ -39,6 +39,7 @@
 | tst2.js:6:24:6:37 | "also tainted" | tst2.js:10:15:10:24 | g(source1) |
 | tst2.js:6:24:6:37 | "also tainted" | tst2.js:11:15:11:24 | g(source2) |
 | tst6.mjs:12:14:12:21 | "source" | tst6.mjs:14:12:14:16 | a.m() |
+| tst6.mjs:16:15:16:23 | "source2" | tst6.mjs:18:13:18:24 | a.m.call(a2) |
 | tst.js:2:17:2:22 | "src1" | tst.js:39:17:39:17 | x |
 | tst.js:2:17:2:22 | "src1" | tst.js:41:19:41:19 | x |
 | tst.js:2:17:2:22 | "src1" | tst.js:45:17:45:17 | x |

--- a/javascript/ql/test/library-tests/InterProceduralFlow/GermanFlow.expected
+++ b/javascript/ql/test/library-tests/InterProceduralFlow/GermanFlow.expected
@@ -40,6 +40,7 @@
 | tst2.js:6:24:6:37 | "also tainted" | tst2.js:10:15:10:24 | g(source1) |
 | tst2.js:6:24:6:37 | "also tainted" | tst2.js:11:15:11:24 | g(source2) |
 | tst6.mjs:12:14:12:21 | "source" | tst6.mjs:14:12:14:16 | a.m() |
+| tst6.mjs:16:15:16:23 | "source2" | tst6.mjs:18:13:18:24 | a.m.call(a2) |
 | tst.js:2:17:2:22 | "src1" | tst.js:39:17:39:17 | x |
 | tst.js:2:17:2:22 | "src1" | tst.js:41:19:41:19 | x |
 | tst.js:2:17:2:22 | "src1" | tst.js:45:17:45:17 | x |

--- a/javascript/ql/test/library-tests/InterProceduralFlow/TaintTracking.expected
+++ b/javascript/ql/test/library-tests/InterProceduralFlow/TaintTracking.expected
@@ -49,6 +49,7 @@
 | tst4.js:2:16:2:24 | "tainted" | tst4.js:16:15:16:28 | p.also_tainted |
 | tst4.js:2:16:2:24 | "tainted" | tst4.js:17:15:17:28 | substr(source) |
 | tst6.mjs:12:14:12:21 | "source" | tst6.mjs:14:12:14:16 | a.m() |
+| tst6.mjs:16:15:16:23 | "source2" | tst6.mjs:18:13:18:24 | a.m.call(a2) |
 | tst.js:2:17:2:22 | "src1" | tst.js:3:15:3:29 | String(source1) |
 | tst.js:2:17:2:22 | "src1" | tst.js:4:15:4:29 | RegExp(source1) |
 | tst.js:2:17:2:22 | "src1" | tst.js:5:15:5:33 | new String(source1) |

--- a/javascript/ql/test/library-tests/InterProceduralFlow/tst6.mjs
+++ b/javascript/ql/test/library-tests/InterProceduralFlow/tst6.mjs
@@ -12,3 +12,7 @@ class A {
 var source = "source";
 var a = new A(source);
 var sink = a.m();
+
+var source2 = "source2";
+var a2 = new A(source2);
+var sink2 = a.m.call(a2);


### PR DESCRIPTION
If you look closely at the last commit of https://github.com/Semmle/ql/pull/1529, you'll notice that it doesn't contain a test case. That's no oversight: I tried adding one, only to realise that I couldn't because we were missing data-flow edges from reflected calls to the corresponding reflective call. That is, for `f.call(...)` we didn't have a flow edge from the result of the implicit call to `f` to the result of `f.call(...)`.

This PR fixes that, fortunately at [no performance cost](https://git.semmle.com/max/dist-compare-reports/blob/master/js/reflective-call-flow/report.md) (internal link).