### PR TITLE
JS: Lower precision of `js/conflicting-html-attribute`

### DIFF
--- a/change-notes/1.22/analysis-javascript.md
+++ b/change-notes/1.22/analysis-javascript.md
@@ -29,6 +29,7 @@
 | **Query**                      | **Expected impact**          | **Change**                                                                |
 |--------------------------------|------------------------------|---------------------------------------------------------------------------|
 | Shift out of range | Fewer false positive results | This rule now correctly handles BigInt shift operands. |
+| Conflicting HTML element attributes | Fewer results | Results are no longer shown on LGTM by default. |
 | Superfluous trailing arguments | Fewer false-positive results. | This rule no longer flags calls to placeholder functions that trivially throw an exception. |
 
 ## Changes to QL libraries

--- a/javascript/ql/src/DOM/ConflictingAttributes.ql
+++ b/javascript/ql/src/DOM/ConflictingAttributes.ql
@@ -8,7 +8,7 @@
  * @tags maintainability
  *       correctness
  *       external/cwe/cwe-758
- * @precision very-high
+ * @precision medium
  */
 
 import javascript


### PR DESCRIPTION
Lowers precision of `js/conflicting-html-attribute` such that it no longer is shown by default on LGTM, we have yet to see an interesting TP.