### PR TITLE
C#: Update a `.qlref`.

### DIFF
--- a/csharp/ql/test/query-tests/Metrics/RefTypes/TNumberOfFields/EnumSize.qlref
+++ b/csharp/ql/test/query-tests/Metrics/RefTypes/TNumberOfFields/EnumSize.qlref
@@ -1,1 +1,1 @@
-RefTypes/TNumberOfFields.ql
+Metrics/RefTypes/TNumberOfFields.ql


### PR DESCRIPTION
This currently relies on the fact that qltest includes `ql/csharp/ql/src/Metrics` in addition to `ql/csharp/ql/src` on its search path when run internally, which is inconsistent with the other languages. Since this is the only test that relies on it, I'd like to update it and get rid of the extra search root eventually.