### PR TITLE
JS: simplify `getStringValue()` calls

### DIFF
--- a/javascript/ql/src/Declarations/DeadStore.qll
+++ b/javascript/ql/src/Declarations/DeadStore.qll
@@ -12,7 +12,7 @@ predicate isDefaultInit(Expr e) {
   // primitive default values: zero, false, empty string, and (integer) -1
   e.(NumberLiteral).getValue().toFloat() = 0.0 or
   e.(NegExpr).getOperand().(NumberLiteral).getValue() = "1" or
-  e.(ConstantString).getStringValue() = "" or
+  e.getStringValue() = "" or
   e.(BooleanLiteral).getValue() = "false" or
   // initialising to an empty array or object literal, even if unnecessary,
   // can convey useful type information to the reader

--- a/javascript/ql/src/Expressions/HapaxLegomenon.ql
+++ b/javascript/ql/src/Expressions/HapaxLegomenon.ql
@@ -23,7 +23,7 @@ int countOccurrences(string name) {
       id.(Identifier).getName() = name
       or
       // count string literals as well to capture meta-programming
-      id.(ConstantString).getStringValue() = name
+      id.getStringValue() = name
     )
 }
 

--- a/javascript/ql/src/Security/CWE-798/HardcodedCredentials.ql
+++ b/javascript/ql/src/Security/CWE-798/HardcodedCredentials.ql
@@ -22,7 +22,7 @@ where
   // use source value in message if it's available
   if source.getNode().asExpr() instanceof ConstantString
   then
-    value = "The hard-coded value \"" + source.getNode().asExpr().getStringValue() +
+    value = "The hard-coded value \"" + source.getNode().getStringValue() +
         "\""
   else value = "This hard-coded value"
 select source.getNode(), source, sink, value + " is used as $@.", sink.getNode(),

--- a/javascript/ql/src/Security/CWE-798/HardcodedCredentials.ql
+++ b/javascript/ql/src/Security/CWE-798/HardcodedCredentials.ql
@@ -22,7 +22,7 @@ where
   // use source value in message if it's available
   if source.getNode().asExpr() instanceof ConstantString
   then
-    value = "The hard-coded value \"" + source.getNode().asExpr().(ConstantString).getStringValue() +
+    value = "The hard-coded value \"" + source.getNode().asExpr().getStringValue() +
         "\""
   else value = "This hard-coded value"
 select source.getNode(), source, sink, value + " is used as $@.", sink.getNode(),

