### PR TITLE
CPP: Taint tracking between function arguments.

### DIFF
--- a/change-notes/1.22/analysis-cpp.md
+++ b/change-notes/1.22/analysis-cpp.md
@@ -23,3 +23,4 @@
 - The `semmle.code.cpp.security.TaintTracking` library now considers a pointer difference calculation as blocking taint flow.
 - Fixed the `LocalScopeVariableReachability.qll` library's handling of loops with an entry condition is both always true upon first entry, and where there is more than one control flow path through the loop condition.  This change increases the accuracy of the `LocalScopeVariableReachability.qll` library and queries which depend on it.
 - The `semmle.code.cpp.models` library now models data flow through `std::swap`.
+- The `semmle.code.cpp.dataflow.TaintTracking` library now tracks taint flow between function arguments.

--- a/cpp/ql/test/library-tests/dataflow/taint-tests/localTaint.expected
+++ b/cpp/ql/test/library-tests/dataflow/taint-tests/localTaint.expected
@@ -254,15 +254,19 @@
 | taint.cpp:299:15:299:15 | ref arg t | taint.cpp:302:16:302:16 | t |  |
 | taint.cpp:299:15:299:15 | ref arg t | taint.cpp:303:17:303:17 | t |  |
 | taint.cpp:299:15:299:15 | ref arg t | taint.cpp:305:7:305:7 | t |  |
+| taint.cpp:299:15:299:15 | t | taint.cpp:299:12:299:12 | ref arg a | TAINT |
 | taint.cpp:300:12:300:12 | ref arg b | taint.cpp:300:12:300:12 | b |  |
 | taint.cpp:300:12:300:12 | ref arg b | taint.cpp:307:7:307:7 | b |  |
+| taint.cpp:300:15:300:15 | t | taint.cpp:300:12:300:12 | ref arg b | TAINT |
 | taint.cpp:301:12:301:13 | ref arg & ... | taint.cpp:301:13:301:13 | c |  |
 | taint.cpp:301:12:301:13 | ref arg & ... | taint.cpp:308:7:308:7 | c |  |
 | taint.cpp:301:13:301:13 | c | taint.cpp:301:12:301:13 | & ... | TAINT |
 | taint.cpp:302:12:302:13 | ref arg & ... | taint.cpp:302:13:302:13 | d |  |
 | taint.cpp:302:12:302:13 | ref arg & ... | taint.cpp:309:7:309:7 | d |  |
 | taint.cpp:302:13:302:13 | d | taint.cpp:302:12:302:13 | & ... | TAINT |
+| taint.cpp:303:14:303:14 | e | taint.cpp:303:14:303:14 | ref arg e | TAINT |
 | taint.cpp:303:14:303:14 | ref arg e | taint.cpp:303:14:303:14 | e |  |
 | taint.cpp:303:14:303:14 | ref arg e | taint.cpp:310:7:310:7 | e |  |
 | taint.cpp:303:17:303:17 | ref arg t | taint.cpp:303:17:303:17 | t |  |
 | taint.cpp:303:17:303:17 | ref arg t | taint.cpp:305:7:305:7 | t |  |
+| taint.cpp:303:17:303:17 | t | taint.cpp:303:17:303:17 | ref arg t | TAINT |

--- a/cpp/ql/test/library-tests/dataflow/taint-tests/localTaint.expected
+++ b/cpp/ql/test/library-tests/dataflow/taint-tests/localTaint.expected
@@ -175,3 +175,94 @@
 | taint.cpp:213:15:213:15 | ref arg y | taint.cpp:213:15:213:15 | y |  |
 | taint.cpp:213:15:213:15 | ref arg y | taint.cpp:216:7:216:7 | y |  |
 | taint.cpp:213:15:213:15 | y | taint.cpp:213:12:213:12 | ref arg x |  |
