### PR TITLE
docs: fix links in QL topics 

### DIFF
--- a/docs/language/learn-ql/java/introduce-libraries-java.rst
+++ b/docs/language/learn-ql/java/introduce-libraries-java.rst
@@ -369,7 +369,7 @@ Conversely, ``Callable.getAReference`` returns a ``Call`` that refers to it. So 
    where not exists(c.getAReference())
    select c
 
-➤ `See this in the query console <https://lgtm.com/query/666680036/>`__. The LGTM.com demo projects all appear to have many methods that are not called directly, but this is unlikely to be the whole story. To explore this area further, see `Navigating the call graph <call-graph>`__.
+➤ `See this in the query console <https://lgtm.com/query/666680036/>`__. The LGTM.com demo projects all appear to have many methods that are not called directly, but this is unlikely to be the whole story. To explore this area further, see :doc:`Navigating the call graph <call-graph>`.
 
 For more information about callables and calls, see the :doc:`call graph tutorial <call-graph>`.
 

--- a/docs/language/learn-ql/javascript/introduce-libraries-ts.rst
+++ b/docs/language/learn-ql/javascript/introduce-libraries-ts.rst
@@ -134,7 +134,7 @@ The QL class `ClassOrInterface <https://help.semmle.com/qldoc/javascript/semmle/
 
 Note that the superclass of a class is an expression, not a type annotation. If the superclass has type arguments, it will be an expression of kind `ExpressionWithTypeArguments <https://help.semmle.com/qldoc/javascript/semmle/javascript/TypeScript.qll/type.TypeScript$ExpressionWithTypeArguments.html>`__.
 
-Also see the documentation for classes in the `Introduction to the QL libraries for JavaScript <introduce-libraries-js#classes>`__.
+Also see the documentation for classes in the `Introduction to the QL libraries for JavaScript <introduce-libraries-js.html#classes>`__.
 
 To select the type references to a class or an interface, use ``getTypeName()``.
 
@@ -443,6 +443,6 @@ A `LocalNamespaceName <https://help.semmle.com/qldoc/javascript/semmle/javascrip
 What next?
 ----------
 
--  Learn about the QL standard libraries used to write queries for JavaScript in :doc:`Introducing the Javacript libraries <introduce-libraries-js>`.
+-  Learn about the QL standard libraries used to write queries for JavaScript in :doc:`Introducing the JavaScript libraries <introduce-libraries-js>`.
 -  Find out more about QL in the `QL language handbook <https://help.semmle.com/QL/ql-handbook/index.html>`__ and `QL language specification <https://help.semmle.com/QL/ql-spec/language.html>`__.
 -  Learn more about the query console in `Using the query console <https://lgtm.com/help/lgtm/using-query-console>`__.


### PR DESCRIPTION
Two links fixed in the QL help:
- In: https://help.semmle.com/QL/learn-ql/javascript/introduce-libraries-ts.html
  "Also see the documentation for classes in the Introduction to the QL libraries for JavaScript."
- In: https://help.semmle.com/QL/learn-ql/java/introduce-libraries-java.html
  "To explore this area further, see Navigating the call graph."

The other three broken links reported in the same issue were fixed in #1930, but the changes haven't been published yet.

I'll post links to the previews when the sphinx PR job goes green.