### PR TITLE
C++: Implement Pos and Spec as int, not newtype

### DIFF
--- a/cpp/ql/src/semmle/code/cpp/controlflow/internal/CFG.qll
+++ b/cpp/ql/src/semmle/code/cpp/controlflow/internal/CFG.qll
@@ -512,7 +512,7 @@ private class Spec extends Pos {
   predicate isBarrier() { this = 7 }
 
   Pos getSourcePos() {
-    this = [0..4] and
+    this = [0 .. 4] and
     result = this
     or
     this.isAround() and
@@ -523,7 +523,7 @@ private class Spec extends Pos {
   }
 
   Pos getTargetPos() {
-    this = [0..4] and
+    this = [0 .. 4] and
     result = this
     or
     this.isAround() and


### PR DESCRIPTION
This change gives a slight performance improvement and makes the QL code shorter. It introduces some magic numbers in the code, but those are confined to the `Pos` and `Spec` classes.

We get a speed-up because the evaluator has built-in support for integer literals in the `OUTPUT` of `JOIN` operations, whereas `newtype`s have to be explicitly joined on. As a result, a predicate like `CFG::straightLineSparse#ffff` drops from 262 pipeline nodes to 242.

I measured performance on https://github.com/jluttine/suitesparse, which is one of the projects that had the biggest slowdown when enabling the QL CFG on lgtm.com. I took two measurements before this change and two after. The `CFG.qll` stage took 117s and 112s before, and it took 106s and 107s after.