### PR TITLE
JavaScript: Add more default source nodes.

### DIFF
--- a/javascript/ql/src/semmle/javascript/dataflow/Sources.qll
+++ b/javascript/ql/src/semmle/javascript/dataflow/Sources.qll
@@ -199,7 +199,7 @@ module SourceNode {
    *
    *   - import specifiers
    *   - function parameters
-   *   - `this` expressions
+   *   - function receivers
    *   - property accesses
    *   - function invocations
    *   - global variable accesses

--- a/javascript/ql/src/semmle/javascript/dataflow/Sources.qll
+++ b/javascript/ql/src/semmle/javascript/dataflow/Sources.qll
@@ -193,10 +193,13 @@ module SourceNode {
   /**
    * A data flow node that is considered a source node by default.
    *
-   * Currently, the following nodes are source nodes:
+   * This includes all nodes that evaluate to a new object and all nodes whose
+   * value is computed using non-local data flow (that is, flow between functions,
+   * between modules, or through the heap):
+   *
    *   - import specifiers
    *   - function parameters
-   *   - `this` nodes
+   *   - `this` expressions
    *   - property accesses
    *   - function invocations
    *   - global variable accesses
@@ -206,6 +209,12 @@ module SourceNode {
    *   - array expressions
    *   - JSX literals
    *   - regular expression literals
+   *   - `yield` expressions
+   *   - `await` expressions
+   *   - dynamic `import` expressions
+   *   - function-bind expressions
+   *   - `function.sent` expressions
+   *   - comprehension expressions.
    *
    * This class is for internal use only and should not normally be used directly.
    */
@@ -220,7 +229,13 @@ module SourceNode {
         astNode instanceof JSXNode or
         astNode instanceof GlobalVarAccess or
         astNode instanceof ExternalModuleReference or
-        astNode instanceof RegExpLiteral
+        astNode instanceof RegExpLiteral or
+        astNode instanceof YieldExpr or
+        astNode instanceof ComprehensionExpr or
+        astNode instanceof AwaitExpr or
+        astNode instanceof FunctionSentExpr or
+        astNode instanceof FunctionBindExpr or
+        astNode instanceof DynamicImportExpr
       )
       or
       this = DataFlow::ssaDefinitionNode(SSA::definition(any(ImportSpecifier imp)))

--- a/javascript/ql/test/library-tests/DataFlow/sources.expected
+++ b/javascript/ql/test/library-tests/DataFlow/sources.expected
@@ -43,16 +43,24 @@
 | tst.js:50:14:53:3 | () {\\n   ... et`\\n  } |
 | tst.js:51:5:51:13 | super(42) |
 | tst.js:58:1:58:3 | tag |
+| tst.js:61:1:61:5 | ::o.m |
 | tst.js:61:3:61:5 | o.m |
+| tst.js:62:1:62:4 | o::g |
 | tst.js:64:1:64:0 | this |
 | tst.js:64:1:67:1 | functio ... lysed\\n} |
+| tst.js:65:3:65:10 | yield 42 |
+| tst.js:66:13:66:25 | function.sent |
 | tst.js:68:12:68:14 | h() |
 | tst.js:69:1:69:9 | iter.next |
 | tst.js:69:1:69:13 | iter.next(23) |
 | tst.js:71:1:71:0 | this |
 | tst.js:71:1:73:1 | async f ... lysed\\n} |
+| tst.js:72:3:72:11 | await p() |
 | tst.js:72:9:72:9 | p |
 | tst.js:72:9:72:11 | p() |
+| tst.js:75:9:75:21 | import('foo') |
+| tst.js:83:11:83:28 | [ for (v of o) v ] |
+| tst.js:85:11:85:28 | ( for (v of o) v ) |
 | tst.js:87:1:96:2 | (functi ... r: 0\\n}) |
 | tst.js:87:2:87:1 | this |
 | tst.js:87:2:92:1 | functio ...  + z;\\n} |


### PR DESCRIPTION
As mentioned by @asger-semmle on https://github.com/Semmle/ql/pull/1495, `await` really should be a source node. This PR makes it so, and also adds in `yield` and dynamic `import` expressions as well as a few other experimental and legacy language features involving non-local flow.

[No changes](https://git.semmle.com/max/dist-compare-reports/blob/master/js/await-sourcenode/report.md) (internal link), so no change note.