### PR TITLE
C#: Nested field flow

### DIFF
--- a/csharp/ql/src/semmle/code/csharp/Assignable.qll
+++ b/csharp/ql/src/semmle/code/csharp/Assignable.qll
@@ -81,7 +81,7 @@ class AssignableRead extends AssignableAccess {
 
   pragma[noinline]
   private ControlFlow::Node getAnAdjacentReadSameVar() {
-    Ssa::Internal::adjacentReadPairSameVar(this.getAControlFlowNode(), result)
+    Ssa::Internal::adjacentReadPairSameVar(_, this.getAControlFlowNode(), result)
   }
 
   /**

--- a/csharp/ql/src/semmle/code/csharp/dataflow/Nullness.qll
+++ b/csharp/ql/src/semmle/code/csharp/dataflow/Nullness.qll
@@ -462,7 +462,7 @@ private predicate defReaches(Ssa::Definition def, ControlFlow::Node cfn, boolean
   (always = true or always = false)
   or
   exists(ControlFlow::Node mid | defReaches(def, mid, always) |
-    Ssa::Internal::adjacentReadPairSameVar(mid, cfn) and
+    Ssa::Internal::adjacentReadPairSameVar(_, mid, cfn) and
     not mid = any(Dereference d |
         if always = true
         then d.isAlwaysNull(def.getSourceVariable())

--- a/csharp/ql/src/semmle/code/csharp/dataflow/SSA.qll
+++ b/csharp/ql/src/semmle/code/csharp/dataflow/SSA.qll
@@ -860,13 +860,15 @@ module Ssa {
       }
 
       /**
-       * Holds if the read at `cfn2` is a read of the same SSA definition as the
-       * read at `cfn1`, and `cfn2` can be reached from `cfn1` without passing
-       * through another read.
+       * Holds if the read at `cfn2` is a read of the same SSA definition `def`
+       * as the read at `cfn1`, and `cfn2` can be reached from `cfn1` without
+       * passing through another read.
        */
       cached
-      predicate adjacentReadPairSameVar(ControlFlow::Node cfn1, ControlFlow::Node cfn2) {
-        exists(TrackedDefinition def, BasicBlock bb1, int i1 |
+      predicate adjacentReadPairSameVar(
+        TrackedDefinition def, ControlFlow::Node cfn1, ControlFlow::Node cfn2
+      ) {
+        exists(BasicBlock bb1, int i1 |
           variableRead(bb1, i1, _, cfn1, _) and
           adjacentVarRead(def, bb1, i1, cfn2)
         )
@@ -1115,9 +1117,7 @@ module Ssa {
       }
 
       /** Gets a run-time target for the delegate call `c`. */
-      Callable getARuntimeDelegateTarget(Call c) {
-        delegateCall(c, delegateCallSource(result))
-      }
+      Callable getARuntimeDelegateTarget(Call c) { delegateCall(c, delegateCallSource(result)) }
     }
 
     /** Holds if `(c1,c2)` is an edge in the call graph. */

--- a/csharp/ql/src/semmle/code/csharp/dataflow/internal/DataFlowPrivate.qll
+++ b/csharp/ql/src/semmle/code/csharp/dataflow/internal/DataFlowPrivate.qll
@@ -297,7 +297,7 @@ private module Cached {
       any(DelegateArgumentConfiguration x).hasExprPath(_, cfn, _, call)
     } or
     TMallocNode(ControlFlow::Nodes::ElementNode cfn) { cfn.getElement() instanceof ObjectCreation } or
-    TArgumentPostCallNode(ControlFlow::Nodes::ElementNode cfn) {
+    TExprPostUpdateNode(ControlFlow::Nodes::ElementNode cfn) {
       exists(Argument a, Type t |
         a = cfn.getElement() and
         t = a.stripCasts().getType()
@@ -305,63 +305,78 @@ private module Cached {
         t instanceof RefType or
         t = any(TypeParameter tp | not tp.isValueType())
       )
-    } or
-    TStoreTargetNode(ControlFlow::Nodes::ElementNode cfn) {
+      or
       instanceFieldLikeAssign(_, _, _, cfn.getElement())
+      or
+      exists(TExprPostUpdateNode upd, FieldLikeAccess fla |
+        upd = TExprPostUpdateNode(fla.getAControlFlowNode())
+      |
+        cfn.getElement() = fla.getQualifier()
+      )
     }
 
-  /**
-   * This is the local flow predicate that's used as a building block in global
-   * data flow. It may have less flow than the `localFlowStep` predicate.
-   */
+  private predicate usesInstanceField(Ssa::Definition def) {
+    exists(Ssa::SourceVariables::FieldOrPropSourceVariable fp | fp = def.getSourceVariable() |
+      not fp.getAssignable().isStatic()
+    )
+  }
+
   cached
-  predicate simpleLocalFlowStep(Node nodeFrom, Node nodeTo) {
-    any(LocalFlow::LocalExprStepConfiguration x).hasNodePath(nodeFrom, nodeTo)
+  predicate localFlowStepImpl(Node nodeFrom, Node nodeTo, boolean simple) {
+    any(LocalFlow::LocalExprStepConfiguration x).hasNodePath(nodeFrom, nodeTo) and
+    simple = true
     or
     // Flow from SSA definition to first read
     exists(Ssa::Definition def, ControlFlow::Node cfn |
-      def = nodeFrom.(SsaDefinitionNode).getDefinition()
-    |
-      nodeTo.asExprAtNode(cfn) = def.getAFirstReadAtNode(cfn)
+      def = nodeFrom.(SsaDefinitionNode).getDefinition() and
+      nodeTo.asExprAtNode(cfn) = def.getAFirstReadAtNode(cfn) and
+      if usesInstanceField(def) then simple = false else simple = true
     )
     or
     // Flow from read to next read
-    exists(ControlFlow::Node cfnFrom, ControlFlow::Node cfnTo |
-      Ssa::Internal::adjacentReadPairSameVar(cfnFrom, cfnTo) and
-      nodeTo = TExprNode(cfnTo)
+    exists(Ssa::Definition def, ControlFlow::Node cfnFrom, ControlFlow::Node cfnTo |
+      Ssa::Internal::adjacentReadPairSameVar(def, cfnFrom, cfnTo) and
+      nodeTo = TExprNode(cfnTo) and
+      if usesInstanceField(def) then simple = false else simple = true
     |
       nodeFrom = TExprNode(cfnFrom)
       or
       cfnFrom = nodeFrom.(PostUpdateNode).getPreUpdateNode().getControlFlowNode()
     )
     or
-    ThisFlow::adjacentThisRefs(nodeFrom, nodeTo)
+    ThisFlow::adjacentThisRefs(nodeFrom, nodeTo) and
+    simple = true
     or
-    ThisFlow::adjacentThisRefs(nodeFrom.(PostUpdateNode).getPreUpdateNode(), nodeTo)
+    ThisFlow::adjacentThisRefs(nodeFrom.(PostUpdateNode).getPreUpdateNode(), nodeTo) and
+    simple = true
     or
     // Flow into SSA pseudo definition
     exists(Ssa::Definition def, Ssa::PseudoDefinition pseudo |
-      LocalFlow::localFlowSsaInput(nodeFrom, def)
-    |
+      LocalFlow::localFlowSsaInput(nodeFrom, def) and
       pseudo = nodeTo.(SsaDefinitionNode).getDefinition() and
-      def = pseudo.getAnInput()
+      def = pseudo.getAnInput() and
+      if usesInstanceField(def) then simple = false else simple = true
     )
     or
     // Flow into uncertain SSA definition
     exists(Ssa::Definition def, LocalFlow::UncertainExplicitSsaDefinition uncertain |
-      LocalFlow::localFlowSsaInput(nodeFrom, def)
-    |
+      LocalFlow::localFlowSsaInput(nodeFrom, def) and
       uncertain = nodeTo.(SsaDefinitionNode).getDefinition() and
-      def = uncertain.getPriorDefinition()
+      def = uncertain.getPriorDefinition() and
+      if usesInstanceField(def) then simple = false else simple = true
     )
     or
-    LocalFlow::localFlowCapturedVarStep(nodeFrom, nodeTo)
+    LocalFlow::localFlowCapturedVarStep(nodeFrom, nodeTo) and
+    simple = true
     or
-    flowOutOfDelegateLibraryCall(nodeFrom, nodeTo, true)
+    flowOutOfDelegateLibraryCall(nodeFrom, nodeTo, true) and
+    simple = true
     or
-    flowThroughLibraryCallableOutRef(_, nodeFrom, nodeTo, true)
+    flowThroughLibraryCallableOutRef(_, nodeFrom, nodeTo, true) and
+    simple = true
     or
-    LocalFlow::localFlowStepCil(nodeFrom, nodeTo)
+    LocalFlow::localFlowStepCil(nodeFrom, nodeTo) and
+    simple = true
   }
 
   /**
@@ -408,6 +423,15 @@ private module Cached {
   }
 }
 import Cached
+
+/**
+ * This is the local flow predicate that is used as a building block in global
+ * data flow. It is a strict subset of the `localFlowStep` predicate, as it
+ * excludes SSA flow through instance fields.
+ */
+predicate simpleLocalFlowStep(Node nodeFrom, Node nodeTo) {
+  localFlowStepImpl(nodeFrom, nodeTo, true)
+}
 
 /** An SSA definition, viewed as a node in a data flow graph. */
 class SsaDefinitionNode extends Node, TSsaDefinitionNode {
@@ -1250,26 +1274,10 @@ private module PostUpdateNodes {
     override MallocNode getPreUpdateNode() { this = TExprNode(result.getControlFlowNode()) }
   }
 
-  private class ArgumentPostCallNode extends PostUpdateNode, TArgumentPostCallNode {
+  private class ExprPostUpdateNode extends PostUpdateNode, TExprPostUpdateNode {
     private ControlFlow::Nodes::ElementNode cfn;
 
-    ArgumentPostCallNode() { this = TArgumentPostCallNode(cfn) }
-
-    override ExprNode getPreUpdateNode() { cfn = result.getControlFlowNode() }
-
-    override Callable getEnclosingCallable() { result = cfn.getEnclosingCallable() }
-
-    override Type getType() { result = cfn.getElement().(Expr).getType() }
-
-    override Location getLocation() { result = cfn.getLocation() }
-
-    override string toString() { result = "[post] " + cfn.toString() }
-  }
-
-  private class StoreTargetNode extends PostUpdateNode, TStoreTargetNode {
-    private ControlFlow::Nodes::ElementNode cfn;
-
-    StoreTargetNode() { this = TStoreTargetNode(cfn) }
+    ExprPostUpdateNode() { this = TExprPostUpdateNode(cfn) }
 
     override ExprNode getPreUpdateNode() { cfn = result.getControlFlowNode() }
 

--- a/csharp/ql/src/semmle/code/csharp/dataflow/internal/DataFlowPublic.qll
+++ b/csharp/ql/src/semmle/code/csharp/dataflow/internal/DataFlowPublic.qll
@@ -152,7 +152,7 @@ ParameterNode parameterNode(DotNet::Parameter p) { result.getParameter() = p }
  * Holds if data flows from `nodeFrom` to `nodeTo` in exactly one local
  * (intra-procedural) step.
  */
-predicate localFlowStep(Node nodeFrom, Node nodeTo) { simpleLocalFlowStep(nodeFrom, nodeTo) }
+predicate localFlowStep(Node nodeFrom, Node nodeTo) { localFlowStepImpl(nodeFrom, nodeTo, _) }
 
 /**
  * Holds if data flows from `source` to `sink` in zero or more local

--- a/csharp/ql/src/semmle/code/csharp/dataflow/internal/DataFlowPublic.qll
+++ b/csharp/ql/src/semmle/code/csharp/dataflow/internal/DataFlowPublic.qll
@@ -152,7 +152,11 @@ ParameterNode parameterNode(DotNet::Parameter p) { result.getParameter() = p }
  * Holds if data flows from `nodeFrom` to `nodeTo` in exactly one local
  * (intra-procedural) step.
  */
-predicate localFlowStep(Node nodeFrom, Node nodeTo) { localFlowStepImpl(nodeFrom, nodeTo, _) }
+predicate localFlowStep(Node nodeFrom, Node nodeTo) {
+  simpleLocalFlowStep(nodeFrom, nodeTo)
+  or
+  extendedLocalFlowStep(nodeFrom, nodeTo)
+}
 
 /**
  * Holds if data flows from `source` to `sink` in zero or more local

--- a/csharp/ql/src/semmle/code/csharp/exprs/Call.qll
+++ b/csharp/ql/src/semmle/code/csharp/exprs/Call.qll
@@ -425,9 +425,7 @@ class ConstructorInitializer extends Call, @constructor_init_expr {
    * }
    * ```
    */
-  predicate isThis() {
-    this.getTargetType() = this.getConstructorType()
-  }
+  predicate isThis() { this.getTargetType() = this.getConstructorType() }
 
   /**
    * Holds if this initialier is a `base` initializer, for example `base(0)`
@@ -445,9 +443,7 @@ class ConstructorInitializer extends Call, @constructor_init_expr {
    * }
    * ```
    */
-  predicate isBase() {
-    this.getTargetType() != this.getConstructorType()
-  }
+  predicate isBase() { this.getTargetType() != this.getConstructorType() }
 
   /**
    * Gets the constructor that this initializer call belongs to. For example,

--- a/csharp/ql/test/library-tests/cil/dataflow/TaintTracking.ql
+++ b/csharp/ql/test/library-tests/cil/dataflow/TaintTracking.ql
@@ -1,6 +1,5 @@
 import csharp
 import semmle.code.csharp.dataflow.TaintTracking
-
 // Test that all the copies of the taint tracking library can be imported
 // simultaneously without errors.
 import semmle.code.csharp.dataflow.TaintTracking2

--- a/csharp/ql/test/library-tests/controlflow/graph/EnclosingCallable.ql
+++ b/csharp/ql/test/library-tests/controlflow/graph/EnclosingCallable.ql
@@ -3,6 +3,4 @@ import Common
 
 query predicate nodeEnclosing(SourceControlFlowNode n, Callable c) { c = n.getEnclosingCallable() }
 
-query predicate blockEnclosing(SourceBasicBlock bb, Callable c) {
-  c = bb.getCallable()
-}
+query predicate blockEnclosing(SourceBasicBlock bb, Callable c) { c = bb.getCallable() }

--- a/csharp/ql/test/library-tests/dataflow/fields/FieldFlow.expected
+++ b/csharp/ql/test/library-tests/dataflow/fields/FieldFlow.expected
@@ -37,13 +37,10 @@ edges
 | A.cs:98:30:98:36 | object creation of type B | A.cs:98:22:98:36 | ... ? ... : ... |
 | A.cs:104:17:104:23 | object creation of type B | A.cs:105:23:105:23 | access to local variable b |
 | A.cs:105:17:105:29 | object creation of type D [b, ... (1)] | A.cs:106:14:106:14 | access to local variable d [b, ... (1)] |
-| A.cs:105:17:105:29 | object creation of type D [b, ... (2)] | A.cs:106:14:106:14 | access to local variable d [b, ... (2)] |
 | A.cs:105:17:105:29 | object creation of type D [b, ... (2)] | A.cs:107:14:107:14 | access to local variable d [b, ... (2)] |
 | A.cs:105:23:105:23 | [post] access to local variable b [c, ... (1)] | A.cs:108:14:108:14 | access to local variable b [c, ... (1)] |
 | A.cs:105:23:105:23 | access to local variable b | A.cs:105:17:105:29 | object creation of type D [b, ... (1)] |
 | A.cs:106:14:106:14 | access to local variable d [b, ... (1)] | A.cs:106:14:106:16 | access to field b |
-| A.cs:106:14:106:14 | access to local variable d [b, ... (2)] | A.cs:106:14:106:16 | access to field b [c, ... (1)] |
-| A.cs:106:14:106:16 | access to field b [c, ... (1)] | A.cs:107:14:107:16 | access to field b [c, ... (1)] |
 | A.cs:107:14:107:14 | access to local variable d [b, ... (2)] | A.cs:107:14:107:16 | access to field b [c, ... (1)] |
 | A.cs:107:14:107:16 | access to field b [c, ... (1)] | A.cs:107:14:107:18 | access to field c |
 | A.cs:108:14:108:14 | access to local variable b [c, ... (1)] | A.cs:108:14:108:16 | access to field c |
@@ -52,12 +49,9 @@ edges
 | A.cs:114:29:114:29 | access to local variable b | A.cs:114:18:114:54 | object creation of type MyList [head, ... (1)] |
 | A.cs:115:18:115:37 | object creation of type MyList [next, ... (2)] | A.cs:116:35:116:36 | access to local variable l2 [next, ... (2)] |
 | A.cs:115:35:115:36 | access to local variable l1 [head, ... (1)] | A.cs:115:18:115:37 | object creation of type MyList [next, ... (2)] |
-| A.cs:116:18:116:37 | object creation of type MyList [next, ... (3)] | A.cs:118:14:118:15 | access to local variable l3 [next, ... (3)] |
 | A.cs:116:18:116:37 | object creation of type MyList [next, ... (3)] | A.cs:119:14:119:15 | access to local variable l3 [next, ... (3)] |
 | A.cs:116:18:116:37 | object creation of type MyList [next, ... (3)] | A.cs:121:41:121:41 | access to local variable l [next, ... (3)] |
 | A.cs:116:35:116:36 | access to local variable l2 [next, ... (2)] | A.cs:116:18:116:37 | object creation of type MyList [next, ... (3)] |
-| A.cs:118:14:118:15 | access to local variable l3 [next, ... (3)] | A.cs:118:14:118:20 | access to field next [next, ... (2)] |
-| A.cs:118:14:118:20 | access to field next [next, ... (2)] | A.cs:119:14:119:20 | access to field next [next, ... (2)] |
 | A.cs:119:14:119:15 | access to local variable l3 [next, ... (3)] | A.cs:119:14:119:20 | access to field next [next, ... (2)] |
 | A.cs:119:14:119:20 | access to field next [next, ... (2)] | A.cs:119:14:119:25 | access to field next [head, ... (1)] |
 | A.cs:119:14:119:25 | access to field next [head, ... (1)] | A.cs:119:14:119:30 | access to field head |
@@ -73,9 +67,7 @@ edges
 | B.cs:7:18:7:29 | object creation of type Box2 [box1, ... (2)] | B.cs:9:14:9:15 | access to local variable b2 [box1, ... (2)] |
 | B.cs:7:27:7:28 | access to local variable b1 [elem1, ... (1)] | B.cs:7:18:7:29 | object creation of type Box2 [box1, ... (2)] |
 | B.cs:8:14:8:15 | access to local variable b2 [box1, ... (2)] | B.cs:8:14:8:20 | access to field box1 [elem1, ... (1)] |
-| B.cs:8:14:8:15 | access to local variable b2 [box1, ... (2)] | B.cs:8:14:8:20 | access to field box1 [elem2, ... (1)] |
 | B.cs:8:14:8:20 | access to field box1 [elem1, ... (1)] | B.cs:8:14:8:26 | access to field elem1 |
-| B.cs:8:14:8:20 | access to field box1 [elem2, ... (1)] | B.cs:9:14:9:20 | access to field box1 [elem2, ... (1)] |
 | B.cs:9:14:9:15 | access to local variable b2 [box1, ... (2)] | B.cs:9:14:9:20 | access to field box1 [elem2, ... (1)] |
 | B.cs:9:14:9:20 | access to field box1 [elem2, ... (1)] | B.cs:9:14:9:26 | access to field elem2 |
 | B.cs:14:17:14:26 | object creation of type Elem | B.cs:15:33:15:33 | access to local variable e |
@@ -85,9 +77,7 @@ edges
 | B.cs:16:18:16:29 | object creation of type Box2 [box1, ... (2)] | B.cs:18:14:18:15 | access to local variable b2 [box1, ... (2)] |
 | B.cs:16:27:16:28 | access to local variable b1 [elem2, ... (1)] | B.cs:16:18:16:29 | object creation of type Box2 [box1, ... (2)] |
 | B.cs:17:14:17:15 | access to local variable b2 [box1, ... (2)] | B.cs:17:14:17:20 | access to field box1 [elem1, ... (1)] |
-| B.cs:17:14:17:15 | access to local variable b2 [box1, ... (2)] | B.cs:17:14:17:20 | access to field box1 [elem2, ... (1)] |
 | B.cs:17:14:17:20 | access to field box1 [elem1, ... (1)] | B.cs:17:14:17:26 | access to field elem1 |
-| B.cs:17:14:17:20 | access to field box1 [elem2, ... (1)] | B.cs:18:14:18:20 | access to field box1 [elem2, ... (1)] |
 | B.cs:18:14:18:15 | access to local variable b2 [box1, ... (2)] | B.cs:18:14:18:20 | access to field box1 [elem2, ... (1)] |
 | B.cs:18:14:18:20 | access to field box1 [elem2, ... (1)] | B.cs:18:14:18:26 | access to field elem2 |
 | C.cs:3:18:3:19 | [post] this access [s1, ... (1)] | C.cs:12:15:12:21 | object creation of type C [s1, ... (1)] |
@@ -96,8 +86,6 @@ edges
 | C.cs:4:32:4:41 | object creation of type Elem | C.cs:4:27:4:28 | [post] this access [s2, ... (1)] |
 | C.cs:6:30:6:39 | object creation of type Elem | C.cs:26:14:26:15 | access to field s4 |
 | C.cs:7:18:7:19 | [post] this access [s5, ... (1)] | C.cs:12:15:12:21 | object creation of type C [s5, ... (1)] |
-| C.cs:7:18:7:19 | [post] this access [s5, ... (1)] | C.cs:12:15:12:21 | object creation of type C [s5, ... (1)] |
-| C.cs:7:37:7:46 | object creation of type Elem | C.cs:7:18:7:19 | [post] this access [s5, ... (1)] |
 | C.cs:7:37:7:46 | object creation of type Elem | C.cs:7:18:7:19 | [post] this access [s5, ... (1)] |
 | C.cs:8:30:8:39 | object creation of type Elem | C.cs:28:14:28:15 | access to property s6 |
 | C.cs:12:15:12:21 | object creation of type C [s1, ... (1)] | C.cs:13:9:13:9 | access to local variable c [s1, ... (1)] |
@@ -158,6 +146,39 @@ edges
 | F.cs:23:13:23:34 | object creation of type F [Field2, ... (1)] | F.cs:25:14:25:14 | access to local variable f [Field2, ... (1)] |
 | F.cs:23:32:23:32 | access to local variable o | F.cs:23:13:23:34 | object creation of type F [Field2, ... (1)] |
 | F.cs:25:14:25:14 | access to local variable f [Field2, ... (1)] | F.cs:25:14:25:21 | access to field Field2 |
+| G.cs:7:18:7:27 | object creation of type Elem | G.cs:9:23:9:23 | access to local variable e |
+| G.cs:9:9:9:9 | [post] access to local variable b [Box1, ... (2)] | G.cs:10:18:10:18 | access to local variable b [Box1, ... (2)] |
+| G.cs:9:9:9:14 | [post] access to field Box1 [Elem, ... (1)] | G.cs:9:9:9:9 | [post] access to local variable b [Box1, ... (2)] |
+| G.cs:9:23:9:23 | access to local variable e | G.cs:9:9:9:14 | [post] access to field Box1 [Elem, ... (1)] |
+| G.cs:10:18:10:18 | access to local variable b [Box1, ... (2)] | G.cs:37:38:37:39 | b2 [Box1, ... (2)] |
+| G.cs:15:18:15:27 | object creation of type Elem | G.cs:17:24:17:24 | access to local variable e |
+| G.cs:17:9:17:9 | [post] access to local variable b [Box1, ... (2)] | G.cs:18:18:18:18 | access to local variable b [Box1, ... (2)] |
+| G.cs:17:9:17:14 | [post] access to field Box1 [Elem, ... (1)] | G.cs:17:9:17:9 | [post] access to local variable b [Box1, ... (2)] |
+| G.cs:17:24:17:24 | access to local variable e | G.cs:17:9:17:14 | [post] access to field Box1 [Elem, ... (1)] |
+| G.cs:18:18:18:18 | access to local variable b [Box1, ... (2)] | G.cs:37:38:37:39 | b2 [Box1, ... (2)] |
+| G.cs:23:18:23:27 | object creation of type Elem | G.cs:25:28:25:28 | access to local variable e |
+| G.cs:25:9:25:9 | [post] access to local variable b [Box1, ... (2)] | G.cs:26:18:26:18 | access to local variable b [Box1, ... (2)] |
+| G.cs:25:9:25:19 | [post] call to method GetBox1 [Elem, ... (1)] | G.cs:25:9:25:9 | [post] access to local variable b [Box1, ... (2)] |
+| G.cs:25:28:25:28 | access to local variable e | G.cs:25:9:25:19 | [post] call to method GetBox1 [Elem, ... (1)] |
+| G.cs:26:18:26:18 | access to local variable b [Box1, ... (2)] | G.cs:37:38:37:39 | b2 [Box1, ... (2)] |
+| G.cs:31:18:31:27 | object creation of type Elem | G.cs:33:29:33:29 | access to local variable e |
+| G.cs:33:9:33:9 | [post] access to local variable b [Box1, ... (2)] | G.cs:34:18:34:18 | access to local variable b [Box1, ... (2)] |
+| G.cs:33:9:33:19 | [post] call to method GetBox1 [Elem, ... (1)] | G.cs:33:9:33:9 | [post] access to local variable b [Box1, ... (2)] |
+| G.cs:33:29:33:29 | access to local variable e | G.cs:33:9:33:19 | [post] call to method GetBox1 [Elem, ... (1)] |
+| G.cs:34:18:34:18 | access to local variable b [Box1, ... (2)] | G.cs:37:38:37:39 | b2 [Box1, ... (2)] |
+| G.cs:37:38:37:39 | b2 [Box1, ... (2)] | G.cs:39:14:39:15 | access to parameter b2 [Box1, ... (2)] |
+| G.cs:39:14:39:15 | access to parameter b2 [Box1, ... (2)] | G.cs:39:14:39:25 | call to method GetBox1 [Elem, ... (1)] |
+| G.cs:39:14:39:25 | call to method GetBox1 [Elem, ... (1)] | G.cs:39:14:39:35 | call to method GetElem |
+| G.cs:44:18:44:27 | object creation of type Elem | G.cs:46:30:46:30 | access to local variable e |
+| G.cs:46:9:46:16 | [post] access to field boxfield [Box1, ... (2)] | G.cs:46:9:46:16 | [post] this access [boxfield, ... (3)] |
+| G.cs:46:9:46:16 | [post] this access [boxfield, ... (3)] | G.cs:47:9:47:13 | this access [boxfield, ... (3)] |
+| G.cs:46:9:46:21 | [post] access to field Box1 [Elem, ... (1)] | G.cs:46:9:46:16 | [post] access to field boxfield [Box1, ... (2)] |
+| G.cs:46:30:46:30 | access to local variable e | G.cs:46:9:46:21 | [post] access to field Box1 [Elem, ... (1)] |
+| G.cs:47:9:47:13 | this access [boxfield, ... (3)] | G.cs:50:18:50:20 | this [boxfield, ... (3)] |
+| G.cs:50:18:50:20 | this [boxfield, ... (3)] | G.cs:52:14:52:21 | this access [boxfield, ... (3)] |
+| G.cs:52:14:52:21 | access to field boxfield [Box1, ... (2)] | G.cs:52:14:52:26 | access to field Box1 [Elem, ... (1)] |
+| G.cs:52:14:52:21 | this access [boxfield, ... (3)] | G.cs:52:14:52:21 | access to field boxfield [Box1, ... (2)] |
+| G.cs:52:14:52:26 | access to field Box1 [Elem, ... (1)] | G.cs:52:14:52:31 | access to field Elem |
 #select
 | A.cs:7:14:7:16 | access to field c | A.cs:5:17:5:23 | object creation of type C | A.cs:7:14:7:16 | access to field c | $@ | A.cs:5:17:5:23 | object creation of type C | object creation of type C |
 | A.cs:14:14:14:20 | call to method Get | A.cs:13:15:13:22 | object creation of type C1 | A.cs:14:14:14:20 | call to method Get | $@ | A.cs:13:15:13:22 | object creation of type C1 | object creation of type C1 |
@@ -195,3 +216,8 @@ edges
 | F.cs:17:14:17:21 | access to field Field2 | F.cs:10:17:10:28 | object creation of type Object | F.cs:17:14:17:21 | access to field Field2 | $@ | F.cs:10:17:10:28 | object creation of type Object | object creation of type Object |
 | F.cs:20:14:20:21 | access to field Field1 | F.cs:10:17:10:28 | object creation of type Object | F.cs:20:14:20:21 | access to field Field1 | $@ | F.cs:10:17:10:28 | object creation of type Object | object creation of type Object |
 | F.cs:25:14:25:21 | access to field Field2 | F.cs:10:17:10:28 | object creation of type Object | F.cs:25:14:25:21 | access to field Field2 | $@ | F.cs:10:17:10:28 | object creation of type Object | object creation of type Object |
+| G.cs:39:14:39:35 | call to method GetElem | G.cs:7:18:7:27 | object creation of type Elem | G.cs:39:14:39:35 | call to method GetElem | $@ | G.cs:7:18:7:27 | object creation of type Elem | object creation of type Elem |
+| G.cs:39:14:39:35 | call to method GetElem | G.cs:15:18:15:27 | object creation of type Elem | G.cs:39:14:39:35 | call to method GetElem | $@ | G.cs:15:18:15:27 | object creation of type Elem | object creation of type Elem |
+| G.cs:39:14:39:35 | call to method GetElem | G.cs:23:18:23:27 | object creation of type Elem | G.cs:39:14:39:35 | call to method GetElem | $@ | G.cs:23:18:23:27 | object creation of type Elem | object creation of type Elem |
+| G.cs:39:14:39:35 | call to method GetElem | G.cs:31:18:31:27 | object creation of type Elem | G.cs:39:14:39:35 | call to method GetElem | $@ | G.cs:31:18:31:27 | object creation of type Elem | object creation of type Elem |
+| G.cs:52:14:52:31 | access to field Elem | G.cs:44:18:44:27 | object creation of type Elem | G.cs:52:14:52:31 | access to field Elem | $@ | G.cs:44:18:44:27 | object creation of type Elem | object creation of type Elem |

--- a/csharp/ql/test/library-tests/dataflow/fields/G.cs
+++ b/csharp/ql/test/library-tests/dataflow/fields/G.cs
@@ -1,0 +1,74 @@
+public class G
+{
+    Box2 boxfield;
+
+    public void M1()
+    {
+        Elem e = new Elem();
+        Box2 b = new Box2(new Box1(null));
+        b.Box1.Elem = e;
+        SinkWrap(b);
+    }
+
+    public void M2()
+    {
+        Elem e = new Elem();
+        Box2 b = new Box2(new Box1(null));
+        b.Box1.SetElem(e);
+        SinkWrap(b);
+    }
+
+    public void M3()
+    {
+        Elem e = new Elem();
+        Box2 b = new Box2(new Box1(null));
+        b.GetBox1().Elem = e;
+        SinkWrap(b);
+    }
+
+    public void M4()
+    {
+        Elem e = new Elem();
+        Box2 b = new Box2(new Box1(null));
+        b.GetBox1().SetElem(e);
+        SinkWrap(b);
+    }
+
+    public static void SinkWrap(Box2 b2)
+    {
+        Sink(b2.GetBox1().GetElem());
+    }
+
+    public void M5a()
+    {
+        Elem e = new Elem();
+        boxfield = new Box2(new Box1(null));
+        boxfield.Box1.Elem = e;
+        M5b();
+    }
+
+    private void M5b()
+    {
+        Sink(boxfield.Box1.Elem);
+    }
+
+    public static void Sink(object o) { }
+
+    public class Elem { }
+
+    public class Box1
+    {
+        public Elem Elem;
+        public Box1(Elem e) { Elem = e; }
+        public Elem GetElem() => Elem;
+        public void SetElem(Elem e) { Elem = e; }
+    }
+
+    public class Box2
+    {
+        public Box1 Box1;
+        public Box2(Box1 b) { Box1 = b; }
+        public Box1 GetBox1() => Box1;
+        public void SetBox1(Box1 b) { Box1 = b; }
+    }
+}

--- a/csharp/ql/test/library-tests/dataflow/local/DataFlowStep.expected
+++ b/csharp/ql/test/library-tests/dataflow/local/DataFlowStep.expected
@@ -653,28 +653,36 @@
 | SSA.cs:59:23:59:30 | access to local variable ssaSink3 | SSA.cs:59:23:59:30 | SSA def(ssaSink3) |
 | SSA.cs:63:23:63:30 | SSA def(nonSink0) | SSA.cs:64:15:64:22 | access to local variable nonSink0 |
 | SSA.cs:63:23:63:30 | access to local variable nonSink0 | SSA.cs:63:23:63:30 | SSA def(nonSink0) |
+| SSA.cs:67:9:67:12 | [post] this access | SSA.cs:68:23:68:26 | this access |
 | SSA.cs:67:9:67:12 | this access | SSA.cs:68:23:68:26 | this access |
 | SSA.cs:67:9:67:14 | [post] access to field S | SSA.cs:68:23:68:28 | access to field S |
 | SSA.cs:67:9:67:14 | access to field S | SSA.cs:68:23:68:28 | access to field S |
 | SSA.cs:67:9:67:38 | SSA def(this.S.SsaFieldSink0) | SSA.cs:68:23:68:28 | SSA qualifier def(this.S.SsaFieldSink0) |
 | SSA.cs:67:32:67:38 | access to parameter tainted | SSA.cs:67:9:67:38 | SSA def(this.S.SsaFieldSink0) |
 | SSA.cs:67:32:67:38 | access to parameter tainted | SSA.cs:77:20:77:26 | access to parameter tainted |
+| SSA.cs:68:23:68:26 | [post] this access | SSA.cs:69:15:69:18 | this access |
 | SSA.cs:68:23:68:26 | this access | SSA.cs:69:15:69:18 | this access |
 | SSA.cs:68:23:68:28 | SSA def(this.S) | SSA.cs:69:15:69:20 | access to field S |
 | SSA.cs:68:23:68:28 | SSA qualifier def(this.S.SsaFieldSink0) | SSA.cs:69:15:69:34 | access to field SsaFieldSink0 |
 | SSA.cs:68:23:68:28 | access to field S | SSA.cs:68:23:68:28 | SSA def(this.S) |
+| SSA.cs:69:15:69:18 | [post] this access | SSA.cs:72:9:72:12 | this access |
 | SSA.cs:69:15:69:18 | this access | SSA.cs:72:9:72:12 | this access |
+| SSA.cs:69:15:69:20 | [post] access to field S | SSA.cs:72:9:72:14 | access to field S |
 | SSA.cs:69:15:69:20 | access to field S | SSA.cs:72:9:72:14 | access to field S |
+| SSA.cs:72:9:72:12 | [post] this access | SSA.cs:73:23:73:26 | this access |
 | SSA.cs:72:9:72:12 | this access | SSA.cs:73:23:73:26 | this access |
 | SSA.cs:72:9:72:14 | [post] access to field S | SSA.cs:73:23:73:28 | access to field S |
 | SSA.cs:72:9:72:14 | access to field S | SSA.cs:73:23:73:28 | access to field S |
 | SSA.cs:72:9:72:36 | SSA def(this.S.SsaFieldNonSink0) | SSA.cs:73:23:73:28 | SSA qualifier def(this.S.SsaFieldNonSink0) |
 | SSA.cs:72:35:72:36 | "" | SSA.cs:72:9:72:36 | SSA def(this.S.SsaFieldNonSink0) |
+| SSA.cs:73:23:73:26 | [post] this access | SSA.cs:74:15:74:18 | this access |
 | SSA.cs:73:23:73:26 | this access | SSA.cs:74:15:74:18 | this access |
 | SSA.cs:73:23:73:28 | SSA def(this.S) | SSA.cs:74:15:74:20 | access to field S |
 | SSA.cs:73:23:73:28 | SSA qualifier def(this.S.SsaFieldNonSink0) | SSA.cs:74:15:74:37 | access to field SsaFieldNonSink0 |
 | SSA.cs:73:23:73:28 | access to field S | SSA.cs:73:23:73:28 | SSA def(this.S) |
+| SSA.cs:74:15:74:18 | [post] this access | SSA.cs:80:9:80:12 | this access |
 | SSA.cs:74:15:74:18 | this access | SSA.cs:80:9:80:12 | this access |
+| SSA.cs:74:15:74:20 | [post] access to field S | SSA.cs:80:9:80:14 | access to field S |
 | SSA.cs:74:15:74:20 | access to field S | SSA.cs:80:9:80:14 | access to field S |
 | SSA.cs:77:9:77:26 | SSA def(nonSink0) | SSA.cs:78:21:78:28 | access to local variable nonSink0 |
 | SSA.cs:77:20:77:26 | access to parameter tainted | SSA.cs:77:9:77:26 | SSA def(nonSink0) |
@@ -684,22 +692,29 @@
 | SSA.cs:79:15:79:22 | [post] access to local variable nonSink0 | SSA.cs:130:39:130:46 | access to local variable nonSink0 |
 | SSA.cs:79:15:79:22 | access to local variable nonSink0 | SSA.cs:104:24:104:31 | access to local variable nonSink0 |
 | SSA.cs:79:15:79:22 | access to local variable nonSink0 | SSA.cs:130:39:130:46 | access to local variable nonSink0 |
+| SSA.cs:80:9:80:12 | [post] this access | SSA.cs:81:21:81:24 | this access |
 | SSA.cs:80:9:80:12 | this access | SSA.cs:81:21:81:24 | this access |
 | SSA.cs:80:9:80:14 | [post] access to field S | SSA.cs:81:21:81:26 | access to field S |
 | SSA.cs:80:9:80:14 | access to field S | SSA.cs:81:21:81:26 | access to field S |
 | SSA.cs:80:35:80:41 | access to parameter tainted | SSA.cs:83:35:83:41 | access to parameter tainted |
+| SSA.cs:81:21:81:24 | [post] this access | SSA.cs:82:15:82:18 | this access |
 | SSA.cs:81:21:81:24 | this access | SSA.cs:82:15:82:18 | this access |
 | SSA.cs:81:21:81:26 | SSA def(this.S) | SSA.cs:82:15:82:20 | access to field S |
 | SSA.cs:81:21:81:26 | SSA qualifier def(this.S.SsaFieldNonSink0) | SSA.cs:82:15:82:37 | access to field SsaFieldNonSink0 |
+| SSA.cs:82:15:82:18 | [post] this access | SSA.cs:83:9:83:12 | this access |
 | SSA.cs:82:15:82:18 | this access | SSA.cs:83:9:83:12 | this access |
+| SSA.cs:82:15:82:20 | [post] access to field S | SSA.cs:83:9:83:14 | access to field S |
 | SSA.cs:82:15:82:20 | access to field S | SSA.cs:83:9:83:14 | access to field S |
+| SSA.cs:83:9:83:12 | [post] this access | SSA.cs:84:9:84:14 | this access |
 | SSA.cs:83:9:83:12 | this access | SSA.cs:84:9:84:14 | this access |
 | SSA.cs:83:35:83:41 | access to parameter tainted | SSA.cs:83:9:83:41 | SSA def(this.S.SsaFieldNonSink0) |
 | SSA.cs:84:9:84:14 | SSA call def(this.S) | SSA.cs:85:15:85:20 | access to field S |
 | SSA.cs:84:9:84:14 | SSA qualifier def(this.S.SsaFieldNonSink0) | SSA.cs:85:15:85:37 | access to field SsaFieldNonSink0 |
 | SSA.cs:84:9:84:14 | [post] this access | SSA.cs:85:15:85:18 | this access |
 | SSA.cs:84:9:84:14 | this access | SSA.cs:85:15:85:18 | this access |
+| SSA.cs:85:15:85:18 | [post] this access | SSA.cs:114:9:114:12 | this access |
 | SSA.cs:85:15:85:18 | this access | SSA.cs:114:9:114:12 | this access |
+| SSA.cs:85:15:85:20 | [post] access to field S | SSA.cs:114:9:114:14 | access to field S |
 | SSA.cs:85:15:85:20 | access to field S | SSA.cs:114:9:114:14 | access to field S |
 | SSA.cs:88:16:88:28 | SSA def(ssaSink4) | SSA.cs:97:9:97:32 | SSA phi(ssaSink4) |
 | SSA.cs:88:27:88:28 | "" | SSA.cs:88:16:88:28 | SSA def(ssaSink4) |
@@ -735,6 +750,8 @@
 | SSA.cs:110:9:110:32 | SSA phi(nonSink3) | SSA.cs:110:23:110:30 | access to local variable nonSink3 |
 | SSA.cs:110:23:110:30 | SSA def(nonSink3) | SSA.cs:111:15:111:22 | access to local variable nonSink3 |
 | SSA.cs:110:23:110:30 | access to local variable nonSink3 | SSA.cs:110:23:110:30 | SSA def(nonSink3) |
+| SSA.cs:114:9:114:12 | [post] this access | SSA.cs:117:13:117:16 | this access |
+| SSA.cs:114:9:114:12 | [post] this access | SSA.cs:123:23:123:26 | this access |
 | SSA.cs:114:9:114:12 | this access | SSA.cs:117:13:117:16 | this access |
 | SSA.cs:114:9:114:12 | this access | SSA.cs:123:23:123:26 | this access |
 | SSA.cs:114:9:114:14 | [post] access to field S | SSA.cs:117:13:117:18 | access to field S |
@@ -747,6 +764,8 @@
 | SSA.cs:115:13:115:22 | [post] access to parameter nonTainted | SSA.cs:128:13:128:22 | access to parameter nonTainted |
 | SSA.cs:115:13:115:22 | access to parameter nonTainted | SSA.cs:118:17:118:26 | access to parameter nonTainted |
 | SSA.cs:115:13:115:22 | access to parameter nonTainted | SSA.cs:128:13:128:22 | access to parameter nonTainted |
+| SSA.cs:117:13:117:16 | [post] this access | SSA.cs:119:21:119:24 | this access |
+| SSA.cs:117:13:117:16 | [post] this access | SSA.cs:121:21:121:24 | this access |
 | SSA.cs:117:13:117:16 | this access | SSA.cs:119:21:119:24 | this access |
 | SSA.cs:117:13:117:16 | this access | SSA.cs:121:21:121:24 | this access |
 | SSA.cs:117:13:117:18 | [post] access to field S | SSA.cs:119:21:119:26 | access to field S |
@@ -758,19 +777,28 @@
 | SSA.cs:117:36:117:43 | access to local variable ssaSink0 | SSA.cs:117:13:117:43 | SSA def(this.S.SsaFieldSink1) |
 | SSA.cs:118:17:118:26 | [post] access to parameter nonTainted | SSA.cs:128:13:128:22 | access to parameter nonTainted |
 | SSA.cs:118:17:118:26 | access to parameter nonTainted | SSA.cs:128:13:128:22 | access to parameter nonTainted |
+| SSA.cs:119:21:119:24 | [post] this access | SSA.cs:123:23:123:26 | this access |
 | SSA.cs:119:21:119:24 | this access | SSA.cs:123:23:123:26 | this access |
+| SSA.cs:119:21:119:26 | [post] access to field S | SSA.cs:123:23:123:28 | access to field S |
 | SSA.cs:119:21:119:26 | access to field S | SSA.cs:123:23:123:28 | access to field S |
 | SSA.cs:119:21:119:40 | access to field SsaFieldSink1 | SSA.cs:123:9:123:30 | SSA phi(this.S.SsaFieldSink1) |
+| SSA.cs:121:21:121:24 | [post] this access | SSA.cs:123:23:123:26 | this access |
 | SSA.cs:121:21:121:24 | this access | SSA.cs:123:23:123:26 | this access |
+| SSA.cs:121:21:121:26 | [post] access to field S | SSA.cs:123:23:123:28 | access to field S |
 | SSA.cs:121:21:121:26 | access to field S | SSA.cs:123:23:123:28 | access to field S |
 | SSA.cs:121:21:121:40 | access to field SsaFieldSink1 | SSA.cs:123:9:123:30 | SSA phi(this.S.SsaFieldSink1) |
 | SSA.cs:123:9:123:30 | SSA phi(this.S.SsaFieldSink1) | SSA.cs:123:23:123:28 | SSA qualifier def(this.S.SsaFieldSink1) |
+| SSA.cs:123:23:123:26 | [post] this access | SSA.cs:124:15:124:18 | this access |
 | SSA.cs:123:23:123:26 | this access | SSA.cs:124:15:124:18 | this access |
 | SSA.cs:123:23:123:28 | SSA def(this.S) | SSA.cs:124:15:124:20 | access to field S |
 | SSA.cs:123:23:123:28 | SSA qualifier def(this.S.SsaFieldSink1) | SSA.cs:124:15:124:34 | access to field SsaFieldSink1 |
 | SSA.cs:123:23:123:28 | access to field S | SSA.cs:123:23:123:28 | SSA def(this.S) |
+| SSA.cs:124:15:124:18 | [post] this access | SSA.cs:127:9:127:12 | this access |
 | SSA.cs:124:15:124:18 | this access | SSA.cs:127:9:127:12 | this access |
+| SSA.cs:124:15:124:20 | [post] access to field S | SSA.cs:127:9:127:14 | access to field S |
 | SSA.cs:124:15:124:20 | access to field S | SSA.cs:127:9:127:14 | access to field S |
+| SSA.cs:127:9:127:12 | [post] this access | SSA.cs:130:13:130:16 | this access |
+| SSA.cs:127:9:127:12 | [post] this access | SSA.cs:136:23:136:26 | this access |
 | SSA.cs:127:9:127:12 | this access | SSA.cs:130:13:130:16 | this access |
 | SSA.cs:127:9:127:12 | this access | SSA.cs:136:23:136:26 | this access |
 | SSA.cs:127:9:127:14 | [post] access to field S | SSA.cs:130:13:130:18 | access to field S |
@@ -781,6 +809,8 @@
 | SSA.cs:127:35:127:36 | "" | SSA.cs:127:9:127:36 | SSA def(this.S.SsaFieldNonSink0) |
 | SSA.cs:128:13:128:22 | [post] access to parameter nonTainted | SSA.cs:131:17:131:26 | access to parameter nonTainted |
 | SSA.cs:128:13:128:22 | access to parameter nonTainted | SSA.cs:131:17:131:26 | access to parameter nonTainted |
+| SSA.cs:130:13:130:16 | [post] this access | SSA.cs:132:21:132:24 | this access |
+| SSA.cs:130:13:130:16 | [post] this access | SSA.cs:134:21:134:24 | this access |
 | SSA.cs:130:13:130:16 | this access | SSA.cs:132:21:132:24 | this access |
 | SSA.cs:130:13:130:16 | this access | SSA.cs:134:21:134:24 | this access |
 | SSA.cs:130:13:130:18 | [post] access to field S | SSA.cs:132:21:132:26 | access to field S |
@@ -790,13 +820,18 @@
 | SSA.cs:130:13:130:46 | SSA def(this.S.SsaFieldNonSink0) | SSA.cs:132:21:132:43 | access to field SsaFieldNonSink0 |
 | SSA.cs:130:13:130:46 | SSA def(this.S.SsaFieldNonSink0) | SSA.cs:134:21:134:43 | access to field SsaFieldNonSink0 |
 | SSA.cs:130:39:130:46 | access to local variable nonSink0 | SSA.cs:130:13:130:46 | SSA def(this.S.SsaFieldNonSink0) |
+| SSA.cs:132:21:132:24 | [post] this access | SSA.cs:136:23:136:26 | this access |
 | SSA.cs:132:21:132:24 | this access | SSA.cs:136:23:136:26 | this access |
+| SSA.cs:132:21:132:26 | [post] access to field S | SSA.cs:136:23:136:28 | access to field S |
 | SSA.cs:132:21:132:26 | access to field S | SSA.cs:136:23:136:28 | access to field S |
 | SSA.cs:132:21:132:43 | access to field SsaFieldNonSink0 | SSA.cs:136:9:136:30 | SSA phi(this.S.SsaFieldNonSink0) |
+| SSA.cs:134:21:134:24 | [post] this access | SSA.cs:136:23:136:26 | this access |
 | SSA.cs:134:21:134:24 | this access | SSA.cs:136:23:136:26 | this access |
+| SSA.cs:134:21:134:26 | [post] access to field S | SSA.cs:136:23:136:28 | access to field S |
 | SSA.cs:134:21:134:26 | access to field S | SSA.cs:136:23:136:28 | access to field S |
 | SSA.cs:134:21:134:43 | access to field SsaFieldNonSink0 | SSA.cs:136:9:136:30 | SSA phi(this.S.SsaFieldNonSink0) |
 | SSA.cs:136:9:136:30 | SSA phi(this.S.SsaFieldNonSink0) | SSA.cs:136:23:136:28 | SSA qualifier def(this.S.SsaFieldNonSink0) |
+| SSA.cs:136:23:136:26 | [post] this access | SSA.cs:137:15:137:18 | this access |
 | SSA.cs:136:23:136:26 | this access | SSA.cs:137:15:137:18 | this access |
 | SSA.cs:136:23:136:28 | SSA def(this.S) | SSA.cs:137:15:137:20 | access to field S |
 | SSA.cs:136:23:136:28 | SSA qualifier def(this.S.SsaFieldNonSink0) | SSA.cs:137:15:137:37 | access to field SsaFieldNonSink0 |

--- a/csharp/ql/test/library-tests/dataflow/local/TaintTrackingStep.expected
+++ b/csharp/ql/test/library-tests/dataflow/local/TaintTrackingStep.expected
@@ -809,28 +809,36 @@
 | SSA.cs:59:23:59:30 | access to local variable ssaSink3 | SSA.cs:59:23:59:30 | SSA def(ssaSink3) |
 | SSA.cs:63:23:63:30 | SSA def(nonSink0) | SSA.cs:64:15:64:22 | access to local variable nonSink0 |
 | SSA.cs:63:23:63:30 | access to local variable nonSink0 | SSA.cs:63:23:63:30 | SSA def(nonSink0) |
+| SSA.cs:67:9:67:12 | [post] this access | SSA.cs:68:23:68:26 | this access |
 | SSA.cs:67:9:67:12 | this access | SSA.cs:68:23:68:26 | this access |
 | SSA.cs:67:9:67:14 | [post] access to field S | SSA.cs:68:23:68:28 | access to field S |
 | SSA.cs:67:9:67:14 | access to field S | SSA.cs:68:23:68:28 | access to field S |
 | SSA.cs:67:9:67:38 | SSA def(this.S.SsaFieldSink0) | SSA.cs:68:23:68:28 | SSA qualifier def(this.S.SsaFieldSink0) |
 | SSA.cs:67:32:67:38 | access to parameter tainted | SSA.cs:67:9:67:38 | SSA def(this.S.SsaFieldSink0) |
 | SSA.cs:67:32:67:38 | access to parameter tainted | SSA.cs:77:20:77:26 | access to parameter tainted |
+| SSA.cs:68:23:68:26 | [post] this access | SSA.cs:69:15:69:18 | this access |
 | SSA.cs:68:23:68:26 | this access | SSA.cs:69:15:69:18 | this access |
 | SSA.cs:68:23:68:28 | SSA def(this.S) | SSA.cs:69:15:69:20 | access to field S |
 | SSA.cs:68:23:68:28 | SSA qualifier def(this.S.SsaFieldSink0) | SSA.cs:69:15:69:34 | access to field SsaFieldSink0 |
 | SSA.cs:68:23:68:28 | access to field S | SSA.cs:68:23:68:28 | SSA def(this.S) |
+| SSA.cs:69:15:69:18 | [post] this access | SSA.cs:72:9:72:12 | this access |
 | SSA.cs:69:15:69:18 | this access | SSA.cs:72:9:72:12 | this access |
+| SSA.cs:69:15:69:20 | [post] access to field S | SSA.cs:72:9:72:14 | access to field S |
 | SSA.cs:69:15:69:20 | access to field S | SSA.cs:72:9:72:14 | access to field S |
+| SSA.cs:72:9:72:12 | [post] this access | SSA.cs:73:23:73:26 | this access |
 | SSA.cs:72:9:72:12 | this access | SSA.cs:73:23:73:26 | this access |
 | SSA.cs:72:9:72:14 | [post] access to field S | SSA.cs:73:23:73:28 | access to field S |
 | SSA.cs:72:9:72:14 | access to field S | SSA.cs:73:23:73:28 | access to field S |
 | SSA.cs:72:9:72:36 | SSA def(this.S.SsaFieldNonSink0) | SSA.cs:73:23:73:28 | SSA qualifier def(this.S.SsaFieldNonSink0) |
 | SSA.cs:72:35:72:36 | "" | SSA.cs:72:9:72:36 | SSA def(this.S.SsaFieldNonSink0) |
+| SSA.cs:73:23:73:26 | [post] this access | SSA.cs:74:15:74:18 | this access |
 | SSA.cs:73:23:73:26 | this access | SSA.cs:74:15:74:18 | this access |
 | SSA.cs:73:23:73:28 | SSA def(this.S) | SSA.cs:74:15:74:20 | access to field S |
 | SSA.cs:73:23:73:28 | SSA qualifier def(this.S.SsaFieldNonSink0) | SSA.cs:74:15:74:37 | access to field SsaFieldNonSink0 |
 | SSA.cs:73:23:73:28 | access to field S | SSA.cs:73:23:73:28 | SSA def(this.S) |
+| SSA.cs:74:15:74:18 | [post] this access | SSA.cs:80:9:80:12 | this access |
 | SSA.cs:74:15:74:18 | this access | SSA.cs:80:9:80:12 | this access |
+| SSA.cs:74:15:74:20 | [post] access to field S | SSA.cs:80:9:80:14 | access to field S |
 | SSA.cs:74:15:74:20 | access to field S | SSA.cs:80:9:80:14 | access to field S |
 | SSA.cs:77:9:77:26 | SSA def(nonSink0) | SSA.cs:78:21:78:28 | access to local variable nonSink0 |
 | SSA.cs:77:20:77:26 | access to parameter tainted | SSA.cs:77:9:77:26 | SSA def(nonSink0) |
@@ -840,22 +848,29 @@
 | SSA.cs:79:15:79:22 | [post] access to local variable nonSink0 | SSA.cs:130:39:130:46 | access to local variable nonSink0 |
 | SSA.cs:79:15:79:22 | access to local variable nonSink0 | SSA.cs:104:24:104:31 | access to local variable nonSink0 |
 | SSA.cs:79:15:79:22 | access to local variable nonSink0 | SSA.cs:130:39:130:46 | access to local variable nonSink0 |
+| SSA.cs:80:9:80:12 | [post] this access | SSA.cs:81:21:81:24 | this access |
 | SSA.cs:80:9:80:12 | this access | SSA.cs:81:21:81:24 | this access |
 | SSA.cs:80:9:80:14 | [post] access to field S | SSA.cs:81:21:81:26 | access to field S |
 | SSA.cs:80:9:80:14 | access to field S | SSA.cs:81:21:81:26 | access to field S |
 | SSA.cs:80:35:80:41 | access to parameter tainted | SSA.cs:83:35:83:41 | access to parameter tainted |
+| SSA.cs:81:21:81:24 | [post] this access | SSA.cs:82:15:82:18 | this access |
 | SSA.cs:81:21:81:24 | this access | SSA.cs:82:15:82:18 | this access |
 | SSA.cs:81:21:81:26 | SSA def(this.S) | SSA.cs:82:15:82:20 | access to field S |
 | SSA.cs:81:21:81:26 | SSA qualifier def(this.S.SsaFieldNonSink0) | SSA.cs:82:15:82:37 | access to field SsaFieldNonSink0 |
+| SSA.cs:82:15:82:18 | [post] this access | SSA.cs:83:9:83:12 | this access |
 | SSA.cs:82:15:82:18 | this access | SSA.cs:83:9:83:12 | this access |
+| SSA.cs:82:15:82:20 | [post] access to field S | SSA.cs:83:9:83:14 | access to field S |
 | SSA.cs:82:15:82:20 | access to field S | SSA.cs:83:9:83:14 | access to field S |
+| SSA.cs:83:9:83:12 | [post] this access | SSA.cs:84:9:84:14 | this access |
 | SSA.cs:83:9:83:12 | this access | SSA.cs:84:9:84:14 | this access |
 | SSA.cs:83:35:83:41 | access to parameter tainted | SSA.cs:83:9:83:41 | SSA def(this.S.SsaFieldNonSink0) |
 | SSA.cs:84:9:84:14 | SSA call def(this.S) | SSA.cs:85:15:85:20 | access to field S |
 | SSA.cs:84:9:84:14 | SSA qualifier def(this.S.SsaFieldNonSink0) | SSA.cs:85:15:85:37 | access to field SsaFieldNonSink0 |
 | SSA.cs:84:9:84:14 | [post] this access | SSA.cs:85:15:85:18 | this access |
 | SSA.cs:84:9:84:14 | this access | SSA.cs:85:15:85:18 | this access |
+| SSA.cs:85:15:85:18 | [post] this access | SSA.cs:114:9:114:12 | this access |
 | SSA.cs:85:15:85:18 | this access | SSA.cs:114:9:114:12 | this access |
+| SSA.cs:85:15:85:20 | [post] access to field S | SSA.cs:114:9:114:14 | access to field S |
 | SSA.cs:85:15:85:20 | access to field S | SSA.cs:114:9:114:14 | access to field S |
 | SSA.cs:88:16:88:28 | SSA def(ssaSink4) | SSA.cs:97:9:97:32 | SSA phi(ssaSink4) |
 | SSA.cs:88:27:88:28 | "" | SSA.cs:88:16:88:28 | SSA def(ssaSink4) |
@@ -895,6 +910,8 @@
 | SSA.cs:110:9:110:32 | SSA phi(nonSink3) | SSA.cs:110:23:110:30 | access to local variable nonSink3 |
 | SSA.cs:110:23:110:30 | SSA def(nonSink3) | SSA.cs:111:15:111:22 | access to local variable nonSink3 |
 | SSA.cs:110:23:110:30 | access to local variable nonSink3 | SSA.cs:110:23:110:30 | SSA def(nonSink3) |
+| SSA.cs:114:9:114:12 | [post] this access | SSA.cs:117:13:117:16 | this access |
+| SSA.cs:114:9:114:12 | [post] this access | SSA.cs:123:23:123:26 | this access |
 | SSA.cs:114:9:114:12 | this access | SSA.cs:117:13:117:16 | this access |
 | SSA.cs:114:9:114:12 | this access | SSA.cs:123:23:123:26 | this access |
 | SSA.cs:114:9:114:14 | [post] access to field S | SSA.cs:117:13:117:18 | access to field S |
@@ -908,6 +925,8 @@
 | SSA.cs:115:13:115:22 | access to parameter nonTainted | SSA.cs:118:17:118:26 | access to parameter nonTainted |
 | SSA.cs:115:13:115:22 | access to parameter nonTainted | SSA.cs:128:13:128:22 | access to parameter nonTainted |
 | SSA.cs:115:13:115:29 | access to property Length | SSA.cs:115:13:115:33 | ... > ... |
+| SSA.cs:117:13:117:16 | [post] this access | SSA.cs:119:21:119:24 | this access |
+| SSA.cs:117:13:117:16 | [post] this access | SSA.cs:121:21:121:24 | this access |
 | SSA.cs:117:13:117:16 | this access | SSA.cs:119:21:119:24 | this access |
 | SSA.cs:117:13:117:16 | this access | SSA.cs:121:21:121:24 | this access |
 | SSA.cs:117:13:117:18 | [post] access to field S | SSA.cs:119:21:119:26 | access to field S |
@@ -920,19 +939,28 @@
 | SSA.cs:118:17:118:26 | [post] access to parameter nonTainted | SSA.cs:128:13:128:22 | access to parameter nonTainted |
 | SSA.cs:118:17:118:26 | access to parameter nonTainted | SSA.cs:128:13:128:22 | access to parameter nonTainted |
 | SSA.cs:118:17:118:33 | access to property Length | SSA.cs:118:17:118:37 | ... > ... |
+| SSA.cs:119:21:119:24 | [post] this access | SSA.cs:123:23:123:26 | this access |
 | SSA.cs:119:21:119:24 | this access | SSA.cs:123:23:123:26 | this access |
+| SSA.cs:119:21:119:26 | [post] access to field S | SSA.cs:123:23:123:28 | access to field S |
 | SSA.cs:119:21:119:26 | access to field S | SSA.cs:123:23:123:28 | access to field S |
 | SSA.cs:119:21:119:40 | access to field SsaFieldSink1 | SSA.cs:123:9:123:30 | SSA phi(this.S.SsaFieldSink1) |
+| SSA.cs:121:21:121:24 | [post] this access | SSA.cs:123:23:123:26 | this access |
 | SSA.cs:121:21:121:24 | this access | SSA.cs:123:23:123:26 | this access |
+| SSA.cs:121:21:121:26 | [post] access to field S | SSA.cs:123:23:123:28 | access to field S |
 | SSA.cs:121:21:121:26 | access to field S | SSA.cs:123:23:123:28 | access to field S |
 | SSA.cs:121:21:121:40 | access to field SsaFieldSink1 | SSA.cs:123:9:123:30 | SSA phi(this.S.SsaFieldSink1) |
 | SSA.cs:123:9:123:30 | SSA phi(this.S.SsaFieldSink1) | SSA.cs:123:23:123:28 | SSA qualifier def(this.S.SsaFieldSink1) |
+| SSA.cs:123:23:123:26 | [post] this access | SSA.cs:124:15:124:18 | this access |
 | SSA.cs:123:23:123:26 | this access | SSA.cs:124:15:124:18 | this access |
 | SSA.cs:123:23:123:28 | SSA def(this.S) | SSA.cs:124:15:124:20 | access to field S |
 | SSA.cs:123:23:123:28 | SSA qualifier def(this.S.SsaFieldSink1) | SSA.cs:124:15:124:34 | access to field SsaFieldSink1 |
 | SSA.cs:123:23:123:28 | access to field S | SSA.cs:123:23:123:28 | SSA def(this.S) |
+| SSA.cs:124:15:124:18 | [post] this access | SSA.cs:127:9:127:12 | this access |
 | SSA.cs:124:15:124:18 | this access | SSA.cs:127:9:127:12 | this access |
+| SSA.cs:124:15:124:20 | [post] access to field S | SSA.cs:127:9:127:14 | access to field S |
 | SSA.cs:124:15:124:20 | access to field S | SSA.cs:127:9:127:14 | access to field S |
+| SSA.cs:127:9:127:12 | [post] this access | SSA.cs:130:13:130:16 | this access |
+| SSA.cs:127:9:127:12 | [post] this access | SSA.cs:136:23:136:26 | this access |
 | SSA.cs:127:9:127:12 | this access | SSA.cs:130:13:130:16 | this access |
 | SSA.cs:127:9:127:12 | this access | SSA.cs:136:23:136:26 | this access |
 | SSA.cs:127:9:127:14 | [post] access to field S | SSA.cs:130:13:130:18 | access to field S |
@@ -944,6 +972,8 @@
 | SSA.cs:128:13:128:22 | [post] access to parameter nonTainted | SSA.cs:131:17:131:26 | access to parameter nonTainted |
 | SSA.cs:128:13:128:22 | access to parameter nonTainted | SSA.cs:131:17:131:26 | access to parameter nonTainted |
 | SSA.cs:128:13:128:29 | access to property Length | SSA.cs:128:13:128:33 | ... > ... |
+| SSA.cs:130:13:130:16 | [post] this access | SSA.cs:132:21:132:24 | this access |
+| SSA.cs:130:13:130:16 | [post] this access | SSA.cs:134:21:134:24 | this access |
 | SSA.cs:130:13:130:16 | this access | SSA.cs:132:21:132:24 | this access |
 | SSA.cs:130:13:130:16 | this access | SSA.cs:134:21:134:24 | this access |
 | SSA.cs:130:13:130:18 | [post] access to field S | SSA.cs:132:21:132:26 | access to field S |
@@ -954,13 +984,18 @@
 | SSA.cs:130:13:130:46 | SSA def(this.S.SsaFieldNonSink0) | SSA.cs:134:21:134:43 | access to field SsaFieldNonSink0 |
 | SSA.cs:130:39:130:46 | access to local variable nonSink0 | SSA.cs:130:13:130:46 | SSA def(this.S.SsaFieldNonSink0) |
 | SSA.cs:131:17:131:33 | access to property Length | SSA.cs:131:17:131:37 | ... > ... |
+| SSA.cs:132:21:132:24 | [post] this access | SSA.cs:136:23:136:26 | this access |
 | SSA.cs:132:21:132:24 | this access | SSA.cs:136:23:136:26 | this access |
+| SSA.cs:132:21:132:26 | [post] access to field S | SSA.cs:136:23:136:28 | access to field S |
 | SSA.cs:132:21:132:26 | access to field S | SSA.cs:136:23:136:28 | access to field S |
 | SSA.cs:132:21:132:43 | access to field SsaFieldNonSink0 | SSA.cs:136:9:136:30 | SSA phi(this.S.SsaFieldNonSink0) |
+| SSA.cs:134:21:134:24 | [post] this access | SSA.cs:136:23:136:26 | this access |
 | SSA.cs:134:21:134:24 | this access | SSA.cs:136:23:136:26 | this access |
+| SSA.cs:134:21:134:26 | [post] access to field S | SSA.cs:136:23:136:28 | access to field S |
 | SSA.cs:134:21:134:26 | access to field S | SSA.cs:136:23:136:28 | access to field S |
 | SSA.cs:134:21:134:43 | access to field SsaFieldNonSink0 | SSA.cs:136:9:136:30 | SSA phi(this.S.SsaFieldNonSink0) |
 | SSA.cs:136:9:136:30 | SSA phi(this.S.SsaFieldNonSink0) | SSA.cs:136:23:136:28 | SSA qualifier def(this.S.SsaFieldNonSink0) |
+| SSA.cs:136:23:136:26 | [post] this access | SSA.cs:137:15:137:18 | this access |
 | SSA.cs:136:23:136:26 | this access | SSA.cs:137:15:137:18 | this access |
 | SSA.cs:136:23:136:28 | SSA def(this.S) | SSA.cs:137:15:137:20 | access to field S |
 | SSA.cs:136:23:136:28 | SSA qualifier def(this.S.SsaFieldNonSink0) | SSA.cs:137:15:137:37 | access to field SsaFieldNonSink0 |

--- a/csharp/ql/test/library-tests/dataflow/ssa/PreSsaConsistency.ql
+++ b/csharp/ql/test/library-tests/dataflow/ssa/PreSsaConsistency.ql
@@ -46,12 +46,13 @@ query predicate readReadInconsistency(
     b = true and
     a = read1.getTarget() and
     PreSsa::adjacentReadPairSameVar(read1, read2) and
-    not Ssa::Internal::adjacentReadPairSameVar(read1.getAControlFlowNode(),
+    not Ssa::Internal::adjacentReadPairSameVar(_, read1.getAControlFlowNode(),
       read2.getAControlFlowNode())
     or
     b = false and
     a = read1.getTarget() and
-    Ssa::Internal::adjacentReadPairSameVar(read1.getAControlFlowNode(), read2.getAControlFlowNode()) and
+    Ssa::Internal::adjacentReadPairSameVar(_, read1.getAControlFlowNode(),
+      read2.getAControlFlowNode()) and
     read1.getTarget() instanceof PreSsa::SimpleAssignable and
     not PreSsa::adjacentReadPairSameVar(read1, read2) and
     // Exclude split CFG elements because SSA may be more precise than pre-SSA

--- a/csharp/ql/test/query-tests/Security Features/CWE-089/SqlInjection.expected
+++ b/csharp/ql/test/query-tests/Security Features/CWE-089/SqlInjection.expected
@@ -1,22 +1,10 @@
 edges
 | SqlInjection.cs:38:21:38:35 | access to field categoryTextBox | SqlInjection.cs:39:50:39:55 | access to local variable query1 |
-| SqlInjection.cs:38:21:38:35 | access to field categoryTextBox | SqlInjection.cs:74:56:74:61 | access to local variable query1 |
-| SqlInjection.cs:38:21:38:35 | access to field categoryTextBox | SqlInjection.cs:75:55:75:60 | access to local variable query1 |
-| SqlInjection.cs:49:62:49:76 | access to field categoryTextBox | SqlInjection.cs:74:56:74:61 | access to local variable query1 |
-| SqlInjection.cs:49:62:49:76 | access to field categoryTextBox | SqlInjection.cs:75:55:75:60 | access to local variable query1 |
-| SqlInjection.cs:61:62:61:76 | access to field categoryTextBox | SqlInjection.cs:74:56:74:61 | access to local variable query1 |
-| SqlInjection.cs:61:62:61:76 | access to field categoryTextBox | SqlInjection.cs:75:55:75:60 | access to local variable query1 |
 | SqlInjection.cs:73:33:73:47 | access to field categoryTextBox | SqlInjection.cs:74:56:74:61 | access to local variable query1 |
 | SqlInjection.cs:73:33:73:47 | access to field categoryTextBox | SqlInjection.cs:75:55:75:60 | access to local variable query1 |
 | SqlInjection.cs:87:21:87:29 | access to property Text | SqlInjection.cs:88:50:88:55 | access to local variable query1 |
 #select
 | SqlInjection.cs:39:50:39:55 | access to local variable query1 | SqlInjection.cs:38:21:38:35 | access to field categoryTextBox | SqlInjection.cs:39:50:39:55 | access to local variable query1 | Query might include code from $@. | SqlInjection.cs:38:21:38:35 | access to field categoryTextBox | this ASP.NET user input |
-| SqlInjection.cs:74:56:74:61 | access to local variable query1 | SqlInjection.cs:38:21:38:35 | access to field categoryTextBox | SqlInjection.cs:74:56:74:61 | access to local variable query1 | Query might include code from $@. | SqlInjection.cs:38:21:38:35 | access to field categoryTextBox | this ASP.NET user input |
-| SqlInjection.cs:74:56:74:61 | access to local variable query1 | SqlInjection.cs:49:62:49:76 | access to field categoryTextBox | SqlInjection.cs:74:56:74:61 | access to local variable query1 | Query might include code from $@. | SqlInjection.cs:49:62:49:76 | access to field categoryTextBox | this ASP.NET user input |
-| SqlInjection.cs:74:56:74:61 | access to local variable query1 | SqlInjection.cs:61:62:61:76 | access to field categoryTextBox | SqlInjection.cs:74:56:74:61 | access to local variable query1 | Query might include code from $@. | SqlInjection.cs:61:62:61:76 | access to field categoryTextBox | this ASP.NET user input |
 | SqlInjection.cs:74:56:74:61 | access to local variable query1 | SqlInjection.cs:73:33:73:47 | access to field categoryTextBox | SqlInjection.cs:74:56:74:61 | access to local variable query1 | Query might include code from $@. | SqlInjection.cs:73:33:73:47 | access to field categoryTextBox | this ASP.NET user input |
-| SqlInjection.cs:75:55:75:60 | access to local variable query1 | SqlInjection.cs:38:21:38:35 | access to field categoryTextBox | SqlInjection.cs:75:55:75:60 | access to local variable query1 | Query might include code from $@. | SqlInjection.cs:38:21:38:35 | access to field categoryTextBox | this ASP.NET user input |
-| SqlInjection.cs:75:55:75:60 | access to local variable query1 | SqlInjection.cs:49:62:49:76 | access to field categoryTextBox | SqlInjection.cs:75:55:75:60 | access to local variable query1 | Query might include code from $@. | SqlInjection.cs:49:62:49:76 | access to field categoryTextBox | this ASP.NET user input |
-| SqlInjection.cs:75:55:75:60 | access to local variable query1 | SqlInjection.cs:61:62:61:76 | access to field categoryTextBox | SqlInjection.cs:75:55:75:60 | access to local variable query1 | Query might include code from $@. | SqlInjection.cs:61:62:61:76 | access to field categoryTextBox | this ASP.NET user input |
 | SqlInjection.cs:75:55:75:60 | access to local variable query1 | SqlInjection.cs:73:33:73:47 | access to field categoryTextBox | SqlInjection.cs:75:55:75:60 | access to local variable query1 | Query might include code from $@. | SqlInjection.cs:73:33:73:47 | access to field categoryTextBox | this ASP.NET user input |
 | SqlInjection.cs:88:50:88:55 | access to local variable query1 | SqlInjection.cs:87:21:87:29 | access to property Text | SqlInjection.cs:88:50:88:55 | access to local variable query1 | Query might include code from $@. | SqlInjection.cs:87:21:87:29 | access to property Text | this TextBox text |


### PR DESCRIPTION
This is the equivalent of @aschackmull's https://github.com/Semmle/ql/pull/1766 for Java. Additionally, I have disabled field-based SSA for global data flow (made possible by @jbj's https://github.com/Semmle/ql/pull/1780), to avoid getting multiple paths for the same result. This has the extra side-effect that data flow sources, which are field accesses, will not have spurious use-use steps as in [this](https://github.com/Semmle/ql/compare/master...hvitved:csharp/dataflow/nested-fields?expand=1#diff-87cc28327cd0c474166e571c9b16299d) test.