### PR TITLE
JavaScript: Deprecate multi-argument `isBarrier` and `isSanitizer` predicates.

### DIFF
--- a/change-notes/1.22/analysis-javascript.md
+++ b/change-notes/1.22/analysis-javascript.md
@@ -31,3 +31,6 @@
 
 - The `getName()` predicate on functions and classes now gets a name
   inferred from the context if the function or class was not declared with a name.
+- The two-argument and three-argument variants of `DataFlow::Configuration::isBarrier` and
+  `TaintTracking::Configuration::isSanitizer` have been deprecated. Overriding them no
+  longer has any effect. Use `isBarrierEdge` and `isSanitizerEdge` instead.

--- a/javascript/ql/src/semmle/javascript/dataflow/Configuration.qll
+++ b/javascript/ql/src/semmle/javascript/dataflow/Configuration.qll
@@ -157,14 +157,14 @@ abstract class Configuration extends string {
    *
    * Holds if flow from `src` to `trg` is prohibited.
    */
-  predicate isBarrier(DataFlow::Node src, DataFlow::Node trg) { none() }
+  deprecated predicate isBarrier(DataFlow::Node src, DataFlow::Node trg) { none() }
 
   /**
    * DEPRECATED: Use `isBarrierEdge` instead.
    *
    * Holds if flow with label `lbl` cannot flow from `src` to `trg`.
    */
-  predicate isBarrier(DataFlow::Node src, DataFlow::Node trg, FlowLabel lbl) { none() }
+  deprecated predicate isBarrier(DataFlow::Node src, DataFlow::Node trg, FlowLabel lbl) { none() }
 
   /**
    * Holds if flow from `pred` to `succ` is prohibited.
@@ -486,7 +486,6 @@ private predicate basicFlowStep(
     // Local flow
     exists(FlowLabel predlbl, FlowLabel succlbl |
       localFlowStep(pred, succ, cfg, predlbl, succlbl) and
-      not cfg.isBarrier(pred, succ, predlbl) and
       not cfg.isBarrierEdge(pred, succ, predlbl) and
       summary = MkPathSummary(false, false, predlbl, succlbl)
     )
@@ -601,7 +600,6 @@ private predicate callInputStep(
     )
   ) and
   not cfg.isBarrier(succ) and
-  not cfg.isBarrier(pred, succ) and
   not cfg.isBarrierEdge(pred, succ)
 }
 
@@ -656,7 +654,6 @@ private predicate flowThroughCall(
     ret.asExpr() = f.getAReturnedExpr() and
     calls(output, f) and // Do not consider partial calls
     reachableFromInput(f, output, input, ret, cfg, summary) and
-    not cfg.isBarrier(ret, output) and
     not cfg.isBarrierEdge(ret, output) and
     not cfg.isLabeledBarrier(output, summary.getEndLabel())
   )
@@ -666,7 +663,6 @@ private predicate flowThroughCall(
     DataFlow::exceptionalInvocationReturnNode(output, invk.asExpr()) and
     calls(invk, f) and
     reachableFromInput(f, invk, input, ret, cfg, summary) and
-    not cfg.isBarrier(ret, output) and
     not cfg.isBarrierEdge(ret, output) and
     not cfg.isLabeledBarrier(output, summary.getEndLabel())
   )
@@ -906,7 +902,6 @@ private predicate flowStep(
     flowIntoHigherOrderCall(pred, succ, cfg, summary)
   ) and
   not cfg.isBarrier(succ) and
-  not cfg.isBarrier(pred, succ) and
   not cfg.isBarrierEdge(pred, succ) and
   not cfg.isLabeledBarrier(succ, summary.getEndLabel())
 }

--- a/javascript/ql/src/semmle/javascript/dataflow/TaintTracking.qll
+++ b/javascript/ql/src/semmle/javascript/dataflow/TaintTracking.qll
@@ -56,14 +56,14 @@ module TaintTracking {
      *
      * Holds if the edge from `source` to `sink` is a taint sanitizer.
      */
-    predicate isSanitizer(DataFlow::Node source, DataFlow::Node sink) { none() }
+    deprecated predicate isSanitizer(DataFlow::Node source, DataFlow::Node sink) { none() }
 
     /**
      * DEPRECATED: Use `isSanitizerEdge` instead.
      *
      * Holds if the edge from `source` to `sink` is a taint sanitizer for data labelled with `lbl`.
      */
-    predicate isSanitizer(DataFlow::Node source, DataFlow::Node sink, DataFlow::FlowLabel lbl) {
+    deprecated predicate isSanitizer(DataFlow::Node source, DataFlow::Node sink, DataFlow::FlowLabel lbl) {
       none()
     }
 
@@ -92,7 +92,6 @@ module TaintTracking {
 
     final override predicate isBarrierEdge(DataFlow::Node source, DataFlow::Node sink) {
       super.isBarrierEdge(source, sink) or
-      isSanitizer(source, sink) or
       isSanitizerEdge(source, sink)
     }
 
@@ -100,7 +99,6 @@ module TaintTracking {
       DataFlow::Node source, DataFlow::Node sink, DataFlow::FlowLabel lbl
     ) {
       super.isBarrierEdge(source, sink, lbl) or
-      isSanitizer(source, sink, lbl) or
       isSanitizerEdge(source, sink, lbl)
     }
 


### PR DESCRIPTION
We informally deprecated them in 1.21, this commit deprecates them properly and removes support from the implementation. The predicates themselves will be removed in a future release.