### PR TITLE
C# extractor: Handle nameof(A.B) where A.B is a qualified namespace

### DIFF
--- a/csharp/extractor/Semmle.Extraction.CSharp/Entities/Expressions/MemberAccess.cs
+++ b/csharp/extractor/Semmle.Extraction.CSharp/Entities/Expressions/MemberAccess.cs
@@ -92,6 +92,9 @@ namespace Semmle.Extraction.CSharp.Entities.Expressions
                 case SymbolKind.Event:
                     kind = ExprKind.EVENT_ACCESS;
                     break;
+                case SymbolKind.Namespace:
+                    kind = ExprKind.NAMESPACE_ACCESS;
+                    break;
                 default:
                     info.Context.ModelError(info.Node, "Unhandled symbol for member access");
                     kind = ExprKind.UNKNOWN;

--- a/csharp/ql/test/library-tests/regressions/NameOf.expected
+++ b/csharp/ql/test/library-tests/regressions/NameOf.expected
@@ -1,3 +1,4 @@
 | Program.cs:62:17:62:35 | nameof(...) | Program.cs:62:24:62:34 | access to method MethodGroup |
 | Program.cs:63:13:63:50 | nameof(...) | Program.cs:63:20:63:49 | access to method MethodGroup |
 | Program.cs:169:16:169:29 | nameof(...) | Program.cs:169:23:169:28 | access to namespace System |
+| Program.cs:169:33:169:62 | nameof(...) | Program.cs:169:40:169:61 | access to namespace Tasks |

--- a/csharp/ql/test/library-tests/regressions/Program.cs
+++ b/csharp/ql/test/library-tests/regressions/Program.cs
@@ -166,7 +166,7 @@ unsafe class ArrayTypesTest
 
 class NameofNamespace
 {
-    string s = nameof(System);
+    string s = nameof(System) + nameof(System.Threading.Tasks);
 }
 
 class UsingDiscard


### PR DESCRIPTION
As a followup to https://github.com/Semmle/ql/pull/1555, handle `nameof` qualified namespaces.

No change note needed as it's a fix of unreleased functionality.