### PR TITLE
Python: Prevent divergence in type-hint analysis. (ODASA-8075)

### DIFF
--- a/python/ql/src/semmle/python/objects/Callables.qll
+++ b/python/ql/src/semmle/python/objects/Callables.qll
@@ -163,6 +163,8 @@ class PythonFunctionObjectInternal extends CallableObjectInternal, TPythonFuncti
 
     override predicate useOriginAsLegacyObject() { none() }
 
+    override predicate isNotSubscriptedType() { any() }
+
 }
 
 
@@ -288,6 +290,8 @@ class BuiltinFunctionObjectInternal extends CallableObjectInternal, TBuiltinFunc
 
     override predicate useOriginAsLegacyObject() { none() }
 
+    override predicate isNotSubscriptedType() { any() }
+
 }
 
 /** Class representing methods of built-in classes (otherwise known as method-descriptors) such as `list.append`.
@@ -382,6 +386,8 @@ class BuiltinMethodObjectInternal extends CallableObjectInternal, TBuiltinMethod
 
     override predicate useOriginAsLegacyObject() { none() }
 
+    override predicate isNotSubscriptedType() { any() }
+
 }
 
 /** Class representing bound-methods.
@@ -472,5 +478,7 @@ class BoundMethodObjectInternal extends CallableObjectInternal, TBoundMethod {
     override predicate contextSensitiveCallee() {
         this.getFunction().contextSensitiveCallee()
     }
+
+    override predicate isNotSubscriptedType() { any() }
 
 }

--- a/python/ql/src/semmle/python/objects/Classes.qll
+++ b/python/ql/src/semmle/python/objects/Classes.qll
@@ -103,6 +103,8 @@ abstract class ClassObjectInternal extends ObjectInternal {
         Types::getBase(this, _).hasAttribute(name)
     }
 
+    override predicate isNotSubscriptedType() { any() }
+
 }
 
 /** Class representing Python source classes */
@@ -444,6 +446,8 @@ class SubscriptedTypeInternal extends ObjectInternal, TSubscriptedType {
 
     /* Classes aren't usually iterable, but can e.g. Enums */
     override ObjectInternal getIterNext() { result = ObjectInternal::unknown() }
+
+    override predicate isNotSubscriptedType() { none() }
 
 }
 

--- a/python/ql/src/semmle/python/objects/Constants.qll
+++ b/python/ql/src/semmle/python/objects/Constants.qll
@@ -76,6 +76,8 @@ abstract class ConstantObjectInternal extends ObjectInternal {
     /** Gets an AST literal with the same value as this object */
     abstract ImmutableLiteral getLiteral();
 
+    override predicate isNotSubscriptedType() { any() }
+
 }
 
 pragma[nomagic]

--- a/python/ql/src/semmle/python/objects/Descriptors.qll
+++ b/python/ql/src/semmle/python/objects/Descriptors.qll
@@ -101,6 +101,8 @@ class PropertyInternal extends ObjectInternal, TProperty {
     /* Properties aren't iterable */
     override ObjectInternal getIterNext() { none() }
 
+    override predicate isNotSubscriptedType() { any() }
+
 }
 
 private class PropertySetterOrDeleter extends ObjectInternal, TPropertySetterOrDeleter {
@@ -173,6 +175,8 @@ private class PropertySetterOrDeleter extends ObjectInternal, TPropertySetterOrD
     override predicate descriptorGetInstance(ObjectInternal instance, ObjectInternal value, CfgOrigin origin) { none() }
 
     override predicate useOriginAsLegacyObject() { none() }
+
+    override predicate isNotSubscriptedType() { any() }
 
 }
 
