### PR TITLE
C++: Improve performance of AliasedSSA::getOverlap

### DIFF
--- a/cpp/ql/src/semmle/code/cpp/ir/implementation/aliased_ssa/internal/AliasedSSA.qll
+++ b/cpp/ql/src/semmle/code/cpp/ir/implementation/aliased_ssa/internal/AliasedSSA.qll
@@ -183,6 +183,14 @@ class UnknownVirtualVariable extends TUnknownVirtualVariable, VirtualVariable {
 Overlap getOverlap(MemoryLocation def, MemoryLocation use) {
   // The def and the use must have the same virtual variable, or no overlap is possible.
   def.getVirtualVariable() = use.getVirtualVariable() and
+  // restrict the result set to be O(defs * uses)
+  // the def must be a def
+  def = getResultMemoryLocation(_) and
+  // the "use" must be a use or an entire virtual variable (used for chi node overlap computations)
+  (
+    use = getOperandMemoryLocation(_) or
+    use instanceof VirtualVariable
+  ) and
   (
     // An UnknownVirtualVariable must totally overlap any location within the same virtual variable.
     def instanceof UnknownVirtualVariable and result instanceof MustTotallyOverlap or


### PR DESCRIPTION
This changes getOverlap to be O(defMemoryLocations * useMemoryLocations) for each virtual variable, rather than O(memoryLocations * memoryLocations) for each virtual variable. This fixes quadratic behavior
when a function has large numbers of read locations or write locations, but not large numbers of both.