### PR TITLE
Python: Fix hasFlowPath default implementation of isSink/2

### DIFF
--- a/python/ql/src/semmle/python/dataflow/Configuration.qll
+++ b/python/ql/src/semmle/python/dataflow/Configuration.qll
@@ -51,6 +51,7 @@ module TaintTracking {
          */
         predicate isSink(DataFlow::Node node, TaintKind kind) {
             exists(TaintSink sink |
+                this.isSink(sink) and
                 node.asCfgNode() = sink and
                 sink.sinks(kind)
             )

--- a/python/ql/test/library-tests/taint/flowpath_regression/Config.qll
+++ b/python/ql/test/library-tests/taint/flowpath_regression/Config.qll
@@ -1,0 +1,45 @@
+import python
+import semmle.python.security.TaintTracking
+import semmle.python.security.strings.Untrusted
+
+class FooSource extends TaintSource {
+    FooSource() { this.(CallNode).getFunction().(NameNode).getId() = "foo_source" }
+
+    override predicate isSourceOf(TaintKind kind) { kind instanceof UntrustedStringKind }
+
+    override string toString() { result = "FooSource" }
+}
+
+class FooSink extends TaintSink {
+    FooSink() {
+        exists(CallNode call |
+            call.getFunction().(NameNode).getId() = "foo_sink" and
+            call.getAnArg() = this
+        )
+    }
+
+    override predicate sinks(TaintKind kind) { kind instanceof UntrustedStringKind }
+
+    override string toString() { result = "FooSink" }
+}
+
+class FooConfig extends TaintTracking::Configuration {
+    FooConfig() { this = "FooConfig" }
+
+    override predicate isSource(TaintTracking::Source source) { source instanceof FooSource }
+
+    override predicate isSink(TaintTracking::Sink sink) { sink instanceof FooSink }
+}
+
+class BarSink extends TaintSink {
+    BarSink() {
+        exists(CallNode call |
+            call.getFunction().(NameNode).getId() = "bar_sink" and
+            call.getAnArg() = this
+        )
+    }
+
+    override predicate sinks(TaintKind kind) { kind instanceof UntrustedStringKind }
+
+    override string toString() { result = "BarSink" }
+}

--- a/python/ql/test/library-tests/taint/flowpath_regression/Path.expected
+++ b/python/ql/test/library-tests/taint/flowpath_regression/Path.expected
@@ -1,0 +1,1 @@
+| test.py:16:9:16:20 | foo_source() | test.py:17:14:17:14 | x |

--- a/python/ql/test/library-tests/taint/flowpath_regression/Path.ql
+++ b/python/ql/test/library-tests/taint/flowpath_regression/Path.ql
@@ -1,0 +1,6 @@
+import python
+import Config
+
+from FooConfig config, TaintedPathSource src, TaintedPathSink sink
+where config.hasFlowPath(src, sink)
+select src.getSource(), sink.getSink()

--- a/python/ql/test/library-tests/taint/flowpath_regression/test.py
+++ b/python/ql/test/library-tests/taint/flowpath_regression/test.py
@@ -1,0 +1,22 @@
+def foo_source():
+    return 'foo'
+
+
+def foo_sink(x):
+    if x == 'foo':
+        print('fire the foo missiles')
+
+
+def bar_sink(x):
+    if x == 'bar':
+        print('fire the bar missiles')
+
+
+def should_report():
+    x = foo_source()
+    foo_sink(x)
+
+
+def should_not_report():
+    x = foo_source()
+    bar_sink(x)


### PR DESCRIPTION
If hasFlowPath was used, and isSink/2 was not overridden,
hasFlowPath(src, sink) would not use isSink/1 to restrict the allowed TaintSink.
This resulted in false-positives when we had flows with unrelated TaintSinks.

FP: https://lgtm.com/projects/g/graphite-project/graphite-web/snapshot/1a8e7ffc2eab2210a73f30b03e9cdeb520a02057/files/webapp/graphite/dashboard/views.py#x2d486922081db956:1

Fixes https://github.com/Semmle/ql/issues/2081

---

@taus-semmle I put this as a draft pull request, since I am not 100% sure what the consequences of changing such a fundamental predicate will be. It does resolve the problems in the graphite snapshot, but other than that I have not run tests locally yet