### PR TITLE
C# IR: Object creation refactor and collection initializers

### DIFF
--- a/csharp/ql/src/semmle/code/csharp/ir/implementation/raw/internal/TranslatedCall.qll
+++ b/csharp/ql/src/semmle/code/csharp/ir/implementation/raw/internal/TranslatedCall.qll
@@ -4,6 +4,7 @@ private import semmle.code.csharp.ir.implementation.internal.OperandTag
 private import InstructionTag
 private import TranslatedElement
 private import TranslatedExpr
+private import TranslatedInitialization
 private import semmle.code.csharp.ir.Util
 private import semmle.code.csharp.ir.implementation.raw.internal.common.TranslatedCallBase
 private import semmle.code.csharp.ir.internal.IRCSharpLanguage as Language
@@ -50,7 +51,13 @@ class TranslatedFunctionCall extends TranslatedNonConstantExpr, TranslatedCall {
     result = getTranslatedExpr(expr.(QualifiableExpr).getQualifier())
   }
 
-  override Instruction getQualifierResult() { result = this.getQualifier().getResult() }
+  override Instruction getQualifierResult() {
+    // since `ElementInitializer`s do not have a qualifier, the qualifier's result is retrieved
+    // from the enclosing initialization context
+    if expr.getParent() instanceof CollectionInitializer
+    then result = getTranslatedExpr(expr.getParent()).(InitializationContext).getTargetAddress()
+    else result = this.getQualifier().getResult()
+  }
 
   override Type getCallResultType() { result = expr.getTarget().getReturnType() }
 

--- a/csharp/ql/src/semmle/code/csharp/ir/implementation/raw/internal/TranslatedElement.qll
+++ b/csharp/ql/src/semmle/code/csharp/ir/implementation/raw/internal/TranslatedElement.qll
@@ -171,7 +171,8 @@ newtype TTranslatedElement =
   } or
   // A creation expression
   TTranslatedCreationExpr(Expr expr) {
-    not ignoreExpr(expr)
+    not ignoreExpr(expr) and
+    (expr instanceof ObjectCreation or expr instanceof DelegateCreation)
   } or
   // A separate element to handle the lvalue-to-rvalue conversion step of an
   // expression.
@@ -231,7 +232,7 @@ newtype TTranslatedElement =
       or
       expr instanceof ObjectInitializer
       or
-      expr = any(ThrowStmt throwStmt).getExpr()
+      expr = any(ThrowElement throwElement).getExpr()
       or
       expr = any(CollectionInitializer colInit).getAnElementInitializer()
       or

--- a/csharp/ql/src/semmle/code/csharp/ir/implementation/raw/internal/TranslatedElement.qll
+++ b/csharp/ql/src/semmle/code/csharp/ir/implementation/raw/internal/TranslatedElement.qll
@@ -169,6 +169,10 @@ newtype TTranslatedElement =
     not isNativeCondition(expr) and
     not isFlexibleCondition(expr)
   } or
+  // A creation expression
+  TTranslatedCreationExpr(Expr expr) {
+    not ignoreExpr(expr)
+  } or
   // A separate element to handle the lvalue-to-rvalue conversion step of an
   // expression.
   TTranslatedLoad(Expr expr) {
@@ -219,32 +223,21 @@ newtype TTranslatedElement =
       // we deal with all the types of initialization separately.
       // First only simple local variable initialization (ie. `int x = 0`)
       exists(LocalVariableDeclAndInitExpr lvInit |
-        lvInit.getInitializer() = expr and
-        not expr instanceof ArrayCreation and
-        not expr instanceof ObjectCreation and
-        not expr instanceof DelegateCreation
+        lvInit.getInitializer() = expr
       )
       or
       // Then treat more complex ones
-      expr instanceof ObjectCreation
-      or
-      expr instanceof DelegateCreation
-      or
       expr instanceof ArrayInitializer
       or
       expr instanceof ObjectInitializer
       or
-      expr = any(ThrowExpr throw).getExpr()
+      expr = any(ThrowStmt throwStmt).getExpr()
       or
       expr = any(CollectionInitializer colInit).getAnElementInitializer()
       or
       expr = any(ReturnStmt returnStmt).getExpr()
       or
       expr = any(ArrayInitializer arrInit).getAnElement()
-      or
-      expr = any(LambdaExpr lambda).getSourceDeclaration()
-      or
-      expr = any(AnonymousMethodExpr anonMethExpr).getSourceDeclaration()
     )
   } or
   // The initialization of an array element via a member of an initializer list.

