### PR TITLE
JavaScript: Add support for `rate-limiter-flexible` package.

### DIFF
--- a/change-notes/1.23/analysis-javascript.md
+++ b/change-notes/1.23/analysis-javascript.md
@@ -6,6 +6,7 @@
   - [firebase](https://www.npmjs.com/package/firebase)
   - [mongodb](https://www.npmjs.com/package/mongodb)
   - [mongoose](https://www.npmjs.com/package/mongoose)
+  - [rate-limiter-flexible](https://www.npmjs.com/package/rate-limiter-flexible)
 
 * The call graph has been improved to resolve method calls in more cases. This may produce more security alerts.
 

--- a/javascript/ql/src/semmle/javascript/security/dataflow/MissingRateLimiting.qll
+++ b/javascript/ql/src/semmle/javascript/security/dataflow/MissingRateLimiting.qll
@@ -23,6 +23,7 @@
  */
 
 import javascript
+private import semmle.javascript.frameworks.ConnectExpressShared::ConnectExpressShared
 
 // main concepts
 /**
@@ -160,8 +161,8 @@ class RouteHandlerLimitedByExpressLimiter extends RateLimitedRouteHandlerExpr {
  * A rate-handler function implemented using one of the rate-limiting classes provided
  * by the `rate-limiter-flexible` package.
  *
- * We look for functions that invoke the `consume` method of one of the `RateLimiter*`
- * classes from the `rate-limiter-flexible` package on a property of their first argument,
+ * We look for route handlers that invoke the `consume` method of one of the `RateLimiter*`
+ * classes from the `rate-limiter-flexible` package on a property of their request parameter,
  * like the `rateLimiterMiddleware` function in this example:
  *
  * ```
@@ -176,14 +177,13 @@ class RateLimiterFlexibleRateLimiter extends DataFlow::FunctionNode {
   RateLimiterFlexibleRateLimiter() {
     exists(
       string rateLimiterClassName, DataFlow::SourceNode rateLimiterClass,
-      DataFlow::SourceNode rateLimiterInstance
+      DataFlow::SourceNode rateLimiterInstance, DataFlow::ParameterNode request
     |
       rateLimiterClassName.matches("RateLimiter%") and
       rateLimiterClass = DataFlow::moduleMember("rate-limiter-flexible", rateLimiterClassName) and
       rateLimiterInstance = rateLimiterClass.getAnInstantiation() and
-      getParameter(0).getAPropertyRead() = rateLimiterInstance
-            .getAMemberCall("consume")
-            .getAnArgument()
+      request.getParameter() = getRouteHandlerParameter(getFunction(), "request") and
+      request.getAPropertyRead() = rateLimiterInstance.getAMemberCall("consume").getAnArgument()
     )
   }
 }

--- a/javascript/ql/test/query-tests/Security/CWE-770/tst.js
+++ b/javascript/ql/test/query-tests/Security/CWE-770/tst.js
@@ -63,3 +63,11 @@ app3.get('/:path', expensiveHandler1); // OK
 
 express().get('/:path', function(req, res) { verifyUser(req); });  // NOT OK
 express().get('/:path', RateLimit(), function(req, res) { verifyUser(req); });  // OK
+
+// rate limiting using rate-limiter-flexible
+const { RateLimiterRedis } = require('rate-limiter-flexible');
+const rateLimiter = new RateLimiterRedis();
+const rateLimiterMiddleware = (req, res, next) => {
+  rateLimiter.consume(req.ip).then(next).catch(res.status(429).send('rate limited'));
+};
+express().get('/:path', rateLimiterMiddleware, expensiveHandler1);


### PR DESCRIPTION
Fixes https://github.com/Semmle/ql/issues/1949, as can be seen in [this run](https://lgtm.com/query/1543015584184000835/) of a modified version of the rate-limiting query that has the changes from this PR patched in by hand.

Evaluation ongoing.