### PR TITLE
Python taint-tracking: Remove 'parents' query from path-queries.

### DIFF
--- a/python/ql/src/semmle/python/security/Paths.qll
+++ b/python/ql/src/semmle/python/security/Paths.qll
@@ -7,21 +7,3 @@ query predicate edges(TaintedNode fromnode, TaintedNode tonode) {
     /* Don't record flow past sinks */
     not fromnode.isSink()
 }
-
-private TaintedNode first_child(TaintedNode parent) {
-    result.getContext().getCaller() = parent.getContext() and
-    edges(parent, result)
-}
-
-private TaintedNode next_sibling(TaintedNode child) {
-    edges(child, result) and
-    child.getContext() = result.getContext()
-}
-
-query predicate parents(TaintedNode child, TaintedNode parent) {
-    child = first_child(parent) or
-    exists(TaintedNode prev |
-        parents(prev, parent) and
-        child = next_sibling(prev)
-    )
-}

--- a/python/ql/test/query-tests/Functions/general/ModificationOfParameterWithDefault.expected
+++ b/python/ql/test/query-tests/Functions/general/ModificationOfParameterWithDefault.expected
@@ -11,11 +11,6 @@ edges
 | functions_test.py:300:26:300:26 | empty mutable value | functions_test.py:301:8:301:8 | empty mutable value |
 | functions_test.py:300:26:300:26 | empty mutable value | functions_test.py:303:12:303:12 | empty mutable value |
 | functions_test.py:305:21:305:25 | empty mutable value | functions_test.py:306:12:306:16 | empty mutable value |
-parents
-| functions_test.py:290:25:290:25 | empty mutable value | functions_test.py:297:25:297:25 | empty mutable value |
-| functions_test.py:291:5:291:5 | empty mutable value | functions_test.py:297:25:297:25 | empty mutable value |
-| functions_test.py:293:21:293:21 | empty mutable value | functions_test.py:298:21:298:21 | empty mutable value |
-| functions_test.py:294:5:294:5 | empty mutable value | functions_test.py:298:21:298:21 | empty mutable value |
 #select
 | functions_test.py:40:5:40:5 | Taint sink | functions_test.py:39:9:39:9 | empty mutable value | functions_test.py:40:5:40:5 | empty mutable value | $@ flows to here and is mutated. | functions_test.py:39:9:39:9 | mutable default value | Default value |
 | functions_test.py:239:5:239:5 | Taint sink | functions_test.py:238:15:238:15 | empty mutable value | functions_test.py:239:5:239:5 | empty mutable value | $@ flows to here and is mutated. | functions_test.py:238:15:238:15 | mutable default value | Default value |

--- a/python/ql/test/query-tests/Security/CWE-022/PathInjection.expected
+++ b/python/ql/test/query-tests/Security/CWE-022/PathInjection.expected
@@ -24,13 +24,6 @@ edges
 | path_injection.py:34:30:34:60 | externally controlled string | ../lib/os/path.py:4:14:4:14 | externally controlled string |
 | path_injection.py:34:30:34:60 | externally controlled string | path_injection.py:34:13:34:61 | normalized path |
 | path_injection.py:34:56:34:59 | externally controlled string | path_injection.py:34:30:34:60 | externally controlled string |
-parents
-| ../lib/os/path.py:4:14:4:14 | externally controlled string | path_injection.py:16:30:16:60 | externally controlled string |
-| ../lib/os/path.py:4:14:4:14 | externally controlled string | path_injection.py:25:30:25:60 | externally controlled string |
-| ../lib/os/path.py:4:14:4:14 | externally controlled string | path_injection.py:34:30:34:60 | externally controlled string |
-| ../lib/os/path.py:5:12:5:12 | externally controlled string | path_injection.py:16:30:16:60 | externally controlled string |
-| ../lib/os/path.py:5:12:5:12 | externally controlled string | path_injection.py:25:30:25:60 | externally controlled string |
-| ../lib/os/path.py:5:12:5:12 | externally controlled string | path_injection.py:34:30:34:60 | externally controlled string |
 #select
 | path_injection.py:10:14:10:44 | argument to open() | path_injection.py:9:12:9:23 | dict of externally controlled string | path_injection.py:10:14:10:44 | externally controlled string | This path depends on $@. | path_injection.py:9:12:9:23 | flask.request.args | a user-provided value |
 | path_injection.py:17:14:17:18 | argument to open() | path_injection.py:15:12:15:23 | dict of externally controlled string | path_injection.py:17:14:17:18 | normalized path | This path depends on $@. | path_injection.py:15:12:15:23 | flask.request.args | a user-provided value |

--- a/python/ql/test/query-tests/Security/CWE-022/TarSlip.expected
+++ b/python/ql/test/query-tests/Security/CWE-022/TarSlip.expected
@@ -24,11 +24,6 @@ edges
 | tarslip.py:51:7:51:39 | tarfile.open | tarslip.py:52:1:52:3 | tarfile.open |
 | tarslip.py:51:7:51:39 | tarfile.open | tarslip.py:52:36:52:38 | tarfile.open |
 | tarslip.py:52:36:52:38 | tarfile.open | tarslip.py:45:17:45:23 | tarfile.open |
