### PR TITLE
JS: Fix lodash version in proto pollution qhelp

### DIFF
--- a/javascript/ql/src/Security/CWE-400/examples/PrototypePollution_fixed.json
+++ b/javascript/ql/src/Security/CWE-400/examples/PrototypePollution_fixed.json
@@ -1,5 +1,5 @@
 {
   "dependencies": {
-    "lodash": "^4.17.11"
+    "lodash": "^4.17.12"
   }
 }


### PR DESCRIPTION
Makes it consistent with the version range the query is actually flagging