### PR TITLE
Add tags tag to a Python query

### DIFF
--- a/python/ql/src/Variables/UndefinedPlaceHolder.ql
+++ b/python/ql/src/Variables/UndefinedPlaceHolder.ql
@@ -2,6 +2,8 @@
  * @name Use of an undefined placeholder variable
  * @description Using a variable before it is initialized causes an exception.
  * @kind problem
+ * @tags reliability
+ *       correctness
  * @problem.severity error
  * @sub-severity low
  * @precision medium


### PR DESCRIPTION
A Python query was missing `@tags` metadata tag and now has one