### PR TITLE
Python: modernise cls self argument name checks

### DIFF
--- a/python/ql/src/Functions/NonCls.qhelp
+++ b/python/ql/src/Functions/NonCls.qhelp
@@ -5,14 +5,14 @@
 
 
 <overview>
-<p> The first argument of a class method, a new method or any metaclass method
-should be called <code>cls</code>. This makes the purpose of the argument clear to other developers.
+<p> The first parameter of a class method, a new method or any metaclass method
+should be called <code>cls</code>. This makes the purpose of the parameter clear to other developers.
 </p>
 
 </overview>
 <recommendation>
 
-<p>Change the name of the first argument to <code>cls</code> as recommended by the style guidelines
+<p>Change the name of the first parameter to <code>cls</code> as recommended by the style guidelines
 in PEP 8.</p>
 
 </recommendation>

--- a/python/ql/src/Functions/NonCls.ql
+++ b/python/ql/src/Functions/NonCls.ql
@@ -23,13 +23,13 @@ predicate first_arg_cls(Function f) {
 }
 
 predicate is_type_method(Function f) {
-    exists(ClassObject c | c.getPyClass() = f.getScope() and c.getASuperType() = theTypeType())
+    exists(ClassValue c | c.getScope() = f.getScope() and c.getASuperType() = ClassValue::type())
 }
 
 predicate classmethod_decorators_only(Function f) {
     forall(Expr decorator |
         decorator = f.getADecorator() |
-            ((Name) decorator).getId() = "classmethod")
+            decorator.(Name).getId() = "classmethod")
 }
 
 from Function f, string message

