### PR TITLE
C++: Add PointerToFieldLiteral class

### DIFF
--- a/cpp/ql/src/semmle/code/cpp/exprs/Access.qll
+++ b/cpp/ql/src/semmle/code/cpp/exprs/Access.qll
@@ -227,6 +227,29 @@ class ImplicitThisFieldAccess extends FieldAccess {
 }
 
 /**
+ * A C++ _pointer to non-static data member_ literal. For example, `&C::x` is
+ * an expression that refers to field `x` of class `C`. If the type of that
+ * field is `int`, then `&C::x` ought to have type `int C::*`. It is currently
+ * modeled in QL as having type `int`.
+ *
+ * See [dcl.mptr] in the C++17 standard or see
+ * https://en.cppreference.com/w/cpp/language/pointer#Pointers_to_data_members.
+ */
+class PointerToFieldLiteral extends ImplicitThisFieldAccess {
+  PointerToFieldLiteral() {
+    // The extractor currently emits a pointer-to-field literal as a field
+    // access without a qualifier. The only other unqualified field accesses it
+    // emits are for compiler-generated constructors and destructors. When we
+    // filter those out, there are only pointer-to-field literals left.
+    not this.isCompilerGenerated()
+  }
+
+  override predicate isConstant() { any() }
+
+  override string getCanonicalQLClass() { result = "PointerToFieldLiteral" }
+}
+
+/**
  * A C/C++ function access expression.
  */
 class FunctionAccess extends Access, @routineexpr {

--- a/cpp/ql/test/library-tests/syntax-zoo/aliased_ssa_sanity.expected
+++ b/cpp/ql/test/library-tests/syntax-zoo/aliased_ssa_sanity.expected
@@ -20,6 +20,7 @@ instructionWithoutSuccessor
 | ms_try_mix.cpp:11:12:11:15 | Chi: call to C |
 | ms_try_mix.cpp:28:12:28:15 | Chi: call to C |
 | ms_try_mix.cpp:48:10:48:13 | Chi: call to C |
+| pointer_to_member.cpp:35:11:35:21 | FieldAddress: {...} |
 | stmt_expr.cpp:27:5:27:15 | Store: ... = ... |
 | vla.c:5:9:5:14 | Uninitialized: definition of matrix |
 | vla.c:11:6:11:16 | UnmodeledDefinition: vla_typedef |

--- a/cpp/ql/test/library-tests/syntax-zoo/drawDifferent.expected
+++ b/cpp/ql/test/library-tests/syntax-zoo/drawDifferent.expected
@@ -1,26 +1,3 @@
-| pointer_to_member__pmIsConst_extractor | false | 15698 | 15698 | pmIsConst |
-| pointer_to_member__pmIsConst_extractor | false | 15724 | 15724 | declaration |
-| pointer_to_member__pmIsConst_extractor | false | 15726 | 15726 | return ... |
-| pointer_to_member__pmIsConst_extractor | false | 15728 | 15728 | { ... } |
-| pointer_to_member__pmIsConst_extractor | false | 15731 | 15731 | {...} |
-| pointer_to_member__pmIsConst_extractor | false | 15734 | 15734 | x1 |
-| pointer_to_member__pmIsConst_extractor | false | 15735 | 15735 | initializer for pms |
-| pointer_to_member__pmIsConst_extractor | true | 15724 | 15726 |  |
-| pointer_to_member__pmIsConst_extractor | true | 15726 | 15698 |  |
-| pointer_to_member__pmIsConst_extractor | true | 15728 | 15724 |  |
-| pointer_to_member__pmIsConst_ql | false | 15698 | 15698 | pmIsConst |
-| pointer_to_member__pmIsConst_ql | false | 15724 | 15724 | declaration |
-| pointer_to_member__pmIsConst_ql | false | 15726 | 15726 | return ... |
-| pointer_to_member__pmIsConst_ql | false | 15728 | 15728 | { ... } |
-| pointer_to_member__pmIsConst_ql | false | 15731 | 15731 | {...} |
-| pointer_to_member__pmIsConst_ql | false | 15734 | 15734 | x1 |
-| pointer_to_member__pmIsConst_ql | false | 15735 | 15735 | initializer for pms |
-| pointer_to_member__pmIsConst_ql | true | 15724 | 15735 |  |
-| pointer_to_member__pmIsConst_ql | true | 15726 | 15698 |  |
-| pointer_to_member__pmIsConst_ql | true | 15728 | 15724 |  |
-| pointer_to_member__pmIsConst_ql | true | 15731 | 15726 |  |
-| pointer_to_member__pmIsConst_ql | true | 15734 | 15731 |  |
-| pointer_to_member__pmIsConst_ql | true | 15735 | 15734 |  |
 | staticlocals__staticlocals_f2_extractor | false | 22465 | 22465 | f2 |
 | staticlocals__staticlocals_f2_extractor | false | 22470 | 22470 | declaration |
 | staticlocals__staticlocals_f2_extractor | false | 22472 | 22472 | declaration |

--- a/cpp/ql/test/library-tests/syntax-zoo/drawDifferent.expected
+++ b/cpp/ql/test/library-tests/syntax-zoo/drawDifferent.expected
@@ -1,53 +1,76 @@
-| staticlocals__staticlocals_f2_extractor | false | 31268 | 31268 | f2 |
-| staticlocals__staticlocals_f2_extractor | false | 31274 | 31274 | declaration |
-| staticlocals__staticlocals_f2_extractor | false | 31277 | 31277 | declaration |
-| staticlocals__staticlocals_f2_extractor | false | 31280 | 31280 | declaration |
-| staticlocals__staticlocals_f2_extractor | false | 31283 | 31283 | declaration |
-| staticlocals__staticlocals_f2_extractor | false | 31286 | 31286 | return ... |
-| staticlocals__staticlocals_f2_extractor | false | 31289 | 31289 | { ... } |
-| staticlocals__staticlocals_f2_extractor | false | 31292 | 31292 | call to C |
-| staticlocals__staticlocals_f2_extractor | false | 31295 | 31295 | initializer for c |
-| staticlocals__staticlocals_f2_extractor | false | 31298 | 31298 | call to addOne |
-| staticlocals__staticlocals_f2_extractor | false | 31304 | 31304 | 2 |
-| staticlocals__staticlocals_f2_extractor | false | 31309 | 31309 | initializer for j |
-| staticlocals__staticlocals_f2_extractor | false | 31311 | 31311 | call to addOne |
-| staticlocals__staticlocals_f2_extractor | false | 31319 | 31319 | 2 |
-| staticlocals__staticlocals_f2_extractor | false | 31321 | 31321 | initializer for two |
-| staticlocals__staticlocals_f2_extractor | false | 31325 | 31325 | two |
-| staticlocals__staticlocals_f2_extractor | false | 31333 | 31333 | initializer for i |
-| staticlocals__staticlocals_f2_extractor | true | 31274 | 31321 |  |
-| staticlocals__staticlocals_f2_extractor | true | 31277 | 31280 |  |
-| staticlocals__staticlocals_f2_extractor | true | 31280 | 31283 |  |
-| staticlocals__staticlocals_f2_extractor | true | 31283 | 31286 |  |
-| staticlocals__staticlocals_f2_extractor | true | 31286 | 31268 |  |
-| staticlocals__staticlocals_f2_extractor | true | 31289 | 31274 |  |
-| staticlocals__staticlocals_f2_extractor | true | 31319 | 31277 |  |
-| staticlocals__staticlocals_f2_extractor | true | 31321 | 31319 |  |
-| staticlocals__staticlocals_f2_ql | false | 31268 | 31268 | f2 |
-| staticlocals__staticlocals_f2_ql | false | 31274 | 31274 | declaration |
-| staticlocals__staticlocals_f2_ql | false | 31277 | 31277 | declaration |
-| staticlocals__staticlocals_f2_ql | false | 31280 | 31280 | declaration |
-| staticlocals__staticlocals_f2_ql | false | 31283 | 31283 | declaration |
-| staticlocals__staticlocals_f2_ql | false | 31286 | 31286 | return ... |
-| staticlocals__staticlocals_f2_ql | false | 31289 | 31289 | { ... } |
-| staticlocals__staticlocals_f2_ql | false | 31292 | 31292 | call to C |
-| staticlocals__staticlocals_f2_ql | false | 31295 | 31295 | initializer for c |
-| staticlocals__staticlocals_f2_ql | false | 31298 | 31298 | call to addOne |
-| staticlocals__staticlocals_f2_ql | false | 31304 | 31304 | 2 |
-| staticlocals__staticlocals_f2_ql | false | 31309 | 31309 | initializer for j |
-| staticlocals__staticlocals_f2_ql | false | 31311 | 31311 | call to addOne |
-| staticlocals__staticlocals_f2_ql | false | 31319 | 31319 | 2 |
-| staticlocals__staticlocals_f2_ql | false | 31321 | 31321 | initializer for two |
-| staticlocals__staticlocals_f2_ql | false | 31325 | 31325 | two |
-| staticlocals__staticlocals_f2_ql | false | 31333 | 31333 | initializer for i |
-| staticlocals__staticlocals_f2_ql | true | 31274 | 31321 |  |
-| staticlocals__staticlocals_f2_ql | true | 31277 | 31280 |  |
-| staticlocals__staticlocals_f2_ql | true | 31280 | 31283 |  |
-| staticlocals__staticlocals_f2_ql | true | 31283 | 31286 |  |
-| staticlocals__staticlocals_f2_ql | true | 31283 | 31295 |  |
-| staticlocals__staticlocals_f2_ql | true | 31286 | 31268 |  |
-| staticlocals__staticlocals_f2_ql | true | 31289 | 31274 |  |
-| staticlocals__staticlocals_f2_ql | true | 31292 | 31286 |  |
-| staticlocals__staticlocals_f2_ql | true | 31295 | 31292 |  |
-| staticlocals__staticlocals_f2_ql | true | 31319 | 31277 |  |
-| staticlocals__staticlocals_f2_ql | true | 31321 | 31319 |  |
+| pointer_to_member__pmIsConst_extractor | false | 15698 | 15698 | pmIsConst |
+| pointer_to_member__pmIsConst_extractor | false | 15724 | 15724 | declaration |
+| pointer_to_member__pmIsConst_extractor | false | 15726 | 15726 | return ... |
+| pointer_to_member__pmIsConst_extractor | false | 15728 | 15728 | { ... } |
+| pointer_to_member__pmIsConst_extractor | false | 15731 | 15731 | {...} |
+| pointer_to_member__pmIsConst_extractor | false | 15734 | 15734 | x1 |
+| pointer_to_member__pmIsConst_extractor | false | 15735 | 15735 | initializer for pms |
+| pointer_to_member__pmIsConst_extractor | true | 15724 | 15726 |  |
+| pointer_to_member__pmIsConst_extractor | true | 15726 | 15698 |  |
+| pointer_to_member__pmIsConst_extractor | true | 15728 | 15724 |  |
+| pointer_to_member__pmIsConst_ql | false | 15698 | 15698 | pmIsConst |
+| pointer_to_member__pmIsConst_ql | false | 15724 | 15724 | declaration |
+| pointer_to_member__pmIsConst_ql | false | 15726 | 15726 | return ... |
+| pointer_to_member__pmIsConst_ql | false | 15728 | 15728 | { ... } |
+| pointer_to_member__pmIsConst_ql | false | 15731 | 15731 | {...} |
+| pointer_to_member__pmIsConst_ql | false | 15734 | 15734 | x1 |
+| pointer_to_member__pmIsConst_ql | false | 15735 | 15735 | initializer for pms |
+| pointer_to_member__pmIsConst_ql | true | 15724 | 15735 |  |
+| pointer_to_member__pmIsConst_ql | true | 15726 | 15698 |  |
+| pointer_to_member__pmIsConst_ql | true | 15728 | 15724 |  |
+| pointer_to_member__pmIsConst_ql | true | 15731 | 15726 |  |
+| pointer_to_member__pmIsConst_ql | true | 15734 | 15731 |  |
+| pointer_to_member__pmIsConst_ql | true | 15735 | 15734 |  |
+| staticlocals__staticlocals_f2_extractor | false | 22465 | 22465 | f2 |
+| staticlocals__staticlocals_f2_extractor | false | 22470 | 22470 | declaration |
+| staticlocals__staticlocals_f2_extractor | false | 22472 | 22472 | declaration |
+| staticlocals__staticlocals_f2_extractor | false | 22474 | 22474 | declaration |
+| staticlocals__staticlocals_f2_extractor | false | 22476 | 22476 | declaration |
+| staticlocals__staticlocals_f2_extractor | false | 22478 | 22478 | return ... |
+| staticlocals__staticlocals_f2_extractor | false | 22480 | 22480 | { ... } |
+| staticlocals__staticlocals_f2_extractor | false | 22482 | 22482 | call to C |
+| staticlocals__staticlocals_f2_extractor | false | 22484 | 22484 | initializer for c |
+| staticlocals__staticlocals_f2_extractor | false | 22486 | 22486 | call to addOne |
+| staticlocals__staticlocals_f2_extractor | false | 22490 | 22490 | 2 |
+| staticlocals__staticlocals_f2_extractor | false | 22493 | 22493 | initializer for j |
+| staticlocals__staticlocals_f2_extractor | false | 22494 | 22494 | call to addOne |
+| staticlocals__staticlocals_f2_extractor | false | 22499 | 22499 | 2 |
+| staticlocals__staticlocals_f2_extractor | false | 22500 | 22500 | initializer for two |
+| staticlocals__staticlocals_f2_extractor | false | 22503 | 22503 | two |
+| staticlocals__staticlocals_f2_extractor | false | 22508 | 22508 | initializer for i |
+| staticlocals__staticlocals_f2_extractor | true | 22470 | 22500 |  |
+| staticlocals__staticlocals_f2_extractor | true | 22472 | 22474 |  |
+| staticlocals__staticlocals_f2_extractor | true | 22474 | 22476 |  |
+| staticlocals__staticlocals_f2_extractor | true | 22476 | 22478 |  |
+| staticlocals__staticlocals_f2_extractor | true | 22478 | 22465 |  |
+| staticlocals__staticlocals_f2_extractor | true | 22480 | 22470 |  |
+| staticlocals__staticlocals_f2_extractor | true | 22499 | 22472 |  |
+| staticlocals__staticlocals_f2_extractor | true | 22500 | 22499 |  |
+| staticlocals__staticlocals_f2_ql | false | 22465 | 22465 | f2 |
+| staticlocals__staticlocals_f2_ql | false | 22470 | 22470 | declaration |
+| staticlocals__staticlocals_f2_ql | false | 22472 | 22472 | declaration |
+| staticlocals__staticlocals_f2_ql | false | 22474 | 22474 | declaration |
+| staticlocals__staticlocals_f2_ql | false | 22476 | 22476 | declaration |
+| staticlocals__staticlocals_f2_ql | false | 22478 | 22478 | return ... |
+| staticlocals__staticlocals_f2_ql | false | 22480 | 22480 | { ... } |
+| staticlocals__staticlocals_f2_ql | false | 22482 | 22482 | call to C |
+| staticlocals__staticlocals_f2_ql | false | 22484 | 22484 | initializer for c |
+| staticlocals__staticlocals_f2_ql | false | 22486 | 22486 | call to addOne |
+| staticlocals__staticlocals_f2_ql | false | 22490 | 22490 | 2 |
+| staticlocals__staticlocals_f2_ql | false | 22493 | 22493 | initializer for j |
+| staticlocals__staticlocals_f2_ql | false | 22494 | 22494 | call to addOne |
+| staticlocals__staticlocals_f2_ql | false | 22499 | 22499 | 2 |
+| staticlocals__staticlocals_f2_ql | false | 22500 | 22500 | initializer for two |
+| staticlocals__staticlocals_f2_ql | false | 22503 | 22503 | two |
+| staticlocals__staticlocals_f2_ql | false | 22508 | 22508 | initializer for i |
+| staticlocals__staticlocals_f2_ql | true | 22470 | 22500 |  |
+| staticlocals__staticlocals_f2_ql | true | 22472 | 22474 |  |
+| staticlocals__staticlocals_f2_ql | true | 22474 | 22476 |  |
+| staticlocals__staticlocals_f2_ql | true | 22476 | 22478 |  |
+| staticlocals__staticlocals_f2_ql | true | 22476 | 22484 |  |
+| staticlocals__staticlocals_f2_ql | true | 22478 | 22465 |  |
+| staticlocals__staticlocals_f2_ql | true | 22480 | 22470 |  |
+| staticlocals__staticlocals_f2_ql | true | 22482 | 22478 |  |
+| staticlocals__staticlocals_f2_ql | true | 22484 | 22482 |  |
+| staticlocals__staticlocals_f2_ql | true | 22499 | 22472 |  |
+| staticlocals__staticlocals_f2_ql | true | 22500 | 22499 |  |

--- a/cpp/ql/test/library-tests/syntax-zoo/pointer_to_member.cpp
+++ b/cpp/ql/test/library-tests/syntax-zoo/pointer_to_member.cpp
@@ -28,3 +28,9 @@ int usePM(int PM::* pm) {
 
     return acc;
 }
+
+void pmIsConst() {
+  static const struct {
+    int PM::* pm1;
+  } pms = { &PM::x1 };
+}

--- a/cpp/ql/test/library-tests/syntax-zoo/raw_sanity.expected
+++ b/cpp/ql/test/library-tests/syntax-zoo/raw_sanity.expected
@@ -7,6 +7,7 @@ missingOperand
 | misc.c:220:3:223:3 | Store: ... = ... | Instruction 'Store' is missing an expected operand with tag 'StoreValue' in function '$@'. | misc.c:219:5:219:26 | IR: assign_designated_init | int assign_designated_init(someStruct*) |
 | misc.c:220:9:223:3 | FieldAddress: {...} | Instruction 'FieldAddress' is missing an expected operand with tag 'Unary' in function '$@'. | misc.c:219:5:219:26 | IR: assign_designated_init | int assign_designated_init(someStruct*) |
 | misc.c:220:9:223:3 | FieldAddress: {...} | Instruction 'FieldAddress' is missing an expected operand with tag 'Unary' in function '$@'. | misc.c:219:5:219:26 | IR: assign_designated_init | int assign_designated_init(someStruct*) |
+| pointer_to_member.cpp:35:13:35:19 | FieldAddress: x1 | Instruction 'FieldAddress' is missing an expected operand with tag 'Unary' in function '$@'. | pointer_to_member.cpp:32:6:32:14 | IR: pmIsConst | void pmIsConst() |
 | range_analysis.c:368:10:368:21 | Store: ... ? ... : ... | Instruction 'Store' is missing an expected operand with tag 'StoreValue' in function '$@'. | range_analysis.c:355:14:355:27 | IR: test_ternary01 | unsigned int test_ternary01(unsigned int) |
 | range_analysis.c:369:10:369:36 | Store: ... ? ... : ... | Instruction 'Store' is missing an expected operand with tag 'StoreValue' in function '$@'. | range_analysis.c:355:14:355:27 | IR: test_ternary01 | unsigned int test_ternary01(unsigned int) |
 | range_analysis.c:370:10:370:38 | Store: ... ? ... : ... | Instruction 'Store' is missing an expected operand with tag 'StoreValue' in function '$@'. | range_analysis.c:355:14:355:27 | IR: test_ternary01 | unsigned int test_ternary01(unsigned int) |
@@ -65,6 +66,7 @@ instructionWithoutSuccessor
 | ms_try_mix.cpp:48:10:48:13 | CallSideEffect: call to C |
 | ms_try_mix.cpp:51:5:51:11 | ThrowValue: throw ... |
 | ms_try_mix.cpp:53:13:54:3 | NoOp: { ... } |
+| pointer_to_member.cpp:35:11:35:21 | FieldAddress: {...} |
 | static_init_templates.cpp:80:27:80:36 | Convert: (void *)... |
 | static_init_templates.cpp:80:27:80:36 | Convert: (void *)... |
 | static_init_templates.cpp:89:27:89:36 | Convert: (void *)... |
@@ -671,6 +673,7 @@ useNotDominatedByDefinition
 | ms_try_mix.cpp:38:16:38:19 | Operand | Operand 'Operand' is not dominated by its definition in function '$@'. | ms_try_mix.cpp:27:6:27:19 | IR: ms_finally_mix | void ms_finally_mix(int) |
 | ms_try_mix.cpp:41:12:41:15 | Operand | Operand 'Operand' is not dominated by its definition in function '$@'. | ms_try_mix.cpp:27:6:27:19 | IR: ms_finally_mix | void ms_finally_mix(int) |
 | ms_try_mix.cpp:51:5:51:11 | Load | Operand 'Load' is not dominated by its definition in function '$@'. | ms_try_mix.cpp:47:6:47:28 | IR: ms_empty_finally_at_end | void ms_empty_finally_at_end() |
+| pointer_to_member.cpp:35:13:35:19 | Address | Operand 'Address' is not dominated by its definition in function '$@'. | pointer_to_member.cpp:32:6:32:14 | IR: pmIsConst | void pmIsConst() |
 | stmt_expr.cpp:30:20:30:21 | Operand | Operand 'Operand' is not dominated by its definition in function '$@'. | stmt_expr.cpp:21:6:21:6 | IR: g | void stmtexpr::g(int) |
 | stmt_expr.cpp:31:16:31:18 | Load | Operand 'Load' is not dominated by its definition in function '$@'. | stmt_expr.cpp:21:6:21:6 | IR: g | void stmtexpr::g(int) |
 | try_catch.cpp:21:13:21:24 | Address | Operand 'Address' is not dominated by its definition in function '$@'. | try_catch.cpp:19:6:19:23 | IR: throw_from_nonstmt | void throw_from_nonstmt(int) |

--- a/cpp/ql/test/library-tests/syntax-zoo/tellDifferent.expected
+++ b/cpp/ql/test/library-tests/syntax-zoo/tellDifferent.expected
@@ -1,8 +1,3 @@
-| pointer_to_member__pmIsConst | pointer_to_member.cpp:33:3:35:22 | declaration | pointer_to_member.cpp:35:11:35:21 | initializer for pms | Standard edge, only from QL |
-| pointer_to_member__pmIsConst | pointer_to_member.cpp:33:3:35:22 | declaration | pointer_to_member.cpp:36:1:36:1 | return ... | Standard edge, only from extractor |
-| pointer_to_member__pmIsConst | pointer_to_member.cpp:35:11:35:21 | initializer for pms | pointer_to_member.cpp:35:13:35:19 | x1 | Standard edge, only from QL |
-| pointer_to_member__pmIsConst | pointer_to_member.cpp:35:11:35:21 | {...} | pointer_to_member.cpp:36:1:36:1 | return ... | Standard edge, only from QL |
-| pointer_to_member__pmIsConst | pointer_to_member.cpp:35:13:35:19 | x1 | pointer_to_member.cpp:35:11:35:21 | {...} | Standard edge, only from QL |
 | staticlocals__staticlocals_f2 | file://:0:0:0:0 | call to C | staticlocals.cpp:30:1:30:1 | return ... | Standard edge, only from QL |
 | staticlocals__staticlocals_f2 | file://:0:0:0:0 | initializer for c | file://:0:0:0:0 | call to C | Standard edge, only from QL |
 | staticlocals__staticlocals_f2 | staticlocals.cpp:29:5:29:17 | declaration | file://:0:0:0:0 | initializer for c | Standard edge, only from QL |

--- a/cpp/ql/test/library-tests/syntax-zoo/tellDifferent.expected
+++ b/cpp/ql/test/library-tests/syntax-zoo/tellDifferent.expected
@@ -1,3 +1,8 @@
+| pointer_to_member__pmIsConst | pointer_to_member.cpp:33:3:35:22 | declaration | pointer_to_member.cpp:35:11:35:21 | initializer for pms | Standard edge, only from QL |
+| pointer_to_member__pmIsConst | pointer_to_member.cpp:33:3:35:22 | declaration | pointer_to_member.cpp:36:1:36:1 | return ... | Standard edge, only from extractor |
+| pointer_to_member__pmIsConst | pointer_to_member.cpp:35:11:35:21 | initializer for pms | pointer_to_member.cpp:35:13:35:19 | x1 | Standard edge, only from QL |
+| pointer_to_member__pmIsConst | pointer_to_member.cpp:35:11:35:21 | {...} | pointer_to_member.cpp:36:1:36:1 | return ... | Standard edge, only from QL |
+| pointer_to_member__pmIsConst | pointer_to_member.cpp:35:13:35:19 | x1 | pointer_to_member.cpp:35:11:35:21 | {...} | Standard edge, only from QL |
 | staticlocals__staticlocals_f2 | file://:0:0:0:0 | call to C | staticlocals.cpp:30:1:30:1 | return ... | Standard edge, only from QL |
 | staticlocals__staticlocals_f2 | file://:0:0:0:0 | initializer for c | file://:0:0:0:0 | call to C | Standard edge, only from QL |
 | staticlocals__staticlocals_f2 | staticlocals.cpp:29:5:29:17 | declaration | file://:0:0:0:0 | initializer for c | Standard edge, only from QL |

--- a/cpp/ql/test/library-tests/syntax-zoo/unaliased_ssa_sanity.expected
+++ b/cpp/ql/test/library-tests/syntax-zoo/unaliased_ssa_sanity.expected
@@ -29,6 +29,7 @@ instructionWithoutSuccessor
 | ms_try_mix.cpp:11:12:11:15 | CallSideEffect: call to C |
 | ms_try_mix.cpp:28:12:28:15 | CallSideEffect: call to C |
 | ms_try_mix.cpp:48:10:48:13 | CallSideEffect: call to C |
+| pointer_to_member.cpp:35:11:35:21 | FieldAddress: {...} |
 | stmt_expr.cpp:27:5:27:15 | Store: ... = ... |
 | vla.c:5:9:5:14 | Uninitialized: definition of matrix |
 | vla.c:11:6:11:16 | UnmodeledDefinition: vla_typedef |


### PR DESCRIPTION
This fixes some discrepancies between the QL CFG and the extractor-generated CFG. The new `PointerToFieldLiteral` is a bit fragile, but extractor work is needed for better modelling -- see CPP-437.