### PR TITLE
Java: support LGTM alert suppression using `@SuppressWarnings` annotations

### DIFF
--- a/java/config/suites/lgtm/java-queries-lgtm
+++ b/java/config/suites/lgtm/java-queries-lgtm
@@ -2,6 +2,8 @@
     @_namespace com.lgtm/java-queries
 + semmlecode-queries/AlertSuppression.ql
     @_namespace com.lgtm/java-queries
++ semmlecode-queries/AlertSuppressionAnnotations.ql
+    @_namespace com.lgtm/java-queries
 + semmlecode-queries/filters/ClassifyFiles.ql
     @_namespace com.lgtm/java-queries
 

--- a/java/ql/src/AlertSuppressionAnnotations.ql
+++ b/java/ql/src/AlertSuppressionAnnotations.ql
@@ -1,0 +1,75 @@
+/**
+ * @name Alert suppression using annotations
+ * @description Generates information about alert suppressions
+ *              using 'SuppressWarnings' annotations.
+ * @kind alert-suppression
+ * @id java/alert-suppression-annotations
+ */
+
+import java
+import Metrics.Internal.Extents
+
+/**
+ * An alert suppression annotation.
+ */
+class SuppressionAnnotation extends SuppressWarningsAnnotation {
+  string annotation;
+
+  SuppressionAnnotation() {
+    exists(string text | text = this.getASuppressedWarningLiteral().getValue() |
+      // match `lgtm[...]` anywhere in the comment
+      annotation = text.regexpFind("(?i)\\blgtm\\s*\\[[^\\]]*\\]", _, _)
+    )
+  }
+
+  /**
+   * Gets the text of this suppression annotation.
+   */
+  string getText() { result = getASuppressedWarningLiteral().getValue() }
+
+  /** Gets the LGTM suppression annotation in this Java annotation. */
+  string getAnnotation() { result = annotation }
+
+  /**
+   * Holds if this annotation applies to the range from column `startcolumn` of line `startline`
+   * to column `endcolumn` of line `endline` in file `filepath`.
+   */
+  predicate covers(string filepath, int startline, int startcolumn, int endline, int endcolumn) {
+    getAnnotatedElement().hasLocationInfo(filepath, startline, startcolumn, endline, endcolumn)
+  }
+
+  /** Gets the scope of this suppression. */
+  SuppressionScope getScope() { this = result.getSuppressionAnnotation() }
+}
+
+/**
+ * The scope of an alert suppression annotation.
+ */
+class SuppressionScope extends @annotation {
+  SuppressionScope() { this instanceof SuppressionAnnotation }
+
+  /** Gets a suppression annotation with this scope. */
+  SuppressionAnnotation getSuppressionAnnotation() { result = this }
+
+  /**
+   * Holds if this element is at the specified location.
+   * The location spans column `startcolumn` of line `startline` to
+   * column `endcolumn` of line `endline` in file `filepath`.
+   * For more information, see
+   * [Locations](https://help.semmle.com/QL/learn-ql/ql/locations.html).
+   */
+  predicate hasLocationInfo(
+    string filepath, int startline, int startcolumn, int endline, int endcolumn
+  ) {
+    this.(SuppressionAnnotation).covers(filepath, startline, startcolumn, endline, endcolumn)
+  }
+
+  /** Gets a textual representation of this element. */
+  string toString() { result = "suppression range" }
+}
+
+from SuppressionAnnotation c
+select c, // suppression comment
+  c.getText(), // text of suppression comment (excluding delimiters)
+  c.getAnnotation(), // text of suppression annotation
+  c.getScope() // scope of suppression

