### PR TITLE
JS: use of returnless function

### DIFF
--- a/change-notes/1.23/analysis-javascript.md
+++ b/change-notes/1.23/analysis-javascript.md
@@ -17,7 +17,7 @@
 | Unused index variable (`js/unused-index-variable`)                        | correctness                                                       | Highlights loops that iterate over an array, but do not use the index variable to access array elements, indicating a possible typo or logic error. Results are shown on LGTM by default. |
 | Loop bound injection (`js/loop-bound-injection`)                          | security, external/cwe/cwe-834                                      | Highlights loops where a user-controlled object with an arbitrary .length value can trick the server to loop indefinitely. Results are not shown on LGTM by default. |
 | Suspicious method name (`js/suspicious-method-name-declaration`)          | correctness, typescript, methods                                  | Highlights suspiciously named methods where the developer likely meant to write a constructor or function. Results are shown on LGTM by default. |
-| Use of returnless function (`js/use-of-returnless-function`)              | maintainability, correctness                                      | Highlights calls to functions where the return value is used, but the called function never returns a value. Results are shown on LGTM by default. |
+| Use of returnless function (`js/use-of-returnless-function`)              | maintainability, correctness                                      | Highlights calls where the return value is used, but the callee never returns a value. Results are shown on LGTM by default. |
 
 
 ## Changes to existing queries

--- a/change-notes/1.23/analysis-javascript.md
+++ b/change-notes/1.23/analysis-javascript.md
@@ -17,6 +17,8 @@
 | Unused index variable (`js/unused-index-variable`)                        | correctness                                                       | Highlights loops that iterate over an array, but do not use the index variable to access array elements, indicating a possible typo or logic error. Results are shown on LGTM by default. |
 | Loop bound injection (`js/loop-bound-injection`)                          | security, external/cwe/cwe-834                                      | Highlights loops where a user-controlled object with an arbitrary .length value can trick the server to loop indefinitely. Results are not shown on LGTM by default. |
 | Suspicious method name (`js/suspicious-method-name-declaration`)          | correctness, typescript, methods                                  | Highlights suspiciously named methods where the developer likely meant to write a constructor or function. Results are shown on LGTM by default. |
+| Use of returnless function (`js/use-of-returnless-function`)              | maintainability, correctness                                      | Highlights calls to functions where the return value is used, but the called function never returns a value. Results are shown on LGTM by default. |
+
 
 ## Changes to existing queries
 

--- a/javascript/ql/src/Expressions/ExprHasNoEffect.qll
+++ b/javascript/ql/src/Expressions/ExprHasNoEffect.qll
@@ -28,8 +28,6 @@ predicate inVoidContext(Expr e) {
     i < n - 1 or inVoidContext(seq)
   ) 
   or
-  exists(ParExpr par | par.getExpression() = e and inVoidContext(par) )
-  or
   exists(ForStmt stmt | e = stmt.getUpdate())
   or
   exists(ForStmt stmt | e = stmt.getInit() |
@@ -38,8 +36,4 @@ predicate inVoidContext(Expr e) {
   )
   or
   exists(LogicalBinaryExpr logical | e = logical.getRightOperand() and inVoidContext(logical))
-  or 
-  exists(TypeAssertion assert | assert.getExpression() = e and inVoidContext(assert))
-  or 
-  exists(UnaryExpr unOp | unOp.getOperator() = "void" and unOp.getOperand() = e)
 }

--- a/javascript/ql/src/Expressions/ExprHasNoEffect.qll
+++ b/javascript/ql/src/Expressions/ExprHasNoEffect.qll
@@ -26,7 +26,7 @@ predicate inVoidContext(Expr e) {
     n = seq.getNumOperands()
   |
     i < n - 1 or inVoidContext(seq)
-  ) 
+  )
   or
   exists(ForStmt stmt | e = stmt.getUpdate())
   or

--- a/javascript/ql/src/Expressions/ExprHasNoEffect.qll
+++ b/javascript/ql/src/Expressions/ExprHasNoEffect.qll
@@ -26,7 +26,9 @@ predicate inVoidContext(Expr e) {
     n = seq.getNumOperands()
   |
     i < n - 1 or inVoidContext(seq)
-  )
+  ) 
+  or
+  exists(ParExpr par | par.getExpression() = e and inVoidContext(par) )
   or
   exists(ForStmt stmt | e = stmt.getUpdate())
   or
@@ -36,4 +38,8 @@ predicate inVoidContext(Expr e) {
   )
   or
   exists(LogicalBinaryExpr logical | e = logical.getRightOperand() and inVoidContext(logical))
