### PR TITLE
Java: Restrict the output of Range Analysis to the best bounds.

### DIFF
--- a/java/ql/src/semmle/code/java/dataflow/RangeAnalysis.qll
+++ b/java/ql/src/semmle/code/java/dataflow/RangeAnalysis.qll
@@ -89,7 +89,8 @@ private module RangeAnalysisCache {
      */
     cached
     predicate bounded(Expr e, Bound b, int delta, boolean upper, Reason reason) {
-      bounded(e, b, delta, upper, _, _, reason)
+      bounded(e, b, delta, upper, _, _, reason) and
+      bestBound(e, b, delta, upper)
     }
   }
 
@@ -104,6 +105,17 @@ private module RangeAnalysisCache {
 
 private import RangeAnalysisCache
 import RangeAnalysisPublic
+
+/**
+ * Holds if `b + delta` is a valid bound for `e` and this is the best such delta.
+ * - `upper = true`  : `e <= b + delta`
+ * - `upper = false` : `e >= b + delta`
+ */
+private predicate bestBound(Expr e, Bound b, int delta, boolean upper) {
+  delta = min(int d | bounded(e, b, d, upper, _, _, _)) and upper = true
+  or
+  delta = max(int d | bounded(e, b, d, upper, _, _, _)) and upper = false
+}
 
 /**
  * Holds if `comp` corresponds to:


### PR DESCRIPTION
In some cases the Range Analysis can report superfluous bounds, which can be confusing.  This small change removes those bounds that are strictly worse than some other bound.