### PR TITLE
CPP: Update taint test comments.

### DIFF
--- a/cpp/ql/test/library-tests/dataflow/taint-tests/taint.cpp
+++ b/cpp/ql/test/library-tests/dataflow/taint-tests/taint.cpp
@@ -227,14 +227,14 @@ void test_lambdas()
 
 	auto a = [t, u]() -> int {
 		sink(t); // tainted
-		sink(u); // clean [FALSE POSITIVE]
+		sink(u); // clean
 		return t;
 	};
 	sink(a()); // tainted
 
 	auto b = [&] {
 		sink(t); // tainted
-		sink(u); // clean [FALSE POSITIVE]
+		sink(u); // clean
 		v = source(); // (v is reference captured)
 	};
 	b();
@@ -242,7 +242,7 @@ void test_lambdas()
 
 	auto c = [=] {
 		sink(t); // tainted
-		sink(u); // clean [FALSE POSITIVE]
+		sink(u); // clean
 	};
 	c();
 


### PR DESCRIPTION
The results were fixed by https://github.com/Semmle/ql/pull/1783 (though locations were incorrect), the locations were fixed by https://github.com/Semmle/ql/pull/1781, but we never removed the `[FALSE POSITIVE]` markers.