### PR TITLE
C#: Disable logger AutoFlush

### DIFF
--- a/csharp/extractor/Semmle.Util/Logger.cs
+++ b/csharp/extractor/Semmle.Util/Logger.cs
@@ -72,7 +72,6 @@ namespace Semmle.Util.Logging
                     Directory.CreateDirectory(dir);
                 writer = new PidStreamWriter(new FileStream(outputFile, FileMode.Append, FileAccess.Write,
                     FileShare.ReadWrite, 8192));
-                writer.AutoFlush = true;
             }
             catch (Exception ex)  // lgtm[cs/catch-of-all-exceptions]
             {


### PR DESCRIPTION
This implementation was carried over from the mono-based extractor, but there's no reason to enable `AutoFlush`. This change should be a theoretical performance improvement, but more importantly, makes `csharp.log` more readable when there are concurrent extractors running.

https://docs.microsoft.com/en-us/dotnet/api/system.io.streamwriter.autoflush?view=netframework-4.8