### PR TITLE
JS: add xlink:href as xss target when using setAttribute

### DIFF
--- a/javascript/ql/src/semmle/javascript/security/dataflow/DOM.qll
+++ b/javascript/ql/src/semmle/javascript/security/dataflow/DOM.qll
@@ -85,7 +85,8 @@ class DomMethodCallExpr extends MethodCallExpr {
         name = "setAttributeNS" and argPos = 2
       ) and
       // restrict to potentially dangerous attributes
-      exists(string attr | attr = "action" or attr = "formaction" or attr = "href" or attr = "src" |
+      exists(string attr | 
+        attr = "action" or attr = "formaction" or attr = "href" or attr = "src" or attr = "xlink:href" |
         getArgument(argPos - 1).getStringValue().toLowerCase() = attr
       )
     )

--- a/javascript/ql/test/query-tests/Security/CWE-079/Xss.expected
+++ b/javascript/ql/test/query-tests/Security/CWE-079/Xss.expected
@@ -60,6 +60,8 @@ nodes
 | tst3.js:5:26:5:31 | data.p |
 | tst3.js:7:32:7:35 | data |
 | tst3.js:7:32:7:37 | data.p |
+| tst3.js:9:38:9:41 | data |
+| tst3.js:9:38:9:43 | data.p |
 | tst.js:2:7:2:39 | target |
 | tst.js:2:16:2:32 | document.location |
 | tst.js:2:16:2:39 | documen ... .search |
@@ -229,6 +231,7 @@ edges
 | tst3.js:2:12:2:75 | JSON.pa ... tr(1))) | tst3.js:4:25:4:28 | data |
 | tst3.js:2:12:2:75 | JSON.pa ... tr(1))) | tst3.js:5:26:5:29 | data |
 | tst3.js:2:12:2:75 | JSON.pa ... tr(1))) | tst3.js:7:32:7:35 | data |
+| tst3.js:2:12:2:75 | JSON.pa ... tr(1))) | tst3.js:9:38:9:41 | data |
 | tst3.js:2:23:2:74 | decodeU ... str(1)) | tst3.js:2:12:2:75 | JSON.pa ... tr(1))) |
 | tst3.js:2:42:2:56 | window.location | tst3.js:2:42:2:63 | window. ... .search |
 | tst3.js:2:42:2:63 | window. ... .search | tst3.js:2:42:2:73 | window. ... bstr(1) |
@@ -236,6 +239,7 @@ edges
 | tst3.js:4:25:4:28 | data | tst3.js:4:25:4:32 | data.src |
 | tst3.js:5:26:5:29 | data | tst3.js:5:26:5:31 | data.p |
 | tst3.js:7:32:7:35 | data | tst3.js:7:32:7:37 | data.p |
+| tst3.js:9:38:9:41 | data | tst3.js:9:38:9:43 | data.p |
 | tst.js:2:7:2:39 | target | tst.js:5:18:5:23 | target |
 | tst.js:2:7:2:39 | target | tst.js:12:28:12:33 | target |
 | tst.js:2:7:2:39 | target | tst.js:23:42:23:47 | target |
@@ -366,6 +370,7 @@ edges
 | tst3.js:4:25:4:32 | data.src | tst3.js:2:42:2:56 | window.location | tst3.js:4:25:4:32 | data.src | Cross-site scripting vulnerability due to $@. | tst3.js:2:42:2:56 | window.location | user-provided value |
 | tst3.js:5:26:5:31 | data.p | tst3.js:2:42:2:56 | window.location | tst3.js:5:26:5:31 | data.p | Cross-site scripting vulnerability due to $@. | tst3.js:2:42:2:56 | window.location | user-provided value |
 | tst3.js:7:32:7:37 | data.p | tst3.js:2:42:2:56 | window.location | tst3.js:7:32:7:37 | data.p | Cross-site scripting vulnerability due to $@. | tst3.js:2:42:2:56 | window.location | user-provided value |
