### PR TITLE
Revert "C++: Work around extractor issue CPP-383"

### DIFF
--- a/cpp/ql/src/semmle/code/cpp/controlflow/internal/ConstantExprs.qll
+++ b/cpp/ql/src/semmle/code/cpp/controlflow/internal/ConstantExprs.qll
@@ -107,42 +107,9 @@ private predicate loopConditionAlwaysUponEntry(ControlFlowNode loop, Expr condit
   )
 }
 
-/**
- * This relation is the same as the `el instanceof Function`, only obfuscated
- * so the optimizer will not understand that any `FunctionCall.getTarget()`
- * should be in this relation.
- */
-pragma[noinline]
-private predicate isFunction(Element el) {
-  el instanceof Function
-  or
-  el.(Expr).getParent() = el
-}
-
-/**
- * Holds if `fc` is a `FunctionCall` with no return value for `getTarget`. This
- * can happen due to extractor issue CPP-383.
- */
-pragma[noopt]
-private predicate callHasNoTarget(@funbindexpr fc) {
-  exists(Function f |
-    funbind(fc, f) and
-    not isFunction(f)
-  )
-}
-
-// This base case is pulled out to work around QL-796
-private predicate potentiallyReturningFunctionCall_base(FunctionCall fc) {
-  fc.isVirtual()
-  or
-  callHasNoTarget(fc)
-}
-
 /** A function call that *may* return; if in doubt, we assume it may. */
 private predicate potentiallyReturningFunctionCall(FunctionCall fc) {
-  potentiallyReturningFunctionCall_base(fc)
-  or
-  potentiallyReturningFunction(fc.getTarget())
+  potentiallyReturningFunction(fc.getTarget()) or fc.isVirtual()
 }
 
 /** A function that *may* return; if in doubt, we assume it may. */


### PR DESCRIPTION
The issue is now fixed in the extractor, and I've confirmed that the workaround is no longer needed for g/an-tao/drogon on the dist upgrade that's currently in progress.

This reverts #1280.