### PR TITLE
Java: Add toString override for SwitchExpr.

### DIFF
--- a/java/ql/src/semmle/code/java/Expr.qll
+++ b/java/ql/src/semmle/code/java/Expr.qll
@@ -1121,6 +1121,9 @@ class SwitchExpr extends Expr, @switchexpr {
       break.(JumpStmt).getTarget() = this and result = break.getValue()
     )
   }
+
+  /** Gets a printable representation of this expression. */
+  override string toString() { result = "switch (...)" }
 }
 
 /** A parenthesised expression. */


### PR DESCRIPTION
Every other `Expr` kind has a similar override - this was just missed when adding `SwitchExpr`.