### PR TITLE
C++: Change name of UncheckedReturnValueForTimeFunctions.ql

### DIFF
--- a/cpp/ql/src/Likely Bugs/Leap Year/Adding365DaysPerYear.ql
+++ b/cpp/ql/src/Likely Bugs/Leap Year/Adding365DaysPerYear.ql
@@ -1,6 +1,8 @@
 /**
- * @name Year field changed using an arithmetic operation is used on an unchecked time conversion function
- * @description A year field changed using an arithmetic operation is used on a time conversion function, but the return value of the function is not checked for success or failure.
+ * @name Arithmetic operation assumes 365 days per year
+ * @description When an arithmetic operation modifies a date by a constant
+ *              value of 365, it may be a sign that leap years are not taken
+ *              into account.
  * @kind problem
  * @problem.severity warning
  * @id cpp/leap-year/adding-365-days-per-year

--- a/cpp/ql/src/Likely Bugs/Leap Year/UncheckedReturnValueForTimeFunctions.ql
+++ b/cpp/ql/src/Likely Bugs/Leap Year/UncheckedReturnValueForTimeFunctions.ql
@@ -1,5 +1,5 @@
 /**
- * @name Year field changed using an arithmetic operation is used on an unchecked time conversion function
+ * @name Unchecked return value for time conversion function
  * @description A year field changed using an arithmetic operation is used on a time conversion function, but the return value of the function is not checked for success or failure
  * @kind problem
  * @problem.severity warning

--- a/cpp/ql/src/Likely Bugs/Leap Year/UncheckedReturnValueForTimeFunctions.ql
+++ b/cpp/ql/src/Likely Bugs/Leap Year/UncheckedReturnValueForTimeFunctions.ql
@@ -1,6 +1,8 @@
 /**
  * @name Unchecked return value for time conversion function
- * @description A year field changed using an arithmetic operation is used on a time conversion function, but the return value of the function is not checked for success or failure
+ * @description When the return value of a fallible time conversion function is
+ *              not checked for failure, its output parameters may contain
+ *              invalid dates.
  * @kind problem
  * @problem.severity warning
  * @id cpp/leap-year/unchecked-return-value-for-time-conversion-function


### PR DESCRIPTION
The previous name was identical to the name of `Adding365DaysPerYear.ql`. It may have been a copy-paste error.