### PR TITLE
docs: a few slide improvements

### DIFF
--- a/docs/language/README.rst
+++ b/docs/language/README.rst
@@ -89,9 +89,11 @@ Building and previewing the QL training presentations
 *****************************************************
 
 To build the QL training presentations, you need to install a Sphinx extension
-called `hieroglyph <https://github.com/nyergler/hieroglyph>`__.
+called `hieroglyph <https://github.com/nyergler/hieroglyph>`__. 
+You also need to install `graphviz <https://graphviz.gitlab.io/download/>`__, which 
+is used to generate graphs on some slides.
 
-After installing hieroglyph, you can build the QL training presentations by running 
+After installing hieroglyph and graphviz, you can build the QL training presentations by running 
 ``sphinx-build``, specifying the ``slides`` builder. For example
 
 .. code::

--- a/docs/language/learn-ql/ql-training.rst
+++ b/docs/language/learn-ql/ql-training.rst
@@ -19,7 +19,10 @@ Start learning how to use QL in variant analysis for a specific language by look
 
 .. |arrow-r| unicode:: U+2192
 
-When you have selected a presentation, use |arrow-r| and |arrow-l| to navigate between slides, press **p** to view the additional notes for a slide (where available), and press **f** to enter full-screen mode.
+.. |info| unicode:: U+24D8
+
+When you have selected a presentation, use |arrow-r| and |arrow-l| to navigate between slides.
+Press **p** to view the additional notes on slides that have an information icon |info| in the top right corner, and press **f** to enter full-screen mode.
 
 The presentations contain a number of QL query examples.
 We recommend that you download `QL for Eclipse <https://help.semmle.com/ql-for-eclipse/Content/WebHelp/home-page.html>`__ and import the example snapshot for each presentation so that you can find the bugs mentioned in the slides. 

--- a/docs/language/ql-training/_static-training/slides-semmle-2/layout.html
+++ b/docs/language/ql-training/_static-training/slides-semmle-2/layout.html
@@ -148,11 +148,18 @@ URL: https://code.google.com/p/io-2012-slides
 </slides>
 
 
+<script type="text/javascript">
 
-<!--[if IE]>
-  <script src="http://ajax.googleapis.com/ajax/libs/chrome-frame/1/CFInstall.min.js"></script>
-  <script>CFInstall.check({mode: 'overlay'});</script>
-<![endif]-->
+//insert info buttons on slides that have additional notes 
+  $(".admonition.note").before("<button id='extra-notes'>&#9432;</button>");
+  $(".admonition-title").before("<button id='close-notes'>&times;</button>");
+  $(document).ready(function() {
+     $('button').click(function() {
+       document.body.classList.toggle('with-notes');
+     });
+  });
+</script>
+
 <script type="text/javascript">
 
 //assigns font-size when document is ready

--- a/docs/language/ql-training/_static-training/slides-semmle-2/static/theme/css/default.css
+++ b/docs/language/ql-training/_static-training/slides-semmle-2/static/theme/css/default.css
@@ -1599,8 +1599,36 @@ p.first.admonition-title {
   font-size: 1em;
 }
 
-.admonition.note  ul {
-  width: inherit;
+.admonition.note  ul li {
+  width: 90%;
+}
+
+
+/* styles for information buttons on slides that have notes */
+
+#extra-notes {
+  display: block;
+  position: fixed;
+  top: 0;
+  right: 1%;
+  font-size: 1em;
+}
+
+#close-notes {
+  display: block;
+  position: fixed;
+  top: 0;
+  right: 0;
+  font-size: 1.2em;
+}
+
+button {
+  border: none;
+  background: none;
+}
+
+button:hover {
+  text-decoration: underline;
 }
 
 /********* images ************/

--- a/docs/language/ql-training/_static-training/slides-semmle-2/static/theme/css/default.css
+++ b/docs/language/ql-training/_static-training/slides-semmle-2/static/theme/css/default.css
@@ -1589,8 +1589,8 @@ p.first.admonition-title {
   font-size: 1em;
 }
 
