### PR TITLE
JS: Avoid tracking classes into receiver of other classes

### DIFF
--- a/javascript/ql/src/semmle/javascript/dataflow/Nodes.qll
+++ b/javascript/ql/src/semmle/javascript/dataflow/Nodes.qll
@@ -715,12 +715,17 @@ class ClassNode extends DataFlow::SourceNode {
     t.start() and
     result = getAReceiverNode()
     or
+    result = getAnInstanceReferenceAux(t) and
+    // Avoid tracking into the receiver of other classes.
+    // Note that this also blocks flows into a property of the receiver,
+    // but the `localFieldStep` rule will often compensate for this.
+    not result = any(DataFlow::ClassNode cls).getAReceiverNode()
+  }
+
+  pragma[noinline]
+  private DataFlow::SourceNode getAnInstanceReferenceAux(DataFlow::TypeTracker t) {
     exists(DataFlow::TypeTracker t2 |
-      result = getAnInstanceReference(t2).track(t2, t) and
-      // Avoid tracking into the receiver of other classes.
-      // Note that this also blocks flows into a property of the receiver,
-      // but the `localFieldStep` rule will often compensate for this.
-      not result = any(DataFlow::ClassNode cls).getAReceiverNode()
+      result = getAnInstanceReference(t2).track(t2, t)
     )
   }
 

--- a/javascript/ql/src/semmle/javascript/dataflow/Nodes.qll
+++ b/javascript/ql/src/semmle/javascript/dataflow/Nodes.qll
@@ -716,7 +716,11 @@ class ClassNode extends DataFlow::SourceNode {
     result = getAReceiverNode()
     or
     exists(DataFlow::TypeTracker t2 |
-      result = getAnInstanceReference(t2).track(t2, t)
+      result = getAnInstanceReference(t2).track(t2, t) and
+      // Avoid tracking into the receiver of other classes.
+      // Note that this also blocks flows into a property of the receiver,
+      // but the `localFieldStep` rule will often compensate for this.
+      not result = any(DataFlow::ClassNode cls).getAReceiverNode()
     )
   }
 

--- a/javascript/ql/test/library-tests/CallGraphs/AnnotatedTest/this-calls.js
+++ b/javascript/ql/test/library-tests/CallGraphs/AnnotatedTest/this-calls.js
@@ -1,0 +1,27 @@
+import 'dummy';
+
+class Foo {
+  a() {
+    /** calls:Foo.b */
+    this.b();
+  }
+
+  /** name:Foo.b */
+  b() {}
+}
+
+class Bar {
+  a() {
+    /** calls:Bar.b */
+    this.b();
+  }
+
+  /** name:Bar.b */
+  b() {}
+}
+
+function callA(x) {
+  x.a();
+}
+callA(new Foo);
+callB(new Bar);


### PR DESCRIPTION
Blocks all flow of class instances into `this` of any class other than itself.

This also blocks flow into super classes, even though it's not immediately wrong to propagate the type there, but it can lead to false call edges. That decision may be worth revisiting later.

[Evaluation](https://git.semmle.com/asger/dist-compare-reports/tree/restrict-receiver-type_1562698689441) looks fine, and a bunch of call edges disappeared as expected.