### PR TITLE
Python: Modernise and fix FP in `py/undefined-export`

### DIFF
--- a/python/ql/src/Variables/UndefinedExport.ql
+++ b/python/ql/src/Variables/UndefinedExport.ql
@@ -25,7 +25,7 @@ predicate declaredInAll(Module m, StrConst name) {
 
 predicate mutates_globals(ModuleValue m) {
     exists(CallNode globals |
-        globals = Object::builtin("globals").(FunctionObject).getACall() and
+        globals = Value::named("globals").(FunctionValue).getACall() and
         globals.getScope() = m.getScope()
     |
         exists(AttrNode attr | attr.getObject() = globals)
@@ -33,11 +33,12 @@ predicate mutates_globals(ModuleValue m) {
         exists(SubscriptNode sub | sub.getValue() = globals and sub.isStore())
     )
     or
-    exists(Object enum_convert |
-        enum_convert.hasLongName("enum.Enum._convert") and
+    exists(Value enum_convert, ClassValue enum_class |
+        enum_class.getASuperType() = Value::named("enum.Enum") and
+        enum_convert = enum_class.attr("_convert") and
         exists(CallNode call | call.getScope() = m.getScope() |
-            enum_convert.(FunctionObject).getACall() = call or
-            call.getFunction().refersTo(enum_convert)
+            enum_convert.getACall() = call or
+            call.getFunction().pointsTo(enum_convert)
         )
     )
 }

--- a/python/ql/src/Variables/UndefinedExport.ql
+++ b/python/ql/src/Variables/UndefinedExport.ql
@@ -14,18 +14,20 @@
 import python
 
 /** Whether name is declared in the __all__ list of this module */
-predicate declaredInAll(Module m, StrConst name)
-{
-    exists(Assign a, GlobalVariable all | 
-        a.defines(all) and a.getScope() = m and
-        all.getId() = "__all__" and ((List)a.getValue()).getAnElt() = name
+predicate declaredInAll(Module m, StrConst name) {
+    exists(Assign a, GlobalVariable all |
+        a.defines(all) and
+        a.getScope() = m and
+        all.getId() = "__all__" and
+        a.getValue().(List).getAnElt() = name
     )
 }
 
 predicate mutates_globals(ModuleValue m) {
     exists(CallNode globals |
         globals = Object::builtin("globals").(FunctionObject).getACall() and
-        globals.getScope() = m.getScope() |
+        globals.getScope() = m.getScope()
+    |
         exists(AttrNode attr | attr.getObject() = globals)
         or
         exists(SubscriptNode sub | sub.getValue() = globals and sub.isStore())
@@ -33,9 +35,7 @@ predicate mutates_globals(ModuleValue m) {
     or
     exists(Object enum_convert |
         enum_convert.hasLongName("enum.Enum._convert") and
-        exists(CallNode call |
-            call.getScope() = m.getScope()
-            |
+        exists(CallNode call | call.getScope() = m.getScope() |
             enum_convert.(FunctionObject).getACall() = call or
             call.getFunction().refersTo(enum_convert)
         )

--- a/python/ql/src/semmle/python/Module.qll
+++ b/python/ql/src/semmle/python/Module.qll
@@ -52,6 +52,13 @@ class Module extends Module_, Scope, AstNode {
         result = moduleNameFromFile(this.getPath())
     }
 
+    /** Gets the short name of the module. For example the short name of module x.y.z is 'z' */
+    string getShortName() {
+        result = this.getName().suffix(this.getPackage().getName().length()+1)
+        or
+        result = this.getName() and not exists(this.getPackage())
+    }
+
     /** Gets this module */
     override Module getEnclosingModule() {
         result = this

--- a/python/ql/src/semmle/python/objects/ObjectAPI.qll
+++ b/python/ql/src/semmle/python/objects/ObjectAPI.qll
@@ -99,6 +99,12 @@ class Value extends TObject {
         this.(ObjectInternal).hasAttribute(name)
     }
 
+    /** Whether this value is absent from the database, but has been inferred to likely exist */
+    predicate isAbsent() {
+        this instanceof AbsentModuleObjectInternal
+        or
+        this instanceof AbsentModuleAttributeObjectInternal
+    }
 }
 
 /** Class representing modules in the Python program


### PR DESCRIPTION
This should fix #2071. (Edit: and fix #1899.)

A few API changes were necessary in order to modernise the query. I decided to add `getShortName` (already present on `ModuleObject`) to `Module` and not `ModuleValue`, as this seemed to be the better place for it. (I could only find a single reference to `ModuleObject::getShortName` -- the one in this query.)

The second change is the addition of `Value::isAbsent`. This one I'm a bit more conflicted about. Previously, lack of points-to information was a good indicator that our analysis was incomplete, and that this might lead to false positives. This no longer works, as we can have a `ModuleValue` for a module that doesn't exist in source code, but which probably _ought_ to exist because of how it is used in the source code. I welcome any comments about the name of the method and its QLDoc string. 

As this FP was essentially fixed by modernising the query, I do not think it merits a change note. Rather than adding a change note for each such modernised query (there will be many of these), I think it will be more useful to just add an overall section to the change notes describing the modernisation effort.