+  or 
+  exists(TypeAssertion assert | assert.getExpression() = e and inVoidContext(assert))
+  or 
+  exists(UnaryExpr unOp | unOp.getOperator() = "void" and unOp.getOperand() = e)
 }

--- a/javascript/ql/src/Statements/UseOfReturnlessFunction.qhelp
+++ b/javascript/ql/src/Statements/UseOfReturnlessFunction.qhelp
@@ -4,7 +4,7 @@
 <qhelp>
 <overview>
 <p>
-JavaScript functions that do not return any value will implicitly return 
+JavaScript functions that do not return an expression will implicitly return 
 <code>undefined</code>. Using the implicit return value from such a function  
 is not an error in itself, but it is a pattern indicating that some
 misunderstanding has occurred. 
@@ -14,8 +14,7 @@ misunderstanding has occurred.
 <recommendation>
 
 <p>
-Do not use the return value from a function that does not explicitly return 
-a value.
+Do not use the return value from a function that does not return an expression.
 </p>
 
 </recommendation>
@@ -23,10 +22,10 @@ a value.
 
 <p>
 In the example below, the function <code>renderText</code> is used to render 
-text through side effects, and the function does not return a value. 
+text through side effects, and the function does not return an expression. 
 However, the programmer still uses the return value from 
-<code>renderText</code> as if the function returned a value, which is clearly 
-an error. 
+<code>renderText</code> as if the function returned an expression, which is 
+clearly an error. 
 </p>
 
 <sample src="examples/UseOfReturnlessFunction.js" />
@@ -34,7 +33,7 @@ an error.
 <p>
 The program can be fixed either removing the use of the value returned by 
 <code>renderText</code>, or by changing the <code>renderText</code> method 
-to return a value.
+to return an expression.
 </p>
 
 </example>

--- a/javascript/ql/src/Statements/UseOfReturnlessFunction.qhelp
+++ b/javascript/ql/src/Statements/UseOfReturnlessFunction.qhelp
@@ -22,7 +22,7 @@ a value.
 <example>
 
 <p>
-In the below example the function <code>renderText</code> is used to render 
+In the example below, the function <code>renderText</code> is used to render 
 text through side effects, and the function does not return a value. 
 However, the programmer still uses the return value from 
 <code>renderText</code> as if the function returned a value, which is clearly 

--- a/javascript/ql/src/Statements/UseOfReturnlessFunction.qhelp
+++ b/javascript/ql/src/Statements/UseOfReturnlessFunction.qhelp
@@ -1,0 +1,38 @@
+<!DOCTYPE qhelp PUBLIC
+  "-//Semmle//qhelp//EN"
+  "qhelp.dtd">
+<qhelp>
+<overview>
+<p>
+JavaScript functions that do not return any value will implicitly return 
+<code>undefined</code>. Using the return value from a function that never 
+explicitly return a value is not an error in itself, but it is a highly 
+suspicious pattern indicating that some misunderstanding has occurred. 
+</p>
+
+</overview>
+<recommendation>
+
+<p>
+Do not use the return value from a function that does not explicitly return 
+a value.
+</p>
+
+</recommendation>
+<example>
+
+<p>
+In the below example the function <code>renderText</code> is used to render 
+text through side effects, and the function does not return a value. 
+However, the programmer still uses the return value from 
+<code>renderText</code> as if the function returned a value, which is clearly 
+an error. 
+</p>
+
+<sample src="examples/UseOfReturnlessFunction.js" />
+
+</example>
+<references>
+<li>Mozilla Developer Network: <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/return">Return</a>.</li>
+</references>
+</qhelp>

--- a/javascript/ql/src/Statements/UseOfReturnlessFunction.qhelp
+++ b/javascript/ql/src/Statements/UseOfReturnlessFunction.qhelp
@@ -4,10 +4,10 @@
 <qhelp>
 <overview>
 <p>
-JavaScript functions that do not explicitly return a value will implicitly return 
-<code>undefined</code>. Using the return value from a function that never 
-explicitly return a value is not an error in itself, but it is a highly 
-suspicious pattern indicating that some misunderstanding has occurred. 
+JavaScript functions that do not return any value will implicitly return 
+<code>undefined</code>. Using the implicit return value from such a function  
+is not an error in itself, but it is a pattern indicating that some 
+misunderstanding has occurred.
 </p>
 
 </overview>

--- a/javascript/ql/src/Statements/UseOfReturnlessFunction.qhelp
+++ b/javascript/ql/src/Statements/UseOfReturnlessFunction.qhelp
@@ -31,8 +31,8 @@ clearly an error.
 <sample src="examples/UseOfReturnlessFunction.js" />
 
 <p>
