### PR TITLE
C#: Remove false positives from `cs/dereferenced-value-may-be-null`

### DIFF
--- a/change-notes/1.23/analysis-csharp.md
+++ b/change-notes/1.23/analysis-csharp.md
@@ -15,6 +15,7 @@ The following changes in version 1.23 affect C# analysis in all applications.
 
 | **Query**                    | **Expected impact**    | **Change**                        |
 |------------------------------|------------------------|-----------------------------------|
+| Dereferenced variable may be null (`cs/dereferenced-value-may-be-null`) | Fewer false positive results | More `null` checks are now taken into account, including `null` checks for `dynamic` expressions and `null` checks such as `object alwaysNull = null; if (x != alwaysNull) ...`. |
 
 ## Removal of old queries
 

--- a/csharp/ql/src/semmle/code/csharp/commons/ComparisonTest.qll
+++ b/csharp/ql/src/semmle/code/csharp/commons/ComparisonTest.qll
@@ -121,7 +121,10 @@ private newtype TComparisonTest =
     )
   } or
   TComparisonOperatorCall(OperatorCall oc, ComparisonKind kind, Expr first, Expr second) {
-    exists(Operator o | o = oc.getTarget() |
+    exists(Operator o |
+      o = oc.getTarget() or
+      o.getName() = oc.(DynamicOperatorCall).getLateBoundTargetName()
+    |
       o instanceof EQOperator and
       kind.isEquality() and
       first = oc.getArgument(0) and

--- a/csharp/ql/src/semmle/code/csharp/controlflow/Guards.qll
+++ b/csharp/ql/src/semmle/code/csharp/controlflow/Guards.qll
@@ -277,11 +277,12 @@ class DereferenceableExpr extends Expr {
   private Expr getABooleanNullCheck(BooleanValue v, boolean isNull) {
     exists(boolean branch | branch = v.getValue() |
       // Comparison with `null`, for example `x != null`
-      exists(ComparisonTest ct, ComparisonKind ck, NullLiteral nl |
+      exists(ComparisonTest ct, ComparisonKind ck, Expr e |
         ct.getExpr() = result and
         ct.getAnArgument() = this and
-        ct.getAnArgument() = nl and
-        this != nl and
+        ct.getAnArgument() = e and
+        e = any(NullValue nv | nv.isNull()).getAnExpr() and
+        this != e and
         ck = ct.getComparisonKind()
       |
         ck.isEquality() and isNull = branch

--- a/csharp/ql/test/library-tests/commons/ComparisonTest/ComparisonTest.cs
+++ b/csharp/ql/test/library-tests/commons/ComparisonTest/ComparisonTest.cs
@@ -106,4 +106,16 @@ class ComparisonTest
             b = x.CompareTo(y).CompareTo(0).CompareTo(1) == 0;
         }
     }
+
+    void DynamicComparisons(object o1, object o2)
+    {
+        dynamic d1 = o1;
+        dynamic d2 = o2;
+        var b = d1 == d2;
+        b = d1 != d2;
+        b = d1 > d2;
+        b = d1 < d2;
+        b = d1 >= d2;
+        b = d1 <= d2;
+    }
 }

--- a/csharp/ql/test/library-tests/commons/ComparisonTest/comparisonTest.expected
+++ b/csharp/ql/test/library-tests/commons/ComparisonTest/comparisonTest.expected
@@ -62,3 +62,9 @@
 | ComparisonTest.cs:106:17:106:61 | ... == ... | < | ComparisonTest.cs:106:42:106:42 | 0 | ComparisonTest.cs:106:17:106:30 | call to method CompareTo |
 | ComparisonTest.cs:106:17:106:61 | ... == ... | = | ComparisonTest.cs:106:17:106:43 | call to method CompareTo | ComparisonTest.cs:106:55:106:55 | 1 |
 | ComparisonTest.cs:106:17:106:61 | ... == ... | = | ComparisonTest.cs:106:17:106:56 | call to method CompareTo | ComparisonTest.cs:106:61:106:61 | 0 |
+| ComparisonTest.cs:114:17:114:24 | dynamic call to operator == | = | ComparisonTest.cs:114:17:114:18 | access to local variable d1 | ComparisonTest.cs:114:23:114:24 | access to local variable d2 |
+| ComparisonTest.cs:115:13:115:20 | dynamic call to operator != | != | ComparisonTest.cs:115:13:115:14 | access to local variable d1 | ComparisonTest.cs:115:19:115:20 | access to local variable d2 |
+| ComparisonTest.cs:116:13:116:19 | dynamic call to operator > | < | ComparisonTest.cs:116:18:116:19 | access to local variable d2 | ComparisonTest.cs:116:13:116:14 | access to local variable d1 |
+| ComparisonTest.cs:117:13:117:19 | dynamic call to operator < | < | ComparisonTest.cs:117:13:117:14 | access to local variable d1 | ComparisonTest.cs:117:18:117:19 | access to local variable d2 |
+| ComparisonTest.cs:118:13:118:20 | dynamic call to operator >= | <= | ComparisonTest.cs:118:19:118:20 | access to local variable d2 | ComparisonTest.cs:118:13:118:14 | access to local variable d1 |
+| ComparisonTest.cs:119:13:119:20 | dynamic call to operator <= | <= | ComparisonTest.cs:119:13:119:14 | access to local variable d1 | ComparisonTest.cs:119:19:119:20 | access to local variable d2 |

--- a/csharp/ql/test/query-tests/Nullness/E.cs
+++ b/csharp/ql/test/query-tests/Nullness/E.cs
@@ -360,7 +360,7 @@ public class E
     {
         var x = s ?? o as string;
         if (x != (string)null)
-            x.ToString(); // GOOD (FALSE POSITIVE)
+            x.ToString(); // GOOD
     }
 }
 

--- a/csharp/ql/test/query-tests/Nullness/E.cs
+++ b/csharp/ql/test/query-tests/Nullness/E.cs
@@ -353,7 +353,7 @@ public class E
     {
         dynamic x = s ?? o as string;
         if (x != null)
-            x.ToString(); // GOOD (FALSE POSITIVE)
+            x.ToString(); // GOOD
     }
 
     static void Ex33(string s, object o)

--- a/csharp/ql/test/query-tests/Nullness/E.cs
+++ b/csharp/ql/test/query-tests/Nullness/E.cs
@@ -342,6 +342,26 @@ public class E
         var x = s ?? o as string;
         x.ToString(); // BAD (maybe)
     }
+
+    static void Ex31(string s, object o)
+    {
+        dynamic x = s ?? o as string;
+        x.ToString(); // BAD (maybe)
+    }
+
+    static void Ex32(string s, object o)
+    {
+        dynamic x = s ?? o as string;
+        if (x != null)
+            x.ToString(); // GOOD (FALSE POSITIVE)
+    }
+
+    static void Ex33(string s, object o)
+    {
+        var x = s ?? o as string;
+        if (x != (string)null)
+            x.ToString(); // GOOD (FALSE POSITIVE)
+    }
 }
 
 public static class Extensions

--- a/csharp/ql/test/query-tests/Nullness/EqualityCheck.expected
+++ b/csharp/ql/test/query-tests/Nullness/EqualityCheck.expected
@@ -216,6 +216,8 @@
 | E.cs:293:13:293:24 | ... == ... | true | E.cs:293:15:293:19 | call to method M2 | E.cs:293:24:293:24 | (...) ... |
 | E.cs:293:13:293:24 | ... == ... | true | E.cs:293:24:293:24 | (...) ... | E.cs:293:15:293:19 | call to method M2 |
 | E.cs:321:13:321:30 | ... is ... | true | E.cs:321:14:321:21 | ... ?? ... | E.cs:321:27:321:30 | null |
+| E.cs:362:13:362:29 | ... != ... | false | E.cs:362:13:362:13 | access to local variable x | E.cs:362:18:362:29 | (...) ... |
+| E.cs:362:13:362:29 | ... != ... | false | E.cs:362:18:362:29 | (...) ... | E.cs:362:13:362:13 | access to local variable x |
 | Forwarding.cs:59:13:59:21 | ... == ... | true | Forwarding.cs:59:13:59:13 | access to parameter o | Forwarding.cs:59:18:59:21 | null |
 | Forwarding.cs:59:13:59:21 | ... == ... | true | Forwarding.cs:59:18:59:21 | null | Forwarding.cs:59:13:59:13 | access to parameter o |
 | Forwarding.cs:78:16:78:39 | call to method ReferenceEquals | true | Forwarding.cs:78:32:78:32 | access to parameter o | Forwarding.cs:78:35:78:38 | null |

--- a/csharp/ql/test/query-tests/Nullness/EqualityCheck.expected
+++ b/csharp/ql/test/query-tests/Nullness/EqualityCheck.expected
@@ -216,6 +216,8 @@
 | E.cs:293:13:293:24 | ... == ... | true | E.cs:293:15:293:19 | call to method M2 | E.cs:293:24:293:24 | (...) ... |
 | E.cs:293:13:293:24 | ... == ... | true | E.cs:293:24:293:24 | (...) ... | E.cs:293:15:293:19 | call to method M2 |
 | E.cs:321:13:321:30 | ... is ... | true | E.cs:321:14:321:21 | ... ?? ... | E.cs:321:27:321:30 | null |
+| E.cs:355:13:355:21 | dynamic call to operator != | false | E.cs:355:13:355:13 | access to local variable x | E.cs:355:18:355:21 | null |
+| E.cs:355:13:355:21 | dynamic call to operator != | false | E.cs:355:18:355:21 | null | E.cs:355:13:355:13 | access to local variable x |
 | E.cs:362:13:362:29 | ... != ... | false | E.cs:362:13:362:13 | access to local variable x | E.cs:362:18:362:29 | (...) ... |
 | E.cs:362:13:362:29 | ... != ... | false | E.cs:362:18:362:29 | (...) ... | E.cs:362:13:362:13 | access to local variable x |
 | Forwarding.cs:59:13:59:21 | ... == ... | true | Forwarding.cs:59:13:59:13 | access to parameter o | Forwarding.cs:59:18:59:21 | null |

--- a/csharp/ql/test/query-tests/Nullness/Implications.expected
+++ b/csharp/ql/test/query-tests/Nullness/Implications.expected
@@ -203,25 +203,33 @@
 | B.cs:12:13:12:24 | access to local variable eqCallAlways | non-null | B.cs:7:26:7:29 | null | non-null |
 | B.cs:12:13:12:24 | access to local variable eqCallAlways | null | B.cs:7:26:7:29 | null | null |
 | B.cs:12:13:12:32 | call to operator == | false | B.cs:12:13:12:24 | access to local variable eqCallAlways | non-null |
+| B.cs:12:13:12:32 | call to operator == | false | B.cs:12:29:12:32 | null | non-null |
 | B.cs:12:13:12:32 | call to operator == | true | B.cs:12:13:12:24 | access to local variable eqCallAlways | null |
+| B.cs:12:13:12:32 | call to operator == | true | B.cs:12:29:12:32 | null | null |
 | B.cs:13:13:13:24 | access to local variable eqCallAlways | non-null | B.cs:7:26:7:29 | null | non-null |
 | B.cs:13:13:13:24 | access to local variable eqCallAlways | null | B.cs:7:26:7:29 | null | null |
 | B.cs:15:13:15:14 | access to local variable b2 | non-null | B.cs:8:16:8:19 | null | non-null |
 | B.cs:15:13:15:14 | access to local variable b2 | null | B.cs:8:16:8:19 | null | null |
 | B.cs:15:13:15:22 | call to operator != | false | B.cs:15:13:15:14 | access to local variable b2 | null |
+| B.cs:15:13:15:22 | call to operator != | false | B.cs:15:19:15:22 | null | null |
 | B.cs:15:13:15:22 | call to operator != | true | B.cs:15:13:15:14 | access to local variable b2 | non-null |
+| B.cs:15:13:15:22 | call to operator != | true | B.cs:15:19:15:22 | null | non-null |
 | B.cs:16:13:16:14 | access to local variable b2 | non-null | B.cs:8:16:8:19 | null | non-null |
 | B.cs:16:13:16:14 | access to local variable b2 | null | B.cs:8:16:8:19 | null | null |
 | B.cs:18:13:18:14 | access to local variable b3 | non-null | B.cs:9:16:9:19 | null | non-null |
 | B.cs:18:13:18:14 | access to local variable b3 | null | B.cs:9:16:9:19 | null | null |
 | B.cs:18:13:18:22 | call to operator == | false | B.cs:18:13:18:14 | access to local variable b3 | non-null |
+| B.cs:18:13:18:22 | call to operator == | false | B.cs:18:19:18:22 | null | non-null |
 | B.cs:18:13:18:22 | call to operator == | true | B.cs:18:13:18:14 | access to local variable b3 | null |
+| B.cs:18:13:18:22 | call to operator == | true | B.cs:18:19:18:22 | null | null |
 | B.cs:20:13:20:14 | access to local variable b3 | non-null | B.cs:9:16:9:19 | null | non-null |
 | B.cs:20:13:20:14 | access to local variable b3 | null | B.cs:9:16:9:19 | null | null |
 | B.cs:22:13:22:25 | access to local variable neqCallAlways | non-null | B.cs:10:27:10:30 | null | non-null |
 | B.cs:22:13:22:25 | access to local variable neqCallAlways | null | B.cs:10:27:10:30 | null | null |
 | B.cs:22:13:22:33 | call to operator != | false | B.cs:22:13:22:25 | access to local variable neqCallAlways | null |
+| B.cs:22:13:22:33 | call to operator != | false | B.cs:22:30:22:33 | null | null |
 | B.cs:22:13:22:33 | call to operator != | true | B.cs:22:13:22:25 | access to local variable neqCallAlways | non-null |
+| B.cs:22:13:22:33 | call to operator != | true | B.cs:22:30:22:33 | null | non-null |
 | B.cs:24:13:24:25 | access to local variable neqCallAlways | non-null | B.cs:10:27:10:30 | null | non-null |
 | B.cs:24:13:24:25 | access to local variable neqCallAlways | null | B.cs:10:27:10:30 | null | null |
 | B.cs:34:16:34:26 | !... | false | B.cs:34:18:34:25 | call to operator == | true |
@@ -229,11 +237,17 @@
 | B.cs:53:17:53:25 | (...) ... | non-null | B.cs:53:25:53:25 | access to local variable o | non-null |
 | B.cs:53:17:53:25 | (...) ... | null | B.cs:53:25:53:25 | access to local variable o | null |
 | B.cs:53:17:53:33 | ... != ... | false | B.cs:53:17:53:25 | (...) ... | null |
+| B.cs:53:17:53:33 | ... != ... | false | B.cs:53:30:53:33 | null | null |
 | B.cs:53:17:53:33 | ... != ... | true | B.cs:53:17:53:25 | (...) ... | non-null |
+| B.cs:53:17:53:33 | ... != ... | true | B.cs:53:30:53:33 | null | non-null |
 | B.cs:53:25:53:25 | access to local variable o | non-null | B.cs:52:24:52:27 | null | non-null |
 | B.cs:53:25:53:25 | access to local variable o | null | B.cs:52:24:52:27 | null | null |
 | B.cs:55:26:55:26 | access to local variable o | non-null | B.cs:52:24:52:27 | null | non-null |
 | B.cs:55:26:55:26 | access to local variable o | null | B.cs:52:24:52:27 | null | null |
+| B.cs:55:26:55:36 | call to method Equals | false | B.cs:55:26:55:26 | access to local variable o | non-null |
+| B.cs:55:26:55:36 | call to method Equals | false | B.cs:55:35:55:35 | access to local variable o | non-null |
+| B.cs:55:26:55:36 | call to method Equals | true | B.cs:55:26:55:26 | access to local variable o | null |
+| B.cs:55:26:55:36 | call to method Equals | true | B.cs:55:35:55:35 | access to local variable o | null |
 | B.cs:55:35:55:35 | access to local variable o | non-null | B.cs:52:24:52:27 | null | non-null |
 | B.cs:55:35:55:35 | access to local variable o | null | B.cs:52:24:52:27 | null | null |
 | C.cs:11:13:11:30 | !... | false | C.cs:11:15:11:29 | !... | true |
@@ -245,7 +259,9 @@
 | C.cs:11:19:11:19 | access to local variable o | non-null | C.cs:10:20:10:23 | null | non-null |
 | C.cs:11:19:11:19 | access to local variable o | null | C.cs:10:20:10:23 | null | null |
 | C.cs:11:19:11:27 | ... == ... | false | C.cs:11:19:11:19 | access to local variable o | non-null |
+| C.cs:11:19:11:27 | ... == ... | false | C.cs:11:24:11:27 | null | non-null |
 | C.cs:11:19:11:27 | ... == ... | true | C.cs:11:19:11:19 | access to local variable o | null |
+| C.cs:11:19:11:27 | ... == ... | true | C.cs:11:24:11:27 | null | null |
 | C.cs:13:13:13:13 | access to local variable o | non-null | C.cs:10:20:10:23 | null | non-null |
 | C.cs:13:13:13:13 | access to local variable o | null | C.cs:10:20:10:23 | null | null |
 | C.cs:16:13:16:24 | !... | false | C.cs:16:15:16:23 | ... != ... | true |
@@ -253,7 +269,9 @@
 | C.cs:16:15:16:15 | access to local variable o | non-null | C.cs:10:20:10:23 | null | non-null |
 | C.cs:16:15:16:15 | access to local variable o | null | C.cs:10:20:10:23 | null | null |
 | C.cs:16:15:16:23 | ... != ... | false | C.cs:16:15:16:15 | access to local variable o | null |
+| C.cs:16:15:16:23 | ... != ... | false | C.cs:16:20:16:23 | null | null |
 | C.cs:16:15:16:23 | ... != ... | true | C.cs:16:15:16:15 | access to local variable o | non-null |
+| C.cs:16:15:16:23 | ... != ... | true | C.cs:16:20:16:23 | null | non-null |
 | C.cs:18:13:18:13 | access to local variable o | non-null | C.cs:10:20:10:23 | null | non-null |
 | C.cs:18:13:18:13 | access to local variable o | null | C.cs:10:20:10:23 | null | null |
 | C.cs:24:13:24:21 | ... != ... | false | C.cs:24:13:24:13 | access to parameter o | null |
@@ -362,7 +380,9 @@
 | C.cs:114:22:114:28 | access to local variable colours | non-null | C.cs:113:26:113:29 | null | non-null |
 | C.cs:114:22:114:28 | access to local variable colours | null | C.cs:113:26:113:29 | null | null |
 | C.cs:114:22:114:36 | ... == ... | false | C.cs:114:22:114:28 | access to local variable colours | non-null |
+| C.cs:114:22:114:36 | ... == ... | false | C.cs:114:33:114:36 | null | non-null |
 | C.cs:114:22:114:36 | ... == ... | true | C.cs:114:22:114:28 | access to local variable colours | null |
+| C.cs:114:22:114:36 | ... == ... | true | C.cs:114:33:114:36 | null | null |
 | C.cs:114:22:114:59 | ... \|\| ... | false | C.cs:114:22:114:36 | ... == ... | false |
 | C.cs:114:22:114:59 | ... \|\| ... | false | C.cs:114:41:114:59 | ... == ... | false |
 | C.cs:114:22:114:90 | ... ? ... : ... | null | C.cs:114:22:114:59 | ... \|\| ... | false |
@@ -376,10 +396,14 @@
 | C.cs:121:13:121:20 | access to local variable children | non-null | C.cs:119:29:119:32 | null | non-null |
 | C.cs:121:13:121:20 | access to local variable children | null | C.cs:119:29:119:32 | null | null |
 | C.cs:121:13:121:28 | ... == ... | false | C.cs:121:13:121:20 | access to local variable children | non-null |
+| C.cs:121:13:121:28 | ... == ... | false | C.cs:121:25:121:28 | null | non-null |
 | C.cs:121:13:121:28 | ... == ... | true | C.cs:121:13:121:20 | access to local variable children | null |
+| C.cs:121:13:121:28 | ... == ... | true | C.cs:121:25:121:28 | null | null |
 | C.cs:123:13:123:31 | ... > ... | true | C.cs:123:13:123:20 | access to local variable children | non-empty |
 | C.cs:130:13:130:38 | ... == ... | false | C.cs:130:14:130:29 | ... = ... | non-null |
+| C.cs:130:13:130:38 | ... == ... | false | C.cs:130:35:130:38 | null | non-null |
 | C.cs:130:13:130:38 | ... == ... | true | C.cs:130:14:130:29 | ... = ... | null |
+| C.cs:130:13:130:38 | ... == ... | true | C.cs:130:35:130:38 | null | null |
 | C.cs:130:13:130:55 | ... \|\| ... | false | C.cs:130:13:130:38 | ... == ... | false |
 | C.cs:130:13:130:55 | ... \|\| ... | false | C.cs:130:43:130:55 | ... > ... | false |
 | C.cs:130:14:130:29 | ... = ... | empty | C.cs:130:14:130:15 | access to local variable ok | empty |
@@ -417,7 +441,9 @@
 | C.cs:138:35:138:37 | access to local variable ok2 | non-null | C.cs:138:23:138:29 | "hello" | non-null |
 | C.cs:138:35:138:37 | access to local variable ok2 | null | C.cs:138:23:138:29 | "hello" | null |
 | C.cs:146:13:146:39 | ... != ... | false | C.cs:146:14:146:30 | ... = ... | null |
+| C.cs:146:13:146:39 | ... != ... | false | C.cs:146:36:146:39 | null | null |
 | C.cs:146:13:146:39 | ... != ... | true | C.cs:146:14:146:30 | ... = ... | non-null |
+| C.cs:146:13:146:39 | ... != ... | true | C.cs:146:36:146:39 | null | non-null |
 | C.cs:146:13:146:57 | ... && ... | true | C.cs:146:13:146:39 | ... != ... | true |
 | C.cs:146:13:146:57 | ... && ... | true | C.cs:146:44:146:57 | ... > ... | true |
 | C.cs:146:14:146:30 | ... = ... | empty | C.cs:146:14:146:15 | access to local variable xx | empty |
@@ -445,19 +471,25 @@
 | C.cs:158:16:158:16 | access to local variable s | non-null | C.cs:156:17:156:20 | null | non-null |
 | C.cs:158:16:158:16 | access to local variable s | null | C.cs:156:17:156:20 | null | null |
 | C.cs:158:16:158:24 | ... != ... | false | C.cs:158:16:158:16 | access to local variable s | null |
+| C.cs:158:16:158:24 | ... != ... | false | C.cs:158:21:158:24 | null | null |
 | C.cs:158:16:158:24 | ... != ... | true | C.cs:158:16:158:16 | access to local variable s | non-null |
+| C.cs:158:16:158:24 | ... != ... | true | C.cs:158:21:158:24 | null | non-null |
 | C.cs:166:16:166:16 | access to local variable s | empty | C.cs:164:17:164:20 | null | empty |
 | C.cs:166:16:166:16 | access to local variable s | non-empty | C.cs:164:17:164:20 | null | non-empty |
 | C.cs:166:16:166:16 | access to local variable s | non-null | C.cs:164:17:164:20 | null | non-null |
 | C.cs:166:16:166:16 | access to local variable s | null | C.cs:164:17:164:20 | null | null |
 | C.cs:166:16:166:24 | ... != ... | false | C.cs:166:16:166:16 | access to local variable s | null |
+| C.cs:166:16:166:24 | ... != ... | false | C.cs:166:21:166:24 | null | null |
 | C.cs:166:16:166:24 | ... != ... | true | C.cs:166:16:166:16 | access to local variable s | non-null |
+| C.cs:166:16:166:24 | ... != ... | true | C.cs:166:21:166:24 | null | non-null |
 | C.cs:171:13:171:13 | access to local variable s | non-null | C.cs:168:13:168:16 | null | non-null |
 | C.cs:171:13:171:13 | access to local variable s | null | C.cs:168:13:168:16 | null | null |
 | C.cs:173:16:173:16 | access to local variable s | non-null | C.cs:168:13:168:16 | null | non-null |
 | C.cs:173:16:173:16 | access to local variable s | null | C.cs:168:13:168:16 | null | null |
 | C.cs:173:16:173:24 | ... != ... | false | C.cs:173:16:173:16 | access to local variable s | null |
+| C.cs:173:16:173:24 | ... != ... | false | C.cs:173:21:173:24 | null | null |
 | C.cs:173:16:173:24 | ... != ... | true | C.cs:173:16:173:16 | access to local variable s | non-null |
+| C.cs:173:16:173:24 | ... != ... | true | C.cs:173:21:173:24 | null | non-null |
 | C.cs:187:16:187:24 | ... != ... | false | C.cs:187:16:187:16 | access to local variable s | null |
 | C.cs:187:16:187:24 | ... != ... | true | C.cs:187:16:187:16 | access to local variable s | non-null |
 | C.cs:211:17:211:35 | ... ? ... : ... | non-null | C.cs:211:17:211:23 | call to method Maybe | false |
@@ -515,7 +547,9 @@
 | C.cs:236:14:236:21 | ... = ... | null | C.cs:236:14:236:14 | access to local variable s | null |
 | C.cs:236:14:236:21 | ... = ... | null | C.cs:236:18:236:21 | null | null |
 | C.cs:236:24:236:32 | ... == ... | false | C.cs:236:24:236:24 | access to local variable s | non-null |
+| C.cs:236:24:236:32 | ... == ... | false | C.cs:236:29:236:32 | null | non-null |
 | C.cs:236:24:236:32 | ... == ... | true | C.cs:236:24:236:24 | access to local variable s | null |
+| C.cs:236:24:236:32 | ... == ... | true | C.cs:236:29:236:32 | null | null |
 | C.cs:236:35:236:42 | ... = ... | empty | C.cs:236:35:236:35 | access to local variable s | empty |
 | C.cs:236:35:236:42 | ... = ... | empty | C.cs:236:39:236:42 | null | empty |
 | C.cs:236:35:236:42 | ... = ... | non-empty | C.cs:236:35:236:35 | access to local variable s | non-empty |
@@ -794,7 +828,9 @@
 | D.cs:212:18:212:18 | access to local variable n | non-null | D.cs:211:20:211:23 | null | non-null |
 | D.cs:212:18:212:18 | access to local variable n | null | D.cs:211:20:211:23 | null | null |
 | D.cs:212:18:212:26 | ... == ... | false | D.cs:212:18:212:18 | access to local variable n | non-null |
+| D.cs:212:18:212:26 | ... == ... | false | D.cs:212:23:212:26 | null | non-null |
 | D.cs:212:18:212:26 | ... == ... | true | D.cs:212:18:212:18 | access to local variable n | null |
+| D.cs:212:18:212:26 | ... == ... | true | D.cs:212:23:212:26 | null | null |
 | D.cs:212:18:212:45 | ... ? ... : ... | non-null | D.cs:212:18:212:26 | ... == ... | true |
 | D.cs:212:18:212:45 | ... ? ... : ... | non-null | D.cs:212:30:212:41 | object creation of type Object | non-null |
 | D.cs:212:18:212:45 | ... ? ... : ... | null | D.cs:212:18:212:26 | ... == ... | false |
@@ -1189,6 +1225,8 @@
 | E.cs:362:13:362:13 | access to local variable x | non-empty | E.cs:361:17:361:32 | ... ?? ... | non-empty |
 | E.cs:362:13:362:13 | access to local variable x | non-null | E.cs:361:17:361:32 | ... ?? ... | non-null |
 | E.cs:362:13:362:13 | access to local variable x | null | E.cs:361:17:361:32 | ... ?? ... | null |
+| E.cs:362:13:362:29 | ... != ... | false | E.cs:362:13:362:13 | access to local variable x | null |
+| E.cs:362:13:362:29 | ... != ... | true | E.cs:362:13:362:13 | access to local variable x | non-null |
 | E.cs:362:18:362:29 | (...) ... | non-null | E.cs:362:26:362:29 | null | non-null |
 | E.cs:362:18:362:29 | (...) ... | null | E.cs:362:26:362:29 | null | null |
 | E.cs:363:13:363:13 | access to local variable x | non-null | E.cs:361:17:361:32 | ... ?? ... | non-null |

--- a/csharp/ql/test/query-tests/Nullness/Implications.expected
+++ b/csharp/ql/test/query-tests/Nullness/Implications.expected
@@ -1179,6 +1179,8 @@
 | E.cs:354:21:354:36 | ... ?? ... | null | E.cs:354:26:354:36 | ... as ... | null |
 | E.cs:355:13:355:13 | access to local variable x | non-null | E.cs:354:21:354:36 | ... ?? ... | non-null |
 | E.cs:355:13:355:13 | access to local variable x | null | E.cs:354:21:354:36 | ... ?? ... | null |
+| E.cs:355:13:355:21 | dynamic call to operator != | false | E.cs:355:13:355:13 | access to local variable x | null |
+| E.cs:355:13:355:21 | dynamic call to operator != | true | E.cs:355:13:355:13 | access to local variable x | non-null |
 | E.cs:356:13:356:13 | access to local variable x | non-null | E.cs:354:21:354:36 | ... ?? ... | non-null |
 | E.cs:356:13:356:13 | access to local variable x | null | E.cs:354:21:354:36 | ... ?? ... | null |
 | E.cs:361:17:361:32 | ... ?? ... | null | E.cs:361:17:361:17 | access to parameter s | null |

--- a/csharp/ql/test/query-tests/Nullness/Implications.expected
+++ b/csharp/ql/test/query-tests/Nullness/Implications.expected
@@ -1171,6 +1171,26 @@
 | E.cs:343:9:343:9 | access to local variable x | non-empty | E.cs:342:17:342:32 | ... ?? ... | non-empty |
 | E.cs:343:9:343:9 | access to local variable x | non-null | E.cs:342:17:342:32 | ... ?? ... | non-null |
 | E.cs:343:9:343:9 | access to local variable x | null | E.cs:342:17:342:32 | ... ?? ... | null |
+| E.cs:348:21:348:36 | ... ?? ... | null | E.cs:348:21:348:21 | access to parameter s | null |
+| E.cs:348:21:348:36 | ... ?? ... | null | E.cs:348:26:348:36 | ... as ... | null |
+| E.cs:349:9:349:9 | access to local variable x | non-null | E.cs:348:21:348:36 | ... ?? ... | non-null |
+| E.cs:349:9:349:9 | access to local variable x | null | E.cs:348:21:348:36 | ... ?? ... | null |
+| E.cs:354:21:354:36 | ... ?? ... | null | E.cs:354:21:354:21 | access to parameter s | null |
+| E.cs:354:21:354:36 | ... ?? ... | null | E.cs:354:26:354:36 | ... as ... | null |
+| E.cs:355:13:355:13 | access to local variable x | non-null | E.cs:354:21:354:36 | ... ?? ... | non-null |
+| E.cs:355:13:355:13 | access to local variable x | null | E.cs:354:21:354:36 | ... ?? ... | null |
+| E.cs:356:13:356:13 | access to local variable x | non-null | E.cs:354:21:354:36 | ... ?? ... | non-null |
+| E.cs:356:13:356:13 | access to local variable x | null | E.cs:354:21:354:36 | ... ?? ... | null |
+| E.cs:361:17:361:32 | ... ?? ... | null | E.cs:361:17:361:17 | access to parameter s | null |
+| E.cs:361:17:361:32 | ... ?? ... | null | E.cs:361:22:361:32 | ... as ... | null |
+| E.cs:362:13:362:13 | access to local variable x | empty | E.cs:361:17:361:32 | ... ?? ... | empty |
+| E.cs:362:13:362:13 | access to local variable x | non-empty | E.cs:361:17:361:32 | ... ?? ... | non-empty |
+| E.cs:362:13:362:13 | access to local variable x | non-null | E.cs:361:17:361:32 | ... ?? ... | non-null |
+| E.cs:362:13:362:13 | access to local variable x | null | E.cs:361:17:361:32 | ... ?? ... | null |
+| E.cs:362:18:362:29 | (...) ... | non-null | E.cs:362:26:362:29 | null | non-null |
+| E.cs:362:18:362:29 | (...) ... | null | E.cs:362:26:362:29 | null | null |
+| E.cs:363:13:363:13 | access to local variable x | non-null | E.cs:361:17:361:32 | ... ?? ... | non-null |
+| E.cs:363:13:363:13 | access to local variable x | null | E.cs:361:17:361:32 | ... ?? ... | null |
 | Forwarding.cs:9:13:9:30 | !... | false | Forwarding.cs:9:14:9:30 | call to method IsNullOrEmpty | true |
 | Forwarding.cs:9:13:9:30 | !... | true | Forwarding.cs:9:14:9:30 | call to method IsNullOrEmpty | false |
 | Forwarding.cs:9:14:9:14 | access to local variable s | empty | Forwarding.cs:7:20:7:23 | null | empty |

--- a/csharp/ql/test/query-tests/Nullness/NullCheck.expected
+++ b/csharp/ql/test/query-tests/Nullness/NullCheck.expected
@@ -217,6 +217,12 @@
 | E.cs:336:17:336:17 | access to parameter s | E.cs:336:17:336:17 | access to parameter s | null | true |
 | E.cs:342:17:342:17 | access to parameter s | E.cs:342:17:342:17 | access to parameter s | non-null | false |
 | E.cs:342:17:342:17 | access to parameter s | E.cs:342:17:342:17 | access to parameter s | null | true |
+| E.cs:348:21:348:21 | access to parameter s | E.cs:348:21:348:21 | access to parameter s | non-null | false |
+| E.cs:348:21:348:21 | access to parameter s | E.cs:348:21:348:21 | access to parameter s | null | true |
+| E.cs:354:21:354:21 | access to parameter s | E.cs:354:21:354:21 | access to parameter s | non-null | false |
+| E.cs:354:21:354:21 | access to parameter s | E.cs:354:21:354:21 | access to parameter s | null | true |
+| E.cs:361:17:361:17 | access to parameter s | E.cs:361:17:361:17 | access to parameter s | non-null | false |
+| E.cs:361:17:361:17 | access to parameter s | E.cs:361:17:361:17 | access to parameter s | null | true |
 | Forwarding.cs:9:14:9:30 | call to method IsNullOrEmpty | Forwarding.cs:9:14:9:14 | access to local variable s | false | false |
 | Forwarding.cs:14:13:14:32 | call to method IsNotNullOrEmpty | Forwarding.cs:14:13:14:13 | access to local variable s | true | false |
 | Forwarding.cs:19:14:19:23 | call to method IsNull | Forwarding.cs:19:14:19:14 | access to local variable s | false | false |

--- a/csharp/ql/test/query-tests/Nullness/NullCheck.expected
+++ b/csharp/ql/test/query-tests/Nullness/NullCheck.expected
@@ -221,6 +221,8 @@
 | E.cs:348:21:348:21 | access to parameter s | E.cs:348:21:348:21 | access to parameter s | null | true |
 | E.cs:354:21:354:21 | access to parameter s | E.cs:354:21:354:21 | access to parameter s | non-null | false |
 | E.cs:354:21:354:21 | access to parameter s | E.cs:354:21:354:21 | access to parameter s | null | true |
+| E.cs:355:13:355:21 | dynamic call to operator != | E.cs:355:13:355:13 | access to local variable x | false | true |
+| E.cs:355:13:355:21 | dynamic call to operator != | E.cs:355:13:355:13 | access to local variable x | true | false |
 | E.cs:361:17:361:17 | access to parameter s | E.cs:361:17:361:17 | access to parameter s | non-null | false |
 | E.cs:361:17:361:17 | access to parameter s | E.cs:361:17:361:17 | access to parameter s | null | true |
 | Forwarding.cs:9:14:9:30 | call to method IsNullOrEmpty | Forwarding.cs:9:14:9:14 | access to local variable s | false | false |

--- a/csharp/ql/test/query-tests/Nullness/NullCheck.expected
+++ b/csharp/ql/test/query-tests/Nullness/NullCheck.expected
@@ -18,18 +18,36 @@
 | Assert.cs:50:24:50:32 | ... != ... | Assert.cs:50:24:50:24 | access to local variable s | true | false |
 | B.cs:12:13:12:32 | call to operator == | B.cs:12:13:12:24 | access to local variable eqCallAlways | false | false |
 | B.cs:12:13:12:32 | call to operator == | B.cs:12:13:12:24 | access to local variable eqCallAlways | true | true |
+| B.cs:12:13:12:32 | call to operator == | B.cs:12:29:12:32 | null | false | false |
+| B.cs:12:13:12:32 | call to operator == | B.cs:12:29:12:32 | null | true | true |
 | B.cs:15:13:15:22 | call to operator != | B.cs:15:13:15:14 | access to local variable b2 | false | true |
 | B.cs:15:13:15:22 | call to operator != | B.cs:15:13:15:14 | access to local variable b2 | true | false |
+| B.cs:15:13:15:22 | call to operator != | B.cs:15:19:15:22 | null | false | true |
+| B.cs:15:13:15:22 | call to operator != | B.cs:15:19:15:22 | null | true | false |
 | B.cs:18:13:18:22 | call to operator == | B.cs:18:13:18:14 | access to local variable b3 | false | false |
 | B.cs:18:13:18:22 | call to operator == | B.cs:18:13:18:14 | access to local variable b3 | true | true |
+| B.cs:18:13:18:22 | call to operator == | B.cs:18:19:18:22 | null | false | false |
+| B.cs:18:13:18:22 | call to operator == | B.cs:18:19:18:22 | null | true | true |
 | B.cs:22:13:22:33 | call to operator != | B.cs:22:13:22:25 | access to local variable neqCallAlways | false | true |
 | B.cs:22:13:22:33 | call to operator != | B.cs:22:13:22:25 | access to local variable neqCallAlways | true | false |
+| B.cs:22:13:22:33 | call to operator != | B.cs:22:30:22:33 | null | false | true |
+| B.cs:22:13:22:33 | call to operator != | B.cs:22:30:22:33 | null | true | false |
 | B.cs:53:17:53:33 | ... != ... | B.cs:53:17:53:25 | (...) ... | false | true |
 | B.cs:53:17:53:33 | ... != ... | B.cs:53:17:53:25 | (...) ... | true | false |
+| B.cs:53:17:53:33 | ... != ... | B.cs:53:30:53:33 | null | false | true |
+| B.cs:53:17:53:33 | ... != ... | B.cs:53:30:53:33 | null | true | false |
+| B.cs:55:26:55:36 | call to method Equals | B.cs:55:26:55:26 | access to local variable o | false | false |
+| B.cs:55:26:55:36 | call to method Equals | B.cs:55:26:55:26 | access to local variable o | true | true |
+| B.cs:55:26:55:36 | call to method Equals | B.cs:55:35:55:35 | access to local variable o | false | false |
+| B.cs:55:26:55:36 | call to method Equals | B.cs:55:35:55:35 | access to local variable o | true | true |
 | C.cs:11:19:11:27 | ... == ... | C.cs:11:19:11:19 | access to local variable o | false | false |
 | C.cs:11:19:11:27 | ... == ... | C.cs:11:19:11:19 | access to local variable o | true | true |
+| C.cs:11:19:11:27 | ... == ... | C.cs:11:24:11:27 | null | false | false |
+| C.cs:11:19:11:27 | ... == ... | C.cs:11:24:11:27 | null | true | true |
 | C.cs:16:15:16:23 | ... != ... | C.cs:16:15:16:15 | access to local variable o | false | true |
 | C.cs:16:15:16:23 | ... != ... | C.cs:16:15:16:15 | access to local variable o | true | false |
+| C.cs:16:15:16:23 | ... != ... | C.cs:16:20:16:23 | null | false | true |
+| C.cs:16:15:16:23 | ... != ... | C.cs:16:20:16:23 | null | true | false |
 | C.cs:24:13:24:21 | ... != ... | C.cs:24:13:24:13 | access to parameter o | false | true |
 | C.cs:24:13:24:21 | ... != ... | C.cs:24:13:24:13 | access to parameter o | true | false |
 | C.cs:28:37:28:45 | ... == ... | C.cs:28:37:28:37 | access to parameter o | false | false |
@@ -49,18 +67,32 @@
 | C.cs:89:13:89:23 | ... is ... | C.cs:89:13:89:13 | access to local variable o | true | false |
 | C.cs:114:22:114:36 | ... == ... | C.cs:114:22:114:28 | access to local variable colours | false | false |
 | C.cs:114:22:114:36 | ... == ... | C.cs:114:22:114:28 | access to local variable colours | true | true |
+| C.cs:114:22:114:36 | ... == ... | C.cs:114:33:114:36 | null | false | false |
+| C.cs:114:22:114:36 | ... == ... | C.cs:114:33:114:36 | null | true | true |
 | C.cs:121:13:121:28 | ... == ... | C.cs:121:13:121:20 | access to local variable children | false | false |
 | C.cs:121:13:121:28 | ... == ... | C.cs:121:13:121:20 | access to local variable children | true | true |
+| C.cs:121:13:121:28 | ... == ... | C.cs:121:25:121:28 | null | false | false |
+| C.cs:121:13:121:28 | ... == ... | C.cs:121:25:121:28 | null | true | true |
 | C.cs:130:13:130:38 | ... == ... | C.cs:130:14:130:29 | ... = ... | false | false |
 | C.cs:130:13:130:38 | ... == ... | C.cs:130:14:130:29 | ... = ... | true | true |
+| C.cs:130:13:130:38 | ... == ... | C.cs:130:35:130:38 | null | false | false |
+| C.cs:130:13:130:38 | ... == ... | C.cs:130:35:130:38 | null | true | true |
 | C.cs:146:13:146:39 | ... != ... | C.cs:146:14:146:30 | ... = ... | false | true |
 | C.cs:146:13:146:39 | ... != ... | C.cs:146:14:146:30 | ... = ... | true | false |
+| C.cs:146:13:146:39 | ... != ... | C.cs:146:36:146:39 | null | false | true |
+| C.cs:146:13:146:39 | ... != ... | C.cs:146:36:146:39 | null | true | false |
 | C.cs:158:16:158:24 | ... != ... | C.cs:158:16:158:16 | access to local variable s | false | true |
 | C.cs:158:16:158:24 | ... != ... | C.cs:158:16:158:16 | access to local variable s | true | false |
+| C.cs:158:16:158:24 | ... != ... | C.cs:158:21:158:24 | null | false | true |
+| C.cs:158:16:158:24 | ... != ... | C.cs:158:21:158:24 | null | true | false |
 | C.cs:166:16:166:24 | ... != ... | C.cs:166:16:166:16 | access to local variable s | false | true |
 | C.cs:166:16:166:24 | ... != ... | C.cs:166:16:166:16 | access to local variable s | true | false |
+| C.cs:166:16:166:24 | ... != ... | C.cs:166:21:166:24 | null | false | true |
+| C.cs:166:16:166:24 | ... != ... | C.cs:166:21:166:24 | null | true | false |
 | C.cs:173:16:173:24 | ... != ... | C.cs:173:16:173:16 | access to local variable s | false | true |
 | C.cs:173:16:173:24 | ... != ... | C.cs:173:16:173:16 | access to local variable s | true | false |
+| C.cs:173:16:173:24 | ... != ... | C.cs:173:21:173:24 | null | false | true |
+| C.cs:173:16:173:24 | ... != ... | C.cs:173:21:173:24 | null | true | false |
 | C.cs:187:16:187:24 | ... != ... | C.cs:187:16:187:16 | access to local variable s | false | true |
 | C.cs:187:16:187:24 | ... != ... | C.cs:187:16:187:16 | access to local variable s | true | false |
 | C.cs:212:13:212:21 | ... != ... | C.cs:212:13:212:13 | access to local variable s | false | true |
@@ -74,6 +106,8 @@
 | C.cs:230:22:230:30 | ... != ... | C.cs:230:22:230:22 | access to local variable s | true | false |
 | C.cs:236:24:236:32 | ... == ... | C.cs:236:24:236:24 | access to local variable s | false | false |
 | C.cs:236:24:236:32 | ... == ... | C.cs:236:24:236:24 | access to local variable s | true | true |
+| C.cs:236:24:236:32 | ... == ... | C.cs:236:29:236:32 | null | false | false |
+| C.cs:236:24:236:32 | ... == ... | C.cs:236:29:236:32 | null | true | true |
 | D.cs:28:13:28:25 | ... != ... | D.cs:28:13:28:17 | access to parameter param | false | true |
 | D.cs:28:13:28:25 | ... != ... | D.cs:28:13:28:17 | access to parameter param | true | false |
 | D.cs:37:13:37:23 | ... is ... | D.cs:37:13:37:13 | access to parameter x | true | false |
@@ -122,6 +156,8 @@
 | D.cs:206:17:206:25 | ... == ... | D.cs:206:17:206:17 | access to local variable e | true | true |
 | D.cs:212:18:212:26 | ... == ... | D.cs:212:18:212:18 | access to local variable n | false | false |
 | D.cs:212:18:212:26 | ... == ... | D.cs:212:18:212:18 | access to local variable n | true | true |
+| D.cs:212:18:212:26 | ... == ... | D.cs:212:23:212:26 | null | false | false |
+| D.cs:212:18:212:26 | ... == ... | D.cs:212:23:212:26 | null | true | true |
 | D.cs:216:13:216:22 | ... == ... | D.cs:216:13:216:14 | access to local variable o3 | false | false |
 | D.cs:216:13:216:22 | ... == ... | D.cs:216:13:216:14 | access to local variable o3 | true | true |
 | D.cs:216:13:216:22 | ... == ... | D.cs:216:19:216:22 | null | true | false |
@@ -225,6 +261,8 @@
 | E.cs:355:13:355:21 | dynamic call to operator != | E.cs:355:13:355:13 | access to local variable x | true | false |
 | E.cs:361:17:361:17 | access to parameter s | E.cs:361:17:361:17 | access to parameter s | non-null | false |
 | E.cs:361:17:361:17 | access to parameter s | E.cs:361:17:361:17 | access to parameter s | null | true |
+| E.cs:362:13:362:29 | ... != ... | E.cs:362:13:362:13 | access to local variable x | false | true |
+| E.cs:362:13:362:29 | ... != ... | E.cs:362:13:362:13 | access to local variable x | true | false |
 | Forwarding.cs:9:14:9:30 | call to method IsNullOrEmpty | Forwarding.cs:9:14:9:14 | access to local variable s | false | false |
 | Forwarding.cs:14:13:14:32 | call to method IsNotNullOrEmpty | Forwarding.cs:14:13:14:13 | access to local variable s | true | false |
 | Forwarding.cs:19:14:19:23 | call to method IsNull | Forwarding.cs:19:14:19:14 | access to local variable s | false | false |

--- a/csharp/ql/test/query-tests/Nullness/NullMaybe.expected
+++ b/csharp/ql/test/query-tests/Nullness/NullMaybe.expected
@@ -351,8 +351,6 @@ nodes
 | E.cs:343:9:343:9 | access to local variable x |
 | E.cs:348:17:348:36 | SSA def(x) |
 | E.cs:349:9:349:9 | access to local variable x |
-| E.cs:354:17:354:36 | SSA def(x) |
-| E.cs:356:13:356:13 | access to local variable x |
 | E.cs:361:13:361:32 | SSA def(x) |
 | E.cs:363:13:363:13 | access to local variable x |
 | Forwarding.cs:7:16:7:23 | SSA def(s) |
@@ -686,7 +684,6 @@ edges
 | E.cs:330:13:330:36 | SSA def(x) | E.cs:331:9:331:9 | access to local variable x |
 | E.cs:342:13:342:32 | SSA def(x) | E.cs:343:9:343:9 | access to local variable x |
 | E.cs:348:17:348:36 | SSA def(x) | E.cs:349:9:349:9 | access to local variable x |
-| E.cs:354:17:354:36 | SSA def(x) | E.cs:356:13:356:13 | access to local variable x |
 | E.cs:361:13:361:32 | SSA def(x) | E.cs:363:13:363:13 | access to local variable x |
 | Forwarding.cs:7:16:7:23 | SSA def(s) | Forwarding.cs:14:9:17:9 | if (...) ... |
 | Forwarding.cs:14:9:17:9 | if (...) ... | Forwarding.cs:19:9:22:9 | if (...) ... |
@@ -788,7 +785,6 @@ edges
 | E.cs:302:9:302:9 | access to local variable s | E.cs:301:13:301:27 | SSA def(s) | E.cs:302:9:302:9 | access to local variable s | Variable $@ may be null here because of $@ assignment. | E.cs:301:13:301:13 | s | s | E.cs:301:13:301:27 | String s = ... | this |
 | E.cs:343:9:343:9 | access to local variable x | E.cs:342:13:342:32 | SSA def(x) | E.cs:343:9:343:9 | access to local variable x | Variable $@ may be null here because of $@ assignment. | E.cs:342:13:342:13 | x | x | E.cs:342:13:342:32 | String x = ... | this |
 | E.cs:349:9:349:9 | access to local variable x | E.cs:348:17:348:36 | SSA def(x) | E.cs:349:9:349:9 | access to local variable x | Variable $@ may be null here because of $@ assignment. | E.cs:348:17:348:17 | x | x | E.cs:348:17:348:36 | dynamic x = ... | this |
-| E.cs:356:13:356:13 | access to local variable x | E.cs:354:17:354:36 | SSA def(x) | E.cs:356:13:356:13 | access to local variable x | Variable $@ may be null here because of $@ assignment. | E.cs:354:17:354:17 | x | x | E.cs:354:17:354:36 | dynamic x = ... | this |
 | E.cs:363:13:363:13 | access to local variable x | E.cs:361:13:361:32 | SSA def(x) | E.cs:363:13:363:13 | access to local variable x | Variable $@ may be null here because of $@ assignment. | E.cs:361:13:361:13 | x | x | E.cs:361:13:361:32 | String x = ... | this |
 | GuardedString.cs:35:31:35:31 | access to local variable s | GuardedString.cs:7:16:7:32 | SSA def(s) | GuardedString.cs:35:31:35:31 | access to local variable s | Variable $@ may be null here because of $@ assignment. | GuardedString.cs:7:16:7:16 | s | s | GuardedString.cs:7:16:7:32 | String s = ... | this |
 | NullMaybeBad.cs:7:27:7:27 | access to parameter o | NullMaybeBad.cs:13:17:13:20 | null | NullMaybeBad.cs:7:27:7:27 | access to parameter o | Variable $@ may be null here because of $@ null argument. | NullMaybeBad.cs:5:25:5:25 | o | o | NullMaybeBad.cs:13:17:13:20 | null | this |

--- a/csharp/ql/test/query-tests/Nullness/NullMaybe.expected
+++ b/csharp/ql/test/query-tests/Nullness/NullMaybe.expected
@@ -351,8 +351,6 @@ nodes
 | E.cs:343:9:343:9 | access to local variable x |
 | E.cs:348:17:348:36 | SSA def(x) |
 | E.cs:349:9:349:9 | access to local variable x |
-| E.cs:361:13:361:32 | SSA def(x) |
-| E.cs:363:13:363:13 | access to local variable x |
 | Forwarding.cs:7:16:7:23 | SSA def(s) |
 | Forwarding.cs:14:9:17:9 | if (...) ... |
 | Forwarding.cs:19:9:22:9 | if (...) ... |
@@ -684,7 +682,6 @@ edges
 | E.cs:330:13:330:36 | SSA def(x) | E.cs:331:9:331:9 | access to local variable x |
 | E.cs:342:13:342:32 | SSA def(x) | E.cs:343:9:343:9 | access to local variable x |
 | E.cs:348:17:348:36 | SSA def(x) | E.cs:349:9:349:9 | access to local variable x |
-| E.cs:361:13:361:32 | SSA def(x) | E.cs:363:13:363:13 | access to local variable x |
 | Forwarding.cs:7:16:7:23 | SSA def(s) | Forwarding.cs:14:9:17:9 | if (...) ... |
 | Forwarding.cs:14:9:17:9 | if (...) ... | Forwarding.cs:19:9:22:9 | if (...) ... |
 | Forwarding.cs:19:9:22:9 | if (...) ... | Forwarding.cs:24:9:27:9 | if (...) ... |
@@ -785,7 +782,6 @@ edges
 | E.cs:302:9:302:9 | access to local variable s | E.cs:301:13:301:27 | SSA def(s) | E.cs:302:9:302:9 | access to local variable s | Variable $@ may be null here because of $@ assignment. | E.cs:301:13:301:13 | s | s | E.cs:301:13:301:27 | String s = ... | this |
 | E.cs:343:9:343:9 | access to local variable x | E.cs:342:13:342:32 | SSA def(x) | E.cs:343:9:343:9 | access to local variable x | Variable $@ may be null here because of $@ assignment. | E.cs:342:13:342:13 | x | x | E.cs:342:13:342:32 | String x = ... | this |
 | E.cs:349:9:349:9 | access to local variable x | E.cs:348:17:348:36 | SSA def(x) | E.cs:349:9:349:9 | access to local variable x | Variable $@ may be null here because of $@ assignment. | E.cs:348:17:348:17 | x | x | E.cs:348:17:348:36 | dynamic x = ... | this |
-| E.cs:363:13:363:13 | access to local variable x | E.cs:361:13:361:32 | SSA def(x) | E.cs:363:13:363:13 | access to local variable x | Variable $@ may be null here because of $@ assignment. | E.cs:361:13:361:13 | x | x | E.cs:361:13:361:32 | String x = ... | this |
 | GuardedString.cs:35:31:35:31 | access to local variable s | GuardedString.cs:7:16:7:32 | SSA def(s) | GuardedString.cs:35:31:35:31 | access to local variable s | Variable $@ may be null here because of $@ assignment. | GuardedString.cs:7:16:7:16 | s | s | GuardedString.cs:7:16:7:32 | String s = ... | this |
 | NullMaybeBad.cs:7:27:7:27 | access to parameter o | NullMaybeBad.cs:13:17:13:20 | null | NullMaybeBad.cs:7:27:7:27 | access to parameter o | Variable $@ may be null here because of $@ null argument. | NullMaybeBad.cs:5:25:5:25 | o | o | NullMaybeBad.cs:13:17:13:20 | null | this |
 | StringConcatenation.cs:16:17:16:17 | access to local variable s | StringConcatenation.cs:14:16:14:23 | SSA def(s) | StringConcatenation.cs:16:17:16:17 | access to local variable s | Variable $@ may be null here because of $@ assignment. | StringConcatenation.cs:14:16:14:16 | s | s | StringConcatenation.cs:14:16:14:23 | String s = ... | this |

--- a/csharp/ql/test/query-tests/Nullness/NullMaybe.expected
+++ b/csharp/ql/test/query-tests/Nullness/NullMaybe.expected
@@ -349,6 +349,12 @@ nodes
 | E.cs:331:9:331:9 | access to local variable x |
 | E.cs:342:13:342:32 | SSA def(x) |
 | E.cs:343:9:343:9 | access to local variable x |
+| E.cs:348:17:348:36 | SSA def(x) |
+| E.cs:349:9:349:9 | access to local variable x |
+| E.cs:354:17:354:36 | SSA def(x) |
+| E.cs:356:13:356:13 | access to local variable x |
+| E.cs:361:13:361:32 | SSA def(x) |
+| E.cs:363:13:363:13 | access to local variable x |
 | Forwarding.cs:7:16:7:23 | SSA def(s) |
 | Forwarding.cs:14:9:17:9 | if (...) ... |
 | Forwarding.cs:19:9:22:9 | if (...) ... |
@@ -679,6 +685,9 @@ edges
 | E.cs:321:27:321:30 | null | E.cs:323:13:323:14 | access to parameter s1 |
 | E.cs:330:13:330:36 | SSA def(x) | E.cs:331:9:331:9 | access to local variable x |
 | E.cs:342:13:342:32 | SSA def(x) | E.cs:343:9:343:9 | access to local variable x |
+| E.cs:348:17:348:36 | SSA def(x) | E.cs:349:9:349:9 | access to local variable x |
+| E.cs:354:17:354:36 | SSA def(x) | E.cs:356:13:356:13 | access to local variable x |
+| E.cs:361:13:361:32 | SSA def(x) | E.cs:363:13:363:13 | access to local variable x |
 | Forwarding.cs:7:16:7:23 | SSA def(s) | Forwarding.cs:14:9:17:9 | if (...) ... |
 | Forwarding.cs:14:9:17:9 | if (...) ... | Forwarding.cs:19:9:22:9 | if (...) ... |
 | Forwarding.cs:19:9:22:9 | if (...) ... | Forwarding.cs:24:9:27:9 | if (...) ... |
@@ -778,6 +787,9 @@ edges
 | E.cs:285:9:285:9 | access to local variable o | E.cs:283:13:283:22 | [b (line 279): true] SSA def(o) | E.cs:285:9:285:9 | access to local variable o | Variable $@ may be null here as suggested by $@ null check. | E.cs:283:13:283:13 | o | o | E.cs:284:9:284:9 | access to local variable o | this |
 | E.cs:302:9:302:9 | access to local variable s | E.cs:301:13:301:27 | SSA def(s) | E.cs:302:9:302:9 | access to local variable s | Variable $@ may be null here because of $@ assignment. | E.cs:301:13:301:13 | s | s | E.cs:301:13:301:27 | String s = ... | this |
 | E.cs:343:9:343:9 | access to local variable x | E.cs:342:13:342:32 | SSA def(x) | E.cs:343:9:343:9 | access to local variable x | Variable $@ may be null here because of $@ assignment. | E.cs:342:13:342:13 | x | x | E.cs:342:13:342:32 | String x = ... | this |
+| E.cs:349:9:349:9 | access to local variable x | E.cs:348:17:348:36 | SSA def(x) | E.cs:349:9:349:9 | access to local variable x | Variable $@ may be null here because of $@ assignment. | E.cs:348:17:348:17 | x | x | E.cs:348:17:348:36 | dynamic x = ... | this |
+| E.cs:356:13:356:13 | access to local variable x | E.cs:354:17:354:36 | SSA def(x) | E.cs:356:13:356:13 | access to local variable x | Variable $@ may be null here because of $@ assignment. | E.cs:354:17:354:17 | x | x | E.cs:354:17:354:36 | dynamic x = ... | this |
+| E.cs:363:13:363:13 | access to local variable x | E.cs:361:13:361:32 | SSA def(x) | E.cs:363:13:363:13 | access to local variable x | Variable $@ may be null here because of $@ assignment. | E.cs:361:13:361:13 | x | x | E.cs:361:13:361:32 | String x = ... | this |
 | GuardedString.cs:35:31:35:31 | access to local variable s | GuardedString.cs:7:16:7:32 | SSA def(s) | GuardedString.cs:35:31:35:31 | access to local variable s | Variable $@ may be null here because of $@ assignment. | GuardedString.cs:7:16:7:16 | s | s | GuardedString.cs:7:16:7:32 | String s = ... | this |
 | NullMaybeBad.cs:7:27:7:27 | access to parameter o | NullMaybeBad.cs:13:17:13:20 | null | NullMaybeBad.cs:7:27:7:27 | access to parameter o | Variable $@ may be null here because of $@ null argument. | NullMaybeBad.cs:5:25:5:25 | o | o | NullMaybeBad.cs:13:17:13:20 | null | this |
 | StringConcatenation.cs:16:17:16:17 | access to local variable s | StringConcatenation.cs:14:16:14:23 | SSA def(s) | StringConcatenation.cs:16:17:16:17 | access to local variable s | Variable $@ may be null here because of $@ assignment. | StringConcatenation.cs:14:16:14:16 | s | s | StringConcatenation.cs:14:16:14:23 | String s = ... | this |


### PR DESCRIPTION
This PR removes [false positives](https://github.com/Semmle/ql/issues/1973) from `cs/dereferenced-value-may-be-null` by
- teaching the comparison library about dynamic comparison operations, and
- teaching the guards library about additional `null` checks.

The PR can be reviewed commit-by-commit.