### PR TITLE
Java: Add `isNotEmpty` to NullGuards

### DIFF
--- a/java/ql/src/semmle/code/java/dataflow/NullGuards.qll
+++ b/java/ql/src/semmle/code/java/dataflow/NullGuards.qll
@@ -120,6 +120,14 @@ predicate nullCheckMethod(Method m, boolean branch, boolean isnull) {
   m.hasName("isBlank") and
   branch = false and
   isnull = false
+  or
+  (
+    m.getDeclaringType().hasQualifiedName("org.apache.commons.collections4", "CollectionUtils") or
+    m.getDeclaringType().hasQualifiedName("org.apache.commons.collections", "CollectionUtils")
+  ) and
+  m.hasName("isNotEmpty") and
+  branch = true and
+  isnull = false
 }
 
 /**


### PR DESCRIPTION
This came up at a customer and seems like a fairly small fix. I wouldn't mind adding a test, although I think that would require stubbing, having looked at the other tests for nullness. As there wasn't one for `StringUtils.isBlank` I left it out, but happy to do so.