### PR TITLE
C++ IR: Support __builtin_addressof

### DIFF
--- a/cpp/ql/src/semmle/code/cpp/ir/implementation/raw/internal/TranslatedExpr.qll
+++ b/cpp/ql/src/semmle/code/cpp/ir/implementation/raw/internal/TranslatedExpr.qll
@@ -727,7 +727,8 @@ class TranslatedTransparentUnaryOperation extends TranslatedTransparentExpr {
       expr instanceof PointerDereferenceExpr or
       // &x is the same as x. &x isn't loadable, but is included
       // here to avoid having two nearly identical classes.
-      expr instanceof AddressOfExpr
+      expr instanceof AddressOfExpr or
+      expr instanceof BuiltInOperationBuiltInAddressOf
     )
   }
 

--- a/cpp/ql/test/library-tests/ir/ir/PrintAST.expected
+++ b/cpp/ql/test/library-tests/ir/ir/PrintAST.expected
@@ -174,6 +174,17 @@ bad_asts.cpp:
 #   27|                   Type = const Point &
 #   27|                   ValueCategory = prvalue(load)
 #   28|     1: return ...
+clang.cpp:
+#    5| int* globalIntAddress()
+#    5|   params: 
+#    5|   body: { ... }
+#    6|     0: return ...
+#    6|       0: __builtin_addressof ...
+#    6|           Type = int *
+#    6|           ValueCategory = prvalue
+#    6|         0: globalInt
+#    6|             Type = int
+#    6|             ValueCategory = lvalue
 ir.cpp:
 #    1| void Constants()
 #    1|   params: 

--- a/cpp/ql/test/library-tests/ir/ir/clang.cpp
+++ b/cpp/ql/test/library-tests/ir/ir/clang.cpp
@@ -1,0 +1,7 @@
+// semmle-extractor-options: --clang
+
+int globalInt;
+
+int *globalIntAddress() {
+  return __builtin_addressof(globalInt);
+}

--- a/cpp/ql/test/library-tests/ir/ir/raw_ir.expected
+++ b/cpp/ql/test/library-tests/ir/ir/raw_ir.expected
@@ -48,6 +48,20 @@ bad_asts.cpp:
 #   26|     v0_13(void)          = UnmodeledUse           : mu*
 #   26|     v0_14(void)          = ExitFunction           : 
 
+clang.cpp:
+#    5| int* globalIntAddress()
+#    5|   Block 0
+#    5|     v0_0(void)         = EnterFunction              : 
+#    5|     mu0_1(unknown)     = AliasedDefinition          : 
+#    5|     mu0_2(unknown)     = UnmodeledDefinition        : 
+#    6|     r0_3(glval<int *>) = VariableAddress[#return]   : 
+#    6|     r0_4(glval<int>)   = VariableAddress[globalInt] : 
+#    6|     mu0_5(int *)       = Store                      : &:r0_3, r0_4
+#    5|     r0_6(glval<int *>) = VariableAddress[#return]   : 
+#    5|     v0_7(void)         = ReturnValue                : &:r0_6, ~mu0_2
+#    5|     v0_8(void)         = UnmodeledUse               : mu*
+#    5|     v0_9(void)         = ExitFunction               : 
+
 ir.cpp:
 #    1| void Constants()
 #    1|   Block 0


### PR DESCRIPTION
This seemed almost too easy. I found only one mention of `AddressOfExpr` in the IR code, so I just put a similar case for `BuiltInOperationBuiltInAddressOf` next to it.