### PR TITLE
Docs: Update supported languages topic

### DIFF
--- a/docs/language/global-sphinx-files/global-conf.py
+++ b/docs/language/global-sphinx-files/global-conf.py
@@ -56,9 +56,9 @@ def setup(sphinx):
 # built documents.
 #
 # The short X.Y version.
-version = u'1.22'
+version = u'1.22.1'
 # The full version, including alpha/beta/rc tags.
-release = u'1.22'
+release = u'1.22.1'
 copyright = u'2019 Semmle Ltd'
 author = u'Semmle Ltd'
 

--- a/docs/language/support/versions-compilers.csv
+++ b/docs/language/support/versions-compilers.csv
@@ -10,6 +10,7 @@ C#,C# up to 7.3. with .NET up to 4.8 [3]_.,"Microsoft Visual Studio up to 2019,
 
 .NET Core up to 2.2","``.sln``, ``.csproj``, ``.cs``, ``.cshtml``, ``.xaml``"
 COBOL,ANSI 85 or newer [4]_.,Not applicable,"``.cbl``, ``.CBL``, ``.cpy``, ``.CPY``, ``.copy``, ``.COPY``"
+Go, "Go up to 1.13", "Go 1.11 or more recent", ``.go``
 Java,"Java 6 to 12 [5]_.","javac (OpenJDK and Oracle JDK),
 
 Eclipse compiler for Java (ECJ) [6]_.",``.java``


### PR DESCRIPTION
This PR adds information about Go support to the supported languages topic and updates the version number for the coming release.

Preview: http://docteam.internal.semmle.com/felicity/go-support/language-support.html

@xiemaisi or @sauyon - please review