### PR TITLE
JavaScript: Classify `__mocks__` and `__tests_` as tests.

### DIFF
--- a/change-notes/1.22/analysis-javascript.md
+++ b/change-notes/1.22/analysis-javascript.md
@@ -2,6 +2,8 @@
 
 ## General improvements
 
+* Automatic classification of test files has been improved, in particular `__tests__` and `__mocks__` folders (as used by [Jest](https://jestjs.io)) are now recognized.
+
 * Support for the following frameworks and libraries has been improved:
   - [cross-spawn](https://www.npmjs.com/package/cross-spawn)
   - [cross-spawn-async](https://www.npmjs.com/package/cross-spawn-async)

--- a/javascript/ql/src/filters/ClassifyFiles.ql
+++ b/javascript/ql/src/filters/ClassifyFiles.ql
@@ -67,6 +67,8 @@ predicate classify(File f, string category) {
     exists(string stemExt | stemExt = "test" or stemExt = "spec" |
       f = getTestFile(any(File orig), stemExt)
     )
+    or
+    f.getAbsolutePath().regexpMatch(".*/__(mocks|tests)__/.*")
   ) and
   category = "test"
   or

--- a/javascript/ql/test/query-tests/filters/ClassifyFiles/ClassifyFiles.expected
+++ b/javascript/ql/test/query-tests/filters/ClassifyFiles/ClassifyFiles.expected
@@ -1,6 +1,8 @@
 | 1.js:0:0:0:0 | 1.js | generated |
 | AutoRest.js:0:0:0:0 | AutoRest.js | generated |
 | ManyElementsOnLine.html:0:0:0:0 | ManyElementsOnLine.html | generated |
+| __mocks__/test.js:0:0:0:0 | __mocks__/test.js | test |
+| __tests__/test.js:0:0:0:0 | __tests__/test.js | test |
 | ai.1.2.3-build0123.js:0:0:0:0 | ai.1.2.3-build0123.js | library |
 | bundle-directive.js:0:0:0:0 | bundle-directive.js | generated |
 | data.js:0:0:0:0 | data.js | generated |

--- a/javascript/ql/test/query-tests/filters/ClassifyFiles/__mocks__/test.js
+++ b/javascript/ql/test/query-tests/filters/ClassifyFiles/__mocks__/test.js
@@ -1,0 +1,3 @@
+// the only reason to classify this file as a test is that it is in a folder called `__mocks__`
+
+export function f() {}

--- a/javascript/ql/test/query-tests/filters/ClassifyFiles/__tests__/test.js
+++ b/javascript/ql/test/query-tests/filters/ClassifyFiles/__tests__/test.js
@@ -1,0 +1,3 @@
+// the only reason to classify this file as a test is that it is in a folder called `__tests__`
+
+export function testF() {}


### PR DESCRIPTION
These are conventions used by jest: https://jestjs.io/docs/en/manual-mocks#mocking-user-modules.