--- a/python/ql/src/Functions/NonCls.ql
+++ b/python/ql/src/Functions/NonCls.ql
@@ -16,7 +16,8 @@ import python
 
 predicate first_arg_cls(Function f) {
     exists(string argname | argname = f.getArgName(0) |
-        argname = "cls" or
+        argname = "cls"
+        or
         /* Not PEP8, but relatively common */
         argname = "mcls"
     )
@@ -27,21 +28,21 @@ predicate is_type_method(Function f) {
 }
 
 predicate classmethod_decorators_only(Function f) {
-    forall(Expr decorator |
-        decorator = f.getADecorator() |
-            decorator.(Name).getId() = "classmethod")
+    forall(Expr decorator | decorator = f.getADecorator() | decorator.(Name).getId() = "classmethod")
 }
 
 from Function f, string message
-where (f.getADecorator().(Name).getId() = "classmethod" or is_type_method(f)) and 
-not first_arg_cls(f) and classmethod_decorators_only(f) and
-not f.getName() = "__new__" and
-(
-  if exists(f.getArgName(0)) then
-      message = "Class methods or methods of a type deriving from type should have 'cls', rather than '" +
-            f.getArgName(0) + "', as their first parameter."
-  else
-      message = "Class methods or methods of a type deriving from type should have 'cls' as their first parameter."
-)
-
+where
+    (f.getADecorator().(Name).getId() = "classmethod" or is_type_method(f)) and
+    not first_arg_cls(f) and
+    classmethod_decorators_only(f) and
+    not f.getName() = "__new__" and
+    (
+        if exists(f.getArgName(0))
+        then
+            message = "Class methods or methods of a type deriving from type should have 'cls', rather than '"
+                    + f.getArgName(0) + "', as their first parameter."
+        else
+            message = "Class methods or methods of a type deriving from type should have 'cls' as their first parameter."
+    )
 select f, message

--- a/python/ql/src/Functions/NonCls.ql
+++ b/python/ql/src/Functions/NonCls.ql
@@ -1,7 +1,7 @@
 /**
  * @name First parameter of a class method is not named 'cls'
- * @description Using an alternative name for the first argument of a class method makes code more
- *              difficult to read; PEP8 states that the first argument to class methods should be 'cls'.
+ * @description Using an alternative name for the first parameter of a class method makes code more
+ *              difficult to read; PEP8 states that the first parameter to class methods should be 'cls'.
  * @kind problem
  * @tags maintainability
  *       readability
@@ -38,10 +38,10 @@ not first_arg_cls(f) and classmethod_decorators_only(f) and
 not f.getName() = "__new__" and
 (
   if exists(f.getArgName(0)) then
-      message = "Class methods or methods of a type deriving from type should have 'cls', rather than '" + 
-            f.getArgName(0) + "', as their first argument."
+      message = "Class methods or methods of a type deriving from type should have 'cls', rather than '" +
+            f.getArgName(0) + "', as their first parameter."
   else
-      message = "Class methods or methods of a type deriving from type should have 'cls' as their first argument."
+      message = "Class methods or methods of a type deriving from type should have 'cls' as their first parameter."
 )
 
 select f, message

--- a/python/ql/src/Functions/NonSelf.py
+++ b/python/ql/src/Functions/NonSelf.py
@@ -1,9 +1,9 @@
 class Point:
-    def __init__(val, x, y):  # first argument is mis-named 'val'
+    def __init__(val, x, y):  # first parameter is mis-named 'val'
         val._x = x
         val._y = y
-		
+
 class Point2:
-    def __init__(self, x, y):  # first argument is correctly named 'self'
+    def __init__(self, x, y):  # first parameter is correctly named 'self'
         self._x = x
         self._y = y

--- a/python/ql/src/Functions/NonSelf.ql
+++ b/python/ql/src/Functions/NonSelf.ql
@@ -21,32 +21,34 @@ predicate is_type_method(FunctionValue fv) {
 }
 
 predicate used_in_defining_scope(FunctionValue fv) {
-    exists(Call c |
-        c.getScope() = fv.getScope().getScope() and c.getFunc().pointsTo(fv)
-    )
+    exists(Call c | c.getScope() = fv.getScope().getScope() and c.getFunc().pointsTo(fv))
 }
 
 from Function f, FunctionValue fv, string message
 where
-exists(ClassValue cls, string name |
-    cls.declaredAttribute(name) = fv and cls.isNewStyle() and
-    not name = "__new__" and
-    not name = "__metaclass__" and
-    /* declared in scope */
-    f.getScope() = cls.getScope()
-) and
-not f.getArgName(0) = "self" and
-not is_type_method(fv) and
-fv.getScope() = f and
-not f.getName() = "lambda" and
-not used_in_defining_scope(fv) and
-(
-  if exists(f.getArgName(0)) then
-      message = "Normal methods should have 'self', rather than '" + f.getArgName(0) + "', as their first parameter."
-  else
-      message = "Normal methods should have at least one parameter (the first of which should be 'self')." and
-      not f.hasVarArg()
-) and
-not fv instanceof ZopeInterfaceMethodValue
-
+    exists(ClassValue cls, string name |
+        cls.declaredAttribute(name) = fv and
+        cls.isNewStyle() and
+        not name = "__new__" and
+        not name = "__metaclass__" and
+        /* declared in scope */
+        f.getScope() = cls.getScope()
+    ) and
+    not f.getArgName(0) = "self" and
+    not is_type_method(fv) and
+    fv.getScope() = f and
+    not f.getName() = "lambda" and
+    not used_in_defining_scope(fv) and
+    (
+        (
+            if exists(f.getArgName(0))
+            then
+                message = "Normal methods should have 'self', rather than '" + f.getArgName(0) +
+                        "', as their first parameter."
+            else
+                message = "Normal methods should have at least one parameter (the first of which should be 'self')."
+        ) and
+        not f.hasVarArg()
+    ) and
+    not fv instanceof ZopeInterfaceMethodValue
 select f, message

