### PR TITLE
QL training slides: increase release number and small css tweaks

### DIFF
--- a/docs/language/ql-training/_static-training/slides-semmle-2/static/theme/css/default.css
+++ b/docs/language/ql-training/_static-training/slides-semmle-2/static/theme/css/default.css
@@ -485,6 +485,7 @@ ul {
   margin-left: 2.2em;
   margin-bottom: 1em;
   position: relative;
+  width: 90%;
 }
 /* line 300, ../scss/default.scss */
 ul li {
@@ -1569,7 +1570,7 @@ p.first.admonition-title {
   text-align: left;
   font-size: 0.8em;
   width: 100%;
-  overflow: scroll;
+  overflow: auto;
   border: 1px solid black;
 }
 
@@ -1608,7 +1609,7 @@ p.first.admonition-title {
   display: block;
   position: fixed;
   top: 0;
-  right: -1%;
+  right: 0;
   font-size: 1.2em;
 }
 

--- a/docs/language/ql-training/conf.py
+++ b/docs/language/ql-training/conf.py
@@ -86,9 +86,9 @@ htmlhelp_basename = 'QL training'
 # built documents.
 #
 # The short X.Y version.
-version = u'1.21'
+version = u'1.22'
 # The full version, including alpha/beta/rc tags.
-release = u'1.21'
+release = u'1.22'
 copyright = u'2019 Semmle Ltd'
 author = u'Semmle Ltd'
 


### PR DESCRIPTION
@shati-patel this PR includes a few changes needed for the republication of the QL training slides. 
- update the version number for the new release
- slightly reposition the `x` on the notes pages
- further correction to the width of list items and overflow behaviour on the notes pages  

I've already updated the output files, so this makes the same changes to the source files.