### PR TITLE
Python: Fix toString for CookieSet classes

### DIFF
--- a/python/ql/src/semmle/python/web/bottle/Response.qll
+++ b/python/ql/src/semmle/python/web/bottle/Response.qll
@@ -44,7 +44,7 @@ class BottleCookieSet extends CookieSet, CallNode {
         any(BottleResponse r).taints(this.getFunction().(AttrNode).getObject("set_cookie"))
     }
 
-    override string toString() { result = this.(CallNode).toString() }
+    override string toString() { result = CallNode.super.toString() }
 
     override ControlFlowNode getKey() { result = this.getArg(0) }
 

--- a/python/ql/src/semmle/python/web/django/Response.qll
+++ b/python/ql/src/semmle/python/web/django/Response.qll
@@ -70,7 +70,7 @@ class DjangoCookieSet extends CookieSet, CallNode {
         any(DjangoResponse r).taints(this.getFunction().(AttrNode).getObject("set_cookie"))
     }
 
-    override string toString() { result = this.(CallNode).toString() }
+    override string toString() { result = CallNode.super.toString() }
 
     override ControlFlowNode getKey() { result = this.getArg(0) }
 

--- a/python/ql/src/semmle/python/web/flask/General.qll
+++ b/python/ql/src/semmle/python/web/flask/General.qll
@@ -122,7 +122,7 @@ class FlaskCookieSet extends CookieSet, CallNode {
         this.getFunction().(AttrNode).getObject("set_cookie").refersTo(_, theFlaskReponseClass(), _)
     }
 
-    override string toString() { result = this.(CallNode).toString() }
+    override string toString() { result = CallNode.super.toString() }
 
     override ControlFlowNode getKey() { result = this.getArg(0) }
 

--- a/python/ql/src/semmle/python/web/pyramid/Response.qll
+++ b/python/ql/src/semmle/python/web/pyramid/Response.qll
@@ -39,7 +39,7 @@ class PyramidCookieSet extends CookieSet, CallNode {
         )
     }
 
-    override string toString() { result = this.(CallNode).toString() }
+    override string toString() { result = CallNode.super.toString() }
 
     override ControlFlowNode getKey() { result = this.getArg(0) }
 

--- a/python/ql/src/semmle/python/web/tornado/Tornado.qll
+++ b/python/ql/src/semmle/python/web/tornado/Tornado.qll
@@ -45,7 +45,7 @@ class TornadoCookieSet extends CookieSet, CallNode {
         )
     }
 
-    override string toString() { result = this.(CallNode).toString() }
+    override string toString() { result = CallNode.super.toString() }
 
     override ControlFlowNode getKey() { result = this.getArg(0) }
 


### PR DESCRIPTION
The old implementation would result in empty recursion.