--- a/python/ql/src/Functions/NonSelf.ql
+++ b/python/ql/src/Functions/NonSelf.ql
@@ -1,7 +1,7 @@
 /**
- * @name First argument of a method is not named 'self'
- * @description Using an alternative name for the first argument of an instance method makes
- *              code more difficult to read; PEP8 states that the first argument to instance
+ * @name First parameter of a method is not named 'self'
+ * @description Using an alternative name for the first parameter of an instance method makes
+ *              code more difficult to read; PEP8 states that the first parameter to instance
  *              methods should be 'self'.
  * @kind problem
  * @tags maintainability

--- a/python/ql/src/Functions/NonSelf.ql
+++ b/python/ql/src/Functions/NonSelf.ql
@@ -16,39 +16,37 @@
 import python
 import semmle.python.libraries.Zope
 
-predicate first_arg_self(Function f) {
-    f.getArgName(0) = "self"
+predicate is_type_method(FunctionValue fv) {
+    exists(ClassValue c | c.declaredAttribute(_) = fv and c.getASuperType() = ClassValue::type())
 }
 
-predicate is_type_method(FunctionObject f) {
-    exists(ClassObject c | c.lookupAttribute(_) = f and c.getASuperType() = theTypeType())
-}
-
-predicate used_in_defining_scope(FunctionObject f) {
-    exists(Call c | 
-        c.getScope() = f.getFunction().getScope() and
-        c.getFunc().refersTo(f)
+predicate used_in_defining_scope(FunctionValue fv) {
+    exists(Call c |
+        c.getScope() = fv.getScope().getScope() and c.getFunc().pointsTo(fv)
     )
 }
 
-from Function f, PyFunctionObject func, string message
+from Function f, FunctionValue fv, string message
 where
-exists(ClassObject cls, string name |
-    cls.declaredAttribute(name) = func and cls.isNewStyle() and
+exists(ClassValue cls, string name |
+    cls.declaredAttribute(name) = fv and cls.isNewStyle() and
     not name = "__new__" and
     not name = "__metaclass__" and
     /* declared in scope */
-    f.getScope() = cls.getPyClass()
+    f.getScope() = cls.getScope()
 ) and
-not first_arg_self(f) and not is_type_method(func) and
-func.getFunction() = f and not f.getName() = "lambda" and
-not used_in_defining_scope(func) and
+not f.getArgName(0) = "self" and
+not is_type_method(fv) and
+fv.getScope() = f and
+not f.getName() = "lambda" and
+not used_in_defining_scope(fv) and
 (
   if exists(f.getArgName(0)) then
       message = "Normal methods should have 'self', rather than '" + f.getArgName(0) + "', as their first parameter."
   else
-      message = "Normal methods should have at least one parameter (the first of which should be 'self')." and not f.hasVarArg()
+      message = "Normal methods should have at least one parameter (the first of which should be 'self')." and
+      not f.hasVarArg()
 ) and
-not func instanceof ZopeInterfaceMethod
+not fv instanceof ZopeInterfaceMethodValue
 
 select f, message

--- a/python/ql/src/semmle/python/libraries/Zope.qll
+++ b/python/ql/src/semmle/python/libraries/Zope.qll
@@ -44,4 +44,15 @@ class ZopeInterfaceMethodValue extends PythonFunctionValue {
         )
     }
 
+    override int minParameters() {
+        result = super.minParameters() + 1
+    }
+
+    override int maxParameters() {
+        if exists(this.getScope().getVararg()) then
+            result = super.maxParameters()
+        else
+            result = super.maxParameters() + 1
+    }
+
 }

--- a/python/ql/src/semmle/python/libraries/Zope.qll
+++ b/python/ql/src/semmle/python/libraries/Zope.qll
@@ -2,8 +2,10 @@
 
 import python
 
+private import semmle.python.pointsto.PointsTo
+
 /** A method that to a sub-class of `zope.interface.Interface` */