-The program can be fixed either removing the use of the value returned by 
-<code>renderText</code>, or by changing the <code>renderText</code> method 
+The program can be fixed either by removing the use of the value returned by 
+<code>renderText</code>, or by changing the <code>renderText</code> function
 to return an expression.
 </p>
 

--- a/javascript/ql/src/Statements/UseOfReturnlessFunction.qhelp
+++ b/javascript/ql/src/Statements/UseOfReturnlessFunction.qhelp
@@ -6,8 +6,8 @@
 <p>
 JavaScript functions that do not return any value will implicitly return 
 <code>undefined</code>. Using the implicit return value from such a function  
-is not an error in itself, but it is a pattern indicating that some 
-misunderstanding has occurred.
+is not an error in itself, but it is a pattern indicating that some
+misunderstanding has occurred. 
 </p>
 
 </overview>
@@ -30,6 +30,12 @@ an error.
 </p>
 
 <sample src="examples/UseOfReturnlessFunction.js" />
+
+<p>
+The program can be fixed either removing the use of the value returned by 
+<code>renderText</code>, or by changing the <code>renderText</code> method 
+to return a value.
+</p>
 
 </example>
 <references>

--- a/javascript/ql/src/Statements/UseOfReturnlessFunction.qhelp
+++ b/javascript/ql/src/Statements/UseOfReturnlessFunction.qhelp
@@ -4,7 +4,7 @@
 <qhelp>
 <overview>
 <p>
-JavaScript functions that do not return any value will implicitly return 
+JavaScript functions that do not explicitly return a value will implicitly return 
 <code>undefined</code>. Using the return value from a function that never 
 explicitly return a value is not an error in itself, but it is a highly 
 suspicious pattern indicating that some misunderstanding has occurred. 

--- a/javascript/ql/src/Statements/UseOfReturnlessFunction.ql
+++ b/javascript/ql/src/Statements/UseOfReturnlessFunction.ql
@@ -98,17 +98,15 @@ predicate callBlacklist(DataFlow::CallNode call) {
   exists(MethodCallExpr e | e.getCalleeName() = "resolve" and call.asExpr() = e.getArgument(0))
 }
 
-from Function f, DataFlow::CallNode call
+from DataFlow::CallNode call
 where
   // Intentionally only considering very precise callee information. It makes almost no difference.
-  f = call.getACallee(0) and
-  count(call.getACallee(0)) = 1 and 
-  
-  not functionBlacklist(f) and
+  not call.isIndefinite(_) and 
+  forex(Function f | f = call.getACallee() | not functionBlacklist(f)) and
   
   exists(call.asExpr()) and // TODO: Need to figure out what to do about reflective calls.
   
   not callBlacklist(call)
 select
-  call, "the function $@ does not return anything, yet the return value is used.", f, call.getCalleeName()
+  call, "the function $@ does not return anything, yet the return value is used.", call.getACallee(), call.getCalleeName()
   

