### PR TITLE
JS: remove false positive in js/missing-space-in-concatenation

### DIFF
--- a/change-notes/1.22/analysis-javascript.md
+++ b/change-notes/1.22/analysis-javascript.md
@@ -36,6 +36,7 @@
 | Shift out of range (`js/shift-out-of-range`| Fewer false positive results | This rule now correctly handles BigInt shift operands. |
 | Superfluous trailing arguments (`js/superfluous-trailing-arguments`) | Fewer false-positive results. | This rule no longer flags calls to placeholder functions that trivially throw an exception. |
 | Undocumented parameter (`js/jsdoc/missing-parameter`) | No changes to results | This rule is now run on LGTM, although its results are still not shown by default. |
+| Missing space in string concatenation (`js/missing-space-in-concatenation`) | Fewer false positive results | The rule now requires a word-like part exists in the string concatenation. | 
 
 ## Changes to QL libraries
 

--- a/javascript/ql/src/Expressions/MissingSpaceInAppend.ql
+++ b/javascript/ql/src/Expressions/MissingSpaceInAppend.ql
@@ -23,7 +23,7 @@ Expr leftChild(Expr e) {
 }
 
 predicate isInConcat(Expr e) {
-    exists(ParExpr par | par.getExpression() = e)
+    exists(ParExpr par | isInConcat(par) and par.getExpression() = e)
     or 
     exists(AddExpr a | a.getAnOperand() = e)
 }

--- a/javascript/ql/test/query-tests/Expressions/MissingSpaceInAppend/MissingSpaceInAppend.expected
+++ b/javascript/ql/test/query-tests/Expressions/MissingSpaceInAppend/MissingSpaceInAppend.expected
@@ -11,4 +11,5 @@
 | missing.js:24:5:24:21 | `missing a space` | This string appears to be missing a space after 'space'. |
 | missing.js:26:5:26:21 | "missing a space" | This string appears to be missing a space after 'space'. |
 | missing.js:28:5:28:21 | `missing a space` | This string appears to be missing a space after 'space'. |
-| missing.js:31:7:31:12 | "h. 0" | This string appears to be missing a space after '0'. |
+| missing.js:30:7:30:21 | "missing space" | This string appears to be missing a space after 'space'. |
+| missing.js:32:7:32:12 | "h. 0" | This string appears to be missing a space after '0'. |

--- a/javascript/ql/test/query-tests/Expressions/MissingSpaceInAppend/MissingSpaceInAppend.expected
+++ b/javascript/ql/test/query-tests/Expressions/MissingSpaceInAppend/MissingSpaceInAppend.expected
@@ -11,3 +11,4 @@
 | missing.js:24:5:24:21 | `missing a space` | This string appears to be missing a space after 'space'. |
 | missing.js:26:5:26:21 | "missing a space" | This string appears to be missing a space after 'space'. |
 | missing.js:28:5:28:21 | `missing a space` | This string appears to be missing a space after 'space'. |
+| missing.js:31:7:31:12 | "h. 0" | This string appears to be missing a space after '0'. |

--- a/javascript/ql/test/query-tests/Expressions/MissingSpaceInAppend/missing.js
+++ b/javascript/ql/test/query-tests/Expressions/MissingSpaceInAppend/missing.js
@@ -27,3 +27,5 @@ s = "missing a space" +
     `here`;
 s = `missing a space` +
     `here`;
+
+s = (("h. 0" + "h")) + "word"

--- a/javascript/ql/test/query-tests/Expressions/MissingSpaceInAppend/missing.js
+++ b/javascript/ql/test/query-tests/Expressions/MissingSpaceInAppend/missing.js
@@ -27,5 +27,6 @@ s = "missing a space" +
     `here`;
 s = `missing a space` +
     `here`;
+s = (("missing space") + "here")
 
 s = (("h. 0" + "h")) + "word"

--- a/javascript/ql/test/query-tests/Expressions/MissingSpaceInAppend/ok.js
+++ b/javascript/ql/test/query-tests/Expressions/MissingSpaceInAppend/ok.js
@@ -9,3 +9,6 @@ s = "some data: a,b,c," +
   "d,e,f";
 s = "overflow: scroll;" +
   "position: absolute;";
+
+s = "h. 0" + "h"
+s = ((("h. 0"))) + (("h")) + ("h")


### PR DESCRIPTION
Fix for #2020 

The fix checks that there is a word-like fragment in the string-concatenation. 

Performance is excellent, but surprisingly it took 2 rounds of dist-compare to get there.