### PR TITLE
Java: Call sensitive dataflow

### DIFF
--- a/cpp/ql/src/semmle/code/cpp/dataflow/internal/DataFlowImpl.qll
+++ b/cpp/ql/src/semmle/code/cpp/dataflow/internal/DataFlowImpl.qll
@@ -905,30 +905,34 @@ private predicate localFlowExit(Node node, Configuration config) {
  */
 pragma[nomagic]
 private predicate localFlowStepPlus(
-  Node node1, Node node2, boolean preservesValue, Configuration config
+  Node node1, Node node2, boolean preservesValue, Configuration config, LocalCallContext cc
 ) {
-  localFlowEntry(node1, config) and
+  not isUnreachableInCall(node2, cc.(LocalCallContextSpecificCall).getCall()) and
   (
-    localFlowStep(node1, node2, config) and preservesValue = true
+    localFlowEntry(node1, config) and
+    (
+      localFlowStep(node1, node2, config) and preservesValue = true
+      or
+      additionalLocalFlowStep(node1, node2, config) and preservesValue = false
+    ) and
+    node1 != node2 and
+    cc.validFor(node1) and
+    nodeCand(node2, unbind(config))
     or
-    additionalLocalFlowStep(node1, node2, config) and preservesValue = false
-  ) and
-  node1 != node2 and
-  nodeCand(node2, unbind(config))
-  or
-  exists(Node mid |
-    localFlowStepPlus(node1, mid, preservesValue, config) and
-    localFlowStep(mid, node2, config) and
-    not mid instanceof CastNode and
-    nodeCand(node2, unbind(config))
-  )
-  or
-  exists(Node mid |
-    localFlowStepPlus(node1, mid, _, config) and
-    additionalLocalFlowStep(mid, node2, config) and
-    not mid instanceof CastNode and
-    preservesValue = false and
-    nodeCand(node2, unbind(config))
+    exists(Node mid |
+      localFlowStepPlus(node1, mid, preservesValue, config, cc) and
+      localFlowStep(mid, node2, config) and
+      not mid instanceof CastNode and
+      nodeCand(node2, unbind(config))
+    )
+    or
+    exists(Node mid |
+      localFlowStepPlus(node1, mid, _, config, cc) and
+      additionalLocalFlowStep(mid, node2, config) and
+      not mid instanceof CastNode and
+      preservesValue = false and
+      nodeCand(node2, unbind(config))
+    )
   )
 }
 
@@ -938,9 +942,9 @@ private predicate localFlowStepPlus(
  */
 pragma[noinline]
 private predicate localFlowBigStep(
-  Node node1, Node node2, boolean preservesValue, Configuration config
+  Node node1, Node node2, boolean preservesValue, Configuration config, LocalCallContext callContext
 ) {
-  localFlowStepPlus(node1, node2, preservesValue, config) and
+  localFlowStepPlus(node1, node2, preservesValue, config, callContext) and
   localFlowExit(node2, config)
 }
 
@@ -1000,7 +1004,7 @@ private class AccessPathFrontNilNode extends Node {
     (
       any(Configuration c).isSource(this)
       or
-      localFlowBigStep(_, this, false, _)
+      localFlowBigStep(_, this, false, _, _)
       or
       additionalJumpStep(_, this, _)
     )
@@ -1023,12 +1027,12 @@ private predicate flowCandFwd0(Node node, boolean fromArg, AccessPathFront apf, 
   (
     exists(Node mid |
       flowCandFwd(mid, fromArg, apf, config) and
-      localFlowBigStep(mid, node, true, config)
+      localFlowBigStep(mid, node, true, config, _)
     )
     or
     exists(Node mid, AccessPathFrontNil nil |
       flowCandFwd(mid, fromArg, nil, config) and
-      localFlowBigStep(mid, node, false, config) and
+      localFlowBigStep(mid, node, false, config, _) and
       apf = node.(AccessPathFrontNilNode).getApf()
     )
     or
@@ -1121,13 +1125,13 @@ private predicate flowCand0(Node node, boolean toReturn, AccessPathFront apf, Co
   apf instanceof AccessPathFrontNil
   or
   exists(Node mid |
-    localFlowBigStep(node, mid, true, config) and
+    localFlowBigStep(node, mid, true, config, _) and
     flowCand(mid, toReturn, apf, config)
   )
   or
   exists(Node mid, AccessPathFrontNil nil |
     flowCandFwd(node, _, apf, config) and
-    localFlowBigStep(node, mid, false, config) and
+    localFlowBigStep(node, mid, false, config, _) and
     flowCand(mid, toReturn, nil, config) and
     apf instanceof AccessPathFrontNil
   )
@@ -1362,12 +1366,12 @@ private predicate flowFwd0(
   (
     exists(Node mid |
       flowFwd(mid, fromArg, apf, ap, config) and
-      localFlowBigStep(mid, node, true, config)
+      localFlowBigStep(mid, node, true, config, _)
     )
     or
     exists(Node mid, AccessPathNil nil |
       flowFwd(mid, fromArg, _, nil, config) and
-      localFlowBigStep(mid, node, false, config) and
+      localFlowBigStep(mid, node, false, config, _) and
       ap = node.(AccessPathNilNode).getAp() and
       apf = ap.(AccessPathNil).getFront()
     )
@@ -1471,13 +1475,13 @@ private predicate flow0(Node node, boolean toReturn, AccessPath ap, Configuratio
   ap instanceof AccessPathNil
   or
   exists(Node mid |
-    localFlowBigStep(node, mid, true, config) and
+    localFlowBigStep(node, mid, true, config, _) and
     flow(mid, toReturn, ap, config)
   )
   or
   exists(Node mid, AccessPathNil nil |
     flowFwd(node, _, _, ap, config) and
-    localFlowBigStep(node, mid, false, config) and
+    localFlowBigStep(node, mid, false, config, _) and
     flow(mid, toReturn, nil, config) and
     ap instanceof AccessPathNil
   )
@@ -1728,37 +1732,42 @@ private class PathNodeSink extends PathNode, TPathNodeSink {
  * a callable is recorded by `cc`.
  */
 private predicate pathStep(PathNodeMid mid, Node node, CallContext cc, AccessPath ap) {
-  localFlowBigStep(mid.getNode(), node, true, mid.getConfiguration()) and
-  cc = mid.getCallContext() and
-  ap = mid.getAp()
+  exists(LocalCallContext localCC | localCC.matchesCallContext(cc) |
+    localFlowBigStep(mid.getNode(), node, true, mid.getConfiguration(), localCC) and
+    cc = mid.getCallContext() and
+    ap = mid.getAp()
+    or
+    localFlowBigStep(mid.getNode(), node, false, mid.getConfiguration(), localCC) and
+    cc = mid.getCallContext() and
+    mid.getAp() instanceof AccessPathNil and
+    ap = node.(AccessPathNilNode).getAp()
+  )
   or
-  localFlowBigStep(mid.getNode(), node, false, mid.getConfiguration()) and
-  cc = mid.getCallContext() and
-  mid.getAp() instanceof AccessPathNil and
-  ap = node.(AccessPathNilNode).getAp()
-  or
-  jumpStep(mid.getNode(), node, mid.getConfiguration()) and
-  cc instanceof CallContextAny and
-  ap = mid.getAp()
-  or
-  additionalJumpStep(mid.getNode(), node, mid.getConfiguration()) and
-  cc instanceof CallContextAny and
-  mid.getAp() instanceof AccessPathNil and
-  ap = node.(AccessPathNilNode).getAp()
-  or
-  contentReadStep(mid, node, ap) and cc = mid.getCallContext()
-  or
-  exists(Content f, AccessPath ap0 | contentStoreStep(mid, node, ap0, f, cc) and push(ap0, f, ap))
-  or
-  pathOutOfArgument(mid, node, cc) and ap = mid.getAp()
-  or
-  pathIntoCallable(mid, node, _, cc, _) and ap = mid.getAp()
-  or
-  pathOutOfCallable(mid, node, cc) and ap = mid.getAp()
-  or
-  pathThroughCallable(mid, node, cc, ap)
-  or
-  valuePathThroughCallable(mid, node, cc) and ap = mid.getAp()
+  not isUnreachableInCall(node, cc.(CallContextSpecificCall).getCall()) and
+  (
+    jumpStep(mid.getNode(), node, mid.getConfiguration()) and
+    cc instanceof CallContextAny and
+    ap = mid.getAp()
+    or
+    additionalJumpStep(mid.getNode(), node, mid.getConfiguration()) and
+    cc instanceof CallContextAny and
+    mid.getAp() instanceof AccessPathNil and
+    ap = node.(AccessPathNilNode).getAp()
+    or
+    contentReadStep(mid, node, ap) and cc = mid.getCallContext()
+    or
+    exists(Content f, AccessPath ap0 | contentStoreStep(mid, node, ap0, f, cc) and push(ap0, f, ap))
+    or
+    pathOutOfArgument(mid, node, cc) and ap = mid.getAp()
+    or
+    pathIntoCallable(mid, node, _, cc, _) and ap = mid.getAp()
+    or
+    pathOutOfCallable(mid, node, cc) and ap = mid.getAp()
+    or
+    pathThroughCallable(mid, node, cc, ap)
+    or
+    valuePathThroughCallable(mid, node, cc) and ap = mid.getAp()
+  )
 }
 
 pragma[noinline]
@@ -1879,7 +1888,7 @@ private predicate pathIntoCallable(
     pathIntoCallable0(mid, callable, i, outercc, call, emptyAp) and
     p.isParameterOf(callable, i)
   |
-    if reducedViableImplInCallContext(_, callable, call)
+    if recordDataFlowCallSite(call, callable)
     then innercc = TSpecificCall(call, i, emptyAp)
     else innercc = TSomeCall(p, emptyAp)
   )
@@ -2377,7 +2386,7 @@ private module FlowExploration {
       partialPathIntoCallable0(mid, callable, i, outercc, call, emptyAp, ap, config) and
       p.isParameterOf(callable, i)
     |
-      if reducedViableImplInCallContext(_, callable, call)
+      if recordDataFlowCallSite(call, callable)
       then innercc = TSpecificCall(call, i, emptyAp)
       else innercc = TSomeCall(p, emptyAp)
     )

--- a/cpp/ql/src/semmle/code/cpp/dataflow/internal/DataFlowImpl2.qll
+++ b/cpp/ql/src/semmle/code/cpp/dataflow/internal/DataFlowImpl2.qll
@@ -905,30 +905,34 @@ private predicate localFlowExit(Node node, Configuration config) {
  */
 pragma[nomagic]
 private predicate localFlowStepPlus(
-  Node node1, Node node2, boolean preservesValue, Configuration config
+  Node node1, Node node2, boolean preservesValue, Configuration config, LocalCallContext cc
 ) {
-  localFlowEntry(node1, config) and
+  not isUnreachableInCall(node2, cc.(LocalCallContextSpecificCall).getCall()) and
   (
-    localFlowStep(node1, node2, config) and preservesValue = true
+    localFlowEntry(node1, config) and
+    (
+      localFlowStep(node1, node2, config) and preservesValue = true
+      or
+      additionalLocalFlowStep(node1, node2, config) and preservesValue = false
+    ) and
+    node1 != node2 and
+    cc.validFor(node1) and
+    nodeCand(node2, unbind(config))
     or
-    additionalLocalFlowStep(node1, node2, config) and preservesValue = false
-  ) and
-  node1 != node2 and
-  nodeCand(node2, unbind(config))
-  or
-  exists(Node mid |
-    localFlowStepPlus(node1, mid, preservesValue, config) and
-    localFlowStep(mid, node2, config) and
-    not mid instanceof CastNode and
-    nodeCand(node2, unbind(config))
-  )
-  or
-  exists(Node mid |
-    localFlowStepPlus(node1, mid, _, config) and
-    additionalLocalFlowStep(mid, node2, config) and
-    not mid instanceof CastNode and
-    preservesValue = false and
-    nodeCand(node2, unbind(config))
+    exists(Node mid |
+      localFlowStepPlus(node1, mid, preservesValue, config, cc) and
+      localFlowStep(mid, node2, config) and
+      not mid instanceof CastNode and
+      nodeCand(node2, unbind(config))
+    )
+    or
+    exists(Node mid |
+      localFlowStepPlus(node1, mid, _, config, cc) and
+      additionalLocalFlowStep(mid, node2, config) and
+      not mid instanceof CastNode and
+      preservesValue = false and
+      nodeCand(node2, unbind(config))
+    )
   )
 }
 
@@ -938,9 +942,9 @@ private predicate localFlowStepPlus(
  */
 pragma[noinline]
 private predicate localFlowBigStep(
-  Node node1, Node node2, boolean preservesValue, Configuration config
+  Node node1, Node node2, boolean preservesValue, Configuration config, LocalCallContext callContext
 ) {
-  localFlowStepPlus(node1, node2, preservesValue, config) and
+  localFlowStepPlus(node1, node2, preservesValue, config, callContext) and
   localFlowExit(node2, config)
 }
 
@@ -1000,7 +1004,7 @@ private class AccessPathFrontNilNode extends Node {
     (
       any(Configuration c).isSource(this)
       or
-      localFlowBigStep(_, this, false, _)
+      localFlowBigStep(_, this, false, _, _)
       or
       additionalJumpStep(_, this, _)
     )
@@ -1023,12 +1027,12 @@ private predicate flowCandFwd0(Node node, boolean fromArg, AccessPathFront apf, 
   (
     exists(Node mid |
       flowCandFwd(mid, fromArg, apf, config) and
-      localFlowBigStep(mid, node, true, config)
+      localFlowBigStep(mid, node, true, config, _)
     )
     or
     exists(Node mid, AccessPathFrontNil nil |
       flowCandFwd(mid, fromArg, nil, config) and
-      localFlowBigStep(mid, node, false, config) and
+      localFlowBigStep(mid, node, false, config, _) and
       apf = node.(AccessPathFrontNilNode).getApf()
     )
     or
@@ -1121,13 +1125,13 @@ private predicate flowCand0(Node node, boolean toReturn, AccessPathFront apf, Co
   apf instanceof AccessPathFrontNil
   or
   exists(Node mid |
-    localFlowBigStep(node, mid, true, config) and
+    localFlowBigStep(node, mid, true, config, _) and
     flowCand(mid, toReturn, apf, config)
   )
   or
   exists(Node mid, AccessPathFrontNil nil |
     flowCandFwd(node, _, apf, config) and
-    localFlowBigStep(node, mid, false, config) and
+    localFlowBigStep(node, mid, false, config, _) and
     flowCand(mid, toReturn, nil, config) and
     apf instanceof AccessPathFrontNil
   )
@@ -1362,12 +1366,12 @@ private predicate flowFwd0(
   (
     exists(Node mid |
       flowFwd(mid, fromArg, apf, ap, config) and
-      localFlowBigStep(mid, node, true, config)
+      localFlowBigStep(mid, node, true, config, _)
     )
     or
     exists(Node mid, AccessPathNil nil |
       flowFwd(mid, fromArg, _, nil, config) and
-      localFlowBigStep(mid, node, false, config) and
+      localFlowBigStep(mid, node, false, config, _) and
       ap = node.(AccessPathNilNode).getAp() and
       apf = ap.(AccessPathNil).getFront()
     )
@@ -1471,13 +1475,13 @@ private predicate flow0(Node node, boolean toReturn, AccessPath ap, Configuratio
   ap instanceof AccessPathNil
   or
   exists(Node mid |
-    localFlowBigStep(node, mid, true, config) and
+    localFlowBigStep(node, mid, true, config, _) and
     flow(mid, toReturn, ap, config)
   )
   or
   exists(Node mid, AccessPathNil nil |
     flowFwd(node, _, _, ap, config) and
-    localFlowBigStep(node, mid, false, config) and
+    localFlowBigStep(node, mid, false, config, _) and
     flow(mid, toReturn, nil, config) and
     ap instanceof AccessPathNil
   )
@@ -1728,37 +1732,42 @@ private class PathNodeSink extends PathNode, TPathNodeSink {
  * a callable is recorded by `cc`.
  */
 private predicate pathStep(PathNodeMid mid, Node node, CallContext cc, AccessPath ap) {
-  localFlowBigStep(mid.getNode(), node, true, mid.getConfiguration()) and
-  cc = mid.getCallContext() and
-  ap = mid.getAp()
+  exists(LocalCallContext localCC | localCC.matchesCallContext(cc) |
+    localFlowBigStep(mid.getNode(), node, true, mid.getConfiguration(), localCC) and
+    cc = mid.getCallContext() and
+    ap = mid.getAp()
+    or
+    localFlowBigStep(mid.getNode(), node, false, mid.getConfiguration(), localCC) and
+    cc = mid.getCallContext() and
+    mid.getAp() instanceof AccessPathNil and
+    ap = node.(AccessPathNilNode).getAp()
+  )
   or
-  localFlowBigStep(mid.getNode(), node, false, mid.getConfiguration()) and
-  cc = mid.getCallContext() and
-  mid.getAp() instanceof AccessPathNil and
-  ap = node.(AccessPathNilNode).getAp()
-  or
-  jumpStep(mid.getNode(), node, mid.getConfiguration()) and
-  cc instanceof CallContextAny and
-  ap = mid.getAp()
-  or
-  additionalJumpStep(mid.getNode(), node, mid.getConfiguration()) and
-  cc instanceof CallContextAny and
-  mid.getAp() instanceof AccessPathNil and
-  ap = node.(AccessPathNilNode).getAp()
-  or
-  contentReadStep(mid, node, ap) and cc = mid.getCallContext()
-  or
-  exists(Content f, AccessPath ap0 | contentStoreStep(mid, node, ap0, f, cc) and push(ap0, f, ap))
-  or
-  pathOutOfArgument(mid, node, cc) and ap = mid.getAp()
-  or
-  pathIntoCallable(mid, node, _, cc, _) and ap = mid.getAp()
-  or
-  pathOutOfCallable(mid, node, cc) and ap = mid.getAp()
-  or
-  pathThroughCallable(mid, node, cc, ap)
-  or
-  valuePathThroughCallable(mid, node, cc) and ap = mid.getAp()
+  not isUnreachableInCall(node, cc.(CallContextSpecificCall).getCall()) and
+  (
+    jumpStep(mid.getNode(), node, mid.getConfiguration()) and
+    cc instanceof CallContextAny and
+    ap = mid.getAp()
+    or
+    additionalJumpStep(mid.getNode(), node, mid.getConfiguration()) and
+    cc instanceof CallContextAny and
+    mid.getAp() instanceof AccessPathNil and
+    ap = node.(AccessPathNilNode).getAp()
+    or
+    contentReadStep(mid, node, ap) and cc = mid.getCallContext()
+    or
+    exists(Content f, AccessPath ap0 | contentStoreStep(mid, node, ap0, f, cc) and push(ap0, f, ap))
+    or
+    pathOutOfArgument(mid, node, cc) and ap = mid.getAp()
+    or
+    pathIntoCallable(mid, node, _, cc, _) and ap = mid.getAp()
+    or
+    pathOutOfCallable(mid, node, cc) and ap = mid.getAp()
+    or
+    pathThroughCallable(mid, node, cc, ap)
+    or
+    valuePathThroughCallable(mid, node, cc) and ap = mid.getAp()
+  )
 }
 
 pragma[noinline]
@@ -1879,7 +1888,7 @@ private predicate pathIntoCallable(
     pathIntoCallable0(mid, callable, i, outercc, call, emptyAp) and
     p.isParameterOf(callable, i)
   |
-    if reducedViableImplInCallContext(_, callable, call)
+    if recordDataFlowCallSite(call, callable)
     then innercc = TSpecificCall(call, i, emptyAp)
     else innercc = TSomeCall(p, emptyAp)
   )
@@ -2377,7 +2386,7 @@ private module FlowExploration {
       partialPathIntoCallable0(mid, callable, i, outercc, call, emptyAp, ap, config) and
       p.isParameterOf(callable, i)
     |
-      if reducedViableImplInCallContext(_, callable, call)
+      if recordDataFlowCallSite(call, callable)
       then innercc = TSpecificCall(call, i, emptyAp)
       else innercc = TSomeCall(p, emptyAp)
     )

--- a/cpp/ql/src/semmle/code/cpp/dataflow/internal/DataFlowImpl3.qll
+++ b/cpp/ql/src/semmle/code/cpp/dataflow/internal/DataFlowImpl3.qll
@@ -905,30 +905,34 @@ private predicate localFlowExit(Node node, Configuration config) {
  */
 pragma[nomagic]
 private predicate localFlowStepPlus(
-  Node node1, Node node2, boolean preservesValue, Configuration config
+  Node node1, Node node2, boolean preservesValue, Configuration config, LocalCallContext cc
 ) {
-  localFlowEntry(node1, config) and
+  not isUnreachableInCall(node2, cc.(LocalCallContextSpecificCall).getCall()) and
   (
-    localFlowStep(node1, node2, config) and preservesValue = true
+    localFlowEntry(node1, config) and
+    (
+      localFlowStep(node1, node2, config) and preservesValue = true
+      or
+      additionalLocalFlowStep(node1, node2, config) and preservesValue = false
+    ) and
+    node1 != node2 and
+    cc.validFor(node1) and
+    nodeCand(node2, unbind(config))
     or
-    additionalLocalFlowStep(node1, node2, config) and preservesValue = false
-  ) and
-  node1 != node2 and
-  nodeCand(node2, unbind(config))
-  or
-  exists(Node mid |
-    localFlowStepPlus(node1, mid, preservesValue, config) and
-    localFlowStep(mid, node2, config) and
-    not mid instanceof CastNode and
-    nodeCand(node2, unbind(config))
-  )
-  or
-  exists(Node mid |
-    localFlowStepPlus(node1, mid, _, config) and
-    additionalLocalFlowStep(mid, node2, config) and
-    not mid instanceof CastNode and
-    preservesValue = false and
-    nodeCand(node2, unbind(config))
+    exists(Node mid |
+      localFlowStepPlus(node1, mid, preservesValue, config, cc) and
+      localFlowStep(mid, node2, config) and
+      not mid instanceof CastNode and
+      nodeCand(node2, unbind(config))
+    )
+    or
+    exists(Node mid |
+      localFlowStepPlus(node1, mid, _, config, cc) and
+      additionalLocalFlowStep(mid, node2, config) and
+      not mid instanceof CastNode and
+      preservesValue = false and
+      nodeCand(node2, unbind(config))
+    )
   )
 }
 
@@ -938,9 +942,9 @@ private predicate localFlowStepPlus(
  */
 pragma[noinline]
 private predicate localFlowBigStep(
-  Node node1, Node node2, boolean preservesValue, Configuration config
+  Node node1, Node node2, boolean preservesValue, Configuration config, LocalCallContext callContext
 ) {
-  localFlowStepPlus(node1, node2, preservesValue, config) and
+  localFlowStepPlus(node1, node2, preservesValue, config, callContext) and
   localFlowExit(node2, config)
 }
 
@@ -1000,7 +1004,7 @@ private class AccessPathFrontNilNode extends Node {
     (
       any(Configuration c).isSource(this)
       or
-      localFlowBigStep(_, this, false, _)
+      localFlowBigStep(_, this, false, _, _)
       or
       additionalJumpStep(_, this, _)
     )
@@ -1023,12 +1027,12 @@ private predicate flowCandFwd0(Node node, boolean fromArg, AccessPathFront apf, 
   (
     exists(Node mid |
       flowCandFwd(mid, fromArg, apf, config) and
-      localFlowBigStep(mid, node, true, config)
+      localFlowBigStep(mid, node, true, config, _)
     )
     or
     exists(Node mid, AccessPathFrontNil nil |
       flowCandFwd(mid, fromArg, nil, config) and
-      localFlowBigStep(mid, node, false, config) and
+      localFlowBigStep(mid, node, false, config, _) and
       apf = node.(AccessPathFrontNilNode).getApf()
     )
     or
@@ -1121,13 +1125,13 @@ private predicate flowCand0(Node node, boolean toReturn, AccessPathFront apf, Co
   apf instanceof AccessPathFrontNil
   or
   exists(Node mid |
-    localFlowBigStep(node, mid, true, config) and
+    localFlowBigStep(node, mid, true, config, _) and
     flowCand(mid, toReturn, apf, config)
   )
   or
   exists(Node mid, AccessPathFrontNil nil |
     flowCandFwd(node, _, apf, config) and
-    localFlowBigStep(node, mid, false, config) and
+    localFlowBigStep(node, mid, false, config, _) and
     flowCand(mid, toReturn, nil, config) and
     apf instanceof AccessPathFrontNil
   )
@@ -1362,12 +1366,12 @@ private predicate flowFwd0(
   (
     exists(Node mid |
       flowFwd(mid, fromArg, apf, ap, config) and
-      localFlowBigStep(mid, node, true, config)
+      localFlowBigStep(mid, node, true, config, _)
     )
     or
     exists(Node mid, AccessPathNil nil |
       flowFwd(mid, fromArg, _, nil, config) and
-      localFlowBigStep(mid, node, false, config) and
+      localFlowBigStep(mid, node, false, config, _) and
       ap = node.(AccessPathNilNode).getAp() and
       apf = ap.(AccessPathNil).getFront()
     )
@@ -1471,13 +1475,13 @@ private predicate flow0(Node node, boolean toReturn, AccessPath ap, Configuratio
   ap instanceof AccessPathNil
   or
   exists(Node mid |
-    localFlowBigStep(node, mid, true, config) and
+    localFlowBigStep(node, mid, true, config, _) and
     flow(mid, toReturn, ap, config)
   )
   or
   exists(Node mid, AccessPathNil nil |
     flowFwd(node, _, _, ap, config) and
-    localFlowBigStep(node, mid, false, config) and
+    localFlowBigStep(node, mid, false, config, _) and
     flow(mid, toReturn, nil, config) and
     ap instanceof AccessPathNil
   )
@@ -1728,37 +1732,42 @@ private class PathNodeSink extends PathNode, TPathNodeSink {
  * a callable is recorded by `cc`.
  */
 private predicate pathStep(PathNodeMid mid, Node node, CallContext cc, AccessPath ap) {
-  localFlowBigStep(mid.getNode(), node, true, mid.getConfiguration()) and
-  cc = mid.getCallContext() and
-  ap = mid.getAp()
+  exists(LocalCallContext localCC | localCC.matchesCallContext(cc) |
+    localFlowBigStep(mid.getNode(), node, true, mid.getConfiguration(), localCC) and
+    cc = mid.getCallContext() and
+    ap = mid.getAp()
+    or
+    localFlowBigStep(mid.getNode(), node, false, mid.getConfiguration(), localCC) and
+    cc = mid.getCallContext() and
+    mid.getAp() instanceof AccessPathNil and
+    ap = node.(AccessPathNilNode).getAp()
+  )
   or
-  localFlowBigStep(mid.getNode(), node, false, mid.getConfiguration()) and
-  cc = mid.getCallContext() and
-  mid.getAp() instanceof AccessPathNil and
-  ap = node.(AccessPathNilNode).getAp()
-  or
-  jumpStep(mid.getNode(), node, mid.getConfiguration()) and
-  cc instanceof CallContextAny and
-  ap = mid.getAp()
-  or
-  additionalJumpStep(mid.getNode(), node, mid.getConfiguration()) and
-  cc instanceof CallContextAny and
-  mid.getAp() instanceof AccessPathNil and
-  ap = node.(AccessPathNilNode).getAp()
-  or
-  contentReadStep(mid, node, ap) and cc = mid.getCallContext()
-  or
-  exists(Content f, AccessPath ap0 | contentStoreStep(mid, node, ap0, f, cc) and push(ap0, f, ap))
-  or
-  pathOutOfArgument(mid, node, cc) and ap = mid.getAp()
-  or
-  pathIntoCallable(mid, node, _, cc, _) and ap = mid.getAp()
-  or
-  pathOutOfCallable(mid, node, cc) and ap = mid.getAp()
-  or
-  pathThroughCallable(mid, node, cc, ap)
-  or
-  valuePathThroughCallable(mid, node, cc) and ap = mid.getAp()
+  not isUnreachableInCall(node, cc.(CallContextSpecificCall).getCall()) and
+  (
+    jumpStep(mid.getNode(), node, mid.getConfiguration()) and
+    cc instanceof CallContextAny and
+    ap = mid.getAp()
+    or
+    additionalJumpStep(mid.getNode(), node, mid.getConfiguration()) and
+    cc instanceof CallContextAny and
+    mid.getAp() instanceof AccessPathNil and
+    ap = node.(AccessPathNilNode).getAp()
+    or
+    contentReadStep(mid, node, ap) and cc = mid.getCallContext()
+    or
+    exists(Content f, AccessPath ap0 | contentStoreStep(mid, node, ap0, f, cc) and push(ap0, f, ap))
+    or
+    pathOutOfArgument(mid, node, cc) and ap = mid.getAp()
+    or
+    pathIntoCallable(mid, node, _, cc, _) and ap = mid.getAp()
+    or
+    pathOutOfCallable(mid, node, cc) and ap = mid.getAp()
+    or
+    pathThroughCallable(mid, node, cc, ap)
+    or
+    valuePathThroughCallable(mid, node, cc) and ap = mid.getAp()
+  )
 }
 
 pragma[noinline]
@@ -1879,7 +1888,7 @@ private predicate pathIntoCallable(
     pathIntoCallable0(mid, callable, i, outercc, call, emptyAp) and
     p.isParameterOf(callable, i)
   |
-    if reducedViableImplInCallContext(_, callable, call)
+    if recordDataFlowCallSite(call, callable)
     then innercc = TSpecificCall(call, i, emptyAp)
     else innercc = TSomeCall(p, emptyAp)
   )
@@ -2377,7 +2386,7 @@ private module FlowExploration {
       partialPathIntoCallable0(mid, callable, i, outercc, call, emptyAp, ap, config) and
       p.isParameterOf(callable, i)
     |
-      if reducedViableImplInCallContext(_, callable, call)
+      if recordDataFlowCallSite(call, callable)
       then innercc = TSpecificCall(call, i, emptyAp)
       else innercc = TSomeCall(p, emptyAp)
     )

--- a/cpp/ql/src/semmle/code/cpp/dataflow/internal/DataFlowImpl4.qll
+++ b/cpp/ql/src/semmle/code/cpp/dataflow/internal/DataFlowImpl4.qll
@@ -905,30 +905,34 @@ private predicate localFlowExit(Node node, Configuration config) {
  */
 pragma[nomagic]
 private predicate localFlowStepPlus(
-  Node node1, Node node2, boolean preservesValue, Configuration config
+  Node node1, Node node2, boolean preservesValue, Configuration config, LocalCallContext cc
 ) {
-  localFlowEntry(node1, config) and
+  not isUnreachableInCall(node2, cc.(LocalCallContextSpecificCall).getCall()) and
   (
-    localFlowStep(node1, node2, config) and preservesValue = true
+    localFlowEntry(node1, config) and
+    (
+      localFlowStep(node1, node2, config) and preservesValue = true
+      or
+      additionalLocalFlowStep(node1, node2, config) and preservesValue = false
+    ) and
+    node1 != node2 and
+    cc.validFor(node1) and
+    nodeCand(node2, unbind(config))
     or
-    additionalLocalFlowStep(node1, node2, config) and preservesValue = false
-  ) and
-  node1 != node2 and
-  nodeCand(node2, unbind(config))
-  or
-  exists(Node mid |
-    localFlowStepPlus(node1, mid, preservesValue, config) and
-    localFlowStep(mid, node2, config) and
-    not mid instanceof CastNode and
-    nodeCand(node2, unbind(config))
-  )
-  or
-  exists(Node mid |
-    localFlowStepPlus(node1, mid, _, config) and
-    additionalLocalFlowStep(mid, node2, config) and
-    not mid instanceof CastNode and
-    preservesValue = false and
-    nodeCand(node2, unbind(config))
+    exists(Node mid |
+      localFlowStepPlus(node1, mid, preservesValue, config, cc) and
+      localFlowStep(mid, node2, config) and
+      not mid instanceof CastNode and
+      nodeCand(node2, unbind(config))
+    )
+    or
+    exists(Node mid |
+      localFlowStepPlus(node1, mid, _, config, cc) and
+      additionalLocalFlowStep(mid, node2, config) and
+      not mid instanceof CastNode and
+      preservesValue = false and
+      nodeCand(node2, unbind(config))
+    )
   )
 }
 
@@ -938,9 +942,9 @@ private predicate localFlowStepPlus(
  */
 pragma[noinline]
 private predicate localFlowBigStep(
-  Node node1, Node node2, boolean preservesValue, Configuration config
+  Node node1, Node node2, boolean preservesValue, Configuration config, LocalCallContext callContext
 ) {
-  localFlowStepPlus(node1, node2, preservesValue, config) and
+  localFlowStepPlus(node1, node2, preservesValue, config, callContext) and
   localFlowExit(node2, config)
 }
 
@@ -1000,7 +1004,7 @@ private class AccessPathFrontNilNode extends Node {
     (
       any(Configuration c).isSource(this)
       or
-      localFlowBigStep(_, this, false, _)
+      localFlowBigStep(_, this, false, _, _)
       or
       additionalJumpStep(_, this, _)
     )
@@ -1023,12 +1027,12 @@ private predicate flowCandFwd0(Node node, boolean fromArg, AccessPathFront apf, 
   (
     exists(Node mid |
       flowCandFwd(mid, fromArg, apf, config) and
-      localFlowBigStep(mid, node, true, config)
+      localFlowBigStep(mid, node, true, config, _)
     )
     or
     exists(Node mid, AccessPathFrontNil nil |
       flowCandFwd(mid, fromArg, nil, config) and
-      localFlowBigStep(mid, node, false, config) and
+      localFlowBigStep(mid, node, false, config, _) and
       apf = node.(AccessPathFrontNilNode).getApf()
     )
     or
@@ -1121,13 +1125,13 @@ private predicate flowCand0(Node node, boolean toReturn, AccessPathFront apf, Co
   apf instanceof AccessPathFrontNil
   or
   exists(Node mid |
-    localFlowBigStep(node, mid, true, config) and
+    localFlowBigStep(node, mid, true, config, _) and
     flowCand(mid, toReturn, apf, config)
   )
   or
   exists(Node mid, AccessPathFrontNil nil |
     flowCandFwd(node, _, apf, config) and
-    localFlowBigStep(node, mid, false, config) and
+    localFlowBigStep(node, mid, false, config, _) and
     flowCand(mid, toReturn, nil, config) and
     apf instanceof AccessPathFrontNil
   )
@@ -1362,12 +1366,12 @@ private predicate flowFwd0(
   (
     exists(Node mid |
       flowFwd(mid, fromArg, apf, ap, config) and
-      localFlowBigStep(mid, node, true, config)
+      localFlowBigStep(mid, node, true, config, _)
     )
     or
     exists(Node mid, AccessPathNil nil |
       flowFwd(mid, fromArg, _, nil, config) and
-      localFlowBigStep(mid, node, false, config) and
+      localFlowBigStep(mid, node, false, config, _) and
       ap = node.(AccessPathNilNode).getAp() and
       apf = ap.(AccessPathNil).getFront()
     )
@@ -1471,13 +1475,13 @@ private predicate flow0(Node node, boolean toReturn, AccessPath ap, Configuratio
   ap instanceof AccessPathNil
   or
   exists(Node mid |
-    localFlowBigStep(node, mid, true, config) and
+    localFlowBigStep(node, mid, true, config, _) and
     flow(mid, toReturn, ap, config)
   )
   or
   exists(Node mid, AccessPathNil nil |
     flowFwd(node, _, _, ap, config) and
-    localFlowBigStep(node, mid, false, config) and
+    localFlowBigStep(node, mid, false, config, _) and
     flow(mid, toReturn, nil, config) and
     ap instanceof AccessPathNil
   )
@@ -1728,37 +1732,42 @@ private class PathNodeSink extends PathNode, TPathNodeSink {
  * a callable is recorded by `cc`.
  */
 private predicate pathStep(PathNodeMid mid, Node node, CallContext cc, AccessPath ap) {
-  localFlowBigStep(mid.getNode(), node, true, mid.getConfiguration()) and
-  cc = mid.getCallContext() and
-  ap = mid.getAp()
+  exists(LocalCallContext localCC | localCC.matchesCallContext(cc) |
+    localFlowBigStep(mid.getNode(), node, true, mid.getConfiguration(), localCC) and
+    cc = mid.getCallContext() and
+    ap = mid.getAp()
+    or
+    localFlowBigStep(mid.getNode(), node, false, mid.getConfiguration(), localCC) and
+    cc = mid.getCallContext() and
+    mid.getAp() instanceof AccessPathNil and
+    ap = node.(AccessPathNilNode).getAp()
+  )
   or
-  localFlowBigStep(mid.getNode(), node, false, mid.getConfiguration()) and
-  cc = mid.getCallContext() and
-  mid.getAp() instanceof AccessPathNil and
-  ap = node.(AccessPathNilNode).getAp()
-  or
-  jumpStep(mid.getNode(), node, mid.getConfiguration()) and
-  cc instanceof CallContextAny and
-  ap = mid.getAp()
-  or
-  additionalJumpStep(mid.getNode(), node, mid.getConfiguration()) and
-  cc instanceof CallContextAny and
-  mid.getAp() instanceof AccessPathNil and
-  ap = node.(AccessPathNilNode).getAp()
-  or
-  contentReadStep(mid, node, ap) and cc = mid.getCallContext()
-  or
-  exists(Content f, AccessPath ap0 | contentStoreStep(mid, node, ap0, f, cc) and push(ap0, f, ap))
-  or
-  pathOutOfArgument(mid, node, cc) and ap = mid.getAp()
-  or
-  pathIntoCallable(mid, node, _, cc, _) and ap = mid.getAp()
-  or
-  pathOutOfCallable(mid, node, cc) and ap = mid.getAp()
-  or
-  pathThroughCallable(mid, node, cc, ap)
-  or
-  valuePathThroughCallable(mid, node, cc) and ap = mid.getAp()
+  not isUnreachableInCall(node, cc.(CallContextSpecificCall).getCall()) and
+  (
+    jumpStep(mid.getNode(), node, mid.getConfiguration()) and
+    cc instanceof CallContextAny and
+    ap = mid.getAp()
+    or
+    additionalJumpStep(mid.getNode(), node, mid.getConfiguration()) and
+    cc instanceof CallContextAny and
+    mid.getAp() instanceof AccessPathNil and
+    ap = node.(AccessPathNilNode).getAp()
+    or
+    contentReadStep(mid, node, ap) and cc = mid.getCallContext()
+    or
+    exists(Content f, AccessPath ap0 | contentStoreStep(mid, node, ap0, f, cc) and push(ap0, f, ap))
+    or
+    pathOutOfArgument(mid, node, cc) and ap = mid.getAp()
+    or
+    pathIntoCallable(mid, node, _, cc, _) and ap = mid.getAp()
+    or
+    pathOutOfCallable(mid, node, cc) and ap = mid.getAp()
+    or
+    pathThroughCallable(mid, node, cc, ap)
+    or
+    valuePathThroughCallable(mid, node, cc) and ap = mid.getAp()
+  )
 }
 
 pragma[noinline]
@@ -1879,7 +1888,7 @@ private predicate pathIntoCallable(
     pathIntoCallable0(mid, callable, i, outercc, call, emptyAp) and
     p.isParameterOf(callable, i)
   |
-    if reducedViableImplInCallContext(_, callable, call)
+    if recordDataFlowCallSite(call, callable)
     then innercc = TSpecificCall(call, i, emptyAp)
     else innercc = TSomeCall(p, emptyAp)
   )
@@ -2377,7 +2386,7 @@ private module FlowExploration {
       partialPathIntoCallable0(mid, callable, i, outercc, call, emptyAp, ap, config) and
       p.isParameterOf(callable, i)
     |
-      if reducedViableImplInCallContext(_, callable, call)
+      if recordDataFlowCallSite(call, callable)
       then innercc = TSpecificCall(call, i, emptyAp)
       else innercc = TSomeCall(p, emptyAp)
     )

--- a/cpp/ql/src/semmle/code/cpp/dataflow/internal/DataFlowImplCommon.qll
+++ b/cpp/ql/src/semmle/code/cpp/dataflow/internal/DataFlowImplCommon.qll
@@ -100,7 +100,7 @@ private module ImplCommon {
       outercc = TSomeCall(getAParameter(c), _)
       or
       exists(DataFlowCall other | outercc = TSpecificCall(other, _, _) |
-        reducedViableImplInCallContext(_, c, other)
+        recordDataFlowCallSite(other, c)
       )
     )
   }
@@ -125,7 +125,7 @@ private module ImplCommon {
     CallContextCall innercc
   ) {
     exists(int i, DataFlowCallable callable | viableParamArg1(p, callable, i, arg, outercc, call) |
-      if reducedViableImplInCallContext(_, callable, call)
+      if recordDataFlowCallSite(call, callable)
       then innercc = TSpecificCall(call, i, true)
       else innercc = TSomeCall(p, true)
     )
@@ -137,7 +137,7 @@ private module ImplCommon {
     exists(DataFlowCall call, int i, DataFlowCallable callable |
       result = TSpecificCall(call, i, _) and
       p.isParameterOf(callable, i) and
-      reducedViableImplInCallContext(_, callable, call)
+      recordDataFlowCallSite(call, callable)
     )
   }
 
@@ -344,11 +344,22 @@ private module ImplCommon {
     exists(ArgumentNode arg | arg.argumentOf(call, -1))
   }
 
+  /**
+   * Record a call site in the dataflow graph if it either improves
+   * virtual dispatch or if we can remove unreachable edges by recoring this call site
+   */
+  cached
+  predicate recordDataFlowCallSite(DataFlowCall call, DataFlowCallable callable) {
+    reducedViableImplInCallContext(_, callable, call)
+    or
+    exists(Node n | n.getEnclosingCallable() = callable | isUnreachableInCall(n, call))
+  }
+
   cached
   newtype TCallContext =
     TAnyCallContext() or
     TSpecificCall(DataFlowCall call, int i, boolean emptyAp) {
-      reducedViableImplInCallContext(_, _, call) and
+      recordDataFlowCallSite(call, _) and
       (emptyAp = true or emptyAp = false) and
       (
         exists(call.getArgument(i))
@@ -362,6 +373,11 @@ private module ImplCommon {
   cached
   newtype TReturnPosition =
     TReturnPosition0(DataFlowCallable c, ReturnKind kind) { returnPosition(_, c, kind) }
+
+  cached
+  newtype TLocalFlowCallContext =
+    TAnyLocalCall() or
+    TSpecificLocalCall(DataFlowCall call) { isUnreachableInCall(_, call) }
 }
 
 import ImplCommon
@@ -380,7 +396,8 @@ private predicate returnPosition(ReturnNode ret, DataFlowCallable c, ReturnKind 
  * - `TAnyCallContext()` : No restrictions on method flow.
  * - `TSpecificCall(DataFlowCall call, int i)` : Flow entered through the `i`th
  *    parameter at the given `call`. This call improves the set of viable
- *    dispatch targets for at least one method call in the current callable.
+ *    dispatch targets for at least one method call in the current callable
+ *    or helps pruning unreachable nodes from the data flow graph.
  * - `TSomeCall(ParameterNode p)` : Flow entered through parameter `p`. The
  *    originating call does not improve the set of dispatch targets for any
  *    method call in the current callable and was therefore not recorded.
@@ -404,6 +421,8 @@ class CallContextSpecificCall extends CallContextCall, TSpecificCall {
       result = "CcCall(" + call + ", " + i + ")"
     )
   }
+
+  DataFlowCall getCall() { this = TSpecificCall(result, _, _) }
 }
 
 class CallContextSomeCall extends CallContextCall, TSomeCall {
@@ -413,6 +432,49 @@ class CallContextSomeCall extends CallContextCall, TSomeCall {
 class CallContextReturn extends CallContext, TReturn {
   override string toString() {
     exists(DataFlowCall call | this = TReturn(_, call) | result = "CcReturn(" + call + ")")
+  }
+}
+
+/**
+ * A call context which is used to restrict local data flow nodes
+ * to nodes which are actually reachable in a call context.
+ */
+abstract class LocalCallContext extends TLocalFlowCallContext {
+  abstract string toString();
+
+  abstract predicate matchesCallContext(CallContext ctx);
+
+  abstract predicate validFor(Node n);
+}
+
+class LocalCallContextAny extends LocalCallContext, TAnyLocalCall {
+  override string toString() { result = "LocalCcAny" }
+
+  override predicate matchesCallContext(CallContext ctx) {
+    not ctx instanceof CallContextSpecificCall or
+    not exists(TSpecificLocalCall(ctx.(CallContextSpecificCall).getCall()))
+  }
+
+  override predicate validFor(Node n) { any() }
+}
+
+class LocalCallContextSpecificCall extends LocalCallContext, TSpecificLocalCall {
+  LocalCallContextSpecificCall() { this = TSpecificLocalCall(call) }
+
+  DataFlowCall call;
+
+  DataFlowCall getCall() { result = call }
+
+  override string toString() { result = "LocalCcCall(" + call + ")" }
+
+  override predicate matchesCallContext(CallContext ctx) {
+    ctx.(CallContextSpecificCall).getCall() = call
+  }
+
+  override predicate validFor(Node n) {
+    exists(Node n2 |
+      isUnreachableInCall(n2, call) and n2.getEnclosingCallable() = n.getEnclosingCallable()
+    )
   }
 }
 

--- a/cpp/ql/src/semmle/code/cpp/dataflow/internal/DataFlowImplLocal.qll
+++ b/cpp/ql/src/semmle/code/cpp/dataflow/internal/DataFlowImplLocal.qll
@@ -905,30 +905,34 @@ private predicate localFlowExit(Node node, Configuration config) {
  */
 pragma[nomagic]
 private predicate localFlowStepPlus(
-  Node node1, Node node2, boolean preservesValue, Configuration config
+  Node node1, Node node2, boolean preservesValue, Configuration config, LocalCallContext cc
 ) {
-  localFlowEntry(node1, config) and
+  not isUnreachableInCall(node2, cc.(LocalCallContextSpecificCall).getCall()) and
   (
-    localFlowStep(node1, node2, config) and preservesValue = true
+    localFlowEntry(node1, config) and
+    (
+      localFlowStep(node1, node2, config) and preservesValue = true
+      or
+      additionalLocalFlowStep(node1, node2, config) and preservesValue = false
+    ) and
+    node1 != node2 and
+    cc.validFor(node1) and
+    nodeCand(node2, unbind(config))
     or
-    additionalLocalFlowStep(node1, node2, config) and preservesValue = false
-  ) and
-  node1 != node2 and
-  nodeCand(node2, unbind(config))
-  or
-  exists(Node mid |
-    localFlowStepPlus(node1, mid, preservesValue, config) and
-    localFlowStep(mid, node2, config) and
-    not mid instanceof CastNode and
-    nodeCand(node2, unbind(config))
-  )
-  or
-  exists(Node mid |
-    localFlowStepPlus(node1, mid, _, config) and
-    additionalLocalFlowStep(mid, node2, config) and
-    not mid instanceof CastNode and
-    preservesValue = false and
-    nodeCand(node2, unbind(config))
+    exists(Node mid |
+      localFlowStepPlus(node1, mid, preservesValue, config, cc) and
+      localFlowStep(mid, node2, config) and
+      not mid instanceof CastNode and
+      nodeCand(node2, unbind(config))
+    )
+    or
+    exists(Node mid |
+      localFlowStepPlus(node1, mid, _, config, cc) and
+      additionalLocalFlowStep(mid, node2, config) and
+      not mid instanceof CastNode and
+      preservesValue = false and
+      nodeCand(node2, unbind(config))
+    )
   )
 }
 
@@ -938,9 +942,9 @@ private predicate localFlowStepPlus(
  */
 pragma[noinline]
 private predicate localFlowBigStep(
-  Node node1, Node node2, boolean preservesValue, Configuration config
+  Node node1, Node node2, boolean preservesValue, Configuration config, LocalCallContext callContext
 ) {
-  localFlowStepPlus(node1, node2, preservesValue, config) and
+  localFlowStepPlus(node1, node2, preservesValue, config, callContext) and
   localFlowExit(node2, config)
 }
 
@@ -1000,7 +1004,7 @@ private class AccessPathFrontNilNode extends Node {
     (
       any(Configuration c).isSource(this)
       or
-      localFlowBigStep(_, this, false, _)
+      localFlowBigStep(_, this, false, _, _)
       or
       additionalJumpStep(_, this, _)
     )
@@ -1023,12 +1027,12 @@ private predicate flowCandFwd0(Node node, boolean fromArg, AccessPathFront apf, 
   (
     exists(Node mid |
       flowCandFwd(mid, fromArg, apf, config) and
-      localFlowBigStep(mid, node, true, config)
+      localFlowBigStep(mid, node, true, config, _)
     )
     or
     exists(Node mid, AccessPathFrontNil nil |
       flowCandFwd(mid, fromArg, nil, config) and
-      localFlowBigStep(mid, node, false, config) and
+      localFlowBigStep(mid, node, false, config, _) and
       apf = node.(AccessPathFrontNilNode).getApf()
     )
     or
@@ -1121,13 +1125,13 @@ private predicate flowCand0(Node node, boolean toReturn, AccessPathFront apf, Co
   apf instanceof AccessPathFrontNil
   or
   exists(Node mid |
-    localFlowBigStep(node, mid, true, config) and
+    localFlowBigStep(node, mid, true, config, _) and
     flowCand(mid, toReturn, apf, config)
   )
   or
   exists(Node mid, AccessPathFrontNil nil |
     flowCandFwd(node, _, apf, config) and
-    localFlowBigStep(node, mid, false, config) and
+    localFlowBigStep(node, mid, false, config, _) and
     flowCand(mid, toReturn, nil, config) and
     apf instanceof AccessPathFrontNil
   )
@@ -1362,12 +1366,12 @@ private predicate flowFwd0(
   (
     exists(Node mid |
       flowFwd(mid, fromArg, apf, ap, config) and
-      localFlowBigStep(mid, node, true, config)
+      localFlowBigStep(mid, node, true, config, _)
     )
     or
     exists(Node mid, AccessPathNil nil |
       flowFwd(mid, fromArg, _, nil, config) and
-      localFlowBigStep(mid, node, false, config) and
+      localFlowBigStep(mid, node, false, config, _) and
       ap = node.(AccessPathNilNode).getAp() and
       apf = ap.(AccessPathNil).getFront()
     )
@@ -1471,13 +1475,13 @@ private predicate flow0(Node node, boolean toReturn, AccessPath ap, Configuratio
   ap instanceof AccessPathNil
   or
   exists(Node mid |
-    localFlowBigStep(node, mid, true, config) and
+    localFlowBigStep(node, mid, true, config, _) and
     flow(mid, toReturn, ap, config)
   )
   or
   exists(Node mid, AccessPathNil nil |
     flowFwd(node, _, _, ap, config) and
-    localFlowBigStep(node, mid, false, config) and
+    localFlowBigStep(node, mid, false, config, _) and
     flow(mid, toReturn, nil, config) and
     ap instanceof AccessPathNil
   )
@@ -1728,37 +1732,42 @@ private class PathNodeSink extends PathNode, TPathNodeSink {
  * a callable is recorded by `cc`.
  */
 private predicate pathStep(PathNodeMid mid, Node node, CallContext cc, AccessPath ap) {
-  localFlowBigStep(mid.getNode(), node, true, mid.getConfiguration()) and
-  cc = mid.getCallContext() and
-  ap = mid.getAp()
+  exists(LocalCallContext localCC | localCC.matchesCallContext(cc) |
+    localFlowBigStep(mid.getNode(), node, true, mid.getConfiguration(), localCC) and
+    cc = mid.getCallContext() and
+    ap = mid.getAp()
+    or
+    localFlowBigStep(mid.getNode(), node, false, mid.getConfiguration(), localCC) and
+    cc = mid.getCallContext() and
+    mid.getAp() instanceof AccessPathNil and
+    ap = node.(AccessPathNilNode).getAp()
+  )
   or
-  localFlowBigStep(mid.getNode(), node, false, mid.getConfiguration()) and
-  cc = mid.getCallContext() and
-  mid.getAp() instanceof AccessPathNil and
-  ap = node.(AccessPathNilNode).getAp()
-  or
-  jumpStep(mid.getNode(), node, mid.getConfiguration()) and
-  cc instanceof CallContextAny and
-  ap = mid.getAp()
-  or
-  additionalJumpStep(mid.getNode(), node, mid.getConfiguration()) and
-  cc instanceof CallContextAny and
-  mid.getAp() instanceof AccessPathNil and
-  ap = node.(AccessPathNilNode).getAp()
-  or
-  contentReadStep(mid, node, ap) and cc = mid.getCallContext()
-  or
-  exists(Content f, AccessPath ap0 | contentStoreStep(mid, node, ap0, f, cc) and push(ap0, f, ap))
-  or
-  pathOutOfArgument(mid, node, cc) and ap = mid.getAp()
-  or
-  pathIntoCallable(mid, node, _, cc, _) and ap = mid.getAp()
-  or
-  pathOutOfCallable(mid, node, cc) and ap = mid.getAp()
-  or
-  pathThroughCallable(mid, node, cc, ap)
-  or
-  valuePathThroughCallable(mid, node, cc) and ap = mid.getAp()
+  not isUnreachableInCall(node, cc.(CallContextSpecificCall).getCall()) and
+  (
+    jumpStep(mid.getNode(), node, mid.getConfiguration()) and
+    cc instanceof CallContextAny and
+    ap = mid.getAp()
+    or
+    additionalJumpStep(mid.getNode(), node, mid.getConfiguration()) and
+    cc instanceof CallContextAny and
+    mid.getAp() instanceof AccessPathNil and
+    ap = node.(AccessPathNilNode).getAp()
+    or
+    contentReadStep(mid, node, ap) and cc = mid.getCallContext()
+    or
+    exists(Content f, AccessPath ap0 | contentStoreStep(mid, node, ap0, f, cc) and push(ap0, f, ap))
+    or
+    pathOutOfArgument(mid, node, cc) and ap = mid.getAp()
+    or
+    pathIntoCallable(mid, node, _, cc, _) and ap = mid.getAp()
+    or
+    pathOutOfCallable(mid, node, cc) and ap = mid.getAp()
+    or
+    pathThroughCallable(mid, node, cc, ap)
+    or
+    valuePathThroughCallable(mid, node, cc) and ap = mid.getAp()
+  )
 }
 
 pragma[noinline]
@@ -1879,7 +1888,7 @@ private predicate pathIntoCallable(
     pathIntoCallable0(mid, callable, i, outercc, call, emptyAp) and
     p.isParameterOf(callable, i)
   |
-    if reducedViableImplInCallContext(_, callable, call)
+    if recordDataFlowCallSite(call, callable)
     then innercc = TSpecificCall(call, i, emptyAp)
     else innercc = TSomeCall(p, emptyAp)
   )
@@ -2377,7 +2386,7 @@ private module FlowExploration {
       partialPathIntoCallable0(mid, callable, i, outercc, call, emptyAp, ap, config) and
       p.isParameterOf(callable, i)
     |
-      if reducedViableImplInCallContext(_, callable, call)
+      if recordDataFlowCallSite(call, callable)
       then innercc = TSpecificCall(call, i, emptyAp)
       else innercc = TSomeCall(p, emptyAp)
     )

--- a/cpp/ql/src/semmle/code/cpp/dataflow/internal/DataFlowPrivate.qll
+++ b/cpp/ql/src/semmle/code/cpp/dataflow/internal/DataFlowPrivate.qll
@@ -264,3 +264,5 @@ class DataFlowCall extends Expr {
   /** Gets the enclosing callable of this call. */
   Function getEnclosingCallable() { result = this.getEnclosingFunction() }
 }
+
+predicate isUnreachableInCall(Node n, DataFlowCall call) { none() } // stub implementation

--- a/cpp/ql/src/semmle/code/cpp/ir/dataflow/internal/DataFlowImpl.qll
+++ b/cpp/ql/src/semmle/code/cpp/ir/dataflow/internal/DataFlowImpl.qll
@@ -905,30 +905,34 @@ private predicate localFlowExit(Node node, Configuration config) {
  */
 pragma[nomagic]
 private predicate localFlowStepPlus(
-  Node node1, Node node2, boolean preservesValue, Configuration config
+  Node node1, Node node2, boolean preservesValue, Configuration config, LocalCallContext cc
 ) {
-  localFlowEntry(node1, config) and
+  not isUnreachableInCall(node2, cc.(LocalCallContextSpecificCall).getCall()) and
   (
-    localFlowStep(node1, node2, config) and preservesValue = true
+    localFlowEntry(node1, config) and
+    (
+      localFlowStep(node1, node2, config) and preservesValue = true
+      or
+      additionalLocalFlowStep(node1, node2, config) and preservesValue = false
+    ) and
+    node1 != node2 and
+    cc.validFor(node1) and
+    nodeCand(node2, unbind(config))
     or
-    additionalLocalFlowStep(node1, node2, config) and preservesValue = false
-  ) and
-  node1 != node2 and
-  nodeCand(node2, unbind(config))
-  or
-  exists(Node mid |
-    localFlowStepPlus(node1, mid, preservesValue, config) and
-    localFlowStep(mid, node2, config) and
-    not mid instanceof CastNode and
-    nodeCand(node2, unbind(config))
-  )
-  or
-  exists(Node mid |
-    localFlowStepPlus(node1, mid, _, config) and
-    additionalLocalFlowStep(mid, node2, config) and
-    not mid instanceof CastNode and
-    preservesValue = false and
-    nodeCand(node2, unbind(config))
+    exists(Node mid |
+      localFlowStepPlus(node1, mid, preservesValue, config, cc) and
+      localFlowStep(mid, node2, config) and
+      not mid instanceof CastNode and
+      nodeCand(node2, unbind(config))
+    )
+    or
+    exists(Node mid |
+      localFlowStepPlus(node1, mid, _, config, cc) and
+      additionalLocalFlowStep(mid, node2, config) and
+      not mid instanceof CastNode and
+      preservesValue = false and
+      nodeCand(node2, unbind(config))
+    )
   )
 }
 
@@ -938,9 +942,9 @@ private predicate localFlowStepPlus(
  */
 pragma[noinline]
 private predicate localFlowBigStep(
-  Node node1, Node node2, boolean preservesValue, Configuration config
+  Node node1, Node node2, boolean preservesValue, Configuration config, LocalCallContext callContext
 ) {
-  localFlowStepPlus(node1, node2, preservesValue, config) and
+  localFlowStepPlus(node1, node2, preservesValue, config, callContext) and
   localFlowExit(node2, config)
 }
 
@@ -1000,7 +1004,7 @@ private class AccessPathFrontNilNode extends Node {
     (
       any(Configuration c).isSource(this)
       or
-      localFlowBigStep(_, this, false, _)
+      localFlowBigStep(_, this, false, _, _)
       or
       additionalJumpStep(_, this, _)
     )
@@ -1023,12 +1027,12 @@ private predicate flowCandFwd0(Node node, boolean fromArg, AccessPathFront apf, 
   (
     exists(Node mid |
       flowCandFwd(mid, fromArg, apf, config) and
-      localFlowBigStep(mid, node, true, config)
+      localFlowBigStep(mid, node, true, config, _)
     )
     or
     exists(Node mid, AccessPathFrontNil nil |
       flowCandFwd(mid, fromArg, nil, config) and
-      localFlowBigStep(mid, node, false, config) and
+      localFlowBigStep(mid, node, false, config, _) and
       apf = node.(AccessPathFrontNilNode).getApf()
     )
     or
@@ -1121,13 +1125,13 @@ private predicate flowCand0(Node node, boolean toReturn, AccessPathFront apf, Co
   apf instanceof AccessPathFrontNil
   or
   exists(Node mid |
-    localFlowBigStep(node, mid, true, config) and
+    localFlowBigStep(node, mid, true, config, _) and
     flowCand(mid, toReturn, apf, config)
   )
   or
   exists(Node mid, AccessPathFrontNil nil |
     flowCandFwd(node, _, apf, config) and
-    localFlowBigStep(node, mid, false, config) and
+    localFlowBigStep(node, mid, false, config, _) and
     flowCand(mid, toReturn, nil, config) and
     apf instanceof AccessPathFrontNil
   )
@@ -1362,12 +1366,12 @@ private predicate flowFwd0(
   (
     exists(Node mid |
       flowFwd(mid, fromArg, apf, ap, config) and
-      localFlowBigStep(mid, node, true, config)
+      localFlowBigStep(mid, node, true, config, _)
     )
     or
     exists(Node mid, AccessPathNil nil |
       flowFwd(mid, fromArg, _, nil, config) and
-      localFlowBigStep(mid, node, false, config) and
+      localFlowBigStep(mid, node, false, config, _) and
       ap = node.(AccessPathNilNode).getAp() and
       apf = ap.(AccessPathNil).getFront()
     )
@@ -1471,13 +1475,13 @@ private predicate flow0(Node node, boolean toReturn, AccessPath ap, Configuratio
   ap instanceof AccessPathNil
   or
   exists(Node mid |
-    localFlowBigStep(node, mid, true, config) and
+    localFlowBigStep(node, mid, true, config, _) and
     flow(mid, toReturn, ap, config)
   )
   or
   exists(Node mid, AccessPathNil nil |
     flowFwd(node, _, _, ap, config) and
-    localFlowBigStep(node, mid, false, config) and
+    localFlowBigStep(node, mid, false, config, _) and
     flow(mid, toReturn, nil, config) and
     ap instanceof AccessPathNil
   )
@@ -1728,37 +1732,42 @@ private class PathNodeSink extends PathNode, TPathNodeSink {
  * a callable is recorded by `cc`.
  */
 private predicate pathStep(PathNodeMid mid, Node node, CallContext cc, AccessPath ap) {
-  localFlowBigStep(mid.getNode(), node, true, mid.getConfiguration()) and
-  cc = mid.getCallContext() and
-  ap = mid.getAp()
+  exists(LocalCallContext localCC | localCC.matchesCallContext(cc) |
+    localFlowBigStep(mid.getNode(), node, true, mid.getConfiguration(), localCC) and
+    cc = mid.getCallContext() and
+    ap = mid.getAp()
+    or
+    localFlowBigStep(mid.getNode(), node, false, mid.getConfiguration(), localCC) and
+    cc = mid.getCallContext() and
+    mid.getAp() instanceof AccessPathNil and
+    ap = node.(AccessPathNilNode).getAp()
+  )
   or
-  localFlowBigStep(mid.getNode(), node, false, mid.getConfiguration()) and
-  cc = mid.getCallContext() and
-  mid.getAp() instanceof AccessPathNil and
-  ap = node.(AccessPathNilNode).getAp()
-  or
-  jumpStep(mid.getNode(), node, mid.getConfiguration()) and
-  cc instanceof CallContextAny and
-  ap = mid.getAp()
-  or
-  additionalJumpStep(mid.getNode(), node, mid.getConfiguration()) and
-  cc instanceof CallContextAny and
-  mid.getAp() instanceof AccessPathNil and
-  ap = node.(AccessPathNilNode).getAp()
-  or
-  contentReadStep(mid, node, ap) and cc = mid.getCallContext()
-  or
-  exists(Content f, AccessPath ap0 | contentStoreStep(mid, node, ap0, f, cc) and push(ap0, f, ap))
-  or
-  pathOutOfArgument(mid, node, cc) and ap = mid.getAp()
-  or
-  pathIntoCallable(mid, node, _, cc, _) and ap = mid.getAp()
-  or
-  pathOutOfCallable(mid, node, cc) and ap = mid.getAp()
-  or
-  pathThroughCallable(mid, node, cc, ap)
-  or
-  valuePathThroughCallable(mid, node, cc) and ap = mid.getAp()
+  not isUnreachableInCall(node, cc.(CallContextSpecificCall).getCall()) and
+  (
+    jumpStep(mid.getNode(), node, mid.getConfiguration()) and
+    cc instanceof CallContextAny and
+    ap = mid.getAp()
+    or
+    additionalJumpStep(mid.getNode(), node, mid.getConfiguration()) and
+    cc instanceof CallContextAny and
+    mid.getAp() instanceof AccessPathNil and
+    ap = node.(AccessPathNilNode).getAp()
+    or
+    contentReadStep(mid, node, ap) and cc = mid.getCallContext()
+    or
+    exists(Content f, AccessPath ap0 | contentStoreStep(mid, node, ap0, f, cc) and push(ap0, f, ap))
+    or
+    pathOutOfArgument(mid, node, cc) and ap = mid.getAp()
+    or
+    pathIntoCallable(mid, node, _, cc, _) and ap = mid.getAp()
+    or
+    pathOutOfCallable(mid, node, cc) and ap = mid.getAp()
+    or
+    pathThroughCallable(mid, node, cc, ap)
+    or
+    valuePathThroughCallable(mid, node, cc) and ap = mid.getAp()
+  )
 }
 
 pragma[noinline]
@@ -1879,7 +1888,7 @@ private predicate pathIntoCallable(
     pathIntoCallable0(mid, callable, i, outercc, call, emptyAp) and
     p.isParameterOf(callable, i)
   |
-    if reducedViableImplInCallContext(_, callable, call)
+    if recordDataFlowCallSite(call, callable)
     then innercc = TSpecificCall(call, i, emptyAp)
     else innercc = TSomeCall(p, emptyAp)
   )
@@ -2377,7 +2386,7 @@ private module FlowExploration {
       partialPathIntoCallable0(mid, callable, i, outercc, call, emptyAp, ap, config) and
       p.isParameterOf(callable, i)
     |
-      if reducedViableImplInCallContext(_, callable, call)
+      if recordDataFlowCallSite(call, callable)
       then innercc = TSpecificCall(call, i, emptyAp)
       else innercc = TSomeCall(p, emptyAp)
     )

--- a/cpp/ql/src/semmle/code/cpp/ir/dataflow/internal/DataFlowImpl2.qll
+++ b/cpp/ql/src/semmle/code/cpp/ir/dataflow/internal/DataFlowImpl2.qll
@@ -905,30 +905,34 @@ private predicate localFlowExit(Node node, Configuration config) {
  */
 pragma[nomagic]
 private predicate localFlowStepPlus(
-  Node node1, Node node2, boolean preservesValue, Configuration config
+  Node node1, Node node2, boolean preservesValue, Configuration config, LocalCallContext cc
 ) {
-  localFlowEntry(node1, config) and
+  not isUnreachableInCall(node2, cc.(LocalCallContextSpecificCall).getCall()) and
   (
-    localFlowStep(node1, node2, config) and preservesValue = true
+    localFlowEntry(node1, config) and
+    (
+      localFlowStep(node1, node2, config) and preservesValue = true
+      or
+      additionalLocalFlowStep(node1, node2, config) and preservesValue = false
+    ) and
+    node1 != node2 and
+    cc.validFor(node1) and
+    nodeCand(node2, unbind(config))
     or
-    additionalLocalFlowStep(node1, node2, config) and preservesValue = false
-  ) and
-  node1 != node2 and
-  nodeCand(node2, unbind(config))
-  or
-  exists(Node mid |
-    localFlowStepPlus(node1, mid, preservesValue, config) and
-    localFlowStep(mid, node2, config) and
-    not mid instanceof CastNode and
-    nodeCand(node2, unbind(config))
-  )
-  or
-  exists(Node mid |
-    localFlowStepPlus(node1, mid, _, config) and
-    additionalLocalFlowStep(mid, node2, config) and
-    not mid instanceof CastNode and
-    preservesValue = false and
-    nodeCand(node2, unbind(config))
+    exists(Node mid |
+      localFlowStepPlus(node1, mid, preservesValue, config, cc) and
+      localFlowStep(mid, node2, config) and
+      not mid instanceof CastNode and
+      nodeCand(node2, unbind(config))
+    )
+    or
+    exists(Node mid |
+      localFlowStepPlus(node1, mid, _, config, cc) and
+      additionalLocalFlowStep(mid, node2, config) and
+      not mid instanceof CastNode and
+      preservesValue = false and
+      nodeCand(node2, unbind(config))
+    )
   )
 }
 
@@ -938,9 +942,9 @@ private predicate localFlowStepPlus(
  */
 pragma[noinline]
 private predicate localFlowBigStep(
-  Node node1, Node node2, boolean preservesValue, Configuration config
+  Node node1, Node node2, boolean preservesValue, Configuration config, LocalCallContext callContext
 ) {
-  localFlowStepPlus(node1, node2, preservesValue, config) and
+  localFlowStepPlus(node1, node2, preservesValue, config, callContext) and
   localFlowExit(node2, config)
 }
 
@@ -1000,7 +1004,7 @@ private class AccessPathFrontNilNode extends Node {
     (
       any(Configuration c).isSource(this)
       or
-      localFlowBigStep(_, this, false, _)
+      localFlowBigStep(_, this, false, _, _)
       or
       additionalJumpStep(_, this, _)
     )
@@ -1023,12 +1027,12 @@ private predicate flowCandFwd0(Node node, boolean fromArg, AccessPathFront apf, 
   (
     exists(Node mid |
       flowCandFwd(mid, fromArg, apf, config) and
-      localFlowBigStep(mid, node, true, config)
+      localFlowBigStep(mid, node, true, config, _)
     )
     or
     exists(Node mid, AccessPathFrontNil nil |
       flowCandFwd(mid, fromArg, nil, config) and
-      localFlowBigStep(mid, node, false, config) and
+      localFlowBigStep(mid, node, false, config, _) and
       apf = node.(AccessPathFrontNilNode).getApf()
     )
     or
@@ -1121,13 +1125,13 @@ private predicate flowCand0(Node node, boolean toReturn, AccessPathFront apf, Co
   apf instanceof AccessPathFrontNil
   or
   exists(Node mid |
-    localFlowBigStep(node, mid, true, config) and
+    localFlowBigStep(node, mid, true, config, _) and
     flowCand(mid, toReturn, apf, config)
   )
   or
   exists(Node mid, AccessPathFrontNil nil |
     flowCandFwd(node, _, apf, config) and
-    localFlowBigStep(node, mid, false, config) and
+    localFlowBigStep(node, mid, false, config, _) and
     flowCand(mid, toReturn, nil, config) and
     apf instanceof AccessPathFrontNil
   )
@@ -1362,12 +1366,12 @@ private predicate flowFwd0(
   (
     exists(Node mid |
       flowFwd(mid, fromArg, apf, ap, config) and
-      localFlowBigStep(mid, node, true, config)
+      localFlowBigStep(mid, node, true, config, _)
     )
     or
     exists(Node mid, AccessPathNil nil |
       flowFwd(mid, fromArg, _, nil, config) and
-      localFlowBigStep(mid, node, false, config) and
+      localFlowBigStep(mid, node, false, config, _) and
       ap = node.(AccessPathNilNode).getAp() and
       apf = ap.(AccessPathNil).getFront()
     )
@@ -1471,13 +1475,13 @@ private predicate flow0(Node node, boolean toReturn, AccessPath ap, Configuratio
   ap instanceof AccessPathNil
   or
   exists(Node mid |
-    localFlowBigStep(node, mid, true, config) and
+    localFlowBigStep(node, mid, true, config, _) and
     flow(mid, toReturn, ap, config)
   )
   or
   exists(Node mid, AccessPathNil nil |
     flowFwd(node, _, _, ap, config) and
-    localFlowBigStep(node, mid, false, config) and
+    localFlowBigStep(node, mid, false, config, _) and
     flow(mid, toReturn, nil, config) and
     ap instanceof AccessPathNil
   )
@@ -1728,37 +1732,42 @@ private class PathNodeSink extends PathNode, TPathNodeSink {
  * a callable is recorded by `cc`.
  */
 private predicate pathStep(PathNodeMid mid, Node node, CallContext cc, AccessPath ap) {
-  localFlowBigStep(mid.getNode(), node, true, mid.getConfiguration()) and
-  cc = mid.getCallContext() and
-  ap = mid.getAp()
+  exists(LocalCallContext localCC | localCC.matchesCallContext(cc) |
+    localFlowBigStep(mid.getNode(), node, true, mid.getConfiguration(), localCC) and
+    cc = mid.getCallContext() and
+    ap = mid.getAp()
+    or
+    localFlowBigStep(mid.getNode(), node, false, mid.getConfiguration(), localCC) and
+    cc = mid.getCallContext() and
+    mid.getAp() instanceof AccessPathNil and
+    ap = node.(AccessPathNilNode).getAp()
+  )
   or
-  localFlowBigStep(mid.getNode(), node, false, mid.getConfiguration()) and
-  cc = mid.getCallContext() and
-  mid.getAp() instanceof AccessPathNil and
-  ap = node.(AccessPathNilNode).getAp()
-  or
-  jumpStep(mid.getNode(), node, mid.getConfiguration()) and
-  cc instanceof CallContextAny and
-  ap = mid.getAp()
-  or
-  additionalJumpStep(mid.getNode(), node, mid.getConfiguration()) and
-  cc instanceof CallContextAny and
-  mid.getAp() instanceof AccessPathNil and
-  ap = node.(AccessPathNilNode).getAp()
-  or
-  contentReadStep(mid, node, ap) and cc = mid.getCallContext()
-  or
-  exists(Content f, AccessPath ap0 | contentStoreStep(mid, node, ap0, f, cc) and push(ap0, f, ap))
-  or
-  pathOutOfArgument(mid, node, cc) and ap = mid.getAp()
-  or
-  pathIntoCallable(mid, node, _, cc, _) and ap = mid.getAp()
-  or
-  pathOutOfCallable(mid, node, cc) and ap = mid.getAp()
-  or
-  pathThroughCallable(mid, node, cc, ap)
-  or
-  valuePathThroughCallable(mid, node, cc) and ap = mid.getAp()
+  not isUnreachableInCall(node, cc.(CallContextSpecificCall).getCall()) and
+  (
+    jumpStep(mid.getNode(), node, mid.getConfiguration()) and
+    cc instanceof CallContextAny and
+    ap = mid.getAp()
+    or
+    additionalJumpStep(mid.getNode(), node, mid.getConfiguration()) and
+    cc instanceof CallContextAny and
+    mid.getAp() instanceof AccessPathNil and
+    ap = node.(AccessPathNilNode).getAp()
+    or
+    contentReadStep(mid, node, ap) and cc = mid.getCallContext()
+    or
+    exists(Content f, AccessPath ap0 | contentStoreStep(mid, node, ap0, f, cc) and push(ap0, f, ap))
+    or
+    pathOutOfArgument(mid, node, cc) and ap = mid.getAp()
+    or
+    pathIntoCallable(mid, node, _, cc, _) and ap = mid.getAp()
+    or
+    pathOutOfCallable(mid, node, cc) and ap = mid.getAp()
+    or
+    pathThroughCallable(mid, node, cc, ap)
+    or
+    valuePathThroughCallable(mid, node, cc) and ap = mid.getAp()
+  )
 }
 
 pragma[noinline]
@@ -1879,7 +1888,7 @@ private predicate pathIntoCallable(
     pathIntoCallable0(mid, callable, i, outercc, call, emptyAp) and
     p.isParameterOf(callable, i)
   |
-    if reducedViableImplInCallContext(_, callable, call)
+    if recordDataFlowCallSite(call, callable)
     then innercc = TSpecificCall(call, i, emptyAp)
     else innercc = TSomeCall(p, emptyAp)
   )
@@ -2377,7 +2386,7 @@ private module FlowExploration {
       partialPathIntoCallable0(mid, callable, i, outercc, call, emptyAp, ap, config) and
       p.isParameterOf(callable, i)
     |
-      if reducedViableImplInCallContext(_, callable, call)
+      if recordDataFlowCallSite(call, callable)
       then innercc = TSpecificCall(call, i, emptyAp)
       else innercc = TSomeCall(p, emptyAp)
     )

--- a/cpp/ql/src/semmle/code/cpp/ir/dataflow/internal/DataFlowImpl3.qll
+++ b/cpp/ql/src/semmle/code/cpp/ir/dataflow/internal/DataFlowImpl3.qll
@@ -905,30 +905,34 @@ private predicate localFlowExit(Node node, Configuration config) {
  */
 pragma[nomagic]
 private predicate localFlowStepPlus(
-  Node node1, Node node2, boolean preservesValue, Configuration config
+  Node node1, Node node2, boolean preservesValue, Configuration config, LocalCallContext cc
 ) {
-  localFlowEntry(node1, config) and
+  not isUnreachableInCall(node2, cc.(LocalCallContextSpecificCall).getCall()) and
   (
-    localFlowStep(node1, node2, config) and preservesValue = true
+    localFlowEntry(node1, config) and
+    (
+      localFlowStep(node1, node2, config) and preservesValue = true
+      or
+      additionalLocalFlowStep(node1, node2, config) and preservesValue = false
+    ) and
+    node1 != node2 and
+    cc.validFor(node1) and
+    nodeCand(node2, unbind(config))
     or
-    additionalLocalFlowStep(node1, node2, config) and preservesValue = false
-  ) and
-  node1 != node2 and
-  nodeCand(node2, unbind(config))
-  or
-  exists(Node mid |
-    localFlowStepPlus(node1, mid, preservesValue, config) and
-    localFlowStep(mid, node2, config) and
-    not mid instanceof CastNode and
-    nodeCand(node2, unbind(config))
-  )
-  or
-  exists(Node mid |
-    localFlowStepPlus(node1, mid, _, config) and
-    additionalLocalFlowStep(mid, node2, config) and
-    not mid instanceof CastNode and
-    preservesValue = false and
-    nodeCand(node2, unbind(config))
+    exists(Node mid |
+      localFlowStepPlus(node1, mid, preservesValue, config, cc) and
+      localFlowStep(mid, node2, config) and
+      not mid instanceof CastNode and
+      nodeCand(node2, unbind(config))
+    )
+    or
+    exists(Node mid |
+      localFlowStepPlus(node1, mid, _, config, cc) and
+      additionalLocalFlowStep(mid, node2, config) and
+      not mid instanceof CastNode and
+      preservesValue = false and
+      nodeCand(node2, unbind(config))
+    )
   )
 }
 
@@ -938,9 +942,9 @@ private predicate localFlowStepPlus(
  */
 pragma[noinline]
 private predicate localFlowBigStep(
-  Node node1, Node node2, boolean preservesValue, Configuration config
+  Node node1, Node node2, boolean preservesValue, Configuration config, LocalCallContext callContext
 ) {
-  localFlowStepPlus(node1, node2, preservesValue, config) and
+  localFlowStepPlus(node1, node2, preservesValue, config, callContext) and
   localFlowExit(node2, config)
 }
 
@@ -1000,7 +1004,7 @@ private class AccessPathFrontNilNode extends Node {
     (
       any(Configuration c).isSource(this)
       or
-      localFlowBigStep(_, this, false, _)
+      localFlowBigStep(_, this, false, _, _)
       or
       additionalJumpStep(_, this, _)
     )
@@ -1023,12 +1027,12 @@ private predicate flowCandFwd0(Node node, boolean fromArg, AccessPathFront apf, 
   (
     exists(Node mid |
       flowCandFwd(mid, fromArg, apf, config) and
-      localFlowBigStep(mid, node, true, config)
+      localFlowBigStep(mid, node, true, config, _)
     )
     or
     exists(Node mid, AccessPathFrontNil nil |
       flowCandFwd(mid, fromArg, nil, config) and
-      localFlowBigStep(mid, node, false, config) and
+      localFlowBigStep(mid, node, false, config, _) and
       apf = node.(AccessPathFrontNilNode).getApf()
     )
     or
@@ -1121,13 +1125,13 @@ private predicate flowCand0(Node node, boolean toReturn, AccessPathFront apf, Co
   apf instanceof AccessPathFrontNil
   or
   exists(Node mid |
-    localFlowBigStep(node, mid, true, config) and
+    localFlowBigStep(node, mid, true, config, _) and
     flowCand(mid, toReturn, apf, config)
   )
   or
   exists(Node mid, AccessPathFrontNil nil |
     flowCandFwd(node, _, apf, config) and
-    localFlowBigStep(node, mid, false, config) and
+    localFlowBigStep(node, mid, false, config, _) and
     flowCand(mid, toReturn, nil, config) and
     apf instanceof AccessPathFrontNil
   )
@@ -1362,12 +1366,12 @@ private predicate flowFwd0(
   (
     exists(Node mid |
       flowFwd(mid, fromArg, apf, ap, config) and
-      localFlowBigStep(mid, node, true, config)
+      localFlowBigStep(mid, node, true, config, _)
     )
     or
     exists(Node mid, AccessPathNil nil |
       flowFwd(mid, fromArg, _, nil, config) and
-      localFlowBigStep(mid, node, false, config) and
+      localFlowBigStep(mid, node, false, config, _) and
       ap = node.(AccessPathNilNode).getAp() and
       apf = ap.(AccessPathNil).getFront()
     )
@@ -1471,13 +1475,13 @@ private predicate flow0(Node node, boolean toReturn, AccessPath ap, Configuratio
   ap instanceof AccessPathNil
   or
   exists(Node mid |
-    localFlowBigStep(node, mid, true, config) and
+    localFlowBigStep(node, mid, true, config, _) and
     flow(mid, toReturn, ap, config)
   )
   or
   exists(Node mid, AccessPathNil nil |
     flowFwd(node, _, _, ap, config) and
-    localFlowBigStep(node, mid, false, config) and
+    localFlowBigStep(node, mid, false, config, _) and
     flow(mid, toReturn, nil, config) and
     ap instanceof AccessPathNil
   )
@@ -1728,37 +1732,42 @@ private class PathNodeSink extends PathNode, TPathNodeSink {
  * a callable is recorded by `cc`.
  */
 private predicate pathStep(PathNodeMid mid, Node node, CallContext cc, AccessPath ap) {
-  localFlowBigStep(mid.getNode(), node, true, mid.getConfiguration()) and
-  cc = mid.getCallContext() and
-  ap = mid.getAp()
+  exists(LocalCallContext localCC | localCC.matchesCallContext(cc) |
+    localFlowBigStep(mid.getNode(), node, true, mid.getConfiguration(), localCC) and
+    cc = mid.getCallContext() and
+    ap = mid.getAp()
+    or
+    localFlowBigStep(mid.getNode(), node, false, mid.getConfiguration(), localCC) and
+    cc = mid.getCallContext() and
+    mid.getAp() instanceof AccessPathNil and
+    ap = node.(AccessPathNilNode).getAp()
+  )
   or
-  localFlowBigStep(mid.getNode(), node, false, mid.getConfiguration()) and
-  cc = mid.getCallContext() and
-  mid.getAp() instanceof AccessPathNil and
-  ap = node.(AccessPathNilNode).getAp()
-  or
-  jumpStep(mid.getNode(), node, mid.getConfiguration()) and
-  cc instanceof CallContextAny and
-  ap = mid.getAp()
-  or
-  additionalJumpStep(mid.getNode(), node, mid.getConfiguration()) and
-  cc instanceof CallContextAny and
-  mid.getAp() instanceof AccessPathNil and
-  ap = node.(AccessPathNilNode).getAp()
-  or
-  contentReadStep(mid, node, ap) and cc = mid.getCallContext()
-  or
-  exists(Content f, AccessPath ap0 | contentStoreStep(mid, node, ap0, f, cc) and push(ap0, f, ap))
-  or
-  pathOutOfArgument(mid, node, cc) and ap = mid.getAp()
-  or
-  pathIntoCallable(mid, node, _, cc, _) and ap = mid.getAp()
-  or
-  pathOutOfCallable(mid, node, cc) and ap = mid.getAp()
-  or
-  pathThroughCallable(mid, node, cc, ap)
-  or
-  valuePathThroughCallable(mid, node, cc) and ap = mid.getAp()
+  not isUnreachableInCall(node, cc.(CallContextSpecificCall).getCall()) and
+  (
+    jumpStep(mid.getNode(), node, mid.getConfiguration()) and
+    cc instanceof CallContextAny and
+    ap = mid.getAp()
+    or
+    additionalJumpStep(mid.getNode(), node, mid.getConfiguration()) and
+    cc instanceof CallContextAny and
+    mid.getAp() instanceof AccessPathNil and
+    ap = node.(AccessPathNilNode).getAp()
+    or
+    contentReadStep(mid, node, ap) and cc = mid.getCallContext()
+    or
+    exists(Content f, AccessPath ap0 | contentStoreStep(mid, node, ap0, f, cc) and push(ap0, f, ap))
+    or
+    pathOutOfArgument(mid, node, cc) and ap = mid.getAp()
+    or
+    pathIntoCallable(mid, node, _, cc, _) and ap = mid.getAp()
+    or
+    pathOutOfCallable(mid, node, cc) and ap = mid.getAp()
+    or
+    pathThroughCallable(mid, node, cc, ap)
+    or
+    valuePathThroughCallable(mid, node, cc) and ap = mid.getAp()
+  )
 }
 
 pragma[noinline]
@@ -1879,7 +1888,7 @@ private predicate pathIntoCallable(
     pathIntoCallable0(mid, callable, i, outercc, call, emptyAp) and
     p.isParameterOf(callable, i)
   |
-    if reducedViableImplInCallContext(_, callable, call)
+    if recordDataFlowCallSite(call, callable)
     then innercc = TSpecificCall(call, i, emptyAp)
     else innercc = TSomeCall(p, emptyAp)
   )
@@ -2377,7 +2386,7 @@ private module FlowExploration {
       partialPathIntoCallable0(mid, callable, i, outercc, call, emptyAp, ap, config) and
       p.isParameterOf(callable, i)
     |
-      if reducedViableImplInCallContext(_, callable, call)
+      if recordDataFlowCallSite(call, callable)
       then innercc = TSpecificCall(call, i, emptyAp)
       else innercc = TSomeCall(p, emptyAp)
     )

--- a/cpp/ql/src/semmle/code/cpp/ir/dataflow/internal/DataFlowImpl4.qll
+++ b/cpp/ql/src/semmle/code/cpp/ir/dataflow/internal/DataFlowImpl4.qll
@@ -905,30 +905,34 @@ private predicate localFlowExit(Node node, Configuration config) {
  */
 pragma[nomagic]
 private predicate localFlowStepPlus(
-  Node node1, Node node2, boolean preservesValue, Configuration config
+  Node node1, Node node2, boolean preservesValue, Configuration config, LocalCallContext cc
 ) {
-  localFlowEntry(node1, config) and
+  not isUnreachableInCall(node2, cc.(LocalCallContextSpecificCall).getCall()) and
   (
-    localFlowStep(node1, node2, config) and preservesValue = true
+    localFlowEntry(node1, config) and
+    (
+      localFlowStep(node1, node2, config) and preservesValue = true
+      or
+      additionalLocalFlowStep(node1, node2, config) and preservesValue = false
+    ) and
+    node1 != node2 and
+    cc.validFor(node1) and
+    nodeCand(node2, unbind(config))
     or
-    additionalLocalFlowStep(node1, node2, config) and preservesValue = false
-  ) and
-  node1 != node2 and
-  nodeCand(node2, unbind(config))
-  or
-  exists(Node mid |
-    localFlowStepPlus(node1, mid, preservesValue, config) and
-    localFlowStep(mid, node2, config) and
-    not mid instanceof CastNode and
-    nodeCand(node2, unbind(config))
-  )
-  or
-  exists(Node mid |
-    localFlowStepPlus(node1, mid, _, config) and
-    additionalLocalFlowStep(mid, node2, config) and
-    not mid instanceof CastNode and
-    preservesValue = false and
-    nodeCand(node2, unbind(config))
+    exists(Node mid |
+      localFlowStepPlus(node1, mid, preservesValue, config, cc) and
+      localFlowStep(mid, node2, config) and
+      not mid instanceof CastNode and
+      nodeCand(node2, unbind(config))
+    )
+    or
+    exists(Node mid |
+      localFlowStepPlus(node1, mid, _, config, cc) and
+      additionalLocalFlowStep(mid, node2, config) and
+      not mid instanceof CastNode and
+      preservesValue = false and
+      nodeCand(node2, unbind(config))
+    )
   )
 }
 
@@ -938,9 +942,9 @@ private predicate localFlowStepPlus(
  */
 pragma[noinline]
 private predicate localFlowBigStep(
-  Node node1, Node node2, boolean preservesValue, Configuration config
+  Node node1, Node node2, boolean preservesValue, Configuration config, LocalCallContext callContext
 ) {
-  localFlowStepPlus(node1, node2, preservesValue, config) and
+  localFlowStepPlus(node1, node2, preservesValue, config, callContext) and
   localFlowExit(node2, config)
 }
 
@@ -1000,7 +1004,7 @@ private class AccessPathFrontNilNode extends Node {
     (
       any(Configuration c).isSource(this)
       or
-      localFlowBigStep(_, this, false, _)
+      localFlowBigStep(_, this, false, _, _)
       or
       additionalJumpStep(_, this, _)
     )
@@ -1023,12 +1027,12 @@ private predicate flowCandFwd0(Node node, boolean fromArg, AccessPathFront apf, 
   (
     exists(Node mid |
       flowCandFwd(mid, fromArg, apf, config) and
-      localFlowBigStep(mid, node, true, config)
+      localFlowBigStep(mid, node, true, config, _)
     )
     or
     exists(Node mid, AccessPathFrontNil nil |
       flowCandFwd(mid, fromArg, nil, config) and
-      localFlowBigStep(mid, node, false, config) and
+      localFlowBigStep(mid, node, false, config, _) and
       apf = node.(AccessPathFrontNilNode).getApf()
     )
     or
@@ -1121,13 +1125,13 @@ private predicate flowCand0(Node node, boolean toReturn, AccessPathFront apf, Co
   apf instanceof AccessPathFrontNil
   or
   exists(Node mid |
-    localFlowBigStep(node, mid, true, config) and
+    localFlowBigStep(node, mid, true, config, _) and
     flowCand(mid, toReturn, apf, config)
   )
   or
   exists(Node mid, AccessPathFrontNil nil |
     flowCandFwd(node, _, apf, config) and
-    localFlowBigStep(node, mid, false, config) and
+    localFlowBigStep(node, mid, false, config, _) and
     flowCand(mid, toReturn, nil, config) and
     apf instanceof AccessPathFrontNil
   )
@@ -1362,12 +1366,12 @@ private predicate flowFwd0(
   (
     exists(Node mid |
       flowFwd(mid, fromArg, apf, ap, config) and
-      localFlowBigStep(mid, node, true, config)
+      localFlowBigStep(mid, node, true, config, _)
     )
     or
     exists(Node mid, AccessPathNil nil |
       flowFwd(mid, fromArg, _, nil, config) and
-      localFlowBigStep(mid, node, false, config) and
+      localFlowBigStep(mid, node, false, config, _) and
       ap = node.(AccessPathNilNode).getAp() and
       apf = ap.(AccessPathNil).getFront()
     )
@@ -1471,13 +1475,13 @@ private predicate flow0(Node node, boolean toReturn, AccessPath ap, Configuratio
   ap instanceof AccessPathNil
   or
   exists(Node mid |
-    localFlowBigStep(node, mid, true, config) and
+    localFlowBigStep(node, mid, true, config, _) and
     flow(mid, toReturn, ap, config)
   )
   or
   exists(Node mid, AccessPathNil nil |
     flowFwd(node, _, _, ap, config) and
-    localFlowBigStep(node, mid, false, config) and
+    localFlowBigStep(node, mid, false, config, _) and
     flow(mid, toReturn, nil, config) and
     ap instanceof AccessPathNil
   )
@@ -1728,37 +1732,42 @@ private class PathNodeSink extends PathNode, TPathNodeSink {
  * a callable is recorded by `cc`.
  */
 private predicate pathStep(PathNodeMid mid, Node node, CallContext cc, AccessPath ap) {
-  localFlowBigStep(mid.getNode(), node, true, mid.getConfiguration()) and
-  cc = mid.getCallContext() and
-  ap = mid.getAp()
+  exists(LocalCallContext localCC | localCC.matchesCallContext(cc) |
+    localFlowBigStep(mid.getNode(), node, true, mid.getConfiguration(), localCC) and
+    cc = mid.getCallContext() and
+    ap = mid.getAp()
+    or
+    localFlowBigStep(mid.getNode(), node, false, mid.getConfiguration(), localCC) and
+    cc = mid.getCallContext() and
+    mid.getAp() instanceof AccessPathNil and
+    ap = node.(AccessPathNilNode).getAp()
+  )
   or
-  localFlowBigStep(mid.getNode(), node, false, mid.getConfiguration()) and
-  cc = mid.getCallContext() and
-  mid.getAp() instanceof AccessPathNil and
-  ap = node.(AccessPathNilNode).getAp()
-  or
-  jumpStep(mid.getNode(), node, mid.getConfiguration()) and
-  cc instanceof CallContextAny and
-  ap = mid.getAp()
-  or
-  additionalJumpStep(mid.getNode(), node, mid.getConfiguration()) and
-  cc instanceof CallContextAny and
-  mid.getAp() instanceof AccessPathNil and
-  ap = node.(AccessPathNilNode).getAp()
-  or
-  contentReadStep(mid, node, ap) and cc = mid.getCallContext()
-  or
-  exists(Content f, AccessPath ap0 | contentStoreStep(mid, node, ap0, f, cc) and push(ap0, f, ap))
-  or
-  pathOutOfArgument(mid, node, cc) and ap = mid.getAp()
-  or
-  pathIntoCallable(mid, node, _, cc, _) and ap = mid.getAp()
-  or
-  pathOutOfCallable(mid, node, cc) and ap = mid.getAp()
-  or
-  pathThroughCallable(mid, node, cc, ap)
-  or
-  valuePathThroughCallable(mid, node, cc) and ap = mid.getAp()
+  not isUnreachableInCall(node, cc.(CallContextSpecificCall).getCall()) and
+  (
+    jumpStep(mid.getNode(), node, mid.getConfiguration()) and
+    cc instanceof CallContextAny and
+    ap = mid.getAp()
+    or
+    additionalJumpStep(mid.getNode(), node, mid.getConfiguration()) and
+    cc instanceof CallContextAny and
+    mid.getAp() instanceof AccessPathNil and
+    ap = node.(AccessPathNilNode).getAp()
+    or
+    contentReadStep(mid, node, ap) and cc = mid.getCallContext()
+    or
+    exists(Content f, AccessPath ap0 | contentStoreStep(mid, node, ap0, f, cc) and push(ap0, f, ap))
+    or
+    pathOutOfArgument(mid, node, cc) and ap = mid.getAp()
+    or
+    pathIntoCallable(mid, node, _, cc, _) and ap = mid.getAp()
+    or
+    pathOutOfCallable(mid, node, cc) and ap = mid.getAp()
+    or
+    pathThroughCallable(mid, node, cc, ap)
+    or
+    valuePathThroughCallable(mid, node, cc) and ap = mid.getAp()
+  )
 }
 
 pragma[noinline]
@@ -1879,7 +1888,7 @@ private predicate pathIntoCallable(
     pathIntoCallable0(mid, callable, i, outercc, call, emptyAp) and
     p.isParameterOf(callable, i)
   |
-    if reducedViableImplInCallContext(_, callable, call)
+    if recordDataFlowCallSite(call, callable)
     then innercc = TSpecificCall(call, i, emptyAp)
     else innercc = TSomeCall(p, emptyAp)
   )
@@ -2377,7 +2386,7 @@ private module FlowExploration {
       partialPathIntoCallable0(mid, callable, i, outercc, call, emptyAp, ap, config) and
       p.isParameterOf(callable, i)
     |
-      if reducedViableImplInCallContext(_, callable, call)
+      if recordDataFlowCallSite(call, callable)
       then innercc = TSpecificCall(call, i, emptyAp)
       else innercc = TSomeCall(p, emptyAp)
     )

--- a/cpp/ql/src/semmle/code/cpp/ir/dataflow/internal/DataFlowImplCommon.qll
+++ b/cpp/ql/src/semmle/code/cpp/ir/dataflow/internal/DataFlowImplCommon.qll
@@ -100,7 +100,7 @@ private module ImplCommon {
       outercc = TSomeCall(getAParameter(c), _)
       or
       exists(DataFlowCall other | outercc = TSpecificCall(other, _, _) |
-        reducedViableImplInCallContext(_, c, other)
+        recordDataFlowCallSite(other, c)
       )
     )
   }
@@ -125,7 +125,7 @@ private module ImplCommon {
     CallContextCall innercc
   ) {
     exists(int i, DataFlowCallable callable | viableParamArg1(p, callable, i, arg, outercc, call) |
-      if reducedViableImplInCallContext(_, callable, call)
+      if recordDataFlowCallSite(call, callable)
       then innercc = TSpecificCall(call, i, true)
       else innercc = TSomeCall(p, true)
     )
@@ -137,7 +137,7 @@ private module ImplCommon {
     exists(DataFlowCall call, int i, DataFlowCallable callable |
       result = TSpecificCall(call, i, _) and
       p.isParameterOf(callable, i) and
-      reducedViableImplInCallContext(_, callable, call)
+      recordDataFlowCallSite(call, callable)
     )
   }
 
@@ -344,11 +344,22 @@ private module ImplCommon {
     exists(ArgumentNode arg | arg.argumentOf(call, -1))
   }
 
+  /**
+   * Record a call site in the dataflow graph if it either improves
+   * virtual dispatch or if we can remove unreachable edges by recoring this call site
+   */
+  cached
+  predicate recordDataFlowCallSite(DataFlowCall call, DataFlowCallable callable) {
+    reducedViableImplInCallContext(_, callable, call)
+    or
+    exists(Node n | n.getEnclosingCallable() = callable | isUnreachableInCall(n, call))
+  }
+
   cached
   newtype TCallContext =
     TAnyCallContext() or
     TSpecificCall(DataFlowCall call, int i, boolean emptyAp) {
-      reducedViableImplInCallContext(_, _, call) and
+      recordDataFlowCallSite(call, _) and
       (emptyAp = true or emptyAp = false) and
       (
         exists(call.getArgument(i))
@@ -362,6 +373,11 @@ private module ImplCommon {
   cached
   newtype TReturnPosition =
     TReturnPosition0(DataFlowCallable c, ReturnKind kind) { returnPosition(_, c, kind) }
+
+  cached
+  newtype TLocalFlowCallContext =
+    TAnyLocalCall() or
+    TSpecificLocalCall(DataFlowCall call) { isUnreachableInCall(_, call) }
 }
 
 import ImplCommon
@@ -380,7 +396,8 @@ private predicate returnPosition(ReturnNode ret, DataFlowCallable c, ReturnKind 
  * - `TAnyCallContext()` : No restrictions on method flow.
  * - `TSpecificCall(DataFlowCall call, int i)` : Flow entered through the `i`th
  *    parameter at the given `call`. This call improves the set of viable
- *    dispatch targets for at least one method call in the current callable.
+ *    dispatch targets for at least one method call in the current callable
+ *    or helps pruning unreachable nodes from the data flow graph.
  * - `TSomeCall(ParameterNode p)` : Flow entered through parameter `p`. The
  *    originating call does not improve the set of dispatch targets for any
  *    method call in the current callable and was therefore not recorded.
@@ -404,6 +421,8 @@ class CallContextSpecificCall extends CallContextCall, TSpecificCall {
       result = "CcCall(" + call + ", " + i + ")"
     )
   }
+
+  DataFlowCall getCall() { this = TSpecificCall(result, _, _) }
 }
 
 class CallContextSomeCall extends CallContextCall, TSomeCall {
@@ -413,6 +432,49 @@ class CallContextSomeCall extends CallContextCall, TSomeCall {
 class CallContextReturn extends CallContext, TReturn {
   override string toString() {
     exists(DataFlowCall call | this = TReturn(_, call) | result = "CcReturn(" + call + ")")
+  }
+}
+
+/**
+ * A call context which is used to restrict local data flow nodes
+ * to nodes which are actually reachable in a call context.
+ */
+abstract class LocalCallContext extends TLocalFlowCallContext {
+  abstract string toString();
+
+  abstract predicate matchesCallContext(CallContext ctx);
+
+  abstract predicate validFor(Node n);
+}
+
+class LocalCallContextAny extends LocalCallContext, TAnyLocalCall {
+  override string toString() { result = "LocalCcAny" }
+
+  override predicate matchesCallContext(CallContext ctx) {
+    not ctx instanceof CallContextSpecificCall or
+    not exists(TSpecificLocalCall(ctx.(CallContextSpecificCall).getCall()))
+  }
+
+  override predicate validFor(Node n) { any() }
+}
+
+class LocalCallContextSpecificCall extends LocalCallContext, TSpecificLocalCall {
+  LocalCallContextSpecificCall() { this = TSpecificLocalCall(call) }
+
+  DataFlowCall call;
+
+  DataFlowCall getCall() { result = call }
+
+  override string toString() { result = "LocalCcCall(" + call + ")" }
+
+  override predicate matchesCallContext(CallContext ctx) {
+    ctx.(CallContextSpecificCall).getCall() = call
+  }
+
+  override predicate validFor(Node n) {
+    exists(Node n2 |
+      isUnreachableInCall(n2, call) and n2.getEnclosingCallable() = n.getEnclosingCallable()
+    )
   }
 }
 

--- a/cpp/ql/src/semmle/code/cpp/ir/dataflow/internal/DataFlowPrivate.qll
+++ b/cpp/ql/src/semmle/code/cpp/ir/dataflow/internal/DataFlowPrivate.qll
@@ -204,3 +204,5 @@ class DataFlowCall extends CallInstruction {
 
   Function getEnclosingCallable() { result = this.getEnclosingFunction() }
 }
+
+predicate isUnreachableInCall(Node n, DataFlowCall call) { none() } // stub implementation

--- a/csharp/ql/src/semmle/code/csharp/dataflow/internal/DataFlowImpl.qll
+++ b/csharp/ql/src/semmle/code/csharp/dataflow/internal/DataFlowImpl.qll
@@ -905,30 +905,34 @@ private predicate localFlowExit(Node node, Configuration config) {
  */
 pragma[nomagic]
 private predicate localFlowStepPlus(
-  Node node1, Node node2, boolean preservesValue, Configuration config
+  Node node1, Node node2, boolean preservesValue, Configuration config, LocalCallContext cc
 ) {
-  localFlowEntry(node1, config) and
+  not isUnreachableInCall(node2, cc.(LocalCallContextSpecificCall).getCall()) and
   (
-    localFlowStep(node1, node2, config) and preservesValue = true
+    localFlowEntry(node1, config) and
+    (
+      localFlowStep(node1, node2, config) and preservesValue = true
+      or
+      additionalLocalFlowStep(node1, node2, config) and preservesValue = false
+    ) and
+    node1 != node2 and
+    cc.validFor(node1) and
+    nodeCand(node2, unbind(config))
     or
-    additionalLocalFlowStep(node1, node2, config) and preservesValue = false
-  ) and
-  node1 != node2 and
-  nodeCand(node2, unbind(config))
-  or
-  exists(Node mid |
-    localFlowStepPlus(node1, mid, preservesValue, config) and
-    localFlowStep(mid, node2, config) and
-    not mid instanceof CastNode and
-    nodeCand(node2, unbind(config))
-  )
-  or
-  exists(Node mid |
-    localFlowStepPlus(node1, mid, _, config) and
-    additionalLocalFlowStep(mid, node2, config) and
-    not mid instanceof CastNode and
-    preservesValue = false and
-    nodeCand(node2, unbind(config))
+    exists(Node mid |
+      localFlowStepPlus(node1, mid, preservesValue, config, cc) and
+      localFlowStep(mid, node2, config) and
+      not mid instanceof CastNode and
+      nodeCand(node2, unbind(config))
+    )
+    or
+    exists(Node mid |
+      localFlowStepPlus(node1, mid, _, config, cc) and
+      additionalLocalFlowStep(mid, node2, config) and
+      not mid instanceof CastNode and
+      preservesValue = false and
+      nodeCand(node2, unbind(config))
+    )
   )
 }
 
@@ -938,9 +942,9 @@ private predicate localFlowStepPlus(
  */
 pragma[noinline]
 private predicate localFlowBigStep(
-  Node node1, Node node2, boolean preservesValue, Configuration config
+  Node node1, Node node2, boolean preservesValue, Configuration config, LocalCallContext callContext
 ) {
-  localFlowStepPlus(node1, node2, preservesValue, config) and
+  localFlowStepPlus(node1, node2, preservesValue, config, callContext) and
   localFlowExit(node2, config)
 }
 
@@ -1000,7 +1004,7 @@ private class AccessPathFrontNilNode extends Node {
     (
       any(Configuration c).isSource(this)
       or
-      localFlowBigStep(_, this, false, _)
+      localFlowBigStep(_, this, false, _, _)
       or
       additionalJumpStep(_, this, _)
     )
@@ -1023,12 +1027,12 @@ private predicate flowCandFwd0(Node node, boolean fromArg, AccessPathFront apf, 
   (
     exists(Node mid |
       flowCandFwd(mid, fromArg, apf, config) and
-      localFlowBigStep(mid, node, true, config)
+      localFlowBigStep(mid, node, true, config, _)
     )
     or
     exists(Node mid, AccessPathFrontNil nil |
       flowCandFwd(mid, fromArg, nil, config) and
-      localFlowBigStep(mid, node, false, config) and
+      localFlowBigStep(mid, node, false, config, _) and
       apf = node.(AccessPathFrontNilNode).getApf()
     )
     or
@@ -1121,13 +1125,13 @@ private predicate flowCand0(Node node, boolean toReturn, AccessPathFront apf, Co
   apf instanceof AccessPathFrontNil
   or
   exists(Node mid |
-    localFlowBigStep(node, mid, true, config) and
+    localFlowBigStep(node, mid, true, config, _) and
     flowCand(mid, toReturn, apf, config)
   )
   or
   exists(Node mid, AccessPathFrontNil nil |
     flowCandFwd(node, _, apf, config) and
-    localFlowBigStep(node, mid, false, config) and
+    localFlowBigStep(node, mid, false, config, _) and
     flowCand(mid, toReturn, nil, config) and
     apf instanceof AccessPathFrontNil
   )
@@ -1362,12 +1366,12 @@ private predicate flowFwd0(
   (
     exists(Node mid |
       flowFwd(mid, fromArg, apf, ap, config) and
-      localFlowBigStep(mid, node, true, config)
+      localFlowBigStep(mid, node, true, config, _)
     )
     or
     exists(Node mid, AccessPathNil nil |
       flowFwd(mid, fromArg, _, nil, config) and
-      localFlowBigStep(mid, node, false, config) and
+      localFlowBigStep(mid, node, false, config, _) and
       ap = node.(AccessPathNilNode).getAp() and
       apf = ap.(AccessPathNil).getFront()
     )
@@ -1471,13 +1475,13 @@ private predicate flow0(Node node, boolean toReturn, AccessPath ap, Configuratio
   ap instanceof AccessPathNil
   or
   exists(Node mid |
-    localFlowBigStep(node, mid, true, config) and
+    localFlowBigStep(node, mid, true, config, _) and
     flow(mid, toReturn, ap, config)
   )
   or
   exists(Node mid, AccessPathNil nil |
     flowFwd(node, _, _, ap, config) and
-    localFlowBigStep(node, mid, false, config) and
+    localFlowBigStep(node, mid, false, config, _) and
     flow(mid, toReturn, nil, config) and
     ap instanceof AccessPathNil
   )
@@ -1728,37 +1732,42 @@ private class PathNodeSink extends PathNode, TPathNodeSink {
  * a callable is recorded by `cc`.
  */
 private predicate pathStep(PathNodeMid mid, Node node, CallContext cc, AccessPath ap) {
-  localFlowBigStep(mid.getNode(), node, true, mid.getConfiguration()) and
-  cc = mid.getCallContext() and
-  ap = mid.getAp()
+  exists(LocalCallContext localCC | localCC.matchesCallContext(cc) |
+    localFlowBigStep(mid.getNode(), node, true, mid.getConfiguration(), localCC) and
+    cc = mid.getCallContext() and
+    ap = mid.getAp()
+    or
+    localFlowBigStep(mid.getNode(), node, false, mid.getConfiguration(), localCC) and
+    cc = mid.getCallContext() and
+    mid.getAp() instanceof AccessPathNil and
+    ap = node.(AccessPathNilNode).getAp()
+  )
   or
-  localFlowBigStep(mid.getNode(), node, false, mid.getConfiguration()) and
-  cc = mid.getCallContext() and
-  mid.getAp() instanceof AccessPathNil and
-  ap = node.(AccessPathNilNode).getAp()
-  or
-  jumpStep(mid.getNode(), node, mid.getConfiguration()) and
-  cc instanceof CallContextAny and
-  ap = mid.getAp()
-  or
-  additionalJumpStep(mid.getNode(), node, mid.getConfiguration()) and
-  cc instanceof CallContextAny and
-  mid.getAp() instanceof AccessPathNil and
-  ap = node.(AccessPathNilNode).getAp()
-  or
-  contentReadStep(mid, node, ap) and cc = mid.getCallContext()
-  or
-  exists(Content f, AccessPath ap0 | contentStoreStep(mid, node, ap0, f, cc) and push(ap0, f, ap))
-  or
-  pathOutOfArgument(mid, node, cc) and ap = mid.getAp()
-  or
-  pathIntoCallable(mid, node, _, cc, _) and ap = mid.getAp()
-  or
-  pathOutOfCallable(mid, node, cc) and ap = mid.getAp()
-  or
-  pathThroughCallable(mid, node, cc, ap)
-  or
-  valuePathThroughCallable(mid, node, cc) and ap = mid.getAp()
+  not isUnreachableInCall(node, cc.(CallContextSpecificCall).getCall()) and
+  (
+    jumpStep(mid.getNode(), node, mid.getConfiguration()) and
+    cc instanceof CallContextAny and
+    ap = mid.getAp()
+    or
+    additionalJumpStep(mid.getNode(), node, mid.getConfiguration()) and
+    cc instanceof CallContextAny and
+    mid.getAp() instanceof AccessPathNil and
+    ap = node.(AccessPathNilNode).getAp()
+    or
+    contentReadStep(mid, node, ap) and cc = mid.getCallContext()
+    or
+    exists(Content f, AccessPath ap0 | contentStoreStep(mid, node, ap0, f, cc) and push(ap0, f, ap))
+    or
+    pathOutOfArgument(mid, node, cc) and ap = mid.getAp()
+    or
+    pathIntoCallable(mid, node, _, cc, _) and ap = mid.getAp()
+    or
+    pathOutOfCallable(mid, node, cc) and ap = mid.getAp()
+    or
+    pathThroughCallable(mid, node, cc, ap)
+    or
+    valuePathThroughCallable(mid, node, cc) and ap = mid.getAp()
+  )
 }
 
 pragma[noinline]
@@ -1879,7 +1888,7 @@ private predicate pathIntoCallable(
     pathIntoCallable0(mid, callable, i, outercc, call, emptyAp) and
     p.isParameterOf(callable, i)
   |
-    if reducedViableImplInCallContext(_, callable, call)
+    if recordDataFlowCallSite(call, callable)
     then innercc = TSpecificCall(call, i, emptyAp)
     else innercc = TSomeCall(p, emptyAp)
   )
@@ -2377,7 +2386,7 @@ private module FlowExploration {
       partialPathIntoCallable0(mid, callable, i, outercc, call, emptyAp, ap, config) and
       p.isParameterOf(callable, i)
     |
-      if reducedViableImplInCallContext(_, callable, call)
+      if recordDataFlowCallSite(call, callable)
       then innercc = TSpecificCall(call, i, emptyAp)
       else innercc = TSomeCall(p, emptyAp)
     )

--- a/csharp/ql/src/semmle/code/csharp/dataflow/internal/DataFlowImpl2.qll
+++ b/csharp/ql/src/semmle/code/csharp/dataflow/internal/DataFlowImpl2.qll
@@ -905,30 +905,34 @@ private predicate localFlowExit(Node node, Configuration config) {
  */
 pragma[nomagic]
 private predicate localFlowStepPlus(
-  Node node1, Node node2, boolean preservesValue, Configuration config
+  Node node1, Node node2, boolean preservesValue, Configuration config, LocalCallContext cc
 ) {
-  localFlowEntry(node1, config) and
+  not isUnreachableInCall(node2, cc.(LocalCallContextSpecificCall).getCall()) and
   (
-    localFlowStep(node1, node2, config) and preservesValue = true
+    localFlowEntry(node1, config) and
+    (
+      localFlowStep(node1, node2, config) and preservesValue = true
+      or
+      additionalLocalFlowStep(node1, node2, config) and preservesValue = false
+    ) and
+    node1 != node2 and
+    cc.validFor(node1) and
+    nodeCand(node2, unbind(config))
     or
-    additionalLocalFlowStep(node1, node2, config) and preservesValue = false
-  ) and
-  node1 != node2 and
-  nodeCand(node2, unbind(config))
-  or
-  exists(Node mid |
-    localFlowStepPlus(node1, mid, preservesValue, config) and
-    localFlowStep(mid, node2, config) and
-    not mid instanceof CastNode and
-    nodeCand(node2, unbind(config))
-  )
-  or
-  exists(Node mid |
-    localFlowStepPlus(node1, mid, _, config) and
-    additionalLocalFlowStep(mid, node2, config) and
-    not mid instanceof CastNode and
-    preservesValue = false and
-    nodeCand(node2, unbind(config))
+    exists(Node mid |
+      localFlowStepPlus(node1, mid, preservesValue, config, cc) and
+      localFlowStep(mid, node2, config) and
+      not mid instanceof CastNode and
+      nodeCand(node2, unbind(config))
+    )
+    or
+    exists(Node mid |
+      localFlowStepPlus(node1, mid, _, config, cc) and
+      additionalLocalFlowStep(mid, node2, config) and
+      not mid instanceof CastNode and
+      preservesValue = false and
+      nodeCand(node2, unbind(config))
+    )
   )
 }
 
@@ -938,9 +942,9 @@ private predicate localFlowStepPlus(
  */
 pragma[noinline]
 private predicate localFlowBigStep(
-  Node node1, Node node2, boolean preservesValue, Configuration config
+  Node node1, Node node2, boolean preservesValue, Configuration config, LocalCallContext callContext
 ) {
-  localFlowStepPlus(node1, node2, preservesValue, config) and
+  localFlowStepPlus(node1, node2, preservesValue, config, callContext) and
   localFlowExit(node2, config)
 }
 
@@ -1000,7 +1004,7 @@ private class AccessPathFrontNilNode extends Node {
     (
       any(Configuration c).isSource(this)
       or
-      localFlowBigStep(_, this, false, _)
+      localFlowBigStep(_, this, false, _, _)
       or
       additionalJumpStep(_, this, _)
     )
@@ -1023,12 +1027,12 @@ private predicate flowCandFwd0(Node node, boolean fromArg, AccessPathFront apf, 
   (
     exists(Node mid |
       flowCandFwd(mid, fromArg, apf, config) and
-      localFlowBigStep(mid, node, true, config)
+      localFlowBigStep(mid, node, true, config, _)
     )
     or
     exists(Node mid, AccessPathFrontNil nil |
       flowCandFwd(mid, fromArg, nil, config) and
-      localFlowBigStep(mid, node, false, config) and
+      localFlowBigStep(mid, node, false, config, _) and
       apf = node.(AccessPathFrontNilNode).getApf()
     )
     or
@@ -1121,13 +1125,13 @@ private predicate flowCand0(Node node, boolean toReturn, AccessPathFront apf, Co
   apf instanceof AccessPathFrontNil
   or
   exists(Node mid |
-    localFlowBigStep(node, mid, true, config) and
+    localFlowBigStep(node, mid, true, config, _) and
     flowCand(mid, toReturn, apf, config)
   )
   or
   exists(Node mid, AccessPathFrontNil nil |
     flowCandFwd(node, _, apf, config) and
-    localFlowBigStep(node, mid, false, config) and
+    localFlowBigStep(node, mid, false, config, _) and
     flowCand(mid, toReturn, nil, config) and
     apf instanceof AccessPathFrontNil
   )
@@ -1362,12 +1366,12 @@ private predicate flowFwd0(
   (
     exists(Node mid |
       flowFwd(mid, fromArg, apf, ap, config) and
-      localFlowBigStep(mid, node, true, config)
+      localFlowBigStep(mid, node, true, config, _)
     )
     or
     exists(Node mid, AccessPathNil nil |
       flowFwd(mid, fromArg, _, nil, config) and
-      localFlowBigStep(mid, node, false, config) and
+      localFlowBigStep(mid, node, false, config, _) and
       ap = node.(AccessPathNilNode).getAp() and
       apf = ap.(AccessPathNil).getFront()
     )
@@ -1471,13 +1475,13 @@ private predicate flow0(Node node, boolean toReturn, AccessPath ap, Configuratio
   ap instanceof AccessPathNil
   or
   exists(Node mid |
-    localFlowBigStep(node, mid, true, config) and
+    localFlowBigStep(node, mid, true, config, _) and
     flow(mid, toReturn, ap, config)
   )
   or
   exists(Node mid, AccessPathNil nil |
     flowFwd(node, _, _, ap, config) and
-    localFlowBigStep(node, mid, false, config) and
+    localFlowBigStep(node, mid, false, config, _) and
     flow(mid, toReturn, nil, config) and
     ap instanceof AccessPathNil
   )
@@ -1728,37 +1732,42 @@ private class PathNodeSink extends PathNode, TPathNodeSink {
  * a callable is recorded by `cc`.
  */
 private predicate pathStep(PathNodeMid mid, Node node, CallContext cc, AccessPath ap) {
-  localFlowBigStep(mid.getNode(), node, true, mid.getConfiguration()) and
-  cc = mid.getCallContext() and
-  ap = mid.getAp()
+  exists(LocalCallContext localCC | localCC.matchesCallContext(cc) |
+    localFlowBigStep(mid.getNode(), node, true, mid.getConfiguration(), localCC) and
+    cc = mid.getCallContext() and
+    ap = mid.getAp()
+    or
+    localFlowBigStep(mid.getNode(), node, false, mid.getConfiguration(), localCC) and
+    cc = mid.getCallContext() and
+    mid.getAp() instanceof AccessPathNil and
+    ap = node.(AccessPathNilNode).getAp()
+  )
   or
-  localFlowBigStep(mid.getNode(), node, false, mid.getConfiguration()) and
-  cc = mid.getCallContext() and
-  mid.getAp() instanceof AccessPathNil and
-  ap = node.(AccessPathNilNode).getAp()
-  or
-  jumpStep(mid.getNode(), node, mid.getConfiguration()) and
-  cc instanceof CallContextAny and
-  ap = mid.getAp()
-  or
-  additionalJumpStep(mid.getNode(), node, mid.getConfiguration()) and
-  cc instanceof CallContextAny and
-  mid.getAp() instanceof AccessPathNil and
-  ap = node.(AccessPathNilNode).getAp()
-  or
-  contentReadStep(mid, node, ap) and cc = mid.getCallContext()
-  or
-  exists(Content f, AccessPath ap0 | contentStoreStep(mid, node, ap0, f, cc) and push(ap0, f, ap))
-  or
-  pathOutOfArgument(mid, node, cc) and ap = mid.getAp()
-  or
-  pathIntoCallable(mid, node, _, cc, _) and ap = mid.getAp()
-  or
-  pathOutOfCallable(mid, node, cc) and ap = mid.getAp()
-  or
-  pathThroughCallable(mid, node, cc, ap)
-  or
-  valuePathThroughCallable(mid, node, cc) and ap = mid.getAp()
+  not isUnreachableInCall(node, cc.(CallContextSpecificCall).getCall()) and
+  (
+    jumpStep(mid.getNode(), node, mid.getConfiguration()) and
+    cc instanceof CallContextAny and
+    ap = mid.getAp()
+    or
+    additionalJumpStep(mid.getNode(), node, mid.getConfiguration()) and
+    cc instanceof CallContextAny and
+    mid.getAp() instanceof AccessPathNil and
+    ap = node.(AccessPathNilNode).getAp()
+    or
+    contentReadStep(mid, node, ap) and cc = mid.getCallContext()
+    or
+    exists(Content f, AccessPath ap0 | contentStoreStep(mid, node, ap0, f, cc) and push(ap0, f, ap))
+    or
+    pathOutOfArgument(mid, node, cc) and ap = mid.getAp()
+    or
+    pathIntoCallable(mid, node, _, cc, _) and ap = mid.getAp()
+    or
+    pathOutOfCallable(mid, node, cc) and ap = mid.getAp()
+    or
+    pathThroughCallable(mid, node, cc, ap)
+    or
+    valuePathThroughCallable(mid, node, cc) and ap = mid.getAp()
+  )
 }
 
 pragma[noinline]
@@ -1879,7 +1888,7 @@ private predicate pathIntoCallable(
     pathIntoCallable0(mid, callable, i, outercc, call, emptyAp) and
     p.isParameterOf(callable, i)
   |
-    if reducedViableImplInCallContext(_, callable, call)
+    if recordDataFlowCallSite(call, callable)
     then innercc = TSpecificCall(call, i, emptyAp)
     else innercc = TSomeCall(p, emptyAp)
   )
@@ -2377,7 +2386,7 @@ private module FlowExploration {
       partialPathIntoCallable0(mid, callable, i, outercc, call, emptyAp, ap, config) and
       p.isParameterOf(callable, i)
     |
-      if reducedViableImplInCallContext(_, callable, call)
+      if recordDataFlowCallSite(call, callable)
       then innercc = TSpecificCall(call, i, emptyAp)
       else innercc = TSomeCall(p, emptyAp)
     )

--- a/csharp/ql/src/semmle/code/csharp/dataflow/internal/DataFlowImpl3.qll
+++ b/csharp/ql/src/semmle/code/csharp/dataflow/internal/DataFlowImpl3.qll
@@ -905,30 +905,34 @@ private predicate localFlowExit(Node node, Configuration config) {
  */
 pragma[nomagic]
 private predicate localFlowStepPlus(
-  Node node1, Node node2, boolean preservesValue, Configuration config
+  Node node1, Node node2, boolean preservesValue, Configuration config, LocalCallContext cc
 ) {
-  localFlowEntry(node1, config) and
+  not isUnreachableInCall(node2, cc.(LocalCallContextSpecificCall).getCall()) and
   (
-    localFlowStep(node1, node2, config) and preservesValue = true
+    localFlowEntry(node1, config) and
+    (
+      localFlowStep(node1, node2, config) and preservesValue = true
+      or
+      additionalLocalFlowStep(node1, node2, config) and preservesValue = false
+    ) and
+    node1 != node2 and
+    cc.validFor(node1) and
+    nodeCand(node2, unbind(config))
     or
-    additionalLocalFlowStep(node1, node2, config) and preservesValue = false
-  ) and
-  node1 != node2 and
-  nodeCand(node2, unbind(config))
-  or
-  exists(Node mid |
-    localFlowStepPlus(node1, mid, preservesValue, config) and
-    localFlowStep(mid, node2, config) and
-    not mid instanceof CastNode and
-    nodeCand(node2, unbind(config))
-  )
-  or
-  exists(Node mid |
-    localFlowStepPlus(node1, mid, _, config) and
-    additionalLocalFlowStep(mid, node2, config) and
-    not mid instanceof CastNode and
-    preservesValue = false and
-    nodeCand(node2, unbind(config))
+    exists(Node mid |
+      localFlowStepPlus(node1, mid, preservesValue, config, cc) and
+      localFlowStep(mid, node2, config) and
+      not mid instanceof CastNode and
+      nodeCand(node2, unbind(config))
+    )
+    or
+    exists(Node mid |
+      localFlowStepPlus(node1, mid, _, config, cc) and
+      additionalLocalFlowStep(mid, node2, config) and
+      not mid instanceof CastNode and
+      preservesValue = false and
+      nodeCand(node2, unbind(config))
+    )
   )
 }
 
@@ -938,9 +942,9 @@ private predicate localFlowStepPlus(
  */
 pragma[noinline]
 private predicate localFlowBigStep(
-  Node node1, Node node2, boolean preservesValue, Configuration config
+  Node node1, Node node2, boolean preservesValue, Configuration config, LocalCallContext callContext
 ) {
-  localFlowStepPlus(node1, node2, preservesValue, config) and
+  localFlowStepPlus(node1, node2, preservesValue, config, callContext) and
   localFlowExit(node2, config)
 }
 
@@ -1000,7 +1004,7 @@ private class AccessPathFrontNilNode extends Node {
     (
       any(Configuration c).isSource(this)
       or
-      localFlowBigStep(_, this, false, _)
+      localFlowBigStep(_, this, false, _, _)
       or
       additionalJumpStep(_, this, _)
     )
@@ -1023,12 +1027,12 @@ private predicate flowCandFwd0(Node node, boolean fromArg, AccessPathFront apf, 
   (
     exists(Node mid |
       flowCandFwd(mid, fromArg, apf, config) and
-      localFlowBigStep(mid, node, true, config)
+      localFlowBigStep(mid, node, true, config, _)
     )
     or
     exists(Node mid, AccessPathFrontNil nil |
       flowCandFwd(mid, fromArg, nil, config) and
-      localFlowBigStep(mid, node, false, config) and
+      localFlowBigStep(mid, node, false, config, _) and
       apf = node.(AccessPathFrontNilNode).getApf()
     )
     or
@@ -1121,13 +1125,13 @@ private predicate flowCand0(Node node, boolean toReturn, AccessPathFront apf, Co
   apf instanceof AccessPathFrontNil
   or
   exists(Node mid |
-    localFlowBigStep(node, mid, true, config) and
+    localFlowBigStep(node, mid, true, config, _) and
     flowCand(mid, toReturn, apf, config)
   )
   or
   exists(Node mid, AccessPathFrontNil nil |
     flowCandFwd(node, _, apf, config) and
-    localFlowBigStep(node, mid, false, config) and
+    localFlowBigStep(node, mid, false, config, _) and
     flowCand(mid, toReturn, nil, config) and
     apf instanceof AccessPathFrontNil
   )
@@ -1362,12 +1366,12 @@ private predicate flowFwd0(
   (
     exists(Node mid |
       flowFwd(mid, fromArg, apf, ap, config) and
-      localFlowBigStep(mid, node, true, config)
+      localFlowBigStep(mid, node, true, config, _)
     )
     or
     exists(Node mid, AccessPathNil nil |
       flowFwd(mid, fromArg, _, nil, config) and
-      localFlowBigStep(mid, node, false, config) and
+      localFlowBigStep(mid, node, false, config, _) and
       ap = node.(AccessPathNilNode).getAp() and
       apf = ap.(AccessPathNil).getFront()
     )
@@ -1471,13 +1475,13 @@ private predicate flow0(Node node, boolean toReturn, AccessPath ap, Configuratio
   ap instanceof AccessPathNil
   or
   exists(Node mid |
-    localFlowBigStep(node, mid, true, config) and
+    localFlowBigStep(node, mid, true, config, _) and
     flow(mid, toReturn, ap, config)
   )
   or
   exists(Node mid, AccessPathNil nil |
     flowFwd(node, _, _, ap, config) and
-    localFlowBigStep(node, mid, false, config) and
+    localFlowBigStep(node, mid, false, config, _) and
     flow(mid, toReturn, nil, config) and
     ap instanceof AccessPathNil
   )
@@ -1728,37 +1732,42 @@ private class PathNodeSink extends PathNode, TPathNodeSink {
  * a callable is recorded by `cc`.
  */
 private predicate pathStep(PathNodeMid mid, Node node, CallContext cc, AccessPath ap) {
-  localFlowBigStep(mid.getNode(), node, true, mid.getConfiguration()) and
-  cc = mid.getCallContext() and
-  ap = mid.getAp()
+  exists(LocalCallContext localCC | localCC.matchesCallContext(cc) |
+    localFlowBigStep(mid.getNode(), node, true, mid.getConfiguration(), localCC) and
+    cc = mid.getCallContext() and
+    ap = mid.getAp()
+    or
+    localFlowBigStep(mid.getNode(), node, false, mid.getConfiguration(), localCC) and
+    cc = mid.getCallContext() and
+    mid.getAp() instanceof AccessPathNil and
+    ap = node.(AccessPathNilNode).getAp()
+  )
   or
-  localFlowBigStep(mid.getNode(), node, false, mid.getConfiguration()) and
-  cc = mid.getCallContext() and
-  mid.getAp() instanceof AccessPathNil and
-  ap = node.(AccessPathNilNode).getAp()
-  or
-  jumpStep(mid.getNode(), node, mid.getConfiguration()) and
-  cc instanceof CallContextAny and
-  ap = mid.getAp()
-  or
-  additionalJumpStep(mid.getNode(), node, mid.getConfiguration()) and
-  cc instanceof CallContextAny and
-  mid.getAp() instanceof AccessPathNil and
-  ap = node.(AccessPathNilNode).getAp()
-  or
-  contentReadStep(mid, node, ap) and cc = mid.getCallContext()
-  or
-  exists(Content f, AccessPath ap0 | contentStoreStep(mid, node, ap0, f, cc) and push(ap0, f, ap))
-  or
-  pathOutOfArgument(mid, node, cc) and ap = mid.getAp()
-  or
-  pathIntoCallable(mid, node, _, cc, _) and ap = mid.getAp()
-  or
-  pathOutOfCallable(mid, node, cc) and ap = mid.getAp()
-  or
-  pathThroughCallable(mid, node, cc, ap)
-  or
-  valuePathThroughCallable(mid, node, cc) and ap = mid.getAp()
+  not isUnreachableInCall(node, cc.(CallContextSpecificCall).getCall()) and
+  (
+    jumpStep(mid.getNode(), node, mid.getConfiguration()) and
+    cc instanceof CallContextAny and
+    ap = mid.getAp()
+    or
+    additionalJumpStep(mid.getNode(), node, mid.getConfiguration()) and
+    cc instanceof CallContextAny and
+    mid.getAp() instanceof AccessPathNil and
+    ap = node.(AccessPathNilNode).getAp()
+    or
+    contentReadStep(mid, node, ap) and cc = mid.getCallContext()
+    or
+    exists(Content f, AccessPath ap0 | contentStoreStep(mid, node, ap0, f, cc) and push(ap0, f, ap))
+    or
+    pathOutOfArgument(mid, node, cc) and ap = mid.getAp()
+    or
+    pathIntoCallable(mid, node, _, cc, _) and ap = mid.getAp()
+    or
+    pathOutOfCallable(mid, node, cc) and ap = mid.getAp()
+    or
+    pathThroughCallable(mid, node, cc, ap)
+    or
+    valuePathThroughCallable(mid, node, cc) and ap = mid.getAp()
+  )
 }
 
 pragma[noinline]
@@ -1879,7 +1888,7 @@ private predicate pathIntoCallable(
     pathIntoCallable0(mid, callable, i, outercc, call, emptyAp) and
     p.isParameterOf(callable, i)
   |
-    if reducedViableImplInCallContext(_, callable, call)
+    if recordDataFlowCallSite(call, callable)
     then innercc = TSpecificCall(call, i, emptyAp)
     else innercc = TSomeCall(p, emptyAp)
   )
@@ -2377,7 +2386,7 @@ private module FlowExploration {
       partialPathIntoCallable0(mid, callable, i, outercc, call, emptyAp, ap, config) and
       p.isParameterOf(callable, i)
     |
-      if reducedViableImplInCallContext(_, callable, call)
+      if recordDataFlowCallSite(call, callable)
       then innercc = TSpecificCall(call, i, emptyAp)
       else innercc = TSomeCall(p, emptyAp)
     )

--- a/csharp/ql/src/semmle/code/csharp/dataflow/internal/DataFlowImpl4.qll
+++ b/csharp/ql/src/semmle/code/csharp/dataflow/internal/DataFlowImpl4.qll
@@ -905,30 +905,34 @@ private predicate localFlowExit(Node node, Configuration config) {
  */
 pragma[nomagic]
 private predicate localFlowStepPlus(
-  Node node1, Node node2, boolean preservesValue, Configuration config
+  Node node1, Node node2, boolean preservesValue, Configuration config, LocalCallContext cc
 ) {
-  localFlowEntry(node1, config) and
+  not isUnreachableInCall(node2, cc.(LocalCallContextSpecificCall).getCall()) and
   (
-    localFlowStep(node1, node2, config) and preservesValue = true
+    localFlowEntry(node1, config) and
+    (
+      localFlowStep(node1, node2, config) and preservesValue = true
+      or
+      additionalLocalFlowStep(node1, node2, config) and preservesValue = false
+    ) and
+    node1 != node2 and
+    cc.validFor(node1) and
+    nodeCand(node2, unbind(config))
     or
-    additionalLocalFlowStep(node1, node2, config) and preservesValue = false
-  ) and
-  node1 != node2 and
-  nodeCand(node2, unbind(config))
-  or
-  exists(Node mid |
-    localFlowStepPlus(node1, mid, preservesValue, config) and
-    localFlowStep(mid, node2, config) and
-    not mid instanceof CastNode and
-    nodeCand(node2, unbind(config))
-  )
-  or
-  exists(Node mid |
-    localFlowStepPlus(node1, mid, _, config) and
-    additionalLocalFlowStep(mid, node2, config) and
-    not mid instanceof CastNode and
-    preservesValue = false and
-    nodeCand(node2, unbind(config))
+    exists(Node mid |
+      localFlowStepPlus(node1, mid, preservesValue, config, cc) and
+      localFlowStep(mid, node2, config) and
+      not mid instanceof CastNode and
+      nodeCand(node2, unbind(config))
+    )
+    or
+    exists(Node mid |
+      localFlowStepPlus(node1, mid, _, config, cc) and
+      additionalLocalFlowStep(mid, node2, config) and
+      not mid instanceof CastNode and
+      preservesValue = false and
+      nodeCand(node2, unbind(config))
+    )
   )
 }
 
@@ -938,9 +942,9 @@ private predicate localFlowStepPlus(
  */
 pragma[noinline]
 private predicate localFlowBigStep(
-  Node node1, Node node2, boolean preservesValue, Configuration config
+  Node node1, Node node2, boolean preservesValue, Configuration config, LocalCallContext callContext
 ) {
-  localFlowStepPlus(node1, node2, preservesValue, config) and
+  localFlowStepPlus(node1, node2, preservesValue, config, callContext) and
   localFlowExit(node2, config)
 }
 
@@ -1000,7 +1004,7 @@ private class AccessPathFrontNilNode extends Node {
     (
       any(Configuration c).isSource(this)
       or
-      localFlowBigStep(_, this, false, _)
+      localFlowBigStep(_, this, false, _, _)
       or
       additionalJumpStep(_, this, _)
     )
@@ -1023,12 +1027,12 @@ private predicate flowCandFwd0(Node node, boolean fromArg, AccessPathFront apf, 
   (
     exists(Node mid |
       flowCandFwd(mid, fromArg, apf, config) and
-      localFlowBigStep(mid, node, true, config)
+      localFlowBigStep(mid, node, true, config, _)
     )
     or
     exists(Node mid, AccessPathFrontNil nil |
       flowCandFwd(mid, fromArg, nil, config) and
-      localFlowBigStep(mid, node, false, config) and
+      localFlowBigStep(mid, node, false, config, _) and
       apf = node.(AccessPathFrontNilNode).getApf()
     )
     or
@@ -1121,13 +1125,13 @@ private predicate flowCand0(Node node, boolean toReturn, AccessPathFront apf, Co
   apf instanceof AccessPathFrontNil
   or
   exists(Node mid |
-    localFlowBigStep(node, mid, true, config) and
+    localFlowBigStep(node, mid, true, config, _) and
     flowCand(mid, toReturn, apf, config)
   )
   or
   exists(Node mid, AccessPathFrontNil nil |
     flowCandFwd(node, _, apf, config) and
-    localFlowBigStep(node, mid, false, config) and
+    localFlowBigStep(node, mid, false, config, _) and
     flowCand(mid, toReturn, nil, config) and
     apf instanceof AccessPathFrontNil
   )
@@ -1362,12 +1366,12 @@ private predicate flowFwd0(
   (
     exists(Node mid |
       flowFwd(mid, fromArg, apf, ap, config) and
-      localFlowBigStep(mid, node, true, config)
+      localFlowBigStep(mid, node, true, config, _)
     )
     or
     exists(Node mid, AccessPathNil nil |
       flowFwd(mid, fromArg, _, nil, config) and
-      localFlowBigStep(mid, node, false, config) and
+      localFlowBigStep(mid, node, false, config, _) and
       ap = node.(AccessPathNilNode).getAp() and
       apf = ap.(AccessPathNil).getFront()
     )
@@ -1471,13 +1475,13 @@ private predicate flow0(Node node, boolean toReturn, AccessPath ap, Configuratio
   ap instanceof AccessPathNil
   or
   exists(Node mid |
-    localFlowBigStep(node, mid, true, config) and
+    localFlowBigStep(node, mid, true, config, _) and
     flow(mid, toReturn, ap, config)
   )
   or
   exists(Node mid, AccessPathNil nil |
     flowFwd(node, _, _, ap, config) and
-    localFlowBigStep(node, mid, false, config) and
+    localFlowBigStep(node, mid, false, config, _) and
     flow(mid, toReturn, nil, config) and
     ap instanceof AccessPathNil
   )
@@ -1728,37 +1732,42 @@ private class PathNodeSink extends PathNode, TPathNodeSink {
  * a callable is recorded by `cc`.
  */
 private predicate pathStep(PathNodeMid mid, Node node, CallContext cc, AccessPath ap) {
-  localFlowBigStep(mid.getNode(), node, true, mid.getConfiguration()) and
-  cc = mid.getCallContext() and
-  ap = mid.getAp()
+  exists(LocalCallContext localCC | localCC.matchesCallContext(cc) |
+    localFlowBigStep(mid.getNode(), node, true, mid.getConfiguration(), localCC) and
+    cc = mid.getCallContext() and
+    ap = mid.getAp()
+    or
+    localFlowBigStep(mid.getNode(), node, false, mid.getConfiguration(), localCC) and
+    cc = mid.getCallContext() and
+    mid.getAp() instanceof AccessPathNil and
+    ap = node.(AccessPathNilNode).getAp()
+  )
   or
-  localFlowBigStep(mid.getNode(), node, false, mid.getConfiguration()) and
-  cc = mid.getCallContext() and
-  mid.getAp() instanceof AccessPathNil and
-  ap = node.(AccessPathNilNode).getAp()
-  or
-  jumpStep(mid.getNode(), node, mid.getConfiguration()) and
-  cc instanceof CallContextAny and
-  ap = mid.getAp()
-  or
-  additionalJumpStep(mid.getNode(), node, mid.getConfiguration()) and
-  cc instanceof CallContextAny and
-  mid.getAp() instanceof AccessPathNil and
-  ap = node.(AccessPathNilNode).getAp()
-  or
-  contentReadStep(mid, node, ap) and cc = mid.getCallContext()
-  or
-  exists(Content f, AccessPath ap0 | contentStoreStep(mid, node, ap0, f, cc) and push(ap0, f, ap))
-  or
-  pathOutOfArgument(mid, node, cc) and ap = mid.getAp()
-  or
-  pathIntoCallable(mid, node, _, cc, _) and ap = mid.getAp()
-  or
-  pathOutOfCallable(mid, node, cc) and ap = mid.getAp()
-  or
-  pathThroughCallable(mid, node, cc, ap)
-  or
-  valuePathThroughCallable(mid, node, cc) and ap = mid.getAp()
+  not isUnreachableInCall(node, cc.(CallContextSpecificCall).getCall()) and
+  (
+    jumpStep(mid.getNode(), node, mid.getConfiguration()) and
+    cc instanceof CallContextAny and
+    ap = mid.getAp()
+    or
+    additionalJumpStep(mid.getNode(), node, mid.getConfiguration()) and
+    cc instanceof CallContextAny and
+    mid.getAp() instanceof AccessPathNil and
+    ap = node.(AccessPathNilNode).getAp()
+    or
+    contentReadStep(mid, node, ap) and cc = mid.getCallContext()
+    or
+    exists(Content f, AccessPath ap0 | contentStoreStep(mid, node, ap0, f, cc) and push(ap0, f, ap))
+    or
+    pathOutOfArgument(mid, node, cc) and ap = mid.getAp()
+    or
+    pathIntoCallable(mid, node, _, cc, _) and ap = mid.getAp()
+    or
+    pathOutOfCallable(mid, node, cc) and ap = mid.getAp()
+    or
+    pathThroughCallable(mid, node, cc, ap)
+    or
+    valuePathThroughCallable(mid, node, cc) and ap = mid.getAp()
+  )
 }
 
 pragma[noinline]
@@ -1879,7 +1888,7 @@ private predicate pathIntoCallable(
     pathIntoCallable0(mid, callable, i, outercc, call, emptyAp) and
     p.isParameterOf(callable, i)
   |
-    if reducedViableImplInCallContext(_, callable, call)
+    if recordDataFlowCallSite(call, callable)
     then innercc = TSpecificCall(call, i, emptyAp)
     else innercc = TSomeCall(p, emptyAp)
   )
@@ -2377,7 +2386,7 @@ private module FlowExploration {
       partialPathIntoCallable0(mid, callable, i, outercc, call, emptyAp, ap, config) and
       p.isParameterOf(callable, i)
     |
-      if reducedViableImplInCallContext(_, callable, call)
+      if recordDataFlowCallSite(call, callable)
       then innercc = TSpecificCall(call, i, emptyAp)
       else innercc = TSomeCall(p, emptyAp)
     )

--- a/csharp/ql/src/semmle/code/csharp/dataflow/internal/DataFlowImpl5.qll
+++ b/csharp/ql/src/semmle/code/csharp/dataflow/internal/DataFlowImpl5.qll
@@ -905,30 +905,34 @@ private predicate localFlowExit(Node node, Configuration config) {
  */
 pragma[nomagic]
 private predicate localFlowStepPlus(
-  Node node1, Node node2, boolean preservesValue, Configuration config
+  Node node1, Node node2, boolean preservesValue, Configuration config, LocalCallContext cc
 ) {
-  localFlowEntry(node1, config) and
+  not isUnreachableInCall(node2, cc.(LocalCallContextSpecificCall).getCall()) and
   (
-    localFlowStep(node1, node2, config) and preservesValue = true
+    localFlowEntry(node1, config) and
+    (
+      localFlowStep(node1, node2, config) and preservesValue = true
+      or
+      additionalLocalFlowStep(node1, node2, config) and preservesValue = false
+    ) and
+    node1 != node2 and
+    cc.validFor(node1) and
+    nodeCand(node2, unbind(config))
     or
-    additionalLocalFlowStep(node1, node2, config) and preservesValue = false
-  ) and
-  node1 != node2 and
-  nodeCand(node2, unbind(config))
-  or
-  exists(Node mid |
-    localFlowStepPlus(node1, mid, preservesValue, config) and
-    localFlowStep(mid, node2, config) and
-    not mid instanceof CastNode and
-    nodeCand(node2, unbind(config))
-  )
-  or
-  exists(Node mid |
-    localFlowStepPlus(node1, mid, _, config) and
-    additionalLocalFlowStep(mid, node2, config) and
-    not mid instanceof CastNode and
-    preservesValue = false and
-    nodeCand(node2, unbind(config))
+    exists(Node mid |
+      localFlowStepPlus(node1, mid, preservesValue, config, cc) and
+      localFlowStep(mid, node2, config) and
+      not mid instanceof CastNode and
+      nodeCand(node2, unbind(config))
+    )
+    or
+    exists(Node mid |
+      localFlowStepPlus(node1, mid, _, config, cc) and
+      additionalLocalFlowStep(mid, node2, config) and
+      not mid instanceof CastNode and
+      preservesValue = false and
+      nodeCand(node2, unbind(config))
+    )
   )
 }
 
@@ -938,9 +942,9 @@ private predicate localFlowStepPlus(
  */
 pragma[noinline]
 private predicate localFlowBigStep(
-  Node node1, Node node2, boolean preservesValue, Configuration config
+  Node node1, Node node2, boolean preservesValue, Configuration config, LocalCallContext callContext
 ) {
-  localFlowStepPlus(node1, node2, preservesValue, config) and
+  localFlowStepPlus(node1, node2, preservesValue, config, callContext) and
   localFlowExit(node2, config)
 }
 
@@ -1000,7 +1004,7 @@ private class AccessPathFrontNilNode extends Node {
     (
       any(Configuration c).isSource(this)
       or
-      localFlowBigStep(_, this, false, _)
+      localFlowBigStep(_, this, false, _, _)
       or
       additionalJumpStep(_, this, _)
     )
@@ -1023,12 +1027,12 @@ private predicate flowCandFwd0(Node node, boolean fromArg, AccessPathFront apf, 
   (
     exists(Node mid |
       flowCandFwd(mid, fromArg, apf, config) and
-      localFlowBigStep(mid, node, true, config)
+      localFlowBigStep(mid, node, true, config, _)
     )
     or
     exists(Node mid, AccessPathFrontNil nil |
       flowCandFwd(mid, fromArg, nil, config) and
-      localFlowBigStep(mid, node, false, config) and
+      localFlowBigStep(mid, node, false, config, _) and
       apf = node.(AccessPathFrontNilNode).getApf()
     )
     or
@@ -1121,13 +1125,13 @@ private predicate flowCand0(Node node, boolean toReturn, AccessPathFront apf, Co
   apf instanceof AccessPathFrontNil
   or
   exists(Node mid |
-    localFlowBigStep(node, mid, true, config) and
+    localFlowBigStep(node, mid, true, config, _) and
     flowCand(mid, toReturn, apf, config)
   )
   or
   exists(Node mid, AccessPathFrontNil nil |
     flowCandFwd(node, _, apf, config) and
-    localFlowBigStep(node, mid, false, config) and
+    localFlowBigStep(node, mid, false, config, _) and
     flowCand(mid, toReturn, nil, config) and
     apf instanceof AccessPathFrontNil
   )
@@ -1362,12 +1366,12 @@ private predicate flowFwd0(
   (
     exists(Node mid |
       flowFwd(mid, fromArg, apf, ap, config) and
-      localFlowBigStep(mid, node, true, config)
+      localFlowBigStep(mid, node, true, config, _)
     )
     or
     exists(Node mid, AccessPathNil nil |
       flowFwd(mid, fromArg, _, nil, config) and
-      localFlowBigStep(mid, node, false, config) and
+      localFlowBigStep(mid, node, false, config, _) and
       ap = node.(AccessPathNilNode).getAp() and
       apf = ap.(AccessPathNil).getFront()
     )
@@ -1471,13 +1475,13 @@ private predicate flow0(Node node, boolean toReturn, AccessPath ap, Configuratio
   ap instanceof AccessPathNil
   or
   exists(Node mid |
-    localFlowBigStep(node, mid, true, config) and
+    localFlowBigStep(node, mid, true, config, _) and
     flow(mid, toReturn, ap, config)
   )
   or
   exists(Node mid, AccessPathNil nil |
     flowFwd(node, _, _, ap, config) and
-    localFlowBigStep(node, mid, false, config) and
+    localFlowBigStep(node, mid, false, config, _) and
     flow(mid, toReturn, nil, config) and
     ap instanceof AccessPathNil
   )
@@ -1728,37 +1732,42 @@ private class PathNodeSink extends PathNode, TPathNodeSink {
  * a callable is recorded by `cc`.
  */
 private predicate pathStep(PathNodeMid mid, Node node, CallContext cc, AccessPath ap) {
-  localFlowBigStep(mid.getNode(), node, true, mid.getConfiguration()) and
-  cc = mid.getCallContext() and
-  ap = mid.getAp()
+  exists(LocalCallContext localCC | localCC.matchesCallContext(cc) |
+    localFlowBigStep(mid.getNode(), node, true, mid.getConfiguration(), localCC) and
+    cc = mid.getCallContext() and
+    ap = mid.getAp()
+    or
+    localFlowBigStep(mid.getNode(), node, false, mid.getConfiguration(), localCC) and
+    cc = mid.getCallContext() and
+    mid.getAp() instanceof AccessPathNil and
+    ap = node.(AccessPathNilNode).getAp()
+  )
   or
-  localFlowBigStep(mid.getNode(), node, false, mid.getConfiguration()) and
-  cc = mid.getCallContext() and
-  mid.getAp() instanceof AccessPathNil and
-  ap = node.(AccessPathNilNode).getAp()
-  or
-  jumpStep(mid.getNode(), node, mid.getConfiguration()) and
-  cc instanceof CallContextAny and
-  ap = mid.getAp()
-  or
-  additionalJumpStep(mid.getNode(), node, mid.getConfiguration()) and
-  cc instanceof CallContextAny and
-  mid.getAp() instanceof AccessPathNil and
-  ap = node.(AccessPathNilNode).getAp()
-  or
-  contentReadStep(mid, node, ap) and cc = mid.getCallContext()
-  or
-  exists(Content f, AccessPath ap0 | contentStoreStep(mid, node, ap0, f, cc) and push(ap0, f, ap))
-  or
-  pathOutOfArgument(mid, node, cc) and ap = mid.getAp()
-  or
-  pathIntoCallable(mid, node, _, cc, _) and ap = mid.getAp()
-  or
-  pathOutOfCallable(mid, node, cc) and ap = mid.getAp()
-  or
-  pathThroughCallable(mid, node, cc, ap)
-  or
-  valuePathThroughCallable(mid, node, cc) and ap = mid.getAp()
+  not isUnreachableInCall(node, cc.(CallContextSpecificCall).getCall()) and
+  (
+    jumpStep(mid.getNode(), node, mid.getConfiguration()) and
+    cc instanceof CallContextAny and
+    ap = mid.getAp()
+    or
+    additionalJumpStep(mid.getNode(), node, mid.getConfiguration()) and
+    cc instanceof CallContextAny and
+    mid.getAp() instanceof AccessPathNil and
+    ap = node.(AccessPathNilNode).getAp()
+    or
+    contentReadStep(mid, node, ap) and cc = mid.getCallContext()
+    or
+    exists(Content f, AccessPath ap0 | contentStoreStep(mid, node, ap0, f, cc) and push(ap0, f, ap))
+    or
+    pathOutOfArgument(mid, node, cc) and ap = mid.getAp()
+    or
+    pathIntoCallable(mid, node, _, cc, _) and ap = mid.getAp()
+    or
+    pathOutOfCallable(mid, node, cc) and ap = mid.getAp()
+    or
+    pathThroughCallable(mid, node, cc, ap)
+    or
+    valuePathThroughCallable(mid, node, cc) and ap = mid.getAp()
+  )
 }
 
 pragma[noinline]
@@ -1879,7 +1888,7 @@ private predicate pathIntoCallable(
     pathIntoCallable0(mid, callable, i, outercc, call, emptyAp) and
     p.isParameterOf(callable, i)
   |
-    if reducedViableImplInCallContext(_, callable, call)
+    if recordDataFlowCallSite(call, callable)
     then innercc = TSpecificCall(call, i, emptyAp)
     else innercc = TSomeCall(p, emptyAp)
   )
@@ -2377,7 +2386,7 @@ private module FlowExploration {
       partialPathIntoCallable0(mid, callable, i, outercc, call, emptyAp, ap, config) and
       p.isParameterOf(callable, i)
     |
-      if reducedViableImplInCallContext(_, callable, call)
+      if recordDataFlowCallSite(call, callable)
       then innercc = TSpecificCall(call, i, emptyAp)
       else innercc = TSomeCall(p, emptyAp)
     )

--- a/csharp/ql/src/semmle/code/csharp/dataflow/internal/DataFlowImplCommon.qll
+++ b/csharp/ql/src/semmle/code/csharp/dataflow/internal/DataFlowImplCommon.qll
@@ -100,7 +100,7 @@ private module ImplCommon {
       outercc = TSomeCall(getAParameter(c), _)
       or
       exists(DataFlowCall other | outercc = TSpecificCall(other, _, _) |
-        reducedViableImplInCallContext(_, c, other)
+        recordDataFlowCallSite(other, c)
       )
     )
   }
@@ -125,7 +125,7 @@ private module ImplCommon {
     CallContextCall innercc
   ) {
     exists(int i, DataFlowCallable callable | viableParamArg1(p, callable, i, arg, outercc, call) |
-      if reducedViableImplInCallContext(_, callable, call)
+      if recordDataFlowCallSite(call, callable)
       then innercc = TSpecificCall(call, i, true)
       else innercc = TSomeCall(p, true)
     )
@@ -137,7 +137,7 @@ private module ImplCommon {
     exists(DataFlowCall call, int i, DataFlowCallable callable |
       result = TSpecificCall(call, i, _) and
       p.isParameterOf(callable, i) and
-      reducedViableImplInCallContext(_, callable, call)
+      recordDataFlowCallSite(call, callable)
     )
   }
 
@@ -344,11 +344,22 @@ private module ImplCommon {
     exists(ArgumentNode arg | arg.argumentOf(call, -1))
   }
 
+  /**
+   * Record a call site in the dataflow graph if it either improves
+   * virtual dispatch or if we can remove unreachable edges by recoring this call site
+   */
+  cached
+  predicate recordDataFlowCallSite(DataFlowCall call, DataFlowCallable callable) {
+    reducedViableImplInCallContext(_, callable, call)
+    or
+    exists(Node n | n.getEnclosingCallable() = callable | isUnreachableInCall(n, call))
+  }
+
   cached
   newtype TCallContext =
     TAnyCallContext() or
     TSpecificCall(DataFlowCall call, int i, boolean emptyAp) {
-      reducedViableImplInCallContext(_, _, call) and
+      recordDataFlowCallSite(call, _) and
       (emptyAp = true or emptyAp = false) and
       (
         exists(call.getArgument(i))
@@ -362,6 +373,11 @@ private module ImplCommon {
   cached
   newtype TReturnPosition =
     TReturnPosition0(DataFlowCallable c, ReturnKind kind) { returnPosition(_, c, kind) }
+
+  cached
+  newtype TLocalFlowCallContext =
+    TAnyLocalCall() or
+    TSpecificLocalCall(DataFlowCall call) { isUnreachableInCall(_, call) }
 }
 
 import ImplCommon
@@ -380,7 +396,8 @@ private predicate returnPosition(ReturnNode ret, DataFlowCallable c, ReturnKind 
  * - `TAnyCallContext()` : No restrictions on method flow.
  * - `TSpecificCall(DataFlowCall call, int i)` : Flow entered through the `i`th
  *    parameter at the given `call`. This call improves the set of viable
- *    dispatch targets for at least one method call in the current callable.
+ *    dispatch targets for at least one method call in the current callable
+ *    or helps pruning unreachable nodes from the data flow graph.
  * - `TSomeCall(ParameterNode p)` : Flow entered through parameter `p`. The
  *    originating call does not improve the set of dispatch targets for any
  *    method call in the current callable and was therefore not recorded.
@@ -404,6 +421,8 @@ class CallContextSpecificCall extends CallContextCall, TSpecificCall {
       result = "CcCall(" + call + ", " + i + ")"
     )
   }
+
+  DataFlowCall getCall() { this = TSpecificCall(result, _, _) }
 }
 
 class CallContextSomeCall extends CallContextCall, TSomeCall {
@@ -413,6 +432,49 @@ class CallContextSomeCall extends CallContextCall, TSomeCall {
 class CallContextReturn extends CallContext, TReturn {
   override string toString() {
     exists(DataFlowCall call | this = TReturn(_, call) | result = "CcReturn(" + call + ")")
+  }
+}
+
+/**
+ * A call context which is used to restrict local data flow nodes
+ * to nodes which are actually reachable in a call context.
+ */
+abstract class LocalCallContext extends TLocalFlowCallContext {
+  abstract string toString();
+
+  abstract predicate matchesCallContext(CallContext ctx);
+
+  abstract predicate validFor(Node n);
+}
+
+class LocalCallContextAny extends LocalCallContext, TAnyLocalCall {
+  override string toString() { result = "LocalCcAny" }
+
+  override predicate matchesCallContext(CallContext ctx) {
+    not ctx instanceof CallContextSpecificCall or
+    not exists(TSpecificLocalCall(ctx.(CallContextSpecificCall).getCall()))
+  }
+
+  override predicate validFor(Node n) { any() }
+}
+
+class LocalCallContextSpecificCall extends LocalCallContext, TSpecificLocalCall {
+  LocalCallContextSpecificCall() { this = TSpecificLocalCall(call) }
+
+  DataFlowCall call;
+
+  DataFlowCall getCall() { result = call }
+
+  override string toString() { result = "LocalCcCall(" + call + ")" }
+
+  override predicate matchesCallContext(CallContext ctx) {
+    ctx.(CallContextSpecificCall).getCall() = call
+  }
+
+  override predicate validFor(Node n) {
+    exists(Node n2 |
+      isUnreachableInCall(n2, call) and n2.getEnclosingCallable() = n.getEnclosingCallable()
+    )
   }
 }
 

--- a/csharp/ql/src/semmle/code/csharp/dataflow/internal/DataFlowPrivate.qll
+++ b/csharp/ql/src/semmle/code/csharp/dataflow/internal/DataFlowPrivate.qll
@@ -1314,3 +1314,5 @@ class DataFlowExpr = DotNet::Expr;
 class DataFlowType = DotNet::Type;
 
 class DataFlowLocation = Location;
+
+predicate isUnreachableInCall(Node n, DataFlowCall call) { none() } // stub implementation

--- a/java/ql/src/semmle/code/java/dataflow/internal/DataFlowImpl.qll
+++ b/java/ql/src/semmle/code/java/dataflow/internal/DataFlowImpl.qll
@@ -917,6 +917,7 @@ private predicate localFlowStepPlus(
     ) and
     node1 != node2 and
     cc.validFor(node1) and
+    not isUnreachableInCall(node1, cc.(LocalCallContextSpecificCall).getCall()) and
     nodeCand(node2, unbind(config))
     or
     exists(Node mid |
@@ -1732,7 +1733,7 @@ private class PathNodeSink extends PathNode, TPathNodeSink {
  * a callable is recorded by `cc`.
  */
 private predicate pathStep(PathNodeMid mid, Node node, CallContext cc, AccessPath ap) {
-  exists(LocalCallContext localCC | localCC.matchesCallContext(cc) |
+  exists(LocalCallContext localCC | localCC = getMatchingLocalCallContext(cc) |
     localFlowBigStep(mid.getNode(), node, true, mid.getConfiguration(), localCC) and
     cc = mid.getCallContext() and
     ap = mid.getAp()
@@ -1743,17 +1744,17 @@ private predicate pathStep(PathNodeMid mid, Node node, CallContext cc, AccessPat
     ap = node.(AccessPathNilNode).getAp()
   )
   or
+  jumpStep(mid.getNode(), node, mid.getConfiguration()) and
+  cc instanceof CallContextAny and
+  ap = mid.getAp()
+  or
+  additionalJumpStep(mid.getNode(), node, mid.getConfiguration()) and
+  cc instanceof CallContextAny and
+  mid.getAp() instanceof AccessPathNil and
+  ap = node.(AccessPathNilNode).getAp()
+  or
   not isUnreachableInCall(node, cc.(CallContextSpecificCall).getCall()) and
   (
-    jumpStep(mid.getNode(), node, mid.getConfiguration()) and
-    cc instanceof CallContextAny and
-    ap = mid.getAp()
-    or
-    additionalJumpStep(mid.getNode(), node, mid.getConfiguration()) and
-    cc instanceof CallContextAny and
-    mid.getAp() instanceof AccessPathNil and
-    ap = node.(AccessPathNilNode).getAp()
-    or
     contentReadStep(mid, node, ap) and cc = mid.getCallContext()
     or
     exists(Content f, AccessPath ap0 | contentStoreStep(mid, node, ap0, f, cc) and push(ap0, f, ap))
@@ -2235,24 +2236,27 @@ private module FlowExploration {
     ap = TPartialNil(getErasedRepr(node.getType())) and
     config = mid.getConfiguration()
     or
-    partialPathStoreStep(mid, _, _, node, ap) and
-    cc = mid.getCallContext() and
-    config = mid.getConfiguration()
-    or
-    exists(PartialAccessPath ap0, Content f |
-      partialPathReadStep(mid, ap0, f, node, cc, config) and
-      apConsFwd(ap, f, ap0, config)
+    not isUnreachableInCall(node, cc.(CallContextSpecificCall).getCall()) and
+    (
+      partialPathStoreStep(mid, _, _, node, ap) and
+      cc = mid.getCallContext() and
+      config = mid.getConfiguration()
+      or
+      exists(PartialAccessPath ap0, Content f |
+        partialPathReadStep(mid, ap0, f, node, cc, config) and
+        apConsFwd(ap, f, ap0, config)
+      )
+      or
+      partialPathOutOfArgument(mid, node, cc, ap, config)
+      or
+      partialPathIntoCallable(mid, node, _, cc, _, ap, config)
+      or
+      partialPathOutOfCallable(mid, node, cc, ap, config)
+      or
+      partialPathThroughCallable(mid, node, cc, ap, config)
+      or
+      valuePartialPathThroughCallable(mid, node, cc, ap, config)
     )
-    or
-    partialPathOutOfArgument(mid, node, cc, ap, config)
-    or
-    partialPathIntoCallable(mid, node, _, cc, _, ap, config)
-    or
-    partialPathOutOfCallable(mid, node, cc, ap, config)
-    or
-    partialPathThroughCallable(mid, node, cc, ap, config)
-    or
-    valuePartialPathThroughCallable(mid, node, cc, ap, config)
   }
 
   bindingset[result, i]

--- a/java/ql/src/semmle/code/java/dataflow/internal/DataFlowImpl.qll
+++ b/java/ql/src/semmle/code/java/dataflow/internal/DataFlowImpl.qll
@@ -905,30 +905,34 @@ private predicate localFlowExit(Node node, Configuration config) {
  */
 pragma[nomagic]
 private predicate localFlowStepPlus(
-  Node node1, Node node2, boolean preservesValue, Configuration config
+  Node node1, Node node2, boolean preservesValue, Configuration config, LocalCallContext cc
 ) {
-  localFlowEntry(node1, config) and
+  not isUnreachableInCall(node2, cc.(LocalCallContextSpecificCall).getCall()) and
   (
-    localFlowStep(node1, node2, config) and preservesValue = true
+    localFlowEntry(node1, config) and
+    (
+      localFlowStep(node1, node2, config) and preservesValue = true
+      or
+      additionalLocalFlowStep(node1, node2, config) and preservesValue = false
+    ) and
+    node1 != node2 and
+    cc.validFor(node1) and
+    nodeCand(node2, unbind(config))
     or
-    additionalLocalFlowStep(node1, node2, config) and preservesValue = false
-  ) and
-  node1 != node2 and
-  nodeCand(node2, unbind(config))
-  or
-  exists(Node mid |
-    localFlowStepPlus(node1, mid, preservesValue, config) and
-    localFlowStep(mid, node2, config) and
-    not mid instanceof CastNode and
-    nodeCand(node2, unbind(config))
-  )
-  or
-  exists(Node mid |
-    localFlowStepPlus(node1, mid, _, config) and
-    additionalLocalFlowStep(mid, node2, config) and
-    not mid instanceof CastNode and
-    preservesValue = false and
-    nodeCand(node2, unbind(config))
+    exists(Node mid |
+      localFlowStepPlus(node1, mid, preservesValue, config, cc) and
+      localFlowStep(mid, node2, config) and
+      not mid instanceof CastNode and
+      nodeCand(node2, unbind(config))
+    )
+    or
+    exists(Node mid |
+      localFlowStepPlus(node1, mid, _, config, cc) and
+      additionalLocalFlowStep(mid, node2, config) and
+      not mid instanceof CastNode and
+      preservesValue = false and
+      nodeCand(node2, unbind(config))
+    )
   )
 }
 
@@ -938,9 +942,9 @@ private predicate localFlowStepPlus(
  */
 pragma[noinline]
 private predicate localFlowBigStep(
-  Node node1, Node node2, boolean preservesValue, Configuration config
+  Node node1, Node node2, boolean preservesValue, Configuration config, LocalCallContext callContext
 ) {
-  localFlowStepPlus(node1, node2, preservesValue, config) and
+  localFlowStepPlus(node1, node2, preservesValue, config, callContext) and
   localFlowExit(node2, config)
 }
 
@@ -1000,7 +1004,7 @@ private class AccessPathFrontNilNode extends Node {
     (
       any(Configuration c).isSource(this)
       or
-      localFlowBigStep(_, this, false, _)
+      localFlowBigStep(_, this, false, _, _)
       or
       additionalJumpStep(_, this, _)
     )
@@ -1023,12 +1027,12 @@ private predicate flowCandFwd0(Node node, boolean fromArg, AccessPathFront apf, 
   (
     exists(Node mid |
       flowCandFwd(mid, fromArg, apf, config) and
-      localFlowBigStep(mid, node, true, config)
+      localFlowBigStep(mid, node, true, config, _)
     )
     or
     exists(Node mid, AccessPathFrontNil nil |
       flowCandFwd(mid, fromArg, nil, config) and
-      localFlowBigStep(mid, node, false, config) and
+      localFlowBigStep(mid, node, false, config, _) and
       apf = node.(AccessPathFrontNilNode).getApf()
     )
     or
@@ -1121,13 +1125,13 @@ private predicate flowCand0(Node node, boolean toReturn, AccessPathFront apf, Co
   apf instanceof AccessPathFrontNil
   or
   exists(Node mid |
-    localFlowBigStep(node, mid, true, config) and
+    localFlowBigStep(node, mid, true, config, _) and
     flowCand(mid, toReturn, apf, config)
   )
   or
   exists(Node mid, AccessPathFrontNil nil |
     flowCandFwd(node, _, apf, config) and
-    localFlowBigStep(node, mid, false, config) and
+    localFlowBigStep(node, mid, false, config, _) and
     flowCand(mid, toReturn, nil, config) and
     apf instanceof AccessPathFrontNil
   )
@@ -1362,12 +1366,12 @@ private predicate flowFwd0(
   (
     exists(Node mid |
       flowFwd(mid, fromArg, apf, ap, config) and
-      localFlowBigStep(mid, node, true, config)
+      localFlowBigStep(mid, node, true, config, _)
     )
     or
     exists(Node mid, AccessPathNil nil |
       flowFwd(mid, fromArg, _, nil, config) and
-      localFlowBigStep(mid, node, false, config) and
+      localFlowBigStep(mid, node, false, config, _) and
       ap = node.(AccessPathNilNode).getAp() and
       apf = ap.(AccessPathNil).getFront()
     )
@@ -1471,13 +1475,13 @@ private predicate flow0(Node node, boolean toReturn, AccessPath ap, Configuratio
   ap instanceof AccessPathNil
   or
   exists(Node mid |
-    localFlowBigStep(node, mid, true, config) and
+    localFlowBigStep(node, mid, true, config, _) and
     flow(mid, toReturn, ap, config)
   )
   or
   exists(Node mid, AccessPathNil nil |
     flowFwd(node, _, _, ap, config) and
-    localFlowBigStep(node, mid, false, config) and
+    localFlowBigStep(node, mid, false, config, _) and
     flow(mid, toReturn, nil, config) and
     ap instanceof AccessPathNil
   )
@@ -1663,8 +1667,11 @@ module PathGraph {
  */
 private class PathNodeMid extends PathNode, TPathNodeMid {
   Node node;
+
   CallContext cc;
+
   AccessPath ap;
+
   Configuration config;
 
   PathNodeMid() { this = TPathNodeMid(node, cc, ap, config) }
@@ -1710,6 +1717,7 @@ private class PathNodeMid extends PathNode, TPathNodeMid {
  */
 private class PathNodeSink extends PathNode, TPathNodeSink {
   Node node;
+
   Configuration config;
 
   PathNodeSink() { this = TPathNodeSink(node, config) }
@@ -1728,37 +1736,41 @@ private class PathNodeSink extends PathNode, TPathNodeSink {
  * a callable is recorded by `cc`.
  */
 private predicate pathStep(PathNodeMid mid, Node node, CallContext cc, AccessPath ap) {
-  localFlowBigStep(mid.getNode(), node, true, mid.getConfiguration()) and
-  cc = mid.getCallContext() and
-  ap = mid.getAp()
-  or
-  localFlowBigStep(mid.getNode(), node, false, mid.getConfiguration()) and
-  cc = mid.getCallContext() and
-  mid.getAp() instanceof AccessPathNil and
-  ap = node.(AccessPathNilNode).getAp()
-  or
-  jumpStep(mid.getNode(), node, mid.getConfiguration()) and
-  cc instanceof CallContextAny and
-  ap = mid.getAp()
-  or
-  additionalJumpStep(mid.getNode(), node, mid.getConfiguration()) and
-  cc instanceof CallContextAny and
-  mid.getAp() instanceof AccessPathNil and
-  ap = node.(AccessPathNilNode).getAp()
-  or
-  contentReadStep(mid, node, ap) and cc = mid.getCallContext()
-  or
-  exists(Content f, AccessPath ap0 | contentStoreStep(mid, node, ap0, f, cc) and push(ap0, f, ap))
-  or
-  pathOutOfArgument(mid, node, cc) and ap = mid.getAp()
-  or
-  pathIntoCallable(mid, node, _, cc, _) and ap = mid.getAp()
-  or
-  pathOutOfCallable(mid, node, cc) and ap = mid.getAp()
-  or
-  pathThroughCallable(mid, node, cc, ap)
-  or
-  valuePathThroughCallable(mid, node, cc) and ap = mid.getAp()
+  exists(LocalCallContext localCC | localCC.matchesCallContext(cc) |
+    localFlowBigStep(mid.getNode(), node, true, mid.getConfiguration(), localCC) and
+    cc = mid.getCallContext() and
+    ap = mid.getAp()
+    or
+    localFlowBigStep(mid.getNode(), node, false, mid.getConfiguration(), localCC) and
+    cc = mid.getCallContext() and
+    mid.getAp() instanceof AccessPathNil and
+    ap = node.(AccessPathNilNode).getAp()
+  ) or
+  not isUnreachableInCall(node, cc.(CallContextSpecificCall).getCall()) and
+  (
+    jumpStep(mid.getNode(), node, mid.getConfiguration()) and
+    cc instanceof CallContextAny and
+    ap = mid.getAp()
+    or
+    additionalJumpStep(mid.getNode(), node, mid.getConfiguration()) and
+    cc instanceof CallContextAny and
+    mid.getAp() instanceof AccessPathNil and
+    ap = node.(AccessPathNilNode).getAp()
+    or
+    contentReadStep(mid, node, ap) and cc = mid.getCallContext()
+    or
+    exists(Content f, AccessPath ap0 | contentStoreStep(mid, node, ap0, f, cc) and push(ap0, f, ap))
+    or
+    pathOutOfArgument(mid, node, cc) and ap = mid.getAp()
+    or
+    pathIntoCallable(mid, node, _, cc, _) and ap = mid.getAp()
+    or
+    pathOutOfCallable(mid, node, cc) and ap = mid.getAp()
+    or
+    pathThroughCallable(mid, node, cc, ap)
+    or
+    valuePathThroughCallable(mid, node, cc) and ap = mid.getAp()
+  )
 }
 
 pragma[noinline]
@@ -1879,7 +1891,7 @@ private predicate pathIntoCallable(
     pathIntoCallable0(mid, callable, i, outercc, call, emptyAp) and
     p.isParameterOf(callable, i)
   |
-    if reducedViableImplInCallContext(_, callable, call)
+    if recordDataFlowCallSite(call, callable)
     then innercc = TSpecificCall(call, i, emptyAp)
     else innercc = TSomeCall(p, emptyAp)
   )
@@ -2179,8 +2191,11 @@ private module FlowExploration {
 
   private class PartialPathNodePriv extends PartialPathNode {
     Node node;
+
     CallContext cc;
+
     PartialAccessPath ap;
+
     Configuration config;
 
     PartialPathNodePriv() { this = TPartialPathNodeMk(node, cc, ap, config) }
@@ -2377,7 +2392,7 @@ private module FlowExploration {
       partialPathIntoCallable0(mid, callable, i, outercc, call, emptyAp, ap, config) and
       p.isParameterOf(callable, i)
     |
-      if reducedViableImplInCallContext(_, callable, call)
+      if recordDataFlowCallSite(call, callable)
       then innercc = TSpecificCall(call, i, emptyAp)
       else innercc = TSomeCall(p, emptyAp)
     )
@@ -2445,7 +2460,6 @@ private module FlowExploration {
     )
   }
 }
-
 import FlowExploration
 
 private predicate partialFlow(

--- a/java/ql/src/semmle/code/java/dataflow/internal/DataFlowImpl.qll
+++ b/java/ql/src/semmle/code/java/dataflow/internal/DataFlowImpl.qll
@@ -1733,7 +1733,7 @@ private class PathNodeSink extends PathNode, TPathNodeSink {
  * a callable is recorded by `cc`.
  */
 private predicate pathStep(PathNodeMid mid, Node node, CallContext cc, AccessPath ap) {
-  exists(LocalCallContext localCC | localCC = getMatchingLocalCallContext(cc) |
+  exists(LocalCallContext localCC | localCC = getMatchingLocalCallContext(cc, node) |
     localFlowBigStep(mid.getNode(), node, true, mid.getConfiguration(), localCC) and
     cc = mid.getCallContext() and
     ap = mid.getAp()

--- a/java/ql/src/semmle/code/java/dataflow/internal/DataFlowImpl.qll
+++ b/java/ql/src/semmle/code/java/dataflow/internal/DataFlowImpl.qll
@@ -1667,11 +1667,8 @@ module PathGraph {
  */
 private class PathNodeMid extends PathNode, TPathNodeMid {
   Node node;
-
   CallContext cc;
-
   AccessPath ap;
-
   Configuration config;
 
   PathNodeMid() { this = TPathNodeMid(node, cc, ap, config) }
@@ -1717,7 +1714,6 @@ private class PathNodeMid extends PathNode, TPathNodeMid {
  */
 private class PathNodeSink extends PathNode, TPathNodeSink {
   Node node;
-
   Configuration config;
 
   PathNodeSink() { this = TPathNodeSink(node, config) }
@@ -1745,7 +1741,8 @@ private predicate pathStep(PathNodeMid mid, Node node, CallContext cc, AccessPat
     cc = mid.getCallContext() and
     mid.getAp() instanceof AccessPathNil and
     ap = node.(AccessPathNilNode).getAp()
-  ) or
+  )
+  or
   not isUnreachableInCall(node, cc.(CallContextSpecificCall).getCall()) and
   (
     jumpStep(mid.getNode(), node, mid.getConfiguration()) and
@@ -2191,11 +2188,8 @@ private module FlowExploration {
 
   private class PartialPathNodePriv extends PartialPathNode {
     Node node;
-
     CallContext cc;
-
     PartialAccessPath ap;
-
     Configuration config;
 
     PartialPathNodePriv() { this = TPartialPathNodeMk(node, cc, ap, config) }
@@ -2460,6 +2454,7 @@ private module FlowExploration {
     )
   }
 }
+
 import FlowExploration
 
 private predicate partialFlow(

--- a/java/ql/src/semmle/code/java/dataflow/internal/DataFlowImpl2.qll
+++ b/java/ql/src/semmle/code/java/dataflow/internal/DataFlowImpl2.qll
@@ -917,6 +917,7 @@ private predicate localFlowStepPlus(
     ) and
     node1 != node2 and
     cc.validFor(node1) and
+    not isUnreachableInCall(node1, cc.(LocalCallContextSpecificCall).getCall()) and
     nodeCand(node2, unbind(config))
     or
     exists(Node mid |
@@ -1732,7 +1733,7 @@ private class PathNodeSink extends PathNode, TPathNodeSink {
  * a callable is recorded by `cc`.
  */
 private predicate pathStep(PathNodeMid mid, Node node, CallContext cc, AccessPath ap) {
-  exists(LocalCallContext localCC | localCC.matchesCallContext(cc) |
+  exists(LocalCallContext localCC | localCC = getMatchingLocalCallContext(cc) |
     localFlowBigStep(mid.getNode(), node, true, mid.getConfiguration(), localCC) and
     cc = mid.getCallContext() and
     ap = mid.getAp()
@@ -1743,17 +1744,17 @@ private predicate pathStep(PathNodeMid mid, Node node, CallContext cc, AccessPat
     ap = node.(AccessPathNilNode).getAp()
   )
   or
+  jumpStep(mid.getNode(), node, mid.getConfiguration()) and
+  cc instanceof CallContextAny and
+  ap = mid.getAp()
+  or
+  additionalJumpStep(mid.getNode(), node, mid.getConfiguration()) and
+  cc instanceof CallContextAny and
+  mid.getAp() instanceof AccessPathNil and
+  ap = node.(AccessPathNilNode).getAp()
+  or
   not isUnreachableInCall(node, cc.(CallContextSpecificCall).getCall()) and
   (
-    jumpStep(mid.getNode(), node, mid.getConfiguration()) and
-    cc instanceof CallContextAny and
-    ap = mid.getAp()
-    or
-    additionalJumpStep(mid.getNode(), node, mid.getConfiguration()) and
-    cc instanceof CallContextAny and
-    mid.getAp() instanceof AccessPathNil and
-    ap = node.(AccessPathNilNode).getAp()
-    or
     contentReadStep(mid, node, ap) and cc = mid.getCallContext()
     or
     exists(Content f, AccessPath ap0 | contentStoreStep(mid, node, ap0, f, cc) and push(ap0, f, ap))
@@ -2235,24 +2236,27 @@ private module FlowExploration {
     ap = TPartialNil(getErasedRepr(node.getType())) and
     config = mid.getConfiguration()
     or
-    partialPathStoreStep(mid, _, _, node, ap) and
-    cc = mid.getCallContext() and
-    config = mid.getConfiguration()
-    or
-    exists(PartialAccessPath ap0, Content f |
-      partialPathReadStep(mid, ap0, f, node, cc, config) and
-      apConsFwd(ap, f, ap0, config)
+    not isUnreachableInCall(node, cc.(CallContextSpecificCall).getCall()) and
+    (
+      partialPathStoreStep(mid, _, _, node, ap) and
+      cc = mid.getCallContext() and
+      config = mid.getConfiguration()
+      or
+      exists(PartialAccessPath ap0, Content f |
+        partialPathReadStep(mid, ap0, f, node, cc, config) and
+        apConsFwd(ap, f, ap0, config)
+      )
+      or
+      partialPathOutOfArgument(mid, node, cc, ap, config)
+      or
+      partialPathIntoCallable(mid, node, _, cc, _, ap, config)
+      or
+      partialPathOutOfCallable(mid, node, cc, ap, config)
+      or
+      partialPathThroughCallable(mid, node, cc, ap, config)
+      or
+      valuePartialPathThroughCallable(mid, node, cc, ap, config)
     )
-    or
-    partialPathOutOfArgument(mid, node, cc, ap, config)
-    or
-    partialPathIntoCallable(mid, node, _, cc, _, ap, config)
-    or
-    partialPathOutOfCallable(mid, node, cc, ap, config)
-    or
-    partialPathThroughCallable(mid, node, cc, ap, config)
-    or
-    valuePartialPathThroughCallable(mid, node, cc, ap, config)
   }
 
   bindingset[result, i]

--- a/java/ql/src/semmle/code/java/dataflow/internal/DataFlowImpl2.qll
+++ b/java/ql/src/semmle/code/java/dataflow/internal/DataFlowImpl2.qll
@@ -1733,7 +1733,7 @@ private class PathNodeSink extends PathNode, TPathNodeSink {
  * a callable is recorded by `cc`.
  */
 private predicate pathStep(PathNodeMid mid, Node node, CallContext cc, AccessPath ap) {
-  exists(LocalCallContext localCC | localCC = getMatchingLocalCallContext(cc) |
+  exists(LocalCallContext localCC | localCC = getMatchingLocalCallContext(cc, node) |
     localFlowBigStep(mid.getNode(), node, true, mid.getConfiguration(), localCC) and
     cc = mid.getCallContext() and
     ap = mid.getAp()

--- a/java/ql/src/semmle/code/java/dataflow/internal/DataFlowImpl2.qll
+++ b/java/ql/src/semmle/code/java/dataflow/internal/DataFlowImpl2.qll
@@ -905,30 +905,34 @@ private predicate localFlowExit(Node node, Configuration config) {
  */
 pragma[nomagic]
 private predicate localFlowStepPlus(
-  Node node1, Node node2, boolean preservesValue, Configuration config
+  Node node1, Node node2, boolean preservesValue, Configuration config, LocalCallContext cc
 ) {
-  localFlowEntry(node1, config) and
+  not isUnreachableInCall(node2, cc.(LocalCallContextSpecificCall).getCall()) and
   (
-    localFlowStep(node1, node2, config) and preservesValue = true
+    localFlowEntry(node1, config) and
+    (
+      localFlowStep(node1, node2, config) and preservesValue = true
+      or
+      additionalLocalFlowStep(node1, node2, config) and preservesValue = false
+    ) and
+    node1 != node2 and
+    cc.validFor(node1) and
+    nodeCand(node2, unbind(config))
     or
-    additionalLocalFlowStep(node1, node2, config) and preservesValue = false
-  ) and
-  node1 != node2 and
-  nodeCand(node2, unbind(config))
-  or
-  exists(Node mid |
-    localFlowStepPlus(node1, mid, preservesValue, config) and
-    localFlowStep(mid, node2, config) and
-    not mid instanceof CastNode and
-    nodeCand(node2, unbind(config))
-  )
-  or
-  exists(Node mid |
-    localFlowStepPlus(node1, mid, _, config) and
-    additionalLocalFlowStep(mid, node2, config) and
-    not mid instanceof CastNode and
-    preservesValue = false and
-    nodeCand(node2, unbind(config))
+    exists(Node mid |
+      localFlowStepPlus(node1, mid, preservesValue, config, cc) and
+      localFlowStep(mid, node2, config) and
+      not mid instanceof CastNode and
+      nodeCand(node2, unbind(config))
+    )
+    or
+    exists(Node mid |
+      localFlowStepPlus(node1, mid, _, config, cc) and
+      additionalLocalFlowStep(mid, node2, config) and
+      not mid instanceof CastNode and
+      preservesValue = false and
+      nodeCand(node2, unbind(config))
+    )
   )
 }
 
@@ -938,9 +942,9 @@ private predicate localFlowStepPlus(
  */
 pragma[noinline]
 private predicate localFlowBigStep(
-  Node node1, Node node2, boolean preservesValue, Configuration config
+  Node node1, Node node2, boolean preservesValue, Configuration config, LocalCallContext callContext
 ) {
-  localFlowStepPlus(node1, node2, preservesValue, config) and
+  localFlowStepPlus(node1, node2, preservesValue, config, callContext) and
   localFlowExit(node2, config)
 }
 
@@ -1000,7 +1004,7 @@ private class AccessPathFrontNilNode extends Node {
     (
       any(Configuration c).isSource(this)
       or
-      localFlowBigStep(_, this, false, _)
+      localFlowBigStep(_, this, false, _, _)
       or
       additionalJumpStep(_, this, _)
     )
@@ -1023,12 +1027,12 @@ private predicate flowCandFwd0(Node node, boolean fromArg, AccessPathFront apf, 
   (
     exists(Node mid |
       flowCandFwd(mid, fromArg, apf, config) and
-      localFlowBigStep(mid, node, true, config)
+      localFlowBigStep(mid, node, true, config, _)
     )
     or
     exists(Node mid, AccessPathFrontNil nil |
       flowCandFwd(mid, fromArg, nil, config) and
-      localFlowBigStep(mid, node, false, config) and
+      localFlowBigStep(mid, node, false, config, _) and
       apf = node.(AccessPathFrontNilNode).getApf()
     )
     or
@@ -1121,13 +1125,13 @@ private predicate flowCand0(Node node, boolean toReturn, AccessPathFront apf, Co
   apf instanceof AccessPathFrontNil
   or
   exists(Node mid |
-    localFlowBigStep(node, mid, true, config) and
+    localFlowBigStep(node, mid, true, config, _) and
     flowCand(mid, toReturn, apf, config)
   )
   or
   exists(Node mid, AccessPathFrontNil nil |
     flowCandFwd(node, _, apf, config) and
-    localFlowBigStep(node, mid, false, config) and
+    localFlowBigStep(node, mid, false, config, _) and
     flowCand(mid, toReturn, nil, config) and
     apf instanceof AccessPathFrontNil
   )
@@ -1362,12 +1366,12 @@ private predicate flowFwd0(
   (
     exists(Node mid |
       flowFwd(mid, fromArg, apf, ap, config) and
-      localFlowBigStep(mid, node, true, config)
+      localFlowBigStep(mid, node, true, config, _)
     )
     or
     exists(Node mid, AccessPathNil nil |
       flowFwd(mid, fromArg, _, nil, config) and
-      localFlowBigStep(mid, node, false, config) and
+      localFlowBigStep(mid, node, false, config, _) and
       ap = node.(AccessPathNilNode).getAp() and
       apf = ap.(AccessPathNil).getFront()
     )
@@ -1471,13 +1475,13 @@ private predicate flow0(Node node, boolean toReturn, AccessPath ap, Configuratio
   ap instanceof AccessPathNil
   or
   exists(Node mid |
-    localFlowBigStep(node, mid, true, config) and
+    localFlowBigStep(node, mid, true, config, _) and
     flow(mid, toReturn, ap, config)
   )
   or
   exists(Node mid, AccessPathNil nil |
     flowFwd(node, _, _, ap, config) and
-    localFlowBigStep(node, mid, false, config) and
+    localFlowBigStep(node, mid, false, config, _) and
     flow(mid, toReturn, nil, config) and
     ap instanceof AccessPathNil
   )
@@ -1728,37 +1732,42 @@ private class PathNodeSink extends PathNode, TPathNodeSink {
  * a callable is recorded by `cc`.
  */
 private predicate pathStep(PathNodeMid mid, Node node, CallContext cc, AccessPath ap) {
-  localFlowBigStep(mid.getNode(), node, true, mid.getConfiguration()) and
-  cc = mid.getCallContext() and
-  ap = mid.getAp()
+  exists(LocalCallContext localCC | localCC.matchesCallContext(cc) |
+    localFlowBigStep(mid.getNode(), node, true, mid.getConfiguration(), localCC) and
+    cc = mid.getCallContext() and
+    ap = mid.getAp()
+    or
+    localFlowBigStep(mid.getNode(), node, false, mid.getConfiguration(), localCC) and
+    cc = mid.getCallContext() and
+    mid.getAp() instanceof AccessPathNil and
+    ap = node.(AccessPathNilNode).getAp()
+  )
   or
-  localFlowBigStep(mid.getNode(), node, false, mid.getConfiguration()) and
-  cc = mid.getCallContext() and
-  mid.getAp() instanceof AccessPathNil and
-  ap = node.(AccessPathNilNode).getAp()
-  or
-  jumpStep(mid.getNode(), node, mid.getConfiguration()) and
-  cc instanceof CallContextAny and
-  ap = mid.getAp()
-  or
-  additionalJumpStep(mid.getNode(), node, mid.getConfiguration()) and
-  cc instanceof CallContextAny and
-  mid.getAp() instanceof AccessPathNil and
-  ap = node.(AccessPathNilNode).getAp()
-  or
-  contentReadStep(mid, node, ap) and cc = mid.getCallContext()
-  or
-  exists(Content f, AccessPath ap0 | contentStoreStep(mid, node, ap0, f, cc) and push(ap0, f, ap))
-  or
-  pathOutOfArgument(mid, node, cc) and ap = mid.getAp()
-  or
-  pathIntoCallable(mid, node, _, cc, _) and ap = mid.getAp()
-  or
-  pathOutOfCallable(mid, node, cc) and ap = mid.getAp()
-  or
-  pathThroughCallable(mid, node, cc, ap)
-  or
-  valuePathThroughCallable(mid, node, cc) and ap = mid.getAp()
+  not isUnreachableInCall(node, cc.(CallContextSpecificCall).getCall()) and
+  (
+    jumpStep(mid.getNode(), node, mid.getConfiguration()) and
+    cc instanceof CallContextAny and
+    ap = mid.getAp()
+    or
+    additionalJumpStep(mid.getNode(), node, mid.getConfiguration()) and
+    cc instanceof CallContextAny and
+    mid.getAp() instanceof AccessPathNil and
+    ap = node.(AccessPathNilNode).getAp()
+    or
+    contentReadStep(mid, node, ap) and cc = mid.getCallContext()
+    or
+    exists(Content f, AccessPath ap0 | contentStoreStep(mid, node, ap0, f, cc) and push(ap0, f, ap))
+    or
+    pathOutOfArgument(mid, node, cc) and ap = mid.getAp()
+    or
+    pathIntoCallable(mid, node, _, cc, _) and ap = mid.getAp()
+    or
+    pathOutOfCallable(mid, node, cc) and ap = mid.getAp()
+    or
+    pathThroughCallable(mid, node, cc, ap)
+    or
+    valuePathThroughCallable(mid, node, cc) and ap = mid.getAp()
+  )
 }
 
 pragma[noinline]
@@ -1879,7 +1888,7 @@ private predicate pathIntoCallable(
     pathIntoCallable0(mid, callable, i, outercc, call, emptyAp) and
     p.isParameterOf(callable, i)
   |
-    if reducedViableImplInCallContext(_, callable, call)
+    if recordDataFlowCallSite(call, callable)
     then innercc = TSpecificCall(call, i, emptyAp)
     else innercc = TSomeCall(p, emptyAp)
   )
@@ -2377,7 +2386,7 @@ private module FlowExploration {
       partialPathIntoCallable0(mid, callable, i, outercc, call, emptyAp, ap, config) and
       p.isParameterOf(callable, i)
     |
-      if reducedViableImplInCallContext(_, callable, call)
+      if recordDataFlowCallSite(call, callable)
       then innercc = TSpecificCall(call, i, emptyAp)
       else innercc = TSomeCall(p, emptyAp)
     )

--- a/java/ql/src/semmle/code/java/dataflow/internal/DataFlowImpl3.qll
+++ b/java/ql/src/semmle/code/java/dataflow/internal/DataFlowImpl3.qll
@@ -917,6 +917,7 @@ private predicate localFlowStepPlus(
     ) and
     node1 != node2 and
     cc.validFor(node1) and
+    not isUnreachableInCall(node1, cc.(LocalCallContextSpecificCall).getCall()) and
     nodeCand(node2, unbind(config))
     or
     exists(Node mid |
@@ -1732,7 +1733,7 @@ private class PathNodeSink extends PathNode, TPathNodeSink {
  * a callable is recorded by `cc`.
  */
 private predicate pathStep(PathNodeMid mid, Node node, CallContext cc, AccessPath ap) {
-  exists(LocalCallContext localCC | localCC.matchesCallContext(cc) |
+  exists(LocalCallContext localCC | localCC = getMatchingLocalCallContext(cc) |
     localFlowBigStep(mid.getNode(), node, true, mid.getConfiguration(), localCC) and
     cc = mid.getCallContext() and
     ap = mid.getAp()
@@ -1743,17 +1744,17 @@ private predicate pathStep(PathNodeMid mid, Node node, CallContext cc, AccessPat
     ap = node.(AccessPathNilNode).getAp()
   )
   or
+  jumpStep(mid.getNode(), node, mid.getConfiguration()) and
+  cc instanceof CallContextAny and
+  ap = mid.getAp()
+  or
+  additionalJumpStep(mid.getNode(), node, mid.getConfiguration()) and
+  cc instanceof CallContextAny and
+  mid.getAp() instanceof AccessPathNil and
+  ap = node.(AccessPathNilNode).getAp()
+  or
   not isUnreachableInCall(node, cc.(CallContextSpecificCall).getCall()) and
   (
-    jumpStep(mid.getNode(), node, mid.getConfiguration()) and
-    cc instanceof CallContextAny and
-    ap = mid.getAp()
-    or
-    additionalJumpStep(mid.getNode(), node, mid.getConfiguration()) and
-    cc instanceof CallContextAny and
-    mid.getAp() instanceof AccessPathNil and
-    ap = node.(AccessPathNilNode).getAp()
-    or
     contentReadStep(mid, node, ap) and cc = mid.getCallContext()
     or
     exists(Content f, AccessPath ap0 | contentStoreStep(mid, node, ap0, f, cc) and push(ap0, f, ap))
@@ -2235,24 +2236,27 @@ private module FlowExploration {
     ap = TPartialNil(getErasedRepr(node.getType())) and
     config = mid.getConfiguration()
     or
-    partialPathStoreStep(mid, _, _, node, ap) and
-    cc = mid.getCallContext() and
-    config = mid.getConfiguration()
-    or
-    exists(PartialAccessPath ap0, Content f |
-      partialPathReadStep(mid, ap0, f, node, cc, config) and
-      apConsFwd(ap, f, ap0, config)
+    not isUnreachableInCall(node, cc.(CallContextSpecificCall).getCall()) and
+    (
+      partialPathStoreStep(mid, _, _, node, ap) and
+      cc = mid.getCallContext() and
+      config = mid.getConfiguration()
+      or
+      exists(PartialAccessPath ap0, Content f |
+        partialPathReadStep(mid, ap0, f, node, cc, config) and
+        apConsFwd(ap, f, ap0, config)
+      )
+      or
+      partialPathOutOfArgument(mid, node, cc, ap, config)
+      or
+      partialPathIntoCallable(mid, node, _, cc, _, ap, config)
+      or
+      partialPathOutOfCallable(mid, node, cc, ap, config)
+      or
+      partialPathThroughCallable(mid, node, cc, ap, config)
+      or
+      valuePartialPathThroughCallable(mid, node, cc, ap, config)
     )
-    or
-    partialPathOutOfArgument(mid, node, cc, ap, config)
-    or
-    partialPathIntoCallable(mid, node, _, cc, _, ap, config)
-    or
-    partialPathOutOfCallable(mid, node, cc, ap, config)
-    or
-    partialPathThroughCallable(mid, node, cc, ap, config)
-    or
-    valuePartialPathThroughCallable(mid, node, cc, ap, config)
   }
 
   bindingset[result, i]

--- a/java/ql/src/semmle/code/java/dataflow/internal/DataFlowImpl3.qll
+++ b/java/ql/src/semmle/code/java/dataflow/internal/DataFlowImpl3.qll
@@ -1733,7 +1733,7 @@ private class PathNodeSink extends PathNode, TPathNodeSink {
  * a callable is recorded by `cc`.
  */
 private predicate pathStep(PathNodeMid mid, Node node, CallContext cc, AccessPath ap) {
-  exists(LocalCallContext localCC | localCC = getMatchingLocalCallContext(cc) |
+  exists(LocalCallContext localCC | localCC = getMatchingLocalCallContext(cc, node) |
     localFlowBigStep(mid.getNode(), node, true, mid.getConfiguration(), localCC) and
     cc = mid.getCallContext() and
     ap = mid.getAp()

--- a/java/ql/src/semmle/code/java/dataflow/internal/DataFlowImpl3.qll
+++ b/java/ql/src/semmle/code/java/dataflow/internal/DataFlowImpl3.qll
@@ -905,30 +905,34 @@ private predicate localFlowExit(Node node, Configuration config) {
  */
 pragma[nomagic]
 private predicate localFlowStepPlus(
-  Node node1, Node node2, boolean preservesValue, Configuration config
+  Node node1, Node node2, boolean preservesValue, Configuration config, LocalCallContext cc
 ) {
-  localFlowEntry(node1, config) and
+  not isUnreachableInCall(node2, cc.(LocalCallContextSpecificCall).getCall()) and
   (
-    localFlowStep(node1, node2, config) and preservesValue = true
+    localFlowEntry(node1, config) and
+    (
+      localFlowStep(node1, node2, config) and preservesValue = true
+      or
+      additionalLocalFlowStep(node1, node2, config) and preservesValue = false
+    ) and
+    node1 != node2 and
+    cc.validFor(node1) and
+    nodeCand(node2, unbind(config))
     or
-    additionalLocalFlowStep(node1, node2, config) and preservesValue = false
-  ) and
-  node1 != node2 and
-  nodeCand(node2, unbind(config))
-  or
-  exists(Node mid |
-    localFlowStepPlus(node1, mid, preservesValue, config) and
-    localFlowStep(mid, node2, config) and
-    not mid instanceof CastNode and
-    nodeCand(node2, unbind(config))
-  )
-  or
-  exists(Node mid |
-    localFlowStepPlus(node1, mid, _, config) and
-    additionalLocalFlowStep(mid, node2, config) and
-    not mid instanceof CastNode and
-    preservesValue = false and
-    nodeCand(node2, unbind(config))
+    exists(Node mid |
+      localFlowStepPlus(node1, mid, preservesValue, config, cc) and
+      localFlowStep(mid, node2, config) and
+      not mid instanceof CastNode and
+      nodeCand(node2, unbind(config))
+    )
+    or
+    exists(Node mid |
+      localFlowStepPlus(node1, mid, _, config, cc) and
+      additionalLocalFlowStep(mid, node2, config) and
+      not mid instanceof CastNode and
+      preservesValue = false and
+      nodeCand(node2, unbind(config))
+    )
   )
 }
 
@@ -938,9 +942,9 @@ private predicate localFlowStepPlus(
  */
 pragma[noinline]
 private predicate localFlowBigStep(
-  Node node1, Node node2, boolean preservesValue, Configuration config
+  Node node1, Node node2, boolean preservesValue, Configuration config, LocalCallContext callContext
 ) {
-  localFlowStepPlus(node1, node2, preservesValue, config) and
+  localFlowStepPlus(node1, node2, preservesValue, config, callContext) and
   localFlowExit(node2, config)
 }
 
@@ -1000,7 +1004,7 @@ private class AccessPathFrontNilNode extends Node {
     (
       any(Configuration c).isSource(this)
       or
-      localFlowBigStep(_, this, false, _)
+      localFlowBigStep(_, this, false, _, _)
       or
       additionalJumpStep(_, this, _)
     )
@@ -1023,12 +1027,12 @@ private predicate flowCandFwd0(Node node, boolean fromArg, AccessPathFront apf, 
   (
     exists(Node mid |
       flowCandFwd(mid, fromArg, apf, config) and
-      localFlowBigStep(mid, node, true, config)
+      localFlowBigStep(mid, node, true, config, _)
     )
     or
     exists(Node mid, AccessPathFrontNil nil |
       flowCandFwd(mid, fromArg, nil, config) and
-      localFlowBigStep(mid, node, false, config) and
+      localFlowBigStep(mid, node, false, config, _) and
       apf = node.(AccessPathFrontNilNode).getApf()
     )
     or
@@ -1121,13 +1125,13 @@ private predicate flowCand0(Node node, boolean toReturn, AccessPathFront apf, Co
   apf instanceof AccessPathFrontNil
   or
   exists(Node mid |
-    localFlowBigStep(node, mid, true, config) and
+    localFlowBigStep(node, mid, true, config, _) and
     flowCand(mid, toReturn, apf, config)
   )
   or
   exists(Node mid, AccessPathFrontNil nil |
     flowCandFwd(node, _, apf, config) and
-    localFlowBigStep(node, mid, false, config) and
+    localFlowBigStep(node, mid, false, config, _) and
     flowCand(mid, toReturn, nil, config) and
     apf instanceof AccessPathFrontNil
   )
@@ -1362,12 +1366,12 @@ private predicate flowFwd0(
   (
     exists(Node mid |
       flowFwd(mid, fromArg, apf, ap, config) and
-      localFlowBigStep(mid, node, true, config)
+      localFlowBigStep(mid, node, true, config, _)
     )
     or
     exists(Node mid, AccessPathNil nil |
       flowFwd(mid, fromArg, _, nil, config) and
-      localFlowBigStep(mid, node, false, config) and
+      localFlowBigStep(mid, node, false, config, _) and
       ap = node.(AccessPathNilNode).getAp() and
       apf = ap.(AccessPathNil).getFront()
     )
@@ -1471,13 +1475,13 @@ private predicate flow0(Node node, boolean toReturn, AccessPath ap, Configuratio
   ap instanceof AccessPathNil
   or
   exists(Node mid |
-    localFlowBigStep(node, mid, true, config) and
+    localFlowBigStep(node, mid, true, config, _) and
     flow(mid, toReturn, ap, config)
   )
   or
   exists(Node mid, AccessPathNil nil |
     flowFwd(node, _, _, ap, config) and
-    localFlowBigStep(node, mid, false, config) and
+    localFlowBigStep(node, mid, false, config, _) and
     flow(mid, toReturn, nil, config) and
     ap instanceof AccessPathNil
   )
@@ -1728,37 +1732,42 @@ private class PathNodeSink extends PathNode, TPathNodeSink {
  * a callable is recorded by `cc`.
  */
 private predicate pathStep(PathNodeMid mid, Node node, CallContext cc, AccessPath ap) {
-  localFlowBigStep(mid.getNode(), node, true, mid.getConfiguration()) and
-  cc = mid.getCallContext() and
-  ap = mid.getAp()
+  exists(LocalCallContext localCC | localCC.matchesCallContext(cc) |
+    localFlowBigStep(mid.getNode(), node, true, mid.getConfiguration(), localCC) and
+    cc = mid.getCallContext() and
+    ap = mid.getAp()
+    or
+    localFlowBigStep(mid.getNode(), node, false, mid.getConfiguration(), localCC) and
+    cc = mid.getCallContext() and
+    mid.getAp() instanceof AccessPathNil and
+    ap = node.(AccessPathNilNode).getAp()
+  )
   or
-  localFlowBigStep(mid.getNode(), node, false, mid.getConfiguration()) and
-  cc = mid.getCallContext() and
-  mid.getAp() instanceof AccessPathNil and
-  ap = node.(AccessPathNilNode).getAp()
-  or
-  jumpStep(mid.getNode(), node, mid.getConfiguration()) and
-  cc instanceof CallContextAny and
-  ap = mid.getAp()
-  or
-  additionalJumpStep(mid.getNode(), node, mid.getConfiguration()) and
-  cc instanceof CallContextAny and
-  mid.getAp() instanceof AccessPathNil and
-  ap = node.(AccessPathNilNode).getAp()
-  or
-  contentReadStep(mid, node, ap) and cc = mid.getCallContext()
-  or
-  exists(Content f, AccessPath ap0 | contentStoreStep(mid, node, ap0, f, cc) and push(ap0, f, ap))
-  or
-  pathOutOfArgument(mid, node, cc) and ap = mid.getAp()
-  or
-  pathIntoCallable(mid, node, _, cc, _) and ap = mid.getAp()
-  or
-  pathOutOfCallable(mid, node, cc) and ap = mid.getAp()
-  or
-  pathThroughCallable(mid, node, cc, ap)
-  or
-  valuePathThroughCallable(mid, node, cc) and ap = mid.getAp()
+  not isUnreachableInCall(node, cc.(CallContextSpecificCall).getCall()) and
+  (
+    jumpStep(mid.getNode(), node, mid.getConfiguration()) and
+    cc instanceof CallContextAny and
+    ap = mid.getAp()
+    or
+    additionalJumpStep(mid.getNode(), node, mid.getConfiguration()) and
+    cc instanceof CallContextAny and
+    mid.getAp() instanceof AccessPathNil and
+    ap = node.(AccessPathNilNode).getAp()
+    or
+    contentReadStep(mid, node, ap) and cc = mid.getCallContext()
+    or
+    exists(Content f, AccessPath ap0 | contentStoreStep(mid, node, ap0, f, cc) and push(ap0, f, ap))
+    or
+    pathOutOfArgument(mid, node, cc) and ap = mid.getAp()
+    or
+    pathIntoCallable(mid, node, _, cc, _) and ap = mid.getAp()
+    or
+    pathOutOfCallable(mid, node, cc) and ap = mid.getAp()
+    or
+    pathThroughCallable(mid, node, cc, ap)
+    or
+    valuePathThroughCallable(mid, node, cc) and ap = mid.getAp()
+  )
 }
 
 pragma[noinline]
@@ -1879,7 +1888,7 @@ private predicate pathIntoCallable(
     pathIntoCallable0(mid, callable, i, outercc, call, emptyAp) and
     p.isParameterOf(callable, i)
   |
-    if reducedViableImplInCallContext(_, callable, call)
+    if recordDataFlowCallSite(call, callable)
     then innercc = TSpecificCall(call, i, emptyAp)
     else innercc = TSomeCall(p, emptyAp)
   )
@@ -2377,7 +2386,7 @@ private module FlowExploration {
       partialPathIntoCallable0(mid, callable, i, outercc, call, emptyAp, ap, config) and
       p.isParameterOf(callable, i)
     |
-      if reducedViableImplInCallContext(_, callable, call)
+      if recordDataFlowCallSite(call, callable)
       then innercc = TSpecificCall(call, i, emptyAp)
       else innercc = TSomeCall(p, emptyAp)
     )

--- a/java/ql/src/semmle/code/java/dataflow/internal/DataFlowImpl4.qll
+++ b/java/ql/src/semmle/code/java/dataflow/internal/DataFlowImpl4.qll
@@ -917,6 +917,7 @@ private predicate localFlowStepPlus(
     ) and
     node1 != node2 and
     cc.validFor(node1) and
+    not isUnreachableInCall(node1, cc.(LocalCallContextSpecificCall).getCall()) and
     nodeCand(node2, unbind(config))
     or
     exists(Node mid |
@@ -1732,7 +1733,7 @@ private class PathNodeSink extends PathNode, TPathNodeSink {
  * a callable is recorded by `cc`.
  */
 private predicate pathStep(PathNodeMid mid, Node node, CallContext cc, AccessPath ap) {
-  exists(LocalCallContext localCC | localCC.matchesCallContext(cc) |
+  exists(LocalCallContext localCC | localCC = getMatchingLocalCallContext(cc) |
     localFlowBigStep(mid.getNode(), node, true, mid.getConfiguration(), localCC) and
     cc = mid.getCallContext() and
     ap = mid.getAp()
@@ -1743,17 +1744,17 @@ private predicate pathStep(PathNodeMid mid, Node node, CallContext cc, AccessPat
     ap = node.(AccessPathNilNode).getAp()
   )
   or
+  jumpStep(mid.getNode(), node, mid.getConfiguration()) and
+  cc instanceof CallContextAny and
+  ap = mid.getAp()
+  or
+  additionalJumpStep(mid.getNode(), node, mid.getConfiguration()) and
+  cc instanceof CallContextAny and
+  mid.getAp() instanceof AccessPathNil and
+  ap = node.(AccessPathNilNode).getAp()
+  or
   not isUnreachableInCall(node, cc.(CallContextSpecificCall).getCall()) and
   (
-    jumpStep(mid.getNode(), node, mid.getConfiguration()) and
-    cc instanceof CallContextAny and
-    ap = mid.getAp()
-    or
-    additionalJumpStep(mid.getNode(), node, mid.getConfiguration()) and
-    cc instanceof CallContextAny and
-    mid.getAp() instanceof AccessPathNil and
-    ap = node.(AccessPathNilNode).getAp()
-    or
     contentReadStep(mid, node, ap) and cc = mid.getCallContext()
     or
     exists(Content f, AccessPath ap0 | contentStoreStep(mid, node, ap0, f, cc) and push(ap0, f, ap))
@@ -2235,24 +2236,27 @@ private module FlowExploration {
     ap = TPartialNil(getErasedRepr(node.getType())) and
     config = mid.getConfiguration()
     or
-    partialPathStoreStep(mid, _, _, node, ap) and
-    cc = mid.getCallContext() and
-    config = mid.getConfiguration()
-    or
-    exists(PartialAccessPath ap0, Content f |
-      partialPathReadStep(mid, ap0, f, node, cc, config) and
-      apConsFwd(ap, f, ap0, config)
+    not isUnreachableInCall(node, cc.(CallContextSpecificCall).getCall()) and
+    (
+      partialPathStoreStep(mid, _, _, node, ap) and
+      cc = mid.getCallContext() and
+      config = mid.getConfiguration()
+      or
+      exists(PartialAccessPath ap0, Content f |
+        partialPathReadStep(mid, ap0, f, node, cc, config) and
+        apConsFwd(ap, f, ap0, config)
+      )
+      or
+      partialPathOutOfArgument(mid, node, cc, ap, config)
+      or
+      partialPathIntoCallable(mid, node, _, cc, _, ap, config)
+      or
+      partialPathOutOfCallable(mid, node, cc, ap, config)
+      or
+      partialPathThroughCallable(mid, node, cc, ap, config)
+      or
+      valuePartialPathThroughCallable(mid, node, cc, ap, config)
     )
-    or
-    partialPathOutOfArgument(mid, node, cc, ap, config)
-    or
-    partialPathIntoCallable(mid, node, _, cc, _, ap, config)
-    or
-    partialPathOutOfCallable(mid, node, cc, ap, config)
-    or
-    partialPathThroughCallable(mid, node, cc, ap, config)
-    or
-    valuePartialPathThroughCallable(mid, node, cc, ap, config)
   }
 
   bindingset[result, i]

--- a/java/ql/src/semmle/code/java/dataflow/internal/DataFlowImpl4.qll
+++ b/java/ql/src/semmle/code/java/dataflow/internal/DataFlowImpl4.qll
@@ -1733,7 +1733,7 @@ private class PathNodeSink extends PathNode, TPathNodeSink {
  * a callable is recorded by `cc`.
  */
 private predicate pathStep(PathNodeMid mid, Node node, CallContext cc, AccessPath ap) {
-  exists(LocalCallContext localCC | localCC = getMatchingLocalCallContext(cc) |
+  exists(LocalCallContext localCC | localCC = getMatchingLocalCallContext(cc, node) |
     localFlowBigStep(mid.getNode(), node, true, mid.getConfiguration(), localCC) and
     cc = mid.getCallContext() and
     ap = mid.getAp()

--- a/java/ql/src/semmle/code/java/dataflow/internal/DataFlowImpl4.qll
+++ b/java/ql/src/semmle/code/java/dataflow/internal/DataFlowImpl4.qll
@@ -905,30 +905,34 @@ private predicate localFlowExit(Node node, Configuration config) {
  */
 pragma[nomagic]
 private predicate localFlowStepPlus(
-  Node node1, Node node2, boolean preservesValue, Configuration config
+  Node node1, Node node2, boolean preservesValue, Configuration config, LocalCallContext cc
 ) {
-  localFlowEntry(node1, config) and
+  not isUnreachableInCall(node2, cc.(LocalCallContextSpecificCall).getCall()) and
   (
-    localFlowStep(node1, node2, config) and preservesValue = true
+    localFlowEntry(node1, config) and
+    (
+      localFlowStep(node1, node2, config) and preservesValue = true
+      or
+      additionalLocalFlowStep(node1, node2, config) and preservesValue = false
+    ) and
+    node1 != node2 and
+    cc.validFor(node1) and
+    nodeCand(node2, unbind(config))
     or
-    additionalLocalFlowStep(node1, node2, config) and preservesValue = false
-  ) and
-  node1 != node2 and
-  nodeCand(node2, unbind(config))
-  or
-  exists(Node mid |
-    localFlowStepPlus(node1, mid, preservesValue, config) and
-    localFlowStep(mid, node2, config) and
-    not mid instanceof CastNode and
-    nodeCand(node2, unbind(config))
-  )
-  or
-  exists(Node mid |
-    localFlowStepPlus(node1, mid, _, config) and
-    additionalLocalFlowStep(mid, node2, config) and
-    not mid instanceof CastNode and
-    preservesValue = false and
-    nodeCand(node2, unbind(config))
+    exists(Node mid |
+      localFlowStepPlus(node1, mid, preservesValue, config, cc) and
+      localFlowStep(mid, node2, config) and
+      not mid instanceof CastNode and
+      nodeCand(node2, unbind(config))
+    )
+    or
+    exists(Node mid |
+      localFlowStepPlus(node1, mid, _, config, cc) and
+      additionalLocalFlowStep(mid, node2, config) and
+      not mid instanceof CastNode and
+      preservesValue = false and
+      nodeCand(node2, unbind(config))
+    )
   )
 }
 
@@ -938,9 +942,9 @@ private predicate localFlowStepPlus(
  */
 pragma[noinline]
 private predicate localFlowBigStep(
-  Node node1, Node node2, boolean preservesValue, Configuration config
+  Node node1, Node node2, boolean preservesValue, Configuration config, LocalCallContext callContext
 ) {
-  localFlowStepPlus(node1, node2, preservesValue, config) and
+  localFlowStepPlus(node1, node2, preservesValue, config, callContext) and
   localFlowExit(node2, config)
 }
 
@@ -1000,7 +1004,7 @@ private class AccessPathFrontNilNode extends Node {
     (
       any(Configuration c).isSource(this)
       or
-      localFlowBigStep(_, this, false, _)
+      localFlowBigStep(_, this, false, _, _)
       or
       additionalJumpStep(_, this, _)
     )
@@ -1023,12 +1027,12 @@ private predicate flowCandFwd0(Node node, boolean fromArg, AccessPathFront apf, 
   (
     exists(Node mid |
       flowCandFwd(mid, fromArg, apf, config) and
-      localFlowBigStep(mid, node, true, config)
+      localFlowBigStep(mid, node, true, config, _)
     )
     or
     exists(Node mid, AccessPathFrontNil nil |
       flowCandFwd(mid, fromArg, nil, config) and
-      localFlowBigStep(mid, node, false, config) and
+      localFlowBigStep(mid, node, false, config, _) and
       apf = node.(AccessPathFrontNilNode).getApf()
     )
     or
@@ -1121,13 +1125,13 @@ private predicate flowCand0(Node node, boolean toReturn, AccessPathFront apf, Co
   apf instanceof AccessPathFrontNil
   or
   exists(Node mid |
-    localFlowBigStep(node, mid, true, config) and
+    localFlowBigStep(node, mid, true, config, _) and
     flowCand(mid, toReturn, apf, config)
   )
   or
   exists(Node mid, AccessPathFrontNil nil |
     flowCandFwd(node, _, apf, config) and
-    localFlowBigStep(node, mid, false, config) and
+    localFlowBigStep(node, mid, false, config, _) and
     flowCand(mid, toReturn, nil, config) and
     apf instanceof AccessPathFrontNil
   )
@@ -1362,12 +1366,12 @@ private predicate flowFwd0(
   (
     exists(Node mid |
       flowFwd(mid, fromArg, apf, ap, config) and
-      localFlowBigStep(mid, node, true, config)
+      localFlowBigStep(mid, node, true, config, _)
     )
     or
     exists(Node mid, AccessPathNil nil |
       flowFwd(mid, fromArg, _, nil, config) and
-      localFlowBigStep(mid, node, false, config) and
+      localFlowBigStep(mid, node, false, config, _) and
       ap = node.(AccessPathNilNode).getAp() and
       apf = ap.(AccessPathNil).getFront()
     )
@@ -1471,13 +1475,13 @@ private predicate flow0(Node node, boolean toReturn, AccessPath ap, Configuratio
   ap instanceof AccessPathNil
   or
   exists(Node mid |
-    localFlowBigStep(node, mid, true, config) and
+    localFlowBigStep(node, mid, true, config, _) and
     flow(mid, toReturn, ap, config)
   )
   or
   exists(Node mid, AccessPathNil nil |
     flowFwd(node, _, _, ap, config) and
-    localFlowBigStep(node, mid, false, config) and
+    localFlowBigStep(node, mid, false, config, _) and
     flow(mid, toReturn, nil, config) and
     ap instanceof AccessPathNil
   )
@@ -1728,37 +1732,42 @@ private class PathNodeSink extends PathNode, TPathNodeSink {
  * a callable is recorded by `cc`.
  */
 private predicate pathStep(PathNodeMid mid, Node node, CallContext cc, AccessPath ap) {
-  localFlowBigStep(mid.getNode(), node, true, mid.getConfiguration()) and
-  cc = mid.getCallContext() and
-  ap = mid.getAp()
+  exists(LocalCallContext localCC | localCC.matchesCallContext(cc) |
+    localFlowBigStep(mid.getNode(), node, true, mid.getConfiguration(), localCC) and
+    cc = mid.getCallContext() and
+    ap = mid.getAp()
+    or
+    localFlowBigStep(mid.getNode(), node, false, mid.getConfiguration(), localCC) and
+    cc = mid.getCallContext() and
+    mid.getAp() instanceof AccessPathNil and
+    ap = node.(AccessPathNilNode).getAp()
+  )
   or
-  localFlowBigStep(mid.getNode(), node, false, mid.getConfiguration()) and
-  cc = mid.getCallContext() and
-  mid.getAp() instanceof AccessPathNil and
-  ap = node.(AccessPathNilNode).getAp()
-  or
-  jumpStep(mid.getNode(), node, mid.getConfiguration()) and
-  cc instanceof CallContextAny and
-  ap = mid.getAp()
-  or
-  additionalJumpStep(mid.getNode(), node, mid.getConfiguration()) and
-  cc instanceof CallContextAny and
-  mid.getAp() instanceof AccessPathNil and
-  ap = node.(AccessPathNilNode).getAp()
-  or
-  contentReadStep(mid, node, ap) and cc = mid.getCallContext()
-  or
-  exists(Content f, AccessPath ap0 | contentStoreStep(mid, node, ap0, f, cc) and push(ap0, f, ap))
-  or
-  pathOutOfArgument(mid, node, cc) and ap = mid.getAp()
-  or
-  pathIntoCallable(mid, node, _, cc, _) and ap = mid.getAp()
-  or
-  pathOutOfCallable(mid, node, cc) and ap = mid.getAp()
-  or
-  pathThroughCallable(mid, node, cc, ap)
-  or
-  valuePathThroughCallable(mid, node, cc) and ap = mid.getAp()
+  not isUnreachableInCall(node, cc.(CallContextSpecificCall).getCall()) and
+  (
+    jumpStep(mid.getNode(), node, mid.getConfiguration()) and
+    cc instanceof CallContextAny and
+    ap = mid.getAp()
+    or
+    additionalJumpStep(mid.getNode(), node, mid.getConfiguration()) and
+    cc instanceof CallContextAny and
+    mid.getAp() instanceof AccessPathNil and
+    ap = node.(AccessPathNilNode).getAp()
+    or
+    contentReadStep(mid, node, ap) and cc = mid.getCallContext()
+    or
+    exists(Content f, AccessPath ap0 | contentStoreStep(mid, node, ap0, f, cc) and push(ap0, f, ap))
+    or
+    pathOutOfArgument(mid, node, cc) and ap = mid.getAp()
+    or
+    pathIntoCallable(mid, node, _, cc, _) and ap = mid.getAp()
+    or
+    pathOutOfCallable(mid, node, cc) and ap = mid.getAp()
+    or
+    pathThroughCallable(mid, node, cc, ap)
+    or
+    valuePathThroughCallable(mid, node, cc) and ap = mid.getAp()
+  )
 }
 
 pragma[noinline]
@@ -1879,7 +1888,7 @@ private predicate pathIntoCallable(
     pathIntoCallable0(mid, callable, i, outercc, call, emptyAp) and
     p.isParameterOf(callable, i)
   |
-    if reducedViableImplInCallContext(_, callable, call)
+    if recordDataFlowCallSite(call, callable)
     then innercc = TSpecificCall(call, i, emptyAp)
     else innercc = TSomeCall(p, emptyAp)
   )
@@ -2377,7 +2386,7 @@ private module FlowExploration {
       partialPathIntoCallable0(mid, callable, i, outercc, call, emptyAp, ap, config) and
       p.isParameterOf(callable, i)
     |
-      if reducedViableImplInCallContext(_, callable, call)
+      if recordDataFlowCallSite(call, callable)
       then innercc = TSpecificCall(call, i, emptyAp)
       else innercc = TSomeCall(p, emptyAp)
     )

--- a/java/ql/src/semmle/code/java/dataflow/internal/DataFlowImpl5.qll
+++ b/java/ql/src/semmle/code/java/dataflow/internal/DataFlowImpl5.qll
@@ -917,6 +917,7 @@ private predicate localFlowStepPlus(
     ) and
     node1 != node2 and
     cc.validFor(node1) and
+    not isUnreachableInCall(node1, cc.(LocalCallContextSpecificCall).getCall()) and
     nodeCand(node2, unbind(config))
     or
     exists(Node mid |
@@ -1732,7 +1733,7 @@ private class PathNodeSink extends PathNode, TPathNodeSink {
  * a callable is recorded by `cc`.
  */
 private predicate pathStep(PathNodeMid mid, Node node, CallContext cc, AccessPath ap) {
-  exists(LocalCallContext localCC | localCC.matchesCallContext(cc) |
+  exists(LocalCallContext localCC | localCC = getMatchingLocalCallContext(cc) |
     localFlowBigStep(mid.getNode(), node, true, mid.getConfiguration(), localCC) and
     cc = mid.getCallContext() and
     ap = mid.getAp()
@@ -1743,17 +1744,17 @@ private predicate pathStep(PathNodeMid mid, Node node, CallContext cc, AccessPat
     ap = node.(AccessPathNilNode).getAp()
   )
   or
+  jumpStep(mid.getNode(), node, mid.getConfiguration()) and
+  cc instanceof CallContextAny and
+  ap = mid.getAp()
+  or
+  additionalJumpStep(mid.getNode(), node, mid.getConfiguration()) and
+  cc instanceof CallContextAny and
+  mid.getAp() instanceof AccessPathNil and
+  ap = node.(AccessPathNilNode).getAp()
+  or
   not isUnreachableInCall(node, cc.(CallContextSpecificCall).getCall()) and
   (
-    jumpStep(mid.getNode(), node, mid.getConfiguration()) and
-    cc instanceof CallContextAny and
-    ap = mid.getAp()
-    or
-    additionalJumpStep(mid.getNode(), node, mid.getConfiguration()) and
-    cc instanceof CallContextAny and
-    mid.getAp() instanceof AccessPathNil and
-    ap = node.(AccessPathNilNode).getAp()
-    or
     contentReadStep(mid, node, ap) and cc = mid.getCallContext()
     or
     exists(Content f, AccessPath ap0 | contentStoreStep(mid, node, ap0, f, cc) and push(ap0, f, ap))
@@ -2235,24 +2236,27 @@ private module FlowExploration {
     ap = TPartialNil(getErasedRepr(node.getType())) and
     config = mid.getConfiguration()
     or
-    partialPathStoreStep(mid, _, _, node, ap) and
-    cc = mid.getCallContext() and
-    config = mid.getConfiguration()
-    or
-    exists(PartialAccessPath ap0, Content f |
-      partialPathReadStep(mid, ap0, f, node, cc, config) and
-      apConsFwd(ap, f, ap0, config)
+    not isUnreachableInCall(node, cc.(CallContextSpecificCall).getCall()) and
+    (
+      partialPathStoreStep(mid, _, _, node, ap) and
+      cc = mid.getCallContext() and
+      config = mid.getConfiguration()
+      or
+      exists(PartialAccessPath ap0, Content f |
+        partialPathReadStep(mid, ap0, f, node, cc, config) and
+        apConsFwd(ap, f, ap0, config)
+      )
+      or
+      partialPathOutOfArgument(mid, node, cc, ap, config)
+      or
+      partialPathIntoCallable(mid, node, _, cc, _, ap, config)
+      or
+      partialPathOutOfCallable(mid, node, cc, ap, config)
+      or
+      partialPathThroughCallable(mid, node, cc, ap, config)
+      or
+      valuePartialPathThroughCallable(mid, node, cc, ap, config)
     )
-    or
-    partialPathOutOfArgument(mid, node, cc, ap, config)
-    or
-    partialPathIntoCallable(mid, node, _, cc, _, ap, config)
-    or
-    partialPathOutOfCallable(mid, node, cc, ap, config)
-    or
-    partialPathThroughCallable(mid, node, cc, ap, config)
-    or
-    valuePartialPathThroughCallable(mid, node, cc, ap, config)
   }
 
   bindingset[result, i]

--- a/java/ql/src/semmle/code/java/dataflow/internal/DataFlowImpl5.qll
+++ b/java/ql/src/semmle/code/java/dataflow/internal/DataFlowImpl5.qll
@@ -1733,7 +1733,7 @@ private class PathNodeSink extends PathNode, TPathNodeSink {
  * a callable is recorded by `cc`.
  */
 private predicate pathStep(PathNodeMid mid, Node node, CallContext cc, AccessPath ap) {
-  exists(LocalCallContext localCC | localCC = getMatchingLocalCallContext(cc) |
+  exists(LocalCallContext localCC | localCC = getMatchingLocalCallContext(cc, node) |
     localFlowBigStep(mid.getNode(), node, true, mid.getConfiguration(), localCC) and
     cc = mid.getCallContext() and
     ap = mid.getAp()

--- a/java/ql/src/semmle/code/java/dataflow/internal/DataFlowImpl5.qll
+++ b/java/ql/src/semmle/code/java/dataflow/internal/DataFlowImpl5.qll
@@ -905,30 +905,34 @@ private predicate localFlowExit(Node node, Configuration config) {
  */
 pragma[nomagic]
 private predicate localFlowStepPlus(
-  Node node1, Node node2, boolean preservesValue, Configuration config
+  Node node1, Node node2, boolean preservesValue, Configuration config, LocalCallContext cc
 ) {
-  localFlowEntry(node1, config) and
+  not isUnreachableInCall(node2, cc.(LocalCallContextSpecificCall).getCall()) and
   (
-    localFlowStep(node1, node2, config) and preservesValue = true
+    localFlowEntry(node1, config) and
+    (
+      localFlowStep(node1, node2, config) and preservesValue = true
+      or
+      additionalLocalFlowStep(node1, node2, config) and preservesValue = false
+    ) and
+    node1 != node2 and
+    cc.validFor(node1) and
+    nodeCand(node2, unbind(config))
     or
-    additionalLocalFlowStep(node1, node2, config) and preservesValue = false
-  ) and
-  node1 != node2 and
-  nodeCand(node2, unbind(config))
-  or
-  exists(Node mid |
-    localFlowStepPlus(node1, mid, preservesValue, config) and
-    localFlowStep(mid, node2, config) and
-    not mid instanceof CastNode and
-    nodeCand(node2, unbind(config))
-  )
-  or
-  exists(Node mid |
-    localFlowStepPlus(node1, mid, _, config) and
-    additionalLocalFlowStep(mid, node2, config) and
-    not mid instanceof CastNode and
-    preservesValue = false and
-    nodeCand(node2, unbind(config))
+    exists(Node mid |
+      localFlowStepPlus(node1, mid, preservesValue, config, cc) and
+      localFlowStep(mid, node2, config) and
+      not mid instanceof CastNode and
+      nodeCand(node2, unbind(config))
+    )
+    or
+    exists(Node mid |
+      localFlowStepPlus(node1, mid, _, config, cc) and
+      additionalLocalFlowStep(mid, node2, config) and
+      not mid instanceof CastNode and
+      preservesValue = false and
+      nodeCand(node2, unbind(config))
+    )
   )
 }
 
@@ -938,9 +942,9 @@ private predicate localFlowStepPlus(
  */
 pragma[noinline]
 private predicate localFlowBigStep(
-  Node node1, Node node2, boolean preservesValue, Configuration config
+  Node node1, Node node2, boolean preservesValue, Configuration config, LocalCallContext callContext
 ) {
-  localFlowStepPlus(node1, node2, preservesValue, config) and
+  localFlowStepPlus(node1, node2, preservesValue, config, callContext) and
   localFlowExit(node2, config)
 }
 
@@ -1000,7 +1004,7 @@ private class AccessPathFrontNilNode extends Node {
     (
       any(Configuration c).isSource(this)
       or
-      localFlowBigStep(_, this, false, _)
+      localFlowBigStep(_, this, false, _, _)
       or
       additionalJumpStep(_, this, _)
     )
@@ -1023,12 +1027,12 @@ private predicate flowCandFwd0(Node node, boolean fromArg, AccessPathFront apf, 
   (
     exists(Node mid |
       flowCandFwd(mid, fromArg, apf, config) and
-      localFlowBigStep(mid, node, true, config)
+      localFlowBigStep(mid, node, true, config, _)
     )
     or
     exists(Node mid, AccessPathFrontNil nil |
       flowCandFwd(mid, fromArg, nil, config) and
-      localFlowBigStep(mid, node, false, config) and
+      localFlowBigStep(mid, node, false, config, _) and
       apf = node.(AccessPathFrontNilNode).getApf()
     )
     or
@@ -1121,13 +1125,13 @@ private predicate flowCand0(Node node, boolean toReturn, AccessPathFront apf, Co
   apf instanceof AccessPathFrontNil
   or
   exists(Node mid |
-    localFlowBigStep(node, mid, true, config) and
+    localFlowBigStep(node, mid, true, config, _) and
     flowCand(mid, toReturn, apf, config)
   )
   or
   exists(Node mid, AccessPathFrontNil nil |
     flowCandFwd(node, _, apf, config) and
-    localFlowBigStep(node, mid, false, config) and
+    localFlowBigStep(node, mid, false, config, _) and
     flowCand(mid, toReturn, nil, config) and
     apf instanceof AccessPathFrontNil
   )
@@ -1362,12 +1366,12 @@ private predicate flowFwd0(
   (
     exists(Node mid |
       flowFwd(mid, fromArg, apf, ap, config) and
-      localFlowBigStep(mid, node, true, config)
+      localFlowBigStep(mid, node, true, config, _)
     )
     or
     exists(Node mid, AccessPathNil nil |
       flowFwd(mid, fromArg, _, nil, config) and
-      localFlowBigStep(mid, node, false, config) and
+      localFlowBigStep(mid, node, false, config, _) and
       ap = node.(AccessPathNilNode).getAp() and
       apf = ap.(AccessPathNil).getFront()
     )
@@ -1471,13 +1475,13 @@ private predicate flow0(Node node, boolean toReturn, AccessPath ap, Configuratio
   ap instanceof AccessPathNil
   or
   exists(Node mid |
-    localFlowBigStep(node, mid, true, config) and
+    localFlowBigStep(node, mid, true, config, _) and
     flow(mid, toReturn, ap, config)
   )
   or
   exists(Node mid, AccessPathNil nil |
     flowFwd(node, _, _, ap, config) and
-    localFlowBigStep(node, mid, false, config) and
+    localFlowBigStep(node, mid, false, config, _) and
     flow(mid, toReturn, nil, config) and
     ap instanceof AccessPathNil
   )
@@ -1728,37 +1732,42 @@ private class PathNodeSink extends PathNode, TPathNodeSink {
  * a callable is recorded by `cc`.
  */
 private predicate pathStep(PathNodeMid mid, Node node, CallContext cc, AccessPath ap) {
-  localFlowBigStep(mid.getNode(), node, true, mid.getConfiguration()) and
-  cc = mid.getCallContext() and
-  ap = mid.getAp()
+  exists(LocalCallContext localCC | localCC.matchesCallContext(cc) |
+    localFlowBigStep(mid.getNode(), node, true, mid.getConfiguration(), localCC) and
+    cc = mid.getCallContext() and
+    ap = mid.getAp()
+    or
+    localFlowBigStep(mid.getNode(), node, false, mid.getConfiguration(), localCC) and
+    cc = mid.getCallContext() and
+    mid.getAp() instanceof AccessPathNil and
+    ap = node.(AccessPathNilNode).getAp()
+  )
   or
-  localFlowBigStep(mid.getNode(), node, false, mid.getConfiguration()) and
-  cc = mid.getCallContext() and
-  mid.getAp() instanceof AccessPathNil and
-  ap = node.(AccessPathNilNode).getAp()
-  or
-  jumpStep(mid.getNode(), node, mid.getConfiguration()) and
-  cc instanceof CallContextAny and
-  ap = mid.getAp()
-  or
-  additionalJumpStep(mid.getNode(), node, mid.getConfiguration()) and
-  cc instanceof CallContextAny and
-  mid.getAp() instanceof AccessPathNil and
-  ap = node.(AccessPathNilNode).getAp()
-  or
-  contentReadStep(mid, node, ap) and cc = mid.getCallContext()
-  or
-  exists(Content f, AccessPath ap0 | contentStoreStep(mid, node, ap0, f, cc) and push(ap0, f, ap))
-  or
-  pathOutOfArgument(mid, node, cc) and ap = mid.getAp()
-  or
-  pathIntoCallable(mid, node, _, cc, _) and ap = mid.getAp()
-  or
-  pathOutOfCallable(mid, node, cc) and ap = mid.getAp()
-  or
-  pathThroughCallable(mid, node, cc, ap)
-  or
-  valuePathThroughCallable(mid, node, cc) and ap = mid.getAp()
+  not isUnreachableInCall(node, cc.(CallContextSpecificCall).getCall()) and
+  (
+    jumpStep(mid.getNode(), node, mid.getConfiguration()) and
+    cc instanceof CallContextAny and
+    ap = mid.getAp()
+    or
+    additionalJumpStep(mid.getNode(), node, mid.getConfiguration()) and
+    cc instanceof CallContextAny and
+    mid.getAp() instanceof AccessPathNil and
+    ap = node.(AccessPathNilNode).getAp()
+    or
+    contentReadStep(mid, node, ap) and cc = mid.getCallContext()
+    or
+    exists(Content f, AccessPath ap0 | contentStoreStep(mid, node, ap0, f, cc) and push(ap0, f, ap))
+    or
+    pathOutOfArgument(mid, node, cc) and ap = mid.getAp()
+    or
+    pathIntoCallable(mid, node, _, cc, _) and ap = mid.getAp()
+    or
+    pathOutOfCallable(mid, node, cc) and ap = mid.getAp()
+    or
+    pathThroughCallable(mid, node, cc, ap)
+    or
+    valuePathThroughCallable(mid, node, cc) and ap = mid.getAp()
+  )
 }
 
 pragma[noinline]
@@ -1879,7 +1888,7 @@ private predicate pathIntoCallable(
     pathIntoCallable0(mid, callable, i, outercc, call, emptyAp) and
     p.isParameterOf(callable, i)
   |
-    if reducedViableImplInCallContext(_, callable, call)
+    if recordDataFlowCallSite(call, callable)
     then innercc = TSpecificCall(call, i, emptyAp)
     else innercc = TSomeCall(p, emptyAp)
   )
@@ -2377,7 +2386,7 @@ private module FlowExploration {
       partialPathIntoCallable0(mid, callable, i, outercc, call, emptyAp, ap, config) and
       p.isParameterOf(callable, i)
     |
-      if reducedViableImplInCallContext(_, callable, call)
+      if recordDataFlowCallSite(call, callable)
       then innercc = TSpecificCall(call, i, emptyAp)
       else innercc = TSomeCall(p, emptyAp)
     )

--- a/java/ql/src/semmle/code/java/dataflow/internal/DataFlowImplCommon.qll
+++ b/java/ql/src/semmle/code/java/dataflow/internal/DataFlowImplCommon.qll
@@ -100,7 +100,7 @@ private module ImplCommon {
       outercc = TSomeCall(getAParameter(c), _)
       or
       exists(DataFlowCall other | outercc = TSpecificCall(other, _, _) |
-        reducedViableImplInCallContext(_, c, other)
+        recordDataFlowCallSite(other, c)
       )
     )
   }
@@ -125,7 +125,7 @@ private module ImplCommon {
     CallContextCall innercc
   ) {
     exists(int i, DataFlowCallable callable | viableParamArg1(p, callable, i, arg, outercc, call) |
-      if reducedViableImplInCallContext(_, callable, call)
+      if recordDataFlowCallSite(call, callable)
       then innercc = TSpecificCall(call, i, true)
       else innercc = TSomeCall(p, true)
     )
@@ -137,7 +137,7 @@ private module ImplCommon {
     exists(DataFlowCall call, int i, DataFlowCallable callable |
       result = TSpecificCall(call, i, _) and
       p.isParameterOf(callable, i) and
-      reducedViableImplInCallContext(_, callable, call)
+      recordDataFlowCallSite(call, callable)
     )
   }
 
@@ -344,11 +344,21 @@ private module ImplCommon {
     exists(ArgumentNode arg | arg.argumentOf(call, -1))
   }
 
+  /**
+   * Record a call site in the dataflow graph if it either improves
+   * virtual dispatch or if we can remove unreachable edges by recoring this call site
+   */
+  cached
+  predicate recordDataFlowCallSite(DataFlowCall call, DataFlowCallable callable) {
+    reducedViableImplInCallContext(_, callable, call) or
+    exists(Node n | n.getEnclosingCallable() = callable | isUnreachableInCall(n, call))
+  }
+
   cached
   newtype TCallContext =
     TAnyCallContext() or
     TSpecificCall(DataFlowCall call, int i, boolean emptyAp) {
-      reducedViableImplInCallContext(_, _, call) and
+      recordDataFlowCallSite(call, _) and
       (emptyAp = true or emptyAp = false) and
       (
         exists(call.getArgument(i))
@@ -362,8 +372,12 @@ private module ImplCommon {
   cached
   newtype TReturnPosition =
     TReturnPosition0(DataFlowCallable c, ReturnKind kind) { returnPosition(_, c, kind) }
-}
 
+  cached
+  newtype TLocalFlowCallContext =
+    TAnyLocalCall() or
+    TSpecificLocalCall(DataFlowCall call) { isUnreachableInCall(_, call) }
+}
 import ImplCommon
 
 pragma[noinline]
@@ -380,7 +394,8 @@ private predicate returnPosition(ReturnNode ret, DataFlowCallable c, ReturnKind 
  * - `TAnyCallContext()` : No restrictions on method flow.
  * - `TSpecificCall(DataFlowCall call, int i)` : Flow entered through the `i`th
  *    parameter at the given `call`. This call improves the set of viable
- *    dispatch targets for at least one method call in the current callable.
+ *    dispatch targets for at least one method call in the current callable
+ *    or helps pruning unreachable nodes from the data flow graph.
  * - `TSomeCall(ParameterNode p)` : Flow entered through parameter `p`. The
  *    originating call does not improve the set of dispatch targets for any
  *    method call in the current callable and was therefore not recorded.
@@ -404,6 +419,8 @@ class CallContextSpecificCall extends CallContextCall, TSpecificCall {
       result = "CcCall(" + call + ", " + i + ")"
     )
   }
+
+  DataFlowCall getCall() { this = TSpecificCall(result, _, _) }
 }
 
 class CallContextSomeCall extends CallContextCall, TSomeCall {
@@ -416,9 +433,53 @@ class CallContextReturn extends CallContext, TReturn {
   }
 }
 
+/**
+ * A call context which is used to restrict local data flow nodes
+ * to nodes which are actually reachable in a call context.
+ */
+abstract class LocalCallContext extends TLocalFlowCallContext {
+  abstract string toString();
+
+  abstract predicate matchesCallContext(CallContext ctx);
+
+  abstract predicate validFor(Node n);
+}
+
+class LocalCallContextAny extends LocalCallContext, TAnyLocalCall {
+  override string toString() { result = "LocalCcAny" }
+
+  override predicate matchesCallContext(CallContext ctx) {
+    not ctx instanceof CallContextSpecificCall or
+    not exists(TSpecificLocalCall(ctx.(CallContextSpecificCall).getCall()))
+  }
+
+  override predicate validFor(Node n) { any() }
+}
+
+class LocalCallContextSpecificCall extends LocalCallContext, TSpecificLocalCall {
+  LocalCallContextSpecificCall() { this = TSpecificLocalCall(call) }
+
+  DataFlowCall call;
+
+  DataFlowCall getCall() { result = call }
+
+  override string toString() { result = "LocalCcCall(" + call + ")" }
+
+  override predicate matchesCallContext(CallContext ctx) {
+    ctx.(CallContextSpecificCall).getCall() = call
+  }
+
+  override predicate validFor(Node n) {
+    exists(Node n2 |
+      isUnreachableInCall(n2, call) and n2.getEnclosingCallable() = n.getEnclosingCallable()
+    )
+  }
+}
+
 /** A callable tagged with a relevant return kind. */
 class ReturnPosition extends TReturnPosition0 {
   private DataFlowCallable c;
+
   private ReturnKind kind;
 
   ReturnPosition() { this = TReturnPosition0(c, kind) }

--- a/java/ql/src/semmle/code/java/dataflow/internal/DataFlowImplCommon.qll
+++ b/java/ql/src/semmle/code/java/dataflow/internal/DataFlowImplCommon.qll
@@ -458,6 +458,11 @@ class LocalCallContextAny extends LocalCallContext, TAnyLocalCall {
   override predicate validFor(Node n) { any() }
 }
 
+pragma[noinline]
+private predicate hasUnreachableNode(DataFlowCall call, DataFlowCallable callable) {
+  isUnreachableInCall(any(Node n | n.getEnclosingCallable() = callable), call)
+}
+
 class LocalCallContextSpecificCall extends LocalCallContext, TSpecificLocalCall {
   LocalCallContextSpecificCall() { this = TSpecificLocalCall(call) }
 
@@ -472,9 +477,7 @@ class LocalCallContextSpecificCall extends LocalCallContext, TSpecificLocalCall 
   }
 
   override predicate validFor(Node n) {
-    exists(Node n2 |
-      isUnreachableInCall(n2, call) and n2.getEnclosingCallable() = n.getEnclosingCallable()
-    )
+    hasUnreachableNode(call, n.getEnclosingCallable())
   }
 }
 

--- a/java/ql/src/semmle/code/java/dataflow/internal/DataFlowImplCommon.qll
+++ b/java/ql/src/semmle/code/java/dataflow/internal/DataFlowImplCommon.qll
@@ -350,7 +350,8 @@ private module ImplCommon {
    */
   cached
   predicate recordDataFlowCallSite(DataFlowCall call, DataFlowCallable callable) {
-    reducedViableImplInCallContext(_, callable, call) or
+    reducedViableImplInCallContext(_, callable, call)
+    or
     exists(Node n | n.getEnclosingCallable() = callable | isUnreachableInCall(n, call))
   }
 
@@ -378,6 +379,7 @@ private module ImplCommon {
     TAnyLocalCall() or
     TSpecificLocalCall(DataFlowCall call) { isUnreachableInCall(_, call) }
 }
+
 import ImplCommon
 
 pragma[noinline]
@@ -479,7 +481,6 @@ class LocalCallContextSpecificCall extends LocalCallContext, TSpecificLocalCall 
 /** A callable tagged with a relevant return kind. */
 class ReturnPosition extends TReturnPosition0 {
   private DataFlowCallable c;
-
   private ReturnKind kind;
 
   ReturnPosition() { this = TReturnPosition0(c, kind) }

--- a/java/ql/test/library-tests/dataflow/call-sensitivity/A.java
+++ b/java/ql/test/library-tests/dataflow/call-sensitivity/A.java
@@ -1,0 +1,104 @@
+public class A {
+
+	public static void sink(Object o) {
+	}
+
+	public void callSinkIfTrue(Object o, boolean cond) {
+		if (cond) {
+			sink(o);
+		}
+	}
+
+	public void callSinkIfFalse(Object o, boolean cond) {
+		if (!cond) {
+			sink(o);
+		}
+	}
+
+	public void callSinkFromLoop(Object o, boolean cond) {
+		while (cond) {
+			sink(o);
+		}
+	}
+
+	public void localCallSensitivity(Object o, boolean c) {
+		Object o1 = o;
+		Object o2 = null;
+		if (c) {
+			Object tmp = o1;
+			o2 = 1 == 1 ? (tmp) : (tmp);
+		}
+		Object o3 = o2;
+		sink(o3);
+	}
+
+	public void f1() {
+		// should not exhibit flow
+		callSinkIfTrue(new Integer(1), false);
+		callSinkIfFalse(new Integer(2), true);
+		callSinkFromLoop(new Integer(3), false);
+		localCallSensitivity(new Integer(4), false);
+		// should exhibit flow
+		callSinkIfTrue(new Integer(1), true);
+		callSinkIfFalse(new Integer(2), false);
+		callSinkFromLoop(new Integer(3), true);
+		localCallSensitivity(new Integer(4), true);
+	}
+
+	public void f2() {
+		boolean t = true;
+		boolean f = false;
+		// should not exhibit flow
+		callSinkIfTrue(new Integer(4), f);
+		callSinkIfFalse(new Integer(5), t);
+		callSinkFromLoop(new Integer(6), f);
+		localCallSensitivity(new Integer(4), f);
+		// should exhibit flow
+		callSinkIfTrue(new Integer(4), t);
+		callSinkIfFalse(new Integer(5), f);
+		callSinkFromLoop(new Integer(6), t);
+		localCallSensitivity(new Integer(4), t);
+	}
+
+	public void f3(InterfaceA b) {
+		boolean t = true;
+		boolean f = false;
+		// should not exhibit flow
+		b.callSinkIfTrue(new Integer(4), f);
+		b.callSinkIfFalse(new Integer(5), t);
+		b.localCallSensitivity(new Integer(4), f);
+		// should exhibit flow
+		b.callSinkIfTrue(new Integer(4), t);
+		b.callSinkIfFalse(new Integer(5), f);
+		b.localCallSensitivity(new Integer(4), t);
+	}
+
+	class B implements InterfaceA {
+		@Override
+		public void callSinkIfTrue(Object o, boolean cond) {
+			if (cond) {
+				sink(o);
+			}
+		}
+
+		@Override
+		public void callSinkIfFalse(Object o, boolean cond) {
+			if (!cond) {
+				sink(o);
+			}
+		}
+
+		@Override
+		public void localCallSensitivity(Object o, boolean c) {
+			Object o1 = o;
+			Object o2 = null;
+			if (c) {
+				Object tmp = o1;
+				o2 = 1 == 1 ? (tmp) : (tmp);
+			}
+			Object o3 = o2;
+			sink(o3);
+		}
+
+	}
+}

--- a/java/ql/test/library-tests/dataflow/call-sensitivity/A.java
+++ b/java/ql/test/library-tests/dataflow/call-sensitivity/A.java
@@ -32,6 +32,17 @@ public class A {
 		sink(o3);
 	}
 
+	public void localCallSensitivity2(Object o, boolean b, boolean c) {
+		Object o1 = o;
+		Object o2 = null;
+		if (b || c) {
+			Object tmp = o1;
+			o2 = 1 == 1 ? (tmp) : (tmp);
+		}
+		Object o3 = o2;
+		sink(o3);
+	}
+
 	public void f1() {
 		// should not exhibit flow
 		callSinkIfTrue(new Integer(1), false);
@@ -43,6 +54,11 @@ public class A {
 		callSinkIfFalse(new Integer(2), false);
 		callSinkFromLoop(new Integer(3), true);
 		localCallSensitivity(new Integer(4), true);
+		localCallSensitivity2(new Integer(4), true, true);
+		localCallSensitivity2(new Integer(4), false, true);
+		localCallSensitivity2(new Integer(4), true, false);
+		// expected false positive
+		localCallSensitivity2(new Integer(4), false, false);
 	}
 
 	public void f2() {

--- a/java/ql/test/library-tests/dataflow/call-sensitivity/A.java
+++ b/java/ql/test/library-tests/dataflow/call-sensitivity/A.java
@@ -3,6 +3,14 @@ public class A {
 	public static void sink(Object o) {
 	}
 
+	public Object flowThrough(Object o, boolean cond) {
+		if (cond) {
+			return o;
+		} else {
+			return null;
+		}
+	}
+
 	public void callSinkIfTrue(Object o, boolean cond) {
 		if (cond) {
 			sink(o);
@@ -49,6 +57,7 @@ public class A {
 		callSinkIfFalse(new Integer(2), true);
 		callSinkFromLoop(new Integer(3), false);
 		localCallSensitivity(new Integer(4), false);
+		sink(flowThrough(new Integer(4), false));
 		// should exhibit flow
 		callSinkIfTrue(new Integer(1), true);
 		callSinkIfFalse(new Integer(2), false);
@@ -57,6 +66,7 @@ public class A {
 		localCallSensitivity2(new Integer(4), true, true);
 		localCallSensitivity2(new Integer(4), false, true);
 		localCallSensitivity2(new Integer(4), true, false);
+		sink(flowThrough(new Integer(4), true));
 		// expected false positive
 		localCallSensitivity2(new Integer(4), false, false);
 	}
@@ -69,11 +79,13 @@ public class A {
 		callSinkIfFalse(new Integer(5), t);
 		callSinkFromLoop(new Integer(6), f);
 		localCallSensitivity(new Integer(4), f);
+		sink(flowThrough(new Integer(4), f));
 		// should exhibit flow
 		callSinkIfTrue(new Integer(4), t);
 		callSinkIfFalse(new Integer(5), f);
 		callSinkFromLoop(new Integer(6), t);
 		localCallSensitivity(new Integer(4), t);
+		sink(flowThrough(new Integer(4), t));
 	}
 
 	public void f3(InterfaceA b) {

--- a/java/ql/test/library-tests/dataflow/call-sensitivity/A2.java
+++ b/java/ql/test/library-tests/dataflow/call-sensitivity/A2.java
@@ -1,0 +1,42 @@
+public class A2 {
+
+	public static void sink(Object o) {
+	}
+
+	public void m() {
+
+	}
+
+	public void callsite(InterfaceB intF) {
+		B b = new B();
+		// in both possible implementations of foo, this callsite is relevant
+		// in IntA, it improves virtual dispatch,
+		// and in IntB, it improves the dataflow analysis.
+		intF.foo(b, new Integer(5), false);
+	}
+
+	private class B extends A2 {
+		@Override
+		public void m() {
+
+		}
+	}
+
+	private class IntA implements InterfaceB {
+		@Override
+		public void foo(A2 obj, Object o, boolean cond) {
+			obj.m();
+			sink(o);
+		}
+	}
+
+	private class IntB implements InterfaceB {
+		@Override
+		public void foo(A2 obj, Object o, boolean cond) {
+			if (cond) {
+				sink(o);
+			}
+		}
+	}
+
+}

--- a/java/ql/test/library-tests/dataflow/call-sensitivity/InterfaceA.java
+++ b/java/ql/test/library-tests/dataflow/call-sensitivity/InterfaceA.java
@@ -1,0 +1,5 @@
+public interface InterfaceA {
+	public void callSinkIfTrue(Object o, boolean cond);
+	public void callSinkIfFalse(Object o, boolean cond);
+	public void localCallSensitivity(Object o, boolean c);
+}

--- a/java/ql/test/library-tests/dataflow/call-sensitivity/InterfaceB.java
+++ b/java/ql/test/library-tests/dataflow/call-sensitivity/InterfaceB.java
@@ -1,0 +1,3 @@
+public interface InterfaceB {
+	public void foo(A2 a, Object o, boolean cond);
+}

--- a/java/ql/test/library-tests/dataflow/call-sensitivity/flow.expected
+++ b/java/ql/test/library-tests/dataflow/call-sensitivity/flow.expected
@@ -3,20 +3,27 @@ edges
 | A.java:12:30:12:37 | o [ : Number] | A.java:14:9:14:9 | o |
 | A.java:18:31:18:38 | o [ : Number] | A.java:20:9:20:9 | o |
 | A.java:24:35:24:42 | o [ : Number] | A.java:32:8:32:9 | o3 |
-| A.java:42:18:42:31 | new Integer(...) [ : Number] | A.java:6:29:6:36 | o [ : Number] |
-| A.java:43:19:43:32 | new Integer(...) [ : Number] | A.java:12:30:12:37 | o [ : Number] |
-| A.java:44:20:44:33 | new Integer(...) [ : Number] | A.java:18:31:18:38 | o [ : Number] |
-| A.java:45:24:45:37 | new Integer(...) [ : Number] | A.java:24:35:24:42 | o [ : Number] |
-| A.java:57:18:57:31 | new Integer(...) [ : Number] | A.java:6:29:6:36 | o [ : Number] |
-| A.java:58:19:58:32 | new Integer(...) [ : Number] | A.java:12:30:12:37 | o [ : Number] |
-| A.java:59:20:59:33 | new Integer(...) [ : Number] | A.java:18:31:18:38 | o [ : Number] |
-| A.java:60:24:60:37 | new Integer(...) [ : Number] | A.java:24:35:24:42 | o [ : Number] |
-| A.java:71:20:71:33 | new Integer(...) [ : Number] | A.java:78:30:78:37 | o [ : Number] |
-| A.java:72:21:72:34 | new Integer(...) [ : Number] | A.java:85:31:85:38 | o [ : Number] |
-| A.java:73:26:73:39 | new Integer(...) [ : Number] | A.java:92:36:92:43 | o [ : Number] |
-| A.java:78:30:78:37 | o [ : Number] | A.java:80:10:80:10 | o |
-| A.java:85:31:85:38 | o [ : Number] | A.java:87:10:87:10 | o |
-| A.java:92:36:92:43 | o [ : Number] | A.java:100:9:100:10 | o3 |
+| A.java:35:36:35:43 | o [ : Number] | A.java:43:8:43:9 | o3 |
+| A.java:35:36:35:43 | o [ : Number] | A.java:43:8:43:9 | o3 |
+| A.java:35:36:35:43 | o [ : Number] | A.java:43:8:43:9 | o3 |
+| A.java:53:18:53:31 | new Integer(...) [ : Number] | A.java:6:29:6:36 | o [ : Number] |
+| A.java:54:19:54:32 | new Integer(...) [ : Number] | A.java:12:30:12:37 | o [ : Number] |
+| A.java:55:20:55:33 | new Integer(...) [ : Number] | A.java:18:31:18:38 | o [ : Number] |
+| A.java:56:24:56:37 | new Integer(...) [ : Number] | A.java:24:35:24:42 | o [ : Number] |
+| A.java:57:25:57:38 | new Integer(...) [ : Number] | A.java:35:36:35:43 | o [ : Number] |
+| A.java:58:25:58:38 | new Integer(...) [ : Number] | A.java:35:36:35:43 | o [ : Number] |
+| A.java:59:25:59:38 | new Integer(...) [ : Number] | A.java:35:36:35:43 | o [ : Number] |
+| A.java:61:25:61:38 | new Integer(...) [ : Number] | A.java:35:36:35:43 | o [ : Number] |
+| A.java:73:18:73:31 | new Integer(...) [ : Number] | A.java:6:29:6:36 | o [ : Number] |
+| A.java:74:19:74:32 | new Integer(...) [ : Number] | A.java:12:30:12:37 | o [ : Number] |
+| A.java:75:20:75:33 | new Integer(...) [ : Number] | A.java:18:31:18:38 | o [ : Number] |
+| A.java:76:24:76:37 | new Integer(...) [ : Number] | A.java:24:35:24:42 | o [ : Number] |
+| A.java:87:20:87:33 | new Integer(...) [ : Number] | A.java:94:30:94:37 | o [ : Number] |
+| A.java:88:21:88:34 | new Integer(...) [ : Number] | A.java:101:31:101:38 | o [ : Number] |
+| A.java:89:26:89:39 | new Integer(...) [ : Number] | A.java:108:36:108:43 | o [ : Number] |
+| A.java:94:30:94:37 | o [ : Number] | A.java:96:10:96:10 | o |
+| A.java:101:31:101:38 | o [ : Number] | A.java:103:10:103:10 | o |
+| A.java:108:36:108:43 | o [ : Number] | A.java:116:9:116:10 | o3 |
 nodes
 | A.java:6:29:6:36 | o [ : Number] | semmle.label | o [ : Number] |
 | A.java:8:9:8:9 | o | semmle.label | o |
@@ -26,32 +33,44 @@ nodes
 | A.java:20:9:20:9 | o | semmle.label | o |
 | A.java:24:35:24:42 | o [ : Number] | semmle.label | o [ : Number] |
 | A.java:32:8:32:9 | o3 | semmle.label | o3 |
-| A.java:42:18:42:31 | new Integer(...) [ : Number] | semmle.label | new Integer(...) [ : Number] |
-| A.java:43:19:43:32 | new Integer(...) [ : Number] | semmle.label | new Integer(...) [ : Number] |
-| A.java:44:20:44:33 | new Integer(...) [ : Number] | semmle.label | new Integer(...) [ : Number] |
-| A.java:45:24:45:37 | new Integer(...) [ : Number] | semmle.label | new Integer(...) [ : Number] |
-| A.java:57:18:57:31 | new Integer(...) [ : Number] | semmle.label | new Integer(...) [ : Number] |
-| A.java:58:19:58:32 | new Integer(...) [ : Number] | semmle.label | new Integer(...) [ : Number] |
-| A.java:59:20:59:33 | new Integer(...) [ : Number] | semmle.label | new Integer(...) [ : Number] |
-| A.java:60:24:60:37 | new Integer(...) [ : Number] | semmle.label | new Integer(...) [ : Number] |
-| A.java:71:20:71:33 | new Integer(...) [ : Number] | semmle.label | new Integer(...) [ : Number] |
-| A.java:72:21:72:34 | new Integer(...) [ : Number] | semmle.label | new Integer(...) [ : Number] |
-| A.java:73:26:73:39 | new Integer(...) [ : Number] | semmle.label | new Integer(...) [ : Number] |
-| A.java:78:30:78:37 | o [ : Number] | semmle.label | o [ : Number] |
-| A.java:80:10:80:10 | o | semmle.label | o |
-| A.java:85:31:85:38 | o [ : Number] | semmle.label | o [ : Number] |
-| A.java:87:10:87:10 | o | semmle.label | o |
-| A.java:92:36:92:43 | o [ : Number] | semmle.label | o [ : Number] |
-| A.java:100:9:100:10 | o3 | semmle.label | o3 |
+| A.java:35:36:35:43 | o [ : Number] | semmle.label | o [ : Number] |
+| A.java:35:36:35:43 | o [ : Number] | semmle.label | o [ : Number] |
+| A.java:35:36:35:43 | o [ : Number] | semmle.label | o [ : Number] |
+| A.java:43:8:43:9 | o3 | semmle.label | o3 |
+| A.java:53:18:53:31 | new Integer(...) [ : Number] | semmle.label | new Integer(...) [ : Number] |
+| A.java:54:19:54:32 | new Integer(...) [ : Number] | semmle.label | new Integer(...) [ : Number] |
+| A.java:55:20:55:33 | new Integer(...) [ : Number] | semmle.label | new Integer(...) [ : Number] |
+| A.java:56:24:56:37 | new Integer(...) [ : Number] | semmle.label | new Integer(...) [ : Number] |
+| A.java:57:25:57:38 | new Integer(...) [ : Number] | semmle.label | new Integer(...) [ : Number] |
+| A.java:58:25:58:38 | new Integer(...) [ : Number] | semmle.label | new Integer(...) [ : Number] |
+| A.java:59:25:59:38 | new Integer(...) [ : Number] | semmle.label | new Integer(...) [ : Number] |
+| A.java:61:25:61:38 | new Integer(...) [ : Number] | semmle.label | new Integer(...) [ : Number] |
+| A.java:73:18:73:31 | new Integer(...) [ : Number] | semmle.label | new Integer(...) [ : Number] |
+| A.java:74:19:74:32 | new Integer(...) [ : Number] | semmle.label | new Integer(...) [ : Number] |
+| A.java:75:20:75:33 | new Integer(...) [ : Number] | semmle.label | new Integer(...) [ : Number] |
+| A.java:76:24:76:37 | new Integer(...) [ : Number] | semmle.label | new Integer(...) [ : Number] |
+| A.java:87:20:87:33 | new Integer(...) [ : Number] | semmle.label | new Integer(...) [ : Number] |
+| A.java:88:21:88:34 | new Integer(...) [ : Number] | semmle.label | new Integer(...) [ : Number] |
+| A.java:89:26:89:39 | new Integer(...) [ : Number] | semmle.label | new Integer(...) [ : Number] |
+| A.java:94:30:94:37 | o [ : Number] | semmle.label | o [ : Number] |
+| A.java:96:10:96:10 | o | semmle.label | o |
+| A.java:101:31:101:38 | o [ : Number] | semmle.label | o [ : Number] |
+| A.java:103:10:103:10 | o | semmle.label | o |
+| A.java:108:36:108:43 | o [ : Number] | semmle.label | o [ : Number] |
+| A.java:116:9:116:10 | o3 | semmle.label | o3 |
 #select
-| A.java:42:18:42:31 | new Integer(...) [ : Number] | A.java:42:18:42:31 | new Integer(...) [ : Number] | A.java:8:9:8:9 | o | $@ | A.java:8:9:8:9 | o | o |
-| A.java:43:19:43:32 | new Integer(...) [ : Number] | A.java:43:19:43:32 | new Integer(...) [ : Number] | A.java:14:9:14:9 | o | $@ | A.java:14:9:14:9 | o | o |
-| A.java:44:20:44:33 | new Integer(...) [ : Number] | A.java:44:20:44:33 | new Integer(...) [ : Number] | A.java:20:9:20:9 | o | $@ | A.java:20:9:20:9 | o | o |
-| A.java:45:24:45:37 | new Integer(...) [ : Number] | A.java:45:24:45:37 | new Integer(...) [ : Number] | A.java:32:8:32:9 | o3 | $@ | A.java:32:8:32:9 | o3 | o3 |
-| A.java:57:18:57:31 | new Integer(...) [ : Number] | A.java:57:18:57:31 | new Integer(...) [ : Number] | A.java:8:9:8:9 | o | $@ | A.java:8:9:8:9 | o | o |
-| A.java:58:19:58:32 | new Integer(...) [ : Number] | A.java:58:19:58:32 | new Integer(...) [ : Number] | A.java:14:9:14:9 | o | $@ | A.java:14:9:14:9 | o | o |
-| A.java:59:20:59:33 | new Integer(...) [ : Number] | A.java:59:20:59:33 | new Integer(...) [ : Number] | A.java:20:9:20:9 | o | $@ | A.java:20:9:20:9 | o | o |
-| A.java:60:24:60:37 | new Integer(...) [ : Number] | A.java:60:24:60:37 | new Integer(...) [ : Number] | A.java:32:8:32:9 | o3 | $@ | A.java:32:8:32:9 | o3 | o3 |
-| A.java:71:20:71:33 | new Integer(...) [ : Number] | A.java:71:20:71:33 | new Integer(...) [ : Number] | A.java:80:10:80:10 | o | $@ | A.java:80:10:80:10 | o | o |
-| A.java:72:21:72:34 | new Integer(...) [ : Number] | A.java:72:21:72:34 | new Integer(...) [ : Number] | A.java:87:10:87:10 | o | $@ | A.java:87:10:87:10 | o | o |
-| A.java:73:26:73:39 | new Integer(...) [ : Number] | A.java:73:26:73:39 | new Integer(...) [ : Number] | A.java:100:9:100:10 | o3 | $@ | A.java:100:9:100:10 | o3 | o3 |
+| A.java:53:18:53:31 | new Integer(...) [ : Number] | A.java:53:18:53:31 | new Integer(...) [ : Number] | A.java:8:9:8:9 | o | $@ | A.java:8:9:8:9 | o | o |
+| A.java:54:19:54:32 | new Integer(...) [ : Number] | A.java:54:19:54:32 | new Integer(...) [ : Number] | A.java:14:9:14:9 | o | $@ | A.java:14:9:14:9 | o | o |
+| A.java:55:20:55:33 | new Integer(...) [ : Number] | A.java:55:20:55:33 | new Integer(...) [ : Number] | A.java:20:9:20:9 | o | $@ | A.java:20:9:20:9 | o | o |
+| A.java:56:24:56:37 | new Integer(...) [ : Number] | A.java:56:24:56:37 | new Integer(...) [ : Number] | A.java:32:8:32:9 | o3 | $@ | A.java:32:8:32:9 | o3 | o3 |
+| A.java:57:25:57:38 | new Integer(...) [ : Number] | A.java:57:25:57:38 | new Integer(...) [ : Number] | A.java:43:8:43:9 | o3 | $@ | A.java:43:8:43:9 | o3 | o3 |
+| A.java:58:25:58:38 | new Integer(...) [ : Number] | A.java:58:25:58:38 | new Integer(...) [ : Number] | A.java:43:8:43:9 | o3 | $@ | A.java:43:8:43:9 | o3 | o3 |
+| A.java:59:25:59:38 | new Integer(...) [ : Number] | A.java:59:25:59:38 | new Integer(...) [ : Number] | A.java:43:8:43:9 | o3 | $@ | A.java:43:8:43:9 | o3 | o3 |
+| A.java:61:25:61:38 | new Integer(...) [ : Number] | A.java:61:25:61:38 | new Integer(...) [ : Number] | A.java:43:8:43:9 | o3 | $@ | A.java:43:8:43:9 | o3 | o3 |
+| A.java:73:18:73:31 | new Integer(...) [ : Number] | A.java:73:18:73:31 | new Integer(...) [ : Number] | A.java:8:9:8:9 | o | $@ | A.java:8:9:8:9 | o | o |
+| A.java:74:19:74:32 | new Integer(...) [ : Number] | A.java:74:19:74:32 | new Integer(...) [ : Number] | A.java:14:9:14:9 | o | $@ | A.java:14:9:14:9 | o | o |
+| A.java:75:20:75:33 | new Integer(...) [ : Number] | A.java:75:20:75:33 | new Integer(...) [ : Number] | A.java:20:9:20:9 | o | $@ | A.java:20:9:20:9 | o | o |
+| A.java:76:24:76:37 | new Integer(...) [ : Number] | A.java:76:24:76:37 | new Integer(...) [ : Number] | A.java:32:8:32:9 | o3 | $@ | A.java:32:8:32:9 | o3 | o3 |
+| A.java:87:20:87:33 | new Integer(...) [ : Number] | A.java:87:20:87:33 | new Integer(...) [ : Number] | A.java:96:10:96:10 | o | $@ | A.java:96:10:96:10 | o | o |
+| A.java:88:21:88:34 | new Integer(...) [ : Number] | A.java:88:21:88:34 | new Integer(...) [ : Number] | A.java:103:10:103:10 | o | $@ | A.java:103:10:103:10 | o | o |
+| A.java:89:26:89:39 | new Integer(...) [ : Number] | A.java:89:26:89:39 | new Integer(...) [ : Number] | A.java:116:9:116:10 | o3 | $@ | A.java:116:9:116:10 | o3 | o3 |

--- a/java/ql/test/library-tests/dataflow/call-sensitivity/flow.expected
+++ b/java/ql/test/library-tests/dataflow/call-sensitivity/flow.expected
@@ -3,25 +3,14 @@ edges
 | A.java:12:30:12:37 | o [ : Number] | A.java:14:9:14:9 | o |
 | A.java:18:31:18:38 | o [ : Number] | A.java:20:9:20:9 | o |
 | A.java:24:35:24:42 | o [ : Number] | A.java:32:8:32:9 | o3 |
-| A.java:37:18:37:31 | new Integer(...) [ : Number] | A.java:6:29:6:36 | o [ : Number] |
-| A.java:38:19:38:32 | new Integer(...) [ : Number] | A.java:12:30:12:37 | o [ : Number] |
-| A.java:39:20:39:33 | new Integer(...) [ : Number] | A.java:18:31:18:38 | o [ : Number] |
-| A.java:40:24:40:37 | new Integer(...) [ : Number] | A.java:24:35:24:42 | o [ : Number] |
 | A.java:42:18:42:31 | new Integer(...) [ : Number] | A.java:6:29:6:36 | o [ : Number] |
 | A.java:43:19:43:32 | new Integer(...) [ : Number] | A.java:12:30:12:37 | o [ : Number] |
 | A.java:44:20:44:33 | new Integer(...) [ : Number] | A.java:18:31:18:38 | o [ : Number] |
 | A.java:45:24:45:37 | new Integer(...) [ : Number] | A.java:24:35:24:42 | o [ : Number] |
-| A.java:52:18:52:31 | new Integer(...) [ : Number] | A.java:6:29:6:36 | o [ : Number] |
-| A.java:53:19:53:32 | new Integer(...) [ : Number] | A.java:12:30:12:37 | o [ : Number] |
-| A.java:54:20:54:33 | new Integer(...) [ : Number] | A.java:18:31:18:38 | o [ : Number] |
-| A.java:55:24:55:37 | new Integer(...) [ : Number] | A.java:24:35:24:42 | o [ : Number] |
 | A.java:57:18:57:31 | new Integer(...) [ : Number] | A.java:6:29:6:36 | o [ : Number] |
 | A.java:58:19:58:32 | new Integer(...) [ : Number] | A.java:12:30:12:37 | o [ : Number] |
 | A.java:59:20:59:33 | new Integer(...) [ : Number] | A.java:18:31:18:38 | o [ : Number] |
 | A.java:60:24:60:37 | new Integer(...) [ : Number] | A.java:24:35:24:42 | o [ : Number] |
-| A.java:67:20:67:33 | new Integer(...) [ : Number] | A.java:78:30:78:37 | o [ : Number] |
-| A.java:68:21:68:34 | new Integer(...) [ : Number] | A.java:85:31:85:38 | o [ : Number] |
-| A.java:69:26:69:39 | new Integer(...) [ : Number] | A.java:92:36:92:43 | o [ : Number] |
 | A.java:71:20:71:33 | new Integer(...) [ : Number] | A.java:78:30:78:37 | o [ : Number] |
 | A.java:72:21:72:34 | new Integer(...) [ : Number] | A.java:85:31:85:38 | o [ : Number] |
 | A.java:73:26:73:39 | new Integer(...) [ : Number] | A.java:92:36:92:43 | o [ : Number] |
@@ -37,25 +26,14 @@ nodes
 | A.java:20:9:20:9 | o | semmle.label | o |
 | A.java:24:35:24:42 | o [ : Number] | semmle.label | o [ : Number] |
 | A.java:32:8:32:9 | o3 | semmle.label | o3 |
-| A.java:37:18:37:31 | new Integer(...) [ : Number] | semmle.label | new Integer(...) [ : Number] |
-| A.java:38:19:38:32 | new Integer(...) [ : Number] | semmle.label | new Integer(...) [ : Number] |
-| A.java:39:20:39:33 | new Integer(...) [ : Number] | semmle.label | new Integer(...) [ : Number] |
-| A.java:40:24:40:37 | new Integer(...) [ : Number] | semmle.label | new Integer(...) [ : Number] |
 | A.java:42:18:42:31 | new Integer(...) [ : Number] | semmle.label | new Integer(...) [ : Number] |
 | A.java:43:19:43:32 | new Integer(...) [ : Number] | semmle.label | new Integer(...) [ : Number] |
 | A.java:44:20:44:33 | new Integer(...) [ : Number] | semmle.label | new Integer(...) [ : Number] |
 | A.java:45:24:45:37 | new Integer(...) [ : Number] | semmle.label | new Integer(...) [ : Number] |
-| A.java:52:18:52:31 | new Integer(...) [ : Number] | semmle.label | new Integer(...) [ : Number] |
-| A.java:53:19:53:32 | new Integer(...) [ : Number] | semmle.label | new Integer(...) [ : Number] |
-| A.java:54:20:54:33 | new Integer(...) [ : Number] | semmle.label | new Integer(...) [ : Number] |
-| A.java:55:24:55:37 | new Integer(...) [ : Number] | semmle.label | new Integer(...) [ : Number] |
 | A.java:57:18:57:31 | new Integer(...) [ : Number] | semmle.label | new Integer(...) [ : Number] |
 | A.java:58:19:58:32 | new Integer(...) [ : Number] | semmle.label | new Integer(...) [ : Number] |
 | A.java:59:20:59:33 | new Integer(...) [ : Number] | semmle.label | new Integer(...) [ : Number] |
 | A.java:60:24:60:37 | new Integer(...) [ : Number] | semmle.label | new Integer(...) [ : Number] |
-| A.java:67:20:67:33 | new Integer(...) [ : Number] | semmle.label | new Integer(...) [ : Number] |
-| A.java:68:21:68:34 | new Integer(...) [ : Number] | semmle.label | new Integer(...) [ : Number] |
-| A.java:69:26:69:39 | new Integer(...) [ : Number] | semmle.label | new Integer(...) [ : Number] |
 | A.java:71:20:71:33 | new Integer(...) [ : Number] | semmle.label | new Integer(...) [ : Number] |
 | A.java:72:21:72:34 | new Integer(...) [ : Number] | semmle.label | new Integer(...) [ : Number] |
 | A.java:73:26:73:39 | new Integer(...) [ : Number] | semmle.label | new Integer(...) [ : Number] |
@@ -66,25 +44,14 @@ nodes
 | A.java:92:36:92:43 | o [ : Number] | semmle.label | o [ : Number] |
 | A.java:100:9:100:10 | o3 | semmle.label | o3 |
 #select
-| A.java:37:18:37:31 | new Integer(...) [ : Number] | A.java:37:18:37:31 | new Integer(...) [ : Number] | A.java:8:9:8:9 | o | $@ | A.java:8:9:8:9 | o | o |
-| A.java:38:19:38:32 | new Integer(...) [ : Number] | A.java:38:19:38:32 | new Integer(...) [ : Number] | A.java:14:9:14:9 | o | $@ | A.java:14:9:14:9 | o | o |
-| A.java:39:20:39:33 | new Integer(...) [ : Number] | A.java:39:20:39:33 | new Integer(...) [ : Number] | A.java:20:9:20:9 | o | $@ | A.java:20:9:20:9 | o | o |
-| A.java:40:24:40:37 | new Integer(...) [ : Number] | A.java:40:24:40:37 | new Integer(...) [ : Number] | A.java:32:8:32:9 | o3 | $@ | A.java:32:8:32:9 | o3 | o3 |
 | A.java:42:18:42:31 | new Integer(...) [ : Number] | A.java:42:18:42:31 | new Integer(...) [ : Number] | A.java:8:9:8:9 | o | $@ | A.java:8:9:8:9 | o | o |
 | A.java:43:19:43:32 | new Integer(...) [ : Number] | A.java:43:19:43:32 | new Integer(...) [ : Number] | A.java:14:9:14:9 | o | $@ | A.java:14:9:14:9 | o | o |
 | A.java:44:20:44:33 | new Integer(...) [ : Number] | A.java:44:20:44:33 | new Integer(...) [ : Number] | A.java:20:9:20:9 | o | $@ | A.java:20:9:20:9 | o | o |
 | A.java:45:24:45:37 | new Integer(...) [ : Number] | A.java:45:24:45:37 | new Integer(...) [ : Number] | A.java:32:8:32:9 | o3 | $@ | A.java:32:8:32:9 | o3 | o3 |
-| A.java:52:18:52:31 | new Integer(...) [ : Number] | A.java:52:18:52:31 | new Integer(...) [ : Number] | A.java:8:9:8:9 | o | $@ | A.java:8:9:8:9 | o | o |
-| A.java:53:19:53:32 | new Integer(...) [ : Number] | A.java:53:19:53:32 | new Integer(...) [ : Number] | A.java:14:9:14:9 | o | $@ | A.java:14:9:14:9 | o | o |
-| A.java:54:20:54:33 | new Integer(...) [ : Number] | A.java:54:20:54:33 | new Integer(...) [ : Number] | A.java:20:9:20:9 | o | $@ | A.java:20:9:20:9 | o | o |
-| A.java:55:24:55:37 | new Integer(...) [ : Number] | A.java:55:24:55:37 | new Integer(...) [ : Number] | A.java:32:8:32:9 | o3 | $@ | A.java:32:8:32:9 | o3 | o3 |
 | A.java:57:18:57:31 | new Integer(...) [ : Number] | A.java:57:18:57:31 | new Integer(...) [ : Number] | A.java:8:9:8:9 | o | $@ | A.java:8:9:8:9 | o | o |
 | A.java:58:19:58:32 | new Integer(...) [ : Number] | A.java:58:19:58:32 | new Integer(...) [ : Number] | A.java:14:9:14:9 | o | $@ | A.java:14:9:14:9 | o | o |
 | A.java:59:20:59:33 | new Integer(...) [ : Number] | A.java:59:20:59:33 | new Integer(...) [ : Number] | A.java:20:9:20:9 | o | $@ | A.java:20:9:20:9 | o | o |
 | A.java:60:24:60:37 | new Integer(...) [ : Number] | A.java:60:24:60:37 | new Integer(...) [ : Number] | A.java:32:8:32:9 | o3 | $@ | A.java:32:8:32:9 | o3 | o3 |
-| A.java:67:20:67:33 | new Integer(...) [ : Number] | A.java:67:20:67:33 | new Integer(...) [ : Number] | A.java:80:10:80:10 | o | $@ | A.java:80:10:80:10 | o | o |
-| A.java:68:21:68:34 | new Integer(...) [ : Number] | A.java:68:21:68:34 | new Integer(...) [ : Number] | A.java:87:10:87:10 | o | $@ | A.java:87:10:87:10 | o | o |
-| A.java:69:26:69:39 | new Integer(...) [ : Number] | A.java:69:26:69:39 | new Integer(...) [ : Number] | A.java:100:9:100:10 | o3 | $@ | A.java:100:9:100:10 | o3 | o3 |
 | A.java:71:20:71:33 | new Integer(...) [ : Number] | A.java:71:20:71:33 | new Integer(...) [ : Number] | A.java:80:10:80:10 | o | $@ | A.java:80:10:80:10 | o | o |
 | A.java:72:21:72:34 | new Integer(...) [ : Number] | A.java:72:21:72:34 | new Integer(...) [ : Number] | A.java:87:10:87:10 | o | $@ | A.java:87:10:87:10 | o | o |
 | A.java:73:26:73:39 | new Integer(...) [ : Number] | A.java:73:26:73:39 | new Integer(...) [ : Number] | A.java:100:9:100:10 | o3 | $@ | A.java:100:9:100:10 | o3 | o3 |

--- a/java/ql/test/library-tests/dataflow/call-sensitivity/flow.expected
+++ b/java/ql/test/library-tests/dataflow/call-sensitivity/flow.expected
@@ -1,0 +1,90 @@
+edges
+| A.java:6:29:6:36 | o [ : Number] | A.java:8:9:8:9 | o |
+| A.java:12:30:12:37 | o [ : Number] | A.java:14:9:14:9 | o |
+| A.java:18:31:18:38 | o [ : Number] | A.java:20:9:20:9 | o |
+| A.java:24:35:24:42 | o [ : Number] | A.java:32:8:32:9 | o3 |
+| A.java:37:18:37:31 | new Integer(...) [ : Number] | A.java:6:29:6:36 | o [ : Number] |
+| A.java:38:19:38:32 | new Integer(...) [ : Number] | A.java:12:30:12:37 | o [ : Number] |
+| A.java:39:20:39:33 | new Integer(...) [ : Number] | A.java:18:31:18:38 | o [ : Number] |
+| A.java:40:24:40:37 | new Integer(...) [ : Number] | A.java:24:35:24:42 | o [ : Number] |
+| A.java:42:18:42:31 | new Integer(...) [ : Number] | A.java:6:29:6:36 | o [ : Number] |
+| A.java:43:19:43:32 | new Integer(...) [ : Number] | A.java:12:30:12:37 | o [ : Number] |
+| A.java:44:20:44:33 | new Integer(...) [ : Number] | A.java:18:31:18:38 | o [ : Number] |
+| A.java:45:24:45:37 | new Integer(...) [ : Number] | A.java:24:35:24:42 | o [ : Number] |
+| A.java:52:18:52:31 | new Integer(...) [ : Number] | A.java:6:29:6:36 | o [ : Number] |
+| A.java:53:19:53:32 | new Integer(...) [ : Number] | A.java:12:30:12:37 | o [ : Number] |
+| A.java:54:20:54:33 | new Integer(...) [ : Number] | A.java:18:31:18:38 | o [ : Number] |
+| A.java:55:24:55:37 | new Integer(...) [ : Number] | A.java:24:35:24:42 | o [ : Number] |
+| A.java:57:18:57:31 | new Integer(...) [ : Number] | A.java:6:29:6:36 | o [ : Number] |
+| A.java:58:19:58:32 | new Integer(...) [ : Number] | A.java:12:30:12:37 | o [ : Number] |
+| A.java:59:20:59:33 | new Integer(...) [ : Number] | A.java:18:31:18:38 | o [ : Number] |
+| A.java:60:24:60:37 | new Integer(...) [ : Number] | A.java:24:35:24:42 | o [ : Number] |
+| A.java:67:20:67:33 | new Integer(...) [ : Number] | A.java:78:30:78:37 | o [ : Number] |
+| A.java:68:21:68:34 | new Integer(...) [ : Number] | A.java:85:31:85:38 | o [ : Number] |
+| A.java:69:26:69:39 | new Integer(...) [ : Number] | A.java:92:36:92:43 | o [ : Number] |
+| A.java:71:20:71:33 | new Integer(...) [ : Number] | A.java:78:30:78:37 | o [ : Number] |
+| A.java:72:21:72:34 | new Integer(...) [ : Number] | A.java:85:31:85:38 | o [ : Number] |
+| A.java:73:26:73:39 | new Integer(...) [ : Number] | A.java:92:36:92:43 | o [ : Number] |
+| A.java:78:30:78:37 | o [ : Number] | A.java:80:10:80:10 | o |
+| A.java:85:31:85:38 | o [ : Number] | A.java:87:10:87:10 | o |
+| A.java:92:36:92:43 | o [ : Number] | A.java:100:9:100:10 | o3 |
+nodes
+| A.java:6:29:6:36 | o [ : Number] | semmle.label | o [ : Number] |
+| A.java:8:9:8:9 | o | semmle.label | o |
+| A.java:12:30:12:37 | o [ : Number] | semmle.label | o [ : Number] |
+| A.java:14:9:14:9 | o | semmle.label | o |
+| A.java:18:31:18:38 | o [ : Number] | semmle.label | o [ : Number] |
+| A.java:20:9:20:9 | o | semmle.label | o |
+| A.java:24:35:24:42 | o [ : Number] | semmle.label | o [ : Number] |
+| A.java:32:8:32:9 | o3 | semmle.label | o3 |
+| A.java:37:18:37:31 | new Integer(...) [ : Number] | semmle.label | new Integer(...) [ : Number] |
+| A.java:38:19:38:32 | new Integer(...) [ : Number] | semmle.label | new Integer(...) [ : Number] |
+| A.java:39:20:39:33 | new Integer(...) [ : Number] | semmle.label | new Integer(...) [ : Number] |
+| A.java:40:24:40:37 | new Integer(...) [ : Number] | semmle.label | new Integer(...) [ : Number] |
+| A.java:42:18:42:31 | new Integer(...) [ : Number] | semmle.label | new Integer(...) [ : Number] |
+| A.java:43:19:43:32 | new Integer(...) [ : Number] | semmle.label | new Integer(...) [ : Number] |
+| A.java:44:20:44:33 | new Integer(...) [ : Number] | semmle.label | new Integer(...) [ : Number] |
+| A.java:45:24:45:37 | new Integer(...) [ : Number] | semmle.label | new Integer(...) [ : Number] |
+| A.java:52:18:52:31 | new Integer(...) [ : Number] | semmle.label | new Integer(...) [ : Number] |
+| A.java:53:19:53:32 | new Integer(...) [ : Number] | semmle.label | new Integer(...) [ : Number] |
+| A.java:54:20:54:33 | new Integer(...) [ : Number] | semmle.label | new Integer(...) [ : Number] |
+| A.java:55:24:55:37 | new Integer(...) [ : Number] | semmle.label | new Integer(...) [ : Number] |
+| A.java:57:18:57:31 | new Integer(...) [ : Number] | semmle.label | new Integer(...) [ : Number] |
+| A.java:58:19:58:32 | new Integer(...) [ : Number] | semmle.label | new Integer(...) [ : Number] |
+| A.java:59:20:59:33 | new Integer(...) [ : Number] | semmle.label | new Integer(...) [ : Number] |
+| A.java:60:24:60:37 | new Integer(...) [ : Number] | semmle.label | new Integer(...) [ : Number] |
+| A.java:67:20:67:33 | new Integer(...) [ : Number] | semmle.label | new Integer(...) [ : Number] |
+| A.java:68:21:68:34 | new Integer(...) [ : Number] | semmle.label | new Integer(...) [ : Number] |
+| A.java:69:26:69:39 | new Integer(...) [ : Number] | semmle.label | new Integer(...) [ : Number] |
+| A.java:71:20:71:33 | new Integer(...) [ : Number] | semmle.label | new Integer(...) [ : Number] |
+| A.java:72:21:72:34 | new Integer(...) [ : Number] | semmle.label | new Integer(...) [ : Number] |
+| A.java:73:26:73:39 | new Integer(...) [ : Number] | semmle.label | new Integer(...) [ : Number] |
+| A.java:78:30:78:37 | o [ : Number] | semmle.label | o [ : Number] |
+| A.java:80:10:80:10 | o | semmle.label | o |
+| A.java:85:31:85:38 | o [ : Number] | semmle.label | o [ : Number] |
+| A.java:87:10:87:10 | o | semmle.label | o |
+| A.java:92:36:92:43 | o [ : Number] | semmle.label | o [ : Number] |
+| A.java:100:9:100:10 | o3 | semmle.label | o3 |
+#select
+| A.java:37:18:37:31 | new Integer(...) [ : Number] | A.java:37:18:37:31 | new Integer(...) [ : Number] | A.java:8:9:8:9 | o | $@ | A.java:8:9:8:9 | o | o |
+| A.java:38:19:38:32 | new Integer(...) [ : Number] | A.java:38:19:38:32 | new Integer(...) [ : Number] | A.java:14:9:14:9 | o | $@ | A.java:14:9:14:9 | o | o |
+| A.java:39:20:39:33 | new Integer(...) [ : Number] | A.java:39:20:39:33 | new Integer(...) [ : Number] | A.java:20:9:20:9 | o | $@ | A.java:20:9:20:9 | o | o |
+| A.java:40:24:40:37 | new Integer(...) [ : Number] | A.java:40:24:40:37 | new Integer(...) [ : Number] | A.java:32:8:32:9 | o3 | $@ | A.java:32:8:32:9 | o3 | o3 |
+| A.java:42:18:42:31 | new Integer(...) [ : Number] | A.java:42:18:42:31 | new Integer(...) [ : Number] | A.java:8:9:8:9 | o | $@ | A.java:8:9:8:9 | o | o |
+| A.java:43:19:43:32 | new Integer(...) [ : Number] | A.java:43:19:43:32 | new Integer(...) [ : Number] | A.java:14:9:14:9 | o | $@ | A.java:14:9:14:9 | o | o |
+| A.java:44:20:44:33 | new Integer(...) [ : Number] | A.java:44:20:44:33 | new Integer(...) [ : Number] | A.java:20:9:20:9 | o | $@ | A.java:20:9:20:9 | o | o |
+| A.java:45:24:45:37 | new Integer(...) [ : Number] | A.java:45:24:45:37 | new Integer(...) [ : Number] | A.java:32:8:32:9 | o3 | $@ | A.java:32:8:32:9 | o3 | o3 |
+| A.java:52:18:52:31 | new Integer(...) [ : Number] | A.java:52:18:52:31 | new Integer(...) [ : Number] | A.java:8:9:8:9 | o | $@ | A.java:8:9:8:9 | o | o |
+| A.java:53:19:53:32 | new Integer(...) [ : Number] | A.java:53:19:53:32 | new Integer(...) [ : Number] | A.java:14:9:14:9 | o | $@ | A.java:14:9:14:9 | o | o |
+| A.java:54:20:54:33 | new Integer(...) [ : Number] | A.java:54:20:54:33 | new Integer(...) [ : Number] | A.java:20:9:20:9 | o | $@ | A.java:20:9:20:9 | o | o |
+| A.java:55:24:55:37 | new Integer(...) [ : Number] | A.java:55:24:55:37 | new Integer(...) [ : Number] | A.java:32:8:32:9 | o3 | $@ | A.java:32:8:32:9 | o3 | o3 |
+| A.java:57:18:57:31 | new Integer(...) [ : Number] | A.java:57:18:57:31 | new Integer(...) [ : Number] | A.java:8:9:8:9 | o | $@ | A.java:8:9:8:9 | o | o |
+| A.java:58:19:58:32 | new Integer(...) [ : Number] | A.java:58:19:58:32 | new Integer(...) [ : Number] | A.java:14:9:14:9 | o | $@ | A.java:14:9:14:9 | o | o |
+| A.java:59:20:59:33 | new Integer(...) [ : Number] | A.java:59:20:59:33 | new Integer(...) [ : Number] | A.java:20:9:20:9 | o | $@ | A.java:20:9:20:9 | o | o |
+| A.java:60:24:60:37 | new Integer(...) [ : Number] | A.java:60:24:60:37 | new Integer(...) [ : Number] | A.java:32:8:32:9 | o3 | $@ | A.java:32:8:32:9 | o3 | o3 |
+| A.java:67:20:67:33 | new Integer(...) [ : Number] | A.java:67:20:67:33 | new Integer(...) [ : Number] | A.java:80:10:80:10 | o | $@ | A.java:80:10:80:10 | o | o |
+| A.java:68:21:68:34 | new Integer(...) [ : Number] | A.java:68:21:68:34 | new Integer(...) [ : Number] | A.java:87:10:87:10 | o | $@ | A.java:87:10:87:10 | o | o |
+| A.java:69:26:69:39 | new Integer(...) [ : Number] | A.java:69:26:69:39 | new Integer(...) [ : Number] | A.java:100:9:100:10 | o3 | $@ | A.java:100:9:100:10 | o3 | o3 |
+| A.java:71:20:71:33 | new Integer(...) [ : Number] | A.java:71:20:71:33 | new Integer(...) [ : Number] | A.java:80:10:80:10 | o | $@ | A.java:80:10:80:10 | o | o |
+| A.java:72:21:72:34 | new Integer(...) [ : Number] | A.java:72:21:72:34 | new Integer(...) [ : Number] | A.java:87:10:87:10 | o | $@ | A.java:87:10:87:10 | o | o |
+| A.java:73:26:73:39 | new Integer(...) [ : Number] | A.java:73:26:73:39 | new Integer(...) [ : Number] | A.java:100:9:100:10 | o3 | $@ | A.java:100:9:100:10 | o3 | o3 |

--- a/java/ql/test/library-tests/dataflow/call-sensitivity/flow.expected
+++ b/java/ql/test/library-tests/dataflow/call-sensitivity/flow.expected
@@ -1,76 +1,91 @@
 edges
-| A.java:6:29:6:36 | o [ : Number] | A.java:8:9:8:9 | o |
-| A.java:12:30:12:37 | o [ : Number] | A.java:14:9:14:9 | o |
-| A.java:18:31:18:38 | o [ : Number] | A.java:20:9:20:9 | o |
-| A.java:24:35:24:42 | o [ : Number] | A.java:32:8:32:9 | o3 |
-| A.java:35:36:35:43 | o [ : Number] | A.java:43:8:43:9 | o3 |
-| A.java:35:36:35:43 | o [ : Number] | A.java:43:8:43:9 | o3 |
-| A.java:35:36:35:43 | o [ : Number] | A.java:43:8:43:9 | o3 |
-| A.java:53:18:53:31 | new Integer(...) [ : Number] | A.java:6:29:6:36 | o [ : Number] |
-| A.java:54:19:54:32 | new Integer(...) [ : Number] | A.java:12:30:12:37 | o [ : Number] |
-| A.java:55:20:55:33 | new Integer(...) [ : Number] | A.java:18:31:18:38 | o [ : Number] |
-| A.java:56:24:56:37 | new Integer(...) [ : Number] | A.java:24:35:24:42 | o [ : Number] |
-| A.java:57:25:57:38 | new Integer(...) [ : Number] | A.java:35:36:35:43 | o [ : Number] |
-| A.java:58:25:58:38 | new Integer(...) [ : Number] | A.java:35:36:35:43 | o [ : Number] |
-| A.java:59:25:59:38 | new Integer(...) [ : Number] | A.java:35:36:35:43 | o [ : Number] |
-| A.java:61:25:61:38 | new Integer(...) [ : Number] | A.java:35:36:35:43 | o [ : Number] |
-| A.java:73:18:73:31 | new Integer(...) [ : Number] | A.java:6:29:6:36 | o [ : Number] |
-| A.java:74:19:74:32 | new Integer(...) [ : Number] | A.java:12:30:12:37 | o [ : Number] |
-| A.java:75:20:75:33 | new Integer(...) [ : Number] | A.java:18:31:18:38 | o [ : Number] |
-| A.java:76:24:76:37 | new Integer(...) [ : Number] | A.java:24:35:24:42 | o [ : Number] |
-| A.java:87:20:87:33 | new Integer(...) [ : Number] | A.java:94:30:94:37 | o [ : Number] |
-| A.java:88:21:88:34 | new Integer(...) [ : Number] | A.java:101:31:101:38 | o [ : Number] |
-| A.java:89:26:89:39 | new Integer(...) [ : Number] | A.java:108:36:108:43 | o [ : Number] |
-| A.java:94:30:94:37 | o [ : Number] | A.java:96:10:96:10 | o |
-| A.java:101:31:101:38 | o [ : Number] | A.java:103:10:103:10 | o |
-| A.java:108:36:108:43 | o [ : Number] | A.java:116:9:116:10 | o3 |
+| A2.java:15:15:15:28 | new Integer(...) [ : Number] | A2.java:27:27:27:34 | o [ : Number] |
+| A2.java:27:27:27:34 | o [ : Number] | A2.java:29:9:29:9 | o |
+| A.java:14:29:14:36 | o [ : Number] | A.java:16:9:16:9 | o |
+| A.java:20:30:20:37 | o [ : Number] | A.java:22:9:22:9 | o |
+| A.java:26:31:26:38 | o [ : Number] | A.java:28:9:28:9 | o |
+| A.java:32:35:32:42 | o [ : Number] | A.java:40:8:40:9 | o3 |
+| A.java:43:36:43:43 | o [ : Number] | A.java:51:8:51:9 | o3 |
+| A.java:43:36:43:43 | o [ : Number] | A.java:51:8:51:9 | o3 |
+| A.java:43:36:43:43 | o [ : Number] | A.java:51:8:51:9 | o3 |
+| A.java:62:18:62:31 | new Integer(...) [ : Number] | A.java:14:29:14:36 | o [ : Number] |
+| A.java:63:19:63:32 | new Integer(...) [ : Number] | A.java:20:30:20:37 | o [ : Number] |
+| A.java:64:20:64:33 | new Integer(...) [ : Number] | A.java:26:31:26:38 | o [ : Number] |
+| A.java:65:24:65:37 | new Integer(...) [ : Number] | A.java:32:35:32:42 | o [ : Number] |
+| A.java:66:25:66:38 | new Integer(...) [ : Number] | A.java:43:36:43:43 | o [ : Number] |
+| A.java:67:25:67:38 | new Integer(...) [ : Number] | A.java:43:36:43:43 | o [ : Number] |
+| A.java:68:25:68:38 | new Integer(...) [ : Number] | A.java:43:36:43:43 | o [ : Number] |
+| A.java:69:20:69:33 | new Integer(...) [ : Number] | A.java:69:8:69:40 | flowThrough(...) |
+| A.java:71:25:71:38 | new Integer(...) [ : Number] | A.java:43:36:43:43 | o [ : Number] |
+| A.java:84:18:84:31 | new Integer(...) [ : Number] | A.java:14:29:14:36 | o [ : Number] |
+| A.java:85:19:85:32 | new Integer(...) [ : Number] | A.java:20:30:20:37 | o [ : Number] |
+| A.java:86:20:86:33 | new Integer(...) [ : Number] | A.java:26:31:26:38 | o [ : Number] |
+| A.java:87:24:87:37 | new Integer(...) [ : Number] | A.java:32:35:32:42 | o [ : Number] |
+| A.java:88:20:88:33 | new Integer(...) [ : Number] | A.java:88:8:88:37 | flowThrough(...) |
+| A.java:99:20:99:33 | new Integer(...) [ : Number] | A.java:106:30:106:37 | o [ : Number] |
+| A.java:100:21:100:34 | new Integer(...) [ : Number] | A.java:113:31:113:38 | o [ : Number] |
+| A.java:101:26:101:39 | new Integer(...) [ : Number] | A.java:120:36:120:43 | o [ : Number] |
+| A.java:106:30:106:37 | o [ : Number] | A.java:108:10:108:10 | o |
+| A.java:113:31:113:38 | o [ : Number] | A.java:115:10:115:10 | o |
+| A.java:120:36:120:43 | o [ : Number] | A.java:128:9:128:10 | o3 |
 nodes
-| A.java:6:29:6:36 | o [ : Number] | semmle.label | o [ : Number] |
-| A.java:8:9:8:9 | o | semmle.label | o |
-| A.java:12:30:12:37 | o [ : Number] | semmle.label | o [ : Number] |
-| A.java:14:9:14:9 | o | semmle.label | o |
-| A.java:18:31:18:38 | o [ : Number] | semmle.label | o [ : Number] |
-| A.java:20:9:20:9 | o | semmle.label | o |
-| A.java:24:35:24:42 | o [ : Number] | semmle.label | o [ : Number] |
-| A.java:32:8:32:9 | o3 | semmle.label | o3 |
-| A.java:35:36:35:43 | o [ : Number] | semmle.label | o [ : Number] |
-| A.java:35:36:35:43 | o [ : Number] | semmle.label | o [ : Number] |
-| A.java:35:36:35:43 | o [ : Number] | semmle.label | o [ : Number] |
-| A.java:43:8:43:9 | o3 | semmle.label | o3 |
-| A.java:53:18:53:31 | new Integer(...) [ : Number] | semmle.label | new Integer(...) [ : Number] |
-| A.java:54:19:54:32 | new Integer(...) [ : Number] | semmle.label | new Integer(...) [ : Number] |
-| A.java:55:20:55:33 | new Integer(...) [ : Number] | semmle.label | new Integer(...) [ : Number] |
-| A.java:56:24:56:37 | new Integer(...) [ : Number] | semmle.label | new Integer(...) [ : Number] |
-| A.java:57:25:57:38 | new Integer(...) [ : Number] | semmle.label | new Integer(...) [ : Number] |
-| A.java:58:25:58:38 | new Integer(...) [ : Number] | semmle.label | new Integer(...) [ : Number] |
-| A.java:59:25:59:38 | new Integer(...) [ : Number] | semmle.label | new Integer(...) [ : Number] |
-| A.java:61:25:61:38 | new Integer(...) [ : Number] | semmle.label | new Integer(...) [ : Number] |
-| A.java:73:18:73:31 | new Integer(...) [ : Number] | semmle.label | new Integer(...) [ : Number] |
-| A.java:74:19:74:32 | new Integer(...) [ : Number] | semmle.label | new Integer(...) [ : Number] |
-| A.java:75:20:75:33 | new Integer(...) [ : Number] | semmle.label | new Integer(...) [ : Number] |
-| A.java:76:24:76:37 | new Integer(...) [ : Number] | semmle.label | new Integer(...) [ : Number] |
-| A.java:87:20:87:33 | new Integer(...) [ : Number] | semmle.label | new Integer(...) [ : Number] |
-| A.java:88:21:88:34 | new Integer(...) [ : Number] | semmle.label | new Integer(...) [ : Number] |
-| A.java:89:26:89:39 | new Integer(...) [ : Number] | semmle.label | new Integer(...) [ : Number] |
-| A.java:94:30:94:37 | o [ : Number] | semmle.label | o [ : Number] |
-| A.java:96:10:96:10 | o | semmle.label | o |
-| A.java:101:31:101:38 | o [ : Number] | semmle.label | o [ : Number] |
-| A.java:103:10:103:10 | o | semmle.label | o |
-| A.java:108:36:108:43 | o [ : Number] | semmle.label | o [ : Number] |
-| A.java:116:9:116:10 | o3 | semmle.label | o3 |
+| A2.java:15:15:15:28 | new Integer(...) [ : Number] | semmle.label | new Integer(...) [ : Number] |
+| A2.java:27:27:27:34 | o [ : Number] | semmle.label | o [ : Number] |
+| A2.java:29:9:29:9 | o | semmle.label | o |
+| A2.java:37:10:37:10 | o | semmle.label | o |
+| A.java:14:29:14:36 | o [ : Number] | semmle.label | o [ : Number] |
+| A.java:16:9:16:9 | o | semmle.label | o |
+| A.java:20:30:20:37 | o [ : Number] | semmle.label | o [ : Number] |
+| A.java:22:9:22:9 | o | semmle.label | o |
+| A.java:26:31:26:38 | o [ : Number] | semmle.label | o [ : Number] |
+| A.java:28:9:28:9 | o | semmle.label | o |
+| A.java:32:35:32:42 | o [ : Number] | semmle.label | o [ : Number] |
+| A.java:40:8:40:9 | o3 | semmle.label | o3 |
+| A.java:43:36:43:43 | o [ : Number] | semmle.label | o [ : Number] |
+| A.java:43:36:43:43 | o [ : Number] | semmle.label | o [ : Number] |
+| A.java:43:36:43:43 | o [ : Number] | semmle.label | o [ : Number] |
+| A.java:51:8:51:9 | o3 | semmle.label | o3 |
+| A.java:62:18:62:31 | new Integer(...) [ : Number] | semmle.label | new Integer(...) [ : Number] |
+| A.java:63:19:63:32 | new Integer(...) [ : Number] | semmle.label | new Integer(...) [ : Number] |
+| A.java:64:20:64:33 | new Integer(...) [ : Number] | semmle.label | new Integer(...) [ : Number] |
+| A.java:65:24:65:37 | new Integer(...) [ : Number] | semmle.label | new Integer(...) [ : Number] |
+| A.java:66:25:66:38 | new Integer(...) [ : Number] | semmle.label | new Integer(...) [ : Number] |
+| A.java:67:25:67:38 | new Integer(...) [ : Number] | semmle.label | new Integer(...) [ : Number] |
+| A.java:68:25:68:38 | new Integer(...) [ : Number] | semmle.label | new Integer(...) [ : Number] |
+| A.java:69:8:69:40 | flowThrough(...) | semmle.label | flowThrough(...) |
+| A.java:69:20:69:33 | new Integer(...) [ : Number] | semmle.label | new Integer(...) [ : Number] |
+| A.java:71:25:71:38 | new Integer(...) [ : Number] | semmle.label | new Integer(...) [ : Number] |
+| A.java:84:18:84:31 | new Integer(...) [ : Number] | semmle.label | new Integer(...) [ : Number] |
+| A.java:85:19:85:32 | new Integer(...) [ : Number] | semmle.label | new Integer(...) [ : Number] |
+| A.java:86:20:86:33 | new Integer(...) [ : Number] | semmle.label | new Integer(...) [ : Number] |
+| A.java:87:24:87:37 | new Integer(...) [ : Number] | semmle.label | new Integer(...) [ : Number] |
+| A.java:88:8:88:37 | flowThrough(...) | semmle.label | flowThrough(...) |
+| A.java:88:20:88:33 | new Integer(...) [ : Number] | semmle.label | new Integer(...) [ : Number] |
+| A.java:99:20:99:33 | new Integer(...) [ : Number] | semmle.label | new Integer(...) [ : Number] |
+| A.java:100:21:100:34 | new Integer(...) [ : Number] | semmle.label | new Integer(...) [ : Number] |
+| A.java:101:26:101:39 | new Integer(...) [ : Number] | semmle.label | new Integer(...) [ : Number] |
+| A.java:106:30:106:37 | o [ : Number] | semmle.label | o [ : Number] |
+| A.java:108:10:108:10 | o | semmle.label | o |
+| A.java:113:31:113:38 | o [ : Number] | semmle.label | o [ : Number] |
+| A.java:115:10:115:10 | o | semmle.label | o |
+| A.java:120:36:120:43 | o [ : Number] | semmle.label | o [ : Number] |
+| A.java:128:9:128:10 | o3 | semmle.label | o3 |
 #select
-| A.java:53:18:53:31 | new Integer(...) [ : Number] | A.java:53:18:53:31 | new Integer(...) [ : Number] | A.java:8:9:8:9 | o | $@ | A.java:8:9:8:9 | o | o |
-| A.java:54:19:54:32 | new Integer(...) [ : Number] | A.java:54:19:54:32 | new Integer(...) [ : Number] | A.java:14:9:14:9 | o | $@ | A.java:14:9:14:9 | o | o |
-| A.java:55:20:55:33 | new Integer(...) [ : Number] | A.java:55:20:55:33 | new Integer(...) [ : Number] | A.java:20:9:20:9 | o | $@ | A.java:20:9:20:9 | o | o |
-| A.java:56:24:56:37 | new Integer(...) [ : Number] | A.java:56:24:56:37 | new Integer(...) [ : Number] | A.java:32:8:32:9 | o3 | $@ | A.java:32:8:32:9 | o3 | o3 |
-| A.java:57:25:57:38 | new Integer(...) [ : Number] | A.java:57:25:57:38 | new Integer(...) [ : Number] | A.java:43:8:43:9 | o3 | $@ | A.java:43:8:43:9 | o3 | o3 |
-| A.java:58:25:58:38 | new Integer(...) [ : Number] | A.java:58:25:58:38 | new Integer(...) [ : Number] | A.java:43:8:43:9 | o3 | $@ | A.java:43:8:43:9 | o3 | o3 |
-| A.java:59:25:59:38 | new Integer(...) [ : Number] | A.java:59:25:59:38 | new Integer(...) [ : Number] | A.java:43:8:43:9 | o3 | $@ | A.java:43:8:43:9 | o3 | o3 |
-| A.java:61:25:61:38 | new Integer(...) [ : Number] | A.java:61:25:61:38 | new Integer(...) [ : Number] | A.java:43:8:43:9 | o3 | $@ | A.java:43:8:43:9 | o3 | o3 |
-| A.java:73:18:73:31 | new Integer(...) [ : Number] | A.java:73:18:73:31 | new Integer(...) [ : Number] | A.java:8:9:8:9 | o | $@ | A.java:8:9:8:9 | o | o |
-| A.java:74:19:74:32 | new Integer(...) [ : Number] | A.java:74:19:74:32 | new Integer(...) [ : Number] | A.java:14:9:14:9 | o | $@ | A.java:14:9:14:9 | o | o |
-| A.java:75:20:75:33 | new Integer(...) [ : Number] | A.java:75:20:75:33 | new Integer(...) [ : Number] | A.java:20:9:20:9 | o | $@ | A.java:20:9:20:9 | o | o |
-| A.java:76:24:76:37 | new Integer(...) [ : Number] | A.java:76:24:76:37 | new Integer(...) [ : Number] | A.java:32:8:32:9 | o3 | $@ | A.java:32:8:32:9 | o3 | o3 |
-| A.java:87:20:87:33 | new Integer(...) [ : Number] | A.java:87:20:87:33 | new Integer(...) [ : Number] | A.java:96:10:96:10 | o | $@ | A.java:96:10:96:10 | o | o |
-| A.java:88:21:88:34 | new Integer(...) [ : Number] | A.java:88:21:88:34 | new Integer(...) [ : Number] | A.java:103:10:103:10 | o | $@ | A.java:103:10:103:10 | o | o |
-| A.java:89:26:89:39 | new Integer(...) [ : Number] | A.java:89:26:89:39 | new Integer(...) [ : Number] | A.java:116:9:116:10 | o3 | $@ | A.java:116:9:116:10 | o3 | o3 |
+| A2.java:15:15:15:28 | new Integer(...) [ : Number] | A2.java:15:15:15:28 | new Integer(...) [ : Number] | A2.java:29:9:29:9 | o | $@ | A2.java:29:9:29:9 | o | o |
+| A.java:62:18:62:31 | new Integer(...) [ : Number] | A.java:62:18:62:31 | new Integer(...) [ : Number] | A.java:16:9:16:9 | o | $@ | A.java:16:9:16:9 | o | o |
+| A.java:63:19:63:32 | new Integer(...) [ : Number] | A.java:63:19:63:32 | new Integer(...) [ : Number] | A.java:22:9:22:9 | o | $@ | A.java:22:9:22:9 | o | o |
+| A.java:64:20:64:33 | new Integer(...) [ : Number] | A.java:64:20:64:33 | new Integer(...) [ : Number] | A.java:28:9:28:9 | o | $@ | A.java:28:9:28:9 | o | o |
+| A.java:65:24:65:37 | new Integer(...) [ : Number] | A.java:65:24:65:37 | new Integer(...) [ : Number] | A.java:40:8:40:9 | o3 | $@ | A.java:40:8:40:9 | o3 | o3 |
+| A.java:66:25:66:38 | new Integer(...) [ : Number] | A.java:66:25:66:38 | new Integer(...) [ : Number] | A.java:51:8:51:9 | o3 | $@ | A.java:51:8:51:9 | o3 | o3 |
+| A.java:67:25:67:38 | new Integer(...) [ : Number] | A.java:67:25:67:38 | new Integer(...) [ : Number] | A.java:51:8:51:9 | o3 | $@ | A.java:51:8:51:9 | o3 | o3 |
+| A.java:68:25:68:38 | new Integer(...) [ : Number] | A.java:68:25:68:38 | new Integer(...) [ : Number] | A.java:51:8:51:9 | o3 | $@ | A.java:51:8:51:9 | o3 | o3 |
+| A.java:69:20:69:33 | new Integer(...) [ : Number] | A.java:69:20:69:33 | new Integer(...) [ : Number] | A.java:69:8:69:40 | flowThrough(...) | $@ | A.java:69:8:69:40 | flowThrough(...) | flowThrough(...) |
+| A.java:71:25:71:38 | new Integer(...) [ : Number] | A.java:71:25:71:38 | new Integer(...) [ : Number] | A.java:51:8:51:9 | o3 | $@ | A.java:51:8:51:9 | o3 | o3 |
+| A.java:84:18:84:31 | new Integer(...) [ : Number] | A.java:84:18:84:31 | new Integer(...) [ : Number] | A.java:16:9:16:9 | o | $@ | A.java:16:9:16:9 | o | o |
+| A.java:85:19:85:32 | new Integer(...) [ : Number] | A.java:85:19:85:32 | new Integer(...) [ : Number] | A.java:22:9:22:9 | o | $@ | A.java:22:9:22:9 | o | o |
+| A.java:86:20:86:33 | new Integer(...) [ : Number] | A.java:86:20:86:33 | new Integer(...) [ : Number] | A.java:28:9:28:9 | o | $@ | A.java:28:9:28:9 | o | o |
+| A.java:87:24:87:37 | new Integer(...) [ : Number] | A.java:87:24:87:37 | new Integer(...) [ : Number] | A.java:40:8:40:9 | o3 | $@ | A.java:40:8:40:9 | o3 | o3 |
+| A.java:88:20:88:33 | new Integer(...) [ : Number] | A.java:88:20:88:33 | new Integer(...) [ : Number] | A.java:88:8:88:37 | flowThrough(...) | $@ | A.java:88:8:88:37 | flowThrough(...) | flowThrough(...) |
+| A.java:99:20:99:33 | new Integer(...) [ : Number] | A.java:99:20:99:33 | new Integer(...) [ : Number] | A.java:108:10:108:10 | o | $@ | A.java:108:10:108:10 | o | o |
+| A.java:100:21:100:34 | new Integer(...) [ : Number] | A.java:100:21:100:34 | new Integer(...) [ : Number] | A.java:115:10:115:10 | o | $@ | A.java:115:10:115:10 | o | o |
+| A.java:101:26:101:39 | new Integer(...) [ : Number] | A.java:101:26:101:39 | new Integer(...) [ : Number] | A.java:128:9:128:10 | o3 | $@ | A.java:128:9:128:10 | o3 | o3 |

--- a/java/ql/test/library-tests/dataflow/call-sensitivity/flow.ql
+++ b/java/ql/test/library-tests/dataflow/call-sensitivity/flow.ql
@@ -1,0 +1,24 @@
+/**
+ * @kind path-problem
+ */
+
+import java
+import semmle.code.java.dataflow.DataFlow
+import DataFlow::PathGraph
+
+class Conf extends DataFlow::Configuration {
+  Conf() { this = "CallSensitiveFlowConf" }
+
+  override predicate isSource(DataFlow::Node src) { src.asExpr() instanceof ClassInstanceExpr }
+
+  override predicate isSink(DataFlow::Node sink) {
+    exists(MethodAccess ma |
+      ma.getMethod().hasName("sink") and
+      ma.getAnArgument() = sink.asExpr()
+    )
+  }
+}
+
+from DataFlow::PathNode source, DataFlow::PathNode sink, Conf conf
+where conf.hasFlowPath(source, sink)
+select source, source, sink, "$@", sink, sink.toString()

--- a/java/ql/test/library-tests/dataflow/call-sensitivity/log/javac-errors.log
+++ b/java/ql/test/library-tests/dataflow/call-sensitivity/log/javac-errors.log
@@ -1,0 +1,8 @@
+[2019-09-30 16:01:44] [ERROR] Exception running the extractor with arguments: --javacOptions -source 8 --strict-javac-errors --encoding UTF-8 --files A.java A2.java InterfaceA.java
+[2019-09-30 16:01:44] [ERROR] Exception: 
+                              com.semmle.util.exception.ResourceError: Neither TRAP_FOLDER nor ODASA_JAVA_LAYOUT was set
+                              	at com.semmle.extractor.java.OdasaOutput.<init>(OdasaOutput.java:95)
+                              	at com.semmle.extractor.java.JavaExtractor.createOutput(JavaExtractor.java:443)
+                              	at com.semmle.extractor.java.JavaExtractor.runExtractor(JavaExtractor.java:234)
+                              	at com.semmle.extractor.java.JavaExtractor.runExtractor(JavaExtractor.java:222)
+                              	at com.semmle.extractor.java.JavaExtractor.main(JavaExtractor.java:475)

--- a/java/ql/test/library-tests/dataflow/call-sensitivity/log/javac-extractor-6836.log
+++ b/java/ql/test/library-tests/dataflow/call-sensitivity/log/javac-extractor-6836.log
@@ -1,0 +1,3 @@
+[2019-09-30 16:01:44] [javac-extractor-6836] Starting extraction for:
+                                             sun.java.command=com.semmle.extractor.java.JavaExtractor --javacOptions -source 8 --strict-javac-errors --encoding UTF-8 --files A.java A2.java InterfaceA.java
+                                             user.dir=/home/corni/build/ql/java/ql/test/library-tests/dataflow/call-sensitivity

--- a/java/ql/test/library-tests/dataflow/call-sensitivity/log/log.log
+++ b/java/ql/test/library-tests/dataflow/call-sensitivity/log/log.log
@@ -1,0 +1,8 @@
+[2019-09-30 16:01:44] [ERROR] Exception running the extractor with arguments: --javacOptions -source 8 --strict-javac-errors --encoding UTF-8 --files A.java A2.java InterfaceA.java
+[2019-09-30 16:01:44] [ERROR] Exception: 
+                              com.semmle.util.exception.ResourceError: Neither TRAP_FOLDER nor ODASA_JAVA_LAYOUT was set
+                              	at com.semmle.extractor.java.OdasaOutput.<init>(OdasaOutput.java:95)
+                              	at com.semmle.extractor.java.JavaExtractor.createOutput(JavaExtractor.java:443)
+                              	at com.semmle.extractor.java.JavaExtractor.runExtractor(JavaExtractor.java:234)
+                              	at com.semmle.extractor.java.JavaExtractor.runExtractor(JavaExtractor.java:222)
+                              	at com.semmle.extractor.java.JavaExtractor.main(JavaExtractor.java:475)


### PR DESCRIPTION
With this PR, we remove false positives from the dataflow library by utilizing call contexts to make the analysis more precise.
With a function like
```
public void callSinkIfTrue(Object o, boolean cond) {
	if (cond) {
		sink(o);
	}
}
```
we now don't detect dataflow anymore when the branch the `sink()`-call is in is not reachable
(i.e. for calls like callSinkIfTrue(o, false)).
An extension of this to enums and to C#/C++ should both be fairly straightforward.