@@ -267,6 +271,8 @@ class ClassMethodObjectInternal extends ObjectInternal, TClassMethod {
     /* Classmethods aren't iterable */
     override ObjectInternal getIterNext() { none() }
 
+    override predicate isNotSubscriptedType() { any() }
+
 }
 
 class StaticMethodObjectInternal extends ObjectInternal, TStaticMethod {
@@ -344,5 +350,7 @@ class StaticMethodObjectInternal extends ObjectInternal, TStaticMethod {
 
     /* Staticmethods aren't iterable */
     override ObjectInternal getIterNext() { none() }
+
+    override predicate isNotSubscriptedType() { any() }
 
 }

--- a/python/ql/src/semmle/python/objects/Instances.qll
+++ b/python/ql/src/semmle/python/objects/Instances.qll
@@ -55,6 +55,8 @@ abstract class InstanceObject extends ObjectInternal {
 
     override ObjectInternal getIterNext() { result = ObjectInternal::unknown() }
 
+    override predicate isNotSubscriptedType() { any() }
+
 }
 
 private predicate self_variable_reaching_init_exit(EssaVariable self) {
@@ -387,6 +389,8 @@ class UnknownInstanceInternal extends TUnknownInstance, ObjectInternal {
 
     override ObjectInternal getIterNext() { result = ObjectInternal::unknown() }
 
+    override predicate isNotSubscriptedType() { any() }
+
 }
 
 private int lengthFromClass(ClassObjectInternal cls) {
@@ -498,6 +502,8 @@ class SuperInstance extends TSuperInstance, ObjectInternal {
     override predicate useOriginAsLegacyObject() { any() }
 
     override ObjectInternal getIterNext() { result = ObjectInternal::unknown() }
+
+    override predicate isNotSubscriptedType() { any() }
 
 }
 

--- a/python/ql/src/semmle/python/objects/Modules.qll
+++ b/python/ql/src/semmle/python/objects/Modules.qll
@@ -71,6 +71,8 @@ abstract class ModuleObjectInternal extends ObjectInternal {
         py_exports(this.getSourceModule(), name)
     }
 
+    override predicate isNotSubscriptedType() { any() }
+
 }
 
 /** A class representing built-in modules */
@@ -444,6 +446,8 @@ class AbsentModuleAttributeObjectInternal extends ObjectInternal, TAbsentModuleA
 
     /* Modules aren't iterable */
     override ObjectInternal getIterNext() { none() }
+
+    override predicate isNotSubscriptedType() { any() }
 
 }
 

--- a/python/ql/src/semmle/python/objects/ObjectInternal.qll
+++ b/python/ql/src/semmle/python/objects/ObjectInternal.qll
@@ -187,6 +187,8 @@ class ObjectInternal extends TObject {
         this.(ObjectInternal).attribute(name, _, _)
     }
 
+    abstract predicate isNotSubscriptedType();
+
 }
 
 
@@ -276,6 +278,8 @@ class BuiltinOpaqueObjectInternal extends ObjectInternal, TBuiltinOpaqueObject {
 
     override ObjectInternal getIterNext() { result = ObjectInternal::unknown() }
 
+    override predicate isNotSubscriptedType() { any() }
+
 }
 
 
@@ -358,6 +362,8 @@ class UnknownInternal extends ObjectInternal, TUnknown {
     override predicate useOriginAsLegacyObject() { none() }
 
     override ObjectInternal getIterNext() { result = ObjectInternal::unknown() }
+
+    override predicate isNotSubscriptedType() { any() }
 
 }
 
@@ -444,6 +450,8 @@ class UndefinedInternal extends ObjectInternal, TUndefined {
     override predicate contextSensitiveCallee() { none() }
 
     override ObjectInternal getIterNext() { none() }
+
+    override predicate isNotSubscriptedType() { any() }
 
 }
 
@@ -629,6 +637,8 @@ class DecoratedFunction extends ObjectInternal, TDecoratedFunction {
     override predicate contextSensitiveCallee() { none() }
 
     override predicate useOriginAsLegacyObject() { none() }
+
+    override predicate isNotSubscriptedType() { any() }
 
 }
 

--- a/python/ql/src/semmle/python/objects/Sequences.qll
+++ b/python/ql/src/semmle/python/objects/Sequences.qll
@@ -131,6 +131,8 @@ class BuiltinTupleObjectInternal extends TBuiltinTuple, TupleObjectInternal {
 
     override predicate useOriginAsLegacyObject() { none() }
 
+    override predicate isNotSubscriptedType() { any() }
+
 }
 
 /** A tuple declared by a tuple expression in the Python source code */
@@ -164,6 +166,8 @@ class PythonTupleObjectInternal extends TPythonTuple, TupleObjectInternal {
 
     override predicate useOriginAsLegacyObject() { none() }
 
+    override predicate isNotSubscriptedType() { any() }
+
 }
 
 /** A tuple created by a `*` parameter */
@@ -194,6 +198,8 @@ class VarargsTupleObjectInternal extends TVarargsTuple,  TupleObjectInternal {
     }
 
     override predicate useOriginAsLegacyObject() { any() }
