### PR TITLE
Change `__builtin_types` to `__builtin_types_compatible_p`

### DIFF
--- a/cpp/ql/src/semmle/code/cpp/exprs/BuiltInOperations.qll
+++ b/cpp/ql/src/semmle/code/cpp/exprs/BuiltInOperations.qll
@@ -210,7 +210,7 @@ class BuiltInOperationIsUnion extends BuiltInOperation, @isunionexpr {
 }
 
 /**
- * DEPRECATED: Use `BuiltInOperationBuiltInTypesCompatibleP instead.
+ * DEPRECATED: Use `BuiltInOperationBuiltInTypesCompatibleP` instead.
  */
 deprecated class BuiltInOperationBuiltInTypes = BuiltInOperationBuiltInTypesCompatibleP;
 

--- a/cpp/ql/src/semmle/code/cpp/exprs/BuiltInOperations.qll
+++ b/cpp/ql/src/semmle/code/cpp/exprs/BuiltInOperations.qll
@@ -210,6 +210,11 @@ class BuiltInOperationIsUnion extends BuiltInOperation, @isunionexpr {
 }
 
 /**
+ * DEPRECATED: Use `BuiltInOperationBuiltInTypesCompatibleP instead.
+ */
+deprecated class BuiltInOperationBuiltInTypes = BuiltInOperationBuiltInTypesCompatibleP;
+
+/**
  * A C++ `__builtin_types_compatible_p` expression (used by some implementations of the type_traits header).
  */
 class BuiltInOperationBuiltInTypesCompatibleP extends BuiltInOperation, @typescompexpr {

--- a/cpp/ql/src/semmle/code/cpp/exprs/BuiltInOperations.qll
+++ b/cpp/ql/src/semmle/code/cpp/exprs/BuiltInOperations.qll
@@ -210,10 +210,10 @@ class BuiltInOperationIsUnion extends BuiltInOperation, @isunionexpr {
 }
 
 /**
- * A C++ `__builtin_types` expression (used by some implementations of the type_traits header).
+ * A C++ `__builtin_types_compatible_p` expression (used by some implementations of the type_traits header).
  */
-class BuiltInOperationBuiltInTypes extends BuiltInOperation, @typescompexpr {
-  override string toString() { result = "__builtin_types" }
+class BuiltInOperationBuiltInTypesCompatibleP extends BuiltInOperation, @typescompexpr {
+  override string toString() { result = "__builtin_types_compatible_p" }
 }
 
 /**

--- a/cpp/ql/test/library-tests/builtins/builtins/builtins.expected
+++ b/cpp/ql/test/library-tests/builtins/builtins/builtins.expected
@@ -1,4 +1,6 @@
 | choose_expr.c:3:13:3:42 | __builtin_choose_expr |
+| types.c:4:9:4:57 | __builtin_types_compatible_p |
+| types.c:6:16:6:65 | __builtin_types_compatible_p |
 | varargs.c:7:5:7:32 | __builtin_va_start |
 | varargs.c:9:13:9:37 | __builtin_va_arg |
 | varargs.c:11:5:11:24 | __builtin_va_end |

--- a/cpp/ql/test/library-tests/builtins/builtins/types.c
+++ b/cpp/ql/test/library-tests/builtins/builtins/types.c
@@ -1,0 +1,11 @@
+
+int main(int argc, char **argv) {
+    char *s;
+    if (__builtin_types_compatible_p(__typeof__(s), long)) {
+        puts("long");
+    } else if (__builtin_types_compatible_p(__typeof__(s), char*)) {
+        puts("str");
+    }
+    return (0);
+};
+


### PR DESCRIPTION
Noting that (1) `__builtin_types` has no known definition or uses and (2) the QL library does not handle `__builtin_types_compatible_p`, I propose to rename the former to the latter.