### PR TITLE
C++: Fix DeclarationHidesVariable FP for nested range-based for loops

### DIFF
--- a/cpp/ql/src/Best Practices/Hiding/DeclarationHidesVariable.ql
+++ b/cpp/ql/src/Best Practices/Hiding/DeclarationHidesVariable.ql
@@ -15,6 +15,8 @@ import Best_Practices.Hiding.Shadowing
 from LocalVariable lv1, LocalVariable lv2
 where
   shadowing(lv1, lv2) and
+  not lv1.isCompilerGenerated() and
+  not lv2.isCompilerGenerated() and
   not lv1.getParentScope().(Block).isInMacroExpansion() and
   not lv2.getParentScope().(Block).isInMacroExpansion()
 select lv1, "Variable " + lv1.getName() + " hides another variable of the same name (on $@).", lv2,

--- a/cpp/ql/test/query-tests/Best Practices/Hiding/DeclarationHidesVariable/DeclarationHidesVariable.expected
+++ b/cpp/ql/test/query-tests/Best Practices/Hiding/DeclarationHidesVariable/DeclarationHidesVariable.expected
@@ -1,5 +1,2 @@
 | hiding.cpp:6:17:6:17 | i | Variable i hides another variable of the same name (on $@). | hiding.cpp:4:13:4:13 | i | line 4 |
 | hiding.cpp:18:15:18:15 | k | Variable k hides another variable of the same name (on $@). | hiding.cpp:15:11:15:11 | k | line 15 |
-| hiding.cpp:30:5:30:5 | (__begin) | Variable (__begin) hides another variable of the same name (on $@). | hiding.cpp:29:3:29:3 | (__begin) | line 29 |
-| hiding.cpp:30:5:30:5 | (__end) | Variable (__end) hides another variable of the same name (on $@). | hiding.cpp:29:3:29:3 | (__end) | line 29 |
-| hiding.cpp:30:5:30:5 | (__range) | Variable (__range) hides another variable of the same name (on $@). | hiding.cpp:29:3:29:3 | (__range) | line 29 |

--- a/cpp/ql/test/query-tests/Best Practices/Hiding/DeclarationHidesVariable/DeclarationHidesVariable.expected
+++ b/cpp/ql/test/query-tests/Best Practices/Hiding/DeclarationHidesVariable/DeclarationHidesVariable.expected
@@ -1,2 +1,5 @@
 | hiding.cpp:6:17:6:17 | i | Variable i hides another variable of the same name (on $@). | hiding.cpp:4:13:4:13 | i | line 4 |
 | hiding.cpp:18:15:18:15 | k | Variable k hides another variable of the same name (on $@). | hiding.cpp:15:11:15:11 | k | line 15 |
+| hiding.cpp:30:5:30:5 | (__begin) | Variable (__begin) hides another variable of the same name (on $@). | hiding.cpp:29:3:29:3 | (__begin) | line 29 |
+| hiding.cpp:30:5:30:5 | (__end) | Variable (__end) hides another variable of the same name (on $@). | hiding.cpp:29:3:29:3 | (__end) | line 29 |
+| hiding.cpp:30:5:30:5 | (__range) | Variable (__range) hides another variable of the same name (on $@). | hiding.cpp:29:3:29:3 | (__range) | line 29 |

--- a/cpp/ql/test/query-tests/Best Practices/Hiding/DeclarationHidesVariable/hiding.cpp
+++ b/cpp/ql/test/query-tests/Best Practices/Hiding/DeclarationHidesVariable/hiding.cpp
@@ -27,6 +27,6 @@ namespace foo {
 void nestedRangeBasedFor() {
   int xs[4], ys[4];
   for (auto x : xs)
-    for (auto y : ys) // GOOD [FALSE POSITIVE]
+    for (auto y : ys) // GOOD
       x = y = 0;
 }

--- a/cpp/ql/test/query-tests/Best Practices/Hiding/DeclarationHidesVariable/hiding.cpp
+++ b/cpp/ql/test/query-tests/Best Practices/Hiding/DeclarationHidesVariable/hiding.cpp
@@ -3,7 +3,7 @@ void f(void) {
     if (1) {
         int i;
 
-        for(int i = 1; i < 10; i++) {
+        for(int i = 1; i < 10; i++) { // BAD
             ;
         }
     }
@@ -15,7 +15,7 @@ namespace foo {
       int k;
       try {
         for (i = 0; i < 3; i++) {
-          int k;
+          int k; // BAD
         }
       }
       catch (int e) {
@@ -24,4 +24,9 @@ namespace foo {
   }
 }
 
-
+void nestedRangeBasedFor() {
+  int xs[4], ys[4];
+  for (auto x : xs)
+    for (auto y : ys) // GOOD [FALSE POSITIVE]
+      x = y = 0;
+}


### PR DESCRIPTION
Fixes #1556.