### PR TITLE
CPP: Reword ComparisonPrecedence.ql query message.

### DIFF
--- a/cpp/ql/src/Likely Bugs/Arithmetic/ComparisonPrecedence.ql
+++ b/cpp/ql/src/Likely Bugs/Arithmetic/ComparisonPrecedence.ql
@@ -18,4 +18,4 @@ where
   co.getAChild() = chco and
   not chco.isParenthesised() and
   not co.isFromUninstantiatedTemplate(_)
-select co, "Check the comparison operator precedence."
+select co, "Comparison as an operand to another comparison." 

--- a/cpp/ql/src/Likely Bugs/Arithmetic/ComparisonPrecedence.ql
+++ b/cpp/ql/src/Likely Bugs/Arithmetic/ComparisonPrecedence.ql
@@ -18,4 +18,4 @@ where
   co.getAChild() = chco and
   not chco.isParenthesised() and
   not co.isFromUninstantiatedTemplate(_)
-select co, "Comparison as an operand to another comparison." 
+select co, "Comparison as an operand to another comparison."

--- a/cpp/ql/test/query-tests/Likely Bugs/Arithmetic/ComparisonPrecedence/ComparisonPrecedence.expected
+++ b/cpp/ql/test/query-tests/Likely Bugs/Arithmetic/ComparisonPrecedence/ComparisonPrecedence.expected
@@ -1,9 +1,9 @@
-| template.cpp:4:7:4:15 | ... < ... | Check the comparison operator precedence. |
-| test.cpp:42:6:42:14 | ... < ... | Check the comparison operator precedence. |
-| test.cpp:43:6:43:14 | ... > ... | Check the comparison operator precedence. |
-| test.cpp:44:6:44:16 | ... <= ... | Check the comparison operator precedence. |
-| test.cpp:45:6:45:16 | ... <= ... | Check the comparison operator precedence. |
-| test.cpp:46:6:46:14 | ... > ... | Check the comparison operator precedence. |
-| test.cpp:50:6:50:32 | ... < ... | Check the comparison operator precedence. |
-| test.cpp:51:6:51:18 | ... < ... | Check the comparison operator precedence. |
-| test.cpp:54:8:54:16 | ... < ... | Check the comparison operator precedence. |
+| template.cpp:4:7:4:15 | ... < ... | Comparison as an operand to another comparison. |
+| test.cpp:42:6:42:14 | ... < ... | Comparison as an operand to another comparison. |
+| test.cpp:43:6:43:14 | ... > ... | Comparison as an operand to another comparison. |
+| test.cpp:44:6:44:16 | ... <= ... | Comparison as an operand to another comparison. |
+| test.cpp:45:6:45:16 | ... <= ... | Comparison as an operand to another comparison. |
+| test.cpp:46:6:46:14 | ... > ... | Comparison as an operand to another comparison. |
+| test.cpp:50:6:50:32 | ... < ... | Comparison as an operand to another comparison. |
+| test.cpp:51:6:51:18 | ... < ... | Comparison as an operand to another comparison. |
+| test.cpp:54:8:54:16 | ... < ... | Comparison as an operand to another comparison. |


### PR DESCRIPTION
I'd promised to modernize the violation message but forgot to do so in https://github.com/Semmle/ql/pull/2035.

Please discuss if you can think of better wording for this or any part of the [query help](https://lgtm.com/rules/2158910263/).