### PR TITLE
C#: Remove two `pragma[nomagic]`

### DIFF
--- a/csharp/ql/src/semmle/code/csharp/controlflow/Guards.qll
+++ b/csharp/ql/src/semmle/code/csharp/controlflow/Guards.qll
@@ -1574,7 +1574,6 @@ module Internal {
    *
    * This predicate does not rely on the control flow graph.
    */
-  pragma[nomagic]
   predicate preImpliesSteps(Guard g1, AbstractValue v1, Guard g2, AbstractValue v2) {
     g1 = g2 and
     v1 = v2 and
@@ -1592,7 +1591,6 @@ module Internal {
    *
    * This predicate relies on the control flow graph.
    */
-  pragma[nomagic]
   predicate impliesSteps(Guard g1, AbstractValue v1, Guard g2, AbstractValue v2) {
     g1 = g2 and
     v1 = v2 and

--- a/csharp/ql/src/semmle/code/csharp/controlflow/internal/PreSsa.qll
+++ b/csharp/ql/src/semmle/code/csharp/controlflow/internal/PreSsa.qll
@@ -125,7 +125,7 @@ class Definition extends TPreSsaDef {
 
   Definition getAnUltimateDefinition() {
     result = this.getAPhiInput*() and
-    not this = TPhiPreSsaDef(_, _)
+    not result = TPhiPreSsaDef(_, _)
   }
 }
 


### PR DESCRIPTION
The two pragmas were introduced in https://github.com/Semmle/ql/pull/1446, but it turns out that magic is rather crucial (as witnessed by the test in `ssa-large`, which would timeout in some cases). Also fixed a bug in `PreSsa:: getAnUltimateDefinition()`, also introduced in https://github.com/Semmle/ql/pull/1446.

Profiling report: https://git.semmle.com/gist/tom/a56b2ff5e44738ca74f73b67ab4e8647 (internal link).