--- a/csharp/ql/src/semmle/code/csharp/ir/implementation/raw/internal/TranslatedExpr.qll
+++ b/csharp/ql/src/semmle/code/csharp/ir/implementation/raw/internal/TranslatedExpr.qll
@@ -532,9 +532,12 @@ class TranslatedCollectionInitializer extends TranslatedNonConstantExpr, Initial
   override Instruction getChildSuccessor(TranslatedElement child) {
     exists(int index |
       child = this.getChild(index) and
-      if exists(this.getChild(index + 1))
-      then result = this.getChild(index + 1).getFirstInstruction()
-      else result = this.getParent().getChildSuccessor(this)
+      (
+        result = this.getChild(index + 1).getFirstInstruction()
+        or
+        not exists(this.getChild(index + 1)) and
+        result = this.getParent().getChildSuccessor(this)
+      )
     )
   }
 
@@ -2028,14 +2031,11 @@ class TranslatedObjectCreation extends TranslatedCreation {
 
   override TranslatedExpr getInitializerExpr() { result = getTranslatedExpr(expr.getInitializer()) }
 
-  override TranslatedExpr getConstructorCall() {
+  override TranslatedConstructorCall getConstructorCall() {
     // Since calls are also expressions, we can't
     // use the predicate getTranslatedExpr (since that would
     // also return `this`).
-    exists(TranslatedConstructorCall cc |
-      cc.getAST() = this.getAST() and
-      result = cc
-    )
+    result.getAST() = this.getAST()
   }
 }
 

--- a/csharp/ql/test/library-tests/ir/ir/collections.cs
+++ b/csharp/ql/test/library-tests/ir/ir/collections.cs
@@ -1,0 +1,19 @@
+using System.Collections.Generic;
+
+public class Collections
+{
+    class MyClass
+    {
+        public string a;
+        public string b;
+    }
+
+    public static void Main()
+    {
+        var dict = new Dictionary<int, MyClass>()
+        {
+            { 0, new MyClass { a="Hello", b="World" } },
+            { 1, new MyClass { a="Foo", b="Bar" } }
+        };
+    }
+}

--- a/csharp/ql/test/library-tests/ir/ir/obj_creation.cs
+++ b/csharp/ql/test/library-tests/ir/ir/obj_creation.cs
@@ -13,11 +13,17 @@ public class ObjCreation
             x = _x;
         }
     }
+
+    public static void SomeFun(MyClass x) 
+    {
+    }
  
     public static void Main() 
     {
         MyClass obj = new MyClass(100);
         MyClass obj_initlist = new MyClass { x = 101 };
         int a = obj.x;
+
+        SomeFun(new MyClass(100));
     }
 }

--- a/csharp/ql/test/library-tests/ir/ir/raw_ir.expected
+++ b/csharp/ql/test/library-tests/ir/ir/raw_ir.expected
@@ -161,6 +161,50 @@ casts.cs:
 #   11|     v0_20(Void)           = UnmodeledUse             : mu*
 #   11|     v0_21(Void)           = ExitFunction             : 
 
