### PR TITLE
JS: Type tracking through imports

### DIFF
--- a/javascript/ql/src/Declarations/DeadStoreOfLocal.ql
+++ b/javascript/ql/src/Declarations/DeadStoreOfLocal.ql
@@ -36,6 +36,11 @@ where
   exists(v.getAnAccess()) and
   // don't flag ambient variable definitions
   not dead.(ASTNode).isAmbient() and
+  // don't flag variables with ambient uses
+  not exists(LexicalAccess access |
+    access.getALexicalName() = v.getADeclaration().getALexicalName() and
+    access.isAmbient()
+  ) and
   // don't flag function expressions
   not exists(FunctionExpr fe | dead = fe.getId()) and
   // don't flag function declarations nested inside blocks or other compound statements;

--- a/javascript/ql/src/semmle/javascript/DefUse.qll
+++ b/javascript/ql/src/semmle/javascript/DefUse.qll
@@ -40,6 +40,8 @@ private predicate defn(ControlFlowNode def, Expr lhs, AST::ValueNode rhs) {
   or
   exists(ImportEqualsDeclaration i | def = i | lhs = i.getId() and rhs = i.getImportedEntity())
   or
+  exists(ImportSpecifier i | def = i | lhs = i.getLocal() and rhs = i)
+  or
   exists(EnumMember member | def = member.getIdentifier() |
     lhs = def and rhs = member.getInitializer()
   )
@@ -70,8 +72,6 @@ private predicate defn(ControlFlowNode def, Expr lhs) {
   lhs = def.(CompoundAssignExpr).getTarget()
   or
   lhs = def.(UpdateExpr).getOperand().getUnderlyingReference()
-  or
-  lhs = def.(ImportSpecifier).getLocal()
   or
   exists(EnhancedForLoop efl | def = efl.getIteratorExpr() |
     lhs = def.(Expr).stripParens() or

--- a/javascript/ql/src/semmle/javascript/ES2015Modules.qll
+++ b/javascript/ql/src/semmle/javascript/ES2015Modules.qll
@@ -65,7 +65,7 @@ class ImportDeclaration extends Stmt, Import, @importdeclaration {
     // `import * as http from 'http'` or `import http from `http`'
     exists(ImportSpecifier is |
       is = getASpecifier() and
-      result = DataFlow::ssaDefinitionNode(SSA::definition(is))
+      result = DataFlow::valueNode(is)
     |
       is instanceof ImportNamespaceSpecifier and
       count(getASpecifier()) = 1

--- a/javascript/ql/src/semmle/javascript/dataflow/DataFlow.qll
+++ b/javascript/ql/src/semmle/javascript/dataflow/DataFlow.qll
@@ -799,21 +799,21 @@ module DataFlow {
   /**
    * A named import specifier seen as a property read on the imported module.
    */
-  private class ImportSpecifierAsPropRead extends PropRead {
+  private class ImportSpecifierAsPropRead extends PropRead, ValueNode {
+    override ImportSpecifier astNode;
+
     ImportDeclaration imprt;
-    ImportSpecifier spec;
 
     ImportSpecifierAsPropRead() {
-      spec = imprt.getASpecifier() and
-      exists(spec.getImportedName()) and
-      this = ssaDefinitionNode(SSA::definition(spec))
+      astNode = imprt.getASpecifier() and
+      exists(astNode.getImportedName())
     }
 
     override Node getBase() { result = TDestructuredModuleImportNode(imprt) }
 
-    override Expr getPropertyNameExpr() { result = spec.getImported() }
+    override Expr getPropertyNameExpr() { result = astNode.getImported() }
 
-    override string getPropertyName() { result = spec.getImportedName() }
+    override string getPropertyName() { result = astNode.getImportedName() }
   }
 
   /**

--- a/javascript/ql/src/semmle/javascript/dataflow/Sources.qll
+++ b/javascript/ql/src/semmle/javascript/dataflow/Sources.qll
@@ -235,12 +235,8 @@ module SourceNode {
         astNode instanceof FunctionSentExpr or
         astNode instanceof FunctionBindExpr or
         astNode instanceof DynamicImportExpr or
-        astNode instanceof NamedImportSpecifier
+        astNode instanceof ImportSpecifier
       )
-      or
-      this = DataFlow::ssaDefinitionNode(SSA::definition(any(ImportNamespaceSpecifier imp)))
-      or
-      this = DataFlow::ssaDefinitionNode(SSA::definition(any(ImportDefaultSpecifier imp)))
       or
       DataFlow::parameterNode(this, _)
       or

--- a/javascript/ql/src/semmle/javascript/dataflow/Sources.qll
+++ b/javascript/ql/src/semmle/javascript/dataflow/Sources.qll
@@ -234,10 +234,13 @@ module SourceNode {
         astNode instanceof AwaitExpr or
         astNode instanceof FunctionSentExpr or
         astNode instanceof FunctionBindExpr or
-        astNode instanceof DynamicImportExpr
+        astNode instanceof DynamicImportExpr or
+        astNode instanceof NamedImportSpecifier
       )
       or
-      this = DataFlow::ssaDefinitionNode(SSA::definition(any(ImportSpecifier imp)))
+      this = DataFlow::ssaDefinitionNode(SSA::definition(any(ImportNamespaceSpecifier imp)))
+      or
+      this = DataFlow::ssaDefinitionNode(SSA::definition(any(ImportDefaultSpecifier imp)))
       or
       DataFlow::parameterNode(this, _)
       or

--- a/javascript/ql/test/library-tests/DataFlow/flowStep.expected
+++ b/javascript/ql/test/library-tests/DataFlow/flowStep.expected
@@ -9,6 +9,7 @@
 | sources.js:5:4:5:5 | 23 | sources.js:3:11:3:11 | x |
 | tst.js:1:1:1:1 | x | tst.js:28:2:28:1 | x |
 | tst.js:1:1:1:1 | x | tst.js:32:1:32:0 | x |
+| tst.js:1:10:1:11 | fs | tst.js:1:10:1:11 | fs |
 | tst.js:1:10:1:11 | fs | tst.js:7:1:7:2 | fs |
 | tst.js:1:10:1:11 | fs | tst.js:22:24:22:25 | fs |
 | tst.js:3:5:3:10 | x | tst.js:8:1:8:1 | x |

--- a/javascript/ql/test/library-tests/DefUse/VarDefSource.expected
+++ b/javascript/ql/test/library-tests/DefUse/VarDefSource.expected
@@ -3,6 +3,9 @@
 | classes.js:7:5:8:5 | class L ... {\\n    } | classes.js:7:5:8:5 | class L ... {\\n    } |
 | classes.js:10:5:10:31 | LocalFo ... ar = 42 | classes.js:10:30:10:31 | 42 |
 | es2015.js:4:10:4:19 | getSquares | es2015.js:4:1:6:1 | functio ... i*i];\\n} |
+| es2015modules.js:1:10:1:12 | foo | es2015modules.js:1:10:1:12 | foo |
+| es2015modules.js:1:15:1:24 | bar as baz | es2015modules.js:1:15:1:24 | bar as baz |
+| es2015modules.js:10:10:10:13 | quux | es2015modules.js:10:10:10:13 | quux |
 | es2015modules.js:15:17:15:17 | f | es2015modules.js:15:8:15:22 | function f() {} |
 | es2015modules.js:16:25:16:25 | g | es2015modules.js:16:16:16:30 | function g() {} |
 | fundecls.js:1:10:1:10 | s | fundecls.js:1:1:5:1 | functio ...  f();\\n} |

--- a/javascript/ql/test/library-tests/ModuleImportNodes/TSGlobalImport.expected
+++ b/javascript/ql/test/library-tests/ModuleImportNodes/TSGlobalImport.expected
@@ -6,11 +6,14 @@
 | client2_lazy.ts:4:28:4:29 | F2 | framework2 |
 | declare-module-client2.ts:3:1:3:22 | import  ...  'foo'; | foo |
 | declare-module-client.ts:3:1:3:22 | import  ...  'foo'; | foo |
+| decls.ts:2:8:2:20 | * as F1_outer | framework1 |
+| decls.ts:3:8:3:20 | * as F2_outer | framework2 |
+| decls.ts:4:8:4:21 | * as net_outer | net |
 | destructuringES6.js:1:1:1:41 | import  ... ctron'; | electron |
 | destructuringRequire.js:1:27:1:45 | require('electron') | electron |
 | instanceThroughDefaultImport.js:1:1:1:82 | import  ... tance'; | myDefaultImportedModuleInstance |
-| instanceThroughDefaultImport.js:1:8:1:42 | myDefaultImportedModuleInstanceName | myDefaultImportedModuleInstance |
-| instanceThroughNamespaceImport.js:1:8:1:49 | myNamespaceImportedModuleInstanceName | myNamespaceImportedModuleInstance |
+| instanceThroughDefaultImport.js:1:8:1:42 | myDefau ... nceName | myDefaultImportedModuleInstance |
+| instanceThroughNamespaceImport.js:1:8:1:49 | * as my ... nceName | myNamespaceImportedModuleInstance |
 | instanceThroughRequire.js:1:36:1:70 | require ... tance') | myRequiredModuleInstance |
 | moduleUses.js:1:11:1:24 | require('mod') | mod |
 | process2.js:1:1:1:13 | require('fs') | fs |

--- a/javascript/ql/test/library-tests/ModuleImportNodes/tests.expected
+++ b/javascript/ql/test/library-tests/ModuleImportNodes/tests.expected
@@ -5,10 +5,10 @@ test_ModuleImportNode
 | client1.ts:6:9:6:11 | net | net | client1.ts:6:9:6:11 | net | net |
 | client2.ts:4:28:4:29 | F2 | framework2 | client2.ts:4:28:4:29 | F2 | F2 |
 | client2_lazy.ts:4:28:4:29 | F2 | framework2 | client2_lazy.ts:4:28:4:29 | F2 | F2 |
-| instanceThroughDefaultImport.js:1:8:1:42 | myDefaultImportedModuleInstanceName | myDefaultImportedModuleInstance | instanceThroughDefaultImport.js:2:1:2:35 | myDefau ... nceName | myDefaultImportedModuleInstanceName |
-| instanceThroughDefaultImport.js:1:8:1:42 | myDefaultImportedModuleInstanceName | myDefaultImportedModuleInstance | instanceThroughDefaultImport.js:4:5:4:39 | myDefau ... nceName | myDefaultImportedModuleInstanceName |
-| instanceThroughNamespaceImport.js:1:8:1:49 | myNamespaceImportedModuleInstanceName | myNamespaceImportedModuleInstance | instanceThroughNamespaceImport.js:2:1:2:37 | myNames ... nceName | myNamespaceImportedModuleInstanceName |
-| instanceThroughNamespaceImport.js:1:8:1:49 | myNamespaceImportedModuleInstanceName | myNamespaceImportedModuleInstance | instanceThroughNamespaceImport.js:4:5:4:41 | myNames ... nceName | myNamespaceImportedModuleInstanceName |
+| instanceThroughDefaultImport.js:1:8:1:42 | myDefau ... nceName | myDefaultImportedModuleInstance | instanceThroughDefaultImport.js:2:1:2:35 | myDefau ... nceName | myDefaultImportedModuleInstanceName |
+| instanceThroughDefaultImport.js:1:8:1:42 | myDefau ... nceName | myDefaultImportedModuleInstance | instanceThroughDefaultImport.js:4:5:4:39 | myDefau ... nceName | myDefaultImportedModuleInstanceName |
+| instanceThroughNamespaceImport.js:1:8:1:49 | * as my ... nceName | myNamespaceImportedModuleInstance | instanceThroughNamespaceImport.js:2:1:2:37 | myNames ... nceName | myNamespaceImportedModuleInstanceName |
+| instanceThroughNamespaceImport.js:1:8:1:49 | * as my ... nceName | myNamespaceImportedModuleInstance | instanceThroughNamespaceImport.js:4:5:4:41 | myNames ... nceName | myNamespaceImportedModuleInstanceName |
 | instanceThroughRequire.js:1:36:1:70 | require ... tance') | myRequiredModuleInstance | instanceThroughRequire.js:2:1:2:28 | myRequi ... nceName | myRequiredModuleInstanceName |
 | instanceThroughRequire.js:1:36:1:70 | require ... tance') | myRequiredModuleInstance | instanceThroughRequire.js:4:5:4:32 | myRequi ... nceName | myRequiredModuleInstanceName |
 | moduleUses.js:1:11:1:24 | require('mod') | mod | moduleUses.js:3:1:3:3 | mod | mod |
@@ -31,22 +31,27 @@ test_moduleImport
 | foo | declare-module-client2.ts:3:1:3:22 | import  ...  'foo'; |
 | foo | declare-module-client.ts:3:1:3:22 | import  ...  'foo'; |
 | framework1 | client1.ts:4:28:4:29 | F1 |
+| framework1 | decls.ts:2:8:2:20 | * as F1_outer |
 | framework2 | client2.ts:4:28:4:29 | F2 |
 | framework2 | client2_lazy.ts:4:28:4:29 | F2 |
+| framework2 | decls.ts:3:8:3:20 | * as F2_outer |
 | fs | amd1.js:1:25:1:26 | fs |
 | fs | amd2.js:2:12:2:24 | require('fs') |
 | fs | process2.js:1:1:1:13 | require('fs') |
 | mod | moduleUses.js:1:11:1:24 | require('mod') |
 | myDefaultImportedModuleInstance | instanceThroughDefaultImport.js:1:1:1:82 | import  ... tance'; |
-| myDefaultImportedModuleInstance | instanceThroughDefaultImport.js:1:8:1:42 | myDefaultImportedModuleInstanceName |
-| myNamespaceImportedModuleInstance | instanceThroughNamespaceImport.js:1:8:1:49 | myNamespaceImportedModuleInstanceName |
+| myDefaultImportedModuleInstance | instanceThroughDefaultImport.js:1:8:1:42 | myDefau ... nceName |
+| myNamespaceImportedModuleInstance | instanceThroughNamespaceImport.js:1:8:1:49 | * as my ... nceName |
 | myRequiredModuleInstance | instanceThroughRequire.js:1:36:1:70 | require ... tance') |
 | net | client1.ts:6:9:6:11 | net |
+| net | decls.ts:4:8:4:21 | * as net_outer |
 | process | process2.js:2:10:2:16 | process |
 | process | process.js:1:10:1:27 | require('process') |
 test_moduleMember
 | electron | BrowserWindow | destructuringES6.js:1:10:1:22 | BrowserWindow |
 | electron | BrowserWindow | destructuringRequire.js:1:9:1:21 | BrowserWindow |
+| foo | C | declare-module-client2.ts:3:9:3:9 | C |
+| foo | C | declare-module-client.ts:3:9:3:9 | C |
 | framework1 | Component | client1.ts:4:28:4:39 | F1.Component |
 | framework2 | Component | client2.ts:4:28:4:39 | F2.Component |
 | framework2 | Component | client2_lazy.ts:4:28:4:39 | F2.Component |
@@ -56,7 +61,7 @@ test_moduleMember
 | mod | moduleField | moduleUses.js:11:1:11:15 | mod.moduleField |
 | mod | moduleFunction | moduleUses.js:5:9:5:26 | mod.moduleFunction |
 | mod | moduleMethod | moduleUses.js:3:1:3:16 | mod.moduleMethod |
-| myDefaultImportedModuleInstance | default | instanceThroughDefaultImport.js:1:8:1:42 | myDefaultImportedModuleInstanceName |
+| myDefaultImportedModuleInstance | default | instanceThroughDefaultImport.js:1:8:1:42 | myDefau ... nceName |
 | net | createServer | client1.ts:6:9:6:24 | net.createServer |
 test_ModuleImportNode_getPath
 | amd1.js:1:25:1:26 | fs | fs |
@@ -67,11 +72,14 @@ test_ModuleImportNode_getPath
 | client2_lazy.ts:4:28:4:29 | F2 | framework2 |
 | declare-module-client2.ts:3:1:3:22 | import  ...  'foo'; | foo |
 | declare-module-client.ts:3:1:3:22 | import  ...  'foo'; | foo |
+| decls.ts:2:8:2:20 | * as F1_outer | framework1 |
+| decls.ts:3:8:3:20 | * as F2_outer | framework2 |
+| decls.ts:4:8:4:21 | * as net_outer | net |
 | destructuringES6.js:1:1:1:41 | import  ... ctron'; | electron |
 | destructuringRequire.js:1:27:1:45 | require('electron') | electron |
 | instanceThroughDefaultImport.js:1:1:1:82 | import  ... tance'; | myDefaultImportedModuleInstance |
-| instanceThroughDefaultImport.js:1:8:1:42 | myDefaultImportedModuleInstanceName | myDefaultImportedModuleInstance |
-| instanceThroughNamespaceImport.js:1:8:1:49 | myNamespaceImportedModuleInstanceName | myNamespaceImportedModuleInstance |
+| instanceThroughDefaultImport.js:1:8:1:42 | myDefau ... nceName | myDefaultImportedModuleInstance |
+| instanceThroughNamespaceImport.js:1:8:1:49 | * as my ... nceName | myNamespaceImportedModuleInstance |
 | instanceThroughRequire.js:1:36:1:70 | require ... tance') | myRequiredModuleInstance |
 | moduleUses.js:1:11:1:24 | require('mod') | mod |
 | process2.js:1:1:1:13 | require('fs') | fs |
@@ -97,6 +105,8 @@ test_ModuleImportNode_getAMemberInvocation
 test_moduleImportProp
 | electron | BrowserWindow | destructuringES6.js:1:10:1:22 | BrowserWindow |
 | electron | BrowserWindow | destructuringRequire.js:1:9:1:21 | BrowserWindow |
+| foo | C | declare-module-client2.ts:3:9:3:9 | C |
+| foo | C | declare-module-client.ts:3:9:3:9 | C |
 | framework1 | Component | client1.ts:4:28:4:39 | F1.Component |
 | framework2 | Component | client2.ts:4:28:4:39 | F2.Component |
 | framework2 | Component | client2_lazy.ts:4:28:4:39 | F2.Component |
@@ -106,7 +116,7 @@ test_moduleImportProp
 | mod | moduleField | moduleUses.js:11:1:11:15 | mod.moduleField |
 | mod | moduleFunction | moduleUses.js:5:9:5:26 | mod.moduleFunction |
 | mod | moduleMethod | moduleUses.js:3:1:3:16 | mod.moduleMethod |
-| myDefaultImportedModuleInstance | default | instanceThroughDefaultImport.js:1:8:1:42 | myDefaultImportedModuleInstanceName |
+| myDefaultImportedModuleInstance | default | instanceThroughDefaultImport.js:1:8:1:42 | myDefau ... nceName |
 | net | createServer | client1.ts:6:9:6:24 | net.createServer |
 test_ModuleImportNode_getAMemberCall
 | amd1.js:1:25:1:26 | fs | amd1.js:2:3:2:29 | fs.read ... a.txt") |
@@ -121,9 +131,11 @@ test_ModuleImportNode_getAPropertyRead
 | client1.ts:6:9:6:11 | net | client1.ts:6:9:6:24 | net.createServer |
 | client2.ts:4:28:4:29 | F2 | client2.ts:4:28:4:39 | F2.Component |
 | client2_lazy.ts:4:28:4:29 | F2 | client2_lazy.ts:4:28:4:39 | F2.Component |
+| declare-module-client2.ts:3:1:3:22 | import  ...  'foo'; | declare-module-client2.ts:3:9:3:9 | C |
+| declare-module-client.ts:3:1:3:22 | import  ...  'foo'; | declare-module-client.ts:3:9:3:9 | C |
 | destructuringES6.js:1:1:1:41 | import  ... ctron'; | destructuringES6.js:1:10:1:22 | BrowserWindow |
 | destructuringRequire.js:1:27:1:45 | require('electron') | destructuringRequire.js:1:9:1:21 | BrowserWindow |
-| instanceThroughDefaultImport.js:1:1:1:82 | import  ... tance'; | instanceThroughDefaultImport.js:1:8:1:42 | myDefaultImportedModuleInstanceName |
+| instanceThroughDefaultImport.js:1:1:1:82 | import  ... tance'; | instanceThroughDefaultImport.js:1:8:1:42 | myDefau ... nceName |
 | moduleUses.js:1:11:1:24 | require('mod') | moduleUses.js:3:1:3:16 | mod.moduleMethod |
 | moduleUses.js:1:11:1:24 | require('mod') | moduleUses.js:5:9:5:26 | mod.moduleFunction |
 | moduleUses.js:1:11:1:24 | require('mod') | moduleUses.js:8:9:8:31 | mod.con ... unction |

--- a/javascript/ql/test/library-tests/TypeTracking/ClassStyle.expected
+++ b/javascript/ql/test/library-tests/TypeTracking/ClassStyle.expected
@@ -10,6 +10,7 @@ test_ApiObject
 | tst_conflict.js:6:38:6:49 | api.chain1() |
 | tst_conflict.js:6:38:6:58 | api.cha ... hain2() |
 test_Connection
+| client.js:1:10:1:27 | exportedConnection |
 | tst.js:7:15:7:18 | conn |
 | tst.js:11:5:11:19 | this.connection |
 | tst.js:16:10:16:49 | api.cha ... ction() |
@@ -22,8 +23,10 @@ test_Connection
 | tst.js:62:40:62:79 | api.cha ... ction() |
 | tst.js:63:38:63:77 | api.cha ... ction() |
 | tst.js:67:14:67:47 | MyAppli ... nection |
+| tst.js:78:35:78:49 | getConnection() |
 | tst_conflict.js:6:38:6:77 | api.cha ... ction() |
 test_DataCallback
+| client.js:3:28:3:34 | x => {} |
 | tst.js:10:11:10:12 | cb |
 | tst.js:21:1:23:1 | functio ... ata);\\n} |
 | tst.js:30:26:30:27 | cb |
@@ -35,6 +38,7 @@ test_DataCallback
 | tst.js:58:16:58:22 | x => {} |
 | tst.js:68:16:70:3 | data => ... a);\\n  } |
 test_DataValue
+| client.js:3:28:3:28 | x |
 | tst.js:21:18:21:21 | data |
 | tst.js:25:19:25:22 | data |
 | tst.js:33:17:33:20 | data |

--- a/javascript/ql/test/library-tests/TypeTracking/PredicateStyle.expected
+++ b/javascript/ql/test/library-tests/TypeTracking/PredicateStyle.expected
@@ -13,6 +13,7 @@ connection
 | type tracker with call steps | tst.js:7:15:7:18 | conn |
 | type tracker with call steps | tst.js:11:5:11:19 | this.connection |
 | type tracker with call steps with property connection | tst.js:7:14:7:13 | this |
+| type tracker without call steps | client.js:1:10:1:27 | exportedConnection |
 | type tracker without call steps | tst.js:16:10:16:49 | api.cha ... ction() |
 | type tracker without call steps | tst.js:19:7:19:21 | getConnection() |
 | type tracker without call steps | tst.js:31:9:31:23 | getConnection() |
@@ -23,12 +24,14 @@ connection
 | type tracker without call steps | tst.js:62:40:62:79 | api.cha ... ction() |
 | type tracker without call steps | tst.js:63:38:63:77 | api.cha ... ction() |
 | type tracker without call steps | tst.js:67:14:67:47 | MyAppli ... nection |
+| type tracker without call steps | tst.js:78:35:78:49 | getConnection() |
 | type tracker without call steps | tst_conflict.js:6:38:6:77 | api.cha ... ction() |
 | type tracker without call steps with property MyApplication.namespace.connection | file://:0:0:0:0 | global access path |
 | type tracker without call steps with property conflict | tst.js:63:3:63:25 | MyAppli ... mespace |
 | type tracker without call steps with property conflict | tst_conflict.js:6:3:6:25 | MyAppli ... mespace |
 | type tracker without call steps with property connection | tst.js:62:3:62:25 | MyAppli ... mespace |
 dataCallback
+| client.js:3:28:3:34 | x => {} |
 | tst.js:10:11:10:12 | cb |
 | tst.js:21:1:23:1 | functio ... ata);\\n} |
 | tst.js:30:26:30:27 | cb |
@@ -40,6 +43,7 @@ dataCallback
 | tst.js:58:16:58:22 | x => {} |
 | tst.js:68:16:70:3 | data => ... a);\\n  } |
 dataValue
+| client.js:3:28:3:28 | x |
 | tst.js:21:18:21:21 | data |
 | tst.js:25:19:25:22 | data |
 | tst.js:33:17:33:20 | data |

--- a/javascript/ql/test/library-tests/TypeTracking/client.js
+++ b/javascript/ql/test/library-tests/TypeTracking/client.js
@@ -1,0 +1,3 @@
+import { exportedConnection } from './tst';
+
+exportedConnection.getData(x => {});

--- a/javascript/ql/test/library-tests/TypeTracking/tst.js
+++ b/javascript/ql/test/library-tests/TypeTracking/tst.js
@@ -74,3 +74,5 @@ function useConnection() {
     useData(data);
   });
 }
+
+export const exportedConnection = getConnection();

--- a/javascript/ql/test/library-tests/frameworks/ReactJS/tests.expected
+++ b/javascript/ql/test/library-tests/frameworks/ReactJS/tests.expected
@@ -42,6 +42,7 @@ test_react
 | globalReactRefs.js:1:1:1:5 | React |
 | globalReactRefs.js:4:5:4:9 | React |
 | globalReactRefs.js:7:1:7:5 | React |
+| importedReactRefs.js:1:8:1:12 | React |
 | importedReactRefs.js:3:1:3:5 | React |
 | importedReactRefs.js:6:5:6:9 | React |
 | importedReactRefs.js:9:1:9:5 | React |
@@ -68,6 +69,7 @@ test_react
 | thisAccesses.js:38:1:38:5 | React |
 | thisAccesses.js:40:9:40:13 | React |
 | thisAccesses.js:47:18:47:22 | React |
+| thisAccesses_importedMappers.js:1:8:1:12 | React |
 | thisAccesses_importedMappers.js:4:1:4:5 | React |
 | thisAccesses_importedMappers.js:6:9:6:13 | React |
 test_ReactComponent_getAPreviousStateSource

--- a/javascript/ql/test/query-tests/Declarations/DeadStoreOfLocal/DeadStoreOfLocal.expected
+++ b/javascript/ql/test/query-tests/Declarations/DeadStoreOfLocal/DeadStoreOfLocal.expected
@@ -1,3 +1,7 @@
+| computedInterfaceProperty.ts:1:10:1:12 | Foo | This definition of Foo is useless, since its value is never read. |
+| computedInterfaceProperty.ts:7:7:7:17 | Bar = "Bar" | The initial value of Bar is unused, since it is always overwritten. |
+| computedInterfaceProperty.ts:13:7:13:17 | Baz = "Baz" | The initial value of Baz is unused, since it is always overwritten. |
+| computedInterfaceProperty.ts:21:1:21:10 | class C {} | This definition of C is useless, since its value is never read. |
 | overload.ts:10:12:10:14 | baz | This definition of baz is useless, since its value is never read. |
 | tst2.js:26:9:26:14 | x = 23 | The initial value of x is unused, since it is always overwritten. |
 | tst2.js:28:9:28:14 | x = 42 | This definition of x is useless, since its value is never read. |

--- a/javascript/ql/test/query-tests/Declarations/DeadStoreOfLocal/DeadStoreOfLocal.expected
+++ b/javascript/ql/test/query-tests/Declarations/DeadStoreOfLocal/DeadStoreOfLocal.expected
@@ -1,7 +1,3 @@
-| computedInterfaceProperty.ts:1:10:1:12 | Foo | This definition of Foo is useless, since its value is never read. |
-| computedInterfaceProperty.ts:7:7:7:17 | Bar = "Bar" | The initial value of Bar is unused, since it is always overwritten. |
-| computedInterfaceProperty.ts:13:7:13:17 | Baz = "Baz" | The initial value of Baz is unused, since it is always overwritten. |
-| computedInterfaceProperty.ts:21:1:21:10 | class C {} | This definition of C is useless, since its value is never read. |
 | overload.ts:10:12:10:14 | baz | This definition of baz is useless, since its value is never read. |
 | tst2.js:26:9:26:14 | x = 23 | The initial value of x is unused, since it is always overwritten. |
 | tst2.js:28:9:28:14 | x = 42 | This definition of x is useless, since its value is never read. |

--- a/javascript/ql/test/query-tests/Declarations/DeadStoreOfLocal/computedInterfaceProperty.ts
+++ b/javascript/ql/test/query-tests/Declarations/DeadStoreOfLocal/computedInterfaceProperty.ts
@@ -1,0 +1,27 @@
+import { Foo } from "./exportSymbol" // OK
+
+export interface FooMap {
+  [Foo]: number; // OK
+}
+
+const Bar = "Bar"; // OK
+
+export interface BarMap {
+  [Bar]: number;
+}
+
+const Baz = "Baz"; // OK
+
+if (false) {
+  Baz;
+}
+
+function getBaz(): typeof Baz { return null; }
+
+class C {} // OK
+
+if (false) {
+  C;
+}
+
+function getC(): C { return null; }

--- a/javascript/ql/test/query-tests/Declarations/DeadStoreOfLocal/exportSymbol.ts
+++ b/javascript/ql/test/query-tests/Declarations/DeadStoreOfLocal/exportSymbol.ts
@@ -1,0 +1,1 @@
+export const Foo = "Foo";


### PR DESCRIPTION
Due to a discrepancy between the data flow graph and the type inference, type tracking through named imports did not work. For example, for
```js
import { Foo } from "./foo"
```
the data flow graph used the SSA definition of `Foo` as the `PropRead` and `SourceNode`, whereas the type inference uses the `ValueNode` corresponding to the `ImportSpecifier` as the `AnalyzedPropertyRead`. This means the `propertyFlowStep` induced by the type inference did not end in a `SourceNode`, which blocked big-step type tracking.

This changes the data flow graph to use the `ValueNode` instead of the SSA definition node as the `PropRead` and `SourceNode`.

The [evaluation](https://git.semmle.com/asger/dist-compare-reports/tree/type-tracking-through-imports_1567590363327) looks very good, there's even a perf win which at first seemed too good to be true, but AFAICT we just got lucky with the optimizer here. It did reveal some FPs which I've addressed in the last two commits.