### PR TITLE
C#: Fix data flow for `out`/`ref` parameters

### DIFF
--- a/csharp/ql/src/semmle/code/csharp/dataflow/internal/DataFlowPrivate.qll
+++ b/csharp/ql/src/semmle/code/csharp/dataflow/internal/DataFlowPrivate.qll
@@ -738,7 +738,8 @@ private module ReturnNodes {
 
     OutRefReturnNode() {
       exists(Parameter p |
-        this.getDefinition().(Ssa::ExplicitDefinition).isLiveOutRefParameterDefinition(p)
+        this.getDefinition().(Ssa::ExplicitDefinition).isLiveOutRefParameterDefinition(p) and
+        kind.getPosition() = p.getPosition()
       |
         p.isOut() and kind instanceof OutReturnKind
         or

--- a/csharp/ql/test/library-tests/dataflow/global/DataFlow.expected
+++ b/csharp/ql/test/library-tests/dataflow/global/DataFlow.expected
@@ -17,9 +17,6 @@
 | GlobalDataFlow.cs:73:15:73:19 | access to local variable sink1 |
 | GlobalDataFlow.cs:76:15:76:19 | access to local variable sink2 |
 | GlobalDataFlow.cs:79:15:79:19 | access to local variable sink3 |
-| GlobalDataFlow.cs:107:15:107:22 | access to local variable nonSink0 |
-| GlobalDataFlow.cs:109:15:109:22 | access to local variable nonSink0 |
-| GlobalDataFlow.cs:111:15:111:22 | access to local variable nonSink0 |
 | GlobalDataFlow.cs:136:15:136:19 | access to local variable sink4 |
 | GlobalDataFlow.cs:144:15:144:19 | access to local variable sink5 |
 | GlobalDataFlow.cs:154:15:154:19 | access to local variable sink6 |

--- a/csharp/ql/test/library-tests/dataflow/global/DataFlow.expected
+++ b/csharp/ql/test/library-tests/dataflow/global/DataFlow.expected
@@ -17,24 +17,27 @@
 | GlobalDataFlow.cs:73:15:73:19 | access to local variable sink1 |
 | GlobalDataFlow.cs:76:15:76:19 | access to local variable sink2 |
 | GlobalDataFlow.cs:79:15:79:19 | access to local variable sink3 |
-| GlobalDataFlow.cs:132:15:132:19 | access to local variable sink4 |
-| GlobalDataFlow.cs:140:15:140:19 | access to local variable sink5 |
-| GlobalDataFlow.cs:150:15:150:19 | access to local variable sink6 |
-| GlobalDataFlow.cs:153:15:153:19 | access to local variable sink7 |
-| GlobalDataFlow.cs:156:15:156:19 | access to local variable sink8 |
-| GlobalDataFlow.cs:160:15:160:20 | access to local variable sink23 |
-| GlobalDataFlow.cs:177:15:177:19 | access to local variable sink9 |
-| GlobalDataFlow.cs:186:15:186:20 | access to local variable sink10 |
-| GlobalDataFlow.cs:194:15:194:20 | access to local variable sink19 |
-| GlobalDataFlow.cs:233:15:233:24 | access to parameter sinkParam0 |
-| GlobalDataFlow.cs:238:15:238:24 | access to parameter sinkParam1 |
-| GlobalDataFlow.cs:243:15:243:24 | access to parameter sinkParam3 |
-| GlobalDataFlow.cs:248:15:248:24 | access to parameter sinkParam4 |
-| GlobalDataFlow.cs:253:15:253:24 | access to parameter sinkParam5 |
-| GlobalDataFlow.cs:258:15:258:24 | access to parameter sinkParam6 |
-| GlobalDataFlow.cs:263:15:263:24 | access to parameter sinkParam7 |
-| GlobalDataFlow.cs:376:15:376:20 | access to local variable sink11 |
-| GlobalDataFlow.cs:399:41:399:46 | access to local variable sink20 |
+| GlobalDataFlow.cs:107:15:107:22 | access to local variable nonSink0 |
+| GlobalDataFlow.cs:109:15:109:22 | access to local variable nonSink0 |
+| GlobalDataFlow.cs:111:15:111:22 | access to local variable nonSink0 |
+| GlobalDataFlow.cs:136:15:136:19 | access to local variable sink4 |
+| GlobalDataFlow.cs:144:15:144:19 | access to local variable sink5 |
+| GlobalDataFlow.cs:154:15:154:19 | access to local variable sink6 |
+| GlobalDataFlow.cs:157:15:157:19 | access to local variable sink7 |
+| GlobalDataFlow.cs:160:15:160:19 | access to local variable sink8 |
+| GlobalDataFlow.cs:164:15:164:20 | access to local variable sink23 |
+| GlobalDataFlow.cs:181:15:181:19 | access to local variable sink9 |
+| GlobalDataFlow.cs:190:15:190:20 | access to local variable sink10 |
+| GlobalDataFlow.cs:198:15:198:20 | access to local variable sink19 |
+| GlobalDataFlow.cs:237:15:237:24 | access to parameter sinkParam0 |
+| GlobalDataFlow.cs:242:15:242:24 | access to parameter sinkParam1 |
+| GlobalDataFlow.cs:247:15:247:24 | access to parameter sinkParam3 |
+| GlobalDataFlow.cs:252:15:252:24 | access to parameter sinkParam4 |
+| GlobalDataFlow.cs:257:15:257:24 | access to parameter sinkParam5 |
+| GlobalDataFlow.cs:262:15:262:24 | access to parameter sinkParam6 |
+| GlobalDataFlow.cs:267:15:267:24 | access to parameter sinkParam7 |
+| GlobalDataFlow.cs:381:15:381:20 | access to local variable sink11 |
+| GlobalDataFlow.cs:404:41:404:46 | access to local variable sink20 |
 | Splitting.cs:9:15:9:15 | [b (line 3): false] access to local variable x |
 | Splitting.cs:9:15:9:15 | [b (line 3): true] access to local variable x |
 | Splitting.cs:11:19:11:19 | access to local variable x |

--- a/csharp/ql/test/library-tests/dataflow/global/DataFlowEdges.expected
+++ b/csharp/ql/test/library-tests/dataflow/global/DataFlowEdges.expected
@@ -1291,8 +1291,6 @@
 | GlobalDataFlow.cs:78:30:78:34 | access to local variable sink3 | GlobalDataFlow.cs:78:30:78:34 | access to local variable sink3 |
 | GlobalDataFlow.cs:78:30:78:34 | access to local variable sink3 | GlobalDataFlow.cs:78:41:78:45 | access to local variable sink3 |
 | GlobalDataFlow.cs:78:30:78:34 | access to local variable sink3 | GlobalDataFlow.cs:78:41:78:45 | access to local variable sink3 |
-| GlobalDataFlow.cs:78:41:78:45 | access to local variable sink3 | GlobalDataFlow.cs:78:30:78:34 | SSA def(sink3) |
-| GlobalDataFlow.cs:78:41:78:45 | access to local variable sink3 | GlobalDataFlow.cs:78:30:78:34 | SSA def(sink3) |
 | GlobalDataFlow.cs:78:41:78:45 | access to local variable sink3 | GlobalDataFlow.cs:78:41:78:45 | access to local variable sink3 |
 | GlobalDataFlow.cs:78:41:78:45 | access to local variable sink3 | GlobalDataFlow.cs:287:50:287:50 | z |
 | GlobalDataFlow.cs:78:41:78:45 | access to local variable sink3 | GlobalDataFlow.cs:287:50:287:50 | z |
@@ -1690,8 +1688,6 @@
 | GlobalDataFlow.cs:105:15:105:22 | access to local variable nonSink0 | GlobalDataFlow.cs:105:15:105:22 | access to local variable nonSink0 |
 | GlobalDataFlow.cs:106:9:106:49 | call to method ReturnOut | GlobalDataFlow.cs:106:9:106:49 | call to method ReturnOut |
 | GlobalDataFlow.cs:106:19:106:23 | access to local variable sink1 | GlobalDataFlow.cs:106:19:106:23 | access to local variable sink1 |
-| GlobalDataFlow.cs:106:19:106:23 | access to local variable sink1 | GlobalDataFlow.cs:106:41:106:48 | SSA def(nonSink0) |
-| GlobalDataFlow.cs:106:19:106:23 | access to local variable sink1 | GlobalDataFlow.cs:106:41:106:48 | SSA def(nonSink0) |
 | GlobalDataFlow.cs:106:19:106:23 | access to local variable sink1 | GlobalDataFlow.cs:110:19:110:23 | access to local variable sink1 |
 | GlobalDataFlow.cs:106:19:106:23 | access to local variable sink1 | GlobalDataFlow.cs:110:19:110:23 | access to local variable sink1 |
 | GlobalDataFlow.cs:106:19:106:23 | access to local variable sink1 | GlobalDataFlow.cs:110:30:110:34 | access to local variable sink1 |
@@ -1731,8 +1727,6 @@
 | GlobalDataFlow.cs:108:27:108:34 | access to local variable nonSink0 | GlobalDataFlow.cs:108:27:108:34 | access to local variable nonSink0 |
 | GlobalDataFlow.cs:108:27:108:34 | access to local variable nonSink0 | GlobalDataFlow.cs:108:41:108:48 | access to local variable nonSink0 |
 | GlobalDataFlow.cs:108:27:108:34 | access to local variable nonSink0 | GlobalDataFlow.cs:108:41:108:48 | access to local variable nonSink0 |
-| GlobalDataFlow.cs:108:41:108:48 | access to local variable nonSink0 | GlobalDataFlow.cs:108:27:108:34 | SSA def(nonSink0) |
-| GlobalDataFlow.cs:108:41:108:48 | access to local variable nonSink0 | GlobalDataFlow.cs:108:27:108:34 | SSA def(nonSink0) |
 | GlobalDataFlow.cs:108:41:108:48 | access to local variable nonSink0 | GlobalDataFlow.cs:108:41:108:48 | access to local variable nonSink0 |
 | GlobalDataFlow.cs:108:41:108:48 | access to local variable nonSink0 | GlobalDataFlow.cs:287:50:287:50 | z |
 | GlobalDataFlow.cs:108:41:108:48 | access to local variable nonSink0 | GlobalDataFlow.cs:287:50:287:50 | z |
@@ -1758,8 +1752,6 @@
 | GlobalDataFlow.cs:110:30:110:34 | SSA def(sink1) | GlobalDataFlow.cs:124:39:124:43 | access to local variable sink1 |
 | GlobalDataFlow.cs:110:30:110:34 | SSA def(sink1) | GlobalDataFlow.cs:124:39:124:43 | access to local variable sink1 |
 | GlobalDataFlow.cs:110:30:110:34 | access to local variable sink1 | GlobalDataFlow.cs:110:30:110:34 | access to local variable sink1 |
-| GlobalDataFlow.cs:110:41:110:48 | access to local variable nonSink0 | GlobalDataFlow.cs:110:30:110:34 | SSA def(sink1) |
-| GlobalDataFlow.cs:110:41:110:48 | access to local variable nonSink0 | GlobalDataFlow.cs:110:30:110:34 | SSA def(sink1) |
 | GlobalDataFlow.cs:110:41:110:48 | access to local variable nonSink0 | GlobalDataFlow.cs:110:41:110:48 | access to local variable nonSink0 |
 | GlobalDataFlow.cs:110:41:110:48 | access to local variable nonSink0 | GlobalDataFlow.cs:111:15:111:22 | access to local variable nonSink0 |
 | GlobalDataFlow.cs:110:41:110:48 | access to local variable nonSink0 | GlobalDataFlow.cs:111:15:111:22 | access to local variable nonSink0 |
@@ -3108,8 +3100,6 @@
 | GlobalDataFlow.cs:283:9:283:13 | SSA def(y) | GlobalDataFlow.cs:75:30:75:34 | SSA def(sink2) |
 | GlobalDataFlow.cs:283:9:283:13 | SSA def(y) | GlobalDataFlow.cs:104:27:104:34 | SSA def(nonSink0) |
 | GlobalDataFlow.cs:283:9:283:13 | SSA def(y) | GlobalDataFlow.cs:104:27:104:34 | SSA def(nonSink0) |
-| GlobalDataFlow.cs:283:9:283:13 | SSA def(y) | GlobalDataFlow.cs:106:41:106:48 | SSA def(nonSink0) |
-| GlobalDataFlow.cs:283:9:283:13 | SSA def(y) | GlobalDataFlow.cs:106:41:106:48 | SSA def(nonSink0) |
 | GlobalDataFlow.cs:283:9:283:13 | SSA def(y) | GlobalDataFlow.cs:283:9:283:13 | SSA def(y) |
 | GlobalDataFlow.cs:283:13:283:13 | access to parameter x | GlobalDataFlow.cs:283:9:283:13 | SSA def(y) |
 | GlobalDataFlow.cs:283:13:283:13 | access to parameter x | GlobalDataFlow.cs:283:9:283:13 | SSA def(y) |
@@ -3117,10 +3107,6 @@
 | GlobalDataFlow.cs:283:13:283:13 | access to parameter x | GlobalDataFlow.cs:283:9:283:13 | SSA def(y) |
 | GlobalDataFlow.cs:283:13:283:13 | access to parameter x | GlobalDataFlow.cs:283:13:283:13 | access to parameter x |
 | GlobalDataFlow.cs:284:9:284:22 | ... = ... | GlobalDataFlow.cs:284:9:284:22 | ... = ... |
-| GlobalDataFlow.cs:284:9:284:22 | SSA def(z) | GlobalDataFlow.cs:75:30:75:34 | SSA def(sink2) |
-| GlobalDataFlow.cs:284:9:284:22 | SSA def(z) | GlobalDataFlow.cs:75:30:75:34 | SSA def(sink2) |
-| GlobalDataFlow.cs:284:9:284:22 | SSA def(z) | GlobalDataFlow.cs:104:27:104:34 | SSA def(nonSink0) |
-| GlobalDataFlow.cs:284:9:284:22 | SSA def(z) | GlobalDataFlow.cs:104:27:104:34 | SSA def(nonSink0) |
 | GlobalDataFlow.cs:284:9:284:22 | SSA def(z) | GlobalDataFlow.cs:106:41:106:48 | SSA def(nonSink0) |
 | GlobalDataFlow.cs:284:9:284:22 | SSA def(z) | GlobalDataFlow.cs:106:41:106:48 | SSA def(nonSink0) |
 | GlobalDataFlow.cs:284:9:284:22 | SSA def(z) | GlobalDataFlow.cs:284:9:284:22 | SSA def(z) |
@@ -3137,12 +3123,6 @@
 | GlobalDataFlow.cs:287:32:287:32 | x | GlobalDataFlow.cs:289:13:289:13 | access to parameter x |
 | GlobalDataFlow.cs:287:32:287:32 | x | GlobalDataFlow.cs:289:13:289:13 | access to parameter x |
 | GlobalDataFlow.cs:287:32:287:32 | x | GlobalDataFlow.cs:289:13:289:13 | access to parameter x |
-| GlobalDataFlow.cs:287:50:287:50 | z | GlobalDataFlow.cs:78:30:78:34 | SSA def(sink3) |
-| GlobalDataFlow.cs:287:50:287:50 | z | GlobalDataFlow.cs:78:30:78:34 | SSA def(sink3) |
-| GlobalDataFlow.cs:287:50:287:50 | z | GlobalDataFlow.cs:108:27:108:34 | SSA def(nonSink0) |
-| GlobalDataFlow.cs:287:50:287:50 | z | GlobalDataFlow.cs:108:27:108:34 | SSA def(nonSink0) |
-| GlobalDataFlow.cs:287:50:287:50 | z | GlobalDataFlow.cs:110:30:110:34 | SSA def(sink1) |
-| GlobalDataFlow.cs:287:50:287:50 | z | GlobalDataFlow.cs:110:30:110:34 | SSA def(sink1) |
 | GlobalDataFlow.cs:287:50:287:50 | z | GlobalDataFlow.cs:287:50:287:50 | z |
 | GlobalDataFlow.cs:287:50:287:50 | z | GlobalDataFlow.cs:287:50:287:50 | z |
 | GlobalDataFlow.cs:289:9:289:13 | ... = ... | GlobalDataFlow.cs:289:9:289:13 | ... = ... |

--- a/csharp/ql/test/library-tests/dataflow/global/DataFlowEdges.expected
+++ b/csharp/ql/test/library-tests/dataflow/global/DataFlowEdges.expected
@@ -590,30 +590,30 @@
 | GlobalDataFlow.cs:14:17:14:17 | this | GlobalDataFlow.cs:64:9:64:18 | this access |
 | GlobalDataFlow.cs:14:17:14:17 | this | GlobalDataFlow.cs:67:9:67:21 | this access |
 | GlobalDataFlow.cs:14:17:14:17 | this | GlobalDataFlow.cs:67:9:67:21 | this access |
-| GlobalDataFlow.cs:14:17:14:17 | this | GlobalDataFlow.cs:149:21:149:25 | this access |
-| GlobalDataFlow.cs:14:17:14:17 | this | GlobalDataFlow.cs:149:21:149:25 | this access |
-| GlobalDataFlow.cs:14:17:14:17 | this | GlobalDataFlow.cs:152:9:152:25 | this access |
-| GlobalDataFlow.cs:14:17:14:17 | this | GlobalDataFlow.cs:152:9:152:25 | this access |
-| GlobalDataFlow.cs:14:17:14:17 | this | GlobalDataFlow.cs:155:9:155:25 | this access |
-| GlobalDataFlow.cs:14:17:14:17 | this | GlobalDataFlow.cs:155:9:155:25 | this access |
-| GlobalDataFlow.cs:14:17:14:17 | this | GlobalDataFlow.cs:157:22:157:31 | this access |
-| GlobalDataFlow.cs:14:17:14:17 | this | GlobalDataFlow.cs:157:22:157:31 | this access |
-| GlobalDataFlow.cs:14:17:14:17 | this | GlobalDataFlow.cs:163:20:163:27 | this access |
-| GlobalDataFlow.cs:14:17:14:17 | this | GlobalDataFlow.cs:163:20:163:27 | this access |
-| GlobalDataFlow.cs:14:17:14:17 | this | GlobalDataFlow.cs:165:9:165:31 | this access |
-| GlobalDataFlow.cs:14:17:14:17 | this | GlobalDataFlow.cs:165:9:165:31 | this access |
-| GlobalDataFlow.cs:14:17:14:17 | this | GlobalDataFlow.cs:167:9:167:31 | this access |
-| GlobalDataFlow.cs:14:17:14:17 | this | GlobalDataFlow.cs:167:9:167:31 | this access |
-| GlobalDataFlow.cs:14:17:14:17 | this | GlobalDataFlow.cs:169:20:169:32 | this access |
-| GlobalDataFlow.cs:14:17:14:17 | this | GlobalDataFlow.cs:169:20:169:32 | this access |
-| GlobalDataFlow.cs:14:17:14:17 | this | GlobalDataFlow.cs:185:39:185:41 | this access |
-| GlobalDataFlow.cs:14:17:14:17 | this | GlobalDataFlow.cs:185:39:185:41 | this access |
-| GlobalDataFlow.cs:14:17:14:17 | this | GlobalDataFlow.cs:189:37:189:42 | this access |
-| GlobalDataFlow.cs:14:17:14:17 | this | GlobalDataFlow.cs:189:37:189:42 | this access |
-| GlobalDataFlow.cs:14:17:14:17 | this | GlobalDataFlow.cs:193:22:193:32 | this access |
-| GlobalDataFlow.cs:14:17:14:17 | this | GlobalDataFlow.cs:193:22:193:32 | this access |
-| GlobalDataFlow.cs:14:17:14:17 | this | GlobalDataFlow.cs:197:20:197:33 | this access |
-| GlobalDataFlow.cs:14:17:14:17 | this | GlobalDataFlow.cs:197:20:197:33 | this access |
+| GlobalDataFlow.cs:14:17:14:17 | this | GlobalDataFlow.cs:153:21:153:25 | this access |
+| GlobalDataFlow.cs:14:17:14:17 | this | GlobalDataFlow.cs:153:21:153:25 | this access |
+| GlobalDataFlow.cs:14:17:14:17 | this | GlobalDataFlow.cs:156:9:156:25 | this access |
+| GlobalDataFlow.cs:14:17:14:17 | this | GlobalDataFlow.cs:156:9:156:25 | this access |
+| GlobalDataFlow.cs:14:17:14:17 | this | GlobalDataFlow.cs:159:9:159:25 | this access |
+| GlobalDataFlow.cs:14:17:14:17 | this | GlobalDataFlow.cs:159:9:159:25 | this access |
+| GlobalDataFlow.cs:14:17:14:17 | this | GlobalDataFlow.cs:161:22:161:31 | this access |
+| GlobalDataFlow.cs:14:17:14:17 | this | GlobalDataFlow.cs:161:22:161:31 | this access |
+| GlobalDataFlow.cs:14:17:14:17 | this | GlobalDataFlow.cs:167:20:167:27 | this access |
+| GlobalDataFlow.cs:14:17:14:17 | this | GlobalDataFlow.cs:167:20:167:27 | this access |
+| GlobalDataFlow.cs:14:17:14:17 | this | GlobalDataFlow.cs:169:9:169:31 | this access |
+| GlobalDataFlow.cs:14:17:14:17 | this | GlobalDataFlow.cs:169:9:169:31 | this access |
+| GlobalDataFlow.cs:14:17:14:17 | this | GlobalDataFlow.cs:171:9:171:31 | this access |
+| GlobalDataFlow.cs:14:17:14:17 | this | GlobalDataFlow.cs:171:9:171:31 | this access |
+| GlobalDataFlow.cs:14:17:14:17 | this | GlobalDataFlow.cs:173:20:173:32 | this access |
+| GlobalDataFlow.cs:14:17:14:17 | this | GlobalDataFlow.cs:173:20:173:32 | this access |
+| GlobalDataFlow.cs:14:17:14:17 | this | GlobalDataFlow.cs:189:39:189:41 | this access |
+| GlobalDataFlow.cs:14:17:14:17 | this | GlobalDataFlow.cs:189:39:189:41 | this access |
+| GlobalDataFlow.cs:14:17:14:17 | this | GlobalDataFlow.cs:193:37:193:42 | this access |
+| GlobalDataFlow.cs:14:17:14:17 | this | GlobalDataFlow.cs:193:37:193:42 | this access |
+| GlobalDataFlow.cs:14:17:14:17 | this | GlobalDataFlow.cs:197:22:197:32 | this access |
+| GlobalDataFlow.cs:14:17:14:17 | this | GlobalDataFlow.cs:197:22:197:32 | this access |
+| GlobalDataFlow.cs:14:17:14:17 | this | GlobalDataFlow.cs:201:20:201:33 | this access |
+| GlobalDataFlow.cs:14:17:14:17 | this | GlobalDataFlow.cs:201:20:201:33 | this access |
 | GlobalDataFlow.cs:17:9:17:40 | ... = ... | GlobalDataFlow.cs:17:9:17:40 | ... = ... |
 | GlobalDataFlow.cs:17:9:17:40 | SSA def(DataFlow.Test.SinkField0) | GlobalDataFlow.cs:17:9:17:40 | SSA def(DataFlow.Test.SinkField0) |
 | GlobalDataFlow.cs:17:9:17:40 | SSA def(DataFlow.Test.SinkField0) | GlobalDataFlow.cs:18:15:18:29 | access to field SinkField0 |
@@ -850,8 +850,8 @@
 | GlobalDataFlow.cs:35:13:35:30 | access to property SinkProperty0 | GlobalDataFlow.cs:64:22:64:39 | access to property SinkProperty0 |
 | GlobalDataFlow.cs:35:13:35:30 | access to property SinkProperty0 | GlobalDataFlow.cs:70:28:70:45 | access to property SinkProperty0 |
 | GlobalDataFlow.cs:35:13:35:30 | access to property SinkProperty0 | GlobalDataFlow.cs:70:28:70:45 | access to property SinkProperty0 |
-| GlobalDataFlow.cs:35:13:35:30 | access to property SinkProperty0 | GlobalDataFlow.cs:230:26:230:35 | sinkParam0 |
-| GlobalDataFlow.cs:35:13:35:30 | access to property SinkProperty0 | GlobalDataFlow.cs:230:26:230:35 | sinkParam0 |
+| GlobalDataFlow.cs:35:13:35:30 | access to property SinkProperty0 | GlobalDataFlow.cs:234:26:234:35 | sinkParam0 |
+| GlobalDataFlow.cs:35:13:35:30 | access to property SinkProperty0 | GlobalDataFlow.cs:234:26:234:35 | sinkParam0 |
 | GlobalDataFlow.cs:36:13:36:58 | MethodInfo methodInfo = ... | GlobalDataFlow.cs:36:13:36:58 | MethodInfo methodInfo = ... |
 | GlobalDataFlow.cs:36:13:36:58 | SSA def(methodInfo) | GlobalDataFlow.cs:36:13:36:58 | SSA def(methodInfo) |
 | GlobalDataFlow.cs:36:13:36:58 | SSA def(methodInfo) | GlobalDataFlow.cs:38:9:38:18 | access to local variable methodInfo |
@@ -890,16 +890,16 @@
 | GlobalDataFlow.cs:37:35:37:52 | access to property SinkProperty0 | GlobalDataFlow.cs:64:22:64:39 | access to property SinkProperty0 |
 | GlobalDataFlow.cs:37:35:37:52 | access to property SinkProperty0 | GlobalDataFlow.cs:70:28:70:45 | access to property SinkProperty0 |
 | GlobalDataFlow.cs:37:35:37:52 | access to property SinkProperty0 | GlobalDataFlow.cs:70:28:70:45 | access to property SinkProperty0 |
-| GlobalDataFlow.cs:37:35:37:52 | access to property SinkProperty0 | GlobalDataFlow.cs:236:26:236:35 | sinkParam1 |
-| GlobalDataFlow.cs:37:35:37:52 | access to property SinkProperty0 | GlobalDataFlow.cs:236:26:236:35 | sinkParam1 |
+| GlobalDataFlow.cs:37:35:37:52 | access to property SinkProperty0 | GlobalDataFlow.cs:240:26:240:35 | sinkParam1 |
+| GlobalDataFlow.cs:37:35:37:52 | access to property SinkProperty0 | GlobalDataFlow.cs:240:26:240:35 | sinkParam1 |
 | GlobalDataFlow.cs:38:9:38:18 | access to local variable methodInfo | GlobalDataFlow.cs:38:9:38:18 | access to local variable methodInfo |
 | GlobalDataFlow.cs:38:9:38:37 | call to method Invoke | GlobalDataFlow.cs:38:9:38:37 | call to method Invoke |
 | GlobalDataFlow.cs:38:27:38:30 | null | GlobalDataFlow.cs:38:27:38:30 | null |
 | GlobalDataFlow.cs:38:33:38:36 | access to local variable args | GlobalDataFlow.cs:38:33:38:36 | access to local variable args |
 | GlobalDataFlow.cs:41:9:41:18 | call to method NonIn0 | GlobalDataFlow.cs:41:9:41:18 | call to method NonIn0 |
 | GlobalDataFlow.cs:41:16:41:17 | "" | GlobalDataFlow.cs:41:16:41:17 | "" |
-| GlobalDataFlow.cs:41:16:41:17 | "" | GlobalDataFlow.cs:266:29:266:41 | nonSinkParam0 |
-| GlobalDataFlow.cs:41:16:41:17 | "" | GlobalDataFlow.cs:266:29:266:41 | nonSinkParam0 |
+| GlobalDataFlow.cs:41:16:41:17 | "" | GlobalDataFlow.cs:270:29:270:41 | nonSinkParam0 |
+| GlobalDataFlow.cs:41:16:41:17 | "" | GlobalDataFlow.cs:270:29:270:41 | nonSinkParam0 |
 | GlobalDataFlow.cs:44:24:44:60 | Action<String> in2 = ... | GlobalDataFlow.cs:44:24:44:60 | Action<String> in2 = ... |
 | GlobalDataFlow.cs:44:24:44:60 | SSA def(in2) | GlobalDataFlow.cs:44:24:44:60 | SSA def(in2) |
 | GlobalDataFlow.cs:44:24:44:60 | SSA def(in2) | GlobalDataFlow.cs:45:9:45:11 | access to local variable in2 |
@@ -961,8 +961,8 @@
 | GlobalDataFlow.cs:52:9:52:38 | call to method Apply | GlobalDataFlow.cs:52:9:52:38 | call to method Apply |
 | GlobalDataFlow.cs:52:15:52:17 | access to method In3 | GlobalDataFlow.cs:52:15:52:17 | access to method In3 |
 | GlobalDataFlow.cs:52:15:52:17 | delegate creation of type Action<String> | GlobalDataFlow.cs:52:15:52:17 | delegate creation of type Action<String> |
-| GlobalDataFlow.cs:52:15:52:17 | delegate creation of type Action<String> | GlobalDataFlow.cs:354:36:354:36 | a |
-| GlobalDataFlow.cs:52:15:52:17 | delegate creation of type Action<String> | GlobalDataFlow.cs:354:36:354:36 | a |
+| GlobalDataFlow.cs:52:15:52:17 | delegate creation of type Action<String> | GlobalDataFlow.cs:359:36:359:36 | a |
+| GlobalDataFlow.cs:52:15:52:17 | delegate creation of type Action<String> | GlobalDataFlow.cs:359:36:359:36 | a |
 | GlobalDataFlow.cs:52:20:52:37 | access to property SinkProperty0 | GlobalDataFlow.cs:52:20:52:37 | access to property SinkProperty0 |
 | GlobalDataFlow.cs:52:20:52:37 | access to property SinkProperty0 | GlobalDataFlow.cs:53:28:53:45 | access to property SinkProperty0 |
 | GlobalDataFlow.cs:52:20:52:37 | access to property SinkProperty0 | GlobalDataFlow.cs:53:28:53:45 | access to property SinkProperty0 |
@@ -976,8 +976,8 @@
 | GlobalDataFlow.cs:52:20:52:37 | access to property SinkProperty0 | GlobalDataFlow.cs:64:22:64:39 | access to property SinkProperty0 |
 | GlobalDataFlow.cs:52:20:52:37 | access to property SinkProperty0 | GlobalDataFlow.cs:70:28:70:45 | access to property SinkProperty0 |
 | GlobalDataFlow.cs:52:20:52:37 | access to property SinkProperty0 | GlobalDataFlow.cs:70:28:70:45 | access to property SinkProperty0 |
-| GlobalDataFlow.cs:52:20:52:37 | access to property SinkProperty0 | GlobalDataFlow.cs:354:41:354:41 | x |
-| GlobalDataFlow.cs:52:20:52:37 | access to property SinkProperty0 | GlobalDataFlow.cs:354:41:354:41 | x |
+| GlobalDataFlow.cs:52:20:52:37 | access to property SinkProperty0 | GlobalDataFlow.cs:359:41:359:41 | x |
+| GlobalDataFlow.cs:52:20:52:37 | access to property SinkProperty0 | GlobalDataFlow.cs:359:41:359:41 | x |
 | GlobalDataFlow.cs:53:9:53:46 | call to method Apply | GlobalDataFlow.cs:53:9:53:46 | call to method Apply |
 | GlobalDataFlow.cs:53:15:53:15 | x | GlobalDataFlow.cs:53:15:53:15 | x |
 | GlobalDataFlow.cs:53:15:53:15 | x | GlobalDataFlow.cs:53:15:53:15 | x |
@@ -986,14 +986,14 @@
 | GlobalDataFlow.cs:53:15:53:15 | x | GlobalDataFlow.cs:53:24:53:24 | access to parameter x |
 | GlobalDataFlow.cs:53:15:53:15 | x | GlobalDataFlow.cs:53:24:53:24 | access to parameter x |
 | GlobalDataFlow.cs:53:15:53:25 | (...) => ... | GlobalDataFlow.cs:53:15:53:25 | (...) => ... |
-| GlobalDataFlow.cs:53:15:53:25 | (...) => ... | GlobalDataFlow.cs:354:36:354:36 | a |
-| GlobalDataFlow.cs:53:15:53:25 | (...) => ... | GlobalDataFlow.cs:354:36:354:36 | a |
+| GlobalDataFlow.cs:53:15:53:25 | (...) => ... | GlobalDataFlow.cs:359:36:359:36 | a |
+| GlobalDataFlow.cs:53:15:53:25 | (...) => ... | GlobalDataFlow.cs:359:36:359:36 | a |
 | GlobalDataFlow.cs:53:20:53:25 | call to method In4 | GlobalDataFlow.cs:53:20:53:25 | call to method In4 |
 | GlobalDataFlow.cs:53:24:53:24 | access to parameter x | GlobalDataFlow.cs:53:24:53:24 | access to parameter x |
-| GlobalDataFlow.cs:53:24:53:24 | access to parameter x | GlobalDataFlow.cs:246:26:246:35 | sinkParam4 |
-| GlobalDataFlow.cs:53:24:53:24 | access to parameter x | GlobalDataFlow.cs:246:26:246:35 | sinkParam4 |
-| GlobalDataFlow.cs:53:24:53:24 | access to parameter x | GlobalDataFlow.cs:246:26:246:35 | sinkParam4 |
-| GlobalDataFlow.cs:53:24:53:24 | access to parameter x | GlobalDataFlow.cs:246:26:246:35 | sinkParam4 |
+| GlobalDataFlow.cs:53:24:53:24 | access to parameter x | GlobalDataFlow.cs:250:26:250:35 | sinkParam4 |
+| GlobalDataFlow.cs:53:24:53:24 | access to parameter x | GlobalDataFlow.cs:250:26:250:35 | sinkParam4 |
+| GlobalDataFlow.cs:53:24:53:24 | access to parameter x | GlobalDataFlow.cs:250:26:250:35 | sinkParam4 |
+| GlobalDataFlow.cs:53:24:53:24 | access to parameter x | GlobalDataFlow.cs:250:26:250:35 | sinkParam4 |
 | GlobalDataFlow.cs:53:28:53:45 | access to property SinkProperty0 | GlobalDataFlow.cs:53:28:53:45 | access to property SinkProperty0 |
 | GlobalDataFlow.cs:53:28:53:45 | access to property SinkProperty0 | GlobalDataFlow.cs:54:44:54:61 | access to property SinkProperty0 |
 | GlobalDataFlow.cs:53:28:53:45 | access to property SinkProperty0 | GlobalDataFlow.cs:54:44:54:61 | access to property SinkProperty0 |
@@ -1005,12 +1005,12 @@
 | GlobalDataFlow.cs:53:28:53:45 | access to property SinkProperty0 | GlobalDataFlow.cs:64:22:64:39 | access to property SinkProperty0 |
 | GlobalDataFlow.cs:53:28:53:45 | access to property SinkProperty0 | GlobalDataFlow.cs:70:28:70:45 | access to property SinkProperty0 |
 | GlobalDataFlow.cs:53:28:53:45 | access to property SinkProperty0 | GlobalDataFlow.cs:70:28:70:45 | access to property SinkProperty0 |
-| GlobalDataFlow.cs:53:28:53:45 | access to property SinkProperty0 | GlobalDataFlow.cs:354:41:354:41 | x |
-| GlobalDataFlow.cs:53:28:53:45 | access to property SinkProperty0 | GlobalDataFlow.cs:354:41:354:41 | x |
+| GlobalDataFlow.cs:53:28:53:45 | access to property SinkProperty0 | GlobalDataFlow.cs:359:41:359:41 | x |
+| GlobalDataFlow.cs:53:28:53:45 | access to property SinkProperty0 | GlobalDataFlow.cs:359:41:359:41 | x |
 | GlobalDataFlow.cs:54:9:54:62 | call to method ApplyDelegate | GlobalDataFlow.cs:54:9:54:62 | call to method ApplyDelegate |
 | GlobalDataFlow.cs:54:23:54:41 | delegate creation of type MyDelegate | GlobalDataFlow.cs:54:23:54:41 | delegate creation of type MyDelegate |
-| GlobalDataFlow.cs:54:23:54:41 | delegate creation of type MyDelegate | GlobalDataFlow.cs:368:42:368:42 | a |
-| GlobalDataFlow.cs:54:23:54:41 | delegate creation of type MyDelegate | GlobalDataFlow.cs:368:42:368:42 | a |
+| GlobalDataFlow.cs:54:23:54:41 | delegate creation of type MyDelegate | GlobalDataFlow.cs:373:42:373:42 | a |
+| GlobalDataFlow.cs:54:23:54:41 | delegate creation of type MyDelegate | GlobalDataFlow.cs:373:42:373:42 | a |
 | GlobalDataFlow.cs:54:38:54:40 | access to method In5 | GlobalDataFlow.cs:54:38:54:40 | access to method In5 |
 | GlobalDataFlow.cs:54:44:54:61 | access to property SinkProperty0 | GlobalDataFlow.cs:54:44:54:61 | access to property SinkProperty0 |
 | GlobalDataFlow.cs:54:44:54:61 | access to property SinkProperty0 | GlobalDataFlow.cs:55:28:55:45 | access to property SinkProperty0 |
@@ -1021,13 +1021,13 @@
 | GlobalDataFlow.cs:54:44:54:61 | access to property SinkProperty0 | GlobalDataFlow.cs:64:22:64:39 | access to property SinkProperty0 |
 | GlobalDataFlow.cs:54:44:54:61 | access to property SinkProperty0 | GlobalDataFlow.cs:70:28:70:45 | access to property SinkProperty0 |
 | GlobalDataFlow.cs:54:44:54:61 | access to property SinkProperty0 | GlobalDataFlow.cs:70:28:70:45 | access to property SinkProperty0 |
-| GlobalDataFlow.cs:54:44:54:61 | access to property SinkProperty0 | GlobalDataFlow.cs:368:52:368:52 | x |
-| GlobalDataFlow.cs:54:44:54:61 | access to property SinkProperty0 | GlobalDataFlow.cs:368:52:368:52 | x |
+| GlobalDataFlow.cs:54:44:54:61 | access to property SinkProperty0 | GlobalDataFlow.cs:373:52:373:52 | x |
+| GlobalDataFlow.cs:54:44:54:61 | access to property SinkProperty0 | GlobalDataFlow.cs:373:52:373:52 | x |
 | GlobalDataFlow.cs:55:9:55:46 | call to method ApplyDelegate | GlobalDataFlow.cs:55:9:55:46 | call to method ApplyDelegate |
 | GlobalDataFlow.cs:55:23:55:25 | access to method In6 | GlobalDataFlow.cs:55:23:55:25 | access to method In6 |
 | GlobalDataFlow.cs:55:23:55:25 | delegate creation of type MyDelegate | GlobalDataFlow.cs:55:23:55:25 | delegate creation of type MyDelegate |
-| GlobalDataFlow.cs:55:23:55:25 | delegate creation of type MyDelegate | GlobalDataFlow.cs:368:42:368:42 | a |
-| GlobalDataFlow.cs:55:23:55:25 | delegate creation of type MyDelegate | GlobalDataFlow.cs:368:42:368:42 | a |
+| GlobalDataFlow.cs:55:23:55:25 | delegate creation of type MyDelegate | GlobalDataFlow.cs:373:42:373:42 | a |
+| GlobalDataFlow.cs:55:23:55:25 | delegate creation of type MyDelegate | GlobalDataFlow.cs:373:42:373:42 | a |
 | GlobalDataFlow.cs:55:28:55:45 | access to property SinkProperty0 | GlobalDataFlow.cs:55:28:55:45 | access to property SinkProperty0 |
 | GlobalDataFlow.cs:55:28:55:45 | access to property SinkProperty0 | GlobalDataFlow.cs:57:35:57:52 | access to property SinkProperty0 |
 | GlobalDataFlow.cs:55:28:55:45 | access to property SinkProperty0 | GlobalDataFlow.cs:57:35:57:52 | access to property SinkProperty0 |
@@ -1035,8 +1035,8 @@
 | GlobalDataFlow.cs:55:28:55:45 | access to property SinkProperty0 | GlobalDataFlow.cs:64:22:64:39 | access to property SinkProperty0 |
 | GlobalDataFlow.cs:55:28:55:45 | access to property SinkProperty0 | GlobalDataFlow.cs:70:28:70:45 | access to property SinkProperty0 |
 | GlobalDataFlow.cs:55:28:55:45 | access to property SinkProperty0 | GlobalDataFlow.cs:70:28:70:45 | access to property SinkProperty0 |
-| GlobalDataFlow.cs:55:28:55:45 | access to property SinkProperty0 | GlobalDataFlow.cs:368:52:368:52 | x |
-| GlobalDataFlow.cs:55:28:55:45 | access to property SinkProperty0 | GlobalDataFlow.cs:368:52:368:52 | x |
+| GlobalDataFlow.cs:55:28:55:45 | access to property SinkProperty0 | GlobalDataFlow.cs:373:52:373:52 | x |
+| GlobalDataFlow.cs:55:28:55:45 | access to property SinkProperty0 | GlobalDataFlow.cs:373:52:373:52 | x |
 | GlobalDataFlow.cs:56:9:56:48 | ... = ... | GlobalDataFlow.cs:56:9:56:48 | ... = ... |
 | GlobalDataFlow.cs:56:9:56:48 | SSA def(DataFlow.myDelegate) | GlobalDataFlow.cs:56:9:56:48 | SSA def(DataFlow.myDelegate) |
 | GlobalDataFlow.cs:56:9:56:48 | SSA def(DataFlow.myDelegate) | GlobalDataFlow.cs:57:23:57:32 | access to field myDelegate |
@@ -1055,21 +1055,21 @@
 | GlobalDataFlow.cs:56:37:56:47 | (...) => ... | GlobalDataFlow.cs:56:37:56:47 | (...) => ... |
 | GlobalDataFlow.cs:56:42:56:47 | call to method In7 | GlobalDataFlow.cs:56:42:56:47 | call to method In7 |
 | GlobalDataFlow.cs:56:46:56:46 | access to parameter x | GlobalDataFlow.cs:56:46:56:46 | access to parameter x |
-| GlobalDataFlow.cs:56:46:56:46 | access to parameter x | GlobalDataFlow.cs:261:26:261:35 | sinkParam7 |
-| GlobalDataFlow.cs:56:46:56:46 | access to parameter x | GlobalDataFlow.cs:261:26:261:35 | sinkParam7 |
-| GlobalDataFlow.cs:56:46:56:46 | access to parameter x | GlobalDataFlow.cs:261:26:261:35 | sinkParam7 |
-| GlobalDataFlow.cs:56:46:56:46 | access to parameter x | GlobalDataFlow.cs:261:26:261:35 | sinkParam7 |
+| GlobalDataFlow.cs:56:46:56:46 | access to parameter x | GlobalDataFlow.cs:265:26:265:35 | sinkParam7 |
+| GlobalDataFlow.cs:56:46:56:46 | access to parameter x | GlobalDataFlow.cs:265:26:265:35 | sinkParam7 |
+| GlobalDataFlow.cs:56:46:56:46 | access to parameter x | GlobalDataFlow.cs:265:26:265:35 | sinkParam7 |
+| GlobalDataFlow.cs:56:46:56:46 | access to parameter x | GlobalDataFlow.cs:265:26:265:35 | sinkParam7 |
 | GlobalDataFlow.cs:57:9:57:53 | call to method ApplyDelegate | GlobalDataFlow.cs:57:9:57:53 | call to method ApplyDelegate |
 | GlobalDataFlow.cs:57:23:57:32 | access to field myDelegate | GlobalDataFlow.cs:57:23:57:32 | access to field myDelegate |
-| GlobalDataFlow.cs:57:23:57:32 | access to field myDelegate | GlobalDataFlow.cs:368:42:368:42 | a |
-| GlobalDataFlow.cs:57:23:57:32 | access to field myDelegate | GlobalDataFlow.cs:368:42:368:42 | a |
+| GlobalDataFlow.cs:57:23:57:32 | access to field myDelegate | GlobalDataFlow.cs:373:42:373:42 | a |
+| GlobalDataFlow.cs:57:23:57:32 | access to field myDelegate | GlobalDataFlow.cs:373:42:373:42 | a |
 | GlobalDataFlow.cs:57:35:57:52 | access to property SinkProperty0 | GlobalDataFlow.cs:57:35:57:52 | access to property SinkProperty0 |
 | GlobalDataFlow.cs:57:35:57:52 | access to property SinkProperty0 | GlobalDataFlow.cs:64:22:64:39 | access to property SinkProperty0 |
 | GlobalDataFlow.cs:57:35:57:52 | access to property SinkProperty0 | GlobalDataFlow.cs:64:22:64:39 | access to property SinkProperty0 |
 | GlobalDataFlow.cs:57:35:57:52 | access to property SinkProperty0 | GlobalDataFlow.cs:70:28:70:45 | access to property SinkProperty0 |
 | GlobalDataFlow.cs:57:35:57:52 | access to property SinkProperty0 | GlobalDataFlow.cs:70:28:70:45 | access to property SinkProperty0 |
-| GlobalDataFlow.cs:57:35:57:52 | access to property SinkProperty0 | GlobalDataFlow.cs:368:52:368:52 | x |
-| GlobalDataFlow.cs:57:35:57:52 | access to property SinkProperty0 | GlobalDataFlow.cs:368:52:368:52 | x |
+| GlobalDataFlow.cs:57:35:57:52 | access to property SinkProperty0 | GlobalDataFlow.cs:373:52:373:52 | x |
+| GlobalDataFlow.cs:57:35:57:52 | access to property SinkProperty0 | GlobalDataFlow.cs:373:52:373:52 | x |
 | GlobalDataFlow.cs:60:9:60:67 | call to method Apply | GlobalDataFlow.cs:60:9:60:67 | call to method Apply |
 | GlobalDataFlow.cs:60:15:60:27 | nonSinkParam0 | GlobalDataFlow.cs:60:15:60:27 | nonSinkParam0 |
 | GlobalDataFlow.cs:60:15:60:27 | nonSinkParam0 | GlobalDataFlow.cs:60:15:60:27 | nonSinkParam0 |
@@ -1078,17 +1078,17 @@
 | GlobalDataFlow.cs:60:15:60:27 | nonSinkParam0 | GlobalDataFlow.cs:60:38:60:50 | access to parameter nonSinkParam0 |
 | GlobalDataFlow.cs:60:15:60:27 | nonSinkParam0 | GlobalDataFlow.cs:60:38:60:50 | access to parameter nonSinkParam0 |
 | GlobalDataFlow.cs:60:15:60:51 | (...) => ... | GlobalDataFlow.cs:60:15:60:51 | (...) => ... |
-| GlobalDataFlow.cs:60:15:60:51 | (...) => ... | GlobalDataFlow.cs:354:36:354:36 | a |
-| GlobalDataFlow.cs:60:15:60:51 | (...) => ... | GlobalDataFlow.cs:354:36:354:36 | a |
+| GlobalDataFlow.cs:60:15:60:51 | (...) => ... | GlobalDataFlow.cs:359:36:359:36 | a |
+| GlobalDataFlow.cs:60:15:60:51 | (...) => ... | GlobalDataFlow.cs:359:36:359:36 | a |
 | GlobalDataFlow.cs:60:32:60:51 | call to method Check | GlobalDataFlow.cs:60:32:60:51 | call to method Check |
 | GlobalDataFlow.cs:60:38:60:50 | access to parameter nonSinkParam0 | GlobalDataFlow.cs:60:38:60:50 | access to parameter nonSinkParam0 |
 | GlobalDataFlow.cs:60:54:60:66 | "not tainted" | GlobalDataFlow.cs:60:54:60:66 | "not tainted" |
-| GlobalDataFlow.cs:60:54:60:66 | "not tainted" | GlobalDataFlow.cs:354:41:354:41 | x |
-| GlobalDataFlow.cs:60:54:60:66 | "not tainted" | GlobalDataFlow.cs:354:41:354:41 | x |
+| GlobalDataFlow.cs:60:54:60:66 | "not tainted" | GlobalDataFlow.cs:359:41:359:41 | x |
+| GlobalDataFlow.cs:60:54:60:66 | "not tainted" | GlobalDataFlow.cs:359:41:359:41 | x |
 | GlobalDataFlow.cs:61:9:61:91 | call to method ApplyDelegate | GlobalDataFlow.cs:61:9:61:91 | call to method ApplyDelegate |
 | GlobalDataFlow.cs:61:23:61:75 | delegate creation of type MyDelegate | GlobalDataFlow.cs:61:23:61:75 | delegate creation of type MyDelegate |
-| GlobalDataFlow.cs:61:23:61:75 | delegate creation of type MyDelegate | GlobalDataFlow.cs:368:42:368:42 | a |
-| GlobalDataFlow.cs:61:23:61:75 | delegate creation of type MyDelegate | GlobalDataFlow.cs:368:42:368:42 | a |
+| GlobalDataFlow.cs:61:23:61:75 | delegate creation of type MyDelegate | GlobalDataFlow.cs:373:42:373:42 | a |
+| GlobalDataFlow.cs:61:23:61:75 | delegate creation of type MyDelegate | GlobalDataFlow.cs:373:42:373:42 | a |
 | GlobalDataFlow.cs:61:38:61:50 | nonSinkParam0 | GlobalDataFlow.cs:61:38:61:50 | nonSinkParam0 |
 | GlobalDataFlow.cs:61:38:61:50 | nonSinkParam0 | GlobalDataFlow.cs:61:38:61:50 | nonSinkParam0 |
 | GlobalDataFlow.cs:61:38:61:50 | nonSinkParam0 | GlobalDataFlow.cs:61:61:61:73 | access to parameter nonSinkParam0 |
@@ -1099,76 +1099,76 @@
 | GlobalDataFlow.cs:61:55:61:74 | call to method Check | GlobalDataFlow.cs:61:55:61:74 | call to method Check |
 | GlobalDataFlow.cs:61:61:61:73 | access to parameter nonSinkParam0 | GlobalDataFlow.cs:61:61:61:73 | access to parameter nonSinkParam0 |
 | GlobalDataFlow.cs:61:78:61:90 | "not tainted" | GlobalDataFlow.cs:61:78:61:90 | "not tainted" |
-| GlobalDataFlow.cs:61:78:61:90 | "not tainted" | GlobalDataFlow.cs:368:52:368:52 | x |
-| GlobalDataFlow.cs:61:78:61:90 | "not tainted" | GlobalDataFlow.cs:368:52:368:52 | x |
+| GlobalDataFlow.cs:61:78:61:90 | "not tainted" | GlobalDataFlow.cs:373:52:373:52 | x |
+| GlobalDataFlow.cs:61:78:61:90 | "not tainted" | GlobalDataFlow.cs:373:52:373:52 | x |
 | GlobalDataFlow.cs:64:9:64:18 | access to property InProperty | GlobalDataFlow.cs:64:9:64:18 | access to property InProperty |
 | GlobalDataFlow.cs:64:9:64:18 | this access | GlobalDataFlow.cs:64:9:64:18 | this access |
 | GlobalDataFlow.cs:64:9:64:18 | this access | GlobalDataFlow.cs:67:9:67:21 | this access |
 | GlobalDataFlow.cs:64:9:64:18 | this access | GlobalDataFlow.cs:67:9:67:21 | this access |
-| GlobalDataFlow.cs:64:9:64:18 | this access | GlobalDataFlow.cs:149:21:149:25 | this access |
-| GlobalDataFlow.cs:64:9:64:18 | this access | GlobalDataFlow.cs:149:21:149:25 | this access |
-| GlobalDataFlow.cs:64:9:64:18 | this access | GlobalDataFlow.cs:152:9:152:25 | this access |
-| GlobalDataFlow.cs:64:9:64:18 | this access | GlobalDataFlow.cs:152:9:152:25 | this access |
-| GlobalDataFlow.cs:64:9:64:18 | this access | GlobalDataFlow.cs:155:9:155:25 | this access |
-| GlobalDataFlow.cs:64:9:64:18 | this access | GlobalDataFlow.cs:155:9:155:25 | this access |
-| GlobalDataFlow.cs:64:9:64:18 | this access | GlobalDataFlow.cs:157:22:157:31 | this access |
-| GlobalDataFlow.cs:64:9:64:18 | this access | GlobalDataFlow.cs:157:22:157:31 | this access |
-| GlobalDataFlow.cs:64:9:64:18 | this access | GlobalDataFlow.cs:163:20:163:27 | this access |
-| GlobalDataFlow.cs:64:9:64:18 | this access | GlobalDataFlow.cs:163:20:163:27 | this access |
-| GlobalDataFlow.cs:64:9:64:18 | this access | GlobalDataFlow.cs:165:9:165:31 | this access |
-| GlobalDataFlow.cs:64:9:64:18 | this access | GlobalDataFlow.cs:165:9:165:31 | this access |
-| GlobalDataFlow.cs:64:9:64:18 | this access | GlobalDataFlow.cs:167:9:167:31 | this access |
-| GlobalDataFlow.cs:64:9:64:18 | this access | GlobalDataFlow.cs:167:9:167:31 | this access |
-| GlobalDataFlow.cs:64:9:64:18 | this access | GlobalDataFlow.cs:169:20:169:32 | this access |
-| GlobalDataFlow.cs:64:9:64:18 | this access | GlobalDataFlow.cs:169:20:169:32 | this access |
-| GlobalDataFlow.cs:64:9:64:18 | this access | GlobalDataFlow.cs:185:39:185:41 | this access |
-| GlobalDataFlow.cs:64:9:64:18 | this access | GlobalDataFlow.cs:185:39:185:41 | this access |
-| GlobalDataFlow.cs:64:9:64:18 | this access | GlobalDataFlow.cs:189:37:189:42 | this access |
-| GlobalDataFlow.cs:64:9:64:18 | this access | GlobalDataFlow.cs:189:37:189:42 | this access |
-| GlobalDataFlow.cs:64:9:64:18 | this access | GlobalDataFlow.cs:193:22:193:32 | this access |
-| GlobalDataFlow.cs:64:9:64:18 | this access | GlobalDataFlow.cs:193:22:193:32 | this access |
-| GlobalDataFlow.cs:64:9:64:18 | this access | GlobalDataFlow.cs:197:20:197:33 | this access |
-| GlobalDataFlow.cs:64:9:64:18 | this access | GlobalDataFlow.cs:197:20:197:33 | this access |
-| GlobalDataFlow.cs:64:9:64:18 | this access | GlobalDataFlow.cs:399:9:399:11 | this |
-| GlobalDataFlow.cs:64:9:64:18 | this access | GlobalDataFlow.cs:399:9:399:11 | this |
+| GlobalDataFlow.cs:64:9:64:18 | this access | GlobalDataFlow.cs:153:21:153:25 | this access |
+| GlobalDataFlow.cs:64:9:64:18 | this access | GlobalDataFlow.cs:153:21:153:25 | this access |
+| GlobalDataFlow.cs:64:9:64:18 | this access | GlobalDataFlow.cs:156:9:156:25 | this access |
+| GlobalDataFlow.cs:64:9:64:18 | this access | GlobalDataFlow.cs:156:9:156:25 | this access |
+| GlobalDataFlow.cs:64:9:64:18 | this access | GlobalDataFlow.cs:159:9:159:25 | this access |
+| GlobalDataFlow.cs:64:9:64:18 | this access | GlobalDataFlow.cs:159:9:159:25 | this access |
+| GlobalDataFlow.cs:64:9:64:18 | this access | GlobalDataFlow.cs:161:22:161:31 | this access |
+| GlobalDataFlow.cs:64:9:64:18 | this access | GlobalDataFlow.cs:161:22:161:31 | this access |
+| GlobalDataFlow.cs:64:9:64:18 | this access | GlobalDataFlow.cs:167:20:167:27 | this access |
+| GlobalDataFlow.cs:64:9:64:18 | this access | GlobalDataFlow.cs:167:20:167:27 | this access |
+| GlobalDataFlow.cs:64:9:64:18 | this access | GlobalDataFlow.cs:169:9:169:31 | this access |
+| GlobalDataFlow.cs:64:9:64:18 | this access | GlobalDataFlow.cs:169:9:169:31 | this access |
+| GlobalDataFlow.cs:64:9:64:18 | this access | GlobalDataFlow.cs:171:9:171:31 | this access |
+| GlobalDataFlow.cs:64:9:64:18 | this access | GlobalDataFlow.cs:171:9:171:31 | this access |
+| GlobalDataFlow.cs:64:9:64:18 | this access | GlobalDataFlow.cs:173:20:173:32 | this access |
+| GlobalDataFlow.cs:64:9:64:18 | this access | GlobalDataFlow.cs:173:20:173:32 | this access |
+| GlobalDataFlow.cs:64:9:64:18 | this access | GlobalDataFlow.cs:189:39:189:41 | this access |
+| GlobalDataFlow.cs:64:9:64:18 | this access | GlobalDataFlow.cs:189:39:189:41 | this access |
+| GlobalDataFlow.cs:64:9:64:18 | this access | GlobalDataFlow.cs:193:37:193:42 | this access |
+| GlobalDataFlow.cs:64:9:64:18 | this access | GlobalDataFlow.cs:193:37:193:42 | this access |
+| GlobalDataFlow.cs:64:9:64:18 | this access | GlobalDataFlow.cs:197:22:197:32 | this access |
+| GlobalDataFlow.cs:64:9:64:18 | this access | GlobalDataFlow.cs:197:22:197:32 | this access |
+| GlobalDataFlow.cs:64:9:64:18 | this access | GlobalDataFlow.cs:201:20:201:33 | this access |
+| GlobalDataFlow.cs:64:9:64:18 | this access | GlobalDataFlow.cs:201:20:201:33 | this access |
+| GlobalDataFlow.cs:64:9:64:18 | this access | GlobalDataFlow.cs:404:9:404:11 | this |
+| GlobalDataFlow.cs:64:9:64:18 | this access | GlobalDataFlow.cs:404:9:404:11 | this |
 | GlobalDataFlow.cs:64:9:64:39 | ... = ... | GlobalDataFlow.cs:64:9:64:39 | ... = ... |
 | GlobalDataFlow.cs:64:22:64:39 | access to property SinkProperty0 | GlobalDataFlow.cs:64:22:64:39 | access to property SinkProperty0 |
 | GlobalDataFlow.cs:64:22:64:39 | access to property SinkProperty0 | GlobalDataFlow.cs:70:28:70:45 | access to property SinkProperty0 |
 | GlobalDataFlow.cs:64:22:64:39 | access to property SinkProperty0 | GlobalDataFlow.cs:70:28:70:45 | access to property SinkProperty0 |
-| GlobalDataFlow.cs:64:22:64:39 | access to property SinkProperty0 | GlobalDataFlow.cs:399:9:399:11 | value |
-| GlobalDataFlow.cs:64:22:64:39 | access to property SinkProperty0 | GlobalDataFlow.cs:399:9:399:11 | value |
+| GlobalDataFlow.cs:64:22:64:39 | access to property SinkProperty0 | GlobalDataFlow.cs:404:9:404:11 | value |
+| GlobalDataFlow.cs:64:22:64:39 | access to property SinkProperty0 | GlobalDataFlow.cs:404:9:404:11 | value |
 | GlobalDataFlow.cs:67:9:67:21 | access to property NonInProperty | GlobalDataFlow.cs:67:9:67:21 | access to property NonInProperty |
 | GlobalDataFlow.cs:67:9:67:21 | this access | GlobalDataFlow.cs:67:9:67:21 | this access |
-| GlobalDataFlow.cs:67:9:67:21 | this access | GlobalDataFlow.cs:149:21:149:25 | this access |
-| GlobalDataFlow.cs:67:9:67:21 | this access | GlobalDataFlow.cs:149:21:149:25 | this access |
-| GlobalDataFlow.cs:67:9:67:21 | this access | GlobalDataFlow.cs:152:9:152:25 | this access |
-| GlobalDataFlow.cs:67:9:67:21 | this access | GlobalDataFlow.cs:152:9:152:25 | this access |
-| GlobalDataFlow.cs:67:9:67:21 | this access | GlobalDataFlow.cs:155:9:155:25 | this access |
-| GlobalDataFlow.cs:67:9:67:21 | this access | GlobalDataFlow.cs:155:9:155:25 | this access |
-| GlobalDataFlow.cs:67:9:67:21 | this access | GlobalDataFlow.cs:157:22:157:31 | this access |
-| GlobalDataFlow.cs:67:9:67:21 | this access | GlobalDataFlow.cs:157:22:157:31 | this access |
-| GlobalDataFlow.cs:67:9:67:21 | this access | GlobalDataFlow.cs:163:20:163:27 | this access |
-| GlobalDataFlow.cs:67:9:67:21 | this access | GlobalDataFlow.cs:163:20:163:27 | this access |
-| GlobalDataFlow.cs:67:9:67:21 | this access | GlobalDataFlow.cs:165:9:165:31 | this access |
-| GlobalDataFlow.cs:67:9:67:21 | this access | GlobalDataFlow.cs:165:9:165:31 | this access |
-| GlobalDataFlow.cs:67:9:67:21 | this access | GlobalDataFlow.cs:167:9:167:31 | this access |
-| GlobalDataFlow.cs:67:9:67:21 | this access | GlobalDataFlow.cs:167:9:167:31 | this access |
-| GlobalDataFlow.cs:67:9:67:21 | this access | GlobalDataFlow.cs:169:20:169:32 | this access |
-| GlobalDataFlow.cs:67:9:67:21 | this access | GlobalDataFlow.cs:169:20:169:32 | this access |
-| GlobalDataFlow.cs:67:9:67:21 | this access | GlobalDataFlow.cs:185:39:185:41 | this access |
-| GlobalDataFlow.cs:67:9:67:21 | this access | GlobalDataFlow.cs:185:39:185:41 | this access |
-| GlobalDataFlow.cs:67:9:67:21 | this access | GlobalDataFlow.cs:189:37:189:42 | this access |
-| GlobalDataFlow.cs:67:9:67:21 | this access | GlobalDataFlow.cs:189:37:189:42 | this access |
-| GlobalDataFlow.cs:67:9:67:21 | this access | GlobalDataFlow.cs:193:22:193:32 | this access |
-| GlobalDataFlow.cs:67:9:67:21 | this access | GlobalDataFlow.cs:193:22:193:32 | this access |
-| GlobalDataFlow.cs:67:9:67:21 | this access | GlobalDataFlow.cs:197:20:197:33 | this access |
-| GlobalDataFlow.cs:67:9:67:21 | this access | GlobalDataFlow.cs:197:20:197:33 | this access |
-| GlobalDataFlow.cs:67:9:67:21 | this access | GlobalDataFlow.cs:405:9:405:11 | this |
-| GlobalDataFlow.cs:67:9:67:21 | this access | GlobalDataFlow.cs:405:9:405:11 | this |
+| GlobalDataFlow.cs:67:9:67:21 | this access | GlobalDataFlow.cs:153:21:153:25 | this access |
+| GlobalDataFlow.cs:67:9:67:21 | this access | GlobalDataFlow.cs:153:21:153:25 | this access |
+| GlobalDataFlow.cs:67:9:67:21 | this access | GlobalDataFlow.cs:156:9:156:25 | this access |
+| GlobalDataFlow.cs:67:9:67:21 | this access | GlobalDataFlow.cs:156:9:156:25 | this access |
+| GlobalDataFlow.cs:67:9:67:21 | this access | GlobalDataFlow.cs:159:9:159:25 | this access |
+| GlobalDataFlow.cs:67:9:67:21 | this access | GlobalDataFlow.cs:159:9:159:25 | this access |
+| GlobalDataFlow.cs:67:9:67:21 | this access | GlobalDataFlow.cs:161:22:161:31 | this access |
+| GlobalDataFlow.cs:67:9:67:21 | this access | GlobalDataFlow.cs:161:22:161:31 | this access |
+| GlobalDataFlow.cs:67:9:67:21 | this access | GlobalDataFlow.cs:167:20:167:27 | this access |
+| GlobalDataFlow.cs:67:9:67:21 | this access | GlobalDataFlow.cs:167:20:167:27 | this access |
+| GlobalDataFlow.cs:67:9:67:21 | this access | GlobalDataFlow.cs:169:9:169:31 | this access |
+| GlobalDataFlow.cs:67:9:67:21 | this access | GlobalDataFlow.cs:169:9:169:31 | this access |
+| GlobalDataFlow.cs:67:9:67:21 | this access | GlobalDataFlow.cs:171:9:171:31 | this access |
+| GlobalDataFlow.cs:67:9:67:21 | this access | GlobalDataFlow.cs:171:9:171:31 | this access |
+| GlobalDataFlow.cs:67:9:67:21 | this access | GlobalDataFlow.cs:173:20:173:32 | this access |
+| GlobalDataFlow.cs:67:9:67:21 | this access | GlobalDataFlow.cs:173:20:173:32 | this access |
+| GlobalDataFlow.cs:67:9:67:21 | this access | GlobalDataFlow.cs:189:39:189:41 | this access |
+| GlobalDataFlow.cs:67:9:67:21 | this access | GlobalDataFlow.cs:189:39:189:41 | this access |
+| GlobalDataFlow.cs:67:9:67:21 | this access | GlobalDataFlow.cs:193:37:193:42 | this access |
+| GlobalDataFlow.cs:67:9:67:21 | this access | GlobalDataFlow.cs:193:37:193:42 | this access |
+| GlobalDataFlow.cs:67:9:67:21 | this access | GlobalDataFlow.cs:197:22:197:32 | this access |
+| GlobalDataFlow.cs:67:9:67:21 | this access | GlobalDataFlow.cs:197:22:197:32 | this access |
+| GlobalDataFlow.cs:67:9:67:21 | this access | GlobalDataFlow.cs:201:20:201:33 | this access |
+| GlobalDataFlow.cs:67:9:67:21 | this access | GlobalDataFlow.cs:201:20:201:33 | this access |
+| GlobalDataFlow.cs:67:9:67:21 | this access | GlobalDataFlow.cs:410:9:410:11 | this |
+| GlobalDataFlow.cs:67:9:67:21 | this access | GlobalDataFlow.cs:410:9:410:11 | this |
 | GlobalDataFlow.cs:67:9:67:37 | ... = ... | GlobalDataFlow.cs:67:9:67:37 | ... = ... |
 | GlobalDataFlow.cs:67:25:67:37 | "not tainted" | GlobalDataFlow.cs:67:25:67:37 | "not tainted" |
-| GlobalDataFlow.cs:67:25:67:37 | "not tainted" | GlobalDataFlow.cs:405:9:405:11 | value |
-| GlobalDataFlow.cs:67:25:67:37 | "not tainted" | GlobalDataFlow.cs:405:9:405:11 | value |
+| GlobalDataFlow.cs:67:25:67:37 | "not tainted" | GlobalDataFlow.cs:410:9:410:11 | value |
+| GlobalDataFlow.cs:67:25:67:37 | "not tainted" | GlobalDataFlow.cs:410:9:410:11 | value |
 | GlobalDataFlow.cs:70:13:70:46 | SSA def(sink0) | GlobalDataFlow.cs:70:13:70:46 | SSA def(sink0) |
 | GlobalDataFlow.cs:70:13:70:46 | SSA def(sink0) | GlobalDataFlow.cs:71:15:71:19 | access to local variable sink0 |
 | GlobalDataFlow.cs:70:13:70:46 | SSA def(sink0) | GlobalDataFlow.cs:71:15:71:19 | access to local variable sink0 |
@@ -1185,8 +1185,8 @@
 | GlobalDataFlow.cs:70:28:70:45 | access to property SinkProperty0 | GlobalDataFlow.cs:70:21:70:46 | call to method Return |
 | GlobalDataFlow.cs:70:28:70:45 | access to property SinkProperty0 | GlobalDataFlow.cs:70:21:70:46 | call to method Return |
 | GlobalDataFlow.cs:70:28:70:45 | access to property SinkProperty0 | GlobalDataFlow.cs:70:28:70:45 | access to property SinkProperty0 |
-| GlobalDataFlow.cs:70:28:70:45 | access to property SinkProperty0 | GlobalDataFlow.cs:271:26:271:26 | x |
-| GlobalDataFlow.cs:70:28:70:45 | access to property SinkProperty0 | GlobalDataFlow.cs:271:26:271:26 | x |
+| GlobalDataFlow.cs:70:28:70:45 | access to property SinkProperty0 | GlobalDataFlow.cs:275:26:275:26 | x |
+| GlobalDataFlow.cs:70:28:70:45 | access to property SinkProperty0 | GlobalDataFlow.cs:275:26:275:26 | x |
 | GlobalDataFlow.cs:71:9:71:20 | call to method Check | GlobalDataFlow.cs:71:9:71:20 | call to method Check |
 | GlobalDataFlow.cs:71:15:71:19 | access to local variable sink0 | GlobalDataFlow.cs:71:15:71:19 | access to local variable sink0 |
 | GlobalDataFlow.cs:71:15:71:19 | access to local variable sink0 | GlobalDataFlow.cs:72:94:72:98 | access to local variable sink0 |
@@ -1196,8 +1196,12 @@
 | GlobalDataFlow.cs:72:13:72:101 | SSA def(sink1) | GlobalDataFlow.cs:73:15:73:19 | access to local variable sink1 |
 | GlobalDataFlow.cs:72:13:72:101 | SSA def(sink1) | GlobalDataFlow.cs:75:19:75:23 | access to local variable sink1 |
 | GlobalDataFlow.cs:72:13:72:101 | SSA def(sink1) | GlobalDataFlow.cs:75:19:75:23 | access to local variable sink1 |
-| GlobalDataFlow.cs:72:13:72:101 | SSA def(sink1) | GlobalDataFlow.cs:120:39:120:43 | access to local variable sink1 |
-| GlobalDataFlow.cs:72:13:72:101 | SSA def(sink1) | GlobalDataFlow.cs:120:39:120:43 | access to local variable sink1 |
+| GlobalDataFlow.cs:72:13:72:101 | SSA def(sink1) | GlobalDataFlow.cs:106:19:106:23 | access to local variable sink1 |
+| GlobalDataFlow.cs:72:13:72:101 | SSA def(sink1) | GlobalDataFlow.cs:106:19:106:23 | access to local variable sink1 |
+| GlobalDataFlow.cs:72:13:72:101 | SSA def(sink1) | GlobalDataFlow.cs:110:19:110:23 | access to local variable sink1 |
+| GlobalDataFlow.cs:72:13:72:101 | SSA def(sink1) | GlobalDataFlow.cs:110:19:110:23 | access to local variable sink1 |
+| GlobalDataFlow.cs:72:13:72:101 | SSA def(sink1) | GlobalDataFlow.cs:110:30:110:34 | access to local variable sink1 |
+| GlobalDataFlow.cs:72:13:72:101 | SSA def(sink1) | GlobalDataFlow.cs:110:30:110:34 | access to local variable sink1 |
 | GlobalDataFlow.cs:72:13:72:101 | String sink1 = ... | GlobalDataFlow.cs:72:13:72:101 | String sink1 = ... |
 | GlobalDataFlow.cs:72:21:72:101 | (...) ... | GlobalDataFlow.cs:72:13:72:101 | SSA def(sink1) |
 | GlobalDataFlow.cs:72:21:72:101 | (...) ... | GlobalDataFlow.cs:72:13:72:101 | SSA def(sink1) |
@@ -1206,8 +1210,12 @@
 | GlobalDataFlow.cs:72:21:72:101 | (...) ... | GlobalDataFlow.cs:73:15:73:19 | access to local variable sink1 |
 | GlobalDataFlow.cs:72:21:72:101 | (...) ... | GlobalDataFlow.cs:75:19:75:23 | access to local variable sink1 |
 | GlobalDataFlow.cs:72:21:72:101 | (...) ... | GlobalDataFlow.cs:75:19:75:23 | access to local variable sink1 |
-| GlobalDataFlow.cs:72:21:72:101 | (...) ... | GlobalDataFlow.cs:120:39:120:43 | access to local variable sink1 |
-| GlobalDataFlow.cs:72:21:72:101 | (...) ... | GlobalDataFlow.cs:120:39:120:43 | access to local variable sink1 |
+| GlobalDataFlow.cs:72:21:72:101 | (...) ... | GlobalDataFlow.cs:106:19:106:23 | access to local variable sink1 |
+| GlobalDataFlow.cs:72:21:72:101 | (...) ... | GlobalDataFlow.cs:106:19:106:23 | access to local variable sink1 |
+| GlobalDataFlow.cs:72:21:72:101 | (...) ... | GlobalDataFlow.cs:110:19:110:23 | access to local variable sink1 |
+| GlobalDataFlow.cs:72:21:72:101 | (...) ... | GlobalDataFlow.cs:110:19:110:23 | access to local variable sink1 |
+| GlobalDataFlow.cs:72:21:72:101 | (...) ... | GlobalDataFlow.cs:110:30:110:34 | access to local variable sink1 |
+| GlobalDataFlow.cs:72:21:72:101 | (...) ... | GlobalDataFlow.cs:110:30:110:34 | access to local variable sink1 |
 | GlobalDataFlow.cs:72:29:72:44 | typeof(...) | GlobalDataFlow.cs:72:29:72:44 | typeof(...) |
 | GlobalDataFlow.cs:72:29:72:64 | call to method GetMethod | GlobalDataFlow.cs:72:29:72:64 | call to method GetMethod |
 | GlobalDataFlow.cs:72:29:72:101 | call to method Invoke | GlobalDataFlow.cs:72:21:72:101 | (...) ... |
@@ -1220,23 +1228,31 @@
 | GlobalDataFlow.cs:72:94:72:98 | access to local variable sink0 | GlobalDataFlow.cs:72:29:72:101 | call to method Invoke |
 | GlobalDataFlow.cs:72:94:72:98 | access to local variable sink0 | GlobalDataFlow.cs:72:29:72:101 | call to method Invoke |
 | GlobalDataFlow.cs:72:94:72:98 | access to local variable sink0 | GlobalDataFlow.cs:72:94:72:98 | access to local variable sink0 |
-| GlobalDataFlow.cs:72:94:72:98 | access to local variable sink0 | GlobalDataFlow.cs:271:26:271:26 | x |
-| GlobalDataFlow.cs:72:94:72:98 | access to local variable sink0 | GlobalDataFlow.cs:271:26:271:26 | x |
+| GlobalDataFlow.cs:72:94:72:98 | access to local variable sink0 | GlobalDataFlow.cs:275:26:275:26 | x |
+| GlobalDataFlow.cs:72:94:72:98 | access to local variable sink0 | GlobalDataFlow.cs:275:26:275:26 | x |
 | GlobalDataFlow.cs:73:9:73:20 | call to method Check | GlobalDataFlow.cs:73:9:73:20 | call to method Check |
 | GlobalDataFlow.cs:73:15:73:19 | access to local variable sink1 | GlobalDataFlow.cs:73:15:73:19 | access to local variable sink1 |
 | GlobalDataFlow.cs:73:15:73:19 | access to local variable sink1 | GlobalDataFlow.cs:75:19:75:23 | access to local variable sink1 |
 | GlobalDataFlow.cs:73:15:73:19 | access to local variable sink1 | GlobalDataFlow.cs:75:19:75:23 | access to local variable sink1 |
-| GlobalDataFlow.cs:73:15:73:19 | access to local variable sink1 | GlobalDataFlow.cs:120:39:120:43 | access to local variable sink1 |
-| GlobalDataFlow.cs:73:15:73:19 | access to local variable sink1 | GlobalDataFlow.cs:120:39:120:43 | access to local variable sink1 |
+| GlobalDataFlow.cs:73:15:73:19 | access to local variable sink1 | GlobalDataFlow.cs:106:19:106:23 | access to local variable sink1 |
+| GlobalDataFlow.cs:73:15:73:19 | access to local variable sink1 | GlobalDataFlow.cs:106:19:106:23 | access to local variable sink1 |
+| GlobalDataFlow.cs:73:15:73:19 | access to local variable sink1 | GlobalDataFlow.cs:110:19:110:23 | access to local variable sink1 |
+| GlobalDataFlow.cs:73:15:73:19 | access to local variable sink1 | GlobalDataFlow.cs:110:19:110:23 | access to local variable sink1 |
+| GlobalDataFlow.cs:73:15:73:19 | access to local variable sink1 | GlobalDataFlow.cs:110:30:110:34 | access to local variable sink1 |
+| GlobalDataFlow.cs:73:15:73:19 | access to local variable sink1 | GlobalDataFlow.cs:110:30:110:34 | access to local variable sink1 |
 | GlobalDataFlow.cs:74:16:74:20 | String sink2 | GlobalDataFlow.cs:74:16:74:20 | String sink2 |
-| GlobalDataFlow.cs:75:9:75:35 | call to method ReturnOut | GlobalDataFlow.cs:75:9:75:35 | call to method ReturnOut |
+| GlobalDataFlow.cs:75:9:75:46 | call to method ReturnOut | GlobalDataFlow.cs:75:9:75:46 | call to method ReturnOut |
 | GlobalDataFlow.cs:75:19:75:23 | access to local variable sink1 | GlobalDataFlow.cs:75:19:75:23 | access to local variable sink1 |
 | GlobalDataFlow.cs:75:19:75:23 | access to local variable sink1 | GlobalDataFlow.cs:75:30:75:34 | SSA def(sink2) |
 | GlobalDataFlow.cs:75:19:75:23 | access to local variable sink1 | GlobalDataFlow.cs:75:30:75:34 | SSA def(sink2) |
-| GlobalDataFlow.cs:75:19:75:23 | access to local variable sink1 | GlobalDataFlow.cs:120:39:120:43 | access to local variable sink1 |
-| GlobalDataFlow.cs:75:19:75:23 | access to local variable sink1 | GlobalDataFlow.cs:120:39:120:43 | access to local variable sink1 |
-| GlobalDataFlow.cs:75:19:75:23 | access to local variable sink1 | GlobalDataFlow.cs:277:32:277:32 | x |
-| GlobalDataFlow.cs:75:19:75:23 | access to local variable sink1 | GlobalDataFlow.cs:277:32:277:32 | x |
+| GlobalDataFlow.cs:75:19:75:23 | access to local variable sink1 | GlobalDataFlow.cs:106:19:106:23 | access to local variable sink1 |
+| GlobalDataFlow.cs:75:19:75:23 | access to local variable sink1 | GlobalDataFlow.cs:106:19:106:23 | access to local variable sink1 |
+| GlobalDataFlow.cs:75:19:75:23 | access to local variable sink1 | GlobalDataFlow.cs:110:19:110:23 | access to local variable sink1 |
+| GlobalDataFlow.cs:75:19:75:23 | access to local variable sink1 | GlobalDataFlow.cs:110:19:110:23 | access to local variable sink1 |
+| GlobalDataFlow.cs:75:19:75:23 | access to local variable sink1 | GlobalDataFlow.cs:110:30:110:34 | access to local variable sink1 |
+| GlobalDataFlow.cs:75:19:75:23 | access to local variable sink1 | GlobalDataFlow.cs:110:30:110:34 | access to local variable sink1 |
+| GlobalDataFlow.cs:75:19:75:23 | access to local variable sink1 | GlobalDataFlow.cs:281:32:281:32 | x |
+| GlobalDataFlow.cs:75:19:75:23 | access to local variable sink1 | GlobalDataFlow.cs:281:32:281:32 | x |
 | GlobalDataFlow.cs:75:30:75:34 | SSA def(sink2) | GlobalDataFlow.cs:75:30:75:34 | SSA def(sink2) |
 | GlobalDataFlow.cs:75:30:75:34 | SSA def(sink2) | GlobalDataFlow.cs:76:15:76:19 | access to local variable sink2 |
 | GlobalDataFlow.cs:75:30:75:34 | SSA def(sink2) | GlobalDataFlow.cs:76:15:76:19 | access to local variable sink2 |
@@ -1249,32 +1265,43 @@
 | GlobalDataFlow.cs:77:13:77:22 | SSA def(sink3) | GlobalDataFlow.cs:77:13:77:22 | SSA def(sink3) |
 | GlobalDataFlow.cs:77:13:77:22 | SSA def(sink3) | GlobalDataFlow.cs:78:30:78:34 | access to local variable sink3 |
 | GlobalDataFlow.cs:77:13:77:22 | SSA def(sink3) | GlobalDataFlow.cs:78:30:78:34 | access to local variable sink3 |
+| GlobalDataFlow.cs:77:13:77:22 | SSA def(sink3) | GlobalDataFlow.cs:78:41:78:45 | access to local variable sink3 |
+| GlobalDataFlow.cs:77:13:77:22 | SSA def(sink3) | GlobalDataFlow.cs:78:41:78:45 | access to local variable sink3 |
 | GlobalDataFlow.cs:77:13:77:22 | String sink3 = ... | GlobalDataFlow.cs:77:13:77:22 | String sink3 = ... |
 | GlobalDataFlow.cs:77:21:77:22 | "" | GlobalDataFlow.cs:77:13:77:22 | SSA def(sink3) |
 | GlobalDataFlow.cs:77:21:77:22 | "" | GlobalDataFlow.cs:77:13:77:22 | SSA def(sink3) |
 | GlobalDataFlow.cs:77:21:77:22 | "" | GlobalDataFlow.cs:77:21:77:22 | "" |
 | GlobalDataFlow.cs:77:21:77:22 | "" | GlobalDataFlow.cs:78:30:78:34 | access to local variable sink3 |
 | GlobalDataFlow.cs:77:21:77:22 | "" | GlobalDataFlow.cs:78:30:78:34 | access to local variable sink3 |
-| GlobalDataFlow.cs:78:9:78:35 | call to method ReturnRef | GlobalDataFlow.cs:78:9:78:35 | call to method ReturnRef |
+| GlobalDataFlow.cs:77:21:77:22 | "" | GlobalDataFlow.cs:78:41:78:45 | access to local variable sink3 |
+| GlobalDataFlow.cs:77:21:77:22 | "" | GlobalDataFlow.cs:78:41:78:45 | access to local variable sink3 |
+| GlobalDataFlow.cs:78:9:78:46 | call to method ReturnRef | GlobalDataFlow.cs:78:9:78:46 | call to method ReturnRef |
 | GlobalDataFlow.cs:78:19:78:23 | access to local variable sink2 | GlobalDataFlow.cs:78:19:78:23 | access to local variable sink2 |
 | GlobalDataFlow.cs:78:19:78:23 | access to local variable sink2 | GlobalDataFlow.cs:78:30:78:34 | SSA def(sink3) |
 | GlobalDataFlow.cs:78:19:78:23 | access to local variable sink2 | GlobalDataFlow.cs:78:30:78:34 | SSA def(sink3) |
-| GlobalDataFlow.cs:78:19:78:23 | access to local variable sink2 | GlobalDataFlow.cs:282:32:282:32 | x |
-| GlobalDataFlow.cs:78:19:78:23 | access to local variable sink2 | GlobalDataFlow.cs:282:32:282:32 | x |
+| GlobalDataFlow.cs:78:19:78:23 | access to local variable sink2 | GlobalDataFlow.cs:287:32:287:32 | x |
+| GlobalDataFlow.cs:78:19:78:23 | access to local variable sink2 | GlobalDataFlow.cs:287:32:287:32 | x |
 | GlobalDataFlow.cs:78:30:78:34 | SSA def(sink3) | GlobalDataFlow.cs:78:30:78:34 | SSA def(sink3) |
 | GlobalDataFlow.cs:78:30:78:34 | SSA def(sink3) | GlobalDataFlow.cs:79:15:79:19 | access to local variable sink3 |
 | GlobalDataFlow.cs:78:30:78:34 | SSA def(sink3) | GlobalDataFlow.cs:79:15:79:19 | access to local variable sink3 |
 | GlobalDataFlow.cs:78:30:78:34 | SSA def(sink3) | GlobalDataFlow.cs:80:59:80:63 | access to local variable sink3 |
 | GlobalDataFlow.cs:78:30:78:34 | SSA def(sink3) | GlobalDataFlow.cs:80:59:80:63 | access to local variable sink3 |
-| GlobalDataFlow.cs:78:30:78:34 | SSA def(sink3) | GlobalDataFlow.cs:131:29:131:33 | access to local variable sink3 |
-| GlobalDataFlow.cs:78:30:78:34 | SSA def(sink3) | GlobalDataFlow.cs:131:29:131:33 | access to local variable sink3 |
+| GlobalDataFlow.cs:78:30:78:34 | SSA def(sink3) | GlobalDataFlow.cs:135:29:135:33 | access to local variable sink3 |
+| GlobalDataFlow.cs:78:30:78:34 | SSA def(sink3) | GlobalDataFlow.cs:135:29:135:33 | access to local variable sink3 |
 | GlobalDataFlow.cs:78:30:78:34 | access to local variable sink3 | GlobalDataFlow.cs:78:30:78:34 | access to local variable sink3 |
+| GlobalDataFlow.cs:78:30:78:34 | access to local variable sink3 | GlobalDataFlow.cs:78:41:78:45 | access to local variable sink3 |
+| GlobalDataFlow.cs:78:30:78:34 | access to local variable sink3 | GlobalDataFlow.cs:78:41:78:45 | access to local variable sink3 |
+| GlobalDataFlow.cs:78:41:78:45 | access to local variable sink3 | GlobalDataFlow.cs:78:30:78:34 | SSA def(sink3) |
+| GlobalDataFlow.cs:78:41:78:45 | access to local variable sink3 | GlobalDataFlow.cs:78:30:78:34 | SSA def(sink3) |
+| GlobalDataFlow.cs:78:41:78:45 | access to local variable sink3 | GlobalDataFlow.cs:78:41:78:45 | access to local variable sink3 |
+| GlobalDataFlow.cs:78:41:78:45 | access to local variable sink3 | GlobalDataFlow.cs:287:50:287:50 | z |
+| GlobalDataFlow.cs:78:41:78:45 | access to local variable sink3 | GlobalDataFlow.cs:287:50:287:50 | z |
 | GlobalDataFlow.cs:79:9:79:20 | call to method Check | GlobalDataFlow.cs:79:9:79:20 | call to method Check |
 | GlobalDataFlow.cs:79:15:79:19 | access to local variable sink3 | GlobalDataFlow.cs:79:15:79:19 | access to local variable sink3 |
 | GlobalDataFlow.cs:79:15:79:19 | access to local variable sink3 | GlobalDataFlow.cs:80:59:80:63 | access to local variable sink3 |
 | GlobalDataFlow.cs:79:15:79:19 | access to local variable sink3 | GlobalDataFlow.cs:80:59:80:63 | access to local variable sink3 |
-| GlobalDataFlow.cs:79:15:79:19 | access to local variable sink3 | GlobalDataFlow.cs:131:29:131:33 | access to local variable sink3 |
-| GlobalDataFlow.cs:79:15:79:19 | access to local variable sink3 | GlobalDataFlow.cs:131:29:131:33 | access to local variable sink3 |
+| GlobalDataFlow.cs:79:15:79:19 | access to local variable sink3 | GlobalDataFlow.cs:135:29:135:33 | access to local variable sink3 |
+| GlobalDataFlow.cs:79:15:79:19 | access to local variable sink3 | GlobalDataFlow.cs:135:29:135:33 | access to local variable sink3 |
 | GlobalDataFlow.cs:80:13:80:85 | IEnumerable<String> sink13 = ... | GlobalDataFlow.cs:80:13:80:85 | IEnumerable<String> sink13 = ... |
 | GlobalDataFlow.cs:80:13:80:85 | SSA def(sink13) | GlobalDataFlow.cs:80:13:80:85 | SSA def(sink13) |
 | GlobalDataFlow.cs:80:13:80:85 | SSA def(sink13) | GlobalDataFlow.cs:81:15:81:20 | access to local variable sink13 |
@@ -1289,15 +1316,15 @@
 | GlobalDataFlow.cs:80:22:80:85 | call to method SelectEven | GlobalDataFlow.cs:82:59:82:64 | access to local variable sink13 |
 | GlobalDataFlow.cs:80:22:80:85 | call to method SelectEven | GlobalDataFlow.cs:82:59:82:64 | access to local variable sink13 |
 | GlobalDataFlow.cs:80:23:80:65 | (...) ... | GlobalDataFlow.cs:80:23:80:65 | (...) ... |
-| GlobalDataFlow.cs:80:23:80:65 | (...) ... | GlobalDataFlow.cs:421:71:421:71 | e |
-| GlobalDataFlow.cs:80:23:80:65 | (...) ... | GlobalDataFlow.cs:421:71:421:71 | e |
+| GlobalDataFlow.cs:80:23:80:65 | (...) ... | GlobalDataFlow.cs:426:71:426:71 | e |
+| GlobalDataFlow.cs:80:23:80:65 | (...) ... | GlobalDataFlow.cs:426:71:426:71 | e |
 | GlobalDataFlow.cs:80:44:80:65 | array creation of type String[] | GlobalDataFlow.cs:80:23:80:65 | (...) ... |
 | GlobalDataFlow.cs:80:44:80:65 | array creation of type String[] | GlobalDataFlow.cs:80:23:80:65 | (...) ... |
 | GlobalDataFlow.cs:80:44:80:65 | array creation of type String[] | GlobalDataFlow.cs:80:44:80:65 | array creation of type String[] |
 | GlobalDataFlow.cs:80:57:80:65 | { ..., ... } | GlobalDataFlow.cs:80:57:80:65 | { ..., ... } |
 | GlobalDataFlow.cs:80:59:80:63 | access to local variable sink3 | GlobalDataFlow.cs:80:59:80:63 | access to local variable sink3 |
-| GlobalDataFlow.cs:80:59:80:63 | access to local variable sink3 | GlobalDataFlow.cs:131:29:131:33 | access to local variable sink3 |
-| GlobalDataFlow.cs:80:59:80:63 | access to local variable sink3 | GlobalDataFlow.cs:131:29:131:33 | access to local variable sink3 |
+| GlobalDataFlow.cs:80:59:80:63 | access to local variable sink3 | GlobalDataFlow.cs:135:29:135:33 | access to local variable sink3 |
+| GlobalDataFlow.cs:80:59:80:63 | access to local variable sink3 | GlobalDataFlow.cs:135:29:135:33 | access to local variable sink3 |
 | GlobalDataFlow.cs:80:79:80:79 | x | GlobalDataFlow.cs:80:79:80:79 | x |
 | GlobalDataFlow.cs:80:79:80:79 | x | GlobalDataFlow.cs:80:79:80:79 | x |
 | GlobalDataFlow.cs:80:79:80:79 | x | GlobalDataFlow.cs:80:84:80:84 | access to parameter x |
@@ -1305,11 +1332,11 @@
 | GlobalDataFlow.cs:80:79:80:79 | x | GlobalDataFlow.cs:80:84:80:84 | access to parameter x |
 | GlobalDataFlow.cs:80:79:80:79 | x | GlobalDataFlow.cs:80:84:80:84 | access to parameter x |
 | GlobalDataFlow.cs:80:79:80:84 | (...) => ... | GlobalDataFlow.cs:80:79:80:84 | (...) => ... |
-| GlobalDataFlow.cs:80:79:80:84 | (...) => ... | GlobalDataFlow.cs:421:85:421:85 | f |
-| GlobalDataFlow.cs:80:79:80:84 | (...) => ... | GlobalDataFlow.cs:421:85:421:85 | f |
+| GlobalDataFlow.cs:80:79:80:84 | (...) => ... | GlobalDataFlow.cs:426:85:426:85 | f |
+| GlobalDataFlow.cs:80:79:80:84 | (...) => ... | GlobalDataFlow.cs:426:85:426:85 | f |
 | GlobalDataFlow.cs:80:84:80:84 | access to parameter x | GlobalDataFlow.cs:80:84:80:84 | access to parameter x |
-| GlobalDataFlow.cs:80:84:80:84 | access to parameter x | GlobalDataFlow.cs:426:44:426:47 | delegate call |
-| GlobalDataFlow.cs:80:84:80:84 | access to parameter x | GlobalDataFlow.cs:426:44:426:47 | delegate call |
+| GlobalDataFlow.cs:80:84:80:84 | access to parameter x | GlobalDataFlow.cs:431:44:431:47 | delegate call |
+| GlobalDataFlow.cs:80:84:80:84 | access to parameter x | GlobalDataFlow.cs:431:44:431:47 | delegate call |
 | GlobalDataFlow.cs:81:9:81:21 | call to method Check | GlobalDataFlow.cs:81:9:81:21 | call to method Check |
 | GlobalDataFlow.cs:81:15:81:20 | access to local variable sink13 | GlobalDataFlow.cs:81:15:81:20 | access to local variable sink13 |
 | GlobalDataFlow.cs:81:15:81:20 | access to local variable sink13 | GlobalDataFlow.cs:82:59:82:64 | access to local variable sink13 |
@@ -1324,12 +1351,12 @@
 | GlobalDataFlow.cs:82:13:82:95 | SSA def(sink14) | GlobalDataFlow.cs:88:22:88:27 | access to local variable sink14 |
 | GlobalDataFlow.cs:82:13:82:95 | SSA def(sink14) | GlobalDataFlow.cs:90:75:90:80 | access to local variable sink14 |
 | GlobalDataFlow.cs:82:13:82:95 | SSA def(sink14) | GlobalDataFlow.cs:90:75:90:80 | access to local variable sink14 |
-| GlobalDataFlow.cs:82:13:82:95 | SSA def(sink14) | GlobalDataFlow.cs:112:57:112:62 | access to local variable sink14 |
-| GlobalDataFlow.cs:82:13:82:95 | SSA def(sink14) | GlobalDataFlow.cs:112:57:112:62 | access to local variable sink14 |
-| GlobalDataFlow.cs:82:13:82:95 | SSA def(sink14) | GlobalDataFlow.cs:116:20:116:25 | access to local variable sink14 |
-| GlobalDataFlow.cs:82:13:82:95 | SSA def(sink14) | GlobalDataFlow.cs:116:20:116:25 | access to local variable sink14 |
-| GlobalDataFlow.cs:82:13:82:95 | SSA def(sink14) | GlobalDataFlow.cs:118:20:118:25 | access to local variable sink14 |
-| GlobalDataFlow.cs:82:13:82:95 | SSA def(sink14) | GlobalDataFlow.cs:118:20:118:25 | access to local variable sink14 |
+| GlobalDataFlow.cs:82:13:82:95 | SSA def(sink14) | GlobalDataFlow.cs:116:57:116:62 | access to local variable sink14 |
+| GlobalDataFlow.cs:82:13:82:95 | SSA def(sink14) | GlobalDataFlow.cs:116:57:116:62 | access to local variable sink14 |
+| GlobalDataFlow.cs:82:13:82:95 | SSA def(sink14) | GlobalDataFlow.cs:120:20:120:25 | access to local variable sink14 |
+| GlobalDataFlow.cs:82:13:82:95 | SSA def(sink14) | GlobalDataFlow.cs:120:20:120:25 | access to local variable sink14 |
+| GlobalDataFlow.cs:82:13:82:95 | SSA def(sink14) | GlobalDataFlow.cs:122:20:122:25 | access to local variable sink14 |
+| GlobalDataFlow.cs:82:13:82:95 | SSA def(sink14) | GlobalDataFlow.cs:122:20:122:25 | access to local variable sink14 |
 | GlobalDataFlow.cs:82:22:82:95 | call to method Select | GlobalDataFlow.cs:82:13:82:95 | SSA def(sink14) |
 | GlobalDataFlow.cs:82:22:82:95 | call to method Select | GlobalDataFlow.cs:82:13:82:95 | SSA def(sink14) |
 | GlobalDataFlow.cs:82:22:82:95 | call to method Select | GlobalDataFlow.cs:82:22:82:95 | call to method Select |
@@ -1341,15 +1368,15 @@
 | GlobalDataFlow.cs:82:22:82:95 | call to method Select | GlobalDataFlow.cs:88:22:88:27 | access to local variable sink14 |
 | GlobalDataFlow.cs:82:22:82:95 | call to method Select | GlobalDataFlow.cs:90:75:90:80 | access to local variable sink14 |
 | GlobalDataFlow.cs:82:22:82:95 | call to method Select | GlobalDataFlow.cs:90:75:90:80 | access to local variable sink14 |
-| GlobalDataFlow.cs:82:22:82:95 | call to method Select | GlobalDataFlow.cs:112:57:112:62 | access to local variable sink14 |
-| GlobalDataFlow.cs:82:22:82:95 | call to method Select | GlobalDataFlow.cs:112:57:112:62 | access to local variable sink14 |
-| GlobalDataFlow.cs:82:22:82:95 | call to method Select | GlobalDataFlow.cs:116:20:116:25 | access to local variable sink14 |
-| GlobalDataFlow.cs:82:22:82:95 | call to method Select | GlobalDataFlow.cs:116:20:116:25 | access to local variable sink14 |
-| GlobalDataFlow.cs:82:22:82:95 | call to method Select | GlobalDataFlow.cs:118:20:118:25 | access to local variable sink14 |
-| GlobalDataFlow.cs:82:22:82:95 | call to method Select | GlobalDataFlow.cs:118:20:118:25 | access to local variable sink14 |
+| GlobalDataFlow.cs:82:22:82:95 | call to method Select | GlobalDataFlow.cs:116:57:116:62 | access to local variable sink14 |
+| GlobalDataFlow.cs:82:22:82:95 | call to method Select | GlobalDataFlow.cs:116:57:116:62 | access to local variable sink14 |
+| GlobalDataFlow.cs:82:22:82:95 | call to method Select | GlobalDataFlow.cs:120:20:120:25 | access to local variable sink14 |
+| GlobalDataFlow.cs:82:22:82:95 | call to method Select | GlobalDataFlow.cs:120:20:120:25 | access to local variable sink14 |
+| GlobalDataFlow.cs:82:22:82:95 | call to method Select | GlobalDataFlow.cs:122:20:122:25 | access to local variable sink14 |
+| GlobalDataFlow.cs:82:22:82:95 | call to method Select | GlobalDataFlow.cs:122:20:122:25 | access to local variable sink14 |
 | GlobalDataFlow.cs:82:23:82:74 | (...) ... | GlobalDataFlow.cs:82:23:82:74 | (...) ... |
-| GlobalDataFlow.cs:82:23:82:74 | (...) ... | GlobalDataFlow.cs:287:31:287:40 | sinkParam8 |
-| GlobalDataFlow.cs:82:23:82:74 | (...) ... | GlobalDataFlow.cs:287:31:287:40 | sinkParam8 |
+| GlobalDataFlow.cs:82:23:82:74 | (...) ... | GlobalDataFlow.cs:292:31:292:40 | sinkParam8 |
+| GlobalDataFlow.cs:82:23:82:74 | (...) ... | GlobalDataFlow.cs:292:31:292:40 | sinkParam8 |
 | GlobalDataFlow.cs:82:44:82:74 | array creation of type String[] | GlobalDataFlow.cs:82:23:82:74 | (...) ... |
 | GlobalDataFlow.cs:82:44:82:74 | array creation of type String[] | GlobalDataFlow.cs:82:23:82:74 | (...) ... |
 | GlobalDataFlow.cs:82:44:82:74 | array creation of type String[] | GlobalDataFlow.cs:82:44:82:74 | array creation of type String[] |
@@ -1367,20 +1394,20 @@
 | GlobalDataFlow.cs:83:15:83:20 | access to local variable sink14 | GlobalDataFlow.cs:88:22:88:27 | access to local variable sink14 |
 | GlobalDataFlow.cs:83:15:83:20 | access to local variable sink14 | GlobalDataFlow.cs:90:75:90:80 | access to local variable sink14 |
 | GlobalDataFlow.cs:83:15:83:20 | access to local variable sink14 | GlobalDataFlow.cs:90:75:90:80 | access to local variable sink14 |
-| GlobalDataFlow.cs:83:15:83:20 | access to local variable sink14 | GlobalDataFlow.cs:112:57:112:62 | access to local variable sink14 |
-| GlobalDataFlow.cs:83:15:83:20 | access to local variable sink14 | GlobalDataFlow.cs:112:57:112:62 | access to local variable sink14 |
-| GlobalDataFlow.cs:83:15:83:20 | access to local variable sink14 | GlobalDataFlow.cs:116:20:116:25 | access to local variable sink14 |
-| GlobalDataFlow.cs:83:15:83:20 | access to local variable sink14 | GlobalDataFlow.cs:116:20:116:25 | access to local variable sink14 |
-| GlobalDataFlow.cs:83:15:83:20 | access to local variable sink14 | GlobalDataFlow.cs:118:20:118:25 | access to local variable sink14 |
-| GlobalDataFlow.cs:83:15:83:20 | access to local variable sink14 | GlobalDataFlow.cs:118:20:118:25 | access to local variable sink14 |
+| GlobalDataFlow.cs:83:15:83:20 | access to local variable sink14 | GlobalDataFlow.cs:116:57:116:62 | access to local variable sink14 |
+| GlobalDataFlow.cs:83:15:83:20 | access to local variable sink14 | GlobalDataFlow.cs:116:57:116:62 | access to local variable sink14 |
+| GlobalDataFlow.cs:83:15:83:20 | access to local variable sink14 | GlobalDataFlow.cs:120:20:120:25 | access to local variable sink14 |
+| GlobalDataFlow.cs:83:15:83:20 | access to local variable sink14 | GlobalDataFlow.cs:120:20:120:25 | access to local variable sink14 |
+| GlobalDataFlow.cs:83:15:83:20 | access to local variable sink14 | GlobalDataFlow.cs:122:20:122:25 | access to local variable sink14 |
+| GlobalDataFlow.cs:83:15:83:20 | access to local variable sink14 | GlobalDataFlow.cs:122:20:122:25 | access to local variable sink14 |
 | GlobalDataFlow.cs:84:13:84:136 | IEnumerable<String> sink15 = ... | GlobalDataFlow.cs:84:13:84:136 | IEnumerable<String> sink15 = ... |
 | GlobalDataFlow.cs:84:13:84:136 | SSA def(sink15) | GlobalDataFlow.cs:84:13:84:136 | SSA def(sink15) |
 | GlobalDataFlow.cs:84:13:84:136 | SSA def(sink15) | GlobalDataFlow.cs:85:15:85:20 | access to local variable sink15 |
 | GlobalDataFlow.cs:84:13:84:136 | SSA def(sink15) | GlobalDataFlow.cs:85:15:85:20 | access to local variable sink15 |
 | GlobalDataFlow.cs:84:13:84:136 | SSA def(sink15) | GlobalDataFlow.cs:86:106:86:111 | access to local variable sink15 |
 | GlobalDataFlow.cs:84:13:84:136 | SSA def(sink15) | GlobalDataFlow.cs:86:106:86:111 | access to local variable sink15 |
-| GlobalDataFlow.cs:84:13:84:136 | SSA def(sink15) | GlobalDataFlow.cs:114:104:114:109 | access to local variable sink15 |
-| GlobalDataFlow.cs:84:13:84:136 | SSA def(sink15) | GlobalDataFlow.cs:114:104:114:109 | access to local variable sink15 |
+| GlobalDataFlow.cs:84:13:84:136 | SSA def(sink15) | GlobalDataFlow.cs:118:104:118:109 | access to local variable sink15 |
+| GlobalDataFlow.cs:84:13:84:136 | SSA def(sink15) | GlobalDataFlow.cs:118:104:118:109 | access to local variable sink15 |
 | GlobalDataFlow.cs:84:22:84:136 | call to method Zip | GlobalDataFlow.cs:84:13:84:136 | SSA def(sink15) |
 | GlobalDataFlow.cs:84:22:84:136 | call to method Zip | GlobalDataFlow.cs:84:13:84:136 | SSA def(sink15) |
 | GlobalDataFlow.cs:84:22:84:136 | call to method Zip | GlobalDataFlow.cs:84:22:84:136 | call to method Zip |
@@ -1388,8 +1415,8 @@
 | GlobalDataFlow.cs:84:22:84:136 | call to method Zip | GlobalDataFlow.cs:85:15:85:20 | access to local variable sink15 |
 | GlobalDataFlow.cs:84:22:84:136 | call to method Zip | GlobalDataFlow.cs:86:106:86:111 | access to local variable sink15 |
 | GlobalDataFlow.cs:84:22:84:136 | call to method Zip | GlobalDataFlow.cs:86:106:86:111 | access to local variable sink15 |
-| GlobalDataFlow.cs:84:22:84:136 | call to method Zip | GlobalDataFlow.cs:114:104:114:109 | access to local variable sink15 |
-| GlobalDataFlow.cs:84:22:84:136 | call to method Zip | GlobalDataFlow.cs:114:104:114:109 | access to local variable sink15 |
+| GlobalDataFlow.cs:84:22:84:136 | call to method Zip | GlobalDataFlow.cs:118:104:118:109 | access to local variable sink15 |
+| GlobalDataFlow.cs:84:22:84:136 | call to method Zip | GlobalDataFlow.cs:118:104:118:109 | access to local variable sink15 |
 | GlobalDataFlow.cs:84:23:84:74 | (...) ... | GlobalDataFlow.cs:84:23:84:74 | (...) ... |
 | GlobalDataFlow.cs:84:23:84:74 | (...) ... | GlobalDataFlow.cs:84:126:84:126 | x |
 | GlobalDataFlow.cs:84:23:84:74 | (...) ... | GlobalDataFlow.cs:84:126:84:126 | x |
@@ -1402,12 +1429,12 @@
 | GlobalDataFlow.cs:84:59:84:64 | access to local variable sink14 | GlobalDataFlow.cs:88:22:88:27 | access to local variable sink14 |
 | GlobalDataFlow.cs:84:59:84:64 | access to local variable sink14 | GlobalDataFlow.cs:90:75:90:80 | access to local variable sink14 |
 | GlobalDataFlow.cs:84:59:84:64 | access to local variable sink14 | GlobalDataFlow.cs:90:75:90:80 | access to local variable sink14 |
-| GlobalDataFlow.cs:84:59:84:64 | access to local variable sink14 | GlobalDataFlow.cs:112:57:112:62 | access to local variable sink14 |
-| GlobalDataFlow.cs:84:59:84:64 | access to local variable sink14 | GlobalDataFlow.cs:112:57:112:62 | access to local variable sink14 |
-| GlobalDataFlow.cs:84:59:84:64 | access to local variable sink14 | GlobalDataFlow.cs:116:20:116:25 | access to local variable sink14 |
-| GlobalDataFlow.cs:84:59:84:64 | access to local variable sink14 | GlobalDataFlow.cs:116:20:116:25 | access to local variable sink14 |
-| GlobalDataFlow.cs:84:59:84:64 | access to local variable sink14 | GlobalDataFlow.cs:118:20:118:25 | access to local variable sink14 |
-| GlobalDataFlow.cs:84:59:84:64 | access to local variable sink14 | GlobalDataFlow.cs:118:20:118:25 | access to local variable sink14 |
+| GlobalDataFlow.cs:84:59:84:64 | access to local variable sink14 | GlobalDataFlow.cs:116:57:116:62 | access to local variable sink14 |
+| GlobalDataFlow.cs:84:59:84:64 | access to local variable sink14 | GlobalDataFlow.cs:116:57:116:62 | access to local variable sink14 |
+| GlobalDataFlow.cs:84:59:84:64 | access to local variable sink14 | GlobalDataFlow.cs:120:20:120:25 | access to local variable sink14 |
+| GlobalDataFlow.cs:84:59:84:64 | access to local variable sink14 | GlobalDataFlow.cs:120:20:120:25 | access to local variable sink14 |
+| GlobalDataFlow.cs:84:59:84:64 | access to local variable sink14 | GlobalDataFlow.cs:122:20:122:25 | access to local variable sink14 |
+| GlobalDataFlow.cs:84:59:84:64 | access to local variable sink14 | GlobalDataFlow.cs:122:20:122:25 | access to local variable sink14 |
 | GlobalDataFlow.cs:84:59:84:72 | call to method First | GlobalDataFlow.cs:84:59:84:72 | call to method First |
 | GlobalDataFlow.cs:84:82:84:121 | (...) ... | GlobalDataFlow.cs:84:82:84:121 | (...) ... |
 | GlobalDataFlow.cs:84:103:84:121 | array creation of type String[] | GlobalDataFlow.cs:84:82:84:121 | (...) ... |
@@ -1428,8 +1455,8 @@
 | GlobalDataFlow.cs:85:15:85:20 | access to local variable sink15 | GlobalDataFlow.cs:85:15:85:20 | access to local variable sink15 |
 | GlobalDataFlow.cs:85:15:85:20 | access to local variable sink15 | GlobalDataFlow.cs:86:106:86:111 | access to local variable sink15 |
 | GlobalDataFlow.cs:85:15:85:20 | access to local variable sink15 | GlobalDataFlow.cs:86:106:86:111 | access to local variable sink15 |
-| GlobalDataFlow.cs:85:15:85:20 | access to local variable sink15 | GlobalDataFlow.cs:114:104:114:109 | access to local variable sink15 |
-| GlobalDataFlow.cs:85:15:85:20 | access to local variable sink15 | GlobalDataFlow.cs:114:104:114:109 | access to local variable sink15 |
+| GlobalDataFlow.cs:85:15:85:20 | access to local variable sink15 | GlobalDataFlow.cs:118:104:118:109 | access to local variable sink15 |
+| GlobalDataFlow.cs:85:15:85:20 | access to local variable sink15 | GlobalDataFlow.cs:118:104:118:109 | access to local variable sink15 |
 | GlobalDataFlow.cs:86:13:86:136 | IEnumerable<String> sink16 = ... | GlobalDataFlow.cs:86:13:86:136 | IEnumerable<String> sink16 = ... |
 | GlobalDataFlow.cs:86:13:86:136 | SSA def(sink16) | GlobalDataFlow.cs:86:13:86:136 | SSA def(sink16) |
 | GlobalDataFlow.cs:86:13:86:136 | SSA def(sink16) | GlobalDataFlow.cs:87:15:87:20 | access to local variable sink16 |
@@ -1453,8 +1480,8 @@
 | GlobalDataFlow.cs:86:91:86:121 | array creation of type String[] | GlobalDataFlow.cs:86:91:86:121 | array creation of type String[] |
 | GlobalDataFlow.cs:86:104:86:121 | { ..., ... } | GlobalDataFlow.cs:86:104:86:121 | { ..., ... } |
 | GlobalDataFlow.cs:86:106:86:111 | access to local variable sink15 | GlobalDataFlow.cs:86:106:86:111 | access to local variable sink15 |
-| GlobalDataFlow.cs:86:106:86:111 | access to local variable sink15 | GlobalDataFlow.cs:114:104:114:109 | access to local variable sink15 |
-| GlobalDataFlow.cs:86:106:86:111 | access to local variable sink15 | GlobalDataFlow.cs:114:104:114:109 | access to local variable sink15 |
+| GlobalDataFlow.cs:86:106:86:111 | access to local variable sink15 | GlobalDataFlow.cs:118:104:118:109 | access to local variable sink15 |
+| GlobalDataFlow.cs:86:106:86:111 | access to local variable sink15 | GlobalDataFlow.cs:118:104:118:109 | access to local variable sink15 |
 | GlobalDataFlow.cs:86:106:86:119 | call to method First | GlobalDataFlow.cs:86:106:86:119 | call to method First |
 | GlobalDataFlow.cs:86:125:86:135 | (...) => ... | GlobalDataFlow.cs:86:125:86:135 | (...) => ... |
 | GlobalDataFlow.cs:86:125:86:135 | [output] (...) => ... | GlobalDataFlow.cs:86:125:86:135 | [output] (...) => ... |
@@ -1476,12 +1503,12 @@
 | GlobalDataFlow.cs:88:22:88:27 | access to local variable sink14 | GlobalDataFlow.cs:88:49:88:49 | s |
 | GlobalDataFlow.cs:88:22:88:27 | access to local variable sink14 | GlobalDataFlow.cs:90:75:90:80 | access to local variable sink14 |
 | GlobalDataFlow.cs:88:22:88:27 | access to local variable sink14 | GlobalDataFlow.cs:90:75:90:80 | access to local variable sink14 |
-| GlobalDataFlow.cs:88:22:88:27 | access to local variable sink14 | GlobalDataFlow.cs:112:57:112:62 | access to local variable sink14 |
-| GlobalDataFlow.cs:88:22:88:27 | access to local variable sink14 | GlobalDataFlow.cs:112:57:112:62 | access to local variable sink14 |
-| GlobalDataFlow.cs:88:22:88:27 | access to local variable sink14 | GlobalDataFlow.cs:116:20:116:25 | access to local variable sink14 |
-| GlobalDataFlow.cs:88:22:88:27 | access to local variable sink14 | GlobalDataFlow.cs:116:20:116:25 | access to local variable sink14 |
-| GlobalDataFlow.cs:88:22:88:27 | access to local variable sink14 | GlobalDataFlow.cs:118:20:118:25 | access to local variable sink14 |
-| GlobalDataFlow.cs:88:22:88:27 | access to local variable sink14 | GlobalDataFlow.cs:118:20:118:25 | access to local variable sink14 |
+| GlobalDataFlow.cs:88:22:88:27 | access to local variable sink14 | GlobalDataFlow.cs:116:57:116:62 | access to local variable sink14 |
+| GlobalDataFlow.cs:88:22:88:27 | access to local variable sink14 | GlobalDataFlow.cs:116:57:116:62 | access to local variable sink14 |
+| GlobalDataFlow.cs:88:22:88:27 | access to local variable sink14 | GlobalDataFlow.cs:120:20:120:25 | access to local variable sink14 |
+| GlobalDataFlow.cs:88:22:88:27 | access to local variable sink14 | GlobalDataFlow.cs:120:20:120:25 | access to local variable sink14 |
+| GlobalDataFlow.cs:88:22:88:27 | access to local variable sink14 | GlobalDataFlow.cs:122:20:122:25 | access to local variable sink14 |
+| GlobalDataFlow.cs:88:22:88:27 | access to local variable sink14 | GlobalDataFlow.cs:122:20:122:25 | access to local variable sink14 |
 | GlobalDataFlow.cs:88:22:88:70 | call to method Aggregate | GlobalDataFlow.cs:88:13:88:70 | SSA def(sink17) |
 | GlobalDataFlow.cs:88:22:88:70 | call to method Aggregate | GlobalDataFlow.cs:88:13:88:70 | SSA def(sink17) |
 | GlobalDataFlow.cs:88:22:88:70 | call to method Aggregate | GlobalDataFlow.cs:88:22:88:70 | call to method Aggregate |
@@ -1544,12 +1571,12 @@
 | GlobalDataFlow.cs:90:57:90:62 | { ..., ... } | GlobalDataFlow.cs:90:57:90:62 | { ..., ... } |
 | GlobalDataFlow.cs:90:59:90:60 | "" | GlobalDataFlow.cs:90:59:90:60 | "" |
 | GlobalDataFlow.cs:90:75:90:80 | access to local variable sink14 | GlobalDataFlow.cs:90:75:90:80 | access to local variable sink14 |
-| GlobalDataFlow.cs:90:75:90:80 | access to local variable sink14 | GlobalDataFlow.cs:112:57:112:62 | access to local variable sink14 |
-| GlobalDataFlow.cs:90:75:90:80 | access to local variable sink14 | GlobalDataFlow.cs:112:57:112:62 | access to local variable sink14 |
-| GlobalDataFlow.cs:90:75:90:80 | access to local variable sink14 | GlobalDataFlow.cs:116:20:116:25 | access to local variable sink14 |
-| GlobalDataFlow.cs:90:75:90:80 | access to local variable sink14 | GlobalDataFlow.cs:116:20:116:25 | access to local variable sink14 |
-| GlobalDataFlow.cs:90:75:90:80 | access to local variable sink14 | GlobalDataFlow.cs:118:20:118:25 | access to local variable sink14 |
-| GlobalDataFlow.cs:90:75:90:80 | access to local variable sink14 | GlobalDataFlow.cs:118:20:118:25 | access to local variable sink14 |
+| GlobalDataFlow.cs:90:75:90:80 | access to local variable sink14 | GlobalDataFlow.cs:116:57:116:62 | access to local variable sink14 |
+| GlobalDataFlow.cs:90:75:90:80 | access to local variable sink14 | GlobalDataFlow.cs:116:57:116:62 | access to local variable sink14 |
+| GlobalDataFlow.cs:90:75:90:80 | access to local variable sink14 | GlobalDataFlow.cs:120:20:120:25 | access to local variable sink14 |
+| GlobalDataFlow.cs:90:75:90:80 | access to local variable sink14 | GlobalDataFlow.cs:120:20:120:25 | access to local variable sink14 |
+| GlobalDataFlow.cs:90:75:90:80 | access to local variable sink14 | GlobalDataFlow.cs:122:20:122:25 | access to local variable sink14 |
+| GlobalDataFlow.cs:90:75:90:80 | access to local variable sink14 | GlobalDataFlow.cs:122:20:122:25 | access to local variable sink14 |
 | GlobalDataFlow.cs:90:75:90:88 | call to method First | GlobalDataFlow.cs:90:75:90:88 | call to method First |
 | GlobalDataFlow.cs:90:75:90:88 | call to method First | GlobalDataFlow.cs:90:92:90:94 | acc |
 | GlobalDataFlow.cs:90:75:90:88 | call to method First | GlobalDataFlow.cs:90:92:90:94 | acc |
@@ -1619,8 +1646,8 @@
 | GlobalDataFlow.cs:100:31:100:32 | "" | GlobalDataFlow.cs:100:24:100:33 | call to method Return |
 | GlobalDataFlow.cs:100:31:100:32 | "" | GlobalDataFlow.cs:100:24:100:33 | call to method Return |
 | GlobalDataFlow.cs:100:31:100:32 | "" | GlobalDataFlow.cs:100:31:100:32 | "" |
-| GlobalDataFlow.cs:100:31:100:32 | "" | GlobalDataFlow.cs:271:26:271:26 | x |
-| GlobalDataFlow.cs:100:31:100:32 | "" | GlobalDataFlow.cs:271:26:271:26 | x |
+| GlobalDataFlow.cs:100:31:100:32 | "" | GlobalDataFlow.cs:275:26:275:26 | x |
+| GlobalDataFlow.cs:100:31:100:32 | "" | GlobalDataFlow.cs:275:26:275:26 | x |
 | GlobalDataFlow.cs:101:9:101:23 | call to method Check | GlobalDataFlow.cs:101:9:101:23 | call to method Check |
 | GlobalDataFlow.cs:101:15:101:22 | access to local variable nonSink0 | GlobalDataFlow.cs:101:15:101:22 | access to local variable nonSink0 |
 | GlobalDataFlow.cs:101:15:101:22 | access to local variable nonSink0 | GlobalDataFlow.cs:102:93:102:100 | access to local variable nonSink0 |
@@ -1646,1929 +1673,2015 @@
 | GlobalDataFlow.cs:102:93:102:100 | access to local variable nonSink0 | GlobalDataFlow.cs:102:28:102:103 | call to method Invoke |
 | GlobalDataFlow.cs:102:93:102:100 | access to local variable nonSink0 | GlobalDataFlow.cs:102:28:102:103 | call to method Invoke |
 | GlobalDataFlow.cs:102:93:102:100 | access to local variable nonSink0 | GlobalDataFlow.cs:102:93:102:100 | access to local variable nonSink0 |
-| GlobalDataFlow.cs:102:93:102:100 | access to local variable nonSink0 | GlobalDataFlow.cs:271:26:271:26 | x |
-| GlobalDataFlow.cs:102:93:102:100 | access to local variable nonSink0 | GlobalDataFlow.cs:271:26:271:26 | x |
+| GlobalDataFlow.cs:102:93:102:100 | access to local variable nonSink0 | GlobalDataFlow.cs:275:26:275:26 | x |
+| GlobalDataFlow.cs:102:93:102:100 | access to local variable nonSink0 | GlobalDataFlow.cs:275:26:275:26 | x |
 | GlobalDataFlow.cs:103:9:103:23 | call to method Check | GlobalDataFlow.cs:103:9:103:23 | call to method Check |
 | GlobalDataFlow.cs:103:15:103:22 | access to local variable nonSink0 | GlobalDataFlow.cs:103:15:103:22 | access to local variable nonSink0 |
-| GlobalDataFlow.cs:104:9:104:35 | call to method ReturnOut | GlobalDataFlow.cs:104:9:104:35 | call to method ReturnOut |
+| GlobalDataFlow.cs:104:9:104:46 | call to method ReturnOut | GlobalDataFlow.cs:104:9:104:46 | call to method ReturnOut |
 | GlobalDataFlow.cs:104:19:104:20 | "" | GlobalDataFlow.cs:104:19:104:20 | "" |
 | GlobalDataFlow.cs:104:19:104:20 | "" | GlobalDataFlow.cs:104:27:104:34 | SSA def(nonSink0) |
 | GlobalDataFlow.cs:104:19:104:20 | "" | GlobalDataFlow.cs:104:27:104:34 | SSA def(nonSink0) |
-| GlobalDataFlow.cs:104:19:104:20 | "" | GlobalDataFlow.cs:277:32:277:32 | x |
-| GlobalDataFlow.cs:104:19:104:20 | "" | GlobalDataFlow.cs:277:32:277:32 | x |
+| GlobalDataFlow.cs:104:19:104:20 | "" | GlobalDataFlow.cs:281:32:281:32 | x |
+| GlobalDataFlow.cs:104:19:104:20 | "" | GlobalDataFlow.cs:281:32:281:32 | x |
 | GlobalDataFlow.cs:104:27:104:34 | SSA def(nonSink0) | GlobalDataFlow.cs:104:27:104:34 | SSA def(nonSink0) |
 | GlobalDataFlow.cs:104:27:104:34 | SSA def(nonSink0) | GlobalDataFlow.cs:105:15:105:22 | access to local variable nonSink0 |
 | GlobalDataFlow.cs:104:27:104:34 | SSA def(nonSink0) | GlobalDataFlow.cs:105:15:105:22 | access to local variable nonSink0 |
-| GlobalDataFlow.cs:104:27:104:34 | SSA def(nonSink0) | GlobalDataFlow.cs:106:27:106:34 | access to local variable nonSink0 |
-| GlobalDataFlow.cs:104:27:104:34 | SSA def(nonSink0) | GlobalDataFlow.cs:106:27:106:34 | access to local variable nonSink0 |
 | GlobalDataFlow.cs:105:9:105:23 | call to method Check | GlobalDataFlow.cs:105:9:105:23 | call to method Check |
 | GlobalDataFlow.cs:105:15:105:22 | access to local variable nonSink0 | GlobalDataFlow.cs:105:15:105:22 | access to local variable nonSink0 |
-| GlobalDataFlow.cs:105:15:105:22 | access to local variable nonSink0 | GlobalDataFlow.cs:106:27:106:34 | access to local variable nonSink0 |
-| GlobalDataFlow.cs:105:15:105:22 | access to local variable nonSink0 | GlobalDataFlow.cs:106:27:106:34 | access to local variable nonSink0 |
-| GlobalDataFlow.cs:106:9:106:35 | call to method ReturnRef | GlobalDataFlow.cs:106:9:106:35 | call to method ReturnRef |
-| GlobalDataFlow.cs:106:19:106:20 | "" | GlobalDataFlow.cs:106:19:106:20 | "" |
-| GlobalDataFlow.cs:106:19:106:20 | "" | GlobalDataFlow.cs:106:27:106:34 | SSA def(nonSink0) |
-| GlobalDataFlow.cs:106:19:106:20 | "" | GlobalDataFlow.cs:106:27:106:34 | SSA def(nonSink0) |
-| GlobalDataFlow.cs:106:19:106:20 | "" | GlobalDataFlow.cs:282:32:282:32 | x |
-| GlobalDataFlow.cs:106:19:106:20 | "" | GlobalDataFlow.cs:282:32:282:32 | x |
-| GlobalDataFlow.cs:106:27:106:34 | SSA def(nonSink0) | GlobalDataFlow.cs:106:27:106:34 | SSA def(nonSink0) |
-| GlobalDataFlow.cs:106:27:106:34 | SSA def(nonSink0) | GlobalDataFlow.cs:107:15:107:22 | access to local variable nonSink0 |
-| GlobalDataFlow.cs:106:27:106:34 | SSA def(nonSink0) | GlobalDataFlow.cs:107:15:107:22 | access to local variable nonSink0 |
-| GlobalDataFlow.cs:106:27:106:34 | SSA def(nonSink0) | GlobalDataFlow.cs:108:61:108:68 | access to local variable nonSink0 |
-| GlobalDataFlow.cs:106:27:106:34 | SSA def(nonSink0) | GlobalDataFlow.cs:108:61:108:68 | access to local variable nonSink0 |
-| GlobalDataFlow.cs:106:27:106:34 | SSA def(nonSink0) | GlobalDataFlow.cs:110:57:110:64 | access to local variable nonSink0 |
-| GlobalDataFlow.cs:106:27:106:34 | SSA def(nonSink0) | GlobalDataFlow.cs:110:57:110:64 | access to local variable nonSink0 |
-| GlobalDataFlow.cs:106:27:106:34 | access to local variable nonSink0 | GlobalDataFlow.cs:106:27:106:34 | access to local variable nonSink0 |
+| GlobalDataFlow.cs:106:9:106:49 | call to method ReturnOut | GlobalDataFlow.cs:106:9:106:49 | call to method ReturnOut |
+| GlobalDataFlow.cs:106:19:106:23 | access to local variable sink1 | GlobalDataFlow.cs:106:19:106:23 | access to local variable sink1 |
+| GlobalDataFlow.cs:106:19:106:23 | access to local variable sink1 | GlobalDataFlow.cs:106:41:106:48 | SSA def(nonSink0) |
+| GlobalDataFlow.cs:106:19:106:23 | access to local variable sink1 | GlobalDataFlow.cs:106:41:106:48 | SSA def(nonSink0) |
+| GlobalDataFlow.cs:106:19:106:23 | access to local variable sink1 | GlobalDataFlow.cs:110:19:110:23 | access to local variable sink1 |
+| GlobalDataFlow.cs:106:19:106:23 | access to local variable sink1 | GlobalDataFlow.cs:110:19:110:23 | access to local variable sink1 |
+| GlobalDataFlow.cs:106:19:106:23 | access to local variable sink1 | GlobalDataFlow.cs:110:30:110:34 | access to local variable sink1 |
+| GlobalDataFlow.cs:106:19:106:23 | access to local variable sink1 | GlobalDataFlow.cs:110:30:110:34 | access to local variable sink1 |
+| GlobalDataFlow.cs:106:19:106:23 | access to local variable sink1 | GlobalDataFlow.cs:281:32:281:32 | x |
+| GlobalDataFlow.cs:106:19:106:23 | access to local variable sink1 | GlobalDataFlow.cs:281:32:281:32 | x |
+| GlobalDataFlow.cs:106:41:106:48 | SSA def(nonSink0) | GlobalDataFlow.cs:106:41:106:48 | SSA def(nonSink0) |
+| GlobalDataFlow.cs:106:41:106:48 | SSA def(nonSink0) | GlobalDataFlow.cs:107:15:107:22 | access to local variable nonSink0 |
+| GlobalDataFlow.cs:106:41:106:48 | SSA def(nonSink0) | GlobalDataFlow.cs:107:15:107:22 | access to local variable nonSink0 |
+| GlobalDataFlow.cs:106:41:106:48 | SSA def(nonSink0) | GlobalDataFlow.cs:108:27:108:34 | access to local variable nonSink0 |
+| GlobalDataFlow.cs:106:41:106:48 | SSA def(nonSink0) | GlobalDataFlow.cs:108:27:108:34 | access to local variable nonSink0 |
+| GlobalDataFlow.cs:106:41:106:48 | SSA def(nonSink0) | GlobalDataFlow.cs:108:41:108:48 | access to local variable nonSink0 |
+| GlobalDataFlow.cs:106:41:106:48 | SSA def(nonSink0) | GlobalDataFlow.cs:108:41:108:48 | access to local variable nonSink0 |
 | GlobalDataFlow.cs:107:9:107:23 | call to method Check | GlobalDataFlow.cs:107:9:107:23 | call to method Check |
 | GlobalDataFlow.cs:107:15:107:22 | access to local variable nonSink0 | GlobalDataFlow.cs:107:15:107:22 | access to local variable nonSink0 |
-| GlobalDataFlow.cs:107:15:107:22 | access to local variable nonSink0 | GlobalDataFlow.cs:108:61:108:68 | access to local variable nonSink0 |
-| GlobalDataFlow.cs:107:15:107:22 | access to local variable nonSink0 | GlobalDataFlow.cs:108:61:108:68 | access to local variable nonSink0 |
-| GlobalDataFlow.cs:107:15:107:22 | access to local variable nonSink0 | GlobalDataFlow.cs:110:57:110:64 | access to local variable nonSink0 |
-| GlobalDataFlow.cs:107:15:107:22 | access to local variable nonSink0 | GlobalDataFlow.cs:110:57:110:64 | access to local variable nonSink0 |
-| GlobalDataFlow.cs:108:13:108:90 | IEnumerable<String> nonSink1 = ... | GlobalDataFlow.cs:108:13:108:90 | IEnumerable<String> nonSink1 = ... |
-| GlobalDataFlow.cs:108:13:108:90 | SSA def(nonSink1) | GlobalDataFlow.cs:108:13:108:90 | SSA def(nonSink1) |
-| GlobalDataFlow.cs:108:13:108:90 | SSA def(nonSink1) | GlobalDataFlow.cs:109:15:109:22 | access to local variable nonSink1 |
-| GlobalDataFlow.cs:108:13:108:90 | SSA def(nonSink1) | GlobalDataFlow.cs:109:15:109:22 | access to local variable nonSink1 |
-| GlobalDataFlow.cs:108:24:108:90 | call to method SelectEven | GlobalDataFlow.cs:108:13:108:90 | SSA def(nonSink1) |
-| GlobalDataFlow.cs:108:24:108:90 | call to method SelectEven | GlobalDataFlow.cs:108:13:108:90 | SSA def(nonSink1) |
-| GlobalDataFlow.cs:108:24:108:90 | call to method SelectEven | GlobalDataFlow.cs:108:24:108:90 | call to method SelectEven |
-| GlobalDataFlow.cs:108:24:108:90 | call to method SelectEven | GlobalDataFlow.cs:109:15:109:22 | access to local variable nonSink1 |
-| GlobalDataFlow.cs:108:24:108:90 | call to method SelectEven | GlobalDataFlow.cs:109:15:109:22 | access to local variable nonSink1 |
-| GlobalDataFlow.cs:108:25:108:70 | (...) ... | GlobalDataFlow.cs:108:25:108:70 | (...) ... |
-| GlobalDataFlow.cs:108:25:108:70 | (...) ... | GlobalDataFlow.cs:421:71:421:71 | e |
-| GlobalDataFlow.cs:108:25:108:70 | (...) ... | GlobalDataFlow.cs:421:71:421:71 | e |
-| GlobalDataFlow.cs:108:46:108:70 | array creation of type String[] | GlobalDataFlow.cs:108:25:108:70 | (...) ... |
-| GlobalDataFlow.cs:108:46:108:70 | array creation of type String[] | GlobalDataFlow.cs:108:25:108:70 | (...) ... |
-| GlobalDataFlow.cs:108:46:108:70 | array creation of type String[] | GlobalDataFlow.cs:108:46:108:70 | array creation of type String[] |
-| GlobalDataFlow.cs:108:59:108:70 | { ..., ... } | GlobalDataFlow.cs:108:59:108:70 | { ..., ... } |
-| GlobalDataFlow.cs:108:61:108:68 | access to local variable nonSink0 | GlobalDataFlow.cs:108:61:108:68 | access to local variable nonSink0 |
-| GlobalDataFlow.cs:108:61:108:68 | access to local variable nonSink0 | GlobalDataFlow.cs:110:57:110:64 | access to local variable nonSink0 |
-| GlobalDataFlow.cs:108:61:108:68 | access to local variable nonSink0 | GlobalDataFlow.cs:110:57:110:64 | access to local variable nonSink0 |
-| GlobalDataFlow.cs:108:84:108:84 | x | GlobalDataFlow.cs:108:84:108:84 | x |
-| GlobalDataFlow.cs:108:84:108:84 | x | GlobalDataFlow.cs:108:84:108:84 | x |
-| GlobalDataFlow.cs:108:84:108:84 | x | GlobalDataFlow.cs:108:89:108:89 | access to parameter x |
-| GlobalDataFlow.cs:108:84:108:84 | x | GlobalDataFlow.cs:108:89:108:89 | access to parameter x |
-| GlobalDataFlow.cs:108:84:108:84 | x | GlobalDataFlow.cs:108:89:108:89 | access to parameter x |
-| GlobalDataFlow.cs:108:84:108:84 | x | GlobalDataFlow.cs:108:89:108:89 | access to parameter x |
-| GlobalDataFlow.cs:108:84:108:89 | (...) => ... | GlobalDataFlow.cs:108:84:108:89 | (...) => ... |
-| GlobalDataFlow.cs:108:84:108:89 | (...) => ... | GlobalDataFlow.cs:421:85:421:85 | f |
-| GlobalDataFlow.cs:108:84:108:89 | (...) => ... | GlobalDataFlow.cs:421:85:421:85 | f |
-| GlobalDataFlow.cs:108:89:108:89 | access to parameter x | GlobalDataFlow.cs:108:89:108:89 | access to parameter x |
-| GlobalDataFlow.cs:108:89:108:89 | access to parameter x | GlobalDataFlow.cs:426:44:426:47 | delegate call |
-| GlobalDataFlow.cs:108:89:108:89 | access to parameter x | GlobalDataFlow.cs:426:44:426:47 | delegate call |
+| GlobalDataFlow.cs:107:15:107:22 | access to local variable nonSink0 | GlobalDataFlow.cs:108:27:108:34 | access to local variable nonSink0 |
+| GlobalDataFlow.cs:107:15:107:22 | access to local variable nonSink0 | GlobalDataFlow.cs:108:27:108:34 | access to local variable nonSink0 |
+| GlobalDataFlow.cs:107:15:107:22 | access to local variable nonSink0 | GlobalDataFlow.cs:108:41:108:48 | access to local variable nonSink0 |
+| GlobalDataFlow.cs:107:15:107:22 | access to local variable nonSink0 | GlobalDataFlow.cs:108:41:108:48 | access to local variable nonSink0 |
+| GlobalDataFlow.cs:108:9:108:49 | call to method ReturnRef | GlobalDataFlow.cs:108:9:108:49 | call to method ReturnRef |
+| GlobalDataFlow.cs:108:19:108:20 | "" | GlobalDataFlow.cs:108:19:108:20 | "" |
+| GlobalDataFlow.cs:108:19:108:20 | "" | GlobalDataFlow.cs:108:27:108:34 | SSA def(nonSink0) |
+| GlobalDataFlow.cs:108:19:108:20 | "" | GlobalDataFlow.cs:108:27:108:34 | SSA def(nonSink0) |
+| GlobalDataFlow.cs:108:19:108:20 | "" | GlobalDataFlow.cs:287:32:287:32 | x |
+| GlobalDataFlow.cs:108:19:108:20 | "" | GlobalDataFlow.cs:287:32:287:32 | x |
+| GlobalDataFlow.cs:108:27:108:34 | SSA def(nonSink0) | GlobalDataFlow.cs:108:27:108:34 | SSA def(nonSink0) |
+| GlobalDataFlow.cs:108:27:108:34 | SSA def(nonSink0) | GlobalDataFlow.cs:109:15:109:22 | access to local variable nonSink0 |
+| GlobalDataFlow.cs:108:27:108:34 | SSA def(nonSink0) | GlobalDataFlow.cs:109:15:109:22 | access to local variable nonSink0 |
+| GlobalDataFlow.cs:108:27:108:34 | SSA def(nonSink0) | GlobalDataFlow.cs:110:41:110:48 | access to local variable nonSink0 |
+| GlobalDataFlow.cs:108:27:108:34 | SSA def(nonSink0) | GlobalDataFlow.cs:110:41:110:48 | access to local variable nonSink0 |
+| GlobalDataFlow.cs:108:27:108:34 | SSA def(nonSink0) | GlobalDataFlow.cs:111:15:111:22 | access to local variable nonSink0 |
+| GlobalDataFlow.cs:108:27:108:34 | SSA def(nonSink0) | GlobalDataFlow.cs:111:15:111:22 | access to local variable nonSink0 |
+| GlobalDataFlow.cs:108:27:108:34 | SSA def(nonSink0) | GlobalDataFlow.cs:112:61:112:68 | access to local variable nonSink0 |
+| GlobalDataFlow.cs:108:27:108:34 | SSA def(nonSink0) | GlobalDataFlow.cs:112:61:112:68 | access to local variable nonSink0 |
+| GlobalDataFlow.cs:108:27:108:34 | SSA def(nonSink0) | GlobalDataFlow.cs:114:57:114:64 | access to local variable nonSink0 |
+| GlobalDataFlow.cs:108:27:108:34 | SSA def(nonSink0) | GlobalDataFlow.cs:114:57:114:64 | access to local variable nonSink0 |
+| GlobalDataFlow.cs:108:27:108:34 | access to local variable nonSink0 | GlobalDataFlow.cs:108:27:108:34 | access to local variable nonSink0 |
+| GlobalDataFlow.cs:108:27:108:34 | access to local variable nonSink0 | GlobalDataFlow.cs:108:41:108:48 | access to local variable nonSink0 |
+| GlobalDataFlow.cs:108:27:108:34 | access to local variable nonSink0 | GlobalDataFlow.cs:108:41:108:48 | access to local variable nonSink0 |
+| GlobalDataFlow.cs:108:41:108:48 | access to local variable nonSink0 | GlobalDataFlow.cs:108:27:108:34 | SSA def(nonSink0) |
+| GlobalDataFlow.cs:108:41:108:48 | access to local variable nonSink0 | GlobalDataFlow.cs:108:27:108:34 | SSA def(nonSink0) |
+| GlobalDataFlow.cs:108:41:108:48 | access to local variable nonSink0 | GlobalDataFlow.cs:108:41:108:48 | access to local variable nonSink0 |
+| GlobalDataFlow.cs:108:41:108:48 | access to local variable nonSink0 | GlobalDataFlow.cs:287:50:287:50 | z |
+| GlobalDataFlow.cs:108:41:108:48 | access to local variable nonSink0 | GlobalDataFlow.cs:287:50:287:50 | z |
 | GlobalDataFlow.cs:109:9:109:23 | call to method Check | GlobalDataFlow.cs:109:9:109:23 | call to method Check |
-| GlobalDataFlow.cs:109:15:109:22 | access to local variable nonSink1 | GlobalDataFlow.cs:109:15:109:22 | access to local variable nonSink1 |
-| GlobalDataFlow.cs:110:9:110:82 | ... = ... | GlobalDataFlow.cs:110:9:110:82 | ... = ... |
-| GlobalDataFlow.cs:110:9:110:82 | SSA def(nonSink1) | GlobalDataFlow.cs:110:9:110:82 | SSA def(nonSink1) |
-| GlobalDataFlow.cs:110:9:110:82 | SSA def(nonSink1) | GlobalDataFlow.cs:111:15:111:22 | access to local variable nonSink1 |
-| GlobalDataFlow.cs:110:9:110:82 | SSA def(nonSink1) | GlobalDataFlow.cs:111:15:111:22 | access to local variable nonSink1 |
-| GlobalDataFlow.cs:110:20:110:82 | call to method Select | GlobalDataFlow.cs:110:9:110:82 | SSA def(nonSink1) |
-| GlobalDataFlow.cs:110:20:110:82 | call to method Select | GlobalDataFlow.cs:110:9:110:82 | SSA def(nonSink1) |
-| GlobalDataFlow.cs:110:20:110:82 | call to method Select | GlobalDataFlow.cs:110:20:110:82 | call to method Select |
-| GlobalDataFlow.cs:110:20:110:82 | call to method Select | GlobalDataFlow.cs:111:15:111:22 | access to local variable nonSink1 |
-| GlobalDataFlow.cs:110:20:110:82 | call to method Select | GlobalDataFlow.cs:111:15:111:22 | access to local variable nonSink1 |
-| GlobalDataFlow.cs:110:21:110:66 | (...) ... | GlobalDataFlow.cs:110:21:110:66 | (...) ... |
-| GlobalDataFlow.cs:110:21:110:66 | (...) ... | GlobalDataFlow.cs:110:76:110:76 | x |
-| GlobalDataFlow.cs:110:21:110:66 | (...) ... | GlobalDataFlow.cs:110:76:110:76 | x |
-| GlobalDataFlow.cs:110:42:110:66 | array creation of type String[] | GlobalDataFlow.cs:110:21:110:66 | (...) ... |
-| GlobalDataFlow.cs:110:42:110:66 | array creation of type String[] | GlobalDataFlow.cs:110:21:110:66 | (...) ... |
-| GlobalDataFlow.cs:110:42:110:66 | array creation of type String[] | GlobalDataFlow.cs:110:42:110:66 | array creation of type String[] |
-| GlobalDataFlow.cs:110:55:110:66 | { ..., ... } | GlobalDataFlow.cs:110:55:110:66 | { ..., ... } |
-| GlobalDataFlow.cs:110:57:110:64 | access to local variable nonSink0 | GlobalDataFlow.cs:110:57:110:64 | access to local variable nonSink0 |
-| GlobalDataFlow.cs:110:76:110:76 | x | GlobalDataFlow.cs:110:76:110:76 | x |
-| GlobalDataFlow.cs:110:76:110:76 | x | GlobalDataFlow.cs:110:76:110:76 | x |
-| GlobalDataFlow.cs:110:76:110:76 | x | GlobalDataFlow.cs:110:81:110:81 | access to parameter x |
-| GlobalDataFlow.cs:110:76:110:76 | x | GlobalDataFlow.cs:110:81:110:81 | access to parameter x |
-| GlobalDataFlow.cs:110:76:110:81 | (...) => ... | GlobalDataFlow.cs:110:76:110:81 | (...) => ... |
-| GlobalDataFlow.cs:110:76:110:81 | [output] (...) => ... | GlobalDataFlow.cs:110:76:110:81 | [output] (...) => ... |
-| GlobalDataFlow.cs:110:81:110:81 | access to parameter x | GlobalDataFlow.cs:110:76:110:81 | [output] (...) => ... |
-| GlobalDataFlow.cs:110:81:110:81 | access to parameter x | GlobalDataFlow.cs:110:76:110:81 | [output] (...) => ... |
-| GlobalDataFlow.cs:110:81:110:81 | access to parameter x | GlobalDataFlow.cs:110:81:110:81 | access to parameter x |
+| GlobalDataFlow.cs:109:15:109:22 | access to local variable nonSink0 | GlobalDataFlow.cs:109:15:109:22 | access to local variable nonSink0 |
+| GlobalDataFlow.cs:109:15:109:22 | access to local variable nonSink0 | GlobalDataFlow.cs:110:41:110:48 | access to local variable nonSink0 |
+| GlobalDataFlow.cs:109:15:109:22 | access to local variable nonSink0 | GlobalDataFlow.cs:110:41:110:48 | access to local variable nonSink0 |
+| GlobalDataFlow.cs:109:15:109:22 | access to local variable nonSink0 | GlobalDataFlow.cs:111:15:111:22 | access to local variable nonSink0 |
+| GlobalDataFlow.cs:109:15:109:22 | access to local variable nonSink0 | GlobalDataFlow.cs:111:15:111:22 | access to local variable nonSink0 |
+| GlobalDataFlow.cs:109:15:109:22 | access to local variable nonSink0 | GlobalDataFlow.cs:112:61:112:68 | access to local variable nonSink0 |
+| GlobalDataFlow.cs:109:15:109:22 | access to local variable nonSink0 | GlobalDataFlow.cs:112:61:112:68 | access to local variable nonSink0 |
+| GlobalDataFlow.cs:109:15:109:22 | access to local variable nonSink0 | GlobalDataFlow.cs:114:57:114:64 | access to local variable nonSink0 |
+| GlobalDataFlow.cs:109:15:109:22 | access to local variable nonSink0 | GlobalDataFlow.cs:114:57:114:64 | access to local variable nonSink0 |
+| GlobalDataFlow.cs:110:9:110:49 | call to method ReturnRef | GlobalDataFlow.cs:110:9:110:49 | call to method ReturnRef |
+| GlobalDataFlow.cs:110:19:110:23 | access to local variable sink1 | GlobalDataFlow.cs:110:19:110:23 | access to local variable sink1 |
+| GlobalDataFlow.cs:110:19:110:23 | access to local variable sink1 | GlobalDataFlow.cs:110:30:110:34 | SSA def(sink1) |
+| GlobalDataFlow.cs:110:19:110:23 | access to local variable sink1 | GlobalDataFlow.cs:110:30:110:34 | SSA def(sink1) |
+| GlobalDataFlow.cs:110:19:110:23 | access to local variable sink1 | GlobalDataFlow.cs:110:30:110:34 | access to local variable sink1 |
+| GlobalDataFlow.cs:110:19:110:23 | access to local variable sink1 | GlobalDataFlow.cs:110:30:110:34 | access to local variable sink1 |
+| GlobalDataFlow.cs:110:19:110:23 | access to local variable sink1 | GlobalDataFlow.cs:287:32:287:32 | x |
+| GlobalDataFlow.cs:110:19:110:23 | access to local variable sink1 | GlobalDataFlow.cs:287:32:287:32 | x |
+| GlobalDataFlow.cs:110:30:110:34 | SSA def(sink1) | GlobalDataFlow.cs:110:30:110:34 | SSA def(sink1) |
+| GlobalDataFlow.cs:110:30:110:34 | SSA def(sink1) | GlobalDataFlow.cs:124:39:124:43 | access to local variable sink1 |
+| GlobalDataFlow.cs:110:30:110:34 | SSA def(sink1) | GlobalDataFlow.cs:124:39:124:43 | access to local variable sink1 |
+| GlobalDataFlow.cs:110:30:110:34 | access to local variable sink1 | GlobalDataFlow.cs:110:30:110:34 | access to local variable sink1 |
+| GlobalDataFlow.cs:110:41:110:48 | access to local variable nonSink0 | GlobalDataFlow.cs:110:30:110:34 | SSA def(sink1) |
+| GlobalDataFlow.cs:110:41:110:48 | access to local variable nonSink0 | GlobalDataFlow.cs:110:30:110:34 | SSA def(sink1) |
+| GlobalDataFlow.cs:110:41:110:48 | access to local variable nonSink0 | GlobalDataFlow.cs:110:41:110:48 | access to local variable nonSink0 |
+| GlobalDataFlow.cs:110:41:110:48 | access to local variable nonSink0 | GlobalDataFlow.cs:111:15:111:22 | access to local variable nonSink0 |
+| GlobalDataFlow.cs:110:41:110:48 | access to local variable nonSink0 | GlobalDataFlow.cs:111:15:111:22 | access to local variable nonSink0 |
+| GlobalDataFlow.cs:110:41:110:48 | access to local variable nonSink0 | GlobalDataFlow.cs:112:61:112:68 | access to local variable nonSink0 |
+| GlobalDataFlow.cs:110:41:110:48 | access to local variable nonSink0 | GlobalDataFlow.cs:112:61:112:68 | access to local variable nonSink0 |
+| GlobalDataFlow.cs:110:41:110:48 | access to local variable nonSink0 | GlobalDataFlow.cs:114:57:114:64 | access to local variable nonSink0 |
+| GlobalDataFlow.cs:110:41:110:48 | access to local variable nonSink0 | GlobalDataFlow.cs:114:57:114:64 | access to local variable nonSink0 |
+| GlobalDataFlow.cs:110:41:110:48 | access to local variable nonSink0 | GlobalDataFlow.cs:287:50:287:50 | z |
+| GlobalDataFlow.cs:110:41:110:48 | access to local variable nonSink0 | GlobalDataFlow.cs:287:50:287:50 | z |
 | GlobalDataFlow.cs:111:9:111:23 | call to method Check | GlobalDataFlow.cs:111:9:111:23 | call to method Check |
-| GlobalDataFlow.cs:111:15:111:22 | access to local variable nonSink1 | GlobalDataFlow.cs:111:15:111:22 | access to local variable nonSink1 |
-| GlobalDataFlow.cs:112:9:112:134 | ... = ... | GlobalDataFlow.cs:112:9:112:134 | ... = ... |
-| GlobalDataFlow.cs:112:9:112:134 | SSA def(nonSink1) | GlobalDataFlow.cs:112:9:112:134 | SSA def(nonSink1) |
-| GlobalDataFlow.cs:112:9:112:134 | SSA def(nonSink1) | GlobalDataFlow.cs:113:15:113:22 | access to local variable nonSink1 |
-| GlobalDataFlow.cs:112:9:112:134 | SSA def(nonSink1) | GlobalDataFlow.cs:113:15:113:22 | access to local variable nonSink1 |
-| GlobalDataFlow.cs:112:20:112:134 | call to method Zip | GlobalDataFlow.cs:112:9:112:134 | SSA def(nonSink1) |
-| GlobalDataFlow.cs:112:20:112:134 | call to method Zip | GlobalDataFlow.cs:112:9:112:134 | SSA def(nonSink1) |
-| GlobalDataFlow.cs:112:20:112:134 | call to method Zip | GlobalDataFlow.cs:112:20:112:134 | call to method Zip |
-| GlobalDataFlow.cs:112:20:112:134 | call to method Zip | GlobalDataFlow.cs:113:15:113:22 | access to local variable nonSink1 |
-| GlobalDataFlow.cs:112:20:112:134 | call to method Zip | GlobalDataFlow.cs:113:15:113:22 | access to local variable nonSink1 |
-| GlobalDataFlow.cs:112:21:112:72 | (...) ... | GlobalDataFlow.cs:112:21:112:72 | (...) ... |
-| GlobalDataFlow.cs:112:42:112:72 | array creation of type String[] | GlobalDataFlow.cs:112:21:112:72 | (...) ... |
-| GlobalDataFlow.cs:112:42:112:72 | array creation of type String[] | GlobalDataFlow.cs:112:21:112:72 | (...) ... |
-| GlobalDataFlow.cs:112:42:112:72 | array creation of type String[] | GlobalDataFlow.cs:112:42:112:72 | array creation of type String[] |
-| GlobalDataFlow.cs:112:55:112:72 | { ..., ... } | GlobalDataFlow.cs:112:55:112:72 | { ..., ... } |
-| GlobalDataFlow.cs:112:57:112:62 | access to local variable sink14 | GlobalDataFlow.cs:112:57:112:62 | access to local variable sink14 |
-| GlobalDataFlow.cs:112:57:112:62 | access to local variable sink14 | GlobalDataFlow.cs:116:20:116:25 | access to local variable sink14 |
-| GlobalDataFlow.cs:112:57:112:62 | access to local variable sink14 | GlobalDataFlow.cs:116:20:116:25 | access to local variable sink14 |
-| GlobalDataFlow.cs:112:57:112:62 | access to local variable sink14 | GlobalDataFlow.cs:118:20:118:25 | access to local variable sink14 |
-| GlobalDataFlow.cs:112:57:112:62 | access to local variable sink14 | GlobalDataFlow.cs:118:20:118:25 | access to local variable sink14 |
-| GlobalDataFlow.cs:112:57:112:70 | call to method First | GlobalDataFlow.cs:112:57:112:70 | call to method First |
-| GlobalDataFlow.cs:112:80:112:119 | (...) ... | GlobalDataFlow.cs:112:80:112:119 | (...) ... |
-| GlobalDataFlow.cs:112:80:112:119 | (...) ... | GlobalDataFlow.cs:112:127:112:127 | y |
-| GlobalDataFlow.cs:112:80:112:119 | (...) ... | GlobalDataFlow.cs:112:127:112:127 | y |
-| GlobalDataFlow.cs:112:101:112:119 | array creation of type String[] | GlobalDataFlow.cs:112:80:112:119 | (...) ... |
-| GlobalDataFlow.cs:112:101:112:119 | array creation of type String[] | GlobalDataFlow.cs:112:80:112:119 | (...) ... |
-| GlobalDataFlow.cs:112:101:112:119 | array creation of type String[] | GlobalDataFlow.cs:112:101:112:119 | array creation of type String[] |
-| GlobalDataFlow.cs:112:114:112:119 | { ..., ... } | GlobalDataFlow.cs:112:114:112:119 | { ..., ... } |
-| GlobalDataFlow.cs:112:116:112:117 | "" | GlobalDataFlow.cs:112:116:112:117 | "" |
-| GlobalDataFlow.cs:112:123:112:133 | (...) => ... | GlobalDataFlow.cs:112:123:112:133 | (...) => ... |
-| GlobalDataFlow.cs:112:123:112:133 | [output] (...) => ... | GlobalDataFlow.cs:112:123:112:133 | [output] (...) => ... |
-| GlobalDataFlow.cs:112:127:112:127 | y | GlobalDataFlow.cs:112:127:112:127 | y |
-| GlobalDataFlow.cs:112:127:112:127 | y | GlobalDataFlow.cs:112:127:112:127 | y |
-| GlobalDataFlow.cs:112:127:112:127 | y | GlobalDataFlow.cs:112:133:112:133 | access to parameter y |
-| GlobalDataFlow.cs:112:127:112:127 | y | GlobalDataFlow.cs:112:133:112:133 | access to parameter y |
-| GlobalDataFlow.cs:112:133:112:133 | access to parameter y | GlobalDataFlow.cs:112:123:112:133 | [output] (...) => ... |
-| GlobalDataFlow.cs:112:133:112:133 | access to parameter y | GlobalDataFlow.cs:112:123:112:133 | [output] (...) => ... |
-| GlobalDataFlow.cs:112:133:112:133 | access to parameter y | GlobalDataFlow.cs:112:133:112:133 | access to parameter y |
+| GlobalDataFlow.cs:111:15:111:22 | access to local variable nonSink0 | GlobalDataFlow.cs:111:15:111:22 | access to local variable nonSink0 |
+| GlobalDataFlow.cs:111:15:111:22 | access to local variable nonSink0 | GlobalDataFlow.cs:112:61:112:68 | access to local variable nonSink0 |
+| GlobalDataFlow.cs:111:15:111:22 | access to local variable nonSink0 | GlobalDataFlow.cs:112:61:112:68 | access to local variable nonSink0 |
+| GlobalDataFlow.cs:111:15:111:22 | access to local variable nonSink0 | GlobalDataFlow.cs:114:57:114:64 | access to local variable nonSink0 |
+| GlobalDataFlow.cs:111:15:111:22 | access to local variable nonSink0 | GlobalDataFlow.cs:114:57:114:64 | access to local variable nonSink0 |
+| GlobalDataFlow.cs:112:13:112:90 | IEnumerable<String> nonSink1 = ... | GlobalDataFlow.cs:112:13:112:90 | IEnumerable<String> nonSink1 = ... |
+| GlobalDataFlow.cs:112:13:112:90 | SSA def(nonSink1) | GlobalDataFlow.cs:112:13:112:90 | SSA def(nonSink1) |
+| GlobalDataFlow.cs:112:13:112:90 | SSA def(nonSink1) | GlobalDataFlow.cs:113:15:113:22 | access to local variable nonSink1 |
+| GlobalDataFlow.cs:112:13:112:90 | SSA def(nonSink1) | GlobalDataFlow.cs:113:15:113:22 | access to local variable nonSink1 |
+| GlobalDataFlow.cs:112:24:112:90 | call to method SelectEven | GlobalDataFlow.cs:112:13:112:90 | SSA def(nonSink1) |
+| GlobalDataFlow.cs:112:24:112:90 | call to method SelectEven | GlobalDataFlow.cs:112:13:112:90 | SSA def(nonSink1) |
+| GlobalDataFlow.cs:112:24:112:90 | call to method SelectEven | GlobalDataFlow.cs:112:24:112:90 | call to method SelectEven |
+| GlobalDataFlow.cs:112:24:112:90 | call to method SelectEven | GlobalDataFlow.cs:113:15:113:22 | access to local variable nonSink1 |
+| GlobalDataFlow.cs:112:24:112:90 | call to method SelectEven | GlobalDataFlow.cs:113:15:113:22 | access to local variable nonSink1 |
+| GlobalDataFlow.cs:112:25:112:70 | (...) ... | GlobalDataFlow.cs:112:25:112:70 | (...) ... |
+| GlobalDataFlow.cs:112:25:112:70 | (...) ... | GlobalDataFlow.cs:426:71:426:71 | e |
+| GlobalDataFlow.cs:112:25:112:70 | (...) ... | GlobalDataFlow.cs:426:71:426:71 | e |
+| GlobalDataFlow.cs:112:46:112:70 | array creation of type String[] | GlobalDataFlow.cs:112:25:112:70 | (...) ... |
+| GlobalDataFlow.cs:112:46:112:70 | array creation of type String[] | GlobalDataFlow.cs:112:25:112:70 | (...) ... |
+| GlobalDataFlow.cs:112:46:112:70 | array creation of type String[] | GlobalDataFlow.cs:112:46:112:70 | array creation of type String[] |
+| GlobalDataFlow.cs:112:59:112:70 | { ..., ... } | GlobalDataFlow.cs:112:59:112:70 | { ..., ... } |
+| GlobalDataFlow.cs:112:61:112:68 | access to local variable nonSink0 | GlobalDataFlow.cs:112:61:112:68 | access to local variable nonSink0 |
+| GlobalDataFlow.cs:112:61:112:68 | access to local variable nonSink0 | GlobalDataFlow.cs:114:57:114:64 | access to local variable nonSink0 |
+| GlobalDataFlow.cs:112:61:112:68 | access to local variable nonSink0 | GlobalDataFlow.cs:114:57:114:64 | access to local variable nonSink0 |
+| GlobalDataFlow.cs:112:84:112:84 | x | GlobalDataFlow.cs:112:84:112:84 | x |
+| GlobalDataFlow.cs:112:84:112:84 | x | GlobalDataFlow.cs:112:84:112:84 | x |
+| GlobalDataFlow.cs:112:84:112:84 | x | GlobalDataFlow.cs:112:89:112:89 | access to parameter x |
+| GlobalDataFlow.cs:112:84:112:84 | x | GlobalDataFlow.cs:112:89:112:89 | access to parameter x |
+| GlobalDataFlow.cs:112:84:112:84 | x | GlobalDataFlow.cs:112:89:112:89 | access to parameter x |
+| GlobalDataFlow.cs:112:84:112:84 | x | GlobalDataFlow.cs:112:89:112:89 | access to parameter x |
+| GlobalDataFlow.cs:112:84:112:89 | (...) => ... | GlobalDataFlow.cs:112:84:112:89 | (...) => ... |
+| GlobalDataFlow.cs:112:84:112:89 | (...) => ... | GlobalDataFlow.cs:426:85:426:85 | f |
+| GlobalDataFlow.cs:112:84:112:89 | (...) => ... | GlobalDataFlow.cs:426:85:426:85 | f |
+| GlobalDataFlow.cs:112:89:112:89 | access to parameter x | GlobalDataFlow.cs:112:89:112:89 | access to parameter x |
+| GlobalDataFlow.cs:112:89:112:89 | access to parameter x | GlobalDataFlow.cs:431:44:431:47 | delegate call |
+| GlobalDataFlow.cs:112:89:112:89 | access to parameter x | GlobalDataFlow.cs:431:44:431:47 | delegate call |
 | GlobalDataFlow.cs:113:9:113:23 | call to method Check | GlobalDataFlow.cs:113:9:113:23 | call to method Check |
 | GlobalDataFlow.cs:113:15:113:22 | access to local variable nonSink1 | GlobalDataFlow.cs:113:15:113:22 | access to local variable nonSink1 |
-| GlobalDataFlow.cs:114:9:114:134 | ... = ... | GlobalDataFlow.cs:114:9:114:134 | ... = ... |
-| GlobalDataFlow.cs:114:9:114:134 | SSA def(nonSink1) | GlobalDataFlow.cs:114:9:114:134 | SSA def(nonSink1) |
-| GlobalDataFlow.cs:114:9:114:134 | SSA def(nonSink1) | GlobalDataFlow.cs:115:15:115:22 | access to local variable nonSink1 |
-| GlobalDataFlow.cs:114:9:114:134 | SSA def(nonSink1) | GlobalDataFlow.cs:115:15:115:22 | access to local variable nonSink1 |
-| GlobalDataFlow.cs:114:9:114:134 | SSA def(nonSink1) | GlobalDataFlow.cs:120:20:120:27 | access to local variable nonSink1 |
-| GlobalDataFlow.cs:114:9:114:134 | SSA def(nonSink1) | GlobalDataFlow.cs:120:20:120:27 | access to local variable nonSink1 |
-| GlobalDataFlow.cs:114:20:114:134 | call to method Zip | GlobalDataFlow.cs:114:9:114:134 | SSA def(nonSink1) |
-| GlobalDataFlow.cs:114:20:114:134 | call to method Zip | GlobalDataFlow.cs:114:9:114:134 | SSA def(nonSink1) |
-| GlobalDataFlow.cs:114:20:114:134 | call to method Zip | GlobalDataFlow.cs:114:20:114:134 | call to method Zip |
-| GlobalDataFlow.cs:114:20:114:134 | call to method Zip | GlobalDataFlow.cs:115:15:115:22 | access to local variable nonSink1 |
-| GlobalDataFlow.cs:114:20:114:134 | call to method Zip | GlobalDataFlow.cs:115:15:115:22 | access to local variable nonSink1 |
-| GlobalDataFlow.cs:114:20:114:134 | call to method Zip | GlobalDataFlow.cs:120:20:120:27 | access to local variable nonSink1 |
-| GlobalDataFlow.cs:114:20:114:134 | call to method Zip | GlobalDataFlow.cs:120:20:120:27 | access to local variable nonSink1 |
-| GlobalDataFlow.cs:114:21:114:60 | (...) ... | GlobalDataFlow.cs:114:21:114:60 | (...) ... |
-| GlobalDataFlow.cs:114:21:114:60 | (...) ... | GlobalDataFlow.cs:114:124:114:124 | x |
-| GlobalDataFlow.cs:114:21:114:60 | (...) ... | GlobalDataFlow.cs:114:124:114:124 | x |
-| GlobalDataFlow.cs:114:42:114:60 | array creation of type String[] | GlobalDataFlow.cs:114:21:114:60 | (...) ... |
-| GlobalDataFlow.cs:114:42:114:60 | array creation of type String[] | GlobalDataFlow.cs:114:21:114:60 | (...) ... |
-| GlobalDataFlow.cs:114:42:114:60 | array creation of type String[] | GlobalDataFlow.cs:114:42:114:60 | array creation of type String[] |
-| GlobalDataFlow.cs:114:55:114:60 | { ..., ... } | GlobalDataFlow.cs:114:55:114:60 | { ..., ... } |
-| GlobalDataFlow.cs:114:57:114:58 | "" | GlobalDataFlow.cs:114:57:114:58 | "" |
-| GlobalDataFlow.cs:114:68:114:119 | (...) ... | GlobalDataFlow.cs:114:68:114:119 | (...) ... |
-| GlobalDataFlow.cs:114:89:114:119 | array creation of type String[] | GlobalDataFlow.cs:114:68:114:119 | (...) ... |
-| GlobalDataFlow.cs:114:89:114:119 | array creation of type String[] | GlobalDataFlow.cs:114:68:114:119 | (...) ... |
-| GlobalDataFlow.cs:114:89:114:119 | array creation of type String[] | GlobalDataFlow.cs:114:89:114:119 | array creation of type String[] |
-| GlobalDataFlow.cs:114:102:114:119 | { ..., ... } | GlobalDataFlow.cs:114:102:114:119 | { ..., ... } |
-| GlobalDataFlow.cs:114:104:114:109 | access to local variable sink15 | GlobalDataFlow.cs:114:104:114:109 | access to local variable sink15 |
-| GlobalDataFlow.cs:114:104:114:117 | call to method First | GlobalDataFlow.cs:114:104:114:117 | call to method First |
-| GlobalDataFlow.cs:114:123:114:133 | (...) => ... | GlobalDataFlow.cs:114:123:114:133 | (...) => ... |
-| GlobalDataFlow.cs:114:123:114:133 | [output] (...) => ... | GlobalDataFlow.cs:114:123:114:133 | [output] (...) => ... |
-| GlobalDataFlow.cs:114:124:114:124 | x | GlobalDataFlow.cs:114:124:114:124 | x |
-| GlobalDataFlow.cs:114:124:114:124 | x | GlobalDataFlow.cs:114:124:114:124 | x |
-| GlobalDataFlow.cs:114:124:114:124 | x | GlobalDataFlow.cs:114:133:114:133 | access to parameter x |
-| GlobalDataFlow.cs:114:124:114:124 | x | GlobalDataFlow.cs:114:133:114:133 | access to parameter x |
-| GlobalDataFlow.cs:114:133:114:133 | access to parameter x | GlobalDataFlow.cs:114:123:114:133 | [output] (...) => ... |
-| GlobalDataFlow.cs:114:133:114:133 | access to parameter x | GlobalDataFlow.cs:114:123:114:133 | [output] (...) => ... |
-| GlobalDataFlow.cs:114:133:114:133 | access to parameter x | GlobalDataFlow.cs:114:133:114:133 | access to parameter x |
+| GlobalDataFlow.cs:114:9:114:82 | ... = ... | GlobalDataFlow.cs:114:9:114:82 | ... = ... |
+| GlobalDataFlow.cs:114:9:114:82 | SSA def(nonSink1) | GlobalDataFlow.cs:114:9:114:82 | SSA def(nonSink1) |
+| GlobalDataFlow.cs:114:9:114:82 | SSA def(nonSink1) | GlobalDataFlow.cs:115:15:115:22 | access to local variable nonSink1 |
+| GlobalDataFlow.cs:114:9:114:82 | SSA def(nonSink1) | GlobalDataFlow.cs:115:15:115:22 | access to local variable nonSink1 |
+| GlobalDataFlow.cs:114:20:114:82 | call to method Select | GlobalDataFlow.cs:114:9:114:82 | SSA def(nonSink1) |
+| GlobalDataFlow.cs:114:20:114:82 | call to method Select | GlobalDataFlow.cs:114:9:114:82 | SSA def(nonSink1) |
+| GlobalDataFlow.cs:114:20:114:82 | call to method Select | GlobalDataFlow.cs:114:20:114:82 | call to method Select |
+| GlobalDataFlow.cs:114:20:114:82 | call to method Select | GlobalDataFlow.cs:115:15:115:22 | access to local variable nonSink1 |
+| GlobalDataFlow.cs:114:20:114:82 | call to method Select | GlobalDataFlow.cs:115:15:115:22 | access to local variable nonSink1 |
+| GlobalDataFlow.cs:114:21:114:66 | (...) ... | GlobalDataFlow.cs:114:21:114:66 | (...) ... |
+| GlobalDataFlow.cs:114:21:114:66 | (...) ... | GlobalDataFlow.cs:114:76:114:76 | x |
+| GlobalDataFlow.cs:114:21:114:66 | (...) ... | GlobalDataFlow.cs:114:76:114:76 | x |
+| GlobalDataFlow.cs:114:42:114:66 | array creation of type String[] | GlobalDataFlow.cs:114:21:114:66 | (...) ... |
+| GlobalDataFlow.cs:114:42:114:66 | array creation of type String[] | GlobalDataFlow.cs:114:21:114:66 | (...) ... |
+| GlobalDataFlow.cs:114:42:114:66 | array creation of type String[] | GlobalDataFlow.cs:114:42:114:66 | array creation of type String[] |
+| GlobalDataFlow.cs:114:55:114:66 | { ..., ... } | GlobalDataFlow.cs:114:55:114:66 | { ..., ... } |
+| GlobalDataFlow.cs:114:57:114:64 | access to local variable nonSink0 | GlobalDataFlow.cs:114:57:114:64 | access to local variable nonSink0 |
+| GlobalDataFlow.cs:114:76:114:76 | x | GlobalDataFlow.cs:114:76:114:76 | x |
+| GlobalDataFlow.cs:114:76:114:76 | x | GlobalDataFlow.cs:114:76:114:76 | x |
+| GlobalDataFlow.cs:114:76:114:76 | x | GlobalDataFlow.cs:114:81:114:81 | access to parameter x |
+| GlobalDataFlow.cs:114:76:114:76 | x | GlobalDataFlow.cs:114:81:114:81 | access to parameter x |
+| GlobalDataFlow.cs:114:76:114:81 | (...) => ... | GlobalDataFlow.cs:114:76:114:81 | (...) => ... |
+| GlobalDataFlow.cs:114:76:114:81 | [output] (...) => ... | GlobalDataFlow.cs:114:76:114:81 | [output] (...) => ... |
+| GlobalDataFlow.cs:114:81:114:81 | access to parameter x | GlobalDataFlow.cs:114:76:114:81 | [output] (...) => ... |
+| GlobalDataFlow.cs:114:81:114:81 | access to parameter x | GlobalDataFlow.cs:114:76:114:81 | [output] (...) => ... |
+| GlobalDataFlow.cs:114:81:114:81 | access to parameter x | GlobalDataFlow.cs:114:81:114:81 | access to parameter x |
 | GlobalDataFlow.cs:115:9:115:23 | call to method Check | GlobalDataFlow.cs:115:9:115:23 | call to method Check |
 | GlobalDataFlow.cs:115:15:115:22 | access to local variable nonSink1 | GlobalDataFlow.cs:115:15:115:22 | access to local variable nonSink1 |
-| GlobalDataFlow.cs:115:15:115:22 | access to local variable nonSink1 | GlobalDataFlow.cs:120:20:120:27 | access to local variable nonSink1 |
-| GlobalDataFlow.cs:115:15:115:22 | access to local variable nonSink1 | GlobalDataFlow.cs:120:20:120:27 | access to local variable nonSink1 |
-| GlobalDataFlow.cs:116:9:116:64 | ... = ... | GlobalDataFlow.cs:116:9:116:64 | ... = ... |
-| GlobalDataFlow.cs:116:9:116:64 | SSA def(nonSink0) | GlobalDataFlow.cs:116:9:116:64 | SSA def(nonSink0) |
-| GlobalDataFlow.cs:116:9:116:64 | SSA def(nonSink0) | GlobalDataFlow.cs:117:15:117:22 | access to local variable nonSink0 |
-| GlobalDataFlow.cs:116:9:116:64 | SSA def(nonSink0) | GlobalDataFlow.cs:117:15:117:22 | access to local variable nonSink0 |
-| GlobalDataFlow.cs:116:20:116:25 | access to local variable sink14 | GlobalDataFlow.cs:116:20:116:25 | access to local variable sink14 |
-| GlobalDataFlow.cs:116:20:116:25 | access to local variable sink14 | GlobalDataFlow.cs:118:20:118:25 | access to local variable sink14 |
-| GlobalDataFlow.cs:116:20:116:25 | access to local variable sink14 | GlobalDataFlow.cs:118:20:118:25 | access to local variable sink14 |
-| GlobalDataFlow.cs:116:20:116:64 | call to method Aggregate | GlobalDataFlow.cs:116:9:116:64 | SSA def(nonSink0) |
-| GlobalDataFlow.cs:116:20:116:64 | call to method Aggregate | GlobalDataFlow.cs:116:9:116:64 | SSA def(nonSink0) |
-| GlobalDataFlow.cs:116:20:116:64 | call to method Aggregate | GlobalDataFlow.cs:116:20:116:64 | call to method Aggregate |
-| GlobalDataFlow.cs:116:20:116:64 | call to method Aggregate | GlobalDataFlow.cs:117:15:117:22 | access to local variable nonSink0 |
-| GlobalDataFlow.cs:116:20:116:64 | call to method Aggregate | GlobalDataFlow.cs:117:15:117:22 | access to local variable nonSink0 |
-| GlobalDataFlow.cs:116:37:116:38 | "" | GlobalDataFlow.cs:116:37:116:38 | "" |
-| GlobalDataFlow.cs:116:37:116:38 | "" | GlobalDataFlow.cs:116:42:116:44 | acc |
-| GlobalDataFlow.cs:116:37:116:38 | "" | GlobalDataFlow.cs:116:42:116:44 | acc |
-| GlobalDataFlow.cs:116:41:116:55 | (...) => ... | GlobalDataFlow.cs:116:41:116:55 | (...) => ... |
-| GlobalDataFlow.cs:116:41:116:55 | [output] (...) => ... | GlobalDataFlow.cs:116:41:116:55 | [output] (...) => ... |
-| GlobalDataFlow.cs:116:41:116:55 | [output] (...) => ... | GlobalDataFlow.cs:116:58:116:58 | x |
-| GlobalDataFlow.cs:116:41:116:55 | [output] (...) => ... | GlobalDataFlow.cs:116:58:116:58 | x |
-| GlobalDataFlow.cs:116:42:116:44 | acc | GlobalDataFlow.cs:116:42:116:44 | acc |
-| GlobalDataFlow.cs:116:42:116:44 | acc | GlobalDataFlow.cs:116:42:116:44 | acc |
-| GlobalDataFlow.cs:116:42:116:44 | acc | GlobalDataFlow.cs:116:53:116:55 | access to parameter acc |
-| GlobalDataFlow.cs:116:42:116:44 | acc | GlobalDataFlow.cs:116:53:116:55 | access to parameter acc |
-| GlobalDataFlow.cs:116:53:116:55 | access to parameter acc | GlobalDataFlow.cs:116:41:116:55 | [output] (...) => ... |
-| GlobalDataFlow.cs:116:53:116:55 | access to parameter acc | GlobalDataFlow.cs:116:41:116:55 | [output] (...) => ... |
-| GlobalDataFlow.cs:116:53:116:55 | access to parameter acc | GlobalDataFlow.cs:116:53:116:55 | access to parameter acc |
-| GlobalDataFlow.cs:116:58:116:58 | x | GlobalDataFlow.cs:116:58:116:58 | x |
-| GlobalDataFlow.cs:116:58:116:58 | x | GlobalDataFlow.cs:116:58:116:58 | x |
-| GlobalDataFlow.cs:116:58:116:58 | x | GlobalDataFlow.cs:116:63:116:63 | access to parameter x |
-| GlobalDataFlow.cs:116:58:116:58 | x | GlobalDataFlow.cs:116:63:116:63 | access to parameter x |
-| GlobalDataFlow.cs:116:58:116:63 | (...) => ... | GlobalDataFlow.cs:116:58:116:63 | (...) => ... |
-| GlobalDataFlow.cs:116:58:116:63 | [output] (...) => ... | GlobalDataFlow.cs:116:58:116:63 | [output] (...) => ... |
-| GlobalDataFlow.cs:116:63:116:63 | access to parameter x | GlobalDataFlow.cs:116:58:116:63 | [output] (...) => ... |
-| GlobalDataFlow.cs:116:63:116:63 | access to parameter x | GlobalDataFlow.cs:116:58:116:63 | [output] (...) => ... |
-| GlobalDataFlow.cs:116:63:116:63 | access to parameter x | GlobalDataFlow.cs:116:63:116:63 | access to parameter x |
+| GlobalDataFlow.cs:116:9:116:134 | ... = ... | GlobalDataFlow.cs:116:9:116:134 | ... = ... |
+| GlobalDataFlow.cs:116:9:116:134 | SSA def(nonSink1) | GlobalDataFlow.cs:116:9:116:134 | SSA def(nonSink1) |
+| GlobalDataFlow.cs:116:9:116:134 | SSA def(nonSink1) | GlobalDataFlow.cs:117:15:117:22 | access to local variable nonSink1 |
+| GlobalDataFlow.cs:116:9:116:134 | SSA def(nonSink1) | GlobalDataFlow.cs:117:15:117:22 | access to local variable nonSink1 |
+| GlobalDataFlow.cs:116:20:116:134 | call to method Zip | GlobalDataFlow.cs:116:9:116:134 | SSA def(nonSink1) |
+| GlobalDataFlow.cs:116:20:116:134 | call to method Zip | GlobalDataFlow.cs:116:9:116:134 | SSA def(nonSink1) |
+| GlobalDataFlow.cs:116:20:116:134 | call to method Zip | GlobalDataFlow.cs:116:20:116:134 | call to method Zip |
+| GlobalDataFlow.cs:116:20:116:134 | call to method Zip | GlobalDataFlow.cs:117:15:117:22 | access to local variable nonSink1 |
+| GlobalDataFlow.cs:116:20:116:134 | call to method Zip | GlobalDataFlow.cs:117:15:117:22 | access to local variable nonSink1 |
+| GlobalDataFlow.cs:116:21:116:72 | (...) ... | GlobalDataFlow.cs:116:21:116:72 | (...) ... |
+| GlobalDataFlow.cs:116:42:116:72 | array creation of type String[] | GlobalDataFlow.cs:116:21:116:72 | (...) ... |
+| GlobalDataFlow.cs:116:42:116:72 | array creation of type String[] | GlobalDataFlow.cs:116:21:116:72 | (...) ... |
+| GlobalDataFlow.cs:116:42:116:72 | array creation of type String[] | GlobalDataFlow.cs:116:42:116:72 | array creation of type String[] |
+| GlobalDataFlow.cs:116:55:116:72 | { ..., ... } | GlobalDataFlow.cs:116:55:116:72 | { ..., ... } |
+| GlobalDataFlow.cs:116:57:116:62 | access to local variable sink14 | GlobalDataFlow.cs:116:57:116:62 | access to local variable sink14 |
+| GlobalDataFlow.cs:116:57:116:62 | access to local variable sink14 | GlobalDataFlow.cs:120:20:120:25 | access to local variable sink14 |
+| GlobalDataFlow.cs:116:57:116:62 | access to local variable sink14 | GlobalDataFlow.cs:120:20:120:25 | access to local variable sink14 |
+| GlobalDataFlow.cs:116:57:116:62 | access to local variable sink14 | GlobalDataFlow.cs:122:20:122:25 | access to local variable sink14 |
+| GlobalDataFlow.cs:116:57:116:62 | access to local variable sink14 | GlobalDataFlow.cs:122:20:122:25 | access to local variable sink14 |
+| GlobalDataFlow.cs:116:57:116:70 | call to method First | GlobalDataFlow.cs:116:57:116:70 | call to method First |
+| GlobalDataFlow.cs:116:80:116:119 | (...) ... | GlobalDataFlow.cs:116:80:116:119 | (...) ... |
+| GlobalDataFlow.cs:116:80:116:119 | (...) ... | GlobalDataFlow.cs:116:127:116:127 | y |
+| GlobalDataFlow.cs:116:80:116:119 | (...) ... | GlobalDataFlow.cs:116:127:116:127 | y |
+| GlobalDataFlow.cs:116:101:116:119 | array creation of type String[] | GlobalDataFlow.cs:116:80:116:119 | (...) ... |
+| GlobalDataFlow.cs:116:101:116:119 | array creation of type String[] | GlobalDataFlow.cs:116:80:116:119 | (...) ... |
+| GlobalDataFlow.cs:116:101:116:119 | array creation of type String[] | GlobalDataFlow.cs:116:101:116:119 | array creation of type String[] |
+| GlobalDataFlow.cs:116:114:116:119 | { ..., ... } | GlobalDataFlow.cs:116:114:116:119 | { ..., ... } |
+| GlobalDataFlow.cs:116:116:116:117 | "" | GlobalDataFlow.cs:116:116:116:117 | "" |
+| GlobalDataFlow.cs:116:123:116:133 | (...) => ... | GlobalDataFlow.cs:116:123:116:133 | (...) => ... |
+| GlobalDataFlow.cs:116:123:116:133 | [output] (...) => ... | GlobalDataFlow.cs:116:123:116:133 | [output] (...) => ... |
+| GlobalDataFlow.cs:116:127:116:127 | y | GlobalDataFlow.cs:116:127:116:127 | y |
+| GlobalDataFlow.cs:116:127:116:127 | y | GlobalDataFlow.cs:116:127:116:127 | y |
+| GlobalDataFlow.cs:116:127:116:127 | y | GlobalDataFlow.cs:116:133:116:133 | access to parameter y |
+| GlobalDataFlow.cs:116:127:116:127 | y | GlobalDataFlow.cs:116:133:116:133 | access to parameter y |
+| GlobalDataFlow.cs:116:133:116:133 | access to parameter y | GlobalDataFlow.cs:116:123:116:133 | [output] (...) => ... |
+| GlobalDataFlow.cs:116:133:116:133 | access to parameter y | GlobalDataFlow.cs:116:123:116:133 | [output] (...) => ... |
+| GlobalDataFlow.cs:116:133:116:133 | access to parameter y | GlobalDataFlow.cs:116:133:116:133 | access to parameter y |
 | GlobalDataFlow.cs:117:9:117:23 | call to method Check | GlobalDataFlow.cs:117:9:117:23 | call to method Check |
-| GlobalDataFlow.cs:117:15:117:22 | access to local variable nonSink0 | GlobalDataFlow.cs:117:15:117:22 | access to local variable nonSink0 |
-| GlobalDataFlow.cs:118:9:118:69 | ... = ... | GlobalDataFlow.cs:118:9:118:69 | ... = ... |
-| GlobalDataFlow.cs:118:9:118:69 | SSA def(nonSink0) | GlobalDataFlow.cs:118:9:118:69 | SSA def(nonSink0) |
-| GlobalDataFlow.cs:118:9:118:69 | SSA def(nonSink0) | GlobalDataFlow.cs:119:15:119:22 | access to local variable nonSink0 |
-| GlobalDataFlow.cs:118:9:118:69 | SSA def(nonSink0) | GlobalDataFlow.cs:119:15:119:22 | access to local variable nonSink0 |
-| GlobalDataFlow.cs:118:20:118:25 | access to local variable sink14 | GlobalDataFlow.cs:118:20:118:25 | access to local variable sink14 |
-| GlobalDataFlow.cs:118:20:118:25 | access to local variable sink14 | GlobalDataFlow.cs:118:47:118:47 | s |
-| GlobalDataFlow.cs:118:20:118:25 | access to local variable sink14 | GlobalDataFlow.cs:118:47:118:47 | s |
-| GlobalDataFlow.cs:118:20:118:69 | call to method Aggregate | GlobalDataFlow.cs:118:9:118:69 | SSA def(nonSink0) |
-| GlobalDataFlow.cs:118:20:118:69 | call to method Aggregate | GlobalDataFlow.cs:118:9:118:69 | SSA def(nonSink0) |
-| GlobalDataFlow.cs:118:20:118:69 | call to method Aggregate | GlobalDataFlow.cs:118:20:118:69 | call to method Aggregate |
-| GlobalDataFlow.cs:118:20:118:69 | call to method Aggregate | GlobalDataFlow.cs:119:15:119:22 | access to local variable nonSink0 |
-| GlobalDataFlow.cs:118:20:118:69 | call to method Aggregate | GlobalDataFlow.cs:119:15:119:22 | access to local variable nonSink0 |
-| GlobalDataFlow.cs:118:37:118:38 | "" | GlobalDataFlow.cs:118:37:118:38 | "" |
-| GlobalDataFlow.cs:118:37:118:38 | "" | GlobalDataFlow.cs:118:42:118:44 | acc |
-| GlobalDataFlow.cs:118:37:118:38 | "" | GlobalDataFlow.cs:118:42:118:44 | acc |
-| GlobalDataFlow.cs:118:41:118:59 | (...) => ... | GlobalDataFlow.cs:118:41:118:59 | (...) => ... |
-| GlobalDataFlow.cs:118:41:118:59 | [output] (...) => ... | GlobalDataFlow.cs:118:41:118:59 | [output] (...) => ... |
-| GlobalDataFlow.cs:118:42:118:44 | acc | GlobalDataFlow.cs:118:42:118:44 | acc |
-| GlobalDataFlow.cs:118:42:118:44 | acc | GlobalDataFlow.cs:118:42:118:44 | acc |
-| GlobalDataFlow.cs:118:42:118:44 | acc | GlobalDataFlow.cs:118:53:118:55 | access to parameter acc |
-| GlobalDataFlow.cs:118:42:118:44 | acc | GlobalDataFlow.cs:118:53:118:55 | access to parameter acc |
-| GlobalDataFlow.cs:118:47:118:47 | s | GlobalDataFlow.cs:118:47:118:47 | s |
-| GlobalDataFlow.cs:118:47:118:47 | s | GlobalDataFlow.cs:118:47:118:47 | s |
-| GlobalDataFlow.cs:118:47:118:47 | s | GlobalDataFlow.cs:118:59:118:59 | access to parameter s |
-| GlobalDataFlow.cs:118:47:118:47 | s | GlobalDataFlow.cs:118:59:118:59 | access to parameter s |
-| GlobalDataFlow.cs:118:53:118:55 | access to parameter acc | GlobalDataFlow.cs:118:53:118:55 | access to parameter acc |
-| GlobalDataFlow.cs:118:53:118:59 | ... + ... | GlobalDataFlow.cs:118:41:118:59 | [output] (...) => ... |
-| GlobalDataFlow.cs:118:53:118:59 | ... + ... | GlobalDataFlow.cs:118:41:118:59 | [output] (...) => ... |
-| GlobalDataFlow.cs:118:53:118:59 | ... + ... | GlobalDataFlow.cs:118:53:118:59 | ... + ... |
-| GlobalDataFlow.cs:118:59:118:59 | access to parameter s | GlobalDataFlow.cs:118:59:118:59 | access to parameter s |
-| GlobalDataFlow.cs:118:62:118:68 | (...) => ... | GlobalDataFlow.cs:118:62:118:68 | (...) => ... |
-| GlobalDataFlow.cs:118:62:118:68 | [output] (...) => ... | GlobalDataFlow.cs:118:62:118:68 | [output] (...) => ... |
-| GlobalDataFlow.cs:118:67:118:68 | "" | GlobalDataFlow.cs:118:62:118:68 | [output] (...) => ... |
-| GlobalDataFlow.cs:118:67:118:68 | "" | GlobalDataFlow.cs:118:62:118:68 | [output] (...) => ... |
-| GlobalDataFlow.cs:118:67:118:68 | "" | GlobalDataFlow.cs:118:67:118:68 | "" |
+| GlobalDataFlow.cs:117:15:117:22 | access to local variable nonSink1 | GlobalDataFlow.cs:117:15:117:22 | access to local variable nonSink1 |
+| GlobalDataFlow.cs:118:9:118:134 | ... = ... | GlobalDataFlow.cs:118:9:118:134 | ... = ... |
+| GlobalDataFlow.cs:118:9:118:134 | SSA def(nonSink1) | GlobalDataFlow.cs:118:9:118:134 | SSA def(nonSink1) |
+| GlobalDataFlow.cs:118:9:118:134 | SSA def(nonSink1) | GlobalDataFlow.cs:119:15:119:22 | access to local variable nonSink1 |
+| GlobalDataFlow.cs:118:9:118:134 | SSA def(nonSink1) | GlobalDataFlow.cs:119:15:119:22 | access to local variable nonSink1 |
+| GlobalDataFlow.cs:118:9:118:134 | SSA def(nonSink1) | GlobalDataFlow.cs:124:20:124:27 | access to local variable nonSink1 |
+| GlobalDataFlow.cs:118:9:118:134 | SSA def(nonSink1) | GlobalDataFlow.cs:124:20:124:27 | access to local variable nonSink1 |
+| GlobalDataFlow.cs:118:20:118:134 | call to method Zip | GlobalDataFlow.cs:118:9:118:134 | SSA def(nonSink1) |
+| GlobalDataFlow.cs:118:20:118:134 | call to method Zip | GlobalDataFlow.cs:118:9:118:134 | SSA def(nonSink1) |
+| GlobalDataFlow.cs:118:20:118:134 | call to method Zip | GlobalDataFlow.cs:118:20:118:134 | call to method Zip |
+| GlobalDataFlow.cs:118:20:118:134 | call to method Zip | GlobalDataFlow.cs:119:15:119:22 | access to local variable nonSink1 |
+| GlobalDataFlow.cs:118:20:118:134 | call to method Zip | GlobalDataFlow.cs:119:15:119:22 | access to local variable nonSink1 |
+| GlobalDataFlow.cs:118:20:118:134 | call to method Zip | GlobalDataFlow.cs:124:20:124:27 | access to local variable nonSink1 |
+| GlobalDataFlow.cs:118:20:118:134 | call to method Zip | GlobalDataFlow.cs:124:20:124:27 | access to local variable nonSink1 |
+| GlobalDataFlow.cs:118:21:118:60 | (...) ... | GlobalDataFlow.cs:118:21:118:60 | (...) ... |
+| GlobalDataFlow.cs:118:21:118:60 | (...) ... | GlobalDataFlow.cs:118:124:118:124 | x |
+| GlobalDataFlow.cs:118:21:118:60 | (...) ... | GlobalDataFlow.cs:118:124:118:124 | x |
+| GlobalDataFlow.cs:118:42:118:60 | array creation of type String[] | GlobalDataFlow.cs:118:21:118:60 | (...) ... |
+| GlobalDataFlow.cs:118:42:118:60 | array creation of type String[] | GlobalDataFlow.cs:118:21:118:60 | (...) ... |
+| GlobalDataFlow.cs:118:42:118:60 | array creation of type String[] | GlobalDataFlow.cs:118:42:118:60 | array creation of type String[] |
+| GlobalDataFlow.cs:118:55:118:60 | { ..., ... } | GlobalDataFlow.cs:118:55:118:60 | { ..., ... } |
+| GlobalDataFlow.cs:118:57:118:58 | "" | GlobalDataFlow.cs:118:57:118:58 | "" |
+| GlobalDataFlow.cs:118:68:118:119 | (...) ... | GlobalDataFlow.cs:118:68:118:119 | (...) ... |
+| GlobalDataFlow.cs:118:89:118:119 | array creation of type String[] | GlobalDataFlow.cs:118:68:118:119 | (...) ... |
+| GlobalDataFlow.cs:118:89:118:119 | array creation of type String[] | GlobalDataFlow.cs:118:68:118:119 | (...) ... |
+| GlobalDataFlow.cs:118:89:118:119 | array creation of type String[] | GlobalDataFlow.cs:118:89:118:119 | array creation of type String[] |
+| GlobalDataFlow.cs:118:102:118:119 | { ..., ... } | GlobalDataFlow.cs:118:102:118:119 | { ..., ... } |
+| GlobalDataFlow.cs:118:104:118:109 | access to local variable sink15 | GlobalDataFlow.cs:118:104:118:109 | access to local variable sink15 |
+| GlobalDataFlow.cs:118:104:118:117 | call to method First | GlobalDataFlow.cs:118:104:118:117 | call to method First |
+| GlobalDataFlow.cs:118:123:118:133 | (...) => ... | GlobalDataFlow.cs:118:123:118:133 | (...) => ... |
+| GlobalDataFlow.cs:118:123:118:133 | [output] (...) => ... | GlobalDataFlow.cs:118:123:118:133 | [output] (...) => ... |
+| GlobalDataFlow.cs:118:124:118:124 | x | GlobalDataFlow.cs:118:124:118:124 | x |
+| GlobalDataFlow.cs:118:124:118:124 | x | GlobalDataFlow.cs:118:124:118:124 | x |
+| GlobalDataFlow.cs:118:124:118:124 | x | GlobalDataFlow.cs:118:133:118:133 | access to parameter x |
+| GlobalDataFlow.cs:118:124:118:124 | x | GlobalDataFlow.cs:118:133:118:133 | access to parameter x |
+| GlobalDataFlow.cs:118:133:118:133 | access to parameter x | GlobalDataFlow.cs:118:123:118:133 | [output] (...) => ... |
+| GlobalDataFlow.cs:118:133:118:133 | access to parameter x | GlobalDataFlow.cs:118:123:118:133 | [output] (...) => ... |
+| GlobalDataFlow.cs:118:133:118:133 | access to parameter x | GlobalDataFlow.cs:118:133:118:133 | access to parameter x |
 | GlobalDataFlow.cs:119:9:119:23 | call to method Check | GlobalDataFlow.cs:119:9:119:23 | call to method Check |
-| GlobalDataFlow.cs:119:15:119:22 | access to local variable nonSink0 | GlobalDataFlow.cs:119:15:119:22 | access to local variable nonSink0 |
-| GlobalDataFlow.cs:120:9:120:67 | ... = ... | GlobalDataFlow.cs:120:9:120:67 | ... = ... |
-| GlobalDataFlow.cs:120:9:120:67 | SSA def(nonSink0) | GlobalDataFlow.cs:120:9:120:67 | SSA def(nonSink0) |
-| GlobalDataFlow.cs:120:9:120:67 | SSA def(nonSink0) | GlobalDataFlow.cs:121:15:121:22 | access to local variable nonSink0 |
-| GlobalDataFlow.cs:120:9:120:67 | SSA def(nonSink0) | GlobalDataFlow.cs:121:15:121:22 | access to local variable nonSink0 |
-| GlobalDataFlow.cs:120:9:120:67 | SSA def(nonSink0) | GlobalDataFlow.cs:123:24:123:31 | access to local variable nonSink0 |
-| GlobalDataFlow.cs:120:9:120:67 | SSA def(nonSink0) | GlobalDataFlow.cs:123:24:123:31 | access to local variable nonSink0 |
-| GlobalDataFlow.cs:120:9:120:67 | SSA def(nonSink0) | GlobalDataFlow.cs:126:23:126:30 | access to local variable nonSink0 |
-| GlobalDataFlow.cs:120:9:120:67 | SSA def(nonSink0) | GlobalDataFlow.cs:126:23:126:30 | access to local variable nonSink0 |
-| GlobalDataFlow.cs:120:9:120:67 | SSA def(nonSink0) | GlobalDataFlow.cs:135:28:135:35 | access to local variable nonSink0 |
-| GlobalDataFlow.cs:120:9:120:67 | SSA def(nonSink0) | GlobalDataFlow.cs:135:28:135:35 | access to local variable nonSink0 |
-| GlobalDataFlow.cs:120:20:120:27 | access to local variable nonSink1 | GlobalDataFlow.cs:120:20:120:27 | access to local variable nonSink1 |
-| GlobalDataFlow.cs:120:20:120:27 | access to local variable nonSink1 | GlobalDataFlow.cs:120:52:120:52 | s |
-| GlobalDataFlow.cs:120:20:120:27 | access to local variable nonSink1 | GlobalDataFlow.cs:120:52:120:52 | s |
-| GlobalDataFlow.cs:120:20:120:67 | call to method Aggregate | GlobalDataFlow.cs:120:9:120:67 | SSA def(nonSink0) |
-| GlobalDataFlow.cs:120:20:120:67 | call to method Aggregate | GlobalDataFlow.cs:120:9:120:67 | SSA def(nonSink0) |
-| GlobalDataFlow.cs:120:20:120:67 | call to method Aggregate | GlobalDataFlow.cs:120:20:120:67 | call to method Aggregate |
-| GlobalDataFlow.cs:120:20:120:67 | call to method Aggregate | GlobalDataFlow.cs:121:15:121:22 | access to local variable nonSink0 |
-| GlobalDataFlow.cs:120:20:120:67 | call to method Aggregate | GlobalDataFlow.cs:121:15:121:22 | access to local variable nonSink0 |
-| GlobalDataFlow.cs:120:20:120:67 | call to method Aggregate | GlobalDataFlow.cs:123:24:123:31 | access to local variable nonSink0 |
-| GlobalDataFlow.cs:120:20:120:67 | call to method Aggregate | GlobalDataFlow.cs:123:24:123:31 | access to local variable nonSink0 |
-| GlobalDataFlow.cs:120:20:120:67 | call to method Aggregate | GlobalDataFlow.cs:126:23:126:30 | access to local variable nonSink0 |
-| GlobalDataFlow.cs:120:20:120:67 | call to method Aggregate | GlobalDataFlow.cs:126:23:126:30 | access to local variable nonSink0 |
-| GlobalDataFlow.cs:120:20:120:67 | call to method Aggregate | GlobalDataFlow.cs:135:28:135:35 | access to local variable nonSink0 |
-| GlobalDataFlow.cs:120:20:120:67 | call to method Aggregate | GlobalDataFlow.cs:135:28:135:35 | access to local variable nonSink0 |
-| GlobalDataFlow.cs:120:39:120:43 | access to local variable sink1 | GlobalDataFlow.cs:120:39:120:43 | access to local variable sink1 |
-| GlobalDataFlow.cs:120:46:120:58 | (...) => ... | GlobalDataFlow.cs:120:46:120:58 | (...) => ... |
-| GlobalDataFlow.cs:120:46:120:58 | [output] (...) => ... | GlobalDataFlow.cs:120:46:120:58 | [output] (...) => ... |
-| GlobalDataFlow.cs:120:46:120:58 | [output] (...) => ... | GlobalDataFlow.cs:120:61:120:61 | x |
-| GlobalDataFlow.cs:120:46:120:58 | [output] (...) => ... | GlobalDataFlow.cs:120:61:120:61 | x |
-| GlobalDataFlow.cs:120:52:120:52 | s | GlobalDataFlow.cs:120:52:120:52 | s |
-| GlobalDataFlow.cs:120:52:120:52 | s | GlobalDataFlow.cs:120:52:120:52 | s |
-| GlobalDataFlow.cs:120:52:120:52 | s | GlobalDataFlow.cs:120:58:120:58 | access to parameter s |
-| GlobalDataFlow.cs:120:52:120:52 | s | GlobalDataFlow.cs:120:58:120:58 | access to parameter s |
-| GlobalDataFlow.cs:120:58:120:58 | access to parameter s | GlobalDataFlow.cs:120:46:120:58 | [output] (...) => ... |
-| GlobalDataFlow.cs:120:58:120:58 | access to parameter s | GlobalDataFlow.cs:120:46:120:58 | [output] (...) => ... |
-| GlobalDataFlow.cs:120:58:120:58 | access to parameter s | GlobalDataFlow.cs:120:58:120:58 | access to parameter s |
-| GlobalDataFlow.cs:120:61:120:61 | x | GlobalDataFlow.cs:120:61:120:61 | x |
-| GlobalDataFlow.cs:120:61:120:61 | x | GlobalDataFlow.cs:120:61:120:61 | x |
-| GlobalDataFlow.cs:120:61:120:61 | x | GlobalDataFlow.cs:120:66:120:66 | access to parameter x |
-| GlobalDataFlow.cs:120:61:120:61 | x | GlobalDataFlow.cs:120:66:120:66 | access to parameter x |
-| GlobalDataFlow.cs:120:61:120:66 | (...) => ... | GlobalDataFlow.cs:120:61:120:66 | (...) => ... |
-| GlobalDataFlow.cs:120:61:120:66 | [output] (...) => ... | GlobalDataFlow.cs:120:61:120:66 | [output] (...) => ... |
-| GlobalDataFlow.cs:120:66:120:66 | access to parameter x | GlobalDataFlow.cs:120:61:120:66 | [output] (...) => ... |
-| GlobalDataFlow.cs:120:66:120:66 | access to parameter x | GlobalDataFlow.cs:120:61:120:66 | [output] (...) => ... |
-| GlobalDataFlow.cs:120:66:120:66 | access to parameter x | GlobalDataFlow.cs:120:66:120:66 | access to parameter x |
+| GlobalDataFlow.cs:119:15:119:22 | access to local variable nonSink1 | GlobalDataFlow.cs:119:15:119:22 | access to local variable nonSink1 |
+| GlobalDataFlow.cs:119:15:119:22 | access to local variable nonSink1 | GlobalDataFlow.cs:124:20:124:27 | access to local variable nonSink1 |
+| GlobalDataFlow.cs:119:15:119:22 | access to local variable nonSink1 | GlobalDataFlow.cs:124:20:124:27 | access to local variable nonSink1 |
+| GlobalDataFlow.cs:120:9:120:64 | ... = ... | GlobalDataFlow.cs:120:9:120:64 | ... = ... |
+| GlobalDataFlow.cs:120:9:120:64 | SSA def(nonSink0) | GlobalDataFlow.cs:120:9:120:64 | SSA def(nonSink0) |
+| GlobalDataFlow.cs:120:9:120:64 | SSA def(nonSink0) | GlobalDataFlow.cs:121:15:121:22 | access to local variable nonSink0 |
+| GlobalDataFlow.cs:120:9:120:64 | SSA def(nonSink0) | GlobalDataFlow.cs:121:15:121:22 | access to local variable nonSink0 |
+| GlobalDataFlow.cs:120:20:120:25 | access to local variable sink14 | GlobalDataFlow.cs:120:20:120:25 | access to local variable sink14 |
+| GlobalDataFlow.cs:120:20:120:25 | access to local variable sink14 | GlobalDataFlow.cs:122:20:122:25 | access to local variable sink14 |
+| GlobalDataFlow.cs:120:20:120:25 | access to local variable sink14 | GlobalDataFlow.cs:122:20:122:25 | access to local variable sink14 |
+| GlobalDataFlow.cs:120:20:120:64 | call to method Aggregate | GlobalDataFlow.cs:120:9:120:64 | SSA def(nonSink0) |
+| GlobalDataFlow.cs:120:20:120:64 | call to method Aggregate | GlobalDataFlow.cs:120:9:120:64 | SSA def(nonSink0) |
+| GlobalDataFlow.cs:120:20:120:64 | call to method Aggregate | GlobalDataFlow.cs:120:20:120:64 | call to method Aggregate |
+| GlobalDataFlow.cs:120:20:120:64 | call to method Aggregate | GlobalDataFlow.cs:121:15:121:22 | access to local variable nonSink0 |
+| GlobalDataFlow.cs:120:20:120:64 | call to method Aggregate | GlobalDataFlow.cs:121:15:121:22 | access to local variable nonSink0 |
+| GlobalDataFlow.cs:120:37:120:38 | "" | GlobalDataFlow.cs:120:37:120:38 | "" |
+| GlobalDataFlow.cs:120:37:120:38 | "" | GlobalDataFlow.cs:120:42:120:44 | acc |
+| GlobalDataFlow.cs:120:37:120:38 | "" | GlobalDataFlow.cs:120:42:120:44 | acc |
+| GlobalDataFlow.cs:120:41:120:55 | (...) => ... | GlobalDataFlow.cs:120:41:120:55 | (...) => ... |
+| GlobalDataFlow.cs:120:41:120:55 | [output] (...) => ... | GlobalDataFlow.cs:120:41:120:55 | [output] (...) => ... |
+| GlobalDataFlow.cs:120:41:120:55 | [output] (...) => ... | GlobalDataFlow.cs:120:58:120:58 | x |
+| GlobalDataFlow.cs:120:41:120:55 | [output] (...) => ... | GlobalDataFlow.cs:120:58:120:58 | x |
+| GlobalDataFlow.cs:120:42:120:44 | acc | GlobalDataFlow.cs:120:42:120:44 | acc |
+| GlobalDataFlow.cs:120:42:120:44 | acc | GlobalDataFlow.cs:120:42:120:44 | acc |
+| GlobalDataFlow.cs:120:42:120:44 | acc | GlobalDataFlow.cs:120:53:120:55 | access to parameter acc |
+| GlobalDataFlow.cs:120:42:120:44 | acc | GlobalDataFlow.cs:120:53:120:55 | access to parameter acc |
+| GlobalDataFlow.cs:120:53:120:55 | access to parameter acc | GlobalDataFlow.cs:120:41:120:55 | [output] (...) => ... |
+| GlobalDataFlow.cs:120:53:120:55 | access to parameter acc | GlobalDataFlow.cs:120:41:120:55 | [output] (...) => ... |
+| GlobalDataFlow.cs:120:53:120:55 | access to parameter acc | GlobalDataFlow.cs:120:53:120:55 | access to parameter acc |
+| GlobalDataFlow.cs:120:58:120:58 | x | GlobalDataFlow.cs:120:58:120:58 | x |
+| GlobalDataFlow.cs:120:58:120:58 | x | GlobalDataFlow.cs:120:58:120:58 | x |
+| GlobalDataFlow.cs:120:58:120:58 | x | GlobalDataFlow.cs:120:63:120:63 | access to parameter x |
+| GlobalDataFlow.cs:120:58:120:58 | x | GlobalDataFlow.cs:120:63:120:63 | access to parameter x |
+| GlobalDataFlow.cs:120:58:120:63 | (...) => ... | GlobalDataFlow.cs:120:58:120:63 | (...) => ... |
+| GlobalDataFlow.cs:120:58:120:63 | [output] (...) => ... | GlobalDataFlow.cs:120:58:120:63 | [output] (...) => ... |
+| GlobalDataFlow.cs:120:63:120:63 | access to parameter x | GlobalDataFlow.cs:120:58:120:63 | [output] (...) => ... |
+| GlobalDataFlow.cs:120:63:120:63 | access to parameter x | GlobalDataFlow.cs:120:58:120:63 | [output] (...) => ... |
+| GlobalDataFlow.cs:120:63:120:63 | access to parameter x | GlobalDataFlow.cs:120:63:120:63 | access to parameter x |
 | GlobalDataFlow.cs:121:9:121:23 | call to method Check | GlobalDataFlow.cs:121:9:121:23 | call to method Check |
 | GlobalDataFlow.cs:121:15:121:22 | access to local variable nonSink0 | GlobalDataFlow.cs:121:15:121:22 | access to local variable nonSink0 |
-| GlobalDataFlow.cs:121:15:121:22 | access to local variable nonSink0 | GlobalDataFlow.cs:123:24:123:31 | access to local variable nonSink0 |
-| GlobalDataFlow.cs:121:15:121:22 | access to local variable nonSink0 | GlobalDataFlow.cs:123:24:123:31 | access to local variable nonSink0 |
-| GlobalDataFlow.cs:121:15:121:22 | access to local variable nonSink0 | GlobalDataFlow.cs:126:23:126:30 | access to local variable nonSink0 |
-| GlobalDataFlow.cs:121:15:121:22 | access to local variable nonSink0 | GlobalDataFlow.cs:126:23:126:30 | access to local variable nonSink0 |
-| GlobalDataFlow.cs:121:15:121:22 | access to local variable nonSink0 | GlobalDataFlow.cs:135:28:135:35 | access to local variable nonSink0 |
-| GlobalDataFlow.cs:121:15:121:22 | access to local variable nonSink0 | GlobalDataFlow.cs:135:28:135:35 | access to local variable nonSink0 |
-| GlobalDataFlow.cs:122:13:122:20 | Int32 nonSink2 | GlobalDataFlow.cs:122:13:122:20 | Int32 nonSink2 |
-| GlobalDataFlow.cs:123:9:123:46 | call to method TryParse | GlobalDataFlow.cs:123:9:123:46 | call to method TryParse |
-| GlobalDataFlow.cs:123:24:123:31 | access to local variable nonSink0 | GlobalDataFlow.cs:123:24:123:31 | access to local variable nonSink0 |
-| GlobalDataFlow.cs:123:24:123:31 | access to local variable nonSink0 | GlobalDataFlow.cs:126:23:126:30 | access to local variable nonSink0 |
-| GlobalDataFlow.cs:123:24:123:31 | access to local variable nonSink0 | GlobalDataFlow.cs:126:23:126:30 | access to local variable nonSink0 |
-| GlobalDataFlow.cs:123:24:123:31 | access to local variable nonSink0 | GlobalDataFlow.cs:135:28:135:35 | access to local variable nonSink0 |
-| GlobalDataFlow.cs:123:24:123:31 | access to local variable nonSink0 | GlobalDataFlow.cs:135:28:135:35 | access to local variable nonSink0 |
-| GlobalDataFlow.cs:123:38:123:45 | SSA def(nonSink2) | GlobalDataFlow.cs:123:38:123:45 | SSA def(nonSink2) |
-| GlobalDataFlow.cs:123:38:123:45 | SSA def(nonSink2) | GlobalDataFlow.cs:124:15:124:22 | access to local variable nonSink2 |
-| GlobalDataFlow.cs:123:38:123:45 | SSA def(nonSink2) | GlobalDataFlow.cs:124:15:124:22 | access to local variable nonSink2 |
-| GlobalDataFlow.cs:124:9:124:23 | call to method Check | GlobalDataFlow.cs:124:9:124:23 | call to method Check |
-| GlobalDataFlow.cs:124:15:124:22 | access to local variable nonSink2 | GlobalDataFlow.cs:124:15:124:22 | access to local variable nonSink2 |
-| GlobalDataFlow.cs:125:14:125:21 | Boolean nonSink3 | GlobalDataFlow.cs:125:14:125:21 | Boolean nonSink3 |
-| GlobalDataFlow.cs:126:9:126:45 | call to method TryParse | GlobalDataFlow.cs:126:9:126:45 | call to method TryParse |
-| GlobalDataFlow.cs:126:23:126:30 | access to local variable nonSink0 | GlobalDataFlow.cs:126:23:126:30 | access to local variable nonSink0 |
-| GlobalDataFlow.cs:126:23:126:30 | access to local variable nonSink0 | GlobalDataFlow.cs:135:28:135:35 | access to local variable nonSink0 |
-| GlobalDataFlow.cs:126:23:126:30 | access to local variable nonSink0 | GlobalDataFlow.cs:135:28:135:35 | access to local variable nonSink0 |
-| GlobalDataFlow.cs:126:37:126:44 | SSA def(nonSink3) | GlobalDataFlow.cs:126:37:126:44 | SSA def(nonSink3) |
-| GlobalDataFlow.cs:126:37:126:44 | SSA def(nonSink3) | GlobalDataFlow.cs:127:15:127:22 | access to local variable nonSink3 |
-| GlobalDataFlow.cs:126:37:126:44 | SSA def(nonSink3) | GlobalDataFlow.cs:127:15:127:22 | access to local variable nonSink3 |
-| GlobalDataFlow.cs:127:9:127:23 | call to method Check | GlobalDataFlow.cs:127:9:127:23 | call to method Check |
-| GlobalDataFlow.cs:127:15:127:22 | access to local variable nonSink3 | GlobalDataFlow.cs:127:15:127:22 | access to local variable nonSink3 |
-| GlobalDataFlow.cs:130:30:130:64 | Func<String,String> return = ... | GlobalDataFlow.cs:130:30:130:64 | Func<String,String> return = ... |
-| GlobalDataFlow.cs:130:30:130:64 | SSA def(return) | GlobalDataFlow.cs:130:30:130:64 | SSA def(return) |
-| GlobalDataFlow.cs:130:30:130:64 | SSA def(return) | GlobalDataFlow.cs:131:21:131:27 | access to local variable return |
-| GlobalDataFlow.cs:130:30:130:64 | SSA def(return) | GlobalDataFlow.cs:131:21:131:27 | access to local variable return |
-| GlobalDataFlow.cs:130:30:130:64 | SSA def(return) | GlobalDataFlow.cs:135:20:135:26 | access to local variable return |
-| GlobalDataFlow.cs:130:30:130:64 | SSA def(return) | GlobalDataFlow.cs:135:20:135:26 | access to local variable return |
-| GlobalDataFlow.cs:130:40:130:40 | x | GlobalDataFlow.cs:130:40:130:40 | x |
-| GlobalDataFlow.cs:130:40:130:40 | x | GlobalDataFlow.cs:130:40:130:40 | x |
-| GlobalDataFlow.cs:130:40:130:40 | x | GlobalDataFlow.cs:130:63:130:63 | access to parameter x |
-| GlobalDataFlow.cs:130:40:130:40 | x | GlobalDataFlow.cs:130:63:130:63 | access to parameter x |
-| GlobalDataFlow.cs:130:40:130:40 | x | GlobalDataFlow.cs:130:63:130:63 | access to parameter x |
-| GlobalDataFlow.cs:130:40:130:40 | x | GlobalDataFlow.cs:130:63:130:63 | access to parameter x |
-| GlobalDataFlow.cs:130:40:130:64 | (...) => ... | GlobalDataFlow.cs:130:30:130:64 | SSA def(return) |
-| GlobalDataFlow.cs:130:40:130:64 | (...) => ... | GlobalDataFlow.cs:130:30:130:64 | SSA def(return) |
-| GlobalDataFlow.cs:130:40:130:64 | (...) => ... | GlobalDataFlow.cs:130:40:130:64 | (...) => ... |
-| GlobalDataFlow.cs:130:40:130:64 | (...) => ... | GlobalDataFlow.cs:131:21:131:27 | access to local variable return |
-| GlobalDataFlow.cs:130:40:130:64 | (...) => ... | GlobalDataFlow.cs:131:21:131:27 | access to local variable return |
-| GlobalDataFlow.cs:130:40:130:64 | (...) => ... | GlobalDataFlow.cs:135:20:135:26 | access to local variable return |
-| GlobalDataFlow.cs:130:40:130:64 | (...) => ... | GlobalDataFlow.cs:135:20:135:26 | access to local variable return |
-| GlobalDataFlow.cs:130:45:130:64 | call to method ApplyFunc | GlobalDataFlow.cs:130:45:130:64 | call to method ApplyFunc |
-| GlobalDataFlow.cs:130:45:130:64 | call to method ApplyFunc | GlobalDataFlow.cs:131:21:131:34 | delegate call |
-| GlobalDataFlow.cs:130:45:130:64 | call to method ApplyFunc | GlobalDataFlow.cs:131:21:131:34 | delegate call |
-| GlobalDataFlow.cs:130:45:130:64 | call to method ApplyFunc | GlobalDataFlow.cs:135:20:135:36 | delegate call |
-| GlobalDataFlow.cs:130:45:130:64 | call to method ApplyFunc | GlobalDataFlow.cs:135:20:135:36 | delegate call |
-| GlobalDataFlow.cs:130:55:130:60 | access to method Return | GlobalDataFlow.cs:130:55:130:60 | access to method Return |
-| GlobalDataFlow.cs:130:55:130:60 | delegate creation of type Func<String,String> | GlobalDataFlow.cs:130:55:130:60 | delegate creation of type Func<String,String> |
-| GlobalDataFlow.cs:130:55:130:60 | delegate creation of type Func<String,String> | GlobalDataFlow.cs:359:41:359:41 | f |
-| GlobalDataFlow.cs:130:55:130:60 | delegate creation of type Func<String,String> | GlobalDataFlow.cs:359:41:359:41 | f |
-| GlobalDataFlow.cs:130:63:130:63 | access to parameter x | GlobalDataFlow.cs:130:45:130:64 | call to method ApplyFunc |
-| GlobalDataFlow.cs:130:63:130:63 | access to parameter x | GlobalDataFlow.cs:130:45:130:64 | call to method ApplyFunc |
-| GlobalDataFlow.cs:130:63:130:63 | access to parameter x | GlobalDataFlow.cs:130:45:130:64 | call to method ApplyFunc |
-| GlobalDataFlow.cs:130:63:130:63 | access to parameter x | GlobalDataFlow.cs:130:45:130:64 | call to method ApplyFunc |
-| GlobalDataFlow.cs:130:63:130:63 | access to parameter x | GlobalDataFlow.cs:130:63:130:63 | access to parameter x |
-| GlobalDataFlow.cs:130:63:130:63 | access to parameter x | GlobalDataFlow.cs:359:46:359:46 | x |
-| GlobalDataFlow.cs:130:63:130:63 | access to parameter x | GlobalDataFlow.cs:359:46:359:46 | x |
-| GlobalDataFlow.cs:130:63:130:63 | access to parameter x | GlobalDataFlow.cs:359:46:359:46 | x |
-| GlobalDataFlow.cs:130:63:130:63 | access to parameter x | GlobalDataFlow.cs:359:46:359:46 | x |
-| GlobalDataFlow.cs:131:13:131:34 | SSA def(sink4) | GlobalDataFlow.cs:131:13:131:34 | SSA def(sink4) |
-| GlobalDataFlow.cs:131:13:131:34 | SSA def(sink4) | GlobalDataFlow.cs:132:15:132:19 | access to local variable sink4 |
-| GlobalDataFlow.cs:131:13:131:34 | SSA def(sink4) | GlobalDataFlow.cs:132:15:132:19 | access to local variable sink4 |
-| GlobalDataFlow.cs:131:13:131:34 | SSA def(sink4) | GlobalDataFlow.cs:139:39:139:43 | access to local variable sink4 |
-| GlobalDataFlow.cs:131:13:131:34 | SSA def(sink4) | GlobalDataFlow.cs:139:39:139:43 | access to local variable sink4 |
-| GlobalDataFlow.cs:131:13:131:34 | String sink4 = ... | GlobalDataFlow.cs:131:13:131:34 | String sink4 = ... |
-| GlobalDataFlow.cs:131:21:131:27 | access to local variable return | GlobalDataFlow.cs:131:21:131:27 | access to local variable return |
-| GlobalDataFlow.cs:131:21:131:27 | access to local variable return | GlobalDataFlow.cs:135:20:135:26 | access to local variable return |
-| GlobalDataFlow.cs:131:21:131:27 | access to local variable return | GlobalDataFlow.cs:135:20:135:26 | access to local variable return |
-| GlobalDataFlow.cs:131:21:131:34 | delegate call | GlobalDataFlow.cs:131:13:131:34 | SSA def(sink4) |
-| GlobalDataFlow.cs:131:21:131:34 | delegate call | GlobalDataFlow.cs:131:13:131:34 | SSA def(sink4) |
-| GlobalDataFlow.cs:131:21:131:34 | delegate call | GlobalDataFlow.cs:131:21:131:34 | delegate call |
-| GlobalDataFlow.cs:131:21:131:34 | delegate call | GlobalDataFlow.cs:132:15:132:19 | access to local variable sink4 |
-| GlobalDataFlow.cs:131:21:131:34 | delegate call | GlobalDataFlow.cs:132:15:132:19 | access to local variable sink4 |
-| GlobalDataFlow.cs:131:21:131:34 | delegate call | GlobalDataFlow.cs:139:39:139:43 | access to local variable sink4 |
-| GlobalDataFlow.cs:131:21:131:34 | delegate call | GlobalDataFlow.cs:139:39:139:43 | access to local variable sink4 |
-| GlobalDataFlow.cs:131:29:131:33 | access to local variable sink3 | GlobalDataFlow.cs:130:40:130:40 | x |
-| GlobalDataFlow.cs:131:29:131:33 | access to local variable sink3 | GlobalDataFlow.cs:130:40:130:40 | x |
-| GlobalDataFlow.cs:131:29:131:33 | access to local variable sink3 | GlobalDataFlow.cs:131:21:131:34 | delegate call |
-| GlobalDataFlow.cs:131:29:131:33 | access to local variable sink3 | GlobalDataFlow.cs:131:21:131:34 | delegate call |
-| GlobalDataFlow.cs:131:29:131:33 | access to local variable sink3 | GlobalDataFlow.cs:131:29:131:33 | access to local variable sink3 |
-| GlobalDataFlow.cs:132:9:132:20 | call to method Check | GlobalDataFlow.cs:132:9:132:20 | call to method Check |
-| GlobalDataFlow.cs:132:15:132:19 | access to local variable sink4 | GlobalDataFlow.cs:132:15:132:19 | access to local variable sink4 |
-| GlobalDataFlow.cs:132:15:132:19 | access to local variable sink4 | GlobalDataFlow.cs:139:39:139:43 | access to local variable sink4 |
-| GlobalDataFlow.cs:132:15:132:19 | access to local variable sink4 | GlobalDataFlow.cs:139:39:139:43 | access to local variable sink4 |
-| GlobalDataFlow.cs:135:9:135:36 | ... = ... | GlobalDataFlow.cs:135:9:135:36 | ... = ... |
-| GlobalDataFlow.cs:135:9:135:36 | SSA def(nonSink0) | GlobalDataFlow.cs:135:9:135:36 | SSA def(nonSink0) |
-| GlobalDataFlow.cs:135:9:135:36 | SSA def(nonSink0) | GlobalDataFlow.cs:136:15:136:22 | access to local variable nonSink0 |
-| GlobalDataFlow.cs:135:9:135:36 | SSA def(nonSink0) | GlobalDataFlow.cs:136:15:136:22 | access to local variable nonSink0 |
-| GlobalDataFlow.cs:135:20:135:26 | access to local variable return | GlobalDataFlow.cs:135:20:135:26 | access to local variable return |
-| GlobalDataFlow.cs:135:20:135:36 | delegate call | GlobalDataFlow.cs:135:9:135:36 | SSA def(nonSink0) |
-| GlobalDataFlow.cs:135:20:135:36 | delegate call | GlobalDataFlow.cs:135:9:135:36 | SSA def(nonSink0) |
-| GlobalDataFlow.cs:135:20:135:36 | delegate call | GlobalDataFlow.cs:135:20:135:36 | delegate call |
-| GlobalDataFlow.cs:135:20:135:36 | delegate call | GlobalDataFlow.cs:136:15:136:22 | access to local variable nonSink0 |
-| GlobalDataFlow.cs:135:20:135:36 | delegate call | GlobalDataFlow.cs:136:15:136:22 | access to local variable nonSink0 |
-| GlobalDataFlow.cs:135:28:135:35 | access to local variable nonSink0 | GlobalDataFlow.cs:130:40:130:40 | x |
-| GlobalDataFlow.cs:135:28:135:35 | access to local variable nonSink0 | GlobalDataFlow.cs:130:40:130:40 | x |
-| GlobalDataFlow.cs:135:28:135:35 | access to local variable nonSink0 | GlobalDataFlow.cs:135:20:135:36 | delegate call |
-| GlobalDataFlow.cs:135:28:135:35 | access to local variable nonSink0 | GlobalDataFlow.cs:135:20:135:36 | delegate call |
-| GlobalDataFlow.cs:135:28:135:35 | access to local variable nonSink0 | GlobalDataFlow.cs:135:28:135:35 | access to local variable nonSink0 |
-| GlobalDataFlow.cs:136:9:136:23 | call to method Check | GlobalDataFlow.cs:136:9:136:23 | call to method Check |
-| GlobalDataFlow.cs:136:15:136:22 | access to local variable nonSink0 | GlobalDataFlow.cs:136:15:136:22 | access to local variable nonSink0 |
-| GlobalDataFlow.cs:139:13:139:44 | SSA def(sink5) | GlobalDataFlow.cs:139:13:139:44 | SSA def(sink5) |
-| GlobalDataFlow.cs:139:13:139:44 | SSA def(sink5) | GlobalDataFlow.cs:140:15:140:19 | access to local variable sink5 |
-| GlobalDataFlow.cs:139:13:139:44 | SSA def(sink5) | GlobalDataFlow.cs:140:15:140:19 | access to local variable sink5 |
-| GlobalDataFlow.cs:139:13:139:44 | SSA def(sink5) | GlobalDataFlow.cs:145:39:145:43 | access to local variable sink5 |
-| GlobalDataFlow.cs:139:13:139:44 | SSA def(sink5) | GlobalDataFlow.cs:145:39:145:43 | access to local variable sink5 |
-| GlobalDataFlow.cs:139:13:139:44 | String sink5 = ... | GlobalDataFlow.cs:139:13:139:44 | String sink5 = ... |
-| GlobalDataFlow.cs:139:21:139:44 | call to method ApplyFunc | GlobalDataFlow.cs:139:13:139:44 | SSA def(sink5) |
-| GlobalDataFlow.cs:139:21:139:44 | call to method ApplyFunc | GlobalDataFlow.cs:139:13:139:44 | SSA def(sink5) |
-| GlobalDataFlow.cs:139:21:139:44 | call to method ApplyFunc | GlobalDataFlow.cs:139:21:139:44 | call to method ApplyFunc |
-| GlobalDataFlow.cs:139:21:139:44 | call to method ApplyFunc | GlobalDataFlow.cs:140:15:140:19 | access to local variable sink5 |
-| GlobalDataFlow.cs:139:21:139:44 | call to method ApplyFunc | GlobalDataFlow.cs:140:15:140:19 | access to local variable sink5 |
-| GlobalDataFlow.cs:139:21:139:44 | call to method ApplyFunc | GlobalDataFlow.cs:145:39:145:43 | access to local variable sink5 |
-| GlobalDataFlow.cs:139:21:139:44 | call to method ApplyFunc | GlobalDataFlow.cs:145:39:145:43 | access to local variable sink5 |
-| GlobalDataFlow.cs:139:31:139:36 | access to method Return | GlobalDataFlow.cs:139:31:139:36 | access to method Return |
-| GlobalDataFlow.cs:139:31:139:36 | delegate creation of type Func<String,String> | GlobalDataFlow.cs:139:31:139:36 | delegate creation of type Func<String,String> |
-| GlobalDataFlow.cs:139:31:139:36 | delegate creation of type Func<String,String> | GlobalDataFlow.cs:359:41:359:41 | f |
-| GlobalDataFlow.cs:139:31:139:36 | delegate creation of type Func<String,String> | GlobalDataFlow.cs:359:41:359:41 | f |
-| GlobalDataFlow.cs:139:39:139:43 | access to local variable sink4 | GlobalDataFlow.cs:139:21:139:44 | call to method ApplyFunc |
-| GlobalDataFlow.cs:139:39:139:43 | access to local variable sink4 | GlobalDataFlow.cs:139:21:139:44 | call to method ApplyFunc |
-| GlobalDataFlow.cs:139:39:139:43 | access to local variable sink4 | GlobalDataFlow.cs:139:39:139:43 | access to local variable sink4 |
-| GlobalDataFlow.cs:139:39:139:43 | access to local variable sink4 | GlobalDataFlow.cs:359:46:359:46 | x |
-| GlobalDataFlow.cs:139:39:139:43 | access to local variable sink4 | GlobalDataFlow.cs:359:46:359:46 | x |
-| GlobalDataFlow.cs:140:9:140:20 | call to method Check | GlobalDataFlow.cs:140:9:140:20 | call to method Check |
-| GlobalDataFlow.cs:140:15:140:19 | access to local variable sink5 | GlobalDataFlow.cs:140:15:140:19 | access to local variable sink5 |
-| GlobalDataFlow.cs:140:15:140:19 | access to local variable sink5 | GlobalDataFlow.cs:145:39:145:43 | access to local variable sink5 |
-| GlobalDataFlow.cs:140:15:140:19 | access to local variable sink5 | GlobalDataFlow.cs:145:39:145:43 | access to local variable sink5 |
-| GlobalDataFlow.cs:143:9:143:40 | ... = ... | GlobalDataFlow.cs:143:9:143:40 | ... = ... |
-| GlobalDataFlow.cs:143:9:143:40 | SSA def(nonSink0) | GlobalDataFlow.cs:143:9:143:40 | SSA def(nonSink0) |
-| GlobalDataFlow.cs:143:9:143:40 | SSA def(nonSink0) | GlobalDataFlow.cs:144:15:144:22 | access to local variable nonSink0 |
-| GlobalDataFlow.cs:143:9:143:40 | SSA def(nonSink0) | GlobalDataFlow.cs:144:15:144:22 | access to local variable nonSink0 |
-| GlobalDataFlow.cs:143:20:143:40 | call to method ApplyFunc | GlobalDataFlow.cs:143:9:143:40 | SSA def(nonSink0) |
-| GlobalDataFlow.cs:143:20:143:40 | call to method ApplyFunc | GlobalDataFlow.cs:143:9:143:40 | SSA def(nonSink0) |
-| GlobalDataFlow.cs:143:20:143:40 | call to method ApplyFunc | GlobalDataFlow.cs:143:20:143:40 | call to method ApplyFunc |
-| GlobalDataFlow.cs:143:20:143:40 | call to method ApplyFunc | GlobalDataFlow.cs:144:15:144:22 | access to local variable nonSink0 |
-| GlobalDataFlow.cs:143:20:143:40 | call to method ApplyFunc | GlobalDataFlow.cs:144:15:144:22 | access to local variable nonSink0 |
-| GlobalDataFlow.cs:143:30:143:35 | access to method Return | GlobalDataFlow.cs:143:30:143:35 | access to method Return |
-| GlobalDataFlow.cs:143:30:143:35 | delegate creation of type Func<String,String> | GlobalDataFlow.cs:143:30:143:35 | delegate creation of type Func<String,String> |
-| GlobalDataFlow.cs:143:30:143:35 | delegate creation of type Func<String,String> | GlobalDataFlow.cs:359:41:359:41 | f |
-| GlobalDataFlow.cs:143:30:143:35 | delegate creation of type Func<String,String> | GlobalDataFlow.cs:359:41:359:41 | f |
-| GlobalDataFlow.cs:143:38:143:39 | "" | GlobalDataFlow.cs:143:20:143:40 | call to method ApplyFunc |
-| GlobalDataFlow.cs:143:38:143:39 | "" | GlobalDataFlow.cs:143:20:143:40 | call to method ApplyFunc |
-| GlobalDataFlow.cs:143:38:143:39 | "" | GlobalDataFlow.cs:143:38:143:39 | "" |
-| GlobalDataFlow.cs:143:38:143:39 | "" | GlobalDataFlow.cs:359:46:359:46 | x |
-| GlobalDataFlow.cs:143:38:143:39 | "" | GlobalDataFlow.cs:359:46:359:46 | x |
-| GlobalDataFlow.cs:144:9:144:23 | call to method Check | GlobalDataFlow.cs:144:9:144:23 | call to method Check |
-| GlobalDataFlow.cs:144:15:144:22 | access to local variable nonSink0 | GlobalDataFlow.cs:144:15:144:22 | access to local variable nonSink0 |
-| GlobalDataFlow.cs:145:9:145:44 | ... = ... | GlobalDataFlow.cs:145:9:145:44 | ... = ... |
-| GlobalDataFlow.cs:145:9:145:44 | SSA def(nonSink0) | GlobalDataFlow.cs:145:9:145:44 | SSA def(nonSink0) |
-| GlobalDataFlow.cs:145:9:145:44 | SSA def(nonSink0) | GlobalDataFlow.cs:146:15:146:22 | access to local variable nonSink0 |
-| GlobalDataFlow.cs:145:9:145:44 | SSA def(nonSink0) | GlobalDataFlow.cs:146:15:146:22 | access to local variable nonSink0 |
-| GlobalDataFlow.cs:145:9:145:44 | SSA def(nonSink0) | GlobalDataFlow.cs:159:35:159:42 | access to local variable nonSink0 |
-| GlobalDataFlow.cs:145:9:145:44 | SSA def(nonSink0) | GlobalDataFlow.cs:159:35:159:42 | access to local variable nonSink0 |
-| GlobalDataFlow.cs:145:20:145:44 | call to method ApplyFunc | GlobalDataFlow.cs:145:9:145:44 | SSA def(nonSink0) |
-| GlobalDataFlow.cs:145:20:145:44 | call to method ApplyFunc | GlobalDataFlow.cs:145:9:145:44 | SSA def(nonSink0) |
-| GlobalDataFlow.cs:145:20:145:44 | call to method ApplyFunc | GlobalDataFlow.cs:145:20:145:44 | call to method ApplyFunc |
-| GlobalDataFlow.cs:145:20:145:44 | call to method ApplyFunc | GlobalDataFlow.cs:146:15:146:22 | access to local variable nonSink0 |
-| GlobalDataFlow.cs:145:20:145:44 | call to method ApplyFunc | GlobalDataFlow.cs:146:15:146:22 | access to local variable nonSink0 |
-| GlobalDataFlow.cs:145:20:145:44 | call to method ApplyFunc | GlobalDataFlow.cs:159:35:159:42 | access to local variable nonSink0 |
-| GlobalDataFlow.cs:145:20:145:44 | call to method ApplyFunc | GlobalDataFlow.cs:159:35:159:42 | access to local variable nonSink0 |
-| GlobalDataFlow.cs:145:30:145:36 | (...) => ... | GlobalDataFlow.cs:145:30:145:36 | (...) => ... |
-| GlobalDataFlow.cs:145:30:145:36 | (...) => ... | GlobalDataFlow.cs:359:41:359:41 | f |
-| GlobalDataFlow.cs:145:30:145:36 | (...) => ... | GlobalDataFlow.cs:359:41:359:41 | f |
-| GlobalDataFlow.cs:145:35:145:36 | "" | GlobalDataFlow.cs:145:35:145:36 | "" |
-| GlobalDataFlow.cs:145:35:145:36 | "" | GlobalDataFlow.cs:361:16:361:19 | delegate call |
-| GlobalDataFlow.cs:145:35:145:36 | "" | GlobalDataFlow.cs:361:16:361:19 | delegate call |
-| GlobalDataFlow.cs:145:39:145:43 | access to local variable sink5 | GlobalDataFlow.cs:145:39:145:43 | access to local variable sink5 |
-| GlobalDataFlow.cs:145:39:145:43 | access to local variable sink5 | GlobalDataFlow.cs:359:46:359:46 | x |
-| GlobalDataFlow.cs:145:39:145:43 | access to local variable sink5 | GlobalDataFlow.cs:359:46:359:46 | x |
-| GlobalDataFlow.cs:146:9:146:23 | call to method Check | GlobalDataFlow.cs:146:9:146:23 | call to method Check |
-| GlobalDataFlow.cs:146:15:146:22 | access to local variable nonSink0 | GlobalDataFlow.cs:146:15:146:22 | access to local variable nonSink0 |
-| GlobalDataFlow.cs:146:15:146:22 | access to local variable nonSink0 | GlobalDataFlow.cs:159:35:159:42 | access to local variable nonSink0 |
-| GlobalDataFlow.cs:146:15:146:22 | access to local variable nonSink0 | GlobalDataFlow.cs:159:35:159:42 | access to local variable nonSink0 |
-| GlobalDataFlow.cs:149:13:149:25 | SSA def(sink6) | GlobalDataFlow.cs:149:13:149:25 | SSA def(sink6) |
-| GlobalDataFlow.cs:149:13:149:25 | SSA def(sink6) | GlobalDataFlow.cs:150:15:150:19 | access to local variable sink6 |
-| GlobalDataFlow.cs:149:13:149:25 | SSA def(sink6) | GlobalDataFlow.cs:150:15:150:19 | access to local variable sink6 |
-| GlobalDataFlow.cs:149:13:149:25 | String sink6 = ... | GlobalDataFlow.cs:149:13:149:25 | String sink6 = ... |
-| GlobalDataFlow.cs:149:21:149:25 | call to method Out | GlobalDataFlow.cs:149:13:149:25 | SSA def(sink6) |
-| GlobalDataFlow.cs:149:21:149:25 | call to method Out | GlobalDataFlow.cs:149:13:149:25 | SSA def(sink6) |
-| GlobalDataFlow.cs:149:21:149:25 | call to method Out | GlobalDataFlow.cs:149:21:149:25 | call to method Out |
-| GlobalDataFlow.cs:149:21:149:25 | call to method Out | GlobalDataFlow.cs:150:15:150:19 | access to local variable sink6 |
-| GlobalDataFlow.cs:149:21:149:25 | call to method Out | GlobalDataFlow.cs:150:15:150:19 | access to local variable sink6 |
-| GlobalDataFlow.cs:149:21:149:25 | this access | GlobalDataFlow.cs:149:21:149:25 | this access |
-| GlobalDataFlow.cs:149:21:149:25 | this access | GlobalDataFlow.cs:152:9:152:25 | this access |
-| GlobalDataFlow.cs:149:21:149:25 | this access | GlobalDataFlow.cs:152:9:152:25 | this access |
-| GlobalDataFlow.cs:149:21:149:25 | this access | GlobalDataFlow.cs:155:9:155:25 | this access |
-| GlobalDataFlow.cs:149:21:149:25 | this access | GlobalDataFlow.cs:155:9:155:25 | this access |
-| GlobalDataFlow.cs:149:21:149:25 | this access | GlobalDataFlow.cs:157:22:157:31 | this access |
-| GlobalDataFlow.cs:149:21:149:25 | this access | GlobalDataFlow.cs:157:22:157:31 | this access |
-| GlobalDataFlow.cs:149:21:149:25 | this access | GlobalDataFlow.cs:163:20:163:27 | this access |
-| GlobalDataFlow.cs:149:21:149:25 | this access | GlobalDataFlow.cs:163:20:163:27 | this access |
-| GlobalDataFlow.cs:149:21:149:25 | this access | GlobalDataFlow.cs:165:9:165:31 | this access |
-| GlobalDataFlow.cs:149:21:149:25 | this access | GlobalDataFlow.cs:165:9:165:31 | this access |
-| GlobalDataFlow.cs:149:21:149:25 | this access | GlobalDataFlow.cs:167:9:167:31 | this access |
-| GlobalDataFlow.cs:149:21:149:25 | this access | GlobalDataFlow.cs:167:9:167:31 | this access |
-| GlobalDataFlow.cs:149:21:149:25 | this access | GlobalDataFlow.cs:169:20:169:32 | this access |
-| GlobalDataFlow.cs:149:21:149:25 | this access | GlobalDataFlow.cs:169:20:169:32 | this access |
-| GlobalDataFlow.cs:149:21:149:25 | this access | GlobalDataFlow.cs:185:39:185:41 | this access |
-| GlobalDataFlow.cs:149:21:149:25 | this access | GlobalDataFlow.cs:185:39:185:41 | this access |
-| GlobalDataFlow.cs:149:21:149:25 | this access | GlobalDataFlow.cs:189:37:189:42 | this access |
-| GlobalDataFlow.cs:149:21:149:25 | this access | GlobalDataFlow.cs:189:37:189:42 | this access |
-| GlobalDataFlow.cs:149:21:149:25 | this access | GlobalDataFlow.cs:193:22:193:32 | this access |
-| GlobalDataFlow.cs:149:21:149:25 | this access | GlobalDataFlow.cs:193:22:193:32 | this access |
-| GlobalDataFlow.cs:149:21:149:25 | this access | GlobalDataFlow.cs:197:20:197:33 | this access |
-| GlobalDataFlow.cs:149:21:149:25 | this access | GlobalDataFlow.cs:197:20:197:33 | this access |
-| GlobalDataFlow.cs:149:21:149:25 | this access | GlobalDataFlow.cs:311:12:311:14 | this |
-| GlobalDataFlow.cs:149:21:149:25 | this access | GlobalDataFlow.cs:311:12:311:14 | this |
-| GlobalDataFlow.cs:150:9:150:20 | call to method Check | GlobalDataFlow.cs:150:9:150:20 | call to method Check |
-| GlobalDataFlow.cs:150:15:150:19 | access to local variable sink6 | GlobalDataFlow.cs:150:15:150:19 | access to local variable sink6 |
-| GlobalDataFlow.cs:151:16:151:20 | String sink7 | GlobalDataFlow.cs:151:16:151:20 | String sink7 |
-| GlobalDataFlow.cs:152:9:152:25 | call to method OutOut | GlobalDataFlow.cs:152:9:152:25 | call to method OutOut |
-| GlobalDataFlow.cs:152:9:152:25 | this access | GlobalDataFlow.cs:152:9:152:25 | this access |
-| GlobalDataFlow.cs:152:9:152:25 | this access | GlobalDataFlow.cs:155:9:155:25 | this access |
-| GlobalDataFlow.cs:152:9:152:25 | this access | GlobalDataFlow.cs:155:9:155:25 | this access |
-| GlobalDataFlow.cs:152:9:152:25 | this access | GlobalDataFlow.cs:157:22:157:31 | this access |
-| GlobalDataFlow.cs:152:9:152:25 | this access | GlobalDataFlow.cs:157:22:157:31 | this access |
-| GlobalDataFlow.cs:152:9:152:25 | this access | GlobalDataFlow.cs:163:20:163:27 | this access |
-| GlobalDataFlow.cs:152:9:152:25 | this access | GlobalDataFlow.cs:163:20:163:27 | this access |
-| GlobalDataFlow.cs:152:9:152:25 | this access | GlobalDataFlow.cs:165:9:165:31 | this access |
-| GlobalDataFlow.cs:152:9:152:25 | this access | GlobalDataFlow.cs:165:9:165:31 | this access |
-| GlobalDataFlow.cs:152:9:152:25 | this access | GlobalDataFlow.cs:167:9:167:31 | this access |
-| GlobalDataFlow.cs:152:9:152:25 | this access | GlobalDataFlow.cs:167:9:167:31 | this access |
-| GlobalDataFlow.cs:152:9:152:25 | this access | GlobalDataFlow.cs:169:20:169:32 | this access |
-| GlobalDataFlow.cs:152:9:152:25 | this access | GlobalDataFlow.cs:169:20:169:32 | this access |
-| GlobalDataFlow.cs:152:9:152:25 | this access | GlobalDataFlow.cs:185:39:185:41 | this access |
-| GlobalDataFlow.cs:152:9:152:25 | this access | GlobalDataFlow.cs:185:39:185:41 | this access |
-| GlobalDataFlow.cs:152:9:152:25 | this access | GlobalDataFlow.cs:189:37:189:42 | this access |
-| GlobalDataFlow.cs:152:9:152:25 | this access | GlobalDataFlow.cs:189:37:189:42 | this access |
-| GlobalDataFlow.cs:152:9:152:25 | this access | GlobalDataFlow.cs:193:22:193:32 | this access |
-| GlobalDataFlow.cs:152:9:152:25 | this access | GlobalDataFlow.cs:193:22:193:32 | this access |
-| GlobalDataFlow.cs:152:9:152:25 | this access | GlobalDataFlow.cs:197:20:197:33 | this access |
-| GlobalDataFlow.cs:152:9:152:25 | this access | GlobalDataFlow.cs:197:20:197:33 | this access |
-| GlobalDataFlow.cs:152:9:152:25 | this access | GlobalDataFlow.cs:316:10:316:15 | this |
-| GlobalDataFlow.cs:152:9:152:25 | this access | GlobalDataFlow.cs:316:10:316:15 | this |
-| GlobalDataFlow.cs:152:20:152:24 | SSA def(sink7) | GlobalDataFlow.cs:152:20:152:24 | SSA def(sink7) |
-| GlobalDataFlow.cs:152:20:152:24 | SSA def(sink7) | GlobalDataFlow.cs:153:15:153:19 | access to local variable sink7 |
-| GlobalDataFlow.cs:152:20:152:24 | SSA def(sink7) | GlobalDataFlow.cs:153:15:153:19 | access to local variable sink7 |
-| GlobalDataFlow.cs:153:9:153:20 | call to method Check | GlobalDataFlow.cs:153:9:153:20 | call to method Check |
-| GlobalDataFlow.cs:153:15:153:19 | access to local variable sink7 | GlobalDataFlow.cs:153:15:153:19 | access to local variable sink7 |
-| GlobalDataFlow.cs:154:13:154:22 | SSA def(sink8) | GlobalDataFlow.cs:154:13:154:22 | SSA def(sink8) |
-| GlobalDataFlow.cs:154:13:154:22 | SSA def(sink8) | GlobalDataFlow.cs:155:20:155:24 | access to local variable sink8 |
-| GlobalDataFlow.cs:154:13:154:22 | SSA def(sink8) | GlobalDataFlow.cs:155:20:155:24 | access to local variable sink8 |
-| GlobalDataFlow.cs:154:13:154:22 | String sink8 = ... | GlobalDataFlow.cs:154:13:154:22 | String sink8 = ... |
-| GlobalDataFlow.cs:154:21:154:22 | "" | GlobalDataFlow.cs:154:13:154:22 | SSA def(sink8) |
-| GlobalDataFlow.cs:154:21:154:22 | "" | GlobalDataFlow.cs:154:13:154:22 | SSA def(sink8) |
-| GlobalDataFlow.cs:154:21:154:22 | "" | GlobalDataFlow.cs:154:21:154:22 | "" |
-| GlobalDataFlow.cs:154:21:154:22 | "" | GlobalDataFlow.cs:155:20:155:24 | access to local variable sink8 |
-| GlobalDataFlow.cs:154:21:154:22 | "" | GlobalDataFlow.cs:155:20:155:24 | access to local variable sink8 |
-| GlobalDataFlow.cs:155:9:155:25 | call to method OutRef | GlobalDataFlow.cs:155:9:155:25 | call to method OutRef |
-| GlobalDataFlow.cs:155:9:155:25 | this access | GlobalDataFlow.cs:155:9:155:25 | this access |
-| GlobalDataFlow.cs:155:9:155:25 | this access | GlobalDataFlow.cs:157:22:157:31 | this access |
-| GlobalDataFlow.cs:155:9:155:25 | this access | GlobalDataFlow.cs:157:22:157:31 | this access |
-| GlobalDataFlow.cs:155:9:155:25 | this access | GlobalDataFlow.cs:163:20:163:27 | this access |
-| GlobalDataFlow.cs:155:9:155:25 | this access | GlobalDataFlow.cs:163:20:163:27 | this access |
-| GlobalDataFlow.cs:155:9:155:25 | this access | GlobalDataFlow.cs:165:9:165:31 | this access |
-| GlobalDataFlow.cs:155:9:155:25 | this access | GlobalDataFlow.cs:165:9:165:31 | this access |
-| GlobalDataFlow.cs:155:9:155:25 | this access | GlobalDataFlow.cs:167:9:167:31 | this access |
-| GlobalDataFlow.cs:155:9:155:25 | this access | GlobalDataFlow.cs:167:9:167:31 | this access |
-| GlobalDataFlow.cs:155:9:155:25 | this access | GlobalDataFlow.cs:169:20:169:32 | this access |
-| GlobalDataFlow.cs:155:9:155:25 | this access | GlobalDataFlow.cs:169:20:169:32 | this access |
-| GlobalDataFlow.cs:155:9:155:25 | this access | GlobalDataFlow.cs:185:39:185:41 | this access |
-| GlobalDataFlow.cs:155:9:155:25 | this access | GlobalDataFlow.cs:185:39:185:41 | this access |
-| GlobalDataFlow.cs:155:9:155:25 | this access | GlobalDataFlow.cs:189:37:189:42 | this access |
-| GlobalDataFlow.cs:155:9:155:25 | this access | GlobalDataFlow.cs:189:37:189:42 | this access |
-| GlobalDataFlow.cs:155:9:155:25 | this access | GlobalDataFlow.cs:193:22:193:32 | this access |
-| GlobalDataFlow.cs:155:9:155:25 | this access | GlobalDataFlow.cs:193:22:193:32 | this access |
-| GlobalDataFlow.cs:155:9:155:25 | this access | GlobalDataFlow.cs:197:20:197:33 | this access |
-| GlobalDataFlow.cs:155:9:155:25 | this access | GlobalDataFlow.cs:197:20:197:33 | this access |
-| GlobalDataFlow.cs:155:9:155:25 | this access | GlobalDataFlow.cs:321:10:321:15 | this |
-| GlobalDataFlow.cs:155:9:155:25 | this access | GlobalDataFlow.cs:321:10:321:15 | this |
-| GlobalDataFlow.cs:155:20:155:24 | SSA def(sink8) | GlobalDataFlow.cs:155:20:155:24 | SSA def(sink8) |
-| GlobalDataFlow.cs:155:20:155:24 | SSA def(sink8) | GlobalDataFlow.cs:156:15:156:19 | access to local variable sink8 |
-| GlobalDataFlow.cs:155:20:155:24 | SSA def(sink8) | GlobalDataFlow.cs:156:15:156:19 | access to local variable sink8 |
-| GlobalDataFlow.cs:155:20:155:24 | access to local variable sink8 | GlobalDataFlow.cs:155:20:155:24 | access to local variable sink8 |
-| GlobalDataFlow.cs:156:9:156:20 | call to method Check | GlobalDataFlow.cs:156:9:156:20 | call to method Check |
-| GlobalDataFlow.cs:156:15:156:19 | access to local variable sink8 | GlobalDataFlow.cs:156:15:156:19 | access to local variable sink8 |
-| GlobalDataFlow.cs:157:13:157:31 | IEnumerable<String> sink12 = ... | GlobalDataFlow.cs:157:13:157:31 | IEnumerable<String> sink12 = ... |
-| GlobalDataFlow.cs:157:13:157:31 | SSA def(sink12) | GlobalDataFlow.cs:157:13:157:31 | SSA def(sink12) |
-| GlobalDataFlow.cs:157:13:157:31 | SSA def(sink12) | GlobalDataFlow.cs:158:15:158:20 | access to local variable sink12 |
-| GlobalDataFlow.cs:157:13:157:31 | SSA def(sink12) | GlobalDataFlow.cs:158:15:158:20 | access to local variable sink12 |
-| GlobalDataFlow.cs:157:22:157:31 | call to method OutYield | GlobalDataFlow.cs:157:13:157:31 | SSA def(sink12) |
-| GlobalDataFlow.cs:157:22:157:31 | call to method OutYield | GlobalDataFlow.cs:157:13:157:31 | SSA def(sink12) |
-| GlobalDataFlow.cs:157:22:157:31 | call to method OutYield | GlobalDataFlow.cs:157:22:157:31 | call to method OutYield |
-| GlobalDataFlow.cs:157:22:157:31 | call to method OutYield | GlobalDataFlow.cs:158:15:158:20 | access to local variable sink12 |
-| GlobalDataFlow.cs:157:22:157:31 | call to method OutYield | GlobalDataFlow.cs:158:15:158:20 | access to local variable sink12 |
-| GlobalDataFlow.cs:157:22:157:31 | this access | GlobalDataFlow.cs:157:22:157:31 | this access |
-| GlobalDataFlow.cs:157:22:157:31 | this access | GlobalDataFlow.cs:163:20:163:27 | this access |
-| GlobalDataFlow.cs:157:22:157:31 | this access | GlobalDataFlow.cs:163:20:163:27 | this access |
-| GlobalDataFlow.cs:157:22:157:31 | this access | GlobalDataFlow.cs:165:9:165:31 | this access |
-| GlobalDataFlow.cs:157:22:157:31 | this access | GlobalDataFlow.cs:165:9:165:31 | this access |
-| GlobalDataFlow.cs:157:22:157:31 | this access | GlobalDataFlow.cs:167:9:167:31 | this access |
-| GlobalDataFlow.cs:157:22:157:31 | this access | GlobalDataFlow.cs:167:9:167:31 | this access |
-| GlobalDataFlow.cs:157:22:157:31 | this access | GlobalDataFlow.cs:169:20:169:32 | this access |
-| GlobalDataFlow.cs:157:22:157:31 | this access | GlobalDataFlow.cs:169:20:169:32 | this access |
-| GlobalDataFlow.cs:157:22:157:31 | this access | GlobalDataFlow.cs:185:39:185:41 | this access |
-| GlobalDataFlow.cs:157:22:157:31 | this access | GlobalDataFlow.cs:185:39:185:41 | this access |
-| GlobalDataFlow.cs:157:22:157:31 | this access | GlobalDataFlow.cs:189:37:189:42 | this access |
-| GlobalDataFlow.cs:157:22:157:31 | this access | GlobalDataFlow.cs:189:37:189:42 | this access |
-| GlobalDataFlow.cs:157:22:157:31 | this access | GlobalDataFlow.cs:193:22:193:32 | this access |
-| GlobalDataFlow.cs:157:22:157:31 | this access | GlobalDataFlow.cs:193:22:193:32 | this access |
-| GlobalDataFlow.cs:157:22:157:31 | this access | GlobalDataFlow.cs:197:20:197:33 | this access |
-| GlobalDataFlow.cs:157:22:157:31 | this access | GlobalDataFlow.cs:197:20:197:33 | this access |
-| GlobalDataFlow.cs:157:22:157:31 | this access | GlobalDataFlow.cs:326:25:326:32 | this |
-| GlobalDataFlow.cs:157:22:157:31 | this access | GlobalDataFlow.cs:326:25:326:32 | this |
-| GlobalDataFlow.cs:158:9:158:21 | call to method Check | GlobalDataFlow.cs:158:9:158:21 | call to method Check |
-| GlobalDataFlow.cs:158:15:158:20 | access to local variable sink12 | GlobalDataFlow.cs:158:15:158:20 | access to local variable sink12 |
-| GlobalDataFlow.cs:159:13:159:43 | SSA def(sink23) | GlobalDataFlow.cs:159:13:159:43 | SSA def(sink23) |
-| GlobalDataFlow.cs:159:13:159:43 | SSA def(sink23) | GlobalDataFlow.cs:160:15:160:20 | access to local variable sink23 |
-| GlobalDataFlow.cs:159:13:159:43 | SSA def(sink23) | GlobalDataFlow.cs:160:15:160:20 | access to local variable sink23 |
-| GlobalDataFlow.cs:159:13:159:43 | String sink23 = ... | GlobalDataFlow.cs:159:13:159:43 | String sink23 = ... |
-| GlobalDataFlow.cs:159:22:159:43 | call to method TaintedParam | GlobalDataFlow.cs:159:13:159:43 | SSA def(sink23) |
-| GlobalDataFlow.cs:159:22:159:43 | call to method TaintedParam | GlobalDataFlow.cs:159:13:159:43 | SSA def(sink23) |
-| GlobalDataFlow.cs:159:22:159:43 | call to method TaintedParam | GlobalDataFlow.cs:159:22:159:43 | call to method TaintedParam |
-| GlobalDataFlow.cs:159:22:159:43 | call to method TaintedParam | GlobalDataFlow.cs:160:15:160:20 | access to local variable sink23 |
-| GlobalDataFlow.cs:159:22:159:43 | call to method TaintedParam | GlobalDataFlow.cs:160:15:160:20 | access to local variable sink23 |
-| GlobalDataFlow.cs:159:35:159:42 | access to local variable nonSink0 | GlobalDataFlow.cs:159:22:159:43 | call to method TaintedParam |
-| GlobalDataFlow.cs:159:35:159:42 | access to local variable nonSink0 | GlobalDataFlow.cs:159:22:159:43 | call to method TaintedParam |
-| GlobalDataFlow.cs:159:35:159:42 | access to local variable nonSink0 | GlobalDataFlow.cs:159:35:159:42 | access to local variable nonSink0 |
-| GlobalDataFlow.cs:159:35:159:42 | access to local variable nonSink0 | GlobalDataFlow.cs:373:39:373:45 | tainted |
-| GlobalDataFlow.cs:159:35:159:42 | access to local variable nonSink0 | GlobalDataFlow.cs:373:39:373:45 | tainted |
-| GlobalDataFlow.cs:160:9:160:21 | call to method Check | GlobalDataFlow.cs:160:9:160:21 | call to method Check |
-| GlobalDataFlow.cs:160:15:160:20 | access to local variable sink23 | GlobalDataFlow.cs:160:15:160:20 | access to local variable sink23 |
-| GlobalDataFlow.cs:163:9:163:27 | ... = ... | GlobalDataFlow.cs:163:9:163:27 | ... = ... |
-| GlobalDataFlow.cs:163:9:163:27 | SSA def(nonSink0) | GlobalDataFlow.cs:163:9:163:27 | SSA def(nonSink0) |
-| GlobalDataFlow.cs:163:9:163:27 | SSA def(nonSink0) | GlobalDataFlow.cs:164:15:164:22 | access to local variable nonSink0 |
-| GlobalDataFlow.cs:163:9:163:27 | SSA def(nonSink0) | GlobalDataFlow.cs:164:15:164:22 | access to local variable nonSink0 |
-| GlobalDataFlow.cs:163:20:163:27 | call to method NonOut | GlobalDataFlow.cs:163:9:163:27 | SSA def(nonSink0) |
-| GlobalDataFlow.cs:163:20:163:27 | call to method NonOut | GlobalDataFlow.cs:163:9:163:27 | SSA def(nonSink0) |
-| GlobalDataFlow.cs:163:20:163:27 | call to method NonOut | GlobalDataFlow.cs:163:20:163:27 | call to method NonOut |
-| GlobalDataFlow.cs:163:20:163:27 | call to method NonOut | GlobalDataFlow.cs:164:15:164:22 | access to local variable nonSink0 |
-| GlobalDataFlow.cs:163:20:163:27 | call to method NonOut | GlobalDataFlow.cs:164:15:164:22 | access to local variable nonSink0 |
-| GlobalDataFlow.cs:163:20:163:27 | this access | GlobalDataFlow.cs:163:20:163:27 | this access |
-| GlobalDataFlow.cs:163:20:163:27 | this access | GlobalDataFlow.cs:165:9:165:31 | this access |
-| GlobalDataFlow.cs:163:20:163:27 | this access | GlobalDataFlow.cs:165:9:165:31 | this access |
-| GlobalDataFlow.cs:163:20:163:27 | this access | GlobalDataFlow.cs:167:9:167:31 | this access |
-| GlobalDataFlow.cs:163:20:163:27 | this access | GlobalDataFlow.cs:167:9:167:31 | this access |
-| GlobalDataFlow.cs:163:20:163:27 | this access | GlobalDataFlow.cs:169:20:169:32 | this access |
-| GlobalDataFlow.cs:163:20:163:27 | this access | GlobalDataFlow.cs:169:20:169:32 | this access |
-| GlobalDataFlow.cs:163:20:163:27 | this access | GlobalDataFlow.cs:185:39:185:41 | this access |
-| GlobalDataFlow.cs:163:20:163:27 | this access | GlobalDataFlow.cs:185:39:185:41 | this access |
-| GlobalDataFlow.cs:163:20:163:27 | this access | GlobalDataFlow.cs:189:37:189:42 | this access |
-| GlobalDataFlow.cs:163:20:163:27 | this access | GlobalDataFlow.cs:189:37:189:42 | this access |
-| GlobalDataFlow.cs:163:20:163:27 | this access | GlobalDataFlow.cs:193:22:193:32 | this access |
-| GlobalDataFlow.cs:163:20:163:27 | this access | GlobalDataFlow.cs:193:22:193:32 | this access |
-| GlobalDataFlow.cs:163:20:163:27 | this access | GlobalDataFlow.cs:197:20:197:33 | this access |
-| GlobalDataFlow.cs:163:20:163:27 | this access | GlobalDataFlow.cs:197:20:197:33 | this access |
-| GlobalDataFlow.cs:163:20:163:27 | this access | GlobalDataFlow.cs:333:12:333:17 | this |
-| GlobalDataFlow.cs:163:20:163:27 | this access | GlobalDataFlow.cs:333:12:333:17 | this |
-| GlobalDataFlow.cs:164:9:164:23 | call to method Check | GlobalDataFlow.cs:164:9:164:23 | call to method Check |
-| GlobalDataFlow.cs:164:15:164:22 | access to local variable nonSink0 | GlobalDataFlow.cs:164:15:164:22 | access to local variable nonSink0 |
-| GlobalDataFlow.cs:165:9:165:31 | call to method NonOutOut | GlobalDataFlow.cs:165:9:165:31 | call to method NonOutOut |
-| GlobalDataFlow.cs:165:9:165:31 | this access | GlobalDataFlow.cs:165:9:165:31 | this access |
-| GlobalDataFlow.cs:165:9:165:31 | this access | GlobalDataFlow.cs:167:9:167:31 | this access |
-| GlobalDataFlow.cs:165:9:165:31 | this access | GlobalDataFlow.cs:167:9:167:31 | this access |
-| GlobalDataFlow.cs:165:9:165:31 | this access | GlobalDataFlow.cs:169:20:169:32 | this access |
-| GlobalDataFlow.cs:165:9:165:31 | this access | GlobalDataFlow.cs:169:20:169:32 | this access |
-| GlobalDataFlow.cs:165:9:165:31 | this access | GlobalDataFlow.cs:185:39:185:41 | this access |
-| GlobalDataFlow.cs:165:9:165:31 | this access | GlobalDataFlow.cs:185:39:185:41 | this access |
-| GlobalDataFlow.cs:165:9:165:31 | this access | GlobalDataFlow.cs:189:37:189:42 | this access |
-| GlobalDataFlow.cs:165:9:165:31 | this access | GlobalDataFlow.cs:189:37:189:42 | this access |
-| GlobalDataFlow.cs:165:9:165:31 | this access | GlobalDataFlow.cs:193:22:193:32 | this access |
-| GlobalDataFlow.cs:165:9:165:31 | this access | GlobalDataFlow.cs:193:22:193:32 | this access |
-| GlobalDataFlow.cs:165:9:165:31 | this access | GlobalDataFlow.cs:197:20:197:33 | this access |
-| GlobalDataFlow.cs:165:9:165:31 | this access | GlobalDataFlow.cs:197:20:197:33 | this access |
-| GlobalDataFlow.cs:165:9:165:31 | this access | GlobalDataFlow.cs:338:10:338:18 | this |
-| GlobalDataFlow.cs:165:9:165:31 | this access | GlobalDataFlow.cs:338:10:338:18 | this |
-| GlobalDataFlow.cs:165:23:165:30 | SSA def(nonSink0) | GlobalDataFlow.cs:165:23:165:30 | SSA def(nonSink0) |
-| GlobalDataFlow.cs:165:23:165:30 | SSA def(nonSink0) | GlobalDataFlow.cs:166:15:166:22 | access to local variable nonSink0 |
-| GlobalDataFlow.cs:165:23:165:30 | SSA def(nonSink0) | GlobalDataFlow.cs:166:15:166:22 | access to local variable nonSink0 |
-| GlobalDataFlow.cs:165:23:165:30 | SSA def(nonSink0) | GlobalDataFlow.cs:167:23:167:30 | access to local variable nonSink0 |
-| GlobalDataFlow.cs:165:23:165:30 | SSA def(nonSink0) | GlobalDataFlow.cs:167:23:167:30 | access to local variable nonSink0 |
-| GlobalDataFlow.cs:166:9:166:23 | call to method Check | GlobalDataFlow.cs:166:9:166:23 | call to method Check |
-| GlobalDataFlow.cs:166:15:166:22 | access to local variable nonSink0 | GlobalDataFlow.cs:166:15:166:22 | access to local variable nonSink0 |
-| GlobalDataFlow.cs:166:15:166:22 | access to local variable nonSink0 | GlobalDataFlow.cs:167:23:167:30 | access to local variable nonSink0 |
-| GlobalDataFlow.cs:166:15:166:22 | access to local variable nonSink0 | GlobalDataFlow.cs:167:23:167:30 | access to local variable nonSink0 |
-| GlobalDataFlow.cs:167:9:167:31 | call to method NonOutRef | GlobalDataFlow.cs:167:9:167:31 | call to method NonOutRef |
-| GlobalDataFlow.cs:167:9:167:31 | this access | GlobalDataFlow.cs:167:9:167:31 | this access |
-| GlobalDataFlow.cs:167:9:167:31 | this access | GlobalDataFlow.cs:169:20:169:32 | this access |
-| GlobalDataFlow.cs:167:9:167:31 | this access | GlobalDataFlow.cs:169:20:169:32 | this access |
-| GlobalDataFlow.cs:167:9:167:31 | this access | GlobalDataFlow.cs:185:39:185:41 | this access |
-| GlobalDataFlow.cs:167:9:167:31 | this access | GlobalDataFlow.cs:185:39:185:41 | this access |
-| GlobalDataFlow.cs:167:9:167:31 | this access | GlobalDataFlow.cs:189:37:189:42 | this access |
-| GlobalDataFlow.cs:167:9:167:31 | this access | GlobalDataFlow.cs:189:37:189:42 | this access |
-| GlobalDataFlow.cs:167:9:167:31 | this access | GlobalDataFlow.cs:193:22:193:32 | this access |
-| GlobalDataFlow.cs:167:9:167:31 | this access | GlobalDataFlow.cs:193:22:193:32 | this access |
-| GlobalDataFlow.cs:167:9:167:31 | this access | GlobalDataFlow.cs:197:20:197:33 | this access |
-| GlobalDataFlow.cs:167:9:167:31 | this access | GlobalDataFlow.cs:197:20:197:33 | this access |
-| GlobalDataFlow.cs:167:9:167:31 | this access | GlobalDataFlow.cs:343:10:343:18 | this |
-| GlobalDataFlow.cs:167:9:167:31 | this access | GlobalDataFlow.cs:343:10:343:18 | this |
-| GlobalDataFlow.cs:167:23:167:30 | SSA def(nonSink0) | GlobalDataFlow.cs:167:23:167:30 | SSA def(nonSink0) |
-| GlobalDataFlow.cs:167:23:167:30 | SSA def(nonSink0) | GlobalDataFlow.cs:168:15:168:22 | access to local variable nonSink0 |
-| GlobalDataFlow.cs:167:23:167:30 | SSA def(nonSink0) | GlobalDataFlow.cs:168:15:168:22 | access to local variable nonSink0 |
-| GlobalDataFlow.cs:167:23:167:30 | access to local variable nonSink0 | GlobalDataFlow.cs:167:23:167:30 | access to local variable nonSink0 |
+| GlobalDataFlow.cs:122:9:122:69 | ... = ... | GlobalDataFlow.cs:122:9:122:69 | ... = ... |
+| GlobalDataFlow.cs:122:9:122:69 | SSA def(nonSink0) | GlobalDataFlow.cs:122:9:122:69 | SSA def(nonSink0) |
+| GlobalDataFlow.cs:122:9:122:69 | SSA def(nonSink0) | GlobalDataFlow.cs:123:15:123:22 | access to local variable nonSink0 |
+| GlobalDataFlow.cs:122:9:122:69 | SSA def(nonSink0) | GlobalDataFlow.cs:123:15:123:22 | access to local variable nonSink0 |
+| GlobalDataFlow.cs:122:20:122:25 | access to local variable sink14 | GlobalDataFlow.cs:122:20:122:25 | access to local variable sink14 |
+| GlobalDataFlow.cs:122:20:122:25 | access to local variable sink14 | GlobalDataFlow.cs:122:47:122:47 | s |
+| GlobalDataFlow.cs:122:20:122:25 | access to local variable sink14 | GlobalDataFlow.cs:122:47:122:47 | s |
+| GlobalDataFlow.cs:122:20:122:69 | call to method Aggregate | GlobalDataFlow.cs:122:9:122:69 | SSA def(nonSink0) |
+| GlobalDataFlow.cs:122:20:122:69 | call to method Aggregate | GlobalDataFlow.cs:122:9:122:69 | SSA def(nonSink0) |
+| GlobalDataFlow.cs:122:20:122:69 | call to method Aggregate | GlobalDataFlow.cs:122:20:122:69 | call to method Aggregate |
+| GlobalDataFlow.cs:122:20:122:69 | call to method Aggregate | GlobalDataFlow.cs:123:15:123:22 | access to local variable nonSink0 |
+| GlobalDataFlow.cs:122:20:122:69 | call to method Aggregate | GlobalDataFlow.cs:123:15:123:22 | access to local variable nonSink0 |
+| GlobalDataFlow.cs:122:37:122:38 | "" | GlobalDataFlow.cs:122:37:122:38 | "" |
+| GlobalDataFlow.cs:122:37:122:38 | "" | GlobalDataFlow.cs:122:42:122:44 | acc |
+| GlobalDataFlow.cs:122:37:122:38 | "" | GlobalDataFlow.cs:122:42:122:44 | acc |
+| GlobalDataFlow.cs:122:41:122:59 | (...) => ... | GlobalDataFlow.cs:122:41:122:59 | (...) => ... |
+| GlobalDataFlow.cs:122:41:122:59 | [output] (...) => ... | GlobalDataFlow.cs:122:41:122:59 | [output] (...) => ... |
+| GlobalDataFlow.cs:122:42:122:44 | acc | GlobalDataFlow.cs:122:42:122:44 | acc |
+| GlobalDataFlow.cs:122:42:122:44 | acc | GlobalDataFlow.cs:122:42:122:44 | acc |
+| GlobalDataFlow.cs:122:42:122:44 | acc | GlobalDataFlow.cs:122:53:122:55 | access to parameter acc |
+| GlobalDataFlow.cs:122:42:122:44 | acc | GlobalDataFlow.cs:122:53:122:55 | access to parameter acc |
+| GlobalDataFlow.cs:122:47:122:47 | s | GlobalDataFlow.cs:122:47:122:47 | s |
+| GlobalDataFlow.cs:122:47:122:47 | s | GlobalDataFlow.cs:122:47:122:47 | s |
+| GlobalDataFlow.cs:122:47:122:47 | s | GlobalDataFlow.cs:122:59:122:59 | access to parameter s |
+| GlobalDataFlow.cs:122:47:122:47 | s | GlobalDataFlow.cs:122:59:122:59 | access to parameter s |
+| GlobalDataFlow.cs:122:53:122:55 | access to parameter acc | GlobalDataFlow.cs:122:53:122:55 | access to parameter acc |
+| GlobalDataFlow.cs:122:53:122:59 | ... + ... | GlobalDataFlow.cs:122:41:122:59 | [output] (...) => ... |
+| GlobalDataFlow.cs:122:53:122:59 | ... + ... | GlobalDataFlow.cs:122:41:122:59 | [output] (...) => ... |
+| GlobalDataFlow.cs:122:53:122:59 | ... + ... | GlobalDataFlow.cs:122:53:122:59 | ... + ... |
+| GlobalDataFlow.cs:122:59:122:59 | access to parameter s | GlobalDataFlow.cs:122:59:122:59 | access to parameter s |
+| GlobalDataFlow.cs:122:62:122:68 | (...) => ... | GlobalDataFlow.cs:122:62:122:68 | (...) => ... |
+| GlobalDataFlow.cs:122:62:122:68 | [output] (...) => ... | GlobalDataFlow.cs:122:62:122:68 | [output] (...) => ... |
+| GlobalDataFlow.cs:122:67:122:68 | "" | GlobalDataFlow.cs:122:62:122:68 | [output] (...) => ... |
+| GlobalDataFlow.cs:122:67:122:68 | "" | GlobalDataFlow.cs:122:62:122:68 | [output] (...) => ... |
+| GlobalDataFlow.cs:122:67:122:68 | "" | GlobalDataFlow.cs:122:67:122:68 | "" |
+| GlobalDataFlow.cs:123:9:123:23 | call to method Check | GlobalDataFlow.cs:123:9:123:23 | call to method Check |
+| GlobalDataFlow.cs:123:15:123:22 | access to local variable nonSink0 | GlobalDataFlow.cs:123:15:123:22 | access to local variable nonSink0 |
+| GlobalDataFlow.cs:124:9:124:67 | ... = ... | GlobalDataFlow.cs:124:9:124:67 | ... = ... |
+| GlobalDataFlow.cs:124:9:124:67 | SSA def(nonSink0) | GlobalDataFlow.cs:124:9:124:67 | SSA def(nonSink0) |
+| GlobalDataFlow.cs:124:9:124:67 | SSA def(nonSink0) | GlobalDataFlow.cs:125:15:125:22 | access to local variable nonSink0 |
+| GlobalDataFlow.cs:124:9:124:67 | SSA def(nonSink0) | GlobalDataFlow.cs:125:15:125:22 | access to local variable nonSink0 |
+| GlobalDataFlow.cs:124:9:124:67 | SSA def(nonSink0) | GlobalDataFlow.cs:127:24:127:31 | access to local variable nonSink0 |
+| GlobalDataFlow.cs:124:9:124:67 | SSA def(nonSink0) | GlobalDataFlow.cs:127:24:127:31 | access to local variable nonSink0 |
+| GlobalDataFlow.cs:124:9:124:67 | SSA def(nonSink0) | GlobalDataFlow.cs:130:23:130:30 | access to local variable nonSink0 |
+| GlobalDataFlow.cs:124:9:124:67 | SSA def(nonSink0) | GlobalDataFlow.cs:130:23:130:30 | access to local variable nonSink0 |
+| GlobalDataFlow.cs:124:9:124:67 | SSA def(nonSink0) | GlobalDataFlow.cs:139:28:139:35 | access to local variable nonSink0 |
+| GlobalDataFlow.cs:124:9:124:67 | SSA def(nonSink0) | GlobalDataFlow.cs:139:28:139:35 | access to local variable nonSink0 |
+| GlobalDataFlow.cs:124:20:124:27 | access to local variable nonSink1 | GlobalDataFlow.cs:124:20:124:27 | access to local variable nonSink1 |
+| GlobalDataFlow.cs:124:20:124:27 | access to local variable nonSink1 | GlobalDataFlow.cs:124:52:124:52 | s |
+| GlobalDataFlow.cs:124:20:124:27 | access to local variable nonSink1 | GlobalDataFlow.cs:124:52:124:52 | s |
+| GlobalDataFlow.cs:124:20:124:67 | call to method Aggregate | GlobalDataFlow.cs:124:9:124:67 | SSA def(nonSink0) |
+| GlobalDataFlow.cs:124:20:124:67 | call to method Aggregate | GlobalDataFlow.cs:124:9:124:67 | SSA def(nonSink0) |
+| GlobalDataFlow.cs:124:20:124:67 | call to method Aggregate | GlobalDataFlow.cs:124:20:124:67 | call to method Aggregate |
+| GlobalDataFlow.cs:124:20:124:67 | call to method Aggregate | GlobalDataFlow.cs:125:15:125:22 | access to local variable nonSink0 |
+| GlobalDataFlow.cs:124:20:124:67 | call to method Aggregate | GlobalDataFlow.cs:125:15:125:22 | access to local variable nonSink0 |
+| GlobalDataFlow.cs:124:20:124:67 | call to method Aggregate | GlobalDataFlow.cs:127:24:127:31 | access to local variable nonSink0 |
+| GlobalDataFlow.cs:124:20:124:67 | call to method Aggregate | GlobalDataFlow.cs:127:24:127:31 | access to local variable nonSink0 |
+| GlobalDataFlow.cs:124:20:124:67 | call to method Aggregate | GlobalDataFlow.cs:130:23:130:30 | access to local variable nonSink0 |
+| GlobalDataFlow.cs:124:20:124:67 | call to method Aggregate | GlobalDataFlow.cs:130:23:130:30 | access to local variable nonSink0 |
+| GlobalDataFlow.cs:124:20:124:67 | call to method Aggregate | GlobalDataFlow.cs:139:28:139:35 | access to local variable nonSink0 |
+| GlobalDataFlow.cs:124:20:124:67 | call to method Aggregate | GlobalDataFlow.cs:139:28:139:35 | access to local variable nonSink0 |
+| GlobalDataFlow.cs:124:39:124:43 | access to local variable sink1 | GlobalDataFlow.cs:124:39:124:43 | access to local variable sink1 |
+| GlobalDataFlow.cs:124:46:124:58 | (...) => ... | GlobalDataFlow.cs:124:46:124:58 | (...) => ... |
+| GlobalDataFlow.cs:124:46:124:58 | [output] (...) => ... | GlobalDataFlow.cs:124:46:124:58 | [output] (...) => ... |
+| GlobalDataFlow.cs:124:46:124:58 | [output] (...) => ... | GlobalDataFlow.cs:124:61:124:61 | x |
+| GlobalDataFlow.cs:124:46:124:58 | [output] (...) => ... | GlobalDataFlow.cs:124:61:124:61 | x |
+| GlobalDataFlow.cs:124:52:124:52 | s | GlobalDataFlow.cs:124:52:124:52 | s |
+| GlobalDataFlow.cs:124:52:124:52 | s | GlobalDataFlow.cs:124:52:124:52 | s |
+| GlobalDataFlow.cs:124:52:124:52 | s | GlobalDataFlow.cs:124:58:124:58 | access to parameter s |
+| GlobalDataFlow.cs:124:52:124:52 | s | GlobalDataFlow.cs:124:58:124:58 | access to parameter s |
+| GlobalDataFlow.cs:124:58:124:58 | access to parameter s | GlobalDataFlow.cs:124:46:124:58 | [output] (...) => ... |
+| GlobalDataFlow.cs:124:58:124:58 | access to parameter s | GlobalDataFlow.cs:124:46:124:58 | [output] (...) => ... |
+| GlobalDataFlow.cs:124:58:124:58 | access to parameter s | GlobalDataFlow.cs:124:58:124:58 | access to parameter s |
+| GlobalDataFlow.cs:124:61:124:61 | x | GlobalDataFlow.cs:124:61:124:61 | x |
+| GlobalDataFlow.cs:124:61:124:61 | x | GlobalDataFlow.cs:124:61:124:61 | x |
+| GlobalDataFlow.cs:124:61:124:61 | x | GlobalDataFlow.cs:124:66:124:66 | access to parameter x |
+| GlobalDataFlow.cs:124:61:124:61 | x | GlobalDataFlow.cs:124:66:124:66 | access to parameter x |
+| GlobalDataFlow.cs:124:61:124:66 | (...) => ... | GlobalDataFlow.cs:124:61:124:66 | (...) => ... |
+| GlobalDataFlow.cs:124:61:124:66 | [output] (...) => ... | GlobalDataFlow.cs:124:61:124:66 | [output] (...) => ... |
+| GlobalDataFlow.cs:124:66:124:66 | access to parameter x | GlobalDataFlow.cs:124:61:124:66 | [output] (...) => ... |
+| GlobalDataFlow.cs:124:66:124:66 | access to parameter x | GlobalDataFlow.cs:124:61:124:66 | [output] (...) => ... |
+| GlobalDataFlow.cs:124:66:124:66 | access to parameter x | GlobalDataFlow.cs:124:66:124:66 | access to parameter x |
+| GlobalDataFlow.cs:125:9:125:23 | call to method Check | GlobalDataFlow.cs:125:9:125:23 | call to method Check |
+| GlobalDataFlow.cs:125:15:125:22 | access to local variable nonSink0 | GlobalDataFlow.cs:125:15:125:22 | access to local variable nonSink0 |
+| GlobalDataFlow.cs:125:15:125:22 | access to local variable nonSink0 | GlobalDataFlow.cs:127:24:127:31 | access to local variable nonSink0 |
+| GlobalDataFlow.cs:125:15:125:22 | access to local variable nonSink0 | GlobalDataFlow.cs:127:24:127:31 | access to local variable nonSink0 |
+| GlobalDataFlow.cs:125:15:125:22 | access to local variable nonSink0 | GlobalDataFlow.cs:130:23:130:30 | access to local variable nonSink0 |
+| GlobalDataFlow.cs:125:15:125:22 | access to local variable nonSink0 | GlobalDataFlow.cs:130:23:130:30 | access to local variable nonSink0 |
+| GlobalDataFlow.cs:125:15:125:22 | access to local variable nonSink0 | GlobalDataFlow.cs:139:28:139:35 | access to local variable nonSink0 |
+| GlobalDataFlow.cs:125:15:125:22 | access to local variable nonSink0 | GlobalDataFlow.cs:139:28:139:35 | access to local variable nonSink0 |
+| GlobalDataFlow.cs:126:13:126:20 | Int32 nonSink2 | GlobalDataFlow.cs:126:13:126:20 | Int32 nonSink2 |
+| GlobalDataFlow.cs:127:9:127:46 | call to method TryParse | GlobalDataFlow.cs:127:9:127:46 | call to method TryParse |
+| GlobalDataFlow.cs:127:24:127:31 | access to local variable nonSink0 | GlobalDataFlow.cs:127:24:127:31 | access to local variable nonSink0 |
+| GlobalDataFlow.cs:127:24:127:31 | access to local variable nonSink0 | GlobalDataFlow.cs:130:23:130:30 | access to local variable nonSink0 |
+| GlobalDataFlow.cs:127:24:127:31 | access to local variable nonSink0 | GlobalDataFlow.cs:130:23:130:30 | access to local variable nonSink0 |
+| GlobalDataFlow.cs:127:24:127:31 | access to local variable nonSink0 | GlobalDataFlow.cs:139:28:139:35 | access to local variable nonSink0 |
+| GlobalDataFlow.cs:127:24:127:31 | access to local variable nonSink0 | GlobalDataFlow.cs:139:28:139:35 | access to local variable nonSink0 |
+| GlobalDataFlow.cs:127:38:127:45 | SSA def(nonSink2) | GlobalDataFlow.cs:127:38:127:45 | SSA def(nonSink2) |
+| GlobalDataFlow.cs:127:38:127:45 | SSA def(nonSink2) | GlobalDataFlow.cs:128:15:128:22 | access to local variable nonSink2 |
+| GlobalDataFlow.cs:127:38:127:45 | SSA def(nonSink2) | GlobalDataFlow.cs:128:15:128:22 | access to local variable nonSink2 |
+| GlobalDataFlow.cs:128:9:128:23 | call to method Check | GlobalDataFlow.cs:128:9:128:23 | call to method Check |
+| GlobalDataFlow.cs:128:15:128:22 | access to local variable nonSink2 | GlobalDataFlow.cs:128:15:128:22 | access to local variable nonSink2 |
+| GlobalDataFlow.cs:129:14:129:21 | Boolean nonSink3 | GlobalDataFlow.cs:129:14:129:21 | Boolean nonSink3 |
+| GlobalDataFlow.cs:130:9:130:45 | call to method TryParse | GlobalDataFlow.cs:130:9:130:45 | call to method TryParse |
+| GlobalDataFlow.cs:130:23:130:30 | access to local variable nonSink0 | GlobalDataFlow.cs:130:23:130:30 | access to local variable nonSink0 |
+| GlobalDataFlow.cs:130:23:130:30 | access to local variable nonSink0 | GlobalDataFlow.cs:139:28:139:35 | access to local variable nonSink0 |
+| GlobalDataFlow.cs:130:23:130:30 | access to local variable nonSink0 | GlobalDataFlow.cs:139:28:139:35 | access to local variable nonSink0 |
+| GlobalDataFlow.cs:130:37:130:44 | SSA def(nonSink3) | GlobalDataFlow.cs:130:37:130:44 | SSA def(nonSink3) |
+| GlobalDataFlow.cs:130:37:130:44 | SSA def(nonSink3) | GlobalDataFlow.cs:131:15:131:22 | access to local variable nonSink3 |
+| GlobalDataFlow.cs:130:37:130:44 | SSA def(nonSink3) | GlobalDataFlow.cs:131:15:131:22 | access to local variable nonSink3 |
+| GlobalDataFlow.cs:131:9:131:23 | call to method Check | GlobalDataFlow.cs:131:9:131:23 | call to method Check |
+| GlobalDataFlow.cs:131:15:131:22 | access to local variable nonSink3 | GlobalDataFlow.cs:131:15:131:22 | access to local variable nonSink3 |
+| GlobalDataFlow.cs:134:30:134:64 | Func<String,String> return = ... | GlobalDataFlow.cs:134:30:134:64 | Func<String,String> return = ... |
+| GlobalDataFlow.cs:134:30:134:64 | SSA def(return) | GlobalDataFlow.cs:134:30:134:64 | SSA def(return) |
+| GlobalDataFlow.cs:134:30:134:64 | SSA def(return) | GlobalDataFlow.cs:135:21:135:27 | access to local variable return |
+| GlobalDataFlow.cs:134:30:134:64 | SSA def(return) | GlobalDataFlow.cs:135:21:135:27 | access to local variable return |
+| GlobalDataFlow.cs:134:30:134:64 | SSA def(return) | GlobalDataFlow.cs:139:20:139:26 | access to local variable return |
+| GlobalDataFlow.cs:134:30:134:64 | SSA def(return) | GlobalDataFlow.cs:139:20:139:26 | access to local variable return |
+| GlobalDataFlow.cs:134:40:134:40 | x | GlobalDataFlow.cs:134:40:134:40 | x |
+| GlobalDataFlow.cs:134:40:134:40 | x | GlobalDataFlow.cs:134:40:134:40 | x |
+| GlobalDataFlow.cs:134:40:134:40 | x | GlobalDataFlow.cs:134:63:134:63 | access to parameter x |
+| GlobalDataFlow.cs:134:40:134:40 | x | GlobalDataFlow.cs:134:63:134:63 | access to parameter x |
+| GlobalDataFlow.cs:134:40:134:40 | x | GlobalDataFlow.cs:134:63:134:63 | access to parameter x |
+| GlobalDataFlow.cs:134:40:134:40 | x | GlobalDataFlow.cs:134:63:134:63 | access to parameter x |
+| GlobalDataFlow.cs:134:40:134:64 | (...) => ... | GlobalDataFlow.cs:134:30:134:64 | SSA def(return) |
+| GlobalDataFlow.cs:134:40:134:64 | (...) => ... | GlobalDataFlow.cs:134:30:134:64 | SSA def(return) |
+| GlobalDataFlow.cs:134:40:134:64 | (...) => ... | GlobalDataFlow.cs:134:40:134:64 | (...) => ... |
+| GlobalDataFlow.cs:134:40:134:64 | (...) => ... | GlobalDataFlow.cs:135:21:135:27 | access to local variable return |
+| GlobalDataFlow.cs:134:40:134:64 | (...) => ... | GlobalDataFlow.cs:135:21:135:27 | access to local variable return |
+| GlobalDataFlow.cs:134:40:134:64 | (...) => ... | GlobalDataFlow.cs:139:20:139:26 | access to local variable return |
+| GlobalDataFlow.cs:134:40:134:64 | (...) => ... | GlobalDataFlow.cs:139:20:139:26 | access to local variable return |
+| GlobalDataFlow.cs:134:45:134:64 | call to method ApplyFunc | GlobalDataFlow.cs:134:45:134:64 | call to method ApplyFunc |
+| GlobalDataFlow.cs:134:45:134:64 | call to method ApplyFunc | GlobalDataFlow.cs:135:21:135:34 | delegate call |
+| GlobalDataFlow.cs:134:45:134:64 | call to method ApplyFunc | GlobalDataFlow.cs:135:21:135:34 | delegate call |
+| GlobalDataFlow.cs:134:45:134:64 | call to method ApplyFunc | GlobalDataFlow.cs:139:20:139:36 | delegate call |
+| GlobalDataFlow.cs:134:45:134:64 | call to method ApplyFunc | GlobalDataFlow.cs:139:20:139:36 | delegate call |
+| GlobalDataFlow.cs:134:55:134:60 | access to method Return | GlobalDataFlow.cs:134:55:134:60 | access to method Return |
+| GlobalDataFlow.cs:134:55:134:60 | delegate creation of type Func<String,String> | GlobalDataFlow.cs:134:55:134:60 | delegate creation of type Func<String,String> |
+| GlobalDataFlow.cs:134:55:134:60 | delegate creation of type Func<String,String> | GlobalDataFlow.cs:364:41:364:41 | f |
+| GlobalDataFlow.cs:134:55:134:60 | delegate creation of type Func<String,String> | GlobalDataFlow.cs:364:41:364:41 | f |
+| GlobalDataFlow.cs:134:63:134:63 | access to parameter x | GlobalDataFlow.cs:134:45:134:64 | call to method ApplyFunc |
+| GlobalDataFlow.cs:134:63:134:63 | access to parameter x | GlobalDataFlow.cs:134:45:134:64 | call to method ApplyFunc |
+| GlobalDataFlow.cs:134:63:134:63 | access to parameter x | GlobalDataFlow.cs:134:45:134:64 | call to method ApplyFunc |
+| GlobalDataFlow.cs:134:63:134:63 | access to parameter x | GlobalDataFlow.cs:134:45:134:64 | call to method ApplyFunc |
+| GlobalDataFlow.cs:134:63:134:63 | access to parameter x | GlobalDataFlow.cs:134:63:134:63 | access to parameter x |
+| GlobalDataFlow.cs:134:63:134:63 | access to parameter x | GlobalDataFlow.cs:364:46:364:46 | x |
+| GlobalDataFlow.cs:134:63:134:63 | access to parameter x | GlobalDataFlow.cs:364:46:364:46 | x |
+| GlobalDataFlow.cs:134:63:134:63 | access to parameter x | GlobalDataFlow.cs:364:46:364:46 | x |
+| GlobalDataFlow.cs:134:63:134:63 | access to parameter x | GlobalDataFlow.cs:364:46:364:46 | x |
+| GlobalDataFlow.cs:135:13:135:34 | SSA def(sink4) | GlobalDataFlow.cs:135:13:135:34 | SSA def(sink4) |
+| GlobalDataFlow.cs:135:13:135:34 | SSA def(sink4) | GlobalDataFlow.cs:136:15:136:19 | access to local variable sink4 |
+| GlobalDataFlow.cs:135:13:135:34 | SSA def(sink4) | GlobalDataFlow.cs:136:15:136:19 | access to local variable sink4 |
+| GlobalDataFlow.cs:135:13:135:34 | SSA def(sink4) | GlobalDataFlow.cs:143:39:143:43 | access to local variable sink4 |
+| GlobalDataFlow.cs:135:13:135:34 | SSA def(sink4) | GlobalDataFlow.cs:143:39:143:43 | access to local variable sink4 |
+| GlobalDataFlow.cs:135:13:135:34 | String sink4 = ... | GlobalDataFlow.cs:135:13:135:34 | String sink4 = ... |
+| GlobalDataFlow.cs:135:21:135:27 | access to local variable return | GlobalDataFlow.cs:135:21:135:27 | access to local variable return |
+| GlobalDataFlow.cs:135:21:135:27 | access to local variable return | GlobalDataFlow.cs:139:20:139:26 | access to local variable return |
+| GlobalDataFlow.cs:135:21:135:27 | access to local variable return | GlobalDataFlow.cs:139:20:139:26 | access to local variable return |
+| GlobalDataFlow.cs:135:21:135:34 | delegate call | GlobalDataFlow.cs:135:13:135:34 | SSA def(sink4) |
+| GlobalDataFlow.cs:135:21:135:34 | delegate call | GlobalDataFlow.cs:135:13:135:34 | SSA def(sink4) |
+| GlobalDataFlow.cs:135:21:135:34 | delegate call | GlobalDataFlow.cs:135:21:135:34 | delegate call |
+| GlobalDataFlow.cs:135:21:135:34 | delegate call | GlobalDataFlow.cs:136:15:136:19 | access to local variable sink4 |
+| GlobalDataFlow.cs:135:21:135:34 | delegate call | GlobalDataFlow.cs:136:15:136:19 | access to local variable sink4 |
+| GlobalDataFlow.cs:135:21:135:34 | delegate call | GlobalDataFlow.cs:143:39:143:43 | access to local variable sink4 |
+| GlobalDataFlow.cs:135:21:135:34 | delegate call | GlobalDataFlow.cs:143:39:143:43 | access to local variable sink4 |
+| GlobalDataFlow.cs:135:29:135:33 | access to local variable sink3 | GlobalDataFlow.cs:134:40:134:40 | x |
+| GlobalDataFlow.cs:135:29:135:33 | access to local variable sink3 | GlobalDataFlow.cs:134:40:134:40 | x |
+| GlobalDataFlow.cs:135:29:135:33 | access to local variable sink3 | GlobalDataFlow.cs:135:21:135:34 | delegate call |
+| GlobalDataFlow.cs:135:29:135:33 | access to local variable sink3 | GlobalDataFlow.cs:135:21:135:34 | delegate call |
+| GlobalDataFlow.cs:135:29:135:33 | access to local variable sink3 | GlobalDataFlow.cs:135:29:135:33 | access to local variable sink3 |
+| GlobalDataFlow.cs:136:9:136:20 | call to method Check | GlobalDataFlow.cs:136:9:136:20 | call to method Check |
+| GlobalDataFlow.cs:136:15:136:19 | access to local variable sink4 | GlobalDataFlow.cs:136:15:136:19 | access to local variable sink4 |
+| GlobalDataFlow.cs:136:15:136:19 | access to local variable sink4 | GlobalDataFlow.cs:143:39:143:43 | access to local variable sink4 |
+| GlobalDataFlow.cs:136:15:136:19 | access to local variable sink4 | GlobalDataFlow.cs:143:39:143:43 | access to local variable sink4 |
+| GlobalDataFlow.cs:139:9:139:36 | ... = ... | GlobalDataFlow.cs:139:9:139:36 | ... = ... |
+| GlobalDataFlow.cs:139:9:139:36 | SSA def(nonSink0) | GlobalDataFlow.cs:139:9:139:36 | SSA def(nonSink0) |
+| GlobalDataFlow.cs:139:9:139:36 | SSA def(nonSink0) | GlobalDataFlow.cs:140:15:140:22 | access to local variable nonSink0 |
+| GlobalDataFlow.cs:139:9:139:36 | SSA def(nonSink0) | GlobalDataFlow.cs:140:15:140:22 | access to local variable nonSink0 |
+| GlobalDataFlow.cs:139:20:139:26 | access to local variable return | GlobalDataFlow.cs:139:20:139:26 | access to local variable return |
+| GlobalDataFlow.cs:139:20:139:36 | delegate call | GlobalDataFlow.cs:139:9:139:36 | SSA def(nonSink0) |
+| GlobalDataFlow.cs:139:20:139:36 | delegate call | GlobalDataFlow.cs:139:9:139:36 | SSA def(nonSink0) |
+| GlobalDataFlow.cs:139:20:139:36 | delegate call | GlobalDataFlow.cs:139:20:139:36 | delegate call |
+| GlobalDataFlow.cs:139:20:139:36 | delegate call | GlobalDataFlow.cs:140:15:140:22 | access to local variable nonSink0 |
+| GlobalDataFlow.cs:139:20:139:36 | delegate call | GlobalDataFlow.cs:140:15:140:22 | access to local variable nonSink0 |
+| GlobalDataFlow.cs:139:28:139:35 | access to local variable nonSink0 | GlobalDataFlow.cs:134:40:134:40 | x |
+| GlobalDataFlow.cs:139:28:139:35 | access to local variable nonSink0 | GlobalDataFlow.cs:134:40:134:40 | x |
+| GlobalDataFlow.cs:139:28:139:35 | access to local variable nonSink0 | GlobalDataFlow.cs:139:20:139:36 | delegate call |
+| GlobalDataFlow.cs:139:28:139:35 | access to local variable nonSink0 | GlobalDataFlow.cs:139:20:139:36 | delegate call |
+| GlobalDataFlow.cs:139:28:139:35 | access to local variable nonSink0 | GlobalDataFlow.cs:139:28:139:35 | access to local variable nonSink0 |
+| GlobalDataFlow.cs:140:9:140:23 | call to method Check | GlobalDataFlow.cs:140:9:140:23 | call to method Check |
+| GlobalDataFlow.cs:140:15:140:22 | access to local variable nonSink0 | GlobalDataFlow.cs:140:15:140:22 | access to local variable nonSink0 |
+| GlobalDataFlow.cs:143:13:143:44 | SSA def(sink5) | GlobalDataFlow.cs:143:13:143:44 | SSA def(sink5) |
+| GlobalDataFlow.cs:143:13:143:44 | SSA def(sink5) | GlobalDataFlow.cs:144:15:144:19 | access to local variable sink5 |
+| GlobalDataFlow.cs:143:13:143:44 | SSA def(sink5) | GlobalDataFlow.cs:144:15:144:19 | access to local variable sink5 |
+| GlobalDataFlow.cs:143:13:143:44 | SSA def(sink5) | GlobalDataFlow.cs:149:39:149:43 | access to local variable sink5 |
+| GlobalDataFlow.cs:143:13:143:44 | SSA def(sink5) | GlobalDataFlow.cs:149:39:149:43 | access to local variable sink5 |
+| GlobalDataFlow.cs:143:13:143:44 | String sink5 = ... | GlobalDataFlow.cs:143:13:143:44 | String sink5 = ... |
+| GlobalDataFlow.cs:143:21:143:44 | call to method ApplyFunc | GlobalDataFlow.cs:143:13:143:44 | SSA def(sink5) |
+| GlobalDataFlow.cs:143:21:143:44 | call to method ApplyFunc | GlobalDataFlow.cs:143:13:143:44 | SSA def(sink5) |
+| GlobalDataFlow.cs:143:21:143:44 | call to method ApplyFunc | GlobalDataFlow.cs:143:21:143:44 | call to method ApplyFunc |
+| GlobalDataFlow.cs:143:21:143:44 | call to method ApplyFunc | GlobalDataFlow.cs:144:15:144:19 | access to local variable sink5 |
+| GlobalDataFlow.cs:143:21:143:44 | call to method ApplyFunc | GlobalDataFlow.cs:144:15:144:19 | access to local variable sink5 |
+| GlobalDataFlow.cs:143:21:143:44 | call to method ApplyFunc | GlobalDataFlow.cs:149:39:149:43 | access to local variable sink5 |
+| GlobalDataFlow.cs:143:21:143:44 | call to method ApplyFunc | GlobalDataFlow.cs:149:39:149:43 | access to local variable sink5 |
+| GlobalDataFlow.cs:143:31:143:36 | access to method Return | GlobalDataFlow.cs:143:31:143:36 | access to method Return |
+| GlobalDataFlow.cs:143:31:143:36 | delegate creation of type Func<String,String> | GlobalDataFlow.cs:143:31:143:36 | delegate creation of type Func<String,String> |
+| GlobalDataFlow.cs:143:31:143:36 | delegate creation of type Func<String,String> | GlobalDataFlow.cs:364:41:364:41 | f |
+| GlobalDataFlow.cs:143:31:143:36 | delegate creation of type Func<String,String> | GlobalDataFlow.cs:364:41:364:41 | f |
+| GlobalDataFlow.cs:143:39:143:43 | access to local variable sink4 | GlobalDataFlow.cs:143:21:143:44 | call to method ApplyFunc |
+| GlobalDataFlow.cs:143:39:143:43 | access to local variable sink4 | GlobalDataFlow.cs:143:21:143:44 | call to method ApplyFunc |
+| GlobalDataFlow.cs:143:39:143:43 | access to local variable sink4 | GlobalDataFlow.cs:143:39:143:43 | access to local variable sink4 |
+| GlobalDataFlow.cs:143:39:143:43 | access to local variable sink4 | GlobalDataFlow.cs:364:46:364:46 | x |
+| GlobalDataFlow.cs:143:39:143:43 | access to local variable sink4 | GlobalDataFlow.cs:364:46:364:46 | x |
+| GlobalDataFlow.cs:144:9:144:20 | call to method Check | GlobalDataFlow.cs:144:9:144:20 | call to method Check |
+| GlobalDataFlow.cs:144:15:144:19 | access to local variable sink5 | GlobalDataFlow.cs:144:15:144:19 | access to local variable sink5 |
+| GlobalDataFlow.cs:144:15:144:19 | access to local variable sink5 | GlobalDataFlow.cs:149:39:149:43 | access to local variable sink5 |
+| GlobalDataFlow.cs:144:15:144:19 | access to local variable sink5 | GlobalDataFlow.cs:149:39:149:43 | access to local variable sink5 |
+| GlobalDataFlow.cs:147:9:147:40 | ... = ... | GlobalDataFlow.cs:147:9:147:40 | ... = ... |
+| GlobalDataFlow.cs:147:9:147:40 | SSA def(nonSink0) | GlobalDataFlow.cs:147:9:147:40 | SSA def(nonSink0) |
+| GlobalDataFlow.cs:147:9:147:40 | SSA def(nonSink0) | GlobalDataFlow.cs:148:15:148:22 | access to local variable nonSink0 |
+| GlobalDataFlow.cs:147:9:147:40 | SSA def(nonSink0) | GlobalDataFlow.cs:148:15:148:22 | access to local variable nonSink0 |
+| GlobalDataFlow.cs:147:20:147:40 | call to method ApplyFunc | GlobalDataFlow.cs:147:9:147:40 | SSA def(nonSink0) |
+| GlobalDataFlow.cs:147:20:147:40 | call to method ApplyFunc | GlobalDataFlow.cs:147:9:147:40 | SSA def(nonSink0) |
+| GlobalDataFlow.cs:147:20:147:40 | call to method ApplyFunc | GlobalDataFlow.cs:147:20:147:40 | call to method ApplyFunc |
+| GlobalDataFlow.cs:147:20:147:40 | call to method ApplyFunc | GlobalDataFlow.cs:148:15:148:22 | access to local variable nonSink0 |
+| GlobalDataFlow.cs:147:20:147:40 | call to method ApplyFunc | GlobalDataFlow.cs:148:15:148:22 | access to local variable nonSink0 |
+| GlobalDataFlow.cs:147:30:147:35 | access to method Return | GlobalDataFlow.cs:147:30:147:35 | access to method Return |
+| GlobalDataFlow.cs:147:30:147:35 | delegate creation of type Func<String,String> | GlobalDataFlow.cs:147:30:147:35 | delegate creation of type Func<String,String> |
+| GlobalDataFlow.cs:147:30:147:35 | delegate creation of type Func<String,String> | GlobalDataFlow.cs:364:41:364:41 | f |
+| GlobalDataFlow.cs:147:30:147:35 | delegate creation of type Func<String,String> | GlobalDataFlow.cs:364:41:364:41 | f |
+| GlobalDataFlow.cs:147:38:147:39 | "" | GlobalDataFlow.cs:147:20:147:40 | call to method ApplyFunc |
+| GlobalDataFlow.cs:147:38:147:39 | "" | GlobalDataFlow.cs:147:20:147:40 | call to method ApplyFunc |
+| GlobalDataFlow.cs:147:38:147:39 | "" | GlobalDataFlow.cs:147:38:147:39 | "" |
+| GlobalDataFlow.cs:147:38:147:39 | "" | GlobalDataFlow.cs:364:46:364:46 | x |
+| GlobalDataFlow.cs:147:38:147:39 | "" | GlobalDataFlow.cs:364:46:364:46 | x |
+| GlobalDataFlow.cs:148:9:148:23 | call to method Check | GlobalDataFlow.cs:148:9:148:23 | call to method Check |
+| GlobalDataFlow.cs:148:15:148:22 | access to local variable nonSink0 | GlobalDataFlow.cs:148:15:148:22 | access to local variable nonSink0 |
+| GlobalDataFlow.cs:149:9:149:44 | ... = ... | GlobalDataFlow.cs:149:9:149:44 | ... = ... |
+| GlobalDataFlow.cs:149:9:149:44 | SSA def(nonSink0) | GlobalDataFlow.cs:149:9:149:44 | SSA def(nonSink0) |
+| GlobalDataFlow.cs:149:9:149:44 | SSA def(nonSink0) | GlobalDataFlow.cs:150:15:150:22 | access to local variable nonSink0 |
+| GlobalDataFlow.cs:149:9:149:44 | SSA def(nonSink0) | GlobalDataFlow.cs:150:15:150:22 | access to local variable nonSink0 |
+| GlobalDataFlow.cs:149:9:149:44 | SSA def(nonSink0) | GlobalDataFlow.cs:163:35:163:42 | access to local variable nonSink0 |
+| GlobalDataFlow.cs:149:9:149:44 | SSA def(nonSink0) | GlobalDataFlow.cs:163:35:163:42 | access to local variable nonSink0 |
+| GlobalDataFlow.cs:149:20:149:44 | call to method ApplyFunc | GlobalDataFlow.cs:149:9:149:44 | SSA def(nonSink0) |
+| GlobalDataFlow.cs:149:20:149:44 | call to method ApplyFunc | GlobalDataFlow.cs:149:9:149:44 | SSA def(nonSink0) |
+| GlobalDataFlow.cs:149:20:149:44 | call to method ApplyFunc | GlobalDataFlow.cs:149:20:149:44 | call to method ApplyFunc |
+| GlobalDataFlow.cs:149:20:149:44 | call to method ApplyFunc | GlobalDataFlow.cs:150:15:150:22 | access to local variable nonSink0 |
+| GlobalDataFlow.cs:149:20:149:44 | call to method ApplyFunc | GlobalDataFlow.cs:150:15:150:22 | access to local variable nonSink0 |
+| GlobalDataFlow.cs:149:20:149:44 | call to method ApplyFunc | GlobalDataFlow.cs:163:35:163:42 | access to local variable nonSink0 |
+| GlobalDataFlow.cs:149:20:149:44 | call to method ApplyFunc | GlobalDataFlow.cs:163:35:163:42 | access to local variable nonSink0 |
+| GlobalDataFlow.cs:149:30:149:36 | (...) => ... | GlobalDataFlow.cs:149:30:149:36 | (...) => ... |
+| GlobalDataFlow.cs:149:30:149:36 | (...) => ... | GlobalDataFlow.cs:364:41:364:41 | f |
+| GlobalDataFlow.cs:149:30:149:36 | (...) => ... | GlobalDataFlow.cs:364:41:364:41 | f |
+| GlobalDataFlow.cs:149:35:149:36 | "" | GlobalDataFlow.cs:149:35:149:36 | "" |
+| GlobalDataFlow.cs:149:35:149:36 | "" | GlobalDataFlow.cs:366:16:366:19 | delegate call |
+| GlobalDataFlow.cs:149:35:149:36 | "" | GlobalDataFlow.cs:366:16:366:19 | delegate call |
+| GlobalDataFlow.cs:149:39:149:43 | access to local variable sink5 | GlobalDataFlow.cs:149:39:149:43 | access to local variable sink5 |
+| GlobalDataFlow.cs:149:39:149:43 | access to local variable sink5 | GlobalDataFlow.cs:364:46:364:46 | x |
+| GlobalDataFlow.cs:149:39:149:43 | access to local variable sink5 | GlobalDataFlow.cs:364:46:364:46 | x |
+| GlobalDataFlow.cs:150:9:150:23 | call to method Check | GlobalDataFlow.cs:150:9:150:23 | call to method Check |
+| GlobalDataFlow.cs:150:15:150:22 | access to local variable nonSink0 | GlobalDataFlow.cs:150:15:150:22 | access to local variable nonSink0 |
+| GlobalDataFlow.cs:150:15:150:22 | access to local variable nonSink0 | GlobalDataFlow.cs:163:35:163:42 | access to local variable nonSink0 |
+| GlobalDataFlow.cs:150:15:150:22 | access to local variable nonSink0 | GlobalDataFlow.cs:163:35:163:42 | access to local variable nonSink0 |
+| GlobalDataFlow.cs:153:13:153:25 | SSA def(sink6) | GlobalDataFlow.cs:153:13:153:25 | SSA def(sink6) |
+| GlobalDataFlow.cs:153:13:153:25 | SSA def(sink6) | GlobalDataFlow.cs:154:15:154:19 | access to local variable sink6 |
+| GlobalDataFlow.cs:153:13:153:25 | SSA def(sink6) | GlobalDataFlow.cs:154:15:154:19 | access to local variable sink6 |
+| GlobalDataFlow.cs:153:13:153:25 | String sink6 = ... | GlobalDataFlow.cs:153:13:153:25 | String sink6 = ... |
+| GlobalDataFlow.cs:153:21:153:25 | call to method Out | GlobalDataFlow.cs:153:13:153:25 | SSA def(sink6) |
+| GlobalDataFlow.cs:153:21:153:25 | call to method Out | GlobalDataFlow.cs:153:13:153:25 | SSA def(sink6) |
+| GlobalDataFlow.cs:153:21:153:25 | call to method Out | GlobalDataFlow.cs:153:21:153:25 | call to method Out |
+| GlobalDataFlow.cs:153:21:153:25 | call to method Out | GlobalDataFlow.cs:154:15:154:19 | access to local variable sink6 |
+| GlobalDataFlow.cs:153:21:153:25 | call to method Out | GlobalDataFlow.cs:154:15:154:19 | access to local variable sink6 |
+| GlobalDataFlow.cs:153:21:153:25 | this access | GlobalDataFlow.cs:153:21:153:25 | this access |
+| GlobalDataFlow.cs:153:21:153:25 | this access | GlobalDataFlow.cs:156:9:156:25 | this access |
+| GlobalDataFlow.cs:153:21:153:25 | this access | GlobalDataFlow.cs:156:9:156:25 | this access |
+| GlobalDataFlow.cs:153:21:153:25 | this access | GlobalDataFlow.cs:159:9:159:25 | this access |
+| GlobalDataFlow.cs:153:21:153:25 | this access | GlobalDataFlow.cs:159:9:159:25 | this access |
+| GlobalDataFlow.cs:153:21:153:25 | this access | GlobalDataFlow.cs:161:22:161:31 | this access |
+| GlobalDataFlow.cs:153:21:153:25 | this access | GlobalDataFlow.cs:161:22:161:31 | this access |
+| GlobalDataFlow.cs:153:21:153:25 | this access | GlobalDataFlow.cs:167:20:167:27 | this access |
+| GlobalDataFlow.cs:153:21:153:25 | this access | GlobalDataFlow.cs:167:20:167:27 | this access |
+| GlobalDataFlow.cs:153:21:153:25 | this access | GlobalDataFlow.cs:169:9:169:31 | this access |
+| GlobalDataFlow.cs:153:21:153:25 | this access | GlobalDataFlow.cs:169:9:169:31 | this access |
+| GlobalDataFlow.cs:153:21:153:25 | this access | GlobalDataFlow.cs:171:9:171:31 | this access |
+| GlobalDataFlow.cs:153:21:153:25 | this access | GlobalDataFlow.cs:171:9:171:31 | this access |
+| GlobalDataFlow.cs:153:21:153:25 | this access | GlobalDataFlow.cs:173:20:173:32 | this access |
+| GlobalDataFlow.cs:153:21:153:25 | this access | GlobalDataFlow.cs:173:20:173:32 | this access |
+| GlobalDataFlow.cs:153:21:153:25 | this access | GlobalDataFlow.cs:189:39:189:41 | this access |
+| GlobalDataFlow.cs:153:21:153:25 | this access | GlobalDataFlow.cs:189:39:189:41 | this access |
+| GlobalDataFlow.cs:153:21:153:25 | this access | GlobalDataFlow.cs:193:37:193:42 | this access |
+| GlobalDataFlow.cs:153:21:153:25 | this access | GlobalDataFlow.cs:193:37:193:42 | this access |
+| GlobalDataFlow.cs:153:21:153:25 | this access | GlobalDataFlow.cs:197:22:197:32 | this access |
+| GlobalDataFlow.cs:153:21:153:25 | this access | GlobalDataFlow.cs:197:22:197:32 | this access |
+| GlobalDataFlow.cs:153:21:153:25 | this access | GlobalDataFlow.cs:201:20:201:33 | this access |
+| GlobalDataFlow.cs:153:21:153:25 | this access | GlobalDataFlow.cs:201:20:201:33 | this access |
+| GlobalDataFlow.cs:153:21:153:25 | this access | GlobalDataFlow.cs:316:12:316:14 | this |
+| GlobalDataFlow.cs:153:21:153:25 | this access | GlobalDataFlow.cs:316:12:316:14 | this |
+| GlobalDataFlow.cs:154:9:154:20 | call to method Check | GlobalDataFlow.cs:154:9:154:20 | call to method Check |
+| GlobalDataFlow.cs:154:15:154:19 | access to local variable sink6 | GlobalDataFlow.cs:154:15:154:19 | access to local variable sink6 |
+| GlobalDataFlow.cs:155:16:155:20 | String sink7 | GlobalDataFlow.cs:155:16:155:20 | String sink7 |
+| GlobalDataFlow.cs:156:9:156:25 | call to method OutOut | GlobalDataFlow.cs:156:9:156:25 | call to method OutOut |
+| GlobalDataFlow.cs:156:9:156:25 | this access | GlobalDataFlow.cs:156:9:156:25 | this access |
+| GlobalDataFlow.cs:156:9:156:25 | this access | GlobalDataFlow.cs:159:9:159:25 | this access |
+| GlobalDataFlow.cs:156:9:156:25 | this access | GlobalDataFlow.cs:159:9:159:25 | this access |
+| GlobalDataFlow.cs:156:9:156:25 | this access | GlobalDataFlow.cs:161:22:161:31 | this access |
+| GlobalDataFlow.cs:156:9:156:25 | this access | GlobalDataFlow.cs:161:22:161:31 | this access |
+| GlobalDataFlow.cs:156:9:156:25 | this access | GlobalDataFlow.cs:167:20:167:27 | this access |
+| GlobalDataFlow.cs:156:9:156:25 | this access | GlobalDataFlow.cs:167:20:167:27 | this access |
+| GlobalDataFlow.cs:156:9:156:25 | this access | GlobalDataFlow.cs:169:9:169:31 | this access |
+| GlobalDataFlow.cs:156:9:156:25 | this access | GlobalDataFlow.cs:169:9:169:31 | this access |
+| GlobalDataFlow.cs:156:9:156:25 | this access | GlobalDataFlow.cs:171:9:171:31 | this access |
+| GlobalDataFlow.cs:156:9:156:25 | this access | GlobalDataFlow.cs:171:9:171:31 | this access |
+| GlobalDataFlow.cs:156:9:156:25 | this access | GlobalDataFlow.cs:173:20:173:32 | this access |
+| GlobalDataFlow.cs:156:9:156:25 | this access | GlobalDataFlow.cs:173:20:173:32 | this access |
+| GlobalDataFlow.cs:156:9:156:25 | this access | GlobalDataFlow.cs:189:39:189:41 | this access |
+| GlobalDataFlow.cs:156:9:156:25 | this access | GlobalDataFlow.cs:189:39:189:41 | this access |
+| GlobalDataFlow.cs:156:9:156:25 | this access | GlobalDataFlow.cs:193:37:193:42 | this access |
+| GlobalDataFlow.cs:156:9:156:25 | this access | GlobalDataFlow.cs:193:37:193:42 | this access |
+| GlobalDataFlow.cs:156:9:156:25 | this access | GlobalDataFlow.cs:197:22:197:32 | this access |
+| GlobalDataFlow.cs:156:9:156:25 | this access | GlobalDataFlow.cs:197:22:197:32 | this access |
+| GlobalDataFlow.cs:156:9:156:25 | this access | GlobalDataFlow.cs:201:20:201:33 | this access |
+| GlobalDataFlow.cs:156:9:156:25 | this access | GlobalDataFlow.cs:201:20:201:33 | this access |
+| GlobalDataFlow.cs:156:9:156:25 | this access | GlobalDataFlow.cs:321:10:321:15 | this |
+| GlobalDataFlow.cs:156:9:156:25 | this access | GlobalDataFlow.cs:321:10:321:15 | this |
+| GlobalDataFlow.cs:156:20:156:24 | SSA def(sink7) | GlobalDataFlow.cs:156:20:156:24 | SSA def(sink7) |
+| GlobalDataFlow.cs:156:20:156:24 | SSA def(sink7) | GlobalDataFlow.cs:157:15:157:19 | access to local variable sink7 |
+| GlobalDataFlow.cs:156:20:156:24 | SSA def(sink7) | GlobalDataFlow.cs:157:15:157:19 | access to local variable sink7 |
+| GlobalDataFlow.cs:157:9:157:20 | call to method Check | GlobalDataFlow.cs:157:9:157:20 | call to method Check |
+| GlobalDataFlow.cs:157:15:157:19 | access to local variable sink7 | GlobalDataFlow.cs:157:15:157:19 | access to local variable sink7 |
+| GlobalDataFlow.cs:158:13:158:22 | SSA def(sink8) | GlobalDataFlow.cs:158:13:158:22 | SSA def(sink8) |
+| GlobalDataFlow.cs:158:13:158:22 | SSA def(sink8) | GlobalDataFlow.cs:159:20:159:24 | access to local variable sink8 |
+| GlobalDataFlow.cs:158:13:158:22 | SSA def(sink8) | GlobalDataFlow.cs:159:20:159:24 | access to local variable sink8 |
+| GlobalDataFlow.cs:158:13:158:22 | String sink8 = ... | GlobalDataFlow.cs:158:13:158:22 | String sink8 = ... |
+| GlobalDataFlow.cs:158:21:158:22 | "" | GlobalDataFlow.cs:158:13:158:22 | SSA def(sink8) |
+| GlobalDataFlow.cs:158:21:158:22 | "" | GlobalDataFlow.cs:158:13:158:22 | SSA def(sink8) |
+| GlobalDataFlow.cs:158:21:158:22 | "" | GlobalDataFlow.cs:158:21:158:22 | "" |
+| GlobalDataFlow.cs:158:21:158:22 | "" | GlobalDataFlow.cs:159:20:159:24 | access to local variable sink8 |
+| GlobalDataFlow.cs:158:21:158:22 | "" | GlobalDataFlow.cs:159:20:159:24 | access to local variable sink8 |
+| GlobalDataFlow.cs:159:9:159:25 | call to method OutRef | GlobalDataFlow.cs:159:9:159:25 | call to method OutRef |
+| GlobalDataFlow.cs:159:9:159:25 | this access | GlobalDataFlow.cs:159:9:159:25 | this access |
+| GlobalDataFlow.cs:159:9:159:25 | this access | GlobalDataFlow.cs:161:22:161:31 | this access |
+| GlobalDataFlow.cs:159:9:159:25 | this access | GlobalDataFlow.cs:161:22:161:31 | this access |
+| GlobalDataFlow.cs:159:9:159:25 | this access | GlobalDataFlow.cs:167:20:167:27 | this access |
+| GlobalDataFlow.cs:159:9:159:25 | this access | GlobalDataFlow.cs:167:20:167:27 | this access |
+| GlobalDataFlow.cs:159:9:159:25 | this access | GlobalDataFlow.cs:169:9:169:31 | this access |
+| GlobalDataFlow.cs:159:9:159:25 | this access | GlobalDataFlow.cs:169:9:169:31 | this access |
+| GlobalDataFlow.cs:159:9:159:25 | this access | GlobalDataFlow.cs:171:9:171:31 | this access |
+| GlobalDataFlow.cs:159:9:159:25 | this access | GlobalDataFlow.cs:171:9:171:31 | this access |
+| GlobalDataFlow.cs:159:9:159:25 | this access | GlobalDataFlow.cs:173:20:173:32 | this access |
+| GlobalDataFlow.cs:159:9:159:25 | this access | GlobalDataFlow.cs:173:20:173:32 | this access |
+| GlobalDataFlow.cs:159:9:159:25 | this access | GlobalDataFlow.cs:189:39:189:41 | this access |
+| GlobalDataFlow.cs:159:9:159:25 | this access | GlobalDataFlow.cs:189:39:189:41 | this access |
+| GlobalDataFlow.cs:159:9:159:25 | this access | GlobalDataFlow.cs:193:37:193:42 | this access |
+| GlobalDataFlow.cs:159:9:159:25 | this access | GlobalDataFlow.cs:193:37:193:42 | this access |
+| GlobalDataFlow.cs:159:9:159:25 | this access | GlobalDataFlow.cs:197:22:197:32 | this access |
+| GlobalDataFlow.cs:159:9:159:25 | this access | GlobalDataFlow.cs:197:22:197:32 | this access |
+| GlobalDataFlow.cs:159:9:159:25 | this access | GlobalDataFlow.cs:201:20:201:33 | this access |
+| GlobalDataFlow.cs:159:9:159:25 | this access | GlobalDataFlow.cs:201:20:201:33 | this access |
+| GlobalDataFlow.cs:159:9:159:25 | this access | GlobalDataFlow.cs:326:10:326:15 | this |
+| GlobalDataFlow.cs:159:9:159:25 | this access | GlobalDataFlow.cs:326:10:326:15 | this |
+| GlobalDataFlow.cs:159:20:159:24 | SSA def(sink8) | GlobalDataFlow.cs:159:20:159:24 | SSA def(sink8) |
+| GlobalDataFlow.cs:159:20:159:24 | SSA def(sink8) | GlobalDataFlow.cs:160:15:160:19 | access to local variable sink8 |
+| GlobalDataFlow.cs:159:20:159:24 | SSA def(sink8) | GlobalDataFlow.cs:160:15:160:19 | access to local variable sink8 |
+| GlobalDataFlow.cs:159:20:159:24 | access to local variable sink8 | GlobalDataFlow.cs:159:20:159:24 | access to local variable sink8 |
+| GlobalDataFlow.cs:160:9:160:20 | call to method Check | GlobalDataFlow.cs:160:9:160:20 | call to method Check |
+| GlobalDataFlow.cs:160:15:160:19 | access to local variable sink8 | GlobalDataFlow.cs:160:15:160:19 | access to local variable sink8 |
+| GlobalDataFlow.cs:161:13:161:31 | IEnumerable<String> sink12 = ... | GlobalDataFlow.cs:161:13:161:31 | IEnumerable<String> sink12 = ... |
+| GlobalDataFlow.cs:161:13:161:31 | SSA def(sink12) | GlobalDataFlow.cs:161:13:161:31 | SSA def(sink12) |
+| GlobalDataFlow.cs:161:13:161:31 | SSA def(sink12) | GlobalDataFlow.cs:162:15:162:20 | access to local variable sink12 |
+| GlobalDataFlow.cs:161:13:161:31 | SSA def(sink12) | GlobalDataFlow.cs:162:15:162:20 | access to local variable sink12 |
+| GlobalDataFlow.cs:161:22:161:31 | call to method OutYield | GlobalDataFlow.cs:161:13:161:31 | SSA def(sink12) |
+| GlobalDataFlow.cs:161:22:161:31 | call to method OutYield | GlobalDataFlow.cs:161:13:161:31 | SSA def(sink12) |
+| GlobalDataFlow.cs:161:22:161:31 | call to method OutYield | GlobalDataFlow.cs:161:22:161:31 | call to method OutYield |
+| GlobalDataFlow.cs:161:22:161:31 | call to method OutYield | GlobalDataFlow.cs:162:15:162:20 | access to local variable sink12 |
+| GlobalDataFlow.cs:161:22:161:31 | call to method OutYield | GlobalDataFlow.cs:162:15:162:20 | access to local variable sink12 |
+| GlobalDataFlow.cs:161:22:161:31 | this access | GlobalDataFlow.cs:161:22:161:31 | this access |
+| GlobalDataFlow.cs:161:22:161:31 | this access | GlobalDataFlow.cs:167:20:167:27 | this access |
+| GlobalDataFlow.cs:161:22:161:31 | this access | GlobalDataFlow.cs:167:20:167:27 | this access |
+| GlobalDataFlow.cs:161:22:161:31 | this access | GlobalDataFlow.cs:169:9:169:31 | this access |
+| GlobalDataFlow.cs:161:22:161:31 | this access | GlobalDataFlow.cs:169:9:169:31 | this access |
+| GlobalDataFlow.cs:161:22:161:31 | this access | GlobalDataFlow.cs:171:9:171:31 | this access |
+| GlobalDataFlow.cs:161:22:161:31 | this access | GlobalDataFlow.cs:171:9:171:31 | this access |
+| GlobalDataFlow.cs:161:22:161:31 | this access | GlobalDataFlow.cs:173:20:173:32 | this access |
+| GlobalDataFlow.cs:161:22:161:31 | this access | GlobalDataFlow.cs:173:20:173:32 | this access |
+| GlobalDataFlow.cs:161:22:161:31 | this access | GlobalDataFlow.cs:189:39:189:41 | this access |
+| GlobalDataFlow.cs:161:22:161:31 | this access | GlobalDataFlow.cs:189:39:189:41 | this access |
+| GlobalDataFlow.cs:161:22:161:31 | this access | GlobalDataFlow.cs:193:37:193:42 | this access |
+| GlobalDataFlow.cs:161:22:161:31 | this access | GlobalDataFlow.cs:193:37:193:42 | this access |
+| GlobalDataFlow.cs:161:22:161:31 | this access | GlobalDataFlow.cs:197:22:197:32 | this access |
+| GlobalDataFlow.cs:161:22:161:31 | this access | GlobalDataFlow.cs:197:22:197:32 | this access |
+| GlobalDataFlow.cs:161:22:161:31 | this access | GlobalDataFlow.cs:201:20:201:33 | this access |
+| GlobalDataFlow.cs:161:22:161:31 | this access | GlobalDataFlow.cs:201:20:201:33 | this access |
+| GlobalDataFlow.cs:161:22:161:31 | this access | GlobalDataFlow.cs:331:25:331:32 | this |
+| GlobalDataFlow.cs:161:22:161:31 | this access | GlobalDataFlow.cs:331:25:331:32 | this |
+| GlobalDataFlow.cs:162:9:162:21 | call to method Check | GlobalDataFlow.cs:162:9:162:21 | call to method Check |
+| GlobalDataFlow.cs:162:15:162:20 | access to local variable sink12 | GlobalDataFlow.cs:162:15:162:20 | access to local variable sink12 |
+| GlobalDataFlow.cs:163:13:163:43 | SSA def(sink23) | GlobalDataFlow.cs:163:13:163:43 | SSA def(sink23) |
+| GlobalDataFlow.cs:163:13:163:43 | SSA def(sink23) | GlobalDataFlow.cs:164:15:164:20 | access to local variable sink23 |
+| GlobalDataFlow.cs:163:13:163:43 | SSA def(sink23) | GlobalDataFlow.cs:164:15:164:20 | access to local variable sink23 |
+| GlobalDataFlow.cs:163:13:163:43 | String sink23 = ... | GlobalDataFlow.cs:163:13:163:43 | String sink23 = ... |
+| GlobalDataFlow.cs:163:22:163:43 | call to method TaintedParam | GlobalDataFlow.cs:163:13:163:43 | SSA def(sink23) |
+| GlobalDataFlow.cs:163:22:163:43 | call to method TaintedParam | GlobalDataFlow.cs:163:13:163:43 | SSA def(sink23) |
+| GlobalDataFlow.cs:163:22:163:43 | call to method TaintedParam | GlobalDataFlow.cs:163:22:163:43 | call to method TaintedParam |
+| GlobalDataFlow.cs:163:22:163:43 | call to method TaintedParam | GlobalDataFlow.cs:164:15:164:20 | access to local variable sink23 |
+| GlobalDataFlow.cs:163:22:163:43 | call to method TaintedParam | GlobalDataFlow.cs:164:15:164:20 | access to local variable sink23 |
+| GlobalDataFlow.cs:163:35:163:42 | access to local variable nonSink0 | GlobalDataFlow.cs:163:22:163:43 | call to method TaintedParam |
+| GlobalDataFlow.cs:163:35:163:42 | access to local variable nonSink0 | GlobalDataFlow.cs:163:22:163:43 | call to method TaintedParam |
+| GlobalDataFlow.cs:163:35:163:42 | access to local variable nonSink0 | GlobalDataFlow.cs:163:35:163:42 | access to local variable nonSink0 |
+| GlobalDataFlow.cs:163:35:163:42 | access to local variable nonSink0 | GlobalDataFlow.cs:378:39:378:45 | tainted |
+| GlobalDataFlow.cs:163:35:163:42 | access to local variable nonSink0 | GlobalDataFlow.cs:378:39:378:45 | tainted |
+| GlobalDataFlow.cs:164:9:164:21 | call to method Check | GlobalDataFlow.cs:164:9:164:21 | call to method Check |
+| GlobalDataFlow.cs:164:15:164:20 | access to local variable sink23 | GlobalDataFlow.cs:164:15:164:20 | access to local variable sink23 |
+| GlobalDataFlow.cs:167:9:167:27 | ... = ... | GlobalDataFlow.cs:167:9:167:27 | ... = ... |
+| GlobalDataFlow.cs:167:9:167:27 | SSA def(nonSink0) | GlobalDataFlow.cs:167:9:167:27 | SSA def(nonSink0) |
+| GlobalDataFlow.cs:167:9:167:27 | SSA def(nonSink0) | GlobalDataFlow.cs:168:15:168:22 | access to local variable nonSink0 |
+| GlobalDataFlow.cs:167:9:167:27 | SSA def(nonSink0) | GlobalDataFlow.cs:168:15:168:22 | access to local variable nonSink0 |
+| GlobalDataFlow.cs:167:20:167:27 | call to method NonOut | GlobalDataFlow.cs:167:9:167:27 | SSA def(nonSink0) |
+| GlobalDataFlow.cs:167:20:167:27 | call to method NonOut | GlobalDataFlow.cs:167:9:167:27 | SSA def(nonSink0) |
+| GlobalDataFlow.cs:167:20:167:27 | call to method NonOut | GlobalDataFlow.cs:167:20:167:27 | call to method NonOut |
+| GlobalDataFlow.cs:167:20:167:27 | call to method NonOut | GlobalDataFlow.cs:168:15:168:22 | access to local variable nonSink0 |
+| GlobalDataFlow.cs:167:20:167:27 | call to method NonOut | GlobalDataFlow.cs:168:15:168:22 | access to local variable nonSink0 |
+| GlobalDataFlow.cs:167:20:167:27 | this access | GlobalDataFlow.cs:167:20:167:27 | this access |
+| GlobalDataFlow.cs:167:20:167:27 | this access | GlobalDataFlow.cs:169:9:169:31 | this access |
+| GlobalDataFlow.cs:167:20:167:27 | this access | GlobalDataFlow.cs:169:9:169:31 | this access |
+| GlobalDataFlow.cs:167:20:167:27 | this access | GlobalDataFlow.cs:171:9:171:31 | this access |
+| GlobalDataFlow.cs:167:20:167:27 | this access | GlobalDataFlow.cs:171:9:171:31 | this access |
+| GlobalDataFlow.cs:167:20:167:27 | this access | GlobalDataFlow.cs:173:20:173:32 | this access |
+| GlobalDataFlow.cs:167:20:167:27 | this access | GlobalDataFlow.cs:173:20:173:32 | this access |
+| GlobalDataFlow.cs:167:20:167:27 | this access | GlobalDataFlow.cs:189:39:189:41 | this access |
+| GlobalDataFlow.cs:167:20:167:27 | this access | GlobalDataFlow.cs:189:39:189:41 | this access |
+| GlobalDataFlow.cs:167:20:167:27 | this access | GlobalDataFlow.cs:193:37:193:42 | this access |
+| GlobalDataFlow.cs:167:20:167:27 | this access | GlobalDataFlow.cs:193:37:193:42 | this access |
+| GlobalDataFlow.cs:167:20:167:27 | this access | GlobalDataFlow.cs:197:22:197:32 | this access |
+| GlobalDataFlow.cs:167:20:167:27 | this access | GlobalDataFlow.cs:197:22:197:32 | this access |
+| GlobalDataFlow.cs:167:20:167:27 | this access | GlobalDataFlow.cs:201:20:201:33 | this access |
+| GlobalDataFlow.cs:167:20:167:27 | this access | GlobalDataFlow.cs:201:20:201:33 | this access |
+| GlobalDataFlow.cs:167:20:167:27 | this access | GlobalDataFlow.cs:338:12:338:17 | this |
+| GlobalDataFlow.cs:167:20:167:27 | this access | GlobalDataFlow.cs:338:12:338:17 | this |
 | GlobalDataFlow.cs:168:9:168:23 | call to method Check | GlobalDataFlow.cs:168:9:168:23 | call to method Check |
 | GlobalDataFlow.cs:168:15:168:22 | access to local variable nonSink0 | GlobalDataFlow.cs:168:15:168:22 | access to local variable nonSink0 |
-| GlobalDataFlow.cs:169:9:169:40 | ... = ... | GlobalDataFlow.cs:169:9:169:40 | ... = ... |
-| GlobalDataFlow.cs:169:9:169:40 | SSA def(nonSink0) | GlobalDataFlow.cs:169:9:169:40 | SSA def(nonSink0) |
-| GlobalDataFlow.cs:169:9:169:40 | SSA def(nonSink0) | GlobalDataFlow.cs:170:15:170:22 | access to local variable nonSink0 |
-| GlobalDataFlow.cs:169:9:169:40 | SSA def(nonSink0) | GlobalDataFlow.cs:170:15:170:22 | access to local variable nonSink0 |
-| GlobalDataFlow.cs:169:9:169:40 | SSA def(nonSink0) | GlobalDataFlow.cs:171:36:171:43 | access to local variable nonSink0 |
-| GlobalDataFlow.cs:169:9:169:40 | SSA def(nonSink0) | GlobalDataFlow.cs:171:36:171:43 | access to local variable nonSink0 |
-| GlobalDataFlow.cs:169:20:169:32 | call to method NonOutYield | GlobalDataFlow.cs:169:20:169:32 | call to method NonOutYield |
-| GlobalDataFlow.cs:169:20:169:32 | this access | GlobalDataFlow.cs:169:20:169:32 | this access |
-| GlobalDataFlow.cs:169:20:169:32 | this access | GlobalDataFlow.cs:185:39:185:41 | this access |
-| GlobalDataFlow.cs:169:20:169:32 | this access | GlobalDataFlow.cs:185:39:185:41 | this access |
-| GlobalDataFlow.cs:169:20:169:32 | this access | GlobalDataFlow.cs:189:37:189:42 | this access |
-| GlobalDataFlow.cs:169:20:169:32 | this access | GlobalDataFlow.cs:189:37:189:42 | this access |
-| GlobalDataFlow.cs:169:20:169:32 | this access | GlobalDataFlow.cs:193:22:193:32 | this access |
-| GlobalDataFlow.cs:169:20:169:32 | this access | GlobalDataFlow.cs:193:22:193:32 | this access |
-| GlobalDataFlow.cs:169:20:169:32 | this access | GlobalDataFlow.cs:197:20:197:33 | this access |
-| GlobalDataFlow.cs:169:20:169:32 | this access | GlobalDataFlow.cs:197:20:197:33 | this access |
-| GlobalDataFlow.cs:169:20:169:32 | this access | GlobalDataFlow.cs:348:25:348:35 | this |
-| GlobalDataFlow.cs:169:20:169:32 | this access | GlobalDataFlow.cs:348:25:348:35 | this |
-| GlobalDataFlow.cs:169:20:169:40 | call to method First | GlobalDataFlow.cs:169:9:169:40 | SSA def(nonSink0) |
-| GlobalDataFlow.cs:169:20:169:40 | call to method First | GlobalDataFlow.cs:169:9:169:40 | SSA def(nonSink0) |
-| GlobalDataFlow.cs:169:20:169:40 | call to method First | GlobalDataFlow.cs:169:20:169:40 | call to method First |
-| GlobalDataFlow.cs:169:20:169:40 | call to method First | GlobalDataFlow.cs:170:15:170:22 | access to local variable nonSink0 |
-| GlobalDataFlow.cs:169:20:169:40 | call to method First | GlobalDataFlow.cs:170:15:170:22 | access to local variable nonSink0 |
-| GlobalDataFlow.cs:169:20:169:40 | call to method First | GlobalDataFlow.cs:171:36:171:43 | access to local variable nonSink0 |
-| GlobalDataFlow.cs:169:20:169:40 | call to method First | GlobalDataFlow.cs:171:36:171:43 | access to local variable nonSink0 |
+| GlobalDataFlow.cs:169:9:169:31 | call to method NonOutOut | GlobalDataFlow.cs:169:9:169:31 | call to method NonOutOut |
+| GlobalDataFlow.cs:169:9:169:31 | this access | GlobalDataFlow.cs:169:9:169:31 | this access |
+| GlobalDataFlow.cs:169:9:169:31 | this access | GlobalDataFlow.cs:171:9:171:31 | this access |
+| GlobalDataFlow.cs:169:9:169:31 | this access | GlobalDataFlow.cs:171:9:171:31 | this access |
+| GlobalDataFlow.cs:169:9:169:31 | this access | GlobalDataFlow.cs:173:20:173:32 | this access |
+| GlobalDataFlow.cs:169:9:169:31 | this access | GlobalDataFlow.cs:173:20:173:32 | this access |
+| GlobalDataFlow.cs:169:9:169:31 | this access | GlobalDataFlow.cs:189:39:189:41 | this access |
+| GlobalDataFlow.cs:169:9:169:31 | this access | GlobalDataFlow.cs:189:39:189:41 | this access |
+| GlobalDataFlow.cs:169:9:169:31 | this access | GlobalDataFlow.cs:193:37:193:42 | this access |
+| GlobalDataFlow.cs:169:9:169:31 | this access | GlobalDataFlow.cs:193:37:193:42 | this access |
+| GlobalDataFlow.cs:169:9:169:31 | this access | GlobalDataFlow.cs:197:22:197:32 | this access |
+| GlobalDataFlow.cs:169:9:169:31 | this access | GlobalDataFlow.cs:197:22:197:32 | this access |
+| GlobalDataFlow.cs:169:9:169:31 | this access | GlobalDataFlow.cs:201:20:201:33 | this access |
+| GlobalDataFlow.cs:169:9:169:31 | this access | GlobalDataFlow.cs:201:20:201:33 | this access |
+| GlobalDataFlow.cs:169:9:169:31 | this access | GlobalDataFlow.cs:343:10:343:18 | this |
+| GlobalDataFlow.cs:169:9:169:31 | this access | GlobalDataFlow.cs:343:10:343:18 | this |
+| GlobalDataFlow.cs:169:23:169:30 | SSA def(nonSink0) | GlobalDataFlow.cs:169:23:169:30 | SSA def(nonSink0) |
+| GlobalDataFlow.cs:169:23:169:30 | SSA def(nonSink0) | GlobalDataFlow.cs:170:15:170:22 | access to local variable nonSink0 |
+| GlobalDataFlow.cs:169:23:169:30 | SSA def(nonSink0) | GlobalDataFlow.cs:170:15:170:22 | access to local variable nonSink0 |
+| GlobalDataFlow.cs:169:23:169:30 | SSA def(nonSink0) | GlobalDataFlow.cs:171:23:171:30 | access to local variable nonSink0 |
+| GlobalDataFlow.cs:169:23:169:30 | SSA def(nonSink0) | GlobalDataFlow.cs:171:23:171:30 | access to local variable nonSink0 |
 | GlobalDataFlow.cs:170:9:170:23 | call to method Check | GlobalDataFlow.cs:170:9:170:23 | call to method Check |
 | GlobalDataFlow.cs:170:15:170:22 | access to local variable nonSink0 | GlobalDataFlow.cs:170:15:170:22 | access to local variable nonSink0 |
-| GlobalDataFlow.cs:170:15:170:22 | access to local variable nonSink0 | GlobalDataFlow.cs:171:36:171:43 | access to local variable nonSink0 |
-| GlobalDataFlow.cs:170:15:170:22 | access to local variable nonSink0 | GlobalDataFlow.cs:171:36:171:43 | access to local variable nonSink0 |
-| GlobalDataFlow.cs:171:9:171:44 | ... = ... | GlobalDataFlow.cs:171:9:171:44 | ... = ... |
-| GlobalDataFlow.cs:171:9:171:44 | SSA def(nonSink0) | GlobalDataFlow.cs:171:9:171:44 | SSA def(nonSink0) |
-| GlobalDataFlow.cs:171:9:171:44 | SSA def(nonSink0) | GlobalDataFlow.cs:172:15:172:22 | access to local variable nonSink0 |
-| GlobalDataFlow.cs:171:9:171:44 | SSA def(nonSink0) | GlobalDataFlow.cs:172:15:172:22 | access to local variable nonSink0 |
-| GlobalDataFlow.cs:171:20:171:44 | call to method NonTaintedParam | GlobalDataFlow.cs:171:9:171:44 | SSA def(nonSink0) |
-| GlobalDataFlow.cs:171:20:171:44 | call to method NonTaintedParam | GlobalDataFlow.cs:171:9:171:44 | SSA def(nonSink0) |
-| GlobalDataFlow.cs:171:20:171:44 | call to method NonTaintedParam | GlobalDataFlow.cs:171:20:171:44 | call to method NonTaintedParam |
-| GlobalDataFlow.cs:171:20:171:44 | call to method NonTaintedParam | GlobalDataFlow.cs:172:15:172:22 | access to local variable nonSink0 |
-| GlobalDataFlow.cs:171:20:171:44 | call to method NonTaintedParam | GlobalDataFlow.cs:172:15:172:22 | access to local variable nonSink0 |
-| GlobalDataFlow.cs:171:36:171:43 | access to local variable nonSink0 | GlobalDataFlow.cs:171:20:171:44 | call to method NonTaintedParam |
-| GlobalDataFlow.cs:171:36:171:43 | access to local variable nonSink0 | GlobalDataFlow.cs:171:20:171:44 | call to method NonTaintedParam |
-| GlobalDataFlow.cs:171:36:171:43 | access to local variable nonSink0 | GlobalDataFlow.cs:171:36:171:43 | access to local variable nonSink0 |
-| GlobalDataFlow.cs:171:36:171:43 | access to local variable nonSink0 | GlobalDataFlow.cs:380:42:380:51 | nonTainted |
-| GlobalDataFlow.cs:171:36:171:43 | access to local variable nonSink0 | GlobalDataFlow.cs:380:42:380:51 | nonTainted |
+| GlobalDataFlow.cs:170:15:170:22 | access to local variable nonSink0 | GlobalDataFlow.cs:171:23:171:30 | access to local variable nonSink0 |
+| GlobalDataFlow.cs:170:15:170:22 | access to local variable nonSink0 | GlobalDataFlow.cs:171:23:171:30 | access to local variable nonSink0 |
+| GlobalDataFlow.cs:171:9:171:31 | call to method NonOutRef | GlobalDataFlow.cs:171:9:171:31 | call to method NonOutRef |
+| GlobalDataFlow.cs:171:9:171:31 | this access | GlobalDataFlow.cs:171:9:171:31 | this access |
+| GlobalDataFlow.cs:171:9:171:31 | this access | GlobalDataFlow.cs:173:20:173:32 | this access |
+| GlobalDataFlow.cs:171:9:171:31 | this access | GlobalDataFlow.cs:173:20:173:32 | this access |
+| GlobalDataFlow.cs:171:9:171:31 | this access | GlobalDataFlow.cs:189:39:189:41 | this access |
+| GlobalDataFlow.cs:171:9:171:31 | this access | GlobalDataFlow.cs:189:39:189:41 | this access |
+| GlobalDataFlow.cs:171:9:171:31 | this access | GlobalDataFlow.cs:193:37:193:42 | this access |
+| GlobalDataFlow.cs:171:9:171:31 | this access | GlobalDataFlow.cs:193:37:193:42 | this access |
+| GlobalDataFlow.cs:171:9:171:31 | this access | GlobalDataFlow.cs:197:22:197:32 | this access |
+| GlobalDataFlow.cs:171:9:171:31 | this access | GlobalDataFlow.cs:197:22:197:32 | this access |
+| GlobalDataFlow.cs:171:9:171:31 | this access | GlobalDataFlow.cs:201:20:201:33 | this access |
+| GlobalDataFlow.cs:171:9:171:31 | this access | GlobalDataFlow.cs:201:20:201:33 | this access |
+| GlobalDataFlow.cs:171:9:171:31 | this access | GlobalDataFlow.cs:348:10:348:18 | this |
+| GlobalDataFlow.cs:171:9:171:31 | this access | GlobalDataFlow.cs:348:10:348:18 | this |
+| GlobalDataFlow.cs:171:23:171:30 | SSA def(nonSink0) | GlobalDataFlow.cs:171:23:171:30 | SSA def(nonSink0) |
+| GlobalDataFlow.cs:171:23:171:30 | SSA def(nonSink0) | GlobalDataFlow.cs:172:15:172:22 | access to local variable nonSink0 |
+| GlobalDataFlow.cs:171:23:171:30 | SSA def(nonSink0) | GlobalDataFlow.cs:172:15:172:22 | access to local variable nonSink0 |
+| GlobalDataFlow.cs:171:23:171:30 | access to local variable nonSink0 | GlobalDataFlow.cs:171:23:171:30 | access to local variable nonSink0 |
 | GlobalDataFlow.cs:172:9:172:23 | call to method Check | GlobalDataFlow.cs:172:9:172:23 | call to method Check |
 | GlobalDataFlow.cs:172:15:172:22 | access to local variable nonSink0 | GlobalDataFlow.cs:172:15:172:22 | access to local variable nonSink0 |
-| GlobalDataFlow.cs:175:22:175:48 | Func<String> out = ... | GlobalDataFlow.cs:175:22:175:48 | Func<String> out = ... |
-| GlobalDataFlow.cs:175:22:175:48 | SSA def(out) | GlobalDataFlow.cs:175:22:175:48 | SSA def(out) |
-| GlobalDataFlow.cs:175:22:175:48 | SSA def(out) | GlobalDataFlow.cs:176:21:176:24 | access to local variable out |
-| GlobalDataFlow.cs:175:22:175:48 | SSA def(out) | GlobalDataFlow.cs:176:21:176:24 | access to local variable out |
-| GlobalDataFlow.cs:175:29:175:48 | (...) => ... | GlobalDataFlow.cs:175:22:175:48 | SSA def(out) |
-| GlobalDataFlow.cs:175:29:175:48 | (...) => ... | GlobalDataFlow.cs:175:22:175:48 | SSA def(out) |
-| GlobalDataFlow.cs:175:29:175:48 | (...) => ... | GlobalDataFlow.cs:175:29:175:48 | (...) => ... |
-| GlobalDataFlow.cs:175:29:175:48 | (...) => ... | GlobalDataFlow.cs:176:21:176:24 | access to local variable out |
-| GlobalDataFlow.cs:175:29:175:48 | (...) => ... | GlobalDataFlow.cs:176:21:176:24 | access to local variable out |
-| GlobalDataFlow.cs:175:35:175:48 | "taint source" | GlobalDataFlow.cs:175:35:175:48 | "taint source" |
-| GlobalDataFlow.cs:175:35:175:48 | "taint source" | GlobalDataFlow.cs:176:21:176:26 | delegate call |
-| GlobalDataFlow.cs:175:35:175:48 | "taint source" | GlobalDataFlow.cs:176:21:176:26 | delegate call |
-| GlobalDataFlow.cs:176:13:176:26 | SSA def(sink9) | GlobalDataFlow.cs:176:13:176:26 | SSA def(sink9) |
-| GlobalDataFlow.cs:176:13:176:26 | SSA def(sink9) | GlobalDataFlow.cs:177:15:177:19 | access to local variable sink9 |
-| GlobalDataFlow.cs:176:13:176:26 | SSA def(sink9) | GlobalDataFlow.cs:177:15:177:19 | access to local variable sink9 |
-| GlobalDataFlow.cs:176:13:176:26 | String sink9 = ... | GlobalDataFlow.cs:176:13:176:26 | String sink9 = ... |
-| GlobalDataFlow.cs:176:21:176:24 | access to local variable out | GlobalDataFlow.cs:176:21:176:24 | access to local variable out |
-| GlobalDataFlow.cs:176:21:176:26 | delegate call | GlobalDataFlow.cs:176:13:176:26 | SSA def(sink9) |
-| GlobalDataFlow.cs:176:21:176:26 | delegate call | GlobalDataFlow.cs:176:13:176:26 | SSA def(sink9) |
-| GlobalDataFlow.cs:176:21:176:26 | delegate call | GlobalDataFlow.cs:176:21:176:26 | delegate call |
-| GlobalDataFlow.cs:176:21:176:26 | delegate call | GlobalDataFlow.cs:177:15:177:19 | access to local variable sink9 |
-| GlobalDataFlow.cs:176:21:176:26 | delegate call | GlobalDataFlow.cs:177:15:177:19 | access to local variable sink9 |
-| GlobalDataFlow.cs:177:9:177:20 | call to method Check | GlobalDataFlow.cs:177:9:177:20 | call to method Check |
-| GlobalDataFlow.cs:177:15:177:19 | access to local variable sink9 | GlobalDataFlow.cs:177:15:177:19 | access to local variable sink9 |
-| GlobalDataFlow.cs:180:22:180:38 | Func<String> nonOut = ... | GlobalDataFlow.cs:180:22:180:38 | Func<String> nonOut = ... |
-| GlobalDataFlow.cs:180:22:180:38 | SSA def(nonOut) | GlobalDataFlow.cs:180:22:180:38 | SSA def(nonOut) |
-| GlobalDataFlow.cs:180:22:180:38 | SSA def(nonOut) | GlobalDataFlow.cs:181:20:181:25 | access to local variable nonOut |
-| GlobalDataFlow.cs:180:22:180:38 | SSA def(nonOut) | GlobalDataFlow.cs:181:20:181:25 | access to local variable nonOut |
-| GlobalDataFlow.cs:180:31:180:38 | (...) => ... | GlobalDataFlow.cs:180:22:180:38 | SSA def(nonOut) |
-| GlobalDataFlow.cs:180:31:180:38 | (...) => ... | GlobalDataFlow.cs:180:22:180:38 | SSA def(nonOut) |
-| GlobalDataFlow.cs:180:31:180:38 | (...) => ... | GlobalDataFlow.cs:180:31:180:38 | (...) => ... |
-| GlobalDataFlow.cs:180:31:180:38 | (...) => ... | GlobalDataFlow.cs:181:20:181:25 | access to local variable nonOut |
-| GlobalDataFlow.cs:180:31:180:38 | (...) => ... | GlobalDataFlow.cs:181:20:181:25 | access to local variable nonOut |
-| GlobalDataFlow.cs:180:37:180:38 | "" | GlobalDataFlow.cs:180:37:180:38 | "" |
-| GlobalDataFlow.cs:180:37:180:38 | "" | GlobalDataFlow.cs:181:20:181:27 | delegate call |
-| GlobalDataFlow.cs:180:37:180:38 | "" | GlobalDataFlow.cs:181:20:181:27 | delegate call |
-| GlobalDataFlow.cs:181:9:181:27 | ... = ... | GlobalDataFlow.cs:181:9:181:27 | ... = ... |
-| GlobalDataFlow.cs:181:9:181:27 | SSA def(nonSink0) | GlobalDataFlow.cs:181:9:181:27 | SSA def(nonSink0) |
-| GlobalDataFlow.cs:181:9:181:27 | SSA def(nonSink0) | GlobalDataFlow.cs:182:15:182:22 | access to local variable nonSink0 |
-| GlobalDataFlow.cs:181:9:181:27 | SSA def(nonSink0) | GlobalDataFlow.cs:182:15:182:22 | access to local variable nonSink0 |
-| GlobalDataFlow.cs:181:20:181:25 | access to local variable nonOut | GlobalDataFlow.cs:181:20:181:25 | access to local variable nonOut |
-| GlobalDataFlow.cs:181:20:181:27 | delegate call | GlobalDataFlow.cs:181:9:181:27 | SSA def(nonSink0) |
-| GlobalDataFlow.cs:181:20:181:27 | delegate call | GlobalDataFlow.cs:181:9:181:27 | SSA def(nonSink0) |
-| GlobalDataFlow.cs:181:20:181:27 | delegate call | GlobalDataFlow.cs:181:20:181:27 | delegate call |
-| GlobalDataFlow.cs:181:20:181:27 | delegate call | GlobalDataFlow.cs:182:15:182:22 | access to local variable nonSink0 |
-| GlobalDataFlow.cs:181:20:181:27 | delegate call | GlobalDataFlow.cs:182:15:182:22 | access to local variable nonSink0 |
-| GlobalDataFlow.cs:182:9:182:23 | call to method Check | GlobalDataFlow.cs:182:9:182:23 | call to method Check |
-| GlobalDataFlow.cs:182:15:182:22 | access to local variable nonSink0 | GlobalDataFlow.cs:182:15:182:22 | access to local variable nonSink0 |
-| GlobalDataFlow.cs:185:13:185:48 | SSA def(sink10) | GlobalDataFlow.cs:185:13:185:48 | SSA def(sink10) |
-| GlobalDataFlow.cs:185:13:185:48 | SSA def(sink10) | GlobalDataFlow.cs:186:15:186:20 | access to local variable sink10 |
-| GlobalDataFlow.cs:185:13:185:48 | SSA def(sink10) | GlobalDataFlow.cs:186:15:186:20 | access to local variable sink10 |
-| GlobalDataFlow.cs:185:13:185:48 | String sink10 = ... | GlobalDataFlow.cs:185:13:185:48 | String sink10 = ... |
-| GlobalDataFlow.cs:185:22:185:42 | malloc | GlobalDataFlow.cs:185:22:185:42 | malloc |
-| GlobalDataFlow.cs:185:22:185:42 | object creation of type Lazy<String> | GlobalDataFlow.cs:185:13:185:48 | SSA def(sink10) |
-| GlobalDataFlow.cs:185:22:185:42 | object creation of type Lazy<String> | GlobalDataFlow.cs:185:13:185:48 | SSA def(sink10) |
-| GlobalDataFlow.cs:185:22:185:42 | object creation of type Lazy<String> | GlobalDataFlow.cs:185:22:185:42 | object creation of type Lazy<String> |
-| GlobalDataFlow.cs:185:22:185:42 | object creation of type Lazy<String> | GlobalDataFlow.cs:185:22:185:48 | access to property Value |
-| GlobalDataFlow.cs:185:22:185:42 | object creation of type Lazy<String> | GlobalDataFlow.cs:185:22:185:48 | access to property Value |
-| GlobalDataFlow.cs:185:22:185:42 | object creation of type Lazy<String> | GlobalDataFlow.cs:186:15:186:20 | access to local variable sink10 |
-| GlobalDataFlow.cs:185:22:185:42 | object creation of type Lazy<String> | GlobalDataFlow.cs:186:15:186:20 | access to local variable sink10 |
-| GlobalDataFlow.cs:185:22:185:48 | access to property Value | GlobalDataFlow.cs:185:13:185:48 | SSA def(sink10) |
-| GlobalDataFlow.cs:185:22:185:48 | access to property Value | GlobalDataFlow.cs:185:13:185:48 | SSA def(sink10) |
-| GlobalDataFlow.cs:185:22:185:48 | access to property Value | GlobalDataFlow.cs:185:22:185:48 | access to property Value |
-| GlobalDataFlow.cs:185:22:185:48 | access to property Value | GlobalDataFlow.cs:186:15:186:20 | access to local variable sink10 |
-| GlobalDataFlow.cs:185:22:185:48 | access to property Value | GlobalDataFlow.cs:186:15:186:20 | access to local variable sink10 |
-| GlobalDataFlow.cs:185:39:185:41 | [output] delegate creation of type Func<String> | GlobalDataFlow.cs:185:13:185:48 | SSA def(sink10) |
-| GlobalDataFlow.cs:185:39:185:41 | [output] delegate creation of type Func<String> | GlobalDataFlow.cs:185:13:185:48 | SSA def(sink10) |
-| GlobalDataFlow.cs:185:39:185:41 | [output] delegate creation of type Func<String> | GlobalDataFlow.cs:185:22:185:42 | object creation of type Lazy<String> |
-| GlobalDataFlow.cs:185:39:185:41 | [output] delegate creation of type Func<String> | GlobalDataFlow.cs:185:22:185:42 | object creation of type Lazy<String> |
-| GlobalDataFlow.cs:185:39:185:41 | [output] delegate creation of type Func<String> | GlobalDataFlow.cs:185:22:185:48 | access to property Value |
-| GlobalDataFlow.cs:185:39:185:41 | [output] delegate creation of type Func<String> | GlobalDataFlow.cs:185:22:185:48 | access to property Value |
-| GlobalDataFlow.cs:185:39:185:41 | [output] delegate creation of type Func<String> | GlobalDataFlow.cs:185:39:185:41 | [output] delegate creation of type Func<String> |
-| GlobalDataFlow.cs:185:39:185:41 | [output] delegate creation of type Func<String> | GlobalDataFlow.cs:186:15:186:20 | access to local variable sink10 |
-| GlobalDataFlow.cs:185:39:185:41 | [output] delegate creation of type Func<String> | GlobalDataFlow.cs:186:15:186:20 | access to local variable sink10 |
-| GlobalDataFlow.cs:185:39:185:41 | access to method Out | GlobalDataFlow.cs:185:39:185:41 | access to method Out |
-| GlobalDataFlow.cs:185:39:185:41 | delegate creation of type Func<String> | GlobalDataFlow.cs:185:39:185:41 | delegate creation of type Func<String> |
-| GlobalDataFlow.cs:185:39:185:41 | this access | GlobalDataFlow.cs:185:39:185:41 | this access |
-| GlobalDataFlow.cs:185:39:185:41 | this access | GlobalDataFlow.cs:189:37:189:42 | this access |
-| GlobalDataFlow.cs:185:39:185:41 | this access | GlobalDataFlow.cs:189:37:189:42 | this access |
-| GlobalDataFlow.cs:185:39:185:41 | this access | GlobalDataFlow.cs:193:22:193:32 | this access |
-| GlobalDataFlow.cs:185:39:185:41 | this access | GlobalDataFlow.cs:193:22:193:32 | this access |
-| GlobalDataFlow.cs:185:39:185:41 | this access | GlobalDataFlow.cs:197:20:197:33 | this access |
-| GlobalDataFlow.cs:185:39:185:41 | this access | GlobalDataFlow.cs:197:20:197:33 | this access |
-| GlobalDataFlow.cs:186:9:186:21 | call to method Check | GlobalDataFlow.cs:186:9:186:21 | call to method Check |
-| GlobalDataFlow.cs:186:15:186:20 | access to local variable sink10 | GlobalDataFlow.cs:186:15:186:20 | access to local variable sink10 |
-| GlobalDataFlow.cs:189:9:189:49 | ... = ... | GlobalDataFlow.cs:189:9:189:49 | ... = ... |
-| GlobalDataFlow.cs:189:9:189:49 | SSA def(nonSink0) | GlobalDataFlow.cs:189:9:189:49 | SSA def(nonSink0) |
-| GlobalDataFlow.cs:189:9:189:49 | SSA def(nonSink0) | GlobalDataFlow.cs:190:15:190:22 | access to local variable nonSink0 |
-| GlobalDataFlow.cs:189:9:189:49 | SSA def(nonSink0) | GlobalDataFlow.cs:190:15:190:22 | access to local variable nonSink0 |
-| GlobalDataFlow.cs:189:20:189:43 | malloc | GlobalDataFlow.cs:189:20:189:43 | malloc |
-| GlobalDataFlow.cs:189:20:189:43 | object creation of type Lazy<String> | GlobalDataFlow.cs:189:9:189:49 | SSA def(nonSink0) |
-| GlobalDataFlow.cs:189:20:189:43 | object creation of type Lazy<String> | GlobalDataFlow.cs:189:9:189:49 | SSA def(nonSink0) |
-| GlobalDataFlow.cs:189:20:189:43 | object creation of type Lazy<String> | GlobalDataFlow.cs:189:20:189:43 | object creation of type Lazy<String> |
-| GlobalDataFlow.cs:189:20:189:43 | object creation of type Lazy<String> | GlobalDataFlow.cs:189:20:189:49 | access to property Value |
-| GlobalDataFlow.cs:189:20:189:43 | object creation of type Lazy<String> | GlobalDataFlow.cs:189:20:189:49 | access to property Value |
-| GlobalDataFlow.cs:189:20:189:43 | object creation of type Lazy<String> | GlobalDataFlow.cs:190:15:190:22 | access to local variable nonSink0 |
-| GlobalDataFlow.cs:189:20:189:43 | object creation of type Lazy<String> | GlobalDataFlow.cs:190:15:190:22 | access to local variable nonSink0 |
-| GlobalDataFlow.cs:189:20:189:49 | access to property Value | GlobalDataFlow.cs:189:9:189:49 | SSA def(nonSink0) |
-| GlobalDataFlow.cs:189:20:189:49 | access to property Value | GlobalDataFlow.cs:189:9:189:49 | SSA def(nonSink0) |
-| GlobalDataFlow.cs:189:20:189:49 | access to property Value | GlobalDataFlow.cs:189:20:189:49 | access to property Value |
-| GlobalDataFlow.cs:189:20:189:49 | access to property Value | GlobalDataFlow.cs:190:15:190:22 | access to local variable nonSink0 |
-| GlobalDataFlow.cs:189:20:189:49 | access to property Value | GlobalDataFlow.cs:190:15:190:22 | access to local variable nonSink0 |
-| GlobalDataFlow.cs:189:37:189:42 | [output] delegate creation of type Func<String> | GlobalDataFlow.cs:189:9:189:49 | SSA def(nonSink0) |
-| GlobalDataFlow.cs:189:37:189:42 | [output] delegate creation of type Func<String> | GlobalDataFlow.cs:189:9:189:49 | SSA def(nonSink0) |
-| GlobalDataFlow.cs:189:37:189:42 | [output] delegate creation of type Func<String> | GlobalDataFlow.cs:189:20:189:43 | object creation of type Lazy<String> |
-| GlobalDataFlow.cs:189:37:189:42 | [output] delegate creation of type Func<String> | GlobalDataFlow.cs:189:20:189:43 | object creation of type Lazy<String> |
-| GlobalDataFlow.cs:189:37:189:42 | [output] delegate creation of type Func<String> | GlobalDataFlow.cs:189:20:189:49 | access to property Value |
-| GlobalDataFlow.cs:189:37:189:42 | [output] delegate creation of type Func<String> | GlobalDataFlow.cs:189:20:189:49 | access to property Value |
-| GlobalDataFlow.cs:189:37:189:42 | [output] delegate creation of type Func<String> | GlobalDataFlow.cs:189:37:189:42 | [output] delegate creation of type Func<String> |
-| GlobalDataFlow.cs:189:37:189:42 | [output] delegate creation of type Func<String> | GlobalDataFlow.cs:190:15:190:22 | access to local variable nonSink0 |
-| GlobalDataFlow.cs:189:37:189:42 | [output] delegate creation of type Func<String> | GlobalDataFlow.cs:190:15:190:22 | access to local variable nonSink0 |
-| GlobalDataFlow.cs:189:37:189:42 | access to method NonOut | GlobalDataFlow.cs:189:37:189:42 | access to method NonOut |
-| GlobalDataFlow.cs:189:37:189:42 | delegate creation of type Func<String> | GlobalDataFlow.cs:189:37:189:42 | delegate creation of type Func<String> |
-| GlobalDataFlow.cs:189:37:189:42 | this access | GlobalDataFlow.cs:189:37:189:42 | this access |
-| GlobalDataFlow.cs:189:37:189:42 | this access | GlobalDataFlow.cs:193:22:193:32 | this access |
-| GlobalDataFlow.cs:189:37:189:42 | this access | GlobalDataFlow.cs:193:22:193:32 | this access |
-| GlobalDataFlow.cs:189:37:189:42 | this access | GlobalDataFlow.cs:197:20:197:33 | this access |
-| GlobalDataFlow.cs:189:37:189:42 | this access | GlobalDataFlow.cs:197:20:197:33 | this access |
-| GlobalDataFlow.cs:190:9:190:23 | call to method Check | GlobalDataFlow.cs:190:9:190:23 | call to method Check |
-| GlobalDataFlow.cs:190:15:190:22 | access to local variable nonSink0 | GlobalDataFlow.cs:190:15:190:22 | access to local variable nonSink0 |
-| GlobalDataFlow.cs:193:13:193:32 | SSA def(sink19) | GlobalDataFlow.cs:193:13:193:32 | SSA def(sink19) |
-| GlobalDataFlow.cs:193:13:193:32 | SSA def(sink19) | GlobalDataFlow.cs:194:15:194:20 | access to local variable sink19 |
-| GlobalDataFlow.cs:193:13:193:32 | SSA def(sink19) | GlobalDataFlow.cs:194:15:194:20 | access to local variable sink19 |
-| GlobalDataFlow.cs:193:13:193:32 | String sink19 = ... | GlobalDataFlow.cs:193:13:193:32 | String sink19 = ... |
-| GlobalDataFlow.cs:193:22:193:32 | SSA untracked def(this.OutProperty) | GlobalDataFlow.cs:193:22:193:32 | SSA untracked def(this.OutProperty) |
-| GlobalDataFlow.cs:193:22:193:32 | access to property OutProperty | GlobalDataFlow.cs:193:13:193:32 | SSA def(sink19) |
-| GlobalDataFlow.cs:193:22:193:32 | access to property OutProperty | GlobalDataFlow.cs:193:13:193:32 | SSA def(sink19) |
-| GlobalDataFlow.cs:193:22:193:32 | access to property OutProperty | GlobalDataFlow.cs:193:22:193:32 | access to property OutProperty |
-| GlobalDataFlow.cs:193:22:193:32 | access to property OutProperty | GlobalDataFlow.cs:194:15:194:20 | access to local variable sink19 |
-| GlobalDataFlow.cs:193:22:193:32 | access to property OutProperty | GlobalDataFlow.cs:194:15:194:20 | access to local variable sink19 |
-| GlobalDataFlow.cs:193:22:193:32 | this access | GlobalDataFlow.cs:193:22:193:32 | this access |
-| GlobalDataFlow.cs:193:22:193:32 | this access | GlobalDataFlow.cs:197:20:197:33 | this access |
-| GlobalDataFlow.cs:193:22:193:32 | this access | GlobalDataFlow.cs:197:20:197:33 | this access |
-| GlobalDataFlow.cs:193:22:193:32 | this access | GlobalDataFlow.cs:410:9:410:11 | this |
-| GlobalDataFlow.cs:193:22:193:32 | this access | GlobalDataFlow.cs:410:9:410:11 | this |
-| GlobalDataFlow.cs:194:9:194:21 | call to method Check | GlobalDataFlow.cs:194:9:194:21 | call to method Check |
-| GlobalDataFlow.cs:194:15:194:20 | access to local variable sink19 | GlobalDataFlow.cs:194:15:194:20 | access to local variable sink19 |
-| GlobalDataFlow.cs:197:9:197:33 | ... = ... | GlobalDataFlow.cs:197:9:197:33 | ... = ... |
-| GlobalDataFlow.cs:197:9:197:33 | SSA def(nonSink0) | GlobalDataFlow.cs:197:9:197:33 | SSA def(nonSink0) |
-| GlobalDataFlow.cs:197:9:197:33 | SSA def(nonSink0) | GlobalDataFlow.cs:198:15:198:22 | access to local variable nonSink0 |
-| GlobalDataFlow.cs:197:9:197:33 | SSA def(nonSink0) | GlobalDataFlow.cs:198:15:198:22 | access to local variable nonSink0 |
-| GlobalDataFlow.cs:197:20:197:33 | SSA untracked def(this.NonOutProperty) | GlobalDataFlow.cs:197:20:197:33 | SSA untracked def(this.NonOutProperty) |
-| GlobalDataFlow.cs:197:20:197:33 | access to property NonOutProperty | GlobalDataFlow.cs:197:9:197:33 | SSA def(nonSink0) |
-| GlobalDataFlow.cs:197:20:197:33 | access to property NonOutProperty | GlobalDataFlow.cs:197:9:197:33 | SSA def(nonSink0) |
-| GlobalDataFlow.cs:197:20:197:33 | access to property NonOutProperty | GlobalDataFlow.cs:197:20:197:33 | access to property NonOutProperty |
-| GlobalDataFlow.cs:197:20:197:33 | access to property NonOutProperty | GlobalDataFlow.cs:198:15:198:22 | access to local variable nonSink0 |
-| GlobalDataFlow.cs:197:20:197:33 | access to property NonOutProperty | GlobalDataFlow.cs:198:15:198:22 | access to local variable nonSink0 |
-| GlobalDataFlow.cs:197:20:197:33 | this access | GlobalDataFlow.cs:197:20:197:33 | this access |
-| GlobalDataFlow.cs:197:20:197:33 | this access | GlobalDataFlow.cs:415:9:415:11 | this |
-| GlobalDataFlow.cs:197:20:197:33 | this access | GlobalDataFlow.cs:415:9:415:11 | this |
-| GlobalDataFlow.cs:198:9:198:23 | call to method Check | GlobalDataFlow.cs:198:9:198:23 | call to method Check |
-| GlobalDataFlow.cs:198:15:198:22 | access to local variable nonSink0 | GlobalDataFlow.cs:198:15:198:22 | access to local variable nonSink0 |
-| GlobalDataFlow.cs:201:17:201:18 | this | GlobalDataFlow.cs:201:17:201:18 | this |
-| GlobalDataFlow.cs:201:39:201:45 | tainted | GlobalDataFlow.cs:201:39:201:45 | tainted |
-| GlobalDataFlow.cs:201:39:201:45 | tainted | GlobalDataFlow.cs:201:39:201:45 | tainted |
-| GlobalDataFlow.cs:201:39:201:45 | tainted | GlobalDataFlow.cs:206:22:206:28 | access to parameter tainted |
-| GlobalDataFlow.cs:201:39:201:45 | tainted | GlobalDataFlow.cs:206:22:206:28 | access to parameter tainted |
-| GlobalDataFlow.cs:201:39:201:45 | tainted | GlobalDataFlow.cs:208:22:208:28 | access to parameter tainted |
-| GlobalDataFlow.cs:201:39:201:45 | tainted | GlobalDataFlow.cs:208:22:208:28 | access to parameter tainted |
-| GlobalDataFlow.cs:201:39:201:45 | tainted | GlobalDataFlow.cs:210:22:210:28 | access to parameter tainted |
-| GlobalDataFlow.cs:201:39:201:45 | tainted | GlobalDataFlow.cs:210:22:210:28 | access to parameter tainted |
-| GlobalDataFlow.cs:201:67:201:76 | notTainted | GlobalDataFlow.cs:201:67:201:76 | notTainted |
-| GlobalDataFlow.cs:201:67:201:76 | notTainted | GlobalDataFlow.cs:201:67:201:76 | notTainted |
-| GlobalDataFlow.cs:201:67:201:76 | notTainted | GlobalDataFlow.cs:216:23:216:32 | access to parameter notTainted |
-| GlobalDataFlow.cs:201:67:201:76 | notTainted | GlobalDataFlow.cs:216:23:216:32 | access to parameter notTainted |
-| GlobalDataFlow.cs:201:67:201:76 | notTainted | GlobalDataFlow.cs:218:19:218:28 | access to parameter notTainted |
-| GlobalDataFlow.cs:201:67:201:76 | notTainted | GlobalDataFlow.cs:218:19:218:28 | access to parameter notTainted |
-| GlobalDataFlow.cs:201:67:201:76 | notTainted | GlobalDataFlow.cs:220:19:220:28 | access to parameter notTainted |
-| GlobalDataFlow.cs:201:67:201:76 | notTainted | GlobalDataFlow.cs:220:19:220:28 | access to parameter notTainted |
-| GlobalDataFlow.cs:201:67:201:76 | notTainted | GlobalDataFlow.cs:222:19:222:28 | access to parameter notTainted |
-| GlobalDataFlow.cs:201:67:201:76 | notTainted | GlobalDataFlow.cs:222:19:222:28 | access to parameter notTainted |
-| GlobalDataFlow.cs:201:67:201:76 | notTainted | GlobalDataFlow.cs:224:19:224:28 | access to parameter notTainted |
-| GlobalDataFlow.cs:201:67:201:76 | notTainted | GlobalDataFlow.cs:224:19:224:28 | access to parameter notTainted |
-| GlobalDataFlow.cs:204:30:204:92 | Func<String,String> f1 = ... | GlobalDataFlow.cs:204:30:204:92 | Func<String,String> f1 = ... |
-| GlobalDataFlow.cs:204:30:204:92 | SSA def(f1) | GlobalDataFlow.cs:204:30:204:92 | SSA def(f1) |
-| GlobalDataFlow.cs:204:30:204:92 | SSA def(f1) | GlobalDataFlow.cs:206:37:206:38 | access to local variable f1 |
-| GlobalDataFlow.cs:204:30:204:92 | SSA def(f1) | GlobalDataFlow.cs:206:37:206:38 | access to local variable f1 |
-| GlobalDataFlow.cs:204:30:204:92 | SSA def(f1) | GlobalDataFlow.cs:216:41:216:42 | access to local variable f1 |
-| GlobalDataFlow.cs:204:30:204:92 | SSA def(f1) | GlobalDataFlow.cs:216:41:216:42 | access to local variable f1 |
-| GlobalDataFlow.cs:204:35:204:45 | sinkParam10 | GlobalDataFlow.cs:204:35:204:45 | sinkParam10 |
-| GlobalDataFlow.cs:204:35:204:45 | sinkParam10 | GlobalDataFlow.cs:204:35:204:45 | sinkParam10 |
-| GlobalDataFlow.cs:204:35:204:45 | sinkParam10 | GlobalDataFlow.cs:204:58:204:68 | access to parameter sinkParam10 |
-| GlobalDataFlow.cs:204:35:204:45 | sinkParam10 | GlobalDataFlow.cs:204:58:204:68 | access to parameter sinkParam10 |
-| GlobalDataFlow.cs:204:35:204:45 | sinkParam10 | GlobalDataFlow.cs:204:79:204:89 | access to parameter sinkParam10 |
-| GlobalDataFlow.cs:204:35:204:45 | sinkParam10 | GlobalDataFlow.cs:204:79:204:89 | access to parameter sinkParam10 |
-| GlobalDataFlow.cs:204:35:204:92 | (...) => ... | GlobalDataFlow.cs:204:30:204:92 | SSA def(f1) |
-| GlobalDataFlow.cs:204:35:204:92 | (...) => ... | GlobalDataFlow.cs:204:30:204:92 | SSA def(f1) |
-| GlobalDataFlow.cs:204:35:204:92 | (...) => ... | GlobalDataFlow.cs:204:35:204:92 | (...) => ... |
-| GlobalDataFlow.cs:204:35:204:92 | (...) => ... | GlobalDataFlow.cs:206:37:206:38 | access to local variable f1 |
-| GlobalDataFlow.cs:204:35:204:92 | (...) => ... | GlobalDataFlow.cs:206:37:206:38 | access to local variable f1 |
-| GlobalDataFlow.cs:204:35:204:92 | (...) => ... | GlobalDataFlow.cs:216:41:216:42 | access to local variable f1 |
-| GlobalDataFlow.cs:204:35:204:92 | (...) => ... | GlobalDataFlow.cs:216:41:216:42 | access to local variable f1 |
-| GlobalDataFlow.cs:204:52:204:69 | call to method Check | GlobalDataFlow.cs:204:52:204:69 | call to method Check |
-| GlobalDataFlow.cs:204:58:204:68 | access to parameter sinkParam10 | GlobalDataFlow.cs:204:58:204:68 | access to parameter sinkParam10 |
-| GlobalDataFlow.cs:204:58:204:68 | access to parameter sinkParam10 | GlobalDataFlow.cs:204:79:204:89 | access to parameter sinkParam10 |
-| GlobalDataFlow.cs:204:58:204:68 | access to parameter sinkParam10 | GlobalDataFlow.cs:204:79:204:89 | access to parameter sinkParam10 |
-| GlobalDataFlow.cs:204:79:204:89 | access to parameter sinkParam10 | GlobalDataFlow.cs:204:79:204:89 | access to parameter sinkParam10 |
-| GlobalDataFlow.cs:204:79:204:89 | access to parameter sinkParam10 | GlobalDataFlow.cs:206:37:206:38 | [output] access to local variable f1 |
-| GlobalDataFlow.cs:204:79:204:89 | access to parameter sinkParam10 | GlobalDataFlow.cs:206:37:206:38 | [output] access to local variable f1 |
-| GlobalDataFlow.cs:204:79:204:89 | access to parameter sinkParam10 | GlobalDataFlow.cs:216:41:216:42 | [output] access to local variable f1 |
-| GlobalDataFlow.cs:204:79:204:89 | access to parameter sinkParam10 | GlobalDataFlow.cs:216:41:216:42 | [output] access to local variable f1 |
-| GlobalDataFlow.cs:205:66:205:90 | Expression<Func<String,String>> f2 = ... | GlobalDataFlow.cs:205:66:205:90 | Expression<Func<String,String>> f2 = ... |
-| GlobalDataFlow.cs:205:66:205:90 | SSA def(f2) | GlobalDataFlow.cs:205:66:205:90 | SSA def(f2) |
-| GlobalDataFlow.cs:205:66:205:90 | SSA def(f2) | GlobalDataFlow.cs:208:37:208:38 | access to local variable f2 |
-| GlobalDataFlow.cs:205:66:205:90 | SSA def(f2) | GlobalDataFlow.cs:208:37:208:38 | access to local variable f2 |
-| GlobalDataFlow.cs:205:66:205:90 | SSA def(f2) | GlobalDataFlow.cs:218:37:218:38 | access to local variable f2 |
-| GlobalDataFlow.cs:205:66:205:90 | SSA def(f2) | GlobalDataFlow.cs:218:37:218:38 | access to local variable f2 |
-| GlobalDataFlow.cs:205:71:205:71 | x | GlobalDataFlow.cs:205:71:205:71 | x |
-| GlobalDataFlow.cs:205:71:205:71 | x | GlobalDataFlow.cs:205:71:205:71 | x |
-| GlobalDataFlow.cs:205:71:205:71 | x | GlobalDataFlow.cs:205:89:205:89 | access to parameter x |
-| GlobalDataFlow.cs:205:71:205:71 | x | GlobalDataFlow.cs:205:89:205:89 | access to parameter x |
-| GlobalDataFlow.cs:205:71:205:90 | (...) => ... | GlobalDataFlow.cs:205:66:205:90 | SSA def(f2) |
-| GlobalDataFlow.cs:205:71:205:90 | (...) => ... | GlobalDataFlow.cs:205:66:205:90 | SSA def(f2) |
-| GlobalDataFlow.cs:205:71:205:90 | (...) => ... | GlobalDataFlow.cs:205:71:205:90 | (...) => ... |
-| GlobalDataFlow.cs:205:71:205:90 | (...) => ... | GlobalDataFlow.cs:208:37:208:38 | access to local variable f2 |
-| GlobalDataFlow.cs:205:71:205:90 | (...) => ... | GlobalDataFlow.cs:208:37:208:38 | access to local variable f2 |
-| GlobalDataFlow.cs:205:71:205:90 | (...) => ... | GlobalDataFlow.cs:218:37:218:38 | access to local variable f2 |
-| GlobalDataFlow.cs:205:71:205:90 | (...) => ... | GlobalDataFlow.cs:218:37:218:38 | access to local variable f2 |
-| GlobalDataFlow.cs:205:76:205:90 | call to method ReturnCheck2 | GlobalDataFlow.cs:205:76:205:90 | call to method ReturnCheck2 |
-| GlobalDataFlow.cs:205:76:205:90 | call to method ReturnCheck2 | GlobalDataFlow.cs:208:37:208:38 | [output] access to local variable f2 |
-| GlobalDataFlow.cs:205:76:205:90 | call to method ReturnCheck2 | GlobalDataFlow.cs:208:37:208:38 | [output] access to local variable f2 |
-| GlobalDataFlow.cs:205:76:205:90 | call to method ReturnCheck2 | GlobalDataFlow.cs:218:37:218:38 | [output] access to local variable f2 |
-| GlobalDataFlow.cs:205:76:205:90 | call to method ReturnCheck2 | GlobalDataFlow.cs:218:37:218:38 | [output] access to local variable f2 |
-| GlobalDataFlow.cs:205:89:205:89 | access to parameter x | GlobalDataFlow.cs:205:76:205:90 | call to method ReturnCheck2 |
-| GlobalDataFlow.cs:205:89:205:89 | access to parameter x | GlobalDataFlow.cs:205:76:205:90 | call to method ReturnCheck2 |
-| GlobalDataFlow.cs:205:89:205:89 | access to parameter x | GlobalDataFlow.cs:205:89:205:89 | access to parameter x |
-| GlobalDataFlow.cs:205:89:205:89 | access to parameter x | GlobalDataFlow.cs:293:32:293:41 | sinkParam9 |
-| GlobalDataFlow.cs:205:89:205:89 | access to parameter x | GlobalDataFlow.cs:293:32:293:41 | sinkParam9 |
-| GlobalDataFlow.cs:206:13:206:39 | IEnumerable<String> sink24 = ... | GlobalDataFlow.cs:206:13:206:39 | IEnumerable<String> sink24 = ... |
-| GlobalDataFlow.cs:206:13:206:39 | SSA def(sink24) | GlobalDataFlow.cs:206:13:206:39 | SSA def(sink24) |
-| GlobalDataFlow.cs:206:13:206:39 | SSA def(sink24) | GlobalDataFlow.cs:207:15:207:20 | access to local variable sink24 |
-| GlobalDataFlow.cs:206:13:206:39 | SSA def(sink24) | GlobalDataFlow.cs:207:15:207:20 | access to local variable sink24 |
-| GlobalDataFlow.cs:206:22:206:28 | access to parameter tainted | GlobalDataFlow.cs:204:35:204:45 | sinkParam10 |
-| GlobalDataFlow.cs:206:22:206:28 | access to parameter tainted | GlobalDataFlow.cs:204:35:204:45 | sinkParam10 |
-| GlobalDataFlow.cs:206:22:206:28 | access to parameter tainted | GlobalDataFlow.cs:206:22:206:28 | access to parameter tainted |
-| GlobalDataFlow.cs:206:22:206:28 | access to parameter tainted | GlobalDataFlow.cs:208:22:208:28 | access to parameter tainted |
-| GlobalDataFlow.cs:206:22:206:28 | access to parameter tainted | GlobalDataFlow.cs:208:22:208:28 | access to parameter tainted |
-| GlobalDataFlow.cs:206:22:206:28 | access to parameter tainted | GlobalDataFlow.cs:210:22:210:28 | access to parameter tainted |
-| GlobalDataFlow.cs:206:22:206:28 | access to parameter tainted | GlobalDataFlow.cs:210:22:210:28 | access to parameter tainted |
-| GlobalDataFlow.cs:206:22:206:39 | call to method Select | GlobalDataFlow.cs:206:13:206:39 | SSA def(sink24) |
-| GlobalDataFlow.cs:206:22:206:39 | call to method Select | GlobalDataFlow.cs:206:13:206:39 | SSA def(sink24) |
-| GlobalDataFlow.cs:206:22:206:39 | call to method Select | GlobalDataFlow.cs:206:22:206:39 | call to method Select |
-| GlobalDataFlow.cs:206:22:206:39 | call to method Select | GlobalDataFlow.cs:207:15:207:20 | access to local variable sink24 |
-| GlobalDataFlow.cs:206:22:206:39 | call to method Select | GlobalDataFlow.cs:207:15:207:20 | access to local variable sink24 |
-| GlobalDataFlow.cs:206:37:206:38 | [output] access to local variable f1 | GlobalDataFlow.cs:206:37:206:38 | [output] access to local variable f1 |
-| GlobalDataFlow.cs:206:37:206:38 | access to local variable f1 | GlobalDataFlow.cs:206:37:206:38 | access to local variable f1 |
-| GlobalDataFlow.cs:206:37:206:38 | access to local variable f1 | GlobalDataFlow.cs:216:41:216:42 | access to local variable f1 |
-| GlobalDataFlow.cs:206:37:206:38 | access to local variable f1 | GlobalDataFlow.cs:216:41:216:42 | access to local variable f1 |
-| GlobalDataFlow.cs:207:9:207:21 | call to method Check | GlobalDataFlow.cs:207:9:207:21 | call to method Check |
-| GlobalDataFlow.cs:207:15:207:20 | access to local variable sink24 | GlobalDataFlow.cs:207:15:207:20 | access to local variable sink24 |
-| GlobalDataFlow.cs:208:13:208:39 | IQueryable<String> sink25 = ... | GlobalDataFlow.cs:208:13:208:39 | IQueryable<String> sink25 = ... |
-| GlobalDataFlow.cs:208:13:208:39 | SSA def(sink25) | GlobalDataFlow.cs:208:13:208:39 | SSA def(sink25) |
-| GlobalDataFlow.cs:208:13:208:39 | SSA def(sink25) | GlobalDataFlow.cs:209:15:209:20 | access to local variable sink25 |
-| GlobalDataFlow.cs:208:13:208:39 | SSA def(sink25) | GlobalDataFlow.cs:209:15:209:20 | access to local variable sink25 |
-| GlobalDataFlow.cs:208:22:208:28 | access to parameter tainted | GlobalDataFlow.cs:205:71:205:71 | x |
-| GlobalDataFlow.cs:208:22:208:28 | access to parameter tainted | GlobalDataFlow.cs:205:71:205:71 | x |
-| GlobalDataFlow.cs:208:22:208:28 | access to parameter tainted | GlobalDataFlow.cs:208:22:208:28 | access to parameter tainted |
-| GlobalDataFlow.cs:208:22:208:28 | access to parameter tainted | GlobalDataFlow.cs:210:22:210:28 | access to parameter tainted |
-| GlobalDataFlow.cs:208:22:208:28 | access to parameter tainted | GlobalDataFlow.cs:210:22:210:28 | access to parameter tainted |
-| GlobalDataFlow.cs:208:22:208:39 | call to method Select | GlobalDataFlow.cs:208:13:208:39 | SSA def(sink25) |
-| GlobalDataFlow.cs:208:22:208:39 | call to method Select | GlobalDataFlow.cs:208:13:208:39 | SSA def(sink25) |
-| GlobalDataFlow.cs:208:22:208:39 | call to method Select | GlobalDataFlow.cs:208:22:208:39 | call to method Select |
-| GlobalDataFlow.cs:208:22:208:39 | call to method Select | GlobalDataFlow.cs:209:15:209:20 | access to local variable sink25 |
-| GlobalDataFlow.cs:208:22:208:39 | call to method Select | GlobalDataFlow.cs:209:15:209:20 | access to local variable sink25 |
-| GlobalDataFlow.cs:208:37:208:38 | [output] access to local variable f2 | GlobalDataFlow.cs:208:37:208:38 | [output] access to local variable f2 |
-| GlobalDataFlow.cs:208:37:208:38 | access to local variable f2 | GlobalDataFlow.cs:208:37:208:38 | access to local variable f2 |
-| GlobalDataFlow.cs:208:37:208:38 | access to local variable f2 | GlobalDataFlow.cs:218:37:218:38 | access to local variable f2 |
-| GlobalDataFlow.cs:208:37:208:38 | access to local variable f2 | GlobalDataFlow.cs:218:37:218:38 | access to local variable f2 |
-| GlobalDataFlow.cs:209:9:209:21 | call to method Check | GlobalDataFlow.cs:209:9:209:21 | call to method Check |
-| GlobalDataFlow.cs:209:15:209:20 | access to local variable sink25 | GlobalDataFlow.cs:209:15:209:20 | access to local variable sink25 |
-| GlobalDataFlow.cs:210:13:210:49 | IEnumerable<String> sink26 = ... | GlobalDataFlow.cs:210:13:210:49 | IEnumerable<String> sink26 = ... |
-| GlobalDataFlow.cs:210:13:210:49 | SSA def(sink26) | GlobalDataFlow.cs:210:13:210:49 | SSA def(sink26) |
-| GlobalDataFlow.cs:210:13:210:49 | SSA def(sink26) | GlobalDataFlow.cs:211:15:211:20 | access to local variable sink26 |
-| GlobalDataFlow.cs:210:13:210:49 | SSA def(sink26) | GlobalDataFlow.cs:211:15:211:20 | access to local variable sink26 |
+| GlobalDataFlow.cs:173:9:173:40 | ... = ... | GlobalDataFlow.cs:173:9:173:40 | ... = ... |
+| GlobalDataFlow.cs:173:9:173:40 | SSA def(nonSink0) | GlobalDataFlow.cs:173:9:173:40 | SSA def(nonSink0) |
+| GlobalDataFlow.cs:173:9:173:40 | SSA def(nonSink0) | GlobalDataFlow.cs:174:15:174:22 | access to local variable nonSink0 |
+| GlobalDataFlow.cs:173:9:173:40 | SSA def(nonSink0) | GlobalDataFlow.cs:174:15:174:22 | access to local variable nonSink0 |
+| GlobalDataFlow.cs:173:9:173:40 | SSA def(nonSink0) | GlobalDataFlow.cs:175:36:175:43 | access to local variable nonSink0 |
+| GlobalDataFlow.cs:173:9:173:40 | SSA def(nonSink0) | GlobalDataFlow.cs:175:36:175:43 | access to local variable nonSink0 |
+| GlobalDataFlow.cs:173:20:173:32 | call to method NonOutYield | GlobalDataFlow.cs:173:20:173:32 | call to method NonOutYield |
+| GlobalDataFlow.cs:173:20:173:32 | this access | GlobalDataFlow.cs:173:20:173:32 | this access |
+| GlobalDataFlow.cs:173:20:173:32 | this access | GlobalDataFlow.cs:189:39:189:41 | this access |
+| GlobalDataFlow.cs:173:20:173:32 | this access | GlobalDataFlow.cs:189:39:189:41 | this access |
+| GlobalDataFlow.cs:173:20:173:32 | this access | GlobalDataFlow.cs:193:37:193:42 | this access |
+| GlobalDataFlow.cs:173:20:173:32 | this access | GlobalDataFlow.cs:193:37:193:42 | this access |
+| GlobalDataFlow.cs:173:20:173:32 | this access | GlobalDataFlow.cs:197:22:197:32 | this access |
+| GlobalDataFlow.cs:173:20:173:32 | this access | GlobalDataFlow.cs:197:22:197:32 | this access |
+| GlobalDataFlow.cs:173:20:173:32 | this access | GlobalDataFlow.cs:201:20:201:33 | this access |
+| GlobalDataFlow.cs:173:20:173:32 | this access | GlobalDataFlow.cs:201:20:201:33 | this access |
+| GlobalDataFlow.cs:173:20:173:32 | this access | GlobalDataFlow.cs:353:25:353:35 | this |
+| GlobalDataFlow.cs:173:20:173:32 | this access | GlobalDataFlow.cs:353:25:353:35 | this |
+| GlobalDataFlow.cs:173:20:173:40 | call to method First | GlobalDataFlow.cs:173:9:173:40 | SSA def(nonSink0) |
+| GlobalDataFlow.cs:173:20:173:40 | call to method First | GlobalDataFlow.cs:173:9:173:40 | SSA def(nonSink0) |
+| GlobalDataFlow.cs:173:20:173:40 | call to method First | GlobalDataFlow.cs:173:20:173:40 | call to method First |
+| GlobalDataFlow.cs:173:20:173:40 | call to method First | GlobalDataFlow.cs:174:15:174:22 | access to local variable nonSink0 |
+| GlobalDataFlow.cs:173:20:173:40 | call to method First | GlobalDataFlow.cs:174:15:174:22 | access to local variable nonSink0 |
+| GlobalDataFlow.cs:173:20:173:40 | call to method First | GlobalDataFlow.cs:175:36:175:43 | access to local variable nonSink0 |
+| GlobalDataFlow.cs:173:20:173:40 | call to method First | GlobalDataFlow.cs:175:36:175:43 | access to local variable nonSink0 |
+| GlobalDataFlow.cs:174:9:174:23 | call to method Check | GlobalDataFlow.cs:174:9:174:23 | call to method Check |
+| GlobalDataFlow.cs:174:15:174:22 | access to local variable nonSink0 | GlobalDataFlow.cs:174:15:174:22 | access to local variable nonSink0 |
+| GlobalDataFlow.cs:174:15:174:22 | access to local variable nonSink0 | GlobalDataFlow.cs:175:36:175:43 | access to local variable nonSink0 |
+| GlobalDataFlow.cs:174:15:174:22 | access to local variable nonSink0 | GlobalDataFlow.cs:175:36:175:43 | access to local variable nonSink0 |
+| GlobalDataFlow.cs:175:9:175:44 | ... = ... | GlobalDataFlow.cs:175:9:175:44 | ... = ... |
+| GlobalDataFlow.cs:175:9:175:44 | SSA def(nonSink0) | GlobalDataFlow.cs:175:9:175:44 | SSA def(nonSink0) |
+| GlobalDataFlow.cs:175:9:175:44 | SSA def(nonSink0) | GlobalDataFlow.cs:176:15:176:22 | access to local variable nonSink0 |
+| GlobalDataFlow.cs:175:9:175:44 | SSA def(nonSink0) | GlobalDataFlow.cs:176:15:176:22 | access to local variable nonSink0 |
+| GlobalDataFlow.cs:175:20:175:44 | call to method NonTaintedParam | GlobalDataFlow.cs:175:9:175:44 | SSA def(nonSink0) |
+| GlobalDataFlow.cs:175:20:175:44 | call to method NonTaintedParam | GlobalDataFlow.cs:175:9:175:44 | SSA def(nonSink0) |
+| GlobalDataFlow.cs:175:20:175:44 | call to method NonTaintedParam | GlobalDataFlow.cs:175:20:175:44 | call to method NonTaintedParam |
+| GlobalDataFlow.cs:175:20:175:44 | call to method NonTaintedParam | GlobalDataFlow.cs:176:15:176:22 | access to local variable nonSink0 |
+| GlobalDataFlow.cs:175:20:175:44 | call to method NonTaintedParam | GlobalDataFlow.cs:176:15:176:22 | access to local variable nonSink0 |
+| GlobalDataFlow.cs:175:36:175:43 | access to local variable nonSink0 | GlobalDataFlow.cs:175:20:175:44 | call to method NonTaintedParam |
+| GlobalDataFlow.cs:175:36:175:43 | access to local variable nonSink0 | GlobalDataFlow.cs:175:20:175:44 | call to method NonTaintedParam |
+| GlobalDataFlow.cs:175:36:175:43 | access to local variable nonSink0 | GlobalDataFlow.cs:175:36:175:43 | access to local variable nonSink0 |
+| GlobalDataFlow.cs:175:36:175:43 | access to local variable nonSink0 | GlobalDataFlow.cs:385:42:385:51 | nonTainted |
+| GlobalDataFlow.cs:175:36:175:43 | access to local variable nonSink0 | GlobalDataFlow.cs:385:42:385:51 | nonTainted |
+| GlobalDataFlow.cs:176:9:176:23 | call to method Check | GlobalDataFlow.cs:176:9:176:23 | call to method Check |
+| GlobalDataFlow.cs:176:15:176:22 | access to local variable nonSink0 | GlobalDataFlow.cs:176:15:176:22 | access to local variable nonSink0 |
+| GlobalDataFlow.cs:179:22:179:48 | Func<String> out = ... | GlobalDataFlow.cs:179:22:179:48 | Func<String> out = ... |
+| GlobalDataFlow.cs:179:22:179:48 | SSA def(out) | GlobalDataFlow.cs:179:22:179:48 | SSA def(out) |
+| GlobalDataFlow.cs:179:22:179:48 | SSA def(out) | GlobalDataFlow.cs:180:21:180:24 | access to local variable out |
+| GlobalDataFlow.cs:179:22:179:48 | SSA def(out) | GlobalDataFlow.cs:180:21:180:24 | access to local variable out |
+| GlobalDataFlow.cs:179:29:179:48 | (...) => ... | GlobalDataFlow.cs:179:22:179:48 | SSA def(out) |
+| GlobalDataFlow.cs:179:29:179:48 | (...) => ... | GlobalDataFlow.cs:179:22:179:48 | SSA def(out) |
+| GlobalDataFlow.cs:179:29:179:48 | (...) => ... | GlobalDataFlow.cs:179:29:179:48 | (...) => ... |
+| GlobalDataFlow.cs:179:29:179:48 | (...) => ... | GlobalDataFlow.cs:180:21:180:24 | access to local variable out |
+| GlobalDataFlow.cs:179:29:179:48 | (...) => ... | GlobalDataFlow.cs:180:21:180:24 | access to local variable out |
+| GlobalDataFlow.cs:179:35:179:48 | "taint source" | GlobalDataFlow.cs:179:35:179:48 | "taint source" |
+| GlobalDataFlow.cs:179:35:179:48 | "taint source" | GlobalDataFlow.cs:180:21:180:26 | delegate call |
+| GlobalDataFlow.cs:179:35:179:48 | "taint source" | GlobalDataFlow.cs:180:21:180:26 | delegate call |
+| GlobalDataFlow.cs:180:13:180:26 | SSA def(sink9) | GlobalDataFlow.cs:180:13:180:26 | SSA def(sink9) |
+| GlobalDataFlow.cs:180:13:180:26 | SSA def(sink9) | GlobalDataFlow.cs:181:15:181:19 | access to local variable sink9 |
+| GlobalDataFlow.cs:180:13:180:26 | SSA def(sink9) | GlobalDataFlow.cs:181:15:181:19 | access to local variable sink9 |
+| GlobalDataFlow.cs:180:13:180:26 | String sink9 = ... | GlobalDataFlow.cs:180:13:180:26 | String sink9 = ... |
+| GlobalDataFlow.cs:180:21:180:24 | access to local variable out | GlobalDataFlow.cs:180:21:180:24 | access to local variable out |
+| GlobalDataFlow.cs:180:21:180:26 | delegate call | GlobalDataFlow.cs:180:13:180:26 | SSA def(sink9) |
+| GlobalDataFlow.cs:180:21:180:26 | delegate call | GlobalDataFlow.cs:180:13:180:26 | SSA def(sink9) |
+| GlobalDataFlow.cs:180:21:180:26 | delegate call | GlobalDataFlow.cs:180:21:180:26 | delegate call |
+| GlobalDataFlow.cs:180:21:180:26 | delegate call | GlobalDataFlow.cs:181:15:181:19 | access to local variable sink9 |
+| GlobalDataFlow.cs:180:21:180:26 | delegate call | GlobalDataFlow.cs:181:15:181:19 | access to local variable sink9 |
+| GlobalDataFlow.cs:181:9:181:20 | call to method Check | GlobalDataFlow.cs:181:9:181:20 | call to method Check |
+| GlobalDataFlow.cs:181:15:181:19 | access to local variable sink9 | GlobalDataFlow.cs:181:15:181:19 | access to local variable sink9 |
+| GlobalDataFlow.cs:184:22:184:38 | Func<String> nonOut = ... | GlobalDataFlow.cs:184:22:184:38 | Func<String> nonOut = ... |
+| GlobalDataFlow.cs:184:22:184:38 | SSA def(nonOut) | GlobalDataFlow.cs:184:22:184:38 | SSA def(nonOut) |
+| GlobalDataFlow.cs:184:22:184:38 | SSA def(nonOut) | GlobalDataFlow.cs:185:20:185:25 | access to local variable nonOut |
+| GlobalDataFlow.cs:184:22:184:38 | SSA def(nonOut) | GlobalDataFlow.cs:185:20:185:25 | access to local variable nonOut |
+| GlobalDataFlow.cs:184:31:184:38 | (...) => ... | GlobalDataFlow.cs:184:22:184:38 | SSA def(nonOut) |
+| GlobalDataFlow.cs:184:31:184:38 | (...) => ... | GlobalDataFlow.cs:184:22:184:38 | SSA def(nonOut) |
+| GlobalDataFlow.cs:184:31:184:38 | (...) => ... | GlobalDataFlow.cs:184:31:184:38 | (...) => ... |
+| GlobalDataFlow.cs:184:31:184:38 | (...) => ... | GlobalDataFlow.cs:185:20:185:25 | access to local variable nonOut |
+| GlobalDataFlow.cs:184:31:184:38 | (...) => ... | GlobalDataFlow.cs:185:20:185:25 | access to local variable nonOut |
+| GlobalDataFlow.cs:184:37:184:38 | "" | GlobalDataFlow.cs:184:37:184:38 | "" |
+| GlobalDataFlow.cs:184:37:184:38 | "" | GlobalDataFlow.cs:185:20:185:27 | delegate call |
+| GlobalDataFlow.cs:184:37:184:38 | "" | GlobalDataFlow.cs:185:20:185:27 | delegate call |
+| GlobalDataFlow.cs:185:9:185:27 | ... = ... | GlobalDataFlow.cs:185:9:185:27 | ... = ... |
+| GlobalDataFlow.cs:185:9:185:27 | SSA def(nonSink0) | GlobalDataFlow.cs:185:9:185:27 | SSA def(nonSink0) |
+| GlobalDataFlow.cs:185:9:185:27 | SSA def(nonSink0) | GlobalDataFlow.cs:186:15:186:22 | access to local variable nonSink0 |
+| GlobalDataFlow.cs:185:9:185:27 | SSA def(nonSink0) | GlobalDataFlow.cs:186:15:186:22 | access to local variable nonSink0 |
+| GlobalDataFlow.cs:185:20:185:25 | access to local variable nonOut | GlobalDataFlow.cs:185:20:185:25 | access to local variable nonOut |
+| GlobalDataFlow.cs:185:20:185:27 | delegate call | GlobalDataFlow.cs:185:9:185:27 | SSA def(nonSink0) |
+| GlobalDataFlow.cs:185:20:185:27 | delegate call | GlobalDataFlow.cs:185:9:185:27 | SSA def(nonSink0) |
+| GlobalDataFlow.cs:185:20:185:27 | delegate call | GlobalDataFlow.cs:185:20:185:27 | delegate call |
+| GlobalDataFlow.cs:185:20:185:27 | delegate call | GlobalDataFlow.cs:186:15:186:22 | access to local variable nonSink0 |
+| GlobalDataFlow.cs:185:20:185:27 | delegate call | GlobalDataFlow.cs:186:15:186:22 | access to local variable nonSink0 |
+| GlobalDataFlow.cs:186:9:186:23 | call to method Check | GlobalDataFlow.cs:186:9:186:23 | call to method Check |
+| GlobalDataFlow.cs:186:15:186:22 | access to local variable nonSink0 | GlobalDataFlow.cs:186:15:186:22 | access to local variable nonSink0 |
+| GlobalDataFlow.cs:189:13:189:48 | SSA def(sink10) | GlobalDataFlow.cs:189:13:189:48 | SSA def(sink10) |
+| GlobalDataFlow.cs:189:13:189:48 | SSA def(sink10) | GlobalDataFlow.cs:190:15:190:20 | access to local variable sink10 |
+| GlobalDataFlow.cs:189:13:189:48 | SSA def(sink10) | GlobalDataFlow.cs:190:15:190:20 | access to local variable sink10 |
+| GlobalDataFlow.cs:189:13:189:48 | String sink10 = ... | GlobalDataFlow.cs:189:13:189:48 | String sink10 = ... |
+| GlobalDataFlow.cs:189:22:189:42 | malloc | GlobalDataFlow.cs:189:22:189:42 | malloc |
+| GlobalDataFlow.cs:189:22:189:42 | object creation of type Lazy<String> | GlobalDataFlow.cs:189:13:189:48 | SSA def(sink10) |
+| GlobalDataFlow.cs:189:22:189:42 | object creation of type Lazy<String> | GlobalDataFlow.cs:189:13:189:48 | SSA def(sink10) |
+| GlobalDataFlow.cs:189:22:189:42 | object creation of type Lazy<String> | GlobalDataFlow.cs:189:22:189:42 | object creation of type Lazy<String> |
+| GlobalDataFlow.cs:189:22:189:42 | object creation of type Lazy<String> | GlobalDataFlow.cs:189:22:189:48 | access to property Value |
+| GlobalDataFlow.cs:189:22:189:42 | object creation of type Lazy<String> | GlobalDataFlow.cs:189:22:189:48 | access to property Value |
+| GlobalDataFlow.cs:189:22:189:42 | object creation of type Lazy<String> | GlobalDataFlow.cs:190:15:190:20 | access to local variable sink10 |
+| GlobalDataFlow.cs:189:22:189:42 | object creation of type Lazy<String> | GlobalDataFlow.cs:190:15:190:20 | access to local variable sink10 |
+| GlobalDataFlow.cs:189:22:189:48 | access to property Value | GlobalDataFlow.cs:189:13:189:48 | SSA def(sink10) |
+| GlobalDataFlow.cs:189:22:189:48 | access to property Value | GlobalDataFlow.cs:189:13:189:48 | SSA def(sink10) |
+| GlobalDataFlow.cs:189:22:189:48 | access to property Value | GlobalDataFlow.cs:189:22:189:48 | access to property Value |
+| GlobalDataFlow.cs:189:22:189:48 | access to property Value | GlobalDataFlow.cs:190:15:190:20 | access to local variable sink10 |
+| GlobalDataFlow.cs:189:22:189:48 | access to property Value | GlobalDataFlow.cs:190:15:190:20 | access to local variable sink10 |
+| GlobalDataFlow.cs:189:39:189:41 | [output] delegate creation of type Func<String> | GlobalDataFlow.cs:189:13:189:48 | SSA def(sink10) |
+| GlobalDataFlow.cs:189:39:189:41 | [output] delegate creation of type Func<String> | GlobalDataFlow.cs:189:13:189:48 | SSA def(sink10) |
+| GlobalDataFlow.cs:189:39:189:41 | [output] delegate creation of type Func<String> | GlobalDataFlow.cs:189:22:189:42 | object creation of type Lazy<String> |
+| GlobalDataFlow.cs:189:39:189:41 | [output] delegate creation of type Func<String> | GlobalDataFlow.cs:189:22:189:42 | object creation of type Lazy<String> |
+| GlobalDataFlow.cs:189:39:189:41 | [output] delegate creation of type Func<String> | GlobalDataFlow.cs:189:22:189:48 | access to property Value |
+| GlobalDataFlow.cs:189:39:189:41 | [output] delegate creation of type Func<String> | GlobalDataFlow.cs:189:22:189:48 | access to property Value |
+| GlobalDataFlow.cs:189:39:189:41 | [output] delegate creation of type Func<String> | GlobalDataFlow.cs:189:39:189:41 | [output] delegate creation of type Func<String> |
+| GlobalDataFlow.cs:189:39:189:41 | [output] delegate creation of type Func<String> | GlobalDataFlow.cs:190:15:190:20 | access to local variable sink10 |
+| GlobalDataFlow.cs:189:39:189:41 | [output] delegate creation of type Func<String> | GlobalDataFlow.cs:190:15:190:20 | access to local variable sink10 |
+| GlobalDataFlow.cs:189:39:189:41 | access to method Out | GlobalDataFlow.cs:189:39:189:41 | access to method Out |
+| GlobalDataFlow.cs:189:39:189:41 | delegate creation of type Func<String> | GlobalDataFlow.cs:189:39:189:41 | delegate creation of type Func<String> |
+| GlobalDataFlow.cs:189:39:189:41 | this access | GlobalDataFlow.cs:189:39:189:41 | this access |
+| GlobalDataFlow.cs:189:39:189:41 | this access | GlobalDataFlow.cs:193:37:193:42 | this access |
+| GlobalDataFlow.cs:189:39:189:41 | this access | GlobalDataFlow.cs:193:37:193:42 | this access |
+| GlobalDataFlow.cs:189:39:189:41 | this access | GlobalDataFlow.cs:197:22:197:32 | this access |
+| GlobalDataFlow.cs:189:39:189:41 | this access | GlobalDataFlow.cs:197:22:197:32 | this access |
+| GlobalDataFlow.cs:189:39:189:41 | this access | GlobalDataFlow.cs:201:20:201:33 | this access |
+| GlobalDataFlow.cs:189:39:189:41 | this access | GlobalDataFlow.cs:201:20:201:33 | this access |
+| GlobalDataFlow.cs:190:9:190:21 | call to method Check | GlobalDataFlow.cs:190:9:190:21 | call to method Check |
+| GlobalDataFlow.cs:190:15:190:20 | access to local variable sink10 | GlobalDataFlow.cs:190:15:190:20 | access to local variable sink10 |
+| GlobalDataFlow.cs:193:9:193:49 | ... = ... | GlobalDataFlow.cs:193:9:193:49 | ... = ... |
+| GlobalDataFlow.cs:193:9:193:49 | SSA def(nonSink0) | GlobalDataFlow.cs:193:9:193:49 | SSA def(nonSink0) |
+| GlobalDataFlow.cs:193:9:193:49 | SSA def(nonSink0) | GlobalDataFlow.cs:194:15:194:22 | access to local variable nonSink0 |
+| GlobalDataFlow.cs:193:9:193:49 | SSA def(nonSink0) | GlobalDataFlow.cs:194:15:194:22 | access to local variable nonSink0 |
+| GlobalDataFlow.cs:193:20:193:43 | malloc | GlobalDataFlow.cs:193:20:193:43 | malloc |
+| GlobalDataFlow.cs:193:20:193:43 | object creation of type Lazy<String> | GlobalDataFlow.cs:193:9:193:49 | SSA def(nonSink0) |
+| GlobalDataFlow.cs:193:20:193:43 | object creation of type Lazy<String> | GlobalDataFlow.cs:193:9:193:49 | SSA def(nonSink0) |
+| GlobalDataFlow.cs:193:20:193:43 | object creation of type Lazy<String> | GlobalDataFlow.cs:193:20:193:43 | object creation of type Lazy<String> |
+| GlobalDataFlow.cs:193:20:193:43 | object creation of type Lazy<String> | GlobalDataFlow.cs:193:20:193:49 | access to property Value |
+| GlobalDataFlow.cs:193:20:193:43 | object creation of type Lazy<String> | GlobalDataFlow.cs:193:20:193:49 | access to property Value |
+| GlobalDataFlow.cs:193:20:193:43 | object creation of type Lazy<String> | GlobalDataFlow.cs:194:15:194:22 | access to local variable nonSink0 |
+| GlobalDataFlow.cs:193:20:193:43 | object creation of type Lazy<String> | GlobalDataFlow.cs:194:15:194:22 | access to local variable nonSink0 |
+| GlobalDataFlow.cs:193:20:193:49 | access to property Value | GlobalDataFlow.cs:193:9:193:49 | SSA def(nonSink0) |
+| GlobalDataFlow.cs:193:20:193:49 | access to property Value | GlobalDataFlow.cs:193:9:193:49 | SSA def(nonSink0) |
+| GlobalDataFlow.cs:193:20:193:49 | access to property Value | GlobalDataFlow.cs:193:20:193:49 | access to property Value |
+| GlobalDataFlow.cs:193:20:193:49 | access to property Value | GlobalDataFlow.cs:194:15:194:22 | access to local variable nonSink0 |
+| GlobalDataFlow.cs:193:20:193:49 | access to property Value | GlobalDataFlow.cs:194:15:194:22 | access to local variable nonSink0 |
+| GlobalDataFlow.cs:193:37:193:42 | [output] delegate creation of type Func<String> | GlobalDataFlow.cs:193:9:193:49 | SSA def(nonSink0) |
+| GlobalDataFlow.cs:193:37:193:42 | [output] delegate creation of type Func<String> | GlobalDataFlow.cs:193:9:193:49 | SSA def(nonSink0) |
+| GlobalDataFlow.cs:193:37:193:42 | [output] delegate creation of type Func<String> | GlobalDataFlow.cs:193:20:193:43 | object creation of type Lazy<String> |
+| GlobalDataFlow.cs:193:37:193:42 | [output] delegate creation of type Func<String> | GlobalDataFlow.cs:193:20:193:43 | object creation of type Lazy<String> |
+| GlobalDataFlow.cs:193:37:193:42 | [output] delegate creation of type Func<String> | GlobalDataFlow.cs:193:20:193:49 | access to property Value |
+| GlobalDataFlow.cs:193:37:193:42 | [output] delegate creation of type Func<String> | GlobalDataFlow.cs:193:20:193:49 | access to property Value |
+| GlobalDataFlow.cs:193:37:193:42 | [output] delegate creation of type Func<String> | GlobalDataFlow.cs:193:37:193:42 | [output] delegate creation of type Func<String> |
+| GlobalDataFlow.cs:193:37:193:42 | [output] delegate creation of type Func<String> | GlobalDataFlow.cs:194:15:194:22 | access to local variable nonSink0 |
+| GlobalDataFlow.cs:193:37:193:42 | [output] delegate creation of type Func<String> | GlobalDataFlow.cs:194:15:194:22 | access to local variable nonSink0 |
+| GlobalDataFlow.cs:193:37:193:42 | access to method NonOut | GlobalDataFlow.cs:193:37:193:42 | access to method NonOut |
+| GlobalDataFlow.cs:193:37:193:42 | delegate creation of type Func<String> | GlobalDataFlow.cs:193:37:193:42 | delegate creation of type Func<String> |
+| GlobalDataFlow.cs:193:37:193:42 | this access | GlobalDataFlow.cs:193:37:193:42 | this access |
+| GlobalDataFlow.cs:193:37:193:42 | this access | GlobalDataFlow.cs:197:22:197:32 | this access |
+| GlobalDataFlow.cs:193:37:193:42 | this access | GlobalDataFlow.cs:197:22:197:32 | this access |
+| GlobalDataFlow.cs:193:37:193:42 | this access | GlobalDataFlow.cs:201:20:201:33 | this access |
+| GlobalDataFlow.cs:193:37:193:42 | this access | GlobalDataFlow.cs:201:20:201:33 | this access |
+| GlobalDataFlow.cs:194:9:194:23 | call to method Check | GlobalDataFlow.cs:194:9:194:23 | call to method Check |
+| GlobalDataFlow.cs:194:15:194:22 | access to local variable nonSink0 | GlobalDataFlow.cs:194:15:194:22 | access to local variable nonSink0 |
+| GlobalDataFlow.cs:197:13:197:32 | SSA def(sink19) | GlobalDataFlow.cs:197:13:197:32 | SSA def(sink19) |
+| GlobalDataFlow.cs:197:13:197:32 | SSA def(sink19) | GlobalDataFlow.cs:198:15:198:20 | access to local variable sink19 |
+| GlobalDataFlow.cs:197:13:197:32 | SSA def(sink19) | GlobalDataFlow.cs:198:15:198:20 | access to local variable sink19 |
+| GlobalDataFlow.cs:197:13:197:32 | String sink19 = ... | GlobalDataFlow.cs:197:13:197:32 | String sink19 = ... |
+| GlobalDataFlow.cs:197:22:197:32 | SSA untracked def(this.OutProperty) | GlobalDataFlow.cs:197:22:197:32 | SSA untracked def(this.OutProperty) |
+| GlobalDataFlow.cs:197:22:197:32 | access to property OutProperty | GlobalDataFlow.cs:197:13:197:32 | SSA def(sink19) |
+| GlobalDataFlow.cs:197:22:197:32 | access to property OutProperty | GlobalDataFlow.cs:197:13:197:32 | SSA def(sink19) |
+| GlobalDataFlow.cs:197:22:197:32 | access to property OutProperty | GlobalDataFlow.cs:197:22:197:32 | access to property OutProperty |
+| GlobalDataFlow.cs:197:22:197:32 | access to property OutProperty | GlobalDataFlow.cs:198:15:198:20 | access to local variable sink19 |
+| GlobalDataFlow.cs:197:22:197:32 | access to property OutProperty | GlobalDataFlow.cs:198:15:198:20 | access to local variable sink19 |
+| GlobalDataFlow.cs:197:22:197:32 | this access | GlobalDataFlow.cs:197:22:197:32 | this access |
+| GlobalDataFlow.cs:197:22:197:32 | this access | GlobalDataFlow.cs:201:20:201:33 | this access |
+| GlobalDataFlow.cs:197:22:197:32 | this access | GlobalDataFlow.cs:201:20:201:33 | this access |
+| GlobalDataFlow.cs:197:22:197:32 | this access | GlobalDataFlow.cs:415:9:415:11 | this |
+| GlobalDataFlow.cs:197:22:197:32 | this access | GlobalDataFlow.cs:415:9:415:11 | this |
+| GlobalDataFlow.cs:198:9:198:21 | call to method Check | GlobalDataFlow.cs:198:9:198:21 | call to method Check |
+| GlobalDataFlow.cs:198:15:198:20 | access to local variable sink19 | GlobalDataFlow.cs:198:15:198:20 | access to local variable sink19 |
+| GlobalDataFlow.cs:201:9:201:33 | ... = ... | GlobalDataFlow.cs:201:9:201:33 | ... = ... |
+| GlobalDataFlow.cs:201:9:201:33 | SSA def(nonSink0) | GlobalDataFlow.cs:201:9:201:33 | SSA def(nonSink0) |
+| GlobalDataFlow.cs:201:9:201:33 | SSA def(nonSink0) | GlobalDataFlow.cs:202:15:202:22 | access to local variable nonSink0 |
+| GlobalDataFlow.cs:201:9:201:33 | SSA def(nonSink0) | GlobalDataFlow.cs:202:15:202:22 | access to local variable nonSink0 |
+| GlobalDataFlow.cs:201:20:201:33 | SSA untracked def(this.NonOutProperty) | GlobalDataFlow.cs:201:20:201:33 | SSA untracked def(this.NonOutProperty) |
+| GlobalDataFlow.cs:201:20:201:33 | access to property NonOutProperty | GlobalDataFlow.cs:201:9:201:33 | SSA def(nonSink0) |
+| GlobalDataFlow.cs:201:20:201:33 | access to property NonOutProperty | GlobalDataFlow.cs:201:9:201:33 | SSA def(nonSink0) |
+| GlobalDataFlow.cs:201:20:201:33 | access to property NonOutProperty | GlobalDataFlow.cs:201:20:201:33 | access to property NonOutProperty |
+| GlobalDataFlow.cs:201:20:201:33 | access to property NonOutProperty | GlobalDataFlow.cs:202:15:202:22 | access to local variable nonSink0 |
+| GlobalDataFlow.cs:201:20:201:33 | access to property NonOutProperty | GlobalDataFlow.cs:202:15:202:22 | access to local variable nonSink0 |
+| GlobalDataFlow.cs:201:20:201:33 | this access | GlobalDataFlow.cs:201:20:201:33 | this access |
+| GlobalDataFlow.cs:201:20:201:33 | this access | GlobalDataFlow.cs:420:9:420:11 | this |
+| GlobalDataFlow.cs:201:20:201:33 | this access | GlobalDataFlow.cs:420:9:420:11 | this |
+| GlobalDataFlow.cs:202:9:202:23 | call to method Check | GlobalDataFlow.cs:202:9:202:23 | call to method Check |
+| GlobalDataFlow.cs:202:15:202:22 | access to local variable nonSink0 | GlobalDataFlow.cs:202:15:202:22 | access to local variable nonSink0 |
+| GlobalDataFlow.cs:205:17:205:18 | this | GlobalDataFlow.cs:205:17:205:18 | this |
+| GlobalDataFlow.cs:205:39:205:45 | tainted | GlobalDataFlow.cs:205:39:205:45 | tainted |
+| GlobalDataFlow.cs:205:39:205:45 | tainted | GlobalDataFlow.cs:205:39:205:45 | tainted |
+| GlobalDataFlow.cs:205:39:205:45 | tainted | GlobalDataFlow.cs:210:22:210:28 | access to parameter tainted |
+| GlobalDataFlow.cs:205:39:205:45 | tainted | GlobalDataFlow.cs:210:22:210:28 | access to parameter tainted |
+| GlobalDataFlow.cs:205:39:205:45 | tainted | GlobalDataFlow.cs:212:22:212:28 | access to parameter tainted |
+| GlobalDataFlow.cs:205:39:205:45 | tainted | GlobalDataFlow.cs:212:22:212:28 | access to parameter tainted |
+| GlobalDataFlow.cs:205:39:205:45 | tainted | GlobalDataFlow.cs:214:22:214:28 | access to parameter tainted |
+| GlobalDataFlow.cs:205:39:205:45 | tainted | GlobalDataFlow.cs:214:22:214:28 | access to parameter tainted |
+| GlobalDataFlow.cs:205:67:205:76 | notTainted | GlobalDataFlow.cs:205:67:205:76 | notTainted |
+| GlobalDataFlow.cs:205:67:205:76 | notTainted | GlobalDataFlow.cs:205:67:205:76 | notTainted |
+| GlobalDataFlow.cs:205:67:205:76 | notTainted | GlobalDataFlow.cs:220:23:220:32 | access to parameter notTainted |
+| GlobalDataFlow.cs:205:67:205:76 | notTainted | GlobalDataFlow.cs:220:23:220:32 | access to parameter notTainted |
+| GlobalDataFlow.cs:205:67:205:76 | notTainted | GlobalDataFlow.cs:222:19:222:28 | access to parameter notTainted |
+| GlobalDataFlow.cs:205:67:205:76 | notTainted | GlobalDataFlow.cs:222:19:222:28 | access to parameter notTainted |
+| GlobalDataFlow.cs:205:67:205:76 | notTainted | GlobalDataFlow.cs:224:19:224:28 | access to parameter notTainted |
+| GlobalDataFlow.cs:205:67:205:76 | notTainted | GlobalDataFlow.cs:224:19:224:28 | access to parameter notTainted |
+| GlobalDataFlow.cs:205:67:205:76 | notTainted | GlobalDataFlow.cs:226:19:226:28 | access to parameter notTainted |
+| GlobalDataFlow.cs:205:67:205:76 | notTainted | GlobalDataFlow.cs:226:19:226:28 | access to parameter notTainted |
+| GlobalDataFlow.cs:205:67:205:76 | notTainted | GlobalDataFlow.cs:228:19:228:28 | access to parameter notTainted |
+| GlobalDataFlow.cs:205:67:205:76 | notTainted | GlobalDataFlow.cs:228:19:228:28 | access to parameter notTainted |
+| GlobalDataFlow.cs:208:30:208:92 | Func<String,String> f1 = ... | GlobalDataFlow.cs:208:30:208:92 | Func<String,String> f1 = ... |
+| GlobalDataFlow.cs:208:30:208:92 | SSA def(f1) | GlobalDataFlow.cs:208:30:208:92 | SSA def(f1) |
+| GlobalDataFlow.cs:208:30:208:92 | SSA def(f1) | GlobalDataFlow.cs:210:37:210:38 | access to local variable f1 |
+| GlobalDataFlow.cs:208:30:208:92 | SSA def(f1) | GlobalDataFlow.cs:210:37:210:38 | access to local variable f1 |
+| GlobalDataFlow.cs:208:30:208:92 | SSA def(f1) | GlobalDataFlow.cs:220:41:220:42 | access to local variable f1 |
+| GlobalDataFlow.cs:208:30:208:92 | SSA def(f1) | GlobalDataFlow.cs:220:41:220:42 | access to local variable f1 |
+| GlobalDataFlow.cs:208:35:208:45 | sinkParam10 | GlobalDataFlow.cs:208:35:208:45 | sinkParam10 |
+| GlobalDataFlow.cs:208:35:208:45 | sinkParam10 | GlobalDataFlow.cs:208:35:208:45 | sinkParam10 |
+| GlobalDataFlow.cs:208:35:208:45 | sinkParam10 | GlobalDataFlow.cs:208:58:208:68 | access to parameter sinkParam10 |
+| GlobalDataFlow.cs:208:35:208:45 | sinkParam10 | GlobalDataFlow.cs:208:58:208:68 | access to parameter sinkParam10 |
+| GlobalDataFlow.cs:208:35:208:45 | sinkParam10 | GlobalDataFlow.cs:208:79:208:89 | access to parameter sinkParam10 |
+| GlobalDataFlow.cs:208:35:208:45 | sinkParam10 | GlobalDataFlow.cs:208:79:208:89 | access to parameter sinkParam10 |
+| GlobalDataFlow.cs:208:35:208:92 | (...) => ... | GlobalDataFlow.cs:208:30:208:92 | SSA def(f1) |
+| GlobalDataFlow.cs:208:35:208:92 | (...) => ... | GlobalDataFlow.cs:208:30:208:92 | SSA def(f1) |
+| GlobalDataFlow.cs:208:35:208:92 | (...) => ... | GlobalDataFlow.cs:208:35:208:92 | (...) => ... |
+| GlobalDataFlow.cs:208:35:208:92 | (...) => ... | GlobalDataFlow.cs:210:37:210:38 | access to local variable f1 |
+| GlobalDataFlow.cs:208:35:208:92 | (...) => ... | GlobalDataFlow.cs:210:37:210:38 | access to local variable f1 |
+| GlobalDataFlow.cs:208:35:208:92 | (...) => ... | GlobalDataFlow.cs:220:41:220:42 | access to local variable f1 |
+| GlobalDataFlow.cs:208:35:208:92 | (...) => ... | GlobalDataFlow.cs:220:41:220:42 | access to local variable f1 |
+| GlobalDataFlow.cs:208:52:208:69 | call to method Check | GlobalDataFlow.cs:208:52:208:69 | call to method Check |
+| GlobalDataFlow.cs:208:58:208:68 | access to parameter sinkParam10 | GlobalDataFlow.cs:208:58:208:68 | access to parameter sinkParam10 |
+| GlobalDataFlow.cs:208:58:208:68 | access to parameter sinkParam10 | GlobalDataFlow.cs:208:79:208:89 | access to parameter sinkParam10 |
+| GlobalDataFlow.cs:208:58:208:68 | access to parameter sinkParam10 | GlobalDataFlow.cs:208:79:208:89 | access to parameter sinkParam10 |
+| GlobalDataFlow.cs:208:79:208:89 | access to parameter sinkParam10 | GlobalDataFlow.cs:208:79:208:89 | access to parameter sinkParam10 |
+| GlobalDataFlow.cs:208:79:208:89 | access to parameter sinkParam10 | GlobalDataFlow.cs:210:37:210:38 | [output] access to local variable f1 |
+| GlobalDataFlow.cs:208:79:208:89 | access to parameter sinkParam10 | GlobalDataFlow.cs:210:37:210:38 | [output] access to local variable f1 |
+| GlobalDataFlow.cs:208:79:208:89 | access to parameter sinkParam10 | GlobalDataFlow.cs:220:41:220:42 | [output] access to local variable f1 |
+| GlobalDataFlow.cs:208:79:208:89 | access to parameter sinkParam10 | GlobalDataFlow.cs:220:41:220:42 | [output] access to local variable f1 |
+| GlobalDataFlow.cs:209:66:209:90 | Expression<Func<String,String>> f2 = ... | GlobalDataFlow.cs:209:66:209:90 | Expression<Func<String,String>> f2 = ... |
+| GlobalDataFlow.cs:209:66:209:90 | SSA def(f2) | GlobalDataFlow.cs:209:66:209:90 | SSA def(f2) |
+| GlobalDataFlow.cs:209:66:209:90 | SSA def(f2) | GlobalDataFlow.cs:212:37:212:38 | access to local variable f2 |
+| GlobalDataFlow.cs:209:66:209:90 | SSA def(f2) | GlobalDataFlow.cs:212:37:212:38 | access to local variable f2 |
+| GlobalDataFlow.cs:209:66:209:90 | SSA def(f2) | GlobalDataFlow.cs:222:37:222:38 | access to local variable f2 |
+| GlobalDataFlow.cs:209:66:209:90 | SSA def(f2) | GlobalDataFlow.cs:222:37:222:38 | access to local variable f2 |
+| GlobalDataFlow.cs:209:71:209:71 | x | GlobalDataFlow.cs:209:71:209:71 | x |
+| GlobalDataFlow.cs:209:71:209:71 | x | GlobalDataFlow.cs:209:71:209:71 | x |
+| GlobalDataFlow.cs:209:71:209:71 | x | GlobalDataFlow.cs:209:89:209:89 | access to parameter x |
+| GlobalDataFlow.cs:209:71:209:71 | x | GlobalDataFlow.cs:209:89:209:89 | access to parameter x |
+| GlobalDataFlow.cs:209:71:209:90 | (...) => ... | GlobalDataFlow.cs:209:66:209:90 | SSA def(f2) |
+| GlobalDataFlow.cs:209:71:209:90 | (...) => ... | GlobalDataFlow.cs:209:66:209:90 | SSA def(f2) |
+| GlobalDataFlow.cs:209:71:209:90 | (...) => ... | GlobalDataFlow.cs:209:71:209:90 | (...) => ... |
+| GlobalDataFlow.cs:209:71:209:90 | (...) => ... | GlobalDataFlow.cs:212:37:212:38 | access to local variable f2 |
+| GlobalDataFlow.cs:209:71:209:90 | (...) => ... | GlobalDataFlow.cs:212:37:212:38 | access to local variable f2 |
+| GlobalDataFlow.cs:209:71:209:90 | (...) => ... | GlobalDataFlow.cs:222:37:222:38 | access to local variable f2 |
+| GlobalDataFlow.cs:209:71:209:90 | (...) => ... | GlobalDataFlow.cs:222:37:222:38 | access to local variable f2 |
+| GlobalDataFlow.cs:209:76:209:90 | call to method ReturnCheck2 | GlobalDataFlow.cs:209:76:209:90 | call to method ReturnCheck2 |
+| GlobalDataFlow.cs:209:76:209:90 | call to method ReturnCheck2 | GlobalDataFlow.cs:212:37:212:38 | [output] access to local variable f2 |
+| GlobalDataFlow.cs:209:76:209:90 | call to method ReturnCheck2 | GlobalDataFlow.cs:212:37:212:38 | [output] access to local variable f2 |
+| GlobalDataFlow.cs:209:76:209:90 | call to method ReturnCheck2 | GlobalDataFlow.cs:222:37:222:38 | [output] access to local variable f2 |
+| GlobalDataFlow.cs:209:76:209:90 | call to method ReturnCheck2 | GlobalDataFlow.cs:222:37:222:38 | [output] access to local variable f2 |
+| GlobalDataFlow.cs:209:89:209:89 | access to parameter x | GlobalDataFlow.cs:209:76:209:90 | call to method ReturnCheck2 |
+| GlobalDataFlow.cs:209:89:209:89 | access to parameter x | GlobalDataFlow.cs:209:76:209:90 | call to method ReturnCheck2 |
+| GlobalDataFlow.cs:209:89:209:89 | access to parameter x | GlobalDataFlow.cs:209:89:209:89 | access to parameter x |
+| GlobalDataFlow.cs:209:89:209:89 | access to parameter x | GlobalDataFlow.cs:298:32:298:41 | sinkParam9 |
+| GlobalDataFlow.cs:209:89:209:89 | access to parameter x | GlobalDataFlow.cs:298:32:298:41 | sinkParam9 |
+| GlobalDataFlow.cs:210:13:210:39 | IEnumerable<String> sink24 = ... | GlobalDataFlow.cs:210:13:210:39 | IEnumerable<String> sink24 = ... |
+| GlobalDataFlow.cs:210:13:210:39 | SSA def(sink24) | GlobalDataFlow.cs:210:13:210:39 | SSA def(sink24) |
+| GlobalDataFlow.cs:210:13:210:39 | SSA def(sink24) | GlobalDataFlow.cs:211:15:211:20 | access to local variable sink24 |
+| GlobalDataFlow.cs:210:13:210:39 | SSA def(sink24) | GlobalDataFlow.cs:211:15:211:20 | access to local variable sink24 |
+| GlobalDataFlow.cs:210:22:210:28 | access to parameter tainted | GlobalDataFlow.cs:208:35:208:45 | sinkParam10 |
+| GlobalDataFlow.cs:210:22:210:28 | access to parameter tainted | GlobalDataFlow.cs:208:35:208:45 | sinkParam10 |
 | GlobalDataFlow.cs:210:22:210:28 | access to parameter tainted | GlobalDataFlow.cs:210:22:210:28 | access to parameter tainted |
-| GlobalDataFlow.cs:210:22:210:28 | access to parameter tainted | GlobalDataFlow.cs:299:32:299:42 | sinkParam11 |
-| GlobalDataFlow.cs:210:22:210:28 | access to parameter tainted | GlobalDataFlow.cs:299:32:299:42 | sinkParam11 |
-| GlobalDataFlow.cs:210:22:210:49 | call to method Select | GlobalDataFlow.cs:210:13:210:49 | SSA def(sink26) |
-| GlobalDataFlow.cs:210:22:210:49 | call to method Select | GlobalDataFlow.cs:210:13:210:49 | SSA def(sink26) |
-| GlobalDataFlow.cs:210:22:210:49 | call to method Select | GlobalDataFlow.cs:210:22:210:49 | call to method Select |
-| GlobalDataFlow.cs:210:22:210:49 | call to method Select | GlobalDataFlow.cs:211:15:211:20 | access to local variable sink26 |
-| GlobalDataFlow.cs:210:22:210:49 | call to method Select | GlobalDataFlow.cs:211:15:211:20 | access to local variable sink26 |
-| GlobalDataFlow.cs:210:37:210:48 | [output] delegate creation of type Func<String,String> | GlobalDataFlow.cs:210:37:210:48 | [output] delegate creation of type Func<String,String> |
-| GlobalDataFlow.cs:210:37:210:48 | access to method ReturnCheck3 | GlobalDataFlow.cs:210:37:210:48 | access to method ReturnCheck3 |
-| GlobalDataFlow.cs:210:37:210:48 | delegate creation of type Func<String,String> | GlobalDataFlow.cs:210:37:210:48 | delegate creation of type Func<String,String> |
+| GlobalDataFlow.cs:210:22:210:28 | access to parameter tainted | GlobalDataFlow.cs:212:22:212:28 | access to parameter tainted |
+| GlobalDataFlow.cs:210:22:210:28 | access to parameter tainted | GlobalDataFlow.cs:212:22:212:28 | access to parameter tainted |
+| GlobalDataFlow.cs:210:22:210:28 | access to parameter tainted | GlobalDataFlow.cs:214:22:214:28 | access to parameter tainted |
+| GlobalDataFlow.cs:210:22:210:28 | access to parameter tainted | GlobalDataFlow.cs:214:22:214:28 | access to parameter tainted |
+| GlobalDataFlow.cs:210:22:210:39 | call to method Select | GlobalDataFlow.cs:210:13:210:39 | SSA def(sink24) |
+| GlobalDataFlow.cs:210:22:210:39 | call to method Select | GlobalDataFlow.cs:210:13:210:39 | SSA def(sink24) |
+| GlobalDataFlow.cs:210:22:210:39 | call to method Select | GlobalDataFlow.cs:210:22:210:39 | call to method Select |
+| GlobalDataFlow.cs:210:22:210:39 | call to method Select | GlobalDataFlow.cs:211:15:211:20 | access to local variable sink24 |
+| GlobalDataFlow.cs:210:22:210:39 | call to method Select | GlobalDataFlow.cs:211:15:211:20 | access to local variable sink24 |
+| GlobalDataFlow.cs:210:37:210:38 | [output] access to local variable f1 | GlobalDataFlow.cs:210:37:210:38 | [output] access to local variable f1 |
+| GlobalDataFlow.cs:210:37:210:38 | access to local variable f1 | GlobalDataFlow.cs:210:37:210:38 | access to local variable f1 |
+| GlobalDataFlow.cs:210:37:210:38 | access to local variable f1 | GlobalDataFlow.cs:220:41:220:42 | access to local variable f1 |
+| GlobalDataFlow.cs:210:37:210:38 | access to local variable f1 | GlobalDataFlow.cs:220:41:220:42 | access to local variable f1 |
 | GlobalDataFlow.cs:211:9:211:21 | call to method Check | GlobalDataFlow.cs:211:9:211:21 | call to method Check |
-| GlobalDataFlow.cs:211:15:211:20 | access to local variable sink26 | GlobalDataFlow.cs:211:15:211:20 | access to local variable sink26 |
-| GlobalDataFlow.cs:214:30:214:95 | Func<String,String> f3 = ... | GlobalDataFlow.cs:214:30:214:95 | Func<String,String> f3 = ... |
-| GlobalDataFlow.cs:214:30:214:95 | SSA def(f3) | GlobalDataFlow.cs:214:30:214:95 | SSA def(f3) |
-| GlobalDataFlow.cs:214:30:214:95 | SSA def(f3) | GlobalDataFlow.cs:220:37:220:38 | access to local variable f3 |
-| GlobalDataFlow.cs:214:30:214:95 | SSA def(f3) | GlobalDataFlow.cs:220:37:220:38 | access to local variable f3 |
-| GlobalDataFlow.cs:214:35:214:46 | nonSinkParam | GlobalDataFlow.cs:214:35:214:46 | nonSinkParam |
-| GlobalDataFlow.cs:214:35:214:46 | nonSinkParam | GlobalDataFlow.cs:214:35:214:46 | nonSinkParam |
-| GlobalDataFlow.cs:214:35:214:46 | nonSinkParam | GlobalDataFlow.cs:214:59:214:70 | access to parameter nonSinkParam |
-| GlobalDataFlow.cs:214:35:214:46 | nonSinkParam | GlobalDataFlow.cs:214:59:214:70 | access to parameter nonSinkParam |
-| GlobalDataFlow.cs:214:35:214:46 | nonSinkParam | GlobalDataFlow.cs:214:81:214:92 | access to parameter nonSinkParam |
-| GlobalDataFlow.cs:214:35:214:46 | nonSinkParam | GlobalDataFlow.cs:214:81:214:92 | access to parameter nonSinkParam |
-| GlobalDataFlow.cs:214:35:214:95 | (...) => ... | GlobalDataFlow.cs:214:30:214:95 | SSA def(f3) |
-| GlobalDataFlow.cs:214:35:214:95 | (...) => ... | GlobalDataFlow.cs:214:30:214:95 | SSA def(f3) |
-| GlobalDataFlow.cs:214:35:214:95 | (...) => ... | GlobalDataFlow.cs:214:35:214:95 | (...) => ... |
-| GlobalDataFlow.cs:214:35:214:95 | (...) => ... | GlobalDataFlow.cs:220:37:220:38 | access to local variable f3 |
-| GlobalDataFlow.cs:214:35:214:95 | (...) => ... | GlobalDataFlow.cs:220:37:220:38 | access to local variable f3 |
-| GlobalDataFlow.cs:214:53:214:71 | call to method Check | GlobalDataFlow.cs:214:53:214:71 | call to method Check |
-| GlobalDataFlow.cs:214:59:214:70 | access to parameter nonSinkParam | GlobalDataFlow.cs:214:59:214:70 | access to parameter nonSinkParam |
-| GlobalDataFlow.cs:214:59:214:70 | access to parameter nonSinkParam | GlobalDataFlow.cs:214:81:214:92 | access to parameter nonSinkParam |
-| GlobalDataFlow.cs:214:59:214:70 | access to parameter nonSinkParam | GlobalDataFlow.cs:214:81:214:92 | access to parameter nonSinkParam |
-| GlobalDataFlow.cs:214:81:214:92 | access to parameter nonSinkParam | GlobalDataFlow.cs:214:81:214:92 | access to parameter nonSinkParam |
-| GlobalDataFlow.cs:214:81:214:92 | access to parameter nonSinkParam | GlobalDataFlow.cs:220:37:220:38 | [output] access to local variable f3 |
-| GlobalDataFlow.cs:214:81:214:92 | access to parameter nonSinkParam | GlobalDataFlow.cs:220:37:220:38 | [output] access to local variable f3 |
-| GlobalDataFlow.cs:215:66:215:92 | Expression<Func<String,String>> f4 = ... | GlobalDataFlow.cs:215:66:215:92 | Expression<Func<String,String>> f4 = ... |
-| GlobalDataFlow.cs:215:66:215:92 | SSA def(f4) | GlobalDataFlow.cs:215:66:215:92 | SSA def(f4) |
-| GlobalDataFlow.cs:215:66:215:92 | SSA def(f4) | GlobalDataFlow.cs:222:37:222:38 | access to local variable f4 |
-| GlobalDataFlow.cs:215:66:215:92 | SSA def(f4) | GlobalDataFlow.cs:222:37:222:38 | access to local variable f4 |
-| GlobalDataFlow.cs:215:71:215:71 | x | GlobalDataFlow.cs:215:71:215:71 | x |
-| GlobalDataFlow.cs:215:71:215:71 | x | GlobalDataFlow.cs:215:71:215:71 | x |
-| GlobalDataFlow.cs:215:71:215:71 | x | GlobalDataFlow.cs:215:91:215:91 | access to parameter x |
-| GlobalDataFlow.cs:215:71:215:71 | x | GlobalDataFlow.cs:215:91:215:91 | access to parameter x |
-| GlobalDataFlow.cs:215:71:215:92 | (...) => ... | GlobalDataFlow.cs:215:66:215:92 | SSA def(f4) |
-| GlobalDataFlow.cs:215:71:215:92 | (...) => ... | GlobalDataFlow.cs:215:66:215:92 | SSA def(f4) |
-| GlobalDataFlow.cs:215:71:215:92 | (...) => ... | GlobalDataFlow.cs:215:71:215:92 | (...) => ... |
-| GlobalDataFlow.cs:215:71:215:92 | (...) => ... | GlobalDataFlow.cs:222:37:222:38 | access to local variable f4 |
-| GlobalDataFlow.cs:215:71:215:92 | (...) => ... | GlobalDataFlow.cs:222:37:222:38 | access to local variable f4 |
-| GlobalDataFlow.cs:215:76:215:92 | call to method NonReturnCheck | GlobalDataFlow.cs:215:76:215:92 | call to method NonReturnCheck |
-| GlobalDataFlow.cs:215:76:215:92 | call to method NonReturnCheck | GlobalDataFlow.cs:222:37:222:38 | [output] access to local variable f4 |
-| GlobalDataFlow.cs:215:76:215:92 | call to method NonReturnCheck | GlobalDataFlow.cs:222:37:222:38 | [output] access to local variable f4 |
-| GlobalDataFlow.cs:215:91:215:91 | access to parameter x | GlobalDataFlow.cs:215:76:215:92 | call to method NonReturnCheck |
-| GlobalDataFlow.cs:215:91:215:91 | access to parameter x | GlobalDataFlow.cs:215:76:215:92 | call to method NonReturnCheck |
-| GlobalDataFlow.cs:215:91:215:91 | access to parameter x | GlobalDataFlow.cs:215:91:215:91 | access to parameter x |
-| GlobalDataFlow.cs:215:91:215:91 | access to parameter x | GlobalDataFlow.cs:305:34:305:45 | nonSinkParam |
-| GlobalDataFlow.cs:215:91:215:91 | access to parameter x | GlobalDataFlow.cs:305:34:305:45 | nonSinkParam |
-| GlobalDataFlow.cs:216:13:216:43 | IEnumerable<String> nonSink = ... | GlobalDataFlow.cs:216:13:216:43 | IEnumerable<String> nonSink = ... |
-| GlobalDataFlow.cs:216:13:216:43 | SSA def(nonSink) | GlobalDataFlow.cs:216:13:216:43 | SSA def(nonSink) |
-| GlobalDataFlow.cs:216:13:216:43 | SSA def(nonSink) | GlobalDataFlow.cs:217:15:217:21 | access to local variable nonSink |
-| GlobalDataFlow.cs:216:13:216:43 | SSA def(nonSink) | GlobalDataFlow.cs:217:15:217:21 | access to local variable nonSink |
-| GlobalDataFlow.cs:216:23:216:32 | access to parameter notTainted | GlobalDataFlow.cs:204:35:204:45 | sinkParam10 |
-| GlobalDataFlow.cs:216:23:216:32 | access to parameter notTainted | GlobalDataFlow.cs:204:35:204:45 | sinkParam10 |
-| GlobalDataFlow.cs:216:23:216:32 | access to parameter notTainted | GlobalDataFlow.cs:216:23:216:32 | access to parameter notTainted |
-| GlobalDataFlow.cs:216:23:216:32 | access to parameter notTainted | GlobalDataFlow.cs:218:19:218:28 | access to parameter notTainted |
-| GlobalDataFlow.cs:216:23:216:32 | access to parameter notTainted | GlobalDataFlow.cs:218:19:218:28 | access to parameter notTainted |
-| GlobalDataFlow.cs:216:23:216:32 | access to parameter notTainted | GlobalDataFlow.cs:220:19:220:28 | access to parameter notTainted |
-| GlobalDataFlow.cs:216:23:216:32 | access to parameter notTainted | GlobalDataFlow.cs:220:19:220:28 | access to parameter notTainted |
-| GlobalDataFlow.cs:216:23:216:32 | access to parameter notTainted | GlobalDataFlow.cs:222:19:222:28 | access to parameter notTainted |
-| GlobalDataFlow.cs:216:23:216:32 | access to parameter notTainted | GlobalDataFlow.cs:222:19:222:28 | access to parameter notTainted |
-| GlobalDataFlow.cs:216:23:216:32 | access to parameter notTainted | GlobalDataFlow.cs:224:19:224:28 | access to parameter notTainted |
-| GlobalDataFlow.cs:216:23:216:32 | access to parameter notTainted | GlobalDataFlow.cs:224:19:224:28 | access to parameter notTainted |
-| GlobalDataFlow.cs:216:23:216:43 | call to method Select | GlobalDataFlow.cs:216:13:216:43 | SSA def(nonSink) |
-| GlobalDataFlow.cs:216:23:216:43 | call to method Select | GlobalDataFlow.cs:216:13:216:43 | SSA def(nonSink) |
-| GlobalDataFlow.cs:216:23:216:43 | call to method Select | GlobalDataFlow.cs:216:23:216:43 | call to method Select |
-| GlobalDataFlow.cs:216:23:216:43 | call to method Select | GlobalDataFlow.cs:217:15:217:21 | access to local variable nonSink |
-| GlobalDataFlow.cs:216:23:216:43 | call to method Select | GlobalDataFlow.cs:217:15:217:21 | access to local variable nonSink |
-| GlobalDataFlow.cs:216:41:216:42 | [output] access to local variable f1 | GlobalDataFlow.cs:216:41:216:42 | [output] access to local variable f1 |
-| GlobalDataFlow.cs:216:41:216:42 | access to local variable f1 | GlobalDataFlow.cs:216:41:216:42 | access to local variable f1 |
-| GlobalDataFlow.cs:217:9:217:22 | call to method Check | GlobalDataFlow.cs:217:9:217:22 | call to method Check |
-| GlobalDataFlow.cs:217:15:217:21 | access to local variable nonSink | GlobalDataFlow.cs:217:15:217:21 | access to local variable nonSink |
-| GlobalDataFlow.cs:218:9:218:39 | ... = ... | GlobalDataFlow.cs:218:9:218:39 | ... = ... |
-| GlobalDataFlow.cs:218:9:218:39 | SSA def(nonSink) | GlobalDataFlow.cs:218:9:218:39 | SSA def(nonSink) |
-| GlobalDataFlow.cs:218:9:218:39 | SSA def(nonSink) | GlobalDataFlow.cs:219:15:219:21 | access to local variable nonSink |
-| GlobalDataFlow.cs:218:9:218:39 | SSA def(nonSink) | GlobalDataFlow.cs:219:15:219:21 | access to local variable nonSink |
-| GlobalDataFlow.cs:218:19:218:28 | access to parameter notTainted | GlobalDataFlow.cs:205:71:205:71 | x |
-| GlobalDataFlow.cs:218:19:218:28 | access to parameter notTainted | GlobalDataFlow.cs:205:71:205:71 | x |
-| GlobalDataFlow.cs:218:19:218:28 | access to parameter notTainted | GlobalDataFlow.cs:218:19:218:28 | access to parameter notTainted |
-| GlobalDataFlow.cs:218:19:218:28 | access to parameter notTainted | GlobalDataFlow.cs:220:19:220:28 | access to parameter notTainted |
-| GlobalDataFlow.cs:218:19:218:28 | access to parameter notTainted | GlobalDataFlow.cs:220:19:220:28 | access to parameter notTainted |
-| GlobalDataFlow.cs:218:19:218:28 | access to parameter notTainted | GlobalDataFlow.cs:222:19:222:28 | access to parameter notTainted |
-| GlobalDataFlow.cs:218:19:218:28 | access to parameter notTainted | GlobalDataFlow.cs:222:19:222:28 | access to parameter notTainted |
-| GlobalDataFlow.cs:218:19:218:28 | access to parameter notTainted | GlobalDataFlow.cs:224:19:224:28 | access to parameter notTainted |
-| GlobalDataFlow.cs:218:19:218:28 | access to parameter notTainted | GlobalDataFlow.cs:224:19:224:28 | access to parameter notTainted |
-| GlobalDataFlow.cs:218:19:218:39 | call to method Select | GlobalDataFlow.cs:218:9:218:39 | SSA def(nonSink) |
-| GlobalDataFlow.cs:218:19:218:39 | call to method Select | GlobalDataFlow.cs:218:9:218:39 | SSA def(nonSink) |
-| GlobalDataFlow.cs:218:19:218:39 | call to method Select | GlobalDataFlow.cs:218:19:218:39 | call to method Select |
-| GlobalDataFlow.cs:218:19:218:39 | call to method Select | GlobalDataFlow.cs:219:15:219:21 | access to local variable nonSink |
-| GlobalDataFlow.cs:218:19:218:39 | call to method Select | GlobalDataFlow.cs:219:15:219:21 | access to local variable nonSink |
-| GlobalDataFlow.cs:218:37:218:38 | [output] access to local variable f2 | GlobalDataFlow.cs:218:37:218:38 | [output] access to local variable f2 |
-| GlobalDataFlow.cs:218:37:218:38 | access to local variable f2 | GlobalDataFlow.cs:218:37:218:38 | access to local variable f2 |
-| GlobalDataFlow.cs:219:9:219:22 | call to method Check | GlobalDataFlow.cs:219:9:219:22 | call to method Check |
-| GlobalDataFlow.cs:219:15:219:21 | access to local variable nonSink | GlobalDataFlow.cs:219:15:219:21 | access to local variable nonSink |
-| GlobalDataFlow.cs:220:9:220:39 | ... = ... | GlobalDataFlow.cs:220:9:220:39 | ... = ... |
-| GlobalDataFlow.cs:220:9:220:39 | SSA def(nonSink) | GlobalDataFlow.cs:220:9:220:39 | SSA def(nonSink) |
-| GlobalDataFlow.cs:220:9:220:39 | SSA def(nonSink) | GlobalDataFlow.cs:221:15:221:21 | access to local variable nonSink |
-| GlobalDataFlow.cs:220:9:220:39 | SSA def(nonSink) | GlobalDataFlow.cs:221:15:221:21 | access to local variable nonSink |
-| GlobalDataFlow.cs:220:19:220:28 | access to parameter notTainted | GlobalDataFlow.cs:214:35:214:46 | nonSinkParam |
-| GlobalDataFlow.cs:220:19:220:28 | access to parameter notTainted | GlobalDataFlow.cs:214:35:214:46 | nonSinkParam |
-| GlobalDataFlow.cs:220:19:220:28 | access to parameter notTainted | GlobalDataFlow.cs:220:19:220:28 | access to parameter notTainted |
-| GlobalDataFlow.cs:220:19:220:28 | access to parameter notTainted | GlobalDataFlow.cs:222:19:222:28 | access to parameter notTainted |
-| GlobalDataFlow.cs:220:19:220:28 | access to parameter notTainted | GlobalDataFlow.cs:222:19:222:28 | access to parameter notTainted |
-| GlobalDataFlow.cs:220:19:220:28 | access to parameter notTainted | GlobalDataFlow.cs:224:19:224:28 | access to parameter notTainted |
-| GlobalDataFlow.cs:220:19:220:28 | access to parameter notTainted | GlobalDataFlow.cs:224:19:224:28 | access to parameter notTainted |
-| GlobalDataFlow.cs:220:19:220:39 | call to method Select | GlobalDataFlow.cs:220:9:220:39 | SSA def(nonSink) |
-| GlobalDataFlow.cs:220:19:220:39 | call to method Select | GlobalDataFlow.cs:220:9:220:39 | SSA def(nonSink) |
-| GlobalDataFlow.cs:220:19:220:39 | call to method Select | GlobalDataFlow.cs:220:19:220:39 | call to method Select |
-| GlobalDataFlow.cs:220:19:220:39 | call to method Select | GlobalDataFlow.cs:221:15:221:21 | access to local variable nonSink |
-| GlobalDataFlow.cs:220:19:220:39 | call to method Select | GlobalDataFlow.cs:221:15:221:21 | access to local variable nonSink |
-| GlobalDataFlow.cs:220:37:220:38 | [output] access to local variable f3 | GlobalDataFlow.cs:220:37:220:38 | [output] access to local variable f3 |
-| GlobalDataFlow.cs:220:37:220:38 | access to local variable f3 | GlobalDataFlow.cs:220:37:220:38 | access to local variable f3 |
+| GlobalDataFlow.cs:211:15:211:20 | access to local variable sink24 | GlobalDataFlow.cs:211:15:211:20 | access to local variable sink24 |
+| GlobalDataFlow.cs:212:13:212:39 | IQueryable<String> sink25 = ... | GlobalDataFlow.cs:212:13:212:39 | IQueryable<String> sink25 = ... |
+| GlobalDataFlow.cs:212:13:212:39 | SSA def(sink25) | GlobalDataFlow.cs:212:13:212:39 | SSA def(sink25) |
+| GlobalDataFlow.cs:212:13:212:39 | SSA def(sink25) | GlobalDataFlow.cs:213:15:213:20 | access to local variable sink25 |
+| GlobalDataFlow.cs:212:13:212:39 | SSA def(sink25) | GlobalDataFlow.cs:213:15:213:20 | access to local variable sink25 |
+| GlobalDataFlow.cs:212:22:212:28 | access to parameter tainted | GlobalDataFlow.cs:209:71:209:71 | x |
+| GlobalDataFlow.cs:212:22:212:28 | access to parameter tainted | GlobalDataFlow.cs:209:71:209:71 | x |
+| GlobalDataFlow.cs:212:22:212:28 | access to parameter tainted | GlobalDataFlow.cs:212:22:212:28 | access to parameter tainted |
+| GlobalDataFlow.cs:212:22:212:28 | access to parameter tainted | GlobalDataFlow.cs:214:22:214:28 | access to parameter tainted |
+| GlobalDataFlow.cs:212:22:212:28 | access to parameter tainted | GlobalDataFlow.cs:214:22:214:28 | access to parameter tainted |
+| GlobalDataFlow.cs:212:22:212:39 | call to method Select | GlobalDataFlow.cs:212:13:212:39 | SSA def(sink25) |
+| GlobalDataFlow.cs:212:22:212:39 | call to method Select | GlobalDataFlow.cs:212:13:212:39 | SSA def(sink25) |
+| GlobalDataFlow.cs:212:22:212:39 | call to method Select | GlobalDataFlow.cs:212:22:212:39 | call to method Select |
+| GlobalDataFlow.cs:212:22:212:39 | call to method Select | GlobalDataFlow.cs:213:15:213:20 | access to local variable sink25 |
+| GlobalDataFlow.cs:212:22:212:39 | call to method Select | GlobalDataFlow.cs:213:15:213:20 | access to local variable sink25 |
+| GlobalDataFlow.cs:212:37:212:38 | [output] access to local variable f2 | GlobalDataFlow.cs:212:37:212:38 | [output] access to local variable f2 |
+| GlobalDataFlow.cs:212:37:212:38 | access to local variable f2 | GlobalDataFlow.cs:212:37:212:38 | access to local variable f2 |
+| GlobalDataFlow.cs:212:37:212:38 | access to local variable f2 | GlobalDataFlow.cs:222:37:222:38 | access to local variable f2 |
+| GlobalDataFlow.cs:212:37:212:38 | access to local variable f2 | GlobalDataFlow.cs:222:37:222:38 | access to local variable f2 |
+| GlobalDataFlow.cs:213:9:213:21 | call to method Check | GlobalDataFlow.cs:213:9:213:21 | call to method Check |
+| GlobalDataFlow.cs:213:15:213:20 | access to local variable sink25 | GlobalDataFlow.cs:213:15:213:20 | access to local variable sink25 |
+| GlobalDataFlow.cs:214:13:214:49 | IEnumerable<String> sink26 = ... | GlobalDataFlow.cs:214:13:214:49 | IEnumerable<String> sink26 = ... |
+| GlobalDataFlow.cs:214:13:214:49 | SSA def(sink26) | GlobalDataFlow.cs:214:13:214:49 | SSA def(sink26) |
+| GlobalDataFlow.cs:214:13:214:49 | SSA def(sink26) | GlobalDataFlow.cs:215:15:215:20 | access to local variable sink26 |
+| GlobalDataFlow.cs:214:13:214:49 | SSA def(sink26) | GlobalDataFlow.cs:215:15:215:20 | access to local variable sink26 |
+| GlobalDataFlow.cs:214:22:214:28 | access to parameter tainted | GlobalDataFlow.cs:214:22:214:28 | access to parameter tainted |
+| GlobalDataFlow.cs:214:22:214:28 | access to parameter tainted | GlobalDataFlow.cs:304:32:304:42 | sinkParam11 |
+| GlobalDataFlow.cs:214:22:214:28 | access to parameter tainted | GlobalDataFlow.cs:304:32:304:42 | sinkParam11 |
+| GlobalDataFlow.cs:214:22:214:49 | call to method Select | GlobalDataFlow.cs:214:13:214:49 | SSA def(sink26) |
+| GlobalDataFlow.cs:214:22:214:49 | call to method Select | GlobalDataFlow.cs:214:13:214:49 | SSA def(sink26) |
+| GlobalDataFlow.cs:214:22:214:49 | call to method Select | GlobalDataFlow.cs:214:22:214:49 | call to method Select |
+| GlobalDataFlow.cs:214:22:214:49 | call to method Select | GlobalDataFlow.cs:215:15:215:20 | access to local variable sink26 |
+| GlobalDataFlow.cs:214:22:214:49 | call to method Select | GlobalDataFlow.cs:215:15:215:20 | access to local variable sink26 |
+| GlobalDataFlow.cs:214:37:214:48 | [output] delegate creation of type Func<String,String> | GlobalDataFlow.cs:214:37:214:48 | [output] delegate creation of type Func<String,String> |
+| GlobalDataFlow.cs:214:37:214:48 | access to method ReturnCheck3 | GlobalDataFlow.cs:214:37:214:48 | access to method ReturnCheck3 |
+| GlobalDataFlow.cs:214:37:214:48 | delegate creation of type Func<String,String> | GlobalDataFlow.cs:214:37:214:48 | delegate creation of type Func<String,String> |
+| GlobalDataFlow.cs:215:9:215:21 | call to method Check | GlobalDataFlow.cs:215:9:215:21 | call to method Check |
+| GlobalDataFlow.cs:215:15:215:20 | access to local variable sink26 | GlobalDataFlow.cs:215:15:215:20 | access to local variable sink26 |
+| GlobalDataFlow.cs:218:30:218:95 | Func<String,String> f3 = ... | GlobalDataFlow.cs:218:30:218:95 | Func<String,String> f3 = ... |
+| GlobalDataFlow.cs:218:30:218:95 | SSA def(f3) | GlobalDataFlow.cs:218:30:218:95 | SSA def(f3) |
+| GlobalDataFlow.cs:218:30:218:95 | SSA def(f3) | GlobalDataFlow.cs:224:37:224:38 | access to local variable f3 |
+| GlobalDataFlow.cs:218:30:218:95 | SSA def(f3) | GlobalDataFlow.cs:224:37:224:38 | access to local variable f3 |
+| GlobalDataFlow.cs:218:35:218:46 | nonSinkParam | GlobalDataFlow.cs:218:35:218:46 | nonSinkParam |
+| GlobalDataFlow.cs:218:35:218:46 | nonSinkParam | GlobalDataFlow.cs:218:35:218:46 | nonSinkParam |
+| GlobalDataFlow.cs:218:35:218:46 | nonSinkParam | GlobalDataFlow.cs:218:59:218:70 | access to parameter nonSinkParam |
+| GlobalDataFlow.cs:218:35:218:46 | nonSinkParam | GlobalDataFlow.cs:218:59:218:70 | access to parameter nonSinkParam |
+| GlobalDataFlow.cs:218:35:218:46 | nonSinkParam | GlobalDataFlow.cs:218:81:218:92 | access to parameter nonSinkParam |
+| GlobalDataFlow.cs:218:35:218:46 | nonSinkParam | GlobalDataFlow.cs:218:81:218:92 | access to parameter nonSinkParam |
+| GlobalDataFlow.cs:218:35:218:95 | (...) => ... | GlobalDataFlow.cs:218:30:218:95 | SSA def(f3) |
+| GlobalDataFlow.cs:218:35:218:95 | (...) => ... | GlobalDataFlow.cs:218:30:218:95 | SSA def(f3) |
+| GlobalDataFlow.cs:218:35:218:95 | (...) => ... | GlobalDataFlow.cs:218:35:218:95 | (...) => ... |
+| GlobalDataFlow.cs:218:35:218:95 | (...) => ... | GlobalDataFlow.cs:224:37:224:38 | access to local variable f3 |
+| GlobalDataFlow.cs:218:35:218:95 | (...) => ... | GlobalDataFlow.cs:224:37:224:38 | access to local variable f3 |
+| GlobalDataFlow.cs:218:53:218:71 | call to method Check | GlobalDataFlow.cs:218:53:218:71 | call to method Check |
+| GlobalDataFlow.cs:218:59:218:70 | access to parameter nonSinkParam | GlobalDataFlow.cs:218:59:218:70 | access to parameter nonSinkParam |
+| GlobalDataFlow.cs:218:59:218:70 | access to parameter nonSinkParam | GlobalDataFlow.cs:218:81:218:92 | access to parameter nonSinkParam |
+| GlobalDataFlow.cs:218:59:218:70 | access to parameter nonSinkParam | GlobalDataFlow.cs:218:81:218:92 | access to parameter nonSinkParam |
+| GlobalDataFlow.cs:218:81:218:92 | access to parameter nonSinkParam | GlobalDataFlow.cs:218:81:218:92 | access to parameter nonSinkParam |
+| GlobalDataFlow.cs:218:81:218:92 | access to parameter nonSinkParam | GlobalDataFlow.cs:224:37:224:38 | [output] access to local variable f3 |
+| GlobalDataFlow.cs:218:81:218:92 | access to parameter nonSinkParam | GlobalDataFlow.cs:224:37:224:38 | [output] access to local variable f3 |
+| GlobalDataFlow.cs:219:66:219:92 | Expression<Func<String,String>> f4 = ... | GlobalDataFlow.cs:219:66:219:92 | Expression<Func<String,String>> f4 = ... |
+| GlobalDataFlow.cs:219:66:219:92 | SSA def(f4) | GlobalDataFlow.cs:219:66:219:92 | SSA def(f4) |
+| GlobalDataFlow.cs:219:66:219:92 | SSA def(f4) | GlobalDataFlow.cs:226:37:226:38 | access to local variable f4 |
+| GlobalDataFlow.cs:219:66:219:92 | SSA def(f4) | GlobalDataFlow.cs:226:37:226:38 | access to local variable f4 |
+| GlobalDataFlow.cs:219:71:219:71 | x | GlobalDataFlow.cs:219:71:219:71 | x |
+| GlobalDataFlow.cs:219:71:219:71 | x | GlobalDataFlow.cs:219:71:219:71 | x |
+| GlobalDataFlow.cs:219:71:219:71 | x | GlobalDataFlow.cs:219:91:219:91 | access to parameter x |
+| GlobalDataFlow.cs:219:71:219:71 | x | GlobalDataFlow.cs:219:91:219:91 | access to parameter x |
+| GlobalDataFlow.cs:219:71:219:92 | (...) => ... | GlobalDataFlow.cs:219:66:219:92 | SSA def(f4) |
+| GlobalDataFlow.cs:219:71:219:92 | (...) => ... | GlobalDataFlow.cs:219:66:219:92 | SSA def(f4) |
+| GlobalDataFlow.cs:219:71:219:92 | (...) => ... | GlobalDataFlow.cs:219:71:219:92 | (...) => ... |
+| GlobalDataFlow.cs:219:71:219:92 | (...) => ... | GlobalDataFlow.cs:226:37:226:38 | access to local variable f4 |
+| GlobalDataFlow.cs:219:71:219:92 | (...) => ... | GlobalDataFlow.cs:226:37:226:38 | access to local variable f4 |
+| GlobalDataFlow.cs:219:76:219:92 | call to method NonReturnCheck | GlobalDataFlow.cs:219:76:219:92 | call to method NonReturnCheck |
+| GlobalDataFlow.cs:219:76:219:92 | call to method NonReturnCheck | GlobalDataFlow.cs:226:37:226:38 | [output] access to local variable f4 |
+| GlobalDataFlow.cs:219:76:219:92 | call to method NonReturnCheck | GlobalDataFlow.cs:226:37:226:38 | [output] access to local variable f4 |
+| GlobalDataFlow.cs:219:91:219:91 | access to parameter x | GlobalDataFlow.cs:219:76:219:92 | call to method NonReturnCheck |
+| GlobalDataFlow.cs:219:91:219:91 | access to parameter x | GlobalDataFlow.cs:219:76:219:92 | call to method NonReturnCheck |
+| GlobalDataFlow.cs:219:91:219:91 | access to parameter x | GlobalDataFlow.cs:219:91:219:91 | access to parameter x |
+| GlobalDataFlow.cs:219:91:219:91 | access to parameter x | GlobalDataFlow.cs:310:34:310:45 | nonSinkParam |
+| GlobalDataFlow.cs:219:91:219:91 | access to parameter x | GlobalDataFlow.cs:310:34:310:45 | nonSinkParam |
+| GlobalDataFlow.cs:220:13:220:43 | IEnumerable<String> nonSink = ... | GlobalDataFlow.cs:220:13:220:43 | IEnumerable<String> nonSink = ... |
+| GlobalDataFlow.cs:220:13:220:43 | SSA def(nonSink) | GlobalDataFlow.cs:220:13:220:43 | SSA def(nonSink) |
+| GlobalDataFlow.cs:220:13:220:43 | SSA def(nonSink) | GlobalDataFlow.cs:221:15:221:21 | access to local variable nonSink |
+| GlobalDataFlow.cs:220:13:220:43 | SSA def(nonSink) | GlobalDataFlow.cs:221:15:221:21 | access to local variable nonSink |
+| GlobalDataFlow.cs:220:23:220:32 | access to parameter notTainted | GlobalDataFlow.cs:208:35:208:45 | sinkParam10 |
+| GlobalDataFlow.cs:220:23:220:32 | access to parameter notTainted | GlobalDataFlow.cs:208:35:208:45 | sinkParam10 |
+| GlobalDataFlow.cs:220:23:220:32 | access to parameter notTainted | GlobalDataFlow.cs:220:23:220:32 | access to parameter notTainted |
+| GlobalDataFlow.cs:220:23:220:32 | access to parameter notTainted | GlobalDataFlow.cs:222:19:222:28 | access to parameter notTainted |
+| GlobalDataFlow.cs:220:23:220:32 | access to parameter notTainted | GlobalDataFlow.cs:222:19:222:28 | access to parameter notTainted |
+| GlobalDataFlow.cs:220:23:220:32 | access to parameter notTainted | GlobalDataFlow.cs:224:19:224:28 | access to parameter notTainted |
+| GlobalDataFlow.cs:220:23:220:32 | access to parameter notTainted | GlobalDataFlow.cs:224:19:224:28 | access to parameter notTainted |
+| GlobalDataFlow.cs:220:23:220:32 | access to parameter notTainted | GlobalDataFlow.cs:226:19:226:28 | access to parameter notTainted |
+| GlobalDataFlow.cs:220:23:220:32 | access to parameter notTainted | GlobalDataFlow.cs:226:19:226:28 | access to parameter notTainted |
+| GlobalDataFlow.cs:220:23:220:32 | access to parameter notTainted | GlobalDataFlow.cs:228:19:228:28 | access to parameter notTainted |
+| GlobalDataFlow.cs:220:23:220:32 | access to parameter notTainted | GlobalDataFlow.cs:228:19:228:28 | access to parameter notTainted |
+| GlobalDataFlow.cs:220:23:220:43 | call to method Select | GlobalDataFlow.cs:220:13:220:43 | SSA def(nonSink) |
+| GlobalDataFlow.cs:220:23:220:43 | call to method Select | GlobalDataFlow.cs:220:13:220:43 | SSA def(nonSink) |
+| GlobalDataFlow.cs:220:23:220:43 | call to method Select | GlobalDataFlow.cs:220:23:220:43 | call to method Select |
+| GlobalDataFlow.cs:220:23:220:43 | call to method Select | GlobalDataFlow.cs:221:15:221:21 | access to local variable nonSink |
+| GlobalDataFlow.cs:220:23:220:43 | call to method Select | GlobalDataFlow.cs:221:15:221:21 | access to local variable nonSink |
+| GlobalDataFlow.cs:220:41:220:42 | [output] access to local variable f1 | GlobalDataFlow.cs:220:41:220:42 | [output] access to local variable f1 |
+| GlobalDataFlow.cs:220:41:220:42 | access to local variable f1 | GlobalDataFlow.cs:220:41:220:42 | access to local variable f1 |
 | GlobalDataFlow.cs:221:9:221:22 | call to method Check | GlobalDataFlow.cs:221:9:221:22 | call to method Check |
 | GlobalDataFlow.cs:221:15:221:21 | access to local variable nonSink | GlobalDataFlow.cs:221:15:221:21 | access to local variable nonSink |
 | GlobalDataFlow.cs:222:9:222:39 | ... = ... | GlobalDataFlow.cs:222:9:222:39 | ... = ... |
 | GlobalDataFlow.cs:222:9:222:39 | SSA def(nonSink) | GlobalDataFlow.cs:222:9:222:39 | SSA def(nonSink) |
 | GlobalDataFlow.cs:222:9:222:39 | SSA def(nonSink) | GlobalDataFlow.cs:223:15:223:21 | access to local variable nonSink |
 | GlobalDataFlow.cs:222:9:222:39 | SSA def(nonSink) | GlobalDataFlow.cs:223:15:223:21 | access to local variable nonSink |
-| GlobalDataFlow.cs:222:19:222:28 | access to parameter notTainted | GlobalDataFlow.cs:215:71:215:71 | x |
-| GlobalDataFlow.cs:222:19:222:28 | access to parameter notTainted | GlobalDataFlow.cs:215:71:215:71 | x |
+| GlobalDataFlow.cs:222:19:222:28 | access to parameter notTainted | GlobalDataFlow.cs:209:71:209:71 | x |
+| GlobalDataFlow.cs:222:19:222:28 | access to parameter notTainted | GlobalDataFlow.cs:209:71:209:71 | x |
 | GlobalDataFlow.cs:222:19:222:28 | access to parameter notTainted | GlobalDataFlow.cs:222:19:222:28 | access to parameter notTainted |
 | GlobalDataFlow.cs:222:19:222:28 | access to parameter notTainted | GlobalDataFlow.cs:224:19:224:28 | access to parameter notTainted |
 | GlobalDataFlow.cs:222:19:222:28 | access to parameter notTainted | GlobalDataFlow.cs:224:19:224:28 | access to parameter notTainted |
+| GlobalDataFlow.cs:222:19:222:28 | access to parameter notTainted | GlobalDataFlow.cs:226:19:226:28 | access to parameter notTainted |
+| GlobalDataFlow.cs:222:19:222:28 | access to parameter notTainted | GlobalDataFlow.cs:226:19:226:28 | access to parameter notTainted |
+| GlobalDataFlow.cs:222:19:222:28 | access to parameter notTainted | GlobalDataFlow.cs:228:19:228:28 | access to parameter notTainted |
+| GlobalDataFlow.cs:222:19:222:28 | access to parameter notTainted | GlobalDataFlow.cs:228:19:228:28 | access to parameter notTainted |
 | GlobalDataFlow.cs:222:19:222:39 | call to method Select | GlobalDataFlow.cs:222:9:222:39 | SSA def(nonSink) |
 | GlobalDataFlow.cs:222:19:222:39 | call to method Select | GlobalDataFlow.cs:222:9:222:39 | SSA def(nonSink) |
 | GlobalDataFlow.cs:222:19:222:39 | call to method Select | GlobalDataFlow.cs:222:19:222:39 | call to method Select |
 | GlobalDataFlow.cs:222:19:222:39 | call to method Select | GlobalDataFlow.cs:223:15:223:21 | access to local variable nonSink |
 | GlobalDataFlow.cs:222:19:222:39 | call to method Select | GlobalDataFlow.cs:223:15:223:21 | access to local variable nonSink |
-| GlobalDataFlow.cs:222:37:222:38 | [output] access to local variable f4 | GlobalDataFlow.cs:222:37:222:38 | [output] access to local variable f4 |
-| GlobalDataFlow.cs:222:37:222:38 | access to local variable f4 | GlobalDataFlow.cs:222:37:222:38 | access to local variable f4 |
+| GlobalDataFlow.cs:222:37:222:38 | [output] access to local variable f2 | GlobalDataFlow.cs:222:37:222:38 | [output] access to local variable f2 |
+| GlobalDataFlow.cs:222:37:222:38 | access to local variable f2 | GlobalDataFlow.cs:222:37:222:38 | access to local variable f2 |
 | GlobalDataFlow.cs:223:9:223:22 | call to method Check | GlobalDataFlow.cs:223:9:223:22 | call to method Check |
 | GlobalDataFlow.cs:223:15:223:21 | access to local variable nonSink | GlobalDataFlow.cs:223:15:223:21 | access to local variable nonSink |
-| GlobalDataFlow.cs:224:9:224:49 | ... = ... | GlobalDataFlow.cs:224:9:224:49 | ... = ... |
-| GlobalDataFlow.cs:224:9:224:49 | SSA def(nonSink) | GlobalDataFlow.cs:224:9:224:49 | SSA def(nonSink) |
-| GlobalDataFlow.cs:224:9:224:49 | SSA def(nonSink) | GlobalDataFlow.cs:225:15:225:21 | access to local variable nonSink |
-| GlobalDataFlow.cs:224:9:224:49 | SSA def(nonSink) | GlobalDataFlow.cs:225:15:225:21 | access to local variable nonSink |
+| GlobalDataFlow.cs:224:9:224:39 | ... = ... | GlobalDataFlow.cs:224:9:224:39 | ... = ... |
+| GlobalDataFlow.cs:224:9:224:39 | SSA def(nonSink) | GlobalDataFlow.cs:224:9:224:39 | SSA def(nonSink) |
+| GlobalDataFlow.cs:224:9:224:39 | SSA def(nonSink) | GlobalDataFlow.cs:225:15:225:21 | access to local variable nonSink |
+| GlobalDataFlow.cs:224:9:224:39 | SSA def(nonSink) | GlobalDataFlow.cs:225:15:225:21 | access to local variable nonSink |
+| GlobalDataFlow.cs:224:19:224:28 | access to parameter notTainted | GlobalDataFlow.cs:218:35:218:46 | nonSinkParam |
+| GlobalDataFlow.cs:224:19:224:28 | access to parameter notTainted | GlobalDataFlow.cs:218:35:218:46 | nonSinkParam |
 | GlobalDataFlow.cs:224:19:224:28 | access to parameter notTainted | GlobalDataFlow.cs:224:19:224:28 | access to parameter notTainted |
-| GlobalDataFlow.cs:224:19:224:28 | access to parameter notTainted | GlobalDataFlow.cs:299:32:299:42 | sinkParam11 |
-| GlobalDataFlow.cs:224:19:224:28 | access to parameter notTainted | GlobalDataFlow.cs:299:32:299:42 | sinkParam11 |
-| GlobalDataFlow.cs:224:19:224:49 | call to method Select | GlobalDataFlow.cs:224:9:224:49 | SSA def(nonSink) |
-| GlobalDataFlow.cs:224:19:224:49 | call to method Select | GlobalDataFlow.cs:224:9:224:49 | SSA def(nonSink) |
-| GlobalDataFlow.cs:224:19:224:49 | call to method Select | GlobalDataFlow.cs:224:19:224:49 | call to method Select |
-| GlobalDataFlow.cs:224:19:224:49 | call to method Select | GlobalDataFlow.cs:225:15:225:21 | access to local variable nonSink |
-| GlobalDataFlow.cs:224:19:224:49 | call to method Select | GlobalDataFlow.cs:225:15:225:21 | access to local variable nonSink |
-| GlobalDataFlow.cs:224:37:224:48 | [output] delegate creation of type Func<String,String> | GlobalDataFlow.cs:224:37:224:48 | [output] delegate creation of type Func<String,String> |
-| GlobalDataFlow.cs:224:37:224:48 | access to method ReturnCheck3 | GlobalDataFlow.cs:224:37:224:48 | access to method ReturnCheck3 |
-| GlobalDataFlow.cs:224:37:224:48 | delegate creation of type Func<String,String> | GlobalDataFlow.cs:224:37:224:48 | delegate creation of type Func<String,String> |
+| GlobalDataFlow.cs:224:19:224:28 | access to parameter notTainted | GlobalDataFlow.cs:226:19:226:28 | access to parameter notTainted |
+| GlobalDataFlow.cs:224:19:224:28 | access to parameter notTainted | GlobalDataFlow.cs:226:19:226:28 | access to parameter notTainted |
+| GlobalDataFlow.cs:224:19:224:28 | access to parameter notTainted | GlobalDataFlow.cs:228:19:228:28 | access to parameter notTainted |
+| GlobalDataFlow.cs:224:19:224:28 | access to parameter notTainted | GlobalDataFlow.cs:228:19:228:28 | access to parameter notTainted |
+| GlobalDataFlow.cs:224:19:224:39 | call to method Select | GlobalDataFlow.cs:224:9:224:39 | SSA def(nonSink) |
+| GlobalDataFlow.cs:224:19:224:39 | call to method Select | GlobalDataFlow.cs:224:9:224:39 | SSA def(nonSink) |
+| GlobalDataFlow.cs:224:19:224:39 | call to method Select | GlobalDataFlow.cs:224:19:224:39 | call to method Select |
+| GlobalDataFlow.cs:224:19:224:39 | call to method Select | GlobalDataFlow.cs:225:15:225:21 | access to local variable nonSink |
+| GlobalDataFlow.cs:224:19:224:39 | call to method Select | GlobalDataFlow.cs:225:15:225:21 | access to local variable nonSink |
+| GlobalDataFlow.cs:224:37:224:38 | [output] access to local variable f3 | GlobalDataFlow.cs:224:37:224:38 | [output] access to local variable f3 |
+| GlobalDataFlow.cs:224:37:224:38 | access to local variable f3 | GlobalDataFlow.cs:224:37:224:38 | access to local variable f3 |
 | GlobalDataFlow.cs:225:9:225:22 | call to method Check | GlobalDataFlow.cs:225:9:225:22 | call to method Check |
 | GlobalDataFlow.cs:225:15:225:21 | access to local variable nonSink | GlobalDataFlow.cs:225:15:225:21 | access to local variable nonSink |
-| GlobalDataFlow.cs:230:26:230:35 | sinkParam0 | GlobalDataFlow.cs:230:26:230:35 | sinkParam0 |
-| GlobalDataFlow.cs:230:26:230:35 | sinkParam0 | GlobalDataFlow.cs:230:26:230:35 | sinkParam0 |
-| GlobalDataFlow.cs:230:26:230:35 | sinkParam0 | GlobalDataFlow.cs:232:16:232:25 | access to parameter sinkParam0 |
-| GlobalDataFlow.cs:230:26:230:35 | sinkParam0 | GlobalDataFlow.cs:232:16:232:25 | access to parameter sinkParam0 |
-| GlobalDataFlow.cs:230:26:230:35 | sinkParam0 | GlobalDataFlow.cs:232:16:232:25 | access to parameter sinkParam0 |
-| GlobalDataFlow.cs:230:26:230:35 | sinkParam0 | GlobalDataFlow.cs:232:16:232:25 | access to parameter sinkParam0 |
-| GlobalDataFlow.cs:230:26:230:35 | sinkParam0 | GlobalDataFlow.cs:233:15:233:24 | access to parameter sinkParam0 |
-| GlobalDataFlow.cs:230:26:230:35 | sinkParam0 | GlobalDataFlow.cs:233:15:233:24 | access to parameter sinkParam0 |
-| GlobalDataFlow.cs:230:26:230:35 | sinkParam0 | GlobalDataFlow.cs:233:15:233:24 | access to parameter sinkParam0 |
-| GlobalDataFlow.cs:230:26:230:35 | sinkParam0 | GlobalDataFlow.cs:233:15:233:24 | access to parameter sinkParam0 |
-| GlobalDataFlow.cs:232:9:232:26 | call to method In0 | GlobalDataFlow.cs:232:9:232:26 | call to method In0 |
-| GlobalDataFlow.cs:232:16:232:25 | access to parameter sinkParam0 | GlobalDataFlow.cs:230:26:230:35 | sinkParam0 |
-| GlobalDataFlow.cs:232:16:232:25 | access to parameter sinkParam0 | GlobalDataFlow.cs:230:26:230:35 | sinkParam0 |
-| GlobalDataFlow.cs:232:16:232:25 | access to parameter sinkParam0 | GlobalDataFlow.cs:230:26:230:35 | sinkParam0 |
-| GlobalDataFlow.cs:232:16:232:25 | access to parameter sinkParam0 | GlobalDataFlow.cs:230:26:230:35 | sinkParam0 |
-| GlobalDataFlow.cs:232:16:232:25 | access to parameter sinkParam0 | GlobalDataFlow.cs:232:16:232:25 | access to parameter sinkParam0 |
-| GlobalDataFlow.cs:232:16:232:25 | access to parameter sinkParam0 | GlobalDataFlow.cs:233:15:233:24 | access to parameter sinkParam0 |
-| GlobalDataFlow.cs:232:16:232:25 | access to parameter sinkParam0 | GlobalDataFlow.cs:233:15:233:24 | access to parameter sinkParam0 |
-| GlobalDataFlow.cs:232:16:232:25 | access to parameter sinkParam0 | GlobalDataFlow.cs:233:15:233:24 | access to parameter sinkParam0 |
-| GlobalDataFlow.cs:232:16:232:25 | access to parameter sinkParam0 | GlobalDataFlow.cs:233:15:233:24 | access to parameter sinkParam0 |
-| GlobalDataFlow.cs:233:9:233:25 | call to method Check | GlobalDataFlow.cs:233:9:233:25 | call to method Check |
-| GlobalDataFlow.cs:233:15:233:24 | access to parameter sinkParam0 | GlobalDataFlow.cs:233:15:233:24 | access to parameter sinkParam0 |
-| GlobalDataFlow.cs:236:26:236:35 | sinkParam1 | GlobalDataFlow.cs:236:26:236:35 | sinkParam1 |
-| GlobalDataFlow.cs:236:26:236:35 | sinkParam1 | GlobalDataFlow.cs:236:26:236:35 | sinkParam1 |
-| GlobalDataFlow.cs:236:26:236:35 | sinkParam1 | GlobalDataFlow.cs:238:15:238:24 | access to parameter sinkParam1 |
-| GlobalDataFlow.cs:236:26:236:35 | sinkParam1 | GlobalDataFlow.cs:238:15:238:24 | access to parameter sinkParam1 |
-| GlobalDataFlow.cs:236:26:236:35 | sinkParam1 | GlobalDataFlow.cs:238:15:238:24 | access to parameter sinkParam1 |
-| GlobalDataFlow.cs:236:26:236:35 | sinkParam1 | GlobalDataFlow.cs:238:15:238:24 | access to parameter sinkParam1 |
-| GlobalDataFlow.cs:238:9:238:25 | call to method Check | GlobalDataFlow.cs:238:9:238:25 | call to method Check |
-| GlobalDataFlow.cs:238:15:238:24 | access to parameter sinkParam1 | GlobalDataFlow.cs:238:15:238:24 | access to parameter sinkParam1 |
-| GlobalDataFlow.cs:241:26:241:35 | sinkParam3 | GlobalDataFlow.cs:241:26:241:35 | sinkParam3 |
-| GlobalDataFlow.cs:241:26:241:35 | sinkParam3 | GlobalDataFlow.cs:241:26:241:35 | sinkParam3 |
-| GlobalDataFlow.cs:241:26:241:35 | sinkParam3 | GlobalDataFlow.cs:243:15:243:24 | access to parameter sinkParam3 |
-| GlobalDataFlow.cs:241:26:241:35 | sinkParam3 | GlobalDataFlow.cs:243:15:243:24 | access to parameter sinkParam3 |
-| GlobalDataFlow.cs:241:26:241:35 | sinkParam3 | GlobalDataFlow.cs:243:15:243:24 | access to parameter sinkParam3 |
-| GlobalDataFlow.cs:241:26:241:35 | sinkParam3 | GlobalDataFlow.cs:243:15:243:24 | access to parameter sinkParam3 |
-| GlobalDataFlow.cs:243:9:243:25 | call to method Check | GlobalDataFlow.cs:243:9:243:25 | call to method Check |
-| GlobalDataFlow.cs:243:15:243:24 | access to parameter sinkParam3 | GlobalDataFlow.cs:243:15:243:24 | access to parameter sinkParam3 |
-| GlobalDataFlow.cs:246:26:246:35 | sinkParam4 | GlobalDataFlow.cs:246:26:246:35 | sinkParam4 |
-| GlobalDataFlow.cs:246:26:246:35 | sinkParam4 | GlobalDataFlow.cs:246:26:246:35 | sinkParam4 |
-| GlobalDataFlow.cs:246:26:246:35 | sinkParam4 | GlobalDataFlow.cs:248:15:248:24 | access to parameter sinkParam4 |
-| GlobalDataFlow.cs:246:26:246:35 | sinkParam4 | GlobalDataFlow.cs:248:15:248:24 | access to parameter sinkParam4 |
-| GlobalDataFlow.cs:246:26:246:35 | sinkParam4 | GlobalDataFlow.cs:248:15:248:24 | access to parameter sinkParam4 |
-| GlobalDataFlow.cs:246:26:246:35 | sinkParam4 | GlobalDataFlow.cs:248:15:248:24 | access to parameter sinkParam4 |
-| GlobalDataFlow.cs:248:9:248:25 | call to method Check | GlobalDataFlow.cs:248:9:248:25 | call to method Check |
-| GlobalDataFlow.cs:248:15:248:24 | access to parameter sinkParam4 | GlobalDataFlow.cs:248:15:248:24 | access to parameter sinkParam4 |
-| GlobalDataFlow.cs:251:26:251:35 | sinkParam5 | GlobalDataFlow.cs:251:26:251:35 | sinkParam5 |
-| GlobalDataFlow.cs:251:26:251:35 | sinkParam5 | GlobalDataFlow.cs:251:26:251:35 | sinkParam5 |
-| GlobalDataFlow.cs:251:26:251:35 | sinkParam5 | GlobalDataFlow.cs:253:15:253:24 | access to parameter sinkParam5 |
-| GlobalDataFlow.cs:251:26:251:35 | sinkParam5 | GlobalDataFlow.cs:253:15:253:24 | access to parameter sinkParam5 |
-| GlobalDataFlow.cs:251:26:251:35 | sinkParam5 | GlobalDataFlow.cs:253:15:253:24 | access to parameter sinkParam5 |
-| GlobalDataFlow.cs:251:26:251:35 | sinkParam5 | GlobalDataFlow.cs:253:15:253:24 | access to parameter sinkParam5 |
-| GlobalDataFlow.cs:253:9:253:25 | call to method Check | GlobalDataFlow.cs:253:9:253:25 | call to method Check |
-| GlobalDataFlow.cs:253:15:253:24 | access to parameter sinkParam5 | GlobalDataFlow.cs:253:15:253:24 | access to parameter sinkParam5 |
-| GlobalDataFlow.cs:256:26:256:35 | sinkParam6 | GlobalDataFlow.cs:256:26:256:35 | sinkParam6 |
-| GlobalDataFlow.cs:256:26:256:35 | sinkParam6 | GlobalDataFlow.cs:256:26:256:35 | sinkParam6 |
-| GlobalDataFlow.cs:256:26:256:35 | sinkParam6 | GlobalDataFlow.cs:258:15:258:24 | access to parameter sinkParam6 |
-| GlobalDataFlow.cs:256:26:256:35 | sinkParam6 | GlobalDataFlow.cs:258:15:258:24 | access to parameter sinkParam6 |
-| GlobalDataFlow.cs:256:26:256:35 | sinkParam6 | GlobalDataFlow.cs:258:15:258:24 | access to parameter sinkParam6 |
-| GlobalDataFlow.cs:256:26:256:35 | sinkParam6 | GlobalDataFlow.cs:258:15:258:24 | access to parameter sinkParam6 |
-| GlobalDataFlow.cs:258:9:258:25 | call to method Check | GlobalDataFlow.cs:258:9:258:25 | call to method Check |
-| GlobalDataFlow.cs:258:15:258:24 | access to parameter sinkParam6 | GlobalDataFlow.cs:258:15:258:24 | access to parameter sinkParam6 |
-| GlobalDataFlow.cs:261:26:261:35 | sinkParam7 | GlobalDataFlow.cs:261:26:261:35 | sinkParam7 |
-| GlobalDataFlow.cs:261:26:261:35 | sinkParam7 | GlobalDataFlow.cs:261:26:261:35 | sinkParam7 |
-| GlobalDataFlow.cs:261:26:261:35 | sinkParam7 | GlobalDataFlow.cs:263:15:263:24 | access to parameter sinkParam7 |
-| GlobalDataFlow.cs:261:26:261:35 | sinkParam7 | GlobalDataFlow.cs:263:15:263:24 | access to parameter sinkParam7 |
-| GlobalDataFlow.cs:261:26:261:35 | sinkParam7 | GlobalDataFlow.cs:263:15:263:24 | access to parameter sinkParam7 |
-| GlobalDataFlow.cs:261:26:261:35 | sinkParam7 | GlobalDataFlow.cs:263:15:263:24 | access to parameter sinkParam7 |
-| GlobalDataFlow.cs:263:9:263:25 | call to method Check | GlobalDataFlow.cs:263:9:263:25 | call to method Check |
-| GlobalDataFlow.cs:263:15:263:24 | access to parameter sinkParam7 | GlobalDataFlow.cs:263:15:263:24 | access to parameter sinkParam7 |
-| GlobalDataFlow.cs:266:29:266:41 | nonSinkParam0 | GlobalDataFlow.cs:266:29:266:41 | nonSinkParam0 |
-| GlobalDataFlow.cs:266:29:266:41 | nonSinkParam0 | GlobalDataFlow.cs:266:29:266:41 | nonSinkParam0 |
-| GlobalDataFlow.cs:266:29:266:41 | nonSinkParam0 | GlobalDataFlow.cs:268:15:268:27 | access to parameter nonSinkParam0 |
-| GlobalDataFlow.cs:266:29:266:41 | nonSinkParam0 | GlobalDataFlow.cs:268:15:268:27 | access to parameter nonSinkParam0 |
-| GlobalDataFlow.cs:266:29:266:41 | nonSinkParam0 | GlobalDataFlow.cs:268:15:268:27 | access to parameter nonSinkParam0 |
-| GlobalDataFlow.cs:266:29:266:41 | nonSinkParam0 | GlobalDataFlow.cs:268:15:268:27 | access to parameter nonSinkParam0 |
-| GlobalDataFlow.cs:268:9:268:28 | call to method Check | GlobalDataFlow.cs:268:9:268:28 | call to method Check |
-| GlobalDataFlow.cs:268:15:268:27 | access to parameter nonSinkParam0 | GlobalDataFlow.cs:268:15:268:27 | access to parameter nonSinkParam0 |
-| GlobalDataFlow.cs:271:26:271:26 | x | GlobalDataFlow.cs:271:26:271:26 | x |
-| GlobalDataFlow.cs:271:26:271:26 | x | GlobalDataFlow.cs:271:26:271:26 | x |
-| GlobalDataFlow.cs:271:26:271:26 | x | GlobalDataFlow.cs:273:37:273:37 | access to parameter x |
-| GlobalDataFlow.cs:271:26:271:26 | x | GlobalDataFlow.cs:273:37:273:37 | access to parameter x |
-| GlobalDataFlow.cs:271:26:271:26 | x | GlobalDataFlow.cs:273:37:273:37 | access to parameter x |
-| GlobalDataFlow.cs:271:26:271:26 | x | GlobalDataFlow.cs:273:37:273:37 | access to parameter x |
-| GlobalDataFlow.cs:273:13:273:38 | SSA def(y) | GlobalDataFlow.cs:273:13:273:38 | SSA def(y) |
-| GlobalDataFlow.cs:273:13:273:38 | SSA def(y) | GlobalDataFlow.cs:274:16:274:16 | (...) ... |
-| GlobalDataFlow.cs:273:13:273:38 | SSA def(y) | GlobalDataFlow.cs:274:16:274:16 | (...) ... |
-| GlobalDataFlow.cs:273:13:273:38 | SSA def(y) | GlobalDataFlow.cs:274:16:274:16 | (...) ... |
-| GlobalDataFlow.cs:273:13:273:38 | SSA def(y) | GlobalDataFlow.cs:274:16:274:16 | (...) ... |
-| GlobalDataFlow.cs:273:13:273:38 | SSA def(y) | GlobalDataFlow.cs:274:16:274:16 | access to local variable y |
-| GlobalDataFlow.cs:273:13:273:38 | SSA def(y) | GlobalDataFlow.cs:274:16:274:16 | access to local variable y |
-| GlobalDataFlow.cs:273:13:273:38 | SSA def(y) | GlobalDataFlow.cs:274:16:274:16 | access to local variable y |
-| GlobalDataFlow.cs:273:13:273:38 | SSA def(y) | GlobalDataFlow.cs:274:16:274:16 | access to local variable y |
-| GlobalDataFlow.cs:273:13:273:38 | SSA def(y) | GlobalDataFlow.cs:274:16:274:41 | ... ? ... : ... |
-| GlobalDataFlow.cs:273:13:273:38 | SSA def(y) | GlobalDataFlow.cs:274:16:274:41 | ... ? ... : ... |
-| GlobalDataFlow.cs:273:13:273:38 | SSA def(y) | GlobalDataFlow.cs:274:16:274:41 | ... ? ... : ... |
-| GlobalDataFlow.cs:273:13:273:38 | SSA def(y) | GlobalDataFlow.cs:274:16:274:41 | ... ? ... : ... |
-| GlobalDataFlow.cs:273:13:273:38 | SSA def(y) | GlobalDataFlow.cs:274:41:274:41 | access to local variable y |
-| GlobalDataFlow.cs:273:13:273:38 | SSA def(y) | GlobalDataFlow.cs:274:41:274:41 | access to local variable y |
-| GlobalDataFlow.cs:273:13:273:38 | SSA def(y) | GlobalDataFlow.cs:274:41:274:41 | access to local variable y |
-| GlobalDataFlow.cs:273:13:273:38 | SSA def(y) | GlobalDataFlow.cs:274:41:274:41 | access to local variable y |
-| GlobalDataFlow.cs:273:13:273:38 | T y = ... | GlobalDataFlow.cs:273:13:273:38 | T y = ... |
-| GlobalDataFlow.cs:273:17:273:38 | call to method ApplyFunc | GlobalDataFlow.cs:273:13:273:38 | SSA def(y) |
-| GlobalDataFlow.cs:273:17:273:38 | call to method ApplyFunc | GlobalDataFlow.cs:273:13:273:38 | SSA def(y) |
-| GlobalDataFlow.cs:273:17:273:38 | call to method ApplyFunc | GlobalDataFlow.cs:273:13:273:38 | SSA def(y) |
-| GlobalDataFlow.cs:273:17:273:38 | call to method ApplyFunc | GlobalDataFlow.cs:273:13:273:38 | SSA def(y) |
-| GlobalDataFlow.cs:273:17:273:38 | call to method ApplyFunc | GlobalDataFlow.cs:273:17:273:38 | call to method ApplyFunc |
-| GlobalDataFlow.cs:273:17:273:38 | call to method ApplyFunc | GlobalDataFlow.cs:274:16:274:16 | (...) ... |
-| GlobalDataFlow.cs:273:17:273:38 | call to method ApplyFunc | GlobalDataFlow.cs:274:16:274:16 | (...) ... |
-| GlobalDataFlow.cs:273:17:273:38 | call to method ApplyFunc | GlobalDataFlow.cs:274:16:274:16 | (...) ... |
-| GlobalDataFlow.cs:273:17:273:38 | call to method ApplyFunc | GlobalDataFlow.cs:274:16:274:16 | (...) ... |
-| GlobalDataFlow.cs:273:17:273:38 | call to method ApplyFunc | GlobalDataFlow.cs:274:16:274:16 | access to local variable y |
-| GlobalDataFlow.cs:273:17:273:38 | call to method ApplyFunc | GlobalDataFlow.cs:274:16:274:16 | access to local variable y |
-| GlobalDataFlow.cs:273:17:273:38 | call to method ApplyFunc | GlobalDataFlow.cs:274:16:274:16 | access to local variable y |
-| GlobalDataFlow.cs:273:17:273:38 | call to method ApplyFunc | GlobalDataFlow.cs:274:16:274:16 | access to local variable y |
-| GlobalDataFlow.cs:273:17:273:38 | call to method ApplyFunc | GlobalDataFlow.cs:274:16:274:41 | ... ? ... : ... |
-| GlobalDataFlow.cs:273:17:273:38 | call to method ApplyFunc | GlobalDataFlow.cs:274:16:274:41 | ... ? ... : ... |
-| GlobalDataFlow.cs:273:17:273:38 | call to method ApplyFunc | GlobalDataFlow.cs:274:16:274:41 | ... ? ... : ... |
-| GlobalDataFlow.cs:273:17:273:38 | call to method ApplyFunc | GlobalDataFlow.cs:274:16:274:41 | ... ? ... : ... |
-| GlobalDataFlow.cs:273:17:273:38 | call to method ApplyFunc | GlobalDataFlow.cs:274:41:274:41 | access to local variable y |
-| GlobalDataFlow.cs:273:17:273:38 | call to method ApplyFunc | GlobalDataFlow.cs:274:41:274:41 | access to local variable y |
-| GlobalDataFlow.cs:273:17:273:38 | call to method ApplyFunc | GlobalDataFlow.cs:274:41:274:41 | access to local variable y |
-| GlobalDataFlow.cs:273:17:273:38 | call to method ApplyFunc | GlobalDataFlow.cs:274:41:274:41 | access to local variable y |
-| GlobalDataFlow.cs:273:27:273:28 | x0 | GlobalDataFlow.cs:273:27:273:28 | x0 |
-| GlobalDataFlow.cs:273:27:273:28 | x0 | GlobalDataFlow.cs:273:27:273:28 | x0 |
-| GlobalDataFlow.cs:273:27:273:28 | x0 | GlobalDataFlow.cs:273:33:273:34 | access to parameter x0 |
-| GlobalDataFlow.cs:273:27:273:28 | x0 | GlobalDataFlow.cs:273:33:273:34 | access to parameter x0 |
-| GlobalDataFlow.cs:273:27:273:28 | x0 | GlobalDataFlow.cs:273:33:273:34 | access to parameter x0 |
-| GlobalDataFlow.cs:273:27:273:28 | x0 | GlobalDataFlow.cs:273:33:273:34 | access to parameter x0 |
-| GlobalDataFlow.cs:273:27:273:34 | (...) => ... | GlobalDataFlow.cs:273:27:273:34 | (...) => ... |
-| GlobalDataFlow.cs:273:27:273:34 | (...) => ... | GlobalDataFlow.cs:359:41:359:41 | f |
-| GlobalDataFlow.cs:273:27:273:34 | (...) => ... | GlobalDataFlow.cs:359:41:359:41 | f |
-| GlobalDataFlow.cs:273:33:273:34 | access to parameter x0 | GlobalDataFlow.cs:273:33:273:34 | access to parameter x0 |
-| GlobalDataFlow.cs:273:33:273:34 | access to parameter x0 | GlobalDataFlow.cs:361:16:361:19 | delegate call |
-| GlobalDataFlow.cs:273:33:273:34 | access to parameter x0 | GlobalDataFlow.cs:361:16:361:19 | delegate call |
-| GlobalDataFlow.cs:273:37:273:37 | access to parameter x | GlobalDataFlow.cs:273:17:273:38 | call to method ApplyFunc |
-| GlobalDataFlow.cs:273:37:273:37 | access to parameter x | GlobalDataFlow.cs:273:17:273:38 | call to method ApplyFunc |
-| GlobalDataFlow.cs:273:37:273:37 | access to parameter x | GlobalDataFlow.cs:273:17:273:38 | call to method ApplyFunc |
-| GlobalDataFlow.cs:273:37:273:37 | access to parameter x | GlobalDataFlow.cs:273:17:273:38 | call to method ApplyFunc |
-| GlobalDataFlow.cs:273:37:273:37 | access to parameter x | GlobalDataFlow.cs:273:37:273:37 | access to parameter x |
-| GlobalDataFlow.cs:273:37:273:37 | access to parameter x | GlobalDataFlow.cs:359:46:359:46 | x |
-| GlobalDataFlow.cs:273:37:273:37 | access to parameter x | GlobalDataFlow.cs:359:46:359:46 | x |
-| GlobalDataFlow.cs:273:37:273:37 | access to parameter x | GlobalDataFlow.cs:359:46:359:46 | x |
-| GlobalDataFlow.cs:273:37:273:37 | access to parameter x | GlobalDataFlow.cs:359:46:359:46 | x |
-| GlobalDataFlow.cs:274:16:274:16 | (...) ... | GlobalDataFlow.cs:274:16:274:16 | (...) ... |
-| GlobalDataFlow.cs:274:16:274:16 | access to local variable y | GlobalDataFlow.cs:274:16:274:16 | (...) ... |
-| GlobalDataFlow.cs:274:16:274:16 | access to local variable y | GlobalDataFlow.cs:274:16:274:16 | (...) ... |
-| GlobalDataFlow.cs:274:16:274:16 | access to local variable y | GlobalDataFlow.cs:274:16:274:16 | (...) ... |
-| GlobalDataFlow.cs:274:16:274:16 | access to local variable y | GlobalDataFlow.cs:274:16:274:16 | (...) ... |
-| GlobalDataFlow.cs:274:16:274:16 | access to local variable y | GlobalDataFlow.cs:274:16:274:16 | access to local variable y |
-| GlobalDataFlow.cs:274:16:274:16 | access to local variable y | GlobalDataFlow.cs:274:16:274:41 | ... ? ... : ... |
-| GlobalDataFlow.cs:274:16:274:16 | access to local variable y | GlobalDataFlow.cs:274:16:274:41 | ... ? ... : ... |
-| GlobalDataFlow.cs:274:16:274:16 | access to local variable y | GlobalDataFlow.cs:274:16:274:41 | ... ? ... : ... |
-| GlobalDataFlow.cs:274:16:274:16 | access to local variable y | GlobalDataFlow.cs:274:16:274:41 | ... ? ... : ... |
-| GlobalDataFlow.cs:274:16:274:16 | access to local variable y | GlobalDataFlow.cs:274:41:274:41 | access to local variable y |
-| GlobalDataFlow.cs:274:16:274:16 | access to local variable y | GlobalDataFlow.cs:274:41:274:41 | access to local variable y |
-| GlobalDataFlow.cs:274:16:274:16 | access to local variable y | GlobalDataFlow.cs:274:41:274:41 | access to local variable y |
-| GlobalDataFlow.cs:274:16:274:16 | access to local variable y | GlobalDataFlow.cs:274:41:274:41 | access to local variable y |
-| GlobalDataFlow.cs:274:16:274:24 | ... == ... | GlobalDataFlow.cs:274:16:274:24 | ... == ... |
-| GlobalDataFlow.cs:274:16:274:41 | ... ? ... : ... | GlobalDataFlow.cs:70:21:70:46 | call to method Return |
-| GlobalDataFlow.cs:274:16:274:41 | ... ? ... : ... | GlobalDataFlow.cs:70:21:70:46 | call to method Return |
-| GlobalDataFlow.cs:274:16:274:41 | ... ? ... : ... | GlobalDataFlow.cs:72:29:72:101 | call to method Invoke |
-| GlobalDataFlow.cs:274:16:274:41 | ... ? ... : ... | GlobalDataFlow.cs:72:29:72:101 | call to method Invoke |
-| GlobalDataFlow.cs:274:16:274:41 | ... ? ... : ... | GlobalDataFlow.cs:100:24:100:33 | call to method Return |
-| GlobalDataFlow.cs:274:16:274:41 | ... ? ... : ... | GlobalDataFlow.cs:100:24:100:33 | call to method Return |
-| GlobalDataFlow.cs:274:16:274:41 | ... ? ... : ... | GlobalDataFlow.cs:102:28:102:103 | call to method Invoke |
-| GlobalDataFlow.cs:274:16:274:41 | ... ? ... : ... | GlobalDataFlow.cs:102:28:102:103 | call to method Invoke |
-| GlobalDataFlow.cs:274:16:274:41 | ... ? ... : ... | GlobalDataFlow.cs:274:16:274:41 | ... ? ... : ... |
-| GlobalDataFlow.cs:274:16:274:41 | ... ? ... : ... | GlobalDataFlow.cs:361:16:361:19 | delegate call |
-| GlobalDataFlow.cs:274:16:274:41 | ... ? ... : ... | GlobalDataFlow.cs:361:16:361:19 | delegate call |
-| GlobalDataFlow.cs:274:21:274:24 | null | GlobalDataFlow.cs:274:21:274:24 | null |
-| GlobalDataFlow.cs:274:28:274:37 | default(...) | GlobalDataFlow.cs:274:16:274:41 | ... ? ... : ... |
-| GlobalDataFlow.cs:274:28:274:37 | default(...) | GlobalDataFlow.cs:274:16:274:41 | ... ? ... : ... |
-| GlobalDataFlow.cs:274:28:274:37 | default(...) | GlobalDataFlow.cs:274:28:274:37 | default(...) |
-| GlobalDataFlow.cs:274:41:274:41 | access to local variable y | GlobalDataFlow.cs:274:16:274:41 | ... ? ... : ... |
-| GlobalDataFlow.cs:274:41:274:41 | access to local variable y | GlobalDataFlow.cs:274:16:274:41 | ... ? ... : ... |
-| GlobalDataFlow.cs:274:41:274:41 | access to local variable y | GlobalDataFlow.cs:274:16:274:41 | ... ? ... : ... |
-| GlobalDataFlow.cs:274:41:274:41 | access to local variable y | GlobalDataFlow.cs:274:16:274:41 | ... ? ... : ... |
-| GlobalDataFlow.cs:274:41:274:41 | access to local variable y | GlobalDataFlow.cs:274:41:274:41 | access to local variable y |
-| GlobalDataFlow.cs:277:32:277:32 | x | GlobalDataFlow.cs:277:32:277:32 | x |
-| GlobalDataFlow.cs:277:32:277:32 | x | GlobalDataFlow.cs:277:32:277:32 | x |
-| GlobalDataFlow.cs:277:32:277:32 | x | GlobalDataFlow.cs:279:9:279:13 | SSA def(y) |
-| GlobalDataFlow.cs:277:32:277:32 | x | GlobalDataFlow.cs:279:9:279:13 | SSA def(y) |
-| GlobalDataFlow.cs:277:32:277:32 | x | GlobalDataFlow.cs:279:9:279:13 | SSA def(y) |
-| GlobalDataFlow.cs:277:32:277:32 | x | GlobalDataFlow.cs:279:9:279:13 | SSA def(y) |
-| GlobalDataFlow.cs:277:32:277:32 | x | GlobalDataFlow.cs:279:13:279:13 | access to parameter x |
-| GlobalDataFlow.cs:277:32:277:32 | x | GlobalDataFlow.cs:279:13:279:13 | access to parameter x |
-| GlobalDataFlow.cs:277:32:277:32 | x | GlobalDataFlow.cs:279:13:279:13 | access to parameter x |
-| GlobalDataFlow.cs:277:32:277:32 | x | GlobalDataFlow.cs:279:13:279:13 | access to parameter x |
-| GlobalDataFlow.cs:279:9:279:13 | ... = ... | GlobalDataFlow.cs:279:9:279:13 | ... = ... |
-| GlobalDataFlow.cs:279:9:279:13 | SSA def(y) | GlobalDataFlow.cs:75:30:75:34 | SSA def(sink2) |
-| GlobalDataFlow.cs:279:9:279:13 | SSA def(y) | GlobalDataFlow.cs:75:30:75:34 | SSA def(sink2) |
-| GlobalDataFlow.cs:279:9:279:13 | SSA def(y) | GlobalDataFlow.cs:104:27:104:34 | SSA def(nonSink0) |
-| GlobalDataFlow.cs:279:9:279:13 | SSA def(y) | GlobalDataFlow.cs:104:27:104:34 | SSA def(nonSink0) |
-| GlobalDataFlow.cs:279:9:279:13 | SSA def(y) | GlobalDataFlow.cs:279:9:279:13 | SSA def(y) |
-| GlobalDataFlow.cs:279:13:279:13 | access to parameter x | GlobalDataFlow.cs:279:9:279:13 | SSA def(y) |
-| GlobalDataFlow.cs:279:13:279:13 | access to parameter x | GlobalDataFlow.cs:279:9:279:13 | SSA def(y) |
-| GlobalDataFlow.cs:279:13:279:13 | access to parameter x | GlobalDataFlow.cs:279:9:279:13 | SSA def(y) |
-| GlobalDataFlow.cs:279:13:279:13 | access to parameter x | GlobalDataFlow.cs:279:9:279:13 | SSA def(y) |
-| GlobalDataFlow.cs:279:13:279:13 | access to parameter x | GlobalDataFlow.cs:279:13:279:13 | access to parameter x |
-| GlobalDataFlow.cs:282:32:282:32 | x | GlobalDataFlow.cs:282:32:282:32 | x |
-| GlobalDataFlow.cs:282:32:282:32 | x | GlobalDataFlow.cs:282:32:282:32 | x |
-| GlobalDataFlow.cs:282:32:282:32 | x | GlobalDataFlow.cs:284:9:284:13 | SSA def(y) |
-| GlobalDataFlow.cs:282:32:282:32 | x | GlobalDataFlow.cs:284:9:284:13 | SSA def(y) |
-| GlobalDataFlow.cs:282:32:282:32 | x | GlobalDataFlow.cs:284:9:284:13 | SSA def(y) |
-| GlobalDataFlow.cs:282:32:282:32 | x | GlobalDataFlow.cs:284:9:284:13 | SSA def(y) |
-| GlobalDataFlow.cs:282:32:282:32 | x | GlobalDataFlow.cs:284:13:284:13 | access to parameter x |
-| GlobalDataFlow.cs:282:32:282:32 | x | GlobalDataFlow.cs:284:13:284:13 | access to parameter x |
-| GlobalDataFlow.cs:282:32:282:32 | x | GlobalDataFlow.cs:284:13:284:13 | access to parameter x |
-| GlobalDataFlow.cs:282:32:282:32 | x | GlobalDataFlow.cs:284:13:284:13 | access to parameter x |
-| GlobalDataFlow.cs:284:9:284:13 | ... = ... | GlobalDataFlow.cs:284:9:284:13 | ... = ... |
-| GlobalDataFlow.cs:284:9:284:13 | SSA def(y) | GlobalDataFlow.cs:78:30:78:34 | SSA def(sink3) |
-| GlobalDataFlow.cs:284:9:284:13 | SSA def(y) | GlobalDataFlow.cs:78:30:78:34 | SSA def(sink3) |
-| GlobalDataFlow.cs:284:9:284:13 | SSA def(y) | GlobalDataFlow.cs:106:27:106:34 | SSA def(nonSink0) |
-| GlobalDataFlow.cs:284:9:284:13 | SSA def(y) | GlobalDataFlow.cs:106:27:106:34 | SSA def(nonSink0) |
-| GlobalDataFlow.cs:284:9:284:13 | SSA def(y) | GlobalDataFlow.cs:284:9:284:13 | SSA def(y) |
-| GlobalDataFlow.cs:284:13:284:13 | access to parameter x | GlobalDataFlow.cs:284:9:284:13 | SSA def(y) |
-| GlobalDataFlow.cs:284:13:284:13 | access to parameter x | GlobalDataFlow.cs:284:9:284:13 | SSA def(y) |
-| GlobalDataFlow.cs:284:13:284:13 | access to parameter x | GlobalDataFlow.cs:284:9:284:13 | SSA def(y) |
-| GlobalDataFlow.cs:284:13:284:13 | access to parameter x | GlobalDataFlow.cs:284:9:284:13 | SSA def(y) |
-| GlobalDataFlow.cs:284:13:284:13 | access to parameter x | GlobalDataFlow.cs:284:13:284:13 | access to parameter x |
-| GlobalDataFlow.cs:287:31:287:40 | sinkParam8 | GlobalDataFlow.cs:287:31:287:40 | sinkParam8 |
-| GlobalDataFlow.cs:287:31:287:40 | sinkParam8 | GlobalDataFlow.cs:287:31:287:40 | sinkParam8 |
-| GlobalDataFlow.cs:287:31:287:40 | sinkParam8 | GlobalDataFlow.cs:289:15:289:24 | access to parameter sinkParam8 |
-| GlobalDataFlow.cs:287:31:287:40 | sinkParam8 | GlobalDataFlow.cs:289:15:289:24 | access to parameter sinkParam8 |
-| GlobalDataFlow.cs:287:31:287:40 | sinkParam8 | GlobalDataFlow.cs:290:16:290:25 | access to parameter sinkParam8 |
-| GlobalDataFlow.cs:287:31:287:40 | sinkParam8 | GlobalDataFlow.cs:290:16:290:25 | access to parameter sinkParam8 |
-| GlobalDataFlow.cs:289:9:289:25 | call to method Check | GlobalDataFlow.cs:289:9:289:25 | call to method Check |
-| GlobalDataFlow.cs:289:15:289:24 | access to parameter sinkParam8 | GlobalDataFlow.cs:289:15:289:24 | access to parameter sinkParam8 |
-| GlobalDataFlow.cs:289:15:289:24 | access to parameter sinkParam8 | GlobalDataFlow.cs:290:16:290:25 | access to parameter sinkParam8 |
-| GlobalDataFlow.cs:289:15:289:24 | access to parameter sinkParam8 | GlobalDataFlow.cs:290:16:290:25 | access to parameter sinkParam8 |
-| GlobalDataFlow.cs:290:16:290:25 | access to parameter sinkParam8 | GlobalDataFlow.cs:82:84:82:94 | [output] delegate creation of type Func<String,String> |
-| GlobalDataFlow.cs:290:16:290:25 | access to parameter sinkParam8 | GlobalDataFlow.cs:82:84:82:94 | [output] delegate creation of type Func<String,String> |
-| GlobalDataFlow.cs:290:16:290:25 | access to parameter sinkParam8 | GlobalDataFlow.cs:290:16:290:25 | access to parameter sinkParam8 |
-| GlobalDataFlow.cs:293:32:293:41 | sinkParam9 | GlobalDataFlow.cs:293:32:293:41 | sinkParam9 |
-| GlobalDataFlow.cs:293:32:293:41 | sinkParam9 | GlobalDataFlow.cs:293:32:293:41 | sinkParam9 |
-| GlobalDataFlow.cs:293:32:293:41 | sinkParam9 | GlobalDataFlow.cs:295:15:295:24 | access to parameter sinkParam9 |
-| GlobalDataFlow.cs:293:32:293:41 | sinkParam9 | GlobalDataFlow.cs:295:15:295:24 | access to parameter sinkParam9 |
-| GlobalDataFlow.cs:293:32:293:41 | sinkParam9 | GlobalDataFlow.cs:295:15:295:24 | access to parameter sinkParam9 |
-| GlobalDataFlow.cs:293:32:293:41 | sinkParam9 | GlobalDataFlow.cs:295:15:295:24 | access to parameter sinkParam9 |
-| GlobalDataFlow.cs:293:32:293:41 | sinkParam9 | GlobalDataFlow.cs:296:16:296:25 | access to parameter sinkParam9 |
-| GlobalDataFlow.cs:293:32:293:41 | sinkParam9 | GlobalDataFlow.cs:296:16:296:25 | access to parameter sinkParam9 |
-| GlobalDataFlow.cs:293:32:293:41 | sinkParam9 | GlobalDataFlow.cs:296:16:296:25 | access to parameter sinkParam9 |
-| GlobalDataFlow.cs:293:32:293:41 | sinkParam9 | GlobalDataFlow.cs:296:16:296:25 | access to parameter sinkParam9 |
-| GlobalDataFlow.cs:295:9:295:25 | call to method Check | GlobalDataFlow.cs:295:9:295:25 | call to method Check |
-| GlobalDataFlow.cs:295:15:295:24 | access to parameter sinkParam9 | GlobalDataFlow.cs:295:15:295:24 | access to parameter sinkParam9 |
-| GlobalDataFlow.cs:295:15:295:24 | access to parameter sinkParam9 | GlobalDataFlow.cs:296:16:296:25 | access to parameter sinkParam9 |
-| GlobalDataFlow.cs:295:15:295:24 | access to parameter sinkParam9 | GlobalDataFlow.cs:296:16:296:25 | access to parameter sinkParam9 |
-| GlobalDataFlow.cs:295:15:295:24 | access to parameter sinkParam9 | GlobalDataFlow.cs:296:16:296:25 | access to parameter sinkParam9 |
-| GlobalDataFlow.cs:295:15:295:24 | access to parameter sinkParam9 | GlobalDataFlow.cs:296:16:296:25 | access to parameter sinkParam9 |
-| GlobalDataFlow.cs:296:16:296:25 | access to parameter sinkParam9 | GlobalDataFlow.cs:205:76:205:90 | call to method ReturnCheck2 |
-| GlobalDataFlow.cs:296:16:296:25 | access to parameter sinkParam9 | GlobalDataFlow.cs:205:76:205:90 | call to method ReturnCheck2 |
-| GlobalDataFlow.cs:296:16:296:25 | access to parameter sinkParam9 | GlobalDataFlow.cs:296:16:296:25 | access to parameter sinkParam9 |
-| GlobalDataFlow.cs:299:32:299:42 | sinkParam11 | GlobalDataFlow.cs:299:32:299:42 | sinkParam11 |
-| GlobalDataFlow.cs:299:32:299:42 | sinkParam11 | GlobalDataFlow.cs:299:32:299:42 | sinkParam11 |
-| GlobalDataFlow.cs:299:32:299:42 | sinkParam11 | GlobalDataFlow.cs:301:15:301:25 | access to parameter sinkParam11 |
-| GlobalDataFlow.cs:299:32:299:42 | sinkParam11 | GlobalDataFlow.cs:301:15:301:25 | access to parameter sinkParam11 |
-| GlobalDataFlow.cs:299:32:299:42 | sinkParam11 | GlobalDataFlow.cs:302:16:302:26 | access to parameter sinkParam11 |
-| GlobalDataFlow.cs:299:32:299:42 | sinkParam11 | GlobalDataFlow.cs:302:16:302:26 | access to parameter sinkParam11 |
-| GlobalDataFlow.cs:301:9:301:26 | call to method Check | GlobalDataFlow.cs:301:9:301:26 | call to method Check |
-| GlobalDataFlow.cs:301:15:301:25 | access to parameter sinkParam11 | GlobalDataFlow.cs:301:15:301:25 | access to parameter sinkParam11 |
-| GlobalDataFlow.cs:301:15:301:25 | access to parameter sinkParam11 | GlobalDataFlow.cs:302:16:302:26 | access to parameter sinkParam11 |
-| GlobalDataFlow.cs:301:15:301:25 | access to parameter sinkParam11 | GlobalDataFlow.cs:302:16:302:26 | access to parameter sinkParam11 |
-| GlobalDataFlow.cs:302:16:302:26 | access to parameter sinkParam11 | GlobalDataFlow.cs:210:37:210:48 | [output] delegate creation of type Func<String,String> |
-| GlobalDataFlow.cs:302:16:302:26 | access to parameter sinkParam11 | GlobalDataFlow.cs:210:37:210:48 | [output] delegate creation of type Func<String,String> |
-| GlobalDataFlow.cs:302:16:302:26 | access to parameter sinkParam11 | GlobalDataFlow.cs:224:37:224:48 | [output] delegate creation of type Func<String,String> |
-| GlobalDataFlow.cs:302:16:302:26 | access to parameter sinkParam11 | GlobalDataFlow.cs:224:37:224:48 | [output] delegate creation of type Func<String,String> |
-| GlobalDataFlow.cs:302:16:302:26 | access to parameter sinkParam11 | GlobalDataFlow.cs:302:16:302:26 | access to parameter sinkParam11 |
-| GlobalDataFlow.cs:305:34:305:45 | nonSinkParam | GlobalDataFlow.cs:305:34:305:45 | nonSinkParam |
-| GlobalDataFlow.cs:305:34:305:45 | nonSinkParam | GlobalDataFlow.cs:305:34:305:45 | nonSinkParam |
-| GlobalDataFlow.cs:305:34:305:45 | nonSinkParam | GlobalDataFlow.cs:307:15:307:26 | access to parameter nonSinkParam |
-| GlobalDataFlow.cs:305:34:305:45 | nonSinkParam | GlobalDataFlow.cs:307:15:307:26 | access to parameter nonSinkParam |
-| GlobalDataFlow.cs:305:34:305:45 | nonSinkParam | GlobalDataFlow.cs:307:15:307:26 | access to parameter nonSinkParam |
-| GlobalDataFlow.cs:305:34:305:45 | nonSinkParam | GlobalDataFlow.cs:307:15:307:26 | access to parameter nonSinkParam |
-| GlobalDataFlow.cs:305:34:305:45 | nonSinkParam | GlobalDataFlow.cs:308:16:308:27 | access to parameter nonSinkParam |
-| GlobalDataFlow.cs:305:34:305:45 | nonSinkParam | GlobalDataFlow.cs:308:16:308:27 | access to parameter nonSinkParam |
-| GlobalDataFlow.cs:305:34:305:45 | nonSinkParam | GlobalDataFlow.cs:308:16:308:27 | access to parameter nonSinkParam |
-| GlobalDataFlow.cs:305:34:305:45 | nonSinkParam | GlobalDataFlow.cs:308:16:308:27 | access to parameter nonSinkParam |
-| GlobalDataFlow.cs:307:9:307:27 | call to method Check | GlobalDataFlow.cs:307:9:307:27 | call to method Check |
-| GlobalDataFlow.cs:307:15:307:26 | access to parameter nonSinkParam | GlobalDataFlow.cs:307:15:307:26 | access to parameter nonSinkParam |
-| GlobalDataFlow.cs:307:15:307:26 | access to parameter nonSinkParam | GlobalDataFlow.cs:308:16:308:27 | access to parameter nonSinkParam |
-| GlobalDataFlow.cs:307:15:307:26 | access to parameter nonSinkParam | GlobalDataFlow.cs:308:16:308:27 | access to parameter nonSinkParam |
-| GlobalDataFlow.cs:307:15:307:26 | access to parameter nonSinkParam | GlobalDataFlow.cs:308:16:308:27 | access to parameter nonSinkParam |
-| GlobalDataFlow.cs:307:15:307:26 | access to parameter nonSinkParam | GlobalDataFlow.cs:308:16:308:27 | access to parameter nonSinkParam |
-| GlobalDataFlow.cs:308:16:308:27 | access to parameter nonSinkParam | GlobalDataFlow.cs:215:76:215:92 | call to method NonReturnCheck |
-| GlobalDataFlow.cs:308:16:308:27 | access to parameter nonSinkParam | GlobalDataFlow.cs:215:76:215:92 | call to method NonReturnCheck |
-| GlobalDataFlow.cs:308:16:308:27 | access to parameter nonSinkParam | GlobalDataFlow.cs:308:16:308:27 | access to parameter nonSinkParam |
-| GlobalDataFlow.cs:311:12:311:14 | this | GlobalDataFlow.cs:311:12:311:14 | this |
-| GlobalDataFlow.cs:313:16:313:29 | "taint source" | GlobalDataFlow.cs:149:21:149:25 | call to method Out |
-| GlobalDataFlow.cs:313:16:313:29 | "taint source" | GlobalDataFlow.cs:149:21:149:25 | call to method Out |
-| GlobalDataFlow.cs:313:16:313:29 | "taint source" | GlobalDataFlow.cs:185:39:185:41 | [output] delegate creation of type Func<String> |
-| GlobalDataFlow.cs:313:16:313:29 | "taint source" | GlobalDataFlow.cs:185:39:185:41 | [output] delegate creation of type Func<String> |
-| GlobalDataFlow.cs:313:16:313:29 | "taint source" | GlobalDataFlow.cs:313:16:313:29 | "taint source" |
-| GlobalDataFlow.cs:316:10:316:15 | this | GlobalDataFlow.cs:316:10:316:15 | this |
-| GlobalDataFlow.cs:318:9:318:26 | ... = ... | GlobalDataFlow.cs:318:9:318:26 | ... = ... |
-| GlobalDataFlow.cs:318:9:318:26 | SSA def(x) | GlobalDataFlow.cs:152:20:152:24 | SSA def(sink7) |
-| GlobalDataFlow.cs:318:9:318:26 | SSA def(x) | GlobalDataFlow.cs:152:20:152:24 | SSA def(sink7) |
-| GlobalDataFlow.cs:318:9:318:26 | SSA def(x) | GlobalDataFlow.cs:318:9:318:26 | SSA def(x) |
-| GlobalDataFlow.cs:318:13:318:26 | "taint source" | GlobalDataFlow.cs:318:9:318:26 | SSA def(x) |
-| GlobalDataFlow.cs:318:13:318:26 | "taint source" | GlobalDataFlow.cs:318:9:318:26 | SSA def(x) |
-| GlobalDataFlow.cs:318:13:318:26 | "taint source" | GlobalDataFlow.cs:318:13:318:26 | "taint source" |
+| GlobalDataFlow.cs:226:9:226:39 | ... = ... | GlobalDataFlow.cs:226:9:226:39 | ... = ... |
+| GlobalDataFlow.cs:226:9:226:39 | SSA def(nonSink) | GlobalDataFlow.cs:226:9:226:39 | SSA def(nonSink) |
+| GlobalDataFlow.cs:226:9:226:39 | SSA def(nonSink) | GlobalDataFlow.cs:227:15:227:21 | access to local variable nonSink |
+| GlobalDataFlow.cs:226:9:226:39 | SSA def(nonSink) | GlobalDataFlow.cs:227:15:227:21 | access to local variable nonSink |
+| GlobalDataFlow.cs:226:19:226:28 | access to parameter notTainted | GlobalDataFlow.cs:219:71:219:71 | x |
+| GlobalDataFlow.cs:226:19:226:28 | access to parameter notTainted | GlobalDataFlow.cs:219:71:219:71 | x |
+| GlobalDataFlow.cs:226:19:226:28 | access to parameter notTainted | GlobalDataFlow.cs:226:19:226:28 | access to parameter notTainted |
+| GlobalDataFlow.cs:226:19:226:28 | access to parameter notTainted | GlobalDataFlow.cs:228:19:228:28 | access to parameter notTainted |
+| GlobalDataFlow.cs:226:19:226:28 | access to parameter notTainted | GlobalDataFlow.cs:228:19:228:28 | access to parameter notTainted |
+| GlobalDataFlow.cs:226:19:226:39 | call to method Select | GlobalDataFlow.cs:226:9:226:39 | SSA def(nonSink) |
+| GlobalDataFlow.cs:226:19:226:39 | call to method Select | GlobalDataFlow.cs:226:9:226:39 | SSA def(nonSink) |
+| GlobalDataFlow.cs:226:19:226:39 | call to method Select | GlobalDataFlow.cs:226:19:226:39 | call to method Select |
+| GlobalDataFlow.cs:226:19:226:39 | call to method Select | GlobalDataFlow.cs:227:15:227:21 | access to local variable nonSink |
+| GlobalDataFlow.cs:226:19:226:39 | call to method Select | GlobalDataFlow.cs:227:15:227:21 | access to local variable nonSink |
+| GlobalDataFlow.cs:226:37:226:38 | [output] access to local variable f4 | GlobalDataFlow.cs:226:37:226:38 | [output] access to local variable f4 |
+| GlobalDataFlow.cs:226:37:226:38 | access to local variable f4 | GlobalDataFlow.cs:226:37:226:38 | access to local variable f4 |
+| GlobalDataFlow.cs:227:9:227:22 | call to method Check | GlobalDataFlow.cs:227:9:227:22 | call to method Check |
+| GlobalDataFlow.cs:227:15:227:21 | access to local variable nonSink | GlobalDataFlow.cs:227:15:227:21 | access to local variable nonSink |
+| GlobalDataFlow.cs:228:9:228:49 | ... = ... | GlobalDataFlow.cs:228:9:228:49 | ... = ... |
+| GlobalDataFlow.cs:228:9:228:49 | SSA def(nonSink) | GlobalDataFlow.cs:228:9:228:49 | SSA def(nonSink) |
+| GlobalDataFlow.cs:228:9:228:49 | SSA def(nonSink) | GlobalDataFlow.cs:229:15:229:21 | access to local variable nonSink |
+| GlobalDataFlow.cs:228:9:228:49 | SSA def(nonSink) | GlobalDataFlow.cs:229:15:229:21 | access to local variable nonSink |
+| GlobalDataFlow.cs:228:19:228:28 | access to parameter notTainted | GlobalDataFlow.cs:228:19:228:28 | access to parameter notTainted |
+| GlobalDataFlow.cs:228:19:228:28 | access to parameter notTainted | GlobalDataFlow.cs:304:32:304:42 | sinkParam11 |
+| GlobalDataFlow.cs:228:19:228:28 | access to parameter notTainted | GlobalDataFlow.cs:304:32:304:42 | sinkParam11 |
+| GlobalDataFlow.cs:228:19:228:49 | call to method Select | GlobalDataFlow.cs:228:9:228:49 | SSA def(nonSink) |
+| GlobalDataFlow.cs:228:19:228:49 | call to method Select | GlobalDataFlow.cs:228:9:228:49 | SSA def(nonSink) |
+| GlobalDataFlow.cs:228:19:228:49 | call to method Select | GlobalDataFlow.cs:228:19:228:49 | call to method Select |
+| GlobalDataFlow.cs:228:19:228:49 | call to method Select | GlobalDataFlow.cs:229:15:229:21 | access to local variable nonSink |
+| GlobalDataFlow.cs:228:19:228:49 | call to method Select | GlobalDataFlow.cs:229:15:229:21 | access to local variable nonSink |
+| GlobalDataFlow.cs:228:37:228:48 | [output] delegate creation of type Func<String,String> | GlobalDataFlow.cs:228:37:228:48 | [output] delegate creation of type Func<String,String> |
+| GlobalDataFlow.cs:228:37:228:48 | access to method ReturnCheck3 | GlobalDataFlow.cs:228:37:228:48 | access to method ReturnCheck3 |
+| GlobalDataFlow.cs:228:37:228:48 | delegate creation of type Func<String,String> | GlobalDataFlow.cs:228:37:228:48 | delegate creation of type Func<String,String> |
+| GlobalDataFlow.cs:229:9:229:22 | call to method Check | GlobalDataFlow.cs:229:9:229:22 | call to method Check |
+| GlobalDataFlow.cs:229:15:229:21 | access to local variable nonSink | GlobalDataFlow.cs:229:15:229:21 | access to local variable nonSink |
+| GlobalDataFlow.cs:234:26:234:35 | sinkParam0 | GlobalDataFlow.cs:234:26:234:35 | sinkParam0 |
+| GlobalDataFlow.cs:234:26:234:35 | sinkParam0 | GlobalDataFlow.cs:234:26:234:35 | sinkParam0 |
+| GlobalDataFlow.cs:234:26:234:35 | sinkParam0 | GlobalDataFlow.cs:236:16:236:25 | access to parameter sinkParam0 |
+| GlobalDataFlow.cs:234:26:234:35 | sinkParam0 | GlobalDataFlow.cs:236:16:236:25 | access to parameter sinkParam0 |
+| GlobalDataFlow.cs:234:26:234:35 | sinkParam0 | GlobalDataFlow.cs:236:16:236:25 | access to parameter sinkParam0 |
+| GlobalDataFlow.cs:234:26:234:35 | sinkParam0 | GlobalDataFlow.cs:236:16:236:25 | access to parameter sinkParam0 |
+| GlobalDataFlow.cs:234:26:234:35 | sinkParam0 | GlobalDataFlow.cs:237:15:237:24 | access to parameter sinkParam0 |
+| GlobalDataFlow.cs:234:26:234:35 | sinkParam0 | GlobalDataFlow.cs:237:15:237:24 | access to parameter sinkParam0 |
+| GlobalDataFlow.cs:234:26:234:35 | sinkParam0 | GlobalDataFlow.cs:237:15:237:24 | access to parameter sinkParam0 |
+| GlobalDataFlow.cs:234:26:234:35 | sinkParam0 | GlobalDataFlow.cs:237:15:237:24 | access to parameter sinkParam0 |
+| GlobalDataFlow.cs:236:9:236:26 | call to method In0 | GlobalDataFlow.cs:236:9:236:26 | call to method In0 |
+| GlobalDataFlow.cs:236:16:236:25 | access to parameter sinkParam0 | GlobalDataFlow.cs:234:26:234:35 | sinkParam0 |
+| GlobalDataFlow.cs:236:16:236:25 | access to parameter sinkParam0 | GlobalDataFlow.cs:234:26:234:35 | sinkParam0 |
+| GlobalDataFlow.cs:236:16:236:25 | access to parameter sinkParam0 | GlobalDataFlow.cs:234:26:234:35 | sinkParam0 |
+| GlobalDataFlow.cs:236:16:236:25 | access to parameter sinkParam0 | GlobalDataFlow.cs:234:26:234:35 | sinkParam0 |
+| GlobalDataFlow.cs:236:16:236:25 | access to parameter sinkParam0 | GlobalDataFlow.cs:236:16:236:25 | access to parameter sinkParam0 |
+| GlobalDataFlow.cs:236:16:236:25 | access to parameter sinkParam0 | GlobalDataFlow.cs:237:15:237:24 | access to parameter sinkParam0 |
+| GlobalDataFlow.cs:236:16:236:25 | access to parameter sinkParam0 | GlobalDataFlow.cs:237:15:237:24 | access to parameter sinkParam0 |
+| GlobalDataFlow.cs:236:16:236:25 | access to parameter sinkParam0 | GlobalDataFlow.cs:237:15:237:24 | access to parameter sinkParam0 |
+| GlobalDataFlow.cs:236:16:236:25 | access to parameter sinkParam0 | GlobalDataFlow.cs:237:15:237:24 | access to parameter sinkParam0 |
+| GlobalDataFlow.cs:237:9:237:25 | call to method Check | GlobalDataFlow.cs:237:9:237:25 | call to method Check |
+| GlobalDataFlow.cs:237:15:237:24 | access to parameter sinkParam0 | GlobalDataFlow.cs:237:15:237:24 | access to parameter sinkParam0 |
+| GlobalDataFlow.cs:240:26:240:35 | sinkParam1 | GlobalDataFlow.cs:240:26:240:35 | sinkParam1 |
+| GlobalDataFlow.cs:240:26:240:35 | sinkParam1 | GlobalDataFlow.cs:240:26:240:35 | sinkParam1 |
+| GlobalDataFlow.cs:240:26:240:35 | sinkParam1 | GlobalDataFlow.cs:242:15:242:24 | access to parameter sinkParam1 |
+| GlobalDataFlow.cs:240:26:240:35 | sinkParam1 | GlobalDataFlow.cs:242:15:242:24 | access to parameter sinkParam1 |
+| GlobalDataFlow.cs:240:26:240:35 | sinkParam1 | GlobalDataFlow.cs:242:15:242:24 | access to parameter sinkParam1 |
+| GlobalDataFlow.cs:240:26:240:35 | sinkParam1 | GlobalDataFlow.cs:242:15:242:24 | access to parameter sinkParam1 |
+| GlobalDataFlow.cs:242:9:242:25 | call to method Check | GlobalDataFlow.cs:242:9:242:25 | call to method Check |
+| GlobalDataFlow.cs:242:15:242:24 | access to parameter sinkParam1 | GlobalDataFlow.cs:242:15:242:24 | access to parameter sinkParam1 |
+| GlobalDataFlow.cs:245:26:245:35 | sinkParam3 | GlobalDataFlow.cs:245:26:245:35 | sinkParam3 |
+| GlobalDataFlow.cs:245:26:245:35 | sinkParam3 | GlobalDataFlow.cs:245:26:245:35 | sinkParam3 |
+| GlobalDataFlow.cs:245:26:245:35 | sinkParam3 | GlobalDataFlow.cs:247:15:247:24 | access to parameter sinkParam3 |
+| GlobalDataFlow.cs:245:26:245:35 | sinkParam3 | GlobalDataFlow.cs:247:15:247:24 | access to parameter sinkParam3 |
+| GlobalDataFlow.cs:245:26:245:35 | sinkParam3 | GlobalDataFlow.cs:247:15:247:24 | access to parameter sinkParam3 |
+| GlobalDataFlow.cs:245:26:245:35 | sinkParam3 | GlobalDataFlow.cs:247:15:247:24 | access to parameter sinkParam3 |
+| GlobalDataFlow.cs:247:9:247:25 | call to method Check | GlobalDataFlow.cs:247:9:247:25 | call to method Check |
+| GlobalDataFlow.cs:247:15:247:24 | access to parameter sinkParam3 | GlobalDataFlow.cs:247:15:247:24 | access to parameter sinkParam3 |
+| GlobalDataFlow.cs:250:26:250:35 | sinkParam4 | GlobalDataFlow.cs:250:26:250:35 | sinkParam4 |
+| GlobalDataFlow.cs:250:26:250:35 | sinkParam4 | GlobalDataFlow.cs:250:26:250:35 | sinkParam4 |
+| GlobalDataFlow.cs:250:26:250:35 | sinkParam4 | GlobalDataFlow.cs:252:15:252:24 | access to parameter sinkParam4 |
+| GlobalDataFlow.cs:250:26:250:35 | sinkParam4 | GlobalDataFlow.cs:252:15:252:24 | access to parameter sinkParam4 |
+| GlobalDataFlow.cs:250:26:250:35 | sinkParam4 | GlobalDataFlow.cs:252:15:252:24 | access to parameter sinkParam4 |
+| GlobalDataFlow.cs:250:26:250:35 | sinkParam4 | GlobalDataFlow.cs:252:15:252:24 | access to parameter sinkParam4 |
+| GlobalDataFlow.cs:252:9:252:25 | call to method Check | GlobalDataFlow.cs:252:9:252:25 | call to method Check |
+| GlobalDataFlow.cs:252:15:252:24 | access to parameter sinkParam4 | GlobalDataFlow.cs:252:15:252:24 | access to parameter sinkParam4 |
+| GlobalDataFlow.cs:255:26:255:35 | sinkParam5 | GlobalDataFlow.cs:255:26:255:35 | sinkParam5 |
+| GlobalDataFlow.cs:255:26:255:35 | sinkParam5 | GlobalDataFlow.cs:255:26:255:35 | sinkParam5 |
+| GlobalDataFlow.cs:255:26:255:35 | sinkParam5 | GlobalDataFlow.cs:257:15:257:24 | access to parameter sinkParam5 |
+| GlobalDataFlow.cs:255:26:255:35 | sinkParam5 | GlobalDataFlow.cs:257:15:257:24 | access to parameter sinkParam5 |
+| GlobalDataFlow.cs:255:26:255:35 | sinkParam5 | GlobalDataFlow.cs:257:15:257:24 | access to parameter sinkParam5 |
+| GlobalDataFlow.cs:255:26:255:35 | sinkParam5 | GlobalDataFlow.cs:257:15:257:24 | access to parameter sinkParam5 |
+| GlobalDataFlow.cs:257:9:257:25 | call to method Check | GlobalDataFlow.cs:257:9:257:25 | call to method Check |
+| GlobalDataFlow.cs:257:15:257:24 | access to parameter sinkParam5 | GlobalDataFlow.cs:257:15:257:24 | access to parameter sinkParam5 |
+| GlobalDataFlow.cs:260:26:260:35 | sinkParam6 | GlobalDataFlow.cs:260:26:260:35 | sinkParam6 |
+| GlobalDataFlow.cs:260:26:260:35 | sinkParam6 | GlobalDataFlow.cs:260:26:260:35 | sinkParam6 |
+| GlobalDataFlow.cs:260:26:260:35 | sinkParam6 | GlobalDataFlow.cs:262:15:262:24 | access to parameter sinkParam6 |
+| GlobalDataFlow.cs:260:26:260:35 | sinkParam6 | GlobalDataFlow.cs:262:15:262:24 | access to parameter sinkParam6 |
+| GlobalDataFlow.cs:260:26:260:35 | sinkParam6 | GlobalDataFlow.cs:262:15:262:24 | access to parameter sinkParam6 |
+| GlobalDataFlow.cs:260:26:260:35 | sinkParam6 | GlobalDataFlow.cs:262:15:262:24 | access to parameter sinkParam6 |
+| GlobalDataFlow.cs:262:9:262:25 | call to method Check | GlobalDataFlow.cs:262:9:262:25 | call to method Check |
+| GlobalDataFlow.cs:262:15:262:24 | access to parameter sinkParam6 | GlobalDataFlow.cs:262:15:262:24 | access to parameter sinkParam6 |
+| GlobalDataFlow.cs:265:26:265:35 | sinkParam7 | GlobalDataFlow.cs:265:26:265:35 | sinkParam7 |
+| GlobalDataFlow.cs:265:26:265:35 | sinkParam7 | GlobalDataFlow.cs:265:26:265:35 | sinkParam7 |
+| GlobalDataFlow.cs:265:26:265:35 | sinkParam7 | GlobalDataFlow.cs:267:15:267:24 | access to parameter sinkParam7 |
+| GlobalDataFlow.cs:265:26:265:35 | sinkParam7 | GlobalDataFlow.cs:267:15:267:24 | access to parameter sinkParam7 |
+| GlobalDataFlow.cs:265:26:265:35 | sinkParam7 | GlobalDataFlow.cs:267:15:267:24 | access to parameter sinkParam7 |
+| GlobalDataFlow.cs:265:26:265:35 | sinkParam7 | GlobalDataFlow.cs:267:15:267:24 | access to parameter sinkParam7 |
+| GlobalDataFlow.cs:267:9:267:25 | call to method Check | GlobalDataFlow.cs:267:9:267:25 | call to method Check |
+| GlobalDataFlow.cs:267:15:267:24 | access to parameter sinkParam7 | GlobalDataFlow.cs:267:15:267:24 | access to parameter sinkParam7 |
+| GlobalDataFlow.cs:270:29:270:41 | nonSinkParam0 | GlobalDataFlow.cs:270:29:270:41 | nonSinkParam0 |
+| GlobalDataFlow.cs:270:29:270:41 | nonSinkParam0 | GlobalDataFlow.cs:270:29:270:41 | nonSinkParam0 |
+| GlobalDataFlow.cs:270:29:270:41 | nonSinkParam0 | GlobalDataFlow.cs:272:15:272:27 | access to parameter nonSinkParam0 |
+| GlobalDataFlow.cs:270:29:270:41 | nonSinkParam0 | GlobalDataFlow.cs:272:15:272:27 | access to parameter nonSinkParam0 |
+| GlobalDataFlow.cs:270:29:270:41 | nonSinkParam0 | GlobalDataFlow.cs:272:15:272:27 | access to parameter nonSinkParam0 |
+| GlobalDataFlow.cs:270:29:270:41 | nonSinkParam0 | GlobalDataFlow.cs:272:15:272:27 | access to parameter nonSinkParam0 |
+| GlobalDataFlow.cs:272:9:272:28 | call to method Check | GlobalDataFlow.cs:272:9:272:28 | call to method Check |
+| GlobalDataFlow.cs:272:15:272:27 | access to parameter nonSinkParam0 | GlobalDataFlow.cs:272:15:272:27 | access to parameter nonSinkParam0 |
+| GlobalDataFlow.cs:275:26:275:26 | x | GlobalDataFlow.cs:275:26:275:26 | x |
+| GlobalDataFlow.cs:275:26:275:26 | x | GlobalDataFlow.cs:275:26:275:26 | x |
+| GlobalDataFlow.cs:275:26:275:26 | x | GlobalDataFlow.cs:277:37:277:37 | access to parameter x |
+| GlobalDataFlow.cs:275:26:275:26 | x | GlobalDataFlow.cs:277:37:277:37 | access to parameter x |
+| GlobalDataFlow.cs:275:26:275:26 | x | GlobalDataFlow.cs:277:37:277:37 | access to parameter x |
+| GlobalDataFlow.cs:275:26:275:26 | x | GlobalDataFlow.cs:277:37:277:37 | access to parameter x |
+| GlobalDataFlow.cs:277:13:277:38 | SSA def(y) | GlobalDataFlow.cs:277:13:277:38 | SSA def(y) |
+| GlobalDataFlow.cs:277:13:277:38 | SSA def(y) | GlobalDataFlow.cs:278:16:278:16 | (...) ... |
+| GlobalDataFlow.cs:277:13:277:38 | SSA def(y) | GlobalDataFlow.cs:278:16:278:16 | (...) ... |
+| GlobalDataFlow.cs:277:13:277:38 | SSA def(y) | GlobalDataFlow.cs:278:16:278:16 | (...) ... |
+| GlobalDataFlow.cs:277:13:277:38 | SSA def(y) | GlobalDataFlow.cs:278:16:278:16 | (...) ... |
+| GlobalDataFlow.cs:277:13:277:38 | SSA def(y) | GlobalDataFlow.cs:278:16:278:16 | access to local variable y |
+| GlobalDataFlow.cs:277:13:277:38 | SSA def(y) | GlobalDataFlow.cs:278:16:278:16 | access to local variable y |
+| GlobalDataFlow.cs:277:13:277:38 | SSA def(y) | GlobalDataFlow.cs:278:16:278:16 | access to local variable y |
+| GlobalDataFlow.cs:277:13:277:38 | SSA def(y) | GlobalDataFlow.cs:278:16:278:16 | access to local variable y |
+| GlobalDataFlow.cs:277:13:277:38 | SSA def(y) | GlobalDataFlow.cs:278:16:278:41 | ... ? ... : ... |
+| GlobalDataFlow.cs:277:13:277:38 | SSA def(y) | GlobalDataFlow.cs:278:16:278:41 | ... ? ... : ... |
+| GlobalDataFlow.cs:277:13:277:38 | SSA def(y) | GlobalDataFlow.cs:278:16:278:41 | ... ? ... : ... |
+| GlobalDataFlow.cs:277:13:277:38 | SSA def(y) | GlobalDataFlow.cs:278:16:278:41 | ... ? ... : ... |
+| GlobalDataFlow.cs:277:13:277:38 | SSA def(y) | GlobalDataFlow.cs:278:41:278:41 | access to local variable y |
+| GlobalDataFlow.cs:277:13:277:38 | SSA def(y) | GlobalDataFlow.cs:278:41:278:41 | access to local variable y |
+| GlobalDataFlow.cs:277:13:277:38 | SSA def(y) | GlobalDataFlow.cs:278:41:278:41 | access to local variable y |
+| GlobalDataFlow.cs:277:13:277:38 | SSA def(y) | GlobalDataFlow.cs:278:41:278:41 | access to local variable y |
+| GlobalDataFlow.cs:277:13:277:38 | T y = ... | GlobalDataFlow.cs:277:13:277:38 | T y = ... |
+| GlobalDataFlow.cs:277:17:277:38 | call to method ApplyFunc | GlobalDataFlow.cs:277:13:277:38 | SSA def(y) |
+| GlobalDataFlow.cs:277:17:277:38 | call to method ApplyFunc | GlobalDataFlow.cs:277:13:277:38 | SSA def(y) |
+| GlobalDataFlow.cs:277:17:277:38 | call to method ApplyFunc | GlobalDataFlow.cs:277:13:277:38 | SSA def(y) |
+| GlobalDataFlow.cs:277:17:277:38 | call to method ApplyFunc | GlobalDataFlow.cs:277:13:277:38 | SSA def(y) |
+| GlobalDataFlow.cs:277:17:277:38 | call to method ApplyFunc | GlobalDataFlow.cs:277:17:277:38 | call to method ApplyFunc |
+| GlobalDataFlow.cs:277:17:277:38 | call to method ApplyFunc | GlobalDataFlow.cs:278:16:278:16 | (...) ... |
+| GlobalDataFlow.cs:277:17:277:38 | call to method ApplyFunc | GlobalDataFlow.cs:278:16:278:16 | (...) ... |
+| GlobalDataFlow.cs:277:17:277:38 | call to method ApplyFunc | GlobalDataFlow.cs:278:16:278:16 | (...) ... |
+| GlobalDataFlow.cs:277:17:277:38 | call to method ApplyFunc | GlobalDataFlow.cs:278:16:278:16 | (...) ... |
+| GlobalDataFlow.cs:277:17:277:38 | call to method ApplyFunc | GlobalDataFlow.cs:278:16:278:16 | access to local variable y |
+| GlobalDataFlow.cs:277:17:277:38 | call to method ApplyFunc | GlobalDataFlow.cs:278:16:278:16 | access to local variable y |
+| GlobalDataFlow.cs:277:17:277:38 | call to method ApplyFunc | GlobalDataFlow.cs:278:16:278:16 | access to local variable y |
+| GlobalDataFlow.cs:277:17:277:38 | call to method ApplyFunc | GlobalDataFlow.cs:278:16:278:16 | access to local variable y |
+| GlobalDataFlow.cs:277:17:277:38 | call to method ApplyFunc | GlobalDataFlow.cs:278:16:278:41 | ... ? ... : ... |
+| GlobalDataFlow.cs:277:17:277:38 | call to method ApplyFunc | GlobalDataFlow.cs:278:16:278:41 | ... ? ... : ... |
+| GlobalDataFlow.cs:277:17:277:38 | call to method ApplyFunc | GlobalDataFlow.cs:278:16:278:41 | ... ? ... : ... |
+| GlobalDataFlow.cs:277:17:277:38 | call to method ApplyFunc | GlobalDataFlow.cs:278:16:278:41 | ... ? ... : ... |
+| GlobalDataFlow.cs:277:17:277:38 | call to method ApplyFunc | GlobalDataFlow.cs:278:41:278:41 | access to local variable y |
+| GlobalDataFlow.cs:277:17:277:38 | call to method ApplyFunc | GlobalDataFlow.cs:278:41:278:41 | access to local variable y |
+| GlobalDataFlow.cs:277:17:277:38 | call to method ApplyFunc | GlobalDataFlow.cs:278:41:278:41 | access to local variable y |
+| GlobalDataFlow.cs:277:17:277:38 | call to method ApplyFunc | GlobalDataFlow.cs:278:41:278:41 | access to local variable y |
+| GlobalDataFlow.cs:277:27:277:28 | x0 | GlobalDataFlow.cs:277:27:277:28 | x0 |
+| GlobalDataFlow.cs:277:27:277:28 | x0 | GlobalDataFlow.cs:277:27:277:28 | x0 |
+| GlobalDataFlow.cs:277:27:277:28 | x0 | GlobalDataFlow.cs:277:33:277:34 | access to parameter x0 |
+| GlobalDataFlow.cs:277:27:277:28 | x0 | GlobalDataFlow.cs:277:33:277:34 | access to parameter x0 |
+| GlobalDataFlow.cs:277:27:277:28 | x0 | GlobalDataFlow.cs:277:33:277:34 | access to parameter x0 |
+| GlobalDataFlow.cs:277:27:277:28 | x0 | GlobalDataFlow.cs:277:33:277:34 | access to parameter x0 |
+| GlobalDataFlow.cs:277:27:277:34 | (...) => ... | GlobalDataFlow.cs:277:27:277:34 | (...) => ... |
+| GlobalDataFlow.cs:277:27:277:34 | (...) => ... | GlobalDataFlow.cs:364:41:364:41 | f |
+| GlobalDataFlow.cs:277:27:277:34 | (...) => ... | GlobalDataFlow.cs:364:41:364:41 | f |
+| GlobalDataFlow.cs:277:33:277:34 | access to parameter x0 | GlobalDataFlow.cs:277:33:277:34 | access to parameter x0 |
+| GlobalDataFlow.cs:277:33:277:34 | access to parameter x0 | GlobalDataFlow.cs:366:16:366:19 | delegate call |
+| GlobalDataFlow.cs:277:33:277:34 | access to parameter x0 | GlobalDataFlow.cs:366:16:366:19 | delegate call |
+| GlobalDataFlow.cs:277:37:277:37 | access to parameter x | GlobalDataFlow.cs:277:17:277:38 | call to method ApplyFunc |
+| GlobalDataFlow.cs:277:37:277:37 | access to parameter x | GlobalDataFlow.cs:277:17:277:38 | call to method ApplyFunc |
+| GlobalDataFlow.cs:277:37:277:37 | access to parameter x | GlobalDataFlow.cs:277:17:277:38 | call to method ApplyFunc |
+| GlobalDataFlow.cs:277:37:277:37 | access to parameter x | GlobalDataFlow.cs:277:17:277:38 | call to method ApplyFunc |
+| GlobalDataFlow.cs:277:37:277:37 | access to parameter x | GlobalDataFlow.cs:277:37:277:37 | access to parameter x |
+| GlobalDataFlow.cs:277:37:277:37 | access to parameter x | GlobalDataFlow.cs:364:46:364:46 | x |
+| GlobalDataFlow.cs:277:37:277:37 | access to parameter x | GlobalDataFlow.cs:364:46:364:46 | x |
+| GlobalDataFlow.cs:277:37:277:37 | access to parameter x | GlobalDataFlow.cs:364:46:364:46 | x |
+| GlobalDataFlow.cs:277:37:277:37 | access to parameter x | GlobalDataFlow.cs:364:46:364:46 | x |
+| GlobalDataFlow.cs:278:16:278:16 | (...) ... | GlobalDataFlow.cs:278:16:278:16 | (...) ... |
+| GlobalDataFlow.cs:278:16:278:16 | access to local variable y | GlobalDataFlow.cs:278:16:278:16 | (...) ... |
+| GlobalDataFlow.cs:278:16:278:16 | access to local variable y | GlobalDataFlow.cs:278:16:278:16 | (...) ... |
+| GlobalDataFlow.cs:278:16:278:16 | access to local variable y | GlobalDataFlow.cs:278:16:278:16 | (...) ... |
+| GlobalDataFlow.cs:278:16:278:16 | access to local variable y | GlobalDataFlow.cs:278:16:278:16 | (...) ... |
+| GlobalDataFlow.cs:278:16:278:16 | access to local variable y | GlobalDataFlow.cs:278:16:278:16 | access to local variable y |
+| GlobalDataFlow.cs:278:16:278:16 | access to local variable y | GlobalDataFlow.cs:278:16:278:41 | ... ? ... : ... |
+| GlobalDataFlow.cs:278:16:278:16 | access to local variable y | GlobalDataFlow.cs:278:16:278:41 | ... ? ... : ... |
+| GlobalDataFlow.cs:278:16:278:16 | access to local variable y | GlobalDataFlow.cs:278:16:278:41 | ... ? ... : ... |
+| GlobalDataFlow.cs:278:16:278:16 | access to local variable y | GlobalDataFlow.cs:278:16:278:41 | ... ? ... : ... |
+| GlobalDataFlow.cs:278:16:278:16 | access to local variable y | GlobalDataFlow.cs:278:41:278:41 | access to local variable y |
+| GlobalDataFlow.cs:278:16:278:16 | access to local variable y | GlobalDataFlow.cs:278:41:278:41 | access to local variable y |
+| GlobalDataFlow.cs:278:16:278:16 | access to local variable y | GlobalDataFlow.cs:278:41:278:41 | access to local variable y |
+| GlobalDataFlow.cs:278:16:278:16 | access to local variable y | GlobalDataFlow.cs:278:41:278:41 | access to local variable y |
+| GlobalDataFlow.cs:278:16:278:24 | ... == ... | GlobalDataFlow.cs:278:16:278:24 | ... == ... |
+| GlobalDataFlow.cs:278:16:278:41 | ... ? ... : ... | GlobalDataFlow.cs:70:21:70:46 | call to method Return |
+| GlobalDataFlow.cs:278:16:278:41 | ... ? ... : ... | GlobalDataFlow.cs:70:21:70:46 | call to method Return |
+| GlobalDataFlow.cs:278:16:278:41 | ... ? ... : ... | GlobalDataFlow.cs:72:29:72:101 | call to method Invoke |
+| GlobalDataFlow.cs:278:16:278:41 | ... ? ... : ... | GlobalDataFlow.cs:72:29:72:101 | call to method Invoke |
+| GlobalDataFlow.cs:278:16:278:41 | ... ? ... : ... | GlobalDataFlow.cs:100:24:100:33 | call to method Return |
+| GlobalDataFlow.cs:278:16:278:41 | ... ? ... : ... | GlobalDataFlow.cs:100:24:100:33 | call to method Return |
+| GlobalDataFlow.cs:278:16:278:41 | ... ? ... : ... | GlobalDataFlow.cs:102:28:102:103 | call to method Invoke |
+| GlobalDataFlow.cs:278:16:278:41 | ... ? ... : ... | GlobalDataFlow.cs:102:28:102:103 | call to method Invoke |
+| GlobalDataFlow.cs:278:16:278:41 | ... ? ... : ... | GlobalDataFlow.cs:278:16:278:41 | ... ? ... : ... |
+| GlobalDataFlow.cs:278:16:278:41 | ... ? ... : ... | GlobalDataFlow.cs:366:16:366:19 | delegate call |
+| GlobalDataFlow.cs:278:16:278:41 | ... ? ... : ... | GlobalDataFlow.cs:366:16:366:19 | delegate call |
+| GlobalDataFlow.cs:278:21:278:24 | null | GlobalDataFlow.cs:278:21:278:24 | null |
+| GlobalDataFlow.cs:278:28:278:37 | default(...) | GlobalDataFlow.cs:278:16:278:41 | ... ? ... : ... |
+| GlobalDataFlow.cs:278:28:278:37 | default(...) | GlobalDataFlow.cs:278:16:278:41 | ... ? ... : ... |
+| GlobalDataFlow.cs:278:28:278:37 | default(...) | GlobalDataFlow.cs:278:28:278:37 | default(...) |
+| GlobalDataFlow.cs:278:41:278:41 | access to local variable y | GlobalDataFlow.cs:278:16:278:41 | ... ? ... : ... |
+| GlobalDataFlow.cs:278:41:278:41 | access to local variable y | GlobalDataFlow.cs:278:16:278:41 | ... ? ... : ... |
+| GlobalDataFlow.cs:278:41:278:41 | access to local variable y | GlobalDataFlow.cs:278:16:278:41 | ... ? ... : ... |
+| GlobalDataFlow.cs:278:41:278:41 | access to local variable y | GlobalDataFlow.cs:278:16:278:41 | ... ? ... : ... |
+| GlobalDataFlow.cs:278:41:278:41 | access to local variable y | GlobalDataFlow.cs:278:41:278:41 | access to local variable y |
+| GlobalDataFlow.cs:281:32:281:32 | x | GlobalDataFlow.cs:281:32:281:32 | x |
+| GlobalDataFlow.cs:281:32:281:32 | x | GlobalDataFlow.cs:281:32:281:32 | x |
+| GlobalDataFlow.cs:281:32:281:32 | x | GlobalDataFlow.cs:283:9:283:13 | SSA def(y) |
+| GlobalDataFlow.cs:281:32:281:32 | x | GlobalDataFlow.cs:283:9:283:13 | SSA def(y) |
+| GlobalDataFlow.cs:281:32:281:32 | x | GlobalDataFlow.cs:283:9:283:13 | SSA def(y) |
+| GlobalDataFlow.cs:281:32:281:32 | x | GlobalDataFlow.cs:283:9:283:13 | SSA def(y) |
+| GlobalDataFlow.cs:281:32:281:32 | x | GlobalDataFlow.cs:283:13:283:13 | access to parameter x |
+| GlobalDataFlow.cs:281:32:281:32 | x | GlobalDataFlow.cs:283:13:283:13 | access to parameter x |
+| GlobalDataFlow.cs:281:32:281:32 | x | GlobalDataFlow.cs:283:13:283:13 | access to parameter x |
+| GlobalDataFlow.cs:281:32:281:32 | x | GlobalDataFlow.cs:283:13:283:13 | access to parameter x |
+| GlobalDataFlow.cs:283:9:283:13 | ... = ... | GlobalDataFlow.cs:283:9:283:13 | ... = ... |
+| GlobalDataFlow.cs:283:9:283:13 | SSA def(y) | GlobalDataFlow.cs:75:30:75:34 | SSA def(sink2) |
+| GlobalDataFlow.cs:283:9:283:13 | SSA def(y) | GlobalDataFlow.cs:75:30:75:34 | SSA def(sink2) |
+| GlobalDataFlow.cs:283:9:283:13 | SSA def(y) | GlobalDataFlow.cs:104:27:104:34 | SSA def(nonSink0) |
+| GlobalDataFlow.cs:283:9:283:13 | SSA def(y) | GlobalDataFlow.cs:104:27:104:34 | SSA def(nonSink0) |
+| GlobalDataFlow.cs:283:9:283:13 | SSA def(y) | GlobalDataFlow.cs:106:41:106:48 | SSA def(nonSink0) |
+| GlobalDataFlow.cs:283:9:283:13 | SSA def(y) | GlobalDataFlow.cs:106:41:106:48 | SSA def(nonSink0) |
+| GlobalDataFlow.cs:283:9:283:13 | SSA def(y) | GlobalDataFlow.cs:283:9:283:13 | SSA def(y) |
+| GlobalDataFlow.cs:283:13:283:13 | access to parameter x | GlobalDataFlow.cs:283:9:283:13 | SSA def(y) |
+| GlobalDataFlow.cs:283:13:283:13 | access to parameter x | GlobalDataFlow.cs:283:9:283:13 | SSA def(y) |
+| GlobalDataFlow.cs:283:13:283:13 | access to parameter x | GlobalDataFlow.cs:283:9:283:13 | SSA def(y) |
+| GlobalDataFlow.cs:283:13:283:13 | access to parameter x | GlobalDataFlow.cs:283:9:283:13 | SSA def(y) |
+| GlobalDataFlow.cs:283:13:283:13 | access to parameter x | GlobalDataFlow.cs:283:13:283:13 | access to parameter x |
+| GlobalDataFlow.cs:284:9:284:22 | ... = ... | GlobalDataFlow.cs:284:9:284:22 | ... = ... |
+| GlobalDataFlow.cs:284:9:284:22 | SSA def(z) | GlobalDataFlow.cs:75:30:75:34 | SSA def(sink2) |
+| GlobalDataFlow.cs:284:9:284:22 | SSA def(z) | GlobalDataFlow.cs:75:30:75:34 | SSA def(sink2) |
+| GlobalDataFlow.cs:284:9:284:22 | SSA def(z) | GlobalDataFlow.cs:104:27:104:34 | SSA def(nonSink0) |
+| GlobalDataFlow.cs:284:9:284:22 | SSA def(z) | GlobalDataFlow.cs:104:27:104:34 | SSA def(nonSink0) |
+| GlobalDataFlow.cs:284:9:284:22 | SSA def(z) | GlobalDataFlow.cs:106:41:106:48 | SSA def(nonSink0) |
+| GlobalDataFlow.cs:284:9:284:22 | SSA def(z) | GlobalDataFlow.cs:106:41:106:48 | SSA def(nonSink0) |
+| GlobalDataFlow.cs:284:9:284:22 | SSA def(z) | GlobalDataFlow.cs:284:9:284:22 | SSA def(z) |
+| GlobalDataFlow.cs:284:13:284:22 | default(...) | GlobalDataFlow.cs:284:9:284:22 | SSA def(z) |
+| GlobalDataFlow.cs:284:13:284:22 | default(...) | GlobalDataFlow.cs:284:9:284:22 | SSA def(z) |
+| GlobalDataFlow.cs:284:13:284:22 | default(...) | GlobalDataFlow.cs:284:13:284:22 | default(...) |
+| GlobalDataFlow.cs:287:32:287:32 | x | GlobalDataFlow.cs:287:32:287:32 | x |
+| GlobalDataFlow.cs:287:32:287:32 | x | GlobalDataFlow.cs:287:32:287:32 | x |
+| GlobalDataFlow.cs:287:32:287:32 | x | GlobalDataFlow.cs:289:9:289:13 | SSA def(y) |
+| GlobalDataFlow.cs:287:32:287:32 | x | GlobalDataFlow.cs:289:9:289:13 | SSA def(y) |
+| GlobalDataFlow.cs:287:32:287:32 | x | GlobalDataFlow.cs:289:9:289:13 | SSA def(y) |
+| GlobalDataFlow.cs:287:32:287:32 | x | GlobalDataFlow.cs:289:9:289:13 | SSA def(y) |
+| GlobalDataFlow.cs:287:32:287:32 | x | GlobalDataFlow.cs:289:13:289:13 | access to parameter x |
+| GlobalDataFlow.cs:287:32:287:32 | x | GlobalDataFlow.cs:289:13:289:13 | access to parameter x |
+| GlobalDataFlow.cs:287:32:287:32 | x | GlobalDataFlow.cs:289:13:289:13 | access to parameter x |
+| GlobalDataFlow.cs:287:32:287:32 | x | GlobalDataFlow.cs:289:13:289:13 | access to parameter x |
+| GlobalDataFlow.cs:287:50:287:50 | z | GlobalDataFlow.cs:78:30:78:34 | SSA def(sink3) |
+| GlobalDataFlow.cs:287:50:287:50 | z | GlobalDataFlow.cs:78:30:78:34 | SSA def(sink3) |
+| GlobalDataFlow.cs:287:50:287:50 | z | GlobalDataFlow.cs:108:27:108:34 | SSA def(nonSink0) |
+| GlobalDataFlow.cs:287:50:287:50 | z | GlobalDataFlow.cs:108:27:108:34 | SSA def(nonSink0) |
+| GlobalDataFlow.cs:287:50:287:50 | z | GlobalDataFlow.cs:110:30:110:34 | SSA def(sink1) |
+| GlobalDataFlow.cs:287:50:287:50 | z | GlobalDataFlow.cs:110:30:110:34 | SSA def(sink1) |
+| GlobalDataFlow.cs:287:50:287:50 | z | GlobalDataFlow.cs:287:50:287:50 | z |
+| GlobalDataFlow.cs:287:50:287:50 | z | GlobalDataFlow.cs:287:50:287:50 | z |
+| GlobalDataFlow.cs:289:9:289:13 | ... = ... | GlobalDataFlow.cs:289:9:289:13 | ... = ... |
+| GlobalDataFlow.cs:289:9:289:13 | SSA def(y) | GlobalDataFlow.cs:78:30:78:34 | SSA def(sink3) |
+| GlobalDataFlow.cs:289:9:289:13 | SSA def(y) | GlobalDataFlow.cs:78:30:78:34 | SSA def(sink3) |
+| GlobalDataFlow.cs:289:9:289:13 | SSA def(y) | GlobalDataFlow.cs:108:27:108:34 | SSA def(nonSink0) |
+| GlobalDataFlow.cs:289:9:289:13 | SSA def(y) | GlobalDataFlow.cs:108:27:108:34 | SSA def(nonSink0) |
+| GlobalDataFlow.cs:289:9:289:13 | SSA def(y) | GlobalDataFlow.cs:110:30:110:34 | SSA def(sink1) |
+| GlobalDataFlow.cs:289:9:289:13 | SSA def(y) | GlobalDataFlow.cs:110:30:110:34 | SSA def(sink1) |
+| GlobalDataFlow.cs:289:9:289:13 | SSA def(y) | GlobalDataFlow.cs:289:9:289:13 | SSA def(y) |
+| GlobalDataFlow.cs:289:13:289:13 | access to parameter x | GlobalDataFlow.cs:289:9:289:13 | SSA def(y) |
+| GlobalDataFlow.cs:289:13:289:13 | access to parameter x | GlobalDataFlow.cs:289:9:289:13 | SSA def(y) |
+| GlobalDataFlow.cs:289:13:289:13 | access to parameter x | GlobalDataFlow.cs:289:9:289:13 | SSA def(y) |
+| GlobalDataFlow.cs:289:13:289:13 | access to parameter x | GlobalDataFlow.cs:289:9:289:13 | SSA def(y) |
+| GlobalDataFlow.cs:289:13:289:13 | access to parameter x | GlobalDataFlow.cs:289:13:289:13 | access to parameter x |
+| GlobalDataFlow.cs:292:31:292:40 | sinkParam8 | GlobalDataFlow.cs:292:31:292:40 | sinkParam8 |
+| GlobalDataFlow.cs:292:31:292:40 | sinkParam8 | GlobalDataFlow.cs:292:31:292:40 | sinkParam8 |
+| GlobalDataFlow.cs:292:31:292:40 | sinkParam8 | GlobalDataFlow.cs:294:15:294:24 | access to parameter sinkParam8 |
+| GlobalDataFlow.cs:292:31:292:40 | sinkParam8 | GlobalDataFlow.cs:294:15:294:24 | access to parameter sinkParam8 |
+| GlobalDataFlow.cs:292:31:292:40 | sinkParam8 | GlobalDataFlow.cs:295:16:295:25 | access to parameter sinkParam8 |
+| GlobalDataFlow.cs:292:31:292:40 | sinkParam8 | GlobalDataFlow.cs:295:16:295:25 | access to parameter sinkParam8 |
+| GlobalDataFlow.cs:294:9:294:25 | call to method Check | GlobalDataFlow.cs:294:9:294:25 | call to method Check |
+| GlobalDataFlow.cs:294:15:294:24 | access to parameter sinkParam8 | GlobalDataFlow.cs:294:15:294:24 | access to parameter sinkParam8 |
+| GlobalDataFlow.cs:294:15:294:24 | access to parameter sinkParam8 | GlobalDataFlow.cs:295:16:295:25 | access to parameter sinkParam8 |
+| GlobalDataFlow.cs:294:15:294:24 | access to parameter sinkParam8 | GlobalDataFlow.cs:295:16:295:25 | access to parameter sinkParam8 |
+| GlobalDataFlow.cs:295:16:295:25 | access to parameter sinkParam8 | GlobalDataFlow.cs:82:84:82:94 | [output] delegate creation of type Func<String,String> |
+| GlobalDataFlow.cs:295:16:295:25 | access to parameter sinkParam8 | GlobalDataFlow.cs:82:84:82:94 | [output] delegate creation of type Func<String,String> |
+| GlobalDataFlow.cs:295:16:295:25 | access to parameter sinkParam8 | GlobalDataFlow.cs:295:16:295:25 | access to parameter sinkParam8 |
+| GlobalDataFlow.cs:298:32:298:41 | sinkParam9 | GlobalDataFlow.cs:298:32:298:41 | sinkParam9 |
+| GlobalDataFlow.cs:298:32:298:41 | sinkParam9 | GlobalDataFlow.cs:298:32:298:41 | sinkParam9 |
+| GlobalDataFlow.cs:298:32:298:41 | sinkParam9 | GlobalDataFlow.cs:300:15:300:24 | access to parameter sinkParam9 |
+| GlobalDataFlow.cs:298:32:298:41 | sinkParam9 | GlobalDataFlow.cs:300:15:300:24 | access to parameter sinkParam9 |
+| GlobalDataFlow.cs:298:32:298:41 | sinkParam9 | GlobalDataFlow.cs:300:15:300:24 | access to parameter sinkParam9 |
+| GlobalDataFlow.cs:298:32:298:41 | sinkParam9 | GlobalDataFlow.cs:300:15:300:24 | access to parameter sinkParam9 |
+| GlobalDataFlow.cs:298:32:298:41 | sinkParam9 | GlobalDataFlow.cs:301:16:301:25 | access to parameter sinkParam9 |
+| GlobalDataFlow.cs:298:32:298:41 | sinkParam9 | GlobalDataFlow.cs:301:16:301:25 | access to parameter sinkParam9 |
+| GlobalDataFlow.cs:298:32:298:41 | sinkParam9 | GlobalDataFlow.cs:301:16:301:25 | access to parameter sinkParam9 |
+| GlobalDataFlow.cs:298:32:298:41 | sinkParam9 | GlobalDataFlow.cs:301:16:301:25 | access to parameter sinkParam9 |
+| GlobalDataFlow.cs:300:9:300:25 | call to method Check | GlobalDataFlow.cs:300:9:300:25 | call to method Check |
+| GlobalDataFlow.cs:300:15:300:24 | access to parameter sinkParam9 | GlobalDataFlow.cs:300:15:300:24 | access to parameter sinkParam9 |
+| GlobalDataFlow.cs:300:15:300:24 | access to parameter sinkParam9 | GlobalDataFlow.cs:301:16:301:25 | access to parameter sinkParam9 |
+| GlobalDataFlow.cs:300:15:300:24 | access to parameter sinkParam9 | GlobalDataFlow.cs:301:16:301:25 | access to parameter sinkParam9 |
+| GlobalDataFlow.cs:300:15:300:24 | access to parameter sinkParam9 | GlobalDataFlow.cs:301:16:301:25 | access to parameter sinkParam9 |
+| GlobalDataFlow.cs:300:15:300:24 | access to parameter sinkParam9 | GlobalDataFlow.cs:301:16:301:25 | access to parameter sinkParam9 |
+| GlobalDataFlow.cs:301:16:301:25 | access to parameter sinkParam9 | GlobalDataFlow.cs:209:76:209:90 | call to method ReturnCheck2 |
+| GlobalDataFlow.cs:301:16:301:25 | access to parameter sinkParam9 | GlobalDataFlow.cs:209:76:209:90 | call to method ReturnCheck2 |
+| GlobalDataFlow.cs:301:16:301:25 | access to parameter sinkParam9 | GlobalDataFlow.cs:301:16:301:25 | access to parameter sinkParam9 |
+| GlobalDataFlow.cs:304:32:304:42 | sinkParam11 | GlobalDataFlow.cs:304:32:304:42 | sinkParam11 |
+| GlobalDataFlow.cs:304:32:304:42 | sinkParam11 | GlobalDataFlow.cs:304:32:304:42 | sinkParam11 |
+| GlobalDataFlow.cs:304:32:304:42 | sinkParam11 | GlobalDataFlow.cs:306:15:306:25 | access to parameter sinkParam11 |
+| GlobalDataFlow.cs:304:32:304:42 | sinkParam11 | GlobalDataFlow.cs:306:15:306:25 | access to parameter sinkParam11 |
+| GlobalDataFlow.cs:304:32:304:42 | sinkParam11 | GlobalDataFlow.cs:307:16:307:26 | access to parameter sinkParam11 |
+| GlobalDataFlow.cs:304:32:304:42 | sinkParam11 | GlobalDataFlow.cs:307:16:307:26 | access to parameter sinkParam11 |
+| GlobalDataFlow.cs:306:9:306:26 | call to method Check | GlobalDataFlow.cs:306:9:306:26 | call to method Check |
+| GlobalDataFlow.cs:306:15:306:25 | access to parameter sinkParam11 | GlobalDataFlow.cs:306:15:306:25 | access to parameter sinkParam11 |
+| GlobalDataFlow.cs:306:15:306:25 | access to parameter sinkParam11 | GlobalDataFlow.cs:307:16:307:26 | access to parameter sinkParam11 |
+| GlobalDataFlow.cs:306:15:306:25 | access to parameter sinkParam11 | GlobalDataFlow.cs:307:16:307:26 | access to parameter sinkParam11 |
+| GlobalDataFlow.cs:307:16:307:26 | access to parameter sinkParam11 | GlobalDataFlow.cs:214:37:214:48 | [output] delegate creation of type Func<String,String> |
+| GlobalDataFlow.cs:307:16:307:26 | access to parameter sinkParam11 | GlobalDataFlow.cs:214:37:214:48 | [output] delegate creation of type Func<String,String> |
+| GlobalDataFlow.cs:307:16:307:26 | access to parameter sinkParam11 | GlobalDataFlow.cs:228:37:228:48 | [output] delegate creation of type Func<String,String> |
+| GlobalDataFlow.cs:307:16:307:26 | access to parameter sinkParam11 | GlobalDataFlow.cs:228:37:228:48 | [output] delegate creation of type Func<String,String> |
+| GlobalDataFlow.cs:307:16:307:26 | access to parameter sinkParam11 | GlobalDataFlow.cs:307:16:307:26 | access to parameter sinkParam11 |
+| GlobalDataFlow.cs:310:34:310:45 | nonSinkParam | GlobalDataFlow.cs:310:34:310:45 | nonSinkParam |
+| GlobalDataFlow.cs:310:34:310:45 | nonSinkParam | GlobalDataFlow.cs:310:34:310:45 | nonSinkParam |
+| GlobalDataFlow.cs:310:34:310:45 | nonSinkParam | GlobalDataFlow.cs:312:15:312:26 | access to parameter nonSinkParam |
+| GlobalDataFlow.cs:310:34:310:45 | nonSinkParam | GlobalDataFlow.cs:312:15:312:26 | access to parameter nonSinkParam |
+| GlobalDataFlow.cs:310:34:310:45 | nonSinkParam | GlobalDataFlow.cs:312:15:312:26 | access to parameter nonSinkParam |
+| GlobalDataFlow.cs:310:34:310:45 | nonSinkParam | GlobalDataFlow.cs:312:15:312:26 | access to parameter nonSinkParam |
+| GlobalDataFlow.cs:310:34:310:45 | nonSinkParam | GlobalDataFlow.cs:313:16:313:27 | access to parameter nonSinkParam |
+| GlobalDataFlow.cs:310:34:310:45 | nonSinkParam | GlobalDataFlow.cs:313:16:313:27 | access to parameter nonSinkParam |
+| GlobalDataFlow.cs:310:34:310:45 | nonSinkParam | GlobalDataFlow.cs:313:16:313:27 | access to parameter nonSinkParam |
+| GlobalDataFlow.cs:310:34:310:45 | nonSinkParam | GlobalDataFlow.cs:313:16:313:27 | access to parameter nonSinkParam |
+| GlobalDataFlow.cs:312:9:312:27 | call to method Check | GlobalDataFlow.cs:312:9:312:27 | call to method Check |
+| GlobalDataFlow.cs:312:15:312:26 | access to parameter nonSinkParam | GlobalDataFlow.cs:312:15:312:26 | access to parameter nonSinkParam |
+| GlobalDataFlow.cs:312:15:312:26 | access to parameter nonSinkParam | GlobalDataFlow.cs:313:16:313:27 | access to parameter nonSinkParam |
+| GlobalDataFlow.cs:312:15:312:26 | access to parameter nonSinkParam | GlobalDataFlow.cs:313:16:313:27 | access to parameter nonSinkParam |
+| GlobalDataFlow.cs:312:15:312:26 | access to parameter nonSinkParam | GlobalDataFlow.cs:313:16:313:27 | access to parameter nonSinkParam |
+| GlobalDataFlow.cs:312:15:312:26 | access to parameter nonSinkParam | GlobalDataFlow.cs:313:16:313:27 | access to parameter nonSinkParam |
+| GlobalDataFlow.cs:313:16:313:27 | access to parameter nonSinkParam | GlobalDataFlow.cs:219:76:219:92 | call to method NonReturnCheck |
+| GlobalDataFlow.cs:313:16:313:27 | access to parameter nonSinkParam | GlobalDataFlow.cs:219:76:219:92 | call to method NonReturnCheck |
+| GlobalDataFlow.cs:313:16:313:27 | access to parameter nonSinkParam | GlobalDataFlow.cs:313:16:313:27 | access to parameter nonSinkParam |
+| GlobalDataFlow.cs:316:12:316:14 | this | GlobalDataFlow.cs:316:12:316:14 | this |
+| GlobalDataFlow.cs:318:16:318:29 | "taint source" | GlobalDataFlow.cs:153:21:153:25 | call to method Out |
+| GlobalDataFlow.cs:318:16:318:29 | "taint source" | GlobalDataFlow.cs:153:21:153:25 | call to method Out |
+| GlobalDataFlow.cs:318:16:318:29 | "taint source" | GlobalDataFlow.cs:189:39:189:41 | [output] delegate creation of type Func<String> |
+| GlobalDataFlow.cs:318:16:318:29 | "taint source" | GlobalDataFlow.cs:189:39:189:41 | [output] delegate creation of type Func<String> |
+| GlobalDataFlow.cs:318:16:318:29 | "taint source" | GlobalDataFlow.cs:318:16:318:29 | "taint source" |
 | GlobalDataFlow.cs:321:10:321:15 | this | GlobalDataFlow.cs:321:10:321:15 | this |
 | GlobalDataFlow.cs:323:9:323:26 | ... = ... | GlobalDataFlow.cs:323:9:323:26 | ... = ... |
-| GlobalDataFlow.cs:323:9:323:26 | SSA def(x) | GlobalDataFlow.cs:155:20:155:24 | SSA def(sink8) |
-| GlobalDataFlow.cs:323:9:323:26 | SSA def(x) | GlobalDataFlow.cs:155:20:155:24 | SSA def(sink8) |
+| GlobalDataFlow.cs:323:9:323:26 | SSA def(x) | GlobalDataFlow.cs:156:20:156:24 | SSA def(sink7) |
+| GlobalDataFlow.cs:323:9:323:26 | SSA def(x) | GlobalDataFlow.cs:156:20:156:24 | SSA def(sink7) |
 | GlobalDataFlow.cs:323:9:323:26 | SSA def(x) | GlobalDataFlow.cs:323:9:323:26 | SSA def(x) |
 | GlobalDataFlow.cs:323:13:323:26 | "taint source" | GlobalDataFlow.cs:323:9:323:26 | SSA def(x) |
 | GlobalDataFlow.cs:323:13:323:26 | "taint source" | GlobalDataFlow.cs:323:9:323:26 | SSA def(x) |
 | GlobalDataFlow.cs:323:13:323:26 | "taint source" | GlobalDataFlow.cs:323:13:323:26 | "taint source" |
-| GlobalDataFlow.cs:326:25:326:32 | this | GlobalDataFlow.cs:326:25:326:32 | this |
-| GlobalDataFlow.cs:328:22:328:23 | "" | GlobalDataFlow.cs:157:22:157:31 | call to method OutYield |
-| GlobalDataFlow.cs:328:22:328:23 | "" | GlobalDataFlow.cs:157:22:157:31 | call to method OutYield |
-| GlobalDataFlow.cs:328:22:328:23 | "" | GlobalDataFlow.cs:328:22:328:23 | "" |
-| GlobalDataFlow.cs:328:22:328:23 | "" | GlobalDataFlow.cs:328:22:328:23 | "" |
-| GlobalDataFlow.cs:329:22:329:35 | "taint source" | GlobalDataFlow.cs:157:22:157:31 | call to method OutYield |
-| GlobalDataFlow.cs:329:22:329:35 | "taint source" | GlobalDataFlow.cs:157:22:157:31 | call to method OutYield |
-| GlobalDataFlow.cs:329:22:329:35 | "taint source" | GlobalDataFlow.cs:329:22:329:35 | "taint source" |
-| GlobalDataFlow.cs:329:22:329:35 | "taint source" | GlobalDataFlow.cs:329:22:329:35 | "taint source" |
-| GlobalDataFlow.cs:330:22:330:23 | "" | GlobalDataFlow.cs:157:22:157:31 | call to method OutYield |
-| GlobalDataFlow.cs:330:22:330:23 | "" | GlobalDataFlow.cs:157:22:157:31 | call to method OutYield |
-| GlobalDataFlow.cs:330:22:330:23 | "" | GlobalDataFlow.cs:330:22:330:23 | "" |
-| GlobalDataFlow.cs:330:22:330:23 | "" | GlobalDataFlow.cs:330:22:330:23 | "" |
-| GlobalDataFlow.cs:333:12:333:17 | this | GlobalDataFlow.cs:333:12:333:17 | this |
-| GlobalDataFlow.cs:335:16:335:17 | "" | GlobalDataFlow.cs:163:20:163:27 | call to method NonOut |
-| GlobalDataFlow.cs:335:16:335:17 | "" | GlobalDataFlow.cs:163:20:163:27 | call to method NonOut |
-| GlobalDataFlow.cs:335:16:335:17 | "" | GlobalDataFlow.cs:189:37:189:42 | [output] delegate creation of type Func<String> |
-| GlobalDataFlow.cs:335:16:335:17 | "" | GlobalDataFlow.cs:189:37:189:42 | [output] delegate creation of type Func<String> |
-| GlobalDataFlow.cs:335:16:335:17 | "" | GlobalDataFlow.cs:335:16:335:17 | "" |
-| GlobalDataFlow.cs:338:10:338:18 | this | GlobalDataFlow.cs:338:10:338:18 | this |
-| GlobalDataFlow.cs:340:9:340:14 | ... = ... | GlobalDataFlow.cs:340:9:340:14 | ... = ... |
-| GlobalDataFlow.cs:340:9:340:14 | SSA def(x) | GlobalDataFlow.cs:165:23:165:30 | SSA def(nonSink0) |
-| GlobalDataFlow.cs:340:9:340:14 | SSA def(x) | GlobalDataFlow.cs:165:23:165:30 | SSA def(nonSink0) |
-| GlobalDataFlow.cs:340:9:340:14 | SSA def(x) | GlobalDataFlow.cs:340:9:340:14 | SSA def(x) |
-| GlobalDataFlow.cs:340:13:340:14 | "" | GlobalDataFlow.cs:340:9:340:14 | SSA def(x) |
-| GlobalDataFlow.cs:340:13:340:14 | "" | GlobalDataFlow.cs:340:9:340:14 | SSA def(x) |
-| GlobalDataFlow.cs:340:13:340:14 | "" | GlobalDataFlow.cs:340:13:340:14 | "" |
+| GlobalDataFlow.cs:326:10:326:15 | this | GlobalDataFlow.cs:326:10:326:15 | this |
+| GlobalDataFlow.cs:328:9:328:26 | ... = ... | GlobalDataFlow.cs:328:9:328:26 | ... = ... |
+| GlobalDataFlow.cs:328:9:328:26 | SSA def(x) | GlobalDataFlow.cs:159:20:159:24 | SSA def(sink8) |
+| GlobalDataFlow.cs:328:9:328:26 | SSA def(x) | GlobalDataFlow.cs:159:20:159:24 | SSA def(sink8) |
+| GlobalDataFlow.cs:328:9:328:26 | SSA def(x) | GlobalDataFlow.cs:328:9:328:26 | SSA def(x) |
+| GlobalDataFlow.cs:328:13:328:26 | "taint source" | GlobalDataFlow.cs:328:9:328:26 | SSA def(x) |
+| GlobalDataFlow.cs:328:13:328:26 | "taint source" | GlobalDataFlow.cs:328:9:328:26 | SSA def(x) |
+| GlobalDataFlow.cs:328:13:328:26 | "taint source" | GlobalDataFlow.cs:328:13:328:26 | "taint source" |
+| GlobalDataFlow.cs:331:25:331:32 | this | GlobalDataFlow.cs:331:25:331:32 | this |
+| GlobalDataFlow.cs:333:22:333:23 | "" | GlobalDataFlow.cs:161:22:161:31 | call to method OutYield |
+| GlobalDataFlow.cs:333:22:333:23 | "" | GlobalDataFlow.cs:161:22:161:31 | call to method OutYield |
+| GlobalDataFlow.cs:333:22:333:23 | "" | GlobalDataFlow.cs:333:22:333:23 | "" |
+| GlobalDataFlow.cs:333:22:333:23 | "" | GlobalDataFlow.cs:333:22:333:23 | "" |
+| GlobalDataFlow.cs:334:22:334:35 | "taint source" | GlobalDataFlow.cs:161:22:161:31 | call to method OutYield |
+| GlobalDataFlow.cs:334:22:334:35 | "taint source" | GlobalDataFlow.cs:161:22:161:31 | call to method OutYield |
+| GlobalDataFlow.cs:334:22:334:35 | "taint source" | GlobalDataFlow.cs:334:22:334:35 | "taint source" |
+| GlobalDataFlow.cs:334:22:334:35 | "taint source" | GlobalDataFlow.cs:334:22:334:35 | "taint source" |
+| GlobalDataFlow.cs:335:22:335:23 | "" | GlobalDataFlow.cs:161:22:161:31 | call to method OutYield |
+| GlobalDataFlow.cs:335:22:335:23 | "" | GlobalDataFlow.cs:161:22:161:31 | call to method OutYield |
+| GlobalDataFlow.cs:335:22:335:23 | "" | GlobalDataFlow.cs:335:22:335:23 | "" |
+| GlobalDataFlow.cs:335:22:335:23 | "" | GlobalDataFlow.cs:335:22:335:23 | "" |
+| GlobalDataFlow.cs:338:12:338:17 | this | GlobalDataFlow.cs:338:12:338:17 | this |
+| GlobalDataFlow.cs:340:16:340:17 | "" | GlobalDataFlow.cs:167:20:167:27 | call to method NonOut |
+| GlobalDataFlow.cs:340:16:340:17 | "" | GlobalDataFlow.cs:167:20:167:27 | call to method NonOut |
+| GlobalDataFlow.cs:340:16:340:17 | "" | GlobalDataFlow.cs:193:37:193:42 | [output] delegate creation of type Func<String> |
+| GlobalDataFlow.cs:340:16:340:17 | "" | GlobalDataFlow.cs:193:37:193:42 | [output] delegate creation of type Func<String> |
+| GlobalDataFlow.cs:340:16:340:17 | "" | GlobalDataFlow.cs:340:16:340:17 | "" |
 | GlobalDataFlow.cs:343:10:343:18 | this | GlobalDataFlow.cs:343:10:343:18 | this |
 | GlobalDataFlow.cs:345:9:345:14 | ... = ... | GlobalDataFlow.cs:345:9:345:14 | ... = ... |
-| GlobalDataFlow.cs:345:9:345:14 | SSA def(x) | GlobalDataFlow.cs:167:23:167:30 | SSA def(nonSink0) |
-| GlobalDataFlow.cs:345:9:345:14 | SSA def(x) | GlobalDataFlow.cs:167:23:167:30 | SSA def(nonSink0) |
+| GlobalDataFlow.cs:345:9:345:14 | SSA def(x) | GlobalDataFlow.cs:169:23:169:30 | SSA def(nonSink0) |
+| GlobalDataFlow.cs:345:9:345:14 | SSA def(x) | GlobalDataFlow.cs:169:23:169:30 | SSA def(nonSink0) |
 | GlobalDataFlow.cs:345:9:345:14 | SSA def(x) | GlobalDataFlow.cs:345:9:345:14 | SSA def(x) |
 | GlobalDataFlow.cs:345:13:345:14 | "" | GlobalDataFlow.cs:345:9:345:14 | SSA def(x) |
 | GlobalDataFlow.cs:345:13:345:14 | "" | GlobalDataFlow.cs:345:9:345:14 | SSA def(x) |
 | GlobalDataFlow.cs:345:13:345:14 | "" | GlobalDataFlow.cs:345:13:345:14 | "" |
-| GlobalDataFlow.cs:348:25:348:35 | this | GlobalDataFlow.cs:348:25:348:35 | this |
-| GlobalDataFlow.cs:350:22:350:23 | "" | GlobalDataFlow.cs:169:20:169:32 | call to method NonOutYield |
-| GlobalDataFlow.cs:350:22:350:23 | "" | GlobalDataFlow.cs:169:20:169:32 | call to method NonOutYield |
-| GlobalDataFlow.cs:350:22:350:23 | "" | GlobalDataFlow.cs:350:22:350:23 | "" |
-| GlobalDataFlow.cs:350:22:350:23 | "" | GlobalDataFlow.cs:350:22:350:23 | "" |
-| GlobalDataFlow.cs:351:22:351:23 | "" | GlobalDataFlow.cs:169:20:169:32 | call to method NonOutYield |
-| GlobalDataFlow.cs:351:22:351:23 | "" | GlobalDataFlow.cs:169:20:169:32 | call to method NonOutYield |
-| GlobalDataFlow.cs:351:22:351:23 | "" | GlobalDataFlow.cs:351:22:351:23 | "" |
-| GlobalDataFlow.cs:351:22:351:23 | "" | GlobalDataFlow.cs:351:22:351:23 | "" |
-| GlobalDataFlow.cs:354:36:354:36 | a | GlobalDataFlow.cs:354:36:354:36 | a |
-| GlobalDataFlow.cs:354:36:354:36 | a | GlobalDataFlow.cs:354:36:354:36 | a |
-| GlobalDataFlow.cs:354:36:354:36 | a | GlobalDataFlow.cs:356:9:356:9 | access to parameter a |
-| GlobalDataFlow.cs:354:36:354:36 | a | GlobalDataFlow.cs:356:9:356:9 | access to parameter a |
-| GlobalDataFlow.cs:354:36:354:36 | a | GlobalDataFlow.cs:356:9:356:9 | access to parameter a |
-| GlobalDataFlow.cs:354:36:354:36 | a | GlobalDataFlow.cs:356:9:356:9 | access to parameter a |
-| GlobalDataFlow.cs:354:36:354:36 | a | GlobalDataFlow.cs:356:9:356:9 | access to parameter a |
-| GlobalDataFlow.cs:354:36:354:36 | a | GlobalDataFlow.cs:356:9:356:9 | access to parameter a |
-| GlobalDataFlow.cs:354:36:354:36 | a | GlobalDataFlow.cs:356:9:356:9 | access to parameter a |
-| GlobalDataFlow.cs:354:36:354:36 | a | GlobalDataFlow.cs:356:9:356:9 | access to parameter a |
-| GlobalDataFlow.cs:354:41:354:41 | x | GlobalDataFlow.cs:354:41:354:41 | x |
-| GlobalDataFlow.cs:354:41:354:41 | x | GlobalDataFlow.cs:354:41:354:41 | x |
-| GlobalDataFlow.cs:354:41:354:41 | x | GlobalDataFlow.cs:356:11:356:11 | access to parameter x |
-| GlobalDataFlow.cs:354:41:354:41 | x | GlobalDataFlow.cs:356:11:356:11 | access to parameter x |
-| GlobalDataFlow.cs:354:41:354:41 | x | GlobalDataFlow.cs:356:11:356:11 | access to parameter x |
-| GlobalDataFlow.cs:354:41:354:41 | x | GlobalDataFlow.cs:356:11:356:11 | access to parameter x |
-| GlobalDataFlow.cs:354:41:354:41 | x | GlobalDataFlow.cs:356:11:356:11 | access to parameter x |
-| GlobalDataFlow.cs:354:41:354:41 | x | GlobalDataFlow.cs:356:11:356:11 | access to parameter x |
-| GlobalDataFlow.cs:354:41:354:41 | x | GlobalDataFlow.cs:356:11:356:11 | access to parameter x |
-| GlobalDataFlow.cs:354:41:354:41 | x | GlobalDataFlow.cs:356:11:356:11 | access to parameter x |
-| GlobalDataFlow.cs:356:9:356:9 | access to parameter a | GlobalDataFlow.cs:356:9:356:9 | access to parameter a |
-| GlobalDataFlow.cs:356:9:356:12 | delegate call | GlobalDataFlow.cs:356:9:356:12 | delegate call |
-| GlobalDataFlow.cs:356:11:356:11 | access to parameter x | GlobalDataFlow.cs:53:15:53:15 | x |
-| GlobalDataFlow.cs:356:11:356:11 | access to parameter x | GlobalDataFlow.cs:53:15:53:15 | x |
-| GlobalDataFlow.cs:356:11:356:11 | access to parameter x | GlobalDataFlow.cs:53:15:53:15 | x |
-| GlobalDataFlow.cs:356:11:356:11 | access to parameter x | GlobalDataFlow.cs:53:15:53:15 | x |
-| GlobalDataFlow.cs:356:11:356:11 | access to parameter x | GlobalDataFlow.cs:60:15:60:27 | nonSinkParam0 |
-| GlobalDataFlow.cs:356:11:356:11 | access to parameter x | GlobalDataFlow.cs:60:15:60:27 | nonSinkParam0 |
-| GlobalDataFlow.cs:356:11:356:11 | access to parameter x | GlobalDataFlow.cs:60:15:60:27 | nonSinkParam0 |
-| GlobalDataFlow.cs:356:11:356:11 | access to parameter x | GlobalDataFlow.cs:60:15:60:27 | nonSinkParam0 |
-| GlobalDataFlow.cs:356:11:356:11 | access to parameter x | GlobalDataFlow.cs:241:26:241:35 | sinkParam3 |
-| GlobalDataFlow.cs:356:11:356:11 | access to parameter x | GlobalDataFlow.cs:241:26:241:35 | sinkParam3 |
-| GlobalDataFlow.cs:356:11:356:11 | access to parameter x | GlobalDataFlow.cs:241:26:241:35 | sinkParam3 |
-| GlobalDataFlow.cs:356:11:356:11 | access to parameter x | GlobalDataFlow.cs:241:26:241:35 | sinkParam3 |
-| GlobalDataFlow.cs:356:11:356:11 | access to parameter x | GlobalDataFlow.cs:356:11:356:11 | access to parameter x |
-| GlobalDataFlow.cs:359:41:359:41 | f | GlobalDataFlow.cs:359:41:359:41 | f |
-| GlobalDataFlow.cs:359:41:359:41 | f | GlobalDataFlow.cs:359:41:359:41 | f |
-| GlobalDataFlow.cs:359:41:359:41 | f | GlobalDataFlow.cs:361:16:361:16 | access to parameter f |
-| GlobalDataFlow.cs:359:41:359:41 | f | GlobalDataFlow.cs:361:16:361:16 | access to parameter f |
-| GlobalDataFlow.cs:359:41:359:41 | f | GlobalDataFlow.cs:361:16:361:16 | access to parameter f |
-| GlobalDataFlow.cs:359:41:359:41 | f | GlobalDataFlow.cs:361:16:361:16 | access to parameter f |
-| GlobalDataFlow.cs:359:41:359:41 | f | GlobalDataFlow.cs:361:16:361:16 | access to parameter f |
-| GlobalDataFlow.cs:359:41:359:41 | f | GlobalDataFlow.cs:361:16:361:16 | access to parameter f |
-| GlobalDataFlow.cs:359:41:359:41 | f | GlobalDataFlow.cs:361:16:361:16 | access to parameter f |
-| GlobalDataFlow.cs:359:41:359:41 | f | GlobalDataFlow.cs:361:16:361:16 | access to parameter f |
-| GlobalDataFlow.cs:359:41:359:41 | f | GlobalDataFlow.cs:361:16:361:16 | access to parameter f |
-| GlobalDataFlow.cs:359:41:359:41 | f | GlobalDataFlow.cs:361:16:361:16 | access to parameter f |
-| GlobalDataFlow.cs:359:41:359:41 | f | GlobalDataFlow.cs:361:16:361:16 | access to parameter f |
-| GlobalDataFlow.cs:359:41:359:41 | f | GlobalDataFlow.cs:361:16:361:16 | access to parameter f |
-| GlobalDataFlow.cs:359:46:359:46 | x | GlobalDataFlow.cs:359:46:359:46 | x |
-| GlobalDataFlow.cs:359:46:359:46 | x | GlobalDataFlow.cs:359:46:359:46 | x |
-| GlobalDataFlow.cs:359:46:359:46 | x | GlobalDataFlow.cs:361:18:361:18 | access to parameter x |
-| GlobalDataFlow.cs:359:46:359:46 | x | GlobalDataFlow.cs:361:18:361:18 | access to parameter x |
-| GlobalDataFlow.cs:359:46:359:46 | x | GlobalDataFlow.cs:361:18:361:18 | access to parameter x |
-| GlobalDataFlow.cs:359:46:359:46 | x | GlobalDataFlow.cs:361:18:361:18 | access to parameter x |
-| GlobalDataFlow.cs:359:46:359:46 | x | GlobalDataFlow.cs:361:18:361:18 | access to parameter x |
-| GlobalDataFlow.cs:359:46:359:46 | x | GlobalDataFlow.cs:361:18:361:18 | access to parameter x |
-| GlobalDataFlow.cs:359:46:359:46 | x | GlobalDataFlow.cs:361:18:361:18 | access to parameter x |
-| GlobalDataFlow.cs:359:46:359:46 | x | GlobalDataFlow.cs:361:18:361:18 | access to parameter x |
-| GlobalDataFlow.cs:359:46:359:46 | x | GlobalDataFlow.cs:361:18:361:18 | access to parameter x |
-| GlobalDataFlow.cs:359:46:359:46 | x | GlobalDataFlow.cs:361:18:361:18 | access to parameter x |
-| GlobalDataFlow.cs:359:46:359:46 | x | GlobalDataFlow.cs:361:18:361:18 | access to parameter x |
-| GlobalDataFlow.cs:359:46:359:46 | x | GlobalDataFlow.cs:361:18:361:18 | access to parameter x |
-| GlobalDataFlow.cs:361:16:361:16 | access to parameter f | GlobalDataFlow.cs:361:16:361:16 | access to parameter f |
-| GlobalDataFlow.cs:361:16:361:19 | delegate call | GlobalDataFlow.cs:130:45:130:64 | call to method ApplyFunc |
-| GlobalDataFlow.cs:361:16:361:19 | delegate call | GlobalDataFlow.cs:130:45:130:64 | call to method ApplyFunc |
-| GlobalDataFlow.cs:361:16:361:19 | delegate call | GlobalDataFlow.cs:130:45:130:64 | call to method ApplyFunc |
-| GlobalDataFlow.cs:361:16:361:19 | delegate call | GlobalDataFlow.cs:130:45:130:64 | call to method ApplyFunc |
-| GlobalDataFlow.cs:361:16:361:19 | delegate call | GlobalDataFlow.cs:139:21:139:44 | call to method ApplyFunc |
-| GlobalDataFlow.cs:361:16:361:19 | delegate call | GlobalDataFlow.cs:139:21:139:44 | call to method ApplyFunc |
-| GlobalDataFlow.cs:361:16:361:19 | delegate call | GlobalDataFlow.cs:139:21:139:44 | call to method ApplyFunc |
-| GlobalDataFlow.cs:361:16:361:19 | delegate call | GlobalDataFlow.cs:139:21:139:44 | call to method ApplyFunc |
-| GlobalDataFlow.cs:361:16:361:19 | delegate call | GlobalDataFlow.cs:143:20:143:40 | call to method ApplyFunc |
-| GlobalDataFlow.cs:361:16:361:19 | delegate call | GlobalDataFlow.cs:143:20:143:40 | call to method ApplyFunc |
-| GlobalDataFlow.cs:361:16:361:19 | delegate call | GlobalDataFlow.cs:143:20:143:40 | call to method ApplyFunc |
-| GlobalDataFlow.cs:361:16:361:19 | delegate call | GlobalDataFlow.cs:143:20:143:40 | call to method ApplyFunc |
-| GlobalDataFlow.cs:361:16:361:19 | delegate call | GlobalDataFlow.cs:145:20:145:44 | call to method ApplyFunc |
-| GlobalDataFlow.cs:361:16:361:19 | delegate call | GlobalDataFlow.cs:145:20:145:44 | call to method ApplyFunc |
-| GlobalDataFlow.cs:361:16:361:19 | delegate call | GlobalDataFlow.cs:145:20:145:44 | call to method ApplyFunc |
-| GlobalDataFlow.cs:361:16:361:19 | delegate call | GlobalDataFlow.cs:145:20:145:44 | call to method ApplyFunc |
-| GlobalDataFlow.cs:361:16:361:19 | delegate call | GlobalDataFlow.cs:273:17:273:38 | call to method ApplyFunc |
-| GlobalDataFlow.cs:361:16:361:19 | delegate call | GlobalDataFlow.cs:273:17:273:38 | call to method ApplyFunc |
-| GlobalDataFlow.cs:361:16:361:19 | delegate call | GlobalDataFlow.cs:273:17:273:38 | call to method ApplyFunc |
-| GlobalDataFlow.cs:361:16:361:19 | delegate call | GlobalDataFlow.cs:273:17:273:38 | call to method ApplyFunc |
-| GlobalDataFlow.cs:361:16:361:19 | delegate call | GlobalDataFlow.cs:361:16:361:19 | delegate call |
-| GlobalDataFlow.cs:361:18:361:18 | access to parameter x | GlobalDataFlow.cs:271:26:271:26 | x |
-| GlobalDataFlow.cs:361:18:361:18 | access to parameter x | GlobalDataFlow.cs:271:26:271:26 | x |
-| GlobalDataFlow.cs:361:18:361:18 | access to parameter x | GlobalDataFlow.cs:271:26:271:26 | x |
-| GlobalDataFlow.cs:361:18:361:18 | access to parameter x | GlobalDataFlow.cs:271:26:271:26 | x |
-| GlobalDataFlow.cs:361:18:361:18 | access to parameter x | GlobalDataFlow.cs:271:26:271:26 | x |
-| GlobalDataFlow.cs:361:18:361:18 | access to parameter x | GlobalDataFlow.cs:271:26:271:26 | x |
-| GlobalDataFlow.cs:361:18:361:18 | access to parameter x | GlobalDataFlow.cs:271:26:271:26 | x |
-| GlobalDataFlow.cs:361:18:361:18 | access to parameter x | GlobalDataFlow.cs:271:26:271:26 | x |
-| GlobalDataFlow.cs:361:18:361:18 | access to parameter x | GlobalDataFlow.cs:273:27:273:28 | x0 |
-| GlobalDataFlow.cs:361:18:361:18 | access to parameter x | GlobalDataFlow.cs:273:27:273:28 | x0 |
-| GlobalDataFlow.cs:361:18:361:18 | access to parameter x | GlobalDataFlow.cs:273:27:273:28 | x0 |
-| GlobalDataFlow.cs:361:18:361:18 | access to parameter x | GlobalDataFlow.cs:273:27:273:28 | x0 |
-| GlobalDataFlow.cs:361:18:361:18 | access to parameter x | GlobalDataFlow.cs:361:16:361:19 | delegate call |
-| GlobalDataFlow.cs:361:18:361:18 | access to parameter x | GlobalDataFlow.cs:361:16:361:19 | delegate call |
-| GlobalDataFlow.cs:361:18:361:18 | access to parameter x | GlobalDataFlow.cs:361:16:361:19 | delegate call |
-| GlobalDataFlow.cs:361:18:361:18 | access to parameter x | GlobalDataFlow.cs:361:16:361:19 | delegate call |
-| GlobalDataFlow.cs:361:18:361:18 | access to parameter x | GlobalDataFlow.cs:361:16:361:19 | delegate call |
-| GlobalDataFlow.cs:361:18:361:18 | access to parameter x | GlobalDataFlow.cs:361:16:361:19 | delegate call |
-| GlobalDataFlow.cs:361:18:361:18 | access to parameter x | GlobalDataFlow.cs:361:16:361:19 | delegate call |
-| GlobalDataFlow.cs:361:18:361:18 | access to parameter x | GlobalDataFlow.cs:361:16:361:19 | delegate call |
-| GlobalDataFlow.cs:361:18:361:18 | access to parameter x | GlobalDataFlow.cs:361:16:361:19 | delegate call |
-| GlobalDataFlow.cs:361:18:361:18 | access to parameter x | GlobalDataFlow.cs:361:16:361:19 | delegate call |
-| GlobalDataFlow.cs:361:18:361:18 | access to parameter x | GlobalDataFlow.cs:361:18:361:18 | access to parameter x |
-| GlobalDataFlow.cs:368:42:368:42 | a | GlobalDataFlow.cs:368:42:368:42 | a |
-| GlobalDataFlow.cs:368:42:368:42 | a | GlobalDataFlow.cs:368:42:368:42 | a |
-| GlobalDataFlow.cs:368:42:368:42 | a | GlobalDataFlow.cs:370:9:370:9 | access to parameter a |
-| GlobalDataFlow.cs:368:42:368:42 | a | GlobalDataFlow.cs:370:9:370:9 | access to parameter a |
-| GlobalDataFlow.cs:368:42:368:42 | a | GlobalDataFlow.cs:370:9:370:9 | access to parameter a |
-| GlobalDataFlow.cs:368:42:368:42 | a | GlobalDataFlow.cs:370:9:370:9 | access to parameter a |
-| GlobalDataFlow.cs:368:42:368:42 | a | GlobalDataFlow.cs:370:9:370:9 | access to parameter a |
-| GlobalDataFlow.cs:368:42:368:42 | a | GlobalDataFlow.cs:370:9:370:9 | access to parameter a |
-| GlobalDataFlow.cs:368:42:368:42 | a | GlobalDataFlow.cs:370:9:370:9 | access to parameter a |
-| GlobalDataFlow.cs:368:42:368:42 | a | GlobalDataFlow.cs:370:9:370:9 | access to parameter a |
-| GlobalDataFlow.cs:368:42:368:42 | a | GlobalDataFlow.cs:370:9:370:9 | access to parameter a |
-| GlobalDataFlow.cs:368:42:368:42 | a | GlobalDataFlow.cs:370:9:370:9 | access to parameter a |
-| GlobalDataFlow.cs:368:52:368:52 | x | GlobalDataFlow.cs:368:52:368:52 | x |
-| GlobalDataFlow.cs:368:52:368:52 | x | GlobalDataFlow.cs:368:52:368:52 | x |
-| GlobalDataFlow.cs:368:52:368:52 | x | GlobalDataFlow.cs:370:11:370:11 | access to parameter x |
-| GlobalDataFlow.cs:368:52:368:52 | x | GlobalDataFlow.cs:370:11:370:11 | access to parameter x |
-| GlobalDataFlow.cs:368:52:368:52 | x | GlobalDataFlow.cs:370:11:370:11 | access to parameter x |
-| GlobalDataFlow.cs:368:52:368:52 | x | GlobalDataFlow.cs:370:11:370:11 | access to parameter x |
-| GlobalDataFlow.cs:368:52:368:52 | x | GlobalDataFlow.cs:370:11:370:11 | access to parameter x |
-| GlobalDataFlow.cs:368:52:368:52 | x | GlobalDataFlow.cs:370:11:370:11 | access to parameter x |
-| GlobalDataFlow.cs:368:52:368:52 | x | GlobalDataFlow.cs:370:11:370:11 | access to parameter x |
-| GlobalDataFlow.cs:368:52:368:52 | x | GlobalDataFlow.cs:370:11:370:11 | access to parameter x |
-| GlobalDataFlow.cs:368:52:368:52 | x | GlobalDataFlow.cs:370:11:370:11 | access to parameter x |
-| GlobalDataFlow.cs:368:52:368:52 | x | GlobalDataFlow.cs:370:11:370:11 | access to parameter x |
-| GlobalDataFlow.cs:370:9:370:9 | access to parameter a | GlobalDataFlow.cs:370:9:370:9 | access to parameter a |
-| GlobalDataFlow.cs:370:9:370:12 | delegate call | GlobalDataFlow.cs:370:9:370:12 | delegate call |
-| GlobalDataFlow.cs:370:11:370:11 | access to parameter x | GlobalDataFlow.cs:56:37:56:37 | x |
-| GlobalDataFlow.cs:370:11:370:11 | access to parameter x | GlobalDataFlow.cs:56:37:56:37 | x |
-| GlobalDataFlow.cs:370:11:370:11 | access to parameter x | GlobalDataFlow.cs:56:37:56:37 | x |
-| GlobalDataFlow.cs:370:11:370:11 | access to parameter x | GlobalDataFlow.cs:56:37:56:37 | x |
-| GlobalDataFlow.cs:370:11:370:11 | access to parameter x | GlobalDataFlow.cs:61:38:61:50 | nonSinkParam0 |
-| GlobalDataFlow.cs:370:11:370:11 | access to parameter x | GlobalDataFlow.cs:61:38:61:50 | nonSinkParam0 |
-| GlobalDataFlow.cs:370:11:370:11 | access to parameter x | GlobalDataFlow.cs:61:38:61:50 | nonSinkParam0 |
-| GlobalDataFlow.cs:370:11:370:11 | access to parameter x | GlobalDataFlow.cs:61:38:61:50 | nonSinkParam0 |
-| GlobalDataFlow.cs:370:11:370:11 | access to parameter x | GlobalDataFlow.cs:251:26:251:35 | sinkParam5 |
-| GlobalDataFlow.cs:370:11:370:11 | access to parameter x | GlobalDataFlow.cs:251:26:251:35 | sinkParam5 |
-| GlobalDataFlow.cs:370:11:370:11 | access to parameter x | GlobalDataFlow.cs:251:26:251:35 | sinkParam5 |
-| GlobalDataFlow.cs:370:11:370:11 | access to parameter x | GlobalDataFlow.cs:251:26:251:35 | sinkParam5 |
-| GlobalDataFlow.cs:370:11:370:11 | access to parameter x | GlobalDataFlow.cs:256:26:256:35 | sinkParam6 |
-| GlobalDataFlow.cs:370:11:370:11 | access to parameter x | GlobalDataFlow.cs:256:26:256:35 | sinkParam6 |
-| GlobalDataFlow.cs:370:11:370:11 | access to parameter x | GlobalDataFlow.cs:256:26:256:35 | sinkParam6 |
-| GlobalDataFlow.cs:370:11:370:11 | access to parameter x | GlobalDataFlow.cs:256:26:256:35 | sinkParam6 |
-| GlobalDataFlow.cs:370:11:370:11 | access to parameter x | GlobalDataFlow.cs:370:11:370:11 | access to parameter x |
-| GlobalDataFlow.cs:373:39:373:45 | tainted | GlobalDataFlow.cs:373:39:373:45 | tainted |
-| GlobalDataFlow.cs:373:39:373:45 | tainted | GlobalDataFlow.cs:373:39:373:45 | tainted |
-| GlobalDataFlow.cs:373:39:373:45 | tainted | GlobalDataFlow.cs:375:13:375:28 | SSA def(sink11) |
-| GlobalDataFlow.cs:373:39:373:45 | tainted | GlobalDataFlow.cs:375:13:375:28 | SSA def(sink11) |
-| GlobalDataFlow.cs:373:39:373:45 | tainted | GlobalDataFlow.cs:375:13:375:28 | SSA def(sink11) |
-| GlobalDataFlow.cs:373:39:373:45 | tainted | GlobalDataFlow.cs:375:13:375:28 | SSA def(sink11) |
-| GlobalDataFlow.cs:373:39:373:45 | tainted | GlobalDataFlow.cs:375:22:375:28 | access to parameter tainted |
-| GlobalDataFlow.cs:373:39:373:45 | tainted | GlobalDataFlow.cs:375:22:375:28 | access to parameter tainted |
-| GlobalDataFlow.cs:373:39:373:45 | tainted | GlobalDataFlow.cs:375:22:375:28 | access to parameter tainted |
-| GlobalDataFlow.cs:373:39:373:45 | tainted | GlobalDataFlow.cs:375:22:375:28 | access to parameter tainted |
-| GlobalDataFlow.cs:373:39:373:45 | tainted | GlobalDataFlow.cs:376:15:376:20 | access to local variable sink11 |
-| GlobalDataFlow.cs:373:39:373:45 | tainted | GlobalDataFlow.cs:376:15:376:20 | access to local variable sink11 |
-| GlobalDataFlow.cs:373:39:373:45 | tainted | GlobalDataFlow.cs:376:15:376:20 | access to local variable sink11 |
-| GlobalDataFlow.cs:373:39:373:45 | tainted | GlobalDataFlow.cs:376:15:376:20 | access to local variable sink11 |
-| GlobalDataFlow.cs:373:39:373:45 | tainted | GlobalDataFlow.cs:377:16:377:21 | access to local variable sink11 |
-| GlobalDataFlow.cs:373:39:373:45 | tainted | GlobalDataFlow.cs:377:16:377:21 | access to local variable sink11 |
-| GlobalDataFlow.cs:373:39:373:45 | tainted | GlobalDataFlow.cs:377:16:377:21 | access to local variable sink11 |
-| GlobalDataFlow.cs:373:39:373:45 | tainted | GlobalDataFlow.cs:377:16:377:21 | access to local variable sink11 |
-| GlobalDataFlow.cs:375:13:375:28 | SSA def(sink11) | GlobalDataFlow.cs:375:13:375:28 | SSA def(sink11) |
-| GlobalDataFlow.cs:375:13:375:28 | SSA def(sink11) | GlobalDataFlow.cs:376:15:376:20 | access to local variable sink11 |
-| GlobalDataFlow.cs:375:13:375:28 | SSA def(sink11) | GlobalDataFlow.cs:376:15:376:20 | access to local variable sink11 |
-| GlobalDataFlow.cs:375:13:375:28 | SSA def(sink11) | GlobalDataFlow.cs:376:15:376:20 | access to local variable sink11 |
-| GlobalDataFlow.cs:375:13:375:28 | SSA def(sink11) | GlobalDataFlow.cs:376:15:376:20 | access to local variable sink11 |
-| GlobalDataFlow.cs:375:13:375:28 | SSA def(sink11) | GlobalDataFlow.cs:377:16:377:21 | access to local variable sink11 |
-| GlobalDataFlow.cs:375:13:375:28 | SSA def(sink11) | GlobalDataFlow.cs:377:16:377:21 | access to local variable sink11 |
-| GlobalDataFlow.cs:375:13:375:28 | SSA def(sink11) | GlobalDataFlow.cs:377:16:377:21 | access to local variable sink11 |
-| GlobalDataFlow.cs:375:13:375:28 | SSA def(sink11) | GlobalDataFlow.cs:377:16:377:21 | access to local variable sink11 |
-| GlobalDataFlow.cs:375:13:375:28 | String sink11 = ... | GlobalDataFlow.cs:375:13:375:28 | String sink11 = ... |
-| GlobalDataFlow.cs:375:22:375:28 | access to parameter tainted | GlobalDataFlow.cs:375:13:375:28 | SSA def(sink11) |
-| GlobalDataFlow.cs:375:22:375:28 | access to parameter tainted | GlobalDataFlow.cs:375:13:375:28 | SSA def(sink11) |
-| GlobalDataFlow.cs:375:22:375:28 | access to parameter tainted | GlobalDataFlow.cs:375:13:375:28 | SSA def(sink11) |
-| GlobalDataFlow.cs:375:22:375:28 | access to parameter tainted | GlobalDataFlow.cs:375:13:375:28 | SSA def(sink11) |
-| GlobalDataFlow.cs:375:22:375:28 | access to parameter tainted | GlobalDataFlow.cs:375:22:375:28 | access to parameter tainted |
-| GlobalDataFlow.cs:375:22:375:28 | access to parameter tainted | GlobalDataFlow.cs:376:15:376:20 | access to local variable sink11 |
-| GlobalDataFlow.cs:375:22:375:28 | access to parameter tainted | GlobalDataFlow.cs:376:15:376:20 | access to local variable sink11 |
-| GlobalDataFlow.cs:375:22:375:28 | access to parameter tainted | GlobalDataFlow.cs:376:15:376:20 | access to local variable sink11 |
-| GlobalDataFlow.cs:375:22:375:28 | access to parameter tainted | GlobalDataFlow.cs:376:15:376:20 | access to local variable sink11 |
-| GlobalDataFlow.cs:375:22:375:28 | access to parameter tainted | GlobalDataFlow.cs:377:16:377:21 | access to local variable sink11 |
-| GlobalDataFlow.cs:375:22:375:28 | access to parameter tainted | GlobalDataFlow.cs:377:16:377:21 | access to local variable sink11 |
-| GlobalDataFlow.cs:375:22:375:28 | access to parameter tainted | GlobalDataFlow.cs:377:16:377:21 | access to local variable sink11 |
-| GlobalDataFlow.cs:375:22:375:28 | access to parameter tainted | GlobalDataFlow.cs:377:16:377:21 | access to local variable sink11 |
-| GlobalDataFlow.cs:376:9:376:21 | call to method Check | GlobalDataFlow.cs:376:9:376:21 | call to method Check |
-| GlobalDataFlow.cs:376:15:376:20 | access to local variable sink11 | GlobalDataFlow.cs:376:15:376:20 | access to local variable sink11 |
-| GlobalDataFlow.cs:376:15:376:20 | access to local variable sink11 | GlobalDataFlow.cs:377:16:377:21 | access to local variable sink11 |
-| GlobalDataFlow.cs:376:15:376:20 | access to local variable sink11 | GlobalDataFlow.cs:377:16:377:21 | access to local variable sink11 |
-| GlobalDataFlow.cs:376:15:376:20 | access to local variable sink11 | GlobalDataFlow.cs:377:16:377:21 | access to local variable sink11 |
-| GlobalDataFlow.cs:376:15:376:20 | access to local variable sink11 | GlobalDataFlow.cs:377:16:377:21 | access to local variable sink11 |
-| GlobalDataFlow.cs:377:16:377:21 | access to local variable sink11 | GlobalDataFlow.cs:159:22:159:43 | call to method TaintedParam |
-| GlobalDataFlow.cs:377:16:377:21 | access to local variable sink11 | GlobalDataFlow.cs:159:22:159:43 | call to method TaintedParam |
-| GlobalDataFlow.cs:377:16:377:21 | access to local variable sink11 | GlobalDataFlow.cs:377:16:377:21 | access to local variable sink11 |
-| GlobalDataFlow.cs:380:42:380:51 | nonTainted | GlobalDataFlow.cs:380:42:380:51 | nonTainted |
-| GlobalDataFlow.cs:380:42:380:51 | nonTainted | GlobalDataFlow.cs:380:42:380:51 | nonTainted |
-| GlobalDataFlow.cs:380:42:380:51 | nonTainted | GlobalDataFlow.cs:382:13:382:33 | SSA def(nonSink0) |
-| GlobalDataFlow.cs:380:42:380:51 | nonTainted | GlobalDataFlow.cs:382:13:382:33 | SSA def(nonSink0) |
-| GlobalDataFlow.cs:380:42:380:51 | nonTainted | GlobalDataFlow.cs:382:13:382:33 | SSA def(nonSink0) |
-| GlobalDataFlow.cs:380:42:380:51 | nonTainted | GlobalDataFlow.cs:382:13:382:33 | SSA def(nonSink0) |
-| GlobalDataFlow.cs:380:42:380:51 | nonTainted | GlobalDataFlow.cs:382:24:382:33 | access to parameter nonTainted |
-| GlobalDataFlow.cs:380:42:380:51 | nonTainted | GlobalDataFlow.cs:382:24:382:33 | access to parameter nonTainted |
-| GlobalDataFlow.cs:380:42:380:51 | nonTainted | GlobalDataFlow.cs:382:24:382:33 | access to parameter nonTainted |
-| GlobalDataFlow.cs:380:42:380:51 | nonTainted | GlobalDataFlow.cs:382:24:382:33 | access to parameter nonTainted |
-| GlobalDataFlow.cs:380:42:380:51 | nonTainted | GlobalDataFlow.cs:383:15:383:22 | access to local variable nonSink0 |
-| GlobalDataFlow.cs:380:42:380:51 | nonTainted | GlobalDataFlow.cs:383:15:383:22 | access to local variable nonSink0 |
-| GlobalDataFlow.cs:380:42:380:51 | nonTainted | GlobalDataFlow.cs:383:15:383:22 | access to local variable nonSink0 |
-| GlobalDataFlow.cs:380:42:380:51 | nonTainted | GlobalDataFlow.cs:383:15:383:22 | access to local variable nonSink0 |
-| GlobalDataFlow.cs:380:42:380:51 | nonTainted | GlobalDataFlow.cs:384:16:384:23 | access to local variable nonSink0 |
-| GlobalDataFlow.cs:380:42:380:51 | nonTainted | GlobalDataFlow.cs:384:16:384:23 | access to local variable nonSink0 |
-| GlobalDataFlow.cs:380:42:380:51 | nonTainted | GlobalDataFlow.cs:384:16:384:23 | access to local variable nonSink0 |
-| GlobalDataFlow.cs:380:42:380:51 | nonTainted | GlobalDataFlow.cs:384:16:384:23 | access to local variable nonSink0 |
-| GlobalDataFlow.cs:382:13:382:33 | SSA def(nonSink0) | GlobalDataFlow.cs:382:13:382:33 | SSA def(nonSink0) |
-| GlobalDataFlow.cs:382:13:382:33 | SSA def(nonSink0) | GlobalDataFlow.cs:383:15:383:22 | access to local variable nonSink0 |
-| GlobalDataFlow.cs:382:13:382:33 | SSA def(nonSink0) | GlobalDataFlow.cs:383:15:383:22 | access to local variable nonSink0 |
-| GlobalDataFlow.cs:382:13:382:33 | SSA def(nonSink0) | GlobalDataFlow.cs:383:15:383:22 | access to local variable nonSink0 |
-| GlobalDataFlow.cs:382:13:382:33 | SSA def(nonSink0) | GlobalDataFlow.cs:383:15:383:22 | access to local variable nonSink0 |
-| GlobalDataFlow.cs:382:13:382:33 | SSA def(nonSink0) | GlobalDataFlow.cs:384:16:384:23 | access to local variable nonSink0 |
-| GlobalDataFlow.cs:382:13:382:33 | SSA def(nonSink0) | GlobalDataFlow.cs:384:16:384:23 | access to local variable nonSink0 |
-| GlobalDataFlow.cs:382:13:382:33 | SSA def(nonSink0) | GlobalDataFlow.cs:384:16:384:23 | access to local variable nonSink0 |
-| GlobalDataFlow.cs:382:13:382:33 | SSA def(nonSink0) | GlobalDataFlow.cs:384:16:384:23 | access to local variable nonSink0 |
-| GlobalDataFlow.cs:382:13:382:33 | String nonSink0 = ... | GlobalDataFlow.cs:382:13:382:33 | String nonSink0 = ... |
-| GlobalDataFlow.cs:382:24:382:33 | access to parameter nonTainted | GlobalDataFlow.cs:382:13:382:33 | SSA def(nonSink0) |
-| GlobalDataFlow.cs:382:24:382:33 | access to parameter nonTainted | GlobalDataFlow.cs:382:13:382:33 | SSA def(nonSink0) |
-| GlobalDataFlow.cs:382:24:382:33 | access to parameter nonTainted | GlobalDataFlow.cs:382:13:382:33 | SSA def(nonSink0) |
-| GlobalDataFlow.cs:382:24:382:33 | access to parameter nonTainted | GlobalDataFlow.cs:382:13:382:33 | SSA def(nonSink0) |
-| GlobalDataFlow.cs:382:24:382:33 | access to parameter nonTainted | GlobalDataFlow.cs:382:24:382:33 | access to parameter nonTainted |
-| GlobalDataFlow.cs:382:24:382:33 | access to parameter nonTainted | GlobalDataFlow.cs:383:15:383:22 | access to local variable nonSink0 |
-| GlobalDataFlow.cs:382:24:382:33 | access to parameter nonTainted | GlobalDataFlow.cs:383:15:383:22 | access to local variable nonSink0 |
-| GlobalDataFlow.cs:382:24:382:33 | access to parameter nonTainted | GlobalDataFlow.cs:383:15:383:22 | access to local variable nonSink0 |
-| GlobalDataFlow.cs:382:24:382:33 | access to parameter nonTainted | GlobalDataFlow.cs:383:15:383:22 | access to local variable nonSink0 |
-| GlobalDataFlow.cs:382:24:382:33 | access to parameter nonTainted | GlobalDataFlow.cs:384:16:384:23 | access to local variable nonSink0 |
-| GlobalDataFlow.cs:382:24:382:33 | access to parameter nonTainted | GlobalDataFlow.cs:384:16:384:23 | access to local variable nonSink0 |
-| GlobalDataFlow.cs:382:24:382:33 | access to parameter nonTainted | GlobalDataFlow.cs:384:16:384:23 | access to local variable nonSink0 |
-| GlobalDataFlow.cs:382:24:382:33 | access to parameter nonTainted | GlobalDataFlow.cs:384:16:384:23 | access to local variable nonSink0 |
-| GlobalDataFlow.cs:383:9:383:23 | call to method Check | GlobalDataFlow.cs:383:9:383:23 | call to method Check |
-| GlobalDataFlow.cs:383:15:383:22 | access to local variable nonSink0 | GlobalDataFlow.cs:383:15:383:22 | access to local variable nonSink0 |
-| GlobalDataFlow.cs:383:15:383:22 | access to local variable nonSink0 | GlobalDataFlow.cs:384:16:384:23 | access to local variable nonSink0 |
-| GlobalDataFlow.cs:383:15:383:22 | access to local variable nonSink0 | GlobalDataFlow.cs:384:16:384:23 | access to local variable nonSink0 |
-| GlobalDataFlow.cs:383:15:383:22 | access to local variable nonSink0 | GlobalDataFlow.cs:384:16:384:23 | access to local variable nonSink0 |
-| GlobalDataFlow.cs:383:15:383:22 | access to local variable nonSink0 | GlobalDataFlow.cs:384:16:384:23 | access to local variable nonSink0 |
-| GlobalDataFlow.cs:384:16:384:23 | access to local variable nonSink0 | GlobalDataFlow.cs:171:20:171:44 | call to method NonTaintedParam |
-| GlobalDataFlow.cs:384:16:384:23 | access to local variable nonSink0 | GlobalDataFlow.cs:171:20:171:44 | call to method NonTaintedParam |
-| GlobalDataFlow.cs:384:16:384:23 | access to local variable nonSink0 | GlobalDataFlow.cs:384:16:384:23 | access to local variable nonSink0 |
-| GlobalDataFlow.cs:393:62:393:63 | "" | GlobalDataFlow.cs:32:15:32:35 | access to property NonSinkProperty1 |
-| GlobalDataFlow.cs:393:62:393:63 | "" | GlobalDataFlow.cs:32:15:32:35 | access to property NonSinkProperty1 |
-| GlobalDataFlow.cs:393:62:393:63 | "" | GlobalDataFlow.cs:393:62:393:63 | "" |
-| GlobalDataFlow.cs:398:9:398:11 | this | GlobalDataFlow.cs:398:9:398:11 | this |
-| GlobalDataFlow.cs:398:22:398:23 | "" | GlobalDataFlow.cs:398:22:398:23 | "" |
-| GlobalDataFlow.cs:399:9:399:11 | this | GlobalDataFlow.cs:399:9:399:11 | this |
-| GlobalDataFlow.cs:399:9:399:11 | value | GlobalDataFlow.cs:399:9:399:11 | value |
-| GlobalDataFlow.cs:399:9:399:11 | value | GlobalDataFlow.cs:399:9:399:11 | value |
-| GlobalDataFlow.cs:399:9:399:11 | value | GlobalDataFlow.cs:399:19:399:32 | SSA def(sink20) |
-| GlobalDataFlow.cs:399:9:399:11 | value | GlobalDataFlow.cs:399:19:399:32 | SSA def(sink20) |
-| GlobalDataFlow.cs:399:9:399:11 | value | GlobalDataFlow.cs:399:19:399:32 | SSA def(sink20) |
-| GlobalDataFlow.cs:399:9:399:11 | value | GlobalDataFlow.cs:399:19:399:32 | SSA def(sink20) |
-| GlobalDataFlow.cs:399:9:399:11 | value | GlobalDataFlow.cs:399:28:399:32 | access to parameter value |
-| GlobalDataFlow.cs:399:9:399:11 | value | GlobalDataFlow.cs:399:28:399:32 | access to parameter value |
-| GlobalDataFlow.cs:399:9:399:11 | value | GlobalDataFlow.cs:399:28:399:32 | access to parameter value |
-| GlobalDataFlow.cs:399:9:399:11 | value | GlobalDataFlow.cs:399:28:399:32 | access to parameter value |
-| GlobalDataFlow.cs:399:9:399:11 | value | GlobalDataFlow.cs:399:41:399:46 | access to local variable sink20 |
-| GlobalDataFlow.cs:399:9:399:11 | value | GlobalDataFlow.cs:399:41:399:46 | access to local variable sink20 |
-| GlobalDataFlow.cs:399:9:399:11 | value | GlobalDataFlow.cs:399:41:399:46 | access to local variable sink20 |
-| GlobalDataFlow.cs:399:9:399:11 | value | GlobalDataFlow.cs:399:41:399:46 | access to local variable sink20 |
-| GlobalDataFlow.cs:399:19:399:32 | SSA def(sink20) | GlobalDataFlow.cs:399:19:399:32 | SSA def(sink20) |
-| GlobalDataFlow.cs:399:19:399:32 | SSA def(sink20) | GlobalDataFlow.cs:399:41:399:46 | access to local variable sink20 |
-| GlobalDataFlow.cs:399:19:399:32 | SSA def(sink20) | GlobalDataFlow.cs:399:41:399:46 | access to local variable sink20 |
-| GlobalDataFlow.cs:399:19:399:32 | SSA def(sink20) | GlobalDataFlow.cs:399:41:399:46 | access to local variable sink20 |
-| GlobalDataFlow.cs:399:19:399:32 | SSA def(sink20) | GlobalDataFlow.cs:399:41:399:46 | access to local variable sink20 |
-| GlobalDataFlow.cs:399:19:399:32 | String sink20 = ... | GlobalDataFlow.cs:399:19:399:32 | String sink20 = ... |
-| GlobalDataFlow.cs:399:28:399:32 | access to parameter value | GlobalDataFlow.cs:399:19:399:32 | SSA def(sink20) |
-| GlobalDataFlow.cs:399:28:399:32 | access to parameter value | GlobalDataFlow.cs:399:19:399:32 | SSA def(sink20) |
-| GlobalDataFlow.cs:399:28:399:32 | access to parameter value | GlobalDataFlow.cs:399:19:399:32 | SSA def(sink20) |
-| GlobalDataFlow.cs:399:28:399:32 | access to parameter value | GlobalDataFlow.cs:399:19:399:32 | SSA def(sink20) |
-| GlobalDataFlow.cs:399:28:399:32 | access to parameter value | GlobalDataFlow.cs:399:28:399:32 | access to parameter value |
-| GlobalDataFlow.cs:399:28:399:32 | access to parameter value | GlobalDataFlow.cs:399:41:399:46 | access to local variable sink20 |
-| GlobalDataFlow.cs:399:28:399:32 | access to parameter value | GlobalDataFlow.cs:399:41:399:46 | access to local variable sink20 |
-| GlobalDataFlow.cs:399:28:399:32 | access to parameter value | GlobalDataFlow.cs:399:41:399:46 | access to local variable sink20 |
-| GlobalDataFlow.cs:399:28:399:32 | access to parameter value | GlobalDataFlow.cs:399:41:399:46 | access to local variable sink20 |
-| GlobalDataFlow.cs:399:35:399:47 | call to method Check | GlobalDataFlow.cs:399:35:399:47 | call to method Check |
-| GlobalDataFlow.cs:399:41:399:46 | access to local variable sink20 | GlobalDataFlow.cs:399:41:399:46 | access to local variable sink20 |
+| GlobalDataFlow.cs:348:10:348:18 | this | GlobalDataFlow.cs:348:10:348:18 | this |
+| GlobalDataFlow.cs:350:9:350:14 | ... = ... | GlobalDataFlow.cs:350:9:350:14 | ... = ... |
+| GlobalDataFlow.cs:350:9:350:14 | SSA def(x) | GlobalDataFlow.cs:171:23:171:30 | SSA def(nonSink0) |
+| GlobalDataFlow.cs:350:9:350:14 | SSA def(x) | GlobalDataFlow.cs:171:23:171:30 | SSA def(nonSink0) |
+| GlobalDataFlow.cs:350:9:350:14 | SSA def(x) | GlobalDataFlow.cs:350:9:350:14 | SSA def(x) |
+| GlobalDataFlow.cs:350:13:350:14 | "" | GlobalDataFlow.cs:350:9:350:14 | SSA def(x) |
+| GlobalDataFlow.cs:350:13:350:14 | "" | GlobalDataFlow.cs:350:9:350:14 | SSA def(x) |
+| GlobalDataFlow.cs:350:13:350:14 | "" | GlobalDataFlow.cs:350:13:350:14 | "" |
+| GlobalDataFlow.cs:353:25:353:35 | this | GlobalDataFlow.cs:353:25:353:35 | this |
+| GlobalDataFlow.cs:355:22:355:23 | "" | GlobalDataFlow.cs:173:20:173:32 | call to method NonOutYield |
+| GlobalDataFlow.cs:355:22:355:23 | "" | GlobalDataFlow.cs:173:20:173:32 | call to method NonOutYield |
+| GlobalDataFlow.cs:355:22:355:23 | "" | GlobalDataFlow.cs:355:22:355:23 | "" |
+| GlobalDataFlow.cs:355:22:355:23 | "" | GlobalDataFlow.cs:355:22:355:23 | "" |
+| GlobalDataFlow.cs:356:22:356:23 | "" | GlobalDataFlow.cs:173:20:173:32 | call to method NonOutYield |
+| GlobalDataFlow.cs:356:22:356:23 | "" | GlobalDataFlow.cs:173:20:173:32 | call to method NonOutYield |
+| GlobalDataFlow.cs:356:22:356:23 | "" | GlobalDataFlow.cs:356:22:356:23 | "" |
+| GlobalDataFlow.cs:356:22:356:23 | "" | GlobalDataFlow.cs:356:22:356:23 | "" |
+| GlobalDataFlow.cs:359:36:359:36 | a | GlobalDataFlow.cs:359:36:359:36 | a |
+| GlobalDataFlow.cs:359:36:359:36 | a | GlobalDataFlow.cs:359:36:359:36 | a |
+| GlobalDataFlow.cs:359:36:359:36 | a | GlobalDataFlow.cs:361:9:361:9 | access to parameter a |
+| GlobalDataFlow.cs:359:36:359:36 | a | GlobalDataFlow.cs:361:9:361:9 | access to parameter a |
+| GlobalDataFlow.cs:359:36:359:36 | a | GlobalDataFlow.cs:361:9:361:9 | access to parameter a |
+| GlobalDataFlow.cs:359:36:359:36 | a | GlobalDataFlow.cs:361:9:361:9 | access to parameter a |
+| GlobalDataFlow.cs:359:36:359:36 | a | GlobalDataFlow.cs:361:9:361:9 | access to parameter a |
+| GlobalDataFlow.cs:359:36:359:36 | a | GlobalDataFlow.cs:361:9:361:9 | access to parameter a |
+| GlobalDataFlow.cs:359:36:359:36 | a | GlobalDataFlow.cs:361:9:361:9 | access to parameter a |
+| GlobalDataFlow.cs:359:36:359:36 | a | GlobalDataFlow.cs:361:9:361:9 | access to parameter a |
+| GlobalDataFlow.cs:359:41:359:41 | x | GlobalDataFlow.cs:359:41:359:41 | x |
+| GlobalDataFlow.cs:359:41:359:41 | x | GlobalDataFlow.cs:359:41:359:41 | x |
+| GlobalDataFlow.cs:359:41:359:41 | x | GlobalDataFlow.cs:361:11:361:11 | access to parameter x |
+| GlobalDataFlow.cs:359:41:359:41 | x | GlobalDataFlow.cs:361:11:361:11 | access to parameter x |
+| GlobalDataFlow.cs:359:41:359:41 | x | GlobalDataFlow.cs:361:11:361:11 | access to parameter x |
+| GlobalDataFlow.cs:359:41:359:41 | x | GlobalDataFlow.cs:361:11:361:11 | access to parameter x |
+| GlobalDataFlow.cs:359:41:359:41 | x | GlobalDataFlow.cs:361:11:361:11 | access to parameter x |
+| GlobalDataFlow.cs:359:41:359:41 | x | GlobalDataFlow.cs:361:11:361:11 | access to parameter x |
+| GlobalDataFlow.cs:359:41:359:41 | x | GlobalDataFlow.cs:361:11:361:11 | access to parameter x |
+| GlobalDataFlow.cs:359:41:359:41 | x | GlobalDataFlow.cs:361:11:361:11 | access to parameter x |
+| GlobalDataFlow.cs:361:9:361:9 | access to parameter a | GlobalDataFlow.cs:361:9:361:9 | access to parameter a |
+| GlobalDataFlow.cs:361:9:361:12 | delegate call | GlobalDataFlow.cs:361:9:361:12 | delegate call |
+| GlobalDataFlow.cs:361:11:361:11 | access to parameter x | GlobalDataFlow.cs:53:15:53:15 | x |
+| GlobalDataFlow.cs:361:11:361:11 | access to parameter x | GlobalDataFlow.cs:53:15:53:15 | x |
+| GlobalDataFlow.cs:361:11:361:11 | access to parameter x | GlobalDataFlow.cs:53:15:53:15 | x |
+| GlobalDataFlow.cs:361:11:361:11 | access to parameter x | GlobalDataFlow.cs:53:15:53:15 | x |
+| GlobalDataFlow.cs:361:11:361:11 | access to parameter x | GlobalDataFlow.cs:60:15:60:27 | nonSinkParam0 |
+| GlobalDataFlow.cs:361:11:361:11 | access to parameter x | GlobalDataFlow.cs:60:15:60:27 | nonSinkParam0 |
+| GlobalDataFlow.cs:361:11:361:11 | access to parameter x | GlobalDataFlow.cs:60:15:60:27 | nonSinkParam0 |
+| GlobalDataFlow.cs:361:11:361:11 | access to parameter x | GlobalDataFlow.cs:60:15:60:27 | nonSinkParam0 |
+| GlobalDataFlow.cs:361:11:361:11 | access to parameter x | GlobalDataFlow.cs:245:26:245:35 | sinkParam3 |
+| GlobalDataFlow.cs:361:11:361:11 | access to parameter x | GlobalDataFlow.cs:245:26:245:35 | sinkParam3 |
+| GlobalDataFlow.cs:361:11:361:11 | access to parameter x | GlobalDataFlow.cs:245:26:245:35 | sinkParam3 |
+| GlobalDataFlow.cs:361:11:361:11 | access to parameter x | GlobalDataFlow.cs:245:26:245:35 | sinkParam3 |
+| GlobalDataFlow.cs:361:11:361:11 | access to parameter x | GlobalDataFlow.cs:361:11:361:11 | access to parameter x |
+| GlobalDataFlow.cs:364:41:364:41 | f | GlobalDataFlow.cs:364:41:364:41 | f |
+| GlobalDataFlow.cs:364:41:364:41 | f | GlobalDataFlow.cs:364:41:364:41 | f |
+| GlobalDataFlow.cs:364:41:364:41 | f | GlobalDataFlow.cs:366:16:366:16 | access to parameter f |
+| GlobalDataFlow.cs:364:41:364:41 | f | GlobalDataFlow.cs:366:16:366:16 | access to parameter f |
+| GlobalDataFlow.cs:364:41:364:41 | f | GlobalDataFlow.cs:366:16:366:16 | access to parameter f |
+| GlobalDataFlow.cs:364:41:364:41 | f | GlobalDataFlow.cs:366:16:366:16 | access to parameter f |
+| GlobalDataFlow.cs:364:41:364:41 | f | GlobalDataFlow.cs:366:16:366:16 | access to parameter f |
+| GlobalDataFlow.cs:364:41:364:41 | f | GlobalDataFlow.cs:366:16:366:16 | access to parameter f |
+| GlobalDataFlow.cs:364:41:364:41 | f | GlobalDataFlow.cs:366:16:366:16 | access to parameter f |
+| GlobalDataFlow.cs:364:41:364:41 | f | GlobalDataFlow.cs:366:16:366:16 | access to parameter f |
+| GlobalDataFlow.cs:364:41:364:41 | f | GlobalDataFlow.cs:366:16:366:16 | access to parameter f |
+| GlobalDataFlow.cs:364:41:364:41 | f | GlobalDataFlow.cs:366:16:366:16 | access to parameter f |
+| GlobalDataFlow.cs:364:41:364:41 | f | GlobalDataFlow.cs:366:16:366:16 | access to parameter f |
+| GlobalDataFlow.cs:364:41:364:41 | f | GlobalDataFlow.cs:366:16:366:16 | access to parameter f |
+| GlobalDataFlow.cs:364:46:364:46 | x | GlobalDataFlow.cs:364:46:364:46 | x |
+| GlobalDataFlow.cs:364:46:364:46 | x | GlobalDataFlow.cs:364:46:364:46 | x |
+| GlobalDataFlow.cs:364:46:364:46 | x | GlobalDataFlow.cs:366:18:366:18 | access to parameter x |
+| GlobalDataFlow.cs:364:46:364:46 | x | GlobalDataFlow.cs:366:18:366:18 | access to parameter x |
+| GlobalDataFlow.cs:364:46:364:46 | x | GlobalDataFlow.cs:366:18:366:18 | access to parameter x |
+| GlobalDataFlow.cs:364:46:364:46 | x | GlobalDataFlow.cs:366:18:366:18 | access to parameter x |
+| GlobalDataFlow.cs:364:46:364:46 | x | GlobalDataFlow.cs:366:18:366:18 | access to parameter x |
+| GlobalDataFlow.cs:364:46:364:46 | x | GlobalDataFlow.cs:366:18:366:18 | access to parameter x |
+| GlobalDataFlow.cs:364:46:364:46 | x | GlobalDataFlow.cs:366:18:366:18 | access to parameter x |
+| GlobalDataFlow.cs:364:46:364:46 | x | GlobalDataFlow.cs:366:18:366:18 | access to parameter x |
+| GlobalDataFlow.cs:364:46:364:46 | x | GlobalDataFlow.cs:366:18:366:18 | access to parameter x |
+| GlobalDataFlow.cs:364:46:364:46 | x | GlobalDataFlow.cs:366:18:366:18 | access to parameter x |
+| GlobalDataFlow.cs:364:46:364:46 | x | GlobalDataFlow.cs:366:18:366:18 | access to parameter x |
+| GlobalDataFlow.cs:364:46:364:46 | x | GlobalDataFlow.cs:366:18:366:18 | access to parameter x |
+| GlobalDataFlow.cs:366:16:366:16 | access to parameter f | GlobalDataFlow.cs:366:16:366:16 | access to parameter f |
+| GlobalDataFlow.cs:366:16:366:19 | delegate call | GlobalDataFlow.cs:134:45:134:64 | call to method ApplyFunc |
+| GlobalDataFlow.cs:366:16:366:19 | delegate call | GlobalDataFlow.cs:134:45:134:64 | call to method ApplyFunc |
+| GlobalDataFlow.cs:366:16:366:19 | delegate call | GlobalDataFlow.cs:134:45:134:64 | call to method ApplyFunc |
+| GlobalDataFlow.cs:366:16:366:19 | delegate call | GlobalDataFlow.cs:134:45:134:64 | call to method ApplyFunc |
+| GlobalDataFlow.cs:366:16:366:19 | delegate call | GlobalDataFlow.cs:143:21:143:44 | call to method ApplyFunc |
+| GlobalDataFlow.cs:366:16:366:19 | delegate call | GlobalDataFlow.cs:143:21:143:44 | call to method ApplyFunc |
+| GlobalDataFlow.cs:366:16:366:19 | delegate call | GlobalDataFlow.cs:143:21:143:44 | call to method ApplyFunc |
+| GlobalDataFlow.cs:366:16:366:19 | delegate call | GlobalDataFlow.cs:143:21:143:44 | call to method ApplyFunc |
+| GlobalDataFlow.cs:366:16:366:19 | delegate call | GlobalDataFlow.cs:147:20:147:40 | call to method ApplyFunc |
+| GlobalDataFlow.cs:366:16:366:19 | delegate call | GlobalDataFlow.cs:147:20:147:40 | call to method ApplyFunc |
+| GlobalDataFlow.cs:366:16:366:19 | delegate call | GlobalDataFlow.cs:147:20:147:40 | call to method ApplyFunc |
+| GlobalDataFlow.cs:366:16:366:19 | delegate call | GlobalDataFlow.cs:147:20:147:40 | call to method ApplyFunc |
+| GlobalDataFlow.cs:366:16:366:19 | delegate call | GlobalDataFlow.cs:149:20:149:44 | call to method ApplyFunc |
+| GlobalDataFlow.cs:366:16:366:19 | delegate call | GlobalDataFlow.cs:149:20:149:44 | call to method ApplyFunc |
+| GlobalDataFlow.cs:366:16:366:19 | delegate call | GlobalDataFlow.cs:149:20:149:44 | call to method ApplyFunc |
+| GlobalDataFlow.cs:366:16:366:19 | delegate call | GlobalDataFlow.cs:149:20:149:44 | call to method ApplyFunc |
+| GlobalDataFlow.cs:366:16:366:19 | delegate call | GlobalDataFlow.cs:277:17:277:38 | call to method ApplyFunc |
+| GlobalDataFlow.cs:366:16:366:19 | delegate call | GlobalDataFlow.cs:277:17:277:38 | call to method ApplyFunc |
+| GlobalDataFlow.cs:366:16:366:19 | delegate call | GlobalDataFlow.cs:277:17:277:38 | call to method ApplyFunc |
+| GlobalDataFlow.cs:366:16:366:19 | delegate call | GlobalDataFlow.cs:277:17:277:38 | call to method ApplyFunc |
+| GlobalDataFlow.cs:366:16:366:19 | delegate call | GlobalDataFlow.cs:366:16:366:19 | delegate call |
+| GlobalDataFlow.cs:366:18:366:18 | access to parameter x | GlobalDataFlow.cs:275:26:275:26 | x |
+| GlobalDataFlow.cs:366:18:366:18 | access to parameter x | GlobalDataFlow.cs:275:26:275:26 | x |
+| GlobalDataFlow.cs:366:18:366:18 | access to parameter x | GlobalDataFlow.cs:275:26:275:26 | x |
+| GlobalDataFlow.cs:366:18:366:18 | access to parameter x | GlobalDataFlow.cs:275:26:275:26 | x |
+| GlobalDataFlow.cs:366:18:366:18 | access to parameter x | GlobalDataFlow.cs:275:26:275:26 | x |
+| GlobalDataFlow.cs:366:18:366:18 | access to parameter x | GlobalDataFlow.cs:275:26:275:26 | x |
+| GlobalDataFlow.cs:366:18:366:18 | access to parameter x | GlobalDataFlow.cs:275:26:275:26 | x |
+| GlobalDataFlow.cs:366:18:366:18 | access to parameter x | GlobalDataFlow.cs:275:26:275:26 | x |
+| GlobalDataFlow.cs:366:18:366:18 | access to parameter x | GlobalDataFlow.cs:277:27:277:28 | x0 |
+| GlobalDataFlow.cs:366:18:366:18 | access to parameter x | GlobalDataFlow.cs:277:27:277:28 | x0 |
+| GlobalDataFlow.cs:366:18:366:18 | access to parameter x | GlobalDataFlow.cs:277:27:277:28 | x0 |
+| GlobalDataFlow.cs:366:18:366:18 | access to parameter x | GlobalDataFlow.cs:277:27:277:28 | x0 |
+| GlobalDataFlow.cs:366:18:366:18 | access to parameter x | GlobalDataFlow.cs:366:16:366:19 | delegate call |
+| GlobalDataFlow.cs:366:18:366:18 | access to parameter x | GlobalDataFlow.cs:366:16:366:19 | delegate call |
+| GlobalDataFlow.cs:366:18:366:18 | access to parameter x | GlobalDataFlow.cs:366:16:366:19 | delegate call |
+| GlobalDataFlow.cs:366:18:366:18 | access to parameter x | GlobalDataFlow.cs:366:16:366:19 | delegate call |
+| GlobalDataFlow.cs:366:18:366:18 | access to parameter x | GlobalDataFlow.cs:366:16:366:19 | delegate call |
+| GlobalDataFlow.cs:366:18:366:18 | access to parameter x | GlobalDataFlow.cs:366:16:366:19 | delegate call |
+| GlobalDataFlow.cs:366:18:366:18 | access to parameter x | GlobalDataFlow.cs:366:16:366:19 | delegate call |
+| GlobalDataFlow.cs:366:18:366:18 | access to parameter x | GlobalDataFlow.cs:366:16:366:19 | delegate call |
+| GlobalDataFlow.cs:366:18:366:18 | access to parameter x | GlobalDataFlow.cs:366:16:366:19 | delegate call |
+| GlobalDataFlow.cs:366:18:366:18 | access to parameter x | GlobalDataFlow.cs:366:16:366:19 | delegate call |
+| GlobalDataFlow.cs:366:18:366:18 | access to parameter x | GlobalDataFlow.cs:366:18:366:18 | access to parameter x |
+| GlobalDataFlow.cs:373:42:373:42 | a | GlobalDataFlow.cs:373:42:373:42 | a |
+| GlobalDataFlow.cs:373:42:373:42 | a | GlobalDataFlow.cs:373:42:373:42 | a |
+| GlobalDataFlow.cs:373:42:373:42 | a | GlobalDataFlow.cs:375:9:375:9 | access to parameter a |
+| GlobalDataFlow.cs:373:42:373:42 | a | GlobalDataFlow.cs:375:9:375:9 | access to parameter a |
+| GlobalDataFlow.cs:373:42:373:42 | a | GlobalDataFlow.cs:375:9:375:9 | access to parameter a |
+| GlobalDataFlow.cs:373:42:373:42 | a | GlobalDataFlow.cs:375:9:375:9 | access to parameter a |
+| GlobalDataFlow.cs:373:42:373:42 | a | GlobalDataFlow.cs:375:9:375:9 | access to parameter a |
+| GlobalDataFlow.cs:373:42:373:42 | a | GlobalDataFlow.cs:375:9:375:9 | access to parameter a |
+| GlobalDataFlow.cs:373:42:373:42 | a | GlobalDataFlow.cs:375:9:375:9 | access to parameter a |
+| GlobalDataFlow.cs:373:42:373:42 | a | GlobalDataFlow.cs:375:9:375:9 | access to parameter a |
+| GlobalDataFlow.cs:373:42:373:42 | a | GlobalDataFlow.cs:375:9:375:9 | access to parameter a |
+| GlobalDataFlow.cs:373:42:373:42 | a | GlobalDataFlow.cs:375:9:375:9 | access to parameter a |
+| GlobalDataFlow.cs:373:52:373:52 | x | GlobalDataFlow.cs:373:52:373:52 | x |
+| GlobalDataFlow.cs:373:52:373:52 | x | GlobalDataFlow.cs:373:52:373:52 | x |
+| GlobalDataFlow.cs:373:52:373:52 | x | GlobalDataFlow.cs:375:11:375:11 | access to parameter x |
+| GlobalDataFlow.cs:373:52:373:52 | x | GlobalDataFlow.cs:375:11:375:11 | access to parameter x |
+| GlobalDataFlow.cs:373:52:373:52 | x | GlobalDataFlow.cs:375:11:375:11 | access to parameter x |
+| GlobalDataFlow.cs:373:52:373:52 | x | GlobalDataFlow.cs:375:11:375:11 | access to parameter x |
+| GlobalDataFlow.cs:373:52:373:52 | x | GlobalDataFlow.cs:375:11:375:11 | access to parameter x |
+| GlobalDataFlow.cs:373:52:373:52 | x | GlobalDataFlow.cs:375:11:375:11 | access to parameter x |
+| GlobalDataFlow.cs:373:52:373:52 | x | GlobalDataFlow.cs:375:11:375:11 | access to parameter x |
+| GlobalDataFlow.cs:373:52:373:52 | x | GlobalDataFlow.cs:375:11:375:11 | access to parameter x |
+| GlobalDataFlow.cs:373:52:373:52 | x | GlobalDataFlow.cs:375:11:375:11 | access to parameter x |
+| GlobalDataFlow.cs:373:52:373:52 | x | GlobalDataFlow.cs:375:11:375:11 | access to parameter x |
+| GlobalDataFlow.cs:375:9:375:9 | access to parameter a | GlobalDataFlow.cs:375:9:375:9 | access to parameter a |
+| GlobalDataFlow.cs:375:9:375:12 | delegate call | GlobalDataFlow.cs:375:9:375:12 | delegate call |
+| GlobalDataFlow.cs:375:11:375:11 | access to parameter x | GlobalDataFlow.cs:56:37:56:37 | x |
+| GlobalDataFlow.cs:375:11:375:11 | access to parameter x | GlobalDataFlow.cs:56:37:56:37 | x |
+| GlobalDataFlow.cs:375:11:375:11 | access to parameter x | GlobalDataFlow.cs:56:37:56:37 | x |
+| GlobalDataFlow.cs:375:11:375:11 | access to parameter x | GlobalDataFlow.cs:56:37:56:37 | x |
+| GlobalDataFlow.cs:375:11:375:11 | access to parameter x | GlobalDataFlow.cs:61:38:61:50 | nonSinkParam0 |
+| GlobalDataFlow.cs:375:11:375:11 | access to parameter x | GlobalDataFlow.cs:61:38:61:50 | nonSinkParam0 |
+| GlobalDataFlow.cs:375:11:375:11 | access to parameter x | GlobalDataFlow.cs:61:38:61:50 | nonSinkParam0 |
+| GlobalDataFlow.cs:375:11:375:11 | access to parameter x | GlobalDataFlow.cs:61:38:61:50 | nonSinkParam0 |
+| GlobalDataFlow.cs:375:11:375:11 | access to parameter x | GlobalDataFlow.cs:255:26:255:35 | sinkParam5 |
+| GlobalDataFlow.cs:375:11:375:11 | access to parameter x | GlobalDataFlow.cs:255:26:255:35 | sinkParam5 |
+| GlobalDataFlow.cs:375:11:375:11 | access to parameter x | GlobalDataFlow.cs:255:26:255:35 | sinkParam5 |
+| GlobalDataFlow.cs:375:11:375:11 | access to parameter x | GlobalDataFlow.cs:255:26:255:35 | sinkParam5 |
+| GlobalDataFlow.cs:375:11:375:11 | access to parameter x | GlobalDataFlow.cs:260:26:260:35 | sinkParam6 |
+| GlobalDataFlow.cs:375:11:375:11 | access to parameter x | GlobalDataFlow.cs:260:26:260:35 | sinkParam6 |
+| GlobalDataFlow.cs:375:11:375:11 | access to parameter x | GlobalDataFlow.cs:260:26:260:35 | sinkParam6 |
+| GlobalDataFlow.cs:375:11:375:11 | access to parameter x | GlobalDataFlow.cs:260:26:260:35 | sinkParam6 |
+| GlobalDataFlow.cs:375:11:375:11 | access to parameter x | GlobalDataFlow.cs:375:11:375:11 | access to parameter x |
+| GlobalDataFlow.cs:378:39:378:45 | tainted | GlobalDataFlow.cs:378:39:378:45 | tainted |
+| GlobalDataFlow.cs:378:39:378:45 | tainted | GlobalDataFlow.cs:378:39:378:45 | tainted |
+| GlobalDataFlow.cs:378:39:378:45 | tainted | GlobalDataFlow.cs:380:13:380:28 | SSA def(sink11) |
+| GlobalDataFlow.cs:378:39:378:45 | tainted | GlobalDataFlow.cs:380:13:380:28 | SSA def(sink11) |
+| GlobalDataFlow.cs:378:39:378:45 | tainted | GlobalDataFlow.cs:380:13:380:28 | SSA def(sink11) |
+| GlobalDataFlow.cs:378:39:378:45 | tainted | GlobalDataFlow.cs:380:13:380:28 | SSA def(sink11) |
+| GlobalDataFlow.cs:378:39:378:45 | tainted | GlobalDataFlow.cs:380:22:380:28 | access to parameter tainted |
+| GlobalDataFlow.cs:378:39:378:45 | tainted | GlobalDataFlow.cs:380:22:380:28 | access to parameter tainted |
+| GlobalDataFlow.cs:378:39:378:45 | tainted | GlobalDataFlow.cs:380:22:380:28 | access to parameter tainted |
+| GlobalDataFlow.cs:378:39:378:45 | tainted | GlobalDataFlow.cs:380:22:380:28 | access to parameter tainted |
+| GlobalDataFlow.cs:378:39:378:45 | tainted | GlobalDataFlow.cs:381:15:381:20 | access to local variable sink11 |
+| GlobalDataFlow.cs:378:39:378:45 | tainted | GlobalDataFlow.cs:381:15:381:20 | access to local variable sink11 |
+| GlobalDataFlow.cs:378:39:378:45 | tainted | GlobalDataFlow.cs:381:15:381:20 | access to local variable sink11 |
+| GlobalDataFlow.cs:378:39:378:45 | tainted | GlobalDataFlow.cs:381:15:381:20 | access to local variable sink11 |
+| GlobalDataFlow.cs:378:39:378:45 | tainted | GlobalDataFlow.cs:382:16:382:21 | access to local variable sink11 |
+| GlobalDataFlow.cs:378:39:378:45 | tainted | GlobalDataFlow.cs:382:16:382:21 | access to local variable sink11 |
+| GlobalDataFlow.cs:378:39:378:45 | tainted | GlobalDataFlow.cs:382:16:382:21 | access to local variable sink11 |
+| GlobalDataFlow.cs:378:39:378:45 | tainted | GlobalDataFlow.cs:382:16:382:21 | access to local variable sink11 |
+| GlobalDataFlow.cs:380:13:380:28 | SSA def(sink11) | GlobalDataFlow.cs:380:13:380:28 | SSA def(sink11) |
+| GlobalDataFlow.cs:380:13:380:28 | SSA def(sink11) | GlobalDataFlow.cs:381:15:381:20 | access to local variable sink11 |
+| GlobalDataFlow.cs:380:13:380:28 | SSA def(sink11) | GlobalDataFlow.cs:381:15:381:20 | access to local variable sink11 |
+| GlobalDataFlow.cs:380:13:380:28 | SSA def(sink11) | GlobalDataFlow.cs:381:15:381:20 | access to local variable sink11 |
+| GlobalDataFlow.cs:380:13:380:28 | SSA def(sink11) | GlobalDataFlow.cs:381:15:381:20 | access to local variable sink11 |
+| GlobalDataFlow.cs:380:13:380:28 | SSA def(sink11) | GlobalDataFlow.cs:382:16:382:21 | access to local variable sink11 |
+| GlobalDataFlow.cs:380:13:380:28 | SSA def(sink11) | GlobalDataFlow.cs:382:16:382:21 | access to local variable sink11 |
+| GlobalDataFlow.cs:380:13:380:28 | SSA def(sink11) | GlobalDataFlow.cs:382:16:382:21 | access to local variable sink11 |
+| GlobalDataFlow.cs:380:13:380:28 | SSA def(sink11) | GlobalDataFlow.cs:382:16:382:21 | access to local variable sink11 |
+| GlobalDataFlow.cs:380:13:380:28 | String sink11 = ... | GlobalDataFlow.cs:380:13:380:28 | String sink11 = ... |
+| GlobalDataFlow.cs:380:22:380:28 | access to parameter tainted | GlobalDataFlow.cs:380:13:380:28 | SSA def(sink11) |
+| GlobalDataFlow.cs:380:22:380:28 | access to parameter tainted | GlobalDataFlow.cs:380:13:380:28 | SSA def(sink11) |
+| GlobalDataFlow.cs:380:22:380:28 | access to parameter tainted | GlobalDataFlow.cs:380:13:380:28 | SSA def(sink11) |
+| GlobalDataFlow.cs:380:22:380:28 | access to parameter tainted | GlobalDataFlow.cs:380:13:380:28 | SSA def(sink11) |
+| GlobalDataFlow.cs:380:22:380:28 | access to parameter tainted | GlobalDataFlow.cs:380:22:380:28 | access to parameter tainted |
+| GlobalDataFlow.cs:380:22:380:28 | access to parameter tainted | GlobalDataFlow.cs:381:15:381:20 | access to local variable sink11 |
+| GlobalDataFlow.cs:380:22:380:28 | access to parameter tainted | GlobalDataFlow.cs:381:15:381:20 | access to local variable sink11 |
+| GlobalDataFlow.cs:380:22:380:28 | access to parameter tainted | GlobalDataFlow.cs:381:15:381:20 | access to local variable sink11 |
+| GlobalDataFlow.cs:380:22:380:28 | access to parameter tainted | GlobalDataFlow.cs:381:15:381:20 | access to local variable sink11 |
+| GlobalDataFlow.cs:380:22:380:28 | access to parameter tainted | GlobalDataFlow.cs:382:16:382:21 | access to local variable sink11 |
+| GlobalDataFlow.cs:380:22:380:28 | access to parameter tainted | GlobalDataFlow.cs:382:16:382:21 | access to local variable sink11 |
+| GlobalDataFlow.cs:380:22:380:28 | access to parameter tainted | GlobalDataFlow.cs:382:16:382:21 | access to local variable sink11 |
+| GlobalDataFlow.cs:380:22:380:28 | access to parameter tainted | GlobalDataFlow.cs:382:16:382:21 | access to local variable sink11 |
+| GlobalDataFlow.cs:381:9:381:21 | call to method Check | GlobalDataFlow.cs:381:9:381:21 | call to method Check |
+| GlobalDataFlow.cs:381:15:381:20 | access to local variable sink11 | GlobalDataFlow.cs:381:15:381:20 | access to local variable sink11 |
+| GlobalDataFlow.cs:381:15:381:20 | access to local variable sink11 | GlobalDataFlow.cs:382:16:382:21 | access to local variable sink11 |
+| GlobalDataFlow.cs:381:15:381:20 | access to local variable sink11 | GlobalDataFlow.cs:382:16:382:21 | access to local variable sink11 |
+| GlobalDataFlow.cs:381:15:381:20 | access to local variable sink11 | GlobalDataFlow.cs:382:16:382:21 | access to local variable sink11 |
+| GlobalDataFlow.cs:381:15:381:20 | access to local variable sink11 | GlobalDataFlow.cs:382:16:382:21 | access to local variable sink11 |
+| GlobalDataFlow.cs:382:16:382:21 | access to local variable sink11 | GlobalDataFlow.cs:163:22:163:43 | call to method TaintedParam |
+| GlobalDataFlow.cs:382:16:382:21 | access to local variable sink11 | GlobalDataFlow.cs:163:22:163:43 | call to method TaintedParam |
+| GlobalDataFlow.cs:382:16:382:21 | access to local variable sink11 | GlobalDataFlow.cs:382:16:382:21 | access to local variable sink11 |
+| GlobalDataFlow.cs:385:42:385:51 | nonTainted | GlobalDataFlow.cs:385:42:385:51 | nonTainted |
+| GlobalDataFlow.cs:385:42:385:51 | nonTainted | GlobalDataFlow.cs:385:42:385:51 | nonTainted |
+| GlobalDataFlow.cs:385:42:385:51 | nonTainted | GlobalDataFlow.cs:387:13:387:33 | SSA def(nonSink0) |
+| GlobalDataFlow.cs:385:42:385:51 | nonTainted | GlobalDataFlow.cs:387:13:387:33 | SSA def(nonSink0) |
+| GlobalDataFlow.cs:385:42:385:51 | nonTainted | GlobalDataFlow.cs:387:13:387:33 | SSA def(nonSink0) |
+| GlobalDataFlow.cs:385:42:385:51 | nonTainted | GlobalDataFlow.cs:387:13:387:33 | SSA def(nonSink0) |
+| GlobalDataFlow.cs:385:42:385:51 | nonTainted | GlobalDataFlow.cs:387:24:387:33 | access to parameter nonTainted |
+| GlobalDataFlow.cs:385:42:385:51 | nonTainted | GlobalDataFlow.cs:387:24:387:33 | access to parameter nonTainted |
+| GlobalDataFlow.cs:385:42:385:51 | nonTainted | GlobalDataFlow.cs:387:24:387:33 | access to parameter nonTainted |
+| GlobalDataFlow.cs:385:42:385:51 | nonTainted | GlobalDataFlow.cs:387:24:387:33 | access to parameter nonTainted |
+| GlobalDataFlow.cs:385:42:385:51 | nonTainted | GlobalDataFlow.cs:388:15:388:22 | access to local variable nonSink0 |
+| GlobalDataFlow.cs:385:42:385:51 | nonTainted | GlobalDataFlow.cs:388:15:388:22 | access to local variable nonSink0 |
+| GlobalDataFlow.cs:385:42:385:51 | nonTainted | GlobalDataFlow.cs:388:15:388:22 | access to local variable nonSink0 |
+| GlobalDataFlow.cs:385:42:385:51 | nonTainted | GlobalDataFlow.cs:388:15:388:22 | access to local variable nonSink0 |
+| GlobalDataFlow.cs:385:42:385:51 | nonTainted | GlobalDataFlow.cs:389:16:389:23 | access to local variable nonSink0 |
+| GlobalDataFlow.cs:385:42:385:51 | nonTainted | GlobalDataFlow.cs:389:16:389:23 | access to local variable nonSink0 |
+| GlobalDataFlow.cs:385:42:385:51 | nonTainted | GlobalDataFlow.cs:389:16:389:23 | access to local variable nonSink0 |
+| GlobalDataFlow.cs:385:42:385:51 | nonTainted | GlobalDataFlow.cs:389:16:389:23 | access to local variable nonSink0 |
+| GlobalDataFlow.cs:387:13:387:33 | SSA def(nonSink0) | GlobalDataFlow.cs:387:13:387:33 | SSA def(nonSink0) |
+| GlobalDataFlow.cs:387:13:387:33 | SSA def(nonSink0) | GlobalDataFlow.cs:388:15:388:22 | access to local variable nonSink0 |
+| GlobalDataFlow.cs:387:13:387:33 | SSA def(nonSink0) | GlobalDataFlow.cs:388:15:388:22 | access to local variable nonSink0 |
+| GlobalDataFlow.cs:387:13:387:33 | SSA def(nonSink0) | GlobalDataFlow.cs:388:15:388:22 | access to local variable nonSink0 |
+| GlobalDataFlow.cs:387:13:387:33 | SSA def(nonSink0) | GlobalDataFlow.cs:388:15:388:22 | access to local variable nonSink0 |
+| GlobalDataFlow.cs:387:13:387:33 | SSA def(nonSink0) | GlobalDataFlow.cs:389:16:389:23 | access to local variable nonSink0 |
+| GlobalDataFlow.cs:387:13:387:33 | SSA def(nonSink0) | GlobalDataFlow.cs:389:16:389:23 | access to local variable nonSink0 |
+| GlobalDataFlow.cs:387:13:387:33 | SSA def(nonSink0) | GlobalDataFlow.cs:389:16:389:23 | access to local variable nonSink0 |
+| GlobalDataFlow.cs:387:13:387:33 | SSA def(nonSink0) | GlobalDataFlow.cs:389:16:389:23 | access to local variable nonSink0 |
+| GlobalDataFlow.cs:387:13:387:33 | String nonSink0 = ... | GlobalDataFlow.cs:387:13:387:33 | String nonSink0 = ... |
+| GlobalDataFlow.cs:387:24:387:33 | access to parameter nonTainted | GlobalDataFlow.cs:387:13:387:33 | SSA def(nonSink0) |
+| GlobalDataFlow.cs:387:24:387:33 | access to parameter nonTainted | GlobalDataFlow.cs:387:13:387:33 | SSA def(nonSink0) |
+| GlobalDataFlow.cs:387:24:387:33 | access to parameter nonTainted | GlobalDataFlow.cs:387:13:387:33 | SSA def(nonSink0) |
+| GlobalDataFlow.cs:387:24:387:33 | access to parameter nonTainted | GlobalDataFlow.cs:387:13:387:33 | SSA def(nonSink0) |
+| GlobalDataFlow.cs:387:24:387:33 | access to parameter nonTainted | GlobalDataFlow.cs:387:24:387:33 | access to parameter nonTainted |
+| GlobalDataFlow.cs:387:24:387:33 | access to parameter nonTainted | GlobalDataFlow.cs:388:15:388:22 | access to local variable nonSink0 |
+| GlobalDataFlow.cs:387:24:387:33 | access to parameter nonTainted | GlobalDataFlow.cs:388:15:388:22 | access to local variable nonSink0 |
+| GlobalDataFlow.cs:387:24:387:33 | access to parameter nonTainted | GlobalDataFlow.cs:388:15:388:22 | access to local variable nonSink0 |
+| GlobalDataFlow.cs:387:24:387:33 | access to parameter nonTainted | GlobalDataFlow.cs:388:15:388:22 | access to local variable nonSink0 |
+| GlobalDataFlow.cs:387:24:387:33 | access to parameter nonTainted | GlobalDataFlow.cs:389:16:389:23 | access to local variable nonSink0 |
+| GlobalDataFlow.cs:387:24:387:33 | access to parameter nonTainted | GlobalDataFlow.cs:389:16:389:23 | access to local variable nonSink0 |
+| GlobalDataFlow.cs:387:24:387:33 | access to parameter nonTainted | GlobalDataFlow.cs:389:16:389:23 | access to local variable nonSink0 |
+| GlobalDataFlow.cs:387:24:387:33 | access to parameter nonTainted | GlobalDataFlow.cs:389:16:389:23 | access to local variable nonSink0 |
+| GlobalDataFlow.cs:388:9:388:23 | call to method Check | GlobalDataFlow.cs:388:9:388:23 | call to method Check |
+| GlobalDataFlow.cs:388:15:388:22 | access to local variable nonSink0 | GlobalDataFlow.cs:388:15:388:22 | access to local variable nonSink0 |
+| GlobalDataFlow.cs:388:15:388:22 | access to local variable nonSink0 | GlobalDataFlow.cs:389:16:389:23 | access to local variable nonSink0 |
+| GlobalDataFlow.cs:388:15:388:22 | access to local variable nonSink0 | GlobalDataFlow.cs:389:16:389:23 | access to local variable nonSink0 |
+| GlobalDataFlow.cs:388:15:388:22 | access to local variable nonSink0 | GlobalDataFlow.cs:389:16:389:23 | access to local variable nonSink0 |
+| GlobalDataFlow.cs:388:15:388:22 | access to local variable nonSink0 | GlobalDataFlow.cs:389:16:389:23 | access to local variable nonSink0 |
+| GlobalDataFlow.cs:389:16:389:23 | access to local variable nonSink0 | GlobalDataFlow.cs:175:20:175:44 | call to method NonTaintedParam |
+| GlobalDataFlow.cs:389:16:389:23 | access to local variable nonSink0 | GlobalDataFlow.cs:175:20:175:44 | call to method NonTaintedParam |
+| GlobalDataFlow.cs:389:16:389:23 | access to local variable nonSink0 | GlobalDataFlow.cs:389:16:389:23 | access to local variable nonSink0 |
+| GlobalDataFlow.cs:398:62:398:63 | "" | GlobalDataFlow.cs:32:15:32:35 | access to property NonSinkProperty1 |
+| GlobalDataFlow.cs:398:62:398:63 | "" | GlobalDataFlow.cs:32:15:32:35 | access to property NonSinkProperty1 |
+| GlobalDataFlow.cs:398:62:398:63 | "" | GlobalDataFlow.cs:398:62:398:63 | "" |
+| GlobalDataFlow.cs:403:9:403:11 | this | GlobalDataFlow.cs:403:9:403:11 | this |
+| GlobalDataFlow.cs:403:22:403:23 | "" | GlobalDataFlow.cs:403:22:403:23 | "" |
 | GlobalDataFlow.cs:404:9:404:11 | this | GlobalDataFlow.cs:404:9:404:11 | this |
-| GlobalDataFlow.cs:404:22:404:23 | "" | GlobalDataFlow.cs:404:22:404:23 | "" |
-| GlobalDataFlow.cs:405:9:405:11 | this | GlobalDataFlow.cs:405:9:405:11 | this |
-| GlobalDataFlow.cs:405:9:405:11 | value | GlobalDataFlow.cs:405:9:405:11 | value |
-| GlobalDataFlow.cs:405:9:405:11 | value | GlobalDataFlow.cs:405:9:405:11 | value |
-| GlobalDataFlow.cs:405:9:405:11 | value | GlobalDataFlow.cs:405:19:405:34 | SSA def(nonSink0) |
-| GlobalDataFlow.cs:405:9:405:11 | value | GlobalDataFlow.cs:405:19:405:34 | SSA def(nonSink0) |
-| GlobalDataFlow.cs:405:9:405:11 | value | GlobalDataFlow.cs:405:19:405:34 | SSA def(nonSink0) |
-| GlobalDataFlow.cs:405:9:405:11 | value | GlobalDataFlow.cs:405:19:405:34 | SSA def(nonSink0) |
-| GlobalDataFlow.cs:405:9:405:11 | value | GlobalDataFlow.cs:405:30:405:34 | access to parameter value |
-| GlobalDataFlow.cs:405:9:405:11 | value | GlobalDataFlow.cs:405:30:405:34 | access to parameter value |
-| GlobalDataFlow.cs:405:9:405:11 | value | GlobalDataFlow.cs:405:30:405:34 | access to parameter value |
-| GlobalDataFlow.cs:405:9:405:11 | value | GlobalDataFlow.cs:405:30:405:34 | access to parameter value |
-| GlobalDataFlow.cs:405:9:405:11 | value | GlobalDataFlow.cs:405:43:405:50 | access to local variable nonSink0 |
-| GlobalDataFlow.cs:405:9:405:11 | value | GlobalDataFlow.cs:405:43:405:50 | access to local variable nonSink0 |
-| GlobalDataFlow.cs:405:9:405:11 | value | GlobalDataFlow.cs:405:43:405:50 | access to local variable nonSink0 |
-| GlobalDataFlow.cs:405:9:405:11 | value | GlobalDataFlow.cs:405:43:405:50 | access to local variable nonSink0 |
-| GlobalDataFlow.cs:405:19:405:34 | SSA def(nonSink0) | GlobalDataFlow.cs:405:19:405:34 | SSA def(nonSink0) |
-| GlobalDataFlow.cs:405:19:405:34 | SSA def(nonSink0) | GlobalDataFlow.cs:405:43:405:50 | access to local variable nonSink0 |
-| GlobalDataFlow.cs:405:19:405:34 | SSA def(nonSink0) | GlobalDataFlow.cs:405:43:405:50 | access to local variable nonSink0 |
-| GlobalDataFlow.cs:405:19:405:34 | SSA def(nonSink0) | GlobalDataFlow.cs:405:43:405:50 | access to local variable nonSink0 |
-| GlobalDataFlow.cs:405:19:405:34 | SSA def(nonSink0) | GlobalDataFlow.cs:405:43:405:50 | access to local variable nonSink0 |
-| GlobalDataFlow.cs:405:19:405:34 | String nonSink0 = ... | GlobalDataFlow.cs:405:19:405:34 | String nonSink0 = ... |
-| GlobalDataFlow.cs:405:30:405:34 | access to parameter value | GlobalDataFlow.cs:405:19:405:34 | SSA def(nonSink0) |
-| GlobalDataFlow.cs:405:30:405:34 | access to parameter value | GlobalDataFlow.cs:405:19:405:34 | SSA def(nonSink0) |
-| GlobalDataFlow.cs:405:30:405:34 | access to parameter value | GlobalDataFlow.cs:405:19:405:34 | SSA def(nonSink0) |
-| GlobalDataFlow.cs:405:30:405:34 | access to parameter value | GlobalDataFlow.cs:405:19:405:34 | SSA def(nonSink0) |
-| GlobalDataFlow.cs:405:30:405:34 | access to parameter value | GlobalDataFlow.cs:405:30:405:34 | access to parameter value |
-| GlobalDataFlow.cs:405:30:405:34 | access to parameter value | GlobalDataFlow.cs:405:43:405:50 | access to local variable nonSink0 |
-| GlobalDataFlow.cs:405:30:405:34 | access to parameter value | GlobalDataFlow.cs:405:43:405:50 | access to local variable nonSink0 |
-| GlobalDataFlow.cs:405:30:405:34 | access to parameter value | GlobalDataFlow.cs:405:43:405:50 | access to local variable nonSink0 |
-| GlobalDataFlow.cs:405:30:405:34 | access to parameter value | GlobalDataFlow.cs:405:43:405:50 | access to local variable nonSink0 |
-| GlobalDataFlow.cs:405:37:405:51 | call to method Check | GlobalDataFlow.cs:405:37:405:51 | call to method Check |
-| GlobalDataFlow.cs:405:43:405:50 | access to local variable nonSink0 | GlobalDataFlow.cs:405:43:405:50 | access to local variable nonSink0 |
+| GlobalDataFlow.cs:404:9:404:11 | value | GlobalDataFlow.cs:404:9:404:11 | value |
+| GlobalDataFlow.cs:404:9:404:11 | value | GlobalDataFlow.cs:404:9:404:11 | value |
+| GlobalDataFlow.cs:404:9:404:11 | value | GlobalDataFlow.cs:404:19:404:32 | SSA def(sink20) |
+| GlobalDataFlow.cs:404:9:404:11 | value | GlobalDataFlow.cs:404:19:404:32 | SSA def(sink20) |
+| GlobalDataFlow.cs:404:9:404:11 | value | GlobalDataFlow.cs:404:19:404:32 | SSA def(sink20) |
+| GlobalDataFlow.cs:404:9:404:11 | value | GlobalDataFlow.cs:404:19:404:32 | SSA def(sink20) |
+| GlobalDataFlow.cs:404:9:404:11 | value | GlobalDataFlow.cs:404:28:404:32 | access to parameter value |
+| GlobalDataFlow.cs:404:9:404:11 | value | GlobalDataFlow.cs:404:28:404:32 | access to parameter value |
+| GlobalDataFlow.cs:404:9:404:11 | value | GlobalDataFlow.cs:404:28:404:32 | access to parameter value |
+| GlobalDataFlow.cs:404:9:404:11 | value | GlobalDataFlow.cs:404:28:404:32 | access to parameter value |
+| GlobalDataFlow.cs:404:9:404:11 | value | GlobalDataFlow.cs:404:41:404:46 | access to local variable sink20 |
+| GlobalDataFlow.cs:404:9:404:11 | value | GlobalDataFlow.cs:404:41:404:46 | access to local variable sink20 |
+| GlobalDataFlow.cs:404:9:404:11 | value | GlobalDataFlow.cs:404:41:404:46 | access to local variable sink20 |
+| GlobalDataFlow.cs:404:9:404:11 | value | GlobalDataFlow.cs:404:41:404:46 | access to local variable sink20 |
+| GlobalDataFlow.cs:404:19:404:32 | SSA def(sink20) | GlobalDataFlow.cs:404:19:404:32 | SSA def(sink20) |
+| GlobalDataFlow.cs:404:19:404:32 | SSA def(sink20) | GlobalDataFlow.cs:404:41:404:46 | access to local variable sink20 |
+| GlobalDataFlow.cs:404:19:404:32 | SSA def(sink20) | GlobalDataFlow.cs:404:41:404:46 | access to local variable sink20 |
+| GlobalDataFlow.cs:404:19:404:32 | SSA def(sink20) | GlobalDataFlow.cs:404:41:404:46 | access to local variable sink20 |
+| GlobalDataFlow.cs:404:19:404:32 | SSA def(sink20) | GlobalDataFlow.cs:404:41:404:46 | access to local variable sink20 |
+| GlobalDataFlow.cs:404:19:404:32 | String sink20 = ... | GlobalDataFlow.cs:404:19:404:32 | String sink20 = ... |
+| GlobalDataFlow.cs:404:28:404:32 | access to parameter value | GlobalDataFlow.cs:404:19:404:32 | SSA def(sink20) |
+| GlobalDataFlow.cs:404:28:404:32 | access to parameter value | GlobalDataFlow.cs:404:19:404:32 | SSA def(sink20) |
+| GlobalDataFlow.cs:404:28:404:32 | access to parameter value | GlobalDataFlow.cs:404:19:404:32 | SSA def(sink20) |
+| GlobalDataFlow.cs:404:28:404:32 | access to parameter value | GlobalDataFlow.cs:404:19:404:32 | SSA def(sink20) |
+| GlobalDataFlow.cs:404:28:404:32 | access to parameter value | GlobalDataFlow.cs:404:28:404:32 | access to parameter value |
+| GlobalDataFlow.cs:404:28:404:32 | access to parameter value | GlobalDataFlow.cs:404:41:404:46 | access to local variable sink20 |
+| GlobalDataFlow.cs:404:28:404:32 | access to parameter value | GlobalDataFlow.cs:404:41:404:46 | access to local variable sink20 |
+| GlobalDataFlow.cs:404:28:404:32 | access to parameter value | GlobalDataFlow.cs:404:41:404:46 | access to local variable sink20 |
+| GlobalDataFlow.cs:404:28:404:32 | access to parameter value | GlobalDataFlow.cs:404:41:404:46 | access to local variable sink20 |
+| GlobalDataFlow.cs:404:35:404:47 | call to method Check | GlobalDataFlow.cs:404:35:404:47 | call to method Check |
+| GlobalDataFlow.cs:404:41:404:46 | access to local variable sink20 | GlobalDataFlow.cs:404:41:404:46 | access to local variable sink20 |
+| GlobalDataFlow.cs:409:9:409:11 | this | GlobalDataFlow.cs:409:9:409:11 | this |
+| GlobalDataFlow.cs:409:22:409:23 | "" | GlobalDataFlow.cs:409:22:409:23 | "" |
 | GlobalDataFlow.cs:410:9:410:11 | this | GlobalDataFlow.cs:410:9:410:11 | this |
-| GlobalDataFlow.cs:410:22:410:35 | "taint source" | GlobalDataFlow.cs:193:22:193:32 | access to property OutProperty |
-| GlobalDataFlow.cs:410:22:410:35 | "taint source" | GlobalDataFlow.cs:193:22:193:32 | access to property OutProperty |
-| GlobalDataFlow.cs:410:22:410:35 | "taint source" | GlobalDataFlow.cs:410:22:410:35 | "taint source" |
+| GlobalDataFlow.cs:410:9:410:11 | value | GlobalDataFlow.cs:410:9:410:11 | value |
+| GlobalDataFlow.cs:410:9:410:11 | value | GlobalDataFlow.cs:410:9:410:11 | value |
+| GlobalDataFlow.cs:410:9:410:11 | value | GlobalDataFlow.cs:410:19:410:34 | SSA def(nonSink0) |
+| GlobalDataFlow.cs:410:9:410:11 | value | GlobalDataFlow.cs:410:19:410:34 | SSA def(nonSink0) |
+| GlobalDataFlow.cs:410:9:410:11 | value | GlobalDataFlow.cs:410:19:410:34 | SSA def(nonSink0) |
+| GlobalDataFlow.cs:410:9:410:11 | value | GlobalDataFlow.cs:410:19:410:34 | SSA def(nonSink0) |
+| GlobalDataFlow.cs:410:9:410:11 | value | GlobalDataFlow.cs:410:30:410:34 | access to parameter value |
+| GlobalDataFlow.cs:410:9:410:11 | value | GlobalDataFlow.cs:410:30:410:34 | access to parameter value |
+| GlobalDataFlow.cs:410:9:410:11 | value | GlobalDataFlow.cs:410:30:410:34 | access to parameter value |
+| GlobalDataFlow.cs:410:9:410:11 | value | GlobalDataFlow.cs:410:30:410:34 | access to parameter value |
+| GlobalDataFlow.cs:410:9:410:11 | value | GlobalDataFlow.cs:410:43:410:50 | access to local variable nonSink0 |
+| GlobalDataFlow.cs:410:9:410:11 | value | GlobalDataFlow.cs:410:43:410:50 | access to local variable nonSink0 |
+| GlobalDataFlow.cs:410:9:410:11 | value | GlobalDataFlow.cs:410:43:410:50 | access to local variable nonSink0 |
+| GlobalDataFlow.cs:410:9:410:11 | value | GlobalDataFlow.cs:410:43:410:50 | access to local variable nonSink0 |
+| GlobalDataFlow.cs:410:19:410:34 | SSA def(nonSink0) | GlobalDataFlow.cs:410:19:410:34 | SSA def(nonSink0) |
+| GlobalDataFlow.cs:410:19:410:34 | SSA def(nonSink0) | GlobalDataFlow.cs:410:43:410:50 | access to local variable nonSink0 |
+| GlobalDataFlow.cs:410:19:410:34 | SSA def(nonSink0) | GlobalDataFlow.cs:410:43:410:50 | access to local variable nonSink0 |
+| GlobalDataFlow.cs:410:19:410:34 | SSA def(nonSink0) | GlobalDataFlow.cs:410:43:410:50 | access to local variable nonSink0 |
+| GlobalDataFlow.cs:410:19:410:34 | SSA def(nonSink0) | GlobalDataFlow.cs:410:43:410:50 | access to local variable nonSink0 |
+| GlobalDataFlow.cs:410:19:410:34 | String nonSink0 = ... | GlobalDataFlow.cs:410:19:410:34 | String nonSink0 = ... |
+| GlobalDataFlow.cs:410:30:410:34 | access to parameter value | GlobalDataFlow.cs:410:19:410:34 | SSA def(nonSink0) |
+| GlobalDataFlow.cs:410:30:410:34 | access to parameter value | GlobalDataFlow.cs:410:19:410:34 | SSA def(nonSink0) |
+| GlobalDataFlow.cs:410:30:410:34 | access to parameter value | GlobalDataFlow.cs:410:19:410:34 | SSA def(nonSink0) |
+| GlobalDataFlow.cs:410:30:410:34 | access to parameter value | GlobalDataFlow.cs:410:19:410:34 | SSA def(nonSink0) |
+| GlobalDataFlow.cs:410:30:410:34 | access to parameter value | GlobalDataFlow.cs:410:30:410:34 | access to parameter value |
+| GlobalDataFlow.cs:410:30:410:34 | access to parameter value | GlobalDataFlow.cs:410:43:410:50 | access to local variable nonSink0 |
+| GlobalDataFlow.cs:410:30:410:34 | access to parameter value | GlobalDataFlow.cs:410:43:410:50 | access to local variable nonSink0 |
+| GlobalDataFlow.cs:410:30:410:34 | access to parameter value | GlobalDataFlow.cs:410:43:410:50 | access to local variable nonSink0 |
+| GlobalDataFlow.cs:410:30:410:34 | access to parameter value | GlobalDataFlow.cs:410:43:410:50 | access to local variable nonSink0 |
+| GlobalDataFlow.cs:410:37:410:51 | call to method Check | GlobalDataFlow.cs:410:37:410:51 | call to method Check |
+| GlobalDataFlow.cs:410:43:410:50 | access to local variable nonSink0 | GlobalDataFlow.cs:410:43:410:50 | access to local variable nonSink0 |
 | GlobalDataFlow.cs:415:9:415:11 | this | GlobalDataFlow.cs:415:9:415:11 | this |
-| GlobalDataFlow.cs:415:22:415:23 | "" | GlobalDataFlow.cs:197:20:197:33 | access to property NonOutProperty |
-| GlobalDataFlow.cs:415:22:415:23 | "" | GlobalDataFlow.cs:197:20:197:33 | access to property NonOutProperty |
-| GlobalDataFlow.cs:415:22:415:23 | "" | GlobalDataFlow.cs:415:22:415:23 | "" |
-| GlobalDataFlow.cs:421:71:421:71 | e | GlobalDataFlow.cs:421:71:421:71 | e |
-| GlobalDataFlow.cs:421:71:421:71 | e | GlobalDataFlow.cs:421:71:421:71 | e |
-| GlobalDataFlow.cs:421:71:421:71 | e | GlobalDataFlow.cs:424:27:424:27 | access to parameter e |
-| GlobalDataFlow.cs:421:71:421:71 | e | GlobalDataFlow.cs:424:27:424:27 | access to parameter e |
-| GlobalDataFlow.cs:421:71:421:71 | e | GlobalDataFlow.cs:424:27:424:27 | access to parameter e |
-| GlobalDataFlow.cs:421:71:421:71 | e | GlobalDataFlow.cs:424:27:424:27 | access to parameter e |
-| GlobalDataFlow.cs:421:71:421:71 | e | GlobalDataFlow.cs:424:27:424:27 | access to parameter e |
-| GlobalDataFlow.cs:421:71:421:71 | e | GlobalDataFlow.cs:424:27:424:27 | access to parameter e |
-| GlobalDataFlow.cs:421:85:421:85 | f | GlobalDataFlow.cs:421:85:421:85 | f |
-| GlobalDataFlow.cs:421:85:421:85 | f | GlobalDataFlow.cs:421:85:421:85 | f |
-| GlobalDataFlow.cs:421:85:421:85 | f | GlobalDataFlow.cs:426:44:426:44 | access to parameter f |
-| GlobalDataFlow.cs:421:85:421:85 | f | GlobalDataFlow.cs:426:44:426:44 | access to parameter f |
-| GlobalDataFlow.cs:421:85:421:85 | f | GlobalDataFlow.cs:426:44:426:44 | access to parameter f |
-| GlobalDataFlow.cs:421:85:421:85 | f | GlobalDataFlow.cs:426:44:426:44 | access to parameter f |
-| GlobalDataFlow.cs:421:85:421:85 | f | GlobalDataFlow.cs:426:44:426:44 | access to parameter f |
-| GlobalDataFlow.cs:421:85:421:85 | f | GlobalDataFlow.cs:426:44:426:44 | access to parameter f |
-| GlobalDataFlow.cs:423:13:423:17 | Int32 i = ... | GlobalDataFlow.cs:423:13:423:17 | Int32 i = ... |
-| GlobalDataFlow.cs:423:13:423:17 | SSA def(i) | GlobalDataFlow.cs:423:13:423:17 | SSA def(i) |
-| GlobalDataFlow.cs:423:13:423:17 | SSA def(i) | GlobalDataFlow.cs:424:9:427:9 | SSA phi(i) |
-| GlobalDataFlow.cs:423:13:423:17 | SSA def(i) | GlobalDataFlow.cs:424:9:427:9 | SSA phi(i) |
-| GlobalDataFlow.cs:423:13:423:17 | SSA def(i) | GlobalDataFlow.cs:426:17:426:17 | access to local variable i |
-| GlobalDataFlow.cs:423:13:423:17 | SSA def(i) | GlobalDataFlow.cs:426:17:426:17 | access to local variable i |
-| GlobalDataFlow.cs:423:17:423:17 | 0 | GlobalDataFlow.cs:423:13:423:17 | SSA def(i) |
-| GlobalDataFlow.cs:423:17:423:17 | 0 | GlobalDataFlow.cs:423:13:423:17 | SSA def(i) |
-| GlobalDataFlow.cs:423:17:423:17 | 0 | GlobalDataFlow.cs:423:17:423:17 | 0 |
-| GlobalDataFlow.cs:423:17:423:17 | 0 | GlobalDataFlow.cs:424:9:427:9 | SSA phi(i) |
-| GlobalDataFlow.cs:423:17:423:17 | 0 | GlobalDataFlow.cs:424:9:427:9 | SSA phi(i) |
-| GlobalDataFlow.cs:423:17:423:17 | 0 | GlobalDataFlow.cs:426:17:426:17 | access to local variable i |
-| GlobalDataFlow.cs:423:17:423:17 | 0 | GlobalDataFlow.cs:426:17:426:17 | access to local variable i |
-| GlobalDataFlow.cs:424:9:427:9 | SSA phi(i) | GlobalDataFlow.cs:424:9:427:9 | SSA phi(i) |
-| GlobalDataFlow.cs:424:9:427:9 | SSA phi(i) | GlobalDataFlow.cs:426:17:426:17 | access to local variable i |
-| GlobalDataFlow.cs:424:9:427:9 | SSA phi(i) | GlobalDataFlow.cs:426:17:426:17 | access to local variable i |
-| GlobalDataFlow.cs:424:22:424:22 | SSA def(x) | GlobalDataFlow.cs:424:22:424:22 | SSA def(x) |
-| GlobalDataFlow.cs:424:22:424:22 | SSA def(x) | GlobalDataFlow.cs:426:46:426:46 | access to local variable x |
-| GlobalDataFlow.cs:424:22:424:22 | SSA def(x) | GlobalDataFlow.cs:426:46:426:46 | access to local variable x |
-| GlobalDataFlow.cs:424:22:424:22 | T x | GlobalDataFlow.cs:424:22:424:22 | T x |
-| GlobalDataFlow.cs:424:27:424:27 | access to parameter e | GlobalDataFlow.cs:424:27:424:27 | access to parameter e |
-| GlobalDataFlow.cs:426:17:426:17 | access to local variable i | GlobalDataFlow.cs:426:17:426:17 | access to local variable i |
-| GlobalDataFlow.cs:426:17:426:19 | ...++ | GlobalDataFlow.cs:426:17:426:19 | ...++ |
-| GlobalDataFlow.cs:426:17:426:19 | SSA def(i) | GlobalDataFlow.cs:424:9:427:9 | SSA phi(i) |
-| GlobalDataFlow.cs:426:17:426:19 | SSA def(i) | GlobalDataFlow.cs:424:9:427:9 | SSA phi(i) |
-| GlobalDataFlow.cs:426:17:426:19 | SSA def(i) | GlobalDataFlow.cs:426:17:426:17 | access to local variable i |
-| GlobalDataFlow.cs:426:17:426:19 | SSA def(i) | GlobalDataFlow.cs:426:17:426:17 | access to local variable i |
-| GlobalDataFlow.cs:426:17:426:19 | SSA def(i) | GlobalDataFlow.cs:426:17:426:19 | SSA def(i) |
-| GlobalDataFlow.cs:426:17:426:23 | ... % ... | GlobalDataFlow.cs:426:17:426:23 | ... % ... |
-| GlobalDataFlow.cs:426:17:426:28 | ... == ... | GlobalDataFlow.cs:426:17:426:28 | ... == ... |
-| GlobalDataFlow.cs:426:23:426:23 | 2 | GlobalDataFlow.cs:426:23:426:23 | 2 |
-| GlobalDataFlow.cs:426:28:426:28 | 0 | GlobalDataFlow.cs:426:28:426:28 | 0 |
-| GlobalDataFlow.cs:426:44:426:44 | access to parameter f | GlobalDataFlow.cs:426:44:426:44 | access to parameter f |
-| GlobalDataFlow.cs:426:44:426:47 | delegate call | GlobalDataFlow.cs:80:22:80:85 | call to method SelectEven |
-| GlobalDataFlow.cs:426:44:426:47 | delegate call | GlobalDataFlow.cs:80:22:80:85 | call to method SelectEven |
-| GlobalDataFlow.cs:426:44:426:47 | delegate call | GlobalDataFlow.cs:108:24:108:90 | call to method SelectEven |
-| GlobalDataFlow.cs:426:44:426:47 | delegate call | GlobalDataFlow.cs:108:24:108:90 | call to method SelectEven |
-| GlobalDataFlow.cs:426:44:426:47 | delegate call | GlobalDataFlow.cs:426:44:426:47 | delegate call |
-| GlobalDataFlow.cs:426:44:426:47 | delegate call | GlobalDataFlow.cs:426:44:426:47 | delegate call |
-| GlobalDataFlow.cs:426:46:426:46 | access to local variable x | GlobalDataFlow.cs:80:79:80:79 | x |
-| GlobalDataFlow.cs:426:46:426:46 | access to local variable x | GlobalDataFlow.cs:80:79:80:79 | x |
-| GlobalDataFlow.cs:426:46:426:46 | access to local variable x | GlobalDataFlow.cs:108:84:108:84 | x |
-| GlobalDataFlow.cs:426:46:426:46 | access to local variable x | GlobalDataFlow.cs:108:84:108:84 | x |
-| GlobalDataFlow.cs:426:46:426:46 | access to local variable x | GlobalDataFlow.cs:426:44:426:47 | delegate call |
-| GlobalDataFlow.cs:426:46:426:46 | access to local variable x | GlobalDataFlow.cs:426:44:426:47 | delegate call |
-| GlobalDataFlow.cs:426:46:426:46 | access to local variable x | GlobalDataFlow.cs:426:46:426:46 | access to local variable x |
+| GlobalDataFlow.cs:415:22:415:35 | "taint source" | GlobalDataFlow.cs:197:22:197:32 | access to property OutProperty |
+| GlobalDataFlow.cs:415:22:415:35 | "taint source" | GlobalDataFlow.cs:197:22:197:32 | access to property OutProperty |
+| GlobalDataFlow.cs:415:22:415:35 | "taint source" | GlobalDataFlow.cs:415:22:415:35 | "taint source" |
+| GlobalDataFlow.cs:420:9:420:11 | this | GlobalDataFlow.cs:420:9:420:11 | this |
+| GlobalDataFlow.cs:420:22:420:23 | "" | GlobalDataFlow.cs:201:20:201:33 | access to property NonOutProperty |
+| GlobalDataFlow.cs:420:22:420:23 | "" | GlobalDataFlow.cs:201:20:201:33 | access to property NonOutProperty |
+| GlobalDataFlow.cs:420:22:420:23 | "" | GlobalDataFlow.cs:420:22:420:23 | "" |
+| GlobalDataFlow.cs:426:71:426:71 | e | GlobalDataFlow.cs:426:71:426:71 | e |
+| GlobalDataFlow.cs:426:71:426:71 | e | GlobalDataFlow.cs:426:71:426:71 | e |
+| GlobalDataFlow.cs:426:71:426:71 | e | GlobalDataFlow.cs:429:27:429:27 | access to parameter e |
+| GlobalDataFlow.cs:426:71:426:71 | e | GlobalDataFlow.cs:429:27:429:27 | access to parameter e |
+| GlobalDataFlow.cs:426:71:426:71 | e | GlobalDataFlow.cs:429:27:429:27 | access to parameter e |
+| GlobalDataFlow.cs:426:71:426:71 | e | GlobalDataFlow.cs:429:27:429:27 | access to parameter e |
+| GlobalDataFlow.cs:426:71:426:71 | e | GlobalDataFlow.cs:429:27:429:27 | access to parameter e |
+| GlobalDataFlow.cs:426:71:426:71 | e | GlobalDataFlow.cs:429:27:429:27 | access to parameter e |
+| GlobalDataFlow.cs:426:85:426:85 | f | GlobalDataFlow.cs:426:85:426:85 | f |
+| GlobalDataFlow.cs:426:85:426:85 | f | GlobalDataFlow.cs:426:85:426:85 | f |
+| GlobalDataFlow.cs:426:85:426:85 | f | GlobalDataFlow.cs:431:44:431:44 | access to parameter f |
+| GlobalDataFlow.cs:426:85:426:85 | f | GlobalDataFlow.cs:431:44:431:44 | access to parameter f |
+| GlobalDataFlow.cs:426:85:426:85 | f | GlobalDataFlow.cs:431:44:431:44 | access to parameter f |
+| GlobalDataFlow.cs:426:85:426:85 | f | GlobalDataFlow.cs:431:44:431:44 | access to parameter f |
+| GlobalDataFlow.cs:426:85:426:85 | f | GlobalDataFlow.cs:431:44:431:44 | access to parameter f |
+| GlobalDataFlow.cs:426:85:426:85 | f | GlobalDataFlow.cs:431:44:431:44 | access to parameter f |
+| GlobalDataFlow.cs:428:13:428:17 | Int32 i = ... | GlobalDataFlow.cs:428:13:428:17 | Int32 i = ... |
+| GlobalDataFlow.cs:428:13:428:17 | SSA def(i) | GlobalDataFlow.cs:428:13:428:17 | SSA def(i) |
+| GlobalDataFlow.cs:428:13:428:17 | SSA def(i) | GlobalDataFlow.cs:429:9:432:9 | SSA phi(i) |
+| GlobalDataFlow.cs:428:13:428:17 | SSA def(i) | GlobalDataFlow.cs:429:9:432:9 | SSA phi(i) |
+| GlobalDataFlow.cs:428:13:428:17 | SSA def(i) | GlobalDataFlow.cs:431:17:431:17 | access to local variable i |
+| GlobalDataFlow.cs:428:13:428:17 | SSA def(i) | GlobalDataFlow.cs:431:17:431:17 | access to local variable i |
+| GlobalDataFlow.cs:428:17:428:17 | 0 | GlobalDataFlow.cs:428:13:428:17 | SSA def(i) |
+| GlobalDataFlow.cs:428:17:428:17 | 0 | GlobalDataFlow.cs:428:13:428:17 | SSA def(i) |
+| GlobalDataFlow.cs:428:17:428:17 | 0 | GlobalDataFlow.cs:428:17:428:17 | 0 |
+| GlobalDataFlow.cs:428:17:428:17 | 0 | GlobalDataFlow.cs:429:9:432:9 | SSA phi(i) |
+| GlobalDataFlow.cs:428:17:428:17 | 0 | GlobalDataFlow.cs:429:9:432:9 | SSA phi(i) |
+| GlobalDataFlow.cs:428:17:428:17 | 0 | GlobalDataFlow.cs:431:17:431:17 | access to local variable i |
+| GlobalDataFlow.cs:428:17:428:17 | 0 | GlobalDataFlow.cs:431:17:431:17 | access to local variable i |
+| GlobalDataFlow.cs:429:9:432:9 | SSA phi(i) | GlobalDataFlow.cs:429:9:432:9 | SSA phi(i) |
+| GlobalDataFlow.cs:429:9:432:9 | SSA phi(i) | GlobalDataFlow.cs:431:17:431:17 | access to local variable i |
+| GlobalDataFlow.cs:429:9:432:9 | SSA phi(i) | GlobalDataFlow.cs:431:17:431:17 | access to local variable i |
+| GlobalDataFlow.cs:429:22:429:22 | SSA def(x) | GlobalDataFlow.cs:429:22:429:22 | SSA def(x) |
+| GlobalDataFlow.cs:429:22:429:22 | SSA def(x) | GlobalDataFlow.cs:431:46:431:46 | access to local variable x |
+| GlobalDataFlow.cs:429:22:429:22 | SSA def(x) | GlobalDataFlow.cs:431:46:431:46 | access to local variable x |
+| GlobalDataFlow.cs:429:22:429:22 | T x | GlobalDataFlow.cs:429:22:429:22 | T x |
+| GlobalDataFlow.cs:429:27:429:27 | access to parameter e | GlobalDataFlow.cs:429:27:429:27 | access to parameter e |
+| GlobalDataFlow.cs:431:17:431:17 | access to local variable i | GlobalDataFlow.cs:431:17:431:17 | access to local variable i |
+| GlobalDataFlow.cs:431:17:431:19 | ...++ | GlobalDataFlow.cs:431:17:431:19 | ...++ |
+| GlobalDataFlow.cs:431:17:431:19 | SSA def(i) | GlobalDataFlow.cs:429:9:432:9 | SSA phi(i) |
+| GlobalDataFlow.cs:431:17:431:19 | SSA def(i) | GlobalDataFlow.cs:429:9:432:9 | SSA phi(i) |
+| GlobalDataFlow.cs:431:17:431:19 | SSA def(i) | GlobalDataFlow.cs:431:17:431:17 | access to local variable i |
+| GlobalDataFlow.cs:431:17:431:19 | SSA def(i) | GlobalDataFlow.cs:431:17:431:17 | access to local variable i |
+| GlobalDataFlow.cs:431:17:431:19 | SSA def(i) | GlobalDataFlow.cs:431:17:431:19 | SSA def(i) |
+| GlobalDataFlow.cs:431:17:431:23 | ... % ... | GlobalDataFlow.cs:431:17:431:23 | ... % ... |
+| GlobalDataFlow.cs:431:17:431:28 | ... == ... | GlobalDataFlow.cs:431:17:431:28 | ... == ... |
+| GlobalDataFlow.cs:431:23:431:23 | 2 | GlobalDataFlow.cs:431:23:431:23 | 2 |
+| GlobalDataFlow.cs:431:28:431:28 | 0 | GlobalDataFlow.cs:431:28:431:28 | 0 |
+| GlobalDataFlow.cs:431:44:431:44 | access to parameter f | GlobalDataFlow.cs:431:44:431:44 | access to parameter f |
+| GlobalDataFlow.cs:431:44:431:47 | delegate call | GlobalDataFlow.cs:80:22:80:85 | call to method SelectEven |
+| GlobalDataFlow.cs:431:44:431:47 | delegate call | GlobalDataFlow.cs:80:22:80:85 | call to method SelectEven |
+| GlobalDataFlow.cs:431:44:431:47 | delegate call | GlobalDataFlow.cs:112:24:112:90 | call to method SelectEven |
+| GlobalDataFlow.cs:431:44:431:47 | delegate call | GlobalDataFlow.cs:112:24:112:90 | call to method SelectEven |
+| GlobalDataFlow.cs:431:44:431:47 | delegate call | GlobalDataFlow.cs:431:44:431:47 | delegate call |
+| GlobalDataFlow.cs:431:44:431:47 | delegate call | GlobalDataFlow.cs:431:44:431:47 | delegate call |
+| GlobalDataFlow.cs:431:46:431:46 | access to local variable x | GlobalDataFlow.cs:80:79:80:79 | x |
+| GlobalDataFlow.cs:431:46:431:46 | access to local variable x | GlobalDataFlow.cs:80:79:80:79 | x |
+| GlobalDataFlow.cs:431:46:431:46 | access to local variable x | GlobalDataFlow.cs:112:84:112:84 | x |
+| GlobalDataFlow.cs:431:46:431:46 | access to local variable x | GlobalDataFlow.cs:112:84:112:84 | x |
+| GlobalDataFlow.cs:431:46:431:46 | access to local variable x | GlobalDataFlow.cs:431:44:431:47 | delegate call |
+| GlobalDataFlow.cs:431:46:431:46 | access to local variable x | GlobalDataFlow.cs:431:44:431:47 | delegate call |
+| GlobalDataFlow.cs:431:46:431:46 | access to local variable x | GlobalDataFlow.cs:431:46:431:46 | access to local variable x |
 | Splitting.cs:3:10:3:11 | this | Splitting.cs:3:10:3:11 | this |
 | Splitting.cs:3:18:3:18 | b | Splitting.cs:3:18:3:18 | b |
 | Splitting.cs:3:18:3:18 | b | Splitting.cs:3:18:3:18 | b |

--- a/csharp/ql/test/library-tests/dataflow/global/DataFlowPath.expected
+++ b/csharp/ql/test/library-tests/dataflow/global/DataFlowPath.expected
@@ -122,7 +122,6 @@ edges
 | GlobalDataFlow.cs:70:28:70:45 | access to property SinkProperty0 | GlobalDataFlow.cs:70:21:70:46 | call to method Return |
 | GlobalDataFlow.cs:72:21:72:101 | (...) ... | GlobalDataFlow.cs:73:15:73:19 | access to local variable sink1 |
 | GlobalDataFlow.cs:72:21:72:101 | (...) ... | GlobalDataFlow.cs:75:19:75:23 | access to local variable sink1 |
-| GlobalDataFlow.cs:72:21:72:101 | (...) ... | GlobalDataFlow.cs:106:19:106:23 | access to local variable sink1 |
 | GlobalDataFlow.cs:72:29:72:101 | call to method Invoke | GlobalDataFlow.cs:72:21:72:101 | (...) ... |
 | GlobalDataFlow.cs:72:94:72:98 | access to local variable sink0 | GlobalDataFlow.cs:72:29:72:101 | call to method Invoke |
 | GlobalDataFlow.cs:75:19:75:23 | access to local variable sink1 | GlobalDataFlow.cs:75:30:75:34 | SSA def(sink2) |
@@ -131,12 +130,6 @@ edges
 | GlobalDataFlow.cs:78:19:78:23 | access to local variable sink2 | GlobalDataFlow.cs:78:30:78:34 | SSA def(sink3) |
 | GlobalDataFlow.cs:78:30:78:34 | SSA def(sink3) | GlobalDataFlow.cs:79:15:79:19 | access to local variable sink3 |
 | GlobalDataFlow.cs:78:30:78:34 | SSA def(sink3) | GlobalDataFlow.cs:135:29:135:33 | access to local variable sink3 |
-| GlobalDataFlow.cs:106:19:106:23 | access to local variable sink1 | GlobalDataFlow.cs:106:41:106:48 | SSA def(nonSink0) |
-| GlobalDataFlow.cs:106:41:106:48 | SSA def(nonSink0) | GlobalDataFlow.cs:107:15:107:22 | access to local variable nonSink0 |
-| GlobalDataFlow.cs:106:41:106:48 | SSA def(nonSink0) | GlobalDataFlow.cs:108:41:108:48 | access to local variable nonSink0 |
-| GlobalDataFlow.cs:108:27:108:34 | SSA def(nonSink0) | GlobalDataFlow.cs:109:15:109:22 | access to local variable nonSink0 |
-| GlobalDataFlow.cs:108:27:108:34 | SSA def(nonSink0) | GlobalDataFlow.cs:111:15:111:22 | access to local variable nonSink0 |
-| GlobalDataFlow.cs:108:41:108:48 | access to local variable nonSink0 | GlobalDataFlow.cs:108:27:108:34 | SSA def(nonSink0) |
 | GlobalDataFlow.cs:135:21:135:34 | delegate call | GlobalDataFlow.cs:136:15:136:19 | access to local variable sink4 |
 | GlobalDataFlow.cs:135:21:135:34 | delegate call | GlobalDataFlow.cs:143:39:143:43 | access to local variable sink4 |
 | GlobalDataFlow.cs:135:29:135:33 | access to local variable sink3 | GlobalDataFlow.cs:135:21:135:34 | delegate call |
@@ -205,9 +198,6 @@ edges
 | Splitting.cs:9:15:9:15 | [b (line 3): false] access to local variable x | Splitting.cs:3:28:3:34 | tainted | Splitting.cs:9:15:9:15 | [b (line 3): false] access to local variable x | [b (line 3): false] access to local variable x |
 | Splitting.cs:9:15:9:15 | [b (line 3): true] access to local variable x | Splitting.cs:3:28:3:34 | tainted | Splitting.cs:9:15:9:15 | [b (line 3): true] access to local variable x | [b (line 3): true] access to local variable x |
 | GlobalDataFlow.cs:18:15:18:29 | access to field SinkField0 | GlobalDataFlow.cs:17:27:17:40 | "taint source" | GlobalDataFlow.cs:18:15:18:29 | access to field SinkField0 | access to field SinkField0 |
-| GlobalDataFlow.cs:107:15:107:22 | access to local variable nonSink0 | GlobalDataFlow.cs:17:27:17:40 | "taint source" | GlobalDataFlow.cs:107:15:107:22 | access to local variable nonSink0 | access to local variable nonSink0 |
-| GlobalDataFlow.cs:109:15:109:22 | access to local variable nonSink0 | GlobalDataFlow.cs:17:27:17:40 | "taint source" | GlobalDataFlow.cs:109:15:109:22 | access to local variable nonSink0 | access to local variable nonSink0 |
-| GlobalDataFlow.cs:111:15:111:22 | access to local variable nonSink0 | GlobalDataFlow.cs:17:27:17:40 | "taint source" | GlobalDataFlow.cs:111:15:111:22 | access to local variable nonSink0 | access to local variable nonSink0 |
 | GlobalDataFlow.cs:71:15:71:19 | access to local variable sink0 | GlobalDataFlow.cs:17:27:17:40 | "taint source" | GlobalDataFlow.cs:71:15:71:19 | access to local variable sink0 | access to local variable sink0 |
 | GlobalDataFlow.cs:73:15:73:19 | access to local variable sink1 | GlobalDataFlow.cs:17:27:17:40 | "taint source" | GlobalDataFlow.cs:73:15:73:19 | access to local variable sink1 | access to local variable sink1 |
 | GlobalDataFlow.cs:190:15:190:20 | access to local variable sink10 | GlobalDataFlow.cs:318:16:318:29 | "taint source" | GlobalDataFlow.cs:190:15:190:20 | access to local variable sink10 | access to local variable sink10 |

--- a/csharp/ql/test/library-tests/dataflow/global/DataFlowPath.expected
+++ b/csharp/ql/test/library-tests/dataflow/global/DataFlowPath.expected
@@ -67,7 +67,7 @@ edges
 | GlobalDataFlow.cs:35:13:35:30 | access to property SinkProperty0 | GlobalDataFlow.cs:57:35:57:52 | access to property SinkProperty0 |
 | GlobalDataFlow.cs:35:13:35:30 | access to property SinkProperty0 | GlobalDataFlow.cs:64:22:64:39 | access to property SinkProperty0 |
 | GlobalDataFlow.cs:35:13:35:30 | access to property SinkProperty0 | GlobalDataFlow.cs:70:28:70:45 | access to property SinkProperty0 |
-| GlobalDataFlow.cs:35:13:35:30 | access to property SinkProperty0 | GlobalDataFlow.cs:230:26:230:35 | sinkParam0 |
+| GlobalDataFlow.cs:35:13:35:30 | access to property SinkProperty0 | GlobalDataFlow.cs:234:26:234:35 | sinkParam0 |
 | GlobalDataFlow.cs:37:35:37:52 | access to property SinkProperty0 | GlobalDataFlow.cs:45:13:45:30 | access to property SinkProperty0 |
 | GlobalDataFlow.cs:37:35:37:52 | access to property SinkProperty0 | GlobalDataFlow.cs:52:20:52:37 | access to property SinkProperty0 |
 | GlobalDataFlow.cs:37:35:37:52 | access to property SinkProperty0 | GlobalDataFlow.cs:53:28:53:45 | access to property SinkProperty0 |
@@ -76,7 +76,7 @@ edges
 | GlobalDataFlow.cs:37:35:37:52 | access to property SinkProperty0 | GlobalDataFlow.cs:57:35:57:52 | access to property SinkProperty0 |
 | GlobalDataFlow.cs:37:35:37:52 | access to property SinkProperty0 | GlobalDataFlow.cs:64:22:64:39 | access to property SinkProperty0 |
 | GlobalDataFlow.cs:37:35:37:52 | access to property SinkProperty0 | GlobalDataFlow.cs:70:28:70:45 | access to property SinkProperty0 |
-| GlobalDataFlow.cs:37:35:37:52 | access to property SinkProperty0 | GlobalDataFlow.cs:236:26:236:35 | sinkParam1 |
+| GlobalDataFlow.cs:37:35:37:52 | access to property SinkProperty0 | GlobalDataFlow.cs:240:26:240:35 | sinkParam1 |
 | GlobalDataFlow.cs:44:30:44:39 | sinkParam2 | GlobalDataFlow.cs:44:50:44:59 | access to parameter sinkParam2 |
 | GlobalDataFlow.cs:45:13:45:30 | access to property SinkProperty0 | GlobalDataFlow.cs:44:30:44:39 | sinkParam2 |
 | GlobalDataFlow.cs:45:13:45:30 | access to property SinkProperty0 | GlobalDataFlow.cs:52:20:52:37 | access to property SinkProperty0 |
@@ -92,36 +92,37 @@ edges
 | GlobalDataFlow.cs:52:20:52:37 | access to property SinkProperty0 | GlobalDataFlow.cs:57:35:57:52 | access to property SinkProperty0 |
 | GlobalDataFlow.cs:52:20:52:37 | access to property SinkProperty0 | GlobalDataFlow.cs:64:22:64:39 | access to property SinkProperty0 |
 | GlobalDataFlow.cs:52:20:52:37 | access to property SinkProperty0 | GlobalDataFlow.cs:70:28:70:45 | access to property SinkProperty0 |
-| GlobalDataFlow.cs:52:20:52:37 | access to property SinkProperty0 | GlobalDataFlow.cs:354:41:354:41 | x |
+| GlobalDataFlow.cs:52:20:52:37 | access to property SinkProperty0 | GlobalDataFlow.cs:359:41:359:41 | x |
 | GlobalDataFlow.cs:53:15:53:15 | x | GlobalDataFlow.cs:53:24:53:24 | access to parameter x |
-| GlobalDataFlow.cs:53:24:53:24 | access to parameter x | GlobalDataFlow.cs:246:26:246:35 | sinkParam4 |
+| GlobalDataFlow.cs:53:24:53:24 | access to parameter x | GlobalDataFlow.cs:250:26:250:35 | sinkParam4 |
 | GlobalDataFlow.cs:53:28:53:45 | access to property SinkProperty0 | GlobalDataFlow.cs:54:44:54:61 | access to property SinkProperty0 |
 | GlobalDataFlow.cs:53:28:53:45 | access to property SinkProperty0 | GlobalDataFlow.cs:55:28:55:45 | access to property SinkProperty0 |
 | GlobalDataFlow.cs:53:28:53:45 | access to property SinkProperty0 | GlobalDataFlow.cs:57:35:57:52 | access to property SinkProperty0 |
 | GlobalDataFlow.cs:53:28:53:45 | access to property SinkProperty0 | GlobalDataFlow.cs:64:22:64:39 | access to property SinkProperty0 |
 | GlobalDataFlow.cs:53:28:53:45 | access to property SinkProperty0 | GlobalDataFlow.cs:70:28:70:45 | access to property SinkProperty0 |
-| GlobalDataFlow.cs:53:28:53:45 | access to property SinkProperty0 | GlobalDataFlow.cs:354:41:354:41 | x |
+| GlobalDataFlow.cs:53:28:53:45 | access to property SinkProperty0 | GlobalDataFlow.cs:359:41:359:41 | x |
 | GlobalDataFlow.cs:54:44:54:61 | access to property SinkProperty0 | GlobalDataFlow.cs:55:28:55:45 | access to property SinkProperty0 |
 | GlobalDataFlow.cs:54:44:54:61 | access to property SinkProperty0 | GlobalDataFlow.cs:57:35:57:52 | access to property SinkProperty0 |
 | GlobalDataFlow.cs:54:44:54:61 | access to property SinkProperty0 | GlobalDataFlow.cs:64:22:64:39 | access to property SinkProperty0 |
 | GlobalDataFlow.cs:54:44:54:61 | access to property SinkProperty0 | GlobalDataFlow.cs:70:28:70:45 | access to property SinkProperty0 |
-| GlobalDataFlow.cs:54:44:54:61 | access to property SinkProperty0 | GlobalDataFlow.cs:368:52:368:52 | x |
+| GlobalDataFlow.cs:54:44:54:61 | access to property SinkProperty0 | GlobalDataFlow.cs:373:52:373:52 | x |
 | GlobalDataFlow.cs:55:28:55:45 | access to property SinkProperty0 | GlobalDataFlow.cs:57:35:57:52 | access to property SinkProperty0 |
 | GlobalDataFlow.cs:55:28:55:45 | access to property SinkProperty0 | GlobalDataFlow.cs:64:22:64:39 | access to property SinkProperty0 |
 | GlobalDataFlow.cs:55:28:55:45 | access to property SinkProperty0 | GlobalDataFlow.cs:70:28:70:45 | access to property SinkProperty0 |
-| GlobalDataFlow.cs:55:28:55:45 | access to property SinkProperty0 | GlobalDataFlow.cs:368:52:368:52 | x |
+| GlobalDataFlow.cs:55:28:55:45 | access to property SinkProperty0 | GlobalDataFlow.cs:373:52:373:52 | x |
 | GlobalDataFlow.cs:56:37:56:37 | x | GlobalDataFlow.cs:56:46:56:46 | access to parameter x |
-| GlobalDataFlow.cs:56:46:56:46 | access to parameter x | GlobalDataFlow.cs:261:26:261:35 | sinkParam7 |
+| GlobalDataFlow.cs:56:46:56:46 | access to parameter x | GlobalDataFlow.cs:265:26:265:35 | sinkParam7 |
 | GlobalDataFlow.cs:57:35:57:52 | access to property SinkProperty0 | GlobalDataFlow.cs:64:22:64:39 | access to property SinkProperty0 |
 | GlobalDataFlow.cs:57:35:57:52 | access to property SinkProperty0 | GlobalDataFlow.cs:70:28:70:45 | access to property SinkProperty0 |
-| GlobalDataFlow.cs:57:35:57:52 | access to property SinkProperty0 | GlobalDataFlow.cs:368:52:368:52 | x |
+| GlobalDataFlow.cs:57:35:57:52 | access to property SinkProperty0 | GlobalDataFlow.cs:373:52:373:52 | x |
 | GlobalDataFlow.cs:64:22:64:39 | access to property SinkProperty0 | GlobalDataFlow.cs:70:28:70:45 | access to property SinkProperty0 |
-| GlobalDataFlow.cs:64:22:64:39 | access to property SinkProperty0 | GlobalDataFlow.cs:399:9:399:11 | value |
+| GlobalDataFlow.cs:64:22:64:39 | access to property SinkProperty0 | GlobalDataFlow.cs:404:9:404:11 | value |
 | GlobalDataFlow.cs:70:21:70:46 | call to method Return | GlobalDataFlow.cs:71:15:71:19 | access to local variable sink0 |
 | GlobalDataFlow.cs:70:21:70:46 | call to method Return | GlobalDataFlow.cs:72:94:72:98 | access to local variable sink0 |
 | GlobalDataFlow.cs:70:28:70:45 | access to property SinkProperty0 | GlobalDataFlow.cs:70:21:70:46 | call to method Return |
 | GlobalDataFlow.cs:72:21:72:101 | (...) ... | GlobalDataFlow.cs:73:15:73:19 | access to local variable sink1 |
 | GlobalDataFlow.cs:72:21:72:101 | (...) ... | GlobalDataFlow.cs:75:19:75:23 | access to local variable sink1 |
+| GlobalDataFlow.cs:72:21:72:101 | (...) ... | GlobalDataFlow.cs:106:19:106:23 | access to local variable sink1 |
 | GlobalDataFlow.cs:72:29:72:101 | call to method Invoke | GlobalDataFlow.cs:72:21:72:101 | (...) ... |
 | GlobalDataFlow.cs:72:94:72:98 | access to local variable sink0 | GlobalDataFlow.cs:72:29:72:101 | call to method Invoke |
 | GlobalDataFlow.cs:75:19:75:23 | access to local variable sink1 | GlobalDataFlow.cs:75:30:75:34 | SSA def(sink2) |
@@ -129,50 +130,56 @@ edges
 | GlobalDataFlow.cs:75:30:75:34 | SSA def(sink2) | GlobalDataFlow.cs:78:19:78:23 | access to local variable sink2 |
 | GlobalDataFlow.cs:78:19:78:23 | access to local variable sink2 | GlobalDataFlow.cs:78:30:78:34 | SSA def(sink3) |
 | GlobalDataFlow.cs:78:30:78:34 | SSA def(sink3) | GlobalDataFlow.cs:79:15:79:19 | access to local variable sink3 |
-| GlobalDataFlow.cs:78:30:78:34 | SSA def(sink3) | GlobalDataFlow.cs:131:29:131:33 | access to local variable sink3 |
-| GlobalDataFlow.cs:131:21:131:34 | delegate call | GlobalDataFlow.cs:132:15:132:19 | access to local variable sink4 |
-| GlobalDataFlow.cs:131:21:131:34 | delegate call | GlobalDataFlow.cs:139:39:139:43 | access to local variable sink4 |
-| GlobalDataFlow.cs:131:29:131:33 | access to local variable sink3 | GlobalDataFlow.cs:131:21:131:34 | delegate call |
-| GlobalDataFlow.cs:139:21:139:44 | call to method ApplyFunc | GlobalDataFlow.cs:140:15:140:19 | access to local variable sink5 |
-| GlobalDataFlow.cs:139:39:139:43 | access to local variable sink4 | GlobalDataFlow.cs:139:21:139:44 | call to method ApplyFunc |
-| GlobalDataFlow.cs:149:21:149:25 | call to method Out | GlobalDataFlow.cs:150:15:150:19 | access to local variable sink6 |
-| GlobalDataFlow.cs:152:20:152:24 | SSA def(sink7) | GlobalDataFlow.cs:153:15:153:19 | access to local variable sink7 |
-| GlobalDataFlow.cs:155:20:155:24 | SSA def(sink8) | GlobalDataFlow.cs:156:15:156:19 | access to local variable sink8 |
-| GlobalDataFlow.cs:159:22:159:43 | call to method TaintedParam | GlobalDataFlow.cs:160:15:160:20 | access to local variable sink23 |
-| GlobalDataFlow.cs:175:35:175:48 | "taint source" | GlobalDataFlow.cs:176:21:176:26 | delegate call |
-| GlobalDataFlow.cs:176:21:176:26 | delegate call | GlobalDataFlow.cs:177:15:177:19 | access to local variable sink9 |
-| GlobalDataFlow.cs:185:39:185:41 | [output] delegate creation of type Func<String> | GlobalDataFlow.cs:186:15:186:20 | access to local variable sink10 |
-| GlobalDataFlow.cs:193:22:193:32 | access to property OutProperty | GlobalDataFlow.cs:194:15:194:20 | access to local variable sink19 |
-| GlobalDataFlow.cs:230:26:230:35 | sinkParam0 | GlobalDataFlow.cs:232:16:232:25 | access to parameter sinkParam0 |
-| GlobalDataFlow.cs:230:26:230:35 | sinkParam0 | GlobalDataFlow.cs:233:15:233:24 | access to parameter sinkParam0 |
-| GlobalDataFlow.cs:232:16:232:25 | access to parameter sinkParam0 | GlobalDataFlow.cs:230:26:230:35 | sinkParam0 |
-| GlobalDataFlow.cs:236:26:236:35 | sinkParam1 | GlobalDataFlow.cs:238:15:238:24 | access to parameter sinkParam1 |
-| GlobalDataFlow.cs:241:26:241:35 | sinkParam3 | GlobalDataFlow.cs:243:15:243:24 | access to parameter sinkParam3 |
-| GlobalDataFlow.cs:246:26:246:35 | sinkParam4 | GlobalDataFlow.cs:248:15:248:24 | access to parameter sinkParam4 |
-| GlobalDataFlow.cs:251:26:251:35 | sinkParam5 | GlobalDataFlow.cs:253:15:253:24 | access to parameter sinkParam5 |
-| GlobalDataFlow.cs:256:26:256:35 | sinkParam6 | GlobalDataFlow.cs:258:15:258:24 | access to parameter sinkParam6 |
-| GlobalDataFlow.cs:261:26:261:35 | sinkParam7 | GlobalDataFlow.cs:263:15:263:24 | access to parameter sinkParam7 |
-| GlobalDataFlow.cs:313:16:313:29 | "taint source" | GlobalDataFlow.cs:149:21:149:25 | call to method Out |
-| GlobalDataFlow.cs:313:16:313:29 | "taint source" | GlobalDataFlow.cs:185:39:185:41 | [output] delegate creation of type Func<String> |
-| GlobalDataFlow.cs:318:9:318:26 | SSA def(x) | GlobalDataFlow.cs:152:20:152:24 | SSA def(sink7) |
-| GlobalDataFlow.cs:318:13:318:26 | "taint source" | GlobalDataFlow.cs:318:9:318:26 | SSA def(x) |
-| GlobalDataFlow.cs:323:9:323:26 | SSA def(x) | GlobalDataFlow.cs:155:20:155:24 | SSA def(sink8) |
+| GlobalDataFlow.cs:78:30:78:34 | SSA def(sink3) | GlobalDataFlow.cs:135:29:135:33 | access to local variable sink3 |
+| GlobalDataFlow.cs:106:19:106:23 | access to local variable sink1 | GlobalDataFlow.cs:106:41:106:48 | SSA def(nonSink0) |
+| GlobalDataFlow.cs:106:41:106:48 | SSA def(nonSink0) | GlobalDataFlow.cs:107:15:107:22 | access to local variable nonSink0 |
+| GlobalDataFlow.cs:106:41:106:48 | SSA def(nonSink0) | GlobalDataFlow.cs:108:41:108:48 | access to local variable nonSink0 |
+| GlobalDataFlow.cs:108:27:108:34 | SSA def(nonSink0) | GlobalDataFlow.cs:109:15:109:22 | access to local variable nonSink0 |
+| GlobalDataFlow.cs:108:27:108:34 | SSA def(nonSink0) | GlobalDataFlow.cs:111:15:111:22 | access to local variable nonSink0 |
+| GlobalDataFlow.cs:108:41:108:48 | access to local variable nonSink0 | GlobalDataFlow.cs:108:27:108:34 | SSA def(nonSink0) |
+| GlobalDataFlow.cs:135:21:135:34 | delegate call | GlobalDataFlow.cs:136:15:136:19 | access to local variable sink4 |
+| GlobalDataFlow.cs:135:21:135:34 | delegate call | GlobalDataFlow.cs:143:39:143:43 | access to local variable sink4 |
+| GlobalDataFlow.cs:135:29:135:33 | access to local variable sink3 | GlobalDataFlow.cs:135:21:135:34 | delegate call |
+| GlobalDataFlow.cs:143:21:143:44 | call to method ApplyFunc | GlobalDataFlow.cs:144:15:144:19 | access to local variable sink5 |
+| GlobalDataFlow.cs:143:39:143:43 | access to local variable sink4 | GlobalDataFlow.cs:143:21:143:44 | call to method ApplyFunc |
+| GlobalDataFlow.cs:153:21:153:25 | call to method Out | GlobalDataFlow.cs:154:15:154:19 | access to local variable sink6 |
+| GlobalDataFlow.cs:156:20:156:24 | SSA def(sink7) | GlobalDataFlow.cs:157:15:157:19 | access to local variable sink7 |
+| GlobalDataFlow.cs:159:20:159:24 | SSA def(sink8) | GlobalDataFlow.cs:160:15:160:19 | access to local variable sink8 |
+| GlobalDataFlow.cs:163:22:163:43 | call to method TaintedParam | GlobalDataFlow.cs:164:15:164:20 | access to local variable sink23 |
+| GlobalDataFlow.cs:179:35:179:48 | "taint source" | GlobalDataFlow.cs:180:21:180:26 | delegate call |
+| GlobalDataFlow.cs:180:21:180:26 | delegate call | GlobalDataFlow.cs:181:15:181:19 | access to local variable sink9 |
+| GlobalDataFlow.cs:189:39:189:41 | [output] delegate creation of type Func<String> | GlobalDataFlow.cs:190:15:190:20 | access to local variable sink10 |
+| GlobalDataFlow.cs:197:22:197:32 | access to property OutProperty | GlobalDataFlow.cs:198:15:198:20 | access to local variable sink19 |
+| GlobalDataFlow.cs:234:26:234:35 | sinkParam0 | GlobalDataFlow.cs:236:16:236:25 | access to parameter sinkParam0 |
+| GlobalDataFlow.cs:234:26:234:35 | sinkParam0 | GlobalDataFlow.cs:237:15:237:24 | access to parameter sinkParam0 |
+| GlobalDataFlow.cs:236:16:236:25 | access to parameter sinkParam0 | GlobalDataFlow.cs:234:26:234:35 | sinkParam0 |
+| GlobalDataFlow.cs:240:26:240:35 | sinkParam1 | GlobalDataFlow.cs:242:15:242:24 | access to parameter sinkParam1 |
+| GlobalDataFlow.cs:245:26:245:35 | sinkParam3 | GlobalDataFlow.cs:247:15:247:24 | access to parameter sinkParam3 |
+| GlobalDataFlow.cs:250:26:250:35 | sinkParam4 | GlobalDataFlow.cs:252:15:252:24 | access to parameter sinkParam4 |
+| GlobalDataFlow.cs:255:26:255:35 | sinkParam5 | GlobalDataFlow.cs:257:15:257:24 | access to parameter sinkParam5 |
+| GlobalDataFlow.cs:260:26:260:35 | sinkParam6 | GlobalDataFlow.cs:262:15:262:24 | access to parameter sinkParam6 |
+| GlobalDataFlow.cs:265:26:265:35 | sinkParam7 | GlobalDataFlow.cs:267:15:267:24 | access to parameter sinkParam7 |
+| GlobalDataFlow.cs:318:16:318:29 | "taint source" | GlobalDataFlow.cs:153:21:153:25 | call to method Out |
+| GlobalDataFlow.cs:318:16:318:29 | "taint source" | GlobalDataFlow.cs:189:39:189:41 | [output] delegate creation of type Func<String> |
+| GlobalDataFlow.cs:323:9:323:26 | SSA def(x) | GlobalDataFlow.cs:156:20:156:24 | SSA def(sink7) |
 | GlobalDataFlow.cs:323:13:323:26 | "taint source" | GlobalDataFlow.cs:323:9:323:26 | SSA def(x) |
-| GlobalDataFlow.cs:354:41:354:41 | x | GlobalDataFlow.cs:356:11:356:11 | access to parameter x |
-| GlobalDataFlow.cs:354:41:354:41 | x | GlobalDataFlow.cs:356:11:356:11 | access to parameter x |
-| GlobalDataFlow.cs:356:11:356:11 | access to parameter x | GlobalDataFlow.cs:53:15:53:15 | x |
-| GlobalDataFlow.cs:356:11:356:11 | access to parameter x | GlobalDataFlow.cs:241:26:241:35 | sinkParam3 |
-| GlobalDataFlow.cs:368:52:368:52 | x | GlobalDataFlow.cs:370:11:370:11 | access to parameter x |
-| GlobalDataFlow.cs:368:52:368:52 | x | GlobalDataFlow.cs:370:11:370:11 | access to parameter x |
-| GlobalDataFlow.cs:368:52:368:52 | x | GlobalDataFlow.cs:370:11:370:11 | access to parameter x |
-| GlobalDataFlow.cs:370:11:370:11 | access to parameter x | GlobalDataFlow.cs:56:37:56:37 | x |
-| GlobalDataFlow.cs:370:11:370:11 | access to parameter x | GlobalDataFlow.cs:251:26:251:35 | sinkParam5 |
-| GlobalDataFlow.cs:370:11:370:11 | access to parameter x | GlobalDataFlow.cs:256:26:256:35 | sinkParam6 |
-| GlobalDataFlow.cs:373:39:373:45 | tainted | GlobalDataFlow.cs:376:15:376:20 | access to local variable sink11 |
-| GlobalDataFlow.cs:373:39:373:45 | tainted | GlobalDataFlow.cs:377:16:377:21 | access to local variable sink11 |
-| GlobalDataFlow.cs:377:16:377:21 | access to local variable sink11 | GlobalDataFlow.cs:159:22:159:43 | call to method TaintedParam |
-| GlobalDataFlow.cs:399:9:399:11 | value | GlobalDataFlow.cs:399:41:399:46 | access to local variable sink20 |
-| GlobalDataFlow.cs:410:22:410:35 | "taint source" | GlobalDataFlow.cs:193:22:193:32 | access to property OutProperty |
+| GlobalDataFlow.cs:328:9:328:26 | SSA def(x) | GlobalDataFlow.cs:159:20:159:24 | SSA def(sink8) |
+| GlobalDataFlow.cs:328:13:328:26 | "taint source" | GlobalDataFlow.cs:328:9:328:26 | SSA def(x) |
+| GlobalDataFlow.cs:359:41:359:41 | x | GlobalDataFlow.cs:361:11:361:11 | access to parameter x |
+| GlobalDataFlow.cs:359:41:359:41 | x | GlobalDataFlow.cs:361:11:361:11 | access to parameter x |
+| GlobalDataFlow.cs:361:11:361:11 | access to parameter x | GlobalDataFlow.cs:53:15:53:15 | x |
+| GlobalDataFlow.cs:361:11:361:11 | access to parameter x | GlobalDataFlow.cs:245:26:245:35 | sinkParam3 |
+| GlobalDataFlow.cs:373:52:373:52 | x | GlobalDataFlow.cs:375:11:375:11 | access to parameter x |
+| GlobalDataFlow.cs:373:52:373:52 | x | GlobalDataFlow.cs:375:11:375:11 | access to parameter x |
+| GlobalDataFlow.cs:373:52:373:52 | x | GlobalDataFlow.cs:375:11:375:11 | access to parameter x |
+| GlobalDataFlow.cs:375:11:375:11 | access to parameter x | GlobalDataFlow.cs:56:37:56:37 | x |
+| GlobalDataFlow.cs:375:11:375:11 | access to parameter x | GlobalDataFlow.cs:255:26:255:35 | sinkParam5 |
+| GlobalDataFlow.cs:375:11:375:11 | access to parameter x | GlobalDataFlow.cs:260:26:260:35 | sinkParam6 |
+| GlobalDataFlow.cs:378:39:378:45 | tainted | GlobalDataFlow.cs:381:15:381:20 | access to local variable sink11 |
+| GlobalDataFlow.cs:378:39:378:45 | tainted | GlobalDataFlow.cs:382:16:382:21 | access to local variable sink11 |
+| GlobalDataFlow.cs:382:16:382:21 | access to local variable sink11 | GlobalDataFlow.cs:163:22:163:43 | call to method TaintedParam |
+| GlobalDataFlow.cs:404:9:404:11 | value | GlobalDataFlow.cs:404:41:404:46 | access to local variable sink20 |
+| GlobalDataFlow.cs:415:22:415:35 | "taint source" | GlobalDataFlow.cs:197:22:197:32 | access to property OutProperty |
 | Splitting.cs:3:28:3:34 | tainted | Splitting.cs:8:24:8:30 | [b (line 3): false] access to parameter tainted |
 | Splitting.cs:3:28:3:34 | tainted | Splitting.cs:8:24:8:30 | [b (line 3): true] access to parameter tainted |
 | Splitting.cs:8:17:8:31 | [b (line 3): false] call to method Return | Splitting.cs:9:15:9:15 | [b (line 3): false] access to local variable x |
@@ -198,14 +205,17 @@ edges
 | Splitting.cs:9:15:9:15 | [b (line 3): false] access to local variable x | Splitting.cs:3:28:3:34 | tainted | Splitting.cs:9:15:9:15 | [b (line 3): false] access to local variable x | [b (line 3): false] access to local variable x |
 | Splitting.cs:9:15:9:15 | [b (line 3): true] access to local variable x | Splitting.cs:3:28:3:34 | tainted | Splitting.cs:9:15:9:15 | [b (line 3): true] access to local variable x | [b (line 3): true] access to local variable x |
 | GlobalDataFlow.cs:18:15:18:29 | access to field SinkField0 | GlobalDataFlow.cs:17:27:17:40 | "taint source" | GlobalDataFlow.cs:18:15:18:29 | access to field SinkField0 | access to field SinkField0 |
+| GlobalDataFlow.cs:107:15:107:22 | access to local variable nonSink0 | GlobalDataFlow.cs:17:27:17:40 | "taint source" | GlobalDataFlow.cs:107:15:107:22 | access to local variable nonSink0 | access to local variable nonSink0 |
+| GlobalDataFlow.cs:109:15:109:22 | access to local variable nonSink0 | GlobalDataFlow.cs:17:27:17:40 | "taint source" | GlobalDataFlow.cs:109:15:109:22 | access to local variable nonSink0 | access to local variable nonSink0 |
+| GlobalDataFlow.cs:111:15:111:22 | access to local variable nonSink0 | GlobalDataFlow.cs:17:27:17:40 | "taint source" | GlobalDataFlow.cs:111:15:111:22 | access to local variable nonSink0 | access to local variable nonSink0 |
 | GlobalDataFlow.cs:71:15:71:19 | access to local variable sink0 | GlobalDataFlow.cs:17:27:17:40 | "taint source" | GlobalDataFlow.cs:71:15:71:19 | access to local variable sink0 | access to local variable sink0 |
 | GlobalDataFlow.cs:73:15:73:19 | access to local variable sink1 | GlobalDataFlow.cs:17:27:17:40 | "taint source" | GlobalDataFlow.cs:73:15:73:19 | access to local variable sink1 | access to local variable sink1 |
-| GlobalDataFlow.cs:186:15:186:20 | access to local variable sink10 | GlobalDataFlow.cs:313:16:313:29 | "taint source" | GlobalDataFlow.cs:186:15:186:20 | access to local variable sink10 | access to local variable sink10 |
-| GlobalDataFlow.cs:376:15:376:20 | access to local variable sink11 | GlobalDataFlow.cs:373:39:373:45 | tainted | GlobalDataFlow.cs:376:15:376:20 | access to local variable sink11 | access to local variable sink11 |
-| GlobalDataFlow.cs:194:15:194:20 | access to local variable sink19 | GlobalDataFlow.cs:410:22:410:35 | "taint source" | GlobalDataFlow.cs:194:15:194:20 | access to local variable sink19 | access to local variable sink19 |
+| GlobalDataFlow.cs:190:15:190:20 | access to local variable sink10 | GlobalDataFlow.cs:318:16:318:29 | "taint source" | GlobalDataFlow.cs:190:15:190:20 | access to local variable sink10 | access to local variable sink10 |
+| GlobalDataFlow.cs:381:15:381:20 | access to local variable sink11 | GlobalDataFlow.cs:378:39:378:45 | tainted | GlobalDataFlow.cs:381:15:381:20 | access to local variable sink11 | access to local variable sink11 |
+| GlobalDataFlow.cs:198:15:198:20 | access to local variable sink19 | GlobalDataFlow.cs:415:22:415:35 | "taint source" | GlobalDataFlow.cs:198:15:198:20 | access to local variable sink19 | access to local variable sink19 |
 | GlobalDataFlow.cs:76:15:76:19 | access to local variable sink2 | GlobalDataFlow.cs:17:27:17:40 | "taint source" | GlobalDataFlow.cs:76:15:76:19 | access to local variable sink2 | access to local variable sink2 |
-| GlobalDataFlow.cs:399:41:399:46 | access to local variable sink20 | GlobalDataFlow.cs:17:27:17:40 | "taint source" | GlobalDataFlow.cs:399:41:399:46 | access to local variable sink20 | access to local variable sink20 |
-| GlobalDataFlow.cs:160:15:160:20 | access to local variable sink23 | GlobalDataFlow.cs:373:39:373:45 | tainted | GlobalDataFlow.cs:160:15:160:20 | access to local variable sink23 | access to local variable sink23 |
+| GlobalDataFlow.cs:404:41:404:46 | access to local variable sink20 | GlobalDataFlow.cs:17:27:17:40 | "taint source" | GlobalDataFlow.cs:404:41:404:46 | access to local variable sink20 | access to local variable sink20 |
+| GlobalDataFlow.cs:164:15:164:20 | access to local variable sink23 | GlobalDataFlow.cs:378:39:378:45 | tainted | GlobalDataFlow.cs:164:15:164:20 | access to local variable sink23 | access to local variable sink23 |
 | Capture.cs:12:19:12:24 | access to local variable sink27 | Capture.cs:7:20:7:26 | tainted | Capture.cs:12:19:12:24 | access to local variable sink27 | access to local variable sink27 |
 | Capture.cs:21:23:21:28 | access to local variable sink28 | Capture.cs:7:20:7:26 | tainted | Capture.cs:21:23:21:28 | access to local variable sink28 | access to local variable sink28 |
 | Capture.cs:30:19:30:24 | access to local variable sink29 | Capture.cs:7:20:7:26 | tainted | Capture.cs:30:19:30:24 | access to local variable sink29 | access to local variable sink29 |
@@ -219,21 +229,21 @@ edges
 | Capture.cs:137:15:137:20 | access to local variable sink36 | Capture.cs:101:25:101:31 | tainted | Capture.cs:137:15:137:20 | access to local variable sink36 | access to local variable sink36 |
 | Capture.cs:145:15:145:20 | access to local variable sink37 | Capture.cs:101:25:101:31 | tainted | Capture.cs:145:15:145:20 | access to local variable sink37 | access to local variable sink37 |
 | Capture.cs:171:15:171:20 | access to local variable sink38 | Capture.cs:101:25:101:31 | tainted | Capture.cs:171:15:171:20 | access to local variable sink38 | access to local variable sink38 |
-| GlobalDataFlow.cs:132:15:132:19 | access to local variable sink4 | GlobalDataFlow.cs:17:27:17:40 | "taint source" | GlobalDataFlow.cs:132:15:132:19 | access to local variable sink4 | access to local variable sink4 |
-| GlobalDataFlow.cs:140:15:140:19 | access to local variable sink5 | GlobalDataFlow.cs:17:27:17:40 | "taint source" | GlobalDataFlow.cs:140:15:140:19 | access to local variable sink5 | access to local variable sink5 |
-| GlobalDataFlow.cs:150:15:150:19 | access to local variable sink6 | GlobalDataFlow.cs:313:16:313:29 | "taint source" | GlobalDataFlow.cs:150:15:150:19 | access to local variable sink6 | access to local variable sink6 |
-| GlobalDataFlow.cs:153:15:153:19 | access to local variable sink7 | GlobalDataFlow.cs:318:13:318:26 | "taint source" | GlobalDataFlow.cs:153:15:153:19 | access to local variable sink7 | access to local variable sink7 |
-| GlobalDataFlow.cs:156:15:156:19 | access to local variable sink8 | GlobalDataFlow.cs:323:13:323:26 | "taint source" | GlobalDataFlow.cs:156:15:156:19 | access to local variable sink8 | access to local variable sink8 |
-| GlobalDataFlow.cs:177:15:177:19 | access to local variable sink9 | GlobalDataFlow.cs:175:35:175:48 | "taint source" | GlobalDataFlow.cs:177:15:177:19 | access to local variable sink9 | access to local variable sink9 |
+| GlobalDataFlow.cs:136:15:136:19 | access to local variable sink4 | GlobalDataFlow.cs:17:27:17:40 | "taint source" | GlobalDataFlow.cs:136:15:136:19 | access to local variable sink4 | access to local variable sink4 |
+| GlobalDataFlow.cs:144:15:144:19 | access to local variable sink5 | GlobalDataFlow.cs:17:27:17:40 | "taint source" | GlobalDataFlow.cs:144:15:144:19 | access to local variable sink5 | access to local variable sink5 |
+| GlobalDataFlow.cs:154:15:154:19 | access to local variable sink6 | GlobalDataFlow.cs:318:16:318:29 | "taint source" | GlobalDataFlow.cs:154:15:154:19 | access to local variable sink6 | access to local variable sink6 |
+| GlobalDataFlow.cs:157:15:157:19 | access to local variable sink7 | GlobalDataFlow.cs:323:13:323:26 | "taint source" | GlobalDataFlow.cs:157:15:157:19 | access to local variable sink7 | access to local variable sink7 |
+| GlobalDataFlow.cs:160:15:160:19 | access to local variable sink8 | GlobalDataFlow.cs:328:13:328:26 | "taint source" | GlobalDataFlow.cs:160:15:160:19 | access to local variable sink8 | access to local variable sink8 |
+| GlobalDataFlow.cs:181:15:181:19 | access to local variable sink9 | GlobalDataFlow.cs:179:35:179:48 | "taint source" | GlobalDataFlow.cs:181:15:181:19 | access to local variable sink9 | access to local variable sink9 |
 | Splitting.cs:11:19:11:19 | access to local variable x | Splitting.cs:3:28:3:34 | tainted | Splitting.cs:11:19:11:19 | access to local variable x | access to local variable x |
 | Splitting.cs:34:19:34:19 | access to local variable x | Splitting.cs:24:28:24:34 | tainted | Splitting.cs:34:19:34:19 | access to local variable x | access to local variable x |
-| GlobalDataFlow.cs:233:15:233:24 | access to parameter sinkParam0 | GlobalDataFlow.cs:17:27:17:40 | "taint source" | GlobalDataFlow.cs:233:15:233:24 | access to parameter sinkParam0 | access to parameter sinkParam0 |
-| GlobalDataFlow.cs:238:15:238:24 | access to parameter sinkParam1 | GlobalDataFlow.cs:17:27:17:40 | "taint source" | GlobalDataFlow.cs:238:15:238:24 | access to parameter sinkParam1 | access to parameter sinkParam1 |
+| GlobalDataFlow.cs:237:15:237:24 | access to parameter sinkParam0 | GlobalDataFlow.cs:17:27:17:40 | "taint source" | GlobalDataFlow.cs:237:15:237:24 | access to parameter sinkParam0 | access to parameter sinkParam0 |
+| GlobalDataFlow.cs:242:15:242:24 | access to parameter sinkParam1 | GlobalDataFlow.cs:17:27:17:40 | "taint source" | GlobalDataFlow.cs:242:15:242:24 | access to parameter sinkParam1 | access to parameter sinkParam1 |
 | GlobalDataFlow.cs:44:50:44:59 | access to parameter sinkParam2 | GlobalDataFlow.cs:17:27:17:40 | "taint source" | GlobalDataFlow.cs:44:50:44:59 | access to parameter sinkParam2 | access to parameter sinkParam2 |
-| GlobalDataFlow.cs:243:15:243:24 | access to parameter sinkParam3 | GlobalDataFlow.cs:17:27:17:40 | "taint source" | GlobalDataFlow.cs:243:15:243:24 | access to parameter sinkParam3 | access to parameter sinkParam3 |
-| GlobalDataFlow.cs:248:15:248:24 | access to parameter sinkParam4 | GlobalDataFlow.cs:17:27:17:40 | "taint source" | GlobalDataFlow.cs:248:15:248:24 | access to parameter sinkParam4 | access to parameter sinkParam4 |
-| GlobalDataFlow.cs:253:15:253:24 | access to parameter sinkParam5 | GlobalDataFlow.cs:17:27:17:40 | "taint source" | GlobalDataFlow.cs:253:15:253:24 | access to parameter sinkParam5 | access to parameter sinkParam5 |
-| GlobalDataFlow.cs:258:15:258:24 | access to parameter sinkParam6 | GlobalDataFlow.cs:17:27:17:40 | "taint source" | GlobalDataFlow.cs:258:15:258:24 | access to parameter sinkParam6 | access to parameter sinkParam6 |
-| GlobalDataFlow.cs:263:15:263:24 | access to parameter sinkParam7 | GlobalDataFlow.cs:17:27:17:40 | "taint source" | GlobalDataFlow.cs:263:15:263:24 | access to parameter sinkParam7 | access to parameter sinkParam7 |
+| GlobalDataFlow.cs:247:15:247:24 | access to parameter sinkParam3 | GlobalDataFlow.cs:17:27:17:40 | "taint source" | GlobalDataFlow.cs:247:15:247:24 | access to parameter sinkParam3 | access to parameter sinkParam3 |
+| GlobalDataFlow.cs:252:15:252:24 | access to parameter sinkParam4 | GlobalDataFlow.cs:17:27:17:40 | "taint source" | GlobalDataFlow.cs:252:15:252:24 | access to parameter sinkParam4 | access to parameter sinkParam4 |
+| GlobalDataFlow.cs:257:15:257:24 | access to parameter sinkParam5 | GlobalDataFlow.cs:17:27:17:40 | "taint source" | GlobalDataFlow.cs:257:15:257:24 | access to parameter sinkParam5 | access to parameter sinkParam5 |
+| GlobalDataFlow.cs:262:15:262:24 | access to parameter sinkParam6 | GlobalDataFlow.cs:17:27:17:40 | "taint source" | GlobalDataFlow.cs:262:15:262:24 | access to parameter sinkParam6 | access to parameter sinkParam6 |
+| GlobalDataFlow.cs:267:15:267:24 | access to parameter sinkParam7 | GlobalDataFlow.cs:17:27:17:40 | "taint source" | GlobalDataFlow.cs:267:15:267:24 | access to parameter sinkParam7 | access to parameter sinkParam7 |
 | Splitting.cs:21:28:21:32 | access to parameter value | Splitting.cs:24:28:24:34 | tainted | Splitting.cs:21:28:21:32 | access to parameter value | access to parameter value |
 | GlobalDataFlow.cs:26:15:26:32 | access to property SinkProperty0 | GlobalDataFlow.cs:17:27:17:40 | "taint source" | GlobalDataFlow.cs:26:15:26:32 | access to property SinkProperty0 | access to property SinkProperty0 |

--- a/csharp/ql/test/library-tests/dataflow/global/GetAnOutNode.expected
+++ b/csharp/ql/test/library-tests/dataflow/global/GetAnOutNode.expected
@@ -48,10 +48,10 @@
 | GlobalDataFlow.cs:70:28:70:45 | access to property SinkProperty0 | return | GlobalDataFlow.cs:70:28:70:45 | access to property SinkProperty0 |
 | GlobalDataFlow.cs:72:29:72:64 | call to method GetMethod | return | GlobalDataFlow.cs:72:29:72:64 | call to method GetMethod |
 | GlobalDataFlow.cs:72:29:72:101 | call to method Invoke | return | GlobalDataFlow.cs:72:29:72:101 | call to method Invoke |
-| GlobalDataFlow.cs:75:9:75:35 | call to method ReturnOut | out | GlobalDataFlow.cs:75:30:75:34 | SSA def(sink2) |
-| GlobalDataFlow.cs:75:9:75:35 | call to method ReturnOut | ref | GlobalDataFlow.cs:75:30:75:34 | SSA def(sink2) |
-| GlobalDataFlow.cs:78:9:78:35 | call to method ReturnRef | out | GlobalDataFlow.cs:78:30:78:34 | SSA def(sink3) |
-| GlobalDataFlow.cs:78:9:78:35 | call to method ReturnRef | ref | GlobalDataFlow.cs:78:30:78:34 | SSA def(sink3) |
+| GlobalDataFlow.cs:75:9:75:46 | call to method ReturnOut | out | GlobalDataFlow.cs:75:30:75:34 | SSA def(sink2) |
+| GlobalDataFlow.cs:75:9:75:46 | call to method ReturnOut | ref | GlobalDataFlow.cs:75:30:75:34 | SSA def(sink2) |
+| GlobalDataFlow.cs:78:9:78:46 | call to method ReturnRef | out | GlobalDataFlow.cs:78:30:78:34 | SSA def(sink3) |
+| GlobalDataFlow.cs:78:9:78:46 | call to method ReturnRef | ref | GlobalDataFlow.cs:78:30:78:34 | SSA def(sink3) |
 | GlobalDataFlow.cs:80:22:80:85 | call to method SelectEven | return | GlobalDataFlow.cs:80:22:80:85 | call to method SelectEven |
 | GlobalDataFlow.cs:80:22:80:85 | call to method SelectEven | yield return | GlobalDataFlow.cs:80:22:80:85 | call to method SelectEven |
 | GlobalDataFlow.cs:82:22:82:95 | call to method Select | return | GlobalDataFlow.cs:82:22:82:95 | call to method Select |
@@ -82,97 +82,100 @@
 | GlobalDataFlow.cs:100:24:100:33 | call to method Return | return | GlobalDataFlow.cs:100:24:100:33 | call to method Return |
 | GlobalDataFlow.cs:102:28:102:63 | call to method GetMethod | return | GlobalDataFlow.cs:102:28:102:63 | call to method GetMethod |
 | GlobalDataFlow.cs:102:28:102:103 | call to method Invoke | return | GlobalDataFlow.cs:102:28:102:103 | call to method Invoke |
-| GlobalDataFlow.cs:104:9:104:35 | call to method ReturnOut | out | GlobalDataFlow.cs:104:27:104:34 | SSA def(nonSink0) |
-| GlobalDataFlow.cs:104:9:104:35 | call to method ReturnOut | ref | GlobalDataFlow.cs:104:27:104:34 | SSA def(nonSink0) |
-| GlobalDataFlow.cs:106:9:106:35 | call to method ReturnRef | out | GlobalDataFlow.cs:106:27:106:34 | SSA def(nonSink0) |
-| GlobalDataFlow.cs:106:9:106:35 | call to method ReturnRef | ref | GlobalDataFlow.cs:106:27:106:34 | SSA def(nonSink0) |
-| GlobalDataFlow.cs:108:24:108:90 | call to method SelectEven | return | GlobalDataFlow.cs:108:24:108:90 | call to method SelectEven |
-| GlobalDataFlow.cs:108:24:108:90 | call to method SelectEven | yield return | GlobalDataFlow.cs:108:24:108:90 | call to method SelectEven |
-| GlobalDataFlow.cs:110:20:110:82 | call to method Select | return | GlobalDataFlow.cs:110:20:110:82 | call to method Select |
-| GlobalDataFlow.cs:110:20:110:82 | call to method Select | yield return | GlobalDataFlow.cs:110:20:110:82 | call to method Select |
-| GlobalDataFlow.cs:110:76:110:81 | [implicit call] (...) => ... | return | GlobalDataFlow.cs:110:76:110:81 | [output] (...) => ... |
-| GlobalDataFlow.cs:112:20:112:134 | call to method Zip | return | GlobalDataFlow.cs:112:20:112:134 | call to method Zip |
-| GlobalDataFlow.cs:112:20:112:134 | call to method Zip | yield return | GlobalDataFlow.cs:112:20:112:134 | call to method Zip |
-| GlobalDataFlow.cs:112:57:112:70 | call to method First | return | GlobalDataFlow.cs:112:57:112:70 | call to method First |
-| GlobalDataFlow.cs:112:123:112:133 | [implicit call] (...) => ... | return | GlobalDataFlow.cs:112:123:112:133 | [output] (...) => ... |
-| GlobalDataFlow.cs:114:20:114:134 | call to method Zip | return | GlobalDataFlow.cs:114:20:114:134 | call to method Zip |
-| GlobalDataFlow.cs:114:20:114:134 | call to method Zip | yield return | GlobalDataFlow.cs:114:20:114:134 | call to method Zip |
-| GlobalDataFlow.cs:114:104:114:117 | call to method First | return | GlobalDataFlow.cs:114:104:114:117 | call to method First |
-| GlobalDataFlow.cs:114:123:114:133 | [implicit call] (...) => ... | return | GlobalDataFlow.cs:114:123:114:133 | [output] (...) => ... |
-| GlobalDataFlow.cs:116:20:116:64 | call to method Aggregate | return | GlobalDataFlow.cs:116:20:116:64 | call to method Aggregate |
-| GlobalDataFlow.cs:116:41:116:55 | [implicit call] (...) => ... | return | GlobalDataFlow.cs:116:41:116:55 | [output] (...) => ... |
-| GlobalDataFlow.cs:116:58:116:63 | [implicit call] (...) => ... | return | GlobalDataFlow.cs:116:58:116:63 | [output] (...) => ... |
-| GlobalDataFlow.cs:118:20:118:69 | call to method Aggregate | return | GlobalDataFlow.cs:118:20:118:69 | call to method Aggregate |
-| GlobalDataFlow.cs:118:41:118:59 | [implicit call] (...) => ... | return | GlobalDataFlow.cs:118:41:118:59 | [output] (...) => ... |
-| GlobalDataFlow.cs:118:62:118:68 | [implicit call] (...) => ... | return | GlobalDataFlow.cs:118:62:118:68 | [output] (...) => ... |
-| GlobalDataFlow.cs:120:20:120:67 | call to method Aggregate | return | GlobalDataFlow.cs:120:20:120:67 | call to method Aggregate |
-| GlobalDataFlow.cs:120:46:120:58 | [implicit call] (...) => ... | return | GlobalDataFlow.cs:120:46:120:58 | [output] (...) => ... |
-| GlobalDataFlow.cs:120:61:120:66 | [implicit call] (...) => ... | return | GlobalDataFlow.cs:120:61:120:66 | [output] (...) => ... |
-| GlobalDataFlow.cs:123:9:123:46 | call to method TryParse | out | GlobalDataFlow.cs:123:38:123:45 | SSA def(nonSink2) |
-| GlobalDataFlow.cs:123:9:123:46 | call to method TryParse | ref | GlobalDataFlow.cs:123:38:123:45 | SSA def(nonSink2) |
-| GlobalDataFlow.cs:123:9:123:46 | call to method TryParse | return | GlobalDataFlow.cs:123:9:123:46 | call to method TryParse |
-| GlobalDataFlow.cs:126:9:126:45 | call to method TryParse | out | GlobalDataFlow.cs:126:37:126:44 | SSA def(nonSink3) |
-| GlobalDataFlow.cs:126:9:126:45 | call to method TryParse | ref | GlobalDataFlow.cs:126:37:126:44 | SSA def(nonSink3) |
-| GlobalDataFlow.cs:126:9:126:45 | call to method TryParse | return | GlobalDataFlow.cs:126:9:126:45 | call to method TryParse |
-| GlobalDataFlow.cs:130:45:130:64 | call to method ApplyFunc | return | GlobalDataFlow.cs:130:45:130:64 | call to method ApplyFunc |
-| GlobalDataFlow.cs:131:21:131:34 | delegate call | return | GlobalDataFlow.cs:131:21:131:34 | delegate call |
-| GlobalDataFlow.cs:135:20:135:36 | delegate call | return | GlobalDataFlow.cs:135:20:135:36 | delegate call |
-| GlobalDataFlow.cs:139:21:139:44 | call to method ApplyFunc | return | GlobalDataFlow.cs:139:21:139:44 | call to method ApplyFunc |
-| GlobalDataFlow.cs:143:20:143:40 | call to method ApplyFunc | return | GlobalDataFlow.cs:143:20:143:40 | call to method ApplyFunc |
-| GlobalDataFlow.cs:145:20:145:44 | call to method ApplyFunc | return | GlobalDataFlow.cs:145:20:145:44 | call to method ApplyFunc |
-| GlobalDataFlow.cs:149:21:149:25 | call to method Out | return | GlobalDataFlow.cs:149:21:149:25 | call to method Out |
-| GlobalDataFlow.cs:152:9:152:25 | call to method OutOut | out | GlobalDataFlow.cs:152:20:152:24 | SSA def(sink7) |
-| GlobalDataFlow.cs:152:9:152:25 | call to method OutOut | ref | GlobalDataFlow.cs:152:20:152:24 | SSA def(sink7) |
-| GlobalDataFlow.cs:155:9:155:25 | call to method OutRef | out | GlobalDataFlow.cs:155:20:155:24 | SSA def(sink8) |
-| GlobalDataFlow.cs:155:9:155:25 | call to method OutRef | ref | GlobalDataFlow.cs:155:20:155:24 | SSA def(sink8) |
-| GlobalDataFlow.cs:157:22:157:31 | call to method OutYield | return | GlobalDataFlow.cs:157:22:157:31 | call to method OutYield |
-| GlobalDataFlow.cs:157:22:157:31 | call to method OutYield | yield return | GlobalDataFlow.cs:157:22:157:31 | call to method OutYield |
-| GlobalDataFlow.cs:159:22:159:43 | call to method TaintedParam | return | GlobalDataFlow.cs:159:22:159:43 | call to method TaintedParam |
-| GlobalDataFlow.cs:163:20:163:27 | call to method NonOut | return | GlobalDataFlow.cs:163:20:163:27 | call to method NonOut |
-| GlobalDataFlow.cs:165:9:165:31 | call to method NonOutOut | out | GlobalDataFlow.cs:165:23:165:30 | SSA def(nonSink0) |
-| GlobalDataFlow.cs:165:9:165:31 | call to method NonOutOut | ref | GlobalDataFlow.cs:165:23:165:30 | SSA def(nonSink0) |
-| GlobalDataFlow.cs:167:9:167:31 | call to method NonOutRef | out | GlobalDataFlow.cs:167:23:167:30 | SSA def(nonSink0) |
-| GlobalDataFlow.cs:167:9:167:31 | call to method NonOutRef | ref | GlobalDataFlow.cs:167:23:167:30 | SSA def(nonSink0) |
-| GlobalDataFlow.cs:169:20:169:32 | call to method NonOutYield | return | GlobalDataFlow.cs:169:20:169:32 | call to method NonOutYield |
-| GlobalDataFlow.cs:169:20:169:32 | call to method NonOutYield | yield return | GlobalDataFlow.cs:169:20:169:32 | call to method NonOutYield |
-| GlobalDataFlow.cs:169:20:169:40 | call to method First | return | GlobalDataFlow.cs:169:20:169:40 | call to method First |
-| GlobalDataFlow.cs:171:20:171:44 | call to method NonTaintedParam | return | GlobalDataFlow.cs:171:20:171:44 | call to method NonTaintedParam |
-| GlobalDataFlow.cs:176:21:176:26 | delegate call | return | GlobalDataFlow.cs:176:21:176:26 | delegate call |
-| GlobalDataFlow.cs:181:20:181:27 | delegate call | return | GlobalDataFlow.cs:181:20:181:27 | delegate call |
-| GlobalDataFlow.cs:185:22:185:42 | object creation of type Lazy<String> | return | GlobalDataFlow.cs:185:22:185:42 | object creation of type Lazy<String> |
-| GlobalDataFlow.cs:185:22:185:48 | access to property Value | return | GlobalDataFlow.cs:185:22:185:48 | access to property Value |
-| GlobalDataFlow.cs:185:39:185:41 | [implicit call] delegate creation of type Func<String> | return | GlobalDataFlow.cs:185:39:185:41 | [output] delegate creation of type Func<String> |
-| GlobalDataFlow.cs:189:20:189:43 | object creation of type Lazy<String> | return | GlobalDataFlow.cs:189:20:189:43 | object creation of type Lazy<String> |
-| GlobalDataFlow.cs:189:20:189:49 | access to property Value | return | GlobalDataFlow.cs:189:20:189:49 | access to property Value |
-| GlobalDataFlow.cs:189:37:189:42 | [implicit call] delegate creation of type Func<String> | return | GlobalDataFlow.cs:189:37:189:42 | [output] delegate creation of type Func<String> |
-| GlobalDataFlow.cs:193:22:193:32 | access to property OutProperty | return | GlobalDataFlow.cs:193:22:193:32 | access to property OutProperty |
-| GlobalDataFlow.cs:197:20:197:33 | access to property NonOutProperty | return | GlobalDataFlow.cs:197:20:197:33 | access to property NonOutProperty |
-| GlobalDataFlow.cs:205:76:205:90 | call to method ReturnCheck2 | return | GlobalDataFlow.cs:205:76:205:90 | call to method ReturnCheck2 |
-| GlobalDataFlow.cs:206:22:206:39 | call to method Select | return | GlobalDataFlow.cs:206:22:206:39 | call to method Select |
-| GlobalDataFlow.cs:206:22:206:39 | call to method Select | yield return | GlobalDataFlow.cs:206:22:206:39 | call to method Select |
-| GlobalDataFlow.cs:206:37:206:38 | [implicit call] access to local variable f1 | return | GlobalDataFlow.cs:206:37:206:38 | [output] access to local variable f1 |
-| GlobalDataFlow.cs:208:22:208:39 | call to method Select | return | GlobalDataFlow.cs:208:22:208:39 | call to method Select |
-| GlobalDataFlow.cs:208:37:208:38 | [implicit call] access to local variable f2 | return | GlobalDataFlow.cs:208:37:208:38 | [output] access to local variable f2 |
-| GlobalDataFlow.cs:210:22:210:49 | call to method Select | return | GlobalDataFlow.cs:210:22:210:49 | call to method Select |
-| GlobalDataFlow.cs:210:22:210:49 | call to method Select | yield return | GlobalDataFlow.cs:210:22:210:49 | call to method Select |
-| GlobalDataFlow.cs:210:37:210:48 | [implicit call] delegate creation of type Func<String,String> | return | GlobalDataFlow.cs:210:37:210:48 | [output] delegate creation of type Func<String,String> |
-| GlobalDataFlow.cs:215:76:215:92 | call to method NonReturnCheck | return | GlobalDataFlow.cs:215:76:215:92 | call to method NonReturnCheck |
-| GlobalDataFlow.cs:216:23:216:43 | call to method Select | return | GlobalDataFlow.cs:216:23:216:43 | call to method Select |
-| GlobalDataFlow.cs:216:23:216:43 | call to method Select | yield return | GlobalDataFlow.cs:216:23:216:43 | call to method Select |
-| GlobalDataFlow.cs:216:41:216:42 | [implicit call] access to local variable f1 | return | GlobalDataFlow.cs:216:41:216:42 | [output] access to local variable f1 |
-| GlobalDataFlow.cs:218:19:218:39 | call to method Select | return | GlobalDataFlow.cs:218:19:218:39 | call to method Select |
-| GlobalDataFlow.cs:218:37:218:38 | [implicit call] access to local variable f2 | return | GlobalDataFlow.cs:218:37:218:38 | [output] access to local variable f2 |
-| GlobalDataFlow.cs:220:19:220:39 | call to method Select | return | GlobalDataFlow.cs:220:19:220:39 | call to method Select |
-| GlobalDataFlow.cs:220:19:220:39 | call to method Select | yield return | GlobalDataFlow.cs:220:19:220:39 | call to method Select |
-| GlobalDataFlow.cs:220:37:220:38 | [implicit call] access to local variable f3 | return | GlobalDataFlow.cs:220:37:220:38 | [output] access to local variable f3 |
+| GlobalDataFlow.cs:104:9:104:46 | call to method ReturnOut | out | GlobalDataFlow.cs:104:27:104:34 | SSA def(nonSink0) |
+| GlobalDataFlow.cs:104:9:104:46 | call to method ReturnOut | ref | GlobalDataFlow.cs:104:27:104:34 | SSA def(nonSink0) |
+| GlobalDataFlow.cs:106:9:106:49 | call to method ReturnOut | out | GlobalDataFlow.cs:106:41:106:48 | SSA def(nonSink0) |
+| GlobalDataFlow.cs:108:9:108:49 | call to method ReturnRef | out | GlobalDataFlow.cs:108:27:108:34 | SSA def(nonSink0) |
+| GlobalDataFlow.cs:108:9:108:49 | call to method ReturnRef | ref | GlobalDataFlow.cs:108:27:108:34 | SSA def(nonSink0) |
+| GlobalDataFlow.cs:110:9:110:49 | call to method ReturnRef | out | GlobalDataFlow.cs:110:30:110:34 | SSA def(sink1) |
+| GlobalDataFlow.cs:110:9:110:49 | call to method ReturnRef | ref | GlobalDataFlow.cs:110:30:110:34 | SSA def(sink1) |
+| GlobalDataFlow.cs:112:24:112:90 | call to method SelectEven | return | GlobalDataFlow.cs:112:24:112:90 | call to method SelectEven |
+| GlobalDataFlow.cs:112:24:112:90 | call to method SelectEven | yield return | GlobalDataFlow.cs:112:24:112:90 | call to method SelectEven |
+| GlobalDataFlow.cs:114:20:114:82 | call to method Select | return | GlobalDataFlow.cs:114:20:114:82 | call to method Select |
+| GlobalDataFlow.cs:114:20:114:82 | call to method Select | yield return | GlobalDataFlow.cs:114:20:114:82 | call to method Select |
+| GlobalDataFlow.cs:114:76:114:81 | [implicit call] (...) => ... | return | GlobalDataFlow.cs:114:76:114:81 | [output] (...) => ... |
+| GlobalDataFlow.cs:116:20:116:134 | call to method Zip | return | GlobalDataFlow.cs:116:20:116:134 | call to method Zip |
+| GlobalDataFlow.cs:116:20:116:134 | call to method Zip | yield return | GlobalDataFlow.cs:116:20:116:134 | call to method Zip |
+| GlobalDataFlow.cs:116:57:116:70 | call to method First | return | GlobalDataFlow.cs:116:57:116:70 | call to method First |
+| GlobalDataFlow.cs:116:123:116:133 | [implicit call] (...) => ... | return | GlobalDataFlow.cs:116:123:116:133 | [output] (...) => ... |
+| GlobalDataFlow.cs:118:20:118:134 | call to method Zip | return | GlobalDataFlow.cs:118:20:118:134 | call to method Zip |
+| GlobalDataFlow.cs:118:20:118:134 | call to method Zip | yield return | GlobalDataFlow.cs:118:20:118:134 | call to method Zip |
+| GlobalDataFlow.cs:118:104:118:117 | call to method First | return | GlobalDataFlow.cs:118:104:118:117 | call to method First |
+| GlobalDataFlow.cs:118:123:118:133 | [implicit call] (...) => ... | return | GlobalDataFlow.cs:118:123:118:133 | [output] (...) => ... |
+| GlobalDataFlow.cs:120:20:120:64 | call to method Aggregate | return | GlobalDataFlow.cs:120:20:120:64 | call to method Aggregate |
+| GlobalDataFlow.cs:120:41:120:55 | [implicit call] (...) => ... | return | GlobalDataFlow.cs:120:41:120:55 | [output] (...) => ... |
+| GlobalDataFlow.cs:120:58:120:63 | [implicit call] (...) => ... | return | GlobalDataFlow.cs:120:58:120:63 | [output] (...) => ... |
+| GlobalDataFlow.cs:122:20:122:69 | call to method Aggregate | return | GlobalDataFlow.cs:122:20:122:69 | call to method Aggregate |
+| GlobalDataFlow.cs:122:41:122:59 | [implicit call] (...) => ... | return | GlobalDataFlow.cs:122:41:122:59 | [output] (...) => ... |
+| GlobalDataFlow.cs:122:62:122:68 | [implicit call] (...) => ... | return | GlobalDataFlow.cs:122:62:122:68 | [output] (...) => ... |
+| GlobalDataFlow.cs:124:20:124:67 | call to method Aggregate | return | GlobalDataFlow.cs:124:20:124:67 | call to method Aggregate |
+| GlobalDataFlow.cs:124:46:124:58 | [implicit call] (...) => ... | return | GlobalDataFlow.cs:124:46:124:58 | [output] (...) => ... |
+| GlobalDataFlow.cs:124:61:124:66 | [implicit call] (...) => ... | return | GlobalDataFlow.cs:124:61:124:66 | [output] (...) => ... |
+| GlobalDataFlow.cs:127:9:127:46 | call to method TryParse | out | GlobalDataFlow.cs:127:38:127:45 | SSA def(nonSink2) |
+| GlobalDataFlow.cs:127:9:127:46 | call to method TryParse | ref | GlobalDataFlow.cs:127:38:127:45 | SSA def(nonSink2) |
+| GlobalDataFlow.cs:127:9:127:46 | call to method TryParse | return | GlobalDataFlow.cs:127:9:127:46 | call to method TryParse |
+| GlobalDataFlow.cs:130:9:130:45 | call to method TryParse | out | GlobalDataFlow.cs:130:37:130:44 | SSA def(nonSink3) |
+| GlobalDataFlow.cs:130:9:130:45 | call to method TryParse | ref | GlobalDataFlow.cs:130:37:130:44 | SSA def(nonSink3) |
+| GlobalDataFlow.cs:130:9:130:45 | call to method TryParse | return | GlobalDataFlow.cs:130:9:130:45 | call to method TryParse |
+| GlobalDataFlow.cs:134:45:134:64 | call to method ApplyFunc | return | GlobalDataFlow.cs:134:45:134:64 | call to method ApplyFunc |
+| GlobalDataFlow.cs:135:21:135:34 | delegate call | return | GlobalDataFlow.cs:135:21:135:34 | delegate call |
+| GlobalDataFlow.cs:139:20:139:36 | delegate call | return | GlobalDataFlow.cs:139:20:139:36 | delegate call |
+| GlobalDataFlow.cs:143:21:143:44 | call to method ApplyFunc | return | GlobalDataFlow.cs:143:21:143:44 | call to method ApplyFunc |
+| GlobalDataFlow.cs:147:20:147:40 | call to method ApplyFunc | return | GlobalDataFlow.cs:147:20:147:40 | call to method ApplyFunc |
+| GlobalDataFlow.cs:149:20:149:44 | call to method ApplyFunc | return | GlobalDataFlow.cs:149:20:149:44 | call to method ApplyFunc |
+| GlobalDataFlow.cs:153:21:153:25 | call to method Out | return | GlobalDataFlow.cs:153:21:153:25 | call to method Out |
+| GlobalDataFlow.cs:156:9:156:25 | call to method OutOut | out | GlobalDataFlow.cs:156:20:156:24 | SSA def(sink7) |
+| GlobalDataFlow.cs:156:9:156:25 | call to method OutOut | ref | GlobalDataFlow.cs:156:20:156:24 | SSA def(sink7) |
+| GlobalDataFlow.cs:159:9:159:25 | call to method OutRef | out | GlobalDataFlow.cs:159:20:159:24 | SSA def(sink8) |
+| GlobalDataFlow.cs:159:9:159:25 | call to method OutRef | ref | GlobalDataFlow.cs:159:20:159:24 | SSA def(sink8) |
+| GlobalDataFlow.cs:161:22:161:31 | call to method OutYield | return | GlobalDataFlow.cs:161:22:161:31 | call to method OutYield |
+| GlobalDataFlow.cs:161:22:161:31 | call to method OutYield | yield return | GlobalDataFlow.cs:161:22:161:31 | call to method OutYield |
+| GlobalDataFlow.cs:163:22:163:43 | call to method TaintedParam | return | GlobalDataFlow.cs:163:22:163:43 | call to method TaintedParam |
+| GlobalDataFlow.cs:167:20:167:27 | call to method NonOut | return | GlobalDataFlow.cs:167:20:167:27 | call to method NonOut |
+| GlobalDataFlow.cs:169:9:169:31 | call to method NonOutOut | out | GlobalDataFlow.cs:169:23:169:30 | SSA def(nonSink0) |
+| GlobalDataFlow.cs:169:9:169:31 | call to method NonOutOut | ref | GlobalDataFlow.cs:169:23:169:30 | SSA def(nonSink0) |
+| GlobalDataFlow.cs:171:9:171:31 | call to method NonOutRef | out | GlobalDataFlow.cs:171:23:171:30 | SSA def(nonSink0) |
+| GlobalDataFlow.cs:171:9:171:31 | call to method NonOutRef | ref | GlobalDataFlow.cs:171:23:171:30 | SSA def(nonSink0) |
+| GlobalDataFlow.cs:173:20:173:32 | call to method NonOutYield | return | GlobalDataFlow.cs:173:20:173:32 | call to method NonOutYield |
+| GlobalDataFlow.cs:173:20:173:32 | call to method NonOutYield | yield return | GlobalDataFlow.cs:173:20:173:32 | call to method NonOutYield |
+| GlobalDataFlow.cs:173:20:173:40 | call to method First | return | GlobalDataFlow.cs:173:20:173:40 | call to method First |
+| GlobalDataFlow.cs:175:20:175:44 | call to method NonTaintedParam | return | GlobalDataFlow.cs:175:20:175:44 | call to method NonTaintedParam |
+| GlobalDataFlow.cs:180:21:180:26 | delegate call | return | GlobalDataFlow.cs:180:21:180:26 | delegate call |
+| GlobalDataFlow.cs:185:20:185:27 | delegate call | return | GlobalDataFlow.cs:185:20:185:27 | delegate call |
+| GlobalDataFlow.cs:189:22:189:42 | object creation of type Lazy<String> | return | GlobalDataFlow.cs:189:22:189:42 | object creation of type Lazy<String> |
+| GlobalDataFlow.cs:189:22:189:48 | access to property Value | return | GlobalDataFlow.cs:189:22:189:48 | access to property Value |
+| GlobalDataFlow.cs:189:39:189:41 | [implicit call] delegate creation of type Func<String> | return | GlobalDataFlow.cs:189:39:189:41 | [output] delegate creation of type Func<String> |
+| GlobalDataFlow.cs:193:20:193:43 | object creation of type Lazy<String> | return | GlobalDataFlow.cs:193:20:193:43 | object creation of type Lazy<String> |
+| GlobalDataFlow.cs:193:20:193:49 | access to property Value | return | GlobalDataFlow.cs:193:20:193:49 | access to property Value |
+| GlobalDataFlow.cs:193:37:193:42 | [implicit call] delegate creation of type Func<String> | return | GlobalDataFlow.cs:193:37:193:42 | [output] delegate creation of type Func<String> |
+| GlobalDataFlow.cs:197:22:197:32 | access to property OutProperty | return | GlobalDataFlow.cs:197:22:197:32 | access to property OutProperty |
+| GlobalDataFlow.cs:201:20:201:33 | access to property NonOutProperty | return | GlobalDataFlow.cs:201:20:201:33 | access to property NonOutProperty |
+| GlobalDataFlow.cs:209:76:209:90 | call to method ReturnCheck2 | return | GlobalDataFlow.cs:209:76:209:90 | call to method ReturnCheck2 |
+| GlobalDataFlow.cs:210:22:210:39 | call to method Select | return | GlobalDataFlow.cs:210:22:210:39 | call to method Select |
+| GlobalDataFlow.cs:210:22:210:39 | call to method Select | yield return | GlobalDataFlow.cs:210:22:210:39 | call to method Select |
+| GlobalDataFlow.cs:210:37:210:38 | [implicit call] access to local variable f1 | return | GlobalDataFlow.cs:210:37:210:38 | [output] access to local variable f1 |
+| GlobalDataFlow.cs:212:22:212:39 | call to method Select | return | GlobalDataFlow.cs:212:22:212:39 | call to method Select |
+| GlobalDataFlow.cs:212:37:212:38 | [implicit call] access to local variable f2 | return | GlobalDataFlow.cs:212:37:212:38 | [output] access to local variable f2 |
+| GlobalDataFlow.cs:214:22:214:49 | call to method Select | return | GlobalDataFlow.cs:214:22:214:49 | call to method Select |
+| GlobalDataFlow.cs:214:22:214:49 | call to method Select | yield return | GlobalDataFlow.cs:214:22:214:49 | call to method Select |
+| GlobalDataFlow.cs:214:37:214:48 | [implicit call] delegate creation of type Func<String,String> | return | GlobalDataFlow.cs:214:37:214:48 | [output] delegate creation of type Func<String,String> |
+| GlobalDataFlow.cs:219:76:219:92 | call to method NonReturnCheck | return | GlobalDataFlow.cs:219:76:219:92 | call to method NonReturnCheck |
+| GlobalDataFlow.cs:220:23:220:43 | call to method Select | return | GlobalDataFlow.cs:220:23:220:43 | call to method Select |
+| GlobalDataFlow.cs:220:23:220:43 | call to method Select | yield return | GlobalDataFlow.cs:220:23:220:43 | call to method Select |
+| GlobalDataFlow.cs:220:41:220:42 | [implicit call] access to local variable f1 | return | GlobalDataFlow.cs:220:41:220:42 | [output] access to local variable f1 |
 | GlobalDataFlow.cs:222:19:222:39 | call to method Select | return | GlobalDataFlow.cs:222:19:222:39 | call to method Select |
-| GlobalDataFlow.cs:222:37:222:38 | [implicit call] access to local variable f4 | return | GlobalDataFlow.cs:222:37:222:38 | [output] access to local variable f4 |
-| GlobalDataFlow.cs:224:19:224:49 | call to method Select | return | GlobalDataFlow.cs:224:19:224:49 | call to method Select |
-| GlobalDataFlow.cs:224:19:224:49 | call to method Select | yield return | GlobalDataFlow.cs:224:19:224:49 | call to method Select |
-| GlobalDataFlow.cs:224:37:224:48 | [implicit call] delegate creation of type Func<String,String> | return | GlobalDataFlow.cs:224:37:224:48 | [output] delegate creation of type Func<String,String> |
-| GlobalDataFlow.cs:273:17:273:38 | call to method ApplyFunc | return | GlobalDataFlow.cs:273:17:273:38 | call to method ApplyFunc |
-| GlobalDataFlow.cs:361:16:361:19 | delegate call | return | GlobalDataFlow.cs:361:16:361:19 | delegate call |
-| GlobalDataFlow.cs:426:44:426:47 | delegate call | return | GlobalDataFlow.cs:426:44:426:47 | delegate call |
+| GlobalDataFlow.cs:222:37:222:38 | [implicit call] access to local variable f2 | return | GlobalDataFlow.cs:222:37:222:38 | [output] access to local variable f2 |
+| GlobalDataFlow.cs:224:19:224:39 | call to method Select | return | GlobalDataFlow.cs:224:19:224:39 | call to method Select |
+| GlobalDataFlow.cs:224:19:224:39 | call to method Select | yield return | GlobalDataFlow.cs:224:19:224:39 | call to method Select |
+| GlobalDataFlow.cs:224:37:224:38 | [implicit call] access to local variable f3 | return | GlobalDataFlow.cs:224:37:224:38 | [output] access to local variable f3 |
+| GlobalDataFlow.cs:226:19:226:39 | call to method Select | return | GlobalDataFlow.cs:226:19:226:39 | call to method Select |
+| GlobalDataFlow.cs:226:37:226:38 | [implicit call] access to local variable f4 | return | GlobalDataFlow.cs:226:37:226:38 | [output] access to local variable f4 |
+| GlobalDataFlow.cs:228:19:228:49 | call to method Select | return | GlobalDataFlow.cs:228:19:228:49 | call to method Select |
+| GlobalDataFlow.cs:228:19:228:49 | call to method Select | yield return | GlobalDataFlow.cs:228:19:228:49 | call to method Select |
+| GlobalDataFlow.cs:228:37:228:48 | [implicit call] delegate creation of type Func<String,String> | return | GlobalDataFlow.cs:228:37:228:48 | [output] delegate creation of type Func<String,String> |
+| GlobalDataFlow.cs:277:17:277:38 | call to method ApplyFunc | return | GlobalDataFlow.cs:277:17:277:38 | call to method ApplyFunc |
+| GlobalDataFlow.cs:366:16:366:19 | delegate call | return | GlobalDataFlow.cs:366:16:366:19 | delegate call |
+| GlobalDataFlow.cs:431:44:431:47 | delegate call | return | GlobalDataFlow.cs:431:44:431:47 | delegate call |
 | Splitting.cs:8:17:8:31 | [b (line 3): false] call to method Return | return | Splitting.cs:8:17:8:31 | [b (line 3): false] call to method Return |
 | Splitting.cs:8:17:8:31 | [b (line 3): true] call to method Return | return | Splitting.cs:8:17:8:31 | [b (line 3): true] call to method Return |
 | Splitting.cs:20:22:20:30 | call to method Return | return | Splitting.cs:20:22:20:30 | call to method Return |

--- a/csharp/ql/test/library-tests/dataflow/global/GlobalDataFlow.cs
+++ b/csharp/ql/test/library-tests/dataflow/global/GlobalDataFlow.cs
@@ -72,10 +72,10 @@ public class DataFlow
         var sink1 = (string)typeof(DataFlow).GetMethod("Return").Invoke(null, new object[] { sink0 });
         Check(sink1);
         string sink2;
-        ReturnOut(sink1, out sink2);
+        ReturnOut(sink1, out sink2, out var _);
         Check(sink2);
         var sink3 = "";
-        ReturnRef(sink2, ref sink3);
+        ReturnRef(sink2, ref sink3, ref sink3);
         Check(sink3);
         var sink13 = ((IEnumerable<string>)new string[] { sink3 }).SelectEven(x => x);
         Check(sink13);
@@ -101,9 +101,13 @@ public class DataFlow
         Check(nonSink0);
         nonSink0 = (string)typeof(DataFlow).GetMethod("Return").Invoke(null, new object[] { nonSink0 });
         Check(nonSink0);
-        ReturnOut("", out nonSink0);
+        ReturnOut("", out nonSink0, out var _);
         Check(nonSink0);
-        ReturnRef("", ref nonSink0);
+        ReturnOut(sink1, out var _, out nonSink0);
+        Check(nonSink0);
+        ReturnRef("", ref nonSink0, ref nonSink0);
+        Check(nonSink0);
+        ReturnRef(sink1, ref sink1, ref nonSink0);
         Check(nonSink0);
         var nonSink1 = ((IEnumerable<string>)new string[] { nonSink0 }).SelectEven(x => x);
         Check(nonSink1);
@@ -274,12 +278,13 @@ public class DataFlow
         return y == null ? default(T) : y;
     }
 
-    static void ReturnOut<T>(T x, out T y)
+    static void ReturnOut<T>(T x, out T y, out T z)
     {
         y = x;
+        z = default(T);
     }
 
-    static void ReturnRef<T>(T x, ref T y)
+    static void ReturnRef<T>(T x, ref T y, ref T z)
     {
         y = x;
     }

--- a/csharp/ql/test/library-tests/dataflow/global/TaintTracking.expected
+++ b/csharp/ql/test/library-tests/dataflow/global/TaintTracking.expected
@@ -25,32 +25,37 @@
 | GlobalDataFlow.cs:91:15:91:20 | access to local variable sink18 |
 | GlobalDataFlow.cs:94:15:94:20 | access to local variable sink21 |
 | GlobalDataFlow.cs:97:15:97:20 | access to local variable sink22 |
-| GlobalDataFlow.cs:132:15:132:19 | access to local variable sink4 |
-| GlobalDataFlow.cs:140:15:140:19 | access to local variable sink5 |
-| GlobalDataFlow.cs:150:15:150:19 | access to local variable sink6 |
-| GlobalDataFlow.cs:153:15:153:19 | access to local variable sink7 |
-| GlobalDataFlow.cs:156:15:156:19 | access to local variable sink8 |
-| GlobalDataFlow.cs:158:15:158:20 | access to local variable sink12 |
-| GlobalDataFlow.cs:160:15:160:20 | access to local variable sink23 |
-| GlobalDataFlow.cs:177:15:177:19 | access to local variable sink9 |
-| GlobalDataFlow.cs:186:15:186:20 | access to local variable sink10 |
-| GlobalDataFlow.cs:194:15:194:20 | access to local variable sink19 |
-| GlobalDataFlow.cs:204:58:204:68 | access to parameter sinkParam10 |
-| GlobalDataFlow.cs:207:15:207:20 | access to local variable sink24 |
-| GlobalDataFlow.cs:209:15:209:20 | access to local variable sink25 |
-| GlobalDataFlow.cs:211:15:211:20 | access to local variable sink26 |
-| GlobalDataFlow.cs:233:15:233:24 | access to parameter sinkParam0 |
-| GlobalDataFlow.cs:238:15:238:24 | access to parameter sinkParam1 |
-| GlobalDataFlow.cs:243:15:243:24 | access to parameter sinkParam3 |
-| GlobalDataFlow.cs:248:15:248:24 | access to parameter sinkParam4 |
-| GlobalDataFlow.cs:253:15:253:24 | access to parameter sinkParam5 |
-| GlobalDataFlow.cs:258:15:258:24 | access to parameter sinkParam6 |
-| GlobalDataFlow.cs:263:15:263:24 | access to parameter sinkParam7 |
-| GlobalDataFlow.cs:289:15:289:24 | access to parameter sinkParam8 |
-| GlobalDataFlow.cs:295:15:295:24 | access to parameter sinkParam9 |
-| GlobalDataFlow.cs:301:15:301:25 | access to parameter sinkParam11 |
-| GlobalDataFlow.cs:376:15:376:20 | access to local variable sink11 |
-| GlobalDataFlow.cs:399:41:399:46 | access to local variable sink20 |
+| GlobalDataFlow.cs:107:15:107:22 | access to local variable nonSink0 |
+| GlobalDataFlow.cs:109:15:109:22 | access to local variable nonSink0 |
+| GlobalDataFlow.cs:111:15:111:22 | access to local variable nonSink0 |
+| GlobalDataFlow.cs:113:15:113:22 | access to local variable nonSink1 |
+| GlobalDataFlow.cs:115:15:115:22 | access to local variable nonSink1 |
+| GlobalDataFlow.cs:136:15:136:19 | access to local variable sink4 |
+| GlobalDataFlow.cs:144:15:144:19 | access to local variable sink5 |
+| GlobalDataFlow.cs:154:15:154:19 | access to local variable sink6 |
+| GlobalDataFlow.cs:157:15:157:19 | access to local variable sink7 |
+| GlobalDataFlow.cs:160:15:160:19 | access to local variable sink8 |
+| GlobalDataFlow.cs:162:15:162:20 | access to local variable sink12 |
+| GlobalDataFlow.cs:164:15:164:20 | access to local variable sink23 |
+| GlobalDataFlow.cs:181:15:181:19 | access to local variable sink9 |
+| GlobalDataFlow.cs:190:15:190:20 | access to local variable sink10 |
+| GlobalDataFlow.cs:198:15:198:20 | access to local variable sink19 |
+| GlobalDataFlow.cs:208:58:208:68 | access to parameter sinkParam10 |
+| GlobalDataFlow.cs:211:15:211:20 | access to local variable sink24 |
+| GlobalDataFlow.cs:213:15:213:20 | access to local variable sink25 |
+| GlobalDataFlow.cs:215:15:215:20 | access to local variable sink26 |
+| GlobalDataFlow.cs:237:15:237:24 | access to parameter sinkParam0 |
+| GlobalDataFlow.cs:242:15:242:24 | access to parameter sinkParam1 |
+| GlobalDataFlow.cs:247:15:247:24 | access to parameter sinkParam3 |
+| GlobalDataFlow.cs:252:15:252:24 | access to parameter sinkParam4 |
+| GlobalDataFlow.cs:257:15:257:24 | access to parameter sinkParam5 |
+| GlobalDataFlow.cs:262:15:262:24 | access to parameter sinkParam6 |
+| GlobalDataFlow.cs:267:15:267:24 | access to parameter sinkParam7 |
+| GlobalDataFlow.cs:294:15:294:24 | access to parameter sinkParam8 |
+| GlobalDataFlow.cs:300:15:300:24 | access to parameter sinkParam9 |
+| GlobalDataFlow.cs:306:15:306:25 | access to parameter sinkParam11 |
+| GlobalDataFlow.cs:381:15:381:20 | access to local variable sink11 |
+| GlobalDataFlow.cs:404:41:404:46 | access to local variable sink20 |
 | Splitting.cs:9:15:9:15 | [b (line 3): false] access to local variable x |
 | Splitting.cs:9:15:9:15 | [b (line 3): true] access to local variable x |
 | Splitting.cs:11:19:11:19 | access to local variable x |

--- a/csharp/ql/test/library-tests/dataflow/global/TaintTracking.expected
+++ b/csharp/ql/test/library-tests/dataflow/global/TaintTracking.expected
@@ -25,11 +25,6 @@
 | GlobalDataFlow.cs:91:15:91:20 | access to local variable sink18 |
 | GlobalDataFlow.cs:94:15:94:20 | access to local variable sink21 |
 | GlobalDataFlow.cs:97:15:97:20 | access to local variable sink22 |
-| GlobalDataFlow.cs:107:15:107:22 | access to local variable nonSink0 |
-| GlobalDataFlow.cs:109:15:109:22 | access to local variable nonSink0 |
-| GlobalDataFlow.cs:111:15:111:22 | access to local variable nonSink0 |
-| GlobalDataFlow.cs:113:15:113:22 | access to local variable nonSink1 |
-| GlobalDataFlow.cs:115:15:115:22 | access to local variable nonSink1 |
 | GlobalDataFlow.cs:136:15:136:19 | access to local variable sink4 |
 | GlobalDataFlow.cs:144:15:144:19 | access to local variable sink5 |
 | GlobalDataFlow.cs:154:15:154:19 | access to local variable sink6 |

--- a/csharp/ql/test/library-tests/dataflow/global/TaintTrackingEdges.expected
+++ b/csharp/ql/test/library-tests/dataflow/global/TaintTrackingEdges.expected
@@ -1467,8 +1467,6 @@
 | GlobalDataFlow.cs:78:30:78:34 | access to local variable sink3 | GlobalDataFlow.cs:78:30:78:34 | access to local variable sink3 |
 | GlobalDataFlow.cs:78:30:78:34 | access to local variable sink3 | GlobalDataFlow.cs:78:41:78:45 | access to local variable sink3 |
 | GlobalDataFlow.cs:78:30:78:34 | access to local variable sink3 | GlobalDataFlow.cs:78:41:78:45 | access to local variable sink3 |
-| GlobalDataFlow.cs:78:41:78:45 | access to local variable sink3 | GlobalDataFlow.cs:78:30:78:34 | SSA def(sink3) |
-| GlobalDataFlow.cs:78:41:78:45 | access to local variable sink3 | GlobalDataFlow.cs:78:30:78:34 | SSA def(sink3) |
 | GlobalDataFlow.cs:78:41:78:45 | access to local variable sink3 | GlobalDataFlow.cs:78:41:78:45 | access to local variable sink3 |
 | GlobalDataFlow.cs:78:41:78:45 | access to local variable sink3 | GlobalDataFlow.cs:287:50:287:50 | z |
 | GlobalDataFlow.cs:78:41:78:45 | access to local variable sink3 | GlobalDataFlow.cs:287:50:287:50 | z |
@@ -2344,8 +2342,6 @@
 | GlobalDataFlow.cs:105:15:105:22 | access to local variable nonSink0 | GlobalDataFlow.cs:105:15:105:22 | access to local variable nonSink0 |
 | GlobalDataFlow.cs:106:9:106:49 | call to method ReturnOut | GlobalDataFlow.cs:106:9:106:49 | call to method ReturnOut |
 | GlobalDataFlow.cs:106:19:106:23 | access to local variable sink1 | GlobalDataFlow.cs:106:19:106:23 | access to local variable sink1 |
-| GlobalDataFlow.cs:106:19:106:23 | access to local variable sink1 | GlobalDataFlow.cs:106:41:106:48 | SSA def(nonSink0) |
-| GlobalDataFlow.cs:106:19:106:23 | access to local variable sink1 | GlobalDataFlow.cs:106:41:106:48 | SSA def(nonSink0) |
 | GlobalDataFlow.cs:106:19:106:23 | access to local variable sink1 | GlobalDataFlow.cs:110:19:110:23 | access to local variable sink1 |
 | GlobalDataFlow.cs:106:19:106:23 | access to local variable sink1 | GlobalDataFlow.cs:110:19:110:23 | access to local variable sink1 |
 | GlobalDataFlow.cs:106:19:106:23 | access to local variable sink1 | GlobalDataFlow.cs:110:30:110:34 | access to local variable sink1 |
@@ -2393,8 +2389,6 @@
 | GlobalDataFlow.cs:108:27:108:34 | access to local variable nonSink0 | GlobalDataFlow.cs:108:27:108:34 | access to local variable nonSink0 |
 | GlobalDataFlow.cs:108:27:108:34 | access to local variable nonSink0 | GlobalDataFlow.cs:108:41:108:48 | access to local variable nonSink0 |
 | GlobalDataFlow.cs:108:27:108:34 | access to local variable nonSink0 | GlobalDataFlow.cs:108:41:108:48 | access to local variable nonSink0 |
-| GlobalDataFlow.cs:108:41:108:48 | access to local variable nonSink0 | GlobalDataFlow.cs:108:27:108:34 | SSA def(nonSink0) |
-| GlobalDataFlow.cs:108:41:108:48 | access to local variable nonSink0 | GlobalDataFlow.cs:108:27:108:34 | SSA def(nonSink0) |
 | GlobalDataFlow.cs:108:41:108:48 | access to local variable nonSink0 | GlobalDataFlow.cs:108:41:108:48 | access to local variable nonSink0 |
 | GlobalDataFlow.cs:108:41:108:48 | access to local variable nonSink0 | GlobalDataFlow.cs:287:50:287:50 | z |
 | GlobalDataFlow.cs:108:41:108:48 | access to local variable nonSink0 | GlobalDataFlow.cs:287:50:287:50 | z |
@@ -2428,8 +2422,6 @@
 | GlobalDataFlow.cs:110:30:110:34 | SSA def(sink1) | GlobalDataFlow.cs:124:39:124:43 | access to local variable sink1 |
 | GlobalDataFlow.cs:110:30:110:34 | SSA def(sink1) | GlobalDataFlow.cs:124:39:124:43 | access to local variable sink1 |
 | GlobalDataFlow.cs:110:30:110:34 | access to local variable sink1 | GlobalDataFlow.cs:110:30:110:34 | access to local variable sink1 |
-| GlobalDataFlow.cs:110:41:110:48 | access to local variable nonSink0 | GlobalDataFlow.cs:110:30:110:34 | SSA def(sink1) |
-| GlobalDataFlow.cs:110:41:110:48 | access to local variable nonSink0 | GlobalDataFlow.cs:110:30:110:34 | SSA def(sink1) |
 | GlobalDataFlow.cs:110:41:110:48 | access to local variable nonSink0 | GlobalDataFlow.cs:110:41:110:48 | access to local variable nonSink0 |
 | GlobalDataFlow.cs:110:41:110:48 | access to local variable nonSink0 | GlobalDataFlow.cs:111:15:111:22 | access to local variable nonSink0 |
 | GlobalDataFlow.cs:110:41:110:48 | access to local variable nonSink0 | GlobalDataFlow.cs:111:15:111:22 | access to local variable nonSink0 |
@@ -4302,8 +4294,6 @@
 | GlobalDataFlow.cs:283:9:283:13 | SSA def(y) | GlobalDataFlow.cs:75:30:75:34 | SSA def(sink2) |
 | GlobalDataFlow.cs:283:9:283:13 | SSA def(y) | GlobalDataFlow.cs:104:27:104:34 | SSA def(nonSink0) |
 | GlobalDataFlow.cs:283:9:283:13 | SSA def(y) | GlobalDataFlow.cs:104:27:104:34 | SSA def(nonSink0) |
-| GlobalDataFlow.cs:283:9:283:13 | SSA def(y) | GlobalDataFlow.cs:106:41:106:48 | SSA def(nonSink0) |
-| GlobalDataFlow.cs:283:9:283:13 | SSA def(y) | GlobalDataFlow.cs:106:41:106:48 | SSA def(nonSink0) |
 | GlobalDataFlow.cs:283:9:283:13 | SSA def(y) | GlobalDataFlow.cs:283:9:283:13 | SSA def(y) |
 | GlobalDataFlow.cs:283:13:283:13 | access to parameter x | GlobalDataFlow.cs:283:9:283:13 | SSA def(y) |
 | GlobalDataFlow.cs:283:13:283:13 | access to parameter x | GlobalDataFlow.cs:283:9:283:13 | SSA def(y) |
@@ -4311,10 +4301,6 @@
 | GlobalDataFlow.cs:283:13:283:13 | access to parameter x | GlobalDataFlow.cs:283:9:283:13 | SSA def(y) |
 | GlobalDataFlow.cs:283:13:283:13 | access to parameter x | GlobalDataFlow.cs:283:13:283:13 | access to parameter x |
 | GlobalDataFlow.cs:284:9:284:22 | ... = ... | GlobalDataFlow.cs:284:9:284:22 | ... = ... |
-| GlobalDataFlow.cs:284:9:284:22 | SSA def(z) | GlobalDataFlow.cs:75:30:75:34 | SSA def(sink2) |
-| GlobalDataFlow.cs:284:9:284:22 | SSA def(z) | GlobalDataFlow.cs:75:30:75:34 | SSA def(sink2) |
-| GlobalDataFlow.cs:284:9:284:22 | SSA def(z) | GlobalDataFlow.cs:104:27:104:34 | SSA def(nonSink0) |
-| GlobalDataFlow.cs:284:9:284:22 | SSA def(z) | GlobalDataFlow.cs:104:27:104:34 | SSA def(nonSink0) |
 | GlobalDataFlow.cs:284:9:284:22 | SSA def(z) | GlobalDataFlow.cs:106:41:106:48 | SSA def(nonSink0) |
 | GlobalDataFlow.cs:284:9:284:22 | SSA def(z) | GlobalDataFlow.cs:106:41:106:48 | SSA def(nonSink0) |
 | GlobalDataFlow.cs:284:9:284:22 | SSA def(z) | GlobalDataFlow.cs:284:9:284:22 | SSA def(z) |
@@ -4337,12 +4323,6 @@
 | GlobalDataFlow.cs:287:32:287:32 | x | GlobalDataFlow.cs:289:13:289:13 | access to parameter x |
 | GlobalDataFlow.cs:287:32:287:32 | x | GlobalDataFlow.cs:289:13:289:13 | access to parameter x |
 | GlobalDataFlow.cs:287:32:287:32 | x | GlobalDataFlow.cs:289:13:289:13 | access to parameter x |
-| GlobalDataFlow.cs:287:50:287:50 | z | GlobalDataFlow.cs:78:30:78:34 | SSA def(sink3) |
-| GlobalDataFlow.cs:287:50:287:50 | z | GlobalDataFlow.cs:78:30:78:34 | SSA def(sink3) |
-| GlobalDataFlow.cs:287:50:287:50 | z | GlobalDataFlow.cs:108:27:108:34 | SSA def(nonSink0) |
-| GlobalDataFlow.cs:287:50:287:50 | z | GlobalDataFlow.cs:108:27:108:34 | SSA def(nonSink0) |
-| GlobalDataFlow.cs:287:50:287:50 | z | GlobalDataFlow.cs:110:30:110:34 | SSA def(sink1) |
-| GlobalDataFlow.cs:287:50:287:50 | z | GlobalDataFlow.cs:110:30:110:34 | SSA def(sink1) |
 | GlobalDataFlow.cs:287:50:287:50 | z | GlobalDataFlow.cs:287:50:287:50 | z |
 | GlobalDataFlow.cs:287:50:287:50 | z | GlobalDataFlow.cs:287:50:287:50 | z |
 | GlobalDataFlow.cs:287:50:287:50 | z | GlobalDataFlow.cs:287:50:287:50 | z |

--- a/csharp/ql/test/library-tests/dataflow/global/TaintTrackingEdges.expected
+++ b/csharp/ql/test/library-tests/dataflow/global/TaintTrackingEdges.expected
@@ -682,30 +682,30 @@
 | GlobalDataFlow.cs:14:17:14:17 | this | GlobalDataFlow.cs:64:9:64:18 | this access |
 | GlobalDataFlow.cs:14:17:14:17 | this | GlobalDataFlow.cs:67:9:67:21 | this access |
 | GlobalDataFlow.cs:14:17:14:17 | this | GlobalDataFlow.cs:67:9:67:21 | this access |
-| GlobalDataFlow.cs:14:17:14:17 | this | GlobalDataFlow.cs:149:21:149:25 | this access |
-| GlobalDataFlow.cs:14:17:14:17 | this | GlobalDataFlow.cs:149:21:149:25 | this access |
-| GlobalDataFlow.cs:14:17:14:17 | this | GlobalDataFlow.cs:152:9:152:25 | this access |
-| GlobalDataFlow.cs:14:17:14:17 | this | GlobalDataFlow.cs:152:9:152:25 | this access |
-| GlobalDataFlow.cs:14:17:14:17 | this | GlobalDataFlow.cs:155:9:155:25 | this access |
-| GlobalDataFlow.cs:14:17:14:17 | this | GlobalDataFlow.cs:155:9:155:25 | this access |
-| GlobalDataFlow.cs:14:17:14:17 | this | GlobalDataFlow.cs:157:22:157:31 | this access |
-| GlobalDataFlow.cs:14:17:14:17 | this | GlobalDataFlow.cs:157:22:157:31 | this access |
-| GlobalDataFlow.cs:14:17:14:17 | this | GlobalDataFlow.cs:163:20:163:27 | this access |
-| GlobalDataFlow.cs:14:17:14:17 | this | GlobalDataFlow.cs:163:20:163:27 | this access |
-| GlobalDataFlow.cs:14:17:14:17 | this | GlobalDataFlow.cs:165:9:165:31 | this access |
-| GlobalDataFlow.cs:14:17:14:17 | this | GlobalDataFlow.cs:165:9:165:31 | this access |
-| GlobalDataFlow.cs:14:17:14:17 | this | GlobalDataFlow.cs:167:9:167:31 | this access |
-| GlobalDataFlow.cs:14:17:14:17 | this | GlobalDataFlow.cs:167:9:167:31 | this access |
-| GlobalDataFlow.cs:14:17:14:17 | this | GlobalDataFlow.cs:169:20:169:32 | this access |
-| GlobalDataFlow.cs:14:17:14:17 | this | GlobalDataFlow.cs:169:20:169:32 | this access |
-| GlobalDataFlow.cs:14:17:14:17 | this | GlobalDataFlow.cs:185:39:185:41 | this access |
-| GlobalDataFlow.cs:14:17:14:17 | this | GlobalDataFlow.cs:185:39:185:41 | this access |
-| GlobalDataFlow.cs:14:17:14:17 | this | GlobalDataFlow.cs:189:37:189:42 | this access |
-| GlobalDataFlow.cs:14:17:14:17 | this | GlobalDataFlow.cs:189:37:189:42 | this access |
-| GlobalDataFlow.cs:14:17:14:17 | this | GlobalDataFlow.cs:193:22:193:32 | this access |
-| GlobalDataFlow.cs:14:17:14:17 | this | GlobalDataFlow.cs:193:22:193:32 | this access |
-| GlobalDataFlow.cs:14:17:14:17 | this | GlobalDataFlow.cs:197:20:197:33 | this access |
-| GlobalDataFlow.cs:14:17:14:17 | this | GlobalDataFlow.cs:197:20:197:33 | this access |
+| GlobalDataFlow.cs:14:17:14:17 | this | GlobalDataFlow.cs:153:21:153:25 | this access |
+| GlobalDataFlow.cs:14:17:14:17 | this | GlobalDataFlow.cs:153:21:153:25 | this access |
+| GlobalDataFlow.cs:14:17:14:17 | this | GlobalDataFlow.cs:156:9:156:25 | this access |
+| GlobalDataFlow.cs:14:17:14:17 | this | GlobalDataFlow.cs:156:9:156:25 | this access |
+| GlobalDataFlow.cs:14:17:14:17 | this | GlobalDataFlow.cs:159:9:159:25 | this access |
+| GlobalDataFlow.cs:14:17:14:17 | this | GlobalDataFlow.cs:159:9:159:25 | this access |
+| GlobalDataFlow.cs:14:17:14:17 | this | GlobalDataFlow.cs:161:22:161:31 | this access |
+| GlobalDataFlow.cs:14:17:14:17 | this | GlobalDataFlow.cs:161:22:161:31 | this access |
+| GlobalDataFlow.cs:14:17:14:17 | this | GlobalDataFlow.cs:167:20:167:27 | this access |
+| GlobalDataFlow.cs:14:17:14:17 | this | GlobalDataFlow.cs:167:20:167:27 | this access |
+| GlobalDataFlow.cs:14:17:14:17 | this | GlobalDataFlow.cs:169:9:169:31 | this access |
+| GlobalDataFlow.cs:14:17:14:17 | this | GlobalDataFlow.cs:169:9:169:31 | this access |
+| GlobalDataFlow.cs:14:17:14:17 | this | GlobalDataFlow.cs:171:9:171:31 | this access |
+| GlobalDataFlow.cs:14:17:14:17 | this | GlobalDataFlow.cs:171:9:171:31 | this access |
+| GlobalDataFlow.cs:14:17:14:17 | this | GlobalDataFlow.cs:173:20:173:32 | this access |
+| GlobalDataFlow.cs:14:17:14:17 | this | GlobalDataFlow.cs:173:20:173:32 | this access |
+| GlobalDataFlow.cs:14:17:14:17 | this | GlobalDataFlow.cs:189:39:189:41 | this access |
+| GlobalDataFlow.cs:14:17:14:17 | this | GlobalDataFlow.cs:189:39:189:41 | this access |
+| GlobalDataFlow.cs:14:17:14:17 | this | GlobalDataFlow.cs:193:37:193:42 | this access |
+| GlobalDataFlow.cs:14:17:14:17 | this | GlobalDataFlow.cs:193:37:193:42 | this access |
+| GlobalDataFlow.cs:14:17:14:17 | this | GlobalDataFlow.cs:197:22:197:32 | this access |
+| GlobalDataFlow.cs:14:17:14:17 | this | GlobalDataFlow.cs:197:22:197:32 | this access |
+| GlobalDataFlow.cs:14:17:14:17 | this | GlobalDataFlow.cs:201:20:201:33 | this access |
+| GlobalDataFlow.cs:14:17:14:17 | this | GlobalDataFlow.cs:201:20:201:33 | this access |
 | GlobalDataFlow.cs:17:9:17:40 | ... = ... | GlobalDataFlow.cs:17:9:17:40 | ... = ... |
 | GlobalDataFlow.cs:17:9:17:40 | SSA def(DataFlow.Test.SinkField0) | GlobalDataFlow.cs:17:9:17:40 | SSA def(DataFlow.Test.SinkField0) |
 | GlobalDataFlow.cs:17:9:17:40 | SSA def(DataFlow.Test.SinkField0) | GlobalDataFlow.cs:18:15:18:29 | access to field SinkField0 |
@@ -984,8 +984,8 @@
 | GlobalDataFlow.cs:35:13:35:30 | access to property SinkProperty0 | GlobalDataFlow.cs:64:22:64:39 | access to property SinkProperty0 |
 | GlobalDataFlow.cs:35:13:35:30 | access to property SinkProperty0 | GlobalDataFlow.cs:70:28:70:45 | access to property SinkProperty0 |
 | GlobalDataFlow.cs:35:13:35:30 | access to property SinkProperty0 | GlobalDataFlow.cs:70:28:70:45 | access to property SinkProperty0 |
-| GlobalDataFlow.cs:35:13:35:30 | access to property SinkProperty0 | GlobalDataFlow.cs:230:26:230:35 | sinkParam0 |
-| GlobalDataFlow.cs:35:13:35:30 | access to property SinkProperty0 | GlobalDataFlow.cs:230:26:230:35 | sinkParam0 |
+| GlobalDataFlow.cs:35:13:35:30 | access to property SinkProperty0 | GlobalDataFlow.cs:234:26:234:35 | sinkParam0 |
+| GlobalDataFlow.cs:35:13:35:30 | access to property SinkProperty0 | GlobalDataFlow.cs:234:26:234:35 | sinkParam0 |
 | GlobalDataFlow.cs:36:13:36:58 | MethodInfo methodInfo = ... | GlobalDataFlow.cs:36:13:36:58 | MethodInfo methodInfo = ... |
 | GlobalDataFlow.cs:36:13:36:58 | SSA def(methodInfo) | GlobalDataFlow.cs:36:13:36:58 | SSA def(methodInfo) |
 | GlobalDataFlow.cs:36:13:36:58 | SSA def(methodInfo) | GlobalDataFlow.cs:38:9:38:18 | access to local variable methodInfo |
@@ -1030,16 +1030,16 @@
 | GlobalDataFlow.cs:37:35:37:52 | access to property SinkProperty0 | GlobalDataFlow.cs:64:22:64:39 | access to property SinkProperty0 |
 | GlobalDataFlow.cs:37:35:37:52 | access to property SinkProperty0 | GlobalDataFlow.cs:70:28:70:45 | access to property SinkProperty0 |
 | GlobalDataFlow.cs:37:35:37:52 | access to property SinkProperty0 | GlobalDataFlow.cs:70:28:70:45 | access to property SinkProperty0 |
-| GlobalDataFlow.cs:37:35:37:52 | access to property SinkProperty0 | GlobalDataFlow.cs:236:26:236:35 | sinkParam1 |
-| GlobalDataFlow.cs:37:35:37:52 | access to property SinkProperty0 | GlobalDataFlow.cs:236:26:236:35 | sinkParam1 |
+| GlobalDataFlow.cs:37:35:37:52 | access to property SinkProperty0 | GlobalDataFlow.cs:240:26:240:35 | sinkParam1 |
+| GlobalDataFlow.cs:37:35:37:52 | access to property SinkProperty0 | GlobalDataFlow.cs:240:26:240:35 | sinkParam1 |
 | GlobalDataFlow.cs:38:9:38:18 | access to local variable methodInfo | GlobalDataFlow.cs:38:9:38:18 | access to local variable methodInfo |
 | GlobalDataFlow.cs:38:9:38:37 | call to method Invoke | GlobalDataFlow.cs:38:9:38:37 | call to method Invoke |
 | GlobalDataFlow.cs:38:27:38:30 | null | GlobalDataFlow.cs:38:27:38:30 | null |
 | GlobalDataFlow.cs:38:33:38:36 | access to local variable args | GlobalDataFlow.cs:38:33:38:36 | access to local variable args |
 | GlobalDataFlow.cs:41:9:41:18 | call to method NonIn0 | GlobalDataFlow.cs:41:9:41:18 | call to method NonIn0 |
 | GlobalDataFlow.cs:41:16:41:17 | "" | GlobalDataFlow.cs:41:16:41:17 | "" |
-| GlobalDataFlow.cs:41:16:41:17 | "" | GlobalDataFlow.cs:266:29:266:41 | nonSinkParam0 |
-| GlobalDataFlow.cs:41:16:41:17 | "" | GlobalDataFlow.cs:266:29:266:41 | nonSinkParam0 |
+| GlobalDataFlow.cs:41:16:41:17 | "" | GlobalDataFlow.cs:270:29:270:41 | nonSinkParam0 |
+| GlobalDataFlow.cs:41:16:41:17 | "" | GlobalDataFlow.cs:270:29:270:41 | nonSinkParam0 |
 | GlobalDataFlow.cs:44:24:44:60 | Action<String> in2 = ... | GlobalDataFlow.cs:44:24:44:60 | Action<String> in2 = ... |
 | GlobalDataFlow.cs:44:24:44:60 | SSA def(in2) | GlobalDataFlow.cs:44:24:44:60 | SSA def(in2) |
 | GlobalDataFlow.cs:44:24:44:60 | SSA def(in2) | GlobalDataFlow.cs:45:9:45:11 | access to local variable in2 |
@@ -1109,8 +1109,8 @@
 | GlobalDataFlow.cs:52:9:52:38 | call to method Apply | GlobalDataFlow.cs:52:9:52:38 | call to method Apply |
 | GlobalDataFlow.cs:52:15:52:17 | access to method In3 | GlobalDataFlow.cs:52:15:52:17 | access to method In3 |
 | GlobalDataFlow.cs:52:15:52:17 | delegate creation of type Action<String> | GlobalDataFlow.cs:52:15:52:17 | delegate creation of type Action<String> |
-| GlobalDataFlow.cs:52:15:52:17 | delegate creation of type Action<String> | GlobalDataFlow.cs:354:36:354:36 | a |
-| GlobalDataFlow.cs:52:15:52:17 | delegate creation of type Action<String> | GlobalDataFlow.cs:354:36:354:36 | a |
+| GlobalDataFlow.cs:52:15:52:17 | delegate creation of type Action<String> | GlobalDataFlow.cs:359:36:359:36 | a |
+| GlobalDataFlow.cs:52:15:52:17 | delegate creation of type Action<String> | GlobalDataFlow.cs:359:36:359:36 | a |
 | GlobalDataFlow.cs:52:20:52:37 | access to property SinkProperty0 | GlobalDataFlow.cs:52:20:52:37 | access to property SinkProperty0 |
 | GlobalDataFlow.cs:52:20:52:37 | access to property SinkProperty0 | GlobalDataFlow.cs:53:28:53:45 | access to property SinkProperty0 |
 | GlobalDataFlow.cs:52:20:52:37 | access to property SinkProperty0 | GlobalDataFlow.cs:53:28:53:45 | access to property SinkProperty0 |
@@ -1124,8 +1124,8 @@
 | GlobalDataFlow.cs:52:20:52:37 | access to property SinkProperty0 | GlobalDataFlow.cs:64:22:64:39 | access to property SinkProperty0 |
 | GlobalDataFlow.cs:52:20:52:37 | access to property SinkProperty0 | GlobalDataFlow.cs:70:28:70:45 | access to property SinkProperty0 |
 | GlobalDataFlow.cs:52:20:52:37 | access to property SinkProperty0 | GlobalDataFlow.cs:70:28:70:45 | access to property SinkProperty0 |
-| GlobalDataFlow.cs:52:20:52:37 | access to property SinkProperty0 | GlobalDataFlow.cs:354:41:354:41 | x |
-| GlobalDataFlow.cs:52:20:52:37 | access to property SinkProperty0 | GlobalDataFlow.cs:354:41:354:41 | x |
+| GlobalDataFlow.cs:52:20:52:37 | access to property SinkProperty0 | GlobalDataFlow.cs:359:41:359:41 | x |
+| GlobalDataFlow.cs:52:20:52:37 | access to property SinkProperty0 | GlobalDataFlow.cs:359:41:359:41 | x |
 | GlobalDataFlow.cs:53:9:53:46 | call to method Apply | GlobalDataFlow.cs:53:9:53:46 | call to method Apply |
 | GlobalDataFlow.cs:53:15:53:15 | x | GlobalDataFlow.cs:53:15:53:15 | x |
 | GlobalDataFlow.cs:53:15:53:15 | x | GlobalDataFlow.cs:53:15:53:15 | x |
@@ -1138,14 +1138,14 @@
 | GlobalDataFlow.cs:53:15:53:15 | x | GlobalDataFlow.cs:53:24:53:24 | access to parameter x |
 | GlobalDataFlow.cs:53:15:53:15 | x | GlobalDataFlow.cs:53:24:53:24 | access to parameter x |
 | GlobalDataFlow.cs:53:15:53:25 | (...) => ... | GlobalDataFlow.cs:53:15:53:25 | (...) => ... |
-| GlobalDataFlow.cs:53:15:53:25 | (...) => ... | GlobalDataFlow.cs:354:36:354:36 | a |
-| GlobalDataFlow.cs:53:15:53:25 | (...) => ... | GlobalDataFlow.cs:354:36:354:36 | a |
+| GlobalDataFlow.cs:53:15:53:25 | (...) => ... | GlobalDataFlow.cs:359:36:359:36 | a |
+| GlobalDataFlow.cs:53:15:53:25 | (...) => ... | GlobalDataFlow.cs:359:36:359:36 | a |
 | GlobalDataFlow.cs:53:20:53:25 | call to method In4 | GlobalDataFlow.cs:53:20:53:25 | call to method In4 |
 | GlobalDataFlow.cs:53:24:53:24 | access to parameter x | GlobalDataFlow.cs:53:24:53:24 | access to parameter x |
-| GlobalDataFlow.cs:53:24:53:24 | access to parameter x | GlobalDataFlow.cs:246:26:246:35 | sinkParam4 |
-| GlobalDataFlow.cs:53:24:53:24 | access to parameter x | GlobalDataFlow.cs:246:26:246:35 | sinkParam4 |
-| GlobalDataFlow.cs:53:24:53:24 | access to parameter x | GlobalDataFlow.cs:246:26:246:35 | sinkParam4 |
-| GlobalDataFlow.cs:53:24:53:24 | access to parameter x | GlobalDataFlow.cs:246:26:246:35 | sinkParam4 |
+| GlobalDataFlow.cs:53:24:53:24 | access to parameter x | GlobalDataFlow.cs:250:26:250:35 | sinkParam4 |
+| GlobalDataFlow.cs:53:24:53:24 | access to parameter x | GlobalDataFlow.cs:250:26:250:35 | sinkParam4 |
+| GlobalDataFlow.cs:53:24:53:24 | access to parameter x | GlobalDataFlow.cs:250:26:250:35 | sinkParam4 |
+| GlobalDataFlow.cs:53:24:53:24 | access to parameter x | GlobalDataFlow.cs:250:26:250:35 | sinkParam4 |
 | GlobalDataFlow.cs:53:28:53:45 | access to property SinkProperty0 | GlobalDataFlow.cs:53:28:53:45 | access to property SinkProperty0 |
 | GlobalDataFlow.cs:53:28:53:45 | access to property SinkProperty0 | GlobalDataFlow.cs:54:44:54:61 | access to property SinkProperty0 |
 | GlobalDataFlow.cs:53:28:53:45 | access to property SinkProperty0 | GlobalDataFlow.cs:54:44:54:61 | access to property SinkProperty0 |
@@ -1157,12 +1157,12 @@
 | GlobalDataFlow.cs:53:28:53:45 | access to property SinkProperty0 | GlobalDataFlow.cs:64:22:64:39 | access to property SinkProperty0 |
 | GlobalDataFlow.cs:53:28:53:45 | access to property SinkProperty0 | GlobalDataFlow.cs:70:28:70:45 | access to property SinkProperty0 |
 | GlobalDataFlow.cs:53:28:53:45 | access to property SinkProperty0 | GlobalDataFlow.cs:70:28:70:45 | access to property SinkProperty0 |
-| GlobalDataFlow.cs:53:28:53:45 | access to property SinkProperty0 | GlobalDataFlow.cs:354:41:354:41 | x |
-| GlobalDataFlow.cs:53:28:53:45 | access to property SinkProperty0 | GlobalDataFlow.cs:354:41:354:41 | x |
+| GlobalDataFlow.cs:53:28:53:45 | access to property SinkProperty0 | GlobalDataFlow.cs:359:41:359:41 | x |
+| GlobalDataFlow.cs:53:28:53:45 | access to property SinkProperty0 | GlobalDataFlow.cs:359:41:359:41 | x |
 | GlobalDataFlow.cs:54:9:54:62 | call to method ApplyDelegate | GlobalDataFlow.cs:54:9:54:62 | call to method ApplyDelegate |
 | GlobalDataFlow.cs:54:23:54:41 | delegate creation of type MyDelegate | GlobalDataFlow.cs:54:23:54:41 | delegate creation of type MyDelegate |
-| GlobalDataFlow.cs:54:23:54:41 | delegate creation of type MyDelegate | GlobalDataFlow.cs:368:42:368:42 | a |
-| GlobalDataFlow.cs:54:23:54:41 | delegate creation of type MyDelegate | GlobalDataFlow.cs:368:42:368:42 | a |
+| GlobalDataFlow.cs:54:23:54:41 | delegate creation of type MyDelegate | GlobalDataFlow.cs:373:42:373:42 | a |
+| GlobalDataFlow.cs:54:23:54:41 | delegate creation of type MyDelegate | GlobalDataFlow.cs:373:42:373:42 | a |
 | GlobalDataFlow.cs:54:38:54:40 | access to method In5 | GlobalDataFlow.cs:54:38:54:40 | access to method In5 |
 | GlobalDataFlow.cs:54:44:54:61 | access to property SinkProperty0 | GlobalDataFlow.cs:54:44:54:61 | access to property SinkProperty0 |
 | GlobalDataFlow.cs:54:44:54:61 | access to property SinkProperty0 | GlobalDataFlow.cs:55:28:55:45 | access to property SinkProperty0 |
@@ -1173,13 +1173,13 @@
 | GlobalDataFlow.cs:54:44:54:61 | access to property SinkProperty0 | GlobalDataFlow.cs:64:22:64:39 | access to property SinkProperty0 |
 | GlobalDataFlow.cs:54:44:54:61 | access to property SinkProperty0 | GlobalDataFlow.cs:70:28:70:45 | access to property SinkProperty0 |
 | GlobalDataFlow.cs:54:44:54:61 | access to property SinkProperty0 | GlobalDataFlow.cs:70:28:70:45 | access to property SinkProperty0 |
-| GlobalDataFlow.cs:54:44:54:61 | access to property SinkProperty0 | GlobalDataFlow.cs:368:52:368:52 | x |
-| GlobalDataFlow.cs:54:44:54:61 | access to property SinkProperty0 | GlobalDataFlow.cs:368:52:368:52 | x |
+| GlobalDataFlow.cs:54:44:54:61 | access to property SinkProperty0 | GlobalDataFlow.cs:373:52:373:52 | x |
+| GlobalDataFlow.cs:54:44:54:61 | access to property SinkProperty0 | GlobalDataFlow.cs:373:52:373:52 | x |
 | GlobalDataFlow.cs:55:9:55:46 | call to method ApplyDelegate | GlobalDataFlow.cs:55:9:55:46 | call to method ApplyDelegate |
 | GlobalDataFlow.cs:55:23:55:25 | access to method In6 | GlobalDataFlow.cs:55:23:55:25 | access to method In6 |
 | GlobalDataFlow.cs:55:23:55:25 | delegate creation of type MyDelegate | GlobalDataFlow.cs:55:23:55:25 | delegate creation of type MyDelegate |
-| GlobalDataFlow.cs:55:23:55:25 | delegate creation of type MyDelegate | GlobalDataFlow.cs:368:42:368:42 | a |
-| GlobalDataFlow.cs:55:23:55:25 | delegate creation of type MyDelegate | GlobalDataFlow.cs:368:42:368:42 | a |
+| GlobalDataFlow.cs:55:23:55:25 | delegate creation of type MyDelegate | GlobalDataFlow.cs:373:42:373:42 | a |
+| GlobalDataFlow.cs:55:23:55:25 | delegate creation of type MyDelegate | GlobalDataFlow.cs:373:42:373:42 | a |
 | GlobalDataFlow.cs:55:28:55:45 | access to property SinkProperty0 | GlobalDataFlow.cs:55:28:55:45 | access to property SinkProperty0 |
 | GlobalDataFlow.cs:55:28:55:45 | access to property SinkProperty0 | GlobalDataFlow.cs:57:35:57:52 | access to property SinkProperty0 |
 | GlobalDataFlow.cs:55:28:55:45 | access to property SinkProperty0 | GlobalDataFlow.cs:57:35:57:52 | access to property SinkProperty0 |
@@ -1187,8 +1187,8 @@
 | GlobalDataFlow.cs:55:28:55:45 | access to property SinkProperty0 | GlobalDataFlow.cs:64:22:64:39 | access to property SinkProperty0 |
 | GlobalDataFlow.cs:55:28:55:45 | access to property SinkProperty0 | GlobalDataFlow.cs:70:28:70:45 | access to property SinkProperty0 |
 | GlobalDataFlow.cs:55:28:55:45 | access to property SinkProperty0 | GlobalDataFlow.cs:70:28:70:45 | access to property SinkProperty0 |
-| GlobalDataFlow.cs:55:28:55:45 | access to property SinkProperty0 | GlobalDataFlow.cs:368:52:368:52 | x |
-| GlobalDataFlow.cs:55:28:55:45 | access to property SinkProperty0 | GlobalDataFlow.cs:368:52:368:52 | x |
+| GlobalDataFlow.cs:55:28:55:45 | access to property SinkProperty0 | GlobalDataFlow.cs:373:52:373:52 | x |
+| GlobalDataFlow.cs:55:28:55:45 | access to property SinkProperty0 | GlobalDataFlow.cs:373:52:373:52 | x |
 | GlobalDataFlow.cs:56:9:56:48 | ... = ... | GlobalDataFlow.cs:56:9:56:48 | ... = ... |
 | GlobalDataFlow.cs:56:9:56:48 | SSA def(DataFlow.myDelegate) | GlobalDataFlow.cs:56:9:56:48 | SSA def(DataFlow.myDelegate) |
 | GlobalDataFlow.cs:56:9:56:48 | SSA def(DataFlow.myDelegate) | GlobalDataFlow.cs:57:23:57:32 | access to field myDelegate |
@@ -1211,21 +1211,21 @@
 | GlobalDataFlow.cs:56:37:56:47 | (...) => ... | GlobalDataFlow.cs:56:37:56:47 | (...) => ... |
 | GlobalDataFlow.cs:56:42:56:47 | call to method In7 | GlobalDataFlow.cs:56:42:56:47 | call to method In7 |
 | GlobalDataFlow.cs:56:46:56:46 | access to parameter x | GlobalDataFlow.cs:56:46:56:46 | access to parameter x |
-| GlobalDataFlow.cs:56:46:56:46 | access to parameter x | GlobalDataFlow.cs:261:26:261:35 | sinkParam7 |
-| GlobalDataFlow.cs:56:46:56:46 | access to parameter x | GlobalDataFlow.cs:261:26:261:35 | sinkParam7 |
-| GlobalDataFlow.cs:56:46:56:46 | access to parameter x | GlobalDataFlow.cs:261:26:261:35 | sinkParam7 |
-| GlobalDataFlow.cs:56:46:56:46 | access to parameter x | GlobalDataFlow.cs:261:26:261:35 | sinkParam7 |
+| GlobalDataFlow.cs:56:46:56:46 | access to parameter x | GlobalDataFlow.cs:265:26:265:35 | sinkParam7 |
+| GlobalDataFlow.cs:56:46:56:46 | access to parameter x | GlobalDataFlow.cs:265:26:265:35 | sinkParam7 |
+| GlobalDataFlow.cs:56:46:56:46 | access to parameter x | GlobalDataFlow.cs:265:26:265:35 | sinkParam7 |
+| GlobalDataFlow.cs:56:46:56:46 | access to parameter x | GlobalDataFlow.cs:265:26:265:35 | sinkParam7 |
 | GlobalDataFlow.cs:57:9:57:53 | call to method ApplyDelegate | GlobalDataFlow.cs:57:9:57:53 | call to method ApplyDelegate |
 | GlobalDataFlow.cs:57:23:57:32 | access to field myDelegate | GlobalDataFlow.cs:57:23:57:32 | access to field myDelegate |
-| GlobalDataFlow.cs:57:23:57:32 | access to field myDelegate | GlobalDataFlow.cs:368:42:368:42 | a |
-| GlobalDataFlow.cs:57:23:57:32 | access to field myDelegate | GlobalDataFlow.cs:368:42:368:42 | a |
+| GlobalDataFlow.cs:57:23:57:32 | access to field myDelegate | GlobalDataFlow.cs:373:42:373:42 | a |
+| GlobalDataFlow.cs:57:23:57:32 | access to field myDelegate | GlobalDataFlow.cs:373:42:373:42 | a |
 | GlobalDataFlow.cs:57:35:57:52 | access to property SinkProperty0 | GlobalDataFlow.cs:57:35:57:52 | access to property SinkProperty0 |
 | GlobalDataFlow.cs:57:35:57:52 | access to property SinkProperty0 | GlobalDataFlow.cs:64:22:64:39 | access to property SinkProperty0 |
 | GlobalDataFlow.cs:57:35:57:52 | access to property SinkProperty0 | GlobalDataFlow.cs:64:22:64:39 | access to property SinkProperty0 |
 | GlobalDataFlow.cs:57:35:57:52 | access to property SinkProperty0 | GlobalDataFlow.cs:70:28:70:45 | access to property SinkProperty0 |
 | GlobalDataFlow.cs:57:35:57:52 | access to property SinkProperty0 | GlobalDataFlow.cs:70:28:70:45 | access to property SinkProperty0 |
-| GlobalDataFlow.cs:57:35:57:52 | access to property SinkProperty0 | GlobalDataFlow.cs:368:52:368:52 | x |
-| GlobalDataFlow.cs:57:35:57:52 | access to property SinkProperty0 | GlobalDataFlow.cs:368:52:368:52 | x |
+| GlobalDataFlow.cs:57:35:57:52 | access to property SinkProperty0 | GlobalDataFlow.cs:373:52:373:52 | x |
+| GlobalDataFlow.cs:57:35:57:52 | access to property SinkProperty0 | GlobalDataFlow.cs:373:52:373:52 | x |
 | GlobalDataFlow.cs:60:9:60:67 | call to method Apply | GlobalDataFlow.cs:60:9:60:67 | call to method Apply |
 | GlobalDataFlow.cs:60:15:60:27 | nonSinkParam0 | GlobalDataFlow.cs:60:15:60:27 | nonSinkParam0 |
 | GlobalDataFlow.cs:60:15:60:27 | nonSinkParam0 | GlobalDataFlow.cs:60:15:60:27 | nonSinkParam0 |
@@ -1238,17 +1238,17 @@
 | GlobalDataFlow.cs:60:15:60:27 | nonSinkParam0 | GlobalDataFlow.cs:60:38:60:50 | access to parameter nonSinkParam0 |
 | GlobalDataFlow.cs:60:15:60:27 | nonSinkParam0 | GlobalDataFlow.cs:60:38:60:50 | access to parameter nonSinkParam0 |
 | GlobalDataFlow.cs:60:15:60:51 | (...) => ... | GlobalDataFlow.cs:60:15:60:51 | (...) => ... |
-| GlobalDataFlow.cs:60:15:60:51 | (...) => ... | GlobalDataFlow.cs:354:36:354:36 | a |
-| GlobalDataFlow.cs:60:15:60:51 | (...) => ... | GlobalDataFlow.cs:354:36:354:36 | a |
+| GlobalDataFlow.cs:60:15:60:51 | (...) => ... | GlobalDataFlow.cs:359:36:359:36 | a |
+| GlobalDataFlow.cs:60:15:60:51 | (...) => ... | GlobalDataFlow.cs:359:36:359:36 | a |
 | GlobalDataFlow.cs:60:32:60:51 | call to method Check | GlobalDataFlow.cs:60:32:60:51 | call to method Check |
 | GlobalDataFlow.cs:60:38:60:50 | access to parameter nonSinkParam0 | GlobalDataFlow.cs:60:38:60:50 | access to parameter nonSinkParam0 |
 | GlobalDataFlow.cs:60:54:60:66 | "not tainted" | GlobalDataFlow.cs:60:54:60:66 | "not tainted" |
-| GlobalDataFlow.cs:60:54:60:66 | "not tainted" | GlobalDataFlow.cs:354:41:354:41 | x |
-| GlobalDataFlow.cs:60:54:60:66 | "not tainted" | GlobalDataFlow.cs:354:41:354:41 | x |
+| GlobalDataFlow.cs:60:54:60:66 | "not tainted" | GlobalDataFlow.cs:359:41:359:41 | x |
+| GlobalDataFlow.cs:60:54:60:66 | "not tainted" | GlobalDataFlow.cs:359:41:359:41 | x |
 | GlobalDataFlow.cs:61:9:61:91 | call to method ApplyDelegate | GlobalDataFlow.cs:61:9:61:91 | call to method ApplyDelegate |
 | GlobalDataFlow.cs:61:23:61:75 | delegate creation of type MyDelegate | GlobalDataFlow.cs:61:23:61:75 | delegate creation of type MyDelegate |
-| GlobalDataFlow.cs:61:23:61:75 | delegate creation of type MyDelegate | GlobalDataFlow.cs:368:42:368:42 | a |
-| GlobalDataFlow.cs:61:23:61:75 | delegate creation of type MyDelegate | GlobalDataFlow.cs:368:42:368:42 | a |
+| GlobalDataFlow.cs:61:23:61:75 | delegate creation of type MyDelegate | GlobalDataFlow.cs:373:42:373:42 | a |
+| GlobalDataFlow.cs:61:23:61:75 | delegate creation of type MyDelegate | GlobalDataFlow.cs:373:42:373:42 | a |
 | GlobalDataFlow.cs:61:38:61:50 | nonSinkParam0 | GlobalDataFlow.cs:61:38:61:50 | nonSinkParam0 |
 | GlobalDataFlow.cs:61:38:61:50 | nonSinkParam0 | GlobalDataFlow.cs:61:38:61:50 | nonSinkParam0 |
 | GlobalDataFlow.cs:61:38:61:50 | nonSinkParam0 | GlobalDataFlow.cs:61:38:61:50 | nonSinkParam0 |
@@ -1263,76 +1263,76 @@
 | GlobalDataFlow.cs:61:55:61:74 | call to method Check | GlobalDataFlow.cs:61:55:61:74 | call to method Check |
 | GlobalDataFlow.cs:61:61:61:73 | access to parameter nonSinkParam0 | GlobalDataFlow.cs:61:61:61:73 | access to parameter nonSinkParam0 |
 | GlobalDataFlow.cs:61:78:61:90 | "not tainted" | GlobalDataFlow.cs:61:78:61:90 | "not tainted" |
-| GlobalDataFlow.cs:61:78:61:90 | "not tainted" | GlobalDataFlow.cs:368:52:368:52 | x |
-| GlobalDataFlow.cs:61:78:61:90 | "not tainted" | GlobalDataFlow.cs:368:52:368:52 | x |
+| GlobalDataFlow.cs:61:78:61:90 | "not tainted" | GlobalDataFlow.cs:373:52:373:52 | x |
+| GlobalDataFlow.cs:61:78:61:90 | "not tainted" | GlobalDataFlow.cs:373:52:373:52 | x |
 | GlobalDataFlow.cs:64:9:64:18 | access to property InProperty | GlobalDataFlow.cs:64:9:64:18 | access to property InProperty |
 | GlobalDataFlow.cs:64:9:64:18 | this access | GlobalDataFlow.cs:64:9:64:18 | this access |
 | GlobalDataFlow.cs:64:9:64:18 | this access | GlobalDataFlow.cs:67:9:67:21 | this access |
 | GlobalDataFlow.cs:64:9:64:18 | this access | GlobalDataFlow.cs:67:9:67:21 | this access |
-| GlobalDataFlow.cs:64:9:64:18 | this access | GlobalDataFlow.cs:149:21:149:25 | this access |
-| GlobalDataFlow.cs:64:9:64:18 | this access | GlobalDataFlow.cs:149:21:149:25 | this access |
-| GlobalDataFlow.cs:64:9:64:18 | this access | GlobalDataFlow.cs:152:9:152:25 | this access |
-| GlobalDataFlow.cs:64:9:64:18 | this access | GlobalDataFlow.cs:152:9:152:25 | this access |
-| GlobalDataFlow.cs:64:9:64:18 | this access | GlobalDataFlow.cs:155:9:155:25 | this access |
-| GlobalDataFlow.cs:64:9:64:18 | this access | GlobalDataFlow.cs:155:9:155:25 | this access |
-| GlobalDataFlow.cs:64:9:64:18 | this access | GlobalDataFlow.cs:157:22:157:31 | this access |
-| GlobalDataFlow.cs:64:9:64:18 | this access | GlobalDataFlow.cs:157:22:157:31 | this access |
-| GlobalDataFlow.cs:64:9:64:18 | this access | GlobalDataFlow.cs:163:20:163:27 | this access |
-| GlobalDataFlow.cs:64:9:64:18 | this access | GlobalDataFlow.cs:163:20:163:27 | this access |
-| GlobalDataFlow.cs:64:9:64:18 | this access | GlobalDataFlow.cs:165:9:165:31 | this access |
-| GlobalDataFlow.cs:64:9:64:18 | this access | GlobalDataFlow.cs:165:9:165:31 | this access |
-| GlobalDataFlow.cs:64:9:64:18 | this access | GlobalDataFlow.cs:167:9:167:31 | this access |
-| GlobalDataFlow.cs:64:9:64:18 | this access | GlobalDataFlow.cs:167:9:167:31 | this access |
-| GlobalDataFlow.cs:64:9:64:18 | this access | GlobalDataFlow.cs:169:20:169:32 | this access |
-| GlobalDataFlow.cs:64:9:64:18 | this access | GlobalDataFlow.cs:169:20:169:32 | this access |
-| GlobalDataFlow.cs:64:9:64:18 | this access | GlobalDataFlow.cs:185:39:185:41 | this access |
-| GlobalDataFlow.cs:64:9:64:18 | this access | GlobalDataFlow.cs:185:39:185:41 | this access |
-| GlobalDataFlow.cs:64:9:64:18 | this access | GlobalDataFlow.cs:189:37:189:42 | this access |
-| GlobalDataFlow.cs:64:9:64:18 | this access | GlobalDataFlow.cs:189:37:189:42 | this access |
-| GlobalDataFlow.cs:64:9:64:18 | this access | GlobalDataFlow.cs:193:22:193:32 | this access |
-| GlobalDataFlow.cs:64:9:64:18 | this access | GlobalDataFlow.cs:193:22:193:32 | this access |
-| GlobalDataFlow.cs:64:9:64:18 | this access | GlobalDataFlow.cs:197:20:197:33 | this access |
-| GlobalDataFlow.cs:64:9:64:18 | this access | GlobalDataFlow.cs:197:20:197:33 | this access |
-| GlobalDataFlow.cs:64:9:64:18 | this access | GlobalDataFlow.cs:399:9:399:11 | this |
-| GlobalDataFlow.cs:64:9:64:18 | this access | GlobalDataFlow.cs:399:9:399:11 | this |
+| GlobalDataFlow.cs:64:9:64:18 | this access | GlobalDataFlow.cs:153:21:153:25 | this access |
+| GlobalDataFlow.cs:64:9:64:18 | this access | GlobalDataFlow.cs:153:21:153:25 | this access |
+| GlobalDataFlow.cs:64:9:64:18 | this access | GlobalDataFlow.cs:156:9:156:25 | this access |
+| GlobalDataFlow.cs:64:9:64:18 | this access | GlobalDataFlow.cs:156:9:156:25 | this access |
+| GlobalDataFlow.cs:64:9:64:18 | this access | GlobalDataFlow.cs:159:9:159:25 | this access |
+| GlobalDataFlow.cs:64:9:64:18 | this access | GlobalDataFlow.cs:159:9:159:25 | this access |
+| GlobalDataFlow.cs:64:9:64:18 | this access | GlobalDataFlow.cs:161:22:161:31 | this access |
+| GlobalDataFlow.cs:64:9:64:18 | this access | GlobalDataFlow.cs:161:22:161:31 | this access |
+| GlobalDataFlow.cs:64:9:64:18 | this access | GlobalDataFlow.cs:167:20:167:27 | this access |
+| GlobalDataFlow.cs:64:9:64:18 | this access | GlobalDataFlow.cs:167:20:167:27 | this access |
+| GlobalDataFlow.cs:64:9:64:18 | this access | GlobalDataFlow.cs:169:9:169:31 | this access |
+| GlobalDataFlow.cs:64:9:64:18 | this access | GlobalDataFlow.cs:169:9:169:31 | this access |
+| GlobalDataFlow.cs:64:9:64:18 | this access | GlobalDataFlow.cs:171:9:171:31 | this access |
+| GlobalDataFlow.cs:64:9:64:18 | this access | GlobalDataFlow.cs:171:9:171:31 | this access |
+| GlobalDataFlow.cs:64:9:64:18 | this access | GlobalDataFlow.cs:173:20:173:32 | this access |
+| GlobalDataFlow.cs:64:9:64:18 | this access | GlobalDataFlow.cs:173:20:173:32 | this access |
+| GlobalDataFlow.cs:64:9:64:18 | this access | GlobalDataFlow.cs:189:39:189:41 | this access |
+| GlobalDataFlow.cs:64:9:64:18 | this access | GlobalDataFlow.cs:189:39:189:41 | this access |
+| GlobalDataFlow.cs:64:9:64:18 | this access | GlobalDataFlow.cs:193:37:193:42 | this access |
+| GlobalDataFlow.cs:64:9:64:18 | this access | GlobalDataFlow.cs:193:37:193:42 | this access |
+| GlobalDataFlow.cs:64:9:64:18 | this access | GlobalDataFlow.cs:197:22:197:32 | this access |
+| GlobalDataFlow.cs:64:9:64:18 | this access | GlobalDataFlow.cs:197:22:197:32 | this access |
+| GlobalDataFlow.cs:64:9:64:18 | this access | GlobalDataFlow.cs:201:20:201:33 | this access |
+| GlobalDataFlow.cs:64:9:64:18 | this access | GlobalDataFlow.cs:201:20:201:33 | this access |
+| GlobalDataFlow.cs:64:9:64:18 | this access | GlobalDataFlow.cs:404:9:404:11 | this |
+| GlobalDataFlow.cs:64:9:64:18 | this access | GlobalDataFlow.cs:404:9:404:11 | this |
 | GlobalDataFlow.cs:64:9:64:39 | ... = ... | GlobalDataFlow.cs:64:9:64:39 | ... = ... |
 | GlobalDataFlow.cs:64:22:64:39 | access to property SinkProperty0 | GlobalDataFlow.cs:64:22:64:39 | access to property SinkProperty0 |
 | GlobalDataFlow.cs:64:22:64:39 | access to property SinkProperty0 | GlobalDataFlow.cs:70:28:70:45 | access to property SinkProperty0 |
 | GlobalDataFlow.cs:64:22:64:39 | access to property SinkProperty0 | GlobalDataFlow.cs:70:28:70:45 | access to property SinkProperty0 |
-| GlobalDataFlow.cs:64:22:64:39 | access to property SinkProperty0 | GlobalDataFlow.cs:399:9:399:11 | value |
-| GlobalDataFlow.cs:64:22:64:39 | access to property SinkProperty0 | GlobalDataFlow.cs:399:9:399:11 | value |
+| GlobalDataFlow.cs:64:22:64:39 | access to property SinkProperty0 | GlobalDataFlow.cs:404:9:404:11 | value |
+| GlobalDataFlow.cs:64:22:64:39 | access to property SinkProperty0 | GlobalDataFlow.cs:404:9:404:11 | value |
 | GlobalDataFlow.cs:67:9:67:21 | access to property NonInProperty | GlobalDataFlow.cs:67:9:67:21 | access to property NonInProperty |
 | GlobalDataFlow.cs:67:9:67:21 | this access | GlobalDataFlow.cs:67:9:67:21 | this access |
-| GlobalDataFlow.cs:67:9:67:21 | this access | GlobalDataFlow.cs:149:21:149:25 | this access |
-| GlobalDataFlow.cs:67:9:67:21 | this access | GlobalDataFlow.cs:149:21:149:25 | this access |
-| GlobalDataFlow.cs:67:9:67:21 | this access | GlobalDataFlow.cs:152:9:152:25 | this access |
-| GlobalDataFlow.cs:67:9:67:21 | this access | GlobalDataFlow.cs:152:9:152:25 | this access |
-| GlobalDataFlow.cs:67:9:67:21 | this access | GlobalDataFlow.cs:155:9:155:25 | this access |
-| GlobalDataFlow.cs:67:9:67:21 | this access | GlobalDataFlow.cs:155:9:155:25 | this access |
-| GlobalDataFlow.cs:67:9:67:21 | this access | GlobalDataFlow.cs:157:22:157:31 | this access |
-| GlobalDataFlow.cs:67:9:67:21 | this access | GlobalDataFlow.cs:157:22:157:31 | this access |
-| GlobalDataFlow.cs:67:9:67:21 | this access | GlobalDataFlow.cs:163:20:163:27 | this access |
-| GlobalDataFlow.cs:67:9:67:21 | this access | GlobalDataFlow.cs:163:20:163:27 | this access |
-| GlobalDataFlow.cs:67:9:67:21 | this access | GlobalDataFlow.cs:165:9:165:31 | this access |
-| GlobalDataFlow.cs:67:9:67:21 | this access | GlobalDataFlow.cs:165:9:165:31 | this access |
-| GlobalDataFlow.cs:67:9:67:21 | this access | GlobalDataFlow.cs:167:9:167:31 | this access |
-| GlobalDataFlow.cs:67:9:67:21 | this access | GlobalDataFlow.cs:167:9:167:31 | this access |
-| GlobalDataFlow.cs:67:9:67:21 | this access | GlobalDataFlow.cs:169:20:169:32 | this access |
-| GlobalDataFlow.cs:67:9:67:21 | this access | GlobalDataFlow.cs:169:20:169:32 | this access |
-| GlobalDataFlow.cs:67:9:67:21 | this access | GlobalDataFlow.cs:185:39:185:41 | this access |
-| GlobalDataFlow.cs:67:9:67:21 | this access | GlobalDataFlow.cs:185:39:185:41 | this access |
-| GlobalDataFlow.cs:67:9:67:21 | this access | GlobalDataFlow.cs:189:37:189:42 | this access |
-| GlobalDataFlow.cs:67:9:67:21 | this access | GlobalDataFlow.cs:189:37:189:42 | this access |
-| GlobalDataFlow.cs:67:9:67:21 | this access | GlobalDataFlow.cs:193:22:193:32 | this access |
-| GlobalDataFlow.cs:67:9:67:21 | this access | GlobalDataFlow.cs:193:22:193:32 | this access |
-| GlobalDataFlow.cs:67:9:67:21 | this access | GlobalDataFlow.cs:197:20:197:33 | this access |
-| GlobalDataFlow.cs:67:9:67:21 | this access | GlobalDataFlow.cs:197:20:197:33 | this access |
-| GlobalDataFlow.cs:67:9:67:21 | this access | GlobalDataFlow.cs:405:9:405:11 | this |
-| GlobalDataFlow.cs:67:9:67:21 | this access | GlobalDataFlow.cs:405:9:405:11 | this |
+| GlobalDataFlow.cs:67:9:67:21 | this access | GlobalDataFlow.cs:153:21:153:25 | this access |
+| GlobalDataFlow.cs:67:9:67:21 | this access | GlobalDataFlow.cs:153:21:153:25 | this access |
+| GlobalDataFlow.cs:67:9:67:21 | this access | GlobalDataFlow.cs:156:9:156:25 | this access |
+| GlobalDataFlow.cs:67:9:67:21 | this access | GlobalDataFlow.cs:156:9:156:25 | this access |
+| GlobalDataFlow.cs:67:9:67:21 | this access | GlobalDataFlow.cs:159:9:159:25 | this access |
+| GlobalDataFlow.cs:67:9:67:21 | this access | GlobalDataFlow.cs:159:9:159:25 | this access |
+| GlobalDataFlow.cs:67:9:67:21 | this access | GlobalDataFlow.cs:161:22:161:31 | this access |
+| GlobalDataFlow.cs:67:9:67:21 | this access | GlobalDataFlow.cs:161:22:161:31 | this access |
+| GlobalDataFlow.cs:67:9:67:21 | this access | GlobalDataFlow.cs:167:20:167:27 | this access |
+| GlobalDataFlow.cs:67:9:67:21 | this access | GlobalDataFlow.cs:167:20:167:27 | this access |
+| GlobalDataFlow.cs:67:9:67:21 | this access | GlobalDataFlow.cs:169:9:169:31 | this access |
+| GlobalDataFlow.cs:67:9:67:21 | this access | GlobalDataFlow.cs:169:9:169:31 | this access |
+| GlobalDataFlow.cs:67:9:67:21 | this access | GlobalDataFlow.cs:171:9:171:31 | this access |
+| GlobalDataFlow.cs:67:9:67:21 | this access | GlobalDataFlow.cs:171:9:171:31 | this access |
+| GlobalDataFlow.cs:67:9:67:21 | this access | GlobalDataFlow.cs:173:20:173:32 | this access |
+| GlobalDataFlow.cs:67:9:67:21 | this access | GlobalDataFlow.cs:173:20:173:32 | this access |
+| GlobalDataFlow.cs:67:9:67:21 | this access | GlobalDataFlow.cs:189:39:189:41 | this access |
+| GlobalDataFlow.cs:67:9:67:21 | this access | GlobalDataFlow.cs:189:39:189:41 | this access |
+| GlobalDataFlow.cs:67:9:67:21 | this access | GlobalDataFlow.cs:193:37:193:42 | this access |
+| GlobalDataFlow.cs:67:9:67:21 | this access | GlobalDataFlow.cs:193:37:193:42 | this access |
+| GlobalDataFlow.cs:67:9:67:21 | this access | GlobalDataFlow.cs:197:22:197:32 | this access |
+| GlobalDataFlow.cs:67:9:67:21 | this access | GlobalDataFlow.cs:197:22:197:32 | this access |
+| GlobalDataFlow.cs:67:9:67:21 | this access | GlobalDataFlow.cs:201:20:201:33 | this access |
+| GlobalDataFlow.cs:67:9:67:21 | this access | GlobalDataFlow.cs:201:20:201:33 | this access |
+| GlobalDataFlow.cs:67:9:67:21 | this access | GlobalDataFlow.cs:410:9:410:11 | this |
+| GlobalDataFlow.cs:67:9:67:21 | this access | GlobalDataFlow.cs:410:9:410:11 | this |
 | GlobalDataFlow.cs:67:9:67:37 | ... = ... | GlobalDataFlow.cs:67:9:67:37 | ... = ... |
 | GlobalDataFlow.cs:67:25:67:37 | "not tainted" | GlobalDataFlow.cs:67:25:67:37 | "not tainted" |
-| GlobalDataFlow.cs:67:25:67:37 | "not tainted" | GlobalDataFlow.cs:405:9:405:11 | value |
-| GlobalDataFlow.cs:67:25:67:37 | "not tainted" | GlobalDataFlow.cs:405:9:405:11 | value |
+| GlobalDataFlow.cs:67:25:67:37 | "not tainted" | GlobalDataFlow.cs:410:9:410:11 | value |
+| GlobalDataFlow.cs:67:25:67:37 | "not tainted" | GlobalDataFlow.cs:410:9:410:11 | value |
 | GlobalDataFlow.cs:70:13:70:46 | SSA def(sink0) | GlobalDataFlow.cs:70:13:70:46 | SSA def(sink0) |
 | GlobalDataFlow.cs:70:13:70:46 | SSA def(sink0) | GlobalDataFlow.cs:71:15:71:19 | access to local variable sink0 |
 | GlobalDataFlow.cs:70:13:70:46 | SSA def(sink0) | GlobalDataFlow.cs:71:15:71:19 | access to local variable sink0 |
@@ -1353,8 +1353,8 @@
 | GlobalDataFlow.cs:70:28:70:45 | access to property SinkProperty0 | GlobalDataFlow.cs:70:21:70:46 | call to method Return |
 | GlobalDataFlow.cs:70:28:70:45 | access to property SinkProperty0 | GlobalDataFlow.cs:70:21:70:46 | call to method Return |
 | GlobalDataFlow.cs:70:28:70:45 | access to property SinkProperty0 | GlobalDataFlow.cs:70:28:70:45 | access to property SinkProperty0 |
-| GlobalDataFlow.cs:70:28:70:45 | access to property SinkProperty0 | GlobalDataFlow.cs:271:26:271:26 | x |
-| GlobalDataFlow.cs:70:28:70:45 | access to property SinkProperty0 | GlobalDataFlow.cs:271:26:271:26 | x |
+| GlobalDataFlow.cs:70:28:70:45 | access to property SinkProperty0 | GlobalDataFlow.cs:275:26:275:26 | x |
+| GlobalDataFlow.cs:70:28:70:45 | access to property SinkProperty0 | GlobalDataFlow.cs:275:26:275:26 | x |
 | GlobalDataFlow.cs:71:9:71:20 | call to method Check | GlobalDataFlow.cs:71:9:71:20 | call to method Check |
 | GlobalDataFlow.cs:71:15:71:19 | access to local variable sink0 | GlobalDataFlow.cs:71:15:71:19 | access to local variable sink0 |
 | GlobalDataFlow.cs:71:15:71:19 | access to local variable sink0 | GlobalDataFlow.cs:72:79:72:100 | array creation of type Object[] |
@@ -1366,8 +1366,12 @@
 | GlobalDataFlow.cs:72:13:72:101 | SSA def(sink1) | GlobalDataFlow.cs:73:15:73:19 | access to local variable sink1 |
 | GlobalDataFlow.cs:72:13:72:101 | SSA def(sink1) | GlobalDataFlow.cs:75:19:75:23 | access to local variable sink1 |
 | GlobalDataFlow.cs:72:13:72:101 | SSA def(sink1) | GlobalDataFlow.cs:75:19:75:23 | access to local variable sink1 |
-| GlobalDataFlow.cs:72:13:72:101 | SSA def(sink1) | GlobalDataFlow.cs:120:39:120:43 | access to local variable sink1 |
-| GlobalDataFlow.cs:72:13:72:101 | SSA def(sink1) | GlobalDataFlow.cs:120:39:120:43 | access to local variable sink1 |
+| GlobalDataFlow.cs:72:13:72:101 | SSA def(sink1) | GlobalDataFlow.cs:106:19:106:23 | access to local variable sink1 |
+| GlobalDataFlow.cs:72:13:72:101 | SSA def(sink1) | GlobalDataFlow.cs:106:19:106:23 | access to local variable sink1 |
+| GlobalDataFlow.cs:72:13:72:101 | SSA def(sink1) | GlobalDataFlow.cs:110:19:110:23 | access to local variable sink1 |
+| GlobalDataFlow.cs:72:13:72:101 | SSA def(sink1) | GlobalDataFlow.cs:110:19:110:23 | access to local variable sink1 |
+| GlobalDataFlow.cs:72:13:72:101 | SSA def(sink1) | GlobalDataFlow.cs:110:30:110:34 | access to local variable sink1 |
+| GlobalDataFlow.cs:72:13:72:101 | SSA def(sink1) | GlobalDataFlow.cs:110:30:110:34 | access to local variable sink1 |
 | GlobalDataFlow.cs:72:13:72:101 | String sink1 = ... | GlobalDataFlow.cs:72:13:72:101 | String sink1 = ... |
 | GlobalDataFlow.cs:72:21:72:101 | (...) ... | GlobalDataFlow.cs:72:13:72:101 | SSA def(sink1) |
 | GlobalDataFlow.cs:72:21:72:101 | (...) ... | GlobalDataFlow.cs:72:13:72:101 | SSA def(sink1) |
@@ -1376,8 +1380,12 @@
 | GlobalDataFlow.cs:72:21:72:101 | (...) ... | GlobalDataFlow.cs:73:15:73:19 | access to local variable sink1 |
 | GlobalDataFlow.cs:72:21:72:101 | (...) ... | GlobalDataFlow.cs:75:19:75:23 | access to local variable sink1 |
 | GlobalDataFlow.cs:72:21:72:101 | (...) ... | GlobalDataFlow.cs:75:19:75:23 | access to local variable sink1 |
-| GlobalDataFlow.cs:72:21:72:101 | (...) ... | GlobalDataFlow.cs:120:39:120:43 | access to local variable sink1 |
-| GlobalDataFlow.cs:72:21:72:101 | (...) ... | GlobalDataFlow.cs:120:39:120:43 | access to local variable sink1 |
+| GlobalDataFlow.cs:72:21:72:101 | (...) ... | GlobalDataFlow.cs:106:19:106:23 | access to local variable sink1 |
+| GlobalDataFlow.cs:72:21:72:101 | (...) ... | GlobalDataFlow.cs:106:19:106:23 | access to local variable sink1 |
+| GlobalDataFlow.cs:72:21:72:101 | (...) ... | GlobalDataFlow.cs:110:19:110:23 | access to local variable sink1 |
+| GlobalDataFlow.cs:72:21:72:101 | (...) ... | GlobalDataFlow.cs:110:19:110:23 | access to local variable sink1 |
+| GlobalDataFlow.cs:72:21:72:101 | (...) ... | GlobalDataFlow.cs:110:30:110:34 | access to local variable sink1 |
+| GlobalDataFlow.cs:72:21:72:101 | (...) ... | GlobalDataFlow.cs:110:30:110:34 | access to local variable sink1 |
 | GlobalDataFlow.cs:72:29:72:44 | typeof(...) | GlobalDataFlow.cs:72:29:72:44 | typeof(...) |
 | GlobalDataFlow.cs:72:29:72:64 | call to method GetMethod | GlobalDataFlow.cs:72:29:72:64 | call to method GetMethod |
 | GlobalDataFlow.cs:72:29:72:101 | call to method Invoke | GlobalDataFlow.cs:72:21:72:101 | (...) ... |
@@ -1392,23 +1400,31 @@
 | GlobalDataFlow.cs:72:94:72:98 | access to local variable sink0 | GlobalDataFlow.cs:72:79:72:100 | array creation of type Object[] |
 | GlobalDataFlow.cs:72:94:72:98 | access to local variable sink0 | GlobalDataFlow.cs:72:79:72:100 | array creation of type Object[] |
 | GlobalDataFlow.cs:72:94:72:98 | access to local variable sink0 | GlobalDataFlow.cs:72:94:72:98 | access to local variable sink0 |
-| GlobalDataFlow.cs:72:94:72:98 | access to local variable sink0 | GlobalDataFlow.cs:271:26:271:26 | x |
-| GlobalDataFlow.cs:72:94:72:98 | access to local variable sink0 | GlobalDataFlow.cs:271:26:271:26 | x |
+| GlobalDataFlow.cs:72:94:72:98 | access to local variable sink0 | GlobalDataFlow.cs:275:26:275:26 | x |
+| GlobalDataFlow.cs:72:94:72:98 | access to local variable sink0 | GlobalDataFlow.cs:275:26:275:26 | x |
 | GlobalDataFlow.cs:73:9:73:20 | call to method Check | GlobalDataFlow.cs:73:9:73:20 | call to method Check |
 | GlobalDataFlow.cs:73:15:73:19 | access to local variable sink1 | GlobalDataFlow.cs:73:15:73:19 | access to local variable sink1 |
 | GlobalDataFlow.cs:73:15:73:19 | access to local variable sink1 | GlobalDataFlow.cs:75:19:75:23 | access to local variable sink1 |
 | GlobalDataFlow.cs:73:15:73:19 | access to local variable sink1 | GlobalDataFlow.cs:75:19:75:23 | access to local variable sink1 |
-| GlobalDataFlow.cs:73:15:73:19 | access to local variable sink1 | GlobalDataFlow.cs:120:39:120:43 | access to local variable sink1 |
-| GlobalDataFlow.cs:73:15:73:19 | access to local variable sink1 | GlobalDataFlow.cs:120:39:120:43 | access to local variable sink1 |
+| GlobalDataFlow.cs:73:15:73:19 | access to local variable sink1 | GlobalDataFlow.cs:106:19:106:23 | access to local variable sink1 |
+| GlobalDataFlow.cs:73:15:73:19 | access to local variable sink1 | GlobalDataFlow.cs:106:19:106:23 | access to local variable sink1 |
+| GlobalDataFlow.cs:73:15:73:19 | access to local variable sink1 | GlobalDataFlow.cs:110:19:110:23 | access to local variable sink1 |
+| GlobalDataFlow.cs:73:15:73:19 | access to local variable sink1 | GlobalDataFlow.cs:110:19:110:23 | access to local variable sink1 |
+| GlobalDataFlow.cs:73:15:73:19 | access to local variable sink1 | GlobalDataFlow.cs:110:30:110:34 | access to local variable sink1 |
+| GlobalDataFlow.cs:73:15:73:19 | access to local variable sink1 | GlobalDataFlow.cs:110:30:110:34 | access to local variable sink1 |
 | GlobalDataFlow.cs:74:16:74:20 | String sink2 | GlobalDataFlow.cs:74:16:74:20 | String sink2 |
-| GlobalDataFlow.cs:75:9:75:35 | call to method ReturnOut | GlobalDataFlow.cs:75:9:75:35 | call to method ReturnOut |
+| GlobalDataFlow.cs:75:9:75:46 | call to method ReturnOut | GlobalDataFlow.cs:75:9:75:46 | call to method ReturnOut |
 | GlobalDataFlow.cs:75:19:75:23 | access to local variable sink1 | GlobalDataFlow.cs:75:19:75:23 | access to local variable sink1 |
 | GlobalDataFlow.cs:75:19:75:23 | access to local variable sink1 | GlobalDataFlow.cs:75:30:75:34 | SSA def(sink2) |
 | GlobalDataFlow.cs:75:19:75:23 | access to local variable sink1 | GlobalDataFlow.cs:75:30:75:34 | SSA def(sink2) |
-| GlobalDataFlow.cs:75:19:75:23 | access to local variable sink1 | GlobalDataFlow.cs:120:39:120:43 | access to local variable sink1 |
-| GlobalDataFlow.cs:75:19:75:23 | access to local variable sink1 | GlobalDataFlow.cs:120:39:120:43 | access to local variable sink1 |
-| GlobalDataFlow.cs:75:19:75:23 | access to local variable sink1 | GlobalDataFlow.cs:277:32:277:32 | x |
-| GlobalDataFlow.cs:75:19:75:23 | access to local variable sink1 | GlobalDataFlow.cs:277:32:277:32 | x |
+| GlobalDataFlow.cs:75:19:75:23 | access to local variable sink1 | GlobalDataFlow.cs:106:19:106:23 | access to local variable sink1 |
+| GlobalDataFlow.cs:75:19:75:23 | access to local variable sink1 | GlobalDataFlow.cs:106:19:106:23 | access to local variable sink1 |
+| GlobalDataFlow.cs:75:19:75:23 | access to local variable sink1 | GlobalDataFlow.cs:110:19:110:23 | access to local variable sink1 |
+| GlobalDataFlow.cs:75:19:75:23 | access to local variable sink1 | GlobalDataFlow.cs:110:19:110:23 | access to local variable sink1 |
+| GlobalDataFlow.cs:75:19:75:23 | access to local variable sink1 | GlobalDataFlow.cs:110:30:110:34 | access to local variable sink1 |
+| GlobalDataFlow.cs:75:19:75:23 | access to local variable sink1 | GlobalDataFlow.cs:110:30:110:34 | access to local variable sink1 |
+| GlobalDataFlow.cs:75:19:75:23 | access to local variable sink1 | GlobalDataFlow.cs:281:32:281:32 | x |
+| GlobalDataFlow.cs:75:19:75:23 | access to local variable sink1 | GlobalDataFlow.cs:281:32:281:32 | x |
 | GlobalDataFlow.cs:75:30:75:34 | SSA def(sink2) | GlobalDataFlow.cs:75:30:75:34 | SSA def(sink2) |
 | GlobalDataFlow.cs:75:30:75:34 | SSA def(sink2) | GlobalDataFlow.cs:76:15:76:19 | access to local variable sink2 |
 | GlobalDataFlow.cs:75:30:75:34 | SSA def(sink2) | GlobalDataFlow.cs:76:15:76:19 | access to local variable sink2 |
@@ -1421,18 +1437,22 @@
 | GlobalDataFlow.cs:77:13:77:22 | SSA def(sink3) | GlobalDataFlow.cs:77:13:77:22 | SSA def(sink3) |
 | GlobalDataFlow.cs:77:13:77:22 | SSA def(sink3) | GlobalDataFlow.cs:78:30:78:34 | access to local variable sink3 |
 | GlobalDataFlow.cs:77:13:77:22 | SSA def(sink3) | GlobalDataFlow.cs:78:30:78:34 | access to local variable sink3 |
+| GlobalDataFlow.cs:77:13:77:22 | SSA def(sink3) | GlobalDataFlow.cs:78:41:78:45 | access to local variable sink3 |
+| GlobalDataFlow.cs:77:13:77:22 | SSA def(sink3) | GlobalDataFlow.cs:78:41:78:45 | access to local variable sink3 |
 | GlobalDataFlow.cs:77:13:77:22 | String sink3 = ... | GlobalDataFlow.cs:77:13:77:22 | String sink3 = ... |
 | GlobalDataFlow.cs:77:21:77:22 | "" | GlobalDataFlow.cs:77:13:77:22 | SSA def(sink3) |
 | GlobalDataFlow.cs:77:21:77:22 | "" | GlobalDataFlow.cs:77:13:77:22 | SSA def(sink3) |
 | GlobalDataFlow.cs:77:21:77:22 | "" | GlobalDataFlow.cs:77:21:77:22 | "" |
 | GlobalDataFlow.cs:77:21:77:22 | "" | GlobalDataFlow.cs:78:30:78:34 | access to local variable sink3 |
 | GlobalDataFlow.cs:77:21:77:22 | "" | GlobalDataFlow.cs:78:30:78:34 | access to local variable sink3 |
-| GlobalDataFlow.cs:78:9:78:35 | call to method ReturnRef | GlobalDataFlow.cs:78:9:78:35 | call to method ReturnRef |
+| GlobalDataFlow.cs:77:21:77:22 | "" | GlobalDataFlow.cs:78:41:78:45 | access to local variable sink3 |
+| GlobalDataFlow.cs:77:21:77:22 | "" | GlobalDataFlow.cs:78:41:78:45 | access to local variable sink3 |
+| GlobalDataFlow.cs:78:9:78:46 | call to method ReturnRef | GlobalDataFlow.cs:78:9:78:46 | call to method ReturnRef |
 | GlobalDataFlow.cs:78:19:78:23 | access to local variable sink2 | GlobalDataFlow.cs:78:19:78:23 | access to local variable sink2 |
 | GlobalDataFlow.cs:78:19:78:23 | access to local variable sink2 | GlobalDataFlow.cs:78:30:78:34 | SSA def(sink3) |
 | GlobalDataFlow.cs:78:19:78:23 | access to local variable sink2 | GlobalDataFlow.cs:78:30:78:34 | SSA def(sink3) |
-| GlobalDataFlow.cs:78:19:78:23 | access to local variable sink2 | GlobalDataFlow.cs:282:32:282:32 | x |
-| GlobalDataFlow.cs:78:19:78:23 | access to local variable sink2 | GlobalDataFlow.cs:282:32:282:32 | x |
+| GlobalDataFlow.cs:78:19:78:23 | access to local variable sink2 | GlobalDataFlow.cs:287:32:287:32 | x |
+| GlobalDataFlow.cs:78:19:78:23 | access to local variable sink2 | GlobalDataFlow.cs:287:32:287:32 | x |
 | GlobalDataFlow.cs:78:30:78:34 | SSA def(sink3) | GlobalDataFlow.cs:78:30:78:34 | SSA def(sink3) |
 | GlobalDataFlow.cs:78:30:78:34 | SSA def(sink3) | GlobalDataFlow.cs:79:15:79:19 | access to local variable sink3 |
 | GlobalDataFlow.cs:78:30:78:34 | SSA def(sink3) | GlobalDataFlow.cs:79:15:79:19 | access to local variable sink3 |
@@ -1442,9 +1462,16 @@
 | GlobalDataFlow.cs:78:30:78:34 | SSA def(sink3) | GlobalDataFlow.cs:80:44:80:65 | array creation of type String[] |
 | GlobalDataFlow.cs:78:30:78:34 | SSA def(sink3) | GlobalDataFlow.cs:80:59:80:63 | access to local variable sink3 |
 | GlobalDataFlow.cs:78:30:78:34 | SSA def(sink3) | GlobalDataFlow.cs:80:59:80:63 | access to local variable sink3 |
-| GlobalDataFlow.cs:78:30:78:34 | SSA def(sink3) | GlobalDataFlow.cs:131:29:131:33 | access to local variable sink3 |
-| GlobalDataFlow.cs:78:30:78:34 | SSA def(sink3) | GlobalDataFlow.cs:131:29:131:33 | access to local variable sink3 |
+| GlobalDataFlow.cs:78:30:78:34 | SSA def(sink3) | GlobalDataFlow.cs:135:29:135:33 | access to local variable sink3 |
+| GlobalDataFlow.cs:78:30:78:34 | SSA def(sink3) | GlobalDataFlow.cs:135:29:135:33 | access to local variable sink3 |
 | GlobalDataFlow.cs:78:30:78:34 | access to local variable sink3 | GlobalDataFlow.cs:78:30:78:34 | access to local variable sink3 |
+| GlobalDataFlow.cs:78:30:78:34 | access to local variable sink3 | GlobalDataFlow.cs:78:41:78:45 | access to local variable sink3 |
+| GlobalDataFlow.cs:78:30:78:34 | access to local variable sink3 | GlobalDataFlow.cs:78:41:78:45 | access to local variable sink3 |
+| GlobalDataFlow.cs:78:41:78:45 | access to local variable sink3 | GlobalDataFlow.cs:78:30:78:34 | SSA def(sink3) |
+| GlobalDataFlow.cs:78:41:78:45 | access to local variable sink3 | GlobalDataFlow.cs:78:30:78:34 | SSA def(sink3) |
+| GlobalDataFlow.cs:78:41:78:45 | access to local variable sink3 | GlobalDataFlow.cs:78:41:78:45 | access to local variable sink3 |
+| GlobalDataFlow.cs:78:41:78:45 | access to local variable sink3 | GlobalDataFlow.cs:287:50:287:50 | z |
+| GlobalDataFlow.cs:78:41:78:45 | access to local variable sink3 | GlobalDataFlow.cs:287:50:287:50 | z |
 | GlobalDataFlow.cs:79:9:79:20 | call to method Check | GlobalDataFlow.cs:79:9:79:20 | call to method Check |
 | GlobalDataFlow.cs:79:15:79:19 | access to local variable sink3 | GlobalDataFlow.cs:79:15:79:19 | access to local variable sink3 |
 | GlobalDataFlow.cs:79:15:79:19 | access to local variable sink3 | GlobalDataFlow.cs:80:23:80:65 | (...) ... |
@@ -1453,8 +1480,8 @@
 | GlobalDataFlow.cs:79:15:79:19 | access to local variable sink3 | GlobalDataFlow.cs:80:44:80:65 | array creation of type String[] |
 | GlobalDataFlow.cs:79:15:79:19 | access to local variable sink3 | GlobalDataFlow.cs:80:59:80:63 | access to local variable sink3 |
 | GlobalDataFlow.cs:79:15:79:19 | access to local variable sink3 | GlobalDataFlow.cs:80:59:80:63 | access to local variable sink3 |
-| GlobalDataFlow.cs:79:15:79:19 | access to local variable sink3 | GlobalDataFlow.cs:131:29:131:33 | access to local variable sink3 |
-| GlobalDataFlow.cs:79:15:79:19 | access to local variable sink3 | GlobalDataFlow.cs:131:29:131:33 | access to local variable sink3 |
+| GlobalDataFlow.cs:79:15:79:19 | access to local variable sink3 | GlobalDataFlow.cs:135:29:135:33 | access to local variable sink3 |
+| GlobalDataFlow.cs:79:15:79:19 | access to local variable sink3 | GlobalDataFlow.cs:135:29:135:33 | access to local variable sink3 |
 | GlobalDataFlow.cs:80:13:80:85 | IEnumerable<String> sink13 = ... | GlobalDataFlow.cs:80:13:80:85 | IEnumerable<String> sink13 = ... |
 | GlobalDataFlow.cs:80:13:80:85 | SSA def(sink13) | GlobalDataFlow.cs:80:13:80:85 | SSA def(sink13) |
 | GlobalDataFlow.cs:80:13:80:85 | SSA def(sink13) | GlobalDataFlow.cs:81:15:81:20 | access to local variable sink13 |
@@ -1483,8 +1510,8 @@
 | GlobalDataFlow.cs:80:23:80:65 | (...) ... | GlobalDataFlow.cs:80:22:80:85 | call to method SelectEven |
 | GlobalDataFlow.cs:80:23:80:65 | (...) ... | GlobalDataFlow.cs:80:22:80:85 | call to method SelectEven |
 | GlobalDataFlow.cs:80:23:80:65 | (...) ... | GlobalDataFlow.cs:80:23:80:65 | (...) ... |
-| GlobalDataFlow.cs:80:23:80:65 | (...) ... | GlobalDataFlow.cs:421:71:421:71 | e |
-| GlobalDataFlow.cs:80:23:80:65 | (...) ... | GlobalDataFlow.cs:421:71:421:71 | e |
+| GlobalDataFlow.cs:80:23:80:65 | (...) ... | GlobalDataFlow.cs:426:71:426:71 | e |
+| GlobalDataFlow.cs:80:23:80:65 | (...) ... | GlobalDataFlow.cs:426:71:426:71 | e |
 | GlobalDataFlow.cs:80:44:80:65 | array creation of type String[] | GlobalDataFlow.cs:80:23:80:65 | (...) ... |
 | GlobalDataFlow.cs:80:44:80:65 | array creation of type String[] | GlobalDataFlow.cs:80:23:80:65 | (...) ... |
 | GlobalDataFlow.cs:80:44:80:65 | array creation of type String[] | GlobalDataFlow.cs:80:44:80:65 | array creation of type String[] |
@@ -1494,8 +1521,8 @@
 | GlobalDataFlow.cs:80:59:80:63 | access to local variable sink3 | GlobalDataFlow.cs:80:44:80:65 | array creation of type String[] |
 | GlobalDataFlow.cs:80:59:80:63 | access to local variable sink3 | GlobalDataFlow.cs:80:44:80:65 | array creation of type String[] |
 | GlobalDataFlow.cs:80:59:80:63 | access to local variable sink3 | GlobalDataFlow.cs:80:59:80:63 | access to local variable sink3 |
-| GlobalDataFlow.cs:80:59:80:63 | access to local variable sink3 | GlobalDataFlow.cs:131:29:131:33 | access to local variable sink3 |
-| GlobalDataFlow.cs:80:59:80:63 | access to local variable sink3 | GlobalDataFlow.cs:131:29:131:33 | access to local variable sink3 |
+| GlobalDataFlow.cs:80:59:80:63 | access to local variable sink3 | GlobalDataFlow.cs:135:29:135:33 | access to local variable sink3 |
+| GlobalDataFlow.cs:80:59:80:63 | access to local variable sink3 | GlobalDataFlow.cs:135:29:135:33 | access to local variable sink3 |
 | GlobalDataFlow.cs:80:79:80:79 | x | GlobalDataFlow.cs:80:79:80:79 | x |
 | GlobalDataFlow.cs:80:79:80:79 | x | GlobalDataFlow.cs:80:79:80:79 | x |
 | GlobalDataFlow.cs:80:79:80:79 | x | GlobalDataFlow.cs:80:79:80:79 | x |
@@ -1507,11 +1534,11 @@
 | GlobalDataFlow.cs:80:79:80:79 | x | GlobalDataFlow.cs:80:84:80:84 | access to parameter x |
 | GlobalDataFlow.cs:80:79:80:79 | x | GlobalDataFlow.cs:80:84:80:84 | access to parameter x |
 | GlobalDataFlow.cs:80:79:80:84 | (...) => ... | GlobalDataFlow.cs:80:79:80:84 | (...) => ... |
-| GlobalDataFlow.cs:80:79:80:84 | (...) => ... | GlobalDataFlow.cs:421:85:421:85 | f |
-| GlobalDataFlow.cs:80:79:80:84 | (...) => ... | GlobalDataFlow.cs:421:85:421:85 | f |
+| GlobalDataFlow.cs:80:79:80:84 | (...) => ... | GlobalDataFlow.cs:426:85:426:85 | f |
+| GlobalDataFlow.cs:80:79:80:84 | (...) => ... | GlobalDataFlow.cs:426:85:426:85 | f |
 | GlobalDataFlow.cs:80:84:80:84 | access to parameter x | GlobalDataFlow.cs:80:84:80:84 | access to parameter x |
-| GlobalDataFlow.cs:80:84:80:84 | access to parameter x | GlobalDataFlow.cs:426:44:426:47 | delegate call |
-| GlobalDataFlow.cs:80:84:80:84 | access to parameter x | GlobalDataFlow.cs:426:44:426:47 | delegate call |
+| GlobalDataFlow.cs:80:84:80:84 | access to parameter x | GlobalDataFlow.cs:431:44:431:47 | delegate call |
+| GlobalDataFlow.cs:80:84:80:84 | access to parameter x | GlobalDataFlow.cs:431:44:431:47 | delegate call |
 | GlobalDataFlow.cs:81:9:81:21 | call to method Check | GlobalDataFlow.cs:81:9:81:21 | call to method Check |
 | GlobalDataFlow.cs:81:15:81:20 | access to local variable sink13 | GlobalDataFlow.cs:81:15:81:20 | access to local variable sink13 |
 | GlobalDataFlow.cs:81:15:81:20 | access to local variable sink13 | GlobalDataFlow.cs:82:23:82:74 | (...) ... |
@@ -1540,18 +1567,18 @@
 | GlobalDataFlow.cs:82:13:82:95 | SSA def(sink14) | GlobalDataFlow.cs:90:75:90:80 | access to local variable sink14 |
 | GlobalDataFlow.cs:82:13:82:95 | SSA def(sink14) | GlobalDataFlow.cs:90:75:90:88 | call to method First |
 | GlobalDataFlow.cs:82:13:82:95 | SSA def(sink14) | GlobalDataFlow.cs:90:75:90:88 | call to method First |
-| GlobalDataFlow.cs:82:13:82:95 | SSA def(sink14) | GlobalDataFlow.cs:112:21:112:72 | (...) ... |
-| GlobalDataFlow.cs:82:13:82:95 | SSA def(sink14) | GlobalDataFlow.cs:112:21:112:72 | (...) ... |
-| GlobalDataFlow.cs:82:13:82:95 | SSA def(sink14) | GlobalDataFlow.cs:112:42:112:72 | array creation of type String[] |
-| GlobalDataFlow.cs:82:13:82:95 | SSA def(sink14) | GlobalDataFlow.cs:112:42:112:72 | array creation of type String[] |
-| GlobalDataFlow.cs:82:13:82:95 | SSA def(sink14) | GlobalDataFlow.cs:112:57:112:62 | access to local variable sink14 |
-| GlobalDataFlow.cs:82:13:82:95 | SSA def(sink14) | GlobalDataFlow.cs:112:57:112:62 | access to local variable sink14 |
-| GlobalDataFlow.cs:82:13:82:95 | SSA def(sink14) | GlobalDataFlow.cs:112:57:112:70 | call to method First |
-| GlobalDataFlow.cs:82:13:82:95 | SSA def(sink14) | GlobalDataFlow.cs:112:57:112:70 | call to method First |
-| GlobalDataFlow.cs:82:13:82:95 | SSA def(sink14) | GlobalDataFlow.cs:116:20:116:25 | access to local variable sink14 |
-| GlobalDataFlow.cs:82:13:82:95 | SSA def(sink14) | GlobalDataFlow.cs:116:20:116:25 | access to local variable sink14 |
-| GlobalDataFlow.cs:82:13:82:95 | SSA def(sink14) | GlobalDataFlow.cs:118:20:118:25 | access to local variable sink14 |
-| GlobalDataFlow.cs:82:13:82:95 | SSA def(sink14) | GlobalDataFlow.cs:118:20:118:25 | access to local variable sink14 |
+| GlobalDataFlow.cs:82:13:82:95 | SSA def(sink14) | GlobalDataFlow.cs:116:21:116:72 | (...) ... |
+| GlobalDataFlow.cs:82:13:82:95 | SSA def(sink14) | GlobalDataFlow.cs:116:21:116:72 | (...) ... |
+| GlobalDataFlow.cs:82:13:82:95 | SSA def(sink14) | GlobalDataFlow.cs:116:42:116:72 | array creation of type String[] |
+| GlobalDataFlow.cs:82:13:82:95 | SSA def(sink14) | GlobalDataFlow.cs:116:42:116:72 | array creation of type String[] |
+| GlobalDataFlow.cs:82:13:82:95 | SSA def(sink14) | GlobalDataFlow.cs:116:57:116:62 | access to local variable sink14 |
+| GlobalDataFlow.cs:82:13:82:95 | SSA def(sink14) | GlobalDataFlow.cs:116:57:116:62 | access to local variable sink14 |
+| GlobalDataFlow.cs:82:13:82:95 | SSA def(sink14) | GlobalDataFlow.cs:116:57:116:70 | call to method First |
+| GlobalDataFlow.cs:82:13:82:95 | SSA def(sink14) | GlobalDataFlow.cs:116:57:116:70 | call to method First |
+| GlobalDataFlow.cs:82:13:82:95 | SSA def(sink14) | GlobalDataFlow.cs:120:20:120:25 | access to local variable sink14 |
+| GlobalDataFlow.cs:82:13:82:95 | SSA def(sink14) | GlobalDataFlow.cs:120:20:120:25 | access to local variable sink14 |
+| GlobalDataFlow.cs:82:13:82:95 | SSA def(sink14) | GlobalDataFlow.cs:122:20:122:25 | access to local variable sink14 |
+| GlobalDataFlow.cs:82:13:82:95 | SSA def(sink14) | GlobalDataFlow.cs:122:20:122:25 | access to local variable sink14 |
 | GlobalDataFlow.cs:82:22:82:95 | call to method Select | GlobalDataFlow.cs:82:13:82:95 | SSA def(sink14) |
 | GlobalDataFlow.cs:82:22:82:95 | call to method Select | GlobalDataFlow.cs:82:13:82:95 | SSA def(sink14) |
 | GlobalDataFlow.cs:82:22:82:95 | call to method Select | GlobalDataFlow.cs:82:22:82:95 | call to method Select |
@@ -1571,23 +1598,23 @@
 | GlobalDataFlow.cs:82:22:82:95 | call to method Select | GlobalDataFlow.cs:90:75:90:80 | access to local variable sink14 |
 | GlobalDataFlow.cs:82:22:82:95 | call to method Select | GlobalDataFlow.cs:90:75:90:88 | call to method First |
 | GlobalDataFlow.cs:82:22:82:95 | call to method Select | GlobalDataFlow.cs:90:75:90:88 | call to method First |
-| GlobalDataFlow.cs:82:22:82:95 | call to method Select | GlobalDataFlow.cs:112:21:112:72 | (...) ... |
-| GlobalDataFlow.cs:82:22:82:95 | call to method Select | GlobalDataFlow.cs:112:21:112:72 | (...) ... |
-| GlobalDataFlow.cs:82:22:82:95 | call to method Select | GlobalDataFlow.cs:112:42:112:72 | array creation of type String[] |
-| GlobalDataFlow.cs:82:22:82:95 | call to method Select | GlobalDataFlow.cs:112:42:112:72 | array creation of type String[] |
-| GlobalDataFlow.cs:82:22:82:95 | call to method Select | GlobalDataFlow.cs:112:57:112:62 | access to local variable sink14 |
-| GlobalDataFlow.cs:82:22:82:95 | call to method Select | GlobalDataFlow.cs:112:57:112:62 | access to local variable sink14 |
-| GlobalDataFlow.cs:82:22:82:95 | call to method Select | GlobalDataFlow.cs:112:57:112:70 | call to method First |
-| GlobalDataFlow.cs:82:22:82:95 | call to method Select | GlobalDataFlow.cs:112:57:112:70 | call to method First |
-| GlobalDataFlow.cs:82:22:82:95 | call to method Select | GlobalDataFlow.cs:116:20:116:25 | access to local variable sink14 |
-| GlobalDataFlow.cs:82:22:82:95 | call to method Select | GlobalDataFlow.cs:116:20:116:25 | access to local variable sink14 |
-| GlobalDataFlow.cs:82:22:82:95 | call to method Select | GlobalDataFlow.cs:118:20:118:25 | access to local variable sink14 |
-| GlobalDataFlow.cs:82:22:82:95 | call to method Select | GlobalDataFlow.cs:118:20:118:25 | access to local variable sink14 |
+| GlobalDataFlow.cs:82:22:82:95 | call to method Select | GlobalDataFlow.cs:116:21:116:72 | (...) ... |
+| GlobalDataFlow.cs:82:22:82:95 | call to method Select | GlobalDataFlow.cs:116:21:116:72 | (...) ... |
+| GlobalDataFlow.cs:82:22:82:95 | call to method Select | GlobalDataFlow.cs:116:42:116:72 | array creation of type String[] |
+| GlobalDataFlow.cs:82:22:82:95 | call to method Select | GlobalDataFlow.cs:116:42:116:72 | array creation of type String[] |
+| GlobalDataFlow.cs:82:22:82:95 | call to method Select | GlobalDataFlow.cs:116:57:116:62 | access to local variable sink14 |
+| GlobalDataFlow.cs:82:22:82:95 | call to method Select | GlobalDataFlow.cs:116:57:116:62 | access to local variable sink14 |
+| GlobalDataFlow.cs:82:22:82:95 | call to method Select | GlobalDataFlow.cs:116:57:116:70 | call to method First |
+| GlobalDataFlow.cs:82:22:82:95 | call to method Select | GlobalDataFlow.cs:116:57:116:70 | call to method First |
+| GlobalDataFlow.cs:82:22:82:95 | call to method Select | GlobalDataFlow.cs:120:20:120:25 | access to local variable sink14 |
+| GlobalDataFlow.cs:82:22:82:95 | call to method Select | GlobalDataFlow.cs:120:20:120:25 | access to local variable sink14 |
+| GlobalDataFlow.cs:82:22:82:95 | call to method Select | GlobalDataFlow.cs:122:20:122:25 | access to local variable sink14 |
+| GlobalDataFlow.cs:82:22:82:95 | call to method Select | GlobalDataFlow.cs:122:20:122:25 | access to local variable sink14 |
 | GlobalDataFlow.cs:82:23:82:74 | (...) ... | GlobalDataFlow.cs:82:23:82:74 | (...) ... |
 | GlobalDataFlow.cs:82:23:82:74 | (...) ... | GlobalDataFlow.cs:82:84:82:94 | [output] delegate creation of type Func<String,String> |
 | GlobalDataFlow.cs:82:23:82:74 | (...) ... | GlobalDataFlow.cs:82:84:82:94 | [output] delegate creation of type Func<String,String> |
-| GlobalDataFlow.cs:82:23:82:74 | (...) ... | GlobalDataFlow.cs:287:31:287:40 | sinkParam8 |
-| GlobalDataFlow.cs:82:23:82:74 | (...) ... | GlobalDataFlow.cs:287:31:287:40 | sinkParam8 |
+| GlobalDataFlow.cs:82:23:82:74 | (...) ... | GlobalDataFlow.cs:292:31:292:40 | sinkParam8 |
+| GlobalDataFlow.cs:82:23:82:74 | (...) ... | GlobalDataFlow.cs:292:31:292:40 | sinkParam8 |
 | GlobalDataFlow.cs:82:44:82:74 | array creation of type String[] | GlobalDataFlow.cs:82:23:82:74 | (...) ... |
 | GlobalDataFlow.cs:82:44:82:74 | array creation of type String[] | GlobalDataFlow.cs:82:23:82:74 | (...) ... |
 | GlobalDataFlow.cs:82:44:82:74 | array creation of type String[] | GlobalDataFlow.cs:82:44:82:74 | array creation of type String[] |
@@ -1625,18 +1652,18 @@
 | GlobalDataFlow.cs:82:84:82:94 | [output] delegate creation of type Func<String,String> | GlobalDataFlow.cs:90:75:90:80 | access to local variable sink14 |
 | GlobalDataFlow.cs:82:84:82:94 | [output] delegate creation of type Func<String,String> | GlobalDataFlow.cs:90:75:90:88 | call to method First |
 | GlobalDataFlow.cs:82:84:82:94 | [output] delegate creation of type Func<String,String> | GlobalDataFlow.cs:90:75:90:88 | call to method First |
-| GlobalDataFlow.cs:82:84:82:94 | [output] delegate creation of type Func<String,String> | GlobalDataFlow.cs:112:21:112:72 | (...) ... |
-| GlobalDataFlow.cs:82:84:82:94 | [output] delegate creation of type Func<String,String> | GlobalDataFlow.cs:112:21:112:72 | (...) ... |
-| GlobalDataFlow.cs:82:84:82:94 | [output] delegate creation of type Func<String,String> | GlobalDataFlow.cs:112:42:112:72 | array creation of type String[] |
-| GlobalDataFlow.cs:82:84:82:94 | [output] delegate creation of type Func<String,String> | GlobalDataFlow.cs:112:42:112:72 | array creation of type String[] |
-| GlobalDataFlow.cs:82:84:82:94 | [output] delegate creation of type Func<String,String> | GlobalDataFlow.cs:112:57:112:62 | access to local variable sink14 |
-| GlobalDataFlow.cs:82:84:82:94 | [output] delegate creation of type Func<String,String> | GlobalDataFlow.cs:112:57:112:62 | access to local variable sink14 |
-| GlobalDataFlow.cs:82:84:82:94 | [output] delegate creation of type Func<String,String> | GlobalDataFlow.cs:112:57:112:70 | call to method First |
-| GlobalDataFlow.cs:82:84:82:94 | [output] delegate creation of type Func<String,String> | GlobalDataFlow.cs:112:57:112:70 | call to method First |
-| GlobalDataFlow.cs:82:84:82:94 | [output] delegate creation of type Func<String,String> | GlobalDataFlow.cs:116:20:116:25 | access to local variable sink14 |
-| GlobalDataFlow.cs:82:84:82:94 | [output] delegate creation of type Func<String,String> | GlobalDataFlow.cs:116:20:116:25 | access to local variable sink14 |
-| GlobalDataFlow.cs:82:84:82:94 | [output] delegate creation of type Func<String,String> | GlobalDataFlow.cs:118:20:118:25 | access to local variable sink14 |
-| GlobalDataFlow.cs:82:84:82:94 | [output] delegate creation of type Func<String,String> | GlobalDataFlow.cs:118:20:118:25 | access to local variable sink14 |
+| GlobalDataFlow.cs:82:84:82:94 | [output] delegate creation of type Func<String,String> | GlobalDataFlow.cs:116:21:116:72 | (...) ... |
+| GlobalDataFlow.cs:82:84:82:94 | [output] delegate creation of type Func<String,String> | GlobalDataFlow.cs:116:21:116:72 | (...) ... |
+| GlobalDataFlow.cs:82:84:82:94 | [output] delegate creation of type Func<String,String> | GlobalDataFlow.cs:116:42:116:72 | array creation of type String[] |
+| GlobalDataFlow.cs:82:84:82:94 | [output] delegate creation of type Func<String,String> | GlobalDataFlow.cs:116:42:116:72 | array creation of type String[] |
+| GlobalDataFlow.cs:82:84:82:94 | [output] delegate creation of type Func<String,String> | GlobalDataFlow.cs:116:57:116:62 | access to local variable sink14 |
+| GlobalDataFlow.cs:82:84:82:94 | [output] delegate creation of type Func<String,String> | GlobalDataFlow.cs:116:57:116:62 | access to local variable sink14 |
+| GlobalDataFlow.cs:82:84:82:94 | [output] delegate creation of type Func<String,String> | GlobalDataFlow.cs:116:57:116:70 | call to method First |
+| GlobalDataFlow.cs:82:84:82:94 | [output] delegate creation of type Func<String,String> | GlobalDataFlow.cs:116:57:116:70 | call to method First |
+| GlobalDataFlow.cs:82:84:82:94 | [output] delegate creation of type Func<String,String> | GlobalDataFlow.cs:120:20:120:25 | access to local variable sink14 |
+| GlobalDataFlow.cs:82:84:82:94 | [output] delegate creation of type Func<String,String> | GlobalDataFlow.cs:120:20:120:25 | access to local variable sink14 |
+| GlobalDataFlow.cs:82:84:82:94 | [output] delegate creation of type Func<String,String> | GlobalDataFlow.cs:122:20:122:25 | access to local variable sink14 |
+| GlobalDataFlow.cs:82:84:82:94 | [output] delegate creation of type Func<String,String> | GlobalDataFlow.cs:122:20:122:25 | access to local variable sink14 |
 | GlobalDataFlow.cs:82:84:82:94 | access to method ReturnCheck | GlobalDataFlow.cs:82:84:82:94 | access to method ReturnCheck |
 | GlobalDataFlow.cs:82:84:82:94 | delegate creation of type Func<String,String> | GlobalDataFlow.cs:82:84:82:94 | delegate creation of type Func<String,String> |
 | GlobalDataFlow.cs:83:9:83:21 | call to method Check | GlobalDataFlow.cs:83:9:83:21 | call to method Check |
@@ -1655,18 +1682,18 @@
 | GlobalDataFlow.cs:83:15:83:20 | access to local variable sink14 | GlobalDataFlow.cs:90:75:90:80 | access to local variable sink14 |
 | GlobalDataFlow.cs:83:15:83:20 | access to local variable sink14 | GlobalDataFlow.cs:90:75:90:88 | call to method First |
 | GlobalDataFlow.cs:83:15:83:20 | access to local variable sink14 | GlobalDataFlow.cs:90:75:90:88 | call to method First |
-| GlobalDataFlow.cs:83:15:83:20 | access to local variable sink14 | GlobalDataFlow.cs:112:21:112:72 | (...) ... |
-| GlobalDataFlow.cs:83:15:83:20 | access to local variable sink14 | GlobalDataFlow.cs:112:21:112:72 | (...) ... |
-| GlobalDataFlow.cs:83:15:83:20 | access to local variable sink14 | GlobalDataFlow.cs:112:42:112:72 | array creation of type String[] |
-| GlobalDataFlow.cs:83:15:83:20 | access to local variable sink14 | GlobalDataFlow.cs:112:42:112:72 | array creation of type String[] |
-| GlobalDataFlow.cs:83:15:83:20 | access to local variable sink14 | GlobalDataFlow.cs:112:57:112:62 | access to local variable sink14 |
-| GlobalDataFlow.cs:83:15:83:20 | access to local variable sink14 | GlobalDataFlow.cs:112:57:112:62 | access to local variable sink14 |
-| GlobalDataFlow.cs:83:15:83:20 | access to local variable sink14 | GlobalDataFlow.cs:112:57:112:70 | call to method First |
-| GlobalDataFlow.cs:83:15:83:20 | access to local variable sink14 | GlobalDataFlow.cs:112:57:112:70 | call to method First |
-| GlobalDataFlow.cs:83:15:83:20 | access to local variable sink14 | GlobalDataFlow.cs:116:20:116:25 | access to local variable sink14 |
-| GlobalDataFlow.cs:83:15:83:20 | access to local variable sink14 | GlobalDataFlow.cs:116:20:116:25 | access to local variable sink14 |
-| GlobalDataFlow.cs:83:15:83:20 | access to local variable sink14 | GlobalDataFlow.cs:118:20:118:25 | access to local variable sink14 |
-| GlobalDataFlow.cs:83:15:83:20 | access to local variable sink14 | GlobalDataFlow.cs:118:20:118:25 | access to local variable sink14 |
+| GlobalDataFlow.cs:83:15:83:20 | access to local variable sink14 | GlobalDataFlow.cs:116:21:116:72 | (...) ... |
+| GlobalDataFlow.cs:83:15:83:20 | access to local variable sink14 | GlobalDataFlow.cs:116:21:116:72 | (...) ... |
+| GlobalDataFlow.cs:83:15:83:20 | access to local variable sink14 | GlobalDataFlow.cs:116:42:116:72 | array creation of type String[] |
+| GlobalDataFlow.cs:83:15:83:20 | access to local variable sink14 | GlobalDataFlow.cs:116:42:116:72 | array creation of type String[] |
+| GlobalDataFlow.cs:83:15:83:20 | access to local variable sink14 | GlobalDataFlow.cs:116:57:116:62 | access to local variable sink14 |
+| GlobalDataFlow.cs:83:15:83:20 | access to local variable sink14 | GlobalDataFlow.cs:116:57:116:62 | access to local variable sink14 |
+| GlobalDataFlow.cs:83:15:83:20 | access to local variable sink14 | GlobalDataFlow.cs:116:57:116:70 | call to method First |
+| GlobalDataFlow.cs:83:15:83:20 | access to local variable sink14 | GlobalDataFlow.cs:116:57:116:70 | call to method First |
+| GlobalDataFlow.cs:83:15:83:20 | access to local variable sink14 | GlobalDataFlow.cs:120:20:120:25 | access to local variable sink14 |
+| GlobalDataFlow.cs:83:15:83:20 | access to local variable sink14 | GlobalDataFlow.cs:120:20:120:25 | access to local variable sink14 |
+| GlobalDataFlow.cs:83:15:83:20 | access to local variable sink14 | GlobalDataFlow.cs:122:20:122:25 | access to local variable sink14 |
+| GlobalDataFlow.cs:83:15:83:20 | access to local variable sink14 | GlobalDataFlow.cs:122:20:122:25 | access to local variable sink14 |
 | GlobalDataFlow.cs:84:13:84:136 | IEnumerable<String> sink15 = ... | GlobalDataFlow.cs:84:13:84:136 | IEnumerable<String> sink15 = ... |
 | GlobalDataFlow.cs:84:13:84:136 | SSA def(sink15) | GlobalDataFlow.cs:84:13:84:136 | SSA def(sink15) |
 | GlobalDataFlow.cs:84:13:84:136 | SSA def(sink15) | GlobalDataFlow.cs:85:15:85:20 | access to local variable sink15 |
@@ -1679,14 +1706,14 @@
 | GlobalDataFlow.cs:84:13:84:136 | SSA def(sink15) | GlobalDataFlow.cs:86:106:86:111 | access to local variable sink15 |
 | GlobalDataFlow.cs:84:13:84:136 | SSA def(sink15) | GlobalDataFlow.cs:86:106:86:119 | call to method First |
 | GlobalDataFlow.cs:84:13:84:136 | SSA def(sink15) | GlobalDataFlow.cs:86:106:86:119 | call to method First |
-| GlobalDataFlow.cs:84:13:84:136 | SSA def(sink15) | GlobalDataFlow.cs:114:68:114:119 | (...) ... |
-| GlobalDataFlow.cs:84:13:84:136 | SSA def(sink15) | GlobalDataFlow.cs:114:68:114:119 | (...) ... |
-| GlobalDataFlow.cs:84:13:84:136 | SSA def(sink15) | GlobalDataFlow.cs:114:89:114:119 | array creation of type String[] |
-| GlobalDataFlow.cs:84:13:84:136 | SSA def(sink15) | GlobalDataFlow.cs:114:89:114:119 | array creation of type String[] |
-| GlobalDataFlow.cs:84:13:84:136 | SSA def(sink15) | GlobalDataFlow.cs:114:104:114:109 | access to local variable sink15 |
-| GlobalDataFlow.cs:84:13:84:136 | SSA def(sink15) | GlobalDataFlow.cs:114:104:114:109 | access to local variable sink15 |
-| GlobalDataFlow.cs:84:13:84:136 | SSA def(sink15) | GlobalDataFlow.cs:114:104:114:117 | call to method First |
-| GlobalDataFlow.cs:84:13:84:136 | SSA def(sink15) | GlobalDataFlow.cs:114:104:114:117 | call to method First |
+| GlobalDataFlow.cs:84:13:84:136 | SSA def(sink15) | GlobalDataFlow.cs:118:68:118:119 | (...) ... |
+| GlobalDataFlow.cs:84:13:84:136 | SSA def(sink15) | GlobalDataFlow.cs:118:68:118:119 | (...) ... |
+| GlobalDataFlow.cs:84:13:84:136 | SSA def(sink15) | GlobalDataFlow.cs:118:89:118:119 | array creation of type String[] |
+| GlobalDataFlow.cs:84:13:84:136 | SSA def(sink15) | GlobalDataFlow.cs:118:89:118:119 | array creation of type String[] |
+| GlobalDataFlow.cs:84:13:84:136 | SSA def(sink15) | GlobalDataFlow.cs:118:104:118:109 | access to local variable sink15 |
+| GlobalDataFlow.cs:84:13:84:136 | SSA def(sink15) | GlobalDataFlow.cs:118:104:118:109 | access to local variable sink15 |
+| GlobalDataFlow.cs:84:13:84:136 | SSA def(sink15) | GlobalDataFlow.cs:118:104:118:117 | call to method First |
+| GlobalDataFlow.cs:84:13:84:136 | SSA def(sink15) | GlobalDataFlow.cs:118:104:118:117 | call to method First |
 | GlobalDataFlow.cs:84:22:84:136 | call to method Zip | GlobalDataFlow.cs:84:13:84:136 | SSA def(sink15) |
 | GlobalDataFlow.cs:84:22:84:136 | call to method Zip | GlobalDataFlow.cs:84:13:84:136 | SSA def(sink15) |
 | GlobalDataFlow.cs:84:22:84:136 | call to method Zip | GlobalDataFlow.cs:84:22:84:136 | call to method Zip |
@@ -1700,14 +1727,14 @@
 | GlobalDataFlow.cs:84:22:84:136 | call to method Zip | GlobalDataFlow.cs:86:106:86:111 | access to local variable sink15 |
 | GlobalDataFlow.cs:84:22:84:136 | call to method Zip | GlobalDataFlow.cs:86:106:86:119 | call to method First |
 | GlobalDataFlow.cs:84:22:84:136 | call to method Zip | GlobalDataFlow.cs:86:106:86:119 | call to method First |
-| GlobalDataFlow.cs:84:22:84:136 | call to method Zip | GlobalDataFlow.cs:114:68:114:119 | (...) ... |
-| GlobalDataFlow.cs:84:22:84:136 | call to method Zip | GlobalDataFlow.cs:114:68:114:119 | (...) ... |
-| GlobalDataFlow.cs:84:22:84:136 | call to method Zip | GlobalDataFlow.cs:114:89:114:119 | array creation of type String[] |
-| GlobalDataFlow.cs:84:22:84:136 | call to method Zip | GlobalDataFlow.cs:114:89:114:119 | array creation of type String[] |
-| GlobalDataFlow.cs:84:22:84:136 | call to method Zip | GlobalDataFlow.cs:114:104:114:109 | access to local variable sink15 |
-| GlobalDataFlow.cs:84:22:84:136 | call to method Zip | GlobalDataFlow.cs:114:104:114:109 | access to local variable sink15 |
-| GlobalDataFlow.cs:84:22:84:136 | call to method Zip | GlobalDataFlow.cs:114:104:114:117 | call to method First |
-| GlobalDataFlow.cs:84:22:84:136 | call to method Zip | GlobalDataFlow.cs:114:104:114:117 | call to method First |
+| GlobalDataFlow.cs:84:22:84:136 | call to method Zip | GlobalDataFlow.cs:118:68:118:119 | (...) ... |
+| GlobalDataFlow.cs:84:22:84:136 | call to method Zip | GlobalDataFlow.cs:118:68:118:119 | (...) ... |
+| GlobalDataFlow.cs:84:22:84:136 | call to method Zip | GlobalDataFlow.cs:118:89:118:119 | array creation of type String[] |
+| GlobalDataFlow.cs:84:22:84:136 | call to method Zip | GlobalDataFlow.cs:118:89:118:119 | array creation of type String[] |
+| GlobalDataFlow.cs:84:22:84:136 | call to method Zip | GlobalDataFlow.cs:118:104:118:109 | access to local variable sink15 |
+| GlobalDataFlow.cs:84:22:84:136 | call to method Zip | GlobalDataFlow.cs:118:104:118:109 | access to local variable sink15 |
+| GlobalDataFlow.cs:84:22:84:136 | call to method Zip | GlobalDataFlow.cs:118:104:118:117 | call to method First |
+| GlobalDataFlow.cs:84:22:84:136 | call to method Zip | GlobalDataFlow.cs:118:104:118:117 | call to method First |
 | GlobalDataFlow.cs:84:23:84:74 | (...) ... | GlobalDataFlow.cs:84:23:84:74 | (...) ... |
 | GlobalDataFlow.cs:84:23:84:74 | (...) ... | GlobalDataFlow.cs:84:125:84:135 | [output] (...) => ... |
 | GlobalDataFlow.cs:84:23:84:74 | (...) ... | GlobalDataFlow.cs:84:125:84:135 | [output] (...) => ... |
@@ -1730,18 +1757,18 @@
 | GlobalDataFlow.cs:84:59:84:64 | access to local variable sink14 | GlobalDataFlow.cs:90:75:90:80 | access to local variable sink14 |
 | GlobalDataFlow.cs:84:59:84:64 | access to local variable sink14 | GlobalDataFlow.cs:90:75:90:88 | call to method First |
 | GlobalDataFlow.cs:84:59:84:64 | access to local variable sink14 | GlobalDataFlow.cs:90:75:90:88 | call to method First |
-| GlobalDataFlow.cs:84:59:84:64 | access to local variable sink14 | GlobalDataFlow.cs:112:21:112:72 | (...) ... |
-| GlobalDataFlow.cs:84:59:84:64 | access to local variable sink14 | GlobalDataFlow.cs:112:21:112:72 | (...) ... |
-| GlobalDataFlow.cs:84:59:84:64 | access to local variable sink14 | GlobalDataFlow.cs:112:42:112:72 | array creation of type String[] |
-| GlobalDataFlow.cs:84:59:84:64 | access to local variable sink14 | GlobalDataFlow.cs:112:42:112:72 | array creation of type String[] |
-| GlobalDataFlow.cs:84:59:84:64 | access to local variable sink14 | GlobalDataFlow.cs:112:57:112:62 | access to local variable sink14 |
-| GlobalDataFlow.cs:84:59:84:64 | access to local variable sink14 | GlobalDataFlow.cs:112:57:112:62 | access to local variable sink14 |
-| GlobalDataFlow.cs:84:59:84:64 | access to local variable sink14 | GlobalDataFlow.cs:112:57:112:70 | call to method First |
-| GlobalDataFlow.cs:84:59:84:64 | access to local variable sink14 | GlobalDataFlow.cs:112:57:112:70 | call to method First |
-| GlobalDataFlow.cs:84:59:84:64 | access to local variable sink14 | GlobalDataFlow.cs:116:20:116:25 | access to local variable sink14 |
-| GlobalDataFlow.cs:84:59:84:64 | access to local variable sink14 | GlobalDataFlow.cs:116:20:116:25 | access to local variable sink14 |
-| GlobalDataFlow.cs:84:59:84:64 | access to local variable sink14 | GlobalDataFlow.cs:118:20:118:25 | access to local variable sink14 |
-| GlobalDataFlow.cs:84:59:84:64 | access to local variable sink14 | GlobalDataFlow.cs:118:20:118:25 | access to local variable sink14 |
+| GlobalDataFlow.cs:84:59:84:64 | access to local variable sink14 | GlobalDataFlow.cs:116:21:116:72 | (...) ... |
+| GlobalDataFlow.cs:84:59:84:64 | access to local variable sink14 | GlobalDataFlow.cs:116:21:116:72 | (...) ... |
+| GlobalDataFlow.cs:84:59:84:64 | access to local variable sink14 | GlobalDataFlow.cs:116:42:116:72 | array creation of type String[] |
+| GlobalDataFlow.cs:84:59:84:64 | access to local variable sink14 | GlobalDataFlow.cs:116:42:116:72 | array creation of type String[] |
+| GlobalDataFlow.cs:84:59:84:64 | access to local variable sink14 | GlobalDataFlow.cs:116:57:116:62 | access to local variable sink14 |
+| GlobalDataFlow.cs:84:59:84:64 | access to local variable sink14 | GlobalDataFlow.cs:116:57:116:62 | access to local variable sink14 |
+| GlobalDataFlow.cs:84:59:84:64 | access to local variable sink14 | GlobalDataFlow.cs:116:57:116:70 | call to method First |
+| GlobalDataFlow.cs:84:59:84:64 | access to local variable sink14 | GlobalDataFlow.cs:116:57:116:70 | call to method First |
+| GlobalDataFlow.cs:84:59:84:64 | access to local variable sink14 | GlobalDataFlow.cs:120:20:120:25 | access to local variable sink14 |
+| GlobalDataFlow.cs:84:59:84:64 | access to local variable sink14 | GlobalDataFlow.cs:120:20:120:25 | access to local variable sink14 |
+| GlobalDataFlow.cs:84:59:84:64 | access to local variable sink14 | GlobalDataFlow.cs:122:20:122:25 | access to local variable sink14 |
+| GlobalDataFlow.cs:84:59:84:64 | access to local variable sink14 | GlobalDataFlow.cs:122:20:122:25 | access to local variable sink14 |
 | GlobalDataFlow.cs:84:59:84:72 | call to method First | GlobalDataFlow.cs:84:23:84:74 | (...) ... |
 | GlobalDataFlow.cs:84:59:84:72 | call to method First | GlobalDataFlow.cs:84:23:84:74 | (...) ... |
 | GlobalDataFlow.cs:84:59:84:72 | call to method First | GlobalDataFlow.cs:84:44:84:74 | array creation of type String[] |
@@ -1773,14 +1800,14 @@
 | GlobalDataFlow.cs:84:125:84:135 | [output] (...) => ... | GlobalDataFlow.cs:86:106:86:111 | access to local variable sink15 |
 | GlobalDataFlow.cs:84:125:84:135 | [output] (...) => ... | GlobalDataFlow.cs:86:106:86:119 | call to method First |
 | GlobalDataFlow.cs:84:125:84:135 | [output] (...) => ... | GlobalDataFlow.cs:86:106:86:119 | call to method First |
-| GlobalDataFlow.cs:84:125:84:135 | [output] (...) => ... | GlobalDataFlow.cs:114:68:114:119 | (...) ... |
-| GlobalDataFlow.cs:84:125:84:135 | [output] (...) => ... | GlobalDataFlow.cs:114:68:114:119 | (...) ... |
-| GlobalDataFlow.cs:84:125:84:135 | [output] (...) => ... | GlobalDataFlow.cs:114:89:114:119 | array creation of type String[] |
-| GlobalDataFlow.cs:84:125:84:135 | [output] (...) => ... | GlobalDataFlow.cs:114:89:114:119 | array creation of type String[] |
-| GlobalDataFlow.cs:84:125:84:135 | [output] (...) => ... | GlobalDataFlow.cs:114:104:114:109 | access to local variable sink15 |
-| GlobalDataFlow.cs:84:125:84:135 | [output] (...) => ... | GlobalDataFlow.cs:114:104:114:109 | access to local variable sink15 |
-| GlobalDataFlow.cs:84:125:84:135 | [output] (...) => ... | GlobalDataFlow.cs:114:104:114:117 | call to method First |
-| GlobalDataFlow.cs:84:125:84:135 | [output] (...) => ... | GlobalDataFlow.cs:114:104:114:117 | call to method First |
+| GlobalDataFlow.cs:84:125:84:135 | [output] (...) => ... | GlobalDataFlow.cs:118:68:118:119 | (...) ... |
+| GlobalDataFlow.cs:84:125:84:135 | [output] (...) => ... | GlobalDataFlow.cs:118:68:118:119 | (...) ... |
+| GlobalDataFlow.cs:84:125:84:135 | [output] (...) => ... | GlobalDataFlow.cs:118:89:118:119 | array creation of type String[] |
+| GlobalDataFlow.cs:84:125:84:135 | [output] (...) => ... | GlobalDataFlow.cs:118:89:118:119 | array creation of type String[] |
+| GlobalDataFlow.cs:84:125:84:135 | [output] (...) => ... | GlobalDataFlow.cs:118:104:118:109 | access to local variable sink15 |
+| GlobalDataFlow.cs:84:125:84:135 | [output] (...) => ... | GlobalDataFlow.cs:118:104:118:109 | access to local variable sink15 |
+| GlobalDataFlow.cs:84:125:84:135 | [output] (...) => ... | GlobalDataFlow.cs:118:104:118:117 | call to method First |
+| GlobalDataFlow.cs:84:125:84:135 | [output] (...) => ... | GlobalDataFlow.cs:118:104:118:117 | call to method First |
 | GlobalDataFlow.cs:84:126:84:126 | x | GlobalDataFlow.cs:84:126:84:126 | x |
 | GlobalDataFlow.cs:84:126:84:126 | x | GlobalDataFlow.cs:84:126:84:126 | x |
 | GlobalDataFlow.cs:84:126:84:126 | x | GlobalDataFlow.cs:84:126:84:126 | x |
@@ -1808,14 +1835,14 @@
 | GlobalDataFlow.cs:85:15:85:20 | access to local variable sink15 | GlobalDataFlow.cs:86:106:86:111 | access to local variable sink15 |
 | GlobalDataFlow.cs:85:15:85:20 | access to local variable sink15 | GlobalDataFlow.cs:86:106:86:119 | call to method First |
 | GlobalDataFlow.cs:85:15:85:20 | access to local variable sink15 | GlobalDataFlow.cs:86:106:86:119 | call to method First |
-| GlobalDataFlow.cs:85:15:85:20 | access to local variable sink15 | GlobalDataFlow.cs:114:68:114:119 | (...) ... |
-| GlobalDataFlow.cs:85:15:85:20 | access to local variable sink15 | GlobalDataFlow.cs:114:68:114:119 | (...) ... |
-| GlobalDataFlow.cs:85:15:85:20 | access to local variable sink15 | GlobalDataFlow.cs:114:89:114:119 | array creation of type String[] |
-| GlobalDataFlow.cs:85:15:85:20 | access to local variable sink15 | GlobalDataFlow.cs:114:89:114:119 | array creation of type String[] |
-| GlobalDataFlow.cs:85:15:85:20 | access to local variable sink15 | GlobalDataFlow.cs:114:104:114:109 | access to local variable sink15 |
-| GlobalDataFlow.cs:85:15:85:20 | access to local variable sink15 | GlobalDataFlow.cs:114:104:114:109 | access to local variable sink15 |
-| GlobalDataFlow.cs:85:15:85:20 | access to local variable sink15 | GlobalDataFlow.cs:114:104:114:117 | call to method First |
-| GlobalDataFlow.cs:85:15:85:20 | access to local variable sink15 | GlobalDataFlow.cs:114:104:114:117 | call to method First |
+| GlobalDataFlow.cs:85:15:85:20 | access to local variable sink15 | GlobalDataFlow.cs:118:68:118:119 | (...) ... |
+| GlobalDataFlow.cs:85:15:85:20 | access to local variable sink15 | GlobalDataFlow.cs:118:68:118:119 | (...) ... |
+| GlobalDataFlow.cs:85:15:85:20 | access to local variable sink15 | GlobalDataFlow.cs:118:89:118:119 | array creation of type String[] |
+| GlobalDataFlow.cs:85:15:85:20 | access to local variable sink15 | GlobalDataFlow.cs:118:89:118:119 | array creation of type String[] |
+| GlobalDataFlow.cs:85:15:85:20 | access to local variable sink15 | GlobalDataFlow.cs:118:104:118:109 | access to local variable sink15 |
+| GlobalDataFlow.cs:85:15:85:20 | access to local variable sink15 | GlobalDataFlow.cs:118:104:118:109 | access to local variable sink15 |
+| GlobalDataFlow.cs:85:15:85:20 | access to local variable sink15 | GlobalDataFlow.cs:118:104:118:117 | call to method First |
+| GlobalDataFlow.cs:85:15:85:20 | access to local variable sink15 | GlobalDataFlow.cs:118:104:118:117 | call to method First |
 | GlobalDataFlow.cs:86:13:86:136 | IEnumerable<String> sink16 = ... | GlobalDataFlow.cs:86:13:86:136 | IEnumerable<String> sink16 = ... |
 | GlobalDataFlow.cs:86:13:86:136 | SSA def(sink16) | GlobalDataFlow.cs:86:13:86:136 | SSA def(sink16) |
 | GlobalDataFlow.cs:86:13:86:136 | SSA def(sink16) | GlobalDataFlow.cs:87:15:87:20 | access to local variable sink16 |
@@ -1851,14 +1878,14 @@
 | GlobalDataFlow.cs:86:106:86:111 | access to local variable sink15 | GlobalDataFlow.cs:86:106:86:111 | access to local variable sink15 |
 | GlobalDataFlow.cs:86:106:86:111 | access to local variable sink15 | GlobalDataFlow.cs:86:106:86:119 | call to method First |
 | GlobalDataFlow.cs:86:106:86:111 | access to local variable sink15 | GlobalDataFlow.cs:86:106:86:119 | call to method First |
-| GlobalDataFlow.cs:86:106:86:111 | access to local variable sink15 | GlobalDataFlow.cs:114:68:114:119 | (...) ... |
-| GlobalDataFlow.cs:86:106:86:111 | access to local variable sink15 | GlobalDataFlow.cs:114:68:114:119 | (...) ... |
-| GlobalDataFlow.cs:86:106:86:111 | access to local variable sink15 | GlobalDataFlow.cs:114:89:114:119 | array creation of type String[] |
-| GlobalDataFlow.cs:86:106:86:111 | access to local variable sink15 | GlobalDataFlow.cs:114:89:114:119 | array creation of type String[] |
-| GlobalDataFlow.cs:86:106:86:111 | access to local variable sink15 | GlobalDataFlow.cs:114:104:114:109 | access to local variable sink15 |
-| GlobalDataFlow.cs:86:106:86:111 | access to local variable sink15 | GlobalDataFlow.cs:114:104:114:109 | access to local variable sink15 |
-| GlobalDataFlow.cs:86:106:86:111 | access to local variable sink15 | GlobalDataFlow.cs:114:104:114:117 | call to method First |
-| GlobalDataFlow.cs:86:106:86:111 | access to local variable sink15 | GlobalDataFlow.cs:114:104:114:117 | call to method First |
+| GlobalDataFlow.cs:86:106:86:111 | access to local variable sink15 | GlobalDataFlow.cs:118:68:118:119 | (...) ... |
+| GlobalDataFlow.cs:86:106:86:111 | access to local variable sink15 | GlobalDataFlow.cs:118:68:118:119 | (...) ... |
+| GlobalDataFlow.cs:86:106:86:111 | access to local variable sink15 | GlobalDataFlow.cs:118:89:118:119 | array creation of type String[] |
+| GlobalDataFlow.cs:86:106:86:111 | access to local variable sink15 | GlobalDataFlow.cs:118:89:118:119 | array creation of type String[] |
+| GlobalDataFlow.cs:86:106:86:111 | access to local variable sink15 | GlobalDataFlow.cs:118:104:118:109 | access to local variable sink15 |
+| GlobalDataFlow.cs:86:106:86:111 | access to local variable sink15 | GlobalDataFlow.cs:118:104:118:109 | access to local variable sink15 |
+| GlobalDataFlow.cs:86:106:86:111 | access to local variable sink15 | GlobalDataFlow.cs:118:104:118:117 | call to method First |
+| GlobalDataFlow.cs:86:106:86:111 | access to local variable sink15 | GlobalDataFlow.cs:118:104:118:117 | call to method First |
 | GlobalDataFlow.cs:86:106:86:119 | call to method First | GlobalDataFlow.cs:86:70:86:121 | (...) ... |
 | GlobalDataFlow.cs:86:106:86:119 | call to method First | GlobalDataFlow.cs:86:70:86:121 | (...) ... |
 | GlobalDataFlow.cs:86:106:86:119 | call to method First | GlobalDataFlow.cs:86:91:86:121 | array creation of type String[] |
@@ -1904,18 +1931,18 @@
 | GlobalDataFlow.cs:88:22:88:27 | access to local variable sink14 | GlobalDataFlow.cs:90:75:90:80 | access to local variable sink14 |
 | GlobalDataFlow.cs:88:22:88:27 | access to local variable sink14 | GlobalDataFlow.cs:90:75:90:88 | call to method First |
 | GlobalDataFlow.cs:88:22:88:27 | access to local variable sink14 | GlobalDataFlow.cs:90:75:90:88 | call to method First |
-| GlobalDataFlow.cs:88:22:88:27 | access to local variable sink14 | GlobalDataFlow.cs:112:21:112:72 | (...) ... |
-| GlobalDataFlow.cs:88:22:88:27 | access to local variable sink14 | GlobalDataFlow.cs:112:21:112:72 | (...) ... |
-| GlobalDataFlow.cs:88:22:88:27 | access to local variable sink14 | GlobalDataFlow.cs:112:42:112:72 | array creation of type String[] |
-| GlobalDataFlow.cs:88:22:88:27 | access to local variable sink14 | GlobalDataFlow.cs:112:42:112:72 | array creation of type String[] |
-| GlobalDataFlow.cs:88:22:88:27 | access to local variable sink14 | GlobalDataFlow.cs:112:57:112:62 | access to local variable sink14 |
-| GlobalDataFlow.cs:88:22:88:27 | access to local variable sink14 | GlobalDataFlow.cs:112:57:112:62 | access to local variable sink14 |
-| GlobalDataFlow.cs:88:22:88:27 | access to local variable sink14 | GlobalDataFlow.cs:112:57:112:70 | call to method First |
-| GlobalDataFlow.cs:88:22:88:27 | access to local variable sink14 | GlobalDataFlow.cs:112:57:112:70 | call to method First |
-| GlobalDataFlow.cs:88:22:88:27 | access to local variable sink14 | GlobalDataFlow.cs:116:20:116:25 | access to local variable sink14 |
-| GlobalDataFlow.cs:88:22:88:27 | access to local variable sink14 | GlobalDataFlow.cs:116:20:116:25 | access to local variable sink14 |
-| GlobalDataFlow.cs:88:22:88:27 | access to local variable sink14 | GlobalDataFlow.cs:118:20:118:25 | access to local variable sink14 |
-| GlobalDataFlow.cs:88:22:88:27 | access to local variable sink14 | GlobalDataFlow.cs:118:20:118:25 | access to local variable sink14 |
+| GlobalDataFlow.cs:88:22:88:27 | access to local variable sink14 | GlobalDataFlow.cs:116:21:116:72 | (...) ... |
+| GlobalDataFlow.cs:88:22:88:27 | access to local variable sink14 | GlobalDataFlow.cs:116:21:116:72 | (...) ... |
+| GlobalDataFlow.cs:88:22:88:27 | access to local variable sink14 | GlobalDataFlow.cs:116:42:116:72 | array creation of type String[] |
+| GlobalDataFlow.cs:88:22:88:27 | access to local variable sink14 | GlobalDataFlow.cs:116:42:116:72 | array creation of type String[] |
+| GlobalDataFlow.cs:88:22:88:27 | access to local variable sink14 | GlobalDataFlow.cs:116:57:116:62 | access to local variable sink14 |
+| GlobalDataFlow.cs:88:22:88:27 | access to local variable sink14 | GlobalDataFlow.cs:116:57:116:62 | access to local variable sink14 |
+| GlobalDataFlow.cs:88:22:88:27 | access to local variable sink14 | GlobalDataFlow.cs:116:57:116:70 | call to method First |
+| GlobalDataFlow.cs:88:22:88:27 | access to local variable sink14 | GlobalDataFlow.cs:116:57:116:70 | call to method First |
+| GlobalDataFlow.cs:88:22:88:27 | access to local variable sink14 | GlobalDataFlow.cs:120:20:120:25 | access to local variable sink14 |
+| GlobalDataFlow.cs:88:22:88:27 | access to local variable sink14 | GlobalDataFlow.cs:120:20:120:25 | access to local variable sink14 |
+| GlobalDataFlow.cs:88:22:88:27 | access to local variable sink14 | GlobalDataFlow.cs:122:20:122:25 | access to local variable sink14 |
+| GlobalDataFlow.cs:88:22:88:27 | access to local variable sink14 | GlobalDataFlow.cs:122:20:122:25 | access to local variable sink14 |
 | GlobalDataFlow.cs:88:22:88:70 | call to method Aggregate | GlobalDataFlow.cs:88:13:88:70 | SSA def(sink17) |
 | GlobalDataFlow.cs:88:22:88:70 | call to method Aggregate | GlobalDataFlow.cs:88:13:88:70 | SSA def(sink17) |
 | GlobalDataFlow.cs:88:22:88:70 | call to method Aggregate | GlobalDataFlow.cs:88:22:88:70 | call to method Aggregate |
@@ -2074,18 +2101,18 @@
 | GlobalDataFlow.cs:90:75:90:80 | access to local variable sink14 | GlobalDataFlow.cs:90:75:90:80 | access to local variable sink14 |
 | GlobalDataFlow.cs:90:75:90:80 | access to local variable sink14 | GlobalDataFlow.cs:90:75:90:88 | call to method First |
 | GlobalDataFlow.cs:90:75:90:80 | access to local variable sink14 | GlobalDataFlow.cs:90:75:90:88 | call to method First |
-| GlobalDataFlow.cs:90:75:90:80 | access to local variable sink14 | GlobalDataFlow.cs:112:21:112:72 | (...) ... |
-| GlobalDataFlow.cs:90:75:90:80 | access to local variable sink14 | GlobalDataFlow.cs:112:21:112:72 | (...) ... |
-| GlobalDataFlow.cs:90:75:90:80 | access to local variable sink14 | GlobalDataFlow.cs:112:42:112:72 | array creation of type String[] |
-| GlobalDataFlow.cs:90:75:90:80 | access to local variable sink14 | GlobalDataFlow.cs:112:42:112:72 | array creation of type String[] |
-| GlobalDataFlow.cs:90:75:90:80 | access to local variable sink14 | GlobalDataFlow.cs:112:57:112:62 | access to local variable sink14 |
-| GlobalDataFlow.cs:90:75:90:80 | access to local variable sink14 | GlobalDataFlow.cs:112:57:112:62 | access to local variable sink14 |
-| GlobalDataFlow.cs:90:75:90:80 | access to local variable sink14 | GlobalDataFlow.cs:112:57:112:70 | call to method First |
-| GlobalDataFlow.cs:90:75:90:80 | access to local variable sink14 | GlobalDataFlow.cs:112:57:112:70 | call to method First |
-| GlobalDataFlow.cs:90:75:90:80 | access to local variable sink14 | GlobalDataFlow.cs:116:20:116:25 | access to local variable sink14 |
-| GlobalDataFlow.cs:90:75:90:80 | access to local variable sink14 | GlobalDataFlow.cs:116:20:116:25 | access to local variable sink14 |
-| GlobalDataFlow.cs:90:75:90:80 | access to local variable sink14 | GlobalDataFlow.cs:118:20:118:25 | access to local variable sink14 |
-| GlobalDataFlow.cs:90:75:90:80 | access to local variable sink14 | GlobalDataFlow.cs:118:20:118:25 | access to local variable sink14 |
+| GlobalDataFlow.cs:90:75:90:80 | access to local variable sink14 | GlobalDataFlow.cs:116:21:116:72 | (...) ... |
+| GlobalDataFlow.cs:90:75:90:80 | access to local variable sink14 | GlobalDataFlow.cs:116:21:116:72 | (...) ... |
+| GlobalDataFlow.cs:90:75:90:80 | access to local variable sink14 | GlobalDataFlow.cs:116:42:116:72 | array creation of type String[] |
+| GlobalDataFlow.cs:90:75:90:80 | access to local variable sink14 | GlobalDataFlow.cs:116:42:116:72 | array creation of type String[] |
+| GlobalDataFlow.cs:90:75:90:80 | access to local variable sink14 | GlobalDataFlow.cs:116:57:116:62 | access to local variable sink14 |
+| GlobalDataFlow.cs:90:75:90:80 | access to local variable sink14 | GlobalDataFlow.cs:116:57:116:62 | access to local variable sink14 |
+| GlobalDataFlow.cs:90:75:90:80 | access to local variable sink14 | GlobalDataFlow.cs:116:57:116:70 | call to method First |
+| GlobalDataFlow.cs:90:75:90:80 | access to local variable sink14 | GlobalDataFlow.cs:116:57:116:70 | call to method First |
+| GlobalDataFlow.cs:90:75:90:80 | access to local variable sink14 | GlobalDataFlow.cs:120:20:120:25 | access to local variable sink14 |
+| GlobalDataFlow.cs:90:75:90:80 | access to local variable sink14 | GlobalDataFlow.cs:120:20:120:25 | access to local variable sink14 |
+| GlobalDataFlow.cs:90:75:90:80 | access to local variable sink14 | GlobalDataFlow.cs:122:20:122:25 | access to local variable sink14 |
+| GlobalDataFlow.cs:90:75:90:80 | access to local variable sink14 | GlobalDataFlow.cs:122:20:122:25 | access to local variable sink14 |
 | GlobalDataFlow.cs:90:75:90:88 | call to method First | GlobalDataFlow.cs:90:75:90:88 | call to method First |
 | GlobalDataFlow.cs:90:75:90:88 | call to method First | GlobalDataFlow.cs:90:91:90:109 | [output] (...) => ... |
 | GlobalDataFlow.cs:90:75:90:88 | call to method First | GlobalDataFlow.cs:90:91:90:109 | [output] (...) => ... |
@@ -2269,8 +2296,8 @@
 | GlobalDataFlow.cs:100:31:100:32 | "" | GlobalDataFlow.cs:100:24:100:33 | call to method Return |
 | GlobalDataFlow.cs:100:31:100:32 | "" | GlobalDataFlow.cs:100:24:100:33 | call to method Return |
 | GlobalDataFlow.cs:100:31:100:32 | "" | GlobalDataFlow.cs:100:31:100:32 | "" |
-| GlobalDataFlow.cs:100:31:100:32 | "" | GlobalDataFlow.cs:271:26:271:26 | x |
-| GlobalDataFlow.cs:100:31:100:32 | "" | GlobalDataFlow.cs:271:26:271:26 | x |
+| GlobalDataFlow.cs:100:31:100:32 | "" | GlobalDataFlow.cs:275:26:275:26 | x |
+| GlobalDataFlow.cs:100:31:100:32 | "" | GlobalDataFlow.cs:275:26:275:26 | x |
 | GlobalDataFlow.cs:101:9:101:23 | call to method Check | GlobalDataFlow.cs:101:9:101:23 | call to method Check |
 | GlobalDataFlow.cs:101:15:101:22 | access to local variable nonSink0 | GlobalDataFlow.cs:101:15:101:22 | access to local variable nonSink0 |
 | GlobalDataFlow.cs:101:15:101:22 | access to local variable nonSink0 | GlobalDataFlow.cs:102:78:102:102 | array creation of type Object[] |
@@ -2300,2641 +2327,2745 @@
 | GlobalDataFlow.cs:102:93:102:100 | access to local variable nonSink0 | GlobalDataFlow.cs:102:78:102:102 | array creation of type Object[] |
 | GlobalDataFlow.cs:102:93:102:100 | access to local variable nonSink0 | GlobalDataFlow.cs:102:78:102:102 | array creation of type Object[] |
 | GlobalDataFlow.cs:102:93:102:100 | access to local variable nonSink0 | GlobalDataFlow.cs:102:93:102:100 | access to local variable nonSink0 |
-| GlobalDataFlow.cs:102:93:102:100 | access to local variable nonSink0 | GlobalDataFlow.cs:271:26:271:26 | x |
-| GlobalDataFlow.cs:102:93:102:100 | access to local variable nonSink0 | GlobalDataFlow.cs:271:26:271:26 | x |
+| GlobalDataFlow.cs:102:93:102:100 | access to local variable nonSink0 | GlobalDataFlow.cs:275:26:275:26 | x |
+| GlobalDataFlow.cs:102:93:102:100 | access to local variable nonSink0 | GlobalDataFlow.cs:275:26:275:26 | x |
 | GlobalDataFlow.cs:103:9:103:23 | call to method Check | GlobalDataFlow.cs:103:9:103:23 | call to method Check |
 | GlobalDataFlow.cs:103:15:103:22 | access to local variable nonSink0 | GlobalDataFlow.cs:103:15:103:22 | access to local variable nonSink0 |
-| GlobalDataFlow.cs:104:9:104:35 | call to method ReturnOut | GlobalDataFlow.cs:104:9:104:35 | call to method ReturnOut |
+| GlobalDataFlow.cs:104:9:104:46 | call to method ReturnOut | GlobalDataFlow.cs:104:9:104:46 | call to method ReturnOut |
 | GlobalDataFlow.cs:104:19:104:20 | "" | GlobalDataFlow.cs:104:19:104:20 | "" |
 | GlobalDataFlow.cs:104:19:104:20 | "" | GlobalDataFlow.cs:104:27:104:34 | SSA def(nonSink0) |
 | GlobalDataFlow.cs:104:19:104:20 | "" | GlobalDataFlow.cs:104:27:104:34 | SSA def(nonSink0) |
-| GlobalDataFlow.cs:104:19:104:20 | "" | GlobalDataFlow.cs:277:32:277:32 | x |
-| GlobalDataFlow.cs:104:19:104:20 | "" | GlobalDataFlow.cs:277:32:277:32 | x |
+| GlobalDataFlow.cs:104:19:104:20 | "" | GlobalDataFlow.cs:281:32:281:32 | x |
+| GlobalDataFlow.cs:104:19:104:20 | "" | GlobalDataFlow.cs:281:32:281:32 | x |
 | GlobalDataFlow.cs:104:27:104:34 | SSA def(nonSink0) | GlobalDataFlow.cs:104:27:104:34 | SSA def(nonSink0) |
 | GlobalDataFlow.cs:104:27:104:34 | SSA def(nonSink0) | GlobalDataFlow.cs:105:15:105:22 | access to local variable nonSink0 |
 | GlobalDataFlow.cs:104:27:104:34 | SSA def(nonSink0) | GlobalDataFlow.cs:105:15:105:22 | access to local variable nonSink0 |
-| GlobalDataFlow.cs:104:27:104:34 | SSA def(nonSink0) | GlobalDataFlow.cs:106:27:106:34 | access to local variable nonSink0 |
-| GlobalDataFlow.cs:104:27:104:34 | SSA def(nonSink0) | GlobalDataFlow.cs:106:27:106:34 | access to local variable nonSink0 |
 | GlobalDataFlow.cs:105:9:105:23 | call to method Check | GlobalDataFlow.cs:105:9:105:23 | call to method Check |
 | GlobalDataFlow.cs:105:15:105:22 | access to local variable nonSink0 | GlobalDataFlow.cs:105:15:105:22 | access to local variable nonSink0 |
-| GlobalDataFlow.cs:105:15:105:22 | access to local variable nonSink0 | GlobalDataFlow.cs:106:27:106:34 | access to local variable nonSink0 |
-| GlobalDataFlow.cs:105:15:105:22 | access to local variable nonSink0 | GlobalDataFlow.cs:106:27:106:34 | access to local variable nonSink0 |
-| GlobalDataFlow.cs:106:9:106:35 | call to method ReturnRef | GlobalDataFlow.cs:106:9:106:35 | call to method ReturnRef |
-| GlobalDataFlow.cs:106:19:106:20 | "" | GlobalDataFlow.cs:106:19:106:20 | "" |
-| GlobalDataFlow.cs:106:19:106:20 | "" | GlobalDataFlow.cs:106:27:106:34 | SSA def(nonSink0) |
-| GlobalDataFlow.cs:106:19:106:20 | "" | GlobalDataFlow.cs:106:27:106:34 | SSA def(nonSink0) |
-| GlobalDataFlow.cs:106:19:106:20 | "" | GlobalDataFlow.cs:282:32:282:32 | x |
-| GlobalDataFlow.cs:106:19:106:20 | "" | GlobalDataFlow.cs:282:32:282:32 | x |
-| GlobalDataFlow.cs:106:27:106:34 | SSA def(nonSink0) | GlobalDataFlow.cs:106:27:106:34 | SSA def(nonSink0) |
-| GlobalDataFlow.cs:106:27:106:34 | SSA def(nonSink0) | GlobalDataFlow.cs:107:15:107:22 | access to local variable nonSink0 |
-| GlobalDataFlow.cs:106:27:106:34 | SSA def(nonSink0) | GlobalDataFlow.cs:107:15:107:22 | access to local variable nonSink0 |
-| GlobalDataFlow.cs:106:27:106:34 | SSA def(nonSink0) | GlobalDataFlow.cs:108:25:108:70 | (...) ... |
-| GlobalDataFlow.cs:106:27:106:34 | SSA def(nonSink0) | GlobalDataFlow.cs:108:25:108:70 | (...) ... |
-| GlobalDataFlow.cs:106:27:106:34 | SSA def(nonSink0) | GlobalDataFlow.cs:108:46:108:70 | array creation of type String[] |
-| GlobalDataFlow.cs:106:27:106:34 | SSA def(nonSink0) | GlobalDataFlow.cs:108:46:108:70 | array creation of type String[] |
-| GlobalDataFlow.cs:106:27:106:34 | SSA def(nonSink0) | GlobalDataFlow.cs:108:61:108:68 | access to local variable nonSink0 |
-| GlobalDataFlow.cs:106:27:106:34 | SSA def(nonSink0) | GlobalDataFlow.cs:108:61:108:68 | access to local variable nonSink0 |
-| GlobalDataFlow.cs:106:27:106:34 | SSA def(nonSink0) | GlobalDataFlow.cs:110:21:110:66 | (...) ... |
-| GlobalDataFlow.cs:106:27:106:34 | SSA def(nonSink0) | GlobalDataFlow.cs:110:21:110:66 | (...) ... |
-| GlobalDataFlow.cs:106:27:106:34 | SSA def(nonSink0) | GlobalDataFlow.cs:110:42:110:66 | array creation of type String[] |
-| GlobalDataFlow.cs:106:27:106:34 | SSA def(nonSink0) | GlobalDataFlow.cs:110:42:110:66 | array creation of type String[] |
-| GlobalDataFlow.cs:106:27:106:34 | SSA def(nonSink0) | GlobalDataFlow.cs:110:57:110:64 | access to local variable nonSink0 |
-| GlobalDataFlow.cs:106:27:106:34 | SSA def(nonSink0) | GlobalDataFlow.cs:110:57:110:64 | access to local variable nonSink0 |
-| GlobalDataFlow.cs:106:27:106:34 | access to local variable nonSink0 | GlobalDataFlow.cs:106:27:106:34 | access to local variable nonSink0 |
+| GlobalDataFlow.cs:106:9:106:49 | call to method ReturnOut | GlobalDataFlow.cs:106:9:106:49 | call to method ReturnOut |
+| GlobalDataFlow.cs:106:19:106:23 | access to local variable sink1 | GlobalDataFlow.cs:106:19:106:23 | access to local variable sink1 |
+| GlobalDataFlow.cs:106:19:106:23 | access to local variable sink1 | GlobalDataFlow.cs:106:41:106:48 | SSA def(nonSink0) |
+| GlobalDataFlow.cs:106:19:106:23 | access to local variable sink1 | GlobalDataFlow.cs:106:41:106:48 | SSA def(nonSink0) |
+| GlobalDataFlow.cs:106:19:106:23 | access to local variable sink1 | GlobalDataFlow.cs:110:19:110:23 | access to local variable sink1 |
+| GlobalDataFlow.cs:106:19:106:23 | access to local variable sink1 | GlobalDataFlow.cs:110:19:110:23 | access to local variable sink1 |
+| GlobalDataFlow.cs:106:19:106:23 | access to local variable sink1 | GlobalDataFlow.cs:110:30:110:34 | access to local variable sink1 |
+| GlobalDataFlow.cs:106:19:106:23 | access to local variable sink1 | GlobalDataFlow.cs:110:30:110:34 | access to local variable sink1 |
+| GlobalDataFlow.cs:106:19:106:23 | access to local variable sink1 | GlobalDataFlow.cs:281:32:281:32 | x |
+| GlobalDataFlow.cs:106:19:106:23 | access to local variable sink1 | GlobalDataFlow.cs:281:32:281:32 | x |
+| GlobalDataFlow.cs:106:41:106:48 | SSA def(nonSink0) | GlobalDataFlow.cs:106:41:106:48 | SSA def(nonSink0) |
+| GlobalDataFlow.cs:106:41:106:48 | SSA def(nonSink0) | GlobalDataFlow.cs:107:15:107:22 | access to local variable nonSink0 |
+| GlobalDataFlow.cs:106:41:106:48 | SSA def(nonSink0) | GlobalDataFlow.cs:107:15:107:22 | access to local variable nonSink0 |
+| GlobalDataFlow.cs:106:41:106:48 | SSA def(nonSink0) | GlobalDataFlow.cs:108:27:108:34 | access to local variable nonSink0 |
+| GlobalDataFlow.cs:106:41:106:48 | SSA def(nonSink0) | GlobalDataFlow.cs:108:27:108:34 | access to local variable nonSink0 |
+| GlobalDataFlow.cs:106:41:106:48 | SSA def(nonSink0) | GlobalDataFlow.cs:108:41:108:48 | access to local variable nonSink0 |
+| GlobalDataFlow.cs:106:41:106:48 | SSA def(nonSink0) | GlobalDataFlow.cs:108:41:108:48 | access to local variable nonSink0 |
 | GlobalDataFlow.cs:107:9:107:23 | call to method Check | GlobalDataFlow.cs:107:9:107:23 | call to method Check |
 | GlobalDataFlow.cs:107:15:107:22 | access to local variable nonSink0 | GlobalDataFlow.cs:107:15:107:22 | access to local variable nonSink0 |
-| GlobalDataFlow.cs:107:15:107:22 | access to local variable nonSink0 | GlobalDataFlow.cs:108:25:108:70 | (...) ... |
-| GlobalDataFlow.cs:107:15:107:22 | access to local variable nonSink0 | GlobalDataFlow.cs:108:25:108:70 | (...) ... |
-| GlobalDataFlow.cs:107:15:107:22 | access to local variable nonSink0 | GlobalDataFlow.cs:108:46:108:70 | array creation of type String[] |
-| GlobalDataFlow.cs:107:15:107:22 | access to local variable nonSink0 | GlobalDataFlow.cs:108:46:108:70 | array creation of type String[] |
-| GlobalDataFlow.cs:107:15:107:22 | access to local variable nonSink0 | GlobalDataFlow.cs:108:61:108:68 | access to local variable nonSink0 |
-| GlobalDataFlow.cs:107:15:107:22 | access to local variable nonSink0 | GlobalDataFlow.cs:108:61:108:68 | access to local variable nonSink0 |
-| GlobalDataFlow.cs:107:15:107:22 | access to local variable nonSink0 | GlobalDataFlow.cs:110:21:110:66 | (...) ... |
-| GlobalDataFlow.cs:107:15:107:22 | access to local variable nonSink0 | GlobalDataFlow.cs:110:21:110:66 | (...) ... |
-| GlobalDataFlow.cs:107:15:107:22 | access to local variable nonSink0 | GlobalDataFlow.cs:110:42:110:66 | array creation of type String[] |
-| GlobalDataFlow.cs:107:15:107:22 | access to local variable nonSink0 | GlobalDataFlow.cs:110:42:110:66 | array creation of type String[] |
-| GlobalDataFlow.cs:107:15:107:22 | access to local variable nonSink0 | GlobalDataFlow.cs:110:57:110:64 | access to local variable nonSink0 |
-| GlobalDataFlow.cs:107:15:107:22 | access to local variable nonSink0 | GlobalDataFlow.cs:110:57:110:64 | access to local variable nonSink0 |
-| GlobalDataFlow.cs:108:13:108:90 | IEnumerable<String> nonSink1 = ... | GlobalDataFlow.cs:108:13:108:90 | IEnumerable<String> nonSink1 = ... |
-| GlobalDataFlow.cs:108:13:108:90 | SSA def(nonSink1) | GlobalDataFlow.cs:108:13:108:90 | SSA def(nonSink1) |
-| GlobalDataFlow.cs:108:13:108:90 | SSA def(nonSink1) | GlobalDataFlow.cs:109:15:109:22 | access to local variable nonSink1 |
-| GlobalDataFlow.cs:108:13:108:90 | SSA def(nonSink1) | GlobalDataFlow.cs:109:15:109:22 | access to local variable nonSink1 |
-| GlobalDataFlow.cs:108:24:108:90 | call to method SelectEven | GlobalDataFlow.cs:108:13:108:90 | SSA def(nonSink1) |
-| GlobalDataFlow.cs:108:24:108:90 | call to method SelectEven | GlobalDataFlow.cs:108:13:108:90 | SSA def(nonSink1) |
-| GlobalDataFlow.cs:108:24:108:90 | call to method SelectEven | GlobalDataFlow.cs:108:24:108:90 | call to method SelectEven |
-| GlobalDataFlow.cs:108:24:108:90 | call to method SelectEven | GlobalDataFlow.cs:109:15:109:22 | access to local variable nonSink1 |
-| GlobalDataFlow.cs:108:24:108:90 | call to method SelectEven | GlobalDataFlow.cs:109:15:109:22 | access to local variable nonSink1 |
-| GlobalDataFlow.cs:108:25:108:70 | (...) ... | GlobalDataFlow.cs:108:24:108:90 | call to method SelectEven |
-| GlobalDataFlow.cs:108:25:108:70 | (...) ... | GlobalDataFlow.cs:108:24:108:90 | call to method SelectEven |
-| GlobalDataFlow.cs:108:25:108:70 | (...) ... | GlobalDataFlow.cs:108:25:108:70 | (...) ... |
-| GlobalDataFlow.cs:108:25:108:70 | (...) ... | GlobalDataFlow.cs:421:71:421:71 | e |
-| GlobalDataFlow.cs:108:25:108:70 | (...) ... | GlobalDataFlow.cs:421:71:421:71 | e |
-| GlobalDataFlow.cs:108:46:108:70 | array creation of type String[] | GlobalDataFlow.cs:108:25:108:70 | (...) ... |
-| GlobalDataFlow.cs:108:46:108:70 | array creation of type String[] | GlobalDataFlow.cs:108:25:108:70 | (...) ... |
-| GlobalDataFlow.cs:108:46:108:70 | array creation of type String[] | GlobalDataFlow.cs:108:46:108:70 | array creation of type String[] |
-| GlobalDataFlow.cs:108:59:108:70 | { ..., ... } | GlobalDataFlow.cs:108:59:108:70 | { ..., ... } |
-| GlobalDataFlow.cs:108:61:108:68 | access to local variable nonSink0 | GlobalDataFlow.cs:108:25:108:70 | (...) ... |
-| GlobalDataFlow.cs:108:61:108:68 | access to local variable nonSink0 | GlobalDataFlow.cs:108:25:108:70 | (...) ... |
-| GlobalDataFlow.cs:108:61:108:68 | access to local variable nonSink0 | GlobalDataFlow.cs:108:46:108:70 | array creation of type String[] |
-| GlobalDataFlow.cs:108:61:108:68 | access to local variable nonSink0 | GlobalDataFlow.cs:108:46:108:70 | array creation of type String[] |
-| GlobalDataFlow.cs:108:61:108:68 | access to local variable nonSink0 | GlobalDataFlow.cs:108:61:108:68 | access to local variable nonSink0 |
-| GlobalDataFlow.cs:108:61:108:68 | access to local variable nonSink0 | GlobalDataFlow.cs:110:21:110:66 | (...) ... |
-| GlobalDataFlow.cs:108:61:108:68 | access to local variable nonSink0 | GlobalDataFlow.cs:110:21:110:66 | (...) ... |
-| GlobalDataFlow.cs:108:61:108:68 | access to local variable nonSink0 | GlobalDataFlow.cs:110:42:110:66 | array creation of type String[] |
-| GlobalDataFlow.cs:108:61:108:68 | access to local variable nonSink0 | GlobalDataFlow.cs:110:42:110:66 | array creation of type String[] |
-| GlobalDataFlow.cs:108:61:108:68 | access to local variable nonSink0 | GlobalDataFlow.cs:110:57:110:64 | access to local variable nonSink0 |
-| GlobalDataFlow.cs:108:61:108:68 | access to local variable nonSink0 | GlobalDataFlow.cs:110:57:110:64 | access to local variable nonSink0 |
-| GlobalDataFlow.cs:108:84:108:84 | x | GlobalDataFlow.cs:108:84:108:84 | x |
-| GlobalDataFlow.cs:108:84:108:84 | x | GlobalDataFlow.cs:108:84:108:84 | x |
-| GlobalDataFlow.cs:108:84:108:84 | x | GlobalDataFlow.cs:108:84:108:84 | x |
-| GlobalDataFlow.cs:108:84:108:84 | x | GlobalDataFlow.cs:108:84:108:84 | x |
-| GlobalDataFlow.cs:108:84:108:84 | x | GlobalDataFlow.cs:108:89:108:89 | access to parameter x |
-| GlobalDataFlow.cs:108:84:108:84 | x | GlobalDataFlow.cs:108:89:108:89 | access to parameter x |
-| GlobalDataFlow.cs:108:84:108:84 | x | GlobalDataFlow.cs:108:89:108:89 | access to parameter x |
-| GlobalDataFlow.cs:108:84:108:84 | x | GlobalDataFlow.cs:108:89:108:89 | access to parameter x |
-| GlobalDataFlow.cs:108:84:108:84 | x | GlobalDataFlow.cs:108:89:108:89 | access to parameter x |
-| GlobalDataFlow.cs:108:84:108:84 | x | GlobalDataFlow.cs:108:89:108:89 | access to parameter x |
-| GlobalDataFlow.cs:108:84:108:89 | (...) => ... | GlobalDataFlow.cs:108:84:108:89 | (...) => ... |
-| GlobalDataFlow.cs:108:84:108:89 | (...) => ... | GlobalDataFlow.cs:421:85:421:85 | f |
-| GlobalDataFlow.cs:108:84:108:89 | (...) => ... | GlobalDataFlow.cs:421:85:421:85 | f |
-| GlobalDataFlow.cs:108:89:108:89 | access to parameter x | GlobalDataFlow.cs:108:89:108:89 | access to parameter x |
-| GlobalDataFlow.cs:108:89:108:89 | access to parameter x | GlobalDataFlow.cs:426:44:426:47 | delegate call |
-| GlobalDataFlow.cs:108:89:108:89 | access to parameter x | GlobalDataFlow.cs:426:44:426:47 | delegate call |
+| GlobalDataFlow.cs:107:15:107:22 | access to local variable nonSink0 | GlobalDataFlow.cs:108:27:108:34 | access to local variable nonSink0 |
+| GlobalDataFlow.cs:107:15:107:22 | access to local variable nonSink0 | GlobalDataFlow.cs:108:27:108:34 | access to local variable nonSink0 |
+| GlobalDataFlow.cs:107:15:107:22 | access to local variable nonSink0 | GlobalDataFlow.cs:108:41:108:48 | access to local variable nonSink0 |
+| GlobalDataFlow.cs:107:15:107:22 | access to local variable nonSink0 | GlobalDataFlow.cs:108:41:108:48 | access to local variable nonSink0 |
+| GlobalDataFlow.cs:108:9:108:49 | call to method ReturnRef | GlobalDataFlow.cs:108:9:108:49 | call to method ReturnRef |
+| GlobalDataFlow.cs:108:19:108:20 | "" | GlobalDataFlow.cs:108:19:108:20 | "" |
+| GlobalDataFlow.cs:108:19:108:20 | "" | GlobalDataFlow.cs:108:27:108:34 | SSA def(nonSink0) |
+| GlobalDataFlow.cs:108:19:108:20 | "" | GlobalDataFlow.cs:108:27:108:34 | SSA def(nonSink0) |
+| GlobalDataFlow.cs:108:19:108:20 | "" | GlobalDataFlow.cs:287:32:287:32 | x |
+| GlobalDataFlow.cs:108:19:108:20 | "" | GlobalDataFlow.cs:287:32:287:32 | x |
+| GlobalDataFlow.cs:108:27:108:34 | SSA def(nonSink0) | GlobalDataFlow.cs:108:27:108:34 | SSA def(nonSink0) |
+| GlobalDataFlow.cs:108:27:108:34 | SSA def(nonSink0) | GlobalDataFlow.cs:109:15:109:22 | access to local variable nonSink0 |
+| GlobalDataFlow.cs:108:27:108:34 | SSA def(nonSink0) | GlobalDataFlow.cs:109:15:109:22 | access to local variable nonSink0 |
+| GlobalDataFlow.cs:108:27:108:34 | SSA def(nonSink0) | GlobalDataFlow.cs:110:41:110:48 | access to local variable nonSink0 |
+| GlobalDataFlow.cs:108:27:108:34 | SSA def(nonSink0) | GlobalDataFlow.cs:110:41:110:48 | access to local variable nonSink0 |
+| GlobalDataFlow.cs:108:27:108:34 | SSA def(nonSink0) | GlobalDataFlow.cs:111:15:111:22 | access to local variable nonSink0 |
+| GlobalDataFlow.cs:108:27:108:34 | SSA def(nonSink0) | GlobalDataFlow.cs:111:15:111:22 | access to local variable nonSink0 |
+| GlobalDataFlow.cs:108:27:108:34 | SSA def(nonSink0) | GlobalDataFlow.cs:112:25:112:70 | (...) ... |
+| GlobalDataFlow.cs:108:27:108:34 | SSA def(nonSink0) | GlobalDataFlow.cs:112:25:112:70 | (...) ... |
+| GlobalDataFlow.cs:108:27:108:34 | SSA def(nonSink0) | GlobalDataFlow.cs:112:46:112:70 | array creation of type String[] |
+| GlobalDataFlow.cs:108:27:108:34 | SSA def(nonSink0) | GlobalDataFlow.cs:112:46:112:70 | array creation of type String[] |
+| GlobalDataFlow.cs:108:27:108:34 | SSA def(nonSink0) | GlobalDataFlow.cs:112:61:112:68 | access to local variable nonSink0 |
+| GlobalDataFlow.cs:108:27:108:34 | SSA def(nonSink0) | GlobalDataFlow.cs:112:61:112:68 | access to local variable nonSink0 |
+| GlobalDataFlow.cs:108:27:108:34 | SSA def(nonSink0) | GlobalDataFlow.cs:114:21:114:66 | (...) ... |
+| GlobalDataFlow.cs:108:27:108:34 | SSA def(nonSink0) | GlobalDataFlow.cs:114:21:114:66 | (...) ... |
+| GlobalDataFlow.cs:108:27:108:34 | SSA def(nonSink0) | GlobalDataFlow.cs:114:42:114:66 | array creation of type String[] |
+| GlobalDataFlow.cs:108:27:108:34 | SSA def(nonSink0) | GlobalDataFlow.cs:114:42:114:66 | array creation of type String[] |
+| GlobalDataFlow.cs:108:27:108:34 | SSA def(nonSink0) | GlobalDataFlow.cs:114:57:114:64 | access to local variable nonSink0 |
+| GlobalDataFlow.cs:108:27:108:34 | SSA def(nonSink0) | GlobalDataFlow.cs:114:57:114:64 | access to local variable nonSink0 |
+| GlobalDataFlow.cs:108:27:108:34 | access to local variable nonSink0 | GlobalDataFlow.cs:108:27:108:34 | access to local variable nonSink0 |
+| GlobalDataFlow.cs:108:27:108:34 | access to local variable nonSink0 | GlobalDataFlow.cs:108:41:108:48 | access to local variable nonSink0 |
+| GlobalDataFlow.cs:108:27:108:34 | access to local variable nonSink0 | GlobalDataFlow.cs:108:41:108:48 | access to local variable nonSink0 |
+| GlobalDataFlow.cs:108:41:108:48 | access to local variable nonSink0 | GlobalDataFlow.cs:108:27:108:34 | SSA def(nonSink0) |
+| GlobalDataFlow.cs:108:41:108:48 | access to local variable nonSink0 | GlobalDataFlow.cs:108:27:108:34 | SSA def(nonSink0) |
+| GlobalDataFlow.cs:108:41:108:48 | access to local variable nonSink0 | GlobalDataFlow.cs:108:41:108:48 | access to local variable nonSink0 |
+| GlobalDataFlow.cs:108:41:108:48 | access to local variable nonSink0 | GlobalDataFlow.cs:287:50:287:50 | z |
+| GlobalDataFlow.cs:108:41:108:48 | access to local variable nonSink0 | GlobalDataFlow.cs:287:50:287:50 | z |
 | GlobalDataFlow.cs:109:9:109:23 | call to method Check | GlobalDataFlow.cs:109:9:109:23 | call to method Check |
-| GlobalDataFlow.cs:109:15:109:22 | access to local variable nonSink1 | GlobalDataFlow.cs:109:15:109:22 | access to local variable nonSink1 |
-| GlobalDataFlow.cs:110:9:110:82 | ... = ... | GlobalDataFlow.cs:110:9:110:82 | ... = ... |
-| GlobalDataFlow.cs:110:9:110:82 | SSA def(nonSink1) | GlobalDataFlow.cs:110:9:110:82 | SSA def(nonSink1) |
-| GlobalDataFlow.cs:110:9:110:82 | SSA def(nonSink1) | GlobalDataFlow.cs:111:15:111:22 | access to local variable nonSink1 |
-| GlobalDataFlow.cs:110:9:110:82 | SSA def(nonSink1) | GlobalDataFlow.cs:111:15:111:22 | access to local variable nonSink1 |
-| GlobalDataFlow.cs:110:20:110:82 | call to method Select | GlobalDataFlow.cs:110:9:110:82 | SSA def(nonSink1) |
-| GlobalDataFlow.cs:110:20:110:82 | call to method Select | GlobalDataFlow.cs:110:9:110:82 | SSA def(nonSink1) |
-| GlobalDataFlow.cs:110:20:110:82 | call to method Select | GlobalDataFlow.cs:110:20:110:82 | call to method Select |
-| GlobalDataFlow.cs:110:20:110:82 | call to method Select | GlobalDataFlow.cs:111:15:111:22 | access to local variable nonSink1 |
-| GlobalDataFlow.cs:110:20:110:82 | call to method Select | GlobalDataFlow.cs:111:15:111:22 | access to local variable nonSink1 |
-| GlobalDataFlow.cs:110:21:110:66 | (...) ... | GlobalDataFlow.cs:110:21:110:66 | (...) ... |
-| GlobalDataFlow.cs:110:21:110:66 | (...) ... | GlobalDataFlow.cs:110:76:110:76 | x |
-| GlobalDataFlow.cs:110:21:110:66 | (...) ... | GlobalDataFlow.cs:110:76:110:76 | x |
-| GlobalDataFlow.cs:110:21:110:66 | (...) ... | GlobalDataFlow.cs:110:76:110:81 | [output] (...) => ... |
-| GlobalDataFlow.cs:110:21:110:66 | (...) ... | GlobalDataFlow.cs:110:76:110:81 | [output] (...) => ... |
-| GlobalDataFlow.cs:110:42:110:66 | array creation of type String[] | GlobalDataFlow.cs:110:21:110:66 | (...) ... |
-| GlobalDataFlow.cs:110:42:110:66 | array creation of type String[] | GlobalDataFlow.cs:110:21:110:66 | (...) ... |
-| GlobalDataFlow.cs:110:42:110:66 | array creation of type String[] | GlobalDataFlow.cs:110:42:110:66 | array creation of type String[] |
-| GlobalDataFlow.cs:110:55:110:66 | { ..., ... } | GlobalDataFlow.cs:110:55:110:66 | { ..., ... } |
-| GlobalDataFlow.cs:110:57:110:64 | access to local variable nonSink0 | GlobalDataFlow.cs:110:21:110:66 | (...) ... |
-| GlobalDataFlow.cs:110:57:110:64 | access to local variable nonSink0 | GlobalDataFlow.cs:110:21:110:66 | (...) ... |
-| GlobalDataFlow.cs:110:57:110:64 | access to local variable nonSink0 | GlobalDataFlow.cs:110:42:110:66 | array creation of type String[] |
-| GlobalDataFlow.cs:110:57:110:64 | access to local variable nonSink0 | GlobalDataFlow.cs:110:42:110:66 | array creation of type String[] |
-| GlobalDataFlow.cs:110:57:110:64 | access to local variable nonSink0 | GlobalDataFlow.cs:110:57:110:64 | access to local variable nonSink0 |
-| GlobalDataFlow.cs:110:76:110:76 | x | GlobalDataFlow.cs:110:76:110:76 | x |
-| GlobalDataFlow.cs:110:76:110:76 | x | GlobalDataFlow.cs:110:76:110:76 | x |
-| GlobalDataFlow.cs:110:76:110:76 | x | GlobalDataFlow.cs:110:76:110:76 | x |
-| GlobalDataFlow.cs:110:76:110:76 | x | GlobalDataFlow.cs:110:76:110:76 | x |
-| GlobalDataFlow.cs:110:76:110:76 | x | GlobalDataFlow.cs:110:76:110:76 | x |
-| GlobalDataFlow.cs:110:76:110:76 | x | GlobalDataFlow.cs:110:76:110:76 | x |
-| GlobalDataFlow.cs:110:76:110:76 | x | GlobalDataFlow.cs:110:81:110:81 | access to parameter x |
-| GlobalDataFlow.cs:110:76:110:76 | x | GlobalDataFlow.cs:110:81:110:81 | access to parameter x |
-| GlobalDataFlow.cs:110:76:110:76 | x | GlobalDataFlow.cs:110:81:110:81 | access to parameter x |
-| GlobalDataFlow.cs:110:76:110:76 | x | GlobalDataFlow.cs:110:81:110:81 | access to parameter x |
-| GlobalDataFlow.cs:110:76:110:76 | x | GlobalDataFlow.cs:110:81:110:81 | access to parameter x |
-| GlobalDataFlow.cs:110:76:110:76 | x | GlobalDataFlow.cs:110:81:110:81 | access to parameter x |
-| GlobalDataFlow.cs:110:76:110:76 | x | GlobalDataFlow.cs:110:81:110:81 | access to parameter x |
-| GlobalDataFlow.cs:110:76:110:76 | x | GlobalDataFlow.cs:110:81:110:81 | access to parameter x |
-| GlobalDataFlow.cs:110:76:110:81 | (...) => ... | GlobalDataFlow.cs:110:76:110:81 | (...) => ... |
-| GlobalDataFlow.cs:110:76:110:81 | [output] (...) => ... | GlobalDataFlow.cs:110:9:110:82 | SSA def(nonSink1) |
-| GlobalDataFlow.cs:110:76:110:81 | [output] (...) => ... | GlobalDataFlow.cs:110:9:110:82 | SSA def(nonSink1) |
-| GlobalDataFlow.cs:110:76:110:81 | [output] (...) => ... | GlobalDataFlow.cs:110:20:110:82 | call to method Select |
-| GlobalDataFlow.cs:110:76:110:81 | [output] (...) => ... | GlobalDataFlow.cs:110:20:110:82 | call to method Select |
-| GlobalDataFlow.cs:110:76:110:81 | [output] (...) => ... | GlobalDataFlow.cs:110:76:110:81 | [output] (...) => ... |
-| GlobalDataFlow.cs:110:76:110:81 | [output] (...) => ... | GlobalDataFlow.cs:111:15:111:22 | access to local variable nonSink1 |
-| GlobalDataFlow.cs:110:76:110:81 | [output] (...) => ... | GlobalDataFlow.cs:111:15:111:22 | access to local variable nonSink1 |
-| GlobalDataFlow.cs:110:81:110:81 | access to parameter x | GlobalDataFlow.cs:110:76:110:81 | [output] (...) => ... |
-| GlobalDataFlow.cs:110:81:110:81 | access to parameter x | GlobalDataFlow.cs:110:76:110:81 | [output] (...) => ... |
-| GlobalDataFlow.cs:110:81:110:81 | access to parameter x | GlobalDataFlow.cs:110:81:110:81 | access to parameter x |
+| GlobalDataFlow.cs:109:15:109:22 | access to local variable nonSink0 | GlobalDataFlow.cs:109:15:109:22 | access to local variable nonSink0 |
+| GlobalDataFlow.cs:109:15:109:22 | access to local variable nonSink0 | GlobalDataFlow.cs:110:41:110:48 | access to local variable nonSink0 |
+| GlobalDataFlow.cs:109:15:109:22 | access to local variable nonSink0 | GlobalDataFlow.cs:110:41:110:48 | access to local variable nonSink0 |
+| GlobalDataFlow.cs:109:15:109:22 | access to local variable nonSink0 | GlobalDataFlow.cs:111:15:111:22 | access to local variable nonSink0 |
+| GlobalDataFlow.cs:109:15:109:22 | access to local variable nonSink0 | GlobalDataFlow.cs:111:15:111:22 | access to local variable nonSink0 |
+| GlobalDataFlow.cs:109:15:109:22 | access to local variable nonSink0 | GlobalDataFlow.cs:112:25:112:70 | (...) ... |
+| GlobalDataFlow.cs:109:15:109:22 | access to local variable nonSink0 | GlobalDataFlow.cs:112:25:112:70 | (...) ... |
+| GlobalDataFlow.cs:109:15:109:22 | access to local variable nonSink0 | GlobalDataFlow.cs:112:46:112:70 | array creation of type String[] |
+| GlobalDataFlow.cs:109:15:109:22 | access to local variable nonSink0 | GlobalDataFlow.cs:112:46:112:70 | array creation of type String[] |
+| GlobalDataFlow.cs:109:15:109:22 | access to local variable nonSink0 | GlobalDataFlow.cs:112:61:112:68 | access to local variable nonSink0 |
+| GlobalDataFlow.cs:109:15:109:22 | access to local variable nonSink0 | GlobalDataFlow.cs:112:61:112:68 | access to local variable nonSink0 |
+| GlobalDataFlow.cs:109:15:109:22 | access to local variable nonSink0 | GlobalDataFlow.cs:114:21:114:66 | (...) ... |
+| GlobalDataFlow.cs:109:15:109:22 | access to local variable nonSink0 | GlobalDataFlow.cs:114:21:114:66 | (...) ... |
+| GlobalDataFlow.cs:109:15:109:22 | access to local variable nonSink0 | GlobalDataFlow.cs:114:42:114:66 | array creation of type String[] |
+| GlobalDataFlow.cs:109:15:109:22 | access to local variable nonSink0 | GlobalDataFlow.cs:114:42:114:66 | array creation of type String[] |
+| GlobalDataFlow.cs:109:15:109:22 | access to local variable nonSink0 | GlobalDataFlow.cs:114:57:114:64 | access to local variable nonSink0 |
+| GlobalDataFlow.cs:109:15:109:22 | access to local variable nonSink0 | GlobalDataFlow.cs:114:57:114:64 | access to local variable nonSink0 |
+| GlobalDataFlow.cs:110:9:110:49 | call to method ReturnRef | GlobalDataFlow.cs:110:9:110:49 | call to method ReturnRef |
+| GlobalDataFlow.cs:110:19:110:23 | access to local variable sink1 | GlobalDataFlow.cs:110:19:110:23 | access to local variable sink1 |
+| GlobalDataFlow.cs:110:19:110:23 | access to local variable sink1 | GlobalDataFlow.cs:110:30:110:34 | SSA def(sink1) |
+| GlobalDataFlow.cs:110:19:110:23 | access to local variable sink1 | GlobalDataFlow.cs:110:30:110:34 | SSA def(sink1) |
+| GlobalDataFlow.cs:110:19:110:23 | access to local variable sink1 | GlobalDataFlow.cs:110:30:110:34 | access to local variable sink1 |
+| GlobalDataFlow.cs:110:19:110:23 | access to local variable sink1 | GlobalDataFlow.cs:110:30:110:34 | access to local variable sink1 |
+| GlobalDataFlow.cs:110:19:110:23 | access to local variable sink1 | GlobalDataFlow.cs:287:32:287:32 | x |
+| GlobalDataFlow.cs:110:19:110:23 | access to local variable sink1 | GlobalDataFlow.cs:287:32:287:32 | x |
+| GlobalDataFlow.cs:110:30:110:34 | SSA def(sink1) | GlobalDataFlow.cs:110:30:110:34 | SSA def(sink1) |
+| GlobalDataFlow.cs:110:30:110:34 | SSA def(sink1) | GlobalDataFlow.cs:124:39:124:43 | access to local variable sink1 |
+| GlobalDataFlow.cs:110:30:110:34 | SSA def(sink1) | GlobalDataFlow.cs:124:39:124:43 | access to local variable sink1 |
+| GlobalDataFlow.cs:110:30:110:34 | access to local variable sink1 | GlobalDataFlow.cs:110:30:110:34 | access to local variable sink1 |
+| GlobalDataFlow.cs:110:41:110:48 | access to local variable nonSink0 | GlobalDataFlow.cs:110:30:110:34 | SSA def(sink1) |
+| GlobalDataFlow.cs:110:41:110:48 | access to local variable nonSink0 | GlobalDataFlow.cs:110:30:110:34 | SSA def(sink1) |
+| GlobalDataFlow.cs:110:41:110:48 | access to local variable nonSink0 | GlobalDataFlow.cs:110:41:110:48 | access to local variable nonSink0 |
+| GlobalDataFlow.cs:110:41:110:48 | access to local variable nonSink0 | GlobalDataFlow.cs:111:15:111:22 | access to local variable nonSink0 |
+| GlobalDataFlow.cs:110:41:110:48 | access to local variable nonSink0 | GlobalDataFlow.cs:111:15:111:22 | access to local variable nonSink0 |
+| GlobalDataFlow.cs:110:41:110:48 | access to local variable nonSink0 | GlobalDataFlow.cs:112:25:112:70 | (...) ... |
+| GlobalDataFlow.cs:110:41:110:48 | access to local variable nonSink0 | GlobalDataFlow.cs:112:25:112:70 | (...) ... |
+| GlobalDataFlow.cs:110:41:110:48 | access to local variable nonSink0 | GlobalDataFlow.cs:112:46:112:70 | array creation of type String[] |
+| GlobalDataFlow.cs:110:41:110:48 | access to local variable nonSink0 | GlobalDataFlow.cs:112:46:112:70 | array creation of type String[] |
+| GlobalDataFlow.cs:110:41:110:48 | access to local variable nonSink0 | GlobalDataFlow.cs:112:61:112:68 | access to local variable nonSink0 |
+| GlobalDataFlow.cs:110:41:110:48 | access to local variable nonSink0 | GlobalDataFlow.cs:112:61:112:68 | access to local variable nonSink0 |
+| GlobalDataFlow.cs:110:41:110:48 | access to local variable nonSink0 | GlobalDataFlow.cs:114:21:114:66 | (...) ... |
+| GlobalDataFlow.cs:110:41:110:48 | access to local variable nonSink0 | GlobalDataFlow.cs:114:21:114:66 | (...) ... |
+| GlobalDataFlow.cs:110:41:110:48 | access to local variable nonSink0 | GlobalDataFlow.cs:114:42:114:66 | array creation of type String[] |
+| GlobalDataFlow.cs:110:41:110:48 | access to local variable nonSink0 | GlobalDataFlow.cs:114:42:114:66 | array creation of type String[] |
+| GlobalDataFlow.cs:110:41:110:48 | access to local variable nonSink0 | GlobalDataFlow.cs:114:57:114:64 | access to local variable nonSink0 |
+| GlobalDataFlow.cs:110:41:110:48 | access to local variable nonSink0 | GlobalDataFlow.cs:114:57:114:64 | access to local variable nonSink0 |
+| GlobalDataFlow.cs:110:41:110:48 | access to local variable nonSink0 | GlobalDataFlow.cs:287:50:287:50 | z |
+| GlobalDataFlow.cs:110:41:110:48 | access to local variable nonSink0 | GlobalDataFlow.cs:287:50:287:50 | z |
 | GlobalDataFlow.cs:111:9:111:23 | call to method Check | GlobalDataFlow.cs:111:9:111:23 | call to method Check |
-| GlobalDataFlow.cs:111:15:111:22 | access to local variable nonSink1 | GlobalDataFlow.cs:111:15:111:22 | access to local variable nonSink1 |
-| GlobalDataFlow.cs:112:9:112:134 | ... = ... | GlobalDataFlow.cs:112:9:112:134 | ... = ... |
-| GlobalDataFlow.cs:112:9:112:134 | SSA def(nonSink1) | GlobalDataFlow.cs:112:9:112:134 | SSA def(nonSink1) |
-| GlobalDataFlow.cs:112:9:112:134 | SSA def(nonSink1) | GlobalDataFlow.cs:113:15:113:22 | access to local variable nonSink1 |
-| GlobalDataFlow.cs:112:9:112:134 | SSA def(nonSink1) | GlobalDataFlow.cs:113:15:113:22 | access to local variable nonSink1 |
-| GlobalDataFlow.cs:112:20:112:134 | call to method Zip | GlobalDataFlow.cs:112:9:112:134 | SSA def(nonSink1) |
-| GlobalDataFlow.cs:112:20:112:134 | call to method Zip | GlobalDataFlow.cs:112:9:112:134 | SSA def(nonSink1) |
-| GlobalDataFlow.cs:112:20:112:134 | call to method Zip | GlobalDataFlow.cs:112:20:112:134 | call to method Zip |
-| GlobalDataFlow.cs:112:20:112:134 | call to method Zip | GlobalDataFlow.cs:113:15:113:22 | access to local variable nonSink1 |
-| GlobalDataFlow.cs:112:20:112:134 | call to method Zip | GlobalDataFlow.cs:113:15:113:22 | access to local variable nonSink1 |
-| GlobalDataFlow.cs:112:21:112:72 | (...) ... | GlobalDataFlow.cs:112:21:112:72 | (...) ... |
-| GlobalDataFlow.cs:112:42:112:72 | array creation of type String[] | GlobalDataFlow.cs:112:21:112:72 | (...) ... |
-| GlobalDataFlow.cs:112:42:112:72 | array creation of type String[] | GlobalDataFlow.cs:112:21:112:72 | (...) ... |
-| GlobalDataFlow.cs:112:42:112:72 | array creation of type String[] | GlobalDataFlow.cs:112:42:112:72 | array creation of type String[] |
-| GlobalDataFlow.cs:112:55:112:72 | { ..., ... } | GlobalDataFlow.cs:112:55:112:72 | { ..., ... } |
-| GlobalDataFlow.cs:112:57:112:62 | access to local variable sink14 | GlobalDataFlow.cs:112:21:112:72 | (...) ... |
-| GlobalDataFlow.cs:112:57:112:62 | access to local variable sink14 | GlobalDataFlow.cs:112:21:112:72 | (...) ... |
-| GlobalDataFlow.cs:112:57:112:62 | access to local variable sink14 | GlobalDataFlow.cs:112:42:112:72 | array creation of type String[] |
-| GlobalDataFlow.cs:112:57:112:62 | access to local variable sink14 | GlobalDataFlow.cs:112:42:112:72 | array creation of type String[] |
-| GlobalDataFlow.cs:112:57:112:62 | access to local variable sink14 | GlobalDataFlow.cs:112:57:112:62 | access to local variable sink14 |
-| GlobalDataFlow.cs:112:57:112:62 | access to local variable sink14 | GlobalDataFlow.cs:112:57:112:70 | call to method First |
-| GlobalDataFlow.cs:112:57:112:62 | access to local variable sink14 | GlobalDataFlow.cs:112:57:112:70 | call to method First |
-| GlobalDataFlow.cs:112:57:112:62 | access to local variable sink14 | GlobalDataFlow.cs:116:20:116:25 | access to local variable sink14 |
-| GlobalDataFlow.cs:112:57:112:62 | access to local variable sink14 | GlobalDataFlow.cs:116:20:116:25 | access to local variable sink14 |
-| GlobalDataFlow.cs:112:57:112:62 | access to local variable sink14 | GlobalDataFlow.cs:118:20:118:25 | access to local variable sink14 |
-| GlobalDataFlow.cs:112:57:112:62 | access to local variable sink14 | GlobalDataFlow.cs:118:20:118:25 | access to local variable sink14 |
-| GlobalDataFlow.cs:112:57:112:70 | call to method First | GlobalDataFlow.cs:112:21:112:72 | (...) ... |
-| GlobalDataFlow.cs:112:57:112:70 | call to method First | GlobalDataFlow.cs:112:21:112:72 | (...) ... |
-| GlobalDataFlow.cs:112:57:112:70 | call to method First | GlobalDataFlow.cs:112:42:112:72 | array creation of type String[] |
-| GlobalDataFlow.cs:112:57:112:70 | call to method First | GlobalDataFlow.cs:112:42:112:72 | array creation of type String[] |
-| GlobalDataFlow.cs:112:57:112:70 | call to method First | GlobalDataFlow.cs:112:57:112:70 | call to method First |
-| GlobalDataFlow.cs:112:80:112:119 | (...) ... | GlobalDataFlow.cs:112:80:112:119 | (...) ... |
-| GlobalDataFlow.cs:112:80:112:119 | (...) ... | GlobalDataFlow.cs:112:123:112:133 | [output] (...) => ... |
-| GlobalDataFlow.cs:112:80:112:119 | (...) ... | GlobalDataFlow.cs:112:123:112:133 | [output] (...) => ... |
-| GlobalDataFlow.cs:112:80:112:119 | (...) ... | GlobalDataFlow.cs:112:127:112:127 | y |
-| GlobalDataFlow.cs:112:80:112:119 | (...) ... | GlobalDataFlow.cs:112:127:112:127 | y |
-| GlobalDataFlow.cs:112:101:112:119 | array creation of type String[] | GlobalDataFlow.cs:112:80:112:119 | (...) ... |
-| GlobalDataFlow.cs:112:101:112:119 | array creation of type String[] | GlobalDataFlow.cs:112:80:112:119 | (...) ... |
-| GlobalDataFlow.cs:112:101:112:119 | array creation of type String[] | GlobalDataFlow.cs:112:101:112:119 | array creation of type String[] |
-| GlobalDataFlow.cs:112:114:112:119 | { ..., ... } | GlobalDataFlow.cs:112:114:112:119 | { ..., ... } |
-| GlobalDataFlow.cs:112:116:112:117 | "" | GlobalDataFlow.cs:112:80:112:119 | (...) ... |
-| GlobalDataFlow.cs:112:116:112:117 | "" | GlobalDataFlow.cs:112:80:112:119 | (...) ... |
-| GlobalDataFlow.cs:112:116:112:117 | "" | GlobalDataFlow.cs:112:101:112:119 | array creation of type String[] |
-| GlobalDataFlow.cs:112:116:112:117 | "" | GlobalDataFlow.cs:112:101:112:119 | array creation of type String[] |
-| GlobalDataFlow.cs:112:116:112:117 | "" | GlobalDataFlow.cs:112:116:112:117 | "" |
-| GlobalDataFlow.cs:112:123:112:133 | (...) => ... | GlobalDataFlow.cs:112:123:112:133 | (...) => ... |
-| GlobalDataFlow.cs:112:123:112:133 | [output] (...) => ... | GlobalDataFlow.cs:112:9:112:134 | SSA def(nonSink1) |
-| GlobalDataFlow.cs:112:123:112:133 | [output] (...) => ... | GlobalDataFlow.cs:112:9:112:134 | SSA def(nonSink1) |
-| GlobalDataFlow.cs:112:123:112:133 | [output] (...) => ... | GlobalDataFlow.cs:112:20:112:134 | call to method Zip |
-| GlobalDataFlow.cs:112:123:112:133 | [output] (...) => ... | GlobalDataFlow.cs:112:20:112:134 | call to method Zip |
-| GlobalDataFlow.cs:112:123:112:133 | [output] (...) => ... | GlobalDataFlow.cs:112:123:112:133 | [output] (...) => ... |
-| GlobalDataFlow.cs:112:123:112:133 | [output] (...) => ... | GlobalDataFlow.cs:113:15:113:22 | access to local variable nonSink1 |
-| GlobalDataFlow.cs:112:123:112:133 | [output] (...) => ... | GlobalDataFlow.cs:113:15:113:22 | access to local variable nonSink1 |
-| GlobalDataFlow.cs:112:127:112:127 | y | GlobalDataFlow.cs:112:127:112:127 | y |
-| GlobalDataFlow.cs:112:127:112:127 | y | GlobalDataFlow.cs:112:127:112:127 | y |
-| GlobalDataFlow.cs:112:127:112:127 | y | GlobalDataFlow.cs:112:127:112:127 | y |
-| GlobalDataFlow.cs:112:127:112:127 | y | GlobalDataFlow.cs:112:127:112:127 | y |
-| GlobalDataFlow.cs:112:127:112:127 | y | GlobalDataFlow.cs:112:127:112:127 | y |
-| GlobalDataFlow.cs:112:127:112:127 | y | GlobalDataFlow.cs:112:127:112:127 | y |
-| GlobalDataFlow.cs:112:127:112:127 | y | GlobalDataFlow.cs:112:133:112:133 | access to parameter y |
-| GlobalDataFlow.cs:112:127:112:127 | y | GlobalDataFlow.cs:112:133:112:133 | access to parameter y |
-| GlobalDataFlow.cs:112:127:112:127 | y | GlobalDataFlow.cs:112:133:112:133 | access to parameter y |
-| GlobalDataFlow.cs:112:127:112:127 | y | GlobalDataFlow.cs:112:133:112:133 | access to parameter y |
-| GlobalDataFlow.cs:112:127:112:127 | y | GlobalDataFlow.cs:112:133:112:133 | access to parameter y |
-| GlobalDataFlow.cs:112:127:112:127 | y | GlobalDataFlow.cs:112:133:112:133 | access to parameter y |
-| GlobalDataFlow.cs:112:127:112:127 | y | GlobalDataFlow.cs:112:133:112:133 | access to parameter y |
-| GlobalDataFlow.cs:112:127:112:127 | y | GlobalDataFlow.cs:112:133:112:133 | access to parameter y |
-| GlobalDataFlow.cs:112:133:112:133 | access to parameter y | GlobalDataFlow.cs:112:123:112:133 | [output] (...) => ... |
-| GlobalDataFlow.cs:112:133:112:133 | access to parameter y | GlobalDataFlow.cs:112:123:112:133 | [output] (...) => ... |
-| GlobalDataFlow.cs:112:133:112:133 | access to parameter y | GlobalDataFlow.cs:112:133:112:133 | access to parameter y |
+| GlobalDataFlow.cs:111:15:111:22 | access to local variable nonSink0 | GlobalDataFlow.cs:111:15:111:22 | access to local variable nonSink0 |
+| GlobalDataFlow.cs:111:15:111:22 | access to local variable nonSink0 | GlobalDataFlow.cs:112:25:112:70 | (...) ... |
+| GlobalDataFlow.cs:111:15:111:22 | access to local variable nonSink0 | GlobalDataFlow.cs:112:25:112:70 | (...) ... |
+| GlobalDataFlow.cs:111:15:111:22 | access to local variable nonSink0 | GlobalDataFlow.cs:112:46:112:70 | array creation of type String[] |
+| GlobalDataFlow.cs:111:15:111:22 | access to local variable nonSink0 | GlobalDataFlow.cs:112:46:112:70 | array creation of type String[] |
+| GlobalDataFlow.cs:111:15:111:22 | access to local variable nonSink0 | GlobalDataFlow.cs:112:61:112:68 | access to local variable nonSink0 |
+| GlobalDataFlow.cs:111:15:111:22 | access to local variable nonSink0 | GlobalDataFlow.cs:112:61:112:68 | access to local variable nonSink0 |
+| GlobalDataFlow.cs:111:15:111:22 | access to local variable nonSink0 | GlobalDataFlow.cs:114:21:114:66 | (...) ... |
+| GlobalDataFlow.cs:111:15:111:22 | access to local variable nonSink0 | GlobalDataFlow.cs:114:21:114:66 | (...) ... |
+| GlobalDataFlow.cs:111:15:111:22 | access to local variable nonSink0 | GlobalDataFlow.cs:114:42:114:66 | array creation of type String[] |
+| GlobalDataFlow.cs:111:15:111:22 | access to local variable nonSink0 | GlobalDataFlow.cs:114:42:114:66 | array creation of type String[] |
+| GlobalDataFlow.cs:111:15:111:22 | access to local variable nonSink0 | GlobalDataFlow.cs:114:57:114:64 | access to local variable nonSink0 |
+| GlobalDataFlow.cs:111:15:111:22 | access to local variable nonSink0 | GlobalDataFlow.cs:114:57:114:64 | access to local variable nonSink0 |
+| GlobalDataFlow.cs:112:13:112:90 | IEnumerable<String> nonSink1 = ... | GlobalDataFlow.cs:112:13:112:90 | IEnumerable<String> nonSink1 = ... |
+| GlobalDataFlow.cs:112:13:112:90 | SSA def(nonSink1) | GlobalDataFlow.cs:112:13:112:90 | SSA def(nonSink1) |
+| GlobalDataFlow.cs:112:13:112:90 | SSA def(nonSink1) | GlobalDataFlow.cs:113:15:113:22 | access to local variable nonSink1 |
+| GlobalDataFlow.cs:112:13:112:90 | SSA def(nonSink1) | GlobalDataFlow.cs:113:15:113:22 | access to local variable nonSink1 |
+| GlobalDataFlow.cs:112:24:112:90 | call to method SelectEven | GlobalDataFlow.cs:112:13:112:90 | SSA def(nonSink1) |
+| GlobalDataFlow.cs:112:24:112:90 | call to method SelectEven | GlobalDataFlow.cs:112:13:112:90 | SSA def(nonSink1) |
+| GlobalDataFlow.cs:112:24:112:90 | call to method SelectEven | GlobalDataFlow.cs:112:24:112:90 | call to method SelectEven |
+| GlobalDataFlow.cs:112:24:112:90 | call to method SelectEven | GlobalDataFlow.cs:113:15:113:22 | access to local variable nonSink1 |
+| GlobalDataFlow.cs:112:24:112:90 | call to method SelectEven | GlobalDataFlow.cs:113:15:113:22 | access to local variable nonSink1 |
+| GlobalDataFlow.cs:112:25:112:70 | (...) ... | GlobalDataFlow.cs:112:24:112:90 | call to method SelectEven |
+| GlobalDataFlow.cs:112:25:112:70 | (...) ... | GlobalDataFlow.cs:112:24:112:90 | call to method SelectEven |
+| GlobalDataFlow.cs:112:25:112:70 | (...) ... | GlobalDataFlow.cs:112:25:112:70 | (...) ... |
+| GlobalDataFlow.cs:112:25:112:70 | (...) ... | GlobalDataFlow.cs:426:71:426:71 | e |
+| GlobalDataFlow.cs:112:25:112:70 | (...) ... | GlobalDataFlow.cs:426:71:426:71 | e |
+| GlobalDataFlow.cs:112:46:112:70 | array creation of type String[] | GlobalDataFlow.cs:112:25:112:70 | (...) ... |
+| GlobalDataFlow.cs:112:46:112:70 | array creation of type String[] | GlobalDataFlow.cs:112:25:112:70 | (...) ... |
+| GlobalDataFlow.cs:112:46:112:70 | array creation of type String[] | GlobalDataFlow.cs:112:46:112:70 | array creation of type String[] |
+| GlobalDataFlow.cs:112:59:112:70 | { ..., ... } | GlobalDataFlow.cs:112:59:112:70 | { ..., ... } |
+| GlobalDataFlow.cs:112:61:112:68 | access to local variable nonSink0 | GlobalDataFlow.cs:112:25:112:70 | (...) ... |
+| GlobalDataFlow.cs:112:61:112:68 | access to local variable nonSink0 | GlobalDataFlow.cs:112:25:112:70 | (...) ... |
+| GlobalDataFlow.cs:112:61:112:68 | access to local variable nonSink0 | GlobalDataFlow.cs:112:46:112:70 | array creation of type String[] |
+| GlobalDataFlow.cs:112:61:112:68 | access to local variable nonSink0 | GlobalDataFlow.cs:112:46:112:70 | array creation of type String[] |
+| GlobalDataFlow.cs:112:61:112:68 | access to local variable nonSink0 | GlobalDataFlow.cs:112:61:112:68 | access to local variable nonSink0 |
+| GlobalDataFlow.cs:112:61:112:68 | access to local variable nonSink0 | GlobalDataFlow.cs:114:21:114:66 | (...) ... |
+| GlobalDataFlow.cs:112:61:112:68 | access to local variable nonSink0 | GlobalDataFlow.cs:114:21:114:66 | (...) ... |
+| GlobalDataFlow.cs:112:61:112:68 | access to local variable nonSink0 | GlobalDataFlow.cs:114:42:114:66 | array creation of type String[] |
+| GlobalDataFlow.cs:112:61:112:68 | access to local variable nonSink0 | GlobalDataFlow.cs:114:42:114:66 | array creation of type String[] |
+| GlobalDataFlow.cs:112:61:112:68 | access to local variable nonSink0 | GlobalDataFlow.cs:114:57:114:64 | access to local variable nonSink0 |
+| GlobalDataFlow.cs:112:61:112:68 | access to local variable nonSink0 | GlobalDataFlow.cs:114:57:114:64 | access to local variable nonSink0 |
+| GlobalDataFlow.cs:112:84:112:84 | x | GlobalDataFlow.cs:112:84:112:84 | x |
+| GlobalDataFlow.cs:112:84:112:84 | x | GlobalDataFlow.cs:112:84:112:84 | x |
+| GlobalDataFlow.cs:112:84:112:84 | x | GlobalDataFlow.cs:112:84:112:84 | x |
+| GlobalDataFlow.cs:112:84:112:84 | x | GlobalDataFlow.cs:112:84:112:84 | x |
+| GlobalDataFlow.cs:112:84:112:84 | x | GlobalDataFlow.cs:112:89:112:89 | access to parameter x |
+| GlobalDataFlow.cs:112:84:112:84 | x | GlobalDataFlow.cs:112:89:112:89 | access to parameter x |
+| GlobalDataFlow.cs:112:84:112:84 | x | GlobalDataFlow.cs:112:89:112:89 | access to parameter x |
+| GlobalDataFlow.cs:112:84:112:84 | x | GlobalDataFlow.cs:112:89:112:89 | access to parameter x |
+| GlobalDataFlow.cs:112:84:112:84 | x | GlobalDataFlow.cs:112:89:112:89 | access to parameter x |
+| GlobalDataFlow.cs:112:84:112:84 | x | GlobalDataFlow.cs:112:89:112:89 | access to parameter x |
+| GlobalDataFlow.cs:112:84:112:89 | (...) => ... | GlobalDataFlow.cs:112:84:112:89 | (...) => ... |
+| GlobalDataFlow.cs:112:84:112:89 | (...) => ... | GlobalDataFlow.cs:426:85:426:85 | f |
+| GlobalDataFlow.cs:112:84:112:89 | (...) => ... | GlobalDataFlow.cs:426:85:426:85 | f |
+| GlobalDataFlow.cs:112:89:112:89 | access to parameter x | GlobalDataFlow.cs:112:89:112:89 | access to parameter x |
+| GlobalDataFlow.cs:112:89:112:89 | access to parameter x | GlobalDataFlow.cs:431:44:431:47 | delegate call |
+| GlobalDataFlow.cs:112:89:112:89 | access to parameter x | GlobalDataFlow.cs:431:44:431:47 | delegate call |
 | GlobalDataFlow.cs:113:9:113:23 | call to method Check | GlobalDataFlow.cs:113:9:113:23 | call to method Check |
 | GlobalDataFlow.cs:113:15:113:22 | access to local variable nonSink1 | GlobalDataFlow.cs:113:15:113:22 | access to local variable nonSink1 |
-| GlobalDataFlow.cs:114:9:114:134 | ... = ... | GlobalDataFlow.cs:114:9:114:134 | ... = ... |
-| GlobalDataFlow.cs:114:9:114:134 | SSA def(nonSink1) | GlobalDataFlow.cs:114:9:114:134 | SSA def(nonSink1) |
-| GlobalDataFlow.cs:114:9:114:134 | SSA def(nonSink1) | GlobalDataFlow.cs:115:15:115:22 | access to local variable nonSink1 |
-| GlobalDataFlow.cs:114:9:114:134 | SSA def(nonSink1) | GlobalDataFlow.cs:115:15:115:22 | access to local variable nonSink1 |
-| GlobalDataFlow.cs:114:9:114:134 | SSA def(nonSink1) | GlobalDataFlow.cs:120:20:120:27 | access to local variable nonSink1 |
-| GlobalDataFlow.cs:114:9:114:134 | SSA def(nonSink1) | GlobalDataFlow.cs:120:20:120:27 | access to local variable nonSink1 |
-| GlobalDataFlow.cs:114:20:114:134 | call to method Zip | GlobalDataFlow.cs:114:9:114:134 | SSA def(nonSink1) |
-| GlobalDataFlow.cs:114:20:114:134 | call to method Zip | GlobalDataFlow.cs:114:9:114:134 | SSA def(nonSink1) |
-| GlobalDataFlow.cs:114:20:114:134 | call to method Zip | GlobalDataFlow.cs:114:20:114:134 | call to method Zip |
-| GlobalDataFlow.cs:114:20:114:134 | call to method Zip | GlobalDataFlow.cs:115:15:115:22 | access to local variable nonSink1 |
-| GlobalDataFlow.cs:114:20:114:134 | call to method Zip | GlobalDataFlow.cs:115:15:115:22 | access to local variable nonSink1 |
-| GlobalDataFlow.cs:114:20:114:134 | call to method Zip | GlobalDataFlow.cs:120:20:120:27 | access to local variable nonSink1 |
-| GlobalDataFlow.cs:114:20:114:134 | call to method Zip | GlobalDataFlow.cs:120:20:120:27 | access to local variable nonSink1 |
-| GlobalDataFlow.cs:114:21:114:60 | (...) ... | GlobalDataFlow.cs:114:21:114:60 | (...) ... |
-| GlobalDataFlow.cs:114:21:114:60 | (...) ... | GlobalDataFlow.cs:114:123:114:133 | [output] (...) => ... |
-| GlobalDataFlow.cs:114:21:114:60 | (...) ... | GlobalDataFlow.cs:114:123:114:133 | [output] (...) => ... |
-| GlobalDataFlow.cs:114:21:114:60 | (...) ... | GlobalDataFlow.cs:114:124:114:124 | x |
-| GlobalDataFlow.cs:114:21:114:60 | (...) ... | GlobalDataFlow.cs:114:124:114:124 | x |
-| GlobalDataFlow.cs:114:42:114:60 | array creation of type String[] | GlobalDataFlow.cs:114:21:114:60 | (...) ... |
-| GlobalDataFlow.cs:114:42:114:60 | array creation of type String[] | GlobalDataFlow.cs:114:21:114:60 | (...) ... |
-| GlobalDataFlow.cs:114:42:114:60 | array creation of type String[] | GlobalDataFlow.cs:114:42:114:60 | array creation of type String[] |
-| GlobalDataFlow.cs:114:55:114:60 | { ..., ... } | GlobalDataFlow.cs:114:55:114:60 | { ..., ... } |
-| GlobalDataFlow.cs:114:57:114:58 | "" | GlobalDataFlow.cs:114:21:114:60 | (...) ... |
-| GlobalDataFlow.cs:114:57:114:58 | "" | GlobalDataFlow.cs:114:21:114:60 | (...) ... |
-| GlobalDataFlow.cs:114:57:114:58 | "" | GlobalDataFlow.cs:114:42:114:60 | array creation of type String[] |
-| GlobalDataFlow.cs:114:57:114:58 | "" | GlobalDataFlow.cs:114:42:114:60 | array creation of type String[] |
-| GlobalDataFlow.cs:114:57:114:58 | "" | GlobalDataFlow.cs:114:57:114:58 | "" |
-| GlobalDataFlow.cs:114:68:114:119 | (...) ... | GlobalDataFlow.cs:114:68:114:119 | (...) ... |
-| GlobalDataFlow.cs:114:89:114:119 | array creation of type String[] | GlobalDataFlow.cs:114:68:114:119 | (...) ... |
-| GlobalDataFlow.cs:114:89:114:119 | array creation of type String[] | GlobalDataFlow.cs:114:68:114:119 | (...) ... |
-| GlobalDataFlow.cs:114:89:114:119 | array creation of type String[] | GlobalDataFlow.cs:114:89:114:119 | array creation of type String[] |
-| GlobalDataFlow.cs:114:102:114:119 | { ..., ... } | GlobalDataFlow.cs:114:102:114:119 | { ..., ... } |
-| GlobalDataFlow.cs:114:104:114:109 | access to local variable sink15 | GlobalDataFlow.cs:114:68:114:119 | (...) ... |
-| GlobalDataFlow.cs:114:104:114:109 | access to local variable sink15 | GlobalDataFlow.cs:114:68:114:119 | (...) ... |
-| GlobalDataFlow.cs:114:104:114:109 | access to local variable sink15 | GlobalDataFlow.cs:114:89:114:119 | array creation of type String[] |
-| GlobalDataFlow.cs:114:104:114:109 | access to local variable sink15 | GlobalDataFlow.cs:114:89:114:119 | array creation of type String[] |
-| GlobalDataFlow.cs:114:104:114:109 | access to local variable sink15 | GlobalDataFlow.cs:114:104:114:109 | access to local variable sink15 |
-| GlobalDataFlow.cs:114:104:114:109 | access to local variable sink15 | GlobalDataFlow.cs:114:104:114:117 | call to method First |
-| GlobalDataFlow.cs:114:104:114:109 | access to local variable sink15 | GlobalDataFlow.cs:114:104:114:117 | call to method First |
-| GlobalDataFlow.cs:114:104:114:117 | call to method First | GlobalDataFlow.cs:114:68:114:119 | (...) ... |
-| GlobalDataFlow.cs:114:104:114:117 | call to method First | GlobalDataFlow.cs:114:68:114:119 | (...) ... |
-| GlobalDataFlow.cs:114:104:114:117 | call to method First | GlobalDataFlow.cs:114:89:114:119 | array creation of type String[] |
-| GlobalDataFlow.cs:114:104:114:117 | call to method First | GlobalDataFlow.cs:114:89:114:119 | array creation of type String[] |
-| GlobalDataFlow.cs:114:104:114:117 | call to method First | GlobalDataFlow.cs:114:104:114:117 | call to method First |
-| GlobalDataFlow.cs:114:123:114:133 | (...) => ... | GlobalDataFlow.cs:114:123:114:133 | (...) => ... |
-| GlobalDataFlow.cs:114:123:114:133 | [output] (...) => ... | GlobalDataFlow.cs:114:9:114:134 | SSA def(nonSink1) |
-| GlobalDataFlow.cs:114:123:114:133 | [output] (...) => ... | GlobalDataFlow.cs:114:9:114:134 | SSA def(nonSink1) |
-| GlobalDataFlow.cs:114:123:114:133 | [output] (...) => ... | GlobalDataFlow.cs:114:20:114:134 | call to method Zip |
-| GlobalDataFlow.cs:114:123:114:133 | [output] (...) => ... | GlobalDataFlow.cs:114:20:114:134 | call to method Zip |
-| GlobalDataFlow.cs:114:123:114:133 | [output] (...) => ... | GlobalDataFlow.cs:114:123:114:133 | [output] (...) => ... |
-| GlobalDataFlow.cs:114:123:114:133 | [output] (...) => ... | GlobalDataFlow.cs:115:15:115:22 | access to local variable nonSink1 |
-| GlobalDataFlow.cs:114:123:114:133 | [output] (...) => ... | GlobalDataFlow.cs:115:15:115:22 | access to local variable nonSink1 |
-| GlobalDataFlow.cs:114:123:114:133 | [output] (...) => ... | GlobalDataFlow.cs:120:20:120:27 | access to local variable nonSink1 |
-| GlobalDataFlow.cs:114:123:114:133 | [output] (...) => ... | GlobalDataFlow.cs:120:20:120:27 | access to local variable nonSink1 |
-| GlobalDataFlow.cs:114:124:114:124 | x | GlobalDataFlow.cs:114:124:114:124 | x |
-| GlobalDataFlow.cs:114:124:114:124 | x | GlobalDataFlow.cs:114:124:114:124 | x |
-| GlobalDataFlow.cs:114:124:114:124 | x | GlobalDataFlow.cs:114:124:114:124 | x |
-| GlobalDataFlow.cs:114:124:114:124 | x | GlobalDataFlow.cs:114:124:114:124 | x |
-| GlobalDataFlow.cs:114:124:114:124 | x | GlobalDataFlow.cs:114:124:114:124 | x |
-| GlobalDataFlow.cs:114:124:114:124 | x | GlobalDataFlow.cs:114:124:114:124 | x |
-| GlobalDataFlow.cs:114:124:114:124 | x | GlobalDataFlow.cs:114:133:114:133 | access to parameter x |
-| GlobalDataFlow.cs:114:124:114:124 | x | GlobalDataFlow.cs:114:133:114:133 | access to parameter x |
-| GlobalDataFlow.cs:114:124:114:124 | x | GlobalDataFlow.cs:114:133:114:133 | access to parameter x |
-| GlobalDataFlow.cs:114:124:114:124 | x | GlobalDataFlow.cs:114:133:114:133 | access to parameter x |
-| GlobalDataFlow.cs:114:124:114:124 | x | GlobalDataFlow.cs:114:133:114:133 | access to parameter x |
-| GlobalDataFlow.cs:114:124:114:124 | x | GlobalDataFlow.cs:114:133:114:133 | access to parameter x |
-| GlobalDataFlow.cs:114:124:114:124 | x | GlobalDataFlow.cs:114:133:114:133 | access to parameter x |
-| GlobalDataFlow.cs:114:124:114:124 | x | GlobalDataFlow.cs:114:133:114:133 | access to parameter x |
-| GlobalDataFlow.cs:114:133:114:133 | access to parameter x | GlobalDataFlow.cs:114:123:114:133 | [output] (...) => ... |
-| GlobalDataFlow.cs:114:133:114:133 | access to parameter x | GlobalDataFlow.cs:114:123:114:133 | [output] (...) => ... |
-| GlobalDataFlow.cs:114:133:114:133 | access to parameter x | GlobalDataFlow.cs:114:133:114:133 | access to parameter x |
+| GlobalDataFlow.cs:114:9:114:82 | ... = ... | GlobalDataFlow.cs:114:9:114:82 | ... = ... |
+| GlobalDataFlow.cs:114:9:114:82 | SSA def(nonSink1) | GlobalDataFlow.cs:114:9:114:82 | SSA def(nonSink1) |
+| GlobalDataFlow.cs:114:9:114:82 | SSA def(nonSink1) | GlobalDataFlow.cs:115:15:115:22 | access to local variable nonSink1 |
+| GlobalDataFlow.cs:114:9:114:82 | SSA def(nonSink1) | GlobalDataFlow.cs:115:15:115:22 | access to local variable nonSink1 |
+| GlobalDataFlow.cs:114:20:114:82 | call to method Select | GlobalDataFlow.cs:114:9:114:82 | SSA def(nonSink1) |
+| GlobalDataFlow.cs:114:20:114:82 | call to method Select | GlobalDataFlow.cs:114:9:114:82 | SSA def(nonSink1) |
+| GlobalDataFlow.cs:114:20:114:82 | call to method Select | GlobalDataFlow.cs:114:20:114:82 | call to method Select |
+| GlobalDataFlow.cs:114:20:114:82 | call to method Select | GlobalDataFlow.cs:115:15:115:22 | access to local variable nonSink1 |
+| GlobalDataFlow.cs:114:20:114:82 | call to method Select | GlobalDataFlow.cs:115:15:115:22 | access to local variable nonSink1 |
+| GlobalDataFlow.cs:114:21:114:66 | (...) ... | GlobalDataFlow.cs:114:21:114:66 | (...) ... |
+| GlobalDataFlow.cs:114:21:114:66 | (...) ... | GlobalDataFlow.cs:114:76:114:76 | x |
+| GlobalDataFlow.cs:114:21:114:66 | (...) ... | GlobalDataFlow.cs:114:76:114:76 | x |
+| GlobalDataFlow.cs:114:21:114:66 | (...) ... | GlobalDataFlow.cs:114:76:114:81 | [output] (...) => ... |
+| GlobalDataFlow.cs:114:21:114:66 | (...) ... | GlobalDataFlow.cs:114:76:114:81 | [output] (...) => ... |
+| GlobalDataFlow.cs:114:42:114:66 | array creation of type String[] | GlobalDataFlow.cs:114:21:114:66 | (...) ... |
+| GlobalDataFlow.cs:114:42:114:66 | array creation of type String[] | GlobalDataFlow.cs:114:21:114:66 | (...) ... |
+| GlobalDataFlow.cs:114:42:114:66 | array creation of type String[] | GlobalDataFlow.cs:114:42:114:66 | array creation of type String[] |
+| GlobalDataFlow.cs:114:55:114:66 | { ..., ... } | GlobalDataFlow.cs:114:55:114:66 | { ..., ... } |
+| GlobalDataFlow.cs:114:57:114:64 | access to local variable nonSink0 | GlobalDataFlow.cs:114:21:114:66 | (...) ... |
+| GlobalDataFlow.cs:114:57:114:64 | access to local variable nonSink0 | GlobalDataFlow.cs:114:21:114:66 | (...) ... |
+| GlobalDataFlow.cs:114:57:114:64 | access to local variable nonSink0 | GlobalDataFlow.cs:114:42:114:66 | array creation of type String[] |
+| GlobalDataFlow.cs:114:57:114:64 | access to local variable nonSink0 | GlobalDataFlow.cs:114:42:114:66 | array creation of type String[] |
+| GlobalDataFlow.cs:114:57:114:64 | access to local variable nonSink0 | GlobalDataFlow.cs:114:57:114:64 | access to local variable nonSink0 |
+| GlobalDataFlow.cs:114:76:114:76 | x | GlobalDataFlow.cs:114:76:114:76 | x |
+| GlobalDataFlow.cs:114:76:114:76 | x | GlobalDataFlow.cs:114:76:114:76 | x |
+| GlobalDataFlow.cs:114:76:114:76 | x | GlobalDataFlow.cs:114:76:114:76 | x |
+| GlobalDataFlow.cs:114:76:114:76 | x | GlobalDataFlow.cs:114:76:114:76 | x |
+| GlobalDataFlow.cs:114:76:114:76 | x | GlobalDataFlow.cs:114:76:114:76 | x |
+| GlobalDataFlow.cs:114:76:114:76 | x | GlobalDataFlow.cs:114:76:114:76 | x |
+| GlobalDataFlow.cs:114:76:114:76 | x | GlobalDataFlow.cs:114:81:114:81 | access to parameter x |
+| GlobalDataFlow.cs:114:76:114:76 | x | GlobalDataFlow.cs:114:81:114:81 | access to parameter x |
+| GlobalDataFlow.cs:114:76:114:76 | x | GlobalDataFlow.cs:114:81:114:81 | access to parameter x |
+| GlobalDataFlow.cs:114:76:114:76 | x | GlobalDataFlow.cs:114:81:114:81 | access to parameter x |
+| GlobalDataFlow.cs:114:76:114:76 | x | GlobalDataFlow.cs:114:81:114:81 | access to parameter x |
+| GlobalDataFlow.cs:114:76:114:76 | x | GlobalDataFlow.cs:114:81:114:81 | access to parameter x |
+| GlobalDataFlow.cs:114:76:114:76 | x | GlobalDataFlow.cs:114:81:114:81 | access to parameter x |
+| GlobalDataFlow.cs:114:76:114:76 | x | GlobalDataFlow.cs:114:81:114:81 | access to parameter x |
+| GlobalDataFlow.cs:114:76:114:81 | (...) => ... | GlobalDataFlow.cs:114:76:114:81 | (...) => ... |
+| GlobalDataFlow.cs:114:76:114:81 | [output] (...) => ... | GlobalDataFlow.cs:114:9:114:82 | SSA def(nonSink1) |
+| GlobalDataFlow.cs:114:76:114:81 | [output] (...) => ... | GlobalDataFlow.cs:114:9:114:82 | SSA def(nonSink1) |
+| GlobalDataFlow.cs:114:76:114:81 | [output] (...) => ... | GlobalDataFlow.cs:114:20:114:82 | call to method Select |
+| GlobalDataFlow.cs:114:76:114:81 | [output] (...) => ... | GlobalDataFlow.cs:114:20:114:82 | call to method Select |
+| GlobalDataFlow.cs:114:76:114:81 | [output] (...) => ... | GlobalDataFlow.cs:114:76:114:81 | [output] (...) => ... |
+| GlobalDataFlow.cs:114:76:114:81 | [output] (...) => ... | GlobalDataFlow.cs:115:15:115:22 | access to local variable nonSink1 |
+| GlobalDataFlow.cs:114:76:114:81 | [output] (...) => ... | GlobalDataFlow.cs:115:15:115:22 | access to local variable nonSink1 |
+| GlobalDataFlow.cs:114:81:114:81 | access to parameter x | GlobalDataFlow.cs:114:76:114:81 | [output] (...) => ... |
+| GlobalDataFlow.cs:114:81:114:81 | access to parameter x | GlobalDataFlow.cs:114:76:114:81 | [output] (...) => ... |
+| GlobalDataFlow.cs:114:81:114:81 | access to parameter x | GlobalDataFlow.cs:114:81:114:81 | access to parameter x |
 | GlobalDataFlow.cs:115:9:115:23 | call to method Check | GlobalDataFlow.cs:115:9:115:23 | call to method Check |
 | GlobalDataFlow.cs:115:15:115:22 | access to local variable nonSink1 | GlobalDataFlow.cs:115:15:115:22 | access to local variable nonSink1 |
-| GlobalDataFlow.cs:115:15:115:22 | access to local variable nonSink1 | GlobalDataFlow.cs:120:20:120:27 | access to local variable nonSink1 |
-| GlobalDataFlow.cs:115:15:115:22 | access to local variable nonSink1 | GlobalDataFlow.cs:120:20:120:27 | access to local variable nonSink1 |
-| GlobalDataFlow.cs:116:9:116:64 | ... = ... | GlobalDataFlow.cs:116:9:116:64 | ... = ... |
-| GlobalDataFlow.cs:116:9:116:64 | SSA def(nonSink0) | GlobalDataFlow.cs:116:9:116:64 | SSA def(nonSink0) |
-| GlobalDataFlow.cs:116:9:116:64 | SSA def(nonSink0) | GlobalDataFlow.cs:117:15:117:22 | access to local variable nonSink0 |
-| GlobalDataFlow.cs:116:9:116:64 | SSA def(nonSink0) | GlobalDataFlow.cs:117:15:117:22 | access to local variable nonSink0 |
-| GlobalDataFlow.cs:116:20:116:25 | access to local variable sink14 | GlobalDataFlow.cs:116:20:116:25 | access to local variable sink14 |
-| GlobalDataFlow.cs:116:20:116:25 | access to local variable sink14 | GlobalDataFlow.cs:118:20:118:25 | access to local variable sink14 |
-| GlobalDataFlow.cs:116:20:116:25 | access to local variable sink14 | GlobalDataFlow.cs:118:20:118:25 | access to local variable sink14 |
-| GlobalDataFlow.cs:116:20:116:64 | call to method Aggregate | GlobalDataFlow.cs:116:9:116:64 | SSA def(nonSink0) |
-| GlobalDataFlow.cs:116:20:116:64 | call to method Aggregate | GlobalDataFlow.cs:116:9:116:64 | SSA def(nonSink0) |
-| GlobalDataFlow.cs:116:20:116:64 | call to method Aggregate | GlobalDataFlow.cs:116:20:116:64 | call to method Aggregate |
-| GlobalDataFlow.cs:116:20:116:64 | call to method Aggregate | GlobalDataFlow.cs:117:15:117:22 | access to local variable nonSink0 |
-| GlobalDataFlow.cs:116:20:116:64 | call to method Aggregate | GlobalDataFlow.cs:117:15:117:22 | access to local variable nonSink0 |
-| GlobalDataFlow.cs:116:37:116:38 | "" | GlobalDataFlow.cs:116:37:116:38 | "" |
-| GlobalDataFlow.cs:116:37:116:38 | "" | GlobalDataFlow.cs:116:41:116:55 | [output] (...) => ... |
-| GlobalDataFlow.cs:116:37:116:38 | "" | GlobalDataFlow.cs:116:41:116:55 | [output] (...) => ... |
-| GlobalDataFlow.cs:116:37:116:38 | "" | GlobalDataFlow.cs:116:42:116:44 | acc |
-| GlobalDataFlow.cs:116:37:116:38 | "" | GlobalDataFlow.cs:116:42:116:44 | acc |
-| GlobalDataFlow.cs:116:41:116:55 | (...) => ... | GlobalDataFlow.cs:116:41:116:55 | (...) => ... |
-| GlobalDataFlow.cs:116:41:116:55 | [output] (...) => ... | GlobalDataFlow.cs:116:41:116:55 | [output] (...) => ... |
-| GlobalDataFlow.cs:116:41:116:55 | [output] (...) => ... | GlobalDataFlow.cs:116:58:116:58 | x |
-| GlobalDataFlow.cs:116:41:116:55 | [output] (...) => ... | GlobalDataFlow.cs:116:58:116:58 | x |
-| GlobalDataFlow.cs:116:41:116:55 | [output] (...) => ... | GlobalDataFlow.cs:116:58:116:63 | [output] (...) => ... |
-| GlobalDataFlow.cs:116:41:116:55 | [output] (...) => ... | GlobalDataFlow.cs:116:58:116:63 | [output] (...) => ... |
-| GlobalDataFlow.cs:116:42:116:44 | acc | GlobalDataFlow.cs:116:42:116:44 | acc |
-| GlobalDataFlow.cs:116:42:116:44 | acc | GlobalDataFlow.cs:116:42:116:44 | acc |
-| GlobalDataFlow.cs:116:42:116:44 | acc | GlobalDataFlow.cs:116:42:116:44 | acc |
-| GlobalDataFlow.cs:116:42:116:44 | acc | GlobalDataFlow.cs:116:42:116:44 | acc |
-| GlobalDataFlow.cs:116:42:116:44 | acc | GlobalDataFlow.cs:116:42:116:44 | acc |
-| GlobalDataFlow.cs:116:42:116:44 | acc | GlobalDataFlow.cs:116:42:116:44 | acc |
-| GlobalDataFlow.cs:116:42:116:44 | acc | GlobalDataFlow.cs:116:53:116:55 | access to parameter acc |
-| GlobalDataFlow.cs:116:42:116:44 | acc | GlobalDataFlow.cs:116:53:116:55 | access to parameter acc |
-| GlobalDataFlow.cs:116:42:116:44 | acc | GlobalDataFlow.cs:116:53:116:55 | access to parameter acc |
-| GlobalDataFlow.cs:116:42:116:44 | acc | GlobalDataFlow.cs:116:53:116:55 | access to parameter acc |
-| GlobalDataFlow.cs:116:42:116:44 | acc | GlobalDataFlow.cs:116:53:116:55 | access to parameter acc |
-| GlobalDataFlow.cs:116:42:116:44 | acc | GlobalDataFlow.cs:116:53:116:55 | access to parameter acc |
-| GlobalDataFlow.cs:116:42:116:44 | acc | GlobalDataFlow.cs:116:53:116:55 | access to parameter acc |
-| GlobalDataFlow.cs:116:42:116:44 | acc | GlobalDataFlow.cs:116:53:116:55 | access to parameter acc |
-| GlobalDataFlow.cs:116:53:116:55 | access to parameter acc | GlobalDataFlow.cs:116:41:116:55 | [output] (...) => ... |
-| GlobalDataFlow.cs:116:53:116:55 | access to parameter acc | GlobalDataFlow.cs:116:41:116:55 | [output] (...) => ... |
-| GlobalDataFlow.cs:116:53:116:55 | access to parameter acc | GlobalDataFlow.cs:116:53:116:55 | access to parameter acc |
-| GlobalDataFlow.cs:116:58:116:58 | x | GlobalDataFlow.cs:116:58:116:58 | x |
-| GlobalDataFlow.cs:116:58:116:58 | x | GlobalDataFlow.cs:116:58:116:58 | x |
-| GlobalDataFlow.cs:116:58:116:58 | x | GlobalDataFlow.cs:116:58:116:58 | x |
-| GlobalDataFlow.cs:116:58:116:58 | x | GlobalDataFlow.cs:116:58:116:58 | x |
-| GlobalDataFlow.cs:116:58:116:58 | x | GlobalDataFlow.cs:116:58:116:58 | x |
-| GlobalDataFlow.cs:116:58:116:58 | x | GlobalDataFlow.cs:116:58:116:58 | x |
-| GlobalDataFlow.cs:116:58:116:58 | x | GlobalDataFlow.cs:116:63:116:63 | access to parameter x |
-| GlobalDataFlow.cs:116:58:116:58 | x | GlobalDataFlow.cs:116:63:116:63 | access to parameter x |
-| GlobalDataFlow.cs:116:58:116:58 | x | GlobalDataFlow.cs:116:63:116:63 | access to parameter x |
-| GlobalDataFlow.cs:116:58:116:58 | x | GlobalDataFlow.cs:116:63:116:63 | access to parameter x |
-| GlobalDataFlow.cs:116:58:116:58 | x | GlobalDataFlow.cs:116:63:116:63 | access to parameter x |
-| GlobalDataFlow.cs:116:58:116:58 | x | GlobalDataFlow.cs:116:63:116:63 | access to parameter x |
-| GlobalDataFlow.cs:116:58:116:58 | x | GlobalDataFlow.cs:116:63:116:63 | access to parameter x |
-| GlobalDataFlow.cs:116:58:116:58 | x | GlobalDataFlow.cs:116:63:116:63 | access to parameter x |
-| GlobalDataFlow.cs:116:58:116:63 | (...) => ... | GlobalDataFlow.cs:116:58:116:63 | (...) => ... |
-| GlobalDataFlow.cs:116:58:116:63 | [output] (...) => ... | GlobalDataFlow.cs:116:9:116:64 | SSA def(nonSink0) |
-| GlobalDataFlow.cs:116:58:116:63 | [output] (...) => ... | GlobalDataFlow.cs:116:9:116:64 | SSA def(nonSink0) |
-| GlobalDataFlow.cs:116:58:116:63 | [output] (...) => ... | GlobalDataFlow.cs:116:20:116:64 | call to method Aggregate |
-| GlobalDataFlow.cs:116:58:116:63 | [output] (...) => ... | GlobalDataFlow.cs:116:20:116:64 | call to method Aggregate |
-| GlobalDataFlow.cs:116:58:116:63 | [output] (...) => ... | GlobalDataFlow.cs:116:58:116:63 | [output] (...) => ... |
-| GlobalDataFlow.cs:116:58:116:63 | [output] (...) => ... | GlobalDataFlow.cs:117:15:117:22 | access to local variable nonSink0 |
-| GlobalDataFlow.cs:116:58:116:63 | [output] (...) => ... | GlobalDataFlow.cs:117:15:117:22 | access to local variable nonSink0 |
-| GlobalDataFlow.cs:116:63:116:63 | access to parameter x | GlobalDataFlow.cs:116:58:116:63 | [output] (...) => ... |
-| GlobalDataFlow.cs:116:63:116:63 | access to parameter x | GlobalDataFlow.cs:116:58:116:63 | [output] (...) => ... |
-| GlobalDataFlow.cs:116:63:116:63 | access to parameter x | GlobalDataFlow.cs:116:63:116:63 | access to parameter x |
+| GlobalDataFlow.cs:116:9:116:134 | ... = ... | GlobalDataFlow.cs:116:9:116:134 | ... = ... |
+| GlobalDataFlow.cs:116:9:116:134 | SSA def(nonSink1) | GlobalDataFlow.cs:116:9:116:134 | SSA def(nonSink1) |
+| GlobalDataFlow.cs:116:9:116:134 | SSA def(nonSink1) | GlobalDataFlow.cs:117:15:117:22 | access to local variable nonSink1 |
+| GlobalDataFlow.cs:116:9:116:134 | SSA def(nonSink1) | GlobalDataFlow.cs:117:15:117:22 | access to local variable nonSink1 |
+| GlobalDataFlow.cs:116:20:116:134 | call to method Zip | GlobalDataFlow.cs:116:9:116:134 | SSA def(nonSink1) |
+| GlobalDataFlow.cs:116:20:116:134 | call to method Zip | GlobalDataFlow.cs:116:9:116:134 | SSA def(nonSink1) |
+| GlobalDataFlow.cs:116:20:116:134 | call to method Zip | GlobalDataFlow.cs:116:20:116:134 | call to method Zip |
+| GlobalDataFlow.cs:116:20:116:134 | call to method Zip | GlobalDataFlow.cs:117:15:117:22 | access to local variable nonSink1 |
+| GlobalDataFlow.cs:116:20:116:134 | call to method Zip | GlobalDataFlow.cs:117:15:117:22 | access to local variable nonSink1 |
+| GlobalDataFlow.cs:116:21:116:72 | (...) ... | GlobalDataFlow.cs:116:21:116:72 | (...) ... |
+| GlobalDataFlow.cs:116:42:116:72 | array creation of type String[] | GlobalDataFlow.cs:116:21:116:72 | (...) ... |
+| GlobalDataFlow.cs:116:42:116:72 | array creation of type String[] | GlobalDataFlow.cs:116:21:116:72 | (...) ... |
+| GlobalDataFlow.cs:116:42:116:72 | array creation of type String[] | GlobalDataFlow.cs:116:42:116:72 | array creation of type String[] |
+| GlobalDataFlow.cs:116:55:116:72 | { ..., ... } | GlobalDataFlow.cs:116:55:116:72 | { ..., ... } |
+| GlobalDataFlow.cs:116:57:116:62 | access to local variable sink14 | GlobalDataFlow.cs:116:21:116:72 | (...) ... |
+| GlobalDataFlow.cs:116:57:116:62 | access to local variable sink14 | GlobalDataFlow.cs:116:21:116:72 | (...) ... |
+| GlobalDataFlow.cs:116:57:116:62 | access to local variable sink14 | GlobalDataFlow.cs:116:42:116:72 | array creation of type String[] |
+| GlobalDataFlow.cs:116:57:116:62 | access to local variable sink14 | GlobalDataFlow.cs:116:42:116:72 | array creation of type String[] |
+| GlobalDataFlow.cs:116:57:116:62 | access to local variable sink14 | GlobalDataFlow.cs:116:57:116:62 | access to local variable sink14 |
+| GlobalDataFlow.cs:116:57:116:62 | access to local variable sink14 | GlobalDataFlow.cs:116:57:116:70 | call to method First |
+| GlobalDataFlow.cs:116:57:116:62 | access to local variable sink14 | GlobalDataFlow.cs:116:57:116:70 | call to method First |
+| GlobalDataFlow.cs:116:57:116:62 | access to local variable sink14 | GlobalDataFlow.cs:120:20:120:25 | access to local variable sink14 |
+| GlobalDataFlow.cs:116:57:116:62 | access to local variable sink14 | GlobalDataFlow.cs:120:20:120:25 | access to local variable sink14 |
+| GlobalDataFlow.cs:116:57:116:62 | access to local variable sink14 | GlobalDataFlow.cs:122:20:122:25 | access to local variable sink14 |
+| GlobalDataFlow.cs:116:57:116:62 | access to local variable sink14 | GlobalDataFlow.cs:122:20:122:25 | access to local variable sink14 |
+| GlobalDataFlow.cs:116:57:116:70 | call to method First | GlobalDataFlow.cs:116:21:116:72 | (...) ... |
+| GlobalDataFlow.cs:116:57:116:70 | call to method First | GlobalDataFlow.cs:116:21:116:72 | (...) ... |
+| GlobalDataFlow.cs:116:57:116:70 | call to method First | GlobalDataFlow.cs:116:42:116:72 | array creation of type String[] |
+| GlobalDataFlow.cs:116:57:116:70 | call to method First | GlobalDataFlow.cs:116:42:116:72 | array creation of type String[] |
+| GlobalDataFlow.cs:116:57:116:70 | call to method First | GlobalDataFlow.cs:116:57:116:70 | call to method First |
+| GlobalDataFlow.cs:116:80:116:119 | (...) ... | GlobalDataFlow.cs:116:80:116:119 | (...) ... |
+| GlobalDataFlow.cs:116:80:116:119 | (...) ... | GlobalDataFlow.cs:116:123:116:133 | [output] (...) => ... |
+| GlobalDataFlow.cs:116:80:116:119 | (...) ... | GlobalDataFlow.cs:116:123:116:133 | [output] (...) => ... |
+| GlobalDataFlow.cs:116:80:116:119 | (...) ... | GlobalDataFlow.cs:116:127:116:127 | y |
+| GlobalDataFlow.cs:116:80:116:119 | (...) ... | GlobalDataFlow.cs:116:127:116:127 | y |
+| GlobalDataFlow.cs:116:101:116:119 | array creation of type String[] | GlobalDataFlow.cs:116:80:116:119 | (...) ... |
+| GlobalDataFlow.cs:116:101:116:119 | array creation of type String[] | GlobalDataFlow.cs:116:80:116:119 | (...) ... |
+| GlobalDataFlow.cs:116:101:116:119 | array creation of type String[] | GlobalDataFlow.cs:116:101:116:119 | array creation of type String[] |
+| GlobalDataFlow.cs:116:114:116:119 | { ..., ... } | GlobalDataFlow.cs:116:114:116:119 | { ..., ... } |
+| GlobalDataFlow.cs:116:116:116:117 | "" | GlobalDataFlow.cs:116:80:116:119 | (...) ... |
+| GlobalDataFlow.cs:116:116:116:117 | "" | GlobalDataFlow.cs:116:80:116:119 | (...) ... |
+| GlobalDataFlow.cs:116:116:116:117 | "" | GlobalDataFlow.cs:116:101:116:119 | array creation of type String[] |
+| GlobalDataFlow.cs:116:116:116:117 | "" | GlobalDataFlow.cs:116:101:116:119 | array creation of type String[] |
+| GlobalDataFlow.cs:116:116:116:117 | "" | GlobalDataFlow.cs:116:116:116:117 | "" |
+| GlobalDataFlow.cs:116:123:116:133 | (...) => ... | GlobalDataFlow.cs:116:123:116:133 | (...) => ... |
+| GlobalDataFlow.cs:116:123:116:133 | [output] (...) => ... | GlobalDataFlow.cs:116:9:116:134 | SSA def(nonSink1) |
+| GlobalDataFlow.cs:116:123:116:133 | [output] (...) => ... | GlobalDataFlow.cs:116:9:116:134 | SSA def(nonSink1) |
+| GlobalDataFlow.cs:116:123:116:133 | [output] (...) => ... | GlobalDataFlow.cs:116:20:116:134 | call to method Zip |
+| GlobalDataFlow.cs:116:123:116:133 | [output] (...) => ... | GlobalDataFlow.cs:116:20:116:134 | call to method Zip |
+| GlobalDataFlow.cs:116:123:116:133 | [output] (...) => ... | GlobalDataFlow.cs:116:123:116:133 | [output] (...) => ... |
+| GlobalDataFlow.cs:116:123:116:133 | [output] (...) => ... | GlobalDataFlow.cs:117:15:117:22 | access to local variable nonSink1 |
+| GlobalDataFlow.cs:116:123:116:133 | [output] (...) => ... | GlobalDataFlow.cs:117:15:117:22 | access to local variable nonSink1 |
+| GlobalDataFlow.cs:116:127:116:127 | y | GlobalDataFlow.cs:116:127:116:127 | y |
+| GlobalDataFlow.cs:116:127:116:127 | y | GlobalDataFlow.cs:116:127:116:127 | y |
+| GlobalDataFlow.cs:116:127:116:127 | y | GlobalDataFlow.cs:116:127:116:127 | y |
+| GlobalDataFlow.cs:116:127:116:127 | y | GlobalDataFlow.cs:116:127:116:127 | y |
+| GlobalDataFlow.cs:116:127:116:127 | y | GlobalDataFlow.cs:116:127:116:127 | y |
+| GlobalDataFlow.cs:116:127:116:127 | y | GlobalDataFlow.cs:116:127:116:127 | y |
+| GlobalDataFlow.cs:116:127:116:127 | y | GlobalDataFlow.cs:116:133:116:133 | access to parameter y |
+| GlobalDataFlow.cs:116:127:116:127 | y | GlobalDataFlow.cs:116:133:116:133 | access to parameter y |
+| GlobalDataFlow.cs:116:127:116:127 | y | GlobalDataFlow.cs:116:133:116:133 | access to parameter y |
+| GlobalDataFlow.cs:116:127:116:127 | y | GlobalDataFlow.cs:116:133:116:133 | access to parameter y |
+| GlobalDataFlow.cs:116:127:116:127 | y | GlobalDataFlow.cs:116:133:116:133 | access to parameter y |
+| GlobalDataFlow.cs:116:127:116:127 | y | GlobalDataFlow.cs:116:133:116:133 | access to parameter y |
+| GlobalDataFlow.cs:116:127:116:127 | y | GlobalDataFlow.cs:116:133:116:133 | access to parameter y |
+| GlobalDataFlow.cs:116:127:116:127 | y | GlobalDataFlow.cs:116:133:116:133 | access to parameter y |
+| GlobalDataFlow.cs:116:133:116:133 | access to parameter y | GlobalDataFlow.cs:116:123:116:133 | [output] (...) => ... |
+| GlobalDataFlow.cs:116:133:116:133 | access to parameter y | GlobalDataFlow.cs:116:123:116:133 | [output] (...) => ... |
+| GlobalDataFlow.cs:116:133:116:133 | access to parameter y | GlobalDataFlow.cs:116:133:116:133 | access to parameter y |
 | GlobalDataFlow.cs:117:9:117:23 | call to method Check | GlobalDataFlow.cs:117:9:117:23 | call to method Check |
-| GlobalDataFlow.cs:117:15:117:22 | access to local variable nonSink0 | GlobalDataFlow.cs:117:15:117:22 | access to local variable nonSink0 |
-| GlobalDataFlow.cs:118:9:118:69 | ... = ... | GlobalDataFlow.cs:118:9:118:69 | ... = ... |
-| GlobalDataFlow.cs:118:9:118:69 | SSA def(nonSink0) | GlobalDataFlow.cs:118:9:118:69 | SSA def(nonSink0) |
-| GlobalDataFlow.cs:118:9:118:69 | SSA def(nonSink0) | GlobalDataFlow.cs:119:15:119:22 | access to local variable nonSink0 |
-| GlobalDataFlow.cs:118:9:118:69 | SSA def(nonSink0) | GlobalDataFlow.cs:119:15:119:22 | access to local variable nonSink0 |
-| GlobalDataFlow.cs:118:20:118:25 | access to local variable sink14 | GlobalDataFlow.cs:118:20:118:25 | access to local variable sink14 |
-| GlobalDataFlow.cs:118:20:118:25 | access to local variable sink14 | GlobalDataFlow.cs:118:41:118:59 | [output] (...) => ... |
-| GlobalDataFlow.cs:118:20:118:25 | access to local variable sink14 | GlobalDataFlow.cs:118:41:118:59 | [output] (...) => ... |
-| GlobalDataFlow.cs:118:20:118:25 | access to local variable sink14 | GlobalDataFlow.cs:118:47:118:47 | s |
-| GlobalDataFlow.cs:118:20:118:25 | access to local variable sink14 | GlobalDataFlow.cs:118:47:118:47 | s |
-| GlobalDataFlow.cs:118:20:118:69 | call to method Aggregate | GlobalDataFlow.cs:118:9:118:69 | SSA def(nonSink0) |
-| GlobalDataFlow.cs:118:20:118:69 | call to method Aggregate | GlobalDataFlow.cs:118:9:118:69 | SSA def(nonSink0) |
-| GlobalDataFlow.cs:118:20:118:69 | call to method Aggregate | GlobalDataFlow.cs:118:20:118:69 | call to method Aggregate |
-| GlobalDataFlow.cs:118:20:118:69 | call to method Aggregate | GlobalDataFlow.cs:119:15:119:22 | access to local variable nonSink0 |
-| GlobalDataFlow.cs:118:20:118:69 | call to method Aggregate | GlobalDataFlow.cs:119:15:119:22 | access to local variable nonSink0 |
-| GlobalDataFlow.cs:118:37:118:38 | "" | GlobalDataFlow.cs:118:37:118:38 | "" |
-| GlobalDataFlow.cs:118:37:118:38 | "" | GlobalDataFlow.cs:118:41:118:59 | [output] (...) => ... |
-| GlobalDataFlow.cs:118:37:118:38 | "" | GlobalDataFlow.cs:118:41:118:59 | [output] (...) => ... |
-| GlobalDataFlow.cs:118:37:118:38 | "" | GlobalDataFlow.cs:118:42:118:44 | acc |
-| GlobalDataFlow.cs:118:37:118:38 | "" | GlobalDataFlow.cs:118:42:118:44 | acc |
-| GlobalDataFlow.cs:118:41:118:59 | (...) => ... | GlobalDataFlow.cs:118:41:118:59 | (...) => ... |
-| GlobalDataFlow.cs:118:41:118:59 | [output] (...) => ... | GlobalDataFlow.cs:118:41:118:59 | [output] (...) => ... |
-| GlobalDataFlow.cs:118:42:118:44 | acc | GlobalDataFlow.cs:118:42:118:44 | acc |
-| GlobalDataFlow.cs:118:42:118:44 | acc | GlobalDataFlow.cs:118:42:118:44 | acc |
-| GlobalDataFlow.cs:118:42:118:44 | acc | GlobalDataFlow.cs:118:42:118:44 | acc |
-| GlobalDataFlow.cs:118:42:118:44 | acc | GlobalDataFlow.cs:118:42:118:44 | acc |
-| GlobalDataFlow.cs:118:42:118:44 | acc | GlobalDataFlow.cs:118:42:118:44 | acc |
-| GlobalDataFlow.cs:118:42:118:44 | acc | GlobalDataFlow.cs:118:42:118:44 | acc |
-| GlobalDataFlow.cs:118:42:118:44 | acc | GlobalDataFlow.cs:118:53:118:55 | access to parameter acc |
-| GlobalDataFlow.cs:118:42:118:44 | acc | GlobalDataFlow.cs:118:53:118:55 | access to parameter acc |
-| GlobalDataFlow.cs:118:42:118:44 | acc | GlobalDataFlow.cs:118:53:118:55 | access to parameter acc |
-| GlobalDataFlow.cs:118:42:118:44 | acc | GlobalDataFlow.cs:118:53:118:55 | access to parameter acc |
-| GlobalDataFlow.cs:118:42:118:44 | acc | GlobalDataFlow.cs:118:53:118:55 | access to parameter acc |
-| GlobalDataFlow.cs:118:42:118:44 | acc | GlobalDataFlow.cs:118:53:118:55 | access to parameter acc |
-| GlobalDataFlow.cs:118:42:118:44 | acc | GlobalDataFlow.cs:118:53:118:55 | access to parameter acc |
-| GlobalDataFlow.cs:118:42:118:44 | acc | GlobalDataFlow.cs:118:53:118:55 | access to parameter acc |
-| GlobalDataFlow.cs:118:42:118:44 | acc | GlobalDataFlow.cs:118:53:118:59 | ... + ... |
-| GlobalDataFlow.cs:118:42:118:44 | acc | GlobalDataFlow.cs:118:53:118:59 | ... + ... |
-| GlobalDataFlow.cs:118:42:118:44 | acc | GlobalDataFlow.cs:118:53:118:59 | ... + ... |
-| GlobalDataFlow.cs:118:42:118:44 | acc | GlobalDataFlow.cs:118:53:118:59 | ... + ... |
-| GlobalDataFlow.cs:118:42:118:44 | acc | GlobalDataFlow.cs:118:53:118:59 | ... + ... |
-| GlobalDataFlow.cs:118:42:118:44 | acc | GlobalDataFlow.cs:118:53:118:59 | ... + ... |
-| GlobalDataFlow.cs:118:42:118:44 | acc | GlobalDataFlow.cs:118:53:118:59 | ... + ... |
-| GlobalDataFlow.cs:118:42:118:44 | acc | GlobalDataFlow.cs:118:53:118:59 | ... + ... |
-| GlobalDataFlow.cs:118:47:118:47 | s | GlobalDataFlow.cs:118:47:118:47 | s |
-| GlobalDataFlow.cs:118:47:118:47 | s | GlobalDataFlow.cs:118:47:118:47 | s |
-| GlobalDataFlow.cs:118:47:118:47 | s | GlobalDataFlow.cs:118:47:118:47 | s |
-| GlobalDataFlow.cs:118:47:118:47 | s | GlobalDataFlow.cs:118:47:118:47 | s |
-| GlobalDataFlow.cs:118:47:118:47 | s | GlobalDataFlow.cs:118:47:118:47 | s |
-| GlobalDataFlow.cs:118:47:118:47 | s | GlobalDataFlow.cs:118:47:118:47 | s |
-| GlobalDataFlow.cs:118:47:118:47 | s | GlobalDataFlow.cs:118:53:118:59 | ... + ... |
-| GlobalDataFlow.cs:118:47:118:47 | s | GlobalDataFlow.cs:118:53:118:59 | ... + ... |
-| GlobalDataFlow.cs:118:47:118:47 | s | GlobalDataFlow.cs:118:53:118:59 | ... + ... |
-| GlobalDataFlow.cs:118:47:118:47 | s | GlobalDataFlow.cs:118:53:118:59 | ... + ... |
-| GlobalDataFlow.cs:118:47:118:47 | s | GlobalDataFlow.cs:118:53:118:59 | ... + ... |
-| GlobalDataFlow.cs:118:47:118:47 | s | GlobalDataFlow.cs:118:53:118:59 | ... + ... |
-| GlobalDataFlow.cs:118:47:118:47 | s | GlobalDataFlow.cs:118:53:118:59 | ... + ... |
-| GlobalDataFlow.cs:118:47:118:47 | s | GlobalDataFlow.cs:118:53:118:59 | ... + ... |
-| GlobalDataFlow.cs:118:47:118:47 | s | GlobalDataFlow.cs:118:59:118:59 | access to parameter s |
-| GlobalDataFlow.cs:118:47:118:47 | s | GlobalDataFlow.cs:118:59:118:59 | access to parameter s |
-| GlobalDataFlow.cs:118:47:118:47 | s | GlobalDataFlow.cs:118:59:118:59 | access to parameter s |
-| GlobalDataFlow.cs:118:47:118:47 | s | GlobalDataFlow.cs:118:59:118:59 | access to parameter s |
-| GlobalDataFlow.cs:118:47:118:47 | s | GlobalDataFlow.cs:118:59:118:59 | access to parameter s |
-| GlobalDataFlow.cs:118:47:118:47 | s | GlobalDataFlow.cs:118:59:118:59 | access to parameter s |
-| GlobalDataFlow.cs:118:47:118:47 | s | GlobalDataFlow.cs:118:59:118:59 | access to parameter s |
-| GlobalDataFlow.cs:118:47:118:47 | s | GlobalDataFlow.cs:118:59:118:59 | access to parameter s |
-| GlobalDataFlow.cs:118:53:118:55 | access to parameter acc | GlobalDataFlow.cs:118:53:118:55 | access to parameter acc |
-| GlobalDataFlow.cs:118:53:118:55 | access to parameter acc | GlobalDataFlow.cs:118:53:118:59 | ... + ... |
-| GlobalDataFlow.cs:118:53:118:55 | access to parameter acc | GlobalDataFlow.cs:118:53:118:59 | ... + ... |
-| GlobalDataFlow.cs:118:53:118:55 | access to parameter acc | GlobalDataFlow.cs:118:53:118:59 | ... + ... |
-| GlobalDataFlow.cs:118:53:118:55 | access to parameter acc | GlobalDataFlow.cs:118:53:118:59 | ... + ... |
-| GlobalDataFlow.cs:118:53:118:59 | ... + ... | GlobalDataFlow.cs:118:41:118:59 | [output] (...) => ... |
-| GlobalDataFlow.cs:118:53:118:59 | ... + ... | GlobalDataFlow.cs:118:41:118:59 | [output] (...) => ... |
-| GlobalDataFlow.cs:118:53:118:59 | ... + ... | GlobalDataFlow.cs:118:53:118:59 | ... + ... |
-| GlobalDataFlow.cs:118:59:118:59 | access to parameter s | GlobalDataFlow.cs:118:53:118:59 | ... + ... |
-| GlobalDataFlow.cs:118:59:118:59 | access to parameter s | GlobalDataFlow.cs:118:53:118:59 | ... + ... |
-| GlobalDataFlow.cs:118:59:118:59 | access to parameter s | GlobalDataFlow.cs:118:53:118:59 | ... + ... |
-| GlobalDataFlow.cs:118:59:118:59 | access to parameter s | GlobalDataFlow.cs:118:53:118:59 | ... + ... |
-| GlobalDataFlow.cs:118:59:118:59 | access to parameter s | GlobalDataFlow.cs:118:59:118:59 | access to parameter s |
-| GlobalDataFlow.cs:118:62:118:68 | (...) => ... | GlobalDataFlow.cs:118:62:118:68 | (...) => ... |
-| GlobalDataFlow.cs:118:62:118:68 | [output] (...) => ... | GlobalDataFlow.cs:118:9:118:69 | SSA def(nonSink0) |
-| GlobalDataFlow.cs:118:62:118:68 | [output] (...) => ... | GlobalDataFlow.cs:118:9:118:69 | SSA def(nonSink0) |
-| GlobalDataFlow.cs:118:62:118:68 | [output] (...) => ... | GlobalDataFlow.cs:118:20:118:69 | call to method Aggregate |
-| GlobalDataFlow.cs:118:62:118:68 | [output] (...) => ... | GlobalDataFlow.cs:118:20:118:69 | call to method Aggregate |
-| GlobalDataFlow.cs:118:62:118:68 | [output] (...) => ... | GlobalDataFlow.cs:118:62:118:68 | [output] (...) => ... |
-| GlobalDataFlow.cs:118:62:118:68 | [output] (...) => ... | GlobalDataFlow.cs:119:15:119:22 | access to local variable nonSink0 |
-| GlobalDataFlow.cs:118:62:118:68 | [output] (...) => ... | GlobalDataFlow.cs:119:15:119:22 | access to local variable nonSink0 |
-| GlobalDataFlow.cs:118:67:118:68 | "" | GlobalDataFlow.cs:118:62:118:68 | [output] (...) => ... |
-| GlobalDataFlow.cs:118:67:118:68 | "" | GlobalDataFlow.cs:118:62:118:68 | [output] (...) => ... |
-| GlobalDataFlow.cs:118:67:118:68 | "" | GlobalDataFlow.cs:118:67:118:68 | "" |
+| GlobalDataFlow.cs:117:15:117:22 | access to local variable nonSink1 | GlobalDataFlow.cs:117:15:117:22 | access to local variable nonSink1 |
+| GlobalDataFlow.cs:118:9:118:134 | ... = ... | GlobalDataFlow.cs:118:9:118:134 | ... = ... |
+| GlobalDataFlow.cs:118:9:118:134 | SSA def(nonSink1) | GlobalDataFlow.cs:118:9:118:134 | SSA def(nonSink1) |
+| GlobalDataFlow.cs:118:9:118:134 | SSA def(nonSink1) | GlobalDataFlow.cs:119:15:119:22 | access to local variable nonSink1 |
+| GlobalDataFlow.cs:118:9:118:134 | SSA def(nonSink1) | GlobalDataFlow.cs:119:15:119:22 | access to local variable nonSink1 |
+| GlobalDataFlow.cs:118:9:118:134 | SSA def(nonSink1) | GlobalDataFlow.cs:124:20:124:27 | access to local variable nonSink1 |
+| GlobalDataFlow.cs:118:9:118:134 | SSA def(nonSink1) | GlobalDataFlow.cs:124:20:124:27 | access to local variable nonSink1 |
+| GlobalDataFlow.cs:118:20:118:134 | call to method Zip | GlobalDataFlow.cs:118:9:118:134 | SSA def(nonSink1) |
+| GlobalDataFlow.cs:118:20:118:134 | call to method Zip | GlobalDataFlow.cs:118:9:118:134 | SSA def(nonSink1) |
+| GlobalDataFlow.cs:118:20:118:134 | call to method Zip | GlobalDataFlow.cs:118:20:118:134 | call to method Zip |
+| GlobalDataFlow.cs:118:20:118:134 | call to method Zip | GlobalDataFlow.cs:119:15:119:22 | access to local variable nonSink1 |
+| GlobalDataFlow.cs:118:20:118:134 | call to method Zip | GlobalDataFlow.cs:119:15:119:22 | access to local variable nonSink1 |
+| GlobalDataFlow.cs:118:20:118:134 | call to method Zip | GlobalDataFlow.cs:124:20:124:27 | access to local variable nonSink1 |
+| GlobalDataFlow.cs:118:20:118:134 | call to method Zip | GlobalDataFlow.cs:124:20:124:27 | access to local variable nonSink1 |
+| GlobalDataFlow.cs:118:21:118:60 | (...) ... | GlobalDataFlow.cs:118:21:118:60 | (...) ... |
+| GlobalDataFlow.cs:118:21:118:60 | (...) ... | GlobalDataFlow.cs:118:123:118:133 | [output] (...) => ... |
+| GlobalDataFlow.cs:118:21:118:60 | (...) ... | GlobalDataFlow.cs:118:123:118:133 | [output] (...) => ... |
+| GlobalDataFlow.cs:118:21:118:60 | (...) ... | GlobalDataFlow.cs:118:124:118:124 | x |
+| GlobalDataFlow.cs:118:21:118:60 | (...) ... | GlobalDataFlow.cs:118:124:118:124 | x |
+| GlobalDataFlow.cs:118:42:118:60 | array creation of type String[] | GlobalDataFlow.cs:118:21:118:60 | (...) ... |
+| GlobalDataFlow.cs:118:42:118:60 | array creation of type String[] | GlobalDataFlow.cs:118:21:118:60 | (...) ... |
+| GlobalDataFlow.cs:118:42:118:60 | array creation of type String[] | GlobalDataFlow.cs:118:42:118:60 | array creation of type String[] |
+| GlobalDataFlow.cs:118:55:118:60 | { ..., ... } | GlobalDataFlow.cs:118:55:118:60 | { ..., ... } |
+| GlobalDataFlow.cs:118:57:118:58 | "" | GlobalDataFlow.cs:118:21:118:60 | (...) ... |
+| GlobalDataFlow.cs:118:57:118:58 | "" | GlobalDataFlow.cs:118:21:118:60 | (...) ... |
+| GlobalDataFlow.cs:118:57:118:58 | "" | GlobalDataFlow.cs:118:42:118:60 | array creation of type String[] |
+| GlobalDataFlow.cs:118:57:118:58 | "" | GlobalDataFlow.cs:118:42:118:60 | array creation of type String[] |
+| GlobalDataFlow.cs:118:57:118:58 | "" | GlobalDataFlow.cs:118:57:118:58 | "" |
+| GlobalDataFlow.cs:118:68:118:119 | (...) ... | GlobalDataFlow.cs:118:68:118:119 | (...) ... |
+| GlobalDataFlow.cs:118:89:118:119 | array creation of type String[] | GlobalDataFlow.cs:118:68:118:119 | (...) ... |
+| GlobalDataFlow.cs:118:89:118:119 | array creation of type String[] | GlobalDataFlow.cs:118:68:118:119 | (...) ... |
+| GlobalDataFlow.cs:118:89:118:119 | array creation of type String[] | GlobalDataFlow.cs:118:89:118:119 | array creation of type String[] |
+| GlobalDataFlow.cs:118:102:118:119 | { ..., ... } | GlobalDataFlow.cs:118:102:118:119 | { ..., ... } |
+| GlobalDataFlow.cs:118:104:118:109 | access to local variable sink15 | GlobalDataFlow.cs:118:68:118:119 | (...) ... |
+| GlobalDataFlow.cs:118:104:118:109 | access to local variable sink15 | GlobalDataFlow.cs:118:68:118:119 | (...) ... |
+| GlobalDataFlow.cs:118:104:118:109 | access to local variable sink15 | GlobalDataFlow.cs:118:89:118:119 | array creation of type String[] |
+| GlobalDataFlow.cs:118:104:118:109 | access to local variable sink15 | GlobalDataFlow.cs:118:89:118:119 | array creation of type String[] |
+| GlobalDataFlow.cs:118:104:118:109 | access to local variable sink15 | GlobalDataFlow.cs:118:104:118:109 | access to local variable sink15 |
+| GlobalDataFlow.cs:118:104:118:109 | access to local variable sink15 | GlobalDataFlow.cs:118:104:118:117 | call to method First |
+| GlobalDataFlow.cs:118:104:118:109 | access to local variable sink15 | GlobalDataFlow.cs:118:104:118:117 | call to method First |
+| GlobalDataFlow.cs:118:104:118:117 | call to method First | GlobalDataFlow.cs:118:68:118:119 | (...) ... |
+| GlobalDataFlow.cs:118:104:118:117 | call to method First | GlobalDataFlow.cs:118:68:118:119 | (...) ... |
+| GlobalDataFlow.cs:118:104:118:117 | call to method First | GlobalDataFlow.cs:118:89:118:119 | array creation of type String[] |
+| GlobalDataFlow.cs:118:104:118:117 | call to method First | GlobalDataFlow.cs:118:89:118:119 | array creation of type String[] |
+| GlobalDataFlow.cs:118:104:118:117 | call to method First | GlobalDataFlow.cs:118:104:118:117 | call to method First |
+| GlobalDataFlow.cs:118:123:118:133 | (...) => ... | GlobalDataFlow.cs:118:123:118:133 | (...) => ... |
+| GlobalDataFlow.cs:118:123:118:133 | [output] (...) => ... | GlobalDataFlow.cs:118:9:118:134 | SSA def(nonSink1) |
+| GlobalDataFlow.cs:118:123:118:133 | [output] (...) => ... | GlobalDataFlow.cs:118:9:118:134 | SSA def(nonSink1) |
+| GlobalDataFlow.cs:118:123:118:133 | [output] (...) => ... | GlobalDataFlow.cs:118:20:118:134 | call to method Zip |
+| GlobalDataFlow.cs:118:123:118:133 | [output] (...) => ... | GlobalDataFlow.cs:118:20:118:134 | call to method Zip |
+| GlobalDataFlow.cs:118:123:118:133 | [output] (...) => ... | GlobalDataFlow.cs:118:123:118:133 | [output] (...) => ... |
+| GlobalDataFlow.cs:118:123:118:133 | [output] (...) => ... | GlobalDataFlow.cs:119:15:119:22 | access to local variable nonSink1 |
+| GlobalDataFlow.cs:118:123:118:133 | [output] (...) => ... | GlobalDataFlow.cs:119:15:119:22 | access to local variable nonSink1 |
+| GlobalDataFlow.cs:118:123:118:133 | [output] (...) => ... | GlobalDataFlow.cs:124:20:124:27 | access to local variable nonSink1 |
+| GlobalDataFlow.cs:118:123:118:133 | [output] (...) => ... | GlobalDataFlow.cs:124:20:124:27 | access to local variable nonSink1 |
+| GlobalDataFlow.cs:118:124:118:124 | x | GlobalDataFlow.cs:118:124:118:124 | x |
+| GlobalDataFlow.cs:118:124:118:124 | x | GlobalDataFlow.cs:118:124:118:124 | x |
+| GlobalDataFlow.cs:118:124:118:124 | x | GlobalDataFlow.cs:118:124:118:124 | x |
+| GlobalDataFlow.cs:118:124:118:124 | x | GlobalDataFlow.cs:118:124:118:124 | x |
+| GlobalDataFlow.cs:118:124:118:124 | x | GlobalDataFlow.cs:118:124:118:124 | x |
+| GlobalDataFlow.cs:118:124:118:124 | x | GlobalDataFlow.cs:118:124:118:124 | x |
+| GlobalDataFlow.cs:118:124:118:124 | x | GlobalDataFlow.cs:118:133:118:133 | access to parameter x |
+| GlobalDataFlow.cs:118:124:118:124 | x | GlobalDataFlow.cs:118:133:118:133 | access to parameter x |
+| GlobalDataFlow.cs:118:124:118:124 | x | GlobalDataFlow.cs:118:133:118:133 | access to parameter x |
+| GlobalDataFlow.cs:118:124:118:124 | x | GlobalDataFlow.cs:118:133:118:133 | access to parameter x |
+| GlobalDataFlow.cs:118:124:118:124 | x | GlobalDataFlow.cs:118:133:118:133 | access to parameter x |
+| GlobalDataFlow.cs:118:124:118:124 | x | GlobalDataFlow.cs:118:133:118:133 | access to parameter x |
+| GlobalDataFlow.cs:118:124:118:124 | x | GlobalDataFlow.cs:118:133:118:133 | access to parameter x |
+| GlobalDataFlow.cs:118:124:118:124 | x | GlobalDataFlow.cs:118:133:118:133 | access to parameter x |
+| GlobalDataFlow.cs:118:133:118:133 | access to parameter x | GlobalDataFlow.cs:118:123:118:133 | [output] (...) => ... |
+| GlobalDataFlow.cs:118:133:118:133 | access to parameter x | GlobalDataFlow.cs:118:123:118:133 | [output] (...) => ... |
+| GlobalDataFlow.cs:118:133:118:133 | access to parameter x | GlobalDataFlow.cs:118:133:118:133 | access to parameter x |
 | GlobalDataFlow.cs:119:9:119:23 | call to method Check | GlobalDataFlow.cs:119:9:119:23 | call to method Check |
-| GlobalDataFlow.cs:119:15:119:22 | access to local variable nonSink0 | GlobalDataFlow.cs:119:15:119:22 | access to local variable nonSink0 |
-| GlobalDataFlow.cs:120:9:120:67 | ... = ... | GlobalDataFlow.cs:120:9:120:67 | ... = ... |
-| GlobalDataFlow.cs:120:9:120:67 | SSA def(nonSink0) | GlobalDataFlow.cs:120:9:120:67 | SSA def(nonSink0) |
-| GlobalDataFlow.cs:120:9:120:67 | SSA def(nonSink0) | GlobalDataFlow.cs:121:15:121:22 | access to local variable nonSink0 |
-| GlobalDataFlow.cs:120:9:120:67 | SSA def(nonSink0) | GlobalDataFlow.cs:121:15:121:22 | access to local variable nonSink0 |
-| GlobalDataFlow.cs:120:9:120:67 | SSA def(nonSink0) | GlobalDataFlow.cs:123:9:123:46 | call to method TryParse |
-| GlobalDataFlow.cs:120:9:120:67 | SSA def(nonSink0) | GlobalDataFlow.cs:123:9:123:46 | call to method TryParse |
-| GlobalDataFlow.cs:120:9:120:67 | SSA def(nonSink0) | GlobalDataFlow.cs:123:24:123:31 | access to local variable nonSink0 |
-| GlobalDataFlow.cs:120:9:120:67 | SSA def(nonSink0) | GlobalDataFlow.cs:123:24:123:31 | access to local variable nonSink0 |
-| GlobalDataFlow.cs:120:9:120:67 | SSA def(nonSink0) | GlobalDataFlow.cs:123:38:123:45 | SSA def(nonSink2) |
-| GlobalDataFlow.cs:120:9:120:67 | SSA def(nonSink0) | GlobalDataFlow.cs:123:38:123:45 | SSA def(nonSink2) |
-| GlobalDataFlow.cs:120:9:120:67 | SSA def(nonSink0) | GlobalDataFlow.cs:124:15:124:22 | access to local variable nonSink2 |
-| GlobalDataFlow.cs:120:9:120:67 | SSA def(nonSink0) | GlobalDataFlow.cs:124:15:124:22 | access to local variable nonSink2 |
-| GlobalDataFlow.cs:120:9:120:67 | SSA def(nonSink0) | GlobalDataFlow.cs:126:9:126:45 | call to method TryParse |
-| GlobalDataFlow.cs:120:9:120:67 | SSA def(nonSink0) | GlobalDataFlow.cs:126:9:126:45 | call to method TryParse |
-| GlobalDataFlow.cs:120:9:120:67 | SSA def(nonSink0) | GlobalDataFlow.cs:126:23:126:30 | access to local variable nonSink0 |
-| GlobalDataFlow.cs:120:9:120:67 | SSA def(nonSink0) | GlobalDataFlow.cs:126:23:126:30 | access to local variable nonSink0 |
-| GlobalDataFlow.cs:120:9:120:67 | SSA def(nonSink0) | GlobalDataFlow.cs:126:37:126:44 | SSA def(nonSink3) |
-| GlobalDataFlow.cs:120:9:120:67 | SSA def(nonSink0) | GlobalDataFlow.cs:126:37:126:44 | SSA def(nonSink3) |
-| GlobalDataFlow.cs:120:9:120:67 | SSA def(nonSink0) | GlobalDataFlow.cs:127:15:127:22 | access to local variable nonSink3 |
-| GlobalDataFlow.cs:120:9:120:67 | SSA def(nonSink0) | GlobalDataFlow.cs:127:15:127:22 | access to local variable nonSink3 |
-| GlobalDataFlow.cs:120:9:120:67 | SSA def(nonSink0) | GlobalDataFlow.cs:135:28:135:35 | access to local variable nonSink0 |
-| GlobalDataFlow.cs:120:9:120:67 | SSA def(nonSink0) | GlobalDataFlow.cs:135:28:135:35 | access to local variable nonSink0 |
-| GlobalDataFlow.cs:120:20:120:27 | access to local variable nonSink1 | GlobalDataFlow.cs:120:20:120:27 | access to local variable nonSink1 |
-| GlobalDataFlow.cs:120:20:120:27 | access to local variable nonSink1 | GlobalDataFlow.cs:120:46:120:58 | [output] (...) => ... |
-| GlobalDataFlow.cs:120:20:120:27 | access to local variable nonSink1 | GlobalDataFlow.cs:120:46:120:58 | [output] (...) => ... |
-| GlobalDataFlow.cs:120:20:120:27 | access to local variable nonSink1 | GlobalDataFlow.cs:120:52:120:52 | s |
-| GlobalDataFlow.cs:120:20:120:27 | access to local variable nonSink1 | GlobalDataFlow.cs:120:52:120:52 | s |
-| GlobalDataFlow.cs:120:20:120:67 | call to method Aggregate | GlobalDataFlow.cs:120:9:120:67 | SSA def(nonSink0) |
-| GlobalDataFlow.cs:120:20:120:67 | call to method Aggregate | GlobalDataFlow.cs:120:9:120:67 | SSA def(nonSink0) |
-| GlobalDataFlow.cs:120:20:120:67 | call to method Aggregate | GlobalDataFlow.cs:120:20:120:67 | call to method Aggregate |
-| GlobalDataFlow.cs:120:20:120:67 | call to method Aggregate | GlobalDataFlow.cs:121:15:121:22 | access to local variable nonSink0 |
-| GlobalDataFlow.cs:120:20:120:67 | call to method Aggregate | GlobalDataFlow.cs:121:15:121:22 | access to local variable nonSink0 |
-| GlobalDataFlow.cs:120:20:120:67 | call to method Aggregate | GlobalDataFlow.cs:123:9:123:46 | call to method TryParse |
-| GlobalDataFlow.cs:120:20:120:67 | call to method Aggregate | GlobalDataFlow.cs:123:9:123:46 | call to method TryParse |
-| GlobalDataFlow.cs:120:20:120:67 | call to method Aggregate | GlobalDataFlow.cs:123:24:123:31 | access to local variable nonSink0 |
-| GlobalDataFlow.cs:120:20:120:67 | call to method Aggregate | GlobalDataFlow.cs:123:24:123:31 | access to local variable nonSink0 |
-| GlobalDataFlow.cs:120:20:120:67 | call to method Aggregate | GlobalDataFlow.cs:123:38:123:45 | SSA def(nonSink2) |
-| GlobalDataFlow.cs:120:20:120:67 | call to method Aggregate | GlobalDataFlow.cs:123:38:123:45 | SSA def(nonSink2) |
-| GlobalDataFlow.cs:120:20:120:67 | call to method Aggregate | GlobalDataFlow.cs:124:15:124:22 | access to local variable nonSink2 |
-| GlobalDataFlow.cs:120:20:120:67 | call to method Aggregate | GlobalDataFlow.cs:124:15:124:22 | access to local variable nonSink2 |
-| GlobalDataFlow.cs:120:20:120:67 | call to method Aggregate | GlobalDataFlow.cs:126:9:126:45 | call to method TryParse |
-| GlobalDataFlow.cs:120:20:120:67 | call to method Aggregate | GlobalDataFlow.cs:126:9:126:45 | call to method TryParse |
-| GlobalDataFlow.cs:120:20:120:67 | call to method Aggregate | GlobalDataFlow.cs:126:23:126:30 | access to local variable nonSink0 |
-| GlobalDataFlow.cs:120:20:120:67 | call to method Aggregate | GlobalDataFlow.cs:126:23:126:30 | access to local variable nonSink0 |
-| GlobalDataFlow.cs:120:20:120:67 | call to method Aggregate | GlobalDataFlow.cs:126:37:126:44 | SSA def(nonSink3) |
-| GlobalDataFlow.cs:120:20:120:67 | call to method Aggregate | GlobalDataFlow.cs:126:37:126:44 | SSA def(nonSink3) |
-| GlobalDataFlow.cs:120:20:120:67 | call to method Aggregate | GlobalDataFlow.cs:127:15:127:22 | access to local variable nonSink3 |
-| GlobalDataFlow.cs:120:20:120:67 | call to method Aggregate | GlobalDataFlow.cs:127:15:127:22 | access to local variable nonSink3 |
-| GlobalDataFlow.cs:120:20:120:67 | call to method Aggregate | GlobalDataFlow.cs:135:28:135:35 | access to local variable nonSink0 |
-| GlobalDataFlow.cs:120:20:120:67 | call to method Aggregate | GlobalDataFlow.cs:135:28:135:35 | access to local variable nonSink0 |
-| GlobalDataFlow.cs:120:39:120:43 | access to local variable sink1 | GlobalDataFlow.cs:120:39:120:43 | access to local variable sink1 |
-| GlobalDataFlow.cs:120:46:120:58 | (...) => ... | GlobalDataFlow.cs:120:46:120:58 | (...) => ... |
-| GlobalDataFlow.cs:120:46:120:58 | [output] (...) => ... | GlobalDataFlow.cs:120:46:120:58 | [output] (...) => ... |
-| GlobalDataFlow.cs:120:46:120:58 | [output] (...) => ... | GlobalDataFlow.cs:120:61:120:61 | x |
-| GlobalDataFlow.cs:120:46:120:58 | [output] (...) => ... | GlobalDataFlow.cs:120:61:120:61 | x |
-| GlobalDataFlow.cs:120:46:120:58 | [output] (...) => ... | GlobalDataFlow.cs:120:61:120:66 | [output] (...) => ... |
-| GlobalDataFlow.cs:120:46:120:58 | [output] (...) => ... | GlobalDataFlow.cs:120:61:120:66 | [output] (...) => ... |
-| GlobalDataFlow.cs:120:52:120:52 | s | GlobalDataFlow.cs:120:52:120:52 | s |
-| GlobalDataFlow.cs:120:52:120:52 | s | GlobalDataFlow.cs:120:52:120:52 | s |
-| GlobalDataFlow.cs:120:52:120:52 | s | GlobalDataFlow.cs:120:52:120:52 | s |
-| GlobalDataFlow.cs:120:52:120:52 | s | GlobalDataFlow.cs:120:52:120:52 | s |
-| GlobalDataFlow.cs:120:52:120:52 | s | GlobalDataFlow.cs:120:52:120:52 | s |
-| GlobalDataFlow.cs:120:52:120:52 | s | GlobalDataFlow.cs:120:52:120:52 | s |
-| GlobalDataFlow.cs:120:52:120:52 | s | GlobalDataFlow.cs:120:58:120:58 | access to parameter s |
-| GlobalDataFlow.cs:120:52:120:52 | s | GlobalDataFlow.cs:120:58:120:58 | access to parameter s |
-| GlobalDataFlow.cs:120:52:120:52 | s | GlobalDataFlow.cs:120:58:120:58 | access to parameter s |
-| GlobalDataFlow.cs:120:52:120:52 | s | GlobalDataFlow.cs:120:58:120:58 | access to parameter s |
-| GlobalDataFlow.cs:120:52:120:52 | s | GlobalDataFlow.cs:120:58:120:58 | access to parameter s |
-| GlobalDataFlow.cs:120:52:120:52 | s | GlobalDataFlow.cs:120:58:120:58 | access to parameter s |
-| GlobalDataFlow.cs:120:52:120:52 | s | GlobalDataFlow.cs:120:58:120:58 | access to parameter s |
-| GlobalDataFlow.cs:120:52:120:52 | s | GlobalDataFlow.cs:120:58:120:58 | access to parameter s |
-| GlobalDataFlow.cs:120:58:120:58 | access to parameter s | GlobalDataFlow.cs:120:46:120:58 | [output] (...) => ... |
-| GlobalDataFlow.cs:120:58:120:58 | access to parameter s | GlobalDataFlow.cs:120:46:120:58 | [output] (...) => ... |
-| GlobalDataFlow.cs:120:58:120:58 | access to parameter s | GlobalDataFlow.cs:120:58:120:58 | access to parameter s |
-| GlobalDataFlow.cs:120:61:120:61 | x | GlobalDataFlow.cs:120:61:120:61 | x |
-| GlobalDataFlow.cs:120:61:120:61 | x | GlobalDataFlow.cs:120:61:120:61 | x |
-| GlobalDataFlow.cs:120:61:120:61 | x | GlobalDataFlow.cs:120:61:120:61 | x |
-| GlobalDataFlow.cs:120:61:120:61 | x | GlobalDataFlow.cs:120:61:120:61 | x |
-| GlobalDataFlow.cs:120:61:120:61 | x | GlobalDataFlow.cs:120:61:120:61 | x |
-| GlobalDataFlow.cs:120:61:120:61 | x | GlobalDataFlow.cs:120:61:120:61 | x |
-| GlobalDataFlow.cs:120:61:120:61 | x | GlobalDataFlow.cs:120:66:120:66 | access to parameter x |
-| GlobalDataFlow.cs:120:61:120:61 | x | GlobalDataFlow.cs:120:66:120:66 | access to parameter x |
-| GlobalDataFlow.cs:120:61:120:61 | x | GlobalDataFlow.cs:120:66:120:66 | access to parameter x |
-| GlobalDataFlow.cs:120:61:120:61 | x | GlobalDataFlow.cs:120:66:120:66 | access to parameter x |
-| GlobalDataFlow.cs:120:61:120:61 | x | GlobalDataFlow.cs:120:66:120:66 | access to parameter x |
-| GlobalDataFlow.cs:120:61:120:61 | x | GlobalDataFlow.cs:120:66:120:66 | access to parameter x |
-| GlobalDataFlow.cs:120:61:120:61 | x | GlobalDataFlow.cs:120:66:120:66 | access to parameter x |
-| GlobalDataFlow.cs:120:61:120:61 | x | GlobalDataFlow.cs:120:66:120:66 | access to parameter x |
-| GlobalDataFlow.cs:120:61:120:66 | (...) => ... | GlobalDataFlow.cs:120:61:120:66 | (...) => ... |
-| GlobalDataFlow.cs:120:61:120:66 | [output] (...) => ... | GlobalDataFlow.cs:120:9:120:67 | SSA def(nonSink0) |
-| GlobalDataFlow.cs:120:61:120:66 | [output] (...) => ... | GlobalDataFlow.cs:120:9:120:67 | SSA def(nonSink0) |
-| GlobalDataFlow.cs:120:61:120:66 | [output] (...) => ... | GlobalDataFlow.cs:120:20:120:67 | call to method Aggregate |
-| GlobalDataFlow.cs:120:61:120:66 | [output] (...) => ... | GlobalDataFlow.cs:120:20:120:67 | call to method Aggregate |
-| GlobalDataFlow.cs:120:61:120:66 | [output] (...) => ... | GlobalDataFlow.cs:120:61:120:66 | [output] (...) => ... |
-| GlobalDataFlow.cs:120:61:120:66 | [output] (...) => ... | GlobalDataFlow.cs:121:15:121:22 | access to local variable nonSink0 |
-| GlobalDataFlow.cs:120:61:120:66 | [output] (...) => ... | GlobalDataFlow.cs:121:15:121:22 | access to local variable nonSink0 |
-| GlobalDataFlow.cs:120:61:120:66 | [output] (...) => ... | GlobalDataFlow.cs:123:9:123:46 | call to method TryParse |
-| GlobalDataFlow.cs:120:61:120:66 | [output] (...) => ... | GlobalDataFlow.cs:123:9:123:46 | call to method TryParse |
-| GlobalDataFlow.cs:120:61:120:66 | [output] (...) => ... | GlobalDataFlow.cs:123:24:123:31 | access to local variable nonSink0 |
-| GlobalDataFlow.cs:120:61:120:66 | [output] (...) => ... | GlobalDataFlow.cs:123:24:123:31 | access to local variable nonSink0 |
-| GlobalDataFlow.cs:120:61:120:66 | [output] (...) => ... | GlobalDataFlow.cs:123:38:123:45 | SSA def(nonSink2) |
-| GlobalDataFlow.cs:120:61:120:66 | [output] (...) => ... | GlobalDataFlow.cs:123:38:123:45 | SSA def(nonSink2) |
-| GlobalDataFlow.cs:120:61:120:66 | [output] (...) => ... | GlobalDataFlow.cs:124:15:124:22 | access to local variable nonSink2 |
-| GlobalDataFlow.cs:120:61:120:66 | [output] (...) => ... | GlobalDataFlow.cs:124:15:124:22 | access to local variable nonSink2 |
-| GlobalDataFlow.cs:120:61:120:66 | [output] (...) => ... | GlobalDataFlow.cs:126:9:126:45 | call to method TryParse |
-| GlobalDataFlow.cs:120:61:120:66 | [output] (...) => ... | GlobalDataFlow.cs:126:9:126:45 | call to method TryParse |
-| GlobalDataFlow.cs:120:61:120:66 | [output] (...) => ... | GlobalDataFlow.cs:126:23:126:30 | access to local variable nonSink0 |
-| GlobalDataFlow.cs:120:61:120:66 | [output] (...) => ... | GlobalDataFlow.cs:126:23:126:30 | access to local variable nonSink0 |
-| GlobalDataFlow.cs:120:61:120:66 | [output] (...) => ... | GlobalDataFlow.cs:126:37:126:44 | SSA def(nonSink3) |
-| GlobalDataFlow.cs:120:61:120:66 | [output] (...) => ... | GlobalDataFlow.cs:126:37:126:44 | SSA def(nonSink3) |
-| GlobalDataFlow.cs:120:61:120:66 | [output] (...) => ... | GlobalDataFlow.cs:127:15:127:22 | access to local variable nonSink3 |
-| GlobalDataFlow.cs:120:61:120:66 | [output] (...) => ... | GlobalDataFlow.cs:127:15:127:22 | access to local variable nonSink3 |
-| GlobalDataFlow.cs:120:61:120:66 | [output] (...) => ... | GlobalDataFlow.cs:135:28:135:35 | access to local variable nonSink0 |
-| GlobalDataFlow.cs:120:61:120:66 | [output] (...) => ... | GlobalDataFlow.cs:135:28:135:35 | access to local variable nonSink0 |
-| GlobalDataFlow.cs:120:66:120:66 | access to parameter x | GlobalDataFlow.cs:120:61:120:66 | [output] (...) => ... |
-| GlobalDataFlow.cs:120:66:120:66 | access to parameter x | GlobalDataFlow.cs:120:61:120:66 | [output] (...) => ... |
-| GlobalDataFlow.cs:120:66:120:66 | access to parameter x | GlobalDataFlow.cs:120:66:120:66 | access to parameter x |
+| GlobalDataFlow.cs:119:15:119:22 | access to local variable nonSink1 | GlobalDataFlow.cs:119:15:119:22 | access to local variable nonSink1 |
+| GlobalDataFlow.cs:119:15:119:22 | access to local variable nonSink1 | GlobalDataFlow.cs:124:20:124:27 | access to local variable nonSink1 |
+| GlobalDataFlow.cs:119:15:119:22 | access to local variable nonSink1 | GlobalDataFlow.cs:124:20:124:27 | access to local variable nonSink1 |
+| GlobalDataFlow.cs:120:9:120:64 | ... = ... | GlobalDataFlow.cs:120:9:120:64 | ... = ... |
+| GlobalDataFlow.cs:120:9:120:64 | SSA def(nonSink0) | GlobalDataFlow.cs:120:9:120:64 | SSA def(nonSink0) |
+| GlobalDataFlow.cs:120:9:120:64 | SSA def(nonSink0) | GlobalDataFlow.cs:121:15:121:22 | access to local variable nonSink0 |
+| GlobalDataFlow.cs:120:9:120:64 | SSA def(nonSink0) | GlobalDataFlow.cs:121:15:121:22 | access to local variable nonSink0 |
+| GlobalDataFlow.cs:120:20:120:25 | access to local variable sink14 | GlobalDataFlow.cs:120:20:120:25 | access to local variable sink14 |
+| GlobalDataFlow.cs:120:20:120:25 | access to local variable sink14 | GlobalDataFlow.cs:122:20:122:25 | access to local variable sink14 |
+| GlobalDataFlow.cs:120:20:120:25 | access to local variable sink14 | GlobalDataFlow.cs:122:20:122:25 | access to local variable sink14 |
+| GlobalDataFlow.cs:120:20:120:64 | call to method Aggregate | GlobalDataFlow.cs:120:9:120:64 | SSA def(nonSink0) |
+| GlobalDataFlow.cs:120:20:120:64 | call to method Aggregate | GlobalDataFlow.cs:120:9:120:64 | SSA def(nonSink0) |
+| GlobalDataFlow.cs:120:20:120:64 | call to method Aggregate | GlobalDataFlow.cs:120:20:120:64 | call to method Aggregate |
+| GlobalDataFlow.cs:120:20:120:64 | call to method Aggregate | GlobalDataFlow.cs:121:15:121:22 | access to local variable nonSink0 |
+| GlobalDataFlow.cs:120:20:120:64 | call to method Aggregate | GlobalDataFlow.cs:121:15:121:22 | access to local variable nonSink0 |
+| GlobalDataFlow.cs:120:37:120:38 | "" | GlobalDataFlow.cs:120:37:120:38 | "" |
+| GlobalDataFlow.cs:120:37:120:38 | "" | GlobalDataFlow.cs:120:41:120:55 | [output] (...) => ... |
+| GlobalDataFlow.cs:120:37:120:38 | "" | GlobalDataFlow.cs:120:41:120:55 | [output] (...) => ... |
+| GlobalDataFlow.cs:120:37:120:38 | "" | GlobalDataFlow.cs:120:42:120:44 | acc |
+| GlobalDataFlow.cs:120:37:120:38 | "" | GlobalDataFlow.cs:120:42:120:44 | acc |
+| GlobalDataFlow.cs:120:41:120:55 | (...) => ... | GlobalDataFlow.cs:120:41:120:55 | (...) => ... |
+| GlobalDataFlow.cs:120:41:120:55 | [output] (...) => ... | GlobalDataFlow.cs:120:41:120:55 | [output] (...) => ... |
+| GlobalDataFlow.cs:120:41:120:55 | [output] (...) => ... | GlobalDataFlow.cs:120:58:120:58 | x |
+| GlobalDataFlow.cs:120:41:120:55 | [output] (...) => ... | GlobalDataFlow.cs:120:58:120:58 | x |
+| GlobalDataFlow.cs:120:41:120:55 | [output] (...) => ... | GlobalDataFlow.cs:120:58:120:63 | [output] (...) => ... |
+| GlobalDataFlow.cs:120:41:120:55 | [output] (...) => ... | GlobalDataFlow.cs:120:58:120:63 | [output] (...) => ... |
+| GlobalDataFlow.cs:120:42:120:44 | acc | GlobalDataFlow.cs:120:42:120:44 | acc |
+| GlobalDataFlow.cs:120:42:120:44 | acc | GlobalDataFlow.cs:120:42:120:44 | acc |
+| GlobalDataFlow.cs:120:42:120:44 | acc | GlobalDataFlow.cs:120:42:120:44 | acc |
+| GlobalDataFlow.cs:120:42:120:44 | acc | GlobalDataFlow.cs:120:42:120:44 | acc |
+| GlobalDataFlow.cs:120:42:120:44 | acc | GlobalDataFlow.cs:120:42:120:44 | acc |
+| GlobalDataFlow.cs:120:42:120:44 | acc | GlobalDataFlow.cs:120:42:120:44 | acc |
+| GlobalDataFlow.cs:120:42:120:44 | acc | GlobalDataFlow.cs:120:53:120:55 | access to parameter acc |
+| GlobalDataFlow.cs:120:42:120:44 | acc | GlobalDataFlow.cs:120:53:120:55 | access to parameter acc |
+| GlobalDataFlow.cs:120:42:120:44 | acc | GlobalDataFlow.cs:120:53:120:55 | access to parameter acc |
+| GlobalDataFlow.cs:120:42:120:44 | acc | GlobalDataFlow.cs:120:53:120:55 | access to parameter acc |
+| GlobalDataFlow.cs:120:42:120:44 | acc | GlobalDataFlow.cs:120:53:120:55 | access to parameter acc |
+| GlobalDataFlow.cs:120:42:120:44 | acc | GlobalDataFlow.cs:120:53:120:55 | access to parameter acc |
+| GlobalDataFlow.cs:120:42:120:44 | acc | GlobalDataFlow.cs:120:53:120:55 | access to parameter acc |
+| GlobalDataFlow.cs:120:42:120:44 | acc | GlobalDataFlow.cs:120:53:120:55 | access to parameter acc |
+| GlobalDataFlow.cs:120:53:120:55 | access to parameter acc | GlobalDataFlow.cs:120:41:120:55 | [output] (...) => ... |
+| GlobalDataFlow.cs:120:53:120:55 | access to parameter acc | GlobalDataFlow.cs:120:41:120:55 | [output] (...) => ... |
+| GlobalDataFlow.cs:120:53:120:55 | access to parameter acc | GlobalDataFlow.cs:120:53:120:55 | access to parameter acc |
+| GlobalDataFlow.cs:120:58:120:58 | x | GlobalDataFlow.cs:120:58:120:58 | x |
+| GlobalDataFlow.cs:120:58:120:58 | x | GlobalDataFlow.cs:120:58:120:58 | x |
+| GlobalDataFlow.cs:120:58:120:58 | x | GlobalDataFlow.cs:120:58:120:58 | x |
+| GlobalDataFlow.cs:120:58:120:58 | x | GlobalDataFlow.cs:120:58:120:58 | x |
+| GlobalDataFlow.cs:120:58:120:58 | x | GlobalDataFlow.cs:120:58:120:58 | x |
+| GlobalDataFlow.cs:120:58:120:58 | x | GlobalDataFlow.cs:120:58:120:58 | x |
+| GlobalDataFlow.cs:120:58:120:58 | x | GlobalDataFlow.cs:120:63:120:63 | access to parameter x |
+| GlobalDataFlow.cs:120:58:120:58 | x | GlobalDataFlow.cs:120:63:120:63 | access to parameter x |
+| GlobalDataFlow.cs:120:58:120:58 | x | GlobalDataFlow.cs:120:63:120:63 | access to parameter x |
+| GlobalDataFlow.cs:120:58:120:58 | x | GlobalDataFlow.cs:120:63:120:63 | access to parameter x |
+| GlobalDataFlow.cs:120:58:120:58 | x | GlobalDataFlow.cs:120:63:120:63 | access to parameter x |
+| GlobalDataFlow.cs:120:58:120:58 | x | GlobalDataFlow.cs:120:63:120:63 | access to parameter x |
+| GlobalDataFlow.cs:120:58:120:58 | x | GlobalDataFlow.cs:120:63:120:63 | access to parameter x |
+| GlobalDataFlow.cs:120:58:120:58 | x | GlobalDataFlow.cs:120:63:120:63 | access to parameter x |
+| GlobalDataFlow.cs:120:58:120:63 | (...) => ... | GlobalDataFlow.cs:120:58:120:63 | (...) => ... |
+| GlobalDataFlow.cs:120:58:120:63 | [output] (...) => ... | GlobalDataFlow.cs:120:9:120:64 | SSA def(nonSink0) |
+| GlobalDataFlow.cs:120:58:120:63 | [output] (...) => ... | GlobalDataFlow.cs:120:9:120:64 | SSA def(nonSink0) |
+| GlobalDataFlow.cs:120:58:120:63 | [output] (...) => ... | GlobalDataFlow.cs:120:20:120:64 | call to method Aggregate |
+| GlobalDataFlow.cs:120:58:120:63 | [output] (...) => ... | GlobalDataFlow.cs:120:20:120:64 | call to method Aggregate |
+| GlobalDataFlow.cs:120:58:120:63 | [output] (...) => ... | GlobalDataFlow.cs:120:58:120:63 | [output] (...) => ... |
+| GlobalDataFlow.cs:120:58:120:63 | [output] (...) => ... | GlobalDataFlow.cs:121:15:121:22 | access to local variable nonSink0 |
+| GlobalDataFlow.cs:120:58:120:63 | [output] (...) => ... | GlobalDataFlow.cs:121:15:121:22 | access to local variable nonSink0 |
+| GlobalDataFlow.cs:120:63:120:63 | access to parameter x | GlobalDataFlow.cs:120:58:120:63 | [output] (...) => ... |
+| GlobalDataFlow.cs:120:63:120:63 | access to parameter x | GlobalDataFlow.cs:120:58:120:63 | [output] (...) => ... |
+| GlobalDataFlow.cs:120:63:120:63 | access to parameter x | GlobalDataFlow.cs:120:63:120:63 | access to parameter x |
 | GlobalDataFlow.cs:121:9:121:23 | call to method Check | GlobalDataFlow.cs:121:9:121:23 | call to method Check |
 | GlobalDataFlow.cs:121:15:121:22 | access to local variable nonSink0 | GlobalDataFlow.cs:121:15:121:22 | access to local variable nonSink0 |
-| GlobalDataFlow.cs:121:15:121:22 | access to local variable nonSink0 | GlobalDataFlow.cs:123:9:123:46 | call to method TryParse |
-| GlobalDataFlow.cs:121:15:121:22 | access to local variable nonSink0 | GlobalDataFlow.cs:123:9:123:46 | call to method TryParse |
-| GlobalDataFlow.cs:121:15:121:22 | access to local variable nonSink0 | GlobalDataFlow.cs:123:24:123:31 | access to local variable nonSink0 |
-| GlobalDataFlow.cs:121:15:121:22 | access to local variable nonSink0 | GlobalDataFlow.cs:123:24:123:31 | access to local variable nonSink0 |
-| GlobalDataFlow.cs:121:15:121:22 | access to local variable nonSink0 | GlobalDataFlow.cs:123:38:123:45 | SSA def(nonSink2) |
-| GlobalDataFlow.cs:121:15:121:22 | access to local variable nonSink0 | GlobalDataFlow.cs:123:38:123:45 | SSA def(nonSink2) |
-| GlobalDataFlow.cs:121:15:121:22 | access to local variable nonSink0 | GlobalDataFlow.cs:124:15:124:22 | access to local variable nonSink2 |
-| GlobalDataFlow.cs:121:15:121:22 | access to local variable nonSink0 | GlobalDataFlow.cs:124:15:124:22 | access to local variable nonSink2 |
-| GlobalDataFlow.cs:121:15:121:22 | access to local variable nonSink0 | GlobalDataFlow.cs:126:9:126:45 | call to method TryParse |
-| GlobalDataFlow.cs:121:15:121:22 | access to local variable nonSink0 | GlobalDataFlow.cs:126:9:126:45 | call to method TryParse |
-| GlobalDataFlow.cs:121:15:121:22 | access to local variable nonSink0 | GlobalDataFlow.cs:126:23:126:30 | access to local variable nonSink0 |
-| GlobalDataFlow.cs:121:15:121:22 | access to local variable nonSink0 | GlobalDataFlow.cs:126:23:126:30 | access to local variable nonSink0 |
-| GlobalDataFlow.cs:121:15:121:22 | access to local variable nonSink0 | GlobalDataFlow.cs:126:37:126:44 | SSA def(nonSink3) |
-| GlobalDataFlow.cs:121:15:121:22 | access to local variable nonSink0 | GlobalDataFlow.cs:126:37:126:44 | SSA def(nonSink3) |
-| GlobalDataFlow.cs:121:15:121:22 | access to local variable nonSink0 | GlobalDataFlow.cs:127:15:127:22 | access to local variable nonSink3 |
-| GlobalDataFlow.cs:121:15:121:22 | access to local variable nonSink0 | GlobalDataFlow.cs:127:15:127:22 | access to local variable nonSink3 |
-| GlobalDataFlow.cs:121:15:121:22 | access to local variable nonSink0 | GlobalDataFlow.cs:135:28:135:35 | access to local variable nonSink0 |
-| GlobalDataFlow.cs:121:15:121:22 | access to local variable nonSink0 | GlobalDataFlow.cs:135:28:135:35 | access to local variable nonSink0 |
-| GlobalDataFlow.cs:122:13:122:20 | Int32 nonSink2 | GlobalDataFlow.cs:122:13:122:20 | Int32 nonSink2 |
-| GlobalDataFlow.cs:123:9:123:46 | call to method TryParse | GlobalDataFlow.cs:123:9:123:46 | call to method TryParse |
-| GlobalDataFlow.cs:123:24:123:31 | access to local variable nonSink0 | GlobalDataFlow.cs:123:9:123:46 | call to method TryParse |
-| GlobalDataFlow.cs:123:24:123:31 | access to local variable nonSink0 | GlobalDataFlow.cs:123:9:123:46 | call to method TryParse |
-| GlobalDataFlow.cs:123:24:123:31 | access to local variable nonSink0 | GlobalDataFlow.cs:123:24:123:31 | access to local variable nonSink0 |
-| GlobalDataFlow.cs:123:24:123:31 | access to local variable nonSink0 | GlobalDataFlow.cs:123:38:123:45 | SSA def(nonSink2) |
-| GlobalDataFlow.cs:123:24:123:31 | access to local variable nonSink0 | GlobalDataFlow.cs:123:38:123:45 | SSA def(nonSink2) |
-| GlobalDataFlow.cs:123:24:123:31 | access to local variable nonSink0 | GlobalDataFlow.cs:124:15:124:22 | access to local variable nonSink2 |
-| GlobalDataFlow.cs:123:24:123:31 | access to local variable nonSink0 | GlobalDataFlow.cs:124:15:124:22 | access to local variable nonSink2 |
-| GlobalDataFlow.cs:123:24:123:31 | access to local variable nonSink0 | GlobalDataFlow.cs:126:9:126:45 | call to method TryParse |
-| GlobalDataFlow.cs:123:24:123:31 | access to local variable nonSink0 | GlobalDataFlow.cs:126:9:126:45 | call to method TryParse |
-| GlobalDataFlow.cs:123:24:123:31 | access to local variable nonSink0 | GlobalDataFlow.cs:126:23:126:30 | access to local variable nonSink0 |
-| GlobalDataFlow.cs:123:24:123:31 | access to local variable nonSink0 | GlobalDataFlow.cs:126:23:126:30 | access to local variable nonSink0 |
-| GlobalDataFlow.cs:123:24:123:31 | access to local variable nonSink0 | GlobalDataFlow.cs:126:37:126:44 | SSA def(nonSink3) |
-| GlobalDataFlow.cs:123:24:123:31 | access to local variable nonSink0 | GlobalDataFlow.cs:126:37:126:44 | SSA def(nonSink3) |
-| GlobalDataFlow.cs:123:24:123:31 | access to local variable nonSink0 | GlobalDataFlow.cs:127:15:127:22 | access to local variable nonSink3 |
-| GlobalDataFlow.cs:123:24:123:31 | access to local variable nonSink0 | GlobalDataFlow.cs:127:15:127:22 | access to local variable nonSink3 |
-| GlobalDataFlow.cs:123:24:123:31 | access to local variable nonSink0 | GlobalDataFlow.cs:135:28:135:35 | access to local variable nonSink0 |
-| GlobalDataFlow.cs:123:24:123:31 | access to local variable nonSink0 | GlobalDataFlow.cs:135:28:135:35 | access to local variable nonSink0 |
-| GlobalDataFlow.cs:123:38:123:45 | SSA def(nonSink2) | GlobalDataFlow.cs:123:38:123:45 | SSA def(nonSink2) |
-| GlobalDataFlow.cs:123:38:123:45 | SSA def(nonSink2) | GlobalDataFlow.cs:124:15:124:22 | access to local variable nonSink2 |
-| GlobalDataFlow.cs:123:38:123:45 | SSA def(nonSink2) | GlobalDataFlow.cs:124:15:124:22 | access to local variable nonSink2 |
-| GlobalDataFlow.cs:124:9:124:23 | call to method Check | GlobalDataFlow.cs:124:9:124:23 | call to method Check |
-| GlobalDataFlow.cs:124:15:124:22 | access to local variable nonSink2 | GlobalDataFlow.cs:124:15:124:22 | access to local variable nonSink2 |
-| GlobalDataFlow.cs:125:14:125:21 | Boolean nonSink3 | GlobalDataFlow.cs:125:14:125:21 | Boolean nonSink3 |
-| GlobalDataFlow.cs:126:9:126:45 | call to method TryParse | GlobalDataFlow.cs:126:9:126:45 | call to method TryParse |
-| GlobalDataFlow.cs:126:23:126:30 | access to local variable nonSink0 | GlobalDataFlow.cs:126:9:126:45 | call to method TryParse |
-| GlobalDataFlow.cs:126:23:126:30 | access to local variable nonSink0 | GlobalDataFlow.cs:126:9:126:45 | call to method TryParse |
-| GlobalDataFlow.cs:126:23:126:30 | access to local variable nonSink0 | GlobalDataFlow.cs:126:23:126:30 | access to local variable nonSink0 |
-| GlobalDataFlow.cs:126:23:126:30 | access to local variable nonSink0 | GlobalDataFlow.cs:126:37:126:44 | SSA def(nonSink3) |
-| GlobalDataFlow.cs:126:23:126:30 | access to local variable nonSink0 | GlobalDataFlow.cs:126:37:126:44 | SSA def(nonSink3) |
-| GlobalDataFlow.cs:126:23:126:30 | access to local variable nonSink0 | GlobalDataFlow.cs:127:15:127:22 | access to local variable nonSink3 |
-| GlobalDataFlow.cs:126:23:126:30 | access to local variable nonSink0 | GlobalDataFlow.cs:127:15:127:22 | access to local variable nonSink3 |
-| GlobalDataFlow.cs:126:23:126:30 | access to local variable nonSink0 | GlobalDataFlow.cs:135:28:135:35 | access to local variable nonSink0 |
-| GlobalDataFlow.cs:126:23:126:30 | access to local variable nonSink0 | GlobalDataFlow.cs:135:28:135:35 | access to local variable nonSink0 |
-| GlobalDataFlow.cs:126:37:126:44 | SSA def(nonSink3) | GlobalDataFlow.cs:126:37:126:44 | SSA def(nonSink3) |
-| GlobalDataFlow.cs:126:37:126:44 | SSA def(nonSink3) | GlobalDataFlow.cs:127:15:127:22 | access to local variable nonSink3 |
-| GlobalDataFlow.cs:126:37:126:44 | SSA def(nonSink3) | GlobalDataFlow.cs:127:15:127:22 | access to local variable nonSink3 |
-| GlobalDataFlow.cs:127:9:127:23 | call to method Check | GlobalDataFlow.cs:127:9:127:23 | call to method Check |
-| GlobalDataFlow.cs:127:15:127:22 | access to local variable nonSink3 | GlobalDataFlow.cs:127:15:127:22 | access to local variable nonSink3 |
-| GlobalDataFlow.cs:130:30:130:64 | Func<String,String> return = ... | GlobalDataFlow.cs:130:30:130:64 | Func<String,String> return = ... |
-| GlobalDataFlow.cs:130:30:130:64 | SSA def(return) | GlobalDataFlow.cs:130:30:130:64 | SSA def(return) |
-| GlobalDataFlow.cs:130:30:130:64 | SSA def(return) | GlobalDataFlow.cs:131:21:131:27 | access to local variable return |
-| GlobalDataFlow.cs:130:30:130:64 | SSA def(return) | GlobalDataFlow.cs:131:21:131:27 | access to local variable return |
-| GlobalDataFlow.cs:130:30:130:64 | SSA def(return) | GlobalDataFlow.cs:135:20:135:26 | access to local variable return |
-| GlobalDataFlow.cs:130:30:130:64 | SSA def(return) | GlobalDataFlow.cs:135:20:135:26 | access to local variable return |
-| GlobalDataFlow.cs:130:40:130:40 | x | GlobalDataFlow.cs:130:40:130:40 | x |
-| GlobalDataFlow.cs:130:40:130:40 | x | GlobalDataFlow.cs:130:40:130:40 | x |
-| GlobalDataFlow.cs:130:40:130:40 | x | GlobalDataFlow.cs:130:40:130:40 | x |
-| GlobalDataFlow.cs:130:40:130:40 | x | GlobalDataFlow.cs:130:40:130:40 | x |
-| GlobalDataFlow.cs:130:40:130:40 | x | GlobalDataFlow.cs:130:63:130:63 | access to parameter x |
-| GlobalDataFlow.cs:130:40:130:40 | x | GlobalDataFlow.cs:130:63:130:63 | access to parameter x |
-| GlobalDataFlow.cs:130:40:130:40 | x | GlobalDataFlow.cs:130:63:130:63 | access to parameter x |
-| GlobalDataFlow.cs:130:40:130:40 | x | GlobalDataFlow.cs:130:63:130:63 | access to parameter x |
-| GlobalDataFlow.cs:130:40:130:40 | x | GlobalDataFlow.cs:130:63:130:63 | access to parameter x |
-| GlobalDataFlow.cs:130:40:130:40 | x | GlobalDataFlow.cs:130:63:130:63 | access to parameter x |
-| GlobalDataFlow.cs:130:40:130:64 | (...) => ... | GlobalDataFlow.cs:130:30:130:64 | SSA def(return) |
-| GlobalDataFlow.cs:130:40:130:64 | (...) => ... | GlobalDataFlow.cs:130:30:130:64 | SSA def(return) |
-| GlobalDataFlow.cs:130:40:130:64 | (...) => ... | GlobalDataFlow.cs:130:40:130:64 | (...) => ... |
-| GlobalDataFlow.cs:130:40:130:64 | (...) => ... | GlobalDataFlow.cs:131:21:131:27 | access to local variable return |
-| GlobalDataFlow.cs:130:40:130:64 | (...) => ... | GlobalDataFlow.cs:131:21:131:27 | access to local variable return |
-| GlobalDataFlow.cs:130:40:130:64 | (...) => ... | GlobalDataFlow.cs:135:20:135:26 | access to local variable return |
-| GlobalDataFlow.cs:130:40:130:64 | (...) => ... | GlobalDataFlow.cs:135:20:135:26 | access to local variable return |
-| GlobalDataFlow.cs:130:45:130:64 | call to method ApplyFunc | GlobalDataFlow.cs:130:45:130:64 | call to method ApplyFunc |
-| GlobalDataFlow.cs:130:45:130:64 | call to method ApplyFunc | GlobalDataFlow.cs:131:21:131:34 | delegate call |
-| GlobalDataFlow.cs:130:45:130:64 | call to method ApplyFunc | GlobalDataFlow.cs:131:21:131:34 | delegate call |
-| GlobalDataFlow.cs:130:45:130:64 | call to method ApplyFunc | GlobalDataFlow.cs:135:20:135:36 | delegate call |
-| GlobalDataFlow.cs:130:45:130:64 | call to method ApplyFunc | GlobalDataFlow.cs:135:20:135:36 | delegate call |
-| GlobalDataFlow.cs:130:55:130:60 | access to method Return | GlobalDataFlow.cs:130:55:130:60 | access to method Return |
-| GlobalDataFlow.cs:130:55:130:60 | delegate creation of type Func<String,String> | GlobalDataFlow.cs:130:55:130:60 | delegate creation of type Func<String,String> |
-| GlobalDataFlow.cs:130:55:130:60 | delegate creation of type Func<String,String> | GlobalDataFlow.cs:359:41:359:41 | f |
-| GlobalDataFlow.cs:130:55:130:60 | delegate creation of type Func<String,String> | GlobalDataFlow.cs:359:41:359:41 | f |
-| GlobalDataFlow.cs:130:63:130:63 | access to parameter x | GlobalDataFlow.cs:130:45:130:64 | call to method ApplyFunc |
-| GlobalDataFlow.cs:130:63:130:63 | access to parameter x | GlobalDataFlow.cs:130:45:130:64 | call to method ApplyFunc |
-| GlobalDataFlow.cs:130:63:130:63 | access to parameter x | GlobalDataFlow.cs:130:45:130:64 | call to method ApplyFunc |
-| GlobalDataFlow.cs:130:63:130:63 | access to parameter x | GlobalDataFlow.cs:130:45:130:64 | call to method ApplyFunc |
-| GlobalDataFlow.cs:130:63:130:63 | access to parameter x | GlobalDataFlow.cs:130:63:130:63 | access to parameter x |
-| GlobalDataFlow.cs:130:63:130:63 | access to parameter x | GlobalDataFlow.cs:359:46:359:46 | x |
-| GlobalDataFlow.cs:130:63:130:63 | access to parameter x | GlobalDataFlow.cs:359:46:359:46 | x |
-| GlobalDataFlow.cs:130:63:130:63 | access to parameter x | GlobalDataFlow.cs:359:46:359:46 | x |
-| GlobalDataFlow.cs:130:63:130:63 | access to parameter x | GlobalDataFlow.cs:359:46:359:46 | x |
-| GlobalDataFlow.cs:131:13:131:34 | SSA def(sink4) | GlobalDataFlow.cs:131:13:131:34 | SSA def(sink4) |
-| GlobalDataFlow.cs:131:13:131:34 | SSA def(sink4) | GlobalDataFlow.cs:132:15:132:19 | access to local variable sink4 |
-| GlobalDataFlow.cs:131:13:131:34 | SSA def(sink4) | GlobalDataFlow.cs:132:15:132:19 | access to local variable sink4 |
-| GlobalDataFlow.cs:131:13:131:34 | SSA def(sink4) | GlobalDataFlow.cs:139:39:139:43 | access to local variable sink4 |
-| GlobalDataFlow.cs:131:13:131:34 | SSA def(sink4) | GlobalDataFlow.cs:139:39:139:43 | access to local variable sink4 |
-| GlobalDataFlow.cs:131:13:131:34 | String sink4 = ... | GlobalDataFlow.cs:131:13:131:34 | String sink4 = ... |
-| GlobalDataFlow.cs:131:21:131:27 | access to local variable return | GlobalDataFlow.cs:131:21:131:27 | access to local variable return |
-| GlobalDataFlow.cs:131:21:131:27 | access to local variable return | GlobalDataFlow.cs:135:20:135:26 | access to local variable return |
-| GlobalDataFlow.cs:131:21:131:27 | access to local variable return | GlobalDataFlow.cs:135:20:135:26 | access to local variable return |
-| GlobalDataFlow.cs:131:21:131:34 | delegate call | GlobalDataFlow.cs:131:13:131:34 | SSA def(sink4) |
-| GlobalDataFlow.cs:131:21:131:34 | delegate call | GlobalDataFlow.cs:131:13:131:34 | SSA def(sink4) |
-| GlobalDataFlow.cs:131:21:131:34 | delegate call | GlobalDataFlow.cs:131:21:131:34 | delegate call |
-| GlobalDataFlow.cs:131:21:131:34 | delegate call | GlobalDataFlow.cs:132:15:132:19 | access to local variable sink4 |
-| GlobalDataFlow.cs:131:21:131:34 | delegate call | GlobalDataFlow.cs:132:15:132:19 | access to local variable sink4 |
-| GlobalDataFlow.cs:131:21:131:34 | delegate call | GlobalDataFlow.cs:139:39:139:43 | access to local variable sink4 |
-| GlobalDataFlow.cs:131:21:131:34 | delegate call | GlobalDataFlow.cs:139:39:139:43 | access to local variable sink4 |
-| GlobalDataFlow.cs:131:29:131:33 | access to local variable sink3 | GlobalDataFlow.cs:130:40:130:40 | x |
-| GlobalDataFlow.cs:131:29:131:33 | access to local variable sink3 | GlobalDataFlow.cs:130:40:130:40 | x |
-| GlobalDataFlow.cs:131:29:131:33 | access to local variable sink3 | GlobalDataFlow.cs:131:21:131:34 | delegate call |
-| GlobalDataFlow.cs:131:29:131:33 | access to local variable sink3 | GlobalDataFlow.cs:131:21:131:34 | delegate call |
-| GlobalDataFlow.cs:131:29:131:33 | access to local variable sink3 | GlobalDataFlow.cs:131:29:131:33 | access to local variable sink3 |
-| GlobalDataFlow.cs:132:9:132:20 | call to method Check | GlobalDataFlow.cs:132:9:132:20 | call to method Check |
-| GlobalDataFlow.cs:132:15:132:19 | access to local variable sink4 | GlobalDataFlow.cs:132:15:132:19 | access to local variable sink4 |
-| GlobalDataFlow.cs:132:15:132:19 | access to local variable sink4 | GlobalDataFlow.cs:139:39:139:43 | access to local variable sink4 |
-| GlobalDataFlow.cs:132:15:132:19 | access to local variable sink4 | GlobalDataFlow.cs:139:39:139:43 | access to local variable sink4 |
-| GlobalDataFlow.cs:135:9:135:36 | ... = ... | GlobalDataFlow.cs:135:9:135:36 | ... = ... |
-| GlobalDataFlow.cs:135:9:135:36 | SSA def(nonSink0) | GlobalDataFlow.cs:135:9:135:36 | SSA def(nonSink0) |
-| GlobalDataFlow.cs:135:9:135:36 | SSA def(nonSink0) | GlobalDataFlow.cs:136:15:136:22 | access to local variable nonSink0 |
-| GlobalDataFlow.cs:135:9:135:36 | SSA def(nonSink0) | GlobalDataFlow.cs:136:15:136:22 | access to local variable nonSink0 |
-| GlobalDataFlow.cs:135:20:135:26 | access to local variable return | GlobalDataFlow.cs:135:20:135:26 | access to local variable return |
-| GlobalDataFlow.cs:135:20:135:36 | delegate call | GlobalDataFlow.cs:135:9:135:36 | SSA def(nonSink0) |
-| GlobalDataFlow.cs:135:20:135:36 | delegate call | GlobalDataFlow.cs:135:9:135:36 | SSA def(nonSink0) |
-| GlobalDataFlow.cs:135:20:135:36 | delegate call | GlobalDataFlow.cs:135:20:135:36 | delegate call |
-| GlobalDataFlow.cs:135:20:135:36 | delegate call | GlobalDataFlow.cs:136:15:136:22 | access to local variable nonSink0 |
-| GlobalDataFlow.cs:135:20:135:36 | delegate call | GlobalDataFlow.cs:136:15:136:22 | access to local variable nonSink0 |
-| GlobalDataFlow.cs:135:28:135:35 | access to local variable nonSink0 | GlobalDataFlow.cs:130:40:130:40 | x |
-| GlobalDataFlow.cs:135:28:135:35 | access to local variable nonSink0 | GlobalDataFlow.cs:130:40:130:40 | x |
-| GlobalDataFlow.cs:135:28:135:35 | access to local variable nonSink0 | GlobalDataFlow.cs:135:20:135:36 | delegate call |
-| GlobalDataFlow.cs:135:28:135:35 | access to local variable nonSink0 | GlobalDataFlow.cs:135:20:135:36 | delegate call |
-| GlobalDataFlow.cs:135:28:135:35 | access to local variable nonSink0 | GlobalDataFlow.cs:135:28:135:35 | access to local variable nonSink0 |
-| GlobalDataFlow.cs:136:9:136:23 | call to method Check | GlobalDataFlow.cs:136:9:136:23 | call to method Check |
-| GlobalDataFlow.cs:136:15:136:22 | access to local variable nonSink0 | GlobalDataFlow.cs:136:15:136:22 | access to local variable nonSink0 |
-| GlobalDataFlow.cs:139:13:139:44 | SSA def(sink5) | GlobalDataFlow.cs:139:13:139:44 | SSA def(sink5) |
-| GlobalDataFlow.cs:139:13:139:44 | SSA def(sink5) | GlobalDataFlow.cs:140:15:140:19 | access to local variable sink5 |
-| GlobalDataFlow.cs:139:13:139:44 | SSA def(sink5) | GlobalDataFlow.cs:140:15:140:19 | access to local variable sink5 |
-| GlobalDataFlow.cs:139:13:139:44 | SSA def(sink5) | GlobalDataFlow.cs:145:39:145:43 | access to local variable sink5 |
-| GlobalDataFlow.cs:139:13:139:44 | SSA def(sink5) | GlobalDataFlow.cs:145:39:145:43 | access to local variable sink5 |
-| GlobalDataFlow.cs:139:13:139:44 | String sink5 = ... | GlobalDataFlow.cs:139:13:139:44 | String sink5 = ... |
-| GlobalDataFlow.cs:139:21:139:44 | call to method ApplyFunc | GlobalDataFlow.cs:139:13:139:44 | SSA def(sink5) |
-| GlobalDataFlow.cs:139:21:139:44 | call to method ApplyFunc | GlobalDataFlow.cs:139:13:139:44 | SSA def(sink5) |
-| GlobalDataFlow.cs:139:21:139:44 | call to method ApplyFunc | GlobalDataFlow.cs:139:21:139:44 | call to method ApplyFunc |
-| GlobalDataFlow.cs:139:21:139:44 | call to method ApplyFunc | GlobalDataFlow.cs:140:15:140:19 | access to local variable sink5 |
-| GlobalDataFlow.cs:139:21:139:44 | call to method ApplyFunc | GlobalDataFlow.cs:140:15:140:19 | access to local variable sink5 |
-| GlobalDataFlow.cs:139:21:139:44 | call to method ApplyFunc | GlobalDataFlow.cs:145:39:145:43 | access to local variable sink5 |
-| GlobalDataFlow.cs:139:21:139:44 | call to method ApplyFunc | GlobalDataFlow.cs:145:39:145:43 | access to local variable sink5 |
-| GlobalDataFlow.cs:139:31:139:36 | access to method Return | GlobalDataFlow.cs:139:31:139:36 | access to method Return |
-| GlobalDataFlow.cs:139:31:139:36 | delegate creation of type Func<String,String> | GlobalDataFlow.cs:139:31:139:36 | delegate creation of type Func<String,String> |
-| GlobalDataFlow.cs:139:31:139:36 | delegate creation of type Func<String,String> | GlobalDataFlow.cs:359:41:359:41 | f |
-| GlobalDataFlow.cs:139:31:139:36 | delegate creation of type Func<String,String> | GlobalDataFlow.cs:359:41:359:41 | f |
-| GlobalDataFlow.cs:139:39:139:43 | access to local variable sink4 | GlobalDataFlow.cs:139:21:139:44 | call to method ApplyFunc |
-| GlobalDataFlow.cs:139:39:139:43 | access to local variable sink4 | GlobalDataFlow.cs:139:21:139:44 | call to method ApplyFunc |
-| GlobalDataFlow.cs:139:39:139:43 | access to local variable sink4 | GlobalDataFlow.cs:139:39:139:43 | access to local variable sink4 |
-| GlobalDataFlow.cs:139:39:139:43 | access to local variable sink4 | GlobalDataFlow.cs:359:46:359:46 | x |
-| GlobalDataFlow.cs:139:39:139:43 | access to local variable sink4 | GlobalDataFlow.cs:359:46:359:46 | x |
-| GlobalDataFlow.cs:140:9:140:20 | call to method Check | GlobalDataFlow.cs:140:9:140:20 | call to method Check |
-| GlobalDataFlow.cs:140:15:140:19 | access to local variable sink5 | GlobalDataFlow.cs:140:15:140:19 | access to local variable sink5 |
-| GlobalDataFlow.cs:140:15:140:19 | access to local variable sink5 | GlobalDataFlow.cs:145:39:145:43 | access to local variable sink5 |
-| GlobalDataFlow.cs:140:15:140:19 | access to local variable sink5 | GlobalDataFlow.cs:145:39:145:43 | access to local variable sink5 |
-| GlobalDataFlow.cs:143:9:143:40 | ... = ... | GlobalDataFlow.cs:143:9:143:40 | ... = ... |
-| GlobalDataFlow.cs:143:9:143:40 | SSA def(nonSink0) | GlobalDataFlow.cs:143:9:143:40 | SSA def(nonSink0) |
-| GlobalDataFlow.cs:143:9:143:40 | SSA def(nonSink0) | GlobalDataFlow.cs:144:15:144:22 | access to local variable nonSink0 |
-| GlobalDataFlow.cs:143:9:143:40 | SSA def(nonSink0) | GlobalDataFlow.cs:144:15:144:22 | access to local variable nonSink0 |
-| GlobalDataFlow.cs:143:20:143:40 | call to method ApplyFunc | GlobalDataFlow.cs:143:9:143:40 | SSA def(nonSink0) |
-| GlobalDataFlow.cs:143:20:143:40 | call to method ApplyFunc | GlobalDataFlow.cs:143:9:143:40 | SSA def(nonSink0) |
-| GlobalDataFlow.cs:143:20:143:40 | call to method ApplyFunc | GlobalDataFlow.cs:143:20:143:40 | call to method ApplyFunc |
-| GlobalDataFlow.cs:143:20:143:40 | call to method ApplyFunc | GlobalDataFlow.cs:144:15:144:22 | access to local variable nonSink0 |
-| GlobalDataFlow.cs:143:20:143:40 | call to method ApplyFunc | GlobalDataFlow.cs:144:15:144:22 | access to local variable nonSink0 |
-| GlobalDataFlow.cs:143:30:143:35 | access to method Return | GlobalDataFlow.cs:143:30:143:35 | access to method Return |
-| GlobalDataFlow.cs:143:30:143:35 | delegate creation of type Func<String,String> | GlobalDataFlow.cs:143:30:143:35 | delegate creation of type Func<String,String> |
-| GlobalDataFlow.cs:143:30:143:35 | delegate creation of type Func<String,String> | GlobalDataFlow.cs:359:41:359:41 | f |
-| GlobalDataFlow.cs:143:30:143:35 | delegate creation of type Func<String,String> | GlobalDataFlow.cs:359:41:359:41 | f |
-| GlobalDataFlow.cs:143:38:143:39 | "" | GlobalDataFlow.cs:143:20:143:40 | call to method ApplyFunc |
-| GlobalDataFlow.cs:143:38:143:39 | "" | GlobalDataFlow.cs:143:20:143:40 | call to method ApplyFunc |
-| GlobalDataFlow.cs:143:38:143:39 | "" | GlobalDataFlow.cs:143:38:143:39 | "" |
-| GlobalDataFlow.cs:143:38:143:39 | "" | GlobalDataFlow.cs:359:46:359:46 | x |
-| GlobalDataFlow.cs:143:38:143:39 | "" | GlobalDataFlow.cs:359:46:359:46 | x |
-| GlobalDataFlow.cs:144:9:144:23 | call to method Check | GlobalDataFlow.cs:144:9:144:23 | call to method Check |
-| GlobalDataFlow.cs:144:15:144:22 | access to local variable nonSink0 | GlobalDataFlow.cs:144:15:144:22 | access to local variable nonSink0 |
-| GlobalDataFlow.cs:145:9:145:44 | ... = ... | GlobalDataFlow.cs:145:9:145:44 | ... = ... |
-| GlobalDataFlow.cs:145:9:145:44 | SSA def(nonSink0) | GlobalDataFlow.cs:145:9:145:44 | SSA def(nonSink0) |
-| GlobalDataFlow.cs:145:9:145:44 | SSA def(nonSink0) | GlobalDataFlow.cs:146:15:146:22 | access to local variable nonSink0 |
-| GlobalDataFlow.cs:145:9:145:44 | SSA def(nonSink0) | GlobalDataFlow.cs:146:15:146:22 | access to local variable nonSink0 |
-| GlobalDataFlow.cs:145:9:145:44 | SSA def(nonSink0) | GlobalDataFlow.cs:159:35:159:42 | access to local variable nonSink0 |
-| GlobalDataFlow.cs:145:9:145:44 | SSA def(nonSink0) | GlobalDataFlow.cs:159:35:159:42 | access to local variable nonSink0 |
-| GlobalDataFlow.cs:145:20:145:44 | call to method ApplyFunc | GlobalDataFlow.cs:145:9:145:44 | SSA def(nonSink0) |
-| GlobalDataFlow.cs:145:20:145:44 | call to method ApplyFunc | GlobalDataFlow.cs:145:9:145:44 | SSA def(nonSink0) |
-| GlobalDataFlow.cs:145:20:145:44 | call to method ApplyFunc | GlobalDataFlow.cs:145:20:145:44 | call to method ApplyFunc |
-| GlobalDataFlow.cs:145:20:145:44 | call to method ApplyFunc | GlobalDataFlow.cs:146:15:146:22 | access to local variable nonSink0 |
-| GlobalDataFlow.cs:145:20:145:44 | call to method ApplyFunc | GlobalDataFlow.cs:146:15:146:22 | access to local variable nonSink0 |
-| GlobalDataFlow.cs:145:20:145:44 | call to method ApplyFunc | GlobalDataFlow.cs:159:35:159:42 | access to local variable nonSink0 |
-| GlobalDataFlow.cs:145:20:145:44 | call to method ApplyFunc | GlobalDataFlow.cs:159:35:159:42 | access to local variable nonSink0 |
-| GlobalDataFlow.cs:145:30:145:36 | (...) => ... | GlobalDataFlow.cs:145:30:145:36 | (...) => ... |
-| GlobalDataFlow.cs:145:30:145:36 | (...) => ... | GlobalDataFlow.cs:359:41:359:41 | f |
-| GlobalDataFlow.cs:145:30:145:36 | (...) => ... | GlobalDataFlow.cs:359:41:359:41 | f |
-| GlobalDataFlow.cs:145:35:145:36 | "" | GlobalDataFlow.cs:145:35:145:36 | "" |
-| GlobalDataFlow.cs:145:35:145:36 | "" | GlobalDataFlow.cs:361:16:361:19 | delegate call |
-| GlobalDataFlow.cs:145:35:145:36 | "" | GlobalDataFlow.cs:361:16:361:19 | delegate call |
-| GlobalDataFlow.cs:145:39:145:43 | access to local variable sink5 | GlobalDataFlow.cs:145:39:145:43 | access to local variable sink5 |
-| GlobalDataFlow.cs:145:39:145:43 | access to local variable sink5 | GlobalDataFlow.cs:359:46:359:46 | x |
-| GlobalDataFlow.cs:145:39:145:43 | access to local variable sink5 | GlobalDataFlow.cs:359:46:359:46 | x |
-| GlobalDataFlow.cs:146:9:146:23 | call to method Check | GlobalDataFlow.cs:146:9:146:23 | call to method Check |
-| GlobalDataFlow.cs:146:15:146:22 | access to local variable nonSink0 | GlobalDataFlow.cs:146:15:146:22 | access to local variable nonSink0 |
-| GlobalDataFlow.cs:146:15:146:22 | access to local variable nonSink0 | GlobalDataFlow.cs:159:35:159:42 | access to local variable nonSink0 |
-| GlobalDataFlow.cs:146:15:146:22 | access to local variable nonSink0 | GlobalDataFlow.cs:159:35:159:42 | access to local variable nonSink0 |
-| GlobalDataFlow.cs:149:13:149:25 | SSA def(sink6) | GlobalDataFlow.cs:149:13:149:25 | SSA def(sink6) |
-| GlobalDataFlow.cs:149:13:149:25 | SSA def(sink6) | GlobalDataFlow.cs:150:15:150:19 | access to local variable sink6 |
-| GlobalDataFlow.cs:149:13:149:25 | SSA def(sink6) | GlobalDataFlow.cs:150:15:150:19 | access to local variable sink6 |
-| GlobalDataFlow.cs:149:13:149:25 | String sink6 = ... | GlobalDataFlow.cs:149:13:149:25 | String sink6 = ... |
-| GlobalDataFlow.cs:149:21:149:25 | call to method Out | GlobalDataFlow.cs:149:13:149:25 | SSA def(sink6) |
-| GlobalDataFlow.cs:149:21:149:25 | call to method Out | GlobalDataFlow.cs:149:13:149:25 | SSA def(sink6) |
-| GlobalDataFlow.cs:149:21:149:25 | call to method Out | GlobalDataFlow.cs:149:21:149:25 | call to method Out |
-| GlobalDataFlow.cs:149:21:149:25 | call to method Out | GlobalDataFlow.cs:150:15:150:19 | access to local variable sink6 |
-| GlobalDataFlow.cs:149:21:149:25 | call to method Out | GlobalDataFlow.cs:150:15:150:19 | access to local variable sink6 |
-| GlobalDataFlow.cs:149:21:149:25 | this access | GlobalDataFlow.cs:149:21:149:25 | this access |
-| GlobalDataFlow.cs:149:21:149:25 | this access | GlobalDataFlow.cs:152:9:152:25 | this access |
-| GlobalDataFlow.cs:149:21:149:25 | this access | GlobalDataFlow.cs:152:9:152:25 | this access |
-| GlobalDataFlow.cs:149:21:149:25 | this access | GlobalDataFlow.cs:155:9:155:25 | this access |
-| GlobalDataFlow.cs:149:21:149:25 | this access | GlobalDataFlow.cs:155:9:155:25 | this access |
-| GlobalDataFlow.cs:149:21:149:25 | this access | GlobalDataFlow.cs:157:22:157:31 | this access |
-| GlobalDataFlow.cs:149:21:149:25 | this access | GlobalDataFlow.cs:157:22:157:31 | this access |
-| GlobalDataFlow.cs:149:21:149:25 | this access | GlobalDataFlow.cs:163:20:163:27 | this access |
-| GlobalDataFlow.cs:149:21:149:25 | this access | GlobalDataFlow.cs:163:20:163:27 | this access |
-| GlobalDataFlow.cs:149:21:149:25 | this access | GlobalDataFlow.cs:165:9:165:31 | this access |
-| GlobalDataFlow.cs:149:21:149:25 | this access | GlobalDataFlow.cs:165:9:165:31 | this access |
-| GlobalDataFlow.cs:149:21:149:25 | this access | GlobalDataFlow.cs:167:9:167:31 | this access |
-| GlobalDataFlow.cs:149:21:149:25 | this access | GlobalDataFlow.cs:167:9:167:31 | this access |
-| GlobalDataFlow.cs:149:21:149:25 | this access | GlobalDataFlow.cs:169:20:169:32 | this access |
-| GlobalDataFlow.cs:149:21:149:25 | this access | GlobalDataFlow.cs:169:20:169:32 | this access |
-| GlobalDataFlow.cs:149:21:149:25 | this access | GlobalDataFlow.cs:185:39:185:41 | this access |
-| GlobalDataFlow.cs:149:21:149:25 | this access | GlobalDataFlow.cs:185:39:185:41 | this access |
-| GlobalDataFlow.cs:149:21:149:25 | this access | GlobalDataFlow.cs:189:37:189:42 | this access |
-| GlobalDataFlow.cs:149:21:149:25 | this access | GlobalDataFlow.cs:189:37:189:42 | this access |
-| GlobalDataFlow.cs:149:21:149:25 | this access | GlobalDataFlow.cs:193:22:193:32 | this access |
-| GlobalDataFlow.cs:149:21:149:25 | this access | GlobalDataFlow.cs:193:22:193:32 | this access |
-| GlobalDataFlow.cs:149:21:149:25 | this access | GlobalDataFlow.cs:197:20:197:33 | this access |
-| GlobalDataFlow.cs:149:21:149:25 | this access | GlobalDataFlow.cs:197:20:197:33 | this access |
-| GlobalDataFlow.cs:149:21:149:25 | this access | GlobalDataFlow.cs:311:12:311:14 | this |
-| GlobalDataFlow.cs:149:21:149:25 | this access | GlobalDataFlow.cs:311:12:311:14 | this |
-| GlobalDataFlow.cs:150:9:150:20 | call to method Check | GlobalDataFlow.cs:150:9:150:20 | call to method Check |
-| GlobalDataFlow.cs:150:15:150:19 | access to local variable sink6 | GlobalDataFlow.cs:150:15:150:19 | access to local variable sink6 |
-| GlobalDataFlow.cs:151:16:151:20 | String sink7 | GlobalDataFlow.cs:151:16:151:20 | String sink7 |
-| GlobalDataFlow.cs:152:9:152:25 | call to method OutOut | GlobalDataFlow.cs:152:9:152:25 | call to method OutOut |
-| GlobalDataFlow.cs:152:9:152:25 | this access | GlobalDataFlow.cs:152:9:152:25 | this access |
-| GlobalDataFlow.cs:152:9:152:25 | this access | GlobalDataFlow.cs:155:9:155:25 | this access |
-| GlobalDataFlow.cs:152:9:152:25 | this access | GlobalDataFlow.cs:155:9:155:25 | this access |
-| GlobalDataFlow.cs:152:9:152:25 | this access | GlobalDataFlow.cs:157:22:157:31 | this access |
-| GlobalDataFlow.cs:152:9:152:25 | this access | GlobalDataFlow.cs:157:22:157:31 | this access |
-| GlobalDataFlow.cs:152:9:152:25 | this access | GlobalDataFlow.cs:163:20:163:27 | this access |
-| GlobalDataFlow.cs:152:9:152:25 | this access | GlobalDataFlow.cs:163:20:163:27 | this access |
-| GlobalDataFlow.cs:152:9:152:25 | this access | GlobalDataFlow.cs:165:9:165:31 | this access |
-| GlobalDataFlow.cs:152:9:152:25 | this access | GlobalDataFlow.cs:165:9:165:31 | this access |
-| GlobalDataFlow.cs:152:9:152:25 | this access | GlobalDataFlow.cs:167:9:167:31 | this access |
-| GlobalDataFlow.cs:152:9:152:25 | this access | GlobalDataFlow.cs:167:9:167:31 | this access |
-| GlobalDataFlow.cs:152:9:152:25 | this access | GlobalDataFlow.cs:169:20:169:32 | this access |
-| GlobalDataFlow.cs:152:9:152:25 | this access | GlobalDataFlow.cs:169:20:169:32 | this access |
-| GlobalDataFlow.cs:152:9:152:25 | this access | GlobalDataFlow.cs:185:39:185:41 | this access |
-| GlobalDataFlow.cs:152:9:152:25 | this access | GlobalDataFlow.cs:185:39:185:41 | this access |
-| GlobalDataFlow.cs:152:9:152:25 | this access | GlobalDataFlow.cs:189:37:189:42 | this access |
-| GlobalDataFlow.cs:152:9:152:25 | this access | GlobalDataFlow.cs:189:37:189:42 | this access |
-| GlobalDataFlow.cs:152:9:152:25 | this access | GlobalDataFlow.cs:193:22:193:32 | this access |
-| GlobalDataFlow.cs:152:9:152:25 | this access | GlobalDataFlow.cs:193:22:193:32 | this access |
-| GlobalDataFlow.cs:152:9:152:25 | this access | GlobalDataFlow.cs:197:20:197:33 | this access |
-| GlobalDataFlow.cs:152:9:152:25 | this access | GlobalDataFlow.cs:197:20:197:33 | this access |
-| GlobalDataFlow.cs:152:9:152:25 | this access | GlobalDataFlow.cs:316:10:316:15 | this |
-| GlobalDataFlow.cs:152:9:152:25 | this access | GlobalDataFlow.cs:316:10:316:15 | this |
-| GlobalDataFlow.cs:152:20:152:24 | SSA def(sink7) | GlobalDataFlow.cs:152:20:152:24 | SSA def(sink7) |
-| GlobalDataFlow.cs:152:20:152:24 | SSA def(sink7) | GlobalDataFlow.cs:153:15:153:19 | access to local variable sink7 |
-| GlobalDataFlow.cs:152:20:152:24 | SSA def(sink7) | GlobalDataFlow.cs:153:15:153:19 | access to local variable sink7 |
-| GlobalDataFlow.cs:153:9:153:20 | call to method Check | GlobalDataFlow.cs:153:9:153:20 | call to method Check |
-| GlobalDataFlow.cs:153:15:153:19 | access to local variable sink7 | GlobalDataFlow.cs:153:15:153:19 | access to local variable sink7 |
-| GlobalDataFlow.cs:154:13:154:22 | SSA def(sink8) | GlobalDataFlow.cs:154:13:154:22 | SSA def(sink8) |
-| GlobalDataFlow.cs:154:13:154:22 | SSA def(sink8) | GlobalDataFlow.cs:155:20:155:24 | access to local variable sink8 |
-| GlobalDataFlow.cs:154:13:154:22 | SSA def(sink8) | GlobalDataFlow.cs:155:20:155:24 | access to local variable sink8 |
-| GlobalDataFlow.cs:154:13:154:22 | String sink8 = ... | GlobalDataFlow.cs:154:13:154:22 | String sink8 = ... |
-| GlobalDataFlow.cs:154:21:154:22 | "" | GlobalDataFlow.cs:154:13:154:22 | SSA def(sink8) |
-| GlobalDataFlow.cs:154:21:154:22 | "" | GlobalDataFlow.cs:154:13:154:22 | SSA def(sink8) |
-| GlobalDataFlow.cs:154:21:154:22 | "" | GlobalDataFlow.cs:154:21:154:22 | "" |
-| GlobalDataFlow.cs:154:21:154:22 | "" | GlobalDataFlow.cs:155:20:155:24 | access to local variable sink8 |
-| GlobalDataFlow.cs:154:21:154:22 | "" | GlobalDataFlow.cs:155:20:155:24 | access to local variable sink8 |
-| GlobalDataFlow.cs:155:9:155:25 | call to method OutRef | GlobalDataFlow.cs:155:9:155:25 | call to method OutRef |
-| GlobalDataFlow.cs:155:9:155:25 | this access | GlobalDataFlow.cs:155:9:155:25 | this access |
-| GlobalDataFlow.cs:155:9:155:25 | this access | GlobalDataFlow.cs:157:22:157:31 | this access |
-| GlobalDataFlow.cs:155:9:155:25 | this access | GlobalDataFlow.cs:157:22:157:31 | this access |
-| GlobalDataFlow.cs:155:9:155:25 | this access | GlobalDataFlow.cs:163:20:163:27 | this access |
-| GlobalDataFlow.cs:155:9:155:25 | this access | GlobalDataFlow.cs:163:20:163:27 | this access |
-| GlobalDataFlow.cs:155:9:155:25 | this access | GlobalDataFlow.cs:165:9:165:31 | this access |
-| GlobalDataFlow.cs:155:9:155:25 | this access | GlobalDataFlow.cs:165:9:165:31 | this access |
-| GlobalDataFlow.cs:155:9:155:25 | this access | GlobalDataFlow.cs:167:9:167:31 | this access |
-| GlobalDataFlow.cs:155:9:155:25 | this access | GlobalDataFlow.cs:167:9:167:31 | this access |
-| GlobalDataFlow.cs:155:9:155:25 | this access | GlobalDataFlow.cs:169:20:169:32 | this access |
-| GlobalDataFlow.cs:155:9:155:25 | this access | GlobalDataFlow.cs:169:20:169:32 | this access |
-| GlobalDataFlow.cs:155:9:155:25 | this access | GlobalDataFlow.cs:185:39:185:41 | this access |
-| GlobalDataFlow.cs:155:9:155:25 | this access | GlobalDataFlow.cs:185:39:185:41 | this access |
-| GlobalDataFlow.cs:155:9:155:25 | this access | GlobalDataFlow.cs:189:37:189:42 | this access |
-| GlobalDataFlow.cs:155:9:155:25 | this access | GlobalDataFlow.cs:189:37:189:42 | this access |
-| GlobalDataFlow.cs:155:9:155:25 | this access | GlobalDataFlow.cs:193:22:193:32 | this access |
-| GlobalDataFlow.cs:155:9:155:25 | this access | GlobalDataFlow.cs:193:22:193:32 | this access |
-| GlobalDataFlow.cs:155:9:155:25 | this access | GlobalDataFlow.cs:197:20:197:33 | this access |
-| GlobalDataFlow.cs:155:9:155:25 | this access | GlobalDataFlow.cs:197:20:197:33 | this access |
-| GlobalDataFlow.cs:155:9:155:25 | this access | GlobalDataFlow.cs:321:10:321:15 | this |
-| GlobalDataFlow.cs:155:9:155:25 | this access | GlobalDataFlow.cs:321:10:321:15 | this |
-| GlobalDataFlow.cs:155:20:155:24 | SSA def(sink8) | GlobalDataFlow.cs:155:20:155:24 | SSA def(sink8) |
-| GlobalDataFlow.cs:155:20:155:24 | SSA def(sink8) | GlobalDataFlow.cs:156:15:156:19 | access to local variable sink8 |
-| GlobalDataFlow.cs:155:20:155:24 | SSA def(sink8) | GlobalDataFlow.cs:156:15:156:19 | access to local variable sink8 |
-| GlobalDataFlow.cs:155:20:155:24 | access to local variable sink8 | GlobalDataFlow.cs:155:20:155:24 | access to local variable sink8 |
-| GlobalDataFlow.cs:156:9:156:20 | call to method Check | GlobalDataFlow.cs:156:9:156:20 | call to method Check |
-| GlobalDataFlow.cs:156:15:156:19 | access to local variable sink8 | GlobalDataFlow.cs:156:15:156:19 | access to local variable sink8 |
-| GlobalDataFlow.cs:157:13:157:31 | IEnumerable<String> sink12 = ... | GlobalDataFlow.cs:157:13:157:31 | IEnumerable<String> sink12 = ... |
-| GlobalDataFlow.cs:157:13:157:31 | SSA def(sink12) | GlobalDataFlow.cs:157:13:157:31 | SSA def(sink12) |
-| GlobalDataFlow.cs:157:13:157:31 | SSA def(sink12) | GlobalDataFlow.cs:158:15:158:20 | access to local variable sink12 |
-| GlobalDataFlow.cs:157:13:157:31 | SSA def(sink12) | GlobalDataFlow.cs:158:15:158:20 | access to local variable sink12 |
-| GlobalDataFlow.cs:157:22:157:31 | call to method OutYield | GlobalDataFlow.cs:157:13:157:31 | SSA def(sink12) |
-| GlobalDataFlow.cs:157:22:157:31 | call to method OutYield | GlobalDataFlow.cs:157:13:157:31 | SSA def(sink12) |
-| GlobalDataFlow.cs:157:22:157:31 | call to method OutYield | GlobalDataFlow.cs:157:22:157:31 | call to method OutYield |
-| GlobalDataFlow.cs:157:22:157:31 | call to method OutYield | GlobalDataFlow.cs:158:15:158:20 | access to local variable sink12 |
-| GlobalDataFlow.cs:157:22:157:31 | call to method OutYield | GlobalDataFlow.cs:158:15:158:20 | access to local variable sink12 |
-| GlobalDataFlow.cs:157:22:157:31 | this access | GlobalDataFlow.cs:157:22:157:31 | this access |
-| GlobalDataFlow.cs:157:22:157:31 | this access | GlobalDataFlow.cs:163:20:163:27 | this access |
-| GlobalDataFlow.cs:157:22:157:31 | this access | GlobalDataFlow.cs:163:20:163:27 | this access |
-| GlobalDataFlow.cs:157:22:157:31 | this access | GlobalDataFlow.cs:165:9:165:31 | this access |
-| GlobalDataFlow.cs:157:22:157:31 | this access | GlobalDataFlow.cs:165:9:165:31 | this access |
-| GlobalDataFlow.cs:157:22:157:31 | this access | GlobalDataFlow.cs:167:9:167:31 | this access |
-| GlobalDataFlow.cs:157:22:157:31 | this access | GlobalDataFlow.cs:167:9:167:31 | this access |
-| GlobalDataFlow.cs:157:22:157:31 | this access | GlobalDataFlow.cs:169:20:169:32 | this access |
-| GlobalDataFlow.cs:157:22:157:31 | this access | GlobalDataFlow.cs:169:20:169:32 | this access |
-| GlobalDataFlow.cs:157:22:157:31 | this access | GlobalDataFlow.cs:185:39:185:41 | this access |
-| GlobalDataFlow.cs:157:22:157:31 | this access | GlobalDataFlow.cs:185:39:185:41 | this access |
-| GlobalDataFlow.cs:157:22:157:31 | this access | GlobalDataFlow.cs:189:37:189:42 | this access |
-| GlobalDataFlow.cs:157:22:157:31 | this access | GlobalDataFlow.cs:189:37:189:42 | this access |
-| GlobalDataFlow.cs:157:22:157:31 | this access | GlobalDataFlow.cs:193:22:193:32 | this access |
-| GlobalDataFlow.cs:157:22:157:31 | this access | GlobalDataFlow.cs:193:22:193:32 | this access |
-| GlobalDataFlow.cs:157:22:157:31 | this access | GlobalDataFlow.cs:197:20:197:33 | this access |
-| GlobalDataFlow.cs:157:22:157:31 | this access | GlobalDataFlow.cs:197:20:197:33 | this access |
-| GlobalDataFlow.cs:157:22:157:31 | this access | GlobalDataFlow.cs:326:25:326:32 | this |
-| GlobalDataFlow.cs:157:22:157:31 | this access | GlobalDataFlow.cs:326:25:326:32 | this |
-| GlobalDataFlow.cs:158:9:158:21 | call to method Check | GlobalDataFlow.cs:158:9:158:21 | call to method Check |
-| GlobalDataFlow.cs:158:15:158:20 | access to local variable sink12 | GlobalDataFlow.cs:158:15:158:20 | access to local variable sink12 |
-| GlobalDataFlow.cs:159:13:159:43 | SSA def(sink23) | GlobalDataFlow.cs:159:13:159:43 | SSA def(sink23) |
-| GlobalDataFlow.cs:159:13:159:43 | SSA def(sink23) | GlobalDataFlow.cs:160:15:160:20 | access to local variable sink23 |
-| GlobalDataFlow.cs:159:13:159:43 | SSA def(sink23) | GlobalDataFlow.cs:160:15:160:20 | access to local variable sink23 |
-| GlobalDataFlow.cs:159:13:159:43 | String sink23 = ... | GlobalDataFlow.cs:159:13:159:43 | String sink23 = ... |
-| GlobalDataFlow.cs:159:22:159:43 | call to method TaintedParam | GlobalDataFlow.cs:159:13:159:43 | SSA def(sink23) |
-| GlobalDataFlow.cs:159:22:159:43 | call to method TaintedParam | GlobalDataFlow.cs:159:13:159:43 | SSA def(sink23) |
-| GlobalDataFlow.cs:159:22:159:43 | call to method TaintedParam | GlobalDataFlow.cs:159:22:159:43 | call to method TaintedParam |
-| GlobalDataFlow.cs:159:22:159:43 | call to method TaintedParam | GlobalDataFlow.cs:160:15:160:20 | access to local variable sink23 |
-| GlobalDataFlow.cs:159:22:159:43 | call to method TaintedParam | GlobalDataFlow.cs:160:15:160:20 | access to local variable sink23 |
-| GlobalDataFlow.cs:159:35:159:42 | access to local variable nonSink0 | GlobalDataFlow.cs:159:22:159:43 | call to method TaintedParam |
-| GlobalDataFlow.cs:159:35:159:42 | access to local variable nonSink0 | GlobalDataFlow.cs:159:22:159:43 | call to method TaintedParam |
-| GlobalDataFlow.cs:159:35:159:42 | access to local variable nonSink0 | GlobalDataFlow.cs:159:35:159:42 | access to local variable nonSink0 |
-| GlobalDataFlow.cs:159:35:159:42 | access to local variable nonSink0 | GlobalDataFlow.cs:373:39:373:45 | tainted |
-| GlobalDataFlow.cs:159:35:159:42 | access to local variable nonSink0 | GlobalDataFlow.cs:373:39:373:45 | tainted |
-| GlobalDataFlow.cs:160:9:160:21 | call to method Check | GlobalDataFlow.cs:160:9:160:21 | call to method Check |
-| GlobalDataFlow.cs:160:15:160:20 | access to local variable sink23 | GlobalDataFlow.cs:160:15:160:20 | access to local variable sink23 |
-| GlobalDataFlow.cs:163:9:163:27 | ... = ... | GlobalDataFlow.cs:163:9:163:27 | ... = ... |
-| GlobalDataFlow.cs:163:9:163:27 | SSA def(nonSink0) | GlobalDataFlow.cs:163:9:163:27 | SSA def(nonSink0) |
-| GlobalDataFlow.cs:163:9:163:27 | SSA def(nonSink0) | GlobalDataFlow.cs:164:15:164:22 | access to local variable nonSink0 |
-| GlobalDataFlow.cs:163:9:163:27 | SSA def(nonSink0) | GlobalDataFlow.cs:164:15:164:22 | access to local variable nonSink0 |
-| GlobalDataFlow.cs:163:20:163:27 | call to method NonOut | GlobalDataFlow.cs:163:9:163:27 | SSA def(nonSink0) |
-| GlobalDataFlow.cs:163:20:163:27 | call to method NonOut | GlobalDataFlow.cs:163:9:163:27 | SSA def(nonSink0) |
-| GlobalDataFlow.cs:163:20:163:27 | call to method NonOut | GlobalDataFlow.cs:163:20:163:27 | call to method NonOut |
-| GlobalDataFlow.cs:163:20:163:27 | call to method NonOut | GlobalDataFlow.cs:164:15:164:22 | access to local variable nonSink0 |
-| GlobalDataFlow.cs:163:20:163:27 | call to method NonOut | GlobalDataFlow.cs:164:15:164:22 | access to local variable nonSink0 |
-| GlobalDataFlow.cs:163:20:163:27 | this access | GlobalDataFlow.cs:163:20:163:27 | this access |
-| GlobalDataFlow.cs:163:20:163:27 | this access | GlobalDataFlow.cs:165:9:165:31 | this access |
-| GlobalDataFlow.cs:163:20:163:27 | this access | GlobalDataFlow.cs:165:9:165:31 | this access |
-| GlobalDataFlow.cs:163:20:163:27 | this access | GlobalDataFlow.cs:167:9:167:31 | this access |
-| GlobalDataFlow.cs:163:20:163:27 | this access | GlobalDataFlow.cs:167:9:167:31 | this access |
-| GlobalDataFlow.cs:163:20:163:27 | this access | GlobalDataFlow.cs:169:20:169:32 | this access |
-| GlobalDataFlow.cs:163:20:163:27 | this access | GlobalDataFlow.cs:169:20:169:32 | this access |
-| GlobalDataFlow.cs:163:20:163:27 | this access | GlobalDataFlow.cs:185:39:185:41 | this access |
-| GlobalDataFlow.cs:163:20:163:27 | this access | GlobalDataFlow.cs:185:39:185:41 | this access |
-| GlobalDataFlow.cs:163:20:163:27 | this access | GlobalDataFlow.cs:189:37:189:42 | this access |
-| GlobalDataFlow.cs:163:20:163:27 | this access | GlobalDataFlow.cs:189:37:189:42 | this access |
-| GlobalDataFlow.cs:163:20:163:27 | this access | GlobalDataFlow.cs:193:22:193:32 | this access |
-| GlobalDataFlow.cs:163:20:163:27 | this access | GlobalDataFlow.cs:193:22:193:32 | this access |
-| GlobalDataFlow.cs:163:20:163:27 | this access | GlobalDataFlow.cs:197:20:197:33 | this access |
-| GlobalDataFlow.cs:163:20:163:27 | this access | GlobalDataFlow.cs:197:20:197:33 | this access |
-| GlobalDataFlow.cs:163:20:163:27 | this access | GlobalDataFlow.cs:333:12:333:17 | this |
-| GlobalDataFlow.cs:163:20:163:27 | this access | GlobalDataFlow.cs:333:12:333:17 | this |
-| GlobalDataFlow.cs:164:9:164:23 | call to method Check | GlobalDataFlow.cs:164:9:164:23 | call to method Check |
-| GlobalDataFlow.cs:164:15:164:22 | access to local variable nonSink0 | GlobalDataFlow.cs:164:15:164:22 | access to local variable nonSink0 |
-| GlobalDataFlow.cs:165:9:165:31 | call to method NonOutOut | GlobalDataFlow.cs:165:9:165:31 | call to method NonOutOut |
-| GlobalDataFlow.cs:165:9:165:31 | this access | GlobalDataFlow.cs:165:9:165:31 | this access |
-| GlobalDataFlow.cs:165:9:165:31 | this access | GlobalDataFlow.cs:167:9:167:31 | this access |
-| GlobalDataFlow.cs:165:9:165:31 | this access | GlobalDataFlow.cs:167:9:167:31 | this access |
-| GlobalDataFlow.cs:165:9:165:31 | this access | GlobalDataFlow.cs:169:20:169:32 | this access |
-| GlobalDataFlow.cs:165:9:165:31 | this access | GlobalDataFlow.cs:169:20:169:32 | this access |
-| GlobalDataFlow.cs:165:9:165:31 | this access | GlobalDataFlow.cs:185:39:185:41 | this access |
-| GlobalDataFlow.cs:165:9:165:31 | this access | GlobalDataFlow.cs:185:39:185:41 | this access |
-| GlobalDataFlow.cs:165:9:165:31 | this access | GlobalDataFlow.cs:189:37:189:42 | this access |
-| GlobalDataFlow.cs:165:9:165:31 | this access | GlobalDataFlow.cs:189:37:189:42 | this access |
-| GlobalDataFlow.cs:165:9:165:31 | this access | GlobalDataFlow.cs:193:22:193:32 | this access |
-| GlobalDataFlow.cs:165:9:165:31 | this access | GlobalDataFlow.cs:193:22:193:32 | this access |
-| GlobalDataFlow.cs:165:9:165:31 | this access | GlobalDataFlow.cs:197:20:197:33 | this access |
-| GlobalDataFlow.cs:165:9:165:31 | this access | GlobalDataFlow.cs:197:20:197:33 | this access |
-| GlobalDataFlow.cs:165:9:165:31 | this access | GlobalDataFlow.cs:338:10:338:18 | this |
-| GlobalDataFlow.cs:165:9:165:31 | this access | GlobalDataFlow.cs:338:10:338:18 | this |
-| GlobalDataFlow.cs:165:23:165:30 | SSA def(nonSink0) | GlobalDataFlow.cs:165:23:165:30 | SSA def(nonSink0) |
-| GlobalDataFlow.cs:165:23:165:30 | SSA def(nonSink0) | GlobalDataFlow.cs:166:15:166:22 | access to local variable nonSink0 |
-| GlobalDataFlow.cs:165:23:165:30 | SSA def(nonSink0) | GlobalDataFlow.cs:166:15:166:22 | access to local variable nonSink0 |
-| GlobalDataFlow.cs:165:23:165:30 | SSA def(nonSink0) | GlobalDataFlow.cs:167:23:167:30 | access to local variable nonSink0 |
-| GlobalDataFlow.cs:165:23:165:30 | SSA def(nonSink0) | GlobalDataFlow.cs:167:23:167:30 | access to local variable nonSink0 |
-| GlobalDataFlow.cs:166:9:166:23 | call to method Check | GlobalDataFlow.cs:166:9:166:23 | call to method Check |
-| GlobalDataFlow.cs:166:15:166:22 | access to local variable nonSink0 | GlobalDataFlow.cs:166:15:166:22 | access to local variable nonSink0 |
-| GlobalDataFlow.cs:166:15:166:22 | access to local variable nonSink0 | GlobalDataFlow.cs:167:23:167:30 | access to local variable nonSink0 |
-| GlobalDataFlow.cs:166:15:166:22 | access to local variable nonSink0 | GlobalDataFlow.cs:167:23:167:30 | access to local variable nonSink0 |
-| GlobalDataFlow.cs:167:9:167:31 | call to method NonOutRef | GlobalDataFlow.cs:167:9:167:31 | call to method NonOutRef |
-| GlobalDataFlow.cs:167:9:167:31 | this access | GlobalDataFlow.cs:167:9:167:31 | this access |
-| GlobalDataFlow.cs:167:9:167:31 | this access | GlobalDataFlow.cs:169:20:169:32 | this access |
-| GlobalDataFlow.cs:167:9:167:31 | this access | GlobalDataFlow.cs:169:20:169:32 | this access |
-| GlobalDataFlow.cs:167:9:167:31 | this access | GlobalDataFlow.cs:185:39:185:41 | this access |
-| GlobalDataFlow.cs:167:9:167:31 | this access | GlobalDataFlow.cs:185:39:185:41 | this access |
-| GlobalDataFlow.cs:167:9:167:31 | this access | GlobalDataFlow.cs:189:37:189:42 | this access |
-| GlobalDataFlow.cs:167:9:167:31 | this access | GlobalDataFlow.cs:189:37:189:42 | this access |
-| GlobalDataFlow.cs:167:9:167:31 | this access | GlobalDataFlow.cs:193:22:193:32 | this access |
-| GlobalDataFlow.cs:167:9:167:31 | this access | GlobalDataFlow.cs:193:22:193:32 | this access |
-| GlobalDataFlow.cs:167:9:167:31 | this access | GlobalDataFlow.cs:197:20:197:33 | this access |
-| GlobalDataFlow.cs:167:9:167:31 | this access | GlobalDataFlow.cs:197:20:197:33 | this access |
-| GlobalDataFlow.cs:167:9:167:31 | this access | GlobalDataFlow.cs:343:10:343:18 | this |
-| GlobalDataFlow.cs:167:9:167:31 | this access | GlobalDataFlow.cs:343:10:343:18 | this |
-| GlobalDataFlow.cs:167:23:167:30 | SSA def(nonSink0) | GlobalDataFlow.cs:167:23:167:30 | SSA def(nonSink0) |
-| GlobalDataFlow.cs:167:23:167:30 | SSA def(nonSink0) | GlobalDataFlow.cs:168:15:168:22 | access to local variable nonSink0 |
-| GlobalDataFlow.cs:167:23:167:30 | SSA def(nonSink0) | GlobalDataFlow.cs:168:15:168:22 | access to local variable nonSink0 |
-| GlobalDataFlow.cs:167:23:167:30 | access to local variable nonSink0 | GlobalDataFlow.cs:167:23:167:30 | access to local variable nonSink0 |
+| GlobalDataFlow.cs:122:9:122:69 | ... = ... | GlobalDataFlow.cs:122:9:122:69 | ... = ... |
+| GlobalDataFlow.cs:122:9:122:69 | SSA def(nonSink0) | GlobalDataFlow.cs:122:9:122:69 | SSA def(nonSink0) |
+| GlobalDataFlow.cs:122:9:122:69 | SSA def(nonSink0) | GlobalDataFlow.cs:123:15:123:22 | access to local variable nonSink0 |
+| GlobalDataFlow.cs:122:9:122:69 | SSA def(nonSink0) | GlobalDataFlow.cs:123:15:123:22 | access to local variable nonSink0 |
+| GlobalDataFlow.cs:122:20:122:25 | access to local variable sink14 | GlobalDataFlow.cs:122:20:122:25 | access to local variable sink14 |
+| GlobalDataFlow.cs:122:20:122:25 | access to local variable sink14 | GlobalDataFlow.cs:122:41:122:59 | [output] (...) => ... |
+| GlobalDataFlow.cs:122:20:122:25 | access to local variable sink14 | GlobalDataFlow.cs:122:41:122:59 | [output] (...) => ... |
+| GlobalDataFlow.cs:122:20:122:25 | access to local variable sink14 | GlobalDataFlow.cs:122:47:122:47 | s |
+| GlobalDataFlow.cs:122:20:122:25 | access to local variable sink14 | GlobalDataFlow.cs:122:47:122:47 | s |
+| GlobalDataFlow.cs:122:20:122:69 | call to method Aggregate | GlobalDataFlow.cs:122:9:122:69 | SSA def(nonSink0) |
+| GlobalDataFlow.cs:122:20:122:69 | call to method Aggregate | GlobalDataFlow.cs:122:9:122:69 | SSA def(nonSink0) |
+| GlobalDataFlow.cs:122:20:122:69 | call to method Aggregate | GlobalDataFlow.cs:122:20:122:69 | call to method Aggregate |
+| GlobalDataFlow.cs:122:20:122:69 | call to method Aggregate | GlobalDataFlow.cs:123:15:123:22 | access to local variable nonSink0 |
+| GlobalDataFlow.cs:122:20:122:69 | call to method Aggregate | GlobalDataFlow.cs:123:15:123:22 | access to local variable nonSink0 |
+| GlobalDataFlow.cs:122:37:122:38 | "" | GlobalDataFlow.cs:122:37:122:38 | "" |
+| GlobalDataFlow.cs:122:37:122:38 | "" | GlobalDataFlow.cs:122:41:122:59 | [output] (...) => ... |
+| GlobalDataFlow.cs:122:37:122:38 | "" | GlobalDataFlow.cs:122:41:122:59 | [output] (...) => ... |
+| GlobalDataFlow.cs:122:37:122:38 | "" | GlobalDataFlow.cs:122:42:122:44 | acc |
+| GlobalDataFlow.cs:122:37:122:38 | "" | GlobalDataFlow.cs:122:42:122:44 | acc |
+| GlobalDataFlow.cs:122:41:122:59 | (...) => ... | GlobalDataFlow.cs:122:41:122:59 | (...) => ... |
+| GlobalDataFlow.cs:122:41:122:59 | [output] (...) => ... | GlobalDataFlow.cs:122:41:122:59 | [output] (...) => ... |
+| GlobalDataFlow.cs:122:42:122:44 | acc | GlobalDataFlow.cs:122:42:122:44 | acc |
+| GlobalDataFlow.cs:122:42:122:44 | acc | GlobalDataFlow.cs:122:42:122:44 | acc |
+| GlobalDataFlow.cs:122:42:122:44 | acc | GlobalDataFlow.cs:122:42:122:44 | acc |
+| GlobalDataFlow.cs:122:42:122:44 | acc | GlobalDataFlow.cs:122:42:122:44 | acc |
+| GlobalDataFlow.cs:122:42:122:44 | acc | GlobalDataFlow.cs:122:42:122:44 | acc |
+| GlobalDataFlow.cs:122:42:122:44 | acc | GlobalDataFlow.cs:122:42:122:44 | acc |
+| GlobalDataFlow.cs:122:42:122:44 | acc | GlobalDataFlow.cs:122:53:122:55 | access to parameter acc |
+| GlobalDataFlow.cs:122:42:122:44 | acc | GlobalDataFlow.cs:122:53:122:55 | access to parameter acc |
+| GlobalDataFlow.cs:122:42:122:44 | acc | GlobalDataFlow.cs:122:53:122:55 | access to parameter acc |
+| GlobalDataFlow.cs:122:42:122:44 | acc | GlobalDataFlow.cs:122:53:122:55 | access to parameter acc |
+| GlobalDataFlow.cs:122:42:122:44 | acc | GlobalDataFlow.cs:122:53:122:55 | access to parameter acc |
+| GlobalDataFlow.cs:122:42:122:44 | acc | GlobalDataFlow.cs:122:53:122:55 | access to parameter acc |
+| GlobalDataFlow.cs:122:42:122:44 | acc | GlobalDataFlow.cs:122:53:122:55 | access to parameter acc |
+| GlobalDataFlow.cs:122:42:122:44 | acc | GlobalDataFlow.cs:122:53:122:55 | access to parameter acc |
+| GlobalDataFlow.cs:122:42:122:44 | acc | GlobalDataFlow.cs:122:53:122:59 | ... + ... |
+| GlobalDataFlow.cs:122:42:122:44 | acc | GlobalDataFlow.cs:122:53:122:59 | ... + ... |
+| GlobalDataFlow.cs:122:42:122:44 | acc | GlobalDataFlow.cs:122:53:122:59 | ... + ... |
+| GlobalDataFlow.cs:122:42:122:44 | acc | GlobalDataFlow.cs:122:53:122:59 | ... + ... |
+| GlobalDataFlow.cs:122:42:122:44 | acc | GlobalDataFlow.cs:122:53:122:59 | ... + ... |
+| GlobalDataFlow.cs:122:42:122:44 | acc | GlobalDataFlow.cs:122:53:122:59 | ... + ... |
+| GlobalDataFlow.cs:122:42:122:44 | acc | GlobalDataFlow.cs:122:53:122:59 | ... + ... |
+| GlobalDataFlow.cs:122:42:122:44 | acc | GlobalDataFlow.cs:122:53:122:59 | ... + ... |
+| GlobalDataFlow.cs:122:47:122:47 | s | GlobalDataFlow.cs:122:47:122:47 | s |
+| GlobalDataFlow.cs:122:47:122:47 | s | GlobalDataFlow.cs:122:47:122:47 | s |
+| GlobalDataFlow.cs:122:47:122:47 | s | GlobalDataFlow.cs:122:47:122:47 | s |
+| GlobalDataFlow.cs:122:47:122:47 | s | GlobalDataFlow.cs:122:47:122:47 | s |
+| GlobalDataFlow.cs:122:47:122:47 | s | GlobalDataFlow.cs:122:47:122:47 | s |
+| GlobalDataFlow.cs:122:47:122:47 | s | GlobalDataFlow.cs:122:47:122:47 | s |
+| GlobalDataFlow.cs:122:47:122:47 | s | GlobalDataFlow.cs:122:53:122:59 | ... + ... |
+| GlobalDataFlow.cs:122:47:122:47 | s | GlobalDataFlow.cs:122:53:122:59 | ... + ... |
+| GlobalDataFlow.cs:122:47:122:47 | s | GlobalDataFlow.cs:122:53:122:59 | ... + ... |
+| GlobalDataFlow.cs:122:47:122:47 | s | GlobalDataFlow.cs:122:53:122:59 | ... + ... |
+| GlobalDataFlow.cs:122:47:122:47 | s | GlobalDataFlow.cs:122:53:122:59 | ... + ... |
+| GlobalDataFlow.cs:122:47:122:47 | s | GlobalDataFlow.cs:122:53:122:59 | ... + ... |
+| GlobalDataFlow.cs:122:47:122:47 | s | GlobalDataFlow.cs:122:53:122:59 | ... + ... |
+| GlobalDataFlow.cs:122:47:122:47 | s | GlobalDataFlow.cs:122:53:122:59 | ... + ... |
+| GlobalDataFlow.cs:122:47:122:47 | s | GlobalDataFlow.cs:122:59:122:59 | access to parameter s |
+| GlobalDataFlow.cs:122:47:122:47 | s | GlobalDataFlow.cs:122:59:122:59 | access to parameter s |
+| GlobalDataFlow.cs:122:47:122:47 | s | GlobalDataFlow.cs:122:59:122:59 | access to parameter s |
+| GlobalDataFlow.cs:122:47:122:47 | s | GlobalDataFlow.cs:122:59:122:59 | access to parameter s |
+| GlobalDataFlow.cs:122:47:122:47 | s | GlobalDataFlow.cs:122:59:122:59 | access to parameter s |
+| GlobalDataFlow.cs:122:47:122:47 | s | GlobalDataFlow.cs:122:59:122:59 | access to parameter s |
+| GlobalDataFlow.cs:122:47:122:47 | s | GlobalDataFlow.cs:122:59:122:59 | access to parameter s |
+| GlobalDataFlow.cs:122:47:122:47 | s | GlobalDataFlow.cs:122:59:122:59 | access to parameter s |
+| GlobalDataFlow.cs:122:53:122:55 | access to parameter acc | GlobalDataFlow.cs:122:53:122:55 | access to parameter acc |
+| GlobalDataFlow.cs:122:53:122:55 | access to parameter acc | GlobalDataFlow.cs:122:53:122:59 | ... + ... |
+| GlobalDataFlow.cs:122:53:122:55 | access to parameter acc | GlobalDataFlow.cs:122:53:122:59 | ... + ... |
+| GlobalDataFlow.cs:122:53:122:55 | access to parameter acc | GlobalDataFlow.cs:122:53:122:59 | ... + ... |
+| GlobalDataFlow.cs:122:53:122:55 | access to parameter acc | GlobalDataFlow.cs:122:53:122:59 | ... + ... |
+| GlobalDataFlow.cs:122:53:122:59 | ... + ... | GlobalDataFlow.cs:122:41:122:59 | [output] (...) => ... |
+| GlobalDataFlow.cs:122:53:122:59 | ... + ... | GlobalDataFlow.cs:122:41:122:59 | [output] (...) => ... |
+| GlobalDataFlow.cs:122:53:122:59 | ... + ... | GlobalDataFlow.cs:122:53:122:59 | ... + ... |
+| GlobalDataFlow.cs:122:59:122:59 | access to parameter s | GlobalDataFlow.cs:122:53:122:59 | ... + ... |
+| GlobalDataFlow.cs:122:59:122:59 | access to parameter s | GlobalDataFlow.cs:122:53:122:59 | ... + ... |
+| GlobalDataFlow.cs:122:59:122:59 | access to parameter s | GlobalDataFlow.cs:122:53:122:59 | ... + ... |
+| GlobalDataFlow.cs:122:59:122:59 | access to parameter s | GlobalDataFlow.cs:122:53:122:59 | ... + ... |
+| GlobalDataFlow.cs:122:59:122:59 | access to parameter s | GlobalDataFlow.cs:122:59:122:59 | access to parameter s |
+| GlobalDataFlow.cs:122:62:122:68 | (...) => ... | GlobalDataFlow.cs:122:62:122:68 | (...) => ... |
+| GlobalDataFlow.cs:122:62:122:68 | [output] (...) => ... | GlobalDataFlow.cs:122:9:122:69 | SSA def(nonSink0) |
+| GlobalDataFlow.cs:122:62:122:68 | [output] (...) => ... | GlobalDataFlow.cs:122:9:122:69 | SSA def(nonSink0) |
+| GlobalDataFlow.cs:122:62:122:68 | [output] (...) => ... | GlobalDataFlow.cs:122:20:122:69 | call to method Aggregate |
+| GlobalDataFlow.cs:122:62:122:68 | [output] (...) => ... | GlobalDataFlow.cs:122:20:122:69 | call to method Aggregate |
+| GlobalDataFlow.cs:122:62:122:68 | [output] (...) => ... | GlobalDataFlow.cs:122:62:122:68 | [output] (...) => ... |
+| GlobalDataFlow.cs:122:62:122:68 | [output] (...) => ... | GlobalDataFlow.cs:123:15:123:22 | access to local variable nonSink0 |
+| GlobalDataFlow.cs:122:62:122:68 | [output] (...) => ... | GlobalDataFlow.cs:123:15:123:22 | access to local variable nonSink0 |
+| GlobalDataFlow.cs:122:67:122:68 | "" | GlobalDataFlow.cs:122:62:122:68 | [output] (...) => ... |
+| GlobalDataFlow.cs:122:67:122:68 | "" | GlobalDataFlow.cs:122:62:122:68 | [output] (...) => ... |
+| GlobalDataFlow.cs:122:67:122:68 | "" | GlobalDataFlow.cs:122:67:122:68 | "" |
+| GlobalDataFlow.cs:123:9:123:23 | call to method Check | GlobalDataFlow.cs:123:9:123:23 | call to method Check |
+| GlobalDataFlow.cs:123:15:123:22 | access to local variable nonSink0 | GlobalDataFlow.cs:123:15:123:22 | access to local variable nonSink0 |
+| GlobalDataFlow.cs:124:9:124:67 | ... = ... | GlobalDataFlow.cs:124:9:124:67 | ... = ... |
+| GlobalDataFlow.cs:124:9:124:67 | SSA def(nonSink0) | GlobalDataFlow.cs:124:9:124:67 | SSA def(nonSink0) |
+| GlobalDataFlow.cs:124:9:124:67 | SSA def(nonSink0) | GlobalDataFlow.cs:125:15:125:22 | access to local variable nonSink0 |
+| GlobalDataFlow.cs:124:9:124:67 | SSA def(nonSink0) | GlobalDataFlow.cs:125:15:125:22 | access to local variable nonSink0 |
+| GlobalDataFlow.cs:124:9:124:67 | SSA def(nonSink0) | GlobalDataFlow.cs:127:9:127:46 | call to method TryParse |
+| GlobalDataFlow.cs:124:9:124:67 | SSA def(nonSink0) | GlobalDataFlow.cs:127:9:127:46 | call to method TryParse |
+| GlobalDataFlow.cs:124:9:124:67 | SSA def(nonSink0) | GlobalDataFlow.cs:127:24:127:31 | access to local variable nonSink0 |
+| GlobalDataFlow.cs:124:9:124:67 | SSA def(nonSink0) | GlobalDataFlow.cs:127:24:127:31 | access to local variable nonSink0 |
+| GlobalDataFlow.cs:124:9:124:67 | SSA def(nonSink0) | GlobalDataFlow.cs:127:38:127:45 | SSA def(nonSink2) |
+| GlobalDataFlow.cs:124:9:124:67 | SSA def(nonSink0) | GlobalDataFlow.cs:127:38:127:45 | SSA def(nonSink2) |
+| GlobalDataFlow.cs:124:9:124:67 | SSA def(nonSink0) | GlobalDataFlow.cs:128:15:128:22 | access to local variable nonSink2 |
+| GlobalDataFlow.cs:124:9:124:67 | SSA def(nonSink0) | GlobalDataFlow.cs:128:15:128:22 | access to local variable nonSink2 |
+| GlobalDataFlow.cs:124:9:124:67 | SSA def(nonSink0) | GlobalDataFlow.cs:130:9:130:45 | call to method TryParse |
+| GlobalDataFlow.cs:124:9:124:67 | SSA def(nonSink0) | GlobalDataFlow.cs:130:9:130:45 | call to method TryParse |
+| GlobalDataFlow.cs:124:9:124:67 | SSA def(nonSink0) | GlobalDataFlow.cs:130:23:130:30 | access to local variable nonSink0 |
+| GlobalDataFlow.cs:124:9:124:67 | SSA def(nonSink0) | GlobalDataFlow.cs:130:23:130:30 | access to local variable nonSink0 |
+| GlobalDataFlow.cs:124:9:124:67 | SSA def(nonSink0) | GlobalDataFlow.cs:130:37:130:44 | SSA def(nonSink3) |
+| GlobalDataFlow.cs:124:9:124:67 | SSA def(nonSink0) | GlobalDataFlow.cs:130:37:130:44 | SSA def(nonSink3) |
+| GlobalDataFlow.cs:124:9:124:67 | SSA def(nonSink0) | GlobalDataFlow.cs:131:15:131:22 | access to local variable nonSink3 |
+| GlobalDataFlow.cs:124:9:124:67 | SSA def(nonSink0) | GlobalDataFlow.cs:131:15:131:22 | access to local variable nonSink3 |
+| GlobalDataFlow.cs:124:9:124:67 | SSA def(nonSink0) | GlobalDataFlow.cs:139:28:139:35 | access to local variable nonSink0 |
+| GlobalDataFlow.cs:124:9:124:67 | SSA def(nonSink0) | GlobalDataFlow.cs:139:28:139:35 | access to local variable nonSink0 |
+| GlobalDataFlow.cs:124:20:124:27 | access to local variable nonSink1 | GlobalDataFlow.cs:124:20:124:27 | access to local variable nonSink1 |
+| GlobalDataFlow.cs:124:20:124:27 | access to local variable nonSink1 | GlobalDataFlow.cs:124:46:124:58 | [output] (...) => ... |
+| GlobalDataFlow.cs:124:20:124:27 | access to local variable nonSink1 | GlobalDataFlow.cs:124:46:124:58 | [output] (...) => ... |
+| GlobalDataFlow.cs:124:20:124:27 | access to local variable nonSink1 | GlobalDataFlow.cs:124:52:124:52 | s |
+| GlobalDataFlow.cs:124:20:124:27 | access to local variable nonSink1 | GlobalDataFlow.cs:124:52:124:52 | s |
+| GlobalDataFlow.cs:124:20:124:67 | call to method Aggregate | GlobalDataFlow.cs:124:9:124:67 | SSA def(nonSink0) |
+| GlobalDataFlow.cs:124:20:124:67 | call to method Aggregate | GlobalDataFlow.cs:124:9:124:67 | SSA def(nonSink0) |
+| GlobalDataFlow.cs:124:20:124:67 | call to method Aggregate | GlobalDataFlow.cs:124:20:124:67 | call to method Aggregate |
+| GlobalDataFlow.cs:124:20:124:67 | call to method Aggregate | GlobalDataFlow.cs:125:15:125:22 | access to local variable nonSink0 |
+| GlobalDataFlow.cs:124:20:124:67 | call to method Aggregate | GlobalDataFlow.cs:125:15:125:22 | access to local variable nonSink0 |
+| GlobalDataFlow.cs:124:20:124:67 | call to method Aggregate | GlobalDataFlow.cs:127:9:127:46 | call to method TryParse |
+| GlobalDataFlow.cs:124:20:124:67 | call to method Aggregate | GlobalDataFlow.cs:127:9:127:46 | call to method TryParse |
+| GlobalDataFlow.cs:124:20:124:67 | call to method Aggregate | GlobalDataFlow.cs:127:24:127:31 | access to local variable nonSink0 |
+| GlobalDataFlow.cs:124:20:124:67 | call to method Aggregate | GlobalDataFlow.cs:127:24:127:31 | access to local variable nonSink0 |
+| GlobalDataFlow.cs:124:20:124:67 | call to method Aggregate | GlobalDataFlow.cs:127:38:127:45 | SSA def(nonSink2) |
+| GlobalDataFlow.cs:124:20:124:67 | call to method Aggregate | GlobalDataFlow.cs:127:38:127:45 | SSA def(nonSink2) |
+| GlobalDataFlow.cs:124:20:124:67 | call to method Aggregate | GlobalDataFlow.cs:128:15:128:22 | access to local variable nonSink2 |
+| GlobalDataFlow.cs:124:20:124:67 | call to method Aggregate | GlobalDataFlow.cs:128:15:128:22 | access to local variable nonSink2 |
+| GlobalDataFlow.cs:124:20:124:67 | call to method Aggregate | GlobalDataFlow.cs:130:9:130:45 | call to method TryParse |
+| GlobalDataFlow.cs:124:20:124:67 | call to method Aggregate | GlobalDataFlow.cs:130:9:130:45 | call to method TryParse |
+| GlobalDataFlow.cs:124:20:124:67 | call to method Aggregate | GlobalDataFlow.cs:130:23:130:30 | access to local variable nonSink0 |
+| GlobalDataFlow.cs:124:20:124:67 | call to method Aggregate | GlobalDataFlow.cs:130:23:130:30 | access to local variable nonSink0 |
+| GlobalDataFlow.cs:124:20:124:67 | call to method Aggregate | GlobalDataFlow.cs:130:37:130:44 | SSA def(nonSink3) |
+| GlobalDataFlow.cs:124:20:124:67 | call to method Aggregate | GlobalDataFlow.cs:130:37:130:44 | SSA def(nonSink3) |
+| GlobalDataFlow.cs:124:20:124:67 | call to method Aggregate | GlobalDataFlow.cs:131:15:131:22 | access to local variable nonSink3 |
+| GlobalDataFlow.cs:124:20:124:67 | call to method Aggregate | GlobalDataFlow.cs:131:15:131:22 | access to local variable nonSink3 |
+| GlobalDataFlow.cs:124:20:124:67 | call to method Aggregate | GlobalDataFlow.cs:139:28:139:35 | access to local variable nonSink0 |
+| GlobalDataFlow.cs:124:20:124:67 | call to method Aggregate | GlobalDataFlow.cs:139:28:139:35 | access to local variable nonSink0 |
+| GlobalDataFlow.cs:124:39:124:43 | access to local variable sink1 | GlobalDataFlow.cs:124:39:124:43 | access to local variable sink1 |
+| GlobalDataFlow.cs:124:46:124:58 | (...) => ... | GlobalDataFlow.cs:124:46:124:58 | (...) => ... |
+| GlobalDataFlow.cs:124:46:124:58 | [output] (...) => ... | GlobalDataFlow.cs:124:46:124:58 | [output] (...) => ... |
+| GlobalDataFlow.cs:124:46:124:58 | [output] (...) => ... | GlobalDataFlow.cs:124:61:124:61 | x |
+| GlobalDataFlow.cs:124:46:124:58 | [output] (...) => ... | GlobalDataFlow.cs:124:61:124:61 | x |
+| GlobalDataFlow.cs:124:46:124:58 | [output] (...) => ... | GlobalDataFlow.cs:124:61:124:66 | [output] (...) => ... |
+| GlobalDataFlow.cs:124:46:124:58 | [output] (...) => ... | GlobalDataFlow.cs:124:61:124:66 | [output] (...) => ... |
+| GlobalDataFlow.cs:124:52:124:52 | s | GlobalDataFlow.cs:124:52:124:52 | s |
+| GlobalDataFlow.cs:124:52:124:52 | s | GlobalDataFlow.cs:124:52:124:52 | s |
+| GlobalDataFlow.cs:124:52:124:52 | s | GlobalDataFlow.cs:124:52:124:52 | s |
+| GlobalDataFlow.cs:124:52:124:52 | s | GlobalDataFlow.cs:124:52:124:52 | s |
+| GlobalDataFlow.cs:124:52:124:52 | s | GlobalDataFlow.cs:124:52:124:52 | s |
+| GlobalDataFlow.cs:124:52:124:52 | s | GlobalDataFlow.cs:124:52:124:52 | s |
+| GlobalDataFlow.cs:124:52:124:52 | s | GlobalDataFlow.cs:124:58:124:58 | access to parameter s |
+| GlobalDataFlow.cs:124:52:124:52 | s | GlobalDataFlow.cs:124:58:124:58 | access to parameter s |
+| GlobalDataFlow.cs:124:52:124:52 | s | GlobalDataFlow.cs:124:58:124:58 | access to parameter s |
+| GlobalDataFlow.cs:124:52:124:52 | s | GlobalDataFlow.cs:124:58:124:58 | access to parameter s |
+| GlobalDataFlow.cs:124:52:124:52 | s | GlobalDataFlow.cs:124:58:124:58 | access to parameter s |
+| GlobalDataFlow.cs:124:52:124:52 | s | GlobalDataFlow.cs:124:58:124:58 | access to parameter s |
+| GlobalDataFlow.cs:124:52:124:52 | s | GlobalDataFlow.cs:124:58:124:58 | access to parameter s |
+| GlobalDataFlow.cs:124:52:124:52 | s | GlobalDataFlow.cs:124:58:124:58 | access to parameter s |
+| GlobalDataFlow.cs:124:58:124:58 | access to parameter s | GlobalDataFlow.cs:124:46:124:58 | [output] (...) => ... |
+| GlobalDataFlow.cs:124:58:124:58 | access to parameter s | GlobalDataFlow.cs:124:46:124:58 | [output] (...) => ... |
+| GlobalDataFlow.cs:124:58:124:58 | access to parameter s | GlobalDataFlow.cs:124:58:124:58 | access to parameter s |
+| GlobalDataFlow.cs:124:61:124:61 | x | GlobalDataFlow.cs:124:61:124:61 | x |
+| GlobalDataFlow.cs:124:61:124:61 | x | GlobalDataFlow.cs:124:61:124:61 | x |
+| GlobalDataFlow.cs:124:61:124:61 | x | GlobalDataFlow.cs:124:61:124:61 | x |
+| GlobalDataFlow.cs:124:61:124:61 | x | GlobalDataFlow.cs:124:61:124:61 | x |
+| GlobalDataFlow.cs:124:61:124:61 | x | GlobalDataFlow.cs:124:61:124:61 | x |
+| GlobalDataFlow.cs:124:61:124:61 | x | GlobalDataFlow.cs:124:61:124:61 | x |
+| GlobalDataFlow.cs:124:61:124:61 | x | GlobalDataFlow.cs:124:66:124:66 | access to parameter x |
+| GlobalDataFlow.cs:124:61:124:61 | x | GlobalDataFlow.cs:124:66:124:66 | access to parameter x |
+| GlobalDataFlow.cs:124:61:124:61 | x | GlobalDataFlow.cs:124:66:124:66 | access to parameter x |
+| GlobalDataFlow.cs:124:61:124:61 | x | GlobalDataFlow.cs:124:66:124:66 | access to parameter x |
+| GlobalDataFlow.cs:124:61:124:61 | x | GlobalDataFlow.cs:124:66:124:66 | access to parameter x |
+| GlobalDataFlow.cs:124:61:124:61 | x | GlobalDataFlow.cs:124:66:124:66 | access to parameter x |
+| GlobalDataFlow.cs:124:61:124:61 | x | GlobalDataFlow.cs:124:66:124:66 | access to parameter x |
+| GlobalDataFlow.cs:124:61:124:61 | x | GlobalDataFlow.cs:124:66:124:66 | access to parameter x |
+| GlobalDataFlow.cs:124:61:124:66 | (...) => ... | GlobalDataFlow.cs:124:61:124:66 | (...) => ... |
+| GlobalDataFlow.cs:124:61:124:66 | [output] (...) => ... | GlobalDataFlow.cs:124:9:124:67 | SSA def(nonSink0) |
+| GlobalDataFlow.cs:124:61:124:66 | [output] (...) => ... | GlobalDataFlow.cs:124:9:124:67 | SSA def(nonSink0) |
+| GlobalDataFlow.cs:124:61:124:66 | [output] (...) => ... | GlobalDataFlow.cs:124:20:124:67 | call to method Aggregate |
+| GlobalDataFlow.cs:124:61:124:66 | [output] (...) => ... | GlobalDataFlow.cs:124:20:124:67 | call to method Aggregate |
+| GlobalDataFlow.cs:124:61:124:66 | [output] (...) => ... | GlobalDataFlow.cs:124:61:124:66 | [output] (...) => ... |
+| GlobalDataFlow.cs:124:61:124:66 | [output] (...) => ... | GlobalDataFlow.cs:125:15:125:22 | access to local variable nonSink0 |
+| GlobalDataFlow.cs:124:61:124:66 | [output] (...) => ... | GlobalDataFlow.cs:125:15:125:22 | access to local variable nonSink0 |
+| GlobalDataFlow.cs:124:61:124:66 | [output] (...) => ... | GlobalDataFlow.cs:127:9:127:46 | call to method TryParse |
+| GlobalDataFlow.cs:124:61:124:66 | [output] (...) => ... | GlobalDataFlow.cs:127:9:127:46 | call to method TryParse |
+| GlobalDataFlow.cs:124:61:124:66 | [output] (...) => ... | GlobalDataFlow.cs:127:24:127:31 | access to local variable nonSink0 |
+| GlobalDataFlow.cs:124:61:124:66 | [output] (...) => ... | GlobalDataFlow.cs:127:24:127:31 | access to local variable nonSink0 |
+| GlobalDataFlow.cs:124:61:124:66 | [output] (...) => ... | GlobalDataFlow.cs:127:38:127:45 | SSA def(nonSink2) |
+| GlobalDataFlow.cs:124:61:124:66 | [output] (...) => ... | GlobalDataFlow.cs:127:38:127:45 | SSA def(nonSink2) |
+| GlobalDataFlow.cs:124:61:124:66 | [output] (...) => ... | GlobalDataFlow.cs:128:15:128:22 | access to local variable nonSink2 |
+| GlobalDataFlow.cs:124:61:124:66 | [output] (...) => ... | GlobalDataFlow.cs:128:15:128:22 | access to local variable nonSink2 |
+| GlobalDataFlow.cs:124:61:124:66 | [output] (...) => ... | GlobalDataFlow.cs:130:9:130:45 | call to method TryParse |
+| GlobalDataFlow.cs:124:61:124:66 | [output] (...) => ... | GlobalDataFlow.cs:130:9:130:45 | call to method TryParse |
+| GlobalDataFlow.cs:124:61:124:66 | [output] (...) => ... | GlobalDataFlow.cs:130:23:130:30 | access to local variable nonSink0 |
+| GlobalDataFlow.cs:124:61:124:66 | [output] (...) => ... | GlobalDataFlow.cs:130:23:130:30 | access to local variable nonSink0 |
+| GlobalDataFlow.cs:124:61:124:66 | [output] (...) => ... | GlobalDataFlow.cs:130:37:130:44 | SSA def(nonSink3) |
+| GlobalDataFlow.cs:124:61:124:66 | [output] (...) => ... | GlobalDataFlow.cs:130:37:130:44 | SSA def(nonSink3) |
+| GlobalDataFlow.cs:124:61:124:66 | [output] (...) => ... | GlobalDataFlow.cs:131:15:131:22 | access to local variable nonSink3 |
+| GlobalDataFlow.cs:124:61:124:66 | [output] (...) => ... | GlobalDataFlow.cs:131:15:131:22 | access to local variable nonSink3 |
+| GlobalDataFlow.cs:124:61:124:66 | [output] (...) => ... | GlobalDataFlow.cs:139:28:139:35 | access to local variable nonSink0 |
+| GlobalDataFlow.cs:124:61:124:66 | [output] (...) => ... | GlobalDataFlow.cs:139:28:139:35 | access to local variable nonSink0 |
+| GlobalDataFlow.cs:124:66:124:66 | access to parameter x | GlobalDataFlow.cs:124:61:124:66 | [output] (...) => ... |
+| GlobalDataFlow.cs:124:66:124:66 | access to parameter x | GlobalDataFlow.cs:124:61:124:66 | [output] (...) => ... |
+| GlobalDataFlow.cs:124:66:124:66 | access to parameter x | GlobalDataFlow.cs:124:66:124:66 | access to parameter x |
+| GlobalDataFlow.cs:125:9:125:23 | call to method Check | GlobalDataFlow.cs:125:9:125:23 | call to method Check |
+| GlobalDataFlow.cs:125:15:125:22 | access to local variable nonSink0 | GlobalDataFlow.cs:125:15:125:22 | access to local variable nonSink0 |
+| GlobalDataFlow.cs:125:15:125:22 | access to local variable nonSink0 | GlobalDataFlow.cs:127:9:127:46 | call to method TryParse |
+| GlobalDataFlow.cs:125:15:125:22 | access to local variable nonSink0 | GlobalDataFlow.cs:127:9:127:46 | call to method TryParse |
+| GlobalDataFlow.cs:125:15:125:22 | access to local variable nonSink0 | GlobalDataFlow.cs:127:24:127:31 | access to local variable nonSink0 |
+| GlobalDataFlow.cs:125:15:125:22 | access to local variable nonSink0 | GlobalDataFlow.cs:127:24:127:31 | access to local variable nonSink0 |
+| GlobalDataFlow.cs:125:15:125:22 | access to local variable nonSink0 | GlobalDataFlow.cs:127:38:127:45 | SSA def(nonSink2) |
+| GlobalDataFlow.cs:125:15:125:22 | access to local variable nonSink0 | GlobalDataFlow.cs:127:38:127:45 | SSA def(nonSink2) |
+| GlobalDataFlow.cs:125:15:125:22 | access to local variable nonSink0 | GlobalDataFlow.cs:128:15:128:22 | access to local variable nonSink2 |
+| GlobalDataFlow.cs:125:15:125:22 | access to local variable nonSink0 | GlobalDataFlow.cs:128:15:128:22 | access to local variable nonSink2 |
+| GlobalDataFlow.cs:125:15:125:22 | access to local variable nonSink0 | GlobalDataFlow.cs:130:9:130:45 | call to method TryParse |
+| GlobalDataFlow.cs:125:15:125:22 | access to local variable nonSink0 | GlobalDataFlow.cs:130:9:130:45 | call to method TryParse |
+| GlobalDataFlow.cs:125:15:125:22 | access to local variable nonSink0 | GlobalDataFlow.cs:130:23:130:30 | access to local variable nonSink0 |
+| GlobalDataFlow.cs:125:15:125:22 | access to local variable nonSink0 | GlobalDataFlow.cs:130:23:130:30 | access to local variable nonSink0 |
+| GlobalDataFlow.cs:125:15:125:22 | access to local variable nonSink0 | GlobalDataFlow.cs:130:37:130:44 | SSA def(nonSink3) |
+| GlobalDataFlow.cs:125:15:125:22 | access to local variable nonSink0 | GlobalDataFlow.cs:130:37:130:44 | SSA def(nonSink3) |
+| GlobalDataFlow.cs:125:15:125:22 | access to local variable nonSink0 | GlobalDataFlow.cs:131:15:131:22 | access to local variable nonSink3 |
+| GlobalDataFlow.cs:125:15:125:22 | access to local variable nonSink0 | GlobalDataFlow.cs:131:15:131:22 | access to local variable nonSink3 |
+| GlobalDataFlow.cs:125:15:125:22 | access to local variable nonSink0 | GlobalDataFlow.cs:139:28:139:35 | access to local variable nonSink0 |
+| GlobalDataFlow.cs:125:15:125:22 | access to local variable nonSink0 | GlobalDataFlow.cs:139:28:139:35 | access to local variable nonSink0 |
+| GlobalDataFlow.cs:126:13:126:20 | Int32 nonSink2 | GlobalDataFlow.cs:126:13:126:20 | Int32 nonSink2 |
+| GlobalDataFlow.cs:127:9:127:46 | call to method TryParse | GlobalDataFlow.cs:127:9:127:46 | call to method TryParse |
+| GlobalDataFlow.cs:127:24:127:31 | access to local variable nonSink0 | GlobalDataFlow.cs:127:9:127:46 | call to method TryParse |
+| GlobalDataFlow.cs:127:24:127:31 | access to local variable nonSink0 | GlobalDataFlow.cs:127:9:127:46 | call to method TryParse |
+| GlobalDataFlow.cs:127:24:127:31 | access to local variable nonSink0 | GlobalDataFlow.cs:127:24:127:31 | access to local variable nonSink0 |
+| GlobalDataFlow.cs:127:24:127:31 | access to local variable nonSink0 | GlobalDataFlow.cs:127:38:127:45 | SSA def(nonSink2) |
+| GlobalDataFlow.cs:127:24:127:31 | access to local variable nonSink0 | GlobalDataFlow.cs:127:38:127:45 | SSA def(nonSink2) |
+| GlobalDataFlow.cs:127:24:127:31 | access to local variable nonSink0 | GlobalDataFlow.cs:128:15:128:22 | access to local variable nonSink2 |
+| GlobalDataFlow.cs:127:24:127:31 | access to local variable nonSink0 | GlobalDataFlow.cs:128:15:128:22 | access to local variable nonSink2 |
+| GlobalDataFlow.cs:127:24:127:31 | access to local variable nonSink0 | GlobalDataFlow.cs:130:9:130:45 | call to method TryParse |
+| GlobalDataFlow.cs:127:24:127:31 | access to local variable nonSink0 | GlobalDataFlow.cs:130:9:130:45 | call to method TryParse |
+| GlobalDataFlow.cs:127:24:127:31 | access to local variable nonSink0 | GlobalDataFlow.cs:130:23:130:30 | access to local variable nonSink0 |
+| GlobalDataFlow.cs:127:24:127:31 | access to local variable nonSink0 | GlobalDataFlow.cs:130:23:130:30 | access to local variable nonSink0 |
+| GlobalDataFlow.cs:127:24:127:31 | access to local variable nonSink0 | GlobalDataFlow.cs:130:37:130:44 | SSA def(nonSink3) |
+| GlobalDataFlow.cs:127:24:127:31 | access to local variable nonSink0 | GlobalDataFlow.cs:130:37:130:44 | SSA def(nonSink3) |
+| GlobalDataFlow.cs:127:24:127:31 | access to local variable nonSink0 | GlobalDataFlow.cs:131:15:131:22 | access to local variable nonSink3 |
+| GlobalDataFlow.cs:127:24:127:31 | access to local variable nonSink0 | GlobalDataFlow.cs:131:15:131:22 | access to local variable nonSink3 |
+| GlobalDataFlow.cs:127:24:127:31 | access to local variable nonSink0 | GlobalDataFlow.cs:139:28:139:35 | access to local variable nonSink0 |
+| GlobalDataFlow.cs:127:24:127:31 | access to local variable nonSink0 | GlobalDataFlow.cs:139:28:139:35 | access to local variable nonSink0 |
+| GlobalDataFlow.cs:127:38:127:45 | SSA def(nonSink2) | GlobalDataFlow.cs:127:38:127:45 | SSA def(nonSink2) |
+| GlobalDataFlow.cs:127:38:127:45 | SSA def(nonSink2) | GlobalDataFlow.cs:128:15:128:22 | access to local variable nonSink2 |
+| GlobalDataFlow.cs:127:38:127:45 | SSA def(nonSink2) | GlobalDataFlow.cs:128:15:128:22 | access to local variable nonSink2 |
+| GlobalDataFlow.cs:128:9:128:23 | call to method Check | GlobalDataFlow.cs:128:9:128:23 | call to method Check |
+| GlobalDataFlow.cs:128:15:128:22 | access to local variable nonSink2 | GlobalDataFlow.cs:128:15:128:22 | access to local variable nonSink2 |
+| GlobalDataFlow.cs:129:14:129:21 | Boolean nonSink3 | GlobalDataFlow.cs:129:14:129:21 | Boolean nonSink3 |
+| GlobalDataFlow.cs:130:9:130:45 | call to method TryParse | GlobalDataFlow.cs:130:9:130:45 | call to method TryParse |
+| GlobalDataFlow.cs:130:23:130:30 | access to local variable nonSink0 | GlobalDataFlow.cs:130:9:130:45 | call to method TryParse |
+| GlobalDataFlow.cs:130:23:130:30 | access to local variable nonSink0 | GlobalDataFlow.cs:130:9:130:45 | call to method TryParse |
+| GlobalDataFlow.cs:130:23:130:30 | access to local variable nonSink0 | GlobalDataFlow.cs:130:23:130:30 | access to local variable nonSink0 |
+| GlobalDataFlow.cs:130:23:130:30 | access to local variable nonSink0 | GlobalDataFlow.cs:130:37:130:44 | SSA def(nonSink3) |
+| GlobalDataFlow.cs:130:23:130:30 | access to local variable nonSink0 | GlobalDataFlow.cs:130:37:130:44 | SSA def(nonSink3) |
+| GlobalDataFlow.cs:130:23:130:30 | access to local variable nonSink0 | GlobalDataFlow.cs:131:15:131:22 | access to local variable nonSink3 |
+| GlobalDataFlow.cs:130:23:130:30 | access to local variable nonSink0 | GlobalDataFlow.cs:131:15:131:22 | access to local variable nonSink3 |
+| GlobalDataFlow.cs:130:23:130:30 | access to local variable nonSink0 | GlobalDataFlow.cs:139:28:139:35 | access to local variable nonSink0 |
+| GlobalDataFlow.cs:130:23:130:30 | access to local variable nonSink0 | GlobalDataFlow.cs:139:28:139:35 | access to local variable nonSink0 |
+| GlobalDataFlow.cs:130:37:130:44 | SSA def(nonSink3) | GlobalDataFlow.cs:130:37:130:44 | SSA def(nonSink3) |
+| GlobalDataFlow.cs:130:37:130:44 | SSA def(nonSink3) | GlobalDataFlow.cs:131:15:131:22 | access to local variable nonSink3 |
+| GlobalDataFlow.cs:130:37:130:44 | SSA def(nonSink3) | GlobalDataFlow.cs:131:15:131:22 | access to local variable nonSink3 |
+| GlobalDataFlow.cs:131:9:131:23 | call to method Check | GlobalDataFlow.cs:131:9:131:23 | call to method Check |
+| GlobalDataFlow.cs:131:15:131:22 | access to local variable nonSink3 | GlobalDataFlow.cs:131:15:131:22 | access to local variable nonSink3 |
+| GlobalDataFlow.cs:134:30:134:64 | Func<String,String> return = ... | GlobalDataFlow.cs:134:30:134:64 | Func<String,String> return = ... |
+| GlobalDataFlow.cs:134:30:134:64 | SSA def(return) | GlobalDataFlow.cs:134:30:134:64 | SSA def(return) |
+| GlobalDataFlow.cs:134:30:134:64 | SSA def(return) | GlobalDataFlow.cs:135:21:135:27 | access to local variable return |
+| GlobalDataFlow.cs:134:30:134:64 | SSA def(return) | GlobalDataFlow.cs:135:21:135:27 | access to local variable return |
+| GlobalDataFlow.cs:134:30:134:64 | SSA def(return) | GlobalDataFlow.cs:139:20:139:26 | access to local variable return |
+| GlobalDataFlow.cs:134:30:134:64 | SSA def(return) | GlobalDataFlow.cs:139:20:139:26 | access to local variable return |
+| GlobalDataFlow.cs:134:40:134:40 | x | GlobalDataFlow.cs:134:40:134:40 | x |
+| GlobalDataFlow.cs:134:40:134:40 | x | GlobalDataFlow.cs:134:40:134:40 | x |
+| GlobalDataFlow.cs:134:40:134:40 | x | GlobalDataFlow.cs:134:40:134:40 | x |
+| GlobalDataFlow.cs:134:40:134:40 | x | GlobalDataFlow.cs:134:40:134:40 | x |
+| GlobalDataFlow.cs:134:40:134:40 | x | GlobalDataFlow.cs:134:63:134:63 | access to parameter x |
+| GlobalDataFlow.cs:134:40:134:40 | x | GlobalDataFlow.cs:134:63:134:63 | access to parameter x |
+| GlobalDataFlow.cs:134:40:134:40 | x | GlobalDataFlow.cs:134:63:134:63 | access to parameter x |
+| GlobalDataFlow.cs:134:40:134:40 | x | GlobalDataFlow.cs:134:63:134:63 | access to parameter x |
+| GlobalDataFlow.cs:134:40:134:40 | x | GlobalDataFlow.cs:134:63:134:63 | access to parameter x |
+| GlobalDataFlow.cs:134:40:134:40 | x | GlobalDataFlow.cs:134:63:134:63 | access to parameter x |
+| GlobalDataFlow.cs:134:40:134:64 | (...) => ... | GlobalDataFlow.cs:134:30:134:64 | SSA def(return) |
+| GlobalDataFlow.cs:134:40:134:64 | (...) => ... | GlobalDataFlow.cs:134:30:134:64 | SSA def(return) |
+| GlobalDataFlow.cs:134:40:134:64 | (...) => ... | GlobalDataFlow.cs:134:40:134:64 | (...) => ... |
+| GlobalDataFlow.cs:134:40:134:64 | (...) => ... | GlobalDataFlow.cs:135:21:135:27 | access to local variable return |
+| GlobalDataFlow.cs:134:40:134:64 | (...) => ... | GlobalDataFlow.cs:135:21:135:27 | access to local variable return |
+| GlobalDataFlow.cs:134:40:134:64 | (...) => ... | GlobalDataFlow.cs:139:20:139:26 | access to local variable return |
+| GlobalDataFlow.cs:134:40:134:64 | (...) => ... | GlobalDataFlow.cs:139:20:139:26 | access to local variable return |
+| GlobalDataFlow.cs:134:45:134:64 | call to method ApplyFunc | GlobalDataFlow.cs:134:45:134:64 | call to method ApplyFunc |
+| GlobalDataFlow.cs:134:45:134:64 | call to method ApplyFunc | GlobalDataFlow.cs:135:21:135:34 | delegate call |
+| GlobalDataFlow.cs:134:45:134:64 | call to method ApplyFunc | GlobalDataFlow.cs:135:21:135:34 | delegate call |
+| GlobalDataFlow.cs:134:45:134:64 | call to method ApplyFunc | GlobalDataFlow.cs:139:20:139:36 | delegate call |
+| GlobalDataFlow.cs:134:45:134:64 | call to method ApplyFunc | GlobalDataFlow.cs:139:20:139:36 | delegate call |
+| GlobalDataFlow.cs:134:55:134:60 | access to method Return | GlobalDataFlow.cs:134:55:134:60 | access to method Return |
+| GlobalDataFlow.cs:134:55:134:60 | delegate creation of type Func<String,String> | GlobalDataFlow.cs:134:55:134:60 | delegate creation of type Func<String,String> |
+| GlobalDataFlow.cs:134:55:134:60 | delegate creation of type Func<String,String> | GlobalDataFlow.cs:364:41:364:41 | f |
+| GlobalDataFlow.cs:134:55:134:60 | delegate creation of type Func<String,String> | GlobalDataFlow.cs:364:41:364:41 | f |
+| GlobalDataFlow.cs:134:63:134:63 | access to parameter x | GlobalDataFlow.cs:134:45:134:64 | call to method ApplyFunc |
+| GlobalDataFlow.cs:134:63:134:63 | access to parameter x | GlobalDataFlow.cs:134:45:134:64 | call to method ApplyFunc |
+| GlobalDataFlow.cs:134:63:134:63 | access to parameter x | GlobalDataFlow.cs:134:45:134:64 | call to method ApplyFunc |
+| GlobalDataFlow.cs:134:63:134:63 | access to parameter x | GlobalDataFlow.cs:134:45:134:64 | call to method ApplyFunc |
+| GlobalDataFlow.cs:134:63:134:63 | access to parameter x | GlobalDataFlow.cs:134:63:134:63 | access to parameter x |
+| GlobalDataFlow.cs:134:63:134:63 | access to parameter x | GlobalDataFlow.cs:364:46:364:46 | x |
+| GlobalDataFlow.cs:134:63:134:63 | access to parameter x | GlobalDataFlow.cs:364:46:364:46 | x |
+| GlobalDataFlow.cs:134:63:134:63 | access to parameter x | GlobalDataFlow.cs:364:46:364:46 | x |
+| GlobalDataFlow.cs:134:63:134:63 | access to parameter x | GlobalDataFlow.cs:364:46:364:46 | x |
+| GlobalDataFlow.cs:135:13:135:34 | SSA def(sink4) | GlobalDataFlow.cs:135:13:135:34 | SSA def(sink4) |
+| GlobalDataFlow.cs:135:13:135:34 | SSA def(sink4) | GlobalDataFlow.cs:136:15:136:19 | access to local variable sink4 |
+| GlobalDataFlow.cs:135:13:135:34 | SSA def(sink4) | GlobalDataFlow.cs:136:15:136:19 | access to local variable sink4 |
+| GlobalDataFlow.cs:135:13:135:34 | SSA def(sink4) | GlobalDataFlow.cs:143:39:143:43 | access to local variable sink4 |
+| GlobalDataFlow.cs:135:13:135:34 | SSA def(sink4) | GlobalDataFlow.cs:143:39:143:43 | access to local variable sink4 |
+| GlobalDataFlow.cs:135:13:135:34 | String sink4 = ... | GlobalDataFlow.cs:135:13:135:34 | String sink4 = ... |
+| GlobalDataFlow.cs:135:21:135:27 | access to local variable return | GlobalDataFlow.cs:135:21:135:27 | access to local variable return |
+| GlobalDataFlow.cs:135:21:135:27 | access to local variable return | GlobalDataFlow.cs:139:20:139:26 | access to local variable return |
+| GlobalDataFlow.cs:135:21:135:27 | access to local variable return | GlobalDataFlow.cs:139:20:139:26 | access to local variable return |
+| GlobalDataFlow.cs:135:21:135:34 | delegate call | GlobalDataFlow.cs:135:13:135:34 | SSA def(sink4) |
+| GlobalDataFlow.cs:135:21:135:34 | delegate call | GlobalDataFlow.cs:135:13:135:34 | SSA def(sink4) |
+| GlobalDataFlow.cs:135:21:135:34 | delegate call | GlobalDataFlow.cs:135:21:135:34 | delegate call |
+| GlobalDataFlow.cs:135:21:135:34 | delegate call | GlobalDataFlow.cs:136:15:136:19 | access to local variable sink4 |
+| GlobalDataFlow.cs:135:21:135:34 | delegate call | GlobalDataFlow.cs:136:15:136:19 | access to local variable sink4 |
+| GlobalDataFlow.cs:135:21:135:34 | delegate call | GlobalDataFlow.cs:143:39:143:43 | access to local variable sink4 |
+| GlobalDataFlow.cs:135:21:135:34 | delegate call | GlobalDataFlow.cs:143:39:143:43 | access to local variable sink4 |
+| GlobalDataFlow.cs:135:29:135:33 | access to local variable sink3 | GlobalDataFlow.cs:134:40:134:40 | x |
+| GlobalDataFlow.cs:135:29:135:33 | access to local variable sink3 | GlobalDataFlow.cs:134:40:134:40 | x |
+| GlobalDataFlow.cs:135:29:135:33 | access to local variable sink3 | GlobalDataFlow.cs:135:21:135:34 | delegate call |
+| GlobalDataFlow.cs:135:29:135:33 | access to local variable sink3 | GlobalDataFlow.cs:135:21:135:34 | delegate call |
+| GlobalDataFlow.cs:135:29:135:33 | access to local variable sink3 | GlobalDataFlow.cs:135:29:135:33 | access to local variable sink3 |
+| GlobalDataFlow.cs:136:9:136:20 | call to method Check | GlobalDataFlow.cs:136:9:136:20 | call to method Check |
+| GlobalDataFlow.cs:136:15:136:19 | access to local variable sink4 | GlobalDataFlow.cs:136:15:136:19 | access to local variable sink4 |
+| GlobalDataFlow.cs:136:15:136:19 | access to local variable sink4 | GlobalDataFlow.cs:143:39:143:43 | access to local variable sink4 |
+| GlobalDataFlow.cs:136:15:136:19 | access to local variable sink4 | GlobalDataFlow.cs:143:39:143:43 | access to local variable sink4 |
+| GlobalDataFlow.cs:139:9:139:36 | ... = ... | GlobalDataFlow.cs:139:9:139:36 | ... = ... |
+| GlobalDataFlow.cs:139:9:139:36 | SSA def(nonSink0) | GlobalDataFlow.cs:139:9:139:36 | SSA def(nonSink0) |
+| GlobalDataFlow.cs:139:9:139:36 | SSA def(nonSink0) | GlobalDataFlow.cs:140:15:140:22 | access to local variable nonSink0 |
+| GlobalDataFlow.cs:139:9:139:36 | SSA def(nonSink0) | GlobalDataFlow.cs:140:15:140:22 | access to local variable nonSink0 |
+| GlobalDataFlow.cs:139:20:139:26 | access to local variable return | GlobalDataFlow.cs:139:20:139:26 | access to local variable return |
+| GlobalDataFlow.cs:139:20:139:36 | delegate call | GlobalDataFlow.cs:139:9:139:36 | SSA def(nonSink0) |
+| GlobalDataFlow.cs:139:20:139:36 | delegate call | GlobalDataFlow.cs:139:9:139:36 | SSA def(nonSink0) |
+| GlobalDataFlow.cs:139:20:139:36 | delegate call | GlobalDataFlow.cs:139:20:139:36 | delegate call |
+| GlobalDataFlow.cs:139:20:139:36 | delegate call | GlobalDataFlow.cs:140:15:140:22 | access to local variable nonSink0 |
+| GlobalDataFlow.cs:139:20:139:36 | delegate call | GlobalDataFlow.cs:140:15:140:22 | access to local variable nonSink0 |
+| GlobalDataFlow.cs:139:28:139:35 | access to local variable nonSink0 | GlobalDataFlow.cs:134:40:134:40 | x |
+| GlobalDataFlow.cs:139:28:139:35 | access to local variable nonSink0 | GlobalDataFlow.cs:134:40:134:40 | x |
+| GlobalDataFlow.cs:139:28:139:35 | access to local variable nonSink0 | GlobalDataFlow.cs:139:20:139:36 | delegate call |
+| GlobalDataFlow.cs:139:28:139:35 | access to local variable nonSink0 | GlobalDataFlow.cs:139:20:139:36 | delegate call |
+| GlobalDataFlow.cs:139:28:139:35 | access to local variable nonSink0 | GlobalDataFlow.cs:139:28:139:35 | access to local variable nonSink0 |
+| GlobalDataFlow.cs:140:9:140:23 | call to method Check | GlobalDataFlow.cs:140:9:140:23 | call to method Check |
+| GlobalDataFlow.cs:140:15:140:22 | access to local variable nonSink0 | GlobalDataFlow.cs:140:15:140:22 | access to local variable nonSink0 |
+| GlobalDataFlow.cs:143:13:143:44 | SSA def(sink5) | GlobalDataFlow.cs:143:13:143:44 | SSA def(sink5) |
+| GlobalDataFlow.cs:143:13:143:44 | SSA def(sink5) | GlobalDataFlow.cs:144:15:144:19 | access to local variable sink5 |
+| GlobalDataFlow.cs:143:13:143:44 | SSA def(sink5) | GlobalDataFlow.cs:144:15:144:19 | access to local variable sink5 |
+| GlobalDataFlow.cs:143:13:143:44 | SSA def(sink5) | GlobalDataFlow.cs:149:39:149:43 | access to local variable sink5 |
+| GlobalDataFlow.cs:143:13:143:44 | SSA def(sink5) | GlobalDataFlow.cs:149:39:149:43 | access to local variable sink5 |
+| GlobalDataFlow.cs:143:13:143:44 | String sink5 = ... | GlobalDataFlow.cs:143:13:143:44 | String sink5 = ... |
+| GlobalDataFlow.cs:143:21:143:44 | call to method ApplyFunc | GlobalDataFlow.cs:143:13:143:44 | SSA def(sink5) |
+| GlobalDataFlow.cs:143:21:143:44 | call to method ApplyFunc | GlobalDataFlow.cs:143:13:143:44 | SSA def(sink5) |
+| GlobalDataFlow.cs:143:21:143:44 | call to method ApplyFunc | GlobalDataFlow.cs:143:21:143:44 | call to method ApplyFunc |
+| GlobalDataFlow.cs:143:21:143:44 | call to method ApplyFunc | GlobalDataFlow.cs:144:15:144:19 | access to local variable sink5 |
+| GlobalDataFlow.cs:143:21:143:44 | call to method ApplyFunc | GlobalDataFlow.cs:144:15:144:19 | access to local variable sink5 |
+| GlobalDataFlow.cs:143:21:143:44 | call to method ApplyFunc | GlobalDataFlow.cs:149:39:149:43 | access to local variable sink5 |
+| GlobalDataFlow.cs:143:21:143:44 | call to method ApplyFunc | GlobalDataFlow.cs:149:39:149:43 | access to local variable sink5 |
+| GlobalDataFlow.cs:143:31:143:36 | access to method Return | GlobalDataFlow.cs:143:31:143:36 | access to method Return |
+| GlobalDataFlow.cs:143:31:143:36 | delegate creation of type Func<String,String> | GlobalDataFlow.cs:143:31:143:36 | delegate creation of type Func<String,String> |
+| GlobalDataFlow.cs:143:31:143:36 | delegate creation of type Func<String,String> | GlobalDataFlow.cs:364:41:364:41 | f |
+| GlobalDataFlow.cs:143:31:143:36 | delegate creation of type Func<String,String> | GlobalDataFlow.cs:364:41:364:41 | f |
+| GlobalDataFlow.cs:143:39:143:43 | access to local variable sink4 | GlobalDataFlow.cs:143:21:143:44 | call to method ApplyFunc |
+| GlobalDataFlow.cs:143:39:143:43 | access to local variable sink4 | GlobalDataFlow.cs:143:21:143:44 | call to method ApplyFunc |
+| GlobalDataFlow.cs:143:39:143:43 | access to local variable sink4 | GlobalDataFlow.cs:143:39:143:43 | access to local variable sink4 |
+| GlobalDataFlow.cs:143:39:143:43 | access to local variable sink4 | GlobalDataFlow.cs:364:46:364:46 | x |
+| GlobalDataFlow.cs:143:39:143:43 | access to local variable sink4 | GlobalDataFlow.cs:364:46:364:46 | x |
+| GlobalDataFlow.cs:144:9:144:20 | call to method Check | GlobalDataFlow.cs:144:9:144:20 | call to method Check |
+| GlobalDataFlow.cs:144:15:144:19 | access to local variable sink5 | GlobalDataFlow.cs:144:15:144:19 | access to local variable sink5 |
+| GlobalDataFlow.cs:144:15:144:19 | access to local variable sink5 | GlobalDataFlow.cs:149:39:149:43 | access to local variable sink5 |
+| GlobalDataFlow.cs:144:15:144:19 | access to local variable sink5 | GlobalDataFlow.cs:149:39:149:43 | access to local variable sink5 |
+| GlobalDataFlow.cs:147:9:147:40 | ... = ... | GlobalDataFlow.cs:147:9:147:40 | ... = ... |
+| GlobalDataFlow.cs:147:9:147:40 | SSA def(nonSink0) | GlobalDataFlow.cs:147:9:147:40 | SSA def(nonSink0) |
+| GlobalDataFlow.cs:147:9:147:40 | SSA def(nonSink0) | GlobalDataFlow.cs:148:15:148:22 | access to local variable nonSink0 |
+| GlobalDataFlow.cs:147:9:147:40 | SSA def(nonSink0) | GlobalDataFlow.cs:148:15:148:22 | access to local variable nonSink0 |
+| GlobalDataFlow.cs:147:20:147:40 | call to method ApplyFunc | GlobalDataFlow.cs:147:9:147:40 | SSA def(nonSink0) |
+| GlobalDataFlow.cs:147:20:147:40 | call to method ApplyFunc | GlobalDataFlow.cs:147:9:147:40 | SSA def(nonSink0) |
+| GlobalDataFlow.cs:147:20:147:40 | call to method ApplyFunc | GlobalDataFlow.cs:147:20:147:40 | call to method ApplyFunc |
+| GlobalDataFlow.cs:147:20:147:40 | call to method ApplyFunc | GlobalDataFlow.cs:148:15:148:22 | access to local variable nonSink0 |
+| GlobalDataFlow.cs:147:20:147:40 | call to method ApplyFunc | GlobalDataFlow.cs:148:15:148:22 | access to local variable nonSink0 |
+| GlobalDataFlow.cs:147:30:147:35 | access to method Return | GlobalDataFlow.cs:147:30:147:35 | access to method Return |
+| GlobalDataFlow.cs:147:30:147:35 | delegate creation of type Func<String,String> | GlobalDataFlow.cs:147:30:147:35 | delegate creation of type Func<String,String> |
+| GlobalDataFlow.cs:147:30:147:35 | delegate creation of type Func<String,String> | GlobalDataFlow.cs:364:41:364:41 | f |
+| GlobalDataFlow.cs:147:30:147:35 | delegate creation of type Func<String,String> | GlobalDataFlow.cs:364:41:364:41 | f |
+| GlobalDataFlow.cs:147:38:147:39 | "" | GlobalDataFlow.cs:147:20:147:40 | call to method ApplyFunc |
+| GlobalDataFlow.cs:147:38:147:39 | "" | GlobalDataFlow.cs:147:20:147:40 | call to method ApplyFunc |
+| GlobalDataFlow.cs:147:38:147:39 | "" | GlobalDataFlow.cs:147:38:147:39 | "" |
+| GlobalDataFlow.cs:147:38:147:39 | "" | GlobalDataFlow.cs:364:46:364:46 | x |
+| GlobalDataFlow.cs:147:38:147:39 | "" | GlobalDataFlow.cs:364:46:364:46 | x |
+| GlobalDataFlow.cs:148:9:148:23 | call to method Check | GlobalDataFlow.cs:148:9:148:23 | call to method Check |
+| GlobalDataFlow.cs:148:15:148:22 | access to local variable nonSink0 | GlobalDataFlow.cs:148:15:148:22 | access to local variable nonSink0 |
+| GlobalDataFlow.cs:149:9:149:44 | ... = ... | GlobalDataFlow.cs:149:9:149:44 | ... = ... |
+| GlobalDataFlow.cs:149:9:149:44 | SSA def(nonSink0) | GlobalDataFlow.cs:149:9:149:44 | SSA def(nonSink0) |
+| GlobalDataFlow.cs:149:9:149:44 | SSA def(nonSink0) | GlobalDataFlow.cs:150:15:150:22 | access to local variable nonSink0 |
+| GlobalDataFlow.cs:149:9:149:44 | SSA def(nonSink0) | GlobalDataFlow.cs:150:15:150:22 | access to local variable nonSink0 |
+| GlobalDataFlow.cs:149:9:149:44 | SSA def(nonSink0) | GlobalDataFlow.cs:163:35:163:42 | access to local variable nonSink0 |
+| GlobalDataFlow.cs:149:9:149:44 | SSA def(nonSink0) | GlobalDataFlow.cs:163:35:163:42 | access to local variable nonSink0 |
+| GlobalDataFlow.cs:149:20:149:44 | call to method ApplyFunc | GlobalDataFlow.cs:149:9:149:44 | SSA def(nonSink0) |
+| GlobalDataFlow.cs:149:20:149:44 | call to method ApplyFunc | GlobalDataFlow.cs:149:9:149:44 | SSA def(nonSink0) |
+| GlobalDataFlow.cs:149:20:149:44 | call to method ApplyFunc | GlobalDataFlow.cs:149:20:149:44 | call to method ApplyFunc |
+| GlobalDataFlow.cs:149:20:149:44 | call to method ApplyFunc | GlobalDataFlow.cs:150:15:150:22 | access to local variable nonSink0 |
+| GlobalDataFlow.cs:149:20:149:44 | call to method ApplyFunc | GlobalDataFlow.cs:150:15:150:22 | access to local variable nonSink0 |
+| GlobalDataFlow.cs:149:20:149:44 | call to method ApplyFunc | GlobalDataFlow.cs:163:35:163:42 | access to local variable nonSink0 |
+| GlobalDataFlow.cs:149:20:149:44 | call to method ApplyFunc | GlobalDataFlow.cs:163:35:163:42 | access to local variable nonSink0 |
+| GlobalDataFlow.cs:149:30:149:36 | (...) => ... | GlobalDataFlow.cs:149:30:149:36 | (...) => ... |
+| GlobalDataFlow.cs:149:30:149:36 | (...) => ... | GlobalDataFlow.cs:364:41:364:41 | f |
+| GlobalDataFlow.cs:149:30:149:36 | (...) => ... | GlobalDataFlow.cs:364:41:364:41 | f |
+| GlobalDataFlow.cs:149:35:149:36 | "" | GlobalDataFlow.cs:149:35:149:36 | "" |
+| GlobalDataFlow.cs:149:35:149:36 | "" | GlobalDataFlow.cs:366:16:366:19 | delegate call |
+| GlobalDataFlow.cs:149:35:149:36 | "" | GlobalDataFlow.cs:366:16:366:19 | delegate call |
+| GlobalDataFlow.cs:149:39:149:43 | access to local variable sink5 | GlobalDataFlow.cs:149:39:149:43 | access to local variable sink5 |
+| GlobalDataFlow.cs:149:39:149:43 | access to local variable sink5 | GlobalDataFlow.cs:364:46:364:46 | x |
+| GlobalDataFlow.cs:149:39:149:43 | access to local variable sink5 | GlobalDataFlow.cs:364:46:364:46 | x |
+| GlobalDataFlow.cs:150:9:150:23 | call to method Check | GlobalDataFlow.cs:150:9:150:23 | call to method Check |
+| GlobalDataFlow.cs:150:15:150:22 | access to local variable nonSink0 | GlobalDataFlow.cs:150:15:150:22 | access to local variable nonSink0 |
+| GlobalDataFlow.cs:150:15:150:22 | access to local variable nonSink0 | GlobalDataFlow.cs:163:35:163:42 | access to local variable nonSink0 |
+| GlobalDataFlow.cs:150:15:150:22 | access to local variable nonSink0 | GlobalDataFlow.cs:163:35:163:42 | access to local variable nonSink0 |
+| GlobalDataFlow.cs:153:13:153:25 | SSA def(sink6) | GlobalDataFlow.cs:153:13:153:25 | SSA def(sink6) |
+| GlobalDataFlow.cs:153:13:153:25 | SSA def(sink6) | GlobalDataFlow.cs:154:15:154:19 | access to local variable sink6 |
+| GlobalDataFlow.cs:153:13:153:25 | SSA def(sink6) | GlobalDataFlow.cs:154:15:154:19 | access to local variable sink6 |
+| GlobalDataFlow.cs:153:13:153:25 | String sink6 = ... | GlobalDataFlow.cs:153:13:153:25 | String sink6 = ... |
+| GlobalDataFlow.cs:153:21:153:25 | call to method Out | GlobalDataFlow.cs:153:13:153:25 | SSA def(sink6) |
+| GlobalDataFlow.cs:153:21:153:25 | call to method Out | GlobalDataFlow.cs:153:13:153:25 | SSA def(sink6) |
+| GlobalDataFlow.cs:153:21:153:25 | call to method Out | GlobalDataFlow.cs:153:21:153:25 | call to method Out |
+| GlobalDataFlow.cs:153:21:153:25 | call to method Out | GlobalDataFlow.cs:154:15:154:19 | access to local variable sink6 |
+| GlobalDataFlow.cs:153:21:153:25 | call to method Out | GlobalDataFlow.cs:154:15:154:19 | access to local variable sink6 |
+| GlobalDataFlow.cs:153:21:153:25 | this access | GlobalDataFlow.cs:153:21:153:25 | this access |
+| GlobalDataFlow.cs:153:21:153:25 | this access | GlobalDataFlow.cs:156:9:156:25 | this access |
+| GlobalDataFlow.cs:153:21:153:25 | this access | GlobalDataFlow.cs:156:9:156:25 | this access |
+| GlobalDataFlow.cs:153:21:153:25 | this access | GlobalDataFlow.cs:159:9:159:25 | this access |
+| GlobalDataFlow.cs:153:21:153:25 | this access | GlobalDataFlow.cs:159:9:159:25 | this access |
+| GlobalDataFlow.cs:153:21:153:25 | this access | GlobalDataFlow.cs:161:22:161:31 | this access |
+| GlobalDataFlow.cs:153:21:153:25 | this access | GlobalDataFlow.cs:161:22:161:31 | this access |
+| GlobalDataFlow.cs:153:21:153:25 | this access | GlobalDataFlow.cs:167:20:167:27 | this access |
+| GlobalDataFlow.cs:153:21:153:25 | this access | GlobalDataFlow.cs:167:20:167:27 | this access |
+| GlobalDataFlow.cs:153:21:153:25 | this access | GlobalDataFlow.cs:169:9:169:31 | this access |
+| GlobalDataFlow.cs:153:21:153:25 | this access | GlobalDataFlow.cs:169:9:169:31 | this access |
+| GlobalDataFlow.cs:153:21:153:25 | this access | GlobalDataFlow.cs:171:9:171:31 | this access |
+| GlobalDataFlow.cs:153:21:153:25 | this access | GlobalDataFlow.cs:171:9:171:31 | this access |
+| GlobalDataFlow.cs:153:21:153:25 | this access | GlobalDataFlow.cs:173:20:173:32 | this access |
+| GlobalDataFlow.cs:153:21:153:25 | this access | GlobalDataFlow.cs:173:20:173:32 | this access |
+| GlobalDataFlow.cs:153:21:153:25 | this access | GlobalDataFlow.cs:189:39:189:41 | this access |
+| GlobalDataFlow.cs:153:21:153:25 | this access | GlobalDataFlow.cs:189:39:189:41 | this access |
+| GlobalDataFlow.cs:153:21:153:25 | this access | GlobalDataFlow.cs:193:37:193:42 | this access |
+| GlobalDataFlow.cs:153:21:153:25 | this access | GlobalDataFlow.cs:193:37:193:42 | this access |
+| GlobalDataFlow.cs:153:21:153:25 | this access | GlobalDataFlow.cs:197:22:197:32 | this access |
+| GlobalDataFlow.cs:153:21:153:25 | this access | GlobalDataFlow.cs:197:22:197:32 | this access |
+| GlobalDataFlow.cs:153:21:153:25 | this access | GlobalDataFlow.cs:201:20:201:33 | this access |
+| GlobalDataFlow.cs:153:21:153:25 | this access | GlobalDataFlow.cs:201:20:201:33 | this access |
+| GlobalDataFlow.cs:153:21:153:25 | this access | GlobalDataFlow.cs:316:12:316:14 | this |
+| GlobalDataFlow.cs:153:21:153:25 | this access | GlobalDataFlow.cs:316:12:316:14 | this |
+| GlobalDataFlow.cs:154:9:154:20 | call to method Check | GlobalDataFlow.cs:154:9:154:20 | call to method Check |
+| GlobalDataFlow.cs:154:15:154:19 | access to local variable sink6 | GlobalDataFlow.cs:154:15:154:19 | access to local variable sink6 |
+| GlobalDataFlow.cs:155:16:155:20 | String sink7 | GlobalDataFlow.cs:155:16:155:20 | String sink7 |
+| GlobalDataFlow.cs:156:9:156:25 | call to method OutOut | GlobalDataFlow.cs:156:9:156:25 | call to method OutOut |
+| GlobalDataFlow.cs:156:9:156:25 | this access | GlobalDataFlow.cs:156:9:156:25 | this access |
+| GlobalDataFlow.cs:156:9:156:25 | this access | GlobalDataFlow.cs:159:9:159:25 | this access |
+| GlobalDataFlow.cs:156:9:156:25 | this access | GlobalDataFlow.cs:159:9:159:25 | this access |
+| GlobalDataFlow.cs:156:9:156:25 | this access | GlobalDataFlow.cs:161:22:161:31 | this access |
+| GlobalDataFlow.cs:156:9:156:25 | this access | GlobalDataFlow.cs:161:22:161:31 | this access |
+| GlobalDataFlow.cs:156:9:156:25 | this access | GlobalDataFlow.cs:167:20:167:27 | this access |
+| GlobalDataFlow.cs:156:9:156:25 | this access | GlobalDataFlow.cs:167:20:167:27 | this access |
+| GlobalDataFlow.cs:156:9:156:25 | this access | GlobalDataFlow.cs:169:9:169:31 | this access |
+| GlobalDataFlow.cs:156:9:156:25 | this access | GlobalDataFlow.cs:169:9:169:31 | this access |
+| GlobalDataFlow.cs:156:9:156:25 | this access | GlobalDataFlow.cs:171:9:171:31 | this access |
+| GlobalDataFlow.cs:156:9:156:25 | this access | GlobalDataFlow.cs:171:9:171:31 | this access |
+| GlobalDataFlow.cs:156:9:156:25 | this access | GlobalDataFlow.cs:173:20:173:32 | this access |
+| GlobalDataFlow.cs:156:9:156:25 | this access | GlobalDataFlow.cs:173:20:173:32 | this access |
+| GlobalDataFlow.cs:156:9:156:25 | this access | GlobalDataFlow.cs:189:39:189:41 | this access |
+| GlobalDataFlow.cs:156:9:156:25 | this access | GlobalDataFlow.cs:189:39:189:41 | this access |
+| GlobalDataFlow.cs:156:9:156:25 | this access | GlobalDataFlow.cs:193:37:193:42 | this access |
+| GlobalDataFlow.cs:156:9:156:25 | this access | GlobalDataFlow.cs:193:37:193:42 | this access |
+| GlobalDataFlow.cs:156:9:156:25 | this access | GlobalDataFlow.cs:197:22:197:32 | this access |
+| GlobalDataFlow.cs:156:9:156:25 | this access | GlobalDataFlow.cs:197:22:197:32 | this access |
+| GlobalDataFlow.cs:156:9:156:25 | this access | GlobalDataFlow.cs:201:20:201:33 | this access |
+| GlobalDataFlow.cs:156:9:156:25 | this access | GlobalDataFlow.cs:201:20:201:33 | this access |
+| GlobalDataFlow.cs:156:9:156:25 | this access | GlobalDataFlow.cs:321:10:321:15 | this |
+| GlobalDataFlow.cs:156:9:156:25 | this access | GlobalDataFlow.cs:321:10:321:15 | this |
+| GlobalDataFlow.cs:156:20:156:24 | SSA def(sink7) | GlobalDataFlow.cs:156:20:156:24 | SSA def(sink7) |
+| GlobalDataFlow.cs:156:20:156:24 | SSA def(sink7) | GlobalDataFlow.cs:157:15:157:19 | access to local variable sink7 |
+| GlobalDataFlow.cs:156:20:156:24 | SSA def(sink7) | GlobalDataFlow.cs:157:15:157:19 | access to local variable sink7 |
+| GlobalDataFlow.cs:157:9:157:20 | call to method Check | GlobalDataFlow.cs:157:9:157:20 | call to method Check |
+| GlobalDataFlow.cs:157:15:157:19 | access to local variable sink7 | GlobalDataFlow.cs:157:15:157:19 | access to local variable sink7 |
+| GlobalDataFlow.cs:158:13:158:22 | SSA def(sink8) | GlobalDataFlow.cs:158:13:158:22 | SSA def(sink8) |
+| GlobalDataFlow.cs:158:13:158:22 | SSA def(sink8) | GlobalDataFlow.cs:159:20:159:24 | access to local variable sink8 |
+| GlobalDataFlow.cs:158:13:158:22 | SSA def(sink8) | GlobalDataFlow.cs:159:20:159:24 | access to local variable sink8 |
+| GlobalDataFlow.cs:158:13:158:22 | String sink8 = ... | GlobalDataFlow.cs:158:13:158:22 | String sink8 = ... |
+| GlobalDataFlow.cs:158:21:158:22 | "" | GlobalDataFlow.cs:158:13:158:22 | SSA def(sink8) |
+| GlobalDataFlow.cs:158:21:158:22 | "" | GlobalDataFlow.cs:158:13:158:22 | SSA def(sink8) |
+| GlobalDataFlow.cs:158:21:158:22 | "" | GlobalDataFlow.cs:158:21:158:22 | "" |
+| GlobalDataFlow.cs:158:21:158:22 | "" | GlobalDataFlow.cs:159:20:159:24 | access to local variable sink8 |
+| GlobalDataFlow.cs:158:21:158:22 | "" | GlobalDataFlow.cs:159:20:159:24 | access to local variable sink8 |
+| GlobalDataFlow.cs:159:9:159:25 | call to method OutRef | GlobalDataFlow.cs:159:9:159:25 | call to method OutRef |
+| GlobalDataFlow.cs:159:9:159:25 | this access | GlobalDataFlow.cs:159:9:159:25 | this access |
+| GlobalDataFlow.cs:159:9:159:25 | this access | GlobalDataFlow.cs:161:22:161:31 | this access |
+| GlobalDataFlow.cs:159:9:159:25 | this access | GlobalDataFlow.cs:161:22:161:31 | this access |
+| GlobalDataFlow.cs:159:9:159:25 | this access | GlobalDataFlow.cs:167:20:167:27 | this access |
+| GlobalDataFlow.cs:159:9:159:25 | this access | GlobalDataFlow.cs:167:20:167:27 | this access |
+| GlobalDataFlow.cs:159:9:159:25 | this access | GlobalDataFlow.cs:169:9:169:31 | this access |
+| GlobalDataFlow.cs:159:9:159:25 | this access | GlobalDataFlow.cs:169:9:169:31 | this access |
+| GlobalDataFlow.cs:159:9:159:25 | this access | GlobalDataFlow.cs:171:9:171:31 | this access |
+| GlobalDataFlow.cs:159:9:159:25 | this access | GlobalDataFlow.cs:171:9:171:31 | this access |
+| GlobalDataFlow.cs:159:9:159:25 | this access | GlobalDataFlow.cs:173:20:173:32 | this access |
+| GlobalDataFlow.cs:159:9:159:25 | this access | GlobalDataFlow.cs:173:20:173:32 | this access |
+| GlobalDataFlow.cs:159:9:159:25 | this access | GlobalDataFlow.cs:189:39:189:41 | this access |
+| GlobalDataFlow.cs:159:9:159:25 | this access | GlobalDataFlow.cs:189:39:189:41 | this access |
+| GlobalDataFlow.cs:159:9:159:25 | this access | GlobalDataFlow.cs:193:37:193:42 | this access |
+| GlobalDataFlow.cs:159:9:159:25 | this access | GlobalDataFlow.cs:193:37:193:42 | this access |
+| GlobalDataFlow.cs:159:9:159:25 | this access | GlobalDataFlow.cs:197:22:197:32 | this access |
+| GlobalDataFlow.cs:159:9:159:25 | this access | GlobalDataFlow.cs:197:22:197:32 | this access |
+| GlobalDataFlow.cs:159:9:159:25 | this access | GlobalDataFlow.cs:201:20:201:33 | this access |
+| GlobalDataFlow.cs:159:9:159:25 | this access | GlobalDataFlow.cs:201:20:201:33 | this access |
+| GlobalDataFlow.cs:159:9:159:25 | this access | GlobalDataFlow.cs:326:10:326:15 | this |
+| GlobalDataFlow.cs:159:9:159:25 | this access | GlobalDataFlow.cs:326:10:326:15 | this |
+| GlobalDataFlow.cs:159:20:159:24 | SSA def(sink8) | GlobalDataFlow.cs:159:20:159:24 | SSA def(sink8) |
+| GlobalDataFlow.cs:159:20:159:24 | SSA def(sink8) | GlobalDataFlow.cs:160:15:160:19 | access to local variable sink8 |
+| GlobalDataFlow.cs:159:20:159:24 | SSA def(sink8) | GlobalDataFlow.cs:160:15:160:19 | access to local variable sink8 |
+| GlobalDataFlow.cs:159:20:159:24 | access to local variable sink8 | GlobalDataFlow.cs:159:20:159:24 | access to local variable sink8 |
+| GlobalDataFlow.cs:160:9:160:20 | call to method Check | GlobalDataFlow.cs:160:9:160:20 | call to method Check |
+| GlobalDataFlow.cs:160:15:160:19 | access to local variable sink8 | GlobalDataFlow.cs:160:15:160:19 | access to local variable sink8 |
+| GlobalDataFlow.cs:161:13:161:31 | IEnumerable<String> sink12 = ... | GlobalDataFlow.cs:161:13:161:31 | IEnumerable<String> sink12 = ... |
+| GlobalDataFlow.cs:161:13:161:31 | SSA def(sink12) | GlobalDataFlow.cs:161:13:161:31 | SSA def(sink12) |
+| GlobalDataFlow.cs:161:13:161:31 | SSA def(sink12) | GlobalDataFlow.cs:162:15:162:20 | access to local variable sink12 |
+| GlobalDataFlow.cs:161:13:161:31 | SSA def(sink12) | GlobalDataFlow.cs:162:15:162:20 | access to local variable sink12 |
+| GlobalDataFlow.cs:161:22:161:31 | call to method OutYield | GlobalDataFlow.cs:161:13:161:31 | SSA def(sink12) |
+| GlobalDataFlow.cs:161:22:161:31 | call to method OutYield | GlobalDataFlow.cs:161:13:161:31 | SSA def(sink12) |
+| GlobalDataFlow.cs:161:22:161:31 | call to method OutYield | GlobalDataFlow.cs:161:22:161:31 | call to method OutYield |
+| GlobalDataFlow.cs:161:22:161:31 | call to method OutYield | GlobalDataFlow.cs:162:15:162:20 | access to local variable sink12 |
+| GlobalDataFlow.cs:161:22:161:31 | call to method OutYield | GlobalDataFlow.cs:162:15:162:20 | access to local variable sink12 |
+| GlobalDataFlow.cs:161:22:161:31 | this access | GlobalDataFlow.cs:161:22:161:31 | this access |
+| GlobalDataFlow.cs:161:22:161:31 | this access | GlobalDataFlow.cs:167:20:167:27 | this access |
+| GlobalDataFlow.cs:161:22:161:31 | this access | GlobalDataFlow.cs:167:20:167:27 | this access |
+| GlobalDataFlow.cs:161:22:161:31 | this access | GlobalDataFlow.cs:169:9:169:31 | this access |
+| GlobalDataFlow.cs:161:22:161:31 | this access | GlobalDataFlow.cs:169:9:169:31 | this access |
+| GlobalDataFlow.cs:161:22:161:31 | this access | GlobalDataFlow.cs:171:9:171:31 | this access |
+| GlobalDataFlow.cs:161:22:161:31 | this access | GlobalDataFlow.cs:171:9:171:31 | this access |
+| GlobalDataFlow.cs:161:22:161:31 | this access | GlobalDataFlow.cs:173:20:173:32 | this access |
+| GlobalDataFlow.cs:161:22:161:31 | this access | GlobalDataFlow.cs:173:20:173:32 | this access |
+| GlobalDataFlow.cs:161:22:161:31 | this access | GlobalDataFlow.cs:189:39:189:41 | this access |
+| GlobalDataFlow.cs:161:22:161:31 | this access | GlobalDataFlow.cs:189:39:189:41 | this access |
+| GlobalDataFlow.cs:161:22:161:31 | this access | GlobalDataFlow.cs:193:37:193:42 | this access |
+| GlobalDataFlow.cs:161:22:161:31 | this access | GlobalDataFlow.cs:193:37:193:42 | this access |
+| GlobalDataFlow.cs:161:22:161:31 | this access | GlobalDataFlow.cs:197:22:197:32 | this access |
+| GlobalDataFlow.cs:161:22:161:31 | this access | GlobalDataFlow.cs:197:22:197:32 | this access |
+| GlobalDataFlow.cs:161:22:161:31 | this access | GlobalDataFlow.cs:201:20:201:33 | this access |
+| GlobalDataFlow.cs:161:22:161:31 | this access | GlobalDataFlow.cs:201:20:201:33 | this access |
+| GlobalDataFlow.cs:161:22:161:31 | this access | GlobalDataFlow.cs:331:25:331:32 | this |
+| GlobalDataFlow.cs:161:22:161:31 | this access | GlobalDataFlow.cs:331:25:331:32 | this |
+| GlobalDataFlow.cs:162:9:162:21 | call to method Check | GlobalDataFlow.cs:162:9:162:21 | call to method Check |
+| GlobalDataFlow.cs:162:15:162:20 | access to local variable sink12 | GlobalDataFlow.cs:162:15:162:20 | access to local variable sink12 |
+| GlobalDataFlow.cs:163:13:163:43 | SSA def(sink23) | GlobalDataFlow.cs:163:13:163:43 | SSA def(sink23) |
+| GlobalDataFlow.cs:163:13:163:43 | SSA def(sink23) | GlobalDataFlow.cs:164:15:164:20 | access to local variable sink23 |
+| GlobalDataFlow.cs:163:13:163:43 | SSA def(sink23) | GlobalDataFlow.cs:164:15:164:20 | access to local variable sink23 |
+| GlobalDataFlow.cs:163:13:163:43 | String sink23 = ... | GlobalDataFlow.cs:163:13:163:43 | String sink23 = ... |
+| GlobalDataFlow.cs:163:22:163:43 | call to method TaintedParam | GlobalDataFlow.cs:163:13:163:43 | SSA def(sink23) |
+| GlobalDataFlow.cs:163:22:163:43 | call to method TaintedParam | GlobalDataFlow.cs:163:13:163:43 | SSA def(sink23) |
+| GlobalDataFlow.cs:163:22:163:43 | call to method TaintedParam | GlobalDataFlow.cs:163:22:163:43 | call to method TaintedParam |
+| GlobalDataFlow.cs:163:22:163:43 | call to method TaintedParam | GlobalDataFlow.cs:164:15:164:20 | access to local variable sink23 |
+| GlobalDataFlow.cs:163:22:163:43 | call to method TaintedParam | GlobalDataFlow.cs:164:15:164:20 | access to local variable sink23 |
+| GlobalDataFlow.cs:163:35:163:42 | access to local variable nonSink0 | GlobalDataFlow.cs:163:22:163:43 | call to method TaintedParam |
+| GlobalDataFlow.cs:163:35:163:42 | access to local variable nonSink0 | GlobalDataFlow.cs:163:22:163:43 | call to method TaintedParam |
+| GlobalDataFlow.cs:163:35:163:42 | access to local variable nonSink0 | GlobalDataFlow.cs:163:35:163:42 | access to local variable nonSink0 |
+| GlobalDataFlow.cs:163:35:163:42 | access to local variable nonSink0 | GlobalDataFlow.cs:378:39:378:45 | tainted |
+| GlobalDataFlow.cs:163:35:163:42 | access to local variable nonSink0 | GlobalDataFlow.cs:378:39:378:45 | tainted |
+| GlobalDataFlow.cs:164:9:164:21 | call to method Check | GlobalDataFlow.cs:164:9:164:21 | call to method Check |
+| GlobalDataFlow.cs:164:15:164:20 | access to local variable sink23 | GlobalDataFlow.cs:164:15:164:20 | access to local variable sink23 |
+| GlobalDataFlow.cs:167:9:167:27 | ... = ... | GlobalDataFlow.cs:167:9:167:27 | ... = ... |
+| GlobalDataFlow.cs:167:9:167:27 | SSA def(nonSink0) | GlobalDataFlow.cs:167:9:167:27 | SSA def(nonSink0) |
+| GlobalDataFlow.cs:167:9:167:27 | SSA def(nonSink0) | GlobalDataFlow.cs:168:15:168:22 | access to local variable nonSink0 |
+| GlobalDataFlow.cs:167:9:167:27 | SSA def(nonSink0) | GlobalDataFlow.cs:168:15:168:22 | access to local variable nonSink0 |
+| GlobalDataFlow.cs:167:20:167:27 | call to method NonOut | GlobalDataFlow.cs:167:9:167:27 | SSA def(nonSink0) |
+| GlobalDataFlow.cs:167:20:167:27 | call to method NonOut | GlobalDataFlow.cs:167:9:167:27 | SSA def(nonSink0) |
+| GlobalDataFlow.cs:167:20:167:27 | call to method NonOut | GlobalDataFlow.cs:167:20:167:27 | call to method NonOut |
+| GlobalDataFlow.cs:167:20:167:27 | call to method NonOut | GlobalDataFlow.cs:168:15:168:22 | access to local variable nonSink0 |
+| GlobalDataFlow.cs:167:20:167:27 | call to method NonOut | GlobalDataFlow.cs:168:15:168:22 | access to local variable nonSink0 |
+| GlobalDataFlow.cs:167:20:167:27 | this access | GlobalDataFlow.cs:167:20:167:27 | this access |
+| GlobalDataFlow.cs:167:20:167:27 | this access | GlobalDataFlow.cs:169:9:169:31 | this access |
+| GlobalDataFlow.cs:167:20:167:27 | this access | GlobalDataFlow.cs:169:9:169:31 | this access |
+| GlobalDataFlow.cs:167:20:167:27 | this access | GlobalDataFlow.cs:171:9:171:31 | this access |
+| GlobalDataFlow.cs:167:20:167:27 | this access | GlobalDataFlow.cs:171:9:171:31 | this access |
+| GlobalDataFlow.cs:167:20:167:27 | this access | GlobalDataFlow.cs:173:20:173:32 | this access |
+| GlobalDataFlow.cs:167:20:167:27 | this access | GlobalDataFlow.cs:173:20:173:32 | this access |
+| GlobalDataFlow.cs:167:20:167:27 | this access | GlobalDataFlow.cs:189:39:189:41 | this access |
+| GlobalDataFlow.cs:167:20:167:27 | this access | GlobalDataFlow.cs:189:39:189:41 | this access |
+| GlobalDataFlow.cs:167:20:167:27 | this access | GlobalDataFlow.cs:193:37:193:42 | this access |
+| GlobalDataFlow.cs:167:20:167:27 | this access | GlobalDataFlow.cs:193:37:193:42 | this access |
+| GlobalDataFlow.cs:167:20:167:27 | this access | GlobalDataFlow.cs:197:22:197:32 | this access |
+| GlobalDataFlow.cs:167:20:167:27 | this access | GlobalDataFlow.cs:197:22:197:32 | this access |
+| GlobalDataFlow.cs:167:20:167:27 | this access | GlobalDataFlow.cs:201:20:201:33 | this access |
+| GlobalDataFlow.cs:167:20:167:27 | this access | GlobalDataFlow.cs:201:20:201:33 | this access |
+| GlobalDataFlow.cs:167:20:167:27 | this access | GlobalDataFlow.cs:338:12:338:17 | this |
+| GlobalDataFlow.cs:167:20:167:27 | this access | GlobalDataFlow.cs:338:12:338:17 | this |
 | GlobalDataFlow.cs:168:9:168:23 | call to method Check | GlobalDataFlow.cs:168:9:168:23 | call to method Check |
 | GlobalDataFlow.cs:168:15:168:22 | access to local variable nonSink0 | GlobalDataFlow.cs:168:15:168:22 | access to local variable nonSink0 |
-| GlobalDataFlow.cs:169:9:169:40 | ... = ... | GlobalDataFlow.cs:169:9:169:40 | ... = ... |
-| GlobalDataFlow.cs:169:9:169:40 | SSA def(nonSink0) | GlobalDataFlow.cs:169:9:169:40 | SSA def(nonSink0) |
-| GlobalDataFlow.cs:169:9:169:40 | SSA def(nonSink0) | GlobalDataFlow.cs:170:15:170:22 | access to local variable nonSink0 |
-| GlobalDataFlow.cs:169:9:169:40 | SSA def(nonSink0) | GlobalDataFlow.cs:170:15:170:22 | access to local variable nonSink0 |
-| GlobalDataFlow.cs:169:9:169:40 | SSA def(nonSink0) | GlobalDataFlow.cs:171:36:171:43 | access to local variable nonSink0 |
-| GlobalDataFlow.cs:169:9:169:40 | SSA def(nonSink0) | GlobalDataFlow.cs:171:36:171:43 | access to local variable nonSink0 |
-| GlobalDataFlow.cs:169:20:169:32 | call to method NonOutYield | GlobalDataFlow.cs:169:9:169:40 | SSA def(nonSink0) |
-| GlobalDataFlow.cs:169:20:169:32 | call to method NonOutYield | GlobalDataFlow.cs:169:9:169:40 | SSA def(nonSink0) |
-| GlobalDataFlow.cs:169:20:169:32 | call to method NonOutYield | GlobalDataFlow.cs:169:20:169:32 | call to method NonOutYield |
-| GlobalDataFlow.cs:169:20:169:32 | call to method NonOutYield | GlobalDataFlow.cs:169:20:169:40 | call to method First |
-| GlobalDataFlow.cs:169:20:169:32 | call to method NonOutYield | GlobalDataFlow.cs:169:20:169:40 | call to method First |
-| GlobalDataFlow.cs:169:20:169:32 | call to method NonOutYield | GlobalDataFlow.cs:170:15:170:22 | access to local variable nonSink0 |
-| GlobalDataFlow.cs:169:20:169:32 | call to method NonOutYield | GlobalDataFlow.cs:170:15:170:22 | access to local variable nonSink0 |
-| GlobalDataFlow.cs:169:20:169:32 | call to method NonOutYield | GlobalDataFlow.cs:171:36:171:43 | access to local variable nonSink0 |
-| GlobalDataFlow.cs:169:20:169:32 | call to method NonOutYield | GlobalDataFlow.cs:171:36:171:43 | access to local variable nonSink0 |
-| GlobalDataFlow.cs:169:20:169:32 | this access | GlobalDataFlow.cs:169:20:169:32 | this access |
-| GlobalDataFlow.cs:169:20:169:32 | this access | GlobalDataFlow.cs:185:39:185:41 | this access |
-| GlobalDataFlow.cs:169:20:169:32 | this access | GlobalDataFlow.cs:185:39:185:41 | this access |
-| GlobalDataFlow.cs:169:20:169:32 | this access | GlobalDataFlow.cs:189:37:189:42 | this access |
-| GlobalDataFlow.cs:169:20:169:32 | this access | GlobalDataFlow.cs:189:37:189:42 | this access |
-| GlobalDataFlow.cs:169:20:169:32 | this access | GlobalDataFlow.cs:193:22:193:32 | this access |
-| GlobalDataFlow.cs:169:20:169:32 | this access | GlobalDataFlow.cs:193:22:193:32 | this access |
-| GlobalDataFlow.cs:169:20:169:32 | this access | GlobalDataFlow.cs:197:20:197:33 | this access |
-| GlobalDataFlow.cs:169:20:169:32 | this access | GlobalDataFlow.cs:197:20:197:33 | this access |
-| GlobalDataFlow.cs:169:20:169:32 | this access | GlobalDataFlow.cs:348:25:348:35 | this |
-| GlobalDataFlow.cs:169:20:169:32 | this access | GlobalDataFlow.cs:348:25:348:35 | this |
-| GlobalDataFlow.cs:169:20:169:40 | call to method First | GlobalDataFlow.cs:169:9:169:40 | SSA def(nonSink0) |
-| GlobalDataFlow.cs:169:20:169:40 | call to method First | GlobalDataFlow.cs:169:9:169:40 | SSA def(nonSink0) |
-| GlobalDataFlow.cs:169:20:169:40 | call to method First | GlobalDataFlow.cs:169:20:169:40 | call to method First |
-| GlobalDataFlow.cs:169:20:169:40 | call to method First | GlobalDataFlow.cs:170:15:170:22 | access to local variable nonSink0 |
-| GlobalDataFlow.cs:169:20:169:40 | call to method First | GlobalDataFlow.cs:170:15:170:22 | access to local variable nonSink0 |
-| GlobalDataFlow.cs:169:20:169:40 | call to method First | GlobalDataFlow.cs:171:36:171:43 | access to local variable nonSink0 |
-| GlobalDataFlow.cs:169:20:169:40 | call to method First | GlobalDataFlow.cs:171:36:171:43 | access to local variable nonSink0 |
+| GlobalDataFlow.cs:169:9:169:31 | call to method NonOutOut | GlobalDataFlow.cs:169:9:169:31 | call to method NonOutOut |
+| GlobalDataFlow.cs:169:9:169:31 | this access | GlobalDataFlow.cs:169:9:169:31 | this access |
+| GlobalDataFlow.cs:169:9:169:31 | this access | GlobalDataFlow.cs:171:9:171:31 | this access |
+| GlobalDataFlow.cs:169:9:169:31 | this access | GlobalDataFlow.cs:171:9:171:31 | this access |
+| GlobalDataFlow.cs:169:9:169:31 | this access | GlobalDataFlow.cs:173:20:173:32 | this access |
+| GlobalDataFlow.cs:169:9:169:31 | this access | GlobalDataFlow.cs:173:20:173:32 | this access |
+| GlobalDataFlow.cs:169:9:169:31 | this access | GlobalDataFlow.cs:189:39:189:41 | this access |
+| GlobalDataFlow.cs:169:9:169:31 | this access | GlobalDataFlow.cs:189:39:189:41 | this access |
+| GlobalDataFlow.cs:169:9:169:31 | this access | GlobalDataFlow.cs:193:37:193:42 | this access |
+| GlobalDataFlow.cs:169:9:169:31 | this access | GlobalDataFlow.cs:193:37:193:42 | this access |
+| GlobalDataFlow.cs:169:9:169:31 | this access | GlobalDataFlow.cs:197:22:197:32 | this access |
+| GlobalDataFlow.cs:169:9:169:31 | this access | GlobalDataFlow.cs:197:22:197:32 | this access |
+| GlobalDataFlow.cs:169:9:169:31 | this access | GlobalDataFlow.cs:201:20:201:33 | this access |
+| GlobalDataFlow.cs:169:9:169:31 | this access | GlobalDataFlow.cs:201:20:201:33 | this access |
+| GlobalDataFlow.cs:169:9:169:31 | this access | GlobalDataFlow.cs:343:10:343:18 | this |
+| GlobalDataFlow.cs:169:9:169:31 | this access | GlobalDataFlow.cs:343:10:343:18 | this |
+| GlobalDataFlow.cs:169:23:169:30 | SSA def(nonSink0) | GlobalDataFlow.cs:169:23:169:30 | SSA def(nonSink0) |
+| GlobalDataFlow.cs:169:23:169:30 | SSA def(nonSink0) | GlobalDataFlow.cs:170:15:170:22 | access to local variable nonSink0 |
+| GlobalDataFlow.cs:169:23:169:30 | SSA def(nonSink0) | GlobalDataFlow.cs:170:15:170:22 | access to local variable nonSink0 |
+| GlobalDataFlow.cs:169:23:169:30 | SSA def(nonSink0) | GlobalDataFlow.cs:171:23:171:30 | access to local variable nonSink0 |
+| GlobalDataFlow.cs:169:23:169:30 | SSA def(nonSink0) | GlobalDataFlow.cs:171:23:171:30 | access to local variable nonSink0 |
 | GlobalDataFlow.cs:170:9:170:23 | call to method Check | GlobalDataFlow.cs:170:9:170:23 | call to method Check |
 | GlobalDataFlow.cs:170:15:170:22 | access to local variable nonSink0 | GlobalDataFlow.cs:170:15:170:22 | access to local variable nonSink0 |
-| GlobalDataFlow.cs:170:15:170:22 | access to local variable nonSink0 | GlobalDataFlow.cs:171:36:171:43 | access to local variable nonSink0 |
-| GlobalDataFlow.cs:170:15:170:22 | access to local variable nonSink0 | GlobalDataFlow.cs:171:36:171:43 | access to local variable nonSink0 |
-| GlobalDataFlow.cs:171:9:171:44 | ... = ... | GlobalDataFlow.cs:171:9:171:44 | ... = ... |
-| GlobalDataFlow.cs:171:9:171:44 | SSA def(nonSink0) | GlobalDataFlow.cs:171:9:171:44 | SSA def(nonSink0) |
-| GlobalDataFlow.cs:171:9:171:44 | SSA def(nonSink0) | GlobalDataFlow.cs:172:15:172:22 | access to local variable nonSink0 |
-| GlobalDataFlow.cs:171:9:171:44 | SSA def(nonSink0) | GlobalDataFlow.cs:172:15:172:22 | access to local variable nonSink0 |
-| GlobalDataFlow.cs:171:20:171:44 | call to method NonTaintedParam | GlobalDataFlow.cs:171:9:171:44 | SSA def(nonSink0) |
-| GlobalDataFlow.cs:171:20:171:44 | call to method NonTaintedParam | GlobalDataFlow.cs:171:9:171:44 | SSA def(nonSink0) |
-| GlobalDataFlow.cs:171:20:171:44 | call to method NonTaintedParam | GlobalDataFlow.cs:171:20:171:44 | call to method NonTaintedParam |
-| GlobalDataFlow.cs:171:20:171:44 | call to method NonTaintedParam | GlobalDataFlow.cs:172:15:172:22 | access to local variable nonSink0 |
-| GlobalDataFlow.cs:171:20:171:44 | call to method NonTaintedParam | GlobalDataFlow.cs:172:15:172:22 | access to local variable nonSink0 |
-| GlobalDataFlow.cs:171:36:171:43 | access to local variable nonSink0 | GlobalDataFlow.cs:171:20:171:44 | call to method NonTaintedParam |
-| GlobalDataFlow.cs:171:36:171:43 | access to local variable nonSink0 | GlobalDataFlow.cs:171:20:171:44 | call to method NonTaintedParam |
-| GlobalDataFlow.cs:171:36:171:43 | access to local variable nonSink0 | GlobalDataFlow.cs:171:36:171:43 | access to local variable nonSink0 |
-| GlobalDataFlow.cs:171:36:171:43 | access to local variable nonSink0 | GlobalDataFlow.cs:380:42:380:51 | nonTainted |
-| GlobalDataFlow.cs:171:36:171:43 | access to local variable nonSink0 | GlobalDataFlow.cs:380:42:380:51 | nonTainted |
+| GlobalDataFlow.cs:170:15:170:22 | access to local variable nonSink0 | GlobalDataFlow.cs:171:23:171:30 | access to local variable nonSink0 |
+| GlobalDataFlow.cs:170:15:170:22 | access to local variable nonSink0 | GlobalDataFlow.cs:171:23:171:30 | access to local variable nonSink0 |
+| GlobalDataFlow.cs:171:9:171:31 | call to method NonOutRef | GlobalDataFlow.cs:171:9:171:31 | call to method NonOutRef |
+| GlobalDataFlow.cs:171:9:171:31 | this access | GlobalDataFlow.cs:171:9:171:31 | this access |
+| GlobalDataFlow.cs:171:9:171:31 | this access | GlobalDataFlow.cs:173:20:173:32 | this access |
+| GlobalDataFlow.cs:171:9:171:31 | this access | GlobalDataFlow.cs:173:20:173:32 | this access |
+| GlobalDataFlow.cs:171:9:171:31 | this access | GlobalDataFlow.cs:189:39:189:41 | this access |
+| GlobalDataFlow.cs:171:9:171:31 | this access | GlobalDataFlow.cs:189:39:189:41 | this access |
+| GlobalDataFlow.cs:171:9:171:31 | this access | GlobalDataFlow.cs:193:37:193:42 | this access |
+| GlobalDataFlow.cs:171:9:171:31 | this access | GlobalDataFlow.cs:193:37:193:42 | this access |
+| GlobalDataFlow.cs:171:9:171:31 | this access | GlobalDataFlow.cs:197:22:197:32 | this access |
+| GlobalDataFlow.cs:171:9:171:31 | this access | GlobalDataFlow.cs:197:22:197:32 | this access |
+| GlobalDataFlow.cs:171:9:171:31 | this access | GlobalDataFlow.cs:201:20:201:33 | this access |
+| GlobalDataFlow.cs:171:9:171:31 | this access | GlobalDataFlow.cs:201:20:201:33 | this access |
+| GlobalDataFlow.cs:171:9:171:31 | this access | GlobalDataFlow.cs:348:10:348:18 | this |
+| GlobalDataFlow.cs:171:9:171:31 | this access | GlobalDataFlow.cs:348:10:348:18 | this |
+| GlobalDataFlow.cs:171:23:171:30 | SSA def(nonSink0) | GlobalDataFlow.cs:171:23:171:30 | SSA def(nonSink0) |
+| GlobalDataFlow.cs:171:23:171:30 | SSA def(nonSink0) | GlobalDataFlow.cs:172:15:172:22 | access to local variable nonSink0 |
+| GlobalDataFlow.cs:171:23:171:30 | SSA def(nonSink0) | GlobalDataFlow.cs:172:15:172:22 | access to local variable nonSink0 |
+| GlobalDataFlow.cs:171:23:171:30 | access to local variable nonSink0 | GlobalDataFlow.cs:171:23:171:30 | access to local variable nonSink0 |
 | GlobalDataFlow.cs:172:9:172:23 | call to method Check | GlobalDataFlow.cs:172:9:172:23 | call to method Check |
 | GlobalDataFlow.cs:172:15:172:22 | access to local variable nonSink0 | GlobalDataFlow.cs:172:15:172:22 | access to local variable nonSink0 |
-| GlobalDataFlow.cs:175:22:175:48 | Func<String> out = ... | GlobalDataFlow.cs:175:22:175:48 | Func<String> out = ... |
-| GlobalDataFlow.cs:175:22:175:48 | SSA def(out) | GlobalDataFlow.cs:175:22:175:48 | SSA def(out) |
-| GlobalDataFlow.cs:175:22:175:48 | SSA def(out) | GlobalDataFlow.cs:176:21:176:24 | access to local variable out |
-| GlobalDataFlow.cs:175:22:175:48 | SSA def(out) | GlobalDataFlow.cs:176:21:176:24 | access to local variable out |
-| GlobalDataFlow.cs:175:29:175:48 | (...) => ... | GlobalDataFlow.cs:175:22:175:48 | SSA def(out) |
-| GlobalDataFlow.cs:175:29:175:48 | (...) => ... | GlobalDataFlow.cs:175:22:175:48 | SSA def(out) |
-| GlobalDataFlow.cs:175:29:175:48 | (...) => ... | GlobalDataFlow.cs:175:29:175:48 | (...) => ... |
-| GlobalDataFlow.cs:175:29:175:48 | (...) => ... | GlobalDataFlow.cs:176:21:176:24 | access to local variable out |
-| GlobalDataFlow.cs:175:29:175:48 | (...) => ... | GlobalDataFlow.cs:176:21:176:24 | access to local variable out |
-| GlobalDataFlow.cs:175:35:175:48 | "taint source" | GlobalDataFlow.cs:175:35:175:48 | "taint source" |
-| GlobalDataFlow.cs:175:35:175:48 | "taint source" | GlobalDataFlow.cs:176:21:176:26 | delegate call |
-| GlobalDataFlow.cs:175:35:175:48 | "taint source" | GlobalDataFlow.cs:176:21:176:26 | delegate call |
-| GlobalDataFlow.cs:176:13:176:26 | SSA def(sink9) | GlobalDataFlow.cs:176:13:176:26 | SSA def(sink9) |
-| GlobalDataFlow.cs:176:13:176:26 | SSA def(sink9) | GlobalDataFlow.cs:177:15:177:19 | access to local variable sink9 |
-| GlobalDataFlow.cs:176:13:176:26 | SSA def(sink9) | GlobalDataFlow.cs:177:15:177:19 | access to local variable sink9 |
-| GlobalDataFlow.cs:176:13:176:26 | String sink9 = ... | GlobalDataFlow.cs:176:13:176:26 | String sink9 = ... |
-| GlobalDataFlow.cs:176:21:176:24 | access to local variable out | GlobalDataFlow.cs:176:21:176:24 | access to local variable out |
-| GlobalDataFlow.cs:176:21:176:26 | delegate call | GlobalDataFlow.cs:176:13:176:26 | SSA def(sink9) |
-| GlobalDataFlow.cs:176:21:176:26 | delegate call | GlobalDataFlow.cs:176:13:176:26 | SSA def(sink9) |
-| GlobalDataFlow.cs:176:21:176:26 | delegate call | GlobalDataFlow.cs:176:21:176:26 | delegate call |
-| GlobalDataFlow.cs:176:21:176:26 | delegate call | GlobalDataFlow.cs:177:15:177:19 | access to local variable sink9 |
-| GlobalDataFlow.cs:176:21:176:26 | delegate call | GlobalDataFlow.cs:177:15:177:19 | access to local variable sink9 |
-| GlobalDataFlow.cs:177:9:177:20 | call to method Check | GlobalDataFlow.cs:177:9:177:20 | call to method Check |
-| GlobalDataFlow.cs:177:15:177:19 | access to local variable sink9 | GlobalDataFlow.cs:177:15:177:19 | access to local variable sink9 |
-| GlobalDataFlow.cs:180:22:180:38 | Func<String> nonOut = ... | GlobalDataFlow.cs:180:22:180:38 | Func<String> nonOut = ... |
-| GlobalDataFlow.cs:180:22:180:38 | SSA def(nonOut) | GlobalDataFlow.cs:180:22:180:38 | SSA def(nonOut) |
-| GlobalDataFlow.cs:180:22:180:38 | SSA def(nonOut) | GlobalDataFlow.cs:181:20:181:25 | access to local variable nonOut |
-| GlobalDataFlow.cs:180:22:180:38 | SSA def(nonOut) | GlobalDataFlow.cs:181:20:181:25 | access to local variable nonOut |
-| GlobalDataFlow.cs:180:31:180:38 | (...) => ... | GlobalDataFlow.cs:180:22:180:38 | SSA def(nonOut) |
-| GlobalDataFlow.cs:180:31:180:38 | (...) => ... | GlobalDataFlow.cs:180:22:180:38 | SSA def(nonOut) |
-| GlobalDataFlow.cs:180:31:180:38 | (...) => ... | GlobalDataFlow.cs:180:31:180:38 | (...) => ... |
-| GlobalDataFlow.cs:180:31:180:38 | (...) => ... | GlobalDataFlow.cs:181:20:181:25 | access to local variable nonOut |
-| GlobalDataFlow.cs:180:31:180:38 | (...) => ... | GlobalDataFlow.cs:181:20:181:25 | access to local variable nonOut |
-| GlobalDataFlow.cs:180:37:180:38 | "" | GlobalDataFlow.cs:180:37:180:38 | "" |
-| GlobalDataFlow.cs:180:37:180:38 | "" | GlobalDataFlow.cs:181:20:181:27 | delegate call |
-| GlobalDataFlow.cs:180:37:180:38 | "" | GlobalDataFlow.cs:181:20:181:27 | delegate call |
-| GlobalDataFlow.cs:181:9:181:27 | ... = ... | GlobalDataFlow.cs:181:9:181:27 | ... = ... |
-| GlobalDataFlow.cs:181:9:181:27 | SSA def(nonSink0) | GlobalDataFlow.cs:181:9:181:27 | SSA def(nonSink0) |
-| GlobalDataFlow.cs:181:9:181:27 | SSA def(nonSink0) | GlobalDataFlow.cs:182:15:182:22 | access to local variable nonSink0 |
-| GlobalDataFlow.cs:181:9:181:27 | SSA def(nonSink0) | GlobalDataFlow.cs:182:15:182:22 | access to local variable nonSink0 |
-| GlobalDataFlow.cs:181:20:181:25 | access to local variable nonOut | GlobalDataFlow.cs:181:20:181:25 | access to local variable nonOut |
-| GlobalDataFlow.cs:181:20:181:27 | delegate call | GlobalDataFlow.cs:181:9:181:27 | SSA def(nonSink0) |
-| GlobalDataFlow.cs:181:20:181:27 | delegate call | GlobalDataFlow.cs:181:9:181:27 | SSA def(nonSink0) |
-| GlobalDataFlow.cs:181:20:181:27 | delegate call | GlobalDataFlow.cs:181:20:181:27 | delegate call |
-| GlobalDataFlow.cs:181:20:181:27 | delegate call | GlobalDataFlow.cs:182:15:182:22 | access to local variable nonSink0 |
-| GlobalDataFlow.cs:181:20:181:27 | delegate call | GlobalDataFlow.cs:182:15:182:22 | access to local variable nonSink0 |
-| GlobalDataFlow.cs:182:9:182:23 | call to method Check | GlobalDataFlow.cs:182:9:182:23 | call to method Check |
-| GlobalDataFlow.cs:182:15:182:22 | access to local variable nonSink0 | GlobalDataFlow.cs:182:15:182:22 | access to local variable nonSink0 |
-| GlobalDataFlow.cs:185:13:185:48 | SSA def(sink10) | GlobalDataFlow.cs:185:13:185:48 | SSA def(sink10) |
-| GlobalDataFlow.cs:185:13:185:48 | SSA def(sink10) | GlobalDataFlow.cs:186:15:186:20 | access to local variable sink10 |
-| GlobalDataFlow.cs:185:13:185:48 | SSA def(sink10) | GlobalDataFlow.cs:186:15:186:20 | access to local variable sink10 |
-| GlobalDataFlow.cs:185:13:185:48 | String sink10 = ... | GlobalDataFlow.cs:185:13:185:48 | String sink10 = ... |
-| GlobalDataFlow.cs:185:22:185:42 | malloc | GlobalDataFlow.cs:185:22:185:42 | malloc |
-| GlobalDataFlow.cs:185:22:185:42 | object creation of type Lazy<String> | GlobalDataFlow.cs:185:13:185:48 | SSA def(sink10) |
-| GlobalDataFlow.cs:185:22:185:42 | object creation of type Lazy<String> | GlobalDataFlow.cs:185:13:185:48 | SSA def(sink10) |
-| GlobalDataFlow.cs:185:22:185:42 | object creation of type Lazy<String> | GlobalDataFlow.cs:185:22:185:42 | object creation of type Lazy<String> |
-| GlobalDataFlow.cs:185:22:185:42 | object creation of type Lazy<String> | GlobalDataFlow.cs:185:22:185:48 | access to property Value |
-| GlobalDataFlow.cs:185:22:185:42 | object creation of type Lazy<String> | GlobalDataFlow.cs:185:22:185:48 | access to property Value |
-| GlobalDataFlow.cs:185:22:185:42 | object creation of type Lazy<String> | GlobalDataFlow.cs:186:15:186:20 | access to local variable sink10 |
-| GlobalDataFlow.cs:185:22:185:42 | object creation of type Lazy<String> | GlobalDataFlow.cs:186:15:186:20 | access to local variable sink10 |
-| GlobalDataFlow.cs:185:22:185:48 | access to property Value | GlobalDataFlow.cs:185:13:185:48 | SSA def(sink10) |
-| GlobalDataFlow.cs:185:22:185:48 | access to property Value | GlobalDataFlow.cs:185:13:185:48 | SSA def(sink10) |
-| GlobalDataFlow.cs:185:22:185:48 | access to property Value | GlobalDataFlow.cs:185:22:185:48 | access to property Value |
-| GlobalDataFlow.cs:185:22:185:48 | access to property Value | GlobalDataFlow.cs:186:15:186:20 | access to local variable sink10 |
-| GlobalDataFlow.cs:185:22:185:48 | access to property Value | GlobalDataFlow.cs:186:15:186:20 | access to local variable sink10 |
-| GlobalDataFlow.cs:185:39:185:41 | [output] delegate creation of type Func<String> | GlobalDataFlow.cs:185:13:185:48 | SSA def(sink10) |
-| GlobalDataFlow.cs:185:39:185:41 | [output] delegate creation of type Func<String> | GlobalDataFlow.cs:185:13:185:48 | SSA def(sink10) |
-| GlobalDataFlow.cs:185:39:185:41 | [output] delegate creation of type Func<String> | GlobalDataFlow.cs:185:22:185:42 | object creation of type Lazy<String> |
-| GlobalDataFlow.cs:185:39:185:41 | [output] delegate creation of type Func<String> | GlobalDataFlow.cs:185:22:185:42 | object creation of type Lazy<String> |
-| GlobalDataFlow.cs:185:39:185:41 | [output] delegate creation of type Func<String> | GlobalDataFlow.cs:185:22:185:48 | access to property Value |
-| GlobalDataFlow.cs:185:39:185:41 | [output] delegate creation of type Func<String> | GlobalDataFlow.cs:185:22:185:48 | access to property Value |
-| GlobalDataFlow.cs:185:39:185:41 | [output] delegate creation of type Func<String> | GlobalDataFlow.cs:185:39:185:41 | [output] delegate creation of type Func<String> |
-| GlobalDataFlow.cs:185:39:185:41 | [output] delegate creation of type Func<String> | GlobalDataFlow.cs:186:15:186:20 | access to local variable sink10 |
-| GlobalDataFlow.cs:185:39:185:41 | [output] delegate creation of type Func<String> | GlobalDataFlow.cs:186:15:186:20 | access to local variable sink10 |
-| GlobalDataFlow.cs:185:39:185:41 | access to method Out | GlobalDataFlow.cs:185:39:185:41 | access to method Out |
-| GlobalDataFlow.cs:185:39:185:41 | delegate creation of type Func<String> | GlobalDataFlow.cs:185:39:185:41 | delegate creation of type Func<String> |
-| GlobalDataFlow.cs:185:39:185:41 | this access | GlobalDataFlow.cs:185:39:185:41 | this access |
-| GlobalDataFlow.cs:185:39:185:41 | this access | GlobalDataFlow.cs:189:37:189:42 | this access |
-| GlobalDataFlow.cs:185:39:185:41 | this access | GlobalDataFlow.cs:189:37:189:42 | this access |
-| GlobalDataFlow.cs:185:39:185:41 | this access | GlobalDataFlow.cs:193:22:193:32 | this access |
-| GlobalDataFlow.cs:185:39:185:41 | this access | GlobalDataFlow.cs:193:22:193:32 | this access |
-| GlobalDataFlow.cs:185:39:185:41 | this access | GlobalDataFlow.cs:197:20:197:33 | this access |
-| GlobalDataFlow.cs:185:39:185:41 | this access | GlobalDataFlow.cs:197:20:197:33 | this access |
-| GlobalDataFlow.cs:186:9:186:21 | call to method Check | GlobalDataFlow.cs:186:9:186:21 | call to method Check |
-| GlobalDataFlow.cs:186:15:186:20 | access to local variable sink10 | GlobalDataFlow.cs:186:15:186:20 | access to local variable sink10 |
-| GlobalDataFlow.cs:189:9:189:49 | ... = ... | GlobalDataFlow.cs:189:9:189:49 | ... = ... |
-| GlobalDataFlow.cs:189:9:189:49 | SSA def(nonSink0) | GlobalDataFlow.cs:189:9:189:49 | SSA def(nonSink0) |
-| GlobalDataFlow.cs:189:9:189:49 | SSA def(nonSink0) | GlobalDataFlow.cs:190:15:190:22 | access to local variable nonSink0 |
-| GlobalDataFlow.cs:189:9:189:49 | SSA def(nonSink0) | GlobalDataFlow.cs:190:15:190:22 | access to local variable nonSink0 |
-| GlobalDataFlow.cs:189:20:189:43 | malloc | GlobalDataFlow.cs:189:20:189:43 | malloc |
-| GlobalDataFlow.cs:189:20:189:43 | object creation of type Lazy<String> | GlobalDataFlow.cs:189:9:189:49 | SSA def(nonSink0) |
-| GlobalDataFlow.cs:189:20:189:43 | object creation of type Lazy<String> | GlobalDataFlow.cs:189:9:189:49 | SSA def(nonSink0) |
-| GlobalDataFlow.cs:189:20:189:43 | object creation of type Lazy<String> | GlobalDataFlow.cs:189:20:189:43 | object creation of type Lazy<String> |
-| GlobalDataFlow.cs:189:20:189:43 | object creation of type Lazy<String> | GlobalDataFlow.cs:189:20:189:49 | access to property Value |
-| GlobalDataFlow.cs:189:20:189:43 | object creation of type Lazy<String> | GlobalDataFlow.cs:189:20:189:49 | access to property Value |
-| GlobalDataFlow.cs:189:20:189:43 | object creation of type Lazy<String> | GlobalDataFlow.cs:190:15:190:22 | access to local variable nonSink0 |
-| GlobalDataFlow.cs:189:20:189:43 | object creation of type Lazy<String> | GlobalDataFlow.cs:190:15:190:22 | access to local variable nonSink0 |
-| GlobalDataFlow.cs:189:20:189:49 | access to property Value | GlobalDataFlow.cs:189:9:189:49 | SSA def(nonSink0) |
-| GlobalDataFlow.cs:189:20:189:49 | access to property Value | GlobalDataFlow.cs:189:9:189:49 | SSA def(nonSink0) |
-| GlobalDataFlow.cs:189:20:189:49 | access to property Value | GlobalDataFlow.cs:189:20:189:49 | access to property Value |
-| GlobalDataFlow.cs:189:20:189:49 | access to property Value | GlobalDataFlow.cs:190:15:190:22 | access to local variable nonSink0 |
-| GlobalDataFlow.cs:189:20:189:49 | access to property Value | GlobalDataFlow.cs:190:15:190:22 | access to local variable nonSink0 |
-| GlobalDataFlow.cs:189:37:189:42 | [output] delegate creation of type Func<String> | GlobalDataFlow.cs:189:9:189:49 | SSA def(nonSink0) |
-| GlobalDataFlow.cs:189:37:189:42 | [output] delegate creation of type Func<String> | GlobalDataFlow.cs:189:9:189:49 | SSA def(nonSink0) |
-| GlobalDataFlow.cs:189:37:189:42 | [output] delegate creation of type Func<String> | GlobalDataFlow.cs:189:20:189:43 | object creation of type Lazy<String> |
-| GlobalDataFlow.cs:189:37:189:42 | [output] delegate creation of type Func<String> | GlobalDataFlow.cs:189:20:189:43 | object creation of type Lazy<String> |
-| GlobalDataFlow.cs:189:37:189:42 | [output] delegate creation of type Func<String> | GlobalDataFlow.cs:189:20:189:49 | access to property Value |
-| GlobalDataFlow.cs:189:37:189:42 | [output] delegate creation of type Func<String> | GlobalDataFlow.cs:189:20:189:49 | access to property Value |
-| GlobalDataFlow.cs:189:37:189:42 | [output] delegate creation of type Func<String> | GlobalDataFlow.cs:189:37:189:42 | [output] delegate creation of type Func<String> |
-| GlobalDataFlow.cs:189:37:189:42 | [output] delegate creation of type Func<String> | GlobalDataFlow.cs:190:15:190:22 | access to local variable nonSink0 |
-| GlobalDataFlow.cs:189:37:189:42 | [output] delegate creation of type Func<String> | GlobalDataFlow.cs:190:15:190:22 | access to local variable nonSink0 |
-| GlobalDataFlow.cs:189:37:189:42 | access to method NonOut | GlobalDataFlow.cs:189:37:189:42 | access to method NonOut |
-| GlobalDataFlow.cs:189:37:189:42 | delegate creation of type Func<String> | GlobalDataFlow.cs:189:37:189:42 | delegate creation of type Func<String> |
-| GlobalDataFlow.cs:189:37:189:42 | this access | GlobalDataFlow.cs:189:37:189:42 | this access |
-| GlobalDataFlow.cs:189:37:189:42 | this access | GlobalDataFlow.cs:193:22:193:32 | this access |
-| GlobalDataFlow.cs:189:37:189:42 | this access | GlobalDataFlow.cs:193:22:193:32 | this access |
-| GlobalDataFlow.cs:189:37:189:42 | this access | GlobalDataFlow.cs:197:20:197:33 | this access |
-| GlobalDataFlow.cs:189:37:189:42 | this access | GlobalDataFlow.cs:197:20:197:33 | this access |
-| GlobalDataFlow.cs:190:9:190:23 | call to method Check | GlobalDataFlow.cs:190:9:190:23 | call to method Check |
-| GlobalDataFlow.cs:190:15:190:22 | access to local variable nonSink0 | GlobalDataFlow.cs:190:15:190:22 | access to local variable nonSink0 |
-| GlobalDataFlow.cs:193:13:193:32 | SSA def(sink19) | GlobalDataFlow.cs:193:13:193:32 | SSA def(sink19) |
-| GlobalDataFlow.cs:193:13:193:32 | SSA def(sink19) | GlobalDataFlow.cs:194:15:194:20 | access to local variable sink19 |
-| GlobalDataFlow.cs:193:13:193:32 | SSA def(sink19) | GlobalDataFlow.cs:194:15:194:20 | access to local variable sink19 |
-| GlobalDataFlow.cs:193:13:193:32 | String sink19 = ... | GlobalDataFlow.cs:193:13:193:32 | String sink19 = ... |
-| GlobalDataFlow.cs:193:22:193:32 | SSA untracked def(this.OutProperty) | GlobalDataFlow.cs:193:22:193:32 | SSA untracked def(this.OutProperty) |
-| GlobalDataFlow.cs:193:22:193:32 | access to property OutProperty | GlobalDataFlow.cs:193:13:193:32 | SSA def(sink19) |
-| GlobalDataFlow.cs:193:22:193:32 | access to property OutProperty | GlobalDataFlow.cs:193:13:193:32 | SSA def(sink19) |
-| GlobalDataFlow.cs:193:22:193:32 | access to property OutProperty | GlobalDataFlow.cs:193:22:193:32 | access to property OutProperty |
-| GlobalDataFlow.cs:193:22:193:32 | access to property OutProperty | GlobalDataFlow.cs:194:15:194:20 | access to local variable sink19 |
-| GlobalDataFlow.cs:193:22:193:32 | access to property OutProperty | GlobalDataFlow.cs:194:15:194:20 | access to local variable sink19 |
-| GlobalDataFlow.cs:193:22:193:32 | this access | GlobalDataFlow.cs:193:22:193:32 | this access |
-| GlobalDataFlow.cs:193:22:193:32 | this access | GlobalDataFlow.cs:197:20:197:33 | this access |
-| GlobalDataFlow.cs:193:22:193:32 | this access | GlobalDataFlow.cs:197:20:197:33 | this access |
-| GlobalDataFlow.cs:193:22:193:32 | this access | GlobalDataFlow.cs:410:9:410:11 | this |
-| GlobalDataFlow.cs:193:22:193:32 | this access | GlobalDataFlow.cs:410:9:410:11 | this |
-| GlobalDataFlow.cs:194:9:194:21 | call to method Check | GlobalDataFlow.cs:194:9:194:21 | call to method Check |
-| GlobalDataFlow.cs:194:15:194:20 | access to local variable sink19 | GlobalDataFlow.cs:194:15:194:20 | access to local variable sink19 |
-| GlobalDataFlow.cs:197:9:197:33 | ... = ... | GlobalDataFlow.cs:197:9:197:33 | ... = ... |
-| GlobalDataFlow.cs:197:9:197:33 | SSA def(nonSink0) | GlobalDataFlow.cs:197:9:197:33 | SSA def(nonSink0) |
-| GlobalDataFlow.cs:197:9:197:33 | SSA def(nonSink0) | GlobalDataFlow.cs:198:15:198:22 | access to local variable nonSink0 |
-| GlobalDataFlow.cs:197:9:197:33 | SSA def(nonSink0) | GlobalDataFlow.cs:198:15:198:22 | access to local variable nonSink0 |
-| GlobalDataFlow.cs:197:20:197:33 | SSA untracked def(this.NonOutProperty) | GlobalDataFlow.cs:197:20:197:33 | SSA untracked def(this.NonOutProperty) |
-| GlobalDataFlow.cs:197:20:197:33 | access to property NonOutProperty | GlobalDataFlow.cs:197:9:197:33 | SSA def(nonSink0) |
-| GlobalDataFlow.cs:197:20:197:33 | access to property NonOutProperty | GlobalDataFlow.cs:197:9:197:33 | SSA def(nonSink0) |
-| GlobalDataFlow.cs:197:20:197:33 | access to property NonOutProperty | GlobalDataFlow.cs:197:20:197:33 | access to property NonOutProperty |
-| GlobalDataFlow.cs:197:20:197:33 | access to property NonOutProperty | GlobalDataFlow.cs:198:15:198:22 | access to local variable nonSink0 |
-| GlobalDataFlow.cs:197:20:197:33 | access to property NonOutProperty | GlobalDataFlow.cs:198:15:198:22 | access to local variable nonSink0 |
-| GlobalDataFlow.cs:197:20:197:33 | this access | GlobalDataFlow.cs:197:20:197:33 | this access |
-| GlobalDataFlow.cs:197:20:197:33 | this access | GlobalDataFlow.cs:415:9:415:11 | this |
-| GlobalDataFlow.cs:197:20:197:33 | this access | GlobalDataFlow.cs:415:9:415:11 | this |
-| GlobalDataFlow.cs:198:9:198:23 | call to method Check | GlobalDataFlow.cs:198:9:198:23 | call to method Check |
-| GlobalDataFlow.cs:198:15:198:22 | access to local variable nonSink0 | GlobalDataFlow.cs:198:15:198:22 | access to local variable nonSink0 |
-| GlobalDataFlow.cs:201:17:201:18 | this | GlobalDataFlow.cs:201:17:201:18 | this |
-| GlobalDataFlow.cs:201:39:201:45 | tainted | GlobalDataFlow.cs:201:39:201:45 | tainted |
-| GlobalDataFlow.cs:201:39:201:45 | tainted | GlobalDataFlow.cs:201:39:201:45 | tainted |
-| GlobalDataFlow.cs:201:39:201:45 | tainted | GlobalDataFlow.cs:201:39:201:45 | tainted |
-| GlobalDataFlow.cs:201:39:201:45 | tainted | GlobalDataFlow.cs:201:39:201:45 | tainted |
-| GlobalDataFlow.cs:201:39:201:45 | tainted | GlobalDataFlow.cs:206:22:206:28 | access to parameter tainted |
-| GlobalDataFlow.cs:201:39:201:45 | tainted | GlobalDataFlow.cs:206:22:206:28 | access to parameter tainted |
-| GlobalDataFlow.cs:201:39:201:45 | tainted | GlobalDataFlow.cs:206:22:206:28 | access to parameter tainted |
-| GlobalDataFlow.cs:201:39:201:45 | tainted | GlobalDataFlow.cs:206:22:206:28 | access to parameter tainted |
-| GlobalDataFlow.cs:201:39:201:45 | tainted | GlobalDataFlow.cs:208:22:208:28 | access to parameter tainted |
-| GlobalDataFlow.cs:201:39:201:45 | tainted | GlobalDataFlow.cs:208:22:208:28 | access to parameter tainted |
-| GlobalDataFlow.cs:201:39:201:45 | tainted | GlobalDataFlow.cs:208:22:208:28 | access to parameter tainted |
-| GlobalDataFlow.cs:201:39:201:45 | tainted | GlobalDataFlow.cs:208:22:208:28 | access to parameter tainted |
-| GlobalDataFlow.cs:201:39:201:45 | tainted | GlobalDataFlow.cs:210:22:210:28 | access to parameter tainted |
-| GlobalDataFlow.cs:201:39:201:45 | tainted | GlobalDataFlow.cs:210:22:210:28 | access to parameter tainted |
-| GlobalDataFlow.cs:201:39:201:45 | tainted | GlobalDataFlow.cs:210:22:210:28 | access to parameter tainted |
-| GlobalDataFlow.cs:201:39:201:45 | tainted | GlobalDataFlow.cs:210:22:210:28 | access to parameter tainted |
-| GlobalDataFlow.cs:201:67:201:76 | notTainted | GlobalDataFlow.cs:201:67:201:76 | notTainted |
-| GlobalDataFlow.cs:201:67:201:76 | notTainted | GlobalDataFlow.cs:201:67:201:76 | notTainted |
-| GlobalDataFlow.cs:201:67:201:76 | notTainted | GlobalDataFlow.cs:201:67:201:76 | notTainted |
-| GlobalDataFlow.cs:201:67:201:76 | notTainted | GlobalDataFlow.cs:201:67:201:76 | notTainted |
-| GlobalDataFlow.cs:201:67:201:76 | notTainted | GlobalDataFlow.cs:216:23:216:32 | access to parameter notTainted |
-| GlobalDataFlow.cs:201:67:201:76 | notTainted | GlobalDataFlow.cs:216:23:216:32 | access to parameter notTainted |
-| GlobalDataFlow.cs:201:67:201:76 | notTainted | GlobalDataFlow.cs:216:23:216:32 | access to parameter notTainted |
-| GlobalDataFlow.cs:201:67:201:76 | notTainted | GlobalDataFlow.cs:216:23:216:32 | access to parameter notTainted |
-| GlobalDataFlow.cs:201:67:201:76 | notTainted | GlobalDataFlow.cs:218:19:218:28 | access to parameter notTainted |
-| GlobalDataFlow.cs:201:67:201:76 | notTainted | GlobalDataFlow.cs:218:19:218:28 | access to parameter notTainted |
-| GlobalDataFlow.cs:201:67:201:76 | notTainted | GlobalDataFlow.cs:218:19:218:28 | access to parameter notTainted |
-| GlobalDataFlow.cs:201:67:201:76 | notTainted | GlobalDataFlow.cs:218:19:218:28 | access to parameter notTainted |
-| GlobalDataFlow.cs:201:67:201:76 | notTainted | GlobalDataFlow.cs:220:19:220:28 | access to parameter notTainted |
-| GlobalDataFlow.cs:201:67:201:76 | notTainted | GlobalDataFlow.cs:220:19:220:28 | access to parameter notTainted |
-| GlobalDataFlow.cs:201:67:201:76 | notTainted | GlobalDataFlow.cs:220:19:220:28 | access to parameter notTainted |
-| GlobalDataFlow.cs:201:67:201:76 | notTainted | GlobalDataFlow.cs:220:19:220:28 | access to parameter notTainted |
-| GlobalDataFlow.cs:201:67:201:76 | notTainted | GlobalDataFlow.cs:222:19:222:28 | access to parameter notTainted |
-| GlobalDataFlow.cs:201:67:201:76 | notTainted | GlobalDataFlow.cs:222:19:222:28 | access to parameter notTainted |
-| GlobalDataFlow.cs:201:67:201:76 | notTainted | GlobalDataFlow.cs:222:19:222:28 | access to parameter notTainted |
-| GlobalDataFlow.cs:201:67:201:76 | notTainted | GlobalDataFlow.cs:222:19:222:28 | access to parameter notTainted |
-| GlobalDataFlow.cs:201:67:201:76 | notTainted | GlobalDataFlow.cs:224:19:224:28 | access to parameter notTainted |
-| GlobalDataFlow.cs:201:67:201:76 | notTainted | GlobalDataFlow.cs:224:19:224:28 | access to parameter notTainted |
-| GlobalDataFlow.cs:201:67:201:76 | notTainted | GlobalDataFlow.cs:224:19:224:28 | access to parameter notTainted |
-| GlobalDataFlow.cs:201:67:201:76 | notTainted | GlobalDataFlow.cs:224:19:224:28 | access to parameter notTainted |
-| GlobalDataFlow.cs:204:30:204:92 | Func<String,String> f1 = ... | GlobalDataFlow.cs:204:30:204:92 | Func<String,String> f1 = ... |
-| GlobalDataFlow.cs:204:30:204:92 | SSA def(f1) | GlobalDataFlow.cs:204:30:204:92 | SSA def(f1) |
-| GlobalDataFlow.cs:204:30:204:92 | SSA def(f1) | GlobalDataFlow.cs:206:37:206:38 | access to local variable f1 |
-| GlobalDataFlow.cs:204:30:204:92 | SSA def(f1) | GlobalDataFlow.cs:206:37:206:38 | access to local variable f1 |
-| GlobalDataFlow.cs:204:30:204:92 | SSA def(f1) | GlobalDataFlow.cs:216:41:216:42 | access to local variable f1 |
-| GlobalDataFlow.cs:204:30:204:92 | SSA def(f1) | GlobalDataFlow.cs:216:41:216:42 | access to local variable f1 |
-| GlobalDataFlow.cs:204:35:204:45 | sinkParam10 | GlobalDataFlow.cs:204:35:204:45 | sinkParam10 |
-| GlobalDataFlow.cs:204:35:204:45 | sinkParam10 | GlobalDataFlow.cs:204:35:204:45 | sinkParam10 |
-| GlobalDataFlow.cs:204:35:204:45 | sinkParam10 | GlobalDataFlow.cs:204:35:204:45 | sinkParam10 |
-| GlobalDataFlow.cs:204:35:204:45 | sinkParam10 | GlobalDataFlow.cs:204:35:204:45 | sinkParam10 |
-| GlobalDataFlow.cs:204:35:204:45 | sinkParam10 | GlobalDataFlow.cs:204:35:204:45 | sinkParam10 |
-| GlobalDataFlow.cs:204:35:204:45 | sinkParam10 | GlobalDataFlow.cs:204:35:204:45 | sinkParam10 |
-| GlobalDataFlow.cs:204:35:204:45 | sinkParam10 | GlobalDataFlow.cs:204:58:204:68 | access to parameter sinkParam10 |
-| GlobalDataFlow.cs:204:35:204:45 | sinkParam10 | GlobalDataFlow.cs:204:58:204:68 | access to parameter sinkParam10 |
-| GlobalDataFlow.cs:204:35:204:45 | sinkParam10 | GlobalDataFlow.cs:204:58:204:68 | access to parameter sinkParam10 |
-| GlobalDataFlow.cs:204:35:204:45 | sinkParam10 | GlobalDataFlow.cs:204:58:204:68 | access to parameter sinkParam10 |
-| GlobalDataFlow.cs:204:35:204:45 | sinkParam10 | GlobalDataFlow.cs:204:58:204:68 | access to parameter sinkParam10 |
-| GlobalDataFlow.cs:204:35:204:45 | sinkParam10 | GlobalDataFlow.cs:204:58:204:68 | access to parameter sinkParam10 |
-| GlobalDataFlow.cs:204:35:204:45 | sinkParam10 | GlobalDataFlow.cs:204:58:204:68 | access to parameter sinkParam10 |
-| GlobalDataFlow.cs:204:35:204:45 | sinkParam10 | GlobalDataFlow.cs:204:58:204:68 | access to parameter sinkParam10 |
-| GlobalDataFlow.cs:204:35:204:45 | sinkParam10 | GlobalDataFlow.cs:204:79:204:89 | access to parameter sinkParam10 |
-| GlobalDataFlow.cs:204:35:204:45 | sinkParam10 | GlobalDataFlow.cs:204:79:204:89 | access to parameter sinkParam10 |
-| GlobalDataFlow.cs:204:35:204:45 | sinkParam10 | GlobalDataFlow.cs:204:79:204:89 | access to parameter sinkParam10 |
-| GlobalDataFlow.cs:204:35:204:45 | sinkParam10 | GlobalDataFlow.cs:204:79:204:89 | access to parameter sinkParam10 |
-| GlobalDataFlow.cs:204:35:204:45 | sinkParam10 | GlobalDataFlow.cs:204:79:204:89 | access to parameter sinkParam10 |
-| GlobalDataFlow.cs:204:35:204:45 | sinkParam10 | GlobalDataFlow.cs:204:79:204:89 | access to parameter sinkParam10 |
-| GlobalDataFlow.cs:204:35:204:45 | sinkParam10 | GlobalDataFlow.cs:204:79:204:89 | access to parameter sinkParam10 |
-| GlobalDataFlow.cs:204:35:204:45 | sinkParam10 | GlobalDataFlow.cs:204:79:204:89 | access to parameter sinkParam10 |
-| GlobalDataFlow.cs:204:35:204:92 | (...) => ... | GlobalDataFlow.cs:204:30:204:92 | SSA def(f1) |
-| GlobalDataFlow.cs:204:35:204:92 | (...) => ... | GlobalDataFlow.cs:204:30:204:92 | SSA def(f1) |
-| GlobalDataFlow.cs:204:35:204:92 | (...) => ... | GlobalDataFlow.cs:204:35:204:92 | (...) => ... |
-| GlobalDataFlow.cs:204:35:204:92 | (...) => ... | GlobalDataFlow.cs:206:37:206:38 | access to local variable f1 |
-| GlobalDataFlow.cs:204:35:204:92 | (...) => ... | GlobalDataFlow.cs:206:37:206:38 | access to local variable f1 |
-| GlobalDataFlow.cs:204:35:204:92 | (...) => ... | GlobalDataFlow.cs:216:41:216:42 | access to local variable f1 |
-| GlobalDataFlow.cs:204:35:204:92 | (...) => ... | GlobalDataFlow.cs:216:41:216:42 | access to local variable f1 |
-| GlobalDataFlow.cs:204:52:204:69 | call to method Check | GlobalDataFlow.cs:204:52:204:69 | call to method Check |
-| GlobalDataFlow.cs:204:58:204:68 | access to parameter sinkParam10 | GlobalDataFlow.cs:204:58:204:68 | access to parameter sinkParam10 |
-| GlobalDataFlow.cs:204:58:204:68 | access to parameter sinkParam10 | GlobalDataFlow.cs:204:79:204:89 | access to parameter sinkParam10 |
-| GlobalDataFlow.cs:204:58:204:68 | access to parameter sinkParam10 | GlobalDataFlow.cs:204:79:204:89 | access to parameter sinkParam10 |
-| GlobalDataFlow.cs:204:58:204:68 | access to parameter sinkParam10 | GlobalDataFlow.cs:204:79:204:89 | access to parameter sinkParam10 |
-| GlobalDataFlow.cs:204:58:204:68 | access to parameter sinkParam10 | GlobalDataFlow.cs:204:79:204:89 | access to parameter sinkParam10 |
-| GlobalDataFlow.cs:204:79:204:89 | access to parameter sinkParam10 | GlobalDataFlow.cs:204:79:204:89 | access to parameter sinkParam10 |
-| GlobalDataFlow.cs:204:79:204:89 | access to parameter sinkParam10 | GlobalDataFlow.cs:206:37:206:38 | [output] access to local variable f1 |
-| GlobalDataFlow.cs:204:79:204:89 | access to parameter sinkParam10 | GlobalDataFlow.cs:206:37:206:38 | [output] access to local variable f1 |
-| GlobalDataFlow.cs:204:79:204:89 | access to parameter sinkParam10 | GlobalDataFlow.cs:216:41:216:42 | [output] access to local variable f1 |
-| GlobalDataFlow.cs:204:79:204:89 | access to parameter sinkParam10 | GlobalDataFlow.cs:216:41:216:42 | [output] access to local variable f1 |
-| GlobalDataFlow.cs:205:66:205:90 | Expression<Func<String,String>> f2 = ... | GlobalDataFlow.cs:205:66:205:90 | Expression<Func<String,String>> f2 = ... |
-| GlobalDataFlow.cs:205:66:205:90 | SSA def(f2) | GlobalDataFlow.cs:205:66:205:90 | SSA def(f2) |
-| GlobalDataFlow.cs:205:66:205:90 | SSA def(f2) | GlobalDataFlow.cs:208:37:208:38 | access to local variable f2 |
-| GlobalDataFlow.cs:205:66:205:90 | SSA def(f2) | GlobalDataFlow.cs:208:37:208:38 | access to local variable f2 |
-| GlobalDataFlow.cs:205:66:205:90 | SSA def(f2) | GlobalDataFlow.cs:218:37:218:38 | access to local variable f2 |
-| GlobalDataFlow.cs:205:66:205:90 | SSA def(f2) | GlobalDataFlow.cs:218:37:218:38 | access to local variable f2 |
-| GlobalDataFlow.cs:205:71:205:71 | x | GlobalDataFlow.cs:205:71:205:71 | x |
-| GlobalDataFlow.cs:205:71:205:71 | x | GlobalDataFlow.cs:205:71:205:71 | x |
-| GlobalDataFlow.cs:205:71:205:71 | x | GlobalDataFlow.cs:205:71:205:71 | x |
-| GlobalDataFlow.cs:205:71:205:71 | x | GlobalDataFlow.cs:205:71:205:71 | x |
-| GlobalDataFlow.cs:205:71:205:71 | x | GlobalDataFlow.cs:205:71:205:71 | x |
-| GlobalDataFlow.cs:205:71:205:71 | x | GlobalDataFlow.cs:205:71:205:71 | x |
-| GlobalDataFlow.cs:205:71:205:71 | x | GlobalDataFlow.cs:205:89:205:89 | access to parameter x |
-| GlobalDataFlow.cs:205:71:205:71 | x | GlobalDataFlow.cs:205:89:205:89 | access to parameter x |
-| GlobalDataFlow.cs:205:71:205:71 | x | GlobalDataFlow.cs:205:89:205:89 | access to parameter x |
-| GlobalDataFlow.cs:205:71:205:71 | x | GlobalDataFlow.cs:205:89:205:89 | access to parameter x |
-| GlobalDataFlow.cs:205:71:205:71 | x | GlobalDataFlow.cs:205:89:205:89 | access to parameter x |
-| GlobalDataFlow.cs:205:71:205:71 | x | GlobalDataFlow.cs:205:89:205:89 | access to parameter x |
-| GlobalDataFlow.cs:205:71:205:71 | x | GlobalDataFlow.cs:205:89:205:89 | access to parameter x |
-| GlobalDataFlow.cs:205:71:205:71 | x | GlobalDataFlow.cs:205:89:205:89 | access to parameter x |
-| GlobalDataFlow.cs:205:71:205:90 | (...) => ... | GlobalDataFlow.cs:205:66:205:90 | SSA def(f2) |
-| GlobalDataFlow.cs:205:71:205:90 | (...) => ... | GlobalDataFlow.cs:205:66:205:90 | SSA def(f2) |
-| GlobalDataFlow.cs:205:71:205:90 | (...) => ... | GlobalDataFlow.cs:205:71:205:90 | (...) => ... |
-| GlobalDataFlow.cs:205:71:205:90 | (...) => ... | GlobalDataFlow.cs:208:37:208:38 | access to local variable f2 |
-| GlobalDataFlow.cs:205:71:205:90 | (...) => ... | GlobalDataFlow.cs:208:37:208:38 | access to local variable f2 |
-| GlobalDataFlow.cs:205:71:205:90 | (...) => ... | GlobalDataFlow.cs:218:37:218:38 | access to local variable f2 |
-| GlobalDataFlow.cs:205:71:205:90 | (...) => ... | GlobalDataFlow.cs:218:37:218:38 | access to local variable f2 |
-| GlobalDataFlow.cs:205:76:205:90 | call to method ReturnCheck2 | GlobalDataFlow.cs:205:76:205:90 | call to method ReturnCheck2 |
-| GlobalDataFlow.cs:205:76:205:90 | call to method ReturnCheck2 | GlobalDataFlow.cs:208:37:208:38 | [output] access to local variable f2 |
-| GlobalDataFlow.cs:205:76:205:90 | call to method ReturnCheck2 | GlobalDataFlow.cs:208:37:208:38 | [output] access to local variable f2 |
-| GlobalDataFlow.cs:205:76:205:90 | call to method ReturnCheck2 | GlobalDataFlow.cs:218:37:218:38 | [output] access to local variable f2 |
-| GlobalDataFlow.cs:205:76:205:90 | call to method ReturnCheck2 | GlobalDataFlow.cs:218:37:218:38 | [output] access to local variable f2 |
-| GlobalDataFlow.cs:205:89:205:89 | access to parameter x | GlobalDataFlow.cs:205:76:205:90 | call to method ReturnCheck2 |
-| GlobalDataFlow.cs:205:89:205:89 | access to parameter x | GlobalDataFlow.cs:205:76:205:90 | call to method ReturnCheck2 |
-| GlobalDataFlow.cs:205:89:205:89 | access to parameter x | GlobalDataFlow.cs:205:76:205:90 | call to method ReturnCheck2 |
-| GlobalDataFlow.cs:205:89:205:89 | access to parameter x | GlobalDataFlow.cs:205:76:205:90 | call to method ReturnCheck2 |
-| GlobalDataFlow.cs:205:89:205:89 | access to parameter x | GlobalDataFlow.cs:205:89:205:89 | access to parameter x |
-| GlobalDataFlow.cs:205:89:205:89 | access to parameter x | GlobalDataFlow.cs:293:32:293:41 | sinkParam9 |
-| GlobalDataFlow.cs:205:89:205:89 | access to parameter x | GlobalDataFlow.cs:293:32:293:41 | sinkParam9 |
-| GlobalDataFlow.cs:205:89:205:89 | access to parameter x | GlobalDataFlow.cs:293:32:293:41 | sinkParam9 |
-| GlobalDataFlow.cs:205:89:205:89 | access to parameter x | GlobalDataFlow.cs:293:32:293:41 | sinkParam9 |
-| GlobalDataFlow.cs:206:13:206:39 | IEnumerable<String> sink24 = ... | GlobalDataFlow.cs:206:13:206:39 | IEnumerable<String> sink24 = ... |
-| GlobalDataFlow.cs:206:13:206:39 | SSA def(sink24) | GlobalDataFlow.cs:206:13:206:39 | SSA def(sink24) |
-| GlobalDataFlow.cs:206:13:206:39 | SSA def(sink24) | GlobalDataFlow.cs:207:15:207:20 | access to local variable sink24 |
-| GlobalDataFlow.cs:206:13:206:39 | SSA def(sink24) | GlobalDataFlow.cs:207:15:207:20 | access to local variable sink24 |
-| GlobalDataFlow.cs:206:22:206:28 | access to parameter tainted | GlobalDataFlow.cs:204:35:204:45 | sinkParam10 |
-| GlobalDataFlow.cs:206:22:206:28 | access to parameter tainted | GlobalDataFlow.cs:204:35:204:45 | sinkParam10 |
-| GlobalDataFlow.cs:206:22:206:28 | access to parameter tainted | GlobalDataFlow.cs:206:22:206:28 | access to parameter tainted |
-| GlobalDataFlow.cs:206:22:206:28 | access to parameter tainted | GlobalDataFlow.cs:206:37:206:38 | [output] access to local variable f1 |
-| GlobalDataFlow.cs:206:22:206:28 | access to parameter tainted | GlobalDataFlow.cs:206:37:206:38 | [output] access to local variable f1 |
-| GlobalDataFlow.cs:206:22:206:28 | access to parameter tainted | GlobalDataFlow.cs:208:22:208:28 | access to parameter tainted |
-| GlobalDataFlow.cs:206:22:206:28 | access to parameter tainted | GlobalDataFlow.cs:208:22:208:28 | access to parameter tainted |
-| GlobalDataFlow.cs:206:22:206:28 | access to parameter tainted | GlobalDataFlow.cs:210:22:210:28 | access to parameter tainted |
-| GlobalDataFlow.cs:206:22:206:28 | access to parameter tainted | GlobalDataFlow.cs:210:22:210:28 | access to parameter tainted |
-| GlobalDataFlow.cs:206:22:206:39 | call to method Select | GlobalDataFlow.cs:206:13:206:39 | SSA def(sink24) |
-| GlobalDataFlow.cs:206:22:206:39 | call to method Select | GlobalDataFlow.cs:206:13:206:39 | SSA def(sink24) |
-| GlobalDataFlow.cs:206:22:206:39 | call to method Select | GlobalDataFlow.cs:206:22:206:39 | call to method Select |
-| GlobalDataFlow.cs:206:22:206:39 | call to method Select | GlobalDataFlow.cs:207:15:207:20 | access to local variable sink24 |
-| GlobalDataFlow.cs:206:22:206:39 | call to method Select | GlobalDataFlow.cs:207:15:207:20 | access to local variable sink24 |
-| GlobalDataFlow.cs:206:37:206:38 | [output] access to local variable f1 | GlobalDataFlow.cs:206:13:206:39 | SSA def(sink24) |
-| GlobalDataFlow.cs:206:37:206:38 | [output] access to local variable f1 | GlobalDataFlow.cs:206:13:206:39 | SSA def(sink24) |
-| GlobalDataFlow.cs:206:37:206:38 | [output] access to local variable f1 | GlobalDataFlow.cs:206:22:206:39 | call to method Select |
-| GlobalDataFlow.cs:206:37:206:38 | [output] access to local variable f1 | GlobalDataFlow.cs:206:22:206:39 | call to method Select |
-| GlobalDataFlow.cs:206:37:206:38 | [output] access to local variable f1 | GlobalDataFlow.cs:206:37:206:38 | [output] access to local variable f1 |
-| GlobalDataFlow.cs:206:37:206:38 | [output] access to local variable f1 | GlobalDataFlow.cs:207:15:207:20 | access to local variable sink24 |
-| GlobalDataFlow.cs:206:37:206:38 | [output] access to local variable f1 | GlobalDataFlow.cs:207:15:207:20 | access to local variable sink24 |
-| GlobalDataFlow.cs:206:37:206:38 | access to local variable f1 | GlobalDataFlow.cs:206:37:206:38 | access to local variable f1 |
-| GlobalDataFlow.cs:206:37:206:38 | access to local variable f1 | GlobalDataFlow.cs:216:41:216:42 | access to local variable f1 |
-| GlobalDataFlow.cs:206:37:206:38 | access to local variable f1 | GlobalDataFlow.cs:216:41:216:42 | access to local variable f1 |
-| GlobalDataFlow.cs:207:9:207:21 | call to method Check | GlobalDataFlow.cs:207:9:207:21 | call to method Check |
-| GlobalDataFlow.cs:207:15:207:20 | access to local variable sink24 | GlobalDataFlow.cs:207:15:207:20 | access to local variable sink24 |
-| GlobalDataFlow.cs:208:13:208:39 | IQueryable<String> sink25 = ... | GlobalDataFlow.cs:208:13:208:39 | IQueryable<String> sink25 = ... |
-| GlobalDataFlow.cs:208:13:208:39 | SSA def(sink25) | GlobalDataFlow.cs:208:13:208:39 | SSA def(sink25) |
-| GlobalDataFlow.cs:208:13:208:39 | SSA def(sink25) | GlobalDataFlow.cs:209:15:209:20 | access to local variable sink25 |
-| GlobalDataFlow.cs:208:13:208:39 | SSA def(sink25) | GlobalDataFlow.cs:209:15:209:20 | access to local variable sink25 |
-| GlobalDataFlow.cs:208:22:208:28 | access to parameter tainted | GlobalDataFlow.cs:205:71:205:71 | x |
-| GlobalDataFlow.cs:208:22:208:28 | access to parameter tainted | GlobalDataFlow.cs:205:71:205:71 | x |
-| GlobalDataFlow.cs:208:22:208:28 | access to parameter tainted | GlobalDataFlow.cs:208:22:208:28 | access to parameter tainted |
-| GlobalDataFlow.cs:208:22:208:28 | access to parameter tainted | GlobalDataFlow.cs:208:37:208:38 | [output] access to local variable f2 |
-| GlobalDataFlow.cs:208:22:208:28 | access to parameter tainted | GlobalDataFlow.cs:208:37:208:38 | [output] access to local variable f2 |
-| GlobalDataFlow.cs:208:22:208:28 | access to parameter tainted | GlobalDataFlow.cs:210:22:210:28 | access to parameter tainted |
-| GlobalDataFlow.cs:208:22:208:28 | access to parameter tainted | GlobalDataFlow.cs:210:22:210:28 | access to parameter tainted |
-| GlobalDataFlow.cs:208:22:208:39 | call to method Select | GlobalDataFlow.cs:208:13:208:39 | SSA def(sink25) |
-| GlobalDataFlow.cs:208:22:208:39 | call to method Select | GlobalDataFlow.cs:208:13:208:39 | SSA def(sink25) |
-| GlobalDataFlow.cs:208:22:208:39 | call to method Select | GlobalDataFlow.cs:208:22:208:39 | call to method Select |
-| GlobalDataFlow.cs:208:22:208:39 | call to method Select | GlobalDataFlow.cs:209:15:209:20 | access to local variable sink25 |
-| GlobalDataFlow.cs:208:22:208:39 | call to method Select | GlobalDataFlow.cs:209:15:209:20 | access to local variable sink25 |
-| GlobalDataFlow.cs:208:37:208:38 | [output] access to local variable f2 | GlobalDataFlow.cs:208:13:208:39 | SSA def(sink25) |
-| GlobalDataFlow.cs:208:37:208:38 | [output] access to local variable f2 | GlobalDataFlow.cs:208:13:208:39 | SSA def(sink25) |
-| GlobalDataFlow.cs:208:37:208:38 | [output] access to local variable f2 | GlobalDataFlow.cs:208:22:208:39 | call to method Select |
-| GlobalDataFlow.cs:208:37:208:38 | [output] access to local variable f2 | GlobalDataFlow.cs:208:22:208:39 | call to method Select |
-| GlobalDataFlow.cs:208:37:208:38 | [output] access to local variable f2 | GlobalDataFlow.cs:208:37:208:38 | [output] access to local variable f2 |
-| GlobalDataFlow.cs:208:37:208:38 | [output] access to local variable f2 | GlobalDataFlow.cs:209:15:209:20 | access to local variable sink25 |
-| GlobalDataFlow.cs:208:37:208:38 | [output] access to local variable f2 | GlobalDataFlow.cs:209:15:209:20 | access to local variable sink25 |
-| GlobalDataFlow.cs:208:37:208:38 | access to local variable f2 | GlobalDataFlow.cs:208:37:208:38 | access to local variable f2 |
-| GlobalDataFlow.cs:208:37:208:38 | access to local variable f2 | GlobalDataFlow.cs:218:37:218:38 | access to local variable f2 |
-| GlobalDataFlow.cs:208:37:208:38 | access to local variable f2 | GlobalDataFlow.cs:218:37:218:38 | access to local variable f2 |
-| GlobalDataFlow.cs:209:9:209:21 | call to method Check | GlobalDataFlow.cs:209:9:209:21 | call to method Check |
-| GlobalDataFlow.cs:209:15:209:20 | access to local variable sink25 | GlobalDataFlow.cs:209:15:209:20 | access to local variable sink25 |
-| GlobalDataFlow.cs:210:13:210:49 | IEnumerable<String> sink26 = ... | GlobalDataFlow.cs:210:13:210:49 | IEnumerable<String> sink26 = ... |
-| GlobalDataFlow.cs:210:13:210:49 | SSA def(sink26) | GlobalDataFlow.cs:210:13:210:49 | SSA def(sink26) |
-| GlobalDataFlow.cs:210:13:210:49 | SSA def(sink26) | GlobalDataFlow.cs:211:15:211:20 | access to local variable sink26 |
-| GlobalDataFlow.cs:210:13:210:49 | SSA def(sink26) | GlobalDataFlow.cs:211:15:211:20 | access to local variable sink26 |
+| GlobalDataFlow.cs:173:9:173:40 | ... = ... | GlobalDataFlow.cs:173:9:173:40 | ... = ... |
+| GlobalDataFlow.cs:173:9:173:40 | SSA def(nonSink0) | GlobalDataFlow.cs:173:9:173:40 | SSA def(nonSink0) |
+| GlobalDataFlow.cs:173:9:173:40 | SSA def(nonSink0) | GlobalDataFlow.cs:174:15:174:22 | access to local variable nonSink0 |
+| GlobalDataFlow.cs:173:9:173:40 | SSA def(nonSink0) | GlobalDataFlow.cs:174:15:174:22 | access to local variable nonSink0 |
+| GlobalDataFlow.cs:173:9:173:40 | SSA def(nonSink0) | GlobalDataFlow.cs:175:36:175:43 | access to local variable nonSink0 |
+| GlobalDataFlow.cs:173:9:173:40 | SSA def(nonSink0) | GlobalDataFlow.cs:175:36:175:43 | access to local variable nonSink0 |
+| GlobalDataFlow.cs:173:20:173:32 | call to method NonOutYield | GlobalDataFlow.cs:173:9:173:40 | SSA def(nonSink0) |
+| GlobalDataFlow.cs:173:20:173:32 | call to method NonOutYield | GlobalDataFlow.cs:173:9:173:40 | SSA def(nonSink0) |
+| GlobalDataFlow.cs:173:20:173:32 | call to method NonOutYield | GlobalDataFlow.cs:173:20:173:32 | call to method NonOutYield |
+| GlobalDataFlow.cs:173:20:173:32 | call to method NonOutYield | GlobalDataFlow.cs:173:20:173:40 | call to method First |
+| GlobalDataFlow.cs:173:20:173:32 | call to method NonOutYield | GlobalDataFlow.cs:173:20:173:40 | call to method First |
+| GlobalDataFlow.cs:173:20:173:32 | call to method NonOutYield | GlobalDataFlow.cs:174:15:174:22 | access to local variable nonSink0 |
+| GlobalDataFlow.cs:173:20:173:32 | call to method NonOutYield | GlobalDataFlow.cs:174:15:174:22 | access to local variable nonSink0 |
+| GlobalDataFlow.cs:173:20:173:32 | call to method NonOutYield | GlobalDataFlow.cs:175:36:175:43 | access to local variable nonSink0 |
+| GlobalDataFlow.cs:173:20:173:32 | call to method NonOutYield | GlobalDataFlow.cs:175:36:175:43 | access to local variable nonSink0 |
+| GlobalDataFlow.cs:173:20:173:32 | this access | GlobalDataFlow.cs:173:20:173:32 | this access |
+| GlobalDataFlow.cs:173:20:173:32 | this access | GlobalDataFlow.cs:189:39:189:41 | this access |
+| GlobalDataFlow.cs:173:20:173:32 | this access | GlobalDataFlow.cs:189:39:189:41 | this access |
+| GlobalDataFlow.cs:173:20:173:32 | this access | GlobalDataFlow.cs:193:37:193:42 | this access |
+| GlobalDataFlow.cs:173:20:173:32 | this access | GlobalDataFlow.cs:193:37:193:42 | this access |
+| GlobalDataFlow.cs:173:20:173:32 | this access | GlobalDataFlow.cs:197:22:197:32 | this access |
+| GlobalDataFlow.cs:173:20:173:32 | this access | GlobalDataFlow.cs:197:22:197:32 | this access |
+| GlobalDataFlow.cs:173:20:173:32 | this access | GlobalDataFlow.cs:201:20:201:33 | this access |
+| GlobalDataFlow.cs:173:20:173:32 | this access | GlobalDataFlow.cs:201:20:201:33 | this access |
+| GlobalDataFlow.cs:173:20:173:32 | this access | GlobalDataFlow.cs:353:25:353:35 | this |
+| GlobalDataFlow.cs:173:20:173:32 | this access | GlobalDataFlow.cs:353:25:353:35 | this |
+| GlobalDataFlow.cs:173:20:173:40 | call to method First | GlobalDataFlow.cs:173:9:173:40 | SSA def(nonSink0) |
+| GlobalDataFlow.cs:173:20:173:40 | call to method First | GlobalDataFlow.cs:173:9:173:40 | SSA def(nonSink0) |
+| GlobalDataFlow.cs:173:20:173:40 | call to method First | GlobalDataFlow.cs:173:20:173:40 | call to method First |
+| GlobalDataFlow.cs:173:20:173:40 | call to method First | GlobalDataFlow.cs:174:15:174:22 | access to local variable nonSink0 |
+| GlobalDataFlow.cs:173:20:173:40 | call to method First | GlobalDataFlow.cs:174:15:174:22 | access to local variable nonSink0 |
+| GlobalDataFlow.cs:173:20:173:40 | call to method First | GlobalDataFlow.cs:175:36:175:43 | access to local variable nonSink0 |
+| GlobalDataFlow.cs:173:20:173:40 | call to method First | GlobalDataFlow.cs:175:36:175:43 | access to local variable nonSink0 |
+| GlobalDataFlow.cs:174:9:174:23 | call to method Check | GlobalDataFlow.cs:174:9:174:23 | call to method Check |
+| GlobalDataFlow.cs:174:15:174:22 | access to local variable nonSink0 | GlobalDataFlow.cs:174:15:174:22 | access to local variable nonSink0 |
+| GlobalDataFlow.cs:174:15:174:22 | access to local variable nonSink0 | GlobalDataFlow.cs:175:36:175:43 | access to local variable nonSink0 |
+| GlobalDataFlow.cs:174:15:174:22 | access to local variable nonSink0 | GlobalDataFlow.cs:175:36:175:43 | access to local variable nonSink0 |
+| GlobalDataFlow.cs:175:9:175:44 | ... = ... | GlobalDataFlow.cs:175:9:175:44 | ... = ... |
+| GlobalDataFlow.cs:175:9:175:44 | SSA def(nonSink0) | GlobalDataFlow.cs:175:9:175:44 | SSA def(nonSink0) |
+| GlobalDataFlow.cs:175:9:175:44 | SSA def(nonSink0) | GlobalDataFlow.cs:176:15:176:22 | access to local variable nonSink0 |
+| GlobalDataFlow.cs:175:9:175:44 | SSA def(nonSink0) | GlobalDataFlow.cs:176:15:176:22 | access to local variable nonSink0 |
+| GlobalDataFlow.cs:175:20:175:44 | call to method NonTaintedParam | GlobalDataFlow.cs:175:9:175:44 | SSA def(nonSink0) |
+| GlobalDataFlow.cs:175:20:175:44 | call to method NonTaintedParam | GlobalDataFlow.cs:175:9:175:44 | SSA def(nonSink0) |
+| GlobalDataFlow.cs:175:20:175:44 | call to method NonTaintedParam | GlobalDataFlow.cs:175:20:175:44 | call to method NonTaintedParam |
+| GlobalDataFlow.cs:175:20:175:44 | call to method NonTaintedParam | GlobalDataFlow.cs:176:15:176:22 | access to local variable nonSink0 |
+| GlobalDataFlow.cs:175:20:175:44 | call to method NonTaintedParam | GlobalDataFlow.cs:176:15:176:22 | access to local variable nonSink0 |
+| GlobalDataFlow.cs:175:36:175:43 | access to local variable nonSink0 | GlobalDataFlow.cs:175:20:175:44 | call to method NonTaintedParam |
+| GlobalDataFlow.cs:175:36:175:43 | access to local variable nonSink0 | GlobalDataFlow.cs:175:20:175:44 | call to method NonTaintedParam |
+| GlobalDataFlow.cs:175:36:175:43 | access to local variable nonSink0 | GlobalDataFlow.cs:175:36:175:43 | access to local variable nonSink0 |
+| GlobalDataFlow.cs:175:36:175:43 | access to local variable nonSink0 | GlobalDataFlow.cs:385:42:385:51 | nonTainted |
+| GlobalDataFlow.cs:175:36:175:43 | access to local variable nonSink0 | GlobalDataFlow.cs:385:42:385:51 | nonTainted |
+| GlobalDataFlow.cs:176:9:176:23 | call to method Check | GlobalDataFlow.cs:176:9:176:23 | call to method Check |
+| GlobalDataFlow.cs:176:15:176:22 | access to local variable nonSink0 | GlobalDataFlow.cs:176:15:176:22 | access to local variable nonSink0 |
+| GlobalDataFlow.cs:179:22:179:48 | Func<String> out = ... | GlobalDataFlow.cs:179:22:179:48 | Func<String> out = ... |
+| GlobalDataFlow.cs:179:22:179:48 | SSA def(out) | GlobalDataFlow.cs:179:22:179:48 | SSA def(out) |
+| GlobalDataFlow.cs:179:22:179:48 | SSA def(out) | GlobalDataFlow.cs:180:21:180:24 | access to local variable out |
+| GlobalDataFlow.cs:179:22:179:48 | SSA def(out) | GlobalDataFlow.cs:180:21:180:24 | access to local variable out |
+| GlobalDataFlow.cs:179:29:179:48 | (...) => ... | GlobalDataFlow.cs:179:22:179:48 | SSA def(out) |
+| GlobalDataFlow.cs:179:29:179:48 | (...) => ... | GlobalDataFlow.cs:179:22:179:48 | SSA def(out) |
+| GlobalDataFlow.cs:179:29:179:48 | (...) => ... | GlobalDataFlow.cs:179:29:179:48 | (...) => ... |
+| GlobalDataFlow.cs:179:29:179:48 | (...) => ... | GlobalDataFlow.cs:180:21:180:24 | access to local variable out |
+| GlobalDataFlow.cs:179:29:179:48 | (...) => ... | GlobalDataFlow.cs:180:21:180:24 | access to local variable out |
+| GlobalDataFlow.cs:179:35:179:48 | "taint source" | GlobalDataFlow.cs:179:35:179:48 | "taint source" |
+| GlobalDataFlow.cs:179:35:179:48 | "taint source" | GlobalDataFlow.cs:180:21:180:26 | delegate call |
+| GlobalDataFlow.cs:179:35:179:48 | "taint source" | GlobalDataFlow.cs:180:21:180:26 | delegate call |
+| GlobalDataFlow.cs:180:13:180:26 | SSA def(sink9) | GlobalDataFlow.cs:180:13:180:26 | SSA def(sink9) |
+| GlobalDataFlow.cs:180:13:180:26 | SSA def(sink9) | GlobalDataFlow.cs:181:15:181:19 | access to local variable sink9 |
+| GlobalDataFlow.cs:180:13:180:26 | SSA def(sink9) | GlobalDataFlow.cs:181:15:181:19 | access to local variable sink9 |
+| GlobalDataFlow.cs:180:13:180:26 | String sink9 = ... | GlobalDataFlow.cs:180:13:180:26 | String sink9 = ... |
+| GlobalDataFlow.cs:180:21:180:24 | access to local variable out | GlobalDataFlow.cs:180:21:180:24 | access to local variable out |
+| GlobalDataFlow.cs:180:21:180:26 | delegate call | GlobalDataFlow.cs:180:13:180:26 | SSA def(sink9) |
+| GlobalDataFlow.cs:180:21:180:26 | delegate call | GlobalDataFlow.cs:180:13:180:26 | SSA def(sink9) |
+| GlobalDataFlow.cs:180:21:180:26 | delegate call | GlobalDataFlow.cs:180:21:180:26 | delegate call |
+| GlobalDataFlow.cs:180:21:180:26 | delegate call | GlobalDataFlow.cs:181:15:181:19 | access to local variable sink9 |
+| GlobalDataFlow.cs:180:21:180:26 | delegate call | GlobalDataFlow.cs:181:15:181:19 | access to local variable sink9 |
+| GlobalDataFlow.cs:181:9:181:20 | call to method Check | GlobalDataFlow.cs:181:9:181:20 | call to method Check |
+| GlobalDataFlow.cs:181:15:181:19 | access to local variable sink9 | GlobalDataFlow.cs:181:15:181:19 | access to local variable sink9 |
+| GlobalDataFlow.cs:184:22:184:38 | Func<String> nonOut = ... | GlobalDataFlow.cs:184:22:184:38 | Func<String> nonOut = ... |
+| GlobalDataFlow.cs:184:22:184:38 | SSA def(nonOut) | GlobalDataFlow.cs:184:22:184:38 | SSA def(nonOut) |
+| GlobalDataFlow.cs:184:22:184:38 | SSA def(nonOut) | GlobalDataFlow.cs:185:20:185:25 | access to local variable nonOut |
+| GlobalDataFlow.cs:184:22:184:38 | SSA def(nonOut) | GlobalDataFlow.cs:185:20:185:25 | access to local variable nonOut |
+| GlobalDataFlow.cs:184:31:184:38 | (...) => ... | GlobalDataFlow.cs:184:22:184:38 | SSA def(nonOut) |
+| GlobalDataFlow.cs:184:31:184:38 | (...) => ... | GlobalDataFlow.cs:184:22:184:38 | SSA def(nonOut) |
+| GlobalDataFlow.cs:184:31:184:38 | (...) => ... | GlobalDataFlow.cs:184:31:184:38 | (...) => ... |
+| GlobalDataFlow.cs:184:31:184:38 | (...) => ... | GlobalDataFlow.cs:185:20:185:25 | access to local variable nonOut |
+| GlobalDataFlow.cs:184:31:184:38 | (...) => ... | GlobalDataFlow.cs:185:20:185:25 | access to local variable nonOut |
+| GlobalDataFlow.cs:184:37:184:38 | "" | GlobalDataFlow.cs:184:37:184:38 | "" |
+| GlobalDataFlow.cs:184:37:184:38 | "" | GlobalDataFlow.cs:185:20:185:27 | delegate call |
+| GlobalDataFlow.cs:184:37:184:38 | "" | GlobalDataFlow.cs:185:20:185:27 | delegate call |
+| GlobalDataFlow.cs:185:9:185:27 | ... = ... | GlobalDataFlow.cs:185:9:185:27 | ... = ... |
+| GlobalDataFlow.cs:185:9:185:27 | SSA def(nonSink0) | GlobalDataFlow.cs:185:9:185:27 | SSA def(nonSink0) |
+| GlobalDataFlow.cs:185:9:185:27 | SSA def(nonSink0) | GlobalDataFlow.cs:186:15:186:22 | access to local variable nonSink0 |
+| GlobalDataFlow.cs:185:9:185:27 | SSA def(nonSink0) | GlobalDataFlow.cs:186:15:186:22 | access to local variable nonSink0 |
+| GlobalDataFlow.cs:185:20:185:25 | access to local variable nonOut | GlobalDataFlow.cs:185:20:185:25 | access to local variable nonOut |
+| GlobalDataFlow.cs:185:20:185:27 | delegate call | GlobalDataFlow.cs:185:9:185:27 | SSA def(nonSink0) |
+| GlobalDataFlow.cs:185:20:185:27 | delegate call | GlobalDataFlow.cs:185:9:185:27 | SSA def(nonSink0) |
+| GlobalDataFlow.cs:185:20:185:27 | delegate call | GlobalDataFlow.cs:185:20:185:27 | delegate call |
+| GlobalDataFlow.cs:185:20:185:27 | delegate call | GlobalDataFlow.cs:186:15:186:22 | access to local variable nonSink0 |
+| GlobalDataFlow.cs:185:20:185:27 | delegate call | GlobalDataFlow.cs:186:15:186:22 | access to local variable nonSink0 |
+| GlobalDataFlow.cs:186:9:186:23 | call to method Check | GlobalDataFlow.cs:186:9:186:23 | call to method Check |
+| GlobalDataFlow.cs:186:15:186:22 | access to local variable nonSink0 | GlobalDataFlow.cs:186:15:186:22 | access to local variable nonSink0 |
+| GlobalDataFlow.cs:189:13:189:48 | SSA def(sink10) | GlobalDataFlow.cs:189:13:189:48 | SSA def(sink10) |
+| GlobalDataFlow.cs:189:13:189:48 | SSA def(sink10) | GlobalDataFlow.cs:190:15:190:20 | access to local variable sink10 |
+| GlobalDataFlow.cs:189:13:189:48 | SSA def(sink10) | GlobalDataFlow.cs:190:15:190:20 | access to local variable sink10 |
+| GlobalDataFlow.cs:189:13:189:48 | String sink10 = ... | GlobalDataFlow.cs:189:13:189:48 | String sink10 = ... |
+| GlobalDataFlow.cs:189:22:189:42 | malloc | GlobalDataFlow.cs:189:22:189:42 | malloc |
+| GlobalDataFlow.cs:189:22:189:42 | object creation of type Lazy<String> | GlobalDataFlow.cs:189:13:189:48 | SSA def(sink10) |
+| GlobalDataFlow.cs:189:22:189:42 | object creation of type Lazy<String> | GlobalDataFlow.cs:189:13:189:48 | SSA def(sink10) |
+| GlobalDataFlow.cs:189:22:189:42 | object creation of type Lazy<String> | GlobalDataFlow.cs:189:22:189:42 | object creation of type Lazy<String> |
+| GlobalDataFlow.cs:189:22:189:42 | object creation of type Lazy<String> | GlobalDataFlow.cs:189:22:189:48 | access to property Value |
+| GlobalDataFlow.cs:189:22:189:42 | object creation of type Lazy<String> | GlobalDataFlow.cs:189:22:189:48 | access to property Value |
+| GlobalDataFlow.cs:189:22:189:42 | object creation of type Lazy<String> | GlobalDataFlow.cs:190:15:190:20 | access to local variable sink10 |
+| GlobalDataFlow.cs:189:22:189:42 | object creation of type Lazy<String> | GlobalDataFlow.cs:190:15:190:20 | access to local variable sink10 |
+| GlobalDataFlow.cs:189:22:189:48 | access to property Value | GlobalDataFlow.cs:189:13:189:48 | SSA def(sink10) |
+| GlobalDataFlow.cs:189:22:189:48 | access to property Value | GlobalDataFlow.cs:189:13:189:48 | SSA def(sink10) |
+| GlobalDataFlow.cs:189:22:189:48 | access to property Value | GlobalDataFlow.cs:189:22:189:48 | access to property Value |
+| GlobalDataFlow.cs:189:22:189:48 | access to property Value | GlobalDataFlow.cs:190:15:190:20 | access to local variable sink10 |
+| GlobalDataFlow.cs:189:22:189:48 | access to property Value | GlobalDataFlow.cs:190:15:190:20 | access to local variable sink10 |
+| GlobalDataFlow.cs:189:39:189:41 | [output] delegate creation of type Func<String> | GlobalDataFlow.cs:189:13:189:48 | SSA def(sink10) |
+| GlobalDataFlow.cs:189:39:189:41 | [output] delegate creation of type Func<String> | GlobalDataFlow.cs:189:13:189:48 | SSA def(sink10) |
+| GlobalDataFlow.cs:189:39:189:41 | [output] delegate creation of type Func<String> | GlobalDataFlow.cs:189:22:189:42 | object creation of type Lazy<String> |
+| GlobalDataFlow.cs:189:39:189:41 | [output] delegate creation of type Func<String> | GlobalDataFlow.cs:189:22:189:42 | object creation of type Lazy<String> |
+| GlobalDataFlow.cs:189:39:189:41 | [output] delegate creation of type Func<String> | GlobalDataFlow.cs:189:22:189:48 | access to property Value |
+| GlobalDataFlow.cs:189:39:189:41 | [output] delegate creation of type Func<String> | GlobalDataFlow.cs:189:22:189:48 | access to property Value |
+| GlobalDataFlow.cs:189:39:189:41 | [output] delegate creation of type Func<String> | GlobalDataFlow.cs:189:39:189:41 | [output] delegate creation of type Func<String> |
+| GlobalDataFlow.cs:189:39:189:41 | [output] delegate creation of type Func<String> | GlobalDataFlow.cs:190:15:190:20 | access to local variable sink10 |
+| GlobalDataFlow.cs:189:39:189:41 | [output] delegate creation of type Func<String> | GlobalDataFlow.cs:190:15:190:20 | access to local variable sink10 |
+| GlobalDataFlow.cs:189:39:189:41 | access to method Out | GlobalDataFlow.cs:189:39:189:41 | access to method Out |
+| GlobalDataFlow.cs:189:39:189:41 | delegate creation of type Func<String> | GlobalDataFlow.cs:189:39:189:41 | delegate creation of type Func<String> |
+| GlobalDataFlow.cs:189:39:189:41 | this access | GlobalDataFlow.cs:189:39:189:41 | this access |
+| GlobalDataFlow.cs:189:39:189:41 | this access | GlobalDataFlow.cs:193:37:193:42 | this access |
+| GlobalDataFlow.cs:189:39:189:41 | this access | GlobalDataFlow.cs:193:37:193:42 | this access |
+| GlobalDataFlow.cs:189:39:189:41 | this access | GlobalDataFlow.cs:197:22:197:32 | this access |
+| GlobalDataFlow.cs:189:39:189:41 | this access | GlobalDataFlow.cs:197:22:197:32 | this access |
+| GlobalDataFlow.cs:189:39:189:41 | this access | GlobalDataFlow.cs:201:20:201:33 | this access |
+| GlobalDataFlow.cs:189:39:189:41 | this access | GlobalDataFlow.cs:201:20:201:33 | this access |
+| GlobalDataFlow.cs:190:9:190:21 | call to method Check | GlobalDataFlow.cs:190:9:190:21 | call to method Check |
+| GlobalDataFlow.cs:190:15:190:20 | access to local variable sink10 | GlobalDataFlow.cs:190:15:190:20 | access to local variable sink10 |
+| GlobalDataFlow.cs:193:9:193:49 | ... = ... | GlobalDataFlow.cs:193:9:193:49 | ... = ... |
+| GlobalDataFlow.cs:193:9:193:49 | SSA def(nonSink0) | GlobalDataFlow.cs:193:9:193:49 | SSA def(nonSink0) |
+| GlobalDataFlow.cs:193:9:193:49 | SSA def(nonSink0) | GlobalDataFlow.cs:194:15:194:22 | access to local variable nonSink0 |
+| GlobalDataFlow.cs:193:9:193:49 | SSA def(nonSink0) | GlobalDataFlow.cs:194:15:194:22 | access to local variable nonSink0 |
+| GlobalDataFlow.cs:193:20:193:43 | malloc | GlobalDataFlow.cs:193:20:193:43 | malloc |
+| GlobalDataFlow.cs:193:20:193:43 | object creation of type Lazy<String> | GlobalDataFlow.cs:193:9:193:49 | SSA def(nonSink0) |
+| GlobalDataFlow.cs:193:20:193:43 | object creation of type Lazy<String> | GlobalDataFlow.cs:193:9:193:49 | SSA def(nonSink0) |
+| GlobalDataFlow.cs:193:20:193:43 | object creation of type Lazy<String> | GlobalDataFlow.cs:193:20:193:43 | object creation of type Lazy<String> |
+| GlobalDataFlow.cs:193:20:193:43 | object creation of type Lazy<String> | GlobalDataFlow.cs:193:20:193:49 | access to property Value |
+| GlobalDataFlow.cs:193:20:193:43 | object creation of type Lazy<String> | GlobalDataFlow.cs:193:20:193:49 | access to property Value |
+| GlobalDataFlow.cs:193:20:193:43 | object creation of type Lazy<String> | GlobalDataFlow.cs:194:15:194:22 | access to local variable nonSink0 |
+| GlobalDataFlow.cs:193:20:193:43 | object creation of type Lazy<String> | GlobalDataFlow.cs:194:15:194:22 | access to local variable nonSink0 |
+| GlobalDataFlow.cs:193:20:193:49 | access to property Value | GlobalDataFlow.cs:193:9:193:49 | SSA def(nonSink0) |
+| GlobalDataFlow.cs:193:20:193:49 | access to property Value | GlobalDataFlow.cs:193:9:193:49 | SSA def(nonSink0) |
+| GlobalDataFlow.cs:193:20:193:49 | access to property Value | GlobalDataFlow.cs:193:20:193:49 | access to property Value |
+| GlobalDataFlow.cs:193:20:193:49 | access to property Value | GlobalDataFlow.cs:194:15:194:22 | access to local variable nonSink0 |
+| GlobalDataFlow.cs:193:20:193:49 | access to property Value | GlobalDataFlow.cs:194:15:194:22 | access to local variable nonSink0 |
+| GlobalDataFlow.cs:193:37:193:42 | [output] delegate creation of type Func<String> | GlobalDataFlow.cs:193:9:193:49 | SSA def(nonSink0) |
+| GlobalDataFlow.cs:193:37:193:42 | [output] delegate creation of type Func<String> | GlobalDataFlow.cs:193:9:193:49 | SSA def(nonSink0) |
+| GlobalDataFlow.cs:193:37:193:42 | [output] delegate creation of type Func<String> | GlobalDataFlow.cs:193:20:193:43 | object creation of type Lazy<String> |
+| GlobalDataFlow.cs:193:37:193:42 | [output] delegate creation of type Func<String> | GlobalDataFlow.cs:193:20:193:43 | object creation of type Lazy<String> |
+| GlobalDataFlow.cs:193:37:193:42 | [output] delegate creation of type Func<String> | GlobalDataFlow.cs:193:20:193:49 | access to property Value |
+| GlobalDataFlow.cs:193:37:193:42 | [output] delegate creation of type Func<String> | GlobalDataFlow.cs:193:20:193:49 | access to property Value |
+| GlobalDataFlow.cs:193:37:193:42 | [output] delegate creation of type Func<String> | GlobalDataFlow.cs:193:37:193:42 | [output] delegate creation of type Func<String> |
+| GlobalDataFlow.cs:193:37:193:42 | [output] delegate creation of type Func<String> | GlobalDataFlow.cs:194:15:194:22 | access to local variable nonSink0 |
+| GlobalDataFlow.cs:193:37:193:42 | [output] delegate creation of type Func<String> | GlobalDataFlow.cs:194:15:194:22 | access to local variable nonSink0 |
+| GlobalDataFlow.cs:193:37:193:42 | access to method NonOut | GlobalDataFlow.cs:193:37:193:42 | access to method NonOut |
+| GlobalDataFlow.cs:193:37:193:42 | delegate creation of type Func<String> | GlobalDataFlow.cs:193:37:193:42 | delegate creation of type Func<String> |
+| GlobalDataFlow.cs:193:37:193:42 | this access | GlobalDataFlow.cs:193:37:193:42 | this access |
+| GlobalDataFlow.cs:193:37:193:42 | this access | GlobalDataFlow.cs:197:22:197:32 | this access |
+| GlobalDataFlow.cs:193:37:193:42 | this access | GlobalDataFlow.cs:197:22:197:32 | this access |
+| GlobalDataFlow.cs:193:37:193:42 | this access | GlobalDataFlow.cs:201:20:201:33 | this access |
+| GlobalDataFlow.cs:193:37:193:42 | this access | GlobalDataFlow.cs:201:20:201:33 | this access |
+| GlobalDataFlow.cs:194:9:194:23 | call to method Check | GlobalDataFlow.cs:194:9:194:23 | call to method Check |
+| GlobalDataFlow.cs:194:15:194:22 | access to local variable nonSink0 | GlobalDataFlow.cs:194:15:194:22 | access to local variable nonSink0 |
+| GlobalDataFlow.cs:197:13:197:32 | SSA def(sink19) | GlobalDataFlow.cs:197:13:197:32 | SSA def(sink19) |
+| GlobalDataFlow.cs:197:13:197:32 | SSA def(sink19) | GlobalDataFlow.cs:198:15:198:20 | access to local variable sink19 |
+| GlobalDataFlow.cs:197:13:197:32 | SSA def(sink19) | GlobalDataFlow.cs:198:15:198:20 | access to local variable sink19 |
+| GlobalDataFlow.cs:197:13:197:32 | String sink19 = ... | GlobalDataFlow.cs:197:13:197:32 | String sink19 = ... |
+| GlobalDataFlow.cs:197:22:197:32 | SSA untracked def(this.OutProperty) | GlobalDataFlow.cs:197:22:197:32 | SSA untracked def(this.OutProperty) |
+| GlobalDataFlow.cs:197:22:197:32 | access to property OutProperty | GlobalDataFlow.cs:197:13:197:32 | SSA def(sink19) |
+| GlobalDataFlow.cs:197:22:197:32 | access to property OutProperty | GlobalDataFlow.cs:197:13:197:32 | SSA def(sink19) |
+| GlobalDataFlow.cs:197:22:197:32 | access to property OutProperty | GlobalDataFlow.cs:197:22:197:32 | access to property OutProperty |
+| GlobalDataFlow.cs:197:22:197:32 | access to property OutProperty | GlobalDataFlow.cs:198:15:198:20 | access to local variable sink19 |
+| GlobalDataFlow.cs:197:22:197:32 | access to property OutProperty | GlobalDataFlow.cs:198:15:198:20 | access to local variable sink19 |
+| GlobalDataFlow.cs:197:22:197:32 | this access | GlobalDataFlow.cs:197:22:197:32 | this access |
+| GlobalDataFlow.cs:197:22:197:32 | this access | GlobalDataFlow.cs:201:20:201:33 | this access |
+| GlobalDataFlow.cs:197:22:197:32 | this access | GlobalDataFlow.cs:201:20:201:33 | this access |
+| GlobalDataFlow.cs:197:22:197:32 | this access | GlobalDataFlow.cs:415:9:415:11 | this |
+| GlobalDataFlow.cs:197:22:197:32 | this access | GlobalDataFlow.cs:415:9:415:11 | this |
+| GlobalDataFlow.cs:198:9:198:21 | call to method Check | GlobalDataFlow.cs:198:9:198:21 | call to method Check |
+| GlobalDataFlow.cs:198:15:198:20 | access to local variable sink19 | GlobalDataFlow.cs:198:15:198:20 | access to local variable sink19 |
+| GlobalDataFlow.cs:201:9:201:33 | ... = ... | GlobalDataFlow.cs:201:9:201:33 | ... = ... |
+| GlobalDataFlow.cs:201:9:201:33 | SSA def(nonSink0) | GlobalDataFlow.cs:201:9:201:33 | SSA def(nonSink0) |
+| GlobalDataFlow.cs:201:9:201:33 | SSA def(nonSink0) | GlobalDataFlow.cs:202:15:202:22 | access to local variable nonSink0 |
+| GlobalDataFlow.cs:201:9:201:33 | SSA def(nonSink0) | GlobalDataFlow.cs:202:15:202:22 | access to local variable nonSink0 |
+| GlobalDataFlow.cs:201:20:201:33 | SSA untracked def(this.NonOutProperty) | GlobalDataFlow.cs:201:20:201:33 | SSA untracked def(this.NonOutProperty) |
+| GlobalDataFlow.cs:201:20:201:33 | access to property NonOutProperty | GlobalDataFlow.cs:201:9:201:33 | SSA def(nonSink0) |
+| GlobalDataFlow.cs:201:20:201:33 | access to property NonOutProperty | GlobalDataFlow.cs:201:9:201:33 | SSA def(nonSink0) |
+| GlobalDataFlow.cs:201:20:201:33 | access to property NonOutProperty | GlobalDataFlow.cs:201:20:201:33 | access to property NonOutProperty |
+| GlobalDataFlow.cs:201:20:201:33 | access to property NonOutProperty | GlobalDataFlow.cs:202:15:202:22 | access to local variable nonSink0 |
+| GlobalDataFlow.cs:201:20:201:33 | access to property NonOutProperty | GlobalDataFlow.cs:202:15:202:22 | access to local variable nonSink0 |
+| GlobalDataFlow.cs:201:20:201:33 | this access | GlobalDataFlow.cs:201:20:201:33 | this access |
+| GlobalDataFlow.cs:201:20:201:33 | this access | GlobalDataFlow.cs:420:9:420:11 | this |
+| GlobalDataFlow.cs:201:20:201:33 | this access | GlobalDataFlow.cs:420:9:420:11 | this |
+| GlobalDataFlow.cs:202:9:202:23 | call to method Check | GlobalDataFlow.cs:202:9:202:23 | call to method Check |
+| GlobalDataFlow.cs:202:15:202:22 | access to local variable nonSink0 | GlobalDataFlow.cs:202:15:202:22 | access to local variable nonSink0 |
+| GlobalDataFlow.cs:205:17:205:18 | this | GlobalDataFlow.cs:205:17:205:18 | this |
+| GlobalDataFlow.cs:205:39:205:45 | tainted | GlobalDataFlow.cs:205:39:205:45 | tainted |
+| GlobalDataFlow.cs:205:39:205:45 | tainted | GlobalDataFlow.cs:205:39:205:45 | tainted |
+| GlobalDataFlow.cs:205:39:205:45 | tainted | GlobalDataFlow.cs:205:39:205:45 | tainted |
+| GlobalDataFlow.cs:205:39:205:45 | tainted | GlobalDataFlow.cs:205:39:205:45 | tainted |
+| GlobalDataFlow.cs:205:39:205:45 | tainted | GlobalDataFlow.cs:210:22:210:28 | access to parameter tainted |
+| GlobalDataFlow.cs:205:39:205:45 | tainted | GlobalDataFlow.cs:210:22:210:28 | access to parameter tainted |
+| GlobalDataFlow.cs:205:39:205:45 | tainted | GlobalDataFlow.cs:210:22:210:28 | access to parameter tainted |
+| GlobalDataFlow.cs:205:39:205:45 | tainted | GlobalDataFlow.cs:210:22:210:28 | access to parameter tainted |
+| GlobalDataFlow.cs:205:39:205:45 | tainted | GlobalDataFlow.cs:212:22:212:28 | access to parameter tainted |
+| GlobalDataFlow.cs:205:39:205:45 | tainted | GlobalDataFlow.cs:212:22:212:28 | access to parameter tainted |
+| GlobalDataFlow.cs:205:39:205:45 | tainted | GlobalDataFlow.cs:212:22:212:28 | access to parameter tainted |
+| GlobalDataFlow.cs:205:39:205:45 | tainted | GlobalDataFlow.cs:212:22:212:28 | access to parameter tainted |
+| GlobalDataFlow.cs:205:39:205:45 | tainted | GlobalDataFlow.cs:214:22:214:28 | access to parameter tainted |
+| GlobalDataFlow.cs:205:39:205:45 | tainted | GlobalDataFlow.cs:214:22:214:28 | access to parameter tainted |
+| GlobalDataFlow.cs:205:39:205:45 | tainted | GlobalDataFlow.cs:214:22:214:28 | access to parameter tainted |
+| GlobalDataFlow.cs:205:39:205:45 | tainted | GlobalDataFlow.cs:214:22:214:28 | access to parameter tainted |
+| GlobalDataFlow.cs:205:67:205:76 | notTainted | GlobalDataFlow.cs:205:67:205:76 | notTainted |
+| GlobalDataFlow.cs:205:67:205:76 | notTainted | GlobalDataFlow.cs:205:67:205:76 | notTainted |
+| GlobalDataFlow.cs:205:67:205:76 | notTainted | GlobalDataFlow.cs:205:67:205:76 | notTainted |
+| GlobalDataFlow.cs:205:67:205:76 | notTainted | GlobalDataFlow.cs:205:67:205:76 | notTainted |
+| GlobalDataFlow.cs:205:67:205:76 | notTainted | GlobalDataFlow.cs:220:23:220:32 | access to parameter notTainted |
+| GlobalDataFlow.cs:205:67:205:76 | notTainted | GlobalDataFlow.cs:220:23:220:32 | access to parameter notTainted |
+| GlobalDataFlow.cs:205:67:205:76 | notTainted | GlobalDataFlow.cs:220:23:220:32 | access to parameter notTainted |
+| GlobalDataFlow.cs:205:67:205:76 | notTainted | GlobalDataFlow.cs:220:23:220:32 | access to parameter notTainted |
+| GlobalDataFlow.cs:205:67:205:76 | notTainted | GlobalDataFlow.cs:222:19:222:28 | access to parameter notTainted |
+| GlobalDataFlow.cs:205:67:205:76 | notTainted | GlobalDataFlow.cs:222:19:222:28 | access to parameter notTainted |
+| GlobalDataFlow.cs:205:67:205:76 | notTainted | GlobalDataFlow.cs:222:19:222:28 | access to parameter notTainted |
+| GlobalDataFlow.cs:205:67:205:76 | notTainted | GlobalDataFlow.cs:222:19:222:28 | access to parameter notTainted |
+| GlobalDataFlow.cs:205:67:205:76 | notTainted | GlobalDataFlow.cs:224:19:224:28 | access to parameter notTainted |
+| GlobalDataFlow.cs:205:67:205:76 | notTainted | GlobalDataFlow.cs:224:19:224:28 | access to parameter notTainted |
+| GlobalDataFlow.cs:205:67:205:76 | notTainted | GlobalDataFlow.cs:224:19:224:28 | access to parameter notTainted |
+| GlobalDataFlow.cs:205:67:205:76 | notTainted | GlobalDataFlow.cs:224:19:224:28 | access to parameter notTainted |
+| GlobalDataFlow.cs:205:67:205:76 | notTainted | GlobalDataFlow.cs:226:19:226:28 | access to parameter notTainted |
+| GlobalDataFlow.cs:205:67:205:76 | notTainted | GlobalDataFlow.cs:226:19:226:28 | access to parameter notTainted |
+| GlobalDataFlow.cs:205:67:205:76 | notTainted | GlobalDataFlow.cs:226:19:226:28 | access to parameter notTainted |
+| GlobalDataFlow.cs:205:67:205:76 | notTainted | GlobalDataFlow.cs:226:19:226:28 | access to parameter notTainted |
+| GlobalDataFlow.cs:205:67:205:76 | notTainted | GlobalDataFlow.cs:228:19:228:28 | access to parameter notTainted |
+| GlobalDataFlow.cs:205:67:205:76 | notTainted | GlobalDataFlow.cs:228:19:228:28 | access to parameter notTainted |
+| GlobalDataFlow.cs:205:67:205:76 | notTainted | GlobalDataFlow.cs:228:19:228:28 | access to parameter notTainted |
+| GlobalDataFlow.cs:205:67:205:76 | notTainted | GlobalDataFlow.cs:228:19:228:28 | access to parameter notTainted |
+| GlobalDataFlow.cs:208:30:208:92 | Func<String,String> f1 = ... | GlobalDataFlow.cs:208:30:208:92 | Func<String,String> f1 = ... |
+| GlobalDataFlow.cs:208:30:208:92 | SSA def(f1) | GlobalDataFlow.cs:208:30:208:92 | SSA def(f1) |
+| GlobalDataFlow.cs:208:30:208:92 | SSA def(f1) | GlobalDataFlow.cs:210:37:210:38 | access to local variable f1 |
+| GlobalDataFlow.cs:208:30:208:92 | SSA def(f1) | GlobalDataFlow.cs:210:37:210:38 | access to local variable f1 |
+| GlobalDataFlow.cs:208:30:208:92 | SSA def(f1) | GlobalDataFlow.cs:220:41:220:42 | access to local variable f1 |
+| GlobalDataFlow.cs:208:30:208:92 | SSA def(f1) | GlobalDataFlow.cs:220:41:220:42 | access to local variable f1 |
+| GlobalDataFlow.cs:208:35:208:45 | sinkParam10 | GlobalDataFlow.cs:208:35:208:45 | sinkParam10 |
+| GlobalDataFlow.cs:208:35:208:45 | sinkParam10 | GlobalDataFlow.cs:208:35:208:45 | sinkParam10 |
+| GlobalDataFlow.cs:208:35:208:45 | sinkParam10 | GlobalDataFlow.cs:208:35:208:45 | sinkParam10 |
+| GlobalDataFlow.cs:208:35:208:45 | sinkParam10 | GlobalDataFlow.cs:208:35:208:45 | sinkParam10 |
+| GlobalDataFlow.cs:208:35:208:45 | sinkParam10 | GlobalDataFlow.cs:208:35:208:45 | sinkParam10 |
+| GlobalDataFlow.cs:208:35:208:45 | sinkParam10 | GlobalDataFlow.cs:208:35:208:45 | sinkParam10 |
+| GlobalDataFlow.cs:208:35:208:45 | sinkParam10 | GlobalDataFlow.cs:208:58:208:68 | access to parameter sinkParam10 |
+| GlobalDataFlow.cs:208:35:208:45 | sinkParam10 | GlobalDataFlow.cs:208:58:208:68 | access to parameter sinkParam10 |
+| GlobalDataFlow.cs:208:35:208:45 | sinkParam10 | GlobalDataFlow.cs:208:58:208:68 | access to parameter sinkParam10 |
+| GlobalDataFlow.cs:208:35:208:45 | sinkParam10 | GlobalDataFlow.cs:208:58:208:68 | access to parameter sinkParam10 |
+| GlobalDataFlow.cs:208:35:208:45 | sinkParam10 | GlobalDataFlow.cs:208:58:208:68 | access to parameter sinkParam10 |
+| GlobalDataFlow.cs:208:35:208:45 | sinkParam10 | GlobalDataFlow.cs:208:58:208:68 | access to parameter sinkParam10 |
+| GlobalDataFlow.cs:208:35:208:45 | sinkParam10 | GlobalDataFlow.cs:208:58:208:68 | access to parameter sinkParam10 |
+| GlobalDataFlow.cs:208:35:208:45 | sinkParam10 | GlobalDataFlow.cs:208:58:208:68 | access to parameter sinkParam10 |
+| GlobalDataFlow.cs:208:35:208:45 | sinkParam10 | GlobalDataFlow.cs:208:79:208:89 | access to parameter sinkParam10 |
+| GlobalDataFlow.cs:208:35:208:45 | sinkParam10 | GlobalDataFlow.cs:208:79:208:89 | access to parameter sinkParam10 |
+| GlobalDataFlow.cs:208:35:208:45 | sinkParam10 | GlobalDataFlow.cs:208:79:208:89 | access to parameter sinkParam10 |
+| GlobalDataFlow.cs:208:35:208:45 | sinkParam10 | GlobalDataFlow.cs:208:79:208:89 | access to parameter sinkParam10 |
+| GlobalDataFlow.cs:208:35:208:45 | sinkParam10 | GlobalDataFlow.cs:208:79:208:89 | access to parameter sinkParam10 |
+| GlobalDataFlow.cs:208:35:208:45 | sinkParam10 | GlobalDataFlow.cs:208:79:208:89 | access to parameter sinkParam10 |
+| GlobalDataFlow.cs:208:35:208:45 | sinkParam10 | GlobalDataFlow.cs:208:79:208:89 | access to parameter sinkParam10 |
+| GlobalDataFlow.cs:208:35:208:45 | sinkParam10 | GlobalDataFlow.cs:208:79:208:89 | access to parameter sinkParam10 |
+| GlobalDataFlow.cs:208:35:208:92 | (...) => ... | GlobalDataFlow.cs:208:30:208:92 | SSA def(f1) |
+| GlobalDataFlow.cs:208:35:208:92 | (...) => ... | GlobalDataFlow.cs:208:30:208:92 | SSA def(f1) |
+| GlobalDataFlow.cs:208:35:208:92 | (...) => ... | GlobalDataFlow.cs:208:35:208:92 | (...) => ... |
+| GlobalDataFlow.cs:208:35:208:92 | (...) => ... | GlobalDataFlow.cs:210:37:210:38 | access to local variable f1 |
+| GlobalDataFlow.cs:208:35:208:92 | (...) => ... | GlobalDataFlow.cs:210:37:210:38 | access to local variable f1 |
+| GlobalDataFlow.cs:208:35:208:92 | (...) => ... | GlobalDataFlow.cs:220:41:220:42 | access to local variable f1 |
+| GlobalDataFlow.cs:208:35:208:92 | (...) => ... | GlobalDataFlow.cs:220:41:220:42 | access to local variable f1 |
+| GlobalDataFlow.cs:208:52:208:69 | call to method Check | GlobalDataFlow.cs:208:52:208:69 | call to method Check |
+| GlobalDataFlow.cs:208:58:208:68 | access to parameter sinkParam10 | GlobalDataFlow.cs:208:58:208:68 | access to parameter sinkParam10 |
+| GlobalDataFlow.cs:208:58:208:68 | access to parameter sinkParam10 | GlobalDataFlow.cs:208:79:208:89 | access to parameter sinkParam10 |
+| GlobalDataFlow.cs:208:58:208:68 | access to parameter sinkParam10 | GlobalDataFlow.cs:208:79:208:89 | access to parameter sinkParam10 |
+| GlobalDataFlow.cs:208:58:208:68 | access to parameter sinkParam10 | GlobalDataFlow.cs:208:79:208:89 | access to parameter sinkParam10 |
+| GlobalDataFlow.cs:208:58:208:68 | access to parameter sinkParam10 | GlobalDataFlow.cs:208:79:208:89 | access to parameter sinkParam10 |
+| GlobalDataFlow.cs:208:79:208:89 | access to parameter sinkParam10 | GlobalDataFlow.cs:208:79:208:89 | access to parameter sinkParam10 |
+| GlobalDataFlow.cs:208:79:208:89 | access to parameter sinkParam10 | GlobalDataFlow.cs:210:37:210:38 | [output] access to local variable f1 |
+| GlobalDataFlow.cs:208:79:208:89 | access to parameter sinkParam10 | GlobalDataFlow.cs:210:37:210:38 | [output] access to local variable f1 |
+| GlobalDataFlow.cs:208:79:208:89 | access to parameter sinkParam10 | GlobalDataFlow.cs:220:41:220:42 | [output] access to local variable f1 |
+| GlobalDataFlow.cs:208:79:208:89 | access to parameter sinkParam10 | GlobalDataFlow.cs:220:41:220:42 | [output] access to local variable f1 |
+| GlobalDataFlow.cs:209:66:209:90 | Expression<Func<String,String>> f2 = ... | GlobalDataFlow.cs:209:66:209:90 | Expression<Func<String,String>> f2 = ... |
+| GlobalDataFlow.cs:209:66:209:90 | SSA def(f2) | GlobalDataFlow.cs:209:66:209:90 | SSA def(f2) |
+| GlobalDataFlow.cs:209:66:209:90 | SSA def(f2) | GlobalDataFlow.cs:212:37:212:38 | access to local variable f2 |
+| GlobalDataFlow.cs:209:66:209:90 | SSA def(f2) | GlobalDataFlow.cs:212:37:212:38 | access to local variable f2 |
+| GlobalDataFlow.cs:209:66:209:90 | SSA def(f2) | GlobalDataFlow.cs:222:37:222:38 | access to local variable f2 |
+| GlobalDataFlow.cs:209:66:209:90 | SSA def(f2) | GlobalDataFlow.cs:222:37:222:38 | access to local variable f2 |
+| GlobalDataFlow.cs:209:71:209:71 | x | GlobalDataFlow.cs:209:71:209:71 | x |
+| GlobalDataFlow.cs:209:71:209:71 | x | GlobalDataFlow.cs:209:71:209:71 | x |
+| GlobalDataFlow.cs:209:71:209:71 | x | GlobalDataFlow.cs:209:71:209:71 | x |
+| GlobalDataFlow.cs:209:71:209:71 | x | GlobalDataFlow.cs:209:71:209:71 | x |
+| GlobalDataFlow.cs:209:71:209:71 | x | GlobalDataFlow.cs:209:71:209:71 | x |
+| GlobalDataFlow.cs:209:71:209:71 | x | GlobalDataFlow.cs:209:71:209:71 | x |
+| GlobalDataFlow.cs:209:71:209:71 | x | GlobalDataFlow.cs:209:89:209:89 | access to parameter x |
+| GlobalDataFlow.cs:209:71:209:71 | x | GlobalDataFlow.cs:209:89:209:89 | access to parameter x |
+| GlobalDataFlow.cs:209:71:209:71 | x | GlobalDataFlow.cs:209:89:209:89 | access to parameter x |
+| GlobalDataFlow.cs:209:71:209:71 | x | GlobalDataFlow.cs:209:89:209:89 | access to parameter x |
+| GlobalDataFlow.cs:209:71:209:71 | x | GlobalDataFlow.cs:209:89:209:89 | access to parameter x |
+| GlobalDataFlow.cs:209:71:209:71 | x | GlobalDataFlow.cs:209:89:209:89 | access to parameter x |
+| GlobalDataFlow.cs:209:71:209:71 | x | GlobalDataFlow.cs:209:89:209:89 | access to parameter x |
+| GlobalDataFlow.cs:209:71:209:71 | x | GlobalDataFlow.cs:209:89:209:89 | access to parameter x |
+| GlobalDataFlow.cs:209:71:209:90 | (...) => ... | GlobalDataFlow.cs:209:66:209:90 | SSA def(f2) |
+| GlobalDataFlow.cs:209:71:209:90 | (...) => ... | GlobalDataFlow.cs:209:66:209:90 | SSA def(f2) |
+| GlobalDataFlow.cs:209:71:209:90 | (...) => ... | GlobalDataFlow.cs:209:71:209:90 | (...) => ... |
+| GlobalDataFlow.cs:209:71:209:90 | (...) => ... | GlobalDataFlow.cs:212:37:212:38 | access to local variable f2 |
+| GlobalDataFlow.cs:209:71:209:90 | (...) => ... | GlobalDataFlow.cs:212:37:212:38 | access to local variable f2 |
+| GlobalDataFlow.cs:209:71:209:90 | (...) => ... | GlobalDataFlow.cs:222:37:222:38 | access to local variable f2 |
+| GlobalDataFlow.cs:209:71:209:90 | (...) => ... | GlobalDataFlow.cs:222:37:222:38 | access to local variable f2 |
+| GlobalDataFlow.cs:209:76:209:90 | call to method ReturnCheck2 | GlobalDataFlow.cs:209:76:209:90 | call to method ReturnCheck2 |
+| GlobalDataFlow.cs:209:76:209:90 | call to method ReturnCheck2 | GlobalDataFlow.cs:212:37:212:38 | [output] access to local variable f2 |
+| GlobalDataFlow.cs:209:76:209:90 | call to method ReturnCheck2 | GlobalDataFlow.cs:212:37:212:38 | [output] access to local variable f2 |
+| GlobalDataFlow.cs:209:76:209:90 | call to method ReturnCheck2 | GlobalDataFlow.cs:222:37:222:38 | [output] access to local variable f2 |
+| GlobalDataFlow.cs:209:76:209:90 | call to method ReturnCheck2 | GlobalDataFlow.cs:222:37:222:38 | [output] access to local variable f2 |
+| GlobalDataFlow.cs:209:89:209:89 | access to parameter x | GlobalDataFlow.cs:209:76:209:90 | call to method ReturnCheck2 |
+| GlobalDataFlow.cs:209:89:209:89 | access to parameter x | GlobalDataFlow.cs:209:76:209:90 | call to method ReturnCheck2 |
+| GlobalDataFlow.cs:209:89:209:89 | access to parameter x | GlobalDataFlow.cs:209:76:209:90 | call to method ReturnCheck2 |
+| GlobalDataFlow.cs:209:89:209:89 | access to parameter x | GlobalDataFlow.cs:209:76:209:90 | call to method ReturnCheck2 |
+| GlobalDataFlow.cs:209:89:209:89 | access to parameter x | GlobalDataFlow.cs:209:89:209:89 | access to parameter x |
+| GlobalDataFlow.cs:209:89:209:89 | access to parameter x | GlobalDataFlow.cs:298:32:298:41 | sinkParam9 |
+| GlobalDataFlow.cs:209:89:209:89 | access to parameter x | GlobalDataFlow.cs:298:32:298:41 | sinkParam9 |
+| GlobalDataFlow.cs:209:89:209:89 | access to parameter x | GlobalDataFlow.cs:298:32:298:41 | sinkParam9 |
+| GlobalDataFlow.cs:209:89:209:89 | access to parameter x | GlobalDataFlow.cs:298:32:298:41 | sinkParam9 |
+| GlobalDataFlow.cs:210:13:210:39 | IEnumerable<String> sink24 = ... | GlobalDataFlow.cs:210:13:210:39 | IEnumerable<String> sink24 = ... |
+| GlobalDataFlow.cs:210:13:210:39 | SSA def(sink24) | GlobalDataFlow.cs:210:13:210:39 | SSA def(sink24) |
+| GlobalDataFlow.cs:210:13:210:39 | SSA def(sink24) | GlobalDataFlow.cs:211:15:211:20 | access to local variable sink24 |
+| GlobalDataFlow.cs:210:13:210:39 | SSA def(sink24) | GlobalDataFlow.cs:211:15:211:20 | access to local variable sink24 |
+| GlobalDataFlow.cs:210:22:210:28 | access to parameter tainted | GlobalDataFlow.cs:208:35:208:45 | sinkParam10 |
+| GlobalDataFlow.cs:210:22:210:28 | access to parameter tainted | GlobalDataFlow.cs:208:35:208:45 | sinkParam10 |
 | GlobalDataFlow.cs:210:22:210:28 | access to parameter tainted | GlobalDataFlow.cs:210:22:210:28 | access to parameter tainted |
-| GlobalDataFlow.cs:210:22:210:28 | access to parameter tainted | GlobalDataFlow.cs:210:37:210:48 | [output] delegate creation of type Func<String,String> |
-| GlobalDataFlow.cs:210:22:210:28 | access to parameter tainted | GlobalDataFlow.cs:210:37:210:48 | [output] delegate creation of type Func<String,String> |
-| GlobalDataFlow.cs:210:22:210:28 | access to parameter tainted | GlobalDataFlow.cs:299:32:299:42 | sinkParam11 |
-| GlobalDataFlow.cs:210:22:210:28 | access to parameter tainted | GlobalDataFlow.cs:299:32:299:42 | sinkParam11 |
-| GlobalDataFlow.cs:210:22:210:49 | call to method Select | GlobalDataFlow.cs:210:13:210:49 | SSA def(sink26) |
-| GlobalDataFlow.cs:210:22:210:49 | call to method Select | GlobalDataFlow.cs:210:13:210:49 | SSA def(sink26) |
-| GlobalDataFlow.cs:210:22:210:49 | call to method Select | GlobalDataFlow.cs:210:22:210:49 | call to method Select |
-| GlobalDataFlow.cs:210:22:210:49 | call to method Select | GlobalDataFlow.cs:211:15:211:20 | access to local variable sink26 |
-| GlobalDataFlow.cs:210:22:210:49 | call to method Select | GlobalDataFlow.cs:211:15:211:20 | access to local variable sink26 |
-| GlobalDataFlow.cs:210:37:210:48 | [output] delegate creation of type Func<String,String> | GlobalDataFlow.cs:210:13:210:49 | SSA def(sink26) |
-| GlobalDataFlow.cs:210:37:210:48 | [output] delegate creation of type Func<String,String> | GlobalDataFlow.cs:210:13:210:49 | SSA def(sink26) |
-| GlobalDataFlow.cs:210:37:210:48 | [output] delegate creation of type Func<String,String> | GlobalDataFlow.cs:210:22:210:49 | call to method Select |
-| GlobalDataFlow.cs:210:37:210:48 | [output] delegate creation of type Func<String,String> | GlobalDataFlow.cs:210:22:210:49 | call to method Select |
-| GlobalDataFlow.cs:210:37:210:48 | [output] delegate creation of type Func<String,String> | GlobalDataFlow.cs:210:37:210:48 | [output] delegate creation of type Func<String,String> |
-| GlobalDataFlow.cs:210:37:210:48 | [output] delegate creation of type Func<String,String> | GlobalDataFlow.cs:211:15:211:20 | access to local variable sink26 |
-| GlobalDataFlow.cs:210:37:210:48 | [output] delegate creation of type Func<String,String> | GlobalDataFlow.cs:211:15:211:20 | access to local variable sink26 |
-| GlobalDataFlow.cs:210:37:210:48 | access to method ReturnCheck3 | GlobalDataFlow.cs:210:37:210:48 | access to method ReturnCheck3 |
-| GlobalDataFlow.cs:210:37:210:48 | delegate creation of type Func<String,String> | GlobalDataFlow.cs:210:37:210:48 | delegate creation of type Func<String,String> |
+| GlobalDataFlow.cs:210:22:210:28 | access to parameter tainted | GlobalDataFlow.cs:210:37:210:38 | [output] access to local variable f1 |
+| GlobalDataFlow.cs:210:22:210:28 | access to parameter tainted | GlobalDataFlow.cs:210:37:210:38 | [output] access to local variable f1 |
+| GlobalDataFlow.cs:210:22:210:28 | access to parameter tainted | GlobalDataFlow.cs:212:22:212:28 | access to parameter tainted |
+| GlobalDataFlow.cs:210:22:210:28 | access to parameter tainted | GlobalDataFlow.cs:212:22:212:28 | access to parameter tainted |
+| GlobalDataFlow.cs:210:22:210:28 | access to parameter tainted | GlobalDataFlow.cs:214:22:214:28 | access to parameter tainted |
+| GlobalDataFlow.cs:210:22:210:28 | access to parameter tainted | GlobalDataFlow.cs:214:22:214:28 | access to parameter tainted |
+| GlobalDataFlow.cs:210:22:210:39 | call to method Select | GlobalDataFlow.cs:210:13:210:39 | SSA def(sink24) |
+| GlobalDataFlow.cs:210:22:210:39 | call to method Select | GlobalDataFlow.cs:210:13:210:39 | SSA def(sink24) |
+| GlobalDataFlow.cs:210:22:210:39 | call to method Select | GlobalDataFlow.cs:210:22:210:39 | call to method Select |
+| GlobalDataFlow.cs:210:22:210:39 | call to method Select | GlobalDataFlow.cs:211:15:211:20 | access to local variable sink24 |
+| GlobalDataFlow.cs:210:22:210:39 | call to method Select | GlobalDataFlow.cs:211:15:211:20 | access to local variable sink24 |
+| GlobalDataFlow.cs:210:37:210:38 | [output] access to local variable f1 | GlobalDataFlow.cs:210:13:210:39 | SSA def(sink24) |
+| GlobalDataFlow.cs:210:37:210:38 | [output] access to local variable f1 | GlobalDataFlow.cs:210:13:210:39 | SSA def(sink24) |
+| GlobalDataFlow.cs:210:37:210:38 | [output] access to local variable f1 | GlobalDataFlow.cs:210:22:210:39 | call to method Select |
+| GlobalDataFlow.cs:210:37:210:38 | [output] access to local variable f1 | GlobalDataFlow.cs:210:22:210:39 | call to method Select |
+| GlobalDataFlow.cs:210:37:210:38 | [output] access to local variable f1 | GlobalDataFlow.cs:210:37:210:38 | [output] access to local variable f1 |
+| GlobalDataFlow.cs:210:37:210:38 | [output] access to local variable f1 | GlobalDataFlow.cs:211:15:211:20 | access to local variable sink24 |
+| GlobalDataFlow.cs:210:37:210:38 | [output] access to local variable f1 | GlobalDataFlow.cs:211:15:211:20 | access to local variable sink24 |
+| GlobalDataFlow.cs:210:37:210:38 | access to local variable f1 | GlobalDataFlow.cs:210:37:210:38 | access to local variable f1 |
+| GlobalDataFlow.cs:210:37:210:38 | access to local variable f1 | GlobalDataFlow.cs:220:41:220:42 | access to local variable f1 |
+| GlobalDataFlow.cs:210:37:210:38 | access to local variable f1 | GlobalDataFlow.cs:220:41:220:42 | access to local variable f1 |
 | GlobalDataFlow.cs:211:9:211:21 | call to method Check | GlobalDataFlow.cs:211:9:211:21 | call to method Check |
-| GlobalDataFlow.cs:211:15:211:20 | access to local variable sink26 | GlobalDataFlow.cs:211:15:211:20 | access to local variable sink26 |
-| GlobalDataFlow.cs:214:30:214:95 | Func<String,String> f3 = ... | GlobalDataFlow.cs:214:30:214:95 | Func<String,String> f3 = ... |
-| GlobalDataFlow.cs:214:30:214:95 | SSA def(f3) | GlobalDataFlow.cs:214:30:214:95 | SSA def(f3) |
-| GlobalDataFlow.cs:214:30:214:95 | SSA def(f3) | GlobalDataFlow.cs:220:37:220:38 | access to local variable f3 |
-| GlobalDataFlow.cs:214:30:214:95 | SSA def(f3) | GlobalDataFlow.cs:220:37:220:38 | access to local variable f3 |
-| GlobalDataFlow.cs:214:35:214:46 | nonSinkParam | GlobalDataFlow.cs:214:35:214:46 | nonSinkParam |
-| GlobalDataFlow.cs:214:35:214:46 | nonSinkParam | GlobalDataFlow.cs:214:35:214:46 | nonSinkParam |
-| GlobalDataFlow.cs:214:35:214:46 | nonSinkParam | GlobalDataFlow.cs:214:35:214:46 | nonSinkParam |
-| GlobalDataFlow.cs:214:35:214:46 | nonSinkParam | GlobalDataFlow.cs:214:35:214:46 | nonSinkParam |
-| GlobalDataFlow.cs:214:35:214:46 | nonSinkParam | GlobalDataFlow.cs:214:35:214:46 | nonSinkParam |
-| GlobalDataFlow.cs:214:35:214:46 | nonSinkParam | GlobalDataFlow.cs:214:35:214:46 | nonSinkParam |
-| GlobalDataFlow.cs:214:35:214:46 | nonSinkParam | GlobalDataFlow.cs:214:59:214:70 | access to parameter nonSinkParam |
-| GlobalDataFlow.cs:214:35:214:46 | nonSinkParam | GlobalDataFlow.cs:214:59:214:70 | access to parameter nonSinkParam |
-| GlobalDataFlow.cs:214:35:214:46 | nonSinkParam | GlobalDataFlow.cs:214:59:214:70 | access to parameter nonSinkParam |
-| GlobalDataFlow.cs:214:35:214:46 | nonSinkParam | GlobalDataFlow.cs:214:59:214:70 | access to parameter nonSinkParam |
-| GlobalDataFlow.cs:214:35:214:46 | nonSinkParam | GlobalDataFlow.cs:214:59:214:70 | access to parameter nonSinkParam |
-| GlobalDataFlow.cs:214:35:214:46 | nonSinkParam | GlobalDataFlow.cs:214:59:214:70 | access to parameter nonSinkParam |
-| GlobalDataFlow.cs:214:35:214:46 | nonSinkParam | GlobalDataFlow.cs:214:59:214:70 | access to parameter nonSinkParam |
-| GlobalDataFlow.cs:214:35:214:46 | nonSinkParam | GlobalDataFlow.cs:214:59:214:70 | access to parameter nonSinkParam |
-| GlobalDataFlow.cs:214:35:214:46 | nonSinkParam | GlobalDataFlow.cs:214:81:214:92 | access to parameter nonSinkParam |
-| GlobalDataFlow.cs:214:35:214:46 | nonSinkParam | GlobalDataFlow.cs:214:81:214:92 | access to parameter nonSinkParam |
-| GlobalDataFlow.cs:214:35:214:46 | nonSinkParam | GlobalDataFlow.cs:214:81:214:92 | access to parameter nonSinkParam |
-| GlobalDataFlow.cs:214:35:214:46 | nonSinkParam | GlobalDataFlow.cs:214:81:214:92 | access to parameter nonSinkParam |
-| GlobalDataFlow.cs:214:35:214:46 | nonSinkParam | GlobalDataFlow.cs:214:81:214:92 | access to parameter nonSinkParam |
-| GlobalDataFlow.cs:214:35:214:46 | nonSinkParam | GlobalDataFlow.cs:214:81:214:92 | access to parameter nonSinkParam |
-| GlobalDataFlow.cs:214:35:214:46 | nonSinkParam | GlobalDataFlow.cs:214:81:214:92 | access to parameter nonSinkParam |
-| GlobalDataFlow.cs:214:35:214:46 | nonSinkParam | GlobalDataFlow.cs:214:81:214:92 | access to parameter nonSinkParam |
-| GlobalDataFlow.cs:214:35:214:95 | (...) => ... | GlobalDataFlow.cs:214:30:214:95 | SSA def(f3) |
-| GlobalDataFlow.cs:214:35:214:95 | (...) => ... | GlobalDataFlow.cs:214:30:214:95 | SSA def(f3) |
-| GlobalDataFlow.cs:214:35:214:95 | (...) => ... | GlobalDataFlow.cs:214:35:214:95 | (...) => ... |
-| GlobalDataFlow.cs:214:35:214:95 | (...) => ... | GlobalDataFlow.cs:220:37:220:38 | access to local variable f3 |
-| GlobalDataFlow.cs:214:35:214:95 | (...) => ... | GlobalDataFlow.cs:220:37:220:38 | access to local variable f3 |
-| GlobalDataFlow.cs:214:53:214:71 | call to method Check | GlobalDataFlow.cs:214:53:214:71 | call to method Check |
-| GlobalDataFlow.cs:214:59:214:70 | access to parameter nonSinkParam | GlobalDataFlow.cs:214:59:214:70 | access to parameter nonSinkParam |
-| GlobalDataFlow.cs:214:59:214:70 | access to parameter nonSinkParam | GlobalDataFlow.cs:214:81:214:92 | access to parameter nonSinkParam |
-| GlobalDataFlow.cs:214:59:214:70 | access to parameter nonSinkParam | GlobalDataFlow.cs:214:81:214:92 | access to parameter nonSinkParam |
-| GlobalDataFlow.cs:214:59:214:70 | access to parameter nonSinkParam | GlobalDataFlow.cs:214:81:214:92 | access to parameter nonSinkParam |
-| GlobalDataFlow.cs:214:59:214:70 | access to parameter nonSinkParam | GlobalDataFlow.cs:214:81:214:92 | access to parameter nonSinkParam |
-| GlobalDataFlow.cs:214:81:214:92 | access to parameter nonSinkParam | GlobalDataFlow.cs:214:81:214:92 | access to parameter nonSinkParam |
-| GlobalDataFlow.cs:214:81:214:92 | access to parameter nonSinkParam | GlobalDataFlow.cs:220:37:220:38 | [output] access to local variable f3 |
-| GlobalDataFlow.cs:214:81:214:92 | access to parameter nonSinkParam | GlobalDataFlow.cs:220:37:220:38 | [output] access to local variable f3 |
-| GlobalDataFlow.cs:215:66:215:92 | Expression<Func<String,String>> f4 = ... | GlobalDataFlow.cs:215:66:215:92 | Expression<Func<String,String>> f4 = ... |
-| GlobalDataFlow.cs:215:66:215:92 | SSA def(f4) | GlobalDataFlow.cs:215:66:215:92 | SSA def(f4) |
-| GlobalDataFlow.cs:215:66:215:92 | SSA def(f4) | GlobalDataFlow.cs:222:37:222:38 | access to local variable f4 |
-| GlobalDataFlow.cs:215:66:215:92 | SSA def(f4) | GlobalDataFlow.cs:222:37:222:38 | access to local variable f4 |
-| GlobalDataFlow.cs:215:71:215:71 | x | GlobalDataFlow.cs:215:71:215:71 | x |
-| GlobalDataFlow.cs:215:71:215:71 | x | GlobalDataFlow.cs:215:71:215:71 | x |
-| GlobalDataFlow.cs:215:71:215:71 | x | GlobalDataFlow.cs:215:71:215:71 | x |
-| GlobalDataFlow.cs:215:71:215:71 | x | GlobalDataFlow.cs:215:71:215:71 | x |
-| GlobalDataFlow.cs:215:71:215:71 | x | GlobalDataFlow.cs:215:71:215:71 | x |
-| GlobalDataFlow.cs:215:71:215:71 | x | GlobalDataFlow.cs:215:71:215:71 | x |
-| GlobalDataFlow.cs:215:71:215:71 | x | GlobalDataFlow.cs:215:91:215:91 | access to parameter x |
-| GlobalDataFlow.cs:215:71:215:71 | x | GlobalDataFlow.cs:215:91:215:91 | access to parameter x |
-| GlobalDataFlow.cs:215:71:215:71 | x | GlobalDataFlow.cs:215:91:215:91 | access to parameter x |
-| GlobalDataFlow.cs:215:71:215:71 | x | GlobalDataFlow.cs:215:91:215:91 | access to parameter x |
-| GlobalDataFlow.cs:215:71:215:71 | x | GlobalDataFlow.cs:215:91:215:91 | access to parameter x |
-| GlobalDataFlow.cs:215:71:215:71 | x | GlobalDataFlow.cs:215:91:215:91 | access to parameter x |
-| GlobalDataFlow.cs:215:71:215:71 | x | GlobalDataFlow.cs:215:91:215:91 | access to parameter x |
-| GlobalDataFlow.cs:215:71:215:71 | x | GlobalDataFlow.cs:215:91:215:91 | access to parameter x |
-| GlobalDataFlow.cs:215:71:215:92 | (...) => ... | GlobalDataFlow.cs:215:66:215:92 | SSA def(f4) |
-| GlobalDataFlow.cs:215:71:215:92 | (...) => ... | GlobalDataFlow.cs:215:66:215:92 | SSA def(f4) |
-| GlobalDataFlow.cs:215:71:215:92 | (...) => ... | GlobalDataFlow.cs:215:71:215:92 | (...) => ... |
-| GlobalDataFlow.cs:215:71:215:92 | (...) => ... | GlobalDataFlow.cs:222:37:222:38 | access to local variable f4 |
-| GlobalDataFlow.cs:215:71:215:92 | (...) => ... | GlobalDataFlow.cs:222:37:222:38 | access to local variable f4 |
-| GlobalDataFlow.cs:215:76:215:92 | call to method NonReturnCheck | GlobalDataFlow.cs:215:76:215:92 | call to method NonReturnCheck |
-| GlobalDataFlow.cs:215:76:215:92 | call to method NonReturnCheck | GlobalDataFlow.cs:222:37:222:38 | [output] access to local variable f4 |
-| GlobalDataFlow.cs:215:76:215:92 | call to method NonReturnCheck | GlobalDataFlow.cs:222:37:222:38 | [output] access to local variable f4 |
-| GlobalDataFlow.cs:215:91:215:91 | access to parameter x | GlobalDataFlow.cs:215:76:215:92 | call to method NonReturnCheck |
-| GlobalDataFlow.cs:215:91:215:91 | access to parameter x | GlobalDataFlow.cs:215:76:215:92 | call to method NonReturnCheck |
-| GlobalDataFlow.cs:215:91:215:91 | access to parameter x | GlobalDataFlow.cs:215:76:215:92 | call to method NonReturnCheck |
-| GlobalDataFlow.cs:215:91:215:91 | access to parameter x | GlobalDataFlow.cs:215:76:215:92 | call to method NonReturnCheck |
-| GlobalDataFlow.cs:215:91:215:91 | access to parameter x | GlobalDataFlow.cs:215:91:215:91 | access to parameter x |
-| GlobalDataFlow.cs:215:91:215:91 | access to parameter x | GlobalDataFlow.cs:305:34:305:45 | nonSinkParam |
-| GlobalDataFlow.cs:215:91:215:91 | access to parameter x | GlobalDataFlow.cs:305:34:305:45 | nonSinkParam |
-| GlobalDataFlow.cs:215:91:215:91 | access to parameter x | GlobalDataFlow.cs:305:34:305:45 | nonSinkParam |
-| GlobalDataFlow.cs:215:91:215:91 | access to parameter x | GlobalDataFlow.cs:305:34:305:45 | nonSinkParam |
-| GlobalDataFlow.cs:216:13:216:43 | IEnumerable<String> nonSink = ... | GlobalDataFlow.cs:216:13:216:43 | IEnumerable<String> nonSink = ... |
-| GlobalDataFlow.cs:216:13:216:43 | SSA def(nonSink) | GlobalDataFlow.cs:216:13:216:43 | SSA def(nonSink) |
-| GlobalDataFlow.cs:216:13:216:43 | SSA def(nonSink) | GlobalDataFlow.cs:217:15:217:21 | access to local variable nonSink |
-| GlobalDataFlow.cs:216:13:216:43 | SSA def(nonSink) | GlobalDataFlow.cs:217:15:217:21 | access to local variable nonSink |
-| GlobalDataFlow.cs:216:23:216:32 | access to parameter notTainted | GlobalDataFlow.cs:204:35:204:45 | sinkParam10 |
-| GlobalDataFlow.cs:216:23:216:32 | access to parameter notTainted | GlobalDataFlow.cs:204:35:204:45 | sinkParam10 |
-| GlobalDataFlow.cs:216:23:216:32 | access to parameter notTainted | GlobalDataFlow.cs:216:23:216:32 | access to parameter notTainted |
-| GlobalDataFlow.cs:216:23:216:32 | access to parameter notTainted | GlobalDataFlow.cs:216:41:216:42 | [output] access to local variable f1 |
-| GlobalDataFlow.cs:216:23:216:32 | access to parameter notTainted | GlobalDataFlow.cs:216:41:216:42 | [output] access to local variable f1 |
-| GlobalDataFlow.cs:216:23:216:32 | access to parameter notTainted | GlobalDataFlow.cs:218:19:218:28 | access to parameter notTainted |
-| GlobalDataFlow.cs:216:23:216:32 | access to parameter notTainted | GlobalDataFlow.cs:218:19:218:28 | access to parameter notTainted |
-| GlobalDataFlow.cs:216:23:216:32 | access to parameter notTainted | GlobalDataFlow.cs:220:19:220:28 | access to parameter notTainted |
-| GlobalDataFlow.cs:216:23:216:32 | access to parameter notTainted | GlobalDataFlow.cs:220:19:220:28 | access to parameter notTainted |
-| GlobalDataFlow.cs:216:23:216:32 | access to parameter notTainted | GlobalDataFlow.cs:222:19:222:28 | access to parameter notTainted |
-| GlobalDataFlow.cs:216:23:216:32 | access to parameter notTainted | GlobalDataFlow.cs:222:19:222:28 | access to parameter notTainted |
-| GlobalDataFlow.cs:216:23:216:32 | access to parameter notTainted | GlobalDataFlow.cs:224:19:224:28 | access to parameter notTainted |
-| GlobalDataFlow.cs:216:23:216:32 | access to parameter notTainted | GlobalDataFlow.cs:224:19:224:28 | access to parameter notTainted |
-| GlobalDataFlow.cs:216:23:216:43 | call to method Select | GlobalDataFlow.cs:216:13:216:43 | SSA def(nonSink) |
-| GlobalDataFlow.cs:216:23:216:43 | call to method Select | GlobalDataFlow.cs:216:13:216:43 | SSA def(nonSink) |
-| GlobalDataFlow.cs:216:23:216:43 | call to method Select | GlobalDataFlow.cs:216:23:216:43 | call to method Select |
-| GlobalDataFlow.cs:216:23:216:43 | call to method Select | GlobalDataFlow.cs:217:15:217:21 | access to local variable nonSink |
-| GlobalDataFlow.cs:216:23:216:43 | call to method Select | GlobalDataFlow.cs:217:15:217:21 | access to local variable nonSink |
-| GlobalDataFlow.cs:216:41:216:42 | [output] access to local variable f1 | GlobalDataFlow.cs:216:13:216:43 | SSA def(nonSink) |
-| GlobalDataFlow.cs:216:41:216:42 | [output] access to local variable f1 | GlobalDataFlow.cs:216:13:216:43 | SSA def(nonSink) |
-| GlobalDataFlow.cs:216:41:216:42 | [output] access to local variable f1 | GlobalDataFlow.cs:216:23:216:43 | call to method Select |
-| GlobalDataFlow.cs:216:41:216:42 | [output] access to local variable f1 | GlobalDataFlow.cs:216:23:216:43 | call to method Select |
-| GlobalDataFlow.cs:216:41:216:42 | [output] access to local variable f1 | GlobalDataFlow.cs:216:41:216:42 | [output] access to local variable f1 |
-| GlobalDataFlow.cs:216:41:216:42 | [output] access to local variable f1 | GlobalDataFlow.cs:217:15:217:21 | access to local variable nonSink |
-| GlobalDataFlow.cs:216:41:216:42 | [output] access to local variable f1 | GlobalDataFlow.cs:217:15:217:21 | access to local variable nonSink |
-| GlobalDataFlow.cs:216:41:216:42 | access to local variable f1 | GlobalDataFlow.cs:216:41:216:42 | access to local variable f1 |
-| GlobalDataFlow.cs:217:9:217:22 | call to method Check | GlobalDataFlow.cs:217:9:217:22 | call to method Check |
-| GlobalDataFlow.cs:217:15:217:21 | access to local variable nonSink | GlobalDataFlow.cs:217:15:217:21 | access to local variable nonSink |
-| GlobalDataFlow.cs:218:9:218:39 | ... = ... | GlobalDataFlow.cs:218:9:218:39 | ... = ... |
-| GlobalDataFlow.cs:218:9:218:39 | SSA def(nonSink) | GlobalDataFlow.cs:218:9:218:39 | SSA def(nonSink) |
-| GlobalDataFlow.cs:218:9:218:39 | SSA def(nonSink) | GlobalDataFlow.cs:219:15:219:21 | access to local variable nonSink |
-| GlobalDataFlow.cs:218:9:218:39 | SSA def(nonSink) | GlobalDataFlow.cs:219:15:219:21 | access to local variable nonSink |
-| GlobalDataFlow.cs:218:19:218:28 | access to parameter notTainted | GlobalDataFlow.cs:205:71:205:71 | x |
-| GlobalDataFlow.cs:218:19:218:28 | access to parameter notTainted | GlobalDataFlow.cs:205:71:205:71 | x |
-| GlobalDataFlow.cs:218:19:218:28 | access to parameter notTainted | GlobalDataFlow.cs:218:19:218:28 | access to parameter notTainted |
-| GlobalDataFlow.cs:218:19:218:28 | access to parameter notTainted | GlobalDataFlow.cs:218:37:218:38 | [output] access to local variable f2 |
-| GlobalDataFlow.cs:218:19:218:28 | access to parameter notTainted | GlobalDataFlow.cs:218:37:218:38 | [output] access to local variable f2 |
-| GlobalDataFlow.cs:218:19:218:28 | access to parameter notTainted | GlobalDataFlow.cs:220:19:220:28 | access to parameter notTainted |
-| GlobalDataFlow.cs:218:19:218:28 | access to parameter notTainted | GlobalDataFlow.cs:220:19:220:28 | access to parameter notTainted |
-| GlobalDataFlow.cs:218:19:218:28 | access to parameter notTainted | GlobalDataFlow.cs:222:19:222:28 | access to parameter notTainted |
-| GlobalDataFlow.cs:218:19:218:28 | access to parameter notTainted | GlobalDataFlow.cs:222:19:222:28 | access to parameter notTainted |
-| GlobalDataFlow.cs:218:19:218:28 | access to parameter notTainted | GlobalDataFlow.cs:224:19:224:28 | access to parameter notTainted |
-| GlobalDataFlow.cs:218:19:218:28 | access to parameter notTainted | GlobalDataFlow.cs:224:19:224:28 | access to parameter notTainted |
-| GlobalDataFlow.cs:218:19:218:39 | call to method Select | GlobalDataFlow.cs:218:9:218:39 | SSA def(nonSink) |
-| GlobalDataFlow.cs:218:19:218:39 | call to method Select | GlobalDataFlow.cs:218:9:218:39 | SSA def(nonSink) |
-| GlobalDataFlow.cs:218:19:218:39 | call to method Select | GlobalDataFlow.cs:218:19:218:39 | call to method Select |
-| GlobalDataFlow.cs:218:19:218:39 | call to method Select | GlobalDataFlow.cs:219:15:219:21 | access to local variable nonSink |
-| GlobalDataFlow.cs:218:19:218:39 | call to method Select | GlobalDataFlow.cs:219:15:219:21 | access to local variable nonSink |
-| GlobalDataFlow.cs:218:37:218:38 | [output] access to local variable f2 | GlobalDataFlow.cs:218:9:218:39 | SSA def(nonSink) |
-| GlobalDataFlow.cs:218:37:218:38 | [output] access to local variable f2 | GlobalDataFlow.cs:218:9:218:39 | SSA def(nonSink) |
-| GlobalDataFlow.cs:218:37:218:38 | [output] access to local variable f2 | GlobalDataFlow.cs:218:19:218:39 | call to method Select |
-| GlobalDataFlow.cs:218:37:218:38 | [output] access to local variable f2 | GlobalDataFlow.cs:218:19:218:39 | call to method Select |
-| GlobalDataFlow.cs:218:37:218:38 | [output] access to local variable f2 | GlobalDataFlow.cs:218:37:218:38 | [output] access to local variable f2 |
-| GlobalDataFlow.cs:218:37:218:38 | [output] access to local variable f2 | GlobalDataFlow.cs:219:15:219:21 | access to local variable nonSink |
-| GlobalDataFlow.cs:218:37:218:38 | [output] access to local variable f2 | GlobalDataFlow.cs:219:15:219:21 | access to local variable nonSink |
-| GlobalDataFlow.cs:218:37:218:38 | access to local variable f2 | GlobalDataFlow.cs:218:37:218:38 | access to local variable f2 |
-| GlobalDataFlow.cs:219:9:219:22 | call to method Check | GlobalDataFlow.cs:219:9:219:22 | call to method Check |
-| GlobalDataFlow.cs:219:15:219:21 | access to local variable nonSink | GlobalDataFlow.cs:219:15:219:21 | access to local variable nonSink |
-| GlobalDataFlow.cs:220:9:220:39 | ... = ... | GlobalDataFlow.cs:220:9:220:39 | ... = ... |
-| GlobalDataFlow.cs:220:9:220:39 | SSA def(nonSink) | GlobalDataFlow.cs:220:9:220:39 | SSA def(nonSink) |
-| GlobalDataFlow.cs:220:9:220:39 | SSA def(nonSink) | GlobalDataFlow.cs:221:15:221:21 | access to local variable nonSink |
-| GlobalDataFlow.cs:220:9:220:39 | SSA def(nonSink) | GlobalDataFlow.cs:221:15:221:21 | access to local variable nonSink |
-| GlobalDataFlow.cs:220:19:220:28 | access to parameter notTainted | GlobalDataFlow.cs:214:35:214:46 | nonSinkParam |
-| GlobalDataFlow.cs:220:19:220:28 | access to parameter notTainted | GlobalDataFlow.cs:214:35:214:46 | nonSinkParam |
-| GlobalDataFlow.cs:220:19:220:28 | access to parameter notTainted | GlobalDataFlow.cs:220:19:220:28 | access to parameter notTainted |
-| GlobalDataFlow.cs:220:19:220:28 | access to parameter notTainted | GlobalDataFlow.cs:220:37:220:38 | [output] access to local variable f3 |
-| GlobalDataFlow.cs:220:19:220:28 | access to parameter notTainted | GlobalDataFlow.cs:220:37:220:38 | [output] access to local variable f3 |
-| GlobalDataFlow.cs:220:19:220:28 | access to parameter notTainted | GlobalDataFlow.cs:222:19:222:28 | access to parameter notTainted |
-| GlobalDataFlow.cs:220:19:220:28 | access to parameter notTainted | GlobalDataFlow.cs:222:19:222:28 | access to parameter notTainted |
-| GlobalDataFlow.cs:220:19:220:28 | access to parameter notTainted | GlobalDataFlow.cs:224:19:224:28 | access to parameter notTainted |
-| GlobalDataFlow.cs:220:19:220:28 | access to parameter notTainted | GlobalDataFlow.cs:224:19:224:28 | access to parameter notTainted |
-| GlobalDataFlow.cs:220:19:220:39 | call to method Select | GlobalDataFlow.cs:220:9:220:39 | SSA def(nonSink) |
-| GlobalDataFlow.cs:220:19:220:39 | call to method Select | GlobalDataFlow.cs:220:9:220:39 | SSA def(nonSink) |
-| GlobalDataFlow.cs:220:19:220:39 | call to method Select | GlobalDataFlow.cs:220:19:220:39 | call to method Select |
-| GlobalDataFlow.cs:220:19:220:39 | call to method Select | GlobalDataFlow.cs:221:15:221:21 | access to local variable nonSink |
-| GlobalDataFlow.cs:220:19:220:39 | call to method Select | GlobalDataFlow.cs:221:15:221:21 | access to local variable nonSink |
-| GlobalDataFlow.cs:220:37:220:38 | [output] access to local variable f3 | GlobalDataFlow.cs:220:9:220:39 | SSA def(nonSink) |
-| GlobalDataFlow.cs:220:37:220:38 | [output] access to local variable f3 | GlobalDataFlow.cs:220:9:220:39 | SSA def(nonSink) |
-| GlobalDataFlow.cs:220:37:220:38 | [output] access to local variable f3 | GlobalDataFlow.cs:220:19:220:39 | call to method Select |
-| GlobalDataFlow.cs:220:37:220:38 | [output] access to local variable f3 | GlobalDataFlow.cs:220:19:220:39 | call to method Select |
-| GlobalDataFlow.cs:220:37:220:38 | [output] access to local variable f3 | GlobalDataFlow.cs:220:37:220:38 | [output] access to local variable f3 |
-| GlobalDataFlow.cs:220:37:220:38 | [output] access to local variable f3 | GlobalDataFlow.cs:221:15:221:21 | access to local variable nonSink |
-| GlobalDataFlow.cs:220:37:220:38 | [output] access to local variable f3 | GlobalDataFlow.cs:221:15:221:21 | access to local variable nonSink |
-| GlobalDataFlow.cs:220:37:220:38 | access to local variable f3 | GlobalDataFlow.cs:220:37:220:38 | access to local variable f3 |
+| GlobalDataFlow.cs:211:15:211:20 | access to local variable sink24 | GlobalDataFlow.cs:211:15:211:20 | access to local variable sink24 |
+| GlobalDataFlow.cs:212:13:212:39 | IQueryable<String> sink25 = ... | GlobalDataFlow.cs:212:13:212:39 | IQueryable<String> sink25 = ... |
+| GlobalDataFlow.cs:212:13:212:39 | SSA def(sink25) | GlobalDataFlow.cs:212:13:212:39 | SSA def(sink25) |
+| GlobalDataFlow.cs:212:13:212:39 | SSA def(sink25) | GlobalDataFlow.cs:213:15:213:20 | access to local variable sink25 |
+| GlobalDataFlow.cs:212:13:212:39 | SSA def(sink25) | GlobalDataFlow.cs:213:15:213:20 | access to local variable sink25 |
+| GlobalDataFlow.cs:212:22:212:28 | access to parameter tainted | GlobalDataFlow.cs:209:71:209:71 | x |
+| GlobalDataFlow.cs:212:22:212:28 | access to parameter tainted | GlobalDataFlow.cs:209:71:209:71 | x |
+| GlobalDataFlow.cs:212:22:212:28 | access to parameter tainted | GlobalDataFlow.cs:212:22:212:28 | access to parameter tainted |
+| GlobalDataFlow.cs:212:22:212:28 | access to parameter tainted | GlobalDataFlow.cs:212:37:212:38 | [output] access to local variable f2 |
+| GlobalDataFlow.cs:212:22:212:28 | access to parameter tainted | GlobalDataFlow.cs:212:37:212:38 | [output] access to local variable f2 |
+| GlobalDataFlow.cs:212:22:212:28 | access to parameter tainted | GlobalDataFlow.cs:214:22:214:28 | access to parameter tainted |
+| GlobalDataFlow.cs:212:22:212:28 | access to parameter tainted | GlobalDataFlow.cs:214:22:214:28 | access to parameter tainted |
+| GlobalDataFlow.cs:212:22:212:39 | call to method Select | GlobalDataFlow.cs:212:13:212:39 | SSA def(sink25) |
+| GlobalDataFlow.cs:212:22:212:39 | call to method Select | GlobalDataFlow.cs:212:13:212:39 | SSA def(sink25) |
+| GlobalDataFlow.cs:212:22:212:39 | call to method Select | GlobalDataFlow.cs:212:22:212:39 | call to method Select |
+| GlobalDataFlow.cs:212:22:212:39 | call to method Select | GlobalDataFlow.cs:213:15:213:20 | access to local variable sink25 |
+| GlobalDataFlow.cs:212:22:212:39 | call to method Select | GlobalDataFlow.cs:213:15:213:20 | access to local variable sink25 |
+| GlobalDataFlow.cs:212:37:212:38 | [output] access to local variable f2 | GlobalDataFlow.cs:212:13:212:39 | SSA def(sink25) |
+| GlobalDataFlow.cs:212:37:212:38 | [output] access to local variable f2 | GlobalDataFlow.cs:212:13:212:39 | SSA def(sink25) |
+| GlobalDataFlow.cs:212:37:212:38 | [output] access to local variable f2 | GlobalDataFlow.cs:212:22:212:39 | call to method Select |
+| GlobalDataFlow.cs:212:37:212:38 | [output] access to local variable f2 | GlobalDataFlow.cs:212:22:212:39 | call to method Select |
+| GlobalDataFlow.cs:212:37:212:38 | [output] access to local variable f2 | GlobalDataFlow.cs:212:37:212:38 | [output] access to local variable f2 |
+| GlobalDataFlow.cs:212:37:212:38 | [output] access to local variable f2 | GlobalDataFlow.cs:213:15:213:20 | access to local variable sink25 |
+| GlobalDataFlow.cs:212:37:212:38 | [output] access to local variable f2 | GlobalDataFlow.cs:213:15:213:20 | access to local variable sink25 |
+| GlobalDataFlow.cs:212:37:212:38 | access to local variable f2 | GlobalDataFlow.cs:212:37:212:38 | access to local variable f2 |
+| GlobalDataFlow.cs:212:37:212:38 | access to local variable f2 | GlobalDataFlow.cs:222:37:222:38 | access to local variable f2 |
+| GlobalDataFlow.cs:212:37:212:38 | access to local variable f2 | GlobalDataFlow.cs:222:37:222:38 | access to local variable f2 |
+| GlobalDataFlow.cs:213:9:213:21 | call to method Check | GlobalDataFlow.cs:213:9:213:21 | call to method Check |
+| GlobalDataFlow.cs:213:15:213:20 | access to local variable sink25 | GlobalDataFlow.cs:213:15:213:20 | access to local variable sink25 |
+| GlobalDataFlow.cs:214:13:214:49 | IEnumerable<String> sink26 = ... | GlobalDataFlow.cs:214:13:214:49 | IEnumerable<String> sink26 = ... |
+| GlobalDataFlow.cs:214:13:214:49 | SSA def(sink26) | GlobalDataFlow.cs:214:13:214:49 | SSA def(sink26) |
+| GlobalDataFlow.cs:214:13:214:49 | SSA def(sink26) | GlobalDataFlow.cs:215:15:215:20 | access to local variable sink26 |
+| GlobalDataFlow.cs:214:13:214:49 | SSA def(sink26) | GlobalDataFlow.cs:215:15:215:20 | access to local variable sink26 |
+| GlobalDataFlow.cs:214:22:214:28 | access to parameter tainted | GlobalDataFlow.cs:214:22:214:28 | access to parameter tainted |
+| GlobalDataFlow.cs:214:22:214:28 | access to parameter tainted | GlobalDataFlow.cs:214:37:214:48 | [output] delegate creation of type Func<String,String> |
+| GlobalDataFlow.cs:214:22:214:28 | access to parameter tainted | GlobalDataFlow.cs:214:37:214:48 | [output] delegate creation of type Func<String,String> |
+| GlobalDataFlow.cs:214:22:214:28 | access to parameter tainted | GlobalDataFlow.cs:304:32:304:42 | sinkParam11 |
+| GlobalDataFlow.cs:214:22:214:28 | access to parameter tainted | GlobalDataFlow.cs:304:32:304:42 | sinkParam11 |
+| GlobalDataFlow.cs:214:22:214:49 | call to method Select | GlobalDataFlow.cs:214:13:214:49 | SSA def(sink26) |
+| GlobalDataFlow.cs:214:22:214:49 | call to method Select | GlobalDataFlow.cs:214:13:214:49 | SSA def(sink26) |
+| GlobalDataFlow.cs:214:22:214:49 | call to method Select | GlobalDataFlow.cs:214:22:214:49 | call to method Select |
+| GlobalDataFlow.cs:214:22:214:49 | call to method Select | GlobalDataFlow.cs:215:15:215:20 | access to local variable sink26 |
+| GlobalDataFlow.cs:214:22:214:49 | call to method Select | GlobalDataFlow.cs:215:15:215:20 | access to local variable sink26 |
+| GlobalDataFlow.cs:214:37:214:48 | [output] delegate creation of type Func<String,String> | GlobalDataFlow.cs:214:13:214:49 | SSA def(sink26) |
+| GlobalDataFlow.cs:214:37:214:48 | [output] delegate creation of type Func<String,String> | GlobalDataFlow.cs:214:13:214:49 | SSA def(sink26) |
+| GlobalDataFlow.cs:214:37:214:48 | [output] delegate creation of type Func<String,String> | GlobalDataFlow.cs:214:22:214:49 | call to method Select |
+| GlobalDataFlow.cs:214:37:214:48 | [output] delegate creation of type Func<String,String> | GlobalDataFlow.cs:214:22:214:49 | call to method Select |
+| GlobalDataFlow.cs:214:37:214:48 | [output] delegate creation of type Func<String,String> | GlobalDataFlow.cs:214:37:214:48 | [output] delegate creation of type Func<String,String> |
+| GlobalDataFlow.cs:214:37:214:48 | [output] delegate creation of type Func<String,String> | GlobalDataFlow.cs:215:15:215:20 | access to local variable sink26 |
+| GlobalDataFlow.cs:214:37:214:48 | [output] delegate creation of type Func<String,String> | GlobalDataFlow.cs:215:15:215:20 | access to local variable sink26 |
+| GlobalDataFlow.cs:214:37:214:48 | access to method ReturnCheck3 | GlobalDataFlow.cs:214:37:214:48 | access to method ReturnCheck3 |
+| GlobalDataFlow.cs:214:37:214:48 | delegate creation of type Func<String,String> | GlobalDataFlow.cs:214:37:214:48 | delegate creation of type Func<String,String> |
+| GlobalDataFlow.cs:215:9:215:21 | call to method Check | GlobalDataFlow.cs:215:9:215:21 | call to method Check |
+| GlobalDataFlow.cs:215:15:215:20 | access to local variable sink26 | GlobalDataFlow.cs:215:15:215:20 | access to local variable sink26 |
+| GlobalDataFlow.cs:218:30:218:95 | Func<String,String> f3 = ... | GlobalDataFlow.cs:218:30:218:95 | Func<String,String> f3 = ... |
+| GlobalDataFlow.cs:218:30:218:95 | SSA def(f3) | GlobalDataFlow.cs:218:30:218:95 | SSA def(f3) |
+| GlobalDataFlow.cs:218:30:218:95 | SSA def(f3) | GlobalDataFlow.cs:224:37:224:38 | access to local variable f3 |
+| GlobalDataFlow.cs:218:30:218:95 | SSA def(f3) | GlobalDataFlow.cs:224:37:224:38 | access to local variable f3 |
+| GlobalDataFlow.cs:218:35:218:46 | nonSinkParam | GlobalDataFlow.cs:218:35:218:46 | nonSinkParam |
+| GlobalDataFlow.cs:218:35:218:46 | nonSinkParam | GlobalDataFlow.cs:218:35:218:46 | nonSinkParam |
+| GlobalDataFlow.cs:218:35:218:46 | nonSinkParam | GlobalDataFlow.cs:218:35:218:46 | nonSinkParam |
+| GlobalDataFlow.cs:218:35:218:46 | nonSinkParam | GlobalDataFlow.cs:218:35:218:46 | nonSinkParam |
+| GlobalDataFlow.cs:218:35:218:46 | nonSinkParam | GlobalDataFlow.cs:218:35:218:46 | nonSinkParam |
+| GlobalDataFlow.cs:218:35:218:46 | nonSinkParam | GlobalDataFlow.cs:218:35:218:46 | nonSinkParam |
+| GlobalDataFlow.cs:218:35:218:46 | nonSinkParam | GlobalDataFlow.cs:218:59:218:70 | access to parameter nonSinkParam |
+| GlobalDataFlow.cs:218:35:218:46 | nonSinkParam | GlobalDataFlow.cs:218:59:218:70 | access to parameter nonSinkParam |
+| GlobalDataFlow.cs:218:35:218:46 | nonSinkParam | GlobalDataFlow.cs:218:59:218:70 | access to parameter nonSinkParam |
+| GlobalDataFlow.cs:218:35:218:46 | nonSinkParam | GlobalDataFlow.cs:218:59:218:70 | access to parameter nonSinkParam |
+| GlobalDataFlow.cs:218:35:218:46 | nonSinkParam | GlobalDataFlow.cs:218:59:218:70 | access to parameter nonSinkParam |
+| GlobalDataFlow.cs:218:35:218:46 | nonSinkParam | GlobalDataFlow.cs:218:59:218:70 | access to parameter nonSinkParam |
+| GlobalDataFlow.cs:218:35:218:46 | nonSinkParam | GlobalDataFlow.cs:218:59:218:70 | access to parameter nonSinkParam |
+| GlobalDataFlow.cs:218:35:218:46 | nonSinkParam | GlobalDataFlow.cs:218:59:218:70 | access to parameter nonSinkParam |
+| GlobalDataFlow.cs:218:35:218:46 | nonSinkParam | GlobalDataFlow.cs:218:81:218:92 | access to parameter nonSinkParam |
+| GlobalDataFlow.cs:218:35:218:46 | nonSinkParam | GlobalDataFlow.cs:218:81:218:92 | access to parameter nonSinkParam |
+| GlobalDataFlow.cs:218:35:218:46 | nonSinkParam | GlobalDataFlow.cs:218:81:218:92 | access to parameter nonSinkParam |
+| GlobalDataFlow.cs:218:35:218:46 | nonSinkParam | GlobalDataFlow.cs:218:81:218:92 | access to parameter nonSinkParam |
+| GlobalDataFlow.cs:218:35:218:46 | nonSinkParam | GlobalDataFlow.cs:218:81:218:92 | access to parameter nonSinkParam |
+| GlobalDataFlow.cs:218:35:218:46 | nonSinkParam | GlobalDataFlow.cs:218:81:218:92 | access to parameter nonSinkParam |
+| GlobalDataFlow.cs:218:35:218:46 | nonSinkParam | GlobalDataFlow.cs:218:81:218:92 | access to parameter nonSinkParam |
+| GlobalDataFlow.cs:218:35:218:46 | nonSinkParam | GlobalDataFlow.cs:218:81:218:92 | access to parameter nonSinkParam |
+| GlobalDataFlow.cs:218:35:218:95 | (...) => ... | GlobalDataFlow.cs:218:30:218:95 | SSA def(f3) |
+| GlobalDataFlow.cs:218:35:218:95 | (...) => ... | GlobalDataFlow.cs:218:30:218:95 | SSA def(f3) |
+| GlobalDataFlow.cs:218:35:218:95 | (...) => ... | GlobalDataFlow.cs:218:35:218:95 | (...) => ... |
+| GlobalDataFlow.cs:218:35:218:95 | (...) => ... | GlobalDataFlow.cs:224:37:224:38 | access to local variable f3 |
+| GlobalDataFlow.cs:218:35:218:95 | (...) => ... | GlobalDataFlow.cs:224:37:224:38 | access to local variable f3 |
+| GlobalDataFlow.cs:218:53:218:71 | call to method Check | GlobalDataFlow.cs:218:53:218:71 | call to method Check |
+| GlobalDataFlow.cs:218:59:218:70 | access to parameter nonSinkParam | GlobalDataFlow.cs:218:59:218:70 | access to parameter nonSinkParam |
+| GlobalDataFlow.cs:218:59:218:70 | access to parameter nonSinkParam | GlobalDataFlow.cs:218:81:218:92 | access to parameter nonSinkParam |
+| GlobalDataFlow.cs:218:59:218:70 | access to parameter nonSinkParam | GlobalDataFlow.cs:218:81:218:92 | access to parameter nonSinkParam |
+| GlobalDataFlow.cs:218:59:218:70 | access to parameter nonSinkParam | GlobalDataFlow.cs:218:81:218:92 | access to parameter nonSinkParam |
+| GlobalDataFlow.cs:218:59:218:70 | access to parameter nonSinkParam | GlobalDataFlow.cs:218:81:218:92 | access to parameter nonSinkParam |
+| GlobalDataFlow.cs:218:81:218:92 | access to parameter nonSinkParam | GlobalDataFlow.cs:218:81:218:92 | access to parameter nonSinkParam |
+| GlobalDataFlow.cs:218:81:218:92 | access to parameter nonSinkParam | GlobalDataFlow.cs:224:37:224:38 | [output] access to local variable f3 |
+| GlobalDataFlow.cs:218:81:218:92 | access to parameter nonSinkParam | GlobalDataFlow.cs:224:37:224:38 | [output] access to local variable f3 |
+| GlobalDataFlow.cs:219:66:219:92 | Expression<Func<String,String>> f4 = ... | GlobalDataFlow.cs:219:66:219:92 | Expression<Func<String,String>> f4 = ... |
+| GlobalDataFlow.cs:219:66:219:92 | SSA def(f4) | GlobalDataFlow.cs:219:66:219:92 | SSA def(f4) |
+| GlobalDataFlow.cs:219:66:219:92 | SSA def(f4) | GlobalDataFlow.cs:226:37:226:38 | access to local variable f4 |
+| GlobalDataFlow.cs:219:66:219:92 | SSA def(f4) | GlobalDataFlow.cs:226:37:226:38 | access to local variable f4 |
+| GlobalDataFlow.cs:219:71:219:71 | x | GlobalDataFlow.cs:219:71:219:71 | x |
+| GlobalDataFlow.cs:219:71:219:71 | x | GlobalDataFlow.cs:219:71:219:71 | x |
+| GlobalDataFlow.cs:219:71:219:71 | x | GlobalDataFlow.cs:219:71:219:71 | x |
+| GlobalDataFlow.cs:219:71:219:71 | x | GlobalDataFlow.cs:219:71:219:71 | x |
+| GlobalDataFlow.cs:219:71:219:71 | x | GlobalDataFlow.cs:219:71:219:71 | x |
+| GlobalDataFlow.cs:219:71:219:71 | x | GlobalDataFlow.cs:219:71:219:71 | x |
+| GlobalDataFlow.cs:219:71:219:71 | x | GlobalDataFlow.cs:219:91:219:91 | access to parameter x |
+| GlobalDataFlow.cs:219:71:219:71 | x | GlobalDataFlow.cs:219:91:219:91 | access to parameter x |
+| GlobalDataFlow.cs:219:71:219:71 | x | GlobalDataFlow.cs:219:91:219:91 | access to parameter x |
+| GlobalDataFlow.cs:219:71:219:71 | x | GlobalDataFlow.cs:219:91:219:91 | access to parameter x |
+| GlobalDataFlow.cs:219:71:219:71 | x | GlobalDataFlow.cs:219:91:219:91 | access to parameter x |
+| GlobalDataFlow.cs:219:71:219:71 | x | GlobalDataFlow.cs:219:91:219:91 | access to parameter x |
+| GlobalDataFlow.cs:219:71:219:71 | x | GlobalDataFlow.cs:219:91:219:91 | access to parameter x |
+| GlobalDataFlow.cs:219:71:219:71 | x | GlobalDataFlow.cs:219:91:219:91 | access to parameter x |
+| GlobalDataFlow.cs:219:71:219:92 | (...) => ... | GlobalDataFlow.cs:219:66:219:92 | SSA def(f4) |
+| GlobalDataFlow.cs:219:71:219:92 | (...) => ... | GlobalDataFlow.cs:219:66:219:92 | SSA def(f4) |
+| GlobalDataFlow.cs:219:71:219:92 | (...) => ... | GlobalDataFlow.cs:219:71:219:92 | (...) => ... |
+| GlobalDataFlow.cs:219:71:219:92 | (...) => ... | GlobalDataFlow.cs:226:37:226:38 | access to local variable f4 |
+| GlobalDataFlow.cs:219:71:219:92 | (...) => ... | GlobalDataFlow.cs:226:37:226:38 | access to local variable f4 |
+| GlobalDataFlow.cs:219:76:219:92 | call to method NonReturnCheck | GlobalDataFlow.cs:219:76:219:92 | call to method NonReturnCheck |
+| GlobalDataFlow.cs:219:76:219:92 | call to method NonReturnCheck | GlobalDataFlow.cs:226:37:226:38 | [output] access to local variable f4 |
+| GlobalDataFlow.cs:219:76:219:92 | call to method NonReturnCheck | GlobalDataFlow.cs:226:37:226:38 | [output] access to local variable f4 |
+| GlobalDataFlow.cs:219:91:219:91 | access to parameter x | GlobalDataFlow.cs:219:76:219:92 | call to method NonReturnCheck |
+| GlobalDataFlow.cs:219:91:219:91 | access to parameter x | GlobalDataFlow.cs:219:76:219:92 | call to method NonReturnCheck |
+| GlobalDataFlow.cs:219:91:219:91 | access to parameter x | GlobalDataFlow.cs:219:76:219:92 | call to method NonReturnCheck |
+| GlobalDataFlow.cs:219:91:219:91 | access to parameter x | GlobalDataFlow.cs:219:76:219:92 | call to method NonReturnCheck |
+| GlobalDataFlow.cs:219:91:219:91 | access to parameter x | GlobalDataFlow.cs:219:91:219:91 | access to parameter x |
+| GlobalDataFlow.cs:219:91:219:91 | access to parameter x | GlobalDataFlow.cs:310:34:310:45 | nonSinkParam |
+| GlobalDataFlow.cs:219:91:219:91 | access to parameter x | GlobalDataFlow.cs:310:34:310:45 | nonSinkParam |
+| GlobalDataFlow.cs:219:91:219:91 | access to parameter x | GlobalDataFlow.cs:310:34:310:45 | nonSinkParam |
+| GlobalDataFlow.cs:219:91:219:91 | access to parameter x | GlobalDataFlow.cs:310:34:310:45 | nonSinkParam |
+| GlobalDataFlow.cs:220:13:220:43 | IEnumerable<String> nonSink = ... | GlobalDataFlow.cs:220:13:220:43 | IEnumerable<String> nonSink = ... |
+| GlobalDataFlow.cs:220:13:220:43 | SSA def(nonSink) | GlobalDataFlow.cs:220:13:220:43 | SSA def(nonSink) |
+| GlobalDataFlow.cs:220:13:220:43 | SSA def(nonSink) | GlobalDataFlow.cs:221:15:221:21 | access to local variable nonSink |
+| GlobalDataFlow.cs:220:13:220:43 | SSA def(nonSink) | GlobalDataFlow.cs:221:15:221:21 | access to local variable nonSink |
+| GlobalDataFlow.cs:220:23:220:32 | access to parameter notTainted | GlobalDataFlow.cs:208:35:208:45 | sinkParam10 |
+| GlobalDataFlow.cs:220:23:220:32 | access to parameter notTainted | GlobalDataFlow.cs:208:35:208:45 | sinkParam10 |
+| GlobalDataFlow.cs:220:23:220:32 | access to parameter notTainted | GlobalDataFlow.cs:220:23:220:32 | access to parameter notTainted |
+| GlobalDataFlow.cs:220:23:220:32 | access to parameter notTainted | GlobalDataFlow.cs:220:41:220:42 | [output] access to local variable f1 |
+| GlobalDataFlow.cs:220:23:220:32 | access to parameter notTainted | GlobalDataFlow.cs:220:41:220:42 | [output] access to local variable f1 |
+| GlobalDataFlow.cs:220:23:220:32 | access to parameter notTainted | GlobalDataFlow.cs:222:19:222:28 | access to parameter notTainted |
+| GlobalDataFlow.cs:220:23:220:32 | access to parameter notTainted | GlobalDataFlow.cs:222:19:222:28 | access to parameter notTainted |
+| GlobalDataFlow.cs:220:23:220:32 | access to parameter notTainted | GlobalDataFlow.cs:224:19:224:28 | access to parameter notTainted |
+| GlobalDataFlow.cs:220:23:220:32 | access to parameter notTainted | GlobalDataFlow.cs:224:19:224:28 | access to parameter notTainted |
+| GlobalDataFlow.cs:220:23:220:32 | access to parameter notTainted | GlobalDataFlow.cs:226:19:226:28 | access to parameter notTainted |
+| GlobalDataFlow.cs:220:23:220:32 | access to parameter notTainted | GlobalDataFlow.cs:226:19:226:28 | access to parameter notTainted |
+| GlobalDataFlow.cs:220:23:220:32 | access to parameter notTainted | GlobalDataFlow.cs:228:19:228:28 | access to parameter notTainted |
+| GlobalDataFlow.cs:220:23:220:32 | access to parameter notTainted | GlobalDataFlow.cs:228:19:228:28 | access to parameter notTainted |
+| GlobalDataFlow.cs:220:23:220:43 | call to method Select | GlobalDataFlow.cs:220:13:220:43 | SSA def(nonSink) |
+| GlobalDataFlow.cs:220:23:220:43 | call to method Select | GlobalDataFlow.cs:220:13:220:43 | SSA def(nonSink) |
+| GlobalDataFlow.cs:220:23:220:43 | call to method Select | GlobalDataFlow.cs:220:23:220:43 | call to method Select |
+| GlobalDataFlow.cs:220:23:220:43 | call to method Select | GlobalDataFlow.cs:221:15:221:21 | access to local variable nonSink |
+| GlobalDataFlow.cs:220:23:220:43 | call to method Select | GlobalDataFlow.cs:221:15:221:21 | access to local variable nonSink |
+| GlobalDataFlow.cs:220:41:220:42 | [output] access to local variable f1 | GlobalDataFlow.cs:220:13:220:43 | SSA def(nonSink) |
+| GlobalDataFlow.cs:220:41:220:42 | [output] access to local variable f1 | GlobalDataFlow.cs:220:13:220:43 | SSA def(nonSink) |
+| GlobalDataFlow.cs:220:41:220:42 | [output] access to local variable f1 | GlobalDataFlow.cs:220:23:220:43 | call to method Select |
+| GlobalDataFlow.cs:220:41:220:42 | [output] access to local variable f1 | GlobalDataFlow.cs:220:23:220:43 | call to method Select |
+| GlobalDataFlow.cs:220:41:220:42 | [output] access to local variable f1 | GlobalDataFlow.cs:220:41:220:42 | [output] access to local variable f1 |
+| GlobalDataFlow.cs:220:41:220:42 | [output] access to local variable f1 | GlobalDataFlow.cs:221:15:221:21 | access to local variable nonSink |
+| GlobalDataFlow.cs:220:41:220:42 | [output] access to local variable f1 | GlobalDataFlow.cs:221:15:221:21 | access to local variable nonSink |
+| GlobalDataFlow.cs:220:41:220:42 | access to local variable f1 | GlobalDataFlow.cs:220:41:220:42 | access to local variable f1 |
 | GlobalDataFlow.cs:221:9:221:22 | call to method Check | GlobalDataFlow.cs:221:9:221:22 | call to method Check |
 | GlobalDataFlow.cs:221:15:221:21 | access to local variable nonSink | GlobalDataFlow.cs:221:15:221:21 | access to local variable nonSink |
 | GlobalDataFlow.cs:222:9:222:39 | ... = ... | GlobalDataFlow.cs:222:9:222:39 | ... = ... |
 | GlobalDataFlow.cs:222:9:222:39 | SSA def(nonSink) | GlobalDataFlow.cs:222:9:222:39 | SSA def(nonSink) |
 | GlobalDataFlow.cs:222:9:222:39 | SSA def(nonSink) | GlobalDataFlow.cs:223:15:223:21 | access to local variable nonSink |
 | GlobalDataFlow.cs:222:9:222:39 | SSA def(nonSink) | GlobalDataFlow.cs:223:15:223:21 | access to local variable nonSink |
-| GlobalDataFlow.cs:222:19:222:28 | access to parameter notTainted | GlobalDataFlow.cs:215:71:215:71 | x |
-| GlobalDataFlow.cs:222:19:222:28 | access to parameter notTainted | GlobalDataFlow.cs:215:71:215:71 | x |
+| GlobalDataFlow.cs:222:19:222:28 | access to parameter notTainted | GlobalDataFlow.cs:209:71:209:71 | x |
+| GlobalDataFlow.cs:222:19:222:28 | access to parameter notTainted | GlobalDataFlow.cs:209:71:209:71 | x |
 | GlobalDataFlow.cs:222:19:222:28 | access to parameter notTainted | GlobalDataFlow.cs:222:19:222:28 | access to parameter notTainted |
-| GlobalDataFlow.cs:222:19:222:28 | access to parameter notTainted | GlobalDataFlow.cs:222:37:222:38 | [output] access to local variable f4 |
-| GlobalDataFlow.cs:222:19:222:28 | access to parameter notTainted | GlobalDataFlow.cs:222:37:222:38 | [output] access to local variable f4 |
+| GlobalDataFlow.cs:222:19:222:28 | access to parameter notTainted | GlobalDataFlow.cs:222:37:222:38 | [output] access to local variable f2 |
+| GlobalDataFlow.cs:222:19:222:28 | access to parameter notTainted | GlobalDataFlow.cs:222:37:222:38 | [output] access to local variable f2 |
 | GlobalDataFlow.cs:222:19:222:28 | access to parameter notTainted | GlobalDataFlow.cs:224:19:224:28 | access to parameter notTainted |
 | GlobalDataFlow.cs:222:19:222:28 | access to parameter notTainted | GlobalDataFlow.cs:224:19:224:28 | access to parameter notTainted |
+| GlobalDataFlow.cs:222:19:222:28 | access to parameter notTainted | GlobalDataFlow.cs:226:19:226:28 | access to parameter notTainted |
+| GlobalDataFlow.cs:222:19:222:28 | access to parameter notTainted | GlobalDataFlow.cs:226:19:226:28 | access to parameter notTainted |
+| GlobalDataFlow.cs:222:19:222:28 | access to parameter notTainted | GlobalDataFlow.cs:228:19:228:28 | access to parameter notTainted |
+| GlobalDataFlow.cs:222:19:222:28 | access to parameter notTainted | GlobalDataFlow.cs:228:19:228:28 | access to parameter notTainted |
 | GlobalDataFlow.cs:222:19:222:39 | call to method Select | GlobalDataFlow.cs:222:9:222:39 | SSA def(nonSink) |
 | GlobalDataFlow.cs:222:19:222:39 | call to method Select | GlobalDataFlow.cs:222:9:222:39 | SSA def(nonSink) |
 | GlobalDataFlow.cs:222:19:222:39 | call to method Select | GlobalDataFlow.cs:222:19:222:39 | call to method Select |
 | GlobalDataFlow.cs:222:19:222:39 | call to method Select | GlobalDataFlow.cs:223:15:223:21 | access to local variable nonSink |
 | GlobalDataFlow.cs:222:19:222:39 | call to method Select | GlobalDataFlow.cs:223:15:223:21 | access to local variable nonSink |
-| GlobalDataFlow.cs:222:37:222:38 | [output] access to local variable f4 | GlobalDataFlow.cs:222:9:222:39 | SSA def(nonSink) |
-| GlobalDataFlow.cs:222:37:222:38 | [output] access to local variable f4 | GlobalDataFlow.cs:222:9:222:39 | SSA def(nonSink) |
-| GlobalDataFlow.cs:222:37:222:38 | [output] access to local variable f4 | GlobalDataFlow.cs:222:19:222:39 | call to method Select |
-| GlobalDataFlow.cs:222:37:222:38 | [output] access to local variable f4 | GlobalDataFlow.cs:222:19:222:39 | call to method Select |
-| GlobalDataFlow.cs:222:37:222:38 | [output] access to local variable f4 | GlobalDataFlow.cs:222:37:222:38 | [output] access to local variable f4 |
-| GlobalDataFlow.cs:222:37:222:38 | [output] access to local variable f4 | GlobalDataFlow.cs:223:15:223:21 | access to local variable nonSink |
-| GlobalDataFlow.cs:222:37:222:38 | [output] access to local variable f4 | GlobalDataFlow.cs:223:15:223:21 | access to local variable nonSink |
-| GlobalDataFlow.cs:222:37:222:38 | access to local variable f4 | GlobalDataFlow.cs:222:37:222:38 | access to local variable f4 |
+| GlobalDataFlow.cs:222:37:222:38 | [output] access to local variable f2 | GlobalDataFlow.cs:222:9:222:39 | SSA def(nonSink) |
+| GlobalDataFlow.cs:222:37:222:38 | [output] access to local variable f2 | GlobalDataFlow.cs:222:9:222:39 | SSA def(nonSink) |
+| GlobalDataFlow.cs:222:37:222:38 | [output] access to local variable f2 | GlobalDataFlow.cs:222:19:222:39 | call to method Select |
+| GlobalDataFlow.cs:222:37:222:38 | [output] access to local variable f2 | GlobalDataFlow.cs:222:19:222:39 | call to method Select |
+| GlobalDataFlow.cs:222:37:222:38 | [output] access to local variable f2 | GlobalDataFlow.cs:222:37:222:38 | [output] access to local variable f2 |
+| GlobalDataFlow.cs:222:37:222:38 | [output] access to local variable f2 | GlobalDataFlow.cs:223:15:223:21 | access to local variable nonSink |
+| GlobalDataFlow.cs:222:37:222:38 | [output] access to local variable f2 | GlobalDataFlow.cs:223:15:223:21 | access to local variable nonSink |
+| GlobalDataFlow.cs:222:37:222:38 | access to local variable f2 | GlobalDataFlow.cs:222:37:222:38 | access to local variable f2 |
 | GlobalDataFlow.cs:223:9:223:22 | call to method Check | GlobalDataFlow.cs:223:9:223:22 | call to method Check |
 | GlobalDataFlow.cs:223:15:223:21 | access to local variable nonSink | GlobalDataFlow.cs:223:15:223:21 | access to local variable nonSink |
-| GlobalDataFlow.cs:224:9:224:49 | ... = ... | GlobalDataFlow.cs:224:9:224:49 | ... = ... |
-| GlobalDataFlow.cs:224:9:224:49 | SSA def(nonSink) | GlobalDataFlow.cs:224:9:224:49 | SSA def(nonSink) |
-| GlobalDataFlow.cs:224:9:224:49 | SSA def(nonSink) | GlobalDataFlow.cs:225:15:225:21 | access to local variable nonSink |
-| GlobalDataFlow.cs:224:9:224:49 | SSA def(nonSink) | GlobalDataFlow.cs:225:15:225:21 | access to local variable nonSink |
+| GlobalDataFlow.cs:224:9:224:39 | ... = ... | GlobalDataFlow.cs:224:9:224:39 | ... = ... |
+| GlobalDataFlow.cs:224:9:224:39 | SSA def(nonSink) | GlobalDataFlow.cs:224:9:224:39 | SSA def(nonSink) |
+| GlobalDataFlow.cs:224:9:224:39 | SSA def(nonSink) | GlobalDataFlow.cs:225:15:225:21 | access to local variable nonSink |
+| GlobalDataFlow.cs:224:9:224:39 | SSA def(nonSink) | GlobalDataFlow.cs:225:15:225:21 | access to local variable nonSink |
+| GlobalDataFlow.cs:224:19:224:28 | access to parameter notTainted | GlobalDataFlow.cs:218:35:218:46 | nonSinkParam |
+| GlobalDataFlow.cs:224:19:224:28 | access to parameter notTainted | GlobalDataFlow.cs:218:35:218:46 | nonSinkParam |
 | GlobalDataFlow.cs:224:19:224:28 | access to parameter notTainted | GlobalDataFlow.cs:224:19:224:28 | access to parameter notTainted |
-| GlobalDataFlow.cs:224:19:224:28 | access to parameter notTainted | GlobalDataFlow.cs:224:37:224:48 | [output] delegate creation of type Func<String,String> |
-| GlobalDataFlow.cs:224:19:224:28 | access to parameter notTainted | GlobalDataFlow.cs:224:37:224:48 | [output] delegate creation of type Func<String,String> |
-| GlobalDataFlow.cs:224:19:224:28 | access to parameter notTainted | GlobalDataFlow.cs:299:32:299:42 | sinkParam11 |
-| GlobalDataFlow.cs:224:19:224:28 | access to parameter notTainted | GlobalDataFlow.cs:299:32:299:42 | sinkParam11 |
-| GlobalDataFlow.cs:224:19:224:49 | call to method Select | GlobalDataFlow.cs:224:9:224:49 | SSA def(nonSink) |
-| GlobalDataFlow.cs:224:19:224:49 | call to method Select | GlobalDataFlow.cs:224:9:224:49 | SSA def(nonSink) |
-| GlobalDataFlow.cs:224:19:224:49 | call to method Select | GlobalDataFlow.cs:224:19:224:49 | call to method Select |
-| GlobalDataFlow.cs:224:19:224:49 | call to method Select | GlobalDataFlow.cs:225:15:225:21 | access to local variable nonSink |
-| GlobalDataFlow.cs:224:19:224:49 | call to method Select | GlobalDataFlow.cs:225:15:225:21 | access to local variable nonSink |
-| GlobalDataFlow.cs:224:37:224:48 | [output] delegate creation of type Func<String,String> | GlobalDataFlow.cs:224:9:224:49 | SSA def(nonSink) |
-| GlobalDataFlow.cs:224:37:224:48 | [output] delegate creation of type Func<String,String> | GlobalDataFlow.cs:224:9:224:49 | SSA def(nonSink) |
-| GlobalDataFlow.cs:224:37:224:48 | [output] delegate creation of type Func<String,String> | GlobalDataFlow.cs:224:19:224:49 | call to method Select |
-| GlobalDataFlow.cs:224:37:224:48 | [output] delegate creation of type Func<String,String> | GlobalDataFlow.cs:224:19:224:49 | call to method Select |
-| GlobalDataFlow.cs:224:37:224:48 | [output] delegate creation of type Func<String,String> | GlobalDataFlow.cs:224:37:224:48 | [output] delegate creation of type Func<String,String> |
-| GlobalDataFlow.cs:224:37:224:48 | [output] delegate creation of type Func<String,String> | GlobalDataFlow.cs:225:15:225:21 | access to local variable nonSink |
-| GlobalDataFlow.cs:224:37:224:48 | [output] delegate creation of type Func<String,String> | GlobalDataFlow.cs:225:15:225:21 | access to local variable nonSink |
-| GlobalDataFlow.cs:224:37:224:48 | access to method ReturnCheck3 | GlobalDataFlow.cs:224:37:224:48 | access to method ReturnCheck3 |
-| GlobalDataFlow.cs:224:37:224:48 | delegate creation of type Func<String,String> | GlobalDataFlow.cs:224:37:224:48 | delegate creation of type Func<String,String> |
+| GlobalDataFlow.cs:224:19:224:28 | access to parameter notTainted | GlobalDataFlow.cs:224:37:224:38 | [output] access to local variable f3 |
+| GlobalDataFlow.cs:224:19:224:28 | access to parameter notTainted | GlobalDataFlow.cs:224:37:224:38 | [output] access to local variable f3 |
+| GlobalDataFlow.cs:224:19:224:28 | access to parameter notTainted | GlobalDataFlow.cs:226:19:226:28 | access to parameter notTainted |
+| GlobalDataFlow.cs:224:19:224:28 | access to parameter notTainted | GlobalDataFlow.cs:226:19:226:28 | access to parameter notTainted |
+| GlobalDataFlow.cs:224:19:224:28 | access to parameter notTainted | GlobalDataFlow.cs:228:19:228:28 | access to parameter notTainted |
+| GlobalDataFlow.cs:224:19:224:28 | access to parameter notTainted | GlobalDataFlow.cs:228:19:228:28 | access to parameter notTainted |
+| GlobalDataFlow.cs:224:19:224:39 | call to method Select | GlobalDataFlow.cs:224:9:224:39 | SSA def(nonSink) |
+| GlobalDataFlow.cs:224:19:224:39 | call to method Select | GlobalDataFlow.cs:224:9:224:39 | SSA def(nonSink) |
+| GlobalDataFlow.cs:224:19:224:39 | call to method Select | GlobalDataFlow.cs:224:19:224:39 | call to method Select |
+| GlobalDataFlow.cs:224:19:224:39 | call to method Select | GlobalDataFlow.cs:225:15:225:21 | access to local variable nonSink |
+| GlobalDataFlow.cs:224:19:224:39 | call to method Select | GlobalDataFlow.cs:225:15:225:21 | access to local variable nonSink |
+| GlobalDataFlow.cs:224:37:224:38 | [output] access to local variable f3 | GlobalDataFlow.cs:224:9:224:39 | SSA def(nonSink) |
+| GlobalDataFlow.cs:224:37:224:38 | [output] access to local variable f3 | GlobalDataFlow.cs:224:9:224:39 | SSA def(nonSink) |
+| GlobalDataFlow.cs:224:37:224:38 | [output] access to local variable f3 | GlobalDataFlow.cs:224:19:224:39 | call to method Select |
+| GlobalDataFlow.cs:224:37:224:38 | [output] access to local variable f3 | GlobalDataFlow.cs:224:19:224:39 | call to method Select |
+| GlobalDataFlow.cs:224:37:224:38 | [output] access to local variable f3 | GlobalDataFlow.cs:224:37:224:38 | [output] access to local variable f3 |
+| GlobalDataFlow.cs:224:37:224:38 | [output] access to local variable f3 | GlobalDataFlow.cs:225:15:225:21 | access to local variable nonSink |
+| GlobalDataFlow.cs:224:37:224:38 | [output] access to local variable f3 | GlobalDataFlow.cs:225:15:225:21 | access to local variable nonSink |
+| GlobalDataFlow.cs:224:37:224:38 | access to local variable f3 | GlobalDataFlow.cs:224:37:224:38 | access to local variable f3 |
 | GlobalDataFlow.cs:225:9:225:22 | call to method Check | GlobalDataFlow.cs:225:9:225:22 | call to method Check |
 | GlobalDataFlow.cs:225:15:225:21 | access to local variable nonSink | GlobalDataFlow.cs:225:15:225:21 | access to local variable nonSink |
-| GlobalDataFlow.cs:230:26:230:35 | sinkParam0 | GlobalDataFlow.cs:230:26:230:35 | sinkParam0 |
-| GlobalDataFlow.cs:230:26:230:35 | sinkParam0 | GlobalDataFlow.cs:230:26:230:35 | sinkParam0 |
-| GlobalDataFlow.cs:230:26:230:35 | sinkParam0 | GlobalDataFlow.cs:230:26:230:35 | sinkParam0 |
-| GlobalDataFlow.cs:230:26:230:35 | sinkParam0 | GlobalDataFlow.cs:230:26:230:35 | sinkParam0 |
-| GlobalDataFlow.cs:230:26:230:35 | sinkParam0 | GlobalDataFlow.cs:232:16:232:25 | access to parameter sinkParam0 |
-| GlobalDataFlow.cs:230:26:230:35 | sinkParam0 | GlobalDataFlow.cs:232:16:232:25 | access to parameter sinkParam0 |
-| GlobalDataFlow.cs:230:26:230:35 | sinkParam0 | GlobalDataFlow.cs:232:16:232:25 | access to parameter sinkParam0 |
-| GlobalDataFlow.cs:230:26:230:35 | sinkParam0 | GlobalDataFlow.cs:232:16:232:25 | access to parameter sinkParam0 |
-| GlobalDataFlow.cs:230:26:230:35 | sinkParam0 | GlobalDataFlow.cs:232:16:232:25 | access to parameter sinkParam0 |
-| GlobalDataFlow.cs:230:26:230:35 | sinkParam0 | GlobalDataFlow.cs:232:16:232:25 | access to parameter sinkParam0 |
-| GlobalDataFlow.cs:230:26:230:35 | sinkParam0 | GlobalDataFlow.cs:233:15:233:24 | access to parameter sinkParam0 |
-| GlobalDataFlow.cs:230:26:230:35 | sinkParam0 | GlobalDataFlow.cs:233:15:233:24 | access to parameter sinkParam0 |
-| GlobalDataFlow.cs:230:26:230:35 | sinkParam0 | GlobalDataFlow.cs:233:15:233:24 | access to parameter sinkParam0 |
-| GlobalDataFlow.cs:230:26:230:35 | sinkParam0 | GlobalDataFlow.cs:233:15:233:24 | access to parameter sinkParam0 |
-| GlobalDataFlow.cs:230:26:230:35 | sinkParam0 | GlobalDataFlow.cs:233:15:233:24 | access to parameter sinkParam0 |
-| GlobalDataFlow.cs:230:26:230:35 | sinkParam0 | GlobalDataFlow.cs:233:15:233:24 | access to parameter sinkParam0 |
-| GlobalDataFlow.cs:232:9:232:26 | call to method In0 | GlobalDataFlow.cs:232:9:232:26 | call to method In0 |
-| GlobalDataFlow.cs:232:16:232:25 | access to parameter sinkParam0 | GlobalDataFlow.cs:230:26:230:35 | sinkParam0 |
-| GlobalDataFlow.cs:232:16:232:25 | access to parameter sinkParam0 | GlobalDataFlow.cs:230:26:230:35 | sinkParam0 |
-| GlobalDataFlow.cs:232:16:232:25 | access to parameter sinkParam0 | GlobalDataFlow.cs:230:26:230:35 | sinkParam0 |
-| GlobalDataFlow.cs:232:16:232:25 | access to parameter sinkParam0 | GlobalDataFlow.cs:230:26:230:35 | sinkParam0 |
-| GlobalDataFlow.cs:232:16:232:25 | access to parameter sinkParam0 | GlobalDataFlow.cs:232:16:232:25 | access to parameter sinkParam0 |
-| GlobalDataFlow.cs:232:16:232:25 | access to parameter sinkParam0 | GlobalDataFlow.cs:233:15:233:24 | access to parameter sinkParam0 |
-| GlobalDataFlow.cs:232:16:232:25 | access to parameter sinkParam0 | GlobalDataFlow.cs:233:15:233:24 | access to parameter sinkParam0 |
-| GlobalDataFlow.cs:232:16:232:25 | access to parameter sinkParam0 | GlobalDataFlow.cs:233:15:233:24 | access to parameter sinkParam0 |
-| GlobalDataFlow.cs:232:16:232:25 | access to parameter sinkParam0 | GlobalDataFlow.cs:233:15:233:24 | access to parameter sinkParam0 |
-| GlobalDataFlow.cs:233:9:233:25 | call to method Check | GlobalDataFlow.cs:233:9:233:25 | call to method Check |
-| GlobalDataFlow.cs:233:15:233:24 | access to parameter sinkParam0 | GlobalDataFlow.cs:233:15:233:24 | access to parameter sinkParam0 |
-| GlobalDataFlow.cs:236:26:236:35 | sinkParam1 | GlobalDataFlow.cs:236:26:236:35 | sinkParam1 |
-| GlobalDataFlow.cs:236:26:236:35 | sinkParam1 | GlobalDataFlow.cs:236:26:236:35 | sinkParam1 |
-| GlobalDataFlow.cs:236:26:236:35 | sinkParam1 | GlobalDataFlow.cs:236:26:236:35 | sinkParam1 |
-| GlobalDataFlow.cs:236:26:236:35 | sinkParam1 | GlobalDataFlow.cs:236:26:236:35 | sinkParam1 |
-| GlobalDataFlow.cs:236:26:236:35 | sinkParam1 | GlobalDataFlow.cs:238:15:238:24 | access to parameter sinkParam1 |
-| GlobalDataFlow.cs:236:26:236:35 | sinkParam1 | GlobalDataFlow.cs:238:15:238:24 | access to parameter sinkParam1 |
-| GlobalDataFlow.cs:236:26:236:35 | sinkParam1 | GlobalDataFlow.cs:238:15:238:24 | access to parameter sinkParam1 |
-| GlobalDataFlow.cs:236:26:236:35 | sinkParam1 | GlobalDataFlow.cs:238:15:238:24 | access to parameter sinkParam1 |
-| GlobalDataFlow.cs:236:26:236:35 | sinkParam1 | GlobalDataFlow.cs:238:15:238:24 | access to parameter sinkParam1 |
-| GlobalDataFlow.cs:236:26:236:35 | sinkParam1 | GlobalDataFlow.cs:238:15:238:24 | access to parameter sinkParam1 |
-| GlobalDataFlow.cs:238:9:238:25 | call to method Check | GlobalDataFlow.cs:238:9:238:25 | call to method Check |
-| GlobalDataFlow.cs:238:15:238:24 | access to parameter sinkParam1 | GlobalDataFlow.cs:238:15:238:24 | access to parameter sinkParam1 |
-| GlobalDataFlow.cs:241:26:241:35 | sinkParam3 | GlobalDataFlow.cs:241:26:241:35 | sinkParam3 |
-| GlobalDataFlow.cs:241:26:241:35 | sinkParam3 | GlobalDataFlow.cs:241:26:241:35 | sinkParam3 |
-| GlobalDataFlow.cs:241:26:241:35 | sinkParam3 | GlobalDataFlow.cs:241:26:241:35 | sinkParam3 |
-| GlobalDataFlow.cs:241:26:241:35 | sinkParam3 | GlobalDataFlow.cs:241:26:241:35 | sinkParam3 |
-| GlobalDataFlow.cs:241:26:241:35 | sinkParam3 | GlobalDataFlow.cs:243:15:243:24 | access to parameter sinkParam3 |
-| GlobalDataFlow.cs:241:26:241:35 | sinkParam3 | GlobalDataFlow.cs:243:15:243:24 | access to parameter sinkParam3 |
-| GlobalDataFlow.cs:241:26:241:35 | sinkParam3 | GlobalDataFlow.cs:243:15:243:24 | access to parameter sinkParam3 |
-| GlobalDataFlow.cs:241:26:241:35 | sinkParam3 | GlobalDataFlow.cs:243:15:243:24 | access to parameter sinkParam3 |
-| GlobalDataFlow.cs:241:26:241:35 | sinkParam3 | GlobalDataFlow.cs:243:15:243:24 | access to parameter sinkParam3 |
-| GlobalDataFlow.cs:241:26:241:35 | sinkParam3 | GlobalDataFlow.cs:243:15:243:24 | access to parameter sinkParam3 |
-| GlobalDataFlow.cs:243:9:243:25 | call to method Check | GlobalDataFlow.cs:243:9:243:25 | call to method Check |
-| GlobalDataFlow.cs:243:15:243:24 | access to parameter sinkParam3 | GlobalDataFlow.cs:243:15:243:24 | access to parameter sinkParam3 |
-| GlobalDataFlow.cs:246:26:246:35 | sinkParam4 | GlobalDataFlow.cs:246:26:246:35 | sinkParam4 |
-| GlobalDataFlow.cs:246:26:246:35 | sinkParam4 | GlobalDataFlow.cs:246:26:246:35 | sinkParam4 |
-| GlobalDataFlow.cs:246:26:246:35 | sinkParam4 | GlobalDataFlow.cs:246:26:246:35 | sinkParam4 |
-| GlobalDataFlow.cs:246:26:246:35 | sinkParam4 | GlobalDataFlow.cs:246:26:246:35 | sinkParam4 |
-| GlobalDataFlow.cs:246:26:246:35 | sinkParam4 | GlobalDataFlow.cs:248:15:248:24 | access to parameter sinkParam4 |
-| GlobalDataFlow.cs:246:26:246:35 | sinkParam4 | GlobalDataFlow.cs:248:15:248:24 | access to parameter sinkParam4 |
-| GlobalDataFlow.cs:246:26:246:35 | sinkParam4 | GlobalDataFlow.cs:248:15:248:24 | access to parameter sinkParam4 |
-| GlobalDataFlow.cs:246:26:246:35 | sinkParam4 | GlobalDataFlow.cs:248:15:248:24 | access to parameter sinkParam4 |
-| GlobalDataFlow.cs:246:26:246:35 | sinkParam4 | GlobalDataFlow.cs:248:15:248:24 | access to parameter sinkParam4 |
-| GlobalDataFlow.cs:246:26:246:35 | sinkParam4 | GlobalDataFlow.cs:248:15:248:24 | access to parameter sinkParam4 |
-| GlobalDataFlow.cs:248:9:248:25 | call to method Check | GlobalDataFlow.cs:248:9:248:25 | call to method Check |
-| GlobalDataFlow.cs:248:15:248:24 | access to parameter sinkParam4 | GlobalDataFlow.cs:248:15:248:24 | access to parameter sinkParam4 |
-| GlobalDataFlow.cs:251:26:251:35 | sinkParam5 | GlobalDataFlow.cs:251:26:251:35 | sinkParam5 |
-| GlobalDataFlow.cs:251:26:251:35 | sinkParam5 | GlobalDataFlow.cs:251:26:251:35 | sinkParam5 |
-| GlobalDataFlow.cs:251:26:251:35 | sinkParam5 | GlobalDataFlow.cs:251:26:251:35 | sinkParam5 |
-| GlobalDataFlow.cs:251:26:251:35 | sinkParam5 | GlobalDataFlow.cs:251:26:251:35 | sinkParam5 |
-| GlobalDataFlow.cs:251:26:251:35 | sinkParam5 | GlobalDataFlow.cs:253:15:253:24 | access to parameter sinkParam5 |
-| GlobalDataFlow.cs:251:26:251:35 | sinkParam5 | GlobalDataFlow.cs:253:15:253:24 | access to parameter sinkParam5 |
-| GlobalDataFlow.cs:251:26:251:35 | sinkParam5 | GlobalDataFlow.cs:253:15:253:24 | access to parameter sinkParam5 |
-| GlobalDataFlow.cs:251:26:251:35 | sinkParam5 | GlobalDataFlow.cs:253:15:253:24 | access to parameter sinkParam5 |
-| GlobalDataFlow.cs:251:26:251:35 | sinkParam5 | GlobalDataFlow.cs:253:15:253:24 | access to parameter sinkParam5 |
-| GlobalDataFlow.cs:251:26:251:35 | sinkParam5 | GlobalDataFlow.cs:253:15:253:24 | access to parameter sinkParam5 |
-| GlobalDataFlow.cs:253:9:253:25 | call to method Check | GlobalDataFlow.cs:253:9:253:25 | call to method Check |
-| GlobalDataFlow.cs:253:15:253:24 | access to parameter sinkParam5 | GlobalDataFlow.cs:253:15:253:24 | access to parameter sinkParam5 |
-| GlobalDataFlow.cs:256:26:256:35 | sinkParam6 | GlobalDataFlow.cs:256:26:256:35 | sinkParam6 |
-| GlobalDataFlow.cs:256:26:256:35 | sinkParam6 | GlobalDataFlow.cs:256:26:256:35 | sinkParam6 |
-| GlobalDataFlow.cs:256:26:256:35 | sinkParam6 | GlobalDataFlow.cs:256:26:256:35 | sinkParam6 |
-| GlobalDataFlow.cs:256:26:256:35 | sinkParam6 | GlobalDataFlow.cs:256:26:256:35 | sinkParam6 |
-| GlobalDataFlow.cs:256:26:256:35 | sinkParam6 | GlobalDataFlow.cs:258:15:258:24 | access to parameter sinkParam6 |
-| GlobalDataFlow.cs:256:26:256:35 | sinkParam6 | GlobalDataFlow.cs:258:15:258:24 | access to parameter sinkParam6 |
-| GlobalDataFlow.cs:256:26:256:35 | sinkParam6 | GlobalDataFlow.cs:258:15:258:24 | access to parameter sinkParam6 |
-| GlobalDataFlow.cs:256:26:256:35 | sinkParam6 | GlobalDataFlow.cs:258:15:258:24 | access to parameter sinkParam6 |
-| GlobalDataFlow.cs:256:26:256:35 | sinkParam6 | GlobalDataFlow.cs:258:15:258:24 | access to parameter sinkParam6 |
-| GlobalDataFlow.cs:256:26:256:35 | sinkParam6 | GlobalDataFlow.cs:258:15:258:24 | access to parameter sinkParam6 |
-| GlobalDataFlow.cs:258:9:258:25 | call to method Check | GlobalDataFlow.cs:258:9:258:25 | call to method Check |
-| GlobalDataFlow.cs:258:15:258:24 | access to parameter sinkParam6 | GlobalDataFlow.cs:258:15:258:24 | access to parameter sinkParam6 |
-| GlobalDataFlow.cs:261:26:261:35 | sinkParam7 | GlobalDataFlow.cs:261:26:261:35 | sinkParam7 |
-| GlobalDataFlow.cs:261:26:261:35 | sinkParam7 | GlobalDataFlow.cs:261:26:261:35 | sinkParam7 |
-| GlobalDataFlow.cs:261:26:261:35 | sinkParam7 | GlobalDataFlow.cs:261:26:261:35 | sinkParam7 |
-| GlobalDataFlow.cs:261:26:261:35 | sinkParam7 | GlobalDataFlow.cs:261:26:261:35 | sinkParam7 |
-| GlobalDataFlow.cs:261:26:261:35 | sinkParam7 | GlobalDataFlow.cs:263:15:263:24 | access to parameter sinkParam7 |
-| GlobalDataFlow.cs:261:26:261:35 | sinkParam7 | GlobalDataFlow.cs:263:15:263:24 | access to parameter sinkParam7 |
-| GlobalDataFlow.cs:261:26:261:35 | sinkParam7 | GlobalDataFlow.cs:263:15:263:24 | access to parameter sinkParam7 |
-| GlobalDataFlow.cs:261:26:261:35 | sinkParam7 | GlobalDataFlow.cs:263:15:263:24 | access to parameter sinkParam7 |
-| GlobalDataFlow.cs:261:26:261:35 | sinkParam7 | GlobalDataFlow.cs:263:15:263:24 | access to parameter sinkParam7 |
-| GlobalDataFlow.cs:261:26:261:35 | sinkParam7 | GlobalDataFlow.cs:263:15:263:24 | access to parameter sinkParam7 |
-| GlobalDataFlow.cs:263:9:263:25 | call to method Check | GlobalDataFlow.cs:263:9:263:25 | call to method Check |
-| GlobalDataFlow.cs:263:15:263:24 | access to parameter sinkParam7 | GlobalDataFlow.cs:263:15:263:24 | access to parameter sinkParam7 |
-| GlobalDataFlow.cs:266:29:266:41 | nonSinkParam0 | GlobalDataFlow.cs:266:29:266:41 | nonSinkParam0 |
-| GlobalDataFlow.cs:266:29:266:41 | nonSinkParam0 | GlobalDataFlow.cs:266:29:266:41 | nonSinkParam0 |
-| GlobalDataFlow.cs:266:29:266:41 | nonSinkParam0 | GlobalDataFlow.cs:266:29:266:41 | nonSinkParam0 |
-| GlobalDataFlow.cs:266:29:266:41 | nonSinkParam0 | GlobalDataFlow.cs:266:29:266:41 | nonSinkParam0 |
-| GlobalDataFlow.cs:266:29:266:41 | nonSinkParam0 | GlobalDataFlow.cs:268:15:268:27 | access to parameter nonSinkParam0 |
-| GlobalDataFlow.cs:266:29:266:41 | nonSinkParam0 | GlobalDataFlow.cs:268:15:268:27 | access to parameter nonSinkParam0 |
-| GlobalDataFlow.cs:266:29:266:41 | nonSinkParam0 | GlobalDataFlow.cs:268:15:268:27 | access to parameter nonSinkParam0 |
-| GlobalDataFlow.cs:266:29:266:41 | nonSinkParam0 | GlobalDataFlow.cs:268:15:268:27 | access to parameter nonSinkParam0 |
-| GlobalDataFlow.cs:266:29:266:41 | nonSinkParam0 | GlobalDataFlow.cs:268:15:268:27 | access to parameter nonSinkParam0 |
-| GlobalDataFlow.cs:266:29:266:41 | nonSinkParam0 | GlobalDataFlow.cs:268:15:268:27 | access to parameter nonSinkParam0 |
-| GlobalDataFlow.cs:268:9:268:28 | call to method Check | GlobalDataFlow.cs:268:9:268:28 | call to method Check |
-| GlobalDataFlow.cs:268:15:268:27 | access to parameter nonSinkParam0 | GlobalDataFlow.cs:268:15:268:27 | access to parameter nonSinkParam0 |
-| GlobalDataFlow.cs:271:26:271:26 | x | GlobalDataFlow.cs:271:26:271:26 | x |
-| GlobalDataFlow.cs:271:26:271:26 | x | GlobalDataFlow.cs:271:26:271:26 | x |
-| GlobalDataFlow.cs:271:26:271:26 | x | GlobalDataFlow.cs:271:26:271:26 | x |
-| GlobalDataFlow.cs:271:26:271:26 | x | GlobalDataFlow.cs:271:26:271:26 | x |
-| GlobalDataFlow.cs:271:26:271:26 | x | GlobalDataFlow.cs:273:37:273:37 | access to parameter x |
-| GlobalDataFlow.cs:271:26:271:26 | x | GlobalDataFlow.cs:273:37:273:37 | access to parameter x |
-| GlobalDataFlow.cs:271:26:271:26 | x | GlobalDataFlow.cs:273:37:273:37 | access to parameter x |
-| GlobalDataFlow.cs:271:26:271:26 | x | GlobalDataFlow.cs:273:37:273:37 | access to parameter x |
-| GlobalDataFlow.cs:271:26:271:26 | x | GlobalDataFlow.cs:273:37:273:37 | access to parameter x |
-| GlobalDataFlow.cs:271:26:271:26 | x | GlobalDataFlow.cs:273:37:273:37 | access to parameter x |
-| GlobalDataFlow.cs:273:13:273:38 | SSA def(y) | GlobalDataFlow.cs:273:13:273:38 | SSA def(y) |
-| GlobalDataFlow.cs:273:13:273:38 | SSA def(y) | GlobalDataFlow.cs:274:16:274:16 | (...) ... |
-| GlobalDataFlow.cs:273:13:273:38 | SSA def(y) | GlobalDataFlow.cs:274:16:274:16 | (...) ... |
-| GlobalDataFlow.cs:273:13:273:38 | SSA def(y) | GlobalDataFlow.cs:274:16:274:16 | (...) ... |
-| GlobalDataFlow.cs:273:13:273:38 | SSA def(y) | GlobalDataFlow.cs:274:16:274:16 | (...) ... |
-| GlobalDataFlow.cs:273:13:273:38 | SSA def(y) | GlobalDataFlow.cs:274:16:274:16 | access to local variable y |
-| GlobalDataFlow.cs:273:13:273:38 | SSA def(y) | GlobalDataFlow.cs:274:16:274:16 | access to local variable y |
-| GlobalDataFlow.cs:273:13:273:38 | SSA def(y) | GlobalDataFlow.cs:274:16:274:16 | access to local variable y |
-| GlobalDataFlow.cs:273:13:273:38 | SSA def(y) | GlobalDataFlow.cs:274:16:274:16 | access to local variable y |
-| GlobalDataFlow.cs:273:13:273:38 | SSA def(y) | GlobalDataFlow.cs:274:16:274:41 | ... ? ... : ... |
-| GlobalDataFlow.cs:273:13:273:38 | SSA def(y) | GlobalDataFlow.cs:274:16:274:41 | ... ? ... : ... |
-| GlobalDataFlow.cs:273:13:273:38 | SSA def(y) | GlobalDataFlow.cs:274:16:274:41 | ... ? ... : ... |
-| GlobalDataFlow.cs:273:13:273:38 | SSA def(y) | GlobalDataFlow.cs:274:16:274:41 | ... ? ... : ... |
-| GlobalDataFlow.cs:273:13:273:38 | SSA def(y) | GlobalDataFlow.cs:274:41:274:41 | access to local variable y |
-| GlobalDataFlow.cs:273:13:273:38 | SSA def(y) | GlobalDataFlow.cs:274:41:274:41 | access to local variable y |
-| GlobalDataFlow.cs:273:13:273:38 | SSA def(y) | GlobalDataFlow.cs:274:41:274:41 | access to local variable y |
-| GlobalDataFlow.cs:273:13:273:38 | SSA def(y) | GlobalDataFlow.cs:274:41:274:41 | access to local variable y |
-| GlobalDataFlow.cs:273:13:273:38 | T y = ... | GlobalDataFlow.cs:273:13:273:38 | T y = ... |
-| GlobalDataFlow.cs:273:17:273:38 | call to method ApplyFunc | GlobalDataFlow.cs:273:13:273:38 | SSA def(y) |
-| GlobalDataFlow.cs:273:17:273:38 | call to method ApplyFunc | GlobalDataFlow.cs:273:13:273:38 | SSA def(y) |
-| GlobalDataFlow.cs:273:17:273:38 | call to method ApplyFunc | GlobalDataFlow.cs:273:13:273:38 | SSA def(y) |
-| GlobalDataFlow.cs:273:17:273:38 | call to method ApplyFunc | GlobalDataFlow.cs:273:13:273:38 | SSA def(y) |
-| GlobalDataFlow.cs:273:17:273:38 | call to method ApplyFunc | GlobalDataFlow.cs:273:17:273:38 | call to method ApplyFunc |
-| GlobalDataFlow.cs:273:17:273:38 | call to method ApplyFunc | GlobalDataFlow.cs:274:16:274:16 | (...) ... |
-| GlobalDataFlow.cs:273:17:273:38 | call to method ApplyFunc | GlobalDataFlow.cs:274:16:274:16 | (...) ... |
-| GlobalDataFlow.cs:273:17:273:38 | call to method ApplyFunc | GlobalDataFlow.cs:274:16:274:16 | (...) ... |
-| GlobalDataFlow.cs:273:17:273:38 | call to method ApplyFunc | GlobalDataFlow.cs:274:16:274:16 | (...) ... |
-| GlobalDataFlow.cs:273:17:273:38 | call to method ApplyFunc | GlobalDataFlow.cs:274:16:274:16 | access to local variable y |
-| GlobalDataFlow.cs:273:17:273:38 | call to method ApplyFunc | GlobalDataFlow.cs:274:16:274:16 | access to local variable y |
-| GlobalDataFlow.cs:273:17:273:38 | call to method ApplyFunc | GlobalDataFlow.cs:274:16:274:16 | access to local variable y |
-| GlobalDataFlow.cs:273:17:273:38 | call to method ApplyFunc | GlobalDataFlow.cs:274:16:274:16 | access to local variable y |
-| GlobalDataFlow.cs:273:17:273:38 | call to method ApplyFunc | GlobalDataFlow.cs:274:16:274:41 | ... ? ... : ... |
-| GlobalDataFlow.cs:273:17:273:38 | call to method ApplyFunc | GlobalDataFlow.cs:274:16:274:41 | ... ? ... : ... |
-| GlobalDataFlow.cs:273:17:273:38 | call to method ApplyFunc | GlobalDataFlow.cs:274:16:274:41 | ... ? ... : ... |
-| GlobalDataFlow.cs:273:17:273:38 | call to method ApplyFunc | GlobalDataFlow.cs:274:16:274:41 | ... ? ... : ... |
-| GlobalDataFlow.cs:273:17:273:38 | call to method ApplyFunc | GlobalDataFlow.cs:274:41:274:41 | access to local variable y |
-| GlobalDataFlow.cs:273:17:273:38 | call to method ApplyFunc | GlobalDataFlow.cs:274:41:274:41 | access to local variable y |
-| GlobalDataFlow.cs:273:17:273:38 | call to method ApplyFunc | GlobalDataFlow.cs:274:41:274:41 | access to local variable y |
-| GlobalDataFlow.cs:273:17:273:38 | call to method ApplyFunc | GlobalDataFlow.cs:274:41:274:41 | access to local variable y |
-| GlobalDataFlow.cs:273:27:273:28 | x0 | GlobalDataFlow.cs:273:27:273:28 | x0 |
-| GlobalDataFlow.cs:273:27:273:28 | x0 | GlobalDataFlow.cs:273:27:273:28 | x0 |
-| GlobalDataFlow.cs:273:27:273:28 | x0 | GlobalDataFlow.cs:273:27:273:28 | x0 |
-| GlobalDataFlow.cs:273:27:273:28 | x0 | GlobalDataFlow.cs:273:27:273:28 | x0 |
-| GlobalDataFlow.cs:273:27:273:28 | x0 | GlobalDataFlow.cs:273:33:273:34 | access to parameter x0 |
-| GlobalDataFlow.cs:273:27:273:28 | x0 | GlobalDataFlow.cs:273:33:273:34 | access to parameter x0 |
-| GlobalDataFlow.cs:273:27:273:28 | x0 | GlobalDataFlow.cs:273:33:273:34 | access to parameter x0 |
-| GlobalDataFlow.cs:273:27:273:28 | x0 | GlobalDataFlow.cs:273:33:273:34 | access to parameter x0 |
-| GlobalDataFlow.cs:273:27:273:28 | x0 | GlobalDataFlow.cs:273:33:273:34 | access to parameter x0 |
-| GlobalDataFlow.cs:273:27:273:28 | x0 | GlobalDataFlow.cs:273:33:273:34 | access to parameter x0 |
-| GlobalDataFlow.cs:273:27:273:34 | (...) => ... | GlobalDataFlow.cs:273:27:273:34 | (...) => ... |
-| GlobalDataFlow.cs:273:27:273:34 | (...) => ... | GlobalDataFlow.cs:359:41:359:41 | f |
-| GlobalDataFlow.cs:273:27:273:34 | (...) => ... | GlobalDataFlow.cs:359:41:359:41 | f |
-| GlobalDataFlow.cs:273:33:273:34 | access to parameter x0 | GlobalDataFlow.cs:273:33:273:34 | access to parameter x0 |
-| GlobalDataFlow.cs:273:33:273:34 | access to parameter x0 | GlobalDataFlow.cs:361:16:361:19 | delegate call |
-| GlobalDataFlow.cs:273:33:273:34 | access to parameter x0 | GlobalDataFlow.cs:361:16:361:19 | delegate call |
-| GlobalDataFlow.cs:273:37:273:37 | access to parameter x | GlobalDataFlow.cs:273:17:273:38 | call to method ApplyFunc |
-| GlobalDataFlow.cs:273:37:273:37 | access to parameter x | GlobalDataFlow.cs:273:17:273:38 | call to method ApplyFunc |
-| GlobalDataFlow.cs:273:37:273:37 | access to parameter x | GlobalDataFlow.cs:273:17:273:38 | call to method ApplyFunc |
-| GlobalDataFlow.cs:273:37:273:37 | access to parameter x | GlobalDataFlow.cs:273:17:273:38 | call to method ApplyFunc |
-| GlobalDataFlow.cs:273:37:273:37 | access to parameter x | GlobalDataFlow.cs:273:37:273:37 | access to parameter x |
-| GlobalDataFlow.cs:273:37:273:37 | access to parameter x | GlobalDataFlow.cs:359:46:359:46 | x |
-| GlobalDataFlow.cs:273:37:273:37 | access to parameter x | GlobalDataFlow.cs:359:46:359:46 | x |
-| GlobalDataFlow.cs:273:37:273:37 | access to parameter x | GlobalDataFlow.cs:359:46:359:46 | x |
-| GlobalDataFlow.cs:273:37:273:37 | access to parameter x | GlobalDataFlow.cs:359:46:359:46 | x |
-| GlobalDataFlow.cs:274:16:274:16 | (...) ... | GlobalDataFlow.cs:274:16:274:16 | (...) ... |
-| GlobalDataFlow.cs:274:16:274:16 | (...) ... | GlobalDataFlow.cs:274:16:274:24 | ... == ... |
-| GlobalDataFlow.cs:274:16:274:16 | (...) ... | GlobalDataFlow.cs:274:16:274:24 | ... == ... |
-| GlobalDataFlow.cs:274:16:274:16 | (...) ... | GlobalDataFlow.cs:274:16:274:24 | ... == ... |
-| GlobalDataFlow.cs:274:16:274:16 | (...) ... | GlobalDataFlow.cs:274:16:274:24 | ... == ... |
-| GlobalDataFlow.cs:274:16:274:16 | (...) ... | GlobalDataFlow.cs:274:16:274:41 | ... ? ... : ... |
-| GlobalDataFlow.cs:274:16:274:16 | (...) ... | GlobalDataFlow.cs:274:16:274:41 | ... ? ... : ... |
-| GlobalDataFlow.cs:274:16:274:16 | (...) ... | GlobalDataFlow.cs:274:16:274:41 | ... ? ... : ... |
-| GlobalDataFlow.cs:274:16:274:16 | (...) ... | GlobalDataFlow.cs:274:16:274:41 | ... ? ... : ... |
-| GlobalDataFlow.cs:274:16:274:16 | access to local variable y | GlobalDataFlow.cs:274:16:274:16 | (...) ... |
-| GlobalDataFlow.cs:274:16:274:16 | access to local variable y | GlobalDataFlow.cs:274:16:274:16 | (...) ... |
-| GlobalDataFlow.cs:274:16:274:16 | access to local variable y | GlobalDataFlow.cs:274:16:274:16 | (...) ... |
-| GlobalDataFlow.cs:274:16:274:16 | access to local variable y | GlobalDataFlow.cs:274:16:274:16 | (...) ... |
-| GlobalDataFlow.cs:274:16:274:16 | access to local variable y | GlobalDataFlow.cs:274:16:274:16 | access to local variable y |
-| GlobalDataFlow.cs:274:16:274:16 | access to local variable y | GlobalDataFlow.cs:274:16:274:41 | ... ? ... : ... |
-| GlobalDataFlow.cs:274:16:274:16 | access to local variable y | GlobalDataFlow.cs:274:16:274:41 | ... ? ... : ... |
-| GlobalDataFlow.cs:274:16:274:16 | access to local variable y | GlobalDataFlow.cs:274:16:274:41 | ... ? ... : ... |
-| GlobalDataFlow.cs:274:16:274:16 | access to local variable y | GlobalDataFlow.cs:274:16:274:41 | ... ? ... : ... |
-| GlobalDataFlow.cs:274:16:274:16 | access to local variable y | GlobalDataFlow.cs:274:41:274:41 | access to local variable y |
-| GlobalDataFlow.cs:274:16:274:16 | access to local variable y | GlobalDataFlow.cs:274:41:274:41 | access to local variable y |
-| GlobalDataFlow.cs:274:16:274:16 | access to local variable y | GlobalDataFlow.cs:274:41:274:41 | access to local variable y |
-| GlobalDataFlow.cs:274:16:274:16 | access to local variable y | GlobalDataFlow.cs:274:41:274:41 | access to local variable y |
-| GlobalDataFlow.cs:274:16:274:24 | ... == ... | GlobalDataFlow.cs:274:16:274:24 | ... == ... |
-| GlobalDataFlow.cs:274:16:274:24 | ... == ... | GlobalDataFlow.cs:274:16:274:41 | ... ? ... : ... |
-| GlobalDataFlow.cs:274:16:274:24 | ... == ... | GlobalDataFlow.cs:274:16:274:41 | ... ? ... : ... |
-| GlobalDataFlow.cs:274:16:274:24 | ... == ... | GlobalDataFlow.cs:274:16:274:41 | ... ? ... : ... |
-| GlobalDataFlow.cs:274:16:274:24 | ... == ... | GlobalDataFlow.cs:274:16:274:41 | ... ? ... : ... |
-| GlobalDataFlow.cs:274:16:274:41 | ... ? ... : ... | GlobalDataFlow.cs:70:21:70:46 | call to method Return |
-| GlobalDataFlow.cs:274:16:274:41 | ... ? ... : ... | GlobalDataFlow.cs:70:21:70:46 | call to method Return |
-| GlobalDataFlow.cs:274:16:274:41 | ... ? ... : ... | GlobalDataFlow.cs:72:29:72:101 | call to method Invoke |
-| GlobalDataFlow.cs:274:16:274:41 | ... ? ... : ... | GlobalDataFlow.cs:72:29:72:101 | call to method Invoke |
-| GlobalDataFlow.cs:274:16:274:41 | ... ? ... : ... | GlobalDataFlow.cs:100:24:100:33 | call to method Return |
-| GlobalDataFlow.cs:274:16:274:41 | ... ? ... : ... | GlobalDataFlow.cs:100:24:100:33 | call to method Return |
-| GlobalDataFlow.cs:274:16:274:41 | ... ? ... : ... | GlobalDataFlow.cs:102:28:102:103 | call to method Invoke |
-| GlobalDataFlow.cs:274:16:274:41 | ... ? ... : ... | GlobalDataFlow.cs:102:28:102:103 | call to method Invoke |
-| GlobalDataFlow.cs:274:16:274:41 | ... ? ... : ... | GlobalDataFlow.cs:274:16:274:41 | ... ? ... : ... |
-| GlobalDataFlow.cs:274:16:274:41 | ... ? ... : ... | GlobalDataFlow.cs:361:16:361:19 | delegate call |
-| GlobalDataFlow.cs:274:16:274:41 | ... ? ... : ... | GlobalDataFlow.cs:361:16:361:19 | delegate call |
-| GlobalDataFlow.cs:274:21:274:24 | null | GlobalDataFlow.cs:274:21:274:24 | null |
-| GlobalDataFlow.cs:274:28:274:37 | default(...) | GlobalDataFlow.cs:274:16:274:41 | ... ? ... : ... |
-| GlobalDataFlow.cs:274:28:274:37 | default(...) | GlobalDataFlow.cs:274:16:274:41 | ... ? ... : ... |
-| GlobalDataFlow.cs:274:28:274:37 | default(...) | GlobalDataFlow.cs:274:28:274:37 | default(...) |
-| GlobalDataFlow.cs:274:41:274:41 | access to local variable y | GlobalDataFlow.cs:274:16:274:41 | ... ? ... : ... |
-| GlobalDataFlow.cs:274:41:274:41 | access to local variable y | GlobalDataFlow.cs:274:16:274:41 | ... ? ... : ... |
-| GlobalDataFlow.cs:274:41:274:41 | access to local variable y | GlobalDataFlow.cs:274:16:274:41 | ... ? ... : ... |
-| GlobalDataFlow.cs:274:41:274:41 | access to local variable y | GlobalDataFlow.cs:274:16:274:41 | ... ? ... : ... |
-| GlobalDataFlow.cs:274:41:274:41 | access to local variable y | GlobalDataFlow.cs:274:41:274:41 | access to local variable y |
-| GlobalDataFlow.cs:277:32:277:32 | x | GlobalDataFlow.cs:277:32:277:32 | x |
-| GlobalDataFlow.cs:277:32:277:32 | x | GlobalDataFlow.cs:277:32:277:32 | x |
-| GlobalDataFlow.cs:277:32:277:32 | x | GlobalDataFlow.cs:277:32:277:32 | x |
-| GlobalDataFlow.cs:277:32:277:32 | x | GlobalDataFlow.cs:277:32:277:32 | x |
-| GlobalDataFlow.cs:277:32:277:32 | x | GlobalDataFlow.cs:279:9:279:13 | SSA def(y) |
-| GlobalDataFlow.cs:277:32:277:32 | x | GlobalDataFlow.cs:279:9:279:13 | SSA def(y) |
-| GlobalDataFlow.cs:277:32:277:32 | x | GlobalDataFlow.cs:279:9:279:13 | SSA def(y) |
-| GlobalDataFlow.cs:277:32:277:32 | x | GlobalDataFlow.cs:279:9:279:13 | SSA def(y) |
-| GlobalDataFlow.cs:277:32:277:32 | x | GlobalDataFlow.cs:279:9:279:13 | SSA def(y) |
-| GlobalDataFlow.cs:277:32:277:32 | x | GlobalDataFlow.cs:279:9:279:13 | SSA def(y) |
-| GlobalDataFlow.cs:277:32:277:32 | x | GlobalDataFlow.cs:279:13:279:13 | access to parameter x |
-| GlobalDataFlow.cs:277:32:277:32 | x | GlobalDataFlow.cs:279:13:279:13 | access to parameter x |
-| GlobalDataFlow.cs:277:32:277:32 | x | GlobalDataFlow.cs:279:13:279:13 | access to parameter x |
-| GlobalDataFlow.cs:277:32:277:32 | x | GlobalDataFlow.cs:279:13:279:13 | access to parameter x |
-| GlobalDataFlow.cs:277:32:277:32 | x | GlobalDataFlow.cs:279:13:279:13 | access to parameter x |
-| GlobalDataFlow.cs:277:32:277:32 | x | GlobalDataFlow.cs:279:13:279:13 | access to parameter x |
-| GlobalDataFlow.cs:279:9:279:13 | ... = ... | GlobalDataFlow.cs:279:9:279:13 | ... = ... |
-| GlobalDataFlow.cs:279:9:279:13 | SSA def(y) | GlobalDataFlow.cs:75:30:75:34 | SSA def(sink2) |
-| GlobalDataFlow.cs:279:9:279:13 | SSA def(y) | GlobalDataFlow.cs:75:30:75:34 | SSA def(sink2) |
-| GlobalDataFlow.cs:279:9:279:13 | SSA def(y) | GlobalDataFlow.cs:104:27:104:34 | SSA def(nonSink0) |
-| GlobalDataFlow.cs:279:9:279:13 | SSA def(y) | GlobalDataFlow.cs:104:27:104:34 | SSA def(nonSink0) |
-| GlobalDataFlow.cs:279:9:279:13 | SSA def(y) | GlobalDataFlow.cs:279:9:279:13 | SSA def(y) |
-| GlobalDataFlow.cs:279:13:279:13 | access to parameter x | GlobalDataFlow.cs:279:9:279:13 | SSA def(y) |
-| GlobalDataFlow.cs:279:13:279:13 | access to parameter x | GlobalDataFlow.cs:279:9:279:13 | SSA def(y) |
-| GlobalDataFlow.cs:279:13:279:13 | access to parameter x | GlobalDataFlow.cs:279:9:279:13 | SSA def(y) |
-| GlobalDataFlow.cs:279:13:279:13 | access to parameter x | GlobalDataFlow.cs:279:9:279:13 | SSA def(y) |
-| GlobalDataFlow.cs:279:13:279:13 | access to parameter x | GlobalDataFlow.cs:279:13:279:13 | access to parameter x |
-| GlobalDataFlow.cs:282:32:282:32 | x | GlobalDataFlow.cs:282:32:282:32 | x |
-| GlobalDataFlow.cs:282:32:282:32 | x | GlobalDataFlow.cs:282:32:282:32 | x |
-| GlobalDataFlow.cs:282:32:282:32 | x | GlobalDataFlow.cs:282:32:282:32 | x |
-| GlobalDataFlow.cs:282:32:282:32 | x | GlobalDataFlow.cs:282:32:282:32 | x |
-| GlobalDataFlow.cs:282:32:282:32 | x | GlobalDataFlow.cs:284:9:284:13 | SSA def(y) |
-| GlobalDataFlow.cs:282:32:282:32 | x | GlobalDataFlow.cs:284:9:284:13 | SSA def(y) |
-| GlobalDataFlow.cs:282:32:282:32 | x | GlobalDataFlow.cs:284:9:284:13 | SSA def(y) |
-| GlobalDataFlow.cs:282:32:282:32 | x | GlobalDataFlow.cs:284:9:284:13 | SSA def(y) |
-| GlobalDataFlow.cs:282:32:282:32 | x | GlobalDataFlow.cs:284:9:284:13 | SSA def(y) |
-| GlobalDataFlow.cs:282:32:282:32 | x | GlobalDataFlow.cs:284:9:284:13 | SSA def(y) |
-| GlobalDataFlow.cs:282:32:282:32 | x | GlobalDataFlow.cs:284:13:284:13 | access to parameter x |
-| GlobalDataFlow.cs:282:32:282:32 | x | GlobalDataFlow.cs:284:13:284:13 | access to parameter x |
-| GlobalDataFlow.cs:282:32:282:32 | x | GlobalDataFlow.cs:284:13:284:13 | access to parameter x |
-| GlobalDataFlow.cs:282:32:282:32 | x | GlobalDataFlow.cs:284:13:284:13 | access to parameter x |
-| GlobalDataFlow.cs:282:32:282:32 | x | GlobalDataFlow.cs:284:13:284:13 | access to parameter x |
-| GlobalDataFlow.cs:282:32:282:32 | x | GlobalDataFlow.cs:284:13:284:13 | access to parameter x |
-| GlobalDataFlow.cs:284:9:284:13 | ... = ... | GlobalDataFlow.cs:284:9:284:13 | ... = ... |
-| GlobalDataFlow.cs:284:9:284:13 | SSA def(y) | GlobalDataFlow.cs:78:30:78:34 | SSA def(sink3) |
-| GlobalDataFlow.cs:284:9:284:13 | SSA def(y) | GlobalDataFlow.cs:78:30:78:34 | SSA def(sink3) |
-| GlobalDataFlow.cs:284:9:284:13 | SSA def(y) | GlobalDataFlow.cs:106:27:106:34 | SSA def(nonSink0) |
-| GlobalDataFlow.cs:284:9:284:13 | SSA def(y) | GlobalDataFlow.cs:106:27:106:34 | SSA def(nonSink0) |
-| GlobalDataFlow.cs:284:9:284:13 | SSA def(y) | GlobalDataFlow.cs:284:9:284:13 | SSA def(y) |
-| GlobalDataFlow.cs:284:13:284:13 | access to parameter x | GlobalDataFlow.cs:284:9:284:13 | SSA def(y) |
-| GlobalDataFlow.cs:284:13:284:13 | access to parameter x | GlobalDataFlow.cs:284:9:284:13 | SSA def(y) |
-| GlobalDataFlow.cs:284:13:284:13 | access to parameter x | GlobalDataFlow.cs:284:9:284:13 | SSA def(y) |
-| GlobalDataFlow.cs:284:13:284:13 | access to parameter x | GlobalDataFlow.cs:284:9:284:13 | SSA def(y) |
-| GlobalDataFlow.cs:284:13:284:13 | access to parameter x | GlobalDataFlow.cs:284:13:284:13 | access to parameter x |
-| GlobalDataFlow.cs:287:31:287:40 | sinkParam8 | GlobalDataFlow.cs:287:31:287:40 | sinkParam8 |
-| GlobalDataFlow.cs:287:31:287:40 | sinkParam8 | GlobalDataFlow.cs:287:31:287:40 | sinkParam8 |
-| GlobalDataFlow.cs:287:31:287:40 | sinkParam8 | GlobalDataFlow.cs:287:31:287:40 | sinkParam8 |
-| GlobalDataFlow.cs:287:31:287:40 | sinkParam8 | GlobalDataFlow.cs:287:31:287:40 | sinkParam8 |
-| GlobalDataFlow.cs:287:31:287:40 | sinkParam8 | GlobalDataFlow.cs:287:31:287:40 | sinkParam8 |
-| GlobalDataFlow.cs:287:31:287:40 | sinkParam8 | GlobalDataFlow.cs:287:31:287:40 | sinkParam8 |
-| GlobalDataFlow.cs:287:31:287:40 | sinkParam8 | GlobalDataFlow.cs:289:15:289:24 | access to parameter sinkParam8 |
-| GlobalDataFlow.cs:287:31:287:40 | sinkParam8 | GlobalDataFlow.cs:289:15:289:24 | access to parameter sinkParam8 |
-| GlobalDataFlow.cs:287:31:287:40 | sinkParam8 | GlobalDataFlow.cs:289:15:289:24 | access to parameter sinkParam8 |
-| GlobalDataFlow.cs:287:31:287:40 | sinkParam8 | GlobalDataFlow.cs:289:15:289:24 | access to parameter sinkParam8 |
-| GlobalDataFlow.cs:287:31:287:40 | sinkParam8 | GlobalDataFlow.cs:289:15:289:24 | access to parameter sinkParam8 |
-| GlobalDataFlow.cs:287:31:287:40 | sinkParam8 | GlobalDataFlow.cs:289:15:289:24 | access to parameter sinkParam8 |
-| GlobalDataFlow.cs:287:31:287:40 | sinkParam8 | GlobalDataFlow.cs:289:15:289:24 | access to parameter sinkParam8 |
-| GlobalDataFlow.cs:287:31:287:40 | sinkParam8 | GlobalDataFlow.cs:289:15:289:24 | access to parameter sinkParam8 |
-| GlobalDataFlow.cs:287:31:287:40 | sinkParam8 | GlobalDataFlow.cs:290:16:290:25 | access to parameter sinkParam8 |
-| GlobalDataFlow.cs:287:31:287:40 | sinkParam8 | GlobalDataFlow.cs:290:16:290:25 | access to parameter sinkParam8 |
-| GlobalDataFlow.cs:287:31:287:40 | sinkParam8 | GlobalDataFlow.cs:290:16:290:25 | access to parameter sinkParam8 |
-| GlobalDataFlow.cs:287:31:287:40 | sinkParam8 | GlobalDataFlow.cs:290:16:290:25 | access to parameter sinkParam8 |
-| GlobalDataFlow.cs:287:31:287:40 | sinkParam8 | GlobalDataFlow.cs:290:16:290:25 | access to parameter sinkParam8 |
-| GlobalDataFlow.cs:287:31:287:40 | sinkParam8 | GlobalDataFlow.cs:290:16:290:25 | access to parameter sinkParam8 |
-| GlobalDataFlow.cs:287:31:287:40 | sinkParam8 | GlobalDataFlow.cs:290:16:290:25 | access to parameter sinkParam8 |
-| GlobalDataFlow.cs:287:31:287:40 | sinkParam8 | GlobalDataFlow.cs:290:16:290:25 | access to parameter sinkParam8 |
-| GlobalDataFlow.cs:289:9:289:25 | call to method Check | GlobalDataFlow.cs:289:9:289:25 | call to method Check |
-| GlobalDataFlow.cs:289:15:289:24 | access to parameter sinkParam8 | GlobalDataFlow.cs:289:15:289:24 | access to parameter sinkParam8 |
-| GlobalDataFlow.cs:289:15:289:24 | access to parameter sinkParam8 | GlobalDataFlow.cs:290:16:290:25 | access to parameter sinkParam8 |
-| GlobalDataFlow.cs:289:15:289:24 | access to parameter sinkParam8 | GlobalDataFlow.cs:290:16:290:25 | access to parameter sinkParam8 |
-| GlobalDataFlow.cs:289:15:289:24 | access to parameter sinkParam8 | GlobalDataFlow.cs:290:16:290:25 | access to parameter sinkParam8 |
-| GlobalDataFlow.cs:289:15:289:24 | access to parameter sinkParam8 | GlobalDataFlow.cs:290:16:290:25 | access to parameter sinkParam8 |
-| GlobalDataFlow.cs:290:16:290:25 | access to parameter sinkParam8 | GlobalDataFlow.cs:82:84:82:94 | [output] delegate creation of type Func<String,String> |
-| GlobalDataFlow.cs:290:16:290:25 | access to parameter sinkParam8 | GlobalDataFlow.cs:82:84:82:94 | [output] delegate creation of type Func<String,String> |
-| GlobalDataFlow.cs:290:16:290:25 | access to parameter sinkParam8 | GlobalDataFlow.cs:290:16:290:25 | access to parameter sinkParam8 |
-| GlobalDataFlow.cs:293:32:293:41 | sinkParam9 | GlobalDataFlow.cs:293:32:293:41 | sinkParam9 |
-| GlobalDataFlow.cs:293:32:293:41 | sinkParam9 | GlobalDataFlow.cs:293:32:293:41 | sinkParam9 |
-| GlobalDataFlow.cs:293:32:293:41 | sinkParam9 | GlobalDataFlow.cs:293:32:293:41 | sinkParam9 |
-| GlobalDataFlow.cs:293:32:293:41 | sinkParam9 | GlobalDataFlow.cs:293:32:293:41 | sinkParam9 |
-| GlobalDataFlow.cs:293:32:293:41 | sinkParam9 | GlobalDataFlow.cs:295:15:295:24 | access to parameter sinkParam9 |
-| GlobalDataFlow.cs:293:32:293:41 | sinkParam9 | GlobalDataFlow.cs:295:15:295:24 | access to parameter sinkParam9 |
-| GlobalDataFlow.cs:293:32:293:41 | sinkParam9 | GlobalDataFlow.cs:295:15:295:24 | access to parameter sinkParam9 |
-| GlobalDataFlow.cs:293:32:293:41 | sinkParam9 | GlobalDataFlow.cs:295:15:295:24 | access to parameter sinkParam9 |
-| GlobalDataFlow.cs:293:32:293:41 | sinkParam9 | GlobalDataFlow.cs:295:15:295:24 | access to parameter sinkParam9 |
-| GlobalDataFlow.cs:293:32:293:41 | sinkParam9 | GlobalDataFlow.cs:295:15:295:24 | access to parameter sinkParam9 |
-| GlobalDataFlow.cs:293:32:293:41 | sinkParam9 | GlobalDataFlow.cs:296:16:296:25 | access to parameter sinkParam9 |
-| GlobalDataFlow.cs:293:32:293:41 | sinkParam9 | GlobalDataFlow.cs:296:16:296:25 | access to parameter sinkParam9 |
-| GlobalDataFlow.cs:293:32:293:41 | sinkParam9 | GlobalDataFlow.cs:296:16:296:25 | access to parameter sinkParam9 |
-| GlobalDataFlow.cs:293:32:293:41 | sinkParam9 | GlobalDataFlow.cs:296:16:296:25 | access to parameter sinkParam9 |
-| GlobalDataFlow.cs:293:32:293:41 | sinkParam9 | GlobalDataFlow.cs:296:16:296:25 | access to parameter sinkParam9 |
-| GlobalDataFlow.cs:293:32:293:41 | sinkParam9 | GlobalDataFlow.cs:296:16:296:25 | access to parameter sinkParam9 |
-| GlobalDataFlow.cs:295:9:295:25 | call to method Check | GlobalDataFlow.cs:295:9:295:25 | call to method Check |
-| GlobalDataFlow.cs:295:15:295:24 | access to parameter sinkParam9 | GlobalDataFlow.cs:295:15:295:24 | access to parameter sinkParam9 |
-| GlobalDataFlow.cs:295:15:295:24 | access to parameter sinkParam9 | GlobalDataFlow.cs:296:16:296:25 | access to parameter sinkParam9 |
-| GlobalDataFlow.cs:295:15:295:24 | access to parameter sinkParam9 | GlobalDataFlow.cs:296:16:296:25 | access to parameter sinkParam9 |
-| GlobalDataFlow.cs:295:15:295:24 | access to parameter sinkParam9 | GlobalDataFlow.cs:296:16:296:25 | access to parameter sinkParam9 |
-| GlobalDataFlow.cs:295:15:295:24 | access to parameter sinkParam9 | GlobalDataFlow.cs:296:16:296:25 | access to parameter sinkParam9 |
-| GlobalDataFlow.cs:296:16:296:25 | access to parameter sinkParam9 | GlobalDataFlow.cs:205:76:205:90 | call to method ReturnCheck2 |
-| GlobalDataFlow.cs:296:16:296:25 | access to parameter sinkParam9 | GlobalDataFlow.cs:205:76:205:90 | call to method ReturnCheck2 |
-| GlobalDataFlow.cs:296:16:296:25 | access to parameter sinkParam9 | GlobalDataFlow.cs:296:16:296:25 | access to parameter sinkParam9 |
-| GlobalDataFlow.cs:299:32:299:42 | sinkParam11 | GlobalDataFlow.cs:299:32:299:42 | sinkParam11 |
-| GlobalDataFlow.cs:299:32:299:42 | sinkParam11 | GlobalDataFlow.cs:299:32:299:42 | sinkParam11 |
-| GlobalDataFlow.cs:299:32:299:42 | sinkParam11 | GlobalDataFlow.cs:299:32:299:42 | sinkParam11 |
-| GlobalDataFlow.cs:299:32:299:42 | sinkParam11 | GlobalDataFlow.cs:299:32:299:42 | sinkParam11 |
-| GlobalDataFlow.cs:299:32:299:42 | sinkParam11 | GlobalDataFlow.cs:299:32:299:42 | sinkParam11 |
-| GlobalDataFlow.cs:299:32:299:42 | sinkParam11 | GlobalDataFlow.cs:299:32:299:42 | sinkParam11 |
-| GlobalDataFlow.cs:299:32:299:42 | sinkParam11 | GlobalDataFlow.cs:301:15:301:25 | access to parameter sinkParam11 |
-| GlobalDataFlow.cs:299:32:299:42 | sinkParam11 | GlobalDataFlow.cs:301:15:301:25 | access to parameter sinkParam11 |
-| GlobalDataFlow.cs:299:32:299:42 | sinkParam11 | GlobalDataFlow.cs:301:15:301:25 | access to parameter sinkParam11 |
-| GlobalDataFlow.cs:299:32:299:42 | sinkParam11 | GlobalDataFlow.cs:301:15:301:25 | access to parameter sinkParam11 |
-| GlobalDataFlow.cs:299:32:299:42 | sinkParam11 | GlobalDataFlow.cs:301:15:301:25 | access to parameter sinkParam11 |
-| GlobalDataFlow.cs:299:32:299:42 | sinkParam11 | GlobalDataFlow.cs:301:15:301:25 | access to parameter sinkParam11 |
-| GlobalDataFlow.cs:299:32:299:42 | sinkParam11 | GlobalDataFlow.cs:301:15:301:25 | access to parameter sinkParam11 |
-| GlobalDataFlow.cs:299:32:299:42 | sinkParam11 | GlobalDataFlow.cs:301:15:301:25 | access to parameter sinkParam11 |
-| GlobalDataFlow.cs:299:32:299:42 | sinkParam11 | GlobalDataFlow.cs:302:16:302:26 | access to parameter sinkParam11 |
-| GlobalDataFlow.cs:299:32:299:42 | sinkParam11 | GlobalDataFlow.cs:302:16:302:26 | access to parameter sinkParam11 |
-| GlobalDataFlow.cs:299:32:299:42 | sinkParam11 | GlobalDataFlow.cs:302:16:302:26 | access to parameter sinkParam11 |
-| GlobalDataFlow.cs:299:32:299:42 | sinkParam11 | GlobalDataFlow.cs:302:16:302:26 | access to parameter sinkParam11 |
-| GlobalDataFlow.cs:299:32:299:42 | sinkParam11 | GlobalDataFlow.cs:302:16:302:26 | access to parameter sinkParam11 |
-| GlobalDataFlow.cs:299:32:299:42 | sinkParam11 | GlobalDataFlow.cs:302:16:302:26 | access to parameter sinkParam11 |
-| GlobalDataFlow.cs:299:32:299:42 | sinkParam11 | GlobalDataFlow.cs:302:16:302:26 | access to parameter sinkParam11 |
-| GlobalDataFlow.cs:299:32:299:42 | sinkParam11 | GlobalDataFlow.cs:302:16:302:26 | access to parameter sinkParam11 |
-| GlobalDataFlow.cs:301:9:301:26 | call to method Check | GlobalDataFlow.cs:301:9:301:26 | call to method Check |
-| GlobalDataFlow.cs:301:15:301:25 | access to parameter sinkParam11 | GlobalDataFlow.cs:301:15:301:25 | access to parameter sinkParam11 |
-| GlobalDataFlow.cs:301:15:301:25 | access to parameter sinkParam11 | GlobalDataFlow.cs:302:16:302:26 | access to parameter sinkParam11 |
-| GlobalDataFlow.cs:301:15:301:25 | access to parameter sinkParam11 | GlobalDataFlow.cs:302:16:302:26 | access to parameter sinkParam11 |
-| GlobalDataFlow.cs:301:15:301:25 | access to parameter sinkParam11 | GlobalDataFlow.cs:302:16:302:26 | access to parameter sinkParam11 |
-| GlobalDataFlow.cs:301:15:301:25 | access to parameter sinkParam11 | GlobalDataFlow.cs:302:16:302:26 | access to parameter sinkParam11 |
-| GlobalDataFlow.cs:302:16:302:26 | access to parameter sinkParam11 | GlobalDataFlow.cs:210:37:210:48 | [output] delegate creation of type Func<String,String> |
-| GlobalDataFlow.cs:302:16:302:26 | access to parameter sinkParam11 | GlobalDataFlow.cs:210:37:210:48 | [output] delegate creation of type Func<String,String> |
-| GlobalDataFlow.cs:302:16:302:26 | access to parameter sinkParam11 | GlobalDataFlow.cs:224:37:224:48 | [output] delegate creation of type Func<String,String> |
-| GlobalDataFlow.cs:302:16:302:26 | access to parameter sinkParam11 | GlobalDataFlow.cs:224:37:224:48 | [output] delegate creation of type Func<String,String> |
-| GlobalDataFlow.cs:302:16:302:26 | access to parameter sinkParam11 | GlobalDataFlow.cs:302:16:302:26 | access to parameter sinkParam11 |
-| GlobalDataFlow.cs:305:34:305:45 | nonSinkParam | GlobalDataFlow.cs:305:34:305:45 | nonSinkParam |
-| GlobalDataFlow.cs:305:34:305:45 | nonSinkParam | GlobalDataFlow.cs:305:34:305:45 | nonSinkParam |
-| GlobalDataFlow.cs:305:34:305:45 | nonSinkParam | GlobalDataFlow.cs:305:34:305:45 | nonSinkParam |
-| GlobalDataFlow.cs:305:34:305:45 | nonSinkParam | GlobalDataFlow.cs:305:34:305:45 | nonSinkParam |
-| GlobalDataFlow.cs:305:34:305:45 | nonSinkParam | GlobalDataFlow.cs:307:15:307:26 | access to parameter nonSinkParam |
-| GlobalDataFlow.cs:305:34:305:45 | nonSinkParam | GlobalDataFlow.cs:307:15:307:26 | access to parameter nonSinkParam |
-| GlobalDataFlow.cs:305:34:305:45 | nonSinkParam | GlobalDataFlow.cs:307:15:307:26 | access to parameter nonSinkParam |
-| GlobalDataFlow.cs:305:34:305:45 | nonSinkParam | GlobalDataFlow.cs:307:15:307:26 | access to parameter nonSinkParam |
-| GlobalDataFlow.cs:305:34:305:45 | nonSinkParam | GlobalDataFlow.cs:307:15:307:26 | access to parameter nonSinkParam |
-| GlobalDataFlow.cs:305:34:305:45 | nonSinkParam | GlobalDataFlow.cs:307:15:307:26 | access to parameter nonSinkParam |
-| GlobalDataFlow.cs:305:34:305:45 | nonSinkParam | GlobalDataFlow.cs:308:16:308:27 | access to parameter nonSinkParam |
-| GlobalDataFlow.cs:305:34:305:45 | nonSinkParam | GlobalDataFlow.cs:308:16:308:27 | access to parameter nonSinkParam |
-| GlobalDataFlow.cs:305:34:305:45 | nonSinkParam | GlobalDataFlow.cs:308:16:308:27 | access to parameter nonSinkParam |
-| GlobalDataFlow.cs:305:34:305:45 | nonSinkParam | GlobalDataFlow.cs:308:16:308:27 | access to parameter nonSinkParam |
-| GlobalDataFlow.cs:305:34:305:45 | nonSinkParam | GlobalDataFlow.cs:308:16:308:27 | access to parameter nonSinkParam |
-| GlobalDataFlow.cs:305:34:305:45 | nonSinkParam | GlobalDataFlow.cs:308:16:308:27 | access to parameter nonSinkParam |
-| GlobalDataFlow.cs:307:9:307:27 | call to method Check | GlobalDataFlow.cs:307:9:307:27 | call to method Check |
-| GlobalDataFlow.cs:307:15:307:26 | access to parameter nonSinkParam | GlobalDataFlow.cs:307:15:307:26 | access to parameter nonSinkParam |
-| GlobalDataFlow.cs:307:15:307:26 | access to parameter nonSinkParam | GlobalDataFlow.cs:308:16:308:27 | access to parameter nonSinkParam |
-| GlobalDataFlow.cs:307:15:307:26 | access to parameter nonSinkParam | GlobalDataFlow.cs:308:16:308:27 | access to parameter nonSinkParam |
-| GlobalDataFlow.cs:307:15:307:26 | access to parameter nonSinkParam | GlobalDataFlow.cs:308:16:308:27 | access to parameter nonSinkParam |
-| GlobalDataFlow.cs:307:15:307:26 | access to parameter nonSinkParam | GlobalDataFlow.cs:308:16:308:27 | access to parameter nonSinkParam |
-| GlobalDataFlow.cs:308:16:308:27 | access to parameter nonSinkParam | GlobalDataFlow.cs:215:76:215:92 | call to method NonReturnCheck |
-| GlobalDataFlow.cs:308:16:308:27 | access to parameter nonSinkParam | GlobalDataFlow.cs:215:76:215:92 | call to method NonReturnCheck |
-| GlobalDataFlow.cs:308:16:308:27 | access to parameter nonSinkParam | GlobalDataFlow.cs:308:16:308:27 | access to parameter nonSinkParam |
-| GlobalDataFlow.cs:311:12:311:14 | this | GlobalDataFlow.cs:311:12:311:14 | this |
-| GlobalDataFlow.cs:313:16:313:29 | "taint source" | GlobalDataFlow.cs:149:21:149:25 | call to method Out |
-| GlobalDataFlow.cs:313:16:313:29 | "taint source" | GlobalDataFlow.cs:149:21:149:25 | call to method Out |
-| GlobalDataFlow.cs:313:16:313:29 | "taint source" | GlobalDataFlow.cs:185:39:185:41 | [output] delegate creation of type Func<String> |
-| GlobalDataFlow.cs:313:16:313:29 | "taint source" | GlobalDataFlow.cs:185:39:185:41 | [output] delegate creation of type Func<String> |
-| GlobalDataFlow.cs:313:16:313:29 | "taint source" | GlobalDataFlow.cs:313:16:313:29 | "taint source" |
-| GlobalDataFlow.cs:316:10:316:15 | this | GlobalDataFlow.cs:316:10:316:15 | this |
-| GlobalDataFlow.cs:318:9:318:26 | ... = ... | GlobalDataFlow.cs:318:9:318:26 | ... = ... |
-| GlobalDataFlow.cs:318:9:318:26 | SSA def(x) | GlobalDataFlow.cs:152:20:152:24 | SSA def(sink7) |
-| GlobalDataFlow.cs:318:9:318:26 | SSA def(x) | GlobalDataFlow.cs:152:20:152:24 | SSA def(sink7) |
-| GlobalDataFlow.cs:318:9:318:26 | SSA def(x) | GlobalDataFlow.cs:318:9:318:26 | SSA def(x) |
-| GlobalDataFlow.cs:318:13:318:26 | "taint source" | GlobalDataFlow.cs:318:9:318:26 | SSA def(x) |
-| GlobalDataFlow.cs:318:13:318:26 | "taint source" | GlobalDataFlow.cs:318:9:318:26 | SSA def(x) |
-| GlobalDataFlow.cs:318:13:318:26 | "taint source" | GlobalDataFlow.cs:318:13:318:26 | "taint source" |
+| GlobalDataFlow.cs:226:9:226:39 | ... = ... | GlobalDataFlow.cs:226:9:226:39 | ... = ... |
+| GlobalDataFlow.cs:226:9:226:39 | SSA def(nonSink) | GlobalDataFlow.cs:226:9:226:39 | SSA def(nonSink) |
+| GlobalDataFlow.cs:226:9:226:39 | SSA def(nonSink) | GlobalDataFlow.cs:227:15:227:21 | access to local variable nonSink |
+| GlobalDataFlow.cs:226:9:226:39 | SSA def(nonSink) | GlobalDataFlow.cs:227:15:227:21 | access to local variable nonSink |
+| GlobalDataFlow.cs:226:19:226:28 | access to parameter notTainted | GlobalDataFlow.cs:219:71:219:71 | x |
+| GlobalDataFlow.cs:226:19:226:28 | access to parameter notTainted | GlobalDataFlow.cs:219:71:219:71 | x |
+| GlobalDataFlow.cs:226:19:226:28 | access to parameter notTainted | GlobalDataFlow.cs:226:19:226:28 | access to parameter notTainted |
+| GlobalDataFlow.cs:226:19:226:28 | access to parameter notTainted | GlobalDataFlow.cs:226:37:226:38 | [output] access to local variable f4 |
+| GlobalDataFlow.cs:226:19:226:28 | access to parameter notTainted | GlobalDataFlow.cs:226:37:226:38 | [output] access to local variable f4 |
+| GlobalDataFlow.cs:226:19:226:28 | access to parameter notTainted | GlobalDataFlow.cs:228:19:228:28 | access to parameter notTainted |
+| GlobalDataFlow.cs:226:19:226:28 | access to parameter notTainted | GlobalDataFlow.cs:228:19:228:28 | access to parameter notTainted |
+| GlobalDataFlow.cs:226:19:226:39 | call to method Select | GlobalDataFlow.cs:226:9:226:39 | SSA def(nonSink) |
+| GlobalDataFlow.cs:226:19:226:39 | call to method Select | GlobalDataFlow.cs:226:9:226:39 | SSA def(nonSink) |
+| GlobalDataFlow.cs:226:19:226:39 | call to method Select | GlobalDataFlow.cs:226:19:226:39 | call to method Select |
+| GlobalDataFlow.cs:226:19:226:39 | call to method Select | GlobalDataFlow.cs:227:15:227:21 | access to local variable nonSink |
+| GlobalDataFlow.cs:226:19:226:39 | call to method Select | GlobalDataFlow.cs:227:15:227:21 | access to local variable nonSink |
+| GlobalDataFlow.cs:226:37:226:38 | [output] access to local variable f4 | GlobalDataFlow.cs:226:9:226:39 | SSA def(nonSink) |
+| GlobalDataFlow.cs:226:37:226:38 | [output] access to local variable f4 | GlobalDataFlow.cs:226:9:226:39 | SSA def(nonSink) |
+| GlobalDataFlow.cs:226:37:226:38 | [output] access to local variable f4 | GlobalDataFlow.cs:226:19:226:39 | call to method Select |
+| GlobalDataFlow.cs:226:37:226:38 | [output] access to local variable f4 | GlobalDataFlow.cs:226:19:226:39 | call to method Select |
+| GlobalDataFlow.cs:226:37:226:38 | [output] access to local variable f4 | GlobalDataFlow.cs:226:37:226:38 | [output] access to local variable f4 |
+| GlobalDataFlow.cs:226:37:226:38 | [output] access to local variable f4 | GlobalDataFlow.cs:227:15:227:21 | access to local variable nonSink |
+| GlobalDataFlow.cs:226:37:226:38 | [output] access to local variable f4 | GlobalDataFlow.cs:227:15:227:21 | access to local variable nonSink |
+| GlobalDataFlow.cs:226:37:226:38 | access to local variable f4 | GlobalDataFlow.cs:226:37:226:38 | access to local variable f4 |
+| GlobalDataFlow.cs:227:9:227:22 | call to method Check | GlobalDataFlow.cs:227:9:227:22 | call to method Check |
+| GlobalDataFlow.cs:227:15:227:21 | access to local variable nonSink | GlobalDataFlow.cs:227:15:227:21 | access to local variable nonSink |
+| GlobalDataFlow.cs:228:9:228:49 | ... = ... | GlobalDataFlow.cs:228:9:228:49 | ... = ... |
+| GlobalDataFlow.cs:228:9:228:49 | SSA def(nonSink) | GlobalDataFlow.cs:228:9:228:49 | SSA def(nonSink) |
+| GlobalDataFlow.cs:228:9:228:49 | SSA def(nonSink) | GlobalDataFlow.cs:229:15:229:21 | access to local variable nonSink |
+| GlobalDataFlow.cs:228:9:228:49 | SSA def(nonSink) | GlobalDataFlow.cs:229:15:229:21 | access to local variable nonSink |
+| GlobalDataFlow.cs:228:19:228:28 | access to parameter notTainted | GlobalDataFlow.cs:228:19:228:28 | access to parameter notTainted |
+| GlobalDataFlow.cs:228:19:228:28 | access to parameter notTainted | GlobalDataFlow.cs:228:37:228:48 | [output] delegate creation of type Func<String,String> |
+| GlobalDataFlow.cs:228:19:228:28 | access to parameter notTainted | GlobalDataFlow.cs:228:37:228:48 | [output] delegate creation of type Func<String,String> |
+| GlobalDataFlow.cs:228:19:228:28 | access to parameter notTainted | GlobalDataFlow.cs:304:32:304:42 | sinkParam11 |
+| GlobalDataFlow.cs:228:19:228:28 | access to parameter notTainted | GlobalDataFlow.cs:304:32:304:42 | sinkParam11 |
+| GlobalDataFlow.cs:228:19:228:49 | call to method Select | GlobalDataFlow.cs:228:9:228:49 | SSA def(nonSink) |
+| GlobalDataFlow.cs:228:19:228:49 | call to method Select | GlobalDataFlow.cs:228:9:228:49 | SSA def(nonSink) |
+| GlobalDataFlow.cs:228:19:228:49 | call to method Select | GlobalDataFlow.cs:228:19:228:49 | call to method Select |
+| GlobalDataFlow.cs:228:19:228:49 | call to method Select | GlobalDataFlow.cs:229:15:229:21 | access to local variable nonSink |
+| GlobalDataFlow.cs:228:19:228:49 | call to method Select | GlobalDataFlow.cs:229:15:229:21 | access to local variable nonSink |
+| GlobalDataFlow.cs:228:37:228:48 | [output] delegate creation of type Func<String,String> | GlobalDataFlow.cs:228:9:228:49 | SSA def(nonSink) |
+| GlobalDataFlow.cs:228:37:228:48 | [output] delegate creation of type Func<String,String> | GlobalDataFlow.cs:228:9:228:49 | SSA def(nonSink) |
+| GlobalDataFlow.cs:228:37:228:48 | [output] delegate creation of type Func<String,String> | GlobalDataFlow.cs:228:19:228:49 | call to method Select |
+| GlobalDataFlow.cs:228:37:228:48 | [output] delegate creation of type Func<String,String> | GlobalDataFlow.cs:228:19:228:49 | call to method Select |
+| GlobalDataFlow.cs:228:37:228:48 | [output] delegate creation of type Func<String,String> | GlobalDataFlow.cs:228:37:228:48 | [output] delegate creation of type Func<String,String> |
+| GlobalDataFlow.cs:228:37:228:48 | [output] delegate creation of type Func<String,String> | GlobalDataFlow.cs:229:15:229:21 | access to local variable nonSink |
+| GlobalDataFlow.cs:228:37:228:48 | [output] delegate creation of type Func<String,String> | GlobalDataFlow.cs:229:15:229:21 | access to local variable nonSink |
+| GlobalDataFlow.cs:228:37:228:48 | access to method ReturnCheck3 | GlobalDataFlow.cs:228:37:228:48 | access to method ReturnCheck3 |
+| GlobalDataFlow.cs:228:37:228:48 | delegate creation of type Func<String,String> | GlobalDataFlow.cs:228:37:228:48 | delegate creation of type Func<String,String> |
+| GlobalDataFlow.cs:229:9:229:22 | call to method Check | GlobalDataFlow.cs:229:9:229:22 | call to method Check |
+| GlobalDataFlow.cs:229:15:229:21 | access to local variable nonSink | GlobalDataFlow.cs:229:15:229:21 | access to local variable nonSink |
+| GlobalDataFlow.cs:234:26:234:35 | sinkParam0 | GlobalDataFlow.cs:234:26:234:35 | sinkParam0 |
+| GlobalDataFlow.cs:234:26:234:35 | sinkParam0 | GlobalDataFlow.cs:234:26:234:35 | sinkParam0 |
+| GlobalDataFlow.cs:234:26:234:35 | sinkParam0 | GlobalDataFlow.cs:234:26:234:35 | sinkParam0 |
+| GlobalDataFlow.cs:234:26:234:35 | sinkParam0 | GlobalDataFlow.cs:234:26:234:35 | sinkParam0 |
+| GlobalDataFlow.cs:234:26:234:35 | sinkParam0 | GlobalDataFlow.cs:236:16:236:25 | access to parameter sinkParam0 |
+| GlobalDataFlow.cs:234:26:234:35 | sinkParam0 | GlobalDataFlow.cs:236:16:236:25 | access to parameter sinkParam0 |
+| GlobalDataFlow.cs:234:26:234:35 | sinkParam0 | GlobalDataFlow.cs:236:16:236:25 | access to parameter sinkParam0 |
+| GlobalDataFlow.cs:234:26:234:35 | sinkParam0 | GlobalDataFlow.cs:236:16:236:25 | access to parameter sinkParam0 |
+| GlobalDataFlow.cs:234:26:234:35 | sinkParam0 | GlobalDataFlow.cs:236:16:236:25 | access to parameter sinkParam0 |
+| GlobalDataFlow.cs:234:26:234:35 | sinkParam0 | GlobalDataFlow.cs:236:16:236:25 | access to parameter sinkParam0 |
+| GlobalDataFlow.cs:234:26:234:35 | sinkParam0 | GlobalDataFlow.cs:237:15:237:24 | access to parameter sinkParam0 |
+| GlobalDataFlow.cs:234:26:234:35 | sinkParam0 | GlobalDataFlow.cs:237:15:237:24 | access to parameter sinkParam0 |
+| GlobalDataFlow.cs:234:26:234:35 | sinkParam0 | GlobalDataFlow.cs:237:15:237:24 | access to parameter sinkParam0 |
+| GlobalDataFlow.cs:234:26:234:35 | sinkParam0 | GlobalDataFlow.cs:237:15:237:24 | access to parameter sinkParam0 |
+| GlobalDataFlow.cs:234:26:234:35 | sinkParam0 | GlobalDataFlow.cs:237:15:237:24 | access to parameter sinkParam0 |
+| GlobalDataFlow.cs:234:26:234:35 | sinkParam0 | GlobalDataFlow.cs:237:15:237:24 | access to parameter sinkParam0 |
+| GlobalDataFlow.cs:236:9:236:26 | call to method In0 | GlobalDataFlow.cs:236:9:236:26 | call to method In0 |
+| GlobalDataFlow.cs:236:16:236:25 | access to parameter sinkParam0 | GlobalDataFlow.cs:234:26:234:35 | sinkParam0 |
+| GlobalDataFlow.cs:236:16:236:25 | access to parameter sinkParam0 | GlobalDataFlow.cs:234:26:234:35 | sinkParam0 |
+| GlobalDataFlow.cs:236:16:236:25 | access to parameter sinkParam0 | GlobalDataFlow.cs:234:26:234:35 | sinkParam0 |
+| GlobalDataFlow.cs:236:16:236:25 | access to parameter sinkParam0 | GlobalDataFlow.cs:234:26:234:35 | sinkParam0 |
+| GlobalDataFlow.cs:236:16:236:25 | access to parameter sinkParam0 | GlobalDataFlow.cs:236:16:236:25 | access to parameter sinkParam0 |
+| GlobalDataFlow.cs:236:16:236:25 | access to parameter sinkParam0 | GlobalDataFlow.cs:237:15:237:24 | access to parameter sinkParam0 |
+| GlobalDataFlow.cs:236:16:236:25 | access to parameter sinkParam0 | GlobalDataFlow.cs:237:15:237:24 | access to parameter sinkParam0 |
+| GlobalDataFlow.cs:236:16:236:25 | access to parameter sinkParam0 | GlobalDataFlow.cs:237:15:237:24 | access to parameter sinkParam0 |
+| GlobalDataFlow.cs:236:16:236:25 | access to parameter sinkParam0 | GlobalDataFlow.cs:237:15:237:24 | access to parameter sinkParam0 |
+| GlobalDataFlow.cs:237:9:237:25 | call to method Check | GlobalDataFlow.cs:237:9:237:25 | call to method Check |
+| GlobalDataFlow.cs:237:15:237:24 | access to parameter sinkParam0 | GlobalDataFlow.cs:237:15:237:24 | access to parameter sinkParam0 |
+| GlobalDataFlow.cs:240:26:240:35 | sinkParam1 | GlobalDataFlow.cs:240:26:240:35 | sinkParam1 |
+| GlobalDataFlow.cs:240:26:240:35 | sinkParam1 | GlobalDataFlow.cs:240:26:240:35 | sinkParam1 |
+| GlobalDataFlow.cs:240:26:240:35 | sinkParam1 | GlobalDataFlow.cs:240:26:240:35 | sinkParam1 |
+| GlobalDataFlow.cs:240:26:240:35 | sinkParam1 | GlobalDataFlow.cs:240:26:240:35 | sinkParam1 |
+| GlobalDataFlow.cs:240:26:240:35 | sinkParam1 | GlobalDataFlow.cs:242:15:242:24 | access to parameter sinkParam1 |
+| GlobalDataFlow.cs:240:26:240:35 | sinkParam1 | GlobalDataFlow.cs:242:15:242:24 | access to parameter sinkParam1 |
+| GlobalDataFlow.cs:240:26:240:35 | sinkParam1 | GlobalDataFlow.cs:242:15:242:24 | access to parameter sinkParam1 |
+| GlobalDataFlow.cs:240:26:240:35 | sinkParam1 | GlobalDataFlow.cs:242:15:242:24 | access to parameter sinkParam1 |
+| GlobalDataFlow.cs:240:26:240:35 | sinkParam1 | GlobalDataFlow.cs:242:15:242:24 | access to parameter sinkParam1 |
+| GlobalDataFlow.cs:240:26:240:35 | sinkParam1 | GlobalDataFlow.cs:242:15:242:24 | access to parameter sinkParam1 |
+| GlobalDataFlow.cs:242:9:242:25 | call to method Check | GlobalDataFlow.cs:242:9:242:25 | call to method Check |
+| GlobalDataFlow.cs:242:15:242:24 | access to parameter sinkParam1 | GlobalDataFlow.cs:242:15:242:24 | access to parameter sinkParam1 |
+| GlobalDataFlow.cs:245:26:245:35 | sinkParam3 | GlobalDataFlow.cs:245:26:245:35 | sinkParam3 |
+| GlobalDataFlow.cs:245:26:245:35 | sinkParam3 | GlobalDataFlow.cs:245:26:245:35 | sinkParam3 |
+| GlobalDataFlow.cs:245:26:245:35 | sinkParam3 | GlobalDataFlow.cs:245:26:245:35 | sinkParam3 |
+| GlobalDataFlow.cs:245:26:245:35 | sinkParam3 | GlobalDataFlow.cs:245:26:245:35 | sinkParam3 |
+| GlobalDataFlow.cs:245:26:245:35 | sinkParam3 | GlobalDataFlow.cs:247:15:247:24 | access to parameter sinkParam3 |
+| GlobalDataFlow.cs:245:26:245:35 | sinkParam3 | GlobalDataFlow.cs:247:15:247:24 | access to parameter sinkParam3 |
+| GlobalDataFlow.cs:245:26:245:35 | sinkParam3 | GlobalDataFlow.cs:247:15:247:24 | access to parameter sinkParam3 |
+| GlobalDataFlow.cs:245:26:245:35 | sinkParam3 | GlobalDataFlow.cs:247:15:247:24 | access to parameter sinkParam3 |
+| GlobalDataFlow.cs:245:26:245:35 | sinkParam3 | GlobalDataFlow.cs:247:15:247:24 | access to parameter sinkParam3 |
+| GlobalDataFlow.cs:245:26:245:35 | sinkParam3 | GlobalDataFlow.cs:247:15:247:24 | access to parameter sinkParam3 |
+| GlobalDataFlow.cs:247:9:247:25 | call to method Check | GlobalDataFlow.cs:247:9:247:25 | call to method Check |
+| GlobalDataFlow.cs:247:15:247:24 | access to parameter sinkParam3 | GlobalDataFlow.cs:247:15:247:24 | access to parameter sinkParam3 |
+| GlobalDataFlow.cs:250:26:250:35 | sinkParam4 | GlobalDataFlow.cs:250:26:250:35 | sinkParam4 |
+| GlobalDataFlow.cs:250:26:250:35 | sinkParam4 | GlobalDataFlow.cs:250:26:250:35 | sinkParam4 |
+| GlobalDataFlow.cs:250:26:250:35 | sinkParam4 | GlobalDataFlow.cs:250:26:250:35 | sinkParam4 |
+| GlobalDataFlow.cs:250:26:250:35 | sinkParam4 | GlobalDataFlow.cs:250:26:250:35 | sinkParam4 |
+| GlobalDataFlow.cs:250:26:250:35 | sinkParam4 | GlobalDataFlow.cs:252:15:252:24 | access to parameter sinkParam4 |
+| GlobalDataFlow.cs:250:26:250:35 | sinkParam4 | GlobalDataFlow.cs:252:15:252:24 | access to parameter sinkParam4 |
+| GlobalDataFlow.cs:250:26:250:35 | sinkParam4 | GlobalDataFlow.cs:252:15:252:24 | access to parameter sinkParam4 |
+| GlobalDataFlow.cs:250:26:250:35 | sinkParam4 | GlobalDataFlow.cs:252:15:252:24 | access to parameter sinkParam4 |
+| GlobalDataFlow.cs:250:26:250:35 | sinkParam4 | GlobalDataFlow.cs:252:15:252:24 | access to parameter sinkParam4 |
+| GlobalDataFlow.cs:250:26:250:35 | sinkParam4 | GlobalDataFlow.cs:252:15:252:24 | access to parameter sinkParam4 |
+| GlobalDataFlow.cs:252:9:252:25 | call to method Check | GlobalDataFlow.cs:252:9:252:25 | call to method Check |
+| GlobalDataFlow.cs:252:15:252:24 | access to parameter sinkParam4 | GlobalDataFlow.cs:252:15:252:24 | access to parameter sinkParam4 |
+| GlobalDataFlow.cs:255:26:255:35 | sinkParam5 | GlobalDataFlow.cs:255:26:255:35 | sinkParam5 |
+| GlobalDataFlow.cs:255:26:255:35 | sinkParam5 | GlobalDataFlow.cs:255:26:255:35 | sinkParam5 |
+| GlobalDataFlow.cs:255:26:255:35 | sinkParam5 | GlobalDataFlow.cs:255:26:255:35 | sinkParam5 |
+| GlobalDataFlow.cs:255:26:255:35 | sinkParam5 | GlobalDataFlow.cs:255:26:255:35 | sinkParam5 |
+| GlobalDataFlow.cs:255:26:255:35 | sinkParam5 | GlobalDataFlow.cs:257:15:257:24 | access to parameter sinkParam5 |
+| GlobalDataFlow.cs:255:26:255:35 | sinkParam5 | GlobalDataFlow.cs:257:15:257:24 | access to parameter sinkParam5 |
+| GlobalDataFlow.cs:255:26:255:35 | sinkParam5 | GlobalDataFlow.cs:257:15:257:24 | access to parameter sinkParam5 |
+| GlobalDataFlow.cs:255:26:255:35 | sinkParam5 | GlobalDataFlow.cs:257:15:257:24 | access to parameter sinkParam5 |
+| GlobalDataFlow.cs:255:26:255:35 | sinkParam5 | GlobalDataFlow.cs:257:15:257:24 | access to parameter sinkParam5 |
+| GlobalDataFlow.cs:255:26:255:35 | sinkParam5 | GlobalDataFlow.cs:257:15:257:24 | access to parameter sinkParam5 |
+| GlobalDataFlow.cs:257:9:257:25 | call to method Check | GlobalDataFlow.cs:257:9:257:25 | call to method Check |
+| GlobalDataFlow.cs:257:15:257:24 | access to parameter sinkParam5 | GlobalDataFlow.cs:257:15:257:24 | access to parameter sinkParam5 |
+| GlobalDataFlow.cs:260:26:260:35 | sinkParam6 | GlobalDataFlow.cs:260:26:260:35 | sinkParam6 |
+| GlobalDataFlow.cs:260:26:260:35 | sinkParam6 | GlobalDataFlow.cs:260:26:260:35 | sinkParam6 |
+| GlobalDataFlow.cs:260:26:260:35 | sinkParam6 | GlobalDataFlow.cs:260:26:260:35 | sinkParam6 |
+| GlobalDataFlow.cs:260:26:260:35 | sinkParam6 | GlobalDataFlow.cs:260:26:260:35 | sinkParam6 |
+| GlobalDataFlow.cs:260:26:260:35 | sinkParam6 | GlobalDataFlow.cs:262:15:262:24 | access to parameter sinkParam6 |
+| GlobalDataFlow.cs:260:26:260:35 | sinkParam6 | GlobalDataFlow.cs:262:15:262:24 | access to parameter sinkParam6 |
+| GlobalDataFlow.cs:260:26:260:35 | sinkParam6 | GlobalDataFlow.cs:262:15:262:24 | access to parameter sinkParam6 |
+| GlobalDataFlow.cs:260:26:260:35 | sinkParam6 | GlobalDataFlow.cs:262:15:262:24 | access to parameter sinkParam6 |
+| GlobalDataFlow.cs:260:26:260:35 | sinkParam6 | GlobalDataFlow.cs:262:15:262:24 | access to parameter sinkParam6 |
+| GlobalDataFlow.cs:260:26:260:35 | sinkParam6 | GlobalDataFlow.cs:262:15:262:24 | access to parameter sinkParam6 |
+| GlobalDataFlow.cs:262:9:262:25 | call to method Check | GlobalDataFlow.cs:262:9:262:25 | call to method Check |
+| GlobalDataFlow.cs:262:15:262:24 | access to parameter sinkParam6 | GlobalDataFlow.cs:262:15:262:24 | access to parameter sinkParam6 |
+| GlobalDataFlow.cs:265:26:265:35 | sinkParam7 | GlobalDataFlow.cs:265:26:265:35 | sinkParam7 |
+| GlobalDataFlow.cs:265:26:265:35 | sinkParam7 | GlobalDataFlow.cs:265:26:265:35 | sinkParam7 |
+| GlobalDataFlow.cs:265:26:265:35 | sinkParam7 | GlobalDataFlow.cs:265:26:265:35 | sinkParam7 |
+| GlobalDataFlow.cs:265:26:265:35 | sinkParam7 | GlobalDataFlow.cs:265:26:265:35 | sinkParam7 |
+| GlobalDataFlow.cs:265:26:265:35 | sinkParam7 | GlobalDataFlow.cs:267:15:267:24 | access to parameter sinkParam7 |
+| GlobalDataFlow.cs:265:26:265:35 | sinkParam7 | GlobalDataFlow.cs:267:15:267:24 | access to parameter sinkParam7 |
+| GlobalDataFlow.cs:265:26:265:35 | sinkParam7 | GlobalDataFlow.cs:267:15:267:24 | access to parameter sinkParam7 |
+| GlobalDataFlow.cs:265:26:265:35 | sinkParam7 | GlobalDataFlow.cs:267:15:267:24 | access to parameter sinkParam7 |
+| GlobalDataFlow.cs:265:26:265:35 | sinkParam7 | GlobalDataFlow.cs:267:15:267:24 | access to parameter sinkParam7 |
+| GlobalDataFlow.cs:265:26:265:35 | sinkParam7 | GlobalDataFlow.cs:267:15:267:24 | access to parameter sinkParam7 |
+| GlobalDataFlow.cs:267:9:267:25 | call to method Check | GlobalDataFlow.cs:267:9:267:25 | call to method Check |
+| GlobalDataFlow.cs:267:15:267:24 | access to parameter sinkParam7 | GlobalDataFlow.cs:267:15:267:24 | access to parameter sinkParam7 |
+| GlobalDataFlow.cs:270:29:270:41 | nonSinkParam0 | GlobalDataFlow.cs:270:29:270:41 | nonSinkParam0 |
+| GlobalDataFlow.cs:270:29:270:41 | nonSinkParam0 | GlobalDataFlow.cs:270:29:270:41 | nonSinkParam0 |
+| GlobalDataFlow.cs:270:29:270:41 | nonSinkParam0 | GlobalDataFlow.cs:270:29:270:41 | nonSinkParam0 |
+| GlobalDataFlow.cs:270:29:270:41 | nonSinkParam0 | GlobalDataFlow.cs:270:29:270:41 | nonSinkParam0 |
+| GlobalDataFlow.cs:270:29:270:41 | nonSinkParam0 | GlobalDataFlow.cs:272:15:272:27 | access to parameter nonSinkParam0 |
+| GlobalDataFlow.cs:270:29:270:41 | nonSinkParam0 | GlobalDataFlow.cs:272:15:272:27 | access to parameter nonSinkParam0 |
+| GlobalDataFlow.cs:270:29:270:41 | nonSinkParam0 | GlobalDataFlow.cs:272:15:272:27 | access to parameter nonSinkParam0 |
+| GlobalDataFlow.cs:270:29:270:41 | nonSinkParam0 | GlobalDataFlow.cs:272:15:272:27 | access to parameter nonSinkParam0 |
+| GlobalDataFlow.cs:270:29:270:41 | nonSinkParam0 | GlobalDataFlow.cs:272:15:272:27 | access to parameter nonSinkParam0 |
+| GlobalDataFlow.cs:270:29:270:41 | nonSinkParam0 | GlobalDataFlow.cs:272:15:272:27 | access to parameter nonSinkParam0 |
+| GlobalDataFlow.cs:272:9:272:28 | call to method Check | GlobalDataFlow.cs:272:9:272:28 | call to method Check |
+| GlobalDataFlow.cs:272:15:272:27 | access to parameter nonSinkParam0 | GlobalDataFlow.cs:272:15:272:27 | access to parameter nonSinkParam0 |
+| GlobalDataFlow.cs:275:26:275:26 | x | GlobalDataFlow.cs:275:26:275:26 | x |
+| GlobalDataFlow.cs:275:26:275:26 | x | GlobalDataFlow.cs:275:26:275:26 | x |
+| GlobalDataFlow.cs:275:26:275:26 | x | GlobalDataFlow.cs:275:26:275:26 | x |
+| GlobalDataFlow.cs:275:26:275:26 | x | GlobalDataFlow.cs:275:26:275:26 | x |
+| GlobalDataFlow.cs:275:26:275:26 | x | GlobalDataFlow.cs:277:37:277:37 | access to parameter x |
+| GlobalDataFlow.cs:275:26:275:26 | x | GlobalDataFlow.cs:277:37:277:37 | access to parameter x |
+| GlobalDataFlow.cs:275:26:275:26 | x | GlobalDataFlow.cs:277:37:277:37 | access to parameter x |
+| GlobalDataFlow.cs:275:26:275:26 | x | GlobalDataFlow.cs:277:37:277:37 | access to parameter x |
+| GlobalDataFlow.cs:275:26:275:26 | x | GlobalDataFlow.cs:277:37:277:37 | access to parameter x |
+| GlobalDataFlow.cs:275:26:275:26 | x | GlobalDataFlow.cs:277:37:277:37 | access to parameter x |
+| GlobalDataFlow.cs:277:13:277:38 | SSA def(y) | GlobalDataFlow.cs:277:13:277:38 | SSA def(y) |
+| GlobalDataFlow.cs:277:13:277:38 | SSA def(y) | GlobalDataFlow.cs:278:16:278:16 | (...) ... |
+| GlobalDataFlow.cs:277:13:277:38 | SSA def(y) | GlobalDataFlow.cs:278:16:278:16 | (...) ... |
+| GlobalDataFlow.cs:277:13:277:38 | SSA def(y) | GlobalDataFlow.cs:278:16:278:16 | (...) ... |
+| GlobalDataFlow.cs:277:13:277:38 | SSA def(y) | GlobalDataFlow.cs:278:16:278:16 | (...) ... |
+| GlobalDataFlow.cs:277:13:277:38 | SSA def(y) | GlobalDataFlow.cs:278:16:278:16 | access to local variable y |
+| GlobalDataFlow.cs:277:13:277:38 | SSA def(y) | GlobalDataFlow.cs:278:16:278:16 | access to local variable y |
+| GlobalDataFlow.cs:277:13:277:38 | SSA def(y) | GlobalDataFlow.cs:278:16:278:16 | access to local variable y |
+| GlobalDataFlow.cs:277:13:277:38 | SSA def(y) | GlobalDataFlow.cs:278:16:278:16 | access to local variable y |
+| GlobalDataFlow.cs:277:13:277:38 | SSA def(y) | GlobalDataFlow.cs:278:16:278:41 | ... ? ... : ... |
+| GlobalDataFlow.cs:277:13:277:38 | SSA def(y) | GlobalDataFlow.cs:278:16:278:41 | ... ? ... : ... |
+| GlobalDataFlow.cs:277:13:277:38 | SSA def(y) | GlobalDataFlow.cs:278:16:278:41 | ... ? ... : ... |
+| GlobalDataFlow.cs:277:13:277:38 | SSA def(y) | GlobalDataFlow.cs:278:16:278:41 | ... ? ... : ... |
+| GlobalDataFlow.cs:277:13:277:38 | SSA def(y) | GlobalDataFlow.cs:278:41:278:41 | access to local variable y |
+| GlobalDataFlow.cs:277:13:277:38 | SSA def(y) | GlobalDataFlow.cs:278:41:278:41 | access to local variable y |
+| GlobalDataFlow.cs:277:13:277:38 | SSA def(y) | GlobalDataFlow.cs:278:41:278:41 | access to local variable y |
+| GlobalDataFlow.cs:277:13:277:38 | SSA def(y) | GlobalDataFlow.cs:278:41:278:41 | access to local variable y |
+| GlobalDataFlow.cs:277:13:277:38 | T y = ... | GlobalDataFlow.cs:277:13:277:38 | T y = ... |
+| GlobalDataFlow.cs:277:17:277:38 | call to method ApplyFunc | GlobalDataFlow.cs:277:13:277:38 | SSA def(y) |
+| GlobalDataFlow.cs:277:17:277:38 | call to method ApplyFunc | GlobalDataFlow.cs:277:13:277:38 | SSA def(y) |
+| GlobalDataFlow.cs:277:17:277:38 | call to method ApplyFunc | GlobalDataFlow.cs:277:13:277:38 | SSA def(y) |
+| GlobalDataFlow.cs:277:17:277:38 | call to method ApplyFunc | GlobalDataFlow.cs:277:13:277:38 | SSA def(y) |
+| GlobalDataFlow.cs:277:17:277:38 | call to method ApplyFunc | GlobalDataFlow.cs:277:17:277:38 | call to method ApplyFunc |
+| GlobalDataFlow.cs:277:17:277:38 | call to method ApplyFunc | GlobalDataFlow.cs:278:16:278:16 | (...) ... |
+| GlobalDataFlow.cs:277:17:277:38 | call to method ApplyFunc | GlobalDataFlow.cs:278:16:278:16 | (...) ... |
+| GlobalDataFlow.cs:277:17:277:38 | call to method ApplyFunc | GlobalDataFlow.cs:278:16:278:16 | (...) ... |
+| GlobalDataFlow.cs:277:17:277:38 | call to method ApplyFunc | GlobalDataFlow.cs:278:16:278:16 | (...) ... |
+| GlobalDataFlow.cs:277:17:277:38 | call to method ApplyFunc | GlobalDataFlow.cs:278:16:278:16 | access to local variable y |
+| GlobalDataFlow.cs:277:17:277:38 | call to method ApplyFunc | GlobalDataFlow.cs:278:16:278:16 | access to local variable y |
+| GlobalDataFlow.cs:277:17:277:38 | call to method ApplyFunc | GlobalDataFlow.cs:278:16:278:16 | access to local variable y |
+| GlobalDataFlow.cs:277:17:277:38 | call to method ApplyFunc | GlobalDataFlow.cs:278:16:278:16 | access to local variable y |
+| GlobalDataFlow.cs:277:17:277:38 | call to method ApplyFunc | GlobalDataFlow.cs:278:16:278:41 | ... ? ... : ... |
+| GlobalDataFlow.cs:277:17:277:38 | call to method ApplyFunc | GlobalDataFlow.cs:278:16:278:41 | ... ? ... : ... |
+| GlobalDataFlow.cs:277:17:277:38 | call to method ApplyFunc | GlobalDataFlow.cs:278:16:278:41 | ... ? ... : ... |
+| GlobalDataFlow.cs:277:17:277:38 | call to method ApplyFunc | GlobalDataFlow.cs:278:16:278:41 | ... ? ... : ... |
+| GlobalDataFlow.cs:277:17:277:38 | call to method ApplyFunc | GlobalDataFlow.cs:278:41:278:41 | access to local variable y |
+| GlobalDataFlow.cs:277:17:277:38 | call to method ApplyFunc | GlobalDataFlow.cs:278:41:278:41 | access to local variable y |
+| GlobalDataFlow.cs:277:17:277:38 | call to method ApplyFunc | GlobalDataFlow.cs:278:41:278:41 | access to local variable y |
+| GlobalDataFlow.cs:277:17:277:38 | call to method ApplyFunc | GlobalDataFlow.cs:278:41:278:41 | access to local variable y |
+| GlobalDataFlow.cs:277:27:277:28 | x0 | GlobalDataFlow.cs:277:27:277:28 | x0 |
+| GlobalDataFlow.cs:277:27:277:28 | x0 | GlobalDataFlow.cs:277:27:277:28 | x0 |
+| GlobalDataFlow.cs:277:27:277:28 | x0 | GlobalDataFlow.cs:277:27:277:28 | x0 |
+| GlobalDataFlow.cs:277:27:277:28 | x0 | GlobalDataFlow.cs:277:27:277:28 | x0 |
+| GlobalDataFlow.cs:277:27:277:28 | x0 | GlobalDataFlow.cs:277:33:277:34 | access to parameter x0 |
+| GlobalDataFlow.cs:277:27:277:28 | x0 | GlobalDataFlow.cs:277:33:277:34 | access to parameter x0 |
+| GlobalDataFlow.cs:277:27:277:28 | x0 | GlobalDataFlow.cs:277:33:277:34 | access to parameter x0 |
+| GlobalDataFlow.cs:277:27:277:28 | x0 | GlobalDataFlow.cs:277:33:277:34 | access to parameter x0 |
+| GlobalDataFlow.cs:277:27:277:28 | x0 | GlobalDataFlow.cs:277:33:277:34 | access to parameter x0 |
+| GlobalDataFlow.cs:277:27:277:28 | x0 | GlobalDataFlow.cs:277:33:277:34 | access to parameter x0 |
+| GlobalDataFlow.cs:277:27:277:34 | (...) => ... | GlobalDataFlow.cs:277:27:277:34 | (...) => ... |
+| GlobalDataFlow.cs:277:27:277:34 | (...) => ... | GlobalDataFlow.cs:364:41:364:41 | f |
+| GlobalDataFlow.cs:277:27:277:34 | (...) => ... | GlobalDataFlow.cs:364:41:364:41 | f |
+| GlobalDataFlow.cs:277:33:277:34 | access to parameter x0 | GlobalDataFlow.cs:277:33:277:34 | access to parameter x0 |
+| GlobalDataFlow.cs:277:33:277:34 | access to parameter x0 | GlobalDataFlow.cs:366:16:366:19 | delegate call |
+| GlobalDataFlow.cs:277:33:277:34 | access to parameter x0 | GlobalDataFlow.cs:366:16:366:19 | delegate call |
+| GlobalDataFlow.cs:277:37:277:37 | access to parameter x | GlobalDataFlow.cs:277:17:277:38 | call to method ApplyFunc |
+| GlobalDataFlow.cs:277:37:277:37 | access to parameter x | GlobalDataFlow.cs:277:17:277:38 | call to method ApplyFunc |
+| GlobalDataFlow.cs:277:37:277:37 | access to parameter x | GlobalDataFlow.cs:277:17:277:38 | call to method ApplyFunc |
+| GlobalDataFlow.cs:277:37:277:37 | access to parameter x | GlobalDataFlow.cs:277:17:277:38 | call to method ApplyFunc |
+| GlobalDataFlow.cs:277:37:277:37 | access to parameter x | GlobalDataFlow.cs:277:37:277:37 | access to parameter x |
+| GlobalDataFlow.cs:277:37:277:37 | access to parameter x | GlobalDataFlow.cs:364:46:364:46 | x |
+| GlobalDataFlow.cs:277:37:277:37 | access to parameter x | GlobalDataFlow.cs:364:46:364:46 | x |
+| GlobalDataFlow.cs:277:37:277:37 | access to parameter x | GlobalDataFlow.cs:364:46:364:46 | x |
+| GlobalDataFlow.cs:277:37:277:37 | access to parameter x | GlobalDataFlow.cs:364:46:364:46 | x |
+| GlobalDataFlow.cs:278:16:278:16 | (...) ... | GlobalDataFlow.cs:278:16:278:16 | (...) ... |
+| GlobalDataFlow.cs:278:16:278:16 | (...) ... | GlobalDataFlow.cs:278:16:278:24 | ... == ... |
+| GlobalDataFlow.cs:278:16:278:16 | (...) ... | GlobalDataFlow.cs:278:16:278:24 | ... == ... |
+| GlobalDataFlow.cs:278:16:278:16 | (...) ... | GlobalDataFlow.cs:278:16:278:24 | ... == ... |
+| GlobalDataFlow.cs:278:16:278:16 | (...) ... | GlobalDataFlow.cs:278:16:278:24 | ... == ... |
+| GlobalDataFlow.cs:278:16:278:16 | (...) ... | GlobalDataFlow.cs:278:16:278:41 | ... ? ... : ... |
+| GlobalDataFlow.cs:278:16:278:16 | (...) ... | GlobalDataFlow.cs:278:16:278:41 | ... ? ... : ... |
+| GlobalDataFlow.cs:278:16:278:16 | (...) ... | GlobalDataFlow.cs:278:16:278:41 | ... ? ... : ... |
+| GlobalDataFlow.cs:278:16:278:16 | (...) ... | GlobalDataFlow.cs:278:16:278:41 | ... ? ... : ... |
+| GlobalDataFlow.cs:278:16:278:16 | access to local variable y | GlobalDataFlow.cs:278:16:278:16 | (...) ... |
+| GlobalDataFlow.cs:278:16:278:16 | access to local variable y | GlobalDataFlow.cs:278:16:278:16 | (...) ... |
+| GlobalDataFlow.cs:278:16:278:16 | access to local variable y | GlobalDataFlow.cs:278:16:278:16 | (...) ... |
+| GlobalDataFlow.cs:278:16:278:16 | access to local variable y | GlobalDataFlow.cs:278:16:278:16 | (...) ... |
+| GlobalDataFlow.cs:278:16:278:16 | access to local variable y | GlobalDataFlow.cs:278:16:278:16 | access to local variable y |
+| GlobalDataFlow.cs:278:16:278:16 | access to local variable y | GlobalDataFlow.cs:278:16:278:41 | ... ? ... : ... |
+| GlobalDataFlow.cs:278:16:278:16 | access to local variable y | GlobalDataFlow.cs:278:16:278:41 | ... ? ... : ... |
+| GlobalDataFlow.cs:278:16:278:16 | access to local variable y | GlobalDataFlow.cs:278:16:278:41 | ... ? ... : ... |
+| GlobalDataFlow.cs:278:16:278:16 | access to local variable y | GlobalDataFlow.cs:278:16:278:41 | ... ? ... : ... |
+| GlobalDataFlow.cs:278:16:278:16 | access to local variable y | GlobalDataFlow.cs:278:41:278:41 | access to local variable y |
+| GlobalDataFlow.cs:278:16:278:16 | access to local variable y | GlobalDataFlow.cs:278:41:278:41 | access to local variable y |
+| GlobalDataFlow.cs:278:16:278:16 | access to local variable y | GlobalDataFlow.cs:278:41:278:41 | access to local variable y |
+| GlobalDataFlow.cs:278:16:278:16 | access to local variable y | GlobalDataFlow.cs:278:41:278:41 | access to local variable y |
+| GlobalDataFlow.cs:278:16:278:24 | ... == ... | GlobalDataFlow.cs:278:16:278:24 | ... == ... |
+| GlobalDataFlow.cs:278:16:278:24 | ... == ... | GlobalDataFlow.cs:278:16:278:41 | ... ? ... : ... |
+| GlobalDataFlow.cs:278:16:278:24 | ... == ... | GlobalDataFlow.cs:278:16:278:41 | ... ? ... : ... |
+| GlobalDataFlow.cs:278:16:278:24 | ... == ... | GlobalDataFlow.cs:278:16:278:41 | ... ? ... : ... |
+| GlobalDataFlow.cs:278:16:278:24 | ... == ... | GlobalDataFlow.cs:278:16:278:41 | ... ? ... : ... |
+| GlobalDataFlow.cs:278:16:278:41 | ... ? ... : ... | GlobalDataFlow.cs:70:21:70:46 | call to method Return |
+| GlobalDataFlow.cs:278:16:278:41 | ... ? ... : ... | GlobalDataFlow.cs:70:21:70:46 | call to method Return |
+| GlobalDataFlow.cs:278:16:278:41 | ... ? ... : ... | GlobalDataFlow.cs:72:29:72:101 | call to method Invoke |
+| GlobalDataFlow.cs:278:16:278:41 | ... ? ... : ... | GlobalDataFlow.cs:72:29:72:101 | call to method Invoke |
+| GlobalDataFlow.cs:278:16:278:41 | ... ? ... : ... | GlobalDataFlow.cs:100:24:100:33 | call to method Return |
+| GlobalDataFlow.cs:278:16:278:41 | ... ? ... : ... | GlobalDataFlow.cs:100:24:100:33 | call to method Return |
+| GlobalDataFlow.cs:278:16:278:41 | ... ? ... : ... | GlobalDataFlow.cs:102:28:102:103 | call to method Invoke |
+| GlobalDataFlow.cs:278:16:278:41 | ... ? ... : ... | GlobalDataFlow.cs:102:28:102:103 | call to method Invoke |
+| GlobalDataFlow.cs:278:16:278:41 | ... ? ... : ... | GlobalDataFlow.cs:278:16:278:41 | ... ? ... : ... |
+| GlobalDataFlow.cs:278:16:278:41 | ... ? ... : ... | GlobalDataFlow.cs:366:16:366:19 | delegate call |
+| GlobalDataFlow.cs:278:16:278:41 | ... ? ... : ... | GlobalDataFlow.cs:366:16:366:19 | delegate call |
+| GlobalDataFlow.cs:278:21:278:24 | null | GlobalDataFlow.cs:278:21:278:24 | null |
+| GlobalDataFlow.cs:278:28:278:37 | default(...) | GlobalDataFlow.cs:278:16:278:41 | ... ? ... : ... |
+| GlobalDataFlow.cs:278:28:278:37 | default(...) | GlobalDataFlow.cs:278:16:278:41 | ... ? ... : ... |
+| GlobalDataFlow.cs:278:28:278:37 | default(...) | GlobalDataFlow.cs:278:28:278:37 | default(...) |
+| GlobalDataFlow.cs:278:41:278:41 | access to local variable y | GlobalDataFlow.cs:278:16:278:41 | ... ? ... : ... |
+| GlobalDataFlow.cs:278:41:278:41 | access to local variable y | GlobalDataFlow.cs:278:16:278:41 | ... ? ... : ... |
+| GlobalDataFlow.cs:278:41:278:41 | access to local variable y | GlobalDataFlow.cs:278:16:278:41 | ... ? ... : ... |
+| GlobalDataFlow.cs:278:41:278:41 | access to local variable y | GlobalDataFlow.cs:278:16:278:41 | ... ? ... : ... |
+| GlobalDataFlow.cs:278:41:278:41 | access to local variable y | GlobalDataFlow.cs:278:41:278:41 | access to local variable y |
+| GlobalDataFlow.cs:281:32:281:32 | x | GlobalDataFlow.cs:281:32:281:32 | x |
+| GlobalDataFlow.cs:281:32:281:32 | x | GlobalDataFlow.cs:281:32:281:32 | x |
+| GlobalDataFlow.cs:281:32:281:32 | x | GlobalDataFlow.cs:281:32:281:32 | x |
+| GlobalDataFlow.cs:281:32:281:32 | x | GlobalDataFlow.cs:281:32:281:32 | x |
+| GlobalDataFlow.cs:281:32:281:32 | x | GlobalDataFlow.cs:283:9:283:13 | SSA def(y) |
+| GlobalDataFlow.cs:281:32:281:32 | x | GlobalDataFlow.cs:283:9:283:13 | SSA def(y) |
+| GlobalDataFlow.cs:281:32:281:32 | x | GlobalDataFlow.cs:283:9:283:13 | SSA def(y) |
+| GlobalDataFlow.cs:281:32:281:32 | x | GlobalDataFlow.cs:283:9:283:13 | SSA def(y) |
+| GlobalDataFlow.cs:281:32:281:32 | x | GlobalDataFlow.cs:283:9:283:13 | SSA def(y) |
+| GlobalDataFlow.cs:281:32:281:32 | x | GlobalDataFlow.cs:283:9:283:13 | SSA def(y) |
+| GlobalDataFlow.cs:281:32:281:32 | x | GlobalDataFlow.cs:283:13:283:13 | access to parameter x |
+| GlobalDataFlow.cs:281:32:281:32 | x | GlobalDataFlow.cs:283:13:283:13 | access to parameter x |
+| GlobalDataFlow.cs:281:32:281:32 | x | GlobalDataFlow.cs:283:13:283:13 | access to parameter x |
+| GlobalDataFlow.cs:281:32:281:32 | x | GlobalDataFlow.cs:283:13:283:13 | access to parameter x |
+| GlobalDataFlow.cs:281:32:281:32 | x | GlobalDataFlow.cs:283:13:283:13 | access to parameter x |
+| GlobalDataFlow.cs:281:32:281:32 | x | GlobalDataFlow.cs:283:13:283:13 | access to parameter x |
+| GlobalDataFlow.cs:283:9:283:13 | ... = ... | GlobalDataFlow.cs:283:9:283:13 | ... = ... |
+| GlobalDataFlow.cs:283:9:283:13 | SSA def(y) | GlobalDataFlow.cs:75:30:75:34 | SSA def(sink2) |
+| GlobalDataFlow.cs:283:9:283:13 | SSA def(y) | GlobalDataFlow.cs:75:30:75:34 | SSA def(sink2) |
+| GlobalDataFlow.cs:283:9:283:13 | SSA def(y) | GlobalDataFlow.cs:104:27:104:34 | SSA def(nonSink0) |
+| GlobalDataFlow.cs:283:9:283:13 | SSA def(y) | GlobalDataFlow.cs:104:27:104:34 | SSA def(nonSink0) |
+| GlobalDataFlow.cs:283:9:283:13 | SSA def(y) | GlobalDataFlow.cs:106:41:106:48 | SSA def(nonSink0) |
+| GlobalDataFlow.cs:283:9:283:13 | SSA def(y) | GlobalDataFlow.cs:106:41:106:48 | SSA def(nonSink0) |
+| GlobalDataFlow.cs:283:9:283:13 | SSA def(y) | GlobalDataFlow.cs:283:9:283:13 | SSA def(y) |
+| GlobalDataFlow.cs:283:13:283:13 | access to parameter x | GlobalDataFlow.cs:283:9:283:13 | SSA def(y) |
+| GlobalDataFlow.cs:283:13:283:13 | access to parameter x | GlobalDataFlow.cs:283:9:283:13 | SSA def(y) |
+| GlobalDataFlow.cs:283:13:283:13 | access to parameter x | GlobalDataFlow.cs:283:9:283:13 | SSA def(y) |
+| GlobalDataFlow.cs:283:13:283:13 | access to parameter x | GlobalDataFlow.cs:283:9:283:13 | SSA def(y) |
+| GlobalDataFlow.cs:283:13:283:13 | access to parameter x | GlobalDataFlow.cs:283:13:283:13 | access to parameter x |
+| GlobalDataFlow.cs:284:9:284:22 | ... = ... | GlobalDataFlow.cs:284:9:284:22 | ... = ... |
+| GlobalDataFlow.cs:284:9:284:22 | SSA def(z) | GlobalDataFlow.cs:75:30:75:34 | SSA def(sink2) |
+| GlobalDataFlow.cs:284:9:284:22 | SSA def(z) | GlobalDataFlow.cs:75:30:75:34 | SSA def(sink2) |
+| GlobalDataFlow.cs:284:9:284:22 | SSA def(z) | GlobalDataFlow.cs:104:27:104:34 | SSA def(nonSink0) |
+| GlobalDataFlow.cs:284:9:284:22 | SSA def(z) | GlobalDataFlow.cs:104:27:104:34 | SSA def(nonSink0) |
+| GlobalDataFlow.cs:284:9:284:22 | SSA def(z) | GlobalDataFlow.cs:106:41:106:48 | SSA def(nonSink0) |
+| GlobalDataFlow.cs:284:9:284:22 | SSA def(z) | GlobalDataFlow.cs:106:41:106:48 | SSA def(nonSink0) |
+| GlobalDataFlow.cs:284:9:284:22 | SSA def(z) | GlobalDataFlow.cs:284:9:284:22 | SSA def(z) |
+| GlobalDataFlow.cs:284:13:284:22 | default(...) | GlobalDataFlow.cs:284:9:284:22 | SSA def(z) |
+| GlobalDataFlow.cs:284:13:284:22 | default(...) | GlobalDataFlow.cs:284:9:284:22 | SSA def(z) |
+| GlobalDataFlow.cs:284:13:284:22 | default(...) | GlobalDataFlow.cs:284:13:284:22 | default(...) |
+| GlobalDataFlow.cs:287:32:287:32 | x | GlobalDataFlow.cs:287:32:287:32 | x |
+| GlobalDataFlow.cs:287:32:287:32 | x | GlobalDataFlow.cs:287:32:287:32 | x |
+| GlobalDataFlow.cs:287:32:287:32 | x | GlobalDataFlow.cs:287:32:287:32 | x |
+| GlobalDataFlow.cs:287:32:287:32 | x | GlobalDataFlow.cs:287:32:287:32 | x |
+| GlobalDataFlow.cs:287:32:287:32 | x | GlobalDataFlow.cs:289:9:289:13 | SSA def(y) |
+| GlobalDataFlow.cs:287:32:287:32 | x | GlobalDataFlow.cs:289:9:289:13 | SSA def(y) |
+| GlobalDataFlow.cs:287:32:287:32 | x | GlobalDataFlow.cs:289:9:289:13 | SSA def(y) |
+| GlobalDataFlow.cs:287:32:287:32 | x | GlobalDataFlow.cs:289:9:289:13 | SSA def(y) |
+| GlobalDataFlow.cs:287:32:287:32 | x | GlobalDataFlow.cs:289:9:289:13 | SSA def(y) |
+| GlobalDataFlow.cs:287:32:287:32 | x | GlobalDataFlow.cs:289:9:289:13 | SSA def(y) |
+| GlobalDataFlow.cs:287:32:287:32 | x | GlobalDataFlow.cs:289:13:289:13 | access to parameter x |
+| GlobalDataFlow.cs:287:32:287:32 | x | GlobalDataFlow.cs:289:13:289:13 | access to parameter x |
+| GlobalDataFlow.cs:287:32:287:32 | x | GlobalDataFlow.cs:289:13:289:13 | access to parameter x |
+| GlobalDataFlow.cs:287:32:287:32 | x | GlobalDataFlow.cs:289:13:289:13 | access to parameter x |
+| GlobalDataFlow.cs:287:32:287:32 | x | GlobalDataFlow.cs:289:13:289:13 | access to parameter x |
+| GlobalDataFlow.cs:287:32:287:32 | x | GlobalDataFlow.cs:289:13:289:13 | access to parameter x |
+| GlobalDataFlow.cs:287:50:287:50 | z | GlobalDataFlow.cs:78:30:78:34 | SSA def(sink3) |
+| GlobalDataFlow.cs:287:50:287:50 | z | GlobalDataFlow.cs:78:30:78:34 | SSA def(sink3) |
+| GlobalDataFlow.cs:287:50:287:50 | z | GlobalDataFlow.cs:108:27:108:34 | SSA def(nonSink0) |
+| GlobalDataFlow.cs:287:50:287:50 | z | GlobalDataFlow.cs:108:27:108:34 | SSA def(nonSink0) |
+| GlobalDataFlow.cs:287:50:287:50 | z | GlobalDataFlow.cs:110:30:110:34 | SSA def(sink1) |
+| GlobalDataFlow.cs:287:50:287:50 | z | GlobalDataFlow.cs:110:30:110:34 | SSA def(sink1) |
+| GlobalDataFlow.cs:287:50:287:50 | z | GlobalDataFlow.cs:287:50:287:50 | z |
+| GlobalDataFlow.cs:287:50:287:50 | z | GlobalDataFlow.cs:287:50:287:50 | z |
+| GlobalDataFlow.cs:287:50:287:50 | z | GlobalDataFlow.cs:287:50:287:50 | z |
+| GlobalDataFlow.cs:287:50:287:50 | z | GlobalDataFlow.cs:287:50:287:50 | z |
+| GlobalDataFlow.cs:289:9:289:13 | ... = ... | GlobalDataFlow.cs:289:9:289:13 | ... = ... |
+| GlobalDataFlow.cs:289:9:289:13 | SSA def(y) | GlobalDataFlow.cs:78:30:78:34 | SSA def(sink3) |
+| GlobalDataFlow.cs:289:9:289:13 | SSA def(y) | GlobalDataFlow.cs:78:30:78:34 | SSA def(sink3) |
+| GlobalDataFlow.cs:289:9:289:13 | SSA def(y) | GlobalDataFlow.cs:108:27:108:34 | SSA def(nonSink0) |
+| GlobalDataFlow.cs:289:9:289:13 | SSA def(y) | GlobalDataFlow.cs:108:27:108:34 | SSA def(nonSink0) |
+| GlobalDataFlow.cs:289:9:289:13 | SSA def(y) | GlobalDataFlow.cs:110:30:110:34 | SSA def(sink1) |
+| GlobalDataFlow.cs:289:9:289:13 | SSA def(y) | GlobalDataFlow.cs:110:30:110:34 | SSA def(sink1) |
+| GlobalDataFlow.cs:289:9:289:13 | SSA def(y) | GlobalDataFlow.cs:289:9:289:13 | SSA def(y) |
+| GlobalDataFlow.cs:289:13:289:13 | access to parameter x | GlobalDataFlow.cs:289:9:289:13 | SSA def(y) |
+| GlobalDataFlow.cs:289:13:289:13 | access to parameter x | GlobalDataFlow.cs:289:9:289:13 | SSA def(y) |
+| GlobalDataFlow.cs:289:13:289:13 | access to parameter x | GlobalDataFlow.cs:289:9:289:13 | SSA def(y) |
+| GlobalDataFlow.cs:289:13:289:13 | access to parameter x | GlobalDataFlow.cs:289:9:289:13 | SSA def(y) |
+| GlobalDataFlow.cs:289:13:289:13 | access to parameter x | GlobalDataFlow.cs:289:13:289:13 | access to parameter x |
+| GlobalDataFlow.cs:292:31:292:40 | sinkParam8 | GlobalDataFlow.cs:292:31:292:40 | sinkParam8 |
+| GlobalDataFlow.cs:292:31:292:40 | sinkParam8 | GlobalDataFlow.cs:292:31:292:40 | sinkParam8 |
+| GlobalDataFlow.cs:292:31:292:40 | sinkParam8 | GlobalDataFlow.cs:292:31:292:40 | sinkParam8 |
+| GlobalDataFlow.cs:292:31:292:40 | sinkParam8 | GlobalDataFlow.cs:292:31:292:40 | sinkParam8 |
+| GlobalDataFlow.cs:292:31:292:40 | sinkParam8 | GlobalDataFlow.cs:292:31:292:40 | sinkParam8 |
+| GlobalDataFlow.cs:292:31:292:40 | sinkParam8 | GlobalDataFlow.cs:292:31:292:40 | sinkParam8 |
+| GlobalDataFlow.cs:292:31:292:40 | sinkParam8 | GlobalDataFlow.cs:294:15:294:24 | access to parameter sinkParam8 |
+| GlobalDataFlow.cs:292:31:292:40 | sinkParam8 | GlobalDataFlow.cs:294:15:294:24 | access to parameter sinkParam8 |
+| GlobalDataFlow.cs:292:31:292:40 | sinkParam8 | GlobalDataFlow.cs:294:15:294:24 | access to parameter sinkParam8 |
+| GlobalDataFlow.cs:292:31:292:40 | sinkParam8 | GlobalDataFlow.cs:294:15:294:24 | access to parameter sinkParam8 |
+| GlobalDataFlow.cs:292:31:292:40 | sinkParam8 | GlobalDataFlow.cs:294:15:294:24 | access to parameter sinkParam8 |
+| GlobalDataFlow.cs:292:31:292:40 | sinkParam8 | GlobalDataFlow.cs:294:15:294:24 | access to parameter sinkParam8 |
+| GlobalDataFlow.cs:292:31:292:40 | sinkParam8 | GlobalDataFlow.cs:294:15:294:24 | access to parameter sinkParam8 |
+| GlobalDataFlow.cs:292:31:292:40 | sinkParam8 | GlobalDataFlow.cs:294:15:294:24 | access to parameter sinkParam8 |
+| GlobalDataFlow.cs:292:31:292:40 | sinkParam8 | GlobalDataFlow.cs:295:16:295:25 | access to parameter sinkParam8 |
+| GlobalDataFlow.cs:292:31:292:40 | sinkParam8 | GlobalDataFlow.cs:295:16:295:25 | access to parameter sinkParam8 |
+| GlobalDataFlow.cs:292:31:292:40 | sinkParam8 | GlobalDataFlow.cs:295:16:295:25 | access to parameter sinkParam8 |
+| GlobalDataFlow.cs:292:31:292:40 | sinkParam8 | GlobalDataFlow.cs:295:16:295:25 | access to parameter sinkParam8 |
+| GlobalDataFlow.cs:292:31:292:40 | sinkParam8 | GlobalDataFlow.cs:295:16:295:25 | access to parameter sinkParam8 |
+| GlobalDataFlow.cs:292:31:292:40 | sinkParam8 | GlobalDataFlow.cs:295:16:295:25 | access to parameter sinkParam8 |
+| GlobalDataFlow.cs:292:31:292:40 | sinkParam8 | GlobalDataFlow.cs:295:16:295:25 | access to parameter sinkParam8 |
+| GlobalDataFlow.cs:292:31:292:40 | sinkParam8 | GlobalDataFlow.cs:295:16:295:25 | access to parameter sinkParam8 |
+| GlobalDataFlow.cs:294:9:294:25 | call to method Check | GlobalDataFlow.cs:294:9:294:25 | call to method Check |
+| GlobalDataFlow.cs:294:15:294:24 | access to parameter sinkParam8 | GlobalDataFlow.cs:294:15:294:24 | access to parameter sinkParam8 |
+| GlobalDataFlow.cs:294:15:294:24 | access to parameter sinkParam8 | GlobalDataFlow.cs:295:16:295:25 | access to parameter sinkParam8 |
+| GlobalDataFlow.cs:294:15:294:24 | access to parameter sinkParam8 | GlobalDataFlow.cs:295:16:295:25 | access to parameter sinkParam8 |
+| GlobalDataFlow.cs:294:15:294:24 | access to parameter sinkParam8 | GlobalDataFlow.cs:295:16:295:25 | access to parameter sinkParam8 |
+| GlobalDataFlow.cs:294:15:294:24 | access to parameter sinkParam8 | GlobalDataFlow.cs:295:16:295:25 | access to parameter sinkParam8 |
+| GlobalDataFlow.cs:295:16:295:25 | access to parameter sinkParam8 | GlobalDataFlow.cs:82:84:82:94 | [output] delegate creation of type Func<String,String> |
+| GlobalDataFlow.cs:295:16:295:25 | access to parameter sinkParam8 | GlobalDataFlow.cs:82:84:82:94 | [output] delegate creation of type Func<String,String> |
+| GlobalDataFlow.cs:295:16:295:25 | access to parameter sinkParam8 | GlobalDataFlow.cs:295:16:295:25 | access to parameter sinkParam8 |
+| GlobalDataFlow.cs:298:32:298:41 | sinkParam9 | GlobalDataFlow.cs:298:32:298:41 | sinkParam9 |
+| GlobalDataFlow.cs:298:32:298:41 | sinkParam9 | GlobalDataFlow.cs:298:32:298:41 | sinkParam9 |
+| GlobalDataFlow.cs:298:32:298:41 | sinkParam9 | GlobalDataFlow.cs:298:32:298:41 | sinkParam9 |
+| GlobalDataFlow.cs:298:32:298:41 | sinkParam9 | GlobalDataFlow.cs:298:32:298:41 | sinkParam9 |
+| GlobalDataFlow.cs:298:32:298:41 | sinkParam9 | GlobalDataFlow.cs:300:15:300:24 | access to parameter sinkParam9 |
+| GlobalDataFlow.cs:298:32:298:41 | sinkParam9 | GlobalDataFlow.cs:300:15:300:24 | access to parameter sinkParam9 |
+| GlobalDataFlow.cs:298:32:298:41 | sinkParam9 | GlobalDataFlow.cs:300:15:300:24 | access to parameter sinkParam9 |
+| GlobalDataFlow.cs:298:32:298:41 | sinkParam9 | GlobalDataFlow.cs:300:15:300:24 | access to parameter sinkParam9 |
+| GlobalDataFlow.cs:298:32:298:41 | sinkParam9 | GlobalDataFlow.cs:300:15:300:24 | access to parameter sinkParam9 |
+| GlobalDataFlow.cs:298:32:298:41 | sinkParam9 | GlobalDataFlow.cs:300:15:300:24 | access to parameter sinkParam9 |
+| GlobalDataFlow.cs:298:32:298:41 | sinkParam9 | GlobalDataFlow.cs:301:16:301:25 | access to parameter sinkParam9 |
+| GlobalDataFlow.cs:298:32:298:41 | sinkParam9 | GlobalDataFlow.cs:301:16:301:25 | access to parameter sinkParam9 |
+| GlobalDataFlow.cs:298:32:298:41 | sinkParam9 | GlobalDataFlow.cs:301:16:301:25 | access to parameter sinkParam9 |
+| GlobalDataFlow.cs:298:32:298:41 | sinkParam9 | GlobalDataFlow.cs:301:16:301:25 | access to parameter sinkParam9 |
+| GlobalDataFlow.cs:298:32:298:41 | sinkParam9 | GlobalDataFlow.cs:301:16:301:25 | access to parameter sinkParam9 |
+| GlobalDataFlow.cs:298:32:298:41 | sinkParam9 | GlobalDataFlow.cs:301:16:301:25 | access to parameter sinkParam9 |
+| GlobalDataFlow.cs:300:9:300:25 | call to method Check | GlobalDataFlow.cs:300:9:300:25 | call to method Check |
+| GlobalDataFlow.cs:300:15:300:24 | access to parameter sinkParam9 | GlobalDataFlow.cs:300:15:300:24 | access to parameter sinkParam9 |
+| GlobalDataFlow.cs:300:15:300:24 | access to parameter sinkParam9 | GlobalDataFlow.cs:301:16:301:25 | access to parameter sinkParam9 |
+| GlobalDataFlow.cs:300:15:300:24 | access to parameter sinkParam9 | GlobalDataFlow.cs:301:16:301:25 | access to parameter sinkParam9 |
+| GlobalDataFlow.cs:300:15:300:24 | access to parameter sinkParam9 | GlobalDataFlow.cs:301:16:301:25 | access to parameter sinkParam9 |
+| GlobalDataFlow.cs:300:15:300:24 | access to parameter sinkParam9 | GlobalDataFlow.cs:301:16:301:25 | access to parameter sinkParam9 |
+| GlobalDataFlow.cs:301:16:301:25 | access to parameter sinkParam9 | GlobalDataFlow.cs:209:76:209:90 | call to method ReturnCheck2 |
+| GlobalDataFlow.cs:301:16:301:25 | access to parameter sinkParam9 | GlobalDataFlow.cs:209:76:209:90 | call to method ReturnCheck2 |
+| GlobalDataFlow.cs:301:16:301:25 | access to parameter sinkParam9 | GlobalDataFlow.cs:301:16:301:25 | access to parameter sinkParam9 |
+| GlobalDataFlow.cs:304:32:304:42 | sinkParam11 | GlobalDataFlow.cs:304:32:304:42 | sinkParam11 |
+| GlobalDataFlow.cs:304:32:304:42 | sinkParam11 | GlobalDataFlow.cs:304:32:304:42 | sinkParam11 |
+| GlobalDataFlow.cs:304:32:304:42 | sinkParam11 | GlobalDataFlow.cs:304:32:304:42 | sinkParam11 |
+| GlobalDataFlow.cs:304:32:304:42 | sinkParam11 | GlobalDataFlow.cs:304:32:304:42 | sinkParam11 |
+| GlobalDataFlow.cs:304:32:304:42 | sinkParam11 | GlobalDataFlow.cs:304:32:304:42 | sinkParam11 |
+| GlobalDataFlow.cs:304:32:304:42 | sinkParam11 | GlobalDataFlow.cs:304:32:304:42 | sinkParam11 |
+| GlobalDataFlow.cs:304:32:304:42 | sinkParam11 | GlobalDataFlow.cs:306:15:306:25 | access to parameter sinkParam11 |
+| GlobalDataFlow.cs:304:32:304:42 | sinkParam11 | GlobalDataFlow.cs:306:15:306:25 | access to parameter sinkParam11 |
+| GlobalDataFlow.cs:304:32:304:42 | sinkParam11 | GlobalDataFlow.cs:306:15:306:25 | access to parameter sinkParam11 |
+| GlobalDataFlow.cs:304:32:304:42 | sinkParam11 | GlobalDataFlow.cs:306:15:306:25 | access to parameter sinkParam11 |
+| GlobalDataFlow.cs:304:32:304:42 | sinkParam11 | GlobalDataFlow.cs:306:15:306:25 | access to parameter sinkParam11 |
+| GlobalDataFlow.cs:304:32:304:42 | sinkParam11 | GlobalDataFlow.cs:306:15:306:25 | access to parameter sinkParam11 |
+| GlobalDataFlow.cs:304:32:304:42 | sinkParam11 | GlobalDataFlow.cs:306:15:306:25 | access to parameter sinkParam11 |
+| GlobalDataFlow.cs:304:32:304:42 | sinkParam11 | GlobalDataFlow.cs:306:15:306:25 | access to parameter sinkParam11 |
+| GlobalDataFlow.cs:304:32:304:42 | sinkParam11 | GlobalDataFlow.cs:307:16:307:26 | access to parameter sinkParam11 |
+| GlobalDataFlow.cs:304:32:304:42 | sinkParam11 | GlobalDataFlow.cs:307:16:307:26 | access to parameter sinkParam11 |
+| GlobalDataFlow.cs:304:32:304:42 | sinkParam11 | GlobalDataFlow.cs:307:16:307:26 | access to parameter sinkParam11 |
+| GlobalDataFlow.cs:304:32:304:42 | sinkParam11 | GlobalDataFlow.cs:307:16:307:26 | access to parameter sinkParam11 |
+| GlobalDataFlow.cs:304:32:304:42 | sinkParam11 | GlobalDataFlow.cs:307:16:307:26 | access to parameter sinkParam11 |
+| GlobalDataFlow.cs:304:32:304:42 | sinkParam11 | GlobalDataFlow.cs:307:16:307:26 | access to parameter sinkParam11 |
+| GlobalDataFlow.cs:304:32:304:42 | sinkParam11 | GlobalDataFlow.cs:307:16:307:26 | access to parameter sinkParam11 |
+| GlobalDataFlow.cs:304:32:304:42 | sinkParam11 | GlobalDataFlow.cs:307:16:307:26 | access to parameter sinkParam11 |
+| GlobalDataFlow.cs:306:9:306:26 | call to method Check | GlobalDataFlow.cs:306:9:306:26 | call to method Check |
+| GlobalDataFlow.cs:306:15:306:25 | access to parameter sinkParam11 | GlobalDataFlow.cs:306:15:306:25 | access to parameter sinkParam11 |
+| GlobalDataFlow.cs:306:15:306:25 | access to parameter sinkParam11 | GlobalDataFlow.cs:307:16:307:26 | access to parameter sinkParam11 |
+| GlobalDataFlow.cs:306:15:306:25 | access to parameter sinkParam11 | GlobalDataFlow.cs:307:16:307:26 | access to parameter sinkParam11 |
+| GlobalDataFlow.cs:306:15:306:25 | access to parameter sinkParam11 | GlobalDataFlow.cs:307:16:307:26 | access to parameter sinkParam11 |
+| GlobalDataFlow.cs:306:15:306:25 | access to parameter sinkParam11 | GlobalDataFlow.cs:307:16:307:26 | access to parameter sinkParam11 |
+| GlobalDataFlow.cs:307:16:307:26 | access to parameter sinkParam11 | GlobalDataFlow.cs:214:37:214:48 | [output] delegate creation of type Func<String,String> |
+| GlobalDataFlow.cs:307:16:307:26 | access to parameter sinkParam11 | GlobalDataFlow.cs:214:37:214:48 | [output] delegate creation of type Func<String,String> |
+| GlobalDataFlow.cs:307:16:307:26 | access to parameter sinkParam11 | GlobalDataFlow.cs:228:37:228:48 | [output] delegate creation of type Func<String,String> |
+| GlobalDataFlow.cs:307:16:307:26 | access to parameter sinkParam11 | GlobalDataFlow.cs:228:37:228:48 | [output] delegate creation of type Func<String,String> |
+| GlobalDataFlow.cs:307:16:307:26 | access to parameter sinkParam11 | GlobalDataFlow.cs:307:16:307:26 | access to parameter sinkParam11 |
+| GlobalDataFlow.cs:310:34:310:45 | nonSinkParam | GlobalDataFlow.cs:310:34:310:45 | nonSinkParam |
+| GlobalDataFlow.cs:310:34:310:45 | nonSinkParam | GlobalDataFlow.cs:310:34:310:45 | nonSinkParam |
+| GlobalDataFlow.cs:310:34:310:45 | nonSinkParam | GlobalDataFlow.cs:310:34:310:45 | nonSinkParam |
+| GlobalDataFlow.cs:310:34:310:45 | nonSinkParam | GlobalDataFlow.cs:310:34:310:45 | nonSinkParam |
+| GlobalDataFlow.cs:310:34:310:45 | nonSinkParam | GlobalDataFlow.cs:312:15:312:26 | access to parameter nonSinkParam |
+| GlobalDataFlow.cs:310:34:310:45 | nonSinkParam | GlobalDataFlow.cs:312:15:312:26 | access to parameter nonSinkParam |
+| GlobalDataFlow.cs:310:34:310:45 | nonSinkParam | GlobalDataFlow.cs:312:15:312:26 | access to parameter nonSinkParam |
+| GlobalDataFlow.cs:310:34:310:45 | nonSinkParam | GlobalDataFlow.cs:312:15:312:26 | access to parameter nonSinkParam |
+| GlobalDataFlow.cs:310:34:310:45 | nonSinkParam | GlobalDataFlow.cs:312:15:312:26 | access to parameter nonSinkParam |
+| GlobalDataFlow.cs:310:34:310:45 | nonSinkParam | GlobalDataFlow.cs:312:15:312:26 | access to parameter nonSinkParam |
+| GlobalDataFlow.cs:310:34:310:45 | nonSinkParam | GlobalDataFlow.cs:313:16:313:27 | access to parameter nonSinkParam |
+| GlobalDataFlow.cs:310:34:310:45 | nonSinkParam | GlobalDataFlow.cs:313:16:313:27 | access to parameter nonSinkParam |
+| GlobalDataFlow.cs:310:34:310:45 | nonSinkParam | GlobalDataFlow.cs:313:16:313:27 | access to parameter nonSinkParam |
+| GlobalDataFlow.cs:310:34:310:45 | nonSinkParam | GlobalDataFlow.cs:313:16:313:27 | access to parameter nonSinkParam |
+| GlobalDataFlow.cs:310:34:310:45 | nonSinkParam | GlobalDataFlow.cs:313:16:313:27 | access to parameter nonSinkParam |
+| GlobalDataFlow.cs:310:34:310:45 | nonSinkParam | GlobalDataFlow.cs:313:16:313:27 | access to parameter nonSinkParam |
+| GlobalDataFlow.cs:312:9:312:27 | call to method Check | GlobalDataFlow.cs:312:9:312:27 | call to method Check |
+| GlobalDataFlow.cs:312:15:312:26 | access to parameter nonSinkParam | GlobalDataFlow.cs:312:15:312:26 | access to parameter nonSinkParam |
+| GlobalDataFlow.cs:312:15:312:26 | access to parameter nonSinkParam | GlobalDataFlow.cs:313:16:313:27 | access to parameter nonSinkParam |
+| GlobalDataFlow.cs:312:15:312:26 | access to parameter nonSinkParam | GlobalDataFlow.cs:313:16:313:27 | access to parameter nonSinkParam |
+| GlobalDataFlow.cs:312:15:312:26 | access to parameter nonSinkParam | GlobalDataFlow.cs:313:16:313:27 | access to parameter nonSinkParam |
+| GlobalDataFlow.cs:312:15:312:26 | access to parameter nonSinkParam | GlobalDataFlow.cs:313:16:313:27 | access to parameter nonSinkParam |
+| GlobalDataFlow.cs:313:16:313:27 | access to parameter nonSinkParam | GlobalDataFlow.cs:219:76:219:92 | call to method NonReturnCheck |
+| GlobalDataFlow.cs:313:16:313:27 | access to parameter nonSinkParam | GlobalDataFlow.cs:219:76:219:92 | call to method NonReturnCheck |
+| GlobalDataFlow.cs:313:16:313:27 | access to parameter nonSinkParam | GlobalDataFlow.cs:313:16:313:27 | access to parameter nonSinkParam |
+| GlobalDataFlow.cs:316:12:316:14 | this | GlobalDataFlow.cs:316:12:316:14 | this |
+| GlobalDataFlow.cs:318:16:318:29 | "taint source" | GlobalDataFlow.cs:153:21:153:25 | call to method Out |
+| GlobalDataFlow.cs:318:16:318:29 | "taint source" | GlobalDataFlow.cs:153:21:153:25 | call to method Out |
+| GlobalDataFlow.cs:318:16:318:29 | "taint source" | GlobalDataFlow.cs:189:39:189:41 | [output] delegate creation of type Func<String> |
+| GlobalDataFlow.cs:318:16:318:29 | "taint source" | GlobalDataFlow.cs:189:39:189:41 | [output] delegate creation of type Func<String> |
+| GlobalDataFlow.cs:318:16:318:29 | "taint source" | GlobalDataFlow.cs:318:16:318:29 | "taint source" |
 | GlobalDataFlow.cs:321:10:321:15 | this | GlobalDataFlow.cs:321:10:321:15 | this |
 | GlobalDataFlow.cs:323:9:323:26 | ... = ... | GlobalDataFlow.cs:323:9:323:26 | ... = ... |
-| GlobalDataFlow.cs:323:9:323:26 | SSA def(x) | GlobalDataFlow.cs:155:20:155:24 | SSA def(sink8) |
-| GlobalDataFlow.cs:323:9:323:26 | SSA def(x) | GlobalDataFlow.cs:155:20:155:24 | SSA def(sink8) |
+| GlobalDataFlow.cs:323:9:323:26 | SSA def(x) | GlobalDataFlow.cs:156:20:156:24 | SSA def(sink7) |
+| GlobalDataFlow.cs:323:9:323:26 | SSA def(x) | GlobalDataFlow.cs:156:20:156:24 | SSA def(sink7) |
 | GlobalDataFlow.cs:323:9:323:26 | SSA def(x) | GlobalDataFlow.cs:323:9:323:26 | SSA def(x) |
 | GlobalDataFlow.cs:323:13:323:26 | "taint source" | GlobalDataFlow.cs:323:9:323:26 | SSA def(x) |
 | GlobalDataFlow.cs:323:13:323:26 | "taint source" | GlobalDataFlow.cs:323:9:323:26 | SSA def(x) |
 | GlobalDataFlow.cs:323:13:323:26 | "taint source" | GlobalDataFlow.cs:323:13:323:26 | "taint source" |
-| GlobalDataFlow.cs:326:25:326:32 | this | GlobalDataFlow.cs:326:25:326:32 | this |
-| GlobalDataFlow.cs:328:22:328:23 | "" | GlobalDataFlow.cs:157:22:157:31 | call to method OutYield |
-| GlobalDataFlow.cs:328:22:328:23 | "" | GlobalDataFlow.cs:157:22:157:31 | call to method OutYield |
-| GlobalDataFlow.cs:328:22:328:23 | "" | GlobalDataFlow.cs:328:22:328:23 | "" |
-| GlobalDataFlow.cs:328:22:328:23 | "" | GlobalDataFlow.cs:328:22:328:23 | "" |
-| GlobalDataFlow.cs:328:22:328:23 | "" | GlobalDataFlow.cs:328:22:328:23 | "" |
-| GlobalDataFlow.cs:328:22:328:23 | "" | GlobalDataFlow.cs:328:22:328:23 | "" |
-| GlobalDataFlow.cs:329:22:329:35 | "taint source" | GlobalDataFlow.cs:157:22:157:31 | call to method OutYield |
-| GlobalDataFlow.cs:329:22:329:35 | "taint source" | GlobalDataFlow.cs:157:22:157:31 | call to method OutYield |
-| GlobalDataFlow.cs:329:22:329:35 | "taint source" | GlobalDataFlow.cs:329:22:329:35 | "taint source" |
-| GlobalDataFlow.cs:329:22:329:35 | "taint source" | GlobalDataFlow.cs:329:22:329:35 | "taint source" |
-| GlobalDataFlow.cs:329:22:329:35 | "taint source" | GlobalDataFlow.cs:329:22:329:35 | "taint source" |
-| GlobalDataFlow.cs:329:22:329:35 | "taint source" | GlobalDataFlow.cs:329:22:329:35 | "taint source" |
-| GlobalDataFlow.cs:330:22:330:23 | "" | GlobalDataFlow.cs:157:22:157:31 | call to method OutYield |
-| GlobalDataFlow.cs:330:22:330:23 | "" | GlobalDataFlow.cs:157:22:157:31 | call to method OutYield |
-| GlobalDataFlow.cs:330:22:330:23 | "" | GlobalDataFlow.cs:330:22:330:23 | "" |
-| GlobalDataFlow.cs:330:22:330:23 | "" | GlobalDataFlow.cs:330:22:330:23 | "" |
-| GlobalDataFlow.cs:330:22:330:23 | "" | GlobalDataFlow.cs:330:22:330:23 | "" |
-| GlobalDataFlow.cs:330:22:330:23 | "" | GlobalDataFlow.cs:330:22:330:23 | "" |
-| GlobalDataFlow.cs:333:12:333:17 | this | GlobalDataFlow.cs:333:12:333:17 | this |
-| GlobalDataFlow.cs:335:16:335:17 | "" | GlobalDataFlow.cs:163:20:163:27 | call to method NonOut |
-| GlobalDataFlow.cs:335:16:335:17 | "" | GlobalDataFlow.cs:163:20:163:27 | call to method NonOut |
-| GlobalDataFlow.cs:335:16:335:17 | "" | GlobalDataFlow.cs:189:37:189:42 | [output] delegate creation of type Func<String> |
-| GlobalDataFlow.cs:335:16:335:17 | "" | GlobalDataFlow.cs:189:37:189:42 | [output] delegate creation of type Func<String> |
-| GlobalDataFlow.cs:335:16:335:17 | "" | GlobalDataFlow.cs:335:16:335:17 | "" |
-| GlobalDataFlow.cs:338:10:338:18 | this | GlobalDataFlow.cs:338:10:338:18 | this |
-| GlobalDataFlow.cs:340:9:340:14 | ... = ... | GlobalDataFlow.cs:340:9:340:14 | ... = ... |
-| GlobalDataFlow.cs:340:9:340:14 | SSA def(x) | GlobalDataFlow.cs:165:23:165:30 | SSA def(nonSink0) |
-| GlobalDataFlow.cs:340:9:340:14 | SSA def(x) | GlobalDataFlow.cs:165:23:165:30 | SSA def(nonSink0) |
-| GlobalDataFlow.cs:340:9:340:14 | SSA def(x) | GlobalDataFlow.cs:340:9:340:14 | SSA def(x) |
-| GlobalDataFlow.cs:340:13:340:14 | "" | GlobalDataFlow.cs:340:9:340:14 | SSA def(x) |
-| GlobalDataFlow.cs:340:13:340:14 | "" | GlobalDataFlow.cs:340:9:340:14 | SSA def(x) |
-| GlobalDataFlow.cs:340:13:340:14 | "" | GlobalDataFlow.cs:340:13:340:14 | "" |
+| GlobalDataFlow.cs:326:10:326:15 | this | GlobalDataFlow.cs:326:10:326:15 | this |
+| GlobalDataFlow.cs:328:9:328:26 | ... = ... | GlobalDataFlow.cs:328:9:328:26 | ... = ... |
+| GlobalDataFlow.cs:328:9:328:26 | SSA def(x) | GlobalDataFlow.cs:159:20:159:24 | SSA def(sink8) |
+| GlobalDataFlow.cs:328:9:328:26 | SSA def(x) | GlobalDataFlow.cs:159:20:159:24 | SSA def(sink8) |
+| GlobalDataFlow.cs:328:9:328:26 | SSA def(x) | GlobalDataFlow.cs:328:9:328:26 | SSA def(x) |
+| GlobalDataFlow.cs:328:13:328:26 | "taint source" | GlobalDataFlow.cs:328:9:328:26 | SSA def(x) |
+| GlobalDataFlow.cs:328:13:328:26 | "taint source" | GlobalDataFlow.cs:328:9:328:26 | SSA def(x) |
+| GlobalDataFlow.cs:328:13:328:26 | "taint source" | GlobalDataFlow.cs:328:13:328:26 | "taint source" |
+| GlobalDataFlow.cs:331:25:331:32 | this | GlobalDataFlow.cs:331:25:331:32 | this |
+| GlobalDataFlow.cs:333:22:333:23 | "" | GlobalDataFlow.cs:161:22:161:31 | call to method OutYield |
+| GlobalDataFlow.cs:333:22:333:23 | "" | GlobalDataFlow.cs:161:22:161:31 | call to method OutYield |
+| GlobalDataFlow.cs:333:22:333:23 | "" | GlobalDataFlow.cs:333:22:333:23 | "" |
+| GlobalDataFlow.cs:333:22:333:23 | "" | GlobalDataFlow.cs:333:22:333:23 | "" |
+| GlobalDataFlow.cs:333:22:333:23 | "" | GlobalDataFlow.cs:333:22:333:23 | "" |
+| GlobalDataFlow.cs:333:22:333:23 | "" | GlobalDataFlow.cs:333:22:333:23 | "" |
+| GlobalDataFlow.cs:334:22:334:35 | "taint source" | GlobalDataFlow.cs:161:22:161:31 | call to method OutYield |
+| GlobalDataFlow.cs:334:22:334:35 | "taint source" | GlobalDataFlow.cs:161:22:161:31 | call to method OutYield |
+| GlobalDataFlow.cs:334:22:334:35 | "taint source" | GlobalDataFlow.cs:334:22:334:35 | "taint source" |
+| GlobalDataFlow.cs:334:22:334:35 | "taint source" | GlobalDataFlow.cs:334:22:334:35 | "taint source" |
+| GlobalDataFlow.cs:334:22:334:35 | "taint source" | GlobalDataFlow.cs:334:22:334:35 | "taint source" |
+| GlobalDataFlow.cs:334:22:334:35 | "taint source" | GlobalDataFlow.cs:334:22:334:35 | "taint source" |
+| GlobalDataFlow.cs:335:22:335:23 | "" | GlobalDataFlow.cs:161:22:161:31 | call to method OutYield |
+| GlobalDataFlow.cs:335:22:335:23 | "" | GlobalDataFlow.cs:161:22:161:31 | call to method OutYield |
+| GlobalDataFlow.cs:335:22:335:23 | "" | GlobalDataFlow.cs:335:22:335:23 | "" |
+| GlobalDataFlow.cs:335:22:335:23 | "" | GlobalDataFlow.cs:335:22:335:23 | "" |
+| GlobalDataFlow.cs:335:22:335:23 | "" | GlobalDataFlow.cs:335:22:335:23 | "" |
+| GlobalDataFlow.cs:335:22:335:23 | "" | GlobalDataFlow.cs:335:22:335:23 | "" |
+| GlobalDataFlow.cs:338:12:338:17 | this | GlobalDataFlow.cs:338:12:338:17 | this |
+| GlobalDataFlow.cs:340:16:340:17 | "" | GlobalDataFlow.cs:167:20:167:27 | call to method NonOut |
+| GlobalDataFlow.cs:340:16:340:17 | "" | GlobalDataFlow.cs:167:20:167:27 | call to method NonOut |
+| GlobalDataFlow.cs:340:16:340:17 | "" | GlobalDataFlow.cs:193:37:193:42 | [output] delegate creation of type Func<String> |
+| GlobalDataFlow.cs:340:16:340:17 | "" | GlobalDataFlow.cs:193:37:193:42 | [output] delegate creation of type Func<String> |
+| GlobalDataFlow.cs:340:16:340:17 | "" | GlobalDataFlow.cs:340:16:340:17 | "" |
 | GlobalDataFlow.cs:343:10:343:18 | this | GlobalDataFlow.cs:343:10:343:18 | this |
 | GlobalDataFlow.cs:345:9:345:14 | ... = ... | GlobalDataFlow.cs:345:9:345:14 | ... = ... |
-| GlobalDataFlow.cs:345:9:345:14 | SSA def(x) | GlobalDataFlow.cs:167:23:167:30 | SSA def(nonSink0) |
-| GlobalDataFlow.cs:345:9:345:14 | SSA def(x) | GlobalDataFlow.cs:167:23:167:30 | SSA def(nonSink0) |
+| GlobalDataFlow.cs:345:9:345:14 | SSA def(x) | GlobalDataFlow.cs:169:23:169:30 | SSA def(nonSink0) |
+| GlobalDataFlow.cs:345:9:345:14 | SSA def(x) | GlobalDataFlow.cs:169:23:169:30 | SSA def(nonSink0) |
 | GlobalDataFlow.cs:345:9:345:14 | SSA def(x) | GlobalDataFlow.cs:345:9:345:14 | SSA def(x) |
 | GlobalDataFlow.cs:345:13:345:14 | "" | GlobalDataFlow.cs:345:9:345:14 | SSA def(x) |
 | GlobalDataFlow.cs:345:13:345:14 | "" | GlobalDataFlow.cs:345:9:345:14 | SSA def(x) |
 | GlobalDataFlow.cs:345:13:345:14 | "" | GlobalDataFlow.cs:345:13:345:14 | "" |
-| GlobalDataFlow.cs:348:25:348:35 | this | GlobalDataFlow.cs:348:25:348:35 | this |
-| GlobalDataFlow.cs:350:22:350:23 | "" | GlobalDataFlow.cs:169:20:169:32 | call to method NonOutYield |
-| GlobalDataFlow.cs:350:22:350:23 | "" | GlobalDataFlow.cs:169:20:169:32 | call to method NonOutYield |
-| GlobalDataFlow.cs:350:22:350:23 | "" | GlobalDataFlow.cs:350:22:350:23 | "" |
-| GlobalDataFlow.cs:350:22:350:23 | "" | GlobalDataFlow.cs:350:22:350:23 | "" |
-| GlobalDataFlow.cs:350:22:350:23 | "" | GlobalDataFlow.cs:350:22:350:23 | "" |
-| GlobalDataFlow.cs:350:22:350:23 | "" | GlobalDataFlow.cs:350:22:350:23 | "" |
-| GlobalDataFlow.cs:351:22:351:23 | "" | GlobalDataFlow.cs:169:20:169:32 | call to method NonOutYield |
-| GlobalDataFlow.cs:351:22:351:23 | "" | GlobalDataFlow.cs:169:20:169:32 | call to method NonOutYield |
-| GlobalDataFlow.cs:351:22:351:23 | "" | GlobalDataFlow.cs:351:22:351:23 | "" |
-| GlobalDataFlow.cs:351:22:351:23 | "" | GlobalDataFlow.cs:351:22:351:23 | "" |
-| GlobalDataFlow.cs:351:22:351:23 | "" | GlobalDataFlow.cs:351:22:351:23 | "" |
-| GlobalDataFlow.cs:351:22:351:23 | "" | GlobalDataFlow.cs:351:22:351:23 | "" |
-| GlobalDataFlow.cs:354:36:354:36 | a | GlobalDataFlow.cs:354:36:354:36 | a |
-| GlobalDataFlow.cs:354:36:354:36 | a | GlobalDataFlow.cs:354:36:354:36 | a |
-| GlobalDataFlow.cs:354:36:354:36 | a | GlobalDataFlow.cs:354:36:354:36 | a |
-| GlobalDataFlow.cs:354:36:354:36 | a | GlobalDataFlow.cs:354:36:354:36 | a |
-| GlobalDataFlow.cs:354:36:354:36 | a | GlobalDataFlow.cs:356:9:356:9 | access to parameter a |
-| GlobalDataFlow.cs:354:36:354:36 | a | GlobalDataFlow.cs:356:9:356:9 | access to parameter a |
-| GlobalDataFlow.cs:354:36:354:36 | a | GlobalDataFlow.cs:356:9:356:9 | access to parameter a |
-| GlobalDataFlow.cs:354:36:354:36 | a | GlobalDataFlow.cs:356:9:356:9 | access to parameter a |
-| GlobalDataFlow.cs:354:36:354:36 | a | GlobalDataFlow.cs:356:9:356:9 | access to parameter a |
-| GlobalDataFlow.cs:354:36:354:36 | a | GlobalDataFlow.cs:356:9:356:9 | access to parameter a |
-| GlobalDataFlow.cs:354:36:354:36 | a | GlobalDataFlow.cs:356:9:356:9 | access to parameter a |
-| GlobalDataFlow.cs:354:36:354:36 | a | GlobalDataFlow.cs:356:9:356:9 | access to parameter a |
-| GlobalDataFlow.cs:354:36:354:36 | a | GlobalDataFlow.cs:356:9:356:9 | access to parameter a |
-| GlobalDataFlow.cs:354:36:354:36 | a | GlobalDataFlow.cs:356:9:356:9 | access to parameter a |
-| GlobalDataFlow.cs:354:41:354:41 | x | GlobalDataFlow.cs:354:41:354:41 | x |
-| GlobalDataFlow.cs:354:41:354:41 | x | GlobalDataFlow.cs:354:41:354:41 | x |
-| GlobalDataFlow.cs:354:41:354:41 | x | GlobalDataFlow.cs:354:41:354:41 | x |
-| GlobalDataFlow.cs:354:41:354:41 | x | GlobalDataFlow.cs:354:41:354:41 | x |
-| GlobalDataFlow.cs:354:41:354:41 | x | GlobalDataFlow.cs:356:11:356:11 | access to parameter x |
-| GlobalDataFlow.cs:354:41:354:41 | x | GlobalDataFlow.cs:356:11:356:11 | access to parameter x |
-| GlobalDataFlow.cs:354:41:354:41 | x | GlobalDataFlow.cs:356:11:356:11 | access to parameter x |
-| GlobalDataFlow.cs:354:41:354:41 | x | GlobalDataFlow.cs:356:11:356:11 | access to parameter x |
-| GlobalDataFlow.cs:354:41:354:41 | x | GlobalDataFlow.cs:356:11:356:11 | access to parameter x |
-| GlobalDataFlow.cs:354:41:354:41 | x | GlobalDataFlow.cs:356:11:356:11 | access to parameter x |
-| GlobalDataFlow.cs:354:41:354:41 | x | GlobalDataFlow.cs:356:11:356:11 | access to parameter x |
-| GlobalDataFlow.cs:354:41:354:41 | x | GlobalDataFlow.cs:356:11:356:11 | access to parameter x |
-| GlobalDataFlow.cs:354:41:354:41 | x | GlobalDataFlow.cs:356:11:356:11 | access to parameter x |
-| GlobalDataFlow.cs:354:41:354:41 | x | GlobalDataFlow.cs:356:11:356:11 | access to parameter x |
-| GlobalDataFlow.cs:356:9:356:9 | access to parameter a | GlobalDataFlow.cs:356:9:356:9 | access to parameter a |
-| GlobalDataFlow.cs:356:9:356:12 | delegate call | GlobalDataFlow.cs:356:9:356:12 | delegate call |
-| GlobalDataFlow.cs:356:11:356:11 | access to parameter x | GlobalDataFlow.cs:53:15:53:15 | x |
-| GlobalDataFlow.cs:356:11:356:11 | access to parameter x | GlobalDataFlow.cs:53:15:53:15 | x |
-| GlobalDataFlow.cs:356:11:356:11 | access to parameter x | GlobalDataFlow.cs:53:15:53:15 | x |
-| GlobalDataFlow.cs:356:11:356:11 | access to parameter x | GlobalDataFlow.cs:53:15:53:15 | x |
-| GlobalDataFlow.cs:356:11:356:11 | access to parameter x | GlobalDataFlow.cs:60:15:60:27 | nonSinkParam0 |
-| GlobalDataFlow.cs:356:11:356:11 | access to parameter x | GlobalDataFlow.cs:60:15:60:27 | nonSinkParam0 |
-| GlobalDataFlow.cs:356:11:356:11 | access to parameter x | GlobalDataFlow.cs:60:15:60:27 | nonSinkParam0 |
-| GlobalDataFlow.cs:356:11:356:11 | access to parameter x | GlobalDataFlow.cs:60:15:60:27 | nonSinkParam0 |
-| GlobalDataFlow.cs:356:11:356:11 | access to parameter x | GlobalDataFlow.cs:241:26:241:35 | sinkParam3 |
-| GlobalDataFlow.cs:356:11:356:11 | access to parameter x | GlobalDataFlow.cs:241:26:241:35 | sinkParam3 |
-| GlobalDataFlow.cs:356:11:356:11 | access to parameter x | GlobalDataFlow.cs:241:26:241:35 | sinkParam3 |
-| GlobalDataFlow.cs:356:11:356:11 | access to parameter x | GlobalDataFlow.cs:241:26:241:35 | sinkParam3 |
-| GlobalDataFlow.cs:356:11:356:11 | access to parameter x | GlobalDataFlow.cs:356:11:356:11 | access to parameter x |
-| GlobalDataFlow.cs:359:41:359:41 | f | GlobalDataFlow.cs:359:41:359:41 | f |
-| GlobalDataFlow.cs:359:41:359:41 | f | GlobalDataFlow.cs:359:41:359:41 | f |
-| GlobalDataFlow.cs:359:41:359:41 | f | GlobalDataFlow.cs:359:41:359:41 | f |
-| GlobalDataFlow.cs:359:41:359:41 | f | GlobalDataFlow.cs:359:41:359:41 | f |
-| GlobalDataFlow.cs:359:41:359:41 | f | GlobalDataFlow.cs:361:16:361:16 | access to parameter f |
-| GlobalDataFlow.cs:359:41:359:41 | f | GlobalDataFlow.cs:361:16:361:16 | access to parameter f |
-| GlobalDataFlow.cs:359:41:359:41 | f | GlobalDataFlow.cs:361:16:361:16 | access to parameter f |
-| GlobalDataFlow.cs:359:41:359:41 | f | GlobalDataFlow.cs:361:16:361:16 | access to parameter f |
-| GlobalDataFlow.cs:359:41:359:41 | f | GlobalDataFlow.cs:361:16:361:16 | access to parameter f |
-| GlobalDataFlow.cs:359:41:359:41 | f | GlobalDataFlow.cs:361:16:361:16 | access to parameter f |
-| GlobalDataFlow.cs:359:41:359:41 | f | GlobalDataFlow.cs:361:16:361:16 | access to parameter f |
-| GlobalDataFlow.cs:359:41:359:41 | f | GlobalDataFlow.cs:361:16:361:16 | access to parameter f |
-| GlobalDataFlow.cs:359:41:359:41 | f | GlobalDataFlow.cs:361:16:361:16 | access to parameter f |
-| GlobalDataFlow.cs:359:41:359:41 | f | GlobalDataFlow.cs:361:16:361:16 | access to parameter f |
-| GlobalDataFlow.cs:359:41:359:41 | f | GlobalDataFlow.cs:361:16:361:16 | access to parameter f |
-| GlobalDataFlow.cs:359:41:359:41 | f | GlobalDataFlow.cs:361:16:361:16 | access to parameter f |
-| GlobalDataFlow.cs:359:41:359:41 | f | GlobalDataFlow.cs:361:16:361:16 | access to parameter f |
-| GlobalDataFlow.cs:359:41:359:41 | f | GlobalDataFlow.cs:361:16:361:16 | access to parameter f |
-| GlobalDataFlow.cs:359:46:359:46 | x | GlobalDataFlow.cs:359:46:359:46 | x |
-| GlobalDataFlow.cs:359:46:359:46 | x | GlobalDataFlow.cs:359:46:359:46 | x |
-| GlobalDataFlow.cs:359:46:359:46 | x | GlobalDataFlow.cs:359:46:359:46 | x |
-| GlobalDataFlow.cs:359:46:359:46 | x | GlobalDataFlow.cs:359:46:359:46 | x |
-| GlobalDataFlow.cs:359:46:359:46 | x | GlobalDataFlow.cs:361:18:361:18 | access to parameter x |
-| GlobalDataFlow.cs:359:46:359:46 | x | GlobalDataFlow.cs:361:18:361:18 | access to parameter x |
-| GlobalDataFlow.cs:359:46:359:46 | x | GlobalDataFlow.cs:361:18:361:18 | access to parameter x |
-| GlobalDataFlow.cs:359:46:359:46 | x | GlobalDataFlow.cs:361:18:361:18 | access to parameter x |
-| GlobalDataFlow.cs:359:46:359:46 | x | GlobalDataFlow.cs:361:18:361:18 | access to parameter x |
-| GlobalDataFlow.cs:359:46:359:46 | x | GlobalDataFlow.cs:361:18:361:18 | access to parameter x |
-| GlobalDataFlow.cs:359:46:359:46 | x | GlobalDataFlow.cs:361:18:361:18 | access to parameter x |
-| GlobalDataFlow.cs:359:46:359:46 | x | GlobalDataFlow.cs:361:18:361:18 | access to parameter x |
-| GlobalDataFlow.cs:359:46:359:46 | x | GlobalDataFlow.cs:361:18:361:18 | access to parameter x |
-| GlobalDataFlow.cs:359:46:359:46 | x | GlobalDataFlow.cs:361:18:361:18 | access to parameter x |
-| GlobalDataFlow.cs:359:46:359:46 | x | GlobalDataFlow.cs:361:18:361:18 | access to parameter x |
-| GlobalDataFlow.cs:359:46:359:46 | x | GlobalDataFlow.cs:361:18:361:18 | access to parameter x |
-| GlobalDataFlow.cs:359:46:359:46 | x | GlobalDataFlow.cs:361:18:361:18 | access to parameter x |
-| GlobalDataFlow.cs:359:46:359:46 | x | GlobalDataFlow.cs:361:18:361:18 | access to parameter x |
-| GlobalDataFlow.cs:361:16:361:16 | access to parameter f | GlobalDataFlow.cs:361:16:361:16 | access to parameter f |
-| GlobalDataFlow.cs:361:16:361:19 | delegate call | GlobalDataFlow.cs:130:45:130:64 | call to method ApplyFunc |
-| GlobalDataFlow.cs:361:16:361:19 | delegate call | GlobalDataFlow.cs:130:45:130:64 | call to method ApplyFunc |
-| GlobalDataFlow.cs:361:16:361:19 | delegate call | GlobalDataFlow.cs:130:45:130:64 | call to method ApplyFunc |
-| GlobalDataFlow.cs:361:16:361:19 | delegate call | GlobalDataFlow.cs:130:45:130:64 | call to method ApplyFunc |
-| GlobalDataFlow.cs:361:16:361:19 | delegate call | GlobalDataFlow.cs:139:21:139:44 | call to method ApplyFunc |
-| GlobalDataFlow.cs:361:16:361:19 | delegate call | GlobalDataFlow.cs:139:21:139:44 | call to method ApplyFunc |
-| GlobalDataFlow.cs:361:16:361:19 | delegate call | GlobalDataFlow.cs:139:21:139:44 | call to method ApplyFunc |
-| GlobalDataFlow.cs:361:16:361:19 | delegate call | GlobalDataFlow.cs:139:21:139:44 | call to method ApplyFunc |
-| GlobalDataFlow.cs:361:16:361:19 | delegate call | GlobalDataFlow.cs:143:20:143:40 | call to method ApplyFunc |
-| GlobalDataFlow.cs:361:16:361:19 | delegate call | GlobalDataFlow.cs:143:20:143:40 | call to method ApplyFunc |
-| GlobalDataFlow.cs:361:16:361:19 | delegate call | GlobalDataFlow.cs:143:20:143:40 | call to method ApplyFunc |
-| GlobalDataFlow.cs:361:16:361:19 | delegate call | GlobalDataFlow.cs:143:20:143:40 | call to method ApplyFunc |
-| GlobalDataFlow.cs:361:16:361:19 | delegate call | GlobalDataFlow.cs:145:20:145:44 | call to method ApplyFunc |
-| GlobalDataFlow.cs:361:16:361:19 | delegate call | GlobalDataFlow.cs:145:20:145:44 | call to method ApplyFunc |
-| GlobalDataFlow.cs:361:16:361:19 | delegate call | GlobalDataFlow.cs:145:20:145:44 | call to method ApplyFunc |
-| GlobalDataFlow.cs:361:16:361:19 | delegate call | GlobalDataFlow.cs:145:20:145:44 | call to method ApplyFunc |
-| GlobalDataFlow.cs:361:16:361:19 | delegate call | GlobalDataFlow.cs:273:17:273:38 | call to method ApplyFunc |
-| GlobalDataFlow.cs:361:16:361:19 | delegate call | GlobalDataFlow.cs:273:17:273:38 | call to method ApplyFunc |
-| GlobalDataFlow.cs:361:16:361:19 | delegate call | GlobalDataFlow.cs:273:17:273:38 | call to method ApplyFunc |
-| GlobalDataFlow.cs:361:16:361:19 | delegate call | GlobalDataFlow.cs:273:17:273:38 | call to method ApplyFunc |
-| GlobalDataFlow.cs:361:16:361:19 | delegate call | GlobalDataFlow.cs:361:16:361:19 | delegate call |
-| GlobalDataFlow.cs:361:18:361:18 | access to parameter x | GlobalDataFlow.cs:271:26:271:26 | x |
-| GlobalDataFlow.cs:361:18:361:18 | access to parameter x | GlobalDataFlow.cs:271:26:271:26 | x |
-| GlobalDataFlow.cs:361:18:361:18 | access to parameter x | GlobalDataFlow.cs:271:26:271:26 | x |
-| GlobalDataFlow.cs:361:18:361:18 | access to parameter x | GlobalDataFlow.cs:271:26:271:26 | x |
-| GlobalDataFlow.cs:361:18:361:18 | access to parameter x | GlobalDataFlow.cs:271:26:271:26 | x |
-| GlobalDataFlow.cs:361:18:361:18 | access to parameter x | GlobalDataFlow.cs:271:26:271:26 | x |
-| GlobalDataFlow.cs:361:18:361:18 | access to parameter x | GlobalDataFlow.cs:271:26:271:26 | x |
-| GlobalDataFlow.cs:361:18:361:18 | access to parameter x | GlobalDataFlow.cs:271:26:271:26 | x |
-| GlobalDataFlow.cs:361:18:361:18 | access to parameter x | GlobalDataFlow.cs:273:27:273:28 | x0 |
-| GlobalDataFlow.cs:361:18:361:18 | access to parameter x | GlobalDataFlow.cs:273:27:273:28 | x0 |
-| GlobalDataFlow.cs:361:18:361:18 | access to parameter x | GlobalDataFlow.cs:273:27:273:28 | x0 |
-| GlobalDataFlow.cs:361:18:361:18 | access to parameter x | GlobalDataFlow.cs:273:27:273:28 | x0 |
-| GlobalDataFlow.cs:361:18:361:18 | access to parameter x | GlobalDataFlow.cs:361:16:361:19 | delegate call |
-| GlobalDataFlow.cs:361:18:361:18 | access to parameter x | GlobalDataFlow.cs:361:16:361:19 | delegate call |
-| GlobalDataFlow.cs:361:18:361:18 | access to parameter x | GlobalDataFlow.cs:361:16:361:19 | delegate call |
-| GlobalDataFlow.cs:361:18:361:18 | access to parameter x | GlobalDataFlow.cs:361:16:361:19 | delegate call |
-| GlobalDataFlow.cs:361:18:361:18 | access to parameter x | GlobalDataFlow.cs:361:16:361:19 | delegate call |
-| GlobalDataFlow.cs:361:18:361:18 | access to parameter x | GlobalDataFlow.cs:361:16:361:19 | delegate call |
-| GlobalDataFlow.cs:361:18:361:18 | access to parameter x | GlobalDataFlow.cs:361:16:361:19 | delegate call |
-| GlobalDataFlow.cs:361:18:361:18 | access to parameter x | GlobalDataFlow.cs:361:16:361:19 | delegate call |
-| GlobalDataFlow.cs:361:18:361:18 | access to parameter x | GlobalDataFlow.cs:361:16:361:19 | delegate call |
-| GlobalDataFlow.cs:361:18:361:18 | access to parameter x | GlobalDataFlow.cs:361:16:361:19 | delegate call |
-| GlobalDataFlow.cs:361:18:361:18 | access to parameter x | GlobalDataFlow.cs:361:18:361:18 | access to parameter x |
-| GlobalDataFlow.cs:368:42:368:42 | a | GlobalDataFlow.cs:368:42:368:42 | a |
-| GlobalDataFlow.cs:368:42:368:42 | a | GlobalDataFlow.cs:368:42:368:42 | a |
-| GlobalDataFlow.cs:368:42:368:42 | a | GlobalDataFlow.cs:368:42:368:42 | a |
-| GlobalDataFlow.cs:368:42:368:42 | a | GlobalDataFlow.cs:368:42:368:42 | a |
-| GlobalDataFlow.cs:368:42:368:42 | a | GlobalDataFlow.cs:370:9:370:9 | access to parameter a |
-| GlobalDataFlow.cs:368:42:368:42 | a | GlobalDataFlow.cs:370:9:370:9 | access to parameter a |
-| GlobalDataFlow.cs:368:42:368:42 | a | GlobalDataFlow.cs:370:9:370:9 | access to parameter a |
-| GlobalDataFlow.cs:368:42:368:42 | a | GlobalDataFlow.cs:370:9:370:9 | access to parameter a |
-| GlobalDataFlow.cs:368:42:368:42 | a | GlobalDataFlow.cs:370:9:370:9 | access to parameter a |
-| GlobalDataFlow.cs:368:42:368:42 | a | GlobalDataFlow.cs:370:9:370:9 | access to parameter a |
-| GlobalDataFlow.cs:368:42:368:42 | a | GlobalDataFlow.cs:370:9:370:9 | access to parameter a |
-| GlobalDataFlow.cs:368:42:368:42 | a | GlobalDataFlow.cs:370:9:370:9 | access to parameter a |
-| GlobalDataFlow.cs:368:42:368:42 | a | GlobalDataFlow.cs:370:9:370:9 | access to parameter a |
-| GlobalDataFlow.cs:368:42:368:42 | a | GlobalDataFlow.cs:370:9:370:9 | access to parameter a |
-| GlobalDataFlow.cs:368:42:368:42 | a | GlobalDataFlow.cs:370:9:370:9 | access to parameter a |
-| GlobalDataFlow.cs:368:42:368:42 | a | GlobalDataFlow.cs:370:9:370:9 | access to parameter a |
-| GlobalDataFlow.cs:368:52:368:52 | x | GlobalDataFlow.cs:368:52:368:52 | x |
-| GlobalDataFlow.cs:368:52:368:52 | x | GlobalDataFlow.cs:368:52:368:52 | x |
-| GlobalDataFlow.cs:368:52:368:52 | x | GlobalDataFlow.cs:368:52:368:52 | x |
-| GlobalDataFlow.cs:368:52:368:52 | x | GlobalDataFlow.cs:368:52:368:52 | x |
-| GlobalDataFlow.cs:368:52:368:52 | x | GlobalDataFlow.cs:370:11:370:11 | access to parameter x |
-| GlobalDataFlow.cs:368:52:368:52 | x | GlobalDataFlow.cs:370:11:370:11 | access to parameter x |
-| GlobalDataFlow.cs:368:52:368:52 | x | GlobalDataFlow.cs:370:11:370:11 | access to parameter x |
-| GlobalDataFlow.cs:368:52:368:52 | x | GlobalDataFlow.cs:370:11:370:11 | access to parameter x |
-| GlobalDataFlow.cs:368:52:368:52 | x | GlobalDataFlow.cs:370:11:370:11 | access to parameter x |
-| GlobalDataFlow.cs:368:52:368:52 | x | GlobalDataFlow.cs:370:11:370:11 | access to parameter x |
-| GlobalDataFlow.cs:368:52:368:52 | x | GlobalDataFlow.cs:370:11:370:11 | access to parameter x |
-| GlobalDataFlow.cs:368:52:368:52 | x | GlobalDataFlow.cs:370:11:370:11 | access to parameter x |
-| GlobalDataFlow.cs:368:52:368:52 | x | GlobalDataFlow.cs:370:11:370:11 | access to parameter x |
-| GlobalDataFlow.cs:368:52:368:52 | x | GlobalDataFlow.cs:370:11:370:11 | access to parameter x |
-| GlobalDataFlow.cs:368:52:368:52 | x | GlobalDataFlow.cs:370:11:370:11 | access to parameter x |
-| GlobalDataFlow.cs:368:52:368:52 | x | GlobalDataFlow.cs:370:11:370:11 | access to parameter x |
-| GlobalDataFlow.cs:370:9:370:9 | access to parameter a | GlobalDataFlow.cs:370:9:370:9 | access to parameter a |
-| GlobalDataFlow.cs:370:9:370:12 | delegate call | GlobalDataFlow.cs:370:9:370:12 | delegate call |
-| GlobalDataFlow.cs:370:11:370:11 | access to parameter x | GlobalDataFlow.cs:56:37:56:37 | x |
-| GlobalDataFlow.cs:370:11:370:11 | access to parameter x | GlobalDataFlow.cs:56:37:56:37 | x |
-| GlobalDataFlow.cs:370:11:370:11 | access to parameter x | GlobalDataFlow.cs:56:37:56:37 | x |
-| GlobalDataFlow.cs:370:11:370:11 | access to parameter x | GlobalDataFlow.cs:56:37:56:37 | x |
-| GlobalDataFlow.cs:370:11:370:11 | access to parameter x | GlobalDataFlow.cs:61:38:61:50 | nonSinkParam0 |
-| GlobalDataFlow.cs:370:11:370:11 | access to parameter x | GlobalDataFlow.cs:61:38:61:50 | nonSinkParam0 |
-| GlobalDataFlow.cs:370:11:370:11 | access to parameter x | GlobalDataFlow.cs:61:38:61:50 | nonSinkParam0 |
-| GlobalDataFlow.cs:370:11:370:11 | access to parameter x | GlobalDataFlow.cs:61:38:61:50 | nonSinkParam0 |
-| GlobalDataFlow.cs:370:11:370:11 | access to parameter x | GlobalDataFlow.cs:251:26:251:35 | sinkParam5 |
-| GlobalDataFlow.cs:370:11:370:11 | access to parameter x | GlobalDataFlow.cs:251:26:251:35 | sinkParam5 |
-| GlobalDataFlow.cs:370:11:370:11 | access to parameter x | GlobalDataFlow.cs:251:26:251:35 | sinkParam5 |
-| GlobalDataFlow.cs:370:11:370:11 | access to parameter x | GlobalDataFlow.cs:251:26:251:35 | sinkParam5 |
-| GlobalDataFlow.cs:370:11:370:11 | access to parameter x | GlobalDataFlow.cs:256:26:256:35 | sinkParam6 |
-| GlobalDataFlow.cs:370:11:370:11 | access to parameter x | GlobalDataFlow.cs:256:26:256:35 | sinkParam6 |
-| GlobalDataFlow.cs:370:11:370:11 | access to parameter x | GlobalDataFlow.cs:256:26:256:35 | sinkParam6 |
-| GlobalDataFlow.cs:370:11:370:11 | access to parameter x | GlobalDataFlow.cs:256:26:256:35 | sinkParam6 |
-| GlobalDataFlow.cs:370:11:370:11 | access to parameter x | GlobalDataFlow.cs:370:11:370:11 | access to parameter x |
-| GlobalDataFlow.cs:373:39:373:45 | tainted | GlobalDataFlow.cs:373:39:373:45 | tainted |
-| GlobalDataFlow.cs:373:39:373:45 | tainted | GlobalDataFlow.cs:373:39:373:45 | tainted |
-| GlobalDataFlow.cs:373:39:373:45 | tainted | GlobalDataFlow.cs:373:39:373:45 | tainted |
-| GlobalDataFlow.cs:373:39:373:45 | tainted | GlobalDataFlow.cs:373:39:373:45 | tainted |
-| GlobalDataFlow.cs:373:39:373:45 | tainted | GlobalDataFlow.cs:375:13:375:28 | SSA def(sink11) |
-| GlobalDataFlow.cs:373:39:373:45 | tainted | GlobalDataFlow.cs:375:13:375:28 | SSA def(sink11) |
-| GlobalDataFlow.cs:373:39:373:45 | tainted | GlobalDataFlow.cs:375:13:375:28 | SSA def(sink11) |
-| GlobalDataFlow.cs:373:39:373:45 | tainted | GlobalDataFlow.cs:375:13:375:28 | SSA def(sink11) |
-| GlobalDataFlow.cs:373:39:373:45 | tainted | GlobalDataFlow.cs:375:13:375:28 | SSA def(sink11) |
-| GlobalDataFlow.cs:373:39:373:45 | tainted | GlobalDataFlow.cs:375:13:375:28 | SSA def(sink11) |
-| GlobalDataFlow.cs:373:39:373:45 | tainted | GlobalDataFlow.cs:375:22:375:28 | access to parameter tainted |
-| GlobalDataFlow.cs:373:39:373:45 | tainted | GlobalDataFlow.cs:375:22:375:28 | access to parameter tainted |
-| GlobalDataFlow.cs:373:39:373:45 | tainted | GlobalDataFlow.cs:375:22:375:28 | access to parameter tainted |
-| GlobalDataFlow.cs:373:39:373:45 | tainted | GlobalDataFlow.cs:375:22:375:28 | access to parameter tainted |
-| GlobalDataFlow.cs:373:39:373:45 | tainted | GlobalDataFlow.cs:375:22:375:28 | access to parameter tainted |
-| GlobalDataFlow.cs:373:39:373:45 | tainted | GlobalDataFlow.cs:375:22:375:28 | access to parameter tainted |
-| GlobalDataFlow.cs:373:39:373:45 | tainted | GlobalDataFlow.cs:376:15:376:20 | access to local variable sink11 |
-| GlobalDataFlow.cs:373:39:373:45 | tainted | GlobalDataFlow.cs:376:15:376:20 | access to local variable sink11 |
-| GlobalDataFlow.cs:373:39:373:45 | tainted | GlobalDataFlow.cs:376:15:376:20 | access to local variable sink11 |
-| GlobalDataFlow.cs:373:39:373:45 | tainted | GlobalDataFlow.cs:376:15:376:20 | access to local variable sink11 |
-| GlobalDataFlow.cs:373:39:373:45 | tainted | GlobalDataFlow.cs:376:15:376:20 | access to local variable sink11 |
-| GlobalDataFlow.cs:373:39:373:45 | tainted | GlobalDataFlow.cs:376:15:376:20 | access to local variable sink11 |
-| GlobalDataFlow.cs:373:39:373:45 | tainted | GlobalDataFlow.cs:377:16:377:21 | access to local variable sink11 |
-| GlobalDataFlow.cs:373:39:373:45 | tainted | GlobalDataFlow.cs:377:16:377:21 | access to local variable sink11 |
-| GlobalDataFlow.cs:373:39:373:45 | tainted | GlobalDataFlow.cs:377:16:377:21 | access to local variable sink11 |
-| GlobalDataFlow.cs:373:39:373:45 | tainted | GlobalDataFlow.cs:377:16:377:21 | access to local variable sink11 |
-| GlobalDataFlow.cs:373:39:373:45 | tainted | GlobalDataFlow.cs:377:16:377:21 | access to local variable sink11 |
-| GlobalDataFlow.cs:373:39:373:45 | tainted | GlobalDataFlow.cs:377:16:377:21 | access to local variable sink11 |
-| GlobalDataFlow.cs:375:13:375:28 | SSA def(sink11) | GlobalDataFlow.cs:375:13:375:28 | SSA def(sink11) |
-| GlobalDataFlow.cs:375:13:375:28 | SSA def(sink11) | GlobalDataFlow.cs:376:15:376:20 | access to local variable sink11 |
-| GlobalDataFlow.cs:375:13:375:28 | SSA def(sink11) | GlobalDataFlow.cs:376:15:376:20 | access to local variable sink11 |
-| GlobalDataFlow.cs:375:13:375:28 | SSA def(sink11) | GlobalDataFlow.cs:376:15:376:20 | access to local variable sink11 |
-| GlobalDataFlow.cs:375:13:375:28 | SSA def(sink11) | GlobalDataFlow.cs:376:15:376:20 | access to local variable sink11 |
-| GlobalDataFlow.cs:375:13:375:28 | SSA def(sink11) | GlobalDataFlow.cs:377:16:377:21 | access to local variable sink11 |
-| GlobalDataFlow.cs:375:13:375:28 | SSA def(sink11) | GlobalDataFlow.cs:377:16:377:21 | access to local variable sink11 |
-| GlobalDataFlow.cs:375:13:375:28 | SSA def(sink11) | GlobalDataFlow.cs:377:16:377:21 | access to local variable sink11 |
-| GlobalDataFlow.cs:375:13:375:28 | SSA def(sink11) | GlobalDataFlow.cs:377:16:377:21 | access to local variable sink11 |
-| GlobalDataFlow.cs:375:13:375:28 | String sink11 = ... | GlobalDataFlow.cs:375:13:375:28 | String sink11 = ... |
-| GlobalDataFlow.cs:375:22:375:28 | access to parameter tainted | GlobalDataFlow.cs:375:13:375:28 | SSA def(sink11) |
-| GlobalDataFlow.cs:375:22:375:28 | access to parameter tainted | GlobalDataFlow.cs:375:13:375:28 | SSA def(sink11) |
-| GlobalDataFlow.cs:375:22:375:28 | access to parameter tainted | GlobalDataFlow.cs:375:13:375:28 | SSA def(sink11) |
-| GlobalDataFlow.cs:375:22:375:28 | access to parameter tainted | GlobalDataFlow.cs:375:13:375:28 | SSA def(sink11) |
-| GlobalDataFlow.cs:375:22:375:28 | access to parameter tainted | GlobalDataFlow.cs:375:22:375:28 | access to parameter tainted |
-| GlobalDataFlow.cs:375:22:375:28 | access to parameter tainted | GlobalDataFlow.cs:376:15:376:20 | access to local variable sink11 |
-| GlobalDataFlow.cs:375:22:375:28 | access to parameter tainted | GlobalDataFlow.cs:376:15:376:20 | access to local variable sink11 |
-| GlobalDataFlow.cs:375:22:375:28 | access to parameter tainted | GlobalDataFlow.cs:376:15:376:20 | access to local variable sink11 |
-| GlobalDataFlow.cs:375:22:375:28 | access to parameter tainted | GlobalDataFlow.cs:376:15:376:20 | access to local variable sink11 |
-| GlobalDataFlow.cs:375:22:375:28 | access to parameter tainted | GlobalDataFlow.cs:377:16:377:21 | access to local variable sink11 |
-| GlobalDataFlow.cs:375:22:375:28 | access to parameter tainted | GlobalDataFlow.cs:377:16:377:21 | access to local variable sink11 |
-| GlobalDataFlow.cs:375:22:375:28 | access to parameter tainted | GlobalDataFlow.cs:377:16:377:21 | access to local variable sink11 |
-| GlobalDataFlow.cs:375:22:375:28 | access to parameter tainted | GlobalDataFlow.cs:377:16:377:21 | access to local variable sink11 |
-| GlobalDataFlow.cs:376:9:376:21 | call to method Check | GlobalDataFlow.cs:376:9:376:21 | call to method Check |
-| GlobalDataFlow.cs:376:15:376:20 | access to local variable sink11 | GlobalDataFlow.cs:376:15:376:20 | access to local variable sink11 |
-| GlobalDataFlow.cs:376:15:376:20 | access to local variable sink11 | GlobalDataFlow.cs:377:16:377:21 | access to local variable sink11 |
-| GlobalDataFlow.cs:376:15:376:20 | access to local variable sink11 | GlobalDataFlow.cs:377:16:377:21 | access to local variable sink11 |
-| GlobalDataFlow.cs:376:15:376:20 | access to local variable sink11 | GlobalDataFlow.cs:377:16:377:21 | access to local variable sink11 |
-| GlobalDataFlow.cs:376:15:376:20 | access to local variable sink11 | GlobalDataFlow.cs:377:16:377:21 | access to local variable sink11 |
-| GlobalDataFlow.cs:377:16:377:21 | access to local variable sink11 | GlobalDataFlow.cs:159:22:159:43 | call to method TaintedParam |
-| GlobalDataFlow.cs:377:16:377:21 | access to local variable sink11 | GlobalDataFlow.cs:159:22:159:43 | call to method TaintedParam |
-| GlobalDataFlow.cs:377:16:377:21 | access to local variable sink11 | GlobalDataFlow.cs:377:16:377:21 | access to local variable sink11 |
-| GlobalDataFlow.cs:380:42:380:51 | nonTainted | GlobalDataFlow.cs:380:42:380:51 | nonTainted |
-| GlobalDataFlow.cs:380:42:380:51 | nonTainted | GlobalDataFlow.cs:380:42:380:51 | nonTainted |
-| GlobalDataFlow.cs:380:42:380:51 | nonTainted | GlobalDataFlow.cs:380:42:380:51 | nonTainted |
-| GlobalDataFlow.cs:380:42:380:51 | nonTainted | GlobalDataFlow.cs:380:42:380:51 | nonTainted |
-| GlobalDataFlow.cs:380:42:380:51 | nonTainted | GlobalDataFlow.cs:382:13:382:33 | SSA def(nonSink0) |
-| GlobalDataFlow.cs:380:42:380:51 | nonTainted | GlobalDataFlow.cs:382:13:382:33 | SSA def(nonSink0) |
-| GlobalDataFlow.cs:380:42:380:51 | nonTainted | GlobalDataFlow.cs:382:13:382:33 | SSA def(nonSink0) |
-| GlobalDataFlow.cs:380:42:380:51 | nonTainted | GlobalDataFlow.cs:382:13:382:33 | SSA def(nonSink0) |
-| GlobalDataFlow.cs:380:42:380:51 | nonTainted | GlobalDataFlow.cs:382:13:382:33 | SSA def(nonSink0) |
-| GlobalDataFlow.cs:380:42:380:51 | nonTainted | GlobalDataFlow.cs:382:13:382:33 | SSA def(nonSink0) |
-| GlobalDataFlow.cs:380:42:380:51 | nonTainted | GlobalDataFlow.cs:382:24:382:33 | access to parameter nonTainted |
-| GlobalDataFlow.cs:380:42:380:51 | nonTainted | GlobalDataFlow.cs:382:24:382:33 | access to parameter nonTainted |
-| GlobalDataFlow.cs:380:42:380:51 | nonTainted | GlobalDataFlow.cs:382:24:382:33 | access to parameter nonTainted |
-| GlobalDataFlow.cs:380:42:380:51 | nonTainted | GlobalDataFlow.cs:382:24:382:33 | access to parameter nonTainted |
-| GlobalDataFlow.cs:380:42:380:51 | nonTainted | GlobalDataFlow.cs:382:24:382:33 | access to parameter nonTainted |
-| GlobalDataFlow.cs:380:42:380:51 | nonTainted | GlobalDataFlow.cs:382:24:382:33 | access to parameter nonTainted |
-| GlobalDataFlow.cs:380:42:380:51 | nonTainted | GlobalDataFlow.cs:383:15:383:22 | access to local variable nonSink0 |
-| GlobalDataFlow.cs:380:42:380:51 | nonTainted | GlobalDataFlow.cs:383:15:383:22 | access to local variable nonSink0 |
-| GlobalDataFlow.cs:380:42:380:51 | nonTainted | GlobalDataFlow.cs:383:15:383:22 | access to local variable nonSink0 |
-| GlobalDataFlow.cs:380:42:380:51 | nonTainted | GlobalDataFlow.cs:383:15:383:22 | access to local variable nonSink0 |
-| GlobalDataFlow.cs:380:42:380:51 | nonTainted | GlobalDataFlow.cs:383:15:383:22 | access to local variable nonSink0 |
-| GlobalDataFlow.cs:380:42:380:51 | nonTainted | GlobalDataFlow.cs:383:15:383:22 | access to local variable nonSink0 |
-| GlobalDataFlow.cs:380:42:380:51 | nonTainted | GlobalDataFlow.cs:384:16:384:23 | access to local variable nonSink0 |
-| GlobalDataFlow.cs:380:42:380:51 | nonTainted | GlobalDataFlow.cs:384:16:384:23 | access to local variable nonSink0 |
-| GlobalDataFlow.cs:380:42:380:51 | nonTainted | GlobalDataFlow.cs:384:16:384:23 | access to local variable nonSink0 |
-| GlobalDataFlow.cs:380:42:380:51 | nonTainted | GlobalDataFlow.cs:384:16:384:23 | access to local variable nonSink0 |
-| GlobalDataFlow.cs:380:42:380:51 | nonTainted | GlobalDataFlow.cs:384:16:384:23 | access to local variable nonSink0 |
-| GlobalDataFlow.cs:380:42:380:51 | nonTainted | GlobalDataFlow.cs:384:16:384:23 | access to local variable nonSink0 |
-| GlobalDataFlow.cs:382:13:382:33 | SSA def(nonSink0) | GlobalDataFlow.cs:382:13:382:33 | SSA def(nonSink0) |
-| GlobalDataFlow.cs:382:13:382:33 | SSA def(nonSink0) | GlobalDataFlow.cs:383:15:383:22 | access to local variable nonSink0 |
-| GlobalDataFlow.cs:382:13:382:33 | SSA def(nonSink0) | GlobalDataFlow.cs:383:15:383:22 | access to local variable nonSink0 |
-| GlobalDataFlow.cs:382:13:382:33 | SSA def(nonSink0) | GlobalDataFlow.cs:383:15:383:22 | access to local variable nonSink0 |
-| GlobalDataFlow.cs:382:13:382:33 | SSA def(nonSink0) | GlobalDataFlow.cs:383:15:383:22 | access to local variable nonSink0 |
-| GlobalDataFlow.cs:382:13:382:33 | SSA def(nonSink0) | GlobalDataFlow.cs:384:16:384:23 | access to local variable nonSink0 |
-| GlobalDataFlow.cs:382:13:382:33 | SSA def(nonSink0) | GlobalDataFlow.cs:384:16:384:23 | access to local variable nonSink0 |
-| GlobalDataFlow.cs:382:13:382:33 | SSA def(nonSink0) | GlobalDataFlow.cs:384:16:384:23 | access to local variable nonSink0 |
-| GlobalDataFlow.cs:382:13:382:33 | SSA def(nonSink0) | GlobalDataFlow.cs:384:16:384:23 | access to local variable nonSink0 |
-| GlobalDataFlow.cs:382:13:382:33 | String nonSink0 = ... | GlobalDataFlow.cs:382:13:382:33 | String nonSink0 = ... |
-| GlobalDataFlow.cs:382:24:382:33 | access to parameter nonTainted | GlobalDataFlow.cs:382:13:382:33 | SSA def(nonSink0) |
-| GlobalDataFlow.cs:382:24:382:33 | access to parameter nonTainted | GlobalDataFlow.cs:382:13:382:33 | SSA def(nonSink0) |
-| GlobalDataFlow.cs:382:24:382:33 | access to parameter nonTainted | GlobalDataFlow.cs:382:13:382:33 | SSA def(nonSink0) |
-| GlobalDataFlow.cs:382:24:382:33 | access to parameter nonTainted | GlobalDataFlow.cs:382:13:382:33 | SSA def(nonSink0) |
-| GlobalDataFlow.cs:382:24:382:33 | access to parameter nonTainted | GlobalDataFlow.cs:382:24:382:33 | access to parameter nonTainted |
-| GlobalDataFlow.cs:382:24:382:33 | access to parameter nonTainted | GlobalDataFlow.cs:383:15:383:22 | access to local variable nonSink0 |
-| GlobalDataFlow.cs:382:24:382:33 | access to parameter nonTainted | GlobalDataFlow.cs:383:15:383:22 | access to local variable nonSink0 |
-| GlobalDataFlow.cs:382:24:382:33 | access to parameter nonTainted | GlobalDataFlow.cs:383:15:383:22 | access to local variable nonSink0 |
-| GlobalDataFlow.cs:382:24:382:33 | access to parameter nonTainted | GlobalDataFlow.cs:383:15:383:22 | access to local variable nonSink0 |
-| GlobalDataFlow.cs:382:24:382:33 | access to parameter nonTainted | GlobalDataFlow.cs:384:16:384:23 | access to local variable nonSink0 |
-| GlobalDataFlow.cs:382:24:382:33 | access to parameter nonTainted | GlobalDataFlow.cs:384:16:384:23 | access to local variable nonSink0 |
-| GlobalDataFlow.cs:382:24:382:33 | access to parameter nonTainted | GlobalDataFlow.cs:384:16:384:23 | access to local variable nonSink0 |
-| GlobalDataFlow.cs:382:24:382:33 | access to parameter nonTainted | GlobalDataFlow.cs:384:16:384:23 | access to local variable nonSink0 |
-| GlobalDataFlow.cs:383:9:383:23 | call to method Check | GlobalDataFlow.cs:383:9:383:23 | call to method Check |
-| GlobalDataFlow.cs:383:15:383:22 | access to local variable nonSink0 | GlobalDataFlow.cs:383:15:383:22 | access to local variable nonSink0 |
-| GlobalDataFlow.cs:383:15:383:22 | access to local variable nonSink0 | GlobalDataFlow.cs:384:16:384:23 | access to local variable nonSink0 |
-| GlobalDataFlow.cs:383:15:383:22 | access to local variable nonSink0 | GlobalDataFlow.cs:384:16:384:23 | access to local variable nonSink0 |
-| GlobalDataFlow.cs:383:15:383:22 | access to local variable nonSink0 | GlobalDataFlow.cs:384:16:384:23 | access to local variable nonSink0 |
-| GlobalDataFlow.cs:383:15:383:22 | access to local variable nonSink0 | GlobalDataFlow.cs:384:16:384:23 | access to local variable nonSink0 |
-| GlobalDataFlow.cs:384:16:384:23 | access to local variable nonSink0 | GlobalDataFlow.cs:171:20:171:44 | call to method NonTaintedParam |
-| GlobalDataFlow.cs:384:16:384:23 | access to local variable nonSink0 | GlobalDataFlow.cs:171:20:171:44 | call to method NonTaintedParam |
-| GlobalDataFlow.cs:384:16:384:23 | access to local variable nonSink0 | GlobalDataFlow.cs:384:16:384:23 | access to local variable nonSink0 |
-| GlobalDataFlow.cs:393:62:393:63 | "" | GlobalDataFlow.cs:32:15:32:35 | access to property NonSinkProperty1 |
-| GlobalDataFlow.cs:393:62:393:63 | "" | GlobalDataFlow.cs:32:15:32:35 | access to property NonSinkProperty1 |
-| GlobalDataFlow.cs:393:62:393:63 | "" | GlobalDataFlow.cs:393:62:393:63 | "" |
-| GlobalDataFlow.cs:398:9:398:11 | this | GlobalDataFlow.cs:398:9:398:11 | this |
-| GlobalDataFlow.cs:398:22:398:23 | "" | GlobalDataFlow.cs:398:22:398:23 | "" |
-| GlobalDataFlow.cs:399:9:399:11 | this | GlobalDataFlow.cs:399:9:399:11 | this |
-| GlobalDataFlow.cs:399:9:399:11 | value | GlobalDataFlow.cs:399:9:399:11 | value |
-| GlobalDataFlow.cs:399:9:399:11 | value | GlobalDataFlow.cs:399:9:399:11 | value |
-| GlobalDataFlow.cs:399:9:399:11 | value | GlobalDataFlow.cs:399:9:399:11 | value |
-| GlobalDataFlow.cs:399:9:399:11 | value | GlobalDataFlow.cs:399:9:399:11 | value |
-| GlobalDataFlow.cs:399:9:399:11 | value | GlobalDataFlow.cs:399:19:399:32 | SSA def(sink20) |
-| GlobalDataFlow.cs:399:9:399:11 | value | GlobalDataFlow.cs:399:19:399:32 | SSA def(sink20) |
-| GlobalDataFlow.cs:399:9:399:11 | value | GlobalDataFlow.cs:399:19:399:32 | SSA def(sink20) |
-| GlobalDataFlow.cs:399:9:399:11 | value | GlobalDataFlow.cs:399:19:399:32 | SSA def(sink20) |
-| GlobalDataFlow.cs:399:9:399:11 | value | GlobalDataFlow.cs:399:19:399:32 | SSA def(sink20) |
-| GlobalDataFlow.cs:399:9:399:11 | value | GlobalDataFlow.cs:399:19:399:32 | SSA def(sink20) |
-| GlobalDataFlow.cs:399:9:399:11 | value | GlobalDataFlow.cs:399:28:399:32 | access to parameter value |
-| GlobalDataFlow.cs:399:9:399:11 | value | GlobalDataFlow.cs:399:28:399:32 | access to parameter value |
-| GlobalDataFlow.cs:399:9:399:11 | value | GlobalDataFlow.cs:399:28:399:32 | access to parameter value |
-| GlobalDataFlow.cs:399:9:399:11 | value | GlobalDataFlow.cs:399:28:399:32 | access to parameter value |
-| GlobalDataFlow.cs:399:9:399:11 | value | GlobalDataFlow.cs:399:28:399:32 | access to parameter value |
-| GlobalDataFlow.cs:399:9:399:11 | value | GlobalDataFlow.cs:399:28:399:32 | access to parameter value |
-| GlobalDataFlow.cs:399:9:399:11 | value | GlobalDataFlow.cs:399:41:399:46 | access to local variable sink20 |
-| GlobalDataFlow.cs:399:9:399:11 | value | GlobalDataFlow.cs:399:41:399:46 | access to local variable sink20 |
-| GlobalDataFlow.cs:399:9:399:11 | value | GlobalDataFlow.cs:399:41:399:46 | access to local variable sink20 |
-| GlobalDataFlow.cs:399:9:399:11 | value | GlobalDataFlow.cs:399:41:399:46 | access to local variable sink20 |
-| GlobalDataFlow.cs:399:9:399:11 | value | GlobalDataFlow.cs:399:41:399:46 | access to local variable sink20 |
-| GlobalDataFlow.cs:399:9:399:11 | value | GlobalDataFlow.cs:399:41:399:46 | access to local variable sink20 |
-| GlobalDataFlow.cs:399:19:399:32 | SSA def(sink20) | GlobalDataFlow.cs:399:19:399:32 | SSA def(sink20) |
-| GlobalDataFlow.cs:399:19:399:32 | SSA def(sink20) | GlobalDataFlow.cs:399:41:399:46 | access to local variable sink20 |
-| GlobalDataFlow.cs:399:19:399:32 | SSA def(sink20) | GlobalDataFlow.cs:399:41:399:46 | access to local variable sink20 |
-| GlobalDataFlow.cs:399:19:399:32 | SSA def(sink20) | GlobalDataFlow.cs:399:41:399:46 | access to local variable sink20 |
-| GlobalDataFlow.cs:399:19:399:32 | SSA def(sink20) | GlobalDataFlow.cs:399:41:399:46 | access to local variable sink20 |
-| GlobalDataFlow.cs:399:19:399:32 | String sink20 = ... | GlobalDataFlow.cs:399:19:399:32 | String sink20 = ... |
-| GlobalDataFlow.cs:399:28:399:32 | access to parameter value | GlobalDataFlow.cs:399:19:399:32 | SSA def(sink20) |
-| GlobalDataFlow.cs:399:28:399:32 | access to parameter value | GlobalDataFlow.cs:399:19:399:32 | SSA def(sink20) |
-| GlobalDataFlow.cs:399:28:399:32 | access to parameter value | GlobalDataFlow.cs:399:19:399:32 | SSA def(sink20) |
-| GlobalDataFlow.cs:399:28:399:32 | access to parameter value | GlobalDataFlow.cs:399:19:399:32 | SSA def(sink20) |
-| GlobalDataFlow.cs:399:28:399:32 | access to parameter value | GlobalDataFlow.cs:399:28:399:32 | access to parameter value |
-| GlobalDataFlow.cs:399:28:399:32 | access to parameter value | GlobalDataFlow.cs:399:41:399:46 | access to local variable sink20 |
-| GlobalDataFlow.cs:399:28:399:32 | access to parameter value | GlobalDataFlow.cs:399:41:399:46 | access to local variable sink20 |
-| GlobalDataFlow.cs:399:28:399:32 | access to parameter value | GlobalDataFlow.cs:399:41:399:46 | access to local variable sink20 |
-| GlobalDataFlow.cs:399:28:399:32 | access to parameter value | GlobalDataFlow.cs:399:41:399:46 | access to local variable sink20 |
-| GlobalDataFlow.cs:399:35:399:47 | call to method Check | GlobalDataFlow.cs:399:35:399:47 | call to method Check |
-| GlobalDataFlow.cs:399:41:399:46 | access to local variable sink20 | GlobalDataFlow.cs:399:41:399:46 | access to local variable sink20 |
+| GlobalDataFlow.cs:348:10:348:18 | this | GlobalDataFlow.cs:348:10:348:18 | this |
+| GlobalDataFlow.cs:350:9:350:14 | ... = ... | GlobalDataFlow.cs:350:9:350:14 | ... = ... |
+| GlobalDataFlow.cs:350:9:350:14 | SSA def(x) | GlobalDataFlow.cs:171:23:171:30 | SSA def(nonSink0) |
+| GlobalDataFlow.cs:350:9:350:14 | SSA def(x) | GlobalDataFlow.cs:171:23:171:30 | SSA def(nonSink0) |
+| GlobalDataFlow.cs:350:9:350:14 | SSA def(x) | GlobalDataFlow.cs:350:9:350:14 | SSA def(x) |
+| GlobalDataFlow.cs:350:13:350:14 | "" | GlobalDataFlow.cs:350:9:350:14 | SSA def(x) |
+| GlobalDataFlow.cs:350:13:350:14 | "" | GlobalDataFlow.cs:350:9:350:14 | SSA def(x) |
+| GlobalDataFlow.cs:350:13:350:14 | "" | GlobalDataFlow.cs:350:13:350:14 | "" |
+| GlobalDataFlow.cs:353:25:353:35 | this | GlobalDataFlow.cs:353:25:353:35 | this |
+| GlobalDataFlow.cs:355:22:355:23 | "" | GlobalDataFlow.cs:173:20:173:32 | call to method NonOutYield |
+| GlobalDataFlow.cs:355:22:355:23 | "" | GlobalDataFlow.cs:173:20:173:32 | call to method NonOutYield |
+| GlobalDataFlow.cs:355:22:355:23 | "" | GlobalDataFlow.cs:355:22:355:23 | "" |
+| GlobalDataFlow.cs:355:22:355:23 | "" | GlobalDataFlow.cs:355:22:355:23 | "" |
+| GlobalDataFlow.cs:355:22:355:23 | "" | GlobalDataFlow.cs:355:22:355:23 | "" |
+| GlobalDataFlow.cs:355:22:355:23 | "" | GlobalDataFlow.cs:355:22:355:23 | "" |
+| GlobalDataFlow.cs:356:22:356:23 | "" | GlobalDataFlow.cs:173:20:173:32 | call to method NonOutYield |
+| GlobalDataFlow.cs:356:22:356:23 | "" | GlobalDataFlow.cs:173:20:173:32 | call to method NonOutYield |
+| GlobalDataFlow.cs:356:22:356:23 | "" | GlobalDataFlow.cs:356:22:356:23 | "" |
+| GlobalDataFlow.cs:356:22:356:23 | "" | GlobalDataFlow.cs:356:22:356:23 | "" |
+| GlobalDataFlow.cs:356:22:356:23 | "" | GlobalDataFlow.cs:356:22:356:23 | "" |
+| GlobalDataFlow.cs:356:22:356:23 | "" | GlobalDataFlow.cs:356:22:356:23 | "" |
+| GlobalDataFlow.cs:359:36:359:36 | a | GlobalDataFlow.cs:359:36:359:36 | a |
+| GlobalDataFlow.cs:359:36:359:36 | a | GlobalDataFlow.cs:359:36:359:36 | a |
+| GlobalDataFlow.cs:359:36:359:36 | a | GlobalDataFlow.cs:359:36:359:36 | a |
+| GlobalDataFlow.cs:359:36:359:36 | a | GlobalDataFlow.cs:359:36:359:36 | a |
+| GlobalDataFlow.cs:359:36:359:36 | a | GlobalDataFlow.cs:361:9:361:9 | access to parameter a |
+| GlobalDataFlow.cs:359:36:359:36 | a | GlobalDataFlow.cs:361:9:361:9 | access to parameter a |
+| GlobalDataFlow.cs:359:36:359:36 | a | GlobalDataFlow.cs:361:9:361:9 | access to parameter a |
+| GlobalDataFlow.cs:359:36:359:36 | a | GlobalDataFlow.cs:361:9:361:9 | access to parameter a |
+| GlobalDataFlow.cs:359:36:359:36 | a | GlobalDataFlow.cs:361:9:361:9 | access to parameter a |
+| GlobalDataFlow.cs:359:36:359:36 | a | GlobalDataFlow.cs:361:9:361:9 | access to parameter a |
+| GlobalDataFlow.cs:359:36:359:36 | a | GlobalDataFlow.cs:361:9:361:9 | access to parameter a |
+| GlobalDataFlow.cs:359:36:359:36 | a | GlobalDataFlow.cs:361:9:361:9 | access to parameter a |
+| GlobalDataFlow.cs:359:36:359:36 | a | GlobalDataFlow.cs:361:9:361:9 | access to parameter a |
+| GlobalDataFlow.cs:359:36:359:36 | a | GlobalDataFlow.cs:361:9:361:9 | access to parameter a |
+| GlobalDataFlow.cs:359:41:359:41 | x | GlobalDataFlow.cs:359:41:359:41 | x |
+| GlobalDataFlow.cs:359:41:359:41 | x | GlobalDataFlow.cs:359:41:359:41 | x |
+| GlobalDataFlow.cs:359:41:359:41 | x | GlobalDataFlow.cs:359:41:359:41 | x |
+| GlobalDataFlow.cs:359:41:359:41 | x | GlobalDataFlow.cs:359:41:359:41 | x |
+| GlobalDataFlow.cs:359:41:359:41 | x | GlobalDataFlow.cs:361:11:361:11 | access to parameter x |
+| GlobalDataFlow.cs:359:41:359:41 | x | GlobalDataFlow.cs:361:11:361:11 | access to parameter x |
+| GlobalDataFlow.cs:359:41:359:41 | x | GlobalDataFlow.cs:361:11:361:11 | access to parameter x |
+| GlobalDataFlow.cs:359:41:359:41 | x | GlobalDataFlow.cs:361:11:361:11 | access to parameter x |
+| GlobalDataFlow.cs:359:41:359:41 | x | GlobalDataFlow.cs:361:11:361:11 | access to parameter x |
+| GlobalDataFlow.cs:359:41:359:41 | x | GlobalDataFlow.cs:361:11:361:11 | access to parameter x |
+| GlobalDataFlow.cs:359:41:359:41 | x | GlobalDataFlow.cs:361:11:361:11 | access to parameter x |
+| GlobalDataFlow.cs:359:41:359:41 | x | GlobalDataFlow.cs:361:11:361:11 | access to parameter x |
+| GlobalDataFlow.cs:359:41:359:41 | x | GlobalDataFlow.cs:361:11:361:11 | access to parameter x |
+| GlobalDataFlow.cs:359:41:359:41 | x | GlobalDataFlow.cs:361:11:361:11 | access to parameter x |
+| GlobalDataFlow.cs:361:9:361:9 | access to parameter a | GlobalDataFlow.cs:361:9:361:9 | access to parameter a |
+| GlobalDataFlow.cs:361:9:361:12 | delegate call | GlobalDataFlow.cs:361:9:361:12 | delegate call |
+| GlobalDataFlow.cs:361:11:361:11 | access to parameter x | GlobalDataFlow.cs:53:15:53:15 | x |
+| GlobalDataFlow.cs:361:11:361:11 | access to parameter x | GlobalDataFlow.cs:53:15:53:15 | x |
+| GlobalDataFlow.cs:361:11:361:11 | access to parameter x | GlobalDataFlow.cs:53:15:53:15 | x |
+| GlobalDataFlow.cs:361:11:361:11 | access to parameter x | GlobalDataFlow.cs:53:15:53:15 | x |
+| GlobalDataFlow.cs:361:11:361:11 | access to parameter x | GlobalDataFlow.cs:60:15:60:27 | nonSinkParam0 |
+| GlobalDataFlow.cs:361:11:361:11 | access to parameter x | GlobalDataFlow.cs:60:15:60:27 | nonSinkParam0 |
+| GlobalDataFlow.cs:361:11:361:11 | access to parameter x | GlobalDataFlow.cs:60:15:60:27 | nonSinkParam0 |
+| GlobalDataFlow.cs:361:11:361:11 | access to parameter x | GlobalDataFlow.cs:60:15:60:27 | nonSinkParam0 |
+| GlobalDataFlow.cs:361:11:361:11 | access to parameter x | GlobalDataFlow.cs:245:26:245:35 | sinkParam3 |
+| GlobalDataFlow.cs:361:11:361:11 | access to parameter x | GlobalDataFlow.cs:245:26:245:35 | sinkParam3 |
+| GlobalDataFlow.cs:361:11:361:11 | access to parameter x | GlobalDataFlow.cs:245:26:245:35 | sinkParam3 |
+| GlobalDataFlow.cs:361:11:361:11 | access to parameter x | GlobalDataFlow.cs:245:26:245:35 | sinkParam3 |
+| GlobalDataFlow.cs:361:11:361:11 | access to parameter x | GlobalDataFlow.cs:361:11:361:11 | access to parameter x |
+| GlobalDataFlow.cs:364:41:364:41 | f | GlobalDataFlow.cs:364:41:364:41 | f |
+| GlobalDataFlow.cs:364:41:364:41 | f | GlobalDataFlow.cs:364:41:364:41 | f |
+| GlobalDataFlow.cs:364:41:364:41 | f | GlobalDataFlow.cs:364:41:364:41 | f |
+| GlobalDataFlow.cs:364:41:364:41 | f | GlobalDataFlow.cs:364:41:364:41 | f |
+| GlobalDataFlow.cs:364:41:364:41 | f | GlobalDataFlow.cs:366:16:366:16 | access to parameter f |
+| GlobalDataFlow.cs:364:41:364:41 | f | GlobalDataFlow.cs:366:16:366:16 | access to parameter f |
+| GlobalDataFlow.cs:364:41:364:41 | f | GlobalDataFlow.cs:366:16:366:16 | access to parameter f |
+| GlobalDataFlow.cs:364:41:364:41 | f | GlobalDataFlow.cs:366:16:366:16 | access to parameter f |
+| GlobalDataFlow.cs:364:41:364:41 | f | GlobalDataFlow.cs:366:16:366:16 | access to parameter f |
+| GlobalDataFlow.cs:364:41:364:41 | f | GlobalDataFlow.cs:366:16:366:16 | access to parameter f |
+| GlobalDataFlow.cs:364:41:364:41 | f | GlobalDataFlow.cs:366:16:366:16 | access to parameter f |
+| GlobalDataFlow.cs:364:41:364:41 | f | GlobalDataFlow.cs:366:16:366:16 | access to parameter f |
+| GlobalDataFlow.cs:364:41:364:41 | f | GlobalDataFlow.cs:366:16:366:16 | access to parameter f |
+| GlobalDataFlow.cs:364:41:364:41 | f | GlobalDataFlow.cs:366:16:366:16 | access to parameter f |
+| GlobalDataFlow.cs:364:41:364:41 | f | GlobalDataFlow.cs:366:16:366:16 | access to parameter f |
+| GlobalDataFlow.cs:364:41:364:41 | f | GlobalDataFlow.cs:366:16:366:16 | access to parameter f |
+| GlobalDataFlow.cs:364:41:364:41 | f | GlobalDataFlow.cs:366:16:366:16 | access to parameter f |
+| GlobalDataFlow.cs:364:41:364:41 | f | GlobalDataFlow.cs:366:16:366:16 | access to parameter f |
+| GlobalDataFlow.cs:364:46:364:46 | x | GlobalDataFlow.cs:364:46:364:46 | x |
+| GlobalDataFlow.cs:364:46:364:46 | x | GlobalDataFlow.cs:364:46:364:46 | x |
+| GlobalDataFlow.cs:364:46:364:46 | x | GlobalDataFlow.cs:364:46:364:46 | x |
+| GlobalDataFlow.cs:364:46:364:46 | x | GlobalDataFlow.cs:364:46:364:46 | x |
+| GlobalDataFlow.cs:364:46:364:46 | x | GlobalDataFlow.cs:366:18:366:18 | access to parameter x |
+| GlobalDataFlow.cs:364:46:364:46 | x | GlobalDataFlow.cs:366:18:366:18 | access to parameter x |
+| GlobalDataFlow.cs:364:46:364:46 | x | GlobalDataFlow.cs:366:18:366:18 | access to parameter x |
+| GlobalDataFlow.cs:364:46:364:46 | x | GlobalDataFlow.cs:366:18:366:18 | access to parameter x |
+| GlobalDataFlow.cs:364:46:364:46 | x | GlobalDataFlow.cs:366:18:366:18 | access to parameter x |
+| GlobalDataFlow.cs:364:46:364:46 | x | GlobalDataFlow.cs:366:18:366:18 | access to parameter x |
+| GlobalDataFlow.cs:364:46:364:46 | x | GlobalDataFlow.cs:366:18:366:18 | access to parameter x |
+| GlobalDataFlow.cs:364:46:364:46 | x | GlobalDataFlow.cs:366:18:366:18 | access to parameter x |
+| GlobalDataFlow.cs:364:46:364:46 | x | GlobalDataFlow.cs:366:18:366:18 | access to parameter x |
+| GlobalDataFlow.cs:364:46:364:46 | x | GlobalDataFlow.cs:366:18:366:18 | access to parameter x |
+| GlobalDataFlow.cs:364:46:364:46 | x | GlobalDataFlow.cs:366:18:366:18 | access to parameter x |
+| GlobalDataFlow.cs:364:46:364:46 | x | GlobalDataFlow.cs:366:18:366:18 | access to parameter x |
+| GlobalDataFlow.cs:364:46:364:46 | x | GlobalDataFlow.cs:366:18:366:18 | access to parameter x |
+| GlobalDataFlow.cs:364:46:364:46 | x | GlobalDataFlow.cs:366:18:366:18 | access to parameter x |
+| GlobalDataFlow.cs:366:16:366:16 | access to parameter f | GlobalDataFlow.cs:366:16:366:16 | access to parameter f |
+| GlobalDataFlow.cs:366:16:366:19 | delegate call | GlobalDataFlow.cs:134:45:134:64 | call to method ApplyFunc |
+| GlobalDataFlow.cs:366:16:366:19 | delegate call | GlobalDataFlow.cs:134:45:134:64 | call to method ApplyFunc |
+| GlobalDataFlow.cs:366:16:366:19 | delegate call | GlobalDataFlow.cs:134:45:134:64 | call to method ApplyFunc |
+| GlobalDataFlow.cs:366:16:366:19 | delegate call | GlobalDataFlow.cs:134:45:134:64 | call to method ApplyFunc |
+| GlobalDataFlow.cs:366:16:366:19 | delegate call | GlobalDataFlow.cs:143:21:143:44 | call to method ApplyFunc |
+| GlobalDataFlow.cs:366:16:366:19 | delegate call | GlobalDataFlow.cs:143:21:143:44 | call to method ApplyFunc |
+| GlobalDataFlow.cs:366:16:366:19 | delegate call | GlobalDataFlow.cs:143:21:143:44 | call to method ApplyFunc |
+| GlobalDataFlow.cs:366:16:366:19 | delegate call | GlobalDataFlow.cs:143:21:143:44 | call to method ApplyFunc |
+| GlobalDataFlow.cs:366:16:366:19 | delegate call | GlobalDataFlow.cs:147:20:147:40 | call to method ApplyFunc |
+| GlobalDataFlow.cs:366:16:366:19 | delegate call | GlobalDataFlow.cs:147:20:147:40 | call to method ApplyFunc |
+| GlobalDataFlow.cs:366:16:366:19 | delegate call | GlobalDataFlow.cs:147:20:147:40 | call to method ApplyFunc |
+| GlobalDataFlow.cs:366:16:366:19 | delegate call | GlobalDataFlow.cs:147:20:147:40 | call to method ApplyFunc |
+| GlobalDataFlow.cs:366:16:366:19 | delegate call | GlobalDataFlow.cs:149:20:149:44 | call to method ApplyFunc |
+| GlobalDataFlow.cs:366:16:366:19 | delegate call | GlobalDataFlow.cs:149:20:149:44 | call to method ApplyFunc |
+| GlobalDataFlow.cs:366:16:366:19 | delegate call | GlobalDataFlow.cs:149:20:149:44 | call to method ApplyFunc |
+| GlobalDataFlow.cs:366:16:366:19 | delegate call | GlobalDataFlow.cs:149:20:149:44 | call to method ApplyFunc |
+| GlobalDataFlow.cs:366:16:366:19 | delegate call | GlobalDataFlow.cs:277:17:277:38 | call to method ApplyFunc |
+| GlobalDataFlow.cs:366:16:366:19 | delegate call | GlobalDataFlow.cs:277:17:277:38 | call to method ApplyFunc |
+| GlobalDataFlow.cs:366:16:366:19 | delegate call | GlobalDataFlow.cs:277:17:277:38 | call to method ApplyFunc |
+| GlobalDataFlow.cs:366:16:366:19 | delegate call | GlobalDataFlow.cs:277:17:277:38 | call to method ApplyFunc |
+| GlobalDataFlow.cs:366:16:366:19 | delegate call | GlobalDataFlow.cs:366:16:366:19 | delegate call |
+| GlobalDataFlow.cs:366:18:366:18 | access to parameter x | GlobalDataFlow.cs:275:26:275:26 | x |
+| GlobalDataFlow.cs:366:18:366:18 | access to parameter x | GlobalDataFlow.cs:275:26:275:26 | x |
+| GlobalDataFlow.cs:366:18:366:18 | access to parameter x | GlobalDataFlow.cs:275:26:275:26 | x |
+| GlobalDataFlow.cs:366:18:366:18 | access to parameter x | GlobalDataFlow.cs:275:26:275:26 | x |
+| GlobalDataFlow.cs:366:18:366:18 | access to parameter x | GlobalDataFlow.cs:275:26:275:26 | x |
+| GlobalDataFlow.cs:366:18:366:18 | access to parameter x | GlobalDataFlow.cs:275:26:275:26 | x |
+| GlobalDataFlow.cs:366:18:366:18 | access to parameter x | GlobalDataFlow.cs:275:26:275:26 | x |
+| GlobalDataFlow.cs:366:18:366:18 | access to parameter x | GlobalDataFlow.cs:275:26:275:26 | x |
+| GlobalDataFlow.cs:366:18:366:18 | access to parameter x | GlobalDataFlow.cs:277:27:277:28 | x0 |
+| GlobalDataFlow.cs:366:18:366:18 | access to parameter x | GlobalDataFlow.cs:277:27:277:28 | x0 |
+| GlobalDataFlow.cs:366:18:366:18 | access to parameter x | GlobalDataFlow.cs:277:27:277:28 | x0 |
+| GlobalDataFlow.cs:366:18:366:18 | access to parameter x | GlobalDataFlow.cs:277:27:277:28 | x0 |
+| GlobalDataFlow.cs:366:18:366:18 | access to parameter x | GlobalDataFlow.cs:366:16:366:19 | delegate call |
+| GlobalDataFlow.cs:366:18:366:18 | access to parameter x | GlobalDataFlow.cs:366:16:366:19 | delegate call |
+| GlobalDataFlow.cs:366:18:366:18 | access to parameter x | GlobalDataFlow.cs:366:16:366:19 | delegate call |
+| GlobalDataFlow.cs:366:18:366:18 | access to parameter x | GlobalDataFlow.cs:366:16:366:19 | delegate call |
+| GlobalDataFlow.cs:366:18:366:18 | access to parameter x | GlobalDataFlow.cs:366:16:366:19 | delegate call |
+| GlobalDataFlow.cs:366:18:366:18 | access to parameter x | GlobalDataFlow.cs:366:16:366:19 | delegate call |
+| GlobalDataFlow.cs:366:18:366:18 | access to parameter x | GlobalDataFlow.cs:366:16:366:19 | delegate call |
+| GlobalDataFlow.cs:366:18:366:18 | access to parameter x | GlobalDataFlow.cs:366:16:366:19 | delegate call |
+| GlobalDataFlow.cs:366:18:366:18 | access to parameter x | GlobalDataFlow.cs:366:16:366:19 | delegate call |
+| GlobalDataFlow.cs:366:18:366:18 | access to parameter x | GlobalDataFlow.cs:366:16:366:19 | delegate call |
+| GlobalDataFlow.cs:366:18:366:18 | access to parameter x | GlobalDataFlow.cs:366:18:366:18 | access to parameter x |
+| GlobalDataFlow.cs:373:42:373:42 | a | GlobalDataFlow.cs:373:42:373:42 | a |
+| GlobalDataFlow.cs:373:42:373:42 | a | GlobalDataFlow.cs:373:42:373:42 | a |
+| GlobalDataFlow.cs:373:42:373:42 | a | GlobalDataFlow.cs:373:42:373:42 | a |
+| GlobalDataFlow.cs:373:42:373:42 | a | GlobalDataFlow.cs:373:42:373:42 | a |
+| GlobalDataFlow.cs:373:42:373:42 | a | GlobalDataFlow.cs:375:9:375:9 | access to parameter a |
+| GlobalDataFlow.cs:373:42:373:42 | a | GlobalDataFlow.cs:375:9:375:9 | access to parameter a |
+| GlobalDataFlow.cs:373:42:373:42 | a | GlobalDataFlow.cs:375:9:375:9 | access to parameter a |
+| GlobalDataFlow.cs:373:42:373:42 | a | GlobalDataFlow.cs:375:9:375:9 | access to parameter a |
+| GlobalDataFlow.cs:373:42:373:42 | a | GlobalDataFlow.cs:375:9:375:9 | access to parameter a |
+| GlobalDataFlow.cs:373:42:373:42 | a | GlobalDataFlow.cs:375:9:375:9 | access to parameter a |
+| GlobalDataFlow.cs:373:42:373:42 | a | GlobalDataFlow.cs:375:9:375:9 | access to parameter a |
+| GlobalDataFlow.cs:373:42:373:42 | a | GlobalDataFlow.cs:375:9:375:9 | access to parameter a |
+| GlobalDataFlow.cs:373:42:373:42 | a | GlobalDataFlow.cs:375:9:375:9 | access to parameter a |
+| GlobalDataFlow.cs:373:42:373:42 | a | GlobalDataFlow.cs:375:9:375:9 | access to parameter a |
+| GlobalDataFlow.cs:373:42:373:42 | a | GlobalDataFlow.cs:375:9:375:9 | access to parameter a |
+| GlobalDataFlow.cs:373:42:373:42 | a | GlobalDataFlow.cs:375:9:375:9 | access to parameter a |
+| GlobalDataFlow.cs:373:52:373:52 | x | GlobalDataFlow.cs:373:52:373:52 | x |
+| GlobalDataFlow.cs:373:52:373:52 | x | GlobalDataFlow.cs:373:52:373:52 | x |
+| GlobalDataFlow.cs:373:52:373:52 | x | GlobalDataFlow.cs:373:52:373:52 | x |
+| GlobalDataFlow.cs:373:52:373:52 | x | GlobalDataFlow.cs:373:52:373:52 | x |
+| GlobalDataFlow.cs:373:52:373:52 | x | GlobalDataFlow.cs:375:11:375:11 | access to parameter x |
+| GlobalDataFlow.cs:373:52:373:52 | x | GlobalDataFlow.cs:375:11:375:11 | access to parameter x |
+| GlobalDataFlow.cs:373:52:373:52 | x | GlobalDataFlow.cs:375:11:375:11 | access to parameter x |
+| GlobalDataFlow.cs:373:52:373:52 | x | GlobalDataFlow.cs:375:11:375:11 | access to parameter x |
+| GlobalDataFlow.cs:373:52:373:52 | x | GlobalDataFlow.cs:375:11:375:11 | access to parameter x |
+| GlobalDataFlow.cs:373:52:373:52 | x | GlobalDataFlow.cs:375:11:375:11 | access to parameter x |
+| GlobalDataFlow.cs:373:52:373:52 | x | GlobalDataFlow.cs:375:11:375:11 | access to parameter x |
+| GlobalDataFlow.cs:373:52:373:52 | x | GlobalDataFlow.cs:375:11:375:11 | access to parameter x |
+| GlobalDataFlow.cs:373:52:373:52 | x | GlobalDataFlow.cs:375:11:375:11 | access to parameter x |
+| GlobalDataFlow.cs:373:52:373:52 | x | GlobalDataFlow.cs:375:11:375:11 | access to parameter x |
+| GlobalDataFlow.cs:373:52:373:52 | x | GlobalDataFlow.cs:375:11:375:11 | access to parameter x |
+| GlobalDataFlow.cs:373:52:373:52 | x | GlobalDataFlow.cs:375:11:375:11 | access to parameter x |
+| GlobalDataFlow.cs:375:9:375:9 | access to parameter a | GlobalDataFlow.cs:375:9:375:9 | access to parameter a |
+| GlobalDataFlow.cs:375:9:375:12 | delegate call | GlobalDataFlow.cs:375:9:375:12 | delegate call |
+| GlobalDataFlow.cs:375:11:375:11 | access to parameter x | GlobalDataFlow.cs:56:37:56:37 | x |
+| GlobalDataFlow.cs:375:11:375:11 | access to parameter x | GlobalDataFlow.cs:56:37:56:37 | x |
+| GlobalDataFlow.cs:375:11:375:11 | access to parameter x | GlobalDataFlow.cs:56:37:56:37 | x |
+| GlobalDataFlow.cs:375:11:375:11 | access to parameter x | GlobalDataFlow.cs:56:37:56:37 | x |
+| GlobalDataFlow.cs:375:11:375:11 | access to parameter x | GlobalDataFlow.cs:61:38:61:50 | nonSinkParam0 |
+| GlobalDataFlow.cs:375:11:375:11 | access to parameter x | GlobalDataFlow.cs:61:38:61:50 | nonSinkParam0 |
+| GlobalDataFlow.cs:375:11:375:11 | access to parameter x | GlobalDataFlow.cs:61:38:61:50 | nonSinkParam0 |
+| GlobalDataFlow.cs:375:11:375:11 | access to parameter x | GlobalDataFlow.cs:61:38:61:50 | nonSinkParam0 |
+| GlobalDataFlow.cs:375:11:375:11 | access to parameter x | GlobalDataFlow.cs:255:26:255:35 | sinkParam5 |
+| GlobalDataFlow.cs:375:11:375:11 | access to parameter x | GlobalDataFlow.cs:255:26:255:35 | sinkParam5 |
+| GlobalDataFlow.cs:375:11:375:11 | access to parameter x | GlobalDataFlow.cs:255:26:255:35 | sinkParam5 |
+| GlobalDataFlow.cs:375:11:375:11 | access to parameter x | GlobalDataFlow.cs:255:26:255:35 | sinkParam5 |
+| GlobalDataFlow.cs:375:11:375:11 | access to parameter x | GlobalDataFlow.cs:260:26:260:35 | sinkParam6 |
+| GlobalDataFlow.cs:375:11:375:11 | access to parameter x | GlobalDataFlow.cs:260:26:260:35 | sinkParam6 |
+| GlobalDataFlow.cs:375:11:375:11 | access to parameter x | GlobalDataFlow.cs:260:26:260:35 | sinkParam6 |
+| GlobalDataFlow.cs:375:11:375:11 | access to parameter x | GlobalDataFlow.cs:260:26:260:35 | sinkParam6 |
+| GlobalDataFlow.cs:375:11:375:11 | access to parameter x | GlobalDataFlow.cs:375:11:375:11 | access to parameter x |
+| GlobalDataFlow.cs:378:39:378:45 | tainted | GlobalDataFlow.cs:378:39:378:45 | tainted |
+| GlobalDataFlow.cs:378:39:378:45 | tainted | GlobalDataFlow.cs:378:39:378:45 | tainted |
+| GlobalDataFlow.cs:378:39:378:45 | tainted | GlobalDataFlow.cs:378:39:378:45 | tainted |
+| GlobalDataFlow.cs:378:39:378:45 | tainted | GlobalDataFlow.cs:378:39:378:45 | tainted |
+| GlobalDataFlow.cs:378:39:378:45 | tainted | GlobalDataFlow.cs:380:13:380:28 | SSA def(sink11) |
+| GlobalDataFlow.cs:378:39:378:45 | tainted | GlobalDataFlow.cs:380:13:380:28 | SSA def(sink11) |
+| GlobalDataFlow.cs:378:39:378:45 | tainted | GlobalDataFlow.cs:380:13:380:28 | SSA def(sink11) |
+| GlobalDataFlow.cs:378:39:378:45 | tainted | GlobalDataFlow.cs:380:13:380:28 | SSA def(sink11) |
+| GlobalDataFlow.cs:378:39:378:45 | tainted | GlobalDataFlow.cs:380:13:380:28 | SSA def(sink11) |
+| GlobalDataFlow.cs:378:39:378:45 | tainted | GlobalDataFlow.cs:380:13:380:28 | SSA def(sink11) |
+| GlobalDataFlow.cs:378:39:378:45 | tainted | GlobalDataFlow.cs:380:22:380:28 | access to parameter tainted |
+| GlobalDataFlow.cs:378:39:378:45 | tainted | GlobalDataFlow.cs:380:22:380:28 | access to parameter tainted |
+| GlobalDataFlow.cs:378:39:378:45 | tainted | GlobalDataFlow.cs:380:22:380:28 | access to parameter tainted |
+| GlobalDataFlow.cs:378:39:378:45 | tainted | GlobalDataFlow.cs:380:22:380:28 | access to parameter tainted |
+| GlobalDataFlow.cs:378:39:378:45 | tainted | GlobalDataFlow.cs:380:22:380:28 | access to parameter tainted |
+| GlobalDataFlow.cs:378:39:378:45 | tainted | GlobalDataFlow.cs:380:22:380:28 | access to parameter tainted |
+| GlobalDataFlow.cs:378:39:378:45 | tainted | GlobalDataFlow.cs:381:15:381:20 | access to local variable sink11 |
+| GlobalDataFlow.cs:378:39:378:45 | tainted | GlobalDataFlow.cs:381:15:381:20 | access to local variable sink11 |
+| GlobalDataFlow.cs:378:39:378:45 | tainted | GlobalDataFlow.cs:381:15:381:20 | access to local variable sink11 |
+| GlobalDataFlow.cs:378:39:378:45 | tainted | GlobalDataFlow.cs:381:15:381:20 | access to local variable sink11 |
+| GlobalDataFlow.cs:378:39:378:45 | tainted | GlobalDataFlow.cs:381:15:381:20 | access to local variable sink11 |
+| GlobalDataFlow.cs:378:39:378:45 | tainted | GlobalDataFlow.cs:381:15:381:20 | access to local variable sink11 |
+| GlobalDataFlow.cs:378:39:378:45 | tainted | GlobalDataFlow.cs:382:16:382:21 | access to local variable sink11 |
+| GlobalDataFlow.cs:378:39:378:45 | tainted | GlobalDataFlow.cs:382:16:382:21 | access to local variable sink11 |
+| GlobalDataFlow.cs:378:39:378:45 | tainted | GlobalDataFlow.cs:382:16:382:21 | access to local variable sink11 |
+| GlobalDataFlow.cs:378:39:378:45 | tainted | GlobalDataFlow.cs:382:16:382:21 | access to local variable sink11 |
+| GlobalDataFlow.cs:378:39:378:45 | tainted | GlobalDataFlow.cs:382:16:382:21 | access to local variable sink11 |
+| GlobalDataFlow.cs:378:39:378:45 | tainted | GlobalDataFlow.cs:382:16:382:21 | access to local variable sink11 |
+| GlobalDataFlow.cs:380:13:380:28 | SSA def(sink11) | GlobalDataFlow.cs:380:13:380:28 | SSA def(sink11) |
+| GlobalDataFlow.cs:380:13:380:28 | SSA def(sink11) | GlobalDataFlow.cs:381:15:381:20 | access to local variable sink11 |
+| GlobalDataFlow.cs:380:13:380:28 | SSA def(sink11) | GlobalDataFlow.cs:381:15:381:20 | access to local variable sink11 |
+| GlobalDataFlow.cs:380:13:380:28 | SSA def(sink11) | GlobalDataFlow.cs:381:15:381:20 | access to local variable sink11 |
+| GlobalDataFlow.cs:380:13:380:28 | SSA def(sink11) | GlobalDataFlow.cs:381:15:381:20 | access to local variable sink11 |
+| GlobalDataFlow.cs:380:13:380:28 | SSA def(sink11) | GlobalDataFlow.cs:382:16:382:21 | access to local variable sink11 |
+| GlobalDataFlow.cs:380:13:380:28 | SSA def(sink11) | GlobalDataFlow.cs:382:16:382:21 | access to local variable sink11 |
+| GlobalDataFlow.cs:380:13:380:28 | SSA def(sink11) | GlobalDataFlow.cs:382:16:382:21 | access to local variable sink11 |
+| GlobalDataFlow.cs:380:13:380:28 | SSA def(sink11) | GlobalDataFlow.cs:382:16:382:21 | access to local variable sink11 |
+| GlobalDataFlow.cs:380:13:380:28 | String sink11 = ... | GlobalDataFlow.cs:380:13:380:28 | String sink11 = ... |
+| GlobalDataFlow.cs:380:22:380:28 | access to parameter tainted | GlobalDataFlow.cs:380:13:380:28 | SSA def(sink11) |
+| GlobalDataFlow.cs:380:22:380:28 | access to parameter tainted | GlobalDataFlow.cs:380:13:380:28 | SSA def(sink11) |
+| GlobalDataFlow.cs:380:22:380:28 | access to parameter tainted | GlobalDataFlow.cs:380:13:380:28 | SSA def(sink11) |
+| GlobalDataFlow.cs:380:22:380:28 | access to parameter tainted | GlobalDataFlow.cs:380:13:380:28 | SSA def(sink11) |
+| GlobalDataFlow.cs:380:22:380:28 | access to parameter tainted | GlobalDataFlow.cs:380:22:380:28 | access to parameter tainted |
+| GlobalDataFlow.cs:380:22:380:28 | access to parameter tainted | GlobalDataFlow.cs:381:15:381:20 | access to local variable sink11 |
+| GlobalDataFlow.cs:380:22:380:28 | access to parameter tainted | GlobalDataFlow.cs:381:15:381:20 | access to local variable sink11 |
+| GlobalDataFlow.cs:380:22:380:28 | access to parameter tainted | GlobalDataFlow.cs:381:15:381:20 | access to local variable sink11 |
+| GlobalDataFlow.cs:380:22:380:28 | access to parameter tainted | GlobalDataFlow.cs:381:15:381:20 | access to local variable sink11 |
+| GlobalDataFlow.cs:380:22:380:28 | access to parameter tainted | GlobalDataFlow.cs:382:16:382:21 | access to local variable sink11 |
+| GlobalDataFlow.cs:380:22:380:28 | access to parameter tainted | GlobalDataFlow.cs:382:16:382:21 | access to local variable sink11 |
+| GlobalDataFlow.cs:380:22:380:28 | access to parameter tainted | GlobalDataFlow.cs:382:16:382:21 | access to local variable sink11 |
+| GlobalDataFlow.cs:380:22:380:28 | access to parameter tainted | GlobalDataFlow.cs:382:16:382:21 | access to local variable sink11 |
+| GlobalDataFlow.cs:381:9:381:21 | call to method Check | GlobalDataFlow.cs:381:9:381:21 | call to method Check |
+| GlobalDataFlow.cs:381:15:381:20 | access to local variable sink11 | GlobalDataFlow.cs:381:15:381:20 | access to local variable sink11 |
+| GlobalDataFlow.cs:381:15:381:20 | access to local variable sink11 | GlobalDataFlow.cs:382:16:382:21 | access to local variable sink11 |
+| GlobalDataFlow.cs:381:15:381:20 | access to local variable sink11 | GlobalDataFlow.cs:382:16:382:21 | access to local variable sink11 |
+| GlobalDataFlow.cs:381:15:381:20 | access to local variable sink11 | GlobalDataFlow.cs:382:16:382:21 | access to local variable sink11 |
+| GlobalDataFlow.cs:381:15:381:20 | access to local variable sink11 | GlobalDataFlow.cs:382:16:382:21 | access to local variable sink11 |
+| GlobalDataFlow.cs:382:16:382:21 | access to local variable sink11 | GlobalDataFlow.cs:163:22:163:43 | call to method TaintedParam |
+| GlobalDataFlow.cs:382:16:382:21 | access to local variable sink11 | GlobalDataFlow.cs:163:22:163:43 | call to method TaintedParam |
+| GlobalDataFlow.cs:382:16:382:21 | access to local variable sink11 | GlobalDataFlow.cs:382:16:382:21 | access to local variable sink11 |
+| GlobalDataFlow.cs:385:42:385:51 | nonTainted | GlobalDataFlow.cs:385:42:385:51 | nonTainted |
+| GlobalDataFlow.cs:385:42:385:51 | nonTainted | GlobalDataFlow.cs:385:42:385:51 | nonTainted |
+| GlobalDataFlow.cs:385:42:385:51 | nonTainted | GlobalDataFlow.cs:385:42:385:51 | nonTainted |
+| GlobalDataFlow.cs:385:42:385:51 | nonTainted | GlobalDataFlow.cs:385:42:385:51 | nonTainted |
+| GlobalDataFlow.cs:385:42:385:51 | nonTainted | GlobalDataFlow.cs:387:13:387:33 | SSA def(nonSink0) |
+| GlobalDataFlow.cs:385:42:385:51 | nonTainted | GlobalDataFlow.cs:387:13:387:33 | SSA def(nonSink0) |
+| GlobalDataFlow.cs:385:42:385:51 | nonTainted | GlobalDataFlow.cs:387:13:387:33 | SSA def(nonSink0) |
+| GlobalDataFlow.cs:385:42:385:51 | nonTainted | GlobalDataFlow.cs:387:13:387:33 | SSA def(nonSink0) |
+| GlobalDataFlow.cs:385:42:385:51 | nonTainted | GlobalDataFlow.cs:387:13:387:33 | SSA def(nonSink0) |
+| GlobalDataFlow.cs:385:42:385:51 | nonTainted | GlobalDataFlow.cs:387:13:387:33 | SSA def(nonSink0) |
+| GlobalDataFlow.cs:385:42:385:51 | nonTainted | GlobalDataFlow.cs:387:24:387:33 | access to parameter nonTainted |
+| GlobalDataFlow.cs:385:42:385:51 | nonTainted | GlobalDataFlow.cs:387:24:387:33 | access to parameter nonTainted |
+| GlobalDataFlow.cs:385:42:385:51 | nonTainted | GlobalDataFlow.cs:387:24:387:33 | access to parameter nonTainted |
+| GlobalDataFlow.cs:385:42:385:51 | nonTainted | GlobalDataFlow.cs:387:24:387:33 | access to parameter nonTainted |
+| GlobalDataFlow.cs:385:42:385:51 | nonTainted | GlobalDataFlow.cs:387:24:387:33 | access to parameter nonTainted |
+| GlobalDataFlow.cs:385:42:385:51 | nonTainted | GlobalDataFlow.cs:387:24:387:33 | access to parameter nonTainted |
+| GlobalDataFlow.cs:385:42:385:51 | nonTainted | GlobalDataFlow.cs:388:15:388:22 | access to local variable nonSink0 |
+| GlobalDataFlow.cs:385:42:385:51 | nonTainted | GlobalDataFlow.cs:388:15:388:22 | access to local variable nonSink0 |
+| GlobalDataFlow.cs:385:42:385:51 | nonTainted | GlobalDataFlow.cs:388:15:388:22 | access to local variable nonSink0 |
+| GlobalDataFlow.cs:385:42:385:51 | nonTainted | GlobalDataFlow.cs:388:15:388:22 | access to local variable nonSink0 |
+| GlobalDataFlow.cs:385:42:385:51 | nonTainted | GlobalDataFlow.cs:388:15:388:22 | access to local variable nonSink0 |
+| GlobalDataFlow.cs:385:42:385:51 | nonTainted | GlobalDataFlow.cs:388:15:388:22 | access to local variable nonSink0 |
+| GlobalDataFlow.cs:385:42:385:51 | nonTainted | GlobalDataFlow.cs:389:16:389:23 | access to local variable nonSink0 |
+| GlobalDataFlow.cs:385:42:385:51 | nonTainted | GlobalDataFlow.cs:389:16:389:23 | access to local variable nonSink0 |
+| GlobalDataFlow.cs:385:42:385:51 | nonTainted | GlobalDataFlow.cs:389:16:389:23 | access to local variable nonSink0 |
+| GlobalDataFlow.cs:385:42:385:51 | nonTainted | GlobalDataFlow.cs:389:16:389:23 | access to local variable nonSink0 |
+| GlobalDataFlow.cs:385:42:385:51 | nonTainted | GlobalDataFlow.cs:389:16:389:23 | access to local variable nonSink0 |
+| GlobalDataFlow.cs:385:42:385:51 | nonTainted | GlobalDataFlow.cs:389:16:389:23 | access to local variable nonSink0 |
+| GlobalDataFlow.cs:387:13:387:33 | SSA def(nonSink0) | GlobalDataFlow.cs:387:13:387:33 | SSA def(nonSink0) |
+| GlobalDataFlow.cs:387:13:387:33 | SSA def(nonSink0) | GlobalDataFlow.cs:388:15:388:22 | access to local variable nonSink0 |
+| GlobalDataFlow.cs:387:13:387:33 | SSA def(nonSink0) | GlobalDataFlow.cs:388:15:388:22 | access to local variable nonSink0 |
+| GlobalDataFlow.cs:387:13:387:33 | SSA def(nonSink0) | GlobalDataFlow.cs:388:15:388:22 | access to local variable nonSink0 |
+| GlobalDataFlow.cs:387:13:387:33 | SSA def(nonSink0) | GlobalDataFlow.cs:388:15:388:22 | access to local variable nonSink0 |
+| GlobalDataFlow.cs:387:13:387:33 | SSA def(nonSink0) | GlobalDataFlow.cs:389:16:389:23 | access to local variable nonSink0 |
+| GlobalDataFlow.cs:387:13:387:33 | SSA def(nonSink0) | GlobalDataFlow.cs:389:16:389:23 | access to local variable nonSink0 |
+| GlobalDataFlow.cs:387:13:387:33 | SSA def(nonSink0) | GlobalDataFlow.cs:389:16:389:23 | access to local variable nonSink0 |
+| GlobalDataFlow.cs:387:13:387:33 | SSA def(nonSink0) | GlobalDataFlow.cs:389:16:389:23 | access to local variable nonSink0 |
+| GlobalDataFlow.cs:387:13:387:33 | String nonSink0 = ... | GlobalDataFlow.cs:387:13:387:33 | String nonSink0 = ... |
+| GlobalDataFlow.cs:387:24:387:33 | access to parameter nonTainted | GlobalDataFlow.cs:387:13:387:33 | SSA def(nonSink0) |
+| GlobalDataFlow.cs:387:24:387:33 | access to parameter nonTainted | GlobalDataFlow.cs:387:13:387:33 | SSA def(nonSink0) |
+| GlobalDataFlow.cs:387:24:387:33 | access to parameter nonTainted | GlobalDataFlow.cs:387:13:387:33 | SSA def(nonSink0) |
+| GlobalDataFlow.cs:387:24:387:33 | access to parameter nonTainted | GlobalDataFlow.cs:387:13:387:33 | SSA def(nonSink0) |
+| GlobalDataFlow.cs:387:24:387:33 | access to parameter nonTainted | GlobalDataFlow.cs:387:24:387:33 | access to parameter nonTainted |
+| GlobalDataFlow.cs:387:24:387:33 | access to parameter nonTainted | GlobalDataFlow.cs:388:15:388:22 | access to local variable nonSink0 |
+| GlobalDataFlow.cs:387:24:387:33 | access to parameter nonTainted | GlobalDataFlow.cs:388:15:388:22 | access to local variable nonSink0 |
+| GlobalDataFlow.cs:387:24:387:33 | access to parameter nonTainted | GlobalDataFlow.cs:388:15:388:22 | access to local variable nonSink0 |
+| GlobalDataFlow.cs:387:24:387:33 | access to parameter nonTainted | GlobalDataFlow.cs:388:15:388:22 | access to local variable nonSink0 |
+| GlobalDataFlow.cs:387:24:387:33 | access to parameter nonTainted | GlobalDataFlow.cs:389:16:389:23 | access to local variable nonSink0 |
+| GlobalDataFlow.cs:387:24:387:33 | access to parameter nonTainted | GlobalDataFlow.cs:389:16:389:23 | access to local variable nonSink0 |
+| GlobalDataFlow.cs:387:24:387:33 | access to parameter nonTainted | GlobalDataFlow.cs:389:16:389:23 | access to local variable nonSink0 |
+| GlobalDataFlow.cs:387:24:387:33 | access to parameter nonTainted | GlobalDataFlow.cs:389:16:389:23 | access to local variable nonSink0 |
+| GlobalDataFlow.cs:388:9:388:23 | call to method Check | GlobalDataFlow.cs:388:9:388:23 | call to method Check |
+| GlobalDataFlow.cs:388:15:388:22 | access to local variable nonSink0 | GlobalDataFlow.cs:388:15:388:22 | access to local variable nonSink0 |
+| GlobalDataFlow.cs:388:15:388:22 | access to local variable nonSink0 | GlobalDataFlow.cs:389:16:389:23 | access to local variable nonSink0 |
+| GlobalDataFlow.cs:388:15:388:22 | access to local variable nonSink0 | GlobalDataFlow.cs:389:16:389:23 | access to local variable nonSink0 |
+| GlobalDataFlow.cs:388:15:388:22 | access to local variable nonSink0 | GlobalDataFlow.cs:389:16:389:23 | access to local variable nonSink0 |
+| GlobalDataFlow.cs:388:15:388:22 | access to local variable nonSink0 | GlobalDataFlow.cs:389:16:389:23 | access to local variable nonSink0 |
+| GlobalDataFlow.cs:389:16:389:23 | access to local variable nonSink0 | GlobalDataFlow.cs:175:20:175:44 | call to method NonTaintedParam |
+| GlobalDataFlow.cs:389:16:389:23 | access to local variable nonSink0 | GlobalDataFlow.cs:175:20:175:44 | call to method NonTaintedParam |
+| GlobalDataFlow.cs:389:16:389:23 | access to local variable nonSink0 | GlobalDataFlow.cs:389:16:389:23 | access to local variable nonSink0 |
+| GlobalDataFlow.cs:398:62:398:63 | "" | GlobalDataFlow.cs:32:15:32:35 | access to property NonSinkProperty1 |
+| GlobalDataFlow.cs:398:62:398:63 | "" | GlobalDataFlow.cs:32:15:32:35 | access to property NonSinkProperty1 |
+| GlobalDataFlow.cs:398:62:398:63 | "" | GlobalDataFlow.cs:398:62:398:63 | "" |
+| GlobalDataFlow.cs:403:9:403:11 | this | GlobalDataFlow.cs:403:9:403:11 | this |
+| GlobalDataFlow.cs:403:22:403:23 | "" | GlobalDataFlow.cs:403:22:403:23 | "" |
 | GlobalDataFlow.cs:404:9:404:11 | this | GlobalDataFlow.cs:404:9:404:11 | this |
-| GlobalDataFlow.cs:404:22:404:23 | "" | GlobalDataFlow.cs:404:22:404:23 | "" |
-| GlobalDataFlow.cs:405:9:405:11 | this | GlobalDataFlow.cs:405:9:405:11 | this |
-| GlobalDataFlow.cs:405:9:405:11 | value | GlobalDataFlow.cs:405:9:405:11 | value |
-| GlobalDataFlow.cs:405:9:405:11 | value | GlobalDataFlow.cs:405:9:405:11 | value |
-| GlobalDataFlow.cs:405:9:405:11 | value | GlobalDataFlow.cs:405:9:405:11 | value |
-| GlobalDataFlow.cs:405:9:405:11 | value | GlobalDataFlow.cs:405:9:405:11 | value |
-| GlobalDataFlow.cs:405:9:405:11 | value | GlobalDataFlow.cs:405:19:405:34 | SSA def(nonSink0) |
-| GlobalDataFlow.cs:405:9:405:11 | value | GlobalDataFlow.cs:405:19:405:34 | SSA def(nonSink0) |
-| GlobalDataFlow.cs:405:9:405:11 | value | GlobalDataFlow.cs:405:19:405:34 | SSA def(nonSink0) |
-| GlobalDataFlow.cs:405:9:405:11 | value | GlobalDataFlow.cs:405:19:405:34 | SSA def(nonSink0) |
-| GlobalDataFlow.cs:405:9:405:11 | value | GlobalDataFlow.cs:405:19:405:34 | SSA def(nonSink0) |
-| GlobalDataFlow.cs:405:9:405:11 | value | GlobalDataFlow.cs:405:19:405:34 | SSA def(nonSink0) |
-| GlobalDataFlow.cs:405:9:405:11 | value | GlobalDataFlow.cs:405:30:405:34 | access to parameter value |
-| GlobalDataFlow.cs:405:9:405:11 | value | GlobalDataFlow.cs:405:30:405:34 | access to parameter value |
-| GlobalDataFlow.cs:405:9:405:11 | value | GlobalDataFlow.cs:405:30:405:34 | access to parameter value |
-| GlobalDataFlow.cs:405:9:405:11 | value | GlobalDataFlow.cs:405:30:405:34 | access to parameter value |
-| GlobalDataFlow.cs:405:9:405:11 | value | GlobalDataFlow.cs:405:30:405:34 | access to parameter value |
-| GlobalDataFlow.cs:405:9:405:11 | value | GlobalDataFlow.cs:405:30:405:34 | access to parameter value |
-| GlobalDataFlow.cs:405:9:405:11 | value | GlobalDataFlow.cs:405:43:405:50 | access to local variable nonSink0 |
-| GlobalDataFlow.cs:405:9:405:11 | value | GlobalDataFlow.cs:405:43:405:50 | access to local variable nonSink0 |
-| GlobalDataFlow.cs:405:9:405:11 | value | GlobalDataFlow.cs:405:43:405:50 | access to local variable nonSink0 |
-| GlobalDataFlow.cs:405:9:405:11 | value | GlobalDataFlow.cs:405:43:405:50 | access to local variable nonSink0 |
-| GlobalDataFlow.cs:405:9:405:11 | value | GlobalDataFlow.cs:405:43:405:50 | access to local variable nonSink0 |
-| GlobalDataFlow.cs:405:9:405:11 | value | GlobalDataFlow.cs:405:43:405:50 | access to local variable nonSink0 |
-| GlobalDataFlow.cs:405:19:405:34 | SSA def(nonSink0) | GlobalDataFlow.cs:405:19:405:34 | SSA def(nonSink0) |
-| GlobalDataFlow.cs:405:19:405:34 | SSA def(nonSink0) | GlobalDataFlow.cs:405:43:405:50 | access to local variable nonSink0 |
-| GlobalDataFlow.cs:405:19:405:34 | SSA def(nonSink0) | GlobalDataFlow.cs:405:43:405:50 | access to local variable nonSink0 |
-| GlobalDataFlow.cs:405:19:405:34 | SSA def(nonSink0) | GlobalDataFlow.cs:405:43:405:50 | access to local variable nonSink0 |
-| GlobalDataFlow.cs:405:19:405:34 | SSA def(nonSink0) | GlobalDataFlow.cs:405:43:405:50 | access to local variable nonSink0 |
-| GlobalDataFlow.cs:405:19:405:34 | String nonSink0 = ... | GlobalDataFlow.cs:405:19:405:34 | String nonSink0 = ... |
-| GlobalDataFlow.cs:405:30:405:34 | access to parameter value | GlobalDataFlow.cs:405:19:405:34 | SSA def(nonSink0) |
-| GlobalDataFlow.cs:405:30:405:34 | access to parameter value | GlobalDataFlow.cs:405:19:405:34 | SSA def(nonSink0) |
-| GlobalDataFlow.cs:405:30:405:34 | access to parameter value | GlobalDataFlow.cs:405:19:405:34 | SSA def(nonSink0) |
-| GlobalDataFlow.cs:405:30:405:34 | access to parameter value | GlobalDataFlow.cs:405:19:405:34 | SSA def(nonSink0) |
-| GlobalDataFlow.cs:405:30:405:34 | access to parameter value | GlobalDataFlow.cs:405:30:405:34 | access to parameter value |
-| GlobalDataFlow.cs:405:30:405:34 | access to parameter value | GlobalDataFlow.cs:405:43:405:50 | access to local variable nonSink0 |
-| GlobalDataFlow.cs:405:30:405:34 | access to parameter value | GlobalDataFlow.cs:405:43:405:50 | access to local variable nonSink0 |
-| GlobalDataFlow.cs:405:30:405:34 | access to parameter value | GlobalDataFlow.cs:405:43:405:50 | access to local variable nonSink0 |
-| GlobalDataFlow.cs:405:30:405:34 | access to parameter value | GlobalDataFlow.cs:405:43:405:50 | access to local variable nonSink0 |
-| GlobalDataFlow.cs:405:37:405:51 | call to method Check | GlobalDataFlow.cs:405:37:405:51 | call to method Check |
-| GlobalDataFlow.cs:405:43:405:50 | access to local variable nonSink0 | GlobalDataFlow.cs:405:43:405:50 | access to local variable nonSink0 |
+| GlobalDataFlow.cs:404:9:404:11 | value | GlobalDataFlow.cs:404:9:404:11 | value |
+| GlobalDataFlow.cs:404:9:404:11 | value | GlobalDataFlow.cs:404:9:404:11 | value |
+| GlobalDataFlow.cs:404:9:404:11 | value | GlobalDataFlow.cs:404:9:404:11 | value |
+| GlobalDataFlow.cs:404:9:404:11 | value | GlobalDataFlow.cs:404:9:404:11 | value |
+| GlobalDataFlow.cs:404:9:404:11 | value | GlobalDataFlow.cs:404:19:404:32 | SSA def(sink20) |
+| GlobalDataFlow.cs:404:9:404:11 | value | GlobalDataFlow.cs:404:19:404:32 | SSA def(sink20) |
+| GlobalDataFlow.cs:404:9:404:11 | value | GlobalDataFlow.cs:404:19:404:32 | SSA def(sink20) |
+| GlobalDataFlow.cs:404:9:404:11 | value | GlobalDataFlow.cs:404:19:404:32 | SSA def(sink20) |
+| GlobalDataFlow.cs:404:9:404:11 | value | GlobalDataFlow.cs:404:19:404:32 | SSA def(sink20) |
+| GlobalDataFlow.cs:404:9:404:11 | value | GlobalDataFlow.cs:404:19:404:32 | SSA def(sink20) |
+| GlobalDataFlow.cs:404:9:404:11 | value | GlobalDataFlow.cs:404:28:404:32 | access to parameter value |
+| GlobalDataFlow.cs:404:9:404:11 | value | GlobalDataFlow.cs:404:28:404:32 | access to parameter value |
+| GlobalDataFlow.cs:404:9:404:11 | value | GlobalDataFlow.cs:404:28:404:32 | access to parameter value |
+| GlobalDataFlow.cs:404:9:404:11 | value | GlobalDataFlow.cs:404:28:404:32 | access to parameter value |
+| GlobalDataFlow.cs:404:9:404:11 | value | GlobalDataFlow.cs:404:28:404:32 | access to parameter value |
+| GlobalDataFlow.cs:404:9:404:11 | value | GlobalDataFlow.cs:404:28:404:32 | access to parameter value |
+| GlobalDataFlow.cs:404:9:404:11 | value | GlobalDataFlow.cs:404:41:404:46 | access to local variable sink20 |
+| GlobalDataFlow.cs:404:9:404:11 | value | GlobalDataFlow.cs:404:41:404:46 | access to local variable sink20 |
+| GlobalDataFlow.cs:404:9:404:11 | value | GlobalDataFlow.cs:404:41:404:46 | access to local variable sink20 |
+| GlobalDataFlow.cs:404:9:404:11 | value | GlobalDataFlow.cs:404:41:404:46 | access to local variable sink20 |
+| GlobalDataFlow.cs:404:9:404:11 | value | GlobalDataFlow.cs:404:41:404:46 | access to local variable sink20 |
+| GlobalDataFlow.cs:404:9:404:11 | value | GlobalDataFlow.cs:404:41:404:46 | access to local variable sink20 |
+| GlobalDataFlow.cs:404:19:404:32 | SSA def(sink20) | GlobalDataFlow.cs:404:19:404:32 | SSA def(sink20) |
+| GlobalDataFlow.cs:404:19:404:32 | SSA def(sink20) | GlobalDataFlow.cs:404:41:404:46 | access to local variable sink20 |
+| GlobalDataFlow.cs:404:19:404:32 | SSA def(sink20) | GlobalDataFlow.cs:404:41:404:46 | access to local variable sink20 |
+| GlobalDataFlow.cs:404:19:404:32 | SSA def(sink20) | GlobalDataFlow.cs:404:41:404:46 | access to local variable sink20 |
+| GlobalDataFlow.cs:404:19:404:32 | SSA def(sink20) | GlobalDataFlow.cs:404:41:404:46 | access to local variable sink20 |
+| GlobalDataFlow.cs:404:19:404:32 | String sink20 = ... | GlobalDataFlow.cs:404:19:404:32 | String sink20 = ... |
+| GlobalDataFlow.cs:404:28:404:32 | access to parameter value | GlobalDataFlow.cs:404:19:404:32 | SSA def(sink20) |
+| GlobalDataFlow.cs:404:28:404:32 | access to parameter value | GlobalDataFlow.cs:404:19:404:32 | SSA def(sink20) |
+| GlobalDataFlow.cs:404:28:404:32 | access to parameter value | GlobalDataFlow.cs:404:19:404:32 | SSA def(sink20) |
+| GlobalDataFlow.cs:404:28:404:32 | access to parameter value | GlobalDataFlow.cs:404:19:404:32 | SSA def(sink20) |
+| GlobalDataFlow.cs:404:28:404:32 | access to parameter value | GlobalDataFlow.cs:404:28:404:32 | access to parameter value |
+| GlobalDataFlow.cs:404:28:404:32 | access to parameter value | GlobalDataFlow.cs:404:41:404:46 | access to local variable sink20 |
+| GlobalDataFlow.cs:404:28:404:32 | access to parameter value | GlobalDataFlow.cs:404:41:404:46 | access to local variable sink20 |
+| GlobalDataFlow.cs:404:28:404:32 | access to parameter value | GlobalDataFlow.cs:404:41:404:46 | access to local variable sink20 |
+| GlobalDataFlow.cs:404:28:404:32 | access to parameter value | GlobalDataFlow.cs:404:41:404:46 | access to local variable sink20 |
+| GlobalDataFlow.cs:404:35:404:47 | call to method Check | GlobalDataFlow.cs:404:35:404:47 | call to method Check |
+| GlobalDataFlow.cs:404:41:404:46 | access to local variable sink20 | GlobalDataFlow.cs:404:41:404:46 | access to local variable sink20 |
+| GlobalDataFlow.cs:409:9:409:11 | this | GlobalDataFlow.cs:409:9:409:11 | this |
+| GlobalDataFlow.cs:409:22:409:23 | "" | GlobalDataFlow.cs:409:22:409:23 | "" |
 | GlobalDataFlow.cs:410:9:410:11 | this | GlobalDataFlow.cs:410:9:410:11 | this |
-| GlobalDataFlow.cs:410:22:410:35 | "taint source" | GlobalDataFlow.cs:193:22:193:32 | access to property OutProperty |
-| GlobalDataFlow.cs:410:22:410:35 | "taint source" | GlobalDataFlow.cs:193:22:193:32 | access to property OutProperty |
-| GlobalDataFlow.cs:410:22:410:35 | "taint source" | GlobalDataFlow.cs:410:22:410:35 | "taint source" |
+| GlobalDataFlow.cs:410:9:410:11 | value | GlobalDataFlow.cs:410:9:410:11 | value |
+| GlobalDataFlow.cs:410:9:410:11 | value | GlobalDataFlow.cs:410:9:410:11 | value |
+| GlobalDataFlow.cs:410:9:410:11 | value | GlobalDataFlow.cs:410:9:410:11 | value |
+| GlobalDataFlow.cs:410:9:410:11 | value | GlobalDataFlow.cs:410:9:410:11 | value |
+| GlobalDataFlow.cs:410:9:410:11 | value | GlobalDataFlow.cs:410:19:410:34 | SSA def(nonSink0) |
+| GlobalDataFlow.cs:410:9:410:11 | value | GlobalDataFlow.cs:410:19:410:34 | SSA def(nonSink0) |
+| GlobalDataFlow.cs:410:9:410:11 | value | GlobalDataFlow.cs:410:19:410:34 | SSA def(nonSink0) |
+| GlobalDataFlow.cs:410:9:410:11 | value | GlobalDataFlow.cs:410:19:410:34 | SSA def(nonSink0) |
+| GlobalDataFlow.cs:410:9:410:11 | value | GlobalDataFlow.cs:410:19:410:34 | SSA def(nonSink0) |
+| GlobalDataFlow.cs:410:9:410:11 | value | GlobalDataFlow.cs:410:19:410:34 | SSA def(nonSink0) |
+| GlobalDataFlow.cs:410:9:410:11 | value | GlobalDataFlow.cs:410:30:410:34 | access to parameter value |
+| GlobalDataFlow.cs:410:9:410:11 | value | GlobalDataFlow.cs:410:30:410:34 | access to parameter value |
+| GlobalDataFlow.cs:410:9:410:11 | value | GlobalDataFlow.cs:410:30:410:34 | access to parameter value |
+| GlobalDataFlow.cs:410:9:410:11 | value | GlobalDataFlow.cs:410:30:410:34 | access to parameter value |
+| GlobalDataFlow.cs:410:9:410:11 | value | GlobalDataFlow.cs:410:30:410:34 | access to parameter value |
+| GlobalDataFlow.cs:410:9:410:11 | value | GlobalDataFlow.cs:410:30:410:34 | access to parameter value |
+| GlobalDataFlow.cs:410:9:410:11 | value | GlobalDataFlow.cs:410:43:410:50 | access to local variable nonSink0 |
+| GlobalDataFlow.cs:410:9:410:11 | value | GlobalDataFlow.cs:410:43:410:50 | access to local variable nonSink0 |
+| GlobalDataFlow.cs:410:9:410:11 | value | GlobalDataFlow.cs:410:43:410:50 | access to local variable nonSink0 |
+| GlobalDataFlow.cs:410:9:410:11 | value | GlobalDataFlow.cs:410:43:410:50 | access to local variable nonSink0 |
+| GlobalDataFlow.cs:410:9:410:11 | value | GlobalDataFlow.cs:410:43:410:50 | access to local variable nonSink0 |
+| GlobalDataFlow.cs:410:9:410:11 | value | GlobalDataFlow.cs:410:43:410:50 | access to local variable nonSink0 |
+| GlobalDataFlow.cs:410:19:410:34 | SSA def(nonSink0) | GlobalDataFlow.cs:410:19:410:34 | SSA def(nonSink0) |
+| GlobalDataFlow.cs:410:19:410:34 | SSA def(nonSink0) | GlobalDataFlow.cs:410:43:410:50 | access to local variable nonSink0 |
+| GlobalDataFlow.cs:410:19:410:34 | SSA def(nonSink0) | GlobalDataFlow.cs:410:43:410:50 | access to local variable nonSink0 |
+| GlobalDataFlow.cs:410:19:410:34 | SSA def(nonSink0) | GlobalDataFlow.cs:410:43:410:50 | access to local variable nonSink0 |
+| GlobalDataFlow.cs:410:19:410:34 | SSA def(nonSink0) | GlobalDataFlow.cs:410:43:410:50 | access to local variable nonSink0 |
+| GlobalDataFlow.cs:410:19:410:34 | String nonSink0 = ... | GlobalDataFlow.cs:410:19:410:34 | String nonSink0 = ... |
+| GlobalDataFlow.cs:410:30:410:34 | access to parameter value | GlobalDataFlow.cs:410:19:410:34 | SSA def(nonSink0) |
+| GlobalDataFlow.cs:410:30:410:34 | access to parameter value | GlobalDataFlow.cs:410:19:410:34 | SSA def(nonSink0) |
+| GlobalDataFlow.cs:410:30:410:34 | access to parameter value | GlobalDataFlow.cs:410:19:410:34 | SSA def(nonSink0) |
+| GlobalDataFlow.cs:410:30:410:34 | access to parameter value | GlobalDataFlow.cs:410:19:410:34 | SSA def(nonSink0) |
+| GlobalDataFlow.cs:410:30:410:34 | access to parameter value | GlobalDataFlow.cs:410:30:410:34 | access to parameter value |
+| GlobalDataFlow.cs:410:30:410:34 | access to parameter value | GlobalDataFlow.cs:410:43:410:50 | access to local variable nonSink0 |
+| GlobalDataFlow.cs:410:30:410:34 | access to parameter value | GlobalDataFlow.cs:410:43:410:50 | access to local variable nonSink0 |
+| GlobalDataFlow.cs:410:30:410:34 | access to parameter value | GlobalDataFlow.cs:410:43:410:50 | access to local variable nonSink0 |
+| GlobalDataFlow.cs:410:30:410:34 | access to parameter value | GlobalDataFlow.cs:410:43:410:50 | access to local variable nonSink0 |
+| GlobalDataFlow.cs:410:37:410:51 | call to method Check | GlobalDataFlow.cs:410:37:410:51 | call to method Check |
+| GlobalDataFlow.cs:410:43:410:50 | access to local variable nonSink0 | GlobalDataFlow.cs:410:43:410:50 | access to local variable nonSink0 |
 | GlobalDataFlow.cs:415:9:415:11 | this | GlobalDataFlow.cs:415:9:415:11 | this |
-| GlobalDataFlow.cs:415:22:415:23 | "" | GlobalDataFlow.cs:197:20:197:33 | access to property NonOutProperty |
-| GlobalDataFlow.cs:415:22:415:23 | "" | GlobalDataFlow.cs:197:20:197:33 | access to property NonOutProperty |
-| GlobalDataFlow.cs:415:22:415:23 | "" | GlobalDataFlow.cs:415:22:415:23 | "" |
-| GlobalDataFlow.cs:421:71:421:71 | e | GlobalDataFlow.cs:421:71:421:71 | e |
-| GlobalDataFlow.cs:421:71:421:71 | e | GlobalDataFlow.cs:421:71:421:71 | e |
-| GlobalDataFlow.cs:421:71:421:71 | e | GlobalDataFlow.cs:421:71:421:71 | e |
-| GlobalDataFlow.cs:421:71:421:71 | e | GlobalDataFlow.cs:421:71:421:71 | e |
-| GlobalDataFlow.cs:421:71:421:71 | e | GlobalDataFlow.cs:424:22:424:22 | SSA def(x) |
-| GlobalDataFlow.cs:421:71:421:71 | e | GlobalDataFlow.cs:424:22:424:22 | SSA def(x) |
-| GlobalDataFlow.cs:421:71:421:71 | e | GlobalDataFlow.cs:424:22:424:22 | SSA def(x) |
-| GlobalDataFlow.cs:421:71:421:71 | e | GlobalDataFlow.cs:424:22:424:22 | SSA def(x) |
-| GlobalDataFlow.cs:421:71:421:71 | e | GlobalDataFlow.cs:424:22:424:22 | SSA def(x) |
-| GlobalDataFlow.cs:421:71:421:71 | e | GlobalDataFlow.cs:424:22:424:22 | SSA def(x) |
-| GlobalDataFlow.cs:421:71:421:71 | e | GlobalDataFlow.cs:424:22:424:22 | SSA def(x) |
-| GlobalDataFlow.cs:421:71:421:71 | e | GlobalDataFlow.cs:424:22:424:22 | SSA def(x) |
-| GlobalDataFlow.cs:421:71:421:71 | e | GlobalDataFlow.cs:424:27:424:27 | access to parameter e |
-| GlobalDataFlow.cs:421:71:421:71 | e | GlobalDataFlow.cs:424:27:424:27 | access to parameter e |
-| GlobalDataFlow.cs:421:71:421:71 | e | GlobalDataFlow.cs:424:27:424:27 | access to parameter e |
-| GlobalDataFlow.cs:421:71:421:71 | e | GlobalDataFlow.cs:424:27:424:27 | access to parameter e |
-| GlobalDataFlow.cs:421:71:421:71 | e | GlobalDataFlow.cs:424:27:424:27 | access to parameter e |
-| GlobalDataFlow.cs:421:71:421:71 | e | GlobalDataFlow.cs:424:27:424:27 | access to parameter e |
-| GlobalDataFlow.cs:421:71:421:71 | e | GlobalDataFlow.cs:424:27:424:27 | access to parameter e |
-| GlobalDataFlow.cs:421:71:421:71 | e | GlobalDataFlow.cs:424:27:424:27 | access to parameter e |
-| GlobalDataFlow.cs:421:71:421:71 | e | GlobalDataFlow.cs:426:46:426:46 | access to local variable x |
-| GlobalDataFlow.cs:421:71:421:71 | e | GlobalDataFlow.cs:426:46:426:46 | access to local variable x |
-| GlobalDataFlow.cs:421:71:421:71 | e | GlobalDataFlow.cs:426:46:426:46 | access to local variable x |
-| GlobalDataFlow.cs:421:71:421:71 | e | GlobalDataFlow.cs:426:46:426:46 | access to local variable x |
-| GlobalDataFlow.cs:421:71:421:71 | e | GlobalDataFlow.cs:426:46:426:46 | access to local variable x |
-| GlobalDataFlow.cs:421:71:421:71 | e | GlobalDataFlow.cs:426:46:426:46 | access to local variable x |
-| GlobalDataFlow.cs:421:71:421:71 | e | GlobalDataFlow.cs:426:46:426:46 | access to local variable x |
-| GlobalDataFlow.cs:421:71:421:71 | e | GlobalDataFlow.cs:426:46:426:46 | access to local variable x |
-| GlobalDataFlow.cs:421:85:421:85 | f | GlobalDataFlow.cs:421:85:421:85 | f |
-| GlobalDataFlow.cs:421:85:421:85 | f | GlobalDataFlow.cs:421:85:421:85 | f |
-| GlobalDataFlow.cs:421:85:421:85 | f | GlobalDataFlow.cs:421:85:421:85 | f |
-| GlobalDataFlow.cs:421:85:421:85 | f | GlobalDataFlow.cs:421:85:421:85 | f |
-| GlobalDataFlow.cs:421:85:421:85 | f | GlobalDataFlow.cs:426:44:426:44 | access to parameter f |
-| GlobalDataFlow.cs:421:85:421:85 | f | GlobalDataFlow.cs:426:44:426:44 | access to parameter f |
-| GlobalDataFlow.cs:421:85:421:85 | f | GlobalDataFlow.cs:426:44:426:44 | access to parameter f |
-| GlobalDataFlow.cs:421:85:421:85 | f | GlobalDataFlow.cs:426:44:426:44 | access to parameter f |
-| GlobalDataFlow.cs:421:85:421:85 | f | GlobalDataFlow.cs:426:44:426:44 | access to parameter f |
-| GlobalDataFlow.cs:421:85:421:85 | f | GlobalDataFlow.cs:426:44:426:44 | access to parameter f |
-| GlobalDataFlow.cs:421:85:421:85 | f | GlobalDataFlow.cs:426:44:426:44 | access to parameter f |
-| GlobalDataFlow.cs:421:85:421:85 | f | GlobalDataFlow.cs:426:44:426:44 | access to parameter f |
-| GlobalDataFlow.cs:423:13:423:17 | Int32 i = ... | GlobalDataFlow.cs:423:13:423:17 | Int32 i = ... |
-| GlobalDataFlow.cs:423:13:423:17 | SSA def(i) | GlobalDataFlow.cs:423:13:423:17 | SSA def(i) |
-| GlobalDataFlow.cs:423:13:423:17 | SSA def(i) | GlobalDataFlow.cs:424:9:427:9 | SSA phi(i) |
-| GlobalDataFlow.cs:423:13:423:17 | SSA def(i) | GlobalDataFlow.cs:424:9:427:9 | SSA phi(i) |
-| GlobalDataFlow.cs:423:13:423:17 | SSA def(i) | GlobalDataFlow.cs:426:17:426:17 | access to local variable i |
-| GlobalDataFlow.cs:423:13:423:17 | SSA def(i) | GlobalDataFlow.cs:426:17:426:17 | access to local variable i |
-| GlobalDataFlow.cs:423:17:423:17 | 0 | GlobalDataFlow.cs:423:13:423:17 | SSA def(i) |
-| GlobalDataFlow.cs:423:17:423:17 | 0 | GlobalDataFlow.cs:423:13:423:17 | SSA def(i) |
-| GlobalDataFlow.cs:423:17:423:17 | 0 | GlobalDataFlow.cs:423:17:423:17 | 0 |
-| GlobalDataFlow.cs:423:17:423:17 | 0 | GlobalDataFlow.cs:424:9:427:9 | SSA phi(i) |
-| GlobalDataFlow.cs:423:17:423:17 | 0 | GlobalDataFlow.cs:424:9:427:9 | SSA phi(i) |
-| GlobalDataFlow.cs:423:17:423:17 | 0 | GlobalDataFlow.cs:426:17:426:17 | access to local variable i |
-| GlobalDataFlow.cs:423:17:423:17 | 0 | GlobalDataFlow.cs:426:17:426:17 | access to local variable i |
-| GlobalDataFlow.cs:424:9:427:9 | SSA phi(i) | GlobalDataFlow.cs:424:9:427:9 | SSA phi(i) |
-| GlobalDataFlow.cs:424:9:427:9 | SSA phi(i) | GlobalDataFlow.cs:426:17:426:17 | access to local variable i |
-| GlobalDataFlow.cs:424:9:427:9 | SSA phi(i) | GlobalDataFlow.cs:426:17:426:17 | access to local variable i |
-| GlobalDataFlow.cs:424:22:424:22 | SSA def(x) | GlobalDataFlow.cs:424:22:424:22 | SSA def(x) |
-| GlobalDataFlow.cs:424:22:424:22 | SSA def(x) | GlobalDataFlow.cs:426:46:426:46 | access to local variable x |
-| GlobalDataFlow.cs:424:22:424:22 | SSA def(x) | GlobalDataFlow.cs:426:46:426:46 | access to local variable x |
-| GlobalDataFlow.cs:424:22:424:22 | SSA def(x) | GlobalDataFlow.cs:426:46:426:46 | access to local variable x |
-| GlobalDataFlow.cs:424:22:424:22 | SSA def(x) | GlobalDataFlow.cs:426:46:426:46 | access to local variable x |
-| GlobalDataFlow.cs:424:22:424:22 | SSA def(x) | GlobalDataFlow.cs:426:46:426:46 | access to local variable x |
-| GlobalDataFlow.cs:424:22:424:22 | SSA def(x) | GlobalDataFlow.cs:426:46:426:46 | access to local variable x |
-| GlobalDataFlow.cs:424:22:424:22 | T x | GlobalDataFlow.cs:424:22:424:22 | T x |
-| GlobalDataFlow.cs:424:27:424:27 | access to parameter e | GlobalDataFlow.cs:424:22:424:22 | SSA def(x) |
-| GlobalDataFlow.cs:424:27:424:27 | access to parameter e | GlobalDataFlow.cs:424:22:424:22 | SSA def(x) |
-| GlobalDataFlow.cs:424:27:424:27 | access to parameter e | GlobalDataFlow.cs:424:22:424:22 | SSA def(x) |
-| GlobalDataFlow.cs:424:27:424:27 | access to parameter e | GlobalDataFlow.cs:424:22:424:22 | SSA def(x) |
-| GlobalDataFlow.cs:424:27:424:27 | access to parameter e | GlobalDataFlow.cs:424:22:424:22 | SSA def(x) |
-| GlobalDataFlow.cs:424:27:424:27 | access to parameter e | GlobalDataFlow.cs:424:22:424:22 | SSA def(x) |
-| GlobalDataFlow.cs:424:27:424:27 | access to parameter e | GlobalDataFlow.cs:424:27:424:27 | access to parameter e |
-| GlobalDataFlow.cs:424:27:424:27 | access to parameter e | GlobalDataFlow.cs:426:46:426:46 | access to local variable x |
-| GlobalDataFlow.cs:424:27:424:27 | access to parameter e | GlobalDataFlow.cs:426:46:426:46 | access to local variable x |
-| GlobalDataFlow.cs:424:27:424:27 | access to parameter e | GlobalDataFlow.cs:426:46:426:46 | access to local variable x |
-| GlobalDataFlow.cs:424:27:424:27 | access to parameter e | GlobalDataFlow.cs:426:46:426:46 | access to local variable x |
-| GlobalDataFlow.cs:424:27:424:27 | access to parameter e | GlobalDataFlow.cs:426:46:426:46 | access to local variable x |
-| GlobalDataFlow.cs:424:27:424:27 | access to parameter e | GlobalDataFlow.cs:426:46:426:46 | access to local variable x |
-| GlobalDataFlow.cs:426:17:426:17 | access to local variable i | GlobalDataFlow.cs:426:17:426:17 | access to local variable i |
-| GlobalDataFlow.cs:426:17:426:19 | ...++ | GlobalDataFlow.cs:426:17:426:19 | ...++ |
-| GlobalDataFlow.cs:426:17:426:19 | SSA def(i) | GlobalDataFlow.cs:424:9:427:9 | SSA phi(i) |
-| GlobalDataFlow.cs:426:17:426:19 | SSA def(i) | GlobalDataFlow.cs:424:9:427:9 | SSA phi(i) |
-| GlobalDataFlow.cs:426:17:426:19 | SSA def(i) | GlobalDataFlow.cs:426:17:426:17 | access to local variable i |
-| GlobalDataFlow.cs:426:17:426:19 | SSA def(i) | GlobalDataFlow.cs:426:17:426:17 | access to local variable i |
-| GlobalDataFlow.cs:426:17:426:19 | SSA def(i) | GlobalDataFlow.cs:426:17:426:19 | SSA def(i) |
-| GlobalDataFlow.cs:426:17:426:23 | ... % ... | GlobalDataFlow.cs:426:17:426:23 | ... % ... |
-| GlobalDataFlow.cs:426:17:426:23 | ... % ... | GlobalDataFlow.cs:426:17:426:28 | ... == ... |
-| GlobalDataFlow.cs:426:17:426:23 | ... % ... | GlobalDataFlow.cs:426:17:426:28 | ... == ... |
-| GlobalDataFlow.cs:426:17:426:28 | ... == ... | GlobalDataFlow.cs:426:17:426:28 | ... == ... |
-| GlobalDataFlow.cs:426:23:426:23 | 2 | GlobalDataFlow.cs:426:23:426:23 | 2 |
-| GlobalDataFlow.cs:426:28:426:28 | 0 | GlobalDataFlow.cs:426:28:426:28 | 0 |
-| GlobalDataFlow.cs:426:44:426:44 | access to parameter f | GlobalDataFlow.cs:426:44:426:44 | access to parameter f |
-| GlobalDataFlow.cs:426:44:426:47 | delegate call | GlobalDataFlow.cs:80:22:80:85 | call to method SelectEven |
-| GlobalDataFlow.cs:426:44:426:47 | delegate call | GlobalDataFlow.cs:80:22:80:85 | call to method SelectEven |
-| GlobalDataFlow.cs:426:44:426:47 | delegate call | GlobalDataFlow.cs:80:22:80:85 | call to method SelectEven |
-| GlobalDataFlow.cs:426:44:426:47 | delegate call | GlobalDataFlow.cs:80:22:80:85 | call to method SelectEven |
-| GlobalDataFlow.cs:426:44:426:47 | delegate call | GlobalDataFlow.cs:108:24:108:90 | call to method SelectEven |
-| GlobalDataFlow.cs:426:44:426:47 | delegate call | GlobalDataFlow.cs:108:24:108:90 | call to method SelectEven |
-| GlobalDataFlow.cs:426:44:426:47 | delegate call | GlobalDataFlow.cs:108:24:108:90 | call to method SelectEven |
-| GlobalDataFlow.cs:426:44:426:47 | delegate call | GlobalDataFlow.cs:108:24:108:90 | call to method SelectEven |
-| GlobalDataFlow.cs:426:44:426:47 | delegate call | GlobalDataFlow.cs:426:44:426:47 | delegate call |
-| GlobalDataFlow.cs:426:44:426:47 | delegate call | GlobalDataFlow.cs:426:44:426:47 | delegate call |
-| GlobalDataFlow.cs:426:44:426:47 | delegate call | GlobalDataFlow.cs:426:44:426:47 | delegate call |
-| GlobalDataFlow.cs:426:44:426:47 | delegate call | GlobalDataFlow.cs:426:44:426:47 | delegate call |
-| GlobalDataFlow.cs:426:44:426:47 | delegate call | GlobalDataFlow.cs:426:44:426:47 | delegate call |
-| GlobalDataFlow.cs:426:44:426:47 | delegate call | GlobalDataFlow.cs:426:44:426:47 | delegate call |
-| GlobalDataFlow.cs:426:44:426:47 | delegate call | GlobalDataFlow.cs:426:44:426:47 | delegate call |
-| GlobalDataFlow.cs:426:44:426:47 | delegate call | GlobalDataFlow.cs:426:44:426:47 | delegate call |
-| GlobalDataFlow.cs:426:44:426:47 | delegate call | GlobalDataFlow.cs:426:44:426:47 | delegate call |
-| GlobalDataFlow.cs:426:44:426:47 | delegate call | GlobalDataFlow.cs:426:44:426:47 | delegate call |
-| GlobalDataFlow.cs:426:44:426:47 | delegate call | GlobalDataFlow.cs:426:44:426:47 | delegate call |
-| GlobalDataFlow.cs:426:44:426:47 | delegate call | GlobalDataFlow.cs:426:44:426:47 | delegate call |
-| GlobalDataFlow.cs:426:46:426:46 | access to local variable x | GlobalDataFlow.cs:80:79:80:79 | x |
-| GlobalDataFlow.cs:426:46:426:46 | access to local variable x | GlobalDataFlow.cs:80:79:80:79 | x |
-| GlobalDataFlow.cs:426:46:426:46 | access to local variable x | GlobalDataFlow.cs:80:79:80:79 | x |
-| GlobalDataFlow.cs:426:46:426:46 | access to local variable x | GlobalDataFlow.cs:80:79:80:79 | x |
-| GlobalDataFlow.cs:426:46:426:46 | access to local variable x | GlobalDataFlow.cs:108:84:108:84 | x |
-| GlobalDataFlow.cs:426:46:426:46 | access to local variable x | GlobalDataFlow.cs:108:84:108:84 | x |
-| GlobalDataFlow.cs:426:46:426:46 | access to local variable x | GlobalDataFlow.cs:108:84:108:84 | x |
-| GlobalDataFlow.cs:426:46:426:46 | access to local variable x | GlobalDataFlow.cs:108:84:108:84 | x |
-| GlobalDataFlow.cs:426:46:426:46 | access to local variable x | GlobalDataFlow.cs:426:44:426:47 | delegate call |
-| GlobalDataFlow.cs:426:46:426:46 | access to local variable x | GlobalDataFlow.cs:426:44:426:47 | delegate call |
-| GlobalDataFlow.cs:426:46:426:46 | access to local variable x | GlobalDataFlow.cs:426:44:426:47 | delegate call |
-| GlobalDataFlow.cs:426:46:426:46 | access to local variable x | GlobalDataFlow.cs:426:44:426:47 | delegate call |
-| GlobalDataFlow.cs:426:46:426:46 | access to local variable x | GlobalDataFlow.cs:426:44:426:47 | delegate call |
-| GlobalDataFlow.cs:426:46:426:46 | access to local variable x | GlobalDataFlow.cs:426:44:426:47 | delegate call |
-| GlobalDataFlow.cs:426:46:426:46 | access to local variable x | GlobalDataFlow.cs:426:46:426:46 | access to local variable x |
+| GlobalDataFlow.cs:415:22:415:35 | "taint source" | GlobalDataFlow.cs:197:22:197:32 | access to property OutProperty |
+| GlobalDataFlow.cs:415:22:415:35 | "taint source" | GlobalDataFlow.cs:197:22:197:32 | access to property OutProperty |
+| GlobalDataFlow.cs:415:22:415:35 | "taint source" | GlobalDataFlow.cs:415:22:415:35 | "taint source" |
+| GlobalDataFlow.cs:420:9:420:11 | this | GlobalDataFlow.cs:420:9:420:11 | this |
+| GlobalDataFlow.cs:420:22:420:23 | "" | GlobalDataFlow.cs:201:20:201:33 | access to property NonOutProperty |
+| GlobalDataFlow.cs:420:22:420:23 | "" | GlobalDataFlow.cs:201:20:201:33 | access to property NonOutProperty |
+| GlobalDataFlow.cs:420:22:420:23 | "" | GlobalDataFlow.cs:420:22:420:23 | "" |
+| GlobalDataFlow.cs:426:71:426:71 | e | GlobalDataFlow.cs:426:71:426:71 | e |
+| GlobalDataFlow.cs:426:71:426:71 | e | GlobalDataFlow.cs:426:71:426:71 | e |
+| GlobalDataFlow.cs:426:71:426:71 | e | GlobalDataFlow.cs:426:71:426:71 | e |
+| GlobalDataFlow.cs:426:71:426:71 | e | GlobalDataFlow.cs:426:71:426:71 | e |
+| GlobalDataFlow.cs:426:71:426:71 | e | GlobalDataFlow.cs:429:22:429:22 | SSA def(x) |
+| GlobalDataFlow.cs:426:71:426:71 | e | GlobalDataFlow.cs:429:22:429:22 | SSA def(x) |
+| GlobalDataFlow.cs:426:71:426:71 | e | GlobalDataFlow.cs:429:22:429:22 | SSA def(x) |
+| GlobalDataFlow.cs:426:71:426:71 | e | GlobalDataFlow.cs:429:22:429:22 | SSA def(x) |
+| GlobalDataFlow.cs:426:71:426:71 | e | GlobalDataFlow.cs:429:22:429:22 | SSA def(x) |
+| GlobalDataFlow.cs:426:71:426:71 | e | GlobalDataFlow.cs:429:22:429:22 | SSA def(x) |
+| GlobalDataFlow.cs:426:71:426:71 | e | GlobalDataFlow.cs:429:22:429:22 | SSA def(x) |
+| GlobalDataFlow.cs:426:71:426:71 | e | GlobalDataFlow.cs:429:22:429:22 | SSA def(x) |
+| GlobalDataFlow.cs:426:71:426:71 | e | GlobalDataFlow.cs:429:27:429:27 | access to parameter e |
+| GlobalDataFlow.cs:426:71:426:71 | e | GlobalDataFlow.cs:429:27:429:27 | access to parameter e |
+| GlobalDataFlow.cs:426:71:426:71 | e | GlobalDataFlow.cs:429:27:429:27 | access to parameter e |
+| GlobalDataFlow.cs:426:71:426:71 | e | GlobalDataFlow.cs:429:27:429:27 | access to parameter e |
+| GlobalDataFlow.cs:426:71:426:71 | e | GlobalDataFlow.cs:429:27:429:27 | access to parameter e |
+| GlobalDataFlow.cs:426:71:426:71 | e | GlobalDataFlow.cs:429:27:429:27 | access to parameter e |
+| GlobalDataFlow.cs:426:71:426:71 | e | GlobalDataFlow.cs:429:27:429:27 | access to parameter e |
+| GlobalDataFlow.cs:426:71:426:71 | e | GlobalDataFlow.cs:429:27:429:27 | access to parameter e |
+| GlobalDataFlow.cs:426:71:426:71 | e | GlobalDataFlow.cs:431:46:431:46 | access to local variable x |
+| GlobalDataFlow.cs:426:71:426:71 | e | GlobalDataFlow.cs:431:46:431:46 | access to local variable x |
+| GlobalDataFlow.cs:426:71:426:71 | e | GlobalDataFlow.cs:431:46:431:46 | access to local variable x |
+| GlobalDataFlow.cs:426:71:426:71 | e | GlobalDataFlow.cs:431:46:431:46 | access to local variable x |
+| GlobalDataFlow.cs:426:71:426:71 | e | GlobalDataFlow.cs:431:46:431:46 | access to local variable x |
+| GlobalDataFlow.cs:426:71:426:71 | e | GlobalDataFlow.cs:431:46:431:46 | access to local variable x |
+| GlobalDataFlow.cs:426:71:426:71 | e | GlobalDataFlow.cs:431:46:431:46 | access to local variable x |
+| GlobalDataFlow.cs:426:71:426:71 | e | GlobalDataFlow.cs:431:46:431:46 | access to local variable x |
+| GlobalDataFlow.cs:426:85:426:85 | f | GlobalDataFlow.cs:426:85:426:85 | f |
+| GlobalDataFlow.cs:426:85:426:85 | f | GlobalDataFlow.cs:426:85:426:85 | f |
+| GlobalDataFlow.cs:426:85:426:85 | f | GlobalDataFlow.cs:426:85:426:85 | f |
+| GlobalDataFlow.cs:426:85:426:85 | f | GlobalDataFlow.cs:426:85:426:85 | f |
+| GlobalDataFlow.cs:426:85:426:85 | f | GlobalDataFlow.cs:431:44:431:44 | access to parameter f |
+| GlobalDataFlow.cs:426:85:426:85 | f | GlobalDataFlow.cs:431:44:431:44 | access to parameter f |
+| GlobalDataFlow.cs:426:85:426:85 | f | GlobalDataFlow.cs:431:44:431:44 | access to parameter f |
+| GlobalDataFlow.cs:426:85:426:85 | f | GlobalDataFlow.cs:431:44:431:44 | access to parameter f |
+| GlobalDataFlow.cs:426:85:426:85 | f | GlobalDataFlow.cs:431:44:431:44 | access to parameter f |
+| GlobalDataFlow.cs:426:85:426:85 | f | GlobalDataFlow.cs:431:44:431:44 | access to parameter f |
+| GlobalDataFlow.cs:426:85:426:85 | f | GlobalDataFlow.cs:431:44:431:44 | access to parameter f |
+| GlobalDataFlow.cs:426:85:426:85 | f | GlobalDataFlow.cs:431:44:431:44 | access to parameter f |
+| GlobalDataFlow.cs:428:13:428:17 | Int32 i = ... | GlobalDataFlow.cs:428:13:428:17 | Int32 i = ... |
+| GlobalDataFlow.cs:428:13:428:17 | SSA def(i) | GlobalDataFlow.cs:428:13:428:17 | SSA def(i) |
+| GlobalDataFlow.cs:428:13:428:17 | SSA def(i) | GlobalDataFlow.cs:429:9:432:9 | SSA phi(i) |
+| GlobalDataFlow.cs:428:13:428:17 | SSA def(i) | GlobalDataFlow.cs:429:9:432:9 | SSA phi(i) |
+| GlobalDataFlow.cs:428:13:428:17 | SSA def(i) | GlobalDataFlow.cs:431:17:431:17 | access to local variable i |
+| GlobalDataFlow.cs:428:13:428:17 | SSA def(i) | GlobalDataFlow.cs:431:17:431:17 | access to local variable i |
+| GlobalDataFlow.cs:428:17:428:17 | 0 | GlobalDataFlow.cs:428:13:428:17 | SSA def(i) |
+| GlobalDataFlow.cs:428:17:428:17 | 0 | GlobalDataFlow.cs:428:13:428:17 | SSA def(i) |
+| GlobalDataFlow.cs:428:17:428:17 | 0 | GlobalDataFlow.cs:428:17:428:17 | 0 |
+| GlobalDataFlow.cs:428:17:428:17 | 0 | GlobalDataFlow.cs:429:9:432:9 | SSA phi(i) |
+| GlobalDataFlow.cs:428:17:428:17 | 0 | GlobalDataFlow.cs:429:9:432:9 | SSA phi(i) |
+| GlobalDataFlow.cs:428:17:428:17 | 0 | GlobalDataFlow.cs:431:17:431:17 | access to local variable i |
+| GlobalDataFlow.cs:428:17:428:17 | 0 | GlobalDataFlow.cs:431:17:431:17 | access to local variable i |
+| GlobalDataFlow.cs:429:9:432:9 | SSA phi(i) | GlobalDataFlow.cs:429:9:432:9 | SSA phi(i) |
+| GlobalDataFlow.cs:429:9:432:9 | SSA phi(i) | GlobalDataFlow.cs:431:17:431:17 | access to local variable i |
+| GlobalDataFlow.cs:429:9:432:9 | SSA phi(i) | GlobalDataFlow.cs:431:17:431:17 | access to local variable i |
+| GlobalDataFlow.cs:429:22:429:22 | SSA def(x) | GlobalDataFlow.cs:429:22:429:22 | SSA def(x) |
+| GlobalDataFlow.cs:429:22:429:22 | SSA def(x) | GlobalDataFlow.cs:431:46:431:46 | access to local variable x |
+| GlobalDataFlow.cs:429:22:429:22 | SSA def(x) | GlobalDataFlow.cs:431:46:431:46 | access to local variable x |
+| GlobalDataFlow.cs:429:22:429:22 | SSA def(x) | GlobalDataFlow.cs:431:46:431:46 | access to local variable x |
+| GlobalDataFlow.cs:429:22:429:22 | SSA def(x) | GlobalDataFlow.cs:431:46:431:46 | access to local variable x |
+| GlobalDataFlow.cs:429:22:429:22 | SSA def(x) | GlobalDataFlow.cs:431:46:431:46 | access to local variable x |
+| GlobalDataFlow.cs:429:22:429:22 | SSA def(x) | GlobalDataFlow.cs:431:46:431:46 | access to local variable x |
+| GlobalDataFlow.cs:429:22:429:22 | T x | GlobalDataFlow.cs:429:22:429:22 | T x |
+| GlobalDataFlow.cs:429:27:429:27 | access to parameter e | GlobalDataFlow.cs:429:22:429:22 | SSA def(x) |
+| GlobalDataFlow.cs:429:27:429:27 | access to parameter e | GlobalDataFlow.cs:429:22:429:22 | SSA def(x) |
+| GlobalDataFlow.cs:429:27:429:27 | access to parameter e | GlobalDataFlow.cs:429:22:429:22 | SSA def(x) |
+| GlobalDataFlow.cs:429:27:429:27 | access to parameter e | GlobalDataFlow.cs:429:22:429:22 | SSA def(x) |
+| GlobalDataFlow.cs:429:27:429:27 | access to parameter e | GlobalDataFlow.cs:429:22:429:22 | SSA def(x) |
+| GlobalDataFlow.cs:429:27:429:27 | access to parameter e | GlobalDataFlow.cs:429:22:429:22 | SSA def(x) |
+| GlobalDataFlow.cs:429:27:429:27 | access to parameter e | GlobalDataFlow.cs:429:27:429:27 | access to parameter e |
+| GlobalDataFlow.cs:429:27:429:27 | access to parameter e | GlobalDataFlow.cs:431:46:431:46 | access to local variable x |
+| GlobalDataFlow.cs:429:27:429:27 | access to parameter e | GlobalDataFlow.cs:431:46:431:46 | access to local variable x |
+| GlobalDataFlow.cs:429:27:429:27 | access to parameter e | GlobalDataFlow.cs:431:46:431:46 | access to local variable x |
+| GlobalDataFlow.cs:429:27:429:27 | access to parameter e | GlobalDataFlow.cs:431:46:431:46 | access to local variable x |
+| GlobalDataFlow.cs:429:27:429:27 | access to parameter e | GlobalDataFlow.cs:431:46:431:46 | access to local variable x |
+| GlobalDataFlow.cs:429:27:429:27 | access to parameter e | GlobalDataFlow.cs:431:46:431:46 | access to local variable x |
+| GlobalDataFlow.cs:431:17:431:17 | access to local variable i | GlobalDataFlow.cs:431:17:431:17 | access to local variable i |
+| GlobalDataFlow.cs:431:17:431:19 | ...++ | GlobalDataFlow.cs:431:17:431:19 | ...++ |
+| GlobalDataFlow.cs:431:17:431:19 | SSA def(i) | GlobalDataFlow.cs:429:9:432:9 | SSA phi(i) |
+| GlobalDataFlow.cs:431:17:431:19 | SSA def(i) | GlobalDataFlow.cs:429:9:432:9 | SSA phi(i) |
+| GlobalDataFlow.cs:431:17:431:19 | SSA def(i) | GlobalDataFlow.cs:431:17:431:17 | access to local variable i |
+| GlobalDataFlow.cs:431:17:431:19 | SSA def(i) | GlobalDataFlow.cs:431:17:431:17 | access to local variable i |
+| GlobalDataFlow.cs:431:17:431:19 | SSA def(i) | GlobalDataFlow.cs:431:17:431:19 | SSA def(i) |
+| GlobalDataFlow.cs:431:17:431:23 | ... % ... | GlobalDataFlow.cs:431:17:431:23 | ... % ... |
+| GlobalDataFlow.cs:431:17:431:23 | ... % ... | GlobalDataFlow.cs:431:17:431:28 | ... == ... |
+| GlobalDataFlow.cs:431:17:431:23 | ... % ... | GlobalDataFlow.cs:431:17:431:28 | ... == ... |
+| GlobalDataFlow.cs:431:17:431:28 | ... == ... | GlobalDataFlow.cs:431:17:431:28 | ... == ... |
+| GlobalDataFlow.cs:431:23:431:23 | 2 | GlobalDataFlow.cs:431:23:431:23 | 2 |
+| GlobalDataFlow.cs:431:28:431:28 | 0 | GlobalDataFlow.cs:431:28:431:28 | 0 |
+| GlobalDataFlow.cs:431:44:431:44 | access to parameter f | GlobalDataFlow.cs:431:44:431:44 | access to parameter f |
+| GlobalDataFlow.cs:431:44:431:47 | delegate call | GlobalDataFlow.cs:80:22:80:85 | call to method SelectEven |
+| GlobalDataFlow.cs:431:44:431:47 | delegate call | GlobalDataFlow.cs:80:22:80:85 | call to method SelectEven |
+| GlobalDataFlow.cs:431:44:431:47 | delegate call | GlobalDataFlow.cs:80:22:80:85 | call to method SelectEven |
+| GlobalDataFlow.cs:431:44:431:47 | delegate call | GlobalDataFlow.cs:80:22:80:85 | call to method SelectEven |
+| GlobalDataFlow.cs:431:44:431:47 | delegate call | GlobalDataFlow.cs:112:24:112:90 | call to method SelectEven |
+| GlobalDataFlow.cs:431:44:431:47 | delegate call | GlobalDataFlow.cs:112:24:112:90 | call to method SelectEven |
+| GlobalDataFlow.cs:431:44:431:47 | delegate call | GlobalDataFlow.cs:112:24:112:90 | call to method SelectEven |
+| GlobalDataFlow.cs:431:44:431:47 | delegate call | GlobalDataFlow.cs:112:24:112:90 | call to method SelectEven |
+| GlobalDataFlow.cs:431:44:431:47 | delegate call | GlobalDataFlow.cs:431:44:431:47 | delegate call |
+| GlobalDataFlow.cs:431:44:431:47 | delegate call | GlobalDataFlow.cs:431:44:431:47 | delegate call |
+| GlobalDataFlow.cs:431:44:431:47 | delegate call | GlobalDataFlow.cs:431:44:431:47 | delegate call |
+| GlobalDataFlow.cs:431:44:431:47 | delegate call | GlobalDataFlow.cs:431:44:431:47 | delegate call |
+| GlobalDataFlow.cs:431:44:431:47 | delegate call | GlobalDataFlow.cs:431:44:431:47 | delegate call |
+| GlobalDataFlow.cs:431:44:431:47 | delegate call | GlobalDataFlow.cs:431:44:431:47 | delegate call |
+| GlobalDataFlow.cs:431:44:431:47 | delegate call | GlobalDataFlow.cs:431:44:431:47 | delegate call |
+| GlobalDataFlow.cs:431:44:431:47 | delegate call | GlobalDataFlow.cs:431:44:431:47 | delegate call |
+| GlobalDataFlow.cs:431:44:431:47 | delegate call | GlobalDataFlow.cs:431:44:431:47 | delegate call |
+| GlobalDataFlow.cs:431:44:431:47 | delegate call | GlobalDataFlow.cs:431:44:431:47 | delegate call |
+| GlobalDataFlow.cs:431:44:431:47 | delegate call | GlobalDataFlow.cs:431:44:431:47 | delegate call |
+| GlobalDataFlow.cs:431:44:431:47 | delegate call | GlobalDataFlow.cs:431:44:431:47 | delegate call |
+| GlobalDataFlow.cs:431:46:431:46 | access to local variable x | GlobalDataFlow.cs:80:79:80:79 | x |
+| GlobalDataFlow.cs:431:46:431:46 | access to local variable x | GlobalDataFlow.cs:80:79:80:79 | x |
+| GlobalDataFlow.cs:431:46:431:46 | access to local variable x | GlobalDataFlow.cs:80:79:80:79 | x |
+| GlobalDataFlow.cs:431:46:431:46 | access to local variable x | GlobalDataFlow.cs:80:79:80:79 | x |
+| GlobalDataFlow.cs:431:46:431:46 | access to local variable x | GlobalDataFlow.cs:112:84:112:84 | x |
+| GlobalDataFlow.cs:431:46:431:46 | access to local variable x | GlobalDataFlow.cs:112:84:112:84 | x |
+| GlobalDataFlow.cs:431:46:431:46 | access to local variable x | GlobalDataFlow.cs:112:84:112:84 | x |
+| GlobalDataFlow.cs:431:46:431:46 | access to local variable x | GlobalDataFlow.cs:112:84:112:84 | x |
+| GlobalDataFlow.cs:431:46:431:46 | access to local variable x | GlobalDataFlow.cs:431:44:431:47 | delegate call |
+| GlobalDataFlow.cs:431:46:431:46 | access to local variable x | GlobalDataFlow.cs:431:44:431:47 | delegate call |
+| GlobalDataFlow.cs:431:46:431:46 | access to local variable x | GlobalDataFlow.cs:431:44:431:47 | delegate call |
+| GlobalDataFlow.cs:431:46:431:46 | access to local variable x | GlobalDataFlow.cs:431:44:431:47 | delegate call |
+| GlobalDataFlow.cs:431:46:431:46 | access to local variable x | GlobalDataFlow.cs:431:44:431:47 | delegate call |
+| GlobalDataFlow.cs:431:46:431:46 | access to local variable x | GlobalDataFlow.cs:431:44:431:47 | delegate call |
+| GlobalDataFlow.cs:431:46:431:46 | access to local variable x | GlobalDataFlow.cs:431:46:431:46 | access to local variable x |
 | Splitting.cs:3:10:3:11 | this | Splitting.cs:3:10:3:11 | this |
 | Splitting.cs:3:18:3:18 | b | Splitting.cs:3:18:3:18 | b |
 | Splitting.cs:3:18:3:18 | b | Splitting.cs:3:18:3:18 | b |

--- a/csharp/ql/test/library-tests/dataflow/global/TaintTrackingPath.expected
+++ b/csharp/ql/test/library-tests/dataflow/global/TaintTrackingPath.expected
@@ -122,7 +122,6 @@ edges
 | GlobalDataFlow.cs:70:28:70:45 | access to property SinkProperty0 | GlobalDataFlow.cs:70:21:70:46 | call to method Return |
 | GlobalDataFlow.cs:72:21:72:101 | (...) ... | GlobalDataFlow.cs:73:15:73:19 | access to local variable sink1 |
 | GlobalDataFlow.cs:72:21:72:101 | (...) ... | GlobalDataFlow.cs:75:19:75:23 | access to local variable sink1 |
-| GlobalDataFlow.cs:72:21:72:101 | (...) ... | GlobalDataFlow.cs:106:19:106:23 | access to local variable sink1 |
 | GlobalDataFlow.cs:72:29:72:101 | call to method Invoke | GlobalDataFlow.cs:72:21:72:101 | (...) ... |
 | GlobalDataFlow.cs:72:94:72:98 | access to local variable sink0 | GlobalDataFlow.cs:72:29:72:101 | call to method Invoke |
 | GlobalDataFlow.cs:75:19:75:23 | access to local variable sink1 | GlobalDataFlow.cs:75:30:75:34 | SSA def(sink2) |
@@ -154,18 +153,6 @@ edges
 | GlobalDataFlow.cs:90:112:90:117 | [output] (...) => ... | GlobalDataFlow.cs:91:15:91:20 | access to local variable sink18 |
 | GlobalDataFlow.cs:90:112:90:117 | [output] (...) => ... | GlobalDataFlow.cs:94:15:94:20 | access to local variable sink21 |
 | GlobalDataFlow.cs:90:112:90:117 | [output] (...) => ... | GlobalDataFlow.cs:97:15:97:20 | access to local variable sink22 |
-| GlobalDataFlow.cs:106:19:106:23 | access to local variable sink1 | GlobalDataFlow.cs:106:41:106:48 | SSA def(nonSink0) |
-| GlobalDataFlow.cs:106:41:106:48 | SSA def(nonSink0) | GlobalDataFlow.cs:107:15:107:22 | access to local variable nonSink0 |
-| GlobalDataFlow.cs:106:41:106:48 | SSA def(nonSink0) | GlobalDataFlow.cs:108:41:108:48 | access to local variable nonSink0 |
-| GlobalDataFlow.cs:108:27:108:34 | SSA def(nonSink0) | GlobalDataFlow.cs:109:15:109:22 | access to local variable nonSink0 |
-| GlobalDataFlow.cs:108:27:108:34 | SSA def(nonSink0) | GlobalDataFlow.cs:111:15:111:22 | access to local variable nonSink0 |
-| GlobalDataFlow.cs:108:27:108:34 | SSA def(nonSink0) | GlobalDataFlow.cs:112:25:112:70 | (...) ... |
-| GlobalDataFlow.cs:108:27:108:34 | SSA def(nonSink0) | GlobalDataFlow.cs:114:21:114:66 | (...) ... |
-| GlobalDataFlow.cs:108:41:108:48 | access to local variable nonSink0 | GlobalDataFlow.cs:108:27:108:34 | SSA def(nonSink0) |
-| GlobalDataFlow.cs:112:24:112:90 | call to method SelectEven | GlobalDataFlow.cs:113:15:113:22 | access to local variable nonSink1 |
-| GlobalDataFlow.cs:112:25:112:70 | (...) ... | GlobalDataFlow.cs:112:24:112:90 | call to method SelectEven |
-| GlobalDataFlow.cs:114:21:114:66 | (...) ... | GlobalDataFlow.cs:114:76:114:81 | [output] (...) => ... |
-| GlobalDataFlow.cs:114:76:114:81 | [output] (...) => ... | GlobalDataFlow.cs:115:15:115:22 | access to local variable nonSink1 |
 | GlobalDataFlow.cs:135:21:135:34 | delegate call | GlobalDataFlow.cs:136:15:136:19 | access to local variable sink4 |
 | GlobalDataFlow.cs:135:21:135:34 | delegate call | GlobalDataFlow.cs:143:39:143:43 | access to local variable sink4 |
 | GlobalDataFlow.cs:135:29:135:33 | access to local variable sink3 | GlobalDataFlow.cs:135:21:135:34 | delegate call |
@@ -280,11 +267,6 @@ edges
 | GlobalDataFlow.cs:91:15:91:20 | access to local variable sink18 | GlobalDataFlow.cs:17:27:17:40 | "taint source" | GlobalDataFlow.cs:91:15:91:20 | access to local variable sink18 | access to local variable sink18 |
 | GlobalDataFlow.cs:94:15:94:20 | access to local variable sink21 | GlobalDataFlow.cs:17:27:17:40 | "taint source" | GlobalDataFlow.cs:94:15:94:20 | access to local variable sink21 | access to local variable sink21 |
 | GlobalDataFlow.cs:97:15:97:20 | access to local variable sink22 | GlobalDataFlow.cs:17:27:17:40 | "taint source" | GlobalDataFlow.cs:97:15:97:20 | access to local variable sink22 | access to local variable sink22 |
-| GlobalDataFlow.cs:107:15:107:22 | access to local variable nonSink0 | GlobalDataFlow.cs:17:27:17:40 | "taint source" | GlobalDataFlow.cs:107:15:107:22 | access to local variable nonSink0 | access to local variable nonSink0 |
-| GlobalDataFlow.cs:109:15:109:22 | access to local variable nonSink0 | GlobalDataFlow.cs:17:27:17:40 | "taint source" | GlobalDataFlow.cs:109:15:109:22 | access to local variable nonSink0 | access to local variable nonSink0 |
-| GlobalDataFlow.cs:111:15:111:22 | access to local variable nonSink0 | GlobalDataFlow.cs:17:27:17:40 | "taint source" | GlobalDataFlow.cs:111:15:111:22 | access to local variable nonSink0 | access to local variable nonSink0 |
-| GlobalDataFlow.cs:113:15:113:22 | access to local variable nonSink1 | GlobalDataFlow.cs:17:27:17:40 | "taint source" | GlobalDataFlow.cs:113:15:113:22 | access to local variable nonSink1 | access to local variable nonSink1 |
-| GlobalDataFlow.cs:115:15:115:22 | access to local variable nonSink1 | GlobalDataFlow.cs:17:27:17:40 | "taint source" | GlobalDataFlow.cs:115:15:115:22 | access to local variable nonSink1 | access to local variable nonSink1 |
 | GlobalDataFlow.cs:136:15:136:19 | access to local variable sink4 | GlobalDataFlow.cs:17:27:17:40 | "taint source" | GlobalDataFlow.cs:136:15:136:19 | access to local variable sink4 | access to local variable sink4 |
 | GlobalDataFlow.cs:144:15:144:19 | access to local variable sink5 | GlobalDataFlow.cs:17:27:17:40 | "taint source" | GlobalDataFlow.cs:144:15:144:19 | access to local variable sink5 | access to local variable sink5 |
 | GlobalDataFlow.cs:154:15:154:19 | access to local variable sink6 | GlobalDataFlow.cs:318:16:318:29 | "taint source" | GlobalDataFlow.cs:154:15:154:19 | access to local variable sink6 | access to local variable sink6 |

--- a/csharp/ql/test/library-tests/dataflow/global/TaintTrackingPath.expected
+++ b/csharp/ql/test/library-tests/dataflow/global/TaintTrackingPath.expected
@@ -67,7 +67,7 @@ edges
 | GlobalDataFlow.cs:35:13:35:30 | access to property SinkProperty0 | GlobalDataFlow.cs:57:35:57:52 | access to property SinkProperty0 |
 | GlobalDataFlow.cs:35:13:35:30 | access to property SinkProperty0 | GlobalDataFlow.cs:64:22:64:39 | access to property SinkProperty0 |
 | GlobalDataFlow.cs:35:13:35:30 | access to property SinkProperty0 | GlobalDataFlow.cs:70:28:70:45 | access to property SinkProperty0 |
-| GlobalDataFlow.cs:35:13:35:30 | access to property SinkProperty0 | GlobalDataFlow.cs:230:26:230:35 | sinkParam0 |
+| GlobalDataFlow.cs:35:13:35:30 | access to property SinkProperty0 | GlobalDataFlow.cs:234:26:234:35 | sinkParam0 |
 | GlobalDataFlow.cs:37:35:37:52 | access to property SinkProperty0 | GlobalDataFlow.cs:45:13:45:30 | access to property SinkProperty0 |
 | GlobalDataFlow.cs:37:35:37:52 | access to property SinkProperty0 | GlobalDataFlow.cs:52:20:52:37 | access to property SinkProperty0 |
 | GlobalDataFlow.cs:37:35:37:52 | access to property SinkProperty0 | GlobalDataFlow.cs:53:28:53:45 | access to property SinkProperty0 |
@@ -76,7 +76,7 @@ edges
 | GlobalDataFlow.cs:37:35:37:52 | access to property SinkProperty0 | GlobalDataFlow.cs:57:35:57:52 | access to property SinkProperty0 |
 | GlobalDataFlow.cs:37:35:37:52 | access to property SinkProperty0 | GlobalDataFlow.cs:64:22:64:39 | access to property SinkProperty0 |
 | GlobalDataFlow.cs:37:35:37:52 | access to property SinkProperty0 | GlobalDataFlow.cs:70:28:70:45 | access to property SinkProperty0 |
-| GlobalDataFlow.cs:37:35:37:52 | access to property SinkProperty0 | GlobalDataFlow.cs:236:26:236:35 | sinkParam1 |
+| GlobalDataFlow.cs:37:35:37:52 | access to property SinkProperty0 | GlobalDataFlow.cs:240:26:240:35 | sinkParam1 |
 | GlobalDataFlow.cs:44:30:44:39 | sinkParam2 | GlobalDataFlow.cs:44:50:44:59 | access to parameter sinkParam2 |
 | GlobalDataFlow.cs:45:13:45:30 | access to property SinkProperty0 | GlobalDataFlow.cs:44:30:44:39 | sinkParam2 |
 | GlobalDataFlow.cs:45:13:45:30 | access to property SinkProperty0 | GlobalDataFlow.cs:52:20:52:37 | access to property SinkProperty0 |
@@ -92,36 +92,37 @@ edges
 | GlobalDataFlow.cs:52:20:52:37 | access to property SinkProperty0 | GlobalDataFlow.cs:57:35:57:52 | access to property SinkProperty0 |
 | GlobalDataFlow.cs:52:20:52:37 | access to property SinkProperty0 | GlobalDataFlow.cs:64:22:64:39 | access to property SinkProperty0 |
 | GlobalDataFlow.cs:52:20:52:37 | access to property SinkProperty0 | GlobalDataFlow.cs:70:28:70:45 | access to property SinkProperty0 |
-| GlobalDataFlow.cs:52:20:52:37 | access to property SinkProperty0 | GlobalDataFlow.cs:354:41:354:41 | x |
+| GlobalDataFlow.cs:52:20:52:37 | access to property SinkProperty0 | GlobalDataFlow.cs:359:41:359:41 | x |
 | GlobalDataFlow.cs:53:15:53:15 | x | GlobalDataFlow.cs:53:24:53:24 | access to parameter x |
-| GlobalDataFlow.cs:53:24:53:24 | access to parameter x | GlobalDataFlow.cs:246:26:246:35 | sinkParam4 |
+| GlobalDataFlow.cs:53:24:53:24 | access to parameter x | GlobalDataFlow.cs:250:26:250:35 | sinkParam4 |
 | GlobalDataFlow.cs:53:28:53:45 | access to property SinkProperty0 | GlobalDataFlow.cs:54:44:54:61 | access to property SinkProperty0 |
 | GlobalDataFlow.cs:53:28:53:45 | access to property SinkProperty0 | GlobalDataFlow.cs:55:28:55:45 | access to property SinkProperty0 |
 | GlobalDataFlow.cs:53:28:53:45 | access to property SinkProperty0 | GlobalDataFlow.cs:57:35:57:52 | access to property SinkProperty0 |
 | GlobalDataFlow.cs:53:28:53:45 | access to property SinkProperty0 | GlobalDataFlow.cs:64:22:64:39 | access to property SinkProperty0 |
 | GlobalDataFlow.cs:53:28:53:45 | access to property SinkProperty0 | GlobalDataFlow.cs:70:28:70:45 | access to property SinkProperty0 |
-| GlobalDataFlow.cs:53:28:53:45 | access to property SinkProperty0 | GlobalDataFlow.cs:354:41:354:41 | x |
+| GlobalDataFlow.cs:53:28:53:45 | access to property SinkProperty0 | GlobalDataFlow.cs:359:41:359:41 | x |
 | GlobalDataFlow.cs:54:44:54:61 | access to property SinkProperty0 | GlobalDataFlow.cs:55:28:55:45 | access to property SinkProperty0 |
 | GlobalDataFlow.cs:54:44:54:61 | access to property SinkProperty0 | GlobalDataFlow.cs:57:35:57:52 | access to property SinkProperty0 |
 | GlobalDataFlow.cs:54:44:54:61 | access to property SinkProperty0 | GlobalDataFlow.cs:64:22:64:39 | access to property SinkProperty0 |
 | GlobalDataFlow.cs:54:44:54:61 | access to property SinkProperty0 | GlobalDataFlow.cs:70:28:70:45 | access to property SinkProperty0 |
-| GlobalDataFlow.cs:54:44:54:61 | access to property SinkProperty0 | GlobalDataFlow.cs:368:52:368:52 | x |
+| GlobalDataFlow.cs:54:44:54:61 | access to property SinkProperty0 | GlobalDataFlow.cs:373:52:373:52 | x |
 | GlobalDataFlow.cs:55:28:55:45 | access to property SinkProperty0 | GlobalDataFlow.cs:57:35:57:52 | access to property SinkProperty0 |
 | GlobalDataFlow.cs:55:28:55:45 | access to property SinkProperty0 | GlobalDataFlow.cs:64:22:64:39 | access to property SinkProperty0 |
 | GlobalDataFlow.cs:55:28:55:45 | access to property SinkProperty0 | GlobalDataFlow.cs:70:28:70:45 | access to property SinkProperty0 |
-| GlobalDataFlow.cs:55:28:55:45 | access to property SinkProperty0 | GlobalDataFlow.cs:368:52:368:52 | x |
+| GlobalDataFlow.cs:55:28:55:45 | access to property SinkProperty0 | GlobalDataFlow.cs:373:52:373:52 | x |
 | GlobalDataFlow.cs:56:37:56:37 | x | GlobalDataFlow.cs:56:46:56:46 | access to parameter x |
-| GlobalDataFlow.cs:56:46:56:46 | access to parameter x | GlobalDataFlow.cs:261:26:261:35 | sinkParam7 |
+| GlobalDataFlow.cs:56:46:56:46 | access to parameter x | GlobalDataFlow.cs:265:26:265:35 | sinkParam7 |
 | GlobalDataFlow.cs:57:35:57:52 | access to property SinkProperty0 | GlobalDataFlow.cs:64:22:64:39 | access to property SinkProperty0 |
 | GlobalDataFlow.cs:57:35:57:52 | access to property SinkProperty0 | GlobalDataFlow.cs:70:28:70:45 | access to property SinkProperty0 |
-| GlobalDataFlow.cs:57:35:57:52 | access to property SinkProperty0 | GlobalDataFlow.cs:368:52:368:52 | x |
+| GlobalDataFlow.cs:57:35:57:52 | access to property SinkProperty0 | GlobalDataFlow.cs:373:52:373:52 | x |
 | GlobalDataFlow.cs:64:22:64:39 | access to property SinkProperty0 | GlobalDataFlow.cs:70:28:70:45 | access to property SinkProperty0 |
-| GlobalDataFlow.cs:64:22:64:39 | access to property SinkProperty0 | GlobalDataFlow.cs:399:9:399:11 | value |
+| GlobalDataFlow.cs:64:22:64:39 | access to property SinkProperty0 | GlobalDataFlow.cs:404:9:404:11 | value |
 | GlobalDataFlow.cs:70:21:70:46 | call to method Return | GlobalDataFlow.cs:71:15:71:19 | access to local variable sink0 |
 | GlobalDataFlow.cs:70:21:70:46 | call to method Return | GlobalDataFlow.cs:72:94:72:98 | access to local variable sink0 |
 | GlobalDataFlow.cs:70:28:70:45 | access to property SinkProperty0 | GlobalDataFlow.cs:70:21:70:46 | call to method Return |
 | GlobalDataFlow.cs:72:21:72:101 | (...) ... | GlobalDataFlow.cs:73:15:73:19 | access to local variable sink1 |
 | GlobalDataFlow.cs:72:21:72:101 | (...) ... | GlobalDataFlow.cs:75:19:75:23 | access to local variable sink1 |
+| GlobalDataFlow.cs:72:21:72:101 | (...) ... | GlobalDataFlow.cs:106:19:106:23 | access to local variable sink1 |
 | GlobalDataFlow.cs:72:29:72:101 | call to method Invoke | GlobalDataFlow.cs:72:21:72:101 | (...) ... |
 | GlobalDataFlow.cs:72:94:72:98 | access to local variable sink0 | GlobalDataFlow.cs:72:29:72:101 | call to method Invoke |
 | GlobalDataFlow.cs:75:19:75:23 | access to local variable sink1 | GlobalDataFlow.cs:75:30:75:34 | SSA def(sink2) |
@@ -130,12 +131,12 @@ edges
 | GlobalDataFlow.cs:78:19:78:23 | access to local variable sink2 | GlobalDataFlow.cs:78:30:78:34 | SSA def(sink3) |
 | GlobalDataFlow.cs:78:30:78:34 | SSA def(sink3) | GlobalDataFlow.cs:79:15:79:19 | access to local variable sink3 |
 | GlobalDataFlow.cs:78:30:78:34 | SSA def(sink3) | GlobalDataFlow.cs:80:23:80:65 | (...) ... |
-| GlobalDataFlow.cs:78:30:78:34 | SSA def(sink3) | GlobalDataFlow.cs:131:29:131:33 | access to local variable sink3 |
+| GlobalDataFlow.cs:78:30:78:34 | SSA def(sink3) | GlobalDataFlow.cs:135:29:135:33 | access to local variable sink3 |
 | GlobalDataFlow.cs:80:22:80:85 | call to method SelectEven | GlobalDataFlow.cs:81:15:81:20 | access to local variable sink13 |
 | GlobalDataFlow.cs:80:22:80:85 | call to method SelectEven | GlobalDataFlow.cs:82:23:82:74 | (...) ... |
 | GlobalDataFlow.cs:80:23:80:65 | (...) ... | GlobalDataFlow.cs:80:22:80:85 | call to method SelectEven |
 | GlobalDataFlow.cs:82:23:82:74 | (...) ... | GlobalDataFlow.cs:82:84:82:94 | [output] delegate creation of type Func<String,String> |
-| GlobalDataFlow.cs:82:23:82:74 | (...) ... | GlobalDataFlow.cs:287:31:287:40 | sinkParam8 |
+| GlobalDataFlow.cs:82:23:82:74 | (...) ... | GlobalDataFlow.cs:292:31:292:40 | sinkParam8 |
 | GlobalDataFlow.cs:82:84:82:94 | [output] delegate creation of type Func<String,String> | GlobalDataFlow.cs:83:15:83:20 | access to local variable sink14 |
 | GlobalDataFlow.cs:82:84:82:94 | [output] delegate creation of type Func<String,String> | GlobalDataFlow.cs:84:23:84:74 | (...) ... |
 | GlobalDataFlow.cs:82:84:82:94 | [output] delegate creation of type Func<String,String> | GlobalDataFlow.cs:88:22:88:27 | access to local variable sink14 |
@@ -153,70 +154,82 @@ edges
 | GlobalDataFlow.cs:90:112:90:117 | [output] (...) => ... | GlobalDataFlow.cs:91:15:91:20 | access to local variable sink18 |
 | GlobalDataFlow.cs:90:112:90:117 | [output] (...) => ... | GlobalDataFlow.cs:94:15:94:20 | access to local variable sink21 |
 | GlobalDataFlow.cs:90:112:90:117 | [output] (...) => ... | GlobalDataFlow.cs:97:15:97:20 | access to local variable sink22 |
-| GlobalDataFlow.cs:131:21:131:34 | delegate call | GlobalDataFlow.cs:132:15:132:19 | access to local variable sink4 |
-| GlobalDataFlow.cs:131:21:131:34 | delegate call | GlobalDataFlow.cs:139:39:139:43 | access to local variable sink4 |
-| GlobalDataFlow.cs:131:29:131:33 | access to local variable sink3 | GlobalDataFlow.cs:131:21:131:34 | delegate call |
-| GlobalDataFlow.cs:139:21:139:44 | call to method ApplyFunc | GlobalDataFlow.cs:140:15:140:19 | access to local variable sink5 |
-| GlobalDataFlow.cs:139:39:139:43 | access to local variable sink4 | GlobalDataFlow.cs:139:21:139:44 | call to method ApplyFunc |
-| GlobalDataFlow.cs:149:21:149:25 | call to method Out | GlobalDataFlow.cs:150:15:150:19 | access to local variable sink6 |
-| GlobalDataFlow.cs:152:20:152:24 | SSA def(sink7) | GlobalDataFlow.cs:153:15:153:19 | access to local variable sink7 |
-| GlobalDataFlow.cs:155:20:155:24 | SSA def(sink8) | GlobalDataFlow.cs:156:15:156:19 | access to local variable sink8 |
-| GlobalDataFlow.cs:157:22:157:31 | call to method OutYield | GlobalDataFlow.cs:158:15:158:20 | access to local variable sink12 |
-| GlobalDataFlow.cs:159:22:159:43 | call to method TaintedParam | GlobalDataFlow.cs:160:15:160:20 | access to local variable sink23 |
-| GlobalDataFlow.cs:175:35:175:48 | "taint source" | GlobalDataFlow.cs:176:21:176:26 | delegate call |
-| GlobalDataFlow.cs:176:21:176:26 | delegate call | GlobalDataFlow.cs:177:15:177:19 | access to local variable sink9 |
-| GlobalDataFlow.cs:185:39:185:41 | [output] delegate creation of type Func<String> | GlobalDataFlow.cs:186:15:186:20 | access to local variable sink10 |
-| GlobalDataFlow.cs:193:22:193:32 | access to property OutProperty | GlobalDataFlow.cs:194:15:194:20 | access to local variable sink19 |
-| GlobalDataFlow.cs:201:39:201:45 | tainted | GlobalDataFlow.cs:206:22:206:28 | access to parameter tainted |
-| GlobalDataFlow.cs:201:39:201:45 | tainted | GlobalDataFlow.cs:208:22:208:28 | access to parameter tainted |
-| GlobalDataFlow.cs:201:39:201:45 | tainted | GlobalDataFlow.cs:210:22:210:28 | access to parameter tainted |
-| GlobalDataFlow.cs:204:35:204:45 | sinkParam10 | GlobalDataFlow.cs:204:58:204:68 | access to parameter sinkParam10 |
-| GlobalDataFlow.cs:205:71:205:71 | x | GlobalDataFlow.cs:205:89:205:89 | access to parameter x |
-| GlobalDataFlow.cs:205:89:205:89 | access to parameter x | GlobalDataFlow.cs:293:32:293:41 | sinkParam9 |
-| GlobalDataFlow.cs:206:22:206:28 | access to parameter tainted | GlobalDataFlow.cs:204:35:204:45 | sinkParam10 |
-| GlobalDataFlow.cs:206:22:206:28 | access to parameter tainted | GlobalDataFlow.cs:206:37:206:38 | [output] access to local variable f1 |
-| GlobalDataFlow.cs:206:37:206:38 | [output] access to local variable f1 | GlobalDataFlow.cs:207:15:207:20 | access to local variable sink24 |
-| GlobalDataFlow.cs:208:22:208:28 | access to parameter tainted | GlobalDataFlow.cs:205:71:205:71 | x |
-| GlobalDataFlow.cs:208:22:208:28 | access to parameter tainted | GlobalDataFlow.cs:208:37:208:38 | [output] access to local variable f2 |
-| GlobalDataFlow.cs:208:37:208:38 | [output] access to local variable f2 | GlobalDataFlow.cs:209:15:209:20 | access to local variable sink25 |
-| GlobalDataFlow.cs:210:22:210:28 | access to parameter tainted | GlobalDataFlow.cs:210:37:210:48 | [output] delegate creation of type Func<String,String> |
-| GlobalDataFlow.cs:210:22:210:28 | access to parameter tainted | GlobalDataFlow.cs:299:32:299:42 | sinkParam11 |
-| GlobalDataFlow.cs:210:37:210:48 | [output] delegate creation of type Func<String,String> | GlobalDataFlow.cs:211:15:211:20 | access to local variable sink26 |
-| GlobalDataFlow.cs:230:26:230:35 | sinkParam0 | GlobalDataFlow.cs:232:16:232:25 | access to parameter sinkParam0 |
-| GlobalDataFlow.cs:230:26:230:35 | sinkParam0 | GlobalDataFlow.cs:233:15:233:24 | access to parameter sinkParam0 |
-| GlobalDataFlow.cs:232:16:232:25 | access to parameter sinkParam0 | GlobalDataFlow.cs:230:26:230:35 | sinkParam0 |
-| GlobalDataFlow.cs:236:26:236:35 | sinkParam1 | GlobalDataFlow.cs:238:15:238:24 | access to parameter sinkParam1 |
-| GlobalDataFlow.cs:241:26:241:35 | sinkParam3 | GlobalDataFlow.cs:243:15:243:24 | access to parameter sinkParam3 |
-| GlobalDataFlow.cs:246:26:246:35 | sinkParam4 | GlobalDataFlow.cs:248:15:248:24 | access to parameter sinkParam4 |
-| GlobalDataFlow.cs:251:26:251:35 | sinkParam5 | GlobalDataFlow.cs:253:15:253:24 | access to parameter sinkParam5 |
-| GlobalDataFlow.cs:256:26:256:35 | sinkParam6 | GlobalDataFlow.cs:258:15:258:24 | access to parameter sinkParam6 |
-| GlobalDataFlow.cs:261:26:261:35 | sinkParam7 | GlobalDataFlow.cs:263:15:263:24 | access to parameter sinkParam7 |
-| GlobalDataFlow.cs:287:31:287:40 | sinkParam8 | GlobalDataFlow.cs:289:15:289:24 | access to parameter sinkParam8 |
-| GlobalDataFlow.cs:293:32:293:41 | sinkParam9 | GlobalDataFlow.cs:295:15:295:24 | access to parameter sinkParam9 |
-| GlobalDataFlow.cs:299:32:299:42 | sinkParam11 | GlobalDataFlow.cs:301:15:301:25 | access to parameter sinkParam11 |
-| GlobalDataFlow.cs:313:16:313:29 | "taint source" | GlobalDataFlow.cs:149:21:149:25 | call to method Out |
-| GlobalDataFlow.cs:313:16:313:29 | "taint source" | GlobalDataFlow.cs:185:39:185:41 | [output] delegate creation of type Func<String> |
-| GlobalDataFlow.cs:318:9:318:26 | SSA def(x) | GlobalDataFlow.cs:152:20:152:24 | SSA def(sink7) |
-| GlobalDataFlow.cs:318:13:318:26 | "taint source" | GlobalDataFlow.cs:318:9:318:26 | SSA def(x) |
-| GlobalDataFlow.cs:323:9:323:26 | SSA def(x) | GlobalDataFlow.cs:155:20:155:24 | SSA def(sink8) |
+| GlobalDataFlow.cs:106:19:106:23 | access to local variable sink1 | GlobalDataFlow.cs:106:41:106:48 | SSA def(nonSink0) |
+| GlobalDataFlow.cs:106:41:106:48 | SSA def(nonSink0) | GlobalDataFlow.cs:107:15:107:22 | access to local variable nonSink0 |
+| GlobalDataFlow.cs:106:41:106:48 | SSA def(nonSink0) | GlobalDataFlow.cs:108:41:108:48 | access to local variable nonSink0 |
+| GlobalDataFlow.cs:108:27:108:34 | SSA def(nonSink0) | GlobalDataFlow.cs:109:15:109:22 | access to local variable nonSink0 |
+| GlobalDataFlow.cs:108:27:108:34 | SSA def(nonSink0) | GlobalDataFlow.cs:111:15:111:22 | access to local variable nonSink0 |
+| GlobalDataFlow.cs:108:27:108:34 | SSA def(nonSink0) | GlobalDataFlow.cs:112:25:112:70 | (...) ... |
+| GlobalDataFlow.cs:108:27:108:34 | SSA def(nonSink0) | GlobalDataFlow.cs:114:21:114:66 | (...) ... |
+| GlobalDataFlow.cs:108:41:108:48 | access to local variable nonSink0 | GlobalDataFlow.cs:108:27:108:34 | SSA def(nonSink0) |
+| GlobalDataFlow.cs:112:24:112:90 | call to method SelectEven | GlobalDataFlow.cs:113:15:113:22 | access to local variable nonSink1 |
+| GlobalDataFlow.cs:112:25:112:70 | (...) ... | GlobalDataFlow.cs:112:24:112:90 | call to method SelectEven |
+| GlobalDataFlow.cs:114:21:114:66 | (...) ... | GlobalDataFlow.cs:114:76:114:81 | [output] (...) => ... |
+| GlobalDataFlow.cs:114:76:114:81 | [output] (...) => ... | GlobalDataFlow.cs:115:15:115:22 | access to local variable nonSink1 |
+| GlobalDataFlow.cs:135:21:135:34 | delegate call | GlobalDataFlow.cs:136:15:136:19 | access to local variable sink4 |
+| GlobalDataFlow.cs:135:21:135:34 | delegate call | GlobalDataFlow.cs:143:39:143:43 | access to local variable sink4 |
+| GlobalDataFlow.cs:135:29:135:33 | access to local variable sink3 | GlobalDataFlow.cs:135:21:135:34 | delegate call |
+| GlobalDataFlow.cs:143:21:143:44 | call to method ApplyFunc | GlobalDataFlow.cs:144:15:144:19 | access to local variable sink5 |
+| GlobalDataFlow.cs:143:39:143:43 | access to local variable sink4 | GlobalDataFlow.cs:143:21:143:44 | call to method ApplyFunc |
+| GlobalDataFlow.cs:153:21:153:25 | call to method Out | GlobalDataFlow.cs:154:15:154:19 | access to local variable sink6 |
+| GlobalDataFlow.cs:156:20:156:24 | SSA def(sink7) | GlobalDataFlow.cs:157:15:157:19 | access to local variable sink7 |
+| GlobalDataFlow.cs:159:20:159:24 | SSA def(sink8) | GlobalDataFlow.cs:160:15:160:19 | access to local variable sink8 |
+| GlobalDataFlow.cs:161:22:161:31 | call to method OutYield | GlobalDataFlow.cs:162:15:162:20 | access to local variable sink12 |
+| GlobalDataFlow.cs:163:22:163:43 | call to method TaintedParam | GlobalDataFlow.cs:164:15:164:20 | access to local variable sink23 |
+| GlobalDataFlow.cs:179:35:179:48 | "taint source" | GlobalDataFlow.cs:180:21:180:26 | delegate call |
+| GlobalDataFlow.cs:180:21:180:26 | delegate call | GlobalDataFlow.cs:181:15:181:19 | access to local variable sink9 |
+| GlobalDataFlow.cs:189:39:189:41 | [output] delegate creation of type Func<String> | GlobalDataFlow.cs:190:15:190:20 | access to local variable sink10 |
+| GlobalDataFlow.cs:197:22:197:32 | access to property OutProperty | GlobalDataFlow.cs:198:15:198:20 | access to local variable sink19 |
+| GlobalDataFlow.cs:205:39:205:45 | tainted | GlobalDataFlow.cs:210:22:210:28 | access to parameter tainted |
+| GlobalDataFlow.cs:205:39:205:45 | tainted | GlobalDataFlow.cs:212:22:212:28 | access to parameter tainted |
+| GlobalDataFlow.cs:205:39:205:45 | tainted | GlobalDataFlow.cs:214:22:214:28 | access to parameter tainted |
+| GlobalDataFlow.cs:208:35:208:45 | sinkParam10 | GlobalDataFlow.cs:208:58:208:68 | access to parameter sinkParam10 |
+| GlobalDataFlow.cs:209:71:209:71 | x | GlobalDataFlow.cs:209:89:209:89 | access to parameter x |
+| GlobalDataFlow.cs:209:89:209:89 | access to parameter x | GlobalDataFlow.cs:298:32:298:41 | sinkParam9 |
+| GlobalDataFlow.cs:210:22:210:28 | access to parameter tainted | GlobalDataFlow.cs:208:35:208:45 | sinkParam10 |
+| GlobalDataFlow.cs:210:22:210:28 | access to parameter tainted | GlobalDataFlow.cs:210:37:210:38 | [output] access to local variable f1 |
+| GlobalDataFlow.cs:210:37:210:38 | [output] access to local variable f1 | GlobalDataFlow.cs:211:15:211:20 | access to local variable sink24 |
+| GlobalDataFlow.cs:212:22:212:28 | access to parameter tainted | GlobalDataFlow.cs:209:71:209:71 | x |
+| GlobalDataFlow.cs:212:22:212:28 | access to parameter tainted | GlobalDataFlow.cs:212:37:212:38 | [output] access to local variable f2 |
+| GlobalDataFlow.cs:212:37:212:38 | [output] access to local variable f2 | GlobalDataFlow.cs:213:15:213:20 | access to local variable sink25 |
+| GlobalDataFlow.cs:214:22:214:28 | access to parameter tainted | GlobalDataFlow.cs:214:37:214:48 | [output] delegate creation of type Func<String,String> |
+| GlobalDataFlow.cs:214:22:214:28 | access to parameter tainted | GlobalDataFlow.cs:304:32:304:42 | sinkParam11 |
+| GlobalDataFlow.cs:214:37:214:48 | [output] delegate creation of type Func<String,String> | GlobalDataFlow.cs:215:15:215:20 | access to local variable sink26 |
+| GlobalDataFlow.cs:234:26:234:35 | sinkParam0 | GlobalDataFlow.cs:236:16:236:25 | access to parameter sinkParam0 |
+| GlobalDataFlow.cs:234:26:234:35 | sinkParam0 | GlobalDataFlow.cs:237:15:237:24 | access to parameter sinkParam0 |
+| GlobalDataFlow.cs:236:16:236:25 | access to parameter sinkParam0 | GlobalDataFlow.cs:234:26:234:35 | sinkParam0 |
+| GlobalDataFlow.cs:240:26:240:35 | sinkParam1 | GlobalDataFlow.cs:242:15:242:24 | access to parameter sinkParam1 |
+| GlobalDataFlow.cs:245:26:245:35 | sinkParam3 | GlobalDataFlow.cs:247:15:247:24 | access to parameter sinkParam3 |
+| GlobalDataFlow.cs:250:26:250:35 | sinkParam4 | GlobalDataFlow.cs:252:15:252:24 | access to parameter sinkParam4 |
+| GlobalDataFlow.cs:255:26:255:35 | sinkParam5 | GlobalDataFlow.cs:257:15:257:24 | access to parameter sinkParam5 |
+| GlobalDataFlow.cs:260:26:260:35 | sinkParam6 | GlobalDataFlow.cs:262:15:262:24 | access to parameter sinkParam6 |
+| GlobalDataFlow.cs:265:26:265:35 | sinkParam7 | GlobalDataFlow.cs:267:15:267:24 | access to parameter sinkParam7 |
+| GlobalDataFlow.cs:292:31:292:40 | sinkParam8 | GlobalDataFlow.cs:294:15:294:24 | access to parameter sinkParam8 |
+| GlobalDataFlow.cs:298:32:298:41 | sinkParam9 | GlobalDataFlow.cs:300:15:300:24 | access to parameter sinkParam9 |
+| GlobalDataFlow.cs:304:32:304:42 | sinkParam11 | GlobalDataFlow.cs:306:15:306:25 | access to parameter sinkParam11 |
+| GlobalDataFlow.cs:318:16:318:29 | "taint source" | GlobalDataFlow.cs:153:21:153:25 | call to method Out |
+| GlobalDataFlow.cs:318:16:318:29 | "taint source" | GlobalDataFlow.cs:189:39:189:41 | [output] delegate creation of type Func<String> |
+| GlobalDataFlow.cs:323:9:323:26 | SSA def(x) | GlobalDataFlow.cs:156:20:156:24 | SSA def(sink7) |
 | GlobalDataFlow.cs:323:13:323:26 | "taint source" | GlobalDataFlow.cs:323:9:323:26 | SSA def(x) |
-| GlobalDataFlow.cs:329:22:329:35 | "taint source" | GlobalDataFlow.cs:157:22:157:31 | call to method OutYield |
-| GlobalDataFlow.cs:329:22:329:35 | "taint source" | GlobalDataFlow.cs:329:22:329:35 | "taint source" |
-| GlobalDataFlow.cs:354:41:354:41 | x | GlobalDataFlow.cs:356:11:356:11 | access to parameter x |
-| GlobalDataFlow.cs:354:41:354:41 | x | GlobalDataFlow.cs:356:11:356:11 | access to parameter x |
-| GlobalDataFlow.cs:356:11:356:11 | access to parameter x | GlobalDataFlow.cs:53:15:53:15 | x |
-| GlobalDataFlow.cs:356:11:356:11 | access to parameter x | GlobalDataFlow.cs:241:26:241:35 | sinkParam3 |
-| GlobalDataFlow.cs:368:52:368:52 | x | GlobalDataFlow.cs:370:11:370:11 | access to parameter x |
-| GlobalDataFlow.cs:368:52:368:52 | x | GlobalDataFlow.cs:370:11:370:11 | access to parameter x |
-| GlobalDataFlow.cs:368:52:368:52 | x | GlobalDataFlow.cs:370:11:370:11 | access to parameter x |
-| GlobalDataFlow.cs:370:11:370:11 | access to parameter x | GlobalDataFlow.cs:56:37:56:37 | x |
-| GlobalDataFlow.cs:370:11:370:11 | access to parameter x | GlobalDataFlow.cs:251:26:251:35 | sinkParam5 |
-| GlobalDataFlow.cs:370:11:370:11 | access to parameter x | GlobalDataFlow.cs:256:26:256:35 | sinkParam6 |
-| GlobalDataFlow.cs:373:39:373:45 | tainted | GlobalDataFlow.cs:376:15:376:20 | access to local variable sink11 |
-| GlobalDataFlow.cs:373:39:373:45 | tainted | GlobalDataFlow.cs:377:16:377:21 | access to local variable sink11 |
-| GlobalDataFlow.cs:377:16:377:21 | access to local variable sink11 | GlobalDataFlow.cs:159:22:159:43 | call to method TaintedParam |
-| GlobalDataFlow.cs:399:9:399:11 | value | GlobalDataFlow.cs:399:41:399:46 | access to local variable sink20 |
-| GlobalDataFlow.cs:410:22:410:35 | "taint source" | GlobalDataFlow.cs:193:22:193:32 | access to property OutProperty |
+| GlobalDataFlow.cs:328:9:328:26 | SSA def(x) | GlobalDataFlow.cs:159:20:159:24 | SSA def(sink8) |
+| GlobalDataFlow.cs:328:13:328:26 | "taint source" | GlobalDataFlow.cs:328:9:328:26 | SSA def(x) |
+| GlobalDataFlow.cs:334:22:334:35 | "taint source" | GlobalDataFlow.cs:161:22:161:31 | call to method OutYield |
+| GlobalDataFlow.cs:334:22:334:35 | "taint source" | GlobalDataFlow.cs:334:22:334:35 | "taint source" |
+| GlobalDataFlow.cs:359:41:359:41 | x | GlobalDataFlow.cs:361:11:361:11 | access to parameter x |
+| GlobalDataFlow.cs:359:41:359:41 | x | GlobalDataFlow.cs:361:11:361:11 | access to parameter x |
+| GlobalDataFlow.cs:361:11:361:11 | access to parameter x | GlobalDataFlow.cs:53:15:53:15 | x |
+| GlobalDataFlow.cs:361:11:361:11 | access to parameter x | GlobalDataFlow.cs:245:26:245:35 | sinkParam3 |
+| GlobalDataFlow.cs:373:52:373:52 | x | GlobalDataFlow.cs:375:11:375:11 | access to parameter x |
+| GlobalDataFlow.cs:373:52:373:52 | x | GlobalDataFlow.cs:375:11:375:11 | access to parameter x |
+| GlobalDataFlow.cs:373:52:373:52 | x | GlobalDataFlow.cs:375:11:375:11 | access to parameter x |
+| GlobalDataFlow.cs:375:11:375:11 | access to parameter x | GlobalDataFlow.cs:56:37:56:37 | x |
+| GlobalDataFlow.cs:375:11:375:11 | access to parameter x | GlobalDataFlow.cs:255:26:255:35 | sinkParam5 |
+| GlobalDataFlow.cs:375:11:375:11 | access to parameter x | GlobalDataFlow.cs:260:26:260:35 | sinkParam6 |
+| GlobalDataFlow.cs:378:39:378:45 | tainted | GlobalDataFlow.cs:381:15:381:20 | access to local variable sink11 |
+| GlobalDataFlow.cs:378:39:378:45 | tainted | GlobalDataFlow.cs:382:16:382:21 | access to local variable sink11 |
+| GlobalDataFlow.cs:382:16:382:21 | access to local variable sink11 | GlobalDataFlow.cs:163:22:163:43 | call to method TaintedParam |
+| GlobalDataFlow.cs:404:9:404:11 | value | GlobalDataFlow.cs:404:41:404:46 | access to local variable sink20 |
+| GlobalDataFlow.cs:415:22:415:35 | "taint source" | GlobalDataFlow.cs:197:22:197:32 | access to property OutProperty |
 | Splitting.cs:3:28:3:34 | tainted | Splitting.cs:8:24:8:30 | [b (line 3): false] access to parameter tainted |
 | Splitting.cs:3:28:3:34 | tainted | Splitting.cs:8:24:8:30 | [b (line 3): true] access to parameter tainted |
 | Splitting.cs:8:17:8:31 | [b (line 3): false] call to method Return | Splitting.cs:9:15:9:15 | [b (line 3): false] access to local variable x |
@@ -267,32 +280,37 @@ edges
 | GlobalDataFlow.cs:91:15:91:20 | access to local variable sink18 | GlobalDataFlow.cs:17:27:17:40 | "taint source" | GlobalDataFlow.cs:91:15:91:20 | access to local variable sink18 | access to local variable sink18 |
 | GlobalDataFlow.cs:94:15:94:20 | access to local variable sink21 | GlobalDataFlow.cs:17:27:17:40 | "taint source" | GlobalDataFlow.cs:94:15:94:20 | access to local variable sink21 | access to local variable sink21 |
 | GlobalDataFlow.cs:97:15:97:20 | access to local variable sink22 | GlobalDataFlow.cs:17:27:17:40 | "taint source" | GlobalDataFlow.cs:97:15:97:20 | access to local variable sink22 | access to local variable sink22 |
-| GlobalDataFlow.cs:132:15:132:19 | access to local variable sink4 | GlobalDataFlow.cs:17:27:17:40 | "taint source" | GlobalDataFlow.cs:132:15:132:19 | access to local variable sink4 | access to local variable sink4 |
-| GlobalDataFlow.cs:140:15:140:19 | access to local variable sink5 | GlobalDataFlow.cs:17:27:17:40 | "taint source" | GlobalDataFlow.cs:140:15:140:19 | access to local variable sink5 | access to local variable sink5 |
-| GlobalDataFlow.cs:150:15:150:19 | access to local variable sink6 | GlobalDataFlow.cs:313:16:313:29 | "taint source" | GlobalDataFlow.cs:150:15:150:19 | access to local variable sink6 | access to local variable sink6 |
-| GlobalDataFlow.cs:153:15:153:19 | access to local variable sink7 | GlobalDataFlow.cs:318:13:318:26 | "taint source" | GlobalDataFlow.cs:153:15:153:19 | access to local variable sink7 | access to local variable sink7 |
-| GlobalDataFlow.cs:156:15:156:19 | access to local variable sink8 | GlobalDataFlow.cs:323:13:323:26 | "taint source" | GlobalDataFlow.cs:156:15:156:19 | access to local variable sink8 | access to local variable sink8 |
-| GlobalDataFlow.cs:158:15:158:20 | access to local variable sink12 | GlobalDataFlow.cs:329:22:329:35 | "taint source" | GlobalDataFlow.cs:158:15:158:20 | access to local variable sink12 | access to local variable sink12 |
-| GlobalDataFlow.cs:160:15:160:20 | access to local variable sink23 | GlobalDataFlow.cs:373:39:373:45 | tainted | GlobalDataFlow.cs:160:15:160:20 | access to local variable sink23 | access to local variable sink23 |
-| GlobalDataFlow.cs:177:15:177:19 | access to local variable sink9 | GlobalDataFlow.cs:175:35:175:48 | "taint source" | GlobalDataFlow.cs:177:15:177:19 | access to local variable sink9 | access to local variable sink9 |
-| GlobalDataFlow.cs:186:15:186:20 | access to local variable sink10 | GlobalDataFlow.cs:313:16:313:29 | "taint source" | GlobalDataFlow.cs:186:15:186:20 | access to local variable sink10 | access to local variable sink10 |
-| GlobalDataFlow.cs:194:15:194:20 | access to local variable sink19 | GlobalDataFlow.cs:410:22:410:35 | "taint source" | GlobalDataFlow.cs:194:15:194:20 | access to local variable sink19 | access to local variable sink19 |
-| GlobalDataFlow.cs:204:58:204:68 | access to parameter sinkParam10 | GlobalDataFlow.cs:201:39:201:45 | tainted | GlobalDataFlow.cs:204:58:204:68 | access to parameter sinkParam10 | access to parameter sinkParam10 |
-| GlobalDataFlow.cs:207:15:207:20 | access to local variable sink24 | GlobalDataFlow.cs:201:39:201:45 | tainted | GlobalDataFlow.cs:207:15:207:20 | access to local variable sink24 | access to local variable sink24 |
-| GlobalDataFlow.cs:209:15:209:20 | access to local variable sink25 | GlobalDataFlow.cs:201:39:201:45 | tainted | GlobalDataFlow.cs:209:15:209:20 | access to local variable sink25 | access to local variable sink25 |
-| GlobalDataFlow.cs:211:15:211:20 | access to local variable sink26 | GlobalDataFlow.cs:201:39:201:45 | tainted | GlobalDataFlow.cs:211:15:211:20 | access to local variable sink26 | access to local variable sink26 |
-| GlobalDataFlow.cs:233:15:233:24 | access to parameter sinkParam0 | GlobalDataFlow.cs:17:27:17:40 | "taint source" | GlobalDataFlow.cs:233:15:233:24 | access to parameter sinkParam0 | access to parameter sinkParam0 |
-| GlobalDataFlow.cs:238:15:238:24 | access to parameter sinkParam1 | GlobalDataFlow.cs:17:27:17:40 | "taint source" | GlobalDataFlow.cs:238:15:238:24 | access to parameter sinkParam1 | access to parameter sinkParam1 |
-| GlobalDataFlow.cs:243:15:243:24 | access to parameter sinkParam3 | GlobalDataFlow.cs:17:27:17:40 | "taint source" | GlobalDataFlow.cs:243:15:243:24 | access to parameter sinkParam3 | access to parameter sinkParam3 |
-| GlobalDataFlow.cs:248:15:248:24 | access to parameter sinkParam4 | GlobalDataFlow.cs:17:27:17:40 | "taint source" | GlobalDataFlow.cs:248:15:248:24 | access to parameter sinkParam4 | access to parameter sinkParam4 |
-| GlobalDataFlow.cs:253:15:253:24 | access to parameter sinkParam5 | GlobalDataFlow.cs:17:27:17:40 | "taint source" | GlobalDataFlow.cs:253:15:253:24 | access to parameter sinkParam5 | access to parameter sinkParam5 |
-| GlobalDataFlow.cs:258:15:258:24 | access to parameter sinkParam6 | GlobalDataFlow.cs:17:27:17:40 | "taint source" | GlobalDataFlow.cs:258:15:258:24 | access to parameter sinkParam6 | access to parameter sinkParam6 |
-| GlobalDataFlow.cs:263:15:263:24 | access to parameter sinkParam7 | GlobalDataFlow.cs:17:27:17:40 | "taint source" | GlobalDataFlow.cs:263:15:263:24 | access to parameter sinkParam7 | access to parameter sinkParam7 |
-| GlobalDataFlow.cs:289:15:289:24 | access to parameter sinkParam8 | GlobalDataFlow.cs:17:27:17:40 | "taint source" | GlobalDataFlow.cs:289:15:289:24 | access to parameter sinkParam8 | access to parameter sinkParam8 |
-| GlobalDataFlow.cs:295:15:295:24 | access to parameter sinkParam9 | GlobalDataFlow.cs:201:39:201:45 | tainted | GlobalDataFlow.cs:295:15:295:24 | access to parameter sinkParam9 | access to parameter sinkParam9 |
-| GlobalDataFlow.cs:301:15:301:25 | access to parameter sinkParam11 | GlobalDataFlow.cs:201:39:201:45 | tainted | GlobalDataFlow.cs:301:15:301:25 | access to parameter sinkParam11 | access to parameter sinkParam11 |
-| GlobalDataFlow.cs:376:15:376:20 | access to local variable sink11 | GlobalDataFlow.cs:373:39:373:45 | tainted | GlobalDataFlow.cs:376:15:376:20 | access to local variable sink11 | access to local variable sink11 |
-| GlobalDataFlow.cs:399:41:399:46 | access to local variable sink20 | GlobalDataFlow.cs:17:27:17:40 | "taint source" | GlobalDataFlow.cs:399:41:399:46 | access to local variable sink20 | access to local variable sink20 |
+| GlobalDataFlow.cs:107:15:107:22 | access to local variable nonSink0 | GlobalDataFlow.cs:17:27:17:40 | "taint source" | GlobalDataFlow.cs:107:15:107:22 | access to local variable nonSink0 | access to local variable nonSink0 |
+| GlobalDataFlow.cs:109:15:109:22 | access to local variable nonSink0 | GlobalDataFlow.cs:17:27:17:40 | "taint source" | GlobalDataFlow.cs:109:15:109:22 | access to local variable nonSink0 | access to local variable nonSink0 |
+| GlobalDataFlow.cs:111:15:111:22 | access to local variable nonSink0 | GlobalDataFlow.cs:17:27:17:40 | "taint source" | GlobalDataFlow.cs:111:15:111:22 | access to local variable nonSink0 | access to local variable nonSink0 |
+| GlobalDataFlow.cs:113:15:113:22 | access to local variable nonSink1 | GlobalDataFlow.cs:17:27:17:40 | "taint source" | GlobalDataFlow.cs:113:15:113:22 | access to local variable nonSink1 | access to local variable nonSink1 |
+| GlobalDataFlow.cs:115:15:115:22 | access to local variable nonSink1 | GlobalDataFlow.cs:17:27:17:40 | "taint source" | GlobalDataFlow.cs:115:15:115:22 | access to local variable nonSink1 | access to local variable nonSink1 |
+| GlobalDataFlow.cs:136:15:136:19 | access to local variable sink4 | GlobalDataFlow.cs:17:27:17:40 | "taint source" | GlobalDataFlow.cs:136:15:136:19 | access to local variable sink4 | access to local variable sink4 |
+| GlobalDataFlow.cs:144:15:144:19 | access to local variable sink5 | GlobalDataFlow.cs:17:27:17:40 | "taint source" | GlobalDataFlow.cs:144:15:144:19 | access to local variable sink5 | access to local variable sink5 |
+| GlobalDataFlow.cs:154:15:154:19 | access to local variable sink6 | GlobalDataFlow.cs:318:16:318:29 | "taint source" | GlobalDataFlow.cs:154:15:154:19 | access to local variable sink6 | access to local variable sink6 |
+| GlobalDataFlow.cs:157:15:157:19 | access to local variable sink7 | GlobalDataFlow.cs:323:13:323:26 | "taint source" | GlobalDataFlow.cs:157:15:157:19 | access to local variable sink7 | access to local variable sink7 |
+| GlobalDataFlow.cs:160:15:160:19 | access to local variable sink8 | GlobalDataFlow.cs:328:13:328:26 | "taint source" | GlobalDataFlow.cs:160:15:160:19 | access to local variable sink8 | access to local variable sink8 |
+| GlobalDataFlow.cs:162:15:162:20 | access to local variable sink12 | GlobalDataFlow.cs:334:22:334:35 | "taint source" | GlobalDataFlow.cs:162:15:162:20 | access to local variable sink12 | access to local variable sink12 |
+| GlobalDataFlow.cs:164:15:164:20 | access to local variable sink23 | GlobalDataFlow.cs:378:39:378:45 | tainted | GlobalDataFlow.cs:164:15:164:20 | access to local variable sink23 | access to local variable sink23 |
+| GlobalDataFlow.cs:181:15:181:19 | access to local variable sink9 | GlobalDataFlow.cs:179:35:179:48 | "taint source" | GlobalDataFlow.cs:181:15:181:19 | access to local variable sink9 | access to local variable sink9 |
+| GlobalDataFlow.cs:190:15:190:20 | access to local variable sink10 | GlobalDataFlow.cs:318:16:318:29 | "taint source" | GlobalDataFlow.cs:190:15:190:20 | access to local variable sink10 | access to local variable sink10 |
+| GlobalDataFlow.cs:198:15:198:20 | access to local variable sink19 | GlobalDataFlow.cs:415:22:415:35 | "taint source" | GlobalDataFlow.cs:198:15:198:20 | access to local variable sink19 | access to local variable sink19 |
+| GlobalDataFlow.cs:208:58:208:68 | access to parameter sinkParam10 | GlobalDataFlow.cs:205:39:205:45 | tainted | GlobalDataFlow.cs:208:58:208:68 | access to parameter sinkParam10 | access to parameter sinkParam10 |
+| GlobalDataFlow.cs:211:15:211:20 | access to local variable sink24 | GlobalDataFlow.cs:205:39:205:45 | tainted | GlobalDataFlow.cs:211:15:211:20 | access to local variable sink24 | access to local variable sink24 |
+| GlobalDataFlow.cs:213:15:213:20 | access to local variable sink25 | GlobalDataFlow.cs:205:39:205:45 | tainted | GlobalDataFlow.cs:213:15:213:20 | access to local variable sink25 | access to local variable sink25 |
+| GlobalDataFlow.cs:215:15:215:20 | access to local variable sink26 | GlobalDataFlow.cs:205:39:205:45 | tainted | GlobalDataFlow.cs:215:15:215:20 | access to local variable sink26 | access to local variable sink26 |
+| GlobalDataFlow.cs:237:15:237:24 | access to parameter sinkParam0 | GlobalDataFlow.cs:17:27:17:40 | "taint source" | GlobalDataFlow.cs:237:15:237:24 | access to parameter sinkParam0 | access to parameter sinkParam0 |
+| GlobalDataFlow.cs:242:15:242:24 | access to parameter sinkParam1 | GlobalDataFlow.cs:17:27:17:40 | "taint source" | GlobalDataFlow.cs:242:15:242:24 | access to parameter sinkParam1 | access to parameter sinkParam1 |
+| GlobalDataFlow.cs:247:15:247:24 | access to parameter sinkParam3 | GlobalDataFlow.cs:17:27:17:40 | "taint source" | GlobalDataFlow.cs:247:15:247:24 | access to parameter sinkParam3 | access to parameter sinkParam3 |
+| GlobalDataFlow.cs:252:15:252:24 | access to parameter sinkParam4 | GlobalDataFlow.cs:17:27:17:40 | "taint source" | GlobalDataFlow.cs:252:15:252:24 | access to parameter sinkParam4 | access to parameter sinkParam4 |
+| GlobalDataFlow.cs:257:15:257:24 | access to parameter sinkParam5 | GlobalDataFlow.cs:17:27:17:40 | "taint source" | GlobalDataFlow.cs:257:15:257:24 | access to parameter sinkParam5 | access to parameter sinkParam5 |
+| GlobalDataFlow.cs:262:15:262:24 | access to parameter sinkParam6 | GlobalDataFlow.cs:17:27:17:40 | "taint source" | GlobalDataFlow.cs:262:15:262:24 | access to parameter sinkParam6 | access to parameter sinkParam6 |
+| GlobalDataFlow.cs:267:15:267:24 | access to parameter sinkParam7 | GlobalDataFlow.cs:17:27:17:40 | "taint source" | GlobalDataFlow.cs:267:15:267:24 | access to parameter sinkParam7 | access to parameter sinkParam7 |
+| GlobalDataFlow.cs:294:15:294:24 | access to parameter sinkParam8 | GlobalDataFlow.cs:17:27:17:40 | "taint source" | GlobalDataFlow.cs:294:15:294:24 | access to parameter sinkParam8 | access to parameter sinkParam8 |
+| GlobalDataFlow.cs:300:15:300:24 | access to parameter sinkParam9 | GlobalDataFlow.cs:205:39:205:45 | tainted | GlobalDataFlow.cs:300:15:300:24 | access to parameter sinkParam9 | access to parameter sinkParam9 |
+| GlobalDataFlow.cs:306:15:306:25 | access to parameter sinkParam11 | GlobalDataFlow.cs:205:39:205:45 | tainted | GlobalDataFlow.cs:306:15:306:25 | access to parameter sinkParam11 | access to parameter sinkParam11 |
+| GlobalDataFlow.cs:381:15:381:20 | access to local variable sink11 | GlobalDataFlow.cs:378:39:378:45 | tainted | GlobalDataFlow.cs:381:15:381:20 | access to local variable sink11 | access to local variable sink11 |
+| GlobalDataFlow.cs:404:41:404:46 | access to local variable sink20 | GlobalDataFlow.cs:17:27:17:40 | "taint source" | GlobalDataFlow.cs:404:41:404:46 | access to local variable sink20 | access to local variable sink20 |
 | Splitting.cs:9:15:9:15 | [b (line 3): false] access to local variable x | Splitting.cs:3:28:3:34 | tainted | Splitting.cs:9:15:9:15 | [b (line 3): false] access to local variable x | [b (line 3): false] access to local variable x |
 | Splitting.cs:9:15:9:15 | [b (line 3): true] access to local variable x | Splitting.cs:3:28:3:34 | tainted | Splitting.cs:9:15:9:15 | [b (line 3): true] access to local variable x | [b (line 3): true] access to local variable x |
 | Splitting.cs:11:19:11:19 | access to local variable x | Splitting.cs:3:28:3:34 | tainted | Splitting.cs:11:19:11:19 | access to local variable x | access to local variable x |


### PR DESCRIPTION
This PR fixes data flow out of `out`/`ref` parameters for methods with multiple `out`/`ref` parameters.