### PR TITLE
QL docs: update paths to change notes in support project

### DIFF
--- a/docs/ql-documentation/support/conf.py
+++ b/docs/ql-documentation/support/conf.py
@@ -80,4 +80,4 @@ htmlhelp_basename = 'Supported languages and frameworks'
 
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.
-# exclude_patterns = ['']
+exclude_patterns = ['read-me-project.rst']

--- a/docs/ql-documentation/support/framework-support.rst
+++ b/docs/ql-documentation/support/framework-support.rst
@@ -1,3 +1,3 @@
 .. This includes the file maintained in the QL repository
 
-.. include:: ../../../ql/change-notes/support/framework-support.rst
+.. include:: ../../../change-notes/support/framework-support.rst

--- a/docs/ql-documentation/support/language-support.rst
+++ b/docs/ql-documentation/support/language-support.rst
@@ -1,3 +1,3 @@
 .. This includes the file maintained in the QL repository
 
-.. include:: ../../../ql/change-notes/support/language-support.rst
+.. include:: ../../../change-notes/support/language-support.rst


### PR DESCRIPTION
I forgot two things when moving the `support` Sphinx project:
- the paths for the `include` directives had to be updated 
- `read-me-project.rst` should be excluded from the build

Preview generated locally:
http://docteam.internal.semmle.com/james/support-paths/language-support.html

These two things caused https://jenkins.internal.semmle.com/job/Docs/job/Generate-Sphinx/533/ to fail, which I started in order to test https://git.semmle.com/Semmle/code/pull/33390.