### PR TITLE
Python: fix property setter handling in points-to.

### DIFF
--- a/python/ql/src/semmle/python/objects/Descriptors.qll
+++ b/python/ql/src/semmle/python/objects/Descriptors.qll
@@ -32,7 +32,7 @@ class PropertyInternal extends ObjectInternal, TProperty {
     private Context getContext() { this = TProperty(_,result,  _) }
 
     override string toString() {
-        result = "property" + this.getName()
+        result = "property " + this.getName()
     }
 
     override boolean booleanValue() { result = true }
@@ -63,7 +63,9 @@ class PropertyInternal extends ObjectInternal, TProperty {
 
     override predicate calleeAndOffset(Function scope, int paramOffset) { none() }
 
-    pragma [noinline] override predicate attribute(string name, ObjectInternal value, CfgOrigin origin) { none() }
+    pragma [noinline] override predicate attribute(string name, ObjectInternal value, CfgOrigin origin) {
+        value = TPropertySetterOrDeleter(this, name) and origin = CfgOrigin::unknown()
+    }
 
     pragma [noinline] override predicate attributesUnknown() { none() }
 
@@ -99,6 +101,82 @@ class PropertyInternal extends ObjectInternal, TProperty {
     override ObjectInternal getIterNext() { none() }
 
 }
+
+private class PropertySetterOrDeleter extends ObjectInternal, TPropertySetterOrDeleter {
+
+    override string toString() {
+        result = this.getProperty().toString() + "." + this.getName()
+    }
+
+    override string getName() {
+        this = TPropertySetterOrDeleter(_, result)
+    }
+
+    PropertyInternal getProperty() {
+        this = TPropertySetterOrDeleter(result, _)
+    }
+
+    override predicate callResult(ObjectInternal obj, CfgOrigin origin) {
+        exists(ControlFlowNode call |
+            obj = this.getProperty() and obj = TProperty(call, _, _) and
+            origin = CfgOrigin::fromCfgNode(call)
+        )
+    }
+
+    override predicate introducedAt(ControlFlowNode node, PointsToContext context) {
+        none()
+    }
+
+    override ClassDecl getClassDeclaration() { none() }
+
+    override boolean isClass() { result = false }
+
+    override ObjectInternal getClass() {
+       result = TBuiltinClassObject(Builtin::special("MethodType"))
+    }
+
+    override predicate notTestableForEquality() { none() }
+
+    override Builtin getBuiltin() { none() }
+
+    override ControlFlowNode getOrigin() { none() }
+
+    override predicate callResult(PointsToContext callee, ObjectInternal obj, CfgOrigin origin) { none() }
+
+    override int intValue() { none() }
+
+    override string strValue() { none() }
+
+    override boolean booleanValue() { result = true }
+
+    override predicate calleeAndOffset(Function scope, int paramOffset) { none() }
+
+    pragma [noinline] override predicate attribute(string name, ObjectInternal value, CfgOrigin origin) {
+        none()
+    }
+
+    pragma [noinline] override predicate attributesUnknown() { none() }
+
+    override predicate subscriptUnknown() { none() }
+
+    override boolean isDescriptor() { result = true }
+
+    override int length() { none() }
+
+    pragma [noinline] override predicate binds(ObjectInternal cls, string name, ObjectInternal descriptor) { none() }
+
+    override predicate contextSensitiveCallee() { none() }
+
+    override ObjectInternal getIterNext() { none() }
+
+    pragma [noinline] override predicate descriptorGetClass(ObjectInternal cls, ObjectInternal value, CfgOrigin origin) { none() }
+
+    pragma [noinline] override predicate descriptorGetInstance(ObjectInternal instance, ObjectInternal value, CfgOrigin origin) { none() }
+
+    override predicate useOriginAsLegacyObject() { none() }
+
+}
+
 
 /** A class representing classmethods in Python */
 class ClassMethodObjectInternal extends ObjectInternal, TClassMethod {

--- a/python/ql/src/semmle/python/objects/Descriptors.qll
+++ b/python/ql/src/semmle/python/objects/Descriptors.qll
@@ -67,14 +67,15 @@ class PropertyInternal extends ObjectInternal, TProperty {
         value = TPropertySetterOrDeleter(this, name) and origin = CfgOrigin::unknown()
     }
 
-    pragma [noinline] override predicate attributesUnknown() { none() }
+    override predicate attributesUnknown() { none() }
 
     override predicate subscriptUnknown() { none() }
 
     override boolean isDescriptor() { result = true }
 
     override int length() { none() }
-    pragma [noinline] override predicate binds(ObjectInternal cls, string name, ObjectInternal descriptor) { none() }
+
+    override predicate binds(ObjectInternal cls, string name, ObjectInternal descriptor) { none() }
 
     pragma [noinline] override predicate descriptorGetClass(ObjectInternal cls, ObjectInternal value, CfgOrigin origin) {
         any(ObjectInternal obj).binds(cls, _, this) and
@@ -151,11 +152,9 @@ private class PropertySetterOrDeleter extends ObjectInternal, TPropertySetterOrD
 
     override predicate calleeAndOffset(Function scope, int paramOffset) { none() }
 
-    pragma [noinline] override predicate attribute(string name, ObjectInternal value, CfgOrigin origin) {
-        none()
-    }
+    override predicate attribute(string name, ObjectInternal value, CfgOrigin origin) { none() }
 
-    pragma [noinline] override predicate attributesUnknown() { none() }
+    override predicate attributesUnknown() { none() }
 
     override predicate subscriptUnknown() { none() }
 
@@ -163,15 +162,15 @@ private class PropertySetterOrDeleter extends ObjectInternal, TPropertySetterOrD
 
     override int length() { none() }
 
-    pragma [noinline] override predicate binds(ObjectInternal cls, string name, ObjectInternal descriptor) { none() }
+    override predicate binds(ObjectInternal cls, string name, ObjectInternal descriptor) { none() }
 
     override predicate contextSensitiveCallee() { none() }
 
     override ObjectInternal getIterNext() { none() }
 
-    pragma [noinline] override predicate descriptorGetClass(ObjectInternal cls, ObjectInternal value, CfgOrigin origin) { none() }
+    override predicate descriptorGetClass(ObjectInternal cls, ObjectInternal value, CfgOrigin origin) { none() }
 
-    pragma [noinline] override predicate descriptorGetInstance(ObjectInternal instance, ObjectInternal value, CfgOrigin origin) { none() }
+    override predicate descriptorGetInstance(ObjectInternal instance, ObjectInternal value, CfgOrigin origin) { none() }
 
     override predicate useOriginAsLegacyObject() { none() }
 
@@ -221,9 +220,9 @@ class ClassMethodObjectInternal extends ObjectInternal, TClassMethod {
 
     override predicate calleeAndOffset(Function scope, int paramOffset) { none() }
 
-    pragma [noinline] override predicate attribute(string name, ObjectInternal value, CfgOrigin origin) { none() }
+    override predicate attribute(string name, ObjectInternal value, CfgOrigin origin) { none() }
 
-    pragma [noinline] override predicate attributesUnknown() { none() }
+    override predicate attributesUnknown() { none() }
 
     override predicate subscriptUnknown() { none() }
 
@@ -313,9 +312,9 @@ class StaticMethodObjectInternal extends ObjectInternal, TStaticMethod {
         this.getFunction().calleeAndOffset(scope, paramOffset)
     }
 
-    pragma [noinline] override predicate attribute(string name, ObjectInternal value, CfgOrigin origin) { none() }
+    override predicate attribute(string name, ObjectInternal value, CfgOrigin origin) { none() }
 
-    pragma [noinline] override predicate attributesUnknown() { none() }
+    override predicate attributesUnknown() { none() }
 
     override predicate subscriptUnknown() { none() }
 
@@ -331,7 +330,7 @@ class StaticMethodObjectInternal extends ObjectInternal, TStaticMethod {
         value = this.getFunction() and origin = CfgOrigin::unknown()
     }
 
-    pragma [noinline] override predicate binds(ObjectInternal instance, string name, ObjectInternal descriptor) { none() }
+    override predicate binds(ObjectInternal instance, string name, ObjectInternal descriptor) { none() }
 
     override int length() { none() }
 

--- a/python/ql/src/semmle/python/objects/TObject.qll
+++ b/python/ql/src/semmle/python/objects/TObject.qll
@@ -194,6 +194,13 @@ cached newtype TObject =
         PointsToInternal::pointsTo(call.getArg(0), ctx, getter, _)
     }
     or
+    TPropertySetterOrDeleter(PropertyInternal property, string method) {
+        exists(AttrNode attr |
+            PointsToInternal::pointsTo(attr.getObject(method), _, property, _)
+        ) and
+        ( method = "setter" or method = "deleter" )
+    }
+    or
     /* Represents a dynamically created class */
     TDynamicClass(CallNode instantiation, ClassObjectInternal metacls, PointsToContext context) {
         PointsToInternal::pointsTo(instantiation.getFunction(), context, metacls, _) and

--- a/python/ql/src/semmle/python/objects/TObject.qll
+++ b/python/ql/src/semmle/python/objects/TObject.qll
@@ -194,6 +194,7 @@ cached newtype TObject =
         PointsToInternal::pointsTo(call.getArg(0), ctx, getter, _)
     }
     or
+    /* Represents the `setter` or `deleter` method of a property object. */
     TPropertySetterOrDeleter(PropertyInternal property, string method) {
         exists(AttrNode attr |
             PointsToInternal::pointsTo(attr.getObject(method), _, property, _)

--- a/python/ql/test/library-tests/PointsTo/properties/Lookup.expected
+++ b/python/ql/test/library-tests/PointsTo/properties/Lookup.expected
@@ -1,0 +1,6 @@
+| class C | p | property p |
+| class D | __init__ | Function D.__init__ |
+| class D | q | property q |
+| class E | __init__ | Function D.__init__ |
+| class E | p | property p |
+| class E | q | property q |

--- a/python/ql/test/library-tests/PointsTo/properties/Lookup.ql
+++ b/python/ql/test/library-tests/PointsTo/properties/Lookup.ql
@@ -1,0 +1,8 @@
+
+import python
+import semmle.python.pointsto.PointsTo
+import semmle.python.objects.ObjectInternal
+
+from ClassObjectInternal cls, string name, ObjectInternal f
+where cls.lookup(name, f, _) and exists(f.getOrigin())
+select cls.toString(), name, f.toString()

--- a/python/ql/test/library-tests/PointsTo/properties/Values.expected
+++ b/python/ql/test/library-tests/PointsTo/properties/Values.expected
@@ -1,27 +1,31 @@
-| test.py:3:1:3:16 | test.py:3 | ControlFlowNode for ClassExpr | import | test.py:3:1:3:16 | class C | file://:0:0:0:0 | builtin-class type |
-| test.py:3:9:3:14 | test.py:3 | ControlFlowNode for object | import | file://:0:0:0:0 | builtin-class object | file://:0:0:0:0 | builtin-class type |
-| test.py:5:6:5:13 | test.py:5 | ControlFlowNode for property | import | file://:0:0:0:0 | builtin-class property | file://:0:0:0:0 | builtin-class type |
-| test.py:5:6:5:13 | test.py:5 | ControlFlowNode for property() | import | test.py:5:6:5:13 | property p | file://:0:0:0:0 | builtin-class property |
-| test.py:6:5:6:16 | test.py:6 | ControlFlowNode for FunctionExpr | import | test.py:6:5:6:16 | Function C.p | file://:0:0:0:0 | builtin-class function |
-| test.py:7:16:7:16 | test.py:7 | ControlFlowNode for IntegerLiteral | runtime | file://:0:0:0:0 | int 0 | file://:0:0:0:0 | builtin-class int |
-| test.py:9:1:9:16 | test.py:9 | ControlFlowNode for ClassExpr | import | test.py:9:1:9:16 | class D | file://:0:0:0:0 | builtin-class type |
-| test.py:9:9:9:14 | test.py:9 | ControlFlowNode for object | import | file://:0:0:0:0 | builtin-class object | file://:0:0:0:0 | builtin-class type |
-| test.py:11:5:11:23 | test.py:11 | ControlFlowNode for FunctionExpr | import | test.py:11:5:11:23 | Function D.__init__ | file://:0:0:0:0 | builtin-class function |
-| test.py:12:9:12:12 | test.py:12 | ControlFlowNode for self | runtime | test.py:11:18:11:21 | self instance of D | test.py:9:1:9:16 | class D |
-| test.py:12:18:12:18 | test.py:12 | ControlFlowNode for IntegerLiteral | runtime | file://:0:0:0:0 | int 0 | file://:0:0:0:0 | builtin-class int |
-| test.py:14:6:14:13 | test.py:14 | ControlFlowNode for property | import | file://:0:0:0:0 | builtin-class property | file://:0:0:0:0 | builtin-class type |
-| test.py:14:6:14:13 | test.py:14 | ControlFlowNode for property() | import | test.py:14:6:14:13 | property q | file://:0:0:0:0 | builtin-class property |
-| test.py:15:5:15:16 | test.py:15 | ControlFlowNode for FunctionExpr | import | test.py:15:5:15:16 | Function D.q | file://:0:0:0:0 | builtin-class function |
-| test.py:16:16:16:19 | test.py:16 | ControlFlowNode for self | runtime | test.py:15:11:15:14 | self instance of D | test.py:9:1:9:16 | class D |
-| test.py:18:6:18:6 | test.py:18 | ControlFlowNode for q | import | test.py:14:6:14:13 | property q | file://:0:0:0:0 | builtin-class property |
-| test.py:19:5:19:23 | test.py:19 | ControlFlowNode for FunctionExpr | import | test.py:19:5:19:23 | Function D.q | file://:0:0:0:0 | builtin-class function |
-| test.py:20:9:20:12 | test.py:20 | ControlFlowNode for self | runtime | test.py:19:11:19:14 | self instance of D | test.py:9:1:9:16 | class D |
-| test.py:22:1:22:14 | test.py:22 | ControlFlowNode for ClassExpr | import | test.py:22:1:22:14 | class E | file://:0:0:0:0 | builtin-class type |
-| test.py:22:9:22:9 | test.py:22 | ControlFlowNode for C | import | test.py:3:1:3:16 | class C | file://:0:0:0:0 | builtin-class type |
-| test.py:22:12:22:12 | test.py:22 | ControlFlowNode for D | import | test.py:9:1:9:16 | class D | file://:0:0:0:0 | builtin-class type |
-| test.py:25:1:25:1 | test.py:25 | ControlFlowNode for C | import | test.py:3:1:3:16 | class C | file://:0:0:0:0 | builtin-class type |
-| test.py:25:1:25:3 | test.py:25 | ControlFlowNode for Attribute | import | test.py:5:6:5:13 | property p | file://:0:0:0:0 | builtin-class property |
-| test.py:26:1:26:1 | test.py:26 | ControlFlowNode for D | import | test.py:9:1:9:16 | class D | file://:0:0:0:0 | builtin-class type |
-| test.py:26:1:26:3 | test.py:26 | ControlFlowNode for Attribute | import | test.py:18:6:18:13 | property q | file://:0:0:0:0 | builtin-class property |
-| test.py:27:1:27:1 | test.py:27 | ControlFlowNode for E | import | test.py:22:1:22:14 | class E | file://:0:0:0:0 | builtin-class type |
-| test.py:28:1:28:1 | test.py:28 | ControlFlowNode for E | import | test.py:22:1:22:14 | class E | file://:0:0:0:0 | builtin-class type |
+| test.py:3:1:3:16 | test.py:3 | ControlFlowNode for ClassExpr | import | class C | builtin-class type |
+| test.py:3:9:3:14 | test.py:3 | ControlFlowNode for object | import | builtin-class object | builtin-class type |
+| test.py:5:6:5:13 | test.py:5 | ControlFlowNode for property | import | builtin-class property | builtin-class type |
+| test.py:5:6:5:13 | test.py:5 | ControlFlowNode for property() | import | property p | builtin-class property |
+| test.py:6:5:6:16 | test.py:6 | ControlFlowNode for FunctionExpr | import | Function C.p | builtin-class function |
+| test.py:7:16:7:16 | test.py:7 | ControlFlowNode for IntegerLiteral | runtime | int 0 | builtin-class int |
+| test.py:9:1:9:16 | test.py:9 | ControlFlowNode for ClassExpr | import | class D | builtin-class type |
+| test.py:9:9:9:14 | test.py:9 | ControlFlowNode for object | import | builtin-class object | builtin-class type |
+| test.py:11:5:11:23 | test.py:11 | ControlFlowNode for FunctionExpr | import | Function D.__init__ | builtin-class function |
+| test.py:12:9:12:12 | test.py:12 | ControlFlowNode for self | runtime | self instance of D | class D |
+| test.py:12:18:12:18 | test.py:12 | ControlFlowNode for IntegerLiteral | runtime | int 0 | builtin-class int |
+| test.py:14:6:14:13 | test.py:14 | ControlFlowNode for property | import | builtin-class property | builtin-class type |
+| test.py:14:6:14:13 | test.py:14 | ControlFlowNode for property() | import | property q | builtin-class property |
+| test.py:15:5:15:16 | test.py:15 | ControlFlowNode for FunctionExpr | import | Function D.q | builtin-class function |
+| test.py:16:16:16:19 | test.py:16 | ControlFlowNode for self | runtime | self instance of D | class D |
+| test.py:18:6:18:6 | test.py:18 | ControlFlowNode for q | import | property q | builtin-class property |
+| test.py:18:6:18:13 | test.py:18 | ControlFlowNode for Attribute | import | property q.setter | builtin-class method |
+| test.py:18:6:18:13 | test.py:18 | ControlFlowNode for Attribute() | import | property q | builtin-class property |
+| test.py:19:5:19:23 | test.py:19 | ControlFlowNode for FunctionExpr | import | Function D.q | builtin-class function |
+| test.py:20:9:20:12 | test.py:20 | ControlFlowNode for self | runtime | self instance of D | class D |
+| test.py:22:1:22:14 | test.py:22 | ControlFlowNode for ClassExpr | import | class E | builtin-class type |
+| test.py:22:9:22:9 | test.py:22 | ControlFlowNode for C | import | class C | builtin-class type |
+| test.py:22:12:22:12 | test.py:22 | ControlFlowNode for D | import | class D | builtin-class type |
+| test.py:25:1:25:1 | test.py:25 | ControlFlowNode for C | import | class C | builtin-class type |
+| test.py:25:1:25:3 | test.py:25 | ControlFlowNode for Attribute | import | property p | builtin-class property |
+| test.py:26:1:26:1 | test.py:26 | ControlFlowNode for D | import | class D | builtin-class type |
+| test.py:26:1:26:3 | test.py:26 | ControlFlowNode for Attribute | import | property q | builtin-class property |
+| test.py:27:1:27:1 | test.py:27 | ControlFlowNode for E | import | class E | builtin-class type |
+| test.py:27:1:27:3 | test.py:27 | ControlFlowNode for Attribute | import | property p | builtin-class property |
+| test.py:28:1:28:1 | test.py:28 | ControlFlowNode for E | import | class E | builtin-class type |
+| test.py:28:1:28:3 | test.py:28 | ControlFlowNode for Attribute | import | property q | builtin-class property |

--- a/python/ql/test/library-tests/PointsTo/properties/Values.expected
+++ b/python/ql/test/library-tests/PointsTo/properties/Values.expected
@@ -1,0 +1,27 @@
+| test.py:3:1:3:16 | test.py:3 | ControlFlowNode for ClassExpr | import | test.py:3:1:3:16 | class C | file://:0:0:0:0 | builtin-class type |
+| test.py:3:9:3:14 | test.py:3 | ControlFlowNode for object | import | file://:0:0:0:0 | builtin-class object | file://:0:0:0:0 | builtin-class type |
+| test.py:5:6:5:13 | test.py:5 | ControlFlowNode for property | import | file://:0:0:0:0 | builtin-class property | file://:0:0:0:0 | builtin-class type |
+| test.py:5:6:5:13 | test.py:5 | ControlFlowNode for property() | import | test.py:5:6:5:13 | property p | file://:0:0:0:0 | builtin-class property |
+| test.py:6:5:6:16 | test.py:6 | ControlFlowNode for FunctionExpr | import | test.py:6:5:6:16 | Function C.p | file://:0:0:0:0 | builtin-class function |
+| test.py:7:16:7:16 | test.py:7 | ControlFlowNode for IntegerLiteral | runtime | file://:0:0:0:0 | int 0 | file://:0:0:0:0 | builtin-class int |
+| test.py:9:1:9:16 | test.py:9 | ControlFlowNode for ClassExpr | import | test.py:9:1:9:16 | class D | file://:0:0:0:0 | builtin-class type |
+| test.py:9:9:9:14 | test.py:9 | ControlFlowNode for object | import | file://:0:0:0:0 | builtin-class object | file://:0:0:0:0 | builtin-class type |
+| test.py:11:5:11:23 | test.py:11 | ControlFlowNode for FunctionExpr | import | test.py:11:5:11:23 | Function D.__init__ | file://:0:0:0:0 | builtin-class function |
+| test.py:12:9:12:12 | test.py:12 | ControlFlowNode for self | runtime | test.py:11:18:11:21 | self instance of D | test.py:9:1:9:16 | class D |
+| test.py:12:18:12:18 | test.py:12 | ControlFlowNode for IntegerLiteral | runtime | file://:0:0:0:0 | int 0 | file://:0:0:0:0 | builtin-class int |
+| test.py:14:6:14:13 | test.py:14 | ControlFlowNode for property | import | file://:0:0:0:0 | builtin-class property | file://:0:0:0:0 | builtin-class type |
+| test.py:14:6:14:13 | test.py:14 | ControlFlowNode for property() | import | test.py:14:6:14:13 | property q | file://:0:0:0:0 | builtin-class property |
+| test.py:15:5:15:16 | test.py:15 | ControlFlowNode for FunctionExpr | import | test.py:15:5:15:16 | Function D.q | file://:0:0:0:0 | builtin-class function |
+| test.py:16:16:16:19 | test.py:16 | ControlFlowNode for self | runtime | test.py:15:11:15:14 | self instance of D | test.py:9:1:9:16 | class D |
+| test.py:18:6:18:6 | test.py:18 | ControlFlowNode for q | import | test.py:14:6:14:13 | property q | file://:0:0:0:0 | builtin-class property |
+| test.py:19:5:19:23 | test.py:19 | ControlFlowNode for FunctionExpr | import | test.py:19:5:19:23 | Function D.q | file://:0:0:0:0 | builtin-class function |
+| test.py:20:9:20:12 | test.py:20 | ControlFlowNode for self | runtime | test.py:19:11:19:14 | self instance of D | test.py:9:1:9:16 | class D |
+| test.py:22:1:22:14 | test.py:22 | ControlFlowNode for ClassExpr | import | test.py:22:1:22:14 | class E | file://:0:0:0:0 | builtin-class type |
+| test.py:22:9:22:9 | test.py:22 | ControlFlowNode for C | import | test.py:3:1:3:16 | class C | file://:0:0:0:0 | builtin-class type |
+| test.py:22:12:22:12 | test.py:22 | ControlFlowNode for D | import | test.py:9:1:9:16 | class D | file://:0:0:0:0 | builtin-class type |
+| test.py:25:1:25:1 | test.py:25 | ControlFlowNode for C | import | test.py:3:1:3:16 | class C | file://:0:0:0:0 | builtin-class type |
+| test.py:25:1:25:3 | test.py:25 | ControlFlowNode for Attribute | import | test.py:5:6:5:13 | property p | file://:0:0:0:0 | builtin-class property |
+| test.py:26:1:26:1 | test.py:26 | ControlFlowNode for D | import | test.py:9:1:9:16 | class D | file://:0:0:0:0 | builtin-class type |
+| test.py:26:1:26:3 | test.py:26 | ControlFlowNode for Attribute | import | test.py:18:6:18:13 | property q | file://:0:0:0:0 | builtin-class property |
+| test.py:27:1:27:1 | test.py:27 | ControlFlowNode for E | import | test.py:22:1:22:14 | class E | file://:0:0:0:0 | builtin-class type |
+| test.py:28:1:28:1 | test.py:28 | ControlFlowNode for E | import | test.py:22:1:22:14 | class E | file://:0:0:0:0 | builtin-class type |

--- a/python/ql/test/library-tests/PointsTo/properties/Values.ql
+++ b/python/ql/test/library-tests/PointsTo/properties/Values.ql
@@ -1,0 +1,8 @@
+
+import python
+
+
+from ControlFlowNode f, Context ctx, Value v, ControlFlowNode origin
+where
+  f.pointsTo(ctx, v, origin)
+select f.getLocation(), f.toString(), ctx, v, v.getClass()

--- a/python/ql/test/library-tests/PointsTo/properties/Values.ql
+++ b/python/ql/test/library-tests/PointsTo/properties/Values.ql
@@ -1,8 +1,15 @@
 
 import python
+import semmle.python.objects.ObjectInternal
 
+string vrepr(Value v) {
+    /* Work around differing names in 2/3 */
+    not v = ObjectInternal::boundMethod() and result = v.toString()
+    or
+    v = ObjectInternal::boundMethod() and result = "builtin-class method"
+}
 
 from ControlFlowNode f, Context ctx, Value v, ControlFlowNode origin
 where
   f.pointsTo(ctx, v, origin)
-select f.getLocation(), f.toString(), ctx, v, v.getClass()
+select f.getLocation(), f.toString(), ctx, vrepr(v), vrepr(v.getClass())

--- a/python/ql/test/library-tests/PointsTo/properties/test.py
+++ b/python/ql/test/library-tests/PointsTo/properties/test.py
@@ -1,0 +1,28 @@
+
+
+class C(object):
+
+    @property
+    def p(self):
+        return 0
+
+class D(object):
+
+    def __init__(self):
+        self.v = 0
+
+    @property
+    def q(self):
+        return self.v
+
+    @q.setter
+    def q(self, value):
+        self.v = value
+
+class E(C, D):
+    pass
+
+C.p
+D.q
+E.p
+E.q


### PR DESCRIPTION
Fixes points-to for properties with `.setter`s.
E.g.
```python
class D(object):

    @property
    def q(self):
        return self.v

    @q.setter
    def q(self, value):
        self.v = value
```

This PR ensures that the property `q` is tracked through the call to its setter method.