--- a/java/ql/src/AlertSuppressionAnnotations.ql
+++ b/java/ql/src/AlertSuppressionAnnotations.ql
@@ -38,21 +38,10 @@ class SuppressionAnnotation extends SuppressWarningsAnnotation {
   }
 
   private Annotation firstAnnotation() {
-    exists(Annotation m, int i |
-      result = m and
-      m = getASiblingAnnotation() and
-      i = rankOfAnnotation(m) and
-      not exists(Annotation other | other = getASiblingAnnotation() | rankOfAnnotation(other) < i)
-    )
-  }
-
-  private int rankOfAnnotation(Annotation m) {
-    this.getASiblingAnnotation() = m and
-    exists(Location mLoc, File f, int maxCol | mLoc = m.getLocation() |
-      f = mLoc.getFile() and
-      maxCol = max(Location loc | loc.getFile() = f | loc.getStartColumn()) and
-      result = mLoc.getStartLine() * maxCol + mLoc.getStartColumn()
-    )
+    result = min(this.getASiblingAnnotation() as m
+        order by
+          m.getLocation().getStartLine(), m.getLocation().getStartColumn()
+      )
   }
 
   /**

--- a/java/ql/src/AlertSuppressionAnnotations.ql
+++ b/java/ql/src/AlertSuppressionAnnotations.ql
@@ -28,7 +28,7 @@ class SuppressionAnnotation extends SuppressWarningsAnnotation {
   string getText() { result = getASuppressedWarningLiteral().getValue() }
 
   /** Gets the LGTM suppression annotation in this Java annotation. */