-class ZopeInterfaceMethod extends PyFunctionObject {
+deprecated class ZopeInterfaceMethod extends PyFunctionObject {
 
     /** Holds if this method belongs to a class that sub-classes `zope.interface.Interface` */
     ZopeInterfaceMethod() {
@@ -23,6 +25,23 @@ class ZopeInterfaceMethod extends PyFunctionObject {
             result = super.maxParameters()
         else
             result = super.maxParameters() + 1
+    }
+
+}
+
+/** A method that belongs to a sub-class of `zope.interface.Interface` */
+class ZopeInterfaceMethodValue extends PythonFunctionValue {
+
+    /** Holds if this method belongs to a class that sub-classes `zope.interface.Interface` */
+    ZopeInterfaceMethodValue() {
+        exists(Value interface, ClassValue owner |
+            interface = Module::named("zope.interface").attr("Interface") and
+            owner.declaredAttribute(_) = this and
+            // `zope.interface.Interface` will be recognized as a Value by the pointsTo analysis,
+            // because it is the result of instantiating a "meta" class. getASuperType only returns
+            // ClassValues, so we do this little trick to make things work
+            Types::getBase(owner.getASuperType(), _) = interface
+        )
     }
 
 }

--- a/python/ql/src/semmle/python/objects/ObjectAPI.qll
+++ b/python/ql/src/semmle/python/objects/ObjectAPI.qll
@@ -560,6 +560,11 @@ module ClassValue {
         result = TBuiltinClassObject(Builtin::special("FunctionType"))
     }
 
+    /** Get the `ClassValue` for the `type` class. */
+    ClassValue type() {
+        result = TType()
+    }
+
     /** Get the `ClassValue` for the class of builtin functions. */
     ClassValue builtinFunction() {
         result = Value::named("len").getClass()

--- a/python/ql/src/semmle/python/objects/ObjectAPI.qll
+++ b/python/ql/src/semmle/python/objects/ObjectAPI.qll
@@ -434,6 +434,11 @@ abstract class FunctionValue extends CallableValue {
 
     abstract string getQualifiedName();
 
+    /** Gets the minimum number of parameters that can be correctly passed to this function */
+    abstract int minParameters();
+
+    /** Gets the maximum number of parameters that can be correctly passed to this function */
+    abstract int maxParameters();
 }
 
 /** Class representing Python functions */
@@ -445,6 +450,23 @@ class PythonFunctionValue extends FunctionValue {
 
     override string getQualifiedName() {
         result = this.(PythonFunctionObjectInternal).getScope().getQualifiedName()
+    }
+
+    override int minParameters() {
+        exists(Function f |
+            f = this.getScope() and
+            result = count(f.getAnArg()) - count(f.getDefinition().getArgs().getADefault())
+        )
+    }
+
+    override int maxParameters() {
+        exists(Function f |
+            f = this.getScope() and
+            if exists(f.getVararg()) then
+                result = 2147483647 // INT_MAX
+            else
+                result = count(f.getAnArg())
+        )
     }
 
 }
@@ -460,6 +482,13 @@ class BuiltinFunctionValue extends FunctionValue {
         result = this.(BuiltinFunctionObjectInternal).getName()
     }
 
+    override int minParameters() {
+        none()
+    }
+
+    override int maxParameters() {
+        none()
+    }
 }
 
 /** Class representing builtin methods, such as `list.append` or `set.add` */
@@ -475,6 +504,14 @@ class BuiltinMethodValue extends FunctionValue {
             cls.getMember(_) = this.(BuiltinMethodObjectInternal).getBuiltin() and
             result = cls.getName() + "." + this.getName()
         )
+    }
+
+    override int minParameters() {
+        none()
+    }
+
+    override int maxParameters() {
+        none()
     }
 
 }

--- a/python/ql/test/library-tests/types/functions/Zope.expected
+++ b/python/ql/test/library-tests/types/functions/Zope.expected
@@ -1,1 +1,1 @@
-| Function yes |
+| Function Z.yes |

--- a/python/ql/test/library-tests/types/functions/Zope.ql
+++ b/python/ql/test/library-tests/types/functions/Zope.ql
@@ -2,5 +2,5 @@
 import python
 import semmle.python.libraries.Zope
 
-from ZopeInterfaceMethod f
+from ZopeInterfaceMethodValue f
 select f.toString()

