### PR TITLE
Python: split tests for Functions into more files

### DIFF
--- a/python/ql/test/query-tests/Functions/general/DeprecatedSliceMethod.expected
+++ b/python/ql/test/query-tests/Functions/general/DeprecatedSliceMethod.expected
@@ -1,3 +1,3 @@
-| functions_test.py:200:5:200:40 | Function __getslice__ | __getslice__ method has been deprecated since Python 2.0 |
-| functions_test.py:203:5:203:47 | Function __setslice__ | __setslice__ method has been deprecated since Python 2.0 |
-| functions_test.py:206:5:206:40 | Function __delslice__ | __delslice__ method has been deprecated since Python 2.0 |
+| functions_test.py:99:5:99:40 | Function __getslice__ | __getslice__ method has been deprecated since Python 2.0 |
+| functions_test.py:102:5:102:47 | Function __setslice__ | __setslice__ method has been deprecated since Python 2.0 |
+| functions_test.py:105:5:105:40 | Function __delslice__ | __delslice__ method has been deprecated since Python 2.0 |

--- a/python/ql/test/query-tests/Functions/general/ExplicitReturnInInit.expected
+++ b/python/ql/test/query-tests/Functions/general/ExplicitReturnInInit.expected
@@ -1,1 +1,1 @@
-| functions_test.py:45:9:45:19 | Return | Explicit return in __init__ method. |
+| explicit_return_in_init.py:4:9:4:19 | Return | Explicit return in __init__ method. |

--- a/python/ql/test/query-tests/Functions/general/InitIsGenerator.expected
+++ b/python/ql/test/query-tests/Functions/general/InitIsGenerator.expected
@@ -1,1 +1,1 @@
-| functions_test.py:73:5:73:23 | Function __init__ | __init__ method is a generator. |
+| explicit_return_in_init.py:32:5:32:23 | Function __init__ | __init__ method is a generator. |

--- a/python/ql/test/query-tests/Functions/general/ModificationOfParameterWithDefault.expected
+++ b/python/ql/test/query-tests/Functions/general/ModificationOfParameterWithDefault.expected
@@ -1,14 +1,14 @@
 edges
 | functions_test.py:39:9:39:9 | empty mutable value | functions_test.py:40:5:40:5 | empty mutable value |
-| functions_test.py:238:15:238:15 | empty mutable value | functions_test.py:239:5:239:5 | empty mutable value |
-| functions_test.py:290:25:290:25 | empty mutable value | functions_test.py:291:5:291:5 | empty mutable value |
-| functions_test.py:293:21:293:21 | empty mutable value | functions_test.py:294:5:294:5 | empty mutable value |
-| functions_test.py:296:27:296:27 | empty mutable value | functions_test.py:297:25:297:25 | empty mutable value |
-| functions_test.py:296:27:296:27 | empty mutable value | functions_test.py:298:21:298:21 | empty mutable value |
-| functions_test.py:297:25:297:25 | empty mutable value | functions_test.py:290:25:290:25 | empty mutable value |
-| functions_test.py:298:21:298:21 | empty mutable value | functions_test.py:293:21:293:21 | empty mutable value |
+| functions_test.py:133:15:133:15 | empty mutable value | functions_test.py:134:5:134:5 | empty mutable value |
+| functions_test.py:185:25:185:25 | empty mutable value | functions_test.py:186:5:186:5 | empty mutable value |
+| functions_test.py:188:21:188:21 | empty mutable value | functions_test.py:189:5:189:5 | empty mutable value |
+| functions_test.py:191:27:191:27 | empty mutable value | functions_test.py:192:25:192:25 | empty mutable value |
+| functions_test.py:191:27:191:27 | empty mutable value | functions_test.py:193:21:193:21 | empty mutable value |
+| functions_test.py:192:25:192:25 | empty mutable value | functions_test.py:185:25:185:25 | empty mutable value |
+| functions_test.py:193:21:193:21 | empty mutable value | functions_test.py:188:21:188:21 | empty mutable value |
 #select
 | functions_test.py:40:5:40:5 | x | functions_test.py:39:9:39:9 | empty mutable value | functions_test.py:40:5:40:5 | empty mutable value | $@ flows to here and is mutated. | functions_test.py:39:9:39:9 | x | Default value |