+collections.cs:
+#   11| System.Void Collections.Main()
+#   11|   Block 0
+#   11|     v0_0(Void)                             = EnterFunction               : 
+#   11|     mu0_1(null)                            = AliasedDefinition           : 
+#   11|     mu0_2(null)                            = UnmodeledDefinition         : 
+#   13|     r0_3(glval<Dictionary<Int32,MyClass>>) = VariableAddress[dict]       : 
+#   13|     r0_4(Dictionary<Int32,MyClass>)        = NewObj                      : 
+#   13|     r0_5(glval<null>)                      = FunctionAddress[Dictionary] : 
+#   13|     v0_6(Void)                             = Call                        : func:r0_5, this:r0_4
+#   13|     mu0_7(null)                            = ^CallSideEffect             : ~mu0_2
+#   15|     r0_8(glval<null>)                      = FunctionAddress[Add]        : 
+#   15|     r0_9(Int32)                            = Constant[0]                 : 
+#   15|     r0_10(MyClass)                         = NewObj                      : 
+#   15|     r0_11(glval<null>)                     = FunctionAddress[MyClass]    : 
+#   15|     v0_12(Void)                            = Call                        : func:r0_11, this:r0_10
+#   15|     mu0_13(null)                           = ^CallSideEffect             : ~mu0_2
+#   15|     r0_14(String)                          = StringConstant["Hello"]     : 
+#   15|     r0_15(glval<String>)                   = FieldAddress[a]             : r0_10
+#   15|     mu0_16(String)                         = Store                       : &:r0_15, r0_14
+#   15|     r0_17(String)                          = StringConstant["World"]     : 
+#   15|     r0_18(glval<String>)                   = FieldAddress[b]             : r0_10
+#   15|     mu0_19(String)                         = Store                       : &:r0_18, r0_17
+#   15|     v0_20(Void)                            = Call                        : func:r0_8, this:r0_4, 0:r0_9, 1:r0_10
+#   15|     mu0_21(null)                           = ^CallSideEffect             : ~mu0_2
+#   16|     r0_22(glval<null>)                     = FunctionAddress[Add]        : 
+#   16|     r0_23(Int32)                           = Constant[1]                 : 
+#   16|     r0_24(MyClass)                         = NewObj                      : 
+#   16|     r0_25(glval<null>)                     = FunctionAddress[MyClass]    : 
+#   16|     v0_26(Void)                            = Call                        : func:r0_25, this:r0_24
+#   16|     mu0_27(null)                           = ^CallSideEffect             : ~mu0_2
+#   16|     r0_28(String)                          = StringConstant["Foo"]       : 
+#   16|     r0_29(glval<String>)                   = FieldAddress[a]             : r0_24
+#   16|     mu0_30(String)                         = Store                       : &:r0_29, r0_28
+#   16|     r0_31(String)                          = StringConstant["Bar"]       : 
+#   16|     r0_32(glval<String>)                   = FieldAddress[b]             : r0_24
+#   16|     mu0_33(String)                         = Store                       : &:r0_32, r0_31
+#   16|     v0_34(Void)                            = Call                        : func:r0_22, this:r0_4, 0:r0_23, 1:r0_24
+#   16|     mu0_35(null)                           = ^CallSideEffect             : ~mu0_2
+#   13|     mu0_36(Dictionary<Int32,MyClass>)      = Store                       : &:r0_3, r0_4
+#   11|     v0_37(Void)                            = ReturnVoid                  : 
+#   11|     v0_38(Void)                            = UnmodeledUse                : mu*
+#   11|     v0_39(Void)                            = ExitFunction                : 
+
 constructor_init.cs:
 #    5| System.Void BaseClass..ctor()
 #    5|   Block 0

--- a/csharp/ql/test/library-tests/ir/ir/raw_ir.expected
+++ b/csharp/ql/test/library-tests/ir/ir/raw_ir.expected
@@ -534,7 +534,7 @@ inheritance_polymorphism.cs:
 #   33|     v0_28(Void)        = Call                      : func:r0_27, this:r0_26
 #   33|     mu0_29(null)       = ^CallSideEffect           : ~mu0_2
 #   33|     r0_30(A)           = Convert                   : r0_26
-#   33|     mu0_31(C)          = Store                     : &:r0_25, r0_30
+#   33|     mu0_31(A)          = Store                     : &:r0_25, r0_26
 #   34|     r0_32(glval<A>)    = VariableAddress[objC]     : 
 #   34|     r0_33(A)           = Load                      : &:r0_32, ~mu0_2
 #   34|     r0_34(glval<null>) = FunctionAddress[function] : 
@@ -547,21 +547,23 @@ inheritance_polymorphism.cs:
 isexpr.cs:
 #    8| System.Void IsExpr.Main()
 #    8|   Block 0
