### PR TITLE
JavaScript: Fix performance regression in `IncorrectSuffixCheck`.

### DIFF
--- a/javascript/ql/src/Security/CWE-020/IncorrectSuffixCheck.ql
+++ b/javascript/ql/src/Security/CWE-020/IncorrectSuffixCheck.ql
@@ -31,16 +31,25 @@ class IndexOfCall extends DataFlow::MethodCallNode {
   }
 
   /**
+   * Holds if `recv` is the local source of the receiver of this call, and `m`
+   * is the name of the invoked method.
+   */
+  private predicate receiverAndMethodName(DataFlow::Node recv, string m) {
+    this.getReceiver().getALocalSource() = recv and
+    this.getMethodName() = m
+  }
+
+  /**
    * Gets an `indexOf` call with the same receiver, argument, and method name, including this call itself.
    */
   IndexOfCall getAnEquivalentIndexOfCall() {
-    result.getReceiver().getALocalSource() = this.getReceiver().getALocalSource() and
-    (
+    exists(DataFlow::Node recv, string m |
+      this.receiverAndMethodName(recv, m) and result.receiverAndMethodName(recv, m)
+    |
       result.getArgument(0).getALocalSource() = this.getArgument(0).getALocalSource()
       or
       result.getArgument(0).getStringValue() = this.getArgument(0).getStringValue()
-    ) and
-    result.getMethodName() = this.getMethodName()
+    )
   }
 
   /**


### PR DESCRIPTION
Originally introduced in https://github.com/Semmle/ql/pull/1894. [Evaluation](https://git.semmle.com/max/dist-compare-reports/blob/master/js/fix-incorrect-suffix-check-performance/report.md) (internal link) shows that this fixes the (single) timeout and improves performance on a few other projects.