### PR TITLE
Vale linter: fix typo

### DIFF
--- a/docs/language/vale-styles/Semmle/ignore.txt
+++ b/docs/language/vale-styles/Semmle/ignore.txt
@@ -89,6 +89,6 @@ typedef
 typedefs
 unary
 unconstructed
-unititialized
+uninitialized
 untrusted
 youtube


### PR DESCRIPTION
Spotted this while browsing the Vale files. 