### PR TITLE
C#: Use containing type instead of containing method in local function TRAP label

### DIFF
--- a/csharp/extractor/Semmle.Extraction.CSharp/Entities/LocalFunction.cs
+++ b/csharp/extractor/Semmle.Extraction.CSharp/Entities/LocalFunction.cs
@@ -11,17 +11,11 @@ namespace Semmle.Extraction.CSharp.Entities
         {
         }
 
-        Method ContainingMethod =>
-            symbol.OriginalDefinition.ContainingSymbol is IMethodSymbol m
-            ? Method.Create(Context, m)
-            : throw new InternalError(symbol, "Unable to determine local function's containing callable");
-
         public override void WriteId(TextWriter trapFile)
         {
-            trapFile.WriteSubId(ContainingMethod);
-            trapFile.Write(".(");
+            trapFile.WriteSubId(ContainingType);
+            trapFile.Write(".");
             trapFile.WriteSubId(Location);
-            trapFile.Write(')');
             if (symbol.IsGenericMethod && !IsSourceDeclaration)
             {
                 trapFile.Write('<');

--- a/csharp/ql/test/library-tests/csharp7/CSharp7.cs
+++ b/csharp/ql/test/library-tests/csharp7/CSharp7.cs
@@ -148,9 +148,9 @@ class LocalFunctions
             return f9(1);
         }
 
-        {
+        Action a = () => {
             int f9() => 0;
-        }
+        };
 
         return f1(2);
     }

--- a/csharp/ql/test/library-tests/csharp7/LocalFunctions.expected
+++ b/csharp/ql/test/library-tests/csharp7/LocalFunctions.expected
@@ -5,7 +5,7 @@
 | CSharp7.cs:143:9:143:31 | f7 | f7 | Int32 | CSharp7.cs:130:5:156:5 | {...} | CSharp7.cs:143:9:143:31 | f7(...) | f7(int) |
 | CSharp7.cs:145:9:149:9 | f8 | f8 | Int32 | CSharp7.cs:130:5:156:5 | {...} | CSharp7.cs:145:9:149:9 | f8(...) | f8() |
 | CSharp7.cs:147:13:147:35 | f9 | f9 | Int32 | CSharp7.cs:146:9:149:9 | {...} | CSharp7.cs:147:13:147:35 | f9(...) | f9(int) |
-| CSharp7.cs:152:13:152:26 | f9 | f9 | Int32 | CSharp7.cs:151:9:153:9 | {...} | CSharp7.cs:152:13:152:26 | f9(...) | f9() |
+| CSharp7.cs:152:13:152:26 | f9 | f9 | Int32 | CSharp7.cs:151:26:153:9 | {...} | CSharp7.cs:152:13:152:26 | f9(...) | f9() |
 | CSharp7.cs:160:9:160:24 | f | f | Int32 | CSharp7.cs:159:5:172:5 | {...} | CSharp7.cs:160:9:160:24 | f(...) | f() |
 | CSharp7.cs:160:9:160:24 | f | f | Int32 | CSharp7.cs:159:5:172:5 | {...} | CSharp7.cs:160:9:160:24 | f(...) | f() |
 | CSharp7.cs:161:9:161:25 | g | g | T | CSharp7.cs:159:5:172:5 | {...} | CSharp7.cs:161:9:161:25 | g(...) | g(T) |

--- a/csharp/ql/test/library-tests/csharp7/LocalVariables.expected
+++ b/csharp/ql/test/library-tests/csharp7/LocalVariables.expected
@@ -35,6 +35,7 @@
 | CSharp7.cs:123:16:123:18 | m13 | string |
 | CSharp7.cs:135:19:135:20 | f4 | Func<int> |
 | CSharp7.cs:139:24:139:25 | f5 | Func<int, int> |
+| CSharp7.cs:151:16:151:16 | a | Action |
 | CSharp7.cs:176:16:176:18 | src | string |
 | CSharp7.cs:181:13:181:17 | sink1 | string |
 | CSharp7.cs:182:13:182:17 | sink2 | string |


### PR DESCRIPTION
This is in order to handle the case where the enclosing callable of a local function is a lambda expression.

This PR is a proper fix for the error attempted fixed by https://github.com/Semmle/ql/pull/2089.