### PR TITLE
CPP: Extend StrcpyFunction and update UsingStrcpyAsBoolean.ql

### DIFF
--- a/cpp/ql/src/Likely Bugs/Likely Typos/UsingStrcpyAsBoolean.ql
+++ b/cpp/ql/src/Likely Bugs/Likely Typos/UsingStrcpyAsBoolean.ql
@@ -12,19 +12,8 @@
  */
 
 import cpp
+import semmle.code.cpp.models.implementations.Strcpy
 import semmle.code.cpp.dataflow.DataFlow
-
-predicate isStringComparisonFunction(string functionName) {
-  functionName = "strcpy" or
-  functionName = "wcscpy" or
-  functionName = "_mbscpy" or
-  functionName = "strncpy" or
-  functionName = "_strncpy_l" or
-  functionName = "wcsncpy" or
-  functionName = "_wcsncpy_l" or
-  functionName = "_mbsncpy" or
-  functionName = "_mbsncpy_l"
-}
 
 predicate isBoolean(Expr e1) {
   exists(Type t1 |
@@ -36,12 +25,12 @@ predicate isBoolean(Expr e1) {
 predicate isStringCopyCastedAsBoolean(FunctionCall func, Expr expr1, string msg) {
   DataFlow::localFlow(DataFlow::exprNode(func), DataFlow::exprNode(expr1)) and
   isBoolean(expr1.getConversion*()) and
-  isStringComparisonFunction(func.getTarget().getName()) and
+  func.getTarget() instanceof StrcpyFunction and
   msg = "Return value of " + func.getTarget().getName() + " used as a Boolean."
 }
 
 predicate isStringCopyUsedInLogicalOperationOrCondition(FunctionCall func, Expr expr1, string msg) {
-  isStringComparisonFunction(func.getTarget().getName()) and
+  func.getTarget() instanceof StrcpyFunction and
   (
     (
       // it is being used in an equality or logical operation

--- a/cpp/ql/src/semmle/code/cpp/models/implementations/Strcpy.qll
+++ b/cpp/ql/src/semmle/code/cpp/models/implementations/Strcpy.qll
@@ -4,7 +4,7 @@ import semmle.code.cpp.models.interfaces.Taint
 
 
 /**
- * The standard function `stract` and its wide, sized, and Microsoft variants.
+ * The standard function `strcpy` and its wide, sized, and Microsoft variants.
  */
 class StrcpyFunction extends ArrayFunction, DataFlowFunction, TaintFunction {
   StrcpyFunction() {

--- a/cpp/ql/src/semmle/code/cpp/models/implementations/Strcpy.qll
+++ b/cpp/ql/src/semmle/code/cpp/models/implementations/Strcpy.qll
@@ -12,8 +12,11 @@ class StrcpyFunction extends ArrayFunction, DataFlowFunction, TaintFunction {
     this.hasName("_mbscpy") or
     this.hasName("wcscpy") or
     this.hasName("strncpy") or
+    this.hasName("_strncpy_l") or
     this.hasName("_mbsncpy") or
-    this.hasName("wcsncpy")
+    this.hasName("_mbsncpy_l") or
+    this.hasName("wcsncpy") or
+    this.hasName("_wcsncpy_l")
   }
   
   override predicate hasArrayInput(int bufParam) {
@@ -31,8 +34,11 @@ class StrcpyFunction extends ArrayFunction, DataFlowFunction, TaintFunction {
   override predicate hasArrayWithVariableSize(int bufParam, int countParam) {
     (
       this.hasName("strncpy") or
+      this.hasName("_strncpy_l") or
       this.hasName("_mbsncpy") or
-      this.hasName("wcsncpy")
+      this.hasName("_mbsncpy_l") or
+      this.hasName("wcsncpy") or
+      this.hasName("_wcsncpy_l")
     ) and
     bufParam = 0 and
     countParam = 2
@@ -76,8 +82,11 @@ class StrcpyFunction extends ArrayFunction, DataFlowFunction, TaintFunction {
       // these may do only a partial copy of the input buffer to the output
       // buffer
       this.hasName("strncpy") or
+      this.hasName("_strncpy_l") or
       this.hasName("_mbsncpy") or
-      this.hasName("wcsncpy")
+      this.hasName("_mbsncpy_l") or
+      this.hasName("wcsncpy") or
+      this.hasName("_wcsncpy_l")
     ) and (
       input.isInParameter(2) or
       input.isInParameterPointer(1)

--- a/cpp/ql/src/semmle/code/cpp/models/implementations/Strcpy.qll
+++ b/cpp/ql/src/semmle/code/cpp/models/implementations/Strcpy.qll
@@ -43,7 +43,7 @@ class StrcpyFunction extends ArrayFunction, DataFlowFunction, TaintFunction {
     bufParam = 0 and
     countParam = 2
   }
-  
+
   override predicate hasArrayWithUnknownSize(int bufParam) {
     (
       this.hasName("strcpy") or
@@ -52,7 +52,6 @@ class StrcpyFunction extends ArrayFunction, DataFlowFunction, TaintFunction {
     ) and
     bufParam = 0
   }
-  
 
   override predicate hasDataFlow(FunctionInput input, FunctionOutput output) {
     (
@@ -76,7 +75,7 @@ class StrcpyFunction extends ArrayFunction, DataFlowFunction, TaintFunction {
       output.isOutReturnValue()
     )
   }
-  
+
   override predicate hasTaintFlow(FunctionInput input, FunctionOutput output) {
     (
       // these may do only a partial copy of the input buffer to the output

--- a/cpp/ql/test/query-tests/Likely Bugs/Likely Typos/UsingStrcpyAsBoolean/UsingStrcpyAsBoolean.expected
+++ b/cpp/ql/test/query-tests/Likely Bugs/Likely Typos/UsingStrcpyAsBoolean/UsingStrcpyAsBoolean.expected
@@ -19,6 +19,9 @@
 | test.cpp:103:9:103:15 | call to strncpy | Return value of strncpy used directly in a conditional expression. |
 | test.cpp:107:9:107:15 | call to wcsncpy | Return value of wcsncpy used directly in a conditional expression. |
 | test.cpp:111:9:111:16 | call to _mbsncpy | Return value of _mbsncpy used directly in a conditional expression. |
+| test.cpp:115:9:115:18 | call to _strncpy_l | Return value of _strncpy_l used directly in a conditional expression. |
+| test.cpp:119:9:119:18 | call to _wcsncpy_l | Return value of _wcsncpy_l used directly in a conditional expression. |
+| test.cpp:123:9:123:18 | call to _mbsncpy_l | Return value of _mbsncpy_l used directly in a conditional expression. |
 | test.cpp:127:9:127:37 | ! ... | Return value of strncpy used in a logical operation. |
 | test.cpp:131:14:131:20 | call to strncpy | Return value of strncpy used as a Boolean. |
 | test.cpp:133:19:133:47 | ! ... | Return value of strncpy used in a logical operation. |

--- a/cpp/ql/test/query-tests/Likely Bugs/Likely Typos/UsingStrcpyAsBoolean/UsingStrcpyAsBoolean.expected
+++ b/cpp/ql/test/query-tests/Likely Bugs/Likely Typos/UsingStrcpyAsBoolean/UsingStrcpyAsBoolean.expected
@@ -19,9 +19,6 @@
 | test.cpp:103:9:103:15 | call to strncpy | Return value of strncpy used directly in a conditional expression. |
 | test.cpp:107:9:107:15 | call to wcsncpy | Return value of wcsncpy used directly in a conditional expression. |
 | test.cpp:111:9:111:16 | call to _mbsncpy | Return value of _mbsncpy used directly in a conditional expression. |
-| test.cpp:115:9:115:18 | call to _strncpy_l | Return value of _strncpy_l used directly in a conditional expression. |
-| test.cpp:119:9:119:18 | call to _wcsncpy_l | Return value of _wcsncpy_l used directly in a conditional expression. |
-| test.cpp:123:9:123:18 | call to _mbsncpy_l | Return value of _mbsncpy_l used directly in a conditional expression. |
 | test.cpp:127:9:127:37 | ! ... | Return value of strncpy used in a logical operation. |
 | test.cpp:131:14:131:20 | call to strncpy | Return value of strncpy used as a Boolean. |
 | test.cpp:133:19:133:47 | ! ... | Return value of strncpy used in a logical operation. |


### PR DESCRIPTION
This is a bit of an experiment into using the 'models' library more widely in our queries.

I discussed this with @jbj, we agreed it's a good idea to do this when we're working on particular queries but (1) it probably isn't worth the effort of a big push right now and (2) we should use the higher level libraries (e.g. 'ArrayFunction', 'DataFlowFunction') over models of specific function groups where possible.