### PR TITLE
doc: fix broken links in js topics

### DIFF
--- a/docs/language/learn-ql/javascript/dataflow-cheat-sheet.rst
+++ b/docs/language/learn-ql/javascript/dataflow-cheat-sheet.rst
@@ -31,7 +31,7 @@ Use the following template to create a taint tracking path query:
 This query reports flow paths which:
 
 - Begin at a node matched by `isSource <https://help.semmle.com/qldoc/javascript/semmle/javascript/dataflow/Configuration.qll/predicate.Configuration$Configuration$isSource.1.html>`__.
-- Step through variables, function calls, properties, strings, arrays, promises, exceptions, and steps added by `isAdditionalTaintStep <https://help.semmle.com/qldoc/javascript/semmle/javascript/dataflow/Configuration.qll/predicate.Configuration$Configuration$isAdditionalTaintStep.2.html>`__.
+- Step through variables, function calls, properties, strings, arrays, promises, exceptions, and steps added by `isAdditionalTaintStep <https://help.semmle.com/qldoc/javascript/semmle/javascript/dataflow/TaintTracking.qll/predicate.TaintTracking$TaintTracking$Configuration$isAdditionalTaintStep.2.html>`__.
 - End at a node matched by `isSink <https://help.semmle.com/qldoc/javascript/semmle/javascript/dataflow/Configuration.qll/predicate.Configuration$Configuration$isSink.1.html>`__.
 
 See also: `Global data flow <https://help.semmle.com/QL/learn-ql/javascript/dataflow.html#global-data-flow>`__ and :doc:`Constructing path queries <../writing-queries/path-queries>`.

--- a/docs/language/learn-ql/javascript/introduce-libraries-js.rst
+++ b/docs/language/learn-ql/javascript/introduce-libraries-js.rst
@@ -357,7 +357,7 @@ JavaScript provides several ways of defining functions: in ECMAScript 5, there a
 
 -  ``Function.getId()`` returns the `Identifier <https://help.semmle.com/qldoc/javascript/semmle/javascript/Expr.qll/type.Expr$Identifier.html>`__ naming the function, which may not be defined for function expressions.
 -  ``Function.getParameter(i)`` and ``Function.getAParameter()`` access the ``i``\ th parameter or any parameter, respectively; parameters are modeled by the class `Parameter <https://help.semmle.com/qldoc/javascript/semmle/javascript/Variables.qll/type.Variables$Parameter.html>`__, which is a subclass of `BindingPattern <https://help.semmle.com/qldoc/javascript/semmle/javascript/Variables.qll/type.Variables$BindingPattern.html>`__ (see below).
--  ``Function.getBody()`` returns the body of the function, which is usually a `Stmt <https://help.semmle.com/qldoc/javascript/semmle/javascript/Stmt.qll/type.Stmt$Stmt.html>`__, but may be an `Expr <https://help.semmle.com/qldoc/javascript/semmle/javascript/Expr.qll/type.Expr$Expr.html>`__ for arrow function expressions and legacy `expression closures <https://developer.mozilla.org/en/docs/Web/JavaScript/Guide/Closures#Expression_closures>`__.
+-  ``Function.getBody()`` returns the body of the function, which is usually a `Stmt <https://help.semmle.com/qldoc/javascript/semmle/javascript/Stmt.qll/type.Stmt$Stmt.html>`__, but may be an `Expr <https://help.semmle.com/qldoc/javascript/semmle/javascript/Expr.qll/type.Expr$Expr.html>`__ for arrow function expressions and legacy `expression closures <https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Expression_closures>`__.
 
 As an example, here is a query that finds all expression closures:
 
@@ -472,7 +472,7 @@ As an example of a query involving properties, consider the following query that
 Modules
 ^^^^^^^
 
