### PR TITLE
Python: Treat calls to `iter` as guards for non-iterator query.

### DIFF
--- a/python/ql/src/Statements/NonIteratorInForLoop.ql
+++ b/python/ql/src/Statements/NonIteratorInForLoop.ql
@@ -13,11 +13,23 @@
 
 import python
 
-from For loop, ControlFlowNode iter, Value v, ClassValue t, ControlFlowNode origin
-where loop.getIter().getAFlowNode() = iter and
-iter.pointsTo(_, v, origin) and v.getClass() = t and
-not t.isIterable() and not t.failedInference(_) and
-not v = Value::named("None") and
-not t.isDescriptorType()
+predicate guarded_by_iter_call(NameNode n) {
+    exists(CallNode iter_call, Variable v |
+        iter_call = Value::named("iter").getACall() and
+        iter_call.dominates(n) and
+        iter_call.getArg(0).(NameNode).uses(v) and
+        n.uses(v)
+    )
+}
 
+from For loop, ControlFlowNode iter, Value v, ClassValue t, ControlFlowNode origin
+where
+    loop.getIter().getAFlowNode() = iter and
+    iter.pointsTo(_, v, origin) and
+    v.getClass() = t and
+    not t.isIterable() and
+    not t.failedInference(_) and
+    not guarded_by_iter_call(iter) and
+    not v = Value::named("None") and
+    not t.isDescriptorType()
 select loop, "$@ of class '$@' may be used in for-loop.", origin, "Non-iterator", t, t.getName()

--- a/python/ql/test/query-tests/Statements/general/NonIteratorInForLoop.expected
+++ b/python/ql/test/query-tests/Statements/general/NonIteratorInForLoop.expected
@@ -1,2 +1,4 @@
+| iter_guard.py:21:5:21:16 | For | $@ of class '$@' may be used in for-loop. | iter_guard.py:25:20:25:20 | ControlFlowNode for IntegerLiteral | Non-iterator | file://:0:0:0:0 | builtin-class int | int |
+| iter_guard.py:37:5:37:16 | For | $@ of class '$@' may be used in for-loop. | iter_guard.py:41:25:41:25 | ControlFlowNode for IntegerLiteral | Non-iterator | file://:0:0:0:0 | builtin-class int | int |
 | test.py:50:1:50:23 | For | $@ of class '$@' may be used in for-loop. | test.py:50:10:50:22 | ControlFlowNode for NonIterator() | Non-iterator | test.py:45:1:45:26 | class NonIterator | NonIterator |
 | test.py:170:10:170:22 | For | $@ of class '$@' may be used in for-loop. | test.py:170:10:170:22 | ControlFlowNode for .0 | Non-iterator | test.py:169:1:169:21 | class false_positive | false_positive |

--- a/python/ql/test/query-tests/Statements/general/iter_guard.py
+++ b/python/ql/test/query-tests/Statements/general/iter_guard.py
@@ -1,0 +1,54 @@
+def iter_guard_ok(xs):
+    try:
+        iter(xs)
+    except TypeError:
+        raise TypeError("Supplied argument is not an iterator")
+    for x in xs:
+        print(x)
+
+try:
+    iter_guard_ok(5)
+except TypeError:
+    pass
+
+
+
+def iter_guard_bad(xs):
+    try:
+        not_iter(xs)
+    except TypeError:
+        raise TypeError("Supplied argument is not an iterator")
+    for x in xs:
+        print(x)
+
+try:
+    iter_guard_bad(5)
+except TypeError:
+    pass
+
+
+# A somewhat contrived false positive
+def iter_guard_indirect(xs):
+    ys = xs
+    try:
+        iter(ys)
+    except TypeError:
+        raise TypeError("Supplied argument is not an iterator")
+    for x in xs:
+        print(x)
+
+try:
+    iter_guard_indirect(5)
+except TypeError:
+    pass
+
+
+
+def iter_no_guard(xs):
+    for x in iter(xs):
+        print(x)
+
+try:
+    iter_no_guard(5)
+except TypeError:
+    pass


### PR DESCRIPTION
Fixes the false positive seen in #1977. 
Note that we don't explicitly check that the call to `iter` is inside a `try` block -- if it isn't, and the argument isn't an iterable, it'll end up throwing an excption anyway, and so the `for` loop won't be reached in this case either.