### PR TITLE
C++: Add test cases for constant initializers

### DIFF
--- a/cpp/ql/test/duplication-tests/constants/constants.cpp
+++ b/cpp/ql/test/duplication-tests/constants/constants.cpp
@@ -1,0 +1,12 @@
+
+int x = int();
+float y = float();
+double z = double();
+
+/* This produces a getValueText() of 0 for R() in line 9, which is debatable.  */
+struct R {};
+struct S {
+  S() : S(R()) { }
+  S(R) { }
+};
+S s;

--- a/cpp/ql/test/duplication-tests/constants/expr.expected
+++ b/cpp/ql/test/duplication-tests/constants/expr.expected
@@ -1,0 +1,4 @@
+| constants.cpp:2:9:2:13 | 0 | int() |
+| constants.cpp:3:11:3:17 | 0.0 | float() |
+| constants.cpp:4:12:4:19 | 0.0 | double() |
+| constants.cpp:9:11:9:13 | 0 | 0 |

--- a/cpp/ql/test/duplication-tests/constants/expr.ql
+++ b/cpp/ql/test/duplication-tests/constants/expr.ql
@@ -1,0 +1,4 @@
+import cpp
+
+from Expr e
+select e, e.getValueText()


### PR DESCRIPTION
Adds test cases for initialisation of constants which aren't simple zeros. 

Example: `int x = int();`

(Internal PR: https://git.semmle.com/Semmle/code/pull/34349)