### PR TITLE
C#: Improve performance of SSA adjacent reads calculation

### DIFF
--- a/csharp/ql/src/semmle/code/csharp/controlflow/Guards.qll
+++ b/csharp/ql/src/semmle/code/csharp/controlflow/Guards.qll
@@ -1058,8 +1058,10 @@ module Internal {
       conditionalAssign(guard, vGuard, def, vDef.getAnExpr())
     }
 
-    private predicate relevantEq(PreSsa::Definition def, AbstractValue v) {
-      conditionalAssignVal(_, _, def, v)
+    pragma[noinline]
+    private predicate relevantEq(PreSsa::Definition def, AbstractValue v, AssignableRead ar) {
+      conditionalAssignVal(_, _, def, v) and
+      ar = def.getARead()
     }
 
     /**
@@ -1156,8 +1158,7 @@ module Internal {
     private predicate guardImpliesNotEqual(
       Expr guard, AbstractValue vGuard, PreSsa::Definition def, AbstractValue vDef
     ) {
-      relevantEq(def, vDef) and
-      exists(AssignableRead ar | ar = def.getARead() |
+      exists(AssignableRead ar | relevantEq(def, vDef, ar) |
         // For example:
         //   if (de == null); vGuard = TBooleanValue(false); vDef = TNullValue(true)
         // but not

--- a/csharp/ql/src/semmle/code/csharp/controlflow/internal/PreSsa.qll
+++ b/csharp/ql/src/semmle/code/csharp/controlflow/internal/PreSsa.qll
@@ -265,77 +265,6 @@ private int maxSsaRefRank(PreBasicBlock bb, SimpleAssignable a) {
   not result + 1 = ssaRefRank(bb, _, a, _)
 }
 
-private predicate reachesEndOf(Definition def, SimpleAssignable a, PreBasicBlock bb) {
-  exists(int last | last = maxSsaRefRank(bb, a) | defReachesRank(bb, def, a, last))
-  or
-  exists(PreBasicBlock mid |
-    reachesEndOf(def, a, mid) and
-    not exists(ssaRefRank(mid, _, a, SsaDef())) and
-    bb = mid.getASuccessor()
-  )
-}
-
-private predicate varOccursInBlock(SimpleAssignable a, PreBasicBlock bb) {
-  exists(ssaRefRank(bb, _, a, _))
-}
-
-pragma[nomagic]
-private predicate blockPrecedesVar(SimpleAssignable a, PreBasicBlock bb) {
-  varOccursInBlock(a, bb.getASuccessor*())
-}
-
-private predicate varBlockReaches(SimpleAssignable a, PreBasicBlock bb1, PreBasicBlock bb2) {
-  varOccursInBlock(a, bb1) and
-  bb2 = bb1.getASuccessor() and
-  blockPrecedesVar(a, bb2)
-  or
-  varBlockReachesRec(a, bb1, bb2) and
-  blockPrecedesVar(a, bb2)
-}
-
-pragma[nomagic]
-private predicate varBlockReachesRec(SimpleAssignable a, PreBasicBlock bb1, PreBasicBlock bb2) {
-  exists(PreBasicBlock mid | varBlockReaches(a, bb1, mid) |
-    bb2 = mid.getASuccessor() and
-    not varOccursInBlock(a, mid)
-  )
-}
-
-private predicate varBlockStep(SimpleAssignable a, PreBasicBlock bb1, PreBasicBlock bb2) {
-  varBlockReaches(a, bb1, bb2) and
-  varOccursInBlock(a, bb2)
-}
-
-private predicate adjacentVarRefs(
-  SimpleAssignable a, PreBasicBlock bb1, int i1, PreBasicBlock bb2, int i2
-) {
-  exists(int rankix |
-    bb1 = bb2 and
-    rankix = ssaRefRank(bb1, i1, a, _) and
-    rankix + 1 = ssaRefRank(bb2, i2, a, _)
-  )
-  or
-  ssaRefRank(bb1, i1, a, _) = maxSsaRefRank(bb1, a) and
-  varBlockStep(a, bb1, bb2) and
-  ssaRefRank(bb2, i2, a, _) = 1
-}
-
-predicate firstReadSameVar(Definition def, AssignableRead read) {
-  exists(SimpleAssignable a, PreBasicBlock b1, int i1, PreBasicBlock b2, int i2 |
-    adjacentVarRefs(a, b1, i1, b2, i2) and
-    defAt(b1, i1, def, a) and
-    readAt(b2, i2, read, a)
-  )
-}
-
-predicate adjacentReadPairSameVar(AssignableRead read1, AssignableRead read2) {
-  exists(SimpleAssignable a, PreBasicBlock bb1, int i1, PreBasicBlock bb2, int i2 |
-    adjacentVarRefs(a, bb1, i1, bb2, i2) and
-    readAt(bb1, i1, read1, a) and
-    readAt(bb2, i2, read2, a)
-  )
-}
-
 pragma[noinline]
 private predicate ssaDefReachesEndOfBlockRec(PreBasicBlock bb, Definition def, SimpleAssignable a) {
   exists(PreBasicBlock idom | ssaDefReachesEndOfBlock(idom, def, a) | idom.immediatelyDominates(bb))
@@ -350,4 +279,83 @@ predicate ssaDefReachesEndOfBlock(PreBasicBlock bb, Definition def, SimpleAssign
   ssaDefReachesEndOfBlockRec(bb, def, a) and
   liveAtExit(bb, a) and
   not ssaRef(bb, _, a, SsaDef())
+}
+
+private predicate ssaDefReachesReadWithinBlock(
+  SimpleAssignable a, Definition def, PreBasicBlock bb, int i
+) {
+  defReachesRank(bb, def, a, ssaRefRank(bb, i, a, SsaRead()))
+}
+
+private predicate ssaDefReachesRead(SimpleAssignable a, Definition def, PreBasicBlock bb, int i) {
+  ssaDefReachesReadWithinBlock(a, def, bb, i)
+  or
+  ssaRef(bb, i, a, SsaRead()) and
+  ssaDefReachesEndOfBlock(bb.getAPredecessor(), def, a) and
+  not ssaDefReachesReadWithinBlock(a, _, bb, i)
+}
+
+private int ssaDefRank(Definition def, PreBasicBlock bb, int i) {
+  exists(SimpleAssignable a |
+    a = def.getAssignable() and
+    result = ssaRefRank(bb, i, a, _)
+  |
+    ssaDefReachesRead(a, def, bb, i)
+    or
+    defAt(bb, i, def, a)
+  )
+}
+
+private predicate varOccursInBlock(Definition def, PreBasicBlock bb, SimpleAssignable a) {
+  exists(ssaDefRank(def, bb, _)) and
+  a = def.getAssignable()
+}
+
+pragma[noinline]
+private PreBasicBlock getAMaybeLiveSuccessor(Definition def, PreBasicBlock bb) {
+  result = bb.getASuccessor() and
+  not varOccursInBlock(_, bb, def.getAssignable()) and
+  ssaDefReachesEndOfBlock(bb, def, _)
+}
+
+private predicate varBlockReaches(Definition def, PreBasicBlock bb1, PreBasicBlock bb2) {
+  varOccursInBlock(def, bb1, _) and
+  bb2 = bb1.getASuccessor()
+  or
+  exists(PreBasicBlock mid | varBlockReaches(def, bb1, mid) |
+    bb2 = getAMaybeLiveSuccessor(def, mid)
+  )
+}
+
+private predicate varBlockReachesRead(Definition def, PreBasicBlock bb1, AssignableRead read) {
+  exists(PreBasicBlock bb2, int i2 |
+    varBlockReaches(def, bb1, bb2) and
+    ssaRefRank(bb2, i2, def.getAssignable(), SsaRead()) = 1 and
+    readAt(bb2, i2, read, _)
+  )
+}
+
+private predicate adjacentVarRead(Definition def, PreBasicBlock bb1, int i1, AssignableRead read) {
+  exists(int rankix, int i2 |
+    rankix = ssaDefRank(def, bb1, i1) and
+    rankix + 1 = ssaDefRank(def, bb1, i2) and
+    readAt(bb1, i2, read, _)
+  )
+  or
+  ssaDefRank(def, bb1, i1) = maxSsaRefRank(bb1, def.getAssignable()) and
+  varBlockReachesRead(def, bb1, read)
+}
+
+predicate firstReadSameVar(Definition def, AssignableRead read) {
+  exists(PreBasicBlock bb1, int i1 |
+    defAt(bb1, i1, def, _) and
+    adjacentVarRead(def, bb1, i1, read)
+  )
+}
+
+predicate adjacentReadPairSameVar(AssignableRead read1, AssignableRead read2) {
+  exists(Definition def, PreBasicBlock bb1, int i1 |
+    readAt(bb1, i1, read1, _) and
+    adjacentVarRead(def, bb1, i1, read2)
+  )
 }

--- a/csharp/ql/test/library-tests/dataflow/ssa/SsaDefLastRead.expected
+++ b/csharp/ql/test/library-tests/dataflow/ssa/SsaDefLastRead.expected
@@ -1,7 +1,9 @@
 | Capture.cs:6:16:6:16 | i | Capture.cs:6:16:6:16 | SSA param(i) | Capture.cs:33:13:33:13 | access to parameter i |
 | Capture.cs:6:16:6:16 | i | Capture.cs:10:20:27:9 | SSA capture def(i) | Capture.cs:12:17:12:17 | access to parameter i |
+| Capture.cs:6:16:6:16 | i | Capture.cs:13:13:13:17 | SSA def(i) | Capture.cs:14:17:14:17 | access to parameter i |
 | Capture.cs:6:16:6:16 | i | Capture.cs:38:9:38:11 | SSA call def(i) | Capture.cs:39:13:39:13 | access to parameter i |
 | Capture.cs:8:13:8:13 | x | Capture.cs:8:13:8:17 | SSA def(x) | Capture.cs:34:13:34:13 | access to local variable x |
+| Capture.cs:8:13:8:13 | x | Capture.cs:15:13:15:17 | SSA def(x) | Capture.cs:17:21:17:21 | access to local variable x |
 | Capture.cs:8:13:8:13 | x | Capture.cs:19:24:23:13 | SSA capture def(x) | Capture.cs:21:21:21:21 | access to local variable x |
 | Capture.cs:8:13:8:13 | x | Capture.cs:38:9:38:11 | SSA call def(x) | Capture.cs:40:13:40:13 | access to local variable x |
 | Capture.cs:8:13:8:13 | x | Capture.cs:43:9:43:13 | SSA def(x) | Capture.cs:44:11:44:11 | access to local variable x |
@@ -35,12 +37,17 @@
 | Capture.cs:92:18:92:18 | d | Capture.cs:92:18:92:18 | SSA param(d) | Capture.cs:92:24:92:24 | access to parameter d |
 | Capture.cs:94:13:94:13 | y | Capture.cs:96:12:100:9 | SSA capture def(y) | Capture.cs:98:21:98:21 | access to local variable y |
 | Capture.cs:98:17:98:17 | x | Capture.cs:98:17:98:21 | SSA def(x) | Capture.cs:99:20:99:20 | access to local variable x |
+| Capture.cs:102:13:102:13 | z | Capture.cs:105:13:105:17 | SSA def(z) | Capture.cs:106:20:106:20 | access to local variable z |
 | Capture.cs:114:13:114:13 | a | Capture.cs:115:9:119:9 | SSA capture def(a) | Capture.cs:117:21:117:21 | access to local variable a |
 | Capture.cs:117:17:117:17 | x | Capture.cs:117:17:117:21 | SSA def(x) | Capture.cs:118:17:118:17 | access to local variable x |
+| Capture.cs:122:13:122:13 | b | Capture.cs:125:13:125:17 | SSA def(b) | Capture.cs:126:17:126:17 | access to local variable b |
+| Capture.cs:130:13:130:13 | c | Capture.cs:133:13:133:17 | SSA def(c) | Capture.cs:134:17:134:17 | access to local variable c |
 | Capture.cs:130:13:130:13 | c | Capture.cs:136:9:136:12 | SSA call def(c) | Capture.cs:137:13:137:13 | access to local variable c |
 | Capture.cs:139:13:139:13 | d | Capture.cs:144:9:144:12 | SSA call def(d) | Capture.cs:145:13:145:13 | access to local variable d |
+| Capture.cs:147:13:147:13 | e | Capture.cs:148:9:152:9 | SSA capture def(e) | Capture.cs:150:17:150:17 | access to local variable e |
 | Capture.cs:154:13:154:13 | f | Capture.cs:154:13:154:18 | SSA def(f) | Capture.cs:155:13:155:13 | access to local variable f |
 | Capture.cs:162:13:162:13 | g | Capture.cs:163:9:166:9 | SSA capture def(g) | Capture.cs:165:17:165:17 | access to local variable g |
+| Capture.cs:168:13:168:13 | h | Capture.cs:176:13:176:16 | SSA call def(h) | Capture.cs:177:17:177:17 | access to local variable h |
 | Capture.cs:182:17:182:17 | i | Capture.cs:183:13:186:13 | SSA capture def(i) | Capture.cs:185:21:185:21 | access to local variable i |
 | Capture.cs:197:17:197:17 | i | Capture.cs:198:33:198:44 | SSA capture def(i) | Capture.cs:198:43:198:43 | access to local variable i |
 | Capture.cs:197:17:197:17 | i | Capture.cs:203:34:203:45 | SSA capture def(i) | Capture.cs:203:44:203:44 | access to local variable i |
@@ -56,6 +63,8 @@
 | Consistency.cs:15:17:15:17 | i | Consistency.cs:15:17:15:21 | [finally: exception(Exception)] SSA def(i) | Consistency.cs:16:17:16:17 | access to local variable i |
 | Consistency.cs:25:29:25:29 | c | Consistency.cs:25:29:25:29 | SSA def(c) | Consistency.cs:27:13:27:13 | access to local variable c |
 | Consistency.cs:26:13:26:19 | c.Field | Consistency.cs:25:29:25:29 | SSA qualifier def(c.Field) | Consistency.cs:27:13:27:19 | access to field Field |
+| Consistency.cs:30:30:30:30 | c | Consistency.cs:32:9:32:29 | SSA def(c) | Consistency.cs:33:9:33:9 | access to parameter c |
+| Consistency.cs:38:13:38:13 | i | Consistency.cs:39:28:39:32 | SSA def(i) | Consistency.cs:39:39:39:39 | access to local variable i |
 | Consistency.cs:44:11:44:11 | s | Consistency.cs:44:11:44:11 | SSA def(s) | Consistency.cs:46:13:46:13 | access to local variable s |
 | Consistency.cs:49:30:49:30 | a | Consistency.cs:49:30:49:30 | SSA param(a) | Consistency.cs:49:47:49:47 | access to parameter a |
 | Consistency.cs:49:37:49:37 | i | Consistency.cs:49:37:49:37 | SSA param(i) | Consistency.cs:49:49:49:49 | access to parameter i |
@@ -64,6 +73,7 @@
 | DefUse.cs:3:26:3:26 | w | DefUse.cs:19:13:19:18 | SSA def(w) | DefUse.cs:20:17:20:17 | access to parameter w |
 | DefUse.cs:3:26:3:26 | w | DefUse.cs:23:9:23:15 | SSA phi(w) | DefUse.cs:24:13:24:13 | access to parameter w |
 | DefUse.cs:3:26:3:26 | w | DefUse.cs:29:13:29:18 | SSA def(w) | DefUse.cs:53:17:53:17 | access to parameter w |
+| DefUse.cs:5:13:5:13 | x | DefUse.cs:5:13:5:17 | SSA def(x) | DefUse.cs:26:13:26:13 | access to local variable x |
 | DefUse.cs:5:13:5:13 | x | DefUse.cs:5:13:5:17 | SSA def(x) | DefUse.cs:56:16:56:16 | access to local variable x |
 | DefUse.cs:6:14:6:14 | y | DefUse.cs:6:14:6:19 | SSA def(y) | DefUse.cs:8:13:8:13 | access to local variable y |
 | DefUse.cs:6:14:6:14 | y | DefUse.cs:13:13:13:18 | SSA def(y) | DefUse.cs:14:17:14:17 | access to local variable y |
@@ -80,6 +90,8 @@
 | DefUse.cs:59:13:59:13 | i | DefUse.cs:72:9:72:11 | SSA def(i) | DefUse.cs:73:13:73:13 | access to local variable i |
 | DefUse.cs:59:13:59:13 | i | DefUse.cs:75:9:75:13 | SSA def(i) | DefUse.cs:76:9:76:9 | access to local variable i |
 | DefUse.cs:59:13:59:13 | i | DefUse.cs:76:9:76:11 | SSA def(i) | DefUse.cs:77:13:77:13 | access to local variable i |
+| DefUse.cs:63:9:63:14 | this.Field2 | DefUse.cs:63:9:63:18 | SSA def(this.Field2) | DefUse.cs:64:13:64:18 | access to field Field2 |
+| DefUse.cs:63:9:63:14 | this.Field2 | DefUse.cs:63:9:63:18 | SSA def(this.Field2) | DefUse.cs:80:37:80:42 | access to field Field2 |
 | DefUse.cs:66:9:66:14 | this.Field3 | DefUse.cs:66:9:66:18 | SSA def(this.Field3) | DefUse.cs:69:13:69:18 | access to field Field3 |
 | DefUse.cs:67:19:67:20 | tc | DefUse.cs:67:19:67:27 | SSA def(tc) | DefUse.cs:68:9:68:10 | access to local variable tc |
 | DefUse.cs:79:13:79:14 | x1 | DefUse.cs:80:16:80:46 | SSA phi(x1) | DefUse.cs:80:30:80:31 | access to local variable x1 |
@@ -100,6 +112,7 @@
 | DefUse.cs:155:9:155:14 | this.Field4 | DefUse.cs:155:9:155:18 | SSA def(this.Field4) | DefUse.cs:157:13:157:18 | access to field Field4 |
 | DefUse.cs:162:13:162:18 | this.Field4 | DefUse.cs:160:10:160:16 | SSA entry def(this.Field4) | DefUse.cs:163:13:163:18 | access to field Field4 |
 | DefUse.cs:167:23:167:23 | i | DefUse.cs:167:23:167:23 | SSA param(i) | DefUse.cs:169:13:169:13 | access to parameter i |
+| DefUse.cs:167:23:167:23 | i | DefUse.cs:173:13:173:17 | SSA def(i) | DefUse.cs:174:17:174:17 | access to parameter i |
 | DefUse.cs:167:23:167:23 | i | DefUse.cs:175:32:179:13 | SSA capture def(i) | DefUse.cs:178:21:178:21 | access to parameter i |
 | DefUse.cs:167:23:167:23 | i | DefUse.cs:181:9:181:11 | SSA call def(i) | DefUse.cs:182:13:182:13 | access to parameter i |
 | DefUse.cs:171:23:171:23 | a | DefUse.cs:171:23:180:9 | SSA def(a) | DefUse.cs:181:9:181:9 | access to local variable a |
@@ -135,6 +148,7 @@
 | Fields.cs:33:19:33:22 | Fields.stat | Fields.cs:34:9:34:16 | SSA call def(Fields.stat) | Fields.cs:37:13:37:16 | access to field stat |
 | Fields.cs:33:19:33:22 | Fields.stat | Fields.cs:38:9:38:13 | SSA call def(Fields.stat) | Fields.cs:41:13:41:16 | access to field stat |
 | Fields.cs:33:19:33:22 | Fields.stat | Fields.cs:51:9:51:20 | SSA call def(Fields.stat) | Fields.cs:54:13:54:16 | access to field stat |
+| Fields.cs:65:24:65:32 | this.LoopField | Fields.cs:61:17:61:17 | SSA entry def(this.LoopField) | Fields.cs:65:24:65:32 | access to field LoopField |
 | Fields.cs:77:13:77:13 | f | Fields.cs:77:13:77:45 | SSA def(f) | Fields.cs:90:19:90:19 | access to local variable f |
 | Fields.cs:77:13:77:13 | f | Fields.cs:78:27:78:54 | SSA capture def(f) | Fields.cs:78:35:78:35 | access to local variable f |
 | Fields.cs:78:23:78:23 | a | Fields.cs:78:23:78:54 | SSA def(a) | Fields.cs:81:9:81:9 | access to local variable a |
@@ -171,10 +185,12 @@
 | OutRef.cs:19:32:19:38 | t.Field | OutRef.cs:18:13:18:28 | SSA qualifier def(t.Field) | OutRef.cs:19:32:19:38 | access to field Field |
 | OutRef.cs:19:32:19:38 | t.Field | OutRef.cs:19:32:19:38 | SSA def(t.Field) | OutRef.cs:21:13:21:19 | access to field Field |
 | OutRef.cs:28:37:28:37 | j | OutRef.cs:28:37:28:37 | SSA param(j) | OutRef.cs:30:13:30:13 | access to parameter j |
+| OutRef.cs:34:38:34:38 | j | OutRef.cs:34:38:34:38 | SSA param(j) | OutRef.cs:36:13:36:13 | access to parameter j |
 | OutRef.cs:39:24:39:24 | b | OutRef.cs:39:24:39:24 | SSA param(b) | OutRef.cs:41:13:41:13 | access to parameter b |
 | Patterns.cs:7:16:7:16 | o | Patterns.cs:7:16:7:23 | SSA def(o) | Patterns.cs:20:17:20:17 | access to local variable o |
 | Patterns.cs:8:22:8:23 | i1 | Patterns.cs:8:18:8:23 | SSA def(i1) | Patterns.cs:10:38:10:39 | access to local variable i1 |
 | Patterns.cs:12:30:12:31 | s1 | Patterns.cs:12:23:12:31 | SSA def(s1) | Patterns.cs:14:41:14:42 | access to local variable s1 |
+| Patterns.cs:24:22:24:23 | i2 | Patterns.cs:24:18:24:23 | SSA def(i2) | Patterns.cs:24:30:24:31 | access to local variable i2 |
 | Patterns.cs:24:22:24:23 | i2 | Patterns.cs:24:18:24:23 | SSA def(i2) | Patterns.cs:25:47:25:48 | access to local variable i2 |
 | Patterns.cs:27:22:27:23 | i3 | Patterns.cs:27:18:27:23 | SSA def(i3) | Patterns.cs:28:42:28:43 | access to local variable i3 |
 | Patterns.cs:30:25:30:26 | s2 | Patterns.cs:30:18:30:26 | SSA def(s2) | Patterns.cs:31:45:31:46 | access to local variable s2 |
@@ -200,6 +216,7 @@
 | Properties.cs:33:19:33:22 | Properties.stat | Properties.cs:38:9:38:13 | SSA call def(Properties.stat) | Properties.cs:41:13:41:16 | access to property stat |
 | Properties.cs:33:19:33:22 | Properties.stat | Properties.cs:51:9:51:24 | SSA call def(Properties.stat) | Properties.cs:54:13:54:16 | access to property stat |
 | Properties.cs:61:23:61:23 | i | Properties.cs:63:16:63:16 | SSA phi(i) | Properties.cs:63:16:63:16 | access to parameter i |
+| Properties.cs:65:24:65:31 | this.LoopProp | Properties.cs:61:17:61:17 | SSA entry def(this.LoopProp) | Properties.cs:65:24:65:31 | access to property LoopProp |
 | Properties.cs:73:13:73:13 | f | Properties.cs:73:13:73:32 | SSA def(f) | Properties.cs:86:19:86:19 | access to local variable f |
 | Properties.cs:73:13:73:13 | f | Properties.cs:74:27:74:54 | SSA capture def(f) | Properties.cs:74:35:74:35 | access to local variable f |
 | Properties.cs:74:23:74:23 | a | Properties.cs:74:23:74:54 | SSA def(a) | Properties.cs:77:9:77:9 | access to local variable a |
@@ -240,6 +257,7 @@
 | Test.cs:9:13:9:13 | y | Test.cs:25:16:25:16 | SSA phi(y) | Test.cs:31:13:31:13 | access to local variable y |
 | Test.cs:9:13:9:13 | y | Test.cs:25:16:25:16 | SSA phi(y) | Test.cs:43:20:43:20 | access to local variable y |
 | Test.cs:10:13:10:13 | z | Test.cs:24:9:24:15 | SSA phi(z) | Test.cs:24:13:24:13 | access to local variable z |
+| Test.cs:34:18:34:18 | i | Test.cs:34:25:34:25 | SSA phi(i) | Test.cs:34:25:34:25 | access to local variable i |
 | Test.cs:34:18:34:18 | i | Test.cs:34:25:34:25 | SSA phi(i) | Test.cs:34:33:34:33 | access to local variable i |
 | Test.cs:39:22:39:22 | w | Test.cs:39:22:39:22 | SSA def(w) | Test.cs:41:23:41:23 | access to local variable w |
 | Test.cs:46:16:46:18 | in | Test.cs:46:16:46:18 | SSA param(in) | Test.cs:48:13:48:15 | access to parameter in |


### PR DESCRIPTION
- Speedup the `varBlockReaches()` predicate, by restricting to basic blocks in which a given SSA definition may still be live, in constrast to just being able to reach *any* access (read or write) to the underlying source variable.
- Account for some missing cases in the `lastRead()` predicate.
- The changes to `PreSsa.qll` mirror the changes in `Ssa.qll` (I also had to copy over the predicates `ssaDefReachesReadWithinBlock` and `ssaDefReachesRead()`).

Update: dist-compare report [here](https://git.semmle.com/gist/tom/9b8f9a792e9798f90789fadcdddebc7d) (internal link).

@calumgrant (also ping @aschackmull, who may be interested in something similar for Java).