+| taint.cpp:221:12:221:12 | x | taint.cpp:223:9:223:9 | x |  |
+| taint.cpp:230:6:230:11 | call to source | taint.cpp:230:2:230:13 | ... = ... |  |
+| taint.cpp:230:6:230:11 | call to source | taint.cpp:235:7:235:7 | t |  |
+| taint.cpp:230:6:230:11 | call to source | taint.cpp:240:9:240:9 | t |  |
+| taint.cpp:230:6:230:11 | call to source | taint.cpp:241:12:241:12 | t |  |
+| taint.cpp:230:6:230:11 | call to source | taint.cpp:244:7:244:7 | t |  |
+| taint.cpp:231:6:231:6 | 0 | taint.cpp:231:2:231:6 | ... = ... |  |
+| taint.cpp:231:6:231:6 | 0 | taint.cpp:236:7:236:7 | x |  |
+| taint.cpp:232:6:232:6 | 0 | taint.cpp:232:2:232:6 | ... = ... |  |
+| taint.cpp:232:6:232:6 | 0 | taint.cpp:237:7:237:7 | y |  |
+| taint.cpp:233:6:233:6 | 0 | taint.cpp:233:2:233:6 | ... = ... |  |
+| taint.cpp:233:6:233:6 | 0 | taint.cpp:238:7:238:7 | z |  |
+| taint.cpp:233:6:233:6 | 0 | taint.cpp:242:9:242:9 | z |  |
+| taint.cpp:240:6:240:7 | call to id | taint.cpp:240:2:240:10 | ... = ... |  |
+| taint.cpp:240:6:240:7 | call to id | taint.cpp:245:7:245:7 | x |  |
+| taint.cpp:241:6:241:7 | call to id | taint.cpp:241:2:241:14 | ... = ... |  |
+| taint.cpp:241:6:241:7 | call to id | taint.cpp:246:7:246:7 | y |  |
+| taint.cpp:242:6:242:7 | call to id | taint.cpp:242:2:242:10 | ... = ... |  |
+| taint.cpp:242:6:242:7 | call to id | taint.cpp:247:7:247:7 | z |  |
+| taint.cpp:252:29:252:29 | b | taint.cpp:254:6:254:6 | b |  |
+| taint.cpp:254:6:254:6 | b | taint.cpp:254:2:254:6 | ... = ... |  |
+| taint.cpp:257:28:257:28 | b | taint.cpp:259:6:259:6 | b |  |
+| taint.cpp:259:6:259:6 | b | taint.cpp:259:2:259:6 | ... = ... |  |
+| taint.cpp:262:21:262:21 | a | taint.cpp:264:3:264:3 | a |  |
+| taint.cpp:262:28:262:28 | b | taint.cpp:264:7:264:7 | b |  |
+| taint.cpp:264:3:264:3 | a | taint.cpp:264:2:264:3 | * ... | TAINT |
+| taint.cpp:264:7:264:7 | b | taint.cpp:264:2:264:7 | ... = ... |  |
+| taint.cpp:267:21:267:21 | a | taint.cpp:272:3:272:3 | a |  |
+| taint.cpp:267:28:267:28 | b | taint.cpp:271:6:271:6 | b |  |
+| taint.cpp:271:6:271:6 | b | taint.cpp:271:6:271:10 | ... + ... | TAINT |
+| taint.cpp:271:6:271:10 | ... + ... | taint.cpp:271:2:271:10 | ... = ... |  |
+| taint.cpp:271:6:271:10 | ... + ... | taint.cpp:272:7:272:7 | c |  |
+| taint.cpp:271:10:271:10 | 1 | taint.cpp:271:6:271:10 | ... + ... | TAINT |
+| taint.cpp:272:3:272:3 | a | taint.cpp:272:2:272:3 | * ... | TAINT |
+| taint.cpp:272:7:272:7 | c | taint.cpp:272:2:272:7 | ... = ... |  |
+| taint.cpp:275:23:275:23 | a | taint.cpp:277:6:277:6 | a |  |
+| taint.cpp:275:31:275:31 | b | taint.cpp:278:6:278:6 | b |  |
+| taint.cpp:277:6:277:6 | a | taint.cpp:277:6:277:10 | ... + ... | TAINT |
+| taint.cpp:277:6:277:10 | ... + ... | taint.cpp:277:2:277:10 | ... = ... |  |
+| taint.cpp:277:10:277:10 | 1 | taint.cpp:277:6:277:10 | ... + ... | TAINT |
+| taint.cpp:278:6:278:6 | b | taint.cpp:278:6:278:10 | ... + ... | TAINT |
+| taint.cpp:278:6:278:10 | ... + ... | taint.cpp:278:2:278:10 | ... = ... |  |
+| taint.cpp:278:10:278:10 | 1 | taint.cpp:278:6:278:10 | ... + ... | TAINT |
+| taint.cpp:285:6:285:11 | call to source | taint.cpp:285:2:285:13 | ... = ... |  |
+| taint.cpp:285:6:285:11 | call to source | taint.cpp:292:7:292:7 | t |  |
+| taint.cpp:285:6:285:11 | call to source | taint.cpp:299:15:299:15 | t |  |
+| taint.cpp:285:6:285:11 | call to source | taint.cpp:300:15:300:15 | t |  |
+| taint.cpp:285:6:285:11 | call to source | taint.cpp:301:16:301:16 | t |  |
+| taint.cpp:285:6:285:11 | call to source | taint.cpp:302:16:302:16 | t |  |
+| taint.cpp:285:6:285:11 | call to source | taint.cpp:303:17:303:17 | t |  |
+| taint.cpp:285:6:285:11 | call to source | taint.cpp:305:7:305:7 | t |  |
+| taint.cpp:286:6:286:6 | 0 | taint.cpp:286:2:286:6 | ... = ... |  |
+| taint.cpp:286:6:286:6 | 0 | taint.cpp:293:7:293:7 | a |  |
+| taint.cpp:286:6:286:6 | 0 | taint.cpp:299:12:299:12 | a |  |
+| taint.cpp:286:6:286:6 | 0 | taint.cpp:306:7:306:7 | a |  |
+| taint.cpp:287:6:287:6 | 0 | taint.cpp:287:2:287:6 | ... = ... |  |
+| taint.cpp:287:6:287:6 | 0 | taint.cpp:294:7:294:7 | b |  |
+| taint.cpp:287:6:287:6 | 0 | taint.cpp:300:12:300:12 | b |  |
+| taint.cpp:287:6:287:6 | 0 | taint.cpp:307:7:307:7 | b |  |
+| taint.cpp:288:6:288:6 | 0 | taint.cpp:288:2:288:6 | ... = ... |  |
+| taint.cpp:288:6:288:6 | 0 | taint.cpp:295:7:295:7 | c |  |
+| taint.cpp:288:6:288:6 | 0 | taint.cpp:301:13:301:13 | c |  |
+| taint.cpp:288:6:288:6 | 0 | taint.cpp:308:7:308:7 | c |  |
+| taint.cpp:289:6:289:6 | 0 | taint.cpp:289:2:289:6 | ... = ... |  |
+| taint.cpp:289:6:289:6 | 0 | taint.cpp:296:7:296:7 | d |  |
+| taint.cpp:289:6:289:6 | 0 | taint.cpp:302:13:302:13 | d |  |
+| taint.cpp:289:6:289:6 | 0 | taint.cpp:309:7:309:7 | d |  |
+| taint.cpp:290:6:290:6 | 0 | taint.cpp:290:2:290:6 | ... = ... |  |
+| taint.cpp:290:6:290:6 | 0 | taint.cpp:297:7:297:7 | e |  |
+| taint.cpp:290:6:290:6 | 0 | taint.cpp:303:14:303:14 | e |  |
+| taint.cpp:290:6:290:6 | 0 | taint.cpp:310:7:310:7 | e |  |
+| taint.cpp:299:12:299:12 | ref arg a | taint.cpp:299:12:299:12 | a |  |
+| taint.cpp:299:12:299:12 | ref arg a | taint.cpp:306:7:306:7 | a |  |
+| taint.cpp:299:15:299:15 | ref arg t | taint.cpp:299:15:299:15 | t |  |
+| taint.cpp:299:15:299:15 | ref arg t | taint.cpp:300:15:300:15 | t |  |
+| taint.cpp:299:15:299:15 | ref arg t | taint.cpp:301:16:301:16 | t |  |
+| taint.cpp:299:15:299:15 | ref arg t | taint.cpp:302:16:302:16 | t |  |
+| taint.cpp:299:15:299:15 | ref arg t | taint.cpp:303:17:303:17 | t |  |
+| taint.cpp:299:15:299:15 | ref arg t | taint.cpp:305:7:305:7 | t |  |
+| taint.cpp:300:12:300:12 | ref arg b | taint.cpp:300:12:300:12 | b |  |
+| taint.cpp:300:12:300:12 | ref arg b | taint.cpp:307:7:307:7 | b |  |
+| taint.cpp:301:12:301:13 | ref arg & ... | taint.cpp:301:13:301:13 | c |  |
+| taint.cpp:301:12:301:13 | ref arg & ... | taint.cpp:308:7:308:7 | c |  |
+| taint.cpp:301:13:301:13 | c | taint.cpp:301:12:301:13 | & ... | TAINT |
+| taint.cpp:302:12:302:13 | ref arg & ... | taint.cpp:302:13:302:13 | d |  |
+| taint.cpp:302:12:302:13 | ref arg & ... | taint.cpp:309:7:309:7 | d |  |
+| taint.cpp:302:13:302:13 | d | taint.cpp:302:12:302:13 | & ... | TAINT |
+| taint.cpp:303:14:303:14 | ref arg e | taint.cpp:303:14:303:14 | e |  |
+| taint.cpp:303:14:303:14 | ref arg e | taint.cpp:310:7:310:7 | e |  |
+| taint.cpp:303:17:303:17 | ref arg t | taint.cpp:303:17:303:17 | t |  |
+| taint.cpp:303:17:303:17 | ref arg t | taint.cpp:305:7:305:7 | t |  |