-| functions_test.py:239:5:239:5 | x | functions_test.py:238:15:238:15 | empty mutable value | functions_test.py:239:5:239:5 | empty mutable value | $@ flows to here and is mutated. | functions_test.py:238:15:238:15 | x | Default value |
-| functions_test.py:291:5:291:5 | x | functions_test.py:296:27:296:27 | empty mutable value | functions_test.py:291:5:291:5 | empty mutable value | $@ flows to here and is mutated. | functions_test.py:296:27:296:27 | y | Default value |
-| functions_test.py:294:5:294:5 | x | functions_test.py:296:27:296:27 | empty mutable value | functions_test.py:294:5:294:5 | empty mutable value | $@ flows to here and is mutated. | functions_test.py:296:27:296:27 | y | Default value |
+| functions_test.py:134:5:134:5 | x | functions_test.py:133:15:133:15 | empty mutable value | functions_test.py:134:5:134:5 | empty mutable value | $@ flows to here and is mutated. | functions_test.py:133:15:133:15 | x | Default value |
+| functions_test.py:186:5:186:5 | x | functions_test.py:191:27:191:27 | empty mutable value | functions_test.py:186:5:186:5 | empty mutable value | $@ flows to here and is mutated. | functions_test.py:191:27:191:27 | y | Default value |
+| functions_test.py:189:5:189:5 | x | functions_test.py:191:27:191:27 | empty mutable value | functions_test.py:189:5:189:5 | empty mutable value | $@ flows to here and is mutated. | functions_test.py:191:27:191:27 | y | Default value |

--- a/python/ql/test/query-tests/Functions/general/NonCls.expected
+++ b/python/ql/test/query-tests/Functions/general/NonCls.expected
@@ -1,2 +1,2 @@
-| functions_test.py:100:5:100:24 | Function n_cmethod | Class methods or methods of a type deriving from type should have 'cls', rather than 'self', as their first argument. |
-| functions_test.py:114:5:114:20 | Function c_method | Class methods or methods of a type deriving from type should have 'cls', rather than 'y', as their first argument. |
+| argument_names.py:17:5:17:24 | Function n_cmethod | Class methods or methods of a type deriving from type should have 'cls', rather than 'self', as their first argument. |
+| argument_names.py:32:5:32:20 | Function c_method | Class methods or methods of a type deriving from type should have 'cls', rather than 'y', as their first argument. |

--- a/python/ql/test/query-tests/Functions/general/NonSelf.expected
+++ b/python/ql/test/query-tests/Functions/general/NonSelf.expected
@@ -1,3 +1,3 @@
-| functions_test.py:130:5:130:20 | Function __init__ | Normal methods should have 'self', rather than 'x', as their first parameter. |
-| functions_test.py:133:5:133:20 | Function s_method | Normal methods should have 'self', rather than 'y', as their first parameter. |
+| argument_names.py:45:5:45:20 | Function __init__ | Normal methods should have 'self', rather than 'x', as their first parameter. |
+| argument_names.py:48:5:48:20 | Function s_method | Normal methods should have 'self', rather than 'y', as their first parameter. |
 | om_test.py:71:5:71:19 | Function __repr__ | Normal methods should have at least one parameter (the first of which should be 'self'). |

--- a/python/ql/test/query-tests/Functions/general/argument_names.py
+++ b/python/ql/test/query-tests/Functions/general/argument_names.py
@@ -1,0 +1,68 @@
+# Using name other than 'self' for first argument in methods.
+# This shouldn't apply to classmethods (first argument should be 'cls' or similar)
+# or static methods (first argument can be anything)
+
+
+class Normal(object):
+
+    def n_ok(self):
+        pass
+
+    @staticmethod
+    def n_smethod(ok):
+        pass
+
+    # not ok
+    @classmethod
+    def n_cmethod(self):
+        pass
+
+    # this is allowed because it has a decorator other than @classmethod
+    @classmethod
+    @id
+    def n_suppress(any_name):
+        pass
+
+
+class Class(type):
+
+    def __init__(cls):
+        pass
+
+    def c_method(y):
+        pass
+
+    def c_ok(cls):
+        pass
+
+    @id
+    def c_suppress(any_name):
+        pass
+
+
+class NonSelf(object):
+
+    def __init__(x):
+        pass
+
+    def s_method(y):
+        pass
+
+    def s_ok(self):
+        pass
+
+    @staticmethod
+    def s_smethod(ok):
+        pass
+
+    @classmethod
+    def s_cmethod(cls):
+        pass
+
+    def s_smethod2(ok):
+        pass
+    s_smethod2 = staticmethod(s_smethod2)
+
+    def s_cmethod2(cls):
+        pass
+    s_cmethod2 = classmethod(s_cmethod2)

--- a/python/ql/test/query-tests/Functions/general/explicit_return_in_init.py
+++ b/python/ql/test/query-tests/Functions/general/explicit_return_in_init.py
@@ -1,0 +1,39 @@
+class ExplicitReturnInInit(object):
+
+    def __init__(self):
+        return self
+
+#These are OK
+class ExplicitReturnNoneInInit(object):
+
+    def __init__(self):
+        return None
+
+class PlainReturnInInit(object):
+
+    def __init__(self):
+        return
+
+def error():
+    raise Exception()
+
+class InitCallsError(object):
+
+    def __init__(self):
+        return error()
+
+class InitCallsInit(InitCallsError):
+
+    def __init__(self):
+        return InitCallsError.__init__(self)
+
+class InitIsGenerator(object):
+
+    def __init__(self):
+        yield self
+
+#OK as it returns result of a call to super().__init__()
+class InitCallsInit(InitCallsError):
+
+    def __init__(self):
+        return super(InitCallsInit, self).__init__()

