### PR TITLE
Python: Use ExternalStringKind instead of UntrustedStringKind

### DIFF
--- a/python/ql/src/semmle/python/web/bottle/Request.qll
+++ b/python/ql/src/semmle/python/web/bottle/Request.qll
@@ -1,6 +1,5 @@
 import python
 import semmle.python.security.TaintTracking
-import semmle.python.security.strings.Untrusted
 import semmle.python.web.Http
 import semmle.python.web.bottle.General
 
@@ -13,7 +12,7 @@ class BottleRequestKind extends TaintKind {
         result instanceof BottleFormsDict and
         (name = "cookies" or name = "query" or name = "form")
         or
-        result instanceof UntrustedStringKind and
+        result instanceof ExternalStringKind and
         (name = "query_string" or name = "url_args")
         or
         result.(DictKind).getValue() instanceof FileUpload and
@@ -34,7 +33,7 @@ class BottleFormsDict extends TaintKind {
         /* Cannot use `getTaintOfAttribute(name)` as it wouldn't bind `name` */
         exists(string name |
             fromnode = tonode.(AttrNode).getObject(name) and
-            result instanceof UntrustedStringKind
+            result instanceof ExternalStringKind
         |
             name != "get" and name != "getunicode" and name != "getall"
         )
@@ -42,9 +41,9 @@ class BottleFormsDict extends TaintKind {
 
     override TaintKind getTaintOfMethodResult(string name) {
         (name = "get" or name = "getunicode") and
-        result instanceof UntrustedStringKind
+        result instanceof ExternalStringKind
         or
-        name = "getall" and result.(SequenceKind).getItem() instanceof UntrustedStringKind
+        name = "getall" and result.(SequenceKind).getItem() instanceof ExternalStringKind
     }
 }
 
@@ -52,9 +51,9 @@ class FileUpload extends TaintKind {
     FileUpload() { this = "bottle.FileUpload" }
 
     override TaintKind getTaintOfAttribute(string name) {
-        name = "filename" and result instanceof UntrustedStringKind
+        name = "filename" and result instanceof ExternalStringKind
         or
-        name = "raw_filename" and result instanceof UntrustedStringKind
+        name = "raw_filename" and result instanceof ExternalStringKind
         or
         name = "file" and result instanceof UntrustedFile
     }
@@ -74,7 +73,7 @@ class BottleRequestParameter extends TaintSource {
         exists(BottleRoute route | route.getNamedArgument() = this.(ControlFlowNode).getNode())
     }
 
-    override predicate isSourceOf(TaintKind kind) { kind instanceof UntrustedStringKind }
+    override predicate isSourceOf(TaintKind kind) { kind instanceof ExternalStringKind }
 
     override string toString() { result = "bottle handler function argument" }
 }

--- a/python/ql/src/semmle/python/web/turbogears/Request.qll
+++ b/python/ql/src/semmle/python/web/turbogears/Request.qll
@@ -1,5 +1,5 @@
 import python
-import semmle.python.security.strings.Untrusted
+import semmle.python.security.strings.External
 
 import TurboGears
 
@@ -26,7 +26,7 @@ class UnvalidatedControllerMethodParameter extends TaintSource {
     }
 
     override predicate isSourceOf(TaintKind kind) {
-        kind instanceof UntrustedStringKind
+        kind instanceof ExternalStringKind
     }
 
 }


### PR DESCRIPTION
This is mostly to bring consistency between the other web libraries. But with
the following reasoning, it is also TheRightThing™

ExternalStringKind is an abstract base class. Currently it has concrete
subclasses UntrustedStringKind and ExternalXmlString.

Before we were doing this

    override predicate isSourceOf(TaintKind kind) {
        kind instanceof UntrustedStringKind
    }

However, if the unstrusted string is deserialized as XML, we will not report the
possible vulnerability (since this requires sink to have kind
ExternalXmlString). By using ExternalStringKind in isSourceOf, we would be
able to report that vulnerability (yay!).