### PR TITLE
C++: Annotate field-flow tests in [ABC].cpp

### DIFF
--- a/cpp/ql/test/library-tests/dataflow/fields/A.cpp
+++ b/cpp/ql/test/library-tests/dataflow/fields/A.cpp
@@ -117,7 +117,7 @@ public:
     }
     if (C1 *c1 = dynamic_cast<C1 *>(cc))
     {
-      sink(c1->a); // no flow, stopped by cast to C2
+      sink(c1->a); // no flow, stopped by cast to C2 [FALSE POSITIVE]
     }
   }
 
@@ -129,7 +129,7 @@ public:
   {
     B *b = new B();
     f7(b);
-    sink(b->c); // flow
+    sink(b->c); // flow [NOT DETECTED]
   }
 
   class D
@@ -151,7 +151,7 @@ public:
     D *d = new D(b, r());
     sink(d->b);    // flow x2
     sink(d->b->c); // flow
-    sink(b->c);    // flow
+    sink(b->c);    // flow [NOT DETECTED]
   }
 
   void f10()
@@ -161,9 +161,9 @@ public:
     MyList *l2 = new MyList(nullptr, l1);
     MyList *l3 = new MyList(nullptr, l2);
     sink(l3->head);                   // no flow, b is nested beneath at least one ->next
-    sink(l3->next->head);             // flow, the precise nesting depth isn't tracked
+    sink(l3->next->head);             // no flow
     sink(l3->next->next->head);       // flow
-    sink(l3->next->next->next->head); // flow
+    sink(l3->next->next->next->head); // no flow
     for (MyList *l = l3; l != nullptr; l = l->next)
     {
       sink(l->head); // flow

--- a/cpp/ql/test/library-tests/dataflow/fields/B.cpp
+++ b/cpp/ql/test/library-tests/dataflow/fields/B.cpp
@@ -7,7 +7,7 @@ class B
     Box1 *b1 = new Box1(e, nullptr);
     Box2 *b2 = new Box2(b1);
     sink(b2->box1->elem1); // flow
-    sink(b2->box1->elem2); // FP due to flow in f2 below
+    sink(b2->box1->elem2); // no flow [FALSE POSITIVE] (due to flow in f2 below)
   }
 
   void f2()
@@ -15,7 +15,7 @@ class B
     Elem *e = new B::Elem();
     Box1 *b1 = new B::Box1(nullptr, e);
     Box2 *b2 = new Box2(b1);
-    sink(b2->box1->elem1); // FP due to flow in f1 above
+    sink(b2->box1->elem1); // no flow [FALSE POSITIVE] (due to flow in f1 above)
     sink(b2->box1->elem2); // flow
   }
 

--- a/cpp/ql/test/library-tests/dataflow/fields/C.cpp
+++ b/cpp/ql/test/library-tests/dataflow/fields/C.cpp
@@ -26,10 +26,10 @@ public:
 
   void func()
   {
-    sink(s1);
-    sink(s2);
-    sink(s3);
-    sink(s4);
+    sink(s1); // flow [NOT DETECTED] (in either place)
+    sink(s2); // flow [NOT DETECTED]
+    sink(s3); // flow
+    sink(s4); // flow [NOT DETECTED]
   }
 
   static void sink(const void *o) {}


### PR DESCRIPTION
This brings the annotation style in sync with how we annotate new tests these days. I also changed a few annotations to have different expected outcome based on my understanding of the code.

@pavgust, have I misunderstood what flow there's supposed to be in your `l3->next*->head` examples?