-  string getAnnotation() { result = annotation }
+  string getAnnotationText() { result = annotation }
 
   private Annotation getASiblingAnnotation() {
     result = getAnnotatedElement().(Annotatable).getAnAnnotation() and
@@ -98,5 +98,5 @@ class SuppressionScope extends @annotation {
 from SuppressionAnnotation c
 select c, // suppression comment
   c.getText(), // text of suppression comment (excluding delimiters)
-  c.getAnnotation(), // text of suppression annotation
+  c.getAnnotationText(), // text of suppression annotation
   c.getScope() // scope of suppression

--- a/java/ql/src/Metrics/Internal/Extents.qll
+++ b/java/ql/src/Metrics/Internal/Extents.qll
@@ -1,14 +1,18 @@
-import java
-
-/*
+/**
+ * Provides classes that modify the default location information
+ * of `RefType`s and `Callable`s to cover their full extent.
+ *
  * When this library is imported, the `hasLocationInfo` predicate of
  * `Callable` and `RefTypes` is overridden to specify their entire range
  * instead of just the range of their name. The latter can still be
  * obtained by invoking the `getLocation()` predicate.
  *
- * The full ranges are required for the purpose of associating a violation
- * with an individual `Callable` or `RefType` as opposed to a whole `File`.
+ * The full ranges may be used to determine whether a given location
+ * (for example, the location of an alert) is contained within the extent
+ * of a `Callable` or `RefType`.
  */
+
+import java
 
 /**
  * A Callable whose `hasLocationInfo` is overridden to specify its entire range

--- a/java/ql/src/Metrics/Internal/Extents.qll
+++ b/java/ql/src/Metrics/Internal/Extents.qll
@@ -52,20 +52,9 @@ class RangeRefType extends RefType {
   }
 
   private Member lastMember() {
-    exists(Member m, int i |
-      result = m and
-      m = getAMember() and
-      i = rankOfMember(m) and
-      not exists(Member other | other = getAMember() and rankOfMember(other) > i)
-    )
-  }
-
-  private int rankOfMember(Member m) {
-    this.getAMember() = m and
-    exists(Location mLoc, File f, int maxCol | mLoc = m.getLocation() |
-      f = mLoc.getFile() and
-      maxCol = max(Location loc | loc.getFile() = f | loc.getStartColumn()) and
-      result = mLoc.getStartLine() * maxCol + mLoc.getStartColumn()
-    )
+    result = max(this.getAMember() as m
+        order by
+          m.getLocation().getStartLine(), m.getLocation().getStartColumn()
+      )
   }
 }

--- a/java/ql/src/semmle/code/java/JDKAnnotations.qll
+++ b/java/ql/src/semmle/code/java/JDKAnnotations.qll
@@ -18,6 +18,12 @@ class OverrideAnnotation extends Annotation {
 class SuppressWarningsAnnotation extends Annotation {
   SuppressWarningsAnnotation() { this.getType().hasQualifiedName("java.lang", "SuppressWarnings") }
 
+  /** Gets the `StringLiteral` of a warning suppressed by this annotation. */
+  StringLiteral getASuppressedWarningLiteral() {
+    result = this.getAValue() or
+    result = this.getAValue().(ArrayInit).getAnInit()
+  }
+
   /** Gets the name of a warning suppressed by this annotation. */
   string getASuppressedWarning() {
     result = this.getAValue().(StringLiteral).getLiteral() or

--- a/java/ql/test/query-tests/AlertSuppression/AlertSuppressionAnnotations.expected
+++ b/java/ql/test/query-tests/AlertSuppression/AlertSuppressionAnnotations.expected
@@ -1,3 +1,3 @@
-| TestSuppressWarnings.java:2:1:2:49 | SuppressWarnings | lgtm[java/non-sync-override] | lgtm[java/non-sync-override] | TestSuppressWarnings.java:4:7:17:5 | suppression range |
-| TestSuppressWarnings.java:5:5:5:31 | SuppressWarnings | lgtm[] | lgtm[] | TestSuppressWarnings.java:6:17:8:5 | suppression range |
-| TestSuppressWarnings.java:10:5:10:57 | SuppressWarnings | lgtm[java/confusing-method-name] | lgtm[java/confusing-method-name] | TestSuppressWarnings.java:11:17:13:5 | suppression range |
+| TestSuppressWarnings.java:2:1:2:49 | SuppressWarnings | lgtm[java/non-sync-override] | lgtm[java/non-sync-override] | TestSuppressWarnings.java:2:1:17:5 | suppression range |
+| TestSuppressWarnings.java:5:5:5:31 | SuppressWarnings | lgtm[] | lgtm[] | TestSuppressWarnings.java:5:5:8:5 | suppression range |
+| TestSuppressWarnings.java:10:5:10:57 | SuppressWarnings | lgtm[java/confusing-method-name] | lgtm[java/confusing-method-name] | TestSuppressWarnings.java:9:5:13:5 | suppression range |

--- a/java/ql/test/query-tests/AlertSuppression/AlertSuppressionAnnotations.expected
+++ b/java/ql/test/query-tests/AlertSuppression/AlertSuppressionAnnotations.expected
@@ -1,4 +1,6 @@
-| TestSuppressWarnings.java:2:1:2:49 | SuppressWarnings | lgtm[java/non-sync-override] | lgtm[java/non-sync-override] | TestSuppressWarnings.java:2:1:17:5 | suppression range |
+| TestSuppressWarnings.java:2:1:2:49 | SuppressWarnings | lgtm[java/non-sync-override] | lgtm[java/non-sync-override] | TestSuppressWarnings.java:2:1:21:5 | suppression range |
 | TestSuppressWarnings.java:5:5:5:31 | SuppressWarnings | lgtm[] | lgtm[] | TestSuppressWarnings.java:5:5:8:5 | suppression range |
 | TestSuppressWarnings.java:10:5:10:104 | SuppressWarnings | lgtm[java/confusing-method-name] not confusing | lgtm[java/confusing-method-name] | TestSuppressWarnings.java:9:5:13:5 | suppression range |
 | TestSuppressWarnings.java:10:5:10:104 | SuppressWarnings | lgtm[java/non-sync-override] | lgtm[java/non-sync-override] | TestSuppressWarnings.java:9:5:13:5 | suppression range |
+| TestSuppressWarnings.java:18:5:18:98 | SuppressWarnings | lgtm[java/confusing-method-name] blah blah lgtm[java/non-sync-override] | lgtm[java/confusing-method-name] | TestSuppressWarnings.java:18:5:21:5 | suppression range |
+| TestSuppressWarnings.java:18:5:18:98 | SuppressWarnings | lgtm[java/confusing-method-name] blah blah lgtm[java/non-sync-override] | lgtm[java/non-sync-override] | TestSuppressWarnings.java:18:5:21:5 | suppression range |

--- a/java/ql/test/query-tests/AlertSuppression/AlertSuppressionAnnotations.expected
+++ b/java/ql/test/query-tests/AlertSuppression/AlertSuppressionAnnotations.expected
@@ -1,0 +1,3 @@
+| TestSuppressWarnings.java:2:1:2:49 | SuppressWarnings | lgtm[java/non-sync-override] | lgtm[java/non-sync-override] | TestSuppressWarnings.java:4:7:17:5 | suppression range |
+| TestSuppressWarnings.java:5:5:5:31 | SuppressWarnings | lgtm[] | lgtm[] | TestSuppressWarnings.java:6:17:8:5 | suppression range |
+| TestSuppressWarnings.java:10:5:10:57 | SuppressWarnings | lgtm[java/confusing-method-name] | lgtm[java/confusing-method-name] | TestSuppressWarnings.java:11:17:13:5 | suppression range |

--- a/java/ql/test/query-tests/AlertSuppression/AlertSuppressionAnnotations.expected
+++ b/java/ql/test/query-tests/AlertSuppression/AlertSuppressionAnnotations.expected
@@ -1,3 +1,4 @@
 | TestSuppressWarnings.java:2:1:2:49 | SuppressWarnings | lgtm[java/non-sync-override] | lgtm[java/non-sync-override] | TestSuppressWarnings.java:2:1:17:5 | suppression range |
 | TestSuppressWarnings.java:5:5:5:31 | SuppressWarnings | lgtm[] | lgtm[] | TestSuppressWarnings.java:5:5:8:5 | suppression range |
-| TestSuppressWarnings.java:10:5:10:57 | SuppressWarnings | lgtm[java/confusing-method-name] | lgtm[java/confusing-method-name] | TestSuppressWarnings.java:9:5:13:5 | suppression range |
+| TestSuppressWarnings.java:10:5:10:104 | SuppressWarnings | lgtm[java/confusing-method-name] not confusing | lgtm[java/confusing-method-name] | TestSuppressWarnings.java:9:5:13:5 | suppression range |
+| TestSuppressWarnings.java:10:5:10:104 | SuppressWarnings | lgtm[java/non-sync-override] | lgtm[java/non-sync-override] | TestSuppressWarnings.java:9:5:13:5 | suppression range |

--- a/java/ql/test/query-tests/AlertSuppression/AlertSuppressionAnnotations.qlref
+++ b/java/ql/test/query-tests/AlertSuppression/AlertSuppressionAnnotations.qlref
@@ -1,0 +1,1 @@
+AlertSuppressionAnnotations.ql

--- a/java/ql/test/query-tests/AlertSuppression/TestSuppressWarnings.java
+++ b/java/ql/test/query-tests/AlertSuppression/TestSuppressWarnings.java
@@ -7,7 +7,7 @@ class TestSuppressWarnings {
         
     }
     @Deprecated
-    @SuppressWarnings("lgtm[java/confusing-method-name]")
+    @SuppressWarnings({"lgtm[java/confusing-method-name] not confusing","lgtm[java/non-sync-override]"})
     public void test2() {
         
     }

--- a/java/ql/test/query-tests/AlertSuppression/TestSuppressWarnings.java
+++ b/java/ql/test/query-tests/AlertSuppression/TestSuppressWarnings.java
@@ -1,0 +1,18 @@
+
+@SuppressWarnings("lgtm[java/non-sync-override]")
+@Deprecated
+class TestSuppressWarnings {
+    @SuppressWarnings("lgtm[]")
+    public void test() {
+        
+    }
+    @Deprecated
+    @SuppressWarnings("lgtm[java/confusing-method-name]")
+    public void test2() {
+        
+    }
+    @SuppressWarnings("lgtm")
+    public void test3() {
+        
+    }
+}

--- a/java/ql/test/query-tests/AlertSuppression/TestSuppressWarnings.java
+++ b/java/ql/test/query-tests/AlertSuppression/TestSuppressWarnings.java
@@ -15,4 +15,8 @@ class TestSuppressWarnings {
     public void test3() {
         
     }
+    @SuppressWarnings({"lgtm[java/confusing-method-name] blah blah lgtm[java/non-sync-override]"})
+    public void test4() {
+        
+    }
 }


### PR DESCRIPTION
Supports alert suppression of the form `@SuppressWarnings("lgtm[query-id]")`.