-parents
-| tarslip.py:45:17:45:23 | tarfile.open | tarslip.py:52:36:52:38 | tarfile.open |
-| tarslip.py:46:5:46:24 | tarfile.entry | tarslip.py:52:36:52:38 | tarfile.open |
-| tarslip.py:46:17:46:23 | tarfile.open | tarslip.py:52:36:52:38 | tarfile.open |
-| tarslip.py:47:20:47:23 | tarfile.entry | tarslip.py:52:36:52:38 | tarfile.open |
 #select
 | tarslip.py:13:1:13:3 | Taint sink | tarslip.py:12:7:12:39 | tarfile.open | tarslip.py:13:1:13:3 | tarfile.open | Extraction of tarfile from $@ | tarslip.py:12:7:12:39 | Taint source | a potentially untrusted source |
 | tarslip.py:18:17:18:21 | Taint sink | tarslip.py:16:7:16:39 | tarfile.open | tarslip.py:18:17:18:21 | tarfile.entry | Extraction of tarfile from $@ | tarslip.py:16:7:16:39 | Taint source | a potentially untrusted source |

--- a/python/ql/test/query-tests/Security/CWE-078/CommandInjection.expected
+++ b/python/ql/test/query-tests/Security/CWE-078/CommandInjection.expected
@@ -12,7 +12,6 @@ edges
 | command_injection.py:30:13:30:24 | dict of externally controlled string | command_injection.py:30:13:30:41 | externally controlled string |
 | command_injection.py:30:13:30:41 | externally controlled string | command_injection.py:32:22:32:26 | externally controlled string |
 | command_injection.py:32:22:32:26 | externally controlled string | command_injection.py:32:14:32:26 | externally controlled string |
-parents
 #select
 | command_injection.py:12:15:12:27 | shell command | command_injection.py:10:13:10:24 | dict of externally controlled string | command_injection.py:12:15:12:27 | externally controlled string | This command depends on $@. | command_injection.py:10:13:10:24 | flask.request.args | a user-provided value |
 | command_injection.py:19:22:19:34 | shell command | command_injection.py:17:13:17:24 | dict of externally controlled string | command_injection.py:19:22:19:34 | sequence of externally controlled string | This command depends on $@. | command_injection.py:17:13:17:24 | flask.request.args | a user-provided value |

--- a/python/ql/test/query-tests/Security/CWE-079/ReflectedXss.expected
+++ b/python/ql/test/query-tests/Security/CWE-079/ReflectedXss.expected
@@ -11,11 +11,5 @@ edges
 | reflected_xss.py:12:18:12:29 | dict of externally controlled string | reflected_xss.py:12:18:12:45 | externally controlled string |
 | reflected_xss.py:12:18:12:45 | externally controlled string | reflected_xss.py:13:51:13:60 | externally controlled string |
 | reflected_xss.py:13:51:13:60 | externally controlled string | ../lib/flask/__init__.py:22:12:22:14 | externally controlled string |
-parents
-| ../lib/flask/__init__.py:14:19:14:20 | externally controlled string | reflected_xss.py:8:26:8:53 | externally controlled string |
-| ../lib/flask/__init__.py:15:19:15:20 | externally controlled string | reflected_xss.py:8:26:8:53 | externally controlled string |
-| ../lib/flask/__init__.py:16:25:16:26 | externally controlled string | reflected_xss.py:8:26:8:53 | externally controlled string |
-| ../lib/flask/__init__.py:22:12:22:14 | externally controlled string | reflected_xss.py:13:51:13:60 | externally controlled string |
-| ../lib/flask/__init__.py:23:26:23:28 | externally controlled string | reflected_xss.py:13:51:13:60 | externally controlled string |
 #select
 | ../lib/flask/__init__.py:16:25:16:26 | flask.response.argument | reflected_xss.py:7:18:7:29 | dict of externally controlled string | ../lib/flask/__init__.py:16:25:16:26 | externally controlled string | Cross-site scripting vulnerability due to $@. | reflected_xss.py:7:18:7:29 | flask.request.args | user-provided value |

--- a/python/ql/test/query-tests/Security/CWE-089/SqlInjection.expected
+++ b/python/ql/test/query-tests/Security/CWE-089/SqlInjection.expected
@@ -17,7 +17,6 @@ edges
 | sql_injection.py:23:76:23:79 | externally controlled string | sql_injection.py:23:26:23:79 | externally controlled string |
 | sql_injection.py:24:9:24:20 | django.db.models.Model.objects | sql_injection.py:24:9:24:82 | django.db.models.Model.objects |
 | sql_injection.py:24:78:24:81 | externally controlled string | sql_injection.py:24:28:24:81 | externally controlled string |
