### PR TITLE
C++: Update test for fix to namespace members

### DIFF
--- a/cpp/ql/test/library-tests/namespaces/same_name/decls.expected
+++ b/cpp/ql/test/library-tests/namespaces/same_name/decls.expected
@@ -7,5 +7,6 @@
 | file://:0:0:0:0 | (global namespace) | file://:0:0:0:0 | p#0 |
 | file://:0:0:0:0 | (global namespace) | file://:0:0:0:0 | p#0 |
 | file://:0:0:0:0 | (global namespace) | file://:0:0:0:0 | reg_save_area |
-| same_name.cpp:4:11:4:21 | namespace_a | same_name.cpp:2:11:2:11 | c |
+| file://:0:0:0:0 | (global namespace) | same_name.cpp:2:11:2:11 | c |
 | same_name.cpp:4:11:4:21 | namespace_a | same_name.cpp:6:12:6:12 | c |
+| same_name.cpp:9:11:9:21 | namespace_b | same_name.cpp:11:12:11:12 | c |

--- a/cpp/ql/test/library-tests/namespaces/same_name/same_name.cpp
+++ b/cpp/ql/test/library-tests/namespaces/same_name/same_name.cpp
@@ -8,9 +8,5 @@ namespace namespace_a
 
 namespace namespace_b
 {
-	//const int c = 1;
-	//
-	// this example is causing a DBCheck failure along the lines of:
-	// 
-	// [INVALID_KEY] Relation namespacembrs((@namespace parentid, unique @namespacembr memberid)): Value 132 of key field memberid occurs in several tuples. Two such tuples are: (134,132) and (144,132)
+	const int c = 1;
 }


### PR DESCRIPTION
Generation of IDs for namespace members has been fixed to generate
unique IDs for variables of the same name but in different namespaces.

Update the same_name test to validate this.