### PR TITLE
Python: Use same dummy `filepath` as in old API.

### DIFF
--- a/python/ql/src/semmle/python/objects/ObjectAPI.qll
+++ b/python/ql/src/semmle/python/objects/ObjectAPI.qll
@@ -83,7 +83,7 @@ class Value extends TObject {
         this.(ObjectInternal).getOrigin().getLocation().hasLocationInfo(filepath, bl, bc, el, ec)
         or
         not exists(this.(ObjectInternal).getOrigin()) and
-        filepath = "" and bl = 0 and bc = 0 and el = 0 and ec = 0
+        filepath = ":Compiled Code" and bl = 0 and bc = 0 and el = 0 and ec = 0
     }
 
     /** Gets the name of this value, if it has one.


### PR DESCRIPTION
This is mainly a test to see how this will affect the `.expected` files for the various tests. Currently, there is a discrepancy between the old `Object` API and the new `Value` API in how unknown locations are reported.