### PR TITLE
C++: Support x-macros that are #undef'ed in header

### DIFF
--- a/cpp/ql/test/query-tests/jsf/4.07 Header Files/AV Rule 35/AV Rule 35.expected
+++ b/cpp/ql/test/query-tests/jsf/4.07 Header Files/AV Rule 35/AV Rule 35.expected
@@ -1,6 +1,7 @@
 | complexcondition2.h:0:0:0:0 | complexcondition2.h | This header file should contain a header guard to prevent multiple inclusion. | file://:0:0:0:0 |  |  | file://:0:0:0:0 |  |  |
 | complexcondition.h:0:0:0:0 | complexcondition.h | This header file should contain a header guard to prevent multiple inclusion. | file://:0:0:0:0 |  |  | file://:0:0:0:0 |  |  |
 | fundecl.h:0:0:0:0 | fundecl.h | This header file should contain a header guard to prevent multiple inclusion. | file://:0:0:0:0 |  |  | file://:0:0:0:0 |  |  |
+| items3.h:0:0:0:0 | items3.h | This header file should contain a header guard to prevent multiple inclusion. | file://:0:0:0:0 |  |  | file://:0:0:0:0 |  |  |
 | multipleguards.h:0:0:0:0 | multipleguards.h | This header file should contain a header guard to prevent multiple inclusion ($@ matching $@ occurs before the end of the file). | multipleguards.h:7:1:7:6 | #endif | #endif | multipleguards.h:2:1:2:24 | #ifndef MULTIPLEGUARDS_H | #ifndef MULTIPLEGUARDS_H |
 | namespace1.h:0:0:0:0 | namespace1.h | This header file should contain a header guard to prevent multiple inclusion. | file://:0:0:0:0 |  |  | file://:0:0:0:0 |  |  |
 | namespace2.h:0:0:0:0 | namespace2.h | This header file should contain a header guard to prevent multiple inclusion. | file://:0:0:0:0 |  |  | file://:0:0:0:0 |  |  |

--- a/cpp/ql/test/query-tests/jsf/4.07 Header Files/AV Rule 35/AV Rule 35.expected
+++ b/cpp/ql/test/query-tests/jsf/4.07 Header Files/AV Rule 35/AV Rule 35.expected
@@ -1,7 +1,6 @@
 | complexcondition2.h:0:0:0:0 | complexcondition2.h | This header file should contain a header guard to prevent multiple inclusion. | file://:0:0:0:0 |  |  | file://:0:0:0:0 |  |  |
 | complexcondition.h:0:0:0:0 | complexcondition.h | This header file should contain a header guard to prevent multiple inclusion. | file://:0:0:0:0 |  |  | file://:0:0:0:0 |  |  |
 | fundecl.h:0:0:0:0 | fundecl.h | This header file should contain a header guard to prevent multiple inclusion. | file://:0:0:0:0 |  |  | file://:0:0:0:0 |  |  |
-| items3.h:0:0:0:0 | items3.h | This header file should contain a header guard to prevent multiple inclusion. | file://:0:0:0:0 |  |  | file://:0:0:0:0 |  |  |
 | multipleguards.h:0:0:0:0 | multipleguards.h | This header file should contain a header guard to prevent multiple inclusion ($@ matching $@ occurs before the end of the file). | multipleguards.h:7:1:7:6 | #endif | #endif | multipleguards.h:2:1:2:24 | #ifndef MULTIPLEGUARDS_H | #ifndef MULTIPLEGUARDS_H |
 | namespace1.h:0:0:0:0 | namespace1.h | This header file should contain a header guard to prevent multiple inclusion. | file://:0:0:0:0 |  |  | file://:0:0:0:0 |  |  |
 | namespace2.h:0:0:0:0 | namespace2.h | This header file should contain a header guard to prevent multiple inclusion. | file://:0:0:0:0 |  |  | file://:0:0:0:0 |  |  |

--- a/cpp/ql/test/query-tests/jsf/4.07 Header Files/AV Rule 35/all1.cpp
+++ b/cpp/ql/test/query-tests/jsf/4.07 Header Files/AV Rule 35/all1.cpp
@@ -53,3 +53,8 @@ enum Items {
 #define XMACRO2(id,desc) void use_##();
 	#include "items2.h"
 #undef XMACRO2
+
+
+#define XMACRO3(id,desc) static const char * id##_item = "The " desc " item";
+	#include "items3.h"
+// No #undef of XMACRO3. That's handled in items3.h.

--- a/cpp/ql/test/query-tests/jsf/4.07 Header Files/AV Rule 35/all2.cpp
+++ b/cpp/ql/test/query-tests/jsf/4.07 Header Files/AV Rule 35/all2.cpp
@@ -32,3 +32,7 @@ enum Items {
 #define XMACRO2(id,desc) void use_##();
 	#include "items2.h"
 #undef XMACRO2
+
+#define XMACRO3(id,desc) static const char * id##_name = desc;
+	#include "items3.h"
+// No #undef of XMACRO3. That's handled in items3.h.

--- a/cpp/ql/test/query-tests/jsf/4.07 Header Files/AV Rule 35/items3.h
+++ b/cpp/ql/test/query-tests/jsf/4.07 Header Files/AV Rule 35/items3.h
@@ -1,0 +1,5 @@
+XMACRO3(shield, "Wooden Shield")
+XMACRO3(boots, "Leather Boots")
+XMACRO3(helmet, "Helmet")
+
+#undef XMACRO3


### PR DESCRIPTION
This change should address the FP reported at https://discuss.lgtm.com/t/false-positive-in-c-header/2265.

The changed predicates take negligible time on all snapshots I've tried. @geoffw0, you must have had some problematic snapshots when you wrote #313. Can you test on those?

I'll create a change note file for 1.23 in a separate PR.