### PR TITLE
CPP: Speed up LeapYear.qll 'ChecksForLeapYearFunctionCall'.

### DIFF
--- a/cpp/ql/src/Likely Bugs/Leap Year/LeapYear.qll
+++ b/cpp/ql/src/Likely Bugs/Leap Year/LeapYear.qll
@@ -195,13 +195,20 @@ class StructTmLeapYearFieldAccess extends LeapYearFieldAccess {
 }
 
 /**
+ * `Function` that includes an operation that is checking for leap year.
+ */
+class ChecksForLeapYearFunction extends Function {
+  ChecksForLeapYearFunction() {
+    this = any(CheckForLeapYearOperation clyo).getEnclosingFunction()
+  }
+}
+
+/**
  * `FunctionCall` that includes an operation that is checking for leap year.
  */
 class ChecksForLeapYearFunctionCall extends FunctionCall {
   ChecksForLeapYearFunctionCall() {
-    exists(Function f, CheckForLeapYearOperation clyo | f.getACallToThisFunction() = this |
-      clyo.getEnclosingFunction() = f
-    )
+    this.getTarget() instanceof ChecksForLeapYearFunction
   }
 }
 


### PR DESCRIPTION
This removes the top cost from runs of 'Adding365DaysPerYear.ql' on large projects:
```
	Adding365DaysPerYear.ql-17:DataFlowImpl::Configuration::isSink_dispred#ff ....................................... 25.5s
```
Sadly this is quite a small effect as a proportion of the overall query run time (about 7% on Qt and 11% on Wireshark).  The rest of the time is made up of a wide variety of predicates, including many of the usual suspects (dominance, expr `toString`, `ConstantExpr` reachability, `exprEnclosingElement`) some of which will hopefully be cached.