### PR TITLE
JS: Do not treat the empty string as a credential

### DIFF
--- a/javascript/ql/src/semmle/javascript/security/dataflow/HardcodedCredentialsCustomizations.qll
+++ b/javascript/ql/src/semmle/javascript/security/dataflow/HardcodedCredentialsCustomizations.qll
@@ -28,6 +28,10 @@ module HardcodedCredentials {
   /** A constant string, considered as a source of hardcoded credentials. */
   class ConstantStringSource extends Source, DataFlow::ValueNode {
     override ConstantString astNode;
+
+    ConstantStringSource() {
+      not astNode.getStringValue() = ""
+    }
   }
 
   /**
@@ -36,11 +40,6 @@ module HardcodedCredentials {
    */
   class DefaultCredentialsSink extends Sink, DataFlow::ValueNode {
     override CredentialsExpr astNode;
-
-    DefaultCredentialsSink() {
-      // Don't flag an empty user name
-      not (astNode.getCredentialsKind() = "user name" and astNode.getStringValue() = "")
-    }
 
     override string getKind() { result = astNode.getCredentialsKind() }
   }

--- a/javascript/ql/test/query-tests/Security/CWE-798/HardcodedCredentials.js
+++ b/javascript/ql/test/query-tests/Security/CWE-798/HardcodedCredentials.js
@@ -144,3 +144,14 @@
         }
     });
 })();
+
+(function(){
+    var request = require('request');
+    let pass = getPassword() || '';
+    request.get(url, { // OK
+        'auth': {
+            'user': process.env.USER || '',
+            'pass': pass,
+        }
+    });
+})();


### PR DESCRIPTION
Got a FP report about this so I'm proposing to stop treating empty strings as credentials.