### PR TITLE
Java/C#/C++: Add change notes for in/out barriers and barrierguards.

### DIFF
--- a/change-notes/1.22/analysis-cpp.md
+++ b/change-notes/1.22/analysis-cpp.md
@@ -30,3 +30,7 @@
 - The `semmle.code.cpp.models` library now models data flow through `std::swap`.
 - There is a new `Variable.isThreadLocal()` predicate. It can be used to tell whether a variable is `thread_local`.
 - Recursion through the `DataFlow` library is now always a compile error. Such recursion has been deprecated since release 1.16. If one `DataFlow::Configuration` needs to depend on the results of another, switch one of them to use one of the `DataFlow2` through `DataFlow4` libraries.
+- The possibility of specifying barrier edges in data-flow configurations has
+  been replaced with the option of specifying in- and out-barriers on nodes.
+  This should be simpler to use effectively, as it does not require knowledge
+  about the actual edges used internally by the library.

--- a/change-notes/1.22/analysis-csharp.md
+++ b/change-notes/1.22/analysis-csharp.md
@@ -41,5 +41,9 @@
   - The new predicate `ConstructedGeneric.getAnnotatedTypeArgument()` gets the annotated type of a type argument
   - The new predicate `TypeParameterConstraints.getAnAnnotatedTypeConstraint()` gets a type constraint with type annotations
 * The new class `SuppressNullableWarningExpr` models suppress-nullable-warning expressions such as `x!`
+* The possibility of specifying barrier edges in data-flow configurations has
+  been replaced with the option of specifying in- and out-barriers on nodes.
+  This should be simpler to use effectively, as it does not require knowledge
+  about the actual edges used internally by the library.
 
 ## Changes to autobuilder

--- a/change-notes/1.22/analysis-java.md
+++ b/change-notes/1.22/analysis-java.md
@@ -16,4 +16,15 @@
   removes false positives that arose from paths through impossible `toString()`
   calls.
 * The library `VCS.qll` and all queries that imported it have been removed.
-* The second copy of the interprocedural `TaintTracking` library has been renamed from `TaintTracking::Configuration2` to `TaintTracking2::Configuration`, and the old name is now deprecated. Import `semmle.code.java.dataflow.TaintTracking2` to access the new name.
+* The second copy of the interprocedural `TaintTracking` library has been
+  renamed from `TaintTracking::Configuration2` to
+  `TaintTracking2::Configuration`, and the old name is now deprecated. Import
+  `semmle.code.java.dataflow.TaintTracking2` to access the new name.
+* The data-flow library now makes it easier to specify barriers/sanitizers
+  arising from guards by overriding the predicate
+  `isBarrierGuard`/`isSanitizerGuard` on data-flow and taint-tracking
+  configurations respectively.
+* The possibility of specifying barrier edges in data-flow configurations has
+  been replaced with the option of specifying in- and out-barriers on nodes.
+  This should be simpler to use effectively, as it does not require knowledge
+  about the actual edges used internally by the library.


### PR DESCRIPTION
The change note on barrier guards is only added for Java, as the feature is not yet enabled for the other languages.