### PR TITLE
C++: Don't create partial defs for calls to const functions

### DIFF
--- a/cpp/ql/src/semmle/code/cpp/dataflow/internal/FlowVar.qll
+++ b/cpp/ql/src/semmle/code/cpp/dataflow/internal/FlowVar.qll
@@ -113,7 +113,12 @@ private module PartialDefinitions {
         )
       )
     } or
-    TExplicitCallQualifier(Expr qualifier, Call call) { qualifier = call.getQualifier() } or
+    TExplicitCallQualifier(Expr qualifier) {
+      exists(Call call |
+        qualifier = call.getQualifier() and
+        not call.getTarget().hasSpecifier("const")
+      )
+    } or
     TReferenceArgument(Expr arg, VariableAccess va) { referenceArgument(va, arg) }
 
   private predicate isInstanceFieldWrite(FieldAccess fa, ControlFlowNode node) {
@@ -128,7 +133,7 @@ private module PartialDefinitions {
     PartialDefinition() {
       this = TExplicitFieldStoreQualifier(definedExpr, node)
       or
-      this = TExplicitCallQualifier(definedExpr, _) and node = definedExpr
+      this = TExplicitCallQualifier(definedExpr) and node = definedExpr
       or
       this = TReferenceArgument(definedExpr, node)
     }

--- a/cpp/ql/test/library-tests/dataflow/partialdefinitions/partialdefinitions.cpp
+++ b/cpp/ql/test/library-tests/dataflow/partialdefinitions/partialdefinitions.cpp
@@ -14,3 +14,18 @@ void test()
 	s.x = 1;
 	s.y.z = 1;
 }
+
+struct Int {
+  int data;
+  Int(int value) : data(value) { } // Not a partial definition but a `PostUpdateNode`
+  int getData() const { return data; }
+  void setData(int value) { data = value; }
+};
+
+int getSet() {
+  Int myInt(1);
+  myInt.setData(
+      myInt.getData() + 1 // should not be a partial def
+  );
+  return myInt.getData(); // should not be a partial def
+}

--- a/cpp/ql/test/library-tests/dataflow/partialdefinitions/partialdefinitions.expected
+++ b/cpp/ql/test/library-tests/dataflow/partialdefinitions/partialdefinitions.expected
@@ -3,5 +3,3 @@
 | partialdefinitions.cpp:15:4:15:4 | partial def of y | partialdefinitions.cpp:15:4:15:4 | y | partialdefinitions.cpp:15:2:15:10 | ... = ... |
 | partialdefinitions.cpp:22:29:22:32 | partial def of this | file://:0:0:0:0 | this | partialdefinitions.cpp:22:29:22:40 | ... = ... |
 | partialdefinitions.cpp:27:3:27:7 | partial def of myInt | partialdefinitions.cpp:27:3:27:7 | myInt | partialdefinitions.cpp:27:3:27:7 | myInt |
-| partialdefinitions.cpp:28:7:28:11 | partial def of myInt | partialdefinitions.cpp:28:7:28:11 | myInt | partialdefinitions.cpp:28:7:28:11 | myInt |
-| partialdefinitions.cpp:30:10:30:14 | partial def of myInt | partialdefinitions.cpp:30:10:30:14 | myInt | partialdefinitions.cpp:30:10:30:14 | myInt |

--- a/cpp/ql/test/library-tests/dataflow/partialdefinitions/partialdefinitions.expected
+++ b/cpp/ql/test/library-tests/dataflow/partialdefinitions/partialdefinitions.expected
@@ -1,3 +1,7 @@
 | partialdefinitions.cpp:14:2:14:2 | partial def of s | partialdefinitions.cpp:14:2:14:2 | s | partialdefinitions.cpp:14:2:14:8 | ... = ... |
 | partialdefinitions.cpp:15:2:15:2 | partial def of s | partialdefinitions.cpp:15:2:15:2 | s | partialdefinitions.cpp:15:2:15:10 | ... = ... |
 | partialdefinitions.cpp:15:4:15:4 | partial def of y | partialdefinitions.cpp:15:4:15:4 | y | partialdefinitions.cpp:15:2:15:10 | ... = ... |
+| partialdefinitions.cpp:22:29:22:32 | partial def of this | file://:0:0:0:0 | this | partialdefinitions.cpp:22:29:22:40 | ... = ... |
+| partialdefinitions.cpp:27:3:27:7 | partial def of myInt | partialdefinitions.cpp:27:3:27:7 | myInt | partialdefinitions.cpp:27:3:27:7 | myInt |
+| partialdefinitions.cpp:28:7:28:11 | partial def of myInt | partialdefinitions.cpp:28:7:28:11 | myInt | partialdefinitions.cpp:28:7:28:11 | myInt |
+| partialdefinitions.cpp:30:10:30:14 | partial def of myInt | partialdefinitions.cpp:30:10:30:14 | myInt | partialdefinitions.cpp:30:10:30:14 | myInt |


### PR DESCRIPTION
These partial defs don't do any harm, but they could hurt performance. In typical C++ snapshots, between 5% and 20% of all calls are to `const` functions.