--- a/javascript/ql/src/semmle/javascript/AMD.qll
+++ b/javascript/ql/src/semmle/javascript/AMD.qll
@@ -189,7 +189,7 @@ private class AmdDependencyPath extends PathExprCandidate {
 private class ConstantAmdDependencyPathElement extends PathExprInModule, ConstantString {
   ConstantAmdDependencyPathElement() { this = any(AmdDependencyPath amd).getAPart() }
 
-  override string getValue() { result = this.(ConstantString).getStringValue() }
+  override string getValue() { result = this.getStringValue() }
 }
 
 /**

--- a/javascript/ql/src/semmle/javascript/AMD.qll
+++ b/javascript/ql/src/semmle/javascript/AMD.qll
@@ -189,7 +189,7 @@ private class AmdDependencyPath extends PathExprCandidate {
 private class ConstantAmdDependencyPathElement extends PathExprInModule, ConstantString {
   ConstantAmdDependencyPathElement() { this = any(AmdDependencyPath amd).getAPart() }
 
-  override string getValue() { result = this.getStringValue() }
+  override string getValue() { result = getStringValue() }
 }
 
 /**

--- a/javascript/ql/src/semmle/javascript/Closure.qll
+++ b/javascript/ql/src/semmle/javascript/Closure.qll
@@ -56,7 +56,7 @@ module Closure {
     ClosureNamespaceRef::Range {
     DefaultNamespaceRef() { this = DataFlow::globalVarRef("goog").getAMethodCall() }
 
-    override string getClosureNamespace() { result = getArgument(0).asExpr().getStringValue() }
+    override string getClosureNamespace() { result = getArgument(0).getStringValue() }
   }
 
   /**

--- a/javascript/ql/src/semmle/javascript/ES2015Modules.qll
+++ b/javascript/ql/src/semmle/javascript/ES2015Modules.qll
@@ -82,7 +82,7 @@ class ImportDeclaration extends Stmt, Import, @importdeclaration {
 private class LiteralImportPath extends PathExprInModule, ConstantString {
   LiteralImportPath() { exists(ImportDeclaration req | this = req.getChildExpr(-1)) }
 
-  override string getValue() { result = this.getStringValue() }
+  override string getValue() { result = getStringValue() }
 }
 
 /**
@@ -596,7 +596,7 @@ abstract class ReExportDeclaration extends ExportDeclaration {
 private class LiteralReExportPath extends PathExprInModule, ConstantString {
   LiteralReExportPath() { exists(ReExportDeclaration bred | this = bred.getImportedPath()) }
 
-  override string getValue() { result = this.getStringValue() }
+  override string getValue() { result = getStringValue() }
 }
 
 /**

--- a/javascript/ql/src/semmle/javascript/ES2015Modules.qll
+++ b/javascript/ql/src/semmle/javascript/ES2015Modules.qll
@@ -82,7 +82,7 @@ class ImportDeclaration extends Stmt, Import, @importdeclaration {
 private class LiteralImportPath extends PathExprInModule, ConstantString {
   LiteralImportPath() { exists(ImportDeclaration req | this = req.getChildExpr(-1)) }
 
-  override string getValue() { result = this.(ConstantString).getStringValue() }
+  override string getValue() { result = this.getStringValue() }
 }
 
 /**
@@ -596,7 +596,7 @@ abstract class ReExportDeclaration extends ExportDeclaration {
 private class LiteralReExportPath extends PathExprInModule, ConstantString {
   LiteralReExportPath() { exists(ReExportDeclaration bred | this = bred.getImportedPath()) }
 
-  override string getValue() { result = this.(ConstantString).getStringValue() }
+  override string getValue() { result = this.getStringValue() }
 }
 
 /**

--- a/javascript/ql/src/semmle/javascript/Expr.qll
+++ b/javascript/ql/src/semmle/javascript/Expr.qll
@@ -2600,7 +2600,7 @@ private class LiteralDynamicImportPath extends PathExprInModule, ConstantString 
     exists(DynamicImportExpr di | this.getParentExpr*() = di.getSource())
   }
 
-  override string getValue() { result = this.(ConstantString).getStringValue() }
+  override string getValue() { result = this.getStringValue() }
 }
 
 /**

--- a/javascript/ql/src/semmle/javascript/Expr.qll
+++ b/javascript/ql/src/semmle/javascript/Expr.qll
@@ -2600,7 +2600,7 @@ private class LiteralDynamicImportPath extends PathExprInModule, ConstantString 
     exists(DynamicImportExpr di | this.getParentExpr*() = di.getSource())
   }
 
-  override string getValue() { result = this.getStringValue() }
+  override string getValue() { result = getStringValue() }
 }
 
 /**

--- a/javascript/ql/src/semmle/javascript/NodeJS.qll
+++ b/javascript/ql/src/semmle/javascript/NodeJS.qll
@@ -269,7 +269,7 @@ private class RequirePath extends PathExprCandidate {
 private class ConstantRequirePathElement extends PathExprInModule, ConstantString {
   ConstantRequirePathElement() { this = any(RequirePath rp).getAPart() }
 
-  override string getValue() { result = this.getStringValue() }
+  override string getValue() { result = getStringValue() }
 }
 
 /** A `__dirname` path expression. */

--- a/javascript/ql/src/semmle/javascript/StandardLibrary.qll
+++ b/javascript/ql/src/semmle/javascript/StandardLibrary.qll
@@ -17,7 +17,7 @@ class CallToObjectDefineProperty extends DataFlow::MethodCallNode {
   DataFlow::Node getBaseObject() { result = getArgument(0) }
 
   /** Gets the name of the property being defined, if it can be determined. */
-  string getPropertyName() { result = getArgument(1).asExpr().getStringValue() }
+  string getPropertyName() { result = getArgument(1).getStringValue() }
 
   /** Gets the data flow node denoting the descriptor of the property being defined. */
   DataFlow::Node getPropertyDescriptor() { result = getArgument(2) }

--- a/javascript/ql/src/semmle/javascript/StandardLibrary.qll
+++ b/javascript/ql/src/semmle/javascript/StandardLibrary.qll
@@ -17,7 +17,7 @@ class CallToObjectDefineProperty extends DataFlow::MethodCallNode {
   DataFlow::Node getBaseObject() { result = getArgument(0) }
 
   /** Gets the name of the property being defined, if it can be determined. */
-  string getPropertyName() { result = getArgument(1).asExpr().(ConstantString).getStringValue() }
+  string getPropertyName() { result = getArgument(1).asExpr().getStringValue() }
 
   /** Gets the data flow node denoting the descriptor of the property being defined. */
   DataFlow::Node getPropertyDescriptor() { result = getArgument(2) }

--- a/javascript/ql/src/semmle/javascript/TypeScript.qll
+++ b/javascript/ql/src/semmle/javascript/TypeScript.qll
@@ -222,7 +222,7 @@ private class LiteralExternalModulePath extends PathExprInModule, ConstantString
     exists(ExternalModuleReference emr | this.getParentExpr*() = emr.getExpression())
   }
 
-  override string getValue() { result = this.(ConstantString).getStringValue() }
+  override string getValue() { result = this.getStringValue() }
 }
 
 /** A TypeScript "export-assign" declaration. */

--- a/javascript/ql/src/semmle/javascript/TypeScript.qll
+++ b/javascript/ql/src/semmle/javascript/TypeScript.qll
@@ -222,7 +222,7 @@ private class LiteralExternalModulePath extends PathExprInModule, ConstantString
     exists(ExternalModuleReference emr | this.getParentExpr*() = emr.getExpression())
   }
 