+
+    override predicate isNotSubscriptedType() { any() }
 
 }
 
@@ -276,5 +282,7 @@ class SysVersionInfoObjectInternal extends TSysVersionInfo, SequenceObjectIntern
     override predicate functionAndOffset(CallableObjectInternal function, int offset) { none() }
 
     override predicate useOriginAsLegacyObject() { any() }
+
+    override predicate isNotSubscriptedType() { any() }
 
 }

--- a/python/ql/src/semmle/python/objects/TObject.qll
+++ b/python/ql/src/semmle/python/objects/TObject.qll
@@ -240,6 +240,8 @@ cached newtype TObject =
     /* Represents a subscript operation applied to a type. For type-hint analysis */
     TSubscriptedType(ObjectInternal generic, ObjectInternal index) {
         isType(generic) and
+        generic.isNotSubscriptedType() and
+        index.isNotSubscriptedType() and
         Expressions::subscriptPartsPointsTo(_, _, generic, index)
     }
 

--- a/python/ql/test/3/library-tests/PointsTo/typehints/Values.expected
+++ b/python/ql/test/3/library-tests/PointsTo/typehints/Values.expected
@@ -10,3 +10,12 @@
 | test.py:6:1:6:20 | test.py:6 | ControlFlowNode for FunctionExpr | import | test.py:6:1:6:20 | Function bar |
 | test.py:6:11:6:13 | test.py:6 | ControlFlowNode for set | import | file://:0:0:0:0 | builtin-class set |
 | test.py:6:17:6:19 | test.py:6 | ControlFlowNode for Set | import | ../../lib/typing.py:23:1:23:23 | class Set |
+| test.py:9:6:9:13 | test.py:9 | ControlFlowNode for Optional | import | ../../lib/typing.py:18:12:18:32 | _Optional() |
+| test.py:9:6:9:28 | test.py:9 | ControlFlowNode for Subscript | import | file://:0:0:0:0 | _Optional()[Unknown value] |
+| test.py:9:15:9:22 | test.py:9 | ControlFlowNode for Optional | import | ../../lib/typing.py:18:12:18:32 | _Optional() |
+| test.py:9:15:9:27 | test.py:9 | ControlFlowNode for Subscript | import | file://:0:0:0:0 | _Optional()[builtin-class int] |
+| test.py:9:24:9:26 | test.py:9 | ControlFlowNode for int | import | file://:0:0:0:0 | builtin-class int |
+| test.py:10:6:10:13 | test.py:10 | ControlFlowNode for Optional | import | ../../lib/typing.py:18:12:18:32 | _Optional() |
+| test.py:10:6:10:18 | test.py:10 | ControlFlowNode for Subscript | import | file://:0:0:0:0 | _Optional()[builtin-class int] |
+| test.py:10:15:10:17 | test.py:10 | ControlFlowNode for int | import | file://:0:0:0:0 | builtin-class int |
+| test.py:10:20:10:22 | test.py:10 | ControlFlowNode for int | import | file://:0:0:0:0 | builtin-class int |

--- a/python/ql/test/3/library-tests/PointsTo/typehints/Values.expected
+++ b/python/ql/test/3/library-tests/PointsTo/typehints/Values.expected
@@ -10,10 +10,3 @@
 | test.py:6:1:6:20 | test.py:6 | ControlFlowNode for FunctionExpr | import | test.py:6:1:6:20 | Function bar |
 | test.py:6:11:6:13 | test.py:6 | ControlFlowNode for set | import | file://:0:0:0:0 | builtin-class set |
 | test.py:6:17:6:19 | test.py:6 | ControlFlowNode for Set | import | ../../lib/typing.py:23:1:23:23 | class Set |
-| test.py:11:1:11:12 | test.py:11 | ControlFlowNode for ClassExpr | import | test.py:11:1:11:12 | class baz |
-| test.py:14:7:14:10 | test.py:14 | ControlFlowNode for True | import | file://:0:0:0:0 | bool True |
-| test.py:15:11:15:13 | test.py:15 | ControlFlowNode for baz | import | file://:0:0:0:0 | class baz[class baz] |
-| test.py:15:11:15:13 | test.py:15 | ControlFlowNode for baz | import | test.py:11:1:11:12 | class baz |
-| test.py:15:11:15:18 | test.py:15 | ControlFlowNode for Subscript | import | file://:0:0:0:0 | class baz[class baz] |
-| test.py:15:15:15:17 | test.py:15 | ControlFlowNode for baz | import | file://:0:0:0:0 | class baz[class baz] |
-| test.py:15:15:15:17 | test.py:15 | ControlFlowNode for baz | import | test.py:11:1:11:12 | class baz |