--- a/cpp/ql/test/library-tests/dataflow/taint-tests/taint.cpp
+++ b/cpp/ql/test/library-tests/dataflow/taint-tests/taint.cpp
@@ -215,3 +215,97 @@ void test_swap() {
 	sink(x); // [FALSE POSITIVE]
 	sink(y); // tainted
 }
+
+// --- taint through return value ---
+
+int id(int x)
+{
+	return x;
+}
+
+void test_return()
+{
+	int x, y, z, t;
+
+	t = source();
+	x = 0;
+	y = 0;
+	z = 0;
+
+	sink(t); // tainted
+	sink(x);
+	sink(y);
+	sink(z);
+
+	x = id(t);
+	y = id(id(t));
+	z = id(z);
+
+	sink(t); // tainted
+	sink(x); // tainted
+	sink(y); // tainted
+	sink(z);
+}
+
+// --- taint through parameters ---
+
+void myAssign1(int &a, int &b)
+{
+	a = b;
+}
+
+void myAssign2(int &a, int b)
+{
+	a = b;
+}
+
+void myAssign3(int *a, int b)
+{
+	*a = b;
+}
+
+void myAssign4(int *a, int b)
+{
+	int c;
+
+	c = b + 1;
+	*a = c;
+}
+
+void myNotAssign(int &a, int &b)
+{
+	a = a + 1;
+	b = b + 1;
+}
+
+void test_outparams()
+{
+	int t, a, b, c, d, e;
+
+	t = source();
+	a = 0;
+	b = 0;
+	c = 0;
+	d = 0;
+	e = 0;
+
+	sink(t); // tainted
+	sink(a);
+	sink(b);
+	sink(c);
+	sink(d);
+	sink(e);
+
+	myAssign1(a, t);
+	myAssign2(b, t);
+	myAssign3(&c, t);
+	myAssign4(&d, t);
+	myNotAssign(e, t);
+
+	sink(t); // tainted
+	sink(a); // tainted [NOT DETECTED]
+	sink(b); // tainted [NOT DETECTED]
+	sink(c); // tainted [NOT DETECTED]
+	sink(d); // tainted [NOT DETECTED]
+	sink(e);
+}

