### PR TITLE
C++/C#/Java: Pyrameterize ConfigurationRecursionPrevention

### DIFF
--- a/change-notes/1.22/analysis-cpp.md
+++ b/change-notes/1.22/analysis-cpp.md
@@ -29,3 +29,4 @@
 - Fixed the `LocalScopeVariableReachability.qll` library's handling of loops with an entry condition is both always true upon first entry, and where there is more than one control flow path through the loop condition.  This change increases the accuracy of the `LocalScopeVariableReachability.qll` library and queries which depend on it.
 - The `semmle.code.cpp.models` library now models data flow through `std::swap`.
 - There is a new `Variable.isThreadLocal()` predicate. It can be used to tell whether a variable is `thread_local`.
+- Recursion through the `DataFlow` library is now always a compile error. Such recursion has been deprecated since release 1.16. If one `DataFlow::Configuration` needs to depend on the results of another, switch one of them to use one of the `DataFlow2` through `DataFlow4` libraries.

--- a/cpp/ql/src/semmle/code/cpp/dataflow/DataFlow2.qll
+++ b/cpp/ql/src/semmle/code/cpp/dataflow/DataFlow2.qll
@@ -12,27 +12,4 @@ import cpp
 
 module DataFlow2 {
   import semmle.code.cpp.dataflow.internal.DataFlowImpl2
-
-  /**
-   * This class exists to prevent mutual recursion between the user-overridden
-   * member predicates of `Configuration` and the rest of the data-flow library.
-   * Good performance cannot be guaranteed in the presence of such recursion, so
-   * it should be replaced by using more than one copy of the data flow library.
-   * Four copies are available: `DataFlow` through `DataFlow4`.
-   */
-  private abstract
-  class ConfigurationRecursionPrevention extends Configuration {
-    bindingset[this]
-    ConfigurationRecursionPrevention() { any() }
-
-    override predicate hasFlow(Node source, Node sink) {
-      strictcount(Node n | this.isSource(n)) < 0
-      or
-      strictcount(Node n | this.isSink(n)) < 0
-      or
-      strictcount(Node n1, Node n2 | this.isAdditionalFlowStep(n1, n2)) < 0
-      or
-      super.hasFlow(source, sink)
-    }
-  }
 }

--- a/cpp/ql/src/semmle/code/cpp/dataflow/DataFlow3.qll
+++ b/cpp/ql/src/semmle/code/cpp/dataflow/DataFlow3.qll
@@ -12,27 +12,4 @@ import cpp
 
 module DataFlow3 {
   import semmle.code.cpp.dataflow.internal.DataFlowImpl3
-
-  /**
-   * This class exists to prevent mutual recursion between the user-overridden
-   * member predicates of `Configuration` and the rest of the data-flow library.
-   * Good performance cannot be guaranteed in the presence of such recursion, so
-   * it should be replaced by using more than one copy of the data flow library.
-   * Four copies are available: `DataFlow` through `DataFlow4`.
-   */
-  private abstract
-  class ConfigurationRecursionPrevention extends Configuration {
-    bindingset[this]
-    ConfigurationRecursionPrevention() { any() }
-
-    override predicate hasFlow(Node source, Node sink) {
-      strictcount(Node n | this.isSource(n)) < 0
-      or
-      strictcount(Node n | this.isSink(n)) < 0
-      or
-      strictcount(Node n1, Node n2 | this.isAdditionalFlowStep(n1, n2)) < 0
-      or
-      super.hasFlow(source, sink)
-    }
-  }
 }

