### PR TITLE
Java: Adjust taint steps for Reader::read.

### DIFF
--- a/java/ql/src/semmle/code/java/dataflow/TaintTracking.qll
+++ b/java/ql/src/semmle/code/java/dataflow/TaintTracking.qll
@@ -363,6 +363,10 @@ module TaintTracking {
     m.getDeclaringType().hasQualifiedName("java.io", "InputStream") and
     m.hasName("read") and
     arg = 0
+    or
+    m.getDeclaringType().getASupertype*().hasQualifiedName("java.io", "Reader") and
+    m.hasName("read") and
+    arg = 0
   }
 
   /** Access to a method that passes taint from the qualifier. */
@@ -398,8 +402,12 @@ module TaintTracking {
       m.getName().matches("%Value")
     )
     or
-    m.getDeclaringType().getQualifiedName().matches("%Reader") and
-    m.getName().matches("read%")
+    m.getDeclaringType().getASupertype*().hasQualifiedName("java.io", "Reader") and
+    (
+      m.getName() = "read" and m.getNumberOfParameters() = 0
+      or
+      m.getName() = "readLine"
+    )
     or
     m.getDeclaringType().getQualifiedName().matches("%StringWriter") and
     m.getName() = "toString"


### PR DESCRIPTION
Tainting any method call with a name starting with "read" on any class with a name ending in "Reader" seems overly general (the introduction of the taint step dates back to 2013: [internal link](https://git.semmle.com/Semmle/code/pull/2419)).
I assume that it was the `read()` methods on classes deriving from `java.io.Reader` that were the intended targets along with various `readLine` methods (on e.g. `java.io.BufferedReader`).  Also, for a tainted qualifier, `Reader::read(char[] cbuf)` and `Reader::read(char[] cbuf, int off, int len)` should taint the `cbuf` argument and not the method result.