### PR TITLE
Python: Add tests for reachability when using `nonlocal`.

### DIFF
--- a/python/ql/test/query-tests/Statements/unreachable_nonlocal/UnreachableCode.qlref
+++ b/python/ql/test/query-tests/Statements/unreachable_nonlocal/UnreachableCode.qlref
@@ -1,0 +1,1 @@
+Statements/UnreachableCode.ql

--- a/python/ql/test/query-tests/Statements/unreachable_nonlocal/nonlocal.py
+++ b/python/ql/test/query-tests/Statements/unreachable_nonlocal/nonlocal.py
@@ -1,0 +1,51 @@
+
+def nonlocal_fp():
+    test = False
+    def set_test():
+        nonlocal test
+        test = True
+    set_test()
+    if test:
+        raise Exception("Foo")
+
+
+# A couple of false negatives, roughly in order of complexity
+
+# test is nonlocal, but not mutated
+def nonlocal_fn1():
+    test = False
+    def set_test():
+        nonlocal test
+    set_test()
+    if test:
+        raise Exception("Foo")
+
+# test is nonlocal and mutated, but does not change truthiness
+def nonlocal_fn2():
+    test = False
+    def set_test():
+        nonlocal test
+        test = 0
+    set_test()
+    if test:
+        raise Exception("Foo")
+
+# test is nonlocal and changes truthiness, but the function is never called
+def nonlocal_fn3():
+    test = False
+    def set_test():
+        nonlocal test
+        test = True
+    if test:
+        raise Exception("Foo")
+
+# test is nonlocal and changes truthiness, but only if the given argument is true
+def nonlocal_fn4(x):
+    test = False
+    def set_test():
+        nonlocal test
+        test = True
+    if x:
+        set_test()
+    if test:
+        raise Exception("Foo")


### PR DESCRIPTION
Variables marked as `nonlocal` can give rise to false negatives for reachability when they are mutated in a different scope. Thus, a variable that is set to `False`, and where a local function (with said variable `nonlocal` mutates it to be `True`, is considered to be `False` throughout, and in particular this may lead the extrator to prune the `True` branch of an `if`-statement depending on this variable.

On an internal PR, I propose that we do not prune these edges when the variable is also mentioned in a `nonlocal` statement. This will inevitably lead to some false negatives, and I have added tests to this effect.

I expect these tests to fail until we've merged the internal PR. (But once this is done, we can re-run the tests, and they should then go through. I have of course verified that they work locally.)