### PR TITLE
Java/C++/C#: Provide path-node locations via `hasLocationInfo`, not `getLocation`.

### DIFF
--- a/cpp/ql/src/semmle/code/cpp/dataflow/internal/DataFlowImpl.qll
+++ b/cpp/ql/src/semmle/code/cpp/dataflow/internal/DataFlowImpl.qll
@@ -1447,8 +1447,18 @@ abstract class PathNode extends TPathNode {
    */
   string toStringWithContext() { result = getNode().toString() + ppAp() + ppCtx() }
 
-  /** Gets the source location for this element. */
-  DataFlowLocation getLocation() { result = getNode().getLocation() }
+  /**
+   * Holds if this element is at the specified location.
+   * The location spans column `startcolumn` of line `startline` to
+   * column `endcolumn` of line `endline` in file `filepath`.
+   * For more information, see
+   * [Locations](https://help.semmle.com/QL/learn-ql/ql/locations.html).
+   */
+  predicate hasLocationInfo(
+    string filepath, int startline, int startcolumn, int endline, int endcolumn
+  ) {
+    getNode().hasLocationInfo(filepath, startline, startcolumn, endline, endcolumn)
+  }
 
   /** Gets the underlying `Node`. */
   abstract Node getNode();

--- a/cpp/ql/src/semmle/code/cpp/dataflow/internal/DataFlowImpl2.qll
+++ b/cpp/ql/src/semmle/code/cpp/dataflow/internal/DataFlowImpl2.qll
@@ -1447,8 +1447,18 @@ abstract class PathNode extends TPathNode {
    */
   string toStringWithContext() { result = getNode().toString() + ppAp() + ppCtx() }
 
-  /** Gets the source location for this element. */
-  DataFlowLocation getLocation() { result = getNode().getLocation() }
+  /**
+   * Holds if this element is at the specified location.
+   * The location spans column `startcolumn` of line `startline` to
+   * column `endcolumn` of line `endline` in file `filepath`.
+   * For more information, see
+   * [Locations](https://help.semmle.com/QL/learn-ql/ql/locations.html).
+   */
+  predicate hasLocationInfo(
+    string filepath, int startline, int startcolumn, int endline, int endcolumn
+  ) {
+    getNode().hasLocationInfo(filepath, startline, startcolumn, endline, endcolumn)
+  }
 
   /** Gets the underlying `Node`. */
   abstract Node getNode();

--- a/cpp/ql/src/semmle/code/cpp/dataflow/internal/DataFlowImpl3.qll
+++ b/cpp/ql/src/semmle/code/cpp/dataflow/internal/DataFlowImpl3.qll
@@ -1447,8 +1447,18 @@ abstract class PathNode extends TPathNode {
    */
   string toStringWithContext() { result = getNode().toString() + ppAp() + ppCtx() }
 
-  /** Gets the source location for this element. */
-  DataFlowLocation getLocation() { result = getNode().getLocation() }
+  /**
+   * Holds if this element is at the specified location.
+   * The location spans column `startcolumn` of line `startline` to
+   * column `endcolumn` of line `endline` in file `filepath`.
+   * For more information, see
+   * [Locations](https://help.semmle.com/QL/learn-ql/ql/locations.html).
+   */
+  predicate hasLocationInfo(
+    string filepath, int startline, int startcolumn, int endline, int endcolumn
+  ) {
+    getNode().hasLocationInfo(filepath, startline, startcolumn, endline, endcolumn)
+  }
 
   /** Gets the underlying `Node`. */
   abstract Node getNode();

--- a/cpp/ql/src/semmle/code/cpp/dataflow/internal/DataFlowImpl4.qll
+++ b/cpp/ql/src/semmle/code/cpp/dataflow/internal/DataFlowImpl4.qll
@@ -1447,8 +1447,18 @@ abstract class PathNode extends TPathNode {
    */
   string toStringWithContext() { result = getNode().toString() + ppAp() + ppCtx() }
 
-  /** Gets the source location for this element. */
-  DataFlowLocation getLocation() { result = getNode().getLocation() }
+  /**
+   * Holds if this element is at the specified location.
+   * The location spans column `startcolumn` of line `startline` to
+   * column `endcolumn` of line `endline` in file `filepath`.
+   * For more information, see
+   * [Locations](https://help.semmle.com/QL/learn-ql/ql/locations.html).
+   */
+  predicate hasLocationInfo(
+    string filepath, int startline, int startcolumn, int endline, int endcolumn
+  ) {
+    getNode().hasLocationInfo(filepath, startline, startcolumn, endline, endcolumn)
+  }
 
   /** Gets the underlying `Node`. */
   abstract Node getNode();

--- a/cpp/ql/src/semmle/code/cpp/dataflow/internal/DataFlowUtil.qll
+++ b/cpp/ql/src/semmle/code/cpp/dataflow/internal/DataFlowUtil.qll
@@ -56,6 +56,19 @@ class Node extends TNode {
   Location getLocation() { none() } // overridden by subclasses
 
   /**
+   * Holds if this element is at the specified location.
+   * The location spans column `startcolumn` of line `startline` to
+   * column `endcolumn` of line `endline` in file `filepath`.
+   * For more information, see
+   * [Locations](https://help.semmle.com/QL/learn-ql/ql/locations.html).
+   */
+  predicate hasLocationInfo(
+    string filepath, int startline, int startcolumn, int endline, int endcolumn
+  ) {
+    getLocation().hasLocationInfo(filepath, startline, startcolumn, endline, endcolumn)
+  }
+
+  /**
    * Gets an upper bound on the type of this node.
    */
   Type getTypeBound() { result = getType() }

--- a/cpp/ql/src/semmle/code/cpp/ir/dataflow/internal/DataFlowImpl.qll
+++ b/cpp/ql/src/semmle/code/cpp/ir/dataflow/internal/DataFlowImpl.qll
@@ -1447,8 +1447,18 @@ abstract class PathNode extends TPathNode {
    */
   string toStringWithContext() { result = getNode().toString() + ppAp() + ppCtx() }
 
-  /** Gets the source location for this element. */
-  DataFlowLocation getLocation() { result = getNode().getLocation() }
+  /**
+   * Holds if this element is at the specified location.
+   * The location spans column `startcolumn` of line `startline` to
+   * column `endcolumn` of line `endline` in file `filepath`.
+   * For more information, see
+   * [Locations](https://help.semmle.com/QL/learn-ql/ql/locations.html).
+   */
+  predicate hasLocationInfo(
+    string filepath, int startline, int startcolumn, int endline, int endcolumn
+  ) {
+    getNode().hasLocationInfo(filepath, startline, startcolumn, endline, endcolumn)
+  }
 
   /** Gets the underlying `Node`. */
   abstract Node getNode();

--- a/cpp/ql/src/semmle/code/cpp/ir/dataflow/internal/DataFlowImpl2.qll
+++ b/cpp/ql/src/semmle/code/cpp/ir/dataflow/internal/DataFlowImpl2.qll
@@ -1447,8 +1447,18 @@ abstract class PathNode extends TPathNode {
    */
   string toStringWithContext() { result = getNode().toString() + ppAp() + ppCtx() }
 
-  /** Gets the source location for this element. */
-  DataFlowLocation getLocation() { result = getNode().getLocation() }
+  /**
+   * Holds if this element is at the specified location.
+   * The location spans column `startcolumn` of line `startline` to
+   * column `endcolumn` of line `endline` in file `filepath`.
+   * For more information, see
+   * [Locations](https://help.semmle.com/QL/learn-ql/ql/locations.html).
+   */
+  predicate hasLocationInfo(
+    string filepath, int startline, int startcolumn, int endline, int endcolumn
+  ) {
+    getNode().hasLocationInfo(filepath, startline, startcolumn, endline, endcolumn)
+  }
 
   /** Gets the underlying `Node`. */
   abstract Node getNode();

--- a/cpp/ql/src/semmle/code/cpp/ir/dataflow/internal/DataFlowImpl3.qll
+++ b/cpp/ql/src/semmle/code/cpp/ir/dataflow/internal/DataFlowImpl3.qll
@@ -1447,8 +1447,18 @@ abstract class PathNode extends TPathNode {
    */
   string toStringWithContext() { result = getNode().toString() + ppAp() + ppCtx() }
 
-  /** Gets the source location for this element. */
-  DataFlowLocation getLocation() { result = getNode().getLocation() }
+  /**
+   * Holds if this element is at the specified location.
+   * The location spans column `startcolumn` of line `startline` to
+   * column `endcolumn` of line `endline` in file `filepath`.
+   * For more information, see
+   * [Locations](https://help.semmle.com/QL/learn-ql/ql/locations.html).
+   */
+  predicate hasLocationInfo(
+    string filepath, int startline, int startcolumn, int endline, int endcolumn
+  ) {
+    getNode().hasLocationInfo(filepath, startline, startcolumn, endline, endcolumn)
+  }
 
   /** Gets the underlying `Node`. */
   abstract Node getNode();

--- a/cpp/ql/src/semmle/code/cpp/ir/dataflow/internal/DataFlowImpl4.qll
+++ b/cpp/ql/src/semmle/code/cpp/ir/dataflow/internal/DataFlowImpl4.qll
@@ -1447,8 +1447,18 @@ abstract class PathNode extends TPathNode {
    */
   string toStringWithContext() { result = getNode().toString() + ppAp() + ppCtx() }
 
-  /** Gets the source location for this element. */
-  DataFlowLocation getLocation() { result = getNode().getLocation() }
+  /**
+   * Holds if this element is at the specified location.
+   * The location spans column `startcolumn` of line `startline` to
+   * column `endcolumn` of line `endline` in file `filepath`.
+   * For more information, see
+   * [Locations](https://help.semmle.com/QL/learn-ql/ql/locations.html).
+   */
+  predicate hasLocationInfo(
+    string filepath, int startline, int startcolumn, int endline, int endcolumn
+  ) {
+    getNode().hasLocationInfo(filepath, startline, startcolumn, endline, endcolumn)
+  }
 
   /** Gets the underlying `Node`. */
   abstract Node getNode();

--- a/cpp/ql/src/semmle/code/cpp/ir/dataflow/internal/DataFlowUtil.qll
+++ b/cpp/ql/src/semmle/code/cpp/ir/dataflow/internal/DataFlowUtil.qll
@@ -51,6 +51,19 @@ class Node extends Instruction {
    * Gets an upper bound on the type of this node.
    */
   Type getTypeBound() { result = getType() }
+
+  /**
+   * Holds if this element is at the specified location.
+   * The location spans column `startcolumn` of line `startline` to
+   * column `endcolumn` of line `endline` in file `filepath`.
+   * For more information, see
+   * [Locations](https://help.semmle.com/QL/learn-ql/ql/locations.html).
+   */
+  predicate hasLocationInfo(
+    string filepath, int startline, int startcolumn, int endline, int endcolumn
+  ) {
+    getLocation().hasLocationInfo(filepath, startline, startcolumn, endline, endcolumn)
+  }
 }
 
 /**

--- a/csharp/ql/src/semmle/code/csharp/dataflow/internal/DataFlowImpl.qll
+++ b/csharp/ql/src/semmle/code/csharp/dataflow/internal/DataFlowImpl.qll
@@ -1447,8 +1447,18 @@ abstract class PathNode extends TPathNode {
    */
   string toStringWithContext() { result = getNode().toString() + ppAp() + ppCtx() }
 
-  /** Gets the source location for this element. */
-  DataFlowLocation getLocation() { result = getNode().getLocation() }
+  /**
+   * Holds if this element is at the specified location.
+   * The location spans column `startcolumn` of line `startline` to
+   * column `endcolumn` of line `endline` in file `filepath`.
+   * For more information, see
+   * [Locations](https://help.semmle.com/QL/learn-ql/ql/locations.html).
+   */
+  predicate hasLocationInfo(
+    string filepath, int startline, int startcolumn, int endline, int endcolumn
+  ) {
+    getNode().hasLocationInfo(filepath, startline, startcolumn, endline, endcolumn)
+  }
 
   /** Gets the underlying `Node`. */
   abstract Node getNode();

--- a/csharp/ql/src/semmle/code/csharp/dataflow/internal/DataFlowImpl2.qll
+++ b/csharp/ql/src/semmle/code/csharp/dataflow/internal/DataFlowImpl2.qll
@@ -1447,8 +1447,18 @@ abstract class PathNode extends TPathNode {
    */
   string toStringWithContext() { result = getNode().toString() + ppAp() + ppCtx() }
 
-  /** Gets the source location for this element. */
-  DataFlowLocation getLocation() { result = getNode().getLocation() }
+  /**
+   * Holds if this element is at the specified location.
+   * The location spans column `startcolumn` of line `startline` to
+   * column `endcolumn` of line `endline` in file `filepath`.
+   * For more information, see
+   * [Locations](https://help.semmle.com/QL/learn-ql/ql/locations.html).
+   */
+  predicate hasLocationInfo(
+    string filepath, int startline, int startcolumn, int endline, int endcolumn
+  ) {
+    getNode().hasLocationInfo(filepath, startline, startcolumn, endline, endcolumn)
+  }
 
   /** Gets the underlying `Node`. */
   abstract Node getNode();

--- a/csharp/ql/src/semmle/code/csharp/dataflow/internal/DataFlowImpl3.qll
+++ b/csharp/ql/src/semmle/code/csharp/dataflow/internal/DataFlowImpl3.qll
@@ -1447,8 +1447,18 @@ abstract class PathNode extends TPathNode {
    */
   string toStringWithContext() { result = getNode().toString() + ppAp() + ppCtx() }
 
-  /** Gets the source location for this element. */
-  DataFlowLocation getLocation() { result = getNode().getLocation() }
+  /**
+   * Holds if this element is at the specified location.
+   * The location spans column `startcolumn` of line `startline` to
+   * column `endcolumn` of line `endline` in file `filepath`.
+   * For more information, see
+   * [Locations](https://help.semmle.com/QL/learn-ql/ql/locations.html).
+   */
+  predicate hasLocationInfo(
+    string filepath, int startline, int startcolumn, int endline, int endcolumn
+  ) {
+    getNode().hasLocationInfo(filepath, startline, startcolumn, endline, endcolumn)
+  }
 
   /** Gets the underlying `Node`. */
   abstract Node getNode();

--- a/csharp/ql/src/semmle/code/csharp/dataflow/internal/DataFlowImpl4.qll
+++ b/csharp/ql/src/semmle/code/csharp/dataflow/internal/DataFlowImpl4.qll
@@ -1447,8 +1447,18 @@ abstract class PathNode extends TPathNode {
    */
   string toStringWithContext() { result = getNode().toString() + ppAp() + ppCtx() }
 
-  /** Gets the source location for this element. */
-  DataFlowLocation getLocation() { result = getNode().getLocation() }
+  /**
+   * Holds if this element is at the specified location.
+   * The location spans column `startcolumn` of line `startline` to
+   * column `endcolumn` of line `endline` in file `filepath`.
+   * For more information, see
+   * [Locations](https://help.semmle.com/QL/learn-ql/ql/locations.html).
+   */
+  predicate hasLocationInfo(
+    string filepath, int startline, int startcolumn, int endline, int endcolumn
+  ) {
+    getNode().hasLocationInfo(filepath, startline, startcolumn, endline, endcolumn)
+  }
 
   /** Gets the underlying `Node`. */
   abstract Node getNode();

--- a/csharp/ql/src/semmle/code/csharp/dataflow/internal/DataFlowImpl5.qll
+++ b/csharp/ql/src/semmle/code/csharp/dataflow/internal/DataFlowImpl5.qll
@@ -1447,8 +1447,18 @@ abstract class PathNode extends TPathNode {
    */
   string toStringWithContext() { result = getNode().toString() + ppAp() + ppCtx() }
 
-  /** Gets the source location for this element. */
-  DataFlowLocation getLocation() { result = getNode().getLocation() }
+  /**
+   * Holds if this element is at the specified location.
+   * The location spans column `startcolumn` of line `startline` to
+   * column `endcolumn` of line `endline` in file `filepath`.
+   * For more information, see
+   * [Locations](https://help.semmle.com/QL/learn-ql/ql/locations.html).
+   */
+  predicate hasLocationInfo(
+    string filepath, int startline, int startcolumn, int endline, int endcolumn
+  ) {
+    getNode().hasLocationInfo(filepath, startline, startcolumn, endline, endcolumn)
+  }
 
   /** Gets the underlying `Node`. */
   abstract Node getNode();

--- a/csharp/ql/src/semmle/code/csharp/dataflow/internal/DataFlowPublic.qll
+++ b/csharp/ql/src/semmle/code/csharp/dataflow/internal/DataFlowPublic.qll
@@ -46,6 +46,19 @@ class Node extends TNode {
   /** Gets the location of this node. */
   cached
   Location getLocation() { none() }
+
+  /**
+   * Holds if this element is at the specified location.
+   * The location spans column `startcolumn` of line `startline` to
+   * column `endcolumn` of line `endline` in file `filepath`.
+   * For more information, see
+   * [Locations](https://help.semmle.com/QL/learn-ql/ql/locations.html).
+   */
+  predicate hasLocationInfo(
+    string filepath, int startline, int startcolumn, int endline, int endcolumn
+  ) {
+    getLocation().hasLocationInfo(filepath, startline, startcolumn, endline, endcolumn)
+  }
 }
 
 /**

--- a/csharp/ql/src/semmle/code/csharp/security/dataflow/XSS.qll
+++ b/csharp/ql/src/semmle/code/csharp/security/dataflow/XSS.qll
@@ -92,7 +92,7 @@ module XSS {
 
     override string toString() { result = node.toString() }
 
-    override Location getLocation() { result = node.getLocation() }
+    override Location getLocation() { result = node.getNode().getLocation() }
   }
 
   /** An ASP inline code element, viewed as an XSS flow node. */

--- a/java/ql/src/semmle/code/java/dataflow/internal/DataFlowImpl.qll
+++ b/java/ql/src/semmle/code/java/dataflow/internal/DataFlowImpl.qll
@@ -1447,8 +1447,18 @@ abstract class PathNode extends TPathNode {
    */
   string toStringWithContext() { result = getNode().toString() + ppAp() + ppCtx() }
 
-  /** Gets the source location for this element. */
-  DataFlowLocation getLocation() { result = getNode().getLocation() }
+  /**
+   * Holds if this element is at the specified location.
+   * The location spans column `startcolumn` of line `startline` to
+   * column `endcolumn` of line `endline` in file `filepath`.
+   * For more information, see
+   * [Locations](https://help.semmle.com/QL/learn-ql/ql/locations.html).
+   */
+  predicate hasLocationInfo(
+    string filepath, int startline, int startcolumn, int endline, int endcolumn
+  ) {
+    getNode().hasLocationInfo(filepath, startline, startcolumn, endline, endcolumn)
+  }
 
   /** Gets the underlying `Node`. */
   abstract Node getNode();

--- a/java/ql/src/semmle/code/java/dataflow/internal/DataFlowImpl2.qll
+++ b/java/ql/src/semmle/code/java/dataflow/internal/DataFlowImpl2.qll
@@ -1447,8 +1447,18 @@ abstract class PathNode extends TPathNode {
    */
   string toStringWithContext() { result = getNode().toString() + ppAp() + ppCtx() }
 
-  /** Gets the source location for this element. */
-  DataFlowLocation getLocation() { result = getNode().getLocation() }
+  /**
+   * Holds if this element is at the specified location.
+   * The location spans column `startcolumn` of line `startline` to
+   * column `endcolumn` of line `endline` in file `filepath`.
+   * For more information, see
+   * [Locations](https://help.semmle.com/QL/learn-ql/ql/locations.html).
+   */
+  predicate hasLocationInfo(
+    string filepath, int startline, int startcolumn, int endline, int endcolumn
+  ) {
+    getNode().hasLocationInfo(filepath, startline, startcolumn, endline, endcolumn)
+  }
 
   /** Gets the underlying `Node`. */
   abstract Node getNode();

--- a/java/ql/src/semmle/code/java/dataflow/internal/DataFlowImpl3.qll
+++ b/java/ql/src/semmle/code/java/dataflow/internal/DataFlowImpl3.qll
@@ -1447,8 +1447,18 @@ abstract class PathNode extends TPathNode {
    */
   string toStringWithContext() { result = getNode().toString() + ppAp() + ppCtx() }
 
-  /** Gets the source location for this element. */
-  DataFlowLocation getLocation() { result = getNode().getLocation() }
+  /**
+   * Holds if this element is at the specified location.
+   * The location spans column `startcolumn` of line `startline` to
+   * column `endcolumn` of line `endline` in file `filepath`.
+   * For more information, see
+   * [Locations](https://help.semmle.com/QL/learn-ql/ql/locations.html).
+   */
+  predicate hasLocationInfo(
+    string filepath, int startline, int startcolumn, int endline, int endcolumn
+  ) {
+    getNode().hasLocationInfo(filepath, startline, startcolumn, endline, endcolumn)
+  }
 
   /** Gets the underlying `Node`. */
   abstract Node getNode();

--- a/java/ql/src/semmle/code/java/dataflow/internal/DataFlowImpl4.qll
+++ b/java/ql/src/semmle/code/java/dataflow/internal/DataFlowImpl4.qll
@@ -1447,8 +1447,18 @@ abstract class PathNode extends TPathNode {
    */
   string toStringWithContext() { result = getNode().toString() + ppAp() + ppCtx() }
 
-  /** Gets the source location for this element. */
-  DataFlowLocation getLocation() { result = getNode().getLocation() }
+  /**
+   * Holds if this element is at the specified location.
+   * The location spans column `startcolumn` of line `startline` to
+   * column `endcolumn` of line `endline` in file `filepath`.
+   * For more information, see
+   * [Locations](https://help.semmle.com/QL/learn-ql/ql/locations.html).
+   */
+  predicate hasLocationInfo(
+    string filepath, int startline, int startcolumn, int endline, int endcolumn
+  ) {
+    getNode().hasLocationInfo(filepath, startline, startcolumn, endline, endcolumn)
+  }
 
   /** Gets the underlying `Node`. */
   abstract Node getNode();

--- a/java/ql/src/semmle/code/java/dataflow/internal/DataFlowImpl5.qll
+++ b/java/ql/src/semmle/code/java/dataflow/internal/DataFlowImpl5.qll
@@ -1447,8 +1447,18 @@ abstract class PathNode extends TPathNode {
    */
   string toStringWithContext() { result = getNode().toString() + ppAp() + ppCtx() }
 
-  /** Gets the source location for this element. */
-  DataFlowLocation getLocation() { result = getNode().getLocation() }
+  /**
+   * Holds if this element is at the specified location.
+   * The location spans column `startcolumn` of line `startline` to
+   * column `endcolumn` of line `endline` in file `filepath`.
+   * For more information, see
+   * [Locations](https://help.semmle.com/QL/learn-ql/ql/locations.html).
+   */
+  predicate hasLocationInfo(
+    string filepath, int startline, int startcolumn, int endline, int endcolumn
+  ) {
+    getNode().hasLocationInfo(filepath, startline, startcolumn, endline, endcolumn)
+  }
 
   /** Gets the underlying `Node`. */
   abstract Node getNode();

--- a/java/ql/src/semmle/code/java/dataflow/internal/DataFlowUtil.qll
+++ b/java/ql/src/semmle/code/java/dataflow/internal/DataFlowUtil.qll
@@ -90,6 +90,19 @@ class Node extends TNode {
     or
     result = getType() and not exists(getImprovedTypeBound())
   }
+
+  /**
+   * Holds if this element is at the specified location.
+   * The location spans column `startcolumn` of line `startline` to
+   * column `endcolumn` of line `endline` in file `filepath`.
+   * For more information, see
+   * [Locations](https://help.semmle.com/QL/learn-ql/ql/locations.html).
+   */
+  predicate hasLocationInfo(
+    string filepath, int startline, int startcolumn, int endline, int endcolumn
+  ) {
+    getLocation().hasLocationInfo(filepath, startline, startcolumn, endline, endcolumn)
+  }
 }
 
 /**


### PR DESCRIPTION
As discussed, this is slightly more flexible and would make my life a little easier in reusing the shared library (though I could work around it in other ways if this change is considered too disruptive). It also eliminates the only uses of `DataFlowLocation`, but  I'm fine with keeping it around for potential future uses.

cc @hvitved, @jbj, @dave-bartolomeo 