### PR TITLE
docs: improve slide layout for printing

### DIFF
--- a/docs/language/ql-training/_static-training/slides-semmle-2/static/theme/css/default.css
+++ b/docs/language/ql-training/_static-training/slides-semmle-2/static/theme/css/default.css
@@ -1684,12 +1684,12 @@ li > ul > li {
   slides slide {
     display: block !important;
     position: relative;
-    background: url('data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0idXRmLTgiPz4gPHN2ZyB2ZXJzaW9uPSIxLjEiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyI+PGRlZnM+PGxpbmVhckdyYWRpZW50IGlkPSJncmFkIiBncmFkaWVudFVuaXRzPSJvYmplY3RCb3VuZGluZ0JveCIgeDE9IjAuNSIgeTE9IjAuMCIgeDI9IjAuNSIgeTI9IjEuMCI+PHN0b3Agb2Zmc2V0PSIwJSIgc3RvcC1jb2xvcj0iI2ZmZmZmZiIvPjxzdG9wIG9mZnNldD0iODUlIiBzdG9wLWNvbG9yPSIjZmZmZmZmIi8+PHN0b3Agb2Zmc2V0PSIxMDAlIiBzdG9wLWNvbG9yPSIjZTZlNmU2Ii8+PC9saW5lYXJHcmFkaWVudD48L2RlZnM+PHJlY3QgeD0iMCIgeT0iMCIgd2lkdGg9IjEwMCUiIGhlaWdodD0iMTAwJSIgZmlsbD0idXJsKCNncmFkKSIgLz48L3N2Zz4g');
+    /*background: url('data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0idXRmLTgiPz4gPHN2ZyB2ZXJzaW9uPSIxLjEiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyI+PGRlZnM+PGxpbmVhckdyYWRpZW50IGlkPSJncmFkIiBncmFkaWVudFVuaXRzPSJvYmplY3RCb3VuZGluZ0JveCIgeDE9IjAuNSIgeTE9IjAuMCIgeDI9IjAuNSIgeTI9IjEuMCI+PHN0b3Agb2Zmc2V0PSIwJSIgc3RvcC1jb2xvcj0iI2ZmZmZmZiIvPjxzdG9wIG9mZnNldD0iODUlIiBzdG9wLWNvbG9yPSIjZmZmZmZmIi8+PHN0b3Agb2Zmc2V0PSIxMDAlIiBzdG9wLWNvbG9yPSIjZTZlNmU2Ii8+PC9saW5lYXJHcmFkaWVudD48L2RlZnM+PHJlY3QgeD0iMCIgeT0iMCIgd2lkdGg9IjEwMCUiIGhlaWdodD0iMTAwJSIgZmlsbD0idXJsKCNncmFkKSIgLz48L3N2Zz4g');
     background: -webkit-gradient(linear, 50% 0%, 50% 100%, color-stop(0%, #ffffff), color-stop(85%, #ffffff), color-stop(100%, #e6e6e6));
     background: -moz-linear-gradient(#ffffff, #ffffff 85%, #e6e6e6);
     background: -webkit-linear-gradient(#ffffff, #ffffff 85%, #e6e6e6);
     background: linear-gradient(#ffffff, #ffffff 85%, #e6e6e6);
-    background-color: white;
+    background-color: white;*/
     -moz-transform: none !important;
     -ms-transform: none !important;
     -webkit-transform: none !important;
@@ -1765,20 +1765,13 @@ li > ul > li {
     position: unset;
   }
   
-  /* make fonts smaller */
-
-  html {
-    font-size: 45%;
-    height: 100%;
-    width: 100%;
-  }
-  
   /* don't display slide number */
   slides > slide:not(.nobackground):after {
     display: none;
   }
 
   slides {
-    bottom: unset;
+    width: 90%;
+    height: 100%;
   }
 }


### PR DESCRIPTION
This PR makes the slides _slightly_ more suitable for printing.
It's still quite bad, but is the best I can do at the moment. 
You can see the difference if you look at the print previews here:
[Before](http://docteam.internal.semmle.com/james/slides-06092019/java/data-flow-java.html#1)
[After](http://docteam.internal.semmle.com/james/slides-06092019-print/java/data-flow-java.html#1)

I think the slides will be good to publish after this is merged.