+| tst3.js:9:38:9:43 | data.p | tst3.js:2:42:2:56 | window.location | tst3.js:9:38:9:43 | data.p | Cross-site scripting vulnerability due to $@. | tst3.js:2:42:2:56 | window.location | user-provided value |
 | tst.js:5:18:5:23 | target | tst.js:2:16:2:32 | document.location | tst.js:5:18:5:23 | target | Cross-site scripting vulnerability due to $@. | tst.js:2:16:2:32 | document.location | user-provided value |
 | tst.js:8:18:8:126 | "<OPTIO ... PTION>" | tst.js:8:37:8:53 | document.location | tst.js:8:18:8:126 | "<OPTIO ... PTION>" | Cross-site scripting vulnerability due to $@. | tst.js:8:37:8:53 | document.location | user-provided value |
 | tst.js:12:5:12:42 | '<div s ...  'px">' | tst.js:2:16:2:32 | document.location | tst.js:12:5:12:42 | '<div s ...  'px">' | Cross-site scripting vulnerability due to $@. | tst.js:2:16:2:32 | document.location | user-provided value |

--- a/javascript/ql/test/query-tests/Security/CWE-079/Xss.expected
+++ b/javascript/ql/test/query-tests/Security/CWE-079/Xss.expected
@@ -58,6 +58,8 @@ nodes
 | tst3.js:4:25:4:32 | data.src |
 | tst3.js:5:26:5:29 | data |
 | tst3.js:5:26:5:31 | data.p |
+| tst3.js:7:32:7:35 | data |
+| tst3.js:7:32:7:37 | data.p |
 | tst.js:2:7:2:39 | target |
 | tst.js:2:16:2:32 | document.location |
 | tst.js:2:16:2:39 | documen ... .search |
@@ -226,12 +228,14 @@ edges
 | translate.js:7:42:7:60 | target.substring(1) | translate.js:9:27:9:50 | searchP ... 'term') |
 | tst3.js:2:12:2:75 | JSON.pa ... tr(1))) | tst3.js:4:25:4:28 | data |
 | tst3.js:2:12:2:75 | JSON.pa ... tr(1))) | tst3.js:5:26:5:29 | data |
+| tst3.js:2:12:2:75 | JSON.pa ... tr(1))) | tst3.js:7:32:7:35 | data |
 | tst3.js:2:23:2:74 | decodeU ... str(1)) | tst3.js:2:12:2:75 | JSON.pa ... tr(1))) |
 | tst3.js:2:42:2:56 | window.location | tst3.js:2:42:2:63 | window. ... .search |
 | tst3.js:2:42:2:63 | window. ... .search | tst3.js:2:42:2:73 | window. ... bstr(1) |
 | tst3.js:2:42:2:73 | window. ... bstr(1) | tst3.js:2:23:2:74 | decodeU ... str(1)) |
 | tst3.js:4:25:4:28 | data | tst3.js:4:25:4:32 | data.src |
 | tst3.js:5:26:5:29 | data | tst3.js:5:26:5:31 | data.p |
+| tst3.js:7:32:7:35 | data | tst3.js:7:32:7:37 | data.p |
 | tst.js:2:7:2:39 | target | tst.js:5:18:5:23 | target |
 | tst.js:2:7:2:39 | target | tst.js:12:28:12:33 | target |
 | tst.js:2:7:2:39 | target | tst.js:23:42:23:47 | target |
@@ -361,6 +365,7 @@ edges
 | translate.js:9:27:9:50 | searchP ... 'term') | translate.js:6:16:6:32 | document.location | translate.js:9:27:9:50 | searchP ... 'term') | Cross-site scripting vulnerability due to $@. | translate.js:6:16:6:32 | document.location | user-provided value |
 | tst3.js:4:25:4:32 | data.src | tst3.js:2:42:2:56 | window.location | tst3.js:4:25:4:32 | data.src | Cross-site scripting vulnerability due to $@. | tst3.js:2:42:2:56 | window.location | user-provided value |
 | tst3.js:5:26:5:31 | data.p | tst3.js:2:42:2:56 | window.location | tst3.js:5:26:5:31 | data.p | Cross-site scripting vulnerability due to $@. | tst3.js:2:42:2:56 | window.location | user-provided value |
