### PR TITLE
CPP: Add date to JapaneseEraDate.ql

### DIFF
--- a/change-notes/1.23/analysis-cpp.md
+++ b/change-notes/1.23/analysis-cpp.md
@@ -17,6 +17,7 @@ The following changes in version 1.23 affect C/C++ analysis in all applications.
 | Query name (`query id`) | Expected impact | Message. |
 | Hard-coded Japanese era start date in call (`cpp/japanese-era/constructor-or-method-with-exact-era-date`) | Deprecated | This query has been deprecated.  Use the new combined query Hard-coded Japanese era start date (`cpp/japanese-era/exact-era-date`) instead. |
 | Hard-coded Japanese era start date in struct (`cpp/japanese-era/struct-with-exact-era-date`) | Deprecated | This query has been deprecated.  Use the new combined query Hard-coded Japanese era start date (`cpp/japanese-era/exact-era-date`) instead. |
+| Hard-coded Japanese era start date (`cpp/japanese-era/exact-era-date`) | More correct results | This query now checks for the beginning date of the Reiwa era (1st May 2019). |
 
 ## Changes to QL libraries
 

--- a/cpp/ql/src/Best Practices/Magic Constants/JapaneseEraDate.ql
+++ b/cpp/ql/src/Best Practices/Magic Constants/JapaneseEraDate.ql
@@ -36,11 +36,22 @@ predicate assignedDay(Struct s, DayFieldAccess day, int value) {
   )
 }
 
+predicate eraDate(int year, int month, int day) {
+  year = 1989 and month = 1 and day = 8
+  or
+  year = 2019 and month = 5 and day = 1
+}
+
+
 predicate badStructInitialization(Element target, string message) {
-  exists(StructLikeClass s, YearFieldAccess year, MonthFieldAccess month, DayFieldAccess day |
-    assignedYear(s, year, 1989) and
-    assignedMonth(s, month, 1) and
-    assignedDay(s, day, 8) and
+  exists(
+    StructLikeClass s, YearFieldAccess year, MonthFieldAccess month, DayFieldAccess day,
+    int yearValue, int monthValue, int dayValue
+  |
+    eraDate(yearValue, monthValue, dayValue) and
+    assignedYear(s, year, yearValue) and
+    assignedMonth(s, month, monthValue) and
+    assignedDay(s, day, dayValue) and
     target = year and
     message = "A time struct that is initialized with exact Japanese calendar era start date."
   )
@@ -48,9 +59,8 @@ predicate badStructInitialization(Element target, string message) {
 
 predicate badCall(Element target, string message) {
   exists(Call cc, int i |
-    cc.getArgument(i).getValue().toInt() = 1989 and
-    cc.getArgument(i + 1).getValue().toInt() = 1 and
-    cc.getArgument(i + 2).getValue().toInt() = 8 and
+    eraDate(cc.getArgument(i).getValue().toInt(), cc.getArgument(i + 1).getValue().toInt(),
+      cc.getArgument(i + 2).getValue().toInt()) and
     target = cc and
     message = "Call that appears to have hard-coded Japanese era start date as parameter."
   )

--- a/cpp/ql/test/query-tests/Best Practices/Magic Constants/Japanese Era/ConstructorOrMethodWithExactDate.cpp
+++ b/cpp/ql/test/query-tests/Best Practices/Magic Constants/Japanese Era/ConstructorOrMethodWithExactDate.cpp
@@ -37,4 +37,7 @@ int Main()
 
     // GOOD: method call with the same parameters in a different order (we only track year, month, day)
     EraInfo * pDateTimeUtil4 = EraInfo::EraInfoFromDate(1, 2, 8, 1, 1989, L"\u5e73\u6210");
+
+    // BAD: constructor creating a EraInfo with exact Reiwa era start date [NOT DETECTED]
+    EraInfo * pDateTimeUtil5 = new EraInfo(2019, 5, 1);
 }

--- a/cpp/ql/test/query-tests/Best Practices/Magic Constants/Japanese Era/ConstructorOrMethodWithExactDate.cpp
+++ b/cpp/ql/test/query-tests/Best Practices/Magic Constants/Japanese Era/ConstructorOrMethodWithExactDate.cpp
@@ -38,6 +38,6 @@ int Main()
     // GOOD: method call with the same parameters in a different order (we only track year, month, day)
     EraInfo * pDateTimeUtil4 = EraInfo::EraInfoFromDate(1, 2, 8, 1, 1989, L"\u5e73\u6210");
 
-    // BAD: constructor creating a EraInfo with exact Reiwa era start date [NOT DETECTED]
+    // BAD: constructor creating a EraInfo with exact Reiwa era start date
     EraInfo * pDateTimeUtil5 = new EraInfo(2019, 5, 1);
 }

--- a/cpp/ql/test/query-tests/Best Practices/Magic Constants/Japanese Era/JapaneseEraDate.expected
+++ b/cpp/ql/test/query-tests/Best Practices/Magic Constants/Japanese Era/JapaneseEraDate.expected
@@ -1,5 +1,7 @@
 | ConstructorOrMethodWithExactDate.cpp:27:31:27:53 | call to EraInfo | Call that appears to have hard-coded Japanese era start date as parameter. |
 | ConstructorOrMethodWithExactDate.cpp:30:32:30:77 | call to EraInfo | Call that appears to have hard-coded Japanese era start date as parameter. |
 | ConstructorOrMethodWithExactDate.cpp:36:32:36:55 | call to EraInfoFromDate | Call that appears to have hard-coded Japanese era start date as parameter. |
+| ConstructorOrMethodWithExactDate.cpp:42:32:42:54 | call to EraInfo | Call that appears to have hard-coded Japanese era start date as parameter. |
 | StructWithExactDate.cpp:31:13:31:19 | tm_year | A time struct that is initialized with exact Japanese calendar era start date. |
 | StructWithExactDate.cpp:46:8:46:12 | wYear | A time struct that is initialized with exact Japanese calendar era start date. |
+| StructWithExactDate.cpp:60:9:60:13 | wYear | A time struct that is initialized with exact Japanese calendar era start date. |

--- a/cpp/ql/test/query-tests/Best Practices/Magic Constants/Japanese Era/StructWithExactDate.cpp
+++ b/cpp/ql/test/query-tests/Best Practices/Magic Constants/Japanese Era/StructWithExactDate.cpp
@@ -53,7 +53,7 @@ int main()
     st1.wYear = 1990;
 
 
-    // BAD: Creation of SYSTEMTIME stuct corresponding to the beginning of Reiwa era [NOT DETECTED]
+    // BAD: Creation of SYSTEMTIME stuct corresponding to the beginning of Reiwa era
     SYSTEMTIME st2;
     st2.wDay = 1;
     st2.wMonth = 5;

--- a/cpp/ql/test/query-tests/Best Practices/Magic Constants/Japanese Era/StructWithExactDate.cpp
+++ b/cpp/ql/test/query-tests/Best Practices/Magic Constants/Japanese Era/StructWithExactDate.cpp
@@ -52,6 +52,13 @@ int main()
     st1.wMonth = 1;
     st1.wYear = 1990;
 
+
+    // BAD: Creation of SYSTEMTIME stuct corresponding to the beginning of Reiwa era [NOT DETECTED]
+    SYSTEMTIME st2;
+    st2.wDay = 1;
+    st2.wMonth = 5;
+    st2.wYear = 2019;
+
     return 0;
 }
 


### PR DESCRIPTION
Add the Reiwa era start date (1st May 2019) to `cpp/japanese-era/exact-era-date` (as requested in https://github.com/Semmle/ql/pull/1847#discussion_r319684391).