### PR TITLE
Java: refine type of parent column in `exprs` relation

### DIFF
--- a/java/ql/src/config/semmlecode.dbscheme
+++ b/java/ql/src/config/semmlecode.dbscheme
@@ -501,7 +501,7 @@ exprs(
   unique int id: @expr,
   int kind: int ref,
   int typeid: @type ref,
-  int parent: @element ref,
+  int parent: @exprparent ref,
   int idx: int ref
 );
 


### PR DESCRIPTION
Should be merged together with the corresponding internal PR.