### PR TITLE
Java/C#/C++: Add change notes for in/out barriers and barrierguards.

### DIFF
--- a/change-notes/1.22/analysis-cpp.md
+++ b/change-notes/1.22/analysis-cpp.md
@@ -30,3 +30,10 @@
 - The `semmle.code.cpp.models` library now models data flow through `std::swap`.
 - There is a new `Variable.isThreadLocal()` predicate. It can be used to tell whether a variable is `thread_local`.
 - Recursion through the `DataFlow` library is now always a compile error. Such recursion has been deprecated since release 1.16. If one `DataFlow::Configuration` needs to depend on the results of another, switch one of them to use one of the `DataFlow2` through `DataFlow4` libraries.
+- The possibility of specifying barrier edges using
+  `isBarrierEdge`/`isSanitizerEdge` in data-flow and taint-tracking
+  configurations has been replaced with the option of specifying in- and
+  out-barriers on nodes by overriding `isBarrierIn`/`isSanitizerIn` and
+  `isBarrierOut`/`isSanitizerOut`. This should be simpler to use effectively,
+  as it does not require knowledge about the actual edges used internally by
+  the library.

--- a/change-notes/1.22/analysis-csharp.md
+++ b/change-notes/1.22/analysis-csharp.md
@@ -42,5 +42,12 @@
   - The new predicate `TypeParameterConstraints.getAnAnnotatedTypeConstraint()` gets a type constraint with type annotations
 * The new class `SuppressNullableWarningExpr` models suppress-nullable-warning expressions such as `x!`
 * The data-flow library (and taint-tracking library) now supports flow through fields. All existing configurations will have field-flow enabled by default, but it can be disabled by adding `override int fieldFlowBranchLimit() { result = 0 }` to the configuration class. Field assignments, `this.Foo = x`, object initializers, `new C() { Foo = x }`, and field initializers `int Foo = 0` are supported.
+* The possibility of specifying barrier edges using
+  `isBarrierEdge`/`isSanitizerEdge` in data-flow and taint-tracking
+  configurations has been replaced with the option of specifying in- and
+  out-barriers on nodes by overriding `isBarrierIn`/`isSanitizerIn` and
+  `isBarrierOut`/`isSanitizerOut`. This should be simpler to use effectively,
+  as it does not require knowledge about the actual edges used internally by
+  the library.
 
 ## Changes to autobuilder

--- a/change-notes/1.22/analysis-java.md
+++ b/change-notes/1.22/analysis-java.md
@@ -16,4 +16,18 @@
   removes false positives that arose from paths through impossible `toString()`
   calls.
 * The library `VCS.qll` and all queries that imported it have been removed.
-* The second copy of the interprocedural `TaintTracking` library has been renamed from `TaintTracking::Configuration2` to `TaintTracking2::Configuration`, and the old name is now deprecated. Import `semmle.code.java.dataflow.TaintTracking2` to access the new name.
+* The second copy of the interprocedural `TaintTracking` library has been
+  renamed from `TaintTracking::Configuration2` to
+  `TaintTracking2::Configuration`, and the old name is now deprecated. Import
+  `semmle.code.java.dataflow.TaintTracking2` to access the new name.
+* The data-flow library now makes it easier to specify barriers/sanitizers
+  arising from guards by overriding the predicate
+  `isBarrierGuard`/`isSanitizerGuard` on data-flow and taint-tracking
+  configurations respectively.
+* The possibility of specifying barrier edges using
+  `isBarrierEdge`/`isSanitizerEdge` in data-flow and taint-tracking
+  configurations has been replaced with the option of specifying in- and
+  out-barriers on nodes by overriding `isBarrierIn`/`isSanitizerIn` and
+  `isBarrierOut`/`isSanitizerOut`. This should be simpler to use effectively,
+  as it does not require knowledge about the actual edges used internally by
+  the library.


### PR DESCRIPTION
The change note on barrier guards is only added for Java, as the feature is not yet enabled for the other languages.