### PR TITLE
C++: Data flow through & and *

### DIFF
--- a/change-notes/1.22/analysis-cpp.md
+++ b/change-notes/1.22/analysis-cpp.md
@@ -24,6 +24,7 @@
 
 - The predicate `Variable.getAnAssignedValue()` now reports assignments to fields resulting from aggregate initialization (` = {...}`).
 - The predicate `TypeMention.toString()` has been simplified to always return the string "`type mention`".  This may improve performance when using `Element.toString()` or its descendants.
+- The `DataFlow::DefinitionByReferenceNode` class now considers `f(x)` to be a definition of `x` when `x` is a variable of pointer type. It no longer considers deep paths such as `f(&x.myField)` to be definitions of `x`. These changes are in line with the user expectations we've observed.
 - The `semmle.code.cpp.security.TaintTracking` library now considers a pointer difference calculation as blocking taint flow.
 - Fixed the `LocalScopeVariableReachability.qll` library's handling of loops with an entry condition is both always true upon first entry, and where there is more than one control flow path through the loop condition.  This change increases the accuracy of the `LocalScopeVariableReachability.qll` library and queries which depend on it.
 - The `semmle.code.cpp.models` library now models data flow through `std::swap`.

--- a/cpp/ql/src/semmle/code/cpp/dataflow/internal/DataFlowUtil.qll
+++ b/cpp/ql/src/semmle/code/cpp/dataflow/internal/DataFlowUtil.qll
@@ -496,6 +496,12 @@ private predicate exprToExprStep_nocfg(Expr fromExpr, Expr toExpr) {
   or
   toExpr = any(StmtExpr stmtExpr | fromExpr = stmtExpr.getResultExpr())
   or
+  toExpr.(AddressOfExpr).getOperand() = fromExpr
+  or
+  toExpr.(BuiltInOperationBuiltInAddressOf).getOperand() = fromExpr
+  or
+  toExpr.(PointerDereferenceExpr).getOperand() = fromExpr
+  or
   // The following case is needed to track the qualifier object for flow
   // through fields. It gives flow from `T(x)` to `new T(x)`. That's not
   // strictly _data_ flow but _taint_ flow because the type of `fromExpr` is

--- a/cpp/ql/src/semmle/code/cpp/dataflow/internal/DataFlowUtil.qll
+++ b/cpp/ql/src/semmle/code/cpp/dataflow/internal/DataFlowUtil.qll
@@ -170,14 +170,13 @@ class ImplicitParameterNode extends ParameterNode, TInstanceParameterNode {
  */
 class DefinitionByReferenceNode extends PartialDefinitionNode {
   VariableAccess va;
-
   Expr argument;
 
   DefinitionByReferenceNode() {
     exists(DefinitionByReference def |
       def = this.getPartialDefinition() and
-      argument = def.getDefinedExpr() and
-      va = def.getVariableAccess()
+      argument = def.getArgument() and
+      va = def.getDefinedExpr()
     )
   }
 

--- a/cpp/ql/src/semmle/code/cpp/dataflow/internal/FlowVar.qll
+++ b/cpp/ql/src/semmle/code/cpp/dataflow/internal/FlowVar.qll
@@ -95,7 +95,7 @@ private module PartialDefinitions {
       )
     } or
     TExplicitCallQualifier(Expr qualifier, Call call) { qualifier = call.getQualifier() } or
-    TReferenceArgument(Expr arg, VariableAccess va) { definitionByReference(va, arg) }
+    TReferenceArgument(Expr arg, VariableAccess va) { referenceArgument(va, arg) }
 
   private predicate isInstanceFieldWrite(FieldAccess fa, ControlFlowNode node) {
     not fa.getTarget().isStatic() and
@@ -133,17 +133,41 @@ private module PartialDefinitions {
   }
 
   /**
-   * A partial definition that's a definition by reference (in the sense of the
-   * `definitionByReference` predicate).
+   * A partial definition that's a definition by reference.
    */
   class DefinitionByReference extends PartialDefinition, TReferenceArgument {
     VariableAccess va;
 
-    DefinitionByReference() { definitionByReference(va, definedExpr) }
+    DefinitionByReference() { referenceArgument(va, definedExpr) }
 
     VariableAccess getVariableAccess() { result = va }
 
     override predicate partiallyDefines(Variable v) { va = v.getAnAccess() }
+  }
+
+  private predicate referenceArgument(VariableAccess va, Expr argument) {
+    argument = any(Call c).getAnArgument() and
+    exists(Type argumentType |
+      argumentType = argument.getFullyConverted().getType().stripTopLevelSpecifiers()
+    |
+      argumentType instanceof ReferenceType and
+      not argumentType.(ReferenceType).getBaseType().isConst() and
+      va = argument
+      or
+      argumentType instanceof PointerType and
+      not argumentType.(PointerType).getBaseType().isConst() and
+      (
+        // f(variable)
+        va = argument
+        or
+        // f(&variable)
+        va = argument.(AddressOfExpr).getOperand()
+        or
+        // f(&array[0])
+        va.getType().getUnspecifiedType() instanceof ArrayType and
+        va = argument.(AddressOfExpr).getOperand().(ArrayExpr).getArrayBase()
+      )
+    )
   }
 }
 import PartialDefinitions

--- a/cpp/ql/src/semmle/code/cpp/dataflow/internal/FlowVar.qll
+++ b/cpp/ql/src/semmle/code/cpp/dataflow/internal/FlowVar.qll
@@ -95,7 +95,7 @@ private module PartialDefinitions {
       )
     } or
     TExplicitCallQualifier(Expr qualifier, Call call) { qualifier = call.getQualifier() } or
-    TReferenceArgument(Expr arg, VariableAccess va) { referenceArgument(va, arg) }
+    TReferenceArgument(Expr arg, VariableAccess va) { referenceArgument(arg, va) }
 
   private predicate isInstanceFieldWrite(FieldAccess fa, ControlFlowNode node) {
     not fa.getTarget().isStatic() and
@@ -109,7 +109,7 @@ private module PartialDefinitions {
     PartialDefinition() {
       this = TExplicitFieldStoreQualifier(definedExpr, node) or
       this = TExplicitCallQualifier(definedExpr, _) and node = definedExpr or
-      this = TReferenceArgument(definedExpr, node)
+      this = TReferenceArgument(_, definedExpr) and node = definedExpr
     }
 
     predicate partiallyDefines(Variable v) { definedExpr = v.getAnAccess() }
@@ -136,16 +136,10 @@ private module PartialDefinitions {
    * A partial definition that's a definition by reference.
    */
   class DefinitionByReference extends PartialDefinition, TReferenceArgument {
-    VariableAccess va;
-
-    DefinitionByReference() { referenceArgument(va, definedExpr) }
-
-    VariableAccess getVariableAccess() { result = va }
-
-    override predicate partiallyDefines(Variable v) { va = v.getAnAccess() }
+    Expr getArgument() { this = TReferenceArgument(result, _) }
   }
 
-  private predicate referenceArgument(VariableAccess va, Expr argument) {
+  private predicate referenceArgument(Expr argument, VariableAccess va) {
     argument = any(Call c).getAnArgument() and
     exists(Type argumentType |
       argumentType = argument.getFullyConverted().getType().stripTopLevelSpecifiers()

--- a/cpp/ql/test/library-tests/dataflow/dataflow-tests/localFlow.expected
+++ b/cpp/ql/test/library-tests/dataflow/dataflow-tests/localFlow.expected
@@ -42,7 +42,6 @@
 | test.cpp:431:12:431:13 | 0 | test.cpp:432:33:432:35 | tmp |
 | test.cpp:431:12:431:13 | 0 | test.cpp:433:8:433:10 | tmp |
 | test.cpp:432:10:432:13 | & ... | test.cpp:432:3:432:8 | call to memcpy |
-| test.cpp:432:10:432:13 | ref arg & ... | test.cpp:432:3:432:8 | call to memcpy |
 | test.cpp:432:10:432:13 | ref arg & ... | test.cpp:432:33:432:35 | tmp |
 | test.cpp:432:10:432:13 | ref arg & ... | test.cpp:433:8:433:10 | tmp |
 | test.cpp:432:17:432:23 | source1 | test.cpp:432:10:432:13 | ref arg & ... |
@@ -54,7 +53,6 @@
 | test.cpp:437:12:437:13 | 0 | test.cpp:440:8:440:10 | tmp |
 | test.cpp:437:12:437:13 | 0 | test.cpp:442:10:442:12 | tmp |
 | test.cpp:439:10:439:13 | & ... | test.cpp:439:3:439:8 | call to memcpy |
-| test.cpp:439:10:439:13 | ref arg & ... | test.cpp:439:3:439:8 | call to memcpy |
 | test.cpp:439:10:439:13 | ref arg & ... | test.cpp:439:33:439:35 | tmp |
 | test.cpp:439:10:439:13 | ref arg & ... | test.cpp:440:8:440:10 | tmp |
 | test.cpp:439:10:439:13 | ref arg & ... | test.cpp:442:10:442:12 | tmp |

--- a/cpp/ql/test/library-tests/dataflow/dataflow-tests/localFlow.expected
+++ b/cpp/ql/test/library-tests/dataflow/dataflow-tests/localFlow.expected
@@ -14,6 +14,10 @@
 | example.c:24:24:24:30 | ... + ... | example.c:24:13:24:30 | ... = ... |
 | example.c:26:13:26:16 | call to getX | example.c:26:2:26:25 | ... = ... |
 | example.c:26:18:26:24 | ref arg & ... | example.c:26:2:26:7 | coords |
+| example.c:26:18:26:24 | ref arg & ... | example.c:26:18:26:24 | & ... |
+| example.c:26:19:26:24 | coords | example.c:26:18:26:24 | & ... |
+| example.c:28:22:28:25 | ref arg & ... | example.c:28:22:28:25 | & ... |
+| example.c:28:23:28:25 | pos | example.c:28:22:28:25 | & ... |
 | test.cpp:6:12:6:17 | call to source | test.cpp:7:8:7:9 | t1 |
 | test.cpp:6:12:6:17 | call to source | test.cpp:8:8:8:9 | t1 |
 | test.cpp:6:12:6:17 | call to source | test.cpp:9:8:9:9 | t1 |
@@ -42,9 +46,12 @@
 | test.cpp:431:12:431:13 | 0 | test.cpp:432:33:432:35 | tmp |
 | test.cpp:431:12:431:13 | 0 | test.cpp:433:8:433:10 | tmp |
 | test.cpp:432:10:432:13 | & ... | test.cpp:432:3:432:8 | call to memcpy |
+| test.cpp:432:10:432:13 | ref arg & ... | test.cpp:432:10:432:13 | & ... |
 | test.cpp:432:10:432:13 | ref arg & ... | test.cpp:432:33:432:35 | tmp |
 | test.cpp:432:10:432:13 | ref arg & ... | test.cpp:433:8:433:10 | tmp |
+| test.cpp:432:11:432:13 | tmp | test.cpp:432:10:432:13 | & ... |
 | test.cpp:432:17:432:23 | source1 | test.cpp:432:10:432:13 | ref arg & ... |
+| test.cpp:432:17:432:23 | source1 | test.cpp:432:16:432:23 | & ... |
 | test.cpp:436:53:436:59 | source1 | test.cpp:439:17:439:23 | source1 |
 | test.cpp:436:66:436:66 | b | test.cpp:441:7:441:7 | b |
 | test.cpp:437:12:437:13 | 0 | test.cpp:438:19:438:21 | tmp |
@@ -52,8 +59,12 @@
 | test.cpp:437:12:437:13 | 0 | test.cpp:439:33:439:35 | tmp |
 | test.cpp:437:12:437:13 | 0 | test.cpp:440:8:440:10 | tmp |
 | test.cpp:437:12:437:13 | 0 | test.cpp:442:10:442:12 | tmp |
+| test.cpp:438:19:438:21 | tmp | test.cpp:438:18:438:21 | & ... |
 | test.cpp:439:10:439:13 | & ... | test.cpp:439:3:439:8 | call to memcpy |
+| test.cpp:439:10:439:13 | ref arg & ... | test.cpp:439:10:439:13 | & ... |
 | test.cpp:439:10:439:13 | ref arg & ... | test.cpp:439:33:439:35 | tmp |
 | test.cpp:439:10:439:13 | ref arg & ... | test.cpp:440:8:440:10 | tmp |
 | test.cpp:439:10:439:13 | ref arg & ... | test.cpp:442:10:442:12 | tmp |
+| test.cpp:439:11:439:13 | tmp | test.cpp:439:10:439:13 | & ... |
 | test.cpp:439:17:439:23 | source1 | test.cpp:439:10:439:13 | ref arg & ... |
+| test.cpp:439:17:439:23 | source1 | test.cpp:439:16:439:23 | & ... |

--- a/cpp/ql/test/library-tests/dataflow/dataflow-tests/test.expected
+++ b/cpp/ql/test/library-tests/dataflow/dataflow-tests/test.expected
@@ -20,6 +20,8 @@
 | test.cpp:90:8:90:14 | source1 | test.cpp:89:28:89:34 | source1 |
 | test.cpp:103:10:103:12 | ref | test.cpp:100:13:100:18 | call to source |
 | test.cpp:126:8:126:19 | sourceArray1 | test.cpp:120:9:120:20 | sourceArray1 |
+| test.cpp:129:8:129:20 | * ... | test.cpp:120:9:120:20 | sourceArray1 |
+| test.cpp:130:8:130:20 | & ... | test.cpp:120:9:120:20 | sourceArray1 |
 | test.cpp:137:27:137:28 | m1 | test.cpp:136:27:136:32 | call to source |
 | test.cpp:138:27:138:34 | call to getFirst | test.cpp:136:27:136:32 | call to source |
 | test.cpp:140:22:140:23 | m1 | test.cpp:136:27:136:32 | call to source |
@@ -50,10 +52,14 @@
 | test.cpp:472:8:472:12 | local | test.cpp:471:20:471:25 | ref arg & ... |
 | test.cpp:478:8:478:12 | local | test.cpp:476:7:476:11 | local |
 | test.cpp:478:8:478:12 | local | test.cpp:477:20:477:24 | ref arg local |
+| test.cpp:479:8:479:13 | * ... | test.cpp:476:7:476:11 | local |
+| test.cpp:479:8:479:13 | * ... | test.cpp:477:20:477:24 | ref arg local |
 | test.cpp:485:8:485:12 | local | test.cpp:483:7:483:11 | local |
 | test.cpp:485:8:485:12 | local | test.cpp:484:18:484:23 | ref arg & ... |
 | test.cpp:491:8:491:12 | local | test.cpp:489:7:489:11 | local |
 | test.cpp:491:8:491:12 | local | test.cpp:490:18:490:22 | ref arg local |
+| test.cpp:492:8:492:13 | * ... | test.cpp:489:7:489:11 | local |
+| test.cpp:492:8:492:13 | * ... | test.cpp:490:18:490:22 | ref arg local |
 | test.cpp:498:9:498:22 | (statement expression) | test.cpp:497:26:497:32 | source1 |
 | test.cpp:509:8:509:12 | local | test.cpp:497:26:497:32 | source1 |
 | true_upon_entry.cpp:21:8:21:8 | x | true_upon_entry.cpp:17:11:17:16 | call to source |

--- a/cpp/ql/test/library-tests/dataflow/dataflow-tests/test_diff.expected
+++ b/cpp/ql/test/library-tests/dataflow/dataflow-tests/test_diff.expected
@@ -5,6 +5,8 @@
 | test.cpp:89:28:89:34 | test.cpp:92:8:92:14 | IR only |
 | test.cpp:100:13:100:18 | test.cpp:103:10:103:12 | AST only |
 | test.cpp:109:9:109:14 | test.cpp:110:10:110:12 | IR only |
+| test.cpp:120:9:120:20 | test.cpp:129:8:129:20 | AST only |
+| test.cpp:120:9:120:20 | test.cpp:130:8:130:20 | AST only |
 | test.cpp:136:27:136:32 | test.cpp:137:27:137:28 | AST only |
 | test.cpp:136:27:136:32 | test.cpp:138:27:138:34 | AST only |
 | test.cpp:136:27:136:32 | test.cpp:140:22:140:23 | AST only |
@@ -22,11 +24,15 @@
 | test.cpp:470:7:470:11 | test.cpp:472:8:472:12 | AST only |
 | test.cpp:471:20:471:25 | test.cpp:472:8:472:12 | AST only |
 | test.cpp:476:7:476:11 | test.cpp:478:8:478:12 | AST only |
+| test.cpp:476:7:476:11 | test.cpp:479:8:479:13 | AST only |
 | test.cpp:477:20:477:24 | test.cpp:478:8:478:12 | AST only |
+| test.cpp:477:20:477:24 | test.cpp:479:8:479:13 | AST only |
 | test.cpp:483:7:483:11 | test.cpp:485:8:485:12 | AST only |
 | test.cpp:484:18:484:23 | test.cpp:485:8:485:12 | AST only |
 | test.cpp:489:7:489:11 | test.cpp:491:8:491:12 | AST only |
+| test.cpp:489:7:489:11 | test.cpp:492:8:492:13 | AST only |
 | test.cpp:490:18:490:22 | test.cpp:491:8:491:12 | AST only |
+| test.cpp:490:18:490:22 | test.cpp:492:8:492:13 | AST only |
 | true_upon_entry.cpp:9:11:9:16 | true_upon_entry.cpp:13:8:13:8 | IR only |
 | true_upon_entry.cpp:62:11:62:16 | true_upon_entry.cpp:66:8:66:8 | IR only |
 | true_upon_entry.cpp:98:11:98:16 | true_upon_entry.cpp:105:8:105:8 | IR only |

--- a/cpp/ql/test/library-tests/dataflow/fields/A.cpp
+++ b/cpp/ql/test/library-tests/dataflow/fields/A.cpp
@@ -129,7 +129,7 @@ public:
   {
     B *b = new B();
     f7(b);
-    sink(b->c); // flow [NOT DETECTED]
+    sink(b->c); // flow
   }
 
   class D
@@ -151,7 +151,7 @@ public:
     D *d = new D(b, r());
     sink(d->b);    // flow x2
     sink(d->b->c); // flow
-    sink(b->c);    // flow [NOT DETECTED]
+    sink(b->c);    // flow
   }
 
   void f10()

--- a/cpp/ql/test/library-tests/dataflow/fields/flow.expected
+++ b/cpp/ql/test/library-tests/dataflow/fields/flow.expected
@@ -127,14 +127,27 @@ edges
 | simple.cpp:48:9:48:9 | g [b_, ... (1)] | simple.cpp:26:15:26:15 | f [b_, ... (1)] |
 | simple.cpp:51:9:51:9 | h [a_, ... (1)] | simple.cpp:26:15:26:15 | f [a_, ... (1)] |
 | simple.cpp:51:9:51:9 | h [b_, ... (1)] | simple.cpp:26:15:26:15 | f [b_, ... (1)] |
+| struct_init.c:14:24:14:25 | ab [a, ... (1)] | struct_init.c:15:8:15:9 | ab [a, ... (1)] |
+| struct_init.c:15:8:15:9 | ab [a, ... (1)] | struct_init.c:15:12:15:12 | a |
 | struct_init.c:20:17:20:36 | {...} [a, ... (1)] | struct_init.c:22:8:22:9 | ab [a, ... (1)] |
+| struct_init.c:20:17:20:36 | {...} [a, ... (1)] | struct_init.c:24:10:24:12 | & ... [a, ... (1)] |
+| struct_init.c:20:17:20:36 | {...} [a, ... (1)] | struct_init.c:28:5:28:7 | & ... [a, ... (1)] |
 | struct_init.c:20:20:20:29 | call to user_input [void] | struct_init.c:20:17:20:36 | {...} [a, ... (1)] |
 | struct_init.c:22:8:22:9 | ab [a, ... (1)] | struct_init.c:22:11:22:11 | a |
+| struct_init.c:24:10:24:12 | & ... [a, ... (1)] | struct_init.c:14:24:14:25 | ab [a, ... (1)] |
 | struct_init.c:26:23:29:3 | {...} [nestedAB, ... (2)] | struct_init.c:31:8:31:12 | outer [nestedAB, ... (2)] |
+| struct_init.c:26:23:29:3 | {...} [nestedAB, ... (2)] | struct_init.c:36:11:36:15 | outer [nestedAB, ... (2)] |
+| struct_init.c:26:23:29:3 | {...} [pointerAB, ... (2)] | struct_init.c:33:8:33:12 | outer [pointerAB, ... (2)] |
 | struct_init.c:27:5:27:23 | {...} [a, ... (1)] | struct_init.c:26:23:29:3 | {...} [nestedAB, ... (2)] |
 | struct_init.c:27:7:27:16 | call to user_input [void] | struct_init.c:27:5:27:23 | {...} [a, ... (1)] |
+| struct_init.c:28:5:28:7 | & ... [a, ... (1)] | struct_init.c:26:23:29:3 | {...} [pointerAB, ... (2)] |
 | struct_init.c:31:8:31:12 | outer [nestedAB, ... (2)] | struct_init.c:31:14:31:21 | nestedAB [a, ... (1)] |
 | struct_init.c:31:14:31:21 | nestedAB [a, ... (1)] | struct_init.c:31:23:31:23 | a |
+| struct_init.c:33:8:33:12 | outer [pointerAB, ... (2)] | struct_init.c:33:14:33:22 | pointerAB [a, ... (1)] |
+| struct_init.c:33:14:33:22 | pointerAB [a, ... (1)] | struct_init.c:33:25:33:25 | a |
+| struct_init.c:36:10:36:24 | & ... [a, ... (1)] | struct_init.c:14:24:14:25 | ab [a, ... (1)] |
+| struct_init.c:36:11:36:15 | outer [nestedAB, ... (2)] | struct_init.c:36:17:36:24 | nestedAB [a, ... (1)] |
+| struct_init.c:36:17:36:24 | nestedAB [a, ... (1)] | struct_init.c:36:10:36:24 | & ... [a, ... (1)] |
 #select
 | A.cpp:43:10:43:12 | & ... | A.cpp:41:15:41:21 | new [void] | A.cpp:43:10:43:12 | & ... | & ... flows from $@ | A.cpp:41:15:41:21 | new [void] | new [void] |
 | A.cpp:49:13:49:13 | c | A.cpp:47:12:47:18 | new [void] | A.cpp:49:13:49:13 | c | c flows from $@ | A.cpp:47:12:47:18 | new [void] | new [void] |
@@ -165,5 +178,8 @@ edges
 | simple.cpp:28:12:28:12 | call to a | simple.cpp:41:12:41:21 | call to user_input [void] | simple.cpp:28:12:28:12 | call to a | call to a flows from $@ | simple.cpp:41:12:41:21 | call to user_input [void] | call to user_input [void] |
 | simple.cpp:29:12:29:12 | call to b | simple.cpp:40:12:40:21 | call to user_input [void] | simple.cpp:29:12:29:12 | call to b | call to b flows from $@ | simple.cpp:40:12:40:21 | call to user_input [void] | call to user_input [void] |
 | simple.cpp:29:12:29:12 | call to b | simple.cpp:42:12:42:21 | call to user_input [void] | simple.cpp:29:12:29:12 | call to b | call to b flows from $@ | simple.cpp:42:12:42:21 | call to user_input [void] | call to user_input [void] |
+| struct_init.c:15:12:15:12 | a | struct_init.c:20:20:20:29 | call to user_input [void] | struct_init.c:15:12:15:12 | a | a flows from $@ | struct_init.c:20:20:20:29 | call to user_input [void] | call to user_input [void] |
+| struct_init.c:15:12:15:12 | a | struct_init.c:27:7:27:16 | call to user_input [void] | struct_init.c:15:12:15:12 | a | a flows from $@ | struct_init.c:27:7:27:16 | call to user_input [void] | call to user_input [void] |
 | struct_init.c:22:11:22:11 | a | struct_init.c:20:20:20:29 | call to user_input [void] | struct_init.c:22:11:22:11 | a | a flows from $@ | struct_init.c:20:20:20:29 | call to user_input [void] | call to user_input [void] |
 | struct_init.c:31:23:31:23 | a | struct_init.c:27:7:27:16 | call to user_input [void] | struct_init.c:31:23:31:23 | a | a flows from $@ | struct_init.c:27:7:27:16 | call to user_input [void] | call to user_input [void] |
+| struct_init.c:33:25:33:25 | a | struct_init.c:20:20:20:29 | call to user_input [void] | struct_init.c:33:25:33:25 | a | a flows from $@ | struct_init.c:20:20:20:29 | call to user_input [void] | call to user_input [void] |

--- a/cpp/ql/test/library-tests/dataflow/fields/flow.expected
+++ b/cpp/ql/test/library-tests/dataflow/fields/flow.expected
@@ -24,7 +24,12 @@ edges
 | A.cpp:103:14:103:14 | c [a, ... (1)] | A.cpp:120:12:120:13 | c1 [a, ... (1)] |
 | A.cpp:107:12:107:13 | c1 [a, ... (1)] | A.cpp:107:16:107:16 | a |
 | A.cpp:120:12:120:13 | c1 [a, ... (1)] | A.cpp:120:16:120:16 | a |
+| A.cpp:126:5:126:5 | b [post update] [c, ... (1)] | A.cpp:131:8:131:8 | ref arg b [c, ... (1)] |
+| A.cpp:126:12:126:18 | new [void] | A.cpp:126:5:126:5 | b [post update] [c, ... (1)] |
+| A.cpp:131:8:131:8 | ref arg b [c, ... (1)] | A.cpp:132:10:132:10 | b [c, ... (1)] |
+| A.cpp:132:10:132:10 | b [c, ... (1)] | A.cpp:132:13:132:13 | c |
 | A.cpp:142:7:142:7 | b [post update] [c, ... (1)] | A.cpp:143:7:143:31 | ... = ... [c, ... (1)] |
+| A.cpp:142:7:142:7 | b [post update] [c, ... (1)] | A.cpp:151:18:151:18 | ref arg b [c, ... (1)] |
 | A.cpp:142:7:142:20 | ... = ... [void] | A.cpp:142:7:142:7 | b [post update] [c, ... (1)] |
 | A.cpp:142:14:142:20 | new [void] | A.cpp:142:7:142:20 | ... = ... [void] |
 | A.cpp:143:7:143:10 | this [post update] [b, ... (1)] | A.cpp:151:12:151:24 | call to D [b, ... (1)] |
@@ -36,9 +41,11 @@ edges
 | A.cpp:151:12:151:24 | call to D [b, ... (1)] | A.cpp:152:10:152:10 | d [b, ... (1)] |
 | A.cpp:151:12:151:24 | call to D [b, ... (2)] | A.cpp:153:10:153:10 | d [b, ... (2)] |
 | A.cpp:151:18:151:18 | b [void] | A.cpp:151:12:151:24 | call to D [b, ... (1)] |
+| A.cpp:151:18:151:18 | ref arg b [c, ... (1)] | A.cpp:154:10:154:10 | b [c, ... (1)] |
 | A.cpp:152:10:152:10 | d [b, ... (1)] | A.cpp:152:13:152:13 | b |
 | A.cpp:153:10:153:10 | d [b, ... (2)] | A.cpp:153:13:153:13 | b [c, ... (1)] |
 | A.cpp:153:13:153:13 | b [c, ... (1)] | A.cpp:153:16:153:16 | c |
+| A.cpp:154:10:154:10 | b [c, ... (1)] | A.cpp:154:13:154:13 | c |
 | A.cpp:159:12:159:18 | new [void] | A.cpp:160:29:160:29 | b [void] |
 | A.cpp:160:18:160:60 | call to MyList [head, ... (1)] | A.cpp:161:38:161:39 | l1 [head, ... (1)] |
 | A.cpp:160:29:160:29 | b [void] | A.cpp:160:18:160:60 | call to MyList [head, ... (1)] |
@@ -137,9 +144,11 @@ edges
 | A.cpp:75:14:75:14 | c | A.cpp:73:25:73:32 | new [void] | A.cpp:75:14:75:14 | c | c flows from $@ | A.cpp:73:25:73:32 | new [void] | new [void] |
 | A.cpp:107:16:107:16 | a | A.cpp:98:12:98:18 | new [void] | A.cpp:107:16:107:16 | a | a flows from $@ | A.cpp:98:12:98:18 | new [void] | new [void] |
 | A.cpp:120:16:120:16 | a | A.cpp:98:12:98:18 | new [void] | A.cpp:120:16:120:16 | a | a flows from $@ | A.cpp:98:12:98:18 | new [void] | new [void] |
+| A.cpp:132:13:132:13 | c | A.cpp:126:12:126:18 | new [void] | A.cpp:132:13:132:13 | c | c flows from $@ | A.cpp:126:12:126:18 | new [void] | new [void] |
 | A.cpp:152:13:152:13 | b | A.cpp:143:25:143:31 | new [void] | A.cpp:152:13:152:13 | b | b flows from $@ | A.cpp:143:25:143:31 | new [void] | new [void] |
 | A.cpp:152:13:152:13 | b | A.cpp:150:12:150:18 | new [void] | A.cpp:152:13:152:13 | b | b flows from $@ | A.cpp:150:12:150:18 | new [void] | new [void] |
 | A.cpp:153:16:153:16 | c | A.cpp:142:14:142:20 | new [void] | A.cpp:153:16:153:16 | c | c flows from $@ | A.cpp:142:14:142:20 | new [void] | new [void] |
+| A.cpp:154:13:154:13 | c | A.cpp:142:14:142:20 | new [void] | A.cpp:154:13:154:13 | c | c flows from $@ | A.cpp:142:14:142:20 | new [void] | new [void] |
 | A.cpp:165:26:165:29 | head | A.cpp:159:12:159:18 | new [void] | A.cpp:165:26:165:29 | head | head flows from $@ | A.cpp:159:12:159:18 | new [void] | new [void] |
 | A.cpp:169:15:169:18 | head | A.cpp:159:12:159:18 | new [void] | A.cpp:169:15:169:18 | head | head flows from $@ | A.cpp:159:12:159:18 | new [void] | new [void] |
 | B.cpp:9:20:9:24 | elem1 | B.cpp:6:15:6:24 | new [void] | B.cpp:9:20:9:24 | elem1 | elem1 flows from $@ | B.cpp:6:15:6:24 | new [void] | new [void] |

--- a/cpp/ql/test/library-tests/dataflow/taint-tests/localTaint.expected
+++ b/cpp/ql/test/library-tests/dataflow/taint-tests/localTaint.expected
@@ -131,26 +131,26 @@
 | taint.cpp:121:10:121:11 | 1 | taint.cpp:124:13:124:14 | t2 |  |
 | taint.cpp:122:10:122:11 | 1 | taint.cpp:125:13:125:14 | t3 |  |
 | taint.cpp:123:12:123:14 | & ... | taint.cpp:129:8:129:9 | p1 |  |
-| taint.cpp:123:13:123:14 | t1 | taint.cpp:123:12:123:14 | & ... | TAINT |
+| taint.cpp:123:13:123:14 | t1 | taint.cpp:123:12:123:14 | & ... |  |
 | taint.cpp:124:12:124:14 | & ... | taint.cpp:127:3:127:4 | p2 |  |
 | taint.cpp:124:12:124:14 | & ... | taint.cpp:130:8:130:9 | p2 |  |
-| taint.cpp:124:13:124:14 | t2 | taint.cpp:124:12:124:14 | & ... | TAINT |
+| taint.cpp:124:13:124:14 | t2 | taint.cpp:124:12:124:14 | & ... |  |
 | taint.cpp:125:12:125:14 | & ... | taint.cpp:131:8:131:9 | p3 |  |
-| taint.cpp:125:13:125:14 | t3 | taint.cpp:125:12:125:14 | & ... | TAINT |
-| taint.cpp:127:3:127:4 | p2 | taint.cpp:127:2:127:4 | * ... | TAINT |
+| taint.cpp:125:13:125:14 | t3 | taint.cpp:125:12:125:14 | & ... |  |
+| taint.cpp:127:3:127:4 | p2 | taint.cpp:127:2:127:4 | * ... |  |
 | taint.cpp:127:8:127:13 | call to source | taint.cpp:127:2:127:15 | ... = ... |  |
-| taint.cpp:129:8:129:9 | p1 | taint.cpp:129:7:129:9 | * ... | TAINT |
-| taint.cpp:130:8:130:9 | p2 | taint.cpp:130:7:130:9 | * ... | TAINT |
-| taint.cpp:131:8:131:9 | p3 | taint.cpp:131:7:131:9 | * ... | TAINT |
+| taint.cpp:129:8:129:9 | p1 | taint.cpp:129:7:129:9 | * ... |  |
+| taint.cpp:130:8:130:9 | p2 | taint.cpp:130:7:130:9 | * ... |  |
+| taint.cpp:131:8:131:9 | p3 | taint.cpp:131:7:131:9 | * ... |  |
 | taint.cpp:133:7:133:9 | & ... | taint.cpp:133:2:133:9 | ... = ... |  |
 | taint.cpp:133:7:133:9 | & ... | taint.cpp:134:8:134:9 | p3 |  |
 | taint.cpp:133:7:133:9 | & ... | taint.cpp:136:3:136:4 | p3 |  |
 | taint.cpp:133:7:133:9 | & ... | taint.cpp:137:8:137:9 | p3 |  |
-| taint.cpp:133:8:133:9 | t1 | taint.cpp:133:7:133:9 | & ... | TAINT |
-| taint.cpp:134:8:134:9 | p3 | taint.cpp:134:7:134:9 | * ... | TAINT |
-| taint.cpp:136:3:136:4 | p3 | taint.cpp:136:2:136:4 | * ... | TAINT |
+| taint.cpp:133:8:133:9 | t1 | taint.cpp:133:7:133:9 | & ... |  |
+| taint.cpp:134:8:134:9 | p3 | taint.cpp:134:7:134:9 | * ... |  |
+| taint.cpp:136:3:136:4 | p3 | taint.cpp:136:2:136:4 | * ... |  |
 | taint.cpp:136:8:136:8 | 0 | taint.cpp:136:2:136:8 | ... = ... |  |
-| taint.cpp:137:8:137:9 | p3 | taint.cpp:137:7:137:9 | * ... | TAINT |
+| taint.cpp:137:8:137:9 | p3 | taint.cpp:137:7:137:9 | * ... |  |
 | taint.cpp:142:16:142:16 | i | taint.cpp:143:6:143:6 | i |  |
 | taint.cpp:142:23:142:23 | a | taint.cpp:144:10:144:10 | a |  |
 | taint.cpp:142:30:142:30 | b | taint.cpp:146:10:146:10 | b |  |
@@ -177,15 +177,17 @@
 | taint.cpp:172:10:172:15 | ref arg buffer | taint.cpp:173:8:173:13 | buffer |  |
 | taint.cpp:172:18:172:24 | tainted | taint.cpp:172:10:172:15 | ref arg buffer | TAINT |
 | taint.cpp:180:19:180:19 | p | taint.cpp:181:9:181:9 | p |  |
-| taint.cpp:181:9:181:9 | p | taint.cpp:181:8:181:9 | * ... | TAINT |
+| taint.cpp:181:9:181:9 | p | taint.cpp:181:8:181:9 | * ... |  |
 | taint.cpp:185:11:185:16 | call to source | taint.cpp:186:11:186:11 | x |  |
-| taint.cpp:186:11:186:11 | x | taint.cpp:186:10:186:11 | & ... | TAINT |
+| taint.cpp:186:10:186:11 | ref arg & ... | taint.cpp:186:10:186:11 | & ... |  |
+| taint.cpp:186:11:186:11 | x | taint.cpp:186:10:186:11 | & ... |  |
 | taint.cpp:192:23:192:28 | source | taint.cpp:194:13:194:18 | source |  |
 | taint.cpp:193:6:193:6 | x | taint.cpp:194:10:194:10 | x |  |
 | taint.cpp:193:6:193:6 | x | taint.cpp:195:7:195:7 | x |  |
 | taint.cpp:194:9:194:10 | & ... | taint.cpp:194:2:194:7 | call to memcpy |  |
+| taint.cpp:194:9:194:10 | ref arg & ... | taint.cpp:194:9:194:10 | & ... |  |
 | taint.cpp:194:9:194:10 | ref arg & ... | taint.cpp:195:7:195:7 | x |  |
-| taint.cpp:194:10:194:10 | x | taint.cpp:194:9:194:10 | & ... | TAINT |
+| taint.cpp:194:10:194:10 | x | taint.cpp:194:9:194:10 | & ... |  |
 | taint.cpp:194:13:194:18 | source | taint.cpp:194:9:194:10 | ref arg & ... | TAINT |
 | taint.cpp:194:21:194:31 | sizeof(int) | taint.cpp:194:9:194:10 | ref arg & ... | TAINT |
 | taint.cpp:207:6:207:11 | call to source | taint.cpp:207:2:207:13 | ... = ... |  |

--- a/cpp/ql/test/library-tests/dataflow/taint-tests/localTaint.expected
+++ b/cpp/ql/test/library-tests/dataflow/taint-tests/localTaint.expected
@@ -184,7 +184,6 @@
 | taint.cpp:193:6:193:6 | x | taint.cpp:194:10:194:10 | x |  |
 | taint.cpp:193:6:193:6 | x | taint.cpp:195:7:195:7 | x |  |
 | taint.cpp:194:9:194:10 | & ... | taint.cpp:194:2:194:7 | call to memcpy |  |
-| taint.cpp:194:9:194:10 | ref arg & ... | taint.cpp:194:2:194:7 | call to memcpy |  |
 | taint.cpp:194:9:194:10 | ref arg & ... | taint.cpp:195:7:195:7 | x |  |
 | taint.cpp:194:10:194:10 | x | taint.cpp:194:9:194:10 | & ... | TAINT |
 | taint.cpp:194:13:194:18 | source | taint.cpp:194:9:194:10 | ref arg & ... | TAINT |

--- a/cpp/ql/test/library-tests/dataflow/taint-tests/localTaint.expected
+++ b/cpp/ql/test/library-tests/dataflow/taint-tests/localTaint.expected
@@ -162,6 +162,7 @@
 | taint.cpp:165:22:165:25 | {...} | taint.cpp:172:10:172:15 | buffer |  |
 | taint.cpp:165:22:165:25 | {...} | taint.cpp:173:8:173:13 | buffer |  |
 | taint.cpp:165:24:165:24 | 0 | taint.cpp:165:22:165:25 | {...} | TAINT |
+| taint.cpp:168:8:168:14 | ref arg tainted | taint.cpp:172:18:172:24 | tainted |  |
 | taint.cpp:170:10:170:15 | buffer | taint.cpp:170:3:170:8 | call to strcpy |  |
 | taint.cpp:170:10:170:15 | ref arg buffer | taint.cpp:170:3:170:8 | call to strcpy |  |
 | taint.cpp:170:10:170:15 | ref arg buffer | taint.cpp:171:8:171:13 | buffer |  |


### PR DESCRIPTION
(the first two commits are from #1777).

The data flow library conflates pointers and their objects in some places but not others. It might be ideal to avoid that conflation, but that's not realistic without using the IR.

We've had good experience in the taint tracking library with conflating pointers and objects, and it improves results for field flow, so perhaps it's time to try it out for all data flow.

To do: performance testing, change note, and discussing whether this is a good idea at all.