### PR TITLE
C#: Fix an InvalidCastException

### DIFF
--- a/csharp/extractor/Semmle.Extraction.CSharp/Entities/Property.cs
+++ b/csharp/extractor/Semmle.Extraction.CSharp/Entities/Property.cs
@@ -111,7 +111,7 @@ namespace Semmle.Extraction.CSharp.Entities
 
         public static Property Create(Context cx, IPropertySymbol prop)
         {
-            bool isIndexer = prop.IsIndexer || prop.ExplicitInterfaceImplementations.Any(e => e.IsIndexer);
+            bool isIndexer = prop.IsIndexer || prop.ExplicitInterfaceImplementations.Any(e => e.IsIndexer) || prop.Parameters.Any();
 
             return isIndexer ? Indexer.Create(cx, prop) : PropertyFactory.Instance.CreateEntity(cx, prop);
         }

--- a/csharp/extractor/Semmle.Extraction.CSharp/Entities/Property.cs
+++ b/csharp/extractor/Semmle.Extraction.CSharp/Entities/Property.cs
@@ -111,7 +111,7 @@ namespace Semmle.Extraction.CSharp.Entities
 
         public static Property Create(Context cx, IPropertySymbol prop)
         {
-            bool isIndexer = prop.IsIndexer || prop.ExplicitInterfaceImplementations.Any(e => e.IsIndexer) || prop.Parameters.Any();
+            bool isIndexer = prop.IsIndexer || prop.Parameters.Any();
 
             return isIndexer ? Indexer.Create(cx, prop) : PropertyFactory.Instance.CreateEntity(cx, prop);
         }


### PR DESCRIPTION
Works around a bug in Roslyn whereby `IPropertySymbol.IsIndexer` would yield erroneous results, resulting in
```
Unable to cast object of type 'Semmle.Extraction.CSharp.Entities.Property' to type 'Semmle.Extraction.CSharp.Entities.Indexer'.
```
appearing in `csharp.log`.

Unable to reproduce in a qltest.

