### PR TITLE
Java: Improve guards for equal ssa variables.

### DIFF
--- a/change-notes/1.23/analysis-java.md
+++ b/change-notes/1.23/analysis-java.md
@@ -6,6 +6,7 @@ The following changes in version 1.23 affect Java analysis in all applications.
 
 | **Query**                    | **Expected impact**    | **Change**                        |
 |------------------------------|------------------------|-----------------------------------|
+| Dereferenced variable may be null (`java/dereferenced-value-may-be-null`) | Fewer false positives | Certain indirect null guards involving two auxiliary variables known to be equal can now be detected. |
 | Query built from user-controlled sources (`java/sql-injection`) | More results | The query now identifies arguments to `Statement.executeLargeUpdate` and `Connection.prepareCall` as SQL expressions sinks. |
 | Query built from local-user-controlled sources (`java/sql-injection-local`) | More results | The query now identifies arguments to `Statement.executeLargeUpdate` and `Connection.prepareCall` as SQL expressions sinks. |
 | Query built without neutralizing special characters (`java/concatenated-sql-query`) | More results | The query now identifies arguments to `Statement.executeLargeUpdate` and `Connection.prepareCall` as SQL expressions sinks. |

--- a/java/ql/src/semmle/code/java/controlflow/Guards.qll
+++ b/java/ql/src/semmle/code/java/controlflow/Guards.qll
@@ -98,6 +98,16 @@ class Guard extends ExprParent {
   }
 
   /**
+   * Gets the basic block containing this guard or the basic block containing
+   * the switch expression if the guard is a switch case.
+   */
+  BasicBlock getBasicBlock() {
+    result = this.(Expr).getBasicBlock() or
+    result = this.(SwitchCase).getSwitch().getExpr().getProperExpr().getBasicBlock() or
+    result = this.(SwitchCase).getSwitchExpr().getExpr().getProperExpr().getBasicBlock()
+  }
+
+  /**
    * Holds if this guard is an equality test between `e1` and `e2`. The test
    * can be either `==`, `!=`, `.equals`, or a switch case. If the test is
    * negated, that is `!=`, then `polarity` is false, otherwise `polarity` is

--- a/java/ql/test/query-tests/Nullness/B.java
+++ b/java/ql/test/query-tests/Nullness/B.java
@@ -101,7 +101,7 @@ public class B {
     if (alen == blen) {
       for(int i = 0; i < alen; i++) {
         sum += a[i]; // OK
-        sum += b[i]; // NPE - false positive
+        sum += b[i]; // OK
       }
     }
     int alen2;

--- a/java/ql/test/query-tests/Nullness/NullMaybe.expected
+++ b/java/ql/test/query-tests/Nullness/NullMaybe.expected
@@ -12,7 +12,6 @@
 | B.java:72:15:72:16 | xs | Variable $@ may be null here because of $@ assignment. | B.java:68:5:68:41 | int[] xs | xs | B.java:68:11:68:40 | xs | this |
 | B.java:75:20:75:21 | xs | Variable $@ may be null here because of $@ assignment. | B.java:68:5:68:41 | int[] xs | xs | B.java:68:11:68:40 | xs | this |
 | B.java:78:20:78:21 | xs | Variable $@ may be null here because of $@ assignment. | B.java:68:5:68:41 | int[] xs | xs | B.java:68:11:68:40 | xs | this |
-| B.java:104:16:104:16 | b | Variable $@ may be null here as suggested by $@ null guard. | B.java:97:36:97:42 | b | b | B.java:99:16:99:24 | ... == ... | this |
 | B.java:118:5:118:7 | obj | Variable $@ may be null here as suggested by $@ null guard. | B.java:117:27:117:36 | obj | obj | B.java:119:13:119:23 | ... != ... | this |
 | B.java:133:5:133:7 | obj | Variable $@ may be null here because of $@ assignment. | B.java:128:5:128:22 | Object obj | obj | B.java:128:12:128:21 | obj | this |
 | B.java:190:7:190:7 | o | Variable $@ may be null here because of $@ assignment. | B.java:178:5:178:20 | Object o | o | B.java:186:5:186:12 | ...=... | this |


### PR DESCRIPTION
Fixes #2026

When a guard reasons about an ssa variable `v1` and that guard is itself guarded by a condition `v1==v2`, then we can carry over any conclusions about `v1` also hold for `v2`.

A qltest for this case was already present, so this is a case we've seen pop up before, even though it appears fairly corner-case.