### PR TITLE
JavaScript: Add concrete syntax examples to `JSDoc`, `RegExp`, `Tokens`, `Variables` and `XML`.

### DIFF
--- a/javascript/ql/src/semmle/javascript/JSDoc.qll
+++ b/javascript/ql/src/semmle/javascript/JSDoc.qll
@@ -4,6 +4,17 @@ import javascript
 
 /**
  * A JSDoc comment.
+ *
+ * Example:
+ *
+ * <pre>
+ * /**
+ *  * An example JSDoc comment documenting a constructor function.
+ *  *
+ *  * @constructor
+ *  * @param {Object=} options An object literal with options.
+ *  *&#47;
+ * </pre>
  */
 class JSDoc extends @jsdoc, Locatable {
   override Location getLocation() { hasLocation(this, result) }
@@ -28,6 +39,20 @@ class JSDoc extends @jsdoc, Locatable {
 
 /**
  * A program element that can have a JSDoc comment.
+ *
+ * Example:
+ *
+ * <pre>
+ * /**
+ *  * An example JSDoc comment documenting a constructor function.
+ *  *
+ *  * @constructor
+ *  * @param {Object=} options An object literal with options.
+ *  *&#47;
+ * function MyConstructor(options) {  // documentable
+ *   this.options = options || {};
+ * }
+ * </pre>
  */
 abstract class Documentable extends ASTNode {
   /** Gets the JSDoc comment for this element, if any. */
@@ -38,6 +63,13 @@ abstract class Documentable extends ASTNode {
 /**
  * A syntactic element that a JSDoc type expression may be nested in, that is,
  * either a JSDoc tag or another JSDoc type expression.
+ *
+ * Examples:
+ *
+ * ```
+ * // the `@param` tag and the `...=` type expressions are JSDoc type expression parents
+ * @param {Object=} options An object literal with options.
+ * ```
  */
 class JSDocTypeExprParent extends @jsdoc_type_expr_parent, Locatable {
   override Location getLocation() { hasLocation(this, result) }
@@ -46,7 +78,14 @@ class JSDocTypeExprParent extends @jsdoc_type_expr_parent, Locatable {
 }
 
 /**
- * A JSDoc tag such as `@param Object options An object literal with options.`
+ * A JSDoc tag.
+ *
+ * Examples:
+ *
+ * ```
+ * @param {Object=} options An object literal with options.
+ * @return {!Server}
+ * ```
  */
 class JSDocTag extends @jsdoc_tag, JSDocTypeExprParent {
   /** Gets the tag title; for instance, the title of a `@param` tag is `"param"`. */
@@ -90,6 +129,12 @@ class JSDocTag extends @jsdoc_tag, JSDocTypeExprParent {
 
 /**
  * A `@param` tag.
+ *
+ * Example:
+ *
+ * ```
+ * @param {Object=} options An object literal with options.
+ * ```
  */
 class JSDocParamTag extends JSDocTag {
   JSDocParamTag() { getTitle().regexpMatch("param|arg(ument)?") }
@@ -104,6 +149,14 @@ class JSDocParamTag extends JSDocTag {
 
 /**
  * A JSDoc type expression.
+ *
+ * Examples:
+ *
+ * ```
+ * *
+ * Array<string>
+ * !Object
+ * ```
  */
 class JSDocTypeExpr extends @jsdoc_type_expr, JSDocTypeExprParent, TypeAnnotation {
   /**
@@ -142,32 +195,81 @@ class JSDocTypeExpr extends @jsdoc_type_expr, JSDocTypeExprParent, TypeAnnotatio
   override TopLevel getTopLevel() { result = getEnclosingStmt().getTopLevel() }
 }
 
-/** An `any` type expression `*`. */
+/**
+ * An `any` type expression.
+ *
+ * Example:
+ *
+ * ```
+ * *
+ * ```
+ */
 class JSDocAnyTypeExpr extends @jsdoc_any_type_expr, JSDocTypeExpr {
   override predicate isAny() { any() }
 }
 
-/** A null type expression. */
+/**
+ * A null type expression.
+ *
+ * Example:
+ *
+ * ```
+ * null
+ * ```
+ */
 class JSDocNullTypeExpr extends @jsdoc_null_type_expr, JSDocTypeExpr {
   override predicate isNull() { any() }
 }
 
-/** A type expression representing the type of `undefined`. */
+/**
+ * A type expression representing the type of `undefined`.
+ *
+ * Example:
+ *
+ * ```
+ * undefined
+ * ```
+ */
 class JSDocUndefinedTypeExpr extends @jsdoc_undefined_type_expr, JSDocTypeExpr {
   override predicate isUndefined() { any() }
 }
 
-/** A type expression representing an unknown type `?`. */
+/**
+ * A type expression representing an unknown type.
+ *
+ * Example:
+ *
+ * ```
+ * ?
+ * ```
+ */
 class JSDocUnknownTypeExpr extends @jsdoc_unknown_type_expr, JSDocTypeExpr {
   override predicate isUnknownKeyword() { any() }
 }
 
-/** A type expression representing the void type. */
+/**
+ * A type expression representing the void type.
+ *
+ * Example:
+ *
+ * ```
+ * void
+ * ```
+ */
 class JSDocVoidTypeExpr extends @jsdoc_void_type_expr, JSDocTypeExpr {
   override predicate isVoid() { any() }
 }
 
-/** A type expression referring to a named type. */
+/**
+ * A type expression referring to a named type.
+ *
+ * Example:
+ *
+ * ```
+ * string
+ * Object
+ * ```
+ */
 class JSDocNamedTypeExpr extends @jsdoc_named_type_expr, JSDocTypeExpr {
   /** Gets the name of the type the expression refers to. */
   string getName() { result = toString() }
@@ -211,7 +313,13 @@ class JSDocNamedTypeExpr extends @jsdoc_named_type_expr, JSDocTypeExpr {
 }
 
 /**
- * An applied type expression such as `Array<string>`.
+ * An applied type expression.
+ *
+ * Example:
+ *
+ * ```
+ * Array<string>
+ * ```
  */
 class JSDocAppliedTypeExpr extends @jsdoc_applied_type_expr, JSDocTypeExpr {
   /** Gets the head type expression, such as `Array` in `Array<string>`. */
@@ -237,7 +345,13 @@ class JSDocAppliedTypeExpr extends @jsdoc_applied_type_expr, JSDocTypeExpr {
 }
 
 /**
- * A nullable type expression such as `?number`.
+ * A nullable type expression.
+ *
+ * Example:
+ *
+ * ```
+ * ?Array
+ * ```
  */
 class JSDocNullableTypeExpr extends @jsdoc_nullable_type_expr, JSDocTypeExpr {
   /** Gets the argument type expression. */
@@ -250,7 +364,13 @@ class JSDocNullableTypeExpr extends @jsdoc_nullable_type_expr, JSDocTypeExpr {
 }
 
 /**
- * A non-nullable type expression such as `!number`.
+ * A non-nullable type expression.
+ *
+ * Example:
+ *
+ * ```
+ * !Array
+ * ```
  */
 class JSDocNonNullableTypeExpr extends @jsdoc_non_nullable_type_expr, JSDocTypeExpr {
   /** Gets the argument type expression. */
@@ -263,7 +383,13 @@ class JSDocNonNullableTypeExpr extends @jsdoc_non_nullable_type_expr, JSDocTypeE
 }
 
 /**
- * A record type expression such as `{ x: number, y: string }`.
+ * A record type expression.
+ *
+ * Example:
+ *
+ * ```
+ * { x: number, y: string }
+ * ```
  */
 class JSDocRecordTypeExpr extends @jsdoc_record_type_expr, JSDocTypeExpr {
   /** Gets the name of the `i`th field of the record type. */
@@ -282,7 +408,13 @@ class JSDocRecordTypeExpr extends @jsdoc_record_type_expr, JSDocTypeExpr {
 }
 
 /**
- * An array type expression such as `[string]`.
+ * An array type expression.
+ *
+ * Example:
+ *
+ * ```
+ * [string]
+ * ```
  */
 class JSDocArrayTypeExpr extends @jsdoc_array_type_expr, JSDocTypeExpr {
   /** Gets the type of the `i`th element of this array type. */
@@ -293,7 +425,13 @@ class JSDocArrayTypeExpr extends @jsdoc_array_type_expr, JSDocTypeExpr {
 }
 
 /**
- * A union type expression such as `number|string`.
+ * A union type expression.
+ *
+ * Example:
+ *
+ * ```
+ * number|string
+ * ```
  */
 class JSDocUnionTypeExpr extends @jsdoc_union_type_expr, JSDocTypeExpr {
   /** Gets one of the type alternatives of this union type. */
@@ -303,7 +441,13 @@ class JSDocUnionTypeExpr extends @jsdoc_union_type_expr, JSDocTypeExpr {
 }
 
 /**
- * A function type expression such as `function(string): number`.
+ * A function type expression.
+ *
+ * Example:
+ *
+ * ```
+ * function(string): number
+ * ```
  */
 class JSDocFunctionTypeExpr extends @jsdoc_function_type_expr, JSDocTypeExpr {
   /** Gets the result type of this function type. */
@@ -323,7 +467,13 @@ class JSDocFunctionTypeExpr extends @jsdoc_function_type_expr, JSDocTypeExpr {
 }
 
 /**
- * An optional parameter type such as `number=`.
+ * An optional parameter type.
+ *
+ * Example:
+ *
+ * ```
+ * number=
+ * ```
  */
 class JSDocOptionalParameterTypeExpr extends @jsdoc_optional_type_expr, JSDocTypeExpr {
   /** Gets the underlying type of this optional type. */
@@ -333,7 +483,13 @@ class JSDocOptionalParameterTypeExpr extends @jsdoc_optional_type_expr, JSDocTyp
 }
 
 /**
- * A rest parameter type such as `string...`.
+ * A rest parameter type.
+ *
+ * Example:
+ *
+ * ```
+ * string...
+ * ```
  */
 class JSDocRestParameterTypeExpr extends @jsdoc_rest_type_expr, JSDocTypeExpr {
   /** Gets the underlying type of this rest parameter type. */

--- a/javascript/ql/src/semmle/javascript/Tokens.qll
+++ b/javascript/ql/src/semmle/javascript/Tokens.qll
@@ -4,7 +4,18 @@
 
 import javascript
 
-/** A token occurring in a piece of JavaScript source code. */
+/**
+ * A token occurring in a piece of JavaScript source code.
+ *
+ * Examples:
+ *
+ * ```
+ * x
+ * /\w+/
+ * 12.3
+ * ;
+ * ```
+ */
 class Token extends Locatable, @token {
   override Location getLocation() { hasLocation(this, result) }
 
@@ -32,26 +43,95 @@ class Token extends Locatable, @token {
 /** An end-of-file token. */
 class EOFToken extends Token, @token_eof { }
 
-/** A null literal token. */
+/**
+ * A null literal token.
+ *
+ * Example:
+ *
+ * ```
+ * null
+ * ```
+ */
 class NullLiteralToken extends Token, @token_null_literal { }
 
-/** A Boolean literal token, that is, `true` or `false`. */
+/**
+ * A Boolean literal token.
+ *
+ * Examples:
+ *
+ * ```
+ * true
+ * false
+ * ```
+ */
 class BooleanLiteralToken extends Token, @token_boolean_literal { }
 
-/** A numeric literal token such as `1` or `2.3`. */
+/**
+ * A numeric literal token.
+ *
+ * Examples:
+ *
+ * ```
+ * 1
+ * 2.3
+ * ```
+ */
 class NumericLiteralToken extends Token, @token_numeric_literal { }
 
-/** A string literal token such as `"hello"` or `'world!'`. */
+/**
+ * A string literal token.
+ *
+ * Examples:
+ *
+ * ```
+ * "hello"
+ * 'world!'
+ * ```
+ */
 class StringLiteralToken extends Token, @token_string_literal { }
 
-/** A regular expression literal token such as `/\w+/`. */
+/**
+ * A regular expression literal token.
+ *
+ * Example:
+ *
+ * ```
+ * /\w+/
+ * ```
+ */
 class RegularExpressionToken extends Token, @token_regular_expression { }
 
-/** An identifier token such as `name`. */
+/**
+ * An identifier token.
+ *
+ * Example:
+ *
+ * ```
+ * x
+ * ```
+ */
 class IdentifierToken extends Token, @token_identifier { }
 
-/** A keyword token such as `function` or `this`. */
+/**
+ * A keyword token.
+ *
+ * Examples:
+ *
+ * ```
+ * function
+ * this
+ * ```
+ */
 class KeywordToken extends Token, @token_keyword { }
 
-/** A punctuator token such as `;` or `+`. */
+/**
+ * A punctuator token.
+ *
+ * Examples:
+ *
+ * ```
+ * ;
+ * +
+ * ```
+ */
 class PunctuatorToken extends Token, @token_punctuator { }

--- a/javascript/ql/src/semmle/javascript/Variables.qll
+++ b/javascript/ql/src/semmle/javascript/Variables.qll
@@ -214,7 +214,18 @@ class ArgumentsVariable extends Variable {
   Function getFunction() { result = getScope().getFunction() }
 }
 
-/** An identifier that refers to a variable, either in a declaration or in a variable access. */
+/**
+ * An identifier that refers to a variable, either in a declaration or in a variable access.
+ *
+ * Examples:
+ *
+ * ```
+ * function f(o) {                 // `f` and `o` are variable references
+ *   var w = 0, { x : y, z } = o;  // `w`, `y`, `z` and `o` are variable references; `x` is not
+ *   o = null;                     // `o` is a variable reference; `null` is not
+ * }
+ * ```
+ */
 class VarRef extends @varref, Identifier, BindingPattern, LexicalRef {
   /** Gets the variable this identifier refers to. */
   override Variable getVariable() { none() } // Overriden in VarAccess and VarDecl
@@ -228,7 +239,18 @@ class VarRef extends @varref, Identifier, BindingPattern, LexicalRef {
   override Expr getUnderlyingReference() { result = this }
 }
 
-/** An identifier that refers to a variable in a non-declaring position. */
+/**
+ * An identifier that refers to a variable in a non-declaring position.
+ *
+ * Examples:
+ *
+ * ```
+ * function f(o) {
+ *   var w = 0, { x : y, z } = o;  // `o` is a variable access
+ *   o = null;                     // `o` is a variable access
+ * }
+ * ```
+ */
 class VarAccess extends @varaccess, VarRef, LexicalAccess {
   /**
    * Gets the variable this identifier refers to.
@@ -252,7 +274,13 @@ class VarAccess extends @varaccess, VarRef, LexicalAccess {
 }
 
 /**
- * An identifier that occurs in a named export declaration, such as in `export { A }`.
+ * An identifier that occurs in a named export declaration.
+ *
+ * Example:
+ *
+ * ```
+ * export { A };
+ * ```
  *
  * Such an identifier may refer to a variable, type, or namespace, or a combination of these.
  */
@@ -298,19 +326,34 @@ class PurelyLocalVariable extends LocalVariable {
   PurelyLocalVariable() { not isCaptured() }
 }
 
-/** An identifier that refers to a global variable. */
+/**
+ * An identifier that refers to a global variable.
+ *
+ * Examples:
+ *
+ * ```
+ * NaN
+ * undefined
+ * ```
+ */
 class GlobalVarAccess extends VarAccess {
   GlobalVarAccess() { getVariable().isGlobal() }
 }
 
 /**
- * A binding pattern, i.e., either an identifier or a destructuring pattern.
+ * A binding pattern, that is, either an identifier or a destructuring pattern.
+ *
+ * Examples:
+ *
+ * ```
+ * function f(x, { y: z }, ...rest) {  // `x`, `{ y: z }`, `z` and `rest` are binding patterns
+ *   var [ a, b ] = rest;              // `[ a, b ]`, `a` and `b` are binding patterns
+ *   var c;                            // `c` is a binding pattern
+ * }
+ * ```
  *
  * Binding patterns can appear on the left hand side of assignments or in
- * variable or parameter declarations. They bind one or more variables to
- * values, either by means of a regular assignment as in `x = 42`, or
- * through a destructuring assignment as in `[x, y] = a`; see Chapter 12 of
- * the ECMAScript standard for more details.
+ * variable or parameter declarations.
  */
 class BindingPattern extends @pattern, Expr {
   /** Gets the name of this binding pattern if it is an identifier. */
@@ -347,13 +390,34 @@ class BindingPattern extends @pattern, Expr {
   }
 }
 
-/** A destructuring pattern, that is, either an array pattern or an object pattern. */
+/**
+ * A destructuring pattern, that is, either an array pattern or an object pattern.
+ *
+ * Examples:
+ *
+ * ```
+ * function f(x, { y: z }, ...rest) {  // `{ y: z }` is a destructuring pattern
+ *   var [ a, b ] = rest;              // `[ a, b ]` is a destructuring pattern
+ *   var c;
+ * }
+ * ```
+ */
 abstract class DestructuringPattern extends BindingPattern {
   /** Gets the rest pattern of this destructuring pattern, if any. */
   abstract Expr getRest();
 }
 
-/** An identifier that declares a variable. */
+/**
+ * An identifier that declares a variable.
+ *
+ * Examples:
+ *
+ * ```
+ * function f(o) {                 // `f` and `o` are variable declarations
+ *   var w = 0, { x : y, z } = o;  // `w`, `y` and `z` are variable declarations
+ *   o = null;
+ * }
+ */
 class VarDecl extends @vardecl, VarRef, LexicalDecl {
   override Variable getVariable() { decl(this, result) }
 
@@ -367,12 +431,32 @@ class VarDecl extends @vardecl, VarRef, LexicalDecl {
   }
 }
 
-/** An identifier that declares a global variable. */
+/**
+ * An identifier that declares a global variable.
+ *
+ * Example:
+ *
+ * ```
+ * var m;  // `m` is a global variable declaration if this is a top-level statement
+ *         // (and not in a module)
+ * ```
+ */
 class GlobalVarDecl extends VarDecl {
   GlobalVarDecl() { getVariable() instanceof GlobalVariable }
 }
 
-/** An array pattern. */
+/**
+ * An array pattern.
+  *
+ * Example:
+ *
+ * ```
+ * function f(x, { y: z }, ...rest) {
+ *   var [ a, b ] = rest;              // `[ a, b ]` is an array pattern
+ *   var c;
+ * }
+ * ```
+*/
 class ArrayPattern extends DestructuringPattern, @arraypattern {
   /** Gets the `i`th element of this array pattern. */
   Expr getElement(int i) {
@@ -417,7 +501,18 @@ class ArrayPattern extends DestructuringPattern, @arraypattern {
   }
 }
 
-/** An object pattern. */
+/**
+ * An object pattern.
+ *
+ * Example:
+ *
+ * ```
+ * function f(x, { y: z }, ...rest) {  // `{ y: z }` is an object pattern
+ *   var [ a, b ] = rest;
+ *   var c;
+ * }
+ * ```
+ */
 class ObjectPattern extends DestructuringPattern, @objectpattern {
   /** Gets the `i`th property pattern in this object pattern. */
   PropertyPattern getPropertyPattern(int i) { properties(result, this, i, _, _) }
@@ -445,7 +540,18 @@ class ObjectPattern extends DestructuringPattern, @objectpattern {
   }
 }
 
-/** A property pattern in an object pattern. */
+/**
+ * A property pattern in an object pattern.
+  *
+ * Examples:
+ *
+ * ```
+ * function f(x, { y: z }, ...rest) {  // `y: z` is a property pattern
+ *   var [ a, b ] = rest;
+ *   var c;
+ * }
+ * ```
+*/
 class PropertyPattern extends @property, ASTNode {
   PropertyPattern() {
     // filter out ordinary properties
@@ -495,7 +601,17 @@ class PropertyPattern extends @property, ASTNode {
   }
 }
 
-/** A variable declarator declaring a local or global variable. */
+/**
+ * A variable declarator declaring a local or global variable.
+ *
+ * Examples:
+ *
+ * ```
+ * var
+ *   x,      // variable declarator
+ *   y = z;  // variable declarator
+ * ```
+ */
 class VariableDeclarator extends Expr, @vardeclarator {
   /** Gets the pattern specifying the declared variable(s). */
   BindingPattern getBindingPattern() { result = this.getChildExpr(0) }
@@ -537,6 +653,17 @@ private class DecoratorList extends Expr, @decorator_list {
 /**
  * A program element that declares parameters, that is, either a function or
  * a catch clause.
+ *
+ * Examples:
+ *
+ * ```
+ * function f(x, y) {  // a parameterized element
+ *   try {
+ *     g();
+ *   } catch(e) {      // a parameterized element
+ *   }
+ * }
+ * ```
  */
 class Parameterized extends @parameterized, Documentable {
   /** Gets a parameter declared by this element. */
@@ -552,7 +679,18 @@ class Parameterized extends @parameterized, Documentable {
   }
 }
 
-/** A parameter declaration. */
+/**
+ * A parameter declaration.
+ *
+ * Examples:
+ *
+ * ```
+ * function f(x, { y: z }, ...rest) {  // `x`, `{ y: z }` and `rest` are parameter declarations
+ *   var [ a, b ] = rest;
+ *   var c;
+ * }
+ * ```
+ */
 class Parameter extends BindingPattern {
   Parameter() {
     exists(Parameterized p, int n |
@@ -613,7 +751,18 @@ class Parameter extends BindingPattern {
   }
 }
 
-/** A parameter declaration that is not an object or array pattern. */
+/**
+ * A parameter declaration that is not an object or array pattern.
+ *
+ * Examples:
+ *
+ * ```
+ * function f(x, { y: z }, ...rest) {  // `x` and `rest` are simple parameter declarations
+ *   var [ a, b ] = rest;
+ *   var c;
+ * }
+ * ```
+ */
 class SimpleParameter extends Parameter, VarDecl {
   override predicate isLValue() { Parameter.super.isLValue() }
 
@@ -644,10 +793,15 @@ class SimpleParameter extends Parameter, VarDecl {
 }
 
 /**
- * A constructor parameter that induces a field in its class, such as the parameter `x` in:
+ * A constructor parameter that induces a field in its class.
+ *
+ * Example:
+ *
  * ```
  * class C {
- *   constructor(public x: number) {}
+ *   constructor(
+ *     public x: number  // constructor parameter
+ *   ) {}
  * }
  * ```
  */
@@ -669,6 +823,15 @@ class DeclarationSpace extends string {
  * A name that is declared in a particular scope.
  *
  * This can be a variable or a local name for a TypeScript type or namespace.
+ *
+ * Examples:
+ *
+ * ```
+ * // `id`, `x` and `String` are lexical names
+ * function id(x: String) : any {
+ *   return x;
+ * }
+ * ``` 
  */
 class LexicalName extends @lexical_name {
   /** Gets the scope in which this name was declared. */
@@ -690,6 +853,14 @@ class LexicalName extends @lexical_name {
 
 /**
  * An identifier that refers to a variable, type, or namespace, or a combination of these.
+ *
+ * Example:
+ *
+ * ```
+ * function id(x: String) : any {  // `id`, `x` and `String` are lexical references
+ *   return x;                     // `x` is a lexical reference
+ * }
+ * ```
  */
 class LexicalRef extends Identifier, @lexical_ref {
   /**
@@ -710,11 +881,27 @@ class LexicalRef extends Identifier, @lexical_ref {
 
 /**
  * An identifier that declares a variable, type, or namespace, or a combination of these.
+ *
+ * Example:
+ *
+ * ```
+ * function id(x: number) : any {  // `id` and `x` are lexical declarations
+ *   return x;
+ * }
+ * ```
  */
 class LexicalDecl extends LexicalRef, @lexical_decl { }
 
 /**
  * An identifier that refers to a variable, type, or namespace, or a combination of these,
  * in a non-declaring position.
+ *
+ * Example:
+ *
+ * ```
+ * function id(x: String) : any {  // `String` is a lexical access
+ *   return x;                     // `x` is a lexical access
+ * }
+ * ```
  */
 class LexicalAccess extends LexicalRef, @lexical_access { }

--- a/javascript/ql/src/semmle/javascript/XML.qll
+++ b/javascript/ql/src/semmle/javascript/XML.qll
@@ -121,7 +121,17 @@ class XMLFile extends XMLParent, File {
   XMLDTD getADTD() { xmlDTDs(result, _, _, _, this) }
 }
 
-/** A "Document Type Definition" of an XML file. */
+/**
+ * An XML document type definition (DTD).
+ *
+ * Example:
+ *
+ * ```
+ * <!ELEMENT person (firstName, lastName?)>
+ * <!ELEMENT firstName (#PCDATA)>
+ * <!ELEMENT lastName (#PCDATA)>
+ * ```
+ */
 class XMLDTD extends @xmldtd {
   /** Gets the name of the root element of this DTD. */
   string getRoot() { xmlDTDs(this, result, _, _, _) }
@@ -148,7 +158,17 @@ class XMLDTD extends @xmldtd {
   }
 }
 
-/** An XML tag in an XML file. */
+/**
+ * An XML element in an XML file.
+ *
+ * Example:
+ *
+ * ```
+ * <manifest xmlns:android="http://schemas.android.com/apk/res/android"
+ *           package="com.example.exampleapp" android:versionCode="1">
+ * </manifest>
+ * ```
+ */
 class XMLElement extends @xmlelement, XMLParent, XMLLocatable {
   /** Holds if this XML element has the given `name`. */
   predicate hasName(string name) { name = getName() }
@@ -193,7 +213,16 @@ class XMLElement extends @xmlelement, XMLParent, XMLLocatable {
   override string toString() { result = XMLParent.super.toString() }
 }
 
-/** An attribute that occurs inside an XML element. */
+/**
+ * An attribute that occurs inside an XML element.
+  *
+ * Examples:
+ *
+ * ```
+ * package="com.example.exampleapp"
+ * android:versionCode="1"
+ * ```
+*/
 class XMLAttribute extends @xmlattribute, XMLLocatable {
   /** Gets the name of this attribute. */
   string getName() { xmlAttrs(this, _, result, _, _, _) }
@@ -214,7 +243,15 @@ class XMLAttribute extends @xmlattribute, XMLLocatable {
   override string toString() { result = this.getName() + "=" + this.getValue() }
 }
 
-/** A namespace used in an XML file */
+/**
+ * A namespace used in an XML file.
+ *
+ * Example:
+ *
+ * ```
+ * xmlns:android="http://schemas.android.com/apk/res/android"
+ * ```
+ */
 class XMLNamespace extends @xmlnamespace {
   /** Gets the prefix of this namespace. */
   string getPrefix() { xmlNs(this, result, _, _) }
@@ -233,7 +270,15 @@ class XMLNamespace extends @xmlnamespace {
   }
 }
 
-/** A comment of the form `<!-- ... -->` is an XML comment. */
+/**
+ * A comment in an XML file.
+ *
+ * Example:
+ *
+ * ```
+ * <!-- This is a comment. -->
+ * ```
+ */
 class XMLComment extends @xmlcomment, XMLLocatable {
   /** Gets the text content of this XML comment. */
   string getText() { xmlComments(this, result, _, _) }
@@ -248,6 +293,12 @@ class XMLComment extends @xmlcomment, XMLLocatable {
 /**
  * A sequence of characters that occurs between opening and
  * closing tags of an XML element, excluding other elements.
+ *
+ * Example:
+ *
+ * ```
+ * <content>This is a sequence of characters.</content>
+ * ```
  */
 class XMLCharacters extends @xmlcharacters, XMLLocatable {
   /** Gets the content of this character sequence. */


### PR DESCRIPTION
I think this covers most of the remaining AST classes, except for TypeScript.