### PR TITLE
IR: add getASTVariable to VariableInstruction

### DIFF
--- a/cpp/ql/src/semmle/code/cpp/ir/implementation/aliased_ssa/Instruction.qll
+++ b/cpp/ql/src/semmle/code/cpp/ir/implementation/aliased_ssa/Instruction.qll
@@ -611,7 +611,7 @@ class VariableInstruction extends Instruction {
 
   override string getImmediateString() { result = var.toString() }
 
-  final IRVariable getVariable() { result = var }
+  final IRVariable getIRVariable() { result = var }
 }
 
 class FieldInstruction extends Instruction {

--- a/cpp/ql/src/semmle/code/cpp/ir/implementation/aliased_ssa/Instruction.qll
+++ b/cpp/ql/src/semmle/code/cpp/ir/implementation/aliased_ssa/Instruction.qll
@@ -612,6 +612,11 @@ class VariableInstruction extends Instruction {
   override string getImmediateString() { result = var.toString() }
 
   final IRVariable getIRVariable() { result = var }
+
+  /**
+   * Gets the AST variable that this instruction's IR variable refers to, if one exists.
+   */
+  final Language::Variable getASTVariable() { result = var.(IRUserVariable).getVariable() }
 }
 
 class FieldInstruction extends Instruction {

--- a/cpp/ql/src/semmle/code/cpp/ir/implementation/aliased_ssa/gvn/ValueNumbering.qll
+++ b/cpp/ql/src/semmle/code/cpp/ir/implementation/aliased_ssa/gvn/ValueNumbering.qll
@@ -135,14 +135,14 @@ private predicate variableAddressValueNumber(
   VariableAddressInstruction instr, IRFunction irFunc, IRVariable var
 ) {
   instr.getEnclosingIRFunction() = irFunc and
-  instr.getVariable() = var
+  instr.getIRVariable() = var
 }
 
 private predicate initializeParameterValueNumber(
   InitializeParameterInstruction instr, IRFunction irFunc, IRVariable var
 ) {
   instr.getEnclosingIRFunction() = irFunc and
-  instr.getVariable() = var
+  instr.getIRVariable() = var
 }
 
 private predicate initializeThisValueNumber(InitializeThisInstruction instr, IRFunction irFunc) {

--- a/cpp/ql/src/semmle/code/cpp/ir/implementation/aliased_ssa/internal/AliasAnalysis.qll
+++ b/cpp/ql/src/semmle/code/cpp/ir/implementation/aliased_ssa/internal/AliasAnalysis.qll
@@ -282,7 +282,7 @@ private predicate automaticVariableAddressEscapes(IRAutomaticVariable var) {
   // The variable's address escapes if the result of any
   // VariableAddressInstruction that computes the variable's address escapes.
   exists(VariableAddressInstruction instr |
-    instr.getVariable() = var and
+    instr.getIRVariable() = var and
     resultEscapesNonReturn(instr)
   )
 }
@@ -305,7 +305,7 @@ predicate variableAddressEscapes(IRVariable var) {
  */
 predicate resultPointsTo(Instruction instr, IRVariable var, IntValue bitOffset) {
   // The address of a variable points to that variable, at offset 0.
-  instr.(VariableAddressInstruction).getVariable() = var and
+  instr.(VariableAddressInstruction).getIRVariable() = var and
   bitOffset = 0
   or
   exists(Operand operand, IntValue originalBitOffset, IntValue propagatedBitOffset |

--- a/cpp/ql/src/semmle/code/cpp/ir/implementation/aliased_ssa/internal/SSAConstruction.qll
+++ b/cpp/ql/src/semmle/code/cpp/ir/implementation/aliased_ssa/internal/SSAConstruction.qll
@@ -334,7 +334,7 @@ private module Cached {
   IRVariable getInstructionVariable(Instruction instruction) {
     result = getNewIRVariable(getOldInstruction(instruction)
             .(OldIR::VariableInstruction)
-            .getVariable())
+            .getIRVariable())
   }
 
   cached

--- a/cpp/ql/src/semmle/code/cpp/ir/implementation/raw/Instruction.qll
+++ b/cpp/ql/src/semmle/code/cpp/ir/implementation/raw/Instruction.qll
@@ -611,7 +611,7 @@ class VariableInstruction extends Instruction {
 
   override string getImmediateString() { result = var.toString() }
 
-  final IRVariable getVariable() { result = var }
+  final IRVariable getIRVariable() { result = var }
 }
 
 class FieldInstruction extends Instruction {

--- a/cpp/ql/src/semmle/code/cpp/ir/implementation/raw/Instruction.qll
+++ b/cpp/ql/src/semmle/code/cpp/ir/implementation/raw/Instruction.qll
@@ -612,6 +612,11 @@ class VariableInstruction extends Instruction {
   override string getImmediateString() { result = var.toString() }
 
   final IRVariable getIRVariable() { result = var }
+
+  /**
+   * Gets the AST variable that this instruction's IR variable refers to, if one exists.
+   */
+  final Language::Variable getASTVariable() { result = var.(IRUserVariable).getVariable() }
 }
 
 class FieldInstruction extends Instruction {

--- a/cpp/ql/src/semmle/code/cpp/ir/implementation/raw/gvn/ValueNumbering.qll
+++ b/cpp/ql/src/semmle/code/cpp/ir/implementation/raw/gvn/ValueNumbering.qll
@@ -135,14 +135,14 @@ private predicate variableAddressValueNumber(
   VariableAddressInstruction instr, IRFunction irFunc, IRVariable var
 ) {
   instr.getEnclosingIRFunction() = irFunc and
-  instr.getVariable() = var
+  instr.getIRVariable() = var
 }
 
 private predicate initializeParameterValueNumber(
   InitializeParameterInstruction instr, IRFunction irFunc, IRVariable var
 ) {
   instr.getEnclosingIRFunction() = irFunc and
-  instr.getVariable() = var
+  instr.getIRVariable() = var
 }
 
 private predicate initializeThisValueNumber(InitializeThisInstruction instr, IRFunction irFunc) {

--- a/cpp/ql/src/semmle/code/cpp/ir/implementation/unaliased_ssa/Instruction.qll
+++ b/cpp/ql/src/semmle/code/cpp/ir/implementation/unaliased_ssa/Instruction.qll
@@ -611,7 +611,7 @@ class VariableInstruction extends Instruction {
 
   override string getImmediateString() { result = var.toString() }
 
-  final IRVariable getVariable() { result = var }
+  final IRVariable getIRVariable() { result = var }
 }
 
 class FieldInstruction extends Instruction {

--- a/cpp/ql/src/semmle/code/cpp/ir/implementation/unaliased_ssa/Instruction.qll
+++ b/cpp/ql/src/semmle/code/cpp/ir/implementation/unaliased_ssa/Instruction.qll
@@ -612,6 +612,11 @@ class VariableInstruction extends Instruction {
   override string getImmediateString() { result = var.toString() }
 
   final IRVariable getIRVariable() { result = var }
+
+  /**
+   * Gets the AST variable that this instruction's IR variable refers to, if one exists.
+   */
+  final Language::Variable getASTVariable() { result = var.(IRUserVariable).getVariable() }
 }
 
 class FieldInstruction extends Instruction {

--- a/cpp/ql/src/semmle/code/cpp/ir/implementation/unaliased_ssa/gvn/ValueNumbering.qll
+++ b/cpp/ql/src/semmle/code/cpp/ir/implementation/unaliased_ssa/gvn/ValueNumbering.qll
@@ -135,14 +135,14 @@ private predicate variableAddressValueNumber(
   VariableAddressInstruction instr, IRFunction irFunc, IRVariable var
 ) {
   instr.getEnclosingIRFunction() = irFunc and
-  instr.getVariable() = var
+  instr.getIRVariable() = var
 }
 
 private predicate initializeParameterValueNumber(
   InitializeParameterInstruction instr, IRFunction irFunc, IRVariable var
 ) {
   instr.getEnclosingIRFunction() = irFunc and
-  instr.getVariable() = var
+  instr.getIRVariable() = var
 }
 
 private predicate initializeThisValueNumber(InitializeThisInstruction instr, IRFunction irFunc) {

--- a/cpp/ql/src/semmle/code/cpp/ir/implementation/unaliased_ssa/internal/AliasAnalysis.qll
+++ b/cpp/ql/src/semmle/code/cpp/ir/implementation/unaliased_ssa/internal/AliasAnalysis.qll
@@ -282,7 +282,7 @@ private predicate automaticVariableAddressEscapes(IRAutomaticVariable var) {
   // The variable's address escapes if the result of any
   // VariableAddressInstruction that computes the variable's address escapes.
   exists(VariableAddressInstruction instr |
-    instr.getVariable() = var and
+    instr.getIRVariable() = var and
     resultEscapesNonReturn(instr)
   )
 }
@@ -305,7 +305,7 @@ predicate variableAddressEscapes(IRVariable var) {
  */
 predicate resultPointsTo(Instruction instr, IRVariable var, IntValue bitOffset) {
   // The address of a variable points to that variable, at offset 0.
-  instr.(VariableAddressInstruction).getVariable() = var and
+  instr.(VariableAddressInstruction).getIRVariable() = var and
   bitOffset = 0
   or
   exists(Operand operand, IntValue originalBitOffset, IntValue propagatedBitOffset |

--- a/cpp/ql/src/semmle/code/cpp/ir/implementation/unaliased_ssa/internal/SSAConstruction.qll
+++ b/cpp/ql/src/semmle/code/cpp/ir/implementation/unaliased_ssa/internal/SSAConstruction.qll
@@ -334,7 +334,7 @@ private module Cached {
   IRVariable getInstructionVariable(Instruction instruction) {
     result = getNewIRVariable(getOldInstruction(instruction)
             .(OldIR::VariableInstruction)
-            .getVariable())
+            .getIRVariable())
   }
 
   cached

--- a/csharp/ql/src/semmle/code/csharp/ir/implementation/raw/Instruction.qll
+++ b/csharp/ql/src/semmle/code/csharp/ir/implementation/raw/Instruction.qll
@@ -611,7 +611,7 @@ class VariableInstruction extends Instruction {
 
   override string getImmediateString() { result = var.toString() }
 
-  final IRVariable getVariable() { result = var }
+  final IRVariable getIRVariable() { result = var }
 }
 
 class FieldInstruction extends Instruction {

--- a/csharp/ql/src/semmle/code/csharp/ir/implementation/raw/Instruction.qll
+++ b/csharp/ql/src/semmle/code/csharp/ir/implementation/raw/Instruction.qll
@@ -612,6 +612,11 @@ class VariableInstruction extends Instruction {
   override string getImmediateString() { result = var.toString() }
 
   final IRVariable getIRVariable() { result = var }
+
+  /**
+   * Gets the AST variable that this instruction's IR variable refers to, if one exists.
+   */
+  final Language::Variable getASTVariable() { result = var.(IRUserVariable).getVariable() }
 }
 
 class FieldInstruction extends Instruction {

--- a/csharp/ql/src/semmle/code/csharp/ir/implementation/unaliased_ssa/Instruction.qll
+++ b/csharp/ql/src/semmle/code/csharp/ir/implementation/unaliased_ssa/Instruction.qll
@@ -611,7 +611,7 @@ class VariableInstruction extends Instruction {
 
   override string getImmediateString() { result = var.toString() }
 
-  final IRVariable getVariable() { result = var }
+  final IRVariable getIRVariable() { result = var }
 }
 
 class FieldInstruction extends Instruction {

--- a/csharp/ql/src/semmle/code/csharp/ir/implementation/unaliased_ssa/Instruction.qll
+++ b/csharp/ql/src/semmle/code/csharp/ir/implementation/unaliased_ssa/Instruction.qll
@@ -612,6 +612,11 @@ class VariableInstruction extends Instruction {
   override string getImmediateString() { result = var.toString() }
 
   final IRVariable getIRVariable() { result = var }
+
+  /**
+   * Gets the AST variable that this instruction's IR variable refers to, if one exists.
+   */
+  final Language::Variable getASTVariable() { result = var.(IRUserVariable).getVariable() }
 }
 
 class FieldInstruction extends Instruction {

--- a/csharp/ql/src/semmle/code/csharp/ir/implementation/unaliased_ssa/gvn/ValueNumbering.qll
+++ b/csharp/ql/src/semmle/code/csharp/ir/implementation/unaliased_ssa/gvn/ValueNumbering.qll
@@ -135,14 +135,14 @@ private predicate variableAddressValueNumber(
   VariableAddressInstruction instr, IRFunction irFunc, IRVariable var
 ) {
   instr.getEnclosingIRFunction() = irFunc and
-  instr.getVariable() = var
+  instr.getIRVariable() = var
 }
 
 private predicate initializeParameterValueNumber(
   InitializeParameterInstruction instr, IRFunction irFunc, IRVariable var
 ) {
   instr.getEnclosingIRFunction() = irFunc and
-  instr.getVariable() = var
+  instr.getIRVariable() = var
 }
 
 private predicate initializeThisValueNumber(InitializeThisInstruction instr, IRFunction irFunc) {

--- a/csharp/ql/src/semmle/code/csharp/ir/implementation/unaliased_ssa/internal/AliasAnalysis.qll
+++ b/csharp/ql/src/semmle/code/csharp/ir/implementation/unaliased_ssa/internal/AliasAnalysis.qll
@@ -269,7 +269,7 @@ private predicate automaticVariableAddressEscapes(IRAutomaticVariable var) {
   // The variable's address escapes if the result of any
   // VariableAddressInstruction that computes the variable's address escapes.
   exists(VariableAddressInstruction instr |
-    instr.getVariable() = var and
+    instr.getIRVariable() = var and
     resultEscapesNonReturn(instr)
   )
 }
@@ -292,7 +292,7 @@ predicate variableAddressEscapes(IRVariable var) {
  */
 predicate resultPointsTo(Instruction instr, IRVariable var, IntValue bitOffset) {
   // The address of a variable points to that variable, at offset 0.
-  instr.(VariableAddressInstruction).getVariable() = var and
+  instr.(VariableAddressInstruction).getIRVariable() = var and
   bitOffset = 0
   or
   exists(Operand operand, IntValue originalBitOffset, IntValue propagatedBitOffset |

--- a/csharp/ql/src/semmle/code/csharp/ir/implementation/unaliased_ssa/internal/SSAConstruction.qll
+++ b/csharp/ql/src/semmle/code/csharp/ir/implementation/unaliased_ssa/internal/SSAConstruction.qll
@@ -337,7 +337,7 @@ private module Cached {
   IRVariable getInstructionVariable(Instruction instruction) {
     result = getNewIRVariable(getOldInstruction(instruction)
             .(OldIR::VariableInstruction)
-            .getVariable())
+            .getIRVariable())
   }
 
   cached


### PR DESCRIPTION
This makes the distinction between IR variables and AST variables explicit in `VariableInstruction`, and simplifies getting an AST variable from a `VariableInstruction`. `vai.getVariable().(IRUserVariable).getVariable() = v` can be replaced with `vai.getASTVariable() = v` after this change.