### PR TITLE
JS: Call graph changes

### DIFF
--- a/javascript/ql/src/LanguageFeatures/IllegalInvocation.ql
+++ b/javascript/ql/src/LanguageFeatures/IllegalInvocation.ql
@@ -61,5 +61,7 @@ where
   forex(DataFlow::InvokeNode cs2, Function otherCallee |
     cs2.getInvokeExpr() = cs.getInvokeExpr() and otherCallee = cs2.getACallee() |
     illegalInvocation(cs, otherCallee, _, _)
-  )
+  ) and
+  // require that all callees are known
+  not cs.isIncomplete()
 select cs, "Illegal invocation of $@ " + how + ".", callee, calleeDesc

--- a/javascript/ql/src/meta/analysis-quality/CallGraphQuality.qll
+++ b/javascript/ql/src/meta/analysis-quality/CallGraphQuality.qll
@@ -48,97 +48,6 @@ class RelevantFunction extends Function {
 }
 
 /**
- * Holds if `name` is a the name of an external module.
- */
-predicate isExternalLibrary(string name) {
-  // Mentioned in package.json
-  any(Dependency dep).info(name, _) or
-  // Node.js built-in
-  name = "assert" or
-  name = "async_hooks" or
-  name = "child_process" or
-  name = "cluster" or
-  name = "crypto" or
-  name = "dns" or
-  name = "domain" or
-  name = "events" or
-  name = "fs" or
-  name = "http" or
-  name = "http2" or
-  name = "https" or
-  name = "inspector" or
-  name = "net" or
-  name = "os" or
-  name = "path" or
-  name = "perf_hooks" or
-  name = "process" or
-  name = "punycode" or
-  name = "querystring" or
-  name = "readline" or
-  name = "repl" or
-  name = "stream" or
-  name = "string_decoder" or
-  name = "timer" or
-  name = "tls" or
-  name = "trace_events" or
-  name = "tty" or
-  name = "dgram" or
-  name = "url" or
-  name = "util" or
-  name = "v8" or
-  name = "vm" or
-  name = "worker_threads" or
-  name = "zlib"
-}
-
-/**
- * Holds if the global variable `name` is defined externally.
- */
-predicate isExternalGlobal(string name) {
-  exists(ExternalGlobalDecl decl | decl.getName() = name)
-  or
-  exists(Dependency dep |
-    // If name is never assigned anywhere, and it coincides with a dependency,
-    // it's most likely coming from there.
-    dep.info(name, _) and
-    not exists(Assignment assign | assign.getLhs().(GlobalVarAccess).getName() = name)
-  )
-  or
-  name = "_"
-}
-
-/**
- * Gets a node that was derived from an import of `moduleName`.
- *
- * This is a rough approximation as it follows all property reads, invocations,
- * and callbacks, so some of these might refer to internal objects.
- *
- * Additionally, we don't recognize when a project imports another file in the
- * same project using its module name (for example import "vscode" from inside the vscode project).
- */
-SourceNode externalNode() {
-  exists(string moduleName |
-    result = moduleImport(moduleName) and
-    isExternalLibrary(moduleName)
-  )
-  or
-  exists(string name |
-    result = globalVarRef(name) and
-    isExternalGlobal(name)
-  )
-  or
-  result = DOM::domValueRef()
-  or
-  result = jquery()
-  or
-  result = externalNode().getAPropertyRead()
-  or
-  result = externalNode().getAnInvocation()
-  or
-  result = externalNode().(InvokeNode).getCallback(_).getParameter(_)
-}
-
-/**
  * Gets a data flow node that can be resolved to a function, usually a callback.
  *
  * These are not part of the static call graph, but the data flow analysis can
@@ -193,46 +102,12 @@ class ResolvableCall extends RelevantInvoke {
 }
 
 /**
- * A call site that is believed to call an external function.
- */
-class ExternalCall extends RelevantInvoke {
-  ExternalCall() {
-    not this instanceof ResolvableCall and // avoid double counting
-    (
-      // Call to modelled external library
-      this = externalNode()
-      or
-      // 'require' call or similar
-      this = moduleImport(_)
-      or
-      // Resolved to externs file
-      exists(this.(InvokeNode).getACallee(1))
-      or
-      // Modelled as taint step but isn't from an NPM module, for example, `substring` or `push`.
-      exists(TaintTracking::AdditionalTaintStep step |
-        step.step(_, this)
-        or
-        step.step(this.getAnArgument(), _)
-      )
-    )
-  }
-}
-
-/**
  * A call site that could not be resolved.
  */
 class UnresolvableCall extends RelevantInvoke {
   UnresolvableCall() {
-    not this instanceof ResolvableCall and
-    not this instanceof ExternalCall
+    not this instanceof ResolvableCall
   }
-}
-
-/**
- * A call that is believed to call a function within the same project.
- */
-class NonExternalCall extends RelevantInvoke {
-  NonExternalCall() { not this instanceof ExternalCall }
 }
 
 /**

--- a/javascript/ql/src/meta/analysis-quality/CallGraphQuality.qll
+++ b/javascript/ql/src/meta/analysis-quality/CallGraphQuality.qll
@@ -76,7 +76,7 @@ SourceNode nodeLeadingToInvocation() {
     result.flowsTo(arg)
   )
   or
-  exists(AdditionalPartialInvokeNode invoke, Node arg |
+  exists(PartialInvokeNode invoke, Node arg |
     invoke.isPartialArgument(arg, _, _) and
     result.flowsTo(arg)
   )

--- a/javascript/ql/src/semmle/javascript/Closure.qll
+++ b/javascript/ql/src/semmle/javascript/Closure.qll
@@ -248,4 +248,25 @@ module Closure {
   DataFlow::SourceNode moduleImport(string moduleName) {
     getClosureNamespaceFromSourceNode(result) = moduleName
   }
+
+  /**
+   * A call to `goog.bind`, as a partial function invocation.
+   */
+  private class BindCall extends DataFlow::PartialInvokeNode::Range, DataFlow::CallNode {
+    BindCall() { this = moduleImport("goog.bind").getACall() }
+
+    override predicate isPartialArgument(DataFlow::Node callback, DataFlow::Node argument, int index) {
+      index >= 0 and
+      callback = getArgument(0) and
+      argument = getArgument(index + 2)
+    }
+
+    override DataFlow::SourceNode getBoundFunction(DataFlow::Node callback, int boundArgs) {
+      boundArgs = getNumArgument() - 2 and
+      callback = getArgument(0) and
+      result = this
+    }
+
+    override DataFlow::Node getBoundReceiver() { result = getArgument(1) }
+  }
 }

--- a/javascript/ql/src/semmle/javascript/dataflow/Configuration.qll
+++ b/javascript/ql/src/semmle/javascript/dataflow/Configuration.qll
@@ -433,18 +433,6 @@ abstract class AdditionalSink extends DataFlow::Node {
 }
 
 /**
- * An invocation that is modeled as a partial function application.
- *
- * This contributes additional argument-passing flow edges that should be added to all data flow configurations.
- */
-abstract class AdditionalPartialInvokeNode extends DataFlow::InvokeNode {
-  /**
-   * Holds if `argument` is passed as argument `index` to the function in `callback`.
-   */
-  abstract predicate isPartialArgument(DataFlow::Node callback, DataFlow::Node argument, int index);
-}
-
-/**
  * Additional flow step to model flow from import specifiers into the SSA variable
  * corresponding to the imported variable.
  */
@@ -454,45 +442,6 @@ private class FlowStepThroughImport extends AdditionalFlowStep, DataFlow::ValueN
   override predicate step(DataFlow::Node pred, DataFlow::Node succ) {
     pred = this and
     succ = DataFlow::ssaDefinitionNode(SSA::definition(astNode))
-  }
-}
-
-/**
- * A partial call through the built-in `Function.prototype.bind`.
- */
-private class BindPartialCall extends AdditionalPartialInvokeNode, DataFlow::MethodCallNode {
-  BindPartialCall() { getMethodName() = "bind" }
-
-  override predicate isPartialArgument(DataFlow::Node callback, DataFlow::Node argument, int index) {
-    callback = getReceiver() and
-    argument = getArgument(index + 1)
-  }
-}
-
-/**
- * A partial call through `_.partial`.
- */
-private class LodashPartialCall extends AdditionalPartialInvokeNode {
-  LodashPartialCall() { this = LodashUnderscore::member("partial").getACall() }
-
-  override predicate isPartialArgument(DataFlow::Node callback, DataFlow::Node argument, int index) {
-    callback = getArgument(0) and
-    argument = getArgument(index + 1)
-  }
-}
-
-/**
- * A partial call through `ramda.partial`.
- */
-private class RamdaPartialCall extends AdditionalPartialInvokeNode {
-  RamdaPartialCall() { this = DataFlow::moduleMember("ramda", "partial").getACall() }
-
-  override predicate isPartialArgument(DataFlow::Node callback, DataFlow::Node argument, int index) {
-    callback = getArgument(0) and
-    exists(DataFlow::ArrayCreationNode array |
-      array.flowsTo(getArgument(1)) and
-      argument = array.getElement(index)
-    )
   }
 }
 

