### PR TITLE
Docs/QL lexer: Require whitespace character after annotation

### DIFF
--- a/docs/language/global-sphinx-files/qllexer.py
+++ b/docs/language/global-sphinx-files/qllexer.py
@@ -35,7 +35,7 @@ class QLLexer(RegexLexer):
             # Keywords
             (r'\b(boolean|date|float|int|string)\b', Keyword.Type),
             (r'\b(abstract|cached|deprecated|external|final|library|override|private|query'
-             r'|(pragma|language|bindingset)\[\w*(,\s*\w*)*\])', 
+             r'|(pragma|language|bindingset)\[\w*(,\s*\w*)*\])\s', 
              Keyword.Reserved),
             (words((
                 'and', 'any', 'as', 'asc', 'avg', 'by', 'class','concat', 'count',


### PR DESCRIPTION
Minor bug in the QL lexer for the Sphinx projects: it highlighted annotation keywords that appeared in certain other contexts, for example in the import statement [in this query](https://help.semmle.com/QL/learn-ql/writing-queries/select-statement.html#basic-select-statement), where ``external`` is definitely not an annotation. 

This should be resolved by only highlighting annotation keywords when they are followed by a whitespace character. (See preview [here](http://docteam.internal.semmle.com/shati/learn-ql/writing-queries/select-statement.html#basic-select-statement).)

