### PR TITLE
JS: Make type inference step through SSA definitions

### DIFF
--- a/javascript/ql/src/semmle/javascript/dataflow/internal/VariableTypeInference.qll
+++ b/javascript/ql/src/semmle/javascript/dataflow/internal/VariableTypeInference.qll
@@ -637,7 +637,11 @@ private class ReflectiveVarFlow extends DataFlow::AnalyzedValueNode {
     )
   }
 
-  override AbstractValue getALocalValue() { result = TIndefiniteAbstractValue("eval") }
+  override AbstractValue getALocalValue() {
+    result = TIndefiniteAbstractValue("eval")
+    or
+    result = AnalyzedValueNode.super.getALocalValue()
+  }
 }
 
 /**
@@ -649,7 +653,11 @@ private class ReflectiveVarFlow extends DataFlow::AnalyzedValueNode {
 private class NamespaceExportVarFlow extends DataFlow::AnalyzedValueNode {
   NamespaceExportVarFlow() { astNode.(VarAccess).getVariable().isNamespaceExport() }
 
-  override AbstractValue getALocalValue() { result = TIndefiniteAbstractValue("namespace") }
+  override AbstractValue getALocalValue() {
+    result = TIndefiniteAbstractValue("namespace")
+    or
+    result = AnalyzedValueNode.super.getALocalValue()
+  }
 }
 
 /**

--- a/javascript/ql/test/library-tests/CallGraphs/FullTest/tests.expected
+++ b/javascript/ql/test/library-tests/CallGraphs/FullTest/tests.expected
@@ -36,7 +36,10 @@ test_isUncertain
 | tst.js:69:1:69:10 | globalfn() |
 test_getAFunctionValue
 | a.js:1:8:1:10 | foo | b.js:1:16:1:27 | function(){} |
+| a.js:1:8:1:10 | foo | b.js:1:16:1:27 | function(){} |
 | a.js:1:15:1:17 | bar | b.js:2:8:2:24 | function bar() {} |
+| a.js:1:15:1:17 | bar | b.js:2:8:2:24 | function bar() {} |
+| a.js:1:20:1:22 | qux | c.js:2:8:2:24 | function bar() {} |
 | a.js:1:20:1:22 | qux | c.js:2:8:2:24 | function bar() {} |
 | a.js:2:1:2:3 | foo | b.js:1:16:1:27 | function(){} |
 | a.js:3:1:3:3 | bar | b.js:2:8:2:24 | function bar() {} |

--- a/javascript/ql/test/library-tests/TaintTracking/BasicTaintTracking.expected
+++ b/javascript/ql/test/library-tests/TaintTracking/BasicTaintTracking.expected
@@ -1,8 +1,4 @@
 typeInferenceMismatch
-| addexpr.js:4:10:4:17 | source() | addexpr.js:4:5:4:17 | x |
-| addexpr.js:4:10:4:17 | source() | addexpr.js:6:3:6:14 | x |
-| addexpr.js:11:15:11:22 | source() | addexpr.js:17:5:17:18 | value |
-| addexpr.js:11:15:11:22 | source() | addexpr.js:19:3:19:14 | value |
 | destruct.js:20:7:20:14 | source() | destruct.js:13:14:13:19 | [a, b] |
 #select
 | access-path-sanitizer.js:2:18:2:25 | source() | access-path-sanitizer.js:4:8:4:12 | obj.x |


### PR DESCRIPTION
Previously, the type inference propagated flow directly from a `VarDef` to the *uses* of the assigned variables, bypassing the intermediate `SsaDefinitionNode`. It now propagates to the SSA definition itself, and using the local flow step from there to the uses.

This is complicated by the fact that `getALocalValue` and `getAValue` is overridden by a few other classes in the AnalyzedNode hierarchy. I believe the main issues were:
- `getAValue` would in some cases not include (indefinite) values from `getALocalValue`.
- `getALocalValue` would in some cases not include values from predecessors.

This brings us closer to being able to use the type inference to block taint flow, though we're still not require there yet. See the diff in BasicTypeTracking.expected.

Another benefit is that `Node.getAFunctionValue()` works for more kinds of data flow nodes (SSA definition nodes), which is needed for some call graph improvements I'm working on.

[Evaluation](https://git.semmle.com/asger/dist-compare-reports/tree/type-inf-consistency_1567589613585) is okay with an unfortunate regression on bwip, due to `getALocalValue` containing more tuples now. The [evaluation from the call graph](https://git.semmle.com/asger/dist-compare-reports/tree/call-graph-2_1567553729951) reorganization (which depends on this PR) seems to overshadow this regression, so I'd like to push on.