### PR TITLE
Java: Improve performance in all dataflow queries.

### DIFF
--- a/java/ql/src/semmle/code/java/frameworks/google/GoogleHttpClientApi.qll
+++ b/java/ql/src/semmle/code/java/frameworks/google/GoogleHttpClientApi.qll
@@ -1,6 +1,7 @@
 import java
 import semmle.code.java.Serializability
 import semmle.code.java.dataflow.DataFlow
+import semmle.code.java.dataflow.DataFlow5
 
 /** The method `parseAs` in `com.google.api.client.http.HttpResponse`. */
 private class ParseAsMethod extends Method {
@@ -10,7 +11,7 @@ private class ParseAsMethod extends Method {
   }
 }
 
-private class TypeLiteralToParseAsFlowConfiguration extends DataFlow::Configuration {
+private class TypeLiteralToParseAsFlowConfiguration extends DataFlow5::Configuration {
   TypeLiteralToParseAsFlowConfiguration() {
     this = "GoogleHttpClientApi::TypeLiteralToParseAsFlowConfiguration"
   }

--- a/java/ql/src/semmle/code/java/frameworks/jackson/JacksonSerializability.qll
+++ b/java/ql/src/semmle/code/java/frameworks/jackson/JacksonSerializability.qll
@@ -7,6 +7,7 @@ import java
 import semmle.code.java.Serializability
 import semmle.code.java.Reflection
 import semmle.code.java.dataflow.DataFlow
+import semmle.code.java.dataflow.DataFlow5
 
 class JacksonJSONIgnoreAnnotation extends NonReflectiveAnnotation {
   JacksonJSONIgnoreAnnotation() {
@@ -52,7 +53,7 @@ library class FieldReferencedJacksonSerializableType extends JacksonSerializable
 
 abstract class JacksonDeserializableType extends Type { }
 
-private class TypeLiteralToJacksonDatabindFlowConfiguration extends DataFlow::Configuration {
+private class TypeLiteralToJacksonDatabindFlowConfiguration extends DataFlow5::Configuration {
   TypeLiteralToJacksonDatabindFlowConfiguration() {
     this = "TypeLiteralToJacksonDatabindFlowConfiguration"
   }


### PR DESCRIPTION
The uses of dataflow in the two `Serializability` framework libraries are in scope as soon as dataflow is brought in scope, by the import chain `VirtualDispatch.qll -> Guards.qll -> GuardsLogic.qll -> IntegerGuards.qll -> RangeAnalysis.qll -> Reflection.qll -> Serializability.qll` and this makes the dataflow configuration used in those libraries a bit bigger than needed for subsequent uses, so we shouldn't use the default dataflow library.

This should be a performance improvement for all dataflow-based queries.