### PR TITLE
docs: mention clang-ci support

### DIFF
--- a/docs/language/support/language-support.rst
+++ b/docs/language/support/language-support.rst
@@ -17,10 +17,11 @@ with any questions you have about language and compiler support.
 
 .. container:: footnote-group
 
-    .. [1] Support for the Arm Compiler (armcc) is preliminary.
-    .. [2] In addition, support is included for the preview features of C# 8.0 and .NET Core 3.0.
-    .. [3] The best results are achieved with COBOL code that stays close to the ANSI 85 standard.  
-    .. [4] Builds that execute on Java 6 to 12 can be analyzed. The analysis understands Java 12 language features.
-    .. [5] ECJ is supported when the build invokes it via the Maven Compiler plugin or the Takari Lifecycle plugin.
-    .. [6] JSX and Flow code, YAML, JSON, HTML, and XML files may also be analyzed with JavaScript files. 
-    .. [7] TypeScript analysis is performed by running the JavaScript extractor with TypeScript enabled. This is the default for LGTM.   
+    .. [1] Support for the clang-cl compiler is preliminary.
+    .. [2] Support for the Arm Compiler (armcc) is preliminary.
+    .. [3] In addition, support is included for the preview features of C# 8.0 and .NET Core 3.0.
+    .. [4] The best results are achieved with COBOL code that stays close to the ANSI 85 standard.  
+    .. [5] Builds that execute on Java 6 to 12 can be analyzed. The analysis understands Java 12 language features.
+    .. [6] ECJ is supported when the build invokes it via the Maven Compiler plugin or the Takari Lifecycle plugin.
+    .. [7] JSX and Flow code, YAML, JSON, HTML, and XML files may also be analyzed with JavaScript files. 
+    .. [8] TypeScript analysis is performed by running the JavaScript extractor with TypeScript enabled. This is the default for LGTM.   

--- a/docs/language/support/versions-compilers.csv
+++ b/docs/language/support/versions-compilers.csv
@@ -1,18 +1,18 @@
 Language,Variants,Compilers,Extensions
-C/C++,"C89, C99, C11, C++98, C++03, C++11, C++14, C++17","Clang extensions (up to Clang 8.0),
+C/C++,"C89, C99, C11, C++98, C++03, C++11, C++14, C++17","Clang (and clang-cl [1]_) extensions (up to Clang 8.0),
 
 GNU extensions (up to GCC 8.3), 
 
 Microsoft extensions (up to VS 2019),
 
-Arm Compiler 5.0 [1]_.","``.cpp``, ``.c++``, ``.cxx``, ``.hpp``, ``.hh``, ``.h++``, ``.hxx``, ``.c``, ``.cc``, ``.h``"
-C#,C# up to 7.3. with .NET up to 4.8 [2]_.,"Microsoft Visual Studio up to 2019, 
+Arm Compiler 5.0 [2]_.","``.cpp``, ``.c++``, ``.cxx``, ``.hpp``, ``.hh``, ``.h++``, ``.hxx``, ``.c``, ``.cc``, ``.h``"
+C#,C# up to 7.3. with .NET up to 4.8 [3]_.,"Microsoft Visual Studio up to 2019, 
 
 .NET Core up to 2.2","``.sln``, ``.csproj``, ``.cs``, ``.cshtml``, ``.xaml``"
-COBOL,ANSI 85 or newer [3]_.,Not applicable,"``.cbl``, ``.CBL``, ``.cpy``, ``.CPY``, ``.copy``, ``.COPY``"
-Java,"Java 6 to 12 [4]_.","javac (OpenJDK and Oracle JDK),
+COBOL,ANSI 85 or newer [4]_.,Not applicable,"``.cbl``, ``.CBL``, ``.cpy``, ``.CPY``, ``.copy``, ``.COPY``"
+Java,"Java 6 to 12 [5]_.","javac (OpenJDK and Oracle JDK),
 
-Eclipse compiler for Java (ECJ) [5]_.",``.java``
-JavaScript,ECMAScript 2019 or lower,Not applicable,"``.js``, ``.jsx``, ``.mjs``, ``.es``, ``.es6``, ``.htm``, ``.html``, ``.xhm``, ``.xhtml``, ``.vue``, ``.json``, ``.yaml``, ``.yml``, ``.raml``, ``.xml`` [6]_."
+Eclipse compiler for Java (ECJ) [6]_.",``.java``
+JavaScript,ECMAScript 2019 or lower,Not applicable,"``.js``, ``.jsx``, ``.mjs``, ``.es``, ``.es6``, ``.htm``, ``.html``, ``.xhm``, ``.xhtml``, ``.vue``, ``.json``, ``.yaml``, ``.yml``, ``.raml``, ``.xml`` [7]_."
 Python,"2.7, 3.5, 3.6, 3.7",Not applicable,``.py``
-TypeScript [7]_.,"2.6-3.5",Standard TypeScript compiler,"``.ts``, ``.tsx``"
+TypeScript [8]_.,"2.6-3.5",Standard TypeScript compiler,"``.ts``, ``.tsx``"


### PR DESCRIPTION
@nickrolfe 
This PR updates the 'Languages and compilers` support doc to include the extra information about `clang-cli` that was added to the LGTM help (in the internal PR #33876).

Due to the way footnotes work in restructuredtext, it's easier to keep the clang-ci and armcc notes separate, even though it would look slightly better if we combined them.

Preview of the output can be seen [here](https://jenkins.internal.semmle.com/job/Docs/job/Generate-Sphinx/597/artifact/target/sphinx/ql-support/language-support.html).