### PR TITLE
JS: Remove call edges from capture

### DIFF
--- a/javascript/ql/src/semmle/javascript/dataflow/Configuration.qll
+++ b/javascript/ql/src/semmle/javascript/dataflow/Configuration.qll
@@ -611,18 +611,8 @@ private predicate callInputStep(
   Function f, DataFlow::Node invk, DataFlow::Node pred, DataFlow::Node succ,
   DataFlow::Configuration cfg
 ) {
-  (
-    isRelevant(pred, cfg) and
-    argumentPassing(invk, pred, f, succ)
-    or
-    isRelevant(pred, cfg) and
-    exists(SsaDefinition prevDef, SsaDefinition def |
-      pred = DataFlow::ssaDefinitionNode(prevDef) and
-      calls(invk, f) and
-      captures(f, prevDef, def) and
-      succ = DataFlow::ssaDefinitionNode(def)
-    )
-  ) and
+  isRelevant(pred, cfg) and
+  argumentPassing(invk, pred, f, succ) and
   not cfg.isBarrier(succ) and
   not cfg.isBarrierEdge(pred, succ)
 }

--- a/javascript/ql/test/library-tests/TaintTracking/BasicTaintTracking.expected
+++ b/javascript/ql/test/library-tests/TaintTracking/BasicTaintTracking.expected
@@ -29,6 +29,8 @@ typeInferenceMismatch
 | callbacks.js:44:17:44:24 | source() | callbacks.js:41:10:41:10 | x |
 | callbacks.js:50:18:50:25 | source() | callbacks.js:30:29:30:29 | y |
 | callbacks.js:51:18:51:25 | source() | callbacks.js:30:29:30:29 | y |
+| capture-flow.js:2:11:2:18 | source() | capture-flow.js:10:8:10:14 | inner() |
+| capture-flow.js:8:7:8:14 | source() | capture-flow.js:10:8:10:14 | inner() |
 | captured-sanitizer.js:25:3:25:10 | source() | captured-sanitizer.js:15:10:15:10 | x |
 | closure.js:6:15:6:22 | source() | closure.js:8:8:8:31 | string. ... (taint) |
 | closure.js:6:15:6:22 | source() | closure.js:9:8:9:25 | string.trim(taint) |

--- a/javascript/ql/test/library-tests/TaintTracking/DataFlowTracking.expected
+++ b/javascript/ql/test/library-tests/TaintTracking/DataFlowTracking.expected
@@ -16,6 +16,8 @@
 | callbacks.js:44:17:44:24 | source() | callbacks.js:41:10:41:10 | x |
 | callbacks.js:50:18:50:25 | source() | callbacks.js:30:29:30:29 | y |
 | callbacks.js:51:18:51:25 | source() | callbacks.js:30:29:30:29 | y |
+| capture-flow.js:2:11:2:18 | source() | capture-flow.js:10:8:10:14 | inner() |
+| capture-flow.js:8:7:8:14 | source() | capture-flow.js:10:8:10:14 | inner() |
 | captured-sanitizer.js:25:3:25:10 | source() | captured-sanitizer.js:15:10:15:10 | x |
 | constructor-calls.js:4:18:4:25 | source() | constructor-calls.js:18:8:18:14 | c.taint |
 | constructor-calls.js:4:18:4:25 | source() | constructor-calls.js:22:8:22:19 | c_safe.taint |

--- a/javascript/ql/test/library-tests/TaintTracking/capture-flow.js
+++ b/javascript/ql/test/library-tests/TaintTracking/capture-flow.js
@@ -1,0 +1,11 @@
+function test() {
+  let x = source();
+
+  function inner() {
+    return x;
+  }
+
+  x = source();
+
+  sink(inner()); // NOT OK
+}


### PR DESCRIPTION
For captured variables, the definitions and uses are connected by both a call edge and a local edge. The local edge subsumes the call edge (it allows strictly more flows) so there's no need to have both.

[Evaluation](https://git.semmle.com/asger/dist-compare-reports/tree/capture-local-edges_1567383472116).