### PR TITLE
Add general question issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/ql---general.md
+++ b/.github/ISSUE_TEMPLATE/ql---general.md
@@ -1,0 +1,14 @@
+---
+name: General issue
+about: Tell us if you think something is wrong or if you have a question
+title: General issue
+labels: question
+assignees: ''
+
+---
+
+**Description of the issue**
+
+<!-- Please explain briefly what is the problem.
+If it is about an LGTM project, please include its URL.-->
+


### PR DESCRIPTION
Adding another issue template to prevent users from creating false positive issues when they have a more general question or issue.