### PR TITLE
Dataflow: Fix bad join-order

### DIFF
--- a/cpp/ql/src/semmle/code/cpp/dataflow/internal/DataFlowImpl.qll
+++ b/cpp/ql/src/semmle/code/cpp/dataflow/internal/DataFlowImpl.qll
@@ -1683,6 +1683,11 @@ private class PathNodeMid extends PathNode, TPathNodeMid {
 
   override Configuration getConfiguration() { result = config }
 
+  pragma[noinline]
+  LocalCallContext getLocalCallContext() {
+    result = getLocalCallContext(cc, node.getEnclosingCallable())
+  }
+
   private PathNodeMid getSuccMid() {
     pathStep(this, result.getNode(), result.getCallContext(), result.getAp()) and
     result.getConfiguration() = unbind(this.getConfiguration())
@@ -1738,7 +1743,7 @@ private predicate pathStep(PathNodeMid mid, Node node, CallContext cc, AccessPat
     midnode = mid.getNode() and
     conf = mid.getConfiguration() and
     cc = mid.getCallContext() and
-    localCC = getLocalCallContext(cc, midnode.getEnclosingCallable()) and
+    localCC = mid.getLocalCallContext() and
     ap0 = mid.getAp()
   |
     localFlowBigStep(midnode, node, true, conf, localCC) and

--- a/cpp/ql/src/semmle/code/cpp/dataflow/internal/DataFlowImpl2.qll
+++ b/cpp/ql/src/semmle/code/cpp/dataflow/internal/DataFlowImpl2.qll
@@ -1683,6 +1683,11 @@ private class PathNodeMid extends PathNode, TPathNodeMid {
 
   override Configuration getConfiguration() { result = config }
 
+  pragma[noinline]
+  LocalCallContext getLocalCallContext() {
+    result = getLocalCallContext(cc, node.getEnclosingCallable())
+  }
+
   private PathNodeMid getSuccMid() {
     pathStep(this, result.getNode(), result.getCallContext(), result.getAp()) and
     result.getConfiguration() = unbind(this.getConfiguration())
@@ -1738,7 +1743,7 @@ private predicate pathStep(PathNodeMid mid, Node node, CallContext cc, AccessPat
     midnode = mid.getNode() and
     conf = mid.getConfiguration() and
     cc = mid.getCallContext() and
-    localCC = getLocalCallContext(cc, midnode.getEnclosingCallable()) and
+    localCC = mid.getLocalCallContext() and
     ap0 = mid.getAp()
   |
     localFlowBigStep(midnode, node, true, conf, localCC) and

--- a/cpp/ql/src/semmle/code/cpp/dataflow/internal/DataFlowImpl3.qll
+++ b/cpp/ql/src/semmle/code/cpp/dataflow/internal/DataFlowImpl3.qll
@@ -1683,6 +1683,11 @@ private class PathNodeMid extends PathNode, TPathNodeMid {
 
   override Configuration getConfiguration() { result = config }
 
+  pragma[noinline]
+  LocalCallContext getLocalCallContext() {
+    result = getLocalCallContext(cc, node.getEnclosingCallable())
+  }
+
   private PathNodeMid getSuccMid() {
     pathStep(this, result.getNode(), result.getCallContext(), result.getAp()) and
     result.getConfiguration() = unbind(this.getConfiguration())
@@ -1738,7 +1743,7 @@ private predicate pathStep(PathNodeMid mid, Node node, CallContext cc, AccessPat
     midnode = mid.getNode() and
     conf = mid.getConfiguration() and
     cc = mid.getCallContext() and
-    localCC = getLocalCallContext(cc, midnode.getEnclosingCallable()) and
+    localCC = mid.getLocalCallContext() and
     ap0 = mid.getAp()
   |
     localFlowBigStep(midnode, node, true, conf, localCC) and

--- a/cpp/ql/src/semmle/code/cpp/dataflow/internal/DataFlowImpl4.qll
+++ b/cpp/ql/src/semmle/code/cpp/dataflow/internal/DataFlowImpl4.qll
@@ -1683,6 +1683,11 @@ private class PathNodeMid extends PathNode, TPathNodeMid {
 
   override Configuration getConfiguration() { result = config }
 
+  pragma[noinline]
+  LocalCallContext getLocalCallContext() {
+    result = getLocalCallContext(cc, node.getEnclosingCallable())
+  }
+
   private PathNodeMid getSuccMid() {
     pathStep(this, result.getNode(), result.getCallContext(), result.getAp()) and
     result.getConfiguration() = unbind(this.getConfiguration())
@@ -1738,7 +1743,7 @@ private predicate pathStep(PathNodeMid mid, Node node, CallContext cc, AccessPat
     midnode = mid.getNode() and
     conf = mid.getConfiguration() and
     cc = mid.getCallContext() and
-    localCC = getLocalCallContext(cc, midnode.getEnclosingCallable()) and
+    localCC = mid.getLocalCallContext() and
     ap0 = mid.getAp()
   |
     localFlowBigStep(midnode, node, true, conf, localCC) and

--- a/cpp/ql/src/semmle/code/cpp/dataflow/internal/DataFlowImplLocal.qll
+++ b/cpp/ql/src/semmle/code/cpp/dataflow/internal/DataFlowImplLocal.qll
@@ -1683,6 +1683,11 @@ private class PathNodeMid extends PathNode, TPathNodeMid {
 
   override Configuration getConfiguration() { result = config }
 
+  pragma[noinline]
+  LocalCallContext getLocalCallContext() {
+    result = getLocalCallContext(cc, node.getEnclosingCallable())
+  }
+
   private PathNodeMid getSuccMid() {
     pathStep(this, result.getNode(), result.getCallContext(), result.getAp()) and
     result.getConfiguration() = unbind(this.getConfiguration())
@@ -1738,7 +1743,7 @@ private predicate pathStep(PathNodeMid mid, Node node, CallContext cc, AccessPat
     midnode = mid.getNode() and
     conf = mid.getConfiguration() and
     cc = mid.getCallContext() and
-    localCC = getLocalCallContext(cc, midnode.getEnclosingCallable()) and
+    localCC = mid.getLocalCallContext() and
     ap0 = mid.getAp()
   |
     localFlowBigStep(midnode, node, true, conf, localCC) and

--- a/cpp/ql/src/semmle/code/cpp/ir/dataflow/internal/DataFlowImpl.qll
+++ b/cpp/ql/src/semmle/code/cpp/ir/dataflow/internal/DataFlowImpl.qll
@@ -1683,6 +1683,11 @@ private class PathNodeMid extends PathNode, TPathNodeMid {
 
   override Configuration getConfiguration() { result = config }
 
+  pragma[noinline]
+  LocalCallContext getLocalCallContext() {
+    result = getLocalCallContext(cc, node.getEnclosingCallable())
+  }
+
   private PathNodeMid getSuccMid() {
     pathStep(this, result.getNode(), result.getCallContext(), result.getAp()) and
     result.getConfiguration() = unbind(this.getConfiguration())
@@ -1738,7 +1743,7 @@ private predicate pathStep(PathNodeMid mid, Node node, CallContext cc, AccessPat
     midnode = mid.getNode() and
     conf = mid.getConfiguration() and
     cc = mid.getCallContext() and
-    localCC = getLocalCallContext(cc, midnode.getEnclosingCallable()) and
+    localCC = mid.getLocalCallContext() and
     ap0 = mid.getAp()
   |
     localFlowBigStep(midnode, node, true, conf, localCC) and

--- a/cpp/ql/src/semmle/code/cpp/ir/dataflow/internal/DataFlowImpl2.qll
+++ b/cpp/ql/src/semmle/code/cpp/ir/dataflow/internal/DataFlowImpl2.qll
@@ -1683,6 +1683,11 @@ private class PathNodeMid extends PathNode, TPathNodeMid {
 
   override Configuration getConfiguration() { result = config }
 
+  pragma[noinline]
+  LocalCallContext getLocalCallContext() {
+    result = getLocalCallContext(cc, node.getEnclosingCallable())
+  }
+
   private PathNodeMid getSuccMid() {
     pathStep(this, result.getNode(), result.getCallContext(), result.getAp()) and
     result.getConfiguration() = unbind(this.getConfiguration())
@@ -1738,7 +1743,7 @@ private predicate pathStep(PathNodeMid mid, Node node, CallContext cc, AccessPat
     midnode = mid.getNode() and
     conf = mid.getConfiguration() and
     cc = mid.getCallContext() and
-    localCC = getLocalCallContext(cc, midnode.getEnclosingCallable()) and
+    localCC = mid.getLocalCallContext() and
     ap0 = mid.getAp()
   |
     localFlowBigStep(midnode, node, true, conf, localCC) and

--- a/cpp/ql/src/semmle/code/cpp/ir/dataflow/internal/DataFlowImpl3.qll
+++ b/cpp/ql/src/semmle/code/cpp/ir/dataflow/internal/DataFlowImpl3.qll
@@ -1683,6 +1683,11 @@ private class PathNodeMid extends PathNode, TPathNodeMid {
 
   override Configuration getConfiguration() { result = config }
 
+  pragma[noinline]
+  LocalCallContext getLocalCallContext() {
+    result = getLocalCallContext(cc, node.getEnclosingCallable())
+  }
+
   private PathNodeMid getSuccMid() {
     pathStep(this, result.getNode(), result.getCallContext(), result.getAp()) and
     result.getConfiguration() = unbind(this.getConfiguration())
@@ -1738,7 +1743,7 @@ private predicate pathStep(PathNodeMid mid, Node node, CallContext cc, AccessPat
     midnode = mid.getNode() and
     conf = mid.getConfiguration() and
     cc = mid.getCallContext() and
-    localCC = getLocalCallContext(cc, midnode.getEnclosingCallable()) and
+    localCC = mid.getLocalCallContext() and
     ap0 = mid.getAp()
   |
     localFlowBigStep(midnode, node, true, conf, localCC) and

--- a/cpp/ql/src/semmle/code/cpp/ir/dataflow/internal/DataFlowImpl4.qll
+++ b/cpp/ql/src/semmle/code/cpp/ir/dataflow/internal/DataFlowImpl4.qll
@@ -1683,6 +1683,11 @@ private class PathNodeMid extends PathNode, TPathNodeMid {
 
   override Configuration getConfiguration() { result = config }
 
+  pragma[noinline]
+  LocalCallContext getLocalCallContext() {
+    result = getLocalCallContext(cc, node.getEnclosingCallable())
+  }
+
   private PathNodeMid getSuccMid() {
     pathStep(this, result.getNode(), result.getCallContext(), result.getAp()) and
     result.getConfiguration() = unbind(this.getConfiguration())
@@ -1738,7 +1743,7 @@ private predicate pathStep(PathNodeMid mid, Node node, CallContext cc, AccessPat
     midnode = mid.getNode() and
     conf = mid.getConfiguration() and
     cc = mid.getCallContext() and
-    localCC = getLocalCallContext(cc, midnode.getEnclosingCallable()) and
+    localCC = mid.getLocalCallContext() and
     ap0 = mid.getAp()
   |
     localFlowBigStep(midnode, node, true, conf, localCC) and

--- a/csharp/ql/src/semmle/code/csharp/dataflow/internal/DataFlowImpl.qll
+++ b/csharp/ql/src/semmle/code/csharp/dataflow/internal/DataFlowImpl.qll
@@ -1683,6 +1683,11 @@ private class PathNodeMid extends PathNode, TPathNodeMid {
 
   override Configuration getConfiguration() { result = config }
 
+  pragma[noinline]
+  LocalCallContext getLocalCallContext() {
+    result = getLocalCallContext(cc, node.getEnclosingCallable())
+  }
+
   private PathNodeMid getSuccMid() {
     pathStep(this, result.getNode(), result.getCallContext(), result.getAp()) and
     result.getConfiguration() = unbind(this.getConfiguration())
@@ -1738,7 +1743,7 @@ private predicate pathStep(PathNodeMid mid, Node node, CallContext cc, AccessPat
     midnode = mid.getNode() and
     conf = mid.getConfiguration() and
     cc = mid.getCallContext() and
-    localCC = getLocalCallContext(cc, midnode.getEnclosingCallable()) and
+    localCC = mid.getLocalCallContext() and
     ap0 = mid.getAp()
   |
     localFlowBigStep(midnode, node, true, conf, localCC) and

--- a/csharp/ql/src/semmle/code/csharp/dataflow/internal/DataFlowImpl2.qll
+++ b/csharp/ql/src/semmle/code/csharp/dataflow/internal/DataFlowImpl2.qll
@@ -1683,6 +1683,11 @@ private class PathNodeMid extends PathNode, TPathNodeMid {
 
   override Configuration getConfiguration() { result = config }
 
+  pragma[noinline]
+  LocalCallContext getLocalCallContext() {
+    result = getLocalCallContext(cc, node.getEnclosingCallable())
+  }
+
   private PathNodeMid getSuccMid() {
     pathStep(this, result.getNode(), result.getCallContext(), result.getAp()) and
     result.getConfiguration() = unbind(this.getConfiguration())
@@ -1738,7 +1743,7 @@ private predicate pathStep(PathNodeMid mid, Node node, CallContext cc, AccessPat
     midnode = mid.getNode() and
     conf = mid.getConfiguration() and
     cc = mid.getCallContext() and
-    localCC = getLocalCallContext(cc, midnode.getEnclosingCallable()) and
+    localCC = mid.getLocalCallContext() and
     ap0 = mid.getAp()
   |
     localFlowBigStep(midnode, node, true, conf, localCC) and

--- a/csharp/ql/src/semmle/code/csharp/dataflow/internal/DataFlowImpl3.qll
+++ b/csharp/ql/src/semmle/code/csharp/dataflow/internal/DataFlowImpl3.qll
@@ -1683,6 +1683,11 @@ private class PathNodeMid extends PathNode, TPathNodeMid {
 
   override Configuration getConfiguration() { result = config }
 
+  pragma[noinline]
+  LocalCallContext getLocalCallContext() {
+    result = getLocalCallContext(cc, node.getEnclosingCallable())
+  }
+
   private PathNodeMid getSuccMid() {
     pathStep(this, result.getNode(), result.getCallContext(), result.getAp()) and
     result.getConfiguration() = unbind(this.getConfiguration())
@@ -1738,7 +1743,7 @@ private predicate pathStep(PathNodeMid mid, Node node, CallContext cc, AccessPat
     midnode = mid.getNode() and
     conf = mid.getConfiguration() and
     cc = mid.getCallContext() and
-    localCC = getLocalCallContext(cc, midnode.getEnclosingCallable()) and
+    localCC = mid.getLocalCallContext() and
     ap0 = mid.getAp()
   |
     localFlowBigStep(midnode, node, true, conf, localCC) and

--- a/csharp/ql/src/semmle/code/csharp/dataflow/internal/DataFlowImpl4.qll
+++ b/csharp/ql/src/semmle/code/csharp/dataflow/internal/DataFlowImpl4.qll
@@ -1683,6 +1683,11 @@ private class PathNodeMid extends PathNode, TPathNodeMid {
 
   override Configuration getConfiguration() { result = config }
 
+  pragma[noinline]
+  LocalCallContext getLocalCallContext() {
+    result = getLocalCallContext(cc, node.getEnclosingCallable())
+  }
+
   private PathNodeMid getSuccMid() {
     pathStep(this, result.getNode(), result.getCallContext(), result.getAp()) and
     result.getConfiguration() = unbind(this.getConfiguration())
@@ -1738,7 +1743,7 @@ private predicate pathStep(PathNodeMid mid, Node node, CallContext cc, AccessPat
     midnode = mid.getNode() and
     conf = mid.getConfiguration() and
     cc = mid.getCallContext() and
-    localCC = getLocalCallContext(cc, midnode.getEnclosingCallable()) and
+    localCC = mid.getLocalCallContext() and
     ap0 = mid.getAp()
   |
     localFlowBigStep(midnode, node, true, conf, localCC) and

--- a/csharp/ql/src/semmle/code/csharp/dataflow/internal/DataFlowImpl5.qll
+++ b/csharp/ql/src/semmle/code/csharp/dataflow/internal/DataFlowImpl5.qll
@@ -1683,6 +1683,11 @@ private class PathNodeMid extends PathNode, TPathNodeMid {
 
   override Configuration getConfiguration() { result = config }
 
+  pragma[noinline]
+  LocalCallContext getLocalCallContext() {
+    result = getLocalCallContext(cc, node.getEnclosingCallable())
+  }
+
   private PathNodeMid getSuccMid() {
     pathStep(this, result.getNode(), result.getCallContext(), result.getAp()) and
     result.getConfiguration() = unbind(this.getConfiguration())
@@ -1738,7 +1743,7 @@ private predicate pathStep(PathNodeMid mid, Node node, CallContext cc, AccessPat
     midnode = mid.getNode() and
     conf = mid.getConfiguration() and
     cc = mid.getCallContext() and
-    localCC = getLocalCallContext(cc, midnode.getEnclosingCallable()) and
+    localCC = mid.getLocalCallContext() and
     ap0 = mid.getAp()
   |
     localFlowBigStep(midnode, node, true, conf, localCC) and

--- a/java/ql/src/semmle/code/java/dataflow/internal/DataFlowImpl.qll
+++ b/java/ql/src/semmle/code/java/dataflow/internal/DataFlowImpl.qll
@@ -1683,6 +1683,11 @@ private class PathNodeMid extends PathNode, TPathNodeMid {
 
   override Configuration getConfiguration() { result = config }
 
+  pragma[noinline]
+  LocalCallContext getLocalCallContext() {
+    result = getLocalCallContext(cc, node.getEnclosingCallable())
+  }
+
   private PathNodeMid getSuccMid() {
     pathStep(this, result.getNode(), result.getCallContext(), result.getAp()) and
     result.getConfiguration() = unbind(this.getConfiguration())
@@ -1738,7 +1743,7 @@ private predicate pathStep(PathNodeMid mid, Node node, CallContext cc, AccessPat
     midnode = mid.getNode() and
     conf = mid.getConfiguration() and
     cc = mid.getCallContext() and
-    localCC = getLocalCallContext(cc, midnode.getEnclosingCallable()) and
+    localCC = mid.getLocalCallContext() and
     ap0 = mid.getAp()
   |
     localFlowBigStep(midnode, node, true, conf, localCC) and

--- a/java/ql/src/semmle/code/java/dataflow/internal/DataFlowImpl2.qll
+++ b/java/ql/src/semmle/code/java/dataflow/internal/DataFlowImpl2.qll
@@ -1683,6 +1683,11 @@ private class PathNodeMid extends PathNode, TPathNodeMid {
 
   override Configuration getConfiguration() { result = config }
 
+  pragma[noinline]
+  LocalCallContext getLocalCallContext() {
+    result = getLocalCallContext(cc, node.getEnclosingCallable())
+  }
+
   private PathNodeMid getSuccMid() {
     pathStep(this, result.getNode(), result.getCallContext(), result.getAp()) and
     result.getConfiguration() = unbind(this.getConfiguration())
@@ -1738,7 +1743,7 @@ private predicate pathStep(PathNodeMid mid, Node node, CallContext cc, AccessPat
     midnode = mid.getNode() and
     conf = mid.getConfiguration() and
     cc = mid.getCallContext() and
-    localCC = getLocalCallContext(cc, midnode.getEnclosingCallable()) and
+    localCC = mid.getLocalCallContext() and
     ap0 = mid.getAp()
   |
     localFlowBigStep(midnode, node, true, conf, localCC) and

--- a/java/ql/src/semmle/code/java/dataflow/internal/DataFlowImpl3.qll
+++ b/java/ql/src/semmle/code/java/dataflow/internal/DataFlowImpl3.qll
@@ -1683,6 +1683,11 @@ private class PathNodeMid extends PathNode, TPathNodeMid {
 
   override Configuration getConfiguration() { result = config }
 
+  pragma[noinline]
+  LocalCallContext getLocalCallContext() {
+    result = getLocalCallContext(cc, node.getEnclosingCallable())
+  }
+
   private PathNodeMid getSuccMid() {
     pathStep(this, result.getNode(), result.getCallContext(), result.getAp()) and
     result.getConfiguration() = unbind(this.getConfiguration())
@@ -1738,7 +1743,7 @@ private predicate pathStep(PathNodeMid mid, Node node, CallContext cc, AccessPat
     midnode = mid.getNode() and
     conf = mid.getConfiguration() and
     cc = mid.getCallContext() and
-    localCC = getLocalCallContext(cc, midnode.getEnclosingCallable()) and
+    localCC = mid.getLocalCallContext() and
     ap0 = mid.getAp()
   |
     localFlowBigStep(midnode, node, true, conf, localCC) and

--- a/java/ql/src/semmle/code/java/dataflow/internal/DataFlowImpl4.qll
+++ b/java/ql/src/semmle/code/java/dataflow/internal/DataFlowImpl4.qll
@@ -1683,6 +1683,11 @@ private class PathNodeMid extends PathNode, TPathNodeMid {
 
   override Configuration getConfiguration() { result = config }
 
+  pragma[noinline]
+  LocalCallContext getLocalCallContext() {
+    result = getLocalCallContext(cc, node.getEnclosingCallable())
+  }
+
   private PathNodeMid getSuccMid() {
     pathStep(this, result.getNode(), result.getCallContext(), result.getAp()) and
     result.getConfiguration() = unbind(this.getConfiguration())
@@ -1738,7 +1743,7 @@ private predicate pathStep(PathNodeMid mid, Node node, CallContext cc, AccessPat
     midnode = mid.getNode() and
     conf = mid.getConfiguration() and
     cc = mid.getCallContext() and
-    localCC = getLocalCallContext(cc, midnode.getEnclosingCallable()) and
+    localCC = mid.getLocalCallContext() and
     ap0 = mid.getAp()
   |
     localFlowBigStep(midnode, node, true, conf, localCC) and

--- a/java/ql/src/semmle/code/java/dataflow/internal/DataFlowImpl5.qll
+++ b/java/ql/src/semmle/code/java/dataflow/internal/DataFlowImpl5.qll
@@ -1683,6 +1683,11 @@ private class PathNodeMid extends PathNode, TPathNodeMid {
 
   override Configuration getConfiguration() { result = config }
 
+  pragma[noinline]
+  LocalCallContext getLocalCallContext() {
+    result = getLocalCallContext(cc, node.getEnclosingCallable())
+  }
+
   private PathNodeMid getSuccMid() {
     pathStep(this, result.getNode(), result.getCallContext(), result.getAp()) and
     result.getConfiguration() = unbind(this.getConfiguration())
@@ -1738,7 +1743,7 @@ private predicate pathStep(PathNodeMid mid, Node node, CallContext cc, AccessPat
     midnode = mid.getNode() and
     conf = mid.getConfiguration() and
     cc = mid.getCallContext() and
-    localCC = getLocalCallContext(cc, midnode.getEnclosingCallable()) and
+    localCC = mid.getLocalCallContext() and
     ap0 = mid.getAp()
   |
     localFlowBigStep(midnode, node, true, conf, localCC) and


### PR DESCRIPTION
Follow-up on https://github.com/Semmle/ql/pull/2099: For C#, the previous PR resulted in a bad join-order:
```
[2019-10-15 19:28:42] (123s) Starting to evaluate predicate DataFlowImpl2::pathStep#ffff#cur_delta/4[6]@5d7f44 (iteration 6)
[2019-10-15 19:34:47] (488s) Tuple counts for DataFlowImpl2::pathStep#ffff#cur_delta:
                      3356       ~0%       {5} r1 = SCAN DataFlowImpl2::PathNodeMid#class#fffff#prev_delta AS I OUTPUT I.<2>, I.<0>, I.<1>, I.<3>, I.<4>
                      2622677084 ~3%       {7} r2 = JOIN r1 WITH DataFlowImplCommon::ImplCommon::getLocalCallContext#fff AS R ON FIRST 1 OUTPUT r1.<2>, R.<1>, r1.<1>, r1.<0>, r1.<3>, r1.<4>, R.<2>
                      3355       ~2%       {7} r3 = JOIN r2 WITH DataFlowPublic::Node::getEnclosingCallable_dispred#ff@staged_ext AS R ON FIRST 2 OUTPUT r2.<0>, true, r2.<5>, r2.<6>, r2.<2>, r2.<3>, r2.<4>
                      22         ~0%       {4} r4 = JOIN r3 WITH DataFlowImpl2::localFlowBigStep#fffff_02341#join_rhs AS R ON FIRST 4 OUTPUT r3.<4>, r3.<5>, r3.<6>, R.<4>
                      3355       ~1%       {6} r5 = JOIN r2 WITH DataFlowPublic::Node::getEnclosingCallable_dispred#ff@staged_ext AS R ON FIRST 2 OUTPUT r2.<4>, r2.<2>, r2.<0>, r2.<3>, r2.<5>, r2.<6>
                      3355       ~0%       {6} r6 = JOIN r5 WITH DataFlowImpl2::TNil#ff_1#join_rhs AS R ON FIRST 1 OUTPUT r5.<2>, false, r5.<4>, r5.<5>, r5.<1>, r5.<3>
                      0          ~0%       {3} r7 = JOIN r6 WITH DataFlowImpl2::localFlowBigStep#fffff_02341#join_rhs AS R ON FIRST 4 OUTPUT R.<4>, r6.<4>, r6.<5>
                      0          ~0%       {4} r8 = JOIN r7 WITH DataFlowImpl2::AccessPathNilNode::getAp_dispred#ff AS R ON FIRST 1 OUTPUT r7.<1>, r7.<2>, R.<1>, r7.<0>
                      22         ~0%       {4} r9 = r4 \/ r8
                      3356       ~0%       {4} r10 = JOIN DataFlowImplCommon::ImplCommon::Cached::TAnyCallContext#f@staged_ext AS L WITH DataFlowImpl2::PathNodeMid#class#fffff#prev_delta AS R CARTESIAN PRODUCT OUTPUT R.<1>, L.<0>, R.<0>, R.<3>
                      0          ~0%       {4} r11 = JOIN r10 WITH DataFlowPrivate::Cached::jumpStepImpl#ff@staged_ext AS R ON FIRST 1 OUTPUT r10.<2>, r10.<1>, r10.<3>, R.<1>
                      22         ~0%       {4} r12 = r9 \/ r11
                      0          ~0%       {4} r13 = JOIN DataFlowImpl2::contentReadStep#fff#prev_delta AS L WITH DataFlowImpl2::PathNodeMid#class#fffff#prev AS R ON FIRST 1 OUTPUT L.<0>, R.<2>, L.<2>, L.<1>
                      22         ~0%       {4} r14 = r12 \/ r13
                      3356       ~0%       {2} r15 = SCAN DataFlowImpl2::PathNodeMid#class#fffff#prev_delta AS I OUTPUT I.<0>, I.<2>
                      0          ~0%       {4} r16 = JOIN r15 WITH DataFlowImpl2::contentReadStep#fff#prev AS R ON FIRST 1 OUTPUT r15.<0>, r15.<1>, R.<2>, R.<1>
                      22         ~0%       {4} r17 = r14 \/ r16
                      0          ~0%       {5} r18 = SCAN DataFlowImpl2::contentStoreStep#fffbf#prev_delta AS I OUTPUT I.<3>, I.<2>, I.<0>, I.<1>, I.<4>
                      0          ~0%       {4} r19 = JOIN r18 WITH DataFlowImpl2::pop#fff_120#join_rhs AS R ON FIRST 2 OUTPUT r18.<2>, r18.<4>, R.<2>, r18.<3>
                      22         ~0%       {4} r20 = r17 \/ r19
                      0          ~0%       {4} r21 = JOIN DataFlowImpl2::pathOutOfArgument#fff#prev_delta AS L WITH DataFlowImpl2::PathNodeMid#class#fffff#prev AS R ON FIRST 1 OUTPUT L.<0>, L.<2>, R.<3>, L.<1>
                      22         ~0%       {4} r22 = r20 \/ r21
                      3356       ~0%       {2} r23 = SCAN DataFlowImpl2::PathNodeMid#class#fffff#prev_delta AS I OUTPUT I.<0>, I.<3>
                      0          ~0%       {4} r24 = JOIN r23 WITH DataFlowImpl2::pathOutOfArgument#fff#prev AS R ON FIRST 1 OUTPUT r23.<0>, R.<2>, r23.<1>, R.<1>
                      22         ~0%       {4} r25 = r22 \/ r24
                      0          ~0%       {3} r26 = SCAN DataFlowImpl2::pathIntoCallable#fffff#prev_delta AS I OUTPUT I.<0>, I.<1>, I.<3>
                      0          ~0%       {4} r27 = JOIN r26 WITH DataFlowImpl2::PathNodeMid#class#fffff#prev AS R ON FIRST 1 OUTPUT r26.<0>, r26.<2>, R.<3>, r26.<1>
                      22         ~0%       {4} r28 = r25 \/ r27
                      0          ~0%       {4} r29 = JOIN r23 WITH DataFlowImpl2::pathIntoCallable#fffff#prev AS R ON FIRST 1 OUTPUT r23.<0>, R.<3>, r23.<1>, R.<1>
                      22         ~0%       {4} r30 = r28 \/ r29
                      0          ~0%       {4} r31 = JOIN DataFlowImpl2::pathOutOfCallable#fff#prev_delta AS L WITH DataFlowImpl2::PathNodeMid#class#fffff#prev AS R ON FIRST 1 OUTPUT L.<0>, L.<2>, R.<3>, L.<1>
                      22         ~0%       {4} r32 = r30 \/ r31
                      0          ~0%       {4} r33 = JOIN r23 WITH DataFlowImpl2::pathOutOfCallable#fff#prev AS R ON FIRST 1 OUTPUT r23.<0>, R.<2>, r23.<1>, R.<1>
                      22         ~0%       {4} r34 = r32 \/ r33
                      0          ~0%       {4} r35 = SCAN DataFlowImpl2::pathThroughCallable#ffff#prev_delta AS I OUTPUT I.<0>, I.<2>, I.<3>, I.<1>
                      22         ~0%       {4} r36 = r34 \/ r35
                      0          ~0%       {5} r37 = JOIN r23 WITH DataFlowImpl2::valuePathThroughCallable0#ffff#reorder_1_0_2_3#prev AS R ON FIRST 1 OUTPUT R.<2>, R.<1>, r23.<0>, r23.<1>, R.<3>
                      0          ~0%       {4} r38 = JOIN r37 WITH DataFlowPrivate::OutNode::getCall_dispred#fff_120#join_rhs AS R ON FIRST 2 OUTPUT r37.<2>, r37.<4>, r37.<3>, R.<2>
                      22         ~0%       {4} r39 = r36 \/ r38
                      0          ~0%       {5} r40 = JOIN DataFlowImpl2::valuePathThroughCallable0#ffff#reorder_1_0_2_3#prev_delta AS L WITH DataFlowImpl2::PathNodeMid#class#fffff#prev AS R ON FIRST 1 OUTPUT L.<2>, L.<1>, L.<0>, L.<3>, R.<3>
                      0          ~0%       {4} r41 = JOIN r40 WITH DataFlowPrivate::OutNode::getCall_dispred#fff_120#join_rhs AS R ON FIRST 2 OUTPUT r40.<2>, r40.<3>, r40.<4>, R.<2>
                      22         ~0%       {4} r42 = r39 \/ r41
                      22         ~0%       {4} r43 = r42 AND NOT DataFlowImpl2::pathStep#ffff#prev AS R(r42.<0>, r42.<3>, r42.<1>, r42.<2>)
                      22         ~4%       {4} r44 = SCAN r43 OUTPUT r43.<0>, r43.<3>, r43.<1>, r43.<2>
                                           return r44

```
This PR fixes the join-order. I have started a dist-compare for C#, and will post the results here once it is ready.