### PR TITLE
C# IR: Fix for init

### DIFF
--- a/csharp/ql/src/semmle/code/csharp/ir/implementation/raw/internal/TranslatedStmt.qll
+++ b/csharp/ql/src/semmle/code/csharp/ir/implementation/raw/internal/TranslatedStmt.qll
@@ -660,8 +660,10 @@ class TranslatedForStmt extends TranslatedLoop {
     id = initializersNo() + updatesNo() + 1 and result = this.getBody()
   }
 
-  private TranslatedLocalDeclaration getDeclAndInit(int index) {
-    result = getTranslatedLocalDeclaration(stmt.getInitializer(index))
+  private TranslatedElement getDeclAndInit(int index) {
+    if stmt.getInitializer(index) instanceof LocalVariableDeclExpr
+    then result = getTranslatedLocalDeclaration(stmt.getInitializer(index))
+    else result = getTranslatedExpr(stmt.getInitializer(index))
   }
 
   private predicate hasInitialization() { exists(stmt.getAnInitializer()) }

--- a/csharp/ql/test/library-tests/ir/ir/raw_ir.expected
+++ b/csharp/ql/test/library-tests/ir/ir/raw_ir.expected
@@ -1089,11 +1089,13 @@ stmts.cs:
 
 #   76|   Block 4
 #   76|     r4_0(glval<Int32>) = VariableAddress[a] : 
-#   76|     r4_1(Int32)        = Constant[0]        : 
-#   76|     mu4_2(Int32)       = Store              : &:r4_0, r4_1
-#   76|     r4_3(glval<Int32>) = VariableAddress[b] : 
-#   76|     r4_4(Int32)        = Constant[10]       : 
-#   76|     mu4_5(Int32)       = Store              : &:r4_3, r4_4
+#   76|     mu4_1(Int32)       = Uninitialized[a]   : &:r4_0
+#   76|     r4_2(glval<Int32>) = VariableAddress[b] : 
+#   76|     r4_3(Int32)        = Constant[10]       : 
+#   76|     mu4_4(Int32)       = Store              : &:r4_2, r4_3
+#   77|     r4_5(Int32)        = Constant[0]        : 
+#   77|     r4_6(glval<Int32>) = VariableAddress[a] : 
+#   77|     mu4_7(Int32)       = Store              : &:r4_6, r4_5
 #-----|   Goto -> Block 5
 
 #   77|   Block 5

--- a/csharp/ql/test/library-tests/ir/ir/stmts.cs
+++ b/csharp/ql/test/library-tests/ir/ir/stmts.cs
@@ -73,8 +73,8 @@ public class test_stmts
             x = x - 1; 
         }
         
-        int a = 0, b = 10;
-        for (; a < b; ) 
+        int a, b = 10;
+        for (a = 0; a < b; ) 
         {
             a++;
         }


### PR DESCRIPTION
This PR fixes a bug where simple assignments (not declarations) in a `for` stmt would be ignored during the translation stage.