### PR TITLE
JavaScript: Raise precision of `UndocumentedParameter` to `high`.

### DIFF
--- a/change-notes/1.22/analysis-javascript.md
+++ b/change-notes/1.22/analysis-javascript.md
@@ -31,6 +31,7 @@
 | Shift out of range | Fewer false positive results | This rule now correctly handles BigInt shift operands. |
 | Conflicting HTML element attributes | Fewer results | Results are no longer shown on LGTM by default. |
 | Superfluous trailing arguments | Fewer false-positive results. | This rule no longer flags calls to placeholder functions that trivially throw an exception. |
+| Undocumented parameter | No changes to results | This rule is now run on LGTM, although its results are still not shown by default. |
 
 ## Changes to QL libraries
 

--- a/javascript/ql/src/JSDoc/UndocumentedParameter.ql
+++ b/javascript/ql/src/JSDoc/UndocumentedParameter.ql
@@ -8,7 +8,7 @@
  * @tags maintainability
  *       readability
  *       documentation
- * @precision medium
+ * @precision high
  */
 
 import javascript
@@ -22,6 +22,6 @@ where
   exists(doc.getATag().(JSDocParamTag).getDocumentedParameter()) and
   // but v is not
   not doc.getATag().(JSDocParamTag).getDocumentedParameter() = v and
-  // don't report a violation in ambiguous cases
+  // don't report an alert in ambiguous cases
   strictcount(JSDoc d | d = f.getDocumentation() and d.getATag() instanceof JSDocParamTag) = 1
 select parm, "Parameter " + v.getName() + " is not documented."


### PR DESCRIPTION
This is more consistent with the other JSDoc queries. Results are still not shown on LGTM by default, but the query can now be enabled selectively for projects that care about JSDoc.

(Partly addresses https://discuss.lgtm.com/t/js-ts-query-suggestion-jsdocs-related.)