+| tst3.js:7:32:7:37 | data.p | tst3.js:2:42:2:56 | window.location | tst3.js:7:32:7:37 | data.p | Cross-site scripting vulnerability due to $@. | tst3.js:2:42:2:56 | window.location | user-provided value |
 | tst.js:5:18:5:23 | target | tst.js:2:16:2:32 | document.location | tst.js:5:18:5:23 | target | Cross-site scripting vulnerability due to $@. | tst.js:2:16:2:32 | document.location | user-provided value |
 | tst.js:8:18:8:126 | "<OPTIO ... PTION>" | tst.js:8:37:8:53 | document.location | tst.js:8:18:8:126 | "<OPTIO ... PTION>" | Cross-site scripting vulnerability due to $@. | tst.js:8:37:8:53 | document.location | user-provided value |
 | tst.js:12:5:12:42 | '<div s ...  'px">' | tst.js:2:16:2:32 | document.location | tst.js:12:5:12:42 | '<div s ...  'px">' | Cross-site scripting vulnerability due to $@. | tst.js:2:16:2:32 | document.location | user-provided value |

--- a/javascript/ql/test/query-tests/Security/CWE-079/Xss.expected
+++ b/javascript/ql/test/query-tests/Security/CWE-079/Xss.expected
@@ -60,8 +60,10 @@ nodes
 | tst3.js:5:26:5:31 | data.p |
 | tst3.js:7:32:7:35 | data |
 | tst3.js:7:32:7:37 | data.p |
-| tst3.js:9:38:9:41 | data |
-| tst3.js:9:38:9:43 | data.p |
+| tst3.js:9:37:9:40 | data |
+| tst3.js:9:37:9:42 | data.p |
+| tst3.js:10:38:10:41 | data |
+| tst3.js:10:38:10:43 | data.p |
 | tst.js:2:7:2:39 | target |
 | tst.js:2:16:2:32 | document.location |
 | tst.js:2:16:2:39 | documen ... .search |
@@ -231,7 +233,8 @@ edges
 | tst3.js:2:12:2:75 | JSON.pa ... tr(1))) | tst3.js:4:25:4:28 | data |
 | tst3.js:2:12:2:75 | JSON.pa ... tr(1))) | tst3.js:5:26:5:29 | data |
 | tst3.js:2:12:2:75 | JSON.pa ... tr(1))) | tst3.js:7:32:7:35 | data |
-| tst3.js:2:12:2:75 | JSON.pa ... tr(1))) | tst3.js:9:38:9:41 | data |
+| tst3.js:2:12:2:75 | JSON.pa ... tr(1))) | tst3.js:9:37:9:40 | data |
+| tst3.js:2:12:2:75 | JSON.pa ... tr(1))) | tst3.js:10:38:10:41 | data |
 | tst3.js:2:23:2:74 | decodeU ... str(1)) | tst3.js:2:12:2:75 | JSON.pa ... tr(1))) |
 | tst3.js:2:42:2:56 | window.location | tst3.js:2:42:2:63 | window. ... .search |
 | tst3.js:2:42:2:63 | window. ... .search | tst3.js:2:42:2:73 | window. ... bstr(1) |
@@ -239,7 +242,8 @@ edges
 | tst3.js:4:25:4:28 | data | tst3.js:4:25:4:32 | data.src |
 | tst3.js:5:26:5:29 | data | tst3.js:5:26:5:31 | data.p |
 | tst3.js:7:32:7:35 | data | tst3.js:7:32:7:37 | data.p |
-| tst3.js:9:38:9:41 | data | tst3.js:9:38:9:43 | data.p |
+| tst3.js:9:37:9:40 | data | tst3.js:9:37:9:42 | data.p |
+| tst3.js:10:38:10:41 | data | tst3.js:10:38:10:43 | data.p |
 | tst.js:2:7:2:39 | target | tst.js:5:18:5:23 | target |
 | tst.js:2:7:2:39 | target | tst.js:12:28:12:33 | target |
 | tst.js:2:7:2:39 | target | tst.js:23:42:23:47 | target |