-  override string getValue() { result = this.getStringValue() }
+  override string getValue() { result = getStringValue() }
 }
 
 /** A TypeScript "export-assign" declaration. */

--- a/javascript/ql/src/semmle/javascript/dataflow/Nodes.qll
+++ b/javascript/ql/src/semmle/javascript/dataflow/Nodes.qll
@@ -476,7 +476,7 @@ module ModuleImportNode {
       exists(AmdModuleDefinition amd, CallExpr req |
         req = amd.getARequireCall() and
         this = DataFlow::valueNode(req) and
-        path = req.getArgument(0).(ConstantString).getStringValue()
+        path = req.getArgument(0).getStringValue()
       )
     }
 

--- a/javascript/ql/src/semmle/javascript/dependencies/FrameworkLibraries.qll
+++ b/javascript/ql/src/semmle/javascript/dependencies/FrameworkLibraries.qll
@@ -390,7 +390,7 @@ private predicate mooToolsObject(ObjectExpr oe, TopLevel tl, string version) {
   |
     d.getBase() instanceof ThisExpr and
     d.getPropertyName() = "MooTools" and
-    version = oe.getPropertyByName("version").getInit().(ConstantString).getStringValue()
+    version = oe.getPropertyByName("version").getInit().getStringValue()
   )
 }
 
