### PR TITLE
Java: restrict `java/non-sync-override` to immediate overrides

### DIFF
--- a/change-notes/1.23/analysis-java.md
+++ b/change-notes/1.23/analysis-java.md
@@ -7,6 +7,7 @@ The following changes in version 1.23 affect Java analysis in all applications.
 | **Query**                    | **Expected impact**    | **Change**                        |
 |------------------------------|------------------------|-----------------------------------|
 | Dereferenced variable may be null (`java/dereferenced-value-may-be-null`) | Fewer false positives | Certain indirect null guards involving two auxiliary variables known to be equal can now be detected. |
+| Non-synchronized override of synchronized method (`java/non-sync-override`) | Fewer false positives | Results are now only reported if the immediately overridden method is synchronized. |
 | Query built from user-controlled sources (`java/sql-injection`) | More results | The query now identifies arguments to `Statement.executeLargeUpdate` and `Connection.prepareCall` as SQL expressions sinks. |
 | Query built from local-user-controlled sources (`java/sql-injection-local`) | More results | The query now identifies arguments to `Statement.executeLargeUpdate` and `Connection.prepareCall` as SQL expressions sinks. |
 | Query built without neutralizing special characters (`java/concatenated-sql-query`) | More results | The query now identifies arguments to `Statement.executeLargeUpdate` and `Connection.prepareCall` as SQL expressions sinks. |

--- a/java/ql/src/Likely Bugs/Concurrency/NonSynchronizedOverride.ql
+++ b/java/ql/src/Likely Bugs/Concurrency/NonSynchronizedOverride.ql
@@ -56,6 +56,7 @@ where
   sup.isSynchronized() and
   not sub.isSynchronized() and
   not delegatingOverride(sub, sup) and
+  not exists(Method mid | sub.overrides(mid) and mid.overrides(sup)) and
   supSrc = sup.getDeclaringType().getSourceDeclaration()
 select sub,
   "Method '" + sub.getName() + "' overrides a synchronized method in $@ but is not synchronized.",


### PR DESCRIPTION
Resolves #2076 by fixing the false positive reported there.