### PR TITLE
Python: Teach `py/unreachable-statement` about `contextlib.suppress`.

### DIFF
--- a/change-notes/1.23/analysis-python.md
+++ b/change-notes/1.23/analysis-python.md
@@ -12,3 +12,11 @@
 | Clear-text logging of sensitive information (`py/clear-text-logging-sensitive-data`) | security, external/cwe/cwe-312 | Finds instances where sensitive information is logged without encryption or hashing. Results are shown on LGTM by default. |
 | Clear-text storage of sensitive information (`py/clear-text-storage-sensitive-data`) | security, external/cwe/cwe-312 | Finds instances where sensitive information is stored without encryption or hashing. Results are shown on LGTM by default. |
 | Binding a socket to all network interfaces (`py/bind-socket-all-network-interfaces`) | security | Finds instances where a socket is bound to all network interfaces. Results are shown on LGTM by default. |
+
+
+## Changes to existing queries
+
+| **Query**                  | **Expected impact**    | **Change** |
+|----------------------------|------------------------|------------|
+| Unreachable code | Fewer false positives | Analysis now accounts for uses of `contextlib.suppress` to suppress exceptions. |
+

--- a/python/ql/src/Statements/UnreachableCode.ql
+++ b/python/ql/src/Statements/UnreachableCode.ql
@@ -31,9 +31,18 @@ predicate unique_yield(Stmt s) {
     )
 }
 
+/** Holds if `contextlib.suppress` may be used in the same scope as `s` */
+predicate suppression_in_scope(Stmt s) {
+    exists(With w |
+        w.getContextExpr().(Call).getFunc().pointsTo(Value::named("contextlib.suppress")) and
+        w.getScope() = s.getScope()
+    )
+}
+
 predicate reportable_unreachable(Stmt s) {
     s.isUnreachable() and
     not typing_import(s) and
+    not suppression_in_scope(s) and
     not exists(Stmt other | other.isUnreachable() |
         other.contains(s)
         or

--- a/python/ql/test/3/query-tests/Statements/unreachable_suppressed/UnreachableCode.qlref
+++ b/python/ql/test/3/query-tests/Statements/unreachable_suppressed/UnreachableCode.qlref
@@ -1,0 +1,1 @@
+Statements/UnreachableCode.ql

--- a/python/ql/test/3/query-tests/Statements/unreachable_suppressed/test.py
+++ b/python/ql/test/3/query-tests/Statements/unreachable_suppressed/test.py
@@ -29,3 +29,11 @@ def bar(x):
 
 bar(True)
 bar(False)
+
+# False negative
+
+def fn_suppression():
+    with suppress(Exception):
+        raise Exception()
+    return False
+    return True

--- a/python/ql/test/3/query-tests/Statements/unreachable_suppressed/test.py
+++ b/python/ql/test/3/query-tests/Statements/unreachable_suppressed/test.py
@@ -1,0 +1,31 @@
+from contextlib import suppress
+
+def raises_exception():
+    raise Exception("This will be suppressed")
+
+def foo():
+    test = False
+    with suppress(Exception):
+        raises_exception()
+        test = True
+    if test:
+        return
+    print("An exception was raised") # FP: not reached
+
+foo()
+
+def bar(x):
+    test = False
+    try:
+        if x:
+            raise Exception("Bar")
+        test = True
+    except Exception:
+        pass
+    if test:
+        print("Test was set")
+        return
+    print("Test was not set")
+
+bar(True)
+bar(False)


### PR DESCRIPTION
The `contextlib.suppress` context handler can be used to suppress exceptions that happen during the execution of the body of the `with` statement. (Essentially, it can be thought of as shorthand for a `try: ... except:` handler where the body of the `except` is `pass`.)

This may lead to false positives due to over-eager pruning in the extractor, as the following example shows:

```python
def raise_exception():
    raise Exception("This will be suppressed")

def foo():
    test = False
    with suppress(Exception):
        raise_exception()
        test = True
    if test:
        return
    print("An exception was raised") # FP: not reached
```

Because an exception is raised before `test = True` is executed, at runtime the early return is never executed. 

In principle, we could fix this in the extractor, by not performing the pruning after all. In this case, however, I think for now it is more useful to detect that an improper pruning may have happened, and suppress the alert in that case. (In part, this means we can resolve `contextlib.suppress` using the `Value` API, which is much better, and precise, than doing it in the extractor.)

Finally, because the unreachable statement is pruned already in the extractor, there is no easy way to check that it is _preceded_ by the suppressing `with` statement (being pruned means there is no control-flow node associated with the statement). Instead, we check if they appear in the same scope.

This still needs a change note before merging.