@@ -370,7 +374,8 @@ edges
 | tst3.js:4:25:4:32 | data.src | tst3.js:2:42:2:56 | window.location | tst3.js:4:25:4:32 | data.src | Cross-site scripting vulnerability due to $@. | tst3.js:2:42:2:56 | window.location | user-provided value |
 | tst3.js:5:26:5:31 | data.p | tst3.js:2:42:2:56 | window.location | tst3.js:5:26:5:31 | data.p | Cross-site scripting vulnerability due to $@. | tst3.js:2:42:2:56 | window.location | user-provided value |
 | tst3.js:7:32:7:37 | data.p | tst3.js:2:42:2:56 | window.location | tst3.js:7:32:7:37 | data.p | Cross-site scripting vulnerability due to $@. | tst3.js:2:42:2:56 | window.location | user-provided value |
-| tst3.js:9:38:9:43 | data.p | tst3.js:2:42:2:56 | window.location | tst3.js:9:38:9:43 | data.p | Cross-site scripting vulnerability due to $@. | tst3.js:2:42:2:56 | window.location | user-provided value |
+| tst3.js:9:37:9:42 | data.p | tst3.js:2:42:2:56 | window.location | tst3.js:9:37:9:42 | data.p | Cross-site scripting vulnerability due to $@. | tst3.js:2:42:2:56 | window.location | user-provided value |
+| tst3.js:10:38:10:43 | data.p | tst3.js:2:42:2:56 | window.location | tst3.js:10:38:10:43 | data.p | Cross-site scripting vulnerability due to $@. | tst3.js:2:42:2:56 | window.location | user-provided value |
 | tst.js:5:18:5:23 | target | tst.js:2:16:2:32 | document.location | tst.js:5:18:5:23 | target | Cross-site scripting vulnerability due to $@. | tst.js:2:16:2:32 | document.location | user-provided value |
 | tst.js:8:18:8:126 | "<OPTIO ... PTION>" | tst.js:8:37:8:53 | document.location | tst.js:8:18:8:126 | "<OPTIO ... PTION>" | Cross-site scripting vulnerability due to $@. | tst.js:8:37:8:53 | document.location | user-provided value |
 | tst.js:12:5:12:42 | '<div s ...  'px">' | tst.js:2:16:2:32 | document.location | tst.js:12:5:12:42 | '<div s ...  'px">' | Cross-site scripting vulnerability due to $@. | tst.js:2:16:2:32 | document.location | user-provided value |

--- a/javascript/ql/test/query-tests/Security/CWE-079/tst3.js
+++ b/javascript/ql/test/query-tests/Security/CWE-079/tst3.js
@@ -6,6 +6,7 @@ foo.setAttribute("HREF", data.p);  // NOT OK
 foo.setAttribute("width", data.w); // OK
 foo.setAttribute("xlink:href", data.p) // NOT OK
 
+foo.setAttributeNS('xlink', 'href', data.p); // NOT OK
 foo.setAttributeNS('foobar', 'href', data.p); // NOT OK
 foo.setAttributeNS('baz', 'width', data.w); // OK
 

--- a/javascript/ql/test/query-tests/Security/CWE-079/tst3.js
+++ b/javascript/ql/test/query-tests/Security/CWE-079/tst3.js
@@ -4,6 +4,7 @@ var data = JSON.parse(decodeURIComponent(window.location.search.substr(1)));
 foo.setAttribute("src", data.src); // NOT OK
 foo.setAttribute("HREF", data.p);  // NOT OK
 foo.setAttribute("width", data.w); // OK
+foo.setAttribute("xlink:href", data.p) // NOT OK
 
 for (var p in data)
   foo.setAttribute(p, data[p]); // not flagged since attribute name is unknown

--- a/javascript/ql/test/query-tests/Security/CWE-079/tst3.js
+++ b/javascript/ql/test/query-tests/Security/CWE-079/tst3.js
@@ -6,5 +6,9 @@ foo.setAttribute("HREF", data.p);  // NOT OK
 foo.setAttribute("width", data.w); // OK
 foo.setAttribute("xlink:href", data.p) // NOT OK
 
+foo.setAttributeNS('foobar', 'href', data.p); // NOT OK
+foo.setAttributeNS('baz', 'width', data.w); // OK
+
+
 for (var p in data)
   foo.setAttribute(p, data[p]); // not flagged since attribute name is unknown


### PR DESCRIPTION
Adds the `xlink:href` attribute to the list of vulnerable attributes. 