-The JavaScript library has support for working with ECMAScript 2015 modules, as well as legacy CommonJS modules (still commonly employed by Node.js code bases) and AMD-style modules. The QL classes `ES2015Module <https://help.semmle.com/qldoc/javascript/semmle/javascript/ES2015Modules.qll/type.ES2015Modules$ES2015Module.html>`__, `NodeModule <https://help.semmle.com/qldoc/javascript/semmle/javascript/NodeJS.qll/type.NodeJS$NodeModule.html>`__ and `AMDModule <https://help.semmle.com/qldoc/javascript/semmle/javascript/AMD.qll/type.AMD$AMDModule.html>`__ represent these three types of modules, and all three extend the common superclass `Module <https://help.semmle.com/qldoc/javascript/semmle/javascript/Modules.qll/type.Modules$Module.html>`__.
+The JavaScript library has support for working with ECMAScript 2015 modules, as well as legacy CommonJS modules (still commonly employed by Node.js code bases) and AMD-style modules. The QL classes `ES2015Module <https://help.semmle.com/qldoc/javascript/semmle/javascript/ES2015Modules.qll/type.ES2015Modules$ES2015Module.html>`__, `NodeModule <https://help.semmle.com/qldoc/javascript/semmle/javascript/NodeJS.qll/type.NodeJS$NodeModule.html>`__, and `AMDModule <https://help.semmle.com/qldoc/javascript/semmle/javascript/AMD.qll/type.AMD$AmdModule.html>`__ represent these three types of modules, and all three extend the common superclass `Module <https://help.semmle.com/qldoc/javascript/semmle/javascript/Modules.qll/type.Modules$Module.html>`__.
 
 The most important member predicates defined by `Module <https://help.semmle.com/qldoc/javascript/semmle/javascript/Modules.qll/type.Modules$Module.html>`__ are:
 


### PR DESCRIPTION
@Semmle/js 

This PR fixes a few broken links that I found when scanning the JavaScript documentation using the Sphinx link checker: http://www.sphinx-doc.org/en/master/usage/builders/index.html#sphinx.builders.linkcheck.CheckExternalLinksBuilder

One the whole they seem like straightforward updates, but please do check that the changes make sense.
I'm not sure what to do about numbers 4 and 5, so I'll hand them over to you.

# Summary of broken links

```
1. javascript\dataflow-cheat-sheet.rst:34: [broken] https://help.semmle.com/qldoc/javascript/semmle/javascript/dataflow/Configuration.qll/predicate.Configuration$Configuration$isAdditionalTaintStep.2.html: 404 Client Error: Not Found for url: https://help.semmle.com/qldoc/javascript/semmle/javascript/dataflow/Configuration.qll/predicate.Configuration$Configuration$isAdditionalTaintStep.2.html

2. javascript\introduce-libraries-js.rst:475: [broken] https://help.semmle.com/qldoc/javascript/semmle/javascript/AMD.qll/type.AMD$AMDModule.html: 404 Client Error: Not Found for url: https://help.semmle.com/qldoc/javascript/semmle/javascript/AMD.qll/type.AMD$AMDModule.html

3. javascript\introduce-libraries-js.rst:360: [broken] https://developer.mozilla.org/en/docs/Web/JavaScript/Guide/Closures#Expression_closures: Anchor 'Expression_closures' not found

4. javascript\introduce-libraries-js.rst:687: [broken] https://help.semmle.com/qldoc/javascript/semmle/javascript/dataflow/CallGraph.qll/type.CallGraph$CallSite.html: 404 Client Error: Not Found for url: https://help.semmle.com/qldoc/javascript/semmle/javascript/dataflow/CallGraph.qll/type.CallGraph$CallSite.html

5. javascript\introduce-libraries-js.rst:811: [broken] https://restify.com/: HTTPSConnectionPool(host='restify.com', port=443): Max retries exceeded with url: / (Caused by SSLError(CertificateError("hostname 'restify.com' doesn't match either of '*.github.com', 'github.com', '*.github.io', 'github.io'",),))
```

# Summary of fixes

1.  Update link to https://help.semmle.com/qldoc/javascript/semmle/javascript/dataflow/TaintTracking.qll/type.TaintTracking$TaintTracking$AdditionalTaintStep.html

2. Fix typo in URL: https://help.semmle.com/qldoc/javascript/semmle/javascript/AMD.qll/type.AMD$AmdModule.html

3. Update link to: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Expression_closures
I also noticed this: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Errors/Deprecated_expression_closures - do you still want to mention expression closures?

4. Not sure of what to do here as I couldn't find any QLDoc for `CallGraph` - any thoughts?

5. The URL is correct, but the link is considered broken due to a certificate error. Over to you to decide what to do about this one.
