### PR TITLE
C++: Don't propagate taint between field and struct [CPP-410]

### DIFF
--- a/cpp/ql/src/semmle/code/cpp/dataflow/internal/TaintTrackingUtil.qll
+++ b/cpp/ql/src/semmle/code/cpp/dataflow/internal/TaintTrackingUtil.qll
@@ -86,6 +86,10 @@ private predicate noFlowFromChildExpr(Expr e) {
   e instanceof SizeofOperator
   or
   e instanceof AlignofOperator
+  or
+  e instanceof ClassAggregateLiteral
+  or
+  e instanceof FieldAccess
 }
 
 private predicate exprToDefinitionByReferenceStep(Expr exprIn, Expr argOut) {

--- a/cpp/ql/test/library-tests/dataflow/taint-tests/localTaint.expected
+++ b/cpp/ql/test/library-tests/dataflow/taint-tests/localTaint.expected
@@ -1,25 +1,9 @@
-| file://:0:0:0:0 | t | taint.cpp:235:11:239:2 | {...} | TAINT |
-| file://:0:0:0:0 | t | taint.cpp:243:11:246:2 | {...} | TAINT |
-| file://:0:0:0:0 | this | file://:0:0:0:0 | t | TAINT |
-| file://:0:0:0:0 | this | file://:0:0:0:0 | t | TAINT |
-| file://:0:0:0:0 | this | file://:0:0:0:0 | t | TAINT |
-| file://:0:0:0:0 | this | file://:0:0:0:0 | t | TAINT |
 | file://:0:0:0:0 | this | file://:0:0:0:0 | this |  |
 | file://:0:0:0:0 | this | file://:0:0:0:0 | this |  |
 | file://:0:0:0:0 | this | file://:0:0:0:0 | this |  |
 | file://:0:0:0:0 | this | file://:0:0:0:0 | this |  |
 | file://:0:0:0:0 | this | file://:0:0:0:0 | this |  |
 | file://:0:0:0:0 | this | file://:0:0:0:0 | this |  |
-| file://:0:0:0:0 | this | file://:0:0:0:0 | u | TAINT |
-| file://:0:0:0:0 | this | file://:0:0:0:0 | u | TAINT |
-| file://:0:0:0:0 | this | file://:0:0:0:0 | u | TAINT |
-| file://:0:0:0:0 | this | file://:0:0:0:0 | v | TAINT |
-| file://:0:0:0:0 | this | taint.cpp:72:3:72:3 | c | TAINT |
-| file://:0:0:0:0 | this | taint.cpp:73:3:73:3 | d | TAINT |
-| file://:0:0:0:0 | this | taint.cpp:77:3:77:3 | d | TAINT |
-| file://:0:0:0:0 | u | taint.cpp:235:11:239:2 | {...} | TAINT |
-| file://:0:0:0:0 | u | taint.cpp:243:11:246:2 | {...} | TAINT |
-| file://:0:0:0:0 | v | taint.cpp:235:11:239:2 | {...} | TAINT |
 | taint.cpp:4:27:4:33 | source1 | taint.cpp:6:13:6:19 | source1 |  |
 | taint.cpp:4:40:4:45 | clean1 | taint.cpp:5:8:5:13 | clean1 |  |
 | taint.cpp:4:40:4:45 | clean1 | taint.cpp:6:3:6:8 | clean1 |  |
@@ -87,14 +71,6 @@
 | taint.cpp:86:2:86:4 | mc1 [post update] | taint.cpp:89:7:89:9 | mc1 |  |
 | taint.cpp:86:2:86:4 | mc1 [post update] | taint.cpp:90:7:90:9 | mc1 |  |
 | taint.cpp:86:2:86:4 | mc1 [post update] | taint.cpp:91:7:91:9 | mc1 |  |
-| taint.cpp:88:7:88:9 | mc1 | taint.cpp:88:11:88:11 | a | TAINT |
-| taint.cpp:89:7:89:9 | mc1 | taint.cpp:89:11:89:11 | b | TAINT |
-| taint.cpp:90:7:90:9 | mc1 | taint.cpp:90:11:90:11 | c | TAINT |
-| taint.cpp:91:7:91:9 | mc1 | taint.cpp:91:11:91:11 | d | TAINT |
-| taint.cpp:92:7:92:9 | mc2 | taint.cpp:92:11:92:11 | a | TAINT |
-| taint.cpp:93:7:93:9 | mc2 | taint.cpp:93:11:93:11 | b | TAINT |
-| taint.cpp:94:7:94:9 | mc2 | taint.cpp:94:11:94:11 | c | TAINT |
-| taint.cpp:95:7:95:9 | mc2 | taint.cpp:95:11:95:11 | d | TAINT |
 | taint.cpp:100:21:100:21 | i | taint.cpp:106:7:106:7 | i |  |
 | taint.cpp:100:21:100:21 | i | taint.cpp:110:12:110:12 | i |  |
 | taint.cpp:100:21:100:21 | i | taint.cpp:112:12:112:12 | i |  |
@@ -220,8 +196,6 @@
 | taint.cpp:228:11:228:11 | `this` parameter in (constructor) | taint.cpp:243:11:243:11 | constructor init of field t [pre-this] |  |
 | taint.cpp:228:11:232:2 | [...](...){...} | taint.cpp:233:7:233:7 | a |  |
 | taint.cpp:228:11:232:2 | {...} | taint.cpp:228:11:232:2 | [...](...){...} |  |
-| taint.cpp:228:12:228:12 | t | taint.cpp:228:11:232:2 | {...} | TAINT |
-| taint.cpp:228:15:228:15 | u | taint.cpp:228:11:232:2 | {...} | TAINT |
 | taint.cpp:228:17:228:17 | `this` parameter in operator() | file://:0:0:0:0 | this |  |
 | taint.cpp:228:17:228:17 | `this` parameter in operator() | file://:0:0:0:0 | this |  |
 | taint.cpp:235:11:235:11 | Unknown literal | taint.cpp:235:11:235:11 | constructor init of field t | TAINT |

--- a/cpp/ql/test/library-tests/dataflow/taint-tests/taint.expected
+++ b/cpp/ql/test/library-tests/dataflow/taint-tests/taint.expected
@@ -1,9 +1,6 @@
 | file://:0:0:0:0 | t | taint.cpp:223:10:223:15 | call to source |
 | file://:0:0:0:0 | t | taint.cpp:223:10:223:15 | call to source |
 | file://:0:0:0:0 | t | taint.cpp:223:10:223:15 | call to source |
-| file://:0:0:0:0 | u | taint.cpp:223:10:223:15 | call to source |
-| file://:0:0:0:0 | u | taint.cpp:223:10:223:15 | call to source |
-| file://:0:0:0:0 | u | taint.cpp:223:10:223:15 | call to source |
 | taint.cpp:8:8:8:13 | clean1 | taint.cpp:4:27:4:33 | source1 |
 | taint.cpp:16:8:16:14 | source1 | taint.cpp:12:22:12:27 | call to source |
 | taint.cpp:17:8:17:16 | ++ ... | taint.cpp:12:22:12:27 | call to source |


### PR DESCRIPTION
To compensate for the lack of field flow, the taint tracking library has previously considered taint to flow from fields to their containing structs and back again from the structs to any of their fields. This leads to false flow between unrelated fields and is not needed now that we have proper flow through fields.

Note: this PR will conflict with #1781.