### PR TITLE
C#: Include runtime target in TTransitiveCaptureCall 

### DIFF
--- a/csharp/ql/src/semmle/code/csharp/dataflow/internal/DataFlowDispatch.qll
+++ b/csharp/ql/src/semmle/code/csharp/dataflow/internal/DataFlowDispatch.qll
@@ -97,8 +97,8 @@ private module Cached {
     TImplicitDelegateCall(ControlFlow::Nodes::ElementNode cfn, DelegateArgumentToLibraryCallable arg) {
       cfn.getElement() = arg
     } or
-    TTransitiveCapturedCall(ControlFlow::Nodes::ElementNode cfn) {
-      transitiveCapturedCallTarget(cfn, _)
+    TTransitiveCapturedCall(ControlFlow::Nodes::ElementNode cfn, Callable target) {
+      transitiveCapturedCallTarget(cfn, target)
     } or
     TCilCall(CIL::Call call) {
       // No need to include calls that are compiled from source
@@ -418,10 +418,11 @@ class ImplicitDelegateDataFlowCall extends DelegateDataFlowCall, TImplicitDelega
  */
 class TransitiveCapturedDataFlowCall extends DataFlowCall, TTransitiveCapturedCall {
   private ControlFlow::Nodes::ElementNode cfn;
+  private Callable target;
 
-  TransitiveCapturedDataFlowCall() { this = TTransitiveCapturedCall(cfn) }
+  TransitiveCapturedDataFlowCall() { this = TTransitiveCapturedCall(cfn, target) }
 
-  override Callable getARuntimeTarget() { transitiveCapturedCallTarget(cfn, result) }
+  override Callable getARuntimeTarget() { result = target }
 
   override ControlFlow::Nodes::ElementNode getControlFlowNode() { result = cfn }
 

--- a/csharp/ql/src/semmle/code/csharp/dataflow/internal/DataFlowPrivate.qll
+++ b/csharp/ql/src/semmle/code/csharp/dataflow/internal/DataFlowPrivate.qll
@@ -953,7 +953,7 @@ private module OutNodes {
         additionalCalls = false and
         call.(ImplicitDelegateDataFlowCall).isArgumentOf(csharpCall(_, cfn), _)
         or
-        additionalCalls = true and call = TTransitiveCapturedCall(cfn, _)
+        additionalCalls = true and call = TTransitiveCapturedCall(cfn, n.getEnclosingCallable())
       )
     }
 

--- a/csharp/ql/src/semmle/code/csharp/dataflow/internal/DataFlowPrivate.qll
+++ b/csharp/ql/src/semmle/code/csharp/dataflow/internal/DataFlowPrivate.qll
@@ -953,7 +953,7 @@ private module OutNodes {
         additionalCalls = false and
         call.(ImplicitDelegateDataFlowCall).isArgumentOf(csharpCall(_, cfn), _)
         or
-        additionalCalls = true and call = TTransitiveCapturedCall(cfn)
+        additionalCalls = true and call = TTransitiveCapturedCall(cfn, _)
       )
     }
 

--- a/csharp/ql/test/library-tests/dataflow/global/Capture.cs
+++ b/csharp/ql/test/library-tests/dataflow/global/Capture.cs
@@ -47,7 +47,7 @@ class Capture
             };
         };
         CaptureIn2NotCalled();
-/*        void CaptureTest(string nonSink0, string sink39)
+        void CaptureTest(string nonSink0, string sink39)
         {
             RunAction(() =>       // Check each lambda captures the correct arguments
             {
@@ -58,7 +58,7 @@ class Capture
                 });
             });
         }
-        CaptureTest("not tainted", tainted);*/
+        CaptureTest("not tainted", tainted);
     }
 
     void Out()
@@ -187,8 +187,8 @@ class Capture
 
     static void Check<T>(T x) { }
 
-/*    static void RunAction(Action a)
+    static void RunAction(Action a)
     {
         a.Invoke();
-    }*/
+    }
 }

--- a/csharp/ql/test/library-tests/dataflow/global/Capture.cs
+++ b/csharp/ql/test/library-tests/dataflow/global/Capture.cs
@@ -47,6 +47,18 @@ class Capture
             };
         };
         CaptureIn2NotCalled();
+/*        void CaptureTest(string nonSink0, string sink39)
+        {
+            RunAction(() =>       // Check each lambda captures the correct arguments
+            {
+                Check(nonSink0);
+                RunAction(() =>
+                {
+                    Check(sink39);
+                });
+            });
+        }
+        CaptureTest("not tainted", tainted);*/
     }
 
     void Out()
@@ -174,4 +186,9 @@ class Capture
     }
 
     static void Check<T>(T x) { }
+
+/*    static void RunAction(Action a)
+    {
+        a.Invoke();
+    }*/
 }

--- a/csharp/ql/test/library-tests/dataflow/global/Capture.cs
+++ b/csharp/ql/test/library-tests/dataflow/global/Capture.cs
@@ -108,18 +108,18 @@ class Capture
         };
         CaptureOut2NotCalled();
         Check(nonSink0);
-        /*string sink40 = "";
+        string sink40 = "";
         void CaptureOutMultipleLambdas()
         {
             RunAction(() => {
                 sink40 = "taint source";
             });
             RunAction(() => {
-                sink40 = "not tainted";
+                nonSink0 = "not tainted";
             });
         };
         CaptureOutMultipleLambdas();
-        Check(sink40);*/
+        Check(sink40); Check(nonSink0);
     }
 
     void Through(string tainted)

--- a/csharp/ql/test/library-tests/dataflow/global/Capture.cs
+++ b/csharp/ql/test/library-tests/dataflow/global/Capture.cs
@@ -108,6 +108,18 @@ class Capture
         };
         CaptureOut2NotCalled();
         Check(nonSink0);
+        /*string sink40 = "";
+        void CaptureOutMultipleLambdas()
+        {
+            RunAction(() => {
+                sink40 = "taint source";
+            });
+            RunAction(() => {
+                sink40 = "not tainted";
+            });
+        };
+        CaptureOutMultipleLambdas();
+        Check(sink40);*/
     }
 
     void Through(string tainted)

--- a/csharp/ql/test/library-tests/dataflow/global/DataFlow.expected
+++ b/csharp/ql/test/library-tests/dataflow/global/DataFlow.expected
@@ -5,12 +5,12 @@
 | Capture.cs:72:15:72:20 | access to local variable sink30 |
 | Capture.cs:84:15:84:20 | access to local variable sink31 |
 | Capture.cs:93:15:93:20 | access to local variable sink32 |
-| Capture.cs:121:15:121:20 | access to local variable sink33 |
-| Capture.cs:133:15:133:20 | access to local variable sink34 |
-| Capture.cs:142:15:142:20 | access to local variable sink35 |
-| Capture.cs:149:15:149:20 | access to local variable sink36 |
-| Capture.cs:157:15:157:20 | access to local variable sink37 |
-| Capture.cs:183:15:183:20 | access to local variable sink38 |
+| Capture.cs:133:15:133:20 | access to local variable sink33 |
+| Capture.cs:145:15:145:20 | access to local variable sink34 |
+| Capture.cs:154:15:154:20 | access to local variable sink35 |
+| Capture.cs:161:15:161:20 | access to local variable sink36 |
+| Capture.cs:169:15:169:20 | access to local variable sink37 |
+| Capture.cs:195:15:195:20 | access to local variable sink38 |
 | GlobalDataFlow.cs:18:15:18:29 | access to field SinkField0 |
 | GlobalDataFlow.cs:26:15:26:32 | access to property SinkProperty0 |
 | GlobalDataFlow.cs:44:50:44:59 | access to parameter sinkParam2 |

--- a/csharp/ql/test/library-tests/dataflow/global/DataFlow.expected
+++ b/csharp/ql/test/library-tests/dataflow/global/DataFlow.expected
@@ -5,6 +5,7 @@
 | Capture.cs:72:15:72:20 | access to local variable sink30 |
 | Capture.cs:84:15:84:20 | access to local variable sink31 |
 | Capture.cs:93:15:93:20 | access to local variable sink32 |
+| Capture.cs:122:15:122:20 | access to local variable sink40 |
 | Capture.cs:133:15:133:20 | access to local variable sink33 |
 | Capture.cs:145:15:145:20 | access to local variable sink34 |
 | Capture.cs:154:15:154:20 | access to local variable sink35 |

--- a/csharp/ql/test/library-tests/dataflow/global/DataFlow.expected
+++ b/csharp/ql/test/library-tests/dataflow/global/DataFlow.expected
@@ -1,6 +1,7 @@
 | Capture.cs:12:19:12:24 | access to local variable sink27 |
 | Capture.cs:21:23:21:28 | access to local variable sink28 |
 | Capture.cs:30:19:30:24 | access to local variable sink29 |
+| Capture.cs:57:27:57:32 | access to parameter sink39 |
 | Capture.cs:72:15:72:20 | access to local variable sink30 |
 | Capture.cs:84:15:84:20 | access to local variable sink31 |
 | Capture.cs:93:15:93:20 | access to local variable sink32 |

--- a/csharp/ql/test/library-tests/dataflow/global/DataFlow.expected
+++ b/csharp/ql/test/library-tests/dataflow/global/DataFlow.expected
@@ -1,15 +1,15 @@
 | Capture.cs:12:19:12:24 | access to local variable sink27 |
 | Capture.cs:21:23:21:28 | access to local variable sink28 |
 | Capture.cs:30:19:30:24 | access to local variable sink29 |
-| Capture.cs:60:15:60:20 | access to local variable sink30 |
-| Capture.cs:72:15:72:20 | access to local variable sink31 |
-| Capture.cs:81:15:81:20 | access to local variable sink32 |
-| Capture.cs:109:15:109:20 | access to local variable sink33 |
-| Capture.cs:121:15:121:20 | access to local variable sink34 |
-| Capture.cs:130:15:130:20 | access to local variable sink35 |
-| Capture.cs:137:15:137:20 | access to local variable sink36 |
-| Capture.cs:145:15:145:20 | access to local variable sink37 |
-| Capture.cs:171:15:171:20 | access to local variable sink38 |
+| Capture.cs:72:15:72:20 | access to local variable sink30 |
+| Capture.cs:84:15:84:20 | access to local variable sink31 |
+| Capture.cs:93:15:93:20 | access to local variable sink32 |
+| Capture.cs:121:15:121:20 | access to local variable sink33 |
+| Capture.cs:133:15:133:20 | access to local variable sink34 |
+| Capture.cs:142:15:142:20 | access to local variable sink35 |
+| Capture.cs:149:15:149:20 | access to local variable sink36 |
+| Capture.cs:157:15:157:20 | access to local variable sink37 |
+| Capture.cs:183:15:183:20 | access to local variable sink38 |
 | GlobalDataFlow.cs:18:15:18:29 | access to field SinkField0 |
 | GlobalDataFlow.cs:26:15:26:32 | access to property SinkProperty0 |
 | GlobalDataFlow.cs:44:50:44:59 | access to parameter sinkParam2 |

--- a/csharp/ql/test/library-tests/dataflow/global/DataFlowEdges.expected
+++ b/csharp/ql/test/library-tests/dataflow/global/DataFlowEdges.expected
@@ -175,416 +175,416 @@
 | Capture.cs:46:23:46:30 | access to local variable nonSink0 | Capture.cs:46:23:46:30 | access to local variable nonSink0 |
 | Capture.cs:49:9:49:27 | access to local function CaptureIn2NotCalled | Capture.cs:49:9:49:27 | access to local function CaptureIn2NotCalled |
 | Capture.cs:49:9:49:29 | call to local function CaptureIn2NotCalled | Capture.cs:49:9:49:29 | call to local function CaptureIn2NotCalled |
-| Capture.cs:52:10:52:12 | this | Capture.cs:52:10:52:12 | this |
-| Capture.cs:54:16:54:26 | SSA def(sink30) | Capture.cs:54:16:54:26 | SSA def(sink30) |
-| Capture.cs:54:16:54:26 | String sink30 = ... | Capture.cs:54:16:54:26 | String sink30 = ... |
-| Capture.cs:54:25:54:26 | "" | Capture.cs:54:16:54:26 | SSA def(sink30) |
-| Capture.cs:54:25:54:26 | "" | Capture.cs:54:16:54:26 | SSA def(sink30) |
-| Capture.cs:54:25:54:26 | "" | Capture.cs:54:25:54:26 | "" |
-| Capture.cs:57:13:57:35 | ... = ... | Capture.cs:57:13:57:35 | ... = ... |
-| Capture.cs:57:13:57:35 | SSA def(sink30) | Capture.cs:57:13:57:35 | SSA def(sink30) |
-| Capture.cs:57:13:57:35 | SSA def(sink30) | Capture.cs:59:9:59:21 | SSA call def(sink30) |
-| Capture.cs:57:13:57:35 | SSA def(sink30) | Capture.cs:59:9:59:21 | SSA call def(sink30) |
-| Capture.cs:57:22:57:35 | "taint source" | Capture.cs:57:13:57:35 | SSA def(sink30) |
-| Capture.cs:57:22:57:35 | "taint source" | Capture.cs:57:13:57:35 | SSA def(sink30) |
-| Capture.cs:57:22:57:35 | "taint source" | Capture.cs:57:22:57:35 | "taint source" |
-| Capture.cs:59:9:59:19 | access to local function CaptureOut1 | Capture.cs:59:9:59:19 | access to local function CaptureOut1 |
-| Capture.cs:59:9:59:21 | SSA call def(sink30) | Capture.cs:59:9:59:21 | SSA call def(sink30) |
-| Capture.cs:59:9:59:21 | SSA call def(sink30) | Capture.cs:60:15:60:20 | access to local variable sink30 |
-| Capture.cs:59:9:59:21 | SSA call def(sink30) | Capture.cs:60:15:60:20 | access to local variable sink30 |
-| Capture.cs:59:9:59:21 | call to local function CaptureOut1 | Capture.cs:59:9:59:21 | call to local function CaptureOut1 |
-| Capture.cs:60:9:60:21 | call to method Check | Capture.cs:60:9:60:21 | call to method Check |
-| Capture.cs:60:15:60:20 | access to local variable sink30 | Capture.cs:60:15:60:20 | access to local variable sink30 |
-| Capture.cs:62:16:62:26 | SSA def(sink31) | Capture.cs:62:16:62:26 | SSA def(sink31) |
-| Capture.cs:62:16:62:26 | String sink31 = ... | Capture.cs:62:16:62:26 | String sink31 = ... |
-| Capture.cs:62:25:62:26 | "" | Capture.cs:62:16:62:26 | SSA def(sink31) |
-| Capture.cs:62:25:62:26 | "" | Capture.cs:62:16:62:26 | SSA def(sink31) |
-| Capture.cs:62:25:62:26 | "" | Capture.cs:62:25:62:26 | "" |
-| Capture.cs:67:17:67:39 | ... = ... | Capture.cs:67:17:67:39 | ... = ... |
-| Capture.cs:67:17:67:39 | SSA def(sink31) | Capture.cs:67:17:67:39 | SSA def(sink31) |
-| Capture.cs:67:17:67:39 | SSA def(sink31) | Capture.cs:71:9:71:21 | SSA call def(sink31) |
-| Capture.cs:67:17:67:39 | SSA def(sink31) | Capture.cs:71:9:71:21 | SSA call def(sink31) |
-| Capture.cs:67:26:67:39 | "taint source" | Capture.cs:67:17:67:39 | SSA def(sink31) |
-| Capture.cs:67:26:67:39 | "taint source" | Capture.cs:67:17:67:39 | SSA def(sink31) |
-| Capture.cs:67:26:67:39 | "taint source" | Capture.cs:67:26:67:39 | "taint source" |
-| Capture.cs:69:13:69:13 | access to local function M | Capture.cs:69:13:69:13 | access to local function M |
-| Capture.cs:69:13:69:15 | call to local function M | Capture.cs:69:13:69:15 | call to local function M |
-| Capture.cs:71:9:71:19 | access to local function CaptureOut2 | Capture.cs:71:9:71:19 | access to local function CaptureOut2 |
-| Capture.cs:71:9:71:21 | SSA call def(sink31) | Capture.cs:71:9:71:21 | SSA call def(sink31) |
-| Capture.cs:71:9:71:21 | SSA call def(sink31) | Capture.cs:72:15:72:20 | access to local variable sink31 |
-| Capture.cs:71:9:71:21 | SSA call def(sink31) | Capture.cs:72:15:72:20 | access to local variable sink31 |
-| Capture.cs:71:9:71:21 | call to local function CaptureOut2 | Capture.cs:71:9:71:21 | call to local function CaptureOut2 |
+| Capture.cs:64:10:64:12 | this | Capture.cs:64:10:64:12 | this |
+| Capture.cs:66:16:66:26 | SSA def(sink30) | Capture.cs:66:16:66:26 | SSA def(sink30) |
+| Capture.cs:66:16:66:26 | String sink30 = ... | Capture.cs:66:16:66:26 | String sink30 = ... |
+| Capture.cs:66:25:66:26 | "" | Capture.cs:66:16:66:26 | SSA def(sink30) |
+| Capture.cs:66:25:66:26 | "" | Capture.cs:66:16:66:26 | SSA def(sink30) |
+| Capture.cs:66:25:66:26 | "" | Capture.cs:66:25:66:26 | "" |
+| Capture.cs:69:13:69:35 | ... = ... | Capture.cs:69:13:69:35 | ... = ... |
+| Capture.cs:69:13:69:35 | SSA def(sink30) | Capture.cs:69:13:69:35 | SSA def(sink30) |
+| Capture.cs:69:13:69:35 | SSA def(sink30) | Capture.cs:71:9:71:21 | SSA call def(sink30) |
+| Capture.cs:69:13:69:35 | SSA def(sink30) | Capture.cs:71:9:71:21 | SSA call def(sink30) |
+| Capture.cs:69:22:69:35 | "taint source" | Capture.cs:69:13:69:35 | SSA def(sink30) |
+| Capture.cs:69:22:69:35 | "taint source" | Capture.cs:69:13:69:35 | SSA def(sink30) |
+| Capture.cs:69:22:69:35 | "taint source" | Capture.cs:69:22:69:35 | "taint source" |
+| Capture.cs:71:9:71:19 | access to local function CaptureOut1 | Capture.cs:71:9:71:19 | access to local function CaptureOut1 |
+| Capture.cs:71:9:71:21 | SSA call def(sink30) | Capture.cs:71:9:71:21 | SSA call def(sink30) |
+| Capture.cs:71:9:71:21 | SSA call def(sink30) | Capture.cs:72:15:72:20 | access to local variable sink30 |
+| Capture.cs:71:9:71:21 | SSA call def(sink30) | Capture.cs:72:15:72:20 | access to local variable sink30 |
+| Capture.cs:71:9:71:21 | call to local function CaptureOut1 | Capture.cs:71:9:71:21 | call to local function CaptureOut1 |
 | Capture.cs:72:9:72:21 | call to method Check | Capture.cs:72:9:72:21 | call to method Check |
-| Capture.cs:72:15:72:20 | access to local variable sink31 | Capture.cs:72:15:72:20 | access to local variable sink31 |
-| Capture.cs:74:16:74:26 | SSA def(sink32) | Capture.cs:74:16:74:26 | SSA def(sink32) |
-| Capture.cs:74:16:74:26 | String sink32 = ... | Capture.cs:74:16:74:26 | String sink32 = ... |
-| Capture.cs:74:25:74:26 | "" | Capture.cs:74:16:74:26 | SSA def(sink32) |
-| Capture.cs:74:25:74:26 | "" | Capture.cs:74:16:74:26 | SSA def(sink32) |
+| Capture.cs:72:15:72:20 | access to local variable sink30 | Capture.cs:72:15:72:20 | access to local variable sink30 |
+| Capture.cs:74:16:74:26 | SSA def(sink31) | Capture.cs:74:16:74:26 | SSA def(sink31) |
+| Capture.cs:74:16:74:26 | String sink31 = ... | Capture.cs:74:16:74:26 | String sink31 = ... |
+| Capture.cs:74:25:74:26 | "" | Capture.cs:74:16:74:26 | SSA def(sink31) |
+| Capture.cs:74:25:74:26 | "" | Capture.cs:74:16:74:26 | SSA def(sink31) |
 | Capture.cs:74:25:74:26 | "" | Capture.cs:74:25:74:26 | "" |
-| Capture.cs:75:30:79:9 | Func<String,String> captureOut3 = ... | Capture.cs:75:30:79:9 | Func<String,String> captureOut3 = ... |
-| Capture.cs:75:30:79:9 | SSA def(captureOut3) | Capture.cs:75:30:79:9 | SSA def(captureOut3) |
-| Capture.cs:75:30:79:9 | SSA def(captureOut3) | Capture.cs:80:30:80:40 | access to local variable captureOut3 |
-| Capture.cs:75:30:79:9 | SSA def(captureOut3) | Capture.cs:80:30:80:40 | access to local variable captureOut3 |
-| Capture.cs:75:44:75:46 | arg | Capture.cs:75:44:75:46 | arg |
-| Capture.cs:75:44:75:46 | arg | Capture.cs:75:44:75:46 | arg |
-| Capture.cs:75:44:75:46 | arg | Capture.cs:78:20:78:22 | access to parameter arg |
-| Capture.cs:75:44:75:46 | arg | Capture.cs:78:20:78:22 | access to parameter arg |
-| Capture.cs:75:44:79:9 | (...) => ... | Capture.cs:75:30:79:9 | SSA def(captureOut3) |
-| Capture.cs:75:44:79:9 | (...) => ... | Capture.cs:75:30:79:9 | SSA def(captureOut3) |
-| Capture.cs:75:44:79:9 | (...) => ... | Capture.cs:75:44:79:9 | (...) => ... |
-| Capture.cs:75:44:79:9 | (...) => ... | Capture.cs:80:30:80:40 | access to local variable captureOut3 |
-| Capture.cs:75:44:79:9 | (...) => ... | Capture.cs:80:30:80:40 | access to local variable captureOut3 |
-| Capture.cs:77:13:77:35 | ... = ... | Capture.cs:77:13:77:35 | ... = ... |
-| Capture.cs:77:13:77:35 | SSA def(sink32) | Capture.cs:77:13:77:35 | SSA def(sink32) |
-| Capture.cs:77:13:77:35 | SSA def(sink32) | Capture.cs:80:9:80:41 | SSA call def(sink32) |
-| Capture.cs:77:13:77:35 | SSA def(sink32) | Capture.cs:80:9:80:41 | SSA call def(sink32) |
-| Capture.cs:77:22:77:35 | "taint source" | Capture.cs:77:13:77:35 | SSA def(sink32) |
-| Capture.cs:77:22:77:35 | "taint source" | Capture.cs:77:13:77:35 | SSA def(sink32) |
-| Capture.cs:77:22:77:35 | "taint source" | Capture.cs:77:22:77:35 | "taint source" |
-| Capture.cs:78:20:78:22 | access to parameter arg | Capture.cs:78:20:78:22 | access to parameter arg |
-| Capture.cs:78:20:78:22 | access to parameter arg | Capture.cs:80:30:80:40 | [output] access to local variable captureOut3 |
-| Capture.cs:78:20:78:22 | access to parameter arg | Capture.cs:80:30:80:40 | [output] access to local variable captureOut3 |
-| Capture.cs:80:9:80:21 | array creation of type String[] | Capture.cs:75:44:75:46 | arg |
-| Capture.cs:80:9:80:21 | array creation of type String[] | Capture.cs:75:44:75:46 | arg |
-| Capture.cs:80:9:80:21 | array creation of type String[] | Capture.cs:80:9:80:21 | array creation of type String[] |
-| Capture.cs:80:9:80:41 | SSA call def(sink32) | Capture.cs:80:9:80:41 | SSA call def(sink32) |
-| Capture.cs:80:9:80:41 | SSA call def(sink32) | Capture.cs:81:15:81:20 | access to local variable sink32 |
-| Capture.cs:80:9:80:41 | SSA call def(sink32) | Capture.cs:81:15:81:20 | access to local variable sink32 |
-| Capture.cs:80:9:80:41 | call to method Select | Capture.cs:80:9:80:41 | call to method Select |
-| Capture.cs:80:9:80:51 | call to method ToArray | Capture.cs:80:9:80:51 | call to method ToArray |
-| Capture.cs:80:15:80:21 | { ..., ... } | Capture.cs:80:15:80:21 | { ..., ... } |
-| Capture.cs:80:17:80:19 | " " | Capture.cs:80:17:80:19 | " " |
-| Capture.cs:80:30:80:40 | [output] access to local variable captureOut3 | Capture.cs:80:30:80:40 | [output] access to local variable captureOut3 |
-| Capture.cs:80:30:80:40 | access to local variable captureOut3 | Capture.cs:80:30:80:40 | access to local variable captureOut3 |
-| Capture.cs:81:9:81:21 | call to method Check | Capture.cs:81:9:81:21 | call to method Check |
-| Capture.cs:81:15:81:20 | access to local variable sink32 | Capture.cs:81:15:81:20 | access to local variable sink32 |
-| Capture.cs:83:16:83:28 | SSA def(nonSink0) | Capture.cs:83:16:83:28 | SSA def(nonSink0) |
-| Capture.cs:83:16:83:28 | SSA def(nonSink0) | Capture.cs:88:15:88:22 | access to local variable nonSink0 |
-| Capture.cs:83:16:83:28 | SSA def(nonSink0) | Capture.cs:88:15:88:22 | access to local variable nonSink0 |
-| Capture.cs:83:16:83:28 | SSA def(nonSink0) | Capture.cs:98:15:98:22 | access to local variable nonSink0 |
-| Capture.cs:83:16:83:28 | SSA def(nonSink0) | Capture.cs:98:15:98:22 | access to local variable nonSink0 |
-| Capture.cs:83:16:83:28 | String nonSink0 = ... | Capture.cs:83:16:83:28 | String nonSink0 = ... |
-| Capture.cs:83:27:83:28 | "" | Capture.cs:83:16:83:28 | SSA def(nonSink0) |
-| Capture.cs:83:27:83:28 | "" | Capture.cs:83:16:83:28 | SSA def(nonSink0) |
-| Capture.cs:83:27:83:28 | "" | Capture.cs:83:27:83:28 | "" |
-| Capture.cs:83:27:83:28 | "" | Capture.cs:88:15:88:22 | access to local variable nonSink0 |
-| Capture.cs:83:27:83:28 | "" | Capture.cs:88:15:88:22 | access to local variable nonSink0 |
-| Capture.cs:83:27:83:28 | "" | Capture.cs:98:15:98:22 | access to local variable nonSink0 |
-| Capture.cs:83:27:83:28 | "" | Capture.cs:98:15:98:22 | access to local variable nonSink0 |
-| Capture.cs:86:13:86:37 | ... = ... | Capture.cs:86:13:86:37 | ... = ... |
-| Capture.cs:86:24:86:37 | "taint source" | Capture.cs:86:24:86:37 | "taint source" |
-| Capture.cs:88:9:88:23 | call to method Check | Capture.cs:88:9:88:23 | call to method Check |
-| Capture.cs:88:15:88:22 | access to local variable nonSink0 | Capture.cs:88:15:88:22 | access to local variable nonSink0 |
-| Capture.cs:88:15:88:22 | access to local variable nonSink0 | Capture.cs:98:15:98:22 | access to local variable nonSink0 |
-| Capture.cs:88:15:88:22 | access to local variable nonSink0 | Capture.cs:98:15:98:22 | access to local variable nonSink0 |
-| Capture.cs:94:17:94:41 | ... = ... | Capture.cs:94:17:94:41 | ... = ... |
-| Capture.cs:94:28:94:41 | "taint source" | Capture.cs:94:28:94:41 | "taint source" |
-| Capture.cs:97:9:97:28 | access to local function CaptureOut2NotCalled | Capture.cs:97:9:97:28 | access to local function CaptureOut2NotCalled |
-| Capture.cs:97:9:97:30 | call to local function CaptureOut2NotCalled | Capture.cs:97:9:97:30 | call to local function CaptureOut2NotCalled |
-| Capture.cs:98:9:98:23 | call to method Check | Capture.cs:98:9:98:23 | call to method Check |
-| Capture.cs:98:15:98:22 | access to local variable nonSink0 | Capture.cs:98:15:98:22 | access to local variable nonSink0 |
-| Capture.cs:101:10:101:16 | this | Capture.cs:101:10:101:16 | this |
-| Capture.cs:101:25:101:31 | tainted | Capture.cs:101:25:101:31 | tainted |
-| Capture.cs:101:25:101:31 | tainted | Capture.cs:101:25:101:31 | tainted |
-| Capture.cs:101:25:101:31 | tainted | Capture.cs:108:9:108:25 | [implicit argument] tainted |
-| Capture.cs:101:25:101:31 | tainted | Capture.cs:108:9:108:25 | [implicit argument] tainted |
-| Capture.cs:101:25:101:31 | tainted | Capture.cs:120:9:120:25 | [implicit argument] tainted |
-| Capture.cs:101:25:101:31 | tainted | Capture.cs:120:9:120:25 | [implicit argument] tainted |
-| Capture.cs:101:25:101:31 | tainted | Capture.cs:129:9:129:45 | [implicit argument] tainted |
-| Capture.cs:101:25:101:31 | tainted | Capture.cs:129:9:129:45 | [implicit argument] tainted |
-| Capture.cs:101:25:101:31 | tainted | Capture.cs:136:22:136:38 | [implicit argument] tainted |
-| Capture.cs:101:25:101:31 | tainted | Capture.cs:136:22:136:38 | [implicit argument] tainted |
-| Capture.cs:101:25:101:31 | tainted | Capture.cs:144:25:144:31 | access to parameter tainted |
-| Capture.cs:101:25:101:31 | tainted | Capture.cs:144:25:144:31 | access to parameter tainted |
-| Capture.cs:101:25:101:31 | tainted | Capture.cs:170:25:170:31 | access to parameter tainted |
-| Capture.cs:101:25:101:31 | tainted | Capture.cs:170:25:170:31 | access to parameter tainted |
-| Capture.cs:103:16:103:26 | SSA def(sink33) | Capture.cs:103:16:103:26 | SSA def(sink33) |
-| Capture.cs:103:16:103:26 | String sink33 = ... | Capture.cs:103:16:103:26 | String sink33 = ... |
-| Capture.cs:103:25:103:26 | "" | Capture.cs:103:16:103:26 | SSA def(sink33) |
-| Capture.cs:103:25:103:26 | "" | Capture.cs:103:16:103:26 | SSA def(sink33) |
-| Capture.cs:103:25:103:26 | "" | Capture.cs:103:25:103:26 | "" |
-| Capture.cs:104:9:107:9 | SSA capture def(tainted) | Capture.cs:104:9:107:9 | SSA capture def(tainted) |
-| Capture.cs:104:9:107:9 | SSA capture def(tainted) | Capture.cs:106:13:106:28 | SSA def(sink33) |
-| Capture.cs:104:9:107:9 | SSA capture def(tainted) | Capture.cs:106:13:106:28 | SSA def(sink33) |
-| Capture.cs:104:9:107:9 | SSA capture def(tainted) | Capture.cs:106:13:106:28 | SSA def(sink33) |
-| Capture.cs:104:9:107:9 | SSA capture def(tainted) | Capture.cs:106:13:106:28 | SSA def(sink33) |
-| Capture.cs:104:9:107:9 | SSA capture def(tainted) | Capture.cs:106:22:106:28 | access to parameter tainted |
-| Capture.cs:104:9:107:9 | SSA capture def(tainted) | Capture.cs:106:22:106:28 | access to parameter tainted |
-| Capture.cs:104:9:107:9 | SSA capture def(tainted) | Capture.cs:106:22:106:28 | access to parameter tainted |
-| Capture.cs:104:9:107:9 | SSA capture def(tainted) | Capture.cs:106:22:106:28 | access to parameter tainted |
-| Capture.cs:106:13:106:28 | ... = ... | Capture.cs:106:13:106:28 | ... = ... |
-| Capture.cs:106:13:106:28 | SSA def(sink33) | Capture.cs:106:13:106:28 | SSA def(sink33) |
-| Capture.cs:106:13:106:28 | SSA def(sink33) | Capture.cs:108:9:108:25 | SSA call def(sink33) |
-| Capture.cs:106:13:106:28 | SSA def(sink33) | Capture.cs:108:9:108:25 | SSA call def(sink33) |
-| Capture.cs:106:22:106:28 | access to parameter tainted | Capture.cs:106:13:106:28 | SSA def(sink33) |
-| Capture.cs:106:22:106:28 | access to parameter tainted | Capture.cs:106:13:106:28 | SSA def(sink33) |
-| Capture.cs:106:22:106:28 | access to parameter tainted | Capture.cs:106:13:106:28 | SSA def(sink33) |
-| Capture.cs:106:22:106:28 | access to parameter tainted | Capture.cs:106:13:106:28 | SSA def(sink33) |
-| Capture.cs:106:22:106:28 | access to parameter tainted | Capture.cs:106:22:106:28 | access to parameter tainted |
-| Capture.cs:108:9:108:23 | access to local function CaptureThrough1 | Capture.cs:108:9:108:23 | access to local function CaptureThrough1 |
-| Capture.cs:108:9:108:25 | SSA call def(sink33) | Capture.cs:108:9:108:25 | SSA call def(sink33) |
-| Capture.cs:108:9:108:25 | SSA call def(sink33) | Capture.cs:109:15:109:20 | access to local variable sink33 |
-| Capture.cs:108:9:108:25 | SSA call def(sink33) | Capture.cs:109:15:109:20 | access to local variable sink33 |
-| Capture.cs:108:9:108:25 | [implicit argument] tainted | Capture.cs:104:9:107:9 | SSA capture def(tainted) |
-| Capture.cs:108:9:108:25 | [implicit argument] tainted | Capture.cs:104:9:107:9 | SSA capture def(tainted) |
-| Capture.cs:108:9:108:25 | [implicit argument] tainted | Capture.cs:108:9:108:25 | SSA call def(sink33) |
-| Capture.cs:108:9:108:25 | [implicit argument] tainted | Capture.cs:108:9:108:25 | SSA call def(sink33) |
-| Capture.cs:108:9:108:25 | [implicit argument] tainted | Capture.cs:108:9:108:25 | [implicit argument] tainted |
-| Capture.cs:108:9:108:25 | call to local function CaptureThrough1 | Capture.cs:108:9:108:25 | call to local function CaptureThrough1 |
-| Capture.cs:109:9:109:21 | call to method Check | Capture.cs:109:9:109:21 | call to method Check |
-| Capture.cs:109:15:109:20 | access to local variable sink33 | Capture.cs:109:15:109:20 | access to local variable sink33 |
-| Capture.cs:111:16:111:26 | SSA def(sink34) | Capture.cs:111:16:111:26 | SSA def(sink34) |
-| Capture.cs:111:16:111:26 | String sink34 = ... | Capture.cs:111:16:111:26 | String sink34 = ... |
-| Capture.cs:111:25:111:26 | "" | Capture.cs:111:16:111:26 | SSA def(sink34) |
-| Capture.cs:111:25:111:26 | "" | Capture.cs:111:16:111:26 | SSA def(sink34) |
-| Capture.cs:111:25:111:26 | "" | Capture.cs:111:25:111:26 | "" |
-| Capture.cs:114:13:117:13 | SSA capture def(tainted) | Capture.cs:114:13:117:13 | SSA capture def(tainted) |
-| Capture.cs:114:13:117:13 | SSA capture def(tainted) | Capture.cs:116:17:116:32 | SSA def(sink34) |
-| Capture.cs:114:13:117:13 | SSA capture def(tainted) | Capture.cs:116:17:116:32 | SSA def(sink34) |
-| Capture.cs:114:13:117:13 | SSA capture def(tainted) | Capture.cs:116:17:116:32 | SSA def(sink34) |
-| Capture.cs:114:13:117:13 | SSA capture def(tainted) | Capture.cs:116:17:116:32 | SSA def(sink34) |
-| Capture.cs:114:13:117:13 | SSA capture def(tainted) | Capture.cs:116:26:116:32 | access to parameter tainted |
-| Capture.cs:114:13:117:13 | SSA capture def(tainted) | Capture.cs:116:26:116:32 | access to parameter tainted |
-| Capture.cs:114:13:117:13 | SSA capture def(tainted) | Capture.cs:116:26:116:32 | access to parameter tainted |
-| Capture.cs:114:13:117:13 | SSA capture def(tainted) | Capture.cs:116:26:116:32 | access to parameter tainted |
-| Capture.cs:116:17:116:32 | ... = ... | Capture.cs:116:17:116:32 | ... = ... |
-| Capture.cs:116:17:116:32 | SSA def(sink34) | Capture.cs:116:17:116:32 | SSA def(sink34) |
-| Capture.cs:116:17:116:32 | SSA def(sink34) | Capture.cs:120:9:120:25 | SSA call def(sink34) |
-| Capture.cs:116:17:116:32 | SSA def(sink34) | Capture.cs:120:9:120:25 | SSA call def(sink34) |
-| Capture.cs:116:26:116:32 | access to parameter tainted | Capture.cs:116:17:116:32 | SSA def(sink34) |
-| Capture.cs:116:26:116:32 | access to parameter tainted | Capture.cs:116:17:116:32 | SSA def(sink34) |
-| Capture.cs:116:26:116:32 | access to parameter tainted | Capture.cs:116:17:116:32 | SSA def(sink34) |
-| Capture.cs:116:26:116:32 | access to parameter tainted | Capture.cs:116:17:116:32 | SSA def(sink34) |
-| Capture.cs:116:26:116:32 | access to parameter tainted | Capture.cs:116:26:116:32 | access to parameter tainted |
-| Capture.cs:118:13:118:13 | access to local function M | Capture.cs:118:13:118:13 | access to local function M |
-| Capture.cs:118:13:118:15 | call to local function M | Capture.cs:118:13:118:15 | call to local function M |
-| Capture.cs:120:9:120:23 | access to local function CaptureThrough2 | Capture.cs:120:9:120:23 | access to local function CaptureThrough2 |
-| Capture.cs:120:9:120:25 | SSA call def(sink34) | Capture.cs:120:9:120:25 | SSA call def(sink34) |
-| Capture.cs:120:9:120:25 | SSA call def(sink34) | Capture.cs:121:15:121:20 | access to local variable sink34 |
-| Capture.cs:120:9:120:25 | SSA call def(sink34) | Capture.cs:121:15:121:20 | access to local variable sink34 |
-| Capture.cs:120:9:120:25 | [implicit argument] tainted | Capture.cs:114:13:117:13 | SSA capture def(tainted) |
-| Capture.cs:120:9:120:25 | [implicit argument] tainted | Capture.cs:114:13:117:13 | SSA capture def(tainted) |
-| Capture.cs:120:9:120:25 | [implicit argument] tainted | Capture.cs:120:9:120:25 | SSA call def(sink34) |
-| Capture.cs:120:9:120:25 | [implicit argument] tainted | Capture.cs:120:9:120:25 | SSA call def(sink34) |
+| Capture.cs:79:17:79:39 | ... = ... | Capture.cs:79:17:79:39 | ... = ... |
+| Capture.cs:79:17:79:39 | SSA def(sink31) | Capture.cs:79:17:79:39 | SSA def(sink31) |
+| Capture.cs:79:17:79:39 | SSA def(sink31) | Capture.cs:83:9:83:21 | SSA call def(sink31) |
+| Capture.cs:79:17:79:39 | SSA def(sink31) | Capture.cs:83:9:83:21 | SSA call def(sink31) |
+| Capture.cs:79:26:79:39 | "taint source" | Capture.cs:79:17:79:39 | SSA def(sink31) |
+| Capture.cs:79:26:79:39 | "taint source" | Capture.cs:79:17:79:39 | SSA def(sink31) |
+| Capture.cs:79:26:79:39 | "taint source" | Capture.cs:79:26:79:39 | "taint source" |
+| Capture.cs:81:13:81:13 | access to local function M | Capture.cs:81:13:81:13 | access to local function M |
+| Capture.cs:81:13:81:15 | call to local function M | Capture.cs:81:13:81:15 | call to local function M |
+| Capture.cs:83:9:83:19 | access to local function CaptureOut2 | Capture.cs:83:9:83:19 | access to local function CaptureOut2 |
+| Capture.cs:83:9:83:21 | SSA call def(sink31) | Capture.cs:83:9:83:21 | SSA call def(sink31) |
+| Capture.cs:83:9:83:21 | SSA call def(sink31) | Capture.cs:84:15:84:20 | access to local variable sink31 |
+| Capture.cs:83:9:83:21 | SSA call def(sink31) | Capture.cs:84:15:84:20 | access to local variable sink31 |
+| Capture.cs:83:9:83:21 | call to local function CaptureOut2 | Capture.cs:83:9:83:21 | call to local function CaptureOut2 |
+| Capture.cs:84:9:84:21 | call to method Check | Capture.cs:84:9:84:21 | call to method Check |
+| Capture.cs:84:15:84:20 | access to local variable sink31 | Capture.cs:84:15:84:20 | access to local variable sink31 |
+| Capture.cs:86:16:86:26 | SSA def(sink32) | Capture.cs:86:16:86:26 | SSA def(sink32) |
+| Capture.cs:86:16:86:26 | String sink32 = ... | Capture.cs:86:16:86:26 | String sink32 = ... |
+| Capture.cs:86:25:86:26 | "" | Capture.cs:86:16:86:26 | SSA def(sink32) |
+| Capture.cs:86:25:86:26 | "" | Capture.cs:86:16:86:26 | SSA def(sink32) |
+| Capture.cs:86:25:86:26 | "" | Capture.cs:86:25:86:26 | "" |
+| Capture.cs:87:30:91:9 | Func<String,String> captureOut3 = ... | Capture.cs:87:30:91:9 | Func<String,String> captureOut3 = ... |
+| Capture.cs:87:30:91:9 | SSA def(captureOut3) | Capture.cs:87:30:91:9 | SSA def(captureOut3) |
+| Capture.cs:87:30:91:9 | SSA def(captureOut3) | Capture.cs:92:30:92:40 | access to local variable captureOut3 |
+| Capture.cs:87:30:91:9 | SSA def(captureOut3) | Capture.cs:92:30:92:40 | access to local variable captureOut3 |
+| Capture.cs:87:44:87:46 | arg | Capture.cs:87:44:87:46 | arg |
+| Capture.cs:87:44:87:46 | arg | Capture.cs:87:44:87:46 | arg |
+| Capture.cs:87:44:87:46 | arg | Capture.cs:90:20:90:22 | access to parameter arg |
+| Capture.cs:87:44:87:46 | arg | Capture.cs:90:20:90:22 | access to parameter arg |
+| Capture.cs:87:44:91:9 | (...) => ... | Capture.cs:87:30:91:9 | SSA def(captureOut3) |
+| Capture.cs:87:44:91:9 | (...) => ... | Capture.cs:87:30:91:9 | SSA def(captureOut3) |
+| Capture.cs:87:44:91:9 | (...) => ... | Capture.cs:87:44:91:9 | (...) => ... |
+| Capture.cs:87:44:91:9 | (...) => ... | Capture.cs:92:30:92:40 | access to local variable captureOut3 |
+| Capture.cs:87:44:91:9 | (...) => ... | Capture.cs:92:30:92:40 | access to local variable captureOut3 |
+| Capture.cs:89:13:89:35 | ... = ... | Capture.cs:89:13:89:35 | ... = ... |
+| Capture.cs:89:13:89:35 | SSA def(sink32) | Capture.cs:89:13:89:35 | SSA def(sink32) |
+| Capture.cs:89:13:89:35 | SSA def(sink32) | Capture.cs:92:9:92:41 | SSA call def(sink32) |
+| Capture.cs:89:13:89:35 | SSA def(sink32) | Capture.cs:92:9:92:41 | SSA call def(sink32) |
+| Capture.cs:89:22:89:35 | "taint source" | Capture.cs:89:13:89:35 | SSA def(sink32) |
+| Capture.cs:89:22:89:35 | "taint source" | Capture.cs:89:13:89:35 | SSA def(sink32) |
+| Capture.cs:89:22:89:35 | "taint source" | Capture.cs:89:22:89:35 | "taint source" |
+| Capture.cs:90:20:90:22 | access to parameter arg | Capture.cs:90:20:90:22 | access to parameter arg |
+| Capture.cs:90:20:90:22 | access to parameter arg | Capture.cs:92:30:92:40 | [output] access to local variable captureOut3 |
+| Capture.cs:90:20:90:22 | access to parameter arg | Capture.cs:92:30:92:40 | [output] access to local variable captureOut3 |
+| Capture.cs:92:9:92:21 | array creation of type String[] | Capture.cs:87:44:87:46 | arg |
+| Capture.cs:92:9:92:21 | array creation of type String[] | Capture.cs:87:44:87:46 | arg |
+| Capture.cs:92:9:92:21 | array creation of type String[] | Capture.cs:92:9:92:21 | array creation of type String[] |
+| Capture.cs:92:9:92:41 | SSA call def(sink32) | Capture.cs:92:9:92:41 | SSA call def(sink32) |
+| Capture.cs:92:9:92:41 | SSA call def(sink32) | Capture.cs:93:15:93:20 | access to local variable sink32 |
+| Capture.cs:92:9:92:41 | SSA call def(sink32) | Capture.cs:93:15:93:20 | access to local variable sink32 |
+| Capture.cs:92:9:92:41 | call to method Select | Capture.cs:92:9:92:41 | call to method Select |
+| Capture.cs:92:9:92:51 | call to method ToArray | Capture.cs:92:9:92:51 | call to method ToArray |
+| Capture.cs:92:15:92:21 | { ..., ... } | Capture.cs:92:15:92:21 | { ..., ... } |
+| Capture.cs:92:17:92:19 | " " | Capture.cs:92:17:92:19 | " " |
+| Capture.cs:92:30:92:40 | [output] access to local variable captureOut3 | Capture.cs:92:30:92:40 | [output] access to local variable captureOut3 |
+| Capture.cs:92:30:92:40 | access to local variable captureOut3 | Capture.cs:92:30:92:40 | access to local variable captureOut3 |
+| Capture.cs:93:9:93:21 | call to method Check | Capture.cs:93:9:93:21 | call to method Check |
+| Capture.cs:93:15:93:20 | access to local variable sink32 | Capture.cs:93:15:93:20 | access to local variable sink32 |
+| Capture.cs:95:16:95:28 | SSA def(nonSink0) | Capture.cs:95:16:95:28 | SSA def(nonSink0) |
+| Capture.cs:95:16:95:28 | SSA def(nonSink0) | Capture.cs:100:15:100:22 | access to local variable nonSink0 |
+| Capture.cs:95:16:95:28 | SSA def(nonSink0) | Capture.cs:100:15:100:22 | access to local variable nonSink0 |
+| Capture.cs:95:16:95:28 | SSA def(nonSink0) | Capture.cs:110:15:110:22 | access to local variable nonSink0 |
+| Capture.cs:95:16:95:28 | SSA def(nonSink0) | Capture.cs:110:15:110:22 | access to local variable nonSink0 |
+| Capture.cs:95:16:95:28 | String nonSink0 = ... | Capture.cs:95:16:95:28 | String nonSink0 = ... |
+| Capture.cs:95:27:95:28 | "" | Capture.cs:95:16:95:28 | SSA def(nonSink0) |
+| Capture.cs:95:27:95:28 | "" | Capture.cs:95:16:95:28 | SSA def(nonSink0) |
+| Capture.cs:95:27:95:28 | "" | Capture.cs:95:27:95:28 | "" |
+| Capture.cs:95:27:95:28 | "" | Capture.cs:100:15:100:22 | access to local variable nonSink0 |
+| Capture.cs:95:27:95:28 | "" | Capture.cs:100:15:100:22 | access to local variable nonSink0 |
+| Capture.cs:95:27:95:28 | "" | Capture.cs:110:15:110:22 | access to local variable nonSink0 |
+| Capture.cs:95:27:95:28 | "" | Capture.cs:110:15:110:22 | access to local variable nonSink0 |
+| Capture.cs:98:13:98:37 | ... = ... | Capture.cs:98:13:98:37 | ... = ... |
+| Capture.cs:98:24:98:37 | "taint source" | Capture.cs:98:24:98:37 | "taint source" |
+| Capture.cs:100:9:100:23 | call to method Check | Capture.cs:100:9:100:23 | call to method Check |
+| Capture.cs:100:15:100:22 | access to local variable nonSink0 | Capture.cs:100:15:100:22 | access to local variable nonSink0 |
+| Capture.cs:100:15:100:22 | access to local variable nonSink0 | Capture.cs:110:15:110:22 | access to local variable nonSink0 |
+| Capture.cs:100:15:100:22 | access to local variable nonSink0 | Capture.cs:110:15:110:22 | access to local variable nonSink0 |
+| Capture.cs:106:17:106:41 | ... = ... | Capture.cs:106:17:106:41 | ... = ... |
+| Capture.cs:106:28:106:41 | "taint source" | Capture.cs:106:28:106:41 | "taint source" |
+| Capture.cs:109:9:109:28 | access to local function CaptureOut2NotCalled | Capture.cs:109:9:109:28 | access to local function CaptureOut2NotCalled |
+| Capture.cs:109:9:109:30 | call to local function CaptureOut2NotCalled | Capture.cs:109:9:109:30 | call to local function CaptureOut2NotCalled |
+| Capture.cs:110:9:110:23 | call to method Check | Capture.cs:110:9:110:23 | call to method Check |
+| Capture.cs:110:15:110:22 | access to local variable nonSink0 | Capture.cs:110:15:110:22 | access to local variable nonSink0 |
+| Capture.cs:113:10:113:16 | this | Capture.cs:113:10:113:16 | this |
+| Capture.cs:113:25:113:31 | tainted | Capture.cs:113:25:113:31 | tainted |
+| Capture.cs:113:25:113:31 | tainted | Capture.cs:113:25:113:31 | tainted |
+| Capture.cs:113:25:113:31 | tainted | Capture.cs:120:9:120:25 | [implicit argument] tainted |
+| Capture.cs:113:25:113:31 | tainted | Capture.cs:120:9:120:25 | [implicit argument] tainted |
+| Capture.cs:113:25:113:31 | tainted | Capture.cs:132:9:132:25 | [implicit argument] tainted |
+| Capture.cs:113:25:113:31 | tainted | Capture.cs:132:9:132:25 | [implicit argument] tainted |
+| Capture.cs:113:25:113:31 | tainted | Capture.cs:141:9:141:45 | [implicit argument] tainted |
+| Capture.cs:113:25:113:31 | tainted | Capture.cs:141:9:141:45 | [implicit argument] tainted |
+| Capture.cs:113:25:113:31 | tainted | Capture.cs:148:22:148:38 | [implicit argument] tainted |
+| Capture.cs:113:25:113:31 | tainted | Capture.cs:148:22:148:38 | [implicit argument] tainted |
+| Capture.cs:113:25:113:31 | tainted | Capture.cs:156:25:156:31 | access to parameter tainted |
+| Capture.cs:113:25:113:31 | tainted | Capture.cs:156:25:156:31 | access to parameter tainted |
+| Capture.cs:113:25:113:31 | tainted | Capture.cs:182:25:182:31 | access to parameter tainted |
+| Capture.cs:113:25:113:31 | tainted | Capture.cs:182:25:182:31 | access to parameter tainted |
+| Capture.cs:115:16:115:26 | SSA def(sink33) | Capture.cs:115:16:115:26 | SSA def(sink33) |
+| Capture.cs:115:16:115:26 | String sink33 = ... | Capture.cs:115:16:115:26 | String sink33 = ... |
+| Capture.cs:115:25:115:26 | "" | Capture.cs:115:16:115:26 | SSA def(sink33) |
+| Capture.cs:115:25:115:26 | "" | Capture.cs:115:16:115:26 | SSA def(sink33) |
+| Capture.cs:115:25:115:26 | "" | Capture.cs:115:25:115:26 | "" |
+| Capture.cs:116:9:119:9 | SSA capture def(tainted) | Capture.cs:116:9:119:9 | SSA capture def(tainted) |
+| Capture.cs:116:9:119:9 | SSA capture def(tainted) | Capture.cs:118:13:118:28 | SSA def(sink33) |
+| Capture.cs:116:9:119:9 | SSA capture def(tainted) | Capture.cs:118:13:118:28 | SSA def(sink33) |
+| Capture.cs:116:9:119:9 | SSA capture def(tainted) | Capture.cs:118:13:118:28 | SSA def(sink33) |
+| Capture.cs:116:9:119:9 | SSA capture def(tainted) | Capture.cs:118:13:118:28 | SSA def(sink33) |
+| Capture.cs:116:9:119:9 | SSA capture def(tainted) | Capture.cs:118:22:118:28 | access to parameter tainted |
+| Capture.cs:116:9:119:9 | SSA capture def(tainted) | Capture.cs:118:22:118:28 | access to parameter tainted |
+| Capture.cs:116:9:119:9 | SSA capture def(tainted) | Capture.cs:118:22:118:28 | access to parameter tainted |
+| Capture.cs:116:9:119:9 | SSA capture def(tainted) | Capture.cs:118:22:118:28 | access to parameter tainted |
+| Capture.cs:118:13:118:28 | ... = ... | Capture.cs:118:13:118:28 | ... = ... |
+| Capture.cs:118:13:118:28 | SSA def(sink33) | Capture.cs:118:13:118:28 | SSA def(sink33) |
+| Capture.cs:118:13:118:28 | SSA def(sink33) | Capture.cs:120:9:120:25 | SSA call def(sink33) |
+| Capture.cs:118:13:118:28 | SSA def(sink33) | Capture.cs:120:9:120:25 | SSA call def(sink33) |
+| Capture.cs:118:22:118:28 | access to parameter tainted | Capture.cs:118:13:118:28 | SSA def(sink33) |
+| Capture.cs:118:22:118:28 | access to parameter tainted | Capture.cs:118:13:118:28 | SSA def(sink33) |
+| Capture.cs:118:22:118:28 | access to parameter tainted | Capture.cs:118:13:118:28 | SSA def(sink33) |
+| Capture.cs:118:22:118:28 | access to parameter tainted | Capture.cs:118:13:118:28 | SSA def(sink33) |
+| Capture.cs:118:22:118:28 | access to parameter tainted | Capture.cs:118:22:118:28 | access to parameter tainted |
+| Capture.cs:120:9:120:23 | access to local function CaptureThrough1 | Capture.cs:120:9:120:23 | access to local function CaptureThrough1 |
+| Capture.cs:120:9:120:25 | SSA call def(sink33) | Capture.cs:120:9:120:25 | SSA call def(sink33) |
+| Capture.cs:120:9:120:25 | SSA call def(sink33) | Capture.cs:121:15:121:20 | access to local variable sink33 |
+| Capture.cs:120:9:120:25 | SSA call def(sink33) | Capture.cs:121:15:121:20 | access to local variable sink33 |
+| Capture.cs:120:9:120:25 | [implicit argument] tainted | Capture.cs:116:9:119:9 | SSA capture def(tainted) |
+| Capture.cs:120:9:120:25 | [implicit argument] tainted | Capture.cs:116:9:119:9 | SSA capture def(tainted) |
+| Capture.cs:120:9:120:25 | [implicit argument] tainted | Capture.cs:120:9:120:25 | SSA call def(sink33) |
+| Capture.cs:120:9:120:25 | [implicit argument] tainted | Capture.cs:120:9:120:25 | SSA call def(sink33) |
 | Capture.cs:120:9:120:25 | [implicit argument] tainted | Capture.cs:120:9:120:25 | [implicit argument] tainted |
-| Capture.cs:120:9:120:25 | call to local function CaptureThrough2 | Capture.cs:120:9:120:25 | call to local function CaptureThrough2 |
+| Capture.cs:120:9:120:25 | call to local function CaptureThrough1 | Capture.cs:120:9:120:25 | call to local function CaptureThrough1 |
 | Capture.cs:121:9:121:21 | call to method Check | Capture.cs:121:9:121:21 | call to method Check |
-| Capture.cs:121:15:121:20 | access to local variable sink34 | Capture.cs:121:15:121:20 | access to local variable sink34 |
-| Capture.cs:123:16:123:26 | SSA def(sink35) | Capture.cs:123:16:123:26 | SSA def(sink35) |
-| Capture.cs:123:16:123:26 | String sink35 = ... | Capture.cs:123:16:123:26 | String sink35 = ... |
-| Capture.cs:123:25:123:26 | "" | Capture.cs:123:16:123:26 | SSA def(sink35) |
-| Capture.cs:123:25:123:26 | "" | Capture.cs:123:16:123:26 | SSA def(sink35) |
+| Capture.cs:121:15:121:20 | access to local variable sink33 | Capture.cs:121:15:121:20 | access to local variable sink33 |
+| Capture.cs:123:16:123:26 | SSA def(sink34) | Capture.cs:123:16:123:26 | SSA def(sink34) |
+| Capture.cs:123:16:123:26 | String sink34 = ... | Capture.cs:123:16:123:26 | String sink34 = ... |
+| Capture.cs:123:25:123:26 | "" | Capture.cs:123:16:123:26 | SSA def(sink34) |
+| Capture.cs:123:25:123:26 | "" | Capture.cs:123:16:123:26 | SSA def(sink34) |
 | Capture.cs:123:25:123:26 | "" | Capture.cs:123:25:123:26 | "" |
-| Capture.cs:124:30:128:9 | Func<String,String> captureThrough3 = ... | Capture.cs:124:30:128:9 | Func<String,String> captureThrough3 = ... |
-| Capture.cs:124:30:128:9 | SSA def(captureThrough3) | Capture.cs:124:30:128:9 | SSA def(captureThrough3) |
-| Capture.cs:124:30:128:9 | SSA def(captureThrough3) | Capture.cs:129:30:129:44 | access to local variable captureThrough3 |
-| Capture.cs:124:30:128:9 | SSA def(captureThrough3) | Capture.cs:129:30:129:44 | access to local variable captureThrough3 |
-| Capture.cs:124:48:124:50 | arg | Capture.cs:124:48:124:50 | arg |
-| Capture.cs:124:48:124:50 | arg | Capture.cs:124:48:124:50 | arg |
-| Capture.cs:124:48:124:50 | arg | Capture.cs:127:20:127:22 | access to parameter arg |
-| Capture.cs:124:48:124:50 | arg | Capture.cs:127:20:127:22 | access to parameter arg |
-| Capture.cs:124:48:128:9 | (...) => ... | Capture.cs:124:30:128:9 | SSA def(captureThrough3) |
-| Capture.cs:124:48:128:9 | (...) => ... | Capture.cs:124:30:128:9 | SSA def(captureThrough3) |
-| Capture.cs:124:48:128:9 | (...) => ... | Capture.cs:124:48:128:9 | (...) => ... |
-| Capture.cs:124:48:128:9 | (...) => ... | Capture.cs:129:30:129:44 | access to local variable captureThrough3 |
-| Capture.cs:124:48:128:9 | (...) => ... | Capture.cs:129:30:129:44 | access to local variable captureThrough3 |
-| Capture.cs:124:48:128:9 | SSA capture def(tainted) | Capture.cs:124:48:128:9 | SSA capture def(tainted) |
-| Capture.cs:124:48:128:9 | SSA capture def(tainted) | Capture.cs:126:13:126:28 | SSA def(sink35) |
-| Capture.cs:124:48:128:9 | SSA capture def(tainted) | Capture.cs:126:13:126:28 | SSA def(sink35) |
-| Capture.cs:124:48:128:9 | SSA capture def(tainted) | Capture.cs:126:13:126:28 | SSA def(sink35) |
-| Capture.cs:124:48:128:9 | SSA capture def(tainted) | Capture.cs:126:13:126:28 | SSA def(sink35) |
-| Capture.cs:124:48:128:9 | SSA capture def(tainted) | Capture.cs:126:22:126:28 | access to parameter tainted |
-| Capture.cs:124:48:128:9 | SSA capture def(tainted) | Capture.cs:126:22:126:28 | access to parameter tainted |
-| Capture.cs:124:48:128:9 | SSA capture def(tainted) | Capture.cs:126:22:126:28 | access to parameter tainted |
-| Capture.cs:124:48:128:9 | SSA capture def(tainted) | Capture.cs:126:22:126:28 | access to parameter tainted |
-| Capture.cs:126:13:126:28 | ... = ... | Capture.cs:126:13:126:28 | ... = ... |
-| Capture.cs:126:13:126:28 | SSA def(sink35) | Capture.cs:126:13:126:28 | SSA def(sink35) |
-| Capture.cs:126:13:126:28 | SSA def(sink35) | Capture.cs:129:9:129:45 | SSA call def(sink35) |
-| Capture.cs:126:13:126:28 | SSA def(sink35) | Capture.cs:129:9:129:45 | SSA call def(sink35) |
-| Capture.cs:126:22:126:28 | access to parameter tainted | Capture.cs:126:13:126:28 | SSA def(sink35) |
-| Capture.cs:126:22:126:28 | access to parameter tainted | Capture.cs:126:13:126:28 | SSA def(sink35) |
-| Capture.cs:126:22:126:28 | access to parameter tainted | Capture.cs:126:13:126:28 | SSA def(sink35) |
-| Capture.cs:126:22:126:28 | access to parameter tainted | Capture.cs:126:13:126:28 | SSA def(sink35) |
-| Capture.cs:126:22:126:28 | access to parameter tainted | Capture.cs:126:22:126:28 | access to parameter tainted |
-| Capture.cs:127:20:127:22 | access to parameter arg | Capture.cs:127:20:127:22 | access to parameter arg |
-| Capture.cs:127:20:127:22 | access to parameter arg | Capture.cs:129:30:129:44 | [output] access to local variable captureThrough3 |
-| Capture.cs:127:20:127:22 | access to parameter arg | Capture.cs:129:30:129:44 | [output] access to local variable captureThrough3 |
-| Capture.cs:129:9:129:21 | array creation of type String[] | Capture.cs:124:48:124:50 | arg |
-| Capture.cs:129:9:129:21 | array creation of type String[] | Capture.cs:124:48:124:50 | arg |
-| Capture.cs:129:9:129:21 | array creation of type String[] | Capture.cs:129:9:129:21 | array creation of type String[] |
-| Capture.cs:129:9:129:45 | SSA call def(sink35) | Capture.cs:129:9:129:45 | SSA call def(sink35) |
-| Capture.cs:129:9:129:45 | SSA call def(sink35) | Capture.cs:130:15:130:20 | access to local variable sink35 |
-| Capture.cs:129:9:129:45 | SSA call def(sink35) | Capture.cs:130:15:130:20 | access to local variable sink35 |
-| Capture.cs:129:9:129:45 | [implicit argument] tainted | Capture.cs:124:48:128:9 | SSA capture def(tainted) |
-| Capture.cs:129:9:129:45 | [implicit argument] tainted | Capture.cs:124:48:128:9 | SSA capture def(tainted) |
-| Capture.cs:129:9:129:45 | [implicit argument] tainted | Capture.cs:129:9:129:45 | SSA call def(sink35) |
-| Capture.cs:129:9:129:45 | [implicit argument] tainted | Capture.cs:129:9:129:45 | SSA call def(sink35) |
-| Capture.cs:129:9:129:45 | [implicit argument] tainted | Capture.cs:129:9:129:45 | [implicit argument] tainted |
-| Capture.cs:129:9:129:45 | call to method Select | Capture.cs:129:9:129:45 | call to method Select |
-| Capture.cs:129:9:129:55 | call to method ToArray | Capture.cs:129:9:129:55 | call to method ToArray |
-| Capture.cs:129:15:129:21 | { ..., ... } | Capture.cs:129:15:129:21 | { ..., ... } |
-| Capture.cs:129:17:129:19 | " " | Capture.cs:129:17:129:19 | " " |
-| Capture.cs:129:30:129:44 | [output] access to local variable captureThrough3 | Capture.cs:129:30:129:44 | [output] access to local variable captureThrough3 |
-| Capture.cs:129:30:129:44 | access to local variable captureThrough3 | Capture.cs:129:30:129:44 | access to local variable captureThrough3 |
-| Capture.cs:130:9:130:21 | call to method Check | Capture.cs:130:9:130:21 | call to method Check |
-| Capture.cs:130:15:130:20 | access to local variable sink35 | Capture.cs:130:15:130:20 | access to local variable sink35 |
-| Capture.cs:132:9:135:9 | SSA capture def(tainted) | Capture.cs:132:9:135:9 | SSA capture def(tainted) |
-| Capture.cs:132:9:135:9 | SSA capture def(tainted) | Capture.cs:134:20:134:26 | access to parameter tainted |
-| Capture.cs:132:9:135:9 | SSA capture def(tainted) | Capture.cs:134:20:134:26 | access to parameter tainted |
-| Capture.cs:132:9:135:9 | SSA capture def(tainted) | Capture.cs:134:20:134:26 | access to parameter tainted |
-| Capture.cs:132:9:135:9 | SSA capture def(tainted) | Capture.cs:134:20:134:26 | access to parameter tainted |
-| Capture.cs:134:20:134:26 | access to parameter tainted | Capture.cs:134:20:134:26 | access to parameter tainted |
-| Capture.cs:134:20:134:26 | access to parameter tainted | Capture.cs:136:22:136:38 | call to local function CaptureThrough4 |
-| Capture.cs:134:20:134:26 | access to parameter tainted | Capture.cs:136:22:136:38 | call to local function CaptureThrough4 |
-| Capture.cs:136:13:136:38 | SSA def(sink36) | Capture.cs:136:13:136:38 | SSA def(sink36) |
-| Capture.cs:136:13:136:38 | SSA def(sink36) | Capture.cs:137:15:137:20 | access to local variable sink36 |
-| Capture.cs:136:13:136:38 | SSA def(sink36) | Capture.cs:137:15:137:20 | access to local variable sink36 |
-| Capture.cs:136:13:136:38 | String sink36 = ... | Capture.cs:136:13:136:38 | String sink36 = ... |
-| Capture.cs:136:22:136:36 | access to local function CaptureThrough4 | Capture.cs:136:22:136:36 | access to local function CaptureThrough4 |
-| Capture.cs:136:22:136:38 | [implicit argument] tainted | Capture.cs:132:9:135:9 | SSA capture def(tainted) |
-| Capture.cs:136:22:136:38 | [implicit argument] tainted | Capture.cs:132:9:135:9 | SSA capture def(tainted) |
-| Capture.cs:136:22:136:38 | [implicit argument] tainted | Capture.cs:136:22:136:38 | [implicit argument] tainted |
-| Capture.cs:136:22:136:38 | [implicit argument] tainted | Capture.cs:136:22:136:38 | call to local function CaptureThrough4 |
-| Capture.cs:136:22:136:38 | [implicit argument] tainted | Capture.cs:136:22:136:38 | call to local function CaptureThrough4 |
-| Capture.cs:136:22:136:38 | call to local function CaptureThrough4 | Capture.cs:136:13:136:38 | SSA def(sink36) |
-| Capture.cs:136:22:136:38 | call to local function CaptureThrough4 | Capture.cs:136:13:136:38 | SSA def(sink36) |
-| Capture.cs:136:22:136:38 | call to local function CaptureThrough4 | Capture.cs:136:22:136:38 | call to local function CaptureThrough4 |
-| Capture.cs:136:22:136:38 | call to local function CaptureThrough4 | Capture.cs:137:15:137:20 | access to local variable sink36 |
-| Capture.cs:136:22:136:38 | call to local function CaptureThrough4 | Capture.cs:137:15:137:20 | access to local variable sink36 |
-| Capture.cs:137:9:137:21 | call to method Check | Capture.cs:137:9:137:21 | call to method Check |
-| Capture.cs:137:15:137:20 | access to local variable sink36 | Capture.cs:137:15:137:20 | access to local variable sink36 |
-| Capture.cs:139:13:139:23 | SSA def(sink37) | Capture.cs:139:13:139:23 | SSA def(sink37) |
-| Capture.cs:139:13:139:23 | String sink37 = ... | Capture.cs:139:13:139:23 | String sink37 = ... |
-| Capture.cs:139:22:139:23 | "" | Capture.cs:139:13:139:23 | SSA def(sink37) |
-| Capture.cs:139:22:139:23 | "" | Capture.cs:139:13:139:23 | SSA def(sink37) |
-| Capture.cs:139:22:139:23 | "" | Capture.cs:139:22:139:23 | "" |
-| Capture.cs:140:37:140:37 | p | Capture.cs:140:37:140:37 | p |
-| Capture.cs:140:37:140:37 | p | Capture.cs:140:37:140:37 | p |
-| Capture.cs:140:37:140:37 | p | Capture.cs:142:13:142:22 | SSA def(sink37) |
-| Capture.cs:140:37:140:37 | p | Capture.cs:142:13:142:22 | SSA def(sink37) |
-| Capture.cs:140:37:140:37 | p | Capture.cs:142:13:142:22 | SSA def(sink37) |
-| Capture.cs:140:37:140:37 | p | Capture.cs:142:13:142:22 | SSA def(sink37) |
-| Capture.cs:140:37:140:37 | p | Capture.cs:142:22:142:22 | access to parameter p |
-| Capture.cs:140:37:140:37 | p | Capture.cs:142:22:142:22 | access to parameter p |
-| Capture.cs:140:37:140:37 | p | Capture.cs:142:22:142:22 | access to parameter p |
-| Capture.cs:140:37:140:37 | p | Capture.cs:142:22:142:22 | access to parameter p |
-| Capture.cs:142:13:142:22 | ... = ... | Capture.cs:142:13:142:22 | ... = ... |
-| Capture.cs:142:13:142:22 | SSA def(sink37) | Capture.cs:142:13:142:22 | SSA def(sink37) |
-| Capture.cs:142:13:142:22 | SSA def(sink37) | Capture.cs:144:9:144:32 | SSA call def(sink37) |
-| Capture.cs:142:13:142:22 | SSA def(sink37) | Capture.cs:144:9:144:32 | SSA call def(sink37) |
-| Capture.cs:142:22:142:22 | access to parameter p | Capture.cs:142:13:142:22 | SSA def(sink37) |
-| Capture.cs:142:22:142:22 | access to parameter p | Capture.cs:142:13:142:22 | SSA def(sink37) |
-| Capture.cs:142:22:142:22 | access to parameter p | Capture.cs:142:13:142:22 | SSA def(sink37) |
-| Capture.cs:142:22:142:22 | access to parameter p | Capture.cs:142:13:142:22 | SSA def(sink37) |
-| Capture.cs:142:22:142:22 | access to parameter p | Capture.cs:142:22:142:22 | access to parameter p |
-| Capture.cs:144:9:144:23 | access to local function CaptureThrough5 | Capture.cs:144:9:144:23 | access to local function CaptureThrough5 |
-| Capture.cs:144:9:144:32 | SSA call def(sink37) | Capture.cs:144:9:144:32 | SSA call def(sink37) |
-| Capture.cs:144:9:144:32 | SSA call def(sink37) | Capture.cs:145:15:145:20 | access to local variable sink37 |
-| Capture.cs:144:9:144:32 | SSA call def(sink37) | Capture.cs:145:15:145:20 | access to local variable sink37 |
-| Capture.cs:144:9:144:32 | call to local function CaptureThrough5 | Capture.cs:144:9:144:32 | call to local function CaptureThrough5 |
-| Capture.cs:144:25:144:31 | access to parameter tainted | Capture.cs:140:37:140:37 | p |
-| Capture.cs:144:25:144:31 | access to parameter tainted | Capture.cs:140:37:140:37 | p |
-| Capture.cs:144:25:144:31 | access to parameter tainted | Capture.cs:144:9:144:32 | SSA call def(sink37) |
-| Capture.cs:144:25:144:31 | access to parameter tainted | Capture.cs:144:9:144:32 | SSA call def(sink37) |
-| Capture.cs:144:25:144:31 | access to parameter tainted | Capture.cs:144:25:144:31 | access to parameter tainted |
-| Capture.cs:144:25:144:31 | access to parameter tainted | Capture.cs:170:25:170:31 | access to parameter tainted |
-| Capture.cs:144:25:144:31 | access to parameter tainted | Capture.cs:170:25:170:31 | access to parameter tainted |
-| Capture.cs:145:9:145:21 | call to method Check | Capture.cs:145:9:145:21 | call to method Check |
-| Capture.cs:145:15:145:20 | access to local variable sink37 | Capture.cs:145:15:145:20 | access to local variable sink37 |
-| Capture.cs:147:16:147:28 | SSA def(nonSink0) | Capture.cs:147:16:147:28 | SSA def(nonSink0) |
-| Capture.cs:147:16:147:28 | SSA def(nonSink0) | Capture.cs:152:15:152:22 | access to local variable nonSink0 |
-| Capture.cs:147:16:147:28 | SSA def(nonSink0) | Capture.cs:152:15:152:22 | access to local variable nonSink0 |
-| Capture.cs:147:16:147:28 | SSA def(nonSink0) | Capture.cs:162:15:162:22 | access to local variable nonSink0 |
-| Capture.cs:147:16:147:28 | SSA def(nonSink0) | Capture.cs:162:15:162:22 | access to local variable nonSink0 |
-| Capture.cs:147:16:147:28 | String nonSink0 = ... | Capture.cs:147:16:147:28 | String nonSink0 = ... |
-| Capture.cs:147:27:147:28 | "" | Capture.cs:147:16:147:28 | SSA def(nonSink0) |
-| Capture.cs:147:27:147:28 | "" | Capture.cs:147:16:147:28 | SSA def(nonSink0) |
-| Capture.cs:147:27:147:28 | "" | Capture.cs:147:27:147:28 | "" |
-| Capture.cs:147:27:147:28 | "" | Capture.cs:152:15:152:22 | access to local variable nonSink0 |
-| Capture.cs:147:27:147:28 | "" | Capture.cs:152:15:152:22 | access to local variable nonSink0 |
-| Capture.cs:147:27:147:28 | "" | Capture.cs:162:15:162:22 | access to local variable nonSink0 |
-| Capture.cs:147:27:147:28 | "" | Capture.cs:162:15:162:22 | access to local variable nonSink0 |
-| Capture.cs:148:9:151:9 | SSA capture def(tainted) | Capture.cs:148:9:151:9 | SSA capture def(tainted) |
-| Capture.cs:148:9:151:9 | SSA capture def(tainted) | Capture.cs:150:24:150:30 | access to parameter tainted |
-| Capture.cs:148:9:151:9 | SSA capture def(tainted) | Capture.cs:150:24:150:30 | access to parameter tainted |
-| Capture.cs:150:13:150:30 | ... = ... | Capture.cs:150:13:150:30 | ... = ... |
-| Capture.cs:150:24:150:30 | access to parameter tainted | Capture.cs:150:24:150:30 | access to parameter tainted |
-| Capture.cs:152:9:152:23 | call to method Check | Capture.cs:152:9:152:23 | call to method Check |
-| Capture.cs:152:15:152:22 | access to local variable nonSink0 | Capture.cs:152:15:152:22 | access to local variable nonSink0 |
-| Capture.cs:152:15:152:22 | access to local variable nonSink0 | Capture.cs:162:15:162:22 | access to local variable nonSink0 |
-| Capture.cs:152:15:152:22 | access to local variable nonSink0 | Capture.cs:162:15:162:22 | access to local variable nonSink0 |
-| Capture.cs:156:13:159:13 | SSA capture def(tainted) | Capture.cs:156:13:159:13 | SSA capture def(tainted) |
-| Capture.cs:156:13:159:13 | SSA capture def(tainted) | Capture.cs:158:28:158:34 | access to parameter tainted |
-| Capture.cs:156:13:159:13 | SSA capture def(tainted) | Capture.cs:158:28:158:34 | access to parameter tainted |
-| Capture.cs:158:17:158:34 | ... = ... | Capture.cs:158:17:158:34 | ... = ... |
-| Capture.cs:158:28:158:34 | access to parameter tainted | Capture.cs:158:28:158:34 | access to parameter tainted |
-| Capture.cs:161:9:161:32 | access to local function CaptureThrough2NotCalled | Capture.cs:161:9:161:32 | access to local function CaptureThrough2NotCalled |
-| Capture.cs:161:9:161:34 | call to local function CaptureThrough2NotCalled | Capture.cs:161:9:161:34 | call to local function CaptureThrough2NotCalled |
-| Capture.cs:162:9:162:23 | call to method Check | Capture.cs:162:9:162:23 | call to method Check |
-| Capture.cs:162:15:162:22 | access to local variable nonSink0 | Capture.cs:162:15:162:22 | access to local variable nonSink0 |
-| Capture.cs:164:26:164:26 | s | Capture.cs:164:26:164:26 | s |
-| Capture.cs:164:26:164:26 | s | Capture.cs:164:26:164:26 | s |
-| Capture.cs:164:26:164:26 | s | Capture.cs:167:20:167:22 | [implicit argument] s |
-| Capture.cs:164:26:164:26 | s | Capture.cs:167:20:167:22 | [implicit argument] s |
-| Capture.cs:164:26:164:26 | s | Capture.cs:167:20:167:22 | [implicit argument] s |
-| Capture.cs:164:26:164:26 | s | Capture.cs:167:20:167:22 | [implicit argument] s |
-| Capture.cs:166:13:166:28 | SSA capture def(s) | Capture.cs:166:13:166:28 | SSA capture def(s) |
-| Capture.cs:166:13:166:28 | SSA capture def(s) | Capture.cs:166:27:166:27 | access to parameter s |
-| Capture.cs:166:13:166:28 | SSA capture def(s) | Capture.cs:166:27:166:27 | access to parameter s |
-| Capture.cs:166:13:166:28 | SSA capture def(s) | Capture.cs:166:27:166:27 | access to parameter s |
-| Capture.cs:166:13:166:28 | SSA capture def(s) | Capture.cs:166:27:166:27 | access to parameter s |
-| Capture.cs:166:27:166:27 | access to parameter s | Capture.cs:166:27:166:27 | access to parameter s |
-| Capture.cs:166:27:166:27 | access to parameter s | Capture.cs:167:20:167:22 | call to local function M |
-| Capture.cs:166:27:166:27 | access to parameter s | Capture.cs:167:20:167:22 | call to local function M |
-| Capture.cs:167:20:167:20 | access to local function M | Capture.cs:167:20:167:20 | access to local function M |
-| Capture.cs:167:20:167:22 | [implicit argument] s | Capture.cs:166:13:166:28 | SSA capture def(s) |
-| Capture.cs:167:20:167:22 | [implicit argument] s | Capture.cs:166:13:166:28 | SSA capture def(s) |
-| Capture.cs:167:20:167:22 | [implicit argument] s | Capture.cs:166:13:166:28 | SSA capture def(s) |
-| Capture.cs:167:20:167:22 | [implicit argument] s | Capture.cs:166:13:166:28 | SSA capture def(s) |
-| Capture.cs:167:20:167:22 | [implicit argument] s | Capture.cs:167:20:167:22 | [implicit argument] s |
-| Capture.cs:167:20:167:22 | [implicit argument] s | Capture.cs:167:20:167:22 | call to local function M |
-| Capture.cs:167:20:167:22 | [implicit argument] s | Capture.cs:167:20:167:22 | call to local function M |
-| Capture.cs:167:20:167:22 | [implicit argument] s | Capture.cs:167:20:167:22 | call to local function M |
-| Capture.cs:167:20:167:22 | [implicit argument] s | Capture.cs:167:20:167:22 | call to local function M |
-| Capture.cs:167:20:167:22 | call to local function M | Capture.cs:167:20:167:22 | call to local function M |
-| Capture.cs:167:20:167:22 | call to local function M | Capture.cs:170:22:170:32 | call to local function Id |
-| Capture.cs:167:20:167:22 | call to local function M | Capture.cs:170:22:170:32 | call to local function Id |
-| Capture.cs:167:20:167:22 | call to local function M | Capture.cs:172:20:172:25 | call to local function Id |
-| Capture.cs:167:20:167:22 | call to local function M | Capture.cs:172:20:172:25 | call to local function Id |
-| Capture.cs:170:13:170:32 | SSA def(sink38) | Capture.cs:170:13:170:32 | SSA def(sink38) |
-| Capture.cs:170:13:170:32 | SSA def(sink38) | Capture.cs:171:15:171:20 | access to local variable sink38 |
-| Capture.cs:170:13:170:32 | SSA def(sink38) | Capture.cs:171:15:171:20 | access to local variable sink38 |
-| Capture.cs:170:13:170:32 | String sink38 = ... | Capture.cs:170:13:170:32 | String sink38 = ... |
-| Capture.cs:170:22:170:23 | access to local function Id | Capture.cs:170:22:170:23 | access to local function Id |
-| Capture.cs:170:22:170:32 | call to local function Id | Capture.cs:170:13:170:32 | SSA def(sink38) |
-| Capture.cs:170:22:170:32 | call to local function Id | Capture.cs:170:13:170:32 | SSA def(sink38) |
-| Capture.cs:170:22:170:32 | call to local function Id | Capture.cs:170:22:170:32 | call to local function Id |
-| Capture.cs:170:22:170:32 | call to local function Id | Capture.cs:171:15:171:20 | access to local variable sink38 |
-| Capture.cs:170:22:170:32 | call to local function Id | Capture.cs:171:15:171:20 | access to local variable sink38 |
-| Capture.cs:170:25:170:31 | access to parameter tainted | Capture.cs:164:26:164:26 | s |
-| Capture.cs:170:25:170:31 | access to parameter tainted | Capture.cs:164:26:164:26 | s |
-| Capture.cs:170:25:170:31 | access to parameter tainted | Capture.cs:170:22:170:32 | call to local function Id |
-| Capture.cs:170:25:170:31 | access to parameter tainted | Capture.cs:170:22:170:32 | call to local function Id |
-| Capture.cs:170:25:170:31 | access to parameter tainted | Capture.cs:170:25:170:31 | access to parameter tainted |
-| Capture.cs:171:9:171:21 | call to method Check | Capture.cs:171:9:171:21 | call to method Check |
-| Capture.cs:171:15:171:20 | access to local variable sink38 | Capture.cs:171:15:171:20 | access to local variable sink38 |
-| Capture.cs:172:9:172:25 | ... = ... | Capture.cs:172:9:172:25 | ... = ... |
-| Capture.cs:172:9:172:25 | SSA def(nonSink0) | Capture.cs:172:9:172:25 | SSA def(nonSink0) |
-| Capture.cs:172:9:172:25 | SSA def(nonSink0) | Capture.cs:173:15:173:22 | access to local variable nonSink0 |
-| Capture.cs:172:9:172:25 | SSA def(nonSink0) | Capture.cs:173:15:173:22 | access to local variable nonSink0 |
-| Capture.cs:172:20:172:21 | access to local function Id | Capture.cs:172:20:172:21 | access to local function Id |
-| Capture.cs:172:20:172:25 | call to local function Id | Capture.cs:172:9:172:25 | SSA def(nonSink0) |
-| Capture.cs:172:20:172:25 | call to local function Id | Capture.cs:172:9:172:25 | SSA def(nonSink0) |
-| Capture.cs:172:20:172:25 | call to local function Id | Capture.cs:172:20:172:25 | call to local function Id |
-| Capture.cs:172:20:172:25 | call to local function Id | Capture.cs:173:15:173:22 | access to local variable nonSink0 |
-| Capture.cs:172:20:172:25 | call to local function Id | Capture.cs:173:15:173:22 | access to local variable nonSink0 |
-| Capture.cs:172:23:172:24 | "" | Capture.cs:164:26:164:26 | s |
-| Capture.cs:172:23:172:24 | "" | Capture.cs:164:26:164:26 | s |
-| Capture.cs:172:23:172:24 | "" | Capture.cs:172:20:172:25 | call to local function Id |
-| Capture.cs:172:23:172:24 | "" | Capture.cs:172:20:172:25 | call to local function Id |
-| Capture.cs:172:23:172:24 | "" | Capture.cs:172:23:172:24 | "" |
-| Capture.cs:173:9:173:23 | call to method Check | Capture.cs:173:9:173:23 | call to method Check |
-| Capture.cs:173:15:173:22 | access to local variable nonSink0 | Capture.cs:173:15:173:22 | access to local variable nonSink0 |
+| Capture.cs:126:13:129:13 | SSA capture def(tainted) | Capture.cs:126:13:129:13 | SSA capture def(tainted) |
+| Capture.cs:126:13:129:13 | SSA capture def(tainted) | Capture.cs:128:17:128:32 | SSA def(sink34) |
+| Capture.cs:126:13:129:13 | SSA capture def(tainted) | Capture.cs:128:17:128:32 | SSA def(sink34) |
+| Capture.cs:126:13:129:13 | SSA capture def(tainted) | Capture.cs:128:17:128:32 | SSA def(sink34) |
+| Capture.cs:126:13:129:13 | SSA capture def(tainted) | Capture.cs:128:17:128:32 | SSA def(sink34) |
+| Capture.cs:126:13:129:13 | SSA capture def(tainted) | Capture.cs:128:26:128:32 | access to parameter tainted |
+| Capture.cs:126:13:129:13 | SSA capture def(tainted) | Capture.cs:128:26:128:32 | access to parameter tainted |
+| Capture.cs:126:13:129:13 | SSA capture def(tainted) | Capture.cs:128:26:128:32 | access to parameter tainted |
+| Capture.cs:126:13:129:13 | SSA capture def(tainted) | Capture.cs:128:26:128:32 | access to parameter tainted |
+| Capture.cs:128:17:128:32 | ... = ... | Capture.cs:128:17:128:32 | ... = ... |
+| Capture.cs:128:17:128:32 | SSA def(sink34) | Capture.cs:128:17:128:32 | SSA def(sink34) |
+| Capture.cs:128:17:128:32 | SSA def(sink34) | Capture.cs:132:9:132:25 | SSA call def(sink34) |
+| Capture.cs:128:17:128:32 | SSA def(sink34) | Capture.cs:132:9:132:25 | SSA call def(sink34) |
+| Capture.cs:128:26:128:32 | access to parameter tainted | Capture.cs:128:17:128:32 | SSA def(sink34) |
+| Capture.cs:128:26:128:32 | access to parameter tainted | Capture.cs:128:17:128:32 | SSA def(sink34) |
+| Capture.cs:128:26:128:32 | access to parameter tainted | Capture.cs:128:17:128:32 | SSA def(sink34) |
+| Capture.cs:128:26:128:32 | access to parameter tainted | Capture.cs:128:17:128:32 | SSA def(sink34) |
+| Capture.cs:128:26:128:32 | access to parameter tainted | Capture.cs:128:26:128:32 | access to parameter tainted |
+| Capture.cs:130:13:130:13 | access to local function M | Capture.cs:130:13:130:13 | access to local function M |
+| Capture.cs:130:13:130:15 | call to local function M | Capture.cs:130:13:130:15 | call to local function M |
+| Capture.cs:132:9:132:23 | access to local function CaptureThrough2 | Capture.cs:132:9:132:23 | access to local function CaptureThrough2 |
+| Capture.cs:132:9:132:25 | SSA call def(sink34) | Capture.cs:132:9:132:25 | SSA call def(sink34) |
+| Capture.cs:132:9:132:25 | SSA call def(sink34) | Capture.cs:133:15:133:20 | access to local variable sink34 |
+| Capture.cs:132:9:132:25 | SSA call def(sink34) | Capture.cs:133:15:133:20 | access to local variable sink34 |
+| Capture.cs:132:9:132:25 | [implicit argument] tainted | Capture.cs:126:13:129:13 | SSA capture def(tainted) |
+| Capture.cs:132:9:132:25 | [implicit argument] tainted | Capture.cs:126:13:129:13 | SSA capture def(tainted) |
+| Capture.cs:132:9:132:25 | [implicit argument] tainted | Capture.cs:132:9:132:25 | SSA call def(sink34) |
+| Capture.cs:132:9:132:25 | [implicit argument] tainted | Capture.cs:132:9:132:25 | SSA call def(sink34) |
+| Capture.cs:132:9:132:25 | [implicit argument] tainted | Capture.cs:132:9:132:25 | [implicit argument] tainted |
+| Capture.cs:132:9:132:25 | call to local function CaptureThrough2 | Capture.cs:132:9:132:25 | call to local function CaptureThrough2 |
+| Capture.cs:133:9:133:21 | call to method Check | Capture.cs:133:9:133:21 | call to method Check |
+| Capture.cs:133:15:133:20 | access to local variable sink34 | Capture.cs:133:15:133:20 | access to local variable sink34 |
+| Capture.cs:135:16:135:26 | SSA def(sink35) | Capture.cs:135:16:135:26 | SSA def(sink35) |
+| Capture.cs:135:16:135:26 | String sink35 = ... | Capture.cs:135:16:135:26 | String sink35 = ... |
+| Capture.cs:135:25:135:26 | "" | Capture.cs:135:16:135:26 | SSA def(sink35) |
+| Capture.cs:135:25:135:26 | "" | Capture.cs:135:16:135:26 | SSA def(sink35) |
+| Capture.cs:135:25:135:26 | "" | Capture.cs:135:25:135:26 | "" |
+| Capture.cs:136:30:140:9 | Func<String,String> captureThrough3 = ... | Capture.cs:136:30:140:9 | Func<String,String> captureThrough3 = ... |
+| Capture.cs:136:30:140:9 | SSA def(captureThrough3) | Capture.cs:136:30:140:9 | SSA def(captureThrough3) |
+| Capture.cs:136:30:140:9 | SSA def(captureThrough3) | Capture.cs:141:30:141:44 | access to local variable captureThrough3 |
+| Capture.cs:136:30:140:9 | SSA def(captureThrough3) | Capture.cs:141:30:141:44 | access to local variable captureThrough3 |
+| Capture.cs:136:48:136:50 | arg | Capture.cs:136:48:136:50 | arg |
+| Capture.cs:136:48:136:50 | arg | Capture.cs:136:48:136:50 | arg |
+| Capture.cs:136:48:136:50 | arg | Capture.cs:139:20:139:22 | access to parameter arg |
+| Capture.cs:136:48:136:50 | arg | Capture.cs:139:20:139:22 | access to parameter arg |
+| Capture.cs:136:48:140:9 | (...) => ... | Capture.cs:136:30:140:9 | SSA def(captureThrough3) |
+| Capture.cs:136:48:140:9 | (...) => ... | Capture.cs:136:30:140:9 | SSA def(captureThrough3) |
+| Capture.cs:136:48:140:9 | (...) => ... | Capture.cs:136:48:140:9 | (...) => ... |
+| Capture.cs:136:48:140:9 | (...) => ... | Capture.cs:141:30:141:44 | access to local variable captureThrough3 |
+| Capture.cs:136:48:140:9 | (...) => ... | Capture.cs:141:30:141:44 | access to local variable captureThrough3 |
+| Capture.cs:136:48:140:9 | SSA capture def(tainted) | Capture.cs:136:48:140:9 | SSA capture def(tainted) |
+| Capture.cs:136:48:140:9 | SSA capture def(tainted) | Capture.cs:138:13:138:28 | SSA def(sink35) |
+| Capture.cs:136:48:140:9 | SSA capture def(tainted) | Capture.cs:138:13:138:28 | SSA def(sink35) |
+| Capture.cs:136:48:140:9 | SSA capture def(tainted) | Capture.cs:138:13:138:28 | SSA def(sink35) |
+| Capture.cs:136:48:140:9 | SSA capture def(tainted) | Capture.cs:138:13:138:28 | SSA def(sink35) |
+| Capture.cs:136:48:140:9 | SSA capture def(tainted) | Capture.cs:138:22:138:28 | access to parameter tainted |
+| Capture.cs:136:48:140:9 | SSA capture def(tainted) | Capture.cs:138:22:138:28 | access to parameter tainted |
+| Capture.cs:136:48:140:9 | SSA capture def(tainted) | Capture.cs:138:22:138:28 | access to parameter tainted |
+| Capture.cs:136:48:140:9 | SSA capture def(tainted) | Capture.cs:138:22:138:28 | access to parameter tainted |
+| Capture.cs:138:13:138:28 | ... = ... | Capture.cs:138:13:138:28 | ... = ... |
+| Capture.cs:138:13:138:28 | SSA def(sink35) | Capture.cs:138:13:138:28 | SSA def(sink35) |
+| Capture.cs:138:13:138:28 | SSA def(sink35) | Capture.cs:141:9:141:45 | SSA call def(sink35) |
+| Capture.cs:138:13:138:28 | SSA def(sink35) | Capture.cs:141:9:141:45 | SSA call def(sink35) |
+| Capture.cs:138:22:138:28 | access to parameter tainted | Capture.cs:138:13:138:28 | SSA def(sink35) |
+| Capture.cs:138:22:138:28 | access to parameter tainted | Capture.cs:138:13:138:28 | SSA def(sink35) |
+| Capture.cs:138:22:138:28 | access to parameter tainted | Capture.cs:138:13:138:28 | SSA def(sink35) |
+| Capture.cs:138:22:138:28 | access to parameter tainted | Capture.cs:138:13:138:28 | SSA def(sink35) |
+| Capture.cs:138:22:138:28 | access to parameter tainted | Capture.cs:138:22:138:28 | access to parameter tainted |
+| Capture.cs:139:20:139:22 | access to parameter arg | Capture.cs:139:20:139:22 | access to parameter arg |
+| Capture.cs:139:20:139:22 | access to parameter arg | Capture.cs:141:30:141:44 | [output] access to local variable captureThrough3 |
+| Capture.cs:139:20:139:22 | access to parameter arg | Capture.cs:141:30:141:44 | [output] access to local variable captureThrough3 |
+| Capture.cs:141:9:141:21 | array creation of type String[] | Capture.cs:136:48:136:50 | arg |
+| Capture.cs:141:9:141:21 | array creation of type String[] | Capture.cs:136:48:136:50 | arg |
+| Capture.cs:141:9:141:21 | array creation of type String[] | Capture.cs:141:9:141:21 | array creation of type String[] |
+| Capture.cs:141:9:141:45 | SSA call def(sink35) | Capture.cs:141:9:141:45 | SSA call def(sink35) |
+| Capture.cs:141:9:141:45 | SSA call def(sink35) | Capture.cs:142:15:142:20 | access to local variable sink35 |
+| Capture.cs:141:9:141:45 | SSA call def(sink35) | Capture.cs:142:15:142:20 | access to local variable sink35 |
+| Capture.cs:141:9:141:45 | [implicit argument] tainted | Capture.cs:136:48:140:9 | SSA capture def(tainted) |
+| Capture.cs:141:9:141:45 | [implicit argument] tainted | Capture.cs:136:48:140:9 | SSA capture def(tainted) |
+| Capture.cs:141:9:141:45 | [implicit argument] tainted | Capture.cs:141:9:141:45 | SSA call def(sink35) |
+| Capture.cs:141:9:141:45 | [implicit argument] tainted | Capture.cs:141:9:141:45 | SSA call def(sink35) |
+| Capture.cs:141:9:141:45 | [implicit argument] tainted | Capture.cs:141:9:141:45 | [implicit argument] tainted |
+| Capture.cs:141:9:141:45 | call to method Select | Capture.cs:141:9:141:45 | call to method Select |
+| Capture.cs:141:9:141:55 | call to method ToArray | Capture.cs:141:9:141:55 | call to method ToArray |
+| Capture.cs:141:15:141:21 | { ..., ... } | Capture.cs:141:15:141:21 | { ..., ... } |
+| Capture.cs:141:17:141:19 | " " | Capture.cs:141:17:141:19 | " " |
+| Capture.cs:141:30:141:44 | [output] access to local variable captureThrough3 | Capture.cs:141:30:141:44 | [output] access to local variable captureThrough3 |
+| Capture.cs:141:30:141:44 | access to local variable captureThrough3 | Capture.cs:141:30:141:44 | access to local variable captureThrough3 |
+| Capture.cs:142:9:142:21 | call to method Check | Capture.cs:142:9:142:21 | call to method Check |
+| Capture.cs:142:15:142:20 | access to local variable sink35 | Capture.cs:142:15:142:20 | access to local variable sink35 |
+| Capture.cs:144:9:147:9 | SSA capture def(tainted) | Capture.cs:144:9:147:9 | SSA capture def(tainted) |
+| Capture.cs:144:9:147:9 | SSA capture def(tainted) | Capture.cs:146:20:146:26 | access to parameter tainted |
+| Capture.cs:144:9:147:9 | SSA capture def(tainted) | Capture.cs:146:20:146:26 | access to parameter tainted |
+| Capture.cs:144:9:147:9 | SSA capture def(tainted) | Capture.cs:146:20:146:26 | access to parameter tainted |
+| Capture.cs:144:9:147:9 | SSA capture def(tainted) | Capture.cs:146:20:146:26 | access to parameter tainted |
+| Capture.cs:146:20:146:26 | access to parameter tainted | Capture.cs:146:20:146:26 | access to parameter tainted |
+| Capture.cs:146:20:146:26 | access to parameter tainted | Capture.cs:148:22:148:38 | call to local function CaptureThrough4 |
+| Capture.cs:146:20:146:26 | access to parameter tainted | Capture.cs:148:22:148:38 | call to local function CaptureThrough4 |
+| Capture.cs:148:13:148:38 | SSA def(sink36) | Capture.cs:148:13:148:38 | SSA def(sink36) |
+| Capture.cs:148:13:148:38 | SSA def(sink36) | Capture.cs:149:15:149:20 | access to local variable sink36 |
+| Capture.cs:148:13:148:38 | SSA def(sink36) | Capture.cs:149:15:149:20 | access to local variable sink36 |
+| Capture.cs:148:13:148:38 | String sink36 = ... | Capture.cs:148:13:148:38 | String sink36 = ... |
+| Capture.cs:148:22:148:36 | access to local function CaptureThrough4 | Capture.cs:148:22:148:36 | access to local function CaptureThrough4 |
+| Capture.cs:148:22:148:38 | [implicit argument] tainted | Capture.cs:144:9:147:9 | SSA capture def(tainted) |
+| Capture.cs:148:22:148:38 | [implicit argument] tainted | Capture.cs:144:9:147:9 | SSA capture def(tainted) |
+| Capture.cs:148:22:148:38 | [implicit argument] tainted | Capture.cs:148:22:148:38 | [implicit argument] tainted |
+| Capture.cs:148:22:148:38 | [implicit argument] tainted | Capture.cs:148:22:148:38 | call to local function CaptureThrough4 |
+| Capture.cs:148:22:148:38 | [implicit argument] tainted | Capture.cs:148:22:148:38 | call to local function CaptureThrough4 |
+| Capture.cs:148:22:148:38 | call to local function CaptureThrough4 | Capture.cs:148:13:148:38 | SSA def(sink36) |
+| Capture.cs:148:22:148:38 | call to local function CaptureThrough4 | Capture.cs:148:13:148:38 | SSA def(sink36) |
+| Capture.cs:148:22:148:38 | call to local function CaptureThrough4 | Capture.cs:148:22:148:38 | call to local function CaptureThrough4 |
+| Capture.cs:148:22:148:38 | call to local function CaptureThrough4 | Capture.cs:149:15:149:20 | access to local variable sink36 |
+| Capture.cs:148:22:148:38 | call to local function CaptureThrough4 | Capture.cs:149:15:149:20 | access to local variable sink36 |
+| Capture.cs:149:9:149:21 | call to method Check | Capture.cs:149:9:149:21 | call to method Check |
+| Capture.cs:149:15:149:20 | access to local variable sink36 | Capture.cs:149:15:149:20 | access to local variable sink36 |
+| Capture.cs:151:13:151:23 | SSA def(sink37) | Capture.cs:151:13:151:23 | SSA def(sink37) |
+| Capture.cs:151:13:151:23 | String sink37 = ... | Capture.cs:151:13:151:23 | String sink37 = ... |
+| Capture.cs:151:22:151:23 | "" | Capture.cs:151:13:151:23 | SSA def(sink37) |
+| Capture.cs:151:22:151:23 | "" | Capture.cs:151:13:151:23 | SSA def(sink37) |
+| Capture.cs:151:22:151:23 | "" | Capture.cs:151:22:151:23 | "" |
+| Capture.cs:152:37:152:37 | p | Capture.cs:152:37:152:37 | p |
+| Capture.cs:152:37:152:37 | p | Capture.cs:152:37:152:37 | p |
+| Capture.cs:152:37:152:37 | p | Capture.cs:154:13:154:22 | SSA def(sink37) |
+| Capture.cs:152:37:152:37 | p | Capture.cs:154:13:154:22 | SSA def(sink37) |
+| Capture.cs:152:37:152:37 | p | Capture.cs:154:13:154:22 | SSA def(sink37) |
+| Capture.cs:152:37:152:37 | p | Capture.cs:154:13:154:22 | SSA def(sink37) |
+| Capture.cs:152:37:152:37 | p | Capture.cs:154:22:154:22 | access to parameter p |
+| Capture.cs:152:37:152:37 | p | Capture.cs:154:22:154:22 | access to parameter p |
+| Capture.cs:152:37:152:37 | p | Capture.cs:154:22:154:22 | access to parameter p |
+| Capture.cs:152:37:152:37 | p | Capture.cs:154:22:154:22 | access to parameter p |
+| Capture.cs:154:13:154:22 | ... = ... | Capture.cs:154:13:154:22 | ... = ... |
+| Capture.cs:154:13:154:22 | SSA def(sink37) | Capture.cs:154:13:154:22 | SSA def(sink37) |
+| Capture.cs:154:13:154:22 | SSA def(sink37) | Capture.cs:156:9:156:32 | SSA call def(sink37) |
+| Capture.cs:154:13:154:22 | SSA def(sink37) | Capture.cs:156:9:156:32 | SSA call def(sink37) |
+| Capture.cs:154:22:154:22 | access to parameter p | Capture.cs:154:13:154:22 | SSA def(sink37) |
+| Capture.cs:154:22:154:22 | access to parameter p | Capture.cs:154:13:154:22 | SSA def(sink37) |
+| Capture.cs:154:22:154:22 | access to parameter p | Capture.cs:154:13:154:22 | SSA def(sink37) |
+| Capture.cs:154:22:154:22 | access to parameter p | Capture.cs:154:13:154:22 | SSA def(sink37) |
+| Capture.cs:154:22:154:22 | access to parameter p | Capture.cs:154:22:154:22 | access to parameter p |
+| Capture.cs:156:9:156:23 | access to local function CaptureThrough5 | Capture.cs:156:9:156:23 | access to local function CaptureThrough5 |
+| Capture.cs:156:9:156:32 | SSA call def(sink37) | Capture.cs:156:9:156:32 | SSA call def(sink37) |
+| Capture.cs:156:9:156:32 | SSA call def(sink37) | Capture.cs:157:15:157:20 | access to local variable sink37 |
+| Capture.cs:156:9:156:32 | SSA call def(sink37) | Capture.cs:157:15:157:20 | access to local variable sink37 |
+| Capture.cs:156:9:156:32 | call to local function CaptureThrough5 | Capture.cs:156:9:156:32 | call to local function CaptureThrough5 |
+| Capture.cs:156:25:156:31 | access to parameter tainted | Capture.cs:152:37:152:37 | p |
+| Capture.cs:156:25:156:31 | access to parameter tainted | Capture.cs:152:37:152:37 | p |
+| Capture.cs:156:25:156:31 | access to parameter tainted | Capture.cs:156:9:156:32 | SSA call def(sink37) |
+| Capture.cs:156:25:156:31 | access to parameter tainted | Capture.cs:156:9:156:32 | SSA call def(sink37) |
+| Capture.cs:156:25:156:31 | access to parameter tainted | Capture.cs:156:25:156:31 | access to parameter tainted |
+| Capture.cs:156:25:156:31 | access to parameter tainted | Capture.cs:182:25:182:31 | access to parameter tainted |
+| Capture.cs:156:25:156:31 | access to parameter tainted | Capture.cs:182:25:182:31 | access to parameter tainted |
+| Capture.cs:157:9:157:21 | call to method Check | Capture.cs:157:9:157:21 | call to method Check |
+| Capture.cs:157:15:157:20 | access to local variable sink37 | Capture.cs:157:15:157:20 | access to local variable sink37 |
+| Capture.cs:159:16:159:28 | SSA def(nonSink0) | Capture.cs:159:16:159:28 | SSA def(nonSink0) |
+| Capture.cs:159:16:159:28 | SSA def(nonSink0) | Capture.cs:164:15:164:22 | access to local variable nonSink0 |
+| Capture.cs:159:16:159:28 | SSA def(nonSink0) | Capture.cs:164:15:164:22 | access to local variable nonSink0 |
+| Capture.cs:159:16:159:28 | SSA def(nonSink0) | Capture.cs:174:15:174:22 | access to local variable nonSink0 |
+| Capture.cs:159:16:159:28 | SSA def(nonSink0) | Capture.cs:174:15:174:22 | access to local variable nonSink0 |
+| Capture.cs:159:16:159:28 | String nonSink0 = ... | Capture.cs:159:16:159:28 | String nonSink0 = ... |
+| Capture.cs:159:27:159:28 | "" | Capture.cs:159:16:159:28 | SSA def(nonSink0) |
+| Capture.cs:159:27:159:28 | "" | Capture.cs:159:16:159:28 | SSA def(nonSink0) |
+| Capture.cs:159:27:159:28 | "" | Capture.cs:159:27:159:28 | "" |
+| Capture.cs:159:27:159:28 | "" | Capture.cs:164:15:164:22 | access to local variable nonSink0 |
+| Capture.cs:159:27:159:28 | "" | Capture.cs:164:15:164:22 | access to local variable nonSink0 |
+| Capture.cs:159:27:159:28 | "" | Capture.cs:174:15:174:22 | access to local variable nonSink0 |
+| Capture.cs:159:27:159:28 | "" | Capture.cs:174:15:174:22 | access to local variable nonSink0 |
+| Capture.cs:160:9:163:9 | SSA capture def(tainted) | Capture.cs:160:9:163:9 | SSA capture def(tainted) |
+| Capture.cs:160:9:163:9 | SSA capture def(tainted) | Capture.cs:162:24:162:30 | access to parameter tainted |
+| Capture.cs:160:9:163:9 | SSA capture def(tainted) | Capture.cs:162:24:162:30 | access to parameter tainted |
+| Capture.cs:162:13:162:30 | ... = ... | Capture.cs:162:13:162:30 | ... = ... |
+| Capture.cs:162:24:162:30 | access to parameter tainted | Capture.cs:162:24:162:30 | access to parameter tainted |
+| Capture.cs:164:9:164:23 | call to method Check | Capture.cs:164:9:164:23 | call to method Check |
+| Capture.cs:164:15:164:22 | access to local variable nonSink0 | Capture.cs:164:15:164:22 | access to local variable nonSink0 |
+| Capture.cs:164:15:164:22 | access to local variable nonSink0 | Capture.cs:174:15:174:22 | access to local variable nonSink0 |
+| Capture.cs:164:15:164:22 | access to local variable nonSink0 | Capture.cs:174:15:174:22 | access to local variable nonSink0 |
+| Capture.cs:168:13:171:13 | SSA capture def(tainted) | Capture.cs:168:13:171:13 | SSA capture def(tainted) |
+| Capture.cs:168:13:171:13 | SSA capture def(tainted) | Capture.cs:170:28:170:34 | access to parameter tainted |
+| Capture.cs:168:13:171:13 | SSA capture def(tainted) | Capture.cs:170:28:170:34 | access to parameter tainted |
+| Capture.cs:170:17:170:34 | ... = ... | Capture.cs:170:17:170:34 | ... = ... |
+| Capture.cs:170:28:170:34 | access to parameter tainted | Capture.cs:170:28:170:34 | access to parameter tainted |
+| Capture.cs:173:9:173:32 | access to local function CaptureThrough2NotCalled | Capture.cs:173:9:173:32 | access to local function CaptureThrough2NotCalled |
+| Capture.cs:173:9:173:34 | call to local function CaptureThrough2NotCalled | Capture.cs:173:9:173:34 | call to local function CaptureThrough2NotCalled |
+| Capture.cs:174:9:174:23 | call to method Check | Capture.cs:174:9:174:23 | call to method Check |
+| Capture.cs:174:15:174:22 | access to local variable nonSink0 | Capture.cs:174:15:174:22 | access to local variable nonSink0 |
+| Capture.cs:176:26:176:26 | s | Capture.cs:176:26:176:26 | s |
+| Capture.cs:176:26:176:26 | s | Capture.cs:176:26:176:26 | s |
+| Capture.cs:176:26:176:26 | s | Capture.cs:179:20:179:22 | [implicit argument] s |
+| Capture.cs:176:26:176:26 | s | Capture.cs:179:20:179:22 | [implicit argument] s |
+| Capture.cs:176:26:176:26 | s | Capture.cs:179:20:179:22 | [implicit argument] s |
+| Capture.cs:176:26:176:26 | s | Capture.cs:179:20:179:22 | [implicit argument] s |
+| Capture.cs:178:13:178:28 | SSA capture def(s) | Capture.cs:178:13:178:28 | SSA capture def(s) |
+| Capture.cs:178:13:178:28 | SSA capture def(s) | Capture.cs:178:27:178:27 | access to parameter s |
+| Capture.cs:178:13:178:28 | SSA capture def(s) | Capture.cs:178:27:178:27 | access to parameter s |
+| Capture.cs:178:13:178:28 | SSA capture def(s) | Capture.cs:178:27:178:27 | access to parameter s |
+| Capture.cs:178:13:178:28 | SSA capture def(s) | Capture.cs:178:27:178:27 | access to parameter s |
+| Capture.cs:178:27:178:27 | access to parameter s | Capture.cs:178:27:178:27 | access to parameter s |
+| Capture.cs:178:27:178:27 | access to parameter s | Capture.cs:179:20:179:22 | call to local function M |
+| Capture.cs:178:27:178:27 | access to parameter s | Capture.cs:179:20:179:22 | call to local function M |
+| Capture.cs:179:20:179:20 | access to local function M | Capture.cs:179:20:179:20 | access to local function M |
+| Capture.cs:179:20:179:22 | [implicit argument] s | Capture.cs:178:13:178:28 | SSA capture def(s) |
+| Capture.cs:179:20:179:22 | [implicit argument] s | Capture.cs:178:13:178:28 | SSA capture def(s) |
+| Capture.cs:179:20:179:22 | [implicit argument] s | Capture.cs:178:13:178:28 | SSA capture def(s) |
+| Capture.cs:179:20:179:22 | [implicit argument] s | Capture.cs:178:13:178:28 | SSA capture def(s) |
+| Capture.cs:179:20:179:22 | [implicit argument] s | Capture.cs:179:20:179:22 | [implicit argument] s |
+| Capture.cs:179:20:179:22 | [implicit argument] s | Capture.cs:179:20:179:22 | call to local function M |
+| Capture.cs:179:20:179:22 | [implicit argument] s | Capture.cs:179:20:179:22 | call to local function M |
+| Capture.cs:179:20:179:22 | [implicit argument] s | Capture.cs:179:20:179:22 | call to local function M |
+| Capture.cs:179:20:179:22 | [implicit argument] s | Capture.cs:179:20:179:22 | call to local function M |
+| Capture.cs:179:20:179:22 | call to local function M | Capture.cs:179:20:179:22 | call to local function M |
+| Capture.cs:179:20:179:22 | call to local function M | Capture.cs:182:22:182:32 | call to local function Id |
+| Capture.cs:179:20:179:22 | call to local function M | Capture.cs:182:22:182:32 | call to local function Id |
+| Capture.cs:179:20:179:22 | call to local function M | Capture.cs:184:20:184:25 | call to local function Id |
+| Capture.cs:179:20:179:22 | call to local function M | Capture.cs:184:20:184:25 | call to local function Id |
+| Capture.cs:182:13:182:32 | SSA def(sink38) | Capture.cs:182:13:182:32 | SSA def(sink38) |
+| Capture.cs:182:13:182:32 | SSA def(sink38) | Capture.cs:183:15:183:20 | access to local variable sink38 |
+| Capture.cs:182:13:182:32 | SSA def(sink38) | Capture.cs:183:15:183:20 | access to local variable sink38 |
+| Capture.cs:182:13:182:32 | String sink38 = ... | Capture.cs:182:13:182:32 | String sink38 = ... |
+| Capture.cs:182:22:182:23 | access to local function Id | Capture.cs:182:22:182:23 | access to local function Id |
+| Capture.cs:182:22:182:32 | call to local function Id | Capture.cs:182:13:182:32 | SSA def(sink38) |
+| Capture.cs:182:22:182:32 | call to local function Id | Capture.cs:182:13:182:32 | SSA def(sink38) |
+| Capture.cs:182:22:182:32 | call to local function Id | Capture.cs:182:22:182:32 | call to local function Id |
+| Capture.cs:182:22:182:32 | call to local function Id | Capture.cs:183:15:183:20 | access to local variable sink38 |
+| Capture.cs:182:22:182:32 | call to local function Id | Capture.cs:183:15:183:20 | access to local variable sink38 |
+| Capture.cs:182:25:182:31 | access to parameter tainted | Capture.cs:176:26:176:26 | s |
+| Capture.cs:182:25:182:31 | access to parameter tainted | Capture.cs:176:26:176:26 | s |
+| Capture.cs:182:25:182:31 | access to parameter tainted | Capture.cs:182:22:182:32 | call to local function Id |
+| Capture.cs:182:25:182:31 | access to parameter tainted | Capture.cs:182:22:182:32 | call to local function Id |
+| Capture.cs:182:25:182:31 | access to parameter tainted | Capture.cs:182:25:182:31 | access to parameter tainted |
+| Capture.cs:183:9:183:21 | call to method Check | Capture.cs:183:9:183:21 | call to method Check |
+| Capture.cs:183:15:183:20 | access to local variable sink38 | Capture.cs:183:15:183:20 | access to local variable sink38 |
+| Capture.cs:184:9:184:25 | ... = ... | Capture.cs:184:9:184:25 | ... = ... |
+| Capture.cs:184:9:184:25 | SSA def(nonSink0) | Capture.cs:184:9:184:25 | SSA def(nonSink0) |
+| Capture.cs:184:9:184:25 | SSA def(nonSink0) | Capture.cs:185:15:185:22 | access to local variable nonSink0 |
+| Capture.cs:184:9:184:25 | SSA def(nonSink0) | Capture.cs:185:15:185:22 | access to local variable nonSink0 |
+| Capture.cs:184:20:184:21 | access to local function Id | Capture.cs:184:20:184:21 | access to local function Id |
+| Capture.cs:184:20:184:25 | call to local function Id | Capture.cs:184:9:184:25 | SSA def(nonSink0) |
+| Capture.cs:184:20:184:25 | call to local function Id | Capture.cs:184:9:184:25 | SSA def(nonSink0) |
+| Capture.cs:184:20:184:25 | call to local function Id | Capture.cs:184:20:184:25 | call to local function Id |
+| Capture.cs:184:20:184:25 | call to local function Id | Capture.cs:185:15:185:22 | access to local variable nonSink0 |
+| Capture.cs:184:20:184:25 | call to local function Id | Capture.cs:185:15:185:22 | access to local variable nonSink0 |
+| Capture.cs:184:23:184:24 | "" | Capture.cs:176:26:176:26 | s |
+| Capture.cs:184:23:184:24 | "" | Capture.cs:176:26:176:26 | s |
+| Capture.cs:184:23:184:24 | "" | Capture.cs:184:20:184:25 | call to local function Id |
+| Capture.cs:184:23:184:24 | "" | Capture.cs:184:20:184:25 | call to local function Id |
+| Capture.cs:184:23:184:24 | "" | Capture.cs:184:23:184:24 | "" |
+| Capture.cs:185:9:185:23 | call to method Check | Capture.cs:185:9:185:23 | call to method Check |
+| Capture.cs:185:15:185:22 | access to local variable nonSink0 | Capture.cs:185:15:185:22 | access to local variable nonSink0 |
 | GlobalDataFlow.cs:14:17:14:17 | this | GlobalDataFlow.cs:14:17:14:17 | this |
 | GlobalDataFlow.cs:14:17:14:17 | this | GlobalDataFlow.cs:64:9:64:18 | this access |
 | GlobalDataFlow.cs:14:17:14:17 | this | GlobalDataFlow.cs:64:9:64:18 | this access |

--- a/csharp/ql/test/library-tests/dataflow/global/DataFlowEdges.expected
+++ b/csharp/ql/test/library-tests/dataflow/global/DataFlowEdges.expected
@@ -7,6 +7,8 @@
 | Capture.cs:7:20:7:26 | tainted | Capture.cs:25:9:25:20 | [implicit argument] tainted |
 | Capture.cs:7:20:7:26 | tainted | Capture.cs:33:9:33:40 | [implicit argument] tainted |
 | Capture.cs:7:20:7:26 | tainted | Capture.cs:33:9:33:40 | [implicit argument] tainted |
+| Capture.cs:7:20:7:26 | tainted | Capture.cs:61:36:61:42 | access to parameter tainted |
+| Capture.cs:7:20:7:26 | tainted | Capture.cs:61:36:61:42 | access to parameter tainted |
 | Capture.cs:9:9:13:9 | SSA capture def(tainted) | Capture.cs:9:9:13:9 | SSA capture def(tainted) |
 | Capture.cs:9:9:13:9 | SSA capture def(tainted) | Capture.cs:11:17:11:32 | SSA def(sink27) |
 | Capture.cs:9:9:13:9 | SSA capture def(tainted) | Capture.cs:11:17:11:32 | SSA def(sink27) |
@@ -175,6 +177,58 @@
 | Capture.cs:46:23:46:30 | access to local variable nonSink0 | Capture.cs:46:23:46:30 | access to local variable nonSink0 |
 | Capture.cs:49:9:49:27 | access to local function CaptureIn2NotCalled | Capture.cs:49:9:49:27 | access to local function CaptureIn2NotCalled |
 | Capture.cs:49:9:49:29 | call to local function CaptureIn2NotCalled | Capture.cs:49:9:49:29 | call to local function CaptureIn2NotCalled |
+| Capture.cs:50:33:50:40 | nonSink0 | Capture.cs:50:33:50:40 | nonSink0 |
+| Capture.cs:50:33:50:40 | nonSink0 | Capture.cs:50:33:50:40 | nonSink0 |
+| Capture.cs:50:33:50:40 | nonSink0 | Capture.cs:52:13:59:14 | [implicit argument] nonSink0 |
+| Capture.cs:50:33:50:40 | nonSink0 | Capture.cs:52:13:59:14 | [implicit argument] nonSink0 |
+| Capture.cs:50:33:50:40 | nonSink0 | Capture.cs:52:13:59:14 | [implicit argument] nonSink0 |
+| Capture.cs:50:33:50:40 | nonSink0 | Capture.cs:52:13:59:14 | [implicit argument] nonSink0 |
+| Capture.cs:50:50:50:55 | sink39 | Capture.cs:50:50:50:55 | sink39 |
+| Capture.cs:50:50:50:55 | sink39 | Capture.cs:50:50:50:55 | sink39 |
+| Capture.cs:50:50:50:55 | sink39 | Capture.cs:52:13:59:14 | [implicit argument] sink39 |
+| Capture.cs:50:50:50:55 | sink39 | Capture.cs:52:13:59:14 | [implicit argument] sink39 |
+| Capture.cs:50:50:50:55 | sink39 | Capture.cs:52:13:59:14 | [implicit argument] sink39 |
+| Capture.cs:50:50:50:55 | sink39 | Capture.cs:52:13:59:14 | [implicit argument] sink39 |
+| Capture.cs:52:13:59:14 | [implicit argument] nonSink0 | Capture.cs:52:13:59:14 | [implicit argument] nonSink0 |
+| Capture.cs:52:13:59:14 | [implicit argument] nonSink0 | Capture.cs:52:23:59:13 | SSA capture def(nonSink0) |
+| Capture.cs:52:13:59:14 | [implicit argument] nonSink0 | Capture.cs:52:23:59:13 | SSA capture def(nonSink0) |
+| Capture.cs:52:13:59:14 | [implicit argument] nonSink0 | Capture.cs:52:23:59:13 | SSA capture def(nonSink0) |
+| Capture.cs:52:13:59:14 | [implicit argument] nonSink0 | Capture.cs:52:23:59:13 | SSA capture def(nonSink0) |
+| Capture.cs:52:13:59:14 | [implicit argument] sink39 | Capture.cs:52:13:59:14 | [implicit argument] sink39 |
+| Capture.cs:52:13:59:14 | [implicit argument] sink39 | Capture.cs:55:27:58:17 | SSA capture def(sink39) |
+| Capture.cs:52:13:59:14 | [implicit argument] sink39 | Capture.cs:55:27:58:17 | SSA capture def(sink39) |
+| Capture.cs:52:13:59:14 | [implicit argument] sink39 | Capture.cs:55:27:58:17 | SSA capture def(sink39) |
+| Capture.cs:52:13:59:14 | [implicit argument] sink39 | Capture.cs:55:27:58:17 | SSA capture def(sink39) |
+| Capture.cs:52:13:59:14 | call to method RunAction | Capture.cs:52:13:59:14 | call to method RunAction |
+| Capture.cs:52:23:59:13 | (...) => ... | Capture.cs:52:23:59:13 | (...) => ... |
+| Capture.cs:52:23:59:13 | (...) => ... | Capture.cs:190:34:190:34 | a |
+| Capture.cs:52:23:59:13 | (...) => ... | Capture.cs:190:34:190:34 | a |
+| Capture.cs:52:23:59:13 | SSA capture def(nonSink0) | Capture.cs:52:23:59:13 | SSA capture def(nonSink0) |
+| Capture.cs:52:23:59:13 | SSA capture def(nonSink0) | Capture.cs:54:23:54:30 | access to parameter nonSink0 |
+| Capture.cs:52:23:59:13 | SSA capture def(nonSink0) | Capture.cs:54:23:54:30 | access to parameter nonSink0 |
+| Capture.cs:52:23:59:13 | SSA capture def(nonSink0) | Capture.cs:54:23:54:30 | access to parameter nonSink0 |
+| Capture.cs:52:23:59:13 | SSA capture def(nonSink0) | Capture.cs:54:23:54:30 | access to parameter nonSink0 |
+| Capture.cs:54:17:54:31 | call to method Check | Capture.cs:54:17:54:31 | call to method Check |
+| Capture.cs:54:23:54:30 | access to parameter nonSink0 | Capture.cs:54:23:54:30 | access to parameter nonSink0 |
+| Capture.cs:55:17:58:18 | call to method RunAction | Capture.cs:55:17:58:18 | call to method RunAction |
+| Capture.cs:55:27:58:17 | (...) => ... | Capture.cs:55:27:58:17 | (...) => ... |
+| Capture.cs:55:27:58:17 | (...) => ... | Capture.cs:190:34:190:34 | a |
+| Capture.cs:55:27:58:17 | (...) => ... | Capture.cs:190:34:190:34 | a |
+| Capture.cs:55:27:58:17 | SSA capture def(sink39) | Capture.cs:55:27:58:17 | SSA capture def(sink39) |
+| Capture.cs:55:27:58:17 | SSA capture def(sink39) | Capture.cs:57:27:57:32 | access to parameter sink39 |
+| Capture.cs:55:27:58:17 | SSA capture def(sink39) | Capture.cs:57:27:57:32 | access to parameter sink39 |
+| Capture.cs:55:27:58:17 | SSA capture def(sink39) | Capture.cs:57:27:57:32 | access to parameter sink39 |
+| Capture.cs:55:27:58:17 | SSA capture def(sink39) | Capture.cs:57:27:57:32 | access to parameter sink39 |
+| Capture.cs:57:21:57:33 | call to method Check | Capture.cs:57:21:57:33 | call to method Check |
+| Capture.cs:57:27:57:32 | access to parameter sink39 | Capture.cs:57:27:57:32 | access to parameter sink39 |
+| Capture.cs:61:9:61:19 | access to local function CaptureTest | Capture.cs:61:9:61:19 | access to local function CaptureTest |
+| Capture.cs:61:9:61:43 | call to local function CaptureTest | Capture.cs:61:9:61:43 | call to local function CaptureTest |
+| Capture.cs:61:21:61:33 | "not tainted" | Capture.cs:50:33:50:40 | nonSink0 |
+| Capture.cs:61:21:61:33 | "not tainted" | Capture.cs:50:33:50:40 | nonSink0 |
+| Capture.cs:61:21:61:33 | "not tainted" | Capture.cs:61:21:61:33 | "not tainted" |
+| Capture.cs:61:36:61:42 | access to parameter tainted | Capture.cs:50:50:50:55 | sink39 |
+| Capture.cs:61:36:61:42 | access to parameter tainted | Capture.cs:50:50:50:55 | sink39 |
+| Capture.cs:61:36:61:42 | access to parameter tainted | Capture.cs:61:36:61:42 | access to parameter tainted |
 | Capture.cs:64:10:64:12 | this | Capture.cs:64:10:64:12 | this |
 | Capture.cs:66:16:66:26 | SSA def(sink30) | Capture.cs:66:16:66:26 | SSA def(sink30) |
 | Capture.cs:66:16:66:26 | String sink30 = ... | Capture.cs:66:16:66:26 | String sink30 = ... |
@@ -585,6 +639,16 @@
 | Capture.cs:184:23:184:24 | "" | Capture.cs:184:23:184:24 | "" |
 | Capture.cs:185:9:185:23 | call to method Check | Capture.cs:185:9:185:23 | call to method Check |
 | Capture.cs:185:15:185:22 | access to local variable nonSink0 | Capture.cs:185:15:185:22 | access to local variable nonSink0 |
+| Capture.cs:190:34:190:34 | a | Capture.cs:190:34:190:34 | a |
+| Capture.cs:190:34:190:34 | a | Capture.cs:190:34:190:34 | a |
+| Capture.cs:190:34:190:34 | a | Capture.cs:192:9:192:9 | access to parameter a |
+| Capture.cs:190:34:190:34 | a | Capture.cs:192:9:192:9 | access to parameter a |
+| Capture.cs:190:34:190:34 | a | Capture.cs:192:9:192:9 | access to parameter a |
+| Capture.cs:190:34:190:34 | a | Capture.cs:192:9:192:9 | access to parameter a |
+| Capture.cs:190:34:190:34 | a | Capture.cs:192:9:192:9 | access to parameter a |
+| Capture.cs:190:34:190:34 | a | Capture.cs:192:9:192:9 | access to parameter a |
+| Capture.cs:192:9:192:9 | access to parameter a | Capture.cs:192:9:192:9 | access to parameter a |
+| Capture.cs:192:9:192:18 | delegate call | Capture.cs:192:9:192:18 | delegate call |
 | GlobalDataFlow.cs:14:17:14:17 | this | GlobalDataFlow.cs:14:17:14:17 | this |
 | GlobalDataFlow.cs:14:17:14:17 | this | GlobalDataFlow.cs:64:9:64:18 | this access |
 | GlobalDataFlow.cs:14:17:14:17 | this | GlobalDataFlow.cs:64:9:64:18 | this access |

--- a/csharp/ql/test/library-tests/dataflow/global/DataFlowEdges.expected
+++ b/csharp/ql/test/library-tests/dataflow/global/DataFlowEdges.expected
@@ -201,8 +201,8 @@
 | Capture.cs:52:13:59:14 | [implicit argument] sink39 | Capture.cs:55:27:58:17 | SSA capture def(sink39) |
 | Capture.cs:52:13:59:14 | call to method RunAction | Capture.cs:52:13:59:14 | call to method RunAction |
 | Capture.cs:52:23:59:13 | (...) => ... | Capture.cs:52:23:59:13 | (...) => ... |
-| Capture.cs:52:23:59:13 | (...) => ... | Capture.cs:190:34:190:34 | a |
-| Capture.cs:52:23:59:13 | (...) => ... | Capture.cs:190:34:190:34 | a |
+| Capture.cs:52:23:59:13 | (...) => ... | Capture.cs:202:34:202:34 | a |
+| Capture.cs:52:23:59:13 | (...) => ... | Capture.cs:202:34:202:34 | a |
 | Capture.cs:52:23:59:13 | SSA capture def(nonSink0) | Capture.cs:52:23:59:13 | SSA capture def(nonSink0) |
 | Capture.cs:52:23:59:13 | SSA capture def(nonSink0) | Capture.cs:54:23:54:30 | access to parameter nonSink0 |
 | Capture.cs:52:23:59:13 | SSA capture def(nonSink0) | Capture.cs:54:23:54:30 | access to parameter nonSink0 |
@@ -212,8 +212,8 @@
 | Capture.cs:54:23:54:30 | access to parameter nonSink0 | Capture.cs:54:23:54:30 | access to parameter nonSink0 |
 | Capture.cs:55:17:58:18 | call to method RunAction | Capture.cs:55:17:58:18 | call to method RunAction |
 | Capture.cs:55:27:58:17 | (...) => ... | Capture.cs:55:27:58:17 | (...) => ... |
-| Capture.cs:55:27:58:17 | (...) => ... | Capture.cs:190:34:190:34 | a |
-| Capture.cs:55:27:58:17 | (...) => ... | Capture.cs:190:34:190:34 | a |
+| Capture.cs:55:27:58:17 | (...) => ... | Capture.cs:202:34:202:34 | a |
+| Capture.cs:55:27:58:17 | (...) => ... | Capture.cs:202:34:202:34 | a |
 | Capture.cs:55:27:58:17 | SSA capture def(sink39) | Capture.cs:55:27:58:17 | SSA capture def(sink39) |
 | Capture.cs:55:27:58:17 | SSA capture def(sink39) | Capture.cs:57:27:57:32 | access to parameter sink39 |
 | Capture.cs:55:27:58:17 | SSA capture def(sink39) | Capture.cs:57:27:57:32 | access to parameter sink39 |
@@ -337,318 +337,318 @@
 | Capture.cs:109:9:109:30 | call to local function CaptureOut2NotCalled | Capture.cs:109:9:109:30 | call to local function CaptureOut2NotCalled |
 | Capture.cs:110:9:110:23 | call to method Check | Capture.cs:110:9:110:23 | call to method Check |
 | Capture.cs:110:15:110:22 | access to local variable nonSink0 | Capture.cs:110:15:110:22 | access to local variable nonSink0 |
-| Capture.cs:113:10:113:16 | this | Capture.cs:113:10:113:16 | this |
-| Capture.cs:113:25:113:31 | tainted | Capture.cs:113:25:113:31 | tainted |
-| Capture.cs:113:25:113:31 | tainted | Capture.cs:113:25:113:31 | tainted |
-| Capture.cs:113:25:113:31 | tainted | Capture.cs:120:9:120:25 | [implicit argument] tainted |
-| Capture.cs:113:25:113:31 | tainted | Capture.cs:120:9:120:25 | [implicit argument] tainted |
-| Capture.cs:113:25:113:31 | tainted | Capture.cs:132:9:132:25 | [implicit argument] tainted |
-| Capture.cs:113:25:113:31 | tainted | Capture.cs:132:9:132:25 | [implicit argument] tainted |
-| Capture.cs:113:25:113:31 | tainted | Capture.cs:141:9:141:45 | [implicit argument] tainted |
-| Capture.cs:113:25:113:31 | tainted | Capture.cs:141:9:141:45 | [implicit argument] tainted |
-| Capture.cs:113:25:113:31 | tainted | Capture.cs:148:22:148:38 | [implicit argument] tainted |
-| Capture.cs:113:25:113:31 | tainted | Capture.cs:148:22:148:38 | [implicit argument] tainted |
-| Capture.cs:113:25:113:31 | tainted | Capture.cs:156:25:156:31 | access to parameter tainted |
-| Capture.cs:113:25:113:31 | tainted | Capture.cs:156:25:156:31 | access to parameter tainted |
-| Capture.cs:113:25:113:31 | tainted | Capture.cs:182:25:182:31 | access to parameter tainted |
-| Capture.cs:113:25:113:31 | tainted | Capture.cs:182:25:182:31 | access to parameter tainted |
-| Capture.cs:115:16:115:26 | SSA def(sink33) | Capture.cs:115:16:115:26 | SSA def(sink33) |
-| Capture.cs:115:16:115:26 | String sink33 = ... | Capture.cs:115:16:115:26 | String sink33 = ... |
-| Capture.cs:115:25:115:26 | "" | Capture.cs:115:16:115:26 | SSA def(sink33) |
-| Capture.cs:115:25:115:26 | "" | Capture.cs:115:16:115:26 | SSA def(sink33) |
-| Capture.cs:115:25:115:26 | "" | Capture.cs:115:25:115:26 | "" |
-| Capture.cs:116:9:119:9 | SSA capture def(tainted) | Capture.cs:116:9:119:9 | SSA capture def(tainted) |
-| Capture.cs:116:9:119:9 | SSA capture def(tainted) | Capture.cs:118:13:118:28 | SSA def(sink33) |
-| Capture.cs:116:9:119:9 | SSA capture def(tainted) | Capture.cs:118:13:118:28 | SSA def(sink33) |
-| Capture.cs:116:9:119:9 | SSA capture def(tainted) | Capture.cs:118:13:118:28 | SSA def(sink33) |
-| Capture.cs:116:9:119:9 | SSA capture def(tainted) | Capture.cs:118:13:118:28 | SSA def(sink33) |
-| Capture.cs:116:9:119:9 | SSA capture def(tainted) | Capture.cs:118:22:118:28 | access to parameter tainted |
-| Capture.cs:116:9:119:9 | SSA capture def(tainted) | Capture.cs:118:22:118:28 | access to parameter tainted |
-| Capture.cs:116:9:119:9 | SSA capture def(tainted) | Capture.cs:118:22:118:28 | access to parameter tainted |
-| Capture.cs:116:9:119:9 | SSA capture def(tainted) | Capture.cs:118:22:118:28 | access to parameter tainted |
-| Capture.cs:118:13:118:28 | ... = ... | Capture.cs:118:13:118:28 | ... = ... |
-| Capture.cs:118:13:118:28 | SSA def(sink33) | Capture.cs:118:13:118:28 | SSA def(sink33) |
-| Capture.cs:118:13:118:28 | SSA def(sink33) | Capture.cs:120:9:120:25 | SSA call def(sink33) |
-| Capture.cs:118:13:118:28 | SSA def(sink33) | Capture.cs:120:9:120:25 | SSA call def(sink33) |
-| Capture.cs:118:22:118:28 | access to parameter tainted | Capture.cs:118:13:118:28 | SSA def(sink33) |
-| Capture.cs:118:22:118:28 | access to parameter tainted | Capture.cs:118:13:118:28 | SSA def(sink33) |
-| Capture.cs:118:22:118:28 | access to parameter tainted | Capture.cs:118:13:118:28 | SSA def(sink33) |
-| Capture.cs:118:22:118:28 | access to parameter tainted | Capture.cs:118:13:118:28 | SSA def(sink33) |
-| Capture.cs:118:22:118:28 | access to parameter tainted | Capture.cs:118:22:118:28 | access to parameter tainted |
-| Capture.cs:120:9:120:23 | access to local function CaptureThrough1 | Capture.cs:120:9:120:23 | access to local function CaptureThrough1 |
-| Capture.cs:120:9:120:25 | SSA call def(sink33) | Capture.cs:120:9:120:25 | SSA call def(sink33) |
-| Capture.cs:120:9:120:25 | SSA call def(sink33) | Capture.cs:121:15:121:20 | access to local variable sink33 |
-| Capture.cs:120:9:120:25 | SSA call def(sink33) | Capture.cs:121:15:121:20 | access to local variable sink33 |
-| Capture.cs:120:9:120:25 | [implicit argument] tainted | Capture.cs:116:9:119:9 | SSA capture def(tainted) |
-| Capture.cs:120:9:120:25 | [implicit argument] tainted | Capture.cs:116:9:119:9 | SSA capture def(tainted) |
-| Capture.cs:120:9:120:25 | [implicit argument] tainted | Capture.cs:120:9:120:25 | SSA call def(sink33) |
-| Capture.cs:120:9:120:25 | [implicit argument] tainted | Capture.cs:120:9:120:25 | SSA call def(sink33) |
-| Capture.cs:120:9:120:25 | [implicit argument] tainted | Capture.cs:120:9:120:25 | [implicit argument] tainted |
-| Capture.cs:120:9:120:25 | call to local function CaptureThrough1 | Capture.cs:120:9:120:25 | call to local function CaptureThrough1 |
-| Capture.cs:121:9:121:21 | call to method Check | Capture.cs:121:9:121:21 | call to method Check |
-| Capture.cs:121:15:121:20 | access to local variable sink33 | Capture.cs:121:15:121:20 | access to local variable sink33 |
-| Capture.cs:123:16:123:26 | SSA def(sink34) | Capture.cs:123:16:123:26 | SSA def(sink34) |
-| Capture.cs:123:16:123:26 | String sink34 = ... | Capture.cs:123:16:123:26 | String sink34 = ... |
-| Capture.cs:123:25:123:26 | "" | Capture.cs:123:16:123:26 | SSA def(sink34) |
-| Capture.cs:123:25:123:26 | "" | Capture.cs:123:16:123:26 | SSA def(sink34) |
-| Capture.cs:123:25:123:26 | "" | Capture.cs:123:25:123:26 | "" |
-| Capture.cs:126:13:129:13 | SSA capture def(tainted) | Capture.cs:126:13:129:13 | SSA capture def(tainted) |
-| Capture.cs:126:13:129:13 | SSA capture def(tainted) | Capture.cs:128:17:128:32 | SSA def(sink34) |
-| Capture.cs:126:13:129:13 | SSA capture def(tainted) | Capture.cs:128:17:128:32 | SSA def(sink34) |
-| Capture.cs:126:13:129:13 | SSA capture def(tainted) | Capture.cs:128:17:128:32 | SSA def(sink34) |
-| Capture.cs:126:13:129:13 | SSA capture def(tainted) | Capture.cs:128:17:128:32 | SSA def(sink34) |
-| Capture.cs:126:13:129:13 | SSA capture def(tainted) | Capture.cs:128:26:128:32 | access to parameter tainted |
-| Capture.cs:126:13:129:13 | SSA capture def(tainted) | Capture.cs:128:26:128:32 | access to parameter tainted |
-| Capture.cs:126:13:129:13 | SSA capture def(tainted) | Capture.cs:128:26:128:32 | access to parameter tainted |
-| Capture.cs:126:13:129:13 | SSA capture def(tainted) | Capture.cs:128:26:128:32 | access to parameter tainted |
-| Capture.cs:128:17:128:32 | ... = ... | Capture.cs:128:17:128:32 | ... = ... |
-| Capture.cs:128:17:128:32 | SSA def(sink34) | Capture.cs:128:17:128:32 | SSA def(sink34) |
-| Capture.cs:128:17:128:32 | SSA def(sink34) | Capture.cs:132:9:132:25 | SSA call def(sink34) |
-| Capture.cs:128:17:128:32 | SSA def(sink34) | Capture.cs:132:9:132:25 | SSA call def(sink34) |
-| Capture.cs:128:26:128:32 | access to parameter tainted | Capture.cs:128:17:128:32 | SSA def(sink34) |
-| Capture.cs:128:26:128:32 | access to parameter tainted | Capture.cs:128:17:128:32 | SSA def(sink34) |
-| Capture.cs:128:26:128:32 | access to parameter tainted | Capture.cs:128:17:128:32 | SSA def(sink34) |
-| Capture.cs:128:26:128:32 | access to parameter tainted | Capture.cs:128:17:128:32 | SSA def(sink34) |
-| Capture.cs:128:26:128:32 | access to parameter tainted | Capture.cs:128:26:128:32 | access to parameter tainted |
-| Capture.cs:130:13:130:13 | access to local function M | Capture.cs:130:13:130:13 | access to local function M |
-| Capture.cs:130:13:130:15 | call to local function M | Capture.cs:130:13:130:15 | call to local function M |
-| Capture.cs:132:9:132:23 | access to local function CaptureThrough2 | Capture.cs:132:9:132:23 | access to local function CaptureThrough2 |
-| Capture.cs:132:9:132:25 | SSA call def(sink34) | Capture.cs:132:9:132:25 | SSA call def(sink34) |
-| Capture.cs:132:9:132:25 | SSA call def(sink34) | Capture.cs:133:15:133:20 | access to local variable sink34 |
-| Capture.cs:132:9:132:25 | SSA call def(sink34) | Capture.cs:133:15:133:20 | access to local variable sink34 |
-| Capture.cs:132:9:132:25 | [implicit argument] tainted | Capture.cs:126:13:129:13 | SSA capture def(tainted) |
-| Capture.cs:132:9:132:25 | [implicit argument] tainted | Capture.cs:126:13:129:13 | SSA capture def(tainted) |
-| Capture.cs:132:9:132:25 | [implicit argument] tainted | Capture.cs:132:9:132:25 | SSA call def(sink34) |
-| Capture.cs:132:9:132:25 | [implicit argument] tainted | Capture.cs:132:9:132:25 | SSA call def(sink34) |
+| Capture.cs:125:10:125:16 | this | Capture.cs:125:10:125:16 | this |
+| Capture.cs:125:25:125:31 | tainted | Capture.cs:125:25:125:31 | tainted |
+| Capture.cs:125:25:125:31 | tainted | Capture.cs:125:25:125:31 | tainted |
+| Capture.cs:125:25:125:31 | tainted | Capture.cs:132:9:132:25 | [implicit argument] tainted |
+| Capture.cs:125:25:125:31 | tainted | Capture.cs:132:9:132:25 | [implicit argument] tainted |
+| Capture.cs:125:25:125:31 | tainted | Capture.cs:144:9:144:25 | [implicit argument] tainted |
+| Capture.cs:125:25:125:31 | tainted | Capture.cs:144:9:144:25 | [implicit argument] tainted |
+| Capture.cs:125:25:125:31 | tainted | Capture.cs:153:9:153:45 | [implicit argument] tainted |
+| Capture.cs:125:25:125:31 | tainted | Capture.cs:153:9:153:45 | [implicit argument] tainted |
+| Capture.cs:125:25:125:31 | tainted | Capture.cs:160:22:160:38 | [implicit argument] tainted |
+| Capture.cs:125:25:125:31 | tainted | Capture.cs:160:22:160:38 | [implicit argument] tainted |
+| Capture.cs:125:25:125:31 | tainted | Capture.cs:168:25:168:31 | access to parameter tainted |
+| Capture.cs:125:25:125:31 | tainted | Capture.cs:168:25:168:31 | access to parameter tainted |
+| Capture.cs:125:25:125:31 | tainted | Capture.cs:194:25:194:31 | access to parameter tainted |
+| Capture.cs:125:25:125:31 | tainted | Capture.cs:194:25:194:31 | access to parameter tainted |
+| Capture.cs:127:16:127:26 | SSA def(sink33) | Capture.cs:127:16:127:26 | SSA def(sink33) |
+| Capture.cs:127:16:127:26 | String sink33 = ... | Capture.cs:127:16:127:26 | String sink33 = ... |
+| Capture.cs:127:25:127:26 | "" | Capture.cs:127:16:127:26 | SSA def(sink33) |
+| Capture.cs:127:25:127:26 | "" | Capture.cs:127:16:127:26 | SSA def(sink33) |
+| Capture.cs:127:25:127:26 | "" | Capture.cs:127:25:127:26 | "" |
+| Capture.cs:128:9:131:9 | SSA capture def(tainted) | Capture.cs:128:9:131:9 | SSA capture def(tainted) |
+| Capture.cs:128:9:131:9 | SSA capture def(tainted) | Capture.cs:130:13:130:28 | SSA def(sink33) |
+| Capture.cs:128:9:131:9 | SSA capture def(tainted) | Capture.cs:130:13:130:28 | SSA def(sink33) |
+| Capture.cs:128:9:131:9 | SSA capture def(tainted) | Capture.cs:130:13:130:28 | SSA def(sink33) |
+| Capture.cs:128:9:131:9 | SSA capture def(tainted) | Capture.cs:130:13:130:28 | SSA def(sink33) |
+| Capture.cs:128:9:131:9 | SSA capture def(tainted) | Capture.cs:130:22:130:28 | access to parameter tainted |
+| Capture.cs:128:9:131:9 | SSA capture def(tainted) | Capture.cs:130:22:130:28 | access to parameter tainted |
+| Capture.cs:128:9:131:9 | SSA capture def(tainted) | Capture.cs:130:22:130:28 | access to parameter tainted |
+| Capture.cs:128:9:131:9 | SSA capture def(tainted) | Capture.cs:130:22:130:28 | access to parameter tainted |
+| Capture.cs:130:13:130:28 | ... = ... | Capture.cs:130:13:130:28 | ... = ... |
+| Capture.cs:130:13:130:28 | SSA def(sink33) | Capture.cs:130:13:130:28 | SSA def(sink33) |
+| Capture.cs:130:13:130:28 | SSA def(sink33) | Capture.cs:132:9:132:25 | SSA call def(sink33) |
+| Capture.cs:130:13:130:28 | SSA def(sink33) | Capture.cs:132:9:132:25 | SSA call def(sink33) |
+| Capture.cs:130:22:130:28 | access to parameter tainted | Capture.cs:130:13:130:28 | SSA def(sink33) |
+| Capture.cs:130:22:130:28 | access to parameter tainted | Capture.cs:130:13:130:28 | SSA def(sink33) |
+| Capture.cs:130:22:130:28 | access to parameter tainted | Capture.cs:130:13:130:28 | SSA def(sink33) |
+| Capture.cs:130:22:130:28 | access to parameter tainted | Capture.cs:130:13:130:28 | SSA def(sink33) |
+| Capture.cs:130:22:130:28 | access to parameter tainted | Capture.cs:130:22:130:28 | access to parameter tainted |
+| Capture.cs:132:9:132:23 | access to local function CaptureThrough1 | Capture.cs:132:9:132:23 | access to local function CaptureThrough1 |
+| Capture.cs:132:9:132:25 | SSA call def(sink33) | Capture.cs:132:9:132:25 | SSA call def(sink33) |
+| Capture.cs:132:9:132:25 | SSA call def(sink33) | Capture.cs:133:15:133:20 | access to local variable sink33 |
+| Capture.cs:132:9:132:25 | SSA call def(sink33) | Capture.cs:133:15:133:20 | access to local variable sink33 |
+| Capture.cs:132:9:132:25 | [implicit argument] tainted | Capture.cs:128:9:131:9 | SSA capture def(tainted) |
+| Capture.cs:132:9:132:25 | [implicit argument] tainted | Capture.cs:128:9:131:9 | SSA capture def(tainted) |
+| Capture.cs:132:9:132:25 | [implicit argument] tainted | Capture.cs:132:9:132:25 | SSA call def(sink33) |
+| Capture.cs:132:9:132:25 | [implicit argument] tainted | Capture.cs:132:9:132:25 | SSA call def(sink33) |
 | Capture.cs:132:9:132:25 | [implicit argument] tainted | Capture.cs:132:9:132:25 | [implicit argument] tainted |
-| Capture.cs:132:9:132:25 | call to local function CaptureThrough2 | Capture.cs:132:9:132:25 | call to local function CaptureThrough2 |
+| Capture.cs:132:9:132:25 | call to local function CaptureThrough1 | Capture.cs:132:9:132:25 | call to local function CaptureThrough1 |
 | Capture.cs:133:9:133:21 | call to method Check | Capture.cs:133:9:133:21 | call to method Check |
-| Capture.cs:133:15:133:20 | access to local variable sink34 | Capture.cs:133:15:133:20 | access to local variable sink34 |
-| Capture.cs:135:16:135:26 | SSA def(sink35) | Capture.cs:135:16:135:26 | SSA def(sink35) |
-| Capture.cs:135:16:135:26 | String sink35 = ... | Capture.cs:135:16:135:26 | String sink35 = ... |
-| Capture.cs:135:25:135:26 | "" | Capture.cs:135:16:135:26 | SSA def(sink35) |
-| Capture.cs:135:25:135:26 | "" | Capture.cs:135:16:135:26 | SSA def(sink35) |
+| Capture.cs:133:15:133:20 | access to local variable sink33 | Capture.cs:133:15:133:20 | access to local variable sink33 |
+| Capture.cs:135:16:135:26 | SSA def(sink34) | Capture.cs:135:16:135:26 | SSA def(sink34) |
+| Capture.cs:135:16:135:26 | String sink34 = ... | Capture.cs:135:16:135:26 | String sink34 = ... |
+| Capture.cs:135:25:135:26 | "" | Capture.cs:135:16:135:26 | SSA def(sink34) |
+| Capture.cs:135:25:135:26 | "" | Capture.cs:135:16:135:26 | SSA def(sink34) |
 | Capture.cs:135:25:135:26 | "" | Capture.cs:135:25:135:26 | "" |
-| Capture.cs:136:30:140:9 | Func<String,String> captureThrough3 = ... | Capture.cs:136:30:140:9 | Func<String,String> captureThrough3 = ... |
-| Capture.cs:136:30:140:9 | SSA def(captureThrough3) | Capture.cs:136:30:140:9 | SSA def(captureThrough3) |
-| Capture.cs:136:30:140:9 | SSA def(captureThrough3) | Capture.cs:141:30:141:44 | access to local variable captureThrough3 |
-| Capture.cs:136:30:140:9 | SSA def(captureThrough3) | Capture.cs:141:30:141:44 | access to local variable captureThrough3 |
-| Capture.cs:136:48:136:50 | arg | Capture.cs:136:48:136:50 | arg |
-| Capture.cs:136:48:136:50 | arg | Capture.cs:136:48:136:50 | arg |
-| Capture.cs:136:48:136:50 | arg | Capture.cs:139:20:139:22 | access to parameter arg |
-| Capture.cs:136:48:136:50 | arg | Capture.cs:139:20:139:22 | access to parameter arg |
-| Capture.cs:136:48:140:9 | (...) => ... | Capture.cs:136:30:140:9 | SSA def(captureThrough3) |
-| Capture.cs:136:48:140:9 | (...) => ... | Capture.cs:136:30:140:9 | SSA def(captureThrough3) |
-| Capture.cs:136:48:140:9 | (...) => ... | Capture.cs:136:48:140:9 | (...) => ... |
-| Capture.cs:136:48:140:9 | (...) => ... | Capture.cs:141:30:141:44 | access to local variable captureThrough3 |
-| Capture.cs:136:48:140:9 | (...) => ... | Capture.cs:141:30:141:44 | access to local variable captureThrough3 |
-| Capture.cs:136:48:140:9 | SSA capture def(tainted) | Capture.cs:136:48:140:9 | SSA capture def(tainted) |
-| Capture.cs:136:48:140:9 | SSA capture def(tainted) | Capture.cs:138:13:138:28 | SSA def(sink35) |
-| Capture.cs:136:48:140:9 | SSA capture def(tainted) | Capture.cs:138:13:138:28 | SSA def(sink35) |
-| Capture.cs:136:48:140:9 | SSA capture def(tainted) | Capture.cs:138:13:138:28 | SSA def(sink35) |
-| Capture.cs:136:48:140:9 | SSA capture def(tainted) | Capture.cs:138:13:138:28 | SSA def(sink35) |
-| Capture.cs:136:48:140:9 | SSA capture def(tainted) | Capture.cs:138:22:138:28 | access to parameter tainted |
-| Capture.cs:136:48:140:9 | SSA capture def(tainted) | Capture.cs:138:22:138:28 | access to parameter tainted |
-| Capture.cs:136:48:140:9 | SSA capture def(tainted) | Capture.cs:138:22:138:28 | access to parameter tainted |
-| Capture.cs:136:48:140:9 | SSA capture def(tainted) | Capture.cs:138:22:138:28 | access to parameter tainted |
-| Capture.cs:138:13:138:28 | ... = ... | Capture.cs:138:13:138:28 | ... = ... |
-| Capture.cs:138:13:138:28 | SSA def(sink35) | Capture.cs:138:13:138:28 | SSA def(sink35) |
-| Capture.cs:138:13:138:28 | SSA def(sink35) | Capture.cs:141:9:141:45 | SSA call def(sink35) |
-| Capture.cs:138:13:138:28 | SSA def(sink35) | Capture.cs:141:9:141:45 | SSA call def(sink35) |
-| Capture.cs:138:22:138:28 | access to parameter tainted | Capture.cs:138:13:138:28 | SSA def(sink35) |
-| Capture.cs:138:22:138:28 | access to parameter tainted | Capture.cs:138:13:138:28 | SSA def(sink35) |
-| Capture.cs:138:22:138:28 | access to parameter tainted | Capture.cs:138:13:138:28 | SSA def(sink35) |
-| Capture.cs:138:22:138:28 | access to parameter tainted | Capture.cs:138:13:138:28 | SSA def(sink35) |
-| Capture.cs:138:22:138:28 | access to parameter tainted | Capture.cs:138:22:138:28 | access to parameter tainted |
-| Capture.cs:139:20:139:22 | access to parameter arg | Capture.cs:139:20:139:22 | access to parameter arg |
-| Capture.cs:139:20:139:22 | access to parameter arg | Capture.cs:141:30:141:44 | [output] access to local variable captureThrough3 |
-| Capture.cs:139:20:139:22 | access to parameter arg | Capture.cs:141:30:141:44 | [output] access to local variable captureThrough3 |
-| Capture.cs:141:9:141:21 | array creation of type String[] | Capture.cs:136:48:136:50 | arg |
-| Capture.cs:141:9:141:21 | array creation of type String[] | Capture.cs:136:48:136:50 | arg |
-| Capture.cs:141:9:141:21 | array creation of type String[] | Capture.cs:141:9:141:21 | array creation of type String[] |
-| Capture.cs:141:9:141:45 | SSA call def(sink35) | Capture.cs:141:9:141:45 | SSA call def(sink35) |
-| Capture.cs:141:9:141:45 | SSA call def(sink35) | Capture.cs:142:15:142:20 | access to local variable sink35 |
-| Capture.cs:141:9:141:45 | SSA call def(sink35) | Capture.cs:142:15:142:20 | access to local variable sink35 |
-| Capture.cs:141:9:141:45 | [implicit argument] tainted | Capture.cs:136:48:140:9 | SSA capture def(tainted) |
-| Capture.cs:141:9:141:45 | [implicit argument] tainted | Capture.cs:136:48:140:9 | SSA capture def(tainted) |
-| Capture.cs:141:9:141:45 | [implicit argument] tainted | Capture.cs:141:9:141:45 | SSA call def(sink35) |
-| Capture.cs:141:9:141:45 | [implicit argument] tainted | Capture.cs:141:9:141:45 | SSA call def(sink35) |
-| Capture.cs:141:9:141:45 | [implicit argument] tainted | Capture.cs:141:9:141:45 | [implicit argument] tainted |
-| Capture.cs:141:9:141:45 | call to method Select | Capture.cs:141:9:141:45 | call to method Select |
-| Capture.cs:141:9:141:55 | call to method ToArray | Capture.cs:141:9:141:55 | call to method ToArray |
-| Capture.cs:141:15:141:21 | { ..., ... } | Capture.cs:141:15:141:21 | { ..., ... } |
-| Capture.cs:141:17:141:19 | " " | Capture.cs:141:17:141:19 | " " |
-| Capture.cs:141:30:141:44 | [output] access to local variable captureThrough3 | Capture.cs:141:30:141:44 | [output] access to local variable captureThrough3 |
-| Capture.cs:141:30:141:44 | access to local variable captureThrough3 | Capture.cs:141:30:141:44 | access to local variable captureThrough3 |
-| Capture.cs:142:9:142:21 | call to method Check | Capture.cs:142:9:142:21 | call to method Check |
-| Capture.cs:142:15:142:20 | access to local variable sink35 | Capture.cs:142:15:142:20 | access to local variable sink35 |
-| Capture.cs:144:9:147:9 | SSA capture def(tainted) | Capture.cs:144:9:147:9 | SSA capture def(tainted) |
-| Capture.cs:144:9:147:9 | SSA capture def(tainted) | Capture.cs:146:20:146:26 | access to parameter tainted |
-| Capture.cs:144:9:147:9 | SSA capture def(tainted) | Capture.cs:146:20:146:26 | access to parameter tainted |
-| Capture.cs:144:9:147:9 | SSA capture def(tainted) | Capture.cs:146:20:146:26 | access to parameter tainted |
-| Capture.cs:144:9:147:9 | SSA capture def(tainted) | Capture.cs:146:20:146:26 | access to parameter tainted |
-| Capture.cs:146:20:146:26 | access to parameter tainted | Capture.cs:146:20:146:26 | access to parameter tainted |
-| Capture.cs:146:20:146:26 | access to parameter tainted | Capture.cs:148:22:148:38 | call to local function CaptureThrough4 |
-| Capture.cs:146:20:146:26 | access to parameter tainted | Capture.cs:148:22:148:38 | call to local function CaptureThrough4 |
-| Capture.cs:148:13:148:38 | SSA def(sink36) | Capture.cs:148:13:148:38 | SSA def(sink36) |
-| Capture.cs:148:13:148:38 | SSA def(sink36) | Capture.cs:149:15:149:20 | access to local variable sink36 |
-| Capture.cs:148:13:148:38 | SSA def(sink36) | Capture.cs:149:15:149:20 | access to local variable sink36 |
-| Capture.cs:148:13:148:38 | String sink36 = ... | Capture.cs:148:13:148:38 | String sink36 = ... |
-| Capture.cs:148:22:148:36 | access to local function CaptureThrough4 | Capture.cs:148:22:148:36 | access to local function CaptureThrough4 |
-| Capture.cs:148:22:148:38 | [implicit argument] tainted | Capture.cs:144:9:147:9 | SSA capture def(tainted) |
-| Capture.cs:148:22:148:38 | [implicit argument] tainted | Capture.cs:144:9:147:9 | SSA capture def(tainted) |
-| Capture.cs:148:22:148:38 | [implicit argument] tainted | Capture.cs:148:22:148:38 | [implicit argument] tainted |
-| Capture.cs:148:22:148:38 | [implicit argument] tainted | Capture.cs:148:22:148:38 | call to local function CaptureThrough4 |
-| Capture.cs:148:22:148:38 | [implicit argument] tainted | Capture.cs:148:22:148:38 | call to local function CaptureThrough4 |
-| Capture.cs:148:22:148:38 | call to local function CaptureThrough4 | Capture.cs:148:13:148:38 | SSA def(sink36) |
-| Capture.cs:148:22:148:38 | call to local function CaptureThrough4 | Capture.cs:148:13:148:38 | SSA def(sink36) |
-| Capture.cs:148:22:148:38 | call to local function CaptureThrough4 | Capture.cs:148:22:148:38 | call to local function CaptureThrough4 |
-| Capture.cs:148:22:148:38 | call to local function CaptureThrough4 | Capture.cs:149:15:149:20 | access to local variable sink36 |
-| Capture.cs:148:22:148:38 | call to local function CaptureThrough4 | Capture.cs:149:15:149:20 | access to local variable sink36 |
-| Capture.cs:149:9:149:21 | call to method Check | Capture.cs:149:9:149:21 | call to method Check |
-| Capture.cs:149:15:149:20 | access to local variable sink36 | Capture.cs:149:15:149:20 | access to local variable sink36 |
-| Capture.cs:151:13:151:23 | SSA def(sink37) | Capture.cs:151:13:151:23 | SSA def(sink37) |
-| Capture.cs:151:13:151:23 | String sink37 = ... | Capture.cs:151:13:151:23 | String sink37 = ... |
-| Capture.cs:151:22:151:23 | "" | Capture.cs:151:13:151:23 | SSA def(sink37) |
-| Capture.cs:151:22:151:23 | "" | Capture.cs:151:13:151:23 | SSA def(sink37) |
-| Capture.cs:151:22:151:23 | "" | Capture.cs:151:22:151:23 | "" |
-| Capture.cs:152:37:152:37 | p | Capture.cs:152:37:152:37 | p |
-| Capture.cs:152:37:152:37 | p | Capture.cs:152:37:152:37 | p |
-| Capture.cs:152:37:152:37 | p | Capture.cs:154:13:154:22 | SSA def(sink37) |
-| Capture.cs:152:37:152:37 | p | Capture.cs:154:13:154:22 | SSA def(sink37) |
-| Capture.cs:152:37:152:37 | p | Capture.cs:154:13:154:22 | SSA def(sink37) |
-| Capture.cs:152:37:152:37 | p | Capture.cs:154:13:154:22 | SSA def(sink37) |
-| Capture.cs:152:37:152:37 | p | Capture.cs:154:22:154:22 | access to parameter p |
-| Capture.cs:152:37:152:37 | p | Capture.cs:154:22:154:22 | access to parameter p |
-| Capture.cs:152:37:152:37 | p | Capture.cs:154:22:154:22 | access to parameter p |
-| Capture.cs:152:37:152:37 | p | Capture.cs:154:22:154:22 | access to parameter p |
-| Capture.cs:154:13:154:22 | ... = ... | Capture.cs:154:13:154:22 | ... = ... |
-| Capture.cs:154:13:154:22 | SSA def(sink37) | Capture.cs:154:13:154:22 | SSA def(sink37) |
-| Capture.cs:154:13:154:22 | SSA def(sink37) | Capture.cs:156:9:156:32 | SSA call def(sink37) |
-| Capture.cs:154:13:154:22 | SSA def(sink37) | Capture.cs:156:9:156:32 | SSA call def(sink37) |
-| Capture.cs:154:22:154:22 | access to parameter p | Capture.cs:154:13:154:22 | SSA def(sink37) |
-| Capture.cs:154:22:154:22 | access to parameter p | Capture.cs:154:13:154:22 | SSA def(sink37) |
-| Capture.cs:154:22:154:22 | access to parameter p | Capture.cs:154:13:154:22 | SSA def(sink37) |
-| Capture.cs:154:22:154:22 | access to parameter p | Capture.cs:154:13:154:22 | SSA def(sink37) |
-| Capture.cs:154:22:154:22 | access to parameter p | Capture.cs:154:22:154:22 | access to parameter p |
-| Capture.cs:156:9:156:23 | access to local function CaptureThrough5 | Capture.cs:156:9:156:23 | access to local function CaptureThrough5 |
-| Capture.cs:156:9:156:32 | SSA call def(sink37) | Capture.cs:156:9:156:32 | SSA call def(sink37) |
-| Capture.cs:156:9:156:32 | SSA call def(sink37) | Capture.cs:157:15:157:20 | access to local variable sink37 |
-| Capture.cs:156:9:156:32 | SSA call def(sink37) | Capture.cs:157:15:157:20 | access to local variable sink37 |
-| Capture.cs:156:9:156:32 | call to local function CaptureThrough5 | Capture.cs:156:9:156:32 | call to local function CaptureThrough5 |
-| Capture.cs:156:25:156:31 | access to parameter tainted | Capture.cs:152:37:152:37 | p |
-| Capture.cs:156:25:156:31 | access to parameter tainted | Capture.cs:152:37:152:37 | p |
-| Capture.cs:156:25:156:31 | access to parameter tainted | Capture.cs:156:9:156:32 | SSA call def(sink37) |
-| Capture.cs:156:25:156:31 | access to parameter tainted | Capture.cs:156:9:156:32 | SSA call def(sink37) |
-| Capture.cs:156:25:156:31 | access to parameter tainted | Capture.cs:156:25:156:31 | access to parameter tainted |
-| Capture.cs:156:25:156:31 | access to parameter tainted | Capture.cs:182:25:182:31 | access to parameter tainted |
-| Capture.cs:156:25:156:31 | access to parameter tainted | Capture.cs:182:25:182:31 | access to parameter tainted |
-| Capture.cs:157:9:157:21 | call to method Check | Capture.cs:157:9:157:21 | call to method Check |
-| Capture.cs:157:15:157:20 | access to local variable sink37 | Capture.cs:157:15:157:20 | access to local variable sink37 |
-| Capture.cs:159:16:159:28 | SSA def(nonSink0) | Capture.cs:159:16:159:28 | SSA def(nonSink0) |
-| Capture.cs:159:16:159:28 | SSA def(nonSink0) | Capture.cs:164:15:164:22 | access to local variable nonSink0 |
-| Capture.cs:159:16:159:28 | SSA def(nonSink0) | Capture.cs:164:15:164:22 | access to local variable nonSink0 |
-| Capture.cs:159:16:159:28 | SSA def(nonSink0) | Capture.cs:174:15:174:22 | access to local variable nonSink0 |
-| Capture.cs:159:16:159:28 | SSA def(nonSink0) | Capture.cs:174:15:174:22 | access to local variable nonSink0 |
-| Capture.cs:159:16:159:28 | String nonSink0 = ... | Capture.cs:159:16:159:28 | String nonSink0 = ... |
-| Capture.cs:159:27:159:28 | "" | Capture.cs:159:16:159:28 | SSA def(nonSink0) |
-| Capture.cs:159:27:159:28 | "" | Capture.cs:159:16:159:28 | SSA def(nonSink0) |
-| Capture.cs:159:27:159:28 | "" | Capture.cs:159:27:159:28 | "" |
-| Capture.cs:159:27:159:28 | "" | Capture.cs:164:15:164:22 | access to local variable nonSink0 |
-| Capture.cs:159:27:159:28 | "" | Capture.cs:164:15:164:22 | access to local variable nonSink0 |
-| Capture.cs:159:27:159:28 | "" | Capture.cs:174:15:174:22 | access to local variable nonSink0 |
-| Capture.cs:159:27:159:28 | "" | Capture.cs:174:15:174:22 | access to local variable nonSink0 |
-| Capture.cs:160:9:163:9 | SSA capture def(tainted) | Capture.cs:160:9:163:9 | SSA capture def(tainted) |
-| Capture.cs:160:9:163:9 | SSA capture def(tainted) | Capture.cs:162:24:162:30 | access to parameter tainted |
-| Capture.cs:160:9:163:9 | SSA capture def(tainted) | Capture.cs:162:24:162:30 | access to parameter tainted |
-| Capture.cs:162:13:162:30 | ... = ... | Capture.cs:162:13:162:30 | ... = ... |
-| Capture.cs:162:24:162:30 | access to parameter tainted | Capture.cs:162:24:162:30 | access to parameter tainted |
-| Capture.cs:164:9:164:23 | call to method Check | Capture.cs:164:9:164:23 | call to method Check |
-| Capture.cs:164:15:164:22 | access to local variable nonSink0 | Capture.cs:164:15:164:22 | access to local variable nonSink0 |
-| Capture.cs:164:15:164:22 | access to local variable nonSink0 | Capture.cs:174:15:174:22 | access to local variable nonSink0 |
-| Capture.cs:164:15:164:22 | access to local variable nonSink0 | Capture.cs:174:15:174:22 | access to local variable nonSink0 |
-| Capture.cs:168:13:171:13 | SSA capture def(tainted) | Capture.cs:168:13:171:13 | SSA capture def(tainted) |
-| Capture.cs:168:13:171:13 | SSA capture def(tainted) | Capture.cs:170:28:170:34 | access to parameter tainted |
-| Capture.cs:168:13:171:13 | SSA capture def(tainted) | Capture.cs:170:28:170:34 | access to parameter tainted |
-| Capture.cs:170:17:170:34 | ... = ... | Capture.cs:170:17:170:34 | ... = ... |
-| Capture.cs:170:28:170:34 | access to parameter tainted | Capture.cs:170:28:170:34 | access to parameter tainted |
-| Capture.cs:173:9:173:32 | access to local function CaptureThrough2NotCalled | Capture.cs:173:9:173:32 | access to local function CaptureThrough2NotCalled |
-| Capture.cs:173:9:173:34 | call to local function CaptureThrough2NotCalled | Capture.cs:173:9:173:34 | call to local function CaptureThrough2NotCalled |
-| Capture.cs:174:9:174:23 | call to method Check | Capture.cs:174:9:174:23 | call to method Check |
-| Capture.cs:174:15:174:22 | access to local variable nonSink0 | Capture.cs:174:15:174:22 | access to local variable nonSink0 |
-| Capture.cs:176:26:176:26 | s | Capture.cs:176:26:176:26 | s |
-| Capture.cs:176:26:176:26 | s | Capture.cs:176:26:176:26 | s |
-| Capture.cs:176:26:176:26 | s | Capture.cs:179:20:179:22 | [implicit argument] s |
-| Capture.cs:176:26:176:26 | s | Capture.cs:179:20:179:22 | [implicit argument] s |
-| Capture.cs:176:26:176:26 | s | Capture.cs:179:20:179:22 | [implicit argument] s |
-| Capture.cs:176:26:176:26 | s | Capture.cs:179:20:179:22 | [implicit argument] s |
-| Capture.cs:178:13:178:28 | SSA capture def(s) | Capture.cs:178:13:178:28 | SSA capture def(s) |
-| Capture.cs:178:13:178:28 | SSA capture def(s) | Capture.cs:178:27:178:27 | access to parameter s |
-| Capture.cs:178:13:178:28 | SSA capture def(s) | Capture.cs:178:27:178:27 | access to parameter s |
-| Capture.cs:178:13:178:28 | SSA capture def(s) | Capture.cs:178:27:178:27 | access to parameter s |
-| Capture.cs:178:13:178:28 | SSA capture def(s) | Capture.cs:178:27:178:27 | access to parameter s |
-| Capture.cs:178:27:178:27 | access to parameter s | Capture.cs:178:27:178:27 | access to parameter s |
-| Capture.cs:178:27:178:27 | access to parameter s | Capture.cs:179:20:179:22 | call to local function M |
-| Capture.cs:178:27:178:27 | access to parameter s | Capture.cs:179:20:179:22 | call to local function M |
-| Capture.cs:179:20:179:20 | access to local function M | Capture.cs:179:20:179:20 | access to local function M |
-| Capture.cs:179:20:179:22 | [implicit argument] s | Capture.cs:178:13:178:28 | SSA capture def(s) |
-| Capture.cs:179:20:179:22 | [implicit argument] s | Capture.cs:178:13:178:28 | SSA capture def(s) |
-| Capture.cs:179:20:179:22 | [implicit argument] s | Capture.cs:178:13:178:28 | SSA capture def(s) |
-| Capture.cs:179:20:179:22 | [implicit argument] s | Capture.cs:178:13:178:28 | SSA capture def(s) |
-| Capture.cs:179:20:179:22 | [implicit argument] s | Capture.cs:179:20:179:22 | [implicit argument] s |
-| Capture.cs:179:20:179:22 | [implicit argument] s | Capture.cs:179:20:179:22 | call to local function M |
-| Capture.cs:179:20:179:22 | [implicit argument] s | Capture.cs:179:20:179:22 | call to local function M |
-| Capture.cs:179:20:179:22 | [implicit argument] s | Capture.cs:179:20:179:22 | call to local function M |
-| Capture.cs:179:20:179:22 | [implicit argument] s | Capture.cs:179:20:179:22 | call to local function M |
-| Capture.cs:179:20:179:22 | call to local function M | Capture.cs:179:20:179:22 | call to local function M |
-| Capture.cs:179:20:179:22 | call to local function M | Capture.cs:182:22:182:32 | call to local function Id |
-| Capture.cs:179:20:179:22 | call to local function M | Capture.cs:182:22:182:32 | call to local function Id |
-| Capture.cs:179:20:179:22 | call to local function M | Capture.cs:184:20:184:25 | call to local function Id |
-| Capture.cs:179:20:179:22 | call to local function M | Capture.cs:184:20:184:25 | call to local function Id |
-| Capture.cs:182:13:182:32 | SSA def(sink38) | Capture.cs:182:13:182:32 | SSA def(sink38) |
-| Capture.cs:182:13:182:32 | SSA def(sink38) | Capture.cs:183:15:183:20 | access to local variable sink38 |
-| Capture.cs:182:13:182:32 | SSA def(sink38) | Capture.cs:183:15:183:20 | access to local variable sink38 |
-| Capture.cs:182:13:182:32 | String sink38 = ... | Capture.cs:182:13:182:32 | String sink38 = ... |
-| Capture.cs:182:22:182:23 | access to local function Id | Capture.cs:182:22:182:23 | access to local function Id |
-| Capture.cs:182:22:182:32 | call to local function Id | Capture.cs:182:13:182:32 | SSA def(sink38) |
-| Capture.cs:182:22:182:32 | call to local function Id | Capture.cs:182:13:182:32 | SSA def(sink38) |
-| Capture.cs:182:22:182:32 | call to local function Id | Capture.cs:182:22:182:32 | call to local function Id |
-| Capture.cs:182:22:182:32 | call to local function Id | Capture.cs:183:15:183:20 | access to local variable sink38 |
-| Capture.cs:182:22:182:32 | call to local function Id | Capture.cs:183:15:183:20 | access to local variable sink38 |
-| Capture.cs:182:25:182:31 | access to parameter tainted | Capture.cs:176:26:176:26 | s |
-| Capture.cs:182:25:182:31 | access to parameter tainted | Capture.cs:176:26:176:26 | s |
-| Capture.cs:182:25:182:31 | access to parameter tainted | Capture.cs:182:22:182:32 | call to local function Id |
-| Capture.cs:182:25:182:31 | access to parameter tainted | Capture.cs:182:22:182:32 | call to local function Id |
-| Capture.cs:182:25:182:31 | access to parameter tainted | Capture.cs:182:25:182:31 | access to parameter tainted |
-| Capture.cs:183:9:183:21 | call to method Check | Capture.cs:183:9:183:21 | call to method Check |
-| Capture.cs:183:15:183:20 | access to local variable sink38 | Capture.cs:183:15:183:20 | access to local variable sink38 |
-| Capture.cs:184:9:184:25 | ... = ... | Capture.cs:184:9:184:25 | ... = ... |
-| Capture.cs:184:9:184:25 | SSA def(nonSink0) | Capture.cs:184:9:184:25 | SSA def(nonSink0) |
-| Capture.cs:184:9:184:25 | SSA def(nonSink0) | Capture.cs:185:15:185:22 | access to local variable nonSink0 |
-| Capture.cs:184:9:184:25 | SSA def(nonSink0) | Capture.cs:185:15:185:22 | access to local variable nonSink0 |
-| Capture.cs:184:20:184:21 | access to local function Id | Capture.cs:184:20:184:21 | access to local function Id |
-| Capture.cs:184:20:184:25 | call to local function Id | Capture.cs:184:9:184:25 | SSA def(nonSink0) |
-| Capture.cs:184:20:184:25 | call to local function Id | Capture.cs:184:9:184:25 | SSA def(nonSink0) |
-| Capture.cs:184:20:184:25 | call to local function Id | Capture.cs:184:20:184:25 | call to local function Id |
-| Capture.cs:184:20:184:25 | call to local function Id | Capture.cs:185:15:185:22 | access to local variable nonSink0 |
-| Capture.cs:184:20:184:25 | call to local function Id | Capture.cs:185:15:185:22 | access to local variable nonSink0 |
-| Capture.cs:184:23:184:24 | "" | Capture.cs:176:26:176:26 | s |
-| Capture.cs:184:23:184:24 | "" | Capture.cs:176:26:176:26 | s |
-| Capture.cs:184:23:184:24 | "" | Capture.cs:184:20:184:25 | call to local function Id |
-| Capture.cs:184:23:184:24 | "" | Capture.cs:184:20:184:25 | call to local function Id |
-| Capture.cs:184:23:184:24 | "" | Capture.cs:184:23:184:24 | "" |
-| Capture.cs:185:9:185:23 | call to method Check | Capture.cs:185:9:185:23 | call to method Check |
-| Capture.cs:185:15:185:22 | access to local variable nonSink0 | Capture.cs:185:15:185:22 | access to local variable nonSink0 |
-| Capture.cs:190:34:190:34 | a | Capture.cs:190:34:190:34 | a |
-| Capture.cs:190:34:190:34 | a | Capture.cs:190:34:190:34 | a |
-| Capture.cs:190:34:190:34 | a | Capture.cs:192:9:192:9 | access to parameter a |
-| Capture.cs:190:34:190:34 | a | Capture.cs:192:9:192:9 | access to parameter a |
-| Capture.cs:190:34:190:34 | a | Capture.cs:192:9:192:9 | access to parameter a |
-| Capture.cs:190:34:190:34 | a | Capture.cs:192:9:192:9 | access to parameter a |
-| Capture.cs:190:34:190:34 | a | Capture.cs:192:9:192:9 | access to parameter a |
-| Capture.cs:190:34:190:34 | a | Capture.cs:192:9:192:9 | access to parameter a |
-| Capture.cs:192:9:192:9 | access to parameter a | Capture.cs:192:9:192:9 | access to parameter a |
-| Capture.cs:192:9:192:18 | delegate call | Capture.cs:192:9:192:18 | delegate call |
+| Capture.cs:138:13:141:13 | SSA capture def(tainted) | Capture.cs:138:13:141:13 | SSA capture def(tainted) |
+| Capture.cs:138:13:141:13 | SSA capture def(tainted) | Capture.cs:140:17:140:32 | SSA def(sink34) |
+| Capture.cs:138:13:141:13 | SSA capture def(tainted) | Capture.cs:140:17:140:32 | SSA def(sink34) |
+| Capture.cs:138:13:141:13 | SSA capture def(tainted) | Capture.cs:140:17:140:32 | SSA def(sink34) |
+| Capture.cs:138:13:141:13 | SSA capture def(tainted) | Capture.cs:140:17:140:32 | SSA def(sink34) |
+| Capture.cs:138:13:141:13 | SSA capture def(tainted) | Capture.cs:140:26:140:32 | access to parameter tainted |
+| Capture.cs:138:13:141:13 | SSA capture def(tainted) | Capture.cs:140:26:140:32 | access to parameter tainted |
+| Capture.cs:138:13:141:13 | SSA capture def(tainted) | Capture.cs:140:26:140:32 | access to parameter tainted |
+| Capture.cs:138:13:141:13 | SSA capture def(tainted) | Capture.cs:140:26:140:32 | access to parameter tainted |
+| Capture.cs:140:17:140:32 | ... = ... | Capture.cs:140:17:140:32 | ... = ... |
+| Capture.cs:140:17:140:32 | SSA def(sink34) | Capture.cs:140:17:140:32 | SSA def(sink34) |
+| Capture.cs:140:17:140:32 | SSA def(sink34) | Capture.cs:144:9:144:25 | SSA call def(sink34) |
+| Capture.cs:140:17:140:32 | SSA def(sink34) | Capture.cs:144:9:144:25 | SSA call def(sink34) |
+| Capture.cs:140:26:140:32 | access to parameter tainted | Capture.cs:140:17:140:32 | SSA def(sink34) |
+| Capture.cs:140:26:140:32 | access to parameter tainted | Capture.cs:140:17:140:32 | SSA def(sink34) |
+| Capture.cs:140:26:140:32 | access to parameter tainted | Capture.cs:140:17:140:32 | SSA def(sink34) |
+| Capture.cs:140:26:140:32 | access to parameter tainted | Capture.cs:140:17:140:32 | SSA def(sink34) |
+| Capture.cs:140:26:140:32 | access to parameter tainted | Capture.cs:140:26:140:32 | access to parameter tainted |
+| Capture.cs:142:13:142:13 | access to local function M | Capture.cs:142:13:142:13 | access to local function M |
+| Capture.cs:142:13:142:15 | call to local function M | Capture.cs:142:13:142:15 | call to local function M |
+| Capture.cs:144:9:144:23 | access to local function CaptureThrough2 | Capture.cs:144:9:144:23 | access to local function CaptureThrough2 |
+| Capture.cs:144:9:144:25 | SSA call def(sink34) | Capture.cs:144:9:144:25 | SSA call def(sink34) |
+| Capture.cs:144:9:144:25 | SSA call def(sink34) | Capture.cs:145:15:145:20 | access to local variable sink34 |
+| Capture.cs:144:9:144:25 | SSA call def(sink34) | Capture.cs:145:15:145:20 | access to local variable sink34 |
+| Capture.cs:144:9:144:25 | [implicit argument] tainted | Capture.cs:138:13:141:13 | SSA capture def(tainted) |
+| Capture.cs:144:9:144:25 | [implicit argument] tainted | Capture.cs:138:13:141:13 | SSA capture def(tainted) |
+| Capture.cs:144:9:144:25 | [implicit argument] tainted | Capture.cs:144:9:144:25 | SSA call def(sink34) |
+| Capture.cs:144:9:144:25 | [implicit argument] tainted | Capture.cs:144:9:144:25 | SSA call def(sink34) |
+| Capture.cs:144:9:144:25 | [implicit argument] tainted | Capture.cs:144:9:144:25 | [implicit argument] tainted |
+| Capture.cs:144:9:144:25 | call to local function CaptureThrough2 | Capture.cs:144:9:144:25 | call to local function CaptureThrough2 |
+| Capture.cs:145:9:145:21 | call to method Check | Capture.cs:145:9:145:21 | call to method Check |
+| Capture.cs:145:15:145:20 | access to local variable sink34 | Capture.cs:145:15:145:20 | access to local variable sink34 |
+| Capture.cs:147:16:147:26 | SSA def(sink35) | Capture.cs:147:16:147:26 | SSA def(sink35) |
+| Capture.cs:147:16:147:26 | String sink35 = ... | Capture.cs:147:16:147:26 | String sink35 = ... |
+| Capture.cs:147:25:147:26 | "" | Capture.cs:147:16:147:26 | SSA def(sink35) |
+| Capture.cs:147:25:147:26 | "" | Capture.cs:147:16:147:26 | SSA def(sink35) |
+| Capture.cs:147:25:147:26 | "" | Capture.cs:147:25:147:26 | "" |
+| Capture.cs:148:30:152:9 | Func<String,String> captureThrough3 = ... | Capture.cs:148:30:152:9 | Func<String,String> captureThrough3 = ... |
+| Capture.cs:148:30:152:9 | SSA def(captureThrough3) | Capture.cs:148:30:152:9 | SSA def(captureThrough3) |
+| Capture.cs:148:30:152:9 | SSA def(captureThrough3) | Capture.cs:153:30:153:44 | access to local variable captureThrough3 |
+| Capture.cs:148:30:152:9 | SSA def(captureThrough3) | Capture.cs:153:30:153:44 | access to local variable captureThrough3 |
+| Capture.cs:148:48:148:50 | arg | Capture.cs:148:48:148:50 | arg |
+| Capture.cs:148:48:148:50 | arg | Capture.cs:148:48:148:50 | arg |
+| Capture.cs:148:48:148:50 | arg | Capture.cs:151:20:151:22 | access to parameter arg |
+| Capture.cs:148:48:148:50 | arg | Capture.cs:151:20:151:22 | access to parameter arg |
+| Capture.cs:148:48:152:9 | (...) => ... | Capture.cs:148:30:152:9 | SSA def(captureThrough3) |
+| Capture.cs:148:48:152:9 | (...) => ... | Capture.cs:148:30:152:9 | SSA def(captureThrough3) |
+| Capture.cs:148:48:152:9 | (...) => ... | Capture.cs:148:48:152:9 | (...) => ... |
+| Capture.cs:148:48:152:9 | (...) => ... | Capture.cs:153:30:153:44 | access to local variable captureThrough3 |
+| Capture.cs:148:48:152:9 | (...) => ... | Capture.cs:153:30:153:44 | access to local variable captureThrough3 |
+| Capture.cs:148:48:152:9 | SSA capture def(tainted) | Capture.cs:148:48:152:9 | SSA capture def(tainted) |
+| Capture.cs:148:48:152:9 | SSA capture def(tainted) | Capture.cs:150:13:150:28 | SSA def(sink35) |
+| Capture.cs:148:48:152:9 | SSA capture def(tainted) | Capture.cs:150:13:150:28 | SSA def(sink35) |
+| Capture.cs:148:48:152:9 | SSA capture def(tainted) | Capture.cs:150:13:150:28 | SSA def(sink35) |
+| Capture.cs:148:48:152:9 | SSA capture def(tainted) | Capture.cs:150:13:150:28 | SSA def(sink35) |
+| Capture.cs:148:48:152:9 | SSA capture def(tainted) | Capture.cs:150:22:150:28 | access to parameter tainted |
+| Capture.cs:148:48:152:9 | SSA capture def(tainted) | Capture.cs:150:22:150:28 | access to parameter tainted |
+| Capture.cs:148:48:152:9 | SSA capture def(tainted) | Capture.cs:150:22:150:28 | access to parameter tainted |
+| Capture.cs:148:48:152:9 | SSA capture def(tainted) | Capture.cs:150:22:150:28 | access to parameter tainted |
+| Capture.cs:150:13:150:28 | ... = ... | Capture.cs:150:13:150:28 | ... = ... |
+| Capture.cs:150:13:150:28 | SSA def(sink35) | Capture.cs:150:13:150:28 | SSA def(sink35) |
+| Capture.cs:150:13:150:28 | SSA def(sink35) | Capture.cs:153:9:153:45 | SSA call def(sink35) |
+| Capture.cs:150:13:150:28 | SSA def(sink35) | Capture.cs:153:9:153:45 | SSA call def(sink35) |
+| Capture.cs:150:22:150:28 | access to parameter tainted | Capture.cs:150:13:150:28 | SSA def(sink35) |
+| Capture.cs:150:22:150:28 | access to parameter tainted | Capture.cs:150:13:150:28 | SSA def(sink35) |
+| Capture.cs:150:22:150:28 | access to parameter tainted | Capture.cs:150:13:150:28 | SSA def(sink35) |
+| Capture.cs:150:22:150:28 | access to parameter tainted | Capture.cs:150:13:150:28 | SSA def(sink35) |
+| Capture.cs:150:22:150:28 | access to parameter tainted | Capture.cs:150:22:150:28 | access to parameter tainted |
+| Capture.cs:151:20:151:22 | access to parameter arg | Capture.cs:151:20:151:22 | access to parameter arg |
+| Capture.cs:151:20:151:22 | access to parameter arg | Capture.cs:153:30:153:44 | [output] access to local variable captureThrough3 |
+| Capture.cs:151:20:151:22 | access to parameter arg | Capture.cs:153:30:153:44 | [output] access to local variable captureThrough3 |
+| Capture.cs:153:9:153:21 | array creation of type String[] | Capture.cs:148:48:148:50 | arg |
+| Capture.cs:153:9:153:21 | array creation of type String[] | Capture.cs:148:48:148:50 | arg |
+| Capture.cs:153:9:153:21 | array creation of type String[] | Capture.cs:153:9:153:21 | array creation of type String[] |
+| Capture.cs:153:9:153:45 | SSA call def(sink35) | Capture.cs:153:9:153:45 | SSA call def(sink35) |
+| Capture.cs:153:9:153:45 | SSA call def(sink35) | Capture.cs:154:15:154:20 | access to local variable sink35 |
+| Capture.cs:153:9:153:45 | SSA call def(sink35) | Capture.cs:154:15:154:20 | access to local variable sink35 |
+| Capture.cs:153:9:153:45 | [implicit argument] tainted | Capture.cs:148:48:152:9 | SSA capture def(tainted) |
+| Capture.cs:153:9:153:45 | [implicit argument] tainted | Capture.cs:148:48:152:9 | SSA capture def(tainted) |
+| Capture.cs:153:9:153:45 | [implicit argument] tainted | Capture.cs:153:9:153:45 | SSA call def(sink35) |
+| Capture.cs:153:9:153:45 | [implicit argument] tainted | Capture.cs:153:9:153:45 | SSA call def(sink35) |
+| Capture.cs:153:9:153:45 | [implicit argument] tainted | Capture.cs:153:9:153:45 | [implicit argument] tainted |
+| Capture.cs:153:9:153:45 | call to method Select | Capture.cs:153:9:153:45 | call to method Select |
+| Capture.cs:153:9:153:55 | call to method ToArray | Capture.cs:153:9:153:55 | call to method ToArray |
+| Capture.cs:153:15:153:21 | { ..., ... } | Capture.cs:153:15:153:21 | { ..., ... } |
+| Capture.cs:153:17:153:19 | " " | Capture.cs:153:17:153:19 | " " |
+| Capture.cs:153:30:153:44 | [output] access to local variable captureThrough3 | Capture.cs:153:30:153:44 | [output] access to local variable captureThrough3 |
+| Capture.cs:153:30:153:44 | access to local variable captureThrough3 | Capture.cs:153:30:153:44 | access to local variable captureThrough3 |
+| Capture.cs:154:9:154:21 | call to method Check | Capture.cs:154:9:154:21 | call to method Check |
+| Capture.cs:154:15:154:20 | access to local variable sink35 | Capture.cs:154:15:154:20 | access to local variable sink35 |
+| Capture.cs:156:9:159:9 | SSA capture def(tainted) | Capture.cs:156:9:159:9 | SSA capture def(tainted) |
+| Capture.cs:156:9:159:9 | SSA capture def(tainted) | Capture.cs:158:20:158:26 | access to parameter tainted |
+| Capture.cs:156:9:159:9 | SSA capture def(tainted) | Capture.cs:158:20:158:26 | access to parameter tainted |
+| Capture.cs:156:9:159:9 | SSA capture def(tainted) | Capture.cs:158:20:158:26 | access to parameter tainted |
+| Capture.cs:156:9:159:9 | SSA capture def(tainted) | Capture.cs:158:20:158:26 | access to parameter tainted |
+| Capture.cs:158:20:158:26 | access to parameter tainted | Capture.cs:158:20:158:26 | access to parameter tainted |
+| Capture.cs:158:20:158:26 | access to parameter tainted | Capture.cs:160:22:160:38 | call to local function CaptureThrough4 |
+| Capture.cs:158:20:158:26 | access to parameter tainted | Capture.cs:160:22:160:38 | call to local function CaptureThrough4 |
+| Capture.cs:160:13:160:38 | SSA def(sink36) | Capture.cs:160:13:160:38 | SSA def(sink36) |
+| Capture.cs:160:13:160:38 | SSA def(sink36) | Capture.cs:161:15:161:20 | access to local variable sink36 |
+| Capture.cs:160:13:160:38 | SSA def(sink36) | Capture.cs:161:15:161:20 | access to local variable sink36 |
+| Capture.cs:160:13:160:38 | String sink36 = ... | Capture.cs:160:13:160:38 | String sink36 = ... |
+| Capture.cs:160:22:160:36 | access to local function CaptureThrough4 | Capture.cs:160:22:160:36 | access to local function CaptureThrough4 |
+| Capture.cs:160:22:160:38 | [implicit argument] tainted | Capture.cs:156:9:159:9 | SSA capture def(tainted) |
+| Capture.cs:160:22:160:38 | [implicit argument] tainted | Capture.cs:156:9:159:9 | SSA capture def(tainted) |
+| Capture.cs:160:22:160:38 | [implicit argument] tainted | Capture.cs:160:22:160:38 | [implicit argument] tainted |
+| Capture.cs:160:22:160:38 | [implicit argument] tainted | Capture.cs:160:22:160:38 | call to local function CaptureThrough4 |
+| Capture.cs:160:22:160:38 | [implicit argument] tainted | Capture.cs:160:22:160:38 | call to local function CaptureThrough4 |
+| Capture.cs:160:22:160:38 | call to local function CaptureThrough4 | Capture.cs:160:13:160:38 | SSA def(sink36) |
+| Capture.cs:160:22:160:38 | call to local function CaptureThrough4 | Capture.cs:160:13:160:38 | SSA def(sink36) |
+| Capture.cs:160:22:160:38 | call to local function CaptureThrough4 | Capture.cs:160:22:160:38 | call to local function CaptureThrough4 |
+| Capture.cs:160:22:160:38 | call to local function CaptureThrough4 | Capture.cs:161:15:161:20 | access to local variable sink36 |
+| Capture.cs:160:22:160:38 | call to local function CaptureThrough4 | Capture.cs:161:15:161:20 | access to local variable sink36 |
+| Capture.cs:161:9:161:21 | call to method Check | Capture.cs:161:9:161:21 | call to method Check |
+| Capture.cs:161:15:161:20 | access to local variable sink36 | Capture.cs:161:15:161:20 | access to local variable sink36 |
+| Capture.cs:163:13:163:23 | SSA def(sink37) | Capture.cs:163:13:163:23 | SSA def(sink37) |
+| Capture.cs:163:13:163:23 | String sink37 = ... | Capture.cs:163:13:163:23 | String sink37 = ... |
+| Capture.cs:163:22:163:23 | "" | Capture.cs:163:13:163:23 | SSA def(sink37) |
+| Capture.cs:163:22:163:23 | "" | Capture.cs:163:13:163:23 | SSA def(sink37) |
+| Capture.cs:163:22:163:23 | "" | Capture.cs:163:22:163:23 | "" |
+| Capture.cs:164:37:164:37 | p | Capture.cs:164:37:164:37 | p |
+| Capture.cs:164:37:164:37 | p | Capture.cs:164:37:164:37 | p |
+| Capture.cs:164:37:164:37 | p | Capture.cs:166:13:166:22 | SSA def(sink37) |
+| Capture.cs:164:37:164:37 | p | Capture.cs:166:13:166:22 | SSA def(sink37) |
+| Capture.cs:164:37:164:37 | p | Capture.cs:166:13:166:22 | SSA def(sink37) |
+| Capture.cs:164:37:164:37 | p | Capture.cs:166:13:166:22 | SSA def(sink37) |
+| Capture.cs:164:37:164:37 | p | Capture.cs:166:22:166:22 | access to parameter p |
+| Capture.cs:164:37:164:37 | p | Capture.cs:166:22:166:22 | access to parameter p |
+| Capture.cs:164:37:164:37 | p | Capture.cs:166:22:166:22 | access to parameter p |
+| Capture.cs:164:37:164:37 | p | Capture.cs:166:22:166:22 | access to parameter p |
+| Capture.cs:166:13:166:22 | ... = ... | Capture.cs:166:13:166:22 | ... = ... |
+| Capture.cs:166:13:166:22 | SSA def(sink37) | Capture.cs:166:13:166:22 | SSA def(sink37) |
+| Capture.cs:166:13:166:22 | SSA def(sink37) | Capture.cs:168:9:168:32 | SSA call def(sink37) |
+| Capture.cs:166:13:166:22 | SSA def(sink37) | Capture.cs:168:9:168:32 | SSA call def(sink37) |
+| Capture.cs:166:22:166:22 | access to parameter p | Capture.cs:166:13:166:22 | SSA def(sink37) |
+| Capture.cs:166:22:166:22 | access to parameter p | Capture.cs:166:13:166:22 | SSA def(sink37) |
+| Capture.cs:166:22:166:22 | access to parameter p | Capture.cs:166:13:166:22 | SSA def(sink37) |
+| Capture.cs:166:22:166:22 | access to parameter p | Capture.cs:166:13:166:22 | SSA def(sink37) |
+| Capture.cs:166:22:166:22 | access to parameter p | Capture.cs:166:22:166:22 | access to parameter p |
+| Capture.cs:168:9:168:23 | access to local function CaptureThrough5 | Capture.cs:168:9:168:23 | access to local function CaptureThrough5 |
+| Capture.cs:168:9:168:32 | SSA call def(sink37) | Capture.cs:168:9:168:32 | SSA call def(sink37) |
+| Capture.cs:168:9:168:32 | SSA call def(sink37) | Capture.cs:169:15:169:20 | access to local variable sink37 |
+| Capture.cs:168:9:168:32 | SSA call def(sink37) | Capture.cs:169:15:169:20 | access to local variable sink37 |
+| Capture.cs:168:9:168:32 | call to local function CaptureThrough5 | Capture.cs:168:9:168:32 | call to local function CaptureThrough5 |
+| Capture.cs:168:25:168:31 | access to parameter tainted | Capture.cs:164:37:164:37 | p |
+| Capture.cs:168:25:168:31 | access to parameter tainted | Capture.cs:164:37:164:37 | p |
+| Capture.cs:168:25:168:31 | access to parameter tainted | Capture.cs:168:9:168:32 | SSA call def(sink37) |
+| Capture.cs:168:25:168:31 | access to parameter tainted | Capture.cs:168:9:168:32 | SSA call def(sink37) |
+| Capture.cs:168:25:168:31 | access to parameter tainted | Capture.cs:168:25:168:31 | access to parameter tainted |
+| Capture.cs:168:25:168:31 | access to parameter tainted | Capture.cs:194:25:194:31 | access to parameter tainted |
+| Capture.cs:168:25:168:31 | access to parameter tainted | Capture.cs:194:25:194:31 | access to parameter tainted |
+| Capture.cs:169:9:169:21 | call to method Check | Capture.cs:169:9:169:21 | call to method Check |
+| Capture.cs:169:15:169:20 | access to local variable sink37 | Capture.cs:169:15:169:20 | access to local variable sink37 |
+| Capture.cs:171:16:171:28 | SSA def(nonSink0) | Capture.cs:171:16:171:28 | SSA def(nonSink0) |
+| Capture.cs:171:16:171:28 | SSA def(nonSink0) | Capture.cs:176:15:176:22 | access to local variable nonSink0 |
+| Capture.cs:171:16:171:28 | SSA def(nonSink0) | Capture.cs:176:15:176:22 | access to local variable nonSink0 |
+| Capture.cs:171:16:171:28 | SSA def(nonSink0) | Capture.cs:186:15:186:22 | access to local variable nonSink0 |
+| Capture.cs:171:16:171:28 | SSA def(nonSink0) | Capture.cs:186:15:186:22 | access to local variable nonSink0 |
+| Capture.cs:171:16:171:28 | String nonSink0 = ... | Capture.cs:171:16:171:28 | String nonSink0 = ... |
+| Capture.cs:171:27:171:28 | "" | Capture.cs:171:16:171:28 | SSA def(nonSink0) |
+| Capture.cs:171:27:171:28 | "" | Capture.cs:171:16:171:28 | SSA def(nonSink0) |
+| Capture.cs:171:27:171:28 | "" | Capture.cs:171:27:171:28 | "" |
+| Capture.cs:171:27:171:28 | "" | Capture.cs:176:15:176:22 | access to local variable nonSink0 |
+| Capture.cs:171:27:171:28 | "" | Capture.cs:176:15:176:22 | access to local variable nonSink0 |
+| Capture.cs:171:27:171:28 | "" | Capture.cs:186:15:186:22 | access to local variable nonSink0 |
+| Capture.cs:171:27:171:28 | "" | Capture.cs:186:15:186:22 | access to local variable nonSink0 |
+| Capture.cs:172:9:175:9 | SSA capture def(tainted) | Capture.cs:172:9:175:9 | SSA capture def(tainted) |
+| Capture.cs:172:9:175:9 | SSA capture def(tainted) | Capture.cs:174:24:174:30 | access to parameter tainted |
+| Capture.cs:172:9:175:9 | SSA capture def(tainted) | Capture.cs:174:24:174:30 | access to parameter tainted |
+| Capture.cs:174:13:174:30 | ... = ... | Capture.cs:174:13:174:30 | ... = ... |
+| Capture.cs:174:24:174:30 | access to parameter tainted | Capture.cs:174:24:174:30 | access to parameter tainted |
+| Capture.cs:176:9:176:23 | call to method Check | Capture.cs:176:9:176:23 | call to method Check |
+| Capture.cs:176:15:176:22 | access to local variable nonSink0 | Capture.cs:176:15:176:22 | access to local variable nonSink0 |
+| Capture.cs:176:15:176:22 | access to local variable nonSink0 | Capture.cs:186:15:186:22 | access to local variable nonSink0 |
+| Capture.cs:176:15:176:22 | access to local variable nonSink0 | Capture.cs:186:15:186:22 | access to local variable nonSink0 |
+| Capture.cs:180:13:183:13 | SSA capture def(tainted) | Capture.cs:180:13:183:13 | SSA capture def(tainted) |
+| Capture.cs:180:13:183:13 | SSA capture def(tainted) | Capture.cs:182:28:182:34 | access to parameter tainted |
+| Capture.cs:180:13:183:13 | SSA capture def(tainted) | Capture.cs:182:28:182:34 | access to parameter tainted |
+| Capture.cs:182:17:182:34 | ... = ... | Capture.cs:182:17:182:34 | ... = ... |
+| Capture.cs:182:28:182:34 | access to parameter tainted | Capture.cs:182:28:182:34 | access to parameter tainted |
+| Capture.cs:185:9:185:32 | access to local function CaptureThrough2NotCalled | Capture.cs:185:9:185:32 | access to local function CaptureThrough2NotCalled |
+| Capture.cs:185:9:185:34 | call to local function CaptureThrough2NotCalled | Capture.cs:185:9:185:34 | call to local function CaptureThrough2NotCalled |
+| Capture.cs:186:9:186:23 | call to method Check | Capture.cs:186:9:186:23 | call to method Check |
+| Capture.cs:186:15:186:22 | access to local variable nonSink0 | Capture.cs:186:15:186:22 | access to local variable nonSink0 |
+| Capture.cs:188:26:188:26 | s | Capture.cs:188:26:188:26 | s |
+| Capture.cs:188:26:188:26 | s | Capture.cs:188:26:188:26 | s |
+| Capture.cs:188:26:188:26 | s | Capture.cs:191:20:191:22 | [implicit argument] s |
+| Capture.cs:188:26:188:26 | s | Capture.cs:191:20:191:22 | [implicit argument] s |
+| Capture.cs:188:26:188:26 | s | Capture.cs:191:20:191:22 | [implicit argument] s |
+| Capture.cs:188:26:188:26 | s | Capture.cs:191:20:191:22 | [implicit argument] s |
+| Capture.cs:190:13:190:28 | SSA capture def(s) | Capture.cs:190:13:190:28 | SSA capture def(s) |
+| Capture.cs:190:13:190:28 | SSA capture def(s) | Capture.cs:190:27:190:27 | access to parameter s |
+| Capture.cs:190:13:190:28 | SSA capture def(s) | Capture.cs:190:27:190:27 | access to parameter s |
+| Capture.cs:190:13:190:28 | SSA capture def(s) | Capture.cs:190:27:190:27 | access to parameter s |
+| Capture.cs:190:13:190:28 | SSA capture def(s) | Capture.cs:190:27:190:27 | access to parameter s |
+| Capture.cs:190:27:190:27 | access to parameter s | Capture.cs:190:27:190:27 | access to parameter s |
+| Capture.cs:190:27:190:27 | access to parameter s | Capture.cs:191:20:191:22 | call to local function M |
+| Capture.cs:190:27:190:27 | access to parameter s | Capture.cs:191:20:191:22 | call to local function M |
+| Capture.cs:191:20:191:20 | access to local function M | Capture.cs:191:20:191:20 | access to local function M |
+| Capture.cs:191:20:191:22 | [implicit argument] s | Capture.cs:190:13:190:28 | SSA capture def(s) |
+| Capture.cs:191:20:191:22 | [implicit argument] s | Capture.cs:190:13:190:28 | SSA capture def(s) |
+| Capture.cs:191:20:191:22 | [implicit argument] s | Capture.cs:190:13:190:28 | SSA capture def(s) |
+| Capture.cs:191:20:191:22 | [implicit argument] s | Capture.cs:190:13:190:28 | SSA capture def(s) |
+| Capture.cs:191:20:191:22 | [implicit argument] s | Capture.cs:191:20:191:22 | [implicit argument] s |
+| Capture.cs:191:20:191:22 | [implicit argument] s | Capture.cs:191:20:191:22 | call to local function M |
+| Capture.cs:191:20:191:22 | [implicit argument] s | Capture.cs:191:20:191:22 | call to local function M |
+| Capture.cs:191:20:191:22 | [implicit argument] s | Capture.cs:191:20:191:22 | call to local function M |
+| Capture.cs:191:20:191:22 | [implicit argument] s | Capture.cs:191:20:191:22 | call to local function M |
+| Capture.cs:191:20:191:22 | call to local function M | Capture.cs:191:20:191:22 | call to local function M |
+| Capture.cs:191:20:191:22 | call to local function M | Capture.cs:194:22:194:32 | call to local function Id |
+| Capture.cs:191:20:191:22 | call to local function M | Capture.cs:194:22:194:32 | call to local function Id |
+| Capture.cs:191:20:191:22 | call to local function M | Capture.cs:196:20:196:25 | call to local function Id |
+| Capture.cs:191:20:191:22 | call to local function M | Capture.cs:196:20:196:25 | call to local function Id |
+| Capture.cs:194:13:194:32 | SSA def(sink38) | Capture.cs:194:13:194:32 | SSA def(sink38) |
+| Capture.cs:194:13:194:32 | SSA def(sink38) | Capture.cs:195:15:195:20 | access to local variable sink38 |
+| Capture.cs:194:13:194:32 | SSA def(sink38) | Capture.cs:195:15:195:20 | access to local variable sink38 |
+| Capture.cs:194:13:194:32 | String sink38 = ... | Capture.cs:194:13:194:32 | String sink38 = ... |
+| Capture.cs:194:22:194:23 | access to local function Id | Capture.cs:194:22:194:23 | access to local function Id |
+| Capture.cs:194:22:194:32 | call to local function Id | Capture.cs:194:13:194:32 | SSA def(sink38) |
+| Capture.cs:194:22:194:32 | call to local function Id | Capture.cs:194:13:194:32 | SSA def(sink38) |
+| Capture.cs:194:22:194:32 | call to local function Id | Capture.cs:194:22:194:32 | call to local function Id |
+| Capture.cs:194:22:194:32 | call to local function Id | Capture.cs:195:15:195:20 | access to local variable sink38 |
+| Capture.cs:194:22:194:32 | call to local function Id | Capture.cs:195:15:195:20 | access to local variable sink38 |
+| Capture.cs:194:25:194:31 | access to parameter tainted | Capture.cs:188:26:188:26 | s |
+| Capture.cs:194:25:194:31 | access to parameter tainted | Capture.cs:188:26:188:26 | s |
+| Capture.cs:194:25:194:31 | access to parameter tainted | Capture.cs:194:22:194:32 | call to local function Id |
+| Capture.cs:194:25:194:31 | access to parameter tainted | Capture.cs:194:22:194:32 | call to local function Id |
+| Capture.cs:194:25:194:31 | access to parameter tainted | Capture.cs:194:25:194:31 | access to parameter tainted |
+| Capture.cs:195:9:195:21 | call to method Check | Capture.cs:195:9:195:21 | call to method Check |
+| Capture.cs:195:15:195:20 | access to local variable sink38 | Capture.cs:195:15:195:20 | access to local variable sink38 |
+| Capture.cs:196:9:196:25 | ... = ... | Capture.cs:196:9:196:25 | ... = ... |
+| Capture.cs:196:9:196:25 | SSA def(nonSink0) | Capture.cs:196:9:196:25 | SSA def(nonSink0) |
+| Capture.cs:196:9:196:25 | SSA def(nonSink0) | Capture.cs:197:15:197:22 | access to local variable nonSink0 |
+| Capture.cs:196:9:196:25 | SSA def(nonSink0) | Capture.cs:197:15:197:22 | access to local variable nonSink0 |
+| Capture.cs:196:20:196:21 | access to local function Id | Capture.cs:196:20:196:21 | access to local function Id |
+| Capture.cs:196:20:196:25 | call to local function Id | Capture.cs:196:9:196:25 | SSA def(nonSink0) |
+| Capture.cs:196:20:196:25 | call to local function Id | Capture.cs:196:9:196:25 | SSA def(nonSink0) |
+| Capture.cs:196:20:196:25 | call to local function Id | Capture.cs:196:20:196:25 | call to local function Id |
+| Capture.cs:196:20:196:25 | call to local function Id | Capture.cs:197:15:197:22 | access to local variable nonSink0 |
+| Capture.cs:196:20:196:25 | call to local function Id | Capture.cs:197:15:197:22 | access to local variable nonSink0 |
+| Capture.cs:196:23:196:24 | "" | Capture.cs:188:26:188:26 | s |
+| Capture.cs:196:23:196:24 | "" | Capture.cs:188:26:188:26 | s |
+| Capture.cs:196:23:196:24 | "" | Capture.cs:196:20:196:25 | call to local function Id |
+| Capture.cs:196:23:196:24 | "" | Capture.cs:196:20:196:25 | call to local function Id |
+| Capture.cs:196:23:196:24 | "" | Capture.cs:196:23:196:24 | "" |
+| Capture.cs:197:9:197:23 | call to method Check | Capture.cs:197:9:197:23 | call to method Check |
+| Capture.cs:197:15:197:22 | access to local variable nonSink0 | Capture.cs:197:15:197:22 | access to local variable nonSink0 |
+| Capture.cs:202:34:202:34 | a | Capture.cs:202:34:202:34 | a |
+| Capture.cs:202:34:202:34 | a | Capture.cs:202:34:202:34 | a |
+| Capture.cs:202:34:202:34 | a | Capture.cs:204:9:204:9 | access to parameter a |
+| Capture.cs:202:34:202:34 | a | Capture.cs:204:9:204:9 | access to parameter a |
+| Capture.cs:202:34:202:34 | a | Capture.cs:204:9:204:9 | access to parameter a |
+| Capture.cs:202:34:202:34 | a | Capture.cs:204:9:204:9 | access to parameter a |
+| Capture.cs:202:34:202:34 | a | Capture.cs:204:9:204:9 | access to parameter a |
+| Capture.cs:202:34:202:34 | a | Capture.cs:204:9:204:9 | access to parameter a |
+| Capture.cs:204:9:204:9 | access to parameter a | Capture.cs:204:9:204:9 | access to parameter a |
+| Capture.cs:204:9:204:18 | delegate call | Capture.cs:204:9:204:18 | delegate call |
 | GlobalDataFlow.cs:14:17:14:17 | this | GlobalDataFlow.cs:14:17:14:17 | this |
 | GlobalDataFlow.cs:14:17:14:17 | this | GlobalDataFlow.cs:64:9:64:18 | this access |
 | GlobalDataFlow.cs:14:17:14:17 | this | GlobalDataFlow.cs:64:9:64:18 | this access |

--- a/csharp/ql/test/library-tests/dataflow/global/DataFlowEdges.expected
+++ b/csharp/ql/test/library-tests/dataflow/global/DataFlowEdges.expected
@@ -337,6 +337,45 @@
 | Capture.cs:109:9:109:30 | call to local function CaptureOut2NotCalled | Capture.cs:109:9:109:30 | call to local function CaptureOut2NotCalled |
 | Capture.cs:110:9:110:23 | call to method Check | Capture.cs:110:9:110:23 | call to method Check |
 | Capture.cs:110:15:110:22 | access to local variable nonSink0 | Capture.cs:110:15:110:22 | access to local variable nonSink0 |
+| Capture.cs:111:16:111:26 | SSA def(sink40) | Capture.cs:111:16:111:26 | SSA def(sink40) |
+| Capture.cs:111:16:111:26 | String sink40 = ... | Capture.cs:111:16:111:26 | String sink40 = ... |
+| Capture.cs:111:25:111:26 | "" | Capture.cs:111:16:111:26 | SSA def(sink40) |
+| Capture.cs:111:25:111:26 | "" | Capture.cs:111:16:111:26 | SSA def(sink40) |
+| Capture.cs:111:25:111:26 | "" | Capture.cs:111:25:111:26 | "" |
+| Capture.cs:114:13:116:14 | call to method RunAction | Capture.cs:114:13:116:14 | call to method RunAction |
+| Capture.cs:114:23:116:13 | (...) => ... | Capture.cs:114:23:116:13 | (...) => ... |
+| Capture.cs:114:23:116:13 | (...) => ... | Capture.cs:202:34:202:34 | a |
+| Capture.cs:114:23:116:13 | (...) => ... | Capture.cs:202:34:202:34 | a |
+| Capture.cs:115:17:115:39 | ... = ... | Capture.cs:115:17:115:39 | ... = ... |
+| Capture.cs:115:17:115:39 | SSA def(sink40) | Capture.cs:115:17:115:39 | SSA def(sink40) |
+| Capture.cs:115:17:115:39 | SSA def(sink40) | Capture.cs:121:9:121:35 | SSA call def(sink40) |
+| Capture.cs:115:17:115:39 | SSA def(sink40) | Capture.cs:121:9:121:35 | SSA call def(sink40) |
+| Capture.cs:115:26:115:39 | "taint source" | Capture.cs:115:17:115:39 | SSA def(sink40) |
+| Capture.cs:115:26:115:39 | "taint source" | Capture.cs:115:17:115:39 | SSA def(sink40) |
+| Capture.cs:115:26:115:39 | "taint source" | Capture.cs:115:26:115:39 | "taint source" |
+| Capture.cs:117:13:119:14 | call to method RunAction | Capture.cs:117:13:119:14 | call to method RunAction |
+| Capture.cs:117:23:119:13 | (...) => ... | Capture.cs:117:23:119:13 | (...) => ... |
+| Capture.cs:117:23:119:13 | (...) => ... | Capture.cs:202:34:202:34 | a |
+| Capture.cs:117:23:119:13 | (...) => ... | Capture.cs:202:34:202:34 | a |
+| Capture.cs:118:17:118:40 | ... = ... | Capture.cs:118:17:118:40 | ... = ... |
+| Capture.cs:118:17:118:40 | SSA def(nonSink0) | Capture.cs:118:17:118:40 | SSA def(nonSink0) |
+| Capture.cs:118:17:118:40 | SSA def(nonSink0) | Capture.cs:121:9:121:35 | SSA call def(nonSink0) |
+| Capture.cs:118:17:118:40 | SSA def(nonSink0) | Capture.cs:121:9:121:35 | SSA call def(nonSink0) |
+| Capture.cs:118:28:118:40 | "not tainted" | Capture.cs:118:17:118:40 | SSA def(nonSink0) |
+| Capture.cs:118:28:118:40 | "not tainted" | Capture.cs:118:17:118:40 | SSA def(nonSink0) |
+| Capture.cs:118:28:118:40 | "not tainted" | Capture.cs:118:28:118:40 | "not tainted" |
+| Capture.cs:121:9:121:33 | access to local function CaptureOutMultipleLambdas | Capture.cs:121:9:121:33 | access to local function CaptureOutMultipleLambdas |
+| Capture.cs:121:9:121:35 | SSA call def(nonSink0) | Capture.cs:121:9:121:35 | SSA call def(nonSink0) |
+| Capture.cs:121:9:121:35 | SSA call def(nonSink0) | Capture.cs:122:30:122:37 | access to local variable nonSink0 |
+| Capture.cs:121:9:121:35 | SSA call def(nonSink0) | Capture.cs:122:30:122:37 | access to local variable nonSink0 |
+| Capture.cs:121:9:121:35 | SSA call def(sink40) | Capture.cs:121:9:121:35 | SSA call def(sink40) |
+| Capture.cs:121:9:121:35 | SSA call def(sink40) | Capture.cs:122:15:122:20 | access to local variable sink40 |
+| Capture.cs:121:9:121:35 | SSA call def(sink40) | Capture.cs:122:15:122:20 | access to local variable sink40 |
+| Capture.cs:121:9:121:35 | call to local function CaptureOutMultipleLambdas | Capture.cs:121:9:121:35 | call to local function CaptureOutMultipleLambdas |
+| Capture.cs:122:9:122:21 | call to method Check | Capture.cs:122:9:122:21 | call to method Check |
+| Capture.cs:122:15:122:20 | access to local variable sink40 | Capture.cs:122:15:122:20 | access to local variable sink40 |
+| Capture.cs:122:24:122:38 | call to method Check | Capture.cs:122:24:122:38 | call to method Check |
+| Capture.cs:122:30:122:37 | access to local variable nonSink0 | Capture.cs:122:30:122:37 | access to local variable nonSink0 |
 | Capture.cs:125:10:125:16 | this | Capture.cs:125:10:125:16 | this |
 | Capture.cs:125:25:125:31 | tainted | Capture.cs:125:25:125:31 | tainted |
 | Capture.cs:125:25:125:31 | tainted | Capture.cs:125:25:125:31 | tainted |
@@ -641,6 +680,10 @@
 | Capture.cs:197:15:197:22 | access to local variable nonSink0 | Capture.cs:197:15:197:22 | access to local variable nonSink0 |
 | Capture.cs:202:34:202:34 | a | Capture.cs:202:34:202:34 | a |
 | Capture.cs:202:34:202:34 | a | Capture.cs:202:34:202:34 | a |
+| Capture.cs:202:34:202:34 | a | Capture.cs:204:9:204:9 | access to parameter a |
+| Capture.cs:202:34:202:34 | a | Capture.cs:204:9:204:9 | access to parameter a |
+| Capture.cs:202:34:202:34 | a | Capture.cs:204:9:204:9 | access to parameter a |
+| Capture.cs:202:34:202:34 | a | Capture.cs:204:9:204:9 | access to parameter a |
 | Capture.cs:202:34:202:34 | a | Capture.cs:204:9:204:9 | access to parameter a |
 | Capture.cs:202:34:202:34 | a | Capture.cs:204:9:204:9 | access to parameter a |
 | Capture.cs:202:34:202:34 | a | Capture.cs:204:9:204:9 | access to parameter a |

--- a/csharp/ql/test/library-tests/dataflow/global/DataFlowPath.expected
+++ b/csharp/ql/test/library-tests/dataflow/global/DataFlowPath.expected
@@ -22,24 +22,24 @@ edges
 | Capture.cs:89:13:89:35 | SSA def(sink32) | Capture.cs:92:9:92:41 | SSA call def(sink32) |
 | Capture.cs:89:22:89:35 | "taint source" | Capture.cs:89:13:89:35 | SSA def(sink32) |
 | Capture.cs:92:9:92:41 | SSA call def(sink32) | Capture.cs:93:15:93:20 | access to local variable sink32 |
-| Capture.cs:113:25:113:31 | tainted | Capture.cs:120:9:120:25 | [implicit argument] tainted |
-| Capture.cs:113:25:113:31 | tainted | Capture.cs:132:9:132:25 | [implicit argument] tainted |
-| Capture.cs:113:25:113:31 | tainted | Capture.cs:141:9:141:45 | [implicit argument] tainted |
-| Capture.cs:113:25:113:31 | tainted | Capture.cs:148:22:148:38 | [implicit argument] tainted |
-| Capture.cs:113:25:113:31 | tainted | Capture.cs:156:25:156:31 | access to parameter tainted |
-| Capture.cs:113:25:113:31 | tainted | Capture.cs:182:25:182:31 | access to parameter tainted |
-| Capture.cs:120:9:120:25 | SSA call def(sink33) | Capture.cs:121:15:121:20 | access to local variable sink33 |
-| Capture.cs:120:9:120:25 | [implicit argument] tainted | Capture.cs:120:9:120:25 | SSA call def(sink33) |
-| Capture.cs:132:9:132:25 | SSA call def(sink34) | Capture.cs:133:15:133:20 | access to local variable sink34 |
-| Capture.cs:132:9:132:25 | [implicit argument] tainted | Capture.cs:132:9:132:25 | SSA call def(sink34) |
-| Capture.cs:141:9:141:45 | SSA call def(sink35) | Capture.cs:142:15:142:20 | access to local variable sink35 |
-| Capture.cs:141:9:141:45 | [implicit argument] tainted | Capture.cs:141:9:141:45 | SSA call def(sink35) |
-| Capture.cs:148:22:148:38 | [implicit argument] tainted | Capture.cs:148:22:148:38 | call to local function CaptureThrough4 |
-| Capture.cs:148:22:148:38 | call to local function CaptureThrough4 | Capture.cs:149:15:149:20 | access to local variable sink36 |
-| Capture.cs:156:9:156:32 | SSA call def(sink37) | Capture.cs:157:15:157:20 | access to local variable sink37 |
-| Capture.cs:156:25:156:31 | access to parameter tainted | Capture.cs:156:9:156:32 | SSA call def(sink37) |
-| Capture.cs:182:22:182:32 | call to local function Id | Capture.cs:183:15:183:20 | access to local variable sink38 |
-| Capture.cs:182:25:182:31 | access to parameter tainted | Capture.cs:182:22:182:32 | call to local function Id |
+| Capture.cs:125:25:125:31 | tainted | Capture.cs:132:9:132:25 | [implicit argument] tainted |
+| Capture.cs:125:25:125:31 | tainted | Capture.cs:144:9:144:25 | [implicit argument] tainted |
+| Capture.cs:125:25:125:31 | tainted | Capture.cs:153:9:153:45 | [implicit argument] tainted |
+| Capture.cs:125:25:125:31 | tainted | Capture.cs:160:22:160:38 | [implicit argument] tainted |
+| Capture.cs:125:25:125:31 | tainted | Capture.cs:168:25:168:31 | access to parameter tainted |
+| Capture.cs:125:25:125:31 | tainted | Capture.cs:194:25:194:31 | access to parameter tainted |
+| Capture.cs:132:9:132:25 | SSA call def(sink33) | Capture.cs:133:15:133:20 | access to local variable sink33 |
+| Capture.cs:132:9:132:25 | [implicit argument] tainted | Capture.cs:132:9:132:25 | SSA call def(sink33) |
+| Capture.cs:144:9:144:25 | SSA call def(sink34) | Capture.cs:145:15:145:20 | access to local variable sink34 |
+| Capture.cs:144:9:144:25 | [implicit argument] tainted | Capture.cs:144:9:144:25 | SSA call def(sink34) |
+| Capture.cs:153:9:153:45 | SSA call def(sink35) | Capture.cs:154:15:154:20 | access to local variable sink35 |
+| Capture.cs:153:9:153:45 | [implicit argument] tainted | Capture.cs:153:9:153:45 | SSA call def(sink35) |
+| Capture.cs:160:22:160:38 | [implicit argument] tainted | Capture.cs:160:22:160:38 | call to local function CaptureThrough4 |
+| Capture.cs:160:22:160:38 | call to local function CaptureThrough4 | Capture.cs:161:15:161:20 | access to local variable sink36 |
+| Capture.cs:168:9:168:32 | SSA call def(sink37) | Capture.cs:169:15:169:20 | access to local variable sink37 |
+| Capture.cs:168:25:168:31 | access to parameter tainted | Capture.cs:168:9:168:32 | SSA call def(sink37) |
+| Capture.cs:194:22:194:32 | call to local function Id | Capture.cs:195:15:195:20 | access to local variable sink38 |
+| Capture.cs:194:25:194:31 | access to parameter tainted | Capture.cs:194:22:194:32 | call to local function Id |
 | GlobalDataFlow.cs:17:27:17:40 | "taint source" | GlobalDataFlow.cs:18:15:18:29 | access to field SinkField0 |
 | GlobalDataFlow.cs:17:27:17:40 | "taint source" | GlobalDataFlow.cs:26:15:26:32 | access to property SinkProperty0 |
 | GlobalDataFlow.cs:17:27:17:40 | "taint source" | GlobalDataFlow.cs:26:15:26:32 | access to property SinkProperty0 |
@@ -218,12 +218,12 @@ edges
 | Capture.cs:72:15:72:20 | access to local variable sink30 | Capture.cs:69:22:69:35 | "taint source" | Capture.cs:72:15:72:20 | access to local variable sink30 | access to local variable sink30 |
 | Capture.cs:84:15:84:20 | access to local variable sink31 | Capture.cs:79:26:79:39 | "taint source" | Capture.cs:84:15:84:20 | access to local variable sink31 | access to local variable sink31 |
 | Capture.cs:93:15:93:20 | access to local variable sink32 | Capture.cs:89:22:89:35 | "taint source" | Capture.cs:93:15:93:20 | access to local variable sink32 | access to local variable sink32 |
-| Capture.cs:121:15:121:20 | access to local variable sink33 | Capture.cs:113:25:113:31 | tainted | Capture.cs:121:15:121:20 | access to local variable sink33 | access to local variable sink33 |
-| Capture.cs:133:15:133:20 | access to local variable sink34 | Capture.cs:113:25:113:31 | tainted | Capture.cs:133:15:133:20 | access to local variable sink34 | access to local variable sink34 |
-| Capture.cs:142:15:142:20 | access to local variable sink35 | Capture.cs:113:25:113:31 | tainted | Capture.cs:142:15:142:20 | access to local variable sink35 | access to local variable sink35 |
-| Capture.cs:149:15:149:20 | access to local variable sink36 | Capture.cs:113:25:113:31 | tainted | Capture.cs:149:15:149:20 | access to local variable sink36 | access to local variable sink36 |
-| Capture.cs:157:15:157:20 | access to local variable sink37 | Capture.cs:113:25:113:31 | tainted | Capture.cs:157:15:157:20 | access to local variable sink37 | access to local variable sink37 |
-| Capture.cs:183:15:183:20 | access to local variable sink38 | Capture.cs:113:25:113:31 | tainted | Capture.cs:183:15:183:20 | access to local variable sink38 | access to local variable sink38 |
+| Capture.cs:133:15:133:20 | access to local variable sink33 | Capture.cs:125:25:125:31 | tainted | Capture.cs:133:15:133:20 | access to local variable sink33 | access to local variable sink33 |
+| Capture.cs:145:15:145:20 | access to local variable sink34 | Capture.cs:125:25:125:31 | tainted | Capture.cs:145:15:145:20 | access to local variable sink34 | access to local variable sink34 |
+| Capture.cs:154:15:154:20 | access to local variable sink35 | Capture.cs:125:25:125:31 | tainted | Capture.cs:154:15:154:20 | access to local variable sink35 | access to local variable sink35 |
+| Capture.cs:161:15:161:20 | access to local variable sink36 | Capture.cs:125:25:125:31 | tainted | Capture.cs:161:15:161:20 | access to local variable sink36 | access to local variable sink36 |
+| Capture.cs:169:15:169:20 | access to local variable sink37 | Capture.cs:125:25:125:31 | tainted | Capture.cs:169:15:169:20 | access to local variable sink37 | access to local variable sink37 |
+| Capture.cs:195:15:195:20 | access to local variable sink38 | Capture.cs:125:25:125:31 | tainted | Capture.cs:195:15:195:20 | access to local variable sink38 | access to local variable sink38 |
 | GlobalDataFlow.cs:136:15:136:19 | access to local variable sink4 | GlobalDataFlow.cs:17:27:17:40 | "taint source" | GlobalDataFlow.cs:136:15:136:19 | access to local variable sink4 | access to local variable sink4 |
 | GlobalDataFlow.cs:144:15:144:19 | access to local variable sink5 | GlobalDataFlow.cs:17:27:17:40 | "taint source" | GlobalDataFlow.cs:144:15:144:19 | access to local variable sink5 | access to local variable sink5 |
 | GlobalDataFlow.cs:154:15:154:19 | access to local variable sink6 | GlobalDataFlow.cs:318:16:318:29 | "taint source" | GlobalDataFlow.cs:154:15:154:19 | access to local variable sink6 | access to local variable sink6 |

--- a/csharp/ql/test/library-tests/dataflow/global/DataFlowPath.expected
+++ b/csharp/ql/test/library-tests/dataflow/global/DataFlowPath.expected
@@ -2,12 +2,17 @@ edges
 | Capture.cs:7:20:7:26 | tainted | Capture.cs:14:9:14:20 | [implicit argument] tainted |
 | Capture.cs:7:20:7:26 | tainted | Capture.cs:25:9:25:20 | [implicit argument] tainted |
 | Capture.cs:7:20:7:26 | tainted | Capture.cs:33:9:33:40 | [implicit argument] tainted |
+| Capture.cs:7:20:7:26 | tainted | Capture.cs:61:36:61:42 | access to parameter tainted |
 | Capture.cs:9:9:13:9 | SSA capture def(tainted) | Capture.cs:12:19:12:24 | access to local variable sink27 |
 | Capture.cs:14:9:14:20 | [implicit argument] tainted | Capture.cs:9:9:13:9 | SSA capture def(tainted) |
 | Capture.cs:18:13:22:13 | SSA capture def(tainted) | Capture.cs:21:23:21:28 | access to local variable sink28 |
 | Capture.cs:25:9:25:20 | [implicit argument] tainted | Capture.cs:18:13:22:13 | SSA capture def(tainted) |
 | Capture.cs:27:43:32:9 | SSA capture def(tainted) | Capture.cs:30:19:30:24 | access to local variable sink29 |
 | Capture.cs:33:9:33:40 | [implicit argument] tainted | Capture.cs:27:43:32:9 | SSA capture def(tainted) |
+| Capture.cs:50:50:50:55 | sink39 | Capture.cs:52:13:59:14 | [implicit argument] sink39 |
+| Capture.cs:52:13:59:14 | [implicit argument] sink39 | Capture.cs:55:27:58:17 | SSA capture def(sink39) |
+| Capture.cs:55:27:58:17 | SSA capture def(sink39) | Capture.cs:57:27:57:32 | access to parameter sink39 |
+| Capture.cs:61:36:61:42 | access to parameter tainted | Capture.cs:50:50:50:55 | sink39 |
 | Capture.cs:69:13:69:35 | SSA def(sink30) | Capture.cs:71:9:71:21 | SSA call def(sink30) |
 | Capture.cs:69:22:69:35 | "taint source" | Capture.cs:69:13:69:35 | SSA def(sink30) |
 | Capture.cs:71:9:71:21 | SSA call def(sink30) | Capture.cs:72:15:72:20 | access to local variable sink30 |
@@ -227,6 +232,7 @@ edges
 | GlobalDataFlow.cs:181:15:181:19 | access to local variable sink9 | GlobalDataFlow.cs:179:35:179:48 | "taint source" | GlobalDataFlow.cs:181:15:181:19 | access to local variable sink9 | access to local variable sink9 |
 | Splitting.cs:11:19:11:19 | access to local variable x | Splitting.cs:3:28:3:34 | tainted | Splitting.cs:11:19:11:19 | access to local variable x | access to local variable x |
 | Splitting.cs:34:19:34:19 | access to local variable x | Splitting.cs:24:28:24:34 | tainted | Splitting.cs:34:19:34:19 | access to local variable x | access to local variable x |
+| Capture.cs:57:27:57:32 | access to parameter sink39 | Capture.cs:7:20:7:26 | tainted | Capture.cs:57:27:57:32 | access to parameter sink39 | access to parameter sink39 |
 | GlobalDataFlow.cs:237:15:237:24 | access to parameter sinkParam0 | GlobalDataFlow.cs:17:27:17:40 | "taint source" | GlobalDataFlow.cs:237:15:237:24 | access to parameter sinkParam0 | access to parameter sinkParam0 |
 | GlobalDataFlow.cs:242:15:242:24 | access to parameter sinkParam1 | GlobalDataFlow.cs:17:27:17:40 | "taint source" | GlobalDataFlow.cs:242:15:242:24 | access to parameter sinkParam1 | access to parameter sinkParam1 |
 | GlobalDataFlow.cs:44:50:44:59 | access to parameter sinkParam2 | GlobalDataFlow.cs:17:27:17:40 | "taint source" | GlobalDataFlow.cs:44:50:44:59 | access to parameter sinkParam2 | access to parameter sinkParam2 |

--- a/csharp/ql/test/library-tests/dataflow/global/DataFlowPath.expected
+++ b/csharp/ql/test/library-tests/dataflow/global/DataFlowPath.expected
@@ -22,6 +22,9 @@ edges
 | Capture.cs:89:13:89:35 | SSA def(sink32) | Capture.cs:92:9:92:41 | SSA call def(sink32) |
 | Capture.cs:89:22:89:35 | "taint source" | Capture.cs:89:13:89:35 | SSA def(sink32) |
 | Capture.cs:92:9:92:41 | SSA call def(sink32) | Capture.cs:93:15:93:20 | access to local variable sink32 |
+| Capture.cs:115:17:115:39 | SSA def(sink40) | Capture.cs:121:9:121:35 | SSA call def(sink40) |
+| Capture.cs:115:26:115:39 | "taint source" | Capture.cs:115:17:115:39 | SSA def(sink40) |
+| Capture.cs:121:9:121:35 | SSA call def(sink40) | Capture.cs:122:15:122:20 | access to local variable sink40 |
 | Capture.cs:125:25:125:31 | tainted | Capture.cs:132:9:132:25 | [implicit argument] tainted |
 | Capture.cs:125:25:125:31 | tainted | Capture.cs:144:9:144:25 | [implicit argument] tainted |
 | Capture.cs:125:25:125:31 | tainted | Capture.cs:153:9:153:45 | [implicit argument] tainted |
@@ -225,6 +228,7 @@ edges
 | Capture.cs:169:15:169:20 | access to local variable sink37 | Capture.cs:125:25:125:31 | tainted | Capture.cs:169:15:169:20 | access to local variable sink37 | access to local variable sink37 |
 | Capture.cs:195:15:195:20 | access to local variable sink38 | Capture.cs:125:25:125:31 | tainted | Capture.cs:195:15:195:20 | access to local variable sink38 | access to local variable sink38 |
 | GlobalDataFlow.cs:136:15:136:19 | access to local variable sink4 | GlobalDataFlow.cs:17:27:17:40 | "taint source" | GlobalDataFlow.cs:136:15:136:19 | access to local variable sink4 | access to local variable sink4 |
+| Capture.cs:122:15:122:20 | access to local variable sink40 | Capture.cs:115:26:115:39 | "taint source" | Capture.cs:122:15:122:20 | access to local variable sink40 | access to local variable sink40 |
 | GlobalDataFlow.cs:144:15:144:19 | access to local variable sink5 | GlobalDataFlow.cs:17:27:17:40 | "taint source" | GlobalDataFlow.cs:144:15:144:19 | access to local variable sink5 | access to local variable sink5 |
 | GlobalDataFlow.cs:154:15:154:19 | access to local variable sink6 | GlobalDataFlow.cs:318:16:318:29 | "taint source" | GlobalDataFlow.cs:154:15:154:19 | access to local variable sink6 | access to local variable sink6 |
 | GlobalDataFlow.cs:157:15:157:19 | access to local variable sink7 | GlobalDataFlow.cs:323:13:323:26 | "taint source" | GlobalDataFlow.cs:157:15:157:19 | access to local variable sink7 | access to local variable sink7 |

--- a/csharp/ql/test/library-tests/dataflow/global/DataFlowPath.expected
+++ b/csharp/ql/test/library-tests/dataflow/global/DataFlowPath.expected
@@ -8,33 +8,33 @@ edges
 | Capture.cs:25:9:25:20 | [implicit argument] tainted | Capture.cs:18:13:22:13 | SSA capture def(tainted) |
 | Capture.cs:27:43:32:9 | SSA capture def(tainted) | Capture.cs:30:19:30:24 | access to local variable sink29 |
 | Capture.cs:33:9:33:40 | [implicit argument] tainted | Capture.cs:27:43:32:9 | SSA capture def(tainted) |
-| Capture.cs:57:13:57:35 | SSA def(sink30) | Capture.cs:59:9:59:21 | SSA call def(sink30) |
-| Capture.cs:57:22:57:35 | "taint source" | Capture.cs:57:13:57:35 | SSA def(sink30) |
-| Capture.cs:59:9:59:21 | SSA call def(sink30) | Capture.cs:60:15:60:20 | access to local variable sink30 |
-| Capture.cs:67:17:67:39 | SSA def(sink31) | Capture.cs:71:9:71:21 | SSA call def(sink31) |
-| Capture.cs:67:26:67:39 | "taint source" | Capture.cs:67:17:67:39 | SSA def(sink31) |
-| Capture.cs:71:9:71:21 | SSA call def(sink31) | Capture.cs:72:15:72:20 | access to local variable sink31 |
-| Capture.cs:77:13:77:35 | SSA def(sink32) | Capture.cs:80:9:80:41 | SSA call def(sink32) |
-| Capture.cs:77:22:77:35 | "taint source" | Capture.cs:77:13:77:35 | SSA def(sink32) |
-| Capture.cs:80:9:80:41 | SSA call def(sink32) | Capture.cs:81:15:81:20 | access to local variable sink32 |
-| Capture.cs:101:25:101:31 | tainted | Capture.cs:108:9:108:25 | [implicit argument] tainted |
-| Capture.cs:101:25:101:31 | tainted | Capture.cs:120:9:120:25 | [implicit argument] tainted |
-| Capture.cs:101:25:101:31 | tainted | Capture.cs:129:9:129:45 | [implicit argument] tainted |
-| Capture.cs:101:25:101:31 | tainted | Capture.cs:136:22:136:38 | [implicit argument] tainted |
-| Capture.cs:101:25:101:31 | tainted | Capture.cs:144:25:144:31 | access to parameter tainted |
-| Capture.cs:101:25:101:31 | tainted | Capture.cs:170:25:170:31 | access to parameter tainted |
-| Capture.cs:108:9:108:25 | SSA call def(sink33) | Capture.cs:109:15:109:20 | access to local variable sink33 |
-| Capture.cs:108:9:108:25 | [implicit argument] tainted | Capture.cs:108:9:108:25 | SSA call def(sink33) |
-| Capture.cs:120:9:120:25 | SSA call def(sink34) | Capture.cs:121:15:121:20 | access to local variable sink34 |
-| Capture.cs:120:9:120:25 | [implicit argument] tainted | Capture.cs:120:9:120:25 | SSA call def(sink34) |
-| Capture.cs:129:9:129:45 | SSA call def(sink35) | Capture.cs:130:15:130:20 | access to local variable sink35 |
-| Capture.cs:129:9:129:45 | [implicit argument] tainted | Capture.cs:129:9:129:45 | SSA call def(sink35) |
-| Capture.cs:136:22:136:38 | [implicit argument] tainted | Capture.cs:136:22:136:38 | call to local function CaptureThrough4 |
-| Capture.cs:136:22:136:38 | call to local function CaptureThrough4 | Capture.cs:137:15:137:20 | access to local variable sink36 |
-| Capture.cs:144:9:144:32 | SSA call def(sink37) | Capture.cs:145:15:145:20 | access to local variable sink37 |
-| Capture.cs:144:25:144:31 | access to parameter tainted | Capture.cs:144:9:144:32 | SSA call def(sink37) |
-| Capture.cs:170:22:170:32 | call to local function Id | Capture.cs:171:15:171:20 | access to local variable sink38 |
-| Capture.cs:170:25:170:31 | access to parameter tainted | Capture.cs:170:22:170:32 | call to local function Id |
+| Capture.cs:69:13:69:35 | SSA def(sink30) | Capture.cs:71:9:71:21 | SSA call def(sink30) |
+| Capture.cs:69:22:69:35 | "taint source" | Capture.cs:69:13:69:35 | SSA def(sink30) |
+| Capture.cs:71:9:71:21 | SSA call def(sink30) | Capture.cs:72:15:72:20 | access to local variable sink30 |
+| Capture.cs:79:17:79:39 | SSA def(sink31) | Capture.cs:83:9:83:21 | SSA call def(sink31) |
+| Capture.cs:79:26:79:39 | "taint source" | Capture.cs:79:17:79:39 | SSA def(sink31) |
+| Capture.cs:83:9:83:21 | SSA call def(sink31) | Capture.cs:84:15:84:20 | access to local variable sink31 |
+| Capture.cs:89:13:89:35 | SSA def(sink32) | Capture.cs:92:9:92:41 | SSA call def(sink32) |
+| Capture.cs:89:22:89:35 | "taint source" | Capture.cs:89:13:89:35 | SSA def(sink32) |
+| Capture.cs:92:9:92:41 | SSA call def(sink32) | Capture.cs:93:15:93:20 | access to local variable sink32 |
+| Capture.cs:113:25:113:31 | tainted | Capture.cs:120:9:120:25 | [implicit argument] tainted |
+| Capture.cs:113:25:113:31 | tainted | Capture.cs:132:9:132:25 | [implicit argument] tainted |
+| Capture.cs:113:25:113:31 | tainted | Capture.cs:141:9:141:45 | [implicit argument] tainted |
+| Capture.cs:113:25:113:31 | tainted | Capture.cs:148:22:148:38 | [implicit argument] tainted |
+| Capture.cs:113:25:113:31 | tainted | Capture.cs:156:25:156:31 | access to parameter tainted |
+| Capture.cs:113:25:113:31 | tainted | Capture.cs:182:25:182:31 | access to parameter tainted |
+| Capture.cs:120:9:120:25 | SSA call def(sink33) | Capture.cs:121:15:121:20 | access to local variable sink33 |
+| Capture.cs:120:9:120:25 | [implicit argument] tainted | Capture.cs:120:9:120:25 | SSA call def(sink33) |
+| Capture.cs:132:9:132:25 | SSA call def(sink34) | Capture.cs:133:15:133:20 | access to local variable sink34 |
+| Capture.cs:132:9:132:25 | [implicit argument] tainted | Capture.cs:132:9:132:25 | SSA call def(sink34) |
+| Capture.cs:141:9:141:45 | SSA call def(sink35) | Capture.cs:142:15:142:20 | access to local variable sink35 |
+| Capture.cs:141:9:141:45 | [implicit argument] tainted | Capture.cs:141:9:141:45 | SSA call def(sink35) |
+| Capture.cs:148:22:148:38 | [implicit argument] tainted | Capture.cs:148:22:148:38 | call to local function CaptureThrough4 |
+| Capture.cs:148:22:148:38 | call to local function CaptureThrough4 | Capture.cs:149:15:149:20 | access to local variable sink36 |
+| Capture.cs:156:9:156:32 | SSA call def(sink37) | Capture.cs:157:15:157:20 | access to local variable sink37 |
+| Capture.cs:156:25:156:31 | access to parameter tainted | Capture.cs:156:9:156:32 | SSA call def(sink37) |
+| Capture.cs:182:22:182:32 | call to local function Id | Capture.cs:183:15:183:20 | access to local variable sink38 |
+| Capture.cs:182:25:182:31 | access to parameter tainted | Capture.cs:182:22:182:32 | call to local function Id |
 | GlobalDataFlow.cs:17:27:17:40 | "taint source" | GlobalDataFlow.cs:18:15:18:29 | access to field SinkField0 |
 | GlobalDataFlow.cs:17:27:17:40 | "taint source" | GlobalDataFlow.cs:26:15:26:32 | access to property SinkProperty0 |
 | GlobalDataFlow.cs:17:27:17:40 | "taint source" | GlobalDataFlow.cs:26:15:26:32 | access to property SinkProperty0 |
@@ -210,15 +210,15 @@ edges
 | Capture.cs:21:23:21:28 | access to local variable sink28 | Capture.cs:7:20:7:26 | tainted | Capture.cs:21:23:21:28 | access to local variable sink28 | access to local variable sink28 |
 | Capture.cs:30:19:30:24 | access to local variable sink29 | Capture.cs:7:20:7:26 | tainted | Capture.cs:30:19:30:24 | access to local variable sink29 | access to local variable sink29 |
 | GlobalDataFlow.cs:79:15:79:19 | access to local variable sink3 | GlobalDataFlow.cs:17:27:17:40 | "taint source" | GlobalDataFlow.cs:79:15:79:19 | access to local variable sink3 | access to local variable sink3 |
-| Capture.cs:60:15:60:20 | access to local variable sink30 | Capture.cs:57:22:57:35 | "taint source" | Capture.cs:60:15:60:20 | access to local variable sink30 | access to local variable sink30 |
-| Capture.cs:72:15:72:20 | access to local variable sink31 | Capture.cs:67:26:67:39 | "taint source" | Capture.cs:72:15:72:20 | access to local variable sink31 | access to local variable sink31 |
-| Capture.cs:81:15:81:20 | access to local variable sink32 | Capture.cs:77:22:77:35 | "taint source" | Capture.cs:81:15:81:20 | access to local variable sink32 | access to local variable sink32 |
-| Capture.cs:109:15:109:20 | access to local variable sink33 | Capture.cs:101:25:101:31 | tainted | Capture.cs:109:15:109:20 | access to local variable sink33 | access to local variable sink33 |
-| Capture.cs:121:15:121:20 | access to local variable sink34 | Capture.cs:101:25:101:31 | tainted | Capture.cs:121:15:121:20 | access to local variable sink34 | access to local variable sink34 |
-| Capture.cs:130:15:130:20 | access to local variable sink35 | Capture.cs:101:25:101:31 | tainted | Capture.cs:130:15:130:20 | access to local variable sink35 | access to local variable sink35 |
-| Capture.cs:137:15:137:20 | access to local variable sink36 | Capture.cs:101:25:101:31 | tainted | Capture.cs:137:15:137:20 | access to local variable sink36 | access to local variable sink36 |
-| Capture.cs:145:15:145:20 | access to local variable sink37 | Capture.cs:101:25:101:31 | tainted | Capture.cs:145:15:145:20 | access to local variable sink37 | access to local variable sink37 |
-| Capture.cs:171:15:171:20 | access to local variable sink38 | Capture.cs:101:25:101:31 | tainted | Capture.cs:171:15:171:20 | access to local variable sink38 | access to local variable sink38 |
+| Capture.cs:72:15:72:20 | access to local variable sink30 | Capture.cs:69:22:69:35 | "taint source" | Capture.cs:72:15:72:20 | access to local variable sink30 | access to local variable sink30 |
+| Capture.cs:84:15:84:20 | access to local variable sink31 | Capture.cs:79:26:79:39 | "taint source" | Capture.cs:84:15:84:20 | access to local variable sink31 | access to local variable sink31 |
+| Capture.cs:93:15:93:20 | access to local variable sink32 | Capture.cs:89:22:89:35 | "taint source" | Capture.cs:93:15:93:20 | access to local variable sink32 | access to local variable sink32 |
+| Capture.cs:121:15:121:20 | access to local variable sink33 | Capture.cs:113:25:113:31 | tainted | Capture.cs:121:15:121:20 | access to local variable sink33 | access to local variable sink33 |
+| Capture.cs:133:15:133:20 | access to local variable sink34 | Capture.cs:113:25:113:31 | tainted | Capture.cs:133:15:133:20 | access to local variable sink34 | access to local variable sink34 |
+| Capture.cs:142:15:142:20 | access to local variable sink35 | Capture.cs:113:25:113:31 | tainted | Capture.cs:142:15:142:20 | access to local variable sink35 | access to local variable sink35 |
+| Capture.cs:149:15:149:20 | access to local variable sink36 | Capture.cs:113:25:113:31 | tainted | Capture.cs:149:15:149:20 | access to local variable sink36 | access to local variable sink36 |
+| Capture.cs:157:15:157:20 | access to local variable sink37 | Capture.cs:113:25:113:31 | tainted | Capture.cs:157:15:157:20 | access to local variable sink37 | access to local variable sink37 |
+| Capture.cs:183:15:183:20 | access to local variable sink38 | Capture.cs:113:25:113:31 | tainted | Capture.cs:183:15:183:20 | access to local variable sink38 | access to local variable sink38 |
 | GlobalDataFlow.cs:136:15:136:19 | access to local variable sink4 | GlobalDataFlow.cs:17:27:17:40 | "taint source" | GlobalDataFlow.cs:136:15:136:19 | access to local variable sink4 | access to local variable sink4 |
 | GlobalDataFlow.cs:144:15:144:19 | access to local variable sink5 | GlobalDataFlow.cs:17:27:17:40 | "taint source" | GlobalDataFlow.cs:144:15:144:19 | access to local variable sink5 | access to local variable sink5 |
 | GlobalDataFlow.cs:154:15:154:19 | access to local variable sink6 | GlobalDataFlow.cs:318:16:318:29 | "taint source" | GlobalDataFlow.cs:154:15:154:19 | access to local variable sink6 | access to local variable sink6 |

--- a/csharp/ql/test/library-tests/dataflow/global/GetAnOutNode.expected
+++ b/csharp/ql/test/library-tests/dataflow/global/GetAnOutNode.expected
@@ -11,20 +11,20 @@
 | Capture.cs:92:9:92:51 | call to method ToArray | return | Capture.cs:92:9:92:51 | call to method ToArray |
 | Capture.cs:92:30:92:40 | [implicit call] access to local variable captureOut3 | captured sink32 | Capture.cs:92:9:92:41 | SSA call def(sink32) |
 | Capture.cs:92:30:92:40 | [implicit call] access to local variable captureOut3 | return | Capture.cs:92:30:92:40 | [output] access to local variable captureOut3 |
-| Capture.cs:120:9:120:25 | call to local function CaptureThrough1 | captured sink33 | Capture.cs:120:9:120:25 | SSA call def(sink33) |
-| Capture.cs:132:9:132:25 | [transitive] call to local function CaptureThrough2 | captured sink34 | Capture.cs:132:9:132:25 | SSA call def(sink34) |
-| Capture.cs:132:9:132:25 | call to local function CaptureThrough2 | captured sink34 | Capture.cs:132:9:132:25 | SSA call def(sink34) |
-| Capture.cs:141:9:141:45 | call to method Select | captured sink35 | Capture.cs:141:9:141:45 | SSA call def(sink35) |
-| Capture.cs:141:9:141:45 | call to method Select | return | Capture.cs:141:9:141:45 | call to method Select |
-| Capture.cs:141:9:141:45 | call to method Select | yield return | Capture.cs:141:9:141:45 | call to method Select |
-| Capture.cs:141:9:141:55 | call to method ToArray | return | Capture.cs:141:9:141:55 | call to method ToArray |
-| Capture.cs:141:30:141:44 | [implicit call] access to local variable captureThrough3 | captured sink35 | Capture.cs:141:9:141:45 | SSA call def(sink35) |
-| Capture.cs:141:30:141:44 | [implicit call] access to local variable captureThrough3 | return | Capture.cs:141:30:141:44 | [output] access to local variable captureThrough3 |
-| Capture.cs:148:22:148:38 | call to local function CaptureThrough4 | return | Capture.cs:148:22:148:38 | call to local function CaptureThrough4 |
-| Capture.cs:156:9:156:32 | call to local function CaptureThrough5 | captured sink37 | Capture.cs:156:9:156:32 | SSA call def(sink37) |
-| Capture.cs:179:20:179:22 | call to local function M | return | Capture.cs:179:20:179:22 | call to local function M |
-| Capture.cs:182:22:182:32 | call to local function Id | return | Capture.cs:182:22:182:32 | call to local function Id |
-| Capture.cs:184:20:184:25 | call to local function Id | return | Capture.cs:184:20:184:25 | call to local function Id |
+| Capture.cs:132:9:132:25 | call to local function CaptureThrough1 | captured sink33 | Capture.cs:132:9:132:25 | SSA call def(sink33) |
+| Capture.cs:144:9:144:25 | [transitive] call to local function CaptureThrough2 | captured sink34 | Capture.cs:144:9:144:25 | SSA call def(sink34) |
+| Capture.cs:144:9:144:25 | call to local function CaptureThrough2 | captured sink34 | Capture.cs:144:9:144:25 | SSA call def(sink34) |
+| Capture.cs:153:9:153:45 | call to method Select | captured sink35 | Capture.cs:153:9:153:45 | SSA call def(sink35) |
+| Capture.cs:153:9:153:45 | call to method Select | return | Capture.cs:153:9:153:45 | call to method Select |
+| Capture.cs:153:9:153:45 | call to method Select | yield return | Capture.cs:153:9:153:45 | call to method Select |
+| Capture.cs:153:9:153:55 | call to method ToArray | return | Capture.cs:153:9:153:55 | call to method ToArray |
+| Capture.cs:153:30:153:44 | [implicit call] access to local variable captureThrough3 | captured sink35 | Capture.cs:153:9:153:45 | SSA call def(sink35) |
+| Capture.cs:153:30:153:44 | [implicit call] access to local variable captureThrough3 | return | Capture.cs:153:30:153:44 | [output] access to local variable captureThrough3 |
+| Capture.cs:160:22:160:38 | call to local function CaptureThrough4 | return | Capture.cs:160:22:160:38 | call to local function CaptureThrough4 |
+| Capture.cs:168:9:168:32 | call to local function CaptureThrough5 | captured sink37 | Capture.cs:168:9:168:32 | SSA call def(sink37) |
+| Capture.cs:191:20:191:22 | call to local function M | return | Capture.cs:191:20:191:22 | call to local function M |
+| Capture.cs:194:22:194:32 | call to local function Id | return | Capture.cs:194:22:194:32 | call to local function Id |
+| Capture.cs:196:20:196:25 | call to local function Id | return | Capture.cs:196:20:196:25 | call to local function Id |
 | GlobalDataFlow.cs:25:9:25:26 | access to property SinkProperty0 | return | GlobalDataFlow.cs:25:9:25:26 | access to property SinkProperty0 |
 | GlobalDataFlow.cs:26:15:26:32 | access to property SinkProperty0 | return | GlobalDataFlow.cs:26:15:26:32 | access to property SinkProperty0 |
 | GlobalDataFlow.cs:29:9:29:29 | access to property NonSinkProperty0 | return | GlobalDataFlow.cs:29:9:29:29 | access to property NonSinkProperty0 |

--- a/csharp/ql/test/library-tests/dataflow/global/GetAnOutNode.expected
+++ b/csharp/ql/test/library-tests/dataflow/global/GetAnOutNode.expected
@@ -11,6 +11,12 @@
 | Capture.cs:92:9:92:51 | call to method ToArray | return | Capture.cs:92:9:92:51 | call to method ToArray |
 | Capture.cs:92:30:92:40 | [implicit call] access to local variable captureOut3 | captured sink32 | Capture.cs:92:9:92:41 | SSA call def(sink32) |
 | Capture.cs:92:30:92:40 | [implicit call] access to local variable captureOut3 | return | Capture.cs:92:30:92:40 | [output] access to local variable captureOut3 |
+| Capture.cs:121:9:121:35 | [transitive] call to local function CaptureOutMultipleLambdas | captured nonSink0 | Capture.cs:121:9:121:35 | SSA call def(nonSink0) |
+| Capture.cs:121:9:121:35 | [transitive] call to local function CaptureOutMultipleLambdas | captured nonSink0 | Capture.cs:121:9:121:35 | SSA call def(nonSink0) |
+| Capture.cs:121:9:121:35 | [transitive] call to local function CaptureOutMultipleLambdas | captured sink40 | Capture.cs:121:9:121:35 | SSA call def(sink40) |
+| Capture.cs:121:9:121:35 | [transitive] call to local function CaptureOutMultipleLambdas | captured sink40 | Capture.cs:121:9:121:35 | SSA call def(sink40) |
+| Capture.cs:121:9:121:35 | call to local function CaptureOutMultipleLambdas | captured nonSink0 | Capture.cs:121:9:121:35 | SSA call def(nonSink0) |
+| Capture.cs:121:9:121:35 | call to local function CaptureOutMultipleLambdas | captured sink40 | Capture.cs:121:9:121:35 | SSA call def(sink40) |
 | Capture.cs:132:9:132:25 | call to local function CaptureThrough1 | captured sink33 | Capture.cs:132:9:132:25 | SSA call def(sink33) |
 | Capture.cs:144:9:144:25 | [transitive] call to local function CaptureThrough2 | captured sink34 | Capture.cs:144:9:144:25 | SSA call def(sink34) |
 | Capture.cs:144:9:144:25 | call to local function CaptureThrough2 | captured sink34 | Capture.cs:144:9:144:25 | SSA call def(sink34) |

--- a/csharp/ql/test/library-tests/dataflow/global/GetAnOutNode.expected
+++ b/csharp/ql/test/library-tests/dataflow/global/GetAnOutNode.expected
@@ -2,29 +2,29 @@
 | Capture.cs:33:9:33:40 | call to method Select | yield return | Capture.cs:33:9:33:40 | call to method Select |
 | Capture.cs:33:9:33:50 | call to method ToArray | return | Capture.cs:33:9:33:50 | call to method ToArray |
 | Capture.cs:33:30:33:39 | [implicit call] access to local variable captureIn3 | return | Capture.cs:33:30:33:39 | [output] access to local variable captureIn3 |
-| Capture.cs:59:9:59:21 | call to local function CaptureOut1 | captured sink30 | Capture.cs:59:9:59:21 | SSA call def(sink30) |
-| Capture.cs:71:9:71:21 | [transitive] call to local function CaptureOut2 | captured sink31 | Capture.cs:71:9:71:21 | SSA call def(sink31) |
-| Capture.cs:71:9:71:21 | call to local function CaptureOut2 | captured sink31 | Capture.cs:71:9:71:21 | SSA call def(sink31) |
-| Capture.cs:80:9:80:41 | call to method Select | captured sink32 | Capture.cs:80:9:80:41 | SSA call def(sink32) |
-| Capture.cs:80:9:80:41 | call to method Select | return | Capture.cs:80:9:80:41 | call to method Select |
-| Capture.cs:80:9:80:41 | call to method Select | yield return | Capture.cs:80:9:80:41 | call to method Select |
-| Capture.cs:80:9:80:51 | call to method ToArray | return | Capture.cs:80:9:80:51 | call to method ToArray |
-| Capture.cs:80:30:80:40 | [implicit call] access to local variable captureOut3 | captured sink32 | Capture.cs:80:9:80:41 | SSA call def(sink32) |
-| Capture.cs:80:30:80:40 | [implicit call] access to local variable captureOut3 | return | Capture.cs:80:30:80:40 | [output] access to local variable captureOut3 |
-| Capture.cs:108:9:108:25 | call to local function CaptureThrough1 | captured sink33 | Capture.cs:108:9:108:25 | SSA call def(sink33) |
-| Capture.cs:120:9:120:25 | [transitive] call to local function CaptureThrough2 | captured sink34 | Capture.cs:120:9:120:25 | SSA call def(sink34) |
-| Capture.cs:120:9:120:25 | call to local function CaptureThrough2 | captured sink34 | Capture.cs:120:9:120:25 | SSA call def(sink34) |
-| Capture.cs:129:9:129:45 | call to method Select | captured sink35 | Capture.cs:129:9:129:45 | SSA call def(sink35) |
-| Capture.cs:129:9:129:45 | call to method Select | return | Capture.cs:129:9:129:45 | call to method Select |
-| Capture.cs:129:9:129:45 | call to method Select | yield return | Capture.cs:129:9:129:45 | call to method Select |
-| Capture.cs:129:9:129:55 | call to method ToArray | return | Capture.cs:129:9:129:55 | call to method ToArray |
-| Capture.cs:129:30:129:44 | [implicit call] access to local variable captureThrough3 | captured sink35 | Capture.cs:129:9:129:45 | SSA call def(sink35) |
-| Capture.cs:129:30:129:44 | [implicit call] access to local variable captureThrough3 | return | Capture.cs:129:30:129:44 | [output] access to local variable captureThrough3 |
-| Capture.cs:136:22:136:38 | call to local function CaptureThrough4 | return | Capture.cs:136:22:136:38 | call to local function CaptureThrough4 |
-| Capture.cs:144:9:144:32 | call to local function CaptureThrough5 | captured sink37 | Capture.cs:144:9:144:32 | SSA call def(sink37) |
-| Capture.cs:167:20:167:22 | call to local function M | return | Capture.cs:167:20:167:22 | call to local function M |
-| Capture.cs:170:22:170:32 | call to local function Id | return | Capture.cs:170:22:170:32 | call to local function Id |
-| Capture.cs:172:20:172:25 | call to local function Id | return | Capture.cs:172:20:172:25 | call to local function Id |
+| Capture.cs:71:9:71:21 | call to local function CaptureOut1 | captured sink30 | Capture.cs:71:9:71:21 | SSA call def(sink30) |
+| Capture.cs:83:9:83:21 | [transitive] call to local function CaptureOut2 | captured sink31 | Capture.cs:83:9:83:21 | SSA call def(sink31) |
+| Capture.cs:83:9:83:21 | call to local function CaptureOut2 | captured sink31 | Capture.cs:83:9:83:21 | SSA call def(sink31) |
+| Capture.cs:92:9:92:41 | call to method Select | captured sink32 | Capture.cs:92:9:92:41 | SSA call def(sink32) |
+| Capture.cs:92:9:92:41 | call to method Select | return | Capture.cs:92:9:92:41 | call to method Select |
+| Capture.cs:92:9:92:41 | call to method Select | yield return | Capture.cs:92:9:92:41 | call to method Select |
+| Capture.cs:92:9:92:51 | call to method ToArray | return | Capture.cs:92:9:92:51 | call to method ToArray |
+| Capture.cs:92:30:92:40 | [implicit call] access to local variable captureOut3 | captured sink32 | Capture.cs:92:9:92:41 | SSA call def(sink32) |
+| Capture.cs:92:30:92:40 | [implicit call] access to local variable captureOut3 | return | Capture.cs:92:30:92:40 | [output] access to local variable captureOut3 |
+| Capture.cs:120:9:120:25 | call to local function CaptureThrough1 | captured sink33 | Capture.cs:120:9:120:25 | SSA call def(sink33) |
+| Capture.cs:132:9:132:25 | [transitive] call to local function CaptureThrough2 | captured sink34 | Capture.cs:132:9:132:25 | SSA call def(sink34) |
+| Capture.cs:132:9:132:25 | call to local function CaptureThrough2 | captured sink34 | Capture.cs:132:9:132:25 | SSA call def(sink34) |
+| Capture.cs:141:9:141:45 | call to method Select | captured sink35 | Capture.cs:141:9:141:45 | SSA call def(sink35) |
+| Capture.cs:141:9:141:45 | call to method Select | return | Capture.cs:141:9:141:45 | call to method Select |
+| Capture.cs:141:9:141:45 | call to method Select | yield return | Capture.cs:141:9:141:45 | call to method Select |
+| Capture.cs:141:9:141:55 | call to method ToArray | return | Capture.cs:141:9:141:55 | call to method ToArray |
+| Capture.cs:141:30:141:44 | [implicit call] access to local variable captureThrough3 | captured sink35 | Capture.cs:141:9:141:45 | SSA call def(sink35) |
+| Capture.cs:141:30:141:44 | [implicit call] access to local variable captureThrough3 | return | Capture.cs:141:30:141:44 | [output] access to local variable captureThrough3 |
+| Capture.cs:148:22:148:38 | call to local function CaptureThrough4 | return | Capture.cs:148:22:148:38 | call to local function CaptureThrough4 |
+| Capture.cs:156:9:156:32 | call to local function CaptureThrough5 | captured sink37 | Capture.cs:156:9:156:32 | SSA call def(sink37) |
+| Capture.cs:179:20:179:22 | call to local function M | return | Capture.cs:179:20:179:22 | call to local function M |
+| Capture.cs:182:22:182:32 | call to local function Id | return | Capture.cs:182:22:182:32 | call to local function Id |
+| Capture.cs:184:20:184:25 | call to local function Id | return | Capture.cs:184:20:184:25 | call to local function Id |
 | GlobalDataFlow.cs:25:9:25:26 | access to property SinkProperty0 | return | GlobalDataFlow.cs:25:9:25:26 | access to property SinkProperty0 |
 | GlobalDataFlow.cs:26:15:26:32 | access to property SinkProperty0 | return | GlobalDataFlow.cs:26:15:26:32 | access to property SinkProperty0 |
 | GlobalDataFlow.cs:29:9:29:29 | access to property NonSinkProperty0 | return | GlobalDataFlow.cs:29:9:29:29 | access to property NonSinkProperty0 |

--- a/csharp/ql/test/library-tests/dataflow/global/TaintTracking.expected
+++ b/csharp/ql/test/library-tests/dataflow/global/TaintTracking.expected
@@ -5,12 +5,12 @@
 | Capture.cs:72:15:72:20 | access to local variable sink30 |
 | Capture.cs:84:15:84:20 | access to local variable sink31 |
 | Capture.cs:93:15:93:20 | access to local variable sink32 |
-| Capture.cs:121:15:121:20 | access to local variable sink33 |
-| Capture.cs:133:15:133:20 | access to local variable sink34 |
-| Capture.cs:142:15:142:20 | access to local variable sink35 |
-| Capture.cs:149:15:149:20 | access to local variable sink36 |
-| Capture.cs:157:15:157:20 | access to local variable sink37 |
-| Capture.cs:183:15:183:20 | access to local variable sink38 |
+| Capture.cs:133:15:133:20 | access to local variable sink33 |
+| Capture.cs:145:15:145:20 | access to local variable sink34 |
+| Capture.cs:154:15:154:20 | access to local variable sink35 |
+| Capture.cs:161:15:161:20 | access to local variable sink36 |
+| Capture.cs:169:15:169:20 | access to local variable sink37 |
+| Capture.cs:195:15:195:20 | access to local variable sink38 |
 | GlobalDataFlow.cs:18:15:18:29 | access to field SinkField0 |
 | GlobalDataFlow.cs:26:15:26:32 | access to property SinkProperty0 |
 | GlobalDataFlow.cs:44:50:44:59 | access to parameter sinkParam2 |

--- a/csharp/ql/test/library-tests/dataflow/global/TaintTracking.expected
+++ b/csharp/ql/test/library-tests/dataflow/global/TaintTracking.expected
@@ -5,6 +5,7 @@
 | Capture.cs:72:15:72:20 | access to local variable sink30 |
 | Capture.cs:84:15:84:20 | access to local variable sink31 |
 | Capture.cs:93:15:93:20 | access to local variable sink32 |
+| Capture.cs:122:15:122:20 | access to local variable sink40 |
 | Capture.cs:133:15:133:20 | access to local variable sink33 |
 | Capture.cs:145:15:145:20 | access to local variable sink34 |
 | Capture.cs:154:15:154:20 | access to local variable sink35 |

--- a/csharp/ql/test/library-tests/dataflow/global/TaintTracking.expected
+++ b/csharp/ql/test/library-tests/dataflow/global/TaintTracking.expected
@@ -1,6 +1,7 @@
 | Capture.cs:12:19:12:24 | access to local variable sink27 |
 | Capture.cs:21:23:21:28 | access to local variable sink28 |
 | Capture.cs:30:19:30:24 | access to local variable sink29 |
+| Capture.cs:57:27:57:32 | access to parameter sink39 |
 | Capture.cs:72:15:72:20 | access to local variable sink30 |
 | Capture.cs:84:15:84:20 | access to local variable sink31 |
 | Capture.cs:93:15:93:20 | access to local variable sink32 |

--- a/csharp/ql/test/library-tests/dataflow/global/TaintTracking.expected
+++ b/csharp/ql/test/library-tests/dataflow/global/TaintTracking.expected
@@ -1,15 +1,15 @@
 | Capture.cs:12:19:12:24 | access to local variable sink27 |
 | Capture.cs:21:23:21:28 | access to local variable sink28 |
 | Capture.cs:30:19:30:24 | access to local variable sink29 |
-| Capture.cs:60:15:60:20 | access to local variable sink30 |
-| Capture.cs:72:15:72:20 | access to local variable sink31 |
-| Capture.cs:81:15:81:20 | access to local variable sink32 |
-| Capture.cs:109:15:109:20 | access to local variable sink33 |
-| Capture.cs:121:15:121:20 | access to local variable sink34 |
-| Capture.cs:130:15:130:20 | access to local variable sink35 |
-| Capture.cs:137:15:137:20 | access to local variable sink36 |
-| Capture.cs:145:15:145:20 | access to local variable sink37 |
-| Capture.cs:171:15:171:20 | access to local variable sink38 |
+| Capture.cs:72:15:72:20 | access to local variable sink30 |
+| Capture.cs:84:15:84:20 | access to local variable sink31 |
+| Capture.cs:93:15:93:20 | access to local variable sink32 |
+| Capture.cs:121:15:121:20 | access to local variable sink33 |
+| Capture.cs:133:15:133:20 | access to local variable sink34 |
+| Capture.cs:142:15:142:20 | access to local variable sink35 |
+| Capture.cs:149:15:149:20 | access to local variable sink36 |
+| Capture.cs:157:15:157:20 | access to local variable sink37 |
+| Capture.cs:183:15:183:20 | access to local variable sink38 |
 | GlobalDataFlow.cs:18:15:18:29 | access to field SinkField0 |
 | GlobalDataFlow.cs:26:15:26:32 | access to property SinkProperty0 |
 | GlobalDataFlow.cs:44:50:44:59 | access to parameter sinkParam2 |

--- a/csharp/ql/test/library-tests/dataflow/global/TaintTrackingEdges.expected
+++ b/csharp/ql/test/library-tests/dataflow/global/TaintTrackingEdges.expected
@@ -203,480 +203,480 @@
 | Capture.cs:46:23:46:30 | access to local variable nonSink0 | Capture.cs:46:23:46:30 | access to local variable nonSink0 |
 | Capture.cs:49:9:49:27 | access to local function CaptureIn2NotCalled | Capture.cs:49:9:49:27 | access to local function CaptureIn2NotCalled |
 | Capture.cs:49:9:49:29 | call to local function CaptureIn2NotCalled | Capture.cs:49:9:49:29 | call to local function CaptureIn2NotCalled |
-| Capture.cs:52:10:52:12 | this | Capture.cs:52:10:52:12 | this |
-| Capture.cs:54:16:54:26 | SSA def(sink30) | Capture.cs:54:16:54:26 | SSA def(sink30) |
-| Capture.cs:54:16:54:26 | String sink30 = ... | Capture.cs:54:16:54:26 | String sink30 = ... |
-| Capture.cs:54:25:54:26 | "" | Capture.cs:54:16:54:26 | SSA def(sink30) |
-| Capture.cs:54:25:54:26 | "" | Capture.cs:54:16:54:26 | SSA def(sink30) |
-| Capture.cs:54:25:54:26 | "" | Capture.cs:54:25:54:26 | "" |
-| Capture.cs:57:13:57:35 | ... = ... | Capture.cs:57:13:57:35 | ... = ... |
-| Capture.cs:57:13:57:35 | SSA def(sink30) | Capture.cs:57:13:57:35 | SSA def(sink30) |
-| Capture.cs:57:13:57:35 | SSA def(sink30) | Capture.cs:59:9:59:21 | SSA call def(sink30) |
-| Capture.cs:57:13:57:35 | SSA def(sink30) | Capture.cs:59:9:59:21 | SSA call def(sink30) |
-| Capture.cs:57:22:57:35 | "taint source" | Capture.cs:57:13:57:35 | SSA def(sink30) |
-| Capture.cs:57:22:57:35 | "taint source" | Capture.cs:57:13:57:35 | SSA def(sink30) |
-| Capture.cs:57:22:57:35 | "taint source" | Capture.cs:57:22:57:35 | "taint source" |
-| Capture.cs:59:9:59:19 | access to local function CaptureOut1 | Capture.cs:59:9:59:19 | access to local function CaptureOut1 |
-| Capture.cs:59:9:59:21 | SSA call def(sink30) | Capture.cs:59:9:59:21 | SSA call def(sink30) |
-| Capture.cs:59:9:59:21 | SSA call def(sink30) | Capture.cs:60:15:60:20 | access to local variable sink30 |
-| Capture.cs:59:9:59:21 | SSA call def(sink30) | Capture.cs:60:15:60:20 | access to local variable sink30 |
-| Capture.cs:59:9:59:21 | call to local function CaptureOut1 | Capture.cs:59:9:59:21 | call to local function CaptureOut1 |
-| Capture.cs:60:9:60:21 | call to method Check | Capture.cs:60:9:60:21 | call to method Check |
-| Capture.cs:60:15:60:20 | access to local variable sink30 | Capture.cs:60:15:60:20 | access to local variable sink30 |
-| Capture.cs:62:16:62:26 | SSA def(sink31) | Capture.cs:62:16:62:26 | SSA def(sink31) |
-| Capture.cs:62:16:62:26 | String sink31 = ... | Capture.cs:62:16:62:26 | String sink31 = ... |
-| Capture.cs:62:25:62:26 | "" | Capture.cs:62:16:62:26 | SSA def(sink31) |
-| Capture.cs:62:25:62:26 | "" | Capture.cs:62:16:62:26 | SSA def(sink31) |
-| Capture.cs:62:25:62:26 | "" | Capture.cs:62:25:62:26 | "" |
-| Capture.cs:67:17:67:39 | ... = ... | Capture.cs:67:17:67:39 | ... = ... |
-| Capture.cs:67:17:67:39 | SSA def(sink31) | Capture.cs:67:17:67:39 | SSA def(sink31) |
-| Capture.cs:67:17:67:39 | SSA def(sink31) | Capture.cs:71:9:71:21 | SSA call def(sink31) |
-| Capture.cs:67:17:67:39 | SSA def(sink31) | Capture.cs:71:9:71:21 | SSA call def(sink31) |
-| Capture.cs:67:26:67:39 | "taint source" | Capture.cs:67:17:67:39 | SSA def(sink31) |
-| Capture.cs:67:26:67:39 | "taint source" | Capture.cs:67:17:67:39 | SSA def(sink31) |
-| Capture.cs:67:26:67:39 | "taint source" | Capture.cs:67:26:67:39 | "taint source" |
-| Capture.cs:69:13:69:13 | access to local function M | Capture.cs:69:13:69:13 | access to local function M |
-| Capture.cs:69:13:69:15 | call to local function M | Capture.cs:69:13:69:15 | call to local function M |
-| Capture.cs:71:9:71:19 | access to local function CaptureOut2 | Capture.cs:71:9:71:19 | access to local function CaptureOut2 |
-| Capture.cs:71:9:71:21 | SSA call def(sink31) | Capture.cs:71:9:71:21 | SSA call def(sink31) |
-| Capture.cs:71:9:71:21 | SSA call def(sink31) | Capture.cs:72:15:72:20 | access to local variable sink31 |
-| Capture.cs:71:9:71:21 | SSA call def(sink31) | Capture.cs:72:15:72:20 | access to local variable sink31 |
-| Capture.cs:71:9:71:21 | call to local function CaptureOut2 | Capture.cs:71:9:71:21 | call to local function CaptureOut2 |
+| Capture.cs:64:10:64:12 | this | Capture.cs:64:10:64:12 | this |
+| Capture.cs:66:16:66:26 | SSA def(sink30) | Capture.cs:66:16:66:26 | SSA def(sink30) |
+| Capture.cs:66:16:66:26 | String sink30 = ... | Capture.cs:66:16:66:26 | String sink30 = ... |
+| Capture.cs:66:25:66:26 | "" | Capture.cs:66:16:66:26 | SSA def(sink30) |
+| Capture.cs:66:25:66:26 | "" | Capture.cs:66:16:66:26 | SSA def(sink30) |
+| Capture.cs:66:25:66:26 | "" | Capture.cs:66:25:66:26 | "" |
+| Capture.cs:69:13:69:35 | ... = ... | Capture.cs:69:13:69:35 | ... = ... |
+| Capture.cs:69:13:69:35 | SSA def(sink30) | Capture.cs:69:13:69:35 | SSA def(sink30) |
+| Capture.cs:69:13:69:35 | SSA def(sink30) | Capture.cs:71:9:71:21 | SSA call def(sink30) |
+| Capture.cs:69:13:69:35 | SSA def(sink30) | Capture.cs:71:9:71:21 | SSA call def(sink30) |
+| Capture.cs:69:22:69:35 | "taint source" | Capture.cs:69:13:69:35 | SSA def(sink30) |
+| Capture.cs:69:22:69:35 | "taint source" | Capture.cs:69:13:69:35 | SSA def(sink30) |
+| Capture.cs:69:22:69:35 | "taint source" | Capture.cs:69:22:69:35 | "taint source" |
+| Capture.cs:71:9:71:19 | access to local function CaptureOut1 | Capture.cs:71:9:71:19 | access to local function CaptureOut1 |
+| Capture.cs:71:9:71:21 | SSA call def(sink30) | Capture.cs:71:9:71:21 | SSA call def(sink30) |
+| Capture.cs:71:9:71:21 | SSA call def(sink30) | Capture.cs:72:15:72:20 | access to local variable sink30 |
+| Capture.cs:71:9:71:21 | SSA call def(sink30) | Capture.cs:72:15:72:20 | access to local variable sink30 |
+| Capture.cs:71:9:71:21 | call to local function CaptureOut1 | Capture.cs:71:9:71:21 | call to local function CaptureOut1 |
 | Capture.cs:72:9:72:21 | call to method Check | Capture.cs:72:9:72:21 | call to method Check |
-| Capture.cs:72:15:72:20 | access to local variable sink31 | Capture.cs:72:15:72:20 | access to local variable sink31 |
-| Capture.cs:74:16:74:26 | SSA def(sink32) | Capture.cs:74:16:74:26 | SSA def(sink32) |
-| Capture.cs:74:16:74:26 | String sink32 = ... | Capture.cs:74:16:74:26 | String sink32 = ... |
-| Capture.cs:74:25:74:26 | "" | Capture.cs:74:16:74:26 | SSA def(sink32) |
-| Capture.cs:74:25:74:26 | "" | Capture.cs:74:16:74:26 | SSA def(sink32) |
+| Capture.cs:72:15:72:20 | access to local variable sink30 | Capture.cs:72:15:72:20 | access to local variable sink30 |
+| Capture.cs:74:16:74:26 | SSA def(sink31) | Capture.cs:74:16:74:26 | SSA def(sink31) |
+| Capture.cs:74:16:74:26 | String sink31 = ... | Capture.cs:74:16:74:26 | String sink31 = ... |
+| Capture.cs:74:25:74:26 | "" | Capture.cs:74:16:74:26 | SSA def(sink31) |
+| Capture.cs:74:25:74:26 | "" | Capture.cs:74:16:74:26 | SSA def(sink31) |
 | Capture.cs:74:25:74:26 | "" | Capture.cs:74:25:74:26 | "" |
-| Capture.cs:75:30:79:9 | Func<String,String> captureOut3 = ... | Capture.cs:75:30:79:9 | Func<String,String> captureOut3 = ... |
-| Capture.cs:75:30:79:9 | SSA def(captureOut3) | Capture.cs:75:30:79:9 | SSA def(captureOut3) |
-| Capture.cs:75:30:79:9 | SSA def(captureOut3) | Capture.cs:80:30:80:40 | access to local variable captureOut3 |
-| Capture.cs:75:30:79:9 | SSA def(captureOut3) | Capture.cs:80:30:80:40 | access to local variable captureOut3 |
-| Capture.cs:75:44:75:46 | arg | Capture.cs:75:44:75:46 | arg |
-| Capture.cs:75:44:75:46 | arg | Capture.cs:75:44:75:46 | arg |
-| Capture.cs:75:44:75:46 | arg | Capture.cs:75:44:75:46 | arg |
-| Capture.cs:75:44:75:46 | arg | Capture.cs:75:44:75:46 | arg |
-| Capture.cs:75:44:75:46 | arg | Capture.cs:75:44:75:46 | arg |
-| Capture.cs:75:44:75:46 | arg | Capture.cs:75:44:75:46 | arg |
-| Capture.cs:75:44:75:46 | arg | Capture.cs:78:20:78:22 | access to parameter arg |
-| Capture.cs:75:44:75:46 | arg | Capture.cs:78:20:78:22 | access to parameter arg |
-| Capture.cs:75:44:75:46 | arg | Capture.cs:78:20:78:22 | access to parameter arg |
-| Capture.cs:75:44:75:46 | arg | Capture.cs:78:20:78:22 | access to parameter arg |
-| Capture.cs:75:44:75:46 | arg | Capture.cs:78:20:78:22 | access to parameter arg |
-| Capture.cs:75:44:75:46 | arg | Capture.cs:78:20:78:22 | access to parameter arg |
-| Capture.cs:75:44:75:46 | arg | Capture.cs:78:20:78:22 | access to parameter arg |
-| Capture.cs:75:44:75:46 | arg | Capture.cs:78:20:78:22 | access to parameter arg |
-| Capture.cs:75:44:79:9 | (...) => ... | Capture.cs:75:30:79:9 | SSA def(captureOut3) |
-| Capture.cs:75:44:79:9 | (...) => ... | Capture.cs:75:30:79:9 | SSA def(captureOut3) |
-| Capture.cs:75:44:79:9 | (...) => ... | Capture.cs:75:44:79:9 | (...) => ... |
-| Capture.cs:75:44:79:9 | (...) => ... | Capture.cs:80:30:80:40 | access to local variable captureOut3 |
-| Capture.cs:75:44:79:9 | (...) => ... | Capture.cs:80:30:80:40 | access to local variable captureOut3 |
-| Capture.cs:77:13:77:35 | ... = ... | Capture.cs:77:13:77:35 | ... = ... |
-| Capture.cs:77:13:77:35 | SSA def(sink32) | Capture.cs:77:13:77:35 | SSA def(sink32) |
-| Capture.cs:77:13:77:35 | SSA def(sink32) | Capture.cs:80:9:80:41 | SSA call def(sink32) |
-| Capture.cs:77:13:77:35 | SSA def(sink32) | Capture.cs:80:9:80:41 | SSA call def(sink32) |
-| Capture.cs:77:22:77:35 | "taint source" | Capture.cs:77:13:77:35 | SSA def(sink32) |
-| Capture.cs:77:22:77:35 | "taint source" | Capture.cs:77:13:77:35 | SSA def(sink32) |
-| Capture.cs:77:22:77:35 | "taint source" | Capture.cs:77:22:77:35 | "taint source" |
-| Capture.cs:78:20:78:22 | access to parameter arg | Capture.cs:78:20:78:22 | access to parameter arg |
-| Capture.cs:78:20:78:22 | access to parameter arg | Capture.cs:80:30:80:40 | [output] access to local variable captureOut3 |
-| Capture.cs:78:20:78:22 | access to parameter arg | Capture.cs:80:30:80:40 | [output] access to local variable captureOut3 |
-| Capture.cs:80:9:80:21 | array creation of type String[] | Capture.cs:75:44:75:46 | arg |
-| Capture.cs:80:9:80:21 | array creation of type String[] | Capture.cs:75:44:75:46 | arg |
-| Capture.cs:80:9:80:21 | array creation of type String[] | Capture.cs:80:9:80:21 | array creation of type String[] |
-| Capture.cs:80:9:80:21 | array creation of type String[] | Capture.cs:80:30:80:40 | [output] access to local variable captureOut3 |
-| Capture.cs:80:9:80:21 | array creation of type String[] | Capture.cs:80:30:80:40 | [output] access to local variable captureOut3 |
-| Capture.cs:80:9:80:41 | SSA call def(sink32) | Capture.cs:80:9:80:41 | SSA call def(sink32) |
-| Capture.cs:80:9:80:41 | SSA call def(sink32) | Capture.cs:81:15:81:20 | access to local variable sink32 |
-| Capture.cs:80:9:80:41 | SSA call def(sink32) | Capture.cs:81:15:81:20 | access to local variable sink32 |
-| Capture.cs:80:9:80:41 | call to method Select | Capture.cs:80:9:80:41 | call to method Select |
-| Capture.cs:80:9:80:41 | call to method Select | Capture.cs:80:9:80:51 | call to method ToArray |
-| Capture.cs:80:9:80:41 | call to method Select | Capture.cs:80:9:80:51 | call to method ToArray |
-| Capture.cs:80:9:80:51 | call to method ToArray | Capture.cs:80:9:80:51 | call to method ToArray |
-| Capture.cs:80:15:80:21 | { ..., ... } | Capture.cs:80:15:80:21 | { ..., ... } |
-| Capture.cs:80:17:80:19 | " " | Capture.cs:80:9:80:21 | array creation of type String[] |
-| Capture.cs:80:17:80:19 | " " | Capture.cs:80:9:80:21 | array creation of type String[] |
-| Capture.cs:80:17:80:19 | " " | Capture.cs:80:17:80:19 | " " |
-| Capture.cs:80:30:80:40 | [output] access to local variable captureOut3 | Capture.cs:80:9:80:41 | call to method Select |
-| Capture.cs:80:30:80:40 | [output] access to local variable captureOut3 | Capture.cs:80:9:80:41 | call to method Select |
-| Capture.cs:80:30:80:40 | [output] access to local variable captureOut3 | Capture.cs:80:9:80:51 | call to method ToArray |
-| Capture.cs:80:30:80:40 | [output] access to local variable captureOut3 | Capture.cs:80:9:80:51 | call to method ToArray |
-| Capture.cs:80:30:80:40 | [output] access to local variable captureOut3 | Capture.cs:80:30:80:40 | [output] access to local variable captureOut3 |
-| Capture.cs:80:30:80:40 | access to local variable captureOut3 | Capture.cs:80:30:80:40 | access to local variable captureOut3 |
-| Capture.cs:81:9:81:21 | call to method Check | Capture.cs:81:9:81:21 | call to method Check |
-| Capture.cs:81:15:81:20 | access to local variable sink32 | Capture.cs:81:15:81:20 | access to local variable sink32 |
-| Capture.cs:83:16:83:28 | SSA def(nonSink0) | Capture.cs:83:16:83:28 | SSA def(nonSink0) |
-| Capture.cs:83:16:83:28 | SSA def(nonSink0) | Capture.cs:88:15:88:22 | access to local variable nonSink0 |
-| Capture.cs:83:16:83:28 | SSA def(nonSink0) | Capture.cs:88:15:88:22 | access to local variable nonSink0 |
-| Capture.cs:83:16:83:28 | SSA def(nonSink0) | Capture.cs:98:15:98:22 | access to local variable nonSink0 |
-| Capture.cs:83:16:83:28 | SSA def(nonSink0) | Capture.cs:98:15:98:22 | access to local variable nonSink0 |
-| Capture.cs:83:16:83:28 | String nonSink0 = ... | Capture.cs:83:16:83:28 | String nonSink0 = ... |
-| Capture.cs:83:27:83:28 | "" | Capture.cs:83:16:83:28 | SSA def(nonSink0) |
-| Capture.cs:83:27:83:28 | "" | Capture.cs:83:16:83:28 | SSA def(nonSink0) |
-| Capture.cs:83:27:83:28 | "" | Capture.cs:83:27:83:28 | "" |
-| Capture.cs:83:27:83:28 | "" | Capture.cs:88:15:88:22 | access to local variable nonSink0 |
-| Capture.cs:83:27:83:28 | "" | Capture.cs:88:15:88:22 | access to local variable nonSink0 |
-| Capture.cs:83:27:83:28 | "" | Capture.cs:98:15:98:22 | access to local variable nonSink0 |
-| Capture.cs:83:27:83:28 | "" | Capture.cs:98:15:98:22 | access to local variable nonSink0 |
-| Capture.cs:86:13:86:37 | ... = ... | Capture.cs:86:13:86:37 | ... = ... |
-| Capture.cs:86:24:86:37 | "taint source" | Capture.cs:86:24:86:37 | "taint source" |
-| Capture.cs:88:9:88:23 | call to method Check | Capture.cs:88:9:88:23 | call to method Check |
-| Capture.cs:88:15:88:22 | access to local variable nonSink0 | Capture.cs:88:15:88:22 | access to local variable nonSink0 |
-| Capture.cs:88:15:88:22 | access to local variable nonSink0 | Capture.cs:98:15:98:22 | access to local variable nonSink0 |
-| Capture.cs:88:15:88:22 | access to local variable nonSink0 | Capture.cs:98:15:98:22 | access to local variable nonSink0 |
-| Capture.cs:94:17:94:41 | ... = ... | Capture.cs:94:17:94:41 | ... = ... |
-| Capture.cs:94:28:94:41 | "taint source" | Capture.cs:94:28:94:41 | "taint source" |
-| Capture.cs:97:9:97:28 | access to local function CaptureOut2NotCalled | Capture.cs:97:9:97:28 | access to local function CaptureOut2NotCalled |
-| Capture.cs:97:9:97:30 | call to local function CaptureOut2NotCalled | Capture.cs:97:9:97:30 | call to local function CaptureOut2NotCalled |
-| Capture.cs:98:9:98:23 | call to method Check | Capture.cs:98:9:98:23 | call to method Check |
-| Capture.cs:98:15:98:22 | access to local variable nonSink0 | Capture.cs:98:15:98:22 | access to local variable nonSink0 |
-| Capture.cs:101:10:101:16 | this | Capture.cs:101:10:101:16 | this |
-| Capture.cs:101:25:101:31 | tainted | Capture.cs:101:25:101:31 | tainted |
-| Capture.cs:101:25:101:31 | tainted | Capture.cs:101:25:101:31 | tainted |
-| Capture.cs:101:25:101:31 | tainted | Capture.cs:101:25:101:31 | tainted |
-| Capture.cs:101:25:101:31 | tainted | Capture.cs:101:25:101:31 | tainted |
-| Capture.cs:101:25:101:31 | tainted | Capture.cs:108:9:108:25 | [implicit argument] tainted |
-| Capture.cs:101:25:101:31 | tainted | Capture.cs:108:9:108:25 | [implicit argument] tainted |
-| Capture.cs:101:25:101:31 | tainted | Capture.cs:108:9:108:25 | [implicit argument] tainted |
-| Capture.cs:101:25:101:31 | tainted | Capture.cs:108:9:108:25 | [implicit argument] tainted |
-| Capture.cs:101:25:101:31 | tainted | Capture.cs:120:9:120:25 | [implicit argument] tainted |
-| Capture.cs:101:25:101:31 | tainted | Capture.cs:120:9:120:25 | [implicit argument] tainted |
-| Capture.cs:101:25:101:31 | tainted | Capture.cs:120:9:120:25 | [implicit argument] tainted |
-| Capture.cs:101:25:101:31 | tainted | Capture.cs:120:9:120:25 | [implicit argument] tainted |
-| Capture.cs:101:25:101:31 | tainted | Capture.cs:129:9:129:45 | [implicit argument] tainted |
-| Capture.cs:101:25:101:31 | tainted | Capture.cs:129:9:129:45 | [implicit argument] tainted |
-| Capture.cs:101:25:101:31 | tainted | Capture.cs:129:9:129:45 | [implicit argument] tainted |
-| Capture.cs:101:25:101:31 | tainted | Capture.cs:129:9:129:45 | [implicit argument] tainted |
-| Capture.cs:101:25:101:31 | tainted | Capture.cs:136:22:136:38 | [implicit argument] tainted |
-| Capture.cs:101:25:101:31 | tainted | Capture.cs:136:22:136:38 | [implicit argument] tainted |
-| Capture.cs:101:25:101:31 | tainted | Capture.cs:136:22:136:38 | [implicit argument] tainted |
-| Capture.cs:101:25:101:31 | tainted | Capture.cs:136:22:136:38 | [implicit argument] tainted |
-| Capture.cs:101:25:101:31 | tainted | Capture.cs:144:25:144:31 | access to parameter tainted |
-| Capture.cs:101:25:101:31 | tainted | Capture.cs:144:25:144:31 | access to parameter tainted |
-| Capture.cs:101:25:101:31 | tainted | Capture.cs:144:25:144:31 | access to parameter tainted |
-| Capture.cs:101:25:101:31 | tainted | Capture.cs:144:25:144:31 | access to parameter tainted |
-| Capture.cs:101:25:101:31 | tainted | Capture.cs:170:25:170:31 | access to parameter tainted |
-| Capture.cs:101:25:101:31 | tainted | Capture.cs:170:25:170:31 | access to parameter tainted |
-| Capture.cs:101:25:101:31 | tainted | Capture.cs:170:25:170:31 | access to parameter tainted |
-| Capture.cs:101:25:101:31 | tainted | Capture.cs:170:25:170:31 | access to parameter tainted |
-| Capture.cs:103:16:103:26 | SSA def(sink33) | Capture.cs:103:16:103:26 | SSA def(sink33) |
-| Capture.cs:103:16:103:26 | String sink33 = ... | Capture.cs:103:16:103:26 | String sink33 = ... |
-| Capture.cs:103:25:103:26 | "" | Capture.cs:103:16:103:26 | SSA def(sink33) |
-| Capture.cs:103:25:103:26 | "" | Capture.cs:103:16:103:26 | SSA def(sink33) |
-| Capture.cs:103:25:103:26 | "" | Capture.cs:103:25:103:26 | "" |
-| Capture.cs:104:9:107:9 | SSA capture def(tainted) | Capture.cs:104:9:107:9 | SSA capture def(tainted) |
-| Capture.cs:104:9:107:9 | SSA capture def(tainted) | Capture.cs:106:13:106:28 | SSA def(sink33) |
-| Capture.cs:104:9:107:9 | SSA capture def(tainted) | Capture.cs:106:13:106:28 | SSA def(sink33) |
-| Capture.cs:104:9:107:9 | SSA capture def(tainted) | Capture.cs:106:13:106:28 | SSA def(sink33) |
-| Capture.cs:104:9:107:9 | SSA capture def(tainted) | Capture.cs:106:13:106:28 | SSA def(sink33) |
-| Capture.cs:104:9:107:9 | SSA capture def(tainted) | Capture.cs:106:22:106:28 | access to parameter tainted |
-| Capture.cs:104:9:107:9 | SSA capture def(tainted) | Capture.cs:106:22:106:28 | access to parameter tainted |
-| Capture.cs:104:9:107:9 | SSA capture def(tainted) | Capture.cs:106:22:106:28 | access to parameter tainted |
-| Capture.cs:104:9:107:9 | SSA capture def(tainted) | Capture.cs:106:22:106:28 | access to parameter tainted |
-| Capture.cs:106:13:106:28 | ... = ... | Capture.cs:106:13:106:28 | ... = ... |
-| Capture.cs:106:13:106:28 | SSA def(sink33) | Capture.cs:106:13:106:28 | SSA def(sink33) |
-| Capture.cs:106:13:106:28 | SSA def(sink33) | Capture.cs:108:9:108:25 | SSA call def(sink33) |
-| Capture.cs:106:13:106:28 | SSA def(sink33) | Capture.cs:108:9:108:25 | SSA call def(sink33) |
-| Capture.cs:106:22:106:28 | access to parameter tainted | Capture.cs:106:13:106:28 | SSA def(sink33) |
-| Capture.cs:106:22:106:28 | access to parameter tainted | Capture.cs:106:13:106:28 | SSA def(sink33) |
-| Capture.cs:106:22:106:28 | access to parameter tainted | Capture.cs:106:13:106:28 | SSA def(sink33) |
-| Capture.cs:106:22:106:28 | access to parameter tainted | Capture.cs:106:13:106:28 | SSA def(sink33) |
-| Capture.cs:106:22:106:28 | access to parameter tainted | Capture.cs:106:22:106:28 | access to parameter tainted |
-| Capture.cs:108:9:108:23 | access to local function CaptureThrough1 | Capture.cs:108:9:108:23 | access to local function CaptureThrough1 |
-| Capture.cs:108:9:108:25 | SSA call def(sink33) | Capture.cs:108:9:108:25 | SSA call def(sink33) |
-| Capture.cs:108:9:108:25 | SSA call def(sink33) | Capture.cs:109:15:109:20 | access to local variable sink33 |
-| Capture.cs:108:9:108:25 | SSA call def(sink33) | Capture.cs:109:15:109:20 | access to local variable sink33 |
-| Capture.cs:108:9:108:25 | [implicit argument] tainted | Capture.cs:104:9:107:9 | SSA capture def(tainted) |
-| Capture.cs:108:9:108:25 | [implicit argument] tainted | Capture.cs:104:9:107:9 | SSA capture def(tainted) |
-| Capture.cs:108:9:108:25 | [implicit argument] tainted | Capture.cs:108:9:108:25 | SSA call def(sink33) |
-| Capture.cs:108:9:108:25 | [implicit argument] tainted | Capture.cs:108:9:108:25 | SSA call def(sink33) |
-| Capture.cs:108:9:108:25 | [implicit argument] tainted | Capture.cs:108:9:108:25 | [implicit argument] tainted |
-| Capture.cs:108:9:108:25 | call to local function CaptureThrough1 | Capture.cs:108:9:108:25 | call to local function CaptureThrough1 |
-| Capture.cs:109:9:109:21 | call to method Check | Capture.cs:109:9:109:21 | call to method Check |
-| Capture.cs:109:15:109:20 | access to local variable sink33 | Capture.cs:109:15:109:20 | access to local variable sink33 |
-| Capture.cs:111:16:111:26 | SSA def(sink34) | Capture.cs:111:16:111:26 | SSA def(sink34) |
-| Capture.cs:111:16:111:26 | String sink34 = ... | Capture.cs:111:16:111:26 | String sink34 = ... |
-| Capture.cs:111:25:111:26 | "" | Capture.cs:111:16:111:26 | SSA def(sink34) |
-| Capture.cs:111:25:111:26 | "" | Capture.cs:111:16:111:26 | SSA def(sink34) |
-| Capture.cs:111:25:111:26 | "" | Capture.cs:111:25:111:26 | "" |
-| Capture.cs:114:13:117:13 | SSA capture def(tainted) | Capture.cs:114:13:117:13 | SSA capture def(tainted) |
-| Capture.cs:114:13:117:13 | SSA capture def(tainted) | Capture.cs:116:17:116:32 | SSA def(sink34) |
-| Capture.cs:114:13:117:13 | SSA capture def(tainted) | Capture.cs:116:17:116:32 | SSA def(sink34) |
-| Capture.cs:114:13:117:13 | SSA capture def(tainted) | Capture.cs:116:17:116:32 | SSA def(sink34) |
-| Capture.cs:114:13:117:13 | SSA capture def(tainted) | Capture.cs:116:17:116:32 | SSA def(sink34) |
-| Capture.cs:114:13:117:13 | SSA capture def(tainted) | Capture.cs:116:26:116:32 | access to parameter tainted |
-| Capture.cs:114:13:117:13 | SSA capture def(tainted) | Capture.cs:116:26:116:32 | access to parameter tainted |
-| Capture.cs:114:13:117:13 | SSA capture def(tainted) | Capture.cs:116:26:116:32 | access to parameter tainted |
-| Capture.cs:114:13:117:13 | SSA capture def(tainted) | Capture.cs:116:26:116:32 | access to parameter tainted |
-| Capture.cs:116:17:116:32 | ... = ... | Capture.cs:116:17:116:32 | ... = ... |
-| Capture.cs:116:17:116:32 | SSA def(sink34) | Capture.cs:116:17:116:32 | SSA def(sink34) |
-| Capture.cs:116:17:116:32 | SSA def(sink34) | Capture.cs:120:9:120:25 | SSA call def(sink34) |
-| Capture.cs:116:17:116:32 | SSA def(sink34) | Capture.cs:120:9:120:25 | SSA call def(sink34) |
-| Capture.cs:116:26:116:32 | access to parameter tainted | Capture.cs:116:17:116:32 | SSA def(sink34) |
-| Capture.cs:116:26:116:32 | access to parameter tainted | Capture.cs:116:17:116:32 | SSA def(sink34) |
-| Capture.cs:116:26:116:32 | access to parameter tainted | Capture.cs:116:17:116:32 | SSA def(sink34) |
-| Capture.cs:116:26:116:32 | access to parameter tainted | Capture.cs:116:17:116:32 | SSA def(sink34) |
-| Capture.cs:116:26:116:32 | access to parameter tainted | Capture.cs:116:26:116:32 | access to parameter tainted |
-| Capture.cs:118:13:118:13 | access to local function M | Capture.cs:118:13:118:13 | access to local function M |
-| Capture.cs:118:13:118:15 | call to local function M | Capture.cs:118:13:118:15 | call to local function M |
-| Capture.cs:120:9:120:23 | access to local function CaptureThrough2 | Capture.cs:120:9:120:23 | access to local function CaptureThrough2 |
-| Capture.cs:120:9:120:25 | SSA call def(sink34) | Capture.cs:120:9:120:25 | SSA call def(sink34) |
-| Capture.cs:120:9:120:25 | SSA call def(sink34) | Capture.cs:121:15:121:20 | access to local variable sink34 |
-| Capture.cs:120:9:120:25 | SSA call def(sink34) | Capture.cs:121:15:121:20 | access to local variable sink34 |
-| Capture.cs:120:9:120:25 | [implicit argument] tainted | Capture.cs:114:13:117:13 | SSA capture def(tainted) |
-| Capture.cs:120:9:120:25 | [implicit argument] tainted | Capture.cs:114:13:117:13 | SSA capture def(tainted) |
-| Capture.cs:120:9:120:25 | [implicit argument] tainted | Capture.cs:120:9:120:25 | SSA call def(sink34) |
-| Capture.cs:120:9:120:25 | [implicit argument] tainted | Capture.cs:120:9:120:25 | SSA call def(sink34) |
+| Capture.cs:79:17:79:39 | ... = ... | Capture.cs:79:17:79:39 | ... = ... |
+| Capture.cs:79:17:79:39 | SSA def(sink31) | Capture.cs:79:17:79:39 | SSA def(sink31) |
+| Capture.cs:79:17:79:39 | SSA def(sink31) | Capture.cs:83:9:83:21 | SSA call def(sink31) |
+| Capture.cs:79:17:79:39 | SSA def(sink31) | Capture.cs:83:9:83:21 | SSA call def(sink31) |
+| Capture.cs:79:26:79:39 | "taint source" | Capture.cs:79:17:79:39 | SSA def(sink31) |
+| Capture.cs:79:26:79:39 | "taint source" | Capture.cs:79:17:79:39 | SSA def(sink31) |
+| Capture.cs:79:26:79:39 | "taint source" | Capture.cs:79:26:79:39 | "taint source" |
+| Capture.cs:81:13:81:13 | access to local function M | Capture.cs:81:13:81:13 | access to local function M |
+| Capture.cs:81:13:81:15 | call to local function M | Capture.cs:81:13:81:15 | call to local function M |
+| Capture.cs:83:9:83:19 | access to local function CaptureOut2 | Capture.cs:83:9:83:19 | access to local function CaptureOut2 |
+| Capture.cs:83:9:83:21 | SSA call def(sink31) | Capture.cs:83:9:83:21 | SSA call def(sink31) |
+| Capture.cs:83:9:83:21 | SSA call def(sink31) | Capture.cs:84:15:84:20 | access to local variable sink31 |
+| Capture.cs:83:9:83:21 | SSA call def(sink31) | Capture.cs:84:15:84:20 | access to local variable sink31 |
+| Capture.cs:83:9:83:21 | call to local function CaptureOut2 | Capture.cs:83:9:83:21 | call to local function CaptureOut2 |
+| Capture.cs:84:9:84:21 | call to method Check | Capture.cs:84:9:84:21 | call to method Check |
+| Capture.cs:84:15:84:20 | access to local variable sink31 | Capture.cs:84:15:84:20 | access to local variable sink31 |
+| Capture.cs:86:16:86:26 | SSA def(sink32) | Capture.cs:86:16:86:26 | SSA def(sink32) |
+| Capture.cs:86:16:86:26 | String sink32 = ... | Capture.cs:86:16:86:26 | String sink32 = ... |
+| Capture.cs:86:25:86:26 | "" | Capture.cs:86:16:86:26 | SSA def(sink32) |
+| Capture.cs:86:25:86:26 | "" | Capture.cs:86:16:86:26 | SSA def(sink32) |
+| Capture.cs:86:25:86:26 | "" | Capture.cs:86:25:86:26 | "" |
+| Capture.cs:87:30:91:9 | Func<String,String> captureOut3 = ... | Capture.cs:87:30:91:9 | Func<String,String> captureOut3 = ... |
+| Capture.cs:87:30:91:9 | SSA def(captureOut3) | Capture.cs:87:30:91:9 | SSA def(captureOut3) |
+| Capture.cs:87:30:91:9 | SSA def(captureOut3) | Capture.cs:92:30:92:40 | access to local variable captureOut3 |
+| Capture.cs:87:30:91:9 | SSA def(captureOut3) | Capture.cs:92:30:92:40 | access to local variable captureOut3 |
+| Capture.cs:87:44:87:46 | arg | Capture.cs:87:44:87:46 | arg |
+| Capture.cs:87:44:87:46 | arg | Capture.cs:87:44:87:46 | arg |
+| Capture.cs:87:44:87:46 | arg | Capture.cs:87:44:87:46 | arg |
+| Capture.cs:87:44:87:46 | arg | Capture.cs:87:44:87:46 | arg |
+| Capture.cs:87:44:87:46 | arg | Capture.cs:87:44:87:46 | arg |
+| Capture.cs:87:44:87:46 | arg | Capture.cs:87:44:87:46 | arg |
+| Capture.cs:87:44:87:46 | arg | Capture.cs:90:20:90:22 | access to parameter arg |
+| Capture.cs:87:44:87:46 | arg | Capture.cs:90:20:90:22 | access to parameter arg |
+| Capture.cs:87:44:87:46 | arg | Capture.cs:90:20:90:22 | access to parameter arg |
+| Capture.cs:87:44:87:46 | arg | Capture.cs:90:20:90:22 | access to parameter arg |
+| Capture.cs:87:44:87:46 | arg | Capture.cs:90:20:90:22 | access to parameter arg |
+| Capture.cs:87:44:87:46 | arg | Capture.cs:90:20:90:22 | access to parameter arg |
+| Capture.cs:87:44:87:46 | arg | Capture.cs:90:20:90:22 | access to parameter arg |
+| Capture.cs:87:44:87:46 | arg | Capture.cs:90:20:90:22 | access to parameter arg |
+| Capture.cs:87:44:91:9 | (...) => ... | Capture.cs:87:30:91:9 | SSA def(captureOut3) |
+| Capture.cs:87:44:91:9 | (...) => ... | Capture.cs:87:30:91:9 | SSA def(captureOut3) |
+| Capture.cs:87:44:91:9 | (...) => ... | Capture.cs:87:44:91:9 | (...) => ... |
+| Capture.cs:87:44:91:9 | (...) => ... | Capture.cs:92:30:92:40 | access to local variable captureOut3 |
+| Capture.cs:87:44:91:9 | (...) => ... | Capture.cs:92:30:92:40 | access to local variable captureOut3 |
+| Capture.cs:89:13:89:35 | ... = ... | Capture.cs:89:13:89:35 | ... = ... |
+| Capture.cs:89:13:89:35 | SSA def(sink32) | Capture.cs:89:13:89:35 | SSA def(sink32) |
+| Capture.cs:89:13:89:35 | SSA def(sink32) | Capture.cs:92:9:92:41 | SSA call def(sink32) |
+| Capture.cs:89:13:89:35 | SSA def(sink32) | Capture.cs:92:9:92:41 | SSA call def(sink32) |
+| Capture.cs:89:22:89:35 | "taint source" | Capture.cs:89:13:89:35 | SSA def(sink32) |
+| Capture.cs:89:22:89:35 | "taint source" | Capture.cs:89:13:89:35 | SSA def(sink32) |
+| Capture.cs:89:22:89:35 | "taint source" | Capture.cs:89:22:89:35 | "taint source" |
+| Capture.cs:90:20:90:22 | access to parameter arg | Capture.cs:90:20:90:22 | access to parameter arg |
+| Capture.cs:90:20:90:22 | access to parameter arg | Capture.cs:92:30:92:40 | [output] access to local variable captureOut3 |
+| Capture.cs:90:20:90:22 | access to parameter arg | Capture.cs:92:30:92:40 | [output] access to local variable captureOut3 |
+| Capture.cs:92:9:92:21 | array creation of type String[] | Capture.cs:87:44:87:46 | arg |
+| Capture.cs:92:9:92:21 | array creation of type String[] | Capture.cs:87:44:87:46 | arg |
+| Capture.cs:92:9:92:21 | array creation of type String[] | Capture.cs:92:9:92:21 | array creation of type String[] |
+| Capture.cs:92:9:92:21 | array creation of type String[] | Capture.cs:92:30:92:40 | [output] access to local variable captureOut3 |
+| Capture.cs:92:9:92:21 | array creation of type String[] | Capture.cs:92:30:92:40 | [output] access to local variable captureOut3 |
+| Capture.cs:92:9:92:41 | SSA call def(sink32) | Capture.cs:92:9:92:41 | SSA call def(sink32) |
+| Capture.cs:92:9:92:41 | SSA call def(sink32) | Capture.cs:93:15:93:20 | access to local variable sink32 |
+| Capture.cs:92:9:92:41 | SSA call def(sink32) | Capture.cs:93:15:93:20 | access to local variable sink32 |
+| Capture.cs:92:9:92:41 | call to method Select | Capture.cs:92:9:92:41 | call to method Select |
+| Capture.cs:92:9:92:41 | call to method Select | Capture.cs:92:9:92:51 | call to method ToArray |
+| Capture.cs:92:9:92:41 | call to method Select | Capture.cs:92:9:92:51 | call to method ToArray |
+| Capture.cs:92:9:92:51 | call to method ToArray | Capture.cs:92:9:92:51 | call to method ToArray |
+| Capture.cs:92:15:92:21 | { ..., ... } | Capture.cs:92:15:92:21 | { ..., ... } |
+| Capture.cs:92:17:92:19 | " " | Capture.cs:92:9:92:21 | array creation of type String[] |
+| Capture.cs:92:17:92:19 | " " | Capture.cs:92:9:92:21 | array creation of type String[] |
+| Capture.cs:92:17:92:19 | " " | Capture.cs:92:17:92:19 | " " |
+| Capture.cs:92:30:92:40 | [output] access to local variable captureOut3 | Capture.cs:92:9:92:41 | call to method Select |
+| Capture.cs:92:30:92:40 | [output] access to local variable captureOut3 | Capture.cs:92:9:92:41 | call to method Select |
+| Capture.cs:92:30:92:40 | [output] access to local variable captureOut3 | Capture.cs:92:9:92:51 | call to method ToArray |
+| Capture.cs:92:30:92:40 | [output] access to local variable captureOut3 | Capture.cs:92:9:92:51 | call to method ToArray |
+| Capture.cs:92:30:92:40 | [output] access to local variable captureOut3 | Capture.cs:92:30:92:40 | [output] access to local variable captureOut3 |
+| Capture.cs:92:30:92:40 | access to local variable captureOut3 | Capture.cs:92:30:92:40 | access to local variable captureOut3 |
+| Capture.cs:93:9:93:21 | call to method Check | Capture.cs:93:9:93:21 | call to method Check |
+| Capture.cs:93:15:93:20 | access to local variable sink32 | Capture.cs:93:15:93:20 | access to local variable sink32 |
+| Capture.cs:95:16:95:28 | SSA def(nonSink0) | Capture.cs:95:16:95:28 | SSA def(nonSink0) |
+| Capture.cs:95:16:95:28 | SSA def(nonSink0) | Capture.cs:100:15:100:22 | access to local variable nonSink0 |
+| Capture.cs:95:16:95:28 | SSA def(nonSink0) | Capture.cs:100:15:100:22 | access to local variable nonSink0 |
+| Capture.cs:95:16:95:28 | SSA def(nonSink0) | Capture.cs:110:15:110:22 | access to local variable nonSink0 |
+| Capture.cs:95:16:95:28 | SSA def(nonSink0) | Capture.cs:110:15:110:22 | access to local variable nonSink0 |
+| Capture.cs:95:16:95:28 | String nonSink0 = ... | Capture.cs:95:16:95:28 | String nonSink0 = ... |
+| Capture.cs:95:27:95:28 | "" | Capture.cs:95:16:95:28 | SSA def(nonSink0) |
+| Capture.cs:95:27:95:28 | "" | Capture.cs:95:16:95:28 | SSA def(nonSink0) |
+| Capture.cs:95:27:95:28 | "" | Capture.cs:95:27:95:28 | "" |
+| Capture.cs:95:27:95:28 | "" | Capture.cs:100:15:100:22 | access to local variable nonSink0 |
+| Capture.cs:95:27:95:28 | "" | Capture.cs:100:15:100:22 | access to local variable nonSink0 |
+| Capture.cs:95:27:95:28 | "" | Capture.cs:110:15:110:22 | access to local variable nonSink0 |
+| Capture.cs:95:27:95:28 | "" | Capture.cs:110:15:110:22 | access to local variable nonSink0 |
+| Capture.cs:98:13:98:37 | ... = ... | Capture.cs:98:13:98:37 | ... = ... |
+| Capture.cs:98:24:98:37 | "taint source" | Capture.cs:98:24:98:37 | "taint source" |
+| Capture.cs:100:9:100:23 | call to method Check | Capture.cs:100:9:100:23 | call to method Check |
+| Capture.cs:100:15:100:22 | access to local variable nonSink0 | Capture.cs:100:15:100:22 | access to local variable nonSink0 |
+| Capture.cs:100:15:100:22 | access to local variable nonSink0 | Capture.cs:110:15:110:22 | access to local variable nonSink0 |
+| Capture.cs:100:15:100:22 | access to local variable nonSink0 | Capture.cs:110:15:110:22 | access to local variable nonSink0 |
+| Capture.cs:106:17:106:41 | ... = ... | Capture.cs:106:17:106:41 | ... = ... |
+| Capture.cs:106:28:106:41 | "taint source" | Capture.cs:106:28:106:41 | "taint source" |
+| Capture.cs:109:9:109:28 | access to local function CaptureOut2NotCalled | Capture.cs:109:9:109:28 | access to local function CaptureOut2NotCalled |
+| Capture.cs:109:9:109:30 | call to local function CaptureOut2NotCalled | Capture.cs:109:9:109:30 | call to local function CaptureOut2NotCalled |
+| Capture.cs:110:9:110:23 | call to method Check | Capture.cs:110:9:110:23 | call to method Check |
+| Capture.cs:110:15:110:22 | access to local variable nonSink0 | Capture.cs:110:15:110:22 | access to local variable nonSink0 |
+| Capture.cs:113:10:113:16 | this | Capture.cs:113:10:113:16 | this |
+| Capture.cs:113:25:113:31 | tainted | Capture.cs:113:25:113:31 | tainted |
+| Capture.cs:113:25:113:31 | tainted | Capture.cs:113:25:113:31 | tainted |
+| Capture.cs:113:25:113:31 | tainted | Capture.cs:113:25:113:31 | tainted |
+| Capture.cs:113:25:113:31 | tainted | Capture.cs:113:25:113:31 | tainted |
+| Capture.cs:113:25:113:31 | tainted | Capture.cs:120:9:120:25 | [implicit argument] tainted |
+| Capture.cs:113:25:113:31 | tainted | Capture.cs:120:9:120:25 | [implicit argument] tainted |
+| Capture.cs:113:25:113:31 | tainted | Capture.cs:120:9:120:25 | [implicit argument] tainted |
+| Capture.cs:113:25:113:31 | tainted | Capture.cs:120:9:120:25 | [implicit argument] tainted |
+| Capture.cs:113:25:113:31 | tainted | Capture.cs:132:9:132:25 | [implicit argument] tainted |
+| Capture.cs:113:25:113:31 | tainted | Capture.cs:132:9:132:25 | [implicit argument] tainted |
+| Capture.cs:113:25:113:31 | tainted | Capture.cs:132:9:132:25 | [implicit argument] tainted |
+| Capture.cs:113:25:113:31 | tainted | Capture.cs:132:9:132:25 | [implicit argument] tainted |
+| Capture.cs:113:25:113:31 | tainted | Capture.cs:141:9:141:45 | [implicit argument] tainted |
+| Capture.cs:113:25:113:31 | tainted | Capture.cs:141:9:141:45 | [implicit argument] tainted |
+| Capture.cs:113:25:113:31 | tainted | Capture.cs:141:9:141:45 | [implicit argument] tainted |
+| Capture.cs:113:25:113:31 | tainted | Capture.cs:141:9:141:45 | [implicit argument] tainted |
+| Capture.cs:113:25:113:31 | tainted | Capture.cs:148:22:148:38 | [implicit argument] tainted |
+| Capture.cs:113:25:113:31 | tainted | Capture.cs:148:22:148:38 | [implicit argument] tainted |
+| Capture.cs:113:25:113:31 | tainted | Capture.cs:148:22:148:38 | [implicit argument] tainted |
+| Capture.cs:113:25:113:31 | tainted | Capture.cs:148:22:148:38 | [implicit argument] tainted |
+| Capture.cs:113:25:113:31 | tainted | Capture.cs:156:25:156:31 | access to parameter tainted |
+| Capture.cs:113:25:113:31 | tainted | Capture.cs:156:25:156:31 | access to parameter tainted |
+| Capture.cs:113:25:113:31 | tainted | Capture.cs:156:25:156:31 | access to parameter tainted |
+| Capture.cs:113:25:113:31 | tainted | Capture.cs:156:25:156:31 | access to parameter tainted |
+| Capture.cs:113:25:113:31 | tainted | Capture.cs:182:25:182:31 | access to parameter tainted |
+| Capture.cs:113:25:113:31 | tainted | Capture.cs:182:25:182:31 | access to parameter tainted |
+| Capture.cs:113:25:113:31 | tainted | Capture.cs:182:25:182:31 | access to parameter tainted |
+| Capture.cs:113:25:113:31 | tainted | Capture.cs:182:25:182:31 | access to parameter tainted |
+| Capture.cs:115:16:115:26 | SSA def(sink33) | Capture.cs:115:16:115:26 | SSA def(sink33) |
+| Capture.cs:115:16:115:26 | String sink33 = ... | Capture.cs:115:16:115:26 | String sink33 = ... |
+| Capture.cs:115:25:115:26 | "" | Capture.cs:115:16:115:26 | SSA def(sink33) |
+| Capture.cs:115:25:115:26 | "" | Capture.cs:115:16:115:26 | SSA def(sink33) |
+| Capture.cs:115:25:115:26 | "" | Capture.cs:115:25:115:26 | "" |
+| Capture.cs:116:9:119:9 | SSA capture def(tainted) | Capture.cs:116:9:119:9 | SSA capture def(tainted) |
+| Capture.cs:116:9:119:9 | SSA capture def(tainted) | Capture.cs:118:13:118:28 | SSA def(sink33) |
+| Capture.cs:116:9:119:9 | SSA capture def(tainted) | Capture.cs:118:13:118:28 | SSA def(sink33) |
+| Capture.cs:116:9:119:9 | SSA capture def(tainted) | Capture.cs:118:13:118:28 | SSA def(sink33) |
+| Capture.cs:116:9:119:9 | SSA capture def(tainted) | Capture.cs:118:13:118:28 | SSA def(sink33) |
+| Capture.cs:116:9:119:9 | SSA capture def(tainted) | Capture.cs:118:22:118:28 | access to parameter tainted |
+| Capture.cs:116:9:119:9 | SSA capture def(tainted) | Capture.cs:118:22:118:28 | access to parameter tainted |
+| Capture.cs:116:9:119:9 | SSA capture def(tainted) | Capture.cs:118:22:118:28 | access to parameter tainted |
+| Capture.cs:116:9:119:9 | SSA capture def(tainted) | Capture.cs:118:22:118:28 | access to parameter tainted |
+| Capture.cs:118:13:118:28 | ... = ... | Capture.cs:118:13:118:28 | ... = ... |
+| Capture.cs:118:13:118:28 | SSA def(sink33) | Capture.cs:118:13:118:28 | SSA def(sink33) |
+| Capture.cs:118:13:118:28 | SSA def(sink33) | Capture.cs:120:9:120:25 | SSA call def(sink33) |
+| Capture.cs:118:13:118:28 | SSA def(sink33) | Capture.cs:120:9:120:25 | SSA call def(sink33) |
+| Capture.cs:118:22:118:28 | access to parameter tainted | Capture.cs:118:13:118:28 | SSA def(sink33) |
+| Capture.cs:118:22:118:28 | access to parameter tainted | Capture.cs:118:13:118:28 | SSA def(sink33) |
+| Capture.cs:118:22:118:28 | access to parameter tainted | Capture.cs:118:13:118:28 | SSA def(sink33) |
+| Capture.cs:118:22:118:28 | access to parameter tainted | Capture.cs:118:13:118:28 | SSA def(sink33) |
+| Capture.cs:118:22:118:28 | access to parameter tainted | Capture.cs:118:22:118:28 | access to parameter tainted |
+| Capture.cs:120:9:120:23 | access to local function CaptureThrough1 | Capture.cs:120:9:120:23 | access to local function CaptureThrough1 |
+| Capture.cs:120:9:120:25 | SSA call def(sink33) | Capture.cs:120:9:120:25 | SSA call def(sink33) |
+| Capture.cs:120:9:120:25 | SSA call def(sink33) | Capture.cs:121:15:121:20 | access to local variable sink33 |
+| Capture.cs:120:9:120:25 | SSA call def(sink33) | Capture.cs:121:15:121:20 | access to local variable sink33 |
+| Capture.cs:120:9:120:25 | [implicit argument] tainted | Capture.cs:116:9:119:9 | SSA capture def(tainted) |
+| Capture.cs:120:9:120:25 | [implicit argument] tainted | Capture.cs:116:9:119:9 | SSA capture def(tainted) |
+| Capture.cs:120:9:120:25 | [implicit argument] tainted | Capture.cs:120:9:120:25 | SSA call def(sink33) |
+| Capture.cs:120:9:120:25 | [implicit argument] tainted | Capture.cs:120:9:120:25 | SSA call def(sink33) |
 | Capture.cs:120:9:120:25 | [implicit argument] tainted | Capture.cs:120:9:120:25 | [implicit argument] tainted |
-| Capture.cs:120:9:120:25 | call to local function CaptureThrough2 | Capture.cs:120:9:120:25 | call to local function CaptureThrough2 |
+| Capture.cs:120:9:120:25 | call to local function CaptureThrough1 | Capture.cs:120:9:120:25 | call to local function CaptureThrough1 |
 | Capture.cs:121:9:121:21 | call to method Check | Capture.cs:121:9:121:21 | call to method Check |
-| Capture.cs:121:15:121:20 | access to local variable sink34 | Capture.cs:121:15:121:20 | access to local variable sink34 |
-| Capture.cs:123:16:123:26 | SSA def(sink35) | Capture.cs:123:16:123:26 | SSA def(sink35) |
-| Capture.cs:123:16:123:26 | String sink35 = ... | Capture.cs:123:16:123:26 | String sink35 = ... |
-| Capture.cs:123:25:123:26 | "" | Capture.cs:123:16:123:26 | SSA def(sink35) |
-| Capture.cs:123:25:123:26 | "" | Capture.cs:123:16:123:26 | SSA def(sink35) |
+| Capture.cs:121:15:121:20 | access to local variable sink33 | Capture.cs:121:15:121:20 | access to local variable sink33 |
+| Capture.cs:123:16:123:26 | SSA def(sink34) | Capture.cs:123:16:123:26 | SSA def(sink34) |
+| Capture.cs:123:16:123:26 | String sink34 = ... | Capture.cs:123:16:123:26 | String sink34 = ... |
+| Capture.cs:123:25:123:26 | "" | Capture.cs:123:16:123:26 | SSA def(sink34) |
+| Capture.cs:123:25:123:26 | "" | Capture.cs:123:16:123:26 | SSA def(sink34) |
 | Capture.cs:123:25:123:26 | "" | Capture.cs:123:25:123:26 | "" |
-| Capture.cs:124:30:128:9 | Func<String,String> captureThrough3 = ... | Capture.cs:124:30:128:9 | Func<String,String> captureThrough3 = ... |
-| Capture.cs:124:30:128:9 | SSA def(captureThrough3) | Capture.cs:124:30:128:9 | SSA def(captureThrough3) |
-| Capture.cs:124:30:128:9 | SSA def(captureThrough3) | Capture.cs:129:30:129:44 | access to local variable captureThrough3 |
-| Capture.cs:124:30:128:9 | SSA def(captureThrough3) | Capture.cs:129:30:129:44 | access to local variable captureThrough3 |
-| Capture.cs:124:48:124:50 | arg | Capture.cs:124:48:124:50 | arg |
-| Capture.cs:124:48:124:50 | arg | Capture.cs:124:48:124:50 | arg |
-| Capture.cs:124:48:124:50 | arg | Capture.cs:124:48:124:50 | arg |
-| Capture.cs:124:48:124:50 | arg | Capture.cs:124:48:124:50 | arg |
-| Capture.cs:124:48:124:50 | arg | Capture.cs:124:48:124:50 | arg |
-| Capture.cs:124:48:124:50 | arg | Capture.cs:124:48:124:50 | arg |
-| Capture.cs:124:48:124:50 | arg | Capture.cs:127:20:127:22 | access to parameter arg |
-| Capture.cs:124:48:124:50 | arg | Capture.cs:127:20:127:22 | access to parameter arg |
-| Capture.cs:124:48:124:50 | arg | Capture.cs:127:20:127:22 | access to parameter arg |
-| Capture.cs:124:48:124:50 | arg | Capture.cs:127:20:127:22 | access to parameter arg |
-| Capture.cs:124:48:124:50 | arg | Capture.cs:127:20:127:22 | access to parameter arg |
-| Capture.cs:124:48:124:50 | arg | Capture.cs:127:20:127:22 | access to parameter arg |
-| Capture.cs:124:48:124:50 | arg | Capture.cs:127:20:127:22 | access to parameter arg |
-| Capture.cs:124:48:124:50 | arg | Capture.cs:127:20:127:22 | access to parameter arg |
-| Capture.cs:124:48:128:9 | (...) => ... | Capture.cs:124:30:128:9 | SSA def(captureThrough3) |
-| Capture.cs:124:48:128:9 | (...) => ... | Capture.cs:124:30:128:9 | SSA def(captureThrough3) |
-| Capture.cs:124:48:128:9 | (...) => ... | Capture.cs:124:48:128:9 | (...) => ... |
-| Capture.cs:124:48:128:9 | (...) => ... | Capture.cs:129:30:129:44 | access to local variable captureThrough3 |
-| Capture.cs:124:48:128:9 | (...) => ... | Capture.cs:129:30:129:44 | access to local variable captureThrough3 |
-| Capture.cs:124:48:128:9 | SSA capture def(tainted) | Capture.cs:124:48:128:9 | SSA capture def(tainted) |
-| Capture.cs:124:48:128:9 | SSA capture def(tainted) | Capture.cs:126:13:126:28 | SSA def(sink35) |
-| Capture.cs:124:48:128:9 | SSA capture def(tainted) | Capture.cs:126:13:126:28 | SSA def(sink35) |
-| Capture.cs:124:48:128:9 | SSA capture def(tainted) | Capture.cs:126:13:126:28 | SSA def(sink35) |
-| Capture.cs:124:48:128:9 | SSA capture def(tainted) | Capture.cs:126:13:126:28 | SSA def(sink35) |
-| Capture.cs:124:48:128:9 | SSA capture def(tainted) | Capture.cs:126:22:126:28 | access to parameter tainted |
-| Capture.cs:124:48:128:9 | SSA capture def(tainted) | Capture.cs:126:22:126:28 | access to parameter tainted |
-| Capture.cs:124:48:128:9 | SSA capture def(tainted) | Capture.cs:126:22:126:28 | access to parameter tainted |
-| Capture.cs:124:48:128:9 | SSA capture def(tainted) | Capture.cs:126:22:126:28 | access to parameter tainted |
-| Capture.cs:126:13:126:28 | ... = ... | Capture.cs:126:13:126:28 | ... = ... |
-| Capture.cs:126:13:126:28 | SSA def(sink35) | Capture.cs:126:13:126:28 | SSA def(sink35) |
-| Capture.cs:126:13:126:28 | SSA def(sink35) | Capture.cs:129:9:129:45 | SSA call def(sink35) |
-| Capture.cs:126:13:126:28 | SSA def(sink35) | Capture.cs:129:9:129:45 | SSA call def(sink35) |
-| Capture.cs:126:22:126:28 | access to parameter tainted | Capture.cs:126:13:126:28 | SSA def(sink35) |
-| Capture.cs:126:22:126:28 | access to parameter tainted | Capture.cs:126:13:126:28 | SSA def(sink35) |
-| Capture.cs:126:22:126:28 | access to parameter tainted | Capture.cs:126:13:126:28 | SSA def(sink35) |
-| Capture.cs:126:22:126:28 | access to parameter tainted | Capture.cs:126:13:126:28 | SSA def(sink35) |
-| Capture.cs:126:22:126:28 | access to parameter tainted | Capture.cs:126:22:126:28 | access to parameter tainted |
-| Capture.cs:127:20:127:22 | access to parameter arg | Capture.cs:127:20:127:22 | access to parameter arg |
-| Capture.cs:127:20:127:22 | access to parameter arg | Capture.cs:129:30:129:44 | [output] access to local variable captureThrough3 |
-| Capture.cs:127:20:127:22 | access to parameter arg | Capture.cs:129:30:129:44 | [output] access to local variable captureThrough3 |
-| Capture.cs:129:9:129:21 | array creation of type String[] | Capture.cs:124:48:124:50 | arg |
-| Capture.cs:129:9:129:21 | array creation of type String[] | Capture.cs:124:48:124:50 | arg |
-| Capture.cs:129:9:129:21 | array creation of type String[] | Capture.cs:129:9:129:21 | array creation of type String[] |
-| Capture.cs:129:9:129:21 | array creation of type String[] | Capture.cs:129:30:129:44 | [output] access to local variable captureThrough3 |
-| Capture.cs:129:9:129:21 | array creation of type String[] | Capture.cs:129:30:129:44 | [output] access to local variable captureThrough3 |
-| Capture.cs:129:9:129:45 | SSA call def(sink35) | Capture.cs:129:9:129:45 | SSA call def(sink35) |
-| Capture.cs:129:9:129:45 | SSA call def(sink35) | Capture.cs:130:15:130:20 | access to local variable sink35 |
-| Capture.cs:129:9:129:45 | SSA call def(sink35) | Capture.cs:130:15:130:20 | access to local variable sink35 |
-| Capture.cs:129:9:129:45 | [implicit argument] tainted | Capture.cs:124:48:128:9 | SSA capture def(tainted) |
-| Capture.cs:129:9:129:45 | [implicit argument] tainted | Capture.cs:124:48:128:9 | SSA capture def(tainted) |
-| Capture.cs:129:9:129:45 | [implicit argument] tainted | Capture.cs:129:9:129:45 | SSA call def(sink35) |
-| Capture.cs:129:9:129:45 | [implicit argument] tainted | Capture.cs:129:9:129:45 | SSA call def(sink35) |
-| Capture.cs:129:9:129:45 | [implicit argument] tainted | Capture.cs:129:9:129:45 | [implicit argument] tainted |
-| Capture.cs:129:9:129:45 | call to method Select | Capture.cs:129:9:129:45 | call to method Select |
-| Capture.cs:129:9:129:45 | call to method Select | Capture.cs:129:9:129:55 | call to method ToArray |
-| Capture.cs:129:9:129:45 | call to method Select | Capture.cs:129:9:129:55 | call to method ToArray |
-| Capture.cs:129:9:129:55 | call to method ToArray | Capture.cs:129:9:129:55 | call to method ToArray |
-| Capture.cs:129:15:129:21 | { ..., ... } | Capture.cs:129:15:129:21 | { ..., ... } |
-| Capture.cs:129:17:129:19 | " " | Capture.cs:129:9:129:21 | array creation of type String[] |
-| Capture.cs:129:17:129:19 | " " | Capture.cs:129:9:129:21 | array creation of type String[] |
-| Capture.cs:129:17:129:19 | " " | Capture.cs:129:17:129:19 | " " |
-| Capture.cs:129:30:129:44 | [output] access to local variable captureThrough3 | Capture.cs:129:9:129:45 | call to method Select |
-| Capture.cs:129:30:129:44 | [output] access to local variable captureThrough3 | Capture.cs:129:9:129:45 | call to method Select |
-| Capture.cs:129:30:129:44 | [output] access to local variable captureThrough3 | Capture.cs:129:9:129:55 | call to method ToArray |
-| Capture.cs:129:30:129:44 | [output] access to local variable captureThrough3 | Capture.cs:129:9:129:55 | call to method ToArray |
-| Capture.cs:129:30:129:44 | [output] access to local variable captureThrough3 | Capture.cs:129:30:129:44 | [output] access to local variable captureThrough3 |
-| Capture.cs:129:30:129:44 | access to local variable captureThrough3 | Capture.cs:129:30:129:44 | access to local variable captureThrough3 |
-| Capture.cs:130:9:130:21 | call to method Check | Capture.cs:130:9:130:21 | call to method Check |
-| Capture.cs:130:15:130:20 | access to local variable sink35 | Capture.cs:130:15:130:20 | access to local variable sink35 |
-| Capture.cs:132:9:135:9 | SSA capture def(tainted) | Capture.cs:132:9:135:9 | SSA capture def(tainted) |
-| Capture.cs:132:9:135:9 | SSA capture def(tainted) | Capture.cs:134:20:134:26 | access to parameter tainted |
-| Capture.cs:132:9:135:9 | SSA capture def(tainted) | Capture.cs:134:20:134:26 | access to parameter tainted |
-| Capture.cs:132:9:135:9 | SSA capture def(tainted) | Capture.cs:134:20:134:26 | access to parameter tainted |
-| Capture.cs:132:9:135:9 | SSA capture def(tainted) | Capture.cs:134:20:134:26 | access to parameter tainted |
-| Capture.cs:134:20:134:26 | access to parameter tainted | Capture.cs:134:20:134:26 | access to parameter tainted |
-| Capture.cs:134:20:134:26 | access to parameter tainted | Capture.cs:136:22:136:38 | call to local function CaptureThrough4 |
-| Capture.cs:134:20:134:26 | access to parameter tainted | Capture.cs:136:22:136:38 | call to local function CaptureThrough4 |
-| Capture.cs:136:13:136:38 | SSA def(sink36) | Capture.cs:136:13:136:38 | SSA def(sink36) |
-| Capture.cs:136:13:136:38 | SSA def(sink36) | Capture.cs:137:15:137:20 | access to local variable sink36 |
-| Capture.cs:136:13:136:38 | SSA def(sink36) | Capture.cs:137:15:137:20 | access to local variable sink36 |
-| Capture.cs:136:13:136:38 | String sink36 = ... | Capture.cs:136:13:136:38 | String sink36 = ... |
-| Capture.cs:136:22:136:36 | access to local function CaptureThrough4 | Capture.cs:136:22:136:36 | access to local function CaptureThrough4 |
-| Capture.cs:136:22:136:38 | [implicit argument] tainted | Capture.cs:132:9:135:9 | SSA capture def(tainted) |
-| Capture.cs:136:22:136:38 | [implicit argument] tainted | Capture.cs:132:9:135:9 | SSA capture def(tainted) |
-| Capture.cs:136:22:136:38 | [implicit argument] tainted | Capture.cs:136:22:136:38 | [implicit argument] tainted |
-| Capture.cs:136:22:136:38 | [implicit argument] tainted | Capture.cs:136:22:136:38 | call to local function CaptureThrough4 |
-| Capture.cs:136:22:136:38 | [implicit argument] tainted | Capture.cs:136:22:136:38 | call to local function CaptureThrough4 |
-| Capture.cs:136:22:136:38 | call to local function CaptureThrough4 | Capture.cs:136:13:136:38 | SSA def(sink36) |
-| Capture.cs:136:22:136:38 | call to local function CaptureThrough4 | Capture.cs:136:13:136:38 | SSA def(sink36) |
-| Capture.cs:136:22:136:38 | call to local function CaptureThrough4 | Capture.cs:136:22:136:38 | call to local function CaptureThrough4 |
-| Capture.cs:136:22:136:38 | call to local function CaptureThrough4 | Capture.cs:137:15:137:20 | access to local variable sink36 |
-| Capture.cs:136:22:136:38 | call to local function CaptureThrough4 | Capture.cs:137:15:137:20 | access to local variable sink36 |
-| Capture.cs:137:9:137:21 | call to method Check | Capture.cs:137:9:137:21 | call to method Check |
-| Capture.cs:137:15:137:20 | access to local variable sink36 | Capture.cs:137:15:137:20 | access to local variable sink36 |
-| Capture.cs:139:13:139:23 | SSA def(sink37) | Capture.cs:139:13:139:23 | SSA def(sink37) |
-| Capture.cs:139:13:139:23 | String sink37 = ... | Capture.cs:139:13:139:23 | String sink37 = ... |
-| Capture.cs:139:22:139:23 | "" | Capture.cs:139:13:139:23 | SSA def(sink37) |
-| Capture.cs:139:22:139:23 | "" | Capture.cs:139:13:139:23 | SSA def(sink37) |
-| Capture.cs:139:22:139:23 | "" | Capture.cs:139:22:139:23 | "" |
-| Capture.cs:140:37:140:37 | p | Capture.cs:140:37:140:37 | p |
-| Capture.cs:140:37:140:37 | p | Capture.cs:140:37:140:37 | p |
-| Capture.cs:140:37:140:37 | p | Capture.cs:140:37:140:37 | p |
-| Capture.cs:140:37:140:37 | p | Capture.cs:140:37:140:37 | p |
-| Capture.cs:140:37:140:37 | p | Capture.cs:142:13:142:22 | SSA def(sink37) |
-| Capture.cs:140:37:140:37 | p | Capture.cs:142:13:142:22 | SSA def(sink37) |
-| Capture.cs:140:37:140:37 | p | Capture.cs:142:13:142:22 | SSA def(sink37) |
-| Capture.cs:140:37:140:37 | p | Capture.cs:142:13:142:22 | SSA def(sink37) |
-| Capture.cs:140:37:140:37 | p | Capture.cs:142:13:142:22 | SSA def(sink37) |
-| Capture.cs:140:37:140:37 | p | Capture.cs:142:13:142:22 | SSA def(sink37) |
-| Capture.cs:140:37:140:37 | p | Capture.cs:142:22:142:22 | access to parameter p |
-| Capture.cs:140:37:140:37 | p | Capture.cs:142:22:142:22 | access to parameter p |
-| Capture.cs:140:37:140:37 | p | Capture.cs:142:22:142:22 | access to parameter p |
-| Capture.cs:140:37:140:37 | p | Capture.cs:142:22:142:22 | access to parameter p |
-| Capture.cs:140:37:140:37 | p | Capture.cs:142:22:142:22 | access to parameter p |
-| Capture.cs:140:37:140:37 | p | Capture.cs:142:22:142:22 | access to parameter p |
-| Capture.cs:142:13:142:22 | ... = ... | Capture.cs:142:13:142:22 | ... = ... |
-| Capture.cs:142:13:142:22 | SSA def(sink37) | Capture.cs:142:13:142:22 | SSA def(sink37) |
-| Capture.cs:142:13:142:22 | SSA def(sink37) | Capture.cs:144:9:144:32 | SSA call def(sink37) |
-| Capture.cs:142:13:142:22 | SSA def(sink37) | Capture.cs:144:9:144:32 | SSA call def(sink37) |
-| Capture.cs:142:22:142:22 | access to parameter p | Capture.cs:142:13:142:22 | SSA def(sink37) |
-| Capture.cs:142:22:142:22 | access to parameter p | Capture.cs:142:13:142:22 | SSA def(sink37) |
-| Capture.cs:142:22:142:22 | access to parameter p | Capture.cs:142:13:142:22 | SSA def(sink37) |
-| Capture.cs:142:22:142:22 | access to parameter p | Capture.cs:142:13:142:22 | SSA def(sink37) |
-| Capture.cs:142:22:142:22 | access to parameter p | Capture.cs:142:22:142:22 | access to parameter p |
-| Capture.cs:144:9:144:23 | access to local function CaptureThrough5 | Capture.cs:144:9:144:23 | access to local function CaptureThrough5 |
-| Capture.cs:144:9:144:32 | SSA call def(sink37) | Capture.cs:144:9:144:32 | SSA call def(sink37) |
-| Capture.cs:144:9:144:32 | SSA call def(sink37) | Capture.cs:145:15:145:20 | access to local variable sink37 |
-| Capture.cs:144:9:144:32 | SSA call def(sink37) | Capture.cs:145:15:145:20 | access to local variable sink37 |
-| Capture.cs:144:9:144:32 | call to local function CaptureThrough5 | Capture.cs:144:9:144:32 | call to local function CaptureThrough5 |
-| Capture.cs:144:25:144:31 | access to parameter tainted | Capture.cs:140:37:140:37 | p |
-| Capture.cs:144:25:144:31 | access to parameter tainted | Capture.cs:140:37:140:37 | p |
-| Capture.cs:144:25:144:31 | access to parameter tainted | Capture.cs:144:9:144:32 | SSA call def(sink37) |
-| Capture.cs:144:25:144:31 | access to parameter tainted | Capture.cs:144:9:144:32 | SSA call def(sink37) |
-| Capture.cs:144:25:144:31 | access to parameter tainted | Capture.cs:144:25:144:31 | access to parameter tainted |
-| Capture.cs:144:25:144:31 | access to parameter tainted | Capture.cs:170:25:170:31 | access to parameter tainted |
-| Capture.cs:144:25:144:31 | access to parameter tainted | Capture.cs:170:25:170:31 | access to parameter tainted |
-| Capture.cs:145:9:145:21 | call to method Check | Capture.cs:145:9:145:21 | call to method Check |
-| Capture.cs:145:15:145:20 | access to local variable sink37 | Capture.cs:145:15:145:20 | access to local variable sink37 |
-| Capture.cs:147:16:147:28 | SSA def(nonSink0) | Capture.cs:147:16:147:28 | SSA def(nonSink0) |
-| Capture.cs:147:16:147:28 | SSA def(nonSink0) | Capture.cs:152:15:152:22 | access to local variable nonSink0 |
-| Capture.cs:147:16:147:28 | SSA def(nonSink0) | Capture.cs:152:15:152:22 | access to local variable nonSink0 |
-| Capture.cs:147:16:147:28 | SSA def(nonSink0) | Capture.cs:162:15:162:22 | access to local variable nonSink0 |
-| Capture.cs:147:16:147:28 | SSA def(nonSink0) | Capture.cs:162:15:162:22 | access to local variable nonSink0 |
-| Capture.cs:147:16:147:28 | String nonSink0 = ... | Capture.cs:147:16:147:28 | String nonSink0 = ... |
-| Capture.cs:147:27:147:28 | "" | Capture.cs:147:16:147:28 | SSA def(nonSink0) |
-| Capture.cs:147:27:147:28 | "" | Capture.cs:147:16:147:28 | SSA def(nonSink0) |
-| Capture.cs:147:27:147:28 | "" | Capture.cs:147:27:147:28 | "" |
-| Capture.cs:147:27:147:28 | "" | Capture.cs:152:15:152:22 | access to local variable nonSink0 |
-| Capture.cs:147:27:147:28 | "" | Capture.cs:152:15:152:22 | access to local variable nonSink0 |
-| Capture.cs:147:27:147:28 | "" | Capture.cs:162:15:162:22 | access to local variable nonSink0 |
-| Capture.cs:147:27:147:28 | "" | Capture.cs:162:15:162:22 | access to local variable nonSink0 |
-| Capture.cs:148:9:151:9 | SSA capture def(tainted) | Capture.cs:148:9:151:9 | SSA capture def(tainted) |
-| Capture.cs:148:9:151:9 | SSA capture def(tainted) | Capture.cs:150:24:150:30 | access to parameter tainted |
-| Capture.cs:148:9:151:9 | SSA capture def(tainted) | Capture.cs:150:24:150:30 | access to parameter tainted |
-| Capture.cs:150:13:150:30 | ... = ... | Capture.cs:150:13:150:30 | ... = ... |
-| Capture.cs:150:24:150:30 | access to parameter tainted | Capture.cs:150:24:150:30 | access to parameter tainted |
-| Capture.cs:152:9:152:23 | call to method Check | Capture.cs:152:9:152:23 | call to method Check |
-| Capture.cs:152:15:152:22 | access to local variable nonSink0 | Capture.cs:152:15:152:22 | access to local variable nonSink0 |
-| Capture.cs:152:15:152:22 | access to local variable nonSink0 | Capture.cs:162:15:162:22 | access to local variable nonSink0 |
-| Capture.cs:152:15:152:22 | access to local variable nonSink0 | Capture.cs:162:15:162:22 | access to local variable nonSink0 |
-| Capture.cs:156:13:159:13 | SSA capture def(tainted) | Capture.cs:156:13:159:13 | SSA capture def(tainted) |
-| Capture.cs:156:13:159:13 | SSA capture def(tainted) | Capture.cs:158:28:158:34 | access to parameter tainted |
-| Capture.cs:156:13:159:13 | SSA capture def(tainted) | Capture.cs:158:28:158:34 | access to parameter tainted |
-| Capture.cs:158:17:158:34 | ... = ... | Capture.cs:158:17:158:34 | ... = ... |
-| Capture.cs:158:28:158:34 | access to parameter tainted | Capture.cs:158:28:158:34 | access to parameter tainted |
-| Capture.cs:161:9:161:32 | access to local function CaptureThrough2NotCalled | Capture.cs:161:9:161:32 | access to local function CaptureThrough2NotCalled |
-| Capture.cs:161:9:161:34 | call to local function CaptureThrough2NotCalled | Capture.cs:161:9:161:34 | call to local function CaptureThrough2NotCalled |
-| Capture.cs:162:9:162:23 | call to method Check | Capture.cs:162:9:162:23 | call to method Check |
-| Capture.cs:162:15:162:22 | access to local variable nonSink0 | Capture.cs:162:15:162:22 | access to local variable nonSink0 |
-| Capture.cs:164:26:164:26 | s | Capture.cs:164:26:164:26 | s |
-| Capture.cs:164:26:164:26 | s | Capture.cs:164:26:164:26 | s |
-| Capture.cs:164:26:164:26 | s | Capture.cs:164:26:164:26 | s |
-| Capture.cs:164:26:164:26 | s | Capture.cs:164:26:164:26 | s |
-| Capture.cs:164:26:164:26 | s | Capture.cs:167:20:167:22 | [implicit argument] s |
-| Capture.cs:164:26:164:26 | s | Capture.cs:167:20:167:22 | [implicit argument] s |
-| Capture.cs:164:26:164:26 | s | Capture.cs:167:20:167:22 | [implicit argument] s |
-| Capture.cs:164:26:164:26 | s | Capture.cs:167:20:167:22 | [implicit argument] s |
-| Capture.cs:164:26:164:26 | s | Capture.cs:167:20:167:22 | [implicit argument] s |
-| Capture.cs:164:26:164:26 | s | Capture.cs:167:20:167:22 | [implicit argument] s |
-| Capture.cs:166:13:166:28 | SSA capture def(s) | Capture.cs:166:13:166:28 | SSA capture def(s) |
-| Capture.cs:166:13:166:28 | SSA capture def(s) | Capture.cs:166:27:166:27 | access to parameter s |
-| Capture.cs:166:13:166:28 | SSA capture def(s) | Capture.cs:166:27:166:27 | access to parameter s |
-| Capture.cs:166:13:166:28 | SSA capture def(s) | Capture.cs:166:27:166:27 | access to parameter s |
-| Capture.cs:166:13:166:28 | SSA capture def(s) | Capture.cs:166:27:166:27 | access to parameter s |
-| Capture.cs:166:27:166:27 | access to parameter s | Capture.cs:166:27:166:27 | access to parameter s |
-| Capture.cs:166:27:166:27 | access to parameter s | Capture.cs:167:20:167:22 | call to local function M |
-| Capture.cs:166:27:166:27 | access to parameter s | Capture.cs:167:20:167:22 | call to local function M |
-| Capture.cs:167:20:167:20 | access to local function M | Capture.cs:167:20:167:20 | access to local function M |
-| Capture.cs:167:20:167:22 | [implicit argument] s | Capture.cs:166:13:166:28 | SSA capture def(s) |
-| Capture.cs:167:20:167:22 | [implicit argument] s | Capture.cs:166:13:166:28 | SSA capture def(s) |
-| Capture.cs:167:20:167:22 | [implicit argument] s | Capture.cs:166:13:166:28 | SSA capture def(s) |
-| Capture.cs:167:20:167:22 | [implicit argument] s | Capture.cs:166:13:166:28 | SSA capture def(s) |
-| Capture.cs:167:20:167:22 | [implicit argument] s | Capture.cs:167:20:167:22 | [implicit argument] s |
-| Capture.cs:167:20:167:22 | [implicit argument] s | Capture.cs:167:20:167:22 | call to local function M |
-| Capture.cs:167:20:167:22 | [implicit argument] s | Capture.cs:167:20:167:22 | call to local function M |
-| Capture.cs:167:20:167:22 | [implicit argument] s | Capture.cs:167:20:167:22 | call to local function M |
-| Capture.cs:167:20:167:22 | [implicit argument] s | Capture.cs:167:20:167:22 | call to local function M |
-| Capture.cs:167:20:167:22 | call to local function M | Capture.cs:167:20:167:22 | call to local function M |
-| Capture.cs:167:20:167:22 | call to local function M | Capture.cs:170:22:170:32 | call to local function Id |
-| Capture.cs:167:20:167:22 | call to local function M | Capture.cs:170:22:170:32 | call to local function Id |
-| Capture.cs:167:20:167:22 | call to local function M | Capture.cs:172:20:172:25 | call to local function Id |
-| Capture.cs:167:20:167:22 | call to local function M | Capture.cs:172:20:172:25 | call to local function Id |
-| Capture.cs:170:13:170:32 | SSA def(sink38) | Capture.cs:170:13:170:32 | SSA def(sink38) |
-| Capture.cs:170:13:170:32 | SSA def(sink38) | Capture.cs:171:15:171:20 | access to local variable sink38 |
-| Capture.cs:170:13:170:32 | SSA def(sink38) | Capture.cs:171:15:171:20 | access to local variable sink38 |
-| Capture.cs:170:13:170:32 | String sink38 = ... | Capture.cs:170:13:170:32 | String sink38 = ... |
-| Capture.cs:170:22:170:23 | access to local function Id | Capture.cs:170:22:170:23 | access to local function Id |
-| Capture.cs:170:22:170:32 | call to local function Id | Capture.cs:170:13:170:32 | SSA def(sink38) |
-| Capture.cs:170:22:170:32 | call to local function Id | Capture.cs:170:13:170:32 | SSA def(sink38) |
-| Capture.cs:170:22:170:32 | call to local function Id | Capture.cs:170:22:170:32 | call to local function Id |
-| Capture.cs:170:22:170:32 | call to local function Id | Capture.cs:171:15:171:20 | access to local variable sink38 |
-| Capture.cs:170:22:170:32 | call to local function Id | Capture.cs:171:15:171:20 | access to local variable sink38 |
-| Capture.cs:170:25:170:31 | access to parameter tainted | Capture.cs:164:26:164:26 | s |
-| Capture.cs:170:25:170:31 | access to parameter tainted | Capture.cs:164:26:164:26 | s |
-| Capture.cs:170:25:170:31 | access to parameter tainted | Capture.cs:170:22:170:32 | call to local function Id |
-| Capture.cs:170:25:170:31 | access to parameter tainted | Capture.cs:170:22:170:32 | call to local function Id |
-| Capture.cs:170:25:170:31 | access to parameter tainted | Capture.cs:170:25:170:31 | access to parameter tainted |
-| Capture.cs:171:9:171:21 | call to method Check | Capture.cs:171:9:171:21 | call to method Check |
-| Capture.cs:171:15:171:20 | access to local variable sink38 | Capture.cs:171:15:171:20 | access to local variable sink38 |
-| Capture.cs:172:9:172:25 | ... = ... | Capture.cs:172:9:172:25 | ... = ... |
-| Capture.cs:172:9:172:25 | SSA def(nonSink0) | Capture.cs:172:9:172:25 | SSA def(nonSink0) |
-| Capture.cs:172:9:172:25 | SSA def(nonSink0) | Capture.cs:173:15:173:22 | access to local variable nonSink0 |
-| Capture.cs:172:9:172:25 | SSA def(nonSink0) | Capture.cs:173:15:173:22 | access to local variable nonSink0 |
-| Capture.cs:172:20:172:21 | access to local function Id | Capture.cs:172:20:172:21 | access to local function Id |
-| Capture.cs:172:20:172:25 | call to local function Id | Capture.cs:172:9:172:25 | SSA def(nonSink0) |
-| Capture.cs:172:20:172:25 | call to local function Id | Capture.cs:172:9:172:25 | SSA def(nonSink0) |
-| Capture.cs:172:20:172:25 | call to local function Id | Capture.cs:172:20:172:25 | call to local function Id |
-| Capture.cs:172:20:172:25 | call to local function Id | Capture.cs:173:15:173:22 | access to local variable nonSink0 |
-| Capture.cs:172:20:172:25 | call to local function Id | Capture.cs:173:15:173:22 | access to local variable nonSink0 |
-| Capture.cs:172:23:172:24 | "" | Capture.cs:164:26:164:26 | s |
-| Capture.cs:172:23:172:24 | "" | Capture.cs:164:26:164:26 | s |
-| Capture.cs:172:23:172:24 | "" | Capture.cs:172:20:172:25 | call to local function Id |
-| Capture.cs:172:23:172:24 | "" | Capture.cs:172:20:172:25 | call to local function Id |
-| Capture.cs:172:23:172:24 | "" | Capture.cs:172:23:172:24 | "" |
-| Capture.cs:173:9:173:23 | call to method Check | Capture.cs:173:9:173:23 | call to method Check |
-| Capture.cs:173:15:173:22 | access to local variable nonSink0 | Capture.cs:173:15:173:22 | access to local variable nonSink0 |
+| Capture.cs:126:13:129:13 | SSA capture def(tainted) | Capture.cs:126:13:129:13 | SSA capture def(tainted) |
+| Capture.cs:126:13:129:13 | SSA capture def(tainted) | Capture.cs:128:17:128:32 | SSA def(sink34) |
+| Capture.cs:126:13:129:13 | SSA capture def(tainted) | Capture.cs:128:17:128:32 | SSA def(sink34) |
+| Capture.cs:126:13:129:13 | SSA capture def(tainted) | Capture.cs:128:17:128:32 | SSA def(sink34) |
+| Capture.cs:126:13:129:13 | SSA capture def(tainted) | Capture.cs:128:17:128:32 | SSA def(sink34) |
+| Capture.cs:126:13:129:13 | SSA capture def(tainted) | Capture.cs:128:26:128:32 | access to parameter tainted |
+| Capture.cs:126:13:129:13 | SSA capture def(tainted) | Capture.cs:128:26:128:32 | access to parameter tainted |
+| Capture.cs:126:13:129:13 | SSA capture def(tainted) | Capture.cs:128:26:128:32 | access to parameter tainted |
+| Capture.cs:126:13:129:13 | SSA capture def(tainted) | Capture.cs:128:26:128:32 | access to parameter tainted |
+| Capture.cs:128:17:128:32 | ... = ... | Capture.cs:128:17:128:32 | ... = ... |
+| Capture.cs:128:17:128:32 | SSA def(sink34) | Capture.cs:128:17:128:32 | SSA def(sink34) |
+| Capture.cs:128:17:128:32 | SSA def(sink34) | Capture.cs:132:9:132:25 | SSA call def(sink34) |
+| Capture.cs:128:17:128:32 | SSA def(sink34) | Capture.cs:132:9:132:25 | SSA call def(sink34) |
+| Capture.cs:128:26:128:32 | access to parameter tainted | Capture.cs:128:17:128:32 | SSA def(sink34) |
+| Capture.cs:128:26:128:32 | access to parameter tainted | Capture.cs:128:17:128:32 | SSA def(sink34) |
+| Capture.cs:128:26:128:32 | access to parameter tainted | Capture.cs:128:17:128:32 | SSA def(sink34) |
+| Capture.cs:128:26:128:32 | access to parameter tainted | Capture.cs:128:17:128:32 | SSA def(sink34) |
+| Capture.cs:128:26:128:32 | access to parameter tainted | Capture.cs:128:26:128:32 | access to parameter tainted |
+| Capture.cs:130:13:130:13 | access to local function M | Capture.cs:130:13:130:13 | access to local function M |
+| Capture.cs:130:13:130:15 | call to local function M | Capture.cs:130:13:130:15 | call to local function M |
+| Capture.cs:132:9:132:23 | access to local function CaptureThrough2 | Capture.cs:132:9:132:23 | access to local function CaptureThrough2 |
+| Capture.cs:132:9:132:25 | SSA call def(sink34) | Capture.cs:132:9:132:25 | SSA call def(sink34) |
+| Capture.cs:132:9:132:25 | SSA call def(sink34) | Capture.cs:133:15:133:20 | access to local variable sink34 |
+| Capture.cs:132:9:132:25 | SSA call def(sink34) | Capture.cs:133:15:133:20 | access to local variable sink34 |
+| Capture.cs:132:9:132:25 | [implicit argument] tainted | Capture.cs:126:13:129:13 | SSA capture def(tainted) |
+| Capture.cs:132:9:132:25 | [implicit argument] tainted | Capture.cs:126:13:129:13 | SSA capture def(tainted) |
+| Capture.cs:132:9:132:25 | [implicit argument] tainted | Capture.cs:132:9:132:25 | SSA call def(sink34) |
+| Capture.cs:132:9:132:25 | [implicit argument] tainted | Capture.cs:132:9:132:25 | SSA call def(sink34) |
+| Capture.cs:132:9:132:25 | [implicit argument] tainted | Capture.cs:132:9:132:25 | [implicit argument] tainted |
+| Capture.cs:132:9:132:25 | call to local function CaptureThrough2 | Capture.cs:132:9:132:25 | call to local function CaptureThrough2 |
+| Capture.cs:133:9:133:21 | call to method Check | Capture.cs:133:9:133:21 | call to method Check |
+| Capture.cs:133:15:133:20 | access to local variable sink34 | Capture.cs:133:15:133:20 | access to local variable sink34 |
+| Capture.cs:135:16:135:26 | SSA def(sink35) | Capture.cs:135:16:135:26 | SSA def(sink35) |
+| Capture.cs:135:16:135:26 | String sink35 = ... | Capture.cs:135:16:135:26 | String sink35 = ... |
+| Capture.cs:135:25:135:26 | "" | Capture.cs:135:16:135:26 | SSA def(sink35) |
+| Capture.cs:135:25:135:26 | "" | Capture.cs:135:16:135:26 | SSA def(sink35) |
+| Capture.cs:135:25:135:26 | "" | Capture.cs:135:25:135:26 | "" |
+| Capture.cs:136:30:140:9 | Func<String,String> captureThrough3 = ... | Capture.cs:136:30:140:9 | Func<String,String> captureThrough3 = ... |
+| Capture.cs:136:30:140:9 | SSA def(captureThrough3) | Capture.cs:136:30:140:9 | SSA def(captureThrough3) |
+| Capture.cs:136:30:140:9 | SSA def(captureThrough3) | Capture.cs:141:30:141:44 | access to local variable captureThrough3 |
+| Capture.cs:136:30:140:9 | SSA def(captureThrough3) | Capture.cs:141:30:141:44 | access to local variable captureThrough3 |
+| Capture.cs:136:48:136:50 | arg | Capture.cs:136:48:136:50 | arg |
+| Capture.cs:136:48:136:50 | arg | Capture.cs:136:48:136:50 | arg |
+| Capture.cs:136:48:136:50 | arg | Capture.cs:136:48:136:50 | arg |
+| Capture.cs:136:48:136:50 | arg | Capture.cs:136:48:136:50 | arg |
+| Capture.cs:136:48:136:50 | arg | Capture.cs:136:48:136:50 | arg |
+| Capture.cs:136:48:136:50 | arg | Capture.cs:136:48:136:50 | arg |
+| Capture.cs:136:48:136:50 | arg | Capture.cs:139:20:139:22 | access to parameter arg |
+| Capture.cs:136:48:136:50 | arg | Capture.cs:139:20:139:22 | access to parameter arg |
+| Capture.cs:136:48:136:50 | arg | Capture.cs:139:20:139:22 | access to parameter arg |
+| Capture.cs:136:48:136:50 | arg | Capture.cs:139:20:139:22 | access to parameter arg |
+| Capture.cs:136:48:136:50 | arg | Capture.cs:139:20:139:22 | access to parameter arg |
+| Capture.cs:136:48:136:50 | arg | Capture.cs:139:20:139:22 | access to parameter arg |
+| Capture.cs:136:48:136:50 | arg | Capture.cs:139:20:139:22 | access to parameter arg |
+| Capture.cs:136:48:136:50 | arg | Capture.cs:139:20:139:22 | access to parameter arg |
+| Capture.cs:136:48:140:9 | (...) => ... | Capture.cs:136:30:140:9 | SSA def(captureThrough3) |
+| Capture.cs:136:48:140:9 | (...) => ... | Capture.cs:136:30:140:9 | SSA def(captureThrough3) |
+| Capture.cs:136:48:140:9 | (...) => ... | Capture.cs:136:48:140:9 | (...) => ... |
+| Capture.cs:136:48:140:9 | (...) => ... | Capture.cs:141:30:141:44 | access to local variable captureThrough3 |
+| Capture.cs:136:48:140:9 | (...) => ... | Capture.cs:141:30:141:44 | access to local variable captureThrough3 |
+| Capture.cs:136:48:140:9 | SSA capture def(tainted) | Capture.cs:136:48:140:9 | SSA capture def(tainted) |
+| Capture.cs:136:48:140:9 | SSA capture def(tainted) | Capture.cs:138:13:138:28 | SSA def(sink35) |
+| Capture.cs:136:48:140:9 | SSA capture def(tainted) | Capture.cs:138:13:138:28 | SSA def(sink35) |
+| Capture.cs:136:48:140:9 | SSA capture def(tainted) | Capture.cs:138:13:138:28 | SSA def(sink35) |
+| Capture.cs:136:48:140:9 | SSA capture def(tainted) | Capture.cs:138:13:138:28 | SSA def(sink35) |
+| Capture.cs:136:48:140:9 | SSA capture def(tainted) | Capture.cs:138:22:138:28 | access to parameter tainted |
+| Capture.cs:136:48:140:9 | SSA capture def(tainted) | Capture.cs:138:22:138:28 | access to parameter tainted |
+| Capture.cs:136:48:140:9 | SSA capture def(tainted) | Capture.cs:138:22:138:28 | access to parameter tainted |
+| Capture.cs:136:48:140:9 | SSA capture def(tainted) | Capture.cs:138:22:138:28 | access to parameter tainted |
+| Capture.cs:138:13:138:28 | ... = ... | Capture.cs:138:13:138:28 | ... = ... |
+| Capture.cs:138:13:138:28 | SSA def(sink35) | Capture.cs:138:13:138:28 | SSA def(sink35) |
+| Capture.cs:138:13:138:28 | SSA def(sink35) | Capture.cs:141:9:141:45 | SSA call def(sink35) |
+| Capture.cs:138:13:138:28 | SSA def(sink35) | Capture.cs:141:9:141:45 | SSA call def(sink35) |
+| Capture.cs:138:22:138:28 | access to parameter tainted | Capture.cs:138:13:138:28 | SSA def(sink35) |
+| Capture.cs:138:22:138:28 | access to parameter tainted | Capture.cs:138:13:138:28 | SSA def(sink35) |
+| Capture.cs:138:22:138:28 | access to parameter tainted | Capture.cs:138:13:138:28 | SSA def(sink35) |
+| Capture.cs:138:22:138:28 | access to parameter tainted | Capture.cs:138:13:138:28 | SSA def(sink35) |
+| Capture.cs:138:22:138:28 | access to parameter tainted | Capture.cs:138:22:138:28 | access to parameter tainted |
+| Capture.cs:139:20:139:22 | access to parameter arg | Capture.cs:139:20:139:22 | access to parameter arg |
+| Capture.cs:139:20:139:22 | access to parameter arg | Capture.cs:141:30:141:44 | [output] access to local variable captureThrough3 |
+| Capture.cs:139:20:139:22 | access to parameter arg | Capture.cs:141:30:141:44 | [output] access to local variable captureThrough3 |
+| Capture.cs:141:9:141:21 | array creation of type String[] | Capture.cs:136:48:136:50 | arg |
+| Capture.cs:141:9:141:21 | array creation of type String[] | Capture.cs:136:48:136:50 | arg |
+| Capture.cs:141:9:141:21 | array creation of type String[] | Capture.cs:141:9:141:21 | array creation of type String[] |
+| Capture.cs:141:9:141:21 | array creation of type String[] | Capture.cs:141:30:141:44 | [output] access to local variable captureThrough3 |
+| Capture.cs:141:9:141:21 | array creation of type String[] | Capture.cs:141:30:141:44 | [output] access to local variable captureThrough3 |
+| Capture.cs:141:9:141:45 | SSA call def(sink35) | Capture.cs:141:9:141:45 | SSA call def(sink35) |
+| Capture.cs:141:9:141:45 | SSA call def(sink35) | Capture.cs:142:15:142:20 | access to local variable sink35 |
+| Capture.cs:141:9:141:45 | SSA call def(sink35) | Capture.cs:142:15:142:20 | access to local variable sink35 |
+| Capture.cs:141:9:141:45 | [implicit argument] tainted | Capture.cs:136:48:140:9 | SSA capture def(tainted) |
+| Capture.cs:141:9:141:45 | [implicit argument] tainted | Capture.cs:136:48:140:9 | SSA capture def(tainted) |
+| Capture.cs:141:9:141:45 | [implicit argument] tainted | Capture.cs:141:9:141:45 | SSA call def(sink35) |
+| Capture.cs:141:9:141:45 | [implicit argument] tainted | Capture.cs:141:9:141:45 | SSA call def(sink35) |
+| Capture.cs:141:9:141:45 | [implicit argument] tainted | Capture.cs:141:9:141:45 | [implicit argument] tainted |
+| Capture.cs:141:9:141:45 | call to method Select | Capture.cs:141:9:141:45 | call to method Select |
+| Capture.cs:141:9:141:45 | call to method Select | Capture.cs:141:9:141:55 | call to method ToArray |
+| Capture.cs:141:9:141:45 | call to method Select | Capture.cs:141:9:141:55 | call to method ToArray |
+| Capture.cs:141:9:141:55 | call to method ToArray | Capture.cs:141:9:141:55 | call to method ToArray |
+| Capture.cs:141:15:141:21 | { ..., ... } | Capture.cs:141:15:141:21 | { ..., ... } |
+| Capture.cs:141:17:141:19 | " " | Capture.cs:141:9:141:21 | array creation of type String[] |
+| Capture.cs:141:17:141:19 | " " | Capture.cs:141:9:141:21 | array creation of type String[] |
+| Capture.cs:141:17:141:19 | " " | Capture.cs:141:17:141:19 | " " |
+| Capture.cs:141:30:141:44 | [output] access to local variable captureThrough3 | Capture.cs:141:9:141:45 | call to method Select |
+| Capture.cs:141:30:141:44 | [output] access to local variable captureThrough3 | Capture.cs:141:9:141:45 | call to method Select |
+| Capture.cs:141:30:141:44 | [output] access to local variable captureThrough3 | Capture.cs:141:9:141:55 | call to method ToArray |
+| Capture.cs:141:30:141:44 | [output] access to local variable captureThrough3 | Capture.cs:141:9:141:55 | call to method ToArray |
+| Capture.cs:141:30:141:44 | [output] access to local variable captureThrough3 | Capture.cs:141:30:141:44 | [output] access to local variable captureThrough3 |
+| Capture.cs:141:30:141:44 | access to local variable captureThrough3 | Capture.cs:141:30:141:44 | access to local variable captureThrough3 |
+| Capture.cs:142:9:142:21 | call to method Check | Capture.cs:142:9:142:21 | call to method Check |
+| Capture.cs:142:15:142:20 | access to local variable sink35 | Capture.cs:142:15:142:20 | access to local variable sink35 |
+| Capture.cs:144:9:147:9 | SSA capture def(tainted) | Capture.cs:144:9:147:9 | SSA capture def(tainted) |
+| Capture.cs:144:9:147:9 | SSA capture def(tainted) | Capture.cs:146:20:146:26 | access to parameter tainted |
+| Capture.cs:144:9:147:9 | SSA capture def(tainted) | Capture.cs:146:20:146:26 | access to parameter tainted |
+| Capture.cs:144:9:147:9 | SSA capture def(tainted) | Capture.cs:146:20:146:26 | access to parameter tainted |
+| Capture.cs:144:9:147:9 | SSA capture def(tainted) | Capture.cs:146:20:146:26 | access to parameter tainted |
+| Capture.cs:146:20:146:26 | access to parameter tainted | Capture.cs:146:20:146:26 | access to parameter tainted |
+| Capture.cs:146:20:146:26 | access to parameter tainted | Capture.cs:148:22:148:38 | call to local function CaptureThrough4 |
+| Capture.cs:146:20:146:26 | access to parameter tainted | Capture.cs:148:22:148:38 | call to local function CaptureThrough4 |
+| Capture.cs:148:13:148:38 | SSA def(sink36) | Capture.cs:148:13:148:38 | SSA def(sink36) |
+| Capture.cs:148:13:148:38 | SSA def(sink36) | Capture.cs:149:15:149:20 | access to local variable sink36 |
+| Capture.cs:148:13:148:38 | SSA def(sink36) | Capture.cs:149:15:149:20 | access to local variable sink36 |
+| Capture.cs:148:13:148:38 | String sink36 = ... | Capture.cs:148:13:148:38 | String sink36 = ... |
+| Capture.cs:148:22:148:36 | access to local function CaptureThrough4 | Capture.cs:148:22:148:36 | access to local function CaptureThrough4 |
+| Capture.cs:148:22:148:38 | [implicit argument] tainted | Capture.cs:144:9:147:9 | SSA capture def(tainted) |
+| Capture.cs:148:22:148:38 | [implicit argument] tainted | Capture.cs:144:9:147:9 | SSA capture def(tainted) |
+| Capture.cs:148:22:148:38 | [implicit argument] tainted | Capture.cs:148:22:148:38 | [implicit argument] tainted |
+| Capture.cs:148:22:148:38 | [implicit argument] tainted | Capture.cs:148:22:148:38 | call to local function CaptureThrough4 |
+| Capture.cs:148:22:148:38 | [implicit argument] tainted | Capture.cs:148:22:148:38 | call to local function CaptureThrough4 |
+| Capture.cs:148:22:148:38 | call to local function CaptureThrough4 | Capture.cs:148:13:148:38 | SSA def(sink36) |
+| Capture.cs:148:22:148:38 | call to local function CaptureThrough4 | Capture.cs:148:13:148:38 | SSA def(sink36) |
+| Capture.cs:148:22:148:38 | call to local function CaptureThrough4 | Capture.cs:148:22:148:38 | call to local function CaptureThrough4 |
+| Capture.cs:148:22:148:38 | call to local function CaptureThrough4 | Capture.cs:149:15:149:20 | access to local variable sink36 |
+| Capture.cs:148:22:148:38 | call to local function CaptureThrough4 | Capture.cs:149:15:149:20 | access to local variable sink36 |
+| Capture.cs:149:9:149:21 | call to method Check | Capture.cs:149:9:149:21 | call to method Check |
+| Capture.cs:149:15:149:20 | access to local variable sink36 | Capture.cs:149:15:149:20 | access to local variable sink36 |
+| Capture.cs:151:13:151:23 | SSA def(sink37) | Capture.cs:151:13:151:23 | SSA def(sink37) |
+| Capture.cs:151:13:151:23 | String sink37 = ... | Capture.cs:151:13:151:23 | String sink37 = ... |
+| Capture.cs:151:22:151:23 | "" | Capture.cs:151:13:151:23 | SSA def(sink37) |
+| Capture.cs:151:22:151:23 | "" | Capture.cs:151:13:151:23 | SSA def(sink37) |
+| Capture.cs:151:22:151:23 | "" | Capture.cs:151:22:151:23 | "" |
+| Capture.cs:152:37:152:37 | p | Capture.cs:152:37:152:37 | p |
+| Capture.cs:152:37:152:37 | p | Capture.cs:152:37:152:37 | p |
+| Capture.cs:152:37:152:37 | p | Capture.cs:152:37:152:37 | p |
+| Capture.cs:152:37:152:37 | p | Capture.cs:152:37:152:37 | p |
+| Capture.cs:152:37:152:37 | p | Capture.cs:154:13:154:22 | SSA def(sink37) |
+| Capture.cs:152:37:152:37 | p | Capture.cs:154:13:154:22 | SSA def(sink37) |
+| Capture.cs:152:37:152:37 | p | Capture.cs:154:13:154:22 | SSA def(sink37) |
+| Capture.cs:152:37:152:37 | p | Capture.cs:154:13:154:22 | SSA def(sink37) |
+| Capture.cs:152:37:152:37 | p | Capture.cs:154:13:154:22 | SSA def(sink37) |
+| Capture.cs:152:37:152:37 | p | Capture.cs:154:13:154:22 | SSA def(sink37) |
+| Capture.cs:152:37:152:37 | p | Capture.cs:154:22:154:22 | access to parameter p |
+| Capture.cs:152:37:152:37 | p | Capture.cs:154:22:154:22 | access to parameter p |
+| Capture.cs:152:37:152:37 | p | Capture.cs:154:22:154:22 | access to parameter p |
+| Capture.cs:152:37:152:37 | p | Capture.cs:154:22:154:22 | access to parameter p |
+| Capture.cs:152:37:152:37 | p | Capture.cs:154:22:154:22 | access to parameter p |
+| Capture.cs:152:37:152:37 | p | Capture.cs:154:22:154:22 | access to parameter p |
+| Capture.cs:154:13:154:22 | ... = ... | Capture.cs:154:13:154:22 | ... = ... |
+| Capture.cs:154:13:154:22 | SSA def(sink37) | Capture.cs:154:13:154:22 | SSA def(sink37) |
+| Capture.cs:154:13:154:22 | SSA def(sink37) | Capture.cs:156:9:156:32 | SSA call def(sink37) |
+| Capture.cs:154:13:154:22 | SSA def(sink37) | Capture.cs:156:9:156:32 | SSA call def(sink37) |
+| Capture.cs:154:22:154:22 | access to parameter p | Capture.cs:154:13:154:22 | SSA def(sink37) |
+| Capture.cs:154:22:154:22 | access to parameter p | Capture.cs:154:13:154:22 | SSA def(sink37) |
+| Capture.cs:154:22:154:22 | access to parameter p | Capture.cs:154:13:154:22 | SSA def(sink37) |
+| Capture.cs:154:22:154:22 | access to parameter p | Capture.cs:154:13:154:22 | SSA def(sink37) |
+| Capture.cs:154:22:154:22 | access to parameter p | Capture.cs:154:22:154:22 | access to parameter p |
+| Capture.cs:156:9:156:23 | access to local function CaptureThrough5 | Capture.cs:156:9:156:23 | access to local function CaptureThrough5 |
+| Capture.cs:156:9:156:32 | SSA call def(sink37) | Capture.cs:156:9:156:32 | SSA call def(sink37) |
+| Capture.cs:156:9:156:32 | SSA call def(sink37) | Capture.cs:157:15:157:20 | access to local variable sink37 |
+| Capture.cs:156:9:156:32 | SSA call def(sink37) | Capture.cs:157:15:157:20 | access to local variable sink37 |
+| Capture.cs:156:9:156:32 | call to local function CaptureThrough5 | Capture.cs:156:9:156:32 | call to local function CaptureThrough5 |
+| Capture.cs:156:25:156:31 | access to parameter tainted | Capture.cs:152:37:152:37 | p |
+| Capture.cs:156:25:156:31 | access to parameter tainted | Capture.cs:152:37:152:37 | p |
+| Capture.cs:156:25:156:31 | access to parameter tainted | Capture.cs:156:9:156:32 | SSA call def(sink37) |
+| Capture.cs:156:25:156:31 | access to parameter tainted | Capture.cs:156:9:156:32 | SSA call def(sink37) |
+| Capture.cs:156:25:156:31 | access to parameter tainted | Capture.cs:156:25:156:31 | access to parameter tainted |
+| Capture.cs:156:25:156:31 | access to parameter tainted | Capture.cs:182:25:182:31 | access to parameter tainted |
+| Capture.cs:156:25:156:31 | access to parameter tainted | Capture.cs:182:25:182:31 | access to parameter tainted |
+| Capture.cs:157:9:157:21 | call to method Check | Capture.cs:157:9:157:21 | call to method Check |
+| Capture.cs:157:15:157:20 | access to local variable sink37 | Capture.cs:157:15:157:20 | access to local variable sink37 |
+| Capture.cs:159:16:159:28 | SSA def(nonSink0) | Capture.cs:159:16:159:28 | SSA def(nonSink0) |
+| Capture.cs:159:16:159:28 | SSA def(nonSink0) | Capture.cs:164:15:164:22 | access to local variable nonSink0 |
+| Capture.cs:159:16:159:28 | SSA def(nonSink0) | Capture.cs:164:15:164:22 | access to local variable nonSink0 |
+| Capture.cs:159:16:159:28 | SSA def(nonSink0) | Capture.cs:174:15:174:22 | access to local variable nonSink0 |
+| Capture.cs:159:16:159:28 | SSA def(nonSink0) | Capture.cs:174:15:174:22 | access to local variable nonSink0 |
+| Capture.cs:159:16:159:28 | String nonSink0 = ... | Capture.cs:159:16:159:28 | String nonSink0 = ... |
+| Capture.cs:159:27:159:28 | "" | Capture.cs:159:16:159:28 | SSA def(nonSink0) |
+| Capture.cs:159:27:159:28 | "" | Capture.cs:159:16:159:28 | SSA def(nonSink0) |
+| Capture.cs:159:27:159:28 | "" | Capture.cs:159:27:159:28 | "" |
+| Capture.cs:159:27:159:28 | "" | Capture.cs:164:15:164:22 | access to local variable nonSink0 |
+| Capture.cs:159:27:159:28 | "" | Capture.cs:164:15:164:22 | access to local variable nonSink0 |
+| Capture.cs:159:27:159:28 | "" | Capture.cs:174:15:174:22 | access to local variable nonSink0 |
+| Capture.cs:159:27:159:28 | "" | Capture.cs:174:15:174:22 | access to local variable nonSink0 |
+| Capture.cs:160:9:163:9 | SSA capture def(tainted) | Capture.cs:160:9:163:9 | SSA capture def(tainted) |
+| Capture.cs:160:9:163:9 | SSA capture def(tainted) | Capture.cs:162:24:162:30 | access to parameter tainted |
+| Capture.cs:160:9:163:9 | SSA capture def(tainted) | Capture.cs:162:24:162:30 | access to parameter tainted |
+| Capture.cs:162:13:162:30 | ... = ... | Capture.cs:162:13:162:30 | ... = ... |
+| Capture.cs:162:24:162:30 | access to parameter tainted | Capture.cs:162:24:162:30 | access to parameter tainted |
+| Capture.cs:164:9:164:23 | call to method Check | Capture.cs:164:9:164:23 | call to method Check |
+| Capture.cs:164:15:164:22 | access to local variable nonSink0 | Capture.cs:164:15:164:22 | access to local variable nonSink0 |
+| Capture.cs:164:15:164:22 | access to local variable nonSink0 | Capture.cs:174:15:174:22 | access to local variable nonSink0 |
+| Capture.cs:164:15:164:22 | access to local variable nonSink0 | Capture.cs:174:15:174:22 | access to local variable nonSink0 |
+| Capture.cs:168:13:171:13 | SSA capture def(tainted) | Capture.cs:168:13:171:13 | SSA capture def(tainted) |
+| Capture.cs:168:13:171:13 | SSA capture def(tainted) | Capture.cs:170:28:170:34 | access to parameter tainted |
+| Capture.cs:168:13:171:13 | SSA capture def(tainted) | Capture.cs:170:28:170:34 | access to parameter tainted |
+| Capture.cs:170:17:170:34 | ... = ... | Capture.cs:170:17:170:34 | ... = ... |
+| Capture.cs:170:28:170:34 | access to parameter tainted | Capture.cs:170:28:170:34 | access to parameter tainted |
+| Capture.cs:173:9:173:32 | access to local function CaptureThrough2NotCalled | Capture.cs:173:9:173:32 | access to local function CaptureThrough2NotCalled |
+| Capture.cs:173:9:173:34 | call to local function CaptureThrough2NotCalled | Capture.cs:173:9:173:34 | call to local function CaptureThrough2NotCalled |
+| Capture.cs:174:9:174:23 | call to method Check | Capture.cs:174:9:174:23 | call to method Check |
+| Capture.cs:174:15:174:22 | access to local variable nonSink0 | Capture.cs:174:15:174:22 | access to local variable nonSink0 |
+| Capture.cs:176:26:176:26 | s | Capture.cs:176:26:176:26 | s |
+| Capture.cs:176:26:176:26 | s | Capture.cs:176:26:176:26 | s |
+| Capture.cs:176:26:176:26 | s | Capture.cs:176:26:176:26 | s |
+| Capture.cs:176:26:176:26 | s | Capture.cs:176:26:176:26 | s |
+| Capture.cs:176:26:176:26 | s | Capture.cs:179:20:179:22 | [implicit argument] s |
+| Capture.cs:176:26:176:26 | s | Capture.cs:179:20:179:22 | [implicit argument] s |
+| Capture.cs:176:26:176:26 | s | Capture.cs:179:20:179:22 | [implicit argument] s |
+| Capture.cs:176:26:176:26 | s | Capture.cs:179:20:179:22 | [implicit argument] s |
+| Capture.cs:176:26:176:26 | s | Capture.cs:179:20:179:22 | [implicit argument] s |
+| Capture.cs:176:26:176:26 | s | Capture.cs:179:20:179:22 | [implicit argument] s |
+| Capture.cs:178:13:178:28 | SSA capture def(s) | Capture.cs:178:13:178:28 | SSA capture def(s) |
+| Capture.cs:178:13:178:28 | SSA capture def(s) | Capture.cs:178:27:178:27 | access to parameter s |
+| Capture.cs:178:13:178:28 | SSA capture def(s) | Capture.cs:178:27:178:27 | access to parameter s |
+| Capture.cs:178:13:178:28 | SSA capture def(s) | Capture.cs:178:27:178:27 | access to parameter s |
+| Capture.cs:178:13:178:28 | SSA capture def(s) | Capture.cs:178:27:178:27 | access to parameter s |
+| Capture.cs:178:27:178:27 | access to parameter s | Capture.cs:178:27:178:27 | access to parameter s |
+| Capture.cs:178:27:178:27 | access to parameter s | Capture.cs:179:20:179:22 | call to local function M |
+| Capture.cs:178:27:178:27 | access to parameter s | Capture.cs:179:20:179:22 | call to local function M |
+| Capture.cs:179:20:179:20 | access to local function M | Capture.cs:179:20:179:20 | access to local function M |
+| Capture.cs:179:20:179:22 | [implicit argument] s | Capture.cs:178:13:178:28 | SSA capture def(s) |
+| Capture.cs:179:20:179:22 | [implicit argument] s | Capture.cs:178:13:178:28 | SSA capture def(s) |
+| Capture.cs:179:20:179:22 | [implicit argument] s | Capture.cs:178:13:178:28 | SSA capture def(s) |
+| Capture.cs:179:20:179:22 | [implicit argument] s | Capture.cs:178:13:178:28 | SSA capture def(s) |
+| Capture.cs:179:20:179:22 | [implicit argument] s | Capture.cs:179:20:179:22 | [implicit argument] s |
+| Capture.cs:179:20:179:22 | [implicit argument] s | Capture.cs:179:20:179:22 | call to local function M |
+| Capture.cs:179:20:179:22 | [implicit argument] s | Capture.cs:179:20:179:22 | call to local function M |
+| Capture.cs:179:20:179:22 | [implicit argument] s | Capture.cs:179:20:179:22 | call to local function M |
+| Capture.cs:179:20:179:22 | [implicit argument] s | Capture.cs:179:20:179:22 | call to local function M |
+| Capture.cs:179:20:179:22 | call to local function M | Capture.cs:179:20:179:22 | call to local function M |
+| Capture.cs:179:20:179:22 | call to local function M | Capture.cs:182:22:182:32 | call to local function Id |
+| Capture.cs:179:20:179:22 | call to local function M | Capture.cs:182:22:182:32 | call to local function Id |
+| Capture.cs:179:20:179:22 | call to local function M | Capture.cs:184:20:184:25 | call to local function Id |
+| Capture.cs:179:20:179:22 | call to local function M | Capture.cs:184:20:184:25 | call to local function Id |
+| Capture.cs:182:13:182:32 | SSA def(sink38) | Capture.cs:182:13:182:32 | SSA def(sink38) |
+| Capture.cs:182:13:182:32 | SSA def(sink38) | Capture.cs:183:15:183:20 | access to local variable sink38 |
+| Capture.cs:182:13:182:32 | SSA def(sink38) | Capture.cs:183:15:183:20 | access to local variable sink38 |
+| Capture.cs:182:13:182:32 | String sink38 = ... | Capture.cs:182:13:182:32 | String sink38 = ... |
+| Capture.cs:182:22:182:23 | access to local function Id | Capture.cs:182:22:182:23 | access to local function Id |
+| Capture.cs:182:22:182:32 | call to local function Id | Capture.cs:182:13:182:32 | SSA def(sink38) |
+| Capture.cs:182:22:182:32 | call to local function Id | Capture.cs:182:13:182:32 | SSA def(sink38) |
+| Capture.cs:182:22:182:32 | call to local function Id | Capture.cs:182:22:182:32 | call to local function Id |
+| Capture.cs:182:22:182:32 | call to local function Id | Capture.cs:183:15:183:20 | access to local variable sink38 |
+| Capture.cs:182:22:182:32 | call to local function Id | Capture.cs:183:15:183:20 | access to local variable sink38 |
+| Capture.cs:182:25:182:31 | access to parameter tainted | Capture.cs:176:26:176:26 | s |
+| Capture.cs:182:25:182:31 | access to parameter tainted | Capture.cs:176:26:176:26 | s |
+| Capture.cs:182:25:182:31 | access to parameter tainted | Capture.cs:182:22:182:32 | call to local function Id |
+| Capture.cs:182:25:182:31 | access to parameter tainted | Capture.cs:182:22:182:32 | call to local function Id |
+| Capture.cs:182:25:182:31 | access to parameter tainted | Capture.cs:182:25:182:31 | access to parameter tainted |
+| Capture.cs:183:9:183:21 | call to method Check | Capture.cs:183:9:183:21 | call to method Check |
+| Capture.cs:183:15:183:20 | access to local variable sink38 | Capture.cs:183:15:183:20 | access to local variable sink38 |
+| Capture.cs:184:9:184:25 | ... = ... | Capture.cs:184:9:184:25 | ... = ... |
+| Capture.cs:184:9:184:25 | SSA def(nonSink0) | Capture.cs:184:9:184:25 | SSA def(nonSink0) |
+| Capture.cs:184:9:184:25 | SSA def(nonSink0) | Capture.cs:185:15:185:22 | access to local variable nonSink0 |
+| Capture.cs:184:9:184:25 | SSA def(nonSink0) | Capture.cs:185:15:185:22 | access to local variable nonSink0 |
+| Capture.cs:184:20:184:21 | access to local function Id | Capture.cs:184:20:184:21 | access to local function Id |
+| Capture.cs:184:20:184:25 | call to local function Id | Capture.cs:184:9:184:25 | SSA def(nonSink0) |
+| Capture.cs:184:20:184:25 | call to local function Id | Capture.cs:184:9:184:25 | SSA def(nonSink0) |
+| Capture.cs:184:20:184:25 | call to local function Id | Capture.cs:184:20:184:25 | call to local function Id |
+| Capture.cs:184:20:184:25 | call to local function Id | Capture.cs:185:15:185:22 | access to local variable nonSink0 |
+| Capture.cs:184:20:184:25 | call to local function Id | Capture.cs:185:15:185:22 | access to local variable nonSink0 |
+| Capture.cs:184:23:184:24 | "" | Capture.cs:176:26:176:26 | s |
+| Capture.cs:184:23:184:24 | "" | Capture.cs:176:26:176:26 | s |
+| Capture.cs:184:23:184:24 | "" | Capture.cs:184:20:184:25 | call to local function Id |
+| Capture.cs:184:23:184:24 | "" | Capture.cs:184:20:184:25 | call to local function Id |
+| Capture.cs:184:23:184:24 | "" | Capture.cs:184:23:184:24 | "" |
+| Capture.cs:185:9:185:23 | call to method Check | Capture.cs:185:9:185:23 | call to method Check |
+| Capture.cs:185:15:185:22 | access to local variable nonSink0 | Capture.cs:185:15:185:22 | access to local variable nonSink0 |
 | GlobalDataFlow.cs:14:17:14:17 | this | GlobalDataFlow.cs:14:17:14:17 | this |
 | GlobalDataFlow.cs:14:17:14:17 | this | GlobalDataFlow.cs:64:9:64:18 | this access |
 | GlobalDataFlow.cs:14:17:14:17 | this | GlobalDataFlow.cs:64:9:64:18 | this access |

--- a/csharp/ql/test/library-tests/dataflow/global/TaintTrackingEdges.expected
+++ b/csharp/ql/test/library-tests/dataflow/global/TaintTrackingEdges.expected
@@ -239,8 +239,8 @@
 | Capture.cs:52:13:59:14 | [implicit argument] sink39 | Capture.cs:55:27:58:17 | SSA capture def(sink39) |
 | Capture.cs:52:13:59:14 | call to method RunAction | Capture.cs:52:13:59:14 | call to method RunAction |
 | Capture.cs:52:23:59:13 | (...) => ... | Capture.cs:52:23:59:13 | (...) => ... |
-| Capture.cs:52:23:59:13 | (...) => ... | Capture.cs:190:34:190:34 | a |
-| Capture.cs:52:23:59:13 | (...) => ... | Capture.cs:190:34:190:34 | a |
+| Capture.cs:52:23:59:13 | (...) => ... | Capture.cs:202:34:202:34 | a |
+| Capture.cs:52:23:59:13 | (...) => ... | Capture.cs:202:34:202:34 | a |
 | Capture.cs:52:23:59:13 | SSA capture def(nonSink0) | Capture.cs:52:23:59:13 | SSA capture def(nonSink0) |
 | Capture.cs:52:23:59:13 | SSA capture def(nonSink0) | Capture.cs:54:23:54:30 | access to parameter nonSink0 |
 | Capture.cs:52:23:59:13 | SSA capture def(nonSink0) | Capture.cs:54:23:54:30 | access to parameter nonSink0 |
@@ -250,8 +250,8 @@
 | Capture.cs:54:23:54:30 | access to parameter nonSink0 | Capture.cs:54:23:54:30 | access to parameter nonSink0 |
 | Capture.cs:55:17:58:18 | call to method RunAction | Capture.cs:55:17:58:18 | call to method RunAction |
 | Capture.cs:55:27:58:17 | (...) => ... | Capture.cs:55:27:58:17 | (...) => ... |
-| Capture.cs:55:27:58:17 | (...) => ... | Capture.cs:190:34:190:34 | a |
-| Capture.cs:55:27:58:17 | (...) => ... | Capture.cs:190:34:190:34 | a |
+| Capture.cs:55:27:58:17 | (...) => ... | Capture.cs:202:34:202:34 | a |
+| Capture.cs:55:27:58:17 | (...) => ... | Capture.cs:202:34:202:34 | a |
 | Capture.cs:55:27:58:17 | SSA capture def(sink39) | Capture.cs:55:27:58:17 | SSA capture def(sink39) |
 | Capture.cs:55:27:58:17 | SSA capture def(sink39) | Capture.cs:57:27:57:32 | access to parameter sink39 |
 | Capture.cs:55:27:58:17 | SSA capture def(sink39) | Capture.cs:57:27:57:32 | access to parameter sink39 |
@@ -395,366 +395,366 @@
 | Capture.cs:109:9:109:30 | call to local function CaptureOut2NotCalled | Capture.cs:109:9:109:30 | call to local function CaptureOut2NotCalled |
 | Capture.cs:110:9:110:23 | call to method Check | Capture.cs:110:9:110:23 | call to method Check |
 | Capture.cs:110:15:110:22 | access to local variable nonSink0 | Capture.cs:110:15:110:22 | access to local variable nonSink0 |
-| Capture.cs:113:10:113:16 | this | Capture.cs:113:10:113:16 | this |
-| Capture.cs:113:25:113:31 | tainted | Capture.cs:113:25:113:31 | tainted |
-| Capture.cs:113:25:113:31 | tainted | Capture.cs:113:25:113:31 | tainted |
-| Capture.cs:113:25:113:31 | tainted | Capture.cs:113:25:113:31 | tainted |
-| Capture.cs:113:25:113:31 | tainted | Capture.cs:113:25:113:31 | tainted |
-| Capture.cs:113:25:113:31 | tainted | Capture.cs:120:9:120:25 | [implicit argument] tainted |
-| Capture.cs:113:25:113:31 | tainted | Capture.cs:120:9:120:25 | [implicit argument] tainted |
-| Capture.cs:113:25:113:31 | tainted | Capture.cs:120:9:120:25 | [implicit argument] tainted |
-| Capture.cs:113:25:113:31 | tainted | Capture.cs:120:9:120:25 | [implicit argument] tainted |
-| Capture.cs:113:25:113:31 | tainted | Capture.cs:132:9:132:25 | [implicit argument] tainted |
-| Capture.cs:113:25:113:31 | tainted | Capture.cs:132:9:132:25 | [implicit argument] tainted |
-| Capture.cs:113:25:113:31 | tainted | Capture.cs:132:9:132:25 | [implicit argument] tainted |
-| Capture.cs:113:25:113:31 | tainted | Capture.cs:132:9:132:25 | [implicit argument] tainted |
-| Capture.cs:113:25:113:31 | tainted | Capture.cs:141:9:141:45 | [implicit argument] tainted |
-| Capture.cs:113:25:113:31 | tainted | Capture.cs:141:9:141:45 | [implicit argument] tainted |
-| Capture.cs:113:25:113:31 | tainted | Capture.cs:141:9:141:45 | [implicit argument] tainted |
-| Capture.cs:113:25:113:31 | tainted | Capture.cs:141:9:141:45 | [implicit argument] tainted |
-| Capture.cs:113:25:113:31 | tainted | Capture.cs:148:22:148:38 | [implicit argument] tainted |
-| Capture.cs:113:25:113:31 | tainted | Capture.cs:148:22:148:38 | [implicit argument] tainted |
-| Capture.cs:113:25:113:31 | tainted | Capture.cs:148:22:148:38 | [implicit argument] tainted |
-| Capture.cs:113:25:113:31 | tainted | Capture.cs:148:22:148:38 | [implicit argument] tainted |
-| Capture.cs:113:25:113:31 | tainted | Capture.cs:156:25:156:31 | access to parameter tainted |
-| Capture.cs:113:25:113:31 | tainted | Capture.cs:156:25:156:31 | access to parameter tainted |
-| Capture.cs:113:25:113:31 | tainted | Capture.cs:156:25:156:31 | access to parameter tainted |
-| Capture.cs:113:25:113:31 | tainted | Capture.cs:156:25:156:31 | access to parameter tainted |
-| Capture.cs:113:25:113:31 | tainted | Capture.cs:182:25:182:31 | access to parameter tainted |
-| Capture.cs:113:25:113:31 | tainted | Capture.cs:182:25:182:31 | access to parameter tainted |
-| Capture.cs:113:25:113:31 | tainted | Capture.cs:182:25:182:31 | access to parameter tainted |
-| Capture.cs:113:25:113:31 | tainted | Capture.cs:182:25:182:31 | access to parameter tainted |
-| Capture.cs:115:16:115:26 | SSA def(sink33) | Capture.cs:115:16:115:26 | SSA def(sink33) |
-| Capture.cs:115:16:115:26 | String sink33 = ... | Capture.cs:115:16:115:26 | String sink33 = ... |
-| Capture.cs:115:25:115:26 | "" | Capture.cs:115:16:115:26 | SSA def(sink33) |
-| Capture.cs:115:25:115:26 | "" | Capture.cs:115:16:115:26 | SSA def(sink33) |
-| Capture.cs:115:25:115:26 | "" | Capture.cs:115:25:115:26 | "" |
-| Capture.cs:116:9:119:9 | SSA capture def(tainted) | Capture.cs:116:9:119:9 | SSA capture def(tainted) |
-| Capture.cs:116:9:119:9 | SSA capture def(tainted) | Capture.cs:118:13:118:28 | SSA def(sink33) |
-| Capture.cs:116:9:119:9 | SSA capture def(tainted) | Capture.cs:118:13:118:28 | SSA def(sink33) |
-| Capture.cs:116:9:119:9 | SSA capture def(tainted) | Capture.cs:118:13:118:28 | SSA def(sink33) |
-| Capture.cs:116:9:119:9 | SSA capture def(tainted) | Capture.cs:118:13:118:28 | SSA def(sink33) |
-| Capture.cs:116:9:119:9 | SSA capture def(tainted) | Capture.cs:118:22:118:28 | access to parameter tainted |
-| Capture.cs:116:9:119:9 | SSA capture def(tainted) | Capture.cs:118:22:118:28 | access to parameter tainted |
-| Capture.cs:116:9:119:9 | SSA capture def(tainted) | Capture.cs:118:22:118:28 | access to parameter tainted |
-| Capture.cs:116:9:119:9 | SSA capture def(tainted) | Capture.cs:118:22:118:28 | access to parameter tainted |
-| Capture.cs:118:13:118:28 | ... = ... | Capture.cs:118:13:118:28 | ... = ... |
-| Capture.cs:118:13:118:28 | SSA def(sink33) | Capture.cs:118:13:118:28 | SSA def(sink33) |
-| Capture.cs:118:13:118:28 | SSA def(sink33) | Capture.cs:120:9:120:25 | SSA call def(sink33) |
-| Capture.cs:118:13:118:28 | SSA def(sink33) | Capture.cs:120:9:120:25 | SSA call def(sink33) |
-| Capture.cs:118:22:118:28 | access to parameter tainted | Capture.cs:118:13:118:28 | SSA def(sink33) |
-| Capture.cs:118:22:118:28 | access to parameter tainted | Capture.cs:118:13:118:28 | SSA def(sink33) |
-| Capture.cs:118:22:118:28 | access to parameter tainted | Capture.cs:118:13:118:28 | SSA def(sink33) |
-| Capture.cs:118:22:118:28 | access to parameter tainted | Capture.cs:118:13:118:28 | SSA def(sink33) |
-| Capture.cs:118:22:118:28 | access to parameter tainted | Capture.cs:118:22:118:28 | access to parameter tainted |
-| Capture.cs:120:9:120:23 | access to local function CaptureThrough1 | Capture.cs:120:9:120:23 | access to local function CaptureThrough1 |
-| Capture.cs:120:9:120:25 | SSA call def(sink33) | Capture.cs:120:9:120:25 | SSA call def(sink33) |
-| Capture.cs:120:9:120:25 | SSA call def(sink33) | Capture.cs:121:15:121:20 | access to local variable sink33 |
-| Capture.cs:120:9:120:25 | SSA call def(sink33) | Capture.cs:121:15:121:20 | access to local variable sink33 |
-| Capture.cs:120:9:120:25 | [implicit argument] tainted | Capture.cs:116:9:119:9 | SSA capture def(tainted) |
-| Capture.cs:120:9:120:25 | [implicit argument] tainted | Capture.cs:116:9:119:9 | SSA capture def(tainted) |
-| Capture.cs:120:9:120:25 | [implicit argument] tainted | Capture.cs:120:9:120:25 | SSA call def(sink33) |
-| Capture.cs:120:9:120:25 | [implicit argument] tainted | Capture.cs:120:9:120:25 | SSA call def(sink33) |
-| Capture.cs:120:9:120:25 | [implicit argument] tainted | Capture.cs:120:9:120:25 | [implicit argument] tainted |
-| Capture.cs:120:9:120:25 | call to local function CaptureThrough1 | Capture.cs:120:9:120:25 | call to local function CaptureThrough1 |
-| Capture.cs:121:9:121:21 | call to method Check | Capture.cs:121:9:121:21 | call to method Check |
-| Capture.cs:121:15:121:20 | access to local variable sink33 | Capture.cs:121:15:121:20 | access to local variable sink33 |
-| Capture.cs:123:16:123:26 | SSA def(sink34) | Capture.cs:123:16:123:26 | SSA def(sink34) |
-| Capture.cs:123:16:123:26 | String sink34 = ... | Capture.cs:123:16:123:26 | String sink34 = ... |
-| Capture.cs:123:25:123:26 | "" | Capture.cs:123:16:123:26 | SSA def(sink34) |
-| Capture.cs:123:25:123:26 | "" | Capture.cs:123:16:123:26 | SSA def(sink34) |
-| Capture.cs:123:25:123:26 | "" | Capture.cs:123:25:123:26 | "" |
-| Capture.cs:126:13:129:13 | SSA capture def(tainted) | Capture.cs:126:13:129:13 | SSA capture def(tainted) |
-| Capture.cs:126:13:129:13 | SSA capture def(tainted) | Capture.cs:128:17:128:32 | SSA def(sink34) |
-| Capture.cs:126:13:129:13 | SSA capture def(tainted) | Capture.cs:128:17:128:32 | SSA def(sink34) |
-| Capture.cs:126:13:129:13 | SSA capture def(tainted) | Capture.cs:128:17:128:32 | SSA def(sink34) |
-| Capture.cs:126:13:129:13 | SSA capture def(tainted) | Capture.cs:128:17:128:32 | SSA def(sink34) |
-| Capture.cs:126:13:129:13 | SSA capture def(tainted) | Capture.cs:128:26:128:32 | access to parameter tainted |
-| Capture.cs:126:13:129:13 | SSA capture def(tainted) | Capture.cs:128:26:128:32 | access to parameter tainted |
-| Capture.cs:126:13:129:13 | SSA capture def(tainted) | Capture.cs:128:26:128:32 | access to parameter tainted |
-| Capture.cs:126:13:129:13 | SSA capture def(tainted) | Capture.cs:128:26:128:32 | access to parameter tainted |
-| Capture.cs:128:17:128:32 | ... = ... | Capture.cs:128:17:128:32 | ... = ... |
-| Capture.cs:128:17:128:32 | SSA def(sink34) | Capture.cs:128:17:128:32 | SSA def(sink34) |
-| Capture.cs:128:17:128:32 | SSA def(sink34) | Capture.cs:132:9:132:25 | SSA call def(sink34) |
-| Capture.cs:128:17:128:32 | SSA def(sink34) | Capture.cs:132:9:132:25 | SSA call def(sink34) |
-| Capture.cs:128:26:128:32 | access to parameter tainted | Capture.cs:128:17:128:32 | SSA def(sink34) |
-| Capture.cs:128:26:128:32 | access to parameter tainted | Capture.cs:128:17:128:32 | SSA def(sink34) |
-| Capture.cs:128:26:128:32 | access to parameter tainted | Capture.cs:128:17:128:32 | SSA def(sink34) |
-| Capture.cs:128:26:128:32 | access to parameter tainted | Capture.cs:128:17:128:32 | SSA def(sink34) |
-| Capture.cs:128:26:128:32 | access to parameter tainted | Capture.cs:128:26:128:32 | access to parameter tainted |
-| Capture.cs:130:13:130:13 | access to local function M | Capture.cs:130:13:130:13 | access to local function M |
-| Capture.cs:130:13:130:15 | call to local function M | Capture.cs:130:13:130:15 | call to local function M |
-| Capture.cs:132:9:132:23 | access to local function CaptureThrough2 | Capture.cs:132:9:132:23 | access to local function CaptureThrough2 |
-| Capture.cs:132:9:132:25 | SSA call def(sink34) | Capture.cs:132:9:132:25 | SSA call def(sink34) |
-| Capture.cs:132:9:132:25 | SSA call def(sink34) | Capture.cs:133:15:133:20 | access to local variable sink34 |
-| Capture.cs:132:9:132:25 | SSA call def(sink34) | Capture.cs:133:15:133:20 | access to local variable sink34 |
-| Capture.cs:132:9:132:25 | [implicit argument] tainted | Capture.cs:126:13:129:13 | SSA capture def(tainted) |
-| Capture.cs:132:9:132:25 | [implicit argument] tainted | Capture.cs:126:13:129:13 | SSA capture def(tainted) |
-| Capture.cs:132:9:132:25 | [implicit argument] tainted | Capture.cs:132:9:132:25 | SSA call def(sink34) |
-| Capture.cs:132:9:132:25 | [implicit argument] tainted | Capture.cs:132:9:132:25 | SSA call def(sink34) |
+| Capture.cs:125:10:125:16 | this | Capture.cs:125:10:125:16 | this |
+| Capture.cs:125:25:125:31 | tainted | Capture.cs:125:25:125:31 | tainted |
+| Capture.cs:125:25:125:31 | tainted | Capture.cs:125:25:125:31 | tainted |
+| Capture.cs:125:25:125:31 | tainted | Capture.cs:125:25:125:31 | tainted |
+| Capture.cs:125:25:125:31 | tainted | Capture.cs:125:25:125:31 | tainted |
+| Capture.cs:125:25:125:31 | tainted | Capture.cs:132:9:132:25 | [implicit argument] tainted |
+| Capture.cs:125:25:125:31 | tainted | Capture.cs:132:9:132:25 | [implicit argument] tainted |
+| Capture.cs:125:25:125:31 | tainted | Capture.cs:132:9:132:25 | [implicit argument] tainted |
+| Capture.cs:125:25:125:31 | tainted | Capture.cs:132:9:132:25 | [implicit argument] tainted |
+| Capture.cs:125:25:125:31 | tainted | Capture.cs:144:9:144:25 | [implicit argument] tainted |
+| Capture.cs:125:25:125:31 | tainted | Capture.cs:144:9:144:25 | [implicit argument] tainted |
+| Capture.cs:125:25:125:31 | tainted | Capture.cs:144:9:144:25 | [implicit argument] tainted |
+| Capture.cs:125:25:125:31 | tainted | Capture.cs:144:9:144:25 | [implicit argument] tainted |
+| Capture.cs:125:25:125:31 | tainted | Capture.cs:153:9:153:45 | [implicit argument] tainted |
+| Capture.cs:125:25:125:31 | tainted | Capture.cs:153:9:153:45 | [implicit argument] tainted |
+| Capture.cs:125:25:125:31 | tainted | Capture.cs:153:9:153:45 | [implicit argument] tainted |
+| Capture.cs:125:25:125:31 | tainted | Capture.cs:153:9:153:45 | [implicit argument] tainted |
+| Capture.cs:125:25:125:31 | tainted | Capture.cs:160:22:160:38 | [implicit argument] tainted |
+| Capture.cs:125:25:125:31 | tainted | Capture.cs:160:22:160:38 | [implicit argument] tainted |
+| Capture.cs:125:25:125:31 | tainted | Capture.cs:160:22:160:38 | [implicit argument] tainted |
+| Capture.cs:125:25:125:31 | tainted | Capture.cs:160:22:160:38 | [implicit argument] tainted |
+| Capture.cs:125:25:125:31 | tainted | Capture.cs:168:25:168:31 | access to parameter tainted |
+| Capture.cs:125:25:125:31 | tainted | Capture.cs:168:25:168:31 | access to parameter tainted |
+| Capture.cs:125:25:125:31 | tainted | Capture.cs:168:25:168:31 | access to parameter tainted |
+| Capture.cs:125:25:125:31 | tainted | Capture.cs:168:25:168:31 | access to parameter tainted |
+| Capture.cs:125:25:125:31 | tainted | Capture.cs:194:25:194:31 | access to parameter tainted |
+| Capture.cs:125:25:125:31 | tainted | Capture.cs:194:25:194:31 | access to parameter tainted |
+| Capture.cs:125:25:125:31 | tainted | Capture.cs:194:25:194:31 | access to parameter tainted |
+| Capture.cs:125:25:125:31 | tainted | Capture.cs:194:25:194:31 | access to parameter tainted |
+| Capture.cs:127:16:127:26 | SSA def(sink33) | Capture.cs:127:16:127:26 | SSA def(sink33) |
+| Capture.cs:127:16:127:26 | String sink33 = ... | Capture.cs:127:16:127:26 | String sink33 = ... |
+| Capture.cs:127:25:127:26 | "" | Capture.cs:127:16:127:26 | SSA def(sink33) |
+| Capture.cs:127:25:127:26 | "" | Capture.cs:127:16:127:26 | SSA def(sink33) |
+| Capture.cs:127:25:127:26 | "" | Capture.cs:127:25:127:26 | "" |
+| Capture.cs:128:9:131:9 | SSA capture def(tainted) | Capture.cs:128:9:131:9 | SSA capture def(tainted) |
+| Capture.cs:128:9:131:9 | SSA capture def(tainted) | Capture.cs:130:13:130:28 | SSA def(sink33) |
+| Capture.cs:128:9:131:9 | SSA capture def(tainted) | Capture.cs:130:13:130:28 | SSA def(sink33) |
+| Capture.cs:128:9:131:9 | SSA capture def(tainted) | Capture.cs:130:13:130:28 | SSA def(sink33) |
+| Capture.cs:128:9:131:9 | SSA capture def(tainted) | Capture.cs:130:13:130:28 | SSA def(sink33) |
+| Capture.cs:128:9:131:9 | SSA capture def(tainted) | Capture.cs:130:22:130:28 | access to parameter tainted |
+| Capture.cs:128:9:131:9 | SSA capture def(tainted) | Capture.cs:130:22:130:28 | access to parameter tainted |
+| Capture.cs:128:9:131:9 | SSA capture def(tainted) | Capture.cs:130:22:130:28 | access to parameter tainted |
+| Capture.cs:128:9:131:9 | SSA capture def(tainted) | Capture.cs:130:22:130:28 | access to parameter tainted |
+| Capture.cs:130:13:130:28 | ... = ... | Capture.cs:130:13:130:28 | ... = ... |
+| Capture.cs:130:13:130:28 | SSA def(sink33) | Capture.cs:130:13:130:28 | SSA def(sink33) |
+| Capture.cs:130:13:130:28 | SSA def(sink33) | Capture.cs:132:9:132:25 | SSA call def(sink33) |
+| Capture.cs:130:13:130:28 | SSA def(sink33) | Capture.cs:132:9:132:25 | SSA call def(sink33) |
+| Capture.cs:130:22:130:28 | access to parameter tainted | Capture.cs:130:13:130:28 | SSA def(sink33) |
+| Capture.cs:130:22:130:28 | access to parameter tainted | Capture.cs:130:13:130:28 | SSA def(sink33) |
+| Capture.cs:130:22:130:28 | access to parameter tainted | Capture.cs:130:13:130:28 | SSA def(sink33) |
+| Capture.cs:130:22:130:28 | access to parameter tainted | Capture.cs:130:13:130:28 | SSA def(sink33) |
+| Capture.cs:130:22:130:28 | access to parameter tainted | Capture.cs:130:22:130:28 | access to parameter tainted |
+| Capture.cs:132:9:132:23 | access to local function CaptureThrough1 | Capture.cs:132:9:132:23 | access to local function CaptureThrough1 |
+| Capture.cs:132:9:132:25 | SSA call def(sink33) | Capture.cs:132:9:132:25 | SSA call def(sink33) |
+| Capture.cs:132:9:132:25 | SSA call def(sink33) | Capture.cs:133:15:133:20 | access to local variable sink33 |
+| Capture.cs:132:9:132:25 | SSA call def(sink33) | Capture.cs:133:15:133:20 | access to local variable sink33 |
+| Capture.cs:132:9:132:25 | [implicit argument] tainted | Capture.cs:128:9:131:9 | SSA capture def(tainted) |
+| Capture.cs:132:9:132:25 | [implicit argument] tainted | Capture.cs:128:9:131:9 | SSA capture def(tainted) |
+| Capture.cs:132:9:132:25 | [implicit argument] tainted | Capture.cs:132:9:132:25 | SSA call def(sink33) |
+| Capture.cs:132:9:132:25 | [implicit argument] tainted | Capture.cs:132:9:132:25 | SSA call def(sink33) |
 | Capture.cs:132:9:132:25 | [implicit argument] tainted | Capture.cs:132:9:132:25 | [implicit argument] tainted |
-| Capture.cs:132:9:132:25 | call to local function CaptureThrough2 | Capture.cs:132:9:132:25 | call to local function CaptureThrough2 |
+| Capture.cs:132:9:132:25 | call to local function CaptureThrough1 | Capture.cs:132:9:132:25 | call to local function CaptureThrough1 |
 | Capture.cs:133:9:133:21 | call to method Check | Capture.cs:133:9:133:21 | call to method Check |
-| Capture.cs:133:15:133:20 | access to local variable sink34 | Capture.cs:133:15:133:20 | access to local variable sink34 |
-| Capture.cs:135:16:135:26 | SSA def(sink35) | Capture.cs:135:16:135:26 | SSA def(sink35) |
-| Capture.cs:135:16:135:26 | String sink35 = ... | Capture.cs:135:16:135:26 | String sink35 = ... |
-| Capture.cs:135:25:135:26 | "" | Capture.cs:135:16:135:26 | SSA def(sink35) |
-| Capture.cs:135:25:135:26 | "" | Capture.cs:135:16:135:26 | SSA def(sink35) |
+| Capture.cs:133:15:133:20 | access to local variable sink33 | Capture.cs:133:15:133:20 | access to local variable sink33 |
+| Capture.cs:135:16:135:26 | SSA def(sink34) | Capture.cs:135:16:135:26 | SSA def(sink34) |
+| Capture.cs:135:16:135:26 | String sink34 = ... | Capture.cs:135:16:135:26 | String sink34 = ... |
+| Capture.cs:135:25:135:26 | "" | Capture.cs:135:16:135:26 | SSA def(sink34) |
+| Capture.cs:135:25:135:26 | "" | Capture.cs:135:16:135:26 | SSA def(sink34) |
 | Capture.cs:135:25:135:26 | "" | Capture.cs:135:25:135:26 | "" |
-| Capture.cs:136:30:140:9 | Func<String,String> captureThrough3 = ... | Capture.cs:136:30:140:9 | Func<String,String> captureThrough3 = ... |
-| Capture.cs:136:30:140:9 | SSA def(captureThrough3) | Capture.cs:136:30:140:9 | SSA def(captureThrough3) |
-| Capture.cs:136:30:140:9 | SSA def(captureThrough3) | Capture.cs:141:30:141:44 | access to local variable captureThrough3 |
-| Capture.cs:136:30:140:9 | SSA def(captureThrough3) | Capture.cs:141:30:141:44 | access to local variable captureThrough3 |
-| Capture.cs:136:48:136:50 | arg | Capture.cs:136:48:136:50 | arg |
-| Capture.cs:136:48:136:50 | arg | Capture.cs:136:48:136:50 | arg |
-| Capture.cs:136:48:136:50 | arg | Capture.cs:136:48:136:50 | arg |
-| Capture.cs:136:48:136:50 | arg | Capture.cs:136:48:136:50 | arg |
-| Capture.cs:136:48:136:50 | arg | Capture.cs:136:48:136:50 | arg |
-| Capture.cs:136:48:136:50 | arg | Capture.cs:136:48:136:50 | arg |
-| Capture.cs:136:48:136:50 | arg | Capture.cs:139:20:139:22 | access to parameter arg |
-| Capture.cs:136:48:136:50 | arg | Capture.cs:139:20:139:22 | access to parameter arg |
-| Capture.cs:136:48:136:50 | arg | Capture.cs:139:20:139:22 | access to parameter arg |
-| Capture.cs:136:48:136:50 | arg | Capture.cs:139:20:139:22 | access to parameter arg |
-| Capture.cs:136:48:136:50 | arg | Capture.cs:139:20:139:22 | access to parameter arg |
-| Capture.cs:136:48:136:50 | arg | Capture.cs:139:20:139:22 | access to parameter arg |
-| Capture.cs:136:48:136:50 | arg | Capture.cs:139:20:139:22 | access to parameter arg |
-| Capture.cs:136:48:136:50 | arg | Capture.cs:139:20:139:22 | access to parameter arg |
-| Capture.cs:136:48:140:9 | (...) => ... | Capture.cs:136:30:140:9 | SSA def(captureThrough3) |
-| Capture.cs:136:48:140:9 | (...) => ... | Capture.cs:136:30:140:9 | SSA def(captureThrough3) |
-| Capture.cs:136:48:140:9 | (...) => ... | Capture.cs:136:48:140:9 | (...) => ... |
-| Capture.cs:136:48:140:9 | (...) => ... | Capture.cs:141:30:141:44 | access to local variable captureThrough3 |
-| Capture.cs:136:48:140:9 | (...) => ... | Capture.cs:141:30:141:44 | access to local variable captureThrough3 |
-| Capture.cs:136:48:140:9 | SSA capture def(tainted) | Capture.cs:136:48:140:9 | SSA capture def(tainted) |
-| Capture.cs:136:48:140:9 | SSA capture def(tainted) | Capture.cs:138:13:138:28 | SSA def(sink35) |
-| Capture.cs:136:48:140:9 | SSA capture def(tainted) | Capture.cs:138:13:138:28 | SSA def(sink35) |
-| Capture.cs:136:48:140:9 | SSA capture def(tainted) | Capture.cs:138:13:138:28 | SSA def(sink35) |
-| Capture.cs:136:48:140:9 | SSA capture def(tainted) | Capture.cs:138:13:138:28 | SSA def(sink35) |
-| Capture.cs:136:48:140:9 | SSA capture def(tainted) | Capture.cs:138:22:138:28 | access to parameter tainted |
-| Capture.cs:136:48:140:9 | SSA capture def(tainted) | Capture.cs:138:22:138:28 | access to parameter tainted |
-| Capture.cs:136:48:140:9 | SSA capture def(tainted) | Capture.cs:138:22:138:28 | access to parameter tainted |
-| Capture.cs:136:48:140:9 | SSA capture def(tainted) | Capture.cs:138:22:138:28 | access to parameter tainted |
-| Capture.cs:138:13:138:28 | ... = ... | Capture.cs:138:13:138:28 | ... = ... |
-| Capture.cs:138:13:138:28 | SSA def(sink35) | Capture.cs:138:13:138:28 | SSA def(sink35) |
-| Capture.cs:138:13:138:28 | SSA def(sink35) | Capture.cs:141:9:141:45 | SSA call def(sink35) |
-| Capture.cs:138:13:138:28 | SSA def(sink35) | Capture.cs:141:9:141:45 | SSA call def(sink35) |
-| Capture.cs:138:22:138:28 | access to parameter tainted | Capture.cs:138:13:138:28 | SSA def(sink35) |
-| Capture.cs:138:22:138:28 | access to parameter tainted | Capture.cs:138:13:138:28 | SSA def(sink35) |
-| Capture.cs:138:22:138:28 | access to parameter tainted | Capture.cs:138:13:138:28 | SSA def(sink35) |
-| Capture.cs:138:22:138:28 | access to parameter tainted | Capture.cs:138:13:138:28 | SSA def(sink35) |
-| Capture.cs:138:22:138:28 | access to parameter tainted | Capture.cs:138:22:138:28 | access to parameter tainted |
-| Capture.cs:139:20:139:22 | access to parameter arg | Capture.cs:139:20:139:22 | access to parameter arg |
-| Capture.cs:139:20:139:22 | access to parameter arg | Capture.cs:141:30:141:44 | [output] access to local variable captureThrough3 |
-| Capture.cs:139:20:139:22 | access to parameter arg | Capture.cs:141:30:141:44 | [output] access to local variable captureThrough3 |
-| Capture.cs:141:9:141:21 | array creation of type String[] | Capture.cs:136:48:136:50 | arg |
-| Capture.cs:141:9:141:21 | array creation of type String[] | Capture.cs:136:48:136:50 | arg |
-| Capture.cs:141:9:141:21 | array creation of type String[] | Capture.cs:141:9:141:21 | array creation of type String[] |
-| Capture.cs:141:9:141:21 | array creation of type String[] | Capture.cs:141:30:141:44 | [output] access to local variable captureThrough3 |
-| Capture.cs:141:9:141:21 | array creation of type String[] | Capture.cs:141:30:141:44 | [output] access to local variable captureThrough3 |
-| Capture.cs:141:9:141:45 | SSA call def(sink35) | Capture.cs:141:9:141:45 | SSA call def(sink35) |
-| Capture.cs:141:9:141:45 | SSA call def(sink35) | Capture.cs:142:15:142:20 | access to local variable sink35 |
-| Capture.cs:141:9:141:45 | SSA call def(sink35) | Capture.cs:142:15:142:20 | access to local variable sink35 |
-| Capture.cs:141:9:141:45 | [implicit argument] tainted | Capture.cs:136:48:140:9 | SSA capture def(tainted) |
-| Capture.cs:141:9:141:45 | [implicit argument] tainted | Capture.cs:136:48:140:9 | SSA capture def(tainted) |
-| Capture.cs:141:9:141:45 | [implicit argument] tainted | Capture.cs:141:9:141:45 | SSA call def(sink35) |
-| Capture.cs:141:9:141:45 | [implicit argument] tainted | Capture.cs:141:9:141:45 | SSA call def(sink35) |
-| Capture.cs:141:9:141:45 | [implicit argument] tainted | Capture.cs:141:9:141:45 | [implicit argument] tainted |
-| Capture.cs:141:9:141:45 | call to method Select | Capture.cs:141:9:141:45 | call to method Select |
-| Capture.cs:141:9:141:45 | call to method Select | Capture.cs:141:9:141:55 | call to method ToArray |
-| Capture.cs:141:9:141:45 | call to method Select | Capture.cs:141:9:141:55 | call to method ToArray |
-| Capture.cs:141:9:141:55 | call to method ToArray | Capture.cs:141:9:141:55 | call to method ToArray |
-| Capture.cs:141:15:141:21 | { ..., ... } | Capture.cs:141:15:141:21 | { ..., ... } |
-| Capture.cs:141:17:141:19 | " " | Capture.cs:141:9:141:21 | array creation of type String[] |
-| Capture.cs:141:17:141:19 | " " | Capture.cs:141:9:141:21 | array creation of type String[] |
-| Capture.cs:141:17:141:19 | " " | Capture.cs:141:17:141:19 | " " |
-| Capture.cs:141:30:141:44 | [output] access to local variable captureThrough3 | Capture.cs:141:9:141:45 | call to method Select |
-| Capture.cs:141:30:141:44 | [output] access to local variable captureThrough3 | Capture.cs:141:9:141:45 | call to method Select |
-| Capture.cs:141:30:141:44 | [output] access to local variable captureThrough3 | Capture.cs:141:9:141:55 | call to method ToArray |
-| Capture.cs:141:30:141:44 | [output] access to local variable captureThrough3 | Capture.cs:141:9:141:55 | call to method ToArray |
-| Capture.cs:141:30:141:44 | [output] access to local variable captureThrough3 | Capture.cs:141:30:141:44 | [output] access to local variable captureThrough3 |
-| Capture.cs:141:30:141:44 | access to local variable captureThrough3 | Capture.cs:141:30:141:44 | access to local variable captureThrough3 |
-| Capture.cs:142:9:142:21 | call to method Check | Capture.cs:142:9:142:21 | call to method Check |
-| Capture.cs:142:15:142:20 | access to local variable sink35 | Capture.cs:142:15:142:20 | access to local variable sink35 |
-| Capture.cs:144:9:147:9 | SSA capture def(tainted) | Capture.cs:144:9:147:9 | SSA capture def(tainted) |
-| Capture.cs:144:9:147:9 | SSA capture def(tainted) | Capture.cs:146:20:146:26 | access to parameter tainted |
-| Capture.cs:144:9:147:9 | SSA capture def(tainted) | Capture.cs:146:20:146:26 | access to parameter tainted |
-| Capture.cs:144:9:147:9 | SSA capture def(tainted) | Capture.cs:146:20:146:26 | access to parameter tainted |
-| Capture.cs:144:9:147:9 | SSA capture def(tainted) | Capture.cs:146:20:146:26 | access to parameter tainted |
-| Capture.cs:146:20:146:26 | access to parameter tainted | Capture.cs:146:20:146:26 | access to parameter tainted |
-| Capture.cs:146:20:146:26 | access to parameter tainted | Capture.cs:148:22:148:38 | call to local function CaptureThrough4 |
-| Capture.cs:146:20:146:26 | access to parameter tainted | Capture.cs:148:22:148:38 | call to local function CaptureThrough4 |
-| Capture.cs:148:13:148:38 | SSA def(sink36) | Capture.cs:148:13:148:38 | SSA def(sink36) |
-| Capture.cs:148:13:148:38 | SSA def(sink36) | Capture.cs:149:15:149:20 | access to local variable sink36 |
-| Capture.cs:148:13:148:38 | SSA def(sink36) | Capture.cs:149:15:149:20 | access to local variable sink36 |
-| Capture.cs:148:13:148:38 | String sink36 = ... | Capture.cs:148:13:148:38 | String sink36 = ... |
-| Capture.cs:148:22:148:36 | access to local function CaptureThrough4 | Capture.cs:148:22:148:36 | access to local function CaptureThrough4 |
-| Capture.cs:148:22:148:38 | [implicit argument] tainted | Capture.cs:144:9:147:9 | SSA capture def(tainted) |
-| Capture.cs:148:22:148:38 | [implicit argument] tainted | Capture.cs:144:9:147:9 | SSA capture def(tainted) |
-| Capture.cs:148:22:148:38 | [implicit argument] tainted | Capture.cs:148:22:148:38 | [implicit argument] tainted |
-| Capture.cs:148:22:148:38 | [implicit argument] tainted | Capture.cs:148:22:148:38 | call to local function CaptureThrough4 |
-| Capture.cs:148:22:148:38 | [implicit argument] tainted | Capture.cs:148:22:148:38 | call to local function CaptureThrough4 |
-| Capture.cs:148:22:148:38 | call to local function CaptureThrough4 | Capture.cs:148:13:148:38 | SSA def(sink36) |
-| Capture.cs:148:22:148:38 | call to local function CaptureThrough4 | Capture.cs:148:13:148:38 | SSA def(sink36) |
-| Capture.cs:148:22:148:38 | call to local function CaptureThrough4 | Capture.cs:148:22:148:38 | call to local function CaptureThrough4 |
-| Capture.cs:148:22:148:38 | call to local function CaptureThrough4 | Capture.cs:149:15:149:20 | access to local variable sink36 |
-| Capture.cs:148:22:148:38 | call to local function CaptureThrough4 | Capture.cs:149:15:149:20 | access to local variable sink36 |
-| Capture.cs:149:9:149:21 | call to method Check | Capture.cs:149:9:149:21 | call to method Check |
-| Capture.cs:149:15:149:20 | access to local variable sink36 | Capture.cs:149:15:149:20 | access to local variable sink36 |
-| Capture.cs:151:13:151:23 | SSA def(sink37) | Capture.cs:151:13:151:23 | SSA def(sink37) |
-| Capture.cs:151:13:151:23 | String sink37 = ... | Capture.cs:151:13:151:23 | String sink37 = ... |
-| Capture.cs:151:22:151:23 | "" | Capture.cs:151:13:151:23 | SSA def(sink37) |
-| Capture.cs:151:22:151:23 | "" | Capture.cs:151:13:151:23 | SSA def(sink37) |
-| Capture.cs:151:22:151:23 | "" | Capture.cs:151:22:151:23 | "" |
-| Capture.cs:152:37:152:37 | p | Capture.cs:152:37:152:37 | p |
-| Capture.cs:152:37:152:37 | p | Capture.cs:152:37:152:37 | p |
-| Capture.cs:152:37:152:37 | p | Capture.cs:152:37:152:37 | p |
-| Capture.cs:152:37:152:37 | p | Capture.cs:152:37:152:37 | p |
-| Capture.cs:152:37:152:37 | p | Capture.cs:154:13:154:22 | SSA def(sink37) |
-| Capture.cs:152:37:152:37 | p | Capture.cs:154:13:154:22 | SSA def(sink37) |
-| Capture.cs:152:37:152:37 | p | Capture.cs:154:13:154:22 | SSA def(sink37) |
-| Capture.cs:152:37:152:37 | p | Capture.cs:154:13:154:22 | SSA def(sink37) |
-| Capture.cs:152:37:152:37 | p | Capture.cs:154:13:154:22 | SSA def(sink37) |
-| Capture.cs:152:37:152:37 | p | Capture.cs:154:13:154:22 | SSA def(sink37) |
-| Capture.cs:152:37:152:37 | p | Capture.cs:154:22:154:22 | access to parameter p |
-| Capture.cs:152:37:152:37 | p | Capture.cs:154:22:154:22 | access to parameter p |
-| Capture.cs:152:37:152:37 | p | Capture.cs:154:22:154:22 | access to parameter p |
-| Capture.cs:152:37:152:37 | p | Capture.cs:154:22:154:22 | access to parameter p |
-| Capture.cs:152:37:152:37 | p | Capture.cs:154:22:154:22 | access to parameter p |
-| Capture.cs:152:37:152:37 | p | Capture.cs:154:22:154:22 | access to parameter p |
-| Capture.cs:154:13:154:22 | ... = ... | Capture.cs:154:13:154:22 | ... = ... |
-| Capture.cs:154:13:154:22 | SSA def(sink37) | Capture.cs:154:13:154:22 | SSA def(sink37) |
-| Capture.cs:154:13:154:22 | SSA def(sink37) | Capture.cs:156:9:156:32 | SSA call def(sink37) |
-| Capture.cs:154:13:154:22 | SSA def(sink37) | Capture.cs:156:9:156:32 | SSA call def(sink37) |
-| Capture.cs:154:22:154:22 | access to parameter p | Capture.cs:154:13:154:22 | SSA def(sink37) |
-| Capture.cs:154:22:154:22 | access to parameter p | Capture.cs:154:13:154:22 | SSA def(sink37) |
-| Capture.cs:154:22:154:22 | access to parameter p | Capture.cs:154:13:154:22 | SSA def(sink37) |
-| Capture.cs:154:22:154:22 | access to parameter p | Capture.cs:154:13:154:22 | SSA def(sink37) |
-| Capture.cs:154:22:154:22 | access to parameter p | Capture.cs:154:22:154:22 | access to parameter p |
-| Capture.cs:156:9:156:23 | access to local function CaptureThrough5 | Capture.cs:156:9:156:23 | access to local function CaptureThrough5 |
-| Capture.cs:156:9:156:32 | SSA call def(sink37) | Capture.cs:156:9:156:32 | SSA call def(sink37) |
-| Capture.cs:156:9:156:32 | SSA call def(sink37) | Capture.cs:157:15:157:20 | access to local variable sink37 |
-| Capture.cs:156:9:156:32 | SSA call def(sink37) | Capture.cs:157:15:157:20 | access to local variable sink37 |
-| Capture.cs:156:9:156:32 | call to local function CaptureThrough5 | Capture.cs:156:9:156:32 | call to local function CaptureThrough5 |
-| Capture.cs:156:25:156:31 | access to parameter tainted | Capture.cs:152:37:152:37 | p |
-| Capture.cs:156:25:156:31 | access to parameter tainted | Capture.cs:152:37:152:37 | p |
-| Capture.cs:156:25:156:31 | access to parameter tainted | Capture.cs:156:9:156:32 | SSA call def(sink37) |
-| Capture.cs:156:25:156:31 | access to parameter tainted | Capture.cs:156:9:156:32 | SSA call def(sink37) |
-| Capture.cs:156:25:156:31 | access to parameter tainted | Capture.cs:156:25:156:31 | access to parameter tainted |
-| Capture.cs:156:25:156:31 | access to parameter tainted | Capture.cs:182:25:182:31 | access to parameter tainted |
-| Capture.cs:156:25:156:31 | access to parameter tainted | Capture.cs:182:25:182:31 | access to parameter tainted |
-| Capture.cs:157:9:157:21 | call to method Check | Capture.cs:157:9:157:21 | call to method Check |
-| Capture.cs:157:15:157:20 | access to local variable sink37 | Capture.cs:157:15:157:20 | access to local variable sink37 |
-| Capture.cs:159:16:159:28 | SSA def(nonSink0) | Capture.cs:159:16:159:28 | SSA def(nonSink0) |
-| Capture.cs:159:16:159:28 | SSA def(nonSink0) | Capture.cs:164:15:164:22 | access to local variable nonSink0 |
-| Capture.cs:159:16:159:28 | SSA def(nonSink0) | Capture.cs:164:15:164:22 | access to local variable nonSink0 |
-| Capture.cs:159:16:159:28 | SSA def(nonSink0) | Capture.cs:174:15:174:22 | access to local variable nonSink0 |
-| Capture.cs:159:16:159:28 | SSA def(nonSink0) | Capture.cs:174:15:174:22 | access to local variable nonSink0 |
-| Capture.cs:159:16:159:28 | String nonSink0 = ... | Capture.cs:159:16:159:28 | String nonSink0 = ... |
-| Capture.cs:159:27:159:28 | "" | Capture.cs:159:16:159:28 | SSA def(nonSink0) |
-| Capture.cs:159:27:159:28 | "" | Capture.cs:159:16:159:28 | SSA def(nonSink0) |
-| Capture.cs:159:27:159:28 | "" | Capture.cs:159:27:159:28 | "" |
-| Capture.cs:159:27:159:28 | "" | Capture.cs:164:15:164:22 | access to local variable nonSink0 |
-| Capture.cs:159:27:159:28 | "" | Capture.cs:164:15:164:22 | access to local variable nonSink0 |
-| Capture.cs:159:27:159:28 | "" | Capture.cs:174:15:174:22 | access to local variable nonSink0 |
-| Capture.cs:159:27:159:28 | "" | Capture.cs:174:15:174:22 | access to local variable nonSink0 |
-| Capture.cs:160:9:163:9 | SSA capture def(tainted) | Capture.cs:160:9:163:9 | SSA capture def(tainted) |
-| Capture.cs:160:9:163:9 | SSA capture def(tainted) | Capture.cs:162:24:162:30 | access to parameter tainted |
-| Capture.cs:160:9:163:9 | SSA capture def(tainted) | Capture.cs:162:24:162:30 | access to parameter tainted |
-| Capture.cs:162:13:162:30 | ... = ... | Capture.cs:162:13:162:30 | ... = ... |
-| Capture.cs:162:24:162:30 | access to parameter tainted | Capture.cs:162:24:162:30 | access to parameter tainted |
-| Capture.cs:164:9:164:23 | call to method Check | Capture.cs:164:9:164:23 | call to method Check |
-| Capture.cs:164:15:164:22 | access to local variable nonSink0 | Capture.cs:164:15:164:22 | access to local variable nonSink0 |
-| Capture.cs:164:15:164:22 | access to local variable nonSink0 | Capture.cs:174:15:174:22 | access to local variable nonSink0 |
-| Capture.cs:164:15:164:22 | access to local variable nonSink0 | Capture.cs:174:15:174:22 | access to local variable nonSink0 |
-| Capture.cs:168:13:171:13 | SSA capture def(tainted) | Capture.cs:168:13:171:13 | SSA capture def(tainted) |
-| Capture.cs:168:13:171:13 | SSA capture def(tainted) | Capture.cs:170:28:170:34 | access to parameter tainted |
-| Capture.cs:168:13:171:13 | SSA capture def(tainted) | Capture.cs:170:28:170:34 | access to parameter tainted |
-| Capture.cs:170:17:170:34 | ... = ... | Capture.cs:170:17:170:34 | ... = ... |
-| Capture.cs:170:28:170:34 | access to parameter tainted | Capture.cs:170:28:170:34 | access to parameter tainted |
-| Capture.cs:173:9:173:32 | access to local function CaptureThrough2NotCalled | Capture.cs:173:9:173:32 | access to local function CaptureThrough2NotCalled |
-| Capture.cs:173:9:173:34 | call to local function CaptureThrough2NotCalled | Capture.cs:173:9:173:34 | call to local function CaptureThrough2NotCalled |
-| Capture.cs:174:9:174:23 | call to method Check | Capture.cs:174:9:174:23 | call to method Check |
-| Capture.cs:174:15:174:22 | access to local variable nonSink0 | Capture.cs:174:15:174:22 | access to local variable nonSink0 |
-| Capture.cs:176:26:176:26 | s | Capture.cs:176:26:176:26 | s |
-| Capture.cs:176:26:176:26 | s | Capture.cs:176:26:176:26 | s |
-| Capture.cs:176:26:176:26 | s | Capture.cs:176:26:176:26 | s |
-| Capture.cs:176:26:176:26 | s | Capture.cs:176:26:176:26 | s |
-| Capture.cs:176:26:176:26 | s | Capture.cs:179:20:179:22 | [implicit argument] s |
-| Capture.cs:176:26:176:26 | s | Capture.cs:179:20:179:22 | [implicit argument] s |
-| Capture.cs:176:26:176:26 | s | Capture.cs:179:20:179:22 | [implicit argument] s |
-| Capture.cs:176:26:176:26 | s | Capture.cs:179:20:179:22 | [implicit argument] s |
-| Capture.cs:176:26:176:26 | s | Capture.cs:179:20:179:22 | [implicit argument] s |
-| Capture.cs:176:26:176:26 | s | Capture.cs:179:20:179:22 | [implicit argument] s |
-| Capture.cs:178:13:178:28 | SSA capture def(s) | Capture.cs:178:13:178:28 | SSA capture def(s) |
-| Capture.cs:178:13:178:28 | SSA capture def(s) | Capture.cs:178:27:178:27 | access to parameter s |
-| Capture.cs:178:13:178:28 | SSA capture def(s) | Capture.cs:178:27:178:27 | access to parameter s |
-| Capture.cs:178:13:178:28 | SSA capture def(s) | Capture.cs:178:27:178:27 | access to parameter s |
-| Capture.cs:178:13:178:28 | SSA capture def(s) | Capture.cs:178:27:178:27 | access to parameter s |
-| Capture.cs:178:27:178:27 | access to parameter s | Capture.cs:178:27:178:27 | access to parameter s |
-| Capture.cs:178:27:178:27 | access to parameter s | Capture.cs:179:20:179:22 | call to local function M |
-| Capture.cs:178:27:178:27 | access to parameter s | Capture.cs:179:20:179:22 | call to local function M |
-| Capture.cs:179:20:179:20 | access to local function M | Capture.cs:179:20:179:20 | access to local function M |
-| Capture.cs:179:20:179:22 | [implicit argument] s | Capture.cs:178:13:178:28 | SSA capture def(s) |
-| Capture.cs:179:20:179:22 | [implicit argument] s | Capture.cs:178:13:178:28 | SSA capture def(s) |
-| Capture.cs:179:20:179:22 | [implicit argument] s | Capture.cs:178:13:178:28 | SSA capture def(s) |
-| Capture.cs:179:20:179:22 | [implicit argument] s | Capture.cs:178:13:178:28 | SSA capture def(s) |
-| Capture.cs:179:20:179:22 | [implicit argument] s | Capture.cs:179:20:179:22 | [implicit argument] s |
-| Capture.cs:179:20:179:22 | [implicit argument] s | Capture.cs:179:20:179:22 | call to local function M |
-| Capture.cs:179:20:179:22 | [implicit argument] s | Capture.cs:179:20:179:22 | call to local function M |
-| Capture.cs:179:20:179:22 | [implicit argument] s | Capture.cs:179:20:179:22 | call to local function M |
-| Capture.cs:179:20:179:22 | [implicit argument] s | Capture.cs:179:20:179:22 | call to local function M |
-| Capture.cs:179:20:179:22 | call to local function M | Capture.cs:179:20:179:22 | call to local function M |
-| Capture.cs:179:20:179:22 | call to local function M | Capture.cs:182:22:182:32 | call to local function Id |
-| Capture.cs:179:20:179:22 | call to local function M | Capture.cs:182:22:182:32 | call to local function Id |
-| Capture.cs:179:20:179:22 | call to local function M | Capture.cs:184:20:184:25 | call to local function Id |
-| Capture.cs:179:20:179:22 | call to local function M | Capture.cs:184:20:184:25 | call to local function Id |
-| Capture.cs:182:13:182:32 | SSA def(sink38) | Capture.cs:182:13:182:32 | SSA def(sink38) |
-| Capture.cs:182:13:182:32 | SSA def(sink38) | Capture.cs:183:15:183:20 | access to local variable sink38 |
-| Capture.cs:182:13:182:32 | SSA def(sink38) | Capture.cs:183:15:183:20 | access to local variable sink38 |
-| Capture.cs:182:13:182:32 | String sink38 = ... | Capture.cs:182:13:182:32 | String sink38 = ... |
-| Capture.cs:182:22:182:23 | access to local function Id | Capture.cs:182:22:182:23 | access to local function Id |
-| Capture.cs:182:22:182:32 | call to local function Id | Capture.cs:182:13:182:32 | SSA def(sink38) |
-| Capture.cs:182:22:182:32 | call to local function Id | Capture.cs:182:13:182:32 | SSA def(sink38) |
-| Capture.cs:182:22:182:32 | call to local function Id | Capture.cs:182:22:182:32 | call to local function Id |
-| Capture.cs:182:22:182:32 | call to local function Id | Capture.cs:183:15:183:20 | access to local variable sink38 |
-| Capture.cs:182:22:182:32 | call to local function Id | Capture.cs:183:15:183:20 | access to local variable sink38 |
-| Capture.cs:182:25:182:31 | access to parameter tainted | Capture.cs:176:26:176:26 | s |
-| Capture.cs:182:25:182:31 | access to parameter tainted | Capture.cs:176:26:176:26 | s |
-| Capture.cs:182:25:182:31 | access to parameter tainted | Capture.cs:182:22:182:32 | call to local function Id |
-| Capture.cs:182:25:182:31 | access to parameter tainted | Capture.cs:182:22:182:32 | call to local function Id |
-| Capture.cs:182:25:182:31 | access to parameter tainted | Capture.cs:182:25:182:31 | access to parameter tainted |
-| Capture.cs:183:9:183:21 | call to method Check | Capture.cs:183:9:183:21 | call to method Check |
-| Capture.cs:183:15:183:20 | access to local variable sink38 | Capture.cs:183:15:183:20 | access to local variable sink38 |
-| Capture.cs:184:9:184:25 | ... = ... | Capture.cs:184:9:184:25 | ... = ... |
-| Capture.cs:184:9:184:25 | SSA def(nonSink0) | Capture.cs:184:9:184:25 | SSA def(nonSink0) |
-| Capture.cs:184:9:184:25 | SSA def(nonSink0) | Capture.cs:185:15:185:22 | access to local variable nonSink0 |
-| Capture.cs:184:9:184:25 | SSA def(nonSink0) | Capture.cs:185:15:185:22 | access to local variable nonSink0 |
-| Capture.cs:184:20:184:21 | access to local function Id | Capture.cs:184:20:184:21 | access to local function Id |
-| Capture.cs:184:20:184:25 | call to local function Id | Capture.cs:184:9:184:25 | SSA def(nonSink0) |
-| Capture.cs:184:20:184:25 | call to local function Id | Capture.cs:184:9:184:25 | SSA def(nonSink0) |
-| Capture.cs:184:20:184:25 | call to local function Id | Capture.cs:184:20:184:25 | call to local function Id |
-| Capture.cs:184:20:184:25 | call to local function Id | Capture.cs:185:15:185:22 | access to local variable nonSink0 |
-| Capture.cs:184:20:184:25 | call to local function Id | Capture.cs:185:15:185:22 | access to local variable nonSink0 |
-| Capture.cs:184:23:184:24 | "" | Capture.cs:176:26:176:26 | s |
-| Capture.cs:184:23:184:24 | "" | Capture.cs:176:26:176:26 | s |
-| Capture.cs:184:23:184:24 | "" | Capture.cs:184:20:184:25 | call to local function Id |
-| Capture.cs:184:23:184:24 | "" | Capture.cs:184:20:184:25 | call to local function Id |
-| Capture.cs:184:23:184:24 | "" | Capture.cs:184:23:184:24 | "" |
-| Capture.cs:185:9:185:23 | call to method Check | Capture.cs:185:9:185:23 | call to method Check |
-| Capture.cs:185:15:185:22 | access to local variable nonSink0 | Capture.cs:185:15:185:22 | access to local variable nonSink0 |
-| Capture.cs:190:34:190:34 | a | Capture.cs:190:34:190:34 | a |
-| Capture.cs:190:34:190:34 | a | Capture.cs:190:34:190:34 | a |
-| Capture.cs:190:34:190:34 | a | Capture.cs:190:34:190:34 | a |
-| Capture.cs:190:34:190:34 | a | Capture.cs:190:34:190:34 | a |
-| Capture.cs:190:34:190:34 | a | Capture.cs:192:9:192:9 | access to parameter a |
-| Capture.cs:190:34:190:34 | a | Capture.cs:192:9:192:9 | access to parameter a |
-| Capture.cs:190:34:190:34 | a | Capture.cs:192:9:192:9 | access to parameter a |
-| Capture.cs:190:34:190:34 | a | Capture.cs:192:9:192:9 | access to parameter a |
-| Capture.cs:190:34:190:34 | a | Capture.cs:192:9:192:9 | access to parameter a |
-| Capture.cs:190:34:190:34 | a | Capture.cs:192:9:192:9 | access to parameter a |
-| Capture.cs:190:34:190:34 | a | Capture.cs:192:9:192:9 | access to parameter a |
-| Capture.cs:190:34:190:34 | a | Capture.cs:192:9:192:9 | access to parameter a |
-| Capture.cs:192:9:192:9 | access to parameter a | Capture.cs:192:9:192:9 | access to parameter a |
-| Capture.cs:192:9:192:18 | delegate call | Capture.cs:192:9:192:18 | delegate call |
+| Capture.cs:138:13:141:13 | SSA capture def(tainted) | Capture.cs:138:13:141:13 | SSA capture def(tainted) |
+| Capture.cs:138:13:141:13 | SSA capture def(tainted) | Capture.cs:140:17:140:32 | SSA def(sink34) |
+| Capture.cs:138:13:141:13 | SSA capture def(tainted) | Capture.cs:140:17:140:32 | SSA def(sink34) |
+| Capture.cs:138:13:141:13 | SSA capture def(tainted) | Capture.cs:140:17:140:32 | SSA def(sink34) |
+| Capture.cs:138:13:141:13 | SSA capture def(tainted) | Capture.cs:140:17:140:32 | SSA def(sink34) |
+| Capture.cs:138:13:141:13 | SSA capture def(tainted) | Capture.cs:140:26:140:32 | access to parameter tainted |
+| Capture.cs:138:13:141:13 | SSA capture def(tainted) | Capture.cs:140:26:140:32 | access to parameter tainted |
+| Capture.cs:138:13:141:13 | SSA capture def(tainted) | Capture.cs:140:26:140:32 | access to parameter tainted |
+| Capture.cs:138:13:141:13 | SSA capture def(tainted) | Capture.cs:140:26:140:32 | access to parameter tainted |
+| Capture.cs:140:17:140:32 | ... = ... | Capture.cs:140:17:140:32 | ... = ... |
+| Capture.cs:140:17:140:32 | SSA def(sink34) | Capture.cs:140:17:140:32 | SSA def(sink34) |
+| Capture.cs:140:17:140:32 | SSA def(sink34) | Capture.cs:144:9:144:25 | SSA call def(sink34) |
+| Capture.cs:140:17:140:32 | SSA def(sink34) | Capture.cs:144:9:144:25 | SSA call def(sink34) |
+| Capture.cs:140:26:140:32 | access to parameter tainted | Capture.cs:140:17:140:32 | SSA def(sink34) |
+| Capture.cs:140:26:140:32 | access to parameter tainted | Capture.cs:140:17:140:32 | SSA def(sink34) |
+| Capture.cs:140:26:140:32 | access to parameter tainted | Capture.cs:140:17:140:32 | SSA def(sink34) |
+| Capture.cs:140:26:140:32 | access to parameter tainted | Capture.cs:140:17:140:32 | SSA def(sink34) |
+| Capture.cs:140:26:140:32 | access to parameter tainted | Capture.cs:140:26:140:32 | access to parameter tainted |
+| Capture.cs:142:13:142:13 | access to local function M | Capture.cs:142:13:142:13 | access to local function M |
+| Capture.cs:142:13:142:15 | call to local function M | Capture.cs:142:13:142:15 | call to local function M |
+| Capture.cs:144:9:144:23 | access to local function CaptureThrough2 | Capture.cs:144:9:144:23 | access to local function CaptureThrough2 |
+| Capture.cs:144:9:144:25 | SSA call def(sink34) | Capture.cs:144:9:144:25 | SSA call def(sink34) |
+| Capture.cs:144:9:144:25 | SSA call def(sink34) | Capture.cs:145:15:145:20 | access to local variable sink34 |
+| Capture.cs:144:9:144:25 | SSA call def(sink34) | Capture.cs:145:15:145:20 | access to local variable sink34 |
+| Capture.cs:144:9:144:25 | [implicit argument] tainted | Capture.cs:138:13:141:13 | SSA capture def(tainted) |
+| Capture.cs:144:9:144:25 | [implicit argument] tainted | Capture.cs:138:13:141:13 | SSA capture def(tainted) |
+| Capture.cs:144:9:144:25 | [implicit argument] tainted | Capture.cs:144:9:144:25 | SSA call def(sink34) |
+| Capture.cs:144:9:144:25 | [implicit argument] tainted | Capture.cs:144:9:144:25 | SSA call def(sink34) |
+| Capture.cs:144:9:144:25 | [implicit argument] tainted | Capture.cs:144:9:144:25 | [implicit argument] tainted |
+| Capture.cs:144:9:144:25 | call to local function CaptureThrough2 | Capture.cs:144:9:144:25 | call to local function CaptureThrough2 |
+| Capture.cs:145:9:145:21 | call to method Check | Capture.cs:145:9:145:21 | call to method Check |
+| Capture.cs:145:15:145:20 | access to local variable sink34 | Capture.cs:145:15:145:20 | access to local variable sink34 |
+| Capture.cs:147:16:147:26 | SSA def(sink35) | Capture.cs:147:16:147:26 | SSA def(sink35) |
+| Capture.cs:147:16:147:26 | String sink35 = ... | Capture.cs:147:16:147:26 | String sink35 = ... |
+| Capture.cs:147:25:147:26 | "" | Capture.cs:147:16:147:26 | SSA def(sink35) |
+| Capture.cs:147:25:147:26 | "" | Capture.cs:147:16:147:26 | SSA def(sink35) |
+| Capture.cs:147:25:147:26 | "" | Capture.cs:147:25:147:26 | "" |
+| Capture.cs:148:30:152:9 | Func<String,String> captureThrough3 = ... | Capture.cs:148:30:152:9 | Func<String,String> captureThrough3 = ... |
+| Capture.cs:148:30:152:9 | SSA def(captureThrough3) | Capture.cs:148:30:152:9 | SSA def(captureThrough3) |
+| Capture.cs:148:30:152:9 | SSA def(captureThrough3) | Capture.cs:153:30:153:44 | access to local variable captureThrough3 |
+| Capture.cs:148:30:152:9 | SSA def(captureThrough3) | Capture.cs:153:30:153:44 | access to local variable captureThrough3 |
+| Capture.cs:148:48:148:50 | arg | Capture.cs:148:48:148:50 | arg |
+| Capture.cs:148:48:148:50 | arg | Capture.cs:148:48:148:50 | arg |
+| Capture.cs:148:48:148:50 | arg | Capture.cs:148:48:148:50 | arg |
+| Capture.cs:148:48:148:50 | arg | Capture.cs:148:48:148:50 | arg |
+| Capture.cs:148:48:148:50 | arg | Capture.cs:148:48:148:50 | arg |
+| Capture.cs:148:48:148:50 | arg | Capture.cs:148:48:148:50 | arg |
+| Capture.cs:148:48:148:50 | arg | Capture.cs:151:20:151:22 | access to parameter arg |
+| Capture.cs:148:48:148:50 | arg | Capture.cs:151:20:151:22 | access to parameter arg |
+| Capture.cs:148:48:148:50 | arg | Capture.cs:151:20:151:22 | access to parameter arg |
+| Capture.cs:148:48:148:50 | arg | Capture.cs:151:20:151:22 | access to parameter arg |
+| Capture.cs:148:48:148:50 | arg | Capture.cs:151:20:151:22 | access to parameter arg |
+| Capture.cs:148:48:148:50 | arg | Capture.cs:151:20:151:22 | access to parameter arg |
+| Capture.cs:148:48:148:50 | arg | Capture.cs:151:20:151:22 | access to parameter arg |
+| Capture.cs:148:48:148:50 | arg | Capture.cs:151:20:151:22 | access to parameter arg |
+| Capture.cs:148:48:152:9 | (...) => ... | Capture.cs:148:30:152:9 | SSA def(captureThrough3) |
+| Capture.cs:148:48:152:9 | (...) => ... | Capture.cs:148:30:152:9 | SSA def(captureThrough3) |
+| Capture.cs:148:48:152:9 | (...) => ... | Capture.cs:148:48:152:9 | (...) => ... |
+| Capture.cs:148:48:152:9 | (...) => ... | Capture.cs:153:30:153:44 | access to local variable captureThrough3 |
+| Capture.cs:148:48:152:9 | (...) => ... | Capture.cs:153:30:153:44 | access to local variable captureThrough3 |
+| Capture.cs:148:48:152:9 | SSA capture def(tainted) | Capture.cs:148:48:152:9 | SSA capture def(tainted) |
+| Capture.cs:148:48:152:9 | SSA capture def(tainted) | Capture.cs:150:13:150:28 | SSA def(sink35) |
+| Capture.cs:148:48:152:9 | SSA capture def(tainted) | Capture.cs:150:13:150:28 | SSA def(sink35) |
+| Capture.cs:148:48:152:9 | SSA capture def(tainted) | Capture.cs:150:13:150:28 | SSA def(sink35) |
+| Capture.cs:148:48:152:9 | SSA capture def(tainted) | Capture.cs:150:13:150:28 | SSA def(sink35) |
+| Capture.cs:148:48:152:9 | SSA capture def(tainted) | Capture.cs:150:22:150:28 | access to parameter tainted |
+| Capture.cs:148:48:152:9 | SSA capture def(tainted) | Capture.cs:150:22:150:28 | access to parameter tainted |
+| Capture.cs:148:48:152:9 | SSA capture def(tainted) | Capture.cs:150:22:150:28 | access to parameter tainted |
+| Capture.cs:148:48:152:9 | SSA capture def(tainted) | Capture.cs:150:22:150:28 | access to parameter tainted |
+| Capture.cs:150:13:150:28 | ... = ... | Capture.cs:150:13:150:28 | ... = ... |
+| Capture.cs:150:13:150:28 | SSA def(sink35) | Capture.cs:150:13:150:28 | SSA def(sink35) |
+| Capture.cs:150:13:150:28 | SSA def(sink35) | Capture.cs:153:9:153:45 | SSA call def(sink35) |
+| Capture.cs:150:13:150:28 | SSA def(sink35) | Capture.cs:153:9:153:45 | SSA call def(sink35) |
+| Capture.cs:150:22:150:28 | access to parameter tainted | Capture.cs:150:13:150:28 | SSA def(sink35) |
+| Capture.cs:150:22:150:28 | access to parameter tainted | Capture.cs:150:13:150:28 | SSA def(sink35) |
+| Capture.cs:150:22:150:28 | access to parameter tainted | Capture.cs:150:13:150:28 | SSA def(sink35) |
+| Capture.cs:150:22:150:28 | access to parameter tainted | Capture.cs:150:13:150:28 | SSA def(sink35) |
+| Capture.cs:150:22:150:28 | access to parameter tainted | Capture.cs:150:22:150:28 | access to parameter tainted |
+| Capture.cs:151:20:151:22 | access to parameter arg | Capture.cs:151:20:151:22 | access to parameter arg |
+| Capture.cs:151:20:151:22 | access to parameter arg | Capture.cs:153:30:153:44 | [output] access to local variable captureThrough3 |
+| Capture.cs:151:20:151:22 | access to parameter arg | Capture.cs:153:30:153:44 | [output] access to local variable captureThrough3 |
+| Capture.cs:153:9:153:21 | array creation of type String[] | Capture.cs:148:48:148:50 | arg |
+| Capture.cs:153:9:153:21 | array creation of type String[] | Capture.cs:148:48:148:50 | arg |
+| Capture.cs:153:9:153:21 | array creation of type String[] | Capture.cs:153:9:153:21 | array creation of type String[] |
+| Capture.cs:153:9:153:21 | array creation of type String[] | Capture.cs:153:30:153:44 | [output] access to local variable captureThrough3 |
+| Capture.cs:153:9:153:21 | array creation of type String[] | Capture.cs:153:30:153:44 | [output] access to local variable captureThrough3 |
+| Capture.cs:153:9:153:45 | SSA call def(sink35) | Capture.cs:153:9:153:45 | SSA call def(sink35) |
+| Capture.cs:153:9:153:45 | SSA call def(sink35) | Capture.cs:154:15:154:20 | access to local variable sink35 |
+| Capture.cs:153:9:153:45 | SSA call def(sink35) | Capture.cs:154:15:154:20 | access to local variable sink35 |
+| Capture.cs:153:9:153:45 | [implicit argument] tainted | Capture.cs:148:48:152:9 | SSA capture def(tainted) |
+| Capture.cs:153:9:153:45 | [implicit argument] tainted | Capture.cs:148:48:152:9 | SSA capture def(tainted) |
+| Capture.cs:153:9:153:45 | [implicit argument] tainted | Capture.cs:153:9:153:45 | SSA call def(sink35) |
+| Capture.cs:153:9:153:45 | [implicit argument] tainted | Capture.cs:153:9:153:45 | SSA call def(sink35) |
+| Capture.cs:153:9:153:45 | [implicit argument] tainted | Capture.cs:153:9:153:45 | [implicit argument] tainted |
+| Capture.cs:153:9:153:45 | call to method Select | Capture.cs:153:9:153:45 | call to method Select |
+| Capture.cs:153:9:153:45 | call to method Select | Capture.cs:153:9:153:55 | call to method ToArray |
+| Capture.cs:153:9:153:45 | call to method Select | Capture.cs:153:9:153:55 | call to method ToArray |
+| Capture.cs:153:9:153:55 | call to method ToArray | Capture.cs:153:9:153:55 | call to method ToArray |
+| Capture.cs:153:15:153:21 | { ..., ... } | Capture.cs:153:15:153:21 | { ..., ... } |
+| Capture.cs:153:17:153:19 | " " | Capture.cs:153:9:153:21 | array creation of type String[] |
+| Capture.cs:153:17:153:19 | " " | Capture.cs:153:9:153:21 | array creation of type String[] |
+| Capture.cs:153:17:153:19 | " " | Capture.cs:153:17:153:19 | " " |
+| Capture.cs:153:30:153:44 | [output] access to local variable captureThrough3 | Capture.cs:153:9:153:45 | call to method Select |
+| Capture.cs:153:30:153:44 | [output] access to local variable captureThrough3 | Capture.cs:153:9:153:45 | call to method Select |
+| Capture.cs:153:30:153:44 | [output] access to local variable captureThrough3 | Capture.cs:153:9:153:55 | call to method ToArray |
+| Capture.cs:153:30:153:44 | [output] access to local variable captureThrough3 | Capture.cs:153:9:153:55 | call to method ToArray |
+| Capture.cs:153:30:153:44 | [output] access to local variable captureThrough3 | Capture.cs:153:30:153:44 | [output] access to local variable captureThrough3 |
+| Capture.cs:153:30:153:44 | access to local variable captureThrough3 | Capture.cs:153:30:153:44 | access to local variable captureThrough3 |
+| Capture.cs:154:9:154:21 | call to method Check | Capture.cs:154:9:154:21 | call to method Check |
+| Capture.cs:154:15:154:20 | access to local variable sink35 | Capture.cs:154:15:154:20 | access to local variable sink35 |
+| Capture.cs:156:9:159:9 | SSA capture def(tainted) | Capture.cs:156:9:159:9 | SSA capture def(tainted) |
+| Capture.cs:156:9:159:9 | SSA capture def(tainted) | Capture.cs:158:20:158:26 | access to parameter tainted |
+| Capture.cs:156:9:159:9 | SSA capture def(tainted) | Capture.cs:158:20:158:26 | access to parameter tainted |
+| Capture.cs:156:9:159:9 | SSA capture def(tainted) | Capture.cs:158:20:158:26 | access to parameter tainted |
+| Capture.cs:156:9:159:9 | SSA capture def(tainted) | Capture.cs:158:20:158:26 | access to parameter tainted |
+| Capture.cs:158:20:158:26 | access to parameter tainted | Capture.cs:158:20:158:26 | access to parameter tainted |
+| Capture.cs:158:20:158:26 | access to parameter tainted | Capture.cs:160:22:160:38 | call to local function CaptureThrough4 |
+| Capture.cs:158:20:158:26 | access to parameter tainted | Capture.cs:160:22:160:38 | call to local function CaptureThrough4 |
+| Capture.cs:160:13:160:38 | SSA def(sink36) | Capture.cs:160:13:160:38 | SSA def(sink36) |
+| Capture.cs:160:13:160:38 | SSA def(sink36) | Capture.cs:161:15:161:20 | access to local variable sink36 |
+| Capture.cs:160:13:160:38 | SSA def(sink36) | Capture.cs:161:15:161:20 | access to local variable sink36 |
+| Capture.cs:160:13:160:38 | String sink36 = ... | Capture.cs:160:13:160:38 | String sink36 = ... |
+| Capture.cs:160:22:160:36 | access to local function CaptureThrough4 | Capture.cs:160:22:160:36 | access to local function CaptureThrough4 |
+| Capture.cs:160:22:160:38 | [implicit argument] tainted | Capture.cs:156:9:159:9 | SSA capture def(tainted) |
+| Capture.cs:160:22:160:38 | [implicit argument] tainted | Capture.cs:156:9:159:9 | SSA capture def(tainted) |
+| Capture.cs:160:22:160:38 | [implicit argument] tainted | Capture.cs:160:22:160:38 | [implicit argument] tainted |
+| Capture.cs:160:22:160:38 | [implicit argument] tainted | Capture.cs:160:22:160:38 | call to local function CaptureThrough4 |
+| Capture.cs:160:22:160:38 | [implicit argument] tainted | Capture.cs:160:22:160:38 | call to local function CaptureThrough4 |
+| Capture.cs:160:22:160:38 | call to local function CaptureThrough4 | Capture.cs:160:13:160:38 | SSA def(sink36) |
+| Capture.cs:160:22:160:38 | call to local function CaptureThrough4 | Capture.cs:160:13:160:38 | SSA def(sink36) |
+| Capture.cs:160:22:160:38 | call to local function CaptureThrough4 | Capture.cs:160:22:160:38 | call to local function CaptureThrough4 |
+| Capture.cs:160:22:160:38 | call to local function CaptureThrough4 | Capture.cs:161:15:161:20 | access to local variable sink36 |
+| Capture.cs:160:22:160:38 | call to local function CaptureThrough4 | Capture.cs:161:15:161:20 | access to local variable sink36 |
+| Capture.cs:161:9:161:21 | call to method Check | Capture.cs:161:9:161:21 | call to method Check |
+| Capture.cs:161:15:161:20 | access to local variable sink36 | Capture.cs:161:15:161:20 | access to local variable sink36 |
+| Capture.cs:163:13:163:23 | SSA def(sink37) | Capture.cs:163:13:163:23 | SSA def(sink37) |
+| Capture.cs:163:13:163:23 | String sink37 = ... | Capture.cs:163:13:163:23 | String sink37 = ... |
+| Capture.cs:163:22:163:23 | "" | Capture.cs:163:13:163:23 | SSA def(sink37) |
+| Capture.cs:163:22:163:23 | "" | Capture.cs:163:13:163:23 | SSA def(sink37) |
+| Capture.cs:163:22:163:23 | "" | Capture.cs:163:22:163:23 | "" |
+| Capture.cs:164:37:164:37 | p | Capture.cs:164:37:164:37 | p |
+| Capture.cs:164:37:164:37 | p | Capture.cs:164:37:164:37 | p |
+| Capture.cs:164:37:164:37 | p | Capture.cs:164:37:164:37 | p |
+| Capture.cs:164:37:164:37 | p | Capture.cs:164:37:164:37 | p |
+| Capture.cs:164:37:164:37 | p | Capture.cs:166:13:166:22 | SSA def(sink37) |
+| Capture.cs:164:37:164:37 | p | Capture.cs:166:13:166:22 | SSA def(sink37) |
+| Capture.cs:164:37:164:37 | p | Capture.cs:166:13:166:22 | SSA def(sink37) |
+| Capture.cs:164:37:164:37 | p | Capture.cs:166:13:166:22 | SSA def(sink37) |
+| Capture.cs:164:37:164:37 | p | Capture.cs:166:13:166:22 | SSA def(sink37) |
+| Capture.cs:164:37:164:37 | p | Capture.cs:166:13:166:22 | SSA def(sink37) |
+| Capture.cs:164:37:164:37 | p | Capture.cs:166:22:166:22 | access to parameter p |
+| Capture.cs:164:37:164:37 | p | Capture.cs:166:22:166:22 | access to parameter p |
+| Capture.cs:164:37:164:37 | p | Capture.cs:166:22:166:22 | access to parameter p |
+| Capture.cs:164:37:164:37 | p | Capture.cs:166:22:166:22 | access to parameter p |
+| Capture.cs:164:37:164:37 | p | Capture.cs:166:22:166:22 | access to parameter p |
+| Capture.cs:164:37:164:37 | p | Capture.cs:166:22:166:22 | access to parameter p |
+| Capture.cs:166:13:166:22 | ... = ... | Capture.cs:166:13:166:22 | ... = ... |
+| Capture.cs:166:13:166:22 | SSA def(sink37) | Capture.cs:166:13:166:22 | SSA def(sink37) |
+| Capture.cs:166:13:166:22 | SSA def(sink37) | Capture.cs:168:9:168:32 | SSA call def(sink37) |
+| Capture.cs:166:13:166:22 | SSA def(sink37) | Capture.cs:168:9:168:32 | SSA call def(sink37) |
+| Capture.cs:166:22:166:22 | access to parameter p | Capture.cs:166:13:166:22 | SSA def(sink37) |
+| Capture.cs:166:22:166:22 | access to parameter p | Capture.cs:166:13:166:22 | SSA def(sink37) |
+| Capture.cs:166:22:166:22 | access to parameter p | Capture.cs:166:13:166:22 | SSA def(sink37) |
+| Capture.cs:166:22:166:22 | access to parameter p | Capture.cs:166:13:166:22 | SSA def(sink37) |
+| Capture.cs:166:22:166:22 | access to parameter p | Capture.cs:166:22:166:22 | access to parameter p |
+| Capture.cs:168:9:168:23 | access to local function CaptureThrough5 | Capture.cs:168:9:168:23 | access to local function CaptureThrough5 |
+| Capture.cs:168:9:168:32 | SSA call def(sink37) | Capture.cs:168:9:168:32 | SSA call def(sink37) |
+| Capture.cs:168:9:168:32 | SSA call def(sink37) | Capture.cs:169:15:169:20 | access to local variable sink37 |
+| Capture.cs:168:9:168:32 | SSA call def(sink37) | Capture.cs:169:15:169:20 | access to local variable sink37 |
+| Capture.cs:168:9:168:32 | call to local function CaptureThrough5 | Capture.cs:168:9:168:32 | call to local function CaptureThrough5 |
+| Capture.cs:168:25:168:31 | access to parameter tainted | Capture.cs:164:37:164:37 | p |
+| Capture.cs:168:25:168:31 | access to parameter tainted | Capture.cs:164:37:164:37 | p |
+| Capture.cs:168:25:168:31 | access to parameter tainted | Capture.cs:168:9:168:32 | SSA call def(sink37) |
+| Capture.cs:168:25:168:31 | access to parameter tainted | Capture.cs:168:9:168:32 | SSA call def(sink37) |
+| Capture.cs:168:25:168:31 | access to parameter tainted | Capture.cs:168:25:168:31 | access to parameter tainted |
+| Capture.cs:168:25:168:31 | access to parameter tainted | Capture.cs:194:25:194:31 | access to parameter tainted |
+| Capture.cs:168:25:168:31 | access to parameter tainted | Capture.cs:194:25:194:31 | access to parameter tainted |
+| Capture.cs:169:9:169:21 | call to method Check | Capture.cs:169:9:169:21 | call to method Check |
+| Capture.cs:169:15:169:20 | access to local variable sink37 | Capture.cs:169:15:169:20 | access to local variable sink37 |
+| Capture.cs:171:16:171:28 | SSA def(nonSink0) | Capture.cs:171:16:171:28 | SSA def(nonSink0) |
+| Capture.cs:171:16:171:28 | SSA def(nonSink0) | Capture.cs:176:15:176:22 | access to local variable nonSink0 |
+| Capture.cs:171:16:171:28 | SSA def(nonSink0) | Capture.cs:176:15:176:22 | access to local variable nonSink0 |
+| Capture.cs:171:16:171:28 | SSA def(nonSink0) | Capture.cs:186:15:186:22 | access to local variable nonSink0 |
+| Capture.cs:171:16:171:28 | SSA def(nonSink0) | Capture.cs:186:15:186:22 | access to local variable nonSink0 |
+| Capture.cs:171:16:171:28 | String nonSink0 = ... | Capture.cs:171:16:171:28 | String nonSink0 = ... |
+| Capture.cs:171:27:171:28 | "" | Capture.cs:171:16:171:28 | SSA def(nonSink0) |
+| Capture.cs:171:27:171:28 | "" | Capture.cs:171:16:171:28 | SSA def(nonSink0) |
+| Capture.cs:171:27:171:28 | "" | Capture.cs:171:27:171:28 | "" |
+| Capture.cs:171:27:171:28 | "" | Capture.cs:176:15:176:22 | access to local variable nonSink0 |
+| Capture.cs:171:27:171:28 | "" | Capture.cs:176:15:176:22 | access to local variable nonSink0 |
+| Capture.cs:171:27:171:28 | "" | Capture.cs:186:15:186:22 | access to local variable nonSink0 |
+| Capture.cs:171:27:171:28 | "" | Capture.cs:186:15:186:22 | access to local variable nonSink0 |
+| Capture.cs:172:9:175:9 | SSA capture def(tainted) | Capture.cs:172:9:175:9 | SSA capture def(tainted) |
+| Capture.cs:172:9:175:9 | SSA capture def(tainted) | Capture.cs:174:24:174:30 | access to parameter tainted |
+| Capture.cs:172:9:175:9 | SSA capture def(tainted) | Capture.cs:174:24:174:30 | access to parameter tainted |
+| Capture.cs:174:13:174:30 | ... = ... | Capture.cs:174:13:174:30 | ... = ... |
+| Capture.cs:174:24:174:30 | access to parameter tainted | Capture.cs:174:24:174:30 | access to parameter tainted |
+| Capture.cs:176:9:176:23 | call to method Check | Capture.cs:176:9:176:23 | call to method Check |
+| Capture.cs:176:15:176:22 | access to local variable nonSink0 | Capture.cs:176:15:176:22 | access to local variable nonSink0 |
+| Capture.cs:176:15:176:22 | access to local variable nonSink0 | Capture.cs:186:15:186:22 | access to local variable nonSink0 |
+| Capture.cs:176:15:176:22 | access to local variable nonSink0 | Capture.cs:186:15:186:22 | access to local variable nonSink0 |
+| Capture.cs:180:13:183:13 | SSA capture def(tainted) | Capture.cs:180:13:183:13 | SSA capture def(tainted) |
+| Capture.cs:180:13:183:13 | SSA capture def(tainted) | Capture.cs:182:28:182:34 | access to parameter tainted |
+| Capture.cs:180:13:183:13 | SSA capture def(tainted) | Capture.cs:182:28:182:34 | access to parameter tainted |
+| Capture.cs:182:17:182:34 | ... = ... | Capture.cs:182:17:182:34 | ... = ... |
+| Capture.cs:182:28:182:34 | access to parameter tainted | Capture.cs:182:28:182:34 | access to parameter tainted |
+| Capture.cs:185:9:185:32 | access to local function CaptureThrough2NotCalled | Capture.cs:185:9:185:32 | access to local function CaptureThrough2NotCalled |
+| Capture.cs:185:9:185:34 | call to local function CaptureThrough2NotCalled | Capture.cs:185:9:185:34 | call to local function CaptureThrough2NotCalled |
+| Capture.cs:186:9:186:23 | call to method Check | Capture.cs:186:9:186:23 | call to method Check |
+| Capture.cs:186:15:186:22 | access to local variable nonSink0 | Capture.cs:186:15:186:22 | access to local variable nonSink0 |
+| Capture.cs:188:26:188:26 | s | Capture.cs:188:26:188:26 | s |
+| Capture.cs:188:26:188:26 | s | Capture.cs:188:26:188:26 | s |
+| Capture.cs:188:26:188:26 | s | Capture.cs:188:26:188:26 | s |
+| Capture.cs:188:26:188:26 | s | Capture.cs:188:26:188:26 | s |
+| Capture.cs:188:26:188:26 | s | Capture.cs:191:20:191:22 | [implicit argument] s |
+| Capture.cs:188:26:188:26 | s | Capture.cs:191:20:191:22 | [implicit argument] s |
+| Capture.cs:188:26:188:26 | s | Capture.cs:191:20:191:22 | [implicit argument] s |
+| Capture.cs:188:26:188:26 | s | Capture.cs:191:20:191:22 | [implicit argument] s |
+| Capture.cs:188:26:188:26 | s | Capture.cs:191:20:191:22 | [implicit argument] s |
+| Capture.cs:188:26:188:26 | s | Capture.cs:191:20:191:22 | [implicit argument] s |
+| Capture.cs:190:13:190:28 | SSA capture def(s) | Capture.cs:190:13:190:28 | SSA capture def(s) |
+| Capture.cs:190:13:190:28 | SSA capture def(s) | Capture.cs:190:27:190:27 | access to parameter s |
+| Capture.cs:190:13:190:28 | SSA capture def(s) | Capture.cs:190:27:190:27 | access to parameter s |
+| Capture.cs:190:13:190:28 | SSA capture def(s) | Capture.cs:190:27:190:27 | access to parameter s |
+| Capture.cs:190:13:190:28 | SSA capture def(s) | Capture.cs:190:27:190:27 | access to parameter s |
+| Capture.cs:190:27:190:27 | access to parameter s | Capture.cs:190:27:190:27 | access to parameter s |
+| Capture.cs:190:27:190:27 | access to parameter s | Capture.cs:191:20:191:22 | call to local function M |
+| Capture.cs:190:27:190:27 | access to parameter s | Capture.cs:191:20:191:22 | call to local function M |
+| Capture.cs:191:20:191:20 | access to local function M | Capture.cs:191:20:191:20 | access to local function M |
+| Capture.cs:191:20:191:22 | [implicit argument] s | Capture.cs:190:13:190:28 | SSA capture def(s) |
+| Capture.cs:191:20:191:22 | [implicit argument] s | Capture.cs:190:13:190:28 | SSA capture def(s) |
+| Capture.cs:191:20:191:22 | [implicit argument] s | Capture.cs:190:13:190:28 | SSA capture def(s) |
+| Capture.cs:191:20:191:22 | [implicit argument] s | Capture.cs:190:13:190:28 | SSA capture def(s) |
+| Capture.cs:191:20:191:22 | [implicit argument] s | Capture.cs:191:20:191:22 | [implicit argument] s |
+| Capture.cs:191:20:191:22 | [implicit argument] s | Capture.cs:191:20:191:22 | call to local function M |
+| Capture.cs:191:20:191:22 | [implicit argument] s | Capture.cs:191:20:191:22 | call to local function M |
+| Capture.cs:191:20:191:22 | [implicit argument] s | Capture.cs:191:20:191:22 | call to local function M |
+| Capture.cs:191:20:191:22 | [implicit argument] s | Capture.cs:191:20:191:22 | call to local function M |
+| Capture.cs:191:20:191:22 | call to local function M | Capture.cs:191:20:191:22 | call to local function M |
+| Capture.cs:191:20:191:22 | call to local function M | Capture.cs:194:22:194:32 | call to local function Id |
+| Capture.cs:191:20:191:22 | call to local function M | Capture.cs:194:22:194:32 | call to local function Id |
+| Capture.cs:191:20:191:22 | call to local function M | Capture.cs:196:20:196:25 | call to local function Id |
+| Capture.cs:191:20:191:22 | call to local function M | Capture.cs:196:20:196:25 | call to local function Id |
+| Capture.cs:194:13:194:32 | SSA def(sink38) | Capture.cs:194:13:194:32 | SSA def(sink38) |
+| Capture.cs:194:13:194:32 | SSA def(sink38) | Capture.cs:195:15:195:20 | access to local variable sink38 |
+| Capture.cs:194:13:194:32 | SSA def(sink38) | Capture.cs:195:15:195:20 | access to local variable sink38 |
+| Capture.cs:194:13:194:32 | String sink38 = ... | Capture.cs:194:13:194:32 | String sink38 = ... |
+| Capture.cs:194:22:194:23 | access to local function Id | Capture.cs:194:22:194:23 | access to local function Id |
+| Capture.cs:194:22:194:32 | call to local function Id | Capture.cs:194:13:194:32 | SSA def(sink38) |
+| Capture.cs:194:22:194:32 | call to local function Id | Capture.cs:194:13:194:32 | SSA def(sink38) |
+| Capture.cs:194:22:194:32 | call to local function Id | Capture.cs:194:22:194:32 | call to local function Id |
+| Capture.cs:194:22:194:32 | call to local function Id | Capture.cs:195:15:195:20 | access to local variable sink38 |
+| Capture.cs:194:22:194:32 | call to local function Id | Capture.cs:195:15:195:20 | access to local variable sink38 |
+| Capture.cs:194:25:194:31 | access to parameter tainted | Capture.cs:188:26:188:26 | s |
+| Capture.cs:194:25:194:31 | access to parameter tainted | Capture.cs:188:26:188:26 | s |
+| Capture.cs:194:25:194:31 | access to parameter tainted | Capture.cs:194:22:194:32 | call to local function Id |
+| Capture.cs:194:25:194:31 | access to parameter tainted | Capture.cs:194:22:194:32 | call to local function Id |
+| Capture.cs:194:25:194:31 | access to parameter tainted | Capture.cs:194:25:194:31 | access to parameter tainted |
+| Capture.cs:195:9:195:21 | call to method Check | Capture.cs:195:9:195:21 | call to method Check |
+| Capture.cs:195:15:195:20 | access to local variable sink38 | Capture.cs:195:15:195:20 | access to local variable sink38 |
+| Capture.cs:196:9:196:25 | ... = ... | Capture.cs:196:9:196:25 | ... = ... |
+| Capture.cs:196:9:196:25 | SSA def(nonSink0) | Capture.cs:196:9:196:25 | SSA def(nonSink0) |
+| Capture.cs:196:9:196:25 | SSA def(nonSink0) | Capture.cs:197:15:197:22 | access to local variable nonSink0 |
+| Capture.cs:196:9:196:25 | SSA def(nonSink0) | Capture.cs:197:15:197:22 | access to local variable nonSink0 |
+| Capture.cs:196:20:196:21 | access to local function Id | Capture.cs:196:20:196:21 | access to local function Id |
+| Capture.cs:196:20:196:25 | call to local function Id | Capture.cs:196:9:196:25 | SSA def(nonSink0) |
+| Capture.cs:196:20:196:25 | call to local function Id | Capture.cs:196:9:196:25 | SSA def(nonSink0) |
+| Capture.cs:196:20:196:25 | call to local function Id | Capture.cs:196:20:196:25 | call to local function Id |
+| Capture.cs:196:20:196:25 | call to local function Id | Capture.cs:197:15:197:22 | access to local variable nonSink0 |
+| Capture.cs:196:20:196:25 | call to local function Id | Capture.cs:197:15:197:22 | access to local variable nonSink0 |
+| Capture.cs:196:23:196:24 | "" | Capture.cs:188:26:188:26 | s |
+| Capture.cs:196:23:196:24 | "" | Capture.cs:188:26:188:26 | s |
+| Capture.cs:196:23:196:24 | "" | Capture.cs:196:20:196:25 | call to local function Id |
+| Capture.cs:196:23:196:24 | "" | Capture.cs:196:20:196:25 | call to local function Id |
+| Capture.cs:196:23:196:24 | "" | Capture.cs:196:23:196:24 | "" |
+| Capture.cs:197:9:197:23 | call to method Check | Capture.cs:197:9:197:23 | call to method Check |
+| Capture.cs:197:15:197:22 | access to local variable nonSink0 | Capture.cs:197:15:197:22 | access to local variable nonSink0 |
+| Capture.cs:202:34:202:34 | a | Capture.cs:202:34:202:34 | a |
+| Capture.cs:202:34:202:34 | a | Capture.cs:202:34:202:34 | a |
+| Capture.cs:202:34:202:34 | a | Capture.cs:202:34:202:34 | a |
+| Capture.cs:202:34:202:34 | a | Capture.cs:202:34:202:34 | a |
+| Capture.cs:202:34:202:34 | a | Capture.cs:204:9:204:9 | access to parameter a |
+| Capture.cs:202:34:202:34 | a | Capture.cs:204:9:204:9 | access to parameter a |
+| Capture.cs:202:34:202:34 | a | Capture.cs:204:9:204:9 | access to parameter a |
+| Capture.cs:202:34:202:34 | a | Capture.cs:204:9:204:9 | access to parameter a |
+| Capture.cs:202:34:202:34 | a | Capture.cs:204:9:204:9 | access to parameter a |
+| Capture.cs:202:34:202:34 | a | Capture.cs:204:9:204:9 | access to parameter a |
+| Capture.cs:202:34:202:34 | a | Capture.cs:204:9:204:9 | access to parameter a |
+| Capture.cs:202:34:202:34 | a | Capture.cs:204:9:204:9 | access to parameter a |
+| Capture.cs:204:9:204:9 | access to parameter a | Capture.cs:204:9:204:9 | access to parameter a |
+| Capture.cs:204:9:204:18 | delegate call | Capture.cs:204:9:204:18 | delegate call |
 | GlobalDataFlow.cs:14:17:14:17 | this | GlobalDataFlow.cs:14:17:14:17 | this |
 | GlobalDataFlow.cs:14:17:14:17 | this | GlobalDataFlow.cs:64:9:64:18 | this access |
 | GlobalDataFlow.cs:14:17:14:17 | this | GlobalDataFlow.cs:64:9:64:18 | this access |

--- a/csharp/ql/test/library-tests/dataflow/global/TaintTrackingEdges.expected
+++ b/csharp/ql/test/library-tests/dataflow/global/TaintTrackingEdges.expected
@@ -395,6 +395,45 @@
 | Capture.cs:109:9:109:30 | call to local function CaptureOut2NotCalled | Capture.cs:109:9:109:30 | call to local function CaptureOut2NotCalled |
 | Capture.cs:110:9:110:23 | call to method Check | Capture.cs:110:9:110:23 | call to method Check |
 | Capture.cs:110:15:110:22 | access to local variable nonSink0 | Capture.cs:110:15:110:22 | access to local variable nonSink0 |
+| Capture.cs:111:16:111:26 | SSA def(sink40) | Capture.cs:111:16:111:26 | SSA def(sink40) |
+| Capture.cs:111:16:111:26 | String sink40 = ... | Capture.cs:111:16:111:26 | String sink40 = ... |
+| Capture.cs:111:25:111:26 | "" | Capture.cs:111:16:111:26 | SSA def(sink40) |
+| Capture.cs:111:25:111:26 | "" | Capture.cs:111:16:111:26 | SSA def(sink40) |
+| Capture.cs:111:25:111:26 | "" | Capture.cs:111:25:111:26 | "" |
+| Capture.cs:114:13:116:14 | call to method RunAction | Capture.cs:114:13:116:14 | call to method RunAction |
+| Capture.cs:114:23:116:13 | (...) => ... | Capture.cs:114:23:116:13 | (...) => ... |
+| Capture.cs:114:23:116:13 | (...) => ... | Capture.cs:202:34:202:34 | a |
+| Capture.cs:114:23:116:13 | (...) => ... | Capture.cs:202:34:202:34 | a |
+| Capture.cs:115:17:115:39 | ... = ... | Capture.cs:115:17:115:39 | ... = ... |
+| Capture.cs:115:17:115:39 | SSA def(sink40) | Capture.cs:115:17:115:39 | SSA def(sink40) |
+| Capture.cs:115:17:115:39 | SSA def(sink40) | Capture.cs:121:9:121:35 | SSA call def(sink40) |
+| Capture.cs:115:17:115:39 | SSA def(sink40) | Capture.cs:121:9:121:35 | SSA call def(sink40) |
+| Capture.cs:115:26:115:39 | "taint source" | Capture.cs:115:17:115:39 | SSA def(sink40) |
+| Capture.cs:115:26:115:39 | "taint source" | Capture.cs:115:17:115:39 | SSA def(sink40) |
+| Capture.cs:115:26:115:39 | "taint source" | Capture.cs:115:26:115:39 | "taint source" |
+| Capture.cs:117:13:119:14 | call to method RunAction | Capture.cs:117:13:119:14 | call to method RunAction |
+| Capture.cs:117:23:119:13 | (...) => ... | Capture.cs:117:23:119:13 | (...) => ... |
+| Capture.cs:117:23:119:13 | (...) => ... | Capture.cs:202:34:202:34 | a |
+| Capture.cs:117:23:119:13 | (...) => ... | Capture.cs:202:34:202:34 | a |
+| Capture.cs:118:17:118:40 | ... = ... | Capture.cs:118:17:118:40 | ... = ... |
+| Capture.cs:118:17:118:40 | SSA def(nonSink0) | Capture.cs:118:17:118:40 | SSA def(nonSink0) |
+| Capture.cs:118:17:118:40 | SSA def(nonSink0) | Capture.cs:121:9:121:35 | SSA call def(nonSink0) |
+| Capture.cs:118:17:118:40 | SSA def(nonSink0) | Capture.cs:121:9:121:35 | SSA call def(nonSink0) |
+| Capture.cs:118:28:118:40 | "not tainted" | Capture.cs:118:17:118:40 | SSA def(nonSink0) |
+| Capture.cs:118:28:118:40 | "not tainted" | Capture.cs:118:17:118:40 | SSA def(nonSink0) |
+| Capture.cs:118:28:118:40 | "not tainted" | Capture.cs:118:28:118:40 | "not tainted" |
+| Capture.cs:121:9:121:33 | access to local function CaptureOutMultipleLambdas | Capture.cs:121:9:121:33 | access to local function CaptureOutMultipleLambdas |
+| Capture.cs:121:9:121:35 | SSA call def(nonSink0) | Capture.cs:121:9:121:35 | SSA call def(nonSink0) |
+| Capture.cs:121:9:121:35 | SSA call def(nonSink0) | Capture.cs:122:30:122:37 | access to local variable nonSink0 |
+| Capture.cs:121:9:121:35 | SSA call def(nonSink0) | Capture.cs:122:30:122:37 | access to local variable nonSink0 |
+| Capture.cs:121:9:121:35 | SSA call def(sink40) | Capture.cs:121:9:121:35 | SSA call def(sink40) |
+| Capture.cs:121:9:121:35 | SSA call def(sink40) | Capture.cs:122:15:122:20 | access to local variable sink40 |
+| Capture.cs:121:9:121:35 | SSA call def(sink40) | Capture.cs:122:15:122:20 | access to local variable sink40 |
+| Capture.cs:121:9:121:35 | call to local function CaptureOutMultipleLambdas | Capture.cs:121:9:121:35 | call to local function CaptureOutMultipleLambdas |
+| Capture.cs:122:9:122:21 | call to method Check | Capture.cs:122:9:122:21 | call to method Check |
+| Capture.cs:122:15:122:20 | access to local variable sink40 | Capture.cs:122:15:122:20 | access to local variable sink40 |
+| Capture.cs:122:24:122:38 | call to method Check | Capture.cs:122:24:122:38 | call to method Check |
+| Capture.cs:122:30:122:37 | access to local variable nonSink0 | Capture.cs:122:30:122:37 | access to local variable nonSink0 |
 | Capture.cs:125:10:125:16 | this | Capture.cs:125:10:125:16 | this |
 | Capture.cs:125:25:125:31 | tainted | Capture.cs:125:25:125:31 | tainted |
 | Capture.cs:125:25:125:31 | tainted | Capture.cs:125:25:125:31 | tainted |
@@ -745,6 +784,10 @@
 | Capture.cs:202:34:202:34 | a | Capture.cs:202:34:202:34 | a |
 | Capture.cs:202:34:202:34 | a | Capture.cs:202:34:202:34 | a |
 | Capture.cs:202:34:202:34 | a | Capture.cs:202:34:202:34 | a |
+| Capture.cs:202:34:202:34 | a | Capture.cs:204:9:204:9 | access to parameter a |
+| Capture.cs:202:34:202:34 | a | Capture.cs:204:9:204:9 | access to parameter a |
+| Capture.cs:202:34:202:34 | a | Capture.cs:204:9:204:9 | access to parameter a |
+| Capture.cs:202:34:202:34 | a | Capture.cs:204:9:204:9 | access to parameter a |
 | Capture.cs:202:34:202:34 | a | Capture.cs:204:9:204:9 | access to parameter a |
 | Capture.cs:202:34:202:34 | a | Capture.cs:204:9:204:9 | access to parameter a |
 | Capture.cs:202:34:202:34 | a | Capture.cs:204:9:204:9 | access to parameter a |

--- a/csharp/ql/test/library-tests/dataflow/global/TaintTrackingEdges.expected
+++ b/csharp/ql/test/library-tests/dataflow/global/TaintTrackingEdges.expected
@@ -15,6 +15,10 @@
 | Capture.cs:7:20:7:26 | tainted | Capture.cs:33:9:33:40 | [implicit argument] tainted |
 | Capture.cs:7:20:7:26 | tainted | Capture.cs:33:9:33:40 | [implicit argument] tainted |
 | Capture.cs:7:20:7:26 | tainted | Capture.cs:33:9:33:40 | [implicit argument] tainted |
+| Capture.cs:7:20:7:26 | tainted | Capture.cs:61:36:61:42 | access to parameter tainted |
+| Capture.cs:7:20:7:26 | tainted | Capture.cs:61:36:61:42 | access to parameter tainted |
+| Capture.cs:7:20:7:26 | tainted | Capture.cs:61:36:61:42 | access to parameter tainted |
+| Capture.cs:7:20:7:26 | tainted | Capture.cs:61:36:61:42 | access to parameter tainted |
 | Capture.cs:9:9:13:9 | SSA capture def(tainted) | Capture.cs:9:9:13:9 | SSA capture def(tainted) |
 | Capture.cs:9:9:13:9 | SSA capture def(tainted) | Capture.cs:11:17:11:32 | SSA def(sink27) |
 | Capture.cs:9:9:13:9 | SSA capture def(tainted) | Capture.cs:11:17:11:32 | SSA def(sink27) |
@@ -203,6 +207,66 @@
 | Capture.cs:46:23:46:30 | access to local variable nonSink0 | Capture.cs:46:23:46:30 | access to local variable nonSink0 |
 | Capture.cs:49:9:49:27 | access to local function CaptureIn2NotCalled | Capture.cs:49:9:49:27 | access to local function CaptureIn2NotCalled |
 | Capture.cs:49:9:49:29 | call to local function CaptureIn2NotCalled | Capture.cs:49:9:49:29 | call to local function CaptureIn2NotCalled |
+| Capture.cs:50:33:50:40 | nonSink0 | Capture.cs:50:33:50:40 | nonSink0 |
+| Capture.cs:50:33:50:40 | nonSink0 | Capture.cs:50:33:50:40 | nonSink0 |
+| Capture.cs:50:33:50:40 | nonSink0 | Capture.cs:50:33:50:40 | nonSink0 |
+| Capture.cs:50:33:50:40 | nonSink0 | Capture.cs:50:33:50:40 | nonSink0 |
+| Capture.cs:50:33:50:40 | nonSink0 | Capture.cs:52:13:59:14 | [implicit argument] nonSink0 |
+| Capture.cs:50:33:50:40 | nonSink0 | Capture.cs:52:13:59:14 | [implicit argument] nonSink0 |
+| Capture.cs:50:33:50:40 | nonSink0 | Capture.cs:52:13:59:14 | [implicit argument] nonSink0 |
+| Capture.cs:50:33:50:40 | nonSink0 | Capture.cs:52:13:59:14 | [implicit argument] nonSink0 |
+| Capture.cs:50:33:50:40 | nonSink0 | Capture.cs:52:13:59:14 | [implicit argument] nonSink0 |
+| Capture.cs:50:33:50:40 | nonSink0 | Capture.cs:52:13:59:14 | [implicit argument] nonSink0 |
+| Capture.cs:50:50:50:55 | sink39 | Capture.cs:50:50:50:55 | sink39 |
+| Capture.cs:50:50:50:55 | sink39 | Capture.cs:50:50:50:55 | sink39 |
+| Capture.cs:50:50:50:55 | sink39 | Capture.cs:50:50:50:55 | sink39 |
+| Capture.cs:50:50:50:55 | sink39 | Capture.cs:50:50:50:55 | sink39 |
+| Capture.cs:50:50:50:55 | sink39 | Capture.cs:52:13:59:14 | [implicit argument] sink39 |
+| Capture.cs:50:50:50:55 | sink39 | Capture.cs:52:13:59:14 | [implicit argument] sink39 |
+| Capture.cs:50:50:50:55 | sink39 | Capture.cs:52:13:59:14 | [implicit argument] sink39 |
+| Capture.cs:50:50:50:55 | sink39 | Capture.cs:52:13:59:14 | [implicit argument] sink39 |
+| Capture.cs:50:50:50:55 | sink39 | Capture.cs:52:13:59:14 | [implicit argument] sink39 |
+| Capture.cs:50:50:50:55 | sink39 | Capture.cs:52:13:59:14 | [implicit argument] sink39 |
+| Capture.cs:52:13:59:14 | [implicit argument] nonSink0 | Capture.cs:52:13:59:14 | [implicit argument] nonSink0 |
+| Capture.cs:52:13:59:14 | [implicit argument] nonSink0 | Capture.cs:52:23:59:13 | SSA capture def(nonSink0) |
+| Capture.cs:52:13:59:14 | [implicit argument] nonSink0 | Capture.cs:52:23:59:13 | SSA capture def(nonSink0) |
+| Capture.cs:52:13:59:14 | [implicit argument] nonSink0 | Capture.cs:52:23:59:13 | SSA capture def(nonSink0) |
+| Capture.cs:52:13:59:14 | [implicit argument] nonSink0 | Capture.cs:52:23:59:13 | SSA capture def(nonSink0) |
+| Capture.cs:52:13:59:14 | [implicit argument] sink39 | Capture.cs:52:13:59:14 | [implicit argument] sink39 |
+| Capture.cs:52:13:59:14 | [implicit argument] sink39 | Capture.cs:55:27:58:17 | SSA capture def(sink39) |
+| Capture.cs:52:13:59:14 | [implicit argument] sink39 | Capture.cs:55:27:58:17 | SSA capture def(sink39) |
+| Capture.cs:52:13:59:14 | [implicit argument] sink39 | Capture.cs:55:27:58:17 | SSA capture def(sink39) |
+| Capture.cs:52:13:59:14 | [implicit argument] sink39 | Capture.cs:55:27:58:17 | SSA capture def(sink39) |
+| Capture.cs:52:13:59:14 | call to method RunAction | Capture.cs:52:13:59:14 | call to method RunAction |
+| Capture.cs:52:23:59:13 | (...) => ... | Capture.cs:52:23:59:13 | (...) => ... |
+| Capture.cs:52:23:59:13 | (...) => ... | Capture.cs:190:34:190:34 | a |
+| Capture.cs:52:23:59:13 | (...) => ... | Capture.cs:190:34:190:34 | a |
+| Capture.cs:52:23:59:13 | SSA capture def(nonSink0) | Capture.cs:52:23:59:13 | SSA capture def(nonSink0) |
+| Capture.cs:52:23:59:13 | SSA capture def(nonSink0) | Capture.cs:54:23:54:30 | access to parameter nonSink0 |
+| Capture.cs:52:23:59:13 | SSA capture def(nonSink0) | Capture.cs:54:23:54:30 | access to parameter nonSink0 |
+| Capture.cs:52:23:59:13 | SSA capture def(nonSink0) | Capture.cs:54:23:54:30 | access to parameter nonSink0 |
+| Capture.cs:52:23:59:13 | SSA capture def(nonSink0) | Capture.cs:54:23:54:30 | access to parameter nonSink0 |
+| Capture.cs:54:17:54:31 | call to method Check | Capture.cs:54:17:54:31 | call to method Check |
+| Capture.cs:54:23:54:30 | access to parameter nonSink0 | Capture.cs:54:23:54:30 | access to parameter nonSink0 |
+| Capture.cs:55:17:58:18 | call to method RunAction | Capture.cs:55:17:58:18 | call to method RunAction |
+| Capture.cs:55:27:58:17 | (...) => ... | Capture.cs:55:27:58:17 | (...) => ... |
+| Capture.cs:55:27:58:17 | (...) => ... | Capture.cs:190:34:190:34 | a |
+| Capture.cs:55:27:58:17 | (...) => ... | Capture.cs:190:34:190:34 | a |
+| Capture.cs:55:27:58:17 | SSA capture def(sink39) | Capture.cs:55:27:58:17 | SSA capture def(sink39) |
+| Capture.cs:55:27:58:17 | SSA capture def(sink39) | Capture.cs:57:27:57:32 | access to parameter sink39 |
+| Capture.cs:55:27:58:17 | SSA capture def(sink39) | Capture.cs:57:27:57:32 | access to parameter sink39 |
+| Capture.cs:55:27:58:17 | SSA capture def(sink39) | Capture.cs:57:27:57:32 | access to parameter sink39 |
+| Capture.cs:55:27:58:17 | SSA capture def(sink39) | Capture.cs:57:27:57:32 | access to parameter sink39 |
+| Capture.cs:57:21:57:33 | call to method Check | Capture.cs:57:21:57:33 | call to method Check |
+| Capture.cs:57:27:57:32 | access to parameter sink39 | Capture.cs:57:27:57:32 | access to parameter sink39 |
+| Capture.cs:61:9:61:19 | access to local function CaptureTest | Capture.cs:61:9:61:19 | access to local function CaptureTest |
+| Capture.cs:61:9:61:43 | call to local function CaptureTest | Capture.cs:61:9:61:43 | call to local function CaptureTest |
+| Capture.cs:61:21:61:33 | "not tainted" | Capture.cs:50:33:50:40 | nonSink0 |
+| Capture.cs:61:21:61:33 | "not tainted" | Capture.cs:50:33:50:40 | nonSink0 |
+| Capture.cs:61:21:61:33 | "not tainted" | Capture.cs:61:21:61:33 | "not tainted" |
+| Capture.cs:61:36:61:42 | access to parameter tainted | Capture.cs:50:50:50:55 | sink39 |
+| Capture.cs:61:36:61:42 | access to parameter tainted | Capture.cs:50:50:50:55 | sink39 |
+| Capture.cs:61:36:61:42 | access to parameter tainted | Capture.cs:61:36:61:42 | access to parameter tainted |
 | Capture.cs:64:10:64:12 | this | Capture.cs:64:10:64:12 | this |
 | Capture.cs:66:16:66:26 | SSA def(sink30) | Capture.cs:66:16:66:26 | SSA def(sink30) |
 | Capture.cs:66:16:66:26 | String sink30 = ... | Capture.cs:66:16:66:26 | String sink30 = ... |
@@ -677,6 +741,20 @@
 | Capture.cs:184:23:184:24 | "" | Capture.cs:184:23:184:24 | "" |
 | Capture.cs:185:9:185:23 | call to method Check | Capture.cs:185:9:185:23 | call to method Check |
 | Capture.cs:185:15:185:22 | access to local variable nonSink0 | Capture.cs:185:15:185:22 | access to local variable nonSink0 |
+| Capture.cs:190:34:190:34 | a | Capture.cs:190:34:190:34 | a |
+| Capture.cs:190:34:190:34 | a | Capture.cs:190:34:190:34 | a |
+| Capture.cs:190:34:190:34 | a | Capture.cs:190:34:190:34 | a |
+| Capture.cs:190:34:190:34 | a | Capture.cs:190:34:190:34 | a |
+| Capture.cs:190:34:190:34 | a | Capture.cs:192:9:192:9 | access to parameter a |
+| Capture.cs:190:34:190:34 | a | Capture.cs:192:9:192:9 | access to parameter a |
+| Capture.cs:190:34:190:34 | a | Capture.cs:192:9:192:9 | access to parameter a |
+| Capture.cs:190:34:190:34 | a | Capture.cs:192:9:192:9 | access to parameter a |
+| Capture.cs:190:34:190:34 | a | Capture.cs:192:9:192:9 | access to parameter a |
+| Capture.cs:190:34:190:34 | a | Capture.cs:192:9:192:9 | access to parameter a |
+| Capture.cs:190:34:190:34 | a | Capture.cs:192:9:192:9 | access to parameter a |
+| Capture.cs:190:34:190:34 | a | Capture.cs:192:9:192:9 | access to parameter a |
+| Capture.cs:192:9:192:9 | access to parameter a | Capture.cs:192:9:192:9 | access to parameter a |
+| Capture.cs:192:9:192:18 | delegate call | Capture.cs:192:9:192:18 | delegate call |
 | GlobalDataFlow.cs:14:17:14:17 | this | GlobalDataFlow.cs:14:17:14:17 | this |
 | GlobalDataFlow.cs:14:17:14:17 | this | GlobalDataFlow.cs:64:9:64:18 | this access |
 | GlobalDataFlow.cs:14:17:14:17 | this | GlobalDataFlow.cs:64:9:64:18 | this access |

--- a/csharp/ql/test/library-tests/dataflow/global/TaintTrackingPath.expected
+++ b/csharp/ql/test/library-tests/dataflow/global/TaintTrackingPath.expected
@@ -22,6 +22,9 @@ edges
 | Capture.cs:89:13:89:35 | SSA def(sink32) | Capture.cs:92:9:92:41 | SSA call def(sink32) |
 | Capture.cs:89:22:89:35 | "taint source" | Capture.cs:89:13:89:35 | SSA def(sink32) |
 | Capture.cs:92:9:92:41 | SSA call def(sink32) | Capture.cs:93:15:93:20 | access to local variable sink32 |
+| Capture.cs:115:17:115:39 | SSA def(sink40) | Capture.cs:121:9:121:35 | SSA call def(sink40) |
+| Capture.cs:115:26:115:39 | "taint source" | Capture.cs:115:17:115:39 | SSA def(sink40) |
+| Capture.cs:121:9:121:35 | SSA call def(sink40) | Capture.cs:122:15:122:20 | access to local variable sink40 |
 | Capture.cs:125:25:125:31 | tainted | Capture.cs:132:9:132:25 | [implicit argument] tainted |
 | Capture.cs:125:25:125:31 | tainted | Capture.cs:144:9:144:25 | [implicit argument] tainted |
 | Capture.cs:125:25:125:31 | tainted | Capture.cs:153:9:153:45 | [implicit argument] tainted |
@@ -252,6 +255,7 @@ edges
 | Capture.cs:72:15:72:20 | access to local variable sink30 | Capture.cs:69:22:69:35 | "taint source" | Capture.cs:72:15:72:20 | access to local variable sink30 | access to local variable sink30 |
 | Capture.cs:84:15:84:20 | access to local variable sink31 | Capture.cs:79:26:79:39 | "taint source" | Capture.cs:84:15:84:20 | access to local variable sink31 | access to local variable sink31 |
 | Capture.cs:93:15:93:20 | access to local variable sink32 | Capture.cs:89:22:89:35 | "taint source" | Capture.cs:93:15:93:20 | access to local variable sink32 | access to local variable sink32 |
+| Capture.cs:122:15:122:20 | access to local variable sink40 | Capture.cs:115:26:115:39 | "taint source" | Capture.cs:122:15:122:20 | access to local variable sink40 | access to local variable sink40 |
 | Capture.cs:133:15:133:20 | access to local variable sink33 | Capture.cs:125:25:125:31 | tainted | Capture.cs:133:15:133:20 | access to local variable sink33 | access to local variable sink33 |
 | Capture.cs:145:15:145:20 | access to local variable sink34 | Capture.cs:125:25:125:31 | tainted | Capture.cs:145:15:145:20 | access to local variable sink34 | access to local variable sink34 |
 | Capture.cs:154:15:154:20 | access to local variable sink35 | Capture.cs:125:25:125:31 | tainted | Capture.cs:154:15:154:20 | access to local variable sink35 | access to local variable sink35 |

--- a/csharp/ql/test/library-tests/dataflow/global/TaintTrackingPath.expected
+++ b/csharp/ql/test/library-tests/dataflow/global/TaintTrackingPath.expected
@@ -8,33 +8,33 @@ edges
 | Capture.cs:25:9:25:20 | [implicit argument] tainted | Capture.cs:18:13:22:13 | SSA capture def(tainted) |
 | Capture.cs:27:43:32:9 | SSA capture def(tainted) | Capture.cs:30:19:30:24 | access to local variable sink29 |
 | Capture.cs:33:9:33:40 | [implicit argument] tainted | Capture.cs:27:43:32:9 | SSA capture def(tainted) |
-| Capture.cs:57:13:57:35 | SSA def(sink30) | Capture.cs:59:9:59:21 | SSA call def(sink30) |
-| Capture.cs:57:22:57:35 | "taint source" | Capture.cs:57:13:57:35 | SSA def(sink30) |
-| Capture.cs:59:9:59:21 | SSA call def(sink30) | Capture.cs:60:15:60:20 | access to local variable sink30 |
-| Capture.cs:67:17:67:39 | SSA def(sink31) | Capture.cs:71:9:71:21 | SSA call def(sink31) |
-| Capture.cs:67:26:67:39 | "taint source" | Capture.cs:67:17:67:39 | SSA def(sink31) |
-| Capture.cs:71:9:71:21 | SSA call def(sink31) | Capture.cs:72:15:72:20 | access to local variable sink31 |
-| Capture.cs:77:13:77:35 | SSA def(sink32) | Capture.cs:80:9:80:41 | SSA call def(sink32) |
-| Capture.cs:77:22:77:35 | "taint source" | Capture.cs:77:13:77:35 | SSA def(sink32) |
-| Capture.cs:80:9:80:41 | SSA call def(sink32) | Capture.cs:81:15:81:20 | access to local variable sink32 |
-| Capture.cs:101:25:101:31 | tainted | Capture.cs:108:9:108:25 | [implicit argument] tainted |
-| Capture.cs:101:25:101:31 | tainted | Capture.cs:120:9:120:25 | [implicit argument] tainted |
-| Capture.cs:101:25:101:31 | tainted | Capture.cs:129:9:129:45 | [implicit argument] tainted |
-| Capture.cs:101:25:101:31 | tainted | Capture.cs:136:22:136:38 | [implicit argument] tainted |
-| Capture.cs:101:25:101:31 | tainted | Capture.cs:144:25:144:31 | access to parameter tainted |
-| Capture.cs:101:25:101:31 | tainted | Capture.cs:170:25:170:31 | access to parameter tainted |
-| Capture.cs:108:9:108:25 | SSA call def(sink33) | Capture.cs:109:15:109:20 | access to local variable sink33 |
-| Capture.cs:108:9:108:25 | [implicit argument] tainted | Capture.cs:108:9:108:25 | SSA call def(sink33) |
-| Capture.cs:120:9:120:25 | SSA call def(sink34) | Capture.cs:121:15:121:20 | access to local variable sink34 |
-| Capture.cs:120:9:120:25 | [implicit argument] tainted | Capture.cs:120:9:120:25 | SSA call def(sink34) |
-| Capture.cs:129:9:129:45 | SSA call def(sink35) | Capture.cs:130:15:130:20 | access to local variable sink35 |
-| Capture.cs:129:9:129:45 | [implicit argument] tainted | Capture.cs:129:9:129:45 | SSA call def(sink35) |
-| Capture.cs:136:22:136:38 | [implicit argument] tainted | Capture.cs:136:22:136:38 | call to local function CaptureThrough4 |
-| Capture.cs:136:22:136:38 | call to local function CaptureThrough4 | Capture.cs:137:15:137:20 | access to local variable sink36 |
-| Capture.cs:144:9:144:32 | SSA call def(sink37) | Capture.cs:145:15:145:20 | access to local variable sink37 |
-| Capture.cs:144:25:144:31 | access to parameter tainted | Capture.cs:144:9:144:32 | SSA call def(sink37) |
-| Capture.cs:170:22:170:32 | call to local function Id | Capture.cs:171:15:171:20 | access to local variable sink38 |
-| Capture.cs:170:25:170:31 | access to parameter tainted | Capture.cs:170:22:170:32 | call to local function Id |
+| Capture.cs:69:13:69:35 | SSA def(sink30) | Capture.cs:71:9:71:21 | SSA call def(sink30) |
+| Capture.cs:69:22:69:35 | "taint source" | Capture.cs:69:13:69:35 | SSA def(sink30) |
+| Capture.cs:71:9:71:21 | SSA call def(sink30) | Capture.cs:72:15:72:20 | access to local variable sink30 |
+| Capture.cs:79:17:79:39 | SSA def(sink31) | Capture.cs:83:9:83:21 | SSA call def(sink31) |
+| Capture.cs:79:26:79:39 | "taint source" | Capture.cs:79:17:79:39 | SSA def(sink31) |
+| Capture.cs:83:9:83:21 | SSA call def(sink31) | Capture.cs:84:15:84:20 | access to local variable sink31 |
+| Capture.cs:89:13:89:35 | SSA def(sink32) | Capture.cs:92:9:92:41 | SSA call def(sink32) |
+| Capture.cs:89:22:89:35 | "taint source" | Capture.cs:89:13:89:35 | SSA def(sink32) |
+| Capture.cs:92:9:92:41 | SSA call def(sink32) | Capture.cs:93:15:93:20 | access to local variable sink32 |
+| Capture.cs:113:25:113:31 | tainted | Capture.cs:120:9:120:25 | [implicit argument] tainted |
+| Capture.cs:113:25:113:31 | tainted | Capture.cs:132:9:132:25 | [implicit argument] tainted |
+| Capture.cs:113:25:113:31 | tainted | Capture.cs:141:9:141:45 | [implicit argument] tainted |
+| Capture.cs:113:25:113:31 | tainted | Capture.cs:148:22:148:38 | [implicit argument] tainted |
+| Capture.cs:113:25:113:31 | tainted | Capture.cs:156:25:156:31 | access to parameter tainted |
+| Capture.cs:113:25:113:31 | tainted | Capture.cs:182:25:182:31 | access to parameter tainted |
+| Capture.cs:120:9:120:25 | SSA call def(sink33) | Capture.cs:121:15:121:20 | access to local variable sink33 |
+| Capture.cs:120:9:120:25 | [implicit argument] tainted | Capture.cs:120:9:120:25 | SSA call def(sink33) |
+| Capture.cs:132:9:132:25 | SSA call def(sink34) | Capture.cs:133:15:133:20 | access to local variable sink34 |
+| Capture.cs:132:9:132:25 | [implicit argument] tainted | Capture.cs:132:9:132:25 | SSA call def(sink34) |
+| Capture.cs:141:9:141:45 | SSA call def(sink35) | Capture.cs:142:15:142:20 | access to local variable sink35 |
+| Capture.cs:141:9:141:45 | [implicit argument] tainted | Capture.cs:141:9:141:45 | SSA call def(sink35) |
+| Capture.cs:148:22:148:38 | [implicit argument] tainted | Capture.cs:148:22:148:38 | call to local function CaptureThrough4 |
+| Capture.cs:148:22:148:38 | call to local function CaptureThrough4 | Capture.cs:149:15:149:20 | access to local variable sink36 |
+| Capture.cs:156:9:156:32 | SSA call def(sink37) | Capture.cs:157:15:157:20 | access to local variable sink37 |
+| Capture.cs:156:25:156:31 | access to parameter tainted | Capture.cs:156:9:156:32 | SSA call def(sink37) |
+| Capture.cs:182:22:182:32 | call to local function Id | Capture.cs:183:15:183:20 | access to local variable sink38 |
+| Capture.cs:182:25:182:31 | access to parameter tainted | Capture.cs:182:22:182:32 | call to local function Id |
 | GlobalDataFlow.cs:17:27:17:40 | "taint source" | GlobalDataFlow.cs:18:15:18:29 | access to field SinkField0 |
 | GlobalDataFlow.cs:17:27:17:40 | "taint source" | GlobalDataFlow.cs:26:15:26:32 | access to property SinkProperty0 |
 | GlobalDataFlow.cs:17:27:17:40 | "taint source" | GlobalDataFlow.cs:26:15:26:32 | access to property SinkProperty0 |
@@ -243,15 +243,15 @@ edges
 | Capture.cs:12:19:12:24 | access to local variable sink27 | Capture.cs:7:20:7:26 | tainted | Capture.cs:12:19:12:24 | access to local variable sink27 | access to local variable sink27 |
 | Capture.cs:21:23:21:28 | access to local variable sink28 | Capture.cs:7:20:7:26 | tainted | Capture.cs:21:23:21:28 | access to local variable sink28 | access to local variable sink28 |
 | Capture.cs:30:19:30:24 | access to local variable sink29 | Capture.cs:7:20:7:26 | tainted | Capture.cs:30:19:30:24 | access to local variable sink29 | access to local variable sink29 |
-| Capture.cs:60:15:60:20 | access to local variable sink30 | Capture.cs:57:22:57:35 | "taint source" | Capture.cs:60:15:60:20 | access to local variable sink30 | access to local variable sink30 |
-| Capture.cs:72:15:72:20 | access to local variable sink31 | Capture.cs:67:26:67:39 | "taint source" | Capture.cs:72:15:72:20 | access to local variable sink31 | access to local variable sink31 |
-| Capture.cs:81:15:81:20 | access to local variable sink32 | Capture.cs:77:22:77:35 | "taint source" | Capture.cs:81:15:81:20 | access to local variable sink32 | access to local variable sink32 |
-| Capture.cs:109:15:109:20 | access to local variable sink33 | Capture.cs:101:25:101:31 | tainted | Capture.cs:109:15:109:20 | access to local variable sink33 | access to local variable sink33 |
-| Capture.cs:121:15:121:20 | access to local variable sink34 | Capture.cs:101:25:101:31 | tainted | Capture.cs:121:15:121:20 | access to local variable sink34 | access to local variable sink34 |
-| Capture.cs:130:15:130:20 | access to local variable sink35 | Capture.cs:101:25:101:31 | tainted | Capture.cs:130:15:130:20 | access to local variable sink35 | access to local variable sink35 |
-| Capture.cs:137:15:137:20 | access to local variable sink36 | Capture.cs:101:25:101:31 | tainted | Capture.cs:137:15:137:20 | access to local variable sink36 | access to local variable sink36 |
-| Capture.cs:145:15:145:20 | access to local variable sink37 | Capture.cs:101:25:101:31 | tainted | Capture.cs:145:15:145:20 | access to local variable sink37 | access to local variable sink37 |
-| Capture.cs:171:15:171:20 | access to local variable sink38 | Capture.cs:101:25:101:31 | tainted | Capture.cs:171:15:171:20 | access to local variable sink38 | access to local variable sink38 |
+| Capture.cs:72:15:72:20 | access to local variable sink30 | Capture.cs:69:22:69:35 | "taint source" | Capture.cs:72:15:72:20 | access to local variable sink30 | access to local variable sink30 |
+| Capture.cs:84:15:84:20 | access to local variable sink31 | Capture.cs:79:26:79:39 | "taint source" | Capture.cs:84:15:84:20 | access to local variable sink31 | access to local variable sink31 |
+| Capture.cs:93:15:93:20 | access to local variable sink32 | Capture.cs:89:22:89:35 | "taint source" | Capture.cs:93:15:93:20 | access to local variable sink32 | access to local variable sink32 |
+| Capture.cs:121:15:121:20 | access to local variable sink33 | Capture.cs:113:25:113:31 | tainted | Capture.cs:121:15:121:20 | access to local variable sink33 | access to local variable sink33 |
+| Capture.cs:133:15:133:20 | access to local variable sink34 | Capture.cs:113:25:113:31 | tainted | Capture.cs:133:15:133:20 | access to local variable sink34 | access to local variable sink34 |
+| Capture.cs:142:15:142:20 | access to local variable sink35 | Capture.cs:113:25:113:31 | tainted | Capture.cs:142:15:142:20 | access to local variable sink35 | access to local variable sink35 |
+| Capture.cs:149:15:149:20 | access to local variable sink36 | Capture.cs:113:25:113:31 | tainted | Capture.cs:149:15:149:20 | access to local variable sink36 | access to local variable sink36 |
+| Capture.cs:157:15:157:20 | access to local variable sink37 | Capture.cs:113:25:113:31 | tainted | Capture.cs:157:15:157:20 | access to local variable sink37 | access to local variable sink37 |
+| Capture.cs:183:15:183:20 | access to local variable sink38 | Capture.cs:113:25:113:31 | tainted | Capture.cs:183:15:183:20 | access to local variable sink38 | access to local variable sink38 |
 | GlobalDataFlow.cs:18:15:18:29 | access to field SinkField0 | GlobalDataFlow.cs:17:27:17:40 | "taint source" | GlobalDataFlow.cs:18:15:18:29 | access to field SinkField0 | access to field SinkField0 |
 | GlobalDataFlow.cs:26:15:26:32 | access to property SinkProperty0 | GlobalDataFlow.cs:17:27:17:40 | "taint source" | GlobalDataFlow.cs:26:15:26:32 | access to property SinkProperty0 | access to property SinkProperty0 |
 | GlobalDataFlow.cs:44:50:44:59 | access to parameter sinkParam2 | GlobalDataFlow.cs:17:27:17:40 | "taint source" | GlobalDataFlow.cs:44:50:44:59 | access to parameter sinkParam2 | access to parameter sinkParam2 |

--- a/csharp/ql/test/library-tests/dataflow/global/TaintTrackingPath.expected
+++ b/csharp/ql/test/library-tests/dataflow/global/TaintTrackingPath.expected
@@ -2,12 +2,17 @@ edges
 | Capture.cs:7:20:7:26 | tainted | Capture.cs:14:9:14:20 | [implicit argument] tainted |
 | Capture.cs:7:20:7:26 | tainted | Capture.cs:25:9:25:20 | [implicit argument] tainted |
 | Capture.cs:7:20:7:26 | tainted | Capture.cs:33:9:33:40 | [implicit argument] tainted |
+| Capture.cs:7:20:7:26 | tainted | Capture.cs:61:36:61:42 | access to parameter tainted |
 | Capture.cs:9:9:13:9 | SSA capture def(tainted) | Capture.cs:12:19:12:24 | access to local variable sink27 |
 | Capture.cs:14:9:14:20 | [implicit argument] tainted | Capture.cs:9:9:13:9 | SSA capture def(tainted) |
 | Capture.cs:18:13:22:13 | SSA capture def(tainted) | Capture.cs:21:23:21:28 | access to local variable sink28 |
 | Capture.cs:25:9:25:20 | [implicit argument] tainted | Capture.cs:18:13:22:13 | SSA capture def(tainted) |
 | Capture.cs:27:43:32:9 | SSA capture def(tainted) | Capture.cs:30:19:30:24 | access to local variable sink29 |
 | Capture.cs:33:9:33:40 | [implicit argument] tainted | Capture.cs:27:43:32:9 | SSA capture def(tainted) |
+| Capture.cs:50:50:50:55 | sink39 | Capture.cs:52:13:59:14 | [implicit argument] sink39 |
+| Capture.cs:52:13:59:14 | [implicit argument] sink39 | Capture.cs:55:27:58:17 | SSA capture def(sink39) |
+| Capture.cs:55:27:58:17 | SSA capture def(sink39) | Capture.cs:57:27:57:32 | access to parameter sink39 |
+| Capture.cs:61:36:61:42 | access to parameter tainted | Capture.cs:50:50:50:55 | sink39 |
 | Capture.cs:69:13:69:35 | SSA def(sink30) | Capture.cs:71:9:71:21 | SSA call def(sink30) |
 | Capture.cs:69:22:69:35 | "taint source" | Capture.cs:69:13:69:35 | SSA def(sink30) |
 | Capture.cs:71:9:71:21 | SSA call def(sink30) | Capture.cs:72:15:72:20 | access to local variable sink30 |
@@ -243,6 +248,7 @@ edges
 | Capture.cs:12:19:12:24 | access to local variable sink27 | Capture.cs:7:20:7:26 | tainted | Capture.cs:12:19:12:24 | access to local variable sink27 | access to local variable sink27 |
 | Capture.cs:21:23:21:28 | access to local variable sink28 | Capture.cs:7:20:7:26 | tainted | Capture.cs:21:23:21:28 | access to local variable sink28 | access to local variable sink28 |
 | Capture.cs:30:19:30:24 | access to local variable sink29 | Capture.cs:7:20:7:26 | tainted | Capture.cs:30:19:30:24 | access to local variable sink29 | access to local variable sink29 |
+| Capture.cs:57:27:57:32 | access to parameter sink39 | Capture.cs:7:20:7:26 | tainted | Capture.cs:57:27:57:32 | access to parameter sink39 | access to parameter sink39 |
 | Capture.cs:72:15:72:20 | access to local variable sink30 | Capture.cs:69:22:69:35 | "taint source" | Capture.cs:72:15:72:20 | access to local variable sink30 | access to local variable sink30 |
 | Capture.cs:84:15:84:20 | access to local variable sink31 | Capture.cs:79:26:79:39 | "taint source" | Capture.cs:84:15:84:20 | access to local variable sink31 | access to local variable sink31 |
 | Capture.cs:93:15:93:20 | access to local variable sink32 | Capture.cs:89:22:89:35 | "taint source" | Capture.cs:93:15:93:20 | access to local variable sink32 | access to local variable sink32 |

--- a/csharp/ql/test/library-tests/dataflow/global/TaintTrackingPath.expected
+++ b/csharp/ql/test/library-tests/dataflow/global/TaintTrackingPath.expected
@@ -22,24 +22,24 @@ edges
 | Capture.cs:89:13:89:35 | SSA def(sink32) | Capture.cs:92:9:92:41 | SSA call def(sink32) |
 | Capture.cs:89:22:89:35 | "taint source" | Capture.cs:89:13:89:35 | SSA def(sink32) |
 | Capture.cs:92:9:92:41 | SSA call def(sink32) | Capture.cs:93:15:93:20 | access to local variable sink32 |
-| Capture.cs:113:25:113:31 | tainted | Capture.cs:120:9:120:25 | [implicit argument] tainted |
-| Capture.cs:113:25:113:31 | tainted | Capture.cs:132:9:132:25 | [implicit argument] tainted |
-| Capture.cs:113:25:113:31 | tainted | Capture.cs:141:9:141:45 | [implicit argument] tainted |
-| Capture.cs:113:25:113:31 | tainted | Capture.cs:148:22:148:38 | [implicit argument] tainted |
-| Capture.cs:113:25:113:31 | tainted | Capture.cs:156:25:156:31 | access to parameter tainted |
-| Capture.cs:113:25:113:31 | tainted | Capture.cs:182:25:182:31 | access to parameter tainted |
-| Capture.cs:120:9:120:25 | SSA call def(sink33) | Capture.cs:121:15:121:20 | access to local variable sink33 |
-| Capture.cs:120:9:120:25 | [implicit argument] tainted | Capture.cs:120:9:120:25 | SSA call def(sink33) |
-| Capture.cs:132:9:132:25 | SSA call def(sink34) | Capture.cs:133:15:133:20 | access to local variable sink34 |
-| Capture.cs:132:9:132:25 | [implicit argument] tainted | Capture.cs:132:9:132:25 | SSA call def(sink34) |
-| Capture.cs:141:9:141:45 | SSA call def(sink35) | Capture.cs:142:15:142:20 | access to local variable sink35 |
-| Capture.cs:141:9:141:45 | [implicit argument] tainted | Capture.cs:141:9:141:45 | SSA call def(sink35) |
-| Capture.cs:148:22:148:38 | [implicit argument] tainted | Capture.cs:148:22:148:38 | call to local function CaptureThrough4 |
-| Capture.cs:148:22:148:38 | call to local function CaptureThrough4 | Capture.cs:149:15:149:20 | access to local variable sink36 |
-| Capture.cs:156:9:156:32 | SSA call def(sink37) | Capture.cs:157:15:157:20 | access to local variable sink37 |
-| Capture.cs:156:25:156:31 | access to parameter tainted | Capture.cs:156:9:156:32 | SSA call def(sink37) |
-| Capture.cs:182:22:182:32 | call to local function Id | Capture.cs:183:15:183:20 | access to local variable sink38 |
-| Capture.cs:182:25:182:31 | access to parameter tainted | Capture.cs:182:22:182:32 | call to local function Id |
+| Capture.cs:125:25:125:31 | tainted | Capture.cs:132:9:132:25 | [implicit argument] tainted |
+| Capture.cs:125:25:125:31 | tainted | Capture.cs:144:9:144:25 | [implicit argument] tainted |
+| Capture.cs:125:25:125:31 | tainted | Capture.cs:153:9:153:45 | [implicit argument] tainted |
+| Capture.cs:125:25:125:31 | tainted | Capture.cs:160:22:160:38 | [implicit argument] tainted |
+| Capture.cs:125:25:125:31 | tainted | Capture.cs:168:25:168:31 | access to parameter tainted |
+| Capture.cs:125:25:125:31 | tainted | Capture.cs:194:25:194:31 | access to parameter tainted |
+| Capture.cs:132:9:132:25 | SSA call def(sink33) | Capture.cs:133:15:133:20 | access to local variable sink33 |
+| Capture.cs:132:9:132:25 | [implicit argument] tainted | Capture.cs:132:9:132:25 | SSA call def(sink33) |
+| Capture.cs:144:9:144:25 | SSA call def(sink34) | Capture.cs:145:15:145:20 | access to local variable sink34 |
+| Capture.cs:144:9:144:25 | [implicit argument] tainted | Capture.cs:144:9:144:25 | SSA call def(sink34) |
+| Capture.cs:153:9:153:45 | SSA call def(sink35) | Capture.cs:154:15:154:20 | access to local variable sink35 |
+| Capture.cs:153:9:153:45 | [implicit argument] tainted | Capture.cs:153:9:153:45 | SSA call def(sink35) |
+| Capture.cs:160:22:160:38 | [implicit argument] tainted | Capture.cs:160:22:160:38 | call to local function CaptureThrough4 |
+| Capture.cs:160:22:160:38 | call to local function CaptureThrough4 | Capture.cs:161:15:161:20 | access to local variable sink36 |
+| Capture.cs:168:9:168:32 | SSA call def(sink37) | Capture.cs:169:15:169:20 | access to local variable sink37 |
+| Capture.cs:168:25:168:31 | access to parameter tainted | Capture.cs:168:9:168:32 | SSA call def(sink37) |
+| Capture.cs:194:22:194:32 | call to local function Id | Capture.cs:195:15:195:20 | access to local variable sink38 |
+| Capture.cs:194:25:194:31 | access to parameter tainted | Capture.cs:194:22:194:32 | call to local function Id |
 | GlobalDataFlow.cs:17:27:17:40 | "taint source" | GlobalDataFlow.cs:18:15:18:29 | access to field SinkField0 |
 | GlobalDataFlow.cs:17:27:17:40 | "taint source" | GlobalDataFlow.cs:26:15:26:32 | access to property SinkProperty0 |
 | GlobalDataFlow.cs:17:27:17:40 | "taint source" | GlobalDataFlow.cs:26:15:26:32 | access to property SinkProperty0 |
@@ -252,12 +252,12 @@ edges
 | Capture.cs:72:15:72:20 | access to local variable sink30 | Capture.cs:69:22:69:35 | "taint source" | Capture.cs:72:15:72:20 | access to local variable sink30 | access to local variable sink30 |
 | Capture.cs:84:15:84:20 | access to local variable sink31 | Capture.cs:79:26:79:39 | "taint source" | Capture.cs:84:15:84:20 | access to local variable sink31 | access to local variable sink31 |
 | Capture.cs:93:15:93:20 | access to local variable sink32 | Capture.cs:89:22:89:35 | "taint source" | Capture.cs:93:15:93:20 | access to local variable sink32 | access to local variable sink32 |
-| Capture.cs:121:15:121:20 | access to local variable sink33 | Capture.cs:113:25:113:31 | tainted | Capture.cs:121:15:121:20 | access to local variable sink33 | access to local variable sink33 |
-| Capture.cs:133:15:133:20 | access to local variable sink34 | Capture.cs:113:25:113:31 | tainted | Capture.cs:133:15:133:20 | access to local variable sink34 | access to local variable sink34 |
-| Capture.cs:142:15:142:20 | access to local variable sink35 | Capture.cs:113:25:113:31 | tainted | Capture.cs:142:15:142:20 | access to local variable sink35 | access to local variable sink35 |
-| Capture.cs:149:15:149:20 | access to local variable sink36 | Capture.cs:113:25:113:31 | tainted | Capture.cs:149:15:149:20 | access to local variable sink36 | access to local variable sink36 |
-| Capture.cs:157:15:157:20 | access to local variable sink37 | Capture.cs:113:25:113:31 | tainted | Capture.cs:157:15:157:20 | access to local variable sink37 | access to local variable sink37 |
-| Capture.cs:183:15:183:20 | access to local variable sink38 | Capture.cs:113:25:113:31 | tainted | Capture.cs:183:15:183:20 | access to local variable sink38 | access to local variable sink38 |
+| Capture.cs:133:15:133:20 | access to local variable sink33 | Capture.cs:125:25:125:31 | tainted | Capture.cs:133:15:133:20 | access to local variable sink33 | access to local variable sink33 |
+| Capture.cs:145:15:145:20 | access to local variable sink34 | Capture.cs:125:25:125:31 | tainted | Capture.cs:145:15:145:20 | access to local variable sink34 | access to local variable sink34 |
+| Capture.cs:154:15:154:20 | access to local variable sink35 | Capture.cs:125:25:125:31 | tainted | Capture.cs:154:15:154:20 | access to local variable sink35 | access to local variable sink35 |
+| Capture.cs:161:15:161:20 | access to local variable sink36 | Capture.cs:125:25:125:31 | tainted | Capture.cs:161:15:161:20 | access to local variable sink36 | access to local variable sink36 |
+| Capture.cs:169:15:169:20 | access to local variable sink37 | Capture.cs:125:25:125:31 | tainted | Capture.cs:169:15:169:20 | access to local variable sink37 | access to local variable sink37 |
+| Capture.cs:195:15:195:20 | access to local variable sink38 | Capture.cs:125:25:125:31 | tainted | Capture.cs:195:15:195:20 | access to local variable sink38 | access to local variable sink38 |
 | GlobalDataFlow.cs:18:15:18:29 | access to field SinkField0 | GlobalDataFlow.cs:17:27:17:40 | "taint source" | GlobalDataFlow.cs:18:15:18:29 | access to field SinkField0 | access to field SinkField0 |
 | GlobalDataFlow.cs:26:15:26:32 | access to property SinkProperty0 | GlobalDataFlow.cs:17:27:17:40 | "taint source" | GlobalDataFlow.cs:26:15:26:32 | access to property SinkProperty0 | access to property SinkProperty0 |
 | GlobalDataFlow.cs:44:50:44:59 | access to parameter sinkParam2 | GlobalDataFlow.cs:17:27:17:40 | "taint source" | GlobalDataFlow.cs:44:50:44:59 | access to parameter sinkParam2 | access to parameter sinkParam2 |


### PR DESCRIPTION
`TTransitiveCaptureCall` represents a control flow node that may transitively call many different callables which capture a variable from the current scope. Captured variables are represented as synthetic parameters to the callable, at negative indices. However, each of the different targets may capture a different subset of variables from the enclosing scope, so we must include the target callable in the `TTransitiveCaptureCall` in order to prevent incorrect capture flow between unrelated capture variables.

For example, in the included test case:
```
        void CaptureTest(string nonSink0, string sink39)
        {
            RunAction(() =>       // Check each lambda captures the correct arguments
            {
                Check(nonSink0);
                RunAction(() =>
                {
                    Check(sink39);
                });
            });
        }
        CaptureTest("not tainted", tainted);
```
`nonSink0` is captured in the outer lambda as a parameter at index `-2`. However, the parameter at index `-2` in the nested lambda is `sink39`. Without the runtime target context, we get flow from the parameter `sink39` to the access of `nonSink0` in `Check(nonSink0)`.

Tests are added in two commits; the first adds the new test cases, but commented out, and adjusts the expected result files to use the new locations. The second commit uncomments the new tests, and adds the new rows to the expected result files

@hvitved I've submitted this against `rc/1.22`, as this issue is affecting a customer.