### PR TITLE
CPP: Tiny fixes

### DIFF
--- a/cpp/ql/src/Likely Bugs/Leap Year/LeapYear.qll
+++ b/cpp/ql/src/Likely Bugs/Leap Year/LeapYear.qll
@@ -4,7 +4,6 @@
 
 import cpp
 import semmle.code.cpp.dataflow.DataFlow
-import semmle.code.cpp.controlflow.Guards
 import semmle.code.cpp.commons.DateTime
 
 /**

--- a/cpp/ql/src/Security/CWE/CWE-190/ComparisonWithWiderType.ql
+++ b/cpp/ql/src/Security/CWE/CWE-190/ComparisonWithWiderType.ql
@@ -12,7 +12,7 @@
  *       external/cwe/cwe-197
  *       external/cwe/cwe-835
  * 
-*/
+ */
 
 import cpp
 import semmle.code.cpp.controlflow.Dominance


### PR DESCRIPTION
Delete an unused include I came across.

Fix alignment of a comment.