### PR TITLE
Sphinx: Add support for collapsible sections

### DIFF
--- a/docs/language/global-sphinx-files/_static/custom.css_t
+++ b/docs/language/global-sphinx-files/_static/custom.css_t
@@ -447,3 +447,18 @@ blockquote.pull-quote > :last-child {
         height:100%;
         }
     }
+
+/* -- COLLAPSIBLE SECTIONS --------------------------------------------------------------------------------- */
+
+.toggle .name {
+    display: block;
+    clear: both;
+}
+
+.toggle .name:after {
+    content: " ▶";
+}
+
+.toggle .name.open:after {
+    content: " ▼";
+}

--- a/docs/language/global-sphinx-files/_static/custom.css_t
+++ b/docs/language/global-sphinx-files/_static/custom.css_t
@@ -455,6 +455,10 @@ blockquote.pull-quote > :last-child {
     clear: both;
 }
 
+.toggle .name:hover {
+    text-decoration: underline;
+}
+
 .toggle .name:after {
     content: " ▶";
 }

--- a/docs/language/global-sphinx-files/_static/custom.css_t
+++ b/docs/language/global-sphinx-files/_static/custom.css_t
@@ -456,7 +456,7 @@ blockquote.pull-quote > :last-child {
 }
 
 .toggle .name:hover {
-    text-decoration: underline;
+    cursor: pointer;
 }
 
 .toggle .name:after {

--- a/docs/language/global-sphinx-files/_templates/layout.html
+++ b/docs/language/global-sphinx-files/_templates/layout.html
@@ -4,6 +4,8 @@
     This header (including the SVG logo) is copied from the Semmle 
     documentation home page at help.semmle.com.
 
+    It also adds some JavaScript (in the footer) to allow collapsible sections.
+
     The source for the default Alabaster stylesheet can be found at:
     https://github.com/bitprophet/alabaster/blob/master/alabaster/layout.html
 #}
@@ -108,6 +110,18 @@
 
 {% endblock %}
 
+{% block footer %}
+ <script type="text/javascript">
+    $(document).ready(function() {
+        $(".toggle > *").hide();
+        $(".toggle .name").show();
+        $(".toggle .name").click(function() {
+            $(this).parent().children().not(".name").toggle(400);
+            $(this).parent().children(".name").toggleClass("open");
+        })
+    });
+</script>
+{% endblock %}
 
     
 


### PR DESCRIPTION
I'm using these collapsible sections in the (upcoming) QL puzzles/tutorials, but it makes sense to have this reviewed in a separate PR first.

This is a fairly basic change (adapted from [here](https://stackoverflow.com/a/25543713)) but it seems to work as expected, using the following syntax:

```
.. container:: toggle

   .. container:: name

      **Name**

   Text that can be expanded and collapsed.
```

[Here](http://docteam.internal.semmle.com/shati/learn-ql/test.html) is a test page with a few toy examples.