### PR TITLE
Python: Prevent bad magic during pruning.

### DIFF
--- a/python/ql/src/semmle/python/Pruning.qll
+++ b/python/ql/src/semmle/python/Pruning.qll
@@ -525,6 +525,7 @@ module Pruner {
     }
 
     /** Holds if `cond` holds for `var` on conditional edge `pred` -> `succ` as a result of the test for that edge */
+    pragma [nomagic]
     predicate constraintOnBranch(UnprunedBasicBlock pred, UnprunedBasicBlock succ, Constraint cond, SsaVariable var) {
         cond = constraintFromTest(var, pred.last()) and
         succ = pred.getATrueSuccessor()


### PR DESCRIPTION
Fixes the performance regression seen on `uncompyle2` and similar projects.

Apart from that, performance seems to be largely unaffected: https://git.semmle.com/gist/taus/301adf79e25da02231534b42015a0462