--- a/cpp/ql/test/library-tests/dataflow/taint-tests/taint.cpp
+++ b/cpp/ql/test/library-tests/dataflow/taint-tests/taint.cpp
@@ -303,8 +303,8 @@ void test_outparams()
 	myNotAssign(e, t);
 
 	sink(t); // tainted
-	sink(a); // tainted [NOT DETECTED]
-	sink(b); // tainted [NOT DETECTED]
+	sink(a); // tainted
+	sink(b); // tainted
 	sink(c); // tainted [NOT DETECTED]
 	sink(d); // tainted [NOT DETECTED]
 	sink(e);

--- a/cpp/ql/test/library-tests/dataflow/taint-tests/taint.expected
+++ b/cpp/ql/test/library-tests/dataflow/taint-tests/taint.expected
@@ -17,3 +17,9 @@
 | taint.cpp:210:7:210:7 | x | taint.cpp:207:6:207:11 | call to source |
 | taint.cpp:215:7:215:7 | x | taint.cpp:207:6:207:11 | call to source |
 | taint.cpp:216:7:216:7 | y | taint.cpp:207:6:207:11 | call to source |
+| taint.cpp:235:7:235:7 | t | taint.cpp:230:6:230:11 | call to source |
+| taint.cpp:244:7:244:7 | t | taint.cpp:230:6:230:11 | call to source |
+| taint.cpp:245:7:245:7 | x | taint.cpp:230:6:230:11 | call to source |
+| taint.cpp:246:7:246:7 | y | taint.cpp:230:6:230:11 | call to source |
+| taint.cpp:292:7:292:7 | t | taint.cpp:285:6:285:11 | call to source |
+| taint.cpp:305:7:305:7 | t | taint.cpp:285:6:285:11 | call to source |

