### PR TITLE
JS: Do not recursively import javascript into DataFlow:: scope

### DIFF
--- a/javascript/ql/src/semmle/javascript/dataflow/AbstractProperties.qll
+++ b/javascript/ql/src/semmle/javascript/dataflow/AbstractProperties.qll
@@ -1,4 +1,4 @@
-import javascript
+private import javascript
 private import semmle.javascript.dataflow.internal.AbstractValuesImpl
 private import semmle.javascript.dataflow.InferredTypes
 private import semmle.javascript.dataflow.internal.AbstractPropertiesImpl

--- a/javascript/ql/src/semmle/javascript/dataflow/AbstractValues.qll
+++ b/javascript/ql/src/semmle/javascript/dataflow/AbstractValues.qll
@@ -38,7 +38,7 @@
  * the source of imprecision that caused them to arise.
  */
 
-import javascript
+private import javascript
 private import semmle.javascript.dataflow.internal.AbstractValuesImpl
 private import InferredTypes
 

--- a/javascript/ql/src/semmle/javascript/dataflow/Configuration.qll
+++ b/javascript/ql/src/semmle/javascript/dataflow/Configuration.qll
@@ -68,7 +68,7 @@
  * computed by `onPath`.
  */
 
-import javascript
+private import javascript
 private import internal.FlowSteps
 private import internal.AccessPaths
 

--- a/javascript/ql/src/semmle/javascript/dataflow/CustomAbstractValueDefinitions.qll
+++ b/javascript/ql/src/semmle/javascript/dataflow/CustomAbstractValueDefinitions.qll
@@ -8,7 +8,7 @@
  * should be part of the standard library.
  */
 
-import javascript
+private import javascript
 private import internal.AbstractValuesImpl
 private import InferredTypes
 

