### PR TITLE
C++: Implement predictableInstruction without Expr

### DIFF
--- a/cpp/ql/src/semmle/code/cpp/ir/dataflow/DefaultTaintTracking.qll
+++ b/cpp/ql/src/semmle/code/cpp/ir/dataflow/DefaultTaintTracking.qll
@@ -4,25 +4,17 @@ private import semmle.code.cpp.ir.dataflow.DataFlow
 private import semmle.code.cpp.ir.IR
 
 /**
- * A predictable expression is one where an external user can predict
+ * A predictable instruction is one where an external user can predict
  * the value. For example, a literal in the source code is considered
  * predictable.
  */
-// TODO: Change to use Instruction instead of Expr. Naive attempt breaks
-// TaintedAllocationSize qltest.
-private predicate predictable(Expr expr) {
-  expr instanceof Literal
-  or
-  exists(BinaryOperation binop | binop = expr |
-    predictable(binop.getLeftOperand()) and predictable(binop.getRightOperand())
-  )
-  or
-  exists(UnaryOperation unop | unop = expr | predictable(unop.getOperand()))
-}
-
-// TODO: remove when `predictable` has an `Instruction` parameter instead of `Expr`.
 private predicate predictableInstruction(Instruction instr) {
-  predictable(DataFlow::instructionNode(instr).asExpr())
+  instr instanceof ConstantInstruction
+  or
+  instr instanceof StringConstantInstruction
+  or
+  // This could be a conversion on a string literal
+  predictableInstruction(instr.(UnaryInstruction).getUnary())
 }
 
 private class DefaultTaintTrackingCfg extends DataFlow::Configuration {


### PR DESCRIPTION
This is one step toward implementing the taint-tracking wrapper in terms of `Instruction` rather than `Expr`.

This leads to a few duplicate results in `TaintedAllocationSize.ql` because the library now considers `sizeof(int)` to be just as predictable as `4`, whereas the `security.TaintTracking` library does not consider `sizeof` to be predictable. I think it's simpler to accept the duplicate results since they are ultimately a quirk of the query, not the library.

The following is the diff between (a) replacing `TaintTracking.qll` with a link to `DefaultTaintTracking.qll` and (b) additionally applying this commit.

```diff
diff --git a b
--- a/cpp/ql/test/query-tests/Security/CWE/CWE-190/semmle/TaintedAllocationSize/TaintedAllocationSize.expected
+++ b/cpp/ql/test/query-tests/Security/CWE/CWE-190/semmle/TaintedAllocationSize/TaintedAllocationSize.expected
@@ -1,5 +1,8 @@
 | test.cpp:42:31:42:36 | call to malloc | This allocation size is derived from $@ and might overflow | test.cpp:39:21:39:24 | argv | user input (argv) |
+| test.cpp:43:31:43:36 | call to malloc | This allocation size is derived from $@ and might overflow | test.cpp:39:21:39:24 | argv | user input (argv) |
 | test.cpp:43:38:43:63 | ... * ... | This allocation size is derived from $@ and might overflow | test.cpp:39:21:39:24 | argv | user input (argv) |
+| test.cpp:45:31:45:36 | call to malloc | This allocation size is derived from $@ and might overflow | test.cpp:39:21:39:24 | argv | user input (argv) |
 | test.cpp:48:25:48:30 | call to malloc | This allocation size is derived from $@ and might overflow | test.cpp:39:21:39:24 | argv | user input (argv) |
 | test.cpp:49:17:49:30 | new[] | This allocation size is derived from $@ and might overflow | test.cpp:39:21:39:24 | argv | user input (argv) |
+| test.cpp:52:21:52:27 | call to realloc | This allocation size is derived from $@ and might overflow | test.cpp:39:21:39:24 | argv | user input (argv) |
 | test.cpp:52:35:52:60 | ... * ... | This allocation size is derived from $@ and might overflow | test.cpp:39:21:39:24 | argv | user input (argv) |
--- a/semmlecode-cpp-tests/DO_NOT_DISTRIBUTE/security-tests/CWE-190/CERT/INT04-C/int04.expected
+++ b/semmlecode-cpp-tests/DO_NOT_DISTRIBUTE/security-tests/CWE-190/CERT/INT04-C/int04.expected
@@ -1 +1,2 @@
 | int04c.c:21:29:21:51 | ... * ... | This allocation size is derived from $@ and might overflow | int04c.c:14:30:14:35 | call to getenv | user input (getenv) |
+| int04c.c:22:33:22:38 | call to malloc | This allocation size is derived from $@ and might overflow | int04c.c:14:30:14:35 | call to getenv | user input (getenv) |
```