### PR TITLE
C++: Avoid `extends Operation` in LeapYear.qll

### DIFF
--- a/cpp/ql/src/Likely Bugs/Leap Year/LeapYear.qll
+++ b/cpp/ql/src/Likely Bugs/Leap Year/LeapYear.qll
@@ -30,7 +30,7 @@ private predicate additionalLogicalCheck(Expr e, string operation, int valueToCh
 /**
  * An `Operation` that seems to be checking for leap year.
  */
-class CheckForLeapYearOperation extends Operation {
+class CheckForLeapYearOperation extends Expr {
   CheckForLeapYearOperation() {
     exists(BinaryArithmeticOperation bo | bo = this |
       bo.getAnOperand().getValue().toInt() = 4 and
@@ -39,8 +39,6 @@ class CheckForLeapYearOperation extends Operation {
       additionalLogicalCheck(this.getEnclosingElement(), "%", 400)
     )
   }
-
-  override string getOperator() { result = "LeapYearCheck" }
 }
 
 /**


### PR DESCRIPTION
The `Operation` class is abstract, and extending it caused cached stages to be recomputed all the way down to the AST. This meant that the leap year queries evaluated their own copy of SSA and data flow.