--- a/javascript/ql/src/semmle/javascript/dataflow/LocalObjects.qll
+++ b/javascript/ql/src/semmle/javascript/dataflow/LocalObjects.qll
@@ -14,7 +14,7 @@ private predicate isEscape(DataFlow::Node escape, string cause) {
   or
   escape = any(ThrowStmt t).getExpr().flow() and cause = "throw"
   or
-  escape = any(DataFlow::GlobalVariable v).getAnAssignedExpr().flow() and cause = "global"
+  escape = any(GlobalVariable v).getAnAssignedExpr().flow() and cause = "global"
   or
   escape = any(DataFlow::PropWrite write).getRhs() and cause = "heap"
   or

--- a/javascript/ql/src/semmle/javascript/dataflow/Nodes.qll
+++ b/javascript/ql/src/semmle/javascript/dataflow/Nodes.qll
@@ -4,8 +4,8 @@
  * parameters.
  */
 
-import javascript
-import semmle.javascript.dependencies.Dependencies
+private import javascript
+private import semmle.javascript.dependencies.Dependencies
 
 /** A data flow node corresponding to an expression. */
 class ExprNode extends DataFlow::ValueNode {

--- a/javascript/ql/src/semmle/javascript/dataflow/Sources.qll
+++ b/javascript/ql/src/semmle/javascript/dataflow/Sources.qll
@@ -6,7 +6,7 @@
  * local tracking within a function.
  */
 
-import javascript
+private import javascript
 private import semmle.javascript.dataflow.TypeTracking
 
 /**

--- a/javascript/ql/src/semmle/javascript/dataflow/TrackedNodes.qll
+++ b/javascript/ql/src/semmle/javascript/dataflow/TrackedNodes.qll
@@ -3,7 +3,7 @@
  * set of data flow nodes.
  */
 
-import javascript
+private import javascript
 private import internal.FlowSteps as FlowSteps
 
 /**

--- a/javascript/ql/src/semmle/javascript/dataflow/TypeInference.qll
+++ b/javascript/ql/src/semmle/javascript/dataflow/TypeInference.qll
@@ -25,7 +25,7 @@
  * read are marked as indefinite.
  */
 
-import javascript
+private import javascript
 import AbstractValues
 import AbstractProperties
 private import InferredTypes

--- a/javascript/ql/src/semmle/javascript/dataflow/TypeTracking.qll
+++ b/javascript/ql/src/semmle/javascript/dataflow/TypeTracking.qll
@@ -6,7 +6,7 @@
  * a given value came from.
  */
 
-import javascript
+private import javascript
 private import internal.FlowSteps
 
 private class PropertyName extends string {

--- a/javascript/ql/src/semmle/javascript/dataflow/internal/AbstractValuesImpl.qll
+++ b/javascript/ql/src/semmle/javascript/dataflow/internal/AbstractValuesImpl.qll
@@ -4,6 +4,7 @@
  * Provides a representation for abstract values.
  */
 
+private import javascript
 import semmle.javascript.dataflow.AbstractValues
 private import semmle.javascript.dataflow.InferredTypes
 import semmle.javascript.dataflow.CustomAbstractValueDefinitions

--- a/javascript/ql/src/semmle/javascript/dataflow/internal/BasicExprTypeInference.qll
+++ b/javascript/ql/src/semmle/javascript/dataflow/internal/BasicExprTypeInference.qll
@@ -5,7 +5,7 @@
  * and property accesses.
  */
 
-import javascript
+private import javascript
 private import AbstractValuesImpl
 private import semmle.javascript.dataflow.InferredTypes
 

--- a/javascript/ql/src/semmle/javascript/dataflow/internal/InterModuleTypeInference.qll
+++ b/javascript/ql/src/semmle/javascript/dataflow/internal/InterModuleTypeInference.qll
@@ -4,7 +4,7 @@
  * Provides classes implementing type inference across imports.
  */
 
-import javascript
+private import javascript
 private import AbstractValuesImpl
 private import semmle.javascript.dataflow.InferredTypes
 private import AbstractPropertiesImpl

--- a/javascript/ql/src/semmle/javascript/dataflow/internal/InterProceduralTypeInference.qll
+++ b/javascript/ql/src/semmle/javascript/dataflow/internal/InterProceduralTypeInference.qll
@@ -4,9 +4,9 @@
  * Provides classes implementing type inference across function calls.
  */
 
-import javascript
+private import javascript
 import AbstractValuesImpl
-import semmle.javascript.dataflow.LocalObjects
+private import semmle.javascript.dataflow.LocalObjects
 
 /**
  * Flow analysis for `this` expressions inside functions.

--- a/javascript/ql/src/semmle/javascript/dataflow/internal/PropertyTypeInference.qll
+++ b/javascript/ql/src/semmle/javascript/dataflow/internal/PropertyTypeInference.qll
@@ -4,7 +4,7 @@
  * Provides classes implementing type inference for properties.
  */
 
-import javascript
+private import javascript
 import semmle.javascript.dataflow.AbstractProperties
 private import AbstractPropertiesImpl
 private import AbstractValuesImpl

--- a/javascript/ql/src/semmle/javascript/dataflow/internal/VariableTypeInference.qll
+++ b/javascript/ql/src/semmle/javascript/dataflow/internal/VariableTypeInference.qll
@@ -4,7 +4,7 @@
  * Provides classes implementing type inference for variables.
  */
 
-import javascript
+private import javascript
 private import AbstractValuesImpl
 private import semmle.javascript.dataflow.InferredTypes
 private import semmle.javascript.dataflow.Refinements


### PR DESCRIPTION
This PR puts a stop to recursive imports of `javascript.qll` in `DataFlow`, through paths like:

```
// javascript.qll
import semmle.javascript.DataFlow

// DataFlow.qll
module DataFlow {
  import Nodes
  import Sources
  import TypeInference
  import Configuration
  import TrackedNodes
  import TypeTracking
}

// Nodes.qll
import javascript
```

So no more shenanigans like
```
import javascript

from DataFlow::DataFlow::DataFlow::DataFlow::DataFlow::DataFlow::DataFlow::Node node
select node
```

More importantly, `DataFlow::InvokeExpr` no longer works, which should help to avoid confusion regarding what's actually part of the data flow library.

Currently the `AnalyzedNode` hierarchy is still exposed through `DataFlow::` which isn't a huge problem as these classes are subclasses of data flow nodes.

