### PR TITLE
Python: Teach `py/unused-local-variable` about `nonlocal`.

### DIFF
--- a/python/ql/src/Variables/UnusedLocalVariable.ql
+++ b/python/ql/src/Variables/UnusedLocalVariable.ql
@@ -15,8 +15,7 @@ import python
 import Definition
 
 predicate unused_local(Name unused, LocalVariable v) {
-    forex(Definition def |
-        def.getNode() = unused |
+    forex(Definition def | def.getNode() = unused |
         def.getVariable() = v and
         def.isUnused() and
         not exists(def.getARedef()) and
@@ -27,9 +26,9 @@ predicate unused_local(Name unused, LocalVariable v) {
     )
 }
 
-
 from Name unused, LocalVariable v
-where unused_local(unused, v) and 
-// If unused is part of a tuple, count it as unused if all elements of that tuple are unused.
-forall(Name el | el = unused.getParentNode().(Tuple).getAnElt() | unused_local(el, _))
+where
+    unused_local(unused, v) and
+    // If unused is part of a tuple, count it as unused if all elements of that tuple are unused.
+    forall(Name el | el = unused.getParentNode().(Tuple).getAnElt() | unused_local(el, _))
 select unused, "The value assigned to local variable '" + v.getId() + "' is never used."

--- a/python/ql/src/Variables/UnusedLocalVariable.ql
+++ b/python/ql/src/Variables/UnusedLocalVariable.ql
@@ -21,6 +21,7 @@ predicate unused_local(Name unused, LocalVariable v) {
         def.isUnused() and
         not exists(def.getARedef()) and
         def.isRelevant() and
+        not v = any(Nonlocal n).getAVariable() and
         not exists(def.getNode().getParentNode().(FunctionDef).getDefinedFunction().getADecorator()) and
         not exists(def.getNode().getParentNode().(ClassDef).getDefinedClass().getADecorator())
     )

--- a/python/ql/test/query-tests/Variables/unused_local_nonlocal/UnusedLocalVariable.expected
+++ b/python/ql/test/query-tests/Variables/unused_local_nonlocal/UnusedLocalVariable.expected
@@ -1,0 +1,1 @@
+| variables_test.py:32:9:32:12 | test | The value assigned to local variable 'test' is never used. |

--- a/python/ql/test/query-tests/Variables/unused_local_nonlocal/UnusedLocalVariable.qlref
+++ b/python/ql/test/query-tests/Variables/unused_local_nonlocal/UnusedLocalVariable.qlref
@@ -1,0 +1,1 @@
+Variables/UnusedLocalVariable.ql

--- a/python/ql/test/query-tests/Variables/unused_local_nonlocal/variables_test.py
+++ b/python/ql/test/query-tests/Variables/unused_local_nonlocal/variables_test.py
@@ -1,0 +1,36 @@
+
+# FPs involving nonlocal
+
+def nonlocal_fp():
+    test = False
+    def set_test():
+        nonlocal test
+        test = True
+    set_test()
+    if test:
+        print("Test is set.")
+
+nonlocal_fp()
+
+def nonlocal_fp2():
+    test = False
+
+    def set_test():
+        nonlocal test
+        test = True
+    set_test()
+    result = 5
+    if not test:
+        return
+    return result
+
+def not_fp():
+    test = False
+    def nonlocal_test():
+        nonlocal test
+    def set_test():
+        test = True
+    nonlocal_test()
+    set_test()
+    if test:
+        print("Test is set.")


### PR DESCRIPTION
Fairly straight-forward. If a local variable is marked as `nonlocal`, then it's reasonable to assume that it will be used non-locally (and thus "useless" assignments may in fact be useful after all).

A more fine-grained analysis would link up the two variables so that we can verify that there is indeed an access of the variable in the outer scope. This will require a larger extension of the SSA code, however, and will have to be future work for now.