### PR TITLE
C#: Remove reference equality check

### DIFF
--- a/csharp/extractor/Semmle.Extraction/Entities/Assembly.cs
+++ b/csharp/extractor/Semmle.Extraction/Entities/Assembly.cs
@@ -36,7 +36,7 @@ namespace Semmle.Extraction.Entities
         }
 
         public override bool NeedsPopulation =>
-            assembly != Context.Compilation.Assembly || !Context.IsGlobalContext;
+            !Equals(assembly, Context.Compilation.Assembly) || !Context.IsGlobalContext;
 
         public override int GetHashCode() =>
             symbol == null ? 91187354 : symbol.GetHashCode();


### PR DESCRIPTION
This removes the warning
```
Entities/Assembly.cs(39,13): warning RS1024: Compare symbols correctly [/Users/tom/Work/code/ql/csharp/extractor/Semmle.Extraction/Semmle.Extraction.csproj]
```
(See also https://github.com/dotnet/roslyn-analyzers/issues/2084.)