### PR TITLE
C#: Cleanup more files after failed autobuilder attempt

### DIFF
--- a/csharp/autobuilder/Semmle.Autobuild/Autobuilder.cs
+++ b/csharp/autobuilder/Semmle.Autobuild/Autobuilder.cs
@@ -262,12 +262,23 @@ namespace Semmle.Autobuild
                         BuildScript.DeleteDirectory(Actions.GetEnvironmentVariable("TRAP_FOLDER"));
                     var cleanSourceArchive =
                         BuildScript.DeleteDirectory(Actions.GetEnvironmentVariable("SOURCE_ARCHIVE"));
-                    var cleanExtractorLog =
-                        BuildScript.DeleteFile(Extractor.GetCSharpLogPath());
+                    var tryCleanExtractorArgsLogs =
+                        BuildScript.Create(actions =>
+                        {
+                            foreach (var file in Extractor.GetCSharpArgsLogs())
+                                try
+                                {
+                                    actions.FileDelete(file);
+                                }
+                                catch // lgtm[cs/catch-of-all-exceptions] lgtm[cs/empty-catch-block]
+                                { }
+                            return 0;
+                        });
                     var attemptExtractorCleanup =
                         BuildScript.Try(cleanTrapFolder) &
                         BuildScript.Try(cleanSourceArchive) &
-                        BuildScript.Try(cleanExtractorLog);
+                        tryCleanExtractorArgsLogs &
+                        BuildScript.DeleteFile(Extractor.GetCSharpLogPath());
 
                     /// <summary>
                     /// Execute script `s` and check that the C# extractor has been executed.

--- a/csharp/extractor/Semmle.Extraction.CSharp/Analyser.cs
+++ b/csharp/extractor/Semmle.Extraction.CSharp/Analyser.cs
@@ -450,8 +450,7 @@ namespace Semmle.Extraction.CSharp
             LogExtractorInfo(extractorVersion);
             Logger.Log(Severity.Info, $"  Arguments to Roslyn: {string.Join(' ', roslynArgs)}");
 
-            var csharpLogDir = Extractor.GetCSharpLogDirectory();
-            var tempFile = Path.Combine(csharpLogDir, $"csharp.{Path.GetRandomFileName()}.txt");
+            var tempFile = Extractor.GetCSharpArgsLogPath(Path.GetRandomFileName());
 
             bool argsWritten;
             using (var streamWriter = new StreamWriter(new FileStream(tempFile, FileMode.Append, FileAccess.Write)))
@@ -461,7 +460,7 @@ namespace Semmle.Extraction.CSharp
             }
 
             var hash = FileUtils.ComputeFileHash(tempFile);
-            var argsFile = Path.Combine(csharpLogDir, $"csharp.{hash}.txt");
+            var argsFile = Extractor.GetCSharpArgsLogPath(hash);
 
             if (argsWritten)
                 Logger.Log(Severity.Info, $"  Arguments have been written to {argsFile}");

--- a/csharp/extractor/Semmle.Extraction.CSharp/Extractor.cs
+++ b/csharp/extractor/Semmle.Extraction.CSharp/Extractor.cs
@@ -391,7 +391,19 @@ namespace Semmle.Extraction.CSharp
         public static string GetCSharpLogPath() =>
             Path.Combine(GetCSharpLogDirectory(), "csharp.log");
 
-        public static string GetCSharpLogDirectory()
+        /// <summary>
+        /// Gets the path to a `csharp.{hash}.txt` file written to by the C# extractor.
+        /// </summary>
+        public static string GetCSharpArgsLogPath(string hash) =>
+            Path.Combine(GetCSharpLogDirectory(), $"csharp.{hash}.txt");
+
+        /// <summary>
+        /// Gets a list of all `csharp.{hash}.txt` files currently written to the log directory.
+        /// </summary>
+        public static IEnumerable<string> GetCSharpArgsLogs() =>
+            Directory.EnumerateFiles(GetCSharpLogDirectory(), "csharp.*.txt");
+
+        static string GetCSharpLogDirectory()
         {
             string snapshot = Environment.GetEnvironmentVariable("ODASA_SNAPSHOT");
             string buildErrorDir = Environment.GetEnvironmentVariable("ODASA_BUILD_ERROR_DIR");


### PR DESCRIPTION
Cleaning up old response files is needed following https://github.com/Semmle/ql/pull/1851, otherwise we may skip extraction for a compilation that was part of a previous failing build attempt.