### PR TITLE
docs: fix heading levels in c/c++ topic

### DIFF
--- a/docs/language/learn-ql/cpp/introduce-libraries-cpp.rst
+++ b/docs/language/learn-ql/cpp/introduce-libraries-cpp.rst
@@ -15,12 +15,12 @@ The rest of this topic summarizes available QL classes and corresponding C/C++ c
 NOTE: You can find related classes and features using the query console's auto-complete feature.  You can also press *F3* to jump to the definition of any element; QL library files are opened in new tabs in the console.
 
 Summary of the library classes
-==============================
+------------------------------
 
 The most commonly used standard QL library classes are listed below.  The listing is broken down by functionality.  Each QL library class is annotated with a C/C++ construct it corresponds to.
 
 Declaration classes
--------------------
+~~~~~~~~~~~~~~~~~~~
 
 This table lists `Declaration <https://help.semmle.com/qldoc/cpp/semmle/code/cpp/Declaration.qll/type.Declaration$Declaration.html>`__ classes representing C/C++ declarations.
 
@@ -149,7 +149,7 @@ This table lists `Declaration <https://help.semmle.com/qldoc/cpp/semmle/code/cpp
 
 
 Statement classes
------------------
+~~~~~~~~~~~~~~~~~
 
 This table lists subclasses of `Stmt <https://help.semmle.com/qldoc/cpp/semmle/code/cpp/stmts/Stmt.qll/type.Stmt$Stmt.html>`__ representing C/C++ statements.
 
@@ -210,7 +210,7 @@ This table lists subclasses of `Stmt <https://help.semmle.com/qldoc/cpp/semmle/c
 
 
 Expression classes
-------------------
+~~~~~~~~~~~~~~~~~~
 
 This table lists subclasses of `Expr <https://help.semmle.com/qldoc/cpp/semmle/code/cpp/exprs/Expr.qll/type.Expr$Expr.html>`__ representing C/C++ expressions.
 
@@ -412,7 +412,7 @@ This table lists subclasses of `Expr <https://help.semmle.com/qldoc/cpp/semmle/c
 
 
 Type classes
-------------
+~~~~~~~~~~~~
 
 This table lists subclasses of `Type <https://help.semmle.com/qldoc/cpp/semmle/code/cpp/Type.qll/type.Type$Type.html>`__ representing C/C++ types.
 
@@ -480,7 +480,7 @@ This table lists subclasses of `Type <https://help.semmle.com/qldoc/cpp/semmle/c
 
 
 Preprocessor classes
---------------------
+~~~~~~~~~~~~~~~~~~~~
 
 This table lists `Preprocessor <https://help.semmle.com/qldoc/cpp/semmle/code/cpp/Preprocessor.qll/module.Preprocessor.html>`__ classes representing C/C++ preprocessing directives.
 


### PR DESCRIPTION
In https://help.semmle.com/QL/learn-ql/cpp/introduce-libraries-cpp.html we appear to have two `h1` headings--this makes the topics in the toc in the sidebar appear at the wrong levels. I've pushed the second h1 down to h2 and shifted all of the following headings down a level accordingly. 