### PR TITLE
C++: Ignore templates in AmbiguouslySignedBitField.ql

### DIFF
--- a/cpp/ql/src/Likely Bugs/AmbiguouslySignedBitField.ql
+++ b/cpp/ql/src/Likely Bugs/AmbiguouslySignedBitField.ql
@@ -28,7 +28,8 @@ where
   not bf.getType().hasName("BOOL") and
   // If this is true, then there cannot be unsigned sign extension or overflow.
   not bf.getDeclaredNumBits() = bf.getType().getSize() * 8 and
-  not bf.isAnonymous()
+  not bf.isAnonymous() and
+  not bf.isFromUninstantiatedTemplate(_)
 select bf,
   "Bit field " + bf.getName() + " of type " + bf.getUnderlyingType().getName() +
     " should have explicitly unsigned integral, explicitly signed integral, or enumeration type."

--- a/cpp/ql/test/query-tests/Likely Bugs/AmbiguouslySignedBitField/AmbiguouslySignedBitField.expected
+++ b/cpp/ql/test/query-tests/Likely Bugs/AmbiguouslySignedBitField/AmbiguouslySignedBitField.expected
@@ -3,4 +3,3 @@
 | test.cpp:20:8:20:18 | nosignshort | Bit field nosignshort of type short should have explicitly unsigned integral, explicitly signed integral, or enumeration type. |
 | test.cpp:21:18:21:30 | nosigntypedef | Bit field nosigntypedef of type int should have explicitly unsigned integral, explicitly signed integral, or enumeration type. |
 | test.cpp:23:15:23:25 | nosignconst | Bit field nosignconst of type const int should have explicitly unsigned integral, explicitly signed integral, or enumeration type. |
-| test.cpp:31:5:31:16 | templatesign | Bit field templatesign of type T should have explicitly unsigned integral, explicitly signed integral, or enumeration type. |

--- a/cpp/ql/test/query-tests/Likely Bugs/AmbiguouslySignedBitField/AmbiguouslySignedBitField.expected
+++ b/cpp/ql/test/query-tests/Likely Bugs/AmbiguouslySignedBitField/AmbiguouslySignedBitField.expected
@@ -3,3 +3,4 @@
 | test.cpp:20:8:20:18 | nosignshort | Bit field nosignshort of type short should have explicitly unsigned integral, explicitly signed integral, or enumeration type. |
 | test.cpp:21:18:21:30 | nosigntypedef | Bit field nosigntypedef of type int should have explicitly unsigned integral, explicitly signed integral, or enumeration type. |
 | test.cpp:23:15:23:25 | nosignconst | Bit field nosignconst of type const int should have explicitly unsigned integral, explicitly signed integral, or enumeration type. |
+| test.cpp:31:5:31:16 | templatesign | Bit field templatesign of type T should have explicitly unsigned integral, explicitly signed integral, or enumeration type. |

--- a/cpp/ql/test/query-tests/Likely Bugs/AmbiguouslySignedBitField/test.cpp
+++ b/cpp/ql/test/query-tests/Likely Bugs/AmbiguouslySignedBitField/test.cpp
@@ -28,7 +28,7 @@ struct {
 
 template<typename T>
 struct TemplateWithBitfield {
-  T templatesign : 2; // GOOD [FALSE POSITIVE]
+  T templatesign : 2; // GOOD
 };
 
 TemplateWithBitfield<signed int> twb;

--- a/cpp/ql/test/query-tests/Likely Bugs/AmbiguouslySignedBitField/test.cpp
+++ b/cpp/ql/test/query-tests/Likely Bugs/AmbiguouslySignedBitField/test.cpp
@@ -25,3 +25,10 @@ struct {
     myEnum nosignenum : 2;
     const myEnum constnosignenum : 2;
 };
+
+template<typename T>
+struct TemplateWithBitfield {
+  T templatesign : 2; // GOOD [FALSE POSITIVE]
+};
+
+TemplateWithBitfield<signed int> twb;


### PR DESCRIPTION
Fixes #1964.