--- a/javascript/ql/src/Statements/UseOfReturnlessFunction.ql
+++ b/javascript/ql/src/Statements/UseOfReturnlessFunction.ql
@@ -50,6 +50,10 @@ predicate benignContext(Expr e) {
   exists(VoidExpr voidExpr | voidExpr.getOperand() = e)
 
   or
+  // weeds out calls inside HTML-attributes.
+  e.getContainer() instanceof CodeInAttribute or  
+  // and JSX-attributes.
+  e = any(JSXAttribute attr).getValue() or 
   
   // It is ok (or to be flagged by another query?) to await a non-async function. 
   exists(AwaitExpr await | await.getOperand() = e and benignContext(await)) 
@@ -83,11 +87,6 @@ predicate callBlacklist(DataFlow::CallNode call) {
   
   // anonymous one-shot closure. Those are used in weird ways and we ignore them.
   call.asExpr() = any(ImmediatelyInvokedFunctionExpr f).getInvocation() or  
-
-  // weeds out calls inside html-attributes.
-  call.asExpr().getParent*() instanceof CodeInAttribute or  
-  // and JSX-attributes.
-  call.asExpr().getParent*() instanceof JSXAttribute or 
   
   // Calls on "this" tend to overloaded. So future overloads might start returning something.
   call.asExpr().(MethodCallExpr).getReceiver() instanceof ThisExpr or 

--- a/javascript/ql/src/Statements/UseOfReturnlessFunction.ql
+++ b/javascript/ql/src/Statements/UseOfReturnlessFunction.ql
@@ -15,7 +15,6 @@ import Expressions.ExprHasNoEffect
 import Statements.UselessConditional
 
 predicate returnsVoid(Function f) {
-  not f instanceof ArrowFunctionExpr and
   not f.isGenerator() and
   not f.isAsync() and
   not exists(f.getAReturnedExpr())

--- a/javascript/ql/src/Statements/UseOfReturnlessFunction.ql
+++ b/javascript/ql/src/Statements/UseOfReturnlessFunction.ql
@@ -88,13 +88,8 @@ predicate callBlacklist(DataFlow::CallNode call) {
   // anonymous one-shot closure. Those are used in weird ways and we ignore them.
   call.asExpr() = any(ImmediatelyInvokedFunctionExpr f).getInvocation() or  
   
-  // Calls on "this" tend to overloaded. So future overloads might start returning something.
-  call.asExpr().(MethodCallExpr).getReceiver() instanceof ThisExpr or 
-  // similarly, methods received through parameters might later receive new dataflow. We have just only seen one callee.
-  call.getCalleeNode().getALocalSource() instanceof DataFlow::ParameterNode or 
-  
   // arguments to Promise.resolve (and promise library variants) are benign. 
-  exists(MethodCallExpr e | e.getCalleeName() = "resolve" and call.asExpr() = e.getArgument(0))
+  call = any(ResolvedPromiseDefinition promise).getValue()
 }
 
 from DataFlow::CallNode call

--- a/javascript/ql/src/Statements/UseOfReturnlessFunction.ql
+++ b/javascript/ql/src/Statements/UseOfReturnlessFunction.ql
@@ -72,6 +72,9 @@ predicate benignContext(Expr e) {
   e = any(ResolvedPromiseDefinition promise).getValue().asExpr()
 }
 
+predicate oneshotClosure(InvokeExpr call) {
+  call.getCallee().getUnderlyingValue() instanceof ImmediatelyInvokedFunctionExpr
+}
 
 from DataFlow::CallNode call
 where
@@ -81,7 +84,7 @@ where
   not benignContext(call.asExpr()) and
   
   // anonymous one-shot closure. Those are used in weird ways and we ignore them.
-  call.asExpr() != any(ImmediatelyInvokedFunctionExpr f).getInvocation()
+  not oneshotClosure(call.asExpr())
 select
   call, "the function $@ does not return anything, yet the return value is used.", call.getACallee(), call.getCalleeName()
   

--- a/javascript/ql/src/Statements/UseOfReturnlessFunction.ql
+++ b/javascript/ql/src/Statements/UseOfReturnlessFunction.ql
@@ -1,0 +1,103 @@
+/**
+ * @name Use of returnless function.
+ * @description Using the return value of a function that does not return anything is highly suspicious.
+ * @kind problem
+ * @problem.severity recommendation
+ * @id js/use-of-returnless-function
+ * @tags maintainability,
+ *       correctness
+ * @precision high
+ */
+
+import javascript
+import Declarations.UnusedVariable
+import Expressions.ExprHasNoEffect
+
+predicate returnsVoid(Function f) {
+  exists(f.getBody().(Stmt)) and
+  not f instanceof ExternalDecl and
+  not f.isGenerator() and
+  not f.isAsync() and
+  not exists(f.getAReturnedExpr())
+}
+
+predicate isStub(Function f) {
+    f.getBodyStmt(0) instanceof ThrowStmt
+    or
+    f.getBody().(BlockStmt).getNumChild() = 0
+}
+
+predicate benignContext(Expr e) {
+  inVoidContext(e) or 
+  
+  // A return statement is often used to just end the function.
+  exists(ReturnStmt ret | 
+    ret.getExpr() = e
+  )
+  or 
+  exists(ConditionalExpr cond | cond.getABranch() = e and benignContext(cond)) 
+  or 
+  exists(BinaryExpr bin | (bin.getOperator() = "&&" or bin.getOperator() = "||") and bin.getAnOperand() = e and benignContext(bin)) 
+  or
+  exists(SeqExpr parent | parent.getAnOperand() = e and benignContext(parent))
+  or
+  exists(ParExpr par | par.getExpression() = e and benignContext(par))
+  or
+  
+  // It is ok (or to be flagged by another query?) to await a non-async function. 
+  exists(AwaitExpr await | await.getOperand() = e) 
+  or
+  
+  // Avoid double reporting. It will always evaluate to false.
+  exists(IfStmt ifStmt | ifStmt.getCondition() = e)
+  or 
+  // Avoid double reporting. `e` will always evaluate to undefined.
+  exists(Comparison binOp | binOp.getAnOperand() = e)
+  or
+  // Avoid double reporting of "The base expression of this property access is always undefined.". 
+  exists(PropAccess ac | ac.getBase() = e)
+  or
+  // The call is only in a non-void context because it is in a lambda.
+  exists(ArrowFunctionExpr arrow |
+    arrow.getBody() = e
+  ) 
+  or
+  // Avoid double-reporting with unused local.
+  exists(VariableDeclarator v | v.getInit() = e and v.getBindingPattern().getVariable() instanceof UnusedLocal)
+}
+
+from Function f, DataFlow::CallNode call
+where
+  // Intentionally only considering very precise callee information. It makes almost no difference.
+  f = call.getACallee(0) and
+  count(call.getACallee(0)) = 1 and 
+  
+  returnsVoid(f) and 
+  
+  // reflective calls don't have an ast-node, thus we can't decide whether or not they are in void-context.
+  exists(call.asExpr()) and 
+  
+  not isStub(f) and 
+  
+  not call.getTopLevel().isMinified() and  
+   
+  not benignContext(call.asExpr()) and
+  
+  // anonymous one-shot closure. Those are used in weird ways and we ignore them.
+  not call.getCalleeNode().asExpr() instanceof FunctionExpr and 
+
+  // weeds out calls inside html-attributes.
+  not(call.asExpr().getParent*() instanceof CodeInAttribute) and 
+  // and JSX-attributes.
+  not(call.asExpr().getParent*() instanceof JSXAttribute) and
+  
+  // Calls on "this" tend to overloaded. So future overloads might start returning something.
+  not call.asExpr().(MethodCallExpr).getReceiver() instanceof ThisExpr and
+  // similarly, methods received through parameters might later receive new dataflow. We have just only seen one callee.
+  not call.getCalleeNode().getALocalSource() instanceof DataFlow::ParameterNode and
+  
+  // arguments to Promise.resolve (and promise library variants) are benign. 
+  not exists(MethodCallExpr e | e.getCalleeName() = "resolve" and call.asExpr() = e.getArgument(0))
+select
+  call, "the function $@ does not return anything, yet the return value is used.", f, call.getCalleeName()
+  

--- a/javascript/ql/src/Statements/UseOfReturnlessFunction.ql
+++ b/javascript/ql/src/Statements/UseOfReturnlessFunction.ql
@@ -42,6 +42,10 @@ predicate benignContext(Expr e) {
   exists(SeqExpr parent | parent.getAnOperand() = e and benignContext(parent))
   or
   exists(ParExpr par | par.getExpression() = e and benignContext(par))
+  or 
+  exists(TypeAssertion assert | assert.getExpression() = e and inVoidContext(assert))
+  or 
+  exists(UnaryExpr unOp | unOp.getOperator() = "void" and unOp.getOperand() = e)
   or
   
   // It is ok (or to be flagged by another query?) to await a non-async function. 

--- a/javascript/ql/src/Statements/UseOfReturnlessFunction.ql
+++ b/javascript/ql/src/Statements/UseOfReturnlessFunction.ql
@@ -1,5 +1,5 @@
 /**
- * @name Use of returnless function.
+ * @name Use of returnless function
  * @description Using the return value of a function that does not explicitly return is indicative of a mistake.
  * @kind problem
  * @problem.severity warning

--- a/javascript/ql/src/Statements/UseOfReturnlessFunction.ql
+++ b/javascript/ql/src/Statements/UseOfReturnlessFunction.ql
@@ -2,7 +2,7 @@
  * @name Use of returnless function.
  * @description Using the return value of a function that does not explicitly return is indicative of a mistake.
  * @kind problem
- * @problem.severity recommendation
+ * @problem.severity warning
  * @id js/use-of-returnless-function
  * @tags maintainability,
  *       correctness

--- a/javascript/ql/src/Statements/UseOfReturnlessFunction.ql
+++ b/javascript/ql/src/Statements/UseOfReturnlessFunction.ql
@@ -1,6 +1,6 @@
 /**
  * @name Use of returnless function.
- * @description Using the return value of a function that does not return anything is highly suspicious.
+ * @description Using the return value of a function that does not explicitly return is indicative of a mistake.
  * @kind problem
  * @problem.severity recommendation
  * @id js/use-of-returnless-function
@@ -15,7 +15,7 @@ import Expressions.ExprHasNoEffect
 import Statements.UselessConditional
 
 predicate returnsVoid(Function f) {
-  exists(f.getBody().(Stmt)) and
+  f.getBody() instanceof Stmt and
   not f instanceof ExternalDecl and
   not f.isGenerator() and
   not f.isAsync() and
@@ -40,7 +40,7 @@ predicate benignContext(Expr e) {
   or
   exists(SeqExpr seq, int i, int n | e = seq.getOperand(i) and n = seq.getNumOperands() |
     i < n - 1 or benignContext(seq)
-  ) 
+exists(SeqExpr seq | seq.getLastOperand() = e and benignContext(seq))
   or
   exists(Expr parent | parent.getUnderlyingValue() = e and benignContext(parent))
   or 

--- a/javascript/ql/src/Statements/UseOfReturnlessFunction.ql
+++ b/javascript/ql/src/Statements/UseOfReturnlessFunction.ql
@@ -12,6 +12,7 @@
 import javascript
 import Declarations.UnusedVariable
 import Expressions.ExprHasNoEffect
+import Statements.UselessConditional
 
 predicate returnsVoid(Function f) {
   exists(f.getBody().(Stmt)) and
@@ -57,9 +58,8 @@ predicate benignContext(Expr e) {
   // It is ok (or to be flagged by another query?) to await a non-async function. 
   exists(AwaitExpr await | await.getOperand() = e and benignContext(await)) 
   or
-  
   // Avoid double reporting with js/trivial-conditional
-  exists(IfStmt ifStmt | ifStmt.getCondition() = e)
+  exists(ASTNode cond | isExplicitConditional(cond, e))
   or 
   // Avoid double reporting with js/comparison-between-incompatible-types
   exists(Comparison binOp | binOp.getAnOperand() = e)

--- a/javascript/ql/src/Statements/UseOfReturnlessFunction.ql
+++ b/javascript/ql/src/Statements/UseOfReturnlessFunction.ql
@@ -1,6 +1,6 @@
 /**
  * @name Use of returnless function
- * @description Using the return value of a function that does not explicitly return is indicative of a mistake.
+ * @description Using the return value of a function that does not return an expression is indicative of a mistake.
  * @kind problem
  * @problem.severity warning
  * @id js/use-of-returnless-function
@@ -15,7 +15,7 @@ import Expressions.ExprHasNoEffect
 import Statements.UselessConditional
 
 predicate returnsVoid(Function f) {
-  f.getBody() instanceof Stmt and
+  not f instanceof ArrowFunctionExpr and
   not f.isGenerator() and
   not f.isAsync() and
   not exists(f.getAReturnedExpr())

--- a/javascript/ql/src/Statements/UseOfReturnlessFunction.ql
+++ b/javascript/ql/src/Statements/UseOfReturnlessFunction.ql
@@ -29,6 +29,9 @@ predicate isStub(Function f) {
     f instanceof ExternalDecl
 }
 
+/**
+ * Holds if `e` is in a syntactic context where it likely is fine that the value of `e` comes from a call to a returnless function.
+ */
 predicate benignContext(Expr e) {
   inVoidContext(e) or 
   

--- a/javascript/ql/src/Statements/UselessConditional.ql
+++ b/javascript/ql/src/Statements/UselessConditional.ql
@@ -16,6 +16,7 @@ import javascript
 import semmle.javascript.RestrictedLocations
 import semmle.javascript.dataflow.Refinements
 import semmle.javascript.DefensiveProgramming
+import UselessConditional
 
 /**
  * Gets the unique definition of `v`.
@@ -123,21 +124,7 @@ predicate whitelist(Expr e) {
   isConstantBooleanReturnValue(e)
 }
 
-/**
- * Holds if `e` is part of a conditional node `cond` that evaluates
- * `e` and checks its value for truthiness, and the return value of `e`
- * is not used for anything other than this truthiness check.
- */
-predicate isExplicitConditional(ASTNode cond, Expr e) {
-  e = cond.(IfStmt).getCondition()
-  or
-  e = cond.(LoopStmt).getTest()
-  or
-  e = cond.(ConditionalExpr).getCondition()
-  or
-  isExplicitConditional(_, cond) and
-  e = cond.(Expr).getUnderlyingValue().(LogicalBinaryExpr).getAnOperand()
-}
+
 
 /**
  * Holds if `e` is part of a conditional node `cond` that evaluates

--- a/javascript/ql/src/Statements/UselessConditional.ql
+++ b/javascript/ql/src/Statements/UselessConditional.ql
@@ -124,8 +124,6 @@ predicate whitelist(Expr e) {
   isConstantBooleanReturnValue(e)
 }
 
-
-
 /**
  * Holds if `e` is part of a conditional node `cond` that evaluates
  * `e` and checks its value for truthiness.

--- a/javascript/ql/src/Statements/UselessConditional.qll
+++ b/javascript/ql/src/Statements/UselessConditional.qll
@@ -1,0 +1,17 @@
+import javascript
+
+/**
+ * Holds if `e` is part of a conditional node `cond` that evaluates
+ * `e` and checks its value for truthiness, and the return value of `e`
+ * is not used for anything other than this truthiness check.
+ */
+predicate isExplicitConditional(ASTNode cond, Expr e) {
+  e = cond.(IfStmt).getCondition()
+  or
+  e = cond.(LoopStmt).getTest()
+  or
+  e = cond.(ConditionalExpr).getCondition()
+  or
+  isExplicitConditional(_, cond) and
+  e = cond.(Expr).getUnderlyingValue().(LogicalBinaryExpr).getAnOperand()
+}

--- a/javascript/ql/src/Statements/UselessConditional.qll
+++ b/javascript/ql/src/Statements/UselessConditional.qll
@@ -1,3 +1,7 @@
+/** 
+ * Provides predicates for working with useless conditionals.  
+ */ 
+
 import javascript
 
 /**

--- a/javascript/ql/src/Statements/examples/UseOfReturnlessFunction.js
+++ b/javascript/ql/src/Statements/examples/UseOfReturnlessFunction.js
@@ -1,0 +1,9 @@
+var stage = require("./stage")
+
+function renderText(text, id) {
+    document.getElementById(id).innerText = text;
+}
+
+var text = renderText("Two households, both alike in dignity", "scene");
+
+stage.show(text);

--- a/javascript/ql/test/query-tests/Statements/UseOfReturnlessFunction/UseOfReturnlessFunction.expected
+++ b/javascript/ql/test/query-tests/Statements/UseOfReturnlessFunction/UseOfReturnlessFunction.expected
@@ -1,0 +1,2 @@
+| tst.js:20:17:20:33 | onlySideEffects() | the function $@ does not return anything, yet the return value is used. | tst.js:11:5:13:5 | functio ... )\\n    } | onlySideEffects |
+| tst.js:24:13:24:29 | onlySideEffects() | the function $@ does not return anything, yet the return value is used. | tst.js:11:5:13:5 | functio ... )\\n    } | onlySideEffects |

--- a/javascript/ql/test/query-tests/Statements/UseOfReturnlessFunction/UseOfReturnlessFunction.expected
+++ b/javascript/ql/test/query-tests/Statements/UseOfReturnlessFunction/UseOfReturnlessFunction.expected
@@ -1,2 +1,3 @@
 | tst.js:20:17:20:33 | onlySideEffects() | the function $@ does not return anything, yet the return value is used. | tst.js:11:5:13:5 | functio ... )\\n    } | onlySideEffects |
 | tst.js:24:13:24:29 | onlySideEffects() | the function $@ does not return anything, yet the return value is used. | tst.js:11:5:13:5 | functio ... )\\n    } | onlySideEffects |
+| tst.js:30:20:30:36 | onlySideEffects() | the function $@ does not return anything, yet the return value is used. | tst.js:11:5:13:5 | functio ... )\\n    } | onlySideEffects |

--- a/javascript/ql/test/query-tests/Statements/UseOfReturnlessFunction/UseOfReturnlessFunction.expected
+++ b/javascript/ql/test/query-tests/Statements/UseOfReturnlessFunction/UseOfReturnlessFunction.expected
@@ -1,3 +1,5 @@
 | tst.js:20:17:20:33 | onlySideEffects() | the function $@ does not return anything, yet the return value is used. | tst.js:11:5:13:5 | functio ... )\\n    } | onlySideEffects |
 | tst.js:24:13:24:29 | onlySideEffects() | the function $@ does not return anything, yet the return value is used. | tst.js:11:5:13:5 | functio ... )\\n    } | onlySideEffects |
 | tst.js:30:20:30:36 | onlySideEffects() | the function $@ does not return anything, yet the return value is used. | tst.js:11:5:13:5 | functio ... )\\n    } | onlySideEffects |
+| tst.js:53:10:53:34 | bothOnl ... fects() | the function $@ does not return anything, yet the return value is used. | tst.js:11:5:13:5 | functio ... )\\n    } | bothOnlyHaveSideEffects |
+| tst.js:53:10:53:34 | bothOnl ... fects() | the function $@ does not return anything, yet the return value is used. | tst.js:48:2:50:5 | functio ... )\\n    } | bothOnlyHaveSideEffects |

--- a/javascript/ql/test/query-tests/Statements/UseOfReturnlessFunction/UseOfReturnlessFunction.qlref
+++ b/javascript/ql/test/query-tests/Statements/UseOfReturnlessFunction/UseOfReturnlessFunction.qlref
@@ -1,0 +1,1 @@
+Statements/UseOfReturnlessFunction.ql

--- a/javascript/ql/test/query-tests/Statements/UseOfReturnlessFunction/tst.js
+++ b/javascript/ql/test/query-tests/Statements/UseOfReturnlessFunction/tst.js
@@ -29,4 +29,12 @@
 	
 	var d = 42 + (42, onlySideEffects()); // NOT OK! 
 	console.log(d);
+	
+	if (onlySideEffects()) { 
+		// nothing.
+	}
+	
+	for (i = 0; onlySideEffects(); i++) {
+		// nothing. 
+	}
 })();

--- a/javascript/ql/test/query-tests/Statements/UseOfReturnlessFunction/tst.js
+++ b/javascript/ql/test/query-tests/Statements/UseOfReturnlessFunction/tst.js
@@ -1,0 +1,26 @@
+(function () {
+    function stub() {
+        throw new Error("Not implemented!");
+    }
+
+    function returnsValue() {
+        var x = 3;
+        return x * 2;
+    }
+
+    function onlySideEffects() {
+        console.log("Boo!")
+    }
+    
+    var arrow = () => onlySideEffects();
+
+    console.log(returnsValue())
+    console.log(stub())
+
+    console.log(onlySideEffects()); // Not OK!
+
+    var a = Math.random() > 0.5 ? returnsValue() : onlySideEffects(); // OK! A is never used.
+    
+    var b = onlySideEffects();
+    console.log(b);
+})();

--- a/javascript/ql/test/query-tests/Statements/UseOfReturnlessFunction/tst.js
+++ b/javascript/ql/test/query-tests/Statements/UseOfReturnlessFunction/tst.js
@@ -56,4 +56,16 @@
 	var oneOfEach = Math.random() > 0.5 ? onlySideEffects : returnsValue;
 	var g = oneOfEach(); // OK
 	console.log(g);
+	
+	function alwaysThrows() {
+		if (Math.random() > 0.5) {
+			console.log("Whatever!")
+		} else {
+			console.log("Boo!")
+		}
+		throw new Error("Important error!")
+	} 
+	
+	var h = returnsValue() || alwaysThrows(); // OK!
+	console.log(h);
 })();

--- a/javascript/ql/test/query-tests/Statements/UseOfReturnlessFunction/tst.js
+++ b/javascript/ql/test/query-tests/Statements/UseOfReturnlessFunction/tst.js
@@ -23,4 +23,10 @@
     
     var b = onlySideEffects();
     console.log(b);
+
+	var c = 42 + (onlySideEffects(), 42); // OK, value is thrown away. 
+	console.log(c);
+	
+	var d = 42 + (42, onlySideEffects()); // NOT OK! 
+	console.log(d);
 })();

--- a/javascript/ql/test/query-tests/Statements/UseOfReturnlessFunction/tst.js
+++ b/javascript/ql/test/query-tests/Statements/UseOfReturnlessFunction/tst.js
@@ -37,4 +37,11 @@
 	for (i = 0; onlySideEffects(); i++) {
 		// nothing. 
 	}
+	
+	var myObj = {
+		onlySideEffects: onlySideEffects
+	}
+	
+	var e = myObj.onlySideEffects.apply(this, arguments); // NOT OK!
+	console.log(e);
 })();

--- a/javascript/ql/test/query-tests/Statements/UseOfReturnlessFunction/tst.js
+++ b/javascript/ql/test/query-tests/Statements/UseOfReturnlessFunction/tst.js
@@ -44,4 +44,16 @@
 	
 	var e = myObj.onlySideEffects.apply(this, arguments); // NOT OK!
 	console.log(e);
+	
+	function onlySideEffects2() {
+        console.log("Boo!")
+    }
+
+	var bothOnlyHaveSideEffects = Math.random() > 0.5 ? onlySideEffects : onlySideEffects2;
+	var f = bothOnlyHaveSideEffects(); // NOT OK!
+	console.log(f);
+	
+	var oneOfEach = Math.random() > 0.5 ? onlySideEffects : returnsValue;
+	var g = oneOfEach(); // OK
+	console.log(g);
 })();


### PR DESCRIPTION
The query detects instances where the resulting value from a callsite is used, and the called function never returns a value. E.g: 

```JavaScript
function render(text) {
    document.getElementByID("text").innerHtml = text;
}
var text = render("The story so far: In the beginning the Universe was created.");
console.log(text)
```

Or [this nice real example: ](https://lgtm.com/projects/g/offsky/ADE/snapshot/08d720c5be3d3514d3c03bcf0f649f038524372d/files/app/common/date.js?sort=name&dir=ASC&mode=heatmap#L2581) `throw $D.Parsing.Exception(fmt);` 



@esben-semmle toyed with creating an initial version of this query where the callsites that were potentially flagged was based on a whitelist.   
This version is instead based on a blacklist of callsites to ignore. 

Removing false positives was a game of whack-a-mole, but there was a decent amount of TP's from the beginning. And in with the current state of the query the results look quite good: https://lgtm.com/query/4501216594830381110/

Performance is just about as good as you can expect a dataflow query to be.
