### PR TITLE
C++: Fix lambda_capture upgrade query join order

### DIFF
--- a/cpp/upgrades/814fae599505510ff15102f4c72600586734770a/lambda_capture.ql
+++ b/cpp/upgrades/814fae599505510ff15102f4c72600586734770a/lambda_capture.ql
@@ -5,11 +5,22 @@ class Field extends @membervariable { string toString() { none() } }
 class Location extends @location_default { string toString() { none() } }
 class Type extends @usertype { string toString() { none() } }
 
+pragma[noopt]
+predicate lambda_capture_new(LambdaCapture lc, Lambda l, int i, Field f,
+     boolean captured_by_reference, boolean is_implicit,
+     Location loc)
+{
+  exists(Type t |
+    lambda_capture(lc, l, i, captured_by_reference, is_implicit, loc) and
+    expr_types(l, t, _) and
+    t instanceof Type and
+    member(t, i, f) and
+    f instanceof Field
+  )
+}
+
 from LambdaCapture lc, Lambda l, int i, Field f,
      boolean captured_by_reference, boolean is_implicit,
-     Location loc, Type t
-where lambda_capture(lc, l, i, captured_by_reference, is_implicit, loc)
-  and expr_types(l, t, _)
-  and member(t, i, f)
+     Location loc
+where lambda_capture_new(lc, l, i, f, captured_by_reference, is_implicit, loc)
 select lc, l, i, f, captured_by_reference, is_implicit, loc
-


### PR DESCRIPTION
When this query was run as an upgrade script, the optimizer picked a bad join order, making the upgrade very slow on large databases. It picked a bad join order because upgrade scripts are run with no stats.

See https://semmle.slack.com/archives/C1ECYQUMN/p1566650458091600.