-.admonition.note  ul {
-  width: 90%;
+.admonition.note  ul li {
+  width: inherit;
 }
 
 

--- a/docs/language/ql-training/_static-training/slides-semmle-2/static/theme/css/default.css
+++ b/docs/language/ql-training/_static-training/slides-semmle-2/static/theme/css/default.css
@@ -587,15 +587,6 @@ dt {
 /* line 386, ../scss/default.scss */
 button {
   display: inline-block;
-  background: url('data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0idXRmLTgiPz4gPHN2ZyB2ZXJzaW9uPSIxLjEiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyI+PGRlZnM+PGxpbmVhckdyYWRpZW50IGlkPSJncmFkIiBncmFkaWVudFVuaXRzPSJvYmplY3RCb3VuZGluZ0JveCIgeDE9IjAuNSIgeTE9IjAuMCIgeDI9IjAuNSIgeTI9IjEuMCI+PHN0b3Agb2Zmc2V0PSI0MCUiIHN0b3AtY29sb3I9IiNmOWY5ZjkiLz48c3RvcCBvZmZzZXQ9IjcwJSIgc3RvcC1jb2xvcj0iI2UzZTNlMyIvPjwvbGluZWFyR3JhZGllbnQ+PC9kZWZzPjxyZWN0IHg9IjAiIHk9IjAiIHdpZHRoPSIxMDAlIiBoZWlnaHQ9IjEwMCUiIGZpbGw9InVybCgjZ3JhZCkiIC8+PC9zdmc+IA==');
-  background: -webkit-gradient(linear, 50% 0%, 50% 100%, color-stop(40%, #f9f9f9), color-stop(70%, #e3e3e3));
-  background: -moz-linear-gradient(#f9f9f9 40%, #e3e3e3 70%);
-  background: -webkit-linear-gradient(#f9f9f9 40%, #e3e3e3 70%);
-  background: linear-gradient(#f9f9f9 40%, #e3e3e3 70%);
-  border: 1px solid #a9a9a9;
-  -moz-border-radius: 3px;
-  -webkit-border-radius: 3px;
-  border-radius: 3px;
   padding: 5px 8px;
   outline: none;
   white-space: nowrap;
@@ -605,7 +596,6 @@ button {
   user-select: none;
   cursor: pointer;
   text-shadow: 1px 1px #fff;
-  font-size: 10pt;
 }
 
 /* line 400, ../scss/default.scss */
@@ -1599,7 +1589,7 @@ p.first.admonition-title {
   font-size: 1em;
 }
 
-.admonition.note  ul li {
+.admonition.note  ul {
   width: 90%;
 }
 
@@ -1618,7 +1608,7 @@ p.first.admonition-title {
   display: block;
   position: fixed;
   top: 0;
-  right: 0;
+  right: -1%;
   font-size: 1.2em;
 }
 

--- a/docs/language/ql-training/conf.py
+++ b/docs/language/ql-training/conf.py
@@ -33,7 +33,6 @@ extensions = [
     'sphinx.ext.intersphinx',
     'sphinx.ext.mathjax',
     'hieroglyph',
-    'sphinxcontrib.blockdiag',
     'sphinx.ext.graphviz',
 ]
 


### PR DESCRIPTION
This PR:
- adds a clickable information icon on slides that have additional notes
- fixes the width of lists on notes pages (they previous overflowed horizontally)
- mentions the graphviz (required to generate graphs) in the readme
- removes an unnecessary extension from conf.py

Previews:
[QL training homepage](http://docteam.internal.semmle.com/james/ql-training/sd-3884/learn-ql/ql-training.html)
[Program representation for C/C++](http://docteam.internal.semmle.com/james/ql-training/sd-3884/ql-training/cpp/program-representation-cpp.html#1)