### PR TITLE
Java: Add localExprFlow and localExprTaint.

### DIFF
--- a/java/ql/src/semmle/code/java/dataflow/internal/DataFlowUtil.qll
+++ b/java/ql/src/semmle/code/java/dataflow/internal/DataFlowUtil.qll
@@ -335,6 +335,12 @@ private module ThisFlow {
 predicate localFlow(Node node1, Node node2) { localFlowStep*(node1, node2) }
 
 /**
+ * Holds if data can flow from `e1` to `e2` in zero or more
+ * local (intra-procedural) steps.
+ */
+predicate localExprFlow(Expr e1, Expr e2) { localFlow(exprNode(e1), exprNode(e2)) }
+
+/**
  * Holds if the `FieldRead` is not completely determined by explicit SSA
  * updates.
  */

--- a/java/ql/src/semmle/code/java/dataflow/internal/TaintTrackingUtil.qll
+++ b/java/ql/src/semmle/code/java/dataflow/internal/TaintTrackingUtil.qll
@@ -18,6 +18,14 @@ private import semmle.code.java.dataflow.internal.ContainerFlow
 predicate localTaint(DataFlow::Node src, DataFlow::Node sink) { localTaintStep*(src, sink) }
 
 /**
+ * Holds if taint can flow from `src` to `sink` in zero or more
+ * local (intra-procedural) steps.
+ */
+predicate localExprTaint(Expr src, Expr sink) {
+  localTaint(DataFlow::exprNode(src), DataFlow::exprNode(sink))
+}
+
+/**
  * Holds if taint can flow in one local step from `src` to `sink`.
  */
 predicate localTaintStep(DataFlow::Node src, DataFlow::Node sink) {


### PR DESCRIPTION
This adds `localExprFlow` and `localExprTaint` to save a bit of typing in common use-cases.