-#    8|     v0_0(Void)          = EnterFunction        : 
-#    8|     mu0_1(null)         = AliasedDefinition    : 
-#    8|     mu0_2(null)         = UnmodeledDefinition  : 
-#   10|     r0_3(glval<Is_A>)   = VariableAddress[obj] : 
-#   10|     r0_4(null)          = Constant[null]       : 
-#   10|     mu0_5(Is_A)         = Store                : &:r0_3, r0_4
-#   12|     r0_6(glval<Object>) = VariableAddress[o]   : 
-#   12|     r0_7(glval<Is_A>)   = VariableAddress[obj] : 
-#   12|     mu0_8(Object)       = Store                : &:r0_6, r0_7
-#   13|     r0_9(glval<Object>) = VariableAddress[o]   : 
-#   13|     r0_10(Object)       = Load                 : &:r0_9, ~mu0_2
-#   13|     r0_11(Is_A)         = CheckedConvertOrNull : r0_10
-#   13|     r0_12(Is_A)         = Constant[0]          : 
-#   13|     r0_13(Boolean)      = CompareNE            : r0_11, r0_12
-#   13|     r0_14(Boolean)      = ConditionalBranch    : r0_13
+#    8|     v0_0(Void)           = EnterFunction        : 
+#    8|     mu0_1(null)          = AliasedDefinition    : 
+#    8|     mu0_2(null)          = UnmodeledDefinition  : 
+#   10|     r0_3(glval<Is_A>)    = VariableAddress[obj] : 
+#   10|     r0_4(null)           = Constant[null]       : 
+#   10|     r0_5(Is_A)           = Convert              : r0_4
+#   10|     mu0_6(Is_A)          = Store                : &:r0_3, r0_4
+#   12|     r0_7(glval<Object>)  = VariableAddress[o]   : 
+#   12|     r0_8(glval<Is_A>)    = VariableAddress[obj] : 
+#   12|     r0_9(Object)         = Convert              : r0_8
+#   12|     mu0_10(Object)       = Store                : &:r0_7, r0_8
+#   13|     r0_11(glval<Object>) = VariableAddress[o]   : 
+#   13|     r0_12(Object)        = Load                 : &:r0_11, ~mu0_2
+#   13|     r0_13(Is_A)          = CheckedConvertOrNull : r0_12
+#   13|     r0_14(Is_A)          = Constant[0]          : 
+#   13|     r0_15(Boolean)       = CompareNE            : r0_13, r0_14
+#   13|     r0_16(Boolean)       = ConditionalBranch    : r0_15
 #-----|   False -> Block 2
 #-----|   True -> Block 3
 
@@ -571,13 +573,13 @@ isexpr.cs:
 #    8|     v1_2(Void) = ExitFunction : 
 
 #   13|   Block 2
-#   13|     v2_0(Void) = ConditionalBranch : r0_13
+#   13|     v2_0(Void) = ConditionalBranch : r0_15
 #-----|   False -> Block 5
 #-----|   True -> Block 4
 
 #   13|   Block 3
 #   13|     r3_0(glval<Is_A>) = VariableAddress[tmp] : 
-#   13|     mu3_1(Is_A)       = Store                : &:r3_0, r0_11
+#   13|     mu3_1(Is_A)       = Store                : &:r3_0, r0_13
 #-----|   Goto -> Block 2
 
 #   15|   Block 4
@@ -684,36 +686,56 @@ obj_creation.cs:
 #   11|     v0_12(Void)          = UnmodeledUse            : mu*
 #   11|     v0_13(Void)          = ExitFunction            : 
 
-#   17| System.Void ObjCreation.Main()
+#   17| System.Void ObjCreation.SomeFun(ObjCreation.MyClass)
 #   17|   Block 0
