### PR TITLE
Java/C++/C#: Tweak `AccessPathNil::toString()`

### DIFF
--- a/cpp/ql/src/semmle/code/cpp/dataflow/internal/DataFlowImpl.qll
+++ b/cpp/ql/src/semmle/code/cpp/dataflow/internal/DataFlowImpl.qll
@@ -1261,7 +1261,7 @@ abstract private class AccessPath extends TAccessPath {
 
 private class AccessPathNil extends AccessPath, TNil {
   override string toString() {
-    exists(DataFlowType t | this = TNil(t) | result = concat(" : " + ppReprType(t)))
+    exists(DataFlowType t | this = TNil(t) | result = concat(": " + ppReprType(t)))
   }
 
   override AccessPathFront getFront() {
@@ -1277,7 +1277,7 @@ private class AccessPathConsNil extends AccessPathCons, TConsNil {
   override string toString() {
     exists(Content f, DataFlowType t | this = TConsNil(f, t) |
       // The `concat` becomes "" if `ppReprType` has no result.
-      result = f.toString() + concat(" : " + ppReprType(t))
+      result = "[" + f.toString() + "]" + concat(" : " + ppReprType(t))
     )
   }
 
@@ -1294,8 +1294,8 @@ private class AccessPathConsCons extends AccessPathCons, TConsCons {
   override string toString() {
     exists(Content f1, Content f2, int len | this = TConsCons(f1, f2, len) |
       if len = 2
-      then result = f1.toString() + ", " + f2.toString()
-      else result = f1.toString() + ", " + f2.toString() + ", ... (" + len.toString() + ")"
+      then result = "[" + f1.toString() + ", " + f2.toString() + "]"
+      else result = "[" + f1.toString() + ", " + f2.toString() + ", ... (" + len.toString() + ")]"
     )
   }
 
@@ -1626,7 +1626,7 @@ abstract class PathNode extends TPathNode {
     this instanceof PathNodeSink and result = ""
     or
     exists(string s | s = this.(PathNodeMid).getAp().toString() |
-      if s = "" then result = "" else result = " [" + s + "]"
+      if s = "" then result = "" else result = " " + s
     )
   }
 
@@ -2071,7 +2071,7 @@ private module FlowExploration {
 
   private class PartialAccessPathNil extends PartialAccessPath, TPartialNil {
     override string toString() {
-      exists(DataFlowType t | this = TPartialNil(t) | result = concat(" : " + ppReprType(t)))
+      exists(DataFlowType t | this = TPartialNil(t) | result = concat(": " + ppReprType(t)))
     }
 
     override AccessPathFront getFront() {
@@ -2083,8 +2083,8 @@ private module FlowExploration {
     override string toString() {
       exists(Content f, int len | this = TPartialCons(f, len) |
         if len = 1
-        then result = f.toString()
-        else result = f.toString() + ", ... (" + len.toString() + ")"
+        then result = "[" + f.toString() + "]"
+        else result = "[" + f.toString() + ", ... (" + len.toString() + ")]"
       )
     }
 
@@ -2161,7 +2161,7 @@ private module FlowExploration {
 
     private string ppAp() {
       exists(string s | s = this.(PartialPathNodePriv).getAp().toString() |
-        if s = "" then result = "" else result = " [" + s + "]"
+        if s = "" then result = "" else result = " " + s
       )
     }
 

--- a/cpp/ql/src/semmle/code/cpp/dataflow/internal/DataFlowImpl2.qll
+++ b/cpp/ql/src/semmle/code/cpp/dataflow/internal/DataFlowImpl2.qll
@@ -1261,7 +1261,7 @@ abstract private class AccessPath extends TAccessPath {
 
 private class AccessPathNil extends AccessPath, TNil {
   override string toString() {
-    exists(DataFlowType t | this = TNil(t) | result = concat(" : " + ppReprType(t)))
+    exists(DataFlowType t | this = TNil(t) | result = concat(": " + ppReprType(t)))
   }
 
   override AccessPathFront getFront() {
@@ -1277,7 +1277,7 @@ private class AccessPathConsNil extends AccessPathCons, TConsNil {
   override string toString() {
     exists(Content f, DataFlowType t | this = TConsNil(f, t) |
       // The `concat` becomes "" if `ppReprType` has no result.
-      result = f.toString() + concat(" : " + ppReprType(t))
+      result = "[" + f.toString() + "]" + concat(" : " + ppReprType(t))
     )
   }
 
@@ -1294,8 +1294,8 @@ private class AccessPathConsCons extends AccessPathCons, TConsCons {
   override string toString() {
     exists(Content f1, Content f2, int len | this = TConsCons(f1, f2, len) |
       if len = 2
-      then result = f1.toString() + ", " + f2.toString()
-      else result = f1.toString() + ", " + f2.toString() + ", ... (" + len.toString() + ")"
+      then result = "[" + f1.toString() + ", " + f2.toString() + "]"
+      else result = "[" + f1.toString() + ", " + f2.toString() + ", ... (" + len.toString() + ")]"
     )
   }
 
@@ -1626,7 +1626,7 @@ abstract class PathNode extends TPathNode {
     this instanceof PathNodeSink and result = ""
     or
     exists(string s | s = this.(PathNodeMid).getAp().toString() |
-      if s = "" then result = "" else result = " [" + s + "]"
+      if s = "" then result = "" else result = " " + s
     )
   }
 
@@ -2071,7 +2071,7 @@ private module FlowExploration {
 
   private class PartialAccessPathNil extends PartialAccessPath, TPartialNil {
     override string toString() {
-      exists(DataFlowType t | this = TPartialNil(t) | result = concat(" : " + ppReprType(t)))
+      exists(DataFlowType t | this = TPartialNil(t) | result = concat(": " + ppReprType(t)))
     }
 
     override AccessPathFront getFront() {
@@ -2083,8 +2083,8 @@ private module FlowExploration {
     override string toString() {
       exists(Content f, int len | this = TPartialCons(f, len) |
         if len = 1
-        then result = f.toString()
-        else result = f.toString() + ", ... (" + len.toString() + ")"
+        then result = "[" + f.toString() + "]"
+        else result = "[" + f.toString() + ", ... (" + len.toString() + ")]"
       )
     }
 
@@ -2161,7 +2161,7 @@ private module FlowExploration {
 
     private string ppAp() {
       exists(string s | s = this.(PartialPathNodePriv).getAp().toString() |
-        if s = "" then result = "" else result = " [" + s + "]"
+        if s = "" then result = "" else result = " " + s
       )
     }
 

--- a/cpp/ql/src/semmle/code/cpp/dataflow/internal/DataFlowImpl3.qll
+++ b/cpp/ql/src/semmle/code/cpp/dataflow/internal/DataFlowImpl3.qll
@@ -1261,7 +1261,7 @@ abstract private class AccessPath extends TAccessPath {
 
 private class AccessPathNil extends AccessPath, TNil {
   override string toString() {
-    exists(DataFlowType t | this = TNil(t) | result = concat(" : " + ppReprType(t)))
+    exists(DataFlowType t | this = TNil(t) | result = concat(": " + ppReprType(t)))
   }
 
   override AccessPathFront getFront() {
@@ -1277,7 +1277,7 @@ private class AccessPathConsNil extends AccessPathCons, TConsNil {
   override string toString() {
     exists(Content f, DataFlowType t | this = TConsNil(f, t) |
       // The `concat` becomes "" if `ppReprType` has no result.
-      result = f.toString() + concat(" : " + ppReprType(t))
+      result = "[" + f.toString() + "]" + concat(" : " + ppReprType(t))
     )
   }
 
@@ -1294,8 +1294,8 @@ private class AccessPathConsCons extends AccessPathCons, TConsCons {
   override string toString() {
     exists(Content f1, Content f2, int len | this = TConsCons(f1, f2, len) |
       if len = 2
-      then result = f1.toString() + ", " + f2.toString()
-      else result = f1.toString() + ", " + f2.toString() + ", ... (" + len.toString() + ")"
+      then result = "[" + f1.toString() + ", " + f2.toString() + "]"
+      else result = "[" + f1.toString() + ", " + f2.toString() + ", ... (" + len.toString() + ")]"
     )
   }
 
@@ -1626,7 +1626,7 @@ abstract class PathNode extends TPathNode {
     this instanceof PathNodeSink and result = ""
     or
     exists(string s | s = this.(PathNodeMid).getAp().toString() |
-      if s = "" then result = "" else result = " [" + s + "]"
+      if s = "" then result = "" else result = " " + s
     )
   }
 
@@ -2071,7 +2071,7 @@ private module FlowExploration {
 
   private class PartialAccessPathNil extends PartialAccessPath, TPartialNil {
     override string toString() {
-      exists(DataFlowType t | this = TPartialNil(t) | result = concat(" : " + ppReprType(t)))
+      exists(DataFlowType t | this = TPartialNil(t) | result = concat(": " + ppReprType(t)))
     }
 
     override AccessPathFront getFront() {
@@ -2083,8 +2083,8 @@ private module FlowExploration {
     override string toString() {
       exists(Content f, int len | this = TPartialCons(f, len) |
         if len = 1
-        then result = f.toString()
-        else result = f.toString() + ", ... (" + len.toString() + ")"
+        then result = "[" + f.toString() + "]"
+        else result = "[" + f.toString() + ", ... (" + len.toString() + ")]"
       )
     }
 
@@ -2161,7 +2161,7 @@ private module FlowExploration {
 
     private string ppAp() {
       exists(string s | s = this.(PartialPathNodePriv).getAp().toString() |
-        if s = "" then result = "" else result = " [" + s + "]"
+        if s = "" then result = "" else result = " " + s
       )
     }
 

--- a/cpp/ql/src/semmle/code/cpp/dataflow/internal/DataFlowImpl4.qll
+++ b/cpp/ql/src/semmle/code/cpp/dataflow/internal/DataFlowImpl4.qll
@@ -1261,7 +1261,7 @@ abstract private class AccessPath extends TAccessPath {
 
 private class AccessPathNil extends AccessPath, TNil {
   override string toString() {
-    exists(DataFlowType t | this = TNil(t) | result = concat(" : " + ppReprType(t)))
+    exists(DataFlowType t | this = TNil(t) | result = concat(": " + ppReprType(t)))
   }
 
   override AccessPathFront getFront() {
@@ -1277,7 +1277,7 @@ private class AccessPathConsNil extends AccessPathCons, TConsNil {
   override string toString() {
     exists(Content f, DataFlowType t | this = TConsNil(f, t) |
       // The `concat` becomes "" if `ppReprType` has no result.
-      result = f.toString() + concat(" : " + ppReprType(t))
+      result = "[" + f.toString() + "]" + concat(" : " + ppReprType(t))
     )
   }
 
@@ -1294,8 +1294,8 @@ private class AccessPathConsCons extends AccessPathCons, TConsCons {
   override string toString() {
     exists(Content f1, Content f2, int len | this = TConsCons(f1, f2, len) |
       if len = 2
-      then result = f1.toString() + ", " + f2.toString()
-      else result = f1.toString() + ", " + f2.toString() + ", ... (" + len.toString() + ")"
+      then result = "[" + f1.toString() + ", " + f2.toString() + "]"
+      else result = "[" + f1.toString() + ", " + f2.toString() + ", ... (" + len.toString() + ")]"
     )
   }
 
@@ -1626,7 +1626,7 @@ abstract class PathNode extends TPathNode {
     this instanceof PathNodeSink and result = ""
     or
     exists(string s | s = this.(PathNodeMid).getAp().toString() |
-      if s = "" then result = "" else result = " [" + s + "]"
+      if s = "" then result = "" else result = " " + s
     )
   }
 
@@ -2071,7 +2071,7 @@ private module FlowExploration {
 
   private class PartialAccessPathNil extends PartialAccessPath, TPartialNil {
     override string toString() {
-      exists(DataFlowType t | this = TPartialNil(t) | result = concat(" : " + ppReprType(t)))
+      exists(DataFlowType t | this = TPartialNil(t) | result = concat(": " + ppReprType(t)))
     }
 
     override AccessPathFront getFront() {
@@ -2083,8 +2083,8 @@ private module FlowExploration {
     override string toString() {
       exists(Content f, int len | this = TPartialCons(f, len) |
         if len = 1
-        then result = f.toString()
-        else result = f.toString() + ", ... (" + len.toString() + ")"
+        then result = "[" + f.toString() + "]"
+        else result = "[" + f.toString() + ", ... (" + len.toString() + ")]"
       )
     }
 
@@ -2161,7 +2161,7 @@ private module FlowExploration {
 
     private string ppAp() {
       exists(string s | s = this.(PartialPathNodePriv).getAp().toString() |
-        if s = "" then result = "" else result = " [" + s + "]"
+        if s = "" then result = "" else result = " " + s
       )
     }
 

--- a/cpp/ql/src/semmle/code/cpp/dataflow/internal/DataFlowImplLocal.qll
+++ b/cpp/ql/src/semmle/code/cpp/dataflow/internal/DataFlowImplLocal.qll
@@ -1261,7 +1261,7 @@ abstract private class AccessPath extends TAccessPath {
 
 private class AccessPathNil extends AccessPath, TNil {
   override string toString() {
-    exists(DataFlowType t | this = TNil(t) | result = concat(" : " + ppReprType(t)))
+    exists(DataFlowType t | this = TNil(t) | result = concat(": " + ppReprType(t)))
   }
 
   override AccessPathFront getFront() {
@@ -1277,7 +1277,7 @@ private class AccessPathConsNil extends AccessPathCons, TConsNil {
   override string toString() {
     exists(Content f, DataFlowType t | this = TConsNil(f, t) |
       // The `concat` becomes "" if `ppReprType` has no result.
-      result = f.toString() + concat(" : " + ppReprType(t))
+      result = "[" + f.toString() + "]" + concat(" : " + ppReprType(t))
     )
   }
 
@@ -1294,8 +1294,8 @@ private class AccessPathConsCons extends AccessPathCons, TConsCons {
   override string toString() {
     exists(Content f1, Content f2, int len | this = TConsCons(f1, f2, len) |
       if len = 2
-      then result = f1.toString() + ", " + f2.toString()
-      else result = f1.toString() + ", " + f2.toString() + ", ... (" + len.toString() + ")"
+      then result = "[" + f1.toString() + ", " + f2.toString() + "]"
+      else result = "[" + f1.toString() + ", " + f2.toString() + ", ... (" + len.toString() + ")]"
     )
   }
 
@@ -1626,7 +1626,7 @@ abstract class PathNode extends TPathNode {
     this instanceof PathNodeSink and result = ""
     or
     exists(string s | s = this.(PathNodeMid).getAp().toString() |
-      if s = "" then result = "" else result = " [" + s + "]"
+      if s = "" then result = "" else result = " " + s
     )
   }
 
@@ -2071,7 +2071,7 @@ private module FlowExploration {
 
   private class PartialAccessPathNil extends PartialAccessPath, TPartialNil {
     override string toString() {
-      exists(DataFlowType t | this = TPartialNil(t) | result = concat(" : " + ppReprType(t)))
+      exists(DataFlowType t | this = TPartialNil(t) | result = concat(": " + ppReprType(t)))
     }
 
     override AccessPathFront getFront() {
@@ -2083,8 +2083,8 @@ private module FlowExploration {
     override string toString() {
       exists(Content f, int len | this = TPartialCons(f, len) |
         if len = 1
-        then result = f.toString()
-        else result = f.toString() + ", ... (" + len.toString() + ")"
+        then result = "[" + f.toString() + "]"
+        else result = "[" + f.toString() + ", ... (" + len.toString() + ")]"
       )
     }
 
@@ -2161,7 +2161,7 @@ private module FlowExploration {
 
     private string ppAp() {
       exists(string s | s = this.(PartialPathNodePriv).getAp().toString() |
-        if s = "" then result = "" else result = " [" + s + "]"
+        if s = "" then result = "" else result = " " + s
       )
     }
 

--- a/cpp/ql/src/semmle/code/cpp/ir/dataflow/internal/DataFlowImpl.qll
+++ b/cpp/ql/src/semmle/code/cpp/ir/dataflow/internal/DataFlowImpl.qll
@@ -1261,7 +1261,7 @@ abstract private class AccessPath extends TAccessPath {
 
 private class AccessPathNil extends AccessPath, TNil {
   override string toString() {
-    exists(DataFlowType t | this = TNil(t) | result = concat(" : " + ppReprType(t)))
+    exists(DataFlowType t | this = TNil(t) | result = concat(": " + ppReprType(t)))
   }
 
   override AccessPathFront getFront() {
@@ -1277,7 +1277,7 @@ private class AccessPathConsNil extends AccessPathCons, TConsNil {
   override string toString() {
     exists(Content f, DataFlowType t | this = TConsNil(f, t) |
       // The `concat` becomes "" if `ppReprType` has no result.
-      result = f.toString() + concat(" : " + ppReprType(t))
+      result = "[" + f.toString() + "]" + concat(" : " + ppReprType(t))
     )
   }
 
@@ -1294,8 +1294,8 @@ private class AccessPathConsCons extends AccessPathCons, TConsCons {
   override string toString() {
     exists(Content f1, Content f2, int len | this = TConsCons(f1, f2, len) |
       if len = 2
-      then result = f1.toString() + ", " + f2.toString()
-      else result = f1.toString() + ", " + f2.toString() + ", ... (" + len.toString() + ")"
+      then result = "[" + f1.toString() + ", " + f2.toString() + "]"
+      else result = "[" + f1.toString() + ", " + f2.toString() + ", ... (" + len.toString() + ")]"
     )
   }
 
@@ -1626,7 +1626,7 @@ abstract class PathNode extends TPathNode {
     this instanceof PathNodeSink and result = ""
     or
     exists(string s | s = this.(PathNodeMid).getAp().toString() |
-      if s = "" then result = "" else result = " [" + s + "]"
+      if s = "" then result = "" else result = " " + s
     )
   }
 
@@ -2071,7 +2071,7 @@ private module FlowExploration {
 
   private class PartialAccessPathNil extends PartialAccessPath, TPartialNil {
     override string toString() {
-      exists(DataFlowType t | this = TPartialNil(t) | result = concat(" : " + ppReprType(t)))
+      exists(DataFlowType t | this = TPartialNil(t) | result = concat(": " + ppReprType(t)))
     }
 
     override AccessPathFront getFront() {
@@ -2083,8 +2083,8 @@ private module FlowExploration {
     override string toString() {
       exists(Content f, int len | this = TPartialCons(f, len) |
         if len = 1
-        then result = f.toString()
-        else result = f.toString() + ", ... (" + len.toString() + ")"
+        then result = "[" + f.toString() + "]"
+        else result = "[" + f.toString() + ", ... (" + len.toString() + ")]"
       )
     }
 
@@ -2161,7 +2161,7 @@ private module FlowExploration {
 
     private string ppAp() {
       exists(string s | s = this.(PartialPathNodePriv).getAp().toString() |
-        if s = "" then result = "" else result = " [" + s + "]"
+        if s = "" then result = "" else result = " " + s
       )
     }
 

--- a/cpp/ql/src/semmle/code/cpp/ir/dataflow/internal/DataFlowImpl2.qll
+++ b/cpp/ql/src/semmle/code/cpp/ir/dataflow/internal/DataFlowImpl2.qll
@@ -1261,7 +1261,7 @@ abstract private class AccessPath extends TAccessPath {
 
 private class AccessPathNil extends AccessPath, TNil {
   override string toString() {
-    exists(DataFlowType t | this = TNil(t) | result = concat(" : " + ppReprType(t)))
+    exists(DataFlowType t | this = TNil(t) | result = concat(": " + ppReprType(t)))
   }
 
   override AccessPathFront getFront() {
@@ -1277,7 +1277,7 @@ private class AccessPathConsNil extends AccessPathCons, TConsNil {
   override string toString() {
     exists(Content f, DataFlowType t | this = TConsNil(f, t) |
       // The `concat` becomes "" if `ppReprType` has no result.
-      result = f.toString() + concat(" : " + ppReprType(t))
+      result = "[" + f.toString() + "]" + concat(" : " + ppReprType(t))
     )
   }
 
@@ -1294,8 +1294,8 @@ private class AccessPathConsCons extends AccessPathCons, TConsCons {
   override string toString() {
     exists(Content f1, Content f2, int len | this = TConsCons(f1, f2, len) |
       if len = 2
-      then result = f1.toString() + ", " + f2.toString()
-      else result = f1.toString() + ", " + f2.toString() + ", ... (" + len.toString() + ")"
+      then result = "[" + f1.toString() + ", " + f2.toString() + "]"
+      else result = "[" + f1.toString() + ", " + f2.toString() + ", ... (" + len.toString() + ")]"
     )
   }
 
@@ -1626,7 +1626,7 @@ abstract class PathNode extends TPathNode {
     this instanceof PathNodeSink and result = ""
     or
     exists(string s | s = this.(PathNodeMid).getAp().toString() |
-      if s = "" then result = "" else result = " [" + s + "]"
+      if s = "" then result = "" else result = " " + s
     )
   }
 
@@ -2071,7 +2071,7 @@ private module FlowExploration {
 
   private class PartialAccessPathNil extends PartialAccessPath, TPartialNil {
     override string toString() {
-      exists(DataFlowType t | this = TPartialNil(t) | result = concat(" : " + ppReprType(t)))
+      exists(DataFlowType t | this = TPartialNil(t) | result = concat(": " + ppReprType(t)))
     }
 
     override AccessPathFront getFront() {
@@ -2083,8 +2083,8 @@ private module FlowExploration {
     override string toString() {
       exists(Content f, int len | this = TPartialCons(f, len) |
         if len = 1
-        then result = f.toString()
-        else result = f.toString() + ", ... (" + len.toString() + ")"
+        then result = "[" + f.toString() + "]"
+        else result = "[" + f.toString() + ", ... (" + len.toString() + ")]"
       )
     }
 
@@ -2161,7 +2161,7 @@ private module FlowExploration {
 
     private string ppAp() {
       exists(string s | s = this.(PartialPathNodePriv).getAp().toString() |
-        if s = "" then result = "" else result = " [" + s + "]"
+        if s = "" then result = "" else result = " " + s
       )
     }
 

--- a/cpp/ql/src/semmle/code/cpp/ir/dataflow/internal/DataFlowImpl3.qll
+++ b/cpp/ql/src/semmle/code/cpp/ir/dataflow/internal/DataFlowImpl3.qll
@@ -1261,7 +1261,7 @@ abstract private class AccessPath extends TAccessPath {
 
 private class AccessPathNil extends AccessPath, TNil {
   override string toString() {
-    exists(DataFlowType t | this = TNil(t) | result = concat(" : " + ppReprType(t)))
+    exists(DataFlowType t | this = TNil(t) | result = concat(": " + ppReprType(t)))
   }
 
   override AccessPathFront getFront() {
@@ -1277,7 +1277,7 @@ private class AccessPathConsNil extends AccessPathCons, TConsNil {
   override string toString() {
     exists(Content f, DataFlowType t | this = TConsNil(f, t) |
       // The `concat` becomes "" if `ppReprType` has no result.
-      result = f.toString() + concat(" : " + ppReprType(t))
+      result = "[" + f.toString() + "]" + concat(" : " + ppReprType(t))
     )
   }
 
@@ -1294,8 +1294,8 @@ private class AccessPathConsCons extends AccessPathCons, TConsCons {
   override string toString() {
     exists(Content f1, Content f2, int len | this = TConsCons(f1, f2, len) |
       if len = 2
-      then result = f1.toString() + ", " + f2.toString()
-      else result = f1.toString() + ", " + f2.toString() + ", ... (" + len.toString() + ")"
+      then result = "[" + f1.toString() + ", " + f2.toString() + "]"
+      else result = "[" + f1.toString() + ", " + f2.toString() + ", ... (" + len.toString() + ")]"
     )
   }
 
@@ -1626,7 +1626,7 @@ abstract class PathNode extends TPathNode {
     this instanceof PathNodeSink and result = ""
     or
     exists(string s | s = this.(PathNodeMid).getAp().toString() |
-      if s = "" then result = "" else result = " [" + s + "]"
+      if s = "" then result = "" else result = " " + s
     )
   }
 
@@ -2071,7 +2071,7 @@ private module FlowExploration {
 
   private class PartialAccessPathNil extends PartialAccessPath, TPartialNil {
     override string toString() {
-      exists(DataFlowType t | this = TPartialNil(t) | result = concat(" : " + ppReprType(t)))
+      exists(DataFlowType t | this = TPartialNil(t) | result = concat(": " + ppReprType(t)))
     }
 
     override AccessPathFront getFront() {
@@ -2083,8 +2083,8 @@ private module FlowExploration {
     override string toString() {
       exists(Content f, int len | this = TPartialCons(f, len) |
         if len = 1
-        then result = f.toString()
-        else result = f.toString() + ", ... (" + len.toString() + ")"
+        then result = "[" + f.toString() + "]"
+        else result = "[" + f.toString() + ", ... (" + len.toString() + ")]"
       )
     }
 
@@ -2161,7 +2161,7 @@ private module FlowExploration {
 
     private string ppAp() {
       exists(string s | s = this.(PartialPathNodePriv).getAp().toString() |
-        if s = "" then result = "" else result = " [" + s + "]"
+        if s = "" then result = "" else result = " " + s
       )
     }
 

--- a/cpp/ql/src/semmle/code/cpp/ir/dataflow/internal/DataFlowImpl4.qll
+++ b/cpp/ql/src/semmle/code/cpp/ir/dataflow/internal/DataFlowImpl4.qll
@@ -1261,7 +1261,7 @@ abstract private class AccessPath extends TAccessPath {
 
 private class AccessPathNil extends AccessPath, TNil {
   override string toString() {
-    exists(DataFlowType t | this = TNil(t) | result = concat(" : " + ppReprType(t)))
+    exists(DataFlowType t | this = TNil(t) | result = concat(": " + ppReprType(t)))
   }
 
   override AccessPathFront getFront() {
@@ -1277,7 +1277,7 @@ private class AccessPathConsNil extends AccessPathCons, TConsNil {
   override string toString() {
     exists(Content f, DataFlowType t | this = TConsNil(f, t) |
       // The `concat` becomes "" if `ppReprType` has no result.
-      result = f.toString() + concat(" : " + ppReprType(t))
+      result = "[" + f.toString() + "]" + concat(" : " + ppReprType(t))
     )
   }
 
@@ -1294,8 +1294,8 @@ private class AccessPathConsCons extends AccessPathCons, TConsCons {
   override string toString() {
     exists(Content f1, Content f2, int len | this = TConsCons(f1, f2, len) |
       if len = 2
-      then result = f1.toString() + ", " + f2.toString()
-      else result = f1.toString() + ", " + f2.toString() + ", ... (" + len.toString() + ")"
+      then result = "[" + f1.toString() + ", " + f2.toString() + "]"
+      else result = "[" + f1.toString() + ", " + f2.toString() + ", ... (" + len.toString() + ")]"
     )
   }
 
@@ -1626,7 +1626,7 @@ abstract class PathNode extends TPathNode {
     this instanceof PathNodeSink and result = ""
     or
     exists(string s | s = this.(PathNodeMid).getAp().toString() |
-      if s = "" then result = "" else result = " [" + s + "]"
+      if s = "" then result = "" else result = " " + s
     )
   }
 
@@ -2071,7 +2071,7 @@ private module FlowExploration {
 
   private class PartialAccessPathNil extends PartialAccessPath, TPartialNil {
     override string toString() {
-      exists(DataFlowType t | this = TPartialNil(t) | result = concat(" : " + ppReprType(t)))
+      exists(DataFlowType t | this = TPartialNil(t) | result = concat(": " + ppReprType(t)))
     }
 
     override AccessPathFront getFront() {
@@ -2083,8 +2083,8 @@ private module FlowExploration {
     override string toString() {
       exists(Content f, int len | this = TPartialCons(f, len) |
         if len = 1
-        then result = f.toString()
-        else result = f.toString() + ", ... (" + len.toString() + ")"
+        then result = "[" + f.toString() + "]"
+        else result = "[" + f.toString() + ", ... (" + len.toString() + ")]"
       )
     }
 
@@ -2161,7 +2161,7 @@ private module FlowExploration {
 
     private string ppAp() {
       exists(string s | s = this.(PartialPathNodePriv).getAp().toString() |
-        if s = "" then result = "" else result = " [" + s + "]"
+        if s = "" then result = "" else result = " " + s
       )
     }
 

--- a/csharp/ql/src/semmle/code/csharp/dataflow/internal/DataFlowImpl.qll
+++ b/csharp/ql/src/semmle/code/csharp/dataflow/internal/DataFlowImpl.qll
@@ -1261,7 +1261,7 @@ abstract private class AccessPath extends TAccessPath {
 
 private class AccessPathNil extends AccessPath, TNil {
   override string toString() {
-    exists(DataFlowType t | this = TNil(t) | result = concat(" : " + ppReprType(t)))
+    exists(DataFlowType t | this = TNil(t) | result = concat(": " + ppReprType(t)))
   }
 
   override AccessPathFront getFront() {
@@ -1277,7 +1277,7 @@ private class AccessPathConsNil extends AccessPathCons, TConsNil {
   override string toString() {
     exists(Content f, DataFlowType t | this = TConsNil(f, t) |
       // The `concat` becomes "" if `ppReprType` has no result.
-      result = f.toString() + concat(" : " + ppReprType(t))
+      result = "[" + f.toString() + "]" + concat(" : " + ppReprType(t))
     )
   }
 
@@ -1294,8 +1294,8 @@ private class AccessPathConsCons extends AccessPathCons, TConsCons {
   override string toString() {
     exists(Content f1, Content f2, int len | this = TConsCons(f1, f2, len) |
       if len = 2
-      then result = f1.toString() + ", " + f2.toString()
-      else result = f1.toString() + ", " + f2.toString() + ", ... (" + len.toString() + ")"
+      then result = "[" + f1.toString() + ", " + f2.toString() + "]"
+      else result = "[" + f1.toString() + ", " + f2.toString() + ", ... (" + len.toString() + ")]"
     )
   }
 
@@ -1626,7 +1626,7 @@ abstract class PathNode extends TPathNode {
     this instanceof PathNodeSink and result = ""
     or
     exists(string s | s = this.(PathNodeMid).getAp().toString() |
-      if s = "" then result = "" else result = " [" + s + "]"
+      if s = "" then result = "" else result = " " + s
     )
   }
 
@@ -2071,7 +2071,7 @@ private module FlowExploration {
 
   private class PartialAccessPathNil extends PartialAccessPath, TPartialNil {
     override string toString() {
-      exists(DataFlowType t | this = TPartialNil(t) | result = concat(" : " + ppReprType(t)))
+      exists(DataFlowType t | this = TPartialNil(t) | result = concat(": " + ppReprType(t)))
     }
 
     override AccessPathFront getFront() {
@@ -2083,8 +2083,8 @@ private module FlowExploration {
     override string toString() {
       exists(Content f, int len | this = TPartialCons(f, len) |
         if len = 1
-        then result = f.toString()
-        else result = f.toString() + ", ... (" + len.toString() + ")"
+        then result = "[" + f.toString() + "]"
+        else result = "[" + f.toString() + ", ... (" + len.toString() + ")]"
       )
     }
 
@@ -2161,7 +2161,7 @@ private module FlowExploration {
 
     private string ppAp() {
       exists(string s | s = this.(PartialPathNodePriv).getAp().toString() |
-        if s = "" then result = "" else result = " [" + s + "]"
+        if s = "" then result = "" else result = " " + s
       )
     }
 

--- a/csharp/ql/src/semmle/code/csharp/dataflow/internal/DataFlowImpl2.qll
+++ b/csharp/ql/src/semmle/code/csharp/dataflow/internal/DataFlowImpl2.qll
@@ -1261,7 +1261,7 @@ abstract private class AccessPath extends TAccessPath {
 
 private class AccessPathNil extends AccessPath, TNil {
   override string toString() {
-    exists(DataFlowType t | this = TNil(t) | result = concat(" : " + ppReprType(t)))
+    exists(DataFlowType t | this = TNil(t) | result = concat(": " + ppReprType(t)))
   }
 
   override AccessPathFront getFront() {
@@ -1277,7 +1277,7 @@ private class AccessPathConsNil extends AccessPathCons, TConsNil {
   override string toString() {
     exists(Content f, DataFlowType t | this = TConsNil(f, t) |
       // The `concat` becomes "" if `ppReprType` has no result.
-      result = f.toString() + concat(" : " + ppReprType(t))
+      result = "[" + f.toString() + "]" + concat(" : " + ppReprType(t))
     )
   }
 
@@ -1294,8 +1294,8 @@ private class AccessPathConsCons extends AccessPathCons, TConsCons {
   override string toString() {
     exists(Content f1, Content f2, int len | this = TConsCons(f1, f2, len) |
       if len = 2
-      then result = f1.toString() + ", " + f2.toString()
-      else result = f1.toString() + ", " + f2.toString() + ", ... (" + len.toString() + ")"
+      then result = "[" + f1.toString() + ", " + f2.toString() + "]"
+      else result = "[" + f1.toString() + ", " + f2.toString() + ", ... (" + len.toString() + ")]"
     )
   }
 
@@ -1626,7 +1626,7 @@ abstract class PathNode extends TPathNode {
     this instanceof PathNodeSink and result = ""
     or
     exists(string s | s = this.(PathNodeMid).getAp().toString() |
-      if s = "" then result = "" else result = " [" + s + "]"
+      if s = "" then result = "" else result = " " + s
     )
   }
 
@@ -2071,7 +2071,7 @@ private module FlowExploration {
 
   private class PartialAccessPathNil extends PartialAccessPath, TPartialNil {
     override string toString() {
-      exists(DataFlowType t | this = TPartialNil(t) | result = concat(" : " + ppReprType(t)))
+      exists(DataFlowType t | this = TPartialNil(t) | result = concat(": " + ppReprType(t)))
     }
 
     override AccessPathFront getFront() {
@@ -2083,8 +2083,8 @@ private module FlowExploration {
     override string toString() {
       exists(Content f, int len | this = TPartialCons(f, len) |
         if len = 1
-        then result = f.toString()
-        else result = f.toString() + ", ... (" + len.toString() + ")"
+        then result = "[" + f.toString() + "]"
+        else result = "[" + f.toString() + ", ... (" + len.toString() + ")]"
       )
     }
 
@@ -2161,7 +2161,7 @@ private module FlowExploration {
 
     private string ppAp() {
       exists(string s | s = this.(PartialPathNodePriv).getAp().toString() |
-        if s = "" then result = "" else result = " [" + s + "]"
+        if s = "" then result = "" else result = " " + s
       )
     }
 

--- a/csharp/ql/src/semmle/code/csharp/dataflow/internal/DataFlowImpl3.qll
+++ b/csharp/ql/src/semmle/code/csharp/dataflow/internal/DataFlowImpl3.qll
@@ -1261,7 +1261,7 @@ abstract private class AccessPath extends TAccessPath {
 
 private class AccessPathNil extends AccessPath, TNil {
   override string toString() {
-    exists(DataFlowType t | this = TNil(t) | result = concat(" : " + ppReprType(t)))
+    exists(DataFlowType t | this = TNil(t) | result = concat(": " + ppReprType(t)))
   }
 
   override AccessPathFront getFront() {
@@ -1277,7 +1277,7 @@ private class AccessPathConsNil extends AccessPathCons, TConsNil {
   override string toString() {
     exists(Content f, DataFlowType t | this = TConsNil(f, t) |
       // The `concat` becomes "" if `ppReprType` has no result.
-      result = f.toString() + concat(" : " + ppReprType(t))
+      result = "[" + f.toString() + "]" + concat(" : " + ppReprType(t))
     )
   }
 
@@ -1294,8 +1294,8 @@ private class AccessPathConsCons extends AccessPathCons, TConsCons {
   override string toString() {
     exists(Content f1, Content f2, int len | this = TConsCons(f1, f2, len) |
       if len = 2
-      then result = f1.toString() + ", " + f2.toString()
-      else result = f1.toString() + ", " + f2.toString() + ", ... (" + len.toString() + ")"
+      then result = "[" + f1.toString() + ", " + f2.toString() + "]"
+      else result = "[" + f1.toString() + ", " + f2.toString() + ", ... (" + len.toString() + ")]"
     )
   }
 
@@ -1626,7 +1626,7 @@ abstract class PathNode extends TPathNode {
     this instanceof PathNodeSink and result = ""
     or
     exists(string s | s = this.(PathNodeMid).getAp().toString() |
-      if s = "" then result = "" else result = " [" + s + "]"
+      if s = "" then result = "" else result = " " + s
     )
   }
 
@@ -2071,7 +2071,7 @@ private module FlowExploration {
 
   private class PartialAccessPathNil extends PartialAccessPath, TPartialNil {
     override string toString() {
-      exists(DataFlowType t | this = TPartialNil(t) | result = concat(" : " + ppReprType(t)))
+      exists(DataFlowType t | this = TPartialNil(t) | result = concat(": " + ppReprType(t)))
     }
 
     override AccessPathFront getFront() {
@@ -2083,8 +2083,8 @@ private module FlowExploration {
     override string toString() {
       exists(Content f, int len | this = TPartialCons(f, len) |
         if len = 1
-        then result = f.toString()
-        else result = f.toString() + ", ... (" + len.toString() + ")"
+        then result = "[" + f.toString() + "]"
+        else result = "[" + f.toString() + ", ... (" + len.toString() + ")]"
       )
     }
 
@@ -2161,7 +2161,7 @@ private module FlowExploration {
 
     private string ppAp() {
       exists(string s | s = this.(PartialPathNodePriv).getAp().toString() |
-        if s = "" then result = "" else result = " [" + s + "]"
+        if s = "" then result = "" else result = " " + s
       )
     }
 

--- a/csharp/ql/src/semmle/code/csharp/dataflow/internal/DataFlowImpl4.qll
+++ b/csharp/ql/src/semmle/code/csharp/dataflow/internal/DataFlowImpl4.qll
@@ -1261,7 +1261,7 @@ abstract private class AccessPath extends TAccessPath {
 
 private class AccessPathNil extends AccessPath, TNil {
   override string toString() {
-    exists(DataFlowType t | this = TNil(t) | result = concat(" : " + ppReprType(t)))
+    exists(DataFlowType t | this = TNil(t) | result = concat(": " + ppReprType(t)))
   }
 
   override AccessPathFront getFront() {
@@ -1277,7 +1277,7 @@ private class AccessPathConsNil extends AccessPathCons, TConsNil {
   override string toString() {
     exists(Content f, DataFlowType t | this = TConsNil(f, t) |
       // The `concat` becomes "" if `ppReprType` has no result.
-      result = f.toString() + concat(" : " + ppReprType(t))
+      result = "[" + f.toString() + "]" + concat(" : " + ppReprType(t))
     )
   }
 
@@ -1294,8 +1294,8 @@ private class AccessPathConsCons extends AccessPathCons, TConsCons {
   override string toString() {
     exists(Content f1, Content f2, int len | this = TConsCons(f1, f2, len) |
       if len = 2
-      then result = f1.toString() + ", " + f2.toString()
-      else result = f1.toString() + ", " + f2.toString() + ", ... (" + len.toString() + ")"
+      then result = "[" + f1.toString() + ", " + f2.toString() + "]"
+      else result = "[" + f1.toString() + ", " + f2.toString() + ", ... (" + len.toString() + ")]"
     )
   }
 
@@ -1626,7 +1626,7 @@ abstract class PathNode extends TPathNode {
     this instanceof PathNodeSink and result = ""
     or
     exists(string s | s = this.(PathNodeMid).getAp().toString() |
-      if s = "" then result = "" else result = " [" + s + "]"
+      if s = "" then result = "" else result = " " + s
     )
   }
 
@@ -2071,7 +2071,7 @@ private module FlowExploration {
 
   private class PartialAccessPathNil extends PartialAccessPath, TPartialNil {
     override string toString() {
-      exists(DataFlowType t | this = TPartialNil(t) | result = concat(" : " + ppReprType(t)))
+      exists(DataFlowType t | this = TPartialNil(t) | result = concat(": " + ppReprType(t)))
     }
 
     override AccessPathFront getFront() {
@@ -2083,8 +2083,8 @@ private module FlowExploration {
     override string toString() {
       exists(Content f, int len | this = TPartialCons(f, len) |
         if len = 1
-        then result = f.toString()
-        else result = f.toString() + ", ... (" + len.toString() + ")"
+        then result = "[" + f.toString() + "]"
+        else result = "[" + f.toString() + ", ... (" + len.toString() + ")]"
       )
     }
 
@@ -2161,7 +2161,7 @@ private module FlowExploration {
 
     private string ppAp() {
       exists(string s | s = this.(PartialPathNodePriv).getAp().toString() |
-        if s = "" then result = "" else result = " [" + s + "]"
+        if s = "" then result = "" else result = " " + s
       )
     }
 

--- a/csharp/ql/src/semmle/code/csharp/dataflow/internal/DataFlowImpl5.qll
+++ b/csharp/ql/src/semmle/code/csharp/dataflow/internal/DataFlowImpl5.qll
@@ -1261,7 +1261,7 @@ abstract private class AccessPath extends TAccessPath {
 
 private class AccessPathNil extends AccessPath, TNil {
   override string toString() {
-    exists(DataFlowType t | this = TNil(t) | result = concat(" : " + ppReprType(t)))
+    exists(DataFlowType t | this = TNil(t) | result = concat(": " + ppReprType(t)))
   }
 
   override AccessPathFront getFront() {
@@ -1277,7 +1277,7 @@ private class AccessPathConsNil extends AccessPathCons, TConsNil {
   override string toString() {
     exists(Content f, DataFlowType t | this = TConsNil(f, t) |
       // The `concat` becomes "" if `ppReprType` has no result.
-      result = f.toString() + concat(" : " + ppReprType(t))
+      result = "[" + f.toString() + "]" + concat(" : " + ppReprType(t))
     )
   }
 
@@ -1294,8 +1294,8 @@ private class AccessPathConsCons extends AccessPathCons, TConsCons {
   override string toString() {
     exists(Content f1, Content f2, int len | this = TConsCons(f1, f2, len) |
       if len = 2
-      then result = f1.toString() + ", " + f2.toString()
-      else result = f1.toString() + ", " + f2.toString() + ", ... (" + len.toString() + ")"
+      then result = "[" + f1.toString() + ", " + f2.toString() + "]"
+      else result = "[" + f1.toString() + ", " + f2.toString() + ", ... (" + len.toString() + ")]"
     )
   }
 
@@ -1626,7 +1626,7 @@ abstract class PathNode extends TPathNode {
     this instanceof PathNodeSink and result = ""
     or
     exists(string s | s = this.(PathNodeMid).getAp().toString() |
-      if s = "" then result = "" else result = " [" + s + "]"
+      if s = "" then result = "" else result = " " + s
     )
   }
 
@@ -2071,7 +2071,7 @@ private module FlowExploration {
 
   private class PartialAccessPathNil extends PartialAccessPath, TPartialNil {
     override string toString() {
-      exists(DataFlowType t | this = TPartialNil(t) | result = concat(" : " + ppReprType(t)))
+      exists(DataFlowType t | this = TPartialNil(t) | result = concat(": " + ppReprType(t)))
     }
 
     override AccessPathFront getFront() {
@@ -2083,8 +2083,8 @@ private module FlowExploration {
     override string toString() {
       exists(Content f, int len | this = TPartialCons(f, len) |
         if len = 1
-        then result = f.toString()
-        else result = f.toString() + ", ... (" + len.toString() + ")"
+        then result = "[" + f.toString() + "]"
+        else result = "[" + f.toString() + ", ... (" + len.toString() + ")]"
       )
     }
 
@@ -2161,7 +2161,7 @@ private module FlowExploration {
 
     private string ppAp() {
       exists(string s | s = this.(PartialPathNodePriv).getAp().toString() |
-        if s = "" then result = "" else result = " [" + s + "]"
+        if s = "" then result = "" else result = " " + s
       )
     }
 

--- a/java/ql/src/semmle/code/java/dataflow/internal/DataFlowImpl.qll
+++ b/java/ql/src/semmle/code/java/dataflow/internal/DataFlowImpl.qll
@@ -1261,7 +1261,7 @@ abstract private class AccessPath extends TAccessPath {
 
 private class AccessPathNil extends AccessPath, TNil {
   override string toString() {
-    exists(DataFlowType t | this = TNil(t) | result = concat(" : " + ppReprType(t)))
+    exists(DataFlowType t | this = TNil(t) | result = concat(": " + ppReprType(t)))
   }
 
   override AccessPathFront getFront() {
@@ -1277,7 +1277,7 @@ private class AccessPathConsNil extends AccessPathCons, TConsNil {
   override string toString() {
     exists(Content f, DataFlowType t | this = TConsNil(f, t) |
       // The `concat` becomes "" if `ppReprType` has no result.
-      result = f.toString() + concat(" : " + ppReprType(t))
+      result = "[" + f.toString() + "]" + concat(" : " + ppReprType(t))
     )
   }
 
@@ -1294,8 +1294,8 @@ private class AccessPathConsCons extends AccessPathCons, TConsCons {
   override string toString() {
     exists(Content f1, Content f2, int len | this = TConsCons(f1, f2, len) |
       if len = 2
-      then result = f1.toString() + ", " + f2.toString()
-      else result = f1.toString() + ", " + f2.toString() + ", ... (" + len.toString() + ")"
+      then result = "[" + f1.toString() + ", " + f2.toString() + "]"
+      else result = "[" + f1.toString() + ", " + f2.toString() + ", ... (" + len.toString() + ")]"
     )
   }
 
@@ -1626,7 +1626,7 @@ abstract class PathNode extends TPathNode {
     this instanceof PathNodeSink and result = ""
     or
     exists(string s | s = this.(PathNodeMid).getAp().toString() |
-      if s = "" then result = "" else result = " [" + s + "]"
+      if s = "" then result = "" else result = " " + s
     )
   }
 
@@ -2071,7 +2071,7 @@ private module FlowExploration {
 
   private class PartialAccessPathNil extends PartialAccessPath, TPartialNil {
     override string toString() {
-      exists(DataFlowType t | this = TPartialNil(t) | result = concat(" : " + ppReprType(t)))
+      exists(DataFlowType t | this = TPartialNil(t) | result = concat(": " + ppReprType(t)))
     }
 
     override AccessPathFront getFront() {
@@ -2083,8 +2083,8 @@ private module FlowExploration {
     override string toString() {
       exists(Content f, int len | this = TPartialCons(f, len) |
         if len = 1
-        then result = f.toString()
-        else result = f.toString() + ", ... (" + len.toString() + ")"
+        then result = "[" + f.toString() + "]"
+        else result = "[" + f.toString() + ", ... (" + len.toString() + ")]"
       )
     }
 
@@ -2161,7 +2161,7 @@ private module FlowExploration {
 
     private string ppAp() {
       exists(string s | s = this.(PartialPathNodePriv).getAp().toString() |
-        if s = "" then result = "" else result = " [" + s + "]"
+        if s = "" then result = "" else result = " " + s
       )
     }
 

--- a/java/ql/src/semmle/code/java/dataflow/internal/DataFlowImpl2.qll
+++ b/java/ql/src/semmle/code/java/dataflow/internal/DataFlowImpl2.qll
@@ -1261,7 +1261,7 @@ abstract private class AccessPath extends TAccessPath {
 
 private class AccessPathNil extends AccessPath, TNil {
   override string toString() {
-    exists(DataFlowType t | this = TNil(t) | result = concat(" : " + ppReprType(t)))
+    exists(DataFlowType t | this = TNil(t) | result = concat(": " + ppReprType(t)))
   }
 
   override AccessPathFront getFront() {
@@ -1277,7 +1277,7 @@ private class AccessPathConsNil extends AccessPathCons, TConsNil {
   override string toString() {
     exists(Content f, DataFlowType t | this = TConsNil(f, t) |
       // The `concat` becomes "" if `ppReprType` has no result.
-      result = f.toString() + concat(" : " + ppReprType(t))
+      result = "[" + f.toString() + "]" + concat(" : " + ppReprType(t))
     )
   }
 
@@ -1294,8 +1294,8 @@ private class AccessPathConsCons extends AccessPathCons, TConsCons {
   override string toString() {
     exists(Content f1, Content f2, int len | this = TConsCons(f1, f2, len) |
       if len = 2
-      then result = f1.toString() + ", " + f2.toString()
-      else result = f1.toString() + ", " + f2.toString() + ", ... (" + len.toString() + ")"
+      then result = "[" + f1.toString() + ", " + f2.toString() + "]"
+      else result = "[" + f1.toString() + ", " + f2.toString() + ", ... (" + len.toString() + ")]"
     )
   }
 
@@ -1626,7 +1626,7 @@ abstract class PathNode extends TPathNode {
     this instanceof PathNodeSink and result = ""
     or
     exists(string s | s = this.(PathNodeMid).getAp().toString() |
-      if s = "" then result = "" else result = " [" + s + "]"
+      if s = "" then result = "" else result = " " + s
     )
   }
 
@@ -2071,7 +2071,7 @@ private module FlowExploration {
 
   private class PartialAccessPathNil extends PartialAccessPath, TPartialNil {
     override string toString() {
-      exists(DataFlowType t | this = TPartialNil(t) | result = concat(" : " + ppReprType(t)))
+      exists(DataFlowType t | this = TPartialNil(t) | result = concat(": " + ppReprType(t)))
     }
 
     override AccessPathFront getFront() {
@@ -2083,8 +2083,8 @@ private module FlowExploration {
     override string toString() {
       exists(Content f, int len | this = TPartialCons(f, len) |
         if len = 1
-        then result = f.toString()
-        else result = f.toString() + ", ... (" + len.toString() + ")"
+        then result = "[" + f.toString() + "]"
+        else result = "[" + f.toString() + ", ... (" + len.toString() + ")]"
       )
     }
 
@@ -2161,7 +2161,7 @@ private module FlowExploration {
 
     private string ppAp() {
       exists(string s | s = this.(PartialPathNodePriv).getAp().toString() |
-        if s = "" then result = "" else result = " [" + s + "]"
+        if s = "" then result = "" else result = " " + s
       )
     }
 

--- a/java/ql/src/semmle/code/java/dataflow/internal/DataFlowImpl3.qll
+++ b/java/ql/src/semmle/code/java/dataflow/internal/DataFlowImpl3.qll
@@ -1261,7 +1261,7 @@ abstract private class AccessPath extends TAccessPath {
 
 private class AccessPathNil extends AccessPath, TNil {
   override string toString() {
-    exists(DataFlowType t | this = TNil(t) | result = concat(" : " + ppReprType(t)))
+    exists(DataFlowType t | this = TNil(t) | result = concat(": " + ppReprType(t)))
   }
 
   override AccessPathFront getFront() {
@@ -1277,7 +1277,7 @@ private class AccessPathConsNil extends AccessPathCons, TConsNil {
   override string toString() {
     exists(Content f, DataFlowType t | this = TConsNil(f, t) |
       // The `concat` becomes "" if `ppReprType` has no result.
-      result = f.toString() + concat(" : " + ppReprType(t))
+      result = "[" + f.toString() + "]" + concat(" : " + ppReprType(t))
     )
   }
 
@@ -1294,8 +1294,8 @@ private class AccessPathConsCons extends AccessPathCons, TConsCons {
   override string toString() {
     exists(Content f1, Content f2, int len | this = TConsCons(f1, f2, len) |
       if len = 2
-      then result = f1.toString() + ", " + f2.toString()
-      else result = f1.toString() + ", " + f2.toString() + ", ... (" + len.toString() + ")"
+      then result = "[" + f1.toString() + ", " + f2.toString() + "]"
+      else result = "[" + f1.toString() + ", " + f2.toString() + ", ... (" + len.toString() + ")]"
     )
   }
 
@@ -1626,7 +1626,7 @@ abstract class PathNode extends TPathNode {
     this instanceof PathNodeSink and result = ""
     or
     exists(string s | s = this.(PathNodeMid).getAp().toString() |
-      if s = "" then result = "" else result = " [" + s + "]"
+      if s = "" then result = "" else result = " " + s
     )
   }
 
@@ -2071,7 +2071,7 @@ private module FlowExploration {
 
   private class PartialAccessPathNil extends PartialAccessPath, TPartialNil {
     override string toString() {
-      exists(DataFlowType t | this = TPartialNil(t) | result = concat(" : " + ppReprType(t)))
+      exists(DataFlowType t | this = TPartialNil(t) | result = concat(": " + ppReprType(t)))
     }
 
     override AccessPathFront getFront() {
@@ -2083,8 +2083,8 @@ private module FlowExploration {
     override string toString() {
       exists(Content f, int len | this = TPartialCons(f, len) |
         if len = 1
-        then result = f.toString()
-        else result = f.toString() + ", ... (" + len.toString() + ")"
+        then result = "[" + f.toString() + "]"
+        else result = "[" + f.toString() + ", ... (" + len.toString() + ")]"
       )
     }
 
@@ -2161,7 +2161,7 @@ private module FlowExploration {
 
     private string ppAp() {
       exists(string s | s = this.(PartialPathNodePriv).getAp().toString() |
-        if s = "" then result = "" else result = " [" + s + "]"
+        if s = "" then result = "" else result = " " + s
       )
     }
 

--- a/java/ql/src/semmle/code/java/dataflow/internal/DataFlowImpl4.qll
+++ b/java/ql/src/semmle/code/java/dataflow/internal/DataFlowImpl4.qll
@@ -1261,7 +1261,7 @@ abstract private class AccessPath extends TAccessPath {
 
 private class AccessPathNil extends AccessPath, TNil {
   override string toString() {
-    exists(DataFlowType t | this = TNil(t) | result = concat(" : " + ppReprType(t)))
+    exists(DataFlowType t | this = TNil(t) | result = concat(": " + ppReprType(t)))
   }
 
   override AccessPathFront getFront() {
@@ -1277,7 +1277,7 @@ private class AccessPathConsNil extends AccessPathCons, TConsNil {
   override string toString() {
     exists(Content f, DataFlowType t | this = TConsNil(f, t) |
       // The `concat` becomes "" if `ppReprType` has no result.
-      result = f.toString() + concat(" : " + ppReprType(t))
+      result = "[" + f.toString() + "]" + concat(" : " + ppReprType(t))
     )
   }
 
@@ -1294,8 +1294,8 @@ private class AccessPathConsCons extends AccessPathCons, TConsCons {
   override string toString() {
     exists(Content f1, Content f2, int len | this = TConsCons(f1, f2, len) |
       if len = 2
-      then result = f1.toString() + ", " + f2.toString()
-      else result = f1.toString() + ", " + f2.toString() + ", ... (" + len.toString() + ")"
+      then result = "[" + f1.toString() + ", " + f2.toString() + "]"
+      else result = "[" + f1.toString() + ", " + f2.toString() + ", ... (" + len.toString() + ")]"
     )
   }
 
@@ -1626,7 +1626,7 @@ abstract class PathNode extends TPathNode {
     this instanceof PathNodeSink and result = ""
     or
     exists(string s | s = this.(PathNodeMid).getAp().toString() |
-      if s = "" then result = "" else result = " [" + s + "]"
+      if s = "" then result = "" else result = " " + s
     )
   }
 
@@ -2071,7 +2071,7 @@ private module FlowExploration {
 
   private class PartialAccessPathNil extends PartialAccessPath, TPartialNil {
     override string toString() {
-      exists(DataFlowType t | this = TPartialNil(t) | result = concat(" : " + ppReprType(t)))
+      exists(DataFlowType t | this = TPartialNil(t) | result = concat(": " + ppReprType(t)))
     }
 
     override AccessPathFront getFront() {
@@ -2083,8 +2083,8 @@ private module FlowExploration {
     override string toString() {
       exists(Content f, int len | this = TPartialCons(f, len) |
         if len = 1
-        then result = f.toString()
-        else result = f.toString() + ", ... (" + len.toString() + ")"
+        then result = "[" + f.toString() + "]"
+        else result = "[" + f.toString() + ", ... (" + len.toString() + ")]"
       )
     }
 
@@ -2161,7 +2161,7 @@ private module FlowExploration {
 
     private string ppAp() {
       exists(string s | s = this.(PartialPathNodePriv).getAp().toString() |
-        if s = "" then result = "" else result = " [" + s + "]"
+        if s = "" then result = "" else result = " " + s
       )
     }
 

--- a/java/ql/src/semmle/code/java/dataflow/internal/DataFlowImpl5.qll
+++ b/java/ql/src/semmle/code/java/dataflow/internal/DataFlowImpl5.qll
@@ -1261,7 +1261,7 @@ abstract private class AccessPath extends TAccessPath {
 
 private class AccessPathNil extends AccessPath, TNil {
   override string toString() {
-    exists(DataFlowType t | this = TNil(t) | result = concat(" : " + ppReprType(t)))
+    exists(DataFlowType t | this = TNil(t) | result = concat(": " + ppReprType(t)))
   }
 
   override AccessPathFront getFront() {
@@ -1277,7 +1277,7 @@ private class AccessPathConsNil extends AccessPathCons, TConsNil {
   override string toString() {
     exists(Content f, DataFlowType t | this = TConsNil(f, t) |
       // The `concat` becomes "" if `ppReprType` has no result.
-      result = f.toString() + concat(" : " + ppReprType(t))
+      result = "[" + f.toString() + "]" + concat(" : " + ppReprType(t))
     )
   }
 
@@ -1294,8 +1294,8 @@ private class AccessPathConsCons extends AccessPathCons, TConsCons {
   override string toString() {
     exists(Content f1, Content f2, int len | this = TConsCons(f1, f2, len) |
       if len = 2
-      then result = f1.toString() + ", " + f2.toString()
-      else result = f1.toString() + ", " + f2.toString() + ", ... (" + len.toString() + ")"
+      then result = "[" + f1.toString() + ", " + f2.toString() + "]"
+      else result = "[" + f1.toString() + ", " + f2.toString() + ", ... (" + len.toString() + ")]"
     )
   }
 
@@ -1626,7 +1626,7 @@ abstract class PathNode extends TPathNode {
     this instanceof PathNodeSink and result = ""
     or
     exists(string s | s = this.(PathNodeMid).getAp().toString() |
-      if s = "" then result = "" else result = " [" + s + "]"
+      if s = "" then result = "" else result = " " + s
     )
   }
 
@@ -2071,7 +2071,7 @@ private module FlowExploration {
 
   private class PartialAccessPathNil extends PartialAccessPath, TPartialNil {
     override string toString() {
-      exists(DataFlowType t | this = TPartialNil(t) | result = concat(" : " + ppReprType(t)))
+      exists(DataFlowType t | this = TPartialNil(t) | result = concat(": " + ppReprType(t)))
     }
 
     override AccessPathFront getFront() {
@@ -2083,8 +2083,8 @@ private module FlowExploration {
     override string toString() {
       exists(Content f, int len | this = TPartialCons(f, len) |
         if len = 1
-        then result = f.toString()
-        else result = f.toString() + ", ... (" + len.toString() + ")"
+        then result = "[" + f.toString() + "]"
+        else result = "[" + f.toString() + ", ... (" + len.toString() + ")]"
       )
     }
 
@@ -2161,7 +2161,7 @@ private module FlowExploration {
 
     private string ppAp() {
       exists(string s | s = this.(PartialPathNodePriv).getAp().toString() |
-        if s = "" then result = "" else result = " [" + s + "]"
+        if s = "" then result = "" else result = " " + s
       )
     }
 

--- a/java/ql/test/library-tests/dataflow/partial/test.expected
+++ b/java/ql/test/library-tests/dataflow/partial/test.expected
@@ -1,13 +1,13 @@
 edges
 | A.java:12:5:12:5 | b [post update] [elem] | A.java:13:12:13:12 | b [elem] |
-| A.java:12:14:12:18 | src(...) [ : Object] | A.java:12:5:12:5 | b [post update] [elem] |
-| A.java:12:14:12:18 | src(...) [ : Object] | A.java:12:5:12:18 | ...=... [ : Object] |
+| A.java:12:14:12:18 | src(...) : Object | A.java:12:5:12:5 | b [post update] [elem] |
+| A.java:12:14:12:18 | src(...) : Object | A.java:12:5:12:18 | ...=... : Object |
 | A.java:13:12:13:12 | b [elem] | A.java:17:13:17:16 | f1(...) [elem] |
 | A.java:17:13:17:16 | f1(...) [elem] | A.java:18:8:18:8 | b [elem] |
 | A.java:18:8:18:8 | b [elem] | A.java:21:11:21:15 | b [elem] |
 #select
 | 0 | A.java:12:5:12:5 | b [post update] [elem] |
-| 0 | A.java:12:5:12:18 | ...=... [ : Object] |
+| 0 | A.java:12:5:12:18 | ...=... : Object |
 | 0 | A.java:13:12:13:12 | b [elem] |
 | 1 | A.java:17:13:17:16 | f1(...) [elem] |
 | 1 | A.java:18:8:18:8 | b [elem] |

--- a/java/ql/test/query-tests/security/CWE-022/semmle/tests/TaintedPath.expected
+++ b/java/ql/test/query-tests/security/CWE-022/semmle/tests/TaintedPath.expected
@@ -1,13 +1,13 @@
 edges
-| Test.java:19:18:19:38 | getHostName(...) [ : String] | Test.java:24:20:24:23 | temp |
-| Test.java:19:18:19:38 | getHostName(...) [ : String] | Test.java:27:21:27:24 | temp |
-| Test.java:19:18:19:38 | getHostName(...) [ : String] | Test.java:30:44:30:47 | temp |
+| Test.java:19:18:19:38 | getHostName(...) : String | Test.java:24:20:24:23 | temp |
+| Test.java:19:18:19:38 | getHostName(...) : String | Test.java:27:21:27:24 | temp |
+| Test.java:19:18:19:38 | getHostName(...) : String | Test.java:30:44:30:47 | temp |
 nodes
-| Test.java:19:18:19:38 | getHostName(...) [ : String] | semmle.label | getHostName(...) [ : String] |
+| Test.java:19:18:19:38 | getHostName(...) : String | semmle.label | getHostName(...) : String |
 | Test.java:24:20:24:23 | temp | semmle.label | temp |
 | Test.java:27:21:27:24 | temp | semmle.label | temp |
 | Test.java:30:44:30:47 | temp | semmle.label | temp |
 #select
-| Test.java:24:11:24:24 | new File(...) | Test.java:19:18:19:38 | getHostName(...) [ : String] | Test.java:24:20:24:23 | temp | $@ flows to here and is used in a path. | Test.java:19:18:19:38 | getHostName(...) | User-provided value |
-| Test.java:27:11:27:25 | get(...) | Test.java:19:18:19:38 | getHostName(...) [ : String] | Test.java:27:21:27:24 | temp | $@ flows to here and is used in a path. | Test.java:19:18:19:38 | getHostName(...) | User-provided value |
-| Test.java:30:11:30:48 | getPath(...) | Test.java:19:18:19:38 | getHostName(...) [ : String] | Test.java:30:44:30:47 | temp | $@ flows to here and is used in a path. | Test.java:19:18:19:38 | getHostName(...) | User-provided value |
+| Test.java:24:11:24:24 | new File(...) | Test.java:19:18:19:38 | getHostName(...) : String | Test.java:24:20:24:23 | temp | $@ flows to here and is used in a path. | Test.java:19:18:19:38 | getHostName(...) | User-provided value |
+| Test.java:27:11:27:25 | get(...) | Test.java:19:18:19:38 | getHostName(...) : String | Test.java:27:21:27:24 | temp | $@ flows to here and is used in a path. | Test.java:19:18:19:38 | getHostName(...) | User-provided value |
+| Test.java:30:11:30:48 | getPath(...) | Test.java:19:18:19:38 | getHostName(...) : String | Test.java:30:44:30:47 | temp | $@ flows to here and is used in a path. | Test.java:19:18:19:38 | getHostName(...) | User-provided value |

--- a/java/ql/test/query-tests/security/CWE-022/semmle/tests/ZipSlip.expected
+++ b/java/ql/test/query-tests/security/CWE-022/semmle/tests/ZipSlip.expected
@@ -1,13 +1,13 @@
 edges
-| ZipTest.java:7:19:7:33 | getName(...) [ : String] | ZipTest.java:9:48:9:51 | file |
-| ZipTest.java:7:19:7:33 | getName(...) [ : String] | ZipTest.java:10:49:10:52 | file |
-| ZipTest.java:7:19:7:33 | getName(...) [ : String] | ZipTest.java:11:36:11:39 | file |
+| ZipTest.java:7:19:7:33 | getName(...) : String | ZipTest.java:9:48:9:51 | file |
+| ZipTest.java:7:19:7:33 | getName(...) : String | ZipTest.java:10:49:10:52 | file |
+| ZipTest.java:7:19:7:33 | getName(...) : String | ZipTest.java:11:36:11:39 | file |
 nodes
-| ZipTest.java:7:19:7:33 | getName(...) [ : String] | semmle.label | getName(...) [ : String] |
+| ZipTest.java:7:19:7:33 | getName(...) : String | semmle.label | getName(...) : String |
 | ZipTest.java:9:48:9:51 | file | semmle.label | file |
 | ZipTest.java:10:49:10:52 | file | semmle.label | file |
 | ZipTest.java:11:36:11:39 | file | semmle.label | file |
 #select
-| ZipTest.java:7:19:7:33 | getName(...) | ZipTest.java:7:19:7:33 | getName(...) [ : String] | ZipTest.java:9:48:9:51 | file | Unsanitized archive entry, which may contain '..', is used in a $@. | ZipTest.java:9:48:9:51 | file | file system operation |
-| ZipTest.java:7:19:7:33 | getName(...) | ZipTest.java:7:19:7:33 | getName(...) [ : String] | ZipTest.java:10:49:10:52 | file | Unsanitized archive entry, which may contain '..', is used in a $@. | ZipTest.java:10:49:10:52 | file | file system operation |
-| ZipTest.java:7:19:7:33 | getName(...) | ZipTest.java:7:19:7:33 | getName(...) [ : String] | ZipTest.java:11:36:11:39 | file | Unsanitized archive entry, which may contain '..', is used in a $@. | ZipTest.java:11:36:11:39 | file | file system operation |
+| ZipTest.java:7:19:7:33 | getName(...) | ZipTest.java:7:19:7:33 | getName(...) : String | ZipTest.java:9:48:9:51 | file | Unsanitized archive entry, which may contain '..', is used in a $@. | ZipTest.java:9:48:9:51 | file | file system operation |
+| ZipTest.java:7:19:7:33 | getName(...) | ZipTest.java:7:19:7:33 | getName(...) : String | ZipTest.java:10:49:10:52 | file | Unsanitized archive entry, which may contain '..', is used in a $@. | ZipTest.java:10:49:10:52 | file | file system operation |
+| ZipTest.java:7:19:7:33 | getName(...) | ZipTest.java:7:19:7:33 | getName(...) : String | ZipTest.java:11:36:11:39 | file | Unsanitized archive entry, which may contain '..', is used in a $@. | ZipTest.java:11:36:11:39 | file | file system operation |

--- a/java/ql/test/query-tests/security/CWE-079/semmle/tests/XSS.expected
+++ b/java/ql/test/query-tests/security/CWE-079/semmle/tests/XSS.expected
@@ -1,19 +1,19 @@
 edges
-| XSS.java:23:21:23:48 | getParameter(...) [ : String] | XSS.java:23:5:23:70 | ... + ... |
-| XSS.java:27:21:27:48 | getParameter(...) [ : String] | XSS.java:27:5:27:70 | ... + ... |
-| XSS.java:38:67:38:87 | getPathInfo(...) [ : String] | XSS.java:38:30:38:87 | ... + ... |
-| XSS.java:41:36:41:56 | getPathInfo(...) [ : String] | XSS.java:41:36:41:67 | getBytes(...) |
+| XSS.java:23:21:23:48 | getParameter(...) : String | XSS.java:23:5:23:70 | ... + ... |
+| XSS.java:27:21:27:48 | getParameter(...) : String | XSS.java:27:5:27:70 | ... + ... |
+| XSS.java:38:67:38:87 | getPathInfo(...) : String | XSS.java:38:30:38:87 | ... + ... |
+| XSS.java:41:36:41:56 | getPathInfo(...) : String | XSS.java:41:36:41:67 | getBytes(...) |
 nodes
 | XSS.java:23:5:23:70 | ... + ... | semmle.label | ... + ... |
-| XSS.java:23:21:23:48 | getParameter(...) [ : String] | semmle.label | getParameter(...) [ : String] |
+| XSS.java:23:21:23:48 | getParameter(...) : String | semmle.label | getParameter(...) : String |
 | XSS.java:27:5:27:70 | ... + ... | semmle.label | ... + ... |
-| XSS.java:27:21:27:48 | getParameter(...) [ : String] | semmle.label | getParameter(...) [ : String] |
+| XSS.java:27:21:27:48 | getParameter(...) : String | semmle.label | getParameter(...) : String |
 | XSS.java:38:30:38:87 | ... + ... | semmle.label | ... + ... |
-| XSS.java:38:67:38:87 | getPathInfo(...) [ : String] | semmle.label | getPathInfo(...) [ : String] |
-| XSS.java:41:36:41:56 | getPathInfo(...) [ : String] | semmle.label | getPathInfo(...) [ : String] |
+| XSS.java:38:67:38:87 | getPathInfo(...) : String | semmle.label | getPathInfo(...) : String |
+| XSS.java:41:36:41:56 | getPathInfo(...) : String | semmle.label | getPathInfo(...) : String |
 | XSS.java:41:36:41:67 | getBytes(...) | semmle.label | getBytes(...) |
 #select
-| XSS.java:23:5:23:70 | ... + ... | XSS.java:23:21:23:48 | getParameter(...) [ : String] | XSS.java:23:5:23:70 | ... + ... | Cross-site scripting vulnerability due to $@. | XSS.java:23:21:23:48 | getParameter(...) | user-provided value |
-| XSS.java:27:5:27:70 | ... + ... | XSS.java:27:21:27:48 | getParameter(...) [ : String] | XSS.java:27:5:27:70 | ... + ... | Cross-site scripting vulnerability due to $@. | XSS.java:27:21:27:48 | getParameter(...) | user-provided value |
-| XSS.java:38:30:38:87 | ... + ... | XSS.java:38:67:38:87 | getPathInfo(...) [ : String] | XSS.java:38:30:38:87 | ... + ... | Cross-site scripting vulnerability due to $@. | XSS.java:38:67:38:87 | getPathInfo(...) | user-provided value |
-| XSS.java:41:36:41:67 | getBytes(...) | XSS.java:41:36:41:56 | getPathInfo(...) [ : String] | XSS.java:41:36:41:67 | getBytes(...) | Cross-site scripting vulnerability due to $@. | XSS.java:41:36:41:56 | getPathInfo(...) | user-provided value |
+| XSS.java:23:5:23:70 | ... + ... | XSS.java:23:21:23:48 | getParameter(...) : String | XSS.java:23:5:23:70 | ... + ... | Cross-site scripting vulnerability due to $@. | XSS.java:23:21:23:48 | getParameter(...) | user-provided value |
+| XSS.java:27:5:27:70 | ... + ... | XSS.java:27:21:27:48 | getParameter(...) : String | XSS.java:27:5:27:70 | ... + ... | Cross-site scripting vulnerability due to $@. | XSS.java:27:21:27:48 | getParameter(...) | user-provided value |
+| XSS.java:38:30:38:87 | ... + ... | XSS.java:38:67:38:87 | getPathInfo(...) : String | XSS.java:38:30:38:87 | ... + ... | Cross-site scripting vulnerability due to $@. | XSS.java:38:67:38:87 | getPathInfo(...) | user-provided value |
+| XSS.java:41:36:41:67 | getBytes(...) | XSS.java:41:36:41:56 | getPathInfo(...) : String | XSS.java:41:36:41:67 | getBytes(...) | Cross-site scripting vulnerability due to $@. | XSS.java:41:36:41:56 | getPathInfo(...) | user-provided value |

--- a/java/ql/test/query-tests/security/CWE-089/semmle/examples/SqlTaintedLocal.expected
+++ b/java/ql/test/query-tests/security/CWE-089/semmle/examples/SqlTaintedLocal.expected
@@ -1,33 +1,33 @@
 edges
-| Test.java:29:30:29:42 | args [ : String[]] | Test.java:36:47:36:52 | query1 |
-| Test.java:29:30:29:42 | args [ : String[]] | Test.java:42:57:42:62 | query2 |
-| Test.java:29:30:29:42 | args [ : String[]] | Test.java:50:62:50:67 | query3 |
-| Test.java:29:30:29:42 | args [ : String[]] | Test.java:62:47:62:61 | querySbToString |
-| Test.java:29:30:29:42 | args [ : String[]] | Test.java:70:40:70:44 | query |
-| Test.java:29:30:29:42 | args [ : String[]] | Test.java:78:46:78:50 | query |
-| Test.java:183:33:183:45 | args [ : String[]] | Test.java:209:47:209:68 | queryWithUserTableName |
-| Test.java:213:26:213:38 | args [ : String[]] | Test.java:214:11:214:14 | args [ : String[]] |
-| Test.java:213:26:213:38 | args [ : String[]] | Test.java:218:14:218:17 | args [ : String[]] |
-| Test.java:214:11:214:14 | args [ : String[]] | Test.java:29:30:29:42 | args [ : String[]] |
-| Test.java:218:14:218:17 | args [ : String[]] | Test.java:183:33:183:45 | args [ : String[]] |
+| Test.java:29:30:29:42 | args : String[] | Test.java:36:47:36:52 | query1 |
+| Test.java:29:30:29:42 | args : String[] | Test.java:42:57:42:62 | query2 |
+| Test.java:29:30:29:42 | args : String[] | Test.java:50:62:50:67 | query3 |
+| Test.java:29:30:29:42 | args : String[] | Test.java:62:47:62:61 | querySbToString |
+| Test.java:29:30:29:42 | args : String[] | Test.java:70:40:70:44 | query |
+| Test.java:29:30:29:42 | args : String[] | Test.java:78:46:78:50 | query |
+| Test.java:183:33:183:45 | args : String[] | Test.java:209:47:209:68 | queryWithUserTableName |
+| Test.java:213:26:213:38 | args : String[] | Test.java:214:11:214:14 | args : String[] |
+| Test.java:213:26:213:38 | args : String[] | Test.java:218:14:218:17 | args : String[] |
+| Test.java:214:11:214:14 | args : String[] | Test.java:29:30:29:42 | args : String[] |
+| Test.java:218:14:218:17 | args : String[] | Test.java:183:33:183:45 | args : String[] |
 nodes
-| Test.java:29:30:29:42 | args [ : String[]] | semmle.label | args [ : String[]] |
+| Test.java:29:30:29:42 | args : String[] | semmle.label | args : String[] |
 | Test.java:36:47:36:52 | query1 | semmle.label | query1 |
 | Test.java:42:57:42:62 | query2 | semmle.label | query2 |
 | Test.java:50:62:50:67 | query3 | semmle.label | query3 |
 | Test.java:62:47:62:61 | querySbToString | semmle.label | querySbToString |
 | Test.java:70:40:70:44 | query | semmle.label | query |
 | Test.java:78:46:78:50 | query | semmle.label | query |
-| Test.java:183:33:183:45 | args [ : String[]] | semmle.label | args [ : String[]] |
+| Test.java:183:33:183:45 | args : String[] | semmle.label | args : String[] |
 | Test.java:209:47:209:68 | queryWithUserTableName | semmle.label | queryWithUserTableName |
-| Test.java:213:26:213:38 | args [ : String[]] | semmle.label | args [ : String[]] |
-| Test.java:214:11:214:14 | args [ : String[]] | semmle.label | args [ : String[]] |
-| Test.java:218:14:218:17 | args [ : String[]] | semmle.label | args [ : String[]] |
+| Test.java:213:26:213:38 | args : String[] | semmle.label | args : String[] |
+| Test.java:214:11:214:14 | args : String[] | semmle.label | args : String[] |
+| Test.java:218:14:218:17 | args : String[] | semmle.label | args : String[] |
 #select
-| Test.java:36:47:36:52 | query1 | Test.java:213:26:213:38 | args [ : String[]] | Test.java:36:47:36:52 | query1 | Query might include code from $@. | Test.java:213:26:213:38 | args | this user input |
-| Test.java:42:57:42:62 | query2 | Test.java:213:26:213:38 | args [ : String[]] | Test.java:42:57:42:62 | query2 | Query might include code from $@. | Test.java:213:26:213:38 | args | this user input |
-| Test.java:50:62:50:67 | query3 | Test.java:213:26:213:38 | args [ : String[]] | Test.java:50:62:50:67 | query3 | Query might include code from $@. | Test.java:213:26:213:38 | args | this user input |
-| Test.java:62:47:62:61 | querySbToString | Test.java:213:26:213:38 | args [ : String[]] | Test.java:62:47:62:61 | querySbToString | Query might include code from $@. | Test.java:213:26:213:38 | args | this user input |
-| Test.java:70:40:70:44 | query | Test.java:213:26:213:38 | args [ : String[]] | Test.java:70:40:70:44 | query | Query might include code from $@. | Test.java:213:26:213:38 | args | this user input |
-| Test.java:78:46:78:50 | query | Test.java:213:26:213:38 | args [ : String[]] | Test.java:78:46:78:50 | query | Query might include code from $@. | Test.java:213:26:213:38 | args | this user input |
-| Test.java:209:47:209:68 | queryWithUserTableName | Test.java:213:26:213:38 | args [ : String[]] | Test.java:209:47:209:68 | queryWithUserTableName | Query might include code from $@. | Test.java:213:26:213:38 | args | this user input |
+| Test.java:36:47:36:52 | query1 | Test.java:213:26:213:38 | args : String[] | Test.java:36:47:36:52 | query1 | Query might include code from $@. | Test.java:213:26:213:38 | args | this user input |
+| Test.java:42:57:42:62 | query2 | Test.java:213:26:213:38 | args : String[] | Test.java:42:57:42:62 | query2 | Query might include code from $@. | Test.java:213:26:213:38 | args | this user input |
+| Test.java:50:62:50:67 | query3 | Test.java:213:26:213:38 | args : String[] | Test.java:50:62:50:67 | query3 | Query might include code from $@. | Test.java:213:26:213:38 | args | this user input |
+| Test.java:62:47:62:61 | querySbToString | Test.java:213:26:213:38 | args : String[] | Test.java:62:47:62:61 | querySbToString | Query might include code from $@. | Test.java:213:26:213:38 | args | this user input |
+| Test.java:70:40:70:44 | query | Test.java:213:26:213:38 | args : String[] | Test.java:70:40:70:44 | query | Query might include code from $@. | Test.java:213:26:213:38 | args | this user input |
+| Test.java:78:46:78:50 | query | Test.java:213:26:213:38 | args : String[] | Test.java:78:46:78:50 | query | Query might include code from $@. | Test.java:213:26:213:38 | args | this user input |
+| Test.java:209:47:209:68 | queryWithUserTableName | Test.java:213:26:213:38 | args : String[] | Test.java:209:47:209:68 | queryWithUserTableName | Query might include code from $@. | Test.java:213:26:213:38 | args | this user input |

--- a/java/ql/test/query-tests/security/CWE-113/semmle/tests/ResponseSplitting.expected
+++ b/java/ql/test/query-tests/security/CWE-113/semmle/tests/ResponseSplitting.expected
@@ -1,11 +1,11 @@
 edges
-| ResponseSplitting.java:22:39:22:66 | getParameter(...) [ : String] | ResponseSplitting.java:23:23:23:28 | cookie |
+| ResponseSplitting.java:22:39:22:66 | getParameter(...) : String | ResponseSplitting.java:23:23:23:28 | cookie |
 nodes
-| ResponseSplitting.java:22:39:22:66 | getParameter(...) [ : String] | semmle.label | getParameter(...) [ : String] |
+| ResponseSplitting.java:22:39:22:66 | getParameter(...) : String | semmle.label | getParameter(...) : String |
 | ResponseSplitting.java:23:23:23:28 | cookie | semmle.label | cookie |
 | ResponseSplitting.java:28:38:28:72 | getParameter(...) | semmle.label | getParameter(...) |
 | ResponseSplitting.java:29:38:29:72 | getParameter(...) | semmle.label | getParameter(...) |
 #select
-| ResponseSplitting.java:23:23:23:28 | cookie | ResponseSplitting.java:22:39:22:66 | getParameter(...) [ : String] | ResponseSplitting.java:23:23:23:28 | cookie | Response-splitting vulnerability due to this $@. | ResponseSplitting.java:22:39:22:66 | getParameter(...) | user-provided value |
+| ResponseSplitting.java:23:23:23:28 | cookie | ResponseSplitting.java:22:39:22:66 | getParameter(...) : String | ResponseSplitting.java:23:23:23:28 | cookie | Response-splitting vulnerability due to this $@. | ResponseSplitting.java:22:39:22:66 | getParameter(...) | user-provided value |
 | ResponseSplitting.java:28:38:28:72 | getParameter(...) | ResponseSplitting.java:28:38:28:72 | getParameter(...) | ResponseSplitting.java:28:38:28:72 | getParameter(...) | Response-splitting vulnerability due to this $@. | ResponseSplitting.java:28:38:28:72 | getParameter(...) | user-provided value |
 | ResponseSplitting.java:29:38:29:72 | getParameter(...) | ResponseSplitting.java:29:38:29:72 | getParameter(...) | ResponseSplitting.java:29:38:29:72 | getParameter(...) | Response-splitting vulnerability due to this $@. | ResponseSplitting.java:29:38:29:72 | getParameter(...) | user-provided value |

--- a/java/ql/test/query-tests/security/CWE-129/semmle/tests/ImproperValidationOfArrayConstructionCodeSpecified.expected
+++ b/java/ql/test/query-tests/security/CWE-129/semmle/tests/ImproperValidationOfArrayConstructionCodeSpecified.expected
@@ -1,7 +1,7 @@
 edges
-| Test.java:86:16:86:16 | 0 [ : Number] | Test.java:88:27:88:30 | size |
+| Test.java:86:16:86:16 | 0 : Number | Test.java:88:27:88:30 | size |
 nodes
-| Test.java:86:16:86:16 | 0 [ : Number] | semmle.label | 0 [ : Number] |
+| Test.java:86:16:86:16 | 0 : Number | semmle.label | 0 : Number |
 | Test.java:88:27:88:30 | size | semmle.label | size |
 #select
-| Test.java:91:30:91:30 | 0 | Test.java:86:16:86:16 | 0 [ : Number] | Test.java:88:27:88:30 | size | The $@ is accessed here, but the array is initialized using $@ which may be zero. | Test.java:88:19:88:31 | new int[] | array | Test.java:86:16:86:16 | 0 | literal value 0 |
+| Test.java:91:30:91:30 | 0 | Test.java:86:16:86:16 | 0 : Number | Test.java:88:27:88:30 | size | The $@ is accessed here, but the array is initialized using $@ which may be zero. | Test.java:88:19:88:31 | new int[] | array | Test.java:86:16:86:16 | 0 | literal value 0 |

--- a/java/ql/test/query-tests/security/CWE-129/semmle/tests/ImproperValidationOfArrayConstructionLocal.expected
+++ b/java/ql/test/query-tests/security/CWE-129/semmle/tests/ImproperValidationOfArrayConstructionLocal.expected
@@ -1,10 +1,10 @@
 edges
-| Test.java:57:27:57:60 | getProperty(...) [ : String] | Test.java:61:31:61:34 | size |
-| Test.java:57:27:57:60 | getProperty(...) [ : String] | Test.java:67:34:67:37 | size |
+| Test.java:57:27:57:60 | getProperty(...) : String | Test.java:61:31:61:34 | size |
+| Test.java:57:27:57:60 | getProperty(...) : String | Test.java:67:34:67:37 | size |
 nodes
-| Test.java:57:27:57:60 | getProperty(...) [ : String] | semmle.label | getProperty(...) [ : String] |
+| Test.java:57:27:57:60 | getProperty(...) : String | semmle.label | getProperty(...) : String |
 | Test.java:61:31:61:34 | size | semmle.label | size |
 | Test.java:67:34:67:37 | size | semmle.label | size |
 #select
-| Test.java:64:34:64:34 | 0 | Test.java:57:27:57:60 | getProperty(...) [ : String] | Test.java:61:31:61:34 | size | The $@ is accessed here, but the array is initialized using $@ which may be zero. | Test.java:61:23:61:35 | new int[] | array | Test.java:57:27:57:60 | getProperty(...) | User-provided value |
-| Test.java:70:37:70:37 | 0 | Test.java:57:27:57:60 | getProperty(...) [ : String] | Test.java:67:34:67:37 | size | The $@ is accessed here, but the array is initialized using $@ which may be zero. | Test.java:67:26:67:38 | new int[] | array | Test.java:57:27:57:60 | getProperty(...) | User-provided value |
+| Test.java:64:34:64:34 | 0 | Test.java:57:27:57:60 | getProperty(...) : String | Test.java:61:31:61:34 | size | The $@ is accessed here, but the array is initialized using $@ which may be zero. | Test.java:61:23:61:35 | new int[] | array | Test.java:57:27:57:60 | getProperty(...) | User-provided value |
+| Test.java:70:37:70:37 | 0 | Test.java:57:27:57:60 | getProperty(...) : String | Test.java:67:34:67:37 | size | The $@ is accessed here, but the array is initialized using $@ which may be zero. | Test.java:67:26:67:38 | new int[] | array | Test.java:57:27:57:60 | getProperty(...) | User-provided value |

--- a/java/ql/test/query-tests/security/CWE-129/semmle/tests/ImproperValidationOfArrayIndexCodeSpecified.expected
+++ b/java/ql/test/query-tests/security/CWE-129/semmle/tests/ImproperValidationOfArrayIndexCodeSpecified.expected
@@ -1,10 +1,10 @@
 edges
-| Test.java:40:17:40:48 | nextInt(...) [ : Number] | Test.java:43:30:43:34 | index |
-| Test.java:40:17:40:48 | nextInt(...) [ : Number] | Test.java:47:32:47:36 | index |
-| Test.java:40:17:40:48 | nextInt(...) [ : Number] | Test.java:51:39:51:43 | index |
-| Test.java:93:17:93:17 | 0 [ : Number] | Test.java:96:32:96:36 | index |
+| Test.java:40:17:40:48 | nextInt(...) : Number | Test.java:43:30:43:34 | index |
+| Test.java:40:17:40:48 | nextInt(...) : Number | Test.java:47:32:47:36 | index |
+| Test.java:40:17:40:48 | nextInt(...) : Number | Test.java:51:39:51:43 | index |
+| Test.java:93:17:93:17 | 0 : Number | Test.java:96:32:96:36 | index |
 nodes
-| Test.java:40:17:40:48 | nextInt(...) [ : Number] | semmle.label | nextInt(...) [ : Number] |
+| Test.java:40:17:40:48 | nextInt(...) : Number | semmle.label | nextInt(...) : Number |
 | Test.java:43:30:43:34 | index | semmle.label | index |
 | Test.java:47:32:47:36 | index | semmle.label | index |
 | Test.java:51:39:51:43 | index | semmle.label | index |
@@ -12,8 +12,8 @@ nodes
 | Test.java:70:37:70:37 | 0 | semmle.label | 0 |
 | Test.java:77:39:77:39 | 0 | semmle.label | 0 |
 | Test.java:91:30:91:30 | 0 | semmle.label | 0 |
-| Test.java:93:17:93:17 | 0 [ : Number] | semmle.label | 0 [ : Number] |
+| Test.java:93:17:93:17 | 0 : Number | semmle.label | 0 : Number |
 | Test.java:96:32:96:36 | index | semmle.label | index |
 | Test.java:102:30:102:30 | 0 | semmle.label | 0 |
 #select
-| Test.java:43:30:43:34 | index | Test.java:40:17:40:48 | nextInt(...) [ : Number] | Test.java:43:30:43:34 | index | $@ flows to the index used in this array access, and may cause the operation to throw an ArrayIndexOutOfBoundsException. | Test.java:40:17:40:48 | nextInt(...) | Random value |
+| Test.java:43:30:43:34 | index | Test.java:40:17:40:48 | nextInt(...) : Number | Test.java:43:30:43:34 | index | $@ flows to the index used in this array access, and may cause the operation to throw an ArrayIndexOutOfBoundsException. | Test.java:40:17:40:48 | nextInt(...) | Random value |

--- a/java/ql/test/query-tests/security/CWE-129/semmle/tests/ImproperValidationOfArrayIndexLocal.expected
+++ b/java/ql/test/query-tests/security/CWE-129/semmle/tests/ImproperValidationOfArrayIndexLocal.expected
@@ -1,7 +1,7 @@
 edges
-| Test.java:13:27:13:60 | getProperty(...) [ : String] | Test.java:18:34:18:38 | index |
+| Test.java:13:27:13:60 | getProperty(...) : String | Test.java:18:34:18:38 | index |
 nodes
-| Test.java:13:27:13:60 | getProperty(...) [ : String] | semmle.label | getProperty(...) [ : String] |
+| Test.java:13:27:13:60 | getProperty(...) : String | semmle.label | getProperty(...) : String |
 | Test.java:18:34:18:38 | index | semmle.label | index |
 #select
-| Test.java:18:34:18:38 | index | Test.java:13:27:13:60 | getProperty(...) [ : String] | Test.java:18:34:18:38 | index | $@ flows to here and is used as an index causing an ArrayIndexOutOfBoundsException. | Test.java:13:27:13:60 | getProperty(...) | User-provided value |
+| Test.java:18:34:18:38 | index | Test.java:13:27:13:60 | getProperty(...) : String | Test.java:18:34:18:38 | index | $@ flows to here and is used as an index causing an ArrayIndexOutOfBoundsException. | Test.java:13:27:13:60 | getProperty(...) | User-provided value |

--- a/java/ql/test/query-tests/security/CWE-134/semmle/tests/ExternallyControlledFormatString.expected
+++ b/java/ql/test/query-tests/security/CWE-134/semmle/tests/ExternallyControlledFormatString.expected
@@ -1,11 +1,11 @@
 edges
-| Test.java:33:30:33:74 | getParameter(...) [ : String] | Test.java:34:20:34:32 | userParameter [ : String] |
-| Test.java:34:20:34:32 | userParameter [ : String] | Test.java:37:31:37:43 | format [ : String] |
-| Test.java:37:31:37:43 | format [ : String] | Test.java:39:25:39:30 | format |
+| Test.java:33:30:33:74 | getParameter(...) : String | Test.java:34:20:34:32 | userParameter : String |
+| Test.java:34:20:34:32 | userParameter : String | Test.java:37:31:37:43 | format : String |
+| Test.java:37:31:37:43 | format : String | Test.java:39:25:39:30 | format |
 nodes
-| Test.java:33:30:33:74 | getParameter(...) [ : String] | semmle.label | getParameter(...) [ : String] |
-| Test.java:34:20:34:32 | userParameter [ : String] | semmle.label | userParameter [ : String] |
-| Test.java:37:31:37:43 | format [ : String] | semmle.label | format [ : String] |
+| Test.java:33:30:33:74 | getParameter(...) : String | semmle.label | getParameter(...) : String |
+| Test.java:34:20:34:32 | userParameter : String | semmle.label | userParameter : String |
+| Test.java:37:31:37:43 | format : String | semmle.label | format : String |
 | Test.java:39:25:39:30 | format | semmle.label | format |
 #select
-| Test.java:39:25:39:30 | format | Test.java:33:30:33:74 | getParameter(...) [ : String] | Test.java:39:25:39:30 | format | $@ flows to here and is used in a format string. | Test.java:33:30:33:74 | getParameter(...) | User-provided value |
+| Test.java:39:25:39:30 | format | Test.java:33:30:33:74 | getParameter(...) : String | Test.java:39:25:39:30 | format | $@ flows to here and is used in a format string. | Test.java:33:30:33:74 | getParameter(...) | User-provided value |

--- a/java/ql/test/query-tests/security/CWE-134/semmle/tests/ExternallyControlledFormatStringLocal.expected
+++ b/java/ql/test/query-tests/security/CWE-134/semmle/tests/ExternallyControlledFormatStringLocal.expected
@@ -1,19 +1,19 @@
 edges
-| Test.java:17:27:17:60 | getProperty(...) [ : String] | Test.java:19:19:19:30 | userProperty |
-| Test.java:17:27:17:60 | getProperty(...) [ : String] | Test.java:21:23:21:34 | userProperty |
-| Test.java:17:27:17:60 | getProperty(...) [ : String] | Test.java:23:23:23:34 | userProperty |
-| Test.java:17:27:17:60 | getProperty(...) [ : String] | Test.java:25:28:25:39 | userProperty |
-| Test.java:17:27:17:60 | getProperty(...) [ : String] | Test.java:27:44:27:55 | userProperty |
+| Test.java:17:27:17:60 | getProperty(...) : String | Test.java:19:19:19:30 | userProperty |
+| Test.java:17:27:17:60 | getProperty(...) : String | Test.java:21:23:21:34 | userProperty |
+| Test.java:17:27:17:60 | getProperty(...) : String | Test.java:23:23:23:34 | userProperty |
+| Test.java:17:27:17:60 | getProperty(...) : String | Test.java:25:28:25:39 | userProperty |
+| Test.java:17:27:17:60 | getProperty(...) : String | Test.java:27:44:27:55 | userProperty |
 nodes
-| Test.java:17:27:17:60 | getProperty(...) [ : String] | semmle.label | getProperty(...) [ : String] |
+| Test.java:17:27:17:60 | getProperty(...) : String | semmle.label | getProperty(...) : String |
 | Test.java:19:19:19:30 | userProperty | semmle.label | userProperty |
 | Test.java:21:23:21:34 | userProperty | semmle.label | userProperty |
 | Test.java:23:23:23:34 | userProperty | semmle.label | userProperty |
 | Test.java:25:28:25:39 | userProperty | semmle.label | userProperty |
 | Test.java:27:44:27:55 | userProperty | semmle.label | userProperty |
 #select
-| Test.java:19:19:19:30 | userProperty | Test.java:17:27:17:60 | getProperty(...) [ : String] | Test.java:19:19:19:30 | userProperty | $@ flows to here and is used in a format string. | Test.java:17:27:17:60 | getProperty(...) | User-provided value |
-| Test.java:21:23:21:34 | userProperty | Test.java:17:27:17:60 | getProperty(...) [ : String] | Test.java:21:23:21:34 | userProperty | $@ flows to here and is used in a format string. | Test.java:17:27:17:60 | getProperty(...) | User-provided value |
-| Test.java:23:23:23:34 | userProperty | Test.java:17:27:17:60 | getProperty(...) [ : String] | Test.java:23:23:23:34 | userProperty | $@ flows to here and is used in a format string. | Test.java:17:27:17:60 | getProperty(...) | User-provided value |
-| Test.java:25:28:25:39 | userProperty | Test.java:17:27:17:60 | getProperty(...) [ : String] | Test.java:25:28:25:39 | userProperty | $@ flows to here and is used in a format string. | Test.java:17:27:17:60 | getProperty(...) | User-provided value |
-| Test.java:27:44:27:55 | userProperty | Test.java:17:27:17:60 | getProperty(...) [ : String] | Test.java:27:44:27:55 | userProperty | $@ flows to here and is used in a format string. | Test.java:17:27:17:60 | getProperty(...) | User-provided value |
+| Test.java:19:19:19:30 | userProperty | Test.java:17:27:17:60 | getProperty(...) : String | Test.java:19:19:19:30 | userProperty | $@ flows to here and is used in a format string. | Test.java:17:27:17:60 | getProperty(...) | User-provided value |
+| Test.java:21:23:21:34 | userProperty | Test.java:17:27:17:60 | getProperty(...) : String | Test.java:21:23:21:34 | userProperty | $@ flows to here and is used in a format string. | Test.java:17:27:17:60 | getProperty(...) | User-provided value |
+| Test.java:23:23:23:34 | userProperty | Test.java:17:27:17:60 | getProperty(...) : String | Test.java:23:23:23:34 | userProperty | $@ flows to here and is used in a format string. | Test.java:17:27:17:60 | getProperty(...) | User-provided value |
+| Test.java:25:28:25:39 | userProperty | Test.java:17:27:17:60 | getProperty(...) : String | Test.java:25:28:25:39 | userProperty | $@ flows to here and is used in a format string. | Test.java:17:27:17:60 | getProperty(...) | User-provided value |
+| Test.java:27:44:27:55 | userProperty | Test.java:17:27:17:60 | getProperty(...) : String | Test.java:27:44:27:55 | userProperty | $@ flows to here and is used in a format string. | Test.java:17:27:17:60 | getProperty(...) | User-provided value |

--- a/java/ql/test/query-tests/security/CWE-190/semmle/tests/ArithmeticTaintedLocal.expected
+++ b/java/ql/test/query-tests/security/CWE-190/semmle/tests/ArithmeticTaintedLocal.expected
@@ -1,56 +1,56 @@
 edges
-| ArithmeticTainted.java:17:46:17:54 | System.in [ : InputStream] | ArithmeticTainted.java:32:17:32:20 | data |
-| ArithmeticTainted.java:17:46:17:54 | System.in [ : InputStream] | ArithmeticTainted.java:40:17:40:20 | data |
-| ArithmeticTainted.java:17:46:17:54 | System.in [ : InputStream] | ArithmeticTainted.java:50:17:50:20 | data |
-| ArithmeticTainted.java:17:46:17:54 | System.in [ : InputStream] | ArithmeticTainted.java:64:20:64:23 | data [ : Number] |
-| ArithmeticTainted.java:17:46:17:54 | System.in [ : InputStream] | ArithmeticTainted.java:95:37:95:40 | data |
-| ArithmeticTainted.java:17:46:17:54 | System.in [ : InputStream] | ArithmeticTainted.java:118:9:118:12 | data [ : Number] |
-| ArithmeticTainted.java:17:46:17:54 | System.in [ : InputStream] | ArithmeticTainted.java:119:10:119:13 | data [ : Number] |
-| ArithmeticTainted.java:17:46:17:54 | System.in [ : InputStream] | ArithmeticTainted.java:120:10:120:13 | data [ : Number] |
-| ArithmeticTainted.java:17:46:17:54 | System.in [ : InputStream] | ArithmeticTainted.java:121:10:121:13 | data [ : Number] |
-| ArithmeticTainted.java:64:4:64:10 | tainted [post update] [dat : Number] | ArithmeticTainted.java:66:18:66:24 | tainted [dat : Number] |
-| ArithmeticTainted.java:64:20:64:23 | data [ : Number] | ArithmeticTainted.java:64:4:64:10 | tainted [post update] [dat : Number] |
-| ArithmeticTainted.java:66:18:66:24 | tainted [dat : Number] | ArithmeticTainted.java:66:18:66:34 | getData(...) [ : Number] |
-| ArithmeticTainted.java:66:18:66:34 | getData(...) [ : Number] | ArithmeticTainted.java:71:17:71:23 | herring |
-| ArithmeticTainted.java:118:9:118:12 | data [ : Number] | ArithmeticTainted.java:125:26:125:33 | data [ : Number] |
-| ArithmeticTainted.java:119:10:119:13 | data [ : Number] | ArithmeticTainted.java:129:27:129:34 | data [ : Number] |
-| ArithmeticTainted.java:120:10:120:13 | data [ : Number] | ArithmeticTainted.java:133:27:133:34 | data [ : Number] |
-| ArithmeticTainted.java:121:10:121:13 | data [ : Number] | ArithmeticTainted.java:137:27:137:34 | data [ : Number] |
-| ArithmeticTainted.java:125:26:125:33 | data [ : Number] | ArithmeticTainted.java:127:3:127:6 | data |
-| ArithmeticTainted.java:129:27:129:34 | data [ : Number] | ArithmeticTainted.java:131:5:131:8 | data |
-| ArithmeticTainted.java:133:27:133:34 | data [ : Number] | ArithmeticTainted.java:135:3:135:6 | data |
-| ArithmeticTainted.java:137:27:137:34 | data [ : Number] | ArithmeticTainted.java:139:5:139:8 | data |
+| ArithmeticTainted.java:17:46:17:54 | System.in : InputStream | ArithmeticTainted.java:32:17:32:20 | data |
+| ArithmeticTainted.java:17:46:17:54 | System.in : InputStream | ArithmeticTainted.java:40:17:40:20 | data |
+| ArithmeticTainted.java:17:46:17:54 | System.in : InputStream | ArithmeticTainted.java:50:17:50:20 | data |
+| ArithmeticTainted.java:17:46:17:54 | System.in : InputStream | ArithmeticTainted.java:64:20:64:23 | data : Number |
+| ArithmeticTainted.java:17:46:17:54 | System.in : InputStream | ArithmeticTainted.java:95:37:95:40 | data |
+| ArithmeticTainted.java:17:46:17:54 | System.in : InputStream | ArithmeticTainted.java:118:9:118:12 | data : Number |
+| ArithmeticTainted.java:17:46:17:54 | System.in : InputStream | ArithmeticTainted.java:119:10:119:13 | data : Number |
+| ArithmeticTainted.java:17:46:17:54 | System.in : InputStream | ArithmeticTainted.java:120:10:120:13 | data : Number |
+| ArithmeticTainted.java:17:46:17:54 | System.in : InputStream | ArithmeticTainted.java:121:10:121:13 | data : Number |
+| ArithmeticTainted.java:64:4:64:10 | tainted [post update] [dat] : Number | ArithmeticTainted.java:66:18:66:24 | tainted [dat] : Number |
+| ArithmeticTainted.java:64:20:64:23 | data : Number | ArithmeticTainted.java:64:4:64:10 | tainted [post update] [dat] : Number |
+| ArithmeticTainted.java:66:18:66:24 | tainted [dat] : Number | ArithmeticTainted.java:66:18:66:34 | getData(...) : Number |
+| ArithmeticTainted.java:66:18:66:34 | getData(...) : Number | ArithmeticTainted.java:71:17:71:23 | herring |
+| ArithmeticTainted.java:118:9:118:12 | data : Number | ArithmeticTainted.java:125:26:125:33 | data : Number |
+| ArithmeticTainted.java:119:10:119:13 | data : Number | ArithmeticTainted.java:129:27:129:34 | data : Number |
+| ArithmeticTainted.java:120:10:120:13 | data : Number | ArithmeticTainted.java:133:27:133:34 | data : Number |
+| ArithmeticTainted.java:121:10:121:13 | data : Number | ArithmeticTainted.java:137:27:137:34 | data : Number |
+| ArithmeticTainted.java:125:26:125:33 | data : Number | ArithmeticTainted.java:127:3:127:6 | data |
+| ArithmeticTainted.java:129:27:129:34 | data : Number | ArithmeticTainted.java:131:5:131:8 | data |
+| ArithmeticTainted.java:133:27:133:34 | data : Number | ArithmeticTainted.java:135:3:135:6 | data |
+| ArithmeticTainted.java:137:27:137:34 | data : Number | ArithmeticTainted.java:139:5:139:8 | data |
 nodes
-| ArithmeticTainted.java:17:46:17:54 | System.in [ : InputStream] | semmle.label | System.in [ : InputStream] |
-| ArithmeticTainted.java:17:46:17:54 | System.in [ : InputStream] | semmle.label | System.in [ : InputStream] |
+| ArithmeticTainted.java:17:46:17:54 | System.in : InputStream | semmle.label | System.in : InputStream |
+| ArithmeticTainted.java:17:46:17:54 | System.in : InputStream | semmle.label | System.in : InputStream |
 | ArithmeticTainted.java:32:17:32:20 | data | semmle.label | data |
 | ArithmeticTainted.java:40:17:40:20 | data | semmle.label | data |
 | ArithmeticTainted.java:50:17:50:20 | data | semmle.label | data |
-| ArithmeticTainted.java:64:4:64:10 | tainted [post update] [dat : Number] | semmle.label | tainted [post update] [dat : Number] |
-| ArithmeticTainted.java:64:20:64:23 | data [ : Number] | semmle.label | data [ : Number] |
-| ArithmeticTainted.java:66:18:66:24 | tainted [dat : Number] | semmle.label | tainted [dat : Number] |
-| ArithmeticTainted.java:66:18:66:34 | getData(...) [ : Number] | semmle.label | getData(...) [ : Number] |
+| ArithmeticTainted.java:64:4:64:10 | tainted [post update] [dat] : Number | semmle.label | tainted [post update] [dat] : Number |
+| ArithmeticTainted.java:64:20:64:23 | data : Number | semmle.label | data : Number |
+| ArithmeticTainted.java:66:18:66:24 | tainted [dat] : Number | semmle.label | tainted [dat] : Number |
+| ArithmeticTainted.java:66:18:66:34 | getData(...) : Number | semmle.label | getData(...) : Number |
 | ArithmeticTainted.java:71:17:71:23 | herring | semmle.label | herring |
 | ArithmeticTainted.java:95:37:95:40 | data | semmle.label | data |
-| ArithmeticTainted.java:118:9:118:12 | data [ : Number] | semmle.label | data [ : Number] |
-| ArithmeticTainted.java:119:10:119:13 | data [ : Number] | semmle.label | data [ : Number] |
-| ArithmeticTainted.java:120:10:120:13 | data [ : Number] | semmle.label | data [ : Number] |
-| ArithmeticTainted.java:121:10:121:13 | data [ : Number] | semmle.label | data [ : Number] |
-| ArithmeticTainted.java:125:26:125:33 | data [ : Number] | semmle.label | data [ : Number] |
+| ArithmeticTainted.java:118:9:118:12 | data : Number | semmle.label | data : Number |
+| ArithmeticTainted.java:119:10:119:13 | data : Number | semmle.label | data : Number |
+| ArithmeticTainted.java:120:10:120:13 | data : Number | semmle.label | data : Number |
+| ArithmeticTainted.java:121:10:121:13 | data : Number | semmle.label | data : Number |
+| ArithmeticTainted.java:125:26:125:33 | data : Number | semmle.label | data : Number |
 | ArithmeticTainted.java:127:3:127:6 | data | semmle.label | data |
-| ArithmeticTainted.java:129:27:129:34 | data [ : Number] | semmle.label | data [ : Number] |
+| ArithmeticTainted.java:129:27:129:34 | data : Number | semmle.label | data : Number |
 | ArithmeticTainted.java:131:5:131:8 | data | semmle.label | data |
-| ArithmeticTainted.java:133:27:133:34 | data [ : Number] | semmle.label | data [ : Number] |
+| ArithmeticTainted.java:133:27:133:34 | data : Number | semmle.label | data : Number |
 | ArithmeticTainted.java:135:3:135:6 | data | semmle.label | data |
-| ArithmeticTainted.java:137:27:137:34 | data [ : Number] | semmle.label | data [ : Number] |
+| ArithmeticTainted.java:137:27:137:34 | data : Number | semmle.label | data : Number |
 | ArithmeticTainted.java:139:5:139:8 | data | semmle.label | data |
 #select
-| ArithmeticTainted.java:32:17:32:25 | ... + ... | ArithmeticTainted.java:17:46:17:54 | System.in [ : InputStream] | ArithmeticTainted.java:32:17:32:20 | data | $@ flows to here and is used in arithmetic, potentially causing an overflow. | ArithmeticTainted.java:17:46:17:54 | System.in | User-provided value |
-| ArithmeticTainted.java:40:17:40:25 | ... - ... | ArithmeticTainted.java:17:46:17:54 | System.in [ : InputStream] | ArithmeticTainted.java:40:17:40:20 | data | $@ flows to here and is used in arithmetic, potentially causing an underflow. | ArithmeticTainted.java:17:46:17:54 | System.in | User-provided value |
-| ArithmeticTainted.java:50:17:50:24 | ... + ... | ArithmeticTainted.java:17:46:17:54 | System.in [ : InputStream] | ArithmeticTainted.java:50:17:50:20 | data | $@ flows to here and is used in arithmetic, potentially causing an overflow. | ArithmeticTainted.java:17:46:17:54 | System.in | User-provided value |
-| ArithmeticTainted.java:71:17:71:27 | ... + ... | ArithmeticTainted.java:17:46:17:54 | System.in [ : InputStream] | ArithmeticTainted.java:71:17:71:23 | herring | $@ flows to here and is used in arithmetic, potentially causing an overflow. | ArithmeticTainted.java:17:46:17:54 | System.in | User-provided value |
-| ArithmeticTainted.java:95:37:95:46 | ... + ... | ArithmeticTainted.java:17:46:17:54 | System.in [ : InputStream] | ArithmeticTainted.java:95:37:95:40 | data | $@ flows to here and is used in arithmetic, potentially causing an overflow. | ArithmeticTainted.java:17:46:17:54 | System.in | User-provided value |
-| ArithmeticTainted.java:127:3:127:8 | ...++ | ArithmeticTainted.java:17:46:17:54 | System.in [ : InputStream] | ArithmeticTainted.java:127:3:127:6 | data | $@ flows to here and is used in arithmetic, potentially causing an overflow. | ArithmeticTainted.java:17:46:17:54 | System.in | User-provided value |
-| ArithmeticTainted.java:131:3:131:8 | ++... | ArithmeticTainted.java:17:46:17:54 | System.in [ : InputStream] | ArithmeticTainted.java:131:5:131:8 | data | $@ flows to here and is used in arithmetic, potentially causing an overflow. | ArithmeticTainted.java:17:46:17:54 | System.in | User-provided value |
-| ArithmeticTainted.java:135:3:135:8 | ...-- | ArithmeticTainted.java:17:46:17:54 | System.in [ : InputStream] | ArithmeticTainted.java:135:3:135:6 | data | $@ flows to here and is used in arithmetic, potentially causing an underflow. | ArithmeticTainted.java:17:46:17:54 | System.in | User-provided value |
-| ArithmeticTainted.java:139:3:139:8 | --... | ArithmeticTainted.java:17:46:17:54 | System.in [ : InputStream] | ArithmeticTainted.java:139:5:139:8 | data | $@ flows to here and is used in arithmetic, potentially causing an underflow. | ArithmeticTainted.java:17:46:17:54 | System.in | User-provided value |
+| ArithmeticTainted.java:32:17:32:25 | ... + ... | ArithmeticTainted.java:17:46:17:54 | System.in : InputStream | ArithmeticTainted.java:32:17:32:20 | data | $@ flows to here and is used in arithmetic, potentially causing an overflow. | ArithmeticTainted.java:17:46:17:54 | System.in | User-provided value |
+| ArithmeticTainted.java:40:17:40:25 | ... - ... | ArithmeticTainted.java:17:46:17:54 | System.in : InputStream | ArithmeticTainted.java:40:17:40:20 | data | $@ flows to here and is used in arithmetic, potentially causing an underflow. | ArithmeticTainted.java:17:46:17:54 | System.in | User-provided value |
+| ArithmeticTainted.java:50:17:50:24 | ... + ... | ArithmeticTainted.java:17:46:17:54 | System.in : InputStream | ArithmeticTainted.java:50:17:50:20 | data | $@ flows to here and is used in arithmetic, potentially causing an overflow. | ArithmeticTainted.java:17:46:17:54 | System.in | User-provided value |
+| ArithmeticTainted.java:71:17:71:27 | ... + ... | ArithmeticTainted.java:17:46:17:54 | System.in : InputStream | ArithmeticTainted.java:71:17:71:23 | herring | $@ flows to here and is used in arithmetic, potentially causing an overflow. | ArithmeticTainted.java:17:46:17:54 | System.in | User-provided value |
+| ArithmeticTainted.java:95:37:95:46 | ... + ... | ArithmeticTainted.java:17:46:17:54 | System.in : InputStream | ArithmeticTainted.java:95:37:95:40 | data | $@ flows to here and is used in arithmetic, potentially causing an overflow. | ArithmeticTainted.java:17:46:17:54 | System.in | User-provided value |
+| ArithmeticTainted.java:127:3:127:8 | ...++ | ArithmeticTainted.java:17:46:17:54 | System.in : InputStream | ArithmeticTainted.java:127:3:127:6 | data | $@ flows to here and is used in arithmetic, potentially causing an overflow. | ArithmeticTainted.java:17:46:17:54 | System.in | User-provided value |
+| ArithmeticTainted.java:131:3:131:8 | ++... | ArithmeticTainted.java:17:46:17:54 | System.in : InputStream | ArithmeticTainted.java:131:5:131:8 | data | $@ flows to here and is used in arithmetic, potentially causing an overflow. | ArithmeticTainted.java:17:46:17:54 | System.in | User-provided value |
+| ArithmeticTainted.java:135:3:135:8 | ...-- | ArithmeticTainted.java:17:46:17:54 | System.in : InputStream | ArithmeticTainted.java:135:3:135:6 | data | $@ flows to here and is used in arithmetic, potentially causing an underflow. | ArithmeticTainted.java:17:46:17:54 | System.in | User-provided value |
+| ArithmeticTainted.java:139:3:139:8 | --... | ArithmeticTainted.java:17:46:17:54 | System.in : InputStream | ArithmeticTainted.java:139:5:139:8 | data | $@ flows to here and is used in arithmetic, potentially causing an underflow. | ArithmeticTainted.java:17:46:17:54 | System.in | User-provided value |

--- a/java/ql/test/query-tests/security/CWE-190/semmle/tests/ArithmeticUncontrolled.expected
+++ b/java/ql/test/query-tests/security/CWE-190/semmle/tests/ArithmeticUncontrolled.expected
@@ -1,10 +1,10 @@
 edges
-| Test.java:205:14:205:57 | nextInt(...) [ : Number] | Test.java:209:17:209:20 | data |
-| Test.java:205:14:205:57 | nextInt(...) [ : Number] | Test.java:240:37:240:40 | data |
+| Test.java:205:14:205:57 | nextInt(...) : Number | Test.java:209:17:209:20 | data |
+| Test.java:205:14:205:57 | nextInt(...) : Number | Test.java:240:37:240:40 | data |
 nodes
-| Test.java:205:14:205:57 | nextInt(...) [ : Number] | semmle.label | nextInt(...) [ : Number] |
+| Test.java:205:14:205:57 | nextInt(...) : Number | semmle.label | nextInt(...) : Number |
 | Test.java:209:17:209:20 | data | semmle.label | data |
 | Test.java:240:37:240:40 | data | semmle.label | data |
 #select
-| Test.java:209:17:209:24 | ... + ... | Test.java:205:14:205:57 | nextInt(...) [ : Number] | Test.java:209:17:209:20 | data | $@ flows to here and is used in arithmetic, potentially causing an overflow. | Test.java:205:14:205:57 | nextInt(...) | Uncontrolled value |
-| Test.java:240:37:240:46 | ... + ... | Test.java:205:14:205:57 | nextInt(...) [ : Number] | Test.java:240:37:240:40 | data | $@ flows to here and is used in arithmetic, potentially causing an overflow. | Test.java:205:14:205:57 | nextInt(...) | Uncontrolled value |
+| Test.java:209:17:209:24 | ... + ... | Test.java:205:14:205:57 | nextInt(...) : Number | Test.java:209:17:209:20 | data | $@ flows to here and is used in arithmetic, potentially causing an overflow. | Test.java:205:14:205:57 | nextInt(...) | Uncontrolled value |
+| Test.java:240:37:240:46 | ... + ... | Test.java:205:14:205:57 | nextInt(...) : Number | Test.java:240:37:240:40 | data | $@ flows to here and is used in arithmetic, potentially causing an overflow. | Test.java:205:14:205:57 | nextInt(...) | Uncontrolled value |

--- a/java/ql/test/query-tests/security/CWE-190/semmle/tests/ArithmeticWithExtremeValues.expected
+++ b/java/ql/test/query-tests/security/CWE-190/semmle/tests/ArithmeticWithExtremeValues.expected
@@ -1,31 +1,31 @@
 edges
-| Test.java:92:8:92:24 | Integer.MAX_VALUE [ : Number] | Test.java:95:8:95:8 | i |
-| Test.java:108:13:108:26 | Long.MIN_VALUE [ : Number] | Test.java:110:13:110:13 | i |
-| Test.java:137:9:137:25 | Integer.MAX_VALUE [ : Number] | Test.java:138:14:138:14 | i |
-| Test.java:143:12:143:28 | Integer.MAX_VALUE [ : Number] | Test.java:146:14:146:14 | i |
-| Test.java:184:13:184:26 | Byte.MAX_VALUE [ : Number] | Test.java:187:39:187:39 | b |
-| Test.java:191:14:191:28 | Short.MAX_VALUE [ : Number] | Test.java:194:41:194:41 | s |
-| Test.java:198:12:198:28 | Integer.MAX_VALUE [ : Number] | Test.java:201:37:201:37 | i |
+| Test.java:92:8:92:24 | Integer.MAX_VALUE : Number | Test.java:95:8:95:8 | i |
+| Test.java:108:13:108:26 | Long.MIN_VALUE : Number | Test.java:110:13:110:13 | i |
+| Test.java:137:9:137:25 | Integer.MAX_VALUE : Number | Test.java:138:14:138:14 | i |
+| Test.java:143:12:143:28 | Integer.MAX_VALUE : Number | Test.java:146:14:146:14 | i |
+| Test.java:184:13:184:26 | Byte.MAX_VALUE : Number | Test.java:187:39:187:39 | b |
+| Test.java:191:14:191:28 | Short.MAX_VALUE : Number | Test.java:194:41:194:41 | s |
+| Test.java:198:12:198:28 | Integer.MAX_VALUE : Number | Test.java:201:37:201:37 | i |
 nodes
-| Test.java:92:8:92:24 | Integer.MAX_VALUE [ : Number] | semmle.label | Integer.MAX_VALUE [ : Number] |
+| Test.java:92:8:92:24 | Integer.MAX_VALUE : Number | semmle.label | Integer.MAX_VALUE : Number |
 | Test.java:95:8:95:8 | i | semmle.label | i |
-| Test.java:108:13:108:26 | Long.MIN_VALUE [ : Number] | semmle.label | Long.MIN_VALUE [ : Number] |
+| Test.java:108:13:108:26 | Long.MIN_VALUE : Number | semmle.label | Long.MIN_VALUE : Number |
 | Test.java:110:13:110:13 | i | semmle.label | i |
-| Test.java:137:9:137:25 | Integer.MAX_VALUE [ : Number] | semmle.label | Integer.MAX_VALUE [ : Number] |
+| Test.java:137:9:137:25 | Integer.MAX_VALUE : Number | semmle.label | Integer.MAX_VALUE : Number |
 | Test.java:138:14:138:14 | i | semmle.label | i |
-| Test.java:143:12:143:28 | Integer.MAX_VALUE [ : Number] | semmle.label | Integer.MAX_VALUE [ : Number] |
+| Test.java:143:12:143:28 | Integer.MAX_VALUE : Number | semmle.label | Integer.MAX_VALUE : Number |
 | Test.java:146:14:146:14 | i | semmle.label | i |
-| Test.java:184:13:184:26 | Byte.MAX_VALUE [ : Number] | semmle.label | Byte.MAX_VALUE [ : Number] |
+| Test.java:184:13:184:26 | Byte.MAX_VALUE : Number | semmle.label | Byte.MAX_VALUE : Number |
 | Test.java:187:39:187:39 | b | semmle.label | b |
-| Test.java:191:14:191:28 | Short.MAX_VALUE [ : Number] | semmle.label | Short.MAX_VALUE [ : Number] |
+| Test.java:191:14:191:28 | Short.MAX_VALUE : Number | semmle.label | Short.MAX_VALUE : Number |
 | Test.java:194:41:194:41 | s | semmle.label | s |
-| Test.java:198:12:198:28 | Integer.MAX_VALUE [ : Number] | semmle.label | Integer.MAX_VALUE [ : Number] |
+| Test.java:198:12:198:28 | Integer.MAX_VALUE : Number | semmle.label | Integer.MAX_VALUE : Number |
 | Test.java:201:37:201:37 | i | semmle.label | i |
 #select
-| Test.java:95:8:95:12 | ... + ... | Test.java:92:8:92:24 | Integer.MAX_VALUE [ : Number] | Test.java:95:8:95:8 | i | Variable i is assigned an extreme value $@, and may cause an overflow. | Test.java:92:8:92:24 | Integer.MAX_VALUE | MAX_VALUE |
-| Test.java:110:13:110:17 | ... - ... | Test.java:108:13:108:26 | Long.MIN_VALUE [ : Number] | Test.java:110:13:110:13 | i | Variable i is assigned an extreme value $@, and may cause an underflow. | Test.java:108:13:108:26 | Long.MIN_VALUE | MIN_VALUE |
-| Test.java:138:14:138:18 | ... + ... | Test.java:137:9:137:25 | Integer.MAX_VALUE [ : Number] | Test.java:138:14:138:14 | i | Variable i is assigned an extreme value $@, and may cause an overflow. | Test.java:137:9:137:25 | Integer.MAX_VALUE | MAX_VALUE |
-| Test.java:146:14:146:18 | ... + ... | Test.java:143:12:143:28 | Integer.MAX_VALUE [ : Number] | Test.java:146:14:146:14 | i | Variable i is assigned an extreme value $@, and may cause an overflow. | Test.java:143:12:143:28 | Integer.MAX_VALUE | MAX_VALUE |
-| Test.java:187:39:187:43 | ... + ... | Test.java:184:13:184:26 | Byte.MAX_VALUE [ : Number] | Test.java:187:39:187:39 | b | Variable b is assigned an extreme value $@, and may cause an overflow. | Test.java:184:13:184:26 | Byte.MAX_VALUE | MAX_VALUE |
-| Test.java:194:41:194:45 | ... + ... | Test.java:191:14:191:28 | Short.MAX_VALUE [ : Number] | Test.java:194:41:194:41 | s | Variable s is assigned an extreme value $@, and may cause an overflow. | Test.java:191:14:191:28 | Short.MAX_VALUE | MAX_VALUE |
-| Test.java:201:37:201:42 | ... + ... | Test.java:198:12:198:28 | Integer.MAX_VALUE [ : Number] | Test.java:201:37:201:37 | i | Variable i is assigned an extreme value $@, and may cause an overflow. | Test.java:198:12:198:28 | Integer.MAX_VALUE | MAX_VALUE |
+| Test.java:95:8:95:12 | ... + ... | Test.java:92:8:92:24 | Integer.MAX_VALUE : Number | Test.java:95:8:95:8 | i | Variable i is assigned an extreme value $@, and may cause an overflow. | Test.java:92:8:92:24 | Integer.MAX_VALUE | MAX_VALUE |
+| Test.java:110:13:110:17 | ... - ... | Test.java:108:13:108:26 | Long.MIN_VALUE : Number | Test.java:110:13:110:13 | i | Variable i is assigned an extreme value $@, and may cause an underflow. | Test.java:108:13:108:26 | Long.MIN_VALUE | MIN_VALUE |
+| Test.java:138:14:138:18 | ... + ... | Test.java:137:9:137:25 | Integer.MAX_VALUE : Number | Test.java:138:14:138:14 | i | Variable i is assigned an extreme value $@, and may cause an overflow. | Test.java:137:9:137:25 | Integer.MAX_VALUE | MAX_VALUE |
+| Test.java:146:14:146:18 | ... + ... | Test.java:143:12:143:28 | Integer.MAX_VALUE : Number | Test.java:146:14:146:14 | i | Variable i is assigned an extreme value $@, and may cause an overflow. | Test.java:143:12:143:28 | Integer.MAX_VALUE | MAX_VALUE |
+| Test.java:187:39:187:43 | ... + ... | Test.java:184:13:184:26 | Byte.MAX_VALUE : Number | Test.java:187:39:187:39 | b | Variable b is assigned an extreme value $@, and may cause an overflow. | Test.java:184:13:184:26 | Byte.MAX_VALUE | MAX_VALUE |
+| Test.java:194:41:194:45 | ... + ... | Test.java:191:14:191:28 | Short.MAX_VALUE : Number | Test.java:194:41:194:41 | s | Variable s is assigned an extreme value $@, and may cause an overflow. | Test.java:191:14:191:28 | Short.MAX_VALUE | MAX_VALUE |
+| Test.java:201:37:201:42 | ... + ... | Test.java:198:12:198:28 | Integer.MAX_VALUE : Number | Test.java:201:37:201:37 | i | Variable i is assigned an extreme value $@, and may cause an overflow. | Test.java:198:12:198:28 | Integer.MAX_VALUE | MAX_VALUE |

--- a/java/ql/test/query-tests/security/CWE-502/UnsafeDeserialization.expected
+++ b/java/ql/test/query-tests/security/CWE-502/UnsafeDeserialization.expected
@@ -1,65 +1,65 @@
 edges
-| A.java:13:31:13:51 | getInputStream(...) [ : InputStream] | A.java:15:12:15:13 | in |
-| A.java:19:31:19:51 | getInputStream(...) [ : InputStream] | A.java:21:12:21:13 | in |
-| A.java:25:31:25:51 | getInputStream(...) [ : InputStream] | A.java:27:12:27:12 | d |
-| A.java:32:31:32:51 | getInputStream(...) [ : InputStream] | A.java:34:23:34:28 | reader |
-| A.java:39:29:39:49 | getInputStream(...) [ : InputStream] | A.java:40:28:40:32 | input |
-| A.java:39:29:39:49 | getInputStream(...) [ : InputStream] | A.java:41:34:41:38 | input |
-| A.java:39:29:39:49 | getInputStream(...) [ : InputStream] | A.java:42:40:42:44 | input |
-| A.java:60:25:60:45 | getInputStream(...) [ : InputStream] | A.java:61:26:61:30 | input |
-| A.java:60:25:60:45 | getInputStream(...) [ : InputStream] | A.java:62:30:62:34 | input |
-| A.java:60:25:60:45 | getInputStream(...) [ : InputStream] | A.java:63:28:63:55 | new InputStreamReader(...) |
-| A.java:60:25:60:45 | getInputStream(...) [ : InputStream] | A.java:64:24:64:28 | input |
-| A.java:60:25:60:45 | getInputStream(...) [ : InputStream] | A.java:65:24:65:51 | new InputStreamReader(...) |
-| A.java:70:25:70:45 | getInputStream(...) [ : InputStream] | A.java:71:26:71:30 | input |
-| A.java:70:25:70:45 | getInputStream(...) [ : InputStream] | A.java:72:30:72:34 | input |
-| A.java:70:25:70:45 | getInputStream(...) [ : InputStream] | A.java:73:28:73:55 | new InputStreamReader(...) |
-| A.java:70:25:70:45 | getInputStream(...) [ : InputStream] | A.java:74:24:74:28 | input |
-| A.java:70:25:70:45 | getInputStream(...) [ : InputStream] | A.java:75:24:75:51 | new InputStreamReader(...) |
-| TestMessageBodyReader.java:20:55:20:78 | entityStream [ : InputStream] | TestMessageBodyReader.java:22:18:22:52 | new ObjectInputStream(...) |
+| A.java:13:31:13:51 | getInputStream(...) : InputStream | A.java:15:12:15:13 | in |
+| A.java:19:31:19:51 | getInputStream(...) : InputStream | A.java:21:12:21:13 | in |
+| A.java:25:31:25:51 | getInputStream(...) : InputStream | A.java:27:12:27:12 | d |
+| A.java:32:31:32:51 | getInputStream(...) : InputStream | A.java:34:23:34:28 | reader |
+| A.java:39:29:39:49 | getInputStream(...) : InputStream | A.java:40:28:40:32 | input |
+| A.java:39:29:39:49 | getInputStream(...) : InputStream | A.java:41:34:41:38 | input |
+| A.java:39:29:39:49 | getInputStream(...) : InputStream | A.java:42:40:42:44 | input |
+| A.java:60:25:60:45 | getInputStream(...) : InputStream | A.java:61:26:61:30 | input |
+| A.java:60:25:60:45 | getInputStream(...) : InputStream | A.java:62:30:62:34 | input |
+| A.java:60:25:60:45 | getInputStream(...) : InputStream | A.java:63:28:63:55 | new InputStreamReader(...) |
+| A.java:60:25:60:45 | getInputStream(...) : InputStream | A.java:64:24:64:28 | input |
+| A.java:60:25:60:45 | getInputStream(...) : InputStream | A.java:65:24:65:51 | new InputStreamReader(...) |
+| A.java:70:25:70:45 | getInputStream(...) : InputStream | A.java:71:26:71:30 | input |
+| A.java:70:25:70:45 | getInputStream(...) : InputStream | A.java:72:30:72:34 | input |
+| A.java:70:25:70:45 | getInputStream(...) : InputStream | A.java:73:28:73:55 | new InputStreamReader(...) |
+| A.java:70:25:70:45 | getInputStream(...) : InputStream | A.java:74:24:74:28 | input |
+| A.java:70:25:70:45 | getInputStream(...) : InputStream | A.java:75:24:75:51 | new InputStreamReader(...) |
+| TestMessageBodyReader.java:20:55:20:78 | entityStream : InputStream | TestMessageBodyReader.java:22:18:22:52 | new ObjectInputStream(...) |
 nodes
-| A.java:13:31:13:51 | getInputStream(...) [ : InputStream] | semmle.label | getInputStream(...) [ : InputStream] |
+| A.java:13:31:13:51 | getInputStream(...) : InputStream | semmle.label | getInputStream(...) : InputStream |
 | A.java:15:12:15:13 | in | semmle.label | in |
-| A.java:19:31:19:51 | getInputStream(...) [ : InputStream] | semmle.label | getInputStream(...) [ : InputStream] |
+| A.java:19:31:19:51 | getInputStream(...) : InputStream | semmle.label | getInputStream(...) : InputStream |
 | A.java:21:12:21:13 | in | semmle.label | in |
-| A.java:25:31:25:51 | getInputStream(...) [ : InputStream] | semmle.label | getInputStream(...) [ : InputStream] |
+| A.java:25:31:25:51 | getInputStream(...) : InputStream | semmle.label | getInputStream(...) : InputStream |
 | A.java:27:12:27:12 | d | semmle.label | d |
-| A.java:32:31:32:51 | getInputStream(...) [ : InputStream] | semmle.label | getInputStream(...) [ : InputStream] |
+| A.java:32:31:32:51 | getInputStream(...) : InputStream | semmle.label | getInputStream(...) : InputStream |
 | A.java:34:23:34:28 | reader | semmle.label | reader |
-| A.java:39:29:39:49 | getInputStream(...) [ : InputStream] | semmle.label | getInputStream(...) [ : InputStream] |
+| A.java:39:29:39:49 | getInputStream(...) : InputStream | semmle.label | getInputStream(...) : InputStream |
 | A.java:40:28:40:32 | input | semmle.label | input |
 | A.java:41:34:41:38 | input | semmle.label | input |
 | A.java:42:40:42:44 | input | semmle.label | input |
-| A.java:60:25:60:45 | getInputStream(...) [ : InputStream] | semmle.label | getInputStream(...) [ : InputStream] |
+| A.java:60:25:60:45 | getInputStream(...) : InputStream | semmle.label | getInputStream(...) : InputStream |
 | A.java:61:26:61:30 | input | semmle.label | input |
 | A.java:62:30:62:34 | input | semmle.label | input |
 | A.java:63:28:63:55 | new InputStreamReader(...) | semmle.label | new InputStreamReader(...) |
 | A.java:64:24:64:28 | input | semmle.label | input |
 | A.java:65:24:65:51 | new InputStreamReader(...) | semmle.label | new InputStreamReader(...) |
-| A.java:70:25:70:45 | getInputStream(...) [ : InputStream] | semmle.label | getInputStream(...) [ : InputStream] |
+| A.java:70:25:70:45 | getInputStream(...) : InputStream | semmle.label | getInputStream(...) : InputStream |
 | A.java:71:26:71:30 | input | semmle.label | input |
 | A.java:72:30:72:34 | input | semmle.label | input |
 | A.java:73:28:73:55 | new InputStreamReader(...) | semmle.label | new InputStreamReader(...) |
 | A.java:74:24:74:28 | input | semmle.label | input |
 | A.java:75:24:75:51 | new InputStreamReader(...) | semmle.label | new InputStreamReader(...) |
-| TestMessageBodyReader.java:20:55:20:78 | entityStream [ : InputStream] | semmle.label | entityStream [ : InputStream] |
+| TestMessageBodyReader.java:20:55:20:78 | entityStream : InputStream | semmle.label | entityStream : InputStream |
 | TestMessageBodyReader.java:22:18:22:52 | new ObjectInputStream(...) | semmle.label | new ObjectInputStream(...) |
 #select
-| A.java:15:12:15:26 | readObject(...) | A.java:13:31:13:51 | getInputStream(...) [ : InputStream] | A.java:15:12:15:13 | in | Unsafe deserialization of $@. | A.java:13:31:13:51 | getInputStream(...) | user input |
-| A.java:21:12:21:28 | readUnshared(...) | A.java:19:31:19:51 | getInputStream(...) [ : InputStream] | A.java:21:12:21:13 | in | Unsafe deserialization of $@. | A.java:19:31:19:51 | getInputStream(...) | user input |
-| A.java:27:12:27:25 | readObject(...) | A.java:25:31:25:51 | getInputStream(...) [ : InputStream] | A.java:27:12:27:12 | d | Unsafe deserialization of $@. | A.java:25:31:25:51 | getInputStream(...) | user input |
-| A.java:34:12:34:29 | fromXML(...) | A.java:32:31:32:51 | getInputStream(...) [ : InputStream] | A.java:34:23:34:28 | reader | Unsafe deserialization of $@. | A.java:32:31:32:51 | getInputStream(...) | user input |
-| A.java:40:12:40:42 | readObject(...) | A.java:39:29:39:49 | getInputStream(...) [ : InputStream] | A.java:40:28:40:32 | input | Unsafe deserialization of $@. | A.java:39:29:39:49 | getInputStream(...) | user input |
-| A.java:41:12:41:48 | readObjectOrNull(...) | A.java:39:29:39:49 | getInputStream(...) [ : InputStream] | A.java:41:34:41:38 | input | Unsafe deserialization of $@. | A.java:39:29:39:49 | getInputStream(...) | user input |
-| A.java:42:16:42:45 | readClassAndObject(...) | A.java:39:29:39:49 | getInputStream(...) [ : InputStream] | A.java:42:40:42:44 | input | Unsafe deserialization of $@. | A.java:39:29:39:49 | getInputStream(...) | user input |
-| A.java:61:16:61:31 | load(...) | A.java:60:25:60:45 | getInputStream(...) [ : InputStream] | A.java:61:26:61:30 | input | Unsafe deserialization of $@. | A.java:60:25:60:45 | getInputStream(...) | user input |
-| A.java:62:17:62:35 | loadAll(...) | A.java:60:25:60:45 | getInputStream(...) [ : InputStream] | A.java:62:30:62:34 | input | Unsafe deserialization of $@. | A.java:60:25:60:45 | getInputStream(...) | user input |
-| A.java:63:17:63:56 | parse(...) | A.java:60:25:60:45 | getInputStream(...) [ : InputStream] | A.java:63:28:63:55 | new InputStreamReader(...) | Unsafe deserialization of $@. | A.java:60:25:60:45 | getInputStream(...) | user input |
-| A.java:64:12:64:38 | loadAs(...) | A.java:60:25:60:45 | getInputStream(...) [ : InputStream] | A.java:64:24:64:28 | input | Unsafe deserialization of $@. | A.java:60:25:60:45 | getInputStream(...) | user input |
-| A.java:65:12:65:61 | loadAs(...) | A.java:60:25:60:45 | getInputStream(...) [ : InputStream] | A.java:65:24:65:51 | new InputStreamReader(...) | Unsafe deserialization of $@. | A.java:60:25:60:45 | getInputStream(...) | user input |
-| A.java:71:16:71:31 | load(...) | A.java:70:25:70:45 | getInputStream(...) [ : InputStream] | A.java:71:26:71:30 | input | Unsafe deserialization of $@. | A.java:70:25:70:45 | getInputStream(...) | user input |
-| A.java:72:17:72:35 | loadAll(...) | A.java:70:25:70:45 | getInputStream(...) [ : InputStream] | A.java:72:30:72:34 | input | Unsafe deserialization of $@. | A.java:70:25:70:45 | getInputStream(...) | user input |
-| A.java:73:17:73:56 | parse(...) | A.java:70:25:70:45 | getInputStream(...) [ : InputStream] | A.java:73:28:73:55 | new InputStreamReader(...) | Unsafe deserialization of $@. | A.java:70:25:70:45 | getInputStream(...) | user input |
-| A.java:74:12:74:38 | loadAs(...) | A.java:70:25:70:45 | getInputStream(...) [ : InputStream] | A.java:74:24:74:28 | input | Unsafe deserialization of $@. | A.java:70:25:70:45 | getInputStream(...) | user input |
-| A.java:75:12:75:61 | loadAs(...) | A.java:70:25:70:45 | getInputStream(...) [ : InputStream] | A.java:75:24:75:51 | new InputStreamReader(...) | Unsafe deserialization of $@. | A.java:70:25:70:45 | getInputStream(...) | user input |
-| TestMessageBodyReader.java:22:18:22:65 | readObject(...) | TestMessageBodyReader.java:20:55:20:78 | entityStream [ : InputStream] | TestMessageBodyReader.java:22:18:22:52 | new ObjectInputStream(...) | Unsafe deserialization of $@. | TestMessageBodyReader.java:20:55:20:78 | entityStream | user input |
+| A.java:15:12:15:26 | readObject(...) | A.java:13:31:13:51 | getInputStream(...) : InputStream | A.java:15:12:15:13 | in | Unsafe deserialization of $@. | A.java:13:31:13:51 | getInputStream(...) | user input |
+| A.java:21:12:21:28 | readUnshared(...) | A.java:19:31:19:51 | getInputStream(...) : InputStream | A.java:21:12:21:13 | in | Unsafe deserialization of $@. | A.java:19:31:19:51 | getInputStream(...) | user input |
+| A.java:27:12:27:25 | readObject(...) | A.java:25:31:25:51 | getInputStream(...) : InputStream | A.java:27:12:27:12 | d | Unsafe deserialization of $@. | A.java:25:31:25:51 | getInputStream(...) | user input |
+| A.java:34:12:34:29 | fromXML(...) | A.java:32:31:32:51 | getInputStream(...) : InputStream | A.java:34:23:34:28 | reader | Unsafe deserialization of $@. | A.java:32:31:32:51 | getInputStream(...) | user input |
+| A.java:40:12:40:42 | readObject(...) | A.java:39:29:39:49 | getInputStream(...) : InputStream | A.java:40:28:40:32 | input | Unsafe deserialization of $@. | A.java:39:29:39:49 | getInputStream(...) | user input |
+| A.java:41:12:41:48 | readObjectOrNull(...) | A.java:39:29:39:49 | getInputStream(...) : InputStream | A.java:41:34:41:38 | input | Unsafe deserialization of $@. | A.java:39:29:39:49 | getInputStream(...) | user input |
+| A.java:42:16:42:45 | readClassAndObject(...) | A.java:39:29:39:49 | getInputStream(...) : InputStream | A.java:42:40:42:44 | input | Unsafe deserialization of $@. | A.java:39:29:39:49 | getInputStream(...) | user input |
+| A.java:61:16:61:31 | load(...) | A.java:60:25:60:45 | getInputStream(...) : InputStream | A.java:61:26:61:30 | input | Unsafe deserialization of $@. | A.java:60:25:60:45 | getInputStream(...) | user input |
+| A.java:62:17:62:35 | loadAll(...) | A.java:60:25:60:45 | getInputStream(...) : InputStream | A.java:62:30:62:34 | input | Unsafe deserialization of $@. | A.java:60:25:60:45 | getInputStream(...) | user input |
+| A.java:63:17:63:56 | parse(...) | A.java:60:25:60:45 | getInputStream(...) : InputStream | A.java:63:28:63:55 | new InputStreamReader(...) | Unsafe deserialization of $@. | A.java:60:25:60:45 | getInputStream(...) | user input |
+| A.java:64:12:64:38 | loadAs(...) | A.java:60:25:60:45 | getInputStream(...) : InputStream | A.java:64:24:64:28 | input | Unsafe deserialization of $@. | A.java:60:25:60:45 | getInputStream(...) | user input |
+| A.java:65:12:65:61 | loadAs(...) | A.java:60:25:60:45 | getInputStream(...) : InputStream | A.java:65:24:65:51 | new InputStreamReader(...) | Unsafe deserialization of $@. | A.java:60:25:60:45 | getInputStream(...) | user input |
+| A.java:71:16:71:31 | load(...) | A.java:70:25:70:45 | getInputStream(...) : InputStream | A.java:71:26:71:30 | input | Unsafe deserialization of $@. | A.java:70:25:70:45 | getInputStream(...) | user input |
+| A.java:72:17:72:35 | loadAll(...) | A.java:70:25:70:45 | getInputStream(...) : InputStream | A.java:72:30:72:34 | input | Unsafe deserialization of $@. | A.java:70:25:70:45 | getInputStream(...) | user input |
+| A.java:73:17:73:56 | parse(...) | A.java:70:25:70:45 | getInputStream(...) : InputStream | A.java:73:28:73:55 | new InputStreamReader(...) | Unsafe deserialization of $@. | A.java:70:25:70:45 | getInputStream(...) | user input |
+| A.java:74:12:74:38 | loadAs(...) | A.java:70:25:70:45 | getInputStream(...) : InputStream | A.java:74:24:74:28 | input | Unsafe deserialization of $@. | A.java:70:25:70:45 | getInputStream(...) | user input |
+| A.java:75:12:75:61 | loadAs(...) | A.java:70:25:70:45 | getInputStream(...) : InputStream | A.java:75:24:75:51 | new InputStreamReader(...) | Unsafe deserialization of $@. | A.java:70:25:70:45 | getInputStream(...) | user input |
+| TestMessageBodyReader.java:22:18:22:65 | readObject(...) | TestMessageBodyReader.java:20:55:20:78 | entityStream : InputStream | TestMessageBodyReader.java:22:18:22:52 | new ObjectInputStream(...) | Unsafe deserialization of $@. | TestMessageBodyReader.java:20:55:20:78 | entityStream | user input |

--- a/java/ql/test/query-tests/security/CWE-601/semmle/tests/UrlRedirect.expected
+++ b/java/ql/test/query-tests/security/CWE-601/semmle/tests/UrlRedirect.expected
@@ -1,13 +1,13 @@
 edges
-| UrlRedirect.java:36:58:36:89 | getParameter(...) [ : String] | UrlRedirect.java:36:25:36:89 | ... + ... |
+| UrlRedirect.java:36:58:36:89 | getParameter(...) : String | UrlRedirect.java:36:25:36:89 | ... + ... |
 nodes
 | UrlRedirect.java:23:25:23:54 | getParameter(...) | semmle.label | getParameter(...) |
 | UrlRedirect.java:36:25:36:89 | ... + ... | semmle.label | ... + ... |
-| UrlRedirect.java:36:58:36:89 | getParameter(...) [ : String] | semmle.label | getParameter(...) [ : String] |
+| UrlRedirect.java:36:58:36:89 | getParameter(...) : String | semmle.label | getParameter(...) : String |
 | UrlRedirect.java:39:34:39:63 | getParameter(...) | semmle.label | getParameter(...) |
 | UrlRedirect.java:42:43:42:72 | getParameter(...) | semmle.label | getParameter(...) |
 #select
 | UrlRedirect.java:23:25:23:54 | getParameter(...) | UrlRedirect.java:23:25:23:54 | getParameter(...) | UrlRedirect.java:23:25:23:54 | getParameter(...) | Potentially untrusted URL redirection due to $@. | UrlRedirect.java:23:25:23:54 | getParameter(...) | user-provided value |
-| UrlRedirect.java:36:25:36:89 | ... + ... | UrlRedirect.java:36:58:36:89 | getParameter(...) [ : String] | UrlRedirect.java:36:25:36:89 | ... + ... | Potentially untrusted URL redirection due to $@. | UrlRedirect.java:36:58:36:89 | getParameter(...) | user-provided value |
+| UrlRedirect.java:36:25:36:89 | ... + ... | UrlRedirect.java:36:58:36:89 | getParameter(...) : String | UrlRedirect.java:36:25:36:89 | ... + ... | Potentially untrusted URL redirection due to $@. | UrlRedirect.java:36:58:36:89 | getParameter(...) | user-provided value |
 | UrlRedirect.java:39:34:39:63 | getParameter(...) | UrlRedirect.java:39:34:39:63 | getParameter(...) | UrlRedirect.java:39:34:39:63 | getParameter(...) | Potentially untrusted URL redirection due to $@. | UrlRedirect.java:39:34:39:63 | getParameter(...) | user-provided value |
 | UrlRedirect.java:42:43:42:72 | getParameter(...) | UrlRedirect.java:42:43:42:72 | getParameter(...) | UrlRedirect.java:42:43:42:72 | getParameter(...) | Potentially untrusted URL redirection due to $@. | UrlRedirect.java:42:43:42:72 | getParameter(...) | user-provided value |

--- a/java/ql/test/query-tests/security/CWE-611/XXE.expected
+++ b/java/ql/test/query-tests/security/CWE-611/XXE.expected
@@ -1,54 +1,54 @@
 edges
-| DocumentBuilderTests.java:93:51:93:71 | getInputStream(...) [ : InputStream] | DocumentBuilderTests.java:94:16:94:38 | getInputSource(...) |
-| DocumentBuilderTests.java:100:41:100:61 | getInputStream(...) [ : InputStream] | DocumentBuilderTests.java:101:16:101:52 | sourceToInputSource(...) |
-| DocumentBuilderTests.java:100:41:100:61 | getInputStream(...) [ : InputStream] | DocumentBuilderTests.java:102:16:102:38 | getInputStream(...) |
-| SchemaTests.java:12:56:12:76 | getInputStream(...) [ : InputStream] | SchemaTests.java:12:39:12:77 | new StreamSource(...) |
-| SchemaTests.java:25:56:25:76 | getInputStream(...) [ : InputStream] | SchemaTests.java:25:39:25:77 | new StreamSource(...) |
-| SchemaTests.java:31:56:31:76 | getInputStream(...) [ : InputStream] | SchemaTests.java:31:39:31:77 | new StreamSource(...) |
-| SchemaTests.java:38:56:38:76 | getInputStream(...) [ : InputStream] | SchemaTests.java:38:39:38:77 | new StreamSource(...) |
-| SchemaTests.java:45:56:45:76 | getInputStream(...) [ : InputStream] | SchemaTests.java:45:39:45:77 | new StreamSource(...) |
-| SimpleXMLTests.java:24:63:24:83 | getInputStream(...) [ : InputStream] | SimpleXMLTests.java:24:41:24:84 | new InputStreamReader(...) |
-| SimpleXMLTests.java:30:5:30:25 | getInputStream(...) [ : InputStream] | SimpleXMLTests.java:31:41:31:53 | new String(...) |
-| SimpleXMLTests.java:37:5:37:25 | getInputStream(...) [ : InputStream] | SimpleXMLTests.java:38:41:38:53 | new String(...) |
-| SimpleXMLTests.java:43:63:43:83 | getInputStream(...) [ : InputStream] | SimpleXMLTests.java:43:41:43:84 | new InputStreamReader(...) |
-| SimpleXMLTests.java:68:59:68:79 | getInputStream(...) [ : InputStream] | SimpleXMLTests.java:68:37:68:80 | new InputStreamReader(...) |
-| SimpleXMLTests.java:73:59:73:79 | getInputStream(...) [ : InputStream] | SimpleXMLTests.java:73:37:73:80 | new InputStreamReader(...) |
-| SimpleXMLTests.java:78:48:78:68 | getInputStream(...) [ : InputStream] | SimpleXMLTests.java:78:26:78:69 | new InputStreamReader(...) |
-| SimpleXMLTests.java:83:48:83:68 | getInputStream(...) [ : InputStream] | SimpleXMLTests.java:83:26:83:69 | new InputStreamReader(...) |
-| SimpleXMLTests.java:89:5:89:25 | getInputStream(...) [ : InputStream] | SimpleXMLTests.java:90:37:90:49 | new String(...) |
-| SimpleXMLTests.java:96:5:96:25 | getInputStream(...) [ : InputStream] | SimpleXMLTests.java:97:37:97:49 | new String(...) |
-| SimpleXMLTests.java:103:5:103:25 | getInputStream(...) [ : InputStream] | SimpleXMLTests.java:104:26:104:38 | new String(...) |
-| SimpleXMLTests.java:110:5:110:25 | getInputStream(...) [ : InputStream] | SimpleXMLTests.java:111:26:111:38 | new String(...) |
-| SimpleXMLTests.java:119:44:119:64 | getInputStream(...) [ : InputStream] | SimpleXMLTests.java:119:22:119:65 | new InputStreamReader(...) |
-| SimpleXMLTests.java:129:44:129:64 | getInputStream(...) [ : InputStream] | SimpleXMLTests.java:129:22:129:65 | new InputStreamReader(...) |
-| SimpleXMLTests.java:139:44:139:64 | getInputStream(...) [ : InputStream] | SimpleXMLTests.java:139:22:139:65 | new InputStreamReader(...) |
-| SimpleXMLTests.java:145:5:145:25 | getInputStream(...) [ : InputStream] | SimpleXMLTests.java:146:22:146:34 | new String(...) |
-| SimpleXMLTests.java:152:5:152:25 | getInputStream(...) [ : InputStream] | SimpleXMLTests.java:153:22:153:34 | new String(...) |
-| TransformerTests.java:20:44:20:64 | getInputStream(...) [ : InputStream] | TransformerTests.java:20:27:20:65 | new StreamSource(...) |
-| TransformerTests.java:21:40:21:60 | getInputStream(...) [ : InputStream] | TransformerTests.java:21:23:21:61 | new StreamSource(...) |
-| TransformerTests.java:71:44:71:64 | getInputStream(...) [ : InputStream] | TransformerTests.java:71:27:71:65 | new StreamSource(...) |
-| TransformerTests.java:72:40:72:60 | getInputStream(...) [ : InputStream] | TransformerTests.java:72:23:72:61 | new StreamSource(...) |
-| TransformerTests.java:79:44:79:64 | getInputStream(...) [ : InputStream] | TransformerTests.java:79:27:79:65 | new StreamSource(...) |
-| TransformerTests.java:80:40:80:60 | getInputStream(...) [ : InputStream] | TransformerTests.java:80:23:80:61 | new StreamSource(...) |
-| TransformerTests.java:88:44:88:64 | getInputStream(...) [ : InputStream] | TransformerTests.java:88:27:88:65 | new StreamSource(...) |
-| TransformerTests.java:89:40:89:60 | getInputStream(...) [ : InputStream] | TransformerTests.java:89:23:89:61 | new StreamSource(...) |
-| TransformerTests.java:97:44:97:64 | getInputStream(...) [ : InputStream] | TransformerTests.java:97:27:97:65 | new StreamSource(...) |
-| TransformerTests.java:98:40:98:60 | getInputStream(...) [ : InputStream] | TransformerTests.java:98:23:98:61 | new StreamSource(...) |
-| TransformerTests.java:103:38:103:58 | getInputStream(...) [ : InputStream] | TransformerTests.java:103:21:103:59 | new StreamSource(...) |
-| TransformerTests.java:116:38:116:58 | getInputStream(...) [ : InputStream] | TransformerTests.java:116:21:116:59 | new StreamSource(...) |
-| TransformerTests.java:122:38:122:58 | getInputStream(...) [ : InputStream] | TransformerTests.java:122:21:122:59 | new StreamSource(...) |
-| TransformerTests.java:129:38:129:58 | getInputStream(...) [ : InputStream] | TransformerTests.java:129:21:129:59 | new StreamSource(...) |
-| TransformerTests.java:136:38:136:58 | getInputStream(...) [ : InputStream] | TransformerTests.java:136:21:136:59 | new StreamSource(...) |
-| TransformerTests.java:141:48:141:68 | getInputStream(...) [ : InputStream] | TransformerTests.java:141:18:141:70 | new SAXSource(...) |
-| XMLReaderTests.java:16:34:16:54 | getInputStream(...) [ : InputStream] | XMLReaderTests.java:16:18:16:55 | new InputSource(...) |
-| XMLReaderTests.java:56:34:56:54 | getInputStream(...) [ : InputStream] | XMLReaderTests.java:56:18:56:55 | new InputSource(...) |
-| XMLReaderTests.java:63:34:63:54 | getInputStream(...) [ : InputStream] | XMLReaderTests.java:63:18:63:55 | new InputSource(...) |
-| XMLReaderTests.java:70:34:70:54 | getInputStream(...) [ : InputStream] | XMLReaderTests.java:70:18:70:55 | new InputSource(...) |
-| XMLReaderTests.java:78:34:78:54 | getInputStream(...) [ : InputStream] | XMLReaderTests.java:78:18:78:55 | new InputSource(...) |
-| XMLReaderTests.java:86:34:86:54 | getInputStream(...) [ : InputStream] | XMLReaderTests.java:86:18:86:55 | new InputSource(...) |
-| XMLReaderTests.java:94:34:94:54 | getInputStream(...) [ : InputStream] | XMLReaderTests.java:94:18:94:55 | new InputSource(...) |
-| XMLReaderTests.java:100:34:100:54 | getInputStream(...) [ : InputStream] | XMLReaderTests.java:100:18:100:55 | new InputSource(...) |
-| XPathExpressionTests.java:27:37:27:57 | getInputStream(...) [ : InputStream] | XPathExpressionTests.java:27:21:27:58 | new InputSource(...) |
+| DocumentBuilderTests.java:93:51:93:71 | getInputStream(...) : InputStream | DocumentBuilderTests.java:94:16:94:38 | getInputSource(...) |
+| DocumentBuilderTests.java:100:41:100:61 | getInputStream(...) : InputStream | DocumentBuilderTests.java:101:16:101:52 | sourceToInputSource(...) |
+| DocumentBuilderTests.java:100:41:100:61 | getInputStream(...) : InputStream | DocumentBuilderTests.java:102:16:102:38 | getInputStream(...) |
+| SchemaTests.java:12:56:12:76 | getInputStream(...) : InputStream | SchemaTests.java:12:39:12:77 | new StreamSource(...) |
+| SchemaTests.java:25:56:25:76 | getInputStream(...) : InputStream | SchemaTests.java:25:39:25:77 | new StreamSource(...) |
+| SchemaTests.java:31:56:31:76 | getInputStream(...) : InputStream | SchemaTests.java:31:39:31:77 | new StreamSource(...) |
+| SchemaTests.java:38:56:38:76 | getInputStream(...) : InputStream | SchemaTests.java:38:39:38:77 | new StreamSource(...) |
+| SchemaTests.java:45:56:45:76 | getInputStream(...) : InputStream | SchemaTests.java:45:39:45:77 | new StreamSource(...) |
+| SimpleXMLTests.java:24:63:24:83 | getInputStream(...) : InputStream | SimpleXMLTests.java:24:41:24:84 | new InputStreamReader(...) |
+| SimpleXMLTests.java:30:5:30:25 | getInputStream(...) : InputStream | SimpleXMLTests.java:31:41:31:53 | new String(...) |
+| SimpleXMLTests.java:37:5:37:25 | getInputStream(...) : InputStream | SimpleXMLTests.java:38:41:38:53 | new String(...) |
+| SimpleXMLTests.java:43:63:43:83 | getInputStream(...) : InputStream | SimpleXMLTests.java:43:41:43:84 | new InputStreamReader(...) |
+| SimpleXMLTests.java:68:59:68:79 | getInputStream(...) : InputStream | SimpleXMLTests.java:68:37:68:80 | new InputStreamReader(...) |
+| SimpleXMLTests.java:73:59:73:79 | getInputStream(...) : InputStream | SimpleXMLTests.java:73:37:73:80 | new InputStreamReader(...) |
+| SimpleXMLTests.java:78:48:78:68 | getInputStream(...) : InputStream | SimpleXMLTests.java:78:26:78:69 | new InputStreamReader(...) |
+| SimpleXMLTests.java:83:48:83:68 | getInputStream(...) : InputStream | SimpleXMLTests.java:83:26:83:69 | new InputStreamReader(...) |
+| SimpleXMLTests.java:89:5:89:25 | getInputStream(...) : InputStream | SimpleXMLTests.java:90:37:90:49 | new String(...) |
+| SimpleXMLTests.java:96:5:96:25 | getInputStream(...) : InputStream | SimpleXMLTests.java:97:37:97:49 | new String(...) |
+| SimpleXMLTests.java:103:5:103:25 | getInputStream(...) : InputStream | SimpleXMLTests.java:104:26:104:38 | new String(...) |
+| SimpleXMLTests.java:110:5:110:25 | getInputStream(...) : InputStream | SimpleXMLTests.java:111:26:111:38 | new String(...) |
+| SimpleXMLTests.java:119:44:119:64 | getInputStream(...) : InputStream | SimpleXMLTests.java:119:22:119:65 | new InputStreamReader(...) |
+| SimpleXMLTests.java:129:44:129:64 | getInputStream(...) : InputStream | SimpleXMLTests.java:129:22:129:65 | new InputStreamReader(...) |
+| SimpleXMLTests.java:139:44:139:64 | getInputStream(...) : InputStream | SimpleXMLTests.java:139:22:139:65 | new InputStreamReader(...) |
+| SimpleXMLTests.java:145:5:145:25 | getInputStream(...) : InputStream | SimpleXMLTests.java:146:22:146:34 | new String(...) |
+| SimpleXMLTests.java:152:5:152:25 | getInputStream(...) : InputStream | SimpleXMLTests.java:153:22:153:34 | new String(...) |
+| TransformerTests.java:20:44:20:64 | getInputStream(...) : InputStream | TransformerTests.java:20:27:20:65 | new StreamSource(...) |
+| TransformerTests.java:21:40:21:60 | getInputStream(...) : InputStream | TransformerTests.java:21:23:21:61 | new StreamSource(...) |
+| TransformerTests.java:71:44:71:64 | getInputStream(...) : InputStream | TransformerTests.java:71:27:71:65 | new StreamSource(...) |
+| TransformerTests.java:72:40:72:60 | getInputStream(...) : InputStream | TransformerTests.java:72:23:72:61 | new StreamSource(...) |
+| TransformerTests.java:79:44:79:64 | getInputStream(...) : InputStream | TransformerTests.java:79:27:79:65 | new StreamSource(...) |
+| TransformerTests.java:80:40:80:60 | getInputStream(...) : InputStream | TransformerTests.java:80:23:80:61 | new StreamSource(...) |
+| TransformerTests.java:88:44:88:64 | getInputStream(...) : InputStream | TransformerTests.java:88:27:88:65 | new StreamSource(...) |
+| TransformerTests.java:89:40:89:60 | getInputStream(...) : InputStream | TransformerTests.java:89:23:89:61 | new StreamSource(...) |
+| TransformerTests.java:97:44:97:64 | getInputStream(...) : InputStream | TransformerTests.java:97:27:97:65 | new StreamSource(...) |
+| TransformerTests.java:98:40:98:60 | getInputStream(...) : InputStream | TransformerTests.java:98:23:98:61 | new StreamSource(...) |
+| TransformerTests.java:103:38:103:58 | getInputStream(...) : InputStream | TransformerTests.java:103:21:103:59 | new StreamSource(...) |
+| TransformerTests.java:116:38:116:58 | getInputStream(...) : InputStream | TransformerTests.java:116:21:116:59 | new StreamSource(...) |
+| TransformerTests.java:122:38:122:58 | getInputStream(...) : InputStream | TransformerTests.java:122:21:122:59 | new StreamSource(...) |
+| TransformerTests.java:129:38:129:58 | getInputStream(...) : InputStream | TransformerTests.java:129:21:129:59 | new StreamSource(...) |
+| TransformerTests.java:136:38:136:58 | getInputStream(...) : InputStream | TransformerTests.java:136:21:136:59 | new StreamSource(...) |
+| TransformerTests.java:141:48:141:68 | getInputStream(...) : InputStream | TransformerTests.java:141:18:141:70 | new SAXSource(...) |
+| XMLReaderTests.java:16:34:16:54 | getInputStream(...) : InputStream | XMLReaderTests.java:16:18:16:55 | new InputSource(...) |
+| XMLReaderTests.java:56:34:56:54 | getInputStream(...) : InputStream | XMLReaderTests.java:56:18:56:55 | new InputSource(...) |
+| XMLReaderTests.java:63:34:63:54 | getInputStream(...) : InputStream | XMLReaderTests.java:63:18:63:55 | new InputSource(...) |
+| XMLReaderTests.java:70:34:70:54 | getInputStream(...) : InputStream | XMLReaderTests.java:70:18:70:55 | new InputSource(...) |
+| XMLReaderTests.java:78:34:78:54 | getInputStream(...) : InputStream | XMLReaderTests.java:78:18:78:55 | new InputSource(...) |
+| XMLReaderTests.java:86:34:86:54 | getInputStream(...) : InputStream | XMLReaderTests.java:86:18:86:55 | new InputSource(...) |
+| XMLReaderTests.java:94:34:94:54 | getInputStream(...) : InputStream | XMLReaderTests.java:94:18:94:55 | new InputSource(...) |
+| XMLReaderTests.java:100:34:100:54 | getInputStream(...) : InputStream | XMLReaderTests.java:100:18:100:55 | new InputSource(...) |
+| XPathExpressionTests.java:27:37:27:57 | getInputStream(...) : InputStream | XPathExpressionTests.java:27:21:27:58 | new InputSource(...) |
 nodes
 | DocumentBuilderTests.java:14:19:14:39 | getInputStream(...) | semmle.label | getInputStream(...) |
 | DocumentBuilderTests.java:42:19:42:39 | getInputStream(...) | semmle.label | getInputStream(...) |
@@ -57,9 +57,9 @@ nodes
 | DocumentBuilderTests.java:71:19:71:39 | getInputStream(...) | semmle.label | getInputStream(...) |
 | DocumentBuilderTests.java:79:19:79:39 | getInputStream(...) | semmle.label | getInputStream(...) |
 | DocumentBuilderTests.java:87:19:87:39 | getInputStream(...) | semmle.label | getInputStream(...) |
-| DocumentBuilderTests.java:93:51:93:71 | getInputStream(...) [ : InputStream] | semmle.label | getInputStream(...) [ : InputStream] |
+| DocumentBuilderTests.java:93:51:93:71 | getInputStream(...) : InputStream | semmle.label | getInputStream(...) : InputStream |
 | DocumentBuilderTests.java:94:16:94:38 | getInputSource(...) | semmle.label | getInputSource(...) |
-| DocumentBuilderTests.java:100:41:100:61 | getInputStream(...) [ : InputStream] | semmle.label | getInputStream(...) [ : InputStream] |
+| DocumentBuilderTests.java:100:41:100:61 | getInputStream(...) : InputStream | semmle.label | getInputStream(...) : InputStream |
 | DocumentBuilderTests.java:101:16:101:52 | sourceToInputSource(...) | semmle.label | sourceToInputSource(...) |
 | DocumentBuilderTests.java:102:16:102:38 | getInputStream(...) | semmle.label | getInputStream(...) |
 | SAXBuilderTests.java:8:19:8:39 | getInputStream(...) | semmle.label | getInputStream(...) |
@@ -79,108 +79,108 @@ nodes
 | SAXReaderTests.java:53:17:53:37 | getInputStream(...) | semmle.label | getInputStream(...) |
 | SAXReaderTests.java:61:17:61:37 | getInputStream(...) | semmle.label | getInputStream(...) |
 | SchemaTests.java:12:39:12:77 | new StreamSource(...) | semmle.label | new StreamSource(...) |
-| SchemaTests.java:12:56:12:76 | getInputStream(...) [ : InputStream] | semmle.label | getInputStream(...) [ : InputStream] |
+| SchemaTests.java:12:56:12:76 | getInputStream(...) : InputStream | semmle.label | getInputStream(...) : InputStream |
 | SchemaTests.java:25:39:25:77 | new StreamSource(...) | semmle.label | new StreamSource(...) |
-| SchemaTests.java:25:56:25:76 | getInputStream(...) [ : InputStream] | semmle.label | getInputStream(...) [ : InputStream] |
+| SchemaTests.java:25:56:25:76 | getInputStream(...) : InputStream | semmle.label | getInputStream(...) : InputStream |
 | SchemaTests.java:31:39:31:77 | new StreamSource(...) | semmle.label | new StreamSource(...) |
-| SchemaTests.java:31:56:31:76 | getInputStream(...) [ : InputStream] | semmle.label | getInputStream(...) [ : InputStream] |
+| SchemaTests.java:31:56:31:76 | getInputStream(...) : InputStream | semmle.label | getInputStream(...) : InputStream |
 | SchemaTests.java:38:39:38:77 | new StreamSource(...) | semmle.label | new StreamSource(...) |
-| SchemaTests.java:38:56:38:76 | getInputStream(...) [ : InputStream] | semmle.label | getInputStream(...) [ : InputStream] |
+| SchemaTests.java:38:56:38:76 | getInputStream(...) : InputStream | semmle.label | getInputStream(...) : InputStream |
 | SchemaTests.java:45:39:45:77 | new StreamSource(...) | semmle.label | new StreamSource(...) |
-| SchemaTests.java:45:56:45:76 | getInputStream(...) [ : InputStream] | semmle.label | getInputStream(...) [ : InputStream] |
+| SchemaTests.java:45:56:45:76 | getInputStream(...) : InputStream | semmle.label | getInputStream(...) : InputStream |
 | SimpleXMLTests.java:14:41:14:61 | getInputStream(...) | semmle.label | getInputStream(...) |
 | SimpleXMLTests.java:19:41:19:61 | getInputStream(...) | semmle.label | getInputStream(...) |
 | SimpleXMLTests.java:24:41:24:84 | new InputStreamReader(...) | semmle.label | new InputStreamReader(...) |
-| SimpleXMLTests.java:24:63:24:83 | getInputStream(...) [ : InputStream] | semmle.label | getInputStream(...) [ : InputStream] |
-| SimpleXMLTests.java:30:5:30:25 | getInputStream(...) [ : InputStream] | semmle.label | getInputStream(...) [ : InputStream] |
+| SimpleXMLTests.java:24:63:24:83 | getInputStream(...) : InputStream | semmle.label | getInputStream(...) : InputStream |
+| SimpleXMLTests.java:30:5:30:25 | getInputStream(...) : InputStream | semmle.label | getInputStream(...) : InputStream |
 | SimpleXMLTests.java:31:41:31:53 | new String(...) | semmle.label | new String(...) |
-| SimpleXMLTests.java:37:5:37:25 | getInputStream(...) [ : InputStream] | semmle.label | getInputStream(...) [ : InputStream] |
+| SimpleXMLTests.java:37:5:37:25 | getInputStream(...) : InputStream | semmle.label | getInputStream(...) : InputStream |
 | SimpleXMLTests.java:38:41:38:53 | new String(...) | semmle.label | new String(...) |
 | SimpleXMLTests.java:43:41:43:84 | new InputStreamReader(...) | semmle.label | new InputStreamReader(...) |
-| SimpleXMLTests.java:43:63:43:83 | getInputStream(...) [ : InputStream] | semmle.label | getInputStream(...) [ : InputStream] |
+| SimpleXMLTests.java:43:63:43:83 | getInputStream(...) : InputStream | semmle.label | getInputStream(...) : InputStream |
 | SimpleXMLTests.java:48:37:48:57 | getInputStream(...) | semmle.label | getInputStream(...) |
 | SimpleXMLTests.java:53:37:53:57 | getInputStream(...) | semmle.label | getInputStream(...) |
 | SimpleXMLTests.java:58:26:58:46 | getInputStream(...) | semmle.label | getInputStream(...) |
 | SimpleXMLTests.java:63:26:63:46 | getInputStream(...) | semmle.label | getInputStream(...) |
 | SimpleXMLTests.java:68:37:68:80 | new InputStreamReader(...) | semmle.label | new InputStreamReader(...) |
-| SimpleXMLTests.java:68:59:68:79 | getInputStream(...) [ : InputStream] | semmle.label | getInputStream(...) [ : InputStream] |
+| SimpleXMLTests.java:68:59:68:79 | getInputStream(...) : InputStream | semmle.label | getInputStream(...) : InputStream |
 | SimpleXMLTests.java:73:37:73:80 | new InputStreamReader(...) | semmle.label | new InputStreamReader(...) |
-| SimpleXMLTests.java:73:59:73:79 | getInputStream(...) [ : InputStream] | semmle.label | getInputStream(...) [ : InputStream] |
+| SimpleXMLTests.java:73:59:73:79 | getInputStream(...) : InputStream | semmle.label | getInputStream(...) : InputStream |
 | SimpleXMLTests.java:78:26:78:69 | new InputStreamReader(...) | semmle.label | new InputStreamReader(...) |
-| SimpleXMLTests.java:78:48:78:68 | getInputStream(...) [ : InputStream] | semmle.label | getInputStream(...) [ : InputStream] |
+| SimpleXMLTests.java:78:48:78:68 | getInputStream(...) : InputStream | semmle.label | getInputStream(...) : InputStream |
 | SimpleXMLTests.java:83:26:83:69 | new InputStreamReader(...) | semmle.label | new InputStreamReader(...) |
-| SimpleXMLTests.java:83:48:83:68 | getInputStream(...) [ : InputStream] | semmle.label | getInputStream(...) [ : InputStream] |
-| SimpleXMLTests.java:89:5:89:25 | getInputStream(...) [ : InputStream] | semmle.label | getInputStream(...) [ : InputStream] |
+| SimpleXMLTests.java:83:48:83:68 | getInputStream(...) : InputStream | semmle.label | getInputStream(...) : InputStream |
+| SimpleXMLTests.java:89:5:89:25 | getInputStream(...) : InputStream | semmle.label | getInputStream(...) : InputStream |
 | SimpleXMLTests.java:90:37:90:49 | new String(...) | semmle.label | new String(...) |
-| SimpleXMLTests.java:96:5:96:25 | getInputStream(...) [ : InputStream] | semmle.label | getInputStream(...) [ : InputStream] |
+| SimpleXMLTests.java:96:5:96:25 | getInputStream(...) : InputStream | semmle.label | getInputStream(...) : InputStream |
 | SimpleXMLTests.java:97:37:97:49 | new String(...) | semmle.label | new String(...) |
-| SimpleXMLTests.java:103:5:103:25 | getInputStream(...) [ : InputStream] | semmle.label | getInputStream(...) [ : InputStream] |
+| SimpleXMLTests.java:103:5:103:25 | getInputStream(...) : InputStream | semmle.label | getInputStream(...) : InputStream |
 | SimpleXMLTests.java:104:26:104:38 | new String(...) | semmle.label | new String(...) |
-| SimpleXMLTests.java:110:5:110:25 | getInputStream(...) [ : InputStream] | semmle.label | getInputStream(...) [ : InputStream] |
+| SimpleXMLTests.java:110:5:110:25 | getInputStream(...) : InputStream | semmle.label | getInputStream(...) : InputStream |
 | SimpleXMLTests.java:111:26:111:38 | new String(...) | semmle.label | new String(...) |
 | SimpleXMLTests.java:115:22:115:42 | getInputStream(...) | semmle.label | getInputStream(...) |
 | SimpleXMLTests.java:119:22:119:65 | new InputStreamReader(...) | semmle.label | new InputStreamReader(...) |
-| SimpleXMLTests.java:119:44:119:64 | getInputStream(...) [ : InputStream] | semmle.label | getInputStream(...) [ : InputStream] |
+| SimpleXMLTests.java:119:44:119:64 | getInputStream(...) : InputStream | semmle.label | getInputStream(...) : InputStream |
 | SimpleXMLTests.java:124:22:124:42 | getInputStream(...) | semmle.label | getInputStream(...) |
 | SimpleXMLTests.java:129:22:129:65 | new InputStreamReader(...) | semmle.label | new InputStreamReader(...) |
-| SimpleXMLTests.java:129:44:129:64 | getInputStream(...) [ : InputStream] | semmle.label | getInputStream(...) [ : InputStream] |
+| SimpleXMLTests.java:129:44:129:64 | getInputStream(...) : InputStream | semmle.label | getInputStream(...) : InputStream |
 | SimpleXMLTests.java:134:22:134:42 | getInputStream(...) | semmle.label | getInputStream(...) |
 | SimpleXMLTests.java:139:22:139:65 | new InputStreamReader(...) | semmle.label | new InputStreamReader(...) |
-| SimpleXMLTests.java:139:44:139:64 | getInputStream(...) [ : InputStream] | semmle.label | getInputStream(...) [ : InputStream] |
-| SimpleXMLTests.java:145:5:145:25 | getInputStream(...) [ : InputStream] | semmle.label | getInputStream(...) [ : InputStream] |
+| SimpleXMLTests.java:139:44:139:64 | getInputStream(...) : InputStream | semmle.label | getInputStream(...) : InputStream |
+| SimpleXMLTests.java:145:5:145:25 | getInputStream(...) : InputStream | semmle.label | getInputStream(...) : InputStream |
 | SimpleXMLTests.java:146:22:146:34 | new String(...) | semmle.label | new String(...) |
-| SimpleXMLTests.java:152:5:152:25 | getInputStream(...) [ : InputStream] | semmle.label | getInputStream(...) [ : InputStream] |
+| SimpleXMLTests.java:152:5:152:25 | getInputStream(...) : InputStream | semmle.label | getInputStream(...) : InputStream |
 | SimpleXMLTests.java:153:22:153:34 | new String(...) | semmle.label | new String(...) |
 | TransformerTests.java:20:27:20:65 | new StreamSource(...) | semmle.label | new StreamSource(...) |
-| TransformerTests.java:20:44:20:64 | getInputStream(...) [ : InputStream] | semmle.label | getInputStream(...) [ : InputStream] |
+| TransformerTests.java:20:44:20:64 | getInputStream(...) : InputStream | semmle.label | getInputStream(...) : InputStream |
 | TransformerTests.java:21:23:21:61 | new StreamSource(...) | semmle.label | new StreamSource(...) |
-| TransformerTests.java:21:40:21:60 | getInputStream(...) [ : InputStream] | semmle.label | getInputStream(...) [ : InputStream] |
+| TransformerTests.java:21:40:21:60 | getInputStream(...) : InputStream | semmle.label | getInputStream(...) : InputStream |
 | TransformerTests.java:71:27:71:65 | new StreamSource(...) | semmle.label | new StreamSource(...) |
-| TransformerTests.java:71:44:71:64 | getInputStream(...) [ : InputStream] | semmle.label | getInputStream(...) [ : InputStream] |
+| TransformerTests.java:71:44:71:64 | getInputStream(...) : InputStream | semmle.label | getInputStream(...) : InputStream |
 | TransformerTests.java:72:23:72:61 | new StreamSource(...) | semmle.label | new StreamSource(...) |
-| TransformerTests.java:72:40:72:60 | getInputStream(...) [ : InputStream] | semmle.label | getInputStream(...) [ : InputStream] |
+| TransformerTests.java:72:40:72:60 | getInputStream(...) : InputStream | semmle.label | getInputStream(...) : InputStream |
 | TransformerTests.java:79:27:79:65 | new StreamSource(...) | semmle.label | new StreamSource(...) |
-| TransformerTests.java:79:44:79:64 | getInputStream(...) [ : InputStream] | semmle.label | getInputStream(...) [ : InputStream] |
+| TransformerTests.java:79:44:79:64 | getInputStream(...) : InputStream | semmle.label | getInputStream(...) : InputStream |
 | TransformerTests.java:80:23:80:61 | new StreamSource(...) | semmle.label | new StreamSource(...) |
-| TransformerTests.java:80:40:80:60 | getInputStream(...) [ : InputStream] | semmle.label | getInputStream(...) [ : InputStream] |
+| TransformerTests.java:80:40:80:60 | getInputStream(...) : InputStream | semmle.label | getInputStream(...) : InputStream |
 | TransformerTests.java:88:27:88:65 | new StreamSource(...) | semmle.label | new StreamSource(...) |
-| TransformerTests.java:88:44:88:64 | getInputStream(...) [ : InputStream] | semmle.label | getInputStream(...) [ : InputStream] |
+| TransformerTests.java:88:44:88:64 | getInputStream(...) : InputStream | semmle.label | getInputStream(...) : InputStream |
 | TransformerTests.java:89:23:89:61 | new StreamSource(...) | semmle.label | new StreamSource(...) |
-| TransformerTests.java:89:40:89:60 | getInputStream(...) [ : InputStream] | semmle.label | getInputStream(...) [ : InputStream] |
+| TransformerTests.java:89:40:89:60 | getInputStream(...) : InputStream | semmle.label | getInputStream(...) : InputStream |
 | TransformerTests.java:97:27:97:65 | new StreamSource(...) | semmle.label | new StreamSource(...) |
-| TransformerTests.java:97:44:97:64 | getInputStream(...) [ : InputStream] | semmle.label | getInputStream(...) [ : InputStream] |
+| TransformerTests.java:97:44:97:64 | getInputStream(...) : InputStream | semmle.label | getInputStream(...) : InputStream |
 | TransformerTests.java:98:23:98:61 | new StreamSource(...) | semmle.label | new StreamSource(...) |
-| TransformerTests.java:98:40:98:60 | getInputStream(...) [ : InputStream] | semmle.label | getInputStream(...) [ : InputStream] |
+| TransformerTests.java:98:40:98:60 | getInputStream(...) : InputStream | semmle.label | getInputStream(...) : InputStream |
 | TransformerTests.java:103:21:103:59 | new StreamSource(...) | semmle.label | new StreamSource(...) |
-| TransformerTests.java:103:38:103:58 | getInputStream(...) [ : InputStream] | semmle.label | getInputStream(...) [ : InputStream] |
+| TransformerTests.java:103:38:103:58 | getInputStream(...) : InputStream | semmle.label | getInputStream(...) : InputStream |
 | TransformerTests.java:116:21:116:59 | new StreamSource(...) | semmle.label | new StreamSource(...) |
-| TransformerTests.java:116:38:116:58 | getInputStream(...) [ : InputStream] | semmle.label | getInputStream(...) [ : InputStream] |
+| TransformerTests.java:116:38:116:58 | getInputStream(...) : InputStream | semmle.label | getInputStream(...) : InputStream |
 | TransformerTests.java:122:21:122:59 | new StreamSource(...) | semmle.label | new StreamSource(...) |
-| TransformerTests.java:122:38:122:58 | getInputStream(...) [ : InputStream] | semmle.label | getInputStream(...) [ : InputStream] |
+| TransformerTests.java:122:38:122:58 | getInputStream(...) : InputStream | semmle.label | getInputStream(...) : InputStream |
 | TransformerTests.java:129:21:129:59 | new StreamSource(...) | semmle.label | new StreamSource(...) |
-| TransformerTests.java:129:38:129:58 | getInputStream(...) [ : InputStream] | semmle.label | getInputStream(...) [ : InputStream] |
+| TransformerTests.java:129:38:129:58 | getInputStream(...) : InputStream | semmle.label | getInputStream(...) : InputStream |
 | TransformerTests.java:136:21:136:59 | new StreamSource(...) | semmle.label | new StreamSource(...) |
-| TransformerTests.java:136:38:136:58 | getInputStream(...) [ : InputStream] | semmle.label | getInputStream(...) [ : InputStream] |
+| TransformerTests.java:136:38:136:58 | getInputStream(...) : InputStream | semmle.label | getInputStream(...) : InputStream |
 | TransformerTests.java:141:18:141:70 | new SAXSource(...) | semmle.label | new SAXSource(...) |
-| TransformerTests.java:141:48:141:68 | getInputStream(...) [ : InputStream] | semmle.label | getInputStream(...) [ : InputStream] |
+| TransformerTests.java:141:48:141:68 | getInputStream(...) : InputStream | semmle.label | getInputStream(...) : InputStream |
 | XMLReaderTests.java:16:18:16:55 | new InputSource(...) | semmle.label | new InputSource(...) |
-| XMLReaderTests.java:16:34:16:54 | getInputStream(...) [ : InputStream] | semmle.label | getInputStream(...) [ : InputStream] |
+| XMLReaderTests.java:16:34:16:54 | getInputStream(...) : InputStream | semmle.label | getInputStream(...) : InputStream |
 | XMLReaderTests.java:56:18:56:55 | new InputSource(...) | semmle.label | new InputSource(...) |
-| XMLReaderTests.java:56:34:56:54 | getInputStream(...) [ : InputStream] | semmle.label | getInputStream(...) [ : InputStream] |
+| XMLReaderTests.java:56:34:56:54 | getInputStream(...) : InputStream | semmle.label | getInputStream(...) : InputStream |
 | XMLReaderTests.java:63:18:63:55 | new InputSource(...) | semmle.label | new InputSource(...) |
-| XMLReaderTests.java:63:34:63:54 | getInputStream(...) [ : InputStream] | semmle.label | getInputStream(...) [ : InputStream] |
+| XMLReaderTests.java:63:34:63:54 | getInputStream(...) : InputStream | semmle.label | getInputStream(...) : InputStream |
 | XMLReaderTests.java:70:18:70:55 | new InputSource(...) | semmle.label | new InputSource(...) |
-| XMLReaderTests.java:70:34:70:54 | getInputStream(...) [ : InputStream] | semmle.label | getInputStream(...) [ : InputStream] |
+| XMLReaderTests.java:70:34:70:54 | getInputStream(...) : InputStream | semmle.label | getInputStream(...) : InputStream |
 | XMLReaderTests.java:78:18:78:55 | new InputSource(...) | semmle.label | new InputSource(...) |
-| XMLReaderTests.java:78:34:78:54 | getInputStream(...) [ : InputStream] | semmle.label | getInputStream(...) [ : InputStream] |
+| XMLReaderTests.java:78:34:78:54 | getInputStream(...) : InputStream | semmle.label | getInputStream(...) : InputStream |
 | XMLReaderTests.java:86:18:86:55 | new InputSource(...) | semmle.label | new InputSource(...) |
-| XMLReaderTests.java:86:34:86:54 | getInputStream(...) [ : InputStream] | semmle.label | getInputStream(...) [ : InputStream] |
+| XMLReaderTests.java:86:34:86:54 | getInputStream(...) : InputStream | semmle.label | getInputStream(...) : InputStream |
 | XMLReaderTests.java:94:18:94:55 | new InputSource(...) | semmle.label | new InputSource(...) |
-| XMLReaderTests.java:94:34:94:54 | getInputStream(...) [ : InputStream] | semmle.label | getInputStream(...) [ : InputStream] |
+| XMLReaderTests.java:94:34:94:54 | getInputStream(...) : InputStream | semmle.label | getInputStream(...) : InputStream |
 | XMLReaderTests.java:100:18:100:55 | new InputSource(...) | semmle.label | new InputSource(...) |
-| XMLReaderTests.java:100:34:100:54 | getInputStream(...) [ : InputStream] | semmle.label | getInputStream(...) [ : InputStream] |
+| XMLReaderTests.java:100:34:100:54 | getInputStream(...) : InputStream | semmle.label | getInputStream(...) : InputStream |
 | XPathExpressionTests.java:27:21:27:58 | new InputSource(...) | semmle.label | new InputSource(...) |
-| XPathExpressionTests.java:27:37:27:57 | getInputStream(...) [ : InputStream] | semmle.label | getInputStream(...) [ : InputStream] |
+| XPathExpressionTests.java:27:37:27:57 | getInputStream(...) : InputStream | semmle.label | getInputStream(...) : InputStream |
 | XmlInputFactoryTests.java:9:35:9:55 | getInputStream(...) | semmle.label | getInputStream(...) |
 | XmlInputFactoryTests.java:10:34:10:54 | getInputStream(...) | semmle.label | getInputStream(...) |
 | XmlInputFactoryTests.java:24:35:24:55 | getInputStream(...) | semmle.label | getInputStream(...) |
@@ -201,9 +201,9 @@ nodes
 | DocumentBuilderTests.java:71:19:71:39 | getInputStream(...) | DocumentBuilderTests.java:71:19:71:39 | getInputStream(...) | DocumentBuilderTests.java:71:19:71:39 | getInputStream(...) | Unsafe parsing of XML file from $@. | DocumentBuilderTests.java:71:19:71:39 | getInputStream(...) | user input |
 | DocumentBuilderTests.java:79:19:79:39 | getInputStream(...) | DocumentBuilderTests.java:79:19:79:39 | getInputStream(...) | DocumentBuilderTests.java:79:19:79:39 | getInputStream(...) | Unsafe parsing of XML file from $@. | DocumentBuilderTests.java:79:19:79:39 | getInputStream(...) | user input |
 | DocumentBuilderTests.java:87:19:87:39 | getInputStream(...) | DocumentBuilderTests.java:87:19:87:39 | getInputStream(...) | DocumentBuilderTests.java:87:19:87:39 | getInputStream(...) | Unsafe parsing of XML file from $@. | DocumentBuilderTests.java:87:19:87:39 | getInputStream(...) | user input |
-| DocumentBuilderTests.java:94:16:94:38 | getInputSource(...) | DocumentBuilderTests.java:93:51:93:71 | getInputStream(...) [ : InputStream] | DocumentBuilderTests.java:94:16:94:38 | getInputSource(...) | Unsafe parsing of XML file from $@. | DocumentBuilderTests.java:93:51:93:71 | getInputStream(...) | user input |
-| DocumentBuilderTests.java:101:16:101:52 | sourceToInputSource(...) | DocumentBuilderTests.java:100:41:100:61 | getInputStream(...) [ : InputStream] | DocumentBuilderTests.java:101:16:101:52 | sourceToInputSource(...) | Unsafe parsing of XML file from $@. | DocumentBuilderTests.java:100:41:100:61 | getInputStream(...) | user input |
-| DocumentBuilderTests.java:102:16:102:38 | getInputStream(...) | DocumentBuilderTests.java:100:41:100:61 | getInputStream(...) [ : InputStream] | DocumentBuilderTests.java:102:16:102:38 | getInputStream(...) | Unsafe parsing of XML file from $@. | DocumentBuilderTests.java:100:41:100:61 | getInputStream(...) | user input |
+| DocumentBuilderTests.java:94:16:94:38 | getInputSource(...) | DocumentBuilderTests.java:93:51:93:71 | getInputStream(...) : InputStream | DocumentBuilderTests.java:94:16:94:38 | getInputSource(...) | Unsafe parsing of XML file from $@. | DocumentBuilderTests.java:93:51:93:71 | getInputStream(...) | user input |
+| DocumentBuilderTests.java:101:16:101:52 | sourceToInputSource(...) | DocumentBuilderTests.java:100:41:100:61 | getInputStream(...) : InputStream | DocumentBuilderTests.java:101:16:101:52 | sourceToInputSource(...) | Unsafe parsing of XML file from $@. | DocumentBuilderTests.java:100:41:100:61 | getInputStream(...) | user input |
+| DocumentBuilderTests.java:102:16:102:38 | getInputStream(...) | DocumentBuilderTests.java:100:41:100:61 | getInputStream(...) : InputStream | DocumentBuilderTests.java:102:16:102:38 | getInputStream(...) | Unsafe parsing of XML file from $@. | DocumentBuilderTests.java:100:41:100:61 | getInputStream(...) | user input |
 | SAXBuilderTests.java:8:19:8:39 | getInputStream(...) | SAXBuilderTests.java:8:19:8:39 | getInputStream(...) | SAXBuilderTests.java:8:19:8:39 | getInputStream(...) | Unsafe parsing of XML file from $@. | SAXBuilderTests.java:8:19:8:39 | getInputStream(...) | user input |
 | SAXBuilderTests.java:20:19:20:39 | getInputStream(...) | SAXBuilderTests.java:20:19:20:39 | getInputStream(...) | SAXBuilderTests.java:20:19:20:39 | getInputStream(...) | Unsafe parsing of XML file from $@. | SAXBuilderTests.java:20:19:20:39 | getInputStream(...) | user input |
 | SAXParserTests.java:13:18:13:38 | getInputStream(...) | SAXParserTests.java:13:18:13:38 | getInputStream(...) | SAXParserTests.java:13:18:13:38 | getInputStream(...) | Unsafe parsing of XML file from $@. | SAXParserTests.java:13:18:13:38 | getInputStream(...) | user input |
@@ -220,62 +220,62 @@ nodes
 | SAXReaderTests.java:45:17:45:37 | getInputStream(...) | SAXReaderTests.java:45:17:45:37 | getInputStream(...) | SAXReaderTests.java:45:17:45:37 | getInputStream(...) | Unsafe parsing of XML file from $@. | SAXReaderTests.java:45:17:45:37 | getInputStream(...) | user input |
 | SAXReaderTests.java:53:17:53:37 | getInputStream(...) | SAXReaderTests.java:53:17:53:37 | getInputStream(...) | SAXReaderTests.java:53:17:53:37 | getInputStream(...) | Unsafe parsing of XML file from $@. | SAXReaderTests.java:53:17:53:37 | getInputStream(...) | user input |
 | SAXReaderTests.java:61:17:61:37 | getInputStream(...) | SAXReaderTests.java:61:17:61:37 | getInputStream(...) | SAXReaderTests.java:61:17:61:37 | getInputStream(...) | Unsafe parsing of XML file from $@. | SAXReaderTests.java:61:17:61:37 | getInputStream(...) | user input |
-| SchemaTests.java:12:39:12:77 | new StreamSource(...) | SchemaTests.java:12:56:12:76 | getInputStream(...) [ : InputStream] | SchemaTests.java:12:39:12:77 | new StreamSource(...) | Unsafe parsing of XML file from $@. | SchemaTests.java:12:56:12:76 | getInputStream(...) | user input |
-| SchemaTests.java:25:39:25:77 | new StreamSource(...) | SchemaTests.java:25:56:25:76 | getInputStream(...) [ : InputStream] | SchemaTests.java:25:39:25:77 | new StreamSource(...) | Unsafe parsing of XML file from $@. | SchemaTests.java:25:56:25:76 | getInputStream(...) | user input |
-| SchemaTests.java:31:39:31:77 | new StreamSource(...) | SchemaTests.java:31:56:31:76 | getInputStream(...) [ : InputStream] | SchemaTests.java:31:39:31:77 | new StreamSource(...) | Unsafe parsing of XML file from $@. | SchemaTests.java:31:56:31:76 | getInputStream(...) | user input |
-| SchemaTests.java:38:39:38:77 | new StreamSource(...) | SchemaTests.java:38:56:38:76 | getInputStream(...) [ : InputStream] | SchemaTests.java:38:39:38:77 | new StreamSource(...) | Unsafe parsing of XML file from $@. | SchemaTests.java:38:56:38:76 | getInputStream(...) | user input |
-| SchemaTests.java:45:39:45:77 | new StreamSource(...) | SchemaTests.java:45:56:45:76 | getInputStream(...) [ : InputStream] | SchemaTests.java:45:39:45:77 | new StreamSource(...) | Unsafe parsing of XML file from $@. | SchemaTests.java:45:56:45:76 | getInputStream(...) | user input |
+| SchemaTests.java:12:39:12:77 | new StreamSource(...) | SchemaTests.java:12:56:12:76 | getInputStream(...) : InputStream | SchemaTests.java:12:39:12:77 | new StreamSource(...) | Unsafe parsing of XML file from $@. | SchemaTests.java:12:56:12:76 | getInputStream(...) | user input |
+| SchemaTests.java:25:39:25:77 | new StreamSource(...) | SchemaTests.java:25:56:25:76 | getInputStream(...) : InputStream | SchemaTests.java:25:39:25:77 | new StreamSource(...) | Unsafe parsing of XML file from $@. | SchemaTests.java:25:56:25:76 | getInputStream(...) | user input |
+| SchemaTests.java:31:39:31:77 | new StreamSource(...) | SchemaTests.java:31:56:31:76 | getInputStream(...) : InputStream | SchemaTests.java:31:39:31:77 | new StreamSource(...) | Unsafe parsing of XML file from $@. | SchemaTests.java:31:56:31:76 | getInputStream(...) | user input |
+| SchemaTests.java:38:39:38:77 | new StreamSource(...) | SchemaTests.java:38:56:38:76 | getInputStream(...) : InputStream | SchemaTests.java:38:39:38:77 | new StreamSource(...) | Unsafe parsing of XML file from $@. | SchemaTests.java:38:56:38:76 | getInputStream(...) | user input |
+| SchemaTests.java:45:39:45:77 | new StreamSource(...) | SchemaTests.java:45:56:45:76 | getInputStream(...) : InputStream | SchemaTests.java:45:39:45:77 | new StreamSource(...) | Unsafe parsing of XML file from $@. | SchemaTests.java:45:56:45:76 | getInputStream(...) | user input |
 | SimpleXMLTests.java:14:41:14:61 | getInputStream(...) | SimpleXMLTests.java:14:41:14:61 | getInputStream(...) | SimpleXMLTests.java:14:41:14:61 | getInputStream(...) | Unsafe parsing of XML file from $@. | SimpleXMLTests.java:14:41:14:61 | getInputStream(...) | user input |
 | SimpleXMLTests.java:19:41:19:61 | getInputStream(...) | SimpleXMLTests.java:19:41:19:61 | getInputStream(...) | SimpleXMLTests.java:19:41:19:61 | getInputStream(...) | Unsafe parsing of XML file from $@. | SimpleXMLTests.java:19:41:19:61 | getInputStream(...) | user input |
-| SimpleXMLTests.java:24:41:24:84 | new InputStreamReader(...) | SimpleXMLTests.java:24:63:24:83 | getInputStream(...) [ : InputStream] | SimpleXMLTests.java:24:41:24:84 | new InputStreamReader(...) | Unsafe parsing of XML file from $@. | SimpleXMLTests.java:24:63:24:83 | getInputStream(...) | user input |
-| SimpleXMLTests.java:31:41:31:53 | new String(...) | SimpleXMLTests.java:30:5:30:25 | getInputStream(...) [ : InputStream] | SimpleXMLTests.java:31:41:31:53 | new String(...) | Unsafe parsing of XML file from $@. | SimpleXMLTests.java:30:5:30:25 | getInputStream(...) | user input |
-| SimpleXMLTests.java:38:41:38:53 | new String(...) | SimpleXMLTests.java:37:5:37:25 | getInputStream(...) [ : InputStream] | SimpleXMLTests.java:38:41:38:53 | new String(...) | Unsafe parsing of XML file from $@. | SimpleXMLTests.java:37:5:37:25 | getInputStream(...) | user input |
-| SimpleXMLTests.java:43:41:43:84 | new InputStreamReader(...) | SimpleXMLTests.java:43:63:43:83 | getInputStream(...) [ : InputStream] | SimpleXMLTests.java:43:41:43:84 | new InputStreamReader(...) | Unsafe parsing of XML file from $@. | SimpleXMLTests.java:43:63:43:83 | getInputStream(...) | user input |
+| SimpleXMLTests.java:24:41:24:84 | new InputStreamReader(...) | SimpleXMLTests.java:24:63:24:83 | getInputStream(...) : InputStream | SimpleXMLTests.java:24:41:24:84 | new InputStreamReader(...) | Unsafe parsing of XML file from $@. | SimpleXMLTests.java:24:63:24:83 | getInputStream(...) | user input |
+| SimpleXMLTests.java:31:41:31:53 | new String(...) | SimpleXMLTests.java:30:5:30:25 | getInputStream(...) : InputStream | SimpleXMLTests.java:31:41:31:53 | new String(...) | Unsafe parsing of XML file from $@. | SimpleXMLTests.java:30:5:30:25 | getInputStream(...) | user input |
+| SimpleXMLTests.java:38:41:38:53 | new String(...) | SimpleXMLTests.java:37:5:37:25 | getInputStream(...) : InputStream | SimpleXMLTests.java:38:41:38:53 | new String(...) | Unsafe parsing of XML file from $@. | SimpleXMLTests.java:37:5:37:25 | getInputStream(...) | user input |
+| SimpleXMLTests.java:43:41:43:84 | new InputStreamReader(...) | SimpleXMLTests.java:43:63:43:83 | getInputStream(...) : InputStream | SimpleXMLTests.java:43:41:43:84 | new InputStreamReader(...) | Unsafe parsing of XML file from $@. | SimpleXMLTests.java:43:63:43:83 | getInputStream(...) | user input |
 | SimpleXMLTests.java:48:37:48:57 | getInputStream(...) | SimpleXMLTests.java:48:37:48:57 | getInputStream(...) | SimpleXMLTests.java:48:37:48:57 | getInputStream(...) | Unsafe parsing of XML file from $@. | SimpleXMLTests.java:48:37:48:57 | getInputStream(...) | user input |
 | SimpleXMLTests.java:53:37:53:57 | getInputStream(...) | SimpleXMLTests.java:53:37:53:57 | getInputStream(...) | SimpleXMLTests.java:53:37:53:57 | getInputStream(...) | Unsafe parsing of XML file from $@. | SimpleXMLTests.java:53:37:53:57 | getInputStream(...) | user input |
 | SimpleXMLTests.java:58:26:58:46 | getInputStream(...) | SimpleXMLTests.java:58:26:58:46 | getInputStream(...) | SimpleXMLTests.java:58:26:58:46 | getInputStream(...) | Unsafe parsing of XML file from $@. | SimpleXMLTests.java:58:26:58:46 | getInputStream(...) | user input |
 | SimpleXMLTests.java:63:26:63:46 | getInputStream(...) | SimpleXMLTests.java:63:26:63:46 | getInputStream(...) | SimpleXMLTests.java:63:26:63:46 | getInputStream(...) | Unsafe parsing of XML file from $@. | SimpleXMLTests.java:63:26:63:46 | getInputStream(...) | user input |
-| SimpleXMLTests.java:68:37:68:80 | new InputStreamReader(...) | SimpleXMLTests.java:68:59:68:79 | getInputStream(...) [ : InputStream] | SimpleXMLTests.java:68:37:68:80 | new InputStreamReader(...) | Unsafe parsing of XML file from $@. | SimpleXMLTests.java:68:59:68:79 | getInputStream(...) | user input |
-| SimpleXMLTests.java:73:37:73:80 | new InputStreamReader(...) | SimpleXMLTests.java:73:59:73:79 | getInputStream(...) [ : InputStream] | SimpleXMLTests.java:73:37:73:80 | new InputStreamReader(...) | Unsafe parsing of XML file from $@. | SimpleXMLTests.java:73:59:73:79 | getInputStream(...) | user input |
-| SimpleXMLTests.java:78:26:78:69 | new InputStreamReader(...) | SimpleXMLTests.java:78:48:78:68 | getInputStream(...) [ : InputStream] | SimpleXMLTests.java:78:26:78:69 | new InputStreamReader(...) | Unsafe parsing of XML file from $@. | SimpleXMLTests.java:78:48:78:68 | getInputStream(...) | user input |
-| SimpleXMLTests.java:83:26:83:69 | new InputStreamReader(...) | SimpleXMLTests.java:83:48:83:68 | getInputStream(...) [ : InputStream] | SimpleXMLTests.java:83:26:83:69 | new InputStreamReader(...) | Unsafe parsing of XML file from $@. | SimpleXMLTests.java:83:48:83:68 | getInputStream(...) | user input |
-| SimpleXMLTests.java:90:37:90:49 | new String(...) | SimpleXMLTests.java:89:5:89:25 | getInputStream(...) [ : InputStream] | SimpleXMLTests.java:90:37:90:49 | new String(...) | Unsafe parsing of XML file from $@. | SimpleXMLTests.java:89:5:89:25 | getInputStream(...) | user input |
-| SimpleXMLTests.java:97:37:97:49 | new String(...) | SimpleXMLTests.java:96:5:96:25 | getInputStream(...) [ : InputStream] | SimpleXMLTests.java:97:37:97:49 | new String(...) | Unsafe parsing of XML file from $@. | SimpleXMLTests.java:96:5:96:25 | getInputStream(...) | user input |
-| SimpleXMLTests.java:104:26:104:38 | new String(...) | SimpleXMLTests.java:103:5:103:25 | getInputStream(...) [ : InputStream] | SimpleXMLTests.java:104:26:104:38 | new String(...) | Unsafe parsing of XML file from $@. | SimpleXMLTests.java:103:5:103:25 | getInputStream(...) | user input |
-| SimpleXMLTests.java:111:26:111:38 | new String(...) | SimpleXMLTests.java:110:5:110:25 | getInputStream(...) [ : InputStream] | SimpleXMLTests.java:111:26:111:38 | new String(...) | Unsafe parsing of XML file from $@. | SimpleXMLTests.java:110:5:110:25 | getInputStream(...) | user input |
+| SimpleXMLTests.java:68:37:68:80 | new InputStreamReader(...) | SimpleXMLTests.java:68:59:68:79 | getInputStream(...) : InputStream | SimpleXMLTests.java:68:37:68:80 | new InputStreamReader(...) | Unsafe parsing of XML file from $@. | SimpleXMLTests.java:68:59:68:79 | getInputStream(...) | user input |
+| SimpleXMLTests.java:73:37:73:80 | new InputStreamReader(...) | SimpleXMLTests.java:73:59:73:79 | getInputStream(...) : InputStream | SimpleXMLTests.java:73:37:73:80 | new InputStreamReader(...) | Unsafe parsing of XML file from $@. | SimpleXMLTests.java:73:59:73:79 | getInputStream(...) | user input |
+| SimpleXMLTests.java:78:26:78:69 | new InputStreamReader(...) | SimpleXMLTests.java:78:48:78:68 | getInputStream(...) : InputStream | SimpleXMLTests.java:78:26:78:69 | new InputStreamReader(...) | Unsafe parsing of XML file from $@. | SimpleXMLTests.java:78:48:78:68 | getInputStream(...) | user input |
+| SimpleXMLTests.java:83:26:83:69 | new InputStreamReader(...) | SimpleXMLTests.java:83:48:83:68 | getInputStream(...) : InputStream | SimpleXMLTests.java:83:26:83:69 | new InputStreamReader(...) | Unsafe parsing of XML file from $@. | SimpleXMLTests.java:83:48:83:68 | getInputStream(...) | user input |
+| SimpleXMLTests.java:90:37:90:49 | new String(...) | SimpleXMLTests.java:89:5:89:25 | getInputStream(...) : InputStream | SimpleXMLTests.java:90:37:90:49 | new String(...) | Unsafe parsing of XML file from $@. | SimpleXMLTests.java:89:5:89:25 | getInputStream(...) | user input |
+| SimpleXMLTests.java:97:37:97:49 | new String(...) | SimpleXMLTests.java:96:5:96:25 | getInputStream(...) : InputStream | SimpleXMLTests.java:97:37:97:49 | new String(...) | Unsafe parsing of XML file from $@. | SimpleXMLTests.java:96:5:96:25 | getInputStream(...) | user input |
+| SimpleXMLTests.java:104:26:104:38 | new String(...) | SimpleXMLTests.java:103:5:103:25 | getInputStream(...) : InputStream | SimpleXMLTests.java:104:26:104:38 | new String(...) | Unsafe parsing of XML file from $@. | SimpleXMLTests.java:103:5:103:25 | getInputStream(...) | user input |
+| SimpleXMLTests.java:111:26:111:38 | new String(...) | SimpleXMLTests.java:110:5:110:25 | getInputStream(...) : InputStream | SimpleXMLTests.java:111:26:111:38 | new String(...) | Unsafe parsing of XML file from $@. | SimpleXMLTests.java:110:5:110:25 | getInputStream(...) | user input |
 | SimpleXMLTests.java:115:22:115:42 | getInputStream(...) | SimpleXMLTests.java:115:22:115:42 | getInputStream(...) | SimpleXMLTests.java:115:22:115:42 | getInputStream(...) | Unsafe parsing of XML file from $@. | SimpleXMLTests.java:115:22:115:42 | getInputStream(...) | user input |
-| SimpleXMLTests.java:119:22:119:65 | new InputStreamReader(...) | SimpleXMLTests.java:119:44:119:64 | getInputStream(...) [ : InputStream] | SimpleXMLTests.java:119:22:119:65 | new InputStreamReader(...) | Unsafe parsing of XML file from $@. | SimpleXMLTests.java:119:44:119:64 | getInputStream(...) | user input |
+| SimpleXMLTests.java:119:22:119:65 | new InputStreamReader(...) | SimpleXMLTests.java:119:44:119:64 | getInputStream(...) : InputStream | SimpleXMLTests.java:119:22:119:65 | new InputStreamReader(...) | Unsafe parsing of XML file from $@. | SimpleXMLTests.java:119:44:119:64 | getInputStream(...) | user input |
 | SimpleXMLTests.java:124:22:124:42 | getInputStream(...) | SimpleXMLTests.java:124:22:124:42 | getInputStream(...) | SimpleXMLTests.java:124:22:124:42 | getInputStream(...) | Unsafe parsing of XML file from $@. | SimpleXMLTests.java:124:22:124:42 | getInputStream(...) | user input |
-| SimpleXMLTests.java:129:22:129:65 | new InputStreamReader(...) | SimpleXMLTests.java:129:44:129:64 | getInputStream(...) [ : InputStream] | SimpleXMLTests.java:129:22:129:65 | new InputStreamReader(...) | Unsafe parsing of XML file from $@. | SimpleXMLTests.java:129:44:129:64 | getInputStream(...) | user input |
+| SimpleXMLTests.java:129:22:129:65 | new InputStreamReader(...) | SimpleXMLTests.java:129:44:129:64 | getInputStream(...) : InputStream | SimpleXMLTests.java:129:22:129:65 | new InputStreamReader(...) | Unsafe parsing of XML file from $@. | SimpleXMLTests.java:129:44:129:64 | getInputStream(...) | user input |
 | SimpleXMLTests.java:134:22:134:42 | getInputStream(...) | SimpleXMLTests.java:134:22:134:42 | getInputStream(...) | SimpleXMLTests.java:134:22:134:42 | getInputStream(...) | Unsafe parsing of XML file from $@. | SimpleXMLTests.java:134:22:134:42 | getInputStream(...) | user input |
-| SimpleXMLTests.java:139:22:139:65 | new InputStreamReader(...) | SimpleXMLTests.java:139:44:139:64 | getInputStream(...) [ : InputStream] | SimpleXMLTests.java:139:22:139:65 | new InputStreamReader(...) | Unsafe parsing of XML file from $@. | SimpleXMLTests.java:139:44:139:64 | getInputStream(...) | user input |
-| SimpleXMLTests.java:146:22:146:34 | new String(...) | SimpleXMLTests.java:145:5:145:25 | getInputStream(...) [ : InputStream] | SimpleXMLTests.java:146:22:146:34 | new String(...) | Unsafe parsing of XML file from $@. | SimpleXMLTests.java:145:5:145:25 | getInputStream(...) | user input |
-| SimpleXMLTests.java:153:22:153:34 | new String(...) | SimpleXMLTests.java:152:5:152:25 | getInputStream(...) [ : InputStream] | SimpleXMLTests.java:153:22:153:34 | new String(...) | Unsafe parsing of XML file from $@. | SimpleXMLTests.java:152:5:152:25 | getInputStream(...) | user input |
-| TransformerTests.java:20:27:20:65 | new StreamSource(...) | TransformerTests.java:20:44:20:64 | getInputStream(...) [ : InputStream] | TransformerTests.java:20:27:20:65 | new StreamSource(...) | Unsafe parsing of XML file from $@. | TransformerTests.java:20:44:20:64 | getInputStream(...) | user input |
-| TransformerTests.java:21:23:21:61 | new StreamSource(...) | TransformerTests.java:21:40:21:60 | getInputStream(...) [ : InputStream] | TransformerTests.java:21:23:21:61 | new StreamSource(...) | Unsafe parsing of XML file from $@. | TransformerTests.java:21:40:21:60 | getInputStream(...) | user input |
-| TransformerTests.java:71:27:71:65 | new StreamSource(...) | TransformerTests.java:71:44:71:64 | getInputStream(...) [ : InputStream] | TransformerTests.java:71:27:71:65 | new StreamSource(...) | Unsafe parsing of XML file from $@. | TransformerTests.java:71:44:71:64 | getInputStream(...) | user input |
-| TransformerTests.java:72:23:72:61 | new StreamSource(...) | TransformerTests.java:72:40:72:60 | getInputStream(...) [ : InputStream] | TransformerTests.java:72:23:72:61 | new StreamSource(...) | Unsafe parsing of XML file from $@. | TransformerTests.java:72:40:72:60 | getInputStream(...) | user input |
-| TransformerTests.java:79:27:79:65 | new StreamSource(...) | TransformerTests.java:79:44:79:64 | getInputStream(...) [ : InputStream] | TransformerTests.java:79:27:79:65 | new StreamSource(...) | Unsafe parsing of XML file from $@. | TransformerTests.java:79:44:79:64 | getInputStream(...) | user input |
-| TransformerTests.java:80:23:80:61 | new StreamSource(...) | TransformerTests.java:80:40:80:60 | getInputStream(...) [ : InputStream] | TransformerTests.java:80:23:80:61 | new StreamSource(...) | Unsafe parsing of XML file from $@. | TransformerTests.java:80:40:80:60 | getInputStream(...) | user input |
-| TransformerTests.java:88:27:88:65 | new StreamSource(...) | TransformerTests.java:88:44:88:64 | getInputStream(...) [ : InputStream] | TransformerTests.java:88:27:88:65 | new StreamSource(...) | Unsafe parsing of XML file from $@. | TransformerTests.java:88:44:88:64 | getInputStream(...) | user input |
-| TransformerTests.java:89:23:89:61 | new StreamSource(...) | TransformerTests.java:89:40:89:60 | getInputStream(...) [ : InputStream] | TransformerTests.java:89:23:89:61 | new StreamSource(...) | Unsafe parsing of XML file from $@. | TransformerTests.java:89:40:89:60 | getInputStream(...) | user input |
-| TransformerTests.java:97:27:97:65 | new StreamSource(...) | TransformerTests.java:97:44:97:64 | getInputStream(...) [ : InputStream] | TransformerTests.java:97:27:97:65 | new StreamSource(...) | Unsafe parsing of XML file from $@. | TransformerTests.java:97:44:97:64 | getInputStream(...) | user input |
-| TransformerTests.java:98:23:98:61 | new StreamSource(...) | TransformerTests.java:98:40:98:60 | getInputStream(...) [ : InputStream] | TransformerTests.java:98:23:98:61 | new StreamSource(...) | Unsafe parsing of XML file from $@. | TransformerTests.java:98:40:98:60 | getInputStream(...) | user input |
-| TransformerTests.java:103:21:103:59 | new StreamSource(...) | TransformerTests.java:103:38:103:58 | getInputStream(...) [ : InputStream] | TransformerTests.java:103:21:103:59 | new StreamSource(...) | Unsafe parsing of XML file from $@. | TransformerTests.java:103:38:103:58 | getInputStream(...) | user input |
-| TransformerTests.java:116:21:116:59 | new StreamSource(...) | TransformerTests.java:116:38:116:58 | getInputStream(...) [ : InputStream] | TransformerTests.java:116:21:116:59 | new StreamSource(...) | Unsafe parsing of XML file from $@. | TransformerTests.java:116:38:116:58 | getInputStream(...) | user input |
-| TransformerTests.java:122:21:122:59 | new StreamSource(...) | TransformerTests.java:122:38:122:58 | getInputStream(...) [ : InputStream] | TransformerTests.java:122:21:122:59 | new StreamSource(...) | Unsafe parsing of XML file from $@. | TransformerTests.java:122:38:122:58 | getInputStream(...) | user input |
-| TransformerTests.java:129:21:129:59 | new StreamSource(...) | TransformerTests.java:129:38:129:58 | getInputStream(...) [ : InputStream] | TransformerTests.java:129:21:129:59 | new StreamSource(...) | Unsafe parsing of XML file from $@. | TransformerTests.java:129:38:129:58 | getInputStream(...) | user input |
-| TransformerTests.java:136:21:136:59 | new StreamSource(...) | TransformerTests.java:136:38:136:58 | getInputStream(...) [ : InputStream] | TransformerTests.java:136:21:136:59 | new StreamSource(...) | Unsafe parsing of XML file from $@. | TransformerTests.java:136:38:136:58 | getInputStream(...) | user input |
-| TransformerTests.java:141:18:141:70 | new SAXSource(...) | TransformerTests.java:141:48:141:68 | getInputStream(...) [ : InputStream] | TransformerTests.java:141:18:141:70 | new SAXSource(...) | Unsafe parsing of XML file from $@. | TransformerTests.java:141:48:141:68 | getInputStream(...) | user input |
-| XMLReaderTests.java:16:18:16:55 | new InputSource(...) | XMLReaderTests.java:16:34:16:54 | getInputStream(...) [ : InputStream] | XMLReaderTests.java:16:18:16:55 | new InputSource(...) | Unsafe parsing of XML file from $@. | XMLReaderTests.java:16:34:16:54 | getInputStream(...) | user input |
-| XMLReaderTests.java:56:18:56:55 | new InputSource(...) | XMLReaderTests.java:56:34:56:54 | getInputStream(...) [ : InputStream] | XMLReaderTests.java:56:18:56:55 | new InputSource(...) | Unsafe parsing of XML file from $@. | XMLReaderTests.java:56:34:56:54 | getInputStream(...) | user input |
-| XMLReaderTests.java:63:18:63:55 | new InputSource(...) | XMLReaderTests.java:63:34:63:54 | getInputStream(...) [ : InputStream] | XMLReaderTests.java:63:18:63:55 | new InputSource(...) | Unsafe parsing of XML file from $@. | XMLReaderTests.java:63:34:63:54 | getInputStream(...) | user input |
-| XMLReaderTests.java:70:18:70:55 | new InputSource(...) | XMLReaderTests.java:70:34:70:54 | getInputStream(...) [ : InputStream] | XMLReaderTests.java:70:18:70:55 | new InputSource(...) | Unsafe parsing of XML file from $@. | XMLReaderTests.java:70:34:70:54 | getInputStream(...) | user input |
-| XMLReaderTests.java:78:18:78:55 | new InputSource(...) | XMLReaderTests.java:78:34:78:54 | getInputStream(...) [ : InputStream] | XMLReaderTests.java:78:18:78:55 | new InputSource(...) | Unsafe parsing of XML file from $@. | XMLReaderTests.java:78:34:78:54 | getInputStream(...) | user input |
-| XMLReaderTests.java:86:18:86:55 | new InputSource(...) | XMLReaderTests.java:86:34:86:54 | getInputStream(...) [ : InputStream] | XMLReaderTests.java:86:18:86:55 | new InputSource(...) | Unsafe parsing of XML file from $@. | XMLReaderTests.java:86:34:86:54 | getInputStream(...) | user input |
-| XMLReaderTests.java:94:18:94:55 | new InputSource(...) | XMLReaderTests.java:94:34:94:54 | getInputStream(...) [ : InputStream] | XMLReaderTests.java:94:18:94:55 | new InputSource(...) | Unsafe parsing of XML file from $@. | XMLReaderTests.java:94:34:94:54 | getInputStream(...) | user input |
-| XMLReaderTests.java:100:18:100:55 | new InputSource(...) | XMLReaderTests.java:100:34:100:54 | getInputStream(...) [ : InputStream] | XMLReaderTests.java:100:18:100:55 | new InputSource(...) | Unsafe parsing of XML file from $@. | XMLReaderTests.java:100:34:100:54 | getInputStream(...) | user input |
-| XPathExpressionTests.java:27:21:27:58 | new InputSource(...) | XPathExpressionTests.java:27:37:27:57 | getInputStream(...) [ : InputStream] | XPathExpressionTests.java:27:21:27:58 | new InputSource(...) | Unsafe parsing of XML file from $@. | XPathExpressionTests.java:27:37:27:57 | getInputStream(...) | user input |
+| SimpleXMLTests.java:139:22:139:65 | new InputStreamReader(...) | SimpleXMLTests.java:139:44:139:64 | getInputStream(...) : InputStream | SimpleXMLTests.java:139:22:139:65 | new InputStreamReader(...) | Unsafe parsing of XML file from $@. | SimpleXMLTests.java:139:44:139:64 | getInputStream(...) | user input |
+| SimpleXMLTests.java:146:22:146:34 | new String(...) | SimpleXMLTests.java:145:5:145:25 | getInputStream(...) : InputStream | SimpleXMLTests.java:146:22:146:34 | new String(...) | Unsafe parsing of XML file from $@. | SimpleXMLTests.java:145:5:145:25 | getInputStream(...) | user input |
+| SimpleXMLTests.java:153:22:153:34 | new String(...) | SimpleXMLTests.java:152:5:152:25 | getInputStream(...) : InputStream | SimpleXMLTests.java:153:22:153:34 | new String(...) | Unsafe parsing of XML file from $@. | SimpleXMLTests.java:152:5:152:25 | getInputStream(...) | user input |
+| TransformerTests.java:20:27:20:65 | new StreamSource(...) | TransformerTests.java:20:44:20:64 | getInputStream(...) : InputStream | TransformerTests.java:20:27:20:65 | new StreamSource(...) | Unsafe parsing of XML file from $@. | TransformerTests.java:20:44:20:64 | getInputStream(...) | user input |
+| TransformerTests.java:21:23:21:61 | new StreamSource(...) | TransformerTests.java:21:40:21:60 | getInputStream(...) : InputStream | TransformerTests.java:21:23:21:61 | new StreamSource(...) | Unsafe parsing of XML file from $@. | TransformerTests.java:21:40:21:60 | getInputStream(...) | user input |
+| TransformerTests.java:71:27:71:65 | new StreamSource(...) | TransformerTests.java:71:44:71:64 | getInputStream(...) : InputStream | TransformerTests.java:71:27:71:65 | new StreamSource(...) | Unsafe parsing of XML file from $@. | TransformerTests.java:71:44:71:64 | getInputStream(...) | user input |
+| TransformerTests.java:72:23:72:61 | new StreamSource(...) | TransformerTests.java:72:40:72:60 | getInputStream(...) : InputStream | TransformerTests.java:72:23:72:61 | new StreamSource(...) | Unsafe parsing of XML file from $@. | TransformerTests.java:72:40:72:60 | getInputStream(...) | user input |
+| TransformerTests.java:79:27:79:65 | new StreamSource(...) | TransformerTests.java:79:44:79:64 | getInputStream(...) : InputStream | TransformerTests.java:79:27:79:65 | new StreamSource(...) | Unsafe parsing of XML file from $@. | TransformerTests.java:79:44:79:64 | getInputStream(...) | user input |
+| TransformerTests.java:80:23:80:61 | new StreamSource(...) | TransformerTests.java:80:40:80:60 | getInputStream(...) : InputStream | TransformerTests.java:80:23:80:61 | new StreamSource(...) | Unsafe parsing of XML file from $@. | TransformerTests.java:80:40:80:60 | getInputStream(...) | user input |
+| TransformerTests.java:88:27:88:65 | new StreamSource(...) | TransformerTests.java:88:44:88:64 | getInputStream(...) : InputStream | TransformerTests.java:88:27:88:65 | new StreamSource(...) | Unsafe parsing of XML file from $@. | TransformerTests.java:88:44:88:64 | getInputStream(...) | user input |
+| TransformerTests.java:89:23:89:61 | new StreamSource(...) | TransformerTests.java:89:40:89:60 | getInputStream(...) : InputStream | TransformerTests.java:89:23:89:61 | new StreamSource(...) | Unsafe parsing of XML file from $@. | TransformerTests.java:89:40:89:60 | getInputStream(...) | user input |
+| TransformerTests.java:97:27:97:65 | new StreamSource(...) | TransformerTests.java:97:44:97:64 | getInputStream(...) : InputStream | TransformerTests.java:97:27:97:65 | new StreamSource(...) | Unsafe parsing of XML file from $@. | TransformerTests.java:97:44:97:64 | getInputStream(...) | user input |
+| TransformerTests.java:98:23:98:61 | new StreamSource(...) | TransformerTests.java:98:40:98:60 | getInputStream(...) : InputStream | TransformerTests.java:98:23:98:61 | new StreamSource(...) | Unsafe parsing of XML file from $@. | TransformerTests.java:98:40:98:60 | getInputStream(...) | user input |
+| TransformerTests.java:103:21:103:59 | new StreamSource(...) | TransformerTests.java:103:38:103:58 | getInputStream(...) : InputStream | TransformerTests.java:103:21:103:59 | new StreamSource(...) | Unsafe parsing of XML file from $@. | TransformerTests.java:103:38:103:58 | getInputStream(...) | user input |
+| TransformerTests.java:116:21:116:59 | new StreamSource(...) | TransformerTests.java:116:38:116:58 | getInputStream(...) : InputStream | TransformerTests.java:116:21:116:59 | new StreamSource(...) | Unsafe parsing of XML file from $@. | TransformerTests.java:116:38:116:58 | getInputStream(...) | user input |
+| TransformerTests.java:122:21:122:59 | new StreamSource(...) | TransformerTests.java:122:38:122:58 | getInputStream(...) : InputStream | TransformerTests.java:122:21:122:59 | new StreamSource(...) | Unsafe parsing of XML file from $@. | TransformerTests.java:122:38:122:58 | getInputStream(...) | user input |
+| TransformerTests.java:129:21:129:59 | new StreamSource(...) | TransformerTests.java:129:38:129:58 | getInputStream(...) : InputStream | TransformerTests.java:129:21:129:59 | new StreamSource(...) | Unsafe parsing of XML file from $@. | TransformerTests.java:129:38:129:58 | getInputStream(...) | user input |
+| TransformerTests.java:136:21:136:59 | new StreamSource(...) | TransformerTests.java:136:38:136:58 | getInputStream(...) : InputStream | TransformerTests.java:136:21:136:59 | new StreamSource(...) | Unsafe parsing of XML file from $@. | TransformerTests.java:136:38:136:58 | getInputStream(...) | user input |
+| TransformerTests.java:141:18:141:70 | new SAXSource(...) | TransformerTests.java:141:48:141:68 | getInputStream(...) : InputStream | TransformerTests.java:141:18:141:70 | new SAXSource(...) | Unsafe parsing of XML file from $@. | TransformerTests.java:141:48:141:68 | getInputStream(...) | user input |
+| XMLReaderTests.java:16:18:16:55 | new InputSource(...) | XMLReaderTests.java:16:34:16:54 | getInputStream(...) : InputStream | XMLReaderTests.java:16:18:16:55 | new InputSource(...) | Unsafe parsing of XML file from $@. | XMLReaderTests.java:16:34:16:54 | getInputStream(...) | user input |
+| XMLReaderTests.java:56:18:56:55 | new InputSource(...) | XMLReaderTests.java:56:34:56:54 | getInputStream(...) : InputStream | XMLReaderTests.java:56:18:56:55 | new InputSource(...) | Unsafe parsing of XML file from $@. | XMLReaderTests.java:56:34:56:54 | getInputStream(...) | user input |
+| XMLReaderTests.java:63:18:63:55 | new InputSource(...) | XMLReaderTests.java:63:34:63:54 | getInputStream(...) : InputStream | XMLReaderTests.java:63:18:63:55 | new InputSource(...) | Unsafe parsing of XML file from $@. | XMLReaderTests.java:63:34:63:54 | getInputStream(...) | user input |
+| XMLReaderTests.java:70:18:70:55 | new InputSource(...) | XMLReaderTests.java:70:34:70:54 | getInputStream(...) : InputStream | XMLReaderTests.java:70:18:70:55 | new InputSource(...) | Unsafe parsing of XML file from $@. | XMLReaderTests.java:70:34:70:54 | getInputStream(...) | user input |
+| XMLReaderTests.java:78:18:78:55 | new InputSource(...) | XMLReaderTests.java:78:34:78:54 | getInputStream(...) : InputStream | XMLReaderTests.java:78:18:78:55 | new InputSource(...) | Unsafe parsing of XML file from $@. | XMLReaderTests.java:78:34:78:54 | getInputStream(...) | user input |
+| XMLReaderTests.java:86:18:86:55 | new InputSource(...) | XMLReaderTests.java:86:34:86:54 | getInputStream(...) : InputStream | XMLReaderTests.java:86:18:86:55 | new InputSource(...) | Unsafe parsing of XML file from $@. | XMLReaderTests.java:86:34:86:54 | getInputStream(...) | user input |
+| XMLReaderTests.java:94:18:94:55 | new InputSource(...) | XMLReaderTests.java:94:34:94:54 | getInputStream(...) : InputStream | XMLReaderTests.java:94:18:94:55 | new InputSource(...) | Unsafe parsing of XML file from $@. | XMLReaderTests.java:94:34:94:54 | getInputStream(...) | user input |
+| XMLReaderTests.java:100:18:100:55 | new InputSource(...) | XMLReaderTests.java:100:34:100:54 | getInputStream(...) : InputStream | XMLReaderTests.java:100:18:100:55 | new InputSource(...) | Unsafe parsing of XML file from $@. | XMLReaderTests.java:100:34:100:54 | getInputStream(...) | user input |
+| XPathExpressionTests.java:27:21:27:58 | new InputSource(...) | XPathExpressionTests.java:27:37:27:57 | getInputStream(...) : InputStream | XPathExpressionTests.java:27:21:27:58 | new InputSource(...) | Unsafe parsing of XML file from $@. | XPathExpressionTests.java:27:37:27:57 | getInputStream(...) | user input |
 | XmlInputFactoryTests.java:9:35:9:55 | getInputStream(...) | XmlInputFactoryTests.java:9:35:9:55 | getInputStream(...) | XmlInputFactoryTests.java:9:35:9:55 | getInputStream(...) | Unsafe parsing of XML file from $@. | XmlInputFactoryTests.java:9:35:9:55 | getInputStream(...) | user input |
 | XmlInputFactoryTests.java:10:34:10:54 | getInputStream(...) | XmlInputFactoryTests.java:10:34:10:54 | getInputStream(...) | XmlInputFactoryTests.java:10:34:10:54 | getInputStream(...) | Unsafe parsing of XML file from $@. | XmlInputFactoryTests.java:10:34:10:54 | getInputStream(...) | user input |
 | XmlInputFactoryTests.java:24:35:24:55 | getInputStream(...) | XmlInputFactoryTests.java:24:35:24:55 | getInputStream(...) | XmlInputFactoryTests.java:24:35:24:55 | getInputStream(...) | Unsafe parsing of XML file from $@. | XmlInputFactoryTests.java:24:35:24:55 | getInputStream(...) | user input |

--- a/java/ql/test/query-tests/security/CWE-681/semmle/tests/NumericCastTaintedLocal.expected
+++ b/java/ql/test/query-tests/security/CWE-681/semmle/tests/NumericCastTaintedLocal.expected
@@ -1,7 +1,7 @@
 edges
-| Test.java:11:28:11:36 | System.in [ : InputStream] | Test.java:21:22:21:25 | data |
+| Test.java:11:28:11:36 | System.in : InputStream | Test.java:21:22:21:25 | data |
 nodes
-| Test.java:11:28:11:36 | System.in [ : InputStream] | semmle.label | System.in [ : InputStream] |
+| Test.java:11:28:11:36 | System.in : InputStream | semmle.label | System.in : InputStream |
 | Test.java:21:22:21:25 | data | semmle.label | data |
 #select
-| Test.java:21:17:21:25 | (...)... | Test.java:11:28:11:36 | System.in [ : InputStream] | Test.java:21:22:21:25 | data | $@ flows to here and is cast to a narrower type, potentially causing truncation. | Test.java:11:28:11:36 | System.in | User-provided value |
+| Test.java:21:17:21:25 | (...)... | Test.java:11:28:11:36 | System.in : InputStream | Test.java:21:22:21:25 | data | $@ flows to here and is cast to a narrower type, potentially causing truncation. | Test.java:11:28:11:36 | System.in | User-provided value |

--- a/java/ql/test/query-tests/security/CWE-798/semmle/tests/HardcodedCredentialsApiCall.expected
+++ b/java/ql/test/query-tests/security/CWE-798/semmle/tests/HardcodedCredentialsApiCall.expected
@@ -1,82 +1,82 @@
 edges
-| CredentialsTest.java:7:34:7:41 | "123456" [ : String] | CredentialsTest.java:13:39:13:39 | p |
-| CredentialsTest.java:7:34:7:41 | "123456" [ : String] | CredentialsTest.java:14:16:14:16 | p [ : String] |
-| CredentialsTest.java:11:14:11:20 | "admin" [ : String] | CredentialsTest.java:13:36:13:36 | u |
-| CredentialsTest.java:11:14:11:20 | "admin" [ : String] | CredentialsTest.java:14:13:14:13 | u [ : String] |
-| CredentialsTest.java:14:13:14:13 | u [ : String] | CredentialsTest.java:17:38:17:45 | v [ : String] |
-| CredentialsTest.java:14:16:14:16 | p [ : String] | CredentialsTest.java:17:48:17:55 | q [ : String] |
-| CredentialsTest.java:17:38:17:45 | v [ : String] | CredentialsTest.java:18:36:18:36 | v |
-| CredentialsTest.java:17:48:17:55 | q [ : String] | CredentialsTest.java:18:39:18:39 | q |
-| FileCredentialTest.java:13:14:13:20 | "admin" [ : String] | FileCredentialTest.java:19:13:19:13 | u [ : String] |
-| FileCredentialTest.java:19:13:19:13 | u [ : String] | FileCredentialTest.java:22:38:22:45 | v [ : String] |
-| FileCredentialTest.java:22:38:22:45 | v [ : String] | FileCredentialTest.java:23:36:23:36 | v |
-| Test.java:9:16:9:22 | "admin" [ : String] | Test.java:12:13:12:15 | usr [ : String] |
-| Test.java:9:16:9:22 | "admin" [ : String] | Test.java:15:36:15:38 | usr |
-| Test.java:9:16:9:22 | "admin" [ : String] | Test.java:17:39:17:41 | usr |
-| Test.java:9:16:9:22 | "admin" [ : String] | Test.java:18:39:18:41 | usr |
-| Test.java:10:17:10:24 | "123456" [ : String] | Test.java:12:18:12:21 | pass [ : String] |
-| Test.java:10:17:10:24 | "123456" [ : String] | Test.java:15:41:15:44 | pass |
-| Test.java:10:17:10:24 | "123456" [ : String] | Test.java:18:44:18:61 | toCharArray(...) |
-| Test.java:12:13:12:15 | usr [ : String] | Test.java:29:38:29:48 | user [ : String] |
-| Test.java:12:18:12:21 | pass [ : String] | Test.java:29:51:29:65 | password [ : String] |
-| Test.java:17:44:17:51 | "123456" [ : String] | Test.java:17:44:17:65 | toCharArray(...) |
-| Test.java:20:16:20:39 | new byte[] [ : byte[]] | Test.java:21:78:21:80 | key |
-| Test.java:23:17:23:26 | "abcdefgh" [ : String] | Test.java:24:79:24:82 | key2 |
-| Test.java:29:38:29:48 | user [ : String] | Test.java:30:36:30:39 | user |
-| Test.java:29:51:29:65 | password [ : String] | Test.java:30:42:30:49 | password |
+| CredentialsTest.java:7:34:7:41 | "123456" : String | CredentialsTest.java:13:39:13:39 | p |
+| CredentialsTest.java:7:34:7:41 | "123456" : String | CredentialsTest.java:14:16:14:16 | p : String |
+| CredentialsTest.java:11:14:11:20 | "admin" : String | CredentialsTest.java:13:36:13:36 | u |
+| CredentialsTest.java:11:14:11:20 | "admin" : String | CredentialsTest.java:14:13:14:13 | u : String |
+| CredentialsTest.java:14:13:14:13 | u : String | CredentialsTest.java:17:38:17:45 | v : String |
+| CredentialsTest.java:14:16:14:16 | p : String | CredentialsTest.java:17:48:17:55 | q : String |
+| CredentialsTest.java:17:38:17:45 | v : String | CredentialsTest.java:18:36:18:36 | v |
+| CredentialsTest.java:17:48:17:55 | q : String | CredentialsTest.java:18:39:18:39 | q |
+| FileCredentialTest.java:13:14:13:20 | "admin" : String | FileCredentialTest.java:19:13:19:13 | u : String |
+| FileCredentialTest.java:19:13:19:13 | u : String | FileCredentialTest.java:22:38:22:45 | v : String |
+| FileCredentialTest.java:22:38:22:45 | v : String | FileCredentialTest.java:23:36:23:36 | v |
+| Test.java:9:16:9:22 | "admin" : String | Test.java:12:13:12:15 | usr : String |
+| Test.java:9:16:9:22 | "admin" : String | Test.java:15:36:15:38 | usr |
+| Test.java:9:16:9:22 | "admin" : String | Test.java:17:39:17:41 | usr |
+| Test.java:9:16:9:22 | "admin" : String | Test.java:18:39:18:41 | usr |
+| Test.java:10:17:10:24 | "123456" : String | Test.java:12:18:12:21 | pass : String |
+| Test.java:10:17:10:24 | "123456" : String | Test.java:15:41:15:44 | pass |
+| Test.java:10:17:10:24 | "123456" : String | Test.java:18:44:18:61 | toCharArray(...) |
+| Test.java:12:13:12:15 | usr : String | Test.java:29:38:29:48 | user : String |
+| Test.java:12:18:12:21 | pass : String | Test.java:29:51:29:65 | password : String |
+| Test.java:17:44:17:51 | "123456" : String | Test.java:17:44:17:65 | toCharArray(...) |
+| Test.java:20:16:20:39 | new byte[] : byte[] | Test.java:21:78:21:80 | key |
+| Test.java:23:17:23:26 | "abcdefgh" : String | Test.java:24:79:24:82 | key2 |
+| Test.java:29:38:29:48 | user : String | Test.java:30:36:30:39 | user |
+| Test.java:29:51:29:65 | password : String | Test.java:30:42:30:49 | password |
 nodes
-| CredentialsTest.java:7:34:7:41 | "123456" [ : String] | semmle.label | "123456" [ : String] |
-| CredentialsTest.java:11:14:11:20 | "admin" [ : String] | semmle.label | "admin" [ : String] |
+| CredentialsTest.java:7:34:7:41 | "123456" : String | semmle.label | "123456" : String |
+| CredentialsTest.java:11:14:11:20 | "admin" : String | semmle.label | "admin" : String |
 | CredentialsTest.java:13:36:13:36 | u | semmle.label | u |
 | CredentialsTest.java:13:39:13:39 | p | semmle.label | p |
-| CredentialsTest.java:14:13:14:13 | u [ : String] | semmle.label | u [ : String] |
-| CredentialsTest.java:14:16:14:16 | p [ : String] | semmle.label | p [ : String] |
-| CredentialsTest.java:17:38:17:45 | v [ : String] | semmle.label | v [ : String] |
-| CredentialsTest.java:17:48:17:55 | q [ : String] | semmle.label | q [ : String] |
+| CredentialsTest.java:14:13:14:13 | u : String | semmle.label | u : String |
+| CredentialsTest.java:14:16:14:16 | p : String | semmle.label | p : String |
+| CredentialsTest.java:17:38:17:45 | v : String | semmle.label | v : String |
+| CredentialsTest.java:17:48:17:55 | q : String | semmle.label | q : String |
 | CredentialsTest.java:18:36:18:36 | v | semmle.label | v |
 | CredentialsTest.java:18:39:18:39 | q | semmle.label | q |
-| FileCredentialTest.java:13:14:13:20 | "admin" [ : String] | semmle.label | "admin" [ : String] |
+| FileCredentialTest.java:13:14:13:20 | "admin" : String | semmle.label | "admin" : String |
 | FileCredentialTest.java:18:35:18:41 | "admin" | semmle.label | "admin" |
-| FileCredentialTest.java:19:13:19:13 | u [ : String] | semmle.label | u [ : String] |
-| FileCredentialTest.java:22:38:22:45 | v [ : String] | semmle.label | v [ : String] |
+| FileCredentialTest.java:19:13:19:13 | u : String | semmle.label | u : String |
+| FileCredentialTest.java:22:38:22:45 | v : String | semmle.label | v : String |
 | FileCredentialTest.java:23:36:23:36 | v | semmle.label | v |
-| Test.java:9:16:9:22 | "admin" [ : String] | semmle.label | "admin" [ : String] |
-| Test.java:10:17:10:24 | "123456" [ : String] | semmle.label | "123456" [ : String] |
-| Test.java:12:13:12:15 | usr [ : String] | semmle.label | usr [ : String] |
-| Test.java:12:18:12:21 | pass [ : String] | semmle.label | pass [ : String] |
+| Test.java:9:16:9:22 | "admin" : String | semmle.label | "admin" : String |
+| Test.java:10:17:10:24 | "123456" : String | semmle.label | "123456" : String |
+| Test.java:12:13:12:15 | usr : String | semmle.label | usr : String |
+| Test.java:12:18:12:21 | pass : String | semmle.label | pass : String |
 | Test.java:14:36:14:42 | "admin" | semmle.label | "admin" |
 | Test.java:14:45:14:52 | "123456" | semmle.label | "123456" |
 | Test.java:15:36:15:38 | usr | semmle.label | usr |
 | Test.java:15:41:15:44 | pass | semmle.label | pass |
 | Test.java:17:39:17:41 | usr | semmle.label | usr |
-| Test.java:17:44:17:51 | "123456" [ : String] | semmle.label | "123456" [ : String] |
+| Test.java:17:44:17:51 | "123456" : String | semmle.label | "123456" : String |
 | Test.java:17:44:17:65 | toCharArray(...) | semmle.label | toCharArray(...) |
 | Test.java:18:39:18:41 | usr | semmle.label | usr |
 | Test.java:18:44:18:61 | toCharArray(...) | semmle.label | toCharArray(...) |
-| Test.java:20:16:20:39 | new byte[] [ : byte[]] | semmle.label | new byte[] [ : byte[]] |
+| Test.java:20:16:20:39 | new byte[] : byte[] | semmle.label | new byte[] : byte[] |
 | Test.java:21:78:21:80 | key | semmle.label | key |
-| Test.java:23:17:23:26 | "abcdefgh" [ : String] | semmle.label | "abcdefgh" [ : String] |
+| Test.java:23:17:23:26 | "abcdefgh" : String | semmle.label | "abcdefgh" : String |
 | Test.java:24:79:24:82 | key2 | semmle.label | key2 |
-| Test.java:29:38:29:48 | user [ : String] | semmle.label | user [ : String] |
-| Test.java:29:51:29:65 | password [ : String] | semmle.label | password [ : String] |
+| Test.java:29:38:29:48 | user : String | semmle.label | user : String |
+| Test.java:29:51:29:65 | password : String | semmle.label | password : String |
 | Test.java:30:36:30:39 | user | semmle.label | user |
 | Test.java:30:42:30:49 | password | semmle.label | password |
 #select
-| CredentialsTest.java:7:34:7:41 | "123456" | CredentialsTest.java:7:34:7:41 | "123456" [ : String] | CredentialsTest.java:13:39:13:39 | p | Hard-coded value flows to $@. | CredentialsTest.java:13:39:13:39 | p | sensitive API call |
-| CredentialsTest.java:7:34:7:41 | "123456" | CredentialsTest.java:7:34:7:41 | "123456" [ : String] | CredentialsTest.java:18:39:18:39 | q | Hard-coded value flows to $@. | CredentialsTest.java:18:39:18:39 | q | sensitive API call |
-| CredentialsTest.java:11:14:11:20 | "admin" | CredentialsTest.java:11:14:11:20 | "admin" [ : String] | CredentialsTest.java:13:36:13:36 | u | Hard-coded value flows to $@. | CredentialsTest.java:13:36:13:36 | u | sensitive API call |
-| CredentialsTest.java:11:14:11:20 | "admin" | CredentialsTest.java:11:14:11:20 | "admin" [ : String] | CredentialsTest.java:18:36:18:36 | v | Hard-coded value flows to $@. | CredentialsTest.java:18:36:18:36 | v | sensitive API call |
-| FileCredentialTest.java:13:14:13:20 | "admin" | FileCredentialTest.java:13:14:13:20 | "admin" [ : String] | FileCredentialTest.java:23:36:23:36 | v | Hard-coded value flows to $@. | FileCredentialTest.java:23:36:23:36 | v | sensitive API call |
+| CredentialsTest.java:7:34:7:41 | "123456" | CredentialsTest.java:7:34:7:41 | "123456" : String | CredentialsTest.java:13:39:13:39 | p | Hard-coded value flows to $@. | CredentialsTest.java:13:39:13:39 | p | sensitive API call |
+| CredentialsTest.java:7:34:7:41 | "123456" | CredentialsTest.java:7:34:7:41 | "123456" : String | CredentialsTest.java:18:39:18:39 | q | Hard-coded value flows to $@. | CredentialsTest.java:18:39:18:39 | q | sensitive API call |
+| CredentialsTest.java:11:14:11:20 | "admin" | CredentialsTest.java:11:14:11:20 | "admin" : String | CredentialsTest.java:13:36:13:36 | u | Hard-coded value flows to $@. | CredentialsTest.java:13:36:13:36 | u | sensitive API call |
+| CredentialsTest.java:11:14:11:20 | "admin" | CredentialsTest.java:11:14:11:20 | "admin" : String | CredentialsTest.java:18:36:18:36 | v | Hard-coded value flows to $@. | CredentialsTest.java:18:36:18:36 | v | sensitive API call |
+| FileCredentialTest.java:13:14:13:20 | "admin" | FileCredentialTest.java:13:14:13:20 | "admin" : String | FileCredentialTest.java:23:36:23:36 | v | Hard-coded value flows to $@. | FileCredentialTest.java:23:36:23:36 | v | sensitive API call |
 | FileCredentialTest.java:18:35:18:41 | "admin" | FileCredentialTest.java:18:35:18:41 | "admin" | FileCredentialTest.java:18:35:18:41 | "admin" | Hard-coded value flows to $@. | FileCredentialTest.java:18:35:18:41 | "admin" | sensitive API call |
-| Test.java:9:16:9:22 | "admin" | Test.java:9:16:9:22 | "admin" [ : String] | Test.java:15:36:15:38 | usr | Hard-coded value flows to $@. | Test.java:15:36:15:38 | usr | sensitive API call |
-| Test.java:9:16:9:22 | "admin" | Test.java:9:16:9:22 | "admin" [ : String] | Test.java:17:39:17:41 | usr | Hard-coded value flows to $@. | Test.java:17:39:17:41 | usr | sensitive API call |
-| Test.java:9:16:9:22 | "admin" | Test.java:9:16:9:22 | "admin" [ : String] | Test.java:18:39:18:41 | usr | Hard-coded value flows to $@. | Test.java:18:39:18:41 | usr | sensitive API call |
-| Test.java:9:16:9:22 | "admin" | Test.java:9:16:9:22 | "admin" [ : String] | Test.java:30:36:30:39 | user | Hard-coded value flows to $@. | Test.java:30:36:30:39 | user | sensitive API call |
-| Test.java:10:17:10:24 | "123456" | Test.java:10:17:10:24 | "123456" [ : String] | Test.java:15:41:15:44 | pass | Hard-coded value flows to $@. | Test.java:15:41:15:44 | pass | sensitive API call |
-| Test.java:10:17:10:24 | "123456" | Test.java:10:17:10:24 | "123456" [ : String] | Test.java:18:44:18:61 | toCharArray(...) | Hard-coded value flows to $@. | Test.java:18:44:18:61 | toCharArray(...) | sensitive API call |
-| Test.java:10:17:10:24 | "123456" | Test.java:10:17:10:24 | "123456" [ : String] | Test.java:30:42:30:49 | password | Hard-coded value flows to $@. | Test.java:30:42:30:49 | password | sensitive API call |
+| Test.java:9:16:9:22 | "admin" | Test.java:9:16:9:22 | "admin" : String | Test.java:15:36:15:38 | usr | Hard-coded value flows to $@. | Test.java:15:36:15:38 | usr | sensitive API call |
+| Test.java:9:16:9:22 | "admin" | Test.java:9:16:9:22 | "admin" : String | Test.java:17:39:17:41 | usr | Hard-coded value flows to $@. | Test.java:17:39:17:41 | usr | sensitive API call |
+| Test.java:9:16:9:22 | "admin" | Test.java:9:16:9:22 | "admin" : String | Test.java:18:39:18:41 | usr | Hard-coded value flows to $@. | Test.java:18:39:18:41 | usr | sensitive API call |
+| Test.java:9:16:9:22 | "admin" | Test.java:9:16:9:22 | "admin" : String | Test.java:30:36:30:39 | user | Hard-coded value flows to $@. | Test.java:30:36:30:39 | user | sensitive API call |
+| Test.java:10:17:10:24 | "123456" | Test.java:10:17:10:24 | "123456" : String | Test.java:15:41:15:44 | pass | Hard-coded value flows to $@. | Test.java:15:41:15:44 | pass | sensitive API call |
+| Test.java:10:17:10:24 | "123456" | Test.java:10:17:10:24 | "123456" : String | Test.java:18:44:18:61 | toCharArray(...) | Hard-coded value flows to $@. | Test.java:18:44:18:61 | toCharArray(...) | sensitive API call |
+| Test.java:10:17:10:24 | "123456" | Test.java:10:17:10:24 | "123456" : String | Test.java:30:42:30:49 | password | Hard-coded value flows to $@. | Test.java:30:42:30:49 | password | sensitive API call |
 | Test.java:14:36:14:42 | "admin" | Test.java:14:36:14:42 | "admin" | Test.java:14:36:14:42 | "admin" | Hard-coded value flows to $@. | Test.java:14:36:14:42 | "admin" | sensitive API call |
 | Test.java:14:45:14:52 | "123456" | Test.java:14:45:14:52 | "123456" | Test.java:14:45:14:52 | "123456" | Hard-coded value flows to $@. | Test.java:14:45:14:52 | "123456" | sensitive API call |
-| Test.java:17:44:17:51 | "123456" | Test.java:17:44:17:51 | "123456" [ : String] | Test.java:17:44:17:65 | toCharArray(...) | Hard-coded value flows to $@. | Test.java:17:44:17:65 | toCharArray(...) | sensitive API call |
-| Test.java:20:16:20:39 | new byte[] | Test.java:20:16:20:39 | new byte[] [ : byte[]] | Test.java:21:78:21:80 | key | Hard-coded value flows to $@. | Test.java:21:78:21:80 | key | sensitive API call |
-| Test.java:23:17:23:26 | "abcdefgh" | Test.java:23:17:23:26 | "abcdefgh" [ : String] | Test.java:24:79:24:82 | key2 | Hard-coded value flows to $@. | Test.java:24:79:24:82 | key2 | sensitive API call |
+| Test.java:17:44:17:51 | "123456" | Test.java:17:44:17:51 | "123456" : String | Test.java:17:44:17:65 | toCharArray(...) | Hard-coded value flows to $@. | Test.java:17:44:17:65 | toCharArray(...) | sensitive API call |
+| Test.java:20:16:20:39 | new byte[] | Test.java:20:16:20:39 | new byte[] : byte[] | Test.java:21:78:21:80 | key | Hard-coded value flows to $@. | Test.java:21:78:21:80 | key | sensitive API call |
+| Test.java:23:17:23:26 | "abcdefgh" | Test.java:23:17:23:26 | "abcdefgh" : String | Test.java:24:79:24:82 | key2 | Hard-coded value flows to $@. | Test.java:24:79:24:82 | key2 | sensitive API call |

--- a/java/ql/test/query-tests/security/CWE-798/semmle/tests/HardcodedCredentialsSourceCall.expected
+++ b/java/ql/test/query-tests/security/CWE-798/semmle/tests/HardcodedCredentialsSourceCall.expected
@@ -1,11 +1,11 @@
 edges
-| Test.java:10:17:10:24 | "123456" [ : String] | Test.java:26:17:26:20 | pass |
-| User.java:2:43:2:50 | "123456" [ : String] | User.java:5:15:5:24 | DEFAULT_PW |
+| Test.java:10:17:10:24 | "123456" : String | Test.java:26:17:26:20 | pass |
+| User.java:2:43:2:50 | "123456" : String | User.java:5:15:5:24 | DEFAULT_PW |
 nodes
-| Test.java:10:17:10:24 | "123456" [ : String] | semmle.label | "123456" [ : String] |
+| Test.java:10:17:10:24 | "123456" : String | semmle.label | "123456" : String |
 | Test.java:26:17:26:20 | pass | semmle.label | pass |
-| User.java:2:43:2:50 | "123456" [ : String] | semmle.label | "123456" [ : String] |
+| User.java:2:43:2:50 | "123456" : String | semmle.label | "123456" : String |
 | User.java:5:15:5:24 | DEFAULT_PW | semmle.label | DEFAULT_PW |
 #select
-| Test.java:10:17:10:24 | "123456" | Test.java:10:17:10:24 | "123456" [ : String] | Test.java:26:17:26:20 | pass | Hard-coded value flows to $@. | Test.java:26:17:26:20 | pass | sensitive call |
-| User.java:2:43:2:50 | "123456" | User.java:2:43:2:50 | "123456" [ : String] | User.java:5:15:5:24 | DEFAULT_PW | Hard-coded value flows to $@. | User.java:5:15:5:24 | DEFAULT_PW | sensitive call |
+| Test.java:10:17:10:24 | "123456" | Test.java:10:17:10:24 | "123456" : String | Test.java:26:17:26:20 | pass | Hard-coded value flows to $@. | Test.java:26:17:26:20 | pass | sensitive call |
+| User.java:2:43:2:50 | "123456" | User.java:2:43:2:50 | "123456" : String | User.java:5:15:5:24 | DEFAULT_PW | Hard-coded value flows to $@. | User.java:5:15:5:24 | DEFAULT_PW | sensitive call |

--- a/java/ql/test/query-tests/security/CWE-807/semmle/tests/ConditionalBypass.expected
+++ b/java/ql/test/query-tests/security/CWE-807/semmle/tests/ConditionalBypass.expected
@@ -1,24 +1,24 @@
 edges
-| Test.java:17:26:17:38 | args [ : String[]] | Test.java:25:6:25:21 | ... == ... |
-| Test.java:31:6:31:27 | getValue(...) [ : String] | Test.java:31:6:31:43 | equals(...) |
-| Test.java:36:6:36:27 | getValue(...) [ : String] | Test.java:36:6:36:36 | ... == ... |
-| Test.java:81:6:81:27 | getValue(...) [ : String] | Test.java:81:6:81:36 | ... == ... |
-| Test.java:91:6:91:27 | getValue(...) [ : String] | Test.java:91:6:91:36 | ... == ... |
+| Test.java:17:26:17:38 | args : String[] | Test.java:25:6:25:21 | ... == ... |
+| Test.java:31:6:31:27 | getValue(...) : String | Test.java:31:6:31:43 | equals(...) |
+| Test.java:36:6:36:27 | getValue(...) : String | Test.java:36:6:36:36 | ... == ... |
+| Test.java:81:6:81:27 | getValue(...) : String | Test.java:81:6:81:36 | ... == ... |
+| Test.java:91:6:91:27 | getValue(...) : String | Test.java:91:6:91:36 | ... == ... |
 nodes
-| Test.java:17:26:17:38 | args [ : String[]] | semmle.label | args [ : String[]] |
+| Test.java:17:26:17:38 | args : String[] | semmle.label | args : String[] |
 | Test.java:25:6:25:21 | ... == ... | semmle.label | ... == ... |
-| Test.java:31:6:31:27 | getValue(...) [ : String] | semmle.label | getValue(...) [ : String] |
+| Test.java:31:6:31:27 | getValue(...) : String | semmle.label | getValue(...) : String |
 | Test.java:31:6:31:43 | equals(...) | semmle.label | equals(...) |
-| Test.java:36:6:36:27 | getValue(...) [ : String] | semmle.label | getValue(...) [ : String] |
+| Test.java:36:6:36:27 | getValue(...) : String | semmle.label | getValue(...) : String |
 | Test.java:36:6:36:36 | ... == ... | semmle.label | ... == ... |
-| Test.java:81:6:81:27 | getValue(...) [ : String] | semmle.label | getValue(...) [ : String] |
+| Test.java:81:6:81:27 | getValue(...) : String | semmle.label | getValue(...) : String |
 | Test.java:81:6:81:36 | ... == ... | semmle.label | ... == ... |
-| Test.java:91:6:91:27 | getValue(...) [ : String] | semmle.label | getValue(...) [ : String] |
+| Test.java:91:6:91:27 | getValue(...) : String | semmle.label | getValue(...) : String |
 | Test.java:91:6:91:36 | ... == ... | semmle.label | ... == ... |
 #select
-| Test.java:26:4:26:24 | login(...) | Test.java:17:26:17:38 | args [ : String[]] | Test.java:25:6:25:21 | ... == ... | Sensitive method may not be executed depending on $@, which flows from $@. | Test.java:25:6:25:21 | ... == ... | this condition | Test.java:17:26:17:38 | args | user input |
-| Test.java:32:4:32:24 | login(...) | Test.java:31:6:31:27 | getValue(...) [ : String] | Test.java:31:6:31:43 | equals(...) | Sensitive method may not be executed depending on $@, which flows from $@. | Test.java:31:6:31:43 | equals(...) | this condition | Test.java:31:6:31:27 | getValue(...) | user input |
-| Test.java:37:4:37:24 | login(...) | Test.java:36:6:36:27 | getValue(...) [ : String] | Test.java:36:6:36:36 | ... == ... | Sensitive method may not be executed depending on $@, which flows from $@. | Test.java:36:6:36:36 | ... == ... | this condition | Test.java:36:6:36:27 | getValue(...) | user input |
-| Test.java:39:4:39:30 | reCheckAuth(...) | Test.java:36:6:36:27 | getValue(...) [ : String] | Test.java:36:6:36:36 | ... == ... | Sensitive method may not be executed depending on $@, which flows from $@. | Test.java:36:6:36:36 | ... == ... | this condition | Test.java:36:6:36:27 | getValue(...) | user input |
-| Test.java:82:4:82:24 | login(...) | Test.java:81:6:81:27 | getValue(...) [ : String] | Test.java:81:6:81:36 | ... == ... | Sensitive method may not be executed depending on $@, which flows from $@. | Test.java:81:6:81:36 | ... == ... | this condition | Test.java:81:6:81:27 | getValue(...) | user input |
-| Test.java:92:4:92:24 | login(...) | Test.java:91:6:91:27 | getValue(...) [ : String] | Test.java:91:6:91:36 | ... == ... | Sensitive method may not be executed depending on $@, which flows from $@. | Test.java:91:6:91:36 | ... == ... | this condition | Test.java:91:6:91:27 | getValue(...) | user input |
+| Test.java:26:4:26:24 | login(...) | Test.java:17:26:17:38 | args : String[] | Test.java:25:6:25:21 | ... == ... | Sensitive method may not be executed depending on $@, which flows from $@. | Test.java:25:6:25:21 | ... == ... | this condition | Test.java:17:26:17:38 | args | user input |
+| Test.java:32:4:32:24 | login(...) | Test.java:31:6:31:27 | getValue(...) : String | Test.java:31:6:31:43 | equals(...) | Sensitive method may not be executed depending on $@, which flows from $@. | Test.java:31:6:31:43 | equals(...) | this condition | Test.java:31:6:31:27 | getValue(...) | user input |
+| Test.java:37:4:37:24 | login(...) | Test.java:36:6:36:27 | getValue(...) : String | Test.java:36:6:36:36 | ... == ... | Sensitive method may not be executed depending on $@, which flows from $@. | Test.java:36:6:36:36 | ... == ... | this condition | Test.java:36:6:36:27 | getValue(...) | user input |
+| Test.java:39:4:39:30 | reCheckAuth(...) | Test.java:36:6:36:27 | getValue(...) : String | Test.java:36:6:36:36 | ... == ... | Sensitive method may not be executed depending on $@, which flows from $@. | Test.java:36:6:36:36 | ... == ... | this condition | Test.java:36:6:36:27 | getValue(...) | user input |
+| Test.java:82:4:82:24 | login(...) | Test.java:81:6:81:27 | getValue(...) : String | Test.java:81:6:81:36 | ... == ... | Sensitive method may not be executed depending on $@, which flows from $@. | Test.java:81:6:81:36 | ... == ... | this condition | Test.java:81:6:81:27 | getValue(...) | user input |
+| Test.java:92:4:92:24 | login(...) | Test.java:91:6:91:27 | getValue(...) : String | Test.java:91:6:91:36 | ... == ... | Sensitive method may not be executed depending on $@, which flows from $@. | Test.java:91:6:91:36 | ... == ... | this condition | Test.java:91:6:91:27 | getValue(...) | user input |

--- a/java/ql/test/query-tests/security/CWE-807/semmle/tests/TaintedPermissionsCheck.expected
+++ b/java/ql/test/query-tests/security/CWE-807/semmle/tests/TaintedPermissionsCheck.expected
@@ -1,7 +1,7 @@
 edges
-| Test.java:17:26:17:38 | args [ : String[]] | Test.java:50:26:50:64 | ... + ... |
+| Test.java:17:26:17:38 | args : String[] | Test.java:50:26:50:64 | ... + ... |
 nodes
-| Test.java:17:26:17:38 | args [ : String[]] | semmle.label | args [ : String[]] |
+| Test.java:17:26:17:38 | args : String[] | semmle.label | args : String[] |
 | Test.java:50:26:50:64 | ... + ... | semmle.label | ... + ... |
 #select
-| Test.java:50:6:50:65 | isPermitted(...) | Test.java:17:26:17:38 | args [ : String[]] | Test.java:50:26:50:64 | ... + ... | Permissions check uses user-controlled $@. | Test.java:17:26:17:38 | args | data |
+| Test.java:50:6:50:65 | isPermitted(...) | Test.java:17:26:17:38 | args : String[] | Test.java:50:26:50:64 | ... + ... | Permissions check uses user-controlled $@. | Test.java:17:26:17:38 | args | data |


### PR DESCRIPTION
Move the type annotation outside the brackets, to avoid prefixes such as
`[ : T]`.