### PR TITLE
Python: Support short mode flags (e.g. `re.M`) in regexes. (ODASA-8056)

### DIFF
--- a/python/ql/src/semmle/python/types/Extensions.qll
+++ b/python/ql/src/semmle/python/types/Extensions.qll
@@ -128,6 +128,20 @@ class BottleRoutePointToExtension extends PointsToExtension {
 
 /* Python 3.6+ regex module constants */
 
+string short_flag(string flag) {
+    (flag = "ASCII" or
+     flag = "IGNORECASE" or
+     flag = "LOCALE" or
+     flag = "UNICODE" or
+     flag = "MULTILINE" or
+     flag = "TEMPLATE")
+    and result = flag.prefix(1)
+    or
+    flag = "DOTALL" and result = "S"
+    or
+    flag = "VERBOSE" and result = "X"
+}
+
 class ReModulePointToExtension extends PointsToExtension {
 
     string name;
@@ -139,9 +153,10 @@ class ReModulePointToExtension extends PointsToExtension {
     }
 
     override predicate pointsTo(Context context, ObjectInternal value, ControlFlowNode origin) {
-        exists(ModuleObjectInternal sre_constants, CfgOrigin orig |
+        exists(ModuleObjectInternal sre_constants, CfgOrigin orig, string flag |
+            (name = flag or name = short_flag(flag)) and
             sre_constants.getName() = "sre_constants" and
-            sre_constants.attribute("SRE_FLAG_" + name, value, orig) and
+            sre_constants.attribute("SRE_FLAG_" + flag, value, orig) and
             origin = orig.asCfgNodeOrHere(this)
         )
         and pointsTo_helper(context)

--- a/python/ql/test/library-tests/regex/Mode.expected
+++ b/python/ql/test/library-tests/regex/Mode.expected
@@ -7,3 +7,4 @@
 | 50 | VERBOSE |
 | 51 | UNICODE |
 | 52 | UNICODE |
+| 64 | MULTILINE |

--- a/python/ql/test/library-tests/regex/test.py
+++ b/python/ql/test/library-tests/regex/test.py
@@ -60,3 +60,5 @@ re.compile(r'(?:(?P<n1>^(?:|x)))')
 
 #Misparsed on LGTM
 re.compile(r"\[(?P<txt>[^[]*)\]\((?P<uri>[^)]*)")
+
+re.compile("", re.M) # ODASA-8056


### PR DESCRIPTION
TL;DR: Short flags were not correctly identified in our points-to extension (as they don't have corresponding constants in `sre_constants`). 

Fixes the false positive mentioned here: https://discuss.lgtm.com/t/python-false-positive-unmatchable-caret-in-regular-expression/2262

@AlexTereshenkov 