### PR TITLE
CPP: Test cases for EmptyBlock.ql with 'if constexpr'

### DIFF
--- a/cpp/ql/test/query-tests/Best Practices/Likely Errors/EmptyBlock/EmptyBlock.expected
+++ b/cpp/ql/test/query-tests/Best Practices/Likely Errors/EmptyBlock/EmptyBlock.expected
@@ -1,3 +1,3 @@
-| empty_block.cpp:7:10:7:11 | { ... } | Empty block without comment |
-| empty_block.cpp:10:10:11:3 | { ... } | Empty block without comment |
-| empty_block.cpp:18:10:19:3 | { ... } | Empty block without comment |
+| empty_block.cpp:9:10:9:11 | { ... } | Empty block without comment |
+| empty_block.cpp:12:10:13:3 | { ... } | Empty block without comment |
+| empty_block.cpp:20:10:21:3 | { ... } | Empty block without comment |

--- a/cpp/ql/test/query-tests/Best Practices/Likely Errors/EmptyBlock/empty_block.cpp
+++ b/cpp/ql/test/query-tests/Best Practices/Likely Errors/EmptyBlock/empty_block.cpp
@@ -76,8 +76,8 @@ int f(int x) {
     if constexpr(1) {
       f();
     } else {
-	  f();
-	}
+      f();
+    }
   }
 
   return 1;

--- a/cpp/ql/test/query-tests/Best Practices/Likely Errors/EmptyBlock/empty_block.cpp
+++ b/cpp/ql/test/query-tests/Best Practices/Likely Errors/EmptyBlock/empty_block.cpp
@@ -56,4 +56,29 @@ int f(int x) {
 
   // GOOD (has comment): [FALSE POSITIVE]
   if (x) {}  // comment
+
+  // GOOD
+  if (x) {
+    if constexpr(1) {
+      f();
+    }
+  }
+
+  // GOOD
+  if (x) {
+    if constexpr(0) {
+      f();
+    }
+  }
+
+  // GOOD
+  if (x) {
+    if constexpr(1) {
+      f();
+    } else {
+	  f();
+	}
+  }
+
+  return 1;
 }

--- a/cpp/ql/test/query-tests/Best Practices/Likely Errors/EmptyBlock/empty_block.cpp
+++ b/cpp/ql/test/query-tests/Best Practices/Likely Errors/EmptyBlock/empty_block.cpp
@@ -1,3 +1,5 @@
+// semmle-extractor-options: -std=c++17
+
 // GOOD:
 void f() {
 }


### PR DESCRIPTION
See https://discuss.lgtm.com/t/c-false-positive-empty-block-without-comment/2183.

~These currently cause an extractor error because `if constexpr()` is not supported (DO NOT MERGE).  The extractor team have plans to fix this - at which point we should review whether this query handles these cases correctly.~