### PR TITLE
Python: Fix missing include in `FCommentedOutCode.qhelp`.

### DIFF
--- a/python/ql/src/Lexical/FCommentedOutCode.qhelp
+++ b/python/ql/src/Lexical/FCommentedOutCode.qhelp
@@ -3,5 +3,6 @@
   "qhelp.dtd">
 <qhelp>
   <include src="CommentedOutCodeMetricOverview.qhelp" />
-  <include src="CommentedOutCodeCommon.qhelp" />
+  <include src="CommentedOutCodeExample.qhelp" />
+  <include src="CommentedOutCodeReferences.qhelp" />
 </qhelp>


### PR DESCRIPTION
This was accidentally left out of #1588 and caused the build to fail.