### PR TITLE
JavaScript: Make flow summaries work for non-taint configurations.

### DIFF
--- a/javascript/ql/src/Security/Summaries/ExtractSinkSummaries.ql
+++ b/javascript/ql/src/Security/Summaries/ExtractSinkSummaries.ql
@@ -11,7 +11,7 @@ import Configurations
 import PortalExitSource
 import SinkFromAnnotation
 
-from TaintTracking::Configuration cfg, DataFlow::PathNode source, DataFlow::PathNode sink, Portal p
+from DataFlow::Configuration cfg, DataFlow::PathNode source, DataFlow::PathNode sink, Portal p
 where
   cfg.hasFlowPath(source, sink) and
   p = source.getNode().(PortalExitSource).getPortal() and

--- a/javascript/ql/src/Security/Summaries/ExtractSourceSummaries.ql
+++ b/javascript/ql/src/Security/Summaries/ExtractSourceSummaries.ql
@@ -11,7 +11,7 @@ import Configurations
 import PortalEntrySink
 import SourceFromAnnotation
 
-from TaintTracking::Configuration cfg, DataFlow::PathNode source, DataFlow::PathNode sink, Portal p
+from DataFlow::Configuration cfg, DataFlow::PathNode source, DataFlow::PathNode sink, Portal p
 where
   cfg.hasFlowPath(source, sink) and
   p = sink.getNode().(PortalEntrySink).getPortal() and

--- a/javascript/ql/src/Security/Summaries/PortalEntrySink.qll
+++ b/javascript/ql/src/Security/Summaries/PortalEntrySink.qll
@@ -11,8 +11,7 @@ class PortalEntrySink extends DataFlow::AdditionalSink {
   PortalEntrySink() { this = p.getAnEntryNode(true) }
 
   override predicate isSinkFor(DataFlow::Configuration cfg, DataFlow::FlowLabel lbl) {
-    cfg instanceof TaintTracking::Configuration and
-    lbl = any(DataFlow::FlowLabel l)
+    any()
   }
 
   /** Gets the portal of which this is an entry node. */

--- a/javascript/ql/src/Security/Summaries/PortalExitSource.qll
+++ b/javascript/ql/src/Security/Summaries/PortalExitSource.qll
@@ -11,8 +11,7 @@ class PortalExitSource extends DataFlow::AdditionalSource {
   PortalExitSource() { this = p.getAnExitNode(true) }
 
   override predicate isSourceFor(DataFlow::Configuration cfg, DataFlow::FlowLabel lbl) {
-    cfg instanceof TaintTracking::Configuration and
-    lbl = any(DataFlow::FlowLabel l)
+    any()
   }
 
   /** Gets the portal of which this is an exit node. */


### PR DESCRIPTION
With flow labels it often makes more sense to use a `DataFlow::Configuration` rather than a `TaintTracking::Configuration`, so flow summaries should support both.