--- a/python/ql/test/3/library-tests/PointsTo/typehints/Values.expected
+++ b/python/ql/test/3/library-tests/PointsTo/typehints/Values.expected
@@ -10,3 +10,10 @@
 | test.py:6:1:6:20 | test.py:6 | ControlFlowNode for FunctionExpr | import | test.py:6:1:6:20 | Function bar |
 | test.py:6:11:6:13 | test.py:6 | ControlFlowNode for set | import | file://:0:0:0:0 | builtin-class set |
 | test.py:6:17:6:19 | test.py:6 | ControlFlowNode for Set | import | ../../lib/typing.py:23:1:23:23 | class Set |
+| test.py:11:1:11:12 | test.py:11 | ControlFlowNode for ClassExpr | import | test.py:11:1:11:12 | class baz |
+| test.py:14:7:14:10 | test.py:14 | ControlFlowNode for True | import | file://:0:0:0:0 | bool True |
+| test.py:15:11:15:13 | test.py:15 | ControlFlowNode for baz | import | file://:0:0:0:0 | class baz[class baz] |
+| test.py:15:11:15:13 | test.py:15 | ControlFlowNode for baz | import | test.py:11:1:11:12 | class baz |
+| test.py:15:11:15:18 | test.py:15 | ControlFlowNode for Subscript | import | file://:0:0:0:0 | class baz[class baz] |
+| test.py:15:15:15:17 | test.py:15 | ControlFlowNode for baz | import | file://:0:0:0:0 | class baz[class baz] |
+| test.py:15:15:15:17 | test.py:15 | ControlFlowNode for baz | import | test.py:11:1:11:12 | class baz |

--- a/python/ql/test/3/library-tests/PointsTo/typehints/test.py
+++ b/python/ql/test/3/library-tests/PointsTo/typehints/test.py
@@ -6,6 +6,8 @@ def foo(x:Optional[int]) -> int:
 def bar(s:set)->Set:
     pass
 
+t1 = Optional[Optional[int]]
+t2 = Optional[int][int]
 
 # ODASA-8075
 # Commented out until the fix has been pushed to LGTM.com

--- a/python/ql/test/3/library-tests/PointsTo/typehints/test.py
+++ b/python/ql/test/3/library-tests/PointsTo/typehints/test.py
@@ -8,8 +8,9 @@ def bar(s:set)->Set:
 
 
 # ODASA-8075
-class baz():
-    pass
-
-while True:
-    baz = baz[baz]
+# Commented out until the fix has been pushed to LGTM.com
+#class baz():
+#    pass
+#
+#while True:
+#    baz = baz[baz]

--- a/python/ql/test/3/library-tests/PointsTo/typehints/test.py
+++ b/python/ql/test/3/library-tests/PointsTo/typehints/test.py
@@ -5,3 +5,11 @@ def foo(x:Optional[int]) -> int:
 
 def bar(s:set)->Set:
     pass
+
+
+# ODASA-8075
+class baz():
+    pass
+
+while True:
+    baz = baz[baz]


### PR DESCRIPTION
This fixes an unfortunate (but highly specific) divergence in the points-to analysis.
The following piece of code is a (more or less) minimal example that exhibits the divergence: 

```python
class foo():
    pass

while True:
    foo = foo[foo]
```

The culprit is the support for subscripted types originally introduced in #1728. Essentially, given the above, `foo` (the variable) can point to the subscripted type `foo[foo]`, but then also the subscripted type `(foo[foo])[(foo[foo])` and so on. Thankfully, only two projects on LGTM.com exhibited the above divergence.

To fix this, we block the recursion by requiring that the two types involved in a type subscripting operation (`A` and `B` in `A[B]`) must not themselves be subscripted types. 

As this fixes an (obscure) regression in the analysis, I don't think it needs a change note.

Performance comparison here: https://git.semmle.com/gist/taus/8c8f31f2bb72055e50cc97bcce070747

Looks like a ~30% increase in performance across the board. Also seems to remove a bunch of false positives.