### PR TITLE
C++: Resolve all classes

### DIFF
--- a/cpp/ql/src/semmle/code/cpp/internal/ResolveClass.qll
+++ b/cpp/ql/src/semmle/code/cpp/internal/ResolveClass.qll
@@ -55,32 +55,29 @@ private predicate oldHasCompleteTwin(@usertype c, @usertype d) {
 }
 
 pragma[noinline]
-private @mangledname getTopLevelClassMangledName(@usertype c) {
+private @mangledname getClassMangledName(@usertype c) {
   isClass(c) and
-  mangled_name(c, result) and
-  not namespacembrs(_, c) and // not in a namespace
-  not member(_, _, c) and // not in some structure
-  not class_instantiation(c, _) // not a template instantiation
+  mangled_name(c, result)
 }
 
 /** Holds if `d` is a unique complete class named `name`. */
 pragma[noinline]
 private predicate existsCompleteWithMangledName(@mangledname name, @usertype d) {
   is_complete(d) and
-  name = getTopLevelClassMangledName(d) and
+  name = getClassMangledName(d) and
   onlyOneCompleteClassExistsWithMangledName(name)
 }
 
 pragma[noinline]
 private predicate onlyOneCompleteClassExistsWithMangledName(@mangledname name) {
-  strictcount(@usertype c | is_complete(c) and getTopLevelClassMangledName(c) = name) = 1
+  strictcount(@usertype c | is_complete(c) and getClassMangledName(c) = name) = 1
 }
 
 /** Holds if `c` is an incomplete class named `name`. */
 pragma[noinline]
 private predicate existsIncompleteWithMangledName(@mangledname name, @usertype c) {
   not is_complete(c) and
-  name = getTopLevelClassMangledName(c)
+  name = getClassMangledName(c)
 }
 
 /**

--- a/cpp/ql/test/library-tests/structs/qualified_names/pointerBaseType.expected
+++ b/cpp/ql/test/library-tests/structs/qualified_names/pointerBaseType.expected
@@ -1,4 +1,4 @@
-| decls.cpp:4:6:4:6 | x | decls.cpp:2:9:2:9 | C |
+| decls.cpp:4:6:4:6 | x | defs.cpp:2:9:2:9 | C |
 | defs.cpp:18:21:18:38 | definedAndDeclared | defs.cpp:11:7:11:24 | DefinedAndDeclared |
 | defs.cpp:25:28:25:32 | mdbsh | header.h:1:8:1:32 | MultipleDefsButSameHeader |
 | defs.cpp:29:24:29:28 | odidf | c1.cpp:7:8:7:28 | OneDefInDifferentFile |


### PR DESCRIPTION
Now that we use mangled names to resolve classes, we can efficiently do so for all classes, not just top-level classes.

No alert changes, and I don't see anything worrying performance-wise, in
https://jenkins.internal.semmle.com/job/Changes/job/CPP-Differences/550/