### PR TITLE
C++: ignore uninstantiated templates in WrongTypeFormatArguments.ql

### DIFF
--- a/cpp/ql/src/Likely Bugs/Format/WrongTypeFormatArguments.ql
+++ b/cpp/ql/src/Likely Bugs/Format/WrongTypeFormatArguments.ql
@@ -157,7 +157,8 @@ where
     formatOtherArgType(ffc, n, expected, arg, actual) and
     not actual.getUnspecifiedType().(IntegralType).getSize() = sizeof_IntType()
   ) and
-  not arg.isAffectedByMacro()
+  not arg.isAffectedByMacro() and
+  not arg.isFromUninstantiatedTemplate(_)
 select arg,
   "This argument should be of type '" + expected.getName() + "' but is of type '" +
     actual.getUnspecifiedType().getName() + "'"

--- a/cpp/ql/test/query-tests/Likely Bugs/Format/WrongTypeFormatArguments/Linux_signed_chars/WrongTypeFormatArguments.expected
+++ b/cpp/ql/test/query-tests/Likely Bugs/Format/WrongTypeFormatArguments/Linux_signed_chars/WrongTypeFormatArguments.expected
@@ -1,6 +1,7 @@
 | format.h:16:59:16:61 | str | This argument should be of type 'int' but is of type 'char *' |
 | format.h:16:64:16:64 | i | This argument should be of type 'double' but is of type 'int' |
 | format.h:16:67:16:67 | d | This argument should be of type 'char *' but is of type 'double' |
+| linux.cpp:15:24:15:41 | call to get_template_value | This argument should be of type 'int' but is of type 'long' |
 | linux_c.c:11:15:11:18 | str3 | This argument should be of type 'char *' but is of type 'short *' |
 | pri_macros.h:15:35:15:40 | my_u64 | This argument should be of type 'unsigned int' but is of type 'unsigned long long' |
 | printf1.h:12:27:12:27 | i | This argument should be of type 'double' but is of type 'int' |

--- a/cpp/ql/test/query-tests/Likely Bugs/Format/WrongTypeFormatArguments/Linux_signed_chars/linux.cpp
+++ b/cpp/ql/test/query-tests/Likely Bugs/Format/WrongTypeFormatArguments/Linux_signed_chars/linux.cpp
@@ -2,3 +2,23 @@ typedef unsigned long size_t;
 typedef long ssize_t;
 
 #include "common.h"
+
+template <typename T>
+struct S {
+  int get_int();
+  T get_template_value();
+};
+
+template <typename U>
+void template_func_calling_printf(S<U> &obj) {
+  ::printf("%d\n", obj.get_int());
+  ::printf("%d\n", obj.get_template_value());
+}
+
+void instantiate() {
+  S<int>  s_int;
+  S<long> s_long;
+
+  template_func_calling_printf(s_int);  // ok
+  template_func_calling_printf(s_long); // not ok (long -> int)
+}


### PR DESCRIPTION
This fixes #1975.