### PR TITLE
C#: Adjust local function TRAP labels

### DIFF
--- a/csharp/extractor/Semmle.Extraction.CSharp/Entities/LocalFunction.cs
+++ b/csharp/extractor/Semmle.Extraction.CSharp/Entities/LocalFunction.cs
@@ -19,9 +19,8 @@ namespace Semmle.Extraction.CSharp.Entities
         public override void WriteId(TextWriter trapFile)
         {
             trapFile.WriteSubId(ContainingMethod);
-            trapFile.Write(".(");
+            trapFile.Write(".");
             trapFile.WriteSubId(Location);
-            trapFile.Write(')');
             if (symbol.IsGenericMethod && !IsSourceDeclaration)
             {
                 trapFile.Write('<');


### PR DESCRIPTION
Follow-up on https://github.com/Semmle/ql/pull/2061. This fixes TRAP import errors like:
```
[2019-10-06 10:43:44] [ERROR] Autobuilder.cs.trap.gz, 6093: Expected '(' and not LABEL
                              com.semmle.util.exception.CatastrophicError: Expected '(' and not LABEL
                                at com.semmle.inmemory.trap.TRAPReader.expectToken(TRAPReader.java:710)
                                at com.semmle.inmemory.trap.TRAPReader.scanTuple(TRAPReader.java:485)
                                at com.semmle.inmemory.trap.TRAPReader.scanTuplesAndLabels(TRAPReader.java:450)
                                at com.semmle.inmemory.trap.TRAPReader.importTuples(TRAPReader.java:384)
                                at com.semmle.inmemory.trap.DirectImporter.process(DirectImporter.java:158)
                                at com.semmle.inmemory.trap.DirectImporter.lambda$importTrap$0(DirectImporter.java:117)
                                at com.semmle.util.concurrent.FutureUtils.lambda$null$8(FutureUtils.java:137)
                                at java.util.concurrent.CompletableFuture$AsyncSupply.run(CompletableFuture.java:1590)
                                at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
                                at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
                                at java.lang.Thread.run(Thread.java:748)
```