--- a/cpp/ql/test/library-tests/dataflow/taint-tests/taint.expected
+++ b/cpp/ql/test/library-tests/dataflow/taint-tests/taint.expected
@@ -23,3 +23,5 @@
 | taint.cpp:246:7:246:7 | y | taint.cpp:230:6:230:11 | call to source |
 | taint.cpp:292:7:292:7 | t | taint.cpp:285:6:285:11 | call to source |
 | taint.cpp:305:7:305:7 | t | taint.cpp:285:6:285:11 | call to source |
+| taint.cpp:306:7:306:7 | a | taint.cpp:285:6:285:11 | call to source |
+| taint.cpp:307:7:307:7 | b | taint.cpp:285:6:285:11 | call to source |

--- a/cpp/ql/test/library-tests/dataflow/taint-tests/test_diff.expected
+++ b/cpp/ql/test/library-tests/dataflow/taint-tests/test_diff.expected
@@ -9,3 +9,5 @@
 | taint.cpp:195:7:195:7 | taint.cpp:193:6:193:6 | AST only |
 | taint.cpp:215:7:215:7 | taint.cpp:207:6:207:11 | AST only |
 | taint.cpp:216:7:216:7 | taint.cpp:207:6:207:11 | AST only |
+| taint.cpp:306:7:306:7 | taint.cpp:285:6:285:11 | AST only |
+| taint.cpp:307:7:307:7 | taint.cpp:285:6:285:11 | AST only |

--- a/cpp/ql/test/library-tests/dataflow/taint-tests/test_ir.expected
+++ b/cpp/ql/test/library-tests/dataflow/taint-tests/test_ir.expected
@@ -8,3 +8,9 @@
 | taint.cpp:167:8:167:13 | Call: call to source | taint.cpp:167:8:167:13 | Call: call to source |
 | taint.cpp:168:8:168:14 | Load: tainted | taint.cpp:164:19:164:24 | Call: call to source |
 | taint.cpp:210:7:210:7 | Load: x | taint.cpp:207:6:207:11 | Call: call to source |
+| taint.cpp:235:7:235:7 | Load: t | taint.cpp:230:6:230:11 | Call: call to source |
+| taint.cpp:244:7:244:7 | Load: t | taint.cpp:230:6:230:11 | Call: call to source |
+| taint.cpp:245:7:245:7 | Load: x | taint.cpp:230:6:230:11 | Call: call to source |
+| taint.cpp:246:7:246:7 | Load: y | taint.cpp:230:6:230:11 | Call: call to source |
+| taint.cpp:292:7:292:7 | Load: t | taint.cpp:285:6:285:11 | Call: call to source |
+| taint.cpp:305:7:305:7 | Load: t | taint.cpp:285:6:285:11 | Call: call to source |


### PR DESCRIPTION
Taint tracking between function arguments.

This is pretty much a copy-paste of @pavgust's code from a Slack discussion about supporting user-defined 'swap' functions.  It works quite nicely in simple cases.

@jbj seemed to suggest such a thing could be built into the dataflow library (i.e. at a lower level than the taint library), which would be great but I currently find the internals of that library quite impenetrable.  It would also be good to have the IR dataflow library cover the same cases.

Discussion encouraged (though we may need to wait until Jonas is back from holiday).