--- a/cpp/ql/src/semmle/code/cpp/dataflow/DataFlow4.qll
+++ b/cpp/ql/src/semmle/code/cpp/dataflow/DataFlow4.qll
@@ -12,27 +12,4 @@ import cpp
 
 module DataFlow4 {
   import semmle.code.cpp.dataflow.internal.DataFlowImpl4
-
-  /**
-   * This class exists to prevent mutual recursion between the user-overridden
-   * member predicates of `Configuration` and the rest of the data-flow library.
-   * Good performance cannot be guaranteed in the presence of such recursion, so
-   * it should be replaced by using more than one copy of the data flow library.
-   * Four copies are available: `DataFlow` through `DataFlow4`.
-   */
-  private abstract
-  class ConfigurationRecursionPrevention extends Configuration {
-    bindingset[this]
-    ConfigurationRecursionPrevention() { any() }
-
-    override predicate hasFlow(Node source, Node sink) {
-      strictcount(Node n | this.isSource(n)) < 0
-      or
-      strictcount(Node n | this.isSink(n)) < 0
-      or
-      strictcount(Node n1, Node n2 | this.isAdditionalFlowStep(n1, n2)) < 0
-      or
-      super.hasFlow(source, sink)
-    }
-  }
 }

--- a/cpp/ql/src/semmle/code/cpp/dataflow/internal/DataFlowImpl.qll
+++ b/cpp/ql/src/semmle/code/cpp/dataflow/internal/DataFlowImpl.qll
@@ -127,8 +127,7 @@ abstract class Configuration extends string {
  * Good performance cannot be guaranteed in the presence of such recursion, so
  * it should be replaced by using more than one copy of the data flow library.
  */
-private abstract
-class ConfigurationRecursionPrevention extends Configuration {
+abstract private class ConfigurationRecursionPrevention extends Configuration {
   bindingset[this]
   ConfigurationRecursionPrevention() { any() }
 

--- a/cpp/ql/src/semmle/code/cpp/dataflow/internal/DataFlowImpl2.qll
+++ b/cpp/ql/src/semmle/code/cpp/dataflow/internal/DataFlowImpl2.qll
@@ -127,8 +127,7 @@ abstract class Configuration extends string {
  * Good performance cannot be guaranteed in the presence of such recursion, so
  * it should be replaced by using more than one copy of the data flow library.
  */
-private abstract
-class ConfigurationRecursionPrevention extends Configuration {
+abstract private class ConfigurationRecursionPrevention extends Configuration {
   bindingset[this]
   ConfigurationRecursionPrevention() { any() }
 

--- a/cpp/ql/src/semmle/code/cpp/dataflow/internal/DataFlowImpl3.qll
+++ b/cpp/ql/src/semmle/code/cpp/dataflow/internal/DataFlowImpl3.qll
@@ -127,8 +127,7 @@ abstract class Configuration extends string {
  * Good performance cannot be guaranteed in the presence of such recursion, so
  * it should be replaced by using more than one copy of the data flow library.
  */
-private abstract
-class ConfigurationRecursionPrevention extends Configuration {
+abstract private class ConfigurationRecursionPrevention extends Configuration {
   bindingset[this]
   ConfigurationRecursionPrevention() { any() }
 

--- a/cpp/ql/src/semmle/code/cpp/dataflow/internal/DataFlowImpl4.qll
+++ b/cpp/ql/src/semmle/code/cpp/dataflow/internal/DataFlowImpl4.qll
@@ -127,8 +127,7 @@ abstract class Configuration extends string {
  * Good performance cannot be guaranteed in the presence of such recursion, so
  * it should be replaced by using more than one copy of the data flow library.
  */
-private abstract
-class ConfigurationRecursionPrevention extends Configuration {
+abstract private class ConfigurationRecursionPrevention extends Configuration {
   bindingset[this]
   ConfigurationRecursionPrevention() { any() }
 

--- a/cpp/ql/src/semmle/code/cpp/ir/dataflow/DataFlow2.qll
+++ b/cpp/ql/src/semmle/code/cpp/ir/dataflow/DataFlow2.qll
@@ -12,27 +12,4 @@ import cpp
 
 module DataFlow2 {
   import semmle.code.cpp.ir.dataflow.internal.DataFlowImpl2
-
-  /**
-   * This class exists to prevent mutual recursion between the user-overridden
-   * member predicates of `Configuration` and the rest of the data-flow library.
-   * Good performance cannot be guaranteed in the presence of such recursion, so
-   * it should be replaced by using more than one copy of the data flow library.
-   * Four copies are available: `DataFlow` through `DataFlow4`.
-   */
-  private abstract
-  class ConfigurationRecursionPrevention extends Configuration {
-    bindingset[this]
-    ConfigurationRecursionPrevention() { any() }
-
-    override predicate hasFlow(Node source, Node sink) {
-      strictcount(Node n | this.isSource(n)) < 0
-      or
-      strictcount(Node n | this.isSink(n)) < 0
-      or
-      strictcount(Node n1, Node n2 | this.isAdditionalFlowStep(n1, n2)) < 0
-      or
-      super.hasFlow(source, sink)
-    }
-  }
 }

--- a/cpp/ql/src/semmle/code/cpp/ir/dataflow/DataFlow3.qll
+++ b/cpp/ql/src/semmle/code/cpp/ir/dataflow/DataFlow3.qll
@@ -12,27 +12,4 @@ import cpp
 
 module DataFlow3 {
   import semmle.code.cpp.ir.dataflow.internal.DataFlowImpl3
-
-  /**
-   * This class exists to prevent mutual recursion between the user-overridden
-   * member predicates of `Configuration` and the rest of the data-flow library.
-   * Good performance cannot be guaranteed in the presence of such recursion, so
-   * it should be replaced by using more than one copy of the data flow library.
-   * Four copies are available: `DataFlow` through `DataFlow4`.
-   */
-  private abstract
-  class ConfigurationRecursionPrevention extends Configuration {
-    bindingset[this]
-    ConfigurationRecursionPrevention() { any() }
-
-    override predicate hasFlow(Node source, Node sink) {
-      strictcount(Node n | this.isSource(n)) < 0
-      or
-      strictcount(Node n | this.isSink(n)) < 0
-      or
-      strictcount(Node n1, Node n2 | this.isAdditionalFlowStep(n1, n2)) < 0
-      or
-      super.hasFlow(source, sink)
-    }
-  }
 }

--- a/cpp/ql/src/semmle/code/cpp/ir/dataflow/DataFlow4.qll
+++ b/cpp/ql/src/semmle/code/cpp/ir/dataflow/DataFlow4.qll
@@ -12,27 +12,4 @@ import cpp
 
 module DataFlow4 {
   import semmle.code.cpp.ir.dataflow.internal.DataFlowImpl4
-
-  /**
-   * This class exists to prevent mutual recursion between the user-overridden
-   * member predicates of `Configuration` and the rest of the data-flow library.
-   * Good performance cannot be guaranteed in the presence of such recursion, so
-   * it should be replaced by using more than one copy of the data flow library.
-   * Four copies are available: `DataFlow` through `DataFlow4`.
-   */
-  private abstract
-  class ConfigurationRecursionPrevention extends Configuration {
-    bindingset[this]
-    ConfigurationRecursionPrevention() { any() }
-
-    override predicate hasFlow(Node source, Node sink) {
-      strictcount(Node n | this.isSource(n)) < 0
-      or
-      strictcount(Node n | this.isSink(n)) < 0
-      or
-      strictcount(Node n1, Node n2 | this.isAdditionalFlowStep(n1, n2)) < 0
-      or
-      super.hasFlow(source, sink)
-    }
-  }
 }

--- a/cpp/ql/src/semmle/code/cpp/ir/dataflow/internal/DataFlowImpl.qll
+++ b/cpp/ql/src/semmle/code/cpp/ir/dataflow/internal/DataFlowImpl.qll
@@ -127,8 +127,7 @@ abstract class Configuration extends string {
  * Good performance cannot be guaranteed in the presence of such recursion, so
  * it should be replaced by using more than one copy of the data flow library.
  */
-private abstract
-class ConfigurationRecursionPrevention extends Configuration {
+abstract private class ConfigurationRecursionPrevention extends Configuration {
   bindingset[this]
   ConfigurationRecursionPrevention() { any() }
 

--- a/cpp/ql/src/semmle/code/cpp/ir/dataflow/internal/DataFlowImpl2.qll
+++ b/cpp/ql/src/semmle/code/cpp/ir/dataflow/internal/DataFlowImpl2.qll
@@ -127,8 +127,7 @@ abstract class Configuration extends string {
  * Good performance cannot be guaranteed in the presence of such recursion, so
  * it should be replaced by using more than one copy of the data flow library.
  */
-private abstract
-class ConfigurationRecursionPrevention extends Configuration {
+abstract private class ConfigurationRecursionPrevention extends Configuration {
   bindingset[this]
   ConfigurationRecursionPrevention() { any() }
 

--- a/cpp/ql/src/semmle/code/cpp/ir/dataflow/internal/DataFlowImpl3.qll
+++ b/cpp/ql/src/semmle/code/cpp/ir/dataflow/internal/DataFlowImpl3.qll
@@ -127,8 +127,7 @@ abstract class Configuration extends string {
  * Good performance cannot be guaranteed in the presence of such recursion, so
  * it should be replaced by using more than one copy of the data flow library.
  */
-private abstract
-class ConfigurationRecursionPrevention extends Configuration {
+abstract private class ConfigurationRecursionPrevention extends Configuration {
   bindingset[this]
   ConfigurationRecursionPrevention() { any() }
 

--- a/cpp/ql/src/semmle/code/cpp/ir/dataflow/internal/DataFlowImpl4.qll
+++ b/cpp/ql/src/semmle/code/cpp/ir/dataflow/internal/DataFlowImpl4.qll
@@ -127,8 +127,7 @@ abstract class Configuration extends string {
  * Good performance cannot be guaranteed in the presence of such recursion, so
  * it should be replaced by using more than one copy of the data flow library.
  */
-private abstract
-class ConfigurationRecursionPrevention extends Configuration {
+abstract private class ConfigurationRecursionPrevention extends Configuration {
   bindingset[this]
   ConfigurationRecursionPrevention() { any() }
 

--- a/csharp/ql/src/semmle/code/csharp/dataflow/DataFlow.qll
+++ b/csharp/ql/src/semmle/code/csharp/dataflow/DataFlow.qll
@@ -7,23 +7,4 @@ import csharp
 
 module DataFlow {
   import semmle.code.csharp.dataflow.internal.DataFlowImpl
-
-  /**
-   * This class exists to prevent mutual recursion between the user-overridden
-   * member predicates of `Configuration` and the rest of the data-flow library.
-   * Good performance cannot be guaranteed in the presence of such recursion, so
-   * it should be replaced by using more than one copy of the data flow library.
-   * Five copies are available: `DataFlow` through `DataFlow5`.
-   */
-  abstract private class ConfigurationRecursionPrevention extends Configuration {
-    bindingset[this]
-    ConfigurationRecursionPrevention() { any() }
-
-    override predicate hasFlow(Node source, Node sink) {
-      strictcount(Node n | this.isSource(n)) < 0 or
-      strictcount(Node n | this.isSink(n)) < 0 or
-      strictcount(Node n1, Node n2 | this.isAdditionalFlowStep(n1, n2)) < 0 or
-      super.hasFlow(source, sink)
-    }
-  }
 }

--- a/csharp/ql/src/semmle/code/csharp/dataflow/DataFlow2.qll
+++ b/csharp/ql/src/semmle/code/csharp/dataflow/DataFlow2.qll
@@ -7,23 +7,4 @@ import csharp
 
 module DataFlow2 {
   import semmle.code.csharp.dataflow.internal.DataFlowImpl2
-
-  /**
-   * This class exists to prevent mutual recursion between the user-overridden
-   * member predicates of `Configuration` and the rest of the data-flow library.
-   * Good performance cannot be guaranteed in the presence of such recursion, so
-   * it should be replaced by using more than one copy of the data flow library.
-   * Five copies are available: `DataFlow` through `DataFlow5`.
-   */
-  abstract private class ConfigurationRecursionPrevention extends Configuration {
-    bindingset[this]
-    ConfigurationRecursionPrevention() { any() }
-
-    override predicate hasFlow(Node source, Node sink) {
-      strictcount(Node n | this.isSource(n)) < 0 or
-      strictcount(Node n | this.isSink(n)) < 0 or
-      strictcount(Node n1, Node n2 | this.isAdditionalFlowStep(n1, n2)) < 0 or
-      super.hasFlow(source, sink)
-    }
-  }
 }

--- a/csharp/ql/src/semmle/code/csharp/dataflow/DataFlow3.qll
+++ b/csharp/ql/src/semmle/code/csharp/dataflow/DataFlow3.qll
@@ -7,23 +7,4 @@ import csharp
 
 module DataFlow3 {
   import semmle.code.csharp.dataflow.internal.DataFlowImpl3
-
-  /**
-   * This class exists to prevent mutual recursion between the user-overridden
-   * member predicates of `Configuration` and the rest of the data-flow library.
-   * Good performance cannot be guaranteed in the presence of such recursion, so
-   * it should be replaced by using more than one copy of the data flow library.
-   * Five copies are available: `DataFlow` through `DataFlow5`.
-   */
-  abstract private class ConfigurationRecursionPrevention extends Configuration {
-    bindingset[this]
-    ConfigurationRecursionPrevention() { any() }
-
-    override predicate hasFlow(Node source, Node sink) {
-      strictcount(Node n | this.isSource(n)) < 0 or
-      strictcount(Node n | this.isSink(n)) < 0 or
-      strictcount(Node n1, Node n2 | this.isAdditionalFlowStep(n1, n2)) < 0 or
-      super.hasFlow(source, sink)
-    }
-  }
 }

--- a/csharp/ql/src/semmle/code/csharp/dataflow/DataFlow4.qll
+++ b/csharp/ql/src/semmle/code/csharp/dataflow/DataFlow4.qll
@@ -7,23 +7,4 @@ import csharp
 
 module DataFlow4 {
   import semmle.code.csharp.dataflow.internal.DataFlowImpl4
-
-  /**
-   * This class exists to prevent mutual recursion between the user-overridden
-   * member predicates of `Configuration` and the rest of the data-flow library.
-   * Good performance cannot be guaranteed in the presence of such recursion, so
-   * it should be replaced by using more than one copy of the data flow library.
-   * Five copies are available: `DataFlow` through `DataFlow5`.
-   */
-  abstract private class ConfigurationRecursionPrevention extends Configuration {
-    bindingset[this]
-    ConfigurationRecursionPrevention() { any() }
-
-    override predicate hasFlow(Node source, Node sink) {
-      strictcount(Node n | this.isSource(n)) < 0 or
-      strictcount(Node n | this.isSink(n)) < 0 or
-      strictcount(Node n1, Node n2 | this.isAdditionalFlowStep(n1, n2)) < 0 or
-      super.hasFlow(source, sink)
-    }
-  }
 }

--- a/csharp/ql/src/semmle/code/csharp/dataflow/DataFlow5.qll
+++ b/csharp/ql/src/semmle/code/csharp/dataflow/DataFlow5.qll
@@ -7,23 +7,4 @@ import csharp
 
 module DataFlow5 {
   import semmle.code.csharp.dataflow.internal.DataFlowImpl5
-
-  /**
-   * This class exists to prevent mutual recursion between the user-overridden
-   * member predicates of `Configuration` and the rest of the data-flow library.
-   * Good performance cannot be guaranteed in the presence of such recursion, so
-   * it should be replaced by using more than one copy of the data flow library.
-   * Five copies are available: `DataFlow` through `DataFlow5`.
-   */
-  abstract private class ConfigurationRecursionPrevention extends Configuration {
-    bindingset[this]
-    ConfigurationRecursionPrevention() { any() }
-
-    override predicate hasFlow(Node source, Node sink) {
-      strictcount(Node n | this.isSource(n)) < 0 or
-      strictcount(Node n | this.isSink(n)) < 0 or
-      strictcount(Node n1, Node n2 | this.isAdditionalFlowStep(n1, n2)) < 0 or
-      super.hasFlow(source, sink)
-    }
-  }
 }

--- a/csharp/ql/src/semmle/code/csharp/dataflow/internal/DataFlowImpl.qll
+++ b/csharp/ql/src/semmle/code/csharp/dataflow/internal/DataFlowImpl.qll
@@ -127,8 +127,7 @@ abstract class Configuration extends string {
  * Good performance cannot be guaranteed in the presence of such recursion, so
  * it should be replaced by using more than one copy of the data flow library.
  */
-private abstract
-class ConfigurationRecursionPrevention extends Configuration {
+abstract private class ConfigurationRecursionPrevention extends Configuration {
   bindingset[this]
   ConfigurationRecursionPrevention() { any() }
 

--- a/csharp/ql/src/semmle/code/csharp/dataflow/internal/DataFlowImpl2.qll
+++ b/csharp/ql/src/semmle/code/csharp/dataflow/internal/DataFlowImpl2.qll
@@ -127,8 +127,7 @@ abstract class Configuration extends string {
  * Good performance cannot be guaranteed in the presence of such recursion, so
  * it should be replaced by using more than one copy of the data flow library.
  */
-private abstract
-class ConfigurationRecursionPrevention extends Configuration {
+abstract private class ConfigurationRecursionPrevention extends Configuration {
   bindingset[this]
   ConfigurationRecursionPrevention() { any() }
 

--- a/csharp/ql/src/semmle/code/csharp/dataflow/internal/DataFlowImpl3.qll
+++ b/csharp/ql/src/semmle/code/csharp/dataflow/internal/DataFlowImpl3.qll
@@ -127,8 +127,7 @@ abstract class Configuration extends string {
  * Good performance cannot be guaranteed in the presence of such recursion, so
  * it should be replaced by using more than one copy of the data flow library.
  */
-private abstract
-class ConfigurationRecursionPrevention extends Configuration {
+abstract private class ConfigurationRecursionPrevention extends Configuration {
   bindingset[this]
   ConfigurationRecursionPrevention() { any() }
 

--- a/csharp/ql/src/semmle/code/csharp/dataflow/internal/DataFlowImpl4.qll
+++ b/csharp/ql/src/semmle/code/csharp/dataflow/internal/DataFlowImpl4.qll
@@ -127,8 +127,7 @@ abstract class Configuration extends string {
  * Good performance cannot be guaranteed in the presence of such recursion, so
  * it should be replaced by using more than one copy of the data flow library.
  */
-private abstract
-class ConfigurationRecursionPrevention extends Configuration {
+abstract private class ConfigurationRecursionPrevention extends Configuration {
   bindingset[this]
   ConfigurationRecursionPrevention() { any() }
 

--- a/csharp/ql/src/semmle/code/csharp/dataflow/internal/DataFlowImpl5.qll
+++ b/csharp/ql/src/semmle/code/csharp/dataflow/internal/DataFlowImpl5.qll
@@ -127,8 +127,7 @@ abstract class Configuration extends string {
  * Good performance cannot be guaranteed in the presence of such recursion, so
  * it should be replaced by using more than one copy of the data flow library.
  */
-private abstract
-class ConfigurationRecursionPrevention extends Configuration {
+abstract private class ConfigurationRecursionPrevention extends Configuration {
   bindingset[this]
   ConfigurationRecursionPrevention() { any() }
 

--- a/java/ql/src/semmle/code/java/dataflow/DataFlow.qll
+++ b/java/ql/src/semmle/code/java/dataflow/DataFlow.qll
@@ -7,23 +7,4 @@ import java
 
 module DataFlow {
   import semmle.code.java.dataflow.internal.DataFlowImpl
-
-  /**
-   * This class exists to prevent mutual recursion between the user-overridden
-   * member predicates of `Configuration` and the rest of the data-flow library.
-   * Good performance cannot be guaranteed in the presence of such recursion, so
-   * it should be replaced by using more than one copy of the data flow library.
-   * Four copies are available: `DataFlow` through `DataFlow4`.
-   */
-  abstract private class ConfigurationRecursionPrevention extends Configuration {
-    bindingset[this]
-    ConfigurationRecursionPrevention() { any() }
-
-    override predicate hasFlow(Node source, Node sink) {
-      strictcount(Node n | this.isSource(n)) < 0 or
-      strictcount(Node n | this.isSink(n)) < 0 or
-      strictcount(Node n1, Node n2 | this.isAdditionalFlowStep(n1, n2)) < 0 or
-      super.hasFlow(source, sink)
-    }
-  }
 }

--- a/java/ql/src/semmle/code/java/dataflow/DataFlow2.qll
+++ b/java/ql/src/semmle/code/java/dataflow/DataFlow2.qll
@@ -7,23 +7,4 @@ import java
 
 module DataFlow2 {
   import semmle.code.java.dataflow.internal.DataFlowImpl2
-
-  /**
-   * This class exists to prevent mutual recursion between the user-overridden
-   * member predicates of `Configuration` and the rest of the data-flow library.
-   * Good performance cannot be guaranteed in the presence of such recursion, so
-   * it should be replaced by using more than one copy of the data flow library.
-   * Four copies are available: `DataFlow` through `DataFlow4`.
-   */
-  abstract private class ConfigurationRecursionPrevention extends Configuration {
-    bindingset[this]
-    ConfigurationRecursionPrevention() { any() }
-
-    override predicate hasFlow(Node source, Node sink) {
-      strictcount(Node n | this.isSource(n)) < 0 or
-      strictcount(Node n | this.isSink(n)) < 0 or
-      strictcount(Node n1, Node n2 | this.isAdditionalFlowStep(n1, n2)) < 0 or
-      super.hasFlow(source, sink)
-    }
-  }
 }

--- a/java/ql/src/semmle/code/java/dataflow/DataFlow3.qll
+++ b/java/ql/src/semmle/code/java/dataflow/DataFlow3.qll
@@ -7,23 +7,4 @@ import java
 
 module DataFlow3 {
   import semmle.code.java.dataflow.internal.DataFlowImpl3
-
-  /**
-   * This class exists to prevent mutual recursion between the user-overridden
-   * member predicates of `Configuration` and the rest of the data-flow library.
-   * Good performance cannot be guaranteed in the presence of such recursion, so
-   * it should be replaced by using more than one copy of the data flow library.
-   * Four copies are available: `DataFlow` through `DataFlow4`.
-   */
-  abstract private class ConfigurationRecursionPrevention extends Configuration {
-    bindingset[this]
-    ConfigurationRecursionPrevention() { any() }
-
-    override predicate hasFlow(Node source, Node sink) {
-      strictcount(Node n | this.isSource(n)) < 0 or
-      strictcount(Node n | this.isSink(n)) < 0 or
-      strictcount(Node n1, Node n2 | this.isAdditionalFlowStep(n1, n2)) < 0 or
-      super.hasFlow(source, sink)
-    }
-  }
 }

--- a/java/ql/src/semmle/code/java/dataflow/DataFlow4.qll
+++ b/java/ql/src/semmle/code/java/dataflow/DataFlow4.qll
@@ -7,23 +7,4 @@ import java
 
 module DataFlow4 {
   import semmle.code.java.dataflow.internal.DataFlowImpl4
-
-  /**
-   * This class exists to prevent mutual recursion between the user-overridden
-   * member predicates of `Configuration` and the rest of the data-flow library.
-   * Good performance cannot be guaranteed in the presence of such recursion, so
-   * it should be replaced by using more than one copy of the data flow library.
-   * Four copies are available: `DataFlow` through `DataFlow4`.
-   */
-  abstract private class ConfigurationRecursionPrevention extends Configuration {
-    bindingset[this]
-    ConfigurationRecursionPrevention() { any() }
-
-    override predicate hasFlow(Node source, Node sink) {
-      strictcount(Node n | this.isSource(n)) < 0 or
-      strictcount(Node n | this.isSink(n)) < 0 or
-      strictcount(Node n1, Node n2 | this.isAdditionalFlowStep(n1, n2)) < 0 or
-      super.hasFlow(source, sink)
-    }
-  }
 }

--- a/java/ql/src/semmle/code/java/dataflow/DataFlow5.qll
+++ b/java/ql/src/semmle/code/java/dataflow/DataFlow5.qll
@@ -7,23 +7,4 @@ import java
 
 module DataFlow5 {
   import semmle.code.java.dataflow.internal.DataFlowImpl5
-
-  /**
-   * This class exists to prevent mutual recursion between the user-overridden
-   * member predicates of `Configuration` and the rest of the data-flow library.
-   * Good performance cannot be guaranteed in the presence of such recursion, so
-   * it should be replaced by using more than one copy of the data flow library.
-   * Four copies are available: `DataFlow` through `DataFlow4`.
-   */
-  abstract private class ConfigurationRecursionPrevention extends Configuration {
-    bindingset[this]
-    ConfigurationRecursionPrevention() { any() }
-
-    override predicate hasFlow(Node source, Node sink) {
-      strictcount(Node n | this.isSource(n)) < 0 or
-      strictcount(Node n | this.isSink(n)) < 0 or
-      strictcount(Node n1, Node n2 | this.isAdditionalFlowStep(n1, n2)) < 0 or
-      super.hasFlow(source, sink)
-    }
-  }
 }

--- a/java/ql/src/semmle/code/java/dataflow/internal/DataFlowImpl.qll
+++ b/java/ql/src/semmle/code/java/dataflow/internal/DataFlowImpl.qll
@@ -127,8 +127,7 @@ abstract class Configuration extends string {
  * Good performance cannot be guaranteed in the presence of such recursion, so
  * it should be replaced by using more than one copy of the data flow library.
  */
-private abstract
-class ConfigurationRecursionPrevention extends Configuration {
+abstract private class ConfigurationRecursionPrevention extends Configuration {
   bindingset[this]
   ConfigurationRecursionPrevention() { any() }
 

--- a/java/ql/src/semmle/code/java/dataflow/internal/DataFlowImpl2.qll
+++ b/java/ql/src/semmle/code/java/dataflow/internal/DataFlowImpl2.qll
@@ -127,8 +127,7 @@ abstract class Configuration extends string {
  * Good performance cannot be guaranteed in the presence of such recursion, so
  * it should be replaced by using more than one copy of the data flow library.
  */
-private abstract
-class ConfigurationRecursionPrevention extends Configuration {
+abstract private class ConfigurationRecursionPrevention extends Configuration {
   bindingset[this]
   ConfigurationRecursionPrevention() { any() }
 

--- a/java/ql/src/semmle/code/java/dataflow/internal/DataFlowImpl3.qll
+++ b/java/ql/src/semmle/code/java/dataflow/internal/DataFlowImpl3.qll
@@ -127,8 +127,7 @@ abstract class Configuration extends string {
  * Good performance cannot be guaranteed in the presence of such recursion, so
  * it should be replaced by using more than one copy of the data flow library.
  */
-private abstract
-class ConfigurationRecursionPrevention extends Configuration {
+abstract private class ConfigurationRecursionPrevention extends Configuration {
   bindingset[this]
   ConfigurationRecursionPrevention() { any() }
 

--- a/java/ql/src/semmle/code/java/dataflow/internal/DataFlowImpl4.qll
+++ b/java/ql/src/semmle/code/java/dataflow/internal/DataFlowImpl4.qll
@@ -127,8 +127,7 @@ abstract class Configuration extends string {
  * Good performance cannot be guaranteed in the presence of such recursion, so
  * it should be replaced by using more than one copy of the data flow library.
  */
-private abstract
-class ConfigurationRecursionPrevention extends Configuration {
+abstract private class ConfigurationRecursionPrevention extends Configuration {
   bindingset[this]
   ConfigurationRecursionPrevention() { any() }
 

--- a/java/ql/src/semmle/code/java/dataflow/internal/DataFlowImpl5.qll
+++ b/java/ql/src/semmle/code/java/dataflow/internal/DataFlowImpl5.qll
@@ -127,8 +127,7 @@ abstract class Configuration extends string {
  * Good performance cannot be guaranteed in the presence of such recursion, so
  * it should be replaced by using more than one copy of the data flow library.
  */
-private abstract
-class ConfigurationRecursionPrevention extends Configuration {
+abstract private class ConfigurationRecursionPrevention extends Configuration {
   bindingset[this]
   ConfigurationRecursionPrevention() { any() }
 


### PR DESCRIPTION
This class was copy-pasted in all `DataFlowN.qll` files without using the identical-files system to keep the copies in sync. The class is now moved to the `DataFlowImplN.qll` files.

This also has the effect of preventing recursion through first data flow library copy for C/C++. Such recursion has been deprecated for over a year, and some forms of recursions are already ruled out by the library implementation.