### PR TITLE
JavaScript: Do not propagate taint through `for`-`in` loop variables.

### DIFF
--- a/change-notes/1.22/analysis-javascript.md
+++ b/change-notes/1.22/analysis-javascript.md
@@ -12,6 +12,8 @@
   - [remote-exec](https://www.npmjs.com/package/remote-exec)
 
 * Support for tracking data flow and taint through getter functions (that is, functions that return a property of one of their arguments) and through the receiver object of method calls has been improved. This may produce more security alerts.
+
+* Taint tracking through object property names has been made more precise, resulting in fewer false positive results.
   
 ## New queries
 

--- a/javascript/ql/src/semmle/javascript/dataflow/TaintTracking.qll
+++ b/javascript/ql/src/semmle/javascript/dataflow/TaintTracking.qll
@@ -231,10 +231,10 @@ module TaintTracking {
       succ.(DataFlow::PropRead).getBase() = pred
       or
       // iterating over a tainted iterator taints the loop variable
-      exists(EnhancedForLoop efl |
-        this = DataFlow::valueNode(efl.getIterationDomain()) and
+      exists(ForOfStmt fos |
+        this = DataFlow::valueNode(fos.getIterationDomain()) and
         pred = this and
-        succ = DataFlow::ssaDefinitionNode(SSA::definition(efl.getIteratorExpr()))
+        succ = DataFlow::ssaDefinitionNode(SSA::definition(fos.getIteratorExpr()))
       )
     }
   }

--- a/javascript/ql/test/query-tests/Security/CWE-079/tst.js
+++ b/javascript/ql/test/query-tests/Security/CWE-079/tst.js
@@ -285,3 +285,10 @@ function testCreateContextualFragment() {
     var documentFragment = range.createContextualFragment(tainted); // NOT OK
     document.body.appendChild(documentFragment);
 }
+
+function flowThroughPropertyNames() {
+    var obj = {};
+    obj[Math.random()] = window.name;
+    for (var p in obj)
+      $(p); // OK
+}


### PR DESCRIPTION
When combined with the step that taints an object `o` if we assign into a dynamically computed property of `o`, this step caused a false positive in an important project. Removing it gets rid of a [handful](https://git.semmle.com/max/dist-compare-reports/blob/master/js/dont-taint-for-in/report.md) of results that I'm not sad to lose, in particular including the one on the important project.

I also tried removing the other taint step instead, which lost us [even more](https://git.semmle.com/max/dist-compare-reports/blob/master/js/dont-taint-object-on-unknown-prop-write/report.md) results, some of which seemed worth keeping (though I doubt they are exploitable or anything), so I think it's better not to go down that route.

Ultimately we'll want to distinguish between objects where only the values are tainted and objects where the keys may also be tainted (because, say, they result from `JSON.parse`), but that's a little more difficult to implement, so I'd suggest we go with the simple version first.