### PR TITLE
JavaScript: Add support for `globalThis`.

### DIFF
--- a/change-notes/1.23/analysis-javascript.md
+++ b/change-notes/1.23/analysis-javascript.md
@@ -2,6 +2,8 @@
 
 ## General improvements
 
+* Suppor for `globalThis` has been added.
+
 * Support for the following frameworks and libraries has been improved:
   - [firebase](https://www.npmjs.com/package/firebase)
   - [mongodb](https://www.npmjs.com/package/mongodb)

--- a/javascript/ql/src/semmle/javascript/dataflow/Nodes.qll
+++ b/javascript/ql/src/semmle/javascript/dataflow/Nodes.qll
@@ -311,6 +311,9 @@ DataFlow::SourceNode globalObjectRef() {
   // DOM and service workers
   result = globalVarRef("self")
   or
+  // ECMAScript 2020
+  result = globalVarRef("globalThis")
+  or
   // `require("global")`
   result = moduleImport("global")
   or

--- a/javascript/ql/test/library-tests/Nodes/globalObjectRef.expected
+++ b/javascript/ql/test/library-tests/Nodes/globalObjectRef.expected
@@ -11,3 +11,4 @@
 | tst.js:4:1:4:6 | window |
 | tst.js:4:1:4:13 | window.window |
 | tst.js:5:1:5:4 | self |
+| tst.js:6:1:6:10 | globalThis |

--- a/javascript/ql/test/library-tests/Nodes/globalVarRef.expected
+++ b/javascript/ql/test/library-tests/Nodes/globalVarRef.expected
@@ -4,9 +4,11 @@
 | document | tst.js:3:1:3:15 | window.document |
 | document | tst.js:4:1:4:22 | window. ... ocument |
 | document | tst.js:5:1:5:13 | self.document |
+| document | tst.js:6:1:6:19 | globalThis.document |
 | foo | tst3.js:4:1:4:5 | w.foo |
 | global | tst2.js:7:1:7:6 | global |
 | global | tst2.js:8:1:8:6 | global |
+| globalThis | tst.js:6:1:6:10 | globalThis |
 | goog | tst3.js:1:1:1:4 | goog |
 | goog | tst3.js:3:9:3:12 | goog |
 | self | tst.js:5:1:5:4 | self |

--- a/javascript/ql/test/library-tests/Nodes/tst.js
+++ b/javascript/ql/test/library-tests/Nodes/tst.js
@@ -3,3 +3,4 @@ this;
 window.document;
 window.window.document;
 self.document;
+globalThis.document;


### PR DESCRIPTION
I created this branch a while ago and then forgot about it. `globalThis` has now reached Stage 4, so it'll be in ES2020.

I've started a dist-compare, which I expect to be very unexciting.