--- a/python/ql/test/query-tests/Functions/general/ModificationOfParameterWithDefault.expected
+++ b/python/ql/test/query-tests/Functions/general/ModificationOfParameterWithDefault.expected
@@ -1,14 +1,14 @@
 edges
 | functions_test.py:39:9:39:9 | empty mutable value | functions_test.py:40:5:40:5 | empty mutable value |
 | functions_test.py:133:15:133:15 | empty mutable value | functions_test.py:134:5:134:5 | empty mutable value |
-| functions_test.py:185:25:185:25 | empty mutable value | functions_test.py:186:5:186:5 | empty mutable value |
-| functions_test.py:188:21:188:21 | empty mutable value | functions_test.py:189:5:189:5 | empty mutable value |
-| functions_test.py:191:27:191:27 | empty mutable value | functions_test.py:192:25:192:25 | empty mutable value |
-| functions_test.py:191:27:191:27 | empty mutable value | functions_test.py:193:21:193:21 | empty mutable value |
-| functions_test.py:192:25:192:25 | empty mutable value | functions_test.py:185:25:185:25 | empty mutable value |
-| functions_test.py:193:21:193:21 | empty mutable value | functions_test.py:188:21:188:21 | empty mutable value |
+| functions_test.py:151:25:151:25 | empty mutable value | functions_test.py:152:5:152:5 | empty mutable value |
+| functions_test.py:154:21:154:21 | empty mutable value | functions_test.py:155:5:155:5 | empty mutable value |
+| functions_test.py:157:27:157:27 | empty mutable value | functions_test.py:158:25:158:25 | empty mutable value |
+| functions_test.py:157:27:157:27 | empty mutable value | functions_test.py:159:21:159:21 | empty mutable value |
+| functions_test.py:158:25:158:25 | empty mutable value | functions_test.py:151:25:151:25 | empty mutable value |
+| functions_test.py:159:21:159:21 | empty mutable value | functions_test.py:154:21:154:21 | empty mutable value |
 #select
 | functions_test.py:40:5:40:5 | x | functions_test.py:39:9:39:9 | empty mutable value | functions_test.py:40:5:40:5 | empty mutable value | $@ flows to here and is mutated. | functions_test.py:39:9:39:9 | x | Default value |
 | functions_test.py:134:5:134:5 | x | functions_test.py:133:15:133:15 | empty mutable value | functions_test.py:134:5:134:5 | empty mutable value | $@ flows to here and is mutated. | functions_test.py:133:15:133:15 | x | Default value |
-| functions_test.py:186:5:186:5 | x | functions_test.py:191:27:191:27 | empty mutable value | functions_test.py:186:5:186:5 | empty mutable value | $@ flows to here and is mutated. | functions_test.py:191:27:191:27 | y | Default value |
-| functions_test.py:189:5:189:5 | x | functions_test.py:191:27:191:27 | empty mutable value | functions_test.py:189:5:189:5 | empty mutable value | $@ flows to here and is mutated. | functions_test.py:191:27:191:27 | y | Default value |
+| functions_test.py:152:5:152:5 | x | functions_test.py:157:27:157:27 | empty mutable value | functions_test.py:152:5:152:5 | empty mutable value | $@ flows to here and is mutated. | functions_test.py:157:27:157:27 | y | Default value |
+| functions_test.py:155:5:155:5 | x | functions_test.py:157:27:157:27 | empty mutable value | functions_test.py:155:5:155:5 | empty mutable value | $@ flows to here and is mutated. | functions_test.py:157:27:157:27 | y | Default value |

--- a/python/ql/test/query-tests/Functions/general/NonCls.expected
+++ b/python/ql/test/query-tests/Functions/general/NonCls.expected
@@ -1,3 +1,3 @@
-| argument_names.py:17:5:17:24 | Function n_cmethod | Class methods or methods of a type deriving from type should have 'cls', rather than 'self', as their first argument. |
-| argument_names.py:22:5:22:21 | Function n_cmethod2 | Class methods or methods of a type deriving from type should have 'cls' as their first argument. |
-| argument_names.py:37:5:37:20 | Function c_method | Class methods or methods of a type deriving from type should have 'cls', rather than 'y', as their first argument. |
+| parameter_names.py:17:5:17:24 | Function n_cmethod | Class methods or methods of a type deriving from type should have 'cls', rather than 'self', as their first parameter. |
+| parameter_names.py:22:5:22:21 | Function n_cmethod2 | Class methods or methods of a type deriving from type should have 'cls' as their first parameter. |
+| parameter_names.py:37:5:37:20 | Function c_method | Class methods or methods of a type deriving from type should have 'cls', rather than 'y', as their first parameter. |

