### PR TITLE
C++: Tests for aliasing of nested structs

### DIFF
--- a/cpp/ql/test/library-tests/dataflow/fields/aliasing.cpp
+++ b/cpp/ql/test/library-tests/dataflow/fields/aliasing.cpp
@@ -61,3 +61,34 @@ void assignBeforeCopy() {
   S copy2 = s2;
   sink(copy2.m1); // flow
 }
+
+struct Wrapper {
+  S s;
+};
+
+void copyIntermediate() {
+  Wrapper w = { { 0, 0 } };
+  S s = w.s;
+  s.m1 = user_input();
+  sink(w.s.m1); // no flow
+}
+
+void pointerIntermediate() {
+  Wrapper w = { { 0, 0 } };
+  S *s = &w.s;
+  s->m1 = user_input();
+  sink(w.s.m1); // flow [FALSE NEGATIVE]
+}
+
+void referenceIntermediate() {
+  Wrapper w = { { 0, 0 } };
+  S &s = w.s;
+  s.m1 = user_input();
+  sink(w.s.m1); // flow [FALSE NEGATIVE]
+}
+
+void nestedAssign() {
+  Wrapper w = { { 0, 0 } };
+  w.s.m1 = user_input();
+  sink(w.s.m1); // flow
+}

--- a/cpp/ql/test/library-tests/dataflow/fields/flow.expected
+++ b/cpp/ql/test/library-tests/dataflow/fields/flow.expected
@@ -102,6 +102,12 @@ edges
 | aliasing.cpp:60:3:60:22 | ... = ... [void] | aliasing.cpp:60:3:60:4 | s2 [post update] [m1, ... (1)] |
 | aliasing.cpp:60:11:60:20 | call to user_input [void] | aliasing.cpp:60:3:60:22 | ... = ... [void] |
 | aliasing.cpp:62:8:62:12 | copy2 [m1, ... (1)] | aliasing.cpp:62:14:62:15 | m1 |
+| aliasing.cpp:92:3:92:3 | w [post update] [s, ... (2)] | aliasing.cpp:93:8:93:8 | w [s, ... (2)] |
+| aliasing.cpp:92:3:92:23 | ... = ... [void] | aliasing.cpp:92:5:92:5 | s [post update] [m1, ... (1)] |
+| aliasing.cpp:92:5:92:5 | s [post update] [m1, ... (1)] | aliasing.cpp:92:3:92:3 | w [post update] [s, ... (2)] |
+| aliasing.cpp:92:12:92:21 | call to user_input [void] | aliasing.cpp:92:3:92:23 | ... = ... [void] |
+| aliasing.cpp:93:8:93:8 | w [s, ... (2)] | aliasing.cpp:93:10:93:10 | s [m1, ... (1)] |
+| aliasing.cpp:93:10:93:10 | s [m1, ... (1)] | aliasing.cpp:93:12:93:13 | m1 |
 | complex.cpp:34:15:34:15 | b [f, ... (2)] | complex.cpp:44:8:44:8 | b [f, ... (2)] |
 | complex.cpp:34:15:34:15 | b [f, ... (2)] | complex.cpp:45:8:45:8 | b [f, ... (2)] |
 | complex.cpp:44:8:44:8 | b [f, ... (2)] | complex.cpp:44:10:44:10 | f [a_, ... (1)] |
@@ -186,6 +192,7 @@ edges
 | aliasing.cpp:29:11:29:12 | m1 | aliasing.cpp:9:11:9:20 | call to user_input [void] | aliasing.cpp:29:11:29:12 | m1 | m1 flows from $@ | aliasing.cpp:9:11:9:20 | call to user_input [void] | call to user_input [void] |
 | aliasing.cpp:30:11:30:12 | m1 | aliasing.cpp:13:10:13:19 | call to user_input [void] | aliasing.cpp:30:11:30:12 | m1 | m1 flows from $@ | aliasing.cpp:13:10:13:19 | call to user_input [void] | call to user_input [void] |
 | aliasing.cpp:62:14:62:15 | m1 | aliasing.cpp:60:11:60:20 | call to user_input [void] | aliasing.cpp:62:14:62:15 | m1 | m1 flows from $@ | aliasing.cpp:60:11:60:20 | call to user_input [void] | call to user_input [void] |
+| aliasing.cpp:93:12:93:13 | m1 | aliasing.cpp:92:12:92:21 | call to user_input [void] | aliasing.cpp:93:12:93:13 | m1 | m1 flows from $@ | aliasing.cpp:92:12:92:21 | call to user_input [void] | call to user_input [void] |
 | complex.cpp:44:12:44:12 | call to a | complex.cpp:55:13:55:22 | call to user_input [void] | complex.cpp:44:12:44:12 | call to a | call to a flows from $@ | complex.cpp:55:13:55:22 | call to user_input [void] | call to user_input [void] |
 | complex.cpp:44:12:44:12 | call to a | complex.cpp:56:13:56:22 | call to user_input [void] | complex.cpp:44:12:44:12 | call to a | call to a flows from $@ | complex.cpp:56:13:56:22 | call to user_input [void] | call to user_input [void] |
 | complex.cpp:44:12:44:12 | call to a | complex.cpp:57:13:57:22 | call to user_input [void] | complex.cpp:44:12:44:12 | call to a | call to a flows from $@ | complex.cpp:57:13:57:22 | call to user_input [void] | call to user_input [void] |


### PR DESCRIPTION
This test shows that local pointers into structs do propagate data flow like pass-by-reference does in calls.