### PR TITLE
Java/C++/C#: Add nodes predicate to PathGraph.

### DIFF
--- a/cpp/ql/src/semmle/code/cpp/dataflow/internal/DataFlowImpl.qll
+++ b/cpp/ql/src/semmle/code/cpp/dataflow/internal/DataFlowImpl.qll
@@ -1260,7 +1260,7 @@ abstract private class AccessPath extends TAccessPath {
 
 private class AccessPathNil extends AccessPath, TNil {
   override string toString() {
-    exists(DataFlowType t | this = TNil(t) | result = concat(ppReprType(t)))
+    exists(DataFlowType t | this = TNil(t) | result = concat(" : " + ppReprType(t)))
   }
 
   override AccessPathFront getFront() {

--- a/cpp/ql/src/semmle/code/cpp/dataflow/internal/DataFlowImpl.qll
+++ b/cpp/ql/src/semmle/code/cpp/dataflow/internal/DataFlowImpl.qll
@@ -1647,6 +1647,11 @@ private predicate pathSuccPlus(PathNode n1, PathNode n2) = fastTC(pathSucc/2)(n1
 module PathGraph {
   /** Holds if `(a,b)` is an edge in the graph of data flow path explanations. */
   query predicate edges(PathNode a, PathNode b) { pathSucc(a, b) }
+
+  /** Holds if `n` is a node in the graph of data flow path explanations. */
+  query predicate nodes(PathNode n, string key, string val) {
+    reach(n) and key = "semmle.label" and val = n.toString()
+  }
 }
 
 /**

--- a/cpp/ql/src/semmle/code/cpp/dataflow/internal/DataFlowImpl2.qll
+++ b/cpp/ql/src/semmle/code/cpp/dataflow/internal/DataFlowImpl2.qll
@@ -1260,7 +1260,7 @@ abstract private class AccessPath extends TAccessPath {
 
 private class AccessPathNil extends AccessPath, TNil {
   override string toString() {
-    exists(DataFlowType t | this = TNil(t) | result = concat(ppReprType(t)))
+    exists(DataFlowType t | this = TNil(t) | result = concat(" : " + ppReprType(t)))
   }
 
   override AccessPathFront getFront() {

--- a/cpp/ql/src/semmle/code/cpp/dataflow/internal/DataFlowImpl2.qll
+++ b/cpp/ql/src/semmle/code/cpp/dataflow/internal/DataFlowImpl2.qll
@@ -1647,6 +1647,11 @@ private predicate pathSuccPlus(PathNode n1, PathNode n2) = fastTC(pathSucc/2)(n1
 module PathGraph {
   /** Holds if `(a,b)` is an edge in the graph of data flow path explanations. */
   query predicate edges(PathNode a, PathNode b) { pathSucc(a, b) }
+
+  /** Holds if `n` is a node in the graph of data flow path explanations. */
+  query predicate nodes(PathNode n, string key, string val) {
+    reach(n) and key = "semmle.label" and val = n.toString()
+  }
 }
 
 /**

--- a/cpp/ql/src/semmle/code/cpp/dataflow/internal/DataFlowImpl3.qll
+++ b/cpp/ql/src/semmle/code/cpp/dataflow/internal/DataFlowImpl3.qll
@@ -1260,7 +1260,7 @@ abstract private class AccessPath extends TAccessPath {
 
 private class AccessPathNil extends AccessPath, TNil {
   override string toString() {
-    exists(DataFlowType t | this = TNil(t) | result = concat(ppReprType(t)))
+    exists(DataFlowType t | this = TNil(t) | result = concat(" : " + ppReprType(t)))
   }
 
   override AccessPathFront getFront() {

--- a/cpp/ql/src/semmle/code/cpp/dataflow/internal/DataFlowImpl3.qll
+++ b/cpp/ql/src/semmle/code/cpp/dataflow/internal/DataFlowImpl3.qll
@@ -1647,6 +1647,11 @@ private predicate pathSuccPlus(PathNode n1, PathNode n2) = fastTC(pathSucc/2)(n1
 module PathGraph {
   /** Holds if `(a,b)` is an edge in the graph of data flow path explanations. */
   query predicate edges(PathNode a, PathNode b) { pathSucc(a, b) }
+
+  /** Holds if `n` is a node in the graph of data flow path explanations. */
+  query predicate nodes(PathNode n, string key, string val) {
+    reach(n) and key = "semmle.label" and val = n.toString()
+  }
 }
 
 /**

--- a/cpp/ql/src/semmle/code/cpp/dataflow/internal/DataFlowImpl4.qll
+++ b/cpp/ql/src/semmle/code/cpp/dataflow/internal/DataFlowImpl4.qll
@@ -1260,7 +1260,7 @@ abstract private class AccessPath extends TAccessPath {
 
 private class AccessPathNil extends AccessPath, TNil {
   override string toString() {
-    exists(DataFlowType t | this = TNil(t) | result = concat(ppReprType(t)))
+    exists(DataFlowType t | this = TNil(t) | result = concat(" : " + ppReprType(t)))
   }
 
   override AccessPathFront getFront() {

--- a/cpp/ql/src/semmle/code/cpp/dataflow/internal/DataFlowImpl4.qll
+++ b/cpp/ql/src/semmle/code/cpp/dataflow/internal/DataFlowImpl4.qll
@@ -1647,6 +1647,11 @@ private predicate pathSuccPlus(PathNode n1, PathNode n2) = fastTC(pathSucc/2)(n1
 module PathGraph {
   /** Holds if `(a,b)` is an edge in the graph of data flow path explanations. */
   query predicate edges(PathNode a, PathNode b) { pathSucc(a, b) }
+
+  /** Holds if `n` is a node in the graph of data flow path explanations. */
+  query predicate nodes(PathNode n, string key, string val) {
+    reach(n) and key = "semmle.label" and val = n.toString()
+  }
 }
 
 /**

--- a/cpp/ql/src/semmle/code/cpp/dataflow/internal/DataFlowImplLocal.qll
+++ b/cpp/ql/src/semmle/code/cpp/dataflow/internal/DataFlowImplLocal.qll
@@ -1260,7 +1260,7 @@ abstract private class AccessPath extends TAccessPath {
 
 private class AccessPathNil extends AccessPath, TNil {
   override string toString() {
-    exists(DataFlowType t | this = TNil(t) | result = concat(ppReprType(t)))
+    exists(DataFlowType t | this = TNil(t) | result = concat(" : " + ppReprType(t)))
   }
 
   override AccessPathFront getFront() {

--- a/cpp/ql/src/semmle/code/cpp/dataflow/internal/DataFlowImplLocal.qll
+++ b/cpp/ql/src/semmle/code/cpp/dataflow/internal/DataFlowImplLocal.qll
@@ -1647,6 +1647,11 @@ private predicate pathSuccPlus(PathNode n1, PathNode n2) = fastTC(pathSucc/2)(n1
 module PathGraph {
   /** Holds if `(a,b)` is an edge in the graph of data flow path explanations. */
   query predicate edges(PathNode a, PathNode b) { pathSucc(a, b) }
+
+  /** Holds if `n` is a node in the graph of data flow path explanations. */
+  query predicate nodes(PathNode n, string key, string val) {
+    reach(n) and key = "semmle.label" and val = n.toString()
+  }
 }
 
 /**

--- a/cpp/ql/src/semmle/code/cpp/ir/dataflow/internal/DataFlowImpl.qll
+++ b/cpp/ql/src/semmle/code/cpp/ir/dataflow/internal/DataFlowImpl.qll
@@ -1260,7 +1260,7 @@ abstract private class AccessPath extends TAccessPath {
 
 private class AccessPathNil extends AccessPath, TNil {
   override string toString() {
-    exists(DataFlowType t | this = TNil(t) | result = concat(ppReprType(t)))
+    exists(DataFlowType t | this = TNil(t) | result = concat(" : " + ppReprType(t)))
   }
 
   override AccessPathFront getFront() {

--- a/cpp/ql/src/semmle/code/cpp/ir/dataflow/internal/DataFlowImpl.qll
+++ b/cpp/ql/src/semmle/code/cpp/ir/dataflow/internal/DataFlowImpl.qll
@@ -1647,6 +1647,11 @@ private predicate pathSuccPlus(PathNode n1, PathNode n2) = fastTC(pathSucc/2)(n1
 module PathGraph {
   /** Holds if `(a,b)` is an edge in the graph of data flow path explanations. */
   query predicate edges(PathNode a, PathNode b) { pathSucc(a, b) }
+
+  /** Holds if `n` is a node in the graph of data flow path explanations. */
+  query predicate nodes(PathNode n, string key, string val) {
+    reach(n) and key = "semmle.label" and val = n.toString()
+  }
 }
 
 /**

--- a/cpp/ql/src/semmle/code/cpp/ir/dataflow/internal/DataFlowImpl2.qll
+++ b/cpp/ql/src/semmle/code/cpp/ir/dataflow/internal/DataFlowImpl2.qll
@@ -1260,7 +1260,7 @@ abstract private class AccessPath extends TAccessPath {
 
 private class AccessPathNil extends AccessPath, TNil {
   override string toString() {
-    exists(DataFlowType t | this = TNil(t) | result = concat(ppReprType(t)))
+    exists(DataFlowType t | this = TNil(t) | result = concat(" : " + ppReprType(t)))
   }
 
   override AccessPathFront getFront() {

--- a/cpp/ql/src/semmle/code/cpp/ir/dataflow/internal/DataFlowImpl2.qll
+++ b/cpp/ql/src/semmle/code/cpp/ir/dataflow/internal/DataFlowImpl2.qll
@@ -1647,6 +1647,11 @@ private predicate pathSuccPlus(PathNode n1, PathNode n2) = fastTC(pathSucc/2)(n1
 module PathGraph {
   /** Holds if `(a,b)` is an edge in the graph of data flow path explanations. */
   query predicate edges(PathNode a, PathNode b) { pathSucc(a, b) }
+
+  /** Holds if `n` is a node in the graph of data flow path explanations. */
+  query predicate nodes(PathNode n, string key, string val) {
+    reach(n) and key = "semmle.label" and val = n.toString()
+  }
 }
 
 /**

--- a/cpp/ql/src/semmle/code/cpp/ir/dataflow/internal/DataFlowImpl3.qll
+++ b/cpp/ql/src/semmle/code/cpp/ir/dataflow/internal/DataFlowImpl3.qll
@@ -1260,7 +1260,7 @@ abstract private class AccessPath extends TAccessPath {
 
 private class AccessPathNil extends AccessPath, TNil {
   override string toString() {
-    exists(DataFlowType t | this = TNil(t) | result = concat(ppReprType(t)))
+    exists(DataFlowType t | this = TNil(t) | result = concat(" : " + ppReprType(t)))
   }
 
   override AccessPathFront getFront() {

--- a/cpp/ql/src/semmle/code/cpp/ir/dataflow/internal/DataFlowImpl3.qll
+++ b/cpp/ql/src/semmle/code/cpp/ir/dataflow/internal/DataFlowImpl3.qll
@@ -1647,6 +1647,11 @@ private predicate pathSuccPlus(PathNode n1, PathNode n2) = fastTC(pathSucc/2)(n1
 module PathGraph {
   /** Holds if `(a,b)` is an edge in the graph of data flow path explanations. */
   query predicate edges(PathNode a, PathNode b) { pathSucc(a, b) }
+
+  /** Holds if `n` is a node in the graph of data flow path explanations. */
+  query predicate nodes(PathNode n, string key, string val) {
+    reach(n) and key = "semmle.label" and val = n.toString()
+  }
 }
 
 /**

--- a/cpp/ql/src/semmle/code/cpp/ir/dataflow/internal/DataFlowImpl4.qll
+++ b/cpp/ql/src/semmle/code/cpp/ir/dataflow/internal/DataFlowImpl4.qll
@@ -1260,7 +1260,7 @@ abstract private class AccessPath extends TAccessPath {
 
 private class AccessPathNil extends AccessPath, TNil {
   override string toString() {
-    exists(DataFlowType t | this = TNil(t) | result = concat(ppReprType(t)))
+    exists(DataFlowType t | this = TNil(t) | result = concat(" : " + ppReprType(t)))
   }
 
   override AccessPathFront getFront() {

--- a/cpp/ql/src/semmle/code/cpp/ir/dataflow/internal/DataFlowImpl4.qll
+++ b/cpp/ql/src/semmle/code/cpp/ir/dataflow/internal/DataFlowImpl4.qll
@@ -1647,6 +1647,11 @@ private predicate pathSuccPlus(PathNode n1, PathNode n2) = fastTC(pathSucc/2)(n1
 module PathGraph {
   /** Holds if `(a,b)` is an edge in the graph of data flow path explanations. */
   query predicate edges(PathNode a, PathNode b) { pathSucc(a, b) }
+
+  /** Holds if `n` is a node in the graph of data flow path explanations. */
+  query predicate nodes(PathNode n, string key, string val) {
+    reach(n) and key = "semmle.label" and val = n.toString()
+  }
 }
 
 /**

--- a/cpp/ql/test/library-tests/dataflow/fields/flow.expected
+++ b/cpp/ql/test/library-tests/dataflow/fields/flow.expected
@@ -213,6 +213,253 @@ edges
 | struct_init.c:27:7:27:16 | call to user_input | struct_init.c:27:5:27:23 | {...} [a] |
 | struct_init.c:31:8:31:12 | outer [nestedAB, a] | struct_init.c:31:14:31:21 | nestedAB [a] |
 | struct_init.c:31:14:31:21 | nestedAB [a] | struct_init.c:31:23:31:23 | a |
+nodes
+| A.cpp:41:15:41:21 | new | semmle.label | new |
+| A.cpp:43:10:43:12 | & ... | semmle.label | & ... |
+| A.cpp:47:12:47:18 | new | semmle.label | new |
+| A.cpp:48:12:48:18 | call to make [c] | semmle.label | call to make [c] |
+| A.cpp:48:20:48:20 | c | semmle.label | c |
+| A.cpp:49:10:49:10 | b [c] | semmle.label | b [c] |
+| A.cpp:49:13:49:13 | c | semmle.label | c |
+| A.cpp:55:5:55:5 | b [post update] [c] | semmle.label | b [post update] [c] |
+| A.cpp:55:12:55:19 | new | semmle.label | new |
+| A.cpp:56:10:56:10 | b [c] | semmle.label | b [c] |
+| A.cpp:56:13:56:15 | call to get | semmle.label | call to get |
+| A.cpp:57:11:57:24 | call to B [c] | semmle.label | call to B [c] |
+| A.cpp:57:11:57:24 | new [c] | semmle.label | new [c] |
+| A.cpp:57:17:57:23 | new | semmle.label | new |
+| A.cpp:57:28:57:30 | call to get | semmle.label | call to get |
+| A.cpp:64:10:64:15 | call to setOnB [c] | semmle.label | call to setOnB [c] |
+| A.cpp:64:21:64:28 | new | semmle.label | new |
+| A.cpp:66:10:66:11 | b2 [c] | semmle.label | b2 [c] |
+| A.cpp:66:14:66:14 | c | semmle.label | c |
+| A.cpp:73:10:73:19 | call to setOnBWrap [c] | semmle.label | call to setOnBWrap [c] |
+| A.cpp:73:25:73:32 | new | semmle.label | new |
+| A.cpp:75:10:75:11 | b2 [c] | semmle.label | b2 [c] |
+| A.cpp:75:14:75:14 | c | semmle.label | c |
+| A.cpp:98:12:98:18 | new | semmle.label | new |
+| A.cpp:100:5:100:6 | c1 [post update] [a] | semmle.label | c1 [post update] [a] |
+| A.cpp:100:5:100:13 | ... = ... | semmle.label | ... = ... |
+| A.cpp:101:8:101:9 | c1 [a] | semmle.label | c1 [a] |
+| A.cpp:103:14:103:14 | c [a] | semmle.label | c [a] |
+| A.cpp:107:12:107:13 | c1 [a] | semmle.label | c1 [a] |
+| A.cpp:107:16:107:16 | a | semmle.label | a |
+| A.cpp:120:12:120:13 | c1 [a] | semmle.label | c1 [a] |
+| A.cpp:120:16:120:16 | a | semmle.label | a |
+| A.cpp:126:5:126:5 | b [post update] [c] | semmle.label | b [post update] [c] |
+| A.cpp:126:12:126:18 | new | semmle.label | new |
+| A.cpp:131:8:131:8 | ref arg b [c] | semmle.label | ref arg b [c] |
+| A.cpp:132:10:132:10 | b [c] | semmle.label | b [c] |
+| A.cpp:132:13:132:13 | c | semmle.label | c |
+| A.cpp:142:7:142:7 | b [post update] [c] | semmle.label | b [post update] [c] |
+| A.cpp:142:7:142:20 | ... = ... | semmle.label | ... = ... |
+| A.cpp:142:14:142:20 | new | semmle.label | new |
+| A.cpp:143:7:143:10 | this [post update] [b, c] | semmle.label | this [post update] [b, c] |
+| A.cpp:143:7:143:10 | this [post update] [b] | semmle.label | this [post update] [b] |
+| A.cpp:143:7:143:31 | ... = ... | semmle.label | ... = ... |
+| A.cpp:143:7:143:31 | ... = ... [c] | semmle.label | ... = ... [c] |
+| A.cpp:143:25:143:31 | new | semmle.label | new |
+| A.cpp:150:12:150:18 | new | semmle.label | new |
+| A.cpp:151:12:151:24 | call to D [b, c] | semmle.label | call to D [b, c] |
+| A.cpp:151:12:151:24 | call to D [b] | semmle.label | call to D [b] |
+| A.cpp:151:18:151:18 | b | semmle.label | b |
+| A.cpp:151:18:151:18 | ref arg b [c] | semmle.label | ref arg b [c] |
+| A.cpp:152:10:152:10 | d [b] | semmle.label | d [b] |
+| A.cpp:152:13:152:13 | b | semmle.label | b |
+| A.cpp:153:10:153:10 | d [b, c] | semmle.label | d [b, c] |
+| A.cpp:153:13:153:13 | b [c] | semmle.label | b [c] |
+| A.cpp:153:16:153:16 | c | semmle.label | c |
+| A.cpp:154:10:154:10 | b [c] | semmle.label | b [c] |
+| A.cpp:154:13:154:13 | c | semmle.label | c |
+| A.cpp:159:12:159:18 | new | semmle.label | new |
+| A.cpp:160:18:160:60 | call to MyList [head] | semmle.label | call to MyList [head] |
+| A.cpp:160:29:160:29 | b | semmle.label | b |
+| A.cpp:161:18:161:40 | call to MyList [next, head] | semmle.label | call to MyList [next, head] |
+| A.cpp:161:38:161:39 | l1 [head] | semmle.label | l1 [head] |
+| A.cpp:162:18:162:40 | call to MyList [next, next, ... (3)] | semmle.label | call to MyList [next, next, ... (3)] |
+| A.cpp:162:38:162:39 | l2 [next, head] | semmle.label | l2 [next, head] |
+| A.cpp:165:10:165:11 | l3 [next, next, ... (3)] | semmle.label | l3 [next, next, ... (3)] |
+| A.cpp:165:14:165:17 | next [next, head] | semmle.label | next [next, head] |
+| A.cpp:165:20:165:23 | next [head] | semmle.label | next [head] |
+| A.cpp:165:26:165:29 | head | semmle.label | head |
+| A.cpp:167:44:167:44 | l [next, head] | semmle.label | l [next, head] |
+| A.cpp:167:44:167:44 | l [next, next, ... (3)] | semmle.label | l [next, next, ... (3)] |
+| A.cpp:167:47:167:50 | next [head] | semmle.label | next [head] |
+| A.cpp:167:47:167:50 | next [next, head] | semmle.label | next [next, head] |
+| A.cpp:169:12:169:12 | l [head] | semmle.label | l [head] |
+| A.cpp:169:15:169:18 | head | semmle.label | head |
+| B.cpp:6:15:6:24 | new | semmle.label | new |
+| B.cpp:7:16:7:35 | call to Box1 [elem1] | semmle.label | call to Box1 [elem1] |
+| B.cpp:7:25:7:25 | e | semmle.label | e |
+| B.cpp:8:16:8:27 | call to Box2 [box1, elem1] | semmle.label | call to Box2 [box1, elem1] |
+| B.cpp:8:25:8:26 | b1 [elem1] | semmle.label | b1 [elem1] |
+| B.cpp:9:10:9:11 | b2 [box1, elem1] | semmle.label | b2 [box1, elem1] |
+| B.cpp:9:14:9:17 | box1 [elem1] | semmle.label | box1 [elem1] |
+| B.cpp:9:20:9:24 | elem1 | semmle.label | elem1 |
+| B.cpp:15:15:15:27 | new | semmle.label | new |
+| B.cpp:16:16:16:38 | call to Box1 [elem2] | semmle.label | call to Box1 [elem2] |
+| B.cpp:16:37:16:37 | e | semmle.label | e |
+| B.cpp:17:16:17:27 | call to Box2 [box1, elem2] | semmle.label | call to Box2 [box1, elem2] |
+| B.cpp:17:25:17:26 | b1 [elem2] | semmle.label | b1 [elem2] |
+| B.cpp:19:10:19:11 | b2 [box1, elem2] | semmle.label | b2 [box1, elem2] |
+| B.cpp:19:14:19:17 | box1 [elem2] | semmle.label | box1 [elem2] |
+| B.cpp:19:20:19:24 | elem2 | semmle.label | elem2 |
+| C.cpp:18:12:18:18 | call to C [s1] | semmle.label | call to C [s1] |
+| C.cpp:18:12:18:18 | call to C [s3] | semmle.label | call to C [s3] |
+| C.cpp:19:5:19:5 | c [s1] | semmle.label | c [s1] |
+| C.cpp:19:5:19:5 | c [s3] | semmle.label | c [s3] |
+| C.cpp:22:9:22:22 | constructor init of field s1 [post-this] [s1] | semmle.label | constructor init of field s1 [post-this] [s1] |
+| C.cpp:22:12:22:21 | new | semmle.label | new |
+| C.cpp:24:5:24:8 | this [post update] [s3] | semmle.label | this [post update] [s3] |
+| C.cpp:24:5:24:25 | ... = ... | semmle.label | ... = ... |
+| C.cpp:24:16:24:25 | new | semmle.label | new |
+| C.cpp:27:8:27:11 | `this` parameter in func [s1] | semmle.label | `this` parameter in func [s1] |
+| C.cpp:27:8:27:11 | `this` parameter in func [s3] | semmle.label | `this` parameter in func [s3] |
+| C.cpp:29:10:29:11 | s1 | semmle.label | s1 |
+| C.cpp:29:10:29:11 | this [s1] | semmle.label | this [s1] |
+| C.cpp:31:10:31:11 | s3 | semmle.label | s3 |
+| C.cpp:31:10:31:11 | this [s3] | semmle.label | this [s3] |
+| D.cpp:21:30:21:31 | b2 [box, elem] | semmle.label | b2 [box, elem] |
+| D.cpp:22:10:22:11 | b2 [box, elem] | semmle.label | b2 [box, elem] |
+| D.cpp:22:14:22:20 | call to getBox1 [elem] | semmle.label | call to getBox1 [elem] |
+| D.cpp:22:25:22:31 | call to getElem | semmle.label | call to getElem |
+| D.cpp:28:15:28:24 | new | semmle.label | new |
+| D.cpp:30:5:30:5 | b [post update] [box, elem] | semmle.label | b [post update] [box, elem] |
+| D.cpp:30:5:30:20 | ... = ... | semmle.label | ... = ... |
+| D.cpp:30:8:30:10 | box [post update] [elem] | semmle.label | box [post update] [elem] |
+| D.cpp:31:14:31:14 | b [box, elem] | semmle.label | b [box, elem] |
+| D.cpp:35:15:35:24 | new | semmle.label | new |
+| D.cpp:37:5:37:5 | b [post update] [box, elem] | semmle.label | b [post update] [box, elem] |
+| D.cpp:37:8:37:10 | box [post update] [elem] | semmle.label | box [post update] [elem] |
+| D.cpp:37:21:37:21 | e | semmle.label | e |
+| D.cpp:38:14:38:14 | b [box, elem] | semmle.label | b [box, elem] |
+| D.cpp:42:15:42:24 | new | semmle.label | new |
+| D.cpp:44:5:44:5 | b [post update] [box, elem] | semmle.label | b [post update] [box, elem] |
+| D.cpp:44:5:44:26 | ... = ... | semmle.label | ... = ... |
+| D.cpp:44:8:44:14 | call to getBox1 [post update] [elem] | semmle.label | call to getBox1 [post update] [elem] |
+| D.cpp:45:14:45:14 | b [box, elem] | semmle.label | b [box, elem] |
+| D.cpp:49:15:49:24 | new | semmle.label | new |
+| D.cpp:51:5:51:5 | b [post update] [box, elem] | semmle.label | b [post update] [box, elem] |
+| D.cpp:51:8:51:14 | call to getBox1 [post update] [elem] | semmle.label | call to getBox1 [post update] [elem] |
+| D.cpp:51:27:51:27 | e | semmle.label | e |
+| D.cpp:52:14:52:14 | b [box, elem] | semmle.label | b [box, elem] |
+| D.cpp:56:15:56:24 | new | semmle.label | new |
+| D.cpp:58:5:58:12 | boxfield [post update] [box, elem] | semmle.label | boxfield [post update] [box, elem] |
+| D.cpp:58:5:58:12 | this [post update] [boxfield, box, ... (3)] | semmle.label | this [post update] [boxfield, box, ... (3)] |
+| D.cpp:58:5:58:27 | ... = ... | semmle.label | ... = ... |
+| D.cpp:58:15:58:17 | box [post update] [elem] | semmle.label | box [post update] [elem] |
+| D.cpp:59:5:59:7 | this [boxfield, box, ... (3)] | semmle.label | this [boxfield, box, ... (3)] |
+| D.cpp:63:8:63:10 | `this` parameter in f5b [boxfield, box, ... (3)] | semmle.label | `this` parameter in f5b [boxfield, box, ... (3)] |
+| D.cpp:64:10:64:17 | boxfield [box, elem] | semmle.label | boxfield [box, elem] |
+| D.cpp:64:10:64:17 | this [boxfield, box, ... (3)] | semmle.label | this [boxfield, box, ... (3)] |
+| D.cpp:64:20:64:22 | box [elem] | semmle.label | box [elem] |
+| D.cpp:64:25:64:28 | elem | semmle.label | elem |
+| aliasing.cpp:9:3:9:3 | s [post update] [m1] | semmle.label | s [post update] [m1] |
+| aliasing.cpp:9:3:9:22 | ... = ... | semmle.label | ... = ... |
+| aliasing.cpp:9:11:9:20 | call to user_input | semmle.label | call to user_input |
+| aliasing.cpp:13:3:13:3 | s [post update] [m1] | semmle.label | s [post update] [m1] |
+| aliasing.cpp:13:3:13:21 | ... = ... | semmle.label | ... = ... |
+| aliasing.cpp:13:10:13:19 | call to user_input | semmle.label | call to user_input |
+| aliasing.cpp:25:17:25:19 | ref arg & ... [m1] | semmle.label | ref arg & ... [m1] |
+| aliasing.cpp:26:19:26:20 | ref arg s2 [m1] | semmle.label | ref arg s2 [m1] |
+| aliasing.cpp:29:8:29:9 | s1 [m1] | semmle.label | s1 [m1] |
+| aliasing.cpp:29:11:29:12 | m1 | semmle.label | m1 |
+| aliasing.cpp:30:8:30:9 | s2 [m1] | semmle.label | s2 [m1] |
+| aliasing.cpp:30:11:30:12 | m1 | semmle.label | m1 |
+| aliasing.cpp:60:3:60:4 | s2 [post update] [m1] | semmle.label | s2 [post update] [m1] |
+| aliasing.cpp:60:3:60:22 | ... = ... | semmle.label | ... = ... |
+| aliasing.cpp:60:11:60:20 | call to user_input | semmle.label | call to user_input |
+| aliasing.cpp:62:8:62:12 | copy2 [m1] | semmle.label | copy2 [m1] |
+| aliasing.cpp:62:14:62:15 | m1 | semmle.label | m1 |
+| aliasing.cpp:92:3:92:3 | w [post update] [s, m1] | semmle.label | w [post update] [s, m1] |
+| aliasing.cpp:92:3:92:23 | ... = ... | semmle.label | ... = ... |
+| aliasing.cpp:92:5:92:5 | s [post update] [m1] | semmle.label | s [post update] [m1] |
+| aliasing.cpp:92:12:92:21 | call to user_input | semmle.label | call to user_input |
+| aliasing.cpp:93:8:93:8 | w [s, m1] | semmle.label | w [s, m1] |
+| aliasing.cpp:93:10:93:10 | s [m1] | semmle.label | s [m1] |
+| aliasing.cpp:93:12:93:13 | m1 | semmle.label | m1 |
+| by_reference.cpp:50:3:50:3 | s [post update] [a] | semmle.label | s [post update] [a] |
+| by_reference.cpp:50:17:50:26 | call to user_input | semmle.label | call to user_input |
+| by_reference.cpp:51:8:51:8 | s [a] | semmle.label | s [a] |
+| by_reference.cpp:51:10:51:20 | call to getDirectly | semmle.label | call to getDirectly |
+| by_reference.cpp:56:3:56:3 | s [post update] [a] | semmle.label | s [post update] [a] |
+| by_reference.cpp:56:19:56:28 | call to user_input | semmle.label | call to user_input |
+| by_reference.cpp:57:8:57:8 | s [a] | semmle.label | s [a] |
+| by_reference.cpp:57:10:57:22 | call to getIndirectly | semmle.label | call to getIndirectly |
+| by_reference.cpp:62:3:62:3 | s [post update] [a] | semmle.label | s [post update] [a] |
+| by_reference.cpp:62:25:62:34 | call to user_input | semmle.label | call to user_input |
+| by_reference.cpp:63:8:63:8 | s [a] | semmle.label | s [a] |
+| by_reference.cpp:63:10:63:28 | call to getThroughNonMember | semmle.label | call to getThroughNonMember |
+| complex.cpp:34:15:34:15 | b [f, a_] | semmle.label | b [f, a_] |
+| complex.cpp:34:15:34:15 | b [f, b_] | semmle.label | b [f, b_] |
+| complex.cpp:44:8:44:8 | b [f, a_] | semmle.label | b [f, a_] |
+| complex.cpp:44:10:44:10 | f [a_] | semmle.label | f [a_] |
+| complex.cpp:44:12:44:12 | call to a | semmle.label | call to a |
+| complex.cpp:45:8:45:8 | b [f, b_] | semmle.label | b [f, b_] |
+| complex.cpp:45:10:45:10 | f [b_] | semmle.label | f [b_] |
+| complex.cpp:45:12:45:12 | call to b | semmle.label | call to b |
+| complex.cpp:55:3:55:4 | b1 [post update] [f, a_] | semmle.label | b1 [post update] [f, a_] |
+| complex.cpp:55:6:55:6 | f [post update] [a_] | semmle.label | f [post update] [a_] |
+| complex.cpp:55:13:55:22 | call to user_input | semmle.label | call to user_input |
+| complex.cpp:56:3:56:4 | b2 [post update] [f, b_] | semmle.label | b2 [post update] [f, b_] |
+| complex.cpp:56:6:56:6 | f [post update] [b_] | semmle.label | f [post update] [b_] |
+| complex.cpp:56:13:56:22 | call to user_input | semmle.label | call to user_input |
+| complex.cpp:57:3:57:4 | b3 [post update] [f, a_] | semmle.label | b3 [post update] [f, a_] |
+| complex.cpp:57:6:57:6 | f [post update] [a_] | semmle.label | f [post update] [a_] |
+| complex.cpp:57:13:57:22 | call to user_input | semmle.label | call to user_input |
+| complex.cpp:58:3:58:4 | b3 [post update] [f, b_] | semmle.label | b3 [post update] [f, b_] |
+| complex.cpp:58:6:58:6 | f [post update] [b_] | semmle.label | f [post update] [b_] |
+| complex.cpp:58:13:58:22 | call to user_input | semmle.label | call to user_input |
+| complex.cpp:61:7:61:8 | b1 [f, a_] | semmle.label | b1 [f, a_] |
+| complex.cpp:64:7:64:8 | b2 [f, b_] | semmle.label | b2 [f, b_] |
+| complex.cpp:67:7:67:8 | b3 [f, a_] | semmle.label | b3 [f, a_] |
+| complex.cpp:67:7:67:8 | b3 [f, b_] | semmle.label | b3 [f, b_] |
+| constructors.cpp:26:15:26:15 | f [a_] | semmle.label | f [a_] |
+| constructors.cpp:26:15:26:15 | f [b_] | semmle.label | f [b_] |
+| constructors.cpp:28:10:28:10 | f [a_] | semmle.label | f [a_] |
+| constructors.cpp:28:12:28:12 | call to a | semmle.label | call to a |
+| constructors.cpp:29:10:29:10 | f [b_] | semmle.label | f [b_] |
+| constructors.cpp:29:12:29:12 | call to b | semmle.label | call to b |
+| constructors.cpp:34:11:34:20 | call to user_input | semmle.label | call to user_input |
+| constructors.cpp:34:11:34:26 | call to Foo [a_] | semmle.label | call to Foo [a_] |
+| constructors.cpp:35:11:35:26 | call to Foo [b_] | semmle.label | call to Foo [b_] |
+| constructors.cpp:35:14:35:23 | call to user_input | semmle.label | call to user_input |
+| constructors.cpp:36:11:36:20 | call to user_input | semmle.label | call to user_input |
+| constructors.cpp:36:11:36:37 | call to Foo [a_] | semmle.label | call to Foo [a_] |
+| constructors.cpp:36:11:36:37 | call to Foo [b_] | semmle.label | call to Foo [b_] |
+| constructors.cpp:36:25:36:34 | call to user_input | semmle.label | call to user_input |
+| constructors.cpp:40:9:40:9 | f [a_] | semmle.label | f [a_] |
+| constructors.cpp:43:9:43:9 | g [b_] | semmle.label | g [b_] |
+| constructors.cpp:46:9:46:9 | h [a_] | semmle.label | h [a_] |
+| constructors.cpp:46:9:46:9 | h [b_] | semmle.label | h [b_] |
+| simple.cpp:26:15:26:15 | f [a_] | semmle.label | f [a_] |
+| simple.cpp:26:15:26:15 | f [b_] | semmle.label | f [b_] |
+| simple.cpp:28:10:28:10 | f [a_] | semmle.label | f [a_] |
+| simple.cpp:28:12:28:12 | call to a | semmle.label | call to a |
+| simple.cpp:29:10:29:10 | f [b_] | semmle.label | f [b_] |
+| simple.cpp:29:12:29:12 | call to b | semmle.label | call to b |
+| simple.cpp:39:5:39:5 | f [post update] [a_] | semmle.label | f [post update] [a_] |
+| simple.cpp:39:12:39:21 | call to user_input | semmle.label | call to user_input |
+| simple.cpp:40:5:40:5 | g [post update] [b_] | semmle.label | g [post update] [b_] |
+| simple.cpp:40:12:40:21 | call to user_input | semmle.label | call to user_input |
+| simple.cpp:41:5:41:5 | h [post update] [a_] | semmle.label | h [post update] [a_] |
+| simple.cpp:41:12:41:21 | call to user_input | semmle.label | call to user_input |
+| simple.cpp:42:5:42:5 | h [post update] [b_] | semmle.label | h [post update] [b_] |
+| simple.cpp:42:12:42:21 | call to user_input | semmle.label | call to user_input |
+| simple.cpp:45:9:45:9 | f [a_] | semmle.label | f [a_] |
+| simple.cpp:48:9:48:9 | g [b_] | semmle.label | g [b_] |
+| simple.cpp:51:9:51:9 | h [a_] | semmle.label | h [a_] |
+| simple.cpp:51:9:51:9 | h [b_] | semmle.label | h [b_] |
+| struct_init.c:20:17:20:36 | {...} [a] | semmle.label | {...} [a] |
+| struct_init.c:20:20:20:29 | call to user_input | semmle.label | call to user_input |
+| struct_init.c:22:8:22:9 | ab [a] | semmle.label | ab [a] |
+| struct_init.c:22:11:22:11 | a | semmle.label | a |
+| struct_init.c:26:23:29:3 | {...} [nestedAB, a] | semmle.label | {...} [nestedAB, a] |
+| struct_init.c:27:5:27:23 | {...} [a] | semmle.label | {...} [a] |
+| struct_init.c:27:7:27:16 | call to user_input | semmle.label | call to user_input |
+| struct_init.c:31:8:31:12 | outer [nestedAB, a] | semmle.label | outer [nestedAB, a] |
+| struct_init.c:31:14:31:21 | nestedAB [a] | semmle.label | nestedAB [a] |
+| struct_init.c:31:23:31:23 | a | semmle.label | a |
 #select
 | A.cpp:43:10:43:12 | & ... | A.cpp:41:15:41:21 | new | A.cpp:43:10:43:12 | & ... | & ... flows from $@ | A.cpp:41:15:41:21 | new | new |
 | A.cpp:49:13:49:13 | c | A.cpp:47:12:47:18 | new | A.cpp:49:13:49:13 | c | c flows from $@ | A.cpp:47:12:47:18 | new | new |

--- a/cpp/ql/test/query-tests/Likely Bugs/Conversion/CastArrayPointerArithmetic/CastArrayPointerArithmetic.expected
+++ b/cpp/ql/test/query-tests/Likely Bugs/Conversion/CastArrayPointerArithmetic/CastArrayPointerArithmetic.expected
@@ -14,6 +14,26 @@ edges
 | test.cpp:88:21:88:22 | d2 | test.cpp:34:31:34:31 | b |
 | test.cpp:95:21:95:21 | d | test.cpp:50:31:50:31 | b |
 | test.cpp:96:21:96:23 | dss | test.cpp:50:31:50:31 | b |
+nodes
+| test.cpp:26:29:26:29 | b | semmle.label | b |
+| test.cpp:27:2:27:2 | b | semmle.label | b |
+| test.cpp:30:34:30:34 | b | semmle.label | b |
+| test.cpp:31:2:31:2 | b | semmle.label | b |
+| test.cpp:34:31:34:31 | b | semmle.label | b |
+| test.cpp:35:2:35:2 | b | semmle.label | b |
+| test.cpp:50:31:50:31 | b | semmle.label | b |
+| test.cpp:51:11:51:11 | b | semmle.label | b |
+| test.cpp:57:19:57:19 | d | semmle.label | d |
+| test.cpp:58:25:58:25 | d | semmle.label | d |
+| test.cpp:59:21:59:21 | d | semmle.label | d |
+| test.cpp:74:19:74:21 | dss | semmle.label | dss |
+| test.cpp:75:25:75:27 | dss | semmle.label | dss |
+| test.cpp:76:21:76:23 | dss | semmle.label | dss |
+| test.cpp:86:19:86:20 | d2 | semmle.label | d2 |
+| test.cpp:87:25:87:26 | d2 | semmle.label | d2 |
+| test.cpp:88:21:88:22 | d2 | semmle.label | d2 |
+| test.cpp:95:21:95:21 | d | semmle.label | d |
+| test.cpp:96:21:96:23 | dss | semmle.label | dss |
 #select
 | test.cpp:27:2:27:2 | b | test.cpp:57:19:57:19 | d | test.cpp:27:2:27:2 | b | Pointer arithmetic here may be done with the wrong type because of the cast $@. | test.cpp:57:19:57:19 | d | here |
 | test.cpp:27:2:27:2 | b | test.cpp:74:19:74:21 | dss | test.cpp:27:2:27:2 | b | Pointer arithmetic here may be done with the wrong type because of the cast $@. | test.cpp:74:19:74:21 | dss | here |

--- a/csharp/ql/src/semmle/code/csharp/dataflow/internal/DataFlowImpl.qll
+++ b/csharp/ql/src/semmle/code/csharp/dataflow/internal/DataFlowImpl.qll
@@ -1260,7 +1260,7 @@ abstract private class AccessPath extends TAccessPath {
 
 private class AccessPathNil extends AccessPath, TNil {
   override string toString() {
-    exists(DataFlowType t | this = TNil(t) | result = concat(ppReprType(t)))
+    exists(DataFlowType t | this = TNil(t) | result = concat(" : " + ppReprType(t)))
   }
 
   override AccessPathFront getFront() {

--- a/csharp/ql/src/semmle/code/csharp/dataflow/internal/DataFlowImpl.qll
+++ b/csharp/ql/src/semmle/code/csharp/dataflow/internal/DataFlowImpl.qll
@@ -1647,6 +1647,11 @@ private predicate pathSuccPlus(PathNode n1, PathNode n2) = fastTC(pathSucc/2)(n1
 module PathGraph {
   /** Holds if `(a,b)` is an edge in the graph of data flow path explanations. */
   query predicate edges(PathNode a, PathNode b) { pathSucc(a, b) }
+
+  /** Holds if `n` is a node in the graph of data flow path explanations. */
+  query predicate nodes(PathNode n, string key, string val) {
+    reach(n) and key = "semmle.label" and val = n.toString()
+  }
 }
 
 /**

--- a/csharp/ql/src/semmle/code/csharp/dataflow/internal/DataFlowImpl2.qll
+++ b/csharp/ql/src/semmle/code/csharp/dataflow/internal/DataFlowImpl2.qll
@@ -1260,7 +1260,7 @@ abstract private class AccessPath extends TAccessPath {
 
 private class AccessPathNil extends AccessPath, TNil {
   override string toString() {
-    exists(DataFlowType t | this = TNil(t) | result = concat(ppReprType(t)))
+    exists(DataFlowType t | this = TNil(t) | result = concat(" : " + ppReprType(t)))
   }
 
   override AccessPathFront getFront() {

--- a/csharp/ql/src/semmle/code/csharp/dataflow/internal/DataFlowImpl2.qll
+++ b/csharp/ql/src/semmle/code/csharp/dataflow/internal/DataFlowImpl2.qll
@@ -1647,6 +1647,11 @@ private predicate pathSuccPlus(PathNode n1, PathNode n2) = fastTC(pathSucc/2)(n1
 module PathGraph {
   /** Holds if `(a,b)` is an edge in the graph of data flow path explanations. */
   query predicate edges(PathNode a, PathNode b) { pathSucc(a, b) }
+
+  /** Holds if `n` is a node in the graph of data flow path explanations. */
+  query predicate nodes(PathNode n, string key, string val) {
+    reach(n) and key = "semmle.label" and val = n.toString()
+  }
 }
 
 /**

--- a/csharp/ql/src/semmle/code/csharp/dataflow/internal/DataFlowImpl3.qll
+++ b/csharp/ql/src/semmle/code/csharp/dataflow/internal/DataFlowImpl3.qll
@@ -1260,7 +1260,7 @@ abstract private class AccessPath extends TAccessPath {
 
 private class AccessPathNil extends AccessPath, TNil {
   override string toString() {
-    exists(DataFlowType t | this = TNil(t) | result = concat(ppReprType(t)))
+    exists(DataFlowType t | this = TNil(t) | result = concat(" : " + ppReprType(t)))
   }
 
   override AccessPathFront getFront() {

--- a/csharp/ql/src/semmle/code/csharp/dataflow/internal/DataFlowImpl3.qll
+++ b/csharp/ql/src/semmle/code/csharp/dataflow/internal/DataFlowImpl3.qll
@@ -1647,6 +1647,11 @@ private predicate pathSuccPlus(PathNode n1, PathNode n2) = fastTC(pathSucc/2)(n1
 module PathGraph {
   /** Holds if `(a,b)` is an edge in the graph of data flow path explanations. */
   query predicate edges(PathNode a, PathNode b) { pathSucc(a, b) }
+
+  /** Holds if `n` is a node in the graph of data flow path explanations. */
+  query predicate nodes(PathNode n, string key, string val) {
+    reach(n) and key = "semmle.label" and val = n.toString()
+  }
 }
 
 /**

--- a/csharp/ql/src/semmle/code/csharp/dataflow/internal/DataFlowImpl4.qll
+++ b/csharp/ql/src/semmle/code/csharp/dataflow/internal/DataFlowImpl4.qll
@@ -1260,7 +1260,7 @@ abstract private class AccessPath extends TAccessPath {
 
 private class AccessPathNil extends AccessPath, TNil {
   override string toString() {
-    exists(DataFlowType t | this = TNil(t) | result = concat(ppReprType(t)))
+    exists(DataFlowType t | this = TNil(t) | result = concat(" : " + ppReprType(t)))
   }
 
   override AccessPathFront getFront() {

--- a/csharp/ql/src/semmle/code/csharp/dataflow/internal/DataFlowImpl4.qll
+++ b/csharp/ql/src/semmle/code/csharp/dataflow/internal/DataFlowImpl4.qll
@@ -1647,6 +1647,11 @@ private predicate pathSuccPlus(PathNode n1, PathNode n2) = fastTC(pathSucc/2)(n1
 module PathGraph {
   /** Holds if `(a,b)` is an edge in the graph of data flow path explanations. */
   query predicate edges(PathNode a, PathNode b) { pathSucc(a, b) }
+
+  /** Holds if `n` is a node in the graph of data flow path explanations. */
+  query predicate nodes(PathNode n, string key, string val) {
+    reach(n) and key = "semmle.label" and val = n.toString()
+  }
 }
 
 /**

--- a/csharp/ql/src/semmle/code/csharp/dataflow/internal/DataFlowImpl5.qll
+++ b/csharp/ql/src/semmle/code/csharp/dataflow/internal/DataFlowImpl5.qll
@@ -1260,7 +1260,7 @@ abstract private class AccessPath extends TAccessPath {
 
 private class AccessPathNil extends AccessPath, TNil {
   override string toString() {
-    exists(DataFlowType t | this = TNil(t) | result = concat(ppReprType(t)))
+    exists(DataFlowType t | this = TNil(t) | result = concat(" : " + ppReprType(t)))
   }
 
   override AccessPathFront getFront() {

--- a/csharp/ql/src/semmle/code/csharp/dataflow/internal/DataFlowImpl5.qll
+++ b/csharp/ql/src/semmle/code/csharp/dataflow/internal/DataFlowImpl5.qll
@@ -1647,6 +1647,11 @@ private predicate pathSuccPlus(PathNode n1, PathNode n2) = fastTC(pathSucc/2)(n1
 module PathGraph {
   /** Holds if `(a,b)` is an edge in the graph of data flow path explanations. */
   query predicate edges(PathNode a, PathNode b) { pathSucc(a, b) }
+
+  /** Holds if `n` is a node in the graph of data flow path explanations. */
+  query predicate nodes(PathNode n, string key, string val) {
+    reach(n) and key = "semmle.label" and val = n.toString()
+  }
 }
 
 /**

--- a/csharp/ql/test/library-tests/dataflow/fields/FieldFlow.expected
+++ b/csharp/ql/test/library-tests/dataflow/fields/FieldFlow.expected
@@ -173,6 +173,204 @@ edges
 | G.cs:52:14:52:21 | access to field boxfield [Box1, Elem] | G.cs:52:14:52:26 | access to field Box1 [Elem] |
 | G.cs:52:14:52:21 | this access [boxfield, Box1, ... (3)] | G.cs:52:14:52:21 | access to field boxfield [Box1, Elem] |
 | G.cs:52:14:52:26 | access to field Box1 [Elem] | G.cs:52:14:52:31 | access to field Elem |
+nodes
+| A.cs:5:17:5:23 | object creation of type C | semmle.label | object creation of type C |
+| A.cs:6:17:6:25 | call to method Make [c] | semmle.label | call to method Make [c] |
+| A.cs:6:24:6:24 | access to local variable c | semmle.label | access to local variable c |
+| A.cs:7:14:7:14 | access to local variable b [c] | semmle.label | access to local variable b [c] |
+| A.cs:7:14:7:16 | access to field c | semmle.label | access to field c |
+| A.cs:13:9:13:9 | [post] access to local variable b [c] | semmle.label | [post] access to local variable b [c] |
+| A.cs:13:15:13:22 | object creation of type C1 | semmle.label | object creation of type C1 |
+| A.cs:14:14:14:14 | access to local variable b [c] | semmle.label | access to local variable b [c] |
+| A.cs:14:14:14:20 | call to method Get | semmle.label | call to method Get |
+| A.cs:15:14:15:35 | call to method Get | semmle.label | call to method Get |
+| A.cs:15:15:15:28 | object creation of type B [c] | semmle.label | object creation of type B [c] |
+| A.cs:15:21:15:27 | object creation of type C | semmle.label | object creation of type C |
+| A.cs:22:14:22:33 | call to method SetOnB [c] | semmle.label | call to method SetOnB [c] |
+| A.cs:22:25:22:32 | object creation of type C2 | semmle.label | object creation of type C2 |
+| A.cs:24:14:24:15 | access to local variable b2 [c] | semmle.label | access to local variable b2 [c] |
+| A.cs:24:14:24:17 | access to field c | semmle.label | access to field c |
+| A.cs:31:14:31:37 | call to method SetOnBWrap [c] | semmle.label | call to method SetOnBWrap [c] |
+| A.cs:31:29:31:36 | object creation of type C2 | semmle.label | object creation of type C2 |
+| A.cs:33:14:33:15 | access to local variable b2 [c] | semmle.label | access to local variable b2 [c] |
+| A.cs:33:14:33:17 | access to field c | semmle.label | access to field c |
+| A.cs:55:17:55:23 | object creation of type A | semmle.label | object creation of type A |
+| A.cs:57:9:57:10 | [post] access to local variable c1 [a] | semmle.label | [post] access to local variable c1 [a] |
+| A.cs:57:16:57:16 | access to local variable a | semmle.label | access to local variable a |
+| A.cs:58:12:58:13 | access to local variable c1 [a] | semmle.label | access to local variable c1 [a] |
+| A.cs:60:22:60:22 | c [a] | semmle.label | c [a] |
+| A.cs:64:18:64:26 | access to field a | semmle.label | access to field a |
+| A.cs:64:19:64:23 | (...) ... [a] | semmle.label | (...) ... [a] |
+| A.cs:69:18:69:22 | (...) ... [a] | semmle.label | (...) ... [a] |
+| A.cs:77:18:77:27 | access to field a | semmle.label | access to field a |
+| A.cs:77:19:77:24 | (...) ... [a] | semmle.label | (...) ... [a] |
+| A.cs:83:9:83:9 | [post] access to parameter b [c] | semmle.label | [post] access to parameter b [c] |
+| A.cs:83:15:83:21 | object creation of type C | semmle.label | object creation of type C |
+| A.cs:88:12:88:12 | [post] access to local variable b [c] | semmle.label | [post] access to local variable b [c] |
+| A.cs:89:14:89:14 | access to local variable b [c] | semmle.label | access to local variable b [c] |
+| A.cs:89:14:89:16 | access to field c | semmle.label | access to field c |
+| A.cs:97:13:97:13 | [post] access to parameter b [c] | semmle.label | [post] access to parameter b [c] |
+| A.cs:97:19:97:25 | object creation of type C | semmle.label | object creation of type C |
+| A.cs:98:13:98:16 | [post] this access [b, c] | semmle.label | [post] this access [b, c] |
+| A.cs:98:13:98:16 | [post] this access [b] | semmle.label | [post] this access [b] |
+| A.cs:98:22:98:36 | ... ? ... : ... | semmle.label | ... ? ... : ... |
+| A.cs:98:22:98:36 | ... ? ... : ... [c] | semmle.label | ... ? ... : ... [c] |
+| A.cs:98:30:98:36 | object creation of type B | semmle.label | object creation of type B |
+| A.cs:104:17:104:23 | object creation of type B | semmle.label | object creation of type B |
+| A.cs:105:17:105:29 | object creation of type D [b, c] | semmle.label | object creation of type D [b, c] |
+| A.cs:105:17:105:29 | object creation of type D [b] | semmle.label | object creation of type D [b] |
+| A.cs:105:23:105:23 | [post] access to local variable b [c] | semmle.label | [post] access to local variable b [c] |
+| A.cs:105:23:105:23 | access to local variable b | semmle.label | access to local variable b |
+| A.cs:106:14:106:14 | access to local variable d [b] | semmle.label | access to local variable d [b] |
+| A.cs:106:14:106:16 | access to field b | semmle.label | access to field b |
+| A.cs:107:14:107:14 | access to local variable d [b, c] | semmle.label | access to local variable d [b, c] |
+| A.cs:107:14:107:16 | access to field b [c] | semmle.label | access to field b [c] |
+| A.cs:107:14:107:18 | access to field c | semmle.label | access to field c |
+| A.cs:108:14:108:14 | access to local variable b [c] | semmle.label | access to local variable b [c] |
+| A.cs:108:14:108:16 | access to field c | semmle.label | access to field c |
+| A.cs:113:17:113:23 | object creation of type B | semmle.label | object creation of type B |
+| A.cs:114:18:114:54 | object creation of type MyList [head] | semmle.label | object creation of type MyList [head] |
+| A.cs:114:29:114:29 | access to local variable b | semmle.label | access to local variable b |
+| A.cs:115:18:115:37 | object creation of type MyList [next, head] | semmle.label | object creation of type MyList [next, head] |
+| A.cs:115:35:115:36 | access to local variable l1 [head] | semmle.label | access to local variable l1 [head] |
+| A.cs:116:18:116:37 | object creation of type MyList [next, next, ... (3)] | semmle.label | object creation of type MyList [next, next, ... (3)] |
+| A.cs:116:35:116:36 | access to local variable l2 [next, head] | semmle.label | access to local variable l2 [next, head] |
+| A.cs:119:14:119:15 | access to local variable l3 [next, next, ... (3)] | semmle.label | access to local variable l3 [next, next, ... (3)] |
+| A.cs:119:14:119:20 | access to field next [next, head] | semmle.label | access to field next [next, head] |
+| A.cs:119:14:119:25 | access to field next [head] | semmle.label | access to field next [head] |
+| A.cs:119:14:119:30 | access to field head | semmle.label | access to field head |
+| A.cs:121:41:121:41 | access to local variable l [next, head] | semmle.label | access to local variable l [next, head] |
+| A.cs:121:41:121:41 | access to local variable l [next, next, ... (3)] | semmle.label | access to local variable l [next, next, ... (3)] |
+| A.cs:121:41:121:46 | access to field next [head] | semmle.label | access to field next [head] |
+| A.cs:121:41:121:46 | access to field next [next, head] | semmle.label | access to field next [next, head] |
+| A.cs:123:18:123:18 | access to local variable l [head] | semmle.label | access to local variable l [head] |
+| A.cs:123:18:123:23 | access to field head | semmle.label | access to field head |
+| B.cs:5:17:5:26 | object creation of type Elem | semmle.label | object creation of type Elem |
+| B.cs:6:18:6:34 | object creation of type Box1 [elem1] | semmle.label | object creation of type Box1 [elem1] |
+| B.cs:6:27:6:27 | access to local variable e | semmle.label | access to local variable e |
+| B.cs:7:18:7:29 | object creation of type Box2 [box1, elem1] | semmle.label | object creation of type Box2 [box1, elem1] |
+| B.cs:7:27:7:28 | access to local variable b1 [elem1] | semmle.label | access to local variable b1 [elem1] |
+| B.cs:8:14:8:15 | access to local variable b2 [box1, elem1] | semmle.label | access to local variable b2 [box1, elem1] |
+| B.cs:8:14:8:20 | access to field box1 [elem1] | semmle.label | access to field box1 [elem1] |
+| B.cs:8:14:8:26 | access to field elem1 | semmle.label | access to field elem1 |
+| B.cs:14:17:14:26 | object creation of type Elem | semmle.label | object creation of type Elem |
+| B.cs:15:18:15:34 | object creation of type Box1 [elem2] | semmle.label | object creation of type Box1 [elem2] |
+| B.cs:15:33:15:33 | access to local variable e | semmle.label | access to local variable e |
+| B.cs:16:18:16:29 | object creation of type Box2 [box1, elem2] | semmle.label | object creation of type Box2 [box1, elem2] |
+| B.cs:16:27:16:28 | access to local variable b1 [elem2] | semmle.label | access to local variable b1 [elem2] |
+| B.cs:18:14:18:15 | access to local variable b2 [box1, elem2] | semmle.label | access to local variable b2 [box1, elem2] |
+| B.cs:18:14:18:20 | access to field box1 [elem2] | semmle.label | access to field box1 [elem2] |
+| B.cs:18:14:18:26 | access to field elem2 | semmle.label | access to field elem2 |
+| C.cs:3:18:3:19 | [post] this access [s1] | semmle.label | [post] this access [s1] |
+| C.cs:3:23:3:32 | object creation of type Elem | semmle.label | object creation of type Elem |
+| C.cs:4:27:4:28 | [post] this access [s2] | semmle.label | [post] this access [s2] |
+| C.cs:4:32:4:41 | object creation of type Elem | semmle.label | object creation of type Elem |
+| C.cs:6:30:6:39 | object creation of type Elem | semmle.label | object creation of type Elem |
+| C.cs:7:18:7:19 | [post] this access [s5] | semmle.label | [post] this access [s5] |
+| C.cs:7:37:7:46 | object creation of type Elem | semmle.label | object creation of type Elem |
+| C.cs:8:30:8:39 | object creation of type Elem | semmle.label | object creation of type Elem |
+| C.cs:12:15:12:21 | object creation of type C [s1] | semmle.label | object creation of type C [s1] |
+| C.cs:12:15:12:21 | object creation of type C [s2] | semmle.label | object creation of type C [s2] |
+| C.cs:12:15:12:21 | object creation of type C [s3] | semmle.label | object creation of type C [s3] |
+| C.cs:12:15:12:21 | object creation of type C [s5] | semmle.label | object creation of type C [s5] |
+| C.cs:13:9:13:9 | access to local variable c [s1] | semmle.label | access to local variable c [s1] |
+| C.cs:13:9:13:9 | access to local variable c [s2] | semmle.label | access to local variable c [s2] |
+| C.cs:13:9:13:9 | access to local variable c [s3] | semmle.label | access to local variable c [s3] |
+| C.cs:13:9:13:9 | access to local variable c [s5] | semmle.label | access to local variable c [s5] |
+| C.cs:18:9:18:12 | [post] this access [s3] | semmle.label | [post] this access [s3] |
+| C.cs:18:19:18:28 | object creation of type Elem | semmle.label | object creation of type Elem |
+| C.cs:21:17:21:18 | this [s1] | semmle.label | this [s1] |
+| C.cs:21:17:21:18 | this [s2] | semmle.label | this [s2] |
+| C.cs:21:17:21:18 | this [s3] | semmle.label | this [s3] |
+| C.cs:21:17:21:18 | this [s5] | semmle.label | this [s5] |
+| C.cs:23:14:23:15 | access to field s1 | semmle.label | access to field s1 |
+| C.cs:23:14:23:15 | this access [s1] | semmle.label | this access [s1] |
+| C.cs:24:14:24:15 | access to field s2 | semmle.label | access to field s2 |
+| C.cs:24:14:24:15 | this access [s2] | semmle.label | this access [s2] |
+| C.cs:25:14:25:15 | access to field s3 | semmle.label | access to field s3 |
+| C.cs:25:14:25:15 | this access [s3] | semmle.label | this access [s3] |
+| C.cs:26:14:26:15 | access to field s4 | semmle.label | access to field s4 |
+| C.cs:27:14:27:15 | access to property s5 | semmle.label | access to property s5 |
+| C.cs:27:14:27:15 | this access [s5] | semmle.label | this access [s5] |
+| C.cs:28:14:28:15 | access to property s6 | semmle.label | access to property s6 |
+| D.cs:29:17:29:28 | object creation of type Object | semmle.label | object creation of type Object |
+| D.cs:31:17:31:37 | call to method Create [AutoProp] | semmle.label | call to method Create [AutoProp] |
+| D.cs:31:24:31:24 | access to local variable o | semmle.label | access to local variable o |
+| D.cs:32:14:32:14 | access to local variable d [AutoProp] | semmle.label | access to local variable d [AutoProp] |
+| D.cs:32:14:32:23 | access to property AutoProp | semmle.label | access to property AutoProp |
+| D.cs:37:13:37:33 | call to method Create [trivialPropField] | semmle.label | call to method Create [trivialPropField] |
+| D.cs:37:26:37:26 | access to local variable o | semmle.label | access to local variable o |
+| D.cs:39:14:39:14 | access to local variable d [trivialPropField] | semmle.label | access to local variable d [trivialPropField] |
+| D.cs:39:14:39:26 | access to property TrivialProp | semmle.label | access to property TrivialProp |
+| D.cs:40:14:40:14 | access to local variable d [trivialPropField] | semmle.label | access to local variable d [trivialPropField] |
+| D.cs:40:14:40:31 | access to field trivialPropField | semmle.label | access to field trivialPropField |
+| D.cs:41:14:41:14 | access to local variable d [trivialPropField] | semmle.label | access to local variable d [trivialPropField] |
+| D.cs:41:14:41:26 | access to property ComplexProp | semmle.label | access to property ComplexProp |
+| D.cs:43:13:43:33 | call to method Create [trivialPropField] | semmle.label | call to method Create [trivialPropField] |
+| D.cs:43:32:43:32 | access to local variable o | semmle.label | access to local variable o |
+| D.cs:45:14:45:14 | access to local variable d [trivialPropField] | semmle.label | access to local variable d [trivialPropField] |
+| D.cs:45:14:45:26 | access to property TrivialProp | semmle.label | access to property TrivialProp |
+| D.cs:46:14:46:14 | access to local variable d [trivialPropField] | semmle.label | access to local variable d [trivialPropField] |
+| D.cs:46:14:46:31 | access to field trivialPropField | semmle.label | access to field trivialPropField |
+| D.cs:47:14:47:14 | access to local variable d [trivialPropField] | semmle.label | access to local variable d [trivialPropField] |
+| D.cs:47:14:47:26 | access to property ComplexProp | semmle.label | access to property ComplexProp |
+| E.cs:22:17:22:28 | object creation of type Object | semmle.label | object creation of type Object |
+| E.cs:23:17:23:26 | call to method CreateS [Field] | semmle.label | call to method CreateS [Field] |
+| E.cs:23:25:23:25 | access to local variable o | semmle.label | access to local variable o |
+| E.cs:24:14:24:14 | access to local variable s [Field] | semmle.label | access to local variable s [Field] |
+| E.cs:24:14:24:20 | access to field Field | semmle.label | access to field Field |
+| F.cs:10:17:10:28 | object creation of type Object | semmle.label | object creation of type Object |
+| F.cs:11:17:11:31 | call to method Create [Field1] | semmle.label | call to method Create [Field1] |
+| F.cs:11:24:11:24 | access to local variable o | semmle.label | access to local variable o |
+| F.cs:12:14:12:14 | access to local variable f [Field1] | semmle.label | access to local variable f [Field1] |
+| F.cs:12:14:12:21 | access to field Field1 | semmle.label | access to field Field1 |
+| F.cs:15:13:15:27 | call to method Create [Field2] | semmle.label | call to method Create [Field2] |
+| F.cs:15:26:15:26 | access to local variable o | semmle.label | access to local variable o |
+| F.cs:17:14:17:14 | access to local variable f [Field2] | semmle.label | access to local variable f [Field2] |
+| F.cs:17:14:17:21 | access to field Field2 | semmle.label | access to field Field2 |
+| F.cs:19:13:19:34 | object creation of type F [Field1] | semmle.label | object creation of type F [Field1] |
+| F.cs:19:32:19:32 | access to local variable o | semmle.label | access to local variable o |
+| F.cs:20:14:20:14 | access to local variable f [Field1] | semmle.label | access to local variable f [Field1] |
+| F.cs:20:14:20:21 | access to field Field1 | semmle.label | access to field Field1 |
+| F.cs:23:13:23:34 | object creation of type F [Field2] | semmle.label | object creation of type F [Field2] |
+| F.cs:23:32:23:32 | access to local variable o | semmle.label | access to local variable o |
+| F.cs:25:14:25:14 | access to local variable f [Field2] | semmle.label | access to local variable f [Field2] |
+| F.cs:25:14:25:21 | access to field Field2 | semmle.label | access to field Field2 |
+| G.cs:7:18:7:27 | object creation of type Elem | semmle.label | object creation of type Elem |
+| G.cs:9:9:9:9 | [post] access to local variable b [Box1, Elem] | semmle.label | [post] access to local variable b [Box1, Elem] |
+| G.cs:9:9:9:14 | [post] access to field Box1 [Elem] | semmle.label | [post] access to field Box1 [Elem] |
+| G.cs:9:23:9:23 | access to local variable e | semmle.label | access to local variable e |
+| G.cs:10:18:10:18 | access to local variable b [Box1, Elem] | semmle.label | access to local variable b [Box1, Elem] |
+| G.cs:15:18:15:27 | object creation of type Elem | semmle.label | object creation of type Elem |
+| G.cs:17:9:17:9 | [post] access to local variable b [Box1, Elem] | semmle.label | [post] access to local variable b [Box1, Elem] |
+| G.cs:17:9:17:14 | [post] access to field Box1 [Elem] | semmle.label | [post] access to field Box1 [Elem] |
+| G.cs:17:24:17:24 | access to local variable e | semmle.label | access to local variable e |
+| G.cs:18:18:18:18 | access to local variable b [Box1, Elem] | semmle.label | access to local variable b [Box1, Elem] |
+| G.cs:23:18:23:27 | object creation of type Elem | semmle.label | object creation of type Elem |
+| G.cs:25:9:25:9 | [post] access to local variable b [Box1, Elem] | semmle.label | [post] access to local variable b [Box1, Elem] |
+| G.cs:25:9:25:19 | [post] call to method GetBox1 [Elem] | semmle.label | [post] call to method GetBox1 [Elem] |
+| G.cs:25:28:25:28 | access to local variable e | semmle.label | access to local variable e |
+| G.cs:26:18:26:18 | access to local variable b [Box1, Elem] | semmle.label | access to local variable b [Box1, Elem] |
+| G.cs:31:18:31:27 | object creation of type Elem | semmle.label | object creation of type Elem |
+| G.cs:33:9:33:9 | [post] access to local variable b [Box1, Elem] | semmle.label | [post] access to local variable b [Box1, Elem] |
+| G.cs:33:9:33:19 | [post] call to method GetBox1 [Elem] | semmle.label | [post] call to method GetBox1 [Elem] |
+| G.cs:33:29:33:29 | access to local variable e | semmle.label | access to local variable e |
+| G.cs:34:18:34:18 | access to local variable b [Box1, Elem] | semmle.label | access to local variable b [Box1, Elem] |
+| G.cs:37:38:37:39 | b2 [Box1, Elem] | semmle.label | b2 [Box1, Elem] |
+| G.cs:39:14:39:15 | access to parameter b2 [Box1, Elem] | semmle.label | access to parameter b2 [Box1, Elem] |
+| G.cs:39:14:39:25 | call to method GetBox1 [Elem] | semmle.label | call to method GetBox1 [Elem] |
+| G.cs:39:14:39:35 | call to method GetElem | semmle.label | call to method GetElem |
+| G.cs:44:18:44:27 | object creation of type Elem | semmle.label | object creation of type Elem |
+| G.cs:46:9:46:16 | [post] access to field boxfield [Box1, Elem] | semmle.label | [post] access to field boxfield [Box1, Elem] |
+| G.cs:46:9:46:16 | [post] this access [boxfield, Box1, ... (3)] | semmle.label | [post] this access [boxfield, Box1, ... (3)] |
+| G.cs:46:9:46:21 | [post] access to field Box1 [Elem] | semmle.label | [post] access to field Box1 [Elem] |
+| G.cs:46:30:46:30 | access to local variable e | semmle.label | access to local variable e |
+| G.cs:47:9:47:13 | this access [boxfield, Box1, ... (3)] | semmle.label | this access [boxfield, Box1, ... (3)] |
+| G.cs:50:18:50:20 | this [boxfield, Box1, ... (3)] | semmle.label | this [boxfield, Box1, ... (3)] |
+| G.cs:52:14:52:21 | access to field boxfield [Box1, Elem] | semmle.label | access to field boxfield [Box1, Elem] |
+| G.cs:52:14:52:21 | this access [boxfield, Box1, ... (3)] | semmle.label | this access [boxfield, Box1, ... (3)] |
+| G.cs:52:14:52:26 | access to field Box1 [Elem] | semmle.label | access to field Box1 [Elem] |
+| G.cs:52:14:52:31 | access to field Elem | semmle.label | access to field Elem |
 #select
 | A.cs:7:14:7:16 | access to field c | A.cs:5:17:5:23 | object creation of type C | A.cs:7:14:7:16 | access to field c | $@ | A.cs:5:17:5:23 | object creation of type C | object creation of type C |
 | A.cs:14:14:14:20 | call to method Get | A.cs:13:15:13:22 | object creation of type C1 | A.cs:14:14:14:20 | call to method Get | $@ | A.cs:13:15:13:22 | object creation of type C1 | object creation of type C1 |

--- a/csharp/ql/test/library-tests/dataflow/global/DataFlowPath.expected
+++ b/csharp/ql/test/library-tests/dataflow/global/DataFlowPath.expected
@@ -192,6 +192,159 @@ edges
 | Splitting.cs:31:17:31:26 | [b (line 24): true] dynamic access to element | Splitting.cs:34:19:34:19 | access to local variable x |
 | Splitting.cs:31:19:31:25 | [b (line 24): false] access to parameter tainted | Splitting.cs:31:17:31:26 | [b (line 24): false] dynamic access to element |
 | Splitting.cs:31:19:31:25 | [b (line 24): true] access to parameter tainted | Splitting.cs:31:17:31:26 | [b (line 24): true] dynamic access to element |
+nodes
+| Capture.cs:7:20:7:26 | tainted | semmle.label | tainted |
+| Capture.cs:9:9:13:9 | SSA capture def(tainted) | semmle.label | SSA capture def(tainted) |
+| Capture.cs:12:19:12:24 | access to local variable sink27 | semmle.label | access to local variable sink27 |
+| Capture.cs:14:9:14:20 | [implicit argument] tainted | semmle.label | [implicit argument] tainted |
+| Capture.cs:18:13:22:13 | SSA capture def(tainted) | semmle.label | SSA capture def(tainted) |
+| Capture.cs:21:23:21:28 | access to local variable sink28 | semmle.label | access to local variable sink28 |
+| Capture.cs:25:9:25:20 | [implicit argument] tainted | semmle.label | [implicit argument] tainted |
+| Capture.cs:27:43:32:9 | SSA capture def(tainted) | semmle.label | SSA capture def(tainted) |
+| Capture.cs:30:19:30:24 | access to local variable sink29 | semmle.label | access to local variable sink29 |
+| Capture.cs:33:9:33:40 | [implicit argument] tainted | semmle.label | [implicit argument] tainted |
+| Capture.cs:57:13:57:35 | SSA def(sink30) | semmle.label | SSA def(sink30) |
+| Capture.cs:57:22:57:35 | "taint source" | semmle.label | "taint source" |
+| Capture.cs:59:9:59:21 | SSA call def(sink30) | semmle.label | SSA call def(sink30) |
+| Capture.cs:60:15:60:20 | access to local variable sink30 | semmle.label | access to local variable sink30 |
+| Capture.cs:67:17:67:39 | SSA def(sink31) | semmle.label | SSA def(sink31) |
+| Capture.cs:67:26:67:39 | "taint source" | semmle.label | "taint source" |
+| Capture.cs:71:9:71:21 | SSA call def(sink31) | semmle.label | SSA call def(sink31) |
+| Capture.cs:72:15:72:20 | access to local variable sink31 | semmle.label | access to local variable sink31 |
+| Capture.cs:77:13:77:35 | SSA def(sink32) | semmle.label | SSA def(sink32) |
+| Capture.cs:77:22:77:35 | "taint source" | semmle.label | "taint source" |
+| Capture.cs:80:9:80:41 | SSA call def(sink32) | semmle.label | SSA call def(sink32) |
+| Capture.cs:81:15:81:20 | access to local variable sink32 | semmle.label | access to local variable sink32 |
+| Capture.cs:101:25:101:31 | tainted | semmle.label | tainted |
+| Capture.cs:108:9:108:25 | SSA call def(sink33) | semmle.label | SSA call def(sink33) |
+| Capture.cs:108:9:108:25 | [implicit argument] tainted | semmle.label | [implicit argument] tainted |
+| Capture.cs:109:15:109:20 | access to local variable sink33 | semmle.label | access to local variable sink33 |
+| Capture.cs:120:9:120:25 | SSA call def(sink34) | semmle.label | SSA call def(sink34) |
+| Capture.cs:120:9:120:25 | [implicit argument] tainted | semmle.label | [implicit argument] tainted |
+| Capture.cs:121:15:121:20 | access to local variable sink34 | semmle.label | access to local variable sink34 |
+| Capture.cs:129:9:129:45 | SSA call def(sink35) | semmle.label | SSA call def(sink35) |
+| Capture.cs:129:9:129:45 | [implicit argument] tainted | semmle.label | [implicit argument] tainted |
+| Capture.cs:130:15:130:20 | access to local variable sink35 | semmle.label | access to local variable sink35 |
+| Capture.cs:136:22:136:38 | [implicit argument] tainted | semmle.label | [implicit argument] tainted |
+| Capture.cs:136:22:136:38 | call to local function CaptureThrough4 | semmle.label | call to local function CaptureThrough4 |
+| Capture.cs:137:15:137:20 | access to local variable sink36 | semmle.label | access to local variable sink36 |
+| Capture.cs:144:9:144:32 | SSA call def(sink37) | semmle.label | SSA call def(sink37) |
+| Capture.cs:144:25:144:31 | access to parameter tainted | semmle.label | access to parameter tainted |
+| Capture.cs:145:15:145:20 | access to local variable sink37 | semmle.label | access to local variable sink37 |
+| Capture.cs:170:22:170:32 | call to local function Id | semmle.label | call to local function Id |
+| Capture.cs:170:25:170:31 | access to parameter tainted | semmle.label | access to parameter tainted |
+| Capture.cs:171:15:171:20 | access to local variable sink38 | semmle.label | access to local variable sink38 |
+| GlobalDataFlow.cs:17:27:17:40 | "taint source" | semmle.label | "taint source" |
+| GlobalDataFlow.cs:18:15:18:29 | access to field SinkField0 | semmle.label | access to field SinkField0 |
+| GlobalDataFlow.cs:26:15:26:32 | access to property SinkProperty0 | semmle.label | access to property SinkProperty0 |
+| GlobalDataFlow.cs:26:15:26:32 | access to property SinkProperty0 | semmle.label | access to property SinkProperty0 |
+| GlobalDataFlow.cs:35:13:35:30 | access to property SinkProperty0 | semmle.label | access to property SinkProperty0 |
+| GlobalDataFlow.cs:37:35:37:52 | access to property SinkProperty0 | semmle.label | access to property SinkProperty0 |
+| GlobalDataFlow.cs:44:30:44:39 | sinkParam2 | semmle.label | sinkParam2 |
+| GlobalDataFlow.cs:44:50:44:59 | access to parameter sinkParam2 | semmle.label | access to parameter sinkParam2 |
+| GlobalDataFlow.cs:45:13:45:30 | access to property SinkProperty0 | semmle.label | access to property SinkProperty0 |
+| GlobalDataFlow.cs:52:20:52:37 | access to property SinkProperty0 | semmle.label | access to property SinkProperty0 |
+| GlobalDataFlow.cs:53:15:53:15 | x | semmle.label | x |
+| GlobalDataFlow.cs:53:24:53:24 | access to parameter x | semmle.label | access to parameter x |
+| GlobalDataFlow.cs:53:28:53:45 | access to property SinkProperty0 | semmle.label | access to property SinkProperty0 |
+| GlobalDataFlow.cs:54:44:54:61 | access to property SinkProperty0 | semmle.label | access to property SinkProperty0 |
+| GlobalDataFlow.cs:55:28:55:45 | access to property SinkProperty0 | semmle.label | access to property SinkProperty0 |
+| GlobalDataFlow.cs:56:37:56:37 | x | semmle.label | x |
+| GlobalDataFlow.cs:56:46:56:46 | access to parameter x | semmle.label | access to parameter x |
+| GlobalDataFlow.cs:57:35:57:52 | access to property SinkProperty0 | semmle.label | access to property SinkProperty0 |
+| GlobalDataFlow.cs:60:38:60:50 | access to parameter nonSinkParam0 | semmle.label | access to parameter nonSinkParam0 |
+| GlobalDataFlow.cs:61:61:61:73 | access to parameter nonSinkParam0 | semmle.label | access to parameter nonSinkParam0 |
+| GlobalDataFlow.cs:64:22:64:39 | access to property SinkProperty0 | semmle.label | access to property SinkProperty0 |
+| GlobalDataFlow.cs:70:21:70:46 | call to method Return | semmle.label | call to method Return |
+| GlobalDataFlow.cs:70:28:70:45 | access to property SinkProperty0 | semmle.label | access to property SinkProperty0 |
+| GlobalDataFlow.cs:71:15:71:19 | access to local variable sink0 | semmle.label | access to local variable sink0 |
+| GlobalDataFlow.cs:72:21:72:101 | (...) ... | semmle.label | (...) ... |
+| GlobalDataFlow.cs:72:29:72:101 | call to method Invoke | semmle.label | call to method Invoke |
+| GlobalDataFlow.cs:72:94:72:98 | access to local variable sink0 | semmle.label | access to local variable sink0 |
+| GlobalDataFlow.cs:73:15:73:19 | access to local variable sink1 | semmle.label | access to local variable sink1 |
+| GlobalDataFlow.cs:75:19:75:23 | access to local variable sink1 | semmle.label | access to local variable sink1 |
+| GlobalDataFlow.cs:75:30:75:34 | SSA def(sink2) | semmle.label | SSA def(sink2) |
+| GlobalDataFlow.cs:76:15:76:19 | access to local variable sink2 | semmle.label | access to local variable sink2 |
+| GlobalDataFlow.cs:78:19:78:23 | access to local variable sink2 | semmle.label | access to local variable sink2 |
+| GlobalDataFlow.cs:78:30:78:34 | SSA def(sink3) | semmle.label | SSA def(sink3) |
+| GlobalDataFlow.cs:79:15:79:19 | access to local variable sink3 | semmle.label | access to local variable sink3 |
+| GlobalDataFlow.cs:135:21:135:34 | delegate call | semmle.label | delegate call |
+| GlobalDataFlow.cs:135:29:135:33 | access to local variable sink3 | semmle.label | access to local variable sink3 |
+| GlobalDataFlow.cs:136:15:136:19 | access to local variable sink4 | semmle.label | access to local variable sink4 |
+| GlobalDataFlow.cs:143:21:143:44 | call to method ApplyFunc | semmle.label | call to method ApplyFunc |
+| GlobalDataFlow.cs:143:39:143:43 | access to local variable sink4 | semmle.label | access to local variable sink4 |
+| GlobalDataFlow.cs:144:15:144:19 | access to local variable sink5 | semmle.label | access to local variable sink5 |
+| GlobalDataFlow.cs:153:21:153:25 | call to method Out | semmle.label | call to method Out |
+| GlobalDataFlow.cs:154:15:154:19 | access to local variable sink6 | semmle.label | access to local variable sink6 |
+| GlobalDataFlow.cs:156:20:156:24 | SSA def(sink7) | semmle.label | SSA def(sink7) |
+| GlobalDataFlow.cs:157:15:157:19 | access to local variable sink7 | semmle.label | access to local variable sink7 |
+| GlobalDataFlow.cs:159:20:159:24 | SSA def(sink8) | semmle.label | SSA def(sink8) |
+| GlobalDataFlow.cs:160:15:160:19 | access to local variable sink8 | semmle.label | access to local variable sink8 |
+| GlobalDataFlow.cs:163:22:163:43 | call to method TaintedParam | semmle.label | call to method TaintedParam |
+| GlobalDataFlow.cs:164:15:164:20 | access to local variable sink23 | semmle.label | access to local variable sink23 |
+| GlobalDataFlow.cs:179:35:179:48 | "taint source" | semmle.label | "taint source" |
+| GlobalDataFlow.cs:180:21:180:26 | delegate call | semmle.label | delegate call |
+| GlobalDataFlow.cs:181:15:181:19 | access to local variable sink9 | semmle.label | access to local variable sink9 |
+| GlobalDataFlow.cs:189:39:189:41 | [output] delegate creation of type Func<String> | semmle.label | [output] delegate creation of type Func<String> |
+| GlobalDataFlow.cs:190:15:190:20 | access to local variable sink10 | semmle.label | access to local variable sink10 |
+| GlobalDataFlow.cs:197:22:197:32 | access to property OutProperty | semmle.label | access to property OutProperty |
+| GlobalDataFlow.cs:198:15:198:20 | access to local variable sink19 | semmle.label | access to local variable sink19 |
+| GlobalDataFlow.cs:234:26:234:35 | sinkParam0 | semmle.label | sinkParam0 |
+| GlobalDataFlow.cs:236:16:236:25 | access to parameter sinkParam0 | semmle.label | access to parameter sinkParam0 |
+| GlobalDataFlow.cs:237:15:237:24 | access to parameter sinkParam0 | semmle.label | access to parameter sinkParam0 |
+| GlobalDataFlow.cs:240:26:240:35 | sinkParam1 | semmle.label | sinkParam1 |
+| GlobalDataFlow.cs:242:15:242:24 | access to parameter sinkParam1 | semmle.label | access to parameter sinkParam1 |
+| GlobalDataFlow.cs:245:26:245:35 | sinkParam3 | semmle.label | sinkParam3 |
+| GlobalDataFlow.cs:247:15:247:24 | access to parameter sinkParam3 | semmle.label | access to parameter sinkParam3 |
+| GlobalDataFlow.cs:250:26:250:35 | sinkParam4 | semmle.label | sinkParam4 |
+| GlobalDataFlow.cs:252:15:252:24 | access to parameter sinkParam4 | semmle.label | access to parameter sinkParam4 |
+| GlobalDataFlow.cs:255:26:255:35 | sinkParam5 | semmle.label | sinkParam5 |
+| GlobalDataFlow.cs:257:15:257:24 | access to parameter sinkParam5 | semmle.label | access to parameter sinkParam5 |
+| GlobalDataFlow.cs:260:26:260:35 | sinkParam6 | semmle.label | sinkParam6 |
+| GlobalDataFlow.cs:262:15:262:24 | access to parameter sinkParam6 | semmle.label | access to parameter sinkParam6 |
+| GlobalDataFlow.cs:265:26:265:35 | sinkParam7 | semmle.label | sinkParam7 |
+| GlobalDataFlow.cs:267:15:267:24 | access to parameter sinkParam7 | semmle.label | access to parameter sinkParam7 |
+| GlobalDataFlow.cs:318:16:318:29 | "taint source" | semmle.label | "taint source" |
+| GlobalDataFlow.cs:323:9:323:26 | SSA def(x) | semmle.label | SSA def(x) |
+| GlobalDataFlow.cs:323:13:323:26 | "taint source" | semmle.label | "taint source" |
+| GlobalDataFlow.cs:328:9:328:26 | SSA def(x) | semmle.label | SSA def(x) |
+| GlobalDataFlow.cs:328:13:328:26 | "taint source" | semmle.label | "taint source" |
+| GlobalDataFlow.cs:359:41:359:41 | x | semmle.label | x |
+| GlobalDataFlow.cs:359:41:359:41 | x | semmle.label | x |
+| GlobalDataFlow.cs:361:11:361:11 | access to parameter x | semmle.label | access to parameter x |
+| GlobalDataFlow.cs:361:11:361:11 | access to parameter x | semmle.label | access to parameter x |
+| GlobalDataFlow.cs:373:52:373:52 | x | semmle.label | x |
+| GlobalDataFlow.cs:373:52:373:52 | x | semmle.label | x |
+| GlobalDataFlow.cs:373:52:373:52 | x | semmle.label | x |
+| GlobalDataFlow.cs:375:11:375:11 | access to parameter x | semmle.label | access to parameter x |
+| GlobalDataFlow.cs:375:11:375:11 | access to parameter x | semmle.label | access to parameter x |
+| GlobalDataFlow.cs:375:11:375:11 | access to parameter x | semmle.label | access to parameter x |
+| GlobalDataFlow.cs:378:39:378:45 | tainted | semmle.label | tainted |
+| GlobalDataFlow.cs:381:15:381:20 | access to local variable sink11 | semmle.label | access to local variable sink11 |
+| GlobalDataFlow.cs:382:16:382:21 | access to local variable sink11 | semmle.label | access to local variable sink11 |
+| GlobalDataFlow.cs:404:9:404:11 | value | semmle.label | value |
+| GlobalDataFlow.cs:404:41:404:46 | access to local variable sink20 | semmle.label | access to local variable sink20 |
+| GlobalDataFlow.cs:415:22:415:35 | "taint source" | semmle.label | "taint source" |
+| Splitting.cs:3:28:3:34 | tainted | semmle.label | tainted |
+| Splitting.cs:8:17:8:31 | [b (line 3): false] call to method Return | semmle.label | [b (line 3): false] call to method Return |
+| Splitting.cs:8:17:8:31 | [b (line 3): true] call to method Return | semmle.label | [b (line 3): true] call to method Return |
+| Splitting.cs:8:24:8:30 | [b (line 3): false] access to parameter tainted | semmle.label | [b (line 3): false] access to parameter tainted |
+| Splitting.cs:8:24:8:30 | [b (line 3): true] access to parameter tainted | semmle.label | [b (line 3): true] access to parameter tainted |
+| Splitting.cs:9:15:9:15 | [b (line 3): false] access to local variable x | semmle.label | [b (line 3): false] access to local variable x |
+| Splitting.cs:9:15:9:15 | [b (line 3): true] access to local variable x | semmle.label | [b (line 3): true] access to local variable x |
+| Splitting.cs:11:19:11:19 | access to local variable x | semmle.label | access to local variable x |
+| Splitting.cs:21:9:21:11 | value | semmle.label | value |
+| Splitting.cs:21:28:21:32 | access to parameter value | semmle.label | access to parameter value |
+| Splitting.cs:24:28:24:34 | tainted | semmle.label | tainted |
+| Splitting.cs:30:17:30:23 | [b (line 24): false] access to parameter tainted | semmle.label | [b (line 24): false] access to parameter tainted |
+| Splitting.cs:30:17:30:23 | [b (line 24): true] access to parameter tainted | semmle.label | [b (line 24): true] access to parameter tainted |
+| Splitting.cs:31:17:31:26 | [b (line 24): false] dynamic access to element | semmle.label | [b (line 24): false] dynamic access to element |
+| Splitting.cs:31:17:31:26 | [b (line 24): true] dynamic access to element | semmle.label | [b (line 24): true] dynamic access to element |
+| Splitting.cs:31:19:31:25 | [b (line 24): false] access to parameter tainted | semmle.label | [b (line 24): false] access to parameter tainted |
+| Splitting.cs:31:19:31:25 | [b (line 24): true] access to parameter tainted | semmle.label | [b (line 24): true] access to parameter tainted |
+| Splitting.cs:32:15:32:15 | [b (line 24): false] access to local variable x | semmle.label | [b (line 24): false] access to local variable x |
+| Splitting.cs:32:15:32:15 | [b (line 24): true] access to local variable x | semmle.label | [b (line 24): true] access to local variable x |
+| Splitting.cs:34:19:34:19 | access to local variable x | semmle.label | access to local variable x |
 #select
 | Splitting.cs:32:15:32:15 | [b (line 24): false] access to local variable x | Splitting.cs:24:28:24:34 | tainted | Splitting.cs:32:15:32:15 | [b (line 24): false] access to local variable x | [b (line 24): false] access to local variable x |
 | Splitting.cs:32:15:32:15 | [b (line 24): true] access to local variable x | Splitting.cs:24:28:24:34 | tainted | Splitting.cs:32:15:32:15 | [b (line 24): true] access to local variable x | [b (line 24): true] access to local variable x |

--- a/csharp/ql/test/library-tests/dataflow/global/TaintTrackingPath.expected
+++ b/csharp/ql/test/library-tests/dataflow/global/TaintTrackingPath.expected
@@ -239,6 +239,205 @@ edges
 | Splitting.cs:31:17:31:26 | [b (line 24): true] dynamic access to element | Splitting.cs:34:19:34:19 | access to local variable x |
 | Splitting.cs:31:19:31:25 | [b (line 24): false] access to parameter tainted | Splitting.cs:31:17:31:26 | [b (line 24): false] dynamic access to element |
 | Splitting.cs:31:19:31:25 | [b (line 24): true] access to parameter tainted | Splitting.cs:31:17:31:26 | [b (line 24): true] dynamic access to element |
+nodes
+| Capture.cs:7:20:7:26 | tainted | semmle.label | tainted |
+| Capture.cs:9:9:13:9 | SSA capture def(tainted) | semmle.label | SSA capture def(tainted) |
+| Capture.cs:12:19:12:24 | access to local variable sink27 | semmle.label | access to local variable sink27 |
+| Capture.cs:14:9:14:20 | [implicit argument] tainted | semmle.label | [implicit argument] tainted |
+| Capture.cs:18:13:22:13 | SSA capture def(tainted) | semmle.label | SSA capture def(tainted) |
+| Capture.cs:21:23:21:28 | access to local variable sink28 | semmle.label | access to local variable sink28 |
+| Capture.cs:25:9:25:20 | [implicit argument] tainted | semmle.label | [implicit argument] tainted |
+| Capture.cs:27:43:32:9 | SSA capture def(tainted) | semmle.label | SSA capture def(tainted) |
+| Capture.cs:30:19:30:24 | access to local variable sink29 | semmle.label | access to local variable sink29 |
+| Capture.cs:33:9:33:40 | [implicit argument] tainted | semmle.label | [implicit argument] tainted |
+| Capture.cs:57:13:57:35 | SSA def(sink30) | semmle.label | SSA def(sink30) |
+| Capture.cs:57:22:57:35 | "taint source" | semmle.label | "taint source" |
+| Capture.cs:59:9:59:21 | SSA call def(sink30) | semmle.label | SSA call def(sink30) |
+| Capture.cs:60:15:60:20 | access to local variable sink30 | semmle.label | access to local variable sink30 |
+| Capture.cs:67:17:67:39 | SSA def(sink31) | semmle.label | SSA def(sink31) |
+| Capture.cs:67:26:67:39 | "taint source" | semmle.label | "taint source" |
+| Capture.cs:71:9:71:21 | SSA call def(sink31) | semmle.label | SSA call def(sink31) |
+| Capture.cs:72:15:72:20 | access to local variable sink31 | semmle.label | access to local variable sink31 |
+| Capture.cs:77:13:77:35 | SSA def(sink32) | semmle.label | SSA def(sink32) |
+| Capture.cs:77:22:77:35 | "taint source" | semmle.label | "taint source" |
+| Capture.cs:80:9:80:41 | SSA call def(sink32) | semmle.label | SSA call def(sink32) |
+| Capture.cs:81:15:81:20 | access to local variable sink32 | semmle.label | access to local variable sink32 |
+| Capture.cs:101:25:101:31 | tainted | semmle.label | tainted |
+| Capture.cs:108:9:108:25 | SSA call def(sink33) | semmle.label | SSA call def(sink33) |
+| Capture.cs:108:9:108:25 | [implicit argument] tainted | semmle.label | [implicit argument] tainted |
+| Capture.cs:109:15:109:20 | access to local variable sink33 | semmle.label | access to local variable sink33 |
+| Capture.cs:120:9:120:25 | SSA call def(sink34) | semmle.label | SSA call def(sink34) |
+| Capture.cs:120:9:120:25 | [implicit argument] tainted | semmle.label | [implicit argument] tainted |
+| Capture.cs:121:15:121:20 | access to local variable sink34 | semmle.label | access to local variable sink34 |
+| Capture.cs:129:9:129:45 | SSA call def(sink35) | semmle.label | SSA call def(sink35) |
+| Capture.cs:129:9:129:45 | [implicit argument] tainted | semmle.label | [implicit argument] tainted |
+| Capture.cs:130:15:130:20 | access to local variable sink35 | semmle.label | access to local variable sink35 |
+| Capture.cs:136:22:136:38 | [implicit argument] tainted | semmle.label | [implicit argument] tainted |
+| Capture.cs:136:22:136:38 | call to local function CaptureThrough4 | semmle.label | call to local function CaptureThrough4 |
+| Capture.cs:137:15:137:20 | access to local variable sink36 | semmle.label | access to local variable sink36 |
+| Capture.cs:144:9:144:32 | SSA call def(sink37) | semmle.label | SSA call def(sink37) |
+| Capture.cs:144:25:144:31 | access to parameter tainted | semmle.label | access to parameter tainted |
+| Capture.cs:145:15:145:20 | access to local variable sink37 | semmle.label | access to local variable sink37 |
+| Capture.cs:170:22:170:32 | call to local function Id | semmle.label | call to local function Id |
+| Capture.cs:170:25:170:31 | access to parameter tainted | semmle.label | access to parameter tainted |
+| Capture.cs:171:15:171:20 | access to local variable sink38 | semmle.label | access to local variable sink38 |
+| GlobalDataFlow.cs:17:27:17:40 | "taint source" | semmle.label | "taint source" |
+| GlobalDataFlow.cs:18:15:18:29 | access to field SinkField0 | semmle.label | access to field SinkField0 |
+| GlobalDataFlow.cs:26:15:26:32 | access to property SinkProperty0 | semmle.label | access to property SinkProperty0 |
+| GlobalDataFlow.cs:26:15:26:32 | access to property SinkProperty0 | semmle.label | access to property SinkProperty0 |
+| GlobalDataFlow.cs:35:13:35:30 | access to property SinkProperty0 | semmle.label | access to property SinkProperty0 |
+| GlobalDataFlow.cs:37:35:37:52 | access to property SinkProperty0 | semmle.label | access to property SinkProperty0 |
+| GlobalDataFlow.cs:44:30:44:39 | sinkParam2 | semmle.label | sinkParam2 |
+| GlobalDataFlow.cs:44:50:44:59 | access to parameter sinkParam2 | semmle.label | access to parameter sinkParam2 |
+| GlobalDataFlow.cs:45:13:45:30 | access to property SinkProperty0 | semmle.label | access to property SinkProperty0 |
+| GlobalDataFlow.cs:52:20:52:37 | access to property SinkProperty0 | semmle.label | access to property SinkProperty0 |
+| GlobalDataFlow.cs:53:15:53:15 | x | semmle.label | x |
+| GlobalDataFlow.cs:53:24:53:24 | access to parameter x | semmle.label | access to parameter x |
+| GlobalDataFlow.cs:53:28:53:45 | access to property SinkProperty0 | semmle.label | access to property SinkProperty0 |
+| GlobalDataFlow.cs:54:44:54:61 | access to property SinkProperty0 | semmle.label | access to property SinkProperty0 |
+| GlobalDataFlow.cs:55:28:55:45 | access to property SinkProperty0 | semmle.label | access to property SinkProperty0 |
+| GlobalDataFlow.cs:56:37:56:37 | x | semmle.label | x |
+| GlobalDataFlow.cs:56:46:56:46 | access to parameter x | semmle.label | access to parameter x |
+| GlobalDataFlow.cs:57:35:57:52 | access to property SinkProperty0 | semmle.label | access to property SinkProperty0 |
+| GlobalDataFlow.cs:60:38:60:50 | access to parameter nonSinkParam0 | semmle.label | access to parameter nonSinkParam0 |
+| GlobalDataFlow.cs:61:61:61:73 | access to parameter nonSinkParam0 | semmle.label | access to parameter nonSinkParam0 |
+| GlobalDataFlow.cs:64:22:64:39 | access to property SinkProperty0 | semmle.label | access to property SinkProperty0 |
+| GlobalDataFlow.cs:70:21:70:46 | call to method Return | semmle.label | call to method Return |
+| GlobalDataFlow.cs:70:28:70:45 | access to property SinkProperty0 | semmle.label | access to property SinkProperty0 |
+| GlobalDataFlow.cs:71:15:71:19 | access to local variable sink0 | semmle.label | access to local variable sink0 |
+| GlobalDataFlow.cs:72:21:72:101 | (...) ... | semmle.label | (...) ... |
+| GlobalDataFlow.cs:72:29:72:101 | call to method Invoke | semmle.label | call to method Invoke |
+| GlobalDataFlow.cs:72:94:72:98 | access to local variable sink0 | semmle.label | access to local variable sink0 |
+| GlobalDataFlow.cs:73:15:73:19 | access to local variable sink1 | semmle.label | access to local variable sink1 |
+| GlobalDataFlow.cs:75:19:75:23 | access to local variable sink1 | semmle.label | access to local variable sink1 |
+| GlobalDataFlow.cs:75:30:75:34 | SSA def(sink2) | semmle.label | SSA def(sink2) |
+| GlobalDataFlow.cs:76:15:76:19 | access to local variable sink2 | semmle.label | access to local variable sink2 |
+| GlobalDataFlow.cs:78:19:78:23 | access to local variable sink2 | semmle.label | access to local variable sink2 |
+| GlobalDataFlow.cs:78:30:78:34 | SSA def(sink3) | semmle.label | SSA def(sink3) |
+| GlobalDataFlow.cs:79:15:79:19 | access to local variable sink3 | semmle.label | access to local variable sink3 |
+| GlobalDataFlow.cs:80:22:80:85 | call to method SelectEven | semmle.label | call to method SelectEven |
+| GlobalDataFlow.cs:80:23:80:65 | (...) ... | semmle.label | (...) ... |
+| GlobalDataFlow.cs:81:15:81:20 | access to local variable sink13 | semmle.label | access to local variable sink13 |
+| GlobalDataFlow.cs:82:23:82:74 | (...) ... | semmle.label | (...) ... |
+| GlobalDataFlow.cs:82:84:82:94 | [output] delegate creation of type Func<String,String> | semmle.label | [output] delegate creation of type Func<String,String> |
+| GlobalDataFlow.cs:83:15:83:20 | access to local variable sink14 | semmle.label | access to local variable sink14 |
+| GlobalDataFlow.cs:84:23:84:74 | (...) ... | semmle.label | (...) ... |
+| GlobalDataFlow.cs:84:125:84:135 | [output] (...) => ... | semmle.label | [output] (...) => ... |
+| GlobalDataFlow.cs:85:15:85:20 | access to local variable sink15 | semmle.label | access to local variable sink15 |
+| GlobalDataFlow.cs:86:70:86:121 | (...) ... | semmle.label | (...) ... |
+| GlobalDataFlow.cs:86:125:86:135 | [output] (...) => ... | semmle.label | [output] (...) => ... |
+| GlobalDataFlow.cs:87:15:87:20 | access to local variable sink16 | semmle.label | access to local variable sink16 |
+| GlobalDataFlow.cs:88:22:88:27 | access to local variable sink14 | semmle.label | access to local variable sink14 |
+| GlobalDataFlow.cs:88:43:88:61 | [output] (...) => ... | semmle.label | [output] (...) => ... |
+| GlobalDataFlow.cs:88:64:88:69 | [output] (...) => ... | semmle.label | [output] (...) => ... |
+| GlobalDataFlow.cs:89:15:89:20 | access to local variable sink17 | semmle.label | access to local variable sink17 |
+| GlobalDataFlow.cs:90:75:90:88 | call to method First | semmle.label | call to method First |
+| GlobalDataFlow.cs:90:91:90:109 | [output] (...) => ... | semmle.label | [output] (...) => ... |
+| GlobalDataFlow.cs:90:112:90:117 | [output] (...) => ... | semmle.label | [output] (...) => ... |
+| GlobalDataFlow.cs:91:15:91:20 | access to local variable sink18 | semmle.label | access to local variable sink18 |
+| GlobalDataFlow.cs:94:15:94:20 | access to local variable sink21 | semmle.label | access to local variable sink21 |
+| GlobalDataFlow.cs:97:15:97:20 | access to local variable sink22 | semmle.label | access to local variable sink22 |
+| GlobalDataFlow.cs:135:21:135:34 | delegate call | semmle.label | delegate call |
+| GlobalDataFlow.cs:135:29:135:33 | access to local variable sink3 | semmle.label | access to local variable sink3 |
+| GlobalDataFlow.cs:136:15:136:19 | access to local variable sink4 | semmle.label | access to local variable sink4 |
+| GlobalDataFlow.cs:143:21:143:44 | call to method ApplyFunc | semmle.label | call to method ApplyFunc |
+| GlobalDataFlow.cs:143:39:143:43 | access to local variable sink4 | semmle.label | access to local variable sink4 |
+| GlobalDataFlow.cs:144:15:144:19 | access to local variable sink5 | semmle.label | access to local variable sink5 |
+| GlobalDataFlow.cs:153:21:153:25 | call to method Out | semmle.label | call to method Out |
+| GlobalDataFlow.cs:154:15:154:19 | access to local variable sink6 | semmle.label | access to local variable sink6 |
+| GlobalDataFlow.cs:156:20:156:24 | SSA def(sink7) | semmle.label | SSA def(sink7) |
+| GlobalDataFlow.cs:157:15:157:19 | access to local variable sink7 | semmle.label | access to local variable sink7 |
+| GlobalDataFlow.cs:159:20:159:24 | SSA def(sink8) | semmle.label | SSA def(sink8) |
+| GlobalDataFlow.cs:160:15:160:19 | access to local variable sink8 | semmle.label | access to local variable sink8 |
+| GlobalDataFlow.cs:161:22:161:31 | call to method OutYield | semmle.label | call to method OutYield |
+| GlobalDataFlow.cs:162:15:162:20 | access to local variable sink12 | semmle.label | access to local variable sink12 |
+| GlobalDataFlow.cs:163:22:163:43 | call to method TaintedParam | semmle.label | call to method TaintedParam |
+| GlobalDataFlow.cs:164:15:164:20 | access to local variable sink23 | semmle.label | access to local variable sink23 |
+| GlobalDataFlow.cs:179:35:179:48 | "taint source" | semmle.label | "taint source" |
+| GlobalDataFlow.cs:180:21:180:26 | delegate call | semmle.label | delegate call |
+| GlobalDataFlow.cs:181:15:181:19 | access to local variable sink9 | semmle.label | access to local variable sink9 |
+| GlobalDataFlow.cs:189:39:189:41 | [output] delegate creation of type Func<String> | semmle.label | [output] delegate creation of type Func<String> |
+| GlobalDataFlow.cs:190:15:190:20 | access to local variable sink10 | semmle.label | access to local variable sink10 |
+| GlobalDataFlow.cs:197:22:197:32 | access to property OutProperty | semmle.label | access to property OutProperty |
+| GlobalDataFlow.cs:198:15:198:20 | access to local variable sink19 | semmle.label | access to local variable sink19 |
+| GlobalDataFlow.cs:205:39:205:45 | tainted | semmle.label | tainted |
+| GlobalDataFlow.cs:208:35:208:45 | sinkParam10 | semmle.label | sinkParam10 |
+| GlobalDataFlow.cs:208:58:208:68 | access to parameter sinkParam10 | semmle.label | access to parameter sinkParam10 |
+| GlobalDataFlow.cs:209:71:209:71 | x | semmle.label | x |
+| GlobalDataFlow.cs:209:89:209:89 | access to parameter x | semmle.label | access to parameter x |
+| GlobalDataFlow.cs:210:22:210:28 | access to parameter tainted | semmle.label | access to parameter tainted |
+| GlobalDataFlow.cs:210:37:210:38 | [output] access to local variable f1 | semmle.label | [output] access to local variable f1 |
+| GlobalDataFlow.cs:211:15:211:20 | access to local variable sink24 | semmle.label | access to local variable sink24 |
+| GlobalDataFlow.cs:212:22:212:28 | access to parameter tainted | semmle.label | access to parameter tainted |
+| GlobalDataFlow.cs:212:37:212:38 | [output] access to local variable f2 | semmle.label | [output] access to local variable f2 |
+| GlobalDataFlow.cs:213:15:213:20 | access to local variable sink25 | semmle.label | access to local variable sink25 |
+| GlobalDataFlow.cs:214:22:214:28 | access to parameter tainted | semmle.label | access to parameter tainted |
+| GlobalDataFlow.cs:214:37:214:48 | [output] delegate creation of type Func<String,String> | semmle.label | [output] delegate creation of type Func<String,String> |
+| GlobalDataFlow.cs:215:15:215:20 | access to local variable sink26 | semmle.label | access to local variable sink26 |
+| GlobalDataFlow.cs:234:26:234:35 | sinkParam0 | semmle.label | sinkParam0 |
+| GlobalDataFlow.cs:236:16:236:25 | access to parameter sinkParam0 | semmle.label | access to parameter sinkParam0 |
+| GlobalDataFlow.cs:237:15:237:24 | access to parameter sinkParam0 | semmle.label | access to parameter sinkParam0 |
+| GlobalDataFlow.cs:240:26:240:35 | sinkParam1 | semmle.label | sinkParam1 |
+| GlobalDataFlow.cs:242:15:242:24 | access to parameter sinkParam1 | semmle.label | access to parameter sinkParam1 |
+| GlobalDataFlow.cs:245:26:245:35 | sinkParam3 | semmle.label | sinkParam3 |
+| GlobalDataFlow.cs:247:15:247:24 | access to parameter sinkParam3 | semmle.label | access to parameter sinkParam3 |
+| GlobalDataFlow.cs:250:26:250:35 | sinkParam4 | semmle.label | sinkParam4 |
+| GlobalDataFlow.cs:252:15:252:24 | access to parameter sinkParam4 | semmle.label | access to parameter sinkParam4 |
+| GlobalDataFlow.cs:255:26:255:35 | sinkParam5 | semmle.label | sinkParam5 |
+| GlobalDataFlow.cs:257:15:257:24 | access to parameter sinkParam5 | semmle.label | access to parameter sinkParam5 |
+| GlobalDataFlow.cs:260:26:260:35 | sinkParam6 | semmle.label | sinkParam6 |
+| GlobalDataFlow.cs:262:15:262:24 | access to parameter sinkParam6 | semmle.label | access to parameter sinkParam6 |
+| GlobalDataFlow.cs:265:26:265:35 | sinkParam7 | semmle.label | sinkParam7 |
+| GlobalDataFlow.cs:267:15:267:24 | access to parameter sinkParam7 | semmle.label | access to parameter sinkParam7 |
+| GlobalDataFlow.cs:292:31:292:40 | sinkParam8 | semmle.label | sinkParam8 |
+| GlobalDataFlow.cs:294:15:294:24 | access to parameter sinkParam8 | semmle.label | access to parameter sinkParam8 |
+| GlobalDataFlow.cs:298:32:298:41 | sinkParam9 | semmle.label | sinkParam9 |
+| GlobalDataFlow.cs:300:15:300:24 | access to parameter sinkParam9 | semmle.label | access to parameter sinkParam9 |
+| GlobalDataFlow.cs:304:32:304:42 | sinkParam11 | semmle.label | sinkParam11 |
+| GlobalDataFlow.cs:306:15:306:25 | access to parameter sinkParam11 | semmle.label | access to parameter sinkParam11 |
+| GlobalDataFlow.cs:318:16:318:29 | "taint source" | semmle.label | "taint source" |
+| GlobalDataFlow.cs:323:9:323:26 | SSA def(x) | semmle.label | SSA def(x) |
+| GlobalDataFlow.cs:323:13:323:26 | "taint source" | semmle.label | "taint source" |
+| GlobalDataFlow.cs:328:9:328:26 | SSA def(x) | semmle.label | SSA def(x) |
+| GlobalDataFlow.cs:328:13:328:26 | "taint source" | semmle.label | "taint source" |
+| GlobalDataFlow.cs:334:22:334:35 | "taint source" | semmle.label | "taint source" |
+| GlobalDataFlow.cs:334:22:334:35 | "taint source" | semmle.label | "taint source" |
+| GlobalDataFlow.cs:359:41:359:41 | x | semmle.label | x |
+| GlobalDataFlow.cs:359:41:359:41 | x | semmle.label | x |
+| GlobalDataFlow.cs:361:11:361:11 | access to parameter x | semmle.label | access to parameter x |
+| GlobalDataFlow.cs:361:11:361:11 | access to parameter x | semmle.label | access to parameter x |
+| GlobalDataFlow.cs:373:52:373:52 | x | semmle.label | x |
+| GlobalDataFlow.cs:373:52:373:52 | x | semmle.label | x |
+| GlobalDataFlow.cs:373:52:373:52 | x | semmle.label | x |
+| GlobalDataFlow.cs:375:11:375:11 | access to parameter x | semmle.label | access to parameter x |
+| GlobalDataFlow.cs:375:11:375:11 | access to parameter x | semmle.label | access to parameter x |
+| GlobalDataFlow.cs:375:11:375:11 | access to parameter x | semmle.label | access to parameter x |
+| GlobalDataFlow.cs:378:39:378:45 | tainted | semmle.label | tainted |
+| GlobalDataFlow.cs:381:15:381:20 | access to local variable sink11 | semmle.label | access to local variable sink11 |
+| GlobalDataFlow.cs:382:16:382:21 | access to local variable sink11 | semmle.label | access to local variable sink11 |
+| GlobalDataFlow.cs:404:9:404:11 | value | semmle.label | value |
+| GlobalDataFlow.cs:404:41:404:46 | access to local variable sink20 | semmle.label | access to local variable sink20 |
+| GlobalDataFlow.cs:415:22:415:35 | "taint source" | semmle.label | "taint source" |
+| Splitting.cs:3:28:3:34 | tainted | semmle.label | tainted |
+| Splitting.cs:8:17:8:31 | [b (line 3): false] call to method Return | semmle.label | [b (line 3): false] call to method Return |
+| Splitting.cs:8:17:8:31 | [b (line 3): true] call to method Return | semmle.label | [b (line 3): true] call to method Return |
+| Splitting.cs:8:24:8:30 | [b (line 3): false] access to parameter tainted | semmle.label | [b (line 3): false] access to parameter tainted |
+| Splitting.cs:8:24:8:30 | [b (line 3): true] access to parameter tainted | semmle.label | [b (line 3): true] access to parameter tainted |
+| Splitting.cs:9:15:9:15 | [b (line 3): false] access to local variable x | semmle.label | [b (line 3): false] access to local variable x |
+| Splitting.cs:9:15:9:15 | [b (line 3): true] access to local variable x | semmle.label | [b (line 3): true] access to local variable x |
+| Splitting.cs:11:19:11:19 | access to local variable x | semmle.label | access to local variable x |
+| Splitting.cs:21:9:21:11 | value | semmle.label | value |
+| Splitting.cs:21:28:21:32 | access to parameter value | semmle.label | access to parameter value |
+| Splitting.cs:24:28:24:34 | tainted | semmle.label | tainted |
+| Splitting.cs:30:17:30:23 | [b (line 24): false] access to parameter tainted | semmle.label | [b (line 24): false] access to parameter tainted |
+| Splitting.cs:30:17:30:23 | [b (line 24): true] access to parameter tainted | semmle.label | [b (line 24): true] access to parameter tainted |
+| Splitting.cs:31:17:31:26 | [b (line 24): false] dynamic access to element | semmle.label | [b (line 24): false] dynamic access to element |
+| Splitting.cs:31:17:31:26 | [b (line 24): true] dynamic access to element | semmle.label | [b (line 24): true] dynamic access to element |
+| Splitting.cs:31:19:31:25 | [b (line 24): false] access to parameter tainted | semmle.label | [b (line 24): false] access to parameter tainted |
+| Splitting.cs:31:19:31:25 | [b (line 24): true] access to parameter tainted | semmle.label | [b (line 24): true] access to parameter tainted |
+| Splitting.cs:32:15:32:15 | [b (line 24): false] access to local variable x | semmle.label | [b (line 24): false] access to local variable x |
+| Splitting.cs:32:15:32:15 | [b (line 24): true] access to local variable x | semmle.label | [b (line 24): true] access to local variable x |
+| Splitting.cs:34:19:34:19 | access to local variable x | semmle.label | access to local variable x |
 #select
 | Capture.cs:12:19:12:24 | access to local variable sink27 | Capture.cs:7:20:7:26 | tainted | Capture.cs:12:19:12:24 | access to local variable sink27 | access to local variable sink27 |
 | Capture.cs:21:23:21:28 | access to local variable sink28 | Capture.cs:7:20:7:26 | tainted | Capture.cs:21:23:21:28 | access to local variable sink28 | access to local variable sink28 |

--- a/csharp/ql/test/query-tests/Likely Bugs/UnsafeYearConstruction/UnsafeYearConstruction.expected
+++ b/csharp/ql/test/query-tests/Likely Bugs/UnsafeYearConstruction/UnsafeYearConstruction.expected
@@ -3,6 +3,14 @@ edges
 | Program.cs:15:27:15:38 | ... + ... | Program.cs:17:37:17:43 | access to local variable endYear |
 | Program.cs:23:31:23:34 | year | Program.cs:26:39:26:42 | access to parameter year |
 | Program.cs:33:18:33:29 | ... - ... | Program.cs:23:31:23:34 | year |
+nodes
+| Program.cs:13:39:13:50 | ... - ... | semmle.label | ... - ... |
+| Program.cs:13:39:13:50 | ... - ... | semmle.label | ... - ... |
+| Program.cs:15:27:15:38 | ... + ... | semmle.label | ... + ... |
+| Program.cs:17:37:17:43 | access to local variable endYear | semmle.label | access to local variable endYear |
+| Program.cs:23:31:23:34 | year | semmle.label | year |
+| Program.cs:26:39:26:42 | access to parameter year | semmle.label | access to parameter year |
+| Program.cs:33:18:33:29 | ... - ... | semmle.label | ... - ... |
 #select
 | Program.cs:13:39:13:50 | ... - ... | Program.cs:13:39:13:50 | ... - ... | Program.cs:13:39:13:50 | ... - ... | This $@ based on a 'System.DateTime.Year' property is used in a construction of a new 'System.DateTime' object, flowing to the 'year' argument. | Program.cs:13:39:13:50 | ... - ... | arithmetic operation |
 | Program.cs:17:37:17:43 | access to local variable endYear | Program.cs:15:27:15:38 | ... + ... | Program.cs:17:37:17:43 | access to local variable endYear | This $@ based on a 'System.DateTime.Year' property is used in a construction of a new 'System.DateTime' object, flowing to the 'year' argument. | Program.cs:15:27:15:38 | ... + ... | arithmetic operation |

--- a/csharp/ql/test/query-tests/Security Features/CWE-022/TaintedPath/TaintedPath.expected
+++ b/csharp/ql/test/query-tests/Security Features/CWE-022/TaintedPath/TaintedPath.expected
@@ -6,6 +6,15 @@ edges
 | TaintedPath.cs:12:23:12:45 | access to property QueryString | TaintedPath.cs:38:25:38:31 | access to local variable badPath |
 | TaintedPath.cs:12:23:12:45 | access to property QueryString | TaintedPath.cs:40:49:40:55 | access to local variable badPath |
 | TaintedPath.cs:12:23:12:45 | access to property QueryString | TaintedPath.cs:53:26:53:29 | access to local variable path |
+nodes
+| TaintedPath.cs:12:23:12:45 | access to property QueryString | semmle.label | access to property QueryString |
+| TaintedPath.cs:14:50:14:53 | access to local variable path | semmle.label | access to local variable path |
+| TaintedPath.cs:19:51:19:54 | access to local variable path | semmle.label | access to local variable path |
+| TaintedPath.cs:27:30:27:33 | access to local variable path | semmle.label | access to local variable path |
+| TaintedPath.cs:33:30:33:33 | access to local variable path | semmle.label | access to local variable path |
+| TaintedPath.cs:38:25:38:31 | access to local variable badPath | semmle.label | access to local variable badPath |
+| TaintedPath.cs:40:49:40:55 | access to local variable badPath | semmle.label | access to local variable badPath |
+| TaintedPath.cs:53:26:53:29 | access to local variable path | semmle.label | access to local variable path |
 #select
 | TaintedPath.cs:14:50:14:53 | access to local variable path | TaintedPath.cs:12:23:12:45 | access to property QueryString | TaintedPath.cs:14:50:14:53 | access to local variable path | $@ flows to here and is used in a path. | TaintedPath.cs:12:23:12:45 | access to property QueryString | User-provided value |
 | TaintedPath.cs:19:51:19:54 | access to local variable path | TaintedPath.cs:12:23:12:45 | access to property QueryString | TaintedPath.cs:19:51:19:54 | access to local variable path | $@ flows to here and is used in a path. | TaintedPath.cs:12:23:12:45 | access to property QueryString | User-provided value |

--- a/csharp/ql/test/query-tests/Security Features/CWE-022/ZipSlip/ZipSlip.expected
+++ b/csharp/ql/test/query-tests/Security Features/CWE-022/ZipSlip/ZipSlip.expected
@@ -8,6 +8,20 @@ edges
 | ZipSlip.cs:62:72:62:85 | access to property FullName | ZipSlip.cs:83:57:83:68 | access to local variable destFilePath |
 | ZipSlip.cs:62:72:62:85 | access to property FullName | ZipSlip.cs:91:58:91:69 | access to local variable destFilePath |
 | ZipSlipBad.cs:9:59:9:72 | access to property FullName | ZipSlipBad.cs:10:29:10:40 | access to local variable destFileName |
+nodes
+| ZipSlip.cs:16:52:16:65 | access to property FullName | semmle.label | access to property FullName |
+| ZipSlip.cs:19:31:19:44 | access to property FullName | semmle.label | access to property FullName |
+| ZipSlip.cs:24:41:24:52 | access to local variable destFileName | semmle.label | access to local variable destFileName |
+| ZipSlip.cs:32:41:32:52 | access to local variable destFilePath | semmle.label | access to local variable destFilePath |
+| ZipSlip.cs:36:45:36:56 | access to local variable destFilePath | semmle.label | access to local variable destFilePath |
+| ZipSlip.cs:40:41:40:52 | access to local variable destFilePath | semmle.label | access to local variable destFilePath |
+| ZipSlip.cs:62:72:62:85 | access to property FullName | semmle.label | access to property FullName |
+| ZipSlip.cs:69:74:69:85 | access to local variable destFilePath | semmle.label | access to local variable destFilePath |
+| ZipSlip.cs:76:71:76:82 | access to local variable destFilePath | semmle.label | access to local variable destFilePath |
+| ZipSlip.cs:83:57:83:68 | access to local variable destFilePath | semmle.label | access to local variable destFilePath |
+| ZipSlip.cs:91:58:91:69 | access to local variable destFilePath | semmle.label | access to local variable destFilePath |
+| ZipSlipBad.cs:9:59:9:72 | access to property FullName | semmle.label | access to property FullName |
+| ZipSlipBad.cs:10:29:10:40 | access to local variable destFileName | semmle.label | access to local variable destFileName |
 #select
 | ZipSlip.cs:24:41:24:52 | access to local variable destFileName | ZipSlip.cs:19:31:19:44 | access to property FullName | ZipSlip.cs:24:41:24:52 | access to local variable destFileName | Unsanitized zip archive $@, which may contain '..', is used in a file system operation. | ZipSlip.cs:19:31:19:44 | access to property FullName | item path |
 | ZipSlip.cs:32:41:32:52 | access to local variable destFilePath | ZipSlip.cs:16:52:16:65 | access to property FullName | ZipSlip.cs:32:41:32:52 | access to local variable destFilePath | Unsanitized zip archive $@, which may contain '..', is used in a file system operation. | ZipSlip.cs:16:52:16:65 | access to property FullName | item path |

--- a/csharp/ql/test/query-tests/Security Features/CWE-078/CommandInjection.expected
+++ b/csharp/ql/test/query-tests/Security Features/CWE-078/CommandInjection.expected
@@ -6,6 +6,15 @@ edges
 | CommandInjection.cs:25:32:25:46 | access to field categoryTextBox | CommandInjection.cs:32:39:32:47 | access to local variable userInput |
 | CommandInjection.cs:25:32:25:46 | access to field categoryTextBox | CommandInjection.cs:33:40:33:48 | access to local variable userInput |
 | CommandInjection.cs:25:32:25:46 | access to field categoryTextBox | CommandInjection.cs:34:47:34:55 | access to local variable userInput |
+nodes
+| CommandInjection.cs:25:32:25:46 | access to field categoryTextBox | semmle.label | access to field categoryTextBox |
+| CommandInjection.cs:26:27:26:47 | ... + ... | semmle.label | ... + ... |
+| CommandInjection.cs:26:50:26:66 | ... + ... | semmle.label | ... + ... |
+| CommandInjection.cs:28:63:28:71 | access to local variable userInput | semmle.label | access to local variable userInput |
+| CommandInjection.cs:28:74:28:82 | access to local variable userInput | semmle.label | access to local variable userInput |
+| CommandInjection.cs:32:39:32:47 | access to local variable userInput | semmle.label | access to local variable userInput |
+| CommandInjection.cs:33:40:33:48 | access to local variable userInput | semmle.label | access to local variable userInput |
+| CommandInjection.cs:34:47:34:55 | access to local variable userInput | semmle.label | access to local variable userInput |
 #select
 | CommandInjection.cs:26:27:26:47 | ... + ... | CommandInjection.cs:25:32:25:46 | access to field categoryTextBox | CommandInjection.cs:26:27:26:47 | ... + ... | $@ flows to here and is used in a command. | CommandInjection.cs:25:32:25:46 | access to field categoryTextBox | User-provided value |
 | CommandInjection.cs:26:50:26:66 | ... + ... | CommandInjection.cs:25:32:25:46 | access to field categoryTextBox | CommandInjection.cs:26:50:26:66 | ... + ... | $@ flows to here and is used in a command. | CommandInjection.cs:25:32:25:46 | access to field categoryTextBox | User-provided value |

--- a/csharp/ql/test/query-tests/Security Features/CWE-078/StoredCommandInjection.expected
+++ b/csharp/ql/test/query-tests/Security Features/CWE-078/StoredCommandInjection.expected
@@ -1,4 +1,7 @@
 edges
 | StoredCommandInjection.cs:24:54:24:80 | call to method GetString | StoredCommandInjection.cs:24:46:24:80 | ... + ... |
+nodes
+| StoredCommandInjection.cs:24:46:24:80 | ... + ... | semmle.label | ... + ... |
+| StoredCommandInjection.cs:24:54:24:80 | call to method GetString | semmle.label | call to method GetString |
 #select
 | StoredCommandInjection.cs:24:46:24:80 | ... + ... | StoredCommandInjection.cs:24:54:24:80 | call to method GetString | StoredCommandInjection.cs:24:46:24:80 | ... + ... | $@ flows to here and is used in a command. | StoredCommandInjection.cs:24:54:24:80 | call to method GetString | Stored user-provided value |

--- a/csharp/ql/test/query-tests/Security Features/CWE-079/StoredXSS/StoredXSS.expected
+++ b/csharp/ql/test/query-tests/Security Features/CWE-079/StoredXSS/StoredXSS.expected
@@ -1,4 +1,7 @@
 edges
 | StoredXSS.cs:24:60:24:86 | call to method GetString | StoredXSS.cs:24:44:24:86 | ... + ... |
+nodes
+| StoredXSS.cs:24:44:24:86 | ... + ... | semmle.label | ... + ... |
+| StoredXSS.cs:24:60:24:86 | call to method GetString | semmle.label | call to method GetString |
 #select
 | StoredXSS.cs:24:44:24:86 | ... + ... | StoredXSS.cs:24:60:24:86 | call to method GetString | StoredXSS.cs:24:44:24:86 | ... + ... | $@ flows to here and is written to HTML or JavaScript. | StoredXSS.cs:24:60:24:86 | call to method GetString | Stored user-provided value |

--- a/csharp/ql/test/query-tests/Security Features/CWE-089/SecondOrderSqlInjection.expected
+++ b/csharp/ql/test/query-tests/Security Features/CWE-089/SecondOrderSqlInjection.expected
@@ -1,4 +1,7 @@
 edges
 | SecondOrderSqlInjection.cs:21:119:21:145 | call to method GetString | SecondOrderSqlInjection.cs:21:71:21:145 | ... + ... |
+nodes
+| SecondOrderSqlInjection.cs:21:71:21:145 | ... + ... | semmle.label | ... + ... |
+| SecondOrderSqlInjection.cs:21:119:21:145 | call to method GetString | semmle.label | call to method GetString |
 #select
 | SecondOrderSqlInjection.cs:21:71:21:145 | ... + ... | SecondOrderSqlInjection.cs:21:119:21:145 | call to method GetString | SecondOrderSqlInjection.cs:21:71:21:145 | ... + ... | $@ flows to here and is used in an SQL query. | SecondOrderSqlInjection.cs:21:119:21:145 | call to method GetString | Stored user-provided value |

--- a/csharp/ql/test/query-tests/Security Features/CWE-089/SqlInjection.expected
+++ b/csharp/ql/test/query-tests/Security Features/CWE-089/SqlInjection.expected
@@ -3,6 +3,14 @@ edges
 | SqlInjection.cs:73:33:73:47 | access to field categoryTextBox | SqlInjection.cs:74:56:74:61 | access to local variable query1 |
 | SqlInjection.cs:73:33:73:47 | access to field categoryTextBox | SqlInjection.cs:75:55:75:60 | access to local variable query1 |
 | SqlInjection.cs:87:21:87:29 | access to property Text | SqlInjection.cs:88:50:88:55 | access to local variable query1 |
+nodes
+| SqlInjection.cs:38:21:38:35 | access to field categoryTextBox | semmle.label | access to field categoryTextBox |
+| SqlInjection.cs:39:50:39:55 | access to local variable query1 | semmle.label | access to local variable query1 |
+| SqlInjection.cs:73:33:73:47 | access to field categoryTextBox | semmle.label | access to field categoryTextBox |
+| SqlInjection.cs:74:56:74:61 | access to local variable query1 | semmle.label | access to local variable query1 |
+| SqlInjection.cs:75:55:75:60 | access to local variable query1 | semmle.label | access to local variable query1 |
+| SqlInjection.cs:87:21:87:29 | access to property Text | semmle.label | access to property Text |
+| SqlInjection.cs:88:50:88:55 | access to local variable query1 | semmle.label | access to local variable query1 |
 #select
 | SqlInjection.cs:39:50:39:55 | access to local variable query1 | SqlInjection.cs:38:21:38:35 | access to field categoryTextBox | SqlInjection.cs:39:50:39:55 | access to local variable query1 | Query might include code from $@. | SqlInjection.cs:38:21:38:35 | access to field categoryTextBox | this ASP.NET user input |
 | SqlInjection.cs:74:56:74:61 | access to local variable query1 | SqlInjection.cs:73:33:73:47 | access to field categoryTextBox | SqlInjection.cs:74:56:74:61 | access to local variable query1 | Query might include code from $@. | SqlInjection.cs:73:33:73:47 | access to field categoryTextBox | this ASP.NET user input |

--- a/csharp/ql/test/query-tests/Security Features/CWE-090/LDAPInjection.expected
+++ b/csharp/ql/test/query-tests/Security Features/CWE-090/LDAPInjection.expected
@@ -5,6 +5,14 @@ edges
 | LDAPInjection.cs:13:27:13:49 | access to property QueryString | LDAPInjection.cs:26:53:26:77 | ... + ... |
 | LDAPInjection.cs:13:27:13:49 | access to property QueryString | LDAPInjection.cs:29:48:29:70 | ... + ... |
 | LDAPInjection.cs:13:27:13:49 | access to property QueryString | LDAPInjection.cs:31:20:31:42 | ... + ... |
+nodes
+| LDAPInjection.cs:13:27:13:49 | access to property QueryString | semmle.label | access to property QueryString |
+| LDAPInjection.cs:16:54:16:78 | ... + ... | semmle.label | ... + ... |
+| LDAPInjection.cs:18:21:18:45 | ... + ... | semmle.label | ... + ... |
+| LDAPInjection.cs:25:21:25:45 | ... + ... | semmle.label | ... + ... |
+| LDAPInjection.cs:26:53:26:77 | ... + ... | semmle.label | ... + ... |
+| LDAPInjection.cs:29:48:29:70 | ... + ... | semmle.label | ... + ... |
+| LDAPInjection.cs:31:20:31:42 | ... + ... | semmle.label | ... + ... |
 #select
 | LDAPInjection.cs:16:54:16:78 | ... + ... | LDAPInjection.cs:13:27:13:49 | access to property QueryString | LDAPInjection.cs:16:54:16:78 | ... + ... | $@ flows to here and is used in an LDAP query. | LDAPInjection.cs:13:27:13:49 | access to property QueryString | User-provided value |
 | LDAPInjection.cs:18:21:18:45 | ... + ... | LDAPInjection.cs:13:27:13:49 | access to property QueryString | LDAPInjection.cs:18:21:18:45 | ... + ... | $@ flows to here and is used in an LDAP query. | LDAPInjection.cs:13:27:13:49 | access to property QueryString | User-provided value |

--- a/csharp/ql/test/query-tests/Security Features/CWE-090/StoredLDAPInjection.expected
+++ b/csharp/ql/test/query-tests/Security Features/CWE-090/StoredLDAPInjection.expected
@@ -1,4 +1,7 @@
 edges
 | StoredLDAPInjection.cs:24:83:24:109 | call to method GetString | StoredLDAPInjection.cs:24:66:24:109 | ... + ... |
+nodes
+| StoredLDAPInjection.cs:24:66:24:109 | ... + ... | semmle.label | ... + ... |
+| StoredLDAPInjection.cs:24:83:24:109 | call to method GetString | semmle.label | call to method GetString |
 #select
 | StoredLDAPInjection.cs:24:66:24:109 | ... + ... | StoredLDAPInjection.cs:24:83:24:109 | call to method GetString | StoredLDAPInjection.cs:24:66:24:109 | ... + ... | $@ flows to here and is used in an LDAP query. | StoredLDAPInjection.cs:24:83:24:109 | call to method GetString | Stored user-provided value |

--- a/csharp/ql/test/query-tests/Security Features/CWE-094/CodeInjection.expected
+++ b/csharp/ql/test/query-tests/Security Features/CWE-094/CodeInjection.expected
@@ -2,6 +2,12 @@ edges
 | CodeInjection.cs:25:23:25:45 | access to property QueryString | CodeInjection.cs:31:64:31:67 | access to local variable code |
 | CodeInjection.cs:25:23:25:45 | access to property QueryString | CodeInjection.cs:42:36:42:39 | access to local variable code |
 | CodeInjection.cs:58:36:58:44 | access to property Text | CodeInjection.cs:58:36:58:44 | access to property Text |
+nodes
+| CodeInjection.cs:25:23:25:45 | access to property QueryString | semmle.label | access to property QueryString |
+| CodeInjection.cs:31:64:31:67 | access to local variable code | semmle.label | access to local variable code |
+| CodeInjection.cs:42:36:42:39 | access to local variable code | semmle.label | access to local variable code |
+| CodeInjection.cs:58:36:58:44 | access to property Text | semmle.label | access to property Text |
+| CodeInjection.cs:58:36:58:44 | access to property Text | semmle.label | access to property Text |
 #select
 | CodeInjection.cs:31:64:31:67 | access to local variable code | CodeInjection.cs:25:23:25:45 | access to property QueryString | CodeInjection.cs:31:64:31:67 | access to local variable code | $@ flows to here and is compiled as code. | CodeInjection.cs:25:23:25:45 | access to property QueryString | User-provided value |
 | CodeInjection.cs:42:36:42:39 | access to local variable code | CodeInjection.cs:25:23:25:45 | access to property QueryString | CodeInjection.cs:42:36:42:39 | access to local variable code | $@ flows to here and is compiled as code. | CodeInjection.cs:25:23:25:45 | access to property QueryString | User-provided value |

--- a/csharp/ql/test/query-tests/Security Features/CWE-099/ResourceInjection.expected
+++ b/csharp/ql/test/query-tests/Security Features/CWE-099/ResourceInjection.expected
@@ -1,6 +1,10 @@
 edges
 | ResourceInjection.cs:10:27:10:49 | access to property QueryString | ResourceInjection.cs:13:57:13:72 | access to local variable connectionString |
 | ResourceInjection.cs:10:27:10:49 | access to property QueryString | ResourceInjection.cs:15:42:15:57 | access to local variable connectionString |
+nodes
+| ResourceInjection.cs:10:27:10:49 | access to property QueryString | semmle.label | access to property QueryString |
+| ResourceInjection.cs:13:57:13:72 | access to local variable connectionString | semmle.label | access to local variable connectionString |
+| ResourceInjection.cs:15:42:15:57 | access to local variable connectionString | semmle.label | access to local variable connectionString |
 #select
 | ResourceInjection.cs:13:57:13:72 | access to local variable connectionString | ResourceInjection.cs:10:27:10:49 | access to property QueryString | ResourceInjection.cs:13:57:13:72 | access to local variable connectionString | $@ flows to here and is used in a resource descriptor. | ResourceInjection.cs:10:27:10:49 | access to property QueryString | User-provided value |
 | ResourceInjection.cs:15:42:15:57 | access to local variable connectionString | ResourceInjection.cs:10:27:10:49 | access to property QueryString | ResourceInjection.cs:15:42:15:57 | access to local variable connectionString | $@ flows to here and is used in a resource descriptor. | ResourceInjection.cs:10:27:10:49 | access to property QueryString | User-provided value |

--- a/csharp/ql/test/query-tests/Security Features/CWE-112/MissingXMLValidation.expected
+++ b/csharp/ql/test/query-tests/Security Features/CWE-112/MissingXMLValidation.expected
@@ -4,6 +4,13 @@ edges
 | MissingXMLValidation.cs:14:34:14:56 | access to property QueryString | MissingXMLValidation.cs:29:26:29:58 | object creation of type StringReader |
 | MissingXMLValidation.cs:14:34:14:56 | access to property QueryString | MissingXMLValidation.cs:37:26:37:58 | object creation of type StringReader |
 | MissingXMLValidation.cs:14:34:14:56 | access to property QueryString | MissingXMLValidation.cs:47:26:47:58 | object creation of type StringReader |
+nodes
+| MissingXMLValidation.cs:14:34:14:56 | access to property QueryString | semmle.label | access to property QueryString |
+| MissingXMLValidation.cs:18:26:18:58 | object creation of type StringReader | semmle.label | object creation of type StringReader |
+| MissingXMLValidation.cs:23:26:23:58 | object creation of type StringReader | semmle.label | object creation of type StringReader |
+| MissingXMLValidation.cs:29:26:29:58 | object creation of type StringReader | semmle.label | object creation of type StringReader |
+| MissingXMLValidation.cs:37:26:37:58 | object creation of type StringReader | semmle.label | object creation of type StringReader |
+| MissingXMLValidation.cs:47:26:47:58 | object creation of type StringReader | semmle.label | object creation of type StringReader |
 #select
 | MissingXMLValidation.cs:18:26:18:58 | object creation of type StringReader | MissingXMLValidation.cs:14:34:14:56 | access to property QueryString | MissingXMLValidation.cs:18:26:18:58 | object creation of type StringReader | $@ flows to here and is processed as XML without validation because there is no 'XmlReaderSettings' instance specifying schema validation. | MissingXMLValidation.cs:14:34:14:56 | access to property QueryString | User-provided value |
 | MissingXMLValidation.cs:23:26:23:58 | object creation of type StringReader | MissingXMLValidation.cs:14:34:14:56 | access to property QueryString | MissingXMLValidation.cs:23:26:23:58 | object creation of type StringReader | $@ flows to here and is processed as XML without validation because the 'XmlReaderSettings' instance does not specify the 'ValidationType' as 'Schema'. | MissingXMLValidation.cs:14:34:14:56 | access to property QueryString | User-provided value |

--- a/csharp/ql/test/query-tests/Security Features/CWE-117/LogForging.expected
+++ b/csharp/ql/test/query-tests/Security Features/CWE-117/LogForging.expected
@@ -1,6 +1,10 @@
 edges
 | LogForging.cs:19:27:19:49 | access to property QueryString | LogForging.cs:22:21:22:43 | ... + ... |
 | LogForging.cs:19:27:19:49 | access to property QueryString | LogForging.cs:28:50:28:72 | ... + ... |
+nodes
+| LogForging.cs:19:27:19:49 | access to property QueryString | semmle.label | access to property QueryString |
+| LogForging.cs:22:21:22:43 | ... + ... | semmle.label | ... + ... |
+| LogForging.cs:28:50:28:72 | ... + ... | semmle.label | ... + ... |
 #select
 | LogForging.cs:22:21:22:43 | ... + ... | LogForging.cs:19:27:19:49 | access to property QueryString | LogForging.cs:22:21:22:43 | ... + ... | $@ flows to log entry. | LogForging.cs:19:27:19:49 | access to property QueryString | User-provided value |
 | LogForging.cs:28:50:28:72 | ... + ... | LogForging.cs:19:27:19:49 | access to property QueryString | LogForging.cs:28:50:28:72 | ... + ... | $@ flows to log entry. | LogForging.cs:19:27:19:49 | access to property QueryString | User-provided value |

--- a/csharp/ql/test/query-tests/Security Features/CWE-134/UncontrolledFormatString.expected
+++ b/csharp/ql/test/query-tests/Security Features/CWE-134/UncontrolledFormatString.expected
@@ -3,6 +3,14 @@ edges
 | UncontrolledFormatString.cs:11:23:11:45 | access to property QueryString | UncontrolledFormatString.cs:17:46:17:49 | access to local variable path |
 | UncontrolledFormatString.cs:31:23:31:31 | access to property Text | UncontrolledFormatString.cs:31:23:31:31 | access to property Text |
 | UncontrolledFormatStringBad.cs:9:25:9:47 | access to property QueryString | UncontrolledFormatStringBad.cs:12:39:12:44 | access to local variable format |
+nodes
+| UncontrolledFormatString.cs:11:23:11:45 | access to property QueryString | semmle.label | access to property QueryString |
+| UncontrolledFormatString.cs:14:23:14:26 | access to local variable path | semmle.label | access to local variable path |
+| UncontrolledFormatString.cs:17:46:17:49 | access to local variable path | semmle.label | access to local variable path |
+| UncontrolledFormatString.cs:31:23:31:31 | access to property Text | semmle.label | access to property Text |
+| UncontrolledFormatString.cs:31:23:31:31 | access to property Text | semmle.label | access to property Text |
+| UncontrolledFormatStringBad.cs:9:25:9:47 | access to property QueryString | semmle.label | access to property QueryString |
+| UncontrolledFormatStringBad.cs:12:39:12:44 | access to local variable format | semmle.label | access to local variable format |
 #select
 | UncontrolledFormatString.cs:14:23:14:26 | access to local variable path | UncontrolledFormatString.cs:11:23:11:45 | access to property QueryString | UncontrolledFormatString.cs:14:23:14:26 | access to local variable path | $@ flows to here and is used as a format string. | UncontrolledFormatString.cs:11:23:11:45 | access to property QueryString | access to property QueryString |
 | UncontrolledFormatString.cs:17:46:17:49 | access to local variable path | UncontrolledFormatString.cs:11:23:11:45 | access to property QueryString | UncontrolledFormatString.cs:17:46:17:49 | access to local variable path | $@ flows to here and is used as a format string. | UncontrolledFormatString.cs:11:23:11:45 | access to property QueryString | access to property QueryString |

--- a/csharp/ql/test/query-tests/Security Features/CWE-201/ExposureInTransmittedData/ExposureInTransmittedData.expected
+++ b/csharp/ql/test/query-tests/Security Features/CWE-201/ExposureInTransmittedData/ExposureInTransmittedData.expected
@@ -8,6 +8,22 @@ edges
 | ExposureInTransmittedData.cs:32:17:32:36 | call to method GetField | ExposureInTransmittedData.cs:33:56:33:56 | access to local variable p |
 | ExposureInTransmittedData.cs:32:17:32:36 | call to method GetField | ExposureInTransmittedData.cs:34:24:34:52 | ... + ... |
 | ExposureInTransmittedData.cs:32:17:32:36 | call to method GetField | ExposureInTransmittedData.cs:35:27:35:27 | access to local variable p |
+nodes
+| ExposureInTransmittedData.cs:16:32:16:39 | access to local variable password | semmle.label | access to local variable password |
+| ExposureInTransmittedData.cs:16:32:16:39 | access to local variable password | semmle.label | access to local variable password |
+| ExposureInTransmittedData.cs:20:32:20:44 | call to method ToString | semmle.label | call to method ToString |
+| ExposureInTransmittedData.cs:20:32:20:44 | call to method ToString | semmle.label | call to method ToString |
+| ExposureInTransmittedData.cs:24:32:24:41 | access to property Message | semmle.label | access to property Message |
+| ExposureInTransmittedData.cs:24:32:24:41 | access to property Message | semmle.label | access to property Message |
+| ExposureInTransmittedData.cs:25:32:25:44 | call to method ToString | semmle.label | call to method ToString |
+| ExposureInTransmittedData.cs:25:32:25:44 | call to method ToString | semmle.label | call to method ToString |
+| ExposureInTransmittedData.cs:26:32:26:38 | access to property Data | semmle.label | access to property Data |
+| ExposureInTransmittedData.cs:26:32:26:50 | access to indexer | semmle.label | access to indexer |
+| ExposureInTransmittedData.cs:32:17:32:36 | call to method GetField | semmle.label | call to method GetField |
+| ExposureInTransmittedData.cs:33:53:33:53 | access to local variable p | semmle.label | access to local variable p |
+| ExposureInTransmittedData.cs:33:56:33:56 | access to local variable p | semmle.label | access to local variable p |
+| ExposureInTransmittedData.cs:34:24:34:52 | ... + ... | semmle.label | ... + ... |
+| ExposureInTransmittedData.cs:35:27:35:27 | access to local variable p | semmle.label | access to local variable p |
 #select
 | ExposureInTransmittedData.cs:16:32:16:39 | access to local variable password | ExposureInTransmittedData.cs:16:32:16:39 | access to local variable password | ExposureInTransmittedData.cs:16:32:16:39 | access to local variable password | Sensitive information from $@ flows to here, and is transmitted to the user. | ExposureInTransmittedData.cs:16:32:16:39 | access to local variable password | access to local variable password |
 | ExposureInTransmittedData.cs:20:32:20:44 | call to method ToString | ExposureInTransmittedData.cs:20:32:20:44 | call to method ToString | ExposureInTransmittedData.cs:20:32:20:44 | call to method ToString | Sensitive information from $@ flows to here, and is transmitted to the user. | ExposureInTransmittedData.cs:20:32:20:44 | call to method ToString | call to method ToString |

--- a/csharp/ql/test/query-tests/Security Features/CWE-209/ExceptionInformationExposure.expected
+++ b/csharp/ql/test/query-tests/Security Features/CWE-209/ExceptionInformationExposure.expected
@@ -5,6 +5,16 @@ edges
 | ExceptionInformationExposure.cs:20:32:20:33 | access to local variable ex | ExceptionInformationExposure.cs:20:32:20:33 | access to local variable ex |
 | ExceptionInformationExposure.cs:22:32:22:44 | access to property StackTrace | ExceptionInformationExposure.cs:22:32:22:44 | access to property StackTrace |
 | ExceptionInformationExposure.cs:41:28:41:55 | call to method ToString | ExceptionInformationExposure.cs:41:28:41:55 | call to method ToString |
+nodes
+| ExceptionInformationExposure.cs:18:32:18:33 | access to local variable ex | semmle.label | access to local variable ex |
+| ExceptionInformationExposure.cs:18:32:18:44 | call to method ToString | semmle.label | call to method ToString |
+| ExceptionInformationExposure.cs:18:32:18:44 | call to method ToString | semmle.label | call to method ToString |
+| ExceptionInformationExposure.cs:20:32:20:33 | access to local variable ex | semmle.label | access to local variable ex |
+| ExceptionInformationExposure.cs:20:32:20:33 | access to local variable ex | semmle.label | access to local variable ex |
+| ExceptionInformationExposure.cs:22:32:22:44 | access to property StackTrace | semmle.label | access to property StackTrace |
+| ExceptionInformationExposure.cs:22:32:22:44 | access to property StackTrace | semmle.label | access to property StackTrace |
+| ExceptionInformationExposure.cs:41:28:41:55 | call to method ToString | semmle.label | call to method ToString |
+| ExceptionInformationExposure.cs:41:28:41:55 | call to method ToString | semmle.label | call to method ToString |
 #select
 | ExceptionInformationExposure.cs:18:32:18:44 | call to method ToString | ExceptionInformationExposure.cs:18:32:18:44 | call to method ToString | ExceptionInformationExposure.cs:18:32:18:44 | call to method ToString | Exception information from $@ flows to here, and is exposed to the user. | ExceptionInformationExposure.cs:18:32:18:44 | call to method ToString | call to method ToString |
 | ExceptionInformationExposure.cs:20:32:20:33 | access to local variable ex | ExceptionInformationExposure.cs:18:32:18:33 | access to local variable ex | ExceptionInformationExposure.cs:20:32:20:33 | access to local variable ex | Exception information from $@ flows to here, and is exposed to the user. | ExceptionInformationExposure.cs:18:32:18:33 | access to local variable ex | access to local variable ex |

--- a/csharp/ql/test/query-tests/Security Features/CWE-312/CleartextStorage.expected
+++ b/csharp/ql/test/query-tests/Security Features/CWE-312/CleartextStorage.expected
@@ -7,6 +7,23 @@ edges
 | CleartextStorage.cs:73:21:73:33 | access to property Text | CleartextStorage.cs:73:21:73:33 | access to property Text |
 | CleartextStorage.cs:74:21:74:29 | access to property Text | CleartextStorage.cs:74:21:74:29 | access to property Text |
 | CleartextStorage.cs:75:21:75:29 | access to property Text | CleartextStorage.cs:75:21:75:29 | access to property Text |
+nodes
+| CleartextStorage.cs:14:50:14:59 | access to field accountKey | semmle.label | access to field accountKey |
+| CleartextStorage.cs:14:50:14:59 | access to field accountKey | semmle.label | access to field accountKey |
+| CleartextStorage.cs:15:62:15:74 | call to method GetPassword | semmle.label | call to method GetPassword |
+| CleartextStorage.cs:15:62:15:74 | call to method GetPassword | semmle.label | call to method GetPassword |
+| CleartextStorage.cs:16:69:16:81 | call to method GetPassword | semmle.label | call to method GetPassword |
+| CleartextStorage.cs:16:69:16:81 | call to method GetPassword | semmle.label | call to method GetPassword |
+| CleartextStorage.cs:17:50:17:63 | call to method GetAccountID | semmle.label | call to method GetAccountID |
+| CleartextStorage.cs:17:50:17:63 | call to method GetAccountID | semmle.label | call to method GetAccountID |
+| CleartextStorage.cs:25:21:25:33 | call to method GetPassword | semmle.label | call to method GetPassword |
+| CleartextStorage.cs:25:21:25:33 | call to method GetPassword | semmle.label | call to method GetPassword |
+| CleartextStorage.cs:73:21:73:33 | access to property Text | semmle.label | access to property Text |
+| CleartextStorage.cs:73:21:73:33 | access to property Text | semmle.label | access to property Text |
+| CleartextStorage.cs:74:21:74:29 | access to property Text | semmle.label | access to property Text |
+| CleartextStorage.cs:74:21:74:29 | access to property Text | semmle.label | access to property Text |
+| CleartextStorage.cs:75:21:75:29 | access to property Text | semmle.label | access to property Text |
+| CleartextStorage.cs:75:21:75:29 | access to property Text | semmle.label | access to property Text |
 #select
 | CleartextStorage.cs:14:50:14:59 | access to field accountKey | CleartextStorage.cs:14:50:14:59 | access to field accountKey | CleartextStorage.cs:14:50:14:59 | access to field accountKey | Sensitive data returned by $@ is stored here. | CleartextStorage.cs:14:50:14:59 | access to field accountKey | access to field accountKey |
 | CleartextStorage.cs:15:62:15:74 | call to method GetPassword | CleartextStorage.cs:15:62:15:74 | call to method GetPassword | CleartextStorage.cs:15:62:15:74 | call to method GetPassword | Sensitive data returned by $@ is stored here. | CleartextStorage.cs:15:62:15:74 | call to method GetPassword | call to method GetPassword |

--- a/csharp/ql/test/query-tests/Security Features/CWE-327/DontInstallRootCert/DontInstallRootCert.expected
+++ b/csharp/ql/test/query-tests/Security Features/CWE-327/DontInstallRootCert/DontInstallRootCert.expected
@@ -2,6 +2,13 @@ edges
 | Test.cs:17:31:17:59 | object creation of type X509Store | Test.cs:20:13:20:17 | access to local variable store |
 | Test.cs:27:31:27:86 | object creation of type X509Store | Test.cs:30:13:30:17 | access to local variable store |
 | Test.cs:72:31:72:86 | object creation of type X509Store | Test.cs:75:13:75:17 | access to local variable store |
+nodes
+| Test.cs:17:31:17:59 | object creation of type X509Store | semmle.label | object creation of type X509Store |
+| Test.cs:20:13:20:17 | access to local variable store | semmle.label | access to local variable store |
+| Test.cs:27:31:27:86 | object creation of type X509Store | semmle.label | object creation of type X509Store |
+| Test.cs:30:13:30:17 | access to local variable store | semmle.label | access to local variable store |
+| Test.cs:72:31:72:86 | object creation of type X509Store | semmle.label | object creation of type X509Store |
+| Test.cs:75:13:75:17 | access to local variable store | semmle.label | access to local variable store |
 #select
 | Test.cs:20:13:20:17 | access to local variable store | Test.cs:17:31:17:59 | object creation of type X509Store | Test.cs:20:13:20:17 | access to local variable store | Certificate added to the root certificate store. |
 | Test.cs:30:13:30:17 | access to local variable store | Test.cs:27:31:27:86 | object creation of type X509Store | Test.cs:30:13:30:17 | access to local variable store | Certificate added to the root certificate store. |

--- a/csharp/ql/test/query-tests/Security Features/CWE-338/InsecureRandomness.expected
+++ b/csharp/ql/test/query-tests/Security Features/CWE-338/InsecureRandomness.expected
@@ -6,6 +6,17 @@ edges
 | InsecureRandomness.cs:62:16:62:32 | call to method ToString | InsecureRandomness.cs:13:20:13:56 | call to method InsecureRandomStringFromSelection |
 | InsecureRandomness.cs:72:31:72:39 | call to method Next | InsecureRandomness.cs:74:16:74:21 | access to local variable result |
 | InsecureRandomness.cs:74:16:74:21 | access to local variable result | InsecureRandomness.cs:14:20:14:54 | call to method InsecureRandomStringFromIndexer |
+nodes
+| InsecureRandomness.cs:12:27:12:50 | call to method InsecureRandomString | semmle.label | call to method InsecureRandomString |
+| InsecureRandomness.cs:13:20:13:56 | call to method InsecureRandomStringFromSelection | semmle.label | call to method InsecureRandomStringFromSelection |
+| InsecureRandomness.cs:14:20:14:54 | call to method InsecureRandomStringFromIndexer | semmle.label | call to method InsecureRandomStringFromIndexer |
+| InsecureRandomness.cs:28:23:28:43 | (...) ... | semmle.label | (...) ... |
+| InsecureRandomness.cs:28:29:28:43 | call to method Next | semmle.label | call to method Next |
+| InsecureRandomness.cs:31:16:31:32 | call to method ToString | semmle.label | call to method ToString |
+| InsecureRandomness.cs:60:31:60:39 | call to method Next | semmle.label | call to method Next |
+| InsecureRandomness.cs:62:16:62:32 | call to method ToString | semmle.label | call to method ToString |
+| InsecureRandomness.cs:72:31:72:39 | call to method Next | semmle.label | call to method Next |
+| InsecureRandomness.cs:74:16:74:21 | access to local variable result | semmle.label | access to local variable result |
 #select
 | InsecureRandomness.cs:12:27:12:50 | call to method InsecureRandomString | InsecureRandomness.cs:28:29:28:43 | call to method Next | InsecureRandomness.cs:12:27:12:50 | call to method InsecureRandomString | Cryptographically insecure random number is generated at $@ and used here in a security context. | InsecureRandomness.cs:28:29:28:43 | call to method Next | call to method Next |
 | InsecureRandomness.cs:13:20:13:56 | call to method InsecureRandomStringFromSelection | InsecureRandomness.cs:60:31:60:39 | call to method Next | InsecureRandomness.cs:13:20:13:56 | call to method InsecureRandomStringFromSelection | Cryptographically insecure random number is generated at $@ and used here in a security context. | InsecureRandomness.cs:60:31:60:39 | call to method Next | call to method Next |

--- a/csharp/ql/test/query-tests/Security Features/CWE-359/ExposureOfPrivateInformation.expected
+++ b/csharp/ql/test/query-tests/Security Features/CWE-359/ExposureOfPrivateInformation.expected
@@ -3,6 +3,15 @@ edges
 | ExposureOfPrivateInformation.cs:20:50:20:65 | call to method getTelephone | ExposureOfPrivateInformation.cs:20:50:20:65 | call to method getTelephone |
 | ExposureOfPrivateInformation.cs:24:21:24:36 | call to method getTelephone | ExposureOfPrivateInformation.cs:24:21:24:36 | call to method getTelephone |
 | ExposureOfPrivateInformation.cs:42:21:42:33 | access to property Text | ExposureOfPrivateInformation.cs:42:21:42:33 | access to property Text |
+nodes
+| ExposureOfPrivateInformation.cs:18:50:18:84 | access to indexer | semmle.label | access to indexer |
+| ExposureOfPrivateInformation.cs:18:50:18:84 | access to indexer | semmle.label | access to indexer |
+| ExposureOfPrivateInformation.cs:20:50:20:65 | call to method getTelephone | semmle.label | call to method getTelephone |
+| ExposureOfPrivateInformation.cs:20:50:20:65 | call to method getTelephone | semmle.label | call to method getTelephone |
+| ExposureOfPrivateInformation.cs:24:21:24:36 | call to method getTelephone | semmle.label | call to method getTelephone |
+| ExposureOfPrivateInformation.cs:24:21:24:36 | call to method getTelephone | semmle.label | call to method getTelephone |
+| ExposureOfPrivateInformation.cs:42:21:42:33 | access to property Text | semmle.label | access to property Text |
+| ExposureOfPrivateInformation.cs:42:21:42:33 | access to property Text | semmle.label | access to property Text |
 #select
 | ExposureOfPrivateInformation.cs:18:50:18:84 | access to indexer | ExposureOfPrivateInformation.cs:18:50:18:84 | access to indexer | ExposureOfPrivateInformation.cs:18:50:18:84 | access to indexer | Private data returned by $@ is written to an external location. | ExposureOfPrivateInformation.cs:18:50:18:84 | access to indexer | access to indexer |
 | ExposureOfPrivateInformation.cs:20:50:20:65 | call to method getTelephone | ExposureOfPrivateInformation.cs:20:50:20:65 | call to method getTelephone | ExposureOfPrivateInformation.cs:20:50:20:65 | call to method getTelephone | Private data returned by $@ is written to an external location. | ExposureOfPrivateInformation.cs:20:50:20:65 | call to method getTelephone | call to method getTelephone |

--- a/csharp/ql/test/query-tests/Security Features/CWE-601/UrlRedirect/UrlRedirect.expected
+++ b/csharp/ql/test/query-tests/Security Features/CWE-601/UrlRedirect/UrlRedirect.expected
@@ -13,6 +13,27 @@ edges
 | UrlRedirectCore.cs:47:51:47:55 | value | UrlRedirectCore.cs:50:28:50:32 | access to parameter value |
 | UrlRedirectCore.cs:47:51:47:55 | value | UrlRedirectCore.cs:55:32:55:45 | object creation of type Uri |
 | UrlRedirectCore.cs:47:51:47:55 | value | UrlRedirectCore.cs:58:31:58:35 | access to parameter value |
+nodes
+| UrlRedirect.cs:14:31:14:53 | access to property QueryString | semmle.label | access to property QueryString |
+| UrlRedirect.cs:14:31:14:61 | access to indexer | semmle.label | access to indexer |
+| UrlRedirect.cs:24:22:24:44 | access to property QueryString | semmle.label | access to property QueryString |
+| UrlRedirect.cs:39:44:39:66 | access to property QueryString | semmle.label | access to property QueryString |
+| UrlRedirect.cs:39:44:39:74 | access to indexer | semmle.label | access to indexer |
+| UrlRedirect.cs:40:47:40:69 | access to property QueryString | semmle.label | access to property QueryString |
+| UrlRedirect.cs:40:47:40:77 | access to indexer | semmle.label | access to indexer |
+| UrlRedirect.cs:49:29:49:31 | access to local variable url | semmle.label | access to local variable url |
+| UrlRedirectCore.cs:15:44:15:48 | value | semmle.label | value |
+| UrlRedirectCore.cs:18:22:18:26 | access to parameter value | semmle.label | access to parameter value |
+| UrlRedirectCore.cs:21:44:21:48 | call to operator implicit conversion | semmle.label | call to operator implicit conversion |
+| UrlRedirectCore.cs:27:46:27:50 | call to operator implicit conversion | semmle.label | call to operator implicit conversion |
+| UrlRedirectCore.cs:33:66:33:70 | access to parameter value | semmle.label | access to parameter value |
+| UrlRedirectCore.cs:36:49:36:53 | call to operator implicit conversion | semmle.label | call to operator implicit conversion |
+| UrlRedirectCore.cs:39:69:39:73 | access to parameter value | semmle.label | access to parameter value |
+| UrlRedirectCore.cs:42:39:42:53 | ... + ... | semmle.label | ... + ... |
+| UrlRedirectCore.cs:47:51:47:55 | value | semmle.label | value |
+| UrlRedirectCore.cs:50:28:50:32 | access to parameter value | semmle.label | access to parameter value |
+| UrlRedirectCore.cs:55:32:55:45 | object creation of type Uri | semmle.label | object creation of type Uri |
+| UrlRedirectCore.cs:58:31:58:35 | access to parameter value | semmle.label | access to parameter value |
 #select
 | UrlRedirect.cs:14:31:14:61 | access to indexer | UrlRedirect.cs:14:31:14:53 | access to property QueryString | UrlRedirect.cs:14:31:14:61 | access to indexer | Untrusted URL redirection due to $@. | UrlRedirect.cs:14:31:14:53 | access to property QueryString | user-provided value |
 | UrlRedirect.cs:39:44:39:74 | access to indexer | UrlRedirect.cs:39:44:39:66 | access to property QueryString | UrlRedirect.cs:39:44:39:74 | access to indexer | Untrusted URL redirection due to $@. | UrlRedirect.cs:39:44:39:66 | access to property QueryString | user-provided value |

--- a/csharp/ql/test/query-tests/Security Features/CWE-611/UntrustedDataInsecureXml.expected
+++ b/csharp/ql/test/query-tests/Security Features/CWE-611/UntrustedDataInsecureXml.expected
@@ -1,4 +1,7 @@
 edges
 | Test.cs:13:50:13:72 | access to property QueryString | Test.cs:13:50:13:84 | access to indexer |
+nodes
+| Test.cs:13:50:13:72 | access to property QueryString | semmle.label | access to property QueryString |
+| Test.cs:13:50:13:84 | access to indexer | semmle.label | access to indexer |
 #select
 | Test.cs:13:50:13:84 | access to indexer | Test.cs:13:50:13:72 | access to property QueryString | Test.cs:13:50:13:84 | access to indexer | $@ flows to here and is loaded insecurely as XML (DTD processing is enabled with an insecure resolver). | Test.cs:13:50:13:72 | access to property QueryString | User-provided value |

--- a/csharp/ql/test/query-tests/Security Features/CWE-643/StoredXPathInjection.expected
+++ b/csharp/ql/test/query-tests/Security Features/CWE-643/StoredXPathInjection.expected
@@ -3,6 +3,11 @@ edges
 | StoredXPathInjection.cs:24:39:24:65 | call to method GetString | StoredXPathInjection.cs:30:41:30:144 | ... + ... |
 | StoredXPathInjection.cs:25:39:25:65 | call to method GetString | StoredXPathInjection.cs:27:45:27:148 | ... + ... |
 | StoredXPathInjection.cs:25:39:25:65 | call to method GetString | StoredXPathInjection.cs:30:41:30:144 | ... + ... |
+nodes
+| StoredXPathInjection.cs:24:39:24:65 | call to method GetString | semmle.label | call to method GetString |
+| StoredXPathInjection.cs:25:39:25:65 | call to method GetString | semmle.label | call to method GetString |
+| StoredXPathInjection.cs:27:45:27:148 | ... + ... | semmle.label | ... + ... |
+| StoredXPathInjection.cs:30:41:30:144 | ... + ... | semmle.label | ... + ... |
 #select
 | StoredXPathInjection.cs:27:45:27:148 | ... + ... | StoredXPathInjection.cs:24:39:24:65 | call to method GetString | StoredXPathInjection.cs:27:45:27:148 | ... + ... | $@ flows to here and is used in an XPath expression. | StoredXPathInjection.cs:24:39:24:65 | call to method GetString | Stored user-provided value |
 | StoredXPathInjection.cs:27:45:27:148 | ... + ... | StoredXPathInjection.cs:25:39:25:65 | call to method GetString | StoredXPathInjection.cs:27:45:27:148 | ... + ... | $@ flows to here and is used in an XPath expression. | StoredXPathInjection.cs:25:39:25:65 | call to method GetString | Stored user-provided value |

--- a/csharp/ql/test/query-tests/Security Features/CWE-643/XPathInjection.expected
+++ b/csharp/ql/test/query-tests/Security Features/CWE-643/XPathInjection.expected
@@ -3,6 +3,11 @@ edges
 | XPathInjection.cs:12:27:12:49 | access to property QueryString | XPathInjection.cs:19:29:19:132 | ... + ... |
 | XPathInjection.cs:13:27:13:49 | access to property QueryString | XPathInjection.cs:16:33:16:136 | ... + ... |
 | XPathInjection.cs:13:27:13:49 | access to property QueryString | XPathInjection.cs:19:29:19:132 | ... + ... |
+nodes
+| XPathInjection.cs:12:27:12:49 | access to property QueryString | semmle.label | access to property QueryString |
+| XPathInjection.cs:13:27:13:49 | access to property QueryString | semmle.label | access to property QueryString |
+| XPathInjection.cs:16:33:16:136 | ... + ... | semmle.label | ... + ... |
+| XPathInjection.cs:19:29:19:132 | ... + ... | semmle.label | ... + ... |
 #select
 | XPathInjection.cs:16:33:16:136 | ... + ... | XPathInjection.cs:12:27:12:49 | access to property QueryString | XPathInjection.cs:16:33:16:136 | ... + ... | $@ flows to here and is used in an XPath expression. | XPathInjection.cs:12:27:12:49 | access to property QueryString | User-provided value |
 | XPathInjection.cs:16:33:16:136 | ... + ... | XPathInjection.cs:13:27:13:49 | access to property QueryString | XPathInjection.cs:16:33:16:136 | ... + ... | $@ flows to here and is used in an XPath expression. | XPathInjection.cs:13:27:13:49 | access to property QueryString | User-provided value |

--- a/csharp/ql/test/query-tests/Security Features/CWE-730/ReDoS/ReDoS.expected
+++ b/csharp/ql/test/query-tests/Security Features/CWE-730/ReDoS/ReDoS.expected
@@ -4,6 +4,13 @@ edges
 | ExponentialRegex.cs:13:28:13:50 | access to property QueryString | ExponentialRegex.cs:21:139:21:147 | access to local variable userInput |
 | ExponentialRegex.cs:13:28:13:50 | access to property QueryString | ExponentialRegex.cs:24:43:24:51 | access to local variable userInput |
 | ExponentialRegex.cs:13:28:13:50 | access to property QueryString | ExponentialRegex.cs:26:21:26:29 | access to local variable userInput |
+nodes
+| ExponentialRegex.cs:13:28:13:50 | access to property QueryString | semmle.label | access to property QueryString |
+| ExponentialRegex.cs:17:40:17:48 | access to local variable userInput | semmle.label | access to local variable userInput |
+| ExponentialRegex.cs:18:42:18:50 | access to local variable userInput | semmle.label | access to local variable userInput |
+| ExponentialRegex.cs:21:139:21:147 | access to local variable userInput | semmle.label | access to local variable userInput |
+| ExponentialRegex.cs:24:43:24:51 | access to local variable userInput | semmle.label | access to local variable userInput |
+| ExponentialRegex.cs:26:21:26:29 | access to local variable userInput | semmle.label | access to local variable userInput |
 #select
 | ExponentialRegex.cs:17:40:17:48 | access to local variable userInput | ExponentialRegex.cs:13:28:13:50 | access to property QueryString | ExponentialRegex.cs:17:40:17:48 | access to local variable userInput | $@ flows to regular expression operation with dangerous regex. | ExponentialRegex.cs:13:28:13:50 | access to property QueryString | User-provided value |
 | ExponentialRegex.cs:18:42:18:50 | access to local variable userInput | ExponentialRegex.cs:13:28:13:50 | access to property QueryString | ExponentialRegex.cs:18:42:18:50 | access to local variable userInput | $@ flows to regular expression operation with dangerous regex. | ExponentialRegex.cs:13:28:13:50 | access to property QueryString | User-provided value |

--- a/csharp/ql/test/query-tests/Security Features/CWE-730/ReDoSGlobalTimeout/ReDoS.expected
+++ b/csharp/ql/test/query-tests/Security Features/CWE-730/ReDoSGlobalTimeout/ReDoS.expected
@@ -1,3 +1,6 @@
 edges
 | ExponentialRegex.cs:15:28:15:50 | access to property QueryString | ExponentialRegex.cs:18:40:18:48 | access to local variable userInput |
+nodes
+| ExponentialRegex.cs:15:28:15:50 | access to property QueryString | semmle.label | access to property QueryString |
+| ExponentialRegex.cs:18:40:18:48 | access to local variable userInput | semmle.label | access to local variable userInput |
 #select

--- a/csharp/ql/test/query-tests/Security Features/CWE-730/RegexInjection/RegexInjection.expected
+++ b/csharp/ql/test/query-tests/Security Features/CWE-730/RegexInjection/RegexInjection.expected
@@ -1,4 +1,7 @@
 edges
 | RegexInjection.cs:12:24:12:46 | access to property QueryString | RegexInjection.cs:16:19:16:23 | access to local variable regex |
+nodes
+| RegexInjection.cs:12:24:12:46 | access to property QueryString | semmle.label | access to property QueryString |
+| RegexInjection.cs:16:19:16:23 | access to local variable regex | semmle.label | access to local variable regex |
 #select
 | RegexInjection.cs:16:19:16:23 | access to local variable regex | RegexInjection.cs:12:24:12:46 | access to property QueryString | RegexInjection.cs:16:19:16:23 | access to local variable regex | $@ flows to the construction of a regular expression. | RegexInjection.cs:12:24:12:46 | access to property QueryString | User-provided value |

--- a/csharp/ql/test/query-tests/Security Features/CWE-798/HardcodedConnectionString.expected
+++ b/csharp/ql/test/query-tests/Security Features/CWE-798/HardcodedConnectionString.expected
@@ -11,6 +11,31 @@ edges
 | TestHardcodedCredentials.cs:21:31:21:42 | "myusername" | TestHardcodedCredentials.cs:21:31:21:42 | "myusername" |
 | TestHardcodedCredentials.cs:21:45:21:56 | "mypassword" | TestHardcodedCredentials.cs:21:45:21:56 | "mypassword" |
 | TestHardcodedCredentials.cs:26:19:26:28 | "username" | TestHardcodedCredentials.cs:26:19:26:28 | "username" |
+nodes
+| HardcodedCredentials.cs:17:25:17:36 | "myPa55word" | semmle.label | "myPa55word" |
+| HardcodedCredentials.cs:17:25:17:36 | "myPa55word" | semmle.label | "myPa55word" |
+| HardcodedCredentials.cs:33:19:33:28 | "username" | semmle.label | "username" |
+| HardcodedCredentials.cs:33:19:33:28 | "username" | semmle.label | "username" |
+| HardcodedCredentials.cs:47:39:47:53 | "myNewPa55word" | semmle.label | "myNewPa55word" |
+| HardcodedCredentials.cs:47:39:47:53 | "myNewPa55word" | semmle.label | "myNewPa55word" |
+| HardcodedCredentials.cs:49:30:49:60 | array creation of type Byte[] | semmle.label | array creation of type Byte[] |
+| HardcodedCredentials.cs:52:13:52:23 | access to local variable rawCertData | semmle.label | access to local variable rawCertData |
+| HardcodedCredentials.cs:53:13:53:24 | "myPa55word" | semmle.label | "myPa55word" |
+| HardcodedCredentials.cs:53:13:53:24 | "myPa55word" | semmle.label | "myPa55word" |
+| HardcodedCredentials.cs:56:48:56:63 | "Password=12345" | semmle.label | "Password=12345" |
+| HardcodedCredentials.cs:56:48:56:63 | "Password=12345" | semmle.label | "Password=12345" |
+| HardcodedCredentials.cs:58:49:58:63 | "User Id=12345" | semmle.label | "User Id=12345" |
+| HardcodedCredentials.cs:58:49:58:63 | "User Id=12345" | semmle.label | "User Id=12345" |
+| HardcodedCredentials.cs:76:31:76:42 | "myusername" | semmle.label | "myusername" |
+| HardcodedCredentials.cs:76:31:76:42 | "myusername" | semmle.label | "myusername" |
+| HardcodedCredentials.cs:76:45:76:56 | "mypassword" | semmle.label | "mypassword" |
+| HardcodedCredentials.cs:76:45:76:56 | "mypassword" | semmle.label | "mypassword" |
+| TestHardcodedCredentials.cs:21:31:21:42 | "myusername" | semmle.label | "myusername" |
+| TestHardcodedCredentials.cs:21:31:21:42 | "myusername" | semmle.label | "myusername" |
+| TestHardcodedCredentials.cs:21:45:21:56 | "mypassword" | semmle.label | "mypassword" |
+| TestHardcodedCredentials.cs:21:45:21:56 | "mypassword" | semmle.label | "mypassword" |
+| TestHardcodedCredentials.cs:26:19:26:28 | "username" | semmle.label | "username" |
+| TestHardcodedCredentials.cs:26:19:26:28 | "username" | semmle.label | "username" |
 #select
 | HardcodedCredentials.cs:56:48:56:63 | "Password=12345" | HardcodedCredentials.cs:56:48:56:63 | "Password=12345" | HardcodedCredentials.cs:56:48:56:63 | "Password=12345" | 'ConnectionString' property includes hard-coded credentials set in $@. | HardcodedCredentials.cs:56:30:56:64 | object creation of type SqlConnection | object creation of type SqlConnection |
 | HardcodedCredentials.cs:58:49:58:63 | "User Id=12345" | HardcodedCredentials.cs:58:49:58:63 | "User Id=12345" | HardcodedCredentials.cs:58:49:58:63 | "User Id=12345" | 'ConnectionString' property includes hard-coded credentials set in $@. | HardcodedCredentials.cs:58:31:58:64 | object creation of type SqlConnection | object creation of type SqlConnection |

--- a/csharp/ql/test/query-tests/Security Features/CWE-798/HardcodedCredentials.expected
+++ b/csharp/ql/test/query-tests/Security Features/CWE-798/HardcodedCredentials.expected
@@ -9,6 +9,27 @@ edges
 | TestHardcodedCredentials.cs:21:31:21:42 | "myusername" | TestHardcodedCredentials.cs:21:31:21:42 | "myusername" |
 | TestHardcodedCredentials.cs:21:45:21:56 | "mypassword" | TestHardcodedCredentials.cs:21:45:21:56 | "mypassword" |
 | TestHardcodedCredentials.cs:26:19:26:28 | "username" | TestHardcodedCredentials.cs:26:19:26:28 | "username" |
+nodes
+| HardcodedCredentials.cs:17:25:17:36 | "myPa55word" | semmle.label | "myPa55word" |
+| HardcodedCredentials.cs:17:25:17:36 | "myPa55word" | semmle.label | "myPa55word" |
+| HardcodedCredentials.cs:33:19:33:28 | "username" | semmle.label | "username" |
+| HardcodedCredentials.cs:33:19:33:28 | "username" | semmle.label | "username" |
+| HardcodedCredentials.cs:47:39:47:53 | "myNewPa55word" | semmle.label | "myNewPa55word" |
+| HardcodedCredentials.cs:47:39:47:53 | "myNewPa55word" | semmle.label | "myNewPa55word" |
+| HardcodedCredentials.cs:49:30:49:60 | array creation of type Byte[] | semmle.label | array creation of type Byte[] |
+| HardcodedCredentials.cs:52:13:52:23 | access to local variable rawCertData | semmle.label | access to local variable rawCertData |
+| HardcodedCredentials.cs:53:13:53:24 | "myPa55word" | semmle.label | "myPa55word" |
+| HardcodedCredentials.cs:53:13:53:24 | "myPa55word" | semmle.label | "myPa55word" |
+| HardcodedCredentials.cs:76:31:76:42 | "myusername" | semmle.label | "myusername" |
+| HardcodedCredentials.cs:76:31:76:42 | "myusername" | semmle.label | "myusername" |
+| HardcodedCredentials.cs:76:45:76:56 | "mypassword" | semmle.label | "mypassword" |
+| HardcodedCredentials.cs:76:45:76:56 | "mypassword" | semmle.label | "mypassword" |
+| TestHardcodedCredentials.cs:21:31:21:42 | "myusername" | semmle.label | "myusername" |
+| TestHardcodedCredentials.cs:21:31:21:42 | "myusername" | semmle.label | "myusername" |
+| TestHardcodedCredentials.cs:21:45:21:56 | "mypassword" | semmle.label | "mypassword" |
+| TestHardcodedCredentials.cs:21:45:21:56 | "mypassword" | semmle.label | "mypassword" |
+| TestHardcodedCredentials.cs:26:19:26:28 | "username" | semmle.label | "username" |
+| TestHardcodedCredentials.cs:26:19:26:28 | "username" | semmle.label | "username" |
 #select
 | HardcodedCredentials.cs:17:25:17:36 | "myPa55word" | HardcodedCredentials.cs:17:25:17:36 | "myPa55word" | HardcodedCredentials.cs:17:25:17:36 | "myPa55word" | The hard-coded value "myPa55word" flows to $@ which is compared against $@. | HardcodedCredentials.cs:17:25:17:36 | "myPa55word" | "myPa55word" | HardcodedCredentials.cs:17:13:17:20 | access to local variable password | access to local variable password |
 | HardcodedCredentials.cs:33:19:33:28 | "username" | HardcodedCredentials.cs:33:19:33:28 | "username" | HardcodedCredentials.cs:33:19:33:28 | "username" | The hard-coded value "username" flows to the $@ parameter in $@. | HardcodedCredentials.cs:33:19:33:28 | "username" | name | HardcodedCredentials.cs:31:31:45:13 | object creation of type MembershipUser | object creation of type MembershipUser |

--- a/csharp/ql/test/query-tests/Security Features/CWE-807/ConditionalBypass.expected
+++ b/csharp/ql/test/query-tests/Security Features/CWE-807/ConditionalBypass.expected
@@ -6,6 +6,19 @@ edges
 | ConditionalBypass.cs:44:32:44:66 | call to method GetHostByAddress | ConditionalBypass.cs:51:13:51:29 | access to property HostName |
 | ConditionalBypass.cs:72:34:72:52 | access to property Cookies | ConditionalBypass.cs:74:13:74:40 | ... == ... |
 | ConditionalBypass.cs:85:34:85:52 | access to property Cookies | ConditionalBypass.cs:86:13:86:40 | ... == ... |
+nodes
+| ConditionalBypass.cs:14:26:14:48 | access to property QueryString | semmle.label | access to property QueryString |
+| ConditionalBypass.cs:18:13:18:30 | ... == ... | semmle.label | ... == ... |
+| ConditionalBypass.cs:21:34:21:52 | access to property Cookies | semmle.label | access to property Cookies |
+| ConditionalBypass.cs:24:13:24:45 | call to method Equals | semmle.label | call to method Equals |
+| ConditionalBypass.cs:29:13:29:40 | ... == ... | semmle.label | ... == ... |
+| ConditionalBypass.cs:44:32:44:66 | call to method GetHostByAddress | semmle.label | call to method GetHostByAddress |
+| ConditionalBypass.cs:46:13:46:46 | ... == ... | semmle.label | ... == ... |
+| ConditionalBypass.cs:51:13:51:29 | access to property HostName | semmle.label | access to property HostName |
+| ConditionalBypass.cs:72:34:72:52 | access to property Cookies | semmle.label | access to property Cookies |
+| ConditionalBypass.cs:74:13:74:40 | ... == ... | semmle.label | ... == ... |
+| ConditionalBypass.cs:85:34:85:52 | access to property Cookies | semmle.label | access to property Cookies |
+| ConditionalBypass.cs:86:13:86:40 | ... == ... | semmle.label | ... == ... |
 #select
 | ConditionalBypass.cs:19:13:19:33 | call to method login | ConditionalBypass.cs:14:26:14:48 | access to property QueryString | ConditionalBypass.cs:18:13:18:30 | ... == ... | Sensitive method may not be executed depending on $@, which flows from $@. | ConditionalBypass.cs:18:13:18:30 | ... == ... | this condition | ConditionalBypass.cs:14:26:14:48 | access to property QueryString | user input |
 | ConditionalBypass.cs:25:13:25:33 | call to method login | ConditionalBypass.cs:21:34:21:52 | access to property Cookies | ConditionalBypass.cs:24:13:24:45 | call to method Equals | Sensitive method may not be executed depending on $@, which flows from $@. | ConditionalBypass.cs:24:13:24:45 | call to method Equals | this condition | ConditionalBypass.cs:21:34:21:52 | access to property Cookies | user input |

--- a/csharp/ql/test/query-tests/Security Features/CWE-838/InappropriateEncoding.expected
+++ b/csharp/ql/test/query-tests/Security Features/CWE-838/InappropriateEncoding.expected
@@ -11,6 +11,28 @@ edges
 | InappropriateEncoding.cs:68:16:68:42 | call to method Replace | InappropriateEncoding.cs:15:28:15:40 | call to method Encode |
 | SqlEncode.cs:16:62:16:87 | call to method Replace | SqlEncode.cs:17:46:17:50 | access to local variable query |
 | UrlEncode.cs:12:43:12:69 | call to method HtmlEncode | UrlEncode.cs:12:31:12:69 | ... + ... |
+nodes
+| HtmlEncode.cs:12:28:12:65 | ... + ... | semmle.label | ... + ... |
+| HtmlEncode.cs:12:40:12:65 | call to method UrlEncode | semmle.label | call to method UrlEncode |
+| InappropriateEncoding.cs:15:28:15:40 | call to method Encode | semmle.label | call to method Encode |
+| InappropriateEncoding.cs:20:46:20:51 | access to local variable query1 | semmle.label | access to local variable query1 |
+| InappropriateEncoding.cs:33:22:33:34 | call to method Encode | semmle.label | call to method Encode |
+| InappropriateEncoding.cs:33:22:33:34 | call to method Encode | semmle.label | call to method Encode |
+| InappropriateEncoding.cs:34:22:34:49 | call to method UrlEncode | semmle.label | call to method UrlEncode |
+| InappropriateEncoding.cs:34:22:34:49 | call to method UrlEncode | semmle.label | call to method UrlEncode |
+| InappropriateEncoding.cs:35:22:35:73 | call to method UrlEncode | semmle.label | call to method UrlEncode |
+| InappropriateEncoding.cs:35:22:35:73 | call to method UrlEncode | semmle.label | call to method UrlEncode |
+| InappropriateEncoding.cs:36:28:36:55 | call to method UrlEncode | semmle.label | call to method UrlEncode |
+| InappropriateEncoding.cs:37:32:37:43 | access to local variable encodedValue | semmle.label | access to local variable encodedValue |
+| InappropriateEncoding.cs:38:22:38:59 | ... + ... | semmle.label | ... + ... |
+| InappropriateEncoding.cs:39:22:39:71 | call to method Format | semmle.label | call to method Format |
+| InappropriateEncoding.cs:57:28:57:56 | call to method HtmlEncode | semmle.label | call to method HtmlEncode |
+| InappropriateEncoding.cs:58:31:58:42 | access to local variable encodedValue | semmle.label | access to local variable encodedValue |
+| InappropriateEncoding.cs:68:16:68:42 | call to method Replace | semmle.label | call to method Replace |
+| SqlEncode.cs:16:62:16:87 | call to method Replace | semmle.label | call to method Replace |
+| SqlEncode.cs:17:46:17:50 | access to local variable query | semmle.label | access to local variable query |
+| UrlEncode.cs:12:31:12:69 | ... + ... | semmle.label | ... + ... |
+| UrlEncode.cs:12:43:12:69 | call to method HtmlEncode | semmle.label | call to method HtmlEncode |
 #select
 | HtmlEncode.cs:12:28:12:65 | ... + ... | HtmlEncode.cs:12:40:12:65 | call to method UrlEncode | HtmlEncode.cs:12:28:12:65 | ... + ... | This HTML expression may include data from a $@. | HtmlEncode.cs:12:40:12:65 | call to method UrlEncode | possibly inappropriately encoded value |
 | InappropriateEncoding.cs:20:46:20:51 | access to local variable query1 | InappropriateEncoding.cs:15:28:15:40 | call to method Encode | InappropriateEncoding.cs:20:46:20:51 | access to local variable query1 | This SQL expression may include data from a $@. | InappropriateEncoding.cs:15:28:15:40 | call to method Encode | possibly inappropriately encoded value |

--- a/java/ql/src/semmle/code/java/dataflow/internal/DataFlowImpl.qll
+++ b/java/ql/src/semmle/code/java/dataflow/internal/DataFlowImpl.qll
@@ -1260,7 +1260,7 @@ abstract private class AccessPath extends TAccessPath {
 
 private class AccessPathNil extends AccessPath, TNil {
   override string toString() {
-    exists(DataFlowType t | this = TNil(t) | result = concat(ppReprType(t)))
+    exists(DataFlowType t | this = TNil(t) | result = concat(" : " + ppReprType(t)))
   }
 
   override AccessPathFront getFront() {

--- a/java/ql/src/semmle/code/java/dataflow/internal/DataFlowImpl.qll
+++ b/java/ql/src/semmle/code/java/dataflow/internal/DataFlowImpl.qll
@@ -1647,6 +1647,11 @@ private predicate pathSuccPlus(PathNode n1, PathNode n2) = fastTC(pathSucc/2)(n1
 module PathGraph {
   /** Holds if `(a,b)` is an edge in the graph of data flow path explanations. */
   query predicate edges(PathNode a, PathNode b) { pathSucc(a, b) }
+
+  /** Holds if `n` is a node in the graph of data flow path explanations. */
+  query predicate nodes(PathNode n, string key, string val) {
+    reach(n) and key = "semmle.label" and val = n.toString()
+  }
 }
 
 /**

--- a/java/ql/src/semmle/code/java/dataflow/internal/DataFlowImpl2.qll
+++ b/java/ql/src/semmle/code/java/dataflow/internal/DataFlowImpl2.qll
@@ -1260,7 +1260,7 @@ abstract private class AccessPath extends TAccessPath {
 
 private class AccessPathNil extends AccessPath, TNil {
   override string toString() {
-    exists(DataFlowType t | this = TNil(t) | result = concat(ppReprType(t)))
+    exists(DataFlowType t | this = TNil(t) | result = concat(" : " + ppReprType(t)))
   }
 
   override AccessPathFront getFront() {

--- a/java/ql/src/semmle/code/java/dataflow/internal/DataFlowImpl2.qll
+++ b/java/ql/src/semmle/code/java/dataflow/internal/DataFlowImpl2.qll
@@ -1647,6 +1647,11 @@ private predicate pathSuccPlus(PathNode n1, PathNode n2) = fastTC(pathSucc/2)(n1
 module PathGraph {
   /** Holds if `(a,b)` is an edge in the graph of data flow path explanations. */
   query predicate edges(PathNode a, PathNode b) { pathSucc(a, b) }
+
+  /** Holds if `n` is a node in the graph of data flow path explanations. */
+  query predicate nodes(PathNode n, string key, string val) {
+    reach(n) and key = "semmle.label" and val = n.toString()
+  }
 }
 
 /**

--- a/java/ql/src/semmle/code/java/dataflow/internal/DataFlowImpl3.qll
+++ b/java/ql/src/semmle/code/java/dataflow/internal/DataFlowImpl3.qll
@@ -1260,7 +1260,7 @@ abstract private class AccessPath extends TAccessPath {
 
 private class AccessPathNil extends AccessPath, TNil {
   override string toString() {
-    exists(DataFlowType t | this = TNil(t) | result = concat(ppReprType(t)))
+    exists(DataFlowType t | this = TNil(t) | result = concat(" : " + ppReprType(t)))
   }
 
   override AccessPathFront getFront() {

--- a/java/ql/src/semmle/code/java/dataflow/internal/DataFlowImpl3.qll
+++ b/java/ql/src/semmle/code/java/dataflow/internal/DataFlowImpl3.qll
@@ -1647,6 +1647,11 @@ private predicate pathSuccPlus(PathNode n1, PathNode n2) = fastTC(pathSucc/2)(n1
 module PathGraph {
   /** Holds if `(a,b)` is an edge in the graph of data flow path explanations. */
   query predicate edges(PathNode a, PathNode b) { pathSucc(a, b) }
+
+  /** Holds if `n` is a node in the graph of data flow path explanations. */
+  query predicate nodes(PathNode n, string key, string val) {
+    reach(n) and key = "semmle.label" and val = n.toString()
+  }
 }
 
 /**

--- a/java/ql/src/semmle/code/java/dataflow/internal/DataFlowImpl4.qll
+++ b/java/ql/src/semmle/code/java/dataflow/internal/DataFlowImpl4.qll
@@ -1260,7 +1260,7 @@ abstract private class AccessPath extends TAccessPath {
 
 private class AccessPathNil extends AccessPath, TNil {
   override string toString() {
-    exists(DataFlowType t | this = TNil(t) | result = concat(ppReprType(t)))
+    exists(DataFlowType t | this = TNil(t) | result = concat(" : " + ppReprType(t)))
   }
 
   override AccessPathFront getFront() {

--- a/java/ql/src/semmle/code/java/dataflow/internal/DataFlowImpl4.qll
+++ b/java/ql/src/semmle/code/java/dataflow/internal/DataFlowImpl4.qll
@@ -1647,6 +1647,11 @@ private predicate pathSuccPlus(PathNode n1, PathNode n2) = fastTC(pathSucc/2)(n1
 module PathGraph {
   /** Holds if `(a,b)` is an edge in the graph of data flow path explanations. */
   query predicate edges(PathNode a, PathNode b) { pathSucc(a, b) }
+
+  /** Holds if `n` is a node in the graph of data flow path explanations. */
+  query predicate nodes(PathNode n, string key, string val) {
+    reach(n) and key = "semmle.label" and val = n.toString()
+  }
 }
 
 /**

--- a/java/ql/src/semmle/code/java/dataflow/internal/DataFlowImpl5.qll
+++ b/java/ql/src/semmle/code/java/dataflow/internal/DataFlowImpl5.qll
@@ -1260,7 +1260,7 @@ abstract private class AccessPath extends TAccessPath {
 
 private class AccessPathNil extends AccessPath, TNil {
   override string toString() {
-    exists(DataFlowType t | this = TNil(t) | result = concat(ppReprType(t)))
+    exists(DataFlowType t | this = TNil(t) | result = concat(" : " + ppReprType(t)))
   }
 
   override AccessPathFront getFront() {

--- a/java/ql/src/semmle/code/java/dataflow/internal/DataFlowImpl5.qll
+++ b/java/ql/src/semmle/code/java/dataflow/internal/DataFlowImpl5.qll
@@ -1647,6 +1647,11 @@ private predicate pathSuccPlus(PathNode n1, PathNode n2) = fastTC(pathSucc/2)(n1
 module PathGraph {
   /** Holds if `(a,b)` is an edge in the graph of data flow path explanations. */
   query predicate edges(PathNode a, PathNode b) { pathSucc(a, b) }
+
+  /** Holds if `n` is a node in the graph of data flow path explanations. */
+  query predicate nodes(PathNode n, string key, string val) {
+    reach(n) and key = "semmle.label" and val = n.toString()
+  }
 }
 
 /**

--- a/java/ql/test/query-tests/security/CWE-022/semmle/tests/TaintedPath.expected
+++ b/java/ql/test/query-tests/security/CWE-022/semmle/tests/TaintedPath.expected
@@ -1,8 +1,13 @@
 edges
-| Test.java:19:18:19:38 | getHostName(...) [String] | Test.java:24:20:24:23 | temp |
-| Test.java:19:18:19:38 | getHostName(...) [String] | Test.java:27:21:27:24 | temp |
-| Test.java:19:18:19:38 | getHostName(...) [String] | Test.java:30:44:30:47 | temp |
+| Test.java:19:18:19:38 | getHostName(...) [ : String] | Test.java:24:20:24:23 | temp |
+| Test.java:19:18:19:38 | getHostName(...) [ : String] | Test.java:27:21:27:24 | temp |
+| Test.java:19:18:19:38 | getHostName(...) [ : String] | Test.java:30:44:30:47 | temp |
+nodes
+| Test.java:19:18:19:38 | getHostName(...) [ : String] | semmle.label | getHostName(...) [ : String] |
+| Test.java:24:20:24:23 | temp | semmle.label | temp |
+| Test.java:27:21:27:24 | temp | semmle.label | temp |
+| Test.java:30:44:30:47 | temp | semmle.label | temp |
 #select
-| Test.java:24:11:24:24 | new File(...) | Test.java:19:18:19:38 | getHostName(...) [String] | Test.java:24:20:24:23 | temp | $@ flows to here and is used in a path. | Test.java:19:18:19:38 | getHostName(...) | User-provided value |
-| Test.java:27:11:27:25 | get(...) | Test.java:19:18:19:38 | getHostName(...) [String] | Test.java:27:21:27:24 | temp | $@ flows to here and is used in a path. | Test.java:19:18:19:38 | getHostName(...) | User-provided value |
-| Test.java:30:11:30:48 | getPath(...) | Test.java:19:18:19:38 | getHostName(...) [String] | Test.java:30:44:30:47 | temp | $@ flows to here and is used in a path. | Test.java:19:18:19:38 | getHostName(...) | User-provided value |
+| Test.java:24:11:24:24 | new File(...) | Test.java:19:18:19:38 | getHostName(...) [ : String] | Test.java:24:20:24:23 | temp | $@ flows to here and is used in a path. | Test.java:19:18:19:38 | getHostName(...) | User-provided value |
+| Test.java:27:11:27:25 | get(...) | Test.java:19:18:19:38 | getHostName(...) [ : String] | Test.java:27:21:27:24 | temp | $@ flows to here and is used in a path. | Test.java:19:18:19:38 | getHostName(...) | User-provided value |
+| Test.java:30:11:30:48 | getPath(...) | Test.java:19:18:19:38 | getHostName(...) [ : String] | Test.java:30:44:30:47 | temp | $@ flows to here and is used in a path. | Test.java:19:18:19:38 | getHostName(...) | User-provided value |

--- a/java/ql/test/query-tests/security/CWE-022/semmle/tests/ZipSlip.expected
+++ b/java/ql/test/query-tests/security/CWE-022/semmle/tests/ZipSlip.expected
@@ -1,8 +1,13 @@
 edges
-| ZipTest.java:7:19:7:33 | getName(...) [String] | ZipTest.java:9:48:9:51 | file |
-| ZipTest.java:7:19:7:33 | getName(...) [String] | ZipTest.java:10:49:10:52 | file |
-| ZipTest.java:7:19:7:33 | getName(...) [String] | ZipTest.java:11:36:11:39 | file |
+| ZipTest.java:7:19:7:33 | getName(...) [ : String] | ZipTest.java:9:48:9:51 | file |
+| ZipTest.java:7:19:7:33 | getName(...) [ : String] | ZipTest.java:10:49:10:52 | file |
+| ZipTest.java:7:19:7:33 | getName(...) [ : String] | ZipTest.java:11:36:11:39 | file |
+nodes
+| ZipTest.java:7:19:7:33 | getName(...) [ : String] | semmle.label | getName(...) [ : String] |
+| ZipTest.java:9:48:9:51 | file | semmle.label | file |
+| ZipTest.java:10:49:10:52 | file | semmle.label | file |
+| ZipTest.java:11:36:11:39 | file | semmle.label | file |
 #select
-| ZipTest.java:7:19:7:33 | getName(...) | ZipTest.java:7:19:7:33 | getName(...) [String] | ZipTest.java:9:48:9:51 | file | Unsanitized archive entry, which may contain '..', is used in a $@. | ZipTest.java:9:48:9:51 | file | file system operation |
-| ZipTest.java:7:19:7:33 | getName(...) | ZipTest.java:7:19:7:33 | getName(...) [String] | ZipTest.java:10:49:10:52 | file | Unsanitized archive entry, which may contain '..', is used in a $@. | ZipTest.java:10:49:10:52 | file | file system operation |
-| ZipTest.java:7:19:7:33 | getName(...) | ZipTest.java:7:19:7:33 | getName(...) [String] | ZipTest.java:11:36:11:39 | file | Unsanitized archive entry, which may contain '..', is used in a $@. | ZipTest.java:11:36:11:39 | file | file system operation |
+| ZipTest.java:7:19:7:33 | getName(...) | ZipTest.java:7:19:7:33 | getName(...) [ : String] | ZipTest.java:9:48:9:51 | file | Unsanitized archive entry, which may contain '..', is used in a $@. | ZipTest.java:9:48:9:51 | file | file system operation |
+| ZipTest.java:7:19:7:33 | getName(...) | ZipTest.java:7:19:7:33 | getName(...) [ : String] | ZipTest.java:10:49:10:52 | file | Unsanitized archive entry, which may contain '..', is used in a $@. | ZipTest.java:10:49:10:52 | file | file system operation |
+| ZipTest.java:7:19:7:33 | getName(...) | ZipTest.java:7:19:7:33 | getName(...) [ : String] | ZipTest.java:11:36:11:39 | file | Unsanitized archive entry, which may contain '..', is used in a $@. | ZipTest.java:11:36:11:39 | file | file system operation |

--- a/java/ql/test/query-tests/security/CWE-079/semmle/tests/XSS.expected
+++ b/java/ql/test/query-tests/security/CWE-079/semmle/tests/XSS.expected
@@ -1,10 +1,19 @@
 edges
-| XSS.java:23:21:23:48 | getParameter(...) [String] | XSS.java:23:5:23:70 | ... + ... |
-| XSS.java:27:21:27:48 | getParameter(...) [String] | XSS.java:27:5:27:70 | ... + ... |
-| XSS.java:38:67:38:87 | getPathInfo(...) [String] | XSS.java:38:30:38:87 | ... + ... |
-| XSS.java:41:36:41:56 | getPathInfo(...) [String] | XSS.java:41:36:41:67 | getBytes(...) |
+| XSS.java:23:21:23:48 | getParameter(...) [ : String] | XSS.java:23:5:23:70 | ... + ... |
+| XSS.java:27:21:27:48 | getParameter(...) [ : String] | XSS.java:27:5:27:70 | ... + ... |
+| XSS.java:38:67:38:87 | getPathInfo(...) [ : String] | XSS.java:38:30:38:87 | ... + ... |
+| XSS.java:41:36:41:56 | getPathInfo(...) [ : String] | XSS.java:41:36:41:67 | getBytes(...) |
+nodes
+| XSS.java:23:5:23:70 | ... + ... | semmle.label | ... + ... |
+| XSS.java:23:21:23:48 | getParameter(...) [ : String] | semmle.label | getParameter(...) [ : String] |
+| XSS.java:27:5:27:70 | ... + ... | semmle.label | ... + ... |
+| XSS.java:27:21:27:48 | getParameter(...) [ : String] | semmle.label | getParameter(...) [ : String] |
+| XSS.java:38:30:38:87 | ... + ... | semmle.label | ... + ... |
+| XSS.java:38:67:38:87 | getPathInfo(...) [ : String] | semmle.label | getPathInfo(...) [ : String] |
+| XSS.java:41:36:41:56 | getPathInfo(...) [ : String] | semmle.label | getPathInfo(...) [ : String] |
+| XSS.java:41:36:41:67 | getBytes(...) | semmle.label | getBytes(...) |
 #select
-| XSS.java:23:5:23:70 | ... + ... | XSS.java:23:21:23:48 | getParameter(...) [String] | XSS.java:23:5:23:70 | ... + ... | Cross-site scripting vulnerability due to $@. | XSS.java:23:21:23:48 | getParameter(...) | user-provided value |
-| XSS.java:27:5:27:70 | ... + ... | XSS.java:27:21:27:48 | getParameter(...) [String] | XSS.java:27:5:27:70 | ... + ... | Cross-site scripting vulnerability due to $@. | XSS.java:27:21:27:48 | getParameter(...) | user-provided value |
-| XSS.java:38:30:38:87 | ... + ... | XSS.java:38:67:38:87 | getPathInfo(...) [String] | XSS.java:38:30:38:87 | ... + ... | Cross-site scripting vulnerability due to $@. | XSS.java:38:67:38:87 | getPathInfo(...) | user-provided value |
-| XSS.java:41:36:41:67 | getBytes(...) | XSS.java:41:36:41:56 | getPathInfo(...) [String] | XSS.java:41:36:41:67 | getBytes(...) | Cross-site scripting vulnerability due to $@. | XSS.java:41:36:41:56 | getPathInfo(...) | user-provided value |
+| XSS.java:23:5:23:70 | ... + ... | XSS.java:23:21:23:48 | getParameter(...) [ : String] | XSS.java:23:5:23:70 | ... + ... | Cross-site scripting vulnerability due to $@. | XSS.java:23:21:23:48 | getParameter(...) | user-provided value |
+| XSS.java:27:5:27:70 | ... + ... | XSS.java:27:21:27:48 | getParameter(...) [ : String] | XSS.java:27:5:27:70 | ... + ... | Cross-site scripting vulnerability due to $@. | XSS.java:27:21:27:48 | getParameter(...) | user-provided value |
+| XSS.java:38:30:38:87 | ... + ... | XSS.java:38:67:38:87 | getPathInfo(...) [ : String] | XSS.java:38:30:38:87 | ... + ... | Cross-site scripting vulnerability due to $@. | XSS.java:38:67:38:87 | getPathInfo(...) | user-provided value |
+| XSS.java:41:36:41:67 | getBytes(...) | XSS.java:41:36:41:56 | getPathInfo(...) [ : String] | XSS.java:41:36:41:67 | getBytes(...) | Cross-site scripting vulnerability due to $@. | XSS.java:41:36:41:56 | getPathInfo(...) | user-provided value |

--- a/java/ql/test/query-tests/security/CWE-089/semmle/examples/SqlTaintedLocal.expected
+++ b/java/ql/test/query-tests/security/CWE-089/semmle/examples/SqlTaintedLocal.expected
@@ -1,20 +1,33 @@
 edges
-| Test.java:29:30:29:42 | args [String[]] | Test.java:36:47:36:52 | query1 |
-| Test.java:29:30:29:42 | args [String[]] | Test.java:42:57:42:62 | query2 |
-| Test.java:29:30:29:42 | args [String[]] | Test.java:50:62:50:67 | query3 |
-| Test.java:29:30:29:42 | args [String[]] | Test.java:62:47:62:61 | querySbToString |
-| Test.java:29:30:29:42 | args [String[]] | Test.java:70:40:70:44 | query |
-| Test.java:29:30:29:42 | args [String[]] | Test.java:78:46:78:50 | query |
-| Test.java:183:33:183:45 | args [String[]] | Test.java:209:47:209:68 | queryWithUserTableName |
-| Test.java:213:26:213:38 | args [String[]] | Test.java:214:11:214:14 | args [String[]] |
-| Test.java:213:26:213:38 | args [String[]] | Test.java:218:14:218:17 | args [String[]] |
-| Test.java:214:11:214:14 | args [String[]] | Test.java:29:30:29:42 | args [String[]] |
-| Test.java:218:14:218:17 | args [String[]] | Test.java:183:33:183:45 | args [String[]] |
+| Test.java:29:30:29:42 | args [ : String[]] | Test.java:36:47:36:52 | query1 |
+| Test.java:29:30:29:42 | args [ : String[]] | Test.java:42:57:42:62 | query2 |
+| Test.java:29:30:29:42 | args [ : String[]] | Test.java:50:62:50:67 | query3 |
+| Test.java:29:30:29:42 | args [ : String[]] | Test.java:62:47:62:61 | querySbToString |
+| Test.java:29:30:29:42 | args [ : String[]] | Test.java:70:40:70:44 | query |
+| Test.java:29:30:29:42 | args [ : String[]] | Test.java:78:46:78:50 | query |
+| Test.java:183:33:183:45 | args [ : String[]] | Test.java:209:47:209:68 | queryWithUserTableName |
+| Test.java:213:26:213:38 | args [ : String[]] | Test.java:214:11:214:14 | args [ : String[]] |
+| Test.java:213:26:213:38 | args [ : String[]] | Test.java:218:14:218:17 | args [ : String[]] |
+| Test.java:214:11:214:14 | args [ : String[]] | Test.java:29:30:29:42 | args [ : String[]] |
+| Test.java:218:14:218:17 | args [ : String[]] | Test.java:183:33:183:45 | args [ : String[]] |
+nodes
+| Test.java:29:30:29:42 | args [ : String[]] | semmle.label | args [ : String[]] |
+| Test.java:36:47:36:52 | query1 | semmle.label | query1 |
+| Test.java:42:57:42:62 | query2 | semmle.label | query2 |
+| Test.java:50:62:50:67 | query3 | semmle.label | query3 |
+| Test.java:62:47:62:61 | querySbToString | semmle.label | querySbToString |
+| Test.java:70:40:70:44 | query | semmle.label | query |
+| Test.java:78:46:78:50 | query | semmle.label | query |
+| Test.java:183:33:183:45 | args [ : String[]] | semmle.label | args [ : String[]] |
+| Test.java:209:47:209:68 | queryWithUserTableName | semmle.label | queryWithUserTableName |
+| Test.java:213:26:213:38 | args [ : String[]] | semmle.label | args [ : String[]] |
+| Test.java:214:11:214:14 | args [ : String[]] | semmle.label | args [ : String[]] |
+| Test.java:218:14:218:17 | args [ : String[]] | semmle.label | args [ : String[]] |
 #select
-| Test.java:36:47:36:52 | query1 | Test.java:213:26:213:38 | args [String[]] | Test.java:36:47:36:52 | query1 | Query might include code from $@. | Test.java:213:26:213:38 | args | this user input |
-| Test.java:42:57:42:62 | query2 | Test.java:213:26:213:38 | args [String[]] | Test.java:42:57:42:62 | query2 | Query might include code from $@. | Test.java:213:26:213:38 | args | this user input |
-| Test.java:50:62:50:67 | query3 | Test.java:213:26:213:38 | args [String[]] | Test.java:50:62:50:67 | query3 | Query might include code from $@. | Test.java:213:26:213:38 | args | this user input |
-| Test.java:62:47:62:61 | querySbToString | Test.java:213:26:213:38 | args [String[]] | Test.java:62:47:62:61 | querySbToString | Query might include code from $@. | Test.java:213:26:213:38 | args | this user input |
-| Test.java:70:40:70:44 | query | Test.java:213:26:213:38 | args [String[]] | Test.java:70:40:70:44 | query | Query might include code from $@. | Test.java:213:26:213:38 | args | this user input |
-| Test.java:78:46:78:50 | query | Test.java:213:26:213:38 | args [String[]] | Test.java:78:46:78:50 | query | Query might include code from $@. | Test.java:213:26:213:38 | args | this user input |
-| Test.java:209:47:209:68 | queryWithUserTableName | Test.java:213:26:213:38 | args [String[]] | Test.java:209:47:209:68 | queryWithUserTableName | Query might include code from $@. | Test.java:213:26:213:38 | args | this user input |
+| Test.java:36:47:36:52 | query1 | Test.java:213:26:213:38 | args [ : String[]] | Test.java:36:47:36:52 | query1 | Query might include code from $@. | Test.java:213:26:213:38 | args | this user input |
+| Test.java:42:57:42:62 | query2 | Test.java:213:26:213:38 | args [ : String[]] | Test.java:42:57:42:62 | query2 | Query might include code from $@. | Test.java:213:26:213:38 | args | this user input |
+| Test.java:50:62:50:67 | query3 | Test.java:213:26:213:38 | args [ : String[]] | Test.java:50:62:50:67 | query3 | Query might include code from $@. | Test.java:213:26:213:38 | args | this user input |
+| Test.java:62:47:62:61 | querySbToString | Test.java:213:26:213:38 | args [ : String[]] | Test.java:62:47:62:61 | querySbToString | Query might include code from $@. | Test.java:213:26:213:38 | args | this user input |
+| Test.java:70:40:70:44 | query | Test.java:213:26:213:38 | args [ : String[]] | Test.java:70:40:70:44 | query | Query might include code from $@. | Test.java:213:26:213:38 | args | this user input |
+| Test.java:78:46:78:50 | query | Test.java:213:26:213:38 | args [ : String[]] | Test.java:78:46:78:50 | query | Query might include code from $@. | Test.java:213:26:213:38 | args | this user input |
+| Test.java:209:47:209:68 | queryWithUserTableName | Test.java:213:26:213:38 | args [ : String[]] | Test.java:209:47:209:68 | queryWithUserTableName | Query might include code from $@. | Test.java:213:26:213:38 | args | this user input |

--- a/java/ql/test/query-tests/security/CWE-113/semmle/tests/ResponseSplitting.expected
+++ b/java/ql/test/query-tests/security/CWE-113/semmle/tests/ResponseSplitting.expected
@@ -1,8 +1,15 @@
 edges
-| ResponseSplitting.java:22:39:22:66 | getParameter(...) [String] | ResponseSplitting.java:23:23:23:28 | cookie |
-| ResponseSplitting.java:28:38:28:72 | getParameter(...) [String] | ResponseSplitting.java:28:38:28:72 | getParameter(...) |
-| ResponseSplitting.java:29:38:29:72 | getParameter(...) [String] | ResponseSplitting.java:29:38:29:72 | getParameter(...) |
+| ResponseSplitting.java:22:39:22:66 | getParameter(...) [ : String] | ResponseSplitting.java:23:23:23:28 | cookie |
+| ResponseSplitting.java:28:38:28:72 | getParameter(...) [ : String] | ResponseSplitting.java:28:38:28:72 | getParameter(...) |
+| ResponseSplitting.java:29:38:29:72 | getParameter(...) [ : String] | ResponseSplitting.java:29:38:29:72 | getParameter(...) |
+nodes
+| ResponseSplitting.java:22:39:22:66 | getParameter(...) [ : String] | semmle.label | getParameter(...) [ : String] |
+| ResponseSplitting.java:23:23:23:28 | cookie | semmle.label | cookie |
+| ResponseSplitting.java:28:38:28:72 | getParameter(...) | semmle.label | getParameter(...) |
+| ResponseSplitting.java:28:38:28:72 | getParameter(...) [ : String] | semmle.label | getParameter(...) [ : String] |
+| ResponseSplitting.java:29:38:29:72 | getParameter(...) | semmle.label | getParameter(...) |
+| ResponseSplitting.java:29:38:29:72 | getParameter(...) [ : String] | semmle.label | getParameter(...) [ : String] |
 #select
-| ResponseSplitting.java:23:23:23:28 | cookie | ResponseSplitting.java:22:39:22:66 | getParameter(...) [String] | ResponseSplitting.java:23:23:23:28 | cookie | Response-splitting vulnerability due to this $@. | ResponseSplitting.java:22:39:22:66 | getParameter(...) | user-provided value |
-| ResponseSplitting.java:28:38:28:72 | getParameter(...) | ResponseSplitting.java:28:38:28:72 | getParameter(...) [String] | ResponseSplitting.java:28:38:28:72 | getParameter(...) | Response-splitting vulnerability due to this $@. | ResponseSplitting.java:28:38:28:72 | getParameter(...) | user-provided value |
-| ResponseSplitting.java:29:38:29:72 | getParameter(...) | ResponseSplitting.java:29:38:29:72 | getParameter(...) [String] | ResponseSplitting.java:29:38:29:72 | getParameter(...) | Response-splitting vulnerability due to this $@. | ResponseSplitting.java:29:38:29:72 | getParameter(...) | user-provided value |
+| ResponseSplitting.java:23:23:23:28 | cookie | ResponseSplitting.java:22:39:22:66 | getParameter(...) [ : String] | ResponseSplitting.java:23:23:23:28 | cookie | Response-splitting vulnerability due to this $@. | ResponseSplitting.java:22:39:22:66 | getParameter(...) | user-provided value |
+| ResponseSplitting.java:28:38:28:72 | getParameter(...) | ResponseSplitting.java:28:38:28:72 | getParameter(...) [ : String] | ResponseSplitting.java:28:38:28:72 | getParameter(...) | Response-splitting vulnerability due to this $@. | ResponseSplitting.java:28:38:28:72 | getParameter(...) | user-provided value |
+| ResponseSplitting.java:29:38:29:72 | getParameter(...) | ResponseSplitting.java:29:38:29:72 | getParameter(...) [ : String] | ResponseSplitting.java:29:38:29:72 | getParameter(...) | Response-splitting vulnerability due to this $@. | ResponseSplitting.java:29:38:29:72 | getParameter(...) | user-provided value |

--- a/java/ql/test/query-tests/security/CWE-129/semmle/tests/ImproperValidationOfArrayConstructionCodeSpecified.expected
+++ b/java/ql/test/query-tests/security/CWE-129/semmle/tests/ImproperValidationOfArrayConstructionCodeSpecified.expected
@@ -1,4 +1,7 @@
 edges
-| Test.java:86:16:86:16 | 0 [Number] | Test.java:88:27:88:30 | size |
+| Test.java:86:16:86:16 | 0 [ : Number] | Test.java:88:27:88:30 | size |
+nodes
+| Test.java:86:16:86:16 | 0 [ : Number] | semmle.label | 0 [ : Number] |
+| Test.java:88:27:88:30 | size | semmle.label | size |
 #select
-| Test.java:91:30:91:30 | 0 | Test.java:86:16:86:16 | 0 [Number] | Test.java:88:27:88:30 | size | The $@ is accessed here, but the array is initialized using $@ which may be zero. | Test.java:88:19:88:31 | new int[] | array | Test.java:86:16:86:16 | 0 | literal value 0 |
+| Test.java:91:30:91:30 | 0 | Test.java:86:16:86:16 | 0 [ : Number] | Test.java:88:27:88:30 | size | The $@ is accessed here, but the array is initialized using $@ which may be zero. | Test.java:88:19:88:31 | new int[] | array | Test.java:86:16:86:16 | 0 | literal value 0 |

--- a/java/ql/test/query-tests/security/CWE-129/semmle/tests/ImproperValidationOfArrayConstructionLocal.expected
+++ b/java/ql/test/query-tests/security/CWE-129/semmle/tests/ImproperValidationOfArrayConstructionLocal.expected
@@ -1,6 +1,10 @@
 edges
-| Test.java:57:27:57:60 | getProperty(...) [String] | Test.java:61:31:61:34 | size |
-| Test.java:57:27:57:60 | getProperty(...) [String] | Test.java:67:34:67:37 | size |
+| Test.java:57:27:57:60 | getProperty(...) [ : String] | Test.java:61:31:61:34 | size |
+| Test.java:57:27:57:60 | getProperty(...) [ : String] | Test.java:67:34:67:37 | size |
+nodes
+| Test.java:57:27:57:60 | getProperty(...) [ : String] | semmle.label | getProperty(...) [ : String] |
+| Test.java:61:31:61:34 | size | semmle.label | size |
+| Test.java:67:34:67:37 | size | semmle.label | size |
 #select
-| Test.java:64:34:64:34 | 0 | Test.java:57:27:57:60 | getProperty(...) [String] | Test.java:61:31:61:34 | size | The $@ is accessed here, but the array is initialized using $@ which may be zero. | Test.java:61:23:61:35 | new int[] | array | Test.java:57:27:57:60 | getProperty(...) | User-provided value |
-| Test.java:70:37:70:37 | 0 | Test.java:57:27:57:60 | getProperty(...) [String] | Test.java:67:34:67:37 | size | The $@ is accessed here, but the array is initialized using $@ which may be zero. | Test.java:67:26:67:38 | new int[] | array | Test.java:57:27:57:60 | getProperty(...) | User-provided value |
+| Test.java:64:34:64:34 | 0 | Test.java:57:27:57:60 | getProperty(...) [ : String] | Test.java:61:31:61:34 | size | The $@ is accessed here, but the array is initialized using $@ which may be zero. | Test.java:61:23:61:35 | new int[] | array | Test.java:57:27:57:60 | getProperty(...) | User-provided value |
+| Test.java:70:37:70:37 | 0 | Test.java:57:27:57:60 | getProperty(...) [ : String] | Test.java:67:34:67:37 | size | The $@ is accessed here, but the array is initialized using $@ which may be zero. | Test.java:67:26:67:38 | new int[] | array | Test.java:57:27:57:60 | getProperty(...) | User-provided value |

--- a/java/ql/test/query-tests/security/CWE-129/semmle/tests/ImproperValidationOfArrayIndexCodeSpecified.expected
+++ b/java/ql/test/query-tests/security/CWE-129/semmle/tests/ImproperValidationOfArrayIndexCodeSpecified.expected
@@ -1,12 +1,29 @@
 edges
-| Test.java:40:17:40:48 | nextInt(...) [Number] | Test.java:43:30:43:34 | index |
-| Test.java:40:17:40:48 | nextInt(...) [Number] | Test.java:47:32:47:36 | index |
-| Test.java:40:17:40:48 | nextInt(...) [Number] | Test.java:51:39:51:43 | index |
-| Test.java:64:34:64:34 | 0 [Number] | Test.java:64:34:64:34 | 0 |
-| Test.java:70:37:70:37 | 0 [Number] | Test.java:70:37:70:37 | 0 |
-| Test.java:77:39:77:39 | 0 [Number] | Test.java:77:39:77:39 | 0 |
-| Test.java:91:30:91:30 | 0 [Number] | Test.java:91:30:91:30 | 0 |
-| Test.java:93:17:93:17 | 0 [Number] | Test.java:96:32:96:36 | index |
-| Test.java:102:30:102:30 | 0 [Number] | Test.java:102:30:102:30 | 0 |
+| Test.java:40:17:40:48 | nextInt(...) [ : Number] | Test.java:43:30:43:34 | index |
+| Test.java:40:17:40:48 | nextInt(...) [ : Number] | Test.java:47:32:47:36 | index |
+| Test.java:40:17:40:48 | nextInt(...) [ : Number] | Test.java:51:39:51:43 | index |
+| Test.java:64:34:64:34 | 0 [ : Number] | Test.java:64:34:64:34 | 0 |
+| Test.java:70:37:70:37 | 0 [ : Number] | Test.java:70:37:70:37 | 0 |
+| Test.java:77:39:77:39 | 0 [ : Number] | Test.java:77:39:77:39 | 0 |
+| Test.java:91:30:91:30 | 0 [ : Number] | Test.java:91:30:91:30 | 0 |
+| Test.java:93:17:93:17 | 0 [ : Number] | Test.java:96:32:96:36 | index |
+| Test.java:102:30:102:30 | 0 [ : Number] | Test.java:102:30:102:30 | 0 |
+nodes
+| Test.java:40:17:40:48 | nextInt(...) [ : Number] | semmle.label | nextInt(...) [ : Number] |
+| Test.java:43:30:43:34 | index | semmle.label | index |
+| Test.java:47:32:47:36 | index | semmle.label | index |
+| Test.java:51:39:51:43 | index | semmle.label | index |
+| Test.java:64:34:64:34 | 0 | semmle.label | 0 |
+| Test.java:64:34:64:34 | 0 [ : Number] | semmle.label | 0 [ : Number] |
+| Test.java:70:37:70:37 | 0 | semmle.label | 0 |
+| Test.java:70:37:70:37 | 0 [ : Number] | semmle.label | 0 [ : Number] |
+| Test.java:77:39:77:39 | 0 | semmle.label | 0 |
+| Test.java:77:39:77:39 | 0 [ : Number] | semmle.label | 0 [ : Number] |
+| Test.java:91:30:91:30 | 0 | semmle.label | 0 |
+| Test.java:91:30:91:30 | 0 [ : Number] | semmle.label | 0 [ : Number] |
+| Test.java:93:17:93:17 | 0 [ : Number] | semmle.label | 0 [ : Number] |
+| Test.java:96:32:96:36 | index | semmle.label | index |
+| Test.java:102:30:102:30 | 0 | semmle.label | 0 |
+| Test.java:102:30:102:30 | 0 [ : Number] | semmle.label | 0 [ : Number] |
 #select
-| Test.java:43:30:43:34 | index | Test.java:40:17:40:48 | nextInt(...) [Number] | Test.java:43:30:43:34 | index | $@ flows to the index used in this array access, and may cause the operation to throw an ArrayIndexOutOfBoundsException. | Test.java:40:17:40:48 | nextInt(...) | Random value |
+| Test.java:43:30:43:34 | index | Test.java:40:17:40:48 | nextInt(...) [ : Number] | Test.java:43:30:43:34 | index | $@ flows to the index used in this array access, and may cause the operation to throw an ArrayIndexOutOfBoundsException. | Test.java:40:17:40:48 | nextInt(...) | Random value |

--- a/java/ql/test/query-tests/security/CWE-129/semmle/tests/ImproperValidationOfArrayIndexLocal.expected
+++ b/java/ql/test/query-tests/security/CWE-129/semmle/tests/ImproperValidationOfArrayIndexLocal.expected
@@ -1,4 +1,7 @@
 edges
-| Test.java:13:27:13:60 | getProperty(...) [String] | Test.java:18:34:18:38 | index |
+| Test.java:13:27:13:60 | getProperty(...) [ : String] | Test.java:18:34:18:38 | index |
+nodes
+| Test.java:13:27:13:60 | getProperty(...) [ : String] | semmle.label | getProperty(...) [ : String] |
+| Test.java:18:34:18:38 | index | semmle.label | index |
 #select
-| Test.java:18:34:18:38 | index | Test.java:13:27:13:60 | getProperty(...) [String] | Test.java:18:34:18:38 | index | $@ flows to here and is used as an index causing an ArrayIndexOutOfBoundsException. | Test.java:13:27:13:60 | getProperty(...) | User-provided value |
+| Test.java:18:34:18:38 | index | Test.java:13:27:13:60 | getProperty(...) [ : String] | Test.java:18:34:18:38 | index | $@ flows to here and is used as an index causing an ArrayIndexOutOfBoundsException. | Test.java:13:27:13:60 | getProperty(...) | User-provided value |

--- a/java/ql/test/query-tests/security/CWE-134/semmle/tests/ExternallyControlledFormatString.expected
+++ b/java/ql/test/query-tests/security/CWE-134/semmle/tests/ExternallyControlledFormatString.expected
@@ -1,6 +1,11 @@
 edges
-| Test.java:33:30:33:74 | getParameter(...) [String] | Test.java:34:20:34:32 | userParameter [String] |
-| Test.java:34:20:34:32 | userParameter [String] | Test.java:37:31:37:43 | format [String] |
-| Test.java:37:31:37:43 | format [String] | Test.java:39:25:39:30 | format |
+| Test.java:33:30:33:74 | getParameter(...) [ : String] | Test.java:34:20:34:32 | userParameter [ : String] |
+| Test.java:34:20:34:32 | userParameter [ : String] | Test.java:37:31:37:43 | format [ : String] |
+| Test.java:37:31:37:43 | format [ : String] | Test.java:39:25:39:30 | format |
+nodes
+| Test.java:33:30:33:74 | getParameter(...) [ : String] | semmle.label | getParameter(...) [ : String] |
+| Test.java:34:20:34:32 | userParameter [ : String] | semmle.label | userParameter [ : String] |
+| Test.java:37:31:37:43 | format [ : String] | semmle.label | format [ : String] |
+| Test.java:39:25:39:30 | format | semmle.label | format |
 #select
-| Test.java:39:25:39:30 | format | Test.java:33:30:33:74 | getParameter(...) [String] | Test.java:39:25:39:30 | format | $@ flows to here and is used in a format string. | Test.java:33:30:33:74 | getParameter(...) | User-provided value |
+| Test.java:39:25:39:30 | format | Test.java:33:30:33:74 | getParameter(...) [ : String] | Test.java:39:25:39:30 | format | $@ flows to here and is used in a format string. | Test.java:33:30:33:74 | getParameter(...) | User-provided value |

--- a/java/ql/test/query-tests/security/CWE-134/semmle/tests/ExternallyControlledFormatStringLocal.expected
+++ b/java/ql/test/query-tests/security/CWE-134/semmle/tests/ExternallyControlledFormatStringLocal.expected
@@ -1,12 +1,19 @@
 edges
-| Test.java:17:27:17:60 | getProperty(...) [String] | Test.java:19:19:19:30 | userProperty |
-| Test.java:17:27:17:60 | getProperty(...) [String] | Test.java:21:23:21:34 | userProperty |
-| Test.java:17:27:17:60 | getProperty(...) [String] | Test.java:23:23:23:34 | userProperty |
-| Test.java:17:27:17:60 | getProperty(...) [String] | Test.java:25:28:25:39 | userProperty |
-| Test.java:17:27:17:60 | getProperty(...) [String] | Test.java:27:44:27:55 | userProperty |
+| Test.java:17:27:17:60 | getProperty(...) [ : String] | Test.java:19:19:19:30 | userProperty |
+| Test.java:17:27:17:60 | getProperty(...) [ : String] | Test.java:21:23:21:34 | userProperty |
+| Test.java:17:27:17:60 | getProperty(...) [ : String] | Test.java:23:23:23:34 | userProperty |
+| Test.java:17:27:17:60 | getProperty(...) [ : String] | Test.java:25:28:25:39 | userProperty |
+| Test.java:17:27:17:60 | getProperty(...) [ : String] | Test.java:27:44:27:55 | userProperty |
+nodes
+| Test.java:17:27:17:60 | getProperty(...) [ : String] | semmle.label | getProperty(...) [ : String] |
+| Test.java:19:19:19:30 | userProperty | semmle.label | userProperty |
+| Test.java:21:23:21:34 | userProperty | semmle.label | userProperty |
+| Test.java:23:23:23:34 | userProperty | semmle.label | userProperty |
+| Test.java:25:28:25:39 | userProperty | semmle.label | userProperty |
+| Test.java:27:44:27:55 | userProperty | semmle.label | userProperty |
 #select
-| Test.java:19:19:19:30 | userProperty | Test.java:17:27:17:60 | getProperty(...) [String] | Test.java:19:19:19:30 | userProperty | $@ flows to here and is used in a format string. | Test.java:17:27:17:60 | getProperty(...) | User-provided value |
-| Test.java:21:23:21:34 | userProperty | Test.java:17:27:17:60 | getProperty(...) [String] | Test.java:21:23:21:34 | userProperty | $@ flows to here and is used in a format string. | Test.java:17:27:17:60 | getProperty(...) | User-provided value |
-| Test.java:23:23:23:34 | userProperty | Test.java:17:27:17:60 | getProperty(...) [String] | Test.java:23:23:23:34 | userProperty | $@ flows to here and is used in a format string. | Test.java:17:27:17:60 | getProperty(...) | User-provided value |
-| Test.java:25:28:25:39 | userProperty | Test.java:17:27:17:60 | getProperty(...) [String] | Test.java:25:28:25:39 | userProperty | $@ flows to here and is used in a format string. | Test.java:17:27:17:60 | getProperty(...) | User-provided value |
-| Test.java:27:44:27:55 | userProperty | Test.java:17:27:17:60 | getProperty(...) [String] | Test.java:27:44:27:55 | userProperty | $@ flows to here and is used in a format string. | Test.java:17:27:17:60 | getProperty(...) | User-provided value |
+| Test.java:19:19:19:30 | userProperty | Test.java:17:27:17:60 | getProperty(...) [ : String] | Test.java:19:19:19:30 | userProperty | $@ flows to here and is used in a format string. | Test.java:17:27:17:60 | getProperty(...) | User-provided value |
+| Test.java:21:23:21:34 | userProperty | Test.java:17:27:17:60 | getProperty(...) [ : String] | Test.java:21:23:21:34 | userProperty | $@ flows to here and is used in a format string. | Test.java:17:27:17:60 | getProperty(...) | User-provided value |
+| Test.java:23:23:23:34 | userProperty | Test.java:17:27:17:60 | getProperty(...) [ : String] | Test.java:23:23:23:34 | userProperty | $@ flows to here and is used in a format string. | Test.java:17:27:17:60 | getProperty(...) | User-provided value |
+| Test.java:25:28:25:39 | userProperty | Test.java:17:27:17:60 | getProperty(...) [ : String] | Test.java:25:28:25:39 | userProperty | $@ flows to here and is used in a format string. | Test.java:17:27:17:60 | getProperty(...) | User-provided value |
+| Test.java:27:44:27:55 | userProperty | Test.java:17:27:17:60 | getProperty(...) [ : String] | Test.java:27:44:27:55 | userProperty | $@ flows to here and is used in a format string. | Test.java:17:27:17:60 | getProperty(...) | User-provided value |

--- a/java/ql/test/query-tests/security/CWE-190/semmle/tests/ArithmeticTaintedLocal.expected
+++ b/java/ql/test/query-tests/security/CWE-190/semmle/tests/ArithmeticTaintedLocal.expected
@@ -1,32 +1,56 @@
 edges
-| ArithmeticTainted.java:17:46:17:54 | System.in [InputStream] | ArithmeticTainted.java:32:17:32:20 | data |
-| ArithmeticTainted.java:17:46:17:54 | System.in [InputStream] | ArithmeticTainted.java:40:17:40:20 | data |
-| ArithmeticTainted.java:17:46:17:54 | System.in [InputStream] | ArithmeticTainted.java:50:17:50:20 | data |
-| ArithmeticTainted.java:17:46:17:54 | System.in [InputStream] | ArithmeticTainted.java:64:20:64:23 | data [Number] |
-| ArithmeticTainted.java:17:46:17:54 | System.in [InputStream] | ArithmeticTainted.java:95:37:95:40 | data |
-| ArithmeticTainted.java:17:46:17:54 | System.in [InputStream] | ArithmeticTainted.java:118:9:118:12 | data [Number] |
-| ArithmeticTainted.java:17:46:17:54 | System.in [InputStream] | ArithmeticTainted.java:119:10:119:13 | data [Number] |
-| ArithmeticTainted.java:17:46:17:54 | System.in [InputStream] | ArithmeticTainted.java:120:10:120:13 | data [Number] |
-| ArithmeticTainted.java:17:46:17:54 | System.in [InputStream] | ArithmeticTainted.java:121:10:121:13 | data [Number] |
+| ArithmeticTainted.java:17:46:17:54 | System.in [ : InputStream] | ArithmeticTainted.java:32:17:32:20 | data |
+| ArithmeticTainted.java:17:46:17:54 | System.in [ : InputStream] | ArithmeticTainted.java:40:17:40:20 | data |
+| ArithmeticTainted.java:17:46:17:54 | System.in [ : InputStream] | ArithmeticTainted.java:50:17:50:20 | data |
+| ArithmeticTainted.java:17:46:17:54 | System.in [ : InputStream] | ArithmeticTainted.java:64:20:64:23 | data [ : Number] |
+| ArithmeticTainted.java:17:46:17:54 | System.in [ : InputStream] | ArithmeticTainted.java:95:37:95:40 | data |
+| ArithmeticTainted.java:17:46:17:54 | System.in [ : InputStream] | ArithmeticTainted.java:118:9:118:12 | data [ : Number] |
+| ArithmeticTainted.java:17:46:17:54 | System.in [ : InputStream] | ArithmeticTainted.java:119:10:119:13 | data [ : Number] |
+| ArithmeticTainted.java:17:46:17:54 | System.in [ : InputStream] | ArithmeticTainted.java:120:10:120:13 | data [ : Number] |
+| ArithmeticTainted.java:17:46:17:54 | System.in [ : InputStream] | ArithmeticTainted.java:121:10:121:13 | data [ : Number] |
 | ArithmeticTainted.java:64:4:64:10 | tainted [post update] [dat : Number] | ArithmeticTainted.java:66:18:66:24 | tainted [dat : Number] |
-| ArithmeticTainted.java:64:20:64:23 | data [Number] | ArithmeticTainted.java:64:4:64:10 | tainted [post update] [dat : Number] |
-| ArithmeticTainted.java:66:18:66:24 | tainted [dat : Number] | ArithmeticTainted.java:66:18:66:34 | getData(...) [Number] |
-| ArithmeticTainted.java:66:18:66:34 | getData(...) [Number] | ArithmeticTainted.java:71:17:71:23 | herring |
-| ArithmeticTainted.java:118:9:118:12 | data [Number] | ArithmeticTainted.java:125:26:125:33 | data [Number] |
-| ArithmeticTainted.java:119:10:119:13 | data [Number] | ArithmeticTainted.java:129:27:129:34 | data [Number] |
-| ArithmeticTainted.java:120:10:120:13 | data [Number] | ArithmeticTainted.java:133:27:133:34 | data [Number] |
-| ArithmeticTainted.java:121:10:121:13 | data [Number] | ArithmeticTainted.java:137:27:137:34 | data [Number] |
-| ArithmeticTainted.java:125:26:125:33 | data [Number] | ArithmeticTainted.java:127:3:127:6 | data |
-| ArithmeticTainted.java:129:27:129:34 | data [Number] | ArithmeticTainted.java:131:5:131:8 | data |
-| ArithmeticTainted.java:133:27:133:34 | data [Number] | ArithmeticTainted.java:135:3:135:6 | data |
-| ArithmeticTainted.java:137:27:137:34 | data [Number] | ArithmeticTainted.java:139:5:139:8 | data |
+| ArithmeticTainted.java:64:20:64:23 | data [ : Number] | ArithmeticTainted.java:64:4:64:10 | tainted [post update] [dat : Number] |
+| ArithmeticTainted.java:66:18:66:24 | tainted [dat : Number] | ArithmeticTainted.java:66:18:66:34 | getData(...) [ : Number] |
+| ArithmeticTainted.java:66:18:66:34 | getData(...) [ : Number] | ArithmeticTainted.java:71:17:71:23 | herring |
+| ArithmeticTainted.java:118:9:118:12 | data [ : Number] | ArithmeticTainted.java:125:26:125:33 | data [ : Number] |
+| ArithmeticTainted.java:119:10:119:13 | data [ : Number] | ArithmeticTainted.java:129:27:129:34 | data [ : Number] |
+| ArithmeticTainted.java:120:10:120:13 | data [ : Number] | ArithmeticTainted.java:133:27:133:34 | data [ : Number] |
+| ArithmeticTainted.java:121:10:121:13 | data [ : Number] | ArithmeticTainted.java:137:27:137:34 | data [ : Number] |
+| ArithmeticTainted.java:125:26:125:33 | data [ : Number] | ArithmeticTainted.java:127:3:127:6 | data |
+| ArithmeticTainted.java:129:27:129:34 | data [ : Number] | ArithmeticTainted.java:131:5:131:8 | data |
+| ArithmeticTainted.java:133:27:133:34 | data [ : Number] | ArithmeticTainted.java:135:3:135:6 | data |
+| ArithmeticTainted.java:137:27:137:34 | data [ : Number] | ArithmeticTainted.java:139:5:139:8 | data |
+nodes
+| ArithmeticTainted.java:17:46:17:54 | System.in [ : InputStream] | semmle.label | System.in [ : InputStream] |
+| ArithmeticTainted.java:17:46:17:54 | System.in [ : InputStream] | semmle.label | System.in [ : InputStream] |
+| ArithmeticTainted.java:32:17:32:20 | data | semmle.label | data |
+| ArithmeticTainted.java:40:17:40:20 | data | semmle.label | data |
+| ArithmeticTainted.java:50:17:50:20 | data | semmle.label | data |
+| ArithmeticTainted.java:64:4:64:10 | tainted [post update] [dat : Number] | semmle.label | tainted [post update] [dat : Number] |
+| ArithmeticTainted.java:64:20:64:23 | data [ : Number] | semmle.label | data [ : Number] |
+| ArithmeticTainted.java:66:18:66:24 | tainted [dat : Number] | semmle.label | tainted [dat : Number] |
+| ArithmeticTainted.java:66:18:66:34 | getData(...) [ : Number] | semmle.label | getData(...) [ : Number] |
+| ArithmeticTainted.java:71:17:71:23 | herring | semmle.label | herring |
+| ArithmeticTainted.java:95:37:95:40 | data | semmle.label | data |
+| ArithmeticTainted.java:118:9:118:12 | data [ : Number] | semmle.label | data [ : Number] |
+| ArithmeticTainted.java:119:10:119:13 | data [ : Number] | semmle.label | data [ : Number] |
+| ArithmeticTainted.java:120:10:120:13 | data [ : Number] | semmle.label | data [ : Number] |
+| ArithmeticTainted.java:121:10:121:13 | data [ : Number] | semmle.label | data [ : Number] |
+| ArithmeticTainted.java:125:26:125:33 | data [ : Number] | semmle.label | data [ : Number] |
+| ArithmeticTainted.java:127:3:127:6 | data | semmle.label | data |
+| ArithmeticTainted.java:129:27:129:34 | data [ : Number] | semmle.label | data [ : Number] |
+| ArithmeticTainted.java:131:5:131:8 | data | semmle.label | data |
+| ArithmeticTainted.java:133:27:133:34 | data [ : Number] | semmle.label | data [ : Number] |
+| ArithmeticTainted.java:135:3:135:6 | data | semmle.label | data |
+| ArithmeticTainted.java:137:27:137:34 | data [ : Number] | semmle.label | data [ : Number] |
+| ArithmeticTainted.java:139:5:139:8 | data | semmle.label | data |
 #select
-| ArithmeticTainted.java:32:17:32:25 | ... + ... | ArithmeticTainted.java:17:46:17:54 | System.in [InputStream] | ArithmeticTainted.java:32:17:32:20 | data | $@ flows to here and is used in arithmetic, potentially causing an overflow. | ArithmeticTainted.java:17:46:17:54 | System.in | User-provided value |
-| ArithmeticTainted.java:40:17:40:25 | ... - ... | ArithmeticTainted.java:17:46:17:54 | System.in [InputStream] | ArithmeticTainted.java:40:17:40:20 | data | $@ flows to here and is used in arithmetic, potentially causing an underflow. | ArithmeticTainted.java:17:46:17:54 | System.in | User-provided value |
-| ArithmeticTainted.java:50:17:50:24 | ... + ... | ArithmeticTainted.java:17:46:17:54 | System.in [InputStream] | ArithmeticTainted.java:50:17:50:20 | data | $@ flows to here and is used in arithmetic, potentially causing an overflow. | ArithmeticTainted.java:17:46:17:54 | System.in | User-provided value |
-| ArithmeticTainted.java:71:17:71:27 | ... + ... | ArithmeticTainted.java:17:46:17:54 | System.in [InputStream] | ArithmeticTainted.java:71:17:71:23 | herring | $@ flows to here and is used in arithmetic, potentially causing an overflow. | ArithmeticTainted.java:17:46:17:54 | System.in | User-provided value |
-| ArithmeticTainted.java:95:37:95:46 | ... + ... | ArithmeticTainted.java:17:46:17:54 | System.in [InputStream] | ArithmeticTainted.java:95:37:95:40 | data | $@ flows to here and is used in arithmetic, potentially causing an overflow. | ArithmeticTainted.java:17:46:17:54 | System.in | User-provided value |
-| ArithmeticTainted.java:127:3:127:8 | ...++ | ArithmeticTainted.java:17:46:17:54 | System.in [InputStream] | ArithmeticTainted.java:127:3:127:6 | data | $@ flows to here and is used in arithmetic, potentially causing an overflow. | ArithmeticTainted.java:17:46:17:54 | System.in | User-provided value |
-| ArithmeticTainted.java:131:3:131:8 | ++... | ArithmeticTainted.java:17:46:17:54 | System.in [InputStream] | ArithmeticTainted.java:131:5:131:8 | data | $@ flows to here and is used in arithmetic, potentially causing an overflow. | ArithmeticTainted.java:17:46:17:54 | System.in | User-provided value |
-| ArithmeticTainted.java:135:3:135:8 | ...-- | ArithmeticTainted.java:17:46:17:54 | System.in [InputStream] | ArithmeticTainted.java:135:3:135:6 | data | $@ flows to here and is used in arithmetic, potentially causing an underflow. | ArithmeticTainted.java:17:46:17:54 | System.in | User-provided value |
-| ArithmeticTainted.java:139:3:139:8 | --... | ArithmeticTainted.java:17:46:17:54 | System.in [InputStream] | ArithmeticTainted.java:139:5:139:8 | data | $@ flows to here and is used in arithmetic, potentially causing an underflow. | ArithmeticTainted.java:17:46:17:54 | System.in | User-provided value |
+| ArithmeticTainted.java:32:17:32:25 | ... + ... | ArithmeticTainted.java:17:46:17:54 | System.in [ : InputStream] | ArithmeticTainted.java:32:17:32:20 | data | $@ flows to here and is used in arithmetic, potentially causing an overflow. | ArithmeticTainted.java:17:46:17:54 | System.in | User-provided value |
+| ArithmeticTainted.java:40:17:40:25 | ... - ... | ArithmeticTainted.java:17:46:17:54 | System.in [ : InputStream] | ArithmeticTainted.java:40:17:40:20 | data | $@ flows to here and is used in arithmetic, potentially causing an underflow. | ArithmeticTainted.java:17:46:17:54 | System.in | User-provided value |
+| ArithmeticTainted.java:50:17:50:24 | ... + ... | ArithmeticTainted.java:17:46:17:54 | System.in [ : InputStream] | ArithmeticTainted.java:50:17:50:20 | data | $@ flows to here and is used in arithmetic, potentially causing an overflow. | ArithmeticTainted.java:17:46:17:54 | System.in | User-provided value |
+| ArithmeticTainted.java:71:17:71:27 | ... + ... | ArithmeticTainted.java:17:46:17:54 | System.in [ : InputStream] | ArithmeticTainted.java:71:17:71:23 | herring | $@ flows to here and is used in arithmetic, potentially causing an overflow. | ArithmeticTainted.java:17:46:17:54 | System.in | User-provided value |
+| ArithmeticTainted.java:95:37:95:46 | ... + ... | ArithmeticTainted.java:17:46:17:54 | System.in [ : InputStream] | ArithmeticTainted.java:95:37:95:40 | data | $@ flows to here and is used in arithmetic, potentially causing an overflow. | ArithmeticTainted.java:17:46:17:54 | System.in | User-provided value |
+| ArithmeticTainted.java:127:3:127:8 | ...++ | ArithmeticTainted.java:17:46:17:54 | System.in [ : InputStream] | ArithmeticTainted.java:127:3:127:6 | data | $@ flows to here and is used in arithmetic, potentially causing an overflow. | ArithmeticTainted.java:17:46:17:54 | System.in | User-provided value |
+| ArithmeticTainted.java:131:3:131:8 | ++... | ArithmeticTainted.java:17:46:17:54 | System.in [ : InputStream] | ArithmeticTainted.java:131:5:131:8 | data | $@ flows to here and is used in arithmetic, potentially causing an overflow. | ArithmeticTainted.java:17:46:17:54 | System.in | User-provided value |
+| ArithmeticTainted.java:135:3:135:8 | ...-- | ArithmeticTainted.java:17:46:17:54 | System.in [ : InputStream] | ArithmeticTainted.java:135:3:135:6 | data | $@ flows to here and is used in arithmetic, potentially causing an underflow. | ArithmeticTainted.java:17:46:17:54 | System.in | User-provided value |
+| ArithmeticTainted.java:139:3:139:8 | --... | ArithmeticTainted.java:17:46:17:54 | System.in [ : InputStream] | ArithmeticTainted.java:139:5:139:8 | data | $@ flows to here and is used in arithmetic, potentially causing an underflow. | ArithmeticTainted.java:17:46:17:54 | System.in | User-provided value |

--- a/java/ql/test/query-tests/security/CWE-190/semmle/tests/ArithmeticUncontrolled.expected
+++ b/java/ql/test/query-tests/security/CWE-190/semmle/tests/ArithmeticUncontrolled.expected
@@ -1,6 +1,10 @@
 edges
-| Test.java:205:14:205:57 | nextInt(...) [Number] | Test.java:209:17:209:20 | data |
-| Test.java:205:14:205:57 | nextInt(...) [Number] | Test.java:240:37:240:40 | data |
+| Test.java:205:14:205:57 | nextInt(...) [ : Number] | Test.java:209:17:209:20 | data |
+| Test.java:205:14:205:57 | nextInt(...) [ : Number] | Test.java:240:37:240:40 | data |
+nodes
+| Test.java:205:14:205:57 | nextInt(...) [ : Number] | semmle.label | nextInt(...) [ : Number] |
+| Test.java:209:17:209:20 | data | semmle.label | data |
+| Test.java:240:37:240:40 | data | semmle.label | data |
 #select
-| Test.java:209:17:209:24 | ... + ... | Test.java:205:14:205:57 | nextInt(...) [Number] | Test.java:209:17:209:20 | data | $@ flows to here and is used in arithmetic, potentially causing an overflow. | Test.java:205:14:205:57 | nextInt(...) | Uncontrolled value |
-| Test.java:240:37:240:46 | ... + ... | Test.java:205:14:205:57 | nextInt(...) [Number] | Test.java:240:37:240:40 | data | $@ flows to here and is used in arithmetic, potentially causing an overflow. | Test.java:205:14:205:57 | nextInt(...) | Uncontrolled value |
+| Test.java:209:17:209:24 | ... + ... | Test.java:205:14:205:57 | nextInt(...) [ : Number] | Test.java:209:17:209:20 | data | $@ flows to here and is used in arithmetic, potentially causing an overflow. | Test.java:205:14:205:57 | nextInt(...) | Uncontrolled value |
+| Test.java:240:37:240:46 | ... + ... | Test.java:205:14:205:57 | nextInt(...) [ : Number] | Test.java:240:37:240:40 | data | $@ flows to here and is used in arithmetic, potentially causing an overflow. | Test.java:205:14:205:57 | nextInt(...) | Uncontrolled value |

--- a/java/ql/test/query-tests/security/CWE-190/semmle/tests/ArithmeticWithExtremeValues.expected
+++ b/java/ql/test/query-tests/security/CWE-190/semmle/tests/ArithmeticWithExtremeValues.expected
@@ -1,16 +1,31 @@
 edges
-| Test.java:92:8:92:24 | Integer.MAX_VALUE [Number] | Test.java:95:8:95:8 | i |
-| Test.java:108:13:108:26 | Long.MIN_VALUE [Number] | Test.java:110:13:110:13 | i |
-| Test.java:137:9:137:25 | Integer.MAX_VALUE [Number] | Test.java:138:14:138:14 | i |
-| Test.java:143:12:143:28 | Integer.MAX_VALUE [Number] | Test.java:146:14:146:14 | i |
-| Test.java:184:13:184:26 | Byte.MAX_VALUE [Number] | Test.java:187:39:187:39 | b |
-| Test.java:191:14:191:28 | Short.MAX_VALUE [Number] | Test.java:194:41:194:41 | s |
-| Test.java:198:12:198:28 | Integer.MAX_VALUE [Number] | Test.java:201:37:201:37 | i |
+| Test.java:92:8:92:24 | Integer.MAX_VALUE [ : Number] | Test.java:95:8:95:8 | i |
+| Test.java:108:13:108:26 | Long.MIN_VALUE [ : Number] | Test.java:110:13:110:13 | i |
+| Test.java:137:9:137:25 | Integer.MAX_VALUE [ : Number] | Test.java:138:14:138:14 | i |
+| Test.java:143:12:143:28 | Integer.MAX_VALUE [ : Number] | Test.java:146:14:146:14 | i |
+| Test.java:184:13:184:26 | Byte.MAX_VALUE [ : Number] | Test.java:187:39:187:39 | b |
+| Test.java:191:14:191:28 | Short.MAX_VALUE [ : Number] | Test.java:194:41:194:41 | s |
+| Test.java:198:12:198:28 | Integer.MAX_VALUE [ : Number] | Test.java:201:37:201:37 | i |
+nodes
+| Test.java:92:8:92:24 | Integer.MAX_VALUE [ : Number] | semmle.label | Integer.MAX_VALUE [ : Number] |
+| Test.java:95:8:95:8 | i | semmle.label | i |
+| Test.java:108:13:108:26 | Long.MIN_VALUE [ : Number] | semmle.label | Long.MIN_VALUE [ : Number] |
+| Test.java:110:13:110:13 | i | semmle.label | i |
+| Test.java:137:9:137:25 | Integer.MAX_VALUE [ : Number] | semmle.label | Integer.MAX_VALUE [ : Number] |
+| Test.java:138:14:138:14 | i | semmle.label | i |
+| Test.java:143:12:143:28 | Integer.MAX_VALUE [ : Number] | semmle.label | Integer.MAX_VALUE [ : Number] |
+| Test.java:146:14:146:14 | i | semmle.label | i |
+| Test.java:184:13:184:26 | Byte.MAX_VALUE [ : Number] | semmle.label | Byte.MAX_VALUE [ : Number] |
+| Test.java:187:39:187:39 | b | semmle.label | b |
+| Test.java:191:14:191:28 | Short.MAX_VALUE [ : Number] | semmle.label | Short.MAX_VALUE [ : Number] |
+| Test.java:194:41:194:41 | s | semmle.label | s |
+| Test.java:198:12:198:28 | Integer.MAX_VALUE [ : Number] | semmle.label | Integer.MAX_VALUE [ : Number] |
+| Test.java:201:37:201:37 | i | semmle.label | i |
 #select
-| Test.java:95:8:95:12 | ... + ... | Test.java:92:8:92:24 | Integer.MAX_VALUE [Number] | Test.java:95:8:95:8 | i | Variable i is assigned an extreme value $@, and may cause an overflow. | Test.java:92:8:92:24 | Integer.MAX_VALUE | MAX_VALUE |
-| Test.java:110:13:110:17 | ... - ... | Test.java:108:13:108:26 | Long.MIN_VALUE [Number] | Test.java:110:13:110:13 | i | Variable i is assigned an extreme value $@, and may cause an underflow. | Test.java:108:13:108:26 | Long.MIN_VALUE | MIN_VALUE |
-| Test.java:138:14:138:18 | ... + ... | Test.java:137:9:137:25 | Integer.MAX_VALUE [Number] | Test.java:138:14:138:14 | i | Variable i is assigned an extreme value $@, and may cause an overflow. | Test.java:137:9:137:25 | Integer.MAX_VALUE | MAX_VALUE |
-| Test.java:146:14:146:18 | ... + ... | Test.java:143:12:143:28 | Integer.MAX_VALUE [Number] | Test.java:146:14:146:14 | i | Variable i is assigned an extreme value $@, and may cause an overflow. | Test.java:143:12:143:28 | Integer.MAX_VALUE | MAX_VALUE |
-| Test.java:187:39:187:43 | ... + ... | Test.java:184:13:184:26 | Byte.MAX_VALUE [Number] | Test.java:187:39:187:39 | b | Variable b is assigned an extreme value $@, and may cause an overflow. | Test.java:184:13:184:26 | Byte.MAX_VALUE | MAX_VALUE |
-| Test.java:194:41:194:45 | ... + ... | Test.java:191:14:191:28 | Short.MAX_VALUE [Number] | Test.java:194:41:194:41 | s | Variable s is assigned an extreme value $@, and may cause an overflow. | Test.java:191:14:191:28 | Short.MAX_VALUE | MAX_VALUE |
-| Test.java:201:37:201:42 | ... + ... | Test.java:198:12:198:28 | Integer.MAX_VALUE [Number] | Test.java:201:37:201:37 | i | Variable i is assigned an extreme value $@, and may cause an overflow. | Test.java:198:12:198:28 | Integer.MAX_VALUE | MAX_VALUE |
+| Test.java:95:8:95:12 | ... + ... | Test.java:92:8:92:24 | Integer.MAX_VALUE [ : Number] | Test.java:95:8:95:8 | i | Variable i is assigned an extreme value $@, and may cause an overflow. | Test.java:92:8:92:24 | Integer.MAX_VALUE | MAX_VALUE |
+| Test.java:110:13:110:17 | ... - ... | Test.java:108:13:108:26 | Long.MIN_VALUE [ : Number] | Test.java:110:13:110:13 | i | Variable i is assigned an extreme value $@, and may cause an underflow. | Test.java:108:13:108:26 | Long.MIN_VALUE | MIN_VALUE |
+| Test.java:138:14:138:18 | ... + ... | Test.java:137:9:137:25 | Integer.MAX_VALUE [ : Number] | Test.java:138:14:138:14 | i | Variable i is assigned an extreme value $@, and may cause an overflow. | Test.java:137:9:137:25 | Integer.MAX_VALUE | MAX_VALUE |
+| Test.java:146:14:146:18 | ... + ... | Test.java:143:12:143:28 | Integer.MAX_VALUE [ : Number] | Test.java:146:14:146:14 | i | Variable i is assigned an extreme value $@, and may cause an overflow. | Test.java:143:12:143:28 | Integer.MAX_VALUE | MAX_VALUE |
+| Test.java:187:39:187:43 | ... + ... | Test.java:184:13:184:26 | Byte.MAX_VALUE [ : Number] | Test.java:187:39:187:39 | b | Variable b is assigned an extreme value $@, and may cause an overflow. | Test.java:184:13:184:26 | Byte.MAX_VALUE | MAX_VALUE |
+| Test.java:194:41:194:45 | ... + ... | Test.java:191:14:191:28 | Short.MAX_VALUE [ : Number] | Test.java:194:41:194:41 | s | Variable s is assigned an extreme value $@, and may cause an overflow. | Test.java:191:14:191:28 | Short.MAX_VALUE | MAX_VALUE |
+| Test.java:201:37:201:42 | ... + ... | Test.java:198:12:198:28 | Integer.MAX_VALUE [ : Number] | Test.java:201:37:201:37 | i | Variable i is assigned an extreme value $@, and may cause an overflow. | Test.java:198:12:198:28 | Integer.MAX_VALUE | MAX_VALUE |

--- a/java/ql/test/query-tests/security/CWE-327/semmle/tests/BrokenCryptoAlgorithm.expected
+++ b/java/ql/test/query-tests/security/CWE-327/semmle/tests/BrokenCryptoAlgorithm.expected
@@ -1,6 +1,11 @@
 edges
-| Test.java:19:45:19:49 | "DES" [String] | Test.java:19:45:19:49 | "DES" |
-| Test.java:42:33:42:37 | "RC2" [String] | Test.java:42:33:42:37 | "RC2" |
+| Test.java:19:45:19:49 | "DES" [ : String] | Test.java:19:45:19:49 | "DES" |
+| Test.java:42:33:42:37 | "RC2" [ : String] | Test.java:42:33:42:37 | "RC2" |
+nodes
+| Test.java:19:45:19:49 | "DES" | semmle.label | "DES" |
+| Test.java:19:45:19:49 | "DES" [ : String] | semmle.label | "DES" [ : String] |
+| Test.java:42:33:42:37 | "RC2" | semmle.label | "RC2" |
+| Test.java:42:33:42:37 | "RC2" [ : String] | semmle.label | "RC2" [ : String] |
 #select
-| Test.java:19:20:19:50 | getInstance(...) | Test.java:19:45:19:49 | "DES" [String] | Test.java:19:45:19:49 | "DES" | Cryptographic algorithm $@ is weak and should not be used. | Test.java:19:45:19:49 | "DES" | "DES" |
-| Test.java:42:14:42:38 | getInstance(...) | Test.java:42:33:42:37 | "RC2" [String] | Test.java:42:33:42:37 | "RC2" | Cryptographic algorithm $@ is weak and should not be used. | Test.java:42:33:42:37 | "RC2" | "RC2" |
+| Test.java:19:20:19:50 | getInstance(...) | Test.java:19:45:19:49 | "DES" [ : String] | Test.java:19:45:19:49 | "DES" | Cryptographic algorithm $@ is weak and should not be used. | Test.java:19:45:19:49 | "DES" | "DES" |
+| Test.java:42:14:42:38 | getInstance(...) | Test.java:42:33:42:37 | "RC2" [ : String] | Test.java:42:33:42:37 | "RC2" | Cryptographic algorithm $@ is weak and should not be used. | Test.java:42:33:42:37 | "RC2" | "RC2" |

--- a/java/ql/test/query-tests/security/CWE-327/semmle/tests/MaybeBrokenCryptoAlgorithm.expected
+++ b/java/ql/test/query-tests/security/CWE-327/semmle/tests/MaybeBrokenCryptoAlgorithm.expected
@@ -1,4 +1,7 @@
 edges
-| Test.java:34:48:34:52 | "foo" [String] | Test.java:34:48:34:52 | "foo" |
+| Test.java:34:48:34:52 | "foo" [ : String] | Test.java:34:48:34:52 | "foo" |
+nodes
+| Test.java:34:48:34:52 | "foo" | semmle.label | "foo" |
+| Test.java:34:48:34:52 | "foo" [ : String] | semmle.label | "foo" [ : String] |
 #select
-| Test.java:34:21:34:53 | new SecretKeySpec(...) | Test.java:34:48:34:52 | "foo" [String] | Test.java:34:48:34:52 | "foo" | Cryptographic algorithm $@ may not be secure, consider using a different algorithm. | Test.java:34:48:34:52 | "foo" | "foo" |
+| Test.java:34:21:34:53 | new SecretKeySpec(...) | Test.java:34:48:34:52 | "foo" [ : String] | Test.java:34:48:34:52 | "foo" | Cryptographic algorithm $@ may not be secure, consider using a different algorithm. | Test.java:34:48:34:52 | "foo" | "foo" |

--- a/java/ql/test/query-tests/security/CWE-502/UnsafeDeserialization.expected
+++ b/java/ql/test/query-tests/security/CWE-502/UnsafeDeserialization.expected
@@ -1,38 +1,65 @@
 edges
-| A.java:13:31:13:51 | getInputStream(...) [InputStream] | A.java:15:12:15:13 | in |
-| A.java:19:31:19:51 | getInputStream(...) [InputStream] | A.java:21:12:21:13 | in |
-| A.java:25:31:25:51 | getInputStream(...) [InputStream] | A.java:27:12:27:12 | d |
-| A.java:32:31:32:51 | getInputStream(...) [InputStream] | A.java:34:23:34:28 | reader |
-| A.java:39:29:39:49 | getInputStream(...) [InputStream] | A.java:40:28:40:32 | input |
-| A.java:39:29:39:49 | getInputStream(...) [InputStream] | A.java:41:34:41:38 | input |
-| A.java:39:29:39:49 | getInputStream(...) [InputStream] | A.java:42:40:42:44 | input |
-| A.java:60:25:60:45 | getInputStream(...) [InputStream] | A.java:61:26:61:30 | input |
-| A.java:60:25:60:45 | getInputStream(...) [InputStream] | A.java:62:30:62:34 | input |
-| A.java:60:25:60:45 | getInputStream(...) [InputStream] | A.java:63:28:63:55 | new InputStreamReader(...) |
-| A.java:60:25:60:45 | getInputStream(...) [InputStream] | A.java:64:24:64:28 | input |
-| A.java:60:25:60:45 | getInputStream(...) [InputStream] | A.java:65:24:65:51 | new InputStreamReader(...) |
-| A.java:70:25:70:45 | getInputStream(...) [InputStream] | A.java:71:26:71:30 | input |
-| A.java:70:25:70:45 | getInputStream(...) [InputStream] | A.java:72:30:72:34 | input |
-| A.java:70:25:70:45 | getInputStream(...) [InputStream] | A.java:73:28:73:55 | new InputStreamReader(...) |
-| A.java:70:25:70:45 | getInputStream(...) [InputStream] | A.java:74:24:74:28 | input |
-| A.java:70:25:70:45 | getInputStream(...) [InputStream] | A.java:75:24:75:51 | new InputStreamReader(...) |
-| TestMessageBodyReader.java:20:55:20:78 | entityStream [InputStream] | TestMessageBodyReader.java:22:18:22:52 | new ObjectInputStream(...) |
+| A.java:13:31:13:51 | getInputStream(...) [ : InputStream] | A.java:15:12:15:13 | in |
+| A.java:19:31:19:51 | getInputStream(...) [ : InputStream] | A.java:21:12:21:13 | in |
+| A.java:25:31:25:51 | getInputStream(...) [ : InputStream] | A.java:27:12:27:12 | d |
+| A.java:32:31:32:51 | getInputStream(...) [ : InputStream] | A.java:34:23:34:28 | reader |
+| A.java:39:29:39:49 | getInputStream(...) [ : InputStream] | A.java:40:28:40:32 | input |
+| A.java:39:29:39:49 | getInputStream(...) [ : InputStream] | A.java:41:34:41:38 | input |
+| A.java:39:29:39:49 | getInputStream(...) [ : InputStream] | A.java:42:40:42:44 | input |
+| A.java:60:25:60:45 | getInputStream(...) [ : InputStream] | A.java:61:26:61:30 | input |
+| A.java:60:25:60:45 | getInputStream(...) [ : InputStream] | A.java:62:30:62:34 | input |
+| A.java:60:25:60:45 | getInputStream(...) [ : InputStream] | A.java:63:28:63:55 | new InputStreamReader(...) |
+| A.java:60:25:60:45 | getInputStream(...) [ : InputStream] | A.java:64:24:64:28 | input |
+| A.java:60:25:60:45 | getInputStream(...) [ : InputStream] | A.java:65:24:65:51 | new InputStreamReader(...) |
+| A.java:70:25:70:45 | getInputStream(...) [ : InputStream] | A.java:71:26:71:30 | input |
+| A.java:70:25:70:45 | getInputStream(...) [ : InputStream] | A.java:72:30:72:34 | input |
+| A.java:70:25:70:45 | getInputStream(...) [ : InputStream] | A.java:73:28:73:55 | new InputStreamReader(...) |
+| A.java:70:25:70:45 | getInputStream(...) [ : InputStream] | A.java:74:24:74:28 | input |
+| A.java:70:25:70:45 | getInputStream(...) [ : InputStream] | A.java:75:24:75:51 | new InputStreamReader(...) |
+| TestMessageBodyReader.java:20:55:20:78 | entityStream [ : InputStream] | TestMessageBodyReader.java:22:18:22:52 | new ObjectInputStream(...) |
+nodes
+| A.java:13:31:13:51 | getInputStream(...) [ : InputStream] | semmle.label | getInputStream(...) [ : InputStream] |
+| A.java:15:12:15:13 | in | semmle.label | in |
+| A.java:19:31:19:51 | getInputStream(...) [ : InputStream] | semmle.label | getInputStream(...) [ : InputStream] |
+| A.java:21:12:21:13 | in | semmle.label | in |
+| A.java:25:31:25:51 | getInputStream(...) [ : InputStream] | semmle.label | getInputStream(...) [ : InputStream] |
+| A.java:27:12:27:12 | d | semmle.label | d |
+| A.java:32:31:32:51 | getInputStream(...) [ : InputStream] | semmle.label | getInputStream(...) [ : InputStream] |
+| A.java:34:23:34:28 | reader | semmle.label | reader |
+| A.java:39:29:39:49 | getInputStream(...) [ : InputStream] | semmle.label | getInputStream(...) [ : InputStream] |
+| A.java:40:28:40:32 | input | semmle.label | input |
+| A.java:41:34:41:38 | input | semmle.label | input |
+| A.java:42:40:42:44 | input | semmle.label | input |
+| A.java:60:25:60:45 | getInputStream(...) [ : InputStream] | semmle.label | getInputStream(...) [ : InputStream] |
+| A.java:61:26:61:30 | input | semmle.label | input |
+| A.java:62:30:62:34 | input | semmle.label | input |
+| A.java:63:28:63:55 | new InputStreamReader(...) | semmle.label | new InputStreamReader(...) |
+| A.java:64:24:64:28 | input | semmle.label | input |
+| A.java:65:24:65:51 | new InputStreamReader(...) | semmle.label | new InputStreamReader(...) |
+| A.java:70:25:70:45 | getInputStream(...) [ : InputStream] | semmle.label | getInputStream(...) [ : InputStream] |
+| A.java:71:26:71:30 | input | semmle.label | input |
+| A.java:72:30:72:34 | input | semmle.label | input |
+| A.java:73:28:73:55 | new InputStreamReader(...) | semmle.label | new InputStreamReader(...) |
+| A.java:74:24:74:28 | input | semmle.label | input |
+| A.java:75:24:75:51 | new InputStreamReader(...) | semmle.label | new InputStreamReader(...) |
+| TestMessageBodyReader.java:20:55:20:78 | entityStream [ : InputStream] | semmle.label | entityStream [ : InputStream] |
+| TestMessageBodyReader.java:22:18:22:52 | new ObjectInputStream(...) | semmle.label | new ObjectInputStream(...) |
 #select
-| A.java:15:12:15:26 | readObject(...) | A.java:13:31:13:51 | getInputStream(...) [InputStream] | A.java:15:12:15:13 | in | Unsafe deserialization of $@. | A.java:13:31:13:51 | getInputStream(...) | user input |
-| A.java:21:12:21:28 | readUnshared(...) | A.java:19:31:19:51 | getInputStream(...) [InputStream] | A.java:21:12:21:13 | in | Unsafe deserialization of $@. | A.java:19:31:19:51 | getInputStream(...) | user input |
-| A.java:27:12:27:25 | readObject(...) | A.java:25:31:25:51 | getInputStream(...) [InputStream] | A.java:27:12:27:12 | d | Unsafe deserialization of $@. | A.java:25:31:25:51 | getInputStream(...) | user input |
-| A.java:34:12:34:29 | fromXML(...) | A.java:32:31:32:51 | getInputStream(...) [InputStream] | A.java:34:23:34:28 | reader | Unsafe deserialization of $@. | A.java:32:31:32:51 | getInputStream(...) | user input |
-| A.java:40:12:40:42 | readObject(...) | A.java:39:29:39:49 | getInputStream(...) [InputStream] | A.java:40:28:40:32 | input | Unsafe deserialization of $@. | A.java:39:29:39:49 | getInputStream(...) | user input |
-| A.java:41:12:41:48 | readObjectOrNull(...) | A.java:39:29:39:49 | getInputStream(...) [InputStream] | A.java:41:34:41:38 | input | Unsafe deserialization of $@. | A.java:39:29:39:49 | getInputStream(...) | user input |
-| A.java:42:16:42:45 | readClassAndObject(...) | A.java:39:29:39:49 | getInputStream(...) [InputStream] | A.java:42:40:42:44 | input | Unsafe deserialization of $@. | A.java:39:29:39:49 | getInputStream(...) | user input |
-| A.java:61:16:61:31 | load(...) | A.java:60:25:60:45 | getInputStream(...) [InputStream] | A.java:61:26:61:30 | input | Unsafe deserialization of $@. | A.java:60:25:60:45 | getInputStream(...) | user input |
-| A.java:62:17:62:35 | loadAll(...) | A.java:60:25:60:45 | getInputStream(...) [InputStream] | A.java:62:30:62:34 | input | Unsafe deserialization of $@. | A.java:60:25:60:45 | getInputStream(...) | user input |
-| A.java:63:17:63:56 | parse(...) | A.java:60:25:60:45 | getInputStream(...) [InputStream] | A.java:63:28:63:55 | new InputStreamReader(...) | Unsafe deserialization of $@. | A.java:60:25:60:45 | getInputStream(...) | user input |
-| A.java:64:12:64:38 | loadAs(...) | A.java:60:25:60:45 | getInputStream(...) [InputStream] | A.java:64:24:64:28 | input | Unsafe deserialization of $@. | A.java:60:25:60:45 | getInputStream(...) | user input |
-| A.java:65:12:65:61 | loadAs(...) | A.java:60:25:60:45 | getInputStream(...) [InputStream] | A.java:65:24:65:51 | new InputStreamReader(...) | Unsafe deserialization of $@. | A.java:60:25:60:45 | getInputStream(...) | user input |
-| A.java:71:16:71:31 | load(...) | A.java:70:25:70:45 | getInputStream(...) [InputStream] | A.java:71:26:71:30 | input | Unsafe deserialization of $@. | A.java:70:25:70:45 | getInputStream(...) | user input |
-| A.java:72:17:72:35 | loadAll(...) | A.java:70:25:70:45 | getInputStream(...) [InputStream] | A.java:72:30:72:34 | input | Unsafe deserialization of $@. | A.java:70:25:70:45 | getInputStream(...) | user input |
-| A.java:73:17:73:56 | parse(...) | A.java:70:25:70:45 | getInputStream(...) [InputStream] | A.java:73:28:73:55 | new InputStreamReader(...) | Unsafe deserialization of $@. | A.java:70:25:70:45 | getInputStream(...) | user input |
-| A.java:74:12:74:38 | loadAs(...) | A.java:70:25:70:45 | getInputStream(...) [InputStream] | A.java:74:24:74:28 | input | Unsafe deserialization of $@. | A.java:70:25:70:45 | getInputStream(...) | user input |
-| A.java:75:12:75:61 | loadAs(...) | A.java:70:25:70:45 | getInputStream(...) [InputStream] | A.java:75:24:75:51 | new InputStreamReader(...) | Unsafe deserialization of $@. | A.java:70:25:70:45 | getInputStream(...) | user input |
-| TestMessageBodyReader.java:22:18:22:65 | readObject(...) | TestMessageBodyReader.java:20:55:20:78 | entityStream [InputStream] | TestMessageBodyReader.java:22:18:22:52 | new ObjectInputStream(...) | Unsafe deserialization of $@. | TestMessageBodyReader.java:20:55:20:78 | entityStream | user input |
+| A.java:15:12:15:26 | readObject(...) | A.java:13:31:13:51 | getInputStream(...) [ : InputStream] | A.java:15:12:15:13 | in | Unsafe deserialization of $@. | A.java:13:31:13:51 | getInputStream(...) | user input |
+| A.java:21:12:21:28 | readUnshared(...) | A.java:19:31:19:51 | getInputStream(...) [ : InputStream] | A.java:21:12:21:13 | in | Unsafe deserialization of $@. | A.java:19:31:19:51 | getInputStream(...) | user input |
+| A.java:27:12:27:25 | readObject(...) | A.java:25:31:25:51 | getInputStream(...) [ : InputStream] | A.java:27:12:27:12 | d | Unsafe deserialization of $@. | A.java:25:31:25:51 | getInputStream(...) | user input |
+| A.java:34:12:34:29 | fromXML(...) | A.java:32:31:32:51 | getInputStream(...) [ : InputStream] | A.java:34:23:34:28 | reader | Unsafe deserialization of $@. | A.java:32:31:32:51 | getInputStream(...) | user input |
+| A.java:40:12:40:42 | readObject(...) | A.java:39:29:39:49 | getInputStream(...) [ : InputStream] | A.java:40:28:40:32 | input | Unsafe deserialization of $@. | A.java:39:29:39:49 | getInputStream(...) | user input |
+| A.java:41:12:41:48 | readObjectOrNull(...) | A.java:39:29:39:49 | getInputStream(...) [ : InputStream] | A.java:41:34:41:38 | input | Unsafe deserialization of $@. | A.java:39:29:39:49 | getInputStream(...) | user input |
+| A.java:42:16:42:45 | readClassAndObject(...) | A.java:39:29:39:49 | getInputStream(...) [ : InputStream] | A.java:42:40:42:44 | input | Unsafe deserialization of $@. | A.java:39:29:39:49 | getInputStream(...) | user input |
+| A.java:61:16:61:31 | load(...) | A.java:60:25:60:45 | getInputStream(...) [ : InputStream] | A.java:61:26:61:30 | input | Unsafe deserialization of $@. | A.java:60:25:60:45 | getInputStream(...) | user input |
+| A.java:62:17:62:35 | loadAll(...) | A.java:60:25:60:45 | getInputStream(...) [ : InputStream] | A.java:62:30:62:34 | input | Unsafe deserialization of $@. | A.java:60:25:60:45 | getInputStream(...) | user input |
+| A.java:63:17:63:56 | parse(...) | A.java:60:25:60:45 | getInputStream(...) [ : InputStream] | A.java:63:28:63:55 | new InputStreamReader(...) | Unsafe deserialization of $@. | A.java:60:25:60:45 | getInputStream(...) | user input |
+| A.java:64:12:64:38 | loadAs(...) | A.java:60:25:60:45 | getInputStream(...) [ : InputStream] | A.java:64:24:64:28 | input | Unsafe deserialization of $@. | A.java:60:25:60:45 | getInputStream(...) | user input |
+| A.java:65:12:65:61 | loadAs(...) | A.java:60:25:60:45 | getInputStream(...) [ : InputStream] | A.java:65:24:65:51 | new InputStreamReader(...) | Unsafe deserialization of $@. | A.java:60:25:60:45 | getInputStream(...) | user input |
+| A.java:71:16:71:31 | load(...) | A.java:70:25:70:45 | getInputStream(...) [ : InputStream] | A.java:71:26:71:30 | input | Unsafe deserialization of $@. | A.java:70:25:70:45 | getInputStream(...) | user input |
+| A.java:72:17:72:35 | loadAll(...) | A.java:70:25:70:45 | getInputStream(...) [ : InputStream] | A.java:72:30:72:34 | input | Unsafe deserialization of $@. | A.java:70:25:70:45 | getInputStream(...) | user input |
+| A.java:73:17:73:56 | parse(...) | A.java:70:25:70:45 | getInputStream(...) [ : InputStream] | A.java:73:28:73:55 | new InputStreamReader(...) | Unsafe deserialization of $@. | A.java:70:25:70:45 | getInputStream(...) | user input |
+| A.java:74:12:74:38 | loadAs(...) | A.java:70:25:70:45 | getInputStream(...) [ : InputStream] | A.java:74:24:74:28 | input | Unsafe deserialization of $@. | A.java:70:25:70:45 | getInputStream(...) | user input |
+| A.java:75:12:75:61 | loadAs(...) | A.java:70:25:70:45 | getInputStream(...) [ : InputStream] | A.java:75:24:75:51 | new InputStreamReader(...) | Unsafe deserialization of $@. | A.java:70:25:70:45 | getInputStream(...) | user input |
+| TestMessageBodyReader.java:22:18:22:65 | readObject(...) | TestMessageBodyReader.java:20:55:20:78 | entityStream [ : InputStream] | TestMessageBodyReader.java:22:18:22:52 | new ObjectInputStream(...) | Unsafe deserialization of $@. | TestMessageBodyReader.java:20:55:20:78 | entityStream | user input |

--- a/java/ql/test/query-tests/security/CWE-601/semmle/tests/UrlRedirect.expected
+++ b/java/ql/test/query-tests/security/CWE-601/semmle/tests/UrlRedirect.expected
@@ -1,10 +1,19 @@
 edges
-| UrlRedirect.java:23:25:23:54 | getParameter(...) [String] | UrlRedirect.java:23:25:23:54 | getParameter(...) |
-| UrlRedirect.java:36:58:36:89 | getParameter(...) [String] | UrlRedirect.java:36:25:36:89 | ... + ... |
-| UrlRedirect.java:39:34:39:63 | getParameter(...) [String] | UrlRedirect.java:39:34:39:63 | getParameter(...) |
-| UrlRedirect.java:42:43:42:72 | getParameter(...) [String] | UrlRedirect.java:42:43:42:72 | getParameter(...) |
+| UrlRedirect.java:23:25:23:54 | getParameter(...) [ : String] | UrlRedirect.java:23:25:23:54 | getParameter(...) |
+| UrlRedirect.java:36:58:36:89 | getParameter(...) [ : String] | UrlRedirect.java:36:25:36:89 | ... + ... |
+| UrlRedirect.java:39:34:39:63 | getParameter(...) [ : String] | UrlRedirect.java:39:34:39:63 | getParameter(...) |
+| UrlRedirect.java:42:43:42:72 | getParameter(...) [ : String] | UrlRedirect.java:42:43:42:72 | getParameter(...) |
+nodes
+| UrlRedirect.java:23:25:23:54 | getParameter(...) | semmle.label | getParameter(...) |
+| UrlRedirect.java:23:25:23:54 | getParameter(...) [ : String] | semmle.label | getParameter(...) [ : String] |
+| UrlRedirect.java:36:25:36:89 | ... + ... | semmle.label | ... + ... |
+| UrlRedirect.java:36:58:36:89 | getParameter(...) [ : String] | semmle.label | getParameter(...) [ : String] |
+| UrlRedirect.java:39:34:39:63 | getParameter(...) | semmle.label | getParameter(...) |
+| UrlRedirect.java:39:34:39:63 | getParameter(...) [ : String] | semmle.label | getParameter(...) [ : String] |
+| UrlRedirect.java:42:43:42:72 | getParameter(...) | semmle.label | getParameter(...) |
+| UrlRedirect.java:42:43:42:72 | getParameter(...) [ : String] | semmle.label | getParameter(...) [ : String] |
 #select
-| UrlRedirect.java:23:25:23:54 | getParameter(...) | UrlRedirect.java:23:25:23:54 | getParameter(...) [String] | UrlRedirect.java:23:25:23:54 | getParameter(...) | Potentially untrusted URL redirection due to $@. | UrlRedirect.java:23:25:23:54 | getParameter(...) | user-provided value |
-| UrlRedirect.java:36:25:36:89 | ... + ... | UrlRedirect.java:36:58:36:89 | getParameter(...) [String] | UrlRedirect.java:36:25:36:89 | ... + ... | Potentially untrusted URL redirection due to $@. | UrlRedirect.java:36:58:36:89 | getParameter(...) | user-provided value |
-| UrlRedirect.java:39:34:39:63 | getParameter(...) | UrlRedirect.java:39:34:39:63 | getParameter(...) [String] | UrlRedirect.java:39:34:39:63 | getParameter(...) | Potentially untrusted URL redirection due to $@. | UrlRedirect.java:39:34:39:63 | getParameter(...) | user-provided value |
-| UrlRedirect.java:42:43:42:72 | getParameter(...) | UrlRedirect.java:42:43:42:72 | getParameter(...) [String] | UrlRedirect.java:42:43:42:72 | getParameter(...) | Potentially untrusted URL redirection due to $@. | UrlRedirect.java:42:43:42:72 | getParameter(...) | user-provided value |
+| UrlRedirect.java:23:25:23:54 | getParameter(...) | UrlRedirect.java:23:25:23:54 | getParameter(...) [ : String] | UrlRedirect.java:23:25:23:54 | getParameter(...) | Potentially untrusted URL redirection due to $@. | UrlRedirect.java:23:25:23:54 | getParameter(...) | user-provided value |
+| UrlRedirect.java:36:25:36:89 | ... + ... | UrlRedirect.java:36:58:36:89 | getParameter(...) [ : String] | UrlRedirect.java:36:25:36:89 | ... + ... | Potentially untrusted URL redirection due to $@. | UrlRedirect.java:36:58:36:89 | getParameter(...) | user-provided value |
+| UrlRedirect.java:39:34:39:63 | getParameter(...) | UrlRedirect.java:39:34:39:63 | getParameter(...) [ : String] | UrlRedirect.java:39:34:39:63 | getParameter(...) | Potentially untrusted URL redirection due to $@. | UrlRedirect.java:39:34:39:63 | getParameter(...) | user-provided value |
+| UrlRedirect.java:42:43:42:72 | getParameter(...) | UrlRedirect.java:42:43:42:72 | getParameter(...) [ : String] | UrlRedirect.java:42:43:42:72 | getParameter(...) | Potentially untrusted URL redirection due to $@. | UrlRedirect.java:42:43:42:72 | getParameter(...) | user-provided value |

--- a/java/ql/test/query-tests/security/CWE-611/XXE.expected
+++ b/java/ql/test/query-tests/security/CWE-611/XXE.expected
@@ -1,190 +1,378 @@
 edges
-| DocumentBuilderTests.java:14:19:14:39 | getInputStream(...) [InputStream] | DocumentBuilderTests.java:14:19:14:39 | getInputStream(...) |
-| DocumentBuilderTests.java:42:19:42:39 | getInputStream(...) [InputStream] | DocumentBuilderTests.java:42:19:42:39 | getInputStream(...) |
-| DocumentBuilderTests.java:49:19:49:39 | getInputStream(...) [InputStream] | DocumentBuilderTests.java:49:19:49:39 | getInputStream(...) |
-| DocumentBuilderTests.java:64:19:64:39 | getInputStream(...) [InputStream] | DocumentBuilderTests.java:64:19:64:39 | getInputStream(...) |
-| DocumentBuilderTests.java:71:19:71:39 | getInputStream(...) [InputStream] | DocumentBuilderTests.java:71:19:71:39 | getInputStream(...) |
-| DocumentBuilderTests.java:79:19:79:39 | getInputStream(...) [InputStream] | DocumentBuilderTests.java:79:19:79:39 | getInputStream(...) |
-| DocumentBuilderTests.java:87:19:87:39 | getInputStream(...) [InputStream] | DocumentBuilderTests.java:87:19:87:39 | getInputStream(...) |
-| DocumentBuilderTests.java:93:51:93:71 | getInputStream(...) [InputStream] | DocumentBuilderTests.java:94:16:94:38 | getInputSource(...) |
-| DocumentBuilderTests.java:100:41:100:61 | getInputStream(...) [InputStream] | DocumentBuilderTests.java:101:16:101:52 | sourceToInputSource(...) |
-| DocumentBuilderTests.java:100:41:100:61 | getInputStream(...) [InputStream] | DocumentBuilderTests.java:102:16:102:38 | getInputStream(...) |
-| SAXBuilderTests.java:8:19:8:39 | getInputStream(...) [InputStream] | SAXBuilderTests.java:8:19:8:39 | getInputStream(...) |
-| SAXBuilderTests.java:20:19:20:39 | getInputStream(...) [InputStream] | SAXBuilderTests.java:20:19:20:39 | getInputStream(...) |
-| SAXParserTests.java:13:18:13:38 | getInputStream(...) [InputStream] | SAXParserTests.java:13:18:13:38 | getInputStream(...) |
-| SAXParserTests.java:30:18:30:38 | getInputStream(...) [InputStream] | SAXParserTests.java:30:18:30:38 | getInputStream(...) |
-| SAXParserTests.java:38:18:38:38 | getInputStream(...) [InputStream] | SAXParserTests.java:38:18:38:38 | getInputStream(...) |
-| SAXParserTests.java:46:18:46:38 | getInputStream(...) [InputStream] | SAXParserTests.java:46:18:46:38 | getInputStream(...) |
-| SAXParserTests.java:55:18:55:38 | getInputStream(...) [InputStream] | SAXParserTests.java:55:18:55:38 | getInputStream(...) |
-| SAXParserTests.java:64:18:64:38 | getInputStream(...) [InputStream] | SAXParserTests.java:64:18:64:38 | getInputStream(...) |
-| SAXParserTests.java:73:18:73:38 | getInputStream(...) [InputStream] | SAXParserTests.java:73:18:73:38 | getInputStream(...) |
-| SAXReaderTests.java:8:17:8:37 | getInputStream(...) [InputStream] | SAXReaderTests.java:8:17:8:37 | getInputStream(...) |
-| SAXReaderTests.java:23:17:23:37 | getInputStream(...) [InputStream] | SAXReaderTests.java:23:17:23:37 | getInputStream(...) |
-| SAXReaderTests.java:30:17:30:37 | getInputStream(...) [InputStream] | SAXReaderTests.java:30:17:30:37 | getInputStream(...) |
-| SAXReaderTests.java:37:17:37:37 | getInputStream(...) [InputStream] | SAXReaderTests.java:37:17:37:37 | getInputStream(...) |
-| SAXReaderTests.java:45:17:45:37 | getInputStream(...) [InputStream] | SAXReaderTests.java:45:17:45:37 | getInputStream(...) |
-| SAXReaderTests.java:53:17:53:37 | getInputStream(...) [InputStream] | SAXReaderTests.java:53:17:53:37 | getInputStream(...) |
-| SAXReaderTests.java:61:17:61:37 | getInputStream(...) [InputStream] | SAXReaderTests.java:61:17:61:37 | getInputStream(...) |
-| SchemaTests.java:12:56:12:76 | getInputStream(...) [InputStream] | SchemaTests.java:12:39:12:77 | new StreamSource(...) |
-| SchemaTests.java:25:56:25:76 | getInputStream(...) [InputStream] | SchemaTests.java:25:39:25:77 | new StreamSource(...) |
-| SchemaTests.java:31:56:31:76 | getInputStream(...) [InputStream] | SchemaTests.java:31:39:31:77 | new StreamSource(...) |
-| SchemaTests.java:38:56:38:76 | getInputStream(...) [InputStream] | SchemaTests.java:38:39:38:77 | new StreamSource(...) |
-| SchemaTests.java:45:56:45:76 | getInputStream(...) [InputStream] | SchemaTests.java:45:39:45:77 | new StreamSource(...) |
-| SimpleXMLTests.java:14:41:14:61 | getInputStream(...) [InputStream] | SimpleXMLTests.java:14:41:14:61 | getInputStream(...) |
-| SimpleXMLTests.java:19:41:19:61 | getInputStream(...) [InputStream] | SimpleXMLTests.java:19:41:19:61 | getInputStream(...) |
-| SimpleXMLTests.java:24:63:24:83 | getInputStream(...) [InputStream] | SimpleXMLTests.java:24:41:24:84 | new InputStreamReader(...) |
-| SimpleXMLTests.java:30:5:30:25 | getInputStream(...) [InputStream] | SimpleXMLTests.java:31:41:31:53 | new String(...) |
-| SimpleXMLTests.java:37:5:37:25 | getInputStream(...) [InputStream] | SimpleXMLTests.java:38:41:38:53 | new String(...) |
-| SimpleXMLTests.java:43:63:43:83 | getInputStream(...) [InputStream] | SimpleXMLTests.java:43:41:43:84 | new InputStreamReader(...) |
-| SimpleXMLTests.java:48:37:48:57 | getInputStream(...) [InputStream] | SimpleXMLTests.java:48:37:48:57 | getInputStream(...) |
-| SimpleXMLTests.java:53:37:53:57 | getInputStream(...) [InputStream] | SimpleXMLTests.java:53:37:53:57 | getInputStream(...) |
-| SimpleXMLTests.java:58:26:58:46 | getInputStream(...) [InputStream] | SimpleXMLTests.java:58:26:58:46 | getInputStream(...) |
-| SimpleXMLTests.java:63:26:63:46 | getInputStream(...) [InputStream] | SimpleXMLTests.java:63:26:63:46 | getInputStream(...) |
-| SimpleXMLTests.java:68:59:68:79 | getInputStream(...) [InputStream] | SimpleXMLTests.java:68:37:68:80 | new InputStreamReader(...) |
-| SimpleXMLTests.java:73:59:73:79 | getInputStream(...) [InputStream] | SimpleXMLTests.java:73:37:73:80 | new InputStreamReader(...) |
-| SimpleXMLTests.java:78:48:78:68 | getInputStream(...) [InputStream] | SimpleXMLTests.java:78:26:78:69 | new InputStreamReader(...) |
-| SimpleXMLTests.java:83:48:83:68 | getInputStream(...) [InputStream] | SimpleXMLTests.java:83:26:83:69 | new InputStreamReader(...) |
-| SimpleXMLTests.java:89:5:89:25 | getInputStream(...) [InputStream] | SimpleXMLTests.java:90:37:90:49 | new String(...) |
-| SimpleXMLTests.java:96:5:96:25 | getInputStream(...) [InputStream] | SimpleXMLTests.java:97:37:97:49 | new String(...) |
-| SimpleXMLTests.java:103:5:103:25 | getInputStream(...) [InputStream] | SimpleXMLTests.java:104:26:104:38 | new String(...) |
-| SimpleXMLTests.java:110:5:110:25 | getInputStream(...) [InputStream] | SimpleXMLTests.java:111:26:111:38 | new String(...) |
-| SimpleXMLTests.java:115:22:115:42 | getInputStream(...) [InputStream] | SimpleXMLTests.java:115:22:115:42 | getInputStream(...) |
-| SimpleXMLTests.java:119:44:119:64 | getInputStream(...) [InputStream] | SimpleXMLTests.java:119:22:119:65 | new InputStreamReader(...) |
-| SimpleXMLTests.java:124:22:124:42 | getInputStream(...) [InputStream] | SimpleXMLTests.java:124:22:124:42 | getInputStream(...) |
-| SimpleXMLTests.java:129:44:129:64 | getInputStream(...) [InputStream] | SimpleXMLTests.java:129:22:129:65 | new InputStreamReader(...) |
-| SimpleXMLTests.java:134:22:134:42 | getInputStream(...) [InputStream] | SimpleXMLTests.java:134:22:134:42 | getInputStream(...) |
-| SimpleXMLTests.java:139:44:139:64 | getInputStream(...) [InputStream] | SimpleXMLTests.java:139:22:139:65 | new InputStreamReader(...) |
-| SimpleXMLTests.java:145:5:145:25 | getInputStream(...) [InputStream] | SimpleXMLTests.java:146:22:146:34 | new String(...) |
-| SimpleXMLTests.java:152:5:152:25 | getInputStream(...) [InputStream] | SimpleXMLTests.java:153:22:153:34 | new String(...) |
-| TransformerTests.java:20:44:20:64 | getInputStream(...) [InputStream] | TransformerTests.java:20:27:20:65 | new StreamSource(...) |
-| TransformerTests.java:21:40:21:60 | getInputStream(...) [InputStream] | TransformerTests.java:21:23:21:61 | new StreamSource(...) |
-| TransformerTests.java:71:44:71:64 | getInputStream(...) [InputStream] | TransformerTests.java:71:27:71:65 | new StreamSource(...) |
-| TransformerTests.java:72:40:72:60 | getInputStream(...) [InputStream] | TransformerTests.java:72:23:72:61 | new StreamSource(...) |
-| TransformerTests.java:79:44:79:64 | getInputStream(...) [InputStream] | TransformerTests.java:79:27:79:65 | new StreamSource(...) |
-| TransformerTests.java:80:40:80:60 | getInputStream(...) [InputStream] | TransformerTests.java:80:23:80:61 | new StreamSource(...) |
-| TransformerTests.java:88:44:88:64 | getInputStream(...) [InputStream] | TransformerTests.java:88:27:88:65 | new StreamSource(...) |
-| TransformerTests.java:89:40:89:60 | getInputStream(...) [InputStream] | TransformerTests.java:89:23:89:61 | new StreamSource(...) |
-| TransformerTests.java:97:44:97:64 | getInputStream(...) [InputStream] | TransformerTests.java:97:27:97:65 | new StreamSource(...) |
-| TransformerTests.java:98:40:98:60 | getInputStream(...) [InputStream] | TransformerTests.java:98:23:98:61 | new StreamSource(...) |
-| TransformerTests.java:103:38:103:58 | getInputStream(...) [InputStream] | TransformerTests.java:103:21:103:59 | new StreamSource(...) |
-| TransformerTests.java:116:38:116:58 | getInputStream(...) [InputStream] | TransformerTests.java:116:21:116:59 | new StreamSource(...) |
-| TransformerTests.java:122:38:122:58 | getInputStream(...) [InputStream] | TransformerTests.java:122:21:122:59 | new StreamSource(...) |
-| TransformerTests.java:129:38:129:58 | getInputStream(...) [InputStream] | TransformerTests.java:129:21:129:59 | new StreamSource(...) |
-| TransformerTests.java:136:38:136:58 | getInputStream(...) [InputStream] | TransformerTests.java:136:21:136:59 | new StreamSource(...) |
-| TransformerTests.java:141:48:141:68 | getInputStream(...) [InputStream] | TransformerTests.java:141:18:141:70 | new SAXSource(...) |
-| XMLReaderTests.java:16:34:16:54 | getInputStream(...) [InputStream] | XMLReaderTests.java:16:18:16:55 | new InputSource(...) |
-| XMLReaderTests.java:56:34:56:54 | getInputStream(...) [InputStream] | XMLReaderTests.java:56:18:56:55 | new InputSource(...) |
-| XMLReaderTests.java:63:34:63:54 | getInputStream(...) [InputStream] | XMLReaderTests.java:63:18:63:55 | new InputSource(...) |
-| XMLReaderTests.java:70:34:70:54 | getInputStream(...) [InputStream] | XMLReaderTests.java:70:18:70:55 | new InputSource(...) |
-| XMLReaderTests.java:78:34:78:54 | getInputStream(...) [InputStream] | XMLReaderTests.java:78:18:78:55 | new InputSource(...) |
-| XMLReaderTests.java:86:34:86:54 | getInputStream(...) [InputStream] | XMLReaderTests.java:86:18:86:55 | new InputSource(...) |
-| XMLReaderTests.java:94:34:94:54 | getInputStream(...) [InputStream] | XMLReaderTests.java:94:18:94:55 | new InputSource(...) |
-| XMLReaderTests.java:100:34:100:54 | getInputStream(...) [InputStream] | XMLReaderTests.java:100:18:100:55 | new InputSource(...) |
-| XPathExpressionTests.java:27:37:27:57 | getInputStream(...) [InputStream] | XPathExpressionTests.java:27:21:27:58 | new InputSource(...) |
-| XmlInputFactoryTests.java:9:35:9:55 | getInputStream(...) [InputStream] | XmlInputFactoryTests.java:9:35:9:55 | getInputStream(...) |
-| XmlInputFactoryTests.java:10:34:10:54 | getInputStream(...) [InputStream] | XmlInputFactoryTests.java:10:34:10:54 | getInputStream(...) |
-| XmlInputFactoryTests.java:24:35:24:55 | getInputStream(...) [InputStream] | XmlInputFactoryTests.java:24:35:24:55 | getInputStream(...) |
-| XmlInputFactoryTests.java:25:34:25:54 | getInputStream(...) [InputStream] | XmlInputFactoryTests.java:25:34:25:54 | getInputStream(...) |
-| XmlInputFactoryTests.java:31:35:31:55 | getInputStream(...) [InputStream] | XmlInputFactoryTests.java:31:35:31:55 | getInputStream(...) |
-| XmlInputFactoryTests.java:32:34:32:54 | getInputStream(...) [InputStream] | XmlInputFactoryTests.java:32:34:32:54 | getInputStream(...) |
-| XmlInputFactoryTests.java:39:35:39:55 | getInputStream(...) [InputStream] | XmlInputFactoryTests.java:39:35:39:55 | getInputStream(...) |
-| XmlInputFactoryTests.java:40:34:40:54 | getInputStream(...) [InputStream] | XmlInputFactoryTests.java:40:34:40:54 | getInputStream(...) |
-| XmlInputFactoryTests.java:47:35:47:55 | getInputStream(...) [InputStream] | XmlInputFactoryTests.java:47:35:47:55 | getInputStream(...) |
-| XmlInputFactoryTests.java:48:34:48:54 | getInputStream(...) [InputStream] | XmlInputFactoryTests.java:48:34:48:54 | getInputStream(...) |
-| XmlInputFactoryTests.java:55:35:55:55 | getInputStream(...) [InputStream] | XmlInputFactoryTests.java:55:35:55:55 | getInputStream(...) |
-| XmlInputFactoryTests.java:56:34:56:54 | getInputStream(...) [InputStream] | XmlInputFactoryTests.java:56:34:56:54 | getInputStream(...) |
+| DocumentBuilderTests.java:14:19:14:39 | getInputStream(...) [ : InputStream] | DocumentBuilderTests.java:14:19:14:39 | getInputStream(...) |
+| DocumentBuilderTests.java:42:19:42:39 | getInputStream(...) [ : InputStream] | DocumentBuilderTests.java:42:19:42:39 | getInputStream(...) |
+| DocumentBuilderTests.java:49:19:49:39 | getInputStream(...) [ : InputStream] | DocumentBuilderTests.java:49:19:49:39 | getInputStream(...) |
+| DocumentBuilderTests.java:64:19:64:39 | getInputStream(...) [ : InputStream] | DocumentBuilderTests.java:64:19:64:39 | getInputStream(...) |
+| DocumentBuilderTests.java:71:19:71:39 | getInputStream(...) [ : InputStream] | DocumentBuilderTests.java:71:19:71:39 | getInputStream(...) |
+| DocumentBuilderTests.java:79:19:79:39 | getInputStream(...) [ : InputStream] | DocumentBuilderTests.java:79:19:79:39 | getInputStream(...) |
+| DocumentBuilderTests.java:87:19:87:39 | getInputStream(...) [ : InputStream] | DocumentBuilderTests.java:87:19:87:39 | getInputStream(...) |
+| DocumentBuilderTests.java:93:51:93:71 | getInputStream(...) [ : InputStream] | DocumentBuilderTests.java:94:16:94:38 | getInputSource(...) |
+| DocumentBuilderTests.java:100:41:100:61 | getInputStream(...) [ : InputStream] | DocumentBuilderTests.java:101:16:101:52 | sourceToInputSource(...) |
+| DocumentBuilderTests.java:100:41:100:61 | getInputStream(...) [ : InputStream] | DocumentBuilderTests.java:102:16:102:38 | getInputStream(...) |
+| SAXBuilderTests.java:8:19:8:39 | getInputStream(...) [ : InputStream] | SAXBuilderTests.java:8:19:8:39 | getInputStream(...) |
+| SAXBuilderTests.java:20:19:20:39 | getInputStream(...) [ : InputStream] | SAXBuilderTests.java:20:19:20:39 | getInputStream(...) |
+| SAXParserTests.java:13:18:13:38 | getInputStream(...) [ : InputStream] | SAXParserTests.java:13:18:13:38 | getInputStream(...) |
+| SAXParserTests.java:30:18:30:38 | getInputStream(...) [ : InputStream] | SAXParserTests.java:30:18:30:38 | getInputStream(...) |
+| SAXParserTests.java:38:18:38:38 | getInputStream(...) [ : InputStream] | SAXParserTests.java:38:18:38:38 | getInputStream(...) |
+| SAXParserTests.java:46:18:46:38 | getInputStream(...) [ : InputStream] | SAXParserTests.java:46:18:46:38 | getInputStream(...) |
+| SAXParserTests.java:55:18:55:38 | getInputStream(...) [ : InputStream] | SAXParserTests.java:55:18:55:38 | getInputStream(...) |
+| SAXParserTests.java:64:18:64:38 | getInputStream(...) [ : InputStream] | SAXParserTests.java:64:18:64:38 | getInputStream(...) |
+| SAXParserTests.java:73:18:73:38 | getInputStream(...) [ : InputStream] | SAXParserTests.java:73:18:73:38 | getInputStream(...) |
+| SAXReaderTests.java:8:17:8:37 | getInputStream(...) [ : InputStream] | SAXReaderTests.java:8:17:8:37 | getInputStream(...) |
+| SAXReaderTests.java:23:17:23:37 | getInputStream(...) [ : InputStream] | SAXReaderTests.java:23:17:23:37 | getInputStream(...) |
+| SAXReaderTests.java:30:17:30:37 | getInputStream(...) [ : InputStream] | SAXReaderTests.java:30:17:30:37 | getInputStream(...) |
+| SAXReaderTests.java:37:17:37:37 | getInputStream(...) [ : InputStream] | SAXReaderTests.java:37:17:37:37 | getInputStream(...) |
+| SAXReaderTests.java:45:17:45:37 | getInputStream(...) [ : InputStream] | SAXReaderTests.java:45:17:45:37 | getInputStream(...) |
+| SAXReaderTests.java:53:17:53:37 | getInputStream(...) [ : InputStream] | SAXReaderTests.java:53:17:53:37 | getInputStream(...) |
+| SAXReaderTests.java:61:17:61:37 | getInputStream(...) [ : InputStream] | SAXReaderTests.java:61:17:61:37 | getInputStream(...) |
+| SchemaTests.java:12:56:12:76 | getInputStream(...) [ : InputStream] | SchemaTests.java:12:39:12:77 | new StreamSource(...) |
+| SchemaTests.java:25:56:25:76 | getInputStream(...) [ : InputStream] | SchemaTests.java:25:39:25:77 | new StreamSource(...) |
+| SchemaTests.java:31:56:31:76 | getInputStream(...) [ : InputStream] | SchemaTests.java:31:39:31:77 | new StreamSource(...) |
+| SchemaTests.java:38:56:38:76 | getInputStream(...) [ : InputStream] | SchemaTests.java:38:39:38:77 | new StreamSource(...) |
+| SchemaTests.java:45:56:45:76 | getInputStream(...) [ : InputStream] | SchemaTests.java:45:39:45:77 | new StreamSource(...) |
+| SimpleXMLTests.java:14:41:14:61 | getInputStream(...) [ : InputStream] | SimpleXMLTests.java:14:41:14:61 | getInputStream(...) |
+| SimpleXMLTests.java:19:41:19:61 | getInputStream(...) [ : InputStream] | SimpleXMLTests.java:19:41:19:61 | getInputStream(...) |
+| SimpleXMLTests.java:24:63:24:83 | getInputStream(...) [ : InputStream] | SimpleXMLTests.java:24:41:24:84 | new InputStreamReader(...) |
+| SimpleXMLTests.java:30:5:30:25 | getInputStream(...) [ : InputStream] | SimpleXMLTests.java:31:41:31:53 | new String(...) |
+| SimpleXMLTests.java:37:5:37:25 | getInputStream(...) [ : InputStream] | SimpleXMLTests.java:38:41:38:53 | new String(...) |
+| SimpleXMLTests.java:43:63:43:83 | getInputStream(...) [ : InputStream] | SimpleXMLTests.java:43:41:43:84 | new InputStreamReader(...) |
+| SimpleXMLTests.java:48:37:48:57 | getInputStream(...) [ : InputStream] | SimpleXMLTests.java:48:37:48:57 | getInputStream(...) |
+| SimpleXMLTests.java:53:37:53:57 | getInputStream(...) [ : InputStream] | SimpleXMLTests.java:53:37:53:57 | getInputStream(...) |
+| SimpleXMLTests.java:58:26:58:46 | getInputStream(...) [ : InputStream] | SimpleXMLTests.java:58:26:58:46 | getInputStream(...) |
+| SimpleXMLTests.java:63:26:63:46 | getInputStream(...) [ : InputStream] | SimpleXMLTests.java:63:26:63:46 | getInputStream(...) |
+| SimpleXMLTests.java:68:59:68:79 | getInputStream(...) [ : InputStream] | SimpleXMLTests.java:68:37:68:80 | new InputStreamReader(...) |
+| SimpleXMLTests.java:73:59:73:79 | getInputStream(...) [ : InputStream] | SimpleXMLTests.java:73:37:73:80 | new InputStreamReader(...) |
+| SimpleXMLTests.java:78:48:78:68 | getInputStream(...) [ : InputStream] | SimpleXMLTests.java:78:26:78:69 | new InputStreamReader(...) |
+| SimpleXMLTests.java:83:48:83:68 | getInputStream(...) [ : InputStream] | SimpleXMLTests.java:83:26:83:69 | new InputStreamReader(...) |
+| SimpleXMLTests.java:89:5:89:25 | getInputStream(...) [ : InputStream] | SimpleXMLTests.java:90:37:90:49 | new String(...) |
+| SimpleXMLTests.java:96:5:96:25 | getInputStream(...) [ : InputStream] | SimpleXMLTests.java:97:37:97:49 | new String(...) |
+| SimpleXMLTests.java:103:5:103:25 | getInputStream(...) [ : InputStream] | SimpleXMLTests.java:104:26:104:38 | new String(...) |
+| SimpleXMLTests.java:110:5:110:25 | getInputStream(...) [ : InputStream] | SimpleXMLTests.java:111:26:111:38 | new String(...) |
+| SimpleXMLTests.java:115:22:115:42 | getInputStream(...) [ : InputStream] | SimpleXMLTests.java:115:22:115:42 | getInputStream(...) |
+| SimpleXMLTests.java:119:44:119:64 | getInputStream(...) [ : InputStream] | SimpleXMLTests.java:119:22:119:65 | new InputStreamReader(...) |
+| SimpleXMLTests.java:124:22:124:42 | getInputStream(...) [ : InputStream] | SimpleXMLTests.java:124:22:124:42 | getInputStream(...) |
+| SimpleXMLTests.java:129:44:129:64 | getInputStream(...) [ : InputStream] | SimpleXMLTests.java:129:22:129:65 | new InputStreamReader(...) |
+| SimpleXMLTests.java:134:22:134:42 | getInputStream(...) [ : InputStream] | SimpleXMLTests.java:134:22:134:42 | getInputStream(...) |
+| SimpleXMLTests.java:139:44:139:64 | getInputStream(...) [ : InputStream] | SimpleXMLTests.java:139:22:139:65 | new InputStreamReader(...) |
+| SimpleXMLTests.java:145:5:145:25 | getInputStream(...) [ : InputStream] | SimpleXMLTests.java:146:22:146:34 | new String(...) |
+| SimpleXMLTests.java:152:5:152:25 | getInputStream(...) [ : InputStream] | SimpleXMLTests.java:153:22:153:34 | new String(...) |
+| TransformerTests.java:20:44:20:64 | getInputStream(...) [ : InputStream] | TransformerTests.java:20:27:20:65 | new StreamSource(...) |
+| TransformerTests.java:21:40:21:60 | getInputStream(...) [ : InputStream] | TransformerTests.java:21:23:21:61 | new StreamSource(...) |
+| TransformerTests.java:71:44:71:64 | getInputStream(...) [ : InputStream] | TransformerTests.java:71:27:71:65 | new StreamSource(...) |
+| TransformerTests.java:72:40:72:60 | getInputStream(...) [ : InputStream] | TransformerTests.java:72:23:72:61 | new StreamSource(...) |
+| TransformerTests.java:79:44:79:64 | getInputStream(...) [ : InputStream] | TransformerTests.java:79:27:79:65 | new StreamSource(...) |
+| TransformerTests.java:80:40:80:60 | getInputStream(...) [ : InputStream] | TransformerTests.java:80:23:80:61 | new StreamSource(...) |
+| TransformerTests.java:88:44:88:64 | getInputStream(...) [ : InputStream] | TransformerTests.java:88:27:88:65 | new StreamSource(...) |
+| TransformerTests.java:89:40:89:60 | getInputStream(...) [ : InputStream] | TransformerTests.java:89:23:89:61 | new StreamSource(...) |
+| TransformerTests.java:97:44:97:64 | getInputStream(...) [ : InputStream] | TransformerTests.java:97:27:97:65 | new StreamSource(...) |
+| TransformerTests.java:98:40:98:60 | getInputStream(...) [ : InputStream] | TransformerTests.java:98:23:98:61 | new StreamSource(...) |
+| TransformerTests.java:103:38:103:58 | getInputStream(...) [ : InputStream] | TransformerTests.java:103:21:103:59 | new StreamSource(...) |
+| TransformerTests.java:116:38:116:58 | getInputStream(...) [ : InputStream] | TransformerTests.java:116:21:116:59 | new StreamSource(...) |
+| TransformerTests.java:122:38:122:58 | getInputStream(...) [ : InputStream] | TransformerTests.java:122:21:122:59 | new StreamSource(...) |
+| TransformerTests.java:129:38:129:58 | getInputStream(...) [ : InputStream] | TransformerTests.java:129:21:129:59 | new StreamSource(...) |
+| TransformerTests.java:136:38:136:58 | getInputStream(...) [ : InputStream] | TransformerTests.java:136:21:136:59 | new StreamSource(...) |
+| TransformerTests.java:141:48:141:68 | getInputStream(...) [ : InputStream] | TransformerTests.java:141:18:141:70 | new SAXSource(...) |
+| XMLReaderTests.java:16:34:16:54 | getInputStream(...) [ : InputStream] | XMLReaderTests.java:16:18:16:55 | new InputSource(...) |
+| XMLReaderTests.java:56:34:56:54 | getInputStream(...) [ : InputStream] | XMLReaderTests.java:56:18:56:55 | new InputSource(...) |
+| XMLReaderTests.java:63:34:63:54 | getInputStream(...) [ : InputStream] | XMLReaderTests.java:63:18:63:55 | new InputSource(...) |
+| XMLReaderTests.java:70:34:70:54 | getInputStream(...) [ : InputStream] | XMLReaderTests.java:70:18:70:55 | new InputSource(...) |
+| XMLReaderTests.java:78:34:78:54 | getInputStream(...) [ : InputStream] | XMLReaderTests.java:78:18:78:55 | new InputSource(...) |
+| XMLReaderTests.java:86:34:86:54 | getInputStream(...) [ : InputStream] | XMLReaderTests.java:86:18:86:55 | new InputSource(...) |
+| XMLReaderTests.java:94:34:94:54 | getInputStream(...) [ : InputStream] | XMLReaderTests.java:94:18:94:55 | new InputSource(...) |
+| XMLReaderTests.java:100:34:100:54 | getInputStream(...) [ : InputStream] | XMLReaderTests.java:100:18:100:55 | new InputSource(...) |
+| XPathExpressionTests.java:27:37:27:57 | getInputStream(...) [ : InputStream] | XPathExpressionTests.java:27:21:27:58 | new InputSource(...) |
+| XmlInputFactoryTests.java:9:35:9:55 | getInputStream(...) [ : InputStream] | XmlInputFactoryTests.java:9:35:9:55 | getInputStream(...) |
+| XmlInputFactoryTests.java:10:34:10:54 | getInputStream(...) [ : InputStream] | XmlInputFactoryTests.java:10:34:10:54 | getInputStream(...) |
+| XmlInputFactoryTests.java:24:35:24:55 | getInputStream(...) [ : InputStream] | XmlInputFactoryTests.java:24:35:24:55 | getInputStream(...) |
+| XmlInputFactoryTests.java:25:34:25:54 | getInputStream(...) [ : InputStream] | XmlInputFactoryTests.java:25:34:25:54 | getInputStream(...) |
+| XmlInputFactoryTests.java:31:35:31:55 | getInputStream(...) [ : InputStream] | XmlInputFactoryTests.java:31:35:31:55 | getInputStream(...) |
+| XmlInputFactoryTests.java:32:34:32:54 | getInputStream(...) [ : InputStream] | XmlInputFactoryTests.java:32:34:32:54 | getInputStream(...) |
+| XmlInputFactoryTests.java:39:35:39:55 | getInputStream(...) [ : InputStream] | XmlInputFactoryTests.java:39:35:39:55 | getInputStream(...) |
+| XmlInputFactoryTests.java:40:34:40:54 | getInputStream(...) [ : InputStream] | XmlInputFactoryTests.java:40:34:40:54 | getInputStream(...) |
+| XmlInputFactoryTests.java:47:35:47:55 | getInputStream(...) [ : InputStream] | XmlInputFactoryTests.java:47:35:47:55 | getInputStream(...) |
+| XmlInputFactoryTests.java:48:34:48:54 | getInputStream(...) [ : InputStream] | XmlInputFactoryTests.java:48:34:48:54 | getInputStream(...) |
+| XmlInputFactoryTests.java:55:35:55:55 | getInputStream(...) [ : InputStream] | XmlInputFactoryTests.java:55:35:55:55 | getInputStream(...) |
+| XmlInputFactoryTests.java:56:34:56:54 | getInputStream(...) [ : InputStream] | XmlInputFactoryTests.java:56:34:56:54 | getInputStream(...) |
+nodes
+| DocumentBuilderTests.java:14:19:14:39 | getInputStream(...) | semmle.label | getInputStream(...) |
+| DocumentBuilderTests.java:14:19:14:39 | getInputStream(...) [ : InputStream] | semmle.label | getInputStream(...) [ : InputStream] |
+| DocumentBuilderTests.java:42:19:42:39 | getInputStream(...) | semmle.label | getInputStream(...) |
+| DocumentBuilderTests.java:42:19:42:39 | getInputStream(...) [ : InputStream] | semmle.label | getInputStream(...) [ : InputStream] |
+| DocumentBuilderTests.java:49:19:49:39 | getInputStream(...) | semmle.label | getInputStream(...) |
+| DocumentBuilderTests.java:49:19:49:39 | getInputStream(...) [ : InputStream] | semmle.label | getInputStream(...) [ : InputStream] |
+| DocumentBuilderTests.java:64:19:64:39 | getInputStream(...) | semmle.label | getInputStream(...) |
+| DocumentBuilderTests.java:64:19:64:39 | getInputStream(...) [ : InputStream] | semmle.label | getInputStream(...) [ : InputStream] |
+| DocumentBuilderTests.java:71:19:71:39 | getInputStream(...) | semmle.label | getInputStream(...) |
+| DocumentBuilderTests.java:71:19:71:39 | getInputStream(...) [ : InputStream] | semmle.label | getInputStream(...) [ : InputStream] |
+| DocumentBuilderTests.java:79:19:79:39 | getInputStream(...) | semmle.label | getInputStream(...) |
+| DocumentBuilderTests.java:79:19:79:39 | getInputStream(...) [ : InputStream] | semmle.label | getInputStream(...) [ : InputStream] |
+| DocumentBuilderTests.java:87:19:87:39 | getInputStream(...) | semmle.label | getInputStream(...) |
+| DocumentBuilderTests.java:87:19:87:39 | getInputStream(...) [ : InputStream] | semmle.label | getInputStream(...) [ : InputStream] |
+| DocumentBuilderTests.java:93:51:93:71 | getInputStream(...) [ : InputStream] | semmle.label | getInputStream(...) [ : InputStream] |
+| DocumentBuilderTests.java:94:16:94:38 | getInputSource(...) | semmle.label | getInputSource(...) |
+| DocumentBuilderTests.java:100:41:100:61 | getInputStream(...) [ : InputStream] | semmle.label | getInputStream(...) [ : InputStream] |
+| DocumentBuilderTests.java:101:16:101:52 | sourceToInputSource(...) | semmle.label | sourceToInputSource(...) |
+| DocumentBuilderTests.java:102:16:102:38 | getInputStream(...) | semmle.label | getInputStream(...) |
+| SAXBuilderTests.java:8:19:8:39 | getInputStream(...) | semmle.label | getInputStream(...) |
+| SAXBuilderTests.java:8:19:8:39 | getInputStream(...) [ : InputStream] | semmle.label | getInputStream(...) [ : InputStream] |
+| SAXBuilderTests.java:20:19:20:39 | getInputStream(...) | semmle.label | getInputStream(...) |
+| SAXBuilderTests.java:20:19:20:39 | getInputStream(...) [ : InputStream] | semmle.label | getInputStream(...) [ : InputStream] |
+| SAXParserTests.java:13:18:13:38 | getInputStream(...) | semmle.label | getInputStream(...) |
+| SAXParserTests.java:13:18:13:38 | getInputStream(...) [ : InputStream] | semmle.label | getInputStream(...) [ : InputStream] |
+| SAXParserTests.java:30:18:30:38 | getInputStream(...) | semmle.label | getInputStream(...) |
+| SAXParserTests.java:30:18:30:38 | getInputStream(...) [ : InputStream] | semmle.label | getInputStream(...) [ : InputStream] |
+| SAXParserTests.java:38:18:38:38 | getInputStream(...) | semmle.label | getInputStream(...) |
+| SAXParserTests.java:38:18:38:38 | getInputStream(...) [ : InputStream] | semmle.label | getInputStream(...) [ : InputStream] |
+| SAXParserTests.java:46:18:46:38 | getInputStream(...) | semmle.label | getInputStream(...) |
+| SAXParserTests.java:46:18:46:38 | getInputStream(...) [ : InputStream] | semmle.label | getInputStream(...) [ : InputStream] |
+| SAXParserTests.java:55:18:55:38 | getInputStream(...) | semmle.label | getInputStream(...) |
+| SAXParserTests.java:55:18:55:38 | getInputStream(...) [ : InputStream] | semmle.label | getInputStream(...) [ : InputStream] |
+| SAXParserTests.java:64:18:64:38 | getInputStream(...) | semmle.label | getInputStream(...) |
+| SAXParserTests.java:64:18:64:38 | getInputStream(...) [ : InputStream] | semmle.label | getInputStream(...) [ : InputStream] |
+| SAXParserTests.java:73:18:73:38 | getInputStream(...) | semmle.label | getInputStream(...) |
+| SAXParserTests.java:73:18:73:38 | getInputStream(...) [ : InputStream] | semmle.label | getInputStream(...) [ : InputStream] |
+| SAXReaderTests.java:8:17:8:37 | getInputStream(...) | semmle.label | getInputStream(...) |
+| SAXReaderTests.java:8:17:8:37 | getInputStream(...) [ : InputStream] | semmle.label | getInputStream(...) [ : InputStream] |
+| SAXReaderTests.java:23:17:23:37 | getInputStream(...) | semmle.label | getInputStream(...) |
+| SAXReaderTests.java:23:17:23:37 | getInputStream(...) [ : InputStream] | semmle.label | getInputStream(...) [ : InputStream] |
+| SAXReaderTests.java:30:17:30:37 | getInputStream(...) | semmle.label | getInputStream(...) |
+| SAXReaderTests.java:30:17:30:37 | getInputStream(...) [ : InputStream] | semmle.label | getInputStream(...) [ : InputStream] |
+| SAXReaderTests.java:37:17:37:37 | getInputStream(...) | semmle.label | getInputStream(...) |
+| SAXReaderTests.java:37:17:37:37 | getInputStream(...) [ : InputStream] | semmle.label | getInputStream(...) [ : InputStream] |
+| SAXReaderTests.java:45:17:45:37 | getInputStream(...) | semmle.label | getInputStream(...) |
+| SAXReaderTests.java:45:17:45:37 | getInputStream(...) [ : InputStream] | semmle.label | getInputStream(...) [ : InputStream] |
+| SAXReaderTests.java:53:17:53:37 | getInputStream(...) | semmle.label | getInputStream(...) |
+| SAXReaderTests.java:53:17:53:37 | getInputStream(...) [ : InputStream] | semmle.label | getInputStream(...) [ : InputStream] |
+| SAXReaderTests.java:61:17:61:37 | getInputStream(...) | semmle.label | getInputStream(...) |
+| SAXReaderTests.java:61:17:61:37 | getInputStream(...) [ : InputStream] | semmle.label | getInputStream(...) [ : InputStream] |
+| SchemaTests.java:12:39:12:77 | new StreamSource(...) | semmle.label | new StreamSource(...) |
+| SchemaTests.java:12:56:12:76 | getInputStream(...) [ : InputStream] | semmle.label | getInputStream(...) [ : InputStream] |
+| SchemaTests.java:25:39:25:77 | new StreamSource(...) | semmle.label | new StreamSource(...) |
+| SchemaTests.java:25:56:25:76 | getInputStream(...) [ : InputStream] | semmle.label | getInputStream(...) [ : InputStream] |
+| SchemaTests.java:31:39:31:77 | new StreamSource(...) | semmle.label | new StreamSource(...) |
+| SchemaTests.java:31:56:31:76 | getInputStream(...) [ : InputStream] | semmle.label | getInputStream(...) [ : InputStream] |
+| SchemaTests.java:38:39:38:77 | new StreamSource(...) | semmle.label | new StreamSource(...) |
+| SchemaTests.java:38:56:38:76 | getInputStream(...) [ : InputStream] | semmle.label | getInputStream(...) [ : InputStream] |
+| SchemaTests.java:45:39:45:77 | new StreamSource(...) | semmle.label | new StreamSource(...) |
+| SchemaTests.java:45:56:45:76 | getInputStream(...) [ : InputStream] | semmle.label | getInputStream(...) [ : InputStream] |
+| SimpleXMLTests.java:14:41:14:61 | getInputStream(...) | semmle.label | getInputStream(...) |
+| SimpleXMLTests.java:14:41:14:61 | getInputStream(...) [ : InputStream] | semmle.label | getInputStream(...) [ : InputStream] |
+| SimpleXMLTests.java:19:41:19:61 | getInputStream(...) | semmle.label | getInputStream(...) |
+| SimpleXMLTests.java:19:41:19:61 | getInputStream(...) [ : InputStream] | semmle.label | getInputStream(...) [ : InputStream] |
+| SimpleXMLTests.java:24:41:24:84 | new InputStreamReader(...) | semmle.label | new InputStreamReader(...) |
+| SimpleXMLTests.java:24:63:24:83 | getInputStream(...) [ : InputStream] | semmle.label | getInputStream(...) [ : InputStream] |
+| SimpleXMLTests.java:30:5:30:25 | getInputStream(...) [ : InputStream] | semmle.label | getInputStream(...) [ : InputStream] |
+| SimpleXMLTests.java:31:41:31:53 | new String(...) | semmle.label | new String(...) |
+| SimpleXMLTests.java:37:5:37:25 | getInputStream(...) [ : InputStream] | semmle.label | getInputStream(...) [ : InputStream] |
+| SimpleXMLTests.java:38:41:38:53 | new String(...) | semmle.label | new String(...) |
+| SimpleXMLTests.java:43:41:43:84 | new InputStreamReader(...) | semmle.label | new InputStreamReader(...) |
+| SimpleXMLTests.java:43:63:43:83 | getInputStream(...) [ : InputStream] | semmle.label | getInputStream(...) [ : InputStream] |
+| SimpleXMLTests.java:48:37:48:57 | getInputStream(...) | semmle.label | getInputStream(...) |
+| SimpleXMLTests.java:48:37:48:57 | getInputStream(...) [ : InputStream] | semmle.label | getInputStream(...) [ : InputStream] |
+| SimpleXMLTests.java:53:37:53:57 | getInputStream(...) | semmle.label | getInputStream(...) |
+| SimpleXMLTests.java:53:37:53:57 | getInputStream(...) [ : InputStream] | semmle.label | getInputStream(...) [ : InputStream] |
+| SimpleXMLTests.java:58:26:58:46 | getInputStream(...) | semmle.label | getInputStream(...) |
+| SimpleXMLTests.java:58:26:58:46 | getInputStream(...) [ : InputStream] | semmle.label | getInputStream(...) [ : InputStream] |
+| SimpleXMLTests.java:63:26:63:46 | getInputStream(...) | semmle.label | getInputStream(...) |
+| SimpleXMLTests.java:63:26:63:46 | getInputStream(...) [ : InputStream] | semmle.label | getInputStream(...) [ : InputStream] |
+| SimpleXMLTests.java:68:37:68:80 | new InputStreamReader(...) | semmle.label | new InputStreamReader(...) |
+| SimpleXMLTests.java:68:59:68:79 | getInputStream(...) [ : InputStream] | semmle.label | getInputStream(...) [ : InputStream] |
+| SimpleXMLTests.java:73:37:73:80 | new InputStreamReader(...) | semmle.label | new InputStreamReader(...) |
+| SimpleXMLTests.java:73:59:73:79 | getInputStream(...) [ : InputStream] | semmle.label | getInputStream(...) [ : InputStream] |
+| SimpleXMLTests.java:78:26:78:69 | new InputStreamReader(...) | semmle.label | new InputStreamReader(...) |
+| SimpleXMLTests.java:78:48:78:68 | getInputStream(...) [ : InputStream] | semmle.label | getInputStream(...) [ : InputStream] |
+| SimpleXMLTests.java:83:26:83:69 | new InputStreamReader(...) | semmle.label | new InputStreamReader(...) |
+| SimpleXMLTests.java:83:48:83:68 | getInputStream(...) [ : InputStream] | semmle.label | getInputStream(...) [ : InputStream] |
+| SimpleXMLTests.java:89:5:89:25 | getInputStream(...) [ : InputStream] | semmle.label | getInputStream(...) [ : InputStream] |
+| SimpleXMLTests.java:90:37:90:49 | new String(...) | semmle.label | new String(...) |
+| SimpleXMLTests.java:96:5:96:25 | getInputStream(...) [ : InputStream] | semmle.label | getInputStream(...) [ : InputStream] |
+| SimpleXMLTests.java:97:37:97:49 | new String(...) | semmle.label | new String(...) |
+| SimpleXMLTests.java:103:5:103:25 | getInputStream(...) [ : InputStream] | semmle.label | getInputStream(...) [ : InputStream] |
+| SimpleXMLTests.java:104:26:104:38 | new String(...) | semmle.label | new String(...) |
+| SimpleXMLTests.java:110:5:110:25 | getInputStream(...) [ : InputStream] | semmle.label | getInputStream(...) [ : InputStream] |
+| SimpleXMLTests.java:111:26:111:38 | new String(...) | semmle.label | new String(...) |
+| SimpleXMLTests.java:115:22:115:42 | getInputStream(...) | semmle.label | getInputStream(...) |
+| SimpleXMLTests.java:115:22:115:42 | getInputStream(...) [ : InputStream] | semmle.label | getInputStream(...) [ : InputStream] |
+| SimpleXMLTests.java:119:22:119:65 | new InputStreamReader(...) | semmle.label | new InputStreamReader(...) |
+| SimpleXMLTests.java:119:44:119:64 | getInputStream(...) [ : InputStream] | semmle.label | getInputStream(...) [ : InputStream] |
+| SimpleXMLTests.java:124:22:124:42 | getInputStream(...) | semmle.label | getInputStream(...) |
+| SimpleXMLTests.java:124:22:124:42 | getInputStream(...) [ : InputStream] | semmle.label | getInputStream(...) [ : InputStream] |
+| SimpleXMLTests.java:129:22:129:65 | new InputStreamReader(...) | semmle.label | new InputStreamReader(...) |
+| SimpleXMLTests.java:129:44:129:64 | getInputStream(...) [ : InputStream] | semmle.label | getInputStream(...) [ : InputStream] |
+| SimpleXMLTests.java:134:22:134:42 | getInputStream(...) | semmle.label | getInputStream(...) |
+| SimpleXMLTests.java:134:22:134:42 | getInputStream(...) [ : InputStream] | semmle.label | getInputStream(...) [ : InputStream] |
+| SimpleXMLTests.java:139:22:139:65 | new InputStreamReader(...) | semmle.label | new InputStreamReader(...) |
+| SimpleXMLTests.java:139:44:139:64 | getInputStream(...) [ : InputStream] | semmle.label | getInputStream(...) [ : InputStream] |
+| SimpleXMLTests.java:145:5:145:25 | getInputStream(...) [ : InputStream] | semmle.label | getInputStream(...) [ : InputStream] |
+| SimpleXMLTests.java:146:22:146:34 | new String(...) | semmle.label | new String(...) |
+| SimpleXMLTests.java:152:5:152:25 | getInputStream(...) [ : InputStream] | semmle.label | getInputStream(...) [ : InputStream] |
+| SimpleXMLTests.java:153:22:153:34 | new String(...) | semmle.label | new String(...) |
+| TransformerTests.java:20:27:20:65 | new StreamSource(...) | semmle.label | new StreamSource(...) |
+| TransformerTests.java:20:44:20:64 | getInputStream(...) [ : InputStream] | semmle.label | getInputStream(...) [ : InputStream] |
+| TransformerTests.java:21:23:21:61 | new StreamSource(...) | semmle.label | new StreamSource(...) |
+| TransformerTests.java:21:40:21:60 | getInputStream(...) [ : InputStream] | semmle.label | getInputStream(...) [ : InputStream] |
+| TransformerTests.java:71:27:71:65 | new StreamSource(...) | semmle.label | new StreamSource(...) |
+| TransformerTests.java:71:44:71:64 | getInputStream(...) [ : InputStream] | semmle.label | getInputStream(...) [ : InputStream] |
+| TransformerTests.java:72:23:72:61 | new StreamSource(...) | semmle.label | new StreamSource(...) |
+| TransformerTests.java:72:40:72:60 | getInputStream(...) [ : InputStream] | semmle.label | getInputStream(...) [ : InputStream] |
+| TransformerTests.java:79:27:79:65 | new StreamSource(...) | semmle.label | new StreamSource(...) |
+| TransformerTests.java:79:44:79:64 | getInputStream(...) [ : InputStream] | semmle.label | getInputStream(...) [ : InputStream] |
+| TransformerTests.java:80:23:80:61 | new StreamSource(...) | semmle.label | new StreamSource(...) |
+| TransformerTests.java:80:40:80:60 | getInputStream(...) [ : InputStream] | semmle.label | getInputStream(...) [ : InputStream] |
+| TransformerTests.java:88:27:88:65 | new StreamSource(...) | semmle.label | new StreamSource(...) |
+| TransformerTests.java:88:44:88:64 | getInputStream(...) [ : InputStream] | semmle.label | getInputStream(...) [ : InputStream] |
+| TransformerTests.java:89:23:89:61 | new StreamSource(...) | semmle.label | new StreamSource(...) |
+| TransformerTests.java:89:40:89:60 | getInputStream(...) [ : InputStream] | semmle.label | getInputStream(...) [ : InputStream] |
+| TransformerTests.java:97:27:97:65 | new StreamSource(...) | semmle.label | new StreamSource(...) |
+| TransformerTests.java:97:44:97:64 | getInputStream(...) [ : InputStream] | semmle.label | getInputStream(...) [ : InputStream] |
+| TransformerTests.java:98:23:98:61 | new StreamSource(...) | semmle.label | new StreamSource(...) |
+| TransformerTests.java:98:40:98:60 | getInputStream(...) [ : InputStream] | semmle.label | getInputStream(...) [ : InputStream] |
+| TransformerTests.java:103:21:103:59 | new StreamSource(...) | semmle.label | new StreamSource(...) |
+| TransformerTests.java:103:38:103:58 | getInputStream(...) [ : InputStream] | semmle.label | getInputStream(...) [ : InputStream] |
+| TransformerTests.java:116:21:116:59 | new StreamSource(...) | semmle.label | new StreamSource(...) |
+| TransformerTests.java:116:38:116:58 | getInputStream(...) [ : InputStream] | semmle.label | getInputStream(...) [ : InputStream] |
+| TransformerTests.java:122:21:122:59 | new StreamSource(...) | semmle.label | new StreamSource(...) |
+| TransformerTests.java:122:38:122:58 | getInputStream(...) [ : InputStream] | semmle.label | getInputStream(...) [ : InputStream] |
+| TransformerTests.java:129:21:129:59 | new StreamSource(...) | semmle.label | new StreamSource(...) |
+| TransformerTests.java:129:38:129:58 | getInputStream(...) [ : InputStream] | semmle.label | getInputStream(...) [ : InputStream] |
+| TransformerTests.java:136:21:136:59 | new StreamSource(...) | semmle.label | new StreamSource(...) |
+| TransformerTests.java:136:38:136:58 | getInputStream(...) [ : InputStream] | semmle.label | getInputStream(...) [ : InputStream] |
+| TransformerTests.java:141:18:141:70 | new SAXSource(...) | semmle.label | new SAXSource(...) |
+| TransformerTests.java:141:48:141:68 | getInputStream(...) [ : InputStream] | semmle.label | getInputStream(...) [ : InputStream] |
+| XMLReaderTests.java:16:18:16:55 | new InputSource(...) | semmle.label | new InputSource(...) |
+| XMLReaderTests.java:16:34:16:54 | getInputStream(...) [ : InputStream] | semmle.label | getInputStream(...) [ : InputStream] |
+| XMLReaderTests.java:56:18:56:55 | new InputSource(...) | semmle.label | new InputSource(...) |
+| XMLReaderTests.java:56:34:56:54 | getInputStream(...) [ : InputStream] | semmle.label | getInputStream(...) [ : InputStream] |
+| XMLReaderTests.java:63:18:63:55 | new InputSource(...) | semmle.label | new InputSource(...) |
+| XMLReaderTests.java:63:34:63:54 | getInputStream(...) [ : InputStream] | semmle.label | getInputStream(...) [ : InputStream] |
+| XMLReaderTests.java:70:18:70:55 | new InputSource(...) | semmle.label | new InputSource(...) |
+| XMLReaderTests.java:70:34:70:54 | getInputStream(...) [ : InputStream] | semmle.label | getInputStream(...) [ : InputStream] |
+| XMLReaderTests.java:78:18:78:55 | new InputSource(...) | semmle.label | new InputSource(...) |
+| XMLReaderTests.java:78:34:78:54 | getInputStream(...) [ : InputStream] | semmle.label | getInputStream(...) [ : InputStream] |
+| XMLReaderTests.java:86:18:86:55 | new InputSource(...) | semmle.label | new InputSource(...) |
+| XMLReaderTests.java:86:34:86:54 | getInputStream(...) [ : InputStream] | semmle.label | getInputStream(...) [ : InputStream] |
+| XMLReaderTests.java:94:18:94:55 | new InputSource(...) | semmle.label | new InputSource(...) |
+| XMLReaderTests.java:94:34:94:54 | getInputStream(...) [ : InputStream] | semmle.label | getInputStream(...) [ : InputStream] |
+| XMLReaderTests.java:100:18:100:55 | new InputSource(...) | semmle.label | new InputSource(...) |
+| XMLReaderTests.java:100:34:100:54 | getInputStream(...) [ : InputStream] | semmle.label | getInputStream(...) [ : InputStream] |
+| XPathExpressionTests.java:27:21:27:58 | new InputSource(...) | semmle.label | new InputSource(...) |
+| XPathExpressionTests.java:27:37:27:57 | getInputStream(...) [ : InputStream] | semmle.label | getInputStream(...) [ : InputStream] |
+| XmlInputFactoryTests.java:9:35:9:55 | getInputStream(...) | semmle.label | getInputStream(...) |
+| XmlInputFactoryTests.java:9:35:9:55 | getInputStream(...) [ : InputStream] | semmle.label | getInputStream(...) [ : InputStream] |
+| XmlInputFactoryTests.java:10:34:10:54 | getInputStream(...) | semmle.label | getInputStream(...) |
+| XmlInputFactoryTests.java:10:34:10:54 | getInputStream(...) [ : InputStream] | semmle.label | getInputStream(...) [ : InputStream] |
+| XmlInputFactoryTests.java:24:35:24:55 | getInputStream(...) | semmle.label | getInputStream(...) |
+| XmlInputFactoryTests.java:24:35:24:55 | getInputStream(...) [ : InputStream] | semmle.label | getInputStream(...) [ : InputStream] |
+| XmlInputFactoryTests.java:25:34:25:54 | getInputStream(...) | semmle.label | getInputStream(...) |
+| XmlInputFactoryTests.java:25:34:25:54 | getInputStream(...) [ : InputStream] | semmle.label | getInputStream(...) [ : InputStream] |
+| XmlInputFactoryTests.java:31:35:31:55 | getInputStream(...) | semmle.label | getInputStream(...) |
+| XmlInputFactoryTests.java:31:35:31:55 | getInputStream(...) [ : InputStream] | semmle.label | getInputStream(...) [ : InputStream] |
+| XmlInputFactoryTests.java:32:34:32:54 | getInputStream(...) | semmle.label | getInputStream(...) |
+| XmlInputFactoryTests.java:32:34:32:54 | getInputStream(...) [ : InputStream] | semmle.label | getInputStream(...) [ : InputStream] |
+| XmlInputFactoryTests.java:39:35:39:55 | getInputStream(...) | semmle.label | getInputStream(...) |
+| XmlInputFactoryTests.java:39:35:39:55 | getInputStream(...) [ : InputStream] | semmle.label | getInputStream(...) [ : InputStream] |
+| XmlInputFactoryTests.java:40:34:40:54 | getInputStream(...) | semmle.label | getInputStream(...) |
+| XmlInputFactoryTests.java:40:34:40:54 | getInputStream(...) [ : InputStream] | semmle.label | getInputStream(...) [ : InputStream] |
+| XmlInputFactoryTests.java:47:35:47:55 | getInputStream(...) | semmle.label | getInputStream(...) |
+| XmlInputFactoryTests.java:47:35:47:55 | getInputStream(...) [ : InputStream] | semmle.label | getInputStream(...) [ : InputStream] |
+| XmlInputFactoryTests.java:48:34:48:54 | getInputStream(...) | semmle.label | getInputStream(...) |
+| XmlInputFactoryTests.java:48:34:48:54 | getInputStream(...) [ : InputStream] | semmle.label | getInputStream(...) [ : InputStream] |
+| XmlInputFactoryTests.java:55:35:55:55 | getInputStream(...) | semmle.label | getInputStream(...) |
+| XmlInputFactoryTests.java:55:35:55:55 | getInputStream(...) [ : InputStream] | semmle.label | getInputStream(...) [ : InputStream] |
+| XmlInputFactoryTests.java:56:34:56:54 | getInputStream(...) | semmle.label | getInputStream(...) |
+| XmlInputFactoryTests.java:56:34:56:54 | getInputStream(...) [ : InputStream] | semmle.label | getInputStream(...) [ : InputStream] |
 #select
-| DocumentBuilderTests.java:14:19:14:39 | getInputStream(...) | DocumentBuilderTests.java:14:19:14:39 | getInputStream(...) [InputStream] | DocumentBuilderTests.java:14:19:14:39 | getInputStream(...) | Unsafe parsing of XML file from $@. | DocumentBuilderTests.java:14:19:14:39 | getInputStream(...) | user input |
-| DocumentBuilderTests.java:42:19:42:39 | getInputStream(...) | DocumentBuilderTests.java:42:19:42:39 | getInputStream(...) [InputStream] | DocumentBuilderTests.java:42:19:42:39 | getInputStream(...) | Unsafe parsing of XML file from $@. | DocumentBuilderTests.java:42:19:42:39 | getInputStream(...) | user input |
-| DocumentBuilderTests.java:49:19:49:39 | getInputStream(...) | DocumentBuilderTests.java:49:19:49:39 | getInputStream(...) [InputStream] | DocumentBuilderTests.java:49:19:49:39 | getInputStream(...) | Unsafe parsing of XML file from $@. | DocumentBuilderTests.java:49:19:49:39 | getInputStream(...) | user input |
-| DocumentBuilderTests.java:64:19:64:39 | getInputStream(...) | DocumentBuilderTests.java:64:19:64:39 | getInputStream(...) [InputStream] | DocumentBuilderTests.java:64:19:64:39 | getInputStream(...) | Unsafe parsing of XML file from $@. | DocumentBuilderTests.java:64:19:64:39 | getInputStream(...) | user input |
-| DocumentBuilderTests.java:71:19:71:39 | getInputStream(...) | DocumentBuilderTests.java:71:19:71:39 | getInputStream(...) [InputStream] | DocumentBuilderTests.java:71:19:71:39 | getInputStream(...) | Unsafe parsing of XML file from $@. | DocumentBuilderTests.java:71:19:71:39 | getInputStream(...) | user input |
-| DocumentBuilderTests.java:79:19:79:39 | getInputStream(...) | DocumentBuilderTests.java:79:19:79:39 | getInputStream(...) [InputStream] | DocumentBuilderTests.java:79:19:79:39 | getInputStream(...) | Unsafe parsing of XML file from $@. | DocumentBuilderTests.java:79:19:79:39 | getInputStream(...) | user input |
-| DocumentBuilderTests.java:87:19:87:39 | getInputStream(...) | DocumentBuilderTests.java:87:19:87:39 | getInputStream(...) [InputStream] | DocumentBuilderTests.java:87:19:87:39 | getInputStream(...) | Unsafe parsing of XML file from $@. | DocumentBuilderTests.java:87:19:87:39 | getInputStream(...) | user input |
-| DocumentBuilderTests.java:94:16:94:38 | getInputSource(...) | DocumentBuilderTests.java:93:51:93:71 | getInputStream(...) [InputStream] | DocumentBuilderTests.java:94:16:94:38 | getInputSource(...) | Unsafe parsing of XML file from $@. | DocumentBuilderTests.java:93:51:93:71 | getInputStream(...) | user input |
-| DocumentBuilderTests.java:101:16:101:52 | sourceToInputSource(...) | DocumentBuilderTests.java:100:41:100:61 | getInputStream(...) [InputStream] | DocumentBuilderTests.java:101:16:101:52 | sourceToInputSource(...) | Unsafe parsing of XML file from $@. | DocumentBuilderTests.java:100:41:100:61 | getInputStream(...) | user input |
-| DocumentBuilderTests.java:102:16:102:38 | getInputStream(...) | DocumentBuilderTests.java:100:41:100:61 | getInputStream(...) [InputStream] | DocumentBuilderTests.java:102:16:102:38 | getInputStream(...) | Unsafe parsing of XML file from $@. | DocumentBuilderTests.java:100:41:100:61 | getInputStream(...) | user input |
-| SAXBuilderTests.java:8:19:8:39 | getInputStream(...) | SAXBuilderTests.java:8:19:8:39 | getInputStream(...) [InputStream] | SAXBuilderTests.java:8:19:8:39 | getInputStream(...) | Unsafe parsing of XML file from $@. | SAXBuilderTests.java:8:19:8:39 | getInputStream(...) | user input |
-| SAXBuilderTests.java:20:19:20:39 | getInputStream(...) | SAXBuilderTests.java:20:19:20:39 | getInputStream(...) [InputStream] | SAXBuilderTests.java:20:19:20:39 | getInputStream(...) | Unsafe parsing of XML file from $@. | SAXBuilderTests.java:20:19:20:39 | getInputStream(...) | user input |
-| SAXParserTests.java:13:18:13:38 | getInputStream(...) | SAXParserTests.java:13:18:13:38 | getInputStream(...) [InputStream] | SAXParserTests.java:13:18:13:38 | getInputStream(...) | Unsafe parsing of XML file from $@. | SAXParserTests.java:13:18:13:38 | getInputStream(...) | user input |
-| SAXParserTests.java:30:18:30:38 | getInputStream(...) | SAXParserTests.java:30:18:30:38 | getInputStream(...) [InputStream] | SAXParserTests.java:30:18:30:38 | getInputStream(...) | Unsafe parsing of XML file from $@. | SAXParserTests.java:30:18:30:38 | getInputStream(...) | user input |
-| SAXParserTests.java:38:18:38:38 | getInputStream(...) | SAXParserTests.java:38:18:38:38 | getInputStream(...) [InputStream] | SAXParserTests.java:38:18:38:38 | getInputStream(...) | Unsafe parsing of XML file from $@. | SAXParserTests.java:38:18:38:38 | getInputStream(...) | user input |
-| SAXParserTests.java:46:18:46:38 | getInputStream(...) | SAXParserTests.java:46:18:46:38 | getInputStream(...) [InputStream] | SAXParserTests.java:46:18:46:38 | getInputStream(...) | Unsafe parsing of XML file from $@. | SAXParserTests.java:46:18:46:38 | getInputStream(...) | user input |
-| SAXParserTests.java:55:18:55:38 | getInputStream(...) | SAXParserTests.java:55:18:55:38 | getInputStream(...) [InputStream] | SAXParserTests.java:55:18:55:38 | getInputStream(...) | Unsafe parsing of XML file from $@. | SAXParserTests.java:55:18:55:38 | getInputStream(...) | user input |
-| SAXParserTests.java:64:18:64:38 | getInputStream(...) | SAXParserTests.java:64:18:64:38 | getInputStream(...) [InputStream] | SAXParserTests.java:64:18:64:38 | getInputStream(...) | Unsafe parsing of XML file from $@. | SAXParserTests.java:64:18:64:38 | getInputStream(...) | user input |
-| SAXParserTests.java:73:18:73:38 | getInputStream(...) | SAXParserTests.java:73:18:73:38 | getInputStream(...) [InputStream] | SAXParserTests.java:73:18:73:38 | getInputStream(...) | Unsafe parsing of XML file from $@. | SAXParserTests.java:73:18:73:38 | getInputStream(...) | user input |
-| SAXReaderTests.java:8:17:8:37 | getInputStream(...) | SAXReaderTests.java:8:17:8:37 | getInputStream(...) [InputStream] | SAXReaderTests.java:8:17:8:37 | getInputStream(...) | Unsafe parsing of XML file from $@. | SAXReaderTests.java:8:17:8:37 | getInputStream(...) | user input |
-| SAXReaderTests.java:23:17:23:37 | getInputStream(...) | SAXReaderTests.java:23:17:23:37 | getInputStream(...) [InputStream] | SAXReaderTests.java:23:17:23:37 | getInputStream(...) | Unsafe parsing of XML file from $@. | SAXReaderTests.java:23:17:23:37 | getInputStream(...) | user input |
-| SAXReaderTests.java:30:17:30:37 | getInputStream(...) | SAXReaderTests.java:30:17:30:37 | getInputStream(...) [InputStream] | SAXReaderTests.java:30:17:30:37 | getInputStream(...) | Unsafe parsing of XML file from $@. | SAXReaderTests.java:30:17:30:37 | getInputStream(...) | user input |
-| SAXReaderTests.java:37:17:37:37 | getInputStream(...) | SAXReaderTests.java:37:17:37:37 | getInputStream(...) [InputStream] | SAXReaderTests.java:37:17:37:37 | getInputStream(...) | Unsafe parsing of XML file from $@. | SAXReaderTests.java:37:17:37:37 | getInputStream(...) | user input |
-| SAXReaderTests.java:45:17:45:37 | getInputStream(...) | SAXReaderTests.java:45:17:45:37 | getInputStream(...) [InputStream] | SAXReaderTests.java:45:17:45:37 | getInputStream(...) | Unsafe parsing of XML file from $@. | SAXReaderTests.java:45:17:45:37 | getInputStream(...) | user input |
-| SAXReaderTests.java:53:17:53:37 | getInputStream(...) | SAXReaderTests.java:53:17:53:37 | getInputStream(...) [InputStream] | SAXReaderTests.java:53:17:53:37 | getInputStream(...) | Unsafe parsing of XML file from $@. | SAXReaderTests.java:53:17:53:37 | getInputStream(...) | user input |
-| SAXReaderTests.java:61:17:61:37 | getInputStream(...) | SAXReaderTests.java:61:17:61:37 | getInputStream(...) [InputStream] | SAXReaderTests.java:61:17:61:37 | getInputStream(...) | Unsafe parsing of XML file from $@. | SAXReaderTests.java:61:17:61:37 | getInputStream(...) | user input |
-| SchemaTests.java:12:39:12:77 | new StreamSource(...) | SchemaTests.java:12:56:12:76 | getInputStream(...) [InputStream] | SchemaTests.java:12:39:12:77 | new StreamSource(...) | Unsafe parsing of XML file from $@. | SchemaTests.java:12:56:12:76 | getInputStream(...) | user input |
-| SchemaTests.java:25:39:25:77 | new StreamSource(...) | SchemaTests.java:25:56:25:76 | getInputStream(...) [InputStream] | SchemaTests.java:25:39:25:77 | new StreamSource(...) | Unsafe parsing of XML file from $@. | SchemaTests.java:25:56:25:76 | getInputStream(...) | user input |
-| SchemaTests.java:31:39:31:77 | new StreamSource(...) | SchemaTests.java:31:56:31:76 | getInputStream(...) [InputStream] | SchemaTests.java:31:39:31:77 | new StreamSource(...) | Unsafe parsing of XML file from $@. | SchemaTests.java:31:56:31:76 | getInputStream(...) | user input |
-| SchemaTests.java:38:39:38:77 | new StreamSource(...) | SchemaTests.java:38:56:38:76 | getInputStream(...) [InputStream] | SchemaTests.java:38:39:38:77 | new StreamSource(...) | Unsafe parsing of XML file from $@. | SchemaTests.java:38:56:38:76 | getInputStream(...) | user input |
-| SchemaTests.java:45:39:45:77 | new StreamSource(...) | SchemaTests.java:45:56:45:76 | getInputStream(...) [InputStream] | SchemaTests.java:45:39:45:77 | new StreamSource(...) | Unsafe parsing of XML file from $@. | SchemaTests.java:45:56:45:76 | getInputStream(...) | user input |
-| SimpleXMLTests.java:14:41:14:61 | getInputStream(...) | SimpleXMLTests.java:14:41:14:61 | getInputStream(...) [InputStream] | SimpleXMLTests.java:14:41:14:61 | getInputStream(...) | Unsafe parsing of XML file from $@. | SimpleXMLTests.java:14:41:14:61 | getInputStream(...) | user input |
-| SimpleXMLTests.java:19:41:19:61 | getInputStream(...) | SimpleXMLTests.java:19:41:19:61 | getInputStream(...) [InputStream] | SimpleXMLTests.java:19:41:19:61 | getInputStream(...) | Unsafe parsing of XML file from $@. | SimpleXMLTests.java:19:41:19:61 | getInputStream(...) | user input |
-| SimpleXMLTests.java:24:41:24:84 | new InputStreamReader(...) | SimpleXMLTests.java:24:63:24:83 | getInputStream(...) [InputStream] | SimpleXMLTests.java:24:41:24:84 | new InputStreamReader(...) | Unsafe parsing of XML file from $@. | SimpleXMLTests.java:24:63:24:83 | getInputStream(...) | user input |
-| SimpleXMLTests.java:31:41:31:53 | new String(...) | SimpleXMLTests.java:30:5:30:25 | getInputStream(...) [InputStream] | SimpleXMLTests.java:31:41:31:53 | new String(...) | Unsafe parsing of XML file from $@. | SimpleXMLTests.java:30:5:30:25 | getInputStream(...) | user input |
-| SimpleXMLTests.java:38:41:38:53 | new String(...) | SimpleXMLTests.java:37:5:37:25 | getInputStream(...) [InputStream] | SimpleXMLTests.java:38:41:38:53 | new String(...) | Unsafe parsing of XML file from $@. | SimpleXMLTests.java:37:5:37:25 | getInputStream(...) | user input |
-| SimpleXMLTests.java:43:41:43:84 | new InputStreamReader(...) | SimpleXMLTests.java:43:63:43:83 | getInputStream(...) [InputStream] | SimpleXMLTests.java:43:41:43:84 | new InputStreamReader(...) | Unsafe parsing of XML file from $@. | SimpleXMLTests.java:43:63:43:83 | getInputStream(...) | user input |
-| SimpleXMLTests.java:48:37:48:57 | getInputStream(...) | SimpleXMLTests.java:48:37:48:57 | getInputStream(...) [InputStream] | SimpleXMLTests.java:48:37:48:57 | getInputStream(...) | Unsafe parsing of XML file from $@. | SimpleXMLTests.java:48:37:48:57 | getInputStream(...) | user input |
-| SimpleXMLTests.java:53:37:53:57 | getInputStream(...) | SimpleXMLTests.java:53:37:53:57 | getInputStream(...) [InputStream] | SimpleXMLTests.java:53:37:53:57 | getInputStream(...) | Unsafe parsing of XML file from $@. | SimpleXMLTests.java:53:37:53:57 | getInputStream(...) | user input |
-| SimpleXMLTests.java:58:26:58:46 | getInputStream(...) | SimpleXMLTests.java:58:26:58:46 | getInputStream(...) [InputStream] | SimpleXMLTests.java:58:26:58:46 | getInputStream(...) | Unsafe parsing of XML file from $@. | SimpleXMLTests.java:58:26:58:46 | getInputStream(...) | user input |
-| SimpleXMLTests.java:63:26:63:46 | getInputStream(...) | SimpleXMLTests.java:63:26:63:46 | getInputStream(...) [InputStream] | SimpleXMLTests.java:63:26:63:46 | getInputStream(...) | Unsafe parsing of XML file from $@. | SimpleXMLTests.java:63:26:63:46 | getInputStream(...) | user input |
-| SimpleXMLTests.java:68:37:68:80 | new InputStreamReader(...) | SimpleXMLTests.java:68:59:68:79 | getInputStream(...) [InputStream] | SimpleXMLTests.java:68:37:68:80 | new InputStreamReader(...) | Unsafe parsing of XML file from $@. | SimpleXMLTests.java:68:59:68:79 | getInputStream(...) | user input |
-| SimpleXMLTests.java:73:37:73:80 | new InputStreamReader(...) | SimpleXMLTests.java:73:59:73:79 | getInputStream(...) [InputStream] | SimpleXMLTests.java:73:37:73:80 | new InputStreamReader(...) | Unsafe parsing of XML file from $@. | SimpleXMLTests.java:73:59:73:79 | getInputStream(...) | user input |
-| SimpleXMLTests.java:78:26:78:69 | new InputStreamReader(...) | SimpleXMLTests.java:78:48:78:68 | getInputStream(...) [InputStream] | SimpleXMLTests.java:78:26:78:69 | new InputStreamReader(...) | Unsafe parsing of XML file from $@. | SimpleXMLTests.java:78:48:78:68 | getInputStream(...) | user input |
-| SimpleXMLTests.java:83:26:83:69 | new InputStreamReader(...) | SimpleXMLTests.java:83:48:83:68 | getInputStream(...) [InputStream] | SimpleXMLTests.java:83:26:83:69 | new InputStreamReader(...) | Unsafe parsing of XML file from $@. | SimpleXMLTests.java:83:48:83:68 | getInputStream(...) | user input |
-| SimpleXMLTests.java:90:37:90:49 | new String(...) | SimpleXMLTests.java:89:5:89:25 | getInputStream(...) [InputStream] | SimpleXMLTests.java:90:37:90:49 | new String(...) | Unsafe parsing of XML file from $@. | SimpleXMLTests.java:89:5:89:25 | getInputStream(...) | user input |
-| SimpleXMLTests.java:97:37:97:49 | new String(...) | SimpleXMLTests.java:96:5:96:25 | getInputStream(...) [InputStream] | SimpleXMLTests.java:97:37:97:49 | new String(...) | Unsafe parsing of XML file from $@. | SimpleXMLTests.java:96:5:96:25 | getInputStream(...) | user input |
-| SimpleXMLTests.java:104:26:104:38 | new String(...) | SimpleXMLTests.java:103:5:103:25 | getInputStream(...) [InputStream] | SimpleXMLTests.java:104:26:104:38 | new String(...) | Unsafe parsing of XML file from $@. | SimpleXMLTests.java:103:5:103:25 | getInputStream(...) | user input |
-| SimpleXMLTests.java:111:26:111:38 | new String(...) | SimpleXMLTests.java:110:5:110:25 | getInputStream(...) [InputStream] | SimpleXMLTests.java:111:26:111:38 | new String(...) | Unsafe parsing of XML file from $@. | SimpleXMLTests.java:110:5:110:25 | getInputStream(...) | user input |
-| SimpleXMLTests.java:115:22:115:42 | getInputStream(...) | SimpleXMLTests.java:115:22:115:42 | getInputStream(...) [InputStream] | SimpleXMLTests.java:115:22:115:42 | getInputStream(...) | Unsafe parsing of XML file from $@. | SimpleXMLTests.java:115:22:115:42 | getInputStream(...) | user input |
-| SimpleXMLTests.java:119:22:119:65 | new InputStreamReader(...) | SimpleXMLTests.java:119:44:119:64 | getInputStream(...) [InputStream] | SimpleXMLTests.java:119:22:119:65 | new InputStreamReader(...) | Unsafe parsing of XML file from $@. | SimpleXMLTests.java:119:44:119:64 | getInputStream(...) | user input |
-| SimpleXMLTests.java:124:22:124:42 | getInputStream(...) | SimpleXMLTests.java:124:22:124:42 | getInputStream(...) [InputStream] | SimpleXMLTests.java:124:22:124:42 | getInputStream(...) | Unsafe parsing of XML file from $@. | SimpleXMLTests.java:124:22:124:42 | getInputStream(...) | user input |
-| SimpleXMLTests.java:129:22:129:65 | new InputStreamReader(...) | SimpleXMLTests.java:129:44:129:64 | getInputStream(...) [InputStream] | SimpleXMLTests.java:129:22:129:65 | new InputStreamReader(...) | Unsafe parsing of XML file from $@. | SimpleXMLTests.java:129:44:129:64 | getInputStream(...) | user input |
-| SimpleXMLTests.java:134:22:134:42 | getInputStream(...) | SimpleXMLTests.java:134:22:134:42 | getInputStream(...) [InputStream] | SimpleXMLTests.java:134:22:134:42 | getInputStream(...) | Unsafe parsing of XML file from $@. | SimpleXMLTests.java:134:22:134:42 | getInputStream(...) | user input |
-| SimpleXMLTests.java:139:22:139:65 | new InputStreamReader(...) | SimpleXMLTests.java:139:44:139:64 | getInputStream(...) [InputStream] | SimpleXMLTests.java:139:22:139:65 | new InputStreamReader(...) | Unsafe parsing of XML file from $@. | SimpleXMLTests.java:139:44:139:64 | getInputStream(...) | user input |
-| SimpleXMLTests.java:146:22:146:34 | new String(...) | SimpleXMLTests.java:145:5:145:25 | getInputStream(...) [InputStream] | SimpleXMLTests.java:146:22:146:34 | new String(...) | Unsafe parsing of XML file from $@. | SimpleXMLTests.java:145:5:145:25 | getInputStream(...) | user input |
-| SimpleXMLTests.java:153:22:153:34 | new String(...) | SimpleXMLTests.java:152:5:152:25 | getInputStream(...) [InputStream] | SimpleXMLTests.java:153:22:153:34 | new String(...) | Unsafe parsing of XML file from $@. | SimpleXMLTests.java:152:5:152:25 | getInputStream(...) | user input |
-| TransformerTests.java:20:27:20:65 | new StreamSource(...) | TransformerTests.java:20:44:20:64 | getInputStream(...) [InputStream] | TransformerTests.java:20:27:20:65 | new StreamSource(...) | Unsafe parsing of XML file from $@. | TransformerTests.java:20:44:20:64 | getInputStream(...) | user input |
-| TransformerTests.java:21:23:21:61 | new StreamSource(...) | TransformerTests.java:21:40:21:60 | getInputStream(...) [InputStream] | TransformerTests.java:21:23:21:61 | new StreamSource(...) | Unsafe parsing of XML file from $@. | TransformerTests.java:21:40:21:60 | getInputStream(...) | user input |
-| TransformerTests.java:71:27:71:65 | new StreamSource(...) | TransformerTests.java:71:44:71:64 | getInputStream(...) [InputStream] | TransformerTests.java:71:27:71:65 | new StreamSource(...) | Unsafe parsing of XML file from $@. | TransformerTests.java:71:44:71:64 | getInputStream(...) | user input |
-| TransformerTests.java:72:23:72:61 | new StreamSource(...) | TransformerTests.java:72:40:72:60 | getInputStream(...) [InputStream] | TransformerTests.java:72:23:72:61 | new StreamSource(...) | Unsafe parsing of XML file from $@. | TransformerTests.java:72:40:72:60 | getInputStream(...) | user input |
-| TransformerTests.java:79:27:79:65 | new StreamSource(...) | TransformerTests.java:79:44:79:64 | getInputStream(...) [InputStream] | TransformerTests.java:79:27:79:65 | new StreamSource(...) | Unsafe parsing of XML file from $@. | TransformerTests.java:79:44:79:64 | getInputStream(...) | user input |
-| TransformerTests.java:80:23:80:61 | new StreamSource(...) | TransformerTests.java:80:40:80:60 | getInputStream(...) [InputStream] | TransformerTests.java:80:23:80:61 | new StreamSource(...) | Unsafe parsing of XML file from $@. | TransformerTests.java:80:40:80:60 | getInputStream(...) | user input |
-| TransformerTests.java:88:27:88:65 | new StreamSource(...) | TransformerTests.java:88:44:88:64 | getInputStream(...) [InputStream] | TransformerTests.java:88:27:88:65 | new StreamSource(...) | Unsafe parsing of XML file from $@. | TransformerTests.java:88:44:88:64 | getInputStream(...) | user input |
-| TransformerTests.java:89:23:89:61 | new StreamSource(...) | TransformerTests.java:89:40:89:60 | getInputStream(...) [InputStream] | TransformerTests.java:89:23:89:61 | new StreamSource(...) | Unsafe parsing of XML file from $@. | TransformerTests.java:89:40:89:60 | getInputStream(...) | user input |
-| TransformerTests.java:97:27:97:65 | new StreamSource(...) | TransformerTests.java:97:44:97:64 | getInputStream(...) [InputStream] | TransformerTests.java:97:27:97:65 | new StreamSource(...) | Unsafe parsing of XML file from $@. | TransformerTests.java:97:44:97:64 | getInputStream(...) | user input |
-| TransformerTests.java:98:23:98:61 | new StreamSource(...) | TransformerTests.java:98:40:98:60 | getInputStream(...) [InputStream] | TransformerTests.java:98:23:98:61 | new StreamSource(...) | Unsafe parsing of XML file from $@. | TransformerTests.java:98:40:98:60 | getInputStream(...) | user input |
-| TransformerTests.java:103:21:103:59 | new StreamSource(...) | TransformerTests.java:103:38:103:58 | getInputStream(...) [InputStream] | TransformerTests.java:103:21:103:59 | new StreamSource(...) | Unsafe parsing of XML file from $@. | TransformerTests.java:103:38:103:58 | getInputStream(...) | user input |
-| TransformerTests.java:116:21:116:59 | new StreamSource(...) | TransformerTests.java:116:38:116:58 | getInputStream(...) [InputStream] | TransformerTests.java:116:21:116:59 | new StreamSource(...) | Unsafe parsing of XML file from $@. | TransformerTests.java:116:38:116:58 | getInputStream(...) | user input |
-| TransformerTests.java:122:21:122:59 | new StreamSource(...) | TransformerTests.java:122:38:122:58 | getInputStream(...) [InputStream] | TransformerTests.java:122:21:122:59 | new StreamSource(...) | Unsafe parsing of XML file from $@. | TransformerTests.java:122:38:122:58 | getInputStream(...) | user input |
-| TransformerTests.java:129:21:129:59 | new StreamSource(...) | TransformerTests.java:129:38:129:58 | getInputStream(...) [InputStream] | TransformerTests.java:129:21:129:59 | new StreamSource(...) | Unsafe parsing of XML file from $@. | TransformerTests.java:129:38:129:58 | getInputStream(...) | user input |
-| TransformerTests.java:136:21:136:59 | new StreamSource(...) | TransformerTests.java:136:38:136:58 | getInputStream(...) [InputStream] | TransformerTests.java:136:21:136:59 | new StreamSource(...) | Unsafe parsing of XML file from $@. | TransformerTests.java:136:38:136:58 | getInputStream(...) | user input |
-| TransformerTests.java:141:18:141:70 | new SAXSource(...) | TransformerTests.java:141:48:141:68 | getInputStream(...) [InputStream] | TransformerTests.java:141:18:141:70 | new SAXSource(...) | Unsafe parsing of XML file from $@. | TransformerTests.java:141:48:141:68 | getInputStream(...) | user input |
-| XMLReaderTests.java:16:18:16:55 | new InputSource(...) | XMLReaderTests.java:16:34:16:54 | getInputStream(...) [InputStream] | XMLReaderTests.java:16:18:16:55 | new InputSource(...) | Unsafe parsing of XML file from $@. | XMLReaderTests.java:16:34:16:54 | getInputStream(...) | user input |
-| XMLReaderTests.java:56:18:56:55 | new InputSource(...) | XMLReaderTests.java:56:34:56:54 | getInputStream(...) [InputStream] | XMLReaderTests.java:56:18:56:55 | new InputSource(...) | Unsafe parsing of XML file from $@. | XMLReaderTests.java:56:34:56:54 | getInputStream(...) | user input |
-| XMLReaderTests.java:63:18:63:55 | new InputSource(...) | XMLReaderTests.java:63:34:63:54 | getInputStream(...) [InputStream] | XMLReaderTests.java:63:18:63:55 | new InputSource(...) | Unsafe parsing of XML file from $@. | XMLReaderTests.java:63:34:63:54 | getInputStream(...) | user input |
-| XMLReaderTests.java:70:18:70:55 | new InputSource(...) | XMLReaderTests.java:70:34:70:54 | getInputStream(...) [InputStream] | XMLReaderTests.java:70:18:70:55 | new InputSource(...) | Unsafe parsing of XML file from $@. | XMLReaderTests.java:70:34:70:54 | getInputStream(...) | user input |
-| XMLReaderTests.java:78:18:78:55 | new InputSource(...) | XMLReaderTests.java:78:34:78:54 | getInputStream(...) [InputStream] | XMLReaderTests.java:78:18:78:55 | new InputSource(...) | Unsafe parsing of XML file from $@. | XMLReaderTests.java:78:34:78:54 | getInputStream(...) | user input |
-| XMLReaderTests.java:86:18:86:55 | new InputSource(...) | XMLReaderTests.java:86:34:86:54 | getInputStream(...) [InputStream] | XMLReaderTests.java:86:18:86:55 | new InputSource(...) | Unsafe parsing of XML file from $@. | XMLReaderTests.java:86:34:86:54 | getInputStream(...) | user input |
-| XMLReaderTests.java:94:18:94:55 | new InputSource(...) | XMLReaderTests.java:94:34:94:54 | getInputStream(...) [InputStream] | XMLReaderTests.java:94:18:94:55 | new InputSource(...) | Unsafe parsing of XML file from $@. | XMLReaderTests.java:94:34:94:54 | getInputStream(...) | user input |
-| XMLReaderTests.java:100:18:100:55 | new InputSource(...) | XMLReaderTests.java:100:34:100:54 | getInputStream(...) [InputStream] | XMLReaderTests.java:100:18:100:55 | new InputSource(...) | Unsafe parsing of XML file from $@. | XMLReaderTests.java:100:34:100:54 | getInputStream(...) | user input |
-| XPathExpressionTests.java:27:21:27:58 | new InputSource(...) | XPathExpressionTests.java:27:37:27:57 | getInputStream(...) [InputStream] | XPathExpressionTests.java:27:21:27:58 | new InputSource(...) | Unsafe parsing of XML file from $@. | XPathExpressionTests.java:27:37:27:57 | getInputStream(...) | user input |
-| XmlInputFactoryTests.java:9:35:9:55 | getInputStream(...) | XmlInputFactoryTests.java:9:35:9:55 | getInputStream(...) [InputStream] | XmlInputFactoryTests.java:9:35:9:55 | getInputStream(...) | Unsafe parsing of XML file from $@. | XmlInputFactoryTests.java:9:35:9:55 | getInputStream(...) | user input |
-| XmlInputFactoryTests.java:10:34:10:54 | getInputStream(...) | XmlInputFactoryTests.java:10:34:10:54 | getInputStream(...) [InputStream] | XmlInputFactoryTests.java:10:34:10:54 | getInputStream(...) | Unsafe parsing of XML file from $@. | XmlInputFactoryTests.java:10:34:10:54 | getInputStream(...) | user input |
-| XmlInputFactoryTests.java:24:35:24:55 | getInputStream(...) | XmlInputFactoryTests.java:24:35:24:55 | getInputStream(...) [InputStream] | XmlInputFactoryTests.java:24:35:24:55 | getInputStream(...) | Unsafe parsing of XML file from $@. | XmlInputFactoryTests.java:24:35:24:55 | getInputStream(...) | user input |
-| XmlInputFactoryTests.java:25:34:25:54 | getInputStream(...) | XmlInputFactoryTests.java:25:34:25:54 | getInputStream(...) [InputStream] | XmlInputFactoryTests.java:25:34:25:54 | getInputStream(...) | Unsafe parsing of XML file from $@. | XmlInputFactoryTests.java:25:34:25:54 | getInputStream(...) | user input |
-| XmlInputFactoryTests.java:31:35:31:55 | getInputStream(...) | XmlInputFactoryTests.java:31:35:31:55 | getInputStream(...) [InputStream] | XmlInputFactoryTests.java:31:35:31:55 | getInputStream(...) | Unsafe parsing of XML file from $@. | XmlInputFactoryTests.java:31:35:31:55 | getInputStream(...) | user input |
-| XmlInputFactoryTests.java:32:34:32:54 | getInputStream(...) | XmlInputFactoryTests.java:32:34:32:54 | getInputStream(...) [InputStream] | XmlInputFactoryTests.java:32:34:32:54 | getInputStream(...) | Unsafe parsing of XML file from $@. | XmlInputFactoryTests.java:32:34:32:54 | getInputStream(...) | user input |
-| XmlInputFactoryTests.java:39:35:39:55 | getInputStream(...) | XmlInputFactoryTests.java:39:35:39:55 | getInputStream(...) [InputStream] | XmlInputFactoryTests.java:39:35:39:55 | getInputStream(...) | Unsafe parsing of XML file from $@. | XmlInputFactoryTests.java:39:35:39:55 | getInputStream(...) | user input |
-| XmlInputFactoryTests.java:40:34:40:54 | getInputStream(...) | XmlInputFactoryTests.java:40:34:40:54 | getInputStream(...) [InputStream] | XmlInputFactoryTests.java:40:34:40:54 | getInputStream(...) | Unsafe parsing of XML file from $@. | XmlInputFactoryTests.java:40:34:40:54 | getInputStream(...) | user input |
-| XmlInputFactoryTests.java:47:35:47:55 | getInputStream(...) | XmlInputFactoryTests.java:47:35:47:55 | getInputStream(...) [InputStream] | XmlInputFactoryTests.java:47:35:47:55 | getInputStream(...) | Unsafe parsing of XML file from $@. | XmlInputFactoryTests.java:47:35:47:55 | getInputStream(...) | user input |
-| XmlInputFactoryTests.java:48:34:48:54 | getInputStream(...) | XmlInputFactoryTests.java:48:34:48:54 | getInputStream(...) [InputStream] | XmlInputFactoryTests.java:48:34:48:54 | getInputStream(...) | Unsafe parsing of XML file from $@. | XmlInputFactoryTests.java:48:34:48:54 | getInputStream(...) | user input |
-| XmlInputFactoryTests.java:55:35:55:55 | getInputStream(...) | XmlInputFactoryTests.java:55:35:55:55 | getInputStream(...) [InputStream] | XmlInputFactoryTests.java:55:35:55:55 | getInputStream(...) | Unsafe parsing of XML file from $@. | XmlInputFactoryTests.java:55:35:55:55 | getInputStream(...) | user input |
-| XmlInputFactoryTests.java:56:34:56:54 | getInputStream(...) | XmlInputFactoryTests.java:56:34:56:54 | getInputStream(...) [InputStream] | XmlInputFactoryTests.java:56:34:56:54 | getInputStream(...) | Unsafe parsing of XML file from $@. | XmlInputFactoryTests.java:56:34:56:54 | getInputStream(...) | user input |
+| DocumentBuilderTests.java:14:19:14:39 | getInputStream(...) | DocumentBuilderTests.java:14:19:14:39 | getInputStream(...) [ : InputStream] | DocumentBuilderTests.java:14:19:14:39 | getInputStream(...) | Unsafe parsing of XML file from $@. | DocumentBuilderTests.java:14:19:14:39 | getInputStream(...) | user input |
+| DocumentBuilderTests.java:42:19:42:39 | getInputStream(...) | DocumentBuilderTests.java:42:19:42:39 | getInputStream(...) [ : InputStream] | DocumentBuilderTests.java:42:19:42:39 | getInputStream(...) | Unsafe parsing of XML file from $@. | DocumentBuilderTests.java:42:19:42:39 | getInputStream(...) | user input |
+| DocumentBuilderTests.java:49:19:49:39 | getInputStream(...) | DocumentBuilderTests.java:49:19:49:39 | getInputStream(...) [ : InputStream] | DocumentBuilderTests.java:49:19:49:39 | getInputStream(...) | Unsafe parsing of XML file from $@. | DocumentBuilderTests.java:49:19:49:39 | getInputStream(...) | user input |
+| DocumentBuilderTests.java:64:19:64:39 | getInputStream(...) | DocumentBuilderTests.java:64:19:64:39 | getInputStream(...) [ : InputStream] | DocumentBuilderTests.java:64:19:64:39 | getInputStream(...) | Unsafe parsing of XML file from $@. | DocumentBuilderTests.java:64:19:64:39 | getInputStream(...) | user input |
+| DocumentBuilderTests.java:71:19:71:39 | getInputStream(...) | DocumentBuilderTests.java:71:19:71:39 | getInputStream(...) [ : InputStream] | DocumentBuilderTests.java:71:19:71:39 | getInputStream(...) | Unsafe parsing of XML file from $@. | DocumentBuilderTests.java:71:19:71:39 | getInputStream(...) | user input |
+| DocumentBuilderTests.java:79:19:79:39 | getInputStream(...) | DocumentBuilderTests.java:79:19:79:39 | getInputStream(...) [ : InputStream] | DocumentBuilderTests.java:79:19:79:39 | getInputStream(...) | Unsafe parsing of XML file from $@. | DocumentBuilderTests.java:79:19:79:39 | getInputStream(...) | user input |
+| DocumentBuilderTests.java:87:19:87:39 | getInputStream(...) | DocumentBuilderTests.java:87:19:87:39 | getInputStream(...) [ : InputStream] | DocumentBuilderTests.java:87:19:87:39 | getInputStream(...) | Unsafe parsing of XML file from $@. | DocumentBuilderTests.java:87:19:87:39 | getInputStream(...) | user input |
+| DocumentBuilderTests.java:94:16:94:38 | getInputSource(...) | DocumentBuilderTests.java:93:51:93:71 | getInputStream(...) [ : InputStream] | DocumentBuilderTests.java:94:16:94:38 | getInputSource(...) | Unsafe parsing of XML file from $@. | DocumentBuilderTests.java:93:51:93:71 | getInputStream(...) | user input |
+| DocumentBuilderTests.java:101:16:101:52 | sourceToInputSource(...) | DocumentBuilderTests.java:100:41:100:61 | getInputStream(...) [ : InputStream] | DocumentBuilderTests.java:101:16:101:52 | sourceToInputSource(...) | Unsafe parsing of XML file from $@. | DocumentBuilderTests.java:100:41:100:61 | getInputStream(...) | user input |
+| DocumentBuilderTests.java:102:16:102:38 | getInputStream(...) | DocumentBuilderTests.java:100:41:100:61 | getInputStream(...) [ : InputStream] | DocumentBuilderTests.java:102:16:102:38 | getInputStream(...) | Unsafe parsing of XML file from $@. | DocumentBuilderTests.java:100:41:100:61 | getInputStream(...) | user input |
+| SAXBuilderTests.java:8:19:8:39 | getInputStream(...) | SAXBuilderTests.java:8:19:8:39 | getInputStream(...) [ : InputStream] | SAXBuilderTests.java:8:19:8:39 | getInputStream(...) | Unsafe parsing of XML file from $@. | SAXBuilderTests.java:8:19:8:39 | getInputStream(...) | user input |
+| SAXBuilderTests.java:20:19:20:39 | getInputStream(...) | SAXBuilderTests.java:20:19:20:39 | getInputStream(...) [ : InputStream] | SAXBuilderTests.java:20:19:20:39 | getInputStream(...) | Unsafe parsing of XML file from $@. | SAXBuilderTests.java:20:19:20:39 | getInputStream(...) | user input |
+| SAXParserTests.java:13:18:13:38 | getInputStream(...) | SAXParserTests.java:13:18:13:38 | getInputStream(...) [ : InputStream] | SAXParserTests.java:13:18:13:38 | getInputStream(...) | Unsafe parsing of XML file from $@. | SAXParserTests.java:13:18:13:38 | getInputStream(...) | user input |
+| SAXParserTests.java:30:18:30:38 | getInputStream(...) | SAXParserTests.java:30:18:30:38 | getInputStream(...) [ : InputStream] | SAXParserTests.java:30:18:30:38 | getInputStream(...) | Unsafe parsing of XML file from $@. | SAXParserTests.java:30:18:30:38 | getInputStream(...) | user input |
+| SAXParserTests.java:38:18:38:38 | getInputStream(...) | SAXParserTests.java:38:18:38:38 | getInputStream(...) [ : InputStream] | SAXParserTests.java:38:18:38:38 | getInputStream(...) | Unsafe parsing of XML file from $@. | SAXParserTests.java:38:18:38:38 | getInputStream(...) | user input |
+| SAXParserTests.java:46:18:46:38 | getInputStream(...) | SAXParserTests.java:46:18:46:38 | getInputStream(...) [ : InputStream] | SAXParserTests.java:46:18:46:38 | getInputStream(...) | Unsafe parsing of XML file from $@. | SAXParserTests.java:46:18:46:38 | getInputStream(...) | user input |
+| SAXParserTests.java:55:18:55:38 | getInputStream(...) | SAXParserTests.java:55:18:55:38 | getInputStream(...) [ : InputStream] | SAXParserTests.java:55:18:55:38 | getInputStream(...) | Unsafe parsing of XML file from $@. | SAXParserTests.java:55:18:55:38 | getInputStream(...) | user input |
+| SAXParserTests.java:64:18:64:38 | getInputStream(...) | SAXParserTests.java:64:18:64:38 | getInputStream(...) [ : InputStream] | SAXParserTests.java:64:18:64:38 | getInputStream(...) | Unsafe parsing of XML file from $@. | SAXParserTests.java:64:18:64:38 | getInputStream(...) | user input |
+| SAXParserTests.java:73:18:73:38 | getInputStream(...) | SAXParserTests.java:73:18:73:38 | getInputStream(...) [ : InputStream] | SAXParserTests.java:73:18:73:38 | getInputStream(...) | Unsafe parsing of XML file from $@. | SAXParserTests.java:73:18:73:38 | getInputStream(...) | user input |
+| SAXReaderTests.java:8:17:8:37 | getInputStream(...) | SAXReaderTests.java:8:17:8:37 | getInputStream(...) [ : InputStream] | SAXReaderTests.java:8:17:8:37 | getInputStream(...) | Unsafe parsing of XML file from $@. | SAXReaderTests.java:8:17:8:37 | getInputStream(...) | user input |
+| SAXReaderTests.java:23:17:23:37 | getInputStream(...) | SAXReaderTests.java:23:17:23:37 | getInputStream(...) [ : InputStream] | SAXReaderTests.java:23:17:23:37 | getInputStream(...) | Unsafe parsing of XML file from $@. | SAXReaderTests.java:23:17:23:37 | getInputStream(...) | user input |
+| SAXReaderTests.java:30:17:30:37 | getInputStream(...) | SAXReaderTests.java:30:17:30:37 | getInputStream(...) [ : InputStream] | SAXReaderTests.java:30:17:30:37 | getInputStream(...) | Unsafe parsing of XML file from $@. | SAXReaderTests.java:30:17:30:37 | getInputStream(...) | user input |
+| SAXReaderTests.java:37:17:37:37 | getInputStream(...) | SAXReaderTests.java:37:17:37:37 | getInputStream(...) [ : InputStream] | SAXReaderTests.java:37:17:37:37 | getInputStream(...) | Unsafe parsing of XML file from $@. | SAXReaderTests.java:37:17:37:37 | getInputStream(...) | user input |
+| SAXReaderTests.java:45:17:45:37 | getInputStream(...) | SAXReaderTests.java:45:17:45:37 | getInputStream(...) [ : InputStream] | SAXReaderTests.java:45:17:45:37 | getInputStream(...) | Unsafe parsing of XML file from $@. | SAXReaderTests.java:45:17:45:37 | getInputStream(...) | user input |
+| SAXReaderTests.java:53:17:53:37 | getInputStream(...) | SAXReaderTests.java:53:17:53:37 | getInputStream(...) [ : InputStream] | SAXReaderTests.java:53:17:53:37 | getInputStream(...) | Unsafe parsing of XML file from $@. | SAXReaderTests.java:53:17:53:37 | getInputStream(...) | user input |
+| SAXReaderTests.java:61:17:61:37 | getInputStream(...) | SAXReaderTests.java:61:17:61:37 | getInputStream(...) [ : InputStream] | SAXReaderTests.java:61:17:61:37 | getInputStream(...) | Unsafe parsing of XML file from $@. | SAXReaderTests.java:61:17:61:37 | getInputStream(...) | user input |
+| SchemaTests.java:12:39:12:77 | new StreamSource(...) | SchemaTests.java:12:56:12:76 | getInputStream(...) [ : InputStream] | SchemaTests.java:12:39:12:77 | new StreamSource(...) | Unsafe parsing of XML file from $@. | SchemaTests.java:12:56:12:76 | getInputStream(...) | user input |
+| SchemaTests.java:25:39:25:77 | new StreamSource(...) | SchemaTests.java:25:56:25:76 | getInputStream(...) [ : InputStream] | SchemaTests.java:25:39:25:77 | new StreamSource(...) | Unsafe parsing of XML file from $@. | SchemaTests.java:25:56:25:76 | getInputStream(...) | user input |
+| SchemaTests.java:31:39:31:77 | new StreamSource(...) | SchemaTests.java:31:56:31:76 | getInputStream(...) [ : InputStream] | SchemaTests.java:31:39:31:77 | new StreamSource(...) | Unsafe parsing of XML file from $@. | SchemaTests.java:31:56:31:76 | getInputStream(...) | user input |
+| SchemaTests.java:38:39:38:77 | new StreamSource(...) | SchemaTests.java:38:56:38:76 | getInputStream(...) [ : InputStream] | SchemaTests.java:38:39:38:77 | new StreamSource(...) | Unsafe parsing of XML file from $@. | SchemaTests.java:38:56:38:76 | getInputStream(...) | user input |
+| SchemaTests.java:45:39:45:77 | new StreamSource(...) | SchemaTests.java:45:56:45:76 | getInputStream(...) [ : InputStream] | SchemaTests.java:45:39:45:77 | new StreamSource(...) | Unsafe parsing of XML file from $@. | SchemaTests.java:45:56:45:76 | getInputStream(...) | user input |
+| SimpleXMLTests.java:14:41:14:61 | getInputStream(...) | SimpleXMLTests.java:14:41:14:61 | getInputStream(...) [ : InputStream] | SimpleXMLTests.java:14:41:14:61 | getInputStream(...) | Unsafe parsing of XML file from $@. | SimpleXMLTests.java:14:41:14:61 | getInputStream(...) | user input |
+| SimpleXMLTests.java:19:41:19:61 | getInputStream(...) | SimpleXMLTests.java:19:41:19:61 | getInputStream(...) [ : InputStream] | SimpleXMLTests.java:19:41:19:61 | getInputStream(...) | Unsafe parsing of XML file from $@. | SimpleXMLTests.java:19:41:19:61 | getInputStream(...) | user input |
+| SimpleXMLTests.java:24:41:24:84 | new InputStreamReader(...) | SimpleXMLTests.java:24:63:24:83 | getInputStream(...) [ : InputStream] | SimpleXMLTests.java:24:41:24:84 | new InputStreamReader(...) | Unsafe parsing of XML file from $@. | SimpleXMLTests.java:24:63:24:83 | getInputStream(...) | user input |
+| SimpleXMLTests.java:31:41:31:53 | new String(...) | SimpleXMLTests.java:30:5:30:25 | getInputStream(...) [ : InputStream] | SimpleXMLTests.java:31:41:31:53 | new String(...) | Unsafe parsing of XML file from $@. | SimpleXMLTests.java:30:5:30:25 | getInputStream(...) | user input |
+| SimpleXMLTests.java:38:41:38:53 | new String(...) | SimpleXMLTests.java:37:5:37:25 | getInputStream(...) [ : InputStream] | SimpleXMLTests.java:38:41:38:53 | new String(...) | Unsafe parsing of XML file from $@. | SimpleXMLTests.java:37:5:37:25 | getInputStream(...) | user input |
+| SimpleXMLTests.java:43:41:43:84 | new InputStreamReader(...) | SimpleXMLTests.java:43:63:43:83 | getInputStream(...) [ : InputStream] | SimpleXMLTests.java:43:41:43:84 | new InputStreamReader(...) | Unsafe parsing of XML file from $@. | SimpleXMLTests.java:43:63:43:83 | getInputStream(...) | user input |
+| SimpleXMLTests.java:48:37:48:57 | getInputStream(...) | SimpleXMLTests.java:48:37:48:57 | getInputStream(...) [ : InputStream] | SimpleXMLTests.java:48:37:48:57 | getInputStream(...) | Unsafe parsing of XML file from $@. | SimpleXMLTests.java:48:37:48:57 | getInputStream(...) | user input |
+| SimpleXMLTests.java:53:37:53:57 | getInputStream(...) | SimpleXMLTests.java:53:37:53:57 | getInputStream(...) [ : InputStream] | SimpleXMLTests.java:53:37:53:57 | getInputStream(...) | Unsafe parsing of XML file from $@. | SimpleXMLTests.java:53:37:53:57 | getInputStream(...) | user input |
+| SimpleXMLTests.java:58:26:58:46 | getInputStream(...) | SimpleXMLTests.java:58:26:58:46 | getInputStream(...) [ : InputStream] | SimpleXMLTests.java:58:26:58:46 | getInputStream(...) | Unsafe parsing of XML file from $@. | SimpleXMLTests.java:58:26:58:46 | getInputStream(...) | user input |
+| SimpleXMLTests.java:63:26:63:46 | getInputStream(...) | SimpleXMLTests.java:63:26:63:46 | getInputStream(...) [ : InputStream] | SimpleXMLTests.java:63:26:63:46 | getInputStream(...) | Unsafe parsing of XML file from $@. | SimpleXMLTests.java:63:26:63:46 | getInputStream(...) | user input |
+| SimpleXMLTests.java:68:37:68:80 | new InputStreamReader(...) | SimpleXMLTests.java:68:59:68:79 | getInputStream(...) [ : InputStream] | SimpleXMLTests.java:68:37:68:80 | new InputStreamReader(...) | Unsafe parsing of XML file from $@. | SimpleXMLTests.java:68:59:68:79 | getInputStream(...) | user input |
+| SimpleXMLTests.java:73:37:73:80 | new InputStreamReader(...) | SimpleXMLTests.java:73:59:73:79 | getInputStream(...) [ : InputStream] | SimpleXMLTests.java:73:37:73:80 | new InputStreamReader(...) | Unsafe parsing of XML file from $@. | SimpleXMLTests.java:73:59:73:79 | getInputStream(...) | user input |
+| SimpleXMLTests.java:78:26:78:69 | new InputStreamReader(...) | SimpleXMLTests.java:78:48:78:68 | getInputStream(...) [ : InputStream] | SimpleXMLTests.java:78:26:78:69 | new InputStreamReader(...) | Unsafe parsing of XML file from $@. | SimpleXMLTests.java:78:48:78:68 | getInputStream(...) | user input |
+| SimpleXMLTests.java:83:26:83:69 | new InputStreamReader(...) | SimpleXMLTests.java:83:48:83:68 | getInputStream(...) [ : InputStream] | SimpleXMLTests.java:83:26:83:69 | new InputStreamReader(...) | Unsafe parsing of XML file from $@. | SimpleXMLTests.java:83:48:83:68 | getInputStream(...) | user input |
+| SimpleXMLTests.java:90:37:90:49 | new String(...) | SimpleXMLTests.java:89:5:89:25 | getInputStream(...) [ : InputStream] | SimpleXMLTests.java:90:37:90:49 | new String(...) | Unsafe parsing of XML file from $@. | SimpleXMLTests.java:89:5:89:25 | getInputStream(...) | user input |
+| SimpleXMLTests.java:97:37:97:49 | new String(...) | SimpleXMLTests.java:96:5:96:25 | getInputStream(...) [ : InputStream] | SimpleXMLTests.java:97:37:97:49 | new String(...) | Unsafe parsing of XML file from $@. | SimpleXMLTests.java:96:5:96:25 | getInputStream(...) | user input |
+| SimpleXMLTests.java:104:26:104:38 | new String(...) | SimpleXMLTests.java:103:5:103:25 | getInputStream(...) [ : InputStream] | SimpleXMLTests.java:104:26:104:38 | new String(...) | Unsafe parsing of XML file from $@. | SimpleXMLTests.java:103:5:103:25 | getInputStream(...) | user input |
+| SimpleXMLTests.java:111:26:111:38 | new String(...) | SimpleXMLTests.java:110:5:110:25 | getInputStream(...) [ : InputStream] | SimpleXMLTests.java:111:26:111:38 | new String(...) | Unsafe parsing of XML file from $@. | SimpleXMLTests.java:110:5:110:25 | getInputStream(...) | user input |
+| SimpleXMLTests.java:115:22:115:42 | getInputStream(...) | SimpleXMLTests.java:115:22:115:42 | getInputStream(...) [ : InputStream] | SimpleXMLTests.java:115:22:115:42 | getInputStream(...) | Unsafe parsing of XML file from $@. | SimpleXMLTests.java:115:22:115:42 | getInputStream(...) | user input |
+| SimpleXMLTests.java:119:22:119:65 | new InputStreamReader(...) | SimpleXMLTests.java:119:44:119:64 | getInputStream(...) [ : InputStream] | SimpleXMLTests.java:119:22:119:65 | new InputStreamReader(...) | Unsafe parsing of XML file from $@. | SimpleXMLTests.java:119:44:119:64 | getInputStream(...) | user input |
+| SimpleXMLTests.java:124:22:124:42 | getInputStream(...) | SimpleXMLTests.java:124:22:124:42 | getInputStream(...) [ : InputStream] | SimpleXMLTests.java:124:22:124:42 | getInputStream(...) | Unsafe parsing of XML file from $@. | SimpleXMLTests.java:124:22:124:42 | getInputStream(...) | user input |
+| SimpleXMLTests.java:129:22:129:65 | new InputStreamReader(...) | SimpleXMLTests.java:129:44:129:64 | getInputStream(...) [ : InputStream] | SimpleXMLTests.java:129:22:129:65 | new InputStreamReader(...) | Unsafe parsing of XML file from $@. | SimpleXMLTests.java:129:44:129:64 | getInputStream(...) | user input |
+| SimpleXMLTests.java:134:22:134:42 | getInputStream(...) | SimpleXMLTests.java:134:22:134:42 | getInputStream(...) [ : InputStream] | SimpleXMLTests.java:134:22:134:42 | getInputStream(...) | Unsafe parsing of XML file from $@. | SimpleXMLTests.java:134:22:134:42 | getInputStream(...) | user input |
+| SimpleXMLTests.java:139:22:139:65 | new InputStreamReader(...) | SimpleXMLTests.java:139:44:139:64 | getInputStream(...) [ : InputStream] | SimpleXMLTests.java:139:22:139:65 | new InputStreamReader(...) | Unsafe parsing of XML file from $@. | SimpleXMLTests.java:139:44:139:64 | getInputStream(...) | user input |
+| SimpleXMLTests.java:146:22:146:34 | new String(...) | SimpleXMLTests.java:145:5:145:25 | getInputStream(...) [ : InputStream] | SimpleXMLTests.java:146:22:146:34 | new String(...) | Unsafe parsing of XML file from $@. | SimpleXMLTests.java:145:5:145:25 | getInputStream(...) | user input |
+| SimpleXMLTests.java:153:22:153:34 | new String(...) | SimpleXMLTests.java:152:5:152:25 | getInputStream(...) [ : InputStream] | SimpleXMLTests.java:153:22:153:34 | new String(...) | Unsafe parsing of XML file from $@. | SimpleXMLTests.java:152:5:152:25 | getInputStream(...) | user input |
+| TransformerTests.java:20:27:20:65 | new StreamSource(...) | TransformerTests.java:20:44:20:64 | getInputStream(...) [ : InputStream] | TransformerTests.java:20:27:20:65 | new StreamSource(...) | Unsafe parsing of XML file from $@. | TransformerTests.java:20:44:20:64 | getInputStream(...) | user input |
+| TransformerTests.java:21:23:21:61 | new StreamSource(...) | TransformerTests.java:21:40:21:60 | getInputStream(...) [ : InputStream] | TransformerTests.java:21:23:21:61 | new StreamSource(...) | Unsafe parsing of XML file from $@. | TransformerTests.java:21:40:21:60 | getInputStream(...) | user input |
+| TransformerTests.java:71:27:71:65 | new StreamSource(...) | TransformerTests.java:71:44:71:64 | getInputStream(...) [ : InputStream] | TransformerTests.java:71:27:71:65 | new StreamSource(...) | Unsafe parsing of XML file from $@. | TransformerTests.java:71:44:71:64 | getInputStream(...) | user input |
+| TransformerTests.java:72:23:72:61 | new StreamSource(...) | TransformerTests.java:72:40:72:60 | getInputStream(...) [ : InputStream] | TransformerTests.java:72:23:72:61 | new StreamSource(...) | Unsafe parsing of XML file from $@. | TransformerTests.java:72:40:72:60 | getInputStream(...) | user input |
+| TransformerTests.java:79:27:79:65 | new StreamSource(...) | TransformerTests.java:79:44:79:64 | getInputStream(...) [ : InputStream] | TransformerTests.java:79:27:79:65 | new StreamSource(...) | Unsafe parsing of XML file from $@. | TransformerTests.java:79:44:79:64 | getInputStream(...) | user input |
+| TransformerTests.java:80:23:80:61 | new StreamSource(...) | TransformerTests.java:80:40:80:60 | getInputStream(...) [ : InputStream] | TransformerTests.java:80:23:80:61 | new StreamSource(...) | Unsafe parsing of XML file from $@. | TransformerTests.java:80:40:80:60 | getInputStream(...) | user input |
+| TransformerTests.java:88:27:88:65 | new StreamSource(...) | TransformerTests.java:88:44:88:64 | getInputStream(...) [ : InputStream] | TransformerTests.java:88:27:88:65 | new StreamSource(...) | Unsafe parsing of XML file from $@. | TransformerTests.java:88:44:88:64 | getInputStream(...) | user input |
+| TransformerTests.java:89:23:89:61 | new StreamSource(...) | TransformerTests.java:89:40:89:60 | getInputStream(...) [ : InputStream] | TransformerTests.java:89:23:89:61 | new StreamSource(...) | Unsafe parsing of XML file from $@. | TransformerTests.java:89:40:89:60 | getInputStream(...) | user input |
+| TransformerTests.java:97:27:97:65 | new StreamSource(...) | TransformerTests.java:97:44:97:64 | getInputStream(...) [ : InputStream] | TransformerTests.java:97:27:97:65 | new StreamSource(...) | Unsafe parsing of XML file from $@. | TransformerTests.java:97:44:97:64 | getInputStream(...) | user input |
+| TransformerTests.java:98:23:98:61 | new StreamSource(...) | TransformerTests.java:98:40:98:60 | getInputStream(...) [ : InputStream] | TransformerTests.java:98:23:98:61 | new StreamSource(...) | Unsafe parsing of XML file from $@. | TransformerTests.java:98:40:98:60 | getInputStream(...) | user input |
+| TransformerTests.java:103:21:103:59 | new StreamSource(...) | TransformerTests.java:103:38:103:58 | getInputStream(...) [ : InputStream] | TransformerTests.java:103:21:103:59 | new StreamSource(...) | Unsafe parsing of XML file from $@. | TransformerTests.java:103:38:103:58 | getInputStream(...) | user input |
+| TransformerTests.java:116:21:116:59 | new StreamSource(...) | TransformerTests.java:116:38:116:58 | getInputStream(...) [ : InputStream] | TransformerTests.java:116:21:116:59 | new StreamSource(...) | Unsafe parsing of XML file from $@. | TransformerTests.java:116:38:116:58 | getInputStream(...) | user input |
+| TransformerTests.java:122:21:122:59 | new StreamSource(...) | TransformerTests.java:122:38:122:58 | getInputStream(...) [ : InputStream] | TransformerTests.java:122:21:122:59 | new StreamSource(...) | Unsafe parsing of XML file from $@. | TransformerTests.java:122:38:122:58 | getInputStream(...) | user input |
+| TransformerTests.java:129:21:129:59 | new StreamSource(...) | TransformerTests.java:129:38:129:58 | getInputStream(...) [ : InputStream] | TransformerTests.java:129:21:129:59 | new StreamSource(...) | Unsafe parsing of XML file from $@. | TransformerTests.java:129:38:129:58 | getInputStream(...) | user input |
+| TransformerTests.java:136:21:136:59 | new StreamSource(...) | TransformerTests.java:136:38:136:58 | getInputStream(...) [ : InputStream] | TransformerTests.java:136:21:136:59 | new StreamSource(...) | Unsafe parsing of XML file from $@. | TransformerTests.java:136:38:136:58 | getInputStream(...) | user input |
+| TransformerTests.java:141:18:141:70 | new SAXSource(...) | TransformerTests.java:141:48:141:68 | getInputStream(...) [ : InputStream] | TransformerTests.java:141:18:141:70 | new SAXSource(...) | Unsafe parsing of XML file from $@. | TransformerTests.java:141:48:141:68 | getInputStream(...) | user input |
+| XMLReaderTests.java:16:18:16:55 | new InputSource(...) | XMLReaderTests.java:16:34:16:54 | getInputStream(...) [ : InputStream] | XMLReaderTests.java:16:18:16:55 | new InputSource(...) | Unsafe parsing of XML file from $@. | XMLReaderTests.java:16:34:16:54 | getInputStream(...) | user input |
+| XMLReaderTests.java:56:18:56:55 | new InputSource(...) | XMLReaderTests.java:56:34:56:54 | getInputStream(...) [ : InputStream] | XMLReaderTests.java:56:18:56:55 | new InputSource(...) | Unsafe parsing of XML file from $@. | XMLReaderTests.java:56:34:56:54 | getInputStream(...) | user input |
+| XMLReaderTests.java:63:18:63:55 | new InputSource(...) | XMLReaderTests.java:63:34:63:54 | getInputStream(...) [ : InputStream] | XMLReaderTests.java:63:18:63:55 | new InputSource(...) | Unsafe parsing of XML file from $@. | XMLReaderTests.java:63:34:63:54 | getInputStream(...) | user input |
+| XMLReaderTests.java:70:18:70:55 | new InputSource(...) | XMLReaderTests.java:70:34:70:54 | getInputStream(...) [ : InputStream] | XMLReaderTests.java:70:18:70:55 | new InputSource(...) | Unsafe parsing of XML file from $@. | XMLReaderTests.java:70:34:70:54 | getInputStream(...) | user input |
+| XMLReaderTests.java:78:18:78:55 | new InputSource(...) | XMLReaderTests.java:78:34:78:54 | getInputStream(...) [ : InputStream] | XMLReaderTests.java:78:18:78:55 | new InputSource(...) | Unsafe parsing of XML file from $@. | XMLReaderTests.java:78:34:78:54 | getInputStream(...) | user input |
+| XMLReaderTests.java:86:18:86:55 | new InputSource(...) | XMLReaderTests.java:86:34:86:54 | getInputStream(...) [ : InputStream] | XMLReaderTests.java:86:18:86:55 | new InputSource(...) | Unsafe parsing of XML file from $@. | XMLReaderTests.java:86:34:86:54 | getInputStream(...) | user input |
+| XMLReaderTests.java:94:18:94:55 | new InputSource(...) | XMLReaderTests.java:94:34:94:54 | getInputStream(...) [ : InputStream] | XMLReaderTests.java:94:18:94:55 | new InputSource(...) | Unsafe parsing of XML file from $@. | XMLReaderTests.java:94:34:94:54 | getInputStream(...) | user input |
+| XMLReaderTests.java:100:18:100:55 | new InputSource(...) | XMLReaderTests.java:100:34:100:54 | getInputStream(...) [ : InputStream] | XMLReaderTests.java:100:18:100:55 | new InputSource(...) | Unsafe parsing of XML file from $@. | XMLReaderTests.java:100:34:100:54 | getInputStream(...) | user input |
+| XPathExpressionTests.java:27:21:27:58 | new InputSource(...) | XPathExpressionTests.java:27:37:27:57 | getInputStream(...) [ : InputStream] | XPathExpressionTests.java:27:21:27:58 | new InputSource(...) | Unsafe parsing of XML file from $@. | XPathExpressionTests.java:27:37:27:57 | getInputStream(...) | user input |
+| XmlInputFactoryTests.java:9:35:9:55 | getInputStream(...) | XmlInputFactoryTests.java:9:35:9:55 | getInputStream(...) [ : InputStream] | XmlInputFactoryTests.java:9:35:9:55 | getInputStream(...) | Unsafe parsing of XML file from $@. | XmlInputFactoryTests.java:9:35:9:55 | getInputStream(...) | user input |
+| XmlInputFactoryTests.java:10:34:10:54 | getInputStream(...) | XmlInputFactoryTests.java:10:34:10:54 | getInputStream(...) [ : InputStream] | XmlInputFactoryTests.java:10:34:10:54 | getInputStream(...) | Unsafe parsing of XML file from $@. | XmlInputFactoryTests.java:10:34:10:54 | getInputStream(...) | user input |
+| XmlInputFactoryTests.java:24:35:24:55 | getInputStream(...) | XmlInputFactoryTests.java:24:35:24:55 | getInputStream(...) [ : InputStream] | XmlInputFactoryTests.java:24:35:24:55 | getInputStream(...) | Unsafe parsing of XML file from $@. | XmlInputFactoryTests.java:24:35:24:55 | getInputStream(...) | user input |
+| XmlInputFactoryTests.java:25:34:25:54 | getInputStream(...) | XmlInputFactoryTests.java:25:34:25:54 | getInputStream(...) [ : InputStream] | XmlInputFactoryTests.java:25:34:25:54 | getInputStream(...) | Unsafe parsing of XML file from $@. | XmlInputFactoryTests.java:25:34:25:54 | getInputStream(...) | user input |
+| XmlInputFactoryTests.java:31:35:31:55 | getInputStream(...) | XmlInputFactoryTests.java:31:35:31:55 | getInputStream(...) [ : InputStream] | XmlInputFactoryTests.java:31:35:31:55 | getInputStream(...) | Unsafe parsing of XML file from $@. | XmlInputFactoryTests.java:31:35:31:55 | getInputStream(...) | user input |
+| XmlInputFactoryTests.java:32:34:32:54 | getInputStream(...) | XmlInputFactoryTests.java:32:34:32:54 | getInputStream(...) [ : InputStream] | XmlInputFactoryTests.java:32:34:32:54 | getInputStream(...) | Unsafe parsing of XML file from $@. | XmlInputFactoryTests.java:32:34:32:54 | getInputStream(...) | user input |
+| XmlInputFactoryTests.java:39:35:39:55 | getInputStream(...) | XmlInputFactoryTests.java:39:35:39:55 | getInputStream(...) [ : InputStream] | XmlInputFactoryTests.java:39:35:39:55 | getInputStream(...) | Unsafe parsing of XML file from $@. | XmlInputFactoryTests.java:39:35:39:55 | getInputStream(...) | user input |
+| XmlInputFactoryTests.java:40:34:40:54 | getInputStream(...) | XmlInputFactoryTests.java:40:34:40:54 | getInputStream(...) [ : InputStream] | XmlInputFactoryTests.java:40:34:40:54 | getInputStream(...) | Unsafe parsing of XML file from $@. | XmlInputFactoryTests.java:40:34:40:54 | getInputStream(...) | user input |
+| XmlInputFactoryTests.java:47:35:47:55 | getInputStream(...) | XmlInputFactoryTests.java:47:35:47:55 | getInputStream(...) [ : InputStream] | XmlInputFactoryTests.java:47:35:47:55 | getInputStream(...) | Unsafe parsing of XML file from $@. | XmlInputFactoryTests.java:47:35:47:55 | getInputStream(...) | user input |
+| XmlInputFactoryTests.java:48:34:48:54 | getInputStream(...) | XmlInputFactoryTests.java:48:34:48:54 | getInputStream(...) [ : InputStream] | XmlInputFactoryTests.java:48:34:48:54 | getInputStream(...) | Unsafe parsing of XML file from $@. | XmlInputFactoryTests.java:48:34:48:54 | getInputStream(...) | user input |
+| XmlInputFactoryTests.java:55:35:55:55 | getInputStream(...) | XmlInputFactoryTests.java:55:35:55:55 | getInputStream(...) [ : InputStream] | XmlInputFactoryTests.java:55:35:55:55 | getInputStream(...) | Unsafe parsing of XML file from $@. | XmlInputFactoryTests.java:55:35:55:55 | getInputStream(...) | user input |
+| XmlInputFactoryTests.java:56:34:56:54 | getInputStream(...) | XmlInputFactoryTests.java:56:34:56:54 | getInputStream(...) [ : InputStream] | XmlInputFactoryTests.java:56:34:56:54 | getInputStream(...) | Unsafe parsing of XML file from $@. | XmlInputFactoryTests.java:56:34:56:54 | getInputStream(...) | user input |

--- a/java/ql/test/query-tests/security/CWE-681/semmle/tests/NumericCastTaintedLocal.expected
+++ b/java/ql/test/query-tests/security/CWE-681/semmle/tests/NumericCastTaintedLocal.expected
@@ -1,4 +1,7 @@
 edges
-| Test.java:11:28:11:36 | System.in [InputStream] | Test.java:21:22:21:25 | data |
+| Test.java:11:28:11:36 | System.in [ : InputStream] | Test.java:21:22:21:25 | data |
+nodes
+| Test.java:11:28:11:36 | System.in [ : InputStream] | semmle.label | System.in [ : InputStream] |
+| Test.java:21:22:21:25 | data | semmle.label | data |
 #select
-| Test.java:21:17:21:25 | (...)... | Test.java:11:28:11:36 | System.in [InputStream] | Test.java:21:22:21:25 | data | $@ flows to here and is cast to a narrower type, potentially causing truncation. | Test.java:11:28:11:36 | System.in | User-provided value |
+| Test.java:21:17:21:25 | (...)... | Test.java:11:28:11:36 | System.in [ : InputStream] | Test.java:21:22:21:25 | data | $@ flows to here and is cast to a narrower type, potentially causing truncation. | Test.java:11:28:11:36 | System.in | User-provided value |

--- a/java/ql/test/query-tests/security/CWE-798/semmle/tests/HardcodedCredentialsApiCall.expected
+++ b/java/ql/test/query-tests/security/CWE-798/semmle/tests/HardcodedCredentialsApiCall.expected
@@ -1,48 +1,88 @@
 edges
-| CredentialsTest.java:7:34:7:41 | "123456" [String] | CredentialsTest.java:13:39:13:39 | p |
-| CredentialsTest.java:7:34:7:41 | "123456" [String] | CredentialsTest.java:14:16:14:16 | p [String] |
-| CredentialsTest.java:11:14:11:20 | "admin" [String] | CredentialsTest.java:13:36:13:36 | u |
-| CredentialsTest.java:11:14:11:20 | "admin" [String] | CredentialsTest.java:14:13:14:13 | u [String] |
-| CredentialsTest.java:14:13:14:13 | u [String] | CredentialsTest.java:17:38:17:45 | v [String] |
-| CredentialsTest.java:14:16:14:16 | p [String] | CredentialsTest.java:17:48:17:55 | q [String] |
-| CredentialsTest.java:17:38:17:45 | v [String] | CredentialsTest.java:18:36:18:36 | v |
-| CredentialsTest.java:17:48:17:55 | q [String] | CredentialsTest.java:18:39:18:39 | q |
-| FileCredentialTest.java:13:14:13:20 | "admin" [String] | FileCredentialTest.java:19:13:19:13 | u [String] |
-| FileCredentialTest.java:18:35:18:41 | "admin" [String] | FileCredentialTest.java:18:35:18:41 | "admin" |
-| FileCredentialTest.java:19:13:19:13 | u [String] | FileCredentialTest.java:22:38:22:45 | v [String] |
-| FileCredentialTest.java:22:38:22:45 | v [String] | FileCredentialTest.java:23:36:23:36 | v |
-| Test.java:9:16:9:22 | "admin" [String] | Test.java:12:13:12:15 | usr [String] |
-| Test.java:9:16:9:22 | "admin" [String] | Test.java:15:36:15:38 | usr |
-| Test.java:9:16:9:22 | "admin" [String] | Test.java:17:39:17:41 | usr |
-| Test.java:9:16:9:22 | "admin" [String] | Test.java:18:39:18:41 | usr |
-| Test.java:10:17:10:24 | "123456" [String] | Test.java:12:18:12:21 | pass [String] |
-| Test.java:10:17:10:24 | "123456" [String] | Test.java:15:41:15:44 | pass |
-| Test.java:10:17:10:24 | "123456" [String] | Test.java:18:44:18:61 | toCharArray(...) |
-| Test.java:12:13:12:15 | usr [String] | Test.java:29:38:29:48 | user [String] |
-| Test.java:12:18:12:21 | pass [String] | Test.java:29:51:29:65 | password [String] |
-| Test.java:14:36:14:42 | "admin" [String] | Test.java:14:36:14:42 | "admin" |
-| Test.java:14:45:14:52 | "123456" [String] | Test.java:14:45:14:52 | "123456" |
-| Test.java:17:44:17:51 | "123456" [String] | Test.java:17:44:17:65 | toCharArray(...) |
-| Test.java:20:16:20:39 | new byte[] [byte[]] | Test.java:21:78:21:80 | key |
-| Test.java:23:17:23:26 | "abcdefgh" [String] | Test.java:24:79:24:82 | key2 |
-| Test.java:29:38:29:48 | user [String] | Test.java:30:36:30:39 | user |
-| Test.java:29:51:29:65 | password [String] | Test.java:30:42:30:49 | password |
+| CredentialsTest.java:7:34:7:41 | "123456" [ : String] | CredentialsTest.java:13:39:13:39 | p |
+| CredentialsTest.java:7:34:7:41 | "123456" [ : String] | CredentialsTest.java:14:16:14:16 | p [ : String] |
+| CredentialsTest.java:11:14:11:20 | "admin" [ : String] | CredentialsTest.java:13:36:13:36 | u |
+| CredentialsTest.java:11:14:11:20 | "admin" [ : String] | CredentialsTest.java:14:13:14:13 | u [ : String] |
+| CredentialsTest.java:14:13:14:13 | u [ : String] | CredentialsTest.java:17:38:17:45 | v [ : String] |
+| CredentialsTest.java:14:16:14:16 | p [ : String] | CredentialsTest.java:17:48:17:55 | q [ : String] |
+| CredentialsTest.java:17:38:17:45 | v [ : String] | CredentialsTest.java:18:36:18:36 | v |
+| CredentialsTest.java:17:48:17:55 | q [ : String] | CredentialsTest.java:18:39:18:39 | q |
+| FileCredentialTest.java:13:14:13:20 | "admin" [ : String] | FileCredentialTest.java:19:13:19:13 | u [ : String] |
+| FileCredentialTest.java:18:35:18:41 | "admin" [ : String] | FileCredentialTest.java:18:35:18:41 | "admin" |
+| FileCredentialTest.java:19:13:19:13 | u [ : String] | FileCredentialTest.java:22:38:22:45 | v [ : String] |
+| FileCredentialTest.java:22:38:22:45 | v [ : String] | FileCredentialTest.java:23:36:23:36 | v |
+| Test.java:9:16:9:22 | "admin" [ : String] | Test.java:12:13:12:15 | usr [ : String] |
+| Test.java:9:16:9:22 | "admin" [ : String] | Test.java:15:36:15:38 | usr |
+| Test.java:9:16:9:22 | "admin" [ : String] | Test.java:17:39:17:41 | usr |
+| Test.java:9:16:9:22 | "admin" [ : String] | Test.java:18:39:18:41 | usr |
+| Test.java:10:17:10:24 | "123456" [ : String] | Test.java:12:18:12:21 | pass [ : String] |
+| Test.java:10:17:10:24 | "123456" [ : String] | Test.java:15:41:15:44 | pass |
+| Test.java:10:17:10:24 | "123456" [ : String] | Test.java:18:44:18:61 | toCharArray(...) |
+| Test.java:12:13:12:15 | usr [ : String] | Test.java:29:38:29:48 | user [ : String] |
+| Test.java:12:18:12:21 | pass [ : String] | Test.java:29:51:29:65 | password [ : String] |
+| Test.java:14:36:14:42 | "admin" [ : String] | Test.java:14:36:14:42 | "admin" |
+| Test.java:14:45:14:52 | "123456" [ : String] | Test.java:14:45:14:52 | "123456" |
+| Test.java:17:44:17:51 | "123456" [ : String] | Test.java:17:44:17:65 | toCharArray(...) |
+| Test.java:20:16:20:39 | new byte[] [ : byte[]] | Test.java:21:78:21:80 | key |
+| Test.java:23:17:23:26 | "abcdefgh" [ : String] | Test.java:24:79:24:82 | key2 |
+| Test.java:29:38:29:48 | user [ : String] | Test.java:30:36:30:39 | user |
+| Test.java:29:51:29:65 | password [ : String] | Test.java:30:42:30:49 | password |
+nodes
+| CredentialsTest.java:7:34:7:41 | "123456" [ : String] | semmle.label | "123456" [ : String] |
+| CredentialsTest.java:11:14:11:20 | "admin" [ : String] | semmle.label | "admin" [ : String] |
+| CredentialsTest.java:13:36:13:36 | u | semmle.label | u |
+| CredentialsTest.java:13:39:13:39 | p | semmle.label | p |
+| CredentialsTest.java:14:13:14:13 | u [ : String] | semmle.label | u [ : String] |
+| CredentialsTest.java:14:16:14:16 | p [ : String] | semmle.label | p [ : String] |
+| CredentialsTest.java:17:38:17:45 | v [ : String] | semmle.label | v [ : String] |
+| CredentialsTest.java:17:48:17:55 | q [ : String] | semmle.label | q [ : String] |
+| CredentialsTest.java:18:36:18:36 | v | semmle.label | v |
+| CredentialsTest.java:18:39:18:39 | q | semmle.label | q |
+| FileCredentialTest.java:13:14:13:20 | "admin" [ : String] | semmle.label | "admin" [ : String] |
+| FileCredentialTest.java:18:35:18:41 | "admin" | semmle.label | "admin" |
+| FileCredentialTest.java:18:35:18:41 | "admin" [ : String] | semmle.label | "admin" [ : String] |
+| FileCredentialTest.java:19:13:19:13 | u [ : String] | semmle.label | u [ : String] |
+| FileCredentialTest.java:22:38:22:45 | v [ : String] | semmle.label | v [ : String] |
+| FileCredentialTest.java:23:36:23:36 | v | semmle.label | v |
+| Test.java:9:16:9:22 | "admin" [ : String] | semmle.label | "admin" [ : String] |
+| Test.java:10:17:10:24 | "123456" [ : String] | semmle.label | "123456" [ : String] |
+| Test.java:12:13:12:15 | usr [ : String] | semmle.label | usr [ : String] |
+| Test.java:12:18:12:21 | pass [ : String] | semmle.label | pass [ : String] |
+| Test.java:14:36:14:42 | "admin" | semmle.label | "admin" |
+| Test.java:14:36:14:42 | "admin" [ : String] | semmle.label | "admin" [ : String] |
+| Test.java:14:45:14:52 | "123456" | semmle.label | "123456" |
+| Test.java:14:45:14:52 | "123456" [ : String] | semmle.label | "123456" [ : String] |
+| Test.java:15:36:15:38 | usr | semmle.label | usr |
+| Test.java:15:41:15:44 | pass | semmle.label | pass |
+| Test.java:17:39:17:41 | usr | semmle.label | usr |
+| Test.java:17:44:17:51 | "123456" [ : String] | semmle.label | "123456" [ : String] |
+| Test.java:17:44:17:65 | toCharArray(...) | semmle.label | toCharArray(...) |
+| Test.java:18:39:18:41 | usr | semmle.label | usr |
+| Test.java:18:44:18:61 | toCharArray(...) | semmle.label | toCharArray(...) |
+| Test.java:20:16:20:39 | new byte[] [ : byte[]] | semmle.label | new byte[] [ : byte[]] |
+| Test.java:21:78:21:80 | key | semmle.label | key |
+| Test.java:23:17:23:26 | "abcdefgh" [ : String] | semmle.label | "abcdefgh" [ : String] |
+| Test.java:24:79:24:82 | key2 | semmle.label | key2 |
+| Test.java:29:38:29:48 | user [ : String] | semmle.label | user [ : String] |
+| Test.java:29:51:29:65 | password [ : String] | semmle.label | password [ : String] |
+| Test.java:30:36:30:39 | user | semmle.label | user |
+| Test.java:30:42:30:49 | password | semmle.label | password |
 #select
-| CredentialsTest.java:7:34:7:41 | "123456" | CredentialsTest.java:7:34:7:41 | "123456" [String] | CredentialsTest.java:13:39:13:39 | p | Hard-coded value flows to $@. | CredentialsTest.java:13:39:13:39 | p | sensitive API call |
-| CredentialsTest.java:7:34:7:41 | "123456" | CredentialsTest.java:7:34:7:41 | "123456" [String] | CredentialsTest.java:18:39:18:39 | q | Hard-coded value flows to $@. | CredentialsTest.java:18:39:18:39 | q | sensitive API call |
-| CredentialsTest.java:11:14:11:20 | "admin" | CredentialsTest.java:11:14:11:20 | "admin" [String] | CredentialsTest.java:13:36:13:36 | u | Hard-coded value flows to $@. | CredentialsTest.java:13:36:13:36 | u | sensitive API call |
-| CredentialsTest.java:11:14:11:20 | "admin" | CredentialsTest.java:11:14:11:20 | "admin" [String] | CredentialsTest.java:18:36:18:36 | v | Hard-coded value flows to $@. | CredentialsTest.java:18:36:18:36 | v | sensitive API call |
-| FileCredentialTest.java:13:14:13:20 | "admin" | FileCredentialTest.java:13:14:13:20 | "admin" [String] | FileCredentialTest.java:23:36:23:36 | v | Hard-coded value flows to $@. | FileCredentialTest.java:23:36:23:36 | v | sensitive API call |
-| FileCredentialTest.java:18:35:18:41 | "admin" | FileCredentialTest.java:18:35:18:41 | "admin" [String] | FileCredentialTest.java:18:35:18:41 | "admin" | Hard-coded value flows to $@. | FileCredentialTest.java:18:35:18:41 | "admin" | sensitive API call |
-| Test.java:9:16:9:22 | "admin" | Test.java:9:16:9:22 | "admin" [String] | Test.java:15:36:15:38 | usr | Hard-coded value flows to $@. | Test.java:15:36:15:38 | usr | sensitive API call |
-| Test.java:9:16:9:22 | "admin" | Test.java:9:16:9:22 | "admin" [String] | Test.java:17:39:17:41 | usr | Hard-coded value flows to $@. | Test.java:17:39:17:41 | usr | sensitive API call |
-| Test.java:9:16:9:22 | "admin" | Test.java:9:16:9:22 | "admin" [String] | Test.java:18:39:18:41 | usr | Hard-coded value flows to $@. | Test.java:18:39:18:41 | usr | sensitive API call |
-| Test.java:9:16:9:22 | "admin" | Test.java:9:16:9:22 | "admin" [String] | Test.java:30:36:30:39 | user | Hard-coded value flows to $@. | Test.java:30:36:30:39 | user | sensitive API call |
-| Test.java:10:17:10:24 | "123456" | Test.java:10:17:10:24 | "123456" [String] | Test.java:15:41:15:44 | pass | Hard-coded value flows to $@. | Test.java:15:41:15:44 | pass | sensitive API call |
-| Test.java:10:17:10:24 | "123456" | Test.java:10:17:10:24 | "123456" [String] | Test.java:18:44:18:61 | toCharArray(...) | Hard-coded value flows to $@. | Test.java:18:44:18:61 | toCharArray(...) | sensitive API call |
-| Test.java:10:17:10:24 | "123456" | Test.java:10:17:10:24 | "123456" [String] | Test.java:30:42:30:49 | password | Hard-coded value flows to $@. | Test.java:30:42:30:49 | password | sensitive API call |
-| Test.java:14:36:14:42 | "admin" | Test.java:14:36:14:42 | "admin" [String] | Test.java:14:36:14:42 | "admin" | Hard-coded value flows to $@. | Test.java:14:36:14:42 | "admin" | sensitive API call |
-| Test.java:14:45:14:52 | "123456" | Test.java:14:45:14:52 | "123456" [String] | Test.java:14:45:14:52 | "123456" | Hard-coded value flows to $@. | Test.java:14:45:14:52 | "123456" | sensitive API call |
-| Test.java:17:44:17:51 | "123456" | Test.java:17:44:17:51 | "123456" [String] | Test.java:17:44:17:65 | toCharArray(...) | Hard-coded value flows to $@. | Test.java:17:44:17:65 | toCharArray(...) | sensitive API call |
-| Test.java:20:16:20:39 | new byte[] | Test.java:20:16:20:39 | new byte[] [byte[]] | Test.java:21:78:21:80 | key | Hard-coded value flows to $@. | Test.java:21:78:21:80 | key | sensitive API call |
-| Test.java:23:17:23:26 | "abcdefgh" | Test.java:23:17:23:26 | "abcdefgh" [String] | Test.java:24:79:24:82 | key2 | Hard-coded value flows to $@. | Test.java:24:79:24:82 | key2 | sensitive API call |
+| CredentialsTest.java:7:34:7:41 | "123456" | CredentialsTest.java:7:34:7:41 | "123456" [ : String] | CredentialsTest.java:13:39:13:39 | p | Hard-coded value flows to $@. | CredentialsTest.java:13:39:13:39 | p | sensitive API call |
+| CredentialsTest.java:7:34:7:41 | "123456" | CredentialsTest.java:7:34:7:41 | "123456" [ : String] | CredentialsTest.java:18:39:18:39 | q | Hard-coded value flows to $@. | CredentialsTest.java:18:39:18:39 | q | sensitive API call |
+| CredentialsTest.java:11:14:11:20 | "admin" | CredentialsTest.java:11:14:11:20 | "admin" [ : String] | CredentialsTest.java:13:36:13:36 | u | Hard-coded value flows to $@. | CredentialsTest.java:13:36:13:36 | u | sensitive API call |
+| CredentialsTest.java:11:14:11:20 | "admin" | CredentialsTest.java:11:14:11:20 | "admin" [ : String] | CredentialsTest.java:18:36:18:36 | v | Hard-coded value flows to $@. | CredentialsTest.java:18:36:18:36 | v | sensitive API call |
+| FileCredentialTest.java:13:14:13:20 | "admin" | FileCredentialTest.java:13:14:13:20 | "admin" [ : String] | FileCredentialTest.java:23:36:23:36 | v | Hard-coded value flows to $@. | FileCredentialTest.java:23:36:23:36 | v | sensitive API call |
+| FileCredentialTest.java:18:35:18:41 | "admin" | FileCredentialTest.java:18:35:18:41 | "admin" [ : String] | FileCredentialTest.java:18:35:18:41 | "admin" | Hard-coded value flows to $@. | FileCredentialTest.java:18:35:18:41 | "admin" | sensitive API call |
+| Test.java:9:16:9:22 | "admin" | Test.java:9:16:9:22 | "admin" [ : String] | Test.java:15:36:15:38 | usr | Hard-coded value flows to $@. | Test.java:15:36:15:38 | usr | sensitive API call |
+| Test.java:9:16:9:22 | "admin" | Test.java:9:16:9:22 | "admin" [ : String] | Test.java:17:39:17:41 | usr | Hard-coded value flows to $@. | Test.java:17:39:17:41 | usr | sensitive API call |
+| Test.java:9:16:9:22 | "admin" | Test.java:9:16:9:22 | "admin" [ : String] | Test.java:18:39:18:41 | usr | Hard-coded value flows to $@. | Test.java:18:39:18:41 | usr | sensitive API call |
+| Test.java:9:16:9:22 | "admin" | Test.java:9:16:9:22 | "admin" [ : String] | Test.java:30:36:30:39 | user | Hard-coded value flows to $@. | Test.java:30:36:30:39 | user | sensitive API call |
+| Test.java:10:17:10:24 | "123456" | Test.java:10:17:10:24 | "123456" [ : String] | Test.java:15:41:15:44 | pass | Hard-coded value flows to $@. | Test.java:15:41:15:44 | pass | sensitive API call |
+| Test.java:10:17:10:24 | "123456" | Test.java:10:17:10:24 | "123456" [ : String] | Test.java:18:44:18:61 | toCharArray(...) | Hard-coded value flows to $@. | Test.java:18:44:18:61 | toCharArray(...) | sensitive API call |
+| Test.java:10:17:10:24 | "123456" | Test.java:10:17:10:24 | "123456" [ : String] | Test.java:30:42:30:49 | password | Hard-coded value flows to $@. | Test.java:30:42:30:49 | password | sensitive API call |
+| Test.java:14:36:14:42 | "admin" | Test.java:14:36:14:42 | "admin" [ : String] | Test.java:14:36:14:42 | "admin" | Hard-coded value flows to $@. | Test.java:14:36:14:42 | "admin" | sensitive API call |
+| Test.java:14:45:14:52 | "123456" | Test.java:14:45:14:52 | "123456" [ : String] | Test.java:14:45:14:52 | "123456" | Hard-coded value flows to $@. | Test.java:14:45:14:52 | "123456" | sensitive API call |
+| Test.java:17:44:17:51 | "123456" | Test.java:17:44:17:51 | "123456" [ : String] | Test.java:17:44:17:65 | toCharArray(...) | Hard-coded value flows to $@. | Test.java:17:44:17:65 | toCharArray(...) | sensitive API call |
+| Test.java:20:16:20:39 | new byte[] | Test.java:20:16:20:39 | new byte[] [ : byte[]] | Test.java:21:78:21:80 | key | Hard-coded value flows to $@. | Test.java:21:78:21:80 | key | sensitive API call |
+| Test.java:23:17:23:26 | "abcdefgh" | Test.java:23:17:23:26 | "abcdefgh" [ : String] | Test.java:24:79:24:82 | key2 | Hard-coded value flows to $@. | Test.java:24:79:24:82 | key2 | sensitive API call |

--- a/java/ql/test/query-tests/security/CWE-798/semmle/tests/HardcodedCredentialsSourceCall.expected
+++ b/java/ql/test/query-tests/security/CWE-798/semmle/tests/HardcodedCredentialsSourceCall.expected
@@ -1,6 +1,11 @@
 edges
-| Test.java:10:17:10:24 | "123456" [String] | Test.java:26:17:26:20 | pass |
-| User.java:2:43:2:50 | "123456" [String] | User.java:5:15:5:24 | DEFAULT_PW |
+| Test.java:10:17:10:24 | "123456" [ : String] | Test.java:26:17:26:20 | pass |
+| User.java:2:43:2:50 | "123456" [ : String] | User.java:5:15:5:24 | DEFAULT_PW |
+nodes
+| Test.java:10:17:10:24 | "123456" [ : String] | semmle.label | "123456" [ : String] |
+| Test.java:26:17:26:20 | pass | semmle.label | pass |
+| User.java:2:43:2:50 | "123456" [ : String] | semmle.label | "123456" [ : String] |
+| User.java:5:15:5:24 | DEFAULT_PW | semmle.label | DEFAULT_PW |
 #select
-| Test.java:10:17:10:24 | "123456" | Test.java:10:17:10:24 | "123456" [String] | Test.java:26:17:26:20 | pass | Hard-coded value flows to $@. | Test.java:26:17:26:20 | pass | sensitive call |
-| User.java:2:43:2:50 | "123456" | User.java:2:43:2:50 | "123456" [String] | User.java:5:15:5:24 | DEFAULT_PW | Hard-coded value flows to $@. | User.java:5:15:5:24 | DEFAULT_PW | sensitive call |
+| Test.java:10:17:10:24 | "123456" | Test.java:10:17:10:24 | "123456" [ : String] | Test.java:26:17:26:20 | pass | Hard-coded value flows to $@. | Test.java:26:17:26:20 | pass | sensitive call |
+| User.java:2:43:2:50 | "123456" | User.java:2:43:2:50 | "123456" [ : String] | User.java:5:15:5:24 | DEFAULT_PW | Hard-coded value flows to $@. | User.java:5:15:5:24 | DEFAULT_PW | sensitive call |

--- a/java/ql/test/query-tests/security/CWE-807/semmle/tests/ConditionalBypass.expected
+++ b/java/ql/test/query-tests/security/CWE-807/semmle/tests/ConditionalBypass.expected
@@ -1,13 +1,24 @@
 edges
-| Test.java:17:26:17:38 | args [String[]] | Test.java:25:6:25:21 | ... == ... |
-| Test.java:31:6:31:27 | getValue(...) [String] | Test.java:31:6:31:43 | equals(...) |
-| Test.java:36:6:36:27 | getValue(...) [String] | Test.java:36:6:36:36 | ... == ... |
-| Test.java:81:6:81:27 | getValue(...) [String] | Test.java:81:6:81:36 | ... == ... |
-| Test.java:91:6:91:27 | getValue(...) [String] | Test.java:91:6:91:36 | ... == ... |
+| Test.java:17:26:17:38 | args [ : String[]] | Test.java:25:6:25:21 | ... == ... |
+| Test.java:31:6:31:27 | getValue(...) [ : String] | Test.java:31:6:31:43 | equals(...) |
+| Test.java:36:6:36:27 | getValue(...) [ : String] | Test.java:36:6:36:36 | ... == ... |
+| Test.java:81:6:81:27 | getValue(...) [ : String] | Test.java:81:6:81:36 | ... == ... |
+| Test.java:91:6:91:27 | getValue(...) [ : String] | Test.java:91:6:91:36 | ... == ... |
+nodes
+| Test.java:17:26:17:38 | args [ : String[]] | semmle.label | args [ : String[]] |
+| Test.java:25:6:25:21 | ... == ... | semmle.label | ... == ... |
+| Test.java:31:6:31:27 | getValue(...) [ : String] | semmle.label | getValue(...) [ : String] |
+| Test.java:31:6:31:43 | equals(...) | semmle.label | equals(...) |
+| Test.java:36:6:36:27 | getValue(...) [ : String] | semmle.label | getValue(...) [ : String] |
+| Test.java:36:6:36:36 | ... == ... | semmle.label | ... == ... |
+| Test.java:81:6:81:27 | getValue(...) [ : String] | semmle.label | getValue(...) [ : String] |
+| Test.java:81:6:81:36 | ... == ... | semmle.label | ... == ... |
+| Test.java:91:6:91:27 | getValue(...) [ : String] | semmle.label | getValue(...) [ : String] |
+| Test.java:91:6:91:36 | ... == ... | semmle.label | ... == ... |
 #select
-| Test.java:26:4:26:24 | login(...) | Test.java:17:26:17:38 | args [String[]] | Test.java:25:6:25:21 | ... == ... | Sensitive method may not be executed depending on $@, which flows from $@. | Test.java:25:6:25:21 | ... == ... | this condition | Test.java:17:26:17:38 | args | user input |
-| Test.java:32:4:32:24 | login(...) | Test.java:31:6:31:27 | getValue(...) [String] | Test.java:31:6:31:43 | equals(...) | Sensitive method may not be executed depending on $@, which flows from $@. | Test.java:31:6:31:43 | equals(...) | this condition | Test.java:31:6:31:27 | getValue(...) | user input |
-| Test.java:37:4:37:24 | login(...) | Test.java:36:6:36:27 | getValue(...) [String] | Test.java:36:6:36:36 | ... == ... | Sensitive method may not be executed depending on $@, which flows from $@. | Test.java:36:6:36:36 | ... == ... | this condition | Test.java:36:6:36:27 | getValue(...) | user input |
-| Test.java:39:4:39:30 | reCheckAuth(...) | Test.java:36:6:36:27 | getValue(...) [String] | Test.java:36:6:36:36 | ... == ... | Sensitive method may not be executed depending on $@, which flows from $@. | Test.java:36:6:36:36 | ... == ... | this condition | Test.java:36:6:36:27 | getValue(...) | user input |
-| Test.java:82:4:82:24 | login(...) | Test.java:81:6:81:27 | getValue(...) [String] | Test.java:81:6:81:36 | ... == ... | Sensitive method may not be executed depending on $@, which flows from $@. | Test.java:81:6:81:36 | ... == ... | this condition | Test.java:81:6:81:27 | getValue(...) | user input |
-| Test.java:92:4:92:24 | login(...) | Test.java:91:6:91:27 | getValue(...) [String] | Test.java:91:6:91:36 | ... == ... | Sensitive method may not be executed depending on $@, which flows from $@. | Test.java:91:6:91:36 | ... == ... | this condition | Test.java:91:6:91:27 | getValue(...) | user input |
+| Test.java:26:4:26:24 | login(...) | Test.java:17:26:17:38 | args [ : String[]] | Test.java:25:6:25:21 | ... == ... | Sensitive method may not be executed depending on $@, which flows from $@. | Test.java:25:6:25:21 | ... == ... | this condition | Test.java:17:26:17:38 | args | user input |
+| Test.java:32:4:32:24 | login(...) | Test.java:31:6:31:27 | getValue(...) [ : String] | Test.java:31:6:31:43 | equals(...) | Sensitive method may not be executed depending on $@, which flows from $@. | Test.java:31:6:31:43 | equals(...) | this condition | Test.java:31:6:31:27 | getValue(...) | user input |
+| Test.java:37:4:37:24 | login(...) | Test.java:36:6:36:27 | getValue(...) [ : String] | Test.java:36:6:36:36 | ... == ... | Sensitive method may not be executed depending on $@, which flows from $@. | Test.java:36:6:36:36 | ... == ... | this condition | Test.java:36:6:36:27 | getValue(...) | user input |
+| Test.java:39:4:39:30 | reCheckAuth(...) | Test.java:36:6:36:27 | getValue(...) [ : String] | Test.java:36:6:36:36 | ... == ... | Sensitive method may not be executed depending on $@, which flows from $@. | Test.java:36:6:36:36 | ... == ... | this condition | Test.java:36:6:36:27 | getValue(...) | user input |
+| Test.java:82:4:82:24 | login(...) | Test.java:81:6:81:27 | getValue(...) [ : String] | Test.java:81:6:81:36 | ... == ... | Sensitive method may not be executed depending on $@, which flows from $@. | Test.java:81:6:81:36 | ... == ... | this condition | Test.java:81:6:81:27 | getValue(...) | user input |
+| Test.java:92:4:92:24 | login(...) | Test.java:91:6:91:27 | getValue(...) [ : String] | Test.java:91:6:91:36 | ... == ... | Sensitive method may not be executed depending on $@, which flows from $@. | Test.java:91:6:91:36 | ... == ... | this condition | Test.java:91:6:91:27 | getValue(...) | user input |

--- a/java/ql/test/query-tests/security/CWE-807/semmle/tests/TaintedPermissionsCheck.expected
+++ b/java/ql/test/query-tests/security/CWE-807/semmle/tests/TaintedPermissionsCheck.expected
@@ -1,4 +1,7 @@
 edges
-| Test.java:17:26:17:38 | args [String[]] | Test.java:50:26:50:64 | ... + ... |
+| Test.java:17:26:17:38 | args [ : String[]] | Test.java:50:26:50:64 | ... + ... |
+nodes
+| Test.java:17:26:17:38 | args [ : String[]] | semmle.label | args [ : String[]] |
+| Test.java:50:26:50:64 | ... + ... | semmle.label | ... + ... |
 #select
-| Test.java:50:6:50:65 | isPermitted(...) | Test.java:17:26:17:38 | args [String[]] | Test.java:50:26:50:64 | ... + ... | Permissions check uses user-controlled $@. | Test.java:17:26:17:38 | args | data |
+| Test.java:50:6:50:65 | isPermitted(...) | Test.java:17:26:17:38 | args [ : String[]] | Test.java:50:26:50:64 | ... + ... | Permissions check uses user-controlled $@. | Test.java:17:26:17:38 | args | data |


### PR DESCRIPTION
This ensures that we show the `toString` and thus the accesspath in all contexts, in particular lgtm.com.