### PR TITLE
.gitignore += codeql

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,6 @@
 # Visual studio temporaries, except a file used by QL4VS
 .vs/*
 !.vs/VSWorkspaceSettings.json
+
+# It's useful (though not required) to be able to unpack codeql in the ql checkout itself
+/codeql/


### PR DESCRIPTION
It is useful (though not necessary) to be able to place codeql in a `Semmle/ql` checkout.