### PR TITLE
YAMLExtractor: Update javadoc link

### DIFF
--- a/javascript/extractor/src/com/semmle/js/extractor/YAMLExtractor.java
+++ b/javascript/extractor/src/com/semmle/js/extractor/YAMLExtractor.java
@@ -135,7 +135,7 @@ public class YAMLExtractor implements IExtractor {
     return parser.checkEvent(Event.ID.StreamEnd);
   }
 
-  /** Extract a complete YAML document; cf. {@link Composer#composeDocument}. */
+  /** Extract a complete YAML document; cf. {@link Composer#getNode}. */
   private void extractDocument(Label parent, int idx, int[] codepoints) {
     // Drop the DOCUMENT-START event
     parser.getEvent();


### PR DESCRIPTION
Recent SnakeYAML has removed the linked method; replace the
link with a reference to what it became.