-parents
 #select
 | sql_injection.py:19:13:19:66 | db.connection.execute | sql_injection.py:9:15:9:21 | django.request.HttpRequest | sql_injection.py:19:13:19:66 | externally controlled string | This SQL query depends on $@. | sql_injection.py:9:15:9:21 | Django request source | a user-provided value |
 | sql_injection.py:22:38:22:91 | django.db.models.expressions.RawSQL(sink,...) | sql_injection.py:9:15:9:21 | django.request.HttpRequest | sql_injection.py:22:38:22:91 | externally controlled string | This SQL query depends on $@. | sql_injection.py:9:15:9:21 | Django request source | a user-provided value |

--- a/python/ql/test/query-tests/Security/CWE-094/CodeInjection.expected
+++ b/python/ql/test/query-tests/Security/CWE-094/CodeInjection.expected
@@ -6,7 +6,5 @@ edges
 | code_injection.py:6:22:6:55 | externally controlled string | code_injection.py:7:34:7:43 | externally controlled string |
 | code_injection.py:7:34:7:43 | externally controlled string | ../lib/base64.py:1:18:1:18 | externally controlled string |
 | code_injection.py:7:34:7:43 | externally controlled string | code_injection.py:7:14:7:44 | externally controlled string |
-parents
-| ../lib/base64.py:1:18:1:18 | externally controlled string | code_injection.py:7:34:7:43 | externally controlled string |
 #select
 | code_injection.py:7:14:7:44 | exec or eval | code_injection.py:4:20:4:26 | django.request.HttpRequest | code_injection.py:7:14:7:44 | externally controlled string | $@ flows to here and is interpreted as code. | code_injection.py:4:20:4:26 | Django request source | User-provided value |

--- a/python/ql/test/query-tests/Security/CWE-209/StackTraceExposure.expected
+++ b/python/ql/test/query-tests/Security/CWE-209/StackTraceExposure.expected
@@ -4,10 +4,6 @@ edges
 | test.py:36:18:36:20 | exception info | test.py:37:25:37:27 | exception info |
 | test.py:37:12:37:27 | exception info | test.py:34:16:34:32 | exception info |
 | test.py:37:25:37:27 | exception info | test.py:37:12:37:27 | exception info |
-parents
-| test.py:36:18:36:20 | exception info | test.py:34:29:34:31 | exception info |
-| test.py:37:12:37:27 | exception info | test.py:34:29:34:31 | exception info |
-| test.py:37:25:37:27 | exception info | test.py:34:29:34:31 | exception info |
 #select
 | test.py:16:16:16:37 | flask.routed.response | test.py:16:16:16:37 | exception info | test.py:16:16:16:37 | exception info | $@ may be exposed to an external user | test.py:16:16:16:37 | exception.info.source | Error information |
 | test.py:34:16:34:32 | flask.routed.response | test.py:33:15:33:36 | exception info | test.py:34:16:34:32 | exception info | $@ may be exposed to an external user | test.py:33:15:33:36 | exception.info.source | Error information |

--- a/python/ql/test/query-tests/Security/CWE-502/UnsafeDeserialization.expected
+++ b/python/ql/test/query-tests/Security/CWE-502/UnsafeDeserialization.expected
@@ -4,7 +4,6 @@ edges
 | test.py:11:15:11:41 | externally controlled string | test.py:13:15:13:21 | externally controlled string |
 | test.py:11:15:11:41 | externally controlled string | test.py:14:19:14:25 | externally controlled string |
 | test.py:11:15:11:41 | externally controlled string | test.py:16:16:16:22 | externally controlled string |
-parents
 #select
 | test.py:12:18:12:24 | unpickling untrusted data | test.py:11:15:11:26 | dict of externally controlled string | test.py:12:18:12:24 | externally controlled string | Deserializing of $@. | test.py:11:15:11:26 | flask.request.args | untrusted input |
 | test.py:13:15:13:21 | yaml.load vulnerability | test.py:11:15:11:26 | dict of externally controlled string | test.py:13:15:13:21 | externally controlled string | Deserializing of $@. | test.py:11:15:11:26 | flask.request.args | untrusted input |

--- a/python/ql/test/query-tests/Security/CWE-601/UrlRedirect.expected
+++ b/python/ql/test/query-tests/Security/CWE-601/UrlRedirect.expected
@@ -3,6 +3,5 @@ edges
 | test.py:7:22:7:51 | externally controlled string | test.py:8:21:8:26 | externally controlled string |
 | test.py:15:17:15:28 | dict of externally controlled string | test.py:15:17:15:42 | externally controlled string |
 | test.py:15:17:15:42 | externally controlled string | test.py:17:13:17:21 | externally controlled string |
-parents
 #select
 | test.py:8:21:8:26 | flask.redirect | test.py:7:22:7:33 | dict of externally controlled string | test.py:8:21:8:26 | externally controlled string | Untrusted URL redirection due to $@. | test.py:7:22:7:33 | flask.request.args | a user-provided value |


### PR DESCRIPTION
Removes the `parents` relation from path-queries, because it is unused by the tooling, and makes extending the taint-tracking API more difficult.