### PR TITLE
C++: Fix performance of unchecked leap year query

### DIFF
--- a/cpp/ql/src/Likely Bugs/Leap Year/UncheckedLeapYearAfterYearModification.ql
+++ b/cpp/ql/src/Likely Bugs/Leap Year/UncheckedLeapYearAfterYearModification.ql
@@ -24,7 +24,7 @@ where
       exists(LeapYearFieldAccess yfacheck |
         yfacheck.getQualifier() = var.getAnAccess() and
         yfacheck.isUsedInCorrectLeapYearCheck() and
-        yfacheck = yfa.getASuccessor*()
+        yfacheck.getBasicBlock() = yfa.getBasicBlock().getASuccessor*()
       )
       or
       // If there is a data flow from the variable that was modified to a function that seems to check for leap year
@@ -50,8 +50,8 @@ where
         mfa.getQualifier() = var.getAnAccess() and
         mfa.isModified() and
         (
-          mfa = yfa.getASuccessor*() or
-          yfa = mfa.getASuccessor*()
+          mfa.getBasicBlock() = yfa.getBasicBlock().getASuccessor*() or
+          yfa.getBasicBlock() = mfa.getBasicBlock().getASuccessor+()
         ) and
         ae = mfa.getEnclosingElement() and
         ae.getAnOperand().getValue().toInt() = 1


### PR DESCRIPTION
This query used `getASuccessor()` on the CFG, which worked in many cases but became quadratic on certain projects including PostgreSQL and MySQL. The problem was that there was just enough context for magic to apply to the transitive closure, but the use of magic meant that the fast transitive closure algorithm wasn't used. In projects where the magic had little effect, that led to the `#ControlFlowGraph::ControlFlowNode::getASuccessor_dispred#bfPlus` predicate taking quadratic time and space.

This commit changes the query to use basic blocks to find successors, which is much faster because (1) there are many more `ControlFlowNode`s than `BasicBlocks`, and (2) the optimizer does not apply magic but uses fast transitive closure instead.

Behavior changes slightly in the `isUsedInCorrectLeapYearCheck` case: we now accept a `yfacheck` that comes _before_ `yfa` if they are in the same basic block. I don't think that matters in practice.