### PR TITLE
C++: side effect IR instructions for pointer arguments

### DIFF
--- a/config/identical-files.json
+++ b/config/identical-files.json
@@ -47,31 +47,36 @@
     "cpp/ql/src/semmle/code/cpp/ir/implementation/raw/Instruction.qll",
     "cpp/ql/src/semmle/code/cpp/ir/implementation/unaliased_ssa/Instruction.qll",
     "cpp/ql/src/semmle/code/cpp/ir/implementation/aliased_ssa/Instruction.qll",
-    "csharp/ql/src/semmle/code/csharp/ir/implementation/raw/Instruction.qll"
+    "csharp/ql/src/semmle/code/csharp/ir/implementation/raw/Instruction.qll",
+    "csharp/ql/src/semmle/code/csharp/ir/implementation/unaliased_ssa/Instruction.qll"
   ],
   "IR IRBlock": [
     "cpp/ql/src/semmle/code/cpp/ir/implementation/raw/IRBlock.qll",
     "cpp/ql/src/semmle/code/cpp/ir/implementation/unaliased_ssa/IRBlock.qll",
     "cpp/ql/src/semmle/code/cpp/ir/implementation/aliased_ssa/IRBlock.qll",
-    "csharp/ql/src/semmle/code/csharp/ir/implementation/raw/IRBlock.qll"
+    "csharp/ql/src/semmle/code/csharp/ir/implementation/raw/IRBlock.qll",
+    "csharp/ql/src/semmle/code/csharp/ir/implementation/unaliased_ssa/IRBlock.qll"
   ],
   "IR IRVariable": [
     "cpp/ql/src/semmle/code/cpp/ir/implementation/raw/IRVariable.qll",
     "cpp/ql/src/semmle/code/cpp/ir/implementation/unaliased_ssa/IRVariable.qll",
     "cpp/ql/src/semmle/code/cpp/ir/implementation/aliased_ssa/IRVariable.qll",
-    "csharp/ql/src/semmle/code/csharp/ir/implementation/raw/IRVariable.qll"
+    "csharp/ql/src/semmle/code/csharp/ir/implementation/raw/IRVariable.qll",
+    "csharp/ql/src/semmle/code/csharp/ir/implementation/unaliased_ssa/IRVariable.qll"
   ],
   "IR IRFunction": [
     "cpp/ql/src/semmle/code/cpp/ir/implementation/raw/IRFunction.qll",
     "cpp/ql/src/semmle/code/cpp/ir/implementation/unaliased_ssa/IRFunction.qll",
     "cpp/ql/src/semmle/code/cpp/ir/implementation/aliased_ssa/IRFunction.qll",
-    "csharp/ql/src/semmle/code/csharp/ir/implementation/raw/IRFunction.qll"
+    "csharp/ql/src/semmle/code/csharp/ir/implementation/raw/IRFunction.qll",
+    "csharp/ql/src/semmle/code/csharp/ir/implementation/unaliased_ssa/IRFunction.qll"
   ],
   "IR Operand": [
     "cpp/ql/src/semmle/code/cpp/ir/implementation/raw/Operand.qll",
     "cpp/ql/src/semmle/code/cpp/ir/implementation/unaliased_ssa/Operand.qll",
     "cpp/ql/src/semmle/code/cpp/ir/implementation/aliased_ssa/Operand.qll",
-    "csharp/ql/src/semmle/code/csharp/ir/implementation/raw/Operand.qll"
+    "csharp/ql/src/semmle/code/csharp/ir/implementation/raw/Operand.qll",
+    "csharp/ql/src/semmle/code/csharp/ir/implementation/unaliased_ssa/Operand.qll"
   ],
   "IR Operand Tag": [
     "cpp/ql/src/semmle/code/cpp/ir/implementation/internal/OperandTag.qll",
@@ -85,19 +90,22 @@
     "cpp/ql/src/semmle/code/cpp/ir/implementation/raw/IR.qll",
     "cpp/ql/src/semmle/code/cpp/ir/implementation/unaliased_ssa/IR.qll",
     "cpp/ql/src/semmle/code/cpp/ir/implementation/aliased_ssa/IR.qll",
-    "csharp/ql/src/semmle/code/csharp/ir/implementation/raw/IR.qll"
+    "csharp/ql/src/semmle/code/csharp/ir/implementation/raw/IR.qll",
+    "csharp/ql/src/semmle/code/csharp/ir/implementation/unaliased_ssa/IR.qll"
   ],
   "IR IRSanity": [
     "cpp/ql/src/semmle/code/cpp/ir/implementation/raw/IRSanity.qll",
     "cpp/ql/src/semmle/code/cpp/ir/implementation/unaliased_ssa/IRSanity.qll",
     "cpp/ql/src/semmle/code/cpp/ir/implementation/aliased_ssa/IRSanity.qll",
-    "csharp/ql/src/semmle/code/csharp/ir/implementation/raw/IRSanity.qll"
+    "csharp/ql/src/semmle/code/csharp/ir/implementation/raw/IRSanity.qll",
+    "csharp/ql/src/semmle/code/csharp/ir/implementation/unaliased_ssa/IRSanity.qll"
   ],
   "IR PrintIR": [
     "cpp/ql/src/semmle/code/cpp/ir/implementation/raw/PrintIR.qll",
     "cpp/ql/src/semmle/code/cpp/ir/implementation/unaliased_ssa/PrintIR.qll",
     "cpp/ql/src/semmle/code/cpp/ir/implementation/aliased_ssa/PrintIR.qll",
-    "csharp/ql/src/semmle/code/csharp/ir/implementation/raw/PrintIR.qll"
+    "csharp/ql/src/semmle/code/csharp/ir/implementation/raw/PrintIR.qll",
+    "csharp/ql/src/semmle/code/csharp/ir/implementation/unaliased_ssa/PrintIR.qll"
   ],
   "IR IntegerConstant": [
     "cpp/ql/src/semmle/code/cpp/ir/internal/IntegerConstant.qll",
@@ -205,21 +213,27 @@
     "cpp/ql/src/semmle/code/cpp/ir/implementation/unaliased_ssa/internal/reachability/PrintDominance.qll"
   ],
   "C# IR InstructionImports": [
-    "csharp/ql/src/semmle/code/csharp/ir/implementation/raw/internal/InstructionImports.qll"
+    "csharp/ql/src/semmle/code/csharp/ir/implementation/raw/internal/InstructionImports.qll",
+    "csharp/ql/src/semmle/code/csharp/ir/implementation/unaliased_ssa/internal/InstructionImports.qll"
   ],
   "C# IR IRImports": [
-    "csharp/ql/src/semmle/code/csharp/ir/implementation/raw/internal/IRImports.qll"
+    "csharp/ql/src/semmle/code/csharp/ir/implementation/raw/internal/IRImports.qll",
+    "csharp/ql/src/semmle/code/csharp/ir/implementation/unaliased_ssa/internal/IRImports.qll"
   ],
   "C# IR IRBlockImports": [
-    "csharp/ql/src/semmle/code/csharp/ir/implementation/raw/internal/IRBlockImports.qll"
+    "csharp/ql/src/semmle/code/csharp/ir/implementation/raw/internal/IRBlockImports.qll",
+    "csharp/ql/src/semmle/code/csharp/ir/implementation/unaliased_ssa/internal/IRBlockImports.qll"
   ],
   "C# IR IRVariableImports": [
-    "csharp/ql/src/semmle/code/csharp/ir/implementation/raw/internal/IRVariableImports.qll"
+    "csharp/ql/src/semmle/code/csharp/ir/implementation/raw/internal/IRVariableImports.qll",
+    "csharp/ql/src/semmle/code/csharp/ir/implementation/unaliased_ssa/internal/IRVariableImports.qll"
   ],
   "C# IR OperandImports": [
-    "csharp/ql/src/semmle/code/csharp/ir/implementation/raw/internal/OperandImports.qll"
+    "csharp/ql/src/semmle/code/csharp/ir/implementation/raw/internal/OperandImports.qll",
+    "csharp/ql/src/semmle/code/csharp/ir/implementation/unaliased_ssa/internal/OperandImports.qll"
   ],
   "C# IR PrintIRImports": [
-    "csharp/ql/src/semmle/code/csharp/ir/implementation/raw/internal/PrintIRImports.qll"
+    "csharp/ql/src/semmle/code/csharp/ir/implementation/raw/internal/PrintIRImports.qll",
+    "csharp/ql/src/semmle/code/csharp/ir/implementation/unaliased_ssa/internal/PrintIRImports.qll"
   ]
 }

--- a/cpp/ql/src/semmle/code/cpp/Parameter.qll
+++ b/cpp/ql/src/semmle/code/cpp/Parameter.qll
@@ -158,3 +158,10 @@ class Parameter extends LocalScopeVariable, @parameter {
     )
   }
 }
+
+/**
+ * An `int` that is a parameter index for some function.  This is needed for binding in certain cases.
+ */
+class ParameterIndex extends int {
+  ParameterIndex() { exists(Parameter p | this = p.getIndex()) }
+}

--- a/cpp/ql/src/semmle/code/cpp/ir/implementation/Opcode.qll
+++ b/cpp/ql/src/semmle/code/cpp/ir/implementation/Opcode.qll
@@ -66,10 +66,10 @@ private newtype TOpcode =
   TCallSideEffect() or
   TCallReadSideEffect() or
   TIndirectReadSideEffect() or
-  TIndirectWriteSideEffect() or
+  TIndirectMustWriteSideEffect() or
   TIndirectMayWriteSideEffect() or
   TBufferReadSideEffect() or
-  TBufferWriteSideEffect() or
+  TBufferMustWriteSideEffect() or
   TBufferMayWriteSideEffect() or
   TChi() or
   TInlineAsm() or
@@ -136,10 +136,15 @@ abstract class ReadSideEffectOpcode extends SideEffectOpcode { }
 abstract class WriteSideEffectOpcode extends SideEffectOpcode { }
 
 /**
+ * An opcode that definitely writes to a set of memory locations as a side effect.
+ */
+abstract class MustWriteSideEffectOpcode extends WriteSideEffectOpcode { }
+
+/**
  * An opcode that may overwrite some, all, or none of an existing set of memory locations. Modeled
  * as a read of the original contents, plus a "may" write of the new contents.
  */
-abstract class MayWriteSideEffectOpcode extends SideEffectOpcode { }
+abstract class MayWriteSideEffectOpcode extends WriteSideEffectOpcode { }
 
 /**
  * An opcode that accesses a buffer via an `AddressOperand` and a `BufferSizeOperand`.
@@ -416,9 +421,9 @@ module Opcode {
     final override string toString() { result = "IndirectReadSideEffect" }
   }
 
-  class IndirectWriteSideEffect extends WriteSideEffectOpcode, MemoryAccessOpcode,
-    TIndirectWriteSideEffect {
-    final override string toString() { result = "IndirectWriteSideEffect" }
+  class IndirectMustWriteSideEffect extends MustWriteSideEffectOpcode, MemoryAccessOpcode,
+    TIndirectMustWriteSideEffect {
+    final override string toString() { result = "IndirectMustWriteSideEffect" }
   }
 
   class IndirectMayWriteSideEffect extends MayWriteSideEffectOpcode, MemoryAccessOpcode,
@@ -430,9 +435,9 @@ module Opcode {
     final override string toString() { result = "BufferReadSideEffect" }
   }
 
-  class BufferWriteSideEffect extends WriteSideEffectOpcode, BufferAccessOpcode,
-    TBufferWriteSideEffect {
-    final override string toString() { result = "BufferWriteSideEffect" }
+  class BufferMustWriteSideEffect extends MustWriteSideEffectOpcode, BufferAccessOpcode,
+    TBufferMustWriteSideEffect {
+    final override string toString() { result = "BufferMustWriteSideEffect" }
   }
 
   class BufferMayWriteSideEffect extends MayWriteSideEffectOpcode, BufferAccessOpcode,
@@ -456,3 +461,4 @@ module Opcode {
     final override string toString() { result = "NewObj" }
   }
 }
+

--- a/cpp/ql/src/semmle/code/cpp/ir/implementation/Opcode.qll
+++ b/cpp/ql/src/semmle/code/cpp/ir/implementation/Opcode.qll
@@ -71,6 +71,9 @@ private newtype TOpcode =
   TBufferReadSideEffect() or
   TBufferMustWriteSideEffect() or
   TBufferMayWriteSideEffect() or
+  TSizedBufferReadSideEffect() or
+  TSizedBufferMustWriteSideEffect() or
+  TSizedBufferMayWriteSideEffect() or
   TChi() or
   TInlineAsm() or
   TUnreached() or
@@ -147,9 +150,15 @@ abstract class MustWriteSideEffectOpcode extends WriteSideEffectOpcode { }
 abstract class MayWriteSideEffectOpcode extends WriteSideEffectOpcode { }
 
 /**
- * An opcode that accesses a buffer via an `AddressOperand` and a `BufferSizeOperand`.
+ * An opcode that accesses a buffer via an `AddressOperand`.
  */
 abstract class BufferAccessOpcode extends MemoryAccessOpcode { }
+
+/**
+ * An opcode that accesses a buffer via an `AddressOperand` with a `BufferSizeOperand` specifying
+ * the number of elements accessed.
+ */
+abstract class SizedBufferAccessOpcode extends BufferAccessOpcode { }
 
 module Opcode {
   class NoOp extends Opcode, TNoOp {
@@ -443,6 +452,21 @@ module Opcode {
   class BufferMayWriteSideEffect extends MayWriteSideEffectOpcode, BufferAccessOpcode,
     TBufferMayWriteSideEffect {
     final override string toString() { result = "BufferMayWriteSideEffect" }
+  }
+
+  class SizedBufferReadSideEffect extends ReadSideEffectOpcode, SizedBufferAccessOpcode,
+    TSizedBufferReadSideEffect {
+    final override string toString() { result = "SizedBufferReadSideEffect" }
+  }
+
+  class SizedBufferMustWriteSideEffect extends MustWriteSideEffectOpcode, SizedBufferAccessOpcode,
+    TSizedBufferMustWriteSideEffect {
+    final override string toString() { result = "SizedBufferMustWriteSideEffect" }
+  }
+
+  class SizedBufferMayWriteSideEffect extends MayWriteSideEffectOpcode, SizedBufferAccessOpcode,
+    TSizedBufferMayWriteSideEffect {
+    final override string toString() { result = "SizedBufferMayWriteSideEffect" }
   }
 
   class Chi extends Opcode, TChi {

--- a/cpp/ql/src/semmle/code/cpp/ir/implementation/Opcode.qll
+++ b/cpp/ql/src/semmle/code/cpp/ir/implementation/Opcode.qll
@@ -485,4 +485,3 @@ module Opcode {
     final override string toString() { result = "NewObj" }
   }
 }
-

--- a/cpp/ql/src/semmle/code/cpp/ir/implementation/aliased_ssa/Instruction.qll
+++ b/cpp/ql/src/semmle/code/cpp/ir/implementation/aliased_ssa/Instruction.qll
@@ -644,6 +644,17 @@ class ConstantValueInstruction extends Instruction {
   final string getValue() { result = value }
 }
 
+class IndexedInstruction extends Instruction {
+  int index;
+
+  IndexedInstruction() { index = Construction::getInstructionIndex(this) }
+  
+
+  final override string getImmediateString() { result = index.toString() }
+
+  final int getIndex() { result = index }
+}
+
 class EnterFunctionInstruction extends Instruction {
   EnterFunctionInstruction() { getOpcode() instanceof Opcode::EnterFunction }
 }

--- a/cpp/ql/src/semmle/code/cpp/ir/implementation/aliased_ssa/Instruction.qll
+++ b/cpp/ql/src/semmle/code/cpp/ir/implementation/aliased_ssa/Instruction.qll
@@ -48,8 +48,8 @@ module InstructionSanity {
         or
         (
           opcode instanceof ReadSideEffectOpcode or
-          opcode instanceof MayWriteSideEffectOpcode or
-          opcode instanceof Opcode::InlineAsm
+          opcode instanceof Opcode::InlineAsm or
+          opcode instanceof Opcode::CallSideEffect
         ) and
         tag instanceof SideEffectOperandTag
       )

--- a/cpp/ql/src/semmle/code/cpp/ir/implementation/aliased_ssa/Instruction.qll
+++ b/cpp/ql/src/semmle/code/cpp/ir/implementation/aliased_ssa/Instruction.qll
@@ -30,7 +30,7 @@ module InstructionSanity {
         or
         opcode instanceof MemoryAccessOpcode and tag instanceof AddressOperandTag
         or
-        opcode instanceof BufferAccessOpcode and tag instanceof BufferSizeOperand
+        opcode instanceof SizedBufferAccessOpcode and tag instanceof BufferSizeOperandTag
         or
         opcode instanceof OpcodeWithCondition and tag instanceof ConditionOperandTag
         or
@@ -1176,7 +1176,7 @@ class CallReadSideEffectInstruction extends SideEffectInstruction {
 class IndirectReadSideEffectInstruction extends SideEffectInstruction {
   IndirectReadSideEffectInstruction() { getOpcode() instanceof Opcode::IndirectReadSideEffect }
 
-  Instruction getArgumentInstruction() { result = getAnOperand().(AddressOperand).getDef() }
+  Instruction getArgumentDef() { result = getAnOperand().(AddressOperand).getDef() }
 }
 
 /**
@@ -1185,7 +1185,20 @@ class IndirectReadSideEffectInstruction extends SideEffectInstruction {
 class BufferReadSideEffectInstruction extends SideEffectInstruction {
   BufferReadSideEffectInstruction() { getOpcode() instanceof Opcode::BufferReadSideEffect }
 
-  Instruction getArgumentInstruction() { result = getAnOperand().(AddressOperand).getDef() }
+  Instruction getArgumentDef() { result = getAnOperand().(AddressOperand).getDef() }
+}
+
+/**
+ * An instruction representing the read of an indirect buffer parameter within a function call.
+ */
+class SizedBufferReadSideEffectInstruction extends SideEffectInstruction {
+  SizedBufferReadSideEffectInstruction() {
+    getOpcode() instanceof Opcode::SizedBufferReadSideEffect
+  }
+
+  Instruction getArgumentDef() { result = getAnOperand().(AddressOperand).getDef() }
+
+  Instruction getSizeDef() { result = getAnOperand().(BufferSizeOperand).getDef() }
 }
 
 /**
@@ -1194,7 +1207,7 @@ class BufferReadSideEffectInstruction extends SideEffectInstruction {
 class WriteSideEffectInstruction extends SideEffectInstruction {
   WriteSideEffectInstruction() { getOpcode() instanceof WriteSideEffectOpcode }
 
-  Instruction getArgumentInstruction() { result = getAnOperand().(AddressOperand).getDef() }
+  Instruction getArgumentDef() { result = getAnOperand().(AddressOperand).getDef() }
 }
 
 /**
@@ -1218,6 +1231,20 @@ class BufferMustWriteSideEffectInstruction extends WriteSideEffectInstruction {
   }
 
   final override MemoryAccessKind getResultMemoryAccess() { result instanceof BufferMemoryAccess }
+}
+
+/**
+ * An instruction representing the write of an indirect buffer parameter within a function call. The
+ * entire buffer is overwritten.
+ */
+class SizedBufferMustWriteSideEffectInstruction extends WriteSideEffectInstruction {
+  SizedBufferMustWriteSideEffectInstruction() {
+    getOpcode() instanceof Opcode::SizedBufferMustWriteSideEffect
+  }
+
+  final override MemoryAccessKind getResultMemoryAccess() { result instanceof BufferMemoryAccess }
+
+  Instruction getSizeDef() { result = getAnOperand().(BufferSizeOperand).getDef() }
 }
 
 /**
@@ -1245,6 +1272,22 @@ class BufferMayWriteSideEffectInstruction extends WriteSideEffectInstruction {
   final override MemoryAccessKind getResultMemoryAccess() {
     result instanceof BufferMayMemoryAccess
   }
+}
+
+/**
+ * An instruction representing the write of an indirect buffer parameter within a function call.
+ * Unlike `BufferWriteSideEffectInstruction`, the buffer might not be completely overwritten.
+ */
+class SizedBufferMayWriteSideEffectInstruction extends WriteSideEffectInstruction {
+  SizedBufferMayWriteSideEffectInstruction() {
+    getOpcode() instanceof Opcode::SizedBufferMayWriteSideEffect
+  }
+
+  final override MemoryAccessKind getResultMemoryAccess() {
+    result instanceof BufferMayMemoryAccess
+  }
+
+  Instruction getSizeDef() { result = getAnOperand().(BufferSizeOperand).getDef() }
 }
 
 /**

--- a/cpp/ql/src/semmle/code/cpp/ir/implementation/aliased_ssa/Instruction.qll
+++ b/cpp/ql/src/semmle/code/cpp/ir/implementation/aliased_ssa/Instruction.qll
@@ -20,23 +20,32 @@ module InstructionSanity {
     exists(Opcode opcode |
       opcode = instr.getOpcode() and
       (
-        opcode instanceof UnaryOpcode and tag instanceof UnaryOperandTag or
+        opcode instanceof UnaryOpcode and tag instanceof UnaryOperandTag
+        or
+        opcode instanceof BinaryOpcode and
         (
-          opcode instanceof BinaryOpcode and
-          (
-            tag instanceof LeftOperandTag or
-            tag instanceof RightOperandTag
-          )
-        ) or
-        opcode instanceof MemoryAccessOpcode and tag instanceof AddressOperandTag or
-        opcode instanceof OpcodeWithCondition and tag instanceof ConditionOperandTag or
-        opcode instanceof OpcodeWithLoad and tag instanceof LoadOperandTag or
-        opcode instanceof Opcode::Store and tag instanceof StoreValueOperandTag or
-        opcode instanceof Opcode::UnmodeledUse and tag instanceof UnmodeledUseOperandTag or
-        opcode instanceof Opcode::Call and tag instanceof CallTargetOperandTag or
-        opcode instanceof Opcode::Chi and tag instanceof ChiTotalOperandTag or
-        opcode instanceof Opcode::Chi and tag instanceof ChiPartialOperandTag or
-
+          tag instanceof LeftOperandTag or
+          tag instanceof RightOperandTag
+        )
+        or
+        opcode instanceof MemoryAccessOpcode and tag instanceof AddressOperandTag
+        or
+        opcode instanceof BufferAccessOpcode and tag instanceof BufferSizeOperand
+        or
+        opcode instanceof OpcodeWithCondition and tag instanceof ConditionOperandTag
+        or
+        opcode instanceof OpcodeWithLoad and tag instanceof LoadOperandTag
+        or
+        opcode instanceof Opcode::Store and tag instanceof StoreValueOperandTag
+        or
+        opcode instanceof Opcode::UnmodeledUse and tag instanceof UnmodeledUseOperandTag
+        or
+        opcode instanceof Opcode::Call and tag instanceof CallTargetOperandTag
+        or
+        opcode instanceof Opcode::Chi and tag instanceof ChiTotalOperandTag
+        or
+        opcode instanceof Opcode::Chi and tag instanceof ChiPartialOperandTag
+        or
         (
           opcode instanceof ReadSideEffectOpcode or
           opcode instanceof MayWriteSideEffectOpcode or
@@ -600,9 +609,7 @@ class VariableInstruction extends Instruction {
 
   VariableInstruction() { var = Construction::getInstructionVariable(this) }
 
-  override string getImmediateString() {
-    result = var.toString()
-  }
+  override string getImmediateString() { result = var.toString() }
 
   final IRVariable getVariable() { result = var }
 }
@@ -648,9 +655,9 @@ class VariableAddressInstruction extends VariableInstruction {
 class InitializeParameterInstruction extends VariableInstruction {
   InitializeParameterInstruction() { getOpcode() instanceof Opcode::InitializeParameter }
 
-  override final MemoryAccessKind getResultMemoryAccess() {
-    result instanceof IndirectMemoryAccess
-  }
+  final Language::Parameter getParameter() { result = var.(IRUserVariable).getVariable() }
+
+  final override MemoryAccessKind getResultMemoryAccess() { result instanceof IndirectMemoryAccess }
 }
 
 /**
@@ -1167,39 +1174,27 @@ class CallReadSideEffectInstruction extends SideEffectInstruction {
  * An instruction representing the read of an indirect parameter within a function call.
  */
 class IndirectReadSideEffectInstruction extends SideEffectInstruction {
-  IndirectReadSideEffectInstruction() {
-    getOpcode() instanceof Opcode::IndirectReadSideEffect
-  }
+  IndirectReadSideEffectInstruction() { getOpcode() instanceof Opcode::IndirectReadSideEffect }
 
-  Instruction getArgumentInstruction() {
-    result = getAnOperand().(AddressOperand).getDef()
-  }
+  Instruction getArgumentInstruction() { result = getAnOperand().(AddressOperand).getDef() }
 }
 
 /**
  * An instruction representing the read of an indirect buffer parameter within a function call.
  */
 class BufferReadSideEffectInstruction extends SideEffectInstruction {
-  BufferReadSideEffectInstruction() {
-    getOpcode() instanceof Opcode::BufferReadSideEffect
-  }
+  BufferReadSideEffectInstruction() { getOpcode() instanceof Opcode::BufferReadSideEffect }
 
-  Instruction getArgumentInstruction() {
-    result = getAnOperand().(AddressOperand).getDef()
-  }
+  Instruction getArgumentInstruction() { result = getAnOperand().(AddressOperand).getDef() }
 }
 
 /**
  * An instruction representing a side effect of a function call.
  */
 class WriteSideEffectInstruction extends SideEffectInstruction {
-  WriteSideEffectInstruction() {
-    getOpcode() instanceof WriteSideEffectOpcode
-  }
+  WriteSideEffectInstruction() { getOpcode() instanceof WriteSideEffectOpcode }
 
-  Instruction getArgumentInstruction() {
-    result = getAnOperand().(AddressOperand).getDef()
-  }
+  Instruction getArgumentInstruction() { result = getAnOperand().(AddressOperand).getDef() }
 }
 
 /**
@@ -1245,9 +1240,7 @@ class IndirectMayWriteSideEffectInstruction extends WriteSideEffectInstruction {
  * Unlike `BufferWriteSideEffectInstruction`, the buffer might not be completely overwritten.
  */
 class BufferMayWriteSideEffectInstruction extends WriteSideEffectInstruction {
-  BufferMayWriteSideEffectInstruction() {
-    getOpcode() instanceof Opcode::BufferMayWriteSideEffect
-  }
+  BufferMayWriteSideEffectInstruction() { getOpcode() instanceof Opcode::BufferMayWriteSideEffect }
 
   final override MemoryAccessKind getResultMemoryAccess() {
     result instanceof BufferMayMemoryAccess

--- a/cpp/ql/src/semmle/code/cpp/ir/implementation/aliased_ssa/Instruction.qll
+++ b/cpp/ql/src/semmle/code/cpp/ir/implementation/aliased_ssa/Instruction.qll
@@ -648,7 +648,6 @@ class IndexedInstruction extends Instruction {
   int index;
 
   IndexedInstruction() { index = Construction::getInstructionIndex(this) }
-  
 
   final override string getImmediateString() { result = index.toString() }
 

--- a/cpp/ql/src/semmle/code/cpp/ir/implementation/aliased_ssa/Operand.qll
+++ b/cpp/ql/src/semmle/code/cpp/ir/implementation/aliased_ssa/Operand.qll
@@ -255,6 +255,16 @@ class AddressOperand extends RegisterOperand {
 }
 
 /**
+ * The buffer size operand of an instruction that represents a read or write of
+ * a buffer.
+ */
+class BufferSizeOperand extends RegisterOperand {
+  override BufferSizeOperandTag tag;
+
+  override string toString() { result = "BufferSize" }
+}
+
+/**
  * The source value operand of an instruction that loads a value from memory (e.g. `Load`,
  * `ReturnValue`, `ThrowValue`).
  */

--- a/cpp/ql/src/semmle/code/cpp/ir/implementation/aliased_ssa/Operand.qll
+++ b/cpp/ql/src/semmle/code/cpp/ir/implementation/aliased_ssa/Operand.qll
@@ -390,10 +390,10 @@ class SideEffectOperand extends TypedOperand {
     useInstr instanceof BufferReadSideEffectInstruction and
     result instanceof BufferMemoryAccess
     or
-    useInstr instanceof IndirectWriteSideEffectInstruction and
+    useInstr instanceof IndirectMustWriteSideEffectInstruction and
     result instanceof IndirectMemoryAccess
     or
-    useInstr instanceof BufferWriteSideEffectInstruction and
+    useInstr instanceof BufferMustWriteSideEffectInstruction and
     result instanceof BufferMemoryAccess
     or
     useInstr instanceof IndirectMayWriteSideEffectInstruction and

--- a/cpp/ql/src/semmle/code/cpp/ir/implementation/aliased_ssa/internal/AliasAnalysis.qll
+++ b/cpp/ql/src/semmle/code/cpp/ir/implementation/aliased_ssa/internal/AliasAnalysis.qll
@@ -226,7 +226,7 @@ private predicate isArgumentForParameter(CallInstruction ci, Operand operand, In
     ci = operand.getUse() and
     f = ci.getStaticCallTarget() and
     (
-      init.(InitializeParameterInstruction).getVariable().getAST() = f
+      init.(InitializeParameterInstruction).getParameter() = f
             .getParameter(operand.(PositionalArgumentOperand).getIndex())
       or
       init instanceof InitializeThisInstruction and

--- a/cpp/ql/src/semmle/code/cpp/ir/implementation/aliased_ssa/internal/AliasAnalysis.qll
+++ b/cpp/ql/src/semmle/code/cpp/ir/implementation/aliased_ssa/internal/AliasAnalysis.qll
@@ -226,7 +226,7 @@ private predicate isArgumentForParameter(CallInstruction ci, Operand operand, In
     ci = operand.getUse() and
     f = ci.getStaticCallTarget() and
     (
-      init.(InitializeParameterInstruction).getParameter() = f
+      init.(InitializeParameterInstruction).getVariable().getAST() = f
             .getParameter(operand.(PositionalArgumentOperand).getIndex())
       or
       init instanceof InitializeThisInstruction and

--- a/cpp/ql/src/semmle/code/cpp/ir/implementation/aliased_ssa/internal/SSAConstruction.qll
+++ b/cpp/ql/src/semmle/code/cpp/ir/implementation/aliased_ssa/internal/SSAConstruction.qll
@@ -343,6 +343,11 @@ private module Cached {
   }
 
   cached
+  int getInstructionIndex(Instruction instruction) {
+    result = getOldInstruction(instruction).(OldIR::IndexedInstruction).getIndex()
+  }
+
+  cached
   Function getInstructionFunction(Instruction instruction) {
     result = getOldInstruction(instruction).(OldIR::FunctionInstruction).getFunctionSymbol()
   }

--- a/cpp/ql/src/semmle/code/cpp/ir/implementation/internal/OperandTag.qll
+++ b/cpp/ql/src/semmle/code/cpp/ir/implementation/internal/OperandTag.qll
@@ -72,6 +72,8 @@ class BufferSizeOperandTag extends RegisterOperandTag, TBufferSizeOperand {
   final override int getSortOrder() { result = 1 }
 }
 
+BufferSizeOperandTag bufferSizeOperand() { result = TBufferSizeOperand() }
+
 /**
  * The operand representing the read side effect of a `SideEffectInstruction`.
  */

--- a/cpp/ql/src/semmle/code/cpp/ir/implementation/internal/OperandTag.qll
+++ b/cpp/ql/src/semmle/code/cpp/ir/implementation/internal/OperandTag.qll
@@ -66,7 +66,7 @@ AddressOperandTag addressOperand() { result = TAddressOperand() }
  * The buffer size operand of an instruction that represents a read or write of
  * a buffer.
  */
-class BufferSizeOperand extends RegisterOperandTag, TBufferSizeOperand {
+class BufferSizeOperandTag extends RegisterOperandTag, TBufferSizeOperand {
   final override string toString() { result = "BufferSize" }
 
   final override int getSortOrder() { result = 1 }

--- a/cpp/ql/src/semmle/code/cpp/ir/implementation/raw/Instruction.qll
+++ b/cpp/ql/src/semmle/code/cpp/ir/implementation/raw/Instruction.qll
@@ -644,6 +644,17 @@ class ConstantValueInstruction extends Instruction {
   final string getValue() { result = value }
 }
 
+class IndexedInstruction extends Instruction {
+  int index;
+
+  IndexedInstruction() { index = Construction::getInstructionIndex(this) }
+  
+
+  final override string getImmediateString() { result = index.toString() }
+
+  final int getIndex() { result = index }
+}
+
 class EnterFunctionInstruction extends Instruction {
   EnterFunctionInstruction() { getOpcode() instanceof Opcode::EnterFunction }
 }

--- a/cpp/ql/src/semmle/code/cpp/ir/implementation/raw/Instruction.qll
+++ b/cpp/ql/src/semmle/code/cpp/ir/implementation/raw/Instruction.qll
@@ -48,8 +48,8 @@ module InstructionSanity {
         or
         (
           opcode instanceof ReadSideEffectOpcode or
-          opcode instanceof MayWriteSideEffectOpcode or
-          opcode instanceof Opcode::InlineAsm
+          opcode instanceof Opcode::InlineAsm or
+          opcode instanceof Opcode::CallSideEffect
         ) and
         tag instanceof SideEffectOperandTag
       )

--- a/cpp/ql/src/semmle/code/cpp/ir/implementation/raw/Instruction.qll
+++ b/cpp/ql/src/semmle/code/cpp/ir/implementation/raw/Instruction.qll
@@ -30,7 +30,7 @@ module InstructionSanity {
         or
         opcode instanceof MemoryAccessOpcode and tag instanceof AddressOperandTag
         or
-        opcode instanceof BufferAccessOpcode and tag instanceof BufferSizeOperand
+        opcode instanceof SizedBufferAccessOpcode and tag instanceof BufferSizeOperandTag
         or
         opcode instanceof OpcodeWithCondition and tag instanceof ConditionOperandTag
         or
@@ -1176,7 +1176,7 @@ class CallReadSideEffectInstruction extends SideEffectInstruction {
 class IndirectReadSideEffectInstruction extends SideEffectInstruction {
   IndirectReadSideEffectInstruction() { getOpcode() instanceof Opcode::IndirectReadSideEffect }
 
-  Instruction getArgumentInstruction() { result = getAnOperand().(AddressOperand).getDef() }
+  Instruction getArgumentDef() { result = getAnOperand().(AddressOperand).getDef() }
 }
 
 /**
@@ -1185,7 +1185,20 @@ class IndirectReadSideEffectInstruction extends SideEffectInstruction {
 class BufferReadSideEffectInstruction extends SideEffectInstruction {
   BufferReadSideEffectInstruction() { getOpcode() instanceof Opcode::BufferReadSideEffect }
 
-  Instruction getArgumentInstruction() { result = getAnOperand().(AddressOperand).getDef() }
+  Instruction getArgumentDef() { result = getAnOperand().(AddressOperand).getDef() }
+}
+
+/**
+ * An instruction representing the read of an indirect buffer parameter within a function call.
+ */
+class SizedBufferReadSideEffectInstruction extends SideEffectInstruction {
+  SizedBufferReadSideEffectInstruction() {
+    getOpcode() instanceof Opcode::SizedBufferReadSideEffect
+  }
+
+  Instruction getArgumentDef() { result = getAnOperand().(AddressOperand).getDef() }
+
+  Instruction getSizeDef() { result = getAnOperand().(BufferSizeOperand).getDef() }
 }
 
 /**
@@ -1194,7 +1207,7 @@ class BufferReadSideEffectInstruction extends SideEffectInstruction {
 class WriteSideEffectInstruction extends SideEffectInstruction {
   WriteSideEffectInstruction() { getOpcode() instanceof WriteSideEffectOpcode }
 
-  Instruction getArgumentInstruction() { result = getAnOperand().(AddressOperand).getDef() }
+  Instruction getArgumentDef() { result = getAnOperand().(AddressOperand).getDef() }
 }
 
 /**
@@ -1218,6 +1231,20 @@ class BufferMustWriteSideEffectInstruction extends WriteSideEffectInstruction {
   }
 
   final override MemoryAccessKind getResultMemoryAccess() { result instanceof BufferMemoryAccess }
+}
+
+/**
+ * An instruction representing the write of an indirect buffer parameter within a function call. The
+ * entire buffer is overwritten.
+ */
+class SizedBufferMustWriteSideEffectInstruction extends WriteSideEffectInstruction {
+  SizedBufferMustWriteSideEffectInstruction() {
+    getOpcode() instanceof Opcode::SizedBufferMustWriteSideEffect
+  }
+
+  final override MemoryAccessKind getResultMemoryAccess() { result instanceof BufferMemoryAccess }
+
+  Instruction getSizeDef() { result = getAnOperand().(BufferSizeOperand).getDef() }
 }
 
 /**
@@ -1245,6 +1272,22 @@ class BufferMayWriteSideEffectInstruction extends WriteSideEffectInstruction {
   final override MemoryAccessKind getResultMemoryAccess() {
     result instanceof BufferMayMemoryAccess
   }
+}
+
+/**
+ * An instruction representing the write of an indirect buffer parameter within a function call.
+ * Unlike `BufferWriteSideEffectInstruction`, the buffer might not be completely overwritten.
+ */
+class SizedBufferMayWriteSideEffectInstruction extends WriteSideEffectInstruction {
+  SizedBufferMayWriteSideEffectInstruction() {
+    getOpcode() instanceof Opcode::SizedBufferMayWriteSideEffect
+  }
+
+  final override MemoryAccessKind getResultMemoryAccess() {
+    result instanceof BufferMayMemoryAccess
+  }
+
+  Instruction getSizeDef() { result = getAnOperand().(BufferSizeOperand).getDef() }
 }
 
 /**

--- a/cpp/ql/src/semmle/code/cpp/ir/implementation/raw/Instruction.qll
+++ b/cpp/ql/src/semmle/code/cpp/ir/implementation/raw/Instruction.qll
@@ -20,23 +20,32 @@ module InstructionSanity {
     exists(Opcode opcode |
       opcode = instr.getOpcode() and
       (
-        opcode instanceof UnaryOpcode and tag instanceof UnaryOperandTag or
+        opcode instanceof UnaryOpcode and tag instanceof UnaryOperandTag
+        or
+        opcode instanceof BinaryOpcode and
         (
-          opcode instanceof BinaryOpcode and
-          (
-            tag instanceof LeftOperandTag or
-            tag instanceof RightOperandTag
-          )
-        ) or
-        opcode instanceof MemoryAccessOpcode and tag instanceof AddressOperandTag or
-        opcode instanceof OpcodeWithCondition and tag instanceof ConditionOperandTag or
-        opcode instanceof OpcodeWithLoad and tag instanceof LoadOperandTag or
-        opcode instanceof Opcode::Store and tag instanceof StoreValueOperandTag or
-        opcode instanceof Opcode::UnmodeledUse and tag instanceof UnmodeledUseOperandTag or
-        opcode instanceof Opcode::Call and tag instanceof CallTargetOperandTag or
-        opcode instanceof Opcode::Chi and tag instanceof ChiTotalOperandTag or
-        opcode instanceof Opcode::Chi and tag instanceof ChiPartialOperandTag or
-
+          tag instanceof LeftOperandTag or
+          tag instanceof RightOperandTag
+        )
+        or
+        opcode instanceof MemoryAccessOpcode and tag instanceof AddressOperandTag
+        or
+        opcode instanceof BufferAccessOpcode and tag instanceof BufferSizeOperand
+        or
+        opcode instanceof OpcodeWithCondition and tag instanceof ConditionOperandTag
+        or
+        opcode instanceof OpcodeWithLoad and tag instanceof LoadOperandTag
+        or
+        opcode instanceof Opcode::Store and tag instanceof StoreValueOperandTag
+        or
+        opcode instanceof Opcode::UnmodeledUse and tag instanceof UnmodeledUseOperandTag
+        or
+        opcode instanceof Opcode::Call and tag instanceof CallTargetOperandTag
+        or
+        opcode instanceof Opcode::Chi and tag instanceof ChiTotalOperandTag
+        or
+        opcode instanceof Opcode::Chi and tag instanceof ChiPartialOperandTag
+        or
         (
           opcode instanceof ReadSideEffectOpcode or
           opcode instanceof MayWriteSideEffectOpcode or
@@ -600,9 +609,7 @@ class VariableInstruction extends Instruction {
 
   VariableInstruction() { var = Construction::getInstructionVariable(this) }
 
-  override string getImmediateString() {
-    result = var.toString()
-  }
+  override string getImmediateString() { result = var.toString() }
 
   final IRVariable getVariable() { result = var }
 }
@@ -648,9 +655,9 @@ class VariableAddressInstruction extends VariableInstruction {
 class InitializeParameterInstruction extends VariableInstruction {
   InitializeParameterInstruction() { getOpcode() instanceof Opcode::InitializeParameter }
 
-  override final MemoryAccessKind getResultMemoryAccess() {
-    result instanceof IndirectMemoryAccess
-  }
+  final Language::Parameter getParameter() { result = var.(IRUserVariable).getVariable() }
+
+  final override MemoryAccessKind getResultMemoryAccess() { result instanceof IndirectMemoryAccess }
 }
 
 /**
@@ -1167,39 +1174,27 @@ class CallReadSideEffectInstruction extends SideEffectInstruction {
  * An instruction representing the read of an indirect parameter within a function call.
  */
 class IndirectReadSideEffectInstruction extends SideEffectInstruction {
-  IndirectReadSideEffectInstruction() {
-    getOpcode() instanceof Opcode::IndirectReadSideEffect
-  }
+  IndirectReadSideEffectInstruction() { getOpcode() instanceof Opcode::IndirectReadSideEffect }
 
-  Instruction getArgumentInstruction() {
-    result = getAnOperand().(AddressOperand).getDef()
-  }
+  Instruction getArgumentInstruction() { result = getAnOperand().(AddressOperand).getDef() }
 }
 
 /**
  * An instruction representing the read of an indirect buffer parameter within a function call.
  */
 class BufferReadSideEffectInstruction extends SideEffectInstruction {
-  BufferReadSideEffectInstruction() {
-    getOpcode() instanceof Opcode::BufferReadSideEffect
-  }
+  BufferReadSideEffectInstruction() { getOpcode() instanceof Opcode::BufferReadSideEffect }
 
-  Instruction getArgumentInstruction() {
-    result = getAnOperand().(AddressOperand).getDef()
-  }
+  Instruction getArgumentInstruction() { result = getAnOperand().(AddressOperand).getDef() }
 }
 
 /**
  * An instruction representing a side effect of a function call.
  */
 class WriteSideEffectInstruction extends SideEffectInstruction {
-  WriteSideEffectInstruction() {
-    getOpcode() instanceof WriteSideEffectOpcode
-  }
+  WriteSideEffectInstruction() { getOpcode() instanceof WriteSideEffectOpcode }
 
-  Instruction getArgumentInstruction() {
-    result = getAnOperand().(AddressOperand).getDef()
-  }
+  Instruction getArgumentInstruction() { result = getAnOperand().(AddressOperand).getDef() }
 }
 
 /**
@@ -1245,9 +1240,7 @@ class IndirectMayWriteSideEffectInstruction extends WriteSideEffectInstruction {
  * Unlike `BufferWriteSideEffectInstruction`, the buffer might not be completely overwritten.
  */
 class BufferMayWriteSideEffectInstruction extends WriteSideEffectInstruction {
-  BufferMayWriteSideEffectInstruction() {
-    getOpcode() instanceof Opcode::BufferMayWriteSideEffect
-  }
+  BufferMayWriteSideEffectInstruction() { getOpcode() instanceof Opcode::BufferMayWriteSideEffect }
 
   final override MemoryAccessKind getResultMemoryAccess() {
     result instanceof BufferMayMemoryAccess

--- a/cpp/ql/src/semmle/code/cpp/ir/implementation/raw/Instruction.qll
+++ b/cpp/ql/src/semmle/code/cpp/ir/implementation/raw/Instruction.qll
@@ -648,7 +648,6 @@ class IndexedInstruction extends Instruction {
   int index;
 
   IndexedInstruction() { index = Construction::getInstructionIndex(this) }
-  
 
   final override string getImmediateString() { result = index.toString() }
 

--- a/cpp/ql/src/semmle/code/cpp/ir/implementation/raw/Operand.qll
+++ b/cpp/ql/src/semmle/code/cpp/ir/implementation/raw/Operand.qll
@@ -255,6 +255,16 @@ class AddressOperand extends RegisterOperand {
 }
 
 /**
+ * The buffer size operand of an instruction that represents a read or write of
+ * a buffer.
+ */
+class BufferSizeOperand extends RegisterOperand {
+  override BufferSizeOperandTag tag;
+
+  override string toString() { result = "BufferSize" }
+}
+
+/**
  * The source value operand of an instruction that loads a value from memory (e.g. `Load`,
  * `ReturnValue`, `ThrowValue`).
  */

--- a/cpp/ql/src/semmle/code/cpp/ir/implementation/raw/Operand.qll
+++ b/cpp/ql/src/semmle/code/cpp/ir/implementation/raw/Operand.qll
@@ -390,10 +390,10 @@ class SideEffectOperand extends TypedOperand {
     useInstr instanceof BufferReadSideEffectInstruction and
     result instanceof BufferMemoryAccess
     or
-    useInstr instanceof IndirectWriteSideEffectInstruction and
+    useInstr instanceof IndirectMustWriteSideEffectInstruction and
     result instanceof IndirectMemoryAccess
     or
-    useInstr instanceof BufferWriteSideEffectInstruction and
+    useInstr instanceof BufferMustWriteSideEffectInstruction and
     result instanceof BufferMemoryAccess
     or
     useInstr instanceof IndirectMayWriteSideEffectInstruction and

--- a/cpp/ql/src/semmle/code/cpp/ir/implementation/raw/internal/IRConstruction.qll
+++ b/cpp/ql/src/semmle/code/cpp/ir/implementation/raw/internal/IRConstruction.qll
@@ -260,6 +260,14 @@ private module Cached {
   }
 
   cached
+  int getInstructionIndex(Instruction instruction) {
+    exists(TranslatedElement element, InstructionTag tag |
+      instructionOrigin(instruction, element, tag) and
+      result = element.getInstructionIndex(tag)
+    )
+  }
+
+  cached
   StringLiteral getInstructionStringLiteral(Instruction instruction) {
     result = getInstructionTranslatedElement(instruction)
           .getInstructionStringLiteral(getInstructionTag(instruction))

--- a/cpp/ql/src/semmle/code/cpp/ir/implementation/raw/internal/TranslatedCall.qll
+++ b/cpp/ql/src/semmle/code/cpp/ir/implementation/raw/internal/TranslatedCall.qll
@@ -449,12 +449,7 @@ class TranslatedSideEffect extends TranslatedElement, TTranslatedArgumentSideEff
     or
     tag instanceof OnlyInstructionTag and
     operandTag instanceof SideEffectOperandTag and
-    not call.getTarget().(SideEffectFunction).hasSpecificWriteSideEffect(index, _, true) and
-    result = getEnclosingFunction().getUnmodeledDefinitionInstruction()
-    or
-    tag instanceof OnlyInstructionTag and
-    operandTag instanceof SideEffectOperandTag and
-    call.getTarget().(SideEffectFunction).hasSpecificReadSideEffect(index, _) and
+    not isWrite() and
     result = getEnclosingFunction().getUnmodeledDefinitionInstruction()
     or
     tag instanceof OnlyInstructionTag and

--- a/cpp/ql/src/semmle/code/cpp/ir/implementation/raw/internal/TranslatedCall.qll
+++ b/cpp/ql/src/semmle/code/cpp/ir/implementation/raw/internal/TranslatedCall.qll
@@ -460,8 +460,8 @@ class TranslatedSideEffect extends TranslatedElement, TTranslatedArgumentSideEff
     tag instanceof OnlyInstructionTag and
     operandTag instanceof BufferSizeOperandTag and
     result = getTranslatedExpr(call
-            .getArgument(call.getTarget().(SideEffectFunction).getParameterSizeIndex(index)).getFullyConverted())
-          .getResult()
+            .getArgument(call.getTarget().(SideEffectFunction).getParameterSizeIndex(index))
+            .getFullyConverted()).getResult()
   }
 
   override Type getInstructionOperandType(InstructionTag tag, TypedOperandTag operandTag) {

--- a/cpp/ql/src/semmle/code/cpp/ir/implementation/raw/internal/TranslatedCall.qll
+++ b/cpp/ql/src/semmle/code/cpp/ir/implementation/raw/internal/TranslatedCall.qll
@@ -94,10 +94,6 @@ abstract class TranslatedCall extends TranslatedExpr {
         then result = getSideEffects().getFirstInstruction()
         else result = getParent().getChildSuccessor(this)
       )
-      or
-      hasSideEffect() and
-      tag = CallSideEffectTag() and
-      result = getParent().getChildSuccessor(this)
     )
   }
 

--- a/cpp/ql/src/semmle/code/cpp/ir/implementation/raw/internal/TranslatedCall.qll
+++ b/cpp/ql/src/semmle/code/cpp/ir/implementation/raw/internal/TranslatedCall.qll
@@ -5,6 +5,7 @@ private import semmle.code.cpp.models.interfaces.SideEffect
 private import InstructionTag
 private import TranslatedElement
 private import TranslatedExpr
+private import TranslatedFunction
 
 /**
  * The IR translation of a call to a function. The call may be from an actual
@@ -22,6 +23,8 @@ abstract class TranslatedCall extends TranslatedExpr {
     id = -1 and result = getCallTarget()
     or
     result = getArgument(id)
+    or
+    id = getNumberOfArguments() and result = getSideEffects()
   }
 
   final override Instruction getFirstInstruction() {
@@ -66,6 +69,9 @@ abstract class TranslatedCall extends TranslatedExpr {
       then result = getArgument(argIndex + 1).getFirstInstruction()
       else result = getInstruction(CallTag())
     )
+    or
+    child = getSideEffects() and
+    result = getParent().getChildSuccessor(this)
   }
 
   override Instruction getInstructionSuccessor(InstructionTag tag, EdgeKind kind) {
@@ -75,6 +81,17 @@ abstract class TranslatedCall extends TranslatedExpr {
         tag = CallTag() and
         if hasSideEffect()
         then result = getInstruction(CallSideEffectTag())
+        else
+          if hasPreciseSideEffect()
+          then result = getSideEffects().getFirstInstruction()
+          else result = getParent().getChildSuccessor(this)
+      )
+      or
+      (
+        hasSideEffect() and
+        tag = CallSideEffectTag() and
+        if hasPreciseSideEffect()
+        then result = getSideEffects().getFirstInstruction()
         else result = getParent().getChildSuccessor(this)
       )
       or
@@ -165,6 +182,8 @@ abstract class TranslatedCall extends TranslatedExpr {
    */
   abstract TranslatedExpr getArgument(int index);
 
+  abstract int getNumberOfArguments();
+
   /**
    * If there are any arguments, gets the first instruction of the first
    * argument. Otherwise, returns the call instruction.
@@ -191,6 +210,10 @@ abstract class TranslatedCall extends TranslatedExpr {
     tag = CallSideEffectTag() and
     result = getResult()
   }
+
+  predicate hasPreciseSideEffect() { exists(getSideEffects()) }
+
+  TranslatedSideEffects getSideEffects() { result.getCall() = expr }
 }
 
 /**
@@ -245,6 +268,8 @@ abstract class TranslatedCallExpr extends TranslatedNonConstantExpr, TranslatedC
   final override TranslatedExpr getArgument(int index) {
     result = getTranslatedExpr(expr.getArgument(index).getFullyConverted())
   }
+
+  final override int getNumberOfArguments() { result = expr.getNumberOfArguments() }
 }
 
 /**
@@ -269,11 +294,11 @@ class TranslatedFunctionCall extends TranslatedCallExpr, TranslatedDirectCall {
   }
 
   override predicate hasReadSideEffect() {
-    not expr.getTarget().(SideEffectFunction).neverReadsMemory()
+    not expr.getTarget().(SideEffectFunction).hasOnlySpecificReadSideEffects()
   }
 
   override predicate hasWriteSideEffect() {
-    not expr.getTarget().(SideEffectFunction).neverWritesMemory()
+    not expr.getTarget().(SideEffectFunction).hasOnlySpecificWriteSideEffects()
   }
 }
 
@@ -294,4 +319,206 @@ class TranslatedStructorCall extends TranslatedFunctionCall {
   }
 
   override predicate hasQualifier() { any() }
+}
+
+class TranslatedSideEffects extends TranslatedElement, TTranslatedSideEffects {
+  Call expr;
+
+  TranslatedSideEffects() { this = TTranslatedSideEffects(expr) }
+
+  override string toString() { result = "(side effects  for " + expr.toString() + ")" }
+
+  override Locatable getAST() { result = expr }
+
+  Call getCall() { result = expr }
+
+  override TranslatedElement getChild(int i) {
+    result = rank[i + 1](TranslatedSideEffect tse, int isWrite, int index |
+        (
+          tse.getCall() = getCall() and
+          tse.getArgumentIndex() = index and
+          if tse.isWrite() then isWrite = 1 else isWrite = 0
+        )
+      |
+        tse order by isWrite, index
+      )
+  }
+
+  override Instruction getChildSuccessor(TranslatedElement te) {
+    exists(int i |
+      getChild(i) = te and
+      if exists(getChild(i + 1))
+      then result = getChild(i + 1).getFirstInstruction()
+      else result = getParent().getChildSuccessor(this)
+    )
+  }
+
+  override predicate hasInstruction(Opcode opcode, InstructionTag tag, Type t, boolean isGLValue) {
+    none()
+  }
+
+  override Instruction getFirstInstruction() { result = getChild(0).getFirstInstruction() }
+
+  override Instruction getInstructionSuccessor(InstructionTag tag, EdgeKind kind) { none() }
+
+  override Instruction getInstructionOperand(InstructionTag tag, OperandTag operandTag) { none() }
+
+  override Type getInstructionOperandType(InstructionTag tag, TypedOperandTag operandTag) { none() }
+
+  /**
+   * Gets the `TranslatedFunction` containing this expression.
+   */
+  final TranslatedFunction getEnclosingFunction() {
+    result = getTranslatedFunction(expr.getEnclosingFunction())
+  }
+
+  /**
+   * Gets the `Function` containing this expression.
+   */
+  override Function getFunction() { result = expr.getEnclosingFunction() }
+}
+
+class TranslatedSideEffect extends TranslatedElement, TTranslatedArgumentSideEffect {
+  Call call;
+  Expr arg;
+  int index;
+  boolean write;
+
+  TranslatedSideEffect() { this = TTranslatedArgumentSideEffect(call, arg, index, write) }
+
+  override Locatable getAST() { result = arg }
+
+  Expr getExpr() { result = arg }
+
+  Call getCall() { result = call }
+
+  int getArgumentIndex() { result = index }
+
+  predicate isWrite() { write = true }
+
+  override string toString() {
+    write = true and
+    result = "(write side effect for " + arg.toString() + ")"
+    or
+    write = false and
+    result = "(read side effect for " + arg.toString() + ")"
+  }
+
+  override TranslatedElement getChild(int n) { none() }
+
+  override Instruction getChildSuccessor(TranslatedElement child) { none() }
+
+  override Instruction getFirstInstruction() { result = getInstruction(OnlyInstructionTag()) }
+
+  override predicate hasInstruction(Opcode opcode, InstructionTag tag, Type t, boolean isGLValue) {
+    isWrite() and
+    hasSpecificWriteSideEffect(opcode) and
+    tag = OnlyInstructionTag() and
+    (
+      opcode instanceof BufferAccessOpcode and
+      t instanceof UnknownType
+      or
+      not opcode instanceof BufferAccessOpcode and
+      (
+        t = arg.getUnspecifiedType().(DerivedType).getBaseType() and
+        not t instanceof VoidType
+        or
+        arg.getUnspecifiedType().(DerivedType).getBaseType() instanceof VoidType and
+        t instanceof UnknownType
+      )
+      or
+      index = -1 and
+      not arg.getUnspecifiedType() instanceof DerivedType and
+      t = arg.getUnspecifiedType()
+    ) and
+    isGLValue = false
+    or
+    not isWrite() and
+    hasSpecificReadSideEffect(opcode) and
+    tag = OnlyInstructionTag() and
+    t instanceof VoidType and
+    isGLValue = false
+  }
+
+  override Instruction getInstructionSuccessor(InstructionTag tag, EdgeKind kind) {
+    result = getParent().getChildSuccessor(this) and
+    tag = OnlyInstructionTag() and
+    kind instanceof GotoEdge
+  }
+
+  override Instruction getInstructionOperand(InstructionTag tag, OperandTag operandTag) {
+    tag instanceof OnlyInstructionTag and
+    operandTag instanceof AddressOperandTag and
+    result = getTranslatedExpr(arg).getResult()
+    or
+    tag instanceof OnlyInstructionTag and
+    operandTag instanceof SideEffectOperandTag and
+    not call.getTarget().(SideEffectFunction).hasSpecificWriteSideEffect(index, _, true) and
+    result = getEnclosingFunction().getUnmodeledDefinitionInstruction()
+    or
+    tag instanceof OnlyInstructionTag and
+    operandTag instanceof SideEffectOperandTag and
+    call.getTarget().(SideEffectFunction).hasSpecificReadSideEffect(index, _) and
+    result = getEnclosingFunction().getUnmodeledDefinitionInstruction()
+  }
+
+  override Type getInstructionOperandType(InstructionTag tag, TypedOperandTag operandTag) {
+    tag instanceof OnlyInstructionTag and
+    result = arg.getType().getUnspecifiedType().(DerivedType).getBaseType() and
+    operandTag instanceof SideEffectOperandTag
+    or
+    tag instanceof OnlyInstructionTag and
+    result = arg.getType().getUnspecifiedType() and
+    not result instanceof DerivedType and
+    operandTag instanceof SideEffectOperandTag
+  }
+
+  predicate hasSpecificWriteSideEffect(Opcode op) {
+    exists(boolean buffer, boolean mustWrite |
+      call.getTarget().(SideEffectFunction).hasSpecificWriteSideEffect(index, buffer, mustWrite) and
+      (
+        buffer = true and mustWrite = false and op instanceof Opcode::BufferMayWriteSideEffect
+        or
+        buffer = false and mustWrite = false and op instanceof Opcode::IndirectMayWriteSideEffect
+        or
+        buffer = true and mustWrite = true and op instanceof Opcode::BufferMustWriteSideEffect
+        or
+        buffer = false and mustWrite = true and op instanceof Opcode::IndirectMustWriteSideEffect
+      )
+    )
+    or
+    not call.getTarget() instanceof SideEffectFunction and
+    getArgumentIndex() != -1 and
+    op instanceof Opcode::BufferMayWriteSideEffect
+    or
+    not call.getTarget() instanceof SideEffectFunction and
+    getArgumentIndex() = -1 and
+    op instanceof Opcode::IndirectMayWriteSideEffect
+  }
+
+  predicate hasSpecificReadSideEffect(Opcode op) {
+    exists(boolean buffer |
+      call.getTarget().(SideEffectFunction).hasSpecificReadSideEffect(index, buffer) and
+      (
+        buffer = true and op instanceof Opcode::BufferReadSideEffect
+        or
+        buffer = false and op instanceof Opcode::IndirectReadSideEffect
+      )
+    )
+    or
+    not call.getTarget() instanceof SideEffectFunction and
+    op instanceof Opcode::IndirectReadSideEffect
+  }
+
+  /**
+   * Gets the `TranslatedFunction` containing this expression.
+   */
+  final TranslatedFunction getEnclosingFunction() {
+    result = getTranslatedFunction(arg.getEnclosingFunction())
+  }
+
+  /**
+   * Gets the `Function` containing this expression.
+   */
+  override Function getFunction() { result = arg.getEnclosingFunction() }
 }

--- a/cpp/ql/src/semmle/code/cpp/ir/implementation/raw/internal/TranslatedElement.qll
+++ b/cpp/ql/src/semmle/code/cpp/ir/implementation/raw/internal/TranslatedElement.qll
@@ -601,6 +601,12 @@ abstract class TranslatedElement extends TTranslatedElement {
   string getInstructionConstantValue(InstructionTag tag) { none() }
 
   /**
+   * If the instruction specified by `tag` is an `IndexedInstruction`, gets the
+   * index for that instruction.
+   */
+  int getInstructionIndex(InstructionTag tag) { none() }
+
+  /**
    * If the instruction specified by `tag` is a `PointerArithmeticInstruction`,
    * gets the size of the type pointed to by the pointer.
    */

--- a/cpp/ql/src/semmle/code/cpp/ir/implementation/raw/internal/TranslatedExpr.qll
+++ b/cpp/ql/src/semmle/code/cpp/ir/implementation/raw/internal/TranslatedExpr.qll
@@ -1642,6 +1642,10 @@ class TranslatedAllocatorCall extends TTranslatedAllocatorCall, TranslatedDirect
     any()
   }
 
+  final override int getNumberOfArguments() {
+    result = expr.getAllocatorCall().getNumberOfArguments()
+  }
+
   final override TranslatedExpr getArgument(int index) {
     // If the allocator is the default operator new(void*), there will be no
     // allocator call in the AST. Otherwise, there will be an allocator call

--- a/cpp/ql/src/semmle/code/cpp/ir/implementation/unaliased_ssa/Instruction.qll
+++ b/cpp/ql/src/semmle/code/cpp/ir/implementation/unaliased_ssa/Instruction.qll
@@ -644,6 +644,17 @@ class ConstantValueInstruction extends Instruction {
   final string getValue() { result = value }
 }
 
+class IndexedInstruction extends Instruction {
+  int index;
+
+  IndexedInstruction() { index = Construction::getInstructionIndex(this) }
+  
+
+  final override string getImmediateString() { result = index.toString() }
+
+  final int getIndex() { result = index }
+}
+
 class EnterFunctionInstruction extends Instruction {
   EnterFunctionInstruction() { getOpcode() instanceof Opcode::EnterFunction }
 }

--- a/cpp/ql/src/semmle/code/cpp/ir/implementation/unaliased_ssa/Instruction.qll
+++ b/cpp/ql/src/semmle/code/cpp/ir/implementation/unaliased_ssa/Instruction.qll
@@ -48,8 +48,8 @@ module InstructionSanity {
         or
         (
           opcode instanceof ReadSideEffectOpcode or
-          opcode instanceof MayWriteSideEffectOpcode or
-          opcode instanceof Opcode::InlineAsm
+          opcode instanceof Opcode::InlineAsm or
+          opcode instanceof Opcode::CallSideEffect
         ) and
         tag instanceof SideEffectOperandTag
       )

--- a/cpp/ql/src/semmle/code/cpp/ir/implementation/unaliased_ssa/Instruction.qll
+++ b/cpp/ql/src/semmle/code/cpp/ir/implementation/unaliased_ssa/Instruction.qll
@@ -30,7 +30,7 @@ module InstructionSanity {
         or
         opcode instanceof MemoryAccessOpcode and tag instanceof AddressOperandTag
         or
-        opcode instanceof BufferAccessOpcode and tag instanceof BufferSizeOperand
+        opcode instanceof SizedBufferAccessOpcode and tag instanceof BufferSizeOperandTag
         or
         opcode instanceof OpcodeWithCondition and tag instanceof ConditionOperandTag
         or
@@ -1176,7 +1176,7 @@ class CallReadSideEffectInstruction extends SideEffectInstruction {
 class IndirectReadSideEffectInstruction extends SideEffectInstruction {
   IndirectReadSideEffectInstruction() { getOpcode() instanceof Opcode::IndirectReadSideEffect }
 
-  Instruction getArgumentInstruction() { result = getAnOperand().(AddressOperand).getDef() }
+  Instruction getArgumentDef() { result = getAnOperand().(AddressOperand).getDef() }
 }
 
 /**
@@ -1185,7 +1185,20 @@ class IndirectReadSideEffectInstruction extends SideEffectInstruction {
 class BufferReadSideEffectInstruction extends SideEffectInstruction {
   BufferReadSideEffectInstruction() { getOpcode() instanceof Opcode::BufferReadSideEffect }
 
-  Instruction getArgumentInstruction() { result = getAnOperand().(AddressOperand).getDef() }
+  Instruction getArgumentDef() { result = getAnOperand().(AddressOperand).getDef() }
+}
+
+/**
+ * An instruction representing the read of an indirect buffer parameter within a function call.
+ */
+class SizedBufferReadSideEffectInstruction extends SideEffectInstruction {
+  SizedBufferReadSideEffectInstruction() {
+    getOpcode() instanceof Opcode::SizedBufferReadSideEffect
+  }
+
+  Instruction getArgumentDef() { result = getAnOperand().(AddressOperand).getDef() }
+
+  Instruction getSizeDef() { result = getAnOperand().(BufferSizeOperand).getDef() }
 }
 
 /**
@@ -1194,7 +1207,7 @@ class BufferReadSideEffectInstruction extends SideEffectInstruction {
 class WriteSideEffectInstruction extends SideEffectInstruction {
   WriteSideEffectInstruction() { getOpcode() instanceof WriteSideEffectOpcode }
 
-  Instruction getArgumentInstruction() { result = getAnOperand().(AddressOperand).getDef() }
+  Instruction getArgumentDef() { result = getAnOperand().(AddressOperand).getDef() }
 }
 
 /**
@@ -1218,6 +1231,20 @@ class BufferMustWriteSideEffectInstruction extends WriteSideEffectInstruction {
   }
 
   final override MemoryAccessKind getResultMemoryAccess() { result instanceof BufferMemoryAccess }
+}
+
+/**
+ * An instruction representing the write of an indirect buffer parameter within a function call. The
+ * entire buffer is overwritten.
+ */
+class SizedBufferMustWriteSideEffectInstruction extends WriteSideEffectInstruction {
+  SizedBufferMustWriteSideEffectInstruction() {
+    getOpcode() instanceof Opcode::SizedBufferMustWriteSideEffect
+  }
+
+  final override MemoryAccessKind getResultMemoryAccess() { result instanceof BufferMemoryAccess }
+
+  Instruction getSizeDef() { result = getAnOperand().(BufferSizeOperand).getDef() }
 }
 
 /**
@@ -1245,6 +1272,22 @@ class BufferMayWriteSideEffectInstruction extends WriteSideEffectInstruction {
   final override MemoryAccessKind getResultMemoryAccess() {
     result instanceof BufferMayMemoryAccess
   }
+}
+
+/**
+ * An instruction representing the write of an indirect buffer parameter within a function call.
+ * Unlike `BufferWriteSideEffectInstruction`, the buffer might not be completely overwritten.
+ */
+class SizedBufferMayWriteSideEffectInstruction extends WriteSideEffectInstruction {
+  SizedBufferMayWriteSideEffectInstruction() {
+    getOpcode() instanceof Opcode::SizedBufferMayWriteSideEffect
+  }
+
+  final override MemoryAccessKind getResultMemoryAccess() {
+    result instanceof BufferMayMemoryAccess
+  }
+
+  Instruction getSizeDef() { result = getAnOperand().(BufferSizeOperand).getDef() }
 }
 
 /**

--- a/cpp/ql/src/semmle/code/cpp/ir/implementation/unaliased_ssa/Instruction.qll
+++ b/cpp/ql/src/semmle/code/cpp/ir/implementation/unaliased_ssa/Instruction.qll
@@ -20,23 +20,32 @@ module InstructionSanity {
     exists(Opcode opcode |
       opcode = instr.getOpcode() and
       (
-        opcode instanceof UnaryOpcode and tag instanceof UnaryOperandTag or
+        opcode instanceof UnaryOpcode and tag instanceof UnaryOperandTag
+        or
+        opcode instanceof BinaryOpcode and
         (
-          opcode instanceof BinaryOpcode and
-          (
-            tag instanceof LeftOperandTag or
-            tag instanceof RightOperandTag
-          )
-        ) or
-        opcode instanceof MemoryAccessOpcode and tag instanceof AddressOperandTag or
-        opcode instanceof OpcodeWithCondition and tag instanceof ConditionOperandTag or
-        opcode instanceof OpcodeWithLoad and tag instanceof LoadOperandTag or
-        opcode instanceof Opcode::Store and tag instanceof StoreValueOperandTag or
-        opcode instanceof Opcode::UnmodeledUse and tag instanceof UnmodeledUseOperandTag or
-        opcode instanceof Opcode::Call and tag instanceof CallTargetOperandTag or
-        opcode instanceof Opcode::Chi and tag instanceof ChiTotalOperandTag or
-        opcode instanceof Opcode::Chi and tag instanceof ChiPartialOperandTag or
-
+          tag instanceof LeftOperandTag or
+          tag instanceof RightOperandTag
+        )
+        or
+        opcode instanceof MemoryAccessOpcode and tag instanceof AddressOperandTag
+        or
+        opcode instanceof BufferAccessOpcode and tag instanceof BufferSizeOperand
+        or
+        opcode instanceof OpcodeWithCondition and tag instanceof ConditionOperandTag
+        or
+        opcode instanceof OpcodeWithLoad and tag instanceof LoadOperandTag
+        or
+        opcode instanceof Opcode::Store and tag instanceof StoreValueOperandTag
+        or
+        opcode instanceof Opcode::UnmodeledUse and tag instanceof UnmodeledUseOperandTag
+        or
+        opcode instanceof Opcode::Call and tag instanceof CallTargetOperandTag
+        or
+        opcode instanceof Opcode::Chi and tag instanceof ChiTotalOperandTag
+        or
+        opcode instanceof Opcode::Chi and tag instanceof ChiPartialOperandTag
+        or
         (
           opcode instanceof ReadSideEffectOpcode or
           opcode instanceof MayWriteSideEffectOpcode or
@@ -600,9 +609,7 @@ class VariableInstruction extends Instruction {
 
   VariableInstruction() { var = Construction::getInstructionVariable(this) }
 
-  override string getImmediateString() {
-    result = var.toString()
-  }
+  override string getImmediateString() { result = var.toString() }
 
   final IRVariable getVariable() { result = var }
 }
@@ -648,9 +655,9 @@ class VariableAddressInstruction extends VariableInstruction {
 class InitializeParameterInstruction extends VariableInstruction {
   InitializeParameterInstruction() { getOpcode() instanceof Opcode::InitializeParameter }
 
-  override final MemoryAccessKind getResultMemoryAccess() {
-    result instanceof IndirectMemoryAccess
-  }
+  final Language::Parameter getParameter() { result = var.(IRUserVariable).getVariable() }
+
+  final override MemoryAccessKind getResultMemoryAccess() { result instanceof IndirectMemoryAccess }
 }
 
 /**
@@ -1167,39 +1174,27 @@ class CallReadSideEffectInstruction extends SideEffectInstruction {
  * An instruction representing the read of an indirect parameter within a function call.
  */
 class IndirectReadSideEffectInstruction extends SideEffectInstruction {
-  IndirectReadSideEffectInstruction() {
-    getOpcode() instanceof Opcode::IndirectReadSideEffect
-  }
+  IndirectReadSideEffectInstruction() { getOpcode() instanceof Opcode::IndirectReadSideEffect }
 
-  Instruction getArgumentInstruction() {
-    result = getAnOperand().(AddressOperand).getDef()
-  }
+  Instruction getArgumentInstruction() { result = getAnOperand().(AddressOperand).getDef() }
 }
 
 /**
  * An instruction representing the read of an indirect buffer parameter within a function call.
  */
 class BufferReadSideEffectInstruction extends SideEffectInstruction {
-  BufferReadSideEffectInstruction() {
-    getOpcode() instanceof Opcode::BufferReadSideEffect
-  }
+  BufferReadSideEffectInstruction() { getOpcode() instanceof Opcode::BufferReadSideEffect }
 
-  Instruction getArgumentInstruction() {
-    result = getAnOperand().(AddressOperand).getDef()
-  }
+  Instruction getArgumentInstruction() { result = getAnOperand().(AddressOperand).getDef() }
 }
 
 /**
  * An instruction representing a side effect of a function call.
  */
 class WriteSideEffectInstruction extends SideEffectInstruction {
-  WriteSideEffectInstruction() {
-    getOpcode() instanceof WriteSideEffectOpcode
-  }
+  WriteSideEffectInstruction() { getOpcode() instanceof WriteSideEffectOpcode }
 
-  Instruction getArgumentInstruction() {
-    result = getAnOperand().(AddressOperand).getDef()
-  }
+  Instruction getArgumentInstruction() { result = getAnOperand().(AddressOperand).getDef() }
 }
 
 /**
@@ -1245,9 +1240,7 @@ class IndirectMayWriteSideEffectInstruction extends WriteSideEffectInstruction {
  * Unlike `BufferWriteSideEffectInstruction`, the buffer might not be completely overwritten.
  */
 class BufferMayWriteSideEffectInstruction extends WriteSideEffectInstruction {
-  BufferMayWriteSideEffectInstruction() {
-    getOpcode() instanceof Opcode::BufferMayWriteSideEffect
-  }
+  BufferMayWriteSideEffectInstruction() { getOpcode() instanceof Opcode::BufferMayWriteSideEffect }
 
   final override MemoryAccessKind getResultMemoryAccess() {
     result instanceof BufferMayMemoryAccess

--- a/cpp/ql/src/semmle/code/cpp/ir/implementation/unaliased_ssa/Instruction.qll
+++ b/cpp/ql/src/semmle/code/cpp/ir/implementation/unaliased_ssa/Instruction.qll
@@ -648,7 +648,6 @@ class IndexedInstruction extends Instruction {
   int index;
 
   IndexedInstruction() { index = Construction::getInstructionIndex(this) }
-  
 
   final override string getImmediateString() { result = index.toString() }
 

--- a/cpp/ql/src/semmle/code/cpp/ir/implementation/unaliased_ssa/Operand.qll
+++ b/cpp/ql/src/semmle/code/cpp/ir/implementation/unaliased_ssa/Operand.qll
@@ -255,6 +255,16 @@ class AddressOperand extends RegisterOperand {
 }
 
 /**
+ * The buffer size operand of an instruction that represents a read or write of
+ * a buffer.
+ */
+class BufferSizeOperand extends RegisterOperand {
+  override BufferSizeOperandTag tag;
+
+  override string toString() { result = "BufferSize" }
+}
+
+/**
  * The source value operand of an instruction that loads a value from memory (e.g. `Load`,
  * `ReturnValue`, `ThrowValue`).
  */

--- a/cpp/ql/src/semmle/code/cpp/ir/implementation/unaliased_ssa/Operand.qll
+++ b/cpp/ql/src/semmle/code/cpp/ir/implementation/unaliased_ssa/Operand.qll
@@ -390,10 +390,10 @@ class SideEffectOperand extends TypedOperand {
     useInstr instanceof BufferReadSideEffectInstruction and
     result instanceof BufferMemoryAccess
     or
-    useInstr instanceof IndirectWriteSideEffectInstruction and
+    useInstr instanceof IndirectMustWriteSideEffectInstruction and
     result instanceof IndirectMemoryAccess
     or
-    useInstr instanceof BufferWriteSideEffectInstruction and
+    useInstr instanceof BufferMustWriteSideEffectInstruction and
     result instanceof BufferMemoryAccess
     or
     useInstr instanceof IndirectMayWriteSideEffectInstruction and

--- a/cpp/ql/src/semmle/code/cpp/ir/implementation/unaliased_ssa/internal/AliasAnalysis.qll
+++ b/cpp/ql/src/semmle/code/cpp/ir/implementation/unaliased_ssa/internal/AliasAnalysis.qll
@@ -226,7 +226,7 @@ private predicate isArgumentForParameter(CallInstruction ci, Operand operand, In
     ci = operand.getUse() and
     f = ci.getStaticCallTarget() and
     (
-      init.(InitializeParameterInstruction).getVariable().getAST() = f
+      init.(InitializeParameterInstruction).getParameter() = f
             .getParameter(operand.(PositionalArgumentOperand).getIndex())
       or
       init instanceof InitializeThisInstruction and

--- a/cpp/ql/src/semmle/code/cpp/ir/implementation/unaliased_ssa/internal/AliasAnalysis.qll
+++ b/cpp/ql/src/semmle/code/cpp/ir/implementation/unaliased_ssa/internal/AliasAnalysis.qll
@@ -226,7 +226,7 @@ private predicate isArgumentForParameter(CallInstruction ci, Operand operand, In
     ci = operand.getUse() and
     f = ci.getStaticCallTarget() and
     (
-      init.(InitializeParameterInstruction).getParameter() = f
+      init.(InitializeParameterInstruction).getVariable().getAST() = f
             .getParameter(operand.(PositionalArgumentOperand).getIndex())
       or
       init instanceof InitializeThisInstruction and

--- a/cpp/ql/src/semmle/code/cpp/ir/implementation/unaliased_ssa/internal/SSAConstruction.qll
+++ b/cpp/ql/src/semmle/code/cpp/ir/implementation/unaliased_ssa/internal/SSAConstruction.qll
@@ -343,6 +343,11 @@ private module Cached {
   }
 
   cached
+  int getInstructionIndex(Instruction instruction) {
+    result = getOldInstruction(instruction).(OldIR::IndexedInstruction).getIndex()
+  }
+
+  cached
   Function getInstructionFunction(Instruction instruction) {
     result = getOldInstruction(instruction).(OldIR::FunctionInstruction).getFunctionSymbol()
   }

--- a/cpp/ql/src/semmle/code/cpp/models/implementations/IdentityFunction.qll
+++ b/cpp/ql/src/semmle/code/cpp/models/implementations/IdentityFunction.qll
@@ -16,9 +16,9 @@ class IdentityFunction extends DataFlowFunction, SideEffectFunction, AliasFuncti
     )
   }
 
-  override predicate neverReadsMemory() { any() }
+  override predicate hasOnlySpecificReadSideEffects() { any() }
 
-  override predicate neverWritesMemory() { any() }
+  override predicate hasOnlySpecificWriteSideEffects() { any() }
 
   override predicate parameterNeverEscapes(int index) { none() }
 
@@ -37,3 +37,4 @@ class IdentityFunction extends DataFlowFunction, SideEffectFunction, AliasFuncti
     input.isParameter(0) and output.isReturnValue()
   }
 }
+

--- a/cpp/ql/src/semmle/code/cpp/models/implementations/IdentityFunction.qll
+++ b/cpp/ql/src/semmle/code/cpp/models/implementations/IdentityFunction.qll
@@ -37,4 +37,3 @@ class IdentityFunction extends DataFlowFunction, SideEffectFunction, AliasFuncti
     input.isParameter(0) and output.isReturnValue()
   }
 }
-

--- a/cpp/ql/src/semmle/code/cpp/models/implementations/Memcpy.qll
+++ b/cpp/ql/src/semmle/code/cpp/models/implementations/Memcpy.qll
@@ -57,5 +57,12 @@ class MemcpyFunction extends ArrayFunction, DataFlowFunction, SideEffectFunction
   override predicate hasSpecificReadSideEffect(ParameterIndex i, boolean buffer) {
     i = 1 and buffer = true
   }
-}
 
+  override ParameterIndex getParameterSizeIndex(ParameterIndex i) {
+    result = 2 and
+    (
+      i = 0 or
+      i = 1
+    )
+  }
+}

--- a/cpp/ql/src/semmle/code/cpp/models/implementations/Memcpy.qll
+++ b/cpp/ql/src/semmle/code/cpp/models/implementations/Memcpy.qll
@@ -1,13 +1,14 @@
 import semmle.code.cpp.Function
 import semmle.code.cpp.models.interfaces.ArrayFunction
 import semmle.code.cpp.models.interfaces.DataFlow
+import semmle.code.cpp.models.interfaces.SideEffect
 import semmle.code.cpp.models.interfaces.Taint
 
 /**
  * The standard functions `memcpy` and `memmove`, and the gcc variant
  * `__builtin___memcpy_chk`
  */
-class MemcpyFunction extends ArrayFunction, DataFlowFunction, TaintFunction {
+class MemcpyFunction extends ArrayFunction, DataFlowFunction, SideEffectFunction, TaintFunction {
   MemcpyFunction() {
     this.hasName("memcpy") or
     this.hasName("memmove") or
@@ -44,4 +45,17 @@ class MemcpyFunction extends ArrayFunction, DataFlowFunction, TaintFunction {
     ) and
     countParam = 2
   }
+
+  override predicate hasOnlySpecificReadSideEffects() { any() }
+
+  override predicate hasOnlySpecificWriteSideEffects() { any() }
+
+  override predicate hasSpecificWriteSideEffect(ParameterIndex i, boolean buffer, boolean mustWrite) {
+    i = 0 and buffer = true and mustWrite = true
+  }
+
+  override predicate hasSpecificReadSideEffect(ParameterIndex i, boolean buffer) {
+    i = 1 and buffer = true
+  }
 }
+

--- a/cpp/ql/src/semmle/code/cpp/models/implementations/Pure.qll
+++ b/cpp/ql/src/semmle/code/cpp/models/implementations/Pure.qll
@@ -95,4 +95,3 @@ class PureFunction extends TaintFunction, SideEffectFunction {
 
   override predicate hasOnlySpecificWriteSideEffects() { any() }
 }
-

--- a/cpp/ql/src/semmle/code/cpp/models/implementations/Pure.qll
+++ b/cpp/ql/src/semmle/code/cpp/models/implementations/Pure.qll
@@ -67,9 +67,9 @@ class PureStrFunction extends AliasFunction, ArrayFunction, TaintFunction, SideE
 
   override predicate parameterIsAlwaysReturned(int i) { none() }
 
-  override predicate neverReadsMemory() { none() }
+  override predicate hasOnlySpecificReadSideEffects() { none() }
 
-  override predicate neverWritesMemory() { any() }
+  override predicate hasOnlySpecificWriteSideEffects() { any() }
 }
 
 class PureFunction extends TaintFunction, SideEffectFunction {
@@ -91,7 +91,8 @@ class PureFunction extends TaintFunction, SideEffectFunction {
     output.isReturnValue()
   }
 
-  override predicate neverReadsMemory() { any() }
+  override predicate hasOnlySpecificReadSideEffects() { any() }
 
-  override predicate neverWritesMemory() { any() }
+  override predicate hasOnlySpecificWriteSideEffects() { any() }
 }
+

--- a/cpp/ql/src/semmle/code/cpp/models/interfaces/FunctionInputsAndOutputs.qll
+++ b/cpp/ql/src/semmle/code/cpp/models/interfaces/FunctionInputsAndOutputs.qll
@@ -6,13 +6,6 @@
 
 import semmle.code.cpp.Parameter
 
-/**
- * An `int` that is a parameter index for some function.  This is needed for binding in certain cases.
- */
-class ParameterIndex extends int {
-  ParameterIndex() { exists(Parameter p | this = p.getIndex()) }
-}
-
 private newtype TFunctionInput =
   TInParameter(ParameterIndex i) or
   TInParameterDeref(ParameterIndex i) or

--- a/cpp/ql/src/semmle/code/cpp/models/interfaces/SideEffect.qll
+++ b/cpp/ql/src/semmle/code/cpp/models/interfaces/SideEffect.qll
@@ -29,12 +29,24 @@ abstract class SideEffectFunction extends Function {
    */
   abstract predicate hasOnlySpecificWriteSideEffects();
 
+  /**
+   * Holds if the value pointed to by the parameter at index `i` is written to. `buffer` is true
+   * if the write may be at an offset. `mustWrite` is true if the write is unconditional. 
+   */
   predicate hasSpecificWriteSideEffect(ParameterIndex i, boolean buffer, boolean mustWrite) {
     none()
   }
 
+  /**
+   * Holds if the value pointed to by the parameter at index `i` is read from. `buffer` is true
+   * if the read may be at an offset. 
+   */
   predicate hasSpecificReadSideEffect(ParameterIndex i, boolean buffer) { none() }
 
   // TODO: name?
+  /**
+   * Gets the index of the parameter that indicates the size of the buffer pointed to by the
+   * parameter at index `i`.
+   */
   ParameterIndex getParameterSizeIndex(ParameterIndex i) { none() }
 }

--- a/cpp/ql/src/semmle/code/cpp/models/interfaces/SideEffect.qll
+++ b/cpp/ql/src/semmle/code/cpp/models/interfaces/SideEffect.qll
@@ -9,6 +9,7 @@
 
 import semmle.code.cpp.Function
 import semmle.code.cpp.models.Models
+import semmle.code.cpp.models.interfaces.FunctionInputsAndOutputs
 
 /**
  * Models the side effects of a library function.
@@ -19,12 +20,19 @@ abstract class SideEffectFunction extends Function {
    * This memory could be from global variables, or from other memory that was reachable from a
    * pointer that was passed into the function.
    */
-  abstract predicate neverReadsMemory();
+  abstract predicate hasOnlySpecificReadSideEffects();
 
   /**
    * Holds if the function never writes to memory that remains allocated after the function
    * returns. This memory could be from global variables, or from other memory that was reachable
    * from a pointer that was passed into the function.
    */
-  abstract predicate neverWritesMemory();
+  abstract predicate hasOnlySpecificWriteSideEffects();
+
+  predicate hasSpecificWriteSideEffect(ParameterIndex i, boolean buffer, boolean mustWrite) {
+    none()
+  }
+
+  predicate hasSpecificReadSideEffect(ParameterIndex i, boolean buffer) { none() }
 }
+

--- a/cpp/ql/src/semmle/code/cpp/models/interfaces/SideEffect.qll
+++ b/cpp/ql/src/semmle/code/cpp/models/interfaces/SideEffect.qll
@@ -34,5 +34,7 @@ abstract class SideEffectFunction extends Function {
   }
 
   predicate hasSpecificReadSideEffect(ParameterIndex i, boolean buffer) { none() }
-}
 
+  // TODO: name?
+  ParameterIndex getParameterSizeIndex(ParameterIndex i) { none() }
+}

--- a/cpp/ql/src/semmle/code/cpp/models/interfaces/SideEffect.qll
+++ b/cpp/ql/src/semmle/code/cpp/models/interfaces/SideEffect.qll
@@ -31,7 +31,7 @@ abstract class SideEffectFunction extends Function {
 
   /**
    * Holds if the value pointed to by the parameter at index `i` is written to. `buffer` is true
-   * if the write may be at an offset. `mustWrite` is true if the write is unconditional. 
+   * if the write may be at an offset. `mustWrite` is true if the write is unconditional.
    */
   predicate hasSpecificWriteSideEffect(ParameterIndex i, boolean buffer, boolean mustWrite) {
     none()
@@ -39,7 +39,7 @@ abstract class SideEffectFunction extends Function {
 
   /**
    * Holds if the value pointed to by the parameter at index `i` is read from. `buffer` is true
-   * if the read may be at an offset. 
+   * if the read may be at an offset.
    */
   predicate hasSpecificReadSideEffect(ParameterIndex i, boolean buffer) { none() }
 

--- a/cpp/ql/test/library-tests/ir/ir/PrintAST.expected
+++ b/cpp/ql/test/library-tests/ir/ir/PrintAST.expected
@@ -8116,6 +8116,59 @@ ir.cpp:
 # 1158|               Type = [SpecifiedType] __attribute((vector_size(16UL))) int
 # 1158|               ValueCategory = prvalue(load)
 # 1159|     5: [ReturnStmt] return ...
+# 1161| [TopLevelFunction] void* memcpy(void*, void*, int)
+# 1161|   params: 
+# 1161|     0: [Parameter] dst
+# 1161|         Type = [VoidPointerType] void *
+# 1161|     1: [Parameter] src
+# 1161|         Type = [VoidPointerType] void *
+# 1161|     2: [Parameter] size
+# 1161|         Type = [IntType] int
+# 1163| [TopLevelFunction] int ModeledCallTarget(int)
+# 1163|   params: 
+# 1163|     0: [Parameter] x
+# 1163|         Type = [IntType] int
+# 1163|   body: [Block] { ... }
+# 1164|     0: [DeclStmt] declaration
+# 1164|       0: [VariableDeclarationEntry] definition of y
+# 1164|           Type = [IntType] int
+# 1165|     1: [ExprStmt] ExprStmt
+# 1165|       0: [FunctionCall] call to memcpy
+# 1165|           Type = [VoidPointerType] void *
+# 1165|           ValueCategory = prvalue
+# 1165|         0: [CStyleCast] (void *)...
+# 1165|             Conversion = [PointerConversion] pointer conversion
+# 1165|             Type = [VoidPointerType] void *
+# 1165|             ValueCategory = prvalue
+# 1165|           expr: [AddressOfExpr] & ...
+# 1165|               Type = [IntPointerType] int *
+# 1165|               ValueCategory = prvalue
+# 1165|             0: [VariableAccess] y
+# 1165|                 Type = [IntType] int
+# 1165|                 ValueCategory = lvalue
+# 1165|         1: [CStyleCast] (void *)...
+# 1165|             Conversion = [PointerConversion] pointer conversion
+# 1165|             Type = [VoidPointerType] void *
+# 1165|             ValueCategory = prvalue
+# 1165|           expr: [AddressOfExpr] & ...
+# 1165|               Type = [IntPointerType] int *
+# 1165|               ValueCategory = prvalue
+# 1165|             0: [VariableAccess] x
+# 1165|                 Type = [IntType] int
+# 1165|                 ValueCategory = lvalue
+# 1165|         2: [CStyleCast] (int)...
+# 1165|             Conversion = [IntegralConversion] integral conversion
+# 1165|             Type = [IntType] int
+# 1165|             Value = [CStyleCast] 4
+# 1165|             ValueCategory = prvalue
+# 1165|           expr: [SizeofTypeOperator] sizeof(int)
+# 1165|               Type = [LongType] unsigned long
+# 1165|               Value = [SizeofTypeOperator] 4
+# 1165|               ValueCategory = prvalue
+# 1166|     2: [ReturnStmt] return ...
+# 1166|       0: [VariableAccess] y
+# 1166|           Type = [IntType] int
+# 1166|           ValueCategory = prvalue(load)
 perf-regression.cpp:
 #    4| [CopyAssignmentOperator] Big& Big::operator=(Big const&)
 #    4|   params: 

--- a/cpp/ql/test/library-tests/ir/ir/ir.cpp
+++ b/cpp/ql/test/library-tests/ir/ir/ir.cpp
@@ -1158,4 +1158,12 @@ void VectorTypes(int i) {
   vi4 = vi4 + vi4_shuffle;
 }
 
+void *memcpy(void *dst, void *src, int size);
+
+int ModeledCallTarget(int x) {
+  int y;
+  memcpy(&y, &x, sizeof(int));
+  return y;
+}
+
 // semmle-extractor-options: -std=c++17 --clang

--- a/cpp/ql/test/library-tests/ir/ir/raw_ir.expected
+++ b/cpp/ql/test/library-tests/ir/ir/raw_ir.expected
@@ -15,7 +15,7 @@ bad_asts.cpp:
 #   16|     r0_11(int)           = Call                            : func:r0_9, this:r0_8, 0:r0_10
 #   16|     mu0_12(unknown)      = ^CallSideEffect                 : ~mu0_2
 #   16|     v0_13(void)          = ^IndirectReadSideEffect[-1]     : &:r0_8, ~mu0_2
-#   16|     mu0_14(S)            = ^IndirectMayWriteSideEffect[-1] : &:r0_8, ~mu0_2
+#   16|     mu0_14(S)            = ^IndirectMayWriteSideEffect[-1] : &:r0_8
 #   17|     v0_15(void)          = NoOp                            : 
 #   14|     v0_16(void)          = ReturnVoid                      : 
 #   14|     v0_17(void)          = UnmodeledUse                    : mu*
@@ -2677,8 +2677,8 @@ ir.cpp:
 #  585|     mu0_10(unknown)      = ^CallSideEffect                 : ~mu0_2
 #  585|     v0_11(void)          = ^IndirectReadSideEffect[0]      : &:r0_5, ~mu0_2
 #  585|     v0_12(void)          = ^IndirectReadSideEffect[2]      : &:r0_8, ~mu0_2
-#  585|     mu0_13(unknown)      = ^BufferMayWriteSideEffect[0]    : &:r0_5, ~mu0_2
-#  585|     mu0_14(unknown)      = ^BufferMayWriteSideEffect[2]    : &:r0_8, ~mu0_2
+#  585|     mu0_13(unknown)      = ^BufferMayWriteSideEffect[0]    : &:r0_5
+#  585|     mu0_14(unknown)      = ^BufferMayWriteSideEffect[2]    : &:r0_8
 #  586|     v0_15(void)          = NoOp                            : 
 #  584|     v0_16(void)          = ReturnVoid                      : 
 #  584|     v0_17(void)          = UnmodeledUse                    : mu*
@@ -2722,7 +2722,7 @@ ir.cpp:
 #  617|     v0_11(void)           = Call                          : func:r0_8, this:r0_7, 0:r0_10
 #  617|     mu0_12(unknown)       = ^CallSideEffect               : ~mu0_2
 #  617|     v0_13(void)           = ^IndirectReadSideEffect[0]    : &:r0_10, ~mu0_2
-#  617|     mu0_14(unknown)       = ^BufferMayWriteSideEffect[0]  : &:r0_10, ~mu0_2
+#  617|     mu0_14(unknown)       = ^BufferMayWriteSideEffect[0]  : &:r0_10
 #  618|     r0_15(glval<String>)  = VariableAddress[s3]           : 
 #  618|     r0_16(glval<unknown>) = FunctionAddress[ReturnObject] : 
 #  618|     r0_17(String)         = Call                          : func:r0_16
@@ -2735,7 +2735,7 @@ ir.cpp:
 #  619|     v0_24(void)           = Call                          : func:r0_21, this:r0_20, 0:r0_23
 #  619|     mu0_25(unknown)       = ^CallSideEffect               : ~mu0_2
 #  619|     v0_26(void)           = ^IndirectReadSideEffect[0]    : &:r0_23, ~mu0_2
-#  619|     mu0_27(unknown)       = ^BufferMayWriteSideEffect[0]  : &:r0_23, ~mu0_2
+#  619|     mu0_27(unknown)       = ^BufferMayWriteSideEffect[0]  : &:r0_23
 #  620|     v0_28(void)           = NoOp                          : 
 #  615|     v0_29(void)           = ReturnVoid                    : 
 #  615|     v0_30(void)           = UnmodeledUse                  : mu*
@@ -2759,7 +2759,7 @@ ir.cpp:
 #  623|     r0_13(char *)          = Call                            : func:r0_12, this:r0_11
 #  623|     mu0_14(unknown)        = ^CallSideEffect                 : ~mu0_2
 #  623|     v0_15(void)            = ^IndirectReadSideEffect[-1]     : &:r0_11, ~mu0_2
-#  623|     mu0_16(String)         = ^IndirectMayWriteSideEffect[-1] : &:r0_11, ~mu0_2
+#  623|     mu0_16(String)         = ^IndirectMayWriteSideEffect[-1] : &:r0_11
 #  624|     r0_17(glval<String *>) = VariableAddress[p]              : 
 #  624|     r0_18(String *)        = Load                            : &:r0_17, ~mu0_2
 #  624|     r0_19(String *)        = Convert                         : r0_18
@@ -2767,14 +2767,14 @@ ir.cpp:
 #  624|     r0_21(char *)          = Call                            : func:r0_20, this:r0_19
 #  624|     mu0_22(unknown)        = ^CallSideEffect                 : ~mu0_2
 #  624|     v0_23(void)            = ^IndirectReadSideEffect[-1]     : &:r0_19, ~mu0_2
-#  624|     mu0_24(String)         = ^IndirectMayWriteSideEffect[-1] : &:r0_19, ~mu0_2
+#  624|     mu0_24(String)         = ^IndirectMayWriteSideEffect[-1] : &:r0_19
 #  625|     r0_25(glval<String>)   = VariableAddress[s]              : 
 #  625|     r0_26(glval<String>)   = Convert                         : r0_25
 #  625|     r0_27(glval<unknown>)  = FunctionAddress[c_str]          : 
 #  625|     r0_28(char *)          = Call                            : func:r0_27, this:r0_26
 #  625|     mu0_29(unknown)        = ^CallSideEffect                 : ~mu0_2
 #  625|     v0_30(void)            = ^IndirectReadSideEffect[-1]     : &:r0_26, ~mu0_2
-#  625|     mu0_31(String)         = ^IndirectMayWriteSideEffect[-1] : &:r0_26, ~mu0_2
+#  625|     mu0_31(String)         = ^IndirectMayWriteSideEffect[-1] : &:r0_26
 #  626|     v0_32(void)            = NoOp                            : 
 #  622|     v0_33(void)            = ReturnVoid                      : 
 #  622|     v0_34(void)            = UnmodeledUse                    : mu*
@@ -2882,21 +2882,21 @@ ir.cpp:
 #  653|     r0_7(int)             = Call                                    : func:r0_5, this:r0_4, 0:r0_6
 #  653|     mu0_8(unknown)        = ^CallSideEffect                         : ~mu0_2
 #  653|     v0_9(void)            = ^IndirectReadSideEffect[-1]             : &:r0_4, ~mu0_2
-#  653|     mu0_10(C)             = ^IndirectMayWriteSideEffect[-1]         : &:r0_4, ~mu0_2
+#  653|     mu0_10(C)             = ^IndirectMayWriteSideEffect[-1]         : &:r0_4
 #  654|     r0_11(C *)            = CopyValue                               : r0_3
 #  654|     r0_12(glval<unknown>) = FunctionAddress[InstanceMemberFunction] : 
 #  654|     r0_13(int)            = Constant[1]                             : 
 #  654|     r0_14(int)            = Call                                    : func:r0_12, this:r0_11, 0:r0_13
 #  654|     mu0_15(unknown)       = ^CallSideEffect                         : ~mu0_2
 #  654|     v0_16(void)           = ^IndirectReadSideEffect[-1]             : &:r0_11, ~mu0_2
-#  654|     mu0_17(C)             = ^IndirectMayWriteSideEffect[-1]         : &:r0_11, ~mu0_2
+#  654|     mu0_17(C)             = ^IndirectMayWriteSideEffect[-1]         : &:r0_11
 #-----|     r0_18(C *)            = CopyValue                               : r0_3
 #  655|     r0_19(glval<unknown>) = FunctionAddress[InstanceMemberFunction] : 
 #  655|     r0_20(int)            = Constant[2]                             : 
 #  655|     r0_21(int)            = Call                                    : func:r0_19, this:r0_18, 0:r0_20
 #  655|     mu0_22(unknown)       = ^CallSideEffect                         : ~mu0_2
 #-----|     v0_23(void)           = ^IndirectReadSideEffect[-1]             : &:r0_18, ~mu0_2
-#-----|     mu0_24(C)             = ^IndirectMayWriteSideEffect[-1]         : &:r0_18, ~mu0_2
+#-----|     mu0_24(C)             = ^IndirectMayWriteSideEffect[-1]         : &:r0_18
 #  656|     v0_25(void)           = NoOp                                    : 
 #  652|     v0_26(void)           = ReturnVoid                              : 
 #  652|     v0_27(void)           = UnmodeledUse                            : mu*
@@ -2928,7 +2928,7 @@ ir.cpp:
 #  662|     v0_21(void)           = Call                         : func:r0_18, this:r0_17, 0:r0_20
 #  662|     mu0_22(unknown)       = ^CallSideEffect              : ~mu0_2
 #  662|     v0_23(void)           = ^IndirectReadSideEffect[0]   : &:r0_20, ~mu0_2
-#  662|     mu0_24(unknown)       = ^BufferMayWriteSideEffect[0] : &:r0_20, ~mu0_2
+#  662|     mu0_24(unknown)       = ^BufferMayWriteSideEffect[0] : &:r0_20
 #  664|     v0_25(void)           = NoOp                         : 
 #  658|     v0_26(void)           = ReturnVoid                   : 
 #  658|     v0_27(void)           = UnmodeledUse                 : mu*
@@ -3128,7 +3128,7 @@ ir.cpp:
 #  721|     r0_7(long)           = Call                         : func:r0_4, 0:r0_5, 1:r0_6
 #  721|     mu0_8(unknown)       = ^CallSideEffect              : ~mu0_2
 #  721|     v0_9(void)           = ^IndirectReadSideEffect[0]   : &:r0_5, ~mu0_2
-#  721|     mu0_10(unknown)      = ^BufferMayWriteSideEffect[0] : &:r0_5, ~mu0_2
+#  721|     mu0_10(unknown)      = ^BufferMayWriteSideEffect[0] : &:r0_5
 #  721|     r0_11(double)        = Convert                      : r0_7
 #  721|     mu0_12(double)       = Store                        : &:r0_3, r0_11
 #  720|     r0_13(glval<double>) = VariableAddress[#return]     : 
@@ -3202,7 +3202,7 @@ ir.cpp:
 #  731|     v7_4(void)            = Call                            : func:r7_1, this:r7_0, 0:r7_3
 #  731|     mu7_5(unknown)        = ^CallSideEffect                 : ~mu0_2
 #  731|     v7_6(void)            = ^IndirectReadSideEffect[0]      : &:r7_3, ~mu0_2
-#  731|     mu7_7(unknown)        = ^BufferMayWriteSideEffect[0]    : &:r7_3, ~mu0_2
+#  731|     mu7_7(unknown)        = ^BufferMayWriteSideEffect[0]    : &:r7_3
 #  731|     v7_8(void)            = ThrowValue                      : &:r7_0, ~mu0_2
 #-----|   Exception -> Block 9
 
@@ -3227,7 +3227,7 @@ ir.cpp:
 #  736|     v10_6(void)           = Call                         : func:r10_3, this:r10_2, 0:r10_5
 #  736|     mu10_7(unknown)       = ^CallSideEffect              : ~mu0_2
 #  736|     v10_8(void)           = ^IndirectReadSideEffect[0]   : &:r10_5, ~mu0_2
-#  736|     mu10_9(unknown)       = ^BufferMayWriteSideEffect[0] : &:r10_5, ~mu0_2
+#  736|     mu10_9(unknown)       = ^BufferMayWriteSideEffect[0] : &:r10_5
 #  736|     v10_10(void)          = ThrowValue                   : &:r10_2, ~mu0_2
 #-----|   Exception -> Block 2
 
@@ -3270,8 +3270,8 @@ ir.cpp:
 #  745|     mu0_13(unknown)      = ^CallSideEffect                 : ~mu0_2
 #-----|     v0_14(void)          = ^IndirectReadSideEffect[-1]     : &:r0_7, ~mu0_2
 #-----|     v0_15(void)          = ^IndirectReadSideEffect[0]      : &:r0_11, ~mu0_2
-#-----|     mu0_16(String)       = ^IndirectMayWriteSideEffect[-1] : &:r0_7, ~mu0_2
-#-----|     mu0_17(unknown)      = ^BufferMayWriteSideEffect[0]    : &:r0_11, ~mu0_2
+#-----|     mu0_16(String)       = ^IndirectMayWriteSideEffect[-1] : &:r0_7
+#-----|     mu0_17(unknown)      = ^BufferMayWriteSideEffect[0]    : &:r0_11
 #-----|     r0_18(glval<Base &>) = VariableAddress[#return]        : 
 #-----|     r0_19(Base *)        = CopyValue                       : r0_3
 #-----|     mu0_20(Base &)       = Store                           : &:r0_18, r0_19
@@ -3345,8 +3345,8 @@ ir.cpp:
 #  754|     mu0_13(unknown)        = ^CallSideEffect                 : ~mu0_2
 #-----|     v0_14(void)            = ^IndirectReadSideEffect[-1]     : &:r0_7, ~mu0_2
 #-----|     v0_15(void)            = ^IndirectReadSideEffect[0]      : &:r0_11, ~mu0_2
-#-----|     mu0_16(Base)           = ^IndirectMayWriteSideEffect[-1] : &:r0_7, ~mu0_2
-#-----|     mu0_17(unknown)        = ^BufferMayWriteSideEffect[0]    : &:r0_11, ~mu0_2
+#-----|     mu0_16(Base)           = ^IndirectMayWriteSideEffect[-1] : &:r0_7
+#-----|     mu0_17(unknown)        = ^BufferMayWriteSideEffect[0]    : &:r0_11
 #-----|     r0_18(Middle *)        = CopyValue                       : r0_3
 #-----|     r0_19(glval<String>)   = FieldAddress[middle_s]          : r0_18
 #  754|     r0_20(glval<unknown>)  = FunctionAddress[operator=]      : 
@@ -3357,8 +3357,8 @@ ir.cpp:
 #  754|     mu0_25(unknown)        = ^CallSideEffect                 : ~mu0_2
 #-----|     v0_26(void)            = ^IndirectReadSideEffect[-1]     : &:r0_19, ~mu0_2
 #-----|     v0_27(void)            = ^IndirectReadSideEffect[0]      : &:r0_23, ~mu0_2
-#-----|     mu0_28(String)         = ^IndirectMayWriteSideEffect[-1] : &:r0_19, ~mu0_2
-#-----|     mu0_29(unknown)        = ^BufferMayWriteSideEffect[0]    : &:r0_23, ~mu0_2
+#-----|     mu0_28(String)         = ^IndirectMayWriteSideEffect[-1] : &:r0_19
+#-----|     mu0_29(unknown)        = ^BufferMayWriteSideEffect[0]    : &:r0_23
 #-----|     r0_30(glval<Middle &>) = VariableAddress[#return]        : 
 #-----|     r0_31(Middle *)        = CopyValue                       : r0_3
 #-----|     mu0_32(Middle &)       = Store                           : &:r0_30, r0_31
@@ -3423,8 +3423,8 @@ ir.cpp:
 #  763|     mu0_13(unknown)         = ^CallSideEffect                 : ~mu0_2
 #-----|     v0_14(void)             = ^IndirectReadSideEffect[-1]     : &:r0_7, ~mu0_2
 #-----|     v0_15(void)             = ^IndirectReadSideEffect[0]      : &:r0_11, ~mu0_2
-#-----|     mu0_16(Middle)          = ^IndirectMayWriteSideEffect[-1] : &:r0_7, ~mu0_2
-#-----|     mu0_17(unknown)         = ^BufferMayWriteSideEffect[0]    : &:r0_11, ~mu0_2
+#-----|     mu0_16(Middle)          = ^IndirectMayWriteSideEffect[-1] : &:r0_7
+#-----|     mu0_17(unknown)         = ^BufferMayWriteSideEffect[0]    : &:r0_11
 #-----|     r0_18(Derived *)        = CopyValue                       : r0_3
 #-----|     r0_19(glval<String>)    = FieldAddress[derived_s]         : r0_18
 #  763|     r0_20(glval<unknown>)   = FunctionAddress[operator=]      : 
@@ -3435,8 +3435,8 @@ ir.cpp:
 #  763|     mu0_25(unknown)         = ^CallSideEffect                 : ~mu0_2
 #-----|     v0_26(void)             = ^IndirectReadSideEffect[-1]     : &:r0_19, ~mu0_2
 #-----|     v0_27(void)             = ^IndirectReadSideEffect[0]      : &:r0_23, ~mu0_2
-#-----|     mu0_28(String)          = ^IndirectMayWriteSideEffect[-1] : &:r0_19, ~mu0_2
-#-----|     mu0_29(unknown)         = ^BufferMayWriteSideEffect[0]    : &:r0_23, ~mu0_2
+#-----|     mu0_28(String)          = ^IndirectMayWriteSideEffect[-1] : &:r0_19
+#-----|     mu0_29(unknown)         = ^BufferMayWriteSideEffect[0]    : &:r0_23
 #-----|     r0_30(glval<Derived &>) = VariableAddress[#return]        : 
 #-----|     r0_31(Derived *)        = CopyValue                       : r0_3
 #-----|     mu0_32(Derived &)       = Store                           : &:r0_30, r0_31
@@ -3647,8 +3647,8 @@ ir.cpp:
 #  808|     mu0_29(unknown)            = ^CallSideEffect                        : ~mu0_2
 #  808|     v0_30(void)                = ^IndirectReadSideEffect[-1]            : &:r0_24, ~mu0_2
 #  808|     v0_31(void)                = ^IndirectReadSideEffect[0]             : &:r0_27, ~mu0_2
-#  808|     mu0_32(Base)               = ^IndirectMayWriteSideEffect[-1]        : &:r0_24, ~mu0_2
-#  808|     mu0_33(unknown)            = ^BufferMayWriteSideEffect[0]           : &:r0_27, ~mu0_2
+#  808|     mu0_32(Base)               = ^IndirectMayWriteSideEffect[-1]        : &:r0_24
+#  808|     mu0_33(unknown)            = ^BufferMayWriteSideEffect[0]           : &:r0_27
 #  809|     r0_34(glval<Base>)         = VariableAddress[b]                     : 
 #  809|     r0_35(glval<unknown>)      = FunctionAddress[operator=]             : 
 #  809|     r0_36(glval<unknown>)      = FunctionAddress[Base]                  : 
@@ -3657,14 +3657,14 @@ ir.cpp:
 #  809|     v0_39(void)                = Call                                   : func:r0_36, 0:r0_38
 #  809|     mu0_40(unknown)            = ^CallSideEffect                        : ~mu0_2
 #  809|     v0_41(void)                = ^IndirectReadSideEffect[0]             : &:r0_38, ~mu0_2
-#  809|     mu0_42(unknown)            = ^BufferMayWriteSideEffect[0]           : &:r0_38, ~mu0_2
+#  809|     mu0_42(unknown)            = ^BufferMayWriteSideEffect[0]           : &:r0_38
 #  809|     r0_43(glval<Base>)         = Convert                                : v0_39
 #  809|     r0_44(Base &)              = Call                                   : func:r0_35, this:r0_34, 0:r0_43
 #  809|     mu0_45(unknown)            = ^CallSideEffect                        : ~mu0_2
 #  809|     v0_46(void)                = ^IndirectReadSideEffect[-1]            : &:r0_34, ~mu0_2
 #  809|     v0_47(void)                = ^IndirectReadSideEffect[0]             : &:r0_43, ~mu0_2
-#  809|     mu0_48(Base)               = ^IndirectMayWriteSideEffect[-1]        : &:r0_34, ~mu0_2
-#  809|     mu0_49(unknown)            = ^BufferMayWriteSideEffect[0]           : &:r0_43, ~mu0_2
+#  809|     mu0_48(Base)               = ^IndirectMayWriteSideEffect[-1]        : &:r0_34
+#  809|     mu0_49(unknown)            = ^BufferMayWriteSideEffect[0]           : &:r0_43
 #  810|     r0_50(glval<Base>)         = VariableAddress[b]                     : 
 #  810|     r0_51(glval<unknown>)      = FunctionAddress[operator=]             : 
 #  810|     r0_52(glval<unknown>)      = FunctionAddress[Base]                  : 
@@ -3673,14 +3673,14 @@ ir.cpp:
 #  810|     v0_55(void)                = Call                                   : func:r0_52, 0:r0_54
 #  810|     mu0_56(unknown)            = ^CallSideEffect                        : ~mu0_2
 #  810|     v0_57(void)                = ^IndirectReadSideEffect[0]             : &:r0_54, ~mu0_2
-#  810|     mu0_58(unknown)            = ^BufferMayWriteSideEffect[0]           : &:r0_54, ~mu0_2
+#  810|     mu0_58(unknown)            = ^BufferMayWriteSideEffect[0]           : &:r0_54
 #  810|     r0_59(glval<Base>)         = Convert                                : v0_55
 #  810|     r0_60(Base &)              = Call                                   : func:r0_51, this:r0_50, 0:r0_59
 #  810|     mu0_61(unknown)            = ^CallSideEffect                        : ~mu0_2
 #  810|     v0_62(void)                = ^IndirectReadSideEffect[-1]            : &:r0_50, ~mu0_2
 #  810|     v0_63(void)                = ^IndirectReadSideEffect[0]             : &:r0_59, ~mu0_2
-#  810|     mu0_64(Base)               = ^IndirectMayWriteSideEffect[-1]        : &:r0_50, ~mu0_2
-#  810|     mu0_65(unknown)            = ^BufferMayWriteSideEffect[0]           : &:r0_59, ~mu0_2
+#  810|     mu0_64(Base)               = ^IndirectMayWriteSideEffect[-1]        : &:r0_50
+#  810|     mu0_65(unknown)            = ^BufferMayWriteSideEffect[0]           : &:r0_59
 #  811|     r0_66(glval<Middle *>)     = VariableAddress[pm]                    : 
 #  811|     r0_67(Middle *)            = Load                                   : &:r0_66, ~mu0_2
 #  811|     r0_68(Base *)              = ConvertToBase[Middle : Base]           : r0_67
@@ -3710,8 +3710,8 @@ ir.cpp:
 #  816|     mu0_92(unknown)            = ^CallSideEffect                        : ~mu0_2
 #  816|     v0_93(void)                = ^IndirectReadSideEffect[-1]            : &:r0_86, ~mu0_2
 #  816|     v0_94(void)                = ^IndirectReadSideEffect[0]             : &:r0_90, ~mu0_2
-#  816|     mu0_95(Middle)             = ^IndirectMayWriteSideEffect[-1]        : &:r0_86, ~mu0_2
-#  816|     mu0_96(unknown)            = ^BufferMayWriteSideEffect[0]           : &:r0_90, ~mu0_2
+#  816|     mu0_95(Middle)             = ^IndirectMayWriteSideEffect[-1]        : &:r0_86
+#  816|     mu0_96(unknown)            = ^BufferMayWriteSideEffect[0]           : &:r0_90
 #  817|     r0_97(glval<Middle>)       = VariableAddress[m]                     : 
 #  817|     r0_98(glval<unknown>)      = FunctionAddress[operator=]             : 
 #  817|     r0_99(glval<Base>)         = VariableAddress[b]                     : 
@@ -3721,8 +3721,8 @@ ir.cpp:
 #  817|     mu0_103(unknown)           = ^CallSideEffect                        : ~mu0_2
 #  817|     v0_104(void)               = ^IndirectReadSideEffect[-1]            : &:r0_97, ~mu0_2
 #  817|     v0_105(void)               = ^IndirectReadSideEffect[0]             : &:r0_101, ~mu0_2
-#  817|     mu0_106(Middle)            = ^IndirectMayWriteSideEffect[-1]        : &:r0_97, ~mu0_2
-#  817|     mu0_107(unknown)           = ^BufferMayWriteSideEffect[0]           : &:r0_101, ~mu0_2
+#  817|     mu0_106(Middle)            = ^IndirectMayWriteSideEffect[-1]        : &:r0_97
+#  817|     mu0_107(unknown)           = ^BufferMayWriteSideEffect[0]           : &:r0_101
 #  818|     r0_108(glval<Base *>)      = VariableAddress[pb]                    : 
 #  818|     r0_109(Base *)             = Load                                   : &:r0_108, ~mu0_2
 #  818|     r0_110(Middle *)           = ConvertToDerived[Middle : Base]        : r0_109
@@ -3747,8 +3747,8 @@ ir.cpp:
 #  822|     mu0_129(unknown)           = ^CallSideEffect                        : ~mu0_2
 #  822|     v0_130(void)               = ^IndirectReadSideEffect[-1]            : &:r0_123, ~mu0_2
 #  822|     v0_131(void)               = ^IndirectReadSideEffect[0]             : &:r0_127, ~mu0_2
-#  822|     mu0_132(Base)              = ^IndirectMayWriteSideEffect[-1]        : &:r0_123, ~mu0_2
-#  822|     mu0_133(unknown)           = ^BufferMayWriteSideEffect[0]           : &:r0_127, ~mu0_2
+#  822|     mu0_132(Base)              = ^IndirectMayWriteSideEffect[-1]        : &:r0_123
+#  822|     mu0_133(unknown)           = ^BufferMayWriteSideEffect[0]           : &:r0_127
 #  823|     r0_134(glval<Base>)        = VariableAddress[b]                     : 
 #  823|     r0_135(glval<unknown>)     = FunctionAddress[operator=]             : 
 #  823|     r0_136(glval<unknown>)     = FunctionAddress[Base]                  : 
@@ -3758,14 +3758,14 @@ ir.cpp:
 #  823|     v0_140(void)               = Call                                   : func:r0_136, 0:r0_139
 #  823|     mu0_141(unknown)           = ^CallSideEffect                        : ~mu0_2
 #  823|     v0_142(void)               = ^IndirectReadSideEffect[0]             : &:r0_139, ~mu0_2
-#  823|     mu0_143(unknown)           = ^BufferMayWriteSideEffect[0]           : &:r0_139, ~mu0_2
+#  823|     mu0_143(unknown)           = ^BufferMayWriteSideEffect[0]           : &:r0_139
 #  823|     r0_144(glval<Base>)        = Convert                                : v0_140
 #  823|     r0_145(Base &)             = Call                                   : func:r0_135, this:r0_134, 0:r0_144
 #  823|     mu0_146(unknown)           = ^CallSideEffect                        : ~mu0_2
 #  823|     v0_147(void)               = ^IndirectReadSideEffect[-1]            : &:r0_134, ~mu0_2
 #  823|     v0_148(void)               = ^IndirectReadSideEffect[0]             : &:r0_144, ~mu0_2
-#  823|     mu0_149(Base)              = ^IndirectMayWriteSideEffect[-1]        : &:r0_134, ~mu0_2
-#  823|     mu0_150(unknown)           = ^BufferMayWriteSideEffect[0]           : &:r0_144, ~mu0_2
+#  823|     mu0_149(Base)              = ^IndirectMayWriteSideEffect[-1]        : &:r0_134
+#  823|     mu0_150(unknown)           = ^BufferMayWriteSideEffect[0]           : &:r0_144
 #  824|     r0_151(glval<Base>)        = VariableAddress[b]                     : 
 #  824|     r0_152(glval<unknown>)     = FunctionAddress[operator=]             : 
 #  824|     r0_153(glval<unknown>)     = FunctionAddress[Base]                  : 
@@ -3775,14 +3775,14 @@ ir.cpp:
 #  824|     v0_157(void)               = Call                                   : func:r0_153, 0:r0_156
 #  824|     mu0_158(unknown)           = ^CallSideEffect                        : ~mu0_2
 #  824|     v0_159(void)               = ^IndirectReadSideEffect[0]             : &:r0_156, ~mu0_2
-#  824|     mu0_160(unknown)           = ^BufferMayWriteSideEffect[0]           : &:r0_156, ~mu0_2
+#  824|     mu0_160(unknown)           = ^BufferMayWriteSideEffect[0]           : &:r0_156
 #  824|     r0_161(glval<Base>)        = Convert                                : v0_157
 #  824|     r0_162(Base &)             = Call                                   : func:r0_152, this:r0_151, 0:r0_161
 #  824|     mu0_163(unknown)           = ^CallSideEffect                        : ~mu0_2
 #  824|     v0_164(void)               = ^IndirectReadSideEffect[-1]            : &:r0_151, ~mu0_2
 #  824|     v0_165(void)               = ^IndirectReadSideEffect[0]             : &:r0_161, ~mu0_2
-#  824|     mu0_166(Base)              = ^IndirectMayWriteSideEffect[-1]        : &:r0_151, ~mu0_2
-#  824|     mu0_167(unknown)           = ^BufferMayWriteSideEffect[0]           : &:r0_161, ~mu0_2
+#  824|     mu0_166(Base)              = ^IndirectMayWriteSideEffect[-1]        : &:r0_151
+#  824|     mu0_167(unknown)           = ^BufferMayWriteSideEffect[0]           : &:r0_161
 #  825|     r0_168(glval<Derived *>)   = VariableAddress[pd]                    : 
 #  825|     r0_169(Derived *)          = Load                                   : &:r0_168, ~mu0_2
 #  825|     r0_170(Middle *)           = ConvertToBase[Derived : Middle]        : r0_169
@@ -3816,8 +3816,8 @@ ir.cpp:
 #  830|     mu0_198(unknown)           = ^CallSideEffect                        : ~mu0_2
 #  830|     v0_199(void)               = ^IndirectReadSideEffect[-1]            : &:r0_191, ~mu0_2
 #  830|     v0_200(void)               = ^IndirectReadSideEffect[0]             : &:r0_196, ~mu0_2
-#  830|     mu0_201(Derived)           = ^IndirectMayWriteSideEffect[-1]        : &:r0_191, ~mu0_2
-#  830|     mu0_202(unknown)           = ^BufferMayWriteSideEffect[0]           : &:r0_196, ~mu0_2
+#  830|     mu0_201(Derived)           = ^IndirectMayWriteSideEffect[-1]        : &:r0_191
+#  830|     mu0_202(unknown)           = ^BufferMayWriteSideEffect[0]           : &:r0_196
 #  831|     r0_203(glval<Derived>)     = VariableAddress[d]                     : 
 #  831|     r0_204(glval<unknown>)     = FunctionAddress[operator=]             : 
 #  831|     r0_205(glval<Base>)        = VariableAddress[b]                     : 
@@ -3828,8 +3828,8 @@ ir.cpp:
 #  831|     mu0_210(unknown)           = ^CallSideEffect                        : ~mu0_2
 #  831|     v0_211(void)               = ^IndirectReadSideEffect[-1]            : &:r0_203, ~mu0_2
 #  831|     v0_212(void)               = ^IndirectReadSideEffect[0]             : &:r0_208, ~mu0_2
-#  831|     mu0_213(Derived)           = ^IndirectMayWriteSideEffect[-1]        : &:r0_203, ~mu0_2
-#  831|     mu0_214(unknown)           = ^BufferMayWriteSideEffect[0]           : &:r0_208, ~mu0_2
+#  831|     mu0_213(Derived)           = ^IndirectMayWriteSideEffect[-1]        : &:r0_203
+#  831|     mu0_214(unknown)           = ^BufferMayWriteSideEffect[0]           : &:r0_208
 #  832|     r0_215(glval<Base *>)      = VariableAddress[pb]                    : 
 #  832|     r0_216(Base *)             = Load                                   : &:r0_215, ~mu0_2
 #  832|     r0_217(Middle *)           = ConvertToDerived[Middle : Base]        : r0_216
@@ -3973,7 +3973,7 @@ ir.cpp:
 #  868|     v0_7(void)           = Call                         : func:r0_4, this:r0_3, 0:r0_6
 #  868|     mu0_8(unknown)       = ^CallSideEffect              : ~mu0_2
 #  868|     v0_9(void)           = ^IndirectReadSideEffect[0]   : &:r0_6, ~mu0_2
-#  868|     mu0_10(unknown)      = ^BufferMayWriteSideEffect[0] : &:r0_6, ~mu0_2
+#  868|     mu0_10(unknown)      = ^BufferMayWriteSideEffect[0] : &:r0_6
 #  869|     v0_11(void)          = NoOp                         : 
 #  867|     v0_12(void)          = ReturnVoid                   : 
 #  867|     v0_13(void)          = UnmodeledUse                 : mu*
@@ -4190,7 +4190,7 @@ ir.cpp:
 #  945|     v0_38(void)           = Call                          : func:r0_35, this:r0_34, 0:r0_37
 #  945|     mu0_39(unknown)       = ^CallSideEffect               : ~mu0_2
 #  945|     v0_40(void)           = ^IndirectReadSideEffect[0]    : &:r0_37, ~mu0_2
-#  945|     mu0_41(unknown)       = ^BufferMayWriteSideEffect[0]  : &:r0_37, ~mu0_2
+#  945|     mu0_41(unknown)       = ^BufferMayWriteSideEffect[0]  : &:r0_37
 #  946|     r0_42(glval<unknown>) = FunctionAddress[operator new] : 
 #  946|     r0_43(unsigned long)  = Constant[256]                 : 
 #  946|     r0_44(align_val_t)    = Constant[128]                 : 
@@ -4678,7 +4678,7 @@ ir.cpp:
 # 1035|     r0_29(char)                              = Call                                   : func:r0_27, this:r0_26, 0:r0_28
 # 1035|     mu0_30(unknown)                          = ^CallSideEffect                        : ~mu0_2
 # 1035|     v0_31(void)                              = ^IndirectReadSideEffect[-1]            : &:r0_26, ~mu0_2
-# 1035|     mu0_32(decltype([...](...){...}))        = ^IndirectMayWriteSideEffect[-1]        : &:r0_26, ~mu0_2
+# 1035|     mu0_32(decltype([...](...){...}))        = ^IndirectMayWriteSideEffect[-1]        : &:r0_26
 # 1036|     r0_33(glval<decltype([...](...){...})>)  = VariableAddress[lambda_val]            : 
 # 1036|     r0_34(glval<unknown>)                    = FunctionAddress[(constructor)]         : 
 # 1036|     r0_35(glval<decltype([...](...){...})>)  = VariableAddress[#temp1036:21]          : 
@@ -4695,7 +4695,7 @@ ir.cpp:
 # 1036|     v0_46(void)                              = Call                                   : func:r0_34, this:r0_33, 0:r0_45
 # 1036|     mu0_47(unknown)                          = ^CallSideEffect                        : ~mu0_2
 # 1036|     v0_48(void)                              = ^IndirectReadSideEffect[0]             : &:r0_45, ~mu0_2
-# 1036|     mu0_49(unknown)                          = ^BufferMayWriteSideEffect[0]           : &:r0_45, ~mu0_2
+# 1036|     mu0_49(unknown)                          = ^BufferMayWriteSideEffect[0]           : &:r0_45
 # 1037|     r0_50(glval<decltype([...](...){...})>)  = VariableAddress[lambda_val]            : 
 # 1037|     r0_51(glval<decltype([...](...){...})>)  = Convert                                : r0_50
 # 1037|     r0_52(glval<unknown>)                    = FunctionAddress[operator()]            : 
@@ -4703,7 +4703,7 @@ ir.cpp:
 # 1037|     r0_54(char)                              = Call                                   : func:r0_52, this:r0_51, 0:r0_53
 # 1037|     mu0_55(unknown)                          = ^CallSideEffect                        : ~mu0_2
 # 1037|     v0_56(void)                              = ^IndirectReadSideEffect[-1]            : &:r0_51, ~mu0_2
-# 1037|     mu0_57(decltype([...](...){...}))        = ^IndirectMayWriteSideEffect[-1]        : &:r0_51, ~mu0_2
+# 1037|     mu0_57(decltype([...](...){...}))        = ^IndirectMayWriteSideEffect[-1]        : &:r0_51
 # 1038|     r0_58(glval<decltype([...](...){...})>)  = VariableAddress[lambda_ref_explicit]   : 
 # 1038|     r0_59(glval<decltype([...](...){...})>)  = VariableAddress[#temp1038:30]          : 
 # 1038|     mu0_60(decltype([...](...){...}))        = Uninitialized[#temp1038:30]            : &:r0_59
@@ -4720,7 +4720,7 @@ ir.cpp:
 # 1039|     r0_71(char)                              = Call                                   : func:r0_69, this:r0_68, 0:r0_70
 # 1039|     mu0_72(unknown)                          = ^CallSideEffect                        : ~mu0_2
 # 1039|     v0_73(void)                              = ^IndirectReadSideEffect[-1]            : &:r0_68, ~mu0_2
-# 1039|     mu0_74(decltype([...](...){...}))        = ^IndirectMayWriteSideEffect[-1]        : &:r0_68, ~mu0_2
+# 1039|     mu0_74(decltype([...](...){...}))        = ^IndirectMayWriteSideEffect[-1]        : &:r0_68
 # 1040|     r0_75(glval<decltype([...](...){...})>)  = VariableAddress[lambda_val_explicit]   : 
 # 1040|     r0_76(glval<unknown>)                    = FunctionAddress[(constructor)]         : 
 # 1040|     r0_77(glval<decltype([...](...){...})>)  = VariableAddress[#temp1040:30]          : 
@@ -4733,7 +4733,7 @@ ir.cpp:
 # 1040|     v0_84(void)                              = Call                                   : func:r0_76, this:r0_75, 0:r0_83
 # 1040|     mu0_85(unknown)                          = ^CallSideEffect                        : ~mu0_2
 # 1040|     v0_86(void)                              = ^IndirectReadSideEffect[0]             : &:r0_83, ~mu0_2
-# 1040|     mu0_87(unknown)                          = ^BufferMayWriteSideEffect[0]           : &:r0_83, ~mu0_2
+# 1040|     mu0_87(unknown)                          = ^BufferMayWriteSideEffect[0]           : &:r0_83
 # 1041|     r0_88(glval<decltype([...](...){...})>)  = VariableAddress[lambda_val_explicit]   : 
 # 1041|     r0_89(glval<decltype([...](...){...})>)  = Convert                                : r0_88
 # 1041|     r0_90(glval<unknown>)                    = FunctionAddress[operator()]            : 
@@ -4741,7 +4741,7 @@ ir.cpp:
 # 1041|     r0_92(char)                              = Call                                   : func:r0_90, this:r0_89, 0:r0_91
 # 1041|     mu0_93(unknown)                          = ^CallSideEffect                        : ~mu0_2
 # 1041|     v0_94(void)                              = ^IndirectReadSideEffect[-1]            : &:r0_89, ~mu0_2
-# 1041|     mu0_95(decltype([...](...){...}))        = ^IndirectMayWriteSideEffect[-1]        : &:r0_89, ~mu0_2
+# 1041|     mu0_95(decltype([...](...){...}))        = ^IndirectMayWriteSideEffect[-1]        : &:r0_89
 # 1042|     r0_96(glval<decltype([...](...){...})>)  = VariableAddress[lambda_mixed_explicit] : 
 # 1042|     r0_97(glval<decltype([...](...){...})>)  = VariableAddress[#temp1042:32]          : 
 # 1042|     mu0_98(decltype([...](...){...}))        = Uninitialized[#temp1042:32]            : &:r0_97
@@ -4762,7 +4762,7 @@ ir.cpp:
 # 1043|     r0_113(char)                             = Call                                   : func:r0_111, this:r0_110, 0:r0_112
 # 1043|     mu0_114(unknown)                         = ^CallSideEffect                        : ~mu0_2
 # 1043|     v0_115(void)                             = ^IndirectReadSideEffect[-1]            : &:r0_110, ~mu0_2
-# 1043|     mu0_116(decltype([...](...){...}))       = ^IndirectMayWriteSideEffect[-1]        : &:r0_110, ~mu0_2
+# 1043|     mu0_116(decltype([...](...){...}))       = ^IndirectMayWriteSideEffect[-1]        : &:r0_110
 # 1044|     r0_117(glval<int>)                       = VariableAddress[r]                     : 
 # 1044|     r0_118(glval<int>)                       = VariableAddress[x]                     : 
 # 1044|     r0_119(int)                              = Load                                   : &:r0_118, ~mu0_2
@@ -4798,7 +4798,7 @@ ir.cpp:
 # 1046|     r0_149(char)                             = Call                                   : func:r0_147, this:r0_146, 0:r0_148
 # 1046|     mu0_150(unknown)                         = ^CallSideEffect                        : ~mu0_2
 # 1046|     v0_151(void)                             = ^IndirectReadSideEffect[-1]            : &:r0_146, ~mu0_2
-# 1046|     mu0_152(decltype([...](...){...}))       = ^IndirectMayWriteSideEffect[-1]        : &:r0_146, ~mu0_2
+# 1046|     mu0_152(decltype([...](...){...}))       = ^IndirectMayWriteSideEffect[-1]        : &:r0_146
 # 1047|     v0_153(void)                             = NoOp                                   : 
 # 1031|     v0_154(void)                             = ReturnVoid                             : 
 # 1031|     v0_155(void)                             = UnmodeledUse                           : mu*
@@ -4863,7 +4863,7 @@ ir.cpp:
 # 1034|     r0_11(char *)                                 = Call                            : func:r0_10, this:r0_9
 # 1034|     mu0_12(unknown)                               = ^CallSideEffect                 : ~mu0_2
 # 1034|     v0_13(void)                                   = ^IndirectReadSideEffect[-1]     : &:r0_9, ~mu0_2
-# 1034|     mu0_14(String)                                = ^IndirectMayWriteSideEffect[-1] : &:r0_9, ~mu0_2
+# 1034|     mu0_14(String)                                = ^IndirectMayWriteSideEffect[-1] : &:r0_9
 #-----|     r0_15(lambda [] type at line 1034, col. 21 *) = CopyValue                       : r0_3
 #-----|     r0_16(glval<int &>)                           = FieldAddress[x]                 : r0_15
 #-----|     r0_17(int &)                                  = Load                            : &:r0_16, ~mu0_2
@@ -4906,7 +4906,7 @@ ir.cpp:
 # 1036|     r0_10(char *)                                 = Call                            : func:r0_9, this:r0_8
 # 1036|     mu0_11(unknown)                               = ^CallSideEffect                 : ~mu0_2
 #-----|     v0_12(void)                                   = ^IndirectReadSideEffect[-1]     : &:r0_8, ~mu0_2
-#-----|     mu0_13(String)                                = ^IndirectMayWriteSideEffect[-1] : &:r0_8, ~mu0_2
+#-----|     mu0_13(String)                                = ^IndirectMayWriteSideEffect[-1] : &:r0_8
 #-----|     r0_14(lambda [] type at line 1036, col. 21 *) = CopyValue                       : r0_3
 #-----|     r0_15(glval<int>)                             = FieldAddress[x]                 : r0_14
 #-----|     r0_16(int)                                    = Load                            : &:r0_15, ~mu0_2
@@ -4934,7 +4934,7 @@ ir.cpp:
 # 1038|     r0_11(char *)                                = Call                            : func:r0_10, this:r0_9
 # 1038|     mu0_12(unknown)                              = ^CallSideEffect                 : ~mu0_2
 # 1038|     v0_13(void)                                  = ^IndirectReadSideEffect[-1]     : &:r0_9, ~mu0_2
-# 1038|     mu0_14(String)                               = ^IndirectMayWriteSideEffect[-1] : &:r0_9, ~mu0_2
+# 1038|     mu0_14(String)                               = ^IndirectMayWriteSideEffect[-1] : &:r0_9
 # 1038|     r0_15(int)                                   = Constant[0]                     : 
 # 1038|     r0_16(glval<char>)                           = PointerAdd[1]                   : r0_11, r0_15
 # 1038|     r0_17(char)                                  = Load                            : &:r0_16, ~mu0_2
@@ -4991,7 +4991,7 @@ ir.cpp:
 # 1040|     r0_10(char *)                                = Call                            : func:r0_9, this:r0_8
 # 1040|     mu0_11(unknown)                              = ^CallSideEffect                 : ~mu0_2
 #-----|     v0_12(void)                                  = ^IndirectReadSideEffect[-1]     : &:r0_8, ~mu0_2
-#-----|     mu0_13(String)                               = ^IndirectMayWriteSideEffect[-1] : &:r0_8, ~mu0_2
+#-----|     mu0_13(String)                               = ^IndirectMayWriteSideEffect[-1] : &:r0_8
 # 1040|     r0_14(int)                                   = Constant[0]                     : 
 # 1040|     r0_15(glval<char>)                           = PointerAdd[1]                   : r0_10, r0_14
 # 1040|     r0_16(char)                                  = Load                            : &:r0_15, ~mu0_2
@@ -5017,7 +5017,7 @@ ir.cpp:
 # 1042|     r0_11(char *)                                 = Call                            : func:r0_10, this:r0_9
 # 1042|     mu0_12(unknown)                               = ^CallSideEffect                 : ~mu0_2
 # 1042|     v0_13(void)                                   = ^IndirectReadSideEffect[-1]     : &:r0_9, ~mu0_2
-# 1042|     mu0_14(String)                                = ^IndirectMayWriteSideEffect[-1] : &:r0_9, ~mu0_2
+# 1042|     mu0_14(String)                                = ^IndirectMayWriteSideEffect[-1] : &:r0_9
 #-----|     r0_15(lambda [] type at line 1042, col. 32 *) = CopyValue                       : r0_3
 #-----|     r0_16(glval<int>)                             = FieldAddress[x]                 : r0_15
 #-----|     r0_17(int)                                    = Load                            : &:r0_16, ~mu0_2
@@ -5045,7 +5045,7 @@ ir.cpp:
 # 1045|     r0_11(char *)                                 = Call                            : func:r0_10, this:r0_9
 # 1045|     mu0_12(unknown)                               = ^CallSideEffect                 : ~mu0_2
 # 1045|     v0_13(void)                                   = ^IndirectReadSideEffect[-1]     : &:r0_9, ~mu0_2
-# 1045|     mu0_14(String)                                = ^IndirectMayWriteSideEffect[-1] : &:r0_9, ~mu0_2
+# 1045|     mu0_14(String)                                = ^IndirectMayWriteSideEffect[-1] : &:r0_9
 #-----|     r0_15(lambda [] type at line 1045, col. 23 *) = CopyValue                       : r0_3
 #-----|     r0_16(glval<int>)                             = FieldAddress[x]                 : r0_15
 #-----|     r0_17(int)                                    = Load                            : &:r0_16, ~mu0_2
@@ -5084,7 +5084,7 @@ ir.cpp:
 # 1069|     r0_13(iterator)             = Call                            : func:r0_12, this:r0_11
 # 1069|     mu0_14(unknown)             = ^CallSideEffect                 : ~mu0_2
 #-----|     v0_15(void)                 = ^IndirectReadSideEffect[-1]     : &:r0_11, ~mu0_2
-#-----|     mu0_16(vector<int>)         = ^IndirectMayWriteSideEffect[-1] : &:r0_11, ~mu0_2
+#-----|     mu0_16(vector<int>)         = ^IndirectMayWriteSideEffect[-1] : &:r0_11
 # 1069|     mu0_17(iterator)            = Store                           : &:r0_9, r0_13
 # 1069|     r0_18(glval<iterator>)      = VariableAddress[(__end)]        : 
 #-----|     r0_19(glval<vector<int> &>) = VariableAddress[(__range)]      : 
@@ -5093,7 +5093,7 @@ ir.cpp:
 # 1069|     r0_22(iterator)             = Call                            : func:r0_21, this:r0_20
 # 1069|     mu0_23(unknown)             = ^CallSideEffect                 : ~mu0_2
 #-----|     v0_24(void)                 = ^IndirectReadSideEffect[-1]     : &:r0_20, ~mu0_2
-#-----|     mu0_25(vector<int>)         = ^IndirectMayWriteSideEffect[-1] : &:r0_20, ~mu0_2
+#-----|     mu0_25(vector<int>)         = ^IndirectMayWriteSideEffect[-1] : &:r0_20
 # 1069|     mu0_26(iterator)            = Store                           : &:r0_18, r0_22
 #-----|   Goto -> Block 4
 
@@ -5105,7 +5105,7 @@ ir.cpp:
 # 1075|     r1_4(int &)           = Call                            : func:r1_3, this:r1_2
 # 1075|     mu1_5(unknown)        = ^CallSideEffect                 : ~mu0_2
 #-----|     v1_6(void)            = ^IndirectReadSideEffect[-1]     : &:r1_2, ~mu0_2
-#-----|     mu1_7(iterator)       = ^IndirectMayWriteSideEffect[-1] : &:r1_2, ~mu0_2
+#-----|     mu1_7(iterator)       = ^IndirectMayWriteSideEffect[-1] : &:r1_2
 # 1075|     r1_8(glval<int>)      = Convert                         : r1_4
 # 1075|     mu1_9(int &)          = Store                           : &:r1_0, r1_8
 # 1076|     r1_10(glval<int &>)   = VariableAddress[e]              : 
@@ -5137,7 +5137,7 @@ ir.cpp:
 # 1069|     r4_5(bool)            = Call                            : func:r4_2, this:r4_1, 0:r4_4
 # 1069|     mu4_6(unknown)        = ^CallSideEffect                 : ~mu0_2
 #-----|     v4_7(void)            = ^IndirectReadSideEffect[-1]     : &:r4_1, ~mu0_2
-#-----|     mu4_8(iterator)       = ^IndirectMayWriteSideEffect[-1] : &:r4_1, ~mu0_2
+#-----|     mu4_8(iterator)       = ^IndirectMayWriteSideEffect[-1] : &:r4_1
 # 1069|     v4_9(void)            = ConditionalBranch               : r4_5
 #-----|   False -> Block 8
 #-----|   True -> Block 5
@@ -5150,7 +5150,7 @@ ir.cpp:
 # 1069|     r5_4(int &)           = Call                            : func:r5_3, this:r5_2
 # 1069|     mu5_5(unknown)        = ^CallSideEffect                 : ~mu0_2
 #-----|     v5_6(void)            = ^IndirectReadSideEffect[-1]     : &:r5_2, ~mu0_2
-#-----|     mu5_7(iterator)       = ^IndirectMayWriteSideEffect[-1] : &:r5_2, ~mu0_2
+#-----|     mu5_7(iterator)       = ^IndirectMayWriteSideEffect[-1] : &:r5_2
 # 1069|     r5_8(int)             = Load                            : &:r5_4, ~mu0_2
 # 1069|     mu5_9(int)            = Store                           : &:r5_0, r5_8
 # 1070|     r5_10(glval<int>)     = VariableAddress[e]              : 
@@ -5172,7 +5172,7 @@ ir.cpp:
 # 1069|     r7_3(iterator &)      = Call                            : func:r7_2, this:r7_1
 # 1069|     mu7_4(unknown)        = ^CallSideEffect                 : ~mu0_2
 #-----|     v7_5(void)            = ^IndirectReadSideEffect[-1]     : &:r7_1, ~mu0_2
-#-----|     mu7_6(iterator)       = ^IndirectMayWriteSideEffect[-1] : &:r7_1, ~mu0_2
+#-----|     mu7_6(iterator)       = ^IndirectMayWriteSideEffect[-1] : &:r7_1
 #-----|   Goto (back edge) -> Block 4
 
 # 1075|   Block 8
@@ -5187,7 +5187,7 @@ ir.cpp:
 # 1075|     r8_8(iterator)              = Call                            : func:r8_7, this:r8_6
 # 1075|     mu8_9(unknown)              = ^CallSideEffect                 : ~mu0_2
 #-----|     v8_10(void)                 = ^IndirectReadSideEffect[-1]     : &:r8_6, ~mu0_2
-#-----|     mu8_11(vector<int>)         = ^IndirectMayWriteSideEffect[-1] : &:r8_6, ~mu0_2
+#-----|     mu8_11(vector<int>)         = ^IndirectMayWriteSideEffect[-1] : &:r8_6
 # 1075|     mu8_12(iterator)            = Store                           : &:r8_4, r8_8
 # 1075|     r8_13(glval<iterator>)      = VariableAddress[(__end)]        : 
 #-----|     r8_14(glval<vector<int> &>) = VariableAddress[(__range)]      : 
@@ -5196,7 +5196,7 @@ ir.cpp:
 # 1075|     r8_17(iterator)             = Call                            : func:r8_16, this:r8_15
 # 1075|     mu8_18(unknown)             = ^CallSideEffect                 : ~mu0_2
 #-----|     v8_19(void)                 = ^IndirectReadSideEffect[-1]     : &:r8_15, ~mu0_2
-#-----|     mu8_20(vector<int>)         = ^IndirectMayWriteSideEffect[-1] : &:r8_15, ~mu0_2
+#-----|     mu8_20(vector<int>)         = ^IndirectMayWriteSideEffect[-1] : &:r8_15
 # 1075|     mu8_21(iterator)            = Store                           : &:r8_13, r8_17
 #-----|   Goto -> Block 9
 
@@ -5209,7 +5209,7 @@ ir.cpp:
 # 1075|     r9_5(bool)            = Call                            : func:r9_2, this:r9_1, 0:r9_4
 # 1075|     mu9_6(unknown)        = ^CallSideEffect                 : ~mu0_2
 #-----|     v9_7(void)            = ^IndirectReadSideEffect[-1]     : &:r9_1, ~mu0_2
-#-----|     mu9_8(iterator)       = ^IndirectMayWriteSideEffect[-1] : &:r9_1, ~mu0_2
+#-----|     mu9_8(iterator)       = ^IndirectMayWriteSideEffect[-1] : &:r9_1
 # 1075|     v9_9(void)            = ConditionalBranch               : r9_5
 #-----|   False -> Block 3
 #-----|   True -> Block 1
@@ -5220,7 +5220,7 @@ ir.cpp:
 # 1075|     r10_2(iterator &)      = Call                            : func:r10_1, this:r10_0
 # 1075|     mu10_3(unknown)        = ^CallSideEffect                 : ~mu0_2
 #-----|     v10_4(void)            = ^IndirectReadSideEffect[-1]     : &:r10_0, ~mu0_2
-#-----|     mu10_5(iterator)       = ^IndirectMayWriteSideEffect[-1] : &:r10_0, ~mu0_2
+#-----|     mu10_5(iterator)       = ^IndirectMayWriteSideEffect[-1] : &:r10_0
 #-----|   Goto (back edge) -> Block 9
 
 # 1099| int AsmStmt(int)
@@ -5379,7 +5379,7 @@ ir.cpp:
 # 1140|     v7_4(void)            = Call                            : func:r7_1, this:r7_0, 0:r7_3
 # 1140|     mu7_5(unknown)        = ^CallSideEffect                 : ~mu0_2
 # 1140|     v7_6(void)            = ^IndirectReadSideEffect[0]      : &:r7_3, ~mu0_2
-# 1140|     mu7_7(unknown)        = ^BufferMayWriteSideEffect[0]    : &:r7_3, ~mu0_2
+# 1140|     mu7_7(unknown)        = ^BufferMayWriteSideEffect[0]    : &:r7_3
 # 1140|     v7_8(void)            = ThrowValue                      : &:r7_0, ~mu0_2
 #-----|   Exception -> Block 9
 
@@ -5404,7 +5404,7 @@ ir.cpp:
 # 1145|     v10_6(void)           = Call                          : func:r10_3, this:r10_2, 0:r10_5
 # 1145|     mu10_7(unknown)       = ^CallSideEffect               : ~mu0_2
 # 1145|     v10_8(void)           = ^IndirectReadSideEffect[0]    : &:r10_5, ~mu0_2
-# 1145|     mu10_9(unknown)       = ^BufferMayWriteSideEffect[0]  : &:r10_5, ~mu0_2
+# 1145|     mu10_9(unknown)       = ^BufferMayWriteSideEffect[0]  : &:r10_5
 # 1145|     v10_10(void)          = ThrowValue                    : &:r10_2, ~mu0_2
 #-----|   Exception -> Block 2
 

--- a/cpp/ql/test/library-tests/ir/ir/raw_ir.expected
+++ b/cpp/ql/test/library-tests/ir/ir/raw_ir.expected
@@ -15,7 +15,7 @@ bad_asts.cpp:
 #   16|     r0_11(int)           = Call                            : func:r0_9, this:r0_8, 0:r0_10
 #   16|     mu0_12(unknown)      = ^CallSideEffect                 : ~mu0_2
 #   16|     v0_13(void)          = ^IndirectReadSideEffect         : &:r0_8, ~mu0_2
-#   16|     r0_14(S)             = ^IndirectMayWriteSideEffect     : &:r0_8, ~mu0_2
+#   16|     mu0_14(S)            = ^IndirectMayWriteSideEffect     : &:r0_8, ~mu0_2
 #   17|     v0_15(void)          = NoOp                            : 
 #   14|     v0_16(void)          = ReturnVoid                      : 
 #   14|     v0_17(void)          = UnmodeledUse                    : mu*
@@ -2675,10 +2675,10 @@ ir.cpp:
 #  585|     r0_8(char *)         = Convert                         : r0_7
 #  585|     v0_9(void)           = Call                            : func:r0_3, 0:r0_5, 1:r0_6, 2:r0_8
 #  585|     mu0_10(unknown)      = ^CallSideEffect                 : ~mu0_2
-#  585|     v0_11(void)          = ^IndirectReadSideEffect[s]      : &:r0_5, ~mu0_2
+#  585|     v0_11(void)          = ^IndirectReadSideEffect         : &:r0_5, ~mu0_2
 #  585|     v0_12(void)          = ^IndirectReadSideEffect         : &:r0_8, ~mu0_2
-#  585|     mu0_13(unknown)      = ^BufferMayWriteSideEffect[s]    : &:r0_5, ~mu0_2
-#  585|     r0_14(unknown)       = ^BufferMayWriteSideEffect       : &:r0_8, ~mu0_2
+#  585|     mu0_13(unknown)      = ^BufferMayWriteSideEffect       : &:r0_5, ~mu0_2
+#  585|     mu0_14(unknown)      = ^BufferMayWriteSideEffect       : &:r0_8, ~mu0_2
 #  586|     v0_15(void)          = NoOp                            : 
 #  584|     v0_16(void)          = ReturnVoid                      : 
 #  584|     v0_17(void)          = UnmodeledUse                    : mu*
@@ -2708,38 +2708,38 @@ ir.cpp:
 
 #  615| void DeclareObject()
 #  615|   Block 0
-#  615|     v0_0(void)            = EnterFunction                  : 
-#  615|     mu0_1(unknown)        = AliasedDefinition              : 
-#  615|     mu0_2(unknown)        = UnmodeledDefinition            : 
-#  616|     r0_3(glval<String>)   = VariableAddress[s1]            : 
-#  616|     r0_4(glval<unknown>)  = FunctionAddress[String]        : 
-#  616|     v0_5(void)            = Call                           : func:r0_4, this:r0_3
-#  616|     mu0_6(unknown)        = ^CallSideEffect                : ~mu0_2
-#  617|     r0_7(glval<String>)   = VariableAddress[s2]            : 
-#  617|     r0_8(glval<unknown>)  = FunctionAddress[String]        : 
-#  617|     r0_9(glval<char[6]>)  = StringConstant["hello"]        : 
-#  617|     r0_10(char *)         = Convert                        : r0_9
-#  617|     v0_11(void)           = Call                           : func:r0_8, this:r0_7, 0:r0_10
-#  617|     mu0_12(unknown)       = ^CallSideEffect                : ~mu0_2
-#  617|     v0_13(void)           = ^IndirectReadSideEffect[p#0]   : &:r0_10, ~mu0_2
-#  617|     mu0_14(unknown)       = ^BufferMayWriteSideEffect[p#0] : &:r0_10, ~mu0_2
-#  618|     r0_15(glval<String>)  = VariableAddress[s3]            : 
-#  618|     r0_16(glval<unknown>) = FunctionAddress[ReturnObject]  : 
-#  618|     r0_17(String)         = Call                           : func:r0_16
-#  618|     mu0_18(unknown)       = ^CallSideEffect                : ~mu0_2
-#  618|     mu0_19(String)        = Store                          : &:r0_15, r0_17
-#  619|     r0_20(glval<String>)  = VariableAddress[s4]            : 
-#  619|     r0_21(glval<unknown>) = FunctionAddress[String]        : 
-#  619|     r0_22(glval<char[5]>) = StringConstant["test"]         : 
-#  619|     r0_23(char *)         = Convert                        : r0_22
-#  619|     v0_24(void)           = Call                           : func:r0_21, this:r0_20, 0:r0_23
-#  619|     mu0_25(unknown)       = ^CallSideEffect                : ~mu0_2
-#  619|     v0_26(void)           = ^IndirectReadSideEffect[p#0]   : &:r0_23, ~mu0_2
-#  619|     mu0_27(unknown)       = ^BufferMayWriteSideEffect[p#0] : &:r0_23, ~mu0_2
-#  620|     v0_28(void)           = NoOp                           : 
-#  615|     v0_29(void)           = ReturnVoid                     : 
-#  615|     v0_30(void)           = UnmodeledUse                   : mu*
-#  615|     v0_31(void)           = ExitFunction                   : 
+#  615|     v0_0(void)            = EnterFunction                 : 
+#  615|     mu0_1(unknown)        = AliasedDefinition             : 
+#  615|     mu0_2(unknown)        = UnmodeledDefinition           : 
+#  616|     r0_3(glval<String>)   = VariableAddress[s1]           : 
+#  616|     r0_4(glval<unknown>)  = FunctionAddress[String]       : 
+#  616|     v0_5(void)            = Call                          : func:r0_4, this:r0_3
+#  616|     mu0_6(unknown)        = ^CallSideEffect               : ~mu0_2
+#  617|     r0_7(glval<String>)   = VariableAddress[s2]           : 
+#  617|     r0_8(glval<unknown>)  = FunctionAddress[String]       : 
+#  617|     r0_9(glval<char[6]>)  = StringConstant["hello"]       : 
+#  617|     r0_10(char *)         = Convert                       : r0_9
+#  617|     v0_11(void)           = Call                          : func:r0_8, this:r0_7, 0:r0_10
+#  617|     mu0_12(unknown)       = ^CallSideEffect               : ~mu0_2
+#  617|     v0_13(void)           = ^IndirectReadSideEffect       : &:r0_10, ~mu0_2
+#  617|     mu0_14(unknown)       = ^BufferMayWriteSideEffect     : &:r0_10, ~mu0_2
+#  618|     r0_15(glval<String>)  = VariableAddress[s3]           : 
+#  618|     r0_16(glval<unknown>) = FunctionAddress[ReturnObject] : 
+#  618|     r0_17(String)         = Call                          : func:r0_16
+#  618|     mu0_18(unknown)       = ^CallSideEffect               : ~mu0_2
+#  618|     mu0_19(String)        = Store                         : &:r0_15, r0_17
+#  619|     r0_20(glval<String>)  = VariableAddress[s4]           : 
+#  619|     r0_21(glval<unknown>) = FunctionAddress[String]       : 
+#  619|     r0_22(glval<char[5]>) = StringConstant["test"]        : 
+#  619|     r0_23(char *)         = Convert                       : r0_22
+#  619|     v0_24(void)           = Call                          : func:r0_21, this:r0_20, 0:r0_23
+#  619|     mu0_25(unknown)       = ^CallSideEffect               : ~mu0_2
+#  619|     v0_26(void)           = ^IndirectReadSideEffect       : &:r0_23, ~mu0_2
+#  619|     mu0_27(unknown)       = ^BufferMayWriteSideEffect     : &:r0_23, ~mu0_2
+#  620|     v0_28(void)           = NoOp                          : 
+#  615|     v0_29(void)           = ReturnVoid                    : 
+#  615|     v0_30(void)           = UnmodeledUse                  : mu*
+#  615|     v0_31(void)           = ExitFunction                  : 
 
 #  622| void CallMethods(String&, String*, String)
 #  622|   Block 0
@@ -2759,7 +2759,7 @@ ir.cpp:
 #  623|     r0_13(char *)          = Call                        : func:r0_12, this:r0_11
 #  623|     mu0_14(unknown)        = ^CallSideEffect             : ~mu0_2
 #  623|     v0_15(void)            = ^IndirectReadSideEffect     : &:r0_11, ~mu0_2
-#  623|     r0_16(String)          = ^IndirectMayWriteSideEffect : &:r0_11, ~mu0_2
+#  623|     mu0_16(String)         = ^IndirectMayWriteSideEffect : &:r0_11, ~mu0_2
 #  624|     r0_17(glval<String *>) = VariableAddress[p]          : 
 #  624|     r0_18(String *)        = Load                        : &:r0_17, ~mu0_2
 #  624|     r0_19(String *)        = Convert                     : r0_18
@@ -2767,14 +2767,14 @@ ir.cpp:
 #  624|     r0_21(char *)          = Call                        : func:r0_20, this:r0_19
 #  624|     mu0_22(unknown)        = ^CallSideEffect             : ~mu0_2
 #  624|     v0_23(void)            = ^IndirectReadSideEffect     : &:r0_19, ~mu0_2
-#  624|     r0_24(String)          = ^IndirectMayWriteSideEffect : &:r0_19, ~mu0_2
+#  624|     mu0_24(String)         = ^IndirectMayWriteSideEffect : &:r0_19, ~mu0_2
 #  625|     r0_25(glval<String>)   = VariableAddress[s]          : 
 #  625|     r0_26(glval<String>)   = Convert                     : r0_25
 #  625|     r0_27(glval<unknown>)  = FunctionAddress[c_str]      : 
 #  625|     r0_28(char *)          = Call                        : func:r0_27, this:r0_26
 #  625|     mu0_29(unknown)        = ^CallSideEffect             : ~mu0_2
 #  625|     v0_30(void)            = ^IndirectReadSideEffect     : &:r0_26, ~mu0_2
-#  625|     r0_31(String)          = ^IndirectMayWriteSideEffect : &:r0_26, ~mu0_2
+#  625|     mu0_31(String)         = ^IndirectMayWriteSideEffect : &:r0_26, ~mu0_2
 #  626|     v0_32(void)            = NoOp                        : 
 #  622|     v0_33(void)            = ReturnVoid                  : 
 #  622|     v0_34(void)            = UnmodeledUse                : mu*
@@ -2882,21 +2882,21 @@ ir.cpp:
 #  653|     r0_7(int)             = Call                                    : func:r0_5, this:r0_4, 0:r0_6
 #  653|     mu0_8(unknown)        = ^CallSideEffect                         : ~mu0_2
 #  653|     v0_9(void)            = ^IndirectReadSideEffect                 : &:r0_4, ~mu0_2
-#  653|     r0_10(C)              = ^IndirectMayWriteSideEffect             : &:r0_4, ~mu0_2
+#  653|     mu0_10(C)             = ^IndirectMayWriteSideEffect             : &:r0_4, ~mu0_2
 #  654|     r0_11(C *)            = CopyValue                               : r0_3
 #  654|     r0_12(glval<unknown>) = FunctionAddress[InstanceMemberFunction] : 
 #  654|     r0_13(int)            = Constant[1]                             : 
 #  654|     r0_14(int)            = Call                                    : func:r0_12, this:r0_11, 0:r0_13
 #  654|     mu0_15(unknown)       = ^CallSideEffect                         : ~mu0_2
 #  654|     v0_16(void)           = ^IndirectReadSideEffect                 : &:r0_11, ~mu0_2
-#  654|     r0_17(C)              = ^IndirectMayWriteSideEffect             : &:r0_11, ~mu0_2
+#  654|     mu0_17(C)             = ^IndirectMayWriteSideEffect             : &:r0_11, ~mu0_2
 #-----|     r0_18(C *)            = CopyValue                               : r0_3
 #  655|     r0_19(glval<unknown>) = FunctionAddress[InstanceMemberFunction] : 
 #  655|     r0_20(int)            = Constant[2]                             : 
 #  655|     r0_21(int)            = Call                                    : func:r0_19, this:r0_18, 0:r0_20
 #  655|     mu0_22(unknown)       = ^CallSideEffect                         : ~mu0_2
 #-----|     v0_23(void)           = ^IndirectReadSideEffect                 : &:r0_18, ~mu0_2
-#-----|     r0_24(C)              = ^IndirectMayWriteSideEffect             : &:r0_18, ~mu0_2
+#-----|     mu0_24(C)             = ^IndirectMayWriteSideEffect             : &:r0_18, ~mu0_2
 #  656|     v0_25(void)           = NoOp                                    : 
 #  652|     v0_26(void)           = ReturnVoid                              : 
 #  652|     v0_27(void)           = UnmodeledUse                            : mu*
@@ -2904,35 +2904,35 @@ ir.cpp:
 
 #  658| void C::C()
 #  658|   Block 0
-#  658|     v0_0(void)            = EnterFunction                  : 
-#  658|     mu0_1(unknown)        = AliasedDefinition              : 
-#  658|     mu0_2(unknown)        = UnmodeledDefinition            : 
-#  658|     r0_3(glval<C>)        = InitializeThis                 : 
-#  659|     r0_4(glval<int>)      = FieldAddress[m_a]              : r0_3
-#  659|     r0_5(int)             = Constant[1]                    : 
-#  659|     mu0_6(int)            = Store                          : &:r0_4, r0_5
-#  663|     r0_7(glval<String>)   = FieldAddress[m_b]              : r0_3
-#  663|     r0_8(glval<unknown>)  = FunctionAddress[String]        : 
-#  663|     v0_9(void)            = Call                           : func:r0_8, this:r0_7
-#  663|     mu0_10(unknown)       = ^CallSideEffect                : ~mu0_2
-#  660|     r0_11(glval<char>)    = FieldAddress[m_c]              : r0_3
-#  660|     r0_12(char)           = Constant[3]                    : 
-#  660|     mu0_13(char)          = Store                          : &:r0_11, r0_12
-#  661|     r0_14(glval<void *>)  = FieldAddress[m_e]              : r0_3
-#  661|     r0_15(void *)         = Constant[0]                    : 
-#  661|     mu0_16(void *)        = Store                          : &:r0_14, r0_15
-#  662|     r0_17(glval<String>)  = FieldAddress[m_f]              : r0_3
-#  662|     r0_18(glval<unknown>) = FunctionAddress[String]        : 
-#  662|     r0_19(glval<char[5]>) = StringConstant["test"]         : 
-#  662|     r0_20(char *)         = Convert                        : r0_19
-#  662|     v0_21(void)           = Call                           : func:r0_18, this:r0_17, 0:r0_20
-#  662|     mu0_22(unknown)       = ^CallSideEffect                : ~mu0_2
-#  662|     v0_23(void)           = ^IndirectReadSideEffect[p#0]   : &:r0_20, ~mu0_2
-#  662|     mu0_24(unknown)       = ^BufferMayWriteSideEffect[p#0] : &:r0_20, ~mu0_2
-#  664|     v0_25(void)           = NoOp                           : 
-#  658|     v0_26(void)           = ReturnVoid                     : 
-#  658|     v0_27(void)           = UnmodeledUse                   : mu*
-#  658|     v0_28(void)           = ExitFunction                   : 
+#  658|     v0_0(void)            = EnterFunction             : 
+#  658|     mu0_1(unknown)        = AliasedDefinition         : 
+#  658|     mu0_2(unknown)        = UnmodeledDefinition       : 
+#  658|     r0_3(glval<C>)        = InitializeThis            : 
+#  659|     r0_4(glval<int>)      = FieldAddress[m_a]         : r0_3
+#  659|     r0_5(int)             = Constant[1]               : 
+#  659|     mu0_6(int)            = Store                     : &:r0_4, r0_5
+#  663|     r0_7(glval<String>)   = FieldAddress[m_b]         : r0_3
+#  663|     r0_8(glval<unknown>)  = FunctionAddress[String]   : 
+#  663|     v0_9(void)            = Call                      : func:r0_8, this:r0_7
+#  663|     mu0_10(unknown)       = ^CallSideEffect           : ~mu0_2
+#  660|     r0_11(glval<char>)    = FieldAddress[m_c]         : r0_3
+#  660|     r0_12(char)           = Constant[3]               : 
+#  660|     mu0_13(char)          = Store                     : &:r0_11, r0_12
+#  661|     r0_14(glval<void *>)  = FieldAddress[m_e]         : r0_3
+#  661|     r0_15(void *)         = Constant[0]               : 
+#  661|     mu0_16(void *)        = Store                     : &:r0_14, r0_15
+#  662|     r0_17(glval<String>)  = FieldAddress[m_f]         : r0_3
+#  662|     r0_18(glval<unknown>) = FunctionAddress[String]   : 
+#  662|     r0_19(glval<char[5]>) = StringConstant["test"]    : 
+#  662|     r0_20(char *)         = Convert                   : r0_19
+#  662|     v0_21(void)           = Call                      : func:r0_18, this:r0_17, 0:r0_20
+#  662|     mu0_22(unknown)       = ^CallSideEffect           : ~mu0_2
+#  662|     v0_23(void)           = ^IndirectReadSideEffect   : &:r0_20, ~mu0_2
+#  662|     mu0_24(unknown)       = ^BufferMayWriteSideEffect : &:r0_20, ~mu0_2
+#  664|     v0_25(void)           = NoOp                      : 
+#  658|     v0_26(void)           = ReturnVoid                : 
+#  658|     v0_27(void)           = UnmodeledUse              : mu*
+#  658|     v0_28(void)           = ExitFunction              : 
 
 #  675| int DerefReference(int&)
 #  675|   Block 0
@@ -3118,23 +3118,23 @@ ir.cpp:
 
 #  720| double CallNestedTemplateFunc()
 #  720|   Block 0
-#  720|     v0_0(void)           = EnterFunction                : 
-#  720|     mu0_1(unknown)       = AliasedDefinition            : 
-#  720|     mu0_2(unknown)       = UnmodeledDefinition          : 
-#  721|     r0_3(glval<double>)  = VariableAddress[#return]     : 
-#  721|     r0_4(glval<unknown>) = FunctionAddress[Func]        : 
-#  721|     r0_5(void *)         = Constant[0]                  : 
-#  721|     r0_6(char)           = Constant[111]                : 
-#  721|     r0_7(long)           = Call                         : func:r0_4, 0:r0_5, 1:r0_6
-#  721|     mu0_8(unknown)       = ^CallSideEffect              : ~mu0_2
-#  721|     v0_9(void)           = ^IndirectReadSideEffect[x]   : &:r0_5, ~mu0_2
-#  721|     mu0_10(unknown)      = ^BufferMayWriteSideEffect[x] : &:r0_5, ~mu0_2
-#  721|     r0_11(double)        = Convert                      : r0_7
-#  721|     mu0_12(double)       = Store                        : &:r0_3, r0_11
-#  720|     r0_13(glval<double>) = VariableAddress[#return]     : 
-#  720|     v0_14(void)          = ReturnValue                  : &:r0_13, ~mu0_2
-#  720|     v0_15(void)          = UnmodeledUse                 : mu*
-#  720|     v0_16(void)          = ExitFunction                 : 
+#  720|     v0_0(void)           = EnterFunction             : 
+#  720|     mu0_1(unknown)       = AliasedDefinition         : 
+#  720|     mu0_2(unknown)       = UnmodeledDefinition       : 
+#  721|     r0_3(glval<double>)  = VariableAddress[#return]  : 
+#  721|     r0_4(glval<unknown>) = FunctionAddress[Func]     : 
+#  721|     r0_5(void *)         = Constant[0]               : 
+#  721|     r0_6(char)           = Constant[111]             : 
+#  721|     r0_7(long)           = Call                      : func:r0_4, 0:r0_5, 1:r0_6
+#  721|     mu0_8(unknown)       = ^CallSideEffect           : ~mu0_2
+#  721|     v0_9(void)           = ^IndirectReadSideEffect   : &:r0_5, ~mu0_2
+#  721|     mu0_10(unknown)      = ^BufferMayWriteSideEffect : &:r0_5, ~mu0_2
+#  721|     r0_11(double)        = Convert                   : r0_7
+#  721|     mu0_12(double)       = Store                     : &:r0_3, r0_11
+#  720|     r0_13(glval<double>) = VariableAddress[#return]  : 
+#  720|     v0_14(void)          = ReturnValue               : &:r0_13, ~mu0_2
+#  720|     v0_15(void)          = UnmodeledUse              : mu*
+#  720|     v0_16(void)          = ExitFunction              : 
 
 #  724| void TryCatch(bool)
 #  724|   Block 0
@@ -3201,8 +3201,8 @@ ir.cpp:
 #  731|     r7_3(char *)          = Convert                         : r7_2
 #  731|     v7_4(void)            = Call                            : func:r7_1, this:r7_0, 0:r7_3
 #  731|     mu7_5(unknown)        = ^CallSideEffect                 : ~mu0_2
-#  731|     v7_6(void)            = ^IndirectReadSideEffect[p#0]    : &:r7_3, ~mu0_2
-#  731|     mu7_7(unknown)        = ^BufferMayWriteSideEffect[p#0]  : &:r7_3, ~mu0_2
+#  731|     v7_6(void)            = ^IndirectReadSideEffect         : &:r7_3, ~mu0_2
+#  731|     mu7_7(unknown)        = ^BufferMayWriteSideEffect       : &:r7_3, ~mu0_2
 #  731|     v7_8(void)            = ThrowValue                      : &:r7_0, ~mu0_2
 #-----|   Exception -> Block 9
 
@@ -3218,17 +3218,17 @@ ir.cpp:
 #-----|   Goto -> Block 10
 
 #  735|   Block 10
-#  735|     r10_0(glval<char *>)  = VariableAddress[s]             : 
-#  735|     mu10_1(char *)        = InitializeParameter[s]         : &:r10_0
-#  736|     r10_2(glval<String>)  = VariableAddress[#throw736:5]   : 
-#  736|     r10_3(glval<unknown>) = FunctionAddress[String]        : 
-#  736|     r10_4(glval<char *>)  = VariableAddress[s]             : 
-#  736|     r10_5(char *)         = Load                           : &:r10_4, ~mu0_2
-#  736|     v10_6(void)           = Call                           : func:r10_3, this:r10_2, 0:r10_5
-#  736|     mu10_7(unknown)       = ^CallSideEffect                : ~mu0_2
-#  736|     v10_8(void)           = ^IndirectReadSideEffect[p#0]   : &:r10_5, ~mu0_2
-#  736|     mu10_9(unknown)       = ^BufferMayWriteSideEffect[p#0] : &:r10_5, ~mu0_2
-#  736|     v10_10(void)          = ThrowValue                     : &:r10_2, ~mu0_2
+#  735|     r10_0(glval<char *>)  = VariableAddress[s]           : 
+#  735|     mu10_1(char *)        = InitializeParameter[s]       : &:r10_0
+#  736|     r10_2(glval<String>)  = VariableAddress[#throw736:5] : 
+#  736|     r10_3(glval<unknown>) = FunctionAddress[String]      : 
+#  736|     r10_4(glval<char *>)  = VariableAddress[s]           : 
+#  736|     r10_5(char *)         = Load                         : &:r10_4, ~mu0_2
+#  736|     v10_6(void)           = Call                         : func:r10_3, this:r10_2, 0:r10_5
+#  736|     mu10_7(unknown)       = ^CallSideEffect              : ~mu0_2
+#  736|     v10_8(void)           = ^IndirectReadSideEffect      : &:r10_5, ~mu0_2
+#  736|     mu10_9(unknown)       = ^BufferMayWriteSideEffect    : &:r10_5, ~mu0_2
+#  736|     v10_10(void)          = ThrowValue                   : &:r10_2, ~mu0_2
 #-----|   Exception -> Block 2
 
 #  738|   Block 11
@@ -3254,31 +3254,31 @@ ir.cpp:
 
 #  745| Base& Base::operator=(Base const&)
 #  745|   Block 0
-#  745|     v0_0(void)           = EnterFunction                  : 
-#  745|     mu0_1(unknown)       = AliasedDefinition              : 
-#  745|     mu0_2(unknown)       = UnmodeledDefinition            : 
-#  745|     r0_3(glval<Base>)    = InitializeThis                 : 
-#-----|     r0_4(glval<Base &>)  = VariableAddress[p#0]           : 
-#-----|     mu0_5(Base &)        = InitializeParameter[p#0]       : &:r0_4
-#-----|     r0_6(Base *)         = CopyValue                      : r0_3
-#-----|     r0_7(glval<String>)  = FieldAddress[base_s]           : r0_6
-#  745|     r0_8(glval<unknown>) = FunctionAddress[operator=]     : 
-#-----|     r0_9(glval<Base &>)  = VariableAddress[p#0]           : 
-#-----|     r0_10(Base &)        = Load                           : &:r0_9, ~mu0_2
-#-----|     r0_11(glval<String>) = FieldAddress[base_s]           : r0_10
-#  745|     r0_12(String &)      = Call                           : func:r0_8, this:r0_7, 0:r0_11
-#  745|     mu0_13(unknown)      = ^CallSideEffect                : ~mu0_2
-#-----|     v0_14(void)          = ^IndirectReadSideEffect        : &:r0_7, ~mu0_2
-#-----|     v0_15(void)          = ^IndirectReadSideEffect[p#0]   : &:r0_11, ~mu0_2
-#-----|     r0_16(String)        = ^IndirectMayWriteSideEffect    : &:r0_7, ~mu0_2
-#-----|     mu0_17(unknown)      = ^BufferMayWriteSideEffect[p#0] : &:r0_11, ~mu0_2
-#-----|     r0_18(glval<Base &>) = VariableAddress[#return]       : 
-#-----|     r0_19(Base *)        = CopyValue                      : r0_3
-#-----|     mu0_20(Base &)       = Store                          : &:r0_18, r0_19
-#  745|     r0_21(glval<Base &>) = VariableAddress[#return]       : 
-#  745|     v0_22(void)          = ReturnValue                    : &:r0_21, ~mu0_2
-#  745|     v0_23(void)          = UnmodeledUse                   : mu*
-#  745|     v0_24(void)          = ExitFunction                   : 
+#  745|     v0_0(void)           = EnterFunction               : 
+#  745|     mu0_1(unknown)       = AliasedDefinition           : 
+#  745|     mu0_2(unknown)       = UnmodeledDefinition         : 
+#  745|     r0_3(glval<Base>)    = InitializeThis              : 
+#-----|     r0_4(glval<Base &>)  = VariableAddress[p#0]        : 
+#-----|     mu0_5(Base &)        = InitializeParameter[p#0]    : &:r0_4
+#-----|     r0_6(Base *)         = CopyValue                   : r0_3
+#-----|     r0_7(glval<String>)  = FieldAddress[base_s]        : r0_6
+#  745|     r0_8(glval<unknown>) = FunctionAddress[operator=]  : 
+#-----|     r0_9(glval<Base &>)  = VariableAddress[p#0]        : 
+#-----|     r0_10(Base &)        = Load                        : &:r0_9, ~mu0_2
+#-----|     r0_11(glval<String>) = FieldAddress[base_s]        : r0_10
+#  745|     r0_12(String &)      = Call                        : func:r0_8, this:r0_7, 0:r0_11
+#  745|     mu0_13(unknown)      = ^CallSideEffect             : ~mu0_2
+#-----|     v0_14(void)          = ^IndirectReadSideEffect     : &:r0_7, ~mu0_2
+#-----|     v0_15(void)          = ^IndirectReadSideEffect     : &:r0_11, ~mu0_2
+#-----|     mu0_16(String)       = ^IndirectMayWriteSideEffect : &:r0_7, ~mu0_2
+#-----|     mu0_17(unknown)      = ^BufferMayWriteSideEffect   : &:r0_11, ~mu0_2
+#-----|     r0_18(glval<Base &>) = VariableAddress[#return]    : 
+#-----|     r0_19(Base *)        = CopyValue                   : r0_3
+#-----|     mu0_20(Base &)       = Store                       : &:r0_18, r0_19
+#  745|     r0_21(glval<Base &>) = VariableAddress[#return]    : 
+#  745|     v0_22(void)          = ReturnValue                 : &:r0_21, ~mu0_2
+#  745|     v0_23(void)          = UnmodeledUse                : mu*
+#  745|     v0_24(void)          = ExitFunction                : 
 
 #  745| void Base::Base(Base const&)
 #  745|   Block 0
@@ -3329,43 +3329,43 @@ ir.cpp:
 
 #  754| Middle& Middle::operator=(Middle const&)
 #  754|   Block 0
-#  754|     v0_0(void)             = EnterFunction                  : 
-#  754|     mu0_1(unknown)         = AliasedDefinition              : 
-#  754|     mu0_2(unknown)         = UnmodeledDefinition            : 
-#  754|     r0_3(glval<Middle>)    = InitializeThis                 : 
-#-----|     r0_4(glval<Middle &>)  = VariableAddress[p#0]           : 
-#-----|     mu0_5(Middle &)        = InitializeParameter[p#0]       : &:r0_4
-#-----|     r0_6(Middle *)         = CopyValue                      : r0_3
-#-----|     r0_7(Base *)           = ConvertToBase[Middle : Base]   : r0_6
-#  754|     r0_8(glval<unknown>)   = FunctionAddress[operator=]     : 
-#-----|     r0_9(glval<Middle &>)  = VariableAddress[p#0]           : 
-#-----|     r0_10(Middle &)        = Load                           : &:r0_9, ~mu0_2
-#-----|     r0_11(Base *)          = ConvertToBase[Middle : Base]   : r0_10
-#  754|     r0_12(Base &)          = Call                           : func:r0_8, this:r0_7, 0:r0_11
-#  754|     mu0_13(unknown)        = ^CallSideEffect                : ~mu0_2
-#-----|     v0_14(void)            = ^IndirectReadSideEffect        : &:r0_7, ~mu0_2
-#-----|     v0_15(void)            = ^IndirectReadSideEffect[p#0]   : &:r0_11, ~mu0_2
-#-----|     r0_16(Base)            = ^IndirectMayWriteSideEffect    : &:r0_7, ~mu0_2
-#-----|     mu0_17(unknown)        = ^BufferMayWriteSideEffect[p#0] : &:r0_11, ~mu0_2
-#-----|     r0_18(Middle *)        = CopyValue                      : r0_3
-#-----|     r0_19(glval<String>)   = FieldAddress[middle_s]         : r0_18
-#  754|     r0_20(glval<unknown>)  = FunctionAddress[operator=]     : 
-#-----|     r0_21(glval<Middle &>) = VariableAddress[p#0]           : 
-#-----|     r0_22(Middle &)        = Load                           : &:r0_21, ~mu0_2
-#-----|     r0_23(glval<String>)   = FieldAddress[middle_s]         : r0_22
-#  754|     r0_24(String &)        = Call                           : func:r0_20, this:r0_19, 0:r0_23
-#  754|     mu0_25(unknown)        = ^CallSideEffect                : ~mu0_2
-#-----|     v0_26(void)            = ^IndirectReadSideEffect        : &:r0_19, ~mu0_2
-#-----|     v0_27(void)            = ^IndirectReadSideEffect[p#0]   : &:r0_23, ~mu0_2
-#-----|     r0_28(String)          = ^IndirectMayWriteSideEffect    : &:r0_19, ~mu0_2
-#-----|     mu0_29(unknown)        = ^BufferMayWriteSideEffect[p#0] : &:r0_23, ~mu0_2
-#-----|     r0_30(glval<Middle &>) = VariableAddress[#return]       : 
-#-----|     r0_31(Middle *)        = CopyValue                      : r0_3
-#-----|     mu0_32(Middle &)       = Store                          : &:r0_30, r0_31
-#  754|     r0_33(glval<Middle &>) = VariableAddress[#return]       : 
-#  754|     v0_34(void)            = ReturnValue                    : &:r0_33, ~mu0_2
-#  754|     v0_35(void)            = UnmodeledUse                   : mu*
-#  754|     v0_36(void)            = ExitFunction                   : 
+#  754|     v0_0(void)             = EnterFunction                : 
+#  754|     mu0_1(unknown)         = AliasedDefinition            : 
+#  754|     mu0_2(unknown)         = UnmodeledDefinition          : 
+#  754|     r0_3(glval<Middle>)    = InitializeThis               : 
+#-----|     r0_4(glval<Middle &>)  = VariableAddress[p#0]         : 
+#-----|     mu0_5(Middle &)        = InitializeParameter[p#0]     : &:r0_4
+#-----|     r0_6(Middle *)         = CopyValue                    : r0_3
+#-----|     r0_7(Base *)           = ConvertToBase[Middle : Base] : r0_6
+#  754|     r0_8(glval<unknown>)   = FunctionAddress[operator=]   : 
+#-----|     r0_9(glval<Middle &>)  = VariableAddress[p#0]         : 
+#-----|     r0_10(Middle &)        = Load                         : &:r0_9, ~mu0_2
+#-----|     r0_11(Base *)          = ConvertToBase[Middle : Base] : r0_10
+#  754|     r0_12(Base &)          = Call                         : func:r0_8, this:r0_7, 0:r0_11
+#  754|     mu0_13(unknown)        = ^CallSideEffect              : ~mu0_2
+#-----|     v0_14(void)            = ^IndirectReadSideEffect      : &:r0_7, ~mu0_2
+#-----|     v0_15(void)            = ^IndirectReadSideEffect      : &:r0_11, ~mu0_2
+#-----|     mu0_16(Base)           = ^IndirectMayWriteSideEffect  : &:r0_7, ~mu0_2
+#-----|     mu0_17(unknown)        = ^BufferMayWriteSideEffect    : &:r0_11, ~mu0_2
+#-----|     r0_18(Middle *)        = CopyValue                    : r0_3
+#-----|     r0_19(glval<String>)   = FieldAddress[middle_s]       : r0_18
+#  754|     r0_20(glval<unknown>)  = FunctionAddress[operator=]   : 
+#-----|     r0_21(glval<Middle &>) = VariableAddress[p#0]         : 
+#-----|     r0_22(Middle &)        = Load                         : &:r0_21, ~mu0_2
+#-----|     r0_23(glval<String>)   = FieldAddress[middle_s]       : r0_22
+#  754|     r0_24(String &)        = Call                         : func:r0_20, this:r0_19, 0:r0_23
+#  754|     mu0_25(unknown)        = ^CallSideEffect              : ~mu0_2
+#-----|     v0_26(void)            = ^IndirectReadSideEffect      : &:r0_19, ~mu0_2
+#-----|     v0_27(void)            = ^IndirectReadSideEffect      : &:r0_23, ~mu0_2
+#-----|     mu0_28(String)         = ^IndirectMayWriteSideEffect  : &:r0_19, ~mu0_2
+#-----|     mu0_29(unknown)        = ^BufferMayWriteSideEffect    : &:r0_23, ~mu0_2
+#-----|     r0_30(glval<Middle &>) = VariableAddress[#return]     : 
+#-----|     r0_31(Middle *)        = CopyValue                    : r0_3
+#-----|     mu0_32(Middle &)       = Store                        : &:r0_30, r0_31
+#  754|     r0_33(glval<Middle &>) = VariableAddress[#return]     : 
+#  754|     v0_34(void)            = ReturnValue                  : &:r0_33, ~mu0_2
+#  754|     v0_35(void)            = UnmodeledUse                 : mu*
+#  754|     v0_36(void)            = ExitFunction                 : 
 
 #  757| void Middle::Middle()
 #  757|   Block 0
@@ -3422,9 +3422,9 @@ ir.cpp:
 #  763|     r0_12(Middle &)         = Call                            : func:r0_8, this:r0_7, 0:r0_11
 #  763|     mu0_13(unknown)         = ^CallSideEffect                 : ~mu0_2
 #-----|     v0_14(void)             = ^IndirectReadSideEffect         : &:r0_7, ~mu0_2
-#-----|     v0_15(void)             = ^IndirectReadSideEffect[p#0]    : &:r0_11, ~mu0_2
-#-----|     r0_16(Middle)           = ^IndirectMayWriteSideEffect     : &:r0_7, ~mu0_2
-#-----|     mu0_17(unknown)         = ^BufferMayWriteSideEffect[p#0]  : &:r0_11, ~mu0_2
+#-----|     v0_15(void)             = ^IndirectReadSideEffect         : &:r0_11, ~mu0_2
+#-----|     mu0_16(Middle)          = ^IndirectMayWriteSideEffect     : &:r0_7, ~mu0_2
+#-----|     mu0_17(unknown)         = ^BufferMayWriteSideEffect       : &:r0_11, ~mu0_2
 #-----|     r0_18(Derived *)        = CopyValue                       : r0_3
 #-----|     r0_19(glval<String>)    = FieldAddress[derived_s]         : r0_18
 #  763|     r0_20(glval<unknown>)   = FunctionAddress[operator=]      : 
@@ -3434,9 +3434,9 @@ ir.cpp:
 #  763|     r0_24(String &)         = Call                            : func:r0_20, this:r0_19, 0:r0_23
 #  763|     mu0_25(unknown)         = ^CallSideEffect                 : ~mu0_2
 #-----|     v0_26(void)             = ^IndirectReadSideEffect         : &:r0_19, ~mu0_2
-#-----|     v0_27(void)             = ^IndirectReadSideEffect[p#0]    : &:r0_23, ~mu0_2
-#-----|     r0_28(String)           = ^IndirectMayWriteSideEffect     : &:r0_19, ~mu0_2
-#-----|     mu0_29(unknown)         = ^BufferMayWriteSideEffect[p#0]  : &:r0_23, ~mu0_2
+#-----|     v0_27(void)             = ^IndirectReadSideEffect         : &:r0_23, ~mu0_2
+#-----|     mu0_28(String)          = ^IndirectMayWriteSideEffect     : &:r0_19, ~mu0_2
+#-----|     mu0_29(unknown)         = ^BufferMayWriteSideEffect       : &:r0_23, ~mu0_2
 #-----|     r0_30(glval<Derived &>) = VariableAddress[#return]        : 
 #-----|     r0_31(Derived *)        = CopyValue                       : r0_3
 #-----|     mu0_32(Derived &)       = Store                           : &:r0_30, r0_31
@@ -3646,9 +3646,9 @@ ir.cpp:
 #  808|     r0_28(Base &)              = Call                                   : func:r0_25, this:r0_24, 0:r0_27
 #  808|     mu0_29(unknown)            = ^CallSideEffect                        : ~mu0_2
 #  808|     v0_30(void)                = ^IndirectReadSideEffect                : &:r0_24, ~mu0_2
-#  808|     v0_31(void)                = ^IndirectReadSideEffect[p#0]           : &:r0_27, ~mu0_2
-#  808|     r0_32(Base)                = ^IndirectMayWriteSideEffect            : &:r0_24, ~mu0_2
-#  808|     mu0_33(unknown)            = ^BufferMayWriteSideEffect[p#0]         : &:r0_27, ~mu0_2
+#  808|     v0_31(void)                = ^IndirectReadSideEffect                : &:r0_27, ~mu0_2
+#  808|     mu0_32(Base)               = ^IndirectMayWriteSideEffect            : &:r0_24, ~mu0_2
+#  808|     mu0_33(unknown)            = ^BufferMayWriteSideEffect              : &:r0_27, ~mu0_2
 #  809|     r0_34(glval<Base>)         = VariableAddress[b]                     : 
 #  809|     r0_35(glval<unknown>)      = FunctionAddress[operator=]             : 
 #  809|     r0_36(glval<unknown>)      = FunctionAddress[Base]                  : 
@@ -3656,15 +3656,15 @@ ir.cpp:
 #  809|     r0_38(glval<Base>)         = ConvertToBase[Middle : Base]           : r0_37
 #  809|     v0_39(void)                = Call                                   : func:r0_36, 0:r0_38
 #  809|     mu0_40(unknown)            = ^CallSideEffect                        : ~mu0_2
-#  809|     v0_41(void)                = ^IndirectReadSideEffect[p#0]           : &:r0_38, ~mu0_2
-#  809|     mu0_42(unknown)            = ^BufferMayWriteSideEffect[p#0]         : &:r0_38, ~mu0_2
+#  809|     v0_41(void)                = ^IndirectReadSideEffect                : &:r0_38, ~mu0_2
+#  809|     mu0_42(unknown)            = ^BufferMayWriteSideEffect              : &:r0_38, ~mu0_2
 #  809|     r0_43(glval<Base>)         = Convert                                : v0_39
 #  809|     r0_44(Base &)              = Call                                   : func:r0_35, this:r0_34, 0:r0_43
 #  809|     mu0_45(unknown)            = ^CallSideEffect                        : ~mu0_2
 #  809|     v0_46(void)                = ^IndirectReadSideEffect                : &:r0_34, ~mu0_2
-#  809|     v0_47(void)                = ^IndirectReadSideEffect[p#0]           : &:r0_43, ~mu0_2
-#  809|     r0_48(Base)                = ^IndirectMayWriteSideEffect            : &:r0_34, ~mu0_2
-#  809|     mu0_49(unknown)            = ^BufferMayWriteSideEffect[p#0]         : &:r0_43, ~mu0_2
+#  809|     v0_47(void)                = ^IndirectReadSideEffect                : &:r0_43, ~mu0_2
+#  809|     mu0_48(Base)               = ^IndirectMayWriteSideEffect            : &:r0_34, ~mu0_2
+#  809|     mu0_49(unknown)            = ^BufferMayWriteSideEffect              : &:r0_43, ~mu0_2
 #  810|     r0_50(glval<Base>)         = VariableAddress[b]                     : 
 #  810|     r0_51(glval<unknown>)      = FunctionAddress[operator=]             : 
 #  810|     r0_52(glval<unknown>)      = FunctionAddress[Base]                  : 
@@ -3672,15 +3672,15 @@ ir.cpp:
 #  810|     r0_54(glval<Base>)         = ConvertToBase[Middle : Base]           : r0_53
 #  810|     v0_55(void)                = Call                                   : func:r0_52, 0:r0_54
 #  810|     mu0_56(unknown)            = ^CallSideEffect                        : ~mu0_2
-#  810|     v0_57(void)                = ^IndirectReadSideEffect[p#0]           : &:r0_54, ~mu0_2
-#  810|     mu0_58(unknown)            = ^BufferMayWriteSideEffect[p#0]         : &:r0_54, ~mu0_2
+#  810|     v0_57(void)                = ^IndirectReadSideEffect                : &:r0_54, ~mu0_2
+#  810|     mu0_58(unknown)            = ^BufferMayWriteSideEffect              : &:r0_54, ~mu0_2
 #  810|     r0_59(glval<Base>)         = Convert                                : v0_55
 #  810|     r0_60(Base &)              = Call                                   : func:r0_51, this:r0_50, 0:r0_59
 #  810|     mu0_61(unknown)            = ^CallSideEffect                        : ~mu0_2
 #  810|     v0_62(void)                = ^IndirectReadSideEffect                : &:r0_50, ~mu0_2
-#  810|     v0_63(void)                = ^IndirectReadSideEffect[p#0]           : &:r0_59, ~mu0_2
-#  810|     r0_64(Base)                = ^IndirectMayWriteSideEffect            : &:r0_50, ~mu0_2
-#  810|     mu0_65(unknown)            = ^BufferMayWriteSideEffect[p#0]         : &:r0_59, ~mu0_2
+#  810|     v0_63(void)                = ^IndirectReadSideEffect                : &:r0_59, ~mu0_2
+#  810|     mu0_64(Base)               = ^IndirectMayWriteSideEffect            : &:r0_50, ~mu0_2
+#  810|     mu0_65(unknown)            = ^BufferMayWriteSideEffect              : &:r0_59, ~mu0_2
 #  811|     r0_66(glval<Middle *>)     = VariableAddress[pm]                    : 
 #  811|     r0_67(Middle *)            = Load                                   : &:r0_66, ~mu0_2
 #  811|     r0_68(Base *)              = ConvertToBase[Middle : Base]           : r0_67
@@ -3709,9 +3709,9 @@ ir.cpp:
 #  816|     r0_91(Middle &)            = Call                                   : func:r0_87, this:r0_86, 0:r0_90
 #  816|     mu0_92(unknown)            = ^CallSideEffect                        : ~mu0_2
 #  816|     v0_93(void)                = ^IndirectReadSideEffect                : &:r0_86, ~mu0_2
-#  816|     v0_94(void)                = ^IndirectReadSideEffect[p#0]           : &:r0_90, ~mu0_2
-#  816|     r0_95(Middle)              = ^IndirectMayWriteSideEffect            : &:r0_86, ~mu0_2
-#  816|     mu0_96(unknown)            = ^BufferMayWriteSideEffect[p#0]         : &:r0_90, ~mu0_2
+#  816|     v0_94(void)                = ^IndirectReadSideEffect                : &:r0_90, ~mu0_2
+#  816|     mu0_95(Middle)             = ^IndirectMayWriteSideEffect            : &:r0_86, ~mu0_2
+#  816|     mu0_96(unknown)            = ^BufferMayWriteSideEffect              : &:r0_90, ~mu0_2
 #  817|     r0_97(glval<Middle>)       = VariableAddress[m]                     : 
 #  817|     r0_98(glval<unknown>)      = FunctionAddress[operator=]             : 
 #  817|     r0_99(glval<Base>)         = VariableAddress[b]                     : 
@@ -3720,9 +3720,9 @@ ir.cpp:
 #  817|     r0_102(Middle &)           = Call                                   : func:r0_98, this:r0_97, 0:r0_101
 #  817|     mu0_103(unknown)           = ^CallSideEffect                        : ~mu0_2
 #  817|     v0_104(void)               = ^IndirectReadSideEffect                : &:r0_97, ~mu0_2
-#  817|     v0_105(void)               = ^IndirectReadSideEffect[p#0]           : &:r0_101, ~mu0_2
-#  817|     r0_106(Middle)             = ^IndirectMayWriteSideEffect            : &:r0_97, ~mu0_2
-#  817|     mu0_107(unknown)           = ^BufferMayWriteSideEffect[p#0]         : &:r0_101, ~mu0_2
+#  817|     v0_105(void)               = ^IndirectReadSideEffect                : &:r0_101, ~mu0_2
+#  817|     mu0_106(Middle)            = ^IndirectMayWriteSideEffect            : &:r0_97, ~mu0_2
+#  817|     mu0_107(unknown)           = ^BufferMayWriteSideEffect              : &:r0_101, ~mu0_2
 #  818|     r0_108(glval<Base *>)      = VariableAddress[pb]                    : 
 #  818|     r0_109(Base *)             = Load                                   : &:r0_108, ~mu0_2
 #  818|     r0_110(Middle *)           = ConvertToDerived[Middle : Base]        : r0_109
@@ -3746,9 +3746,9 @@ ir.cpp:
 #  822|     r0_128(Base &)             = Call                                   : func:r0_124, this:r0_123, 0:r0_127
 #  822|     mu0_129(unknown)           = ^CallSideEffect                        : ~mu0_2
 #  822|     v0_130(void)               = ^IndirectReadSideEffect                : &:r0_123, ~mu0_2
-#  822|     v0_131(void)               = ^IndirectReadSideEffect[p#0]           : &:r0_127, ~mu0_2
-#  822|     r0_132(Base)               = ^IndirectMayWriteSideEffect            : &:r0_123, ~mu0_2
-#  822|     mu0_133(unknown)           = ^BufferMayWriteSideEffect[p#0]         : &:r0_127, ~mu0_2
+#  822|     v0_131(void)               = ^IndirectReadSideEffect                : &:r0_127, ~mu0_2
+#  822|     mu0_132(Base)              = ^IndirectMayWriteSideEffect            : &:r0_123, ~mu0_2
+#  822|     mu0_133(unknown)           = ^BufferMayWriteSideEffect              : &:r0_127, ~mu0_2
 #  823|     r0_134(glval<Base>)        = VariableAddress[b]                     : 
 #  823|     r0_135(glval<unknown>)     = FunctionAddress[operator=]             : 
 #  823|     r0_136(glval<unknown>)     = FunctionAddress[Base]                  : 
@@ -3757,15 +3757,15 @@ ir.cpp:
 #  823|     r0_139(glval<Base>)        = ConvertToBase[Middle : Base]           : r0_138
 #  823|     v0_140(void)               = Call                                   : func:r0_136, 0:r0_139
 #  823|     mu0_141(unknown)           = ^CallSideEffect                        : ~mu0_2
-#  823|     v0_142(void)               = ^IndirectReadSideEffect[p#0]           : &:r0_139, ~mu0_2
-#  823|     mu0_143(unknown)           = ^BufferMayWriteSideEffect[p#0]         : &:r0_139, ~mu0_2
+#  823|     v0_142(void)               = ^IndirectReadSideEffect                : &:r0_139, ~mu0_2
+#  823|     mu0_143(unknown)           = ^BufferMayWriteSideEffect              : &:r0_139, ~mu0_2
 #  823|     r0_144(glval<Base>)        = Convert                                : v0_140
 #  823|     r0_145(Base &)             = Call                                   : func:r0_135, this:r0_134, 0:r0_144
 #  823|     mu0_146(unknown)           = ^CallSideEffect                        : ~mu0_2
 #  823|     v0_147(void)               = ^IndirectReadSideEffect                : &:r0_134, ~mu0_2
-#  823|     v0_148(void)               = ^IndirectReadSideEffect[p#0]           : &:r0_144, ~mu0_2
-#  823|     r0_149(Base)               = ^IndirectMayWriteSideEffect            : &:r0_134, ~mu0_2
-#  823|     mu0_150(unknown)           = ^BufferMayWriteSideEffect[p#0]         : &:r0_144, ~mu0_2
+#  823|     v0_148(void)               = ^IndirectReadSideEffect                : &:r0_144, ~mu0_2
+#  823|     mu0_149(Base)              = ^IndirectMayWriteSideEffect            : &:r0_134, ~mu0_2
+#  823|     mu0_150(unknown)           = ^BufferMayWriteSideEffect              : &:r0_144, ~mu0_2
 #  824|     r0_151(glval<Base>)        = VariableAddress[b]                     : 
 #  824|     r0_152(glval<unknown>)     = FunctionAddress[operator=]             : 
 #  824|     r0_153(glval<unknown>)     = FunctionAddress[Base]                  : 
@@ -3774,15 +3774,15 @@ ir.cpp:
 #  824|     r0_156(glval<Base>)        = ConvertToBase[Middle : Base]           : r0_155
 #  824|     v0_157(void)               = Call                                   : func:r0_153, 0:r0_156
 #  824|     mu0_158(unknown)           = ^CallSideEffect                        : ~mu0_2
-#  824|     v0_159(void)               = ^IndirectReadSideEffect[p#0]           : &:r0_156, ~mu0_2
-#  824|     mu0_160(unknown)           = ^BufferMayWriteSideEffect[p#0]         : &:r0_156, ~mu0_2
+#  824|     v0_159(void)               = ^IndirectReadSideEffect                : &:r0_156, ~mu0_2
+#  824|     mu0_160(unknown)           = ^BufferMayWriteSideEffect              : &:r0_156, ~mu0_2
 #  824|     r0_161(glval<Base>)        = Convert                                : v0_157
 #  824|     r0_162(Base &)             = Call                                   : func:r0_152, this:r0_151, 0:r0_161
 #  824|     mu0_163(unknown)           = ^CallSideEffect                        : ~mu0_2
 #  824|     v0_164(void)               = ^IndirectReadSideEffect                : &:r0_151, ~mu0_2
-#  824|     v0_165(void)               = ^IndirectReadSideEffect[p#0]           : &:r0_161, ~mu0_2
-#  824|     r0_166(Base)               = ^IndirectMayWriteSideEffect            : &:r0_151, ~mu0_2
-#  824|     mu0_167(unknown)           = ^BufferMayWriteSideEffect[p#0]         : &:r0_161, ~mu0_2
+#  824|     v0_165(void)               = ^IndirectReadSideEffect                : &:r0_161, ~mu0_2
+#  824|     mu0_166(Base)              = ^IndirectMayWriteSideEffect            : &:r0_151, ~mu0_2
+#  824|     mu0_167(unknown)           = ^BufferMayWriteSideEffect              : &:r0_161, ~mu0_2
 #  825|     r0_168(glval<Derived *>)   = VariableAddress[pd]                    : 
 #  825|     r0_169(Derived *)          = Load                                   : &:r0_168, ~mu0_2
 #  825|     r0_170(Middle *)           = ConvertToBase[Derived : Middle]        : r0_169
@@ -3815,9 +3815,9 @@ ir.cpp:
 #  830|     r0_197(Derived &)          = Call                                   : func:r0_192, this:r0_191, 0:r0_196
 #  830|     mu0_198(unknown)           = ^CallSideEffect                        : ~mu0_2
 #  830|     v0_199(void)               = ^IndirectReadSideEffect                : &:r0_191, ~mu0_2
-#  830|     v0_200(void)               = ^IndirectReadSideEffect[p#0]           : &:r0_196, ~mu0_2
-#  830|     r0_201(Derived)            = ^IndirectMayWriteSideEffect            : &:r0_191, ~mu0_2
-#  830|     mu0_202(unknown)           = ^BufferMayWriteSideEffect[p#0]         : &:r0_196, ~mu0_2
+#  830|     v0_200(void)               = ^IndirectReadSideEffect                : &:r0_196, ~mu0_2
+#  830|     mu0_201(Derived)           = ^IndirectMayWriteSideEffect            : &:r0_191, ~mu0_2
+#  830|     mu0_202(unknown)           = ^BufferMayWriteSideEffect              : &:r0_196, ~mu0_2
 #  831|     r0_203(glval<Derived>)     = VariableAddress[d]                     : 
 #  831|     r0_204(glval<unknown>)     = FunctionAddress[operator=]             : 
 #  831|     r0_205(glval<Base>)        = VariableAddress[b]                     : 
@@ -3827,9 +3827,9 @@ ir.cpp:
 #  831|     r0_209(Derived &)          = Call                                   : func:r0_204, this:r0_203, 0:r0_208
 #  831|     mu0_210(unknown)           = ^CallSideEffect                        : ~mu0_2
 #  831|     v0_211(void)               = ^IndirectReadSideEffect                : &:r0_203, ~mu0_2
-#  831|     v0_212(void)               = ^IndirectReadSideEffect[p#0]           : &:r0_208, ~mu0_2
-#  831|     r0_213(Derived)            = ^IndirectMayWriteSideEffect            : &:r0_203, ~mu0_2
-#  831|     mu0_214(unknown)           = ^BufferMayWriteSideEffect[p#0]         : &:r0_208, ~mu0_2
+#  831|     v0_212(void)               = ^IndirectReadSideEffect                : &:r0_208, ~mu0_2
+#  831|     mu0_213(Derived)           = ^IndirectMayWriteSideEffect            : &:r0_203, ~mu0_2
+#  831|     mu0_214(unknown)           = ^BufferMayWriteSideEffect              : &:r0_208, ~mu0_2
 #  832|     r0_215(glval<Base *>)      = VariableAddress[pb]                    : 
 #  832|     r0_216(Base *)             = Load                                   : &:r0_215, ~mu0_2
 #  832|     r0_217(Middle *)           = ConvertToDerived[Middle : Base]        : r0_216
@@ -3963,21 +3963,21 @@ ir.cpp:
 
 #  867| void String::String()
 #  867|   Block 0
-#  867|     v0_0(void)           = EnterFunction                  : 
-#  867|     mu0_1(unknown)       = AliasedDefinition              : 
-#  867|     mu0_2(unknown)       = UnmodeledDefinition            : 
-#  867|     r0_3(glval<String>)  = InitializeThis                 : 
-#  868|     r0_4(glval<unknown>) = FunctionAddress[String]        : 
-#  868|     r0_5(glval<char[1]>) = StringConstant[""]             : 
-#  868|     r0_6(char *)         = Convert                        : r0_5
-#  868|     v0_7(void)           = Call                           : func:r0_4, this:r0_3, 0:r0_6
-#  868|     mu0_8(unknown)       = ^CallSideEffect                : ~mu0_2
-#  868|     v0_9(void)           = ^IndirectReadSideEffect[p#0]   : &:r0_6, ~mu0_2
-#  868|     mu0_10(unknown)      = ^BufferMayWriteSideEffect[p#0] : &:r0_6, ~mu0_2
-#  869|     v0_11(void)          = NoOp                           : 
-#  867|     v0_12(void)          = ReturnVoid                     : 
-#  867|     v0_13(void)          = UnmodeledUse                   : mu*
-#  867|     v0_14(void)          = ExitFunction                   : 
+#  867|     v0_0(void)           = EnterFunction             : 
+#  867|     mu0_1(unknown)       = AliasedDefinition         : 
+#  867|     mu0_2(unknown)       = UnmodeledDefinition       : 
+#  867|     r0_3(glval<String>)  = InitializeThis            : 
+#  868|     r0_4(glval<unknown>) = FunctionAddress[String]   : 
+#  868|     r0_5(glval<char[1]>) = StringConstant[""]        : 
+#  868|     r0_6(char *)         = Convert                   : r0_5
+#  868|     v0_7(void)           = Call                      : func:r0_4, this:r0_3, 0:r0_6
+#  868|     mu0_8(unknown)       = ^CallSideEffect           : ~mu0_2
+#  868|     v0_9(void)           = ^IndirectReadSideEffect   : &:r0_6, ~mu0_2
+#  868|     mu0_10(unknown)      = ^BufferMayWriteSideEffect : &:r0_6, ~mu0_2
+#  869|     v0_11(void)          = NoOp                      : 
+#  867|     v0_12(void)          = ReturnVoid                : 
+#  867|     v0_13(void)          = UnmodeledUse              : mu*
+#  867|     v0_14(void)          = ExitFunction              : 
 
 #  871| void ArrayConversions()
 #  871|   Block 0
@@ -4149,67 +4149,67 @@ ir.cpp:
 
 #  940| void OperatorNew()
 #  940|   Block 0
-#  940|     v0_0(void)            = EnterFunction                  : 
-#  940|     mu0_1(unknown)        = AliasedDefinition              : 
-#  940|     mu0_2(unknown)        = UnmodeledDefinition            : 
-#  941|     r0_3(glval<unknown>)  = FunctionAddress[operator new]  : 
-#  941|     r0_4(unsigned long)   = Constant[4]                    : 
-#  941|     r0_5(void *)          = Call                           : func:r0_3, 0:r0_4
-#  941|     mu0_6(unknown)        = ^CallSideEffect                : ~mu0_2
-#  941|     r0_7(int *)           = Convert                        : r0_5
-#  942|     r0_8(glval<unknown>)  = FunctionAddress[operator new]  : 
-#  942|     r0_9(unsigned long)   = Constant[4]                    : 
-#  942|     r0_10(float)          = Constant[1.0]                  : 
-#  942|     r0_11(void *)         = Call                           : func:r0_8, 0:r0_9, 1:r0_10
-#  942|     mu0_12(unknown)       = ^CallSideEffect                : ~mu0_2
-#  942|     r0_13(int *)          = Convert                        : r0_11
-#  943|     r0_14(glval<unknown>) = FunctionAddress[operator new]  : 
-#  943|     r0_15(unsigned long)  = Constant[4]                    : 
-#  943|     r0_16(void *)         = Call                           : func:r0_14, 0:r0_15
-#  943|     mu0_17(unknown)       = ^CallSideEffect                : ~mu0_2
-#  943|     r0_18(int *)          = Convert                        : r0_16
-#  943|     r0_19(int)            = Constant[0]                    : 
-#  943|     mu0_20(int)           = Store                          : &:r0_18, r0_19
-#  944|     r0_21(glval<unknown>) = FunctionAddress[operator new]  : 
-#  944|     r0_22(unsigned long)  = Constant[8]                    : 
-#  944|     r0_23(void *)         = Call                           : func:r0_21, 0:r0_22
-#  944|     mu0_24(unknown)       = ^CallSideEffect                : ~mu0_2
-#  944|     r0_25(String *)       = Convert                        : r0_23
-#  944|     r0_26(glval<unknown>) = FunctionAddress[String]        : 
-#  944|     v0_27(void)           = Call                           : func:r0_26, this:r0_25
-#  944|     mu0_28(unknown)       = ^CallSideEffect                : ~mu0_2
-#  945|     r0_29(glval<unknown>) = FunctionAddress[operator new]  : 
-#  945|     r0_30(unsigned long)  = Constant[8]                    : 
-#  945|     r0_31(float)          = Constant[1.0]                  : 
-#  945|     r0_32(void *)         = Call                           : func:r0_29, 0:r0_30, 1:r0_31
-#  945|     mu0_33(unknown)       = ^CallSideEffect                : ~mu0_2
-#  945|     r0_34(String *)       = Convert                        : r0_32
-#  945|     r0_35(glval<unknown>) = FunctionAddress[String]        : 
-#  945|     r0_36(glval<char[6]>) = StringConstant["hello"]        : 
-#  945|     r0_37(char *)         = Convert                        : r0_36
-#  945|     v0_38(void)           = Call                           : func:r0_35, this:r0_34, 0:r0_37
-#  945|     mu0_39(unknown)       = ^CallSideEffect                : ~mu0_2
-#  945|     v0_40(void)           = ^IndirectReadSideEffect[p#0]   : &:r0_37, ~mu0_2
-#  945|     mu0_41(unknown)       = ^BufferMayWriteSideEffect[p#0] : &:r0_37, ~mu0_2
-#  946|     r0_42(glval<unknown>) = FunctionAddress[operator new]  : 
-#  946|     r0_43(unsigned long)  = Constant[256]                  : 
-#  946|     r0_44(align_val_t)    = Constant[128]                  : 
-#  946|     r0_45(void *)         = Call                           : func:r0_42, 0:r0_43, 1:r0_44
-#  946|     mu0_46(unknown)       = ^CallSideEffect                : ~mu0_2
-#  946|     r0_47(Overaligned *)  = Convert                        : r0_45
-#  947|     r0_48(glval<unknown>) = FunctionAddress[operator new]  : 
-#  947|     r0_49(unsigned long)  = Constant[256]                  : 
-#  947|     r0_50(align_val_t)    = Constant[128]                  : 
-#  947|     r0_51(float)          = Constant[1.0]                  : 
-#  947|     r0_52(void *)         = Call                           : func:r0_48, 0:r0_49, 1:r0_50, 2:r0_51
-#  947|     mu0_53(unknown)       = ^CallSideEffect                : ~mu0_2
-#  947|     r0_54(Overaligned *)  = Convert                        : r0_52
-#  947|     r0_55(Overaligned)    = Constant[0]                    : 
-#  947|     mu0_56(Overaligned)   = Store                          : &:r0_54, r0_55
-#  948|     v0_57(void)           = NoOp                           : 
-#  940|     v0_58(void)           = ReturnVoid                     : 
-#  940|     v0_59(void)           = UnmodeledUse                   : mu*
-#  940|     v0_60(void)           = ExitFunction                   : 
+#  940|     v0_0(void)            = EnterFunction                 : 
+#  940|     mu0_1(unknown)        = AliasedDefinition             : 
+#  940|     mu0_2(unknown)        = UnmodeledDefinition           : 
+#  941|     r0_3(glval<unknown>)  = FunctionAddress[operator new] : 
+#  941|     r0_4(unsigned long)   = Constant[4]                   : 
+#  941|     r0_5(void *)          = Call                          : func:r0_3, 0:r0_4
+#  941|     mu0_6(unknown)        = ^CallSideEffect               : ~mu0_2
+#  941|     r0_7(int *)           = Convert                       : r0_5
+#  942|     r0_8(glval<unknown>)  = FunctionAddress[operator new] : 
+#  942|     r0_9(unsigned long)   = Constant[4]                   : 
+#  942|     r0_10(float)          = Constant[1.0]                 : 
+#  942|     r0_11(void *)         = Call                          : func:r0_8, 0:r0_9, 1:r0_10
+#  942|     mu0_12(unknown)       = ^CallSideEffect               : ~mu0_2
+#  942|     r0_13(int *)          = Convert                       : r0_11
+#  943|     r0_14(glval<unknown>) = FunctionAddress[operator new] : 
+#  943|     r0_15(unsigned long)  = Constant[4]                   : 
+#  943|     r0_16(void *)         = Call                          : func:r0_14, 0:r0_15
+#  943|     mu0_17(unknown)       = ^CallSideEffect               : ~mu0_2
+#  943|     r0_18(int *)          = Convert                       : r0_16
+#  943|     r0_19(int)            = Constant[0]                   : 
+#  943|     mu0_20(int)           = Store                         : &:r0_18, r0_19
+#  944|     r0_21(glval<unknown>) = FunctionAddress[operator new] : 
+#  944|     r0_22(unsigned long)  = Constant[8]                   : 
+#  944|     r0_23(void *)         = Call                          : func:r0_21, 0:r0_22
+#  944|     mu0_24(unknown)       = ^CallSideEffect               : ~mu0_2
+#  944|     r0_25(String *)       = Convert                       : r0_23
+#  944|     r0_26(glval<unknown>) = FunctionAddress[String]       : 
+#  944|     v0_27(void)           = Call                          : func:r0_26, this:r0_25
+#  944|     mu0_28(unknown)       = ^CallSideEffect               : ~mu0_2
+#  945|     r0_29(glval<unknown>) = FunctionAddress[operator new] : 
+#  945|     r0_30(unsigned long)  = Constant[8]                   : 
+#  945|     r0_31(float)          = Constant[1.0]                 : 
+#  945|     r0_32(void *)         = Call                          : func:r0_29, 0:r0_30, 1:r0_31
+#  945|     mu0_33(unknown)       = ^CallSideEffect               : ~mu0_2
+#  945|     r0_34(String *)       = Convert                       : r0_32
+#  945|     r0_35(glval<unknown>) = FunctionAddress[String]       : 
+#  945|     r0_36(glval<char[6]>) = StringConstant["hello"]       : 
+#  945|     r0_37(char *)         = Convert                       : r0_36
+#  945|     v0_38(void)           = Call                          : func:r0_35, this:r0_34, 0:r0_37
+#  945|     mu0_39(unknown)       = ^CallSideEffect               : ~mu0_2
+#  945|     v0_40(void)           = ^IndirectReadSideEffect       : &:r0_37, ~mu0_2
+#  945|     mu0_41(unknown)       = ^BufferMayWriteSideEffect     : &:r0_37, ~mu0_2
+#  946|     r0_42(glval<unknown>) = FunctionAddress[operator new] : 
+#  946|     r0_43(unsigned long)  = Constant[256]                 : 
+#  946|     r0_44(align_val_t)    = Constant[128]                 : 
+#  946|     r0_45(void *)         = Call                          : func:r0_42, 0:r0_43, 1:r0_44
+#  946|     mu0_46(unknown)       = ^CallSideEffect               : ~mu0_2
+#  946|     r0_47(Overaligned *)  = Convert                       : r0_45
+#  947|     r0_48(glval<unknown>) = FunctionAddress[operator new] : 
+#  947|     r0_49(unsigned long)  = Constant[256]                 : 
+#  947|     r0_50(align_val_t)    = Constant[128]                 : 
+#  947|     r0_51(float)          = Constant[1.0]                 : 
+#  947|     r0_52(void *)         = Call                          : func:r0_48, 0:r0_49, 1:r0_50, 2:r0_51
+#  947|     mu0_53(unknown)       = ^CallSideEffect               : ~mu0_2
+#  947|     r0_54(Overaligned *)  = Convert                       : r0_52
+#  947|     r0_55(Overaligned)    = Constant[0]                   : 
+#  947|     mu0_56(Overaligned)   = Store                         : &:r0_54, r0_55
+#  948|     v0_57(void)           = NoOp                          : 
+#  940|     v0_58(void)           = ReturnVoid                    : 
+#  940|     v0_59(void)           = UnmodeledUse                  : mu*
+#  940|     v0_60(void)           = ExitFunction                  : 
 
 #  950| void OperatorNewArray(int)
 #  950|   Block 0
@@ -4678,7 +4678,7 @@ ir.cpp:
 # 1035|     r0_29(char)                              = Call                                   : func:r0_27, this:r0_26, 0:r0_28
 # 1035|     mu0_30(unknown)                          = ^CallSideEffect                        : ~mu0_2
 # 1035|     v0_31(void)                              = ^IndirectReadSideEffect                : &:r0_26, ~mu0_2
-# 1035|     r0_32(decltype([...](...){...}))         = ^IndirectMayWriteSideEffect            : &:r0_26, ~mu0_2
+# 1035|     mu0_32(decltype([...](...){...}))        = ^IndirectMayWriteSideEffect            : &:r0_26, ~mu0_2
 # 1036|     r0_33(glval<decltype([...](...){...})>)  = VariableAddress[lambda_val]            : 
 # 1036|     r0_34(glval<unknown>)                    = FunctionAddress[(constructor)]         : 
 # 1036|     r0_35(glval<decltype([...](...){...})>)  = VariableAddress[#temp1036:21]          : 
@@ -4694,8 +4694,8 @@ ir.cpp:
 # 1036|     r0_45(decltype([...](...){...}))         = Load                                   : &:r0_35, ~mu0_2
 # 1036|     v0_46(void)                              = Call                                   : func:r0_34, this:r0_33, 0:r0_45
 # 1036|     mu0_47(unknown)                          = ^CallSideEffect                        : ~mu0_2
-# 1036|     v0_48(void)                              = ^IndirectReadSideEffect[p#0]           : &:r0_45, ~mu0_2
-# 1036|     mu0_49(unknown)                          = ^BufferMayWriteSideEffect[p#0]         : &:r0_45, ~mu0_2
+# 1036|     v0_48(void)                              = ^IndirectReadSideEffect                : &:r0_45, ~mu0_2
+# 1036|     mu0_49(unknown)                          = ^BufferMayWriteSideEffect              : &:r0_45, ~mu0_2
 # 1037|     r0_50(glval<decltype([...](...){...})>)  = VariableAddress[lambda_val]            : 
 # 1037|     r0_51(glval<decltype([...](...){...})>)  = Convert                                : r0_50
 # 1037|     r0_52(glval<unknown>)                    = FunctionAddress[operator()]            : 
@@ -4703,7 +4703,7 @@ ir.cpp:
 # 1037|     r0_54(char)                              = Call                                   : func:r0_52, this:r0_51, 0:r0_53
 # 1037|     mu0_55(unknown)                          = ^CallSideEffect                        : ~mu0_2
 # 1037|     v0_56(void)                              = ^IndirectReadSideEffect                : &:r0_51, ~mu0_2
-# 1037|     r0_57(decltype([...](...){...}))         = ^IndirectMayWriteSideEffect            : &:r0_51, ~mu0_2
+# 1037|     mu0_57(decltype([...](...){...}))        = ^IndirectMayWriteSideEffect            : &:r0_51, ~mu0_2
 # 1038|     r0_58(glval<decltype([...](...){...})>)  = VariableAddress[lambda_ref_explicit]   : 
 # 1038|     r0_59(glval<decltype([...](...){...})>)  = VariableAddress[#temp1038:30]          : 
 # 1038|     mu0_60(decltype([...](...){...}))        = Uninitialized[#temp1038:30]            : &:r0_59
@@ -4720,7 +4720,7 @@ ir.cpp:
 # 1039|     r0_71(char)                              = Call                                   : func:r0_69, this:r0_68, 0:r0_70
 # 1039|     mu0_72(unknown)                          = ^CallSideEffect                        : ~mu0_2
 # 1039|     v0_73(void)                              = ^IndirectReadSideEffect                : &:r0_68, ~mu0_2
-# 1039|     r0_74(decltype([...](...){...}))         = ^IndirectMayWriteSideEffect            : &:r0_68, ~mu0_2
+# 1039|     mu0_74(decltype([...](...){...}))        = ^IndirectMayWriteSideEffect            : &:r0_68, ~mu0_2
 # 1040|     r0_75(glval<decltype([...](...){...})>)  = VariableAddress[lambda_val_explicit]   : 
 # 1040|     r0_76(glval<unknown>)                    = FunctionAddress[(constructor)]         : 
 # 1040|     r0_77(glval<decltype([...](...){...})>)  = VariableAddress[#temp1040:30]          : 
@@ -4732,8 +4732,8 @@ ir.cpp:
 # 1040|     r0_83(decltype([...](...){...}))         = Load                                   : &:r0_77, ~mu0_2
 # 1040|     v0_84(void)                              = Call                                   : func:r0_76, this:r0_75, 0:r0_83
 # 1040|     mu0_85(unknown)                          = ^CallSideEffect                        : ~mu0_2
-# 1040|     v0_86(void)                              = ^IndirectReadSideEffect[p#0]           : &:r0_83, ~mu0_2
-# 1040|     mu0_87(unknown)                          = ^BufferMayWriteSideEffect[p#0]         : &:r0_83, ~mu0_2
+# 1040|     v0_86(void)                              = ^IndirectReadSideEffect                : &:r0_83, ~mu0_2
+# 1040|     mu0_87(unknown)                          = ^BufferMayWriteSideEffect              : &:r0_83, ~mu0_2
 # 1041|     r0_88(glval<decltype([...](...){...})>)  = VariableAddress[lambda_val_explicit]   : 
 # 1041|     r0_89(glval<decltype([...](...){...})>)  = Convert                                : r0_88
 # 1041|     r0_90(glval<unknown>)                    = FunctionAddress[operator()]            : 
@@ -4741,7 +4741,7 @@ ir.cpp:
 # 1041|     r0_92(char)                              = Call                                   : func:r0_90, this:r0_89, 0:r0_91
 # 1041|     mu0_93(unknown)                          = ^CallSideEffect                        : ~mu0_2
 # 1041|     v0_94(void)                              = ^IndirectReadSideEffect                : &:r0_89, ~mu0_2
-# 1041|     r0_95(decltype([...](...){...}))         = ^IndirectMayWriteSideEffect            : &:r0_89, ~mu0_2
+# 1041|     mu0_95(decltype([...](...){...}))        = ^IndirectMayWriteSideEffect            : &:r0_89, ~mu0_2
 # 1042|     r0_96(glval<decltype([...](...){...})>)  = VariableAddress[lambda_mixed_explicit] : 
 # 1042|     r0_97(glval<decltype([...](...){...})>)  = VariableAddress[#temp1042:32]          : 
 # 1042|     mu0_98(decltype([...](...){...}))        = Uninitialized[#temp1042:32]            : &:r0_97
@@ -4762,7 +4762,7 @@ ir.cpp:
 # 1043|     r0_113(char)                             = Call                                   : func:r0_111, this:r0_110, 0:r0_112
 # 1043|     mu0_114(unknown)                         = ^CallSideEffect                        : ~mu0_2
 # 1043|     v0_115(void)                             = ^IndirectReadSideEffect                : &:r0_110, ~mu0_2
-# 1043|     r0_116(decltype([...](...){...}))        = ^IndirectMayWriteSideEffect            : &:r0_110, ~mu0_2
+# 1043|     mu0_116(decltype([...](...){...}))       = ^IndirectMayWriteSideEffect            : &:r0_110, ~mu0_2
 # 1044|     r0_117(glval<int>)                       = VariableAddress[r]                     : 
 # 1044|     r0_118(glval<int>)                       = VariableAddress[x]                     : 
 # 1044|     r0_119(int)                              = Load                                   : &:r0_118, ~mu0_2
@@ -4798,7 +4798,7 @@ ir.cpp:
 # 1046|     r0_149(char)                             = Call                                   : func:r0_147, this:r0_146, 0:r0_148
 # 1046|     mu0_150(unknown)                         = ^CallSideEffect                        : ~mu0_2
 # 1046|     v0_151(void)                             = ^IndirectReadSideEffect                : &:r0_146, ~mu0_2
-# 1046|     r0_152(decltype([...](...){...}))        = ^IndirectMayWriteSideEffect            : &:r0_146, ~mu0_2
+# 1046|     mu0_152(decltype([...](...){...}))       = ^IndirectMayWriteSideEffect            : &:r0_146, ~mu0_2
 # 1047|     v0_153(void)                             = NoOp                                   : 
 # 1031|     v0_154(void)                             = ReturnVoid                             : 
 # 1031|     v0_155(void)                             = UnmodeledUse                           : mu*
@@ -4863,7 +4863,7 @@ ir.cpp:
 # 1034|     r0_11(char *)                                 = Call                        : func:r0_10, this:r0_9
 # 1034|     mu0_12(unknown)                               = ^CallSideEffect             : ~mu0_2
 # 1034|     v0_13(void)                                   = ^IndirectReadSideEffect     : &:r0_9, ~mu0_2
-# 1034|     r0_14(String)                                 = ^IndirectMayWriteSideEffect : &:r0_9, ~mu0_2
+# 1034|     mu0_14(String)                                = ^IndirectMayWriteSideEffect : &:r0_9, ~mu0_2
 #-----|     r0_15(lambda [] type at line 1034, col. 21 *) = CopyValue                   : r0_3
 #-----|     r0_16(glval<int &>)                           = FieldAddress[x]             : r0_15
 #-----|     r0_17(int &)                                  = Load                        : &:r0_16, ~mu0_2
@@ -4906,7 +4906,7 @@ ir.cpp:
 # 1036|     r0_10(char *)                                 = Call                        : func:r0_9, this:r0_8
 # 1036|     mu0_11(unknown)                               = ^CallSideEffect             : ~mu0_2
 #-----|     v0_12(void)                                   = ^IndirectReadSideEffect     : &:r0_8, ~mu0_2
-#-----|     r0_13(String)                                 = ^IndirectMayWriteSideEffect : &:r0_8, ~mu0_2
+#-----|     mu0_13(String)                                = ^IndirectMayWriteSideEffect : &:r0_8, ~mu0_2
 #-----|     r0_14(lambda [] type at line 1036, col. 21 *) = CopyValue                   : r0_3
 #-----|     r0_15(glval<int>)                             = FieldAddress[x]             : r0_14
 #-----|     r0_16(int)                                    = Load                        : &:r0_15, ~mu0_2
@@ -4934,7 +4934,7 @@ ir.cpp:
 # 1038|     r0_11(char *)                                = Call                        : func:r0_10, this:r0_9
 # 1038|     mu0_12(unknown)                              = ^CallSideEffect             : ~mu0_2
 # 1038|     v0_13(void)                                  = ^IndirectReadSideEffect     : &:r0_9, ~mu0_2
-# 1038|     r0_14(String)                                = ^IndirectMayWriteSideEffect : &:r0_9, ~mu0_2
+# 1038|     mu0_14(String)                               = ^IndirectMayWriteSideEffect : &:r0_9, ~mu0_2
 # 1038|     r0_15(int)                                   = Constant[0]                 : 
 # 1038|     r0_16(glval<char>)                           = PointerAdd[1]               : r0_11, r0_15
 # 1038|     r0_17(char)                                  = Load                        : &:r0_16, ~mu0_2
@@ -4991,7 +4991,7 @@ ir.cpp:
 # 1040|     r0_10(char *)                                = Call                        : func:r0_9, this:r0_8
 # 1040|     mu0_11(unknown)                              = ^CallSideEffect             : ~mu0_2
 #-----|     v0_12(void)                                  = ^IndirectReadSideEffect     : &:r0_8, ~mu0_2
-#-----|     r0_13(String)                                = ^IndirectMayWriteSideEffect : &:r0_8, ~mu0_2
+#-----|     mu0_13(String)                               = ^IndirectMayWriteSideEffect : &:r0_8, ~mu0_2
 # 1040|     r0_14(int)                                   = Constant[0]                 : 
 # 1040|     r0_15(glval<char>)                           = PointerAdd[1]               : r0_10, r0_14
 # 1040|     r0_16(char)                                  = Load                        : &:r0_15, ~mu0_2
@@ -5017,7 +5017,7 @@ ir.cpp:
 # 1042|     r0_11(char *)                                 = Call                        : func:r0_10, this:r0_9
 # 1042|     mu0_12(unknown)                               = ^CallSideEffect             : ~mu0_2
 # 1042|     v0_13(void)                                   = ^IndirectReadSideEffect     : &:r0_9, ~mu0_2
-# 1042|     r0_14(String)                                 = ^IndirectMayWriteSideEffect : &:r0_9, ~mu0_2
+# 1042|     mu0_14(String)                                = ^IndirectMayWriteSideEffect : &:r0_9, ~mu0_2
 #-----|     r0_15(lambda [] type at line 1042, col. 32 *) = CopyValue                   : r0_3
 #-----|     r0_16(glval<int>)                             = FieldAddress[x]             : r0_15
 #-----|     r0_17(int)                                    = Load                        : &:r0_16, ~mu0_2
@@ -5045,7 +5045,7 @@ ir.cpp:
 # 1045|     r0_11(char *)                                 = Call                        : func:r0_10, this:r0_9
 # 1045|     mu0_12(unknown)                               = ^CallSideEffect             : ~mu0_2
 # 1045|     v0_13(void)                                   = ^IndirectReadSideEffect     : &:r0_9, ~mu0_2
-# 1045|     r0_14(String)                                 = ^IndirectMayWriteSideEffect : &:r0_9, ~mu0_2
+# 1045|     mu0_14(String)                                = ^IndirectMayWriteSideEffect : &:r0_9, ~mu0_2
 #-----|     r0_15(lambda [] type at line 1045, col. 23 *) = CopyValue                   : r0_3
 #-----|     r0_16(glval<int>)                             = FieldAddress[x]             : r0_15
 #-----|     r0_17(int)                                    = Load                        : &:r0_16, ~mu0_2
@@ -5084,7 +5084,7 @@ ir.cpp:
 # 1069|     r0_13(iterator)             = Call                        : func:r0_12, this:r0_11
 # 1069|     mu0_14(unknown)             = ^CallSideEffect             : ~mu0_2
 #-----|     v0_15(void)                 = ^IndirectReadSideEffect     : &:r0_11, ~mu0_2
-#-----|     r0_16(vector<int>)          = ^IndirectMayWriteSideEffect : &:r0_11, ~mu0_2
+#-----|     mu0_16(vector<int>)         = ^IndirectMayWriteSideEffect : &:r0_11, ~mu0_2
 # 1069|     mu0_17(iterator)            = Store                       : &:r0_9, r0_13
 # 1069|     r0_18(glval<iterator>)      = VariableAddress[(__end)]    : 
 #-----|     r0_19(glval<vector<int> &>) = VariableAddress[(__range)]  : 
@@ -5093,7 +5093,7 @@ ir.cpp:
 # 1069|     r0_22(iterator)             = Call                        : func:r0_21, this:r0_20
 # 1069|     mu0_23(unknown)             = ^CallSideEffect             : ~mu0_2
 #-----|     v0_24(void)                 = ^IndirectReadSideEffect     : &:r0_20, ~mu0_2
-#-----|     r0_25(vector<int>)          = ^IndirectMayWriteSideEffect : &:r0_20, ~mu0_2
+#-----|     mu0_25(vector<int>)         = ^IndirectMayWriteSideEffect : &:r0_20, ~mu0_2
 # 1069|     mu0_26(iterator)            = Store                       : &:r0_18, r0_22
 #-----|   Goto -> Block 4
 
@@ -5105,7 +5105,7 @@ ir.cpp:
 # 1075|     r1_4(int &)           = Call                        : func:r1_3, this:r1_2
 # 1075|     mu1_5(unknown)        = ^CallSideEffect             : ~mu0_2
 #-----|     v1_6(void)            = ^IndirectReadSideEffect     : &:r1_2, ~mu0_2
-#-----|     r1_7(iterator)        = ^IndirectMayWriteSideEffect : &:r1_2, ~mu0_2
+#-----|     mu1_7(iterator)       = ^IndirectMayWriteSideEffect : &:r1_2, ~mu0_2
 # 1075|     r1_8(glval<int>)      = Convert                     : r1_4
 # 1075|     mu1_9(int &)          = Store                       : &:r1_0, r1_8
 # 1076|     r1_10(glval<int &>)   = VariableAddress[e]          : 
@@ -5137,7 +5137,7 @@ ir.cpp:
 # 1069|     r4_5(bool)            = Call                        : func:r4_2, this:r4_1, 0:r4_4
 # 1069|     mu4_6(unknown)        = ^CallSideEffect             : ~mu0_2
 #-----|     v4_7(void)            = ^IndirectReadSideEffect     : &:r4_1, ~mu0_2
-#-----|     r4_8(iterator)        = ^IndirectMayWriteSideEffect : &:r4_1, ~mu0_2
+#-----|     mu4_8(iterator)       = ^IndirectMayWriteSideEffect : &:r4_1, ~mu0_2
 # 1069|     v4_9(void)            = ConditionalBranch           : r4_5
 #-----|   False -> Block 8
 #-----|   True -> Block 5
@@ -5150,7 +5150,7 @@ ir.cpp:
 # 1069|     r5_4(int &)           = Call                        : func:r5_3, this:r5_2
 # 1069|     mu5_5(unknown)        = ^CallSideEffect             : ~mu0_2
 #-----|     v5_6(void)            = ^IndirectReadSideEffect     : &:r5_2, ~mu0_2
-#-----|     r5_7(iterator)        = ^IndirectMayWriteSideEffect : &:r5_2, ~mu0_2
+#-----|     mu5_7(iterator)       = ^IndirectMayWriteSideEffect : &:r5_2, ~mu0_2
 # 1069|     r5_8(int)             = Load                        : &:r5_4, ~mu0_2
 # 1069|     mu5_9(int)            = Store                       : &:r5_0, r5_8
 # 1070|     r5_10(glval<int>)     = VariableAddress[e]          : 
@@ -5172,7 +5172,7 @@ ir.cpp:
 # 1069|     r7_3(iterator &)      = Call                        : func:r7_2, this:r7_1
 # 1069|     mu7_4(unknown)        = ^CallSideEffect             : ~mu0_2
 #-----|     v7_5(void)            = ^IndirectReadSideEffect     : &:r7_1, ~mu0_2
-#-----|     r7_6(iterator)        = ^IndirectMayWriteSideEffect : &:r7_1, ~mu0_2
+#-----|     mu7_6(iterator)       = ^IndirectMayWriteSideEffect : &:r7_1, ~mu0_2
 #-----|   Goto (back edge) -> Block 4
 
 # 1075|   Block 8
@@ -5187,7 +5187,7 @@ ir.cpp:
 # 1075|     r8_8(iterator)              = Call                        : func:r8_7, this:r8_6
 # 1075|     mu8_9(unknown)              = ^CallSideEffect             : ~mu0_2
 #-----|     v8_10(void)                 = ^IndirectReadSideEffect     : &:r8_6, ~mu0_2
-#-----|     r8_11(vector<int>)          = ^IndirectMayWriteSideEffect : &:r8_6, ~mu0_2
+#-----|     mu8_11(vector<int>)         = ^IndirectMayWriteSideEffect : &:r8_6, ~mu0_2
 # 1075|     mu8_12(iterator)            = Store                       : &:r8_4, r8_8
 # 1075|     r8_13(glval<iterator>)      = VariableAddress[(__end)]    : 
 #-----|     r8_14(glval<vector<int> &>) = VariableAddress[(__range)]  : 
@@ -5196,7 +5196,7 @@ ir.cpp:
 # 1075|     r8_17(iterator)             = Call                        : func:r8_16, this:r8_15
 # 1075|     mu8_18(unknown)             = ^CallSideEffect             : ~mu0_2
 #-----|     v8_19(void)                 = ^IndirectReadSideEffect     : &:r8_15, ~mu0_2
-#-----|     r8_20(vector<int>)          = ^IndirectMayWriteSideEffect : &:r8_15, ~mu0_2
+#-----|     mu8_20(vector<int>)         = ^IndirectMayWriteSideEffect : &:r8_15, ~mu0_2
 # 1075|     mu8_21(iterator)            = Store                       : &:r8_13, r8_17
 #-----|   Goto -> Block 9
 
@@ -5209,7 +5209,7 @@ ir.cpp:
 # 1075|     r9_5(bool)            = Call                        : func:r9_2, this:r9_1, 0:r9_4
 # 1075|     mu9_6(unknown)        = ^CallSideEffect             : ~mu0_2
 #-----|     v9_7(void)            = ^IndirectReadSideEffect     : &:r9_1, ~mu0_2
-#-----|     r9_8(iterator)        = ^IndirectMayWriteSideEffect : &:r9_1, ~mu0_2
+#-----|     mu9_8(iterator)       = ^IndirectMayWriteSideEffect : &:r9_1, ~mu0_2
 # 1075|     v9_9(void)            = ConditionalBranch           : r9_5
 #-----|   False -> Block 3
 #-----|   True -> Block 1
@@ -5220,7 +5220,7 @@ ir.cpp:
 # 1075|     r10_2(iterator &)      = Call                        : func:r10_1, this:r10_0
 # 1075|     mu10_3(unknown)        = ^CallSideEffect             : ~mu0_2
 #-----|     v10_4(void)            = ^IndirectReadSideEffect     : &:r10_0, ~mu0_2
-#-----|     r10_5(iterator)        = ^IndirectMayWriteSideEffect : &:r10_0, ~mu0_2
+#-----|     mu10_5(iterator)       = ^IndirectMayWriteSideEffect : &:r10_0, ~mu0_2
 #-----|   Goto (back edge) -> Block 9
 
 # 1099| int AsmStmt(int)
@@ -5378,8 +5378,8 @@ ir.cpp:
 # 1140|     r7_3(char *)          = Convert                         : r7_2
 # 1140|     v7_4(void)            = Call                            : func:r7_1, this:r7_0, 0:r7_3
 # 1140|     mu7_5(unknown)        = ^CallSideEffect                 : ~mu0_2
-# 1140|     v7_6(void)            = ^IndirectReadSideEffect[p#0]    : &:r7_3, ~mu0_2
-# 1140|     mu7_7(unknown)        = ^BufferMayWriteSideEffect[p#0]  : &:r7_3, ~mu0_2
+# 1140|     v7_6(void)            = ^IndirectReadSideEffect         : &:r7_3, ~mu0_2
+# 1140|     mu7_7(unknown)        = ^BufferMayWriteSideEffect       : &:r7_3, ~mu0_2
 # 1140|     v7_8(void)            = ThrowValue                      : &:r7_0, ~mu0_2
 #-----|   Exception -> Block 9
 
@@ -5395,17 +5395,17 @@ ir.cpp:
 #-----|   Goto -> Block 10
 
 # 1144|   Block 10
-# 1144|     r10_0(glval<char *>)  = VariableAddress[s]             : 
-# 1144|     mu10_1(char *)        = InitializeParameter[s]         : &:r10_0
-# 1145|     r10_2(glval<String>)  = VariableAddress[#throw1145:5]  : 
-# 1145|     r10_3(glval<unknown>) = FunctionAddress[String]        : 
-# 1145|     r10_4(glval<char *>)  = VariableAddress[s]             : 
-# 1145|     r10_5(char *)         = Load                           : &:r10_4, ~mu0_2
-# 1145|     v10_6(void)           = Call                           : func:r10_3, this:r10_2, 0:r10_5
-# 1145|     mu10_7(unknown)       = ^CallSideEffect                : ~mu0_2
-# 1145|     v10_8(void)           = ^IndirectReadSideEffect[p#0]   : &:r10_5, ~mu0_2
-# 1145|     mu10_9(unknown)       = ^BufferMayWriteSideEffect[p#0] : &:r10_5, ~mu0_2
-# 1145|     v10_10(void)          = ThrowValue                     : &:r10_2, ~mu0_2
+# 1144|     r10_0(glval<char *>)  = VariableAddress[s]            : 
+# 1144|     mu10_1(char *)        = InitializeParameter[s]        : &:r10_0
+# 1145|     r10_2(glval<String>)  = VariableAddress[#throw1145:5] : 
+# 1145|     r10_3(glval<unknown>) = FunctionAddress[String]       : 
+# 1145|     r10_4(glval<char *>)  = VariableAddress[s]            : 
+# 1145|     r10_5(char *)         = Load                          : &:r10_4, ~mu0_2
+# 1145|     v10_6(void)           = Call                          : func:r10_3, this:r10_2, 0:r10_5
+# 1145|     mu10_7(unknown)       = ^CallSideEffect               : ~mu0_2
+# 1145|     v10_8(void)           = ^IndirectReadSideEffect       : &:r10_5, ~mu0_2
+# 1145|     mu10_9(unknown)       = ^BufferMayWriteSideEffect     : &:r10_5, ~mu0_2
+# 1145|     v10_10(void)          = ThrowValue                    : &:r10_2, ~mu0_2
 #-----|   Exception -> Block 2
 
 # 1147|   Block 11
@@ -5488,30 +5488,30 @@ ir.cpp:
 
 # 1163| int ModeledCallTarget(int)
 # 1163|   Block 0
-# 1163|     v0_0(void)           = EnterFunction                   : 
-# 1163|     mu0_1(unknown)       = AliasedDefinition               : 
-# 1163|     mu0_2(unknown)       = UnmodeledDefinition             : 
-# 1163|     r0_3(glval<int>)     = VariableAddress[x]              : 
-# 1163|     mu0_4(int)           = InitializeParameter[x]          : &:r0_3
-# 1164|     r0_5(glval<int>)     = VariableAddress[y]              : 
-# 1164|     mu0_6(int)           = Uninitialized[y]                : &:r0_5
-# 1165|     r0_7(glval<unknown>) = FunctionAddress[memcpy]         : 
-# 1165|     r0_8(glval<int>)     = VariableAddress[y]              : 
-# 1165|     r0_9(void *)         = Convert                         : r0_8
-# 1165|     r0_10(glval<int>)    = VariableAddress[x]              : 
-# 1165|     r0_11(void *)        = Convert                         : r0_10
-# 1165|     r0_12(int)           = Constant[4]                     : 
-# 1165|     r0_13(void *)        = Call                            : func:r0_7, 0:r0_9, 1:r0_11, 2:r0_12
-# 1165|     v0_14(void)          = ^BufferReadSideEffect[src]      : &:r0_11, ~mu0_2
-# 1165|     mu0_15(unknown)      = ^BufferMustWriteSideEffect[dst] : &:r0_9
-# 1166|     r0_16(glval<int>)    = VariableAddress[#return]        : 
-# 1166|     r0_17(glval<int>)    = VariableAddress[y]              : 
-# 1166|     r0_18(int)           = Load                            : &:r0_17, ~mu0_2
-# 1166|     mu0_19(int)          = Store                           : &:r0_16, r0_18
-# 1163|     r0_20(glval<int>)    = VariableAddress[#return]        : 
-# 1163|     v0_21(void)          = ReturnValue                     : &:r0_20, ~mu0_2
-# 1163|     v0_22(void)          = UnmodeledUse                    : mu*
-# 1163|     v0_23(void)          = ExitFunction                    : 
+# 1163|     v0_0(void)           = EnterFunction              : 
+# 1163|     mu0_1(unknown)       = AliasedDefinition          : 
+# 1163|     mu0_2(unknown)       = UnmodeledDefinition        : 
+# 1163|     r0_3(glval<int>)     = VariableAddress[x]         : 
+# 1163|     mu0_4(int)           = InitializeParameter[x]     : &:r0_3
+# 1164|     r0_5(glval<int>)     = VariableAddress[y]         : 
+# 1164|     mu0_6(int)           = Uninitialized[y]           : &:r0_5
+# 1165|     r0_7(glval<unknown>) = FunctionAddress[memcpy]    : 
+# 1165|     r0_8(glval<int>)     = VariableAddress[y]         : 
+# 1165|     r0_9(void *)         = Convert                    : r0_8
+# 1165|     r0_10(glval<int>)    = VariableAddress[x]         : 
+# 1165|     r0_11(void *)        = Convert                    : r0_10
+# 1165|     r0_12(int)           = Constant[4]                : 
+# 1165|     r0_13(void *)        = Call                       : func:r0_7, 0:r0_9, 1:r0_11, 2:r0_12
+# 1165|     v0_14(void)          = ^BufferReadSideEffect      : &:r0_11, ~mu0_2
+# 1165|     mu0_15(unknown)      = ^BufferMustWriteSideEffect : &:r0_9
+# 1166|     r0_16(glval<int>)    = VariableAddress[#return]   : 
+# 1166|     r0_17(glval<int>)    = VariableAddress[y]         : 
+# 1166|     r0_18(int)           = Load                       : &:r0_17, ~mu0_2
+# 1166|     mu0_19(int)          = Store                      : &:r0_16, r0_18
+# 1163|     r0_20(glval<int>)    = VariableAddress[#return]   : 
+# 1163|     v0_21(void)          = ReturnValue                : &:r0_20, ~mu0_2
+# 1163|     v0_22(void)          = UnmodeledUse               : mu*
+# 1163|     v0_23(void)          = ExitFunction               : 
 
 perf-regression.cpp:
 #    6| void Big::Big()

--- a/cpp/ql/test/library-tests/ir/ir/raw_ir.expected
+++ b/cpp/ql/test/library-tests/ir/ir/raw_ir.expected
@@ -14,10 +14,12 @@ bad_asts.cpp:
 #   16|     r0_10(int)           = Constant[1]                     : 
 #   16|     r0_11(int)           = Call                            : func:r0_9, this:r0_8, 0:r0_10
 #   16|     mu0_12(unknown)      = ^CallSideEffect                 : ~mu0_2
-#   17|     v0_13(void)          = NoOp                            : 
-#   14|     v0_14(void)          = ReturnVoid                      : 
-#   14|     v0_15(void)          = UnmodeledUse                    : mu*
-#   14|     v0_16(void)          = ExitFunction                    : 
+#   16|     v0_13(void)          = ^IndirectReadSideEffect         : &:r0_8, ~mu0_2
+#   16|     r0_14(S)             = ^IndirectMayWriteSideEffect     : &:r0_8, ~mu0_2
+#   17|     v0_15(void)          = NoOp                            : 
+#   14|     v0_16(void)          = ReturnVoid                      : 
+#   14|     v0_17(void)          = UnmodeledUse                    : mu*
+#   14|     v0_18(void)          = ExitFunction                    : 
 
 #   22| void Bad::Point::Point()
 #   22|   Block 0
@@ -2673,10 +2675,14 @@ ir.cpp:
 #  585|     r0_8(char *)         = Convert                         : r0_7
 #  585|     v0_9(void)           = Call                            : func:r0_3, 0:r0_5, 1:r0_6, 2:r0_8
 #  585|     mu0_10(unknown)      = ^CallSideEffect                 : ~mu0_2
-#  586|     v0_11(void)          = NoOp                            : 
-#  584|     v0_12(void)          = ReturnVoid                      : 
-#  584|     v0_13(void)          = UnmodeledUse                    : mu*
-#  584|     v0_14(void)          = ExitFunction                    : 
+#  585|     v0_11(void)          = ^IndirectReadSideEffect[s]      : &:r0_5, ~mu0_2
+#  585|     v0_12(void)          = ^IndirectReadSideEffect         : &:r0_8, ~mu0_2
+#  585|     mu0_13(unknown)      = ^BufferMayWriteSideEffect[s]    : &:r0_5, ~mu0_2
+#  585|     r0_14(unknown)       = ^BufferMayWriteSideEffect       : &:r0_8, ~mu0_2
+#  586|     v0_15(void)          = NoOp                            : 
+#  584|     v0_16(void)          = ReturnVoid                      : 
+#  584|     v0_17(void)          = UnmodeledUse                    : mu*
+#  584|     v0_18(void)          = ExitFunction                    : 
 
 #  590| void SetFuncPtr()
 #  590|   Block 0
@@ -2702,67 +2708,77 @@ ir.cpp:
 
 #  615| void DeclareObject()
 #  615|   Block 0
-#  615|     v0_0(void)            = EnterFunction                 : 
-#  615|     mu0_1(unknown)        = AliasedDefinition             : 
-#  615|     mu0_2(unknown)        = UnmodeledDefinition           : 
-#  616|     r0_3(glval<String>)   = VariableAddress[s1]           : 
-#  616|     r0_4(glval<unknown>)  = FunctionAddress[String]       : 
-#  616|     v0_5(void)            = Call                          : func:r0_4, this:r0_3
-#  616|     mu0_6(unknown)        = ^CallSideEffect               : ~mu0_2
-#  617|     r0_7(glval<String>)   = VariableAddress[s2]           : 
-#  617|     r0_8(glval<unknown>)  = FunctionAddress[String]       : 
-#  617|     r0_9(glval<char[6]>)  = StringConstant["hello"]       : 
-#  617|     r0_10(char *)         = Convert                       : r0_9
-#  617|     v0_11(void)           = Call                          : func:r0_8, this:r0_7, 0:r0_10
-#  617|     mu0_12(unknown)       = ^CallSideEffect               : ~mu0_2
-#  618|     r0_13(glval<String>)  = VariableAddress[s3]           : 
-#  618|     r0_14(glval<unknown>) = FunctionAddress[ReturnObject] : 
-#  618|     r0_15(String)         = Call                          : func:r0_14
-#  618|     mu0_16(unknown)       = ^CallSideEffect               : ~mu0_2
-#  618|     mu0_17(String)        = Store                         : &:r0_13, r0_15
-#  619|     r0_18(glval<String>)  = VariableAddress[s4]           : 
-#  619|     r0_19(glval<unknown>) = FunctionAddress[String]       : 
-#  619|     r0_20(glval<char[5]>) = StringConstant["test"]        : 
-#  619|     r0_21(char *)         = Convert                       : r0_20
-#  619|     v0_22(void)           = Call                          : func:r0_19, this:r0_18, 0:r0_21
-#  619|     mu0_23(unknown)       = ^CallSideEffect               : ~mu0_2
-#  620|     v0_24(void)           = NoOp                          : 
-#  615|     v0_25(void)           = ReturnVoid                    : 
-#  615|     v0_26(void)           = UnmodeledUse                  : mu*
-#  615|     v0_27(void)           = ExitFunction                  : 
+#  615|     v0_0(void)            = EnterFunction                  : 
+#  615|     mu0_1(unknown)        = AliasedDefinition              : 
+#  615|     mu0_2(unknown)        = UnmodeledDefinition            : 
+#  616|     r0_3(glval<String>)   = VariableAddress[s1]            : 
+#  616|     r0_4(glval<unknown>)  = FunctionAddress[String]        : 
+#  616|     v0_5(void)            = Call                           : func:r0_4, this:r0_3
+#  616|     mu0_6(unknown)        = ^CallSideEffect                : ~mu0_2
+#  617|     r0_7(glval<String>)   = VariableAddress[s2]            : 
+#  617|     r0_8(glval<unknown>)  = FunctionAddress[String]        : 
+#  617|     r0_9(glval<char[6]>)  = StringConstant["hello"]        : 
+#  617|     r0_10(char *)         = Convert                        : r0_9
+#  617|     v0_11(void)           = Call                           : func:r0_8, this:r0_7, 0:r0_10
+#  617|     mu0_12(unknown)       = ^CallSideEffect                : ~mu0_2
+#  617|     v0_13(void)           = ^IndirectReadSideEffect[p#0]   : &:r0_10, ~mu0_2
+#  617|     mu0_14(unknown)       = ^BufferMayWriteSideEffect[p#0] : &:r0_10, ~mu0_2
+#  618|     r0_15(glval<String>)  = VariableAddress[s3]            : 
+#  618|     r0_16(glval<unknown>) = FunctionAddress[ReturnObject]  : 
+#  618|     r0_17(String)         = Call                           : func:r0_16
+#  618|     mu0_18(unknown)       = ^CallSideEffect                : ~mu0_2
+#  618|     mu0_19(String)        = Store                          : &:r0_15, r0_17
+#  619|     r0_20(glval<String>)  = VariableAddress[s4]            : 
+#  619|     r0_21(glval<unknown>) = FunctionAddress[String]        : 
+#  619|     r0_22(glval<char[5]>) = StringConstant["test"]         : 
+#  619|     r0_23(char *)         = Convert                        : r0_22
+#  619|     v0_24(void)           = Call                           : func:r0_21, this:r0_20, 0:r0_23
+#  619|     mu0_25(unknown)       = ^CallSideEffect                : ~mu0_2
+#  619|     v0_26(void)           = ^IndirectReadSideEffect[p#0]   : &:r0_23, ~mu0_2
+#  619|     mu0_27(unknown)       = ^BufferMayWriteSideEffect[p#0] : &:r0_23, ~mu0_2
+#  620|     v0_28(void)           = NoOp                           : 
+#  615|     v0_29(void)           = ReturnVoid                     : 
+#  615|     v0_30(void)           = UnmodeledUse                   : mu*
+#  615|     v0_31(void)           = ExitFunction                   : 
 
 #  622| void CallMethods(String&, String*, String)
 #  622|   Block 0
-#  622|     v0_0(void)             = EnterFunction          : 
-#  622|     mu0_1(unknown)         = AliasedDefinition      : 
-#  622|     mu0_2(unknown)         = UnmodeledDefinition    : 
-#  622|     r0_3(glval<String &>)  = VariableAddress[r]     : 
-#  622|     mu0_4(String &)        = InitializeParameter[r] : &:r0_3
-#  622|     r0_5(glval<String *>)  = VariableAddress[p]     : 
-#  622|     mu0_6(String *)        = InitializeParameter[p] : &:r0_5
-#  622|     r0_7(glval<String>)    = VariableAddress[s]     : 
-#  622|     mu0_8(String)          = InitializeParameter[s] : &:r0_7
-#  623|     r0_9(glval<String &>)  = VariableAddress[r]     : 
-#  623|     r0_10(String &)        = Load                   : &:r0_9, ~mu0_2
-#  623|     r0_11(glval<String>)   = Convert                : r0_10
-#  623|     r0_12(glval<unknown>)  = FunctionAddress[c_str] : 
-#  623|     r0_13(char *)          = Call                   : func:r0_12, this:r0_11
-#  623|     mu0_14(unknown)        = ^CallSideEffect        : ~mu0_2
-#  624|     r0_15(glval<String *>) = VariableAddress[p]     : 
-#  624|     r0_16(String *)        = Load                   : &:r0_15, ~mu0_2
-#  624|     r0_17(String *)        = Convert                : r0_16
-#  624|     r0_18(glval<unknown>)  = FunctionAddress[c_str] : 
-#  624|     r0_19(char *)          = Call                   : func:r0_18, this:r0_17
-#  624|     mu0_20(unknown)        = ^CallSideEffect        : ~mu0_2
-#  625|     r0_21(glval<String>)   = VariableAddress[s]     : 
-#  625|     r0_22(glval<String>)   = Convert                : r0_21
-#  625|     r0_23(glval<unknown>)  = FunctionAddress[c_str] : 
-#  625|     r0_24(char *)          = Call                   : func:r0_23, this:r0_22
-#  625|     mu0_25(unknown)        = ^CallSideEffect        : ~mu0_2
-#  626|     v0_26(void)            = NoOp                   : 
-#  622|     v0_27(void)            = ReturnVoid             : 
-#  622|     v0_28(void)            = UnmodeledUse           : mu*
-#  622|     v0_29(void)            = ExitFunction           : 
+#  622|     v0_0(void)             = EnterFunction               : 
+#  622|     mu0_1(unknown)         = AliasedDefinition           : 
+#  622|     mu0_2(unknown)         = UnmodeledDefinition         : 
+#  622|     r0_3(glval<String &>)  = VariableAddress[r]          : 
+#  622|     mu0_4(String &)        = InitializeParameter[r]      : &:r0_3
+#  622|     r0_5(glval<String *>)  = VariableAddress[p]          : 
+#  622|     mu0_6(String *)        = InitializeParameter[p]      : &:r0_5
+#  622|     r0_7(glval<String>)    = VariableAddress[s]          : 
+#  622|     mu0_8(String)          = InitializeParameter[s]      : &:r0_7
+#  623|     r0_9(glval<String &>)  = VariableAddress[r]          : 
+#  623|     r0_10(String &)        = Load                        : &:r0_9, ~mu0_2
+#  623|     r0_11(glval<String>)   = Convert                     : r0_10
+#  623|     r0_12(glval<unknown>)  = FunctionAddress[c_str]      : 
+#  623|     r0_13(char *)          = Call                        : func:r0_12, this:r0_11
+#  623|     mu0_14(unknown)        = ^CallSideEffect             : ~mu0_2
+#  623|     v0_15(void)            = ^IndirectReadSideEffect     : &:r0_11, ~mu0_2
+#  623|     r0_16(String)          = ^IndirectMayWriteSideEffect : &:r0_11, ~mu0_2
+#  624|     r0_17(glval<String *>) = VariableAddress[p]          : 
+#  624|     r0_18(String *)        = Load                        : &:r0_17, ~mu0_2
+#  624|     r0_19(String *)        = Convert                     : r0_18
+#  624|     r0_20(glval<unknown>)  = FunctionAddress[c_str]      : 
+#  624|     r0_21(char *)          = Call                        : func:r0_20, this:r0_19
+#  624|     mu0_22(unknown)        = ^CallSideEffect             : ~mu0_2
+#  624|     v0_23(void)            = ^IndirectReadSideEffect     : &:r0_19, ~mu0_2
+#  624|     r0_24(String)          = ^IndirectMayWriteSideEffect : &:r0_19, ~mu0_2
+#  625|     r0_25(glval<String>)   = VariableAddress[s]          : 
+#  625|     r0_26(glval<String>)   = Convert                     : r0_25
+#  625|     r0_27(glval<unknown>)  = FunctionAddress[c_str]      : 
+#  625|     r0_28(char *)          = Call                        : func:r0_27, this:r0_26
+#  625|     mu0_29(unknown)        = ^CallSideEffect             : ~mu0_2
+#  625|     v0_30(void)            = ^IndirectReadSideEffect     : &:r0_26, ~mu0_2
+#  625|     r0_31(String)          = ^IndirectMayWriteSideEffect : &:r0_26, ~mu0_2
+#  626|     v0_32(void)            = NoOp                        : 
+#  622|     v0_33(void)            = ReturnVoid                  : 
+#  622|     v0_34(void)            = UnmodeledUse                : mu*
+#  622|     v0_35(void)            = ExitFunction                : 
 
 #  630| int C::StaticMemberFunction(int)
 #  630|   Block 0
@@ -2865,50 +2881,58 @@ ir.cpp:
 #  653|     r0_6(int)             = Constant[0]                             : 
 #  653|     r0_7(int)             = Call                                    : func:r0_5, this:r0_4, 0:r0_6
 #  653|     mu0_8(unknown)        = ^CallSideEffect                         : ~mu0_2
-#  654|     r0_9(C *)             = CopyValue                               : r0_3
-#  654|     r0_10(glval<unknown>) = FunctionAddress[InstanceMemberFunction] : 
-#  654|     r0_11(int)            = Constant[1]                             : 
-#  654|     r0_12(int)            = Call                                    : func:r0_10, this:r0_9, 0:r0_11
-#  654|     mu0_13(unknown)       = ^CallSideEffect                         : ~mu0_2
-#-----|     r0_14(C *)            = CopyValue                               : r0_3
-#  655|     r0_15(glval<unknown>) = FunctionAddress[InstanceMemberFunction] : 
-#  655|     r0_16(int)            = Constant[2]                             : 
-#  655|     r0_17(int)            = Call                                    : func:r0_15, this:r0_14, 0:r0_16
-#  655|     mu0_18(unknown)       = ^CallSideEffect                         : ~mu0_2
-#  656|     v0_19(void)           = NoOp                                    : 
-#  652|     v0_20(void)           = ReturnVoid                              : 
-#  652|     v0_21(void)           = UnmodeledUse                            : mu*
-#  652|     v0_22(void)           = ExitFunction                            : 
+#  653|     v0_9(void)            = ^IndirectReadSideEffect                 : &:r0_4, ~mu0_2
+#  653|     r0_10(C)              = ^IndirectMayWriteSideEffect             : &:r0_4, ~mu0_2
+#  654|     r0_11(C *)            = CopyValue                               : r0_3
+#  654|     r0_12(glval<unknown>) = FunctionAddress[InstanceMemberFunction] : 
+#  654|     r0_13(int)            = Constant[1]                             : 
+#  654|     r0_14(int)            = Call                                    : func:r0_12, this:r0_11, 0:r0_13
+#  654|     mu0_15(unknown)       = ^CallSideEffect                         : ~mu0_2
+#  654|     v0_16(void)           = ^IndirectReadSideEffect                 : &:r0_11, ~mu0_2
+#  654|     r0_17(C)              = ^IndirectMayWriteSideEffect             : &:r0_11, ~mu0_2
+#-----|     r0_18(C *)            = CopyValue                               : r0_3
+#  655|     r0_19(glval<unknown>) = FunctionAddress[InstanceMemberFunction] : 
+#  655|     r0_20(int)            = Constant[2]                             : 
+#  655|     r0_21(int)            = Call                                    : func:r0_19, this:r0_18, 0:r0_20
+#  655|     mu0_22(unknown)       = ^CallSideEffect                         : ~mu0_2
+#-----|     v0_23(void)           = ^IndirectReadSideEffect                 : &:r0_18, ~mu0_2
+#-----|     r0_24(C)              = ^IndirectMayWriteSideEffect             : &:r0_18, ~mu0_2
+#  656|     v0_25(void)           = NoOp                                    : 
+#  652|     v0_26(void)           = ReturnVoid                              : 
+#  652|     v0_27(void)           = UnmodeledUse                            : mu*
+#  652|     v0_28(void)           = ExitFunction                            : 
 
 #  658| void C::C()
 #  658|   Block 0
-#  658|     v0_0(void)            = EnterFunction           : 
-#  658|     mu0_1(unknown)        = AliasedDefinition       : 
-#  658|     mu0_2(unknown)        = UnmodeledDefinition     : 
-#  658|     r0_3(glval<C>)        = InitializeThis          : 
-#  659|     r0_4(glval<int>)      = FieldAddress[m_a]       : r0_3
-#  659|     r0_5(int)             = Constant[1]             : 
-#  659|     mu0_6(int)            = Store                   : &:r0_4, r0_5
-#  663|     r0_7(glval<String>)   = FieldAddress[m_b]       : r0_3
-#  663|     r0_8(glval<unknown>)  = FunctionAddress[String] : 
-#  663|     v0_9(void)            = Call                    : func:r0_8, this:r0_7
-#  663|     mu0_10(unknown)       = ^CallSideEffect         : ~mu0_2
-#  660|     r0_11(glval<char>)    = FieldAddress[m_c]       : r0_3
-#  660|     r0_12(char)           = Constant[3]             : 
-#  660|     mu0_13(char)          = Store                   : &:r0_11, r0_12
-#  661|     r0_14(glval<void *>)  = FieldAddress[m_e]       : r0_3
-#  661|     r0_15(void *)         = Constant[0]             : 
-#  661|     mu0_16(void *)        = Store                   : &:r0_14, r0_15
-#  662|     r0_17(glval<String>)  = FieldAddress[m_f]       : r0_3
-#  662|     r0_18(glval<unknown>) = FunctionAddress[String] : 
-#  662|     r0_19(glval<char[5]>) = StringConstant["test"]  : 
-#  662|     r0_20(char *)         = Convert                 : r0_19
-#  662|     v0_21(void)           = Call                    : func:r0_18, this:r0_17, 0:r0_20
-#  662|     mu0_22(unknown)       = ^CallSideEffect         : ~mu0_2
-#  664|     v0_23(void)           = NoOp                    : 
-#  658|     v0_24(void)           = ReturnVoid              : 
-#  658|     v0_25(void)           = UnmodeledUse            : mu*
-#  658|     v0_26(void)           = ExitFunction            : 
+#  658|     v0_0(void)            = EnterFunction                  : 
+#  658|     mu0_1(unknown)        = AliasedDefinition              : 
+#  658|     mu0_2(unknown)        = UnmodeledDefinition            : 
+#  658|     r0_3(glval<C>)        = InitializeThis                 : 
+#  659|     r0_4(glval<int>)      = FieldAddress[m_a]              : r0_3
+#  659|     r0_5(int)             = Constant[1]                    : 
+#  659|     mu0_6(int)            = Store                          : &:r0_4, r0_5
+#  663|     r0_7(glval<String>)   = FieldAddress[m_b]              : r0_3
+#  663|     r0_8(glval<unknown>)  = FunctionAddress[String]        : 
+#  663|     v0_9(void)            = Call                           : func:r0_8, this:r0_7
+#  663|     mu0_10(unknown)       = ^CallSideEffect                : ~mu0_2
+#  660|     r0_11(glval<char>)    = FieldAddress[m_c]              : r0_3
+#  660|     r0_12(char)           = Constant[3]                    : 
+#  660|     mu0_13(char)          = Store                          : &:r0_11, r0_12
+#  661|     r0_14(glval<void *>)  = FieldAddress[m_e]              : r0_3
+#  661|     r0_15(void *)         = Constant[0]                    : 
+#  661|     mu0_16(void *)        = Store                          : &:r0_14, r0_15
+#  662|     r0_17(glval<String>)  = FieldAddress[m_f]              : r0_3
+#  662|     r0_18(glval<unknown>) = FunctionAddress[String]        : 
+#  662|     r0_19(glval<char[5]>) = StringConstant["test"]         : 
+#  662|     r0_20(char *)         = Convert                        : r0_19
+#  662|     v0_21(void)           = Call                           : func:r0_18, this:r0_17, 0:r0_20
+#  662|     mu0_22(unknown)       = ^CallSideEffect                : ~mu0_2
+#  662|     v0_23(void)           = ^IndirectReadSideEffect[p#0]   : &:r0_20, ~mu0_2
+#  662|     mu0_24(unknown)       = ^BufferMayWriteSideEffect[p#0] : &:r0_20, ~mu0_2
+#  664|     v0_25(void)           = NoOp                           : 
+#  658|     v0_26(void)           = ReturnVoid                     : 
+#  658|     v0_27(void)           = UnmodeledUse                   : mu*
+#  658|     v0_28(void)           = ExitFunction                   : 
 
 #  675| int DerefReference(int&)
 #  675|   Block 0
@@ -3094,21 +3118,23 @@ ir.cpp:
 
 #  720| double CallNestedTemplateFunc()
 #  720|   Block 0
-#  720|     v0_0(void)           = EnterFunction            : 
-#  720|     mu0_1(unknown)       = AliasedDefinition        : 
-#  720|     mu0_2(unknown)       = UnmodeledDefinition      : 
-#  721|     r0_3(glval<double>)  = VariableAddress[#return] : 
-#  721|     r0_4(glval<unknown>) = FunctionAddress[Func]    : 
-#  721|     r0_5(void *)         = Constant[0]              : 
-#  721|     r0_6(char)           = Constant[111]            : 
-#  721|     r0_7(long)           = Call                     : func:r0_4, 0:r0_5, 1:r0_6
-#  721|     mu0_8(unknown)       = ^CallSideEffect          : ~mu0_2
-#  721|     r0_9(double)         = Convert                  : r0_7
-#  721|     mu0_10(double)       = Store                    : &:r0_3, r0_9
-#  720|     r0_11(glval<double>) = VariableAddress[#return] : 
-#  720|     v0_12(void)          = ReturnValue              : &:r0_11, ~mu0_2
-#  720|     v0_13(void)          = UnmodeledUse             : mu*
-#  720|     v0_14(void)          = ExitFunction             : 
+#  720|     v0_0(void)           = EnterFunction                : 
+#  720|     mu0_1(unknown)       = AliasedDefinition            : 
+#  720|     mu0_2(unknown)       = UnmodeledDefinition          : 
+#  721|     r0_3(glval<double>)  = VariableAddress[#return]     : 
+#  721|     r0_4(glval<unknown>) = FunctionAddress[Func]        : 
+#  721|     r0_5(void *)         = Constant[0]                  : 
+#  721|     r0_6(char)           = Constant[111]                : 
+#  721|     r0_7(long)           = Call                         : func:r0_4, 0:r0_5, 1:r0_6
+#  721|     mu0_8(unknown)       = ^CallSideEffect              : ~mu0_2
+#  721|     v0_9(void)           = ^IndirectReadSideEffect[x]   : &:r0_5, ~mu0_2
+#  721|     mu0_10(unknown)      = ^BufferMayWriteSideEffect[x] : &:r0_5, ~mu0_2
+#  721|     r0_11(double)        = Convert                      : r0_7
+#  721|     mu0_12(double)       = Store                        : &:r0_3, r0_11
+#  720|     r0_13(glval<double>) = VariableAddress[#return]     : 
+#  720|     v0_14(void)          = ReturnValue                  : &:r0_13, ~mu0_2
+#  720|     v0_15(void)          = UnmodeledUse                 : mu*
+#  720|     v0_16(void)          = ExitFunction                 : 
 
 #  724| void TryCatch(bool)
 #  724|   Block 0
@@ -3175,7 +3201,9 @@ ir.cpp:
 #  731|     r7_3(char *)          = Convert                         : r7_2
 #  731|     v7_4(void)            = Call                            : func:r7_1, this:r7_0, 0:r7_3
 #  731|     mu7_5(unknown)        = ^CallSideEffect                 : ~mu0_2
-#  731|     v7_6(void)            = ThrowValue                      : &:r7_0, ~mu0_2
+#  731|     v7_6(void)            = ^IndirectReadSideEffect[p#0]    : &:r7_3, ~mu0_2
+#  731|     mu7_7(unknown)        = ^BufferMayWriteSideEffect[p#0]  : &:r7_3, ~mu0_2
+#  731|     v7_8(void)            = ThrowValue                      : &:r7_0, ~mu0_2
 #-----|   Exception -> Block 9
 
 #  733|   Block 8
@@ -3190,15 +3218,17 @@ ir.cpp:
 #-----|   Goto -> Block 10
 
 #  735|   Block 10
-#  735|     r10_0(glval<char *>)  = VariableAddress[s]           : 
-#  735|     mu10_1(char *)        = InitializeParameter[s]       : &:r10_0
-#  736|     r10_2(glval<String>)  = VariableAddress[#throw736:5] : 
-#  736|     r10_3(glval<unknown>) = FunctionAddress[String]      : 
-#  736|     r10_4(glval<char *>)  = VariableAddress[s]           : 
-#  736|     r10_5(char *)         = Load                         : &:r10_4, ~mu0_2
-#  736|     v10_6(void)           = Call                         : func:r10_3, this:r10_2, 0:r10_5
-#  736|     mu10_7(unknown)       = ^CallSideEffect              : ~mu0_2
-#  736|     v10_8(void)           = ThrowValue                   : &:r10_2, ~mu0_2
+#  735|     r10_0(glval<char *>)  = VariableAddress[s]             : 
+#  735|     mu10_1(char *)        = InitializeParameter[s]         : &:r10_0
+#  736|     r10_2(glval<String>)  = VariableAddress[#throw736:5]   : 
+#  736|     r10_3(glval<unknown>) = FunctionAddress[String]        : 
+#  736|     r10_4(glval<char *>)  = VariableAddress[s]             : 
+#  736|     r10_5(char *)         = Load                           : &:r10_4, ~mu0_2
+#  736|     v10_6(void)           = Call                           : func:r10_3, this:r10_2, 0:r10_5
+#  736|     mu10_7(unknown)       = ^CallSideEffect                : ~mu0_2
+#  736|     v10_8(void)           = ^IndirectReadSideEffect[p#0]   : &:r10_5, ~mu0_2
+#  736|     mu10_9(unknown)       = ^BufferMayWriteSideEffect[p#0] : &:r10_5, ~mu0_2
+#  736|     v10_10(void)          = ThrowValue                     : &:r10_2, ~mu0_2
 #-----|   Exception -> Block 2
 
 #  738|   Block 11
@@ -3224,27 +3254,31 @@ ir.cpp:
 
 #  745| Base& Base::operator=(Base const&)
 #  745|   Block 0
-#  745|     v0_0(void)           = EnterFunction              : 
-#  745|     mu0_1(unknown)       = AliasedDefinition          : 
-#  745|     mu0_2(unknown)       = UnmodeledDefinition        : 
-#  745|     r0_3(glval<Base>)    = InitializeThis             : 
-#-----|     r0_4(glval<Base &>)  = VariableAddress[p#0]       : 
-#-----|     mu0_5(Base &)        = InitializeParameter[p#0]   : &:r0_4
-#-----|     r0_6(Base *)         = CopyValue                  : r0_3
-#-----|     r0_7(glval<String>)  = FieldAddress[base_s]       : r0_6
-#  745|     r0_8(glval<unknown>) = FunctionAddress[operator=] : 
-#-----|     r0_9(glval<Base &>)  = VariableAddress[p#0]       : 
-#-----|     r0_10(Base &)        = Load                       : &:r0_9, ~mu0_2
-#-----|     r0_11(glval<String>) = FieldAddress[base_s]       : r0_10
-#  745|     r0_12(String &)      = Call                       : func:r0_8, this:r0_7, 0:r0_11
-#  745|     mu0_13(unknown)      = ^CallSideEffect            : ~mu0_2
-#-----|     r0_14(glval<Base &>) = VariableAddress[#return]   : 
-#-----|     r0_15(Base *)        = CopyValue                  : r0_3
-#-----|     mu0_16(Base &)       = Store                      : &:r0_14, r0_15
-#  745|     r0_17(glval<Base &>) = VariableAddress[#return]   : 
-#  745|     v0_18(void)          = ReturnValue                : &:r0_17, ~mu0_2
-#  745|     v0_19(void)          = UnmodeledUse               : mu*
-#  745|     v0_20(void)          = ExitFunction               : 
+#  745|     v0_0(void)           = EnterFunction                  : 
+#  745|     mu0_1(unknown)       = AliasedDefinition              : 
+#  745|     mu0_2(unknown)       = UnmodeledDefinition            : 
+#  745|     r0_3(glval<Base>)    = InitializeThis                 : 
+#-----|     r0_4(glval<Base &>)  = VariableAddress[p#0]           : 
+#-----|     mu0_5(Base &)        = InitializeParameter[p#0]       : &:r0_4
+#-----|     r0_6(Base *)         = CopyValue                      : r0_3
+#-----|     r0_7(glval<String>)  = FieldAddress[base_s]           : r0_6
+#  745|     r0_8(glval<unknown>) = FunctionAddress[operator=]     : 
+#-----|     r0_9(glval<Base &>)  = VariableAddress[p#0]           : 
+#-----|     r0_10(Base &)        = Load                           : &:r0_9, ~mu0_2
+#-----|     r0_11(glval<String>) = FieldAddress[base_s]           : r0_10
+#  745|     r0_12(String &)      = Call                           : func:r0_8, this:r0_7, 0:r0_11
+#  745|     mu0_13(unknown)      = ^CallSideEffect                : ~mu0_2
+#-----|     v0_14(void)          = ^IndirectReadSideEffect        : &:r0_7, ~mu0_2
+#-----|     v0_15(void)          = ^IndirectReadSideEffect[p#0]   : &:r0_11, ~mu0_2
+#-----|     r0_16(String)        = ^IndirectMayWriteSideEffect    : &:r0_7, ~mu0_2
+#-----|     mu0_17(unknown)      = ^BufferMayWriteSideEffect[p#0] : &:r0_11, ~mu0_2
+#-----|     r0_18(glval<Base &>) = VariableAddress[#return]       : 
+#-----|     r0_19(Base *)        = CopyValue                      : r0_3
+#-----|     mu0_20(Base &)       = Store                          : &:r0_18, r0_19
+#  745|     r0_21(glval<Base &>) = VariableAddress[#return]       : 
+#  745|     v0_22(void)          = ReturnValue                    : &:r0_21, ~mu0_2
+#  745|     v0_23(void)          = UnmodeledUse                   : mu*
+#  745|     v0_24(void)          = ExitFunction                   : 
 
 #  745| void Base::Base(Base const&)
 #  745|   Block 0
@@ -3295,35 +3329,43 @@ ir.cpp:
 
 #  754| Middle& Middle::operator=(Middle const&)
 #  754|   Block 0
-#  754|     v0_0(void)             = EnterFunction                : 
-#  754|     mu0_1(unknown)         = AliasedDefinition            : 
-#  754|     mu0_2(unknown)         = UnmodeledDefinition          : 
-#  754|     r0_3(glval<Middle>)    = InitializeThis               : 
-#-----|     r0_4(glval<Middle &>)  = VariableAddress[p#0]         : 
-#-----|     mu0_5(Middle &)        = InitializeParameter[p#0]     : &:r0_4
-#-----|     r0_6(Middle *)         = CopyValue                    : r0_3
-#-----|     r0_7(Base *)           = ConvertToBase[Middle : Base] : r0_6
-#  754|     r0_8(glval<unknown>)   = FunctionAddress[operator=]   : 
-#-----|     r0_9(glval<Middle &>)  = VariableAddress[p#0]         : 
-#-----|     r0_10(Middle &)        = Load                         : &:r0_9, ~mu0_2
-#-----|     r0_11(Base *)          = ConvertToBase[Middle : Base] : r0_10
-#  754|     r0_12(Base &)          = Call                         : func:r0_8, this:r0_7, 0:r0_11
-#  754|     mu0_13(unknown)        = ^CallSideEffect              : ~mu0_2
-#-----|     r0_14(Middle *)        = CopyValue                    : r0_3
-#-----|     r0_15(glval<String>)   = FieldAddress[middle_s]       : r0_14
-#  754|     r0_16(glval<unknown>)  = FunctionAddress[operator=]   : 
-#-----|     r0_17(glval<Middle &>) = VariableAddress[p#0]         : 
-#-----|     r0_18(Middle &)        = Load                         : &:r0_17, ~mu0_2
-#-----|     r0_19(glval<String>)   = FieldAddress[middle_s]       : r0_18
-#  754|     r0_20(String &)        = Call                         : func:r0_16, this:r0_15, 0:r0_19
-#  754|     mu0_21(unknown)        = ^CallSideEffect              : ~mu0_2
-#-----|     r0_22(glval<Middle &>) = VariableAddress[#return]     : 
-#-----|     r0_23(Middle *)        = CopyValue                    : r0_3
-#-----|     mu0_24(Middle &)       = Store                        : &:r0_22, r0_23
-#  754|     r0_25(glval<Middle &>) = VariableAddress[#return]     : 
-#  754|     v0_26(void)            = ReturnValue                  : &:r0_25, ~mu0_2
-#  754|     v0_27(void)            = UnmodeledUse                 : mu*
-#  754|     v0_28(void)            = ExitFunction                 : 
+#  754|     v0_0(void)             = EnterFunction                  : 
+#  754|     mu0_1(unknown)         = AliasedDefinition              : 
+#  754|     mu0_2(unknown)         = UnmodeledDefinition            : 
+#  754|     r0_3(glval<Middle>)    = InitializeThis                 : 
+#-----|     r0_4(glval<Middle &>)  = VariableAddress[p#0]           : 
+#-----|     mu0_5(Middle &)        = InitializeParameter[p#0]       : &:r0_4
+#-----|     r0_6(Middle *)         = CopyValue                      : r0_3
+#-----|     r0_7(Base *)           = ConvertToBase[Middle : Base]   : r0_6
+#  754|     r0_8(glval<unknown>)   = FunctionAddress[operator=]     : 
+#-----|     r0_9(glval<Middle &>)  = VariableAddress[p#0]           : 
+#-----|     r0_10(Middle &)        = Load                           : &:r0_9, ~mu0_2
+#-----|     r0_11(Base *)          = ConvertToBase[Middle : Base]   : r0_10
+#  754|     r0_12(Base &)          = Call                           : func:r0_8, this:r0_7, 0:r0_11
+#  754|     mu0_13(unknown)        = ^CallSideEffect                : ~mu0_2
+#-----|     v0_14(void)            = ^IndirectReadSideEffect        : &:r0_7, ~mu0_2
+#-----|     v0_15(void)            = ^IndirectReadSideEffect[p#0]   : &:r0_11, ~mu0_2
+#-----|     r0_16(Base)            = ^IndirectMayWriteSideEffect    : &:r0_7, ~mu0_2
+#-----|     mu0_17(unknown)        = ^BufferMayWriteSideEffect[p#0] : &:r0_11, ~mu0_2
+#-----|     r0_18(Middle *)        = CopyValue                      : r0_3
+#-----|     r0_19(glval<String>)   = FieldAddress[middle_s]         : r0_18
+#  754|     r0_20(glval<unknown>)  = FunctionAddress[operator=]     : 
+#-----|     r0_21(glval<Middle &>) = VariableAddress[p#0]           : 
+#-----|     r0_22(Middle &)        = Load                           : &:r0_21, ~mu0_2
+#-----|     r0_23(glval<String>)   = FieldAddress[middle_s]         : r0_22
+#  754|     r0_24(String &)        = Call                           : func:r0_20, this:r0_19, 0:r0_23
+#  754|     mu0_25(unknown)        = ^CallSideEffect                : ~mu0_2
+#-----|     v0_26(void)            = ^IndirectReadSideEffect        : &:r0_19, ~mu0_2
+#-----|     v0_27(void)            = ^IndirectReadSideEffect[p#0]   : &:r0_23, ~mu0_2
+#-----|     r0_28(String)          = ^IndirectMayWriteSideEffect    : &:r0_19, ~mu0_2
+#-----|     mu0_29(unknown)        = ^BufferMayWriteSideEffect[p#0] : &:r0_23, ~mu0_2
+#-----|     r0_30(glval<Middle &>) = VariableAddress[#return]       : 
+#-----|     r0_31(Middle *)        = CopyValue                      : r0_3
+#-----|     mu0_32(Middle &)       = Store                          : &:r0_30, r0_31
+#  754|     r0_33(glval<Middle &>) = VariableAddress[#return]       : 
+#  754|     v0_34(void)            = ReturnValue                    : &:r0_33, ~mu0_2
+#  754|     v0_35(void)            = UnmodeledUse                   : mu*
+#  754|     v0_36(void)            = ExitFunction                   : 
 
 #  757| void Middle::Middle()
 #  757|   Block 0
@@ -3379,21 +3421,29 @@ ir.cpp:
 #-----|     r0_11(Middle *)         = ConvertToBase[Derived : Middle] : r0_10
 #  763|     r0_12(Middle &)         = Call                            : func:r0_8, this:r0_7, 0:r0_11
 #  763|     mu0_13(unknown)         = ^CallSideEffect                 : ~mu0_2
-#-----|     r0_14(Derived *)        = CopyValue                       : r0_3
-#-----|     r0_15(glval<String>)    = FieldAddress[derived_s]         : r0_14
-#  763|     r0_16(glval<unknown>)   = FunctionAddress[operator=]      : 
-#-----|     r0_17(glval<Derived &>) = VariableAddress[p#0]            : 
-#-----|     r0_18(Derived &)        = Load                            : &:r0_17, ~mu0_2
+#-----|     v0_14(void)             = ^IndirectReadSideEffect         : &:r0_7, ~mu0_2
+#-----|     v0_15(void)             = ^IndirectReadSideEffect[p#0]    : &:r0_11, ~mu0_2
+#-----|     r0_16(Middle)           = ^IndirectMayWriteSideEffect     : &:r0_7, ~mu0_2
+#-----|     mu0_17(unknown)         = ^BufferMayWriteSideEffect[p#0]  : &:r0_11, ~mu0_2
+#-----|     r0_18(Derived *)        = CopyValue                       : r0_3
 #-----|     r0_19(glval<String>)    = FieldAddress[derived_s]         : r0_18
-#  763|     r0_20(String &)         = Call                            : func:r0_16, this:r0_15, 0:r0_19
-#  763|     mu0_21(unknown)         = ^CallSideEffect                 : ~mu0_2
-#-----|     r0_22(glval<Derived &>) = VariableAddress[#return]        : 
-#-----|     r0_23(Derived *)        = CopyValue                       : r0_3
-#-----|     mu0_24(Derived &)       = Store                           : &:r0_22, r0_23
-#  763|     r0_25(glval<Derived &>) = VariableAddress[#return]        : 
-#  763|     v0_26(void)             = ReturnValue                     : &:r0_25, ~mu0_2
-#  763|     v0_27(void)             = UnmodeledUse                    : mu*
-#  763|     v0_28(void)             = ExitFunction                    : 
+#  763|     r0_20(glval<unknown>)   = FunctionAddress[operator=]      : 
+#-----|     r0_21(glval<Derived &>) = VariableAddress[p#0]            : 
+#-----|     r0_22(Derived &)        = Load                            : &:r0_21, ~mu0_2
+#-----|     r0_23(glval<String>)    = FieldAddress[derived_s]         : r0_22
+#  763|     r0_24(String &)         = Call                            : func:r0_20, this:r0_19, 0:r0_23
+#  763|     mu0_25(unknown)         = ^CallSideEffect                 : ~mu0_2
+#-----|     v0_26(void)             = ^IndirectReadSideEffect         : &:r0_19, ~mu0_2
+#-----|     v0_27(void)             = ^IndirectReadSideEffect[p#0]    : &:r0_23, ~mu0_2
+#-----|     r0_28(String)           = ^IndirectMayWriteSideEffect     : &:r0_19, ~mu0_2
+#-----|     mu0_29(unknown)         = ^BufferMayWriteSideEffect[p#0]  : &:r0_23, ~mu0_2
+#-----|     r0_30(glval<Derived &>) = VariableAddress[#return]        : 
+#-----|     r0_31(Derived *)        = CopyValue                       : r0_3
+#-----|     mu0_32(Derived &)       = Store                           : &:r0_30, r0_31
+#  763|     r0_33(glval<Derived &>) = VariableAddress[#return]        : 
+#  763|     v0_34(void)             = ReturnValue                     : &:r0_33, ~mu0_2
+#  763|     v0_35(void)             = UnmodeledUse                    : mu*
+#  763|     v0_36(void)             = ExitFunction                    : 
 
 #  766| void Derived::Derived()
 #  766|   Block 0
@@ -3595,180 +3645,228 @@ ir.cpp:
 #  808|     r0_27(glval<Base>)         = ConvertToBase[Middle : Base]           : r0_26
 #  808|     r0_28(Base &)              = Call                                   : func:r0_25, this:r0_24, 0:r0_27
 #  808|     mu0_29(unknown)            = ^CallSideEffect                        : ~mu0_2
-#  809|     r0_30(glval<Base>)         = VariableAddress[b]                     : 
-#  809|     r0_31(glval<unknown>)      = FunctionAddress[operator=]             : 
-#  809|     r0_32(glval<unknown>)      = FunctionAddress[Base]                  : 
-#  809|     r0_33(glval<Middle>)       = VariableAddress[m]                     : 
-#  809|     r0_34(glval<Base>)         = ConvertToBase[Middle : Base]           : r0_33
-#  809|     v0_35(void)                = Call                                   : func:r0_32, 0:r0_34
-#  809|     mu0_36(unknown)            = ^CallSideEffect                        : ~mu0_2
-#  809|     r0_37(glval<Base>)         = Convert                                : v0_35
-#  809|     r0_38(Base &)              = Call                                   : func:r0_31, this:r0_30, 0:r0_37
-#  809|     mu0_39(unknown)            = ^CallSideEffect                        : ~mu0_2
-#  810|     r0_40(glval<Base>)         = VariableAddress[b]                     : 
-#  810|     r0_41(glval<unknown>)      = FunctionAddress[operator=]             : 
-#  810|     r0_42(glval<unknown>)      = FunctionAddress[Base]                  : 
-#  810|     r0_43(glval<Middle>)       = VariableAddress[m]                     : 
-#  810|     r0_44(glval<Base>)         = ConvertToBase[Middle : Base]           : r0_43
-#  810|     v0_45(void)                = Call                                   : func:r0_42, 0:r0_44
-#  810|     mu0_46(unknown)            = ^CallSideEffect                        : ~mu0_2
-#  810|     r0_47(glval<Base>)         = Convert                                : v0_45
-#  810|     r0_48(Base &)              = Call                                   : func:r0_41, this:r0_40, 0:r0_47
-#  810|     mu0_49(unknown)            = ^CallSideEffect                        : ~mu0_2
-#  811|     r0_50(glval<Middle *>)     = VariableAddress[pm]                    : 
-#  811|     r0_51(Middle *)            = Load                                   : &:r0_50, ~mu0_2
-#  811|     r0_52(Base *)              = ConvertToBase[Middle : Base]           : r0_51
-#  811|     r0_53(glval<Base *>)       = VariableAddress[pb]                    : 
-#  811|     mu0_54(Base *)             = Store                                  : &:r0_53, r0_52
-#  812|     r0_55(glval<Middle *>)     = VariableAddress[pm]                    : 
-#  812|     r0_56(Middle *)            = Load                                   : &:r0_55, ~mu0_2
-#  812|     r0_57(Base *)              = ConvertToBase[Middle : Base]           : r0_56
-#  812|     r0_58(glval<Base *>)       = VariableAddress[pb]                    : 
-#  812|     mu0_59(Base *)             = Store                                  : &:r0_58, r0_57
-#  813|     r0_60(glval<Middle *>)     = VariableAddress[pm]                    : 
-#  813|     r0_61(Middle *)            = Load                                   : &:r0_60, ~mu0_2
-#  813|     r0_62(Base *)              = ConvertToBase[Middle : Base]           : r0_61
-#  813|     r0_63(glval<Base *>)       = VariableAddress[pb]                    : 
-#  813|     mu0_64(Base *)             = Store                                  : &:r0_63, r0_62
-#  814|     r0_65(glval<Middle *>)     = VariableAddress[pm]                    : 
-#  814|     r0_66(Middle *)            = Load                                   : &:r0_65, ~mu0_2
-#  814|     r0_67(Base *)              = Convert                                : r0_66
-#  814|     r0_68(glval<Base *>)       = VariableAddress[pb]                    : 
-#  814|     mu0_69(Base *)             = Store                                  : &:r0_68, r0_67
-#  816|     r0_70(glval<Middle>)       = VariableAddress[m]                     : 
-#  816|     r0_71(glval<unknown>)      = FunctionAddress[operator=]             : 
-#  816|     r0_72(glval<Base>)         = VariableAddress[b]                     : 
-#  816|     r0_73(glval<Middle>)       = ConvertToDerived[Middle : Base]        : r0_72
-#  816|     r0_74(glval<Middle>)       = Convert                                : r0_73
-#  816|     r0_75(Middle &)            = Call                                   : func:r0_71, this:r0_70, 0:r0_74
-#  816|     mu0_76(unknown)            = ^CallSideEffect                        : ~mu0_2
-#  817|     r0_77(glval<Middle>)       = VariableAddress[m]                     : 
-#  817|     r0_78(glval<unknown>)      = FunctionAddress[operator=]             : 
-#  817|     r0_79(glval<Base>)         = VariableAddress[b]                     : 
-#  817|     r0_80(glval<Middle>)       = ConvertToDerived[Middle : Base]        : r0_79
-#  817|     r0_81(glval<Middle>)       = Convert                                : r0_80
-#  817|     r0_82(Middle &)            = Call                                   : func:r0_78, this:r0_77, 0:r0_81
-#  817|     mu0_83(unknown)            = ^CallSideEffect                        : ~mu0_2
-#  818|     r0_84(glval<Base *>)       = VariableAddress[pb]                    : 
-#  818|     r0_85(Base *)              = Load                                   : &:r0_84, ~mu0_2
-#  818|     r0_86(Middle *)            = ConvertToDerived[Middle : Base]        : r0_85
-#  818|     r0_87(glval<Middle *>)     = VariableAddress[pm]                    : 
-#  818|     mu0_88(Middle *)           = Store                                  : &:r0_87, r0_86
-#  819|     r0_89(glval<Base *>)       = VariableAddress[pb]                    : 
-#  819|     r0_90(Base *)              = Load                                   : &:r0_89, ~mu0_2
-#  819|     r0_91(Middle *)            = ConvertToDerived[Middle : Base]        : r0_90
-#  819|     r0_92(glval<Middle *>)     = VariableAddress[pm]                    : 
-#  819|     mu0_93(Middle *)           = Store                                  : &:r0_92, r0_91
-#  820|     r0_94(glval<Base *>)       = VariableAddress[pb]                    : 
-#  820|     r0_95(Base *)              = Load                                   : &:r0_94, ~mu0_2
-#  820|     r0_96(Middle *)            = Convert                                : r0_95
-#  820|     r0_97(glval<Middle *>)     = VariableAddress[pm]                    : 
-#  820|     mu0_98(Middle *)           = Store                                  : &:r0_97, r0_96
-#  822|     r0_99(glval<Base>)         = VariableAddress[b]                     : 
-#  822|     r0_100(glval<unknown>)     = FunctionAddress[operator=]             : 
-#  822|     r0_101(glval<Derived>)     = VariableAddress[d]                     : 
-#  822|     r0_102(glval<Middle>)      = ConvertToBase[Derived : Middle]        : r0_101
-#  822|     r0_103(glval<Base>)        = ConvertToBase[Middle : Base]           : r0_102
-#  822|     r0_104(Base &)             = Call                                   : func:r0_100, this:r0_99, 0:r0_103
-#  822|     mu0_105(unknown)           = ^CallSideEffect                        : ~mu0_2
-#  823|     r0_106(glval<Base>)        = VariableAddress[b]                     : 
-#  823|     r0_107(glval<unknown>)     = FunctionAddress[operator=]             : 
-#  823|     r0_108(glval<unknown>)     = FunctionAddress[Base]                  : 
-#  823|     r0_109(glval<Derived>)     = VariableAddress[d]                     : 
-#  823|     r0_110(glval<Middle>)      = ConvertToBase[Derived : Middle]        : r0_109
-#  823|     r0_111(glval<Base>)        = ConvertToBase[Middle : Base]           : r0_110
-#  823|     v0_112(void)               = Call                                   : func:r0_108, 0:r0_111
-#  823|     mu0_113(unknown)           = ^CallSideEffect                        : ~mu0_2
-#  823|     r0_114(glval<Base>)        = Convert                                : v0_112
-#  823|     r0_115(Base &)             = Call                                   : func:r0_107, this:r0_106, 0:r0_114
-#  823|     mu0_116(unknown)           = ^CallSideEffect                        : ~mu0_2
-#  824|     r0_117(glval<Base>)        = VariableAddress[b]                     : 
-#  824|     r0_118(glval<unknown>)     = FunctionAddress[operator=]             : 
-#  824|     r0_119(glval<unknown>)     = FunctionAddress[Base]                  : 
-#  824|     r0_120(glval<Derived>)     = VariableAddress[d]                     : 
-#  824|     r0_121(glval<Middle>)      = ConvertToBase[Derived : Middle]        : r0_120
-#  824|     r0_122(glval<Base>)        = ConvertToBase[Middle : Base]           : r0_121
-#  824|     v0_123(void)               = Call                                   : func:r0_119, 0:r0_122
-#  824|     mu0_124(unknown)           = ^CallSideEffect                        : ~mu0_2
-#  824|     r0_125(glval<Base>)        = Convert                                : v0_123
-#  824|     r0_126(Base &)             = Call                                   : func:r0_118, this:r0_117, 0:r0_125
-#  824|     mu0_127(unknown)           = ^CallSideEffect                        : ~mu0_2
-#  825|     r0_128(glval<Derived *>)   = VariableAddress[pd]                    : 
-#  825|     r0_129(Derived *)          = Load                                   : &:r0_128, ~mu0_2
-#  825|     r0_130(Middle *)           = ConvertToBase[Derived : Middle]        : r0_129
-#  825|     r0_131(Base *)             = ConvertToBase[Middle : Base]           : r0_130
-#  825|     r0_132(glval<Base *>)      = VariableAddress[pb]                    : 
-#  825|     mu0_133(Base *)            = Store                                  : &:r0_132, r0_131
-#  826|     r0_134(glval<Derived *>)   = VariableAddress[pd]                    : 
-#  826|     r0_135(Derived *)          = Load                                   : &:r0_134, ~mu0_2
-#  826|     r0_136(Middle *)           = ConvertToBase[Derived : Middle]        : r0_135
-#  826|     r0_137(Base *)             = ConvertToBase[Middle : Base]           : r0_136
-#  826|     r0_138(glval<Base *>)      = VariableAddress[pb]                    : 
-#  826|     mu0_139(Base *)            = Store                                  : &:r0_138, r0_137
-#  827|     r0_140(glval<Derived *>)   = VariableAddress[pd]                    : 
-#  827|     r0_141(Derived *)          = Load                                   : &:r0_140, ~mu0_2
-#  827|     r0_142(Middle *)           = ConvertToBase[Derived : Middle]        : r0_141
-#  827|     r0_143(Base *)             = ConvertToBase[Middle : Base]           : r0_142
-#  827|     r0_144(glval<Base *>)      = VariableAddress[pb]                    : 
-#  827|     mu0_145(Base *)            = Store                                  : &:r0_144, r0_143
-#  828|     r0_146(glval<Derived *>)   = VariableAddress[pd]                    : 
-#  828|     r0_147(Derived *)          = Load                                   : &:r0_146, ~mu0_2
-#  828|     r0_148(Base *)             = Convert                                : r0_147
-#  828|     r0_149(glval<Base *>)      = VariableAddress[pb]                    : 
-#  828|     mu0_150(Base *)            = Store                                  : &:r0_149, r0_148
-#  830|     r0_151(glval<Derived>)     = VariableAddress[d]                     : 
-#  830|     r0_152(glval<unknown>)     = FunctionAddress[operator=]             : 
-#  830|     r0_153(glval<Base>)        = VariableAddress[b]                     : 
-#  830|     r0_154(glval<Middle>)      = ConvertToDerived[Middle : Base]        : r0_153
-#  830|     r0_155(glval<Derived>)     = ConvertToDerived[Derived : Middle]     : r0_154
-#  830|     r0_156(glval<Derived>)     = Convert                                : r0_155
-#  830|     r0_157(Derived &)          = Call                                   : func:r0_152, this:r0_151, 0:r0_156
-#  830|     mu0_158(unknown)           = ^CallSideEffect                        : ~mu0_2
-#  831|     r0_159(glval<Derived>)     = VariableAddress[d]                     : 
-#  831|     r0_160(glval<unknown>)     = FunctionAddress[operator=]             : 
-#  831|     r0_161(glval<Base>)        = VariableAddress[b]                     : 
-#  831|     r0_162(glval<Middle>)      = ConvertToDerived[Middle : Base]        : r0_161
-#  831|     r0_163(glval<Derived>)     = ConvertToDerived[Derived : Middle]     : r0_162
-#  831|     r0_164(glval<Derived>)     = Convert                                : r0_163
-#  831|     r0_165(Derived &)          = Call                                   : func:r0_160, this:r0_159, 0:r0_164
-#  831|     mu0_166(unknown)           = ^CallSideEffect                        : ~mu0_2
-#  832|     r0_167(glval<Base *>)      = VariableAddress[pb]                    : 
-#  832|     r0_168(Base *)             = Load                                   : &:r0_167, ~mu0_2
-#  832|     r0_169(Middle *)           = ConvertToDerived[Middle : Base]        : r0_168
-#  832|     r0_170(Derived *)          = ConvertToDerived[Derived : Middle]     : r0_169
-#  832|     r0_171(glval<Derived *>)   = VariableAddress[pd]                    : 
-#  832|     mu0_172(Derived *)         = Store                                  : &:r0_171, r0_170
-#  833|     r0_173(glval<Base *>)      = VariableAddress[pb]                    : 
-#  833|     r0_174(Base *)             = Load                                   : &:r0_173, ~mu0_2
-#  833|     r0_175(Middle *)           = ConvertToDerived[Middle : Base]        : r0_174
-#  833|     r0_176(Derived *)          = ConvertToDerived[Derived : Middle]     : r0_175
-#  833|     r0_177(glval<Derived *>)   = VariableAddress[pd]                    : 
-#  833|     mu0_178(Derived *)         = Store                                  : &:r0_177, r0_176
-#  834|     r0_179(glval<Base *>)      = VariableAddress[pb]                    : 
-#  834|     r0_180(Base *)             = Load                                   : &:r0_179, ~mu0_2
-#  834|     r0_181(Derived *)          = Convert                                : r0_180
-#  834|     r0_182(glval<Derived *>)   = VariableAddress[pd]                    : 
-#  834|     mu0_183(Derived *)         = Store                                  : &:r0_182, r0_181
-#  836|     r0_184(glval<MiddleVB1 *>) = VariableAddress[pmv]                   : 
-#  836|     r0_185(MiddleVB1 *)        = Constant[0]                            : 
-#  836|     mu0_186(MiddleVB1 *)       = Store                                  : &:r0_184, r0_185
-#  837|     r0_187(glval<DerivedVB *>) = VariableAddress[pdv]                   : 
-#  837|     r0_188(DerivedVB *)        = Constant[0]                            : 
-#  837|     mu0_189(DerivedVB *)       = Store                                  : &:r0_187, r0_188
-#  838|     r0_190(glval<MiddleVB1 *>) = VariableAddress[pmv]                   : 
-#  838|     r0_191(MiddleVB1 *)        = Load                                   : &:r0_190, ~mu0_2
-#  838|     r0_192(Base *)             = ConvertToVirtualBase[MiddleVB1 : Base] : r0_191
-#  838|     r0_193(glval<Base *>)      = VariableAddress[pb]                    : 
-#  838|     mu0_194(Base *)            = Store                                  : &:r0_193, r0_192
-#  839|     r0_195(glval<DerivedVB *>) = VariableAddress[pdv]                   : 
-#  839|     r0_196(DerivedVB *)        = Load                                   : &:r0_195, ~mu0_2
-#  839|     r0_197(Base *)             = ConvertToVirtualBase[DerivedVB : Base] : r0_196
-#  839|     r0_198(glval<Base *>)      = VariableAddress[pb]                    : 
-#  839|     mu0_199(Base *)            = Store                                  : &:r0_198, r0_197
-#  840|     v0_200(void)               = NoOp                                   : 
-#  799|     v0_201(void)               = ReturnVoid                             : 
-#  799|     v0_202(void)               = UnmodeledUse                           : mu*
-#  799|     v0_203(void)               = ExitFunction                           : 
+#  808|     v0_30(void)                = ^IndirectReadSideEffect                : &:r0_24, ~mu0_2
+#  808|     v0_31(void)                = ^IndirectReadSideEffect[p#0]           : &:r0_27, ~mu0_2
+#  808|     r0_32(Base)                = ^IndirectMayWriteSideEffect            : &:r0_24, ~mu0_2
+#  808|     mu0_33(unknown)            = ^BufferMayWriteSideEffect[p#0]         : &:r0_27, ~mu0_2
+#  809|     r0_34(glval<Base>)         = VariableAddress[b]                     : 
+#  809|     r0_35(glval<unknown>)      = FunctionAddress[operator=]             : 
+#  809|     r0_36(glval<unknown>)      = FunctionAddress[Base]                  : 
+#  809|     r0_37(glval<Middle>)       = VariableAddress[m]                     : 
+#  809|     r0_38(glval<Base>)         = ConvertToBase[Middle : Base]           : r0_37
+#  809|     v0_39(void)                = Call                                   : func:r0_36, 0:r0_38
+#  809|     mu0_40(unknown)            = ^CallSideEffect                        : ~mu0_2
+#  809|     v0_41(void)                = ^IndirectReadSideEffect[p#0]           : &:r0_38, ~mu0_2
+#  809|     mu0_42(unknown)            = ^BufferMayWriteSideEffect[p#0]         : &:r0_38, ~mu0_2
+#  809|     r0_43(glval<Base>)         = Convert                                : v0_39
+#  809|     r0_44(Base &)              = Call                                   : func:r0_35, this:r0_34, 0:r0_43
+#  809|     mu0_45(unknown)            = ^CallSideEffect                        : ~mu0_2
+#  809|     v0_46(void)                = ^IndirectReadSideEffect                : &:r0_34, ~mu0_2
+#  809|     v0_47(void)                = ^IndirectReadSideEffect[p#0]           : &:r0_43, ~mu0_2
+#  809|     r0_48(Base)                = ^IndirectMayWriteSideEffect            : &:r0_34, ~mu0_2
+#  809|     mu0_49(unknown)            = ^BufferMayWriteSideEffect[p#0]         : &:r0_43, ~mu0_2
+#  810|     r0_50(glval<Base>)         = VariableAddress[b]                     : 
+#  810|     r0_51(glval<unknown>)      = FunctionAddress[operator=]             : 
+#  810|     r0_52(glval<unknown>)      = FunctionAddress[Base]                  : 
+#  810|     r0_53(glval<Middle>)       = VariableAddress[m]                     : 
+#  810|     r0_54(glval<Base>)         = ConvertToBase[Middle : Base]           : r0_53
+#  810|     v0_55(void)                = Call                                   : func:r0_52, 0:r0_54
+#  810|     mu0_56(unknown)            = ^CallSideEffect                        : ~mu0_2
+#  810|     v0_57(void)                = ^IndirectReadSideEffect[p#0]           : &:r0_54, ~mu0_2
+#  810|     mu0_58(unknown)            = ^BufferMayWriteSideEffect[p#0]         : &:r0_54, ~mu0_2
+#  810|     r0_59(glval<Base>)         = Convert                                : v0_55
+#  810|     r0_60(Base &)              = Call                                   : func:r0_51, this:r0_50, 0:r0_59
+#  810|     mu0_61(unknown)            = ^CallSideEffect                        : ~mu0_2
+#  810|     v0_62(void)                = ^IndirectReadSideEffect                : &:r0_50, ~mu0_2
+#  810|     v0_63(void)                = ^IndirectReadSideEffect[p#0]           : &:r0_59, ~mu0_2
+#  810|     r0_64(Base)                = ^IndirectMayWriteSideEffect            : &:r0_50, ~mu0_2
+#  810|     mu0_65(unknown)            = ^BufferMayWriteSideEffect[p#0]         : &:r0_59, ~mu0_2
+#  811|     r0_66(glval<Middle *>)     = VariableAddress[pm]                    : 
+#  811|     r0_67(Middle *)            = Load                                   : &:r0_66, ~mu0_2
+#  811|     r0_68(Base *)              = ConvertToBase[Middle : Base]           : r0_67
+#  811|     r0_69(glval<Base *>)       = VariableAddress[pb]                    : 
+#  811|     mu0_70(Base *)             = Store                                  : &:r0_69, r0_68
+#  812|     r0_71(glval<Middle *>)     = VariableAddress[pm]                    : 
+#  812|     r0_72(Middle *)            = Load                                   : &:r0_71, ~mu0_2
+#  812|     r0_73(Base *)              = ConvertToBase[Middle : Base]           : r0_72
+#  812|     r0_74(glval<Base *>)       = VariableAddress[pb]                    : 
+#  812|     mu0_75(Base *)             = Store                                  : &:r0_74, r0_73
+#  813|     r0_76(glval<Middle *>)     = VariableAddress[pm]                    : 
+#  813|     r0_77(Middle *)            = Load                                   : &:r0_76, ~mu0_2
+#  813|     r0_78(Base *)              = ConvertToBase[Middle : Base]           : r0_77
+#  813|     r0_79(glval<Base *>)       = VariableAddress[pb]                    : 
+#  813|     mu0_80(Base *)             = Store                                  : &:r0_79, r0_78
+#  814|     r0_81(glval<Middle *>)     = VariableAddress[pm]                    : 
+#  814|     r0_82(Middle *)            = Load                                   : &:r0_81, ~mu0_2
+#  814|     r0_83(Base *)              = Convert                                : r0_82
+#  814|     r0_84(glval<Base *>)       = VariableAddress[pb]                    : 
+#  814|     mu0_85(Base *)             = Store                                  : &:r0_84, r0_83
+#  816|     r0_86(glval<Middle>)       = VariableAddress[m]                     : 
+#  816|     r0_87(glval<unknown>)      = FunctionAddress[operator=]             : 
+#  816|     r0_88(glval<Base>)         = VariableAddress[b]                     : 
+#  816|     r0_89(glval<Middle>)       = ConvertToDerived[Middle : Base]        : r0_88
+#  816|     r0_90(glval<Middle>)       = Convert                                : r0_89
+#  816|     r0_91(Middle &)            = Call                                   : func:r0_87, this:r0_86, 0:r0_90
+#  816|     mu0_92(unknown)            = ^CallSideEffect                        : ~mu0_2
+#  816|     v0_93(void)                = ^IndirectReadSideEffect                : &:r0_86, ~mu0_2
+#  816|     v0_94(void)                = ^IndirectReadSideEffect[p#0]           : &:r0_90, ~mu0_2
+#  816|     r0_95(Middle)              = ^IndirectMayWriteSideEffect            : &:r0_86, ~mu0_2
+#  816|     mu0_96(unknown)            = ^BufferMayWriteSideEffect[p#0]         : &:r0_90, ~mu0_2
+#  817|     r0_97(glval<Middle>)       = VariableAddress[m]                     : 
+#  817|     r0_98(glval<unknown>)      = FunctionAddress[operator=]             : 
+#  817|     r0_99(glval<Base>)         = VariableAddress[b]                     : 
+#  817|     r0_100(glval<Middle>)      = ConvertToDerived[Middle : Base]        : r0_99
+#  817|     r0_101(glval<Middle>)      = Convert                                : r0_100
+#  817|     r0_102(Middle &)           = Call                                   : func:r0_98, this:r0_97, 0:r0_101
+#  817|     mu0_103(unknown)           = ^CallSideEffect                        : ~mu0_2
+#  817|     v0_104(void)               = ^IndirectReadSideEffect                : &:r0_97, ~mu0_2
+#  817|     v0_105(void)               = ^IndirectReadSideEffect[p#0]           : &:r0_101, ~mu0_2
+#  817|     r0_106(Middle)             = ^IndirectMayWriteSideEffect            : &:r0_97, ~mu0_2
+#  817|     mu0_107(unknown)           = ^BufferMayWriteSideEffect[p#0]         : &:r0_101, ~mu0_2
+#  818|     r0_108(glval<Base *>)      = VariableAddress[pb]                    : 
+#  818|     r0_109(Base *)             = Load                                   : &:r0_108, ~mu0_2
+#  818|     r0_110(Middle *)           = ConvertToDerived[Middle : Base]        : r0_109
+#  818|     r0_111(glval<Middle *>)    = VariableAddress[pm]                    : 
+#  818|     mu0_112(Middle *)          = Store                                  : &:r0_111, r0_110
+#  819|     r0_113(glval<Base *>)      = VariableAddress[pb]                    : 
+#  819|     r0_114(Base *)             = Load                                   : &:r0_113, ~mu0_2
+#  819|     r0_115(Middle *)           = ConvertToDerived[Middle : Base]        : r0_114
+#  819|     r0_116(glval<Middle *>)    = VariableAddress[pm]                    : 
+#  819|     mu0_117(Middle *)          = Store                                  : &:r0_116, r0_115
+#  820|     r0_118(glval<Base *>)      = VariableAddress[pb]                    : 
+#  820|     r0_119(Base *)             = Load                                   : &:r0_118, ~mu0_2
+#  820|     r0_120(Middle *)           = Convert                                : r0_119
+#  820|     r0_121(glval<Middle *>)    = VariableAddress[pm]                    : 
+#  820|     mu0_122(Middle *)          = Store                                  : &:r0_121, r0_120
+#  822|     r0_123(glval<Base>)        = VariableAddress[b]                     : 
+#  822|     r0_124(glval<unknown>)     = FunctionAddress[operator=]             : 
+#  822|     r0_125(glval<Derived>)     = VariableAddress[d]                     : 
+#  822|     r0_126(glval<Middle>)      = ConvertToBase[Derived : Middle]        : r0_125
+#  822|     r0_127(glval<Base>)        = ConvertToBase[Middle : Base]           : r0_126
+#  822|     r0_128(Base &)             = Call                                   : func:r0_124, this:r0_123, 0:r0_127
+#  822|     mu0_129(unknown)           = ^CallSideEffect                        : ~mu0_2
+#  822|     v0_130(void)               = ^IndirectReadSideEffect                : &:r0_123, ~mu0_2
+#  822|     v0_131(void)               = ^IndirectReadSideEffect[p#0]           : &:r0_127, ~mu0_2
+#  822|     r0_132(Base)               = ^IndirectMayWriteSideEffect            : &:r0_123, ~mu0_2
+#  822|     mu0_133(unknown)           = ^BufferMayWriteSideEffect[p#0]         : &:r0_127, ~mu0_2
+#  823|     r0_134(glval<Base>)        = VariableAddress[b]                     : 
+#  823|     r0_135(glval<unknown>)     = FunctionAddress[operator=]             : 
+#  823|     r0_136(glval<unknown>)     = FunctionAddress[Base]                  : 
+#  823|     r0_137(glval<Derived>)     = VariableAddress[d]                     : 
+#  823|     r0_138(glval<Middle>)      = ConvertToBase[Derived : Middle]        : r0_137
+#  823|     r0_139(glval<Base>)        = ConvertToBase[Middle : Base]           : r0_138
+#  823|     v0_140(void)               = Call                                   : func:r0_136, 0:r0_139
+#  823|     mu0_141(unknown)           = ^CallSideEffect                        : ~mu0_2
+#  823|     v0_142(void)               = ^IndirectReadSideEffect[p#0]           : &:r0_139, ~mu0_2
+#  823|     mu0_143(unknown)           = ^BufferMayWriteSideEffect[p#0]         : &:r0_139, ~mu0_2
+#  823|     r0_144(glval<Base>)        = Convert                                : v0_140
+#  823|     r0_145(Base &)             = Call                                   : func:r0_135, this:r0_134, 0:r0_144
+#  823|     mu0_146(unknown)           = ^CallSideEffect                        : ~mu0_2
+#  823|     v0_147(void)               = ^IndirectReadSideEffect                : &:r0_134, ~mu0_2
+#  823|     v0_148(void)               = ^IndirectReadSideEffect[p#0]           : &:r0_144, ~mu0_2
+#  823|     r0_149(Base)               = ^IndirectMayWriteSideEffect            : &:r0_134, ~mu0_2
+#  823|     mu0_150(unknown)           = ^BufferMayWriteSideEffect[p#0]         : &:r0_144, ~mu0_2
+#  824|     r0_151(glval<Base>)        = VariableAddress[b]                     : 
+#  824|     r0_152(glval<unknown>)     = FunctionAddress[operator=]             : 
+#  824|     r0_153(glval<unknown>)     = FunctionAddress[Base]                  : 
+#  824|     r0_154(glval<Derived>)     = VariableAddress[d]                     : 
+#  824|     r0_155(glval<Middle>)      = ConvertToBase[Derived : Middle]        : r0_154
+#  824|     r0_156(glval<Base>)        = ConvertToBase[Middle : Base]           : r0_155
+#  824|     v0_157(void)               = Call                                   : func:r0_153, 0:r0_156
+#  824|     mu0_158(unknown)           = ^CallSideEffect                        : ~mu0_2
+#  824|     v0_159(void)               = ^IndirectReadSideEffect[p#0]           : &:r0_156, ~mu0_2
+#  824|     mu0_160(unknown)           = ^BufferMayWriteSideEffect[p#0]         : &:r0_156, ~mu0_2
+#  824|     r0_161(glval<Base>)        = Convert                                : v0_157
+#  824|     r0_162(Base &)             = Call                                   : func:r0_152, this:r0_151, 0:r0_161
+#  824|     mu0_163(unknown)           = ^CallSideEffect                        : ~mu0_2
+#  824|     v0_164(void)               = ^IndirectReadSideEffect                : &:r0_151, ~mu0_2
+#  824|     v0_165(void)               = ^IndirectReadSideEffect[p#0]           : &:r0_161, ~mu0_2
+#  824|     r0_166(Base)               = ^IndirectMayWriteSideEffect            : &:r0_151, ~mu0_2
+#  824|     mu0_167(unknown)           = ^BufferMayWriteSideEffect[p#0]         : &:r0_161, ~mu0_2
+#  825|     r0_168(glval<Derived *>)   = VariableAddress[pd]                    : 
+#  825|     r0_169(Derived *)          = Load                                   : &:r0_168, ~mu0_2
+#  825|     r0_170(Middle *)           = ConvertToBase[Derived : Middle]        : r0_169
+#  825|     r0_171(Base *)             = ConvertToBase[Middle : Base]           : r0_170
+#  825|     r0_172(glval<Base *>)      = VariableAddress[pb]                    : 
+#  825|     mu0_173(Base *)            = Store                                  : &:r0_172, r0_171
+#  826|     r0_174(glval<Derived *>)   = VariableAddress[pd]                    : 
+#  826|     r0_175(Derived *)          = Load                                   : &:r0_174, ~mu0_2
+#  826|     r0_176(Middle *)           = ConvertToBase[Derived : Middle]        : r0_175
+#  826|     r0_177(Base *)             = ConvertToBase[Middle : Base]           : r0_176
+#  826|     r0_178(glval<Base *>)      = VariableAddress[pb]                    : 
+#  826|     mu0_179(Base *)            = Store                                  : &:r0_178, r0_177
+#  827|     r0_180(glval<Derived *>)   = VariableAddress[pd]                    : 
+#  827|     r0_181(Derived *)          = Load                                   : &:r0_180, ~mu0_2
+#  827|     r0_182(Middle *)           = ConvertToBase[Derived : Middle]        : r0_181
+#  827|     r0_183(Base *)             = ConvertToBase[Middle : Base]           : r0_182
+#  827|     r0_184(glval<Base *>)      = VariableAddress[pb]                    : 
+#  827|     mu0_185(Base *)            = Store                                  : &:r0_184, r0_183
+#  828|     r0_186(glval<Derived *>)   = VariableAddress[pd]                    : 
+#  828|     r0_187(Derived *)          = Load                                   : &:r0_186, ~mu0_2
+#  828|     r0_188(Base *)             = Convert                                : r0_187
+#  828|     r0_189(glval<Base *>)      = VariableAddress[pb]                    : 
+#  828|     mu0_190(Base *)            = Store                                  : &:r0_189, r0_188
+#  830|     r0_191(glval<Derived>)     = VariableAddress[d]                     : 
+#  830|     r0_192(glval<unknown>)     = FunctionAddress[operator=]             : 
+#  830|     r0_193(glval<Base>)        = VariableAddress[b]                     : 
+#  830|     r0_194(glval<Middle>)      = ConvertToDerived[Middle : Base]        : r0_193
+#  830|     r0_195(glval<Derived>)     = ConvertToDerived[Derived : Middle]     : r0_194
+#  830|     r0_196(glval<Derived>)     = Convert                                : r0_195
+#  830|     r0_197(Derived &)          = Call                                   : func:r0_192, this:r0_191, 0:r0_196
+#  830|     mu0_198(unknown)           = ^CallSideEffect                        : ~mu0_2
+#  830|     v0_199(void)               = ^IndirectReadSideEffect                : &:r0_191, ~mu0_2
+#  830|     v0_200(void)               = ^IndirectReadSideEffect[p#0]           : &:r0_196, ~mu0_2
+#  830|     r0_201(Derived)            = ^IndirectMayWriteSideEffect            : &:r0_191, ~mu0_2
+#  830|     mu0_202(unknown)           = ^BufferMayWriteSideEffect[p#0]         : &:r0_196, ~mu0_2
+#  831|     r0_203(glval<Derived>)     = VariableAddress[d]                     : 
+#  831|     r0_204(glval<unknown>)     = FunctionAddress[operator=]             : 
+#  831|     r0_205(glval<Base>)        = VariableAddress[b]                     : 
+#  831|     r0_206(glval<Middle>)      = ConvertToDerived[Middle : Base]        : r0_205
+#  831|     r0_207(glval<Derived>)     = ConvertToDerived[Derived : Middle]     : r0_206
+#  831|     r0_208(glval<Derived>)     = Convert                                : r0_207
+#  831|     r0_209(Derived &)          = Call                                   : func:r0_204, this:r0_203, 0:r0_208
+#  831|     mu0_210(unknown)           = ^CallSideEffect                        : ~mu0_2
+#  831|     v0_211(void)               = ^IndirectReadSideEffect                : &:r0_203, ~mu0_2
+#  831|     v0_212(void)               = ^IndirectReadSideEffect[p#0]           : &:r0_208, ~mu0_2
+#  831|     r0_213(Derived)            = ^IndirectMayWriteSideEffect            : &:r0_203, ~mu0_2
+#  831|     mu0_214(unknown)           = ^BufferMayWriteSideEffect[p#0]         : &:r0_208, ~mu0_2
+#  832|     r0_215(glval<Base *>)      = VariableAddress[pb]                    : 
+#  832|     r0_216(Base *)             = Load                                   : &:r0_215, ~mu0_2
+#  832|     r0_217(Middle *)           = ConvertToDerived[Middle : Base]        : r0_216
+#  832|     r0_218(Derived *)          = ConvertToDerived[Derived : Middle]     : r0_217
+#  832|     r0_219(glval<Derived *>)   = VariableAddress[pd]                    : 
+#  832|     mu0_220(Derived *)         = Store                                  : &:r0_219, r0_218
+#  833|     r0_221(glval<Base *>)      = VariableAddress[pb]                    : 
+#  833|     r0_222(Base *)             = Load                                   : &:r0_221, ~mu0_2
+#  833|     r0_223(Middle *)           = ConvertToDerived[Middle : Base]        : r0_222
+#  833|     r0_224(Derived *)          = ConvertToDerived[Derived : Middle]     : r0_223
+#  833|     r0_225(glval<Derived *>)   = VariableAddress[pd]                    : 
+#  833|     mu0_226(Derived *)         = Store                                  : &:r0_225, r0_224
+#  834|     r0_227(glval<Base *>)      = VariableAddress[pb]                    : 
+#  834|     r0_228(Base *)             = Load                                   : &:r0_227, ~mu0_2
+#  834|     r0_229(Derived *)          = Convert                                : r0_228
+#  834|     r0_230(glval<Derived *>)   = VariableAddress[pd]                    : 
+#  834|     mu0_231(Derived *)         = Store                                  : &:r0_230, r0_229
+#  836|     r0_232(glval<MiddleVB1 *>) = VariableAddress[pmv]                   : 
+#  836|     r0_233(MiddleVB1 *)        = Constant[0]                            : 
+#  836|     mu0_234(MiddleVB1 *)       = Store                                  : &:r0_232, r0_233
+#  837|     r0_235(glval<DerivedVB *>) = VariableAddress[pdv]                   : 
+#  837|     r0_236(DerivedVB *)        = Constant[0]                            : 
+#  837|     mu0_237(DerivedVB *)       = Store                                  : &:r0_235, r0_236
+#  838|     r0_238(glval<MiddleVB1 *>) = VariableAddress[pmv]                   : 
+#  838|     r0_239(MiddleVB1 *)        = Load                                   : &:r0_238, ~mu0_2
+#  838|     r0_240(Base *)             = ConvertToVirtualBase[MiddleVB1 : Base] : r0_239
+#  838|     r0_241(glval<Base *>)      = VariableAddress[pb]                    : 
+#  838|     mu0_242(Base *)            = Store                                  : &:r0_241, r0_240
+#  839|     r0_243(glval<DerivedVB *>) = VariableAddress[pdv]                   : 
+#  839|     r0_244(DerivedVB *)        = Load                                   : &:r0_243, ~mu0_2
+#  839|     r0_245(Base *)             = ConvertToVirtualBase[DerivedVB : Base] : r0_244
+#  839|     r0_246(glval<Base *>)      = VariableAddress[pb]                    : 
+#  839|     mu0_247(Base *)            = Store                                  : &:r0_246, r0_245
+#  840|     v0_248(void)               = NoOp                                   : 
+#  799|     v0_249(void)               = ReturnVoid                             : 
+#  799|     v0_250(void)               = UnmodeledUse                           : mu*
+#  799|     v0_251(void)               = ExitFunction                           : 
 
 #  842| void PolymorphicBase::PolymorphicBase()
 #  842|   Block 0
@@ -3865,19 +3963,21 @@ ir.cpp:
 
 #  867| void String::String()
 #  867|   Block 0
-#  867|     v0_0(void)           = EnterFunction           : 
-#  867|     mu0_1(unknown)       = AliasedDefinition       : 
-#  867|     mu0_2(unknown)       = UnmodeledDefinition     : 
-#  867|     r0_3(glval<String>)  = InitializeThis          : 
-#  868|     r0_4(glval<unknown>) = FunctionAddress[String] : 
-#  868|     r0_5(glval<char[1]>) = StringConstant[""]      : 
-#  868|     r0_6(char *)         = Convert                 : r0_5
-#  868|     v0_7(void)           = Call                    : func:r0_4, this:r0_3, 0:r0_6
-#  868|     mu0_8(unknown)       = ^CallSideEffect         : ~mu0_2
-#  869|     v0_9(void)           = NoOp                    : 
-#  867|     v0_10(void)          = ReturnVoid              : 
-#  867|     v0_11(void)          = UnmodeledUse            : mu*
-#  867|     v0_12(void)          = ExitFunction            : 
+#  867|     v0_0(void)           = EnterFunction                  : 
+#  867|     mu0_1(unknown)       = AliasedDefinition              : 
+#  867|     mu0_2(unknown)       = UnmodeledDefinition            : 
+#  867|     r0_3(glval<String>)  = InitializeThis                 : 
+#  868|     r0_4(glval<unknown>) = FunctionAddress[String]        : 
+#  868|     r0_5(glval<char[1]>) = StringConstant[""]             : 
+#  868|     r0_6(char *)         = Convert                        : r0_5
+#  868|     v0_7(void)           = Call                           : func:r0_4, this:r0_3, 0:r0_6
+#  868|     mu0_8(unknown)       = ^CallSideEffect                : ~mu0_2
+#  868|     v0_9(void)           = ^IndirectReadSideEffect[p#0]   : &:r0_6, ~mu0_2
+#  868|     mu0_10(unknown)      = ^BufferMayWriteSideEffect[p#0] : &:r0_6, ~mu0_2
+#  869|     v0_11(void)          = NoOp                           : 
+#  867|     v0_12(void)          = ReturnVoid                     : 
+#  867|     v0_13(void)          = UnmodeledUse                   : mu*
+#  867|     v0_14(void)          = ExitFunction                   : 
 
 #  871| void ArrayConversions()
 #  871|   Block 0
@@ -4049,65 +4149,67 @@ ir.cpp:
 
 #  940| void OperatorNew()
 #  940|   Block 0
-#  940|     v0_0(void)            = EnterFunction                 : 
-#  940|     mu0_1(unknown)        = AliasedDefinition             : 
-#  940|     mu0_2(unknown)        = UnmodeledDefinition           : 
-#  941|     r0_3(glval<unknown>)  = FunctionAddress[operator new] : 
-#  941|     r0_4(unsigned long)   = Constant[4]                   : 
-#  941|     r0_5(void *)          = Call                          : func:r0_3, 0:r0_4
-#  941|     mu0_6(unknown)        = ^CallSideEffect               : ~mu0_2
-#  941|     r0_7(int *)           = Convert                       : r0_5
-#  942|     r0_8(glval<unknown>)  = FunctionAddress[operator new] : 
-#  942|     r0_9(unsigned long)   = Constant[4]                   : 
-#  942|     r0_10(float)          = Constant[1.0]                 : 
-#  942|     r0_11(void *)         = Call                          : func:r0_8, 0:r0_9, 1:r0_10
-#  942|     mu0_12(unknown)       = ^CallSideEffect               : ~mu0_2
-#  942|     r0_13(int *)          = Convert                       : r0_11
-#  943|     r0_14(glval<unknown>) = FunctionAddress[operator new] : 
-#  943|     r0_15(unsigned long)  = Constant[4]                   : 
-#  943|     r0_16(void *)         = Call                          : func:r0_14, 0:r0_15
-#  943|     mu0_17(unknown)       = ^CallSideEffect               : ~mu0_2
-#  943|     r0_18(int *)          = Convert                       : r0_16
-#  943|     r0_19(int)            = Constant[0]                   : 
-#  943|     mu0_20(int)           = Store                         : &:r0_18, r0_19
-#  944|     r0_21(glval<unknown>) = FunctionAddress[operator new] : 
-#  944|     r0_22(unsigned long)  = Constant[8]                   : 
-#  944|     r0_23(void *)         = Call                          : func:r0_21, 0:r0_22
-#  944|     mu0_24(unknown)       = ^CallSideEffect               : ~mu0_2
-#  944|     r0_25(String *)       = Convert                       : r0_23
-#  944|     r0_26(glval<unknown>) = FunctionAddress[String]       : 
-#  944|     v0_27(void)           = Call                          : func:r0_26, this:r0_25
-#  944|     mu0_28(unknown)       = ^CallSideEffect               : ~mu0_2
-#  945|     r0_29(glval<unknown>) = FunctionAddress[operator new] : 
-#  945|     r0_30(unsigned long)  = Constant[8]                   : 
-#  945|     r0_31(float)          = Constant[1.0]                 : 
-#  945|     r0_32(void *)         = Call                          : func:r0_29, 0:r0_30, 1:r0_31
-#  945|     mu0_33(unknown)       = ^CallSideEffect               : ~mu0_2
-#  945|     r0_34(String *)       = Convert                       : r0_32
-#  945|     r0_35(glval<unknown>) = FunctionAddress[String]       : 
-#  945|     r0_36(glval<char[6]>) = StringConstant["hello"]       : 
-#  945|     r0_37(char *)         = Convert                       : r0_36
-#  945|     v0_38(void)           = Call                          : func:r0_35, this:r0_34, 0:r0_37
-#  945|     mu0_39(unknown)       = ^CallSideEffect               : ~mu0_2
-#  946|     r0_40(glval<unknown>) = FunctionAddress[operator new] : 
-#  946|     r0_41(unsigned long)  = Constant[256]                 : 
-#  946|     r0_42(align_val_t)    = Constant[128]                 : 
-#  946|     r0_43(void *)         = Call                          : func:r0_40, 0:r0_41, 1:r0_42
-#  946|     mu0_44(unknown)       = ^CallSideEffect               : ~mu0_2
-#  946|     r0_45(Overaligned *)  = Convert                       : r0_43
-#  947|     r0_46(glval<unknown>) = FunctionAddress[operator new] : 
-#  947|     r0_47(unsigned long)  = Constant[256]                 : 
-#  947|     r0_48(align_val_t)    = Constant[128]                 : 
-#  947|     r0_49(float)          = Constant[1.0]                 : 
-#  947|     r0_50(void *)         = Call                          : func:r0_46, 0:r0_47, 1:r0_48, 2:r0_49
-#  947|     mu0_51(unknown)       = ^CallSideEffect               : ~mu0_2
-#  947|     r0_52(Overaligned *)  = Convert                       : r0_50
-#  947|     r0_53(Overaligned)    = Constant[0]                   : 
-#  947|     mu0_54(Overaligned)   = Store                         : &:r0_52, r0_53
-#  948|     v0_55(void)           = NoOp                          : 
-#  940|     v0_56(void)           = ReturnVoid                    : 
-#  940|     v0_57(void)           = UnmodeledUse                  : mu*
-#  940|     v0_58(void)           = ExitFunction                  : 
+#  940|     v0_0(void)            = EnterFunction                  : 
+#  940|     mu0_1(unknown)        = AliasedDefinition              : 
+#  940|     mu0_2(unknown)        = UnmodeledDefinition            : 
+#  941|     r0_3(glval<unknown>)  = FunctionAddress[operator new]  : 
+#  941|     r0_4(unsigned long)   = Constant[4]                    : 
+#  941|     r0_5(void *)          = Call                           : func:r0_3, 0:r0_4
+#  941|     mu0_6(unknown)        = ^CallSideEffect                : ~mu0_2
+#  941|     r0_7(int *)           = Convert                        : r0_5
+#  942|     r0_8(glval<unknown>)  = FunctionAddress[operator new]  : 
+#  942|     r0_9(unsigned long)   = Constant[4]                    : 
+#  942|     r0_10(float)          = Constant[1.0]                  : 
+#  942|     r0_11(void *)         = Call                           : func:r0_8, 0:r0_9, 1:r0_10
+#  942|     mu0_12(unknown)       = ^CallSideEffect                : ~mu0_2
+#  942|     r0_13(int *)          = Convert                        : r0_11
+#  943|     r0_14(glval<unknown>) = FunctionAddress[operator new]  : 
+#  943|     r0_15(unsigned long)  = Constant[4]                    : 
+#  943|     r0_16(void *)         = Call                           : func:r0_14, 0:r0_15
+#  943|     mu0_17(unknown)       = ^CallSideEffect                : ~mu0_2
+#  943|     r0_18(int *)          = Convert                        : r0_16
+#  943|     r0_19(int)            = Constant[0]                    : 
+#  943|     mu0_20(int)           = Store                          : &:r0_18, r0_19
+#  944|     r0_21(glval<unknown>) = FunctionAddress[operator new]  : 
+#  944|     r0_22(unsigned long)  = Constant[8]                    : 
+#  944|     r0_23(void *)         = Call                           : func:r0_21, 0:r0_22
+#  944|     mu0_24(unknown)       = ^CallSideEffect                : ~mu0_2
+#  944|     r0_25(String *)       = Convert                        : r0_23
+#  944|     r0_26(glval<unknown>) = FunctionAddress[String]        : 
+#  944|     v0_27(void)           = Call                           : func:r0_26, this:r0_25
+#  944|     mu0_28(unknown)       = ^CallSideEffect                : ~mu0_2
+#  945|     r0_29(glval<unknown>) = FunctionAddress[operator new]  : 
+#  945|     r0_30(unsigned long)  = Constant[8]                    : 
+#  945|     r0_31(float)          = Constant[1.0]                  : 
+#  945|     r0_32(void *)         = Call                           : func:r0_29, 0:r0_30, 1:r0_31
+#  945|     mu0_33(unknown)       = ^CallSideEffect                : ~mu0_2
+#  945|     r0_34(String *)       = Convert                        : r0_32
+#  945|     r0_35(glval<unknown>) = FunctionAddress[String]        : 
+#  945|     r0_36(glval<char[6]>) = StringConstant["hello"]        : 
+#  945|     r0_37(char *)         = Convert                        : r0_36
+#  945|     v0_38(void)           = Call                           : func:r0_35, this:r0_34, 0:r0_37
+#  945|     mu0_39(unknown)       = ^CallSideEffect                : ~mu0_2
+#  945|     v0_40(void)           = ^IndirectReadSideEffect[p#0]   : &:r0_37, ~mu0_2
+#  945|     mu0_41(unknown)       = ^BufferMayWriteSideEffect[p#0] : &:r0_37, ~mu0_2
+#  946|     r0_42(glval<unknown>) = FunctionAddress[operator new]  : 
+#  946|     r0_43(unsigned long)  = Constant[256]                  : 
+#  946|     r0_44(align_val_t)    = Constant[128]                  : 
+#  946|     r0_45(void *)         = Call                           : func:r0_42, 0:r0_43, 1:r0_44
+#  946|     mu0_46(unknown)       = ^CallSideEffect                : ~mu0_2
+#  946|     r0_47(Overaligned *)  = Convert                        : r0_45
+#  947|     r0_48(glval<unknown>) = FunctionAddress[operator new]  : 
+#  947|     r0_49(unsigned long)  = Constant[256]                  : 
+#  947|     r0_50(align_val_t)    = Constant[128]                  : 
+#  947|     r0_51(float)          = Constant[1.0]                  : 
+#  947|     r0_52(void *)         = Call                           : func:r0_48, 0:r0_49, 1:r0_50, 2:r0_51
+#  947|     mu0_53(unknown)       = ^CallSideEffect                : ~mu0_2
+#  947|     r0_54(Overaligned *)  = Convert                        : r0_52
+#  947|     r0_55(Overaligned)    = Constant[0]                    : 
+#  947|     mu0_56(Overaligned)   = Store                          : &:r0_54, r0_55
+#  948|     v0_57(void)           = NoOp                           : 
+#  940|     v0_58(void)           = ReturnVoid                     : 
+#  940|     v0_59(void)           = UnmodeledUse                   : mu*
+#  940|     v0_60(void)           = ExitFunction                   : 
 
 #  950| void OperatorNewArray(int)
 #  950|   Block 0
@@ -4575,116 +4677,132 @@ ir.cpp:
 # 1035|     r0_28(float)                             = Constant[1.0]                          : 
 # 1035|     r0_29(char)                              = Call                                   : func:r0_27, this:r0_26, 0:r0_28
 # 1035|     mu0_30(unknown)                          = ^CallSideEffect                        : ~mu0_2
-# 1036|     r0_31(glval<decltype([...](...){...})>)  = VariableAddress[lambda_val]            : 
-# 1036|     r0_32(glval<unknown>)                    = FunctionAddress[(constructor)]         : 
-# 1036|     r0_33(glval<decltype([...](...){...})>)  = VariableAddress[#temp1036:21]          : 
-# 1036|     mu0_34(decltype([...](...){...}))        = Uninitialized[#temp1036:21]            : &:r0_33
-# 1036|     r0_35(glval<String>)                     = FieldAddress[s]                        : r0_33
-#-----|     r0_36(glval<unknown>)                    = FunctionAddress[String]                : 
-#-----|     v0_37(void)                              = Call                                   : func:r0_36, this:r0_35
-#-----|     mu0_38(unknown)                          = ^CallSideEffect                        : ~mu0_2
-# 1036|     r0_39(glval<int>)                        = FieldAddress[x]                        : r0_33
-#-----|     r0_40(glval<int>)                        = VariableAddress[x]                     : 
-#-----|     r0_41(int)                               = Load                                   : &:r0_40, ~mu0_2
-#-----|     mu0_42(int)                              = Store                                  : &:r0_39, r0_41
-# 1036|     r0_43(decltype([...](...){...}))         = Load                                   : &:r0_33, ~mu0_2
-# 1036|     v0_44(void)                              = Call                                   : func:r0_32, this:r0_31, 0:r0_43
-# 1036|     mu0_45(unknown)                          = ^CallSideEffect                        : ~mu0_2
-# 1037|     r0_46(glval<decltype([...](...){...})>)  = VariableAddress[lambda_val]            : 
-# 1037|     r0_47(glval<decltype([...](...){...})>)  = Convert                                : r0_46
-# 1037|     r0_48(glval<unknown>)                    = FunctionAddress[operator()]            : 
-# 1037|     r0_49(float)                             = Constant[2.0]                          : 
-# 1037|     r0_50(char)                              = Call                                   : func:r0_48, this:r0_47, 0:r0_49
-# 1037|     mu0_51(unknown)                          = ^CallSideEffect                        : ~mu0_2
-# 1038|     r0_52(glval<decltype([...](...){...})>)  = VariableAddress[lambda_ref_explicit]   : 
-# 1038|     r0_53(glval<decltype([...](...){...})>)  = VariableAddress[#temp1038:30]          : 
-# 1038|     mu0_54(decltype([...](...){...}))        = Uninitialized[#temp1038:30]            : &:r0_53
-# 1038|     r0_55(glval<String &>)                   = FieldAddress[s]                        : r0_53
-# 1038|     r0_56(glval<String &>)                   = VariableAddress[s]                     : 
-# 1038|     r0_57(String &)                          = Load                                   : &:r0_56, ~mu0_2
-# 1038|     mu0_58(String &)                         = Store                                  : &:r0_55, r0_57
-# 1038|     r0_59(decltype([...](...){...}))         = Load                                   : &:r0_53, ~mu0_2
-# 1038|     mu0_60(decltype([...](...){...}))        = Store                                  : &:r0_52, r0_59
-# 1039|     r0_61(glval<decltype([...](...){...})>)  = VariableAddress[lambda_ref_explicit]   : 
-# 1039|     r0_62(glval<decltype([...](...){...})>)  = Convert                                : r0_61
-# 1039|     r0_63(glval<unknown>)                    = FunctionAddress[operator()]            : 
-# 1039|     r0_64(float)                             = Constant[3.0]                          : 
-# 1039|     r0_65(char)                              = Call                                   : func:r0_63, this:r0_62, 0:r0_64
-# 1039|     mu0_66(unknown)                          = ^CallSideEffect                        : ~mu0_2
-# 1040|     r0_67(glval<decltype([...](...){...})>)  = VariableAddress[lambda_val_explicit]   : 
-# 1040|     r0_68(glval<unknown>)                    = FunctionAddress[(constructor)]         : 
-# 1040|     r0_69(glval<decltype([...](...){...})>)  = VariableAddress[#temp1040:30]          : 
-# 1040|     mu0_70(decltype([...](...){...}))        = Uninitialized[#temp1040:30]            : &:r0_69
-# 1040|     r0_71(glval<String>)                     = FieldAddress[s]                        : r0_69
-#-----|     r0_72(glval<unknown>)                    = FunctionAddress[String]                : 
-#-----|     v0_73(void)                              = Call                                   : func:r0_72, this:r0_71
-#-----|     mu0_74(unknown)                          = ^CallSideEffect                        : ~mu0_2
-# 1040|     r0_75(decltype([...](...){...}))         = Load                                   : &:r0_69, ~mu0_2
-# 1040|     v0_76(void)                              = Call                                   : func:r0_68, this:r0_67, 0:r0_75
-# 1040|     mu0_77(unknown)                          = ^CallSideEffect                        : ~mu0_2
-# 1041|     r0_78(glval<decltype([...](...){...})>)  = VariableAddress[lambda_val_explicit]   : 
-# 1041|     r0_79(glval<decltype([...](...){...})>)  = Convert                                : r0_78
-# 1041|     r0_80(glval<unknown>)                    = FunctionAddress[operator()]            : 
-# 1041|     r0_81(float)                             = Constant[4.0]                          : 
-# 1041|     r0_82(char)                              = Call                                   : func:r0_80, this:r0_79, 0:r0_81
-# 1041|     mu0_83(unknown)                          = ^CallSideEffect                        : ~mu0_2
-# 1042|     r0_84(glval<decltype([...](...){...})>)  = VariableAddress[lambda_mixed_explicit] : 
-# 1042|     r0_85(glval<decltype([...](...){...})>)  = VariableAddress[#temp1042:32]          : 
-# 1042|     mu0_86(decltype([...](...){...}))        = Uninitialized[#temp1042:32]            : &:r0_85
-# 1042|     r0_87(glval<String &>)                   = FieldAddress[s]                        : r0_85
-# 1042|     r0_88(glval<String &>)                   = VariableAddress[s]                     : 
-# 1042|     r0_89(String &)                          = Load                                   : &:r0_88, ~mu0_2
-# 1042|     mu0_90(String &)                         = Store                                  : &:r0_87, r0_89
-# 1042|     r0_91(glval<int>)                        = FieldAddress[x]                        : r0_85
-# 1042|     r0_92(glval<int>)                        = VariableAddress[x]                     : 
-# 1042|     r0_93(int)                               = Load                                   : &:r0_92, ~mu0_2
-# 1042|     mu0_94(int)                              = Store                                  : &:r0_91, r0_93
-# 1042|     r0_95(decltype([...](...){...}))         = Load                                   : &:r0_85, ~mu0_2
-# 1042|     mu0_96(decltype([...](...){...}))        = Store                                  : &:r0_84, r0_95
-# 1043|     r0_97(glval<decltype([...](...){...})>)  = VariableAddress[lambda_mixed_explicit] : 
-# 1043|     r0_98(glval<decltype([...](...){...})>)  = Convert                                : r0_97
-# 1043|     r0_99(glval<unknown>)                    = FunctionAddress[operator()]            : 
-# 1043|     r0_100(float)                            = Constant[5.0]                          : 
-# 1043|     r0_101(char)                             = Call                                   : func:r0_99, this:r0_98, 0:r0_100
-# 1043|     mu0_102(unknown)                         = ^CallSideEffect                        : ~mu0_2
-# 1044|     r0_103(glval<int>)                       = VariableAddress[r]                     : 
-# 1044|     r0_104(glval<int>)                       = VariableAddress[x]                     : 
-# 1044|     r0_105(int)                              = Load                                   : &:r0_104, ~mu0_2
-# 1044|     r0_106(int)                              = Constant[1]                            : 
-# 1044|     r0_107(int)                              = Sub                                    : r0_105, r0_106
-# 1044|     mu0_108(int)                             = Store                                  : &:r0_103, r0_107
-# 1045|     r0_109(glval<decltype([...](...){...})>) = VariableAddress[lambda_inits]          : 
-# 1045|     r0_110(glval<decltype([...](...){...})>) = VariableAddress[#temp1045:23]          : 
-# 1045|     mu0_111(decltype([...](...){...}))       = Uninitialized[#temp1045:23]            : &:r0_110
-# 1045|     r0_112(glval<String &>)                  = FieldAddress[s]                        : r0_110
-# 1045|     r0_113(glval<String &>)                  = VariableAddress[s]                     : 
-# 1045|     r0_114(String &)                         = Load                                   : &:r0_113, ~mu0_2
-# 1045|     mu0_115(String &)                        = Store                                  : &:r0_112, r0_114
-# 1045|     r0_116(glval<int>)                       = FieldAddress[x]                        : r0_110
-# 1045|     r0_117(glval<int>)                       = VariableAddress[x]                     : 
-# 1045|     r0_118(int)                              = Load                                   : &:r0_117, ~mu0_2
-# 1045|     mu0_119(int)                             = Store                                  : &:r0_116, r0_118
-# 1045|     r0_120(glval<int>)                       = FieldAddress[i]                        : r0_110
-# 1045|     r0_121(glval<int>)                       = VariableAddress[x]                     : 
-# 1045|     r0_122(int)                              = Load                                   : &:r0_121, ~mu0_2
-# 1045|     r0_123(int)                              = Constant[1]                            : 
-# 1045|     r0_124(int)                              = Add                                    : r0_122, r0_123
-# 1045|     mu0_125(int)                             = Store                                  : &:r0_120, r0_124
-# 1045|     r0_126(glval<int &>)                     = FieldAddress[j]                        : r0_110
-# 1045|     r0_127(glval<int>)                       = VariableAddress[r]                     : 
-# 1045|     mu0_128(int &)                           = Store                                  : &:r0_126, r0_127
-# 1045|     r0_129(decltype([...](...){...}))        = Load                                   : &:r0_110, ~mu0_2
-# 1045|     mu0_130(decltype([...](...){...}))       = Store                                  : &:r0_109, r0_129
-# 1046|     r0_131(glval<decltype([...](...){...})>) = VariableAddress[lambda_inits]          : 
-# 1046|     r0_132(glval<decltype([...](...){...})>) = Convert                                : r0_131
-# 1046|     r0_133(glval<unknown>)                   = FunctionAddress[operator()]            : 
-# 1046|     r0_134(float)                            = Constant[6.0]                          : 
-# 1046|     r0_135(char)                             = Call                                   : func:r0_133, this:r0_132, 0:r0_134
-# 1046|     mu0_136(unknown)                         = ^CallSideEffect                        : ~mu0_2
-# 1047|     v0_137(void)                             = NoOp                                   : 
-# 1031|     v0_138(void)                             = ReturnVoid                             : 
-# 1031|     v0_139(void)                             = UnmodeledUse                           : mu*
-# 1031|     v0_140(void)                             = ExitFunction                           : 
+# 1035|     v0_31(void)                              = ^IndirectReadSideEffect                : &:r0_26, ~mu0_2
+# 1035|     r0_32(decltype([...](...){...}))         = ^IndirectMayWriteSideEffect            : &:r0_26, ~mu0_2
+# 1036|     r0_33(glval<decltype([...](...){...})>)  = VariableAddress[lambda_val]            : 
+# 1036|     r0_34(glval<unknown>)                    = FunctionAddress[(constructor)]         : 
+# 1036|     r0_35(glval<decltype([...](...){...})>)  = VariableAddress[#temp1036:21]          : 
+# 1036|     mu0_36(decltype([...](...){...}))        = Uninitialized[#temp1036:21]            : &:r0_35
+# 1036|     r0_37(glval<String>)                     = FieldAddress[s]                        : r0_35
+#-----|     r0_38(glval<unknown>)                    = FunctionAddress[String]                : 
+#-----|     v0_39(void)                              = Call                                   : func:r0_38, this:r0_37
+#-----|     mu0_40(unknown)                          = ^CallSideEffect                        : ~mu0_2
+# 1036|     r0_41(glval<int>)                        = FieldAddress[x]                        : r0_35
+#-----|     r0_42(glval<int>)                        = VariableAddress[x]                     : 
+#-----|     r0_43(int)                               = Load                                   : &:r0_42, ~mu0_2
+#-----|     mu0_44(int)                              = Store                                  : &:r0_41, r0_43
+# 1036|     r0_45(decltype([...](...){...}))         = Load                                   : &:r0_35, ~mu0_2
+# 1036|     v0_46(void)                              = Call                                   : func:r0_34, this:r0_33, 0:r0_45
+# 1036|     mu0_47(unknown)                          = ^CallSideEffect                        : ~mu0_2
+# 1036|     v0_48(void)                              = ^IndirectReadSideEffect[p#0]           : &:r0_45, ~mu0_2
+# 1036|     mu0_49(unknown)                          = ^BufferMayWriteSideEffect[p#0]         : &:r0_45, ~mu0_2
+# 1037|     r0_50(glval<decltype([...](...){...})>)  = VariableAddress[lambda_val]            : 
+# 1037|     r0_51(glval<decltype([...](...){...})>)  = Convert                                : r0_50
+# 1037|     r0_52(glval<unknown>)                    = FunctionAddress[operator()]            : 
+# 1037|     r0_53(float)                             = Constant[2.0]                          : 
+# 1037|     r0_54(char)                              = Call                                   : func:r0_52, this:r0_51, 0:r0_53
+# 1037|     mu0_55(unknown)                          = ^CallSideEffect                        : ~mu0_2
+# 1037|     v0_56(void)                              = ^IndirectReadSideEffect                : &:r0_51, ~mu0_2
+# 1037|     r0_57(decltype([...](...){...}))         = ^IndirectMayWriteSideEffect            : &:r0_51, ~mu0_2
+# 1038|     r0_58(glval<decltype([...](...){...})>)  = VariableAddress[lambda_ref_explicit]   : 
+# 1038|     r0_59(glval<decltype([...](...){...})>)  = VariableAddress[#temp1038:30]          : 
+# 1038|     mu0_60(decltype([...](...){...}))        = Uninitialized[#temp1038:30]            : &:r0_59
+# 1038|     r0_61(glval<String &>)                   = FieldAddress[s]                        : r0_59
+# 1038|     r0_62(glval<String &>)                   = VariableAddress[s]                     : 
+# 1038|     r0_63(String &)                          = Load                                   : &:r0_62, ~mu0_2
+# 1038|     mu0_64(String &)                         = Store                                  : &:r0_61, r0_63
+# 1038|     r0_65(decltype([...](...){...}))         = Load                                   : &:r0_59, ~mu0_2
+# 1038|     mu0_66(decltype([...](...){...}))        = Store                                  : &:r0_58, r0_65
+# 1039|     r0_67(glval<decltype([...](...){...})>)  = VariableAddress[lambda_ref_explicit]   : 
+# 1039|     r0_68(glval<decltype([...](...){...})>)  = Convert                                : r0_67
+# 1039|     r0_69(glval<unknown>)                    = FunctionAddress[operator()]            : 
+# 1039|     r0_70(float)                             = Constant[3.0]                          : 
+# 1039|     r0_71(char)                              = Call                                   : func:r0_69, this:r0_68, 0:r0_70
+# 1039|     mu0_72(unknown)                          = ^CallSideEffect                        : ~mu0_2
+# 1039|     v0_73(void)                              = ^IndirectReadSideEffect                : &:r0_68, ~mu0_2
+# 1039|     r0_74(decltype([...](...){...}))         = ^IndirectMayWriteSideEffect            : &:r0_68, ~mu0_2
+# 1040|     r0_75(glval<decltype([...](...){...})>)  = VariableAddress[lambda_val_explicit]   : 
+# 1040|     r0_76(glval<unknown>)                    = FunctionAddress[(constructor)]         : 
+# 1040|     r0_77(glval<decltype([...](...){...})>)  = VariableAddress[#temp1040:30]          : 
+# 1040|     mu0_78(decltype([...](...){...}))        = Uninitialized[#temp1040:30]            : &:r0_77
+# 1040|     r0_79(glval<String>)                     = FieldAddress[s]                        : r0_77
+#-----|     r0_80(glval<unknown>)                    = FunctionAddress[String]                : 
+#-----|     v0_81(void)                              = Call                                   : func:r0_80, this:r0_79
+#-----|     mu0_82(unknown)                          = ^CallSideEffect                        : ~mu0_2
+# 1040|     r0_83(decltype([...](...){...}))         = Load                                   : &:r0_77, ~mu0_2
+# 1040|     v0_84(void)                              = Call                                   : func:r0_76, this:r0_75, 0:r0_83
+# 1040|     mu0_85(unknown)                          = ^CallSideEffect                        : ~mu0_2
+# 1040|     v0_86(void)                              = ^IndirectReadSideEffect[p#0]           : &:r0_83, ~mu0_2
+# 1040|     mu0_87(unknown)                          = ^BufferMayWriteSideEffect[p#0]         : &:r0_83, ~mu0_2
+# 1041|     r0_88(glval<decltype([...](...){...})>)  = VariableAddress[lambda_val_explicit]   : 
+# 1041|     r0_89(glval<decltype([...](...){...})>)  = Convert                                : r0_88
+# 1041|     r0_90(glval<unknown>)                    = FunctionAddress[operator()]            : 
+# 1041|     r0_91(float)                             = Constant[4.0]                          : 
+# 1041|     r0_92(char)                              = Call                                   : func:r0_90, this:r0_89, 0:r0_91
+# 1041|     mu0_93(unknown)                          = ^CallSideEffect                        : ~mu0_2
+# 1041|     v0_94(void)                              = ^IndirectReadSideEffect                : &:r0_89, ~mu0_2
+# 1041|     r0_95(decltype([...](...){...}))         = ^IndirectMayWriteSideEffect            : &:r0_89, ~mu0_2
+# 1042|     r0_96(glval<decltype([...](...){...})>)  = VariableAddress[lambda_mixed_explicit] : 
+# 1042|     r0_97(glval<decltype([...](...){...})>)  = VariableAddress[#temp1042:32]          : 
+# 1042|     mu0_98(decltype([...](...){...}))        = Uninitialized[#temp1042:32]            : &:r0_97
+# 1042|     r0_99(glval<String &>)                   = FieldAddress[s]                        : r0_97
+# 1042|     r0_100(glval<String &>)                  = VariableAddress[s]                     : 
+# 1042|     r0_101(String &)                         = Load                                   : &:r0_100, ~mu0_2
+# 1042|     mu0_102(String &)                        = Store                                  : &:r0_99, r0_101
+# 1042|     r0_103(glval<int>)                       = FieldAddress[x]                        : r0_97
+# 1042|     r0_104(glval<int>)                       = VariableAddress[x]                     : 
+# 1042|     r0_105(int)                              = Load                                   : &:r0_104, ~mu0_2
+# 1042|     mu0_106(int)                             = Store                                  : &:r0_103, r0_105
+# 1042|     r0_107(decltype([...](...){...}))        = Load                                   : &:r0_97, ~mu0_2
+# 1042|     mu0_108(decltype([...](...){...}))       = Store                                  : &:r0_96, r0_107
+# 1043|     r0_109(glval<decltype([...](...){...})>) = VariableAddress[lambda_mixed_explicit] : 
+# 1043|     r0_110(glval<decltype([...](...){...})>) = Convert                                : r0_109
+# 1043|     r0_111(glval<unknown>)                   = FunctionAddress[operator()]            : 
+# 1043|     r0_112(float)                            = Constant[5.0]                          : 
+# 1043|     r0_113(char)                             = Call                                   : func:r0_111, this:r0_110, 0:r0_112
+# 1043|     mu0_114(unknown)                         = ^CallSideEffect                        : ~mu0_2
+# 1043|     v0_115(void)                             = ^IndirectReadSideEffect                : &:r0_110, ~mu0_2
+# 1043|     r0_116(decltype([...](...){...}))        = ^IndirectMayWriteSideEffect            : &:r0_110, ~mu0_2
+# 1044|     r0_117(glval<int>)                       = VariableAddress[r]                     : 
+# 1044|     r0_118(glval<int>)                       = VariableAddress[x]                     : 
+# 1044|     r0_119(int)                              = Load                                   : &:r0_118, ~mu0_2
+# 1044|     r0_120(int)                              = Constant[1]                            : 
+# 1044|     r0_121(int)                              = Sub                                    : r0_119, r0_120
+# 1044|     mu0_122(int)                             = Store                                  : &:r0_117, r0_121
+# 1045|     r0_123(glval<decltype([...](...){...})>) = VariableAddress[lambda_inits]          : 
+# 1045|     r0_124(glval<decltype([...](...){...})>) = VariableAddress[#temp1045:23]          : 
+# 1045|     mu0_125(decltype([...](...){...}))       = Uninitialized[#temp1045:23]            : &:r0_124
+# 1045|     r0_126(glval<String &>)                  = FieldAddress[s]                        : r0_124
+# 1045|     r0_127(glval<String &>)                  = VariableAddress[s]                     : 
+# 1045|     r0_128(String &)                         = Load                                   : &:r0_127, ~mu0_2
+# 1045|     mu0_129(String &)                        = Store                                  : &:r0_126, r0_128
+# 1045|     r0_130(glval<int>)                       = FieldAddress[x]                        : r0_124
+# 1045|     r0_131(glval<int>)                       = VariableAddress[x]                     : 
+# 1045|     r0_132(int)                              = Load                                   : &:r0_131, ~mu0_2
+# 1045|     mu0_133(int)                             = Store                                  : &:r0_130, r0_132
+# 1045|     r0_134(glval<int>)                       = FieldAddress[i]                        : r0_124
+# 1045|     r0_135(glval<int>)                       = VariableAddress[x]                     : 
+# 1045|     r0_136(int)                              = Load                                   : &:r0_135, ~mu0_2
+# 1045|     r0_137(int)                              = Constant[1]                            : 
+# 1045|     r0_138(int)                              = Add                                    : r0_136, r0_137
+# 1045|     mu0_139(int)                             = Store                                  : &:r0_134, r0_138
+# 1045|     r0_140(glval<int &>)                     = FieldAddress[j]                        : r0_124
+# 1045|     r0_141(glval<int>)                       = VariableAddress[r]                     : 
+# 1045|     mu0_142(int &)                           = Store                                  : &:r0_140, r0_141
+# 1045|     r0_143(decltype([...](...){...}))        = Load                                   : &:r0_124, ~mu0_2
+# 1045|     mu0_144(decltype([...](...){...}))       = Store                                  : &:r0_123, r0_143
+# 1046|     r0_145(glval<decltype([...](...){...})>) = VariableAddress[lambda_inits]          : 
+# 1046|     r0_146(glval<decltype([...](...){...})>) = Convert                                : r0_145
+# 1046|     r0_147(glval<unknown>)                   = FunctionAddress[operator()]            : 
+# 1046|     r0_148(float)                            = Constant[6.0]                          : 
+# 1046|     r0_149(char)                             = Call                                   : func:r0_147, this:r0_146, 0:r0_148
+# 1046|     mu0_150(unknown)                         = ^CallSideEffect                        : ~mu0_2
+# 1046|     v0_151(void)                             = ^IndirectReadSideEffect                : &:r0_146, ~mu0_2
+# 1046|     r0_152(decltype([...](...){...}))        = ^IndirectMayWriteSideEffect            : &:r0_146, ~mu0_2
+# 1047|     v0_153(void)                             = NoOp                                   : 
+# 1031|     v0_154(void)                             = ReturnVoid                             : 
+# 1031|     v0_155(void)                             = UnmodeledUse                           : mu*
+# 1031|     v0_156(void)                             = ExitFunction                           : 
 
 # 1032| void (void Lambda(int, String const&))::(lambda [] type at line 1032, col. 23)::(constructor)((void Lambda(int, String const&))::(lambda [] type at line 1032, col. 23)&&)
 # 1032|   Block 0
@@ -4731,30 +4849,32 @@ ir.cpp:
 
 # 1034| char (void Lambda(int, String const&))::(lambda [] type at line 1034, col. 21)::operator()(float) const
 # 1034|   Block 0
-# 1034|     v0_0(void)                                    = EnterFunction            : 
-# 1034|     mu0_1(unknown)                                = AliasedDefinition        : 
-# 1034|     mu0_2(unknown)                                = UnmodeledDefinition      : 
-# 1034|     r0_3(glval<decltype([...](...){...})>)        = InitializeThis           : 
-# 1034|     r0_4(glval<float>)                            = VariableAddress[f]       : 
-# 1034|     mu0_5(float)                                  = InitializeParameter[f]   : &:r0_4
-# 1034|     r0_6(glval<char>)                             = VariableAddress[#return] : 
-#-----|     r0_7(lambda [] type at line 1034, col. 21 *)  = CopyValue                : r0_3
-#-----|     r0_8(glval<String &>)                         = FieldAddress[s]          : r0_7
-#-----|     r0_9(String &)                                = Load                     : &:r0_8, ~mu0_2
-# 1034|     r0_10(glval<unknown>)                         = FunctionAddress[c_str]   : 
-# 1034|     r0_11(char *)                                 = Call                     : func:r0_10, this:r0_9
-# 1034|     mu0_12(unknown)                               = ^CallSideEffect          : ~mu0_2
-#-----|     r0_13(lambda [] type at line 1034, col. 21 *) = CopyValue                : r0_3
-#-----|     r0_14(glval<int &>)                           = FieldAddress[x]          : r0_13
-#-----|     r0_15(int &)                                  = Load                     : &:r0_14, ~mu0_2
-# 1034|     r0_16(int)                                    = Load                     : &:r0_15, ~mu0_2
-# 1034|     r0_17(glval<char>)                            = PointerAdd[1]            : r0_11, r0_16
-# 1034|     r0_18(char)                                   = Load                     : &:r0_17, ~mu0_2
-# 1034|     mu0_19(char)                                  = Store                    : &:r0_6, r0_18
-# 1034|     r0_20(glval<char>)                            = VariableAddress[#return] : 
-# 1034|     v0_21(void)                                   = ReturnValue              : &:r0_20, ~mu0_2
-# 1034|     v0_22(void)                                   = UnmodeledUse             : mu*
-# 1034|     v0_23(void)                                   = ExitFunction             : 
+# 1034|     v0_0(void)                                    = EnterFunction               : 
+# 1034|     mu0_1(unknown)                                = AliasedDefinition           : 
+# 1034|     mu0_2(unknown)                                = UnmodeledDefinition         : 
+# 1034|     r0_3(glval<decltype([...](...){...})>)        = InitializeThis              : 
+# 1034|     r0_4(glval<float>)                            = VariableAddress[f]          : 
+# 1034|     mu0_5(float)                                  = InitializeParameter[f]      : &:r0_4
+# 1034|     r0_6(glval<char>)                             = VariableAddress[#return]    : 
+#-----|     r0_7(lambda [] type at line 1034, col. 21 *)  = CopyValue                   : r0_3
+#-----|     r0_8(glval<String &>)                         = FieldAddress[s]             : r0_7
+#-----|     r0_9(String &)                                = Load                        : &:r0_8, ~mu0_2
+# 1034|     r0_10(glval<unknown>)                         = FunctionAddress[c_str]      : 
+# 1034|     r0_11(char *)                                 = Call                        : func:r0_10, this:r0_9
+# 1034|     mu0_12(unknown)                               = ^CallSideEffect             : ~mu0_2
+# 1034|     v0_13(void)                                   = ^IndirectReadSideEffect     : &:r0_9, ~mu0_2
+# 1034|     r0_14(String)                                 = ^IndirectMayWriteSideEffect : &:r0_9, ~mu0_2
+#-----|     r0_15(lambda [] type at line 1034, col. 21 *) = CopyValue                   : r0_3
+#-----|     r0_16(glval<int &>)                           = FieldAddress[x]             : r0_15
+#-----|     r0_17(int &)                                  = Load                        : &:r0_16, ~mu0_2
+# 1034|     r0_18(int)                                    = Load                        : &:r0_17, ~mu0_2
+# 1034|     r0_19(glval<char>)                            = PointerAdd[1]               : r0_11, r0_18
+# 1034|     r0_20(char)                                   = Load                        : &:r0_19, ~mu0_2
+# 1034|     mu0_21(char)                                  = Store                       : &:r0_6, r0_20
+# 1034|     r0_22(glval<char>)                            = VariableAddress[#return]    : 
+# 1034|     v0_23(void)                                   = ReturnValue                 : &:r0_22, ~mu0_2
+# 1034|     v0_24(void)                                   = UnmodeledUse                : mu*
+# 1034|     v0_25(void)                                   = ExitFunction                : 
 
 # 1036| void (void Lambda(int, String const&))::(lambda [] type at line 1036, col. 21)::~<unnamed>()
 # 1036|   Block 0
@@ -4773,52 +4893,56 @@ ir.cpp:
 
 # 1036| char (void Lambda(int, String const&))::(lambda [] type at line 1036, col. 21)::operator()(float) const
 # 1036|   Block 0
-# 1036|     v0_0(void)                                    = EnterFunction            : 
-# 1036|     mu0_1(unknown)                                = AliasedDefinition        : 
-# 1036|     mu0_2(unknown)                                = UnmodeledDefinition      : 
-# 1036|     r0_3(glval<decltype([...](...){...})>)        = InitializeThis           : 
-# 1036|     r0_4(glval<float>)                            = VariableAddress[f]       : 
-# 1036|     mu0_5(float)                                  = InitializeParameter[f]   : &:r0_4
-# 1036|     r0_6(glval<char>)                             = VariableAddress[#return] : 
-#-----|     r0_7(lambda [] type at line 1036, col. 21 *)  = CopyValue                : r0_3
-#-----|     r0_8(glval<String>)                           = FieldAddress[s]          : r0_7
-# 1036|     r0_9(glval<unknown>)                          = FunctionAddress[c_str]   : 
-# 1036|     r0_10(char *)                                 = Call                     : func:r0_9, this:r0_8
-# 1036|     mu0_11(unknown)                               = ^CallSideEffect          : ~mu0_2
-#-----|     r0_12(lambda [] type at line 1036, col. 21 *) = CopyValue                : r0_3
-#-----|     r0_13(glval<int>)                             = FieldAddress[x]          : r0_12
-#-----|     r0_14(int)                                    = Load                     : &:r0_13, ~mu0_2
-# 1036|     r0_15(glval<char>)                            = PointerAdd[1]            : r0_10, r0_14
-# 1036|     r0_16(char)                                   = Load                     : &:r0_15, ~mu0_2
-# 1036|     mu0_17(char)                                  = Store                    : &:r0_6, r0_16
-# 1036|     r0_18(glval<char>)                            = VariableAddress[#return] : 
-# 1036|     v0_19(void)                                   = ReturnValue              : &:r0_18, ~mu0_2
-# 1036|     v0_20(void)                                   = UnmodeledUse             : mu*
-# 1036|     v0_21(void)                                   = ExitFunction             : 
+# 1036|     v0_0(void)                                    = EnterFunction               : 
+# 1036|     mu0_1(unknown)                                = AliasedDefinition           : 
+# 1036|     mu0_2(unknown)                                = UnmodeledDefinition         : 
+# 1036|     r0_3(glval<decltype([...](...){...})>)        = InitializeThis              : 
+# 1036|     r0_4(glval<float>)                            = VariableAddress[f]          : 
+# 1036|     mu0_5(float)                                  = InitializeParameter[f]      : &:r0_4
+# 1036|     r0_6(glval<char>)                             = VariableAddress[#return]    : 
+#-----|     r0_7(lambda [] type at line 1036, col. 21 *)  = CopyValue                   : r0_3
+#-----|     r0_8(glval<String>)                           = FieldAddress[s]             : r0_7
+# 1036|     r0_9(glval<unknown>)                          = FunctionAddress[c_str]      : 
+# 1036|     r0_10(char *)                                 = Call                        : func:r0_9, this:r0_8
+# 1036|     mu0_11(unknown)                               = ^CallSideEffect             : ~mu0_2
+#-----|     v0_12(void)                                   = ^IndirectReadSideEffect     : &:r0_8, ~mu0_2
+#-----|     r0_13(String)                                 = ^IndirectMayWriteSideEffect : &:r0_8, ~mu0_2
+#-----|     r0_14(lambda [] type at line 1036, col. 21 *) = CopyValue                   : r0_3
+#-----|     r0_15(glval<int>)                             = FieldAddress[x]             : r0_14
+#-----|     r0_16(int)                                    = Load                        : &:r0_15, ~mu0_2
+# 1036|     r0_17(glval<char>)                            = PointerAdd[1]               : r0_10, r0_16
+# 1036|     r0_18(char)                                   = Load                        : &:r0_17, ~mu0_2
+# 1036|     mu0_19(char)                                  = Store                       : &:r0_6, r0_18
+# 1036|     r0_20(glval<char>)                            = VariableAddress[#return]    : 
+# 1036|     v0_21(void)                                   = ReturnValue                 : &:r0_20, ~mu0_2
+# 1036|     v0_22(void)                                   = UnmodeledUse                : mu*
+# 1036|     v0_23(void)                                   = ExitFunction                : 
 
 # 1038| char (void Lambda(int, String const&))::(lambda [] type at line 1038, col. 30)::operator()(float) const
 # 1038|   Block 0
-# 1038|     v0_0(void)                                   = EnterFunction            : 
-# 1038|     mu0_1(unknown)                               = AliasedDefinition        : 
-# 1038|     mu0_2(unknown)                               = UnmodeledDefinition      : 
-# 1038|     r0_3(glval<decltype([...](...){...})>)       = InitializeThis           : 
-# 1038|     r0_4(glval<float>)                           = VariableAddress[f]       : 
-# 1038|     mu0_5(float)                                 = InitializeParameter[f]   : &:r0_4
-# 1038|     r0_6(glval<char>)                            = VariableAddress[#return] : 
-#-----|     r0_7(lambda [] type at line 1038, col. 30 *) = CopyValue                : r0_3
-#-----|     r0_8(glval<String &>)                        = FieldAddress[s]          : r0_7
-#-----|     r0_9(String &)                               = Load                     : &:r0_8, ~mu0_2
-# 1038|     r0_10(glval<unknown>)                        = FunctionAddress[c_str]   : 
-# 1038|     r0_11(char *)                                = Call                     : func:r0_10, this:r0_9
-# 1038|     mu0_12(unknown)                              = ^CallSideEffect          : ~mu0_2
-# 1038|     r0_13(int)                                   = Constant[0]              : 
-# 1038|     r0_14(glval<char>)                           = PointerAdd[1]            : r0_11, r0_13
-# 1038|     r0_15(char)                                  = Load                     : &:r0_14, ~mu0_2
-# 1038|     mu0_16(char)                                 = Store                    : &:r0_6, r0_15
-# 1038|     r0_17(glval<char>)                           = VariableAddress[#return] : 
-# 1038|     v0_18(void)                                  = ReturnValue              : &:r0_17, ~mu0_2
-# 1038|     v0_19(void)                                  = UnmodeledUse             : mu*
-# 1038|     v0_20(void)                                  = ExitFunction             : 
+# 1038|     v0_0(void)                                   = EnterFunction               : 
+# 1038|     mu0_1(unknown)                               = AliasedDefinition           : 
+# 1038|     mu0_2(unknown)                               = UnmodeledDefinition         : 
+# 1038|     r0_3(glval<decltype([...](...){...})>)       = InitializeThis              : 
+# 1038|     r0_4(glval<float>)                           = VariableAddress[f]          : 
+# 1038|     mu0_5(float)                                 = InitializeParameter[f]      : &:r0_4
+# 1038|     r0_6(glval<char>)                            = VariableAddress[#return]    : 
+#-----|     r0_7(lambda [] type at line 1038, col. 30 *) = CopyValue                   : r0_3
+#-----|     r0_8(glval<String &>)                        = FieldAddress[s]             : r0_7
+#-----|     r0_9(String &)                               = Load                        : &:r0_8, ~mu0_2
+# 1038|     r0_10(glval<unknown>)                        = FunctionAddress[c_str]      : 
+# 1038|     r0_11(char *)                                = Call                        : func:r0_10, this:r0_9
+# 1038|     mu0_12(unknown)                              = ^CallSideEffect             : ~mu0_2
+# 1038|     v0_13(void)                                  = ^IndirectReadSideEffect     : &:r0_9, ~mu0_2
+# 1038|     r0_14(String)                                = ^IndirectMayWriteSideEffect : &:r0_9, ~mu0_2
+# 1038|     r0_15(int)                                   = Constant[0]                 : 
+# 1038|     r0_16(glval<char>)                           = PointerAdd[1]               : r0_11, r0_15
+# 1038|     r0_17(char)                                  = Load                        : &:r0_16, ~mu0_2
+# 1038|     mu0_18(char)                                 = Store                       : &:r0_6, r0_17
+# 1038|     r0_19(glval<char>)                           = VariableAddress[#return]    : 
+# 1038|     v0_20(void)                                  = ReturnValue                 : &:r0_19, ~mu0_2
+# 1038|     v0_21(void)                                  = UnmodeledUse                : mu*
+# 1038|     v0_22(void)                                  = ExitFunction                : 
 
 # 1040| void (void Lambda(int, String const&))::(lambda [] type at line 1040, col. 30)::(constructor)((void Lambda(int, String const&))::(lambda [] type at line 1040, col. 30)&&)
 # 1040|   Block 0
@@ -4854,224 +4978,250 @@ ir.cpp:
 
 # 1040| char (void Lambda(int, String const&))::(lambda [] type at line 1040, col. 30)::operator()(float) const
 # 1040|   Block 0
-# 1040|     v0_0(void)                                   = EnterFunction            : 
-# 1040|     mu0_1(unknown)                               = AliasedDefinition        : 
-# 1040|     mu0_2(unknown)                               = UnmodeledDefinition      : 
-# 1040|     r0_3(glval<decltype([...](...){...})>)       = InitializeThis           : 
-# 1040|     r0_4(glval<float>)                           = VariableAddress[f]       : 
-# 1040|     mu0_5(float)                                 = InitializeParameter[f]   : &:r0_4
-# 1040|     r0_6(glval<char>)                            = VariableAddress[#return] : 
-#-----|     r0_7(lambda [] type at line 1040, col. 30 *) = CopyValue                : r0_3
-#-----|     r0_8(glval<String>)                          = FieldAddress[s]          : r0_7
-# 1040|     r0_9(glval<unknown>)                         = FunctionAddress[c_str]   : 
-# 1040|     r0_10(char *)                                = Call                     : func:r0_9, this:r0_8
-# 1040|     mu0_11(unknown)                              = ^CallSideEffect          : ~mu0_2
-# 1040|     r0_12(int)                                   = Constant[0]              : 
-# 1040|     r0_13(glval<char>)                           = PointerAdd[1]            : r0_10, r0_12
-# 1040|     r0_14(char)                                  = Load                     : &:r0_13, ~mu0_2
-# 1040|     mu0_15(char)                                 = Store                    : &:r0_6, r0_14
-# 1040|     r0_16(glval<char>)                           = VariableAddress[#return] : 
-# 1040|     v0_17(void)                                  = ReturnValue              : &:r0_16, ~mu0_2
-# 1040|     v0_18(void)                                  = UnmodeledUse             : mu*
-# 1040|     v0_19(void)                                  = ExitFunction             : 
+# 1040|     v0_0(void)                                   = EnterFunction               : 
+# 1040|     mu0_1(unknown)                               = AliasedDefinition           : 
+# 1040|     mu0_2(unknown)                               = UnmodeledDefinition         : 
+# 1040|     r0_3(glval<decltype([...](...){...})>)       = InitializeThis              : 
+# 1040|     r0_4(glval<float>)                           = VariableAddress[f]          : 
+# 1040|     mu0_5(float)                                 = InitializeParameter[f]      : &:r0_4
+# 1040|     r0_6(glval<char>)                            = VariableAddress[#return]    : 
+#-----|     r0_7(lambda [] type at line 1040, col. 30 *) = CopyValue                   : r0_3
+#-----|     r0_8(glval<String>)                          = FieldAddress[s]             : r0_7
+# 1040|     r0_9(glval<unknown>)                         = FunctionAddress[c_str]      : 
+# 1040|     r0_10(char *)                                = Call                        : func:r0_9, this:r0_8
+# 1040|     mu0_11(unknown)                              = ^CallSideEffect             : ~mu0_2
+#-----|     v0_12(void)                                  = ^IndirectReadSideEffect     : &:r0_8, ~mu0_2
+#-----|     r0_13(String)                                = ^IndirectMayWriteSideEffect : &:r0_8, ~mu0_2
+# 1040|     r0_14(int)                                   = Constant[0]                 : 
+# 1040|     r0_15(glval<char>)                           = PointerAdd[1]               : r0_10, r0_14
+# 1040|     r0_16(char)                                  = Load                        : &:r0_15, ~mu0_2
+# 1040|     mu0_17(char)                                 = Store                       : &:r0_6, r0_16
+# 1040|     r0_18(glval<char>)                           = VariableAddress[#return]    : 
+# 1040|     v0_19(void)                                  = ReturnValue                 : &:r0_18, ~mu0_2
+# 1040|     v0_20(void)                                  = UnmodeledUse                : mu*
+# 1040|     v0_21(void)                                  = ExitFunction                : 
 
 # 1042| char (void Lambda(int, String const&))::(lambda [] type at line 1042, col. 32)::operator()(float) const
 # 1042|   Block 0
-# 1042|     v0_0(void)                                    = EnterFunction            : 
-# 1042|     mu0_1(unknown)                                = AliasedDefinition        : 
-# 1042|     mu0_2(unknown)                                = UnmodeledDefinition      : 
-# 1042|     r0_3(glval<decltype([...](...){...})>)        = InitializeThis           : 
-# 1042|     r0_4(glval<float>)                            = VariableAddress[f]       : 
-# 1042|     mu0_5(float)                                  = InitializeParameter[f]   : &:r0_4
-# 1042|     r0_6(glval<char>)                             = VariableAddress[#return] : 
-#-----|     r0_7(lambda [] type at line 1042, col. 32 *)  = CopyValue                : r0_3
-#-----|     r0_8(glval<String &>)                         = FieldAddress[s]          : r0_7
-#-----|     r0_9(String &)                                = Load                     : &:r0_8, ~mu0_2
-# 1042|     r0_10(glval<unknown>)                         = FunctionAddress[c_str]   : 
-# 1042|     r0_11(char *)                                 = Call                     : func:r0_10, this:r0_9
-# 1042|     mu0_12(unknown)                               = ^CallSideEffect          : ~mu0_2
-#-----|     r0_13(lambda [] type at line 1042, col. 32 *) = CopyValue                : r0_3
-#-----|     r0_14(glval<int>)                             = FieldAddress[x]          : r0_13
-#-----|     r0_15(int)                                    = Load                     : &:r0_14, ~mu0_2
-# 1042|     r0_16(glval<char>)                            = PointerAdd[1]            : r0_11, r0_15
-# 1042|     r0_17(char)                                   = Load                     : &:r0_16, ~mu0_2
-# 1042|     mu0_18(char)                                  = Store                    : &:r0_6, r0_17
-# 1042|     r0_19(glval<char>)                            = VariableAddress[#return] : 
-# 1042|     v0_20(void)                                   = ReturnValue              : &:r0_19, ~mu0_2
-# 1042|     v0_21(void)                                   = UnmodeledUse             : mu*
-# 1042|     v0_22(void)                                   = ExitFunction             : 
+# 1042|     v0_0(void)                                    = EnterFunction               : 
+# 1042|     mu0_1(unknown)                                = AliasedDefinition           : 
+# 1042|     mu0_2(unknown)                                = UnmodeledDefinition         : 
+# 1042|     r0_3(glval<decltype([...](...){...})>)        = InitializeThis              : 
+# 1042|     r0_4(glval<float>)                            = VariableAddress[f]          : 
+# 1042|     mu0_5(float)                                  = InitializeParameter[f]      : &:r0_4
+# 1042|     r0_6(glval<char>)                             = VariableAddress[#return]    : 
+#-----|     r0_7(lambda [] type at line 1042, col. 32 *)  = CopyValue                   : r0_3
+#-----|     r0_8(glval<String &>)                         = FieldAddress[s]             : r0_7
+#-----|     r0_9(String &)                                = Load                        : &:r0_8, ~mu0_2
+# 1042|     r0_10(glval<unknown>)                         = FunctionAddress[c_str]      : 
+# 1042|     r0_11(char *)                                 = Call                        : func:r0_10, this:r0_9
+# 1042|     mu0_12(unknown)                               = ^CallSideEffect             : ~mu0_2
+# 1042|     v0_13(void)                                   = ^IndirectReadSideEffect     : &:r0_9, ~mu0_2
+# 1042|     r0_14(String)                                 = ^IndirectMayWriteSideEffect : &:r0_9, ~mu0_2
+#-----|     r0_15(lambda [] type at line 1042, col. 32 *) = CopyValue                   : r0_3
+#-----|     r0_16(glval<int>)                             = FieldAddress[x]             : r0_15
+#-----|     r0_17(int)                                    = Load                        : &:r0_16, ~mu0_2
+# 1042|     r0_18(glval<char>)                            = PointerAdd[1]               : r0_11, r0_17
+# 1042|     r0_19(char)                                   = Load                        : &:r0_18, ~mu0_2
+# 1042|     mu0_20(char)                                  = Store                       : &:r0_6, r0_19
+# 1042|     r0_21(glval<char>)                            = VariableAddress[#return]    : 
+# 1042|     v0_22(void)                                   = ReturnValue                 : &:r0_21, ~mu0_2
+# 1042|     v0_23(void)                                   = UnmodeledUse                : mu*
+# 1042|     v0_24(void)                                   = ExitFunction                : 
 
 # 1045| char (void Lambda(int, String const&))::(lambda [] type at line 1045, col. 23)::operator()(float) const
 # 1045|   Block 0
-# 1045|     v0_0(void)                                    = EnterFunction            : 
-# 1045|     mu0_1(unknown)                                = AliasedDefinition        : 
-# 1045|     mu0_2(unknown)                                = UnmodeledDefinition      : 
-# 1045|     r0_3(glval<decltype([...](...){...})>)        = InitializeThis           : 
-# 1045|     r0_4(glval<float>)                            = VariableAddress[f]       : 
-# 1045|     mu0_5(float)                                  = InitializeParameter[f]   : &:r0_4
-# 1045|     r0_6(glval<char>)                             = VariableAddress[#return] : 
-#-----|     r0_7(lambda [] type at line 1045, col. 23 *)  = CopyValue                : r0_3
-#-----|     r0_8(glval<String &>)                         = FieldAddress[s]          : r0_7
-#-----|     r0_9(String &)                                = Load                     : &:r0_8, ~mu0_2
-# 1045|     r0_10(glval<unknown>)                         = FunctionAddress[c_str]   : 
-# 1045|     r0_11(char *)                                 = Call                     : func:r0_10, this:r0_9
-# 1045|     mu0_12(unknown)                               = ^CallSideEffect          : ~mu0_2
-#-----|     r0_13(lambda [] type at line 1045, col. 23 *) = CopyValue                : r0_3
-#-----|     r0_14(glval<int>)                             = FieldAddress[x]          : r0_13
-#-----|     r0_15(int)                                    = Load                     : &:r0_14, ~mu0_2
-#-----|     r0_16(lambda [] type at line 1045, col. 23 *) = CopyValue                : r0_3
-# 1045|     r0_17(glval<int>)                             = FieldAddress[i]          : r0_16
-# 1045|     r0_18(int)                                    = Load                     : &:r0_17, ~mu0_2
-# 1045|     r0_19(int)                                    = Add                      : r0_15, r0_18
-#-----|     r0_20(lambda [] type at line 1045, col. 23 *) = CopyValue                : r0_3
-# 1045|     r0_21(glval<int &>)                           = FieldAddress[j]          : r0_20
-# 1045|     r0_22(int &)                                  = Load                     : &:r0_21, ~mu0_2
-# 1045|     r0_23(int)                                    = Load                     : &:r0_22, ~mu0_2
-# 1045|     r0_24(int)                                    = Sub                      : r0_19, r0_23
-# 1045|     r0_25(glval<char>)                            = PointerAdd[1]            : r0_11, r0_24
-# 1045|     r0_26(char)                                   = Load                     : &:r0_25, ~mu0_2
-# 1045|     mu0_27(char)                                  = Store                    : &:r0_6, r0_26
-# 1045|     r0_28(glval<char>)                            = VariableAddress[#return] : 
-# 1045|     v0_29(void)                                   = ReturnValue              : &:r0_28, ~mu0_2
-# 1045|     v0_30(void)                                   = UnmodeledUse             : mu*
-# 1045|     v0_31(void)                                   = ExitFunction             : 
+# 1045|     v0_0(void)                                    = EnterFunction               : 
+# 1045|     mu0_1(unknown)                                = AliasedDefinition           : 
+# 1045|     mu0_2(unknown)                                = UnmodeledDefinition         : 
+# 1045|     r0_3(glval<decltype([...](...){...})>)        = InitializeThis              : 
+# 1045|     r0_4(glval<float>)                            = VariableAddress[f]          : 
+# 1045|     mu0_5(float)                                  = InitializeParameter[f]      : &:r0_4
+# 1045|     r0_6(glval<char>)                             = VariableAddress[#return]    : 
+#-----|     r0_7(lambda [] type at line 1045, col. 23 *)  = CopyValue                   : r0_3
+#-----|     r0_8(glval<String &>)                         = FieldAddress[s]             : r0_7
+#-----|     r0_9(String &)                                = Load                        : &:r0_8, ~mu0_2
+# 1045|     r0_10(glval<unknown>)                         = FunctionAddress[c_str]      : 
+# 1045|     r0_11(char *)                                 = Call                        : func:r0_10, this:r0_9
+# 1045|     mu0_12(unknown)                               = ^CallSideEffect             : ~mu0_2
+# 1045|     v0_13(void)                                   = ^IndirectReadSideEffect     : &:r0_9, ~mu0_2
+# 1045|     r0_14(String)                                 = ^IndirectMayWriteSideEffect : &:r0_9, ~mu0_2
+#-----|     r0_15(lambda [] type at line 1045, col. 23 *) = CopyValue                   : r0_3
+#-----|     r0_16(glval<int>)                             = FieldAddress[x]             : r0_15
+#-----|     r0_17(int)                                    = Load                        : &:r0_16, ~mu0_2
+#-----|     r0_18(lambda [] type at line 1045, col. 23 *) = CopyValue                   : r0_3
+# 1045|     r0_19(glval<int>)                             = FieldAddress[i]             : r0_18
+# 1045|     r0_20(int)                                    = Load                        : &:r0_19, ~mu0_2
+# 1045|     r0_21(int)                                    = Add                         : r0_17, r0_20
+#-----|     r0_22(lambda [] type at line 1045, col. 23 *) = CopyValue                   : r0_3
+# 1045|     r0_23(glval<int &>)                           = FieldAddress[j]             : r0_22
+# 1045|     r0_24(int &)                                  = Load                        : &:r0_23, ~mu0_2
+# 1045|     r0_25(int)                                    = Load                        : &:r0_24, ~mu0_2
+# 1045|     r0_26(int)                                    = Sub                         : r0_21, r0_25
+# 1045|     r0_27(glval<char>)                            = PointerAdd[1]               : r0_11, r0_26
+# 1045|     r0_28(char)                                   = Load                        : &:r0_27, ~mu0_2
+# 1045|     mu0_29(char)                                  = Store                       : &:r0_6, r0_28
+# 1045|     r0_30(glval<char>)                            = VariableAddress[#return]    : 
+# 1045|     v0_31(void)                                   = ReturnValue                 : &:r0_30, ~mu0_2
+# 1045|     v0_32(void)                                   = UnmodeledUse                : mu*
+# 1045|     v0_33(void)                                   = ExitFunction                : 
 
 # 1068| void RangeBasedFor(vector<int> const&)
 # 1068|   Block 0
-# 1068|     v0_0(void)                  = EnterFunction              : 
-# 1068|     mu0_1(unknown)              = AliasedDefinition          : 
-# 1068|     mu0_2(unknown)              = UnmodeledDefinition        : 
-# 1068|     r0_3(glval<vector<int> &>)  = VariableAddress[v]         : 
-# 1068|     mu0_4(vector<int> &)        = InitializeParameter[v]     : &:r0_3
-# 1069|     r0_5(glval<vector<int> &>)  = VariableAddress[(__range)] : 
-# 1069|     r0_6(glval<vector<int> &>)  = VariableAddress[v]         : 
-# 1069|     r0_7(vector<int> &)         = Load                       : &:r0_6, ~mu0_2
-# 1069|     mu0_8(vector<int> &)        = Store                      : &:r0_5, r0_7
-# 1069|     r0_9(glval<iterator>)       = VariableAddress[(__begin)] : 
-#-----|     r0_10(glval<vector<int> &>) = VariableAddress[(__range)] : 
-#-----|     r0_11(vector<int> &)        = Load                       : &:r0_10, ~mu0_2
-# 1069|     r0_12(glval<unknown>)       = FunctionAddress[begin]     : 
-# 1069|     r0_13(iterator)             = Call                       : func:r0_12, this:r0_11
-# 1069|     mu0_14(unknown)             = ^CallSideEffect            : ~mu0_2
-# 1069|     mu0_15(iterator)            = Store                      : &:r0_9, r0_13
-# 1069|     r0_16(glval<iterator>)      = VariableAddress[(__end)]   : 
-#-----|     r0_17(glval<vector<int> &>) = VariableAddress[(__range)] : 
-#-----|     r0_18(vector<int> &)        = Load                       : &:r0_17, ~mu0_2
-# 1069|     r0_19(glval<unknown>)       = FunctionAddress[end]       : 
-# 1069|     r0_20(iterator)             = Call                       : func:r0_19, this:r0_18
-# 1069|     mu0_21(unknown)             = ^CallSideEffect            : ~mu0_2
-# 1069|     mu0_22(iterator)            = Store                      : &:r0_16, r0_20
-#-----|   Goto -> Block 1
-
-#-----|   Block 1
-#-----|     r1_0(glval<iterator>) = VariableAddress[(__begin)]  : 
-#-----|     r1_1(glval<iterator>) = Convert                     : r1_0
-# 1069|     r1_2(glval<unknown>)  = FunctionAddress[operator!=] : 
-#-----|     r1_3(glval<iterator>) = VariableAddress[(__end)]    : 
-#-----|     r1_4(iterator)        = Load                        : &:r1_3, ~mu0_2
-# 1069|     r1_5(bool)            = Call                        : func:r1_2, this:r1_1, 0:r1_4
-# 1069|     mu1_6(unknown)        = ^CallSideEffect             : ~mu0_2
-# 1069|     v1_7(void)            = ConditionalBranch           : r1_5
-#-----|   False -> Block 5
-#-----|   True -> Block 2
-
-# 1069|   Block 2
-# 1069|     r2_0(glval<int>)      = VariableAddress[e]         : 
-#-----|     r2_1(glval<iterator>) = VariableAddress[(__begin)] : 
-#-----|     r2_2(glval<iterator>) = Convert                    : r2_1
-# 1069|     r2_3(glval<unknown>)  = FunctionAddress[operator*] : 
-# 1069|     r2_4(int &)           = Call                       : func:r2_3, this:r2_2
-# 1069|     mu2_5(unknown)        = ^CallSideEffect            : ~mu0_2
-# 1069|     r2_6(int)             = Load                       : &:r2_4, ~mu0_2
-# 1069|     mu2_7(int)            = Store                      : &:r2_0, r2_6
-# 1070|     r2_8(glval<int>)      = VariableAddress[e]         : 
-# 1070|     r2_9(int)             = Load                       : &:r2_8, ~mu0_2
-# 1070|     r2_10(int)            = Constant[0]                : 
-# 1070|     r2_11(bool)           = CompareGT                  : r2_9, r2_10
-# 1070|     v2_12(void)           = ConditionalBranch          : r2_11
-#-----|   False -> Block 4
-#-----|   True -> Block 3
-
-# 1071|   Block 3
-# 1071|     v3_0(void) = NoOp : 
+# 1068|     v0_0(void)                  = EnterFunction               : 
+# 1068|     mu0_1(unknown)              = AliasedDefinition           : 
+# 1068|     mu0_2(unknown)              = UnmodeledDefinition         : 
+# 1068|     r0_3(glval<vector<int> &>)  = VariableAddress[v]          : 
+# 1068|     mu0_4(vector<int> &)        = InitializeParameter[v]      : &:r0_3
+# 1069|     r0_5(glval<vector<int> &>)  = VariableAddress[(__range)]  : 
+# 1069|     r0_6(glval<vector<int> &>)  = VariableAddress[v]          : 
+# 1069|     r0_7(vector<int> &)         = Load                        : &:r0_6, ~mu0_2
+# 1069|     mu0_8(vector<int> &)        = Store                       : &:r0_5, r0_7
+# 1069|     r0_9(glval<iterator>)       = VariableAddress[(__begin)]  : 
+#-----|     r0_10(glval<vector<int> &>) = VariableAddress[(__range)]  : 
+#-----|     r0_11(vector<int> &)        = Load                        : &:r0_10, ~mu0_2
+# 1069|     r0_12(glval<unknown>)       = FunctionAddress[begin]      : 
+# 1069|     r0_13(iterator)             = Call                        : func:r0_12, this:r0_11
+# 1069|     mu0_14(unknown)             = ^CallSideEffect             : ~mu0_2
+#-----|     v0_15(void)                 = ^IndirectReadSideEffect     : &:r0_11, ~mu0_2
+#-----|     r0_16(vector<int>)          = ^IndirectMayWriteSideEffect : &:r0_11, ~mu0_2
+# 1069|     mu0_17(iterator)            = Store                       : &:r0_9, r0_13
+# 1069|     r0_18(glval<iterator>)      = VariableAddress[(__end)]    : 
+#-----|     r0_19(glval<vector<int> &>) = VariableAddress[(__range)]  : 
+#-----|     r0_20(vector<int> &)        = Load                        : &:r0_19, ~mu0_2
+# 1069|     r0_21(glval<unknown>)       = FunctionAddress[end]        : 
+# 1069|     r0_22(iterator)             = Call                        : func:r0_21, this:r0_20
+# 1069|     mu0_23(unknown)             = ^CallSideEffect             : ~mu0_2
+#-----|     v0_24(void)                 = ^IndirectReadSideEffect     : &:r0_20, ~mu0_2
+#-----|     r0_25(vector<int>)          = ^IndirectMayWriteSideEffect : &:r0_20, ~mu0_2
+# 1069|     mu0_26(iterator)            = Store                       : &:r0_18, r0_22
 #-----|   Goto -> Block 4
 
-# 1069|   Block 4
-# 1069|     v4_0(void)            = NoOp                        : 
-#-----|     r4_1(glval<iterator>) = VariableAddress[(__begin)]  : 
-# 1069|     r4_2(glval<unknown>)  = FunctionAddress[operator++] : 
-# 1069|     r4_3(iterator &)      = Call                        : func:r4_2, this:r4_1
-# 1069|     mu4_4(unknown)        = ^CallSideEffect             : ~mu0_2
-#-----|   Goto (back edge) -> Block 1
-
-# 1075|   Block 5
-# 1075|     r5_0(glval<vector<int> &>)  = VariableAddress[(__range)] : 
-# 1075|     r5_1(glval<vector<int> &>)  = VariableAddress[v]         : 
-# 1075|     r5_2(vector<int> &)         = Load                       : &:r5_1, ~mu0_2
-# 1075|     mu5_3(vector<int> &)        = Store                      : &:r5_0, r5_2
-# 1075|     r5_4(glval<iterator>)       = VariableAddress[(__begin)] : 
-#-----|     r5_5(glval<vector<int> &>)  = VariableAddress[(__range)] : 
-#-----|     r5_6(vector<int> &)         = Load                       : &:r5_5, ~mu0_2
-# 1075|     r5_7(glval<unknown>)        = FunctionAddress[begin]     : 
-# 1075|     r5_8(iterator)              = Call                       : func:r5_7, this:r5_6
-# 1075|     mu5_9(unknown)              = ^CallSideEffect            : ~mu0_2
-# 1075|     mu5_10(iterator)            = Store                      : &:r5_4, r5_8
-# 1075|     r5_11(glval<iterator>)      = VariableAddress[(__end)]   : 
-#-----|     r5_12(glval<vector<int> &>) = VariableAddress[(__range)] : 
-#-----|     r5_13(vector<int> &)        = Load                       : &:r5_12, ~mu0_2
-# 1075|     r5_14(glval<unknown>)       = FunctionAddress[end]       : 
-# 1075|     r5_15(iterator)             = Call                       : func:r5_14, this:r5_13
-# 1075|     mu5_16(unknown)             = ^CallSideEffect            : ~mu0_2
-# 1075|     mu5_17(iterator)            = Store                      : &:r5_11, r5_15
-#-----|   Goto -> Block 6
-
-#-----|   Block 6
-#-----|     r6_0(glval<iterator>) = VariableAddress[(__begin)]  : 
-#-----|     r6_1(glval<iterator>) = Convert                     : r6_0
-# 1075|     r6_2(glval<unknown>)  = FunctionAddress[operator!=] : 
-#-----|     r6_3(glval<iterator>) = VariableAddress[(__end)]    : 
-#-----|     r6_4(iterator)        = Load                        : &:r6_3, ~mu0_2
-# 1075|     r6_5(bool)            = Call                        : func:r6_2, this:r6_1, 0:r6_4
-# 1075|     mu6_6(unknown)        = ^CallSideEffect             : ~mu0_2
-# 1075|     v6_7(void)            = ConditionalBranch           : r6_5
+# 1075|   Block 1
+# 1075|     r1_0(glval<int &>)    = VariableAddress[e]          : 
+#-----|     r1_1(glval<iterator>) = VariableAddress[(__begin)]  : 
+#-----|     r1_2(glval<iterator>) = Convert                     : r1_1
+# 1075|     r1_3(glval<unknown>)  = FunctionAddress[operator*]  : 
+# 1075|     r1_4(int &)           = Call                        : func:r1_3, this:r1_2
+# 1075|     mu1_5(unknown)        = ^CallSideEffect             : ~mu0_2
+#-----|     v1_6(void)            = ^IndirectReadSideEffect     : &:r1_2, ~mu0_2
+#-----|     r1_7(iterator)        = ^IndirectMayWriteSideEffect : &:r1_2, ~mu0_2
+# 1075|     r1_8(glval<int>)      = Convert                     : r1_4
+# 1075|     mu1_9(int &)          = Store                       : &:r1_0, r1_8
+# 1076|     r1_10(glval<int &>)   = VariableAddress[e]          : 
+# 1076|     r1_11(int &)          = Load                        : &:r1_10, ~mu0_2
+# 1076|     r1_12(int)            = Load                        : &:r1_11, ~mu0_2
+# 1076|     r1_13(int)            = Constant[5]                 : 
+# 1076|     r1_14(bool)           = CompareLT                   : r1_12, r1_13
+# 1076|     v1_15(void)           = ConditionalBranch           : r1_14
 #-----|   False -> Block 10
-#-----|   True -> Block 8
+#-----|   True -> Block 2
 
-#-----|   Block 7
-#-----|     r7_0(glval<iterator>) = VariableAddress[(__begin)]  : 
-# 1075|     r7_1(glval<unknown>)  = FunctionAddress[operator++] : 
-# 1075|     r7_2(iterator &)      = Call                        : func:r7_1, this:r7_0
-# 1075|     mu7_3(unknown)        = ^CallSideEffect             : ~mu0_2
-#-----|   Goto (back edge) -> Block 6
+# 1077|   Block 2
+# 1077|     v2_0(void) = NoOp : 
+#-----|   Goto -> Block 3
+
+# 1079|   Block 3
+# 1079|     v3_0(void) = NoOp         : 
+# 1080|     v3_1(void) = NoOp         : 
+# 1068|     v3_2(void) = ReturnVoid   : 
+# 1068|     v3_3(void) = UnmodeledUse : mu*
+# 1068|     v3_4(void) = ExitFunction : 
+
+#-----|   Block 4
+#-----|     r4_0(glval<iterator>) = VariableAddress[(__begin)]  : 
+#-----|     r4_1(glval<iterator>) = Convert                     : r4_0
+# 1069|     r4_2(glval<unknown>)  = FunctionAddress[operator!=] : 
+#-----|     r4_3(glval<iterator>) = VariableAddress[(__end)]    : 
+#-----|     r4_4(iterator)        = Load                        : &:r4_3, ~mu0_2
+# 1069|     r4_5(bool)            = Call                        : func:r4_2, this:r4_1, 0:r4_4
+# 1069|     mu4_6(unknown)        = ^CallSideEffect             : ~mu0_2
+#-----|     v4_7(void)            = ^IndirectReadSideEffect     : &:r4_1, ~mu0_2
+#-----|     r4_8(iterator)        = ^IndirectMayWriteSideEffect : &:r4_1, ~mu0_2
+# 1069|     v4_9(void)            = ConditionalBranch           : r4_5
+#-----|   False -> Block 8
+#-----|   True -> Block 5
+
+# 1069|   Block 5
+# 1069|     r5_0(glval<int>)      = VariableAddress[e]          : 
+#-----|     r5_1(glval<iterator>) = VariableAddress[(__begin)]  : 
+#-----|     r5_2(glval<iterator>) = Convert                     : r5_1
+# 1069|     r5_3(glval<unknown>)  = FunctionAddress[operator*]  : 
+# 1069|     r5_4(int &)           = Call                        : func:r5_3, this:r5_2
+# 1069|     mu5_5(unknown)        = ^CallSideEffect             : ~mu0_2
+#-----|     v5_6(void)            = ^IndirectReadSideEffect     : &:r5_2, ~mu0_2
+#-----|     r5_7(iterator)        = ^IndirectMayWriteSideEffect : &:r5_2, ~mu0_2
+# 1069|     r5_8(int)             = Load                        : &:r5_4, ~mu0_2
+# 1069|     mu5_9(int)            = Store                       : &:r5_0, r5_8
+# 1070|     r5_10(glval<int>)     = VariableAddress[e]          : 
+# 1070|     r5_11(int)            = Load                        : &:r5_10, ~mu0_2
+# 1070|     r5_12(int)            = Constant[0]                 : 
+# 1070|     r5_13(bool)           = CompareGT                   : r5_11, r5_12
+# 1070|     v5_14(void)           = ConditionalBranch           : r5_13
+#-----|   False -> Block 7
+#-----|   True -> Block 6
+
+# 1071|   Block 6
+# 1071|     v6_0(void) = NoOp : 
+#-----|   Goto -> Block 7
+
+# 1069|   Block 7
+# 1069|     v7_0(void)            = NoOp                        : 
+#-----|     r7_1(glval<iterator>) = VariableAddress[(__begin)]  : 
+# 1069|     r7_2(glval<unknown>)  = FunctionAddress[operator++] : 
+# 1069|     r7_3(iterator &)      = Call                        : func:r7_2, this:r7_1
+# 1069|     mu7_4(unknown)        = ^CallSideEffect             : ~mu0_2
+#-----|     v7_5(void)            = ^IndirectReadSideEffect     : &:r7_1, ~mu0_2
+#-----|     r7_6(iterator)        = ^IndirectMayWriteSideEffect : &:r7_1, ~mu0_2
+#-----|   Goto (back edge) -> Block 4
 
 # 1075|   Block 8
-# 1075|     r8_0(glval<int &>)    = VariableAddress[e]         : 
-#-----|     r8_1(glval<iterator>) = VariableAddress[(__begin)] : 
-#-----|     r8_2(glval<iterator>) = Convert                    : r8_1
-# 1075|     r8_3(glval<unknown>)  = FunctionAddress[operator*] : 
-# 1075|     r8_4(int &)           = Call                       : func:r8_3, this:r8_2
-# 1075|     mu8_5(unknown)        = ^CallSideEffect            : ~mu0_2
-# 1075|     r8_6(glval<int>)      = Convert                    : r8_4
-# 1075|     mu8_7(int &)          = Store                      : &:r8_0, r8_6
-# 1076|     r8_8(glval<int &>)    = VariableAddress[e]         : 
-# 1076|     r8_9(int &)           = Load                       : &:r8_8, ~mu0_2
-# 1076|     r8_10(int)            = Load                       : &:r8_9, ~mu0_2
-# 1076|     r8_11(int)            = Constant[5]                : 
-# 1076|     r8_12(bool)           = CompareLT                  : r8_10, r8_11
-# 1076|     v8_13(void)           = ConditionalBranch          : r8_12
-#-----|   False -> Block 7
-#-----|   True -> Block 9
+# 1075|     r8_0(glval<vector<int> &>)  = VariableAddress[(__range)]  : 
+# 1075|     r8_1(glval<vector<int> &>)  = VariableAddress[v]          : 
+# 1075|     r8_2(vector<int> &)         = Load                        : &:r8_1, ~mu0_2
+# 1075|     mu8_3(vector<int> &)        = Store                       : &:r8_0, r8_2
+# 1075|     r8_4(glval<iterator>)       = VariableAddress[(__begin)]  : 
+#-----|     r8_5(glval<vector<int> &>)  = VariableAddress[(__range)]  : 
+#-----|     r8_6(vector<int> &)         = Load                        : &:r8_5, ~mu0_2
+# 1075|     r8_7(glval<unknown>)        = FunctionAddress[begin]      : 
+# 1075|     r8_8(iterator)              = Call                        : func:r8_7, this:r8_6
+# 1075|     mu8_9(unknown)              = ^CallSideEffect             : ~mu0_2
+#-----|     v8_10(void)                 = ^IndirectReadSideEffect     : &:r8_6, ~mu0_2
+#-----|     r8_11(vector<int>)          = ^IndirectMayWriteSideEffect : &:r8_6, ~mu0_2
+# 1075|     mu8_12(iterator)            = Store                       : &:r8_4, r8_8
+# 1075|     r8_13(glval<iterator>)      = VariableAddress[(__end)]    : 
+#-----|     r8_14(glval<vector<int> &>) = VariableAddress[(__range)]  : 
+#-----|     r8_15(vector<int> &)        = Load                        : &:r8_14, ~mu0_2
+# 1075|     r8_16(glval<unknown>)       = FunctionAddress[end]        : 
+# 1075|     r8_17(iterator)             = Call                        : func:r8_16, this:r8_15
+# 1075|     mu8_18(unknown)             = ^CallSideEffect             : ~mu0_2
+#-----|     v8_19(void)                 = ^IndirectReadSideEffect     : &:r8_15, ~mu0_2
+#-----|     r8_20(vector<int>)          = ^IndirectMayWriteSideEffect : &:r8_15, ~mu0_2
+# 1075|     mu8_21(iterator)            = Store                       : &:r8_13, r8_17
+#-----|   Goto -> Block 9
 
-# 1077|   Block 9
-# 1077|     v9_0(void) = NoOp : 
-#-----|   Goto -> Block 10
+#-----|   Block 9
+#-----|     r9_0(glval<iterator>) = VariableAddress[(__begin)]  : 
+#-----|     r9_1(glval<iterator>) = Convert                     : r9_0
+# 1075|     r9_2(glval<unknown>)  = FunctionAddress[operator!=] : 
+#-----|     r9_3(glval<iterator>) = VariableAddress[(__end)]    : 
+#-----|     r9_4(iterator)        = Load                        : &:r9_3, ~mu0_2
+# 1075|     r9_5(bool)            = Call                        : func:r9_2, this:r9_1, 0:r9_4
+# 1075|     mu9_6(unknown)        = ^CallSideEffect             : ~mu0_2
+#-----|     v9_7(void)            = ^IndirectReadSideEffect     : &:r9_1, ~mu0_2
+#-----|     r9_8(iterator)        = ^IndirectMayWriteSideEffect : &:r9_1, ~mu0_2
+# 1075|     v9_9(void)            = ConditionalBranch           : r9_5
+#-----|   False -> Block 3
+#-----|   True -> Block 1
 
-# 1079|   Block 10
-# 1079|     v10_0(void) = NoOp         : 
-# 1080|     v10_1(void) = NoOp         : 
-# 1068|     v10_2(void) = ReturnVoid   : 
-# 1068|     v10_3(void) = UnmodeledUse : mu*
-# 1068|     v10_4(void) = ExitFunction : 
+#-----|   Block 10
+#-----|     r10_0(glval<iterator>) = VariableAddress[(__begin)]  : 
+# 1075|     r10_1(glval<unknown>)  = FunctionAddress[operator++] : 
+# 1075|     r10_2(iterator &)      = Call                        : func:r10_1, this:r10_0
+# 1075|     mu10_3(unknown)        = ^CallSideEffect             : ~mu0_2
+#-----|     v10_4(void)            = ^IndirectReadSideEffect     : &:r10_0, ~mu0_2
+#-----|     r10_5(iterator)        = ^IndirectMayWriteSideEffect : &:r10_0, ~mu0_2
+#-----|   Goto (back edge) -> Block 9
 
 # 1099| int AsmStmt(int)
 # 1099|   Block 0
@@ -5228,7 +5378,9 @@ ir.cpp:
 # 1140|     r7_3(char *)          = Convert                         : r7_2
 # 1140|     v7_4(void)            = Call                            : func:r7_1, this:r7_0, 0:r7_3
 # 1140|     mu7_5(unknown)        = ^CallSideEffect                 : ~mu0_2
-# 1140|     v7_6(void)            = ThrowValue                      : &:r7_0, ~mu0_2
+# 1140|     v7_6(void)            = ^IndirectReadSideEffect[p#0]    : &:r7_3, ~mu0_2
+# 1140|     mu7_7(unknown)        = ^BufferMayWriteSideEffect[p#0]  : &:r7_3, ~mu0_2
+# 1140|     v7_8(void)            = ThrowValue                      : &:r7_0, ~mu0_2
 #-----|   Exception -> Block 9
 
 # 1142|   Block 8
@@ -5243,15 +5395,17 @@ ir.cpp:
 #-----|   Goto -> Block 10
 
 # 1144|   Block 10
-# 1144|     r10_0(glval<char *>)  = VariableAddress[s]            : 
-# 1144|     mu10_1(char *)        = InitializeParameter[s]        : &:r10_0
-# 1145|     r10_2(glval<String>)  = VariableAddress[#throw1145:5] : 
-# 1145|     r10_3(glval<unknown>) = FunctionAddress[String]       : 
-# 1145|     r10_4(glval<char *>)  = VariableAddress[s]            : 
-# 1145|     r10_5(char *)         = Load                          : &:r10_4, ~mu0_2
-# 1145|     v10_6(void)           = Call                          : func:r10_3, this:r10_2, 0:r10_5
-# 1145|     mu10_7(unknown)       = ^CallSideEffect               : ~mu0_2
-# 1145|     v10_8(void)           = ThrowValue                    : &:r10_2, ~mu0_2
+# 1144|     r10_0(glval<char *>)  = VariableAddress[s]             : 
+# 1144|     mu10_1(char *)        = InitializeParameter[s]         : &:r10_0
+# 1145|     r10_2(glval<String>)  = VariableAddress[#throw1145:5]  : 
+# 1145|     r10_3(glval<unknown>) = FunctionAddress[String]        : 
+# 1145|     r10_4(glval<char *>)  = VariableAddress[s]             : 
+# 1145|     r10_5(char *)         = Load                           : &:r10_4, ~mu0_2
+# 1145|     v10_6(void)           = Call                           : func:r10_3, this:r10_2, 0:r10_5
+# 1145|     mu10_7(unknown)       = ^CallSideEffect                : ~mu0_2
+# 1145|     v10_8(void)           = ^IndirectReadSideEffect[p#0]   : &:r10_5, ~mu0_2
+# 1145|     mu10_9(unknown)       = ^BufferMayWriteSideEffect[p#0] : &:r10_5, ~mu0_2
+# 1145|     v10_10(void)          = ThrowValue                     : &:r10_2, ~mu0_2
 #-----|   Exception -> Block 2
 
 # 1147|   Block 11
@@ -5331,6 +5485,33 @@ ir.cpp:
 # 1153|     v0_56(void)                                        = ReturnVoid                       : 
 # 1153|     v0_57(void)                                        = UnmodeledUse                     : mu*
 # 1153|     v0_58(void)                                        = ExitFunction                     : 
+
+# 1163| int ModeledCallTarget(int)
+# 1163|   Block 0
+# 1163|     v0_0(void)           = EnterFunction                   : 
+# 1163|     mu0_1(unknown)       = AliasedDefinition               : 
+# 1163|     mu0_2(unknown)       = UnmodeledDefinition             : 
+# 1163|     r0_3(glval<int>)     = VariableAddress[x]              : 
+# 1163|     mu0_4(int)           = InitializeParameter[x]          : &:r0_3
+# 1164|     r0_5(glval<int>)     = VariableAddress[y]              : 
+# 1164|     mu0_6(int)           = Uninitialized[y]                : &:r0_5
+# 1165|     r0_7(glval<unknown>) = FunctionAddress[memcpy]         : 
+# 1165|     r0_8(glval<int>)     = VariableAddress[y]              : 
+# 1165|     r0_9(void *)         = Convert                         : r0_8
+# 1165|     r0_10(glval<int>)    = VariableAddress[x]              : 
+# 1165|     r0_11(void *)        = Convert                         : r0_10
+# 1165|     r0_12(int)           = Constant[4]                     : 
+# 1165|     r0_13(void *)        = Call                            : func:r0_7, 0:r0_9, 1:r0_11, 2:r0_12
+# 1165|     v0_14(void)          = ^BufferReadSideEffect[src]      : &:r0_11, ~mu0_2
+# 1165|     mu0_15(unknown)      = ^BufferMustWriteSideEffect[dst] : &:r0_9
+# 1166|     r0_16(glval<int>)    = VariableAddress[#return]        : 
+# 1166|     r0_17(glval<int>)    = VariableAddress[y]              : 
+# 1166|     r0_18(int)           = Load                            : &:r0_17, ~mu0_2
+# 1166|     mu0_19(int)          = Store                           : &:r0_16, r0_18
+# 1163|     r0_20(glval<int>)    = VariableAddress[#return]        : 
+# 1163|     v0_21(void)          = ReturnValue                     : &:r0_20, ~mu0_2
+# 1163|     v0_22(void)          = UnmodeledUse                    : mu*
+# 1163|     v0_23(void)          = ExitFunction                    : 
 
 perf-regression.cpp:
 #    6| void Big::Big()

--- a/cpp/ql/test/library-tests/ir/ir/raw_ir.expected
+++ b/cpp/ql/test/library-tests/ir/ir/raw_ir.expected
@@ -14,8 +14,8 @@ bad_asts.cpp:
 #   16|     r0_10(int)           = Constant[1]                     : 
 #   16|     r0_11(int)           = Call                            : func:r0_9, this:r0_8, 0:r0_10
 #   16|     mu0_12(unknown)      = ^CallSideEffect                 : ~mu0_2
-#   16|     v0_13(void)          = ^IndirectReadSideEffect         : &:r0_8, ~mu0_2
-#   16|     mu0_14(S)            = ^IndirectMayWriteSideEffect     : &:r0_8, ~mu0_2
+#   16|     v0_13(void)          = ^IndirectReadSideEffect[-1]     : &:r0_8, ~mu0_2
+#   16|     mu0_14(S)            = ^IndirectMayWriteSideEffect[-1] : &:r0_8, ~mu0_2
 #   17|     v0_15(void)          = NoOp                            : 
 #   14|     v0_16(void)          = ReturnVoid                      : 
 #   14|     v0_17(void)          = UnmodeledUse                    : mu*
@@ -2675,10 +2675,10 @@ ir.cpp:
 #  585|     r0_8(char *)         = Convert                         : r0_7
 #  585|     v0_9(void)           = Call                            : func:r0_3, 0:r0_5, 1:r0_6, 2:r0_8
 #  585|     mu0_10(unknown)      = ^CallSideEffect                 : ~mu0_2
-#  585|     v0_11(void)          = ^IndirectReadSideEffect         : &:r0_5, ~mu0_2
-#  585|     v0_12(void)          = ^IndirectReadSideEffect         : &:r0_8, ~mu0_2
-#  585|     mu0_13(unknown)      = ^BufferMayWriteSideEffect       : &:r0_5, ~mu0_2
-#  585|     mu0_14(unknown)      = ^BufferMayWriteSideEffect       : &:r0_8, ~mu0_2
+#  585|     v0_11(void)          = ^IndirectReadSideEffect[0]      : &:r0_5, ~mu0_2
+#  585|     v0_12(void)          = ^IndirectReadSideEffect[2]      : &:r0_8, ~mu0_2
+#  585|     mu0_13(unknown)      = ^BufferMayWriteSideEffect[0]    : &:r0_5, ~mu0_2
+#  585|     mu0_14(unknown)      = ^BufferMayWriteSideEffect[2]    : &:r0_8, ~mu0_2
 #  586|     v0_15(void)          = NoOp                            : 
 #  584|     v0_16(void)          = ReturnVoid                      : 
 #  584|     v0_17(void)          = UnmodeledUse                    : mu*
@@ -2721,8 +2721,8 @@ ir.cpp:
 #  617|     r0_10(char *)         = Convert                       : r0_9
 #  617|     v0_11(void)           = Call                          : func:r0_8, this:r0_7, 0:r0_10
 #  617|     mu0_12(unknown)       = ^CallSideEffect               : ~mu0_2
-#  617|     v0_13(void)           = ^IndirectReadSideEffect       : &:r0_10, ~mu0_2
-#  617|     mu0_14(unknown)       = ^BufferMayWriteSideEffect     : &:r0_10, ~mu0_2
+#  617|     v0_13(void)           = ^IndirectReadSideEffect[0]    : &:r0_10, ~mu0_2
+#  617|     mu0_14(unknown)       = ^BufferMayWriteSideEffect[0]  : &:r0_10, ~mu0_2
 #  618|     r0_15(glval<String>)  = VariableAddress[s3]           : 
 #  618|     r0_16(glval<unknown>) = FunctionAddress[ReturnObject] : 
 #  618|     r0_17(String)         = Call                          : func:r0_16
@@ -2734,8 +2734,8 @@ ir.cpp:
 #  619|     r0_23(char *)         = Convert                       : r0_22
 #  619|     v0_24(void)           = Call                          : func:r0_21, this:r0_20, 0:r0_23
 #  619|     mu0_25(unknown)       = ^CallSideEffect               : ~mu0_2
-#  619|     v0_26(void)           = ^IndirectReadSideEffect       : &:r0_23, ~mu0_2
-#  619|     mu0_27(unknown)       = ^BufferMayWriteSideEffect     : &:r0_23, ~mu0_2
+#  619|     v0_26(void)           = ^IndirectReadSideEffect[0]    : &:r0_23, ~mu0_2
+#  619|     mu0_27(unknown)       = ^BufferMayWriteSideEffect[0]  : &:r0_23, ~mu0_2
 #  620|     v0_28(void)           = NoOp                          : 
 #  615|     v0_29(void)           = ReturnVoid                    : 
 #  615|     v0_30(void)           = UnmodeledUse                  : mu*
@@ -2743,42 +2743,42 @@ ir.cpp:
 
 #  622| void CallMethods(String&, String*, String)
 #  622|   Block 0
-#  622|     v0_0(void)             = EnterFunction               : 
-#  622|     mu0_1(unknown)         = AliasedDefinition           : 
-#  622|     mu0_2(unknown)         = UnmodeledDefinition         : 
-#  622|     r0_3(glval<String &>)  = VariableAddress[r]          : 
-#  622|     mu0_4(String &)        = InitializeParameter[r]      : &:r0_3
-#  622|     r0_5(glval<String *>)  = VariableAddress[p]          : 
-#  622|     mu0_6(String *)        = InitializeParameter[p]      : &:r0_5
-#  622|     r0_7(glval<String>)    = VariableAddress[s]          : 
-#  622|     mu0_8(String)          = InitializeParameter[s]      : &:r0_7
-#  623|     r0_9(glval<String &>)  = VariableAddress[r]          : 
-#  623|     r0_10(String &)        = Load                        : &:r0_9, ~mu0_2
-#  623|     r0_11(glval<String>)   = Convert                     : r0_10
-#  623|     r0_12(glval<unknown>)  = FunctionAddress[c_str]      : 
-#  623|     r0_13(char *)          = Call                        : func:r0_12, this:r0_11
-#  623|     mu0_14(unknown)        = ^CallSideEffect             : ~mu0_2
-#  623|     v0_15(void)            = ^IndirectReadSideEffect     : &:r0_11, ~mu0_2
-#  623|     mu0_16(String)         = ^IndirectMayWriteSideEffect : &:r0_11, ~mu0_2
-#  624|     r0_17(glval<String *>) = VariableAddress[p]          : 
-#  624|     r0_18(String *)        = Load                        : &:r0_17, ~mu0_2
-#  624|     r0_19(String *)        = Convert                     : r0_18
-#  624|     r0_20(glval<unknown>)  = FunctionAddress[c_str]      : 
-#  624|     r0_21(char *)          = Call                        : func:r0_20, this:r0_19
-#  624|     mu0_22(unknown)        = ^CallSideEffect             : ~mu0_2
-#  624|     v0_23(void)            = ^IndirectReadSideEffect     : &:r0_19, ~mu0_2
-#  624|     mu0_24(String)         = ^IndirectMayWriteSideEffect : &:r0_19, ~mu0_2
-#  625|     r0_25(glval<String>)   = VariableAddress[s]          : 
-#  625|     r0_26(glval<String>)   = Convert                     : r0_25
-#  625|     r0_27(glval<unknown>)  = FunctionAddress[c_str]      : 
-#  625|     r0_28(char *)          = Call                        : func:r0_27, this:r0_26
-#  625|     mu0_29(unknown)        = ^CallSideEffect             : ~mu0_2
-#  625|     v0_30(void)            = ^IndirectReadSideEffect     : &:r0_26, ~mu0_2
-#  625|     mu0_31(String)         = ^IndirectMayWriteSideEffect : &:r0_26, ~mu0_2
-#  626|     v0_32(void)            = NoOp                        : 
-#  622|     v0_33(void)            = ReturnVoid                  : 
-#  622|     v0_34(void)            = UnmodeledUse                : mu*
-#  622|     v0_35(void)            = ExitFunction                : 
+#  622|     v0_0(void)             = EnterFunction                   : 
+#  622|     mu0_1(unknown)         = AliasedDefinition               : 
+#  622|     mu0_2(unknown)         = UnmodeledDefinition             : 
+#  622|     r0_3(glval<String &>)  = VariableAddress[r]              : 
+#  622|     mu0_4(String &)        = InitializeParameter[r]          : &:r0_3
+#  622|     r0_5(glval<String *>)  = VariableAddress[p]              : 
+#  622|     mu0_6(String *)        = InitializeParameter[p]          : &:r0_5
+#  622|     r0_7(glval<String>)    = VariableAddress[s]              : 
+#  622|     mu0_8(String)          = InitializeParameter[s]          : &:r0_7
+#  623|     r0_9(glval<String &>)  = VariableAddress[r]              : 
+#  623|     r0_10(String &)        = Load                            : &:r0_9, ~mu0_2
+#  623|     r0_11(glval<String>)   = Convert                         : r0_10
+#  623|     r0_12(glval<unknown>)  = FunctionAddress[c_str]          : 
+#  623|     r0_13(char *)          = Call                            : func:r0_12, this:r0_11
+#  623|     mu0_14(unknown)        = ^CallSideEffect                 : ~mu0_2
+#  623|     v0_15(void)            = ^IndirectReadSideEffect[-1]     : &:r0_11, ~mu0_2
+#  623|     mu0_16(String)         = ^IndirectMayWriteSideEffect[-1] : &:r0_11, ~mu0_2
+#  624|     r0_17(glval<String *>) = VariableAddress[p]              : 
+#  624|     r0_18(String *)        = Load                            : &:r0_17, ~mu0_2
+#  624|     r0_19(String *)        = Convert                         : r0_18
+#  624|     r0_20(glval<unknown>)  = FunctionAddress[c_str]          : 
+#  624|     r0_21(char *)          = Call                            : func:r0_20, this:r0_19
+#  624|     mu0_22(unknown)        = ^CallSideEffect                 : ~mu0_2
+#  624|     v0_23(void)            = ^IndirectReadSideEffect[-1]     : &:r0_19, ~mu0_2
+#  624|     mu0_24(String)         = ^IndirectMayWriteSideEffect[-1] : &:r0_19, ~mu0_2
+#  625|     r0_25(glval<String>)   = VariableAddress[s]              : 
+#  625|     r0_26(glval<String>)   = Convert                         : r0_25
+#  625|     r0_27(glval<unknown>)  = FunctionAddress[c_str]          : 
+#  625|     r0_28(char *)          = Call                            : func:r0_27, this:r0_26
+#  625|     mu0_29(unknown)        = ^CallSideEffect                 : ~mu0_2
+#  625|     v0_30(void)            = ^IndirectReadSideEffect[-1]     : &:r0_26, ~mu0_2
+#  625|     mu0_31(String)         = ^IndirectMayWriteSideEffect[-1] : &:r0_26, ~mu0_2
+#  626|     v0_32(void)            = NoOp                            : 
+#  622|     v0_33(void)            = ReturnVoid                      : 
+#  622|     v0_34(void)            = UnmodeledUse                    : mu*
+#  622|     v0_35(void)            = ExitFunction                    : 
 
 #  630| int C::StaticMemberFunction(int)
 #  630|   Block 0
@@ -2881,22 +2881,22 @@ ir.cpp:
 #  653|     r0_6(int)             = Constant[0]                             : 
 #  653|     r0_7(int)             = Call                                    : func:r0_5, this:r0_4, 0:r0_6
 #  653|     mu0_8(unknown)        = ^CallSideEffect                         : ~mu0_2
-#  653|     v0_9(void)            = ^IndirectReadSideEffect                 : &:r0_4, ~mu0_2
-#  653|     mu0_10(C)             = ^IndirectMayWriteSideEffect             : &:r0_4, ~mu0_2
+#  653|     v0_9(void)            = ^IndirectReadSideEffect[-1]             : &:r0_4, ~mu0_2
+#  653|     mu0_10(C)             = ^IndirectMayWriteSideEffect[-1]         : &:r0_4, ~mu0_2
 #  654|     r0_11(C *)            = CopyValue                               : r0_3
 #  654|     r0_12(glval<unknown>) = FunctionAddress[InstanceMemberFunction] : 
 #  654|     r0_13(int)            = Constant[1]                             : 
 #  654|     r0_14(int)            = Call                                    : func:r0_12, this:r0_11, 0:r0_13
 #  654|     mu0_15(unknown)       = ^CallSideEffect                         : ~mu0_2
-#  654|     v0_16(void)           = ^IndirectReadSideEffect                 : &:r0_11, ~mu0_2
-#  654|     mu0_17(C)             = ^IndirectMayWriteSideEffect             : &:r0_11, ~mu0_2
+#  654|     v0_16(void)           = ^IndirectReadSideEffect[-1]             : &:r0_11, ~mu0_2
+#  654|     mu0_17(C)             = ^IndirectMayWriteSideEffect[-1]         : &:r0_11, ~mu0_2
 #-----|     r0_18(C *)            = CopyValue                               : r0_3
 #  655|     r0_19(glval<unknown>) = FunctionAddress[InstanceMemberFunction] : 
 #  655|     r0_20(int)            = Constant[2]                             : 
 #  655|     r0_21(int)            = Call                                    : func:r0_19, this:r0_18, 0:r0_20
 #  655|     mu0_22(unknown)       = ^CallSideEffect                         : ~mu0_2
-#-----|     v0_23(void)           = ^IndirectReadSideEffect                 : &:r0_18, ~mu0_2
-#-----|     mu0_24(C)             = ^IndirectMayWriteSideEffect             : &:r0_18, ~mu0_2
+#-----|     v0_23(void)           = ^IndirectReadSideEffect[-1]             : &:r0_18, ~mu0_2
+#-----|     mu0_24(C)             = ^IndirectMayWriteSideEffect[-1]         : &:r0_18, ~mu0_2
 #  656|     v0_25(void)           = NoOp                                    : 
 #  652|     v0_26(void)           = ReturnVoid                              : 
 #  652|     v0_27(void)           = UnmodeledUse                            : mu*
@@ -2904,35 +2904,35 @@ ir.cpp:
 
 #  658| void C::C()
 #  658|   Block 0
-#  658|     v0_0(void)            = EnterFunction             : 
-#  658|     mu0_1(unknown)        = AliasedDefinition         : 
-#  658|     mu0_2(unknown)        = UnmodeledDefinition       : 
-#  658|     r0_3(glval<C>)        = InitializeThis            : 
-#  659|     r0_4(glval<int>)      = FieldAddress[m_a]         : r0_3
-#  659|     r0_5(int)             = Constant[1]               : 
-#  659|     mu0_6(int)            = Store                     : &:r0_4, r0_5
-#  663|     r0_7(glval<String>)   = FieldAddress[m_b]         : r0_3
-#  663|     r0_8(glval<unknown>)  = FunctionAddress[String]   : 
-#  663|     v0_9(void)            = Call                      : func:r0_8, this:r0_7
-#  663|     mu0_10(unknown)       = ^CallSideEffect           : ~mu0_2
-#  660|     r0_11(glval<char>)    = FieldAddress[m_c]         : r0_3
-#  660|     r0_12(char)           = Constant[3]               : 
-#  660|     mu0_13(char)          = Store                     : &:r0_11, r0_12
-#  661|     r0_14(glval<void *>)  = FieldAddress[m_e]         : r0_3
-#  661|     r0_15(void *)         = Constant[0]               : 
-#  661|     mu0_16(void *)        = Store                     : &:r0_14, r0_15
-#  662|     r0_17(glval<String>)  = FieldAddress[m_f]         : r0_3
-#  662|     r0_18(glval<unknown>) = FunctionAddress[String]   : 
-#  662|     r0_19(glval<char[5]>) = StringConstant["test"]    : 
-#  662|     r0_20(char *)         = Convert                   : r0_19
-#  662|     v0_21(void)           = Call                      : func:r0_18, this:r0_17, 0:r0_20
-#  662|     mu0_22(unknown)       = ^CallSideEffect           : ~mu0_2
-#  662|     v0_23(void)           = ^IndirectReadSideEffect   : &:r0_20, ~mu0_2
-#  662|     mu0_24(unknown)       = ^BufferMayWriteSideEffect : &:r0_20, ~mu0_2
-#  664|     v0_25(void)           = NoOp                      : 
-#  658|     v0_26(void)           = ReturnVoid                : 
-#  658|     v0_27(void)           = UnmodeledUse              : mu*
-#  658|     v0_28(void)           = ExitFunction              : 
+#  658|     v0_0(void)            = EnterFunction                : 
+#  658|     mu0_1(unknown)        = AliasedDefinition            : 
+#  658|     mu0_2(unknown)        = UnmodeledDefinition          : 
+#  658|     r0_3(glval<C>)        = InitializeThis               : 
+#  659|     r0_4(glval<int>)      = FieldAddress[m_a]            : r0_3
+#  659|     r0_5(int)             = Constant[1]                  : 
+#  659|     mu0_6(int)            = Store                        : &:r0_4, r0_5
+#  663|     r0_7(glval<String>)   = FieldAddress[m_b]            : r0_3
+#  663|     r0_8(glval<unknown>)  = FunctionAddress[String]      : 
+#  663|     v0_9(void)            = Call                         : func:r0_8, this:r0_7
+#  663|     mu0_10(unknown)       = ^CallSideEffect              : ~mu0_2
+#  660|     r0_11(glval<char>)    = FieldAddress[m_c]            : r0_3
+#  660|     r0_12(char)           = Constant[3]                  : 
+#  660|     mu0_13(char)          = Store                        : &:r0_11, r0_12
+#  661|     r0_14(glval<void *>)  = FieldAddress[m_e]            : r0_3
+#  661|     r0_15(void *)         = Constant[0]                  : 
+#  661|     mu0_16(void *)        = Store                        : &:r0_14, r0_15
+#  662|     r0_17(glval<String>)  = FieldAddress[m_f]            : r0_3
+#  662|     r0_18(glval<unknown>) = FunctionAddress[String]      : 
+#  662|     r0_19(glval<char[5]>) = StringConstant["test"]       : 
+#  662|     r0_20(char *)         = Convert                      : r0_19
+#  662|     v0_21(void)           = Call                         : func:r0_18, this:r0_17, 0:r0_20
+#  662|     mu0_22(unknown)       = ^CallSideEffect              : ~mu0_2
+#  662|     v0_23(void)           = ^IndirectReadSideEffect[0]   : &:r0_20, ~mu0_2
+#  662|     mu0_24(unknown)       = ^BufferMayWriteSideEffect[0] : &:r0_20, ~mu0_2
+#  664|     v0_25(void)           = NoOp                         : 
+#  658|     v0_26(void)           = ReturnVoid                   : 
+#  658|     v0_27(void)           = UnmodeledUse                 : mu*
+#  658|     v0_28(void)           = ExitFunction                 : 
 
 #  675| int DerefReference(int&)
 #  675|   Block 0
@@ -3118,23 +3118,23 @@ ir.cpp:
 
 #  720| double CallNestedTemplateFunc()
 #  720|   Block 0
-#  720|     v0_0(void)           = EnterFunction             : 
-#  720|     mu0_1(unknown)       = AliasedDefinition         : 
-#  720|     mu0_2(unknown)       = UnmodeledDefinition       : 
-#  721|     r0_3(glval<double>)  = VariableAddress[#return]  : 
-#  721|     r0_4(glval<unknown>) = FunctionAddress[Func]     : 
-#  721|     r0_5(void *)         = Constant[0]               : 
-#  721|     r0_6(char)           = Constant[111]             : 
-#  721|     r0_7(long)           = Call                      : func:r0_4, 0:r0_5, 1:r0_6
-#  721|     mu0_8(unknown)       = ^CallSideEffect           : ~mu0_2
-#  721|     v0_9(void)           = ^IndirectReadSideEffect   : &:r0_5, ~mu0_2
-#  721|     mu0_10(unknown)      = ^BufferMayWriteSideEffect : &:r0_5, ~mu0_2
-#  721|     r0_11(double)        = Convert                   : r0_7
-#  721|     mu0_12(double)       = Store                     : &:r0_3, r0_11
-#  720|     r0_13(glval<double>) = VariableAddress[#return]  : 
-#  720|     v0_14(void)          = ReturnValue               : &:r0_13, ~mu0_2
-#  720|     v0_15(void)          = UnmodeledUse              : mu*
-#  720|     v0_16(void)          = ExitFunction              : 
+#  720|     v0_0(void)           = EnterFunction                : 
+#  720|     mu0_1(unknown)       = AliasedDefinition            : 
+#  720|     mu0_2(unknown)       = UnmodeledDefinition          : 
+#  721|     r0_3(glval<double>)  = VariableAddress[#return]     : 
+#  721|     r0_4(glval<unknown>) = FunctionAddress[Func]        : 
+#  721|     r0_5(void *)         = Constant[0]                  : 
+#  721|     r0_6(char)           = Constant[111]                : 
+#  721|     r0_7(long)           = Call                         : func:r0_4, 0:r0_5, 1:r0_6
+#  721|     mu0_8(unknown)       = ^CallSideEffect              : ~mu0_2
+#  721|     v0_9(void)           = ^IndirectReadSideEffect[0]   : &:r0_5, ~mu0_2
+#  721|     mu0_10(unknown)      = ^BufferMayWriteSideEffect[0] : &:r0_5, ~mu0_2
+#  721|     r0_11(double)        = Convert                      : r0_7
+#  721|     mu0_12(double)       = Store                        : &:r0_3, r0_11
+#  720|     r0_13(glval<double>) = VariableAddress[#return]     : 
+#  720|     v0_14(void)          = ReturnValue                  : &:r0_13, ~mu0_2
+#  720|     v0_15(void)          = UnmodeledUse                 : mu*
+#  720|     v0_16(void)          = ExitFunction                 : 
 
 #  724| void TryCatch(bool)
 #  724|   Block 0
@@ -3201,8 +3201,8 @@ ir.cpp:
 #  731|     r7_3(char *)          = Convert                         : r7_2
 #  731|     v7_4(void)            = Call                            : func:r7_1, this:r7_0, 0:r7_3
 #  731|     mu7_5(unknown)        = ^CallSideEffect                 : ~mu0_2
-#  731|     v7_6(void)            = ^IndirectReadSideEffect         : &:r7_3, ~mu0_2
-#  731|     mu7_7(unknown)        = ^BufferMayWriteSideEffect       : &:r7_3, ~mu0_2
+#  731|     v7_6(void)            = ^IndirectReadSideEffect[0]      : &:r7_3, ~mu0_2
+#  731|     mu7_7(unknown)        = ^BufferMayWriteSideEffect[0]    : &:r7_3, ~mu0_2
 #  731|     v7_8(void)            = ThrowValue                      : &:r7_0, ~mu0_2
 #-----|   Exception -> Block 9
 
@@ -3226,8 +3226,8 @@ ir.cpp:
 #  736|     r10_5(char *)         = Load                         : &:r10_4, ~mu0_2
 #  736|     v10_6(void)           = Call                         : func:r10_3, this:r10_2, 0:r10_5
 #  736|     mu10_7(unknown)       = ^CallSideEffect              : ~mu0_2
-#  736|     v10_8(void)           = ^IndirectReadSideEffect      : &:r10_5, ~mu0_2
-#  736|     mu10_9(unknown)       = ^BufferMayWriteSideEffect    : &:r10_5, ~mu0_2
+#  736|     v10_8(void)           = ^IndirectReadSideEffect[0]   : &:r10_5, ~mu0_2
+#  736|     mu10_9(unknown)       = ^BufferMayWriteSideEffect[0] : &:r10_5, ~mu0_2
 #  736|     v10_10(void)          = ThrowValue                   : &:r10_2, ~mu0_2
 #-----|   Exception -> Block 2
 
@@ -3254,31 +3254,31 @@ ir.cpp:
 
 #  745| Base& Base::operator=(Base const&)
 #  745|   Block 0
-#  745|     v0_0(void)           = EnterFunction               : 
-#  745|     mu0_1(unknown)       = AliasedDefinition           : 
-#  745|     mu0_2(unknown)       = UnmodeledDefinition         : 
-#  745|     r0_3(glval<Base>)    = InitializeThis              : 
-#-----|     r0_4(glval<Base &>)  = VariableAddress[p#0]        : 
-#-----|     mu0_5(Base &)        = InitializeParameter[p#0]    : &:r0_4
-#-----|     r0_6(Base *)         = CopyValue                   : r0_3
-#-----|     r0_7(glval<String>)  = FieldAddress[base_s]        : r0_6
-#  745|     r0_8(glval<unknown>) = FunctionAddress[operator=]  : 
-#-----|     r0_9(glval<Base &>)  = VariableAddress[p#0]        : 
-#-----|     r0_10(Base &)        = Load                        : &:r0_9, ~mu0_2
-#-----|     r0_11(glval<String>) = FieldAddress[base_s]        : r0_10
-#  745|     r0_12(String &)      = Call                        : func:r0_8, this:r0_7, 0:r0_11
-#  745|     mu0_13(unknown)      = ^CallSideEffect             : ~mu0_2
-#-----|     v0_14(void)          = ^IndirectReadSideEffect     : &:r0_7, ~mu0_2
-#-----|     v0_15(void)          = ^IndirectReadSideEffect     : &:r0_11, ~mu0_2
-#-----|     mu0_16(String)       = ^IndirectMayWriteSideEffect : &:r0_7, ~mu0_2
-#-----|     mu0_17(unknown)      = ^BufferMayWriteSideEffect   : &:r0_11, ~mu0_2
-#-----|     r0_18(glval<Base &>) = VariableAddress[#return]    : 
-#-----|     r0_19(Base *)        = CopyValue                   : r0_3
-#-----|     mu0_20(Base &)       = Store                       : &:r0_18, r0_19
-#  745|     r0_21(glval<Base &>) = VariableAddress[#return]    : 
-#  745|     v0_22(void)          = ReturnValue                 : &:r0_21, ~mu0_2
-#  745|     v0_23(void)          = UnmodeledUse                : mu*
-#  745|     v0_24(void)          = ExitFunction                : 
+#  745|     v0_0(void)           = EnterFunction                   : 
+#  745|     mu0_1(unknown)       = AliasedDefinition               : 
+#  745|     mu0_2(unknown)       = UnmodeledDefinition             : 
+#  745|     r0_3(glval<Base>)    = InitializeThis                  : 
+#-----|     r0_4(glval<Base &>)  = VariableAddress[p#0]            : 
+#-----|     mu0_5(Base &)        = InitializeParameter[p#0]        : &:r0_4
+#-----|     r0_6(Base *)         = CopyValue                       : r0_3
+#-----|     r0_7(glval<String>)  = FieldAddress[base_s]            : r0_6
+#  745|     r0_8(glval<unknown>) = FunctionAddress[operator=]      : 
+#-----|     r0_9(glval<Base &>)  = VariableAddress[p#0]            : 
+#-----|     r0_10(Base &)        = Load                            : &:r0_9, ~mu0_2
+#-----|     r0_11(glval<String>) = FieldAddress[base_s]            : r0_10
+#  745|     r0_12(String &)      = Call                            : func:r0_8, this:r0_7, 0:r0_11
+#  745|     mu0_13(unknown)      = ^CallSideEffect                 : ~mu0_2
+#-----|     v0_14(void)          = ^IndirectReadSideEffect[-1]     : &:r0_7, ~mu0_2
+#-----|     v0_15(void)          = ^IndirectReadSideEffect[0]      : &:r0_11, ~mu0_2
+#-----|     mu0_16(String)       = ^IndirectMayWriteSideEffect[-1] : &:r0_7, ~mu0_2
+#-----|     mu0_17(unknown)      = ^BufferMayWriteSideEffect[0]    : &:r0_11, ~mu0_2
+#-----|     r0_18(glval<Base &>) = VariableAddress[#return]        : 
+#-----|     r0_19(Base *)        = CopyValue                       : r0_3
+#-----|     mu0_20(Base &)       = Store                           : &:r0_18, r0_19
+#  745|     r0_21(glval<Base &>) = VariableAddress[#return]        : 
+#  745|     v0_22(void)          = ReturnValue                     : &:r0_21, ~mu0_2
+#  745|     v0_23(void)          = UnmodeledUse                    : mu*
+#  745|     v0_24(void)          = ExitFunction                    : 
 
 #  745| void Base::Base(Base const&)
 #  745|   Block 0
@@ -3329,43 +3329,43 @@ ir.cpp:
 
 #  754| Middle& Middle::operator=(Middle const&)
 #  754|   Block 0
-#  754|     v0_0(void)             = EnterFunction                : 
-#  754|     mu0_1(unknown)         = AliasedDefinition            : 
-#  754|     mu0_2(unknown)         = UnmodeledDefinition          : 
-#  754|     r0_3(glval<Middle>)    = InitializeThis               : 
-#-----|     r0_4(glval<Middle &>)  = VariableAddress[p#0]         : 
-#-----|     mu0_5(Middle &)        = InitializeParameter[p#0]     : &:r0_4
-#-----|     r0_6(Middle *)         = CopyValue                    : r0_3
-#-----|     r0_7(Base *)           = ConvertToBase[Middle : Base] : r0_6
-#  754|     r0_8(glval<unknown>)   = FunctionAddress[operator=]   : 
-#-----|     r0_9(glval<Middle &>)  = VariableAddress[p#0]         : 
-#-----|     r0_10(Middle &)        = Load                         : &:r0_9, ~mu0_2
-#-----|     r0_11(Base *)          = ConvertToBase[Middle : Base] : r0_10
-#  754|     r0_12(Base &)          = Call                         : func:r0_8, this:r0_7, 0:r0_11
-#  754|     mu0_13(unknown)        = ^CallSideEffect              : ~mu0_2
-#-----|     v0_14(void)            = ^IndirectReadSideEffect      : &:r0_7, ~mu0_2
-#-----|     v0_15(void)            = ^IndirectReadSideEffect      : &:r0_11, ~mu0_2
-#-----|     mu0_16(Base)           = ^IndirectMayWriteSideEffect  : &:r0_7, ~mu0_2
-#-----|     mu0_17(unknown)        = ^BufferMayWriteSideEffect    : &:r0_11, ~mu0_2
-#-----|     r0_18(Middle *)        = CopyValue                    : r0_3
-#-----|     r0_19(glval<String>)   = FieldAddress[middle_s]       : r0_18
-#  754|     r0_20(glval<unknown>)  = FunctionAddress[operator=]   : 
-#-----|     r0_21(glval<Middle &>) = VariableAddress[p#0]         : 
-#-----|     r0_22(Middle &)        = Load                         : &:r0_21, ~mu0_2
-#-----|     r0_23(glval<String>)   = FieldAddress[middle_s]       : r0_22
-#  754|     r0_24(String &)        = Call                         : func:r0_20, this:r0_19, 0:r0_23
-#  754|     mu0_25(unknown)        = ^CallSideEffect              : ~mu0_2
-#-----|     v0_26(void)            = ^IndirectReadSideEffect      : &:r0_19, ~mu0_2
-#-----|     v0_27(void)            = ^IndirectReadSideEffect      : &:r0_23, ~mu0_2
-#-----|     mu0_28(String)         = ^IndirectMayWriteSideEffect  : &:r0_19, ~mu0_2
-#-----|     mu0_29(unknown)        = ^BufferMayWriteSideEffect    : &:r0_23, ~mu0_2
-#-----|     r0_30(glval<Middle &>) = VariableAddress[#return]     : 
-#-----|     r0_31(Middle *)        = CopyValue                    : r0_3
-#-----|     mu0_32(Middle &)       = Store                        : &:r0_30, r0_31
-#  754|     r0_33(glval<Middle &>) = VariableAddress[#return]     : 
-#  754|     v0_34(void)            = ReturnValue                  : &:r0_33, ~mu0_2
-#  754|     v0_35(void)            = UnmodeledUse                 : mu*
-#  754|     v0_36(void)            = ExitFunction                 : 
+#  754|     v0_0(void)             = EnterFunction                   : 
+#  754|     mu0_1(unknown)         = AliasedDefinition               : 
+#  754|     mu0_2(unknown)         = UnmodeledDefinition             : 
+#  754|     r0_3(glval<Middle>)    = InitializeThis                  : 
+#-----|     r0_4(glval<Middle &>)  = VariableAddress[p#0]            : 
+#-----|     mu0_5(Middle &)        = InitializeParameter[p#0]        : &:r0_4
+#-----|     r0_6(Middle *)         = CopyValue                       : r0_3
+#-----|     r0_7(Base *)           = ConvertToBase[Middle : Base]    : r0_6
+#  754|     r0_8(glval<unknown>)   = FunctionAddress[operator=]      : 
+#-----|     r0_9(glval<Middle &>)  = VariableAddress[p#0]            : 
+#-----|     r0_10(Middle &)        = Load                            : &:r0_9, ~mu0_2
+#-----|     r0_11(Base *)          = ConvertToBase[Middle : Base]    : r0_10
+#  754|     r0_12(Base &)          = Call                            : func:r0_8, this:r0_7, 0:r0_11
+#  754|     mu0_13(unknown)        = ^CallSideEffect                 : ~mu0_2
+#-----|     v0_14(void)            = ^IndirectReadSideEffect[-1]     : &:r0_7, ~mu0_2
+#-----|     v0_15(void)            = ^IndirectReadSideEffect[0]      : &:r0_11, ~mu0_2
+#-----|     mu0_16(Base)           = ^IndirectMayWriteSideEffect[-1] : &:r0_7, ~mu0_2
+#-----|     mu0_17(unknown)        = ^BufferMayWriteSideEffect[0]    : &:r0_11, ~mu0_2
+#-----|     r0_18(Middle *)        = CopyValue                       : r0_3
+#-----|     r0_19(glval<String>)   = FieldAddress[middle_s]          : r0_18
+#  754|     r0_20(glval<unknown>)  = FunctionAddress[operator=]      : 
+#-----|     r0_21(glval<Middle &>) = VariableAddress[p#0]            : 
+#-----|     r0_22(Middle &)        = Load                            : &:r0_21, ~mu0_2
+#-----|     r0_23(glval<String>)   = FieldAddress[middle_s]          : r0_22
+#  754|     r0_24(String &)        = Call                            : func:r0_20, this:r0_19, 0:r0_23
+#  754|     mu0_25(unknown)        = ^CallSideEffect                 : ~mu0_2
+#-----|     v0_26(void)            = ^IndirectReadSideEffect[-1]     : &:r0_19, ~mu0_2
+#-----|     v0_27(void)            = ^IndirectReadSideEffect[0]      : &:r0_23, ~mu0_2
+#-----|     mu0_28(String)         = ^IndirectMayWriteSideEffect[-1] : &:r0_19, ~mu0_2
+#-----|     mu0_29(unknown)        = ^BufferMayWriteSideEffect[0]    : &:r0_23, ~mu0_2
+#-----|     r0_30(glval<Middle &>) = VariableAddress[#return]        : 
+#-----|     r0_31(Middle *)        = CopyValue                       : r0_3
+#-----|     mu0_32(Middle &)       = Store                           : &:r0_30, r0_31
+#  754|     r0_33(glval<Middle &>) = VariableAddress[#return]        : 
+#  754|     v0_34(void)            = ReturnValue                     : &:r0_33, ~mu0_2
+#  754|     v0_35(void)            = UnmodeledUse                    : mu*
+#  754|     v0_36(void)            = ExitFunction                    : 
 
 #  757| void Middle::Middle()
 #  757|   Block 0
@@ -3421,10 +3421,10 @@ ir.cpp:
 #-----|     r0_11(Middle *)         = ConvertToBase[Derived : Middle] : r0_10
 #  763|     r0_12(Middle &)         = Call                            : func:r0_8, this:r0_7, 0:r0_11
 #  763|     mu0_13(unknown)         = ^CallSideEffect                 : ~mu0_2
-#-----|     v0_14(void)             = ^IndirectReadSideEffect         : &:r0_7, ~mu0_2
-#-----|     v0_15(void)             = ^IndirectReadSideEffect         : &:r0_11, ~mu0_2
-#-----|     mu0_16(Middle)          = ^IndirectMayWriteSideEffect     : &:r0_7, ~mu0_2
-#-----|     mu0_17(unknown)         = ^BufferMayWriteSideEffect       : &:r0_11, ~mu0_2
+#-----|     v0_14(void)             = ^IndirectReadSideEffect[-1]     : &:r0_7, ~mu0_2
+#-----|     v0_15(void)             = ^IndirectReadSideEffect[0]      : &:r0_11, ~mu0_2
+#-----|     mu0_16(Middle)          = ^IndirectMayWriteSideEffect[-1] : &:r0_7, ~mu0_2
+#-----|     mu0_17(unknown)         = ^BufferMayWriteSideEffect[0]    : &:r0_11, ~mu0_2
 #-----|     r0_18(Derived *)        = CopyValue                       : r0_3
 #-----|     r0_19(glval<String>)    = FieldAddress[derived_s]         : r0_18
 #  763|     r0_20(glval<unknown>)   = FunctionAddress[operator=]      : 
@@ -3433,10 +3433,10 @@ ir.cpp:
 #-----|     r0_23(glval<String>)    = FieldAddress[derived_s]         : r0_22
 #  763|     r0_24(String &)         = Call                            : func:r0_20, this:r0_19, 0:r0_23
 #  763|     mu0_25(unknown)         = ^CallSideEffect                 : ~mu0_2
-#-----|     v0_26(void)             = ^IndirectReadSideEffect         : &:r0_19, ~mu0_2
-#-----|     v0_27(void)             = ^IndirectReadSideEffect         : &:r0_23, ~mu0_2
-#-----|     mu0_28(String)          = ^IndirectMayWriteSideEffect     : &:r0_19, ~mu0_2
-#-----|     mu0_29(unknown)         = ^BufferMayWriteSideEffect       : &:r0_23, ~mu0_2
+#-----|     v0_26(void)             = ^IndirectReadSideEffect[-1]     : &:r0_19, ~mu0_2
+#-----|     v0_27(void)             = ^IndirectReadSideEffect[0]      : &:r0_23, ~mu0_2
+#-----|     mu0_28(String)          = ^IndirectMayWriteSideEffect[-1] : &:r0_19, ~mu0_2
+#-----|     mu0_29(unknown)         = ^BufferMayWriteSideEffect[0]    : &:r0_23, ~mu0_2
 #-----|     r0_30(glval<Derived &>) = VariableAddress[#return]        : 
 #-----|     r0_31(Derived *)        = CopyValue                       : r0_3
 #-----|     mu0_32(Derived &)       = Store                           : &:r0_30, r0_31
@@ -3645,10 +3645,10 @@ ir.cpp:
 #  808|     r0_27(glval<Base>)         = ConvertToBase[Middle : Base]           : r0_26
 #  808|     r0_28(Base &)              = Call                                   : func:r0_25, this:r0_24, 0:r0_27
 #  808|     mu0_29(unknown)            = ^CallSideEffect                        : ~mu0_2
-#  808|     v0_30(void)                = ^IndirectReadSideEffect                : &:r0_24, ~mu0_2
-#  808|     v0_31(void)                = ^IndirectReadSideEffect                : &:r0_27, ~mu0_2
-#  808|     mu0_32(Base)               = ^IndirectMayWriteSideEffect            : &:r0_24, ~mu0_2
-#  808|     mu0_33(unknown)            = ^BufferMayWriteSideEffect              : &:r0_27, ~mu0_2
+#  808|     v0_30(void)                = ^IndirectReadSideEffect[-1]            : &:r0_24, ~mu0_2
+#  808|     v0_31(void)                = ^IndirectReadSideEffect[0]             : &:r0_27, ~mu0_2
+#  808|     mu0_32(Base)               = ^IndirectMayWriteSideEffect[-1]        : &:r0_24, ~mu0_2
+#  808|     mu0_33(unknown)            = ^BufferMayWriteSideEffect[0]           : &:r0_27, ~mu0_2
 #  809|     r0_34(glval<Base>)         = VariableAddress[b]                     : 
 #  809|     r0_35(glval<unknown>)      = FunctionAddress[operator=]             : 
 #  809|     r0_36(glval<unknown>)      = FunctionAddress[Base]                  : 
@@ -3656,15 +3656,15 @@ ir.cpp:
 #  809|     r0_38(glval<Base>)         = ConvertToBase[Middle : Base]           : r0_37
 #  809|     v0_39(void)                = Call                                   : func:r0_36, 0:r0_38
 #  809|     mu0_40(unknown)            = ^CallSideEffect                        : ~mu0_2
-#  809|     v0_41(void)                = ^IndirectReadSideEffect                : &:r0_38, ~mu0_2
-#  809|     mu0_42(unknown)            = ^BufferMayWriteSideEffect              : &:r0_38, ~mu0_2
+#  809|     v0_41(void)                = ^IndirectReadSideEffect[0]             : &:r0_38, ~mu0_2
+#  809|     mu0_42(unknown)            = ^BufferMayWriteSideEffect[0]           : &:r0_38, ~mu0_2
 #  809|     r0_43(glval<Base>)         = Convert                                : v0_39
 #  809|     r0_44(Base &)              = Call                                   : func:r0_35, this:r0_34, 0:r0_43
 #  809|     mu0_45(unknown)            = ^CallSideEffect                        : ~mu0_2
-#  809|     v0_46(void)                = ^IndirectReadSideEffect                : &:r0_34, ~mu0_2
-#  809|     v0_47(void)                = ^IndirectReadSideEffect                : &:r0_43, ~mu0_2
-#  809|     mu0_48(Base)               = ^IndirectMayWriteSideEffect            : &:r0_34, ~mu0_2
-#  809|     mu0_49(unknown)            = ^BufferMayWriteSideEffect              : &:r0_43, ~mu0_2
+#  809|     v0_46(void)                = ^IndirectReadSideEffect[-1]            : &:r0_34, ~mu0_2
+#  809|     v0_47(void)                = ^IndirectReadSideEffect[0]             : &:r0_43, ~mu0_2
+#  809|     mu0_48(Base)               = ^IndirectMayWriteSideEffect[-1]        : &:r0_34, ~mu0_2
+#  809|     mu0_49(unknown)            = ^BufferMayWriteSideEffect[0]           : &:r0_43, ~mu0_2
 #  810|     r0_50(glval<Base>)         = VariableAddress[b]                     : 
 #  810|     r0_51(glval<unknown>)      = FunctionAddress[operator=]             : 
 #  810|     r0_52(glval<unknown>)      = FunctionAddress[Base]                  : 
@@ -3672,15 +3672,15 @@ ir.cpp:
 #  810|     r0_54(glval<Base>)         = ConvertToBase[Middle : Base]           : r0_53
 #  810|     v0_55(void)                = Call                                   : func:r0_52, 0:r0_54
 #  810|     mu0_56(unknown)            = ^CallSideEffect                        : ~mu0_2
-#  810|     v0_57(void)                = ^IndirectReadSideEffect                : &:r0_54, ~mu0_2
-#  810|     mu0_58(unknown)            = ^BufferMayWriteSideEffect              : &:r0_54, ~mu0_2
+#  810|     v0_57(void)                = ^IndirectReadSideEffect[0]             : &:r0_54, ~mu0_2
+#  810|     mu0_58(unknown)            = ^BufferMayWriteSideEffect[0]           : &:r0_54, ~mu0_2
 #  810|     r0_59(glval<Base>)         = Convert                                : v0_55
 #  810|     r0_60(Base &)              = Call                                   : func:r0_51, this:r0_50, 0:r0_59
 #  810|     mu0_61(unknown)            = ^CallSideEffect                        : ~mu0_2
-#  810|     v0_62(void)                = ^IndirectReadSideEffect                : &:r0_50, ~mu0_2
-#  810|     v0_63(void)                = ^IndirectReadSideEffect                : &:r0_59, ~mu0_2
-#  810|     mu0_64(Base)               = ^IndirectMayWriteSideEffect            : &:r0_50, ~mu0_2
-#  810|     mu0_65(unknown)            = ^BufferMayWriteSideEffect              : &:r0_59, ~mu0_2
+#  810|     v0_62(void)                = ^IndirectReadSideEffect[-1]            : &:r0_50, ~mu0_2
+#  810|     v0_63(void)                = ^IndirectReadSideEffect[0]             : &:r0_59, ~mu0_2
+#  810|     mu0_64(Base)               = ^IndirectMayWriteSideEffect[-1]        : &:r0_50, ~mu0_2
+#  810|     mu0_65(unknown)            = ^BufferMayWriteSideEffect[0]           : &:r0_59, ~mu0_2
 #  811|     r0_66(glval<Middle *>)     = VariableAddress[pm]                    : 
 #  811|     r0_67(Middle *)            = Load                                   : &:r0_66, ~mu0_2
 #  811|     r0_68(Base *)              = ConvertToBase[Middle : Base]           : r0_67
@@ -3708,10 +3708,10 @@ ir.cpp:
 #  816|     r0_90(glval<Middle>)       = Convert                                : r0_89
 #  816|     r0_91(Middle &)            = Call                                   : func:r0_87, this:r0_86, 0:r0_90
 #  816|     mu0_92(unknown)            = ^CallSideEffect                        : ~mu0_2
-#  816|     v0_93(void)                = ^IndirectReadSideEffect                : &:r0_86, ~mu0_2
-#  816|     v0_94(void)                = ^IndirectReadSideEffect                : &:r0_90, ~mu0_2
-#  816|     mu0_95(Middle)             = ^IndirectMayWriteSideEffect            : &:r0_86, ~mu0_2
-#  816|     mu0_96(unknown)            = ^BufferMayWriteSideEffect              : &:r0_90, ~mu0_2
+#  816|     v0_93(void)                = ^IndirectReadSideEffect[-1]            : &:r0_86, ~mu0_2
+#  816|     v0_94(void)                = ^IndirectReadSideEffect[0]             : &:r0_90, ~mu0_2
+#  816|     mu0_95(Middle)             = ^IndirectMayWriteSideEffect[-1]        : &:r0_86, ~mu0_2
+#  816|     mu0_96(unknown)            = ^BufferMayWriteSideEffect[0]           : &:r0_90, ~mu0_2
 #  817|     r0_97(glval<Middle>)       = VariableAddress[m]                     : 
 #  817|     r0_98(glval<unknown>)      = FunctionAddress[operator=]             : 
 #  817|     r0_99(glval<Base>)         = VariableAddress[b]                     : 
@@ -3719,10 +3719,10 @@ ir.cpp:
 #  817|     r0_101(glval<Middle>)      = Convert                                : r0_100
 #  817|     r0_102(Middle &)           = Call                                   : func:r0_98, this:r0_97, 0:r0_101
 #  817|     mu0_103(unknown)           = ^CallSideEffect                        : ~mu0_2
-#  817|     v0_104(void)               = ^IndirectReadSideEffect                : &:r0_97, ~mu0_2
-#  817|     v0_105(void)               = ^IndirectReadSideEffect                : &:r0_101, ~mu0_2
-#  817|     mu0_106(Middle)            = ^IndirectMayWriteSideEffect            : &:r0_97, ~mu0_2
-#  817|     mu0_107(unknown)           = ^BufferMayWriteSideEffect              : &:r0_101, ~mu0_2
+#  817|     v0_104(void)               = ^IndirectReadSideEffect[-1]            : &:r0_97, ~mu0_2
+#  817|     v0_105(void)               = ^IndirectReadSideEffect[0]             : &:r0_101, ~mu0_2
+#  817|     mu0_106(Middle)            = ^IndirectMayWriteSideEffect[-1]        : &:r0_97, ~mu0_2
+#  817|     mu0_107(unknown)           = ^BufferMayWriteSideEffect[0]           : &:r0_101, ~mu0_2
 #  818|     r0_108(glval<Base *>)      = VariableAddress[pb]                    : 
 #  818|     r0_109(Base *)             = Load                                   : &:r0_108, ~mu0_2
 #  818|     r0_110(Middle *)           = ConvertToDerived[Middle : Base]        : r0_109
@@ -3745,10 +3745,10 @@ ir.cpp:
 #  822|     r0_127(glval<Base>)        = ConvertToBase[Middle : Base]           : r0_126
 #  822|     r0_128(Base &)             = Call                                   : func:r0_124, this:r0_123, 0:r0_127
 #  822|     mu0_129(unknown)           = ^CallSideEffect                        : ~mu0_2
-#  822|     v0_130(void)               = ^IndirectReadSideEffect                : &:r0_123, ~mu0_2
-#  822|     v0_131(void)               = ^IndirectReadSideEffect                : &:r0_127, ~mu0_2
-#  822|     mu0_132(Base)              = ^IndirectMayWriteSideEffect            : &:r0_123, ~mu0_2
-#  822|     mu0_133(unknown)           = ^BufferMayWriteSideEffect              : &:r0_127, ~mu0_2
+#  822|     v0_130(void)               = ^IndirectReadSideEffect[-1]            : &:r0_123, ~mu0_2
+#  822|     v0_131(void)               = ^IndirectReadSideEffect[0]             : &:r0_127, ~mu0_2
+#  822|     mu0_132(Base)              = ^IndirectMayWriteSideEffect[-1]        : &:r0_123, ~mu0_2
+#  822|     mu0_133(unknown)           = ^BufferMayWriteSideEffect[0]           : &:r0_127, ~mu0_2
 #  823|     r0_134(glval<Base>)        = VariableAddress[b]                     : 
 #  823|     r0_135(glval<unknown>)     = FunctionAddress[operator=]             : 
 #  823|     r0_136(glval<unknown>)     = FunctionAddress[Base]                  : 
@@ -3757,15 +3757,15 @@ ir.cpp:
 #  823|     r0_139(glval<Base>)        = ConvertToBase[Middle : Base]           : r0_138
 #  823|     v0_140(void)               = Call                                   : func:r0_136, 0:r0_139
 #  823|     mu0_141(unknown)           = ^CallSideEffect                        : ~mu0_2
-#  823|     v0_142(void)               = ^IndirectReadSideEffect                : &:r0_139, ~mu0_2
-#  823|     mu0_143(unknown)           = ^BufferMayWriteSideEffect              : &:r0_139, ~mu0_2
+#  823|     v0_142(void)               = ^IndirectReadSideEffect[0]             : &:r0_139, ~mu0_2
+#  823|     mu0_143(unknown)           = ^BufferMayWriteSideEffect[0]           : &:r0_139, ~mu0_2
 #  823|     r0_144(glval<Base>)        = Convert                                : v0_140
 #  823|     r0_145(Base &)             = Call                                   : func:r0_135, this:r0_134, 0:r0_144
 #  823|     mu0_146(unknown)           = ^CallSideEffect                        : ~mu0_2
-#  823|     v0_147(void)               = ^IndirectReadSideEffect                : &:r0_134, ~mu0_2
-#  823|     v0_148(void)               = ^IndirectReadSideEffect                : &:r0_144, ~mu0_2
-#  823|     mu0_149(Base)              = ^IndirectMayWriteSideEffect            : &:r0_134, ~mu0_2
-#  823|     mu0_150(unknown)           = ^BufferMayWriteSideEffect              : &:r0_144, ~mu0_2
+#  823|     v0_147(void)               = ^IndirectReadSideEffect[-1]            : &:r0_134, ~mu0_2
+#  823|     v0_148(void)               = ^IndirectReadSideEffect[0]             : &:r0_144, ~mu0_2
+#  823|     mu0_149(Base)              = ^IndirectMayWriteSideEffect[-1]        : &:r0_134, ~mu0_2
+#  823|     mu0_150(unknown)           = ^BufferMayWriteSideEffect[0]           : &:r0_144, ~mu0_2
 #  824|     r0_151(glval<Base>)        = VariableAddress[b]                     : 
 #  824|     r0_152(glval<unknown>)     = FunctionAddress[operator=]             : 
 #  824|     r0_153(glval<unknown>)     = FunctionAddress[Base]                  : 
@@ -3774,15 +3774,15 @@ ir.cpp:
 #  824|     r0_156(glval<Base>)        = ConvertToBase[Middle : Base]           : r0_155
 #  824|     v0_157(void)               = Call                                   : func:r0_153, 0:r0_156
 #  824|     mu0_158(unknown)           = ^CallSideEffect                        : ~mu0_2
-#  824|     v0_159(void)               = ^IndirectReadSideEffect                : &:r0_156, ~mu0_2
-#  824|     mu0_160(unknown)           = ^BufferMayWriteSideEffect              : &:r0_156, ~mu0_2
+#  824|     v0_159(void)               = ^IndirectReadSideEffect[0]             : &:r0_156, ~mu0_2
+#  824|     mu0_160(unknown)           = ^BufferMayWriteSideEffect[0]           : &:r0_156, ~mu0_2
 #  824|     r0_161(glval<Base>)        = Convert                                : v0_157
 #  824|     r0_162(Base &)             = Call                                   : func:r0_152, this:r0_151, 0:r0_161
 #  824|     mu0_163(unknown)           = ^CallSideEffect                        : ~mu0_2
-#  824|     v0_164(void)               = ^IndirectReadSideEffect                : &:r0_151, ~mu0_2
-#  824|     v0_165(void)               = ^IndirectReadSideEffect                : &:r0_161, ~mu0_2
-#  824|     mu0_166(Base)              = ^IndirectMayWriteSideEffect            : &:r0_151, ~mu0_2
-#  824|     mu0_167(unknown)           = ^BufferMayWriteSideEffect              : &:r0_161, ~mu0_2
+#  824|     v0_164(void)               = ^IndirectReadSideEffect[-1]            : &:r0_151, ~mu0_2
+#  824|     v0_165(void)               = ^IndirectReadSideEffect[0]             : &:r0_161, ~mu0_2
+#  824|     mu0_166(Base)              = ^IndirectMayWriteSideEffect[-1]        : &:r0_151, ~mu0_2
+#  824|     mu0_167(unknown)           = ^BufferMayWriteSideEffect[0]           : &:r0_161, ~mu0_2
 #  825|     r0_168(glval<Derived *>)   = VariableAddress[pd]                    : 
 #  825|     r0_169(Derived *)          = Load                                   : &:r0_168, ~mu0_2
 #  825|     r0_170(Middle *)           = ConvertToBase[Derived : Middle]        : r0_169
@@ -3814,10 +3814,10 @@ ir.cpp:
 #  830|     r0_196(glval<Derived>)     = Convert                                : r0_195
 #  830|     r0_197(Derived &)          = Call                                   : func:r0_192, this:r0_191, 0:r0_196
 #  830|     mu0_198(unknown)           = ^CallSideEffect                        : ~mu0_2
-#  830|     v0_199(void)               = ^IndirectReadSideEffect                : &:r0_191, ~mu0_2
-#  830|     v0_200(void)               = ^IndirectReadSideEffect                : &:r0_196, ~mu0_2
-#  830|     mu0_201(Derived)           = ^IndirectMayWriteSideEffect            : &:r0_191, ~mu0_2
-#  830|     mu0_202(unknown)           = ^BufferMayWriteSideEffect              : &:r0_196, ~mu0_2
+#  830|     v0_199(void)               = ^IndirectReadSideEffect[-1]            : &:r0_191, ~mu0_2
+#  830|     v0_200(void)               = ^IndirectReadSideEffect[0]             : &:r0_196, ~mu0_2
+#  830|     mu0_201(Derived)           = ^IndirectMayWriteSideEffect[-1]        : &:r0_191, ~mu0_2
+#  830|     mu0_202(unknown)           = ^BufferMayWriteSideEffect[0]           : &:r0_196, ~mu0_2
 #  831|     r0_203(glval<Derived>)     = VariableAddress[d]                     : 
 #  831|     r0_204(glval<unknown>)     = FunctionAddress[operator=]             : 
 #  831|     r0_205(glval<Base>)        = VariableAddress[b]                     : 
@@ -3826,10 +3826,10 @@ ir.cpp:
 #  831|     r0_208(glval<Derived>)     = Convert                                : r0_207
 #  831|     r0_209(Derived &)          = Call                                   : func:r0_204, this:r0_203, 0:r0_208
 #  831|     mu0_210(unknown)           = ^CallSideEffect                        : ~mu0_2
-#  831|     v0_211(void)               = ^IndirectReadSideEffect                : &:r0_203, ~mu0_2
-#  831|     v0_212(void)               = ^IndirectReadSideEffect                : &:r0_208, ~mu0_2
-#  831|     mu0_213(Derived)           = ^IndirectMayWriteSideEffect            : &:r0_203, ~mu0_2
-#  831|     mu0_214(unknown)           = ^BufferMayWriteSideEffect              : &:r0_208, ~mu0_2
+#  831|     v0_211(void)               = ^IndirectReadSideEffect[-1]            : &:r0_203, ~mu0_2
+#  831|     v0_212(void)               = ^IndirectReadSideEffect[0]             : &:r0_208, ~mu0_2
+#  831|     mu0_213(Derived)           = ^IndirectMayWriteSideEffect[-1]        : &:r0_203, ~mu0_2
+#  831|     mu0_214(unknown)           = ^BufferMayWriteSideEffect[0]           : &:r0_208, ~mu0_2
 #  832|     r0_215(glval<Base *>)      = VariableAddress[pb]                    : 
 #  832|     r0_216(Base *)             = Load                                   : &:r0_215, ~mu0_2
 #  832|     r0_217(Middle *)           = ConvertToDerived[Middle : Base]        : r0_216
@@ -3963,21 +3963,21 @@ ir.cpp:
 
 #  867| void String::String()
 #  867|   Block 0
-#  867|     v0_0(void)           = EnterFunction             : 
-#  867|     mu0_1(unknown)       = AliasedDefinition         : 
-#  867|     mu0_2(unknown)       = UnmodeledDefinition       : 
-#  867|     r0_3(glval<String>)  = InitializeThis            : 
-#  868|     r0_4(glval<unknown>) = FunctionAddress[String]   : 
-#  868|     r0_5(glval<char[1]>) = StringConstant[""]        : 
-#  868|     r0_6(char *)         = Convert                   : r0_5
-#  868|     v0_7(void)           = Call                      : func:r0_4, this:r0_3, 0:r0_6
-#  868|     mu0_8(unknown)       = ^CallSideEffect           : ~mu0_2
-#  868|     v0_9(void)           = ^IndirectReadSideEffect   : &:r0_6, ~mu0_2
-#  868|     mu0_10(unknown)      = ^BufferMayWriteSideEffect : &:r0_6, ~mu0_2
-#  869|     v0_11(void)          = NoOp                      : 
-#  867|     v0_12(void)          = ReturnVoid                : 
-#  867|     v0_13(void)          = UnmodeledUse              : mu*
-#  867|     v0_14(void)          = ExitFunction              : 
+#  867|     v0_0(void)           = EnterFunction                : 
+#  867|     mu0_1(unknown)       = AliasedDefinition            : 
+#  867|     mu0_2(unknown)       = UnmodeledDefinition          : 
+#  867|     r0_3(glval<String>)  = InitializeThis               : 
+#  868|     r0_4(glval<unknown>) = FunctionAddress[String]      : 
+#  868|     r0_5(glval<char[1]>) = StringConstant[""]           : 
+#  868|     r0_6(char *)         = Convert                      : r0_5
+#  868|     v0_7(void)           = Call                         : func:r0_4, this:r0_3, 0:r0_6
+#  868|     mu0_8(unknown)       = ^CallSideEffect              : ~mu0_2
+#  868|     v0_9(void)           = ^IndirectReadSideEffect[0]   : &:r0_6, ~mu0_2
+#  868|     mu0_10(unknown)      = ^BufferMayWriteSideEffect[0] : &:r0_6, ~mu0_2
+#  869|     v0_11(void)          = NoOp                         : 
+#  867|     v0_12(void)          = ReturnVoid                   : 
+#  867|     v0_13(void)          = UnmodeledUse                 : mu*
+#  867|     v0_14(void)          = ExitFunction                 : 
 
 #  871| void ArrayConversions()
 #  871|   Block 0
@@ -4189,8 +4189,8 @@ ir.cpp:
 #  945|     r0_37(char *)         = Convert                       : r0_36
 #  945|     v0_38(void)           = Call                          : func:r0_35, this:r0_34, 0:r0_37
 #  945|     mu0_39(unknown)       = ^CallSideEffect               : ~mu0_2
-#  945|     v0_40(void)           = ^IndirectReadSideEffect       : &:r0_37, ~mu0_2
-#  945|     mu0_41(unknown)       = ^BufferMayWriteSideEffect     : &:r0_37, ~mu0_2
+#  945|     v0_40(void)           = ^IndirectReadSideEffect[0]    : &:r0_37, ~mu0_2
+#  945|     mu0_41(unknown)       = ^BufferMayWriteSideEffect[0]  : &:r0_37, ~mu0_2
 #  946|     r0_42(glval<unknown>) = FunctionAddress[operator new] : 
 #  946|     r0_43(unsigned long)  = Constant[256]                 : 
 #  946|     r0_44(align_val_t)    = Constant[128]                 : 
@@ -4677,8 +4677,8 @@ ir.cpp:
 # 1035|     r0_28(float)                             = Constant[1.0]                          : 
 # 1035|     r0_29(char)                              = Call                                   : func:r0_27, this:r0_26, 0:r0_28
 # 1035|     mu0_30(unknown)                          = ^CallSideEffect                        : ~mu0_2
-# 1035|     v0_31(void)                              = ^IndirectReadSideEffect                : &:r0_26, ~mu0_2
-# 1035|     mu0_32(decltype([...](...){...}))        = ^IndirectMayWriteSideEffect            : &:r0_26, ~mu0_2
+# 1035|     v0_31(void)                              = ^IndirectReadSideEffect[-1]            : &:r0_26, ~mu0_2
+# 1035|     mu0_32(decltype([...](...){...}))        = ^IndirectMayWriteSideEffect[-1]        : &:r0_26, ~mu0_2
 # 1036|     r0_33(glval<decltype([...](...){...})>)  = VariableAddress[lambda_val]            : 
 # 1036|     r0_34(glval<unknown>)                    = FunctionAddress[(constructor)]         : 
 # 1036|     r0_35(glval<decltype([...](...){...})>)  = VariableAddress[#temp1036:21]          : 
@@ -4694,16 +4694,16 @@ ir.cpp:
 # 1036|     r0_45(decltype([...](...){...}))         = Load                                   : &:r0_35, ~mu0_2
 # 1036|     v0_46(void)                              = Call                                   : func:r0_34, this:r0_33, 0:r0_45
 # 1036|     mu0_47(unknown)                          = ^CallSideEffect                        : ~mu0_2
-# 1036|     v0_48(void)                              = ^IndirectReadSideEffect                : &:r0_45, ~mu0_2
-# 1036|     mu0_49(unknown)                          = ^BufferMayWriteSideEffect              : &:r0_45, ~mu0_2
+# 1036|     v0_48(void)                              = ^IndirectReadSideEffect[0]             : &:r0_45, ~mu0_2
+# 1036|     mu0_49(unknown)                          = ^BufferMayWriteSideEffect[0]           : &:r0_45, ~mu0_2
 # 1037|     r0_50(glval<decltype([...](...){...})>)  = VariableAddress[lambda_val]            : 
 # 1037|     r0_51(glval<decltype([...](...){...})>)  = Convert                                : r0_50
 # 1037|     r0_52(glval<unknown>)                    = FunctionAddress[operator()]            : 
 # 1037|     r0_53(float)                             = Constant[2.0]                          : 
 # 1037|     r0_54(char)                              = Call                                   : func:r0_52, this:r0_51, 0:r0_53
 # 1037|     mu0_55(unknown)                          = ^CallSideEffect                        : ~mu0_2
-# 1037|     v0_56(void)                              = ^IndirectReadSideEffect                : &:r0_51, ~mu0_2
-# 1037|     mu0_57(decltype([...](...){...}))        = ^IndirectMayWriteSideEffect            : &:r0_51, ~mu0_2
+# 1037|     v0_56(void)                              = ^IndirectReadSideEffect[-1]            : &:r0_51, ~mu0_2
+# 1037|     mu0_57(decltype([...](...){...}))        = ^IndirectMayWriteSideEffect[-1]        : &:r0_51, ~mu0_2
 # 1038|     r0_58(glval<decltype([...](...){...})>)  = VariableAddress[lambda_ref_explicit]   : 
 # 1038|     r0_59(glval<decltype([...](...){...})>)  = VariableAddress[#temp1038:30]          : 
 # 1038|     mu0_60(decltype([...](...){...}))        = Uninitialized[#temp1038:30]            : &:r0_59
@@ -4719,8 +4719,8 @@ ir.cpp:
 # 1039|     r0_70(float)                             = Constant[3.0]                          : 
 # 1039|     r0_71(char)                              = Call                                   : func:r0_69, this:r0_68, 0:r0_70
 # 1039|     mu0_72(unknown)                          = ^CallSideEffect                        : ~mu0_2
-# 1039|     v0_73(void)                              = ^IndirectReadSideEffect                : &:r0_68, ~mu0_2
-# 1039|     mu0_74(decltype([...](...){...}))        = ^IndirectMayWriteSideEffect            : &:r0_68, ~mu0_2
+# 1039|     v0_73(void)                              = ^IndirectReadSideEffect[-1]            : &:r0_68, ~mu0_2
+# 1039|     mu0_74(decltype([...](...){...}))        = ^IndirectMayWriteSideEffect[-1]        : &:r0_68, ~mu0_2
 # 1040|     r0_75(glval<decltype([...](...){...})>)  = VariableAddress[lambda_val_explicit]   : 
 # 1040|     r0_76(glval<unknown>)                    = FunctionAddress[(constructor)]         : 
 # 1040|     r0_77(glval<decltype([...](...){...})>)  = VariableAddress[#temp1040:30]          : 
@@ -4732,16 +4732,16 @@ ir.cpp:
 # 1040|     r0_83(decltype([...](...){...}))         = Load                                   : &:r0_77, ~mu0_2
 # 1040|     v0_84(void)                              = Call                                   : func:r0_76, this:r0_75, 0:r0_83
 # 1040|     mu0_85(unknown)                          = ^CallSideEffect                        : ~mu0_2
-# 1040|     v0_86(void)                              = ^IndirectReadSideEffect                : &:r0_83, ~mu0_2
-# 1040|     mu0_87(unknown)                          = ^BufferMayWriteSideEffect              : &:r0_83, ~mu0_2
+# 1040|     v0_86(void)                              = ^IndirectReadSideEffect[0]             : &:r0_83, ~mu0_2
+# 1040|     mu0_87(unknown)                          = ^BufferMayWriteSideEffect[0]           : &:r0_83, ~mu0_2
 # 1041|     r0_88(glval<decltype([...](...){...})>)  = VariableAddress[lambda_val_explicit]   : 
 # 1041|     r0_89(glval<decltype([...](...){...})>)  = Convert                                : r0_88
 # 1041|     r0_90(glval<unknown>)                    = FunctionAddress[operator()]            : 
 # 1041|     r0_91(float)                             = Constant[4.0]                          : 
 # 1041|     r0_92(char)                              = Call                                   : func:r0_90, this:r0_89, 0:r0_91
 # 1041|     mu0_93(unknown)                          = ^CallSideEffect                        : ~mu0_2
-# 1041|     v0_94(void)                              = ^IndirectReadSideEffect                : &:r0_89, ~mu0_2
-# 1041|     mu0_95(decltype([...](...){...}))        = ^IndirectMayWriteSideEffect            : &:r0_89, ~mu0_2
+# 1041|     v0_94(void)                              = ^IndirectReadSideEffect[-1]            : &:r0_89, ~mu0_2
+# 1041|     mu0_95(decltype([...](...){...}))        = ^IndirectMayWriteSideEffect[-1]        : &:r0_89, ~mu0_2
 # 1042|     r0_96(glval<decltype([...](...){...})>)  = VariableAddress[lambda_mixed_explicit] : 
 # 1042|     r0_97(glval<decltype([...](...){...})>)  = VariableAddress[#temp1042:32]          : 
 # 1042|     mu0_98(decltype([...](...){...}))        = Uninitialized[#temp1042:32]            : &:r0_97
@@ -4761,8 +4761,8 @@ ir.cpp:
 # 1043|     r0_112(float)                            = Constant[5.0]                          : 
 # 1043|     r0_113(char)                             = Call                                   : func:r0_111, this:r0_110, 0:r0_112
 # 1043|     mu0_114(unknown)                         = ^CallSideEffect                        : ~mu0_2
-# 1043|     v0_115(void)                             = ^IndirectReadSideEffect                : &:r0_110, ~mu0_2
-# 1043|     mu0_116(decltype([...](...){...}))       = ^IndirectMayWriteSideEffect            : &:r0_110, ~mu0_2
+# 1043|     v0_115(void)                             = ^IndirectReadSideEffect[-1]            : &:r0_110, ~mu0_2
+# 1043|     mu0_116(decltype([...](...){...}))       = ^IndirectMayWriteSideEffect[-1]        : &:r0_110, ~mu0_2
 # 1044|     r0_117(glval<int>)                       = VariableAddress[r]                     : 
 # 1044|     r0_118(glval<int>)                       = VariableAddress[x]                     : 
 # 1044|     r0_119(int)                              = Load                                   : &:r0_118, ~mu0_2
@@ -4797,8 +4797,8 @@ ir.cpp:
 # 1046|     r0_148(float)                            = Constant[6.0]                          : 
 # 1046|     r0_149(char)                             = Call                                   : func:r0_147, this:r0_146, 0:r0_148
 # 1046|     mu0_150(unknown)                         = ^CallSideEffect                        : ~mu0_2
-# 1046|     v0_151(void)                             = ^IndirectReadSideEffect                : &:r0_146, ~mu0_2
-# 1046|     mu0_152(decltype([...](...){...}))       = ^IndirectMayWriteSideEffect            : &:r0_146, ~mu0_2
+# 1046|     v0_151(void)                             = ^IndirectReadSideEffect[-1]            : &:r0_146, ~mu0_2
+# 1046|     mu0_152(decltype([...](...){...}))       = ^IndirectMayWriteSideEffect[-1]        : &:r0_146, ~mu0_2
 # 1047|     v0_153(void)                             = NoOp                                   : 
 # 1031|     v0_154(void)                             = ReturnVoid                             : 
 # 1031|     v0_155(void)                             = UnmodeledUse                           : mu*
@@ -4849,32 +4849,32 @@ ir.cpp:
 
 # 1034| char (void Lambda(int, String const&))::(lambda [] type at line 1034, col. 21)::operator()(float) const
 # 1034|   Block 0
-# 1034|     v0_0(void)                                    = EnterFunction               : 
-# 1034|     mu0_1(unknown)                                = AliasedDefinition           : 
-# 1034|     mu0_2(unknown)                                = UnmodeledDefinition         : 
-# 1034|     r0_3(glval<decltype([...](...){...})>)        = InitializeThis              : 
-# 1034|     r0_4(glval<float>)                            = VariableAddress[f]          : 
-# 1034|     mu0_5(float)                                  = InitializeParameter[f]      : &:r0_4
-# 1034|     r0_6(glval<char>)                             = VariableAddress[#return]    : 
-#-----|     r0_7(lambda [] type at line 1034, col. 21 *)  = CopyValue                   : r0_3
-#-----|     r0_8(glval<String &>)                         = FieldAddress[s]             : r0_7
-#-----|     r0_9(String &)                                = Load                        : &:r0_8, ~mu0_2
-# 1034|     r0_10(glval<unknown>)                         = FunctionAddress[c_str]      : 
-# 1034|     r0_11(char *)                                 = Call                        : func:r0_10, this:r0_9
-# 1034|     mu0_12(unknown)                               = ^CallSideEffect             : ~mu0_2
-# 1034|     v0_13(void)                                   = ^IndirectReadSideEffect     : &:r0_9, ~mu0_2
-# 1034|     mu0_14(String)                                = ^IndirectMayWriteSideEffect : &:r0_9, ~mu0_2
-#-----|     r0_15(lambda [] type at line 1034, col. 21 *) = CopyValue                   : r0_3
-#-----|     r0_16(glval<int &>)                           = FieldAddress[x]             : r0_15
-#-----|     r0_17(int &)                                  = Load                        : &:r0_16, ~mu0_2
-# 1034|     r0_18(int)                                    = Load                        : &:r0_17, ~mu0_2
-# 1034|     r0_19(glval<char>)                            = PointerAdd[1]               : r0_11, r0_18
-# 1034|     r0_20(char)                                   = Load                        : &:r0_19, ~mu0_2
-# 1034|     mu0_21(char)                                  = Store                       : &:r0_6, r0_20
-# 1034|     r0_22(glval<char>)                            = VariableAddress[#return]    : 
-# 1034|     v0_23(void)                                   = ReturnValue                 : &:r0_22, ~mu0_2
-# 1034|     v0_24(void)                                   = UnmodeledUse                : mu*
-# 1034|     v0_25(void)                                   = ExitFunction                : 
+# 1034|     v0_0(void)                                    = EnterFunction                   : 
+# 1034|     mu0_1(unknown)                                = AliasedDefinition               : 
+# 1034|     mu0_2(unknown)                                = UnmodeledDefinition             : 
+# 1034|     r0_3(glval<decltype([...](...){...})>)        = InitializeThis                  : 
+# 1034|     r0_4(glval<float>)                            = VariableAddress[f]              : 
+# 1034|     mu0_5(float)                                  = InitializeParameter[f]          : &:r0_4
+# 1034|     r0_6(glval<char>)                             = VariableAddress[#return]        : 
+#-----|     r0_7(lambda [] type at line 1034, col. 21 *)  = CopyValue                       : r0_3
+#-----|     r0_8(glval<String &>)                         = FieldAddress[s]                 : r0_7
+#-----|     r0_9(String &)                                = Load                            : &:r0_8, ~mu0_2
+# 1034|     r0_10(glval<unknown>)                         = FunctionAddress[c_str]          : 
+# 1034|     r0_11(char *)                                 = Call                            : func:r0_10, this:r0_9
+# 1034|     mu0_12(unknown)                               = ^CallSideEffect                 : ~mu0_2
+# 1034|     v0_13(void)                                   = ^IndirectReadSideEffect[-1]     : &:r0_9, ~mu0_2
+# 1034|     mu0_14(String)                                = ^IndirectMayWriteSideEffect[-1] : &:r0_9, ~mu0_2
+#-----|     r0_15(lambda [] type at line 1034, col. 21 *) = CopyValue                       : r0_3
+#-----|     r0_16(glval<int &>)                           = FieldAddress[x]                 : r0_15
+#-----|     r0_17(int &)                                  = Load                            : &:r0_16, ~mu0_2
+# 1034|     r0_18(int)                                    = Load                            : &:r0_17, ~mu0_2
+# 1034|     r0_19(glval<char>)                            = PointerAdd[1]                   : r0_11, r0_18
+# 1034|     r0_20(char)                                   = Load                            : &:r0_19, ~mu0_2
+# 1034|     mu0_21(char)                                  = Store                           : &:r0_6, r0_20
+# 1034|     r0_22(glval<char>)                            = VariableAddress[#return]        : 
+# 1034|     v0_23(void)                                   = ReturnValue                     : &:r0_22, ~mu0_2
+# 1034|     v0_24(void)                                   = UnmodeledUse                    : mu*
+# 1034|     v0_25(void)                                   = ExitFunction                    : 
 
 # 1036| void (void Lambda(int, String const&))::(lambda [] type at line 1036, col. 21)::~<unnamed>()
 # 1036|   Block 0
@@ -4893,56 +4893,56 @@ ir.cpp:
 
 # 1036| char (void Lambda(int, String const&))::(lambda [] type at line 1036, col. 21)::operator()(float) const
 # 1036|   Block 0
-# 1036|     v0_0(void)                                    = EnterFunction               : 
-# 1036|     mu0_1(unknown)                                = AliasedDefinition           : 
-# 1036|     mu0_2(unknown)                                = UnmodeledDefinition         : 
-# 1036|     r0_3(glval<decltype([...](...){...})>)        = InitializeThis              : 
-# 1036|     r0_4(glval<float>)                            = VariableAddress[f]          : 
-# 1036|     mu0_5(float)                                  = InitializeParameter[f]      : &:r0_4
-# 1036|     r0_6(glval<char>)                             = VariableAddress[#return]    : 
-#-----|     r0_7(lambda [] type at line 1036, col. 21 *)  = CopyValue                   : r0_3
-#-----|     r0_8(glval<String>)                           = FieldAddress[s]             : r0_7
-# 1036|     r0_9(glval<unknown>)                          = FunctionAddress[c_str]      : 
-# 1036|     r0_10(char *)                                 = Call                        : func:r0_9, this:r0_8
-# 1036|     mu0_11(unknown)                               = ^CallSideEffect             : ~mu0_2
-#-----|     v0_12(void)                                   = ^IndirectReadSideEffect     : &:r0_8, ~mu0_2
-#-----|     mu0_13(String)                                = ^IndirectMayWriteSideEffect : &:r0_8, ~mu0_2
-#-----|     r0_14(lambda [] type at line 1036, col. 21 *) = CopyValue                   : r0_3
-#-----|     r0_15(glval<int>)                             = FieldAddress[x]             : r0_14
-#-----|     r0_16(int)                                    = Load                        : &:r0_15, ~mu0_2
-# 1036|     r0_17(glval<char>)                            = PointerAdd[1]               : r0_10, r0_16
-# 1036|     r0_18(char)                                   = Load                        : &:r0_17, ~mu0_2
-# 1036|     mu0_19(char)                                  = Store                       : &:r0_6, r0_18
-# 1036|     r0_20(glval<char>)                            = VariableAddress[#return]    : 
-# 1036|     v0_21(void)                                   = ReturnValue                 : &:r0_20, ~mu0_2
-# 1036|     v0_22(void)                                   = UnmodeledUse                : mu*
-# 1036|     v0_23(void)                                   = ExitFunction                : 
+# 1036|     v0_0(void)                                    = EnterFunction                   : 
+# 1036|     mu0_1(unknown)                                = AliasedDefinition               : 
+# 1036|     mu0_2(unknown)                                = UnmodeledDefinition             : 
+# 1036|     r0_3(glval<decltype([...](...){...})>)        = InitializeThis                  : 
+# 1036|     r0_4(glval<float>)                            = VariableAddress[f]              : 
+# 1036|     mu0_5(float)                                  = InitializeParameter[f]          : &:r0_4
+# 1036|     r0_6(glval<char>)                             = VariableAddress[#return]        : 
+#-----|     r0_7(lambda [] type at line 1036, col. 21 *)  = CopyValue                       : r0_3
+#-----|     r0_8(glval<String>)                           = FieldAddress[s]                 : r0_7
+# 1036|     r0_9(glval<unknown>)                          = FunctionAddress[c_str]          : 
+# 1036|     r0_10(char *)                                 = Call                            : func:r0_9, this:r0_8
+# 1036|     mu0_11(unknown)                               = ^CallSideEffect                 : ~mu0_2
+#-----|     v0_12(void)                                   = ^IndirectReadSideEffect[-1]     : &:r0_8, ~mu0_2
+#-----|     mu0_13(String)                                = ^IndirectMayWriteSideEffect[-1] : &:r0_8, ~mu0_2
+#-----|     r0_14(lambda [] type at line 1036, col. 21 *) = CopyValue                       : r0_3
+#-----|     r0_15(glval<int>)                             = FieldAddress[x]                 : r0_14
+#-----|     r0_16(int)                                    = Load                            : &:r0_15, ~mu0_2
+# 1036|     r0_17(glval<char>)                            = PointerAdd[1]                   : r0_10, r0_16
+# 1036|     r0_18(char)                                   = Load                            : &:r0_17, ~mu0_2
+# 1036|     mu0_19(char)                                  = Store                           : &:r0_6, r0_18
+# 1036|     r0_20(glval<char>)                            = VariableAddress[#return]        : 
+# 1036|     v0_21(void)                                   = ReturnValue                     : &:r0_20, ~mu0_2
+# 1036|     v0_22(void)                                   = UnmodeledUse                    : mu*
+# 1036|     v0_23(void)                                   = ExitFunction                    : 
 
 # 1038| char (void Lambda(int, String const&))::(lambda [] type at line 1038, col. 30)::operator()(float) const
 # 1038|   Block 0
-# 1038|     v0_0(void)                                   = EnterFunction               : 
-# 1038|     mu0_1(unknown)                               = AliasedDefinition           : 
-# 1038|     mu0_2(unknown)                               = UnmodeledDefinition         : 
-# 1038|     r0_3(glval<decltype([...](...){...})>)       = InitializeThis              : 
-# 1038|     r0_4(glval<float>)                           = VariableAddress[f]          : 
-# 1038|     mu0_5(float)                                 = InitializeParameter[f]      : &:r0_4
-# 1038|     r0_6(glval<char>)                            = VariableAddress[#return]    : 
-#-----|     r0_7(lambda [] type at line 1038, col. 30 *) = CopyValue                   : r0_3
-#-----|     r0_8(glval<String &>)                        = FieldAddress[s]             : r0_7
-#-----|     r0_9(String &)                               = Load                        : &:r0_8, ~mu0_2
-# 1038|     r0_10(glval<unknown>)                        = FunctionAddress[c_str]      : 
-# 1038|     r0_11(char *)                                = Call                        : func:r0_10, this:r0_9
-# 1038|     mu0_12(unknown)                              = ^CallSideEffect             : ~mu0_2
-# 1038|     v0_13(void)                                  = ^IndirectReadSideEffect     : &:r0_9, ~mu0_2
-# 1038|     mu0_14(String)                               = ^IndirectMayWriteSideEffect : &:r0_9, ~mu0_2
-# 1038|     r0_15(int)                                   = Constant[0]                 : 
-# 1038|     r0_16(glval<char>)                           = PointerAdd[1]               : r0_11, r0_15
-# 1038|     r0_17(char)                                  = Load                        : &:r0_16, ~mu0_2
-# 1038|     mu0_18(char)                                 = Store                       : &:r0_6, r0_17
-# 1038|     r0_19(glval<char>)                           = VariableAddress[#return]    : 
-# 1038|     v0_20(void)                                  = ReturnValue                 : &:r0_19, ~mu0_2
-# 1038|     v0_21(void)                                  = UnmodeledUse                : mu*
-# 1038|     v0_22(void)                                  = ExitFunction                : 
+# 1038|     v0_0(void)                                   = EnterFunction                   : 
+# 1038|     mu0_1(unknown)                               = AliasedDefinition               : 
+# 1038|     mu0_2(unknown)                               = UnmodeledDefinition             : 
+# 1038|     r0_3(glval<decltype([...](...){...})>)       = InitializeThis                  : 
+# 1038|     r0_4(glval<float>)                           = VariableAddress[f]              : 
+# 1038|     mu0_5(float)                                 = InitializeParameter[f]          : &:r0_4
+# 1038|     r0_6(glval<char>)                            = VariableAddress[#return]        : 
+#-----|     r0_7(lambda [] type at line 1038, col. 30 *) = CopyValue                       : r0_3
+#-----|     r0_8(glval<String &>)                        = FieldAddress[s]                 : r0_7
+#-----|     r0_9(String &)                               = Load                            : &:r0_8, ~mu0_2
+# 1038|     r0_10(glval<unknown>)                        = FunctionAddress[c_str]          : 
+# 1038|     r0_11(char *)                                = Call                            : func:r0_10, this:r0_9
+# 1038|     mu0_12(unknown)                              = ^CallSideEffect                 : ~mu0_2
+# 1038|     v0_13(void)                                  = ^IndirectReadSideEffect[-1]     : &:r0_9, ~mu0_2
+# 1038|     mu0_14(String)                               = ^IndirectMayWriteSideEffect[-1] : &:r0_9, ~mu0_2
+# 1038|     r0_15(int)                                   = Constant[0]                     : 
+# 1038|     r0_16(glval<char>)                           = PointerAdd[1]                   : r0_11, r0_15
+# 1038|     r0_17(char)                                  = Load                            : &:r0_16, ~mu0_2
+# 1038|     mu0_18(char)                                 = Store                           : &:r0_6, r0_17
+# 1038|     r0_19(glval<char>)                           = VariableAddress[#return]        : 
+# 1038|     v0_20(void)                                  = ReturnValue                     : &:r0_19, ~mu0_2
+# 1038|     v0_21(void)                                  = UnmodeledUse                    : mu*
+# 1038|     v0_22(void)                                  = ExitFunction                    : 
 
 # 1040| void (void Lambda(int, String const&))::(lambda [] type at line 1040, col. 30)::(constructor)((void Lambda(int, String const&))::(lambda [] type at line 1040, col. 30)&&)
 # 1040|   Block 0
@@ -4978,142 +4978,142 @@ ir.cpp:
 
 # 1040| char (void Lambda(int, String const&))::(lambda [] type at line 1040, col. 30)::operator()(float) const
 # 1040|   Block 0
-# 1040|     v0_0(void)                                   = EnterFunction               : 
-# 1040|     mu0_1(unknown)                               = AliasedDefinition           : 
-# 1040|     mu0_2(unknown)                               = UnmodeledDefinition         : 
-# 1040|     r0_3(glval<decltype([...](...){...})>)       = InitializeThis              : 
-# 1040|     r0_4(glval<float>)                           = VariableAddress[f]          : 
-# 1040|     mu0_5(float)                                 = InitializeParameter[f]      : &:r0_4
-# 1040|     r0_6(glval<char>)                            = VariableAddress[#return]    : 
-#-----|     r0_7(lambda [] type at line 1040, col. 30 *) = CopyValue                   : r0_3
-#-----|     r0_8(glval<String>)                          = FieldAddress[s]             : r0_7
-# 1040|     r0_9(glval<unknown>)                         = FunctionAddress[c_str]      : 
-# 1040|     r0_10(char *)                                = Call                        : func:r0_9, this:r0_8
-# 1040|     mu0_11(unknown)                              = ^CallSideEffect             : ~mu0_2
-#-----|     v0_12(void)                                  = ^IndirectReadSideEffect     : &:r0_8, ~mu0_2
-#-----|     mu0_13(String)                               = ^IndirectMayWriteSideEffect : &:r0_8, ~mu0_2
-# 1040|     r0_14(int)                                   = Constant[0]                 : 
-# 1040|     r0_15(glval<char>)                           = PointerAdd[1]               : r0_10, r0_14
-# 1040|     r0_16(char)                                  = Load                        : &:r0_15, ~mu0_2
-# 1040|     mu0_17(char)                                 = Store                       : &:r0_6, r0_16
-# 1040|     r0_18(glval<char>)                           = VariableAddress[#return]    : 
-# 1040|     v0_19(void)                                  = ReturnValue                 : &:r0_18, ~mu0_2
-# 1040|     v0_20(void)                                  = UnmodeledUse                : mu*
-# 1040|     v0_21(void)                                  = ExitFunction                : 
+# 1040|     v0_0(void)                                   = EnterFunction                   : 
+# 1040|     mu0_1(unknown)                               = AliasedDefinition               : 
+# 1040|     mu0_2(unknown)                               = UnmodeledDefinition             : 
+# 1040|     r0_3(glval<decltype([...](...){...})>)       = InitializeThis                  : 
+# 1040|     r0_4(glval<float>)                           = VariableAddress[f]              : 
+# 1040|     mu0_5(float)                                 = InitializeParameter[f]          : &:r0_4
+# 1040|     r0_6(glval<char>)                            = VariableAddress[#return]        : 
+#-----|     r0_7(lambda [] type at line 1040, col. 30 *) = CopyValue                       : r0_3
+#-----|     r0_8(glval<String>)                          = FieldAddress[s]                 : r0_7
+# 1040|     r0_9(glval<unknown>)                         = FunctionAddress[c_str]          : 
+# 1040|     r0_10(char *)                                = Call                            : func:r0_9, this:r0_8
+# 1040|     mu0_11(unknown)                              = ^CallSideEffect                 : ~mu0_2
+#-----|     v0_12(void)                                  = ^IndirectReadSideEffect[-1]     : &:r0_8, ~mu0_2
+#-----|     mu0_13(String)                               = ^IndirectMayWriteSideEffect[-1] : &:r0_8, ~mu0_2
+# 1040|     r0_14(int)                                   = Constant[0]                     : 
+# 1040|     r0_15(glval<char>)                           = PointerAdd[1]                   : r0_10, r0_14
+# 1040|     r0_16(char)                                  = Load                            : &:r0_15, ~mu0_2
+# 1040|     mu0_17(char)                                 = Store                           : &:r0_6, r0_16
+# 1040|     r0_18(glval<char>)                           = VariableAddress[#return]        : 
+# 1040|     v0_19(void)                                  = ReturnValue                     : &:r0_18, ~mu0_2
+# 1040|     v0_20(void)                                  = UnmodeledUse                    : mu*
+# 1040|     v0_21(void)                                  = ExitFunction                    : 
 
 # 1042| char (void Lambda(int, String const&))::(lambda [] type at line 1042, col. 32)::operator()(float) const
 # 1042|   Block 0
-# 1042|     v0_0(void)                                    = EnterFunction               : 
-# 1042|     mu0_1(unknown)                                = AliasedDefinition           : 
-# 1042|     mu0_2(unknown)                                = UnmodeledDefinition         : 
-# 1042|     r0_3(glval<decltype([...](...){...})>)        = InitializeThis              : 
-# 1042|     r0_4(glval<float>)                            = VariableAddress[f]          : 
-# 1042|     mu0_5(float)                                  = InitializeParameter[f]      : &:r0_4
-# 1042|     r0_6(glval<char>)                             = VariableAddress[#return]    : 
-#-----|     r0_7(lambda [] type at line 1042, col. 32 *)  = CopyValue                   : r0_3
-#-----|     r0_8(glval<String &>)                         = FieldAddress[s]             : r0_7
-#-----|     r0_9(String &)                                = Load                        : &:r0_8, ~mu0_2
-# 1042|     r0_10(glval<unknown>)                         = FunctionAddress[c_str]      : 
-# 1042|     r0_11(char *)                                 = Call                        : func:r0_10, this:r0_9
-# 1042|     mu0_12(unknown)                               = ^CallSideEffect             : ~mu0_2
-# 1042|     v0_13(void)                                   = ^IndirectReadSideEffect     : &:r0_9, ~mu0_2
-# 1042|     mu0_14(String)                                = ^IndirectMayWriteSideEffect : &:r0_9, ~mu0_2
-#-----|     r0_15(lambda [] type at line 1042, col. 32 *) = CopyValue                   : r0_3
-#-----|     r0_16(glval<int>)                             = FieldAddress[x]             : r0_15
-#-----|     r0_17(int)                                    = Load                        : &:r0_16, ~mu0_2
-# 1042|     r0_18(glval<char>)                            = PointerAdd[1]               : r0_11, r0_17
-# 1042|     r0_19(char)                                   = Load                        : &:r0_18, ~mu0_2
-# 1042|     mu0_20(char)                                  = Store                       : &:r0_6, r0_19
-# 1042|     r0_21(glval<char>)                            = VariableAddress[#return]    : 
-# 1042|     v0_22(void)                                   = ReturnValue                 : &:r0_21, ~mu0_2
-# 1042|     v0_23(void)                                   = UnmodeledUse                : mu*
-# 1042|     v0_24(void)                                   = ExitFunction                : 
+# 1042|     v0_0(void)                                    = EnterFunction                   : 
+# 1042|     mu0_1(unknown)                                = AliasedDefinition               : 
+# 1042|     mu0_2(unknown)                                = UnmodeledDefinition             : 
+# 1042|     r0_3(glval<decltype([...](...){...})>)        = InitializeThis                  : 
+# 1042|     r0_4(glval<float>)                            = VariableAddress[f]              : 
+# 1042|     mu0_5(float)                                  = InitializeParameter[f]          : &:r0_4
+# 1042|     r0_6(glval<char>)                             = VariableAddress[#return]        : 
+#-----|     r0_7(lambda [] type at line 1042, col. 32 *)  = CopyValue                       : r0_3
+#-----|     r0_8(glval<String &>)                         = FieldAddress[s]                 : r0_7
+#-----|     r0_9(String &)                                = Load                            : &:r0_8, ~mu0_2
+# 1042|     r0_10(glval<unknown>)                         = FunctionAddress[c_str]          : 
+# 1042|     r0_11(char *)                                 = Call                            : func:r0_10, this:r0_9
+# 1042|     mu0_12(unknown)                               = ^CallSideEffect                 : ~mu0_2
+# 1042|     v0_13(void)                                   = ^IndirectReadSideEffect[-1]     : &:r0_9, ~mu0_2
+# 1042|     mu0_14(String)                                = ^IndirectMayWriteSideEffect[-1] : &:r0_9, ~mu0_2
+#-----|     r0_15(lambda [] type at line 1042, col. 32 *) = CopyValue                       : r0_3
+#-----|     r0_16(glval<int>)                             = FieldAddress[x]                 : r0_15
+#-----|     r0_17(int)                                    = Load                            : &:r0_16, ~mu0_2
+# 1042|     r0_18(glval<char>)                            = PointerAdd[1]                   : r0_11, r0_17
+# 1042|     r0_19(char)                                   = Load                            : &:r0_18, ~mu0_2
+# 1042|     mu0_20(char)                                  = Store                           : &:r0_6, r0_19
+# 1042|     r0_21(glval<char>)                            = VariableAddress[#return]        : 
+# 1042|     v0_22(void)                                   = ReturnValue                     : &:r0_21, ~mu0_2
+# 1042|     v0_23(void)                                   = UnmodeledUse                    : mu*
+# 1042|     v0_24(void)                                   = ExitFunction                    : 
 
 # 1045| char (void Lambda(int, String const&))::(lambda [] type at line 1045, col. 23)::operator()(float) const
 # 1045|   Block 0
-# 1045|     v0_0(void)                                    = EnterFunction               : 
-# 1045|     mu0_1(unknown)                                = AliasedDefinition           : 
-# 1045|     mu0_2(unknown)                                = UnmodeledDefinition         : 
-# 1045|     r0_3(glval<decltype([...](...){...})>)        = InitializeThis              : 
-# 1045|     r0_4(glval<float>)                            = VariableAddress[f]          : 
-# 1045|     mu0_5(float)                                  = InitializeParameter[f]      : &:r0_4
-# 1045|     r0_6(glval<char>)                             = VariableAddress[#return]    : 
-#-----|     r0_7(lambda [] type at line 1045, col. 23 *)  = CopyValue                   : r0_3
-#-----|     r0_8(glval<String &>)                         = FieldAddress[s]             : r0_7
-#-----|     r0_9(String &)                                = Load                        : &:r0_8, ~mu0_2
-# 1045|     r0_10(glval<unknown>)                         = FunctionAddress[c_str]      : 
-# 1045|     r0_11(char *)                                 = Call                        : func:r0_10, this:r0_9
-# 1045|     mu0_12(unknown)                               = ^CallSideEffect             : ~mu0_2
-# 1045|     v0_13(void)                                   = ^IndirectReadSideEffect     : &:r0_9, ~mu0_2
-# 1045|     mu0_14(String)                                = ^IndirectMayWriteSideEffect : &:r0_9, ~mu0_2
-#-----|     r0_15(lambda [] type at line 1045, col. 23 *) = CopyValue                   : r0_3
-#-----|     r0_16(glval<int>)                             = FieldAddress[x]             : r0_15
-#-----|     r0_17(int)                                    = Load                        : &:r0_16, ~mu0_2
-#-----|     r0_18(lambda [] type at line 1045, col. 23 *) = CopyValue                   : r0_3
-# 1045|     r0_19(glval<int>)                             = FieldAddress[i]             : r0_18
-# 1045|     r0_20(int)                                    = Load                        : &:r0_19, ~mu0_2
-# 1045|     r0_21(int)                                    = Add                         : r0_17, r0_20
-#-----|     r0_22(lambda [] type at line 1045, col. 23 *) = CopyValue                   : r0_3
-# 1045|     r0_23(glval<int &>)                           = FieldAddress[j]             : r0_22
-# 1045|     r0_24(int &)                                  = Load                        : &:r0_23, ~mu0_2
-# 1045|     r0_25(int)                                    = Load                        : &:r0_24, ~mu0_2
-# 1045|     r0_26(int)                                    = Sub                         : r0_21, r0_25
-# 1045|     r0_27(glval<char>)                            = PointerAdd[1]               : r0_11, r0_26
-# 1045|     r0_28(char)                                   = Load                        : &:r0_27, ~mu0_2
-# 1045|     mu0_29(char)                                  = Store                       : &:r0_6, r0_28
-# 1045|     r0_30(glval<char>)                            = VariableAddress[#return]    : 
-# 1045|     v0_31(void)                                   = ReturnValue                 : &:r0_30, ~mu0_2
-# 1045|     v0_32(void)                                   = UnmodeledUse                : mu*
-# 1045|     v0_33(void)                                   = ExitFunction                : 
+# 1045|     v0_0(void)                                    = EnterFunction                   : 
+# 1045|     mu0_1(unknown)                                = AliasedDefinition               : 
+# 1045|     mu0_2(unknown)                                = UnmodeledDefinition             : 
+# 1045|     r0_3(glval<decltype([...](...){...})>)        = InitializeThis                  : 
+# 1045|     r0_4(glval<float>)                            = VariableAddress[f]              : 
+# 1045|     mu0_5(float)                                  = InitializeParameter[f]          : &:r0_4
+# 1045|     r0_6(glval<char>)                             = VariableAddress[#return]        : 
+#-----|     r0_7(lambda [] type at line 1045, col. 23 *)  = CopyValue                       : r0_3
+#-----|     r0_8(glval<String &>)                         = FieldAddress[s]                 : r0_7
+#-----|     r0_9(String &)                                = Load                            : &:r0_8, ~mu0_2
+# 1045|     r0_10(glval<unknown>)                         = FunctionAddress[c_str]          : 
+# 1045|     r0_11(char *)                                 = Call                            : func:r0_10, this:r0_9
+# 1045|     mu0_12(unknown)                               = ^CallSideEffect                 : ~mu0_2
+# 1045|     v0_13(void)                                   = ^IndirectReadSideEffect[-1]     : &:r0_9, ~mu0_2
+# 1045|     mu0_14(String)                                = ^IndirectMayWriteSideEffect[-1] : &:r0_9, ~mu0_2
+#-----|     r0_15(lambda [] type at line 1045, col. 23 *) = CopyValue                       : r0_3
+#-----|     r0_16(glval<int>)                             = FieldAddress[x]                 : r0_15
+#-----|     r0_17(int)                                    = Load                            : &:r0_16, ~mu0_2
+#-----|     r0_18(lambda [] type at line 1045, col. 23 *) = CopyValue                       : r0_3
+# 1045|     r0_19(glval<int>)                             = FieldAddress[i]                 : r0_18
+# 1045|     r0_20(int)                                    = Load                            : &:r0_19, ~mu0_2
+# 1045|     r0_21(int)                                    = Add                             : r0_17, r0_20
+#-----|     r0_22(lambda [] type at line 1045, col. 23 *) = CopyValue                       : r0_3
+# 1045|     r0_23(glval<int &>)                           = FieldAddress[j]                 : r0_22
+# 1045|     r0_24(int &)                                  = Load                            : &:r0_23, ~mu0_2
+# 1045|     r0_25(int)                                    = Load                            : &:r0_24, ~mu0_2
+# 1045|     r0_26(int)                                    = Sub                             : r0_21, r0_25
+# 1045|     r0_27(glval<char>)                            = PointerAdd[1]                   : r0_11, r0_26
+# 1045|     r0_28(char)                                   = Load                            : &:r0_27, ~mu0_2
+# 1045|     mu0_29(char)                                  = Store                           : &:r0_6, r0_28
+# 1045|     r0_30(glval<char>)                            = VariableAddress[#return]        : 
+# 1045|     v0_31(void)                                   = ReturnValue                     : &:r0_30, ~mu0_2
+# 1045|     v0_32(void)                                   = UnmodeledUse                    : mu*
+# 1045|     v0_33(void)                                   = ExitFunction                    : 
 
 # 1068| void RangeBasedFor(vector<int> const&)
 # 1068|   Block 0
-# 1068|     v0_0(void)                  = EnterFunction               : 
-# 1068|     mu0_1(unknown)              = AliasedDefinition           : 
-# 1068|     mu0_2(unknown)              = UnmodeledDefinition         : 
-# 1068|     r0_3(glval<vector<int> &>)  = VariableAddress[v]          : 
-# 1068|     mu0_4(vector<int> &)        = InitializeParameter[v]      : &:r0_3
-# 1069|     r0_5(glval<vector<int> &>)  = VariableAddress[(__range)]  : 
-# 1069|     r0_6(glval<vector<int> &>)  = VariableAddress[v]          : 
-# 1069|     r0_7(vector<int> &)         = Load                        : &:r0_6, ~mu0_2
-# 1069|     mu0_8(vector<int> &)        = Store                       : &:r0_5, r0_7
-# 1069|     r0_9(glval<iterator>)       = VariableAddress[(__begin)]  : 
-#-----|     r0_10(glval<vector<int> &>) = VariableAddress[(__range)]  : 
-#-----|     r0_11(vector<int> &)        = Load                        : &:r0_10, ~mu0_2
-# 1069|     r0_12(glval<unknown>)       = FunctionAddress[begin]      : 
-# 1069|     r0_13(iterator)             = Call                        : func:r0_12, this:r0_11
-# 1069|     mu0_14(unknown)             = ^CallSideEffect             : ~mu0_2
-#-----|     v0_15(void)                 = ^IndirectReadSideEffect     : &:r0_11, ~mu0_2
-#-----|     mu0_16(vector<int>)         = ^IndirectMayWriteSideEffect : &:r0_11, ~mu0_2
-# 1069|     mu0_17(iterator)            = Store                       : &:r0_9, r0_13
-# 1069|     r0_18(glval<iterator>)      = VariableAddress[(__end)]    : 
-#-----|     r0_19(glval<vector<int> &>) = VariableAddress[(__range)]  : 
-#-----|     r0_20(vector<int> &)        = Load                        : &:r0_19, ~mu0_2
-# 1069|     r0_21(glval<unknown>)       = FunctionAddress[end]        : 
-# 1069|     r0_22(iterator)             = Call                        : func:r0_21, this:r0_20
-# 1069|     mu0_23(unknown)             = ^CallSideEffect             : ~mu0_2
-#-----|     v0_24(void)                 = ^IndirectReadSideEffect     : &:r0_20, ~mu0_2
-#-----|     mu0_25(vector<int>)         = ^IndirectMayWriteSideEffect : &:r0_20, ~mu0_2
-# 1069|     mu0_26(iterator)            = Store                       : &:r0_18, r0_22
+# 1068|     v0_0(void)                  = EnterFunction                   : 
+# 1068|     mu0_1(unknown)              = AliasedDefinition               : 
+# 1068|     mu0_2(unknown)              = UnmodeledDefinition             : 
+# 1068|     r0_3(glval<vector<int> &>)  = VariableAddress[v]              : 
+# 1068|     mu0_4(vector<int> &)        = InitializeParameter[v]          : &:r0_3
+# 1069|     r0_5(glval<vector<int> &>)  = VariableAddress[(__range)]      : 
+# 1069|     r0_6(glval<vector<int> &>)  = VariableAddress[v]              : 
+# 1069|     r0_7(vector<int> &)         = Load                            : &:r0_6, ~mu0_2
+# 1069|     mu0_8(vector<int> &)        = Store                           : &:r0_5, r0_7
+# 1069|     r0_9(glval<iterator>)       = VariableAddress[(__begin)]      : 
+#-----|     r0_10(glval<vector<int> &>) = VariableAddress[(__range)]      : 
+#-----|     r0_11(vector<int> &)        = Load                            : &:r0_10, ~mu0_2
+# 1069|     r0_12(glval<unknown>)       = FunctionAddress[begin]          : 
+# 1069|     r0_13(iterator)             = Call                            : func:r0_12, this:r0_11
+# 1069|     mu0_14(unknown)             = ^CallSideEffect                 : ~mu0_2
+#-----|     v0_15(void)                 = ^IndirectReadSideEffect[-1]     : &:r0_11, ~mu0_2
+#-----|     mu0_16(vector<int>)         = ^IndirectMayWriteSideEffect[-1] : &:r0_11, ~mu0_2
+# 1069|     mu0_17(iterator)            = Store                           : &:r0_9, r0_13
+# 1069|     r0_18(glval<iterator>)      = VariableAddress[(__end)]        : 
+#-----|     r0_19(glval<vector<int> &>) = VariableAddress[(__range)]      : 
+#-----|     r0_20(vector<int> &)        = Load                            : &:r0_19, ~mu0_2
+# 1069|     r0_21(glval<unknown>)       = FunctionAddress[end]            : 
+# 1069|     r0_22(iterator)             = Call                            : func:r0_21, this:r0_20
+# 1069|     mu0_23(unknown)             = ^CallSideEffect                 : ~mu0_2
+#-----|     v0_24(void)                 = ^IndirectReadSideEffect[-1]     : &:r0_20, ~mu0_2
+#-----|     mu0_25(vector<int>)         = ^IndirectMayWriteSideEffect[-1] : &:r0_20, ~mu0_2
+# 1069|     mu0_26(iterator)            = Store                           : &:r0_18, r0_22
 #-----|   Goto -> Block 4
 
 # 1075|   Block 1
-# 1075|     r1_0(glval<int &>)    = VariableAddress[e]          : 
-#-----|     r1_1(glval<iterator>) = VariableAddress[(__begin)]  : 
-#-----|     r1_2(glval<iterator>) = Convert                     : r1_1
-# 1075|     r1_3(glval<unknown>)  = FunctionAddress[operator*]  : 
-# 1075|     r1_4(int &)           = Call                        : func:r1_3, this:r1_2
-# 1075|     mu1_5(unknown)        = ^CallSideEffect             : ~mu0_2
-#-----|     v1_6(void)            = ^IndirectReadSideEffect     : &:r1_2, ~mu0_2
-#-----|     mu1_7(iterator)       = ^IndirectMayWriteSideEffect : &:r1_2, ~mu0_2
-# 1075|     r1_8(glval<int>)      = Convert                     : r1_4
-# 1075|     mu1_9(int &)          = Store                       : &:r1_0, r1_8
-# 1076|     r1_10(glval<int &>)   = VariableAddress[e]          : 
-# 1076|     r1_11(int &)          = Load                        : &:r1_10, ~mu0_2
-# 1076|     r1_12(int)            = Load                        : &:r1_11, ~mu0_2
-# 1076|     r1_13(int)            = Constant[5]                 : 
-# 1076|     r1_14(bool)           = CompareLT                   : r1_12, r1_13
-# 1076|     v1_15(void)           = ConditionalBranch           : r1_14
+# 1075|     r1_0(glval<int &>)    = VariableAddress[e]              : 
+#-----|     r1_1(glval<iterator>) = VariableAddress[(__begin)]      : 
+#-----|     r1_2(glval<iterator>) = Convert                         : r1_1
+# 1075|     r1_3(glval<unknown>)  = FunctionAddress[operator*]      : 
+# 1075|     r1_4(int &)           = Call                            : func:r1_3, this:r1_2
+# 1075|     mu1_5(unknown)        = ^CallSideEffect                 : ~mu0_2
+#-----|     v1_6(void)            = ^IndirectReadSideEffect[-1]     : &:r1_2, ~mu0_2
+#-----|     mu1_7(iterator)       = ^IndirectMayWriteSideEffect[-1] : &:r1_2, ~mu0_2
+# 1075|     r1_8(glval<int>)      = Convert                         : r1_4
+# 1075|     mu1_9(int &)          = Store                           : &:r1_0, r1_8
+# 1076|     r1_10(glval<int &>)   = VariableAddress[e]              : 
+# 1076|     r1_11(int &)          = Load                            : &:r1_10, ~mu0_2
+# 1076|     r1_12(int)            = Load                            : &:r1_11, ~mu0_2
+# 1076|     r1_13(int)            = Constant[5]                     : 
+# 1076|     r1_14(bool)           = CompareLT                       : r1_12, r1_13
+# 1076|     v1_15(void)           = ConditionalBranch               : r1_14
 #-----|   False -> Block 10
 #-----|   True -> Block 2
 
@@ -5129,35 +5129,35 @@ ir.cpp:
 # 1068|     v3_4(void) = ExitFunction : 
 
 #-----|   Block 4
-#-----|     r4_0(glval<iterator>) = VariableAddress[(__begin)]  : 
-#-----|     r4_1(glval<iterator>) = Convert                     : r4_0
-# 1069|     r4_2(glval<unknown>)  = FunctionAddress[operator!=] : 
-#-----|     r4_3(glval<iterator>) = VariableAddress[(__end)]    : 
-#-----|     r4_4(iterator)        = Load                        : &:r4_3, ~mu0_2
-# 1069|     r4_5(bool)            = Call                        : func:r4_2, this:r4_1, 0:r4_4
-# 1069|     mu4_6(unknown)        = ^CallSideEffect             : ~mu0_2
-#-----|     v4_7(void)            = ^IndirectReadSideEffect     : &:r4_1, ~mu0_2
-#-----|     mu4_8(iterator)       = ^IndirectMayWriteSideEffect : &:r4_1, ~mu0_2
-# 1069|     v4_9(void)            = ConditionalBranch           : r4_5
+#-----|     r4_0(glval<iterator>) = VariableAddress[(__begin)]      : 
+#-----|     r4_1(glval<iterator>) = Convert                         : r4_0
+# 1069|     r4_2(glval<unknown>)  = FunctionAddress[operator!=]     : 
+#-----|     r4_3(glval<iterator>) = VariableAddress[(__end)]        : 
+#-----|     r4_4(iterator)        = Load                            : &:r4_3, ~mu0_2
+# 1069|     r4_5(bool)            = Call                            : func:r4_2, this:r4_1, 0:r4_4
+# 1069|     mu4_6(unknown)        = ^CallSideEffect                 : ~mu0_2
+#-----|     v4_7(void)            = ^IndirectReadSideEffect[-1]     : &:r4_1, ~mu0_2
+#-----|     mu4_8(iterator)       = ^IndirectMayWriteSideEffect[-1] : &:r4_1, ~mu0_2
+# 1069|     v4_9(void)            = ConditionalBranch               : r4_5
 #-----|   False -> Block 8
 #-----|   True -> Block 5
 
 # 1069|   Block 5
-# 1069|     r5_0(glval<int>)      = VariableAddress[e]          : 
-#-----|     r5_1(glval<iterator>) = VariableAddress[(__begin)]  : 
-#-----|     r5_2(glval<iterator>) = Convert                     : r5_1
-# 1069|     r5_3(glval<unknown>)  = FunctionAddress[operator*]  : 
-# 1069|     r5_4(int &)           = Call                        : func:r5_3, this:r5_2
-# 1069|     mu5_5(unknown)        = ^CallSideEffect             : ~mu0_2
-#-----|     v5_6(void)            = ^IndirectReadSideEffect     : &:r5_2, ~mu0_2
-#-----|     mu5_7(iterator)       = ^IndirectMayWriteSideEffect : &:r5_2, ~mu0_2
-# 1069|     r5_8(int)             = Load                        : &:r5_4, ~mu0_2
-# 1069|     mu5_9(int)            = Store                       : &:r5_0, r5_8
-# 1070|     r5_10(glval<int>)     = VariableAddress[e]          : 
-# 1070|     r5_11(int)            = Load                        : &:r5_10, ~mu0_2
-# 1070|     r5_12(int)            = Constant[0]                 : 
-# 1070|     r5_13(bool)           = CompareGT                   : r5_11, r5_12
-# 1070|     v5_14(void)           = ConditionalBranch           : r5_13
+# 1069|     r5_0(glval<int>)      = VariableAddress[e]              : 
+#-----|     r5_1(glval<iterator>) = VariableAddress[(__begin)]      : 
+#-----|     r5_2(glval<iterator>) = Convert                         : r5_1
+# 1069|     r5_3(glval<unknown>)  = FunctionAddress[operator*]      : 
+# 1069|     r5_4(int &)           = Call                            : func:r5_3, this:r5_2
+# 1069|     mu5_5(unknown)        = ^CallSideEffect                 : ~mu0_2
+#-----|     v5_6(void)            = ^IndirectReadSideEffect[-1]     : &:r5_2, ~mu0_2
+#-----|     mu5_7(iterator)       = ^IndirectMayWriteSideEffect[-1] : &:r5_2, ~mu0_2
+# 1069|     r5_8(int)             = Load                            : &:r5_4, ~mu0_2
+# 1069|     mu5_9(int)            = Store                           : &:r5_0, r5_8
+# 1070|     r5_10(glval<int>)     = VariableAddress[e]              : 
+# 1070|     r5_11(int)            = Load                            : &:r5_10, ~mu0_2
+# 1070|     r5_12(int)            = Constant[0]                     : 
+# 1070|     r5_13(bool)           = CompareGT                       : r5_11, r5_12
+# 1070|     v5_14(void)           = ConditionalBranch               : r5_13
 #-----|   False -> Block 7
 #-----|   True -> Block 6
 
@@ -5166,61 +5166,61 @@ ir.cpp:
 #-----|   Goto -> Block 7
 
 # 1069|   Block 7
-# 1069|     v7_0(void)            = NoOp                        : 
-#-----|     r7_1(glval<iterator>) = VariableAddress[(__begin)]  : 
-# 1069|     r7_2(glval<unknown>)  = FunctionAddress[operator++] : 
-# 1069|     r7_3(iterator &)      = Call                        : func:r7_2, this:r7_1
-# 1069|     mu7_4(unknown)        = ^CallSideEffect             : ~mu0_2
-#-----|     v7_5(void)            = ^IndirectReadSideEffect     : &:r7_1, ~mu0_2
-#-----|     mu7_6(iterator)       = ^IndirectMayWriteSideEffect : &:r7_1, ~mu0_2
+# 1069|     v7_0(void)            = NoOp                            : 
+#-----|     r7_1(glval<iterator>) = VariableAddress[(__begin)]      : 
+# 1069|     r7_2(glval<unknown>)  = FunctionAddress[operator++]     : 
+# 1069|     r7_3(iterator &)      = Call                            : func:r7_2, this:r7_1
+# 1069|     mu7_4(unknown)        = ^CallSideEffect                 : ~mu0_2
+#-----|     v7_5(void)            = ^IndirectReadSideEffect[-1]     : &:r7_1, ~mu0_2
+#-----|     mu7_6(iterator)       = ^IndirectMayWriteSideEffect[-1] : &:r7_1, ~mu0_2
 #-----|   Goto (back edge) -> Block 4
 
 # 1075|   Block 8
-# 1075|     r8_0(glval<vector<int> &>)  = VariableAddress[(__range)]  : 
-# 1075|     r8_1(glval<vector<int> &>)  = VariableAddress[v]          : 
-# 1075|     r8_2(vector<int> &)         = Load                        : &:r8_1, ~mu0_2
-# 1075|     mu8_3(vector<int> &)        = Store                       : &:r8_0, r8_2
-# 1075|     r8_4(glval<iterator>)       = VariableAddress[(__begin)]  : 
-#-----|     r8_5(glval<vector<int> &>)  = VariableAddress[(__range)]  : 
-#-----|     r8_6(vector<int> &)         = Load                        : &:r8_5, ~mu0_2
-# 1075|     r8_7(glval<unknown>)        = FunctionAddress[begin]      : 
-# 1075|     r8_8(iterator)              = Call                        : func:r8_7, this:r8_6
-# 1075|     mu8_9(unknown)              = ^CallSideEffect             : ~mu0_2
-#-----|     v8_10(void)                 = ^IndirectReadSideEffect     : &:r8_6, ~mu0_2
-#-----|     mu8_11(vector<int>)         = ^IndirectMayWriteSideEffect : &:r8_6, ~mu0_2
-# 1075|     mu8_12(iterator)            = Store                       : &:r8_4, r8_8
-# 1075|     r8_13(glval<iterator>)      = VariableAddress[(__end)]    : 
-#-----|     r8_14(glval<vector<int> &>) = VariableAddress[(__range)]  : 
-#-----|     r8_15(vector<int> &)        = Load                        : &:r8_14, ~mu0_2
-# 1075|     r8_16(glval<unknown>)       = FunctionAddress[end]        : 
-# 1075|     r8_17(iterator)             = Call                        : func:r8_16, this:r8_15
-# 1075|     mu8_18(unknown)             = ^CallSideEffect             : ~mu0_2
-#-----|     v8_19(void)                 = ^IndirectReadSideEffect     : &:r8_15, ~mu0_2
-#-----|     mu8_20(vector<int>)         = ^IndirectMayWriteSideEffect : &:r8_15, ~mu0_2
-# 1075|     mu8_21(iterator)            = Store                       : &:r8_13, r8_17
+# 1075|     r8_0(glval<vector<int> &>)  = VariableAddress[(__range)]      : 
+# 1075|     r8_1(glval<vector<int> &>)  = VariableAddress[v]              : 
+# 1075|     r8_2(vector<int> &)         = Load                            : &:r8_1, ~mu0_2
+# 1075|     mu8_3(vector<int> &)        = Store                           : &:r8_0, r8_2
+# 1075|     r8_4(glval<iterator>)       = VariableAddress[(__begin)]      : 
+#-----|     r8_5(glval<vector<int> &>)  = VariableAddress[(__range)]      : 
+#-----|     r8_6(vector<int> &)         = Load                            : &:r8_5, ~mu0_2
+# 1075|     r8_7(glval<unknown>)        = FunctionAddress[begin]          : 
+# 1075|     r8_8(iterator)              = Call                            : func:r8_7, this:r8_6
+# 1075|     mu8_9(unknown)              = ^CallSideEffect                 : ~mu0_2
+#-----|     v8_10(void)                 = ^IndirectReadSideEffect[-1]     : &:r8_6, ~mu0_2
+#-----|     mu8_11(vector<int>)         = ^IndirectMayWriteSideEffect[-1] : &:r8_6, ~mu0_2
+# 1075|     mu8_12(iterator)            = Store                           : &:r8_4, r8_8
+# 1075|     r8_13(glval<iterator>)      = VariableAddress[(__end)]        : 
+#-----|     r8_14(glval<vector<int> &>) = VariableAddress[(__range)]      : 
+#-----|     r8_15(vector<int> &)        = Load                            : &:r8_14, ~mu0_2
+# 1075|     r8_16(glval<unknown>)       = FunctionAddress[end]            : 
+# 1075|     r8_17(iterator)             = Call                            : func:r8_16, this:r8_15
+# 1075|     mu8_18(unknown)             = ^CallSideEffect                 : ~mu0_2
+#-----|     v8_19(void)                 = ^IndirectReadSideEffect[-1]     : &:r8_15, ~mu0_2
+#-----|     mu8_20(vector<int>)         = ^IndirectMayWriteSideEffect[-1] : &:r8_15, ~mu0_2
+# 1075|     mu8_21(iterator)            = Store                           : &:r8_13, r8_17
 #-----|   Goto -> Block 9
 
 #-----|   Block 9
-#-----|     r9_0(glval<iterator>) = VariableAddress[(__begin)]  : 
-#-----|     r9_1(glval<iterator>) = Convert                     : r9_0
-# 1075|     r9_2(glval<unknown>)  = FunctionAddress[operator!=] : 
-#-----|     r9_3(glval<iterator>) = VariableAddress[(__end)]    : 
-#-----|     r9_4(iterator)        = Load                        : &:r9_3, ~mu0_2
-# 1075|     r9_5(bool)            = Call                        : func:r9_2, this:r9_1, 0:r9_4
-# 1075|     mu9_6(unknown)        = ^CallSideEffect             : ~mu0_2
-#-----|     v9_7(void)            = ^IndirectReadSideEffect     : &:r9_1, ~mu0_2
-#-----|     mu9_8(iterator)       = ^IndirectMayWriteSideEffect : &:r9_1, ~mu0_2
-# 1075|     v9_9(void)            = ConditionalBranch           : r9_5
+#-----|     r9_0(glval<iterator>) = VariableAddress[(__begin)]      : 
+#-----|     r9_1(glval<iterator>) = Convert                         : r9_0
+# 1075|     r9_2(glval<unknown>)  = FunctionAddress[operator!=]     : 
+#-----|     r9_3(glval<iterator>) = VariableAddress[(__end)]        : 
+#-----|     r9_4(iterator)        = Load                            : &:r9_3, ~mu0_2
+# 1075|     r9_5(bool)            = Call                            : func:r9_2, this:r9_1, 0:r9_4
+# 1075|     mu9_6(unknown)        = ^CallSideEffect                 : ~mu0_2
+#-----|     v9_7(void)            = ^IndirectReadSideEffect[-1]     : &:r9_1, ~mu0_2
+#-----|     mu9_8(iterator)       = ^IndirectMayWriteSideEffect[-1] : &:r9_1, ~mu0_2
+# 1075|     v9_9(void)            = ConditionalBranch               : r9_5
 #-----|   False -> Block 3
 #-----|   True -> Block 1
 
 #-----|   Block 10
-#-----|     r10_0(glval<iterator>) = VariableAddress[(__begin)]  : 
-# 1075|     r10_1(glval<unknown>)  = FunctionAddress[operator++] : 
-# 1075|     r10_2(iterator &)      = Call                        : func:r10_1, this:r10_0
-# 1075|     mu10_3(unknown)        = ^CallSideEffect             : ~mu0_2
-#-----|     v10_4(void)            = ^IndirectReadSideEffect     : &:r10_0, ~mu0_2
-#-----|     mu10_5(iterator)       = ^IndirectMayWriteSideEffect : &:r10_0, ~mu0_2
+#-----|     r10_0(glval<iterator>) = VariableAddress[(__begin)]      : 
+# 1075|     r10_1(glval<unknown>)  = FunctionAddress[operator++]     : 
+# 1075|     r10_2(iterator &)      = Call                            : func:r10_1, this:r10_0
+# 1075|     mu10_3(unknown)        = ^CallSideEffect                 : ~mu0_2
+#-----|     v10_4(void)            = ^IndirectReadSideEffect[-1]     : &:r10_0, ~mu0_2
+#-----|     mu10_5(iterator)       = ^IndirectMayWriteSideEffect[-1] : &:r10_0, ~mu0_2
 #-----|   Goto (back edge) -> Block 9
 
 # 1099| int AsmStmt(int)
@@ -5378,8 +5378,8 @@ ir.cpp:
 # 1140|     r7_3(char *)          = Convert                         : r7_2
 # 1140|     v7_4(void)            = Call                            : func:r7_1, this:r7_0, 0:r7_3
 # 1140|     mu7_5(unknown)        = ^CallSideEffect                 : ~mu0_2
-# 1140|     v7_6(void)            = ^IndirectReadSideEffect         : &:r7_3, ~mu0_2
-# 1140|     mu7_7(unknown)        = ^BufferMayWriteSideEffect       : &:r7_3, ~mu0_2
+# 1140|     v7_6(void)            = ^IndirectReadSideEffect[0]      : &:r7_3, ~mu0_2
+# 1140|     mu7_7(unknown)        = ^BufferMayWriteSideEffect[0]    : &:r7_3, ~mu0_2
 # 1140|     v7_8(void)            = ThrowValue                      : &:r7_0, ~mu0_2
 #-----|   Exception -> Block 9
 
@@ -5403,8 +5403,8 @@ ir.cpp:
 # 1145|     r10_5(char *)         = Load                          : &:r10_4, ~mu0_2
 # 1145|     v10_6(void)           = Call                          : func:r10_3, this:r10_2, 0:r10_5
 # 1145|     mu10_7(unknown)       = ^CallSideEffect               : ~mu0_2
-# 1145|     v10_8(void)           = ^IndirectReadSideEffect       : &:r10_5, ~mu0_2
-# 1145|     mu10_9(unknown)       = ^BufferMayWriteSideEffect     : &:r10_5, ~mu0_2
+# 1145|     v10_8(void)           = ^IndirectReadSideEffect[0]    : &:r10_5, ~mu0_2
+# 1145|     mu10_9(unknown)       = ^BufferMayWriteSideEffect[0]  : &:r10_5, ~mu0_2
 # 1145|     v10_10(void)          = ThrowValue                    : &:r10_2, ~mu0_2
 #-----|   Exception -> Block 2
 
@@ -5488,30 +5488,30 @@ ir.cpp:
 
 # 1163| int ModeledCallTarget(int)
 # 1163|   Block 0
-# 1163|     v0_0(void)           = EnterFunction              : 
-# 1163|     mu0_1(unknown)       = AliasedDefinition          : 
-# 1163|     mu0_2(unknown)       = UnmodeledDefinition        : 
-# 1163|     r0_3(glval<int>)     = VariableAddress[x]         : 
-# 1163|     mu0_4(int)           = InitializeParameter[x]     : &:r0_3
-# 1164|     r0_5(glval<int>)     = VariableAddress[y]         : 
-# 1164|     mu0_6(int)           = Uninitialized[y]           : &:r0_5
-# 1165|     r0_7(glval<unknown>) = FunctionAddress[memcpy]    : 
-# 1165|     r0_8(glval<int>)     = VariableAddress[y]         : 
-# 1165|     r0_9(void *)         = Convert                    : r0_8
-# 1165|     r0_10(glval<int>)    = VariableAddress[x]         : 
-# 1165|     r0_11(void *)        = Convert                    : r0_10
-# 1165|     r0_12(int)           = Constant[4]                : 
-# 1165|     r0_13(void *)        = Call                       : func:r0_7, 0:r0_9, 1:r0_11, 2:r0_12
-# 1165|     v0_14(void)          = ^BufferReadSideEffect      : &:r0_11, ~mu0_2
-# 1165|     mu0_15(unknown)      = ^BufferMustWriteSideEffect : &:r0_9
-# 1166|     r0_16(glval<int>)    = VariableAddress[#return]   : 
-# 1166|     r0_17(glval<int>)    = VariableAddress[y]         : 
-# 1166|     r0_18(int)           = Load                       : &:r0_17, ~mu0_2
-# 1166|     mu0_19(int)          = Store                      : &:r0_16, r0_18
-# 1163|     r0_20(glval<int>)    = VariableAddress[#return]   : 
-# 1163|     v0_21(void)          = ReturnValue                : &:r0_20, ~mu0_2
-# 1163|     v0_22(void)          = UnmodeledUse               : mu*
-# 1163|     v0_23(void)          = ExitFunction               : 
+# 1163|     v0_0(void)           = EnterFunction                      : 
+# 1163|     mu0_1(unknown)       = AliasedDefinition                  : 
+# 1163|     mu0_2(unknown)       = UnmodeledDefinition                : 
+# 1163|     r0_3(glval<int>)     = VariableAddress[x]                 : 
+# 1163|     mu0_4(int)           = InitializeParameter[x]             : &:r0_3
+# 1164|     r0_5(glval<int>)     = VariableAddress[y]                 : 
+# 1164|     mu0_6(int)           = Uninitialized[y]                   : &:r0_5
+# 1165|     r0_7(glval<unknown>) = FunctionAddress[memcpy]            : 
+# 1165|     r0_8(glval<int>)     = VariableAddress[y]                 : 
+# 1165|     r0_9(void *)         = Convert                            : r0_8
+# 1165|     r0_10(glval<int>)    = VariableAddress[x]                 : 
+# 1165|     r0_11(void *)        = Convert                            : r0_10
+# 1165|     r0_12(int)           = Constant[4]                        : 
+# 1165|     r0_13(void *)        = Call                               : func:r0_7, 0:r0_9, 1:r0_11, 2:r0_12
+# 1165|     v0_14(void)          = ^SizedBufferReadSideEffect[1]      : &:r0_11, r0_12, ~mu0_2
+# 1165|     mu0_15(unknown)      = ^SizedBufferMustWriteSideEffect[0] : &:r0_9, r0_12
+# 1166|     r0_16(glval<int>)    = VariableAddress[#return]           : 
+# 1166|     r0_17(glval<int>)    = VariableAddress[y]                 : 
+# 1166|     r0_18(int)           = Load                               : &:r0_17, ~mu0_2
+# 1166|     mu0_19(int)          = Store                              : &:r0_16, r0_18
+# 1163|     r0_20(glval<int>)    = VariableAddress[#return]           : 
+# 1163|     v0_21(void)          = ReturnValue                        : &:r0_20, ~mu0_2
+# 1163|     v0_22(void)          = UnmodeledUse                       : mu*
+# 1163|     v0_23(void)          = ExitFunction                       : 
 
 perf-regression.cpp:
 #    6| void Big::Big()

--- a/cpp/ql/test/library-tests/ir/ssa/aliased_ssa_ir.expected
+++ b/cpp/ql/test/library-tests/ir/ssa/aliased_ssa_ir.expected
@@ -311,26 +311,29 @@ ssa.cpp:
 
 #   95| void MustExactlyOverlapEscaped(Point)
 #   95|   Block 0
-#   95|     v0_0(void)            = EnterFunction           : 
-#   95|     m0_1(unknown)         = AliasedDefinition       : 
-#   95|     mu0_2(unknown)        = UnmodeledDefinition     : 
-#   95|     r0_3(glval<Point>)    = VariableAddress[a]      : 
-#   95|     m0_4(Point)           = InitializeParameter[a]  : &:r0_3
-#   95|     m0_5(unknown)         = Chi                     : total:m0_1, partial:m0_4
-#   96|     r0_6(glval<Point>)    = VariableAddress[b]      : 
-#   96|     r0_7(glval<Point>)    = VariableAddress[a]      : 
-#   96|     r0_8(Point)           = Load                    : &:r0_7, m0_4
-#   96|     m0_9(Point)           = Store                   : &:r0_6, r0_8
-#   97|     r0_10(glval<unknown>) = FunctionAddress[Escape] : 
-#   97|     r0_11(glval<Point>)   = VariableAddress[a]      : 
-#   97|     r0_12(void *)         = Convert                 : r0_11
-#   97|     v0_13(void)           = Call                    : func:r0_10, 0:r0_12
-#   97|     m0_14(unknown)        = ^CallSideEffect         : ~m0_5
-#   97|     m0_15(unknown)        = Chi                     : total:m0_5, partial:m0_14
-#   98|     v0_16(void)           = NoOp                    : 
-#   95|     v0_17(void)           = ReturnVoid              : 
-#   95|     v0_18(void)           = UnmodeledUse            : mu*
-#   95|     v0_19(void)           = ExitFunction            : 
+#   95|     v0_0(void)            = EnterFunction                : 
+#   95|     m0_1(unknown)         = AliasedDefinition            : 
+#   95|     mu0_2(unknown)        = UnmodeledDefinition          : 
+#   95|     r0_3(glval<Point>)    = VariableAddress[a]           : 
+#   95|     m0_4(Point)           = InitializeParameter[a]       : &:r0_3
+#   95|     m0_5(unknown)         = Chi                          : total:m0_1, partial:m0_4
+#   96|     r0_6(glval<Point>)    = VariableAddress[b]           : 
+#   96|     r0_7(glval<Point>)    = VariableAddress[a]           : 
+#   96|     r0_8(Point)           = Load                         : &:r0_7, m0_4
+#   96|     m0_9(Point)           = Store                        : &:r0_6, r0_8
+#   97|     r0_10(glval<unknown>) = FunctionAddress[Escape]      : 
+#   97|     r0_11(glval<Point>)   = VariableAddress[a]           : 
+#   97|     r0_12(void *)         = Convert                      : r0_11
+#   97|     v0_13(void)           = Call                         : func:r0_10, 0:r0_12
+#   97|     m0_14(unknown)        = ^CallSideEffect              : ~m0_5
+#   97|     m0_15(unknown)        = Chi                          : total:m0_5, partial:m0_14
+#   97|     v0_16(void)           = ^IndirectReadSideEffect[p]   : &:r0_12, ~m0_15
+#   97|     m0_17(unknown)        = ^BufferMayWriteSideEffect[p] : &:r0_12, ~m0_15
+#   97|     m0_18(unknown)        = Chi                          : total:m0_15, partial:m0_17
+#   98|     v0_19(void)           = NoOp                         : 
+#   95|     v0_20(void)           = ReturnVoid                   : 
+#   95|     v0_21(void)           = UnmodeledUse                 : mu*
+#   95|     v0_22(void)           = ExitFunction                 : 
 
 #  100| void MustTotallyOverlap(Point)
 #  100|   Block 0
@@ -356,32 +359,35 @@ ssa.cpp:
 
 #  105| void MustTotallyOverlapEscaped(Point)
 #  105|   Block 0
-#  105|     v0_0(void)            = EnterFunction           : 
-#  105|     m0_1(unknown)         = AliasedDefinition       : 
-#  105|     mu0_2(unknown)        = UnmodeledDefinition     : 
-#  105|     r0_3(glval<Point>)    = VariableAddress[a]      : 
-#  105|     m0_4(Point)           = InitializeParameter[a]  : &:r0_3
-#  105|     m0_5(unknown)         = Chi                     : total:m0_1, partial:m0_4
-#  106|     r0_6(glval<int>)      = VariableAddress[x]      : 
-#  106|     r0_7(glval<Point>)    = VariableAddress[a]      : 
-#  106|     r0_8(glval<int>)      = FieldAddress[x]         : r0_7
-#  106|     r0_9(int)             = Load                    : &:r0_8, ~m0_4
-#  106|     m0_10(int)            = Store                   : &:r0_6, r0_9
-#  107|     r0_11(glval<int>)     = VariableAddress[y]      : 
-#  107|     r0_12(glval<Point>)   = VariableAddress[a]      : 
-#  107|     r0_13(glval<int>)     = FieldAddress[y]         : r0_12
-#  107|     r0_14(int)            = Load                    : &:r0_13, ~m0_4
-#  107|     m0_15(int)            = Store                   : &:r0_11, r0_14
-#  108|     r0_16(glval<unknown>) = FunctionAddress[Escape] : 
-#  108|     r0_17(glval<Point>)   = VariableAddress[a]      : 
-#  108|     r0_18(void *)         = Convert                 : r0_17
-#  108|     v0_19(void)           = Call                    : func:r0_16, 0:r0_18
-#  108|     m0_20(unknown)        = ^CallSideEffect         : ~m0_5
-#  108|     m0_21(unknown)        = Chi                     : total:m0_5, partial:m0_20
-#  109|     v0_22(void)           = NoOp                    : 
-#  105|     v0_23(void)           = ReturnVoid              : 
-#  105|     v0_24(void)           = UnmodeledUse            : mu*
-#  105|     v0_25(void)           = ExitFunction            : 
+#  105|     v0_0(void)            = EnterFunction                : 
+#  105|     m0_1(unknown)         = AliasedDefinition            : 
+#  105|     mu0_2(unknown)        = UnmodeledDefinition          : 
+#  105|     r0_3(glval<Point>)    = VariableAddress[a]           : 
+#  105|     m0_4(Point)           = InitializeParameter[a]       : &:r0_3
+#  105|     m0_5(unknown)         = Chi                          : total:m0_1, partial:m0_4
+#  106|     r0_6(glval<int>)      = VariableAddress[x]           : 
+#  106|     r0_7(glval<Point>)    = VariableAddress[a]           : 
+#  106|     r0_8(glval<int>)      = FieldAddress[x]              : r0_7
+#  106|     r0_9(int)             = Load                         : &:r0_8, ~m0_4
+#  106|     m0_10(int)            = Store                        : &:r0_6, r0_9
+#  107|     r0_11(glval<int>)     = VariableAddress[y]           : 
+#  107|     r0_12(glval<Point>)   = VariableAddress[a]           : 
+#  107|     r0_13(glval<int>)     = FieldAddress[y]              : r0_12
+#  107|     r0_14(int)            = Load                         : &:r0_13, ~m0_4
+#  107|     m0_15(int)            = Store                        : &:r0_11, r0_14
+#  108|     r0_16(glval<unknown>) = FunctionAddress[Escape]      : 
+#  108|     r0_17(glval<Point>)   = VariableAddress[a]           : 
+#  108|     r0_18(void *)         = Convert                      : r0_17
+#  108|     v0_19(void)           = Call                         : func:r0_16, 0:r0_18
+#  108|     m0_20(unknown)        = ^CallSideEffect              : ~m0_5
+#  108|     m0_21(unknown)        = Chi                          : total:m0_5, partial:m0_20
+#  108|     v0_22(void)           = ^IndirectReadSideEffect[p]   : &:r0_18, ~m0_21
+#  108|     m0_23(unknown)        = ^BufferMayWriteSideEffect[p] : &:r0_18, ~m0_21
+#  108|     m0_24(unknown)        = Chi                          : total:m0_21, partial:m0_23
+#  109|     v0_25(void)           = NoOp                         : 
+#  105|     v0_26(void)           = ReturnVoid                   : 
+#  105|     v0_27(void)           = UnmodeledUse                 : mu*
+#  105|     v0_28(void)           = ExitFunction                 : 
 
 #  111| void MayPartiallyOverlap(int, int)
 #  111|   Block 0
@@ -415,40 +421,43 @@ ssa.cpp:
 
 #  116| void MayPartiallyOverlapEscaped(int, int)
 #  116|   Block 0
-#  116|     v0_0(void)            = EnterFunction           : 
-#  116|     m0_1(unknown)         = AliasedDefinition       : 
-#  116|     mu0_2(unknown)        = UnmodeledDefinition     : 
-#  116|     r0_3(glval<int>)      = VariableAddress[x]      : 
-#  116|     m0_4(int)             = InitializeParameter[x]  : &:r0_3
-#  116|     r0_5(glval<int>)      = VariableAddress[y]      : 
-#  116|     m0_6(int)             = InitializeParameter[y]  : &:r0_5
-#  117|     r0_7(glval<Point>)    = VariableAddress[a]      : 
-#  117|     m0_8(Point)           = Uninitialized[a]        : &:r0_7
-#  117|     m0_9(unknown)         = Chi                     : total:m0_1, partial:m0_8
-#  117|     r0_10(glval<int>)     = FieldAddress[x]         : r0_7
-#  117|     r0_11(glval<int>)     = VariableAddress[x]      : 
-#  117|     r0_12(int)            = Load                    : &:r0_11, m0_4
-#  117|     m0_13(int)            = Store                   : &:r0_10, r0_12
-#  117|     m0_14(unknown)        = Chi                     : total:m0_9, partial:m0_13
-#  117|     r0_15(glval<int>)     = FieldAddress[y]         : r0_7
-#  117|     r0_16(glval<int>)     = VariableAddress[y]      : 
-#  117|     r0_17(int)            = Load                    : &:r0_16, m0_6
-#  117|     m0_18(int)            = Store                   : &:r0_15, r0_17
-#  117|     m0_19(unknown)        = Chi                     : total:m0_14, partial:m0_18
-#  118|     r0_20(glval<Point>)   = VariableAddress[b]      : 
-#  118|     r0_21(glval<Point>)   = VariableAddress[a]      : 
-#  118|     r0_22(Point)          = Load                    : &:r0_21, ~m0_19
-#  118|     m0_23(Point)          = Store                   : &:r0_20, r0_22
-#  119|     r0_24(glval<unknown>) = FunctionAddress[Escape] : 
-#  119|     r0_25(glval<Point>)   = VariableAddress[a]      : 
-#  119|     r0_26(void *)         = Convert                 : r0_25
-#  119|     v0_27(void)           = Call                    : func:r0_24, 0:r0_26
-#  119|     m0_28(unknown)        = ^CallSideEffect         : ~m0_19
-#  119|     m0_29(unknown)        = Chi                     : total:m0_19, partial:m0_28
-#  120|     v0_30(void)           = NoOp                    : 
-#  116|     v0_31(void)           = ReturnVoid              : 
-#  116|     v0_32(void)           = UnmodeledUse            : mu*
-#  116|     v0_33(void)           = ExitFunction            : 
+#  116|     v0_0(void)            = EnterFunction                : 
+#  116|     m0_1(unknown)         = AliasedDefinition            : 
+#  116|     mu0_2(unknown)        = UnmodeledDefinition          : 
+#  116|     r0_3(glval<int>)      = VariableAddress[x]           : 
+#  116|     m0_4(int)             = InitializeParameter[x]       : &:r0_3
+#  116|     r0_5(glval<int>)      = VariableAddress[y]           : 
+#  116|     m0_6(int)             = InitializeParameter[y]       : &:r0_5
+#  117|     r0_7(glval<Point>)    = VariableAddress[a]           : 
+#  117|     m0_8(Point)           = Uninitialized[a]             : &:r0_7
+#  117|     m0_9(unknown)         = Chi                          : total:m0_1, partial:m0_8
+#  117|     r0_10(glval<int>)     = FieldAddress[x]              : r0_7
+#  117|     r0_11(glval<int>)     = VariableAddress[x]           : 
+#  117|     r0_12(int)            = Load                         : &:r0_11, m0_4
+#  117|     m0_13(int)            = Store                        : &:r0_10, r0_12
+#  117|     m0_14(unknown)        = Chi                          : total:m0_9, partial:m0_13
+#  117|     r0_15(glval<int>)     = FieldAddress[y]              : r0_7
+#  117|     r0_16(glval<int>)     = VariableAddress[y]           : 
+#  117|     r0_17(int)            = Load                         : &:r0_16, m0_6
+#  117|     m0_18(int)            = Store                        : &:r0_15, r0_17
+#  117|     m0_19(unknown)        = Chi                          : total:m0_14, partial:m0_18
+#  118|     r0_20(glval<Point>)   = VariableAddress[b]           : 
+#  118|     r0_21(glval<Point>)   = VariableAddress[a]           : 
+#  118|     r0_22(Point)          = Load                         : &:r0_21, ~m0_19
+#  118|     m0_23(Point)          = Store                        : &:r0_20, r0_22
+#  119|     r0_24(glval<unknown>) = FunctionAddress[Escape]      : 
+#  119|     r0_25(glval<Point>)   = VariableAddress[a]           : 
+#  119|     r0_26(void *)         = Convert                      : r0_25
+#  119|     v0_27(void)           = Call                         : func:r0_24, 0:r0_26
+#  119|     m0_28(unknown)        = ^CallSideEffect              : ~m0_19
+#  119|     m0_29(unknown)        = Chi                          : total:m0_19, partial:m0_28
+#  119|     v0_30(void)           = ^IndirectReadSideEffect[p]   : &:r0_26, ~m0_29
+#  119|     m0_31(unknown)        = ^BufferMayWriteSideEffect[p] : &:r0_26, ~m0_29
+#  119|     m0_32(unknown)        = Chi                          : total:m0_29, partial:m0_31
+#  120|     v0_33(void)           = NoOp                         : 
+#  116|     v0_34(void)           = ReturnVoid                   : 
+#  116|     v0_35(void)           = UnmodeledUse                 : mu*
+#  116|     v0_36(void)           = ExitFunction                 : 
 
 #  122| void MergeMustExactlyOverlap(bool, int, int)
 #  122|   Block 0
@@ -807,3 +816,33 @@ ssa.cpp:
 #  198|     v0_43(void)           = ReturnValue               : &:r0_42, m0_41
 #  198|     v0_44(void)           = UnmodeledUse              : mu*
 #  198|     v0_45(void)           = ExitFunction              : 
+
+#  207| int ModeledCallTarget(int)
+#  207|   Block 0
+#  207|     v0_0(void)           = EnterFunction                   : 
+#  207|     m0_1(unknown)        = AliasedDefinition               : 
+#  207|     mu0_2(unknown)       = UnmodeledDefinition             : 
+#  207|     r0_3(glval<int>)     = VariableAddress[x]              : 
+#  207|     m0_4(int)            = InitializeParameter[x]          : &:r0_3
+#  207|     m0_5(unknown)        = Chi                             : total:m0_1, partial:m0_4
+#  208|     r0_6(glval<int>)     = VariableAddress[y]              : 
+#  208|     m0_7(int)            = Uninitialized[y]                : &:r0_6
+#  208|     m0_8(unknown)        = Chi                             : total:m0_5, partial:m0_7
+#  209|     r0_9(glval<unknown>) = FunctionAddress[memcpy]         : 
+#  209|     r0_10(glval<int>)    = VariableAddress[y]              : 
+#  209|     r0_11(void *)        = Convert                         : r0_10
+#  209|     r0_12(glval<int>)    = VariableAddress[x]              : 
+#  209|     r0_13(void *)        = Convert                         : r0_12
+#  209|     r0_14(int)           = Constant[4]                     : 
+#  209|     r0_15(void *)        = Call                            : func:r0_9, 0:r0_11, 1:r0_13, 2:r0_14
+#  209|     v0_16(void)          = ^BufferReadSideEffect[src]      : &:r0_13, ~m0_4
+#  209|     m0_17(unknown)       = ^BufferMustWriteSideEffect[dst] : &:r0_11
+#  209|     m0_18(unknown)       = Chi                             : total:m0_8, partial:m0_17
+#  210|     r0_19(glval<int>)    = VariableAddress[#return]        : 
+#  210|     r0_20(glval<int>)    = VariableAddress[y]              : 
+#  210|     r0_21(int)           = Load                            : &:r0_20, ~m0_18
+#  210|     m0_22(int)           = Store                           : &:r0_19, r0_21
+#  207|     r0_23(glval<int>)    = VariableAddress[#return]        : 
+#  207|     v0_24(void)          = ReturnValue                     : &:r0_23, m0_22
+#  207|     v0_25(void)          = UnmodeledUse                    : mu*
+#  207|     v0_26(void)          = ExitFunction                    : 

--- a/cpp/ql/test/library-tests/ir/ssa/aliased_ssa_ir.expected
+++ b/cpp/ql/test/library-tests/ir/ssa/aliased_ssa_ir.expected
@@ -311,29 +311,29 @@ ssa.cpp:
 
 #   95| void MustExactlyOverlapEscaped(Point)
 #   95|   Block 0
-#   95|     v0_0(void)            = EnterFunction                : 
-#   95|     m0_1(unknown)         = AliasedDefinition            : 
-#   95|     mu0_2(unknown)        = UnmodeledDefinition          : 
-#   95|     r0_3(glval<Point>)    = VariableAddress[a]           : 
-#   95|     m0_4(Point)           = InitializeParameter[a]       : &:r0_3
-#   95|     m0_5(unknown)         = Chi                          : total:m0_1, partial:m0_4
-#   96|     r0_6(glval<Point>)    = VariableAddress[b]           : 
-#   96|     r0_7(glval<Point>)    = VariableAddress[a]           : 
-#   96|     r0_8(Point)           = Load                         : &:r0_7, m0_4
-#   96|     m0_9(Point)           = Store                        : &:r0_6, r0_8
-#   97|     r0_10(glval<unknown>) = FunctionAddress[Escape]      : 
-#   97|     r0_11(glval<Point>)   = VariableAddress[a]           : 
-#   97|     r0_12(void *)         = Convert                      : r0_11
-#   97|     v0_13(void)           = Call                         : func:r0_10, 0:r0_12
-#   97|     m0_14(unknown)        = ^CallSideEffect              : ~m0_5
-#   97|     m0_15(unknown)        = Chi                          : total:m0_5, partial:m0_14
-#   97|     v0_16(void)           = ^IndirectReadSideEffect[p]   : &:r0_12, ~m0_15
-#   97|     m0_17(unknown)        = ^BufferMayWriteSideEffect[p] : &:r0_12, ~m0_15
-#   97|     m0_18(unknown)        = Chi                          : total:m0_15, partial:m0_17
-#   98|     v0_19(void)           = NoOp                         : 
-#   95|     v0_20(void)           = ReturnVoid                   : 
-#   95|     v0_21(void)           = UnmodeledUse                 : mu*
-#   95|     v0_22(void)           = ExitFunction                 : 
+#   95|     v0_0(void)            = EnterFunction             : 
+#   95|     m0_1(unknown)         = AliasedDefinition         : 
+#   95|     mu0_2(unknown)        = UnmodeledDefinition       : 
+#   95|     r0_3(glval<Point>)    = VariableAddress[a]        : 
+#   95|     m0_4(Point)           = InitializeParameter[a]    : &:r0_3
+#   95|     m0_5(unknown)         = Chi                       : total:m0_1, partial:m0_4
+#   96|     r0_6(glval<Point>)    = VariableAddress[b]        : 
+#   96|     r0_7(glval<Point>)    = VariableAddress[a]        : 
+#   96|     r0_8(Point)           = Load                      : &:r0_7, m0_4
+#   96|     m0_9(Point)           = Store                     : &:r0_6, r0_8
+#   97|     r0_10(glval<unknown>) = FunctionAddress[Escape]   : 
+#   97|     r0_11(glval<Point>)   = VariableAddress[a]        : 
+#   97|     r0_12(void *)         = Convert                   : r0_11
+#   97|     v0_13(void)           = Call                      : func:r0_10, 0:r0_12
+#   97|     m0_14(unknown)        = ^CallSideEffect           : ~m0_5
+#   97|     m0_15(unknown)        = Chi                       : total:m0_5, partial:m0_14
+#   97|     v0_16(void)           = ^IndirectReadSideEffect   : &:r0_12, ~m0_15
+#   97|     m0_17(unknown)        = ^BufferMayWriteSideEffect : &:r0_12, ~m0_15
+#   97|     m0_18(unknown)        = Chi                       : total:m0_15, partial:m0_17
+#   98|     v0_19(void)           = NoOp                      : 
+#   95|     v0_20(void)           = ReturnVoid                : 
+#   95|     v0_21(void)           = UnmodeledUse              : mu*
+#   95|     v0_22(void)           = ExitFunction              : 
 
 #  100| void MustTotallyOverlap(Point)
 #  100|   Block 0
@@ -359,35 +359,35 @@ ssa.cpp:
 
 #  105| void MustTotallyOverlapEscaped(Point)
 #  105|   Block 0
-#  105|     v0_0(void)            = EnterFunction                : 
-#  105|     m0_1(unknown)         = AliasedDefinition            : 
-#  105|     mu0_2(unknown)        = UnmodeledDefinition          : 
-#  105|     r0_3(glval<Point>)    = VariableAddress[a]           : 
-#  105|     m0_4(Point)           = InitializeParameter[a]       : &:r0_3
-#  105|     m0_5(unknown)         = Chi                          : total:m0_1, partial:m0_4
-#  106|     r0_6(glval<int>)      = VariableAddress[x]           : 
-#  106|     r0_7(glval<Point>)    = VariableAddress[a]           : 
-#  106|     r0_8(glval<int>)      = FieldAddress[x]              : r0_7
-#  106|     r0_9(int)             = Load                         : &:r0_8, ~m0_4
-#  106|     m0_10(int)            = Store                        : &:r0_6, r0_9
-#  107|     r0_11(glval<int>)     = VariableAddress[y]           : 
-#  107|     r0_12(glval<Point>)   = VariableAddress[a]           : 
-#  107|     r0_13(glval<int>)     = FieldAddress[y]              : r0_12
-#  107|     r0_14(int)            = Load                         : &:r0_13, ~m0_4
-#  107|     m0_15(int)            = Store                        : &:r0_11, r0_14
-#  108|     r0_16(glval<unknown>) = FunctionAddress[Escape]      : 
-#  108|     r0_17(glval<Point>)   = VariableAddress[a]           : 
-#  108|     r0_18(void *)         = Convert                      : r0_17
-#  108|     v0_19(void)           = Call                         : func:r0_16, 0:r0_18
-#  108|     m0_20(unknown)        = ^CallSideEffect              : ~m0_5
-#  108|     m0_21(unknown)        = Chi                          : total:m0_5, partial:m0_20
-#  108|     v0_22(void)           = ^IndirectReadSideEffect[p]   : &:r0_18, ~m0_21
-#  108|     m0_23(unknown)        = ^BufferMayWriteSideEffect[p] : &:r0_18, ~m0_21
-#  108|     m0_24(unknown)        = Chi                          : total:m0_21, partial:m0_23
-#  109|     v0_25(void)           = NoOp                         : 
-#  105|     v0_26(void)           = ReturnVoid                   : 
-#  105|     v0_27(void)           = UnmodeledUse                 : mu*
-#  105|     v0_28(void)           = ExitFunction                 : 
+#  105|     v0_0(void)            = EnterFunction             : 
+#  105|     m0_1(unknown)         = AliasedDefinition         : 
+#  105|     mu0_2(unknown)        = UnmodeledDefinition       : 
+#  105|     r0_3(glval<Point>)    = VariableAddress[a]        : 
+#  105|     m0_4(Point)           = InitializeParameter[a]    : &:r0_3
+#  105|     m0_5(unknown)         = Chi                       : total:m0_1, partial:m0_4
+#  106|     r0_6(glval<int>)      = VariableAddress[x]        : 
+#  106|     r0_7(glval<Point>)    = VariableAddress[a]        : 
+#  106|     r0_8(glval<int>)      = FieldAddress[x]           : r0_7
+#  106|     r0_9(int)             = Load                      : &:r0_8, ~m0_4
+#  106|     m0_10(int)            = Store                     : &:r0_6, r0_9
+#  107|     r0_11(glval<int>)     = VariableAddress[y]        : 
+#  107|     r0_12(glval<Point>)   = VariableAddress[a]        : 
+#  107|     r0_13(glval<int>)     = FieldAddress[y]           : r0_12
+#  107|     r0_14(int)            = Load                      : &:r0_13, ~m0_4
+#  107|     m0_15(int)            = Store                     : &:r0_11, r0_14
+#  108|     r0_16(glval<unknown>) = FunctionAddress[Escape]   : 
+#  108|     r0_17(glval<Point>)   = VariableAddress[a]        : 
+#  108|     r0_18(void *)         = Convert                   : r0_17
+#  108|     v0_19(void)           = Call                      : func:r0_16, 0:r0_18
+#  108|     m0_20(unknown)        = ^CallSideEffect           : ~m0_5
+#  108|     m0_21(unknown)        = Chi                       : total:m0_5, partial:m0_20
+#  108|     v0_22(void)           = ^IndirectReadSideEffect   : &:r0_18, ~m0_21
+#  108|     m0_23(unknown)        = ^BufferMayWriteSideEffect : &:r0_18, ~m0_21
+#  108|     m0_24(unknown)        = Chi                       : total:m0_21, partial:m0_23
+#  109|     v0_25(void)           = NoOp                      : 
+#  105|     v0_26(void)           = ReturnVoid                : 
+#  105|     v0_27(void)           = UnmodeledUse              : mu*
+#  105|     v0_28(void)           = ExitFunction              : 
 
 #  111| void MayPartiallyOverlap(int, int)
 #  111|   Block 0
@@ -421,43 +421,43 @@ ssa.cpp:
 
 #  116| void MayPartiallyOverlapEscaped(int, int)
 #  116|   Block 0
-#  116|     v0_0(void)            = EnterFunction                : 
-#  116|     m0_1(unknown)         = AliasedDefinition            : 
-#  116|     mu0_2(unknown)        = UnmodeledDefinition          : 
-#  116|     r0_3(glval<int>)      = VariableAddress[x]           : 
-#  116|     m0_4(int)             = InitializeParameter[x]       : &:r0_3
-#  116|     r0_5(glval<int>)      = VariableAddress[y]           : 
-#  116|     m0_6(int)             = InitializeParameter[y]       : &:r0_5
-#  117|     r0_7(glval<Point>)    = VariableAddress[a]           : 
-#  117|     m0_8(Point)           = Uninitialized[a]             : &:r0_7
-#  117|     m0_9(unknown)         = Chi                          : total:m0_1, partial:m0_8
-#  117|     r0_10(glval<int>)     = FieldAddress[x]              : r0_7
-#  117|     r0_11(glval<int>)     = VariableAddress[x]           : 
-#  117|     r0_12(int)            = Load                         : &:r0_11, m0_4
-#  117|     m0_13(int)            = Store                        : &:r0_10, r0_12
-#  117|     m0_14(unknown)        = Chi                          : total:m0_9, partial:m0_13
-#  117|     r0_15(glval<int>)     = FieldAddress[y]              : r0_7
-#  117|     r0_16(glval<int>)     = VariableAddress[y]           : 
-#  117|     r0_17(int)            = Load                         : &:r0_16, m0_6
-#  117|     m0_18(int)            = Store                        : &:r0_15, r0_17
-#  117|     m0_19(unknown)        = Chi                          : total:m0_14, partial:m0_18
-#  118|     r0_20(glval<Point>)   = VariableAddress[b]           : 
-#  118|     r0_21(glval<Point>)   = VariableAddress[a]           : 
-#  118|     r0_22(Point)          = Load                         : &:r0_21, ~m0_19
-#  118|     m0_23(Point)          = Store                        : &:r0_20, r0_22
-#  119|     r0_24(glval<unknown>) = FunctionAddress[Escape]      : 
-#  119|     r0_25(glval<Point>)   = VariableAddress[a]           : 
-#  119|     r0_26(void *)         = Convert                      : r0_25
-#  119|     v0_27(void)           = Call                         : func:r0_24, 0:r0_26
-#  119|     m0_28(unknown)        = ^CallSideEffect              : ~m0_19
-#  119|     m0_29(unknown)        = Chi                          : total:m0_19, partial:m0_28
-#  119|     v0_30(void)           = ^IndirectReadSideEffect[p]   : &:r0_26, ~m0_29
-#  119|     m0_31(unknown)        = ^BufferMayWriteSideEffect[p] : &:r0_26, ~m0_29
-#  119|     m0_32(unknown)        = Chi                          : total:m0_29, partial:m0_31
-#  120|     v0_33(void)           = NoOp                         : 
-#  116|     v0_34(void)           = ReturnVoid                   : 
-#  116|     v0_35(void)           = UnmodeledUse                 : mu*
-#  116|     v0_36(void)           = ExitFunction                 : 
+#  116|     v0_0(void)            = EnterFunction             : 
+#  116|     m0_1(unknown)         = AliasedDefinition         : 
+#  116|     mu0_2(unknown)        = UnmodeledDefinition       : 
+#  116|     r0_3(glval<int>)      = VariableAddress[x]        : 
+#  116|     m0_4(int)             = InitializeParameter[x]    : &:r0_3
+#  116|     r0_5(glval<int>)      = VariableAddress[y]        : 
+#  116|     m0_6(int)             = InitializeParameter[y]    : &:r0_5
+#  117|     r0_7(glval<Point>)    = VariableAddress[a]        : 
+#  117|     m0_8(Point)           = Uninitialized[a]          : &:r0_7
+#  117|     m0_9(unknown)         = Chi                       : total:m0_1, partial:m0_8
+#  117|     r0_10(glval<int>)     = FieldAddress[x]           : r0_7
+#  117|     r0_11(glval<int>)     = VariableAddress[x]        : 
+#  117|     r0_12(int)            = Load                      : &:r0_11, m0_4
+#  117|     m0_13(int)            = Store                     : &:r0_10, r0_12
+#  117|     m0_14(unknown)        = Chi                       : total:m0_9, partial:m0_13
+#  117|     r0_15(glval<int>)     = FieldAddress[y]           : r0_7
+#  117|     r0_16(glval<int>)     = VariableAddress[y]        : 
+#  117|     r0_17(int)            = Load                      : &:r0_16, m0_6
+#  117|     m0_18(int)            = Store                     : &:r0_15, r0_17
+#  117|     m0_19(unknown)        = Chi                       : total:m0_14, partial:m0_18
+#  118|     r0_20(glval<Point>)   = VariableAddress[b]        : 
+#  118|     r0_21(glval<Point>)   = VariableAddress[a]        : 
+#  118|     r0_22(Point)          = Load                      : &:r0_21, ~m0_19
+#  118|     m0_23(Point)          = Store                     : &:r0_20, r0_22
+#  119|     r0_24(glval<unknown>) = FunctionAddress[Escape]   : 
+#  119|     r0_25(glval<Point>)   = VariableAddress[a]        : 
+#  119|     r0_26(void *)         = Convert                   : r0_25
+#  119|     v0_27(void)           = Call                      : func:r0_24, 0:r0_26
+#  119|     m0_28(unknown)        = ^CallSideEffect           : ~m0_19
+#  119|     m0_29(unknown)        = Chi                       : total:m0_19, partial:m0_28
+#  119|     v0_30(void)           = ^IndirectReadSideEffect   : &:r0_26, ~m0_29
+#  119|     m0_31(unknown)        = ^BufferMayWriteSideEffect : &:r0_26, ~m0_29
+#  119|     m0_32(unknown)        = Chi                       : total:m0_29, partial:m0_31
+#  120|     v0_33(void)           = NoOp                      : 
+#  116|     v0_34(void)           = ReturnVoid                : 
+#  116|     v0_35(void)           = UnmodeledUse              : mu*
+#  116|     v0_36(void)           = ExitFunction              : 
 
 #  122| void MergeMustExactlyOverlap(bool, int, int)
 #  122|   Block 0
@@ -819,30 +819,30 @@ ssa.cpp:
 
 #  207| int ModeledCallTarget(int)
 #  207|   Block 0
-#  207|     v0_0(void)           = EnterFunction                   : 
-#  207|     m0_1(unknown)        = AliasedDefinition               : 
-#  207|     mu0_2(unknown)       = UnmodeledDefinition             : 
-#  207|     r0_3(glval<int>)     = VariableAddress[x]              : 
-#  207|     m0_4(int)            = InitializeParameter[x]          : &:r0_3
-#  207|     m0_5(unknown)        = Chi                             : total:m0_1, partial:m0_4
-#  208|     r0_6(glval<int>)     = VariableAddress[y]              : 
-#  208|     m0_7(int)            = Uninitialized[y]                : &:r0_6
-#  208|     m0_8(unknown)        = Chi                             : total:m0_5, partial:m0_7
-#  209|     r0_9(glval<unknown>) = FunctionAddress[memcpy]         : 
-#  209|     r0_10(glval<int>)    = VariableAddress[y]              : 
-#  209|     r0_11(void *)        = Convert                         : r0_10
-#  209|     r0_12(glval<int>)    = VariableAddress[x]              : 
-#  209|     r0_13(void *)        = Convert                         : r0_12
-#  209|     r0_14(int)           = Constant[4]                     : 
-#  209|     r0_15(void *)        = Call                            : func:r0_9, 0:r0_11, 1:r0_13, 2:r0_14
-#  209|     v0_16(void)          = ^BufferReadSideEffect[src]      : &:r0_13, ~m0_4
-#  209|     m0_17(unknown)       = ^BufferMustWriteSideEffect[dst] : &:r0_11
-#  209|     m0_18(unknown)       = Chi                             : total:m0_8, partial:m0_17
-#  210|     r0_19(glval<int>)    = VariableAddress[#return]        : 
-#  210|     r0_20(glval<int>)    = VariableAddress[y]              : 
-#  210|     r0_21(int)           = Load                            : &:r0_20, ~m0_18
-#  210|     m0_22(int)           = Store                           : &:r0_19, r0_21
-#  207|     r0_23(glval<int>)    = VariableAddress[#return]        : 
-#  207|     v0_24(void)          = ReturnValue                     : &:r0_23, m0_22
-#  207|     v0_25(void)          = UnmodeledUse                    : mu*
-#  207|     v0_26(void)          = ExitFunction                    : 
+#  207|     v0_0(void)           = EnterFunction              : 
+#  207|     m0_1(unknown)        = AliasedDefinition          : 
+#  207|     mu0_2(unknown)       = UnmodeledDefinition        : 
+#  207|     r0_3(glval<int>)     = VariableAddress[x]         : 
+#  207|     m0_4(int)            = InitializeParameter[x]     : &:r0_3
+#  207|     m0_5(unknown)        = Chi                        : total:m0_1, partial:m0_4
+#  208|     r0_6(glval<int>)     = VariableAddress[y]         : 
+#  208|     m0_7(int)            = Uninitialized[y]           : &:r0_6
+#  208|     m0_8(unknown)        = Chi                        : total:m0_5, partial:m0_7
+#  209|     r0_9(glval<unknown>) = FunctionAddress[memcpy]    : 
+#  209|     r0_10(glval<int>)    = VariableAddress[y]         : 
+#  209|     r0_11(void *)        = Convert                    : r0_10
+#  209|     r0_12(glval<int>)    = VariableAddress[x]         : 
+#  209|     r0_13(void *)        = Convert                    : r0_12
+#  209|     r0_14(int)           = Constant[4]                : 
+#  209|     r0_15(void *)        = Call                       : func:r0_9, 0:r0_11, 1:r0_13, 2:r0_14
+#  209|     v0_16(void)          = ^BufferReadSideEffect      : &:r0_13, ~m0_4
+#  209|     m0_17(unknown)       = ^BufferMustWriteSideEffect : &:r0_11
+#  209|     m0_18(unknown)       = Chi                        : total:m0_8, partial:m0_17
+#  210|     r0_19(glval<int>)    = VariableAddress[#return]   : 
+#  210|     r0_20(glval<int>)    = VariableAddress[y]         : 
+#  210|     r0_21(int)           = Load                       : &:r0_20, ~m0_18
+#  210|     m0_22(int)           = Store                      : &:r0_19, r0_21
+#  207|     r0_23(glval<int>)    = VariableAddress[#return]   : 
+#  207|     v0_24(void)          = ReturnValue                : &:r0_23, m0_22
+#  207|     v0_25(void)          = UnmodeledUse               : mu*
+#  207|     v0_26(void)          = ExitFunction               : 

--- a/cpp/ql/test/library-tests/ir/ssa/aliased_ssa_ir.expected
+++ b/cpp/ql/test/library-tests/ir/ssa/aliased_ssa_ir.expected
@@ -328,7 +328,7 @@ ssa.cpp:
 #   97|     m0_14(unknown)        = ^CallSideEffect              : ~m0_5
 #   97|     m0_15(unknown)        = Chi                          : total:m0_5, partial:m0_14
 #   97|     v0_16(void)           = ^IndirectReadSideEffect[0]   : &:r0_12, ~m0_15
-#   97|     m0_17(unknown)        = ^BufferMayWriteSideEffect[0] : &:r0_12, ~m0_15
+#   97|     m0_17(unknown)        = ^BufferMayWriteSideEffect[0] : &:r0_12
 #   97|     m0_18(unknown)        = Chi                          : total:m0_15, partial:m0_17
 #   98|     v0_19(void)           = NoOp                         : 
 #   95|     v0_20(void)           = ReturnVoid                   : 
@@ -382,7 +382,7 @@ ssa.cpp:
 #  108|     m0_20(unknown)        = ^CallSideEffect              : ~m0_5
 #  108|     m0_21(unknown)        = Chi                          : total:m0_5, partial:m0_20
 #  108|     v0_22(void)           = ^IndirectReadSideEffect[0]   : &:r0_18, ~m0_21
-#  108|     m0_23(unknown)        = ^BufferMayWriteSideEffect[0] : &:r0_18, ~m0_21
+#  108|     m0_23(unknown)        = ^BufferMayWriteSideEffect[0] : &:r0_18
 #  108|     m0_24(unknown)        = Chi                          : total:m0_21, partial:m0_23
 #  109|     v0_25(void)           = NoOp                         : 
 #  105|     v0_26(void)           = ReturnVoid                   : 
@@ -452,7 +452,7 @@ ssa.cpp:
 #  119|     m0_28(unknown)        = ^CallSideEffect              : ~m0_19
 #  119|     m0_29(unknown)        = Chi                          : total:m0_19, partial:m0_28
 #  119|     v0_30(void)           = ^IndirectReadSideEffect[0]   : &:r0_26, ~m0_29
-#  119|     m0_31(unknown)        = ^BufferMayWriteSideEffect[0] : &:r0_26, ~m0_29
+#  119|     m0_31(unknown)        = ^BufferMayWriteSideEffect[0] : &:r0_26
 #  119|     m0_32(unknown)        = Chi                          : total:m0_29, partial:m0_31
 #  120|     v0_33(void)           = NoOp                         : 
 #  116|     v0_34(void)           = ReturnVoid                   : 

--- a/cpp/ql/test/library-tests/ir/ssa/aliased_ssa_ir.expected
+++ b/cpp/ql/test/library-tests/ir/ssa/aliased_ssa_ir.expected
@@ -311,29 +311,29 @@ ssa.cpp:
 
 #   95| void MustExactlyOverlapEscaped(Point)
 #   95|   Block 0
-#   95|     v0_0(void)            = EnterFunction             : 
-#   95|     m0_1(unknown)         = AliasedDefinition         : 
-#   95|     mu0_2(unknown)        = UnmodeledDefinition       : 
-#   95|     r0_3(glval<Point>)    = VariableAddress[a]        : 
-#   95|     m0_4(Point)           = InitializeParameter[a]    : &:r0_3
-#   95|     m0_5(unknown)         = Chi                       : total:m0_1, partial:m0_4
-#   96|     r0_6(glval<Point>)    = VariableAddress[b]        : 
-#   96|     r0_7(glval<Point>)    = VariableAddress[a]        : 
-#   96|     r0_8(Point)           = Load                      : &:r0_7, m0_4
-#   96|     m0_9(Point)           = Store                     : &:r0_6, r0_8
-#   97|     r0_10(glval<unknown>) = FunctionAddress[Escape]   : 
-#   97|     r0_11(glval<Point>)   = VariableAddress[a]        : 
-#   97|     r0_12(void *)         = Convert                   : r0_11
-#   97|     v0_13(void)           = Call                      : func:r0_10, 0:r0_12
-#   97|     m0_14(unknown)        = ^CallSideEffect           : ~m0_5
-#   97|     m0_15(unknown)        = Chi                       : total:m0_5, partial:m0_14
-#   97|     v0_16(void)           = ^IndirectReadSideEffect   : &:r0_12, ~m0_15
-#   97|     m0_17(unknown)        = ^BufferMayWriteSideEffect : &:r0_12, ~m0_15
-#   97|     m0_18(unknown)        = Chi                       : total:m0_15, partial:m0_17
-#   98|     v0_19(void)           = NoOp                      : 
-#   95|     v0_20(void)           = ReturnVoid                : 
-#   95|     v0_21(void)           = UnmodeledUse              : mu*
-#   95|     v0_22(void)           = ExitFunction              : 
+#   95|     v0_0(void)            = EnterFunction                : 
+#   95|     m0_1(unknown)         = AliasedDefinition            : 
+#   95|     mu0_2(unknown)        = UnmodeledDefinition          : 
+#   95|     r0_3(glval<Point>)    = VariableAddress[a]           : 
+#   95|     m0_4(Point)           = InitializeParameter[a]       : &:r0_3
+#   95|     m0_5(unknown)         = Chi                          : total:m0_1, partial:m0_4
+#   96|     r0_6(glval<Point>)    = VariableAddress[b]           : 
+#   96|     r0_7(glval<Point>)    = VariableAddress[a]           : 
+#   96|     r0_8(Point)           = Load                         : &:r0_7, m0_4
+#   96|     m0_9(Point)           = Store                        : &:r0_6, r0_8
+#   97|     r0_10(glval<unknown>) = FunctionAddress[Escape]      : 
+#   97|     r0_11(glval<Point>)   = VariableAddress[a]           : 
+#   97|     r0_12(void *)         = Convert                      : r0_11
+#   97|     v0_13(void)           = Call                         : func:r0_10, 0:r0_12
+#   97|     m0_14(unknown)        = ^CallSideEffect              : ~m0_5
+#   97|     m0_15(unknown)        = Chi                          : total:m0_5, partial:m0_14
+#   97|     v0_16(void)           = ^IndirectReadSideEffect[0]   : &:r0_12, ~m0_15
+#   97|     m0_17(unknown)        = ^BufferMayWriteSideEffect[0] : &:r0_12, ~m0_15
+#   97|     m0_18(unknown)        = Chi                          : total:m0_15, partial:m0_17
+#   98|     v0_19(void)           = NoOp                         : 
+#   95|     v0_20(void)           = ReturnVoid                   : 
+#   95|     v0_21(void)           = UnmodeledUse                 : mu*
+#   95|     v0_22(void)           = ExitFunction                 : 
 
 #  100| void MustTotallyOverlap(Point)
 #  100|   Block 0
@@ -359,35 +359,35 @@ ssa.cpp:
 
 #  105| void MustTotallyOverlapEscaped(Point)
 #  105|   Block 0
-#  105|     v0_0(void)            = EnterFunction             : 
-#  105|     m0_1(unknown)         = AliasedDefinition         : 
-#  105|     mu0_2(unknown)        = UnmodeledDefinition       : 
-#  105|     r0_3(glval<Point>)    = VariableAddress[a]        : 
-#  105|     m0_4(Point)           = InitializeParameter[a]    : &:r0_3
-#  105|     m0_5(unknown)         = Chi                       : total:m0_1, partial:m0_4
-#  106|     r0_6(glval<int>)      = VariableAddress[x]        : 
-#  106|     r0_7(glval<Point>)    = VariableAddress[a]        : 
-#  106|     r0_8(glval<int>)      = FieldAddress[x]           : r0_7
-#  106|     r0_9(int)             = Load                      : &:r0_8, ~m0_4
-#  106|     m0_10(int)            = Store                     : &:r0_6, r0_9
-#  107|     r0_11(glval<int>)     = VariableAddress[y]        : 
-#  107|     r0_12(glval<Point>)   = VariableAddress[a]        : 
-#  107|     r0_13(glval<int>)     = FieldAddress[y]           : r0_12
-#  107|     r0_14(int)            = Load                      : &:r0_13, ~m0_4
-#  107|     m0_15(int)            = Store                     : &:r0_11, r0_14
-#  108|     r0_16(glval<unknown>) = FunctionAddress[Escape]   : 
-#  108|     r0_17(glval<Point>)   = VariableAddress[a]        : 
-#  108|     r0_18(void *)         = Convert                   : r0_17
-#  108|     v0_19(void)           = Call                      : func:r0_16, 0:r0_18
-#  108|     m0_20(unknown)        = ^CallSideEffect           : ~m0_5
-#  108|     m0_21(unknown)        = Chi                       : total:m0_5, partial:m0_20
-#  108|     v0_22(void)           = ^IndirectReadSideEffect   : &:r0_18, ~m0_21
-#  108|     m0_23(unknown)        = ^BufferMayWriteSideEffect : &:r0_18, ~m0_21
-#  108|     m0_24(unknown)        = Chi                       : total:m0_21, partial:m0_23
-#  109|     v0_25(void)           = NoOp                      : 
-#  105|     v0_26(void)           = ReturnVoid                : 
-#  105|     v0_27(void)           = UnmodeledUse              : mu*
-#  105|     v0_28(void)           = ExitFunction              : 
+#  105|     v0_0(void)            = EnterFunction                : 
+#  105|     m0_1(unknown)         = AliasedDefinition            : 
+#  105|     mu0_2(unknown)        = UnmodeledDefinition          : 
+#  105|     r0_3(glval<Point>)    = VariableAddress[a]           : 
+#  105|     m0_4(Point)           = InitializeParameter[a]       : &:r0_3
+#  105|     m0_5(unknown)         = Chi                          : total:m0_1, partial:m0_4
+#  106|     r0_6(glval<int>)      = VariableAddress[x]           : 
+#  106|     r0_7(glval<Point>)    = VariableAddress[a]           : 
+#  106|     r0_8(glval<int>)      = FieldAddress[x]              : r0_7
+#  106|     r0_9(int)             = Load                         : &:r0_8, ~m0_4
+#  106|     m0_10(int)            = Store                        : &:r0_6, r0_9
+#  107|     r0_11(glval<int>)     = VariableAddress[y]           : 
+#  107|     r0_12(glval<Point>)   = VariableAddress[a]           : 
+#  107|     r0_13(glval<int>)     = FieldAddress[y]              : r0_12
+#  107|     r0_14(int)            = Load                         : &:r0_13, ~m0_4
+#  107|     m0_15(int)            = Store                        : &:r0_11, r0_14
+#  108|     r0_16(glval<unknown>) = FunctionAddress[Escape]      : 
+#  108|     r0_17(glval<Point>)   = VariableAddress[a]           : 
+#  108|     r0_18(void *)         = Convert                      : r0_17
+#  108|     v0_19(void)           = Call                         : func:r0_16, 0:r0_18
+#  108|     m0_20(unknown)        = ^CallSideEffect              : ~m0_5
+#  108|     m0_21(unknown)        = Chi                          : total:m0_5, partial:m0_20
+#  108|     v0_22(void)           = ^IndirectReadSideEffect[0]   : &:r0_18, ~m0_21
+#  108|     m0_23(unknown)        = ^BufferMayWriteSideEffect[0] : &:r0_18, ~m0_21
+#  108|     m0_24(unknown)        = Chi                          : total:m0_21, partial:m0_23
+#  109|     v0_25(void)           = NoOp                         : 
+#  105|     v0_26(void)           = ReturnVoid                   : 
+#  105|     v0_27(void)           = UnmodeledUse                 : mu*
+#  105|     v0_28(void)           = ExitFunction                 : 
 
 #  111| void MayPartiallyOverlap(int, int)
 #  111|   Block 0
@@ -421,43 +421,43 @@ ssa.cpp:
 
 #  116| void MayPartiallyOverlapEscaped(int, int)
 #  116|   Block 0
-#  116|     v0_0(void)            = EnterFunction             : 
-#  116|     m0_1(unknown)         = AliasedDefinition         : 
-#  116|     mu0_2(unknown)        = UnmodeledDefinition       : 
-#  116|     r0_3(glval<int>)      = VariableAddress[x]        : 
-#  116|     m0_4(int)             = InitializeParameter[x]    : &:r0_3
-#  116|     r0_5(glval<int>)      = VariableAddress[y]        : 
-#  116|     m0_6(int)             = InitializeParameter[y]    : &:r0_5
-#  117|     r0_7(glval<Point>)    = VariableAddress[a]        : 
-#  117|     m0_8(Point)           = Uninitialized[a]          : &:r0_7
-#  117|     m0_9(unknown)         = Chi                       : total:m0_1, partial:m0_8
-#  117|     r0_10(glval<int>)     = FieldAddress[x]           : r0_7
-#  117|     r0_11(glval<int>)     = VariableAddress[x]        : 
-#  117|     r0_12(int)            = Load                      : &:r0_11, m0_4
-#  117|     m0_13(int)            = Store                     : &:r0_10, r0_12
-#  117|     m0_14(unknown)        = Chi                       : total:m0_9, partial:m0_13
-#  117|     r0_15(glval<int>)     = FieldAddress[y]           : r0_7
-#  117|     r0_16(glval<int>)     = VariableAddress[y]        : 
-#  117|     r0_17(int)            = Load                      : &:r0_16, m0_6
-#  117|     m0_18(int)            = Store                     : &:r0_15, r0_17
-#  117|     m0_19(unknown)        = Chi                       : total:m0_14, partial:m0_18
-#  118|     r0_20(glval<Point>)   = VariableAddress[b]        : 
-#  118|     r0_21(glval<Point>)   = VariableAddress[a]        : 
-#  118|     r0_22(Point)          = Load                      : &:r0_21, ~m0_19
-#  118|     m0_23(Point)          = Store                     : &:r0_20, r0_22
-#  119|     r0_24(glval<unknown>) = FunctionAddress[Escape]   : 
-#  119|     r0_25(glval<Point>)   = VariableAddress[a]        : 
-#  119|     r0_26(void *)         = Convert                   : r0_25
-#  119|     v0_27(void)           = Call                      : func:r0_24, 0:r0_26
-#  119|     m0_28(unknown)        = ^CallSideEffect           : ~m0_19
-#  119|     m0_29(unknown)        = Chi                       : total:m0_19, partial:m0_28
-#  119|     v0_30(void)           = ^IndirectReadSideEffect   : &:r0_26, ~m0_29
-#  119|     m0_31(unknown)        = ^BufferMayWriteSideEffect : &:r0_26, ~m0_29
-#  119|     m0_32(unknown)        = Chi                       : total:m0_29, partial:m0_31
-#  120|     v0_33(void)           = NoOp                      : 
-#  116|     v0_34(void)           = ReturnVoid                : 
-#  116|     v0_35(void)           = UnmodeledUse              : mu*
-#  116|     v0_36(void)           = ExitFunction              : 
+#  116|     v0_0(void)            = EnterFunction                : 
+#  116|     m0_1(unknown)         = AliasedDefinition            : 
+#  116|     mu0_2(unknown)        = UnmodeledDefinition          : 
+#  116|     r0_3(glval<int>)      = VariableAddress[x]           : 
+#  116|     m0_4(int)             = InitializeParameter[x]       : &:r0_3
+#  116|     r0_5(glval<int>)      = VariableAddress[y]           : 
+#  116|     m0_6(int)             = InitializeParameter[y]       : &:r0_5
+#  117|     r0_7(glval<Point>)    = VariableAddress[a]           : 
+#  117|     m0_8(Point)           = Uninitialized[a]             : &:r0_7
+#  117|     m0_9(unknown)         = Chi                          : total:m0_1, partial:m0_8
+#  117|     r0_10(glval<int>)     = FieldAddress[x]              : r0_7
+#  117|     r0_11(glval<int>)     = VariableAddress[x]           : 
+#  117|     r0_12(int)            = Load                         : &:r0_11, m0_4
+#  117|     m0_13(int)            = Store                        : &:r0_10, r0_12
+#  117|     m0_14(unknown)        = Chi                          : total:m0_9, partial:m0_13
+#  117|     r0_15(glval<int>)     = FieldAddress[y]              : r0_7
+#  117|     r0_16(glval<int>)     = VariableAddress[y]           : 
+#  117|     r0_17(int)            = Load                         : &:r0_16, m0_6
+#  117|     m0_18(int)            = Store                        : &:r0_15, r0_17
+#  117|     m0_19(unknown)        = Chi                          : total:m0_14, partial:m0_18
+#  118|     r0_20(glval<Point>)   = VariableAddress[b]           : 
+#  118|     r0_21(glval<Point>)   = VariableAddress[a]           : 
+#  118|     r0_22(Point)          = Load                         : &:r0_21, ~m0_19
+#  118|     m0_23(Point)          = Store                        : &:r0_20, r0_22
+#  119|     r0_24(glval<unknown>) = FunctionAddress[Escape]      : 
+#  119|     r0_25(glval<Point>)   = VariableAddress[a]           : 
+#  119|     r0_26(void *)         = Convert                      : r0_25
+#  119|     v0_27(void)           = Call                         : func:r0_24, 0:r0_26
+#  119|     m0_28(unknown)        = ^CallSideEffect              : ~m0_19
+#  119|     m0_29(unknown)        = Chi                          : total:m0_19, partial:m0_28
+#  119|     v0_30(void)           = ^IndirectReadSideEffect[0]   : &:r0_26, ~m0_29
+#  119|     m0_31(unknown)        = ^BufferMayWriteSideEffect[0] : &:r0_26, ~m0_29
+#  119|     m0_32(unknown)        = Chi                          : total:m0_29, partial:m0_31
+#  120|     v0_33(void)           = NoOp                         : 
+#  116|     v0_34(void)           = ReturnVoid                   : 
+#  116|     v0_35(void)           = UnmodeledUse                 : mu*
+#  116|     v0_36(void)           = ExitFunction                 : 
 
 #  122| void MergeMustExactlyOverlap(bool, int, int)
 #  122|   Block 0
@@ -819,30 +819,30 @@ ssa.cpp:
 
 #  207| int ModeledCallTarget(int)
 #  207|   Block 0
-#  207|     v0_0(void)           = EnterFunction              : 
-#  207|     m0_1(unknown)        = AliasedDefinition          : 
-#  207|     mu0_2(unknown)       = UnmodeledDefinition        : 
-#  207|     r0_3(glval<int>)     = VariableAddress[x]         : 
-#  207|     m0_4(int)            = InitializeParameter[x]     : &:r0_3
-#  207|     m0_5(unknown)        = Chi                        : total:m0_1, partial:m0_4
-#  208|     r0_6(glval<int>)     = VariableAddress[y]         : 
-#  208|     m0_7(int)            = Uninitialized[y]           : &:r0_6
-#  208|     m0_8(unknown)        = Chi                        : total:m0_5, partial:m0_7
-#  209|     r0_9(glval<unknown>) = FunctionAddress[memcpy]    : 
-#  209|     r0_10(glval<int>)    = VariableAddress[y]         : 
-#  209|     r0_11(void *)        = Convert                    : r0_10
-#  209|     r0_12(glval<int>)    = VariableAddress[x]         : 
-#  209|     r0_13(void *)        = Convert                    : r0_12
-#  209|     r0_14(int)           = Constant[4]                : 
-#  209|     r0_15(void *)        = Call                       : func:r0_9, 0:r0_11, 1:r0_13, 2:r0_14
-#  209|     v0_16(void)          = ^BufferReadSideEffect      : &:r0_13, ~m0_4
-#  209|     m0_17(unknown)       = ^BufferMustWriteSideEffect : &:r0_11
-#  209|     m0_18(unknown)       = Chi                        : total:m0_8, partial:m0_17
-#  210|     r0_19(glval<int>)    = VariableAddress[#return]   : 
-#  210|     r0_20(glval<int>)    = VariableAddress[y]         : 
-#  210|     r0_21(int)           = Load                       : &:r0_20, ~m0_18
-#  210|     m0_22(int)           = Store                      : &:r0_19, r0_21
-#  207|     r0_23(glval<int>)    = VariableAddress[#return]   : 
-#  207|     v0_24(void)          = ReturnValue                : &:r0_23, m0_22
-#  207|     v0_25(void)          = UnmodeledUse               : mu*
-#  207|     v0_26(void)          = ExitFunction               : 
+#  207|     v0_0(void)           = EnterFunction                      : 
+#  207|     m0_1(unknown)        = AliasedDefinition                  : 
+#  207|     mu0_2(unknown)       = UnmodeledDefinition                : 
+#  207|     r0_3(glval<int>)     = VariableAddress[x]                 : 
+#  207|     m0_4(int)            = InitializeParameter[x]             : &:r0_3
+#  207|     m0_5(unknown)        = Chi                                : total:m0_1, partial:m0_4
+#  208|     r0_6(glval<int>)     = VariableAddress[y]                 : 
+#  208|     m0_7(int)            = Uninitialized[y]                   : &:r0_6
+#  208|     m0_8(unknown)        = Chi                                : total:m0_5, partial:m0_7
+#  209|     r0_9(glval<unknown>) = FunctionAddress[memcpy]            : 
+#  209|     r0_10(glval<int>)    = VariableAddress[y]                 : 
+#  209|     r0_11(void *)        = Convert                            : r0_10
+#  209|     r0_12(glval<int>)    = VariableAddress[x]                 : 
+#  209|     r0_13(void *)        = Convert                            : r0_12
+#  209|     r0_14(int)           = Constant[4]                        : 
+#  209|     r0_15(void *)        = Call                               : func:r0_9, 0:r0_11, 1:r0_13, 2:r0_14
+#  209|     v0_16(void)          = ^SizedBufferReadSideEffect[1]      : &:r0_13, r0_14, ~mu0_2
+#  209|     m0_17(unknown)       = ^SizedBufferMustWriteSideEffect[0] : &:r0_11, r0_14
+#  209|     m0_18(unknown)       = Chi                                : total:m0_8, partial:m0_17
+#  210|     r0_19(glval<int>)    = VariableAddress[#return]           : 
+#  210|     r0_20(glval<int>)    = VariableAddress[y]                 : 
+#  210|     r0_21(int)           = Load                               : &:r0_20, ~m0_18
+#  210|     m0_22(int)           = Store                              : &:r0_19, r0_21
+#  207|     r0_23(glval<int>)    = VariableAddress[#return]           : 
+#  207|     v0_24(void)          = ReturnValue                        : &:r0_23, m0_22
+#  207|     v0_25(void)          = UnmodeledUse                       : mu*
+#  207|     v0_26(void)          = ExitFunction                       : 

--- a/cpp/ql/test/library-tests/ir/ssa/ssa.cpp
+++ b/cpp/ql/test/library-tests/ir/ssa/ssa.cpp
@@ -201,3 +201,12 @@ int PureFunctions(char *str1, char *str2, int x) {
   ret += abs(x);
   return ret;
 }
+
+void *memcpy(void *dst, void *src, int size);
+
+int ModeledCallTarget(int x) {
+  int y;
+  memcpy(&y, &x, sizeof(int));
+  return y;
+}
+

--- a/cpp/ql/test/library-tests/ir/ssa/unaliased_ssa_ir.expected
+++ b/cpp/ql/test/library-tests/ir/ssa/unaliased_ssa_ir.expected
@@ -327,7 +327,7 @@ ssa.cpp:
 #   97|     v0_12(void)          = Call                         : func:r0_9, 0:r0_11
 #   97|     mu0_13(unknown)      = ^CallSideEffect              : ~mu0_2
 #   97|     v0_14(void)          = ^IndirectReadSideEffect[0]   : &:r0_11, ~mu0_2
-#   97|     mu0_15(unknown)      = ^BufferMayWriteSideEffect[0] : &:r0_11, ~mu0_2
+#   97|     mu0_15(unknown)      = ^BufferMayWriteSideEffect[0] : &:r0_11
 #   98|     v0_16(void)          = NoOp                         : 
 #   95|     v0_17(void)          = ReturnVoid                   : 
 #   95|     v0_18(void)          = UnmodeledUse                 : mu*
@@ -378,7 +378,7 @@ ssa.cpp:
 #  108|     v0_18(void)           = Call                         : func:r0_15, 0:r0_17
 #  108|     mu0_19(unknown)       = ^CallSideEffect              : ~mu0_2
 #  108|     v0_20(void)           = ^IndirectReadSideEffect[0]   : &:r0_17, ~mu0_2
-#  108|     mu0_21(unknown)       = ^BufferMayWriteSideEffect[0] : &:r0_17, ~mu0_2
+#  108|     mu0_21(unknown)       = ^BufferMayWriteSideEffect[0] : &:r0_17
 #  109|     v0_22(void)           = NoOp                         : 
 #  105|     v0_23(void)           = ReturnVoid                   : 
 #  105|     v0_24(void)           = UnmodeledUse                 : mu*
@@ -441,7 +441,7 @@ ssa.cpp:
 #  119|     v0_24(void)           = Call                         : func:r0_21, 0:r0_23
 #  119|     mu0_25(unknown)       = ^CallSideEffect              : ~mu0_2
 #  119|     v0_26(void)           = ^IndirectReadSideEffect[0]   : &:r0_23, ~mu0_2
-#  119|     mu0_27(unknown)       = ^BufferMayWriteSideEffect[0] : &:r0_23, ~mu0_2
+#  119|     mu0_27(unknown)       = ^BufferMayWriteSideEffect[0] : &:r0_23
 #  120|     v0_28(void)           = NoOp                         : 
 #  116|     v0_29(void)           = ReturnVoid                   : 
 #  116|     v0_30(void)           = UnmodeledUse                 : mu*

--- a/cpp/ql/test/library-tests/ir/ssa/unaliased_ssa_ir.expected
+++ b/cpp/ql/test/library-tests/ir/ssa/unaliased_ssa_ir.expected
@@ -312,24 +312,26 @@ ssa.cpp:
 
 #   95| void MustExactlyOverlapEscaped(Point)
 #   95|   Block 0
-#   95|     v0_0(void)           = EnterFunction           : 
-#   95|     mu0_1(unknown)       = AliasedDefinition       : 
-#   95|     mu0_2(unknown)       = UnmodeledDefinition     : 
-#   95|     r0_3(glval<Point>)   = VariableAddress[a]      : 
-#   95|     mu0_4(Point)         = InitializeParameter[a]  : &:r0_3
-#   96|     r0_5(glval<Point>)   = VariableAddress[b]      : 
-#   96|     r0_6(glval<Point>)   = VariableAddress[a]      : 
-#   96|     r0_7(Point)          = Load                    : &:r0_6, ~mu0_2
-#   96|     m0_8(Point)          = Store                   : &:r0_5, r0_7
-#   97|     r0_9(glval<unknown>) = FunctionAddress[Escape] : 
-#   97|     r0_10(glval<Point>)  = VariableAddress[a]      : 
-#   97|     r0_11(void *)        = Convert                 : r0_10
-#   97|     v0_12(void)          = Call                    : func:r0_9, 0:r0_11
-#   97|     mu0_13(unknown)      = ^CallSideEffect         : ~mu0_2
-#   98|     v0_14(void)          = NoOp                    : 
-#   95|     v0_15(void)          = ReturnVoid              : 
-#   95|     v0_16(void)          = UnmodeledUse            : mu*
-#   95|     v0_17(void)          = ExitFunction            : 
+#   95|     v0_0(void)           = EnterFunction                : 
+#   95|     mu0_1(unknown)       = AliasedDefinition            : 
+#   95|     mu0_2(unknown)       = UnmodeledDefinition          : 
+#   95|     r0_3(glval<Point>)   = VariableAddress[a]           : 
+#   95|     mu0_4(Point)         = InitializeParameter[a]       : &:r0_3
+#   96|     r0_5(glval<Point>)   = VariableAddress[b]           : 
+#   96|     r0_6(glval<Point>)   = VariableAddress[a]           : 
+#   96|     r0_7(Point)          = Load                         : &:r0_6, ~mu0_2
+#   96|     m0_8(Point)          = Store                        : &:r0_5, r0_7
+#   97|     r0_9(glval<unknown>) = FunctionAddress[Escape]      : 
+#   97|     r0_10(glval<Point>)  = VariableAddress[a]           : 
+#   97|     r0_11(void *)        = Convert                      : r0_10
+#   97|     v0_12(void)          = Call                         : func:r0_9, 0:r0_11
+#   97|     mu0_13(unknown)      = ^CallSideEffect              : ~mu0_2
+#   97|     v0_14(void)          = ^IndirectReadSideEffect[p]   : &:r0_11, ~mu0_2
+#   97|     mu0_15(unknown)      = ^BufferMayWriteSideEffect[p] : &:r0_11, ~mu0_2
+#   98|     v0_16(void)          = NoOp                         : 
+#   95|     v0_17(void)          = ReturnVoid                   : 
+#   95|     v0_18(void)          = UnmodeledUse                 : mu*
+#   95|     v0_19(void)          = ExitFunction                 : 
 
 #  100| void MustTotallyOverlap(Point)
 #  100|   Block 0
@@ -355,30 +357,32 @@ ssa.cpp:
 
 #  105| void MustTotallyOverlapEscaped(Point)
 #  105|   Block 0
-#  105|     v0_0(void)            = EnterFunction           : 
-#  105|     mu0_1(unknown)        = AliasedDefinition       : 
-#  105|     mu0_2(unknown)        = UnmodeledDefinition     : 
-#  105|     r0_3(glval<Point>)    = VariableAddress[a]      : 
-#  105|     mu0_4(Point)          = InitializeParameter[a]  : &:r0_3
-#  106|     r0_5(glval<int>)      = VariableAddress[x]      : 
-#  106|     r0_6(glval<Point>)    = VariableAddress[a]      : 
-#  106|     r0_7(glval<int>)      = FieldAddress[x]         : r0_6
-#  106|     r0_8(int)             = Load                    : &:r0_7, ~mu0_2
-#  106|     m0_9(int)             = Store                   : &:r0_5, r0_8
-#  107|     r0_10(glval<int>)     = VariableAddress[y]      : 
-#  107|     r0_11(glval<Point>)   = VariableAddress[a]      : 
-#  107|     r0_12(glval<int>)     = FieldAddress[y]         : r0_11
-#  107|     r0_13(int)            = Load                    : &:r0_12, ~mu0_2
-#  107|     m0_14(int)            = Store                   : &:r0_10, r0_13
-#  108|     r0_15(glval<unknown>) = FunctionAddress[Escape] : 
-#  108|     r0_16(glval<Point>)   = VariableAddress[a]      : 
-#  108|     r0_17(void *)         = Convert                 : r0_16
-#  108|     v0_18(void)           = Call                    : func:r0_15, 0:r0_17
-#  108|     mu0_19(unknown)       = ^CallSideEffect         : ~mu0_2
-#  109|     v0_20(void)           = NoOp                    : 
-#  105|     v0_21(void)           = ReturnVoid              : 
-#  105|     v0_22(void)           = UnmodeledUse            : mu*
-#  105|     v0_23(void)           = ExitFunction            : 
+#  105|     v0_0(void)            = EnterFunction                : 
+#  105|     mu0_1(unknown)        = AliasedDefinition            : 
+#  105|     mu0_2(unknown)        = UnmodeledDefinition          : 
+#  105|     r0_3(glval<Point>)    = VariableAddress[a]           : 
+#  105|     mu0_4(Point)          = InitializeParameter[a]       : &:r0_3
+#  106|     r0_5(glval<int>)      = VariableAddress[x]           : 
+#  106|     r0_6(glval<Point>)    = VariableAddress[a]           : 
+#  106|     r0_7(glval<int>)      = FieldAddress[x]              : r0_6
+#  106|     r0_8(int)             = Load                         : &:r0_7, ~mu0_2
+#  106|     m0_9(int)             = Store                        : &:r0_5, r0_8
+#  107|     r0_10(glval<int>)     = VariableAddress[y]           : 
+#  107|     r0_11(glval<Point>)   = VariableAddress[a]           : 
+#  107|     r0_12(glval<int>)     = FieldAddress[y]              : r0_11
+#  107|     r0_13(int)            = Load                         : &:r0_12, ~mu0_2
+#  107|     m0_14(int)            = Store                        : &:r0_10, r0_13
+#  108|     r0_15(glval<unknown>) = FunctionAddress[Escape]      : 
+#  108|     r0_16(glval<Point>)   = VariableAddress[a]           : 
+#  108|     r0_17(void *)         = Convert                      : r0_16
+#  108|     v0_18(void)           = Call                         : func:r0_15, 0:r0_17
+#  108|     mu0_19(unknown)       = ^CallSideEffect              : ~mu0_2
+#  108|     v0_20(void)           = ^IndirectReadSideEffect[p]   : &:r0_17, ~mu0_2
+#  108|     mu0_21(unknown)       = ^BufferMayWriteSideEffect[p] : &:r0_17, ~mu0_2
+#  109|     v0_22(void)           = NoOp                         : 
+#  105|     v0_23(void)           = ReturnVoid                   : 
+#  105|     v0_24(void)           = UnmodeledUse                 : mu*
+#  105|     v0_25(void)           = ExitFunction                 : 
 
 #  111| void MayPartiallyOverlap(int, int)
 #  111|   Block 0
@@ -410,36 +414,38 @@ ssa.cpp:
 
 #  116| void MayPartiallyOverlapEscaped(int, int)
 #  116|   Block 0
-#  116|     v0_0(void)            = EnterFunction           : 
-#  116|     mu0_1(unknown)        = AliasedDefinition       : 
-#  116|     mu0_2(unknown)        = UnmodeledDefinition     : 
-#  116|     r0_3(glval<int>)      = VariableAddress[x]      : 
-#  116|     m0_4(int)             = InitializeParameter[x]  : &:r0_3
-#  116|     r0_5(glval<int>)      = VariableAddress[y]      : 
-#  116|     m0_6(int)             = InitializeParameter[y]  : &:r0_5
-#  117|     r0_7(glval<Point>)    = VariableAddress[a]      : 
-#  117|     mu0_8(Point)          = Uninitialized[a]        : &:r0_7
-#  117|     r0_9(glval<int>)      = FieldAddress[x]         : r0_7
-#  117|     r0_10(glval<int>)     = VariableAddress[x]      : 
-#  117|     r0_11(int)            = Load                    : &:r0_10, m0_4
-#  117|     mu0_12(int)           = Store                   : &:r0_9, r0_11
-#  117|     r0_13(glval<int>)     = FieldAddress[y]         : r0_7
-#  117|     r0_14(glval<int>)     = VariableAddress[y]      : 
-#  117|     r0_15(int)            = Load                    : &:r0_14, m0_6
-#  117|     mu0_16(int)           = Store                   : &:r0_13, r0_15
-#  118|     r0_17(glval<Point>)   = VariableAddress[b]      : 
-#  118|     r0_18(glval<Point>)   = VariableAddress[a]      : 
-#  118|     r0_19(Point)          = Load                    : &:r0_18, ~mu0_2
-#  118|     m0_20(Point)          = Store                   : &:r0_17, r0_19
-#  119|     r0_21(glval<unknown>) = FunctionAddress[Escape] : 
-#  119|     r0_22(glval<Point>)   = VariableAddress[a]      : 
-#  119|     r0_23(void *)         = Convert                 : r0_22
-#  119|     v0_24(void)           = Call                    : func:r0_21, 0:r0_23
-#  119|     mu0_25(unknown)       = ^CallSideEffect         : ~mu0_2
-#  120|     v0_26(void)           = NoOp                    : 
-#  116|     v0_27(void)           = ReturnVoid              : 
-#  116|     v0_28(void)           = UnmodeledUse            : mu*
-#  116|     v0_29(void)           = ExitFunction            : 
+#  116|     v0_0(void)            = EnterFunction                : 
+#  116|     mu0_1(unknown)        = AliasedDefinition            : 
+#  116|     mu0_2(unknown)        = UnmodeledDefinition          : 
+#  116|     r0_3(glval<int>)      = VariableAddress[x]           : 
+#  116|     m0_4(int)             = InitializeParameter[x]       : &:r0_3
+#  116|     r0_5(glval<int>)      = VariableAddress[y]           : 
+#  116|     m0_6(int)             = InitializeParameter[y]       : &:r0_5
+#  117|     r0_7(glval<Point>)    = VariableAddress[a]           : 
+#  117|     mu0_8(Point)          = Uninitialized[a]             : &:r0_7
+#  117|     r0_9(glval<int>)      = FieldAddress[x]              : r0_7
+#  117|     r0_10(glval<int>)     = VariableAddress[x]           : 
+#  117|     r0_11(int)            = Load                         : &:r0_10, m0_4
+#  117|     mu0_12(int)           = Store                        : &:r0_9, r0_11
+#  117|     r0_13(glval<int>)     = FieldAddress[y]              : r0_7
+#  117|     r0_14(glval<int>)     = VariableAddress[y]           : 
+#  117|     r0_15(int)            = Load                         : &:r0_14, m0_6
+#  117|     mu0_16(int)           = Store                        : &:r0_13, r0_15
+#  118|     r0_17(glval<Point>)   = VariableAddress[b]           : 
+#  118|     r0_18(glval<Point>)   = VariableAddress[a]           : 
+#  118|     r0_19(Point)          = Load                         : &:r0_18, ~mu0_2
+#  118|     m0_20(Point)          = Store                        : &:r0_17, r0_19
+#  119|     r0_21(glval<unknown>) = FunctionAddress[Escape]      : 
+#  119|     r0_22(glval<Point>)   = VariableAddress[a]           : 
+#  119|     r0_23(void *)         = Convert                      : r0_22
+#  119|     v0_24(void)           = Call                         : func:r0_21, 0:r0_23
+#  119|     mu0_25(unknown)       = ^CallSideEffect              : ~mu0_2
+#  119|     v0_26(void)           = ^IndirectReadSideEffect[p]   : &:r0_23, ~mu0_2
+#  119|     mu0_27(unknown)       = ^BufferMayWriteSideEffect[p] : &:r0_23, ~mu0_2
+#  120|     v0_28(void)           = NoOp                         : 
+#  116|     v0_29(void)           = ReturnVoid                   : 
+#  116|     v0_30(void)           = UnmodeledUse                 : mu*
+#  116|     v0_31(void)           = ExitFunction                 : 
 
 #  122| void MergeMustExactlyOverlap(bool, int, int)
 #  122|   Block 0
@@ -773,3 +779,30 @@ ssa.cpp:
 #  198|     v0_43(void)           = ReturnValue               : &:r0_42, m0_41
 #  198|     v0_44(void)           = UnmodeledUse              : mu*
 #  198|     v0_45(void)           = ExitFunction              : 
+
+#  207| int ModeledCallTarget(int)
+#  207|   Block 0
+#  207|     v0_0(void)           = EnterFunction                   : 
+#  207|     mu0_1(unknown)       = AliasedDefinition               : 
+#  207|     mu0_2(unknown)       = UnmodeledDefinition             : 
+#  207|     r0_3(glval<int>)     = VariableAddress[x]              : 
+#  207|     mu0_4(int)           = InitializeParameter[x]          : &:r0_3
+#  208|     r0_5(glval<int>)     = VariableAddress[y]              : 
+#  208|     mu0_6(int)           = Uninitialized[y]                : &:r0_5
+#  209|     r0_7(glval<unknown>) = FunctionAddress[memcpy]         : 
+#  209|     r0_8(glval<int>)     = VariableAddress[y]              : 
+#  209|     r0_9(void *)         = Convert                         : r0_8
+#  209|     r0_10(glval<int>)    = VariableAddress[x]              : 
+#  209|     r0_11(void *)        = Convert                         : r0_10
+#  209|     r0_12(int)           = Constant[4]                     : 
+#  209|     r0_13(void *)        = Call                            : func:r0_7, 0:r0_9, 1:r0_11, 2:r0_12
+#  209|     v0_14(void)          = ^BufferReadSideEffect[src]      : &:r0_11, ~mu0_2
+#  209|     mu0_15(unknown)      = ^BufferMustWriteSideEffect[dst] : &:r0_9
+#  210|     r0_16(glval<int>)    = VariableAddress[#return]        : 
+#  210|     r0_17(glval<int>)    = VariableAddress[y]              : 
+#  210|     r0_18(int)           = Load                            : &:r0_17, ~mu0_2
+#  210|     m0_19(int)           = Store                           : &:r0_16, r0_18
+#  207|     r0_20(glval<int>)    = VariableAddress[#return]        : 
+#  207|     v0_21(void)          = ReturnValue                     : &:r0_20, m0_19
+#  207|     v0_22(void)          = UnmodeledUse                    : mu*
+#  207|     v0_23(void)          = ExitFunction                    : 

--- a/cpp/ql/test/library-tests/ir/ssa/unaliased_ssa_ir.expected
+++ b/cpp/ql/test/library-tests/ir/ssa/unaliased_ssa_ir.expected
@@ -312,26 +312,26 @@ ssa.cpp:
 
 #   95| void MustExactlyOverlapEscaped(Point)
 #   95|   Block 0
-#   95|     v0_0(void)           = EnterFunction                : 
-#   95|     mu0_1(unknown)       = AliasedDefinition            : 
-#   95|     mu0_2(unknown)       = UnmodeledDefinition          : 
-#   95|     r0_3(glval<Point>)   = VariableAddress[a]           : 
-#   95|     mu0_4(Point)         = InitializeParameter[a]       : &:r0_3
-#   96|     r0_5(glval<Point>)   = VariableAddress[b]           : 
-#   96|     r0_6(glval<Point>)   = VariableAddress[a]           : 
-#   96|     r0_7(Point)          = Load                         : &:r0_6, ~mu0_2
-#   96|     m0_8(Point)          = Store                        : &:r0_5, r0_7
-#   97|     r0_9(glval<unknown>) = FunctionAddress[Escape]      : 
-#   97|     r0_10(glval<Point>)  = VariableAddress[a]           : 
-#   97|     r0_11(void *)        = Convert                      : r0_10
-#   97|     v0_12(void)          = Call                         : func:r0_9, 0:r0_11
-#   97|     mu0_13(unknown)      = ^CallSideEffect              : ~mu0_2
-#   97|     v0_14(void)          = ^IndirectReadSideEffect[p]   : &:r0_11, ~mu0_2
-#   97|     mu0_15(unknown)      = ^BufferMayWriteSideEffect[p] : &:r0_11, ~mu0_2
-#   98|     v0_16(void)          = NoOp                         : 
-#   95|     v0_17(void)          = ReturnVoid                   : 
-#   95|     v0_18(void)          = UnmodeledUse                 : mu*
-#   95|     v0_19(void)          = ExitFunction                 : 
+#   95|     v0_0(void)           = EnterFunction             : 
+#   95|     mu0_1(unknown)       = AliasedDefinition         : 
+#   95|     mu0_2(unknown)       = UnmodeledDefinition       : 
+#   95|     r0_3(glval<Point>)   = VariableAddress[a]        : 
+#   95|     mu0_4(Point)         = InitializeParameter[a]    : &:r0_3
+#   96|     r0_5(glval<Point>)   = VariableAddress[b]        : 
+#   96|     r0_6(glval<Point>)   = VariableAddress[a]        : 
+#   96|     r0_7(Point)          = Load                      : &:r0_6, ~mu0_2
+#   96|     m0_8(Point)          = Store                     : &:r0_5, r0_7
+#   97|     r0_9(glval<unknown>) = FunctionAddress[Escape]   : 
+#   97|     r0_10(glval<Point>)  = VariableAddress[a]        : 
+#   97|     r0_11(void *)        = Convert                   : r0_10
+#   97|     v0_12(void)          = Call                      : func:r0_9, 0:r0_11
+#   97|     mu0_13(unknown)      = ^CallSideEffect           : ~mu0_2
+#   97|     v0_14(void)          = ^IndirectReadSideEffect   : &:r0_11, ~mu0_2
+#   97|     mu0_15(unknown)      = ^BufferMayWriteSideEffect : &:r0_11, ~mu0_2
+#   98|     v0_16(void)          = NoOp                      : 
+#   95|     v0_17(void)          = ReturnVoid                : 
+#   95|     v0_18(void)          = UnmodeledUse              : mu*
+#   95|     v0_19(void)          = ExitFunction              : 
 
 #  100| void MustTotallyOverlap(Point)
 #  100|   Block 0
@@ -357,32 +357,32 @@ ssa.cpp:
 
 #  105| void MustTotallyOverlapEscaped(Point)
 #  105|   Block 0
-#  105|     v0_0(void)            = EnterFunction                : 
-#  105|     mu0_1(unknown)        = AliasedDefinition            : 
-#  105|     mu0_2(unknown)        = UnmodeledDefinition          : 
-#  105|     r0_3(glval<Point>)    = VariableAddress[a]           : 
-#  105|     mu0_4(Point)          = InitializeParameter[a]       : &:r0_3
-#  106|     r0_5(glval<int>)      = VariableAddress[x]           : 
-#  106|     r0_6(glval<Point>)    = VariableAddress[a]           : 
-#  106|     r0_7(glval<int>)      = FieldAddress[x]              : r0_6
-#  106|     r0_8(int)             = Load                         : &:r0_7, ~mu0_2
-#  106|     m0_9(int)             = Store                        : &:r0_5, r0_8
-#  107|     r0_10(glval<int>)     = VariableAddress[y]           : 
-#  107|     r0_11(glval<Point>)   = VariableAddress[a]           : 
-#  107|     r0_12(glval<int>)     = FieldAddress[y]              : r0_11
-#  107|     r0_13(int)            = Load                         : &:r0_12, ~mu0_2
-#  107|     m0_14(int)            = Store                        : &:r0_10, r0_13
-#  108|     r0_15(glval<unknown>) = FunctionAddress[Escape]      : 
-#  108|     r0_16(glval<Point>)   = VariableAddress[a]           : 
-#  108|     r0_17(void *)         = Convert                      : r0_16
-#  108|     v0_18(void)           = Call                         : func:r0_15, 0:r0_17
-#  108|     mu0_19(unknown)       = ^CallSideEffect              : ~mu0_2
-#  108|     v0_20(void)           = ^IndirectReadSideEffect[p]   : &:r0_17, ~mu0_2
-#  108|     mu0_21(unknown)       = ^BufferMayWriteSideEffect[p] : &:r0_17, ~mu0_2
-#  109|     v0_22(void)           = NoOp                         : 
-#  105|     v0_23(void)           = ReturnVoid                   : 
-#  105|     v0_24(void)           = UnmodeledUse                 : mu*
-#  105|     v0_25(void)           = ExitFunction                 : 
+#  105|     v0_0(void)            = EnterFunction             : 
+#  105|     mu0_1(unknown)        = AliasedDefinition         : 
+#  105|     mu0_2(unknown)        = UnmodeledDefinition       : 
+#  105|     r0_3(glval<Point>)    = VariableAddress[a]        : 
+#  105|     mu0_4(Point)          = InitializeParameter[a]    : &:r0_3
+#  106|     r0_5(glval<int>)      = VariableAddress[x]        : 
+#  106|     r0_6(glval<Point>)    = VariableAddress[a]        : 
+#  106|     r0_7(glval<int>)      = FieldAddress[x]           : r0_6
+#  106|     r0_8(int)             = Load                      : &:r0_7, ~mu0_2
+#  106|     m0_9(int)             = Store                     : &:r0_5, r0_8
+#  107|     r0_10(glval<int>)     = VariableAddress[y]        : 
+#  107|     r0_11(glval<Point>)   = VariableAddress[a]        : 
+#  107|     r0_12(glval<int>)     = FieldAddress[y]           : r0_11
+#  107|     r0_13(int)            = Load                      : &:r0_12, ~mu0_2
+#  107|     m0_14(int)            = Store                     : &:r0_10, r0_13
+#  108|     r0_15(glval<unknown>) = FunctionAddress[Escape]   : 
+#  108|     r0_16(glval<Point>)   = VariableAddress[a]        : 
+#  108|     r0_17(void *)         = Convert                   : r0_16
+#  108|     v0_18(void)           = Call                      : func:r0_15, 0:r0_17
+#  108|     mu0_19(unknown)       = ^CallSideEffect           : ~mu0_2
+#  108|     v0_20(void)           = ^IndirectReadSideEffect   : &:r0_17, ~mu0_2
+#  108|     mu0_21(unknown)       = ^BufferMayWriteSideEffect : &:r0_17, ~mu0_2
+#  109|     v0_22(void)           = NoOp                      : 
+#  105|     v0_23(void)           = ReturnVoid                : 
+#  105|     v0_24(void)           = UnmodeledUse              : mu*
+#  105|     v0_25(void)           = ExitFunction              : 
 
 #  111| void MayPartiallyOverlap(int, int)
 #  111|   Block 0
@@ -414,38 +414,38 @@ ssa.cpp:
 
 #  116| void MayPartiallyOverlapEscaped(int, int)
 #  116|   Block 0
-#  116|     v0_0(void)            = EnterFunction                : 
-#  116|     mu0_1(unknown)        = AliasedDefinition            : 
-#  116|     mu0_2(unknown)        = UnmodeledDefinition          : 
-#  116|     r0_3(glval<int>)      = VariableAddress[x]           : 
-#  116|     m0_4(int)             = InitializeParameter[x]       : &:r0_3
-#  116|     r0_5(glval<int>)      = VariableAddress[y]           : 
-#  116|     m0_6(int)             = InitializeParameter[y]       : &:r0_5
-#  117|     r0_7(glval<Point>)    = VariableAddress[a]           : 
-#  117|     mu0_8(Point)          = Uninitialized[a]             : &:r0_7
-#  117|     r0_9(glval<int>)      = FieldAddress[x]              : r0_7
-#  117|     r0_10(glval<int>)     = VariableAddress[x]           : 
-#  117|     r0_11(int)            = Load                         : &:r0_10, m0_4
-#  117|     mu0_12(int)           = Store                        : &:r0_9, r0_11
-#  117|     r0_13(glval<int>)     = FieldAddress[y]              : r0_7
-#  117|     r0_14(glval<int>)     = VariableAddress[y]           : 
-#  117|     r0_15(int)            = Load                         : &:r0_14, m0_6
-#  117|     mu0_16(int)           = Store                        : &:r0_13, r0_15
-#  118|     r0_17(glval<Point>)   = VariableAddress[b]           : 
-#  118|     r0_18(glval<Point>)   = VariableAddress[a]           : 
-#  118|     r0_19(Point)          = Load                         : &:r0_18, ~mu0_2
-#  118|     m0_20(Point)          = Store                        : &:r0_17, r0_19
-#  119|     r0_21(glval<unknown>) = FunctionAddress[Escape]      : 
-#  119|     r0_22(glval<Point>)   = VariableAddress[a]           : 
-#  119|     r0_23(void *)         = Convert                      : r0_22
-#  119|     v0_24(void)           = Call                         : func:r0_21, 0:r0_23
-#  119|     mu0_25(unknown)       = ^CallSideEffect              : ~mu0_2
-#  119|     v0_26(void)           = ^IndirectReadSideEffect[p]   : &:r0_23, ~mu0_2
-#  119|     mu0_27(unknown)       = ^BufferMayWriteSideEffect[p] : &:r0_23, ~mu0_2
-#  120|     v0_28(void)           = NoOp                         : 
-#  116|     v0_29(void)           = ReturnVoid                   : 
-#  116|     v0_30(void)           = UnmodeledUse                 : mu*
-#  116|     v0_31(void)           = ExitFunction                 : 
+#  116|     v0_0(void)            = EnterFunction             : 
+#  116|     mu0_1(unknown)        = AliasedDefinition         : 
+#  116|     mu0_2(unknown)        = UnmodeledDefinition       : 
+#  116|     r0_3(glval<int>)      = VariableAddress[x]        : 
+#  116|     m0_4(int)             = InitializeParameter[x]    : &:r0_3
+#  116|     r0_5(glval<int>)      = VariableAddress[y]        : 
+#  116|     m0_6(int)             = InitializeParameter[y]    : &:r0_5
+#  117|     r0_7(glval<Point>)    = VariableAddress[a]        : 
+#  117|     mu0_8(Point)          = Uninitialized[a]          : &:r0_7
+#  117|     r0_9(glval<int>)      = FieldAddress[x]           : r0_7
+#  117|     r0_10(glval<int>)     = VariableAddress[x]        : 
+#  117|     r0_11(int)            = Load                      : &:r0_10, m0_4
+#  117|     mu0_12(int)           = Store                     : &:r0_9, r0_11
+#  117|     r0_13(glval<int>)     = FieldAddress[y]           : r0_7
+#  117|     r0_14(glval<int>)     = VariableAddress[y]        : 
+#  117|     r0_15(int)            = Load                      : &:r0_14, m0_6
+#  117|     mu0_16(int)           = Store                     : &:r0_13, r0_15
+#  118|     r0_17(glval<Point>)   = VariableAddress[b]        : 
+#  118|     r0_18(glval<Point>)   = VariableAddress[a]        : 
+#  118|     r0_19(Point)          = Load                      : &:r0_18, ~mu0_2
+#  118|     m0_20(Point)          = Store                     : &:r0_17, r0_19
+#  119|     r0_21(glval<unknown>) = FunctionAddress[Escape]   : 
+#  119|     r0_22(glval<Point>)   = VariableAddress[a]        : 
+#  119|     r0_23(void *)         = Convert                   : r0_22
+#  119|     v0_24(void)           = Call                      : func:r0_21, 0:r0_23
+#  119|     mu0_25(unknown)       = ^CallSideEffect           : ~mu0_2
+#  119|     v0_26(void)           = ^IndirectReadSideEffect   : &:r0_23, ~mu0_2
+#  119|     mu0_27(unknown)       = ^BufferMayWriteSideEffect : &:r0_23, ~mu0_2
+#  120|     v0_28(void)           = NoOp                      : 
+#  116|     v0_29(void)           = ReturnVoid                : 
+#  116|     v0_30(void)           = UnmodeledUse              : mu*
+#  116|     v0_31(void)           = ExitFunction              : 
 
 #  122| void MergeMustExactlyOverlap(bool, int, int)
 #  122|   Block 0
@@ -782,27 +782,27 @@ ssa.cpp:
 
 #  207| int ModeledCallTarget(int)
 #  207|   Block 0
-#  207|     v0_0(void)           = EnterFunction                   : 
-#  207|     mu0_1(unknown)       = AliasedDefinition               : 
-#  207|     mu0_2(unknown)       = UnmodeledDefinition             : 
-#  207|     r0_3(glval<int>)     = VariableAddress[x]              : 
-#  207|     mu0_4(int)           = InitializeParameter[x]          : &:r0_3
-#  208|     r0_5(glval<int>)     = VariableAddress[y]              : 
-#  208|     mu0_6(int)           = Uninitialized[y]                : &:r0_5
-#  209|     r0_7(glval<unknown>) = FunctionAddress[memcpy]         : 
-#  209|     r0_8(glval<int>)     = VariableAddress[y]              : 
-#  209|     r0_9(void *)         = Convert                         : r0_8
-#  209|     r0_10(glval<int>)    = VariableAddress[x]              : 
-#  209|     r0_11(void *)        = Convert                         : r0_10
-#  209|     r0_12(int)           = Constant[4]                     : 
-#  209|     r0_13(void *)        = Call                            : func:r0_7, 0:r0_9, 1:r0_11, 2:r0_12
-#  209|     v0_14(void)          = ^BufferReadSideEffect[src]      : &:r0_11, ~mu0_2
-#  209|     mu0_15(unknown)      = ^BufferMustWriteSideEffect[dst] : &:r0_9
-#  210|     r0_16(glval<int>)    = VariableAddress[#return]        : 
-#  210|     r0_17(glval<int>)    = VariableAddress[y]              : 
-#  210|     r0_18(int)           = Load                            : &:r0_17, ~mu0_2
-#  210|     m0_19(int)           = Store                           : &:r0_16, r0_18
-#  207|     r0_20(glval<int>)    = VariableAddress[#return]        : 
-#  207|     v0_21(void)          = ReturnValue                     : &:r0_20, m0_19
-#  207|     v0_22(void)          = UnmodeledUse                    : mu*
-#  207|     v0_23(void)          = ExitFunction                    : 
+#  207|     v0_0(void)           = EnterFunction              : 
+#  207|     mu0_1(unknown)       = AliasedDefinition          : 
+#  207|     mu0_2(unknown)       = UnmodeledDefinition        : 
+#  207|     r0_3(glval<int>)     = VariableAddress[x]         : 
+#  207|     mu0_4(int)           = InitializeParameter[x]     : &:r0_3
+#  208|     r0_5(glval<int>)     = VariableAddress[y]         : 
+#  208|     mu0_6(int)           = Uninitialized[y]           : &:r0_5
+#  209|     r0_7(glval<unknown>) = FunctionAddress[memcpy]    : 
+#  209|     r0_8(glval<int>)     = VariableAddress[y]         : 
+#  209|     r0_9(void *)         = Convert                    : r0_8
+#  209|     r0_10(glval<int>)    = VariableAddress[x]         : 
+#  209|     r0_11(void *)        = Convert                    : r0_10
+#  209|     r0_12(int)           = Constant[4]                : 
+#  209|     r0_13(void *)        = Call                       : func:r0_7, 0:r0_9, 1:r0_11, 2:r0_12
+#  209|     v0_14(void)          = ^BufferReadSideEffect      : &:r0_11, ~mu0_2
+#  209|     mu0_15(unknown)      = ^BufferMustWriteSideEffect : &:r0_9
+#  210|     r0_16(glval<int>)    = VariableAddress[#return]   : 
+#  210|     r0_17(glval<int>)    = VariableAddress[y]         : 
+#  210|     r0_18(int)           = Load                       : &:r0_17, ~mu0_2
+#  210|     m0_19(int)           = Store                      : &:r0_16, r0_18
+#  207|     r0_20(glval<int>)    = VariableAddress[#return]   : 
+#  207|     v0_21(void)          = ReturnValue                : &:r0_20, m0_19
+#  207|     v0_22(void)          = UnmodeledUse               : mu*
+#  207|     v0_23(void)          = ExitFunction               : 

--- a/cpp/ql/test/library-tests/ir/ssa/unaliased_ssa_ir.expected
+++ b/cpp/ql/test/library-tests/ir/ssa/unaliased_ssa_ir.expected
@@ -312,26 +312,26 @@ ssa.cpp:
 
 #   95| void MustExactlyOverlapEscaped(Point)
 #   95|   Block 0
-#   95|     v0_0(void)           = EnterFunction             : 
-#   95|     mu0_1(unknown)       = AliasedDefinition         : 
-#   95|     mu0_2(unknown)       = UnmodeledDefinition       : 
-#   95|     r0_3(glval<Point>)   = VariableAddress[a]        : 
-#   95|     mu0_4(Point)         = InitializeParameter[a]    : &:r0_3
-#   96|     r0_5(glval<Point>)   = VariableAddress[b]        : 
-#   96|     r0_6(glval<Point>)   = VariableAddress[a]        : 
-#   96|     r0_7(Point)          = Load                      : &:r0_6, ~mu0_2
-#   96|     m0_8(Point)          = Store                     : &:r0_5, r0_7
-#   97|     r0_9(glval<unknown>) = FunctionAddress[Escape]   : 
-#   97|     r0_10(glval<Point>)  = VariableAddress[a]        : 
-#   97|     r0_11(void *)        = Convert                   : r0_10
-#   97|     v0_12(void)          = Call                      : func:r0_9, 0:r0_11
-#   97|     mu0_13(unknown)      = ^CallSideEffect           : ~mu0_2
-#   97|     v0_14(void)          = ^IndirectReadSideEffect   : &:r0_11, ~mu0_2
-#   97|     mu0_15(unknown)      = ^BufferMayWriteSideEffect : &:r0_11, ~mu0_2
-#   98|     v0_16(void)          = NoOp                      : 
-#   95|     v0_17(void)          = ReturnVoid                : 
-#   95|     v0_18(void)          = UnmodeledUse              : mu*
-#   95|     v0_19(void)          = ExitFunction              : 
+#   95|     v0_0(void)           = EnterFunction                : 
+#   95|     mu0_1(unknown)       = AliasedDefinition            : 
+#   95|     mu0_2(unknown)       = UnmodeledDefinition          : 
+#   95|     r0_3(glval<Point>)   = VariableAddress[a]           : 
+#   95|     mu0_4(Point)         = InitializeParameter[a]       : &:r0_3
+#   96|     r0_5(glval<Point>)   = VariableAddress[b]           : 
+#   96|     r0_6(glval<Point>)   = VariableAddress[a]           : 
+#   96|     r0_7(Point)          = Load                         : &:r0_6, ~mu0_2
+#   96|     m0_8(Point)          = Store                        : &:r0_5, r0_7
+#   97|     r0_9(glval<unknown>) = FunctionAddress[Escape]      : 
+#   97|     r0_10(glval<Point>)  = VariableAddress[a]           : 
+#   97|     r0_11(void *)        = Convert                      : r0_10
+#   97|     v0_12(void)          = Call                         : func:r0_9, 0:r0_11
+#   97|     mu0_13(unknown)      = ^CallSideEffect              : ~mu0_2
+#   97|     v0_14(void)          = ^IndirectReadSideEffect[0]   : &:r0_11, ~mu0_2
+#   97|     mu0_15(unknown)      = ^BufferMayWriteSideEffect[0] : &:r0_11, ~mu0_2
+#   98|     v0_16(void)          = NoOp                         : 
+#   95|     v0_17(void)          = ReturnVoid                   : 
+#   95|     v0_18(void)          = UnmodeledUse                 : mu*
+#   95|     v0_19(void)          = ExitFunction                 : 
 
 #  100| void MustTotallyOverlap(Point)
 #  100|   Block 0
@@ -357,32 +357,32 @@ ssa.cpp:
 
 #  105| void MustTotallyOverlapEscaped(Point)
 #  105|   Block 0
-#  105|     v0_0(void)            = EnterFunction             : 
-#  105|     mu0_1(unknown)        = AliasedDefinition         : 
-#  105|     mu0_2(unknown)        = UnmodeledDefinition       : 
-#  105|     r0_3(glval<Point>)    = VariableAddress[a]        : 
-#  105|     mu0_4(Point)          = InitializeParameter[a]    : &:r0_3
-#  106|     r0_5(glval<int>)      = VariableAddress[x]        : 
-#  106|     r0_6(glval<Point>)    = VariableAddress[a]        : 
-#  106|     r0_7(glval<int>)      = FieldAddress[x]           : r0_6
-#  106|     r0_8(int)             = Load                      : &:r0_7, ~mu0_2
-#  106|     m0_9(int)             = Store                     : &:r0_5, r0_8
-#  107|     r0_10(glval<int>)     = VariableAddress[y]        : 
-#  107|     r0_11(glval<Point>)   = VariableAddress[a]        : 
-#  107|     r0_12(glval<int>)     = FieldAddress[y]           : r0_11
-#  107|     r0_13(int)            = Load                      : &:r0_12, ~mu0_2
-#  107|     m0_14(int)            = Store                     : &:r0_10, r0_13
-#  108|     r0_15(glval<unknown>) = FunctionAddress[Escape]   : 
-#  108|     r0_16(glval<Point>)   = VariableAddress[a]        : 
-#  108|     r0_17(void *)         = Convert                   : r0_16
-#  108|     v0_18(void)           = Call                      : func:r0_15, 0:r0_17
-#  108|     mu0_19(unknown)       = ^CallSideEffect           : ~mu0_2
-#  108|     v0_20(void)           = ^IndirectReadSideEffect   : &:r0_17, ~mu0_2
-#  108|     mu0_21(unknown)       = ^BufferMayWriteSideEffect : &:r0_17, ~mu0_2
-#  109|     v0_22(void)           = NoOp                      : 
-#  105|     v0_23(void)           = ReturnVoid                : 
-#  105|     v0_24(void)           = UnmodeledUse              : mu*
-#  105|     v0_25(void)           = ExitFunction              : 
+#  105|     v0_0(void)            = EnterFunction                : 
+#  105|     mu0_1(unknown)        = AliasedDefinition            : 
+#  105|     mu0_2(unknown)        = UnmodeledDefinition          : 
+#  105|     r0_3(glval<Point>)    = VariableAddress[a]           : 
+#  105|     mu0_4(Point)          = InitializeParameter[a]       : &:r0_3
+#  106|     r0_5(glval<int>)      = VariableAddress[x]           : 
+#  106|     r0_6(glval<Point>)    = VariableAddress[a]           : 
+#  106|     r0_7(glval<int>)      = FieldAddress[x]              : r0_6
+#  106|     r0_8(int)             = Load                         : &:r0_7, ~mu0_2
+#  106|     m0_9(int)             = Store                        : &:r0_5, r0_8
+#  107|     r0_10(glval<int>)     = VariableAddress[y]           : 
+#  107|     r0_11(glval<Point>)   = VariableAddress[a]           : 
+#  107|     r0_12(glval<int>)     = FieldAddress[y]              : r0_11
+#  107|     r0_13(int)            = Load                         : &:r0_12, ~mu0_2
+#  107|     m0_14(int)            = Store                        : &:r0_10, r0_13
+#  108|     r0_15(glval<unknown>) = FunctionAddress[Escape]      : 
+#  108|     r0_16(glval<Point>)   = VariableAddress[a]           : 
+#  108|     r0_17(void *)         = Convert                      : r0_16
+#  108|     v0_18(void)           = Call                         : func:r0_15, 0:r0_17
+#  108|     mu0_19(unknown)       = ^CallSideEffect              : ~mu0_2
+#  108|     v0_20(void)           = ^IndirectReadSideEffect[0]   : &:r0_17, ~mu0_2
+#  108|     mu0_21(unknown)       = ^BufferMayWriteSideEffect[0] : &:r0_17, ~mu0_2
+#  109|     v0_22(void)           = NoOp                         : 
+#  105|     v0_23(void)           = ReturnVoid                   : 
+#  105|     v0_24(void)           = UnmodeledUse                 : mu*
+#  105|     v0_25(void)           = ExitFunction                 : 
 
 #  111| void MayPartiallyOverlap(int, int)
 #  111|   Block 0
@@ -414,38 +414,38 @@ ssa.cpp:
 
 #  116| void MayPartiallyOverlapEscaped(int, int)
 #  116|   Block 0
-#  116|     v0_0(void)            = EnterFunction             : 
-#  116|     mu0_1(unknown)        = AliasedDefinition         : 
-#  116|     mu0_2(unknown)        = UnmodeledDefinition       : 
-#  116|     r0_3(glval<int>)      = VariableAddress[x]        : 
-#  116|     m0_4(int)             = InitializeParameter[x]    : &:r0_3
-#  116|     r0_5(glval<int>)      = VariableAddress[y]        : 
-#  116|     m0_6(int)             = InitializeParameter[y]    : &:r0_5
-#  117|     r0_7(glval<Point>)    = VariableAddress[a]        : 
-#  117|     mu0_8(Point)          = Uninitialized[a]          : &:r0_7
-#  117|     r0_9(glval<int>)      = FieldAddress[x]           : r0_7
-#  117|     r0_10(glval<int>)     = VariableAddress[x]        : 
-#  117|     r0_11(int)            = Load                      : &:r0_10, m0_4
-#  117|     mu0_12(int)           = Store                     : &:r0_9, r0_11
-#  117|     r0_13(glval<int>)     = FieldAddress[y]           : r0_7
-#  117|     r0_14(glval<int>)     = VariableAddress[y]        : 
-#  117|     r0_15(int)            = Load                      : &:r0_14, m0_6
-#  117|     mu0_16(int)           = Store                     : &:r0_13, r0_15
-#  118|     r0_17(glval<Point>)   = VariableAddress[b]        : 
-#  118|     r0_18(glval<Point>)   = VariableAddress[a]        : 
-#  118|     r0_19(Point)          = Load                      : &:r0_18, ~mu0_2
-#  118|     m0_20(Point)          = Store                     : &:r0_17, r0_19
-#  119|     r0_21(glval<unknown>) = FunctionAddress[Escape]   : 
-#  119|     r0_22(glval<Point>)   = VariableAddress[a]        : 
-#  119|     r0_23(void *)         = Convert                   : r0_22
-#  119|     v0_24(void)           = Call                      : func:r0_21, 0:r0_23
-#  119|     mu0_25(unknown)       = ^CallSideEffect           : ~mu0_2
-#  119|     v0_26(void)           = ^IndirectReadSideEffect   : &:r0_23, ~mu0_2
-#  119|     mu0_27(unknown)       = ^BufferMayWriteSideEffect : &:r0_23, ~mu0_2
-#  120|     v0_28(void)           = NoOp                      : 
-#  116|     v0_29(void)           = ReturnVoid                : 
-#  116|     v0_30(void)           = UnmodeledUse              : mu*
-#  116|     v0_31(void)           = ExitFunction              : 
+#  116|     v0_0(void)            = EnterFunction                : 
+#  116|     mu0_1(unknown)        = AliasedDefinition            : 
+#  116|     mu0_2(unknown)        = UnmodeledDefinition          : 
+#  116|     r0_3(glval<int>)      = VariableAddress[x]           : 
+#  116|     m0_4(int)             = InitializeParameter[x]       : &:r0_3
+#  116|     r0_5(glval<int>)      = VariableAddress[y]           : 
+#  116|     m0_6(int)             = InitializeParameter[y]       : &:r0_5
+#  117|     r0_7(glval<Point>)    = VariableAddress[a]           : 
+#  117|     mu0_8(Point)          = Uninitialized[a]             : &:r0_7
+#  117|     r0_9(glval<int>)      = FieldAddress[x]              : r0_7
+#  117|     r0_10(glval<int>)     = VariableAddress[x]           : 
+#  117|     r0_11(int)            = Load                         : &:r0_10, m0_4
+#  117|     mu0_12(int)           = Store                        : &:r0_9, r0_11
+#  117|     r0_13(glval<int>)     = FieldAddress[y]              : r0_7
+#  117|     r0_14(glval<int>)     = VariableAddress[y]           : 
+#  117|     r0_15(int)            = Load                         : &:r0_14, m0_6
+#  117|     mu0_16(int)           = Store                        : &:r0_13, r0_15
+#  118|     r0_17(glval<Point>)   = VariableAddress[b]           : 
+#  118|     r0_18(glval<Point>)   = VariableAddress[a]           : 
+#  118|     r0_19(Point)          = Load                         : &:r0_18, ~mu0_2
+#  118|     m0_20(Point)          = Store                        : &:r0_17, r0_19
+#  119|     r0_21(glval<unknown>) = FunctionAddress[Escape]      : 
+#  119|     r0_22(glval<Point>)   = VariableAddress[a]           : 
+#  119|     r0_23(void *)         = Convert                      : r0_22
+#  119|     v0_24(void)           = Call                         : func:r0_21, 0:r0_23
+#  119|     mu0_25(unknown)       = ^CallSideEffect              : ~mu0_2
+#  119|     v0_26(void)           = ^IndirectReadSideEffect[0]   : &:r0_23, ~mu0_2
+#  119|     mu0_27(unknown)       = ^BufferMayWriteSideEffect[0] : &:r0_23, ~mu0_2
+#  120|     v0_28(void)           = NoOp                         : 
+#  116|     v0_29(void)           = ReturnVoid                   : 
+#  116|     v0_30(void)           = UnmodeledUse                 : mu*
+#  116|     v0_31(void)           = ExitFunction                 : 
 
 #  122| void MergeMustExactlyOverlap(bool, int, int)
 #  122|   Block 0
@@ -782,27 +782,27 @@ ssa.cpp:
 
 #  207| int ModeledCallTarget(int)
 #  207|   Block 0
-#  207|     v0_0(void)           = EnterFunction              : 
-#  207|     mu0_1(unknown)       = AliasedDefinition          : 
-#  207|     mu0_2(unknown)       = UnmodeledDefinition        : 
-#  207|     r0_3(glval<int>)     = VariableAddress[x]         : 
-#  207|     mu0_4(int)           = InitializeParameter[x]     : &:r0_3
-#  208|     r0_5(glval<int>)     = VariableAddress[y]         : 
-#  208|     mu0_6(int)           = Uninitialized[y]           : &:r0_5
-#  209|     r0_7(glval<unknown>) = FunctionAddress[memcpy]    : 
-#  209|     r0_8(glval<int>)     = VariableAddress[y]         : 
-#  209|     r0_9(void *)         = Convert                    : r0_8
-#  209|     r0_10(glval<int>)    = VariableAddress[x]         : 
-#  209|     r0_11(void *)        = Convert                    : r0_10
-#  209|     r0_12(int)           = Constant[4]                : 
-#  209|     r0_13(void *)        = Call                       : func:r0_7, 0:r0_9, 1:r0_11, 2:r0_12
-#  209|     v0_14(void)          = ^BufferReadSideEffect      : &:r0_11, ~mu0_2
-#  209|     mu0_15(unknown)      = ^BufferMustWriteSideEffect : &:r0_9
-#  210|     r0_16(glval<int>)    = VariableAddress[#return]   : 
-#  210|     r0_17(glval<int>)    = VariableAddress[y]         : 
-#  210|     r0_18(int)           = Load                       : &:r0_17, ~mu0_2
-#  210|     m0_19(int)           = Store                      : &:r0_16, r0_18
-#  207|     r0_20(glval<int>)    = VariableAddress[#return]   : 
-#  207|     v0_21(void)          = ReturnValue                : &:r0_20, m0_19
-#  207|     v0_22(void)          = UnmodeledUse               : mu*
-#  207|     v0_23(void)          = ExitFunction               : 
+#  207|     v0_0(void)           = EnterFunction                      : 
+#  207|     mu0_1(unknown)       = AliasedDefinition                  : 
+#  207|     mu0_2(unknown)       = UnmodeledDefinition                : 
+#  207|     r0_3(glval<int>)     = VariableAddress[x]                 : 
+#  207|     mu0_4(int)           = InitializeParameter[x]             : &:r0_3
+#  208|     r0_5(glval<int>)     = VariableAddress[y]                 : 
+#  208|     mu0_6(int)           = Uninitialized[y]                   : &:r0_5
+#  209|     r0_7(glval<unknown>) = FunctionAddress[memcpy]            : 
+#  209|     r0_8(glval<int>)     = VariableAddress[y]                 : 
+#  209|     r0_9(void *)         = Convert                            : r0_8
+#  209|     r0_10(glval<int>)    = VariableAddress[x]                 : 
+#  209|     r0_11(void *)        = Convert                            : r0_10
+#  209|     r0_12(int)           = Constant[4]                        : 
+#  209|     r0_13(void *)        = Call                               : func:r0_7, 0:r0_9, 1:r0_11, 2:r0_12
+#  209|     v0_14(void)          = ^SizedBufferReadSideEffect[1]      : &:r0_11, r0_12, ~mu0_2
+#  209|     mu0_15(unknown)      = ^SizedBufferMustWriteSideEffect[0] : &:r0_9, r0_12
+#  210|     r0_16(glval<int>)    = VariableAddress[#return]           : 
+#  210|     r0_17(glval<int>)    = VariableAddress[y]                 : 
+#  210|     r0_18(int)           = Load                               : &:r0_17, ~mu0_2
+#  210|     m0_19(int)           = Store                              : &:r0_16, r0_18
+#  207|     r0_20(glval<int>)    = VariableAddress[#return]           : 
+#  207|     v0_21(void)          = ReturnValue                        : &:r0_20, m0_19
+#  207|     v0_22(void)          = UnmodeledUse                       : mu*
+#  207|     v0_23(void)          = ExitFunction                       : 

--- a/cpp/ql/test/library-tests/syntax-zoo/aliased_ssa_sanity.expected
+++ b/cpp/ql/test/library-tests/syntax-zoo/aliased_ssa_sanity.expected
@@ -1,5 +1,9 @@
 missingOperand
 | misc.c:125:5:125:11 | CopyValue: (statement expression) | Instruction 'CopyValue' is missing an expected operand with tag 'Unary' in function '$@'. | misc.c:97:6:97:10 | IR: misc3 | void misc3() |
+| parameterinitializer.cpp:27:3:27:6 | IndirectReadSideEffect: my_c | Instruction 'IndirectReadSideEffect' is missing an expected operand with tag 'SideEffect' in function '$@'. | allocators.cpp:14:5:14:8 | IR: main | int main() |
+| parameterinitializer.cpp:27:3:27:6 | IndirectReadSideEffect: my_c | Instruction 'IndirectReadSideEffect' is missing an expected operand with tag 'SideEffect' in function '$@'. | no_dynamic_init.cpp:9:5:9:8 | IR: main | int main() |
+| parameterinitializer.cpp:27:3:27:6 | IndirectReadSideEffect: my_c | Instruction 'IndirectReadSideEffect' is missing an expected operand with tag 'SideEffect' in function '$@'. | parameterinitializer.cpp:18:5:18:8 | IR: main | int main() |
+| parameterinitializer.cpp:27:3:27:6 | IndirectReadSideEffect: my_c | Instruction 'IndirectReadSideEffect' is missing an expected operand with tag 'SideEffect' in function '$@'. | stream_it.cpp:16:5:16:8 | IR: main | int main() |
 | try_catch.cpp:13:5:13:16 | ThrowValue: throw ... | Instruction 'ThrowValue' is missing an expected operand with tag 'Load' in function '$@'. | try_catch.cpp:11:6:11:17 | IR: bypass_catch | void bypass_catch() |
 unexpectedOperand
 duplicateOperand

--- a/cpp/ql/test/library-tests/syntax-zoo/raw_sanity.expected
+++ b/cpp/ql/test/library-tests/syntax-zoo/raw_sanity.expected
@@ -27,7 +27,7 @@ instructionWithoutSuccessor
 | assume0.cpp:7:2:7:2 | CallSideEffect: call to f |
 | assume0.cpp:9:11:9:11 | Constant: (bool)... |
 | condition_decls.cpp:16:19:16:20 | CallSideEffect: call to BoxedInt |
-| condition_decls.cpp:26:19:26:19 | CallSideEffect: call to operator int |
+| condition_decls.cpp:26:19:26:20 | IndirectMayWriteSideEffect: bi |
 | condition_decls.cpp:26:23:26:24 | CallSideEffect: call to BoxedInt |
 | condition_decls.cpp:41:22:41:23 | CallSideEffect: call to BoxedInt |
 | condition_decls.cpp:48:52:48:53 | CallSideEffect: call to BoxedInt |
@@ -614,12 +614,14 @@ useNotDominatedByDefinition
 | assume0.cpp:11:2:11:2 | Operand | Operand 'Operand' is not dominated by its definition in function '$@'. | assume0.cpp:5:6:5:6 | IR: h | void h() |
 | condition_decls.cpp:16:15:16:15 | Operand | Operand 'Operand' is not dominated by its definition in function '$@'. | condition_decls.cpp:15:6:15:17 | IR: if_decl_bind | void if_decl_bind(int) |
 | condition_decls.cpp:16:15:16:16 | Load | Operand 'Load' is not dominated by its definition in function '$@'. | condition_decls.cpp:15:6:15:17 | IR: if_decl_bind | void if_decl_bind(int) |
+| condition_decls.cpp:16:15:16:16 | Operand | Operand 'Operand' is not dominated by its definition in function '$@'. | condition_decls.cpp:15:6:15:17 | IR: if_decl_bind | void if_decl_bind(int) |
 | condition_decls.cpp:17:5:17:15 | Load | Operand 'Load' is not dominated by its definition in function '$@'. | condition_decls.cpp:15:6:15:17 | IR: if_decl_bind | void if_decl_bind(int) |
 | condition_decls.cpp:17:11:17:15 | Load | Operand 'Load' is not dominated by its definition in function '$@'. | condition_decls.cpp:15:6:15:17 | IR: if_decl_bind | void if_decl_bind(int) |
 | condition_decls.cpp:20:5:20:15 | Load | Operand 'Load' is not dominated by its definition in function '$@'. | condition_decls.cpp:15:6:15:17 | IR: if_decl_bind | void if_decl_bind(int) |
 | condition_decls.cpp:20:11:20:15 | Load | Operand 'Load' is not dominated by its definition in function '$@'. | condition_decls.cpp:15:6:15:17 | IR: if_decl_bind | void if_decl_bind(int) |
 | condition_decls.cpp:26:19:26:19 | Operand | Operand 'Operand' is not dominated by its definition in function '$@'. | condition_decls.cpp:25:6:25:21 | IR: switch_decl_bind | void switch_decl_bind(int) |
 | condition_decls.cpp:26:19:26:20 | Load | Operand 'Load' is not dominated by its definition in function '$@'. | condition_decls.cpp:25:6:25:21 | IR: switch_decl_bind | void switch_decl_bind(int) |
+| condition_decls.cpp:26:19:26:20 | Operand | Operand 'Operand' is not dominated by its definition in function '$@'. | condition_decls.cpp:25:6:25:21 | IR: switch_decl_bind | void switch_decl_bind(int) |
 | condition_decls.cpp:28:5:28:15 | Load | Operand 'Load' is not dominated by its definition in function '$@'. | condition_decls.cpp:25:6:25:21 | IR: switch_decl_bind | void switch_decl_bind(int) |
 | condition_decls.cpp:28:11:28:15 | Load | Operand 'Load' is not dominated by its definition in function '$@'. | condition_decls.cpp:25:6:25:21 | IR: switch_decl_bind | void switch_decl_bind(int) |
 | condition_decls.cpp:31:5:31:15 | Load | Operand 'Load' is not dominated by its definition in function '$@'. | condition_decls.cpp:25:6:25:21 | IR: switch_decl_bind | void switch_decl_bind(int) |
@@ -628,14 +630,17 @@ useNotDominatedByDefinition
 | condition_decls.cpp:34:9:34:13 | Load | Operand 'Load' is not dominated by its definition in function '$@'. | condition_decls.cpp:25:6:25:21 | IR: switch_decl_bind | void switch_decl_bind(int) |
 | condition_decls.cpp:41:18:41:18 | Operand | Operand 'Operand' is not dominated by its definition in function '$@'. | condition_decls.cpp:40:6:40:20 | IR: while_decl_bind | void while_decl_bind(int) |
 | condition_decls.cpp:41:18:41:19 | Load | Operand 'Load' is not dominated by its definition in function '$@'. | condition_decls.cpp:40:6:40:20 | IR: while_decl_bind | void while_decl_bind(int) |
+| condition_decls.cpp:41:18:41:19 | Operand | Operand 'Operand' is not dominated by its definition in function '$@'. | condition_decls.cpp:40:6:40:20 | IR: while_decl_bind | void while_decl_bind(int) |
 | condition_decls.cpp:42:5:42:7 | Load | Operand 'Load' is not dominated by its definition in function '$@'. | condition_decls.cpp:40:6:40:20 | IR: while_decl_bind | void while_decl_bind(int) |
 | condition_decls.cpp:44:3:44:5 | Load | Operand 'Load' is not dominated by its definition in function '$@'. | condition_decls.cpp:40:6:40:20 | IR: while_decl_bind | void while_decl_bind(int) |
 | condition_decls.cpp:48:48:48:48 | Operand | Operand 'Operand' is not dominated by its definition in function '$@'. | condition_decls.cpp:47:6:47:18 | IR: for_decl_bind | void for_decl_bind(int) |
 | condition_decls.cpp:48:48:48:49 | Load | Operand 'Load' is not dominated by its definition in function '$@'. | condition_decls.cpp:47:6:47:18 | IR: for_decl_bind | void for_decl_bind(int) |
+| condition_decls.cpp:48:48:48:49 | Operand | Operand 'Operand' is not dominated by its definition in function '$@'. | condition_decls.cpp:47:6:47:18 | IR: for_decl_bind | void for_decl_bind(int) |
 | condition_decls.cpp:48:56:48:61 | Load | Operand 'Load' is not dominated by its definition in function '$@'. | condition_decls.cpp:47:6:47:18 | IR: for_decl_bind | void for_decl_bind(int) |
 | condition_decls.cpp:49:5:49:7 | Load | Operand 'Load' is not dominated by its definition in function '$@'. | condition_decls.cpp:47:6:47:18 | IR: for_decl_bind | void for_decl_bind(int) |
 | condition_decls.cpp:51:3:51:5 | Load | Operand 'Load' is not dominated by its definition in function '$@'. | condition_decls.cpp:47:6:47:18 | IR: for_decl_bind | void for_decl_bind(int) |
 | cpp11.cpp:28:21:28:21 | Operand | Operand 'Operand' is not dominated by its definition in function '$@'. | cpp11.cpp:27:7:27:14 | IR: getFirst | int range_based_for_11::getFirst() |
+| file://:0:0:0:0 | Operand | Operand 'Operand' is not dominated by its definition in function '$@'. | cpp11.cpp:27:7:27:14 | IR: getFirst | int range_based_for_11::getFirst() |
 | misc.c:68:16:68:16 | Load | Operand 'Load' is not dominated by its definition in function '$@'. | misc.c:16:6:16:10 | IR: misc1 | void misc1(int, int) |
 | misc.c:70:13:70:15 | Load | Operand 'Load' is not dominated by its definition in function '$@'. | misc.c:16:6:16:10 | IR: misc1 | void misc1(int, int) |
 | misc.c:72:11:72:11 | Load | Operand 'Load' is not dominated by its definition in function '$@'. | misc.c:16:6:16:10 | IR: misc1 | void misc1(int, int) |

--- a/cpp/ql/test/library-tests/syntax-zoo/unaliased_ssa_sanity.expected
+++ b/cpp/ql/test/library-tests/syntax-zoo/unaliased_ssa_sanity.expected
@@ -1,5 +1,9 @@
 missingOperand
 | misc.c:125:5:125:11 | CopyValue: (statement expression) | Instruction 'CopyValue' is missing an expected operand with tag 'Unary' in function '$@'. | misc.c:97:6:97:10 | IR: misc3 | void misc3() |
+| parameterinitializer.cpp:27:3:27:6 | IndirectReadSideEffect: my_c | Instruction 'IndirectReadSideEffect' is missing an expected operand with tag 'SideEffect' in function '$@'. | allocators.cpp:14:5:14:8 | IR: main | int main() |
+| parameterinitializer.cpp:27:3:27:6 | IndirectReadSideEffect: my_c | Instruction 'IndirectReadSideEffect' is missing an expected operand with tag 'SideEffect' in function '$@'. | no_dynamic_init.cpp:9:5:9:8 | IR: main | int main() |
+| parameterinitializer.cpp:27:3:27:6 | IndirectReadSideEffect: my_c | Instruction 'IndirectReadSideEffect' is missing an expected operand with tag 'SideEffect' in function '$@'. | parameterinitializer.cpp:18:5:18:8 | IR: main | int main() |
+| parameterinitializer.cpp:27:3:27:6 | IndirectReadSideEffect: my_c | Instruction 'IndirectReadSideEffect' is missing an expected operand with tag 'SideEffect' in function '$@'. | stream_it.cpp:16:5:16:8 | IR: main | int main() |
 | try_catch.cpp:13:5:13:16 | ThrowValue: throw ... | Instruction 'ThrowValue' is missing an expected operand with tag 'Load' in function '$@'. | try_catch.cpp:11:6:11:17 | IR: bypass_catch | void bypass_catch() |
 unexpectedOperand
 duplicateOperand

--- a/csharp/ql/src/semmle/code/csharp/ir/implementation/Opcode.qll
+++ b/csharp/ql/src/semmle/code/csharp/ir/implementation/Opcode.qll
@@ -66,10 +66,10 @@ private newtype TOpcode =
   TCallSideEffect() or
   TCallReadSideEffect() or
   TIndirectReadSideEffect() or
-  TIndirectWriteSideEffect() or
+  TIndirectMustWriteSideEffect() or
   TIndirectMayWriteSideEffect() or
   TBufferReadSideEffect() or
-  TBufferWriteSideEffect() or
+  TBufferMustWriteSideEffect() or
   TBufferMayWriteSideEffect() or
   TChi() or
   TInlineAsm() or
@@ -136,10 +136,15 @@ abstract class ReadSideEffectOpcode extends SideEffectOpcode { }
 abstract class WriteSideEffectOpcode extends SideEffectOpcode { }
 
 /**
+ * An opcode that definitely writes to a set of memory locations as a side effect.
+ */
+abstract class MustWriteSideEffectOpcode extends WriteSideEffectOpcode { }
+
+/**
  * An opcode that may overwrite some, all, or none of an existing set of memory locations. Modeled
  * as a read of the original contents, plus a "may" write of the new contents.
  */
-abstract class MayWriteSideEffectOpcode extends SideEffectOpcode { }
+abstract class MayWriteSideEffectOpcode extends WriteSideEffectOpcode { }
 
 /**
  * An opcode that accesses a buffer via an `AddressOperand` and a `BufferSizeOperand`.
@@ -416,9 +421,9 @@ module Opcode {
     final override string toString() { result = "IndirectReadSideEffect" }
   }
 
-  class IndirectWriteSideEffect extends WriteSideEffectOpcode, MemoryAccessOpcode,
-    TIndirectWriteSideEffect {
-    final override string toString() { result = "IndirectWriteSideEffect" }
+  class IndirectMustWriteSideEffect extends MustWriteSideEffectOpcode, MemoryAccessOpcode,
+    TIndirectMustWriteSideEffect {
+    final override string toString() { result = "IndirectMustWriteSideEffect" }
   }
 
   class IndirectMayWriteSideEffect extends MayWriteSideEffectOpcode, MemoryAccessOpcode,
@@ -430,9 +435,9 @@ module Opcode {
     final override string toString() { result = "BufferReadSideEffect" }
   }
 
-  class BufferWriteSideEffect extends WriteSideEffectOpcode, BufferAccessOpcode,
-    TBufferWriteSideEffect {
-    final override string toString() { result = "BufferWriteSideEffect" }
+  class BufferMustWriteSideEffect extends MustWriteSideEffectOpcode, BufferAccessOpcode,
+    TBufferMustWriteSideEffect {
+    final override string toString() { result = "BufferMustWriteSideEffect" }
   }
 
   class BufferMayWriteSideEffect extends MayWriteSideEffectOpcode, BufferAccessOpcode,
@@ -456,3 +461,4 @@ module Opcode {
     final override string toString() { result = "NewObj" }
   }
 }
+

--- a/csharp/ql/src/semmle/code/csharp/ir/implementation/Opcode.qll
+++ b/csharp/ql/src/semmle/code/csharp/ir/implementation/Opcode.qll
@@ -71,6 +71,9 @@ private newtype TOpcode =
   TBufferReadSideEffect() or
   TBufferMustWriteSideEffect() or
   TBufferMayWriteSideEffect() or
+  TSizedBufferReadSideEffect() or
+  TSizedBufferMustWriteSideEffect() or
+  TSizedBufferMayWriteSideEffect() or
   TChi() or
   TInlineAsm() or
   TUnreached() or
@@ -147,9 +150,15 @@ abstract class MustWriteSideEffectOpcode extends WriteSideEffectOpcode { }
 abstract class MayWriteSideEffectOpcode extends WriteSideEffectOpcode { }
 
 /**
- * An opcode that accesses a buffer via an `AddressOperand` and a `BufferSizeOperand`.
+ * An opcode that accesses a buffer via an `AddressOperand`.
  */
 abstract class BufferAccessOpcode extends MemoryAccessOpcode { }
+
+/**
+ * An opcode that accesses a buffer via an `AddressOperand` with a `BufferSizeOperand` specifying
+ * the number of elements accessed.
+ */
+abstract class SizedBufferAccessOpcode extends BufferAccessOpcode { }
 
 module Opcode {
   class NoOp extends Opcode, TNoOp {
@@ -443,6 +452,21 @@ module Opcode {
   class BufferMayWriteSideEffect extends MayWriteSideEffectOpcode, BufferAccessOpcode,
     TBufferMayWriteSideEffect {
     final override string toString() { result = "BufferMayWriteSideEffect" }
+  }
+
+  class SizedBufferReadSideEffect extends ReadSideEffectOpcode, SizedBufferAccessOpcode,
+    TSizedBufferReadSideEffect {
+    final override string toString() { result = "SizedBufferReadSideEffect" }
+  }
+
+  class SizedBufferMustWriteSideEffect extends MustWriteSideEffectOpcode, SizedBufferAccessOpcode,
+    TSizedBufferMustWriteSideEffect {
+    final override string toString() { result = "SizedBufferMustWriteSideEffect" }
+  }
+
+  class SizedBufferMayWriteSideEffect extends MayWriteSideEffectOpcode, SizedBufferAccessOpcode,
+    TSizedBufferMayWriteSideEffect {
+    final override string toString() { result = "SizedBufferMayWriteSideEffect" }
   }
 
   class Chi extends Opcode, TChi {

--- a/csharp/ql/src/semmle/code/csharp/ir/implementation/Opcode.qll
+++ b/csharp/ql/src/semmle/code/csharp/ir/implementation/Opcode.qll
@@ -485,4 +485,3 @@ module Opcode {
     final override string toString() { result = "NewObj" }
   }
 }
-

--- a/csharp/ql/src/semmle/code/csharp/ir/implementation/internal/OperandTag.qll
+++ b/csharp/ql/src/semmle/code/csharp/ir/implementation/internal/OperandTag.qll
@@ -66,11 +66,13 @@ AddressOperandTag addressOperand() { result = TAddressOperand() }
  * The buffer size operand of an instruction that represents a read or write of
  * a buffer.
  */
-class BufferSizeOperand extends RegisterOperandTag, TBufferSizeOperand {
+class BufferSizeOperandTag extends RegisterOperandTag, TBufferSizeOperand {
   final override string toString() { result = "BufferSize" }
 
   final override int getSortOrder() { result = 1 }
 }
+
+BufferSizeOperandTag bufferSizeOperand() { result = TBufferSizeOperand() }
 
 /**
  * The operand representing the read side effect of a `SideEffectInstruction`.

--- a/csharp/ql/src/semmle/code/csharp/ir/implementation/raw/Instruction.qll
+++ b/csharp/ql/src/semmle/code/csharp/ir/implementation/raw/Instruction.qll
@@ -48,8 +48,8 @@ module InstructionSanity {
         or
         (
           opcode instanceof ReadSideEffectOpcode or
-          opcode instanceof MayWriteSideEffectOpcode or
-          opcode instanceof Opcode::InlineAsm
+          opcode instanceof Opcode::InlineAsm or
+          opcode instanceof Opcode::CallSideEffect
         ) and
         tag instanceof SideEffectOperandTag
       )

--- a/csharp/ql/src/semmle/code/csharp/ir/implementation/raw/Instruction.qll
+++ b/csharp/ql/src/semmle/code/csharp/ir/implementation/raw/Instruction.qll
@@ -30,7 +30,7 @@ module InstructionSanity {
         or
         opcode instanceof MemoryAccessOpcode and tag instanceof AddressOperandTag
         or
-        opcode instanceof BufferAccessOpcode and tag instanceof BufferSizeOperand
+        opcode instanceof SizedBufferAccessOpcode and tag instanceof BufferSizeOperandTag
         or
         opcode instanceof OpcodeWithCondition and tag instanceof ConditionOperandTag
         or
@@ -644,6 +644,17 @@ class ConstantValueInstruction extends Instruction {
   final string getValue() { result = value }
 }
 
+class IndexedInstruction extends Instruction {
+  int index;
+
+  IndexedInstruction() { index = Construction::getInstructionIndex(this) }
+  
+
+  final override string getImmediateString() { result = index.toString() }
+
+  final int getIndex() { result = index }
+}
+
 class EnterFunctionInstruction extends Instruction {
   EnterFunctionInstruction() { getOpcode() instanceof Opcode::EnterFunction }
 }
@@ -1176,7 +1187,7 @@ class CallReadSideEffectInstruction extends SideEffectInstruction {
 class IndirectReadSideEffectInstruction extends SideEffectInstruction {
   IndirectReadSideEffectInstruction() { getOpcode() instanceof Opcode::IndirectReadSideEffect }
 
-  Instruction getArgumentInstruction() { result = getAnOperand().(AddressOperand).getDef() }
+  Instruction getArgumentDef() { result = getAnOperand().(AddressOperand).getDef() }
 }
 
 /**
@@ -1185,7 +1196,20 @@ class IndirectReadSideEffectInstruction extends SideEffectInstruction {
 class BufferReadSideEffectInstruction extends SideEffectInstruction {
   BufferReadSideEffectInstruction() { getOpcode() instanceof Opcode::BufferReadSideEffect }
 
-  Instruction getArgumentInstruction() { result = getAnOperand().(AddressOperand).getDef() }
+  Instruction getArgumentDef() { result = getAnOperand().(AddressOperand).getDef() }
+}
+
+/**
+ * An instruction representing the read of an indirect buffer parameter within a function call.
+ */
+class SizedBufferReadSideEffectInstruction extends SideEffectInstruction {
+  SizedBufferReadSideEffectInstruction() {
+    getOpcode() instanceof Opcode::SizedBufferReadSideEffect
+  }
+
+  Instruction getArgumentDef() { result = getAnOperand().(AddressOperand).getDef() }
+
+  Instruction getSizeDef() { result = getAnOperand().(BufferSizeOperand).getDef() }
 }
 
 /**
@@ -1194,7 +1218,7 @@ class BufferReadSideEffectInstruction extends SideEffectInstruction {
 class WriteSideEffectInstruction extends SideEffectInstruction {
   WriteSideEffectInstruction() { getOpcode() instanceof WriteSideEffectOpcode }
 
-  Instruction getArgumentInstruction() { result = getAnOperand().(AddressOperand).getDef() }
+  Instruction getArgumentDef() { result = getAnOperand().(AddressOperand).getDef() }
 }
 
 /**
@@ -1218,6 +1242,20 @@ class BufferMustWriteSideEffectInstruction extends WriteSideEffectInstruction {
   }
 
   final override MemoryAccessKind getResultMemoryAccess() { result instanceof BufferMemoryAccess }
+}
+
+/**
+ * An instruction representing the write of an indirect buffer parameter within a function call. The
+ * entire buffer is overwritten.
+ */
+class SizedBufferMustWriteSideEffectInstruction extends WriteSideEffectInstruction {
+  SizedBufferMustWriteSideEffectInstruction() {
+    getOpcode() instanceof Opcode::SizedBufferMustWriteSideEffect
+  }
+
+  final override MemoryAccessKind getResultMemoryAccess() { result instanceof BufferMemoryAccess }
+
+  Instruction getSizeDef() { result = getAnOperand().(BufferSizeOperand).getDef() }
 }
 
 /**
@@ -1245,6 +1283,22 @@ class BufferMayWriteSideEffectInstruction extends WriteSideEffectInstruction {
   final override MemoryAccessKind getResultMemoryAccess() {
     result instanceof BufferMayMemoryAccess
   }
+}
+
+/**
+ * An instruction representing the write of an indirect buffer parameter within a function call.
+ * Unlike `BufferWriteSideEffectInstruction`, the buffer might not be completely overwritten.
+ */
+class SizedBufferMayWriteSideEffectInstruction extends WriteSideEffectInstruction {
+  SizedBufferMayWriteSideEffectInstruction() {
+    getOpcode() instanceof Opcode::SizedBufferMayWriteSideEffect
+  }
+
+  final override MemoryAccessKind getResultMemoryAccess() {
+    result instanceof BufferMayMemoryAccess
+  }
+
+  Instruction getSizeDef() { result = getAnOperand().(BufferSizeOperand).getDef() }
 }
 
 /**

--- a/csharp/ql/src/semmle/code/csharp/ir/implementation/raw/Instruction.qll
+++ b/csharp/ql/src/semmle/code/csharp/ir/implementation/raw/Instruction.qll
@@ -20,23 +20,32 @@ module InstructionSanity {
     exists(Opcode opcode |
       opcode = instr.getOpcode() and
       (
-        opcode instanceof UnaryOpcode and tag instanceof UnaryOperandTag or
+        opcode instanceof UnaryOpcode and tag instanceof UnaryOperandTag
+        or
+        opcode instanceof BinaryOpcode and
         (
-          opcode instanceof BinaryOpcode and
-          (
-            tag instanceof LeftOperandTag or
-            tag instanceof RightOperandTag
-          )
-        ) or
-        opcode instanceof MemoryAccessOpcode and tag instanceof AddressOperandTag or
-        opcode instanceof OpcodeWithCondition and tag instanceof ConditionOperandTag or
-        opcode instanceof OpcodeWithLoad and tag instanceof LoadOperandTag or
-        opcode instanceof Opcode::Store and tag instanceof StoreValueOperandTag or
-        opcode instanceof Opcode::UnmodeledUse and tag instanceof UnmodeledUseOperandTag or
-        opcode instanceof Opcode::Call and tag instanceof CallTargetOperandTag or
-        opcode instanceof Opcode::Chi and tag instanceof ChiTotalOperandTag or
-        opcode instanceof Opcode::Chi and tag instanceof ChiPartialOperandTag or
-
+          tag instanceof LeftOperandTag or
+          tag instanceof RightOperandTag
+        )
+        or
+        opcode instanceof MemoryAccessOpcode and tag instanceof AddressOperandTag
+        or
+        opcode instanceof BufferAccessOpcode and tag instanceof BufferSizeOperand
+        or
+        opcode instanceof OpcodeWithCondition and tag instanceof ConditionOperandTag
+        or
+        opcode instanceof OpcodeWithLoad and tag instanceof LoadOperandTag
+        or
+        opcode instanceof Opcode::Store and tag instanceof StoreValueOperandTag
+        or
+        opcode instanceof Opcode::UnmodeledUse and tag instanceof UnmodeledUseOperandTag
+        or
+        opcode instanceof Opcode::Call and tag instanceof CallTargetOperandTag
+        or
+        opcode instanceof Opcode::Chi and tag instanceof ChiTotalOperandTag
+        or
+        opcode instanceof Opcode::Chi and tag instanceof ChiPartialOperandTag
+        or
         (
           opcode instanceof ReadSideEffectOpcode or
           opcode instanceof MayWriteSideEffectOpcode or
@@ -600,9 +609,7 @@ class VariableInstruction extends Instruction {
 
   VariableInstruction() { var = Construction::getInstructionVariable(this) }
 
-  override string getImmediateString() {
-    result = var.toString()
-  }
+  override string getImmediateString() { result = var.toString() }
 
   final IRVariable getVariable() { result = var }
 }
@@ -648,9 +655,9 @@ class VariableAddressInstruction extends VariableInstruction {
 class InitializeParameterInstruction extends VariableInstruction {
   InitializeParameterInstruction() { getOpcode() instanceof Opcode::InitializeParameter }
 
-  override final MemoryAccessKind getResultMemoryAccess() {
-    result instanceof IndirectMemoryAccess
-  }
+  final Language::Parameter getParameter() { result = var.(IRUserVariable).getVariable() }
+
+  final override MemoryAccessKind getResultMemoryAccess() { result instanceof IndirectMemoryAccess }
 }
 
 /**
@@ -1167,39 +1174,27 @@ class CallReadSideEffectInstruction extends SideEffectInstruction {
  * An instruction representing the read of an indirect parameter within a function call.
  */
 class IndirectReadSideEffectInstruction extends SideEffectInstruction {
-  IndirectReadSideEffectInstruction() {
-    getOpcode() instanceof Opcode::IndirectReadSideEffect
-  }
+  IndirectReadSideEffectInstruction() { getOpcode() instanceof Opcode::IndirectReadSideEffect }
 
-  Instruction getArgumentInstruction() {
-    result = getAnOperand().(AddressOperand).getDef()
-  }
+  Instruction getArgumentInstruction() { result = getAnOperand().(AddressOperand).getDef() }
 }
 
 /**
  * An instruction representing the read of an indirect buffer parameter within a function call.
  */
 class BufferReadSideEffectInstruction extends SideEffectInstruction {
-  BufferReadSideEffectInstruction() {
-    getOpcode() instanceof Opcode::BufferReadSideEffect
-  }
+  BufferReadSideEffectInstruction() { getOpcode() instanceof Opcode::BufferReadSideEffect }
 
-  Instruction getArgumentInstruction() {
-    result = getAnOperand().(AddressOperand).getDef()
-  }
+  Instruction getArgumentInstruction() { result = getAnOperand().(AddressOperand).getDef() }
 }
 
 /**
  * An instruction representing a side effect of a function call.
  */
 class WriteSideEffectInstruction extends SideEffectInstruction {
-  WriteSideEffectInstruction() {
-    getOpcode() instanceof WriteSideEffectOpcode
-  }
+  WriteSideEffectInstruction() { getOpcode() instanceof WriteSideEffectOpcode }
 
-  Instruction getArgumentInstruction() {
-    result = getAnOperand().(AddressOperand).getDef()
-  }
+  Instruction getArgumentInstruction() { result = getAnOperand().(AddressOperand).getDef() }
 }
 
 /**
@@ -1245,9 +1240,7 @@ class IndirectMayWriteSideEffectInstruction extends WriteSideEffectInstruction {
  * Unlike `BufferWriteSideEffectInstruction`, the buffer might not be completely overwritten.
  */
 class BufferMayWriteSideEffectInstruction extends WriteSideEffectInstruction {
-  BufferMayWriteSideEffectInstruction() {
-    getOpcode() instanceof Opcode::BufferMayWriteSideEffect
-  }
+  BufferMayWriteSideEffectInstruction() { getOpcode() instanceof Opcode::BufferMayWriteSideEffect }
 
   final override MemoryAccessKind getResultMemoryAccess() {
     result instanceof BufferMayMemoryAccess

--- a/csharp/ql/src/semmle/code/csharp/ir/implementation/raw/Instruction.qll
+++ b/csharp/ql/src/semmle/code/csharp/ir/implementation/raw/Instruction.qll
@@ -648,7 +648,6 @@ class IndexedInstruction extends Instruction {
   int index;
 
   IndexedInstruction() { index = Construction::getInstructionIndex(this) }
-  
 
   final override string getImmediateString() { result = index.toString() }
 

--- a/csharp/ql/src/semmle/code/csharp/ir/implementation/raw/Operand.qll
+++ b/csharp/ql/src/semmle/code/csharp/ir/implementation/raw/Operand.qll
@@ -255,6 +255,16 @@ class AddressOperand extends RegisterOperand {
 }
 
 /**
+ * The buffer size operand of an instruction that represents a read or write of
+ * a buffer.
+ */
+class BufferSizeOperand extends RegisterOperand {
+  override BufferSizeOperandTag tag;
+
+  override string toString() { result = "BufferSize" }
+}
+
+/**
  * The source value operand of an instruction that loads a value from memory (e.g. `Load`,
  * `ReturnValue`, `ThrowValue`).
  */

--- a/csharp/ql/src/semmle/code/csharp/ir/implementation/raw/Operand.qll
+++ b/csharp/ql/src/semmle/code/csharp/ir/implementation/raw/Operand.qll
@@ -390,10 +390,10 @@ class SideEffectOperand extends TypedOperand {
     useInstr instanceof BufferReadSideEffectInstruction and
     result instanceof BufferMemoryAccess
     or
-    useInstr instanceof IndirectWriteSideEffectInstruction and
+    useInstr instanceof IndirectMustWriteSideEffectInstruction and
     result instanceof IndirectMemoryAccess
     or
-    useInstr instanceof BufferWriteSideEffectInstruction and
+    useInstr instanceof BufferMustWriteSideEffectInstruction and
     result instanceof BufferMemoryAccess
     or
     useInstr instanceof IndirectMayWriteSideEffectInstruction and

--- a/csharp/ql/src/semmle/code/csharp/ir/implementation/raw/internal/IRConstruction.qll
+++ b/csharp/ql/src/semmle/code/csharp/ir/implementation/raw/internal/IRConstruction.qll
@@ -253,6 +253,9 @@ private module Cached {
   }
 
   cached
+  int getInstructionIndex(Instruction instruction) { none() }
+
+  cached
   Callable getInstructionFunction(Instruction instruction) {
     result = getInstructionTranslatedElement(instruction)
           .getInstructionFunction(getInstructionTag(instruction))

--- a/csharp/ql/src/semmle/code/csharp/ir/implementation/unaliased_ssa/Operand.qll
+++ b/csharp/ql/src/semmle/code/csharp/ir/implementation/unaliased_ssa/Operand.qll
@@ -255,6 +255,16 @@ class AddressOperand extends RegisterOperand {
 }
 
 /**
+ * The buffer size operand of an instruction that represents a read or write of
+ * a buffer.
+ */
+class BufferSizeOperand extends RegisterOperand {
+  override BufferSizeOperandTag tag;
+
+  override string toString() { result = "BufferSize" }
+}
+
+/**
  * The source value operand of an instruction that loads a value from memory (e.g. `Load`,
  * `ReturnValue`, `ThrowValue`).
  */
@@ -390,10 +400,10 @@ class SideEffectOperand extends TypedOperand {
     useInstr instanceof BufferReadSideEffectInstruction and
     result instanceof BufferMemoryAccess
     or
-    useInstr instanceof IndirectWriteSideEffectInstruction and
+    useInstr instanceof IndirectMustWriteSideEffectInstruction and
     result instanceof IndirectMemoryAccess
     or
-    useInstr instanceof BufferWriteSideEffectInstruction and
+    useInstr instanceof BufferMustWriteSideEffectInstruction and
     result instanceof BufferMemoryAccess
     or
     useInstr instanceof IndirectMayWriteSideEffectInstruction and

--- a/csharp/ql/src/semmle/code/csharp/ir/implementation/unaliased_ssa/internal/SSAConstruction.qll
+++ b/csharp/ql/src/semmle/code/csharp/ir/implementation/unaliased_ssa/internal/SSAConstruction.qll
@@ -346,6 +346,11 @@ private module Cached {
   }
 
   cached
+  int getInstructionIndex(Instruction instruction) {
+    result = getOldInstruction(instruction).(OldIR::IndexedInstruction).getIndex()
+  }
+
+  cached
   Language::Function getInstructionFunction(Instruction instruction) {
     result = getOldInstruction(instruction).(OldIR::FunctionInstruction).getFunctionSymbol()
   }


### PR DESCRIPTION
This adds new instructions to the IR to model potential side effects of calls with pointer arguments. The bulk of the implementation is in the `TranslatedSideEffects` and `TranslatedSideEffect` classes in `TranslatedCall.qll`. One `TranslatedSideEffects` is generated for each call with pointer or reference arguments, while two `TranslatedSideEffect` objects are generated for each argument, one representing read side effects and the other representing write side effects. Currently these are generated unconditionally; constness, rvalue references, and whether the function actually writes to a non-const pointer aren't taken into account.