### PR TITLE
TS: Fixes in base type relation

### DIFF
--- a/javascript/extractor/lib/typescript/src/type_table.ts
+++ b/javascript/extractor/lib/typescript/src/type_table.ts
@@ -974,8 +974,10 @@ export class TypeTable {
             if (superType == null) continue;
             let baseTypeSymbol = superType.symbol;
             if (baseTypeSymbol == null) continue;
+            let baseId = this.getSymbolId(baseTypeSymbol);
+            // Note: take care not to perform a recursive call between the two `push` calls.
             this.baseTypes.symbols.push(symbolId);
-            this.baseTypes.baseTypeSymbols.push(this.getSymbolId(baseTypeSymbol));
+            this.baseTypes.baseTypeSymbols.push(baseId);
           }
         }
       }

--- a/javascript/ql/src/semmle/javascript/CanonicalNames.qll
+++ b/javascript/ql/src/semmle/javascript/CanonicalNames.qll
@@ -210,7 +210,9 @@ class CanonicalName extends @symbol {
 class TypeName extends CanonicalName {
   TypeName() {
     exists(TypeReference ref | type_symbol(ref, this)) or
-    exists(TypeDefinition def | ast_node_symbol(def, this))
+    exists(TypeDefinition def | ast_node_symbol(def, this)) or
+    base_type_names(_, this) or
+    base_type_names(this, _)
   }
 
   /**

--- a/javascript/ql/test/library-tests/TypeScript/ExternalBaseTypes/BaseTypes.expected
+++ b/javascript/ql/test/library-tests/TypeScript/ExternalBaseTypes/BaseTypes.expected
@@ -1,0 +1,3 @@
+| B in module 'mylib' | A in module 'mylib' |
+| C in module 'mylib' | B in module 'mylib' |
+| D in module 'mylib' | C in module 'mylib' |

--- a/javascript/ql/test/library-tests/TypeScript/ExternalBaseTypes/BaseTypes.ql
+++ b/javascript/ql/test/library-tests/TypeScript/ExternalBaseTypes/BaseTypes.ql
@@ -1,0 +1,5 @@
+import javascript
+
+from TypeName tn
+where tn.hasQualifiedName("mylib", _)
+select tn, tn.getABaseTypeName()

--- a/javascript/ql/test/library-tests/TypeScript/ExternalBaseTypes/node_modules/@types/mylib/index.d.ts
+++ b/javascript/ql/test/library-tests/TypeScript/ExternalBaseTypes/node_modules/@types/mylib/index.d.ts
@@ -1,0 +1,4 @@
+export interface A {}
+export interface B extends A {}
+export interface C extends B {}
+export interface D extends C {}

--- a/javascript/ql/test/library-tests/TypeScript/ExternalBaseTypes/options
+++ b/javascript/ql/test/library-tests/TypeScript/ExternalBaseTypes/options
@@ -1,0 +1,1 @@
+semmle-extractor-options:--exclude node_modules/**

--- a/javascript/ql/test/library-tests/TypeScript/ExternalBaseTypes/tsconfig.json
+++ b/javascript/ql/test/library-tests/TypeScript/ExternalBaseTypes/tsconfig.json
@@ -1,0 +1,5 @@
+{
+	"compilerOptions": {
+		"baseUrl": "./"
+	}
+}

--- a/javascript/ql/test/library-tests/TypeScript/ExternalBaseTypes/tst.ts
+++ b/javascript/ql/test/library-tests/TypeScript/ExternalBaseTypes/tst.ts
@@ -1,0 +1,3 @@
+import { D } from "mylib";
+
+export var foo: D = null;


### PR DESCRIPTION
There were two bugs in the base type relation:
- The extractor would perform a recursive call while an incomplete tuple had been put in the `baseTypeSymbols` relation . To recap, the columns of this relation are stored as separate arrays, so to push a tuple (A,B) you'd do `firstCol.push(A); secondCol.push(B)`. What happened was essentially `firstCol.push(A); doStuff(); secondCol.push(B)` where `doStuff()` is a recursive call that itself pushed more rows, so A and B ended up at different indices.
- The `TypeName` class only included symbols that were referenced from a type or AST node, which in some cases excluded named types from an external library.