### PR TITLE
JS: Add FlowLabel.isData() and .isTaint()

### DIFF
--- a/javascript/ql/src/Security/Summaries/Shared.qll
+++ b/javascript/ql/src/Security/Summaries/Shared.qll
@@ -22,7 +22,7 @@ predicate sourceFlowLabelSpec(DataFlow::FlowLabel lbl, string spec) {
   lbl.toString() = spec
   or
   spec = "" and
-  lbl = DataFlow::FlowLabel::data()
+  lbl.isData()
 }
 
 /**
@@ -33,7 +33,7 @@ predicate sinkFlowLabelSpec(DataFlow::FlowLabel lbl, string spec) {
   lbl.toString() = spec
   or
   spec = "" and
-  lbl instanceof DataFlow::StandardFlowLabel
+  lbl.isDataOrTaint()
 }
 
 /**

--- a/javascript/ql/src/semmle/javascript/dataflow/Configuration.qll
+++ b/javascript/ql/src/semmle/javascript/dataflow/Configuration.qll
@@ -229,6 +229,25 @@ abstract class Configuration extends string {
 abstract class FlowLabel extends string {
   bindingset[this]
   FlowLabel() { any() }
+
+  /**
+   * Holds if this is the standard `FlowLabel::data()` flow label,
+   * describing values that directly originate from a flow source.
+   */
+  final predicate isData() { this = FlowLabel::data() }
+
+  /**
+   * Holds if this is the standard `FlowLabel::taint()` flow label,
+   * describing values that are influenced ("tainted") by a flow
+   * source, but not necessarily directly derived from it.
+   */
+  final predicate isTaint() { this = FlowLabel::taint() }
+
+  /**
+   * Holds if this is one of the standard flow labels `FlowLabel::data()`
+   * or `FlowLabel::taint()`.
+   */
+  final predicate isDataOrTaint() { isData() or isTaint() }
 }
 
 /**

--- a/javascript/ql/src/semmle/javascript/security/TaintedObject.qll
+++ b/javascript/ql/src/semmle/javascript/security/TaintedObject.qll
@@ -36,7 +36,7 @@ module TaintedObject {
    */
   predicate step(Node src, Node trg, FlowLabel inlbl, FlowLabel outlbl) {
     // JSON parsers map tainted inputs to tainted JSON
-    (inlbl = FlowLabel::data() or inlbl = FlowLabel::taint()) and
+    inlbl.isDataOrTaint() and
     outlbl = label() and
     exists(JsonParserCall parse |
       src = parse.getInput() and

--- a/javascript/ql/src/semmle/javascript/security/dataflow/ClientSideUrlRedirect.qll
+++ b/javascript/ql/src/semmle/javascript/security/dataflow/ClientSideUrlRedirect.qll
@@ -43,7 +43,7 @@ module ClientSideUrlRedirect {
     ) {
       queryAccess(pred, succ) and
       f instanceof DocumentUrl and
-      g = DataFlow::FlowLabel::taint()
+      g.isTaint()
       or
       // preserve document.url label in step from `location` to `location.href`
       f instanceof DocumentUrl and

--- a/javascript/ql/src/semmle/javascript/security/dataflow/HardcodedDataInterpretedAsCodeCustomizations.qll
+++ b/javascript/ql/src/semmle/javascript/security/dataflow/HardcodedDataInterpretedAsCodeCustomizations.qll
@@ -13,7 +13,7 @@ module HardcodedDataInterpretedAsCode {
    */
   abstract class Source extends DataFlow::Node {
     /** Gets a flow label for which this is a source. */
-    DataFlow::FlowLabel getLabel() { result = DataFlow::FlowLabel::data() }
+    DataFlow::FlowLabel getLabel() { result.isData() }
   }
 
   /**
@@ -52,7 +52,7 @@ module HardcodedDataInterpretedAsCode {
   private class DefaultCodeInjectionSink extends Sink {
     DefaultCodeInjectionSink() { this instanceof CodeInjection::Sink }
 
-    override DataFlow::FlowLabel getLabel() { result = DataFlow::FlowLabel::taint() }
+    override DataFlow::FlowLabel getLabel() { result.isTaint() }
 
     override string getKind() { result = "code" }
   }
@@ -63,11 +63,7 @@ module HardcodedDataInterpretedAsCode {
   private class RequireArgumentSink extends Sink {
     RequireArgumentSink() { this = any(Require r).getAnArgument().flow() }
 
-    override DataFlow::FlowLabel getLabel() {
-      result = DataFlow::FlowLabel::data()
-      or
-      result = DataFlow::FlowLabel::taint()
-    }
+    override DataFlow::FlowLabel getLabel() { result.isDataOrTaint() }
 
     override string getKind() { result = "an import path" }
   }

--- a/javascript/ql/src/semmle/javascript/security/dataflow/PostMessageStar.qll
+++ b/javascript/ql/src/semmle/javascript/security/dataflow/PostMessageStar.qll
@@ -53,7 +53,7 @@ module PostMessageStar {
         src = toString.getArgument(0)
       ) and
       inlbl instanceof PartiallyTaintedObject and
-      outlbl = DataFlow::FlowLabel::taint()
+      outlbl.isTaint()
       or
       // `valueOf` preserves partial taint
       trg.(DataFlow::MethodCallNode).calls(src, "valueOf") and

--- a/javascript/ql/src/semmle/javascript/security/dataflow/PostMessageStarCustomizations.qll
+++ b/javascript/ql/src/semmle/javascript/security/dataflow/PostMessageStarCustomizations.qll
@@ -34,7 +34,7 @@ module PostMessageStar {
    * Gets either a standard flow label or the partial-taint label.
    */
   DataFlow::FlowLabel anyLabel() {
-    result instanceof DataFlow::StandardFlowLabel or result instanceof PartiallyTaintedObject
+    result.isDataOrTaint() or result instanceof PartiallyTaintedObject
   }
 
   /**

--- a/javascript/ql/src/semmle/javascript/security/dataflow/PrototypePollutionCustomizations.qll
+++ b/javascript/ql/src/semmle/javascript/security/dataflow/PrototypePollutionCustomizations.qll
@@ -66,7 +66,7 @@ module PrototypePollution {
   private class RemoteFlowAsSource extends Source {
     RemoteFlowAsSource() { this instanceof RemoteFlowSource }
 
-    override DataFlow::FlowLabel getAFlowLabel() { result = DataFlow::FlowLabel::data() }
+    override DataFlow::FlowLabel getAFlowLabel() { result.isData() }
   }
 
   /**


### PR DESCRIPTION
I often find that the `DataFlow::FlowLabel::` prefix is a bit of a mouthful to type, to the point where it's almost one of the most off-putting reasons for introducing flow labels to a query. This isn't a big problem for the queries in our repo, but it is taxing when writing lots of one-off queries.

This adds `.isData()`, `.isTaint()` and `isDataOrTaint()` predicates to flow labels to make them easier to use.

I'm not sure whether to add `isStandardFlowLabel()` as it's not clear to me what this would mean when or if we add more kinds of labels in the default taint-tracking configuration, like `TaintedObject`.

WDYT?