### PR TITLE
C++ IR: Make TOperand cached

### DIFF
--- a/cpp/ql/src/semmle/code/cpp/ir/implementation/aliased_ssa/Operand.qll
+++ b/cpp/ql/src/semmle/code/cpp/ir/implementation/aliased_ssa/Operand.qll
@@ -6,6 +6,7 @@ import semmle.code.cpp.ir.implementation.MemoryAccessKind
 import semmle.code.cpp.ir.internal.Overlap
 private import semmle.code.cpp.ir.internal.OperandTag
 
+cached
 private newtype TOperand =
   TRegisterOperand(Instruction useInstr, RegisterOperandTag tag, Instruction defInstr) {
     defInstr = Construction::getRegisterOperandDefinition(useInstr, tag)

--- a/cpp/ql/src/semmle/code/cpp/ir/implementation/raw/Operand.qll
+++ b/cpp/ql/src/semmle/code/cpp/ir/implementation/raw/Operand.qll
@@ -6,6 +6,7 @@ import semmle.code.cpp.ir.implementation.MemoryAccessKind
 import semmle.code.cpp.ir.internal.Overlap
 private import semmle.code.cpp.ir.internal.OperandTag
 
+cached
 private newtype TOperand =
   TRegisterOperand(Instruction useInstr, RegisterOperandTag tag, Instruction defInstr) {
     defInstr = Construction::getRegisterOperandDefinition(useInstr, tag)

--- a/cpp/ql/src/semmle/code/cpp/ir/implementation/unaliased_ssa/Operand.qll
+++ b/cpp/ql/src/semmle/code/cpp/ir/implementation/unaliased_ssa/Operand.qll
@@ -6,6 +6,7 @@ import semmle.code.cpp.ir.implementation.MemoryAccessKind
 import semmle.code.cpp.ir.internal.Overlap
 private import semmle.code.cpp.ir.internal.OperandTag
 
+cached
 private newtype TOperand =
   TRegisterOperand(Instruction useInstr, RegisterOperandTag tag, Instruction defInstr) {
     defInstr = Construction::getRegisterOperandDefinition(useInstr, tag)


### PR DESCRIPTION
Just like `TInstruction` is cached to prevent re-numbering its tuples in every IR query, I think `TOperand` should be cached too. I tested it on the small comdb2 snapshot, where it only saves one second of work when running a second IR query, but the savings should grow when snapshots are larger and when there are more IR queries in a suite. Tuple numbering is mildly quadratic, so it should be good to avoid repeating it.

Adding these annotations adds three cached stages to the existing four cached stages of the IR. The new cached stages are small and do not appear to repeat any work from the other stages, so I see no advantage to merging them with the existing stages.

This PR is _not_ part of the effort to put the IR into production. I don't consider it urgent or necessary, but I've noticed unnecessary recomputation of `TOperand` while working on more urgent IR fixes, and I thought it was useful to turn it into a PR so I could get it out of my todo list.