--- a/python/ql/test/query-tests/Functions/general/functions_test.py
+++ b/python/ql/test/query-tests/Functions/general/functions_test.py
@@ -24,7 +24,7 @@ def cr2(x):
         return 4
     else:
         return
-    
+
 def ok3(x):
     try:
         return
@@ -39,39 +39,6 @@ def ok4(x = []):
 def mpd(x = []):
     x.append("x")
 
-class ExplicitReturnInInit(object):
-
-    def __init__(self):
-        return self
-        
-#These are OK
-class ExplicitReturnNoneInInit(object):
-
-    def __init__(self):
-        return None
-
-class PlainReturnInInit(object):
-
-    def __init__(self):
-        return
-    
-def error():
-    raise Exception()
-    
-class InitCallsError(object):
-
-    def __init__(self):
-        return error()
-    
-class InitCallsInit(InitCallsError):
-
-    def __init__(self):
-        return InitCallsError.__init__(self)
-
-class InitIsGenerator(object):
-
-    def __init__(self):
-        yield self
 
 def use_implicit_return_value(arg):
     x = do_nothing()
@@ -83,74 +50,6 @@ y = lambda x : do_nothing()
 def do_nothing():
     pass
 
-#Using name other than 'cls' for first parameter in methods.
-# This shouldn't apply to classmethods (first parameter should be 'cls' or similar)
-# or static methods (first parameter can be anything)
-
-class Normal(object):
-
-    def n_ok(self):
-        pass
-
-    @staticmethod
-    def n_smethod(ok):
-        pass
-
-    @classmethod
-    def n_cmethod(self):
-        pass
-
-    # this is allowed because it has a decorator other than @classmethod
-    @classmethod
-    @id
-    def n_suppress(any_name):
-        pass
-
-class Class(type):
-
-    def __init__(cls):
-        pass
-
-    def c_method(y):
-        pass
-
-    def c_ok(cls):
-        pass
-
-    @id
-    def c_suppress(any_name):
-        pass
-
-#Using name other than 'self' for first parameter in methods.
-# This shouldn't apply to classmethods (first parameter should be 'cls' or similar)
-# or static methods (first parameter can be anything)
-
-class NonSelf(object):
-
-    def __init__(x):
-        pass
-
-    def s_method(y):
-        pass
-
-    def s_ok(self):
-        pass
-
-    @staticmethod
-    def s_smethod(ok):
-        pass
-
-    @classmethod
-    def s_cmethod(cls):
-        pass
-
-    def s_smethod2(ok):
-        pass
-    s_smethod2 = staticmethod(s_smethod2)
-
-    def s_cmethod2(cls):
-        pass
-    s_cmethod2 = classmethod(s_cmethod2)
 
 def returns_self(self):
     return self
@@ -159,9 +58,9 @@ def return_value_ignored():
     ok2()
     ok4()
     sorted([1,2])
-    
+
 d = {}
- 
+
 def use_return_values():
     x = ok2()
     x = ok2()
@@ -194,15 +93,15 @@ def ok_to_ignore():
     returns_self()
     ok3()
     y()
-    
+
 class DeprecatedSliceMethods(object):
-    
+
     def __getslice__(self, start, stop):
         pass
-    
+
     def __setslice__(self, start, stop, value):
         pass
-    
+
     def __delslice__(self, start, stop):
         pass
 
@@ -217,36 +116,32 @@ def nested_call_implicit_return_func_ok(arg):
 
 
 
-#OK as it returns result of a call to super().__init__()
-class InitCallsInit(InitCallsError):
 
-    def __init__(self):
-        return super(InitCallsInit, self).__init__()
-    
+
 #Harmless, so we allow it.
 def use_implicit_return_value_ok(arg):
     return do_nothing()
-   
+
 def mutli_return(arg):
     if arg:
         return do_something()
     else:
         return do_nothing()
-    
+
 #Modification of parameter with default
 
 def augassign(x = []):
     x += ["x"]
-    
-    
+
+
 #Possible FPs for non-self. ODASA-2439
 
 class C(object):
     def _func(f):
         return f
-  
+
     _func(x)
-    
+
     #or
     @_func
     def meth(self):


### PR DESCRIPTION
Makes it easier to see what the testcases are relevant for what queries.

Also cleans up some trailing whitespace :smile: 