### PR TITLE
Reduce precision from `very-high` to `low` due to inability to handle…

### DIFF
--- a/cpp/ql/src/Likely Bugs/Underspecified Functions/TooManyArguments.ql
+++ b/cpp/ql/src/Likely Bugs/Underspecified Functions/TooManyArguments.ql
@@ -5,7 +5,7 @@
  *              that the code does not follow the author's intent.
  * @kind problem
  * @problem.severity warning
- * @precision very-high
+ * @precision low
  * @id cpp/futile-params
  * @tags correctness
  *       maintainability

--- a/cpp/ql/src/Likely Bugs/Underspecified Functions/TooManyArguments.ql
+++ b/cpp/ql/src/Likely Bugs/Underspecified Functions/TooManyArguments.ql
@@ -5,7 +5,7 @@
  *              that the code does not follow the author's intent.
  * @kind problem
  * @problem.severity warning
- * @precision high
+ * @precision very-high
  * @id cpp/futile-params
  * @tags correctness
  *       maintainability
@@ -34,7 +34,6 @@ predicate isCompiledAsC(Function f) {
 from FunctionCall fc, Function f
 where
   f = fc.getTarget() and
-  f.getNumberOfParameters() = 0 and
   not f.isVarargs() and
   hasZeroParamDecl(f) and
   isCompiledAsC(f) and

--- a/cpp/ql/src/Likely Bugs/Underspecified Functions/TooManyArguments.ql
+++ b/cpp/ql/src/Likely Bugs/Underspecified Functions/TooManyArguments.ql
@@ -34,6 +34,7 @@ predicate isCompiledAsC(Function f) {
 from FunctionCall fc, Function f
 where
   f = fc.getTarget() and
+  f.getNumberOfParameters() = 0 and
   not f.isVarargs() and
   hasZeroParamDecl(f) and
   isCompiledAsC(f) and

--- a/cpp/ql/src/Likely Bugs/Underspecified Functions/TooManyArguments.ql
+++ b/cpp/ql/src/Likely Bugs/Underspecified Functions/TooManyArguments.ql
@@ -5,7 +5,7 @@
  *              that the code does not follow the author's intent.
  * @kind problem
  * @problem.severity warning
- * @precision low
+ * @precision high
  * @id cpp/futile-params
  * @tags correctness
  *       maintainability

--- a/cpp/ql/test/query-tests/Likely Bugs/Underspecified Functions/test.c
+++ b/cpp/ql/test/query-tests/Likely Bugs/Underspecified Functions/test.c
@@ -38,7 +38,7 @@ void test(int *argv[]) {
 
   int x;
   declared_empty_defined_with(&x); // BAD
-  declared_empty_defined_with(3, &x); // BAD
+  declared_empty_defined_with(3, &x); // BAD [NOT DETECTED]
 
   not_declared_defined_with(-1, 0, 2U); // GOOD
   not_declared_defined_with(4LL, 0, 2.5e9f); // BAD
@@ -114,3 +114,13 @@ unsigned int defined_with_ptr_arr(unsigned int *ptr[]) {
 void declared_and_defined_empty() {
 	return;
 }
+
+extern int will_be_k_and_r();
+
+int call_k_and_r(int i) {
+	return will_be_k_and_r(i);  // GOOD
+}
+
+int will_be_k_and_r(val)
+  int val;
+{ return val + 1; }

--- a/cpp/ql/test/query-tests/Likely Bugs/Underspecified Functions/test.c
+++ b/cpp/ql/test/query-tests/Likely Bugs/Underspecified Functions/test.c
@@ -38,7 +38,7 @@ void test(int *argv[]) {
 
   int x;
   declared_empty_defined_with(&x); // BAD
-  declared_empty_defined_with(3, &x); // BAD [NOT DETECTED]
+  declared_empty_defined_with(3, &x); // BAD
 
   not_declared_defined_with(-1, 0, 2U); // GOOD
   not_declared_defined_with(4LL, 0, 2.5e9f); // BAD


### PR DESCRIPTION
… K&R definitions correctly.

If someone can figure out how to reliably detect K&R definitions (and their parameters count), please let me know.  Otherwise, we'll reduce precision.  (Query should still be useful in other contexts.)