### PR TITLE
CPP: AV Rule 114 test cases

### DIFF
--- a/cpp/ql/test/query-tests/jsf/4.13 Functions/AV Rule 114/AV Rule 114.expected
+++ b/cpp/ql/test/query-tests/jsf/4.13 Functions/AV Rule 114/AV Rule 114.expected
@@ -1,3 +1,5 @@
+| complex.c:3:2:3:45 | declaration | Function complexTest1 should return a value of type _Complex double but does not return a value here |
+| complex.c:7:2:7:41 | declaration | Function complexTest2 should return a value of type _Complex double but does not return a value here |
 | test.c:8:5:8:14 | declaration | Function f2 should return a value of type int but does not return a value here |
 | test.c:25:9:25:14 | ExprStmt | Function f4 should return a value of type int but does not return a value here |
 | test.c:39:9:39:14 | ExprStmt | Function f6 should return a value of type int but does not return a value here |

--- a/cpp/ql/test/query-tests/jsf/4.13 Functions/AV Rule 114/complex.c
+++ b/cpp/ql/test/query-tests/jsf/4.13 Functions/AV Rule 114/complex.c
@@ -1,0 +1,16 @@
+
+/*_Complex double complexTest1(float a, float b) {
+	_Complex double x = __builtin_complex(a, b); // BAD [EXTRACTOR ERROR]
+}
+
+_Complex double complexTest2(float a, float b) {
+	auto x = __builtin_complex(a, b) * 2.0f; // BAD [EXTRACTOR ERROR]
+}
+
+_Complex double complexTest3(float a, float b) {
+	return __builtin_complex(a, b); // GOOD [EXTRACTOR ERROR]
+}
+
+auto complexTest4(float a, float b) {
+	return __builtin_complex(a, b) * 2.0f; // GOOD [EXTRACTOR ERROR]
+}*/

--- a/cpp/ql/test/query-tests/jsf/4.13 Functions/AV Rule 114/complex.c
+++ b/cpp/ql/test/query-tests/jsf/4.13 Functions/AV Rule 114/complex.c
@@ -1,16 +1,16 @@
 
-/*_Complex double complexTest1(float a, float b) {
-	_Complex double x = __builtin_complex(a, b); // BAD [EXTRACTOR ERROR]
+_Complex double complexTest1(float a, float b) {
+	_Complex double x = __builtin_complex(a, b); // BAD
 }
 
 _Complex double complexTest2(float a, float b) {
-	auto x = __builtin_complex(a, b) * 2.0f; // BAD [EXTRACTOR ERROR]
+	auto x = __builtin_complex(a, b) * 2.0f; // BAD
 }
 
 _Complex double complexTest3(float a, float b) {
-	return __builtin_complex(a, b); // GOOD [EXTRACTOR ERROR]
+	return __builtin_complex(a, b); // GOOD
 }
 
 auto complexTest4(float a, float b) {
-	return __builtin_complex(a, b) * 2.0f; // GOOD [EXTRACTOR ERROR]
-}*/
+	return __builtin_complex(a, b) * 2.0f; // GOOD
+}


### PR DESCRIPTION
Test the `__builtin_complex` issues in the `AV Rule 114.ql` test (as they occurred in https://github.com/Semmle/ql/pull/2077).  This was fixed (and tested) by https://github.com/Semmle/ql/pull/2115 / https://git.semmle.com/Semmle/code/pull/34689, but I felt it's worth having query tests for the problem as we encountered it, in addition to the library tests.