### PR TITLE
CPP: Test + workaround for UseInOwnInitializer.ql

### DIFF
--- a/change-notes/1.22/analysis-cpp.md
+++ b/change-notes/1.22/analysis-cpp.md
@@ -16,6 +16,7 @@
 | No space for zero terminator (`cpp/no-space-for-terminator`) | Fewer false positive results | False positives involving strings that are not null-terminated have been excluded. |
 | Suspicious pointer scaling (`cpp/suspicious-pointer-scaling`) | Lower precision | The precision of this query has been reduced to "medium". This coding pattern is used intentionally and safely in a number of real-world projects. Results are no longer displayed on LGTM unless you choose to display them. |
 | Non-constant format string (`cpp/non-constant-format`) | Fewer false positive results | Rewritten using the taint-tracking library. |
+| Variable used in its own initializer (`cpp/use-in-own-initializer`) | Fewer false positive results | False positives for constant variables with the same name in different namespaces have been removed. |
 
 ## Changes to QL libraries
 

--- a/cpp/ql/src/Likely Bugs/UseInOwnInitializer.ql
+++ b/cpp/ql/src/Likely Bugs/UseInOwnInitializer.ql
@@ -32,6 +32,7 @@ where va.initializesItself(v, init)
     exists (CrementOperation crement | crement.getAnOperand() = va)
   )
   and not va.isUnevaluated()
+  and not v.isConst()
   and not (
     va.getParent() = init and
     exists(MacroInvocation mi |

--- a/cpp/ql/test/query-tests/Likely Bugs/UseInOwnInitializer/UseInOwnInitializer.expected
+++ b/cpp/ql/test/query-tests/Likely Bugs/UseInOwnInitializer/UseInOwnInitializer.expected
@@ -2,7 +2,3 @@
 | test.cpp:8:10:8:10 | x | x is used in its own initializer. |
 | test.cpp:57:10:57:10 | x | x is used in its own initializer. |
 | test.cpp:61:24:61:24 | x | x is used in its own initializer. |
-| test.cpp:80:17:80:23 | v2 | v2 is used in its own initializer. |
-| test.cpp:84:16:84:22 | v4 | v4 is used in its own initializer. |
-| test.cpp:89:17:89:23 | v6 | v6 is used in its own initializer. |
-| test.cpp:90:17:90:23 | v7 | v7 is used in its own initializer. |

--- a/cpp/ql/test/query-tests/Likely Bugs/UseInOwnInitializer/UseInOwnInitializer.expected
+++ b/cpp/ql/test/query-tests/Likely Bugs/UseInOwnInitializer/UseInOwnInitializer.expected
@@ -2,3 +2,7 @@
 | test.cpp:8:10:8:10 | x | x is used in its own initializer. |
 | test.cpp:57:10:57:10 | x | x is used in its own initializer. |
 | test.cpp:61:24:61:24 | x | x is used in its own initializer. |
+| test.cpp:80:17:80:23 | v2 | v2 is used in its own initializer. |
+| test.cpp:84:16:84:22 | v4 | v4 is used in its own initializer. |
+| test.cpp:89:17:89:23 | v6 | v6 is used in its own initializer. |
+| test.cpp:90:17:90:23 | v7 | v7 is used in its own initializer. |

--- a/cpp/ql/test/query-tests/Likely Bugs/UseInOwnInitializer/test.cpp
+++ b/cpp/ql/test/query-tests/Likely Bugs/UseInOwnInitializer/test.cpp
@@ -77,15 +77,15 @@ namespace ns1
 namespace ns2
 {
 	const int v1 = ns1::v2; // GOOD
-	const int v2 = ns1::v2; // GOOD [FALSE POSITIVE; produces INVALID_KEY trap warning]
+	const int v2 = ns1::v2; // GOOD [produces INVALID_KEY trap warning]
 };
 
 const int v3 = ns1::v4; // GOOD
-const int v4 = ns1::v4; // GOOD [FALSE POSITIVE]
+const int v4 = ns1::v4; // GOOD
 
 namespace ns3
 {
 	const int v5 = ns1::v6 + 1; // GOOD
-	const int v6 = ns1::v6 + 1; // GOOD  [FALSE POSITIVE; produces INVALID_KEY trap warning]
-	const int v7 = ns3::v7; // BAD
+	const int v6 = ns1::v6 + 1; // GOOD  [produces INVALID_KEY trap warning]
+	const int v7 = ns3::v7; // BAD [NOT DETECTED]
 };

--- a/cpp/ql/test/query-tests/Likely Bugs/UseInOwnInitializer/test.cpp
+++ b/cpp/ql/test/query-tests/Likely Bugs/UseInOwnInitializer/test.cpp
@@ -66,3 +66,26 @@ void test11() {
 void test12() {
 	self_initialize(int, x); // GOOD (statement is from a macro)
 }
+
+namespace ns1
+{
+	const int v2 = 1;
+	const int v4 = 1;
+	const int v6 = 1;
+};
+
+namespace ns2
+{
+	const int v1 = ns1::v2; // GOOD
+	const int v2 = ns1::v2; // GOOD [FALSE POSITIVE; produces INVALID_KEY trap warning]
+};
+
+const int v3 = ns1::v4; // GOOD
+const int v4 = ns1::v4; // GOOD [FALSE POSITIVE]
+
+namespace ns3
+{
+	const int v5 = ns1::v6 + 1; // GOOD
+	const int v6 = ns1::v6 + 1; // GOOD  [FALSE POSITIVE; produces INVALID_KEY trap warning]
+	const int v7 = ns3::v7; // BAD
+};


### PR DESCRIPTION
This PR works around a false positive in UseInOwnInitializer.ql, by excluding constant variables from the query.  The justification is that the false positive only occurs if the variable (both instances) are `const`, and true positives with `const` are rare (I haven't found any).

@ian-semmle the underlying issue is an extractor bug, which I think we've seen before.

Fixes https://discuss.lgtm.com/t/c-false-positive/2214.