### PR TITLE
Python: Fix false positives in `py/unused-import`.

### DIFF
--- a/python/ql/src/Imports/UnusedImport.ql
+++ b/python/ql/src/Imports/UnusedImport.ql
@@ -20,7 +20,7 @@ predicate global_name_used(Module m, Variable name) {
         u.getEnclosingModule() = m
     )
     or
-    /* A use of an undefined class local variable, will use the global variable */
+    // A use of an undefined class local variable, will use the global variable
     exists(Name u, LocalVariable v |
         u.uses(v) and
         v.getId() = name.getId() and
@@ -33,10 +33,10 @@ predicate global_name_used(Module m, Variable name) {
 predicate all_not_understood(Module m) {
     exists(GlobalVariable a | 
         a.getId() = "__all__" and a.getScope() = m |
-        /* __all__ is not defined as a simple list */
+        // `__all__` is not defined as a simple list
         not m.declaredInAll(_)
         or
-        /* __all__ is modified */
+        // `__all__` is modified
         exists(Call c | c.getFunc().(Attribute).getObject() = a.getALoad())
     )
 }
@@ -45,10 +45,9 @@ predicate imported_module_used_in_doctest(Import imp) {
     exists(string modname |
         imp.getAName().getAsname().(Name).getId() = modname
         and
-        /* Look for doctests containing the patterns:
-         * >>> …name…
-         * ... …name…
-         */
+        // Look for doctests containing the patterns:
+        // >>> …name…
+        // ... …name…
         exists(StrConst doc |
             doc.getEnclosingModule() = imp.getScope() and
             doc.isDocString() and
@@ -62,9 +61,8 @@ predicate imported_module_used_in_typehint(Import imp) {
         imp.getAName().getAsname().(Name).getId() = modname and
         loc.getFile() = imp.getScope().(Module).getFile()
         |
-        /* Look for typehints containing the patterns:
-         * # type: …name…
-         */
+        // Look for type hints containing the patterns:
+        // # type: …name…
         exists(Comment typehint |
             loc = typehint.getLocation() and
             typehint.getText().regexpMatch("# type:.*" + modname + ".*")
@@ -95,10 +93,10 @@ predicate unused_import(Import imp, Variable name) {
     and
     not global_name_used(imp.getScope(), name)
     and
-    /* Imports in __init__.py are used to force module loading */
+    // Imports in `__init__.py` are used to force module loading
     not imp.getEnclosingModule().isPackageInit()
     and
-    /* Name may be imported for use in epytext documentation */
+    // Name may be imported for use in epytext documentation
     not exists(Comment cmt |
         cmt.getText().matches("%L{" + name.getId() + "}%") |
         cmt.getLocation().getFile() = imp.getLocation().getFile()
@@ -106,16 +104,15 @@ predicate unused_import(Import imp, Variable name) {
     and
     not name_acceptable_for_unused_variable(name)
     and
-    /* Assume that opaque `__all__` includes imported module */
+    // Assume that opaque `__all__` includes imported module
     not all_not_understood(imp.getEnclosingModule())
     and
     not imported_module_used_in_doctest(imp)
     and
     not imported_module_used_in_typehint(imp)
     and
-    /* Only consider import statements that actually point-to something (possibly an unknown module). 
-     * If this is not the case, it's likely that the import statement never gets executed.
-     */
+    // Only consider import statements that actually point-to something (possibly an unknown module). 
+    // If this is not the case, it's likely that the import statement never gets executed.
     imp.getAName().getValue().pointsTo(_)
 }
 

--- a/python/ql/test/query-tests/Imports/unused/imports_test.py
+++ b/python/ql/test/query-tests/Imports/unused/imports_test.py
@@ -76,3 +76,17 @@ import typing
 
 foo = None # type: typing.Optional[int]
 
+
+# OK since the import statement is never executed
+if False:
+    import never_imported
+
+# OK since the imported module is used in a forward-referenced type annotation.
+import only_used_in_parameter_annotation
+
+def func(x: 'Optional[only_used_in_parameter_annotation]'):
+    pass
+
+import only_used_in_annotated_assignment
+
+var : 'Optional[only_used_in_annotated_assignment]' = 5


### PR DESCRIPTION
Fixes one of the false positives reported in #2014 (in two different ways).

Firstly, we now consider occurrences of a module name inside a string annotation of a parameter to be a "use" of that module.

Secondly, we only report unused modules arising from `import` statements that are likely to be executed, using the existence of points-to information for the module name as a proxy for reachability. This should be fairly safe -- even if we don't correctly identify what the module actually points to, we should infer that it points to some unknown module. On its own, this would also prevent the reported false positive from occurring, since the import in question is guarded by a check of `typing.TYPE_CHECKING`, which is `False` except during type checking.

This still needs careful testing to see how it affects the already existing alerts on LGTM.com.