### PR TITLE
Add qlpack.json files

### DIFF
--- a/cpp/ql/src/qlpack.json
+++ b/cpp/ql/src/qlpack.json
@@ -1,0 +1,5 @@
+{
+    "name": "codeql-cpp",
+    "version": "0.0.0",
+    "dbscheme": "semmlecode.cpp.dbscheme"
+}

--- a/csharp/ql/src/qlpack.json
+++ b/csharp/ql/src/qlpack.json
@@ -1,0 +1,5 @@
+{
+    "name": "codeql-csharp",
+    "version": "0.0.0",
+    "dbscheme": "semmlecode.csharp.dbscheme"
+}

--- a/java/ql/src/qlpack.json
+++ b/java/ql/src/qlpack.json
@@ -1,0 +1,5 @@
+{
+    "name": "codeql-java",
+    "version": "0.0.0",
+    "dbscheme": "config/semmlecode.dbscheme"
+}

--- a/javascript/ql/src/qlpack.json
+++ b/javascript/ql/src/qlpack.json
@@ -1,0 +1,5 @@
+{
+    "name": "codeql-javascript",
+    "version": "0.0.0",
+    "dbscheme": "semmlecode.javascript.dbscheme"
+}

--- a/misc/legacy-support/cpp/qlpack.json
+++ b/misc/legacy-support/cpp/qlpack.json
@@ -1,0 +1,5 @@
+{
+    "name": "legacy-libraries-cpp",
+    "version": "0.0.0",
+    "libraryPathDependencies": ["codeql-cpp"]
+}

--- a/misc/legacy-support/csharp/qlpack.json
+++ b/misc/legacy-support/csharp/qlpack.json
@@ -1,0 +1,5 @@
+{
+    "name": "legacy-libraries-csharp",
+    "version": "0.0.0",
+    "libraryPathDependencies": ["codeql-csharp"]
+}

--- a/misc/legacy-support/java/qlpack.json
+++ b/misc/legacy-support/java/qlpack.json
@@ -1,0 +1,5 @@
+{
+    "name": "legacy-libraries-java",
+    "version": "0.0.0",
+    "libraryPathDependencies": ["codeql-java"]
+}

--- a/misc/legacy-support/javascript/qlpack.json
+++ b/misc/legacy-support/javascript/qlpack.json
@@ -1,0 +1,5 @@
+{
+    "name": "legacy-libraries-javascript",
+    "version": "0.0.0",
+    "libraryPathDependencies": ["codeql-javascript"]
+}

--- a/misc/legacy-support/python/qlpack.json
+++ b/misc/legacy-support/python/qlpack.json
@@ -1,0 +1,5 @@
+{
+    "name": "legacy-libraries-python",
+    "version": "0.0.0",
+    "libraryPathDependencies": ["codeql-python"]
+}

--- a/python/ql/src/qlpack.json
+++ b/python/ql/src/qlpack.json
@@ -1,0 +1,5 @@
+{
+    "name": "codeql-python",
+    "version": "0.0.0",
+    "dbscheme": "semmlecode.python.dbscheme"
+}


### PR DESCRIPTION
Eventually these files will subsume the current `queries.xml` files at the top of query-containing and library directories. For now they're just here to support internal testing of the tooling support that we're writing on.

Format and contents is a work in progress. If you're not in Semmle, don't depend on anything here making sense (or staying stable) until you see the version tags increase to something nonzero.