### PR TITLE
Python points-to: add .getAstNode() method to TaintedNode

### DIFF
--- a/python/ql/src/semmle/python/security/TaintTracking.qll
+++ b/python/ql/src/semmle/python/security/TaintTracking.qll
@@ -665,6 +665,11 @@ class TaintedNode extends TTaintedNode {
         this = TTaintedNode_(_, _, result)
     }
 
+    /** Get the AST node for this node. */
+    AstNode getAstNode() {
+        result = this.getNode().getNode()
+    }
+
     /** Gets the data-flow context for this node. */
     CallContext getContext() {
         this = TTaintedNode_(_, result, _)

--- a/python/ql/test/3/library-tests/web/django/Taint.ql
+++ b/python/ql/test/3/library-tests/web/django/Taint.ql
@@ -10,5 +10,5 @@ import semmle.python.security.strings.Untrusted
 
 from TaintedNode node
 
-select node.getLocation().toString(), node.getNode().getNode().toString(), node.getTaintKind().toString()
+select node.getLocation().toString(), node.getAstNode().toString(), node.getTaintKind().toString()
 

--- a/python/ql/test/library-tests/taint/strings/DistinctStringKinds.ql
+++ b/python/ql/test/library-tests/taint/strings/DistinctStringKinds.ql
@@ -35,5 +35,5 @@ class ExternalStringSource extends TaintSource {
 
 from TaintedNode n
 where n.getLocation().getFile().getName().matches("%test.py")
-select n.getTrackedValue(), n.getLocation().toString(), n.getNode().getNode(), n.getContext()
+select n.getTrackedValue(), n.getLocation().toString(), n.getAstNode(), n.getContext()
 

--- a/python/ql/test/library-tests/taint/strings/TestNode.ql
+++ b/python/ql/test/library-tests/taint/strings/TestNode.ql
@@ -5,5 +5,5 @@ import Taint
 
 from TaintedNode n
 where n.getLocation().getFile().getName().matches("%test.py")
-select n.getTrackedValue(), n.getLocation().toString(), n.getNode().getNode(), n.getContext()
+select n.getTrackedValue(), n.getLocation().toString(), n.getAstNode(), n.getContext()
 

--- a/python/ql/test/library-tests/taint/strings/TestStep.ql
+++ b/python/ql/test/library-tests/taint/strings/TestStep.ql
@@ -8,6 +8,6 @@ where n.getLocation().getFile().getName().matches("%test.py") and
 s.getLocation().getFile().getName().matches("%test.py") and
 s = n.getASuccessor()
 select 
-    n.getTrackedValue(), n.getLocation().toString(), n.getNode().getNode(), n.getContext(), 
+    n.getTrackedValue(), n.getLocation().toString(), n.getAstNode(), n.getContext(), 
     " --> ",
-    s.getTrackedValue(), s.getLocation().toString(), s.getNode().getNode(), s.getContext()
+    s.getTrackedValue(), s.getLocation().toString(), s.getAstNode(), s.getContext()

--- a/python/ql/test/library-tests/web/bottle/Taint.ql
+++ b/python/ql/test/library-tests/web/bottle/Taint.ql
@@ -9,5 +9,5 @@ import semmle.python.security.strings.Untrusted
 
 from TaintedNode node
 
-select node.getLocation().toString(), node.getNode().getNode().toString(), node.getTaintKind()
+select node.getLocation().toString(), node.getAstNode().toString(), node.getTaintKind()
 

--- a/python/ql/test/library-tests/web/falcon/Taint.ql
+++ b/python/ql/test/library-tests/web/falcon/Taint.ql
@@ -9,5 +9,5 @@ import semmle.python.security.strings.Untrusted
 
 from TaintedNode node
 where node.getLocation().getFile().getName().matches("%falcon/test.py")
-select node.getLocation().toString(), node.getNode().getNode().toString(), node.getTaintKind()
+select node.getLocation().toString(), node.getAstNode().toString(), node.getTaintKind()
 

--- a/python/ql/test/library-tests/web/turbogears/Taint.ql
+++ b/python/ql/test/library-tests/web/turbogears/Taint.ql
@@ -9,5 +9,5 @@ import semmle.python.security.strings.Untrusted
 
 from TaintedNode node
 
-select node.getLocation().toString(), node.getNode().getNode().toString(), node.getTaintKind()
+select node.getLocation().toString(), node.getAstNode().toString(), node.getTaintKind()
 

--- a/python/ql/test/query-tests/Security/CWE-327/TestNode.ql
+++ b/python/ql/test/query-tests/Security/CWE-327/TestNode.ql
@@ -6,5 +6,5 @@ import semmle.python.security.SensitiveData
 import semmle.python.security.Crypto
 
 from TaintedNode n, AstNode src
-where src = n.getNode().getNode() and src.getLocation().getFile().getName().matches("%test%")
+where src = n.getAstNode() and src.getLocation().getFile().getName().matches("%test%")
 select n.getTrackedValue(), n.getLocation(), src, n.getContext()


### PR DESCRIPTION
 For forward compatibility with upcoming taint-tracking enhancements. Specifically to reduce the number of warnings in https://github.com/Semmle/ql/pull/1747