### PR TITLE
JavaScript: Expand qldoc for `{Barrier,Sanitizer}GuardNode`.

### DIFF
--- a/javascript/ql/src/semmle/javascript/dataflow/Configuration.qll
+++ b/javascript/ql/src/semmle/javascript/dataflow/Configuration.qll
@@ -280,8 +280,13 @@ module FlowLabel {
 /**
  * A node that can act as a barrier when appearing in a condition.
  *
- * To use this barrier in `Configuration` `cfg`, add this barrier to the
- * extent of `cfg.isBarrierGuard`.
+ * To add a barrier guard to a configuration, define a subclass of this class overriding the
+ * `blocks` predicate, and then extend the configuration's `isBarrierGuard` predicate to include
+ * the new class.
+ *
+ * Note that it is generally a good idea to make the characteristic predicate of barrier guard
+ * classes as precise as possible: if two subclasses of `BarrierGuardNode` overlap, their
+ * implementations of `blocks` will _both_ apply to any configuration that includes either of them.
  */
 abstract class BarrierGuardNode extends DataFlow::Node {
   /**

--- a/javascript/ql/src/semmle/javascript/dataflow/TaintTracking.qll
+++ b/javascript/ql/src/semmle/javascript/dataflow/TaintTracking.qll
@@ -143,6 +143,15 @@ module TaintTracking {
 
   /**
    * A node that can act as a sanitizer when appearing in a condition.
+   *
+   * To add a sanitizer guard to a configuration, define a subclass of this class overriding the
+   * `sanitizes` predicate, and then extend the configuration's `isSanitizerGuard` predicate to
+   * include the new class.
+   *
+   * Note that it is generally a good idea to make the characteristic predicate of sanitizer guard
+   * classes as precise as possible: if two subclasses of `SanitizerGuardNode` overlap, their
+   * implementations of `sanitizes` will _both_ apply to any configuration that includes either of
+   * them.
    */
   abstract class SanitizerGuardNode extends DataFlow::BarrierGuardNode {
     override predicate blocks(boolean outcome, Expr e) { sanitizes(outcome, e) }


### PR DESCRIPTION
Thanks to @jbj and @aschackmull for pointing out this subtlety.