### PR TITLE
JS: Make getDocumentation handle chain assignments

### DIFF
--- a/change-notes/1.23/analysis-javascript.md
+++ b/change-notes/1.23/analysis-javascript.md
@@ -18,3 +18,5 @@
 | Client-side cross-site scripting (`js/xss`) | More results | More potential vulnerabilities involving functions that manipulate DOM attributes are now recognized. |
 
 ## Changes to QL libraries
+
+* `Expr.getDocumentation()` now handles chain assignments.

--- a/javascript/ql/src/semmle/javascript/Expr.qll
+++ b/javascript/ql/src/semmle/javascript/Expr.qll
@@ -55,6 +55,14 @@ class ExprOrType extends @exprortype, Documentable {
       exists(DotExpr dot | this = dot.getProperty() |
         result = dot.getDocumentation()
       )
+      or
+      exists(AssignExpr e | this = e.getRhs() |
+        result = e.getDocumentation()
+      )
+      or
+      exists(ParExpr p | this = p.getExpression() |
+        result = p.getDocumentation()
+      )
     )
   }
 

--- a/javascript/ql/test/query-tests/JSDoc/JSDocForNonExistentParameter/JSDocForNonExistentParameter.expected
+++ b/javascript/ql/test/query-tests/JSDoc/JSDocForNonExistentParameter/JSDocForNonExistentParameter.expected
@@ -1,2 +1,4 @@
 | tst.js:4:4:4:9 | @param | @param tag refers to non-existent parameter prameter. |
 | tst.js:12:4:12:9 | @param | @param tag refers to non-existent parameter sign. |
+| tst.js:51:4:51:9 | @param | @param tag refers to non-existent parameter opts. |
+| tst.js:57:4:57:9 | @param | @param tag refers to non-existent parameter opts. |

--- a/javascript/ql/test/query-tests/JSDoc/JSDocForNonExistentParameter/tst.js
+++ b/javascript/ql/test/query-tests/JSDoc/JSDocForNonExistentParameter/tst.js
@@ -46,3 +46,15 @@ function good3() {
   }
   return firstName + sep + lastName;
 }
+
+/**
+ * @param {IncomingMessage} opts
+ */
+var Cookie = foo.bar = function Cookie(options) {
+}
+
+/**
+ * @param {IncomingMessage} opts
+ */
+Cookie2 = foo.bar2 = function Cookie2(options) {
+}


### PR DESCRIPTION
The use of `getUnderlyingValue` isn't always enough to associate an expression with its documentation.

Fixes https://jira.semmle.com/browse/ODASA-8067

(Not intended for 1.22)