### PR TITLE
C++: DefaultTaintTracking flow from a to a[i]

### DIFF
--- a/cpp/ql/src/semmle/code/cpp/ir/dataflow/DefaultTaintTracking.qll
+++ b/cpp/ql/src/semmle/code/cpp/ir/dataflow/DefaultTaintTracking.qll
@@ -90,10 +90,10 @@ private predicate instructionTaintStep(Instruction i1, Instruction i2) {
     predictableInstruction(i2.getAnOperand().getDef()) and
     i1 = i2.getAnOperand().getDef()
   )
-  // TODO: Check that we have flow from `a` to `a[i]`. It may work for constant
-  // `i` because there is flow through `predictable` `BinaryInstruction` and
-  // through `LoadInstruction`.
-  //
+  or
+  // This is part of the translation of `a[i]`, where we want taint to flow
+  // from `a`.
+  i2.(PointerAddInstruction).getLeft() = i1
   // TODO: Flow from argument to return of known functions: Port missing parts
   // of `returnArgument` to the `interfaces.Taint` and `interfaces.DataFlow`
   // libraries.


### PR DESCRIPTION
Switching `security.TaintTracking` to use `DefaultTaintTracking` causes us to lose a result from `UnboundedWrite.ql`, while this commit restores it:

```diff
diff --git a/semmlecode-cpp-tests/DO_NOT_DISTRIBUTE/security-tests/CWE-120/CERT/STR35-C/UnboundedWrite.expected b/semmlecode-cpp-tests/DO_NOT_DISTRIBUTE/security-tests/CWE-120/CERT/STR35-C/UnboundedWrite.expected
index 1eba0e52f0e..d947b33b9d9 100644
--- a/semmlecode-cpp-tests/DO_NOT_DISTRIBUTE/security-tests/CWE-120/CERT/STR35-C/UnboundedWrite.expected
+++ b/semmlecode-cpp-tests/DO_NOT_DISTRIBUTE/security-tests/CWE-120/CERT/STR35-C/UnboundedWrite.expected
@@ -1,2 +1,3 @@
+| main.c:54:7:54:12 | call to strcat | This 'call to strcat' with input from $@ may overflow the destination. | main.c:93:15:93:18 | argv | argv |
 | main.c:99:9:99:12 | call to gets | This 'call to gets' with input from $@ may overflow the destination. | main.c:99:9:99:12 | call to gets | call to gets |
 | main.c:213:17:213:19 | buf | This 'scanf string argument' with input from $@ may overflow the destination. | main.c:213:17:213:19 | buf | buf |
```