### PR TITLE
 Python: Extend `hasAttribute` to unknown-but-defined module variables. (ODASA-8028)

### DIFF
--- a/python/ql/src/semmle/python/types/ModuleObject.qll
+++ b/python/ql/src/semmle/python/types/ModuleObject.qll
@@ -54,6 +54,8 @@ abstract class ModuleObject extends Object {
 
     predicate hasAttribute(string name) {
         exists(theModule().attr(name))
+        or
+        exists(SsaVariable var | name = var.getId() and var.getAUse() = this.getModule().getANormalExit())
     }
 
     predicate attributeRefersTo(string name, Object obj, ControlFlowNode origin) {

--- a/python/ql/test/query-tests/Variables/undefined/UndefinedExport.expected
+++ b/python/ql/test/query-tests/Variables/undefined/UndefinedExport.expected
@@ -1,0 +1,2 @@
+| decorated_exports.py:3:33:3:45 | Str | The name 'not_defined' is exported by __all__ but is not defined. |
+| exports.py:1:57:1:64 | Str | The name 'nosuch' is exported by __all__ but is not defined. |

--- a/python/ql/test/query-tests/Variables/undefined/UndefinedExport.qlref
+++ b/python/ql/test/query-tests/Variables/undefined/UndefinedExport.qlref
@@ -1,0 +1,1 @@
+Variables/UndefinedExport.ql

--- a/python/ql/test/query-tests/Variables/undefined/UndefinedGlobal.expected
+++ b/python/ql/test/query-tests/Variables/undefined/UndefinedGlobal.expected
@@ -4,3 +4,5 @@
 | UndefinedGlobal.py:123:5:123:7 | ug3 | This use of global variable 'ug3' may be undefined. |
 | UninitializedLocal.py:5:13:5:15 | ug1 | This use of global variable 'ug1' may be undefined. |
 | UninitializedLocal.py:22:9:22:11 | ug1 | This use of global variable 'ug1' may be undefined. |
+| decorated_exports.py:10:2:10:19 | undotted_decorator | This use of global variable 'undotted_decorator' may be undefined. |
+| decorated_exports.py:14:2:14:13 | not_imported | This use of global variable 'not_imported' may be undefined. |

--- a/python/ql/test/query-tests/Variables/undefined/decorated_exports.py
+++ b/python/ql/test/query-tests/Variables/undefined/decorated_exports.py
@@ -1,0 +1,16 @@
+import dotted
+
+__all__ = ["foo", "bar", "baz", "not_defined"]
+
+
+@dotted.decorator
+def foo():
+    pass
+
+@undotted_decorator
+def bar():
+    pass
+
+@not_imported.but_dotted
+def baz():
+    pass

--- a/python/ql/test/query-tests/Variables/undefined/exports.py
+++ b/python/ql/test/query-tests/Variables/undefined/exports.py
@@ -1,0 +1,19 @@
+__all__ = ["foo", "bar", "baz", "quux", "blat", "frob", "nosuch", "i_got_it_elsewhere"]
+
+with open("foo.txt") as f:
+    foo = f.read()
+
+b = open("bar.txt")
+bar = b.read()
+
+baz = open("baz.txt")
+
+from unknown_module import unknown_value
+
+quux = 5 + unknown_value
+
+blat = str(5)
+
+frob = "5"
+
+from unknown_module import i_got_it_elsewhere

--- a/python/ql/test/query-tests/Variables/undefined/unknown_import_star.py
+++ b/python/ql/test/query-tests/Variables/undefined/unknown_import_star.py
@@ -1,0 +1,3 @@
+__all__ = ["foo"]
+
+from unknown_module import *


### PR DESCRIPTION
Eliminates the false positive seen here: https://discuss.lgtm.com/t/python-undefined-export-false-positive-when-reexporting/2259
(and possibly others reported on the forum).

@AlexTereshenkov 