--- a/javascript/ql/src/semmle/javascript/dataflow/DataFlow.qll
+++ b/javascript/ql/src/semmle/javascript/dataflow/DataFlow.qll
@@ -127,6 +127,8 @@ module DataFlow {
      * possibly derived from a partial function invocation.
      */
     final FunctionNode getABoundFunctionValue(int boundArgs) {
+      result = getAFunctionValue() and boundArgs = 0
+      or
       CallGraph::getABoundFunctionReference(result, boundArgs).flowsTo(this)
     }
 

--- a/javascript/ql/src/semmle/javascript/dataflow/DataFlow.qll
+++ b/javascript/ql/src/semmle/javascript/dataflow/DataFlow.qll
@@ -122,6 +122,11 @@ module DataFlow {
       CallGraph::getAFunctionReference(result, 0).flowsTo(this)
     }
 
+    /** Gets a function value that may reach this node with the given `imprecision` level. */
+    final FunctionNode getAFunctionValue(int imprecision) {
+      CallGraph::getAFunctionReference(result, imprecision).flowsTo(this)
+    }
+
     /**
      * Gets a function value that may reach this node,
      * possibly derived from a partial function invocation.

--- a/javascript/ql/src/semmle/javascript/dataflow/DataFlow.qll
+++ b/javascript/ql/src/semmle/javascript/dataflow/DataFlow.qll
@@ -19,6 +19,7 @@
  */
 
 import javascript
+private import internal.CallGraphs
 
 module DataFlow {
   cached
@@ -118,57 +119,15 @@ module DataFlow {
 
     /** Gets a function value that may reach this node. */
     final FunctionNode getAFunctionValue() {
-      result = getAFunctionValue(_)
+      CallGraph::getAFunctionReference(result, 0).flowsTo(this)
     }
 
     /**
-     * Gets a function value that may reach this node.
-     *
-     * This predicate may be overridden to customize the call graph.
-     *
-     * Note that any additional values added by overiding predicates will not
-     * be propagated along data flow edges.
-     *
-     * `imprecision` is a heuristic measure of how likely it is that `callee`
-     * is only suggested as a potential callee due to
-     * imprecise analysis of global variables and is not, in fact, a viable callee at all.
+     * Gets a function value that may reach this node,
+     * possibly derived from a partial function invocation.
      */
-    cached
-    FunctionNode getAFunctionValue(int imprecision) {
-      exists(Function fun |
-        result = fun.flow() and
-        fun = analyze().getAValue().(AbstractCallable).getFunction()
-      |
-        if analyze().getAValue().isIndefinite("global") then
-          fun.getFile() = getFile() and imprecision = 0
-          or
-          fun.inExternsFile() and imprecision = 1
-          or
-          imprecision = 2
-        else
-          imprecision = 0
-      )
-      or
-      imprecision = 0 and
-      exists(string name |
-        GlobalAccessPath::isAssignedInUniqueFile(name) and
-        GlobalAccessPath::fromRhs(result) = name and
-        GlobalAccessPath::fromReference(this) = name
-      )
-      or
-      imprecision = 0 and
-      exists(DataFlow::ClassNode cls |
-        exists(string name |
-          cls.getAnInstanceMemberAccess(name).flowsTo(this) and
-          result = cls.getInstanceMethod(name)
-          or
-          cls.getAStaticMemberAccess(name).flowsTo(this) and
-          result = cls.getStaticMethod(name)
-        )
-        or
-        cls.getAClassReference().flowsTo(this) and
-        result = cls.getConstructor()
-      )
+    final FunctionNode getABoundFunctionValue(int boundArgs) {
+      CallGraph::getABoundFunctionReference(result, boundArgs).flowsTo(this)
     }
 
     /**

--- a/javascript/ql/src/semmle/javascript/dataflow/Nodes.qll
+++ b/javascript/ql/src/semmle/javascript/dataflow/Nodes.qll
@@ -141,19 +141,8 @@ class InvokeNode extends DataFlow::SourceNode {
    * This predicate can be overridden to alter the call graph used by the interprocedural
    * data flow libraries.
    */
-  cached
   Function getACallee(int imprecision) {
-    CallGraph::getAFunctionReference(result.flow(), imprecision).flowsTo(getCalleeNode())
-    or
-    imprecision = 0 and
-    exists(InvokeExpr expr | expr = this.(DataFlow::Impl::ExplicitInvokeNode).asExpr() |
-      result = expr.getResolvedCallee()
-      or
-      exists(DataFlow::ClassNode cls |
-        expr.(SuperCall).getBinder() = cls.getConstructor().getFunction() and
-        result = cls.getADirectSuperClass().getConstructor().getFunction()
-      )
-    )
+    result = CallGraph::getACallee(this, imprecision).getFunction()
   }
 
   /**

--- a/javascript/ql/src/semmle/javascript/dataflow/Nodes.qll
+++ b/javascript/ql/src/semmle/javascript/dataflow/Nodes.qll
@@ -1054,7 +1054,13 @@ module PartialInvokeNode {
   * A partial call through the built-in `Function.prototype.bind`.
   */
   private class BindPartialCall extends PartialInvokeNode::Range, DataFlow::MethodCallNode {
-    BindPartialCall() { getMethodName() = "bind" }
+    BindPartialCall() {
+      getMethodName() = "bind" and
+
+      // Avoid overlap with angular.bind and goog.bind
+      not this = AngularJS::angular().getAMethodCall() and
+      not getReceiver().accessesGlobal("goog")
+    }
 
     override predicate isPartialArgument(DataFlow::Node callback, DataFlow::Node argument, int index) {
       index >= 0 and
@@ -1086,7 +1092,7 @@ module PartialInvokeNode {
     }
 
     override DataFlow::SourceNode getBoundFunction(DataFlow::Node callback, int boundArgs) {
-      callback = getReceiver() and
+      callback = getArgument(0) and
       boundArgs = getNumArgument() - 1 and
       result = this
     }

--- a/javascript/ql/src/semmle/javascript/dataflow/Nodes.qll
+++ b/javascript/ql/src/semmle/javascript/dataflow/Nodes.qll
@@ -674,7 +674,12 @@ class ClassNode extends DataFlow::SourceNode {
    */
   DataFlow::SourceNode getAClassReference(DataFlow::TypeTracker t) {
     t.start() and
-    result.(AnalyzedNode).getAValue() = getAbstractClassValue()
+    result.(AnalyzedNode).getAValue() = getAbstractClassValue() and
+    (
+      not CallGraph::isIndefiniteGlobal(result)
+      or
+      result.getAstNode().getFile() = this.getAstNode().getFile()
+    )
     or
     exists(DataFlow::TypeTracker t2 | result = getAClassReference(t2).track(t2, t))
   }

--- a/javascript/ql/src/semmle/javascript/dataflow/Nodes.qll
+++ b/javascript/ql/src/semmle/javascript/dataflow/Nodes.qll
@@ -983,73 +983,132 @@ module ClassNode {
 }
 
 /**
+ * A data flow node that performs a partial function application.
+ *
+ * Examples:
+ * ```
+ * fn.bind(this)
+ * x.method.bind(x)
+ * _.partial(fn, x, y, z)
+ * ```
+ */
+class PartialInvokeNode extends DataFlow::Node {
+  PartialInvokeNode::Range range;
+
+  PartialInvokeNode() { this = range }
+
+  /**
+   * Holds if `argument` is passed as argument `index` to the function in `callback`.
+   */
+  predicate isPartialArgument(DataFlow::Node callback, DataFlow::Node argument, int index) {
+    range.isPartialArgument(callback, argument, index)
+  }
+
+  /**
+   * Gets a node referring to a bound version of `callback` with `boundArgs` arguments bound.
+   */
+  DataFlow::SourceNode getBoundFunction(DataFlow::Node callback, int boundArgs) {
+    result = range.getBoundFunction(callback, boundArgs)
+  }
+
+  /**
+   * Gets the node holding the receiver to be passed to the bound function, if specified.
+   */
+  DataFlow::Node getBoundReceiver() { result = range.getBoundReceiver() }
+}
+
+module PartialInvokeNode {
+  /**
+   * A data flow node that performs a partial function application.
+   */
+  abstract class Range extends DataFlow::Node {
+    /**
+     * Holds if `argument` is passed as argument `index` to the function in `callback`.
+     */
+    predicate isPartialArgument(DataFlow::Node callback, DataFlow::Node argument, int index) { none() }
+
+    /**
+     * Gets a node referring to a bound version of `callback` with `boundArgs` arguments bound.
+     */
+    DataFlow::SourceNode getBoundFunction(DataFlow::Node callback, int boundArgs) { none() }
+
+    /**
+     * Gets the node holding the receiver to be passed to the bound function, if specified.
+     */
+    DataFlow::Node getBoundReceiver() { none() }
+  }
+
+  /**
+  * A partial call through the built-in `Function.prototype.bind`.
+  */
+  private class BindPartialCall extends PartialInvokeNode::Range, DataFlow::MethodCallNode {
+    BindPartialCall() { getMethodName() = "bind" }
+
+    override predicate isPartialArgument(DataFlow::Node callback, DataFlow::Node argument, int index) {
+      index >= 0 and
+      callback = getReceiver() and
+      argument = getArgument(index + 1)
+    }
+
+    override DataFlow::SourceNode getBoundFunction(DataFlow::Node callback, int boundArgs) {
+      callback = getReceiver() and
+      boundArgs = getNumArgument() - 1 and
+      result = this
+    }
+
+    override DataFlow::Node getBoundReceiver() {
+      result = getArgument(0)
+    }
+  }
+
+  /**
+  * A partial call through `_.partial`.
+  */
+  private class LodashPartialCall extends PartialInvokeNode::Range, DataFlow::CallNode {
+    LodashPartialCall() { this = LodashUnderscore::member("partial").getACall() }
+
+    override predicate isPartialArgument(DataFlow::Node callback, DataFlow::Node argument, int index) {
+      index >= 0 and
+      callback = getArgument(0) and
+      argument = getArgument(index + 1)
+    }
+
+    override DataFlow::SourceNode getBoundFunction(DataFlow::Node callback, int boundArgs) {
+      callback = getReceiver() and
+      boundArgs = getNumArgument() - 1 and
+      result = this
+    }
+  }
+
+  /**
+   * A partial call through `ramda.partial`.
+   */
+  private class RamdaPartialCall extends PartialInvokeNode::Range, DataFlow::CallNode {
+    RamdaPartialCall() { this = DataFlow::moduleMember("ramda", "partial").getACall() }
+
+    private DataFlow::ArrayCreationNode getArgumentsArray() {
+      result.flowsTo(getArgument(1))
+    }
+
+    override predicate isPartialArgument(DataFlow::Node callback, DataFlow::Node argument, int index) {
+      callback = getArgument(0) and
+      argument = getArgumentsArray().getElement(index)
+    }
+
+    override DataFlow::SourceNode getBoundFunction(DataFlow::Node callback, int boundArgs) {
+      callback = getArgument(0) and
+      boundArgs = getArgumentsArray().getSize() and
+      result = this
+    }
+  }
+}
+
+/**
+ * DEPRECATED. Subclasses should extend `PartialInvokeNode::Range` instead,
+ * and predicates should use `PartialInvokeNode` instead.
+ *
  * An invocation that is modeled as a partial function application.
  *
  * This contributes additional argument-passing flow edges that should be added to all data flow configurations.
  */
-abstract class AdditionalPartialInvokeNode extends DataFlow::InvokeNode {
-  /**
-   * Holds if `argument` is passed as argument `index` to the function in `callback`.
-   */
-  abstract predicate isPartialArgument(DataFlow::Node callback, DataFlow::Node argument, int index);
-
-  /** Gets the data flow node referring to the bound function, if such a node exists. */
-  DataFlow::SourceNode getBoundFunction(int boundArgs) { none() }
-}
-
-/**
- * A partial call through the built-in `Function.prototype.bind`.
- */
-private class BindPartialCall extends AdditionalPartialInvokeNode, DataFlow::MethodCallNode {
-  BindPartialCall() { getMethodName() = "bind" }
-
-  override predicate isPartialArgument(DataFlow::Node callback, DataFlow::Node argument, int index) {
-    index >= 0 and
-    callback = getReceiver() and
-    argument = getArgument(index + 1)
-  }
-
-  override DataFlow::SourceNode getBoundFunction(int boundArgs) {
-    boundArgs = getNumArgument() - 1 and
-    result = this
-  }
-}
-
-/**
- * A partial call through `_.partial`.
- */
-private class LodashPartialCall extends AdditionalPartialInvokeNode {
-  LodashPartialCall() { this = LodashUnderscore::member("partial").getACall() }
-
-  override predicate isPartialArgument(DataFlow::Node callback, DataFlow::Node argument, int index) {
-    index >= 0 and
-    callback = getArgument(0) and
-    argument = getArgument(index + 1)
-  }
-
-  override DataFlow::SourceNode getBoundFunction(int boundArgs) {
-    boundArgs = getNumArgument() - 1 and
-    result = this
-  }
-}
-
-/**
- * A partial call through `ramda.partial`.
- */
-private class RamdaPartialCall extends AdditionalPartialInvokeNode {
-  RamdaPartialCall() { this = DataFlow::moduleMember("ramda", "partial").getACall() }
-
-  private DataFlow::ArrayCreationNode getArgumentsArray() {
-    result.flowsTo(getArgument(1))
-  }
-
-  override predicate isPartialArgument(DataFlow::Node callback, DataFlow::Node argument, int index) {
-    callback = getArgument(0) and
-    argument = getArgumentsArray().getElement(index)
-  }
-
-  override DataFlow::SourceNode getBoundFunction(int boundArgs) {
-    boundArgs = getArgumentsArray().getSize() and
-    result = this
-  }
-}
+deprecated class AdditionalPartialInvokeNode = PartialInvokeNode::Range;

--- a/javascript/ql/src/semmle/javascript/dataflow/Nodes.qll
+++ b/javascript/ql/src/semmle/javascript/dataflow/Nodes.qll
@@ -94,13 +94,32 @@ class InvokeNode extends DataFlow::SourceNode {
    * Gets a function passed as the `i`th argument of this invocation.
    *
    * This predicate only performs local data flow tracking.
-   * Use `getACallbackSource` to handle interprocedural flow of callback functions.
+   * Consider using `getABoundCallbackParameter` to handle interprocedural flow of callback functions.
    */
   FunctionNode getCallback(int i) { result.flowsTo(getArgument(i)) }
 
   /**
-   * Gets a function passed as the `i`th argument of this invocation,
-   * possibly through non-local data flow and bound by partial function invocations.
+   * Gets a parameter of a callback passed into this call.
+   *
+   * `callback` indicates which argument the callback passed into, and `param`
+   * is the index of the parameter in the callback function.
+   *
+   * For example, for the call below, `getABoundCallbackParameter(1, 0)` refers
+   * to the parameter `e` (the first parameter of the second callback argument):
+   * ```js
+   * addEventHandler("click", e => { ... })
+   * ```
+   *
+   * This predicate takes interprocedural data flow into account, as well as
+   * partial function applications such as `.bind`.
+   *
+   * For example, for the call below `getABoundCallbackParameter(1, 0)` returns the parameter `e`,
+   * (the first parameter of the second callback argument), since the first parameter of `foo`
+   * has been bound by the `bind` call:
+   * ```js
+   * function foo(x, e) { }
+   * addEventHandler("click", foo.bind(this, "value of x"))
+   * ```
    */
   ParameterNode getABoundCallbackParameter(int callback, int param) {
     exists(int boundArgs |

--- a/javascript/ql/src/semmle/javascript/dataflow/Nodes.qll
+++ b/javascript/ql/src/semmle/javascript/dataflow/Nodes.qll
@@ -147,7 +147,7 @@ class InvokeNode extends DataFlow::SourceNode {
    * To alter the call graph as seen by the interprocedural data flow libraries, override
    * the `getACallee(int imprecision)` predicate instead.
    */
-  final Function getACallee() { result = getACallee(_) }
+  final Function getACallee() { result = getACallee(0) }
 
   /**
    * Gets a callee of this call site where `imprecision` is a heuristic measure of how
@@ -155,7 +155,8 @@ class InvokeNode extends DataFlow::SourceNode {
    * imprecise analysis of global variables and is not, in fact, a viable callee at all.
    *
    * Callees with imprecision zero, in particular, have either been derived without
-   * considering global variables, or are calls to a global variable within the same file.
+   * considering global variables, or are calls to a global variable within the same file,
+   * or a global variable that has unique definition within the project.
    *
    * This predicate can be overridden to alter the call graph used by the interprocedural
    * data flow libraries.

--- a/javascript/ql/src/semmle/javascript/dataflow/TypeTracking.qll
+++ b/javascript/ql/src/semmle/javascript/dataflow/TypeTracking.qll
@@ -55,6 +55,7 @@ module StepSummary {
   /**
    * INTERNAL: Use `SourceNode.track()` or `SourceNode.backtrack()` instead.
    */
+  cached
   predicate step(DataFlow::SourceNode pred, DataFlow::SourceNode succ, StepSummary summary) {
     exists(DataFlow::Node mid | pred.flowsTo(mid) | smallstep(mid, succ, summary))
   }
@@ -170,6 +171,7 @@ class TypeTracker extends TTypeTracker {
   TypeTracker() { this = MkTypeTracker(hasCall, prop) }
 
   /** Gets the summary resulting from appending `step` to this type-tracking summary. */
+  cached
   TypeTracker append(StepSummary step) {
     step = LevelStep() and result = this
     or

--- a/javascript/ql/src/semmle/javascript/dataflow/internal/CallGraphs.qll
+++ b/javascript/ql/src/semmle/javascript/dataflow/internal/CallGraphs.qll
@@ -1,3 +1,6 @@
+/**
+ * Internal predicates for computing the call graph.
+ */
 private import javascript
 
 cached

--- a/javascript/ql/src/semmle/javascript/dataflow/internal/CallGraphs.qll
+++ b/javascript/ql/src/semmle/javascript/dataflow/internal/CallGraphs.qll
@@ -1,0 +1,108 @@
+private import javascript
+
+cached
+module CallGraph {
+  /**
+   * Gets a data flow node that refers to the given function.
+   */
+  private
+  DataFlow::SourceNode getAFunctionReference(DataFlow::FunctionNode function, int imprecision, DataFlow::TypeTracker t) {
+    t.start() and
+    exists(Function fun |
+      fun = function.getFunction() and
+      fun = result.analyze().getAValue().(AbstractCallable).getFunction()
+    |
+      if result.analyze().getAValue().isIndefinite("global") then
+        fun.getFile() = result.getFile() and imprecision = 0
+        or
+        fun.inExternsFile() and imprecision = 1
+        or
+        imprecision = 2
+      else
+        imprecision = 0
+    )
+    or
+    imprecision = 0 and
+    t.start() and
+    exists(string name |
+      GlobalAccessPath::isAssignedInUniqueFile(name) and
+      GlobalAccessPath::fromRhs(function) = name and
+      GlobalAccessPath::fromReference(result) = name
+    )
+    or
+    imprecision = 0 and
+    exists(DataFlow::ClassNode cls |
+      exists(string name |
+        function = cls.getInstanceMethod(name) and
+        getAnInstanceMemberAccess(cls, name, t.continue()).flowsTo(result)
+        or
+        function = cls.getStaticMethod(name) and
+        cls.getAClassReference(t.continue()).getAPropertyRead(name).flowsTo(result)
+      )
+      or
+      function = cls.getConstructor() and
+      cls.getAClassReference(t.continue()).flowsTo(result)
+    )
+  }
+
+  /**
+   * Gets a data flow node that refers to the given function.
+   */
+  cached
+  DataFlow::SourceNode getAFunctionReference(DataFlow::FunctionNode function, int imprecision) {
+    result = getAFunctionReference(function, imprecision, DataFlow::TypeTracker::end())
+  }
+
+  /**
+   * Gets a data flow node that refers to the result of the given partial function invocation,
+   * with `function` as the underlying function.
+   */
+  private
+  DataFlow::SourceNode getABoundFunctionReference(DataFlow::FunctionNode function, int boundArgs, DataFlow::TypeTracker t) {
+    exists(DataFlow::PartialInvokeNode partial, DataFlow::Node callback |
+      result = partial.getBoundFunction(callback, boundArgs) and
+      getAFunctionReference(function, 0, t.continue()).flowsTo(callback)
+    )
+    or
+    result = getABoundFunctionReferenceAux(function, boundArgs, t)
+  }
+
+  pragma[noopt]
+  private
+  DataFlow::SourceNode getABoundFunctionReferenceAux(DataFlow::FunctionNode function, int boundArgs, DataFlow::TypeTracker t) {
+    exists(DataFlow::TypeTracker t2, DataFlow::SourceNode prev |
+      prev = getABoundFunctionReference(function, boundArgs, t2) and
+      exists(DataFlow::StepSummary summary |
+        DataFlow::StepSummary::step(prev, result, summary) and
+        t = t2.append(summary)
+      )
+    )
+  }
+
+  /**
+   * Gets a data flow node that refers to the result of the given partial function invocation,
+   * with `function` as the underlying function.
+   */
+  cached
+  DataFlow::SourceNode getABoundFunctionReference(DataFlow::FunctionNode function, int boundArgs) {
+    result = getABoundFunctionReference(function, boundArgs, DataFlow::TypeTracker::end())
+  }
+
+  /**
+   * Gets a property read that accesses the property `name` on an instance of this class.
+   *
+   * Concretely, this holds when the base is an instance of this class or a subclass thereof.
+   *
+   * This predicate may be overridden to customize the class hierarchy analysis.
+   */
+  private
+  DataFlow::PropRead getAnInstanceMemberAccess(DataFlow::ClassNode cls, string name, DataFlow::TypeTracker t) {
+    result = cls.getAnInstanceReference(t.continue()).getAPropertyRead(name)
+    or
+    exists(DataFlow::ClassNode subclass |
+      result = getAnInstanceMemberAccess(subclass, name, t) and
+      not exists(subclass.getAnInstanceMember(name)) and
+      cls = subclass.getADirectSuperClass()
+    )
+  }
+}

--- a/javascript/ql/src/semmle/javascript/dataflow/internal/CallGraphs.qll
+++ b/javascript/ql/src/semmle/javascript/dataflow/internal/CallGraphs.qll
@@ -84,18 +84,18 @@ module CallGraph {
       getAFunctionReference(function, 0, t.continue()).flowsTo(callback)
     )
     or
-    result = getABoundFunctionReferenceAux(function, boundArgs, t)
+    exists(DataFlow::StepSummary summary, DataFlow::TypeTracker t2 |
+      result = getABoundFunctionReferenceAux(function, boundArgs, t2, summary) and
+      t = t2.append(summary)
+    )
   }
 
-  pragma[noopt]
+  pragma[noinline]
   private
-  DataFlow::SourceNode getABoundFunctionReferenceAux(DataFlow::FunctionNode function, int boundArgs, DataFlow::TypeTracker t) {
-    exists(DataFlow::TypeTracker t2, DataFlow::SourceNode prev |
-      prev = getABoundFunctionReference(function, boundArgs, t2) and
-      exists(DataFlow::StepSummary summary |
-        DataFlow::StepSummary::step(prev, result, summary) and
-        t = t2.append(summary)
-      )
+  DataFlow::SourceNode getABoundFunctionReferenceAux(DataFlow::FunctionNode function, int boundArgs, DataFlow::TypeTracker t, DataFlow::StepSummary summary) {
+    exists(DataFlow::SourceNode prev |
+      prev = getABoundFunctionReference(function, boundArgs, t) and
+      DataFlow::StepSummary::step(prev, result, summary)
     )
   }
 

--- a/javascript/ql/src/semmle/javascript/dataflow/internal/FlowSteps.qll
+++ b/javascript/ql/src/semmle/javascript/dataflow/internal/FlowSteps.qll
@@ -141,7 +141,7 @@ private module CachedSteps {
     )
     or
     exists(DataFlow::Node callback, int i, Parameter p |
-      invk.(DataFlow::AdditionalPartialInvokeNode).isPartialArgument(callback, arg, i) and
+      invk.(DataFlow::PartialInvokeNode).isPartialArgument(callback, arg, i) and
       partiallyCalls(invk, callback, f) and
       f.getParameter(i) = p and
       not p.isRestParameter() and

--- a/javascript/ql/src/semmle/javascript/dataflow/internal/FlowSteps.qll
+++ b/javascript/ql/src/semmle/javascript/dataflow/internal/FlowSteps.qll
@@ -109,7 +109,7 @@ private module CachedSteps {
    * This only holds for explicitly modeled partial calls.
    */
   private predicate partiallyCalls(
-    DataFlow::AdditionalPartialInvokeNode invk, DataFlow::AnalyzedNode callback, Function f
+    DataFlow::PartialInvokeNode invk, DataFlow::AnalyzedNode callback, Function f
   ) {
     invk.isPartialArgument(callback, _, _) and
     exists(AbstractFunction callee | callee = callback.getAValue() |

--- a/javascript/ql/src/semmle/javascript/dataflow/internal/FlowSteps.qll
+++ b/javascript/ql/src/semmle/javascript/dataflow/internal/FlowSteps.qll
@@ -98,53 +98,10 @@ private module CachedSteps {
   }
 
   /**
-   * Holds if the method invoked by `invoke` resolved to a member named `name` in `cls`
-   * or one of its super classes.
-   */
-  cached
-  predicate callResolvesToMember(DataFlow::InvokeNode invoke, DataFlow::ClassNode cls, string name) {
-    invoke = cls.getAnInstanceReference().getAMethodCall(name)
-    or
-    exists(DataFlow::ClassNode subclass |
-      callResolvesToMember(invoke, subclass, name) and
-      not exists(subclass.getAnInstanceMember(name)) and
-      cls = subclass.getADirectSuperClass()
-    )
-  }
-
-  /**
    * Holds if `invk` may invoke `f`.
    */
   cached
-  predicate calls(DataFlow::InvokeNode invk, Function f) {
-    f = invk.getACallee(0)
-    or
-    exists(DataFlow::ClassNode cls |
-      // Call to class member
-      exists(string name |
-        callResolvesToMember(invk, cls, name) and
-        f = cls.getInstanceMethod(name).getFunction()
-        or
-        invk = cls.getAClassReference().getAMethodCall(name) and
-        f = cls.getStaticMethod(name).getFunction()
-      )
-      or
-      // Call to constructor
-      invk = cls.getAClassReference().getAnInvocation() and
-      f = cls.getConstructor().getFunction()
-      or
-      // Super call to constructor
-      invk.asExpr().(SuperCall).getBinder() = cls.getConstructor().getFunction() and
-      f = cls.getADirectSuperClass().getConstructor().getFunction()
-    )
-    or
-    // Call from `foo.bar.baz()` to `foo.bar.baz = function()`
-    exists(string name |
-      GlobalAccessPath::isAssignedInUniqueFile(name) and
-      GlobalAccessPath::fromRhs(f.flow()) = name and
-      GlobalAccessPath::fromReference(invk.getCalleeNode()) = name
-    )
-  }
+  predicate calls(DataFlow::InvokeNode invk, Function f) { f = invk.getACallee(0) }
 
   /**
    * Holds if `invk` may invoke `f` indirectly through the given `callback` argument.
@@ -525,3 +482,4 @@ module PathSummary {
    */
   PathSummary return() { exists(FlowLabel lbl | result = MkPathSummary(true, false, lbl, lbl)) }
 }
+

--- a/javascript/ql/src/semmle/javascript/frameworks/AngularJS/AngularJSCore.qll
+++ b/javascript/ql/src/semmle/javascript/frameworks/AngularJS/AngularJSCore.qll
@@ -1062,21 +1062,21 @@ private class RouteInstantiatedController extends Controller {
 /**
  * Dataflow for the arguments of AngularJS dependency-injected functions.
  */
-private class DependencyInjectedArgumentInitializer extends DataFlow::AnalyzedValueNode {
+private class DependencyInjectedArgumentInitializer extends DataFlow::AnalyzedNode {
   DataFlow::AnalyzedNode service;
 
   DependencyInjectedArgumentInitializer() {
     exists(
-      AngularJS::InjectableFunction f, SimpleParameter param, AngularJS::CustomServiceDefinition def
+      AngularJS::InjectableFunction f, Parameter param, AngularJS::CustomServiceDefinition def
     |
-      astNode = param.getAnInitialUse() and
+      this = DataFlow::parameterNode(param) and
       def.getServiceReference() = f.getAResolvedDependency(param) and
       service = def.getAService()
     )
   }
 
   override AbstractValue getAValue() {
-    result = DataFlow::AnalyzedValueNode.super.getAValue() or
+    result = DataFlow::AnalyzedNode.super.getAValue() or
     result = service.getALocalValue()
   }
 }

--- a/javascript/ql/src/semmle/javascript/frameworks/AngularJS/AngularJSCore.qll
+++ b/javascript/ql/src/semmle/javascript/frameworks/AngularJS/AngularJSCore.qll
@@ -1080,3 +1080,24 @@ private class DependencyInjectedArgumentInitializer extends DataFlow::AnalyzedVa
     result = service.getALocalValue()
   }
 }
+
+/**
+ * A call to `angular.bind`, as a partial function invocation.
+ */
+private class BindCall extends DataFlow::PartialInvokeNode::Range, DataFlow::CallNode {
+  BindCall() { this = angular().getAMemberCall("bind") }
+
+  override predicate isPartialArgument(DataFlow::Node callback, DataFlow::Node argument, int index) {
+    index >= 0 and
+    callback = getArgument(1) and
+    argument = getArgument(index + 2)
+  }
+
+  override DataFlow::SourceNode getBoundFunction(DataFlow::Node callback, int boundArgs) {
+    callback = getArgument(1) and
+    boundArgs = getNumArgument() - 2 and
+    result = this
+  }
+
+  override DataFlow::Node getBoundReceiver() { result = getArgument(0) }
+}

--- a/javascript/ql/src/semmle/javascript/frameworks/AsyncPackage.qll
+++ b/javascript/ql/src/semmle/javascript/frameworks/AsyncPackage.qll
@@ -70,7 +70,7 @@ module AsyncPackage {
    * to the first parameter of the final callback, while `result1, result2, ...` are propagated to
    * the parameters of the following task.
    */
-  private class WaterfallNextTaskCall extends DataFlow::AdditionalPartialInvokeNode {
+  private class WaterfallNextTaskCall extends DataFlow::PartialInvokeNode::Range, DataFlow::CallNode {
     Waterfall waterfall;
     int n;
 

--- a/javascript/ql/src/semmle/javascript/security/dataflow/DOM.qll
+++ b/javascript/ql/src/semmle/javascript/security/dataflow/DOM.qll
@@ -174,18 +174,20 @@ private module PersistentWebStorage {
  * An event handler that handles `postMessage` events.
  */
 class PostMessageEventHandler extends Function {
+  int paramIndex;
+
   PostMessageEventHandler() {
-    exists(CallExpr addEventListener |
-      addEventListener.getCallee().accessesGlobal("addEventListener") and
+    exists(DataFlow::CallNode addEventListener |
+      addEventListener = DataFlow::globalVarRef("addEventListener").getACall() and
       addEventListener.getArgument(0).mayHaveStringValue("message") and
-      addEventListener.getArgument(1).analyze().getAValue().(AbstractFunction).getFunction() = this
+      addEventListener.getArgument(1).getABoundFunctionValue(paramIndex).getFunction() = this
     )
   }
 
   /**
    * Gets the parameter that contains the event.
    */
-  SimpleParameter getEventParameter() { result = getParameter(0) }
+  Parameter getEventParameter() { result = getParameter(paramIndex) }
 }
 
 /**

--- a/javascript/ql/test/library-tests/CallGraphs/FullTest/tests.expected
+++ b/javascript/ql/test/library-tests/CallGraphs/FullTest/tests.expected
@@ -439,7 +439,6 @@ test_getACallee
 | tst.js:64:13:64:19 | new B() | tst.js:50:1:50:15 | function B() {} |
 | tst.js:66:5:66:9 | b.f() | tst.js:52:5:54:2 | functio ... g();\\n\\t} |
 | tst.js:66:5:66:9 | b.f() | tst.js:65:11:65:23 | function() {} |
-| tst.js:69:1:69:10 | globalfn() | tst3.js:1:1:1:22 | functio ... fn() {} |
 | tst.js:70:1:70:11 | globalfn2() | tst3.js:2:1:2:23 | functio ... n2() {} |
 test_getCalleeName
 | a.js:2:1:2:5 | foo() | foo |

--- a/javascript/ql/test/library-tests/CallGraphs/FullTest/tests.expected
+++ b/javascript/ql/test/library-tests/CallGraphs/FullTest/tests.expected
@@ -60,7 +60,6 @@ test_getAFunctionValue
 | classes.js:12:3:16:3 | class B ...   }\\n  } | classes.js:12:21:12:20 | (...arg ... rgs); } |
 | classes.js:12:19:12:19 | A | classes.js:2:11:2:10 | () {} |
 | classes.js:12:21:12:20 | (...arg ... rgs); } | classes.js:12:21:12:20 | (...arg ... rgs); } |
-| classes.js:12:21:12:20 | super | classes.js:2:11:2:10 | () {} |
 | classes.js:13:10:15:5 | () {\\n   ... ;\\n    } | classes.js:13:10:15:5 | () {\\n   ... ;\\n    } |
 | classes.js:18:3:18:15 | new B().hello | classes.js:13:10:15:5 | () {\\n   ... ;\\n    } |
 | classes.js:18:7:18:7 | B | classes.js:12:21:12:20 | (...arg ... rgs); } |
@@ -76,12 +75,10 @@ test_getAFunctionValue
 | es2015.js:14:20:14:46 | "Wait f ... leClass | es2015.js:2:14:4:3 | () {\\n   ... ");\\n  } |
 | es2015.js:14:35:14:46 | ExampleClass | es2015.js:2:14:4:3 | () {\\n   ... ");\\n  } |
 | es2015.js:15:14:17:3 | () {\\n   ... ();\\n  } | es2015.js:15:14:17:3 | () {\\n   ... ();\\n  } |
-| es2015.js:16:5:16:9 | super | es2015.js:2:14:4:3 | () {\\n   ... ");\\n  } |
 | es2015.js:20:1:22:1 | functio ... = 42;\\n} | es2015.js:20:1:22:1 | functio ... = 42;\\n} |
 | es2015.js:24:1:29:1 | class O ... ;\\n  }\\n} | es2015.js:25:14:28:3 | () {\\n   ... x);\\n  } |
 | es2015.js:24:24:24:34 | PseudoClass | es2015.js:20:1:22:1 | functio ... = 42;\\n} |
 | es2015.js:25:14:28:3 | () {\\n   ... x);\\n  } | es2015.js:25:14:28:3 | () {\\n   ... x);\\n  } |
-| es2015.js:26:5:26:9 | super | es2015.js:20:1:22:1 | functio ... = 42;\\n} |
 | es2015.js:31:1:33:1 | functio ... +y+z;\\n} | es2015.js:31:1:33:1 | functio ... +y+z;\\n} |
 | es2015.js:34:1:34:3 | sum | es2015.js:31:1:33:1 | functio ... +y+z;\\n} |
 | es2015.js:35:1:35:3 | sum | es2015.js:31:1:33:1 | functio ... +y+z;\\n} |
@@ -184,8 +181,8 @@ test_getAFunctionValue
 | tst.js:64:17:64:17 | B | tst.js:50:1:50:15 | function B() {} |
 | tst.js:65:5:65:23 | b.f = function() {} | tst.js:65:11:65:23 | function() {} |
 | tst.js:65:11:65:23 | function() {} | tst.js:65:11:65:23 | function() {} |
+| tst.js:66:5:66:7 | b.f | tst.js:52:5:54:2 | functio ... g();\\n\\t} |
 | tst.js:66:5:66:7 | b.f | tst.js:65:11:65:23 | function() {} |
-| tst.js:69:1:69:8 | globalfn | tst3.js:1:1:1:22 | functio ... fn() {} |
 | tst.js:70:1:70:9 | globalfn2 | tst3.js:2:1:2:23 | functio ... n2() {} |
 test_getArgument
 | classes.js:4:7:4:26 | console.log("Hello") | 0 | classes.js:4:19:4:25 | "Hello" |
@@ -404,7 +401,6 @@ test_getACallee
 | es2015.js:6:1:6:18 | new ExampleClass() | es2015.js:2:14:4:3 | () {\\n   ... ");\\n  } |
 | es2015.js:10:5:10:22 | arguments.callee() | es2015.js:8:2:12:1 | functio ... \\n  };\\n} |
 | es2015.js:16:5:16:11 | super() | es2015.js:2:14:4:3 | () {\\n   ... ");\\n  } |
-| es2015.js:26:5:26:11 | super() | es2015.js:20:1:22:1 | functio ... = 42;\\n} |
 | es2015.js:34:1:34:17 | sum(...[1, 2, 3]) | es2015.js:31:1:33:1 | functio ... +y+z;\\n} |
 | es2015.js:35:1:35:17 | sum(1, ...[2, 3]) | es2015.js:31:1:33:1 | functio ... +y+z;\\n} |
 | es2015.js:36:1:36:17 | sum(1, ...[2], 3) | es2015.js:31:1:33:1 | functio ... +y+z;\\n} |
@@ -441,6 +437,7 @@ test_getACallee
 | tst.js:53:3:53:10 | this.g() | tst.js:57:39:57:51 | function() {} |
 | tst.js:60:15:60:21 | new A() | tst.js:44:1:44:15 | function A() {} |
 | tst.js:64:13:64:19 | new B() | tst.js:50:1:50:15 | function B() {} |
+| tst.js:66:5:66:9 | b.f() | tst.js:52:5:54:2 | functio ... g();\\n\\t} |
 | tst.js:66:5:66:9 | b.f() | tst.js:65:11:65:23 | function() {} |
 | tst.js:69:1:69:10 | globalfn() | tst3.js:1:1:1:22 | functio ... fn() {} |
 | tst.js:70:1:70:11 | globalfn2() | tst3.js:2:1:2:23 | functio ... n2() {} |

--- a/javascript/ql/test/library-tests/PartialInvokeNode/closure.js
+++ b/javascript/ql/test/library-tests/PartialInvokeNode/closure.js
@@ -1,0 +1,5 @@
+goog.module('test');
+
+function test(x) {
+  addEventListener("click", goog.bind(function(x, event) {}, this, x));
+}

--- a/javascript/ql/test/library-tests/PartialInvokeNode/test.expected
+++ b/javascript/ql/test/library-tests/PartialInvokeNode/test.expected
@@ -1,0 +1,26 @@
+getBoundFunction
+| closure.js:4:29:4:69 | goog.bi ... his, x) | closure.js:4:39:4:59 | functio ... ent) {} | 1 | closure.js:4:29:4:69 | goog.bi ... his, x) |
+| tst.js:5:29:5:63 | functio ... his, x) | tst.js:5:29:5:49 | functio ... ent) {} | 1 | tst.js:5:29:5:63 | functio ... his, x) |
+| tst.js:6:29:6:68 | lodash. ...  {}, x) | tst.js:6:44:6:64 | functio ... ent) {} | 1 | tst.js:6:29:6:68 | lodash. ...  {}, x) |
+| tst.js:7:29:7:65 | R.parti ... }, [x]) | tst.js:7:39:7:59 | functio ... ent) {} | 1 | tst.js:7:29:7:65 | R.parti ... }, [x]) |
+| tst.js:8:29:8:72 | angular ...  {}, x) | tst.js:8:48:8:68 | functio ... ent) {} | 1 | tst.js:8:29:8:72 | angular ...  {}, x) |
+| tst.js:11:29:11:43 | f.bind(this, x) | tst.js:11:29:11:29 | f | 1 | tst.js:11:29:11:43 | f.bind(this, x) |
+isPartialArgument
+| closure.js:4:29:4:69 | goog.bi ... his, x) | closure.js:4:39:4:59 | functio ... ent) {} | closure.js:4:68:4:68 | x | 0 |
+| tst.js:5:29:5:63 | functio ... his, x) | tst.js:5:29:5:49 | functio ... ent) {} | tst.js:5:62:5:62 | x | 0 |
+| tst.js:6:29:6:68 | lodash. ...  {}, x) | tst.js:6:44:6:64 | functio ... ent) {} | tst.js:6:67:6:67 | x | 0 |
+| tst.js:7:29:7:65 | R.parti ... }, [x]) | tst.js:7:39:7:59 | functio ... ent) {} | tst.js:7:63:7:63 | x | 0 |
+| tst.js:8:29:8:72 | angular ...  {}, x) | tst.js:8:48:8:68 | functio ... ent) {} | tst.js:8:71:8:71 | x | 0 |
+| tst.js:11:29:11:43 | f.bind(this, x) | tst.js:11:29:11:29 | f | tst.js:11:42:11:42 | x | 0 |
+getBoundReceiver
+| closure.js:4:29:4:69 | goog.bi ... his, x) | closure.js:4:62:4:65 | this |
+| tst.js:5:29:5:63 | functio ... his, x) | tst.js:5:56:5:59 | this |
+| tst.js:8:29:8:72 | angular ...  {}, x) | tst.js:8:42:8:45 | this |
+| tst.js:11:29:11:43 | f.bind(this, x) | tst.js:11:36:11:39 | this |
+clickEvent
+| closure.js:4:51:4:55 | event |
+| tst.js:5:41:5:45 | event |
+| tst.js:6:56:6:60 | event |
+| tst.js:7:51:7:55 | event |
+| tst.js:8:60:8:64 | event |
+| tst.js:10:17:10:21 | event |

--- a/javascript/ql/test/library-tests/PartialInvokeNode/test.ql
+++ b/javascript/ql/test/library-tests/PartialInvokeNode/test.ql
@@ -1,0 +1,21 @@
+import javascript
+
+query
+DataFlow::Node getBoundFunction(DataFlow::PartialInvokeNode invoke, DataFlow::Node callback, int boundArgs) {
+  result = invoke.getBoundFunction(callback, boundArgs)
+}
+
+query
+predicate isPartialArgument(DataFlow::PartialInvokeNode invoke, DataFlow::Node callback, DataFlow::Node argument, int index) {
+  invoke.isPartialArgument(callback, argument, index)
+}
+
+query
+DataFlow::Node getBoundReceiver(DataFlow::PartialInvokeNode invoke) {
+  result = invoke.getBoundReceiver()
+}
+
+query
+DataFlow::Node clickEvent() {
+  result = DataFlow::globalVarRef("addEventListener").getACall().getABoundCallbackParameter(1, 0)
+}

--- a/javascript/ql/test/library-tests/PartialInvokeNode/tst.js
+++ b/javascript/ql/test/library-tests/PartialInvokeNode/tst.js
@@ -1,0 +1,12 @@
+let lodash = require('lodash');
+let R = require('ramda');
+
+function test(x) {
+  addEventListener("click", function(x, event) {}.bind(this, x));
+  addEventListener("click", lodash.partial(function(x, event) {}, x));
+  addEventListener("click", R.partial(function(x, event) {}, [x]));
+  addEventListener("click", angular.bind(this, function(x, event) {}, x));
+
+  function f(x, event) {}
+  addEventListener("click", f.bind(this, x));
+}

--- a/javascript/ql/test/library-tests/TypeScript/CallGraph/CallGraph.expected
+++ b/javascript/ql/test/library-tests/TypeScript/CallGraph/CallGraph.expected
@@ -1,4 +1,5 @@
 | tst.ts:4:5:4:21 | x.method("Hello") | tst.ts:15:3:17:3 | public  ... x);\\n  } |
 | tst.ts:9:17:9:33 | new AngryLogger() | tst.ts:20:34:20:33 | (...arg ... rgs); } |
+| tst.ts:10:5:10:49 | (newLog ... hello") | tst.ts:15:3:17:3 | public  ... x);\\n  } |
 | tst.ts:10:5:10:49 | (newLog ... hello") | tst.ts:21:3:23:3 | public  ... ");\\n  } |
 | tst.ts:20:34:20:33 | super(...args) | tst.ts:14:14:14:13 | () {} |

--- a/javascript/ql/test/library-tests/TypeScript/CallGraph/tst.ts
+++ b/javascript/ql/test/library-tests/TypeScript/CallGraph/tst.ts
@@ -4,7 +4,7 @@ class MyClass {
     x.method("Hello");
 
     // Resolve based on local dataflow.
-    // Type information should not degrade call graph precision.
+    // Type information may degrade call graph precision.
     var newLogger: Logger;
     newLogger = new AngryLogger();
     (newLogger as Logger).method("I said, hello");

--- a/javascript/ql/test/query-tests/LanguageFeatures/IllegalInvocation/IllegalInvocation.expected
+++ b/javascript/ql/test/query-tests/LanguageFeatures/IllegalInvocation/IllegalInvocation.expected
@@ -6,3 +6,4 @@
 | tst.js:43:1:43:7 | new h() | Illegal invocation of $@ using 'new'. | tst.js:40:1:40:21 | async f ...  h() {} | an async function |
 | tst.js:45:1:45:8 | reflective call | Illegal invocation of $@ as a function. | tst.js:1:9:1:8 | () {} | a constructor |
 | tst.js:46:1:46:9 | reflective call | Illegal invocation of $@ as a function. | tst.js:1:9:1:8 | () {} | a constructor |
+| tst.js:50:5:50:8 | fn() | Illegal invocation of $@ as a function. | tst.js:1:9:1:8 | () {} | a constructor |

--- a/javascript/ql/test/query-tests/LanguageFeatures/IllegalInvocation/IllegalInvocation.expected
+++ b/javascript/ql/test/query-tests/LanguageFeatures/IllegalInvocation/IllegalInvocation.expected
@@ -1,9 +1,6 @@
 | tst.js:12:1:12:3 | C() | Illegal invocation of $@ as a function. | tst.js:1:9:1:8 | () {} | a constructor |
 | tst.js:13:1:13:10 | new (x=>x) | Illegal invocation of $@ using 'new'. | tst.js:13:6:13:9 | x=>x | an arrow function |
-| tst.js:15:1:15:9 | new c.m() | Illegal invocation of $@ using 'new'. | tst.js:2:4:2:8 | () {} | a method |
-| tst.js:24:1:24:9 | new o.g() | Illegal invocation of $@ using 'new'. | tst.js:19:4:19:8 | () {} | a method |
 | tst.js:42:1:42:7 | new g() | Illegal invocation of $@ using 'new'. | tst.js:39:1:39:16 | function* g() {} | a generator function |
 | tst.js:43:1:43:7 | new h() | Illegal invocation of $@ using 'new'. | tst.js:40:1:40:21 | async f ...  h() {} | an async function |
 | tst.js:45:1:45:8 | reflective call | Illegal invocation of $@ as a function. | tst.js:1:9:1:8 | () {} | a constructor |
 | tst.js:46:1:46:9 | reflective call | Illegal invocation of $@ as a function. | tst.js:1:9:1:8 | () {} | a constructor |
-| tst.js:50:5:50:8 | fn() | Illegal invocation of $@ as a function. | tst.js:1:9:1:8 | () {} | a constructor |

--- a/javascript/ql/test/query-tests/LanguageFeatures/IllegalInvocation/tst.js
+++ b/javascript/ql/test/query-tests/LanguageFeatures/IllegalInvocation/tst.js
@@ -53,4 +53,12 @@ class E {
 E.call();        // OK
 E.apply();       // OK
 
+function invoke(fn) {
+  if (typeof fn === "function" && fn.hasOwnProperty("foo")) {
+    fn(); // OK
+  }
+}
+invoke(C);
+invoke(function() {});
+
 //semmle-extractor-options: --experimental

--- a/javascript/ql/test/query-tests/LanguageFeatures/IllegalInvocation/tst.js
+++ b/javascript/ql/test/query-tests/LanguageFeatures/IllegalInvocation/tst.js
@@ -12,7 +12,7 @@ let c = new C(); // OK
 C();             // NOT OK
 new (x=>x);      // NOT OK
 c.m();           // OK
-new c.m();       // NOT OK
+new c.m();       // NOT OK - but not flagged
 
 var o = {
   f: function() {},
@@ -21,7 +21,7 @@ var o = {
 o.f();           // OK
 new o.f();       // OK
 o.g();           // OK
-new o.g();       // NOT OK
+new o.g();       // NOT OK - but not flagged
 
 function f(b) {
   var g;

--- a/javascript/ql/test/query-tests/LanguageFeatures/InconsistentNew/InconsistentNew.expected
+++ b/javascript/ql/test/query-tests/LanguageFeatures/InconsistentNew/InconsistentNew.expected
@@ -1,2 +1,3 @@
+| arraydef.js:1:1:1:19 | function Array() {} | Function Array is sometimes invoked as a constructor (for example $@), and sometimes as a normal function (for example $@). | arraycalls.js:2:1:2:13 | new Array(45) | here | arraycalls.js:1:1:1:9 | Array(45) | here |
 | m.js:1:8:1:22 | functio ...  = x;\\n} | Function A is sometimes invoked as a constructor (for example $@), and sometimes as a normal function (for example $@). | c1.js:2:1:2:9 | new A(42) | here | c2.js:2:1:2:5 | A(23) | here |
 | tst.js:1:1:1:22 | functio ...  = y;\\n} | Function Point is sometimes invoked as a constructor (for example $@), and sometimes as a normal function (for example $@). | tst.js:6:1:6:17 | new Point(23, 42) | here | tst.js:7:1:7:13 | Point(56, 72) | here |

--- a/javascript/ql/test/query-tests/LanguageFeatures/InconsistentNew/InconsistentNew.expected
+++ b/javascript/ql/test/query-tests/LanguageFeatures/InconsistentNew/InconsistentNew.expected
@@ -1,3 +1,2 @@
-| arraydef.js:1:1:1:19 | function Array() {} | Function Array is sometimes invoked as a constructor (for example $@), and sometimes as a normal function (for example $@). | arraycalls.js:2:1:2:13 | new Array(45) | here | arraycalls.js:1:1:1:9 | Array(45) | here |
 | m.js:1:8:1:22 | functio ...  = x;\\n} | Function A is sometimes invoked as a constructor (for example $@), and sometimes as a normal function (for example $@). | c1.js:2:1:2:9 | new A(42) | here | c2.js:2:1:2:5 | A(23) | here |
 | tst.js:1:1:1:22 | functio ...  = y;\\n} | Function Point is sometimes invoked as a constructor (for example $@), and sometimes as a normal function (for example $@). | tst.js:6:1:6:17 | new Point(23, 42) | here | tst.js:7:1:7:13 | Point(56, 72) | here |

--- a/javascript/ql/test/query-tests/LanguageFeatures/InconsistentNew/arraycalls.js
+++ b/javascript/ql/test/query-tests/LanguageFeatures/InconsistentNew/arraycalls.js
@@ -1,0 +1,2 @@
+Array(45); // OK
+new Array(45); // OK

--- a/javascript/ql/test/query-tests/LanguageFeatures/InconsistentNew/arraydef.js
+++ b/javascript/ql/test/query-tests/LanguageFeatures/InconsistentNew/arraydef.js
@@ -1,0 +1,2 @@
+function Array() {}
+Array.prototype.foo = function() {};

--- a/javascript/ql/test/query-tests/LanguageFeatures/InconsistentNew/externs.js
+++ b/javascript/ql/test/query-tests/LanguageFeatures/InconsistentNew/externs.js
@@ -1,4 +1,10 @@
 function Error() {}
+Error.prototype.toString = function() {};
+
 function String() {}
+String.prototype.toString = function() {};
+
+function Array() {}
+Array.prototype.toString = function() {};
 
 //semmle-extractor-options: --externs

--- a/javascript/ql/test/query-tests/Security/CWE-079/Xss.expected
+++ b/javascript/ql/test/query-tests/Security/CWE-079/Xss.expected
@@ -2,6 +2,13 @@ nodes
 | addEventListener.js:1:43:1:47 | event |
 | addEventListener.js:2:20:2:24 | event |
 | addEventListener.js:2:20:2:29 | event.data |
+| addEventListener.js:5:43:5:48 | data |
+| addEventListener.js:5:43:5:48 | {data} |
+| addEventListener.js:5:44:5:47 | data |
+| addEventListener.js:6:20:6:23 | data |
+| addEventListener.js:10:21:10:25 | event |
+| addEventListener.js:12:24:12:28 | event |
+| addEventListener.js:12:24:12:33 | event.data |
 | jquery.js:2:7:2:40 | tainted |
 | jquery.js:2:17:2:33 | document.location |
 | jquery.js:2:17:2:40 | documen ... .search |
@@ -195,6 +202,11 @@ nodes
 edges
 | addEventListener.js:1:43:1:47 | event | addEventListener.js:2:20:2:24 | event |
 | addEventListener.js:2:20:2:24 | event | addEventListener.js:2:20:2:29 | event.data |
+| addEventListener.js:5:43:5:48 | data | addEventListener.js:6:20:6:23 | data |
+| addEventListener.js:5:43:5:48 | {data} | addEventListener.js:5:44:5:47 | data |
+| addEventListener.js:5:44:5:47 | data | addEventListener.js:5:43:5:48 | data |
+| addEventListener.js:10:21:10:25 | event | addEventListener.js:12:24:12:28 | event |
+| addEventListener.js:12:24:12:28 | event | addEventListener.js:12:24:12:33 | event.data |
 | jquery.js:2:7:2:40 | tainted | jquery.js:4:5:4:11 | tainted |
 | jquery.js:2:7:2:40 | tainted | jquery.js:7:20:7:26 | tainted |
 | jquery.js:2:7:2:40 | tainted | jquery.js:8:28:8:34 | tainted |
@@ -354,6 +366,8 @@ edges
 | winjs.js:2:17:2:53 | documen ... ring(1) | winjs.js:2:7:2:53 | tainted |
 #select
 | addEventListener.js:2:20:2:29 | event.data | addEventListener.js:1:43:1:47 | event | addEventListener.js:2:20:2:29 | event.data | Cross-site scripting vulnerability due to $@. | addEventListener.js:1:43:1:47 | event | user-provided value |
+| addEventListener.js:6:20:6:23 | data | addEventListener.js:5:43:5:48 | {data} | addEventListener.js:6:20:6:23 | data | Cross-site scripting vulnerability due to $@. | addEventListener.js:5:43:5:48 | {data} | user-provided value |
+| addEventListener.js:12:24:12:33 | event.data | addEventListener.js:10:21:10:25 | event | addEventListener.js:12:24:12:33 | event.data | Cross-site scripting vulnerability due to $@. | addEventListener.js:10:21:10:25 | event | user-provided value |
 | jquery.js:4:5:4:11 | tainted | jquery.js:2:17:2:33 | document.location | jquery.js:4:5:4:11 | tainted | Cross-site scripting vulnerability due to $@. | jquery.js:2:17:2:33 | document.location | user-provided value |
 | jquery.js:7:5:7:34 | "<div i ... + "\\">" | jquery.js:2:17:2:33 | document.location | jquery.js:7:5:7:34 | "<div i ... + "\\">" | Cross-site scripting vulnerability due to $@. | jquery.js:2:17:2:33 | document.location | user-provided value |
 | jquery.js:8:18:8:34 | "XSS: " + tainted | jquery.js:2:17:2:33 | document.location | jquery.js:8:18:8:34 | "XSS: " + tainted | Cross-site scripting vulnerability due to $@. | jquery.js:2:17:2:33 | document.location | user-provided value |

--- a/javascript/ql/test/query-tests/Security/CWE-079/addEventListener.js
+++ b/javascript/ql/test/query-tests/Security/CWE-079/addEventListener.js
@@ -1,3 +1,17 @@
 this.addEventListener('message', function(event) {
     document.write(event.data); // NOT OK
 })
+
+this.addEventListener('message', function({data}) {
+    document.write(data); // NOT OK
+})
+
+function test() {
+    function foo(x, event, y) {
+        document.write(x.data);     // OK
+        document.write(event.data); // NOT OK
+        document.write(y.data);     // OK
+    }
+
+    window.addEventListener("message", foo.bind(null, {data: 'items'}));
+}


### PR DESCRIPTION
Reorganizes the call graph computation motivated by the need for library models to reason about callbacks that escape into the library. For example, in the following we could now detect that `event` refers to an untrusted cross-window event:
```js
function addListener(cb) {
  window.addEventListener("message", cb)
}
function foo(x, event) { /* ... */ }
addListener(foo.bind(this, x))
```

This consists of a number of changes seemed independent but I had to roll them up into a single change to avoid intermediate regressions or redundant work:
- Call graph computation is now centralized in `CallGraphs.qll`
- `InvokeNode.getACallee()` and `Node.getAFunctionValue()` now include the call edges discovered through type tracking -- previously only available internally through `FlowSteps::calls`.
- `AdditionalPartialInvokeNode` has been renamed to `PartialInvokeNode` with a `::Range` companion.
- Added type tracking for the output of a `PartialInvokeNode`. (To keep the scope of this PR in check, we don't currently type-track function objects in general, just the result of partial invokes.)

Previously, the call graph exposed through `getACallee(0)` had the nice property that if _any_ callees were found, we almost certainly had _all_ of them. This is doesn't quite hold anymore. Since it now includes results from type tracking, there will be cases where a proper subset of the callees could be found (where previously nothing was found). This has a few ramifications:

- Static types now contribute to the call graph even if some edges were also found through data flow. We would lose useful call edges otherwise.
- The illegal-invocation and inconsistent-new queries had to be dialed back to be more conservative. In principle we could restore their original behaviour by using `analyze().getAValue()` directly, but the results we lose didn't seem valuable.

Also some changes that could in principle be landed separately, but helped me verify that things actually work:
- Support for the `goog.bind` and `angular.bind` partial invokes.
- `PostMessageEventHandler` uses the new API (as per the above example)

Evaluations:
- [Evaluation](https://git.semmle.com/asger/dist-compare-reports/tree/call-graph-3_1569491268940) and [re-run of the outlier](https://git.semmle.com/asger/dist-compare-reports/tree/call-graph-3_1570631462515)
- [Call graph metrics](https://git.semmle.com/asger/dist-compare-reports/tree/call-graph-3_1568768434549) show some ups and downs. I've spent a lot of time looking at call graph diffs, and concluded that the remaining changes are benign, although I obvs haven't check all of it. The lost call edges I've seen were either spurious or a call to an extern that is also defined by a polyfill (no longer found due to `GlobalAcessPaths::isAssignedInUniqueFile`).