--- a/python/ql/test/query-tests/Functions/general/NonCls.expected
+++ b/python/ql/test/query-tests/Functions/general/NonCls.expected
@@ -1,2 +1,3 @@
 | argument_names.py:17:5:17:24 | Function n_cmethod | Class methods or methods of a type deriving from type should have 'cls', rather than 'self', as their first argument. |
-| argument_names.py:32:5:32:20 | Function c_method | Class methods or methods of a type deriving from type should have 'cls', rather than 'y', as their first argument. |
+| argument_names.py:22:5:22:21 | Function n_cmethod2 | Class methods or methods of a type deriving from type should have 'cls' as their first argument. |
+| argument_names.py:37:5:37:20 | Function c_method | Class methods or methods of a type deriving from type should have 'cls', rather than 'y', as their first argument. |

--- a/python/ql/test/query-tests/Functions/general/NonSelf.expected
+++ b/python/ql/test/query-tests/Functions/general/NonSelf.expected
@@ -1,4 +1,4 @@
-| argument_names.py:50:5:50:20 | Function __init__ | Normal methods should have 'self', rather than 'x', as their first parameter. |
-| argument_names.py:53:5:53:20 | Function s_method | Normal methods should have 'self', rather than 'y', as their first parameter. |
-| argument_names.py:56:5:56:20 | Function s_method2 | Normal methods should have at least one parameter (the first of which should be 'self'). |
 | om_test.py:71:5:71:19 | Function __repr__ | Normal methods should have at least one parameter (the first of which should be 'self'). |
+| parameter_names.py:50:5:50:20 | Function __init__ | Normal methods should have 'self', rather than 'x', as their first parameter. |
+| parameter_names.py:53:5:53:20 | Function s_method | Normal methods should have 'self', rather than 'y', as their first parameter. |
+| parameter_names.py:56:5:56:20 | Function s_method2 | Normal methods should have at least one parameter (the first of which should be 'self'). |

--- a/python/ql/test/query-tests/Functions/general/NonSelf.expected
+++ b/python/ql/test/query-tests/Functions/general/NonSelf.expected
@@ -1,3 +1,4 @@
-| argument_names.py:45:5:45:20 | Function __init__ | Normal methods should have 'self', rather than 'x', as their first parameter. |
-| argument_names.py:48:5:48:20 | Function s_method | Normal methods should have 'self', rather than 'y', as their first parameter. |
+| argument_names.py:50:5:50:20 | Function __init__ | Normal methods should have 'self', rather than 'x', as their first parameter. |
+| argument_names.py:53:5:53:20 | Function s_method | Normal methods should have 'self', rather than 'y', as their first parameter. |
+| argument_names.py:56:5:56:20 | Function s_method2 | Normal methods should have at least one parameter (the first of which should be 'self'). |
 | om_test.py:71:5:71:19 | Function __repr__ | Normal methods should have at least one parameter (the first of which should be 'self'). |

--- a/python/ql/test/query-tests/Functions/general/argument_names.py
+++ b/python/ql/test/query-tests/Functions/general/argument_names.py
@@ -17,6 +17,11 @@ class Normal(object):
     def n_cmethod(self):
         pass
 
+    # not ok
+    @classmethod
+    def n_cmethod2():
+        pass
+
     # this is allowed because it has a decorator other than @classmethod
     @classmethod
     @id
@@ -48,6 +53,9 @@ class NonSelf(object):
     def s_method(y):
         pass
 
