### PR TITLE
CPP: Delete invalid URL

### DIFF
--- a/cpp/ql/src/Best Practices/Likely Errors/Slicing.ql
+++ b/cpp/ql/src/Best Practices/Likely Errors/Slicing.ql
@@ -12,8 +12,6 @@
 
 import cpp
 
-//see http://www.cs.ualberta.ca/~hoover/Courses/201/201-New-Notes/lectures/section/slice.htm
-//Does not find anything in rivers (unfortunately)
 from AssignExpr e, Class lhsType, Class rhsType
 where
   e.getLValue().getType() = lhsType and
@@ -22,6 +20,6 @@ where
   exists(Declaration m |
     rhsType.getAMember() = m and
     not m.(VirtualFunction).isPure()
-  ) //add additional checks for concrete members in in-between supertypes
+  ) // add additional checks for concrete members in in-between supertypes
 select e, "This assignment expression slices from type $@ to $@", rhsType, rhsType.getName(),
   lhsType, lhsType.getName()


### PR DESCRIPTION
Delete invalid URL from a query comment, along with a comment that appears to make no sense without the URL.