### PR TITLE
Java: Improve the precision of java/hardcoded-credential-api-call.

### DIFF
--- a/java/ql/src/Security/CWE/CWE-798/HardcodedCredentialsApiCall.ql
+++ b/java/ql/src/Security/CWE/CWE-798/HardcodedCredentialsApiCall.ql
@@ -31,6 +31,10 @@ class HardcodedCredentialApiCallConfiguration extends DataFlow::Configuration {
       ma.getQualifier() = node1.asExpr()
     )
   }
+
+  override predicate isBarrier(DataFlow::Node n) {
+    n.asExpr().(MethodAccess).getMethod() instanceof MethodSystemGetenv
+  }
 }
 
 from


### PR DESCRIPTION
More than 98% of the FPs on jdk8 involve flow through `System.getenv`, which is definitely not a hardcoded value, so this is an easy win.  The number of results on jdk8 fall from 6961 to 99.