### PR TITLE
Python: Modernise flask + correctly handle flask.make_response

### DIFF
--- a/python/ql/src/Security/CWE-215/FlaskDebug.ql
+++ b/python/ql/src/Security/CWE-215/FlaskDebug.ql
@@ -17,7 +17,7 @@ import semmle.python.web.flask.General
 
 from CallNode call, Object isTrue
 where
-    call = theFlaskClass().declaredAttribute("run").(FunctionObject).getACall() and
+    call = theFlaskClass().declaredAttribute("run").(FunctionValue).getACall() and
     call.getArgByName("debug").refersTo(isTrue) and
     isTrue.booleanValue() = true
 select call, "A Flask app appears to be run in debug mode. This may allow an attacker to run arbitrary code through the debugger."

--- a/python/ql/src/semmle/python/web/flask/General.qll
+++ b/python/ql/src/semmle/python/web/flask/General.qll
@@ -1,5 +1,6 @@
 import python
 import semmle.python.web.Http
+import semmle.python.web.flask.Response
 
 /** The flask app class */
 ClassValue theFlaskClass() { result = Value::named("flask.Flask") }
@@ -92,7 +93,7 @@ private class AsView extends TaintSource {
 
 class FlaskCookieSet extends CookieSet, CallNode {
     FlaskCookieSet() {
-        this.getFunction().(AttrNode).getObject("set_cookie").pointsTo().getClass() = theFlaskReponseClass()
+        any(FlaskResponseTaintKind t).taints(this.getFunction().(AttrNode).getObject("set_cookie"))
     }
 
     override string toString() { result = CallNode.super.toString() }

--- a/python/ql/src/semmle/python/web/flask/Redirect.qll
+++ b/python/ql/src/semmle/python/web/flask/Redirect.qll
@@ -8,8 +8,8 @@ import semmle.python.security.TaintTracking
 import semmle.python.security.strings.Basic
 import semmle.python.web.flask.General
 
-FunctionObject flask_redirect() {
-    result = theFlaskModule().attr("redirect")
+FunctionValue flask_redirect() {
+    result = Value::named("flask.redirect")
 }
 
 /**

--- a/python/ql/src/semmle/python/web/flask/Redirect.qll
+++ b/python/ql/src/semmle/python/web/flask/Redirect.qll
@@ -1,25 +1,21 @@
-/** Provides class representing the `flask.redirect` function.
+/**
+ * Provides class representing the `flask.redirect` function.
  * This module is intended to be imported into a taint-tracking query
  * to extend `TaintSink`.
  */
-import python
 
+import python
 import semmle.python.security.TaintTracking
 import semmle.python.security.strings.Basic
 import semmle.python.web.flask.General
 
-FunctionValue flask_redirect() {
-    result = Value::named("flask.redirect")
-}
+FunctionValue flask_redirect() { result = Value::named("flask.redirect") }
 
 /**
  * Represents an argument to the `flask.redirect` function.
  */
 class FlaskRedirect extends HttpRedirectTaintSink {
-
-    override string toString() {
-        result = "flask.redirect"
-    }
+    override string toString() { result = "flask.redirect" }
 
     FlaskRedirect() {
         exists(CallNode call |
@@ -27,5 +23,4 @@ class FlaskRedirect extends HttpRedirectTaintSink {
             this = call.getAnArg()
         )
     }
-
 }

--- a/python/ql/src/semmle/python/web/flask/Request.qll
+++ b/python/ql/src/semmle/python/web/flask/Request.qll
@@ -4,15 +4,15 @@ import semmle.python.security.TaintTracking
 import semmle.python.web.Http
 import semmle.python.web.flask.General
 
-private Object theFlaskRequestObject() {
-    result = theFlaskModule().attr("request")
+private Value theFlaskRequestObject() {
+    result = Value::named("flask.request")
 
 }
 
 /** Holds if `attr` is an access of attribute `name` of the flask request object */
 private predicate flask_request_attr(AttrNode attr, string name) {
     attr.isLoad() and
-    attr.getObject(name).refersTo(theFlaskRequestObject())
+    attr.getObject(name).pointsTo(theFlaskRequestObject())
 }
 
 /** Source of external data from a flask request */

--- a/python/ql/src/semmle/python/web/flask/Request.qll
+++ b/python/ql/src/semmle/python/web/flask/Request.qll
@@ -1,13 +1,9 @@
 import python
-
 import semmle.python.security.TaintTracking
 import semmle.python.web.Http
 import semmle.python.web.flask.General
 
-private Value theFlaskRequestObject() {
-    result = Value::named("flask.request")
-
-}
+private Value theFlaskRequestObject() { result = Value::named("flask.request") }
 
 /** Holds if `attr` is an access of attribute `name` of the flask request object */
 private predicate flask_request_attr(AttrNode attr, string name) {
@@ -17,63 +13,44 @@ private predicate flask_request_attr(AttrNode attr, string name) {
 
 /** Source of external data from a flask request */
 class FlaskRequestData extends HttpRequestTaintSource {
-
     FlaskRequestData() {
         not this instanceof FlaskRequestArgs and
-        exists(string name |
-            flask_request_attr(this, name) |
-            name = "path" or name = "full_path" or
-            name = "base_url" or name = "url"
+        exists(string name | flask_request_attr(this, name) |
+            name = "path" or
+            name = "full_path" or
+            name = "base_url" or
+            name = "url"
         )
     }
 
-    override predicate isSourceOf(TaintKind kind) { 
-        kind instanceof ExternalStringKind
-    }
+    override predicate isSourceOf(TaintKind kind) { kind instanceof ExternalStringKind }
 
-    override string toString() {
-        result = "flask.request"
-    }
-
+    override string toString() { result = "flask.request" }
 }
 
 /** Source of dictionary whose values are externally controlled */
 class FlaskRequestArgs extends HttpRequestTaintSource {
-
     FlaskRequestArgs() {
-        exists(string attr |
-            flask_request_attr(this, attr) |
-            attr = "args" or attr = "form" or
-            attr = "values" or attr = "files" or
-            attr = "headers" or attr = "json"
+        exists(string attr | flask_request_attr(this, attr) |
+            attr = "args" or
+            attr = "form" or
+            attr = "values" or
+            attr = "files" or
+            attr = "headers" or
+            attr = "json"
         )
     }
 
-    override predicate isSourceOf(TaintKind kind) {
-        kind instanceof ExternalStringDictKind
-    }
+    override predicate isSourceOf(TaintKind kind) { kind instanceof ExternalStringDictKind }
 
-    override string toString() {
-        result = "flask.request.args"
-    }
-
+    override string toString() { result = "flask.request.args" }
 }
-
 
 /** Source of dictionary whose values are externally controlled */
 class FlaskRequestJson extends TaintSource {
+    FlaskRequestJson() { flask_request_attr(this, "json") }
 
-    FlaskRequestJson() {
-        flask_request_attr(this, "json")
-    }
+    override predicate isSourceOf(TaintKind kind) { kind instanceof ExternalJsonKind }
 
-    override predicate isSourceOf(TaintKind kind) {
-        kind instanceof ExternalJsonKind
-    }
-
-    override string toString() {
-        result = "flask.request.json"
-    }
-
+    override string toString() { result = "flask.request.json" }
 }
-

--- a/python/ql/src/semmle/python/web/flask/Response.qll
+++ b/python/ql/src/semmle/python/web/flask/Response.qll
@@ -32,7 +32,7 @@ class FlaskResponseArgument extends HttpResponseTaintSink {
 
     FlaskResponseArgument() {
         exists(CallNode call |
-            call.getFunction().refersTo(theFlaskReponseClass()) and
+            call.getFunction().pointsTo(theFlaskReponseClass()) and
             call.getArg(0) = this
         )
     }

--- a/python/ql/src/semmle/python/web/flask/Response.qll
+++ b/python/ql/src/semmle/python/web/flask/Response.qll
@@ -1,15 +1,13 @@
 import python
-
-
 import semmle.python.security.TaintTracking
 import semmle.python.security.strings.Basic
-
 import semmle.python.web.flask.General
 
-/** A flask response, which is vulnerable to any sort of 
- * http response malice. */
+/**
+ * A flask response, which is vulnerable to any sort of
+ * http response malice.
+ */
 class FlaskRoutedResponse extends HttpResponseTaintSink {
-
     FlaskRoutedResponse() {
         exists(PyFunctionObject response |
             flask_routing(_, response.getFunction()) and
@@ -17,19 +15,12 @@ class FlaskRoutedResponse extends HttpResponseTaintSink {
         )
     }
 
-    override predicate sinks(TaintKind kind) {
-        kind instanceof StringKind
-    }
+    override predicate sinks(TaintKind kind) { kind instanceof StringKind }
 
-    override string toString() {
-        result = "flask.routed.response"
-    }
-
+    override string toString() { result = "flask.routed.response" }
 }
 
-
 class FlaskResponseArgument extends HttpResponseTaintSink {
-
     FlaskResponseArgument() {
         exists(CallNode call |
             call.getFunction().pointsTo(theFlaskReponseClass()) and
@@ -37,12 +28,7 @@ class FlaskResponseArgument extends HttpResponseTaintSink {
         )
     }
 
-    override predicate sinks(TaintKind kind) {
-        kind instanceof StringKind
-    }
+    override predicate sinks(TaintKind kind) { kind instanceof StringKind }
 
-    override string toString() {
-        result = "flask.response.argument"
-    }
-
+    override string toString() { result = "flask.response.argument" }
 }

--- a/python/ql/test/library-tests/web/flask/Routing.expected
+++ b/python/ql/test/library-tests/web/flask/Routing.expected
@@ -1,0 +1,4 @@
+| / | Function hello |
+| /dangerous | Function dangerous |
+| /dangerous-with-cfg-split | Function dangerous2 |
+| /the/ | Function get |

--- a/python/ql/test/library-tests/web/flask/Routing.expected
+++ b/python/ql/test/library-tests/web/flask/Routing.expected
@@ -1,4 +1,6 @@
 | / | Function hello |
 | /dangerous | Function dangerous |
 | /dangerous-with-cfg-split | Function dangerous2 |
+| /safe | Function safe |
 | /the/ | Function get |
+| /unsafe | Function unsafe |

--- a/python/ql/test/library-tests/web/flask/Routing.ql
+++ b/python/ql/test/library-tests/web/flask/Routing.ql
@@ -1,0 +1,9 @@
+import python
+
+import semmle.python.web.flask.General
+
+from ControlFlowNode regex, Function func
+
+where flask_routing(regex, func)
+
+select regex.getNode().(StrConst).getText(), func.toString()

--- a/python/ql/test/library-tests/web/flask/Sinks.expected
+++ b/python/ql/test/library-tests/web/flask/Sinks.expected
@@ -1,0 +1,4 @@
+| test.py:8 | Str | externally controlled string |
+| test.py:29 | Attribute() | externally controlled string |
+| test.py:35 | Subscript | externally controlled string |
+| test.py:36 | None | externally controlled string |

--- a/python/ql/test/library-tests/web/flask/Sinks.expected
+++ b/python/ql/test/library-tests/web/flask/Sinks.expected
@@ -2,3 +2,7 @@
 | test.py:29 | Attribute() | externally controlled string |
 | test.py:35 | Subscript | externally controlled string |
 | test.py:36 | None | externally controlled string |
+| test.py:41 | BinaryExpr | externally controlled string |
+| test.py:41 | make_response() | externally controlled string |
+| test.py:46 | BinaryExpr | externally controlled string |
+| test.py:46 | make_response() | externally controlled string |

--- a/python/ql/test/library-tests/web/flask/Sinks.ql
+++ b/python/ql/test/library-tests/web/flask/Sinks.ql
@@ -1,0 +1,10 @@
+
+import python
+
+import semmle.python.web.HttpRequest
+import semmle.python.web.HttpResponse
+import semmle.python.security.strings.Untrusted
+
+from TaintSink sink, TaintKind kind
+where sink.sinks(kind)
+select sink.getLocation().toString(), sink.(ControlFlowNode).getNode().toString(), kind

--- a/python/ql/test/library-tests/web/flask/Sources.expected
+++ b/python/ql/test/library-tests/web/flask/Sources.expected
@@ -1,0 +1,4 @@
+| test.py:22 | Attribute() | flask/MyView.as.view |
+| test.py:29 | Attribute | {externally controlled string} |
+| test.py:33 | Attribute | {externally controlled string} |
+| test.py:35 | Attribute | {externally controlled string} |

--- a/python/ql/test/library-tests/web/flask/Sources.expected
+++ b/python/ql/test/library-tests/web/flask/Sources.expected
@@ -2,3 +2,5 @@
 | test.py:29 | Attribute | {externally controlled string} |
 | test.py:33 | Attribute | {externally controlled string} |
 | test.py:35 | Attribute | {externally controlled string} |
+| test.py:40 | Attribute | {externally controlled string} |
+| test.py:45 | Attribute | {externally controlled string} |

--- a/python/ql/test/library-tests/web/flask/Sources.ql
+++ b/python/ql/test/library-tests/web/flask/Sources.ql
@@ -1,0 +1,11 @@
+
+import python
+
+import semmle.python.web.HttpRequest
+import semmle.python.web.HttpResponse
+import semmle.python.security.strings.Untrusted
+
+
+from TaintSource src, TaintKind kind
+where src.isSourceOf(kind)
+select src.getLocation().toString(), src.(ControlFlowNode).getNode().toString(), kind

--- a/python/ql/test/library-tests/web/flask/Taint.expected
+++ b/python/ql/test/library-tests/web/flask/Taint.expected
@@ -1,0 +1,8 @@
+| test.py:22 | Attribute() | flask/MyView.as.view |
+| test.py:25 | the_view | flask/MyView.as.view |
+| test.py:29 | Attribute | {externally controlled string} |
+| test.py:29 | Attribute() | externally controlled string |
+| test.py:33 | Attribute | {externally controlled string} |
+| test.py:33 | Subscript | externally controlled string |
+| test.py:35 | Attribute | {externally controlled string} |
+| test.py:35 | Subscript | externally controlled string |

--- a/python/ql/test/library-tests/web/flask/Taint.expected
+++ b/python/ql/test/library-tests/web/flask/Taint.expected
@@ -6,3 +6,12 @@
 | test.py:33 | Subscript | externally controlled string |
 | test.py:35 | Attribute | {externally controlled string} |
 | test.py:35 | Subscript | externally controlled string |
+| test.py:40 | Attribute | {externally controlled string} |
+| test.py:40 | Attribute() | externally controlled string |
+| test.py:41 | BinaryExpr | externally controlled string |
+| test.py:41 | first_name | externally controlled string |
+| test.py:41 | make_response() | flask.Response |
+| test.py:45 | Attribute | {externally controlled string} |
+| test.py:45 | Attribute() | externally controlled string |
+| test.py:46 | first_name | externally controlled string |
+| test.py:46 | make_response() | flask.Response |

--- a/python/ql/test/library-tests/web/flask/Taint.ql
+++ b/python/ql/test/library-tests/web/flask/Taint.ql
@@ -1,0 +1,12 @@
+
+import python
+
+
+import semmle.python.web.HttpRequest
+import semmle.python.web.HttpResponse
+import semmle.python.security.strings.Untrusted
+
+
+from TaintedNode node
+where node.getLocation().getFile().getName().matches("%test.py")
+select node.getLocation().toString(), node.getAstNode().toString(), node.getTaintKind()

--- a/python/ql/test/library-tests/web/flask/options
+++ b/python/ql/test/library-tests/web/flask/options
@@ -1,0 +1,2 @@
+semmle-extractor-options: --max-import-depth=3 --lang=3 -p ../../../query-tests/Security/lib/
+optimize: true

--- a/python/ql/test/library-tests/web/flask/test.py
+++ b/python/ql/test/library-tests/web/flask/test.py
@@ -1,6 +1,6 @@
 import flask
 
-from flask import Flask, request
+from flask import Flask, request, make_response
 app = Flask(__name__)
 
 @app.route("/")
@@ -34,3 +34,13 @@ def dangerous2():
     if request.method == "POST":
         return request.form['param1']
     return None
+
+@app.route('/unsafe')
+def unsafe():
+    first_name = request.args.get('name', '')
+    return make_response("Your name is " + first_name)
+
+@app.route('/safe')
+def safe():
+    first_name = request.args.get('name', '')
+    return make_response("Your name is " + escape(first_name))

--- a/python/ql/test/library-tests/web/flask/test.py
+++ b/python/ql/test/library-tests/web/flask/test.py
@@ -1,0 +1,36 @@
+import flask
+
+from flask import Flask, request
+app = Flask(__name__)
+
+@app.route("/")
+def hello():
+    return "Hello World!"
+
+from flask.views import MethodView
+
+class MyView(MethodView):
+
+    def get(self, user_id):
+        if user_id is None:
+            # return a list of users
+            pass
+        else:
+            # expose a single user
+            pass
+
+the_view = MyView.as_view('my_view')
+
+app.add_url_rule('/the/', defaults={'user_id': None},
+                 view_func=the_view, methods=['GET',])
+
+@app.route("/dangerous")
+def dangerous():
+    return request.args.get('payload')
+
+@app.route("/dangerous-with-cfg-split")
+def dangerous2():
+    x = request.form['param0']
+    if request.method == "POST":
+        return request.form['param1']
+    return None

--- a/python/ql/test/query-tests/Security/CWE-079/ReflectedXss.expected
+++ b/python/ql/test/query-tests/Security/CWE-079/ReflectedXss.expected
@@ -1,13 +1,9 @@
 edges
-| ../lib/flask/__init__.py:14:19:14:20 | externally controlled string | ../lib/flask/__init__.py:16:25:16:26 | externally controlled string |
-| ../lib/flask/__init__.py:14:19:14:20 | externally controlled string | ../lib/flask/__init__.py:16:25:16:26 | externally controlled string |
 | reflected_xss.py:7:18:7:29 | dict of externally controlled string | reflected_xss.py:7:18:7:45 | externally controlled string |
 | reflected_xss.py:7:18:7:29 | dict of externally controlled string | reflected_xss.py:7:18:7:45 | externally controlled string |
 | reflected_xss.py:7:18:7:45 | externally controlled string | reflected_xss.py:8:44:8:53 | externally controlled string |
 | reflected_xss.py:7:18:7:45 | externally controlled string | reflected_xss.py:8:44:8:53 | externally controlled string |
-| reflected_xss.py:8:26:8:53 | externally controlled string | ../lib/flask/__init__.py:14:19:14:20 | externally controlled string |
-| reflected_xss.py:8:26:8:53 | externally controlled string | ../lib/flask/__init__.py:14:19:14:20 | externally controlled string |
 | reflected_xss.py:8:44:8:53 | externally controlled string | reflected_xss.py:8:26:8:53 | externally controlled string |
 | reflected_xss.py:8:44:8:53 | externally controlled string | reflected_xss.py:8:26:8:53 | externally controlled string |
 #select
-| ../lib/flask/__init__.py:16:25:16:26 | rv | reflected_xss.py:7:18:7:29 | dict of externally controlled string | ../lib/flask/__init__.py:16:25:16:26 | externally controlled string | Cross-site scripting vulnerability due to $@. | reflected_xss.py:7:18:7:29 | Attribute | user-provided value |
+| reflected_xss.py:8:26:8:53 | BinaryExpr | reflected_xss.py:7:18:7:29 | dict of externally controlled string | reflected_xss.py:8:26:8:53 | externally controlled string | Cross-site scripting vulnerability due to $@. | reflected_xss.py:7:18:7:29 | Attribute | user-provided value |

--- a/python/ql/test/query-tests/Security/CWE-079/reflected_xss.py
+++ b/python/ql/test/query-tests/Security/CWE-079/reflected_xss.py
@@ -11,8 +11,3 @@ def unsafe():
 def safe():
     first_name = request.args.get('name', '')
     return make_response("Your name is " + escape(first_name))
-
-urlpatterns = [
-    url(r'^r1$', response_unsafe, name='response-unsafe'),
-    url(r'^r2$', response_safe, name='response-safe')
-]

--- a/python/ql/test/query-tests/Security/CWE-312/CleartextLogging.expected
+++ b/python/ql/test/query-tests/Security/CWE-312/CleartextLogging.expected
@@ -1,5 +1,6 @@
 edges
 | password_in_cookie.py:7:16:7:43 | a password | password_in_cookie.py:9:33:9:40 | a password |
+| password_in_cookie.py:14:16:14:43 | a password | password_in_cookie.py:16:33:16:40 | a password |
 | test.py:7:16:7:29 | a password | test.py:8:35:8:42 | a password |
 | test.py:7:16:7:29 | a password | test.py:8:35:8:42 | a password |
 | test.py:20:12:20:21 | a certificate or key | test.py:22:20:22:23 | a certificate or key |

--- a/python/ql/test/query-tests/Security/CWE-312/CleartextStorage.expected
+++ b/python/ql/test/query-tests/Security/CWE-312/CleartextStorage.expected
@@ -1,9 +1,12 @@
 edges
 | password_in_cookie.py:7:16:7:43 | a password | password_in_cookie.py:9:33:9:40 | a password |
 | password_in_cookie.py:7:16:7:43 | a password | password_in_cookie.py:9:33:9:40 | a password |
+| password_in_cookie.py:14:16:14:43 | a password | password_in_cookie.py:16:33:16:40 | a password |
+| password_in_cookie.py:14:16:14:43 | a password | password_in_cookie.py:16:33:16:40 | a password |
 | test.py:7:16:7:29 | a password | test.py:8:35:8:42 | a password |
 | test.py:20:12:20:21 | a certificate or key | test.py:22:20:22:23 | a certificate or key |
 | test.py:20:12:20:21 | a certificate or key | test.py:22:20:22:23 | a certificate or key |
 #select
 | password_in_cookie.py:9:33:9:40 | password | password_in_cookie.py:7:16:7:43 | a password | password_in_cookie.py:9:33:9:40 | a password | Sensitive data from $@ is stored here. | password_in_cookie.py:7:16:7:43 | Attribute() | a request parameter containing a password |
+| password_in_cookie.py:16:33:16:40 | password | password_in_cookie.py:14:16:14:43 | a password | password_in_cookie.py:16:33:16:40 | a password | Sensitive data from $@ is stored here. | password_in_cookie.py:14:16:14:43 | Attribute() | a request parameter containing a password |
 | test.py:22:20:22:23 | cert | test.py:20:12:20:21 | a certificate or key | test.py:22:20:22:23 | a certificate or key | Sensitive data from $@ is stored here. | test.py:20:12:20:21 | get_cert() | a call returning a certificate or key |

--- a/python/ql/test/query-tests/Security/CWE-312/password_in_cookie.py
+++ b/python/ql/test/query-tests/Security/CWE-312/password_in_cookie.py
@@ -1,4 +1,4 @@
-from flask import Flask, make_response, request
+from flask import Flask, make_response, request, Response
 
 app = Flask("Leak password")
 
@@ -6,5 +6,12 @@ app = Flask("Leak password")
 def index():
     password = request.args.get("password")
     resp = make_response(render_template(...))
+    resp.set_cookie("password", password)
+    return resp
+
+@app.route('/')
+def index2():
+    password = request.args.get("password")
+    resp = Response(...)
     resp.set_cookie("password", password)
     return resp

--- a/python/ql/test/query-tests/Security/lib/flask/__init__.py
+++ b/python/ql/test/query-tests/Security/lib/flask/__init__.py
@@ -1,9 +1,17 @@
-
-
-class Flask(object): 
-    def run(self, *args, **kwargs): pass
-
 from .globals import request
+from .globals import current_app
+
+class Flask(object):
+    # Only some methods mocked, signature copied from
+    # https://flask.palletsprojects.com/en/1.1.x/api/#flask.Flask
+    def run(host=None, port=None, debug=None, load_dotenv=True, **options):
+        pass
+
+    def make_response(rv):
+        pass
+
+    def add_url_rule(rule, endpoint=None, view_func=None, provide_automatic_options=None, **options):
+        pass
 
 class Response(object):
     pass
@@ -12,12 +20,11 @@ def redirect(location, code=302, Response=None):
     pass
 
 def make_response(rv):
-    if isinstance(rv, str):
-        return Response(rv)
-    elif isinstance(rv, Response):
-        return rv
-    else:
-        pass
+    if not args:
+        return current_app.response_class()
+    if len(args) == 1:
+        args = args[0]
+    return current_app.make_response(args)
 
 def escape(txt):
     return Markup.escape(txt)

--- a/python/ql/test/query-tests/Security/lib/flask/globals.py
+++ b/python/ql/test/query-tests/Security/lib/flask/globals.py
@@ -3,3 +3,4 @@ class LocalProxy(object):
     pass
 
 request = LocalProxy()
+current_app = LocalProxy()

--- a/python/ql/test/query-tests/Security/lib/flask/views.py
+++ b/python/ql/test/query-tests/Security/lib/flask/views.py
@@ -1,11 +1,6 @@
-
-
-
 class View(object):
     pass
 
 
 class MethodView(object):
     pass
-
-


### PR DESCRIPTION
This is the first pull requests where I move tests from our internal repo into the ql repo, as we discussed. This caused me to think a bit more about testing, specifically _To mock or not to mock?_

### To mock or not to mock?

The tests in our internal repo are not mocked, but run against the real library. Tests in this repo run against mocked versions.

I'm not sure moving the non-mocked tests into this repo, just next to the mocked tests, is a foolproof idea. I think it is going to cause confusion in the future. For example

By looking at `python/ql/test/library-tests/web/falcon/test.py` that is using the mock from [python/ql/test/query-tests/Security/lib/falcon](https://github.com/Semmle/ql/tree/742c1d0fa7456b639576e1acf725e8ae285c7340/python/ql/test/query-tests/Security/lib/falcon), then you might reasonably expect `python/ql/test/library-tests/web/flask/test.py` to use the mock from [python/ql/test/query-tests/Security/lib/flask](https://github.com/Semmle/ql/tree/fab2cb5a32ac70eb8a745c485befde60b65c087a/python/ql/test/query-tests/Security/lib/flask). But it is **not**. You need to look at the `options` file, and an obscure number of `../..` to figure this out.

Furthermore, https://github.com/Semmle/ql/issues/1572 highlighted the problems with mocks. If the mock doesn't correctly replicate what the library does, we create a false sense of security.

#### What should we do then?

I think it would be cool to always run against the real libraries. I have no clue how bad the performance overhead will be, but right now I want to get rid of those mock really bad :smile: 