### PR TITLE
JS: Raise precision of prototype pollution query

### DIFF
--- a/change-notes/1.23/analysis-javascript.md
+++ b/change-notes/1.23/analysis-javascript.md
@@ -18,6 +18,7 @@
 | **Query**                      | **Expected impact**          | **Change**                                                                |
 |--------------------------------|------------------------------|---------------------------------------------------------------------------|
 | Client-side cross-site scripting (`js/xss`) | More results | More potential vulnerabilities involving functions that manipulate DOM attributes are now recognized. |
+| Prototype pollution (`js/prototype-pollution`) | Same results | The results are now shown on LGTM by default. |
 
 ## Changes to QL libraries
 

--- a/javascript/ql/src/Security/CWE-400/PrototypePollution.ql
+++ b/javascript/ql/src/Security/CWE-400/PrototypePollution.ql
@@ -3,8 +3,8 @@
  * @description Recursively merging a user-controlled object into another object
  *              can allow an attacker to modify the built-in Object prototype. 
  * @kind path-problem
- * @problem.severity warning
- * @precision medium
+ * @problem.severity error
+ * @precision high
  * @id js/prototype-pollution
  * @tags security
  *       external/cwe/cwe-250


### PR DESCRIPTION
I thought this was already `@precision high` but it looks like we forgot to bump it after adding dependency information.