@@ -429,7 +429,7 @@ private class Prototype extends FrameworkLibraryWithGenericURL {
 private predicate prototypeObject(ObjectExpr oe, TopLevel tl, string version) {
   exists(VariableDeclarator vd | tl = vd.getTopLevel() and oe = vd.getInit() |
     vd.getBindingPattern().(Identifier).getName() = "Prototype" and
-    version = oe.getPropertyByName("Version").getInit().(ConstantString).getStringValue()
+    version = oe.getPropertyByName("Version").getInit().getStringValue()
   )
 }
 
@@ -468,7 +468,7 @@ private class Scriptaculous extends FrameworkLibraryWithGenericURL {
 private predicate scriptaculousObject(ObjectExpr oe, TopLevel tl, string version) {
   exists(VariableDeclarator vd | tl = vd.getTopLevel() and oe = vd.getInit() |
     vd.getBindingPattern().(Identifier).getName() = "Scriptaculous" and
-    version = oe.getPropertyByName("Version").getInit().(ConstantString).getStringValue()
+    version = oe.getPropertyByName("Version").getInit().getStringValue()
   )
 }
 

--- a/javascript/ql/src/semmle/javascript/frameworks/Electron.qll
+++ b/javascript/ql/src/semmle/javascript/frameworks/Electron.qll
@@ -116,7 +116,7 @@ module Electron {
       Process getProcess() { result = process }
 
       /** Gets the name of the channel the callback is listening on. */
-      string getChannelName() { result = channel.asExpr().getStringValue() }
+      string getChannelName() { result = channel.getStringValue() }
 
       /** Gets the data flow node containing the message received by the callback. */
       DataFlow::Node getMessage() { result = getParameter(1) }
@@ -156,7 +156,7 @@ module Electron {
 
       override Process getProcess() { result = process }
 
-      override string getChannelName() { result = channel.asExpr().getStringValue() }
+      override string getChannelName() { result = channel.getStringValue() }
     }
 
     /**
@@ -186,7 +186,7 @@ module Electron {
 
       override Process getProcess() { result = callback.getProcess() }
 
-      override string getChannelName() { result = channel.asExpr().getStringValue() }
+      override string getChannelName() { result = channel.getStringValue() }
     }
 
     /**
@@ -221,7 +221,7 @@ module Electron {
 
       override Process getProcess() { result = Process::main() }
 
-      override string getChannelName() { result = channel.asExpr().getStringValue() }
+      override string getChannelName() { result = channel.getStringValue() }
     }
 
     /**

--- a/javascript/ql/src/semmle/javascript/frameworks/xUnit.qll
+++ b/javascript/ql/src/semmle/javascript/frameworks/xUnit.qll
@@ -11,7 +11,7 @@ private predicate xUnitDetected() {
     mc.getParent() instanceof ExprStmt and
     mc = DataFlow::globalVarRef("Function").getAMemberCall("RegisterNamespace").asExpr() and
     mc.getNumArgument() = 1 and
-    mc.getArgument(0).(ConstantString).getStringValue() = "xUnit.js"
+    mc.getArgument(0).getStringValue() = "xUnit.js"
   )
 }
 

--- a/javascript/ql/src/semmle/javascript/security/dataflow/TaintedPathCustomizations.qll
+++ b/javascript/ql/src/semmle/javascript/security/dataflow/TaintedPathCustomizations.qll
@@ -229,11 +229,11 @@ module TaintedPath {
    * Holds if `node` is a prefix of the string `../`.
    */
   private predicate isDotDotSlashPrefix(DataFlow::Node node) {
-    node.asExpr().getStringValue() + any(string s) = "../"
+    node.getStringValue() + any(string s) = "../"
     or
     // ".." + path.sep
     exists(StringOps::Concatenation conc | node = conc |
-      conc.getOperand(0).asExpr().getStringValue() = ".." and
+      conc.getOperand(0).getStringValue() = ".." and
       conc.getOperand(1).getALocalSource() = DataFlow::moduleMember("path", "sep") and
       conc.getNumOperand() = 2
     )
@@ -277,7 +277,7 @@ module TaintedPath {
       this = startsWith and
       not isDotDotSlashPrefix(startsWith.getSubstring()) and
       // do not confuse this with a simple isAbsolute() check
-      not startsWith.getSubstring().asExpr().getStringValue() = "/"
+      not startsWith.getSubstring().getStringValue() = "/"
     }
 
     override predicate blocks(boolean outcome, Expr e, DataFlow::FlowLabel label) {
@@ -308,7 +308,7 @@ module TaintedPath {
       )
       or
       exists(StringOps::StartsWith startsWith, string substring | this = startsWith |
-        startsWith.getSubstring().asExpr().getStringValue() = "/" + substring and
+        startsWith.getSubstring().getStringValue() = "/" + substring and
         operand = startsWith.getBaseString() and
         polarity = startsWith.getPolarity() and
         if substring = "" then negatable = true else negatable = false

--- a/javascript/ql/test/library-tests/StringConcatenation/ContainsTwo.ql
+++ b/javascript/ql/test/library-tests/StringConcatenation/ContainsTwo.ql
@@ -2,7 +2,7 @@ import javascript
 
 // Select all expressions whose string value contains the word "two"
 predicate containsTwo(DataFlow::Node node) {
-  node.asExpr().getStringValue().regexpMatch(".*two.*")
+  node.getStringValue().regexpMatch(".*two.*")
   or
   containsTwo(node.getAPredecessor())
   or

--- a/javascript/ql/test/library-tests/TypeScript/Namespaces/CheckBindings.ql
+++ b/javascript/ql/test/library-tests/TypeScript/Namespaces/CheckBindings.ql
@@ -5,10 +5,10 @@ class ResolveCall extends CallExpr {
 
   Variable getVariable() { result = this.getArgument(0).(VarUse).getVariable() }
 
-  string getExpectation() { result = this.getArgument(1).(ConstantString).getStringValue() }
+  string getExpectation() { result = this.getArgument(1).getStringValue() }
 
   string getDeclaredValue() {
-    result = getVariable().getAnAssignedExpr().(ConstantString).getStringValue()
+    result = getVariable().getAnAssignedExpr().getStringValue()
     or
     exists(NamespaceDeclaration decl | decl.getId() = getVariable().getADeclaration() |
       result = getNamespaceName(decl)
@@ -17,7 +17,7 @@ class ResolveCall extends CallExpr {
 }
 
 string getNamespaceName(NamespaceDeclaration decl) {
-  result = decl.getStmt(0).(ExprStmt).getExpr().(ConstantString).getStringValue()
+  result = decl.getStmt(0).(ExprStmt).getExpr().getStringValue()
   or
   not decl.getStmt(0).(ExprStmt).getExpr() instanceof ConstantString and
   result = "Namespace " + decl.getId() + " on line " +

--- a/javascript/ql/test/tutorials/Validating RAML-based APIs/Osprey.qll
+++ b/javascript/ql/test/tutorials/Validating RAML-based APIs/Osprey.qll
@@ -50,7 +50,7 @@ class OspreyMethodDefinition extends MethodCallExpr {
   string getVerb() { result = getMethodName() }
 
   /** Get the resource path to which this method belongs. */
-  string getResourcePath() { result = getArgument(0).(ConstantString).getStringValue() }
+  string getResourcePath() { result = getArgument(0).getStringValue() }
 }
 
 /** A callback function bound to a REST method. */


### PR DESCRIPTION
Inspired by <https://github.com/Semmle/ql/pull/1875#discussion_r323120149>

I am open to abandoning this PR if we prefer the more explicit form.

The changes are done with `sed`, but they have all been inspected indivually.

Do we want a dist-compare run for this?