### PR TITLE
C#: Tidy up cs/unsafe-year-construction and cs/mishandling-japanese-era

### DIFF
--- a/change-notes/1.23/analysis-csharp.md
+++ b/change-notes/1.23/analysis-csharp.md
@@ -2,6 +2,15 @@
 
 The following changes in version 1.23 affect C# analysis in all applications.
 
+## New queries
+
+## New queries
+
+| **Query**                   | **Tags**  | **Purpose**                                                        |
+|-----------------------------|-----------|--------------------------------------------------------------------|
+| Unsafe year argument for 'DateTime' constructor (`cs/unsafe-year-construction`) | reliability, date-time | Finds incorrect manipulation of `DateTime` values, which could lead to invalid dates. |
+| Mishandling the Japanese era start date (`cs/mishandling-japanese-era`) | reliability, date-time | Finds hard-coded Japanese era start dates that could be invalid. |
+
 ## Changes to existing queries
 
 | **Query**                    | **Expected impact**    | **Change**                        |

--- a/csharp/ql/src/Likely Bugs/LeapYear/UnsafeYearConstruction.ql
+++ b/csharp/ql/src/Likely Bugs/LeapYear/UnsafeYearConstruction.ql
@@ -1,11 +1,11 @@
 /**
  * @name Unsafe year argument for 'DateTime' constructor
- * @description Constructing a 'DateTime' struct by setting the year argument to an increment or decrement of the year of a different 'DateTime' struct
+ * @description Constructing a 'DateTime' struct by setting the year argument to an increment or decrement of the year of a different 'DateTime' struct.
  * @kind path-problem
- * @problem.severity error
+ * @problem.severity warning
+ * @precision medium
  * @id cs/unsafe-year-construction
- * @tags security
- *       date-time
+ * @tags date-time
  *       reliability
  */
 

--- a/csharp/ql/src/Likely Bugs/MishandlingJapaneseEra.ql
+++ b/csharp/ql/src/Likely Bugs/MishandlingJapaneseEra.ql
@@ -4,6 +4,7 @@
  * @id cs/mishandling-japanese-era
  * @kind problem
  * @problem.severity warning
+ * @precision medium
  * @tags reliability
  *       date-time
  */


### PR DESCRIPTION
Mainly, add a change note, and add a precision that is consistent with the corresponding C++ queries (https://github.com/Semmle/ql/pull/1467)