-#   17|     v0_0(Void)            = EnterFunction                 : 
-#   17|     mu0_1(null)           = AliasedDefinition             : 
-#   17|     mu0_2(null)           = UnmodeledDefinition           : 
-#   19|     r0_3(glval<MyClass>)  = VariableAddress[obj]          : 
-#   19|     r0_4(MyClass)         = NewObj                        : 
-#   19|     r0_5(glval<null>)     = FunctionAddress[MyClass]      : 
-#   19|     r0_6(Int32)           = Constant[100]                 : 
-#   19|     v0_7(Void)            = Call                          : func:r0_5, this:r0_4, 0:r0_6
-#   19|     mu0_8(null)           = ^CallSideEffect               : ~mu0_2
-#   19|     mu0_9(MyClass)        = Store                         : &:r0_3, r0_4
-#   20|     r0_10(glval<MyClass>) = VariableAddress[obj_initlist] : 
-#   20|     r0_11(MyClass)        = NewObj                        : 
-#   20|     r0_12(glval<null>)    = FunctionAddress[MyClass]      : 
-#   20|     v0_13(Void)           = Call                          : func:r0_12, this:r0_11
-#   20|     mu0_14(null)          = ^CallSideEffect               : ~mu0_2
-#   20|     r0_15(Int32)          = Constant[101]                 : 
-#   20|     r0_16(glval<Int32>)   = FieldAddress[x]               : r0_11
-#   20|     mu0_17(Int32)         = Store                         : &:r0_16, r0_15
-#   20|     mu0_18(MyClass)       = Store                         : &:r0_10, r0_11
-#   21|     r0_19(glval<Int32>)   = VariableAddress[a]            : 
-#   21|     r0_20(glval<MyClass>) = VariableAddress[obj]          : 
-#   21|     r0_21(MyClass)        = Load                          : &:r0_20, ~mu0_2
-#   21|     r0_22(glval<Int32>)   = FieldAddress[x]               : r0_21
-#   21|     r0_23(Int32)          = Load                          : &:r0_22, ~mu0_2
-#   21|     mu0_24(Int32)         = Store                         : &:r0_19, r0_23
-#   17|     v0_25(Void)           = ReturnVoid                    : 
-#   17|     v0_26(Void)           = UnmodeledUse                  : mu*
-#   17|     v0_27(Void)           = ExitFunction                  : 
+#   17|     v0_0(Void)           = EnterFunction          : 
+#   17|     mu0_1(null)          = AliasedDefinition      : 
+#   17|     mu0_2(null)          = UnmodeledDefinition    : 
+#   17|     r0_3(glval<MyClass>) = VariableAddress[x]     : 
+#   17|     mu0_4(MyClass)       = InitializeParameter[x] : &:r0_3
+#   18|     v0_5(Void)           = NoOp                   : 
+#   17|     v0_6(Void)           = ReturnVoid             : 
+#   17|     v0_7(Void)           = UnmodeledUse           : mu*
+#   17|     v0_8(Void)           = ExitFunction           : 
+
+#   21| System.Void ObjCreation.Main()
+#   21|   Block 0
+#   21|     v0_0(Void)            = EnterFunction                 : 
+#   21|     mu0_1(null)           = AliasedDefinition             : 
+#   21|     mu0_2(null)           = UnmodeledDefinition           : 
+#   23|     r0_3(glval<MyClass>)  = VariableAddress[obj]          : 
+#   23|     r0_4(MyClass)         = NewObj                        : 
+#   23|     r0_5(glval<null>)     = FunctionAddress[MyClass]      : 
+#   23|     r0_6(Int32)           = Constant[100]                 : 
+#   23|     v0_7(Void)            = Call                          : func:r0_5, this:r0_4, 0:r0_6
+#   23|     mu0_8(null)           = ^CallSideEffect               : ~mu0_2
+#   23|     mu0_9(MyClass)        = Store                         : &:r0_3, r0_4
+#   24|     r0_10(glval<MyClass>) = VariableAddress[obj_initlist] : 
+#   24|     r0_11(MyClass)        = NewObj                        : 
+#   24|     r0_12(glval<null>)    = FunctionAddress[MyClass]      : 
+#   24|     v0_13(Void)           = Call                          : func:r0_12, this:r0_11
+#   24|     mu0_14(null)          = ^CallSideEffect               : ~mu0_2
+#   24|     r0_15(Int32)          = Constant[101]                 : 
+#   24|     r0_16(glval<Int32>)   = FieldAddress[x]               : r0_11
+#   24|     mu0_17(Int32)         = Store                         : &:r0_16, r0_15
+#   24|     mu0_18(MyClass)       = Store                         : &:r0_10, r0_11
+#   25|     r0_19(glval<Int32>)   = VariableAddress[a]            : 
+#   25|     r0_20(glval<MyClass>) = VariableAddress[obj]          : 
+#   25|     r0_21(MyClass)        = Load                          : &:r0_20, ~mu0_2
+#   25|     r0_22(glval<Int32>)   = FieldAddress[x]               : r0_21
+#   25|     r0_23(Int32)          = Load                          : &:r0_22, ~mu0_2
+#   25|     mu0_24(Int32)         = Store                         : &:r0_19, r0_23
+#   27|     r0_25(glval<null>)    = FunctionAddress[SomeFun]      : 
+#   27|     r0_26(MyClass)        = NewObj                        : 
+#   27|     r0_27(glval<null>)    = FunctionAddress[MyClass]      : 
+#   27|     r0_28(Int32)          = Constant[100]                 : 
+#   27|     v0_29(Void)           = Call                          : func:r0_27, this:r0_26, 0:r0_28
+#   27|     mu0_30(null)          = ^CallSideEffect               : ~mu0_2
+#   27|     v0_31(Void)           = Call                          : func:r0_25, 0:r0_26
+#   27|     mu0_32(null)          = ^CallSideEffect               : ~mu0_2
+#   21|     v0_33(Void)           = ReturnVoid                    : 
+#   21|     v0_34(Void)           = UnmodeledUse                  : mu*
+#   21|     v0_35(Void)           = ExitFunction                  : 
 
 prop.cs:
 #    7| System.Int32 PropClass.get_Prop()


### PR DESCRIPTION
This PR refactors the code that deals with object creation and adds support for collection initializers. 

Now object and delegate creation are treated as expressions (before they were dealt with in the file `TranslatedInitialization.qll`). This not only fixes the logic of the translation process, but it also enables expressions like `someFun(new object())` to properly be translated - a test case has been added.

This PR also adds support for collection initializers and other minor changes related to initializers.