### PR TITLE
C#: Search from delegate creation in `delegateCallSource()`

### DIFF
--- a/csharp/ql/src/semmle/code/csharp/dataflow/SSA.qll
+++ b/csharp/ql/src/semmle/code/csharp/dataflow/SSA.qll
@@ -1076,29 +1076,27 @@ module Ssa {
         )
       }
 
-      private predicate reachableFromDelegateCreation(Expr e) {
-        delegateCreation(e, _, _)
+      private predicate reachesDelegateCall(Expr e) {
+        delegateCall(_, e)
         or
-        exists(Expr mid | reachableFromDelegateCreation(mid) | delegateFlowStep(mid, e))
+        exists(Expr mid | reachesDelegateCall(mid) | delegateFlowStep(e, mid))
       }
 
       pragma[noinline]
-      private predicate delegateFlowStepReachable(Expr pred, Expr succ) {
+      private predicate delegateFlowStepReaches(Expr pred, Expr succ) {
         delegateFlowStep(pred, succ) and
-        reachableFromDelegateCreation(pred)
+        reachesDelegateCall(succ)
       }
 
-      private Expr delegateCallSource(Call c) {
-        // Base case
-        delegateCall(c, result)
+      private Expr delegateCallSource(Callable c) {
+        delegateCreation(result, c, _)
         or
-        // Recursive case
-        delegateFlowStepReachable(result, delegateCallSource(c))
+        delegateFlowStepReaches(delegateCallSource(c), result)
       }
 
       /** Gets a run-time target for the delegate call `c`. */
       Callable getARuntimeDelegateTarget(Call c) {
-        delegateCreation(delegateCallSource(c), result, _)
+        delegateCall(c, delegateCallSource(result))
       }
     }
 


### PR DESCRIPTION
Searching from the delegate creation instead of the delegate call in `delegateCallSource()` yields a [small performance improvement](https://git.semmle.com/gist/tom/82e0ff319f8a8306ebc15c150620f577), most notably on mono:

Before:
```
SsaDef.ql-25:SSA::Ssa::FieldOrPropsImpl::SimpleDelegateAnalysis::delegateCallSource#ff#reorder_1_0 ... 5m27s (executed 73 times)
````

After:
```
SsaDef.ql-25:SSA::Ssa::FieldOrPropsImpl::SimpleDelegateAnalysis::delegateCallSource#ff#reorder_1_0 ... 3m3s (executed 67 times)
```