+    def s_method2():
+        pass
+
     def s_ok(self):
         pass
 
@@ -69,25 +77,32 @@ class NonSelf(object):
 
 #Possible FPs for non-self. ODASA-2439
 
-class C(object):
+class Acceptable1(object):
+    def _func(f):
+        return f
+    _func(x)
+
+class Acceptable2(object):
     def _func(f):
         return f
 
-    _func(x)
-
-    #or
     @_func
     def meth(self):
         pass
 
-
+# Handling methods defined in a different scope than the class it belongs to,
+# gets problmematic since we need to show the full-path from method definition
+# to actually adding it to the class. We tried to enable warnings for these in
+# September 2019, but ended up sticking to the decision from ODASA-2439 (where
+# results are both obvious and useful to the end-user).
 def dont_care(arg):
     pass
 
-class C(object):
+class Acceptable3(object):
 
     meth = dont_care
 
+# OK
 class Meta(type):
 
     #__new__ is an implicit class method, so the first arg is the metaclass

--- a/python/ql/test/query-tests/Functions/general/argument_names.py
+++ b/python/ql/test/query-tests/Functions/general/argument_names.py
@@ -66,3 +66,39 @@ class NonSelf(object):
     def s_cmethod2(cls):
         pass
     s_cmethod2 = classmethod(s_cmethod2)
+
+#Possible FPs for non-self. ODASA-2439
+
+class C(object):
+    def _func(f):
+        return f
+
+    _func(x)
+
+    #or
+    @_func
+    def meth(self):
+        pass
+
+
+def dont_care(arg):
+    pass
+
+class C(object):
+
+    meth = dont_care
+
+class Meta(type):
+
+    #__new__ is an implicit class method, so the first arg is the metaclass
+    def __new__(metacls, name, bases, cls_dict):
+        return super(Meta, metacls).__new__(metacls, name, bases, cls_dict)
+
+#ODASA-6062
+import zope.interface
+class Z(zope.interface.Interface):
+
+    def meth(arg):
+        pass
+
+Z().meth(0)

--- a/python/ql/test/query-tests/Functions/general/functions_test.py
+++ b/python/ql/test/query-tests/Functions/general/functions_test.py
@@ -134,33 +134,6 @@ def augassign(x = []):
     x += ["x"]
 
 
-#Possible FPs for non-self. ODASA-2439
-
-class C(object):
-    def _func(f):
-        return f
-
-    _func(x)
-
-    #or
-    @_func
-    def meth(self):
-        pass
-
-
-def dont_care(arg):
-    pass
-
-class C(object):
-
-    meth = dont_care
-
-class Meta(type):
-
-    #__new__ is an implicit class method, so the first arg is the metaclass
-    def __new__(metacls, name, bases, cls_dict):
-        return super(Meta, metacls).__new__(metacls, name, bases, cls_dict)
-
 #ODASA 3658
 from sys import exit
 #Consistent returns
@@ -172,14 +145,7 @@ def ok5():
         print(e)
         exit(EXIT_ERROR)
 
-#ODASA-6062
-import zope.interface
-class Z(zope.interface.Interface):
 
-    def meth(arg):
-        pass
-
-Z().meth(0)
 
 # indirect modification of parameter with default
 def aug_assign_argument(x):

--- a/python/ql/test/query-tests/Functions/general/parameter_names.py
+++ b/python/ql/test/query-tests/Functions/general/parameter_names.py
@@ -1,6 +1,6 @@
-# Using name other than 'self' for first argument in methods.
-# This shouldn't apply to classmethods (first argument should be 'cls' or similar)
-# or static methods (first argument can be anything)
+# Using name other than 'self' for first parameter in methods.
+# This shouldn't apply to classmethods (first parameter should be 'cls' or similar)
+# or static methods (first parameter can be anything)
 
 
 class Normal(object):


### PR DESCRIPTION
One thing I'm not sure about is the fact that I deprecated the old `class ZopeInterfaceMethod extends PyFunctionObject`,  but I thought it was the easy way to remember it by doing it now!