### PR TITLE
Java/C++/C#: Refactor dataflow to simplify return flow.

### DIFF
--- a/cpp/ql/src/semmle/code/cpp/dataflow/internal/DataFlowImpl.qll
+++ b/cpp/ql/src/semmle/code/cpp/dataflow/internal/DataFlowImpl.qll
@@ -317,7 +317,7 @@ private predicate nodeCandFwd1(Node node, Configuration config) {
     exists(DataFlowCall call, ReturnNodeExt ret, ReturnKindExt kind |
       nodeCandFwd1(ret, config) and
       getReturnPosition(ret) = viableReturnPos(call, kind) and
-      node = getAnOutNodeExt(call, kind)
+      node = kind.getAnOutNode(call)
     )
   )
 }
@@ -409,7 +409,7 @@ private predicate nodeCand1ReturnPosition(ReturnPosition pos, Configuration conf
   exists(DataFlowCall call, ReturnKindExt kind, Node out |
     nodeCand1(out, config) and
     pos = viableReturnPos(call, kind) and
-    out = getAnOutNodeExt(call, kind)
+    out = kind.getAnOutNode(call)
   )
 }
 
@@ -576,7 +576,7 @@ private predicate flowOutOfCallable(Node node1, Node node2, Configuration config
   not inBarrier(node2, config) and
   exists(DataFlowCall call, ReturnKindExt kind |
     getReturnPosition1(node1, unbind(config)) = viableReturnPos(call, kind) and
-    node2 = getAnOutNodeExt(call, kind)
+    node2 = kind.getAnOutNode(call)
   )
 }
 
@@ -1806,7 +1806,7 @@ private predicate pathOutOfCallable1(
 pragma[noinline]
 private predicate pathOutOfCallable(PathNodeMid mid, Node out, CallContext cc) {
   exists(ReturnKindExt kind, DataFlowCall call | pathOutOfCallable1(mid, call, kind, cc) |
-    out = getAnOutNodeExt(call, kind)
+    out = kind.getAnOutNode(call)
   )
 }
 
@@ -1905,7 +1905,7 @@ pragma[noinline]
 private predicate pathThroughCallable(PathNodeMid mid, Node out, CallContext cc, AccessPathNil apnil) {
   exists(DataFlowCall call, ReturnKindExt kind |
     pathThroughCallable0(call, mid, kind, cc, apnil) and
-    out = getAnOutNodeExt(call, kind)
+    out = kind.getAnOutNode(call)
   )
 }
 
@@ -1965,7 +1965,7 @@ private module FlowExploration {
       // flow out of a callable
       exists(DataFlowCall call, ReturnKindExt kind |
         getReturnPosition(node1) = viableReturnPos(call, kind) and
-        node2 = getAnOutNodeExt(call, kind)
+        node2 = kind.getAnOutNode(call)
       )
     |
       c1 = node1.getEnclosingCallable() and
@@ -2287,7 +2287,7 @@ private module FlowExploration {
     exists(ReturnKindExt kind, DataFlowCall call |
       partialPathOutOfCallable1(mid, call, kind, cc, ap, config)
     |
-      out = getAnOutNodeExt(call, kind)
+      out = kind.getAnOutNode(call)
     )
   }
 
@@ -2370,7 +2370,7 @@ private module FlowExploration {
   ) {
     exists(DataFlowCall call, ReturnKindExt kind |
       partialPathThroughCallable0(call, mid, kind, cc, apnil, config) and
-      out = getAnOutNodeExt(call, kind)
+      out = kind.getAnOutNode(call)
     )
   }
 

--- a/cpp/ql/src/semmle/code/cpp/dataflow/internal/DataFlowImpl.qll
+++ b/cpp/ql/src/semmle/code/cpp/dataflow/internal/DataFlowImpl.qll
@@ -1785,7 +1785,7 @@ private predicate pathOutOfCallable0(PathNodeMid mid, ReturnPosition pos, CallCo
   not innercc instanceof CallContextCall
 }
 
-pragma[noinline]
+pragma[nomagic]
 private predicate pathOutOfCallable1(
   PathNodeMid mid, DataFlowCall call, ReturnKindExt kind, CallContext cc
 ) {

--- a/cpp/ql/src/semmle/code/cpp/dataflow/internal/DataFlowImpl.qll
+++ b/cpp/ql/src/semmle/code/cpp/dataflow/internal/DataFlowImpl.qll
@@ -314,11 +314,19 @@ private predicate nodeCandFwd1(Node node, Configuration config) {
     )
     or
     // flow out of a callable
-    exists(DataFlowCall call, ReturnNodeExt ret, ReturnKindExt kind |
-      nodeCandFwd1(ret, config) and
-      getReturnPosition(ret) = viableReturnPos(call, kind) and
+    exists(DataFlowCall call, ReturnPosition pos, ReturnKindExt kind |
+      nodeCandFwd1ReturnPosition(pos, config) and
+      pos = viableReturnPos(call, kind) and
       node = kind.getAnOutNode(call)
     )
+  )
+}
+
+pragma[noinline]
+private predicate nodeCandFwd1ReturnPosition(ReturnPosition pos, Configuration config) {
+  exists(ReturnNodeExt ret |
+    nodeCandFwd1(ret, config) and
+    getReturnPosition(ret) = pos
   )
 }
 
@@ -1885,7 +1893,7 @@ private predicate paramFlowsThrough(
   )
 }
 
-pragma[noinline]
+pragma[nomagic]
 private predicate pathThroughCallable0(
   DataFlowCall call, PathNodeMid mid, ReturnKindExt kind, CallContext cc, AccessPathNil apnil
 ) {

--- a/cpp/ql/src/semmle/code/cpp/dataflow/internal/DataFlowImpl2.qll
+++ b/cpp/ql/src/semmle/code/cpp/dataflow/internal/DataFlowImpl2.qll
@@ -317,7 +317,7 @@ private predicate nodeCandFwd1(Node node, Configuration config) {
     exists(DataFlowCall call, ReturnNodeExt ret, ReturnKindExt kind |
       nodeCandFwd1(ret, config) and
       getReturnPosition(ret) = viableReturnPos(call, kind) and
-      node = getAnOutNodeExt(call, kind)
+      node = kind.getAnOutNode(call)
     )
   )
 }
@@ -409,7 +409,7 @@ private predicate nodeCand1ReturnPosition(ReturnPosition pos, Configuration conf
   exists(DataFlowCall call, ReturnKindExt kind, Node out |
     nodeCand1(out, config) and
     pos = viableReturnPos(call, kind) and
-    out = getAnOutNodeExt(call, kind)
+    out = kind.getAnOutNode(call)
   )
 }
 
@@ -576,7 +576,7 @@ private predicate flowOutOfCallable(Node node1, Node node2, Configuration config
   not inBarrier(node2, config) and
   exists(DataFlowCall call, ReturnKindExt kind |
     getReturnPosition1(node1, unbind(config)) = viableReturnPos(call, kind) and
-    node2 = getAnOutNodeExt(call, kind)
+    node2 = kind.getAnOutNode(call)
   )
 }
 
@@ -1806,7 +1806,7 @@ private predicate pathOutOfCallable1(
 pragma[noinline]
 private predicate pathOutOfCallable(PathNodeMid mid, Node out, CallContext cc) {
   exists(ReturnKindExt kind, DataFlowCall call | pathOutOfCallable1(mid, call, kind, cc) |
-    out = getAnOutNodeExt(call, kind)
+    out = kind.getAnOutNode(call)
   )
 }
 
@@ -1905,7 +1905,7 @@ pragma[noinline]
 private predicate pathThroughCallable(PathNodeMid mid, Node out, CallContext cc, AccessPathNil apnil) {
   exists(DataFlowCall call, ReturnKindExt kind |
     pathThroughCallable0(call, mid, kind, cc, apnil) and
-    out = getAnOutNodeExt(call, kind)
+    out = kind.getAnOutNode(call)
   )
 }
 
@@ -1965,7 +1965,7 @@ private module FlowExploration {
       // flow out of a callable
       exists(DataFlowCall call, ReturnKindExt kind |
         getReturnPosition(node1) = viableReturnPos(call, kind) and
-        node2 = getAnOutNodeExt(call, kind)
+        node2 = kind.getAnOutNode(call)
       )
     |
       c1 = node1.getEnclosingCallable() and
@@ -2287,7 +2287,7 @@ private module FlowExploration {
     exists(ReturnKindExt kind, DataFlowCall call |
       partialPathOutOfCallable1(mid, call, kind, cc, ap, config)
     |
-      out = getAnOutNodeExt(call, kind)
+      out = kind.getAnOutNode(call)
     )
   }
 
@@ -2370,7 +2370,7 @@ private module FlowExploration {
   ) {
     exists(DataFlowCall call, ReturnKindExt kind |
       partialPathThroughCallable0(call, mid, kind, cc, apnil, config) and
-      out = getAnOutNodeExt(call, kind)
+      out = kind.getAnOutNode(call)
     )
   }
 

--- a/cpp/ql/src/semmle/code/cpp/dataflow/internal/DataFlowImpl2.qll
+++ b/cpp/ql/src/semmle/code/cpp/dataflow/internal/DataFlowImpl2.qll
@@ -1785,7 +1785,7 @@ private predicate pathOutOfCallable0(PathNodeMid mid, ReturnPosition pos, CallCo
   not innercc instanceof CallContextCall
 }
 
-pragma[noinline]
+pragma[nomagic]
 private predicate pathOutOfCallable1(
   PathNodeMid mid, DataFlowCall call, ReturnKindExt kind, CallContext cc
 ) {

--- a/cpp/ql/src/semmle/code/cpp/dataflow/internal/DataFlowImpl2.qll
+++ b/cpp/ql/src/semmle/code/cpp/dataflow/internal/DataFlowImpl2.qll
@@ -314,11 +314,19 @@ private predicate nodeCandFwd1(Node node, Configuration config) {
     )
     or
     // flow out of a callable
-    exists(DataFlowCall call, ReturnNodeExt ret, ReturnKindExt kind |
-      nodeCandFwd1(ret, config) and
-      getReturnPosition(ret) = viableReturnPos(call, kind) and
+    exists(DataFlowCall call, ReturnPosition pos, ReturnKindExt kind |
+      nodeCandFwd1ReturnPosition(pos, config) and
+      pos = viableReturnPos(call, kind) and
       node = kind.getAnOutNode(call)
     )
+  )
+}
+
+pragma[noinline]
+private predicate nodeCandFwd1ReturnPosition(ReturnPosition pos, Configuration config) {
+  exists(ReturnNodeExt ret |
+    nodeCandFwd1(ret, config) and
+    getReturnPosition(ret) = pos
   )
 }
 
@@ -1885,7 +1893,7 @@ private predicate paramFlowsThrough(
   )
 }
 
-pragma[noinline]
+pragma[nomagic]
 private predicate pathThroughCallable0(
   DataFlowCall call, PathNodeMid mid, ReturnKindExt kind, CallContext cc, AccessPathNil apnil
 ) {

--- a/cpp/ql/src/semmle/code/cpp/dataflow/internal/DataFlowImpl3.qll
+++ b/cpp/ql/src/semmle/code/cpp/dataflow/internal/DataFlowImpl3.qll
@@ -317,7 +317,7 @@ private predicate nodeCandFwd1(Node node, Configuration config) {
     exists(DataFlowCall call, ReturnNodeExt ret, ReturnKindExt kind |
       nodeCandFwd1(ret, config) and
       getReturnPosition(ret) = viableReturnPos(call, kind) and
-      node = getAnOutNodeExt(call, kind)
+      node = kind.getAnOutNode(call)
     )
   )
 }
@@ -409,7 +409,7 @@ private predicate nodeCand1ReturnPosition(ReturnPosition pos, Configuration conf
   exists(DataFlowCall call, ReturnKindExt kind, Node out |
     nodeCand1(out, config) and
     pos = viableReturnPos(call, kind) and
-    out = getAnOutNodeExt(call, kind)
+    out = kind.getAnOutNode(call)
   )
 }
 
@@ -576,7 +576,7 @@ private predicate flowOutOfCallable(Node node1, Node node2, Configuration config
   not inBarrier(node2, config) and
   exists(DataFlowCall call, ReturnKindExt kind |
     getReturnPosition1(node1, unbind(config)) = viableReturnPos(call, kind) and
-    node2 = getAnOutNodeExt(call, kind)
+    node2 = kind.getAnOutNode(call)
   )
 }
 
@@ -1806,7 +1806,7 @@ private predicate pathOutOfCallable1(
 pragma[noinline]
 private predicate pathOutOfCallable(PathNodeMid mid, Node out, CallContext cc) {
   exists(ReturnKindExt kind, DataFlowCall call | pathOutOfCallable1(mid, call, kind, cc) |
-    out = getAnOutNodeExt(call, kind)
+    out = kind.getAnOutNode(call)
   )
 }
 
@@ -1905,7 +1905,7 @@ pragma[noinline]
 private predicate pathThroughCallable(PathNodeMid mid, Node out, CallContext cc, AccessPathNil apnil) {
   exists(DataFlowCall call, ReturnKindExt kind |
     pathThroughCallable0(call, mid, kind, cc, apnil) and
-    out = getAnOutNodeExt(call, kind)
+    out = kind.getAnOutNode(call)
   )
 }
 
@@ -1965,7 +1965,7 @@ private module FlowExploration {
       // flow out of a callable
       exists(DataFlowCall call, ReturnKindExt kind |
         getReturnPosition(node1) = viableReturnPos(call, kind) and
-        node2 = getAnOutNodeExt(call, kind)
+        node2 = kind.getAnOutNode(call)
       )
     |
       c1 = node1.getEnclosingCallable() and
@@ -2287,7 +2287,7 @@ private module FlowExploration {
     exists(ReturnKindExt kind, DataFlowCall call |
       partialPathOutOfCallable1(mid, call, kind, cc, ap, config)
     |
-      out = getAnOutNodeExt(call, kind)
+      out = kind.getAnOutNode(call)
     )
   }
 
@@ -2370,7 +2370,7 @@ private module FlowExploration {
   ) {
     exists(DataFlowCall call, ReturnKindExt kind |
       partialPathThroughCallable0(call, mid, kind, cc, apnil, config) and
-      out = getAnOutNodeExt(call, kind)
+      out = kind.getAnOutNode(call)
     )
   }
 

--- a/cpp/ql/src/semmle/code/cpp/dataflow/internal/DataFlowImpl3.qll
+++ b/cpp/ql/src/semmle/code/cpp/dataflow/internal/DataFlowImpl3.qll
@@ -1785,7 +1785,7 @@ private predicate pathOutOfCallable0(PathNodeMid mid, ReturnPosition pos, CallCo
   not innercc instanceof CallContextCall
 }
 
-pragma[noinline]
+pragma[nomagic]
 private predicate pathOutOfCallable1(
   PathNodeMid mid, DataFlowCall call, ReturnKindExt kind, CallContext cc
 ) {

--- a/cpp/ql/src/semmle/code/cpp/dataflow/internal/DataFlowImpl3.qll
+++ b/cpp/ql/src/semmle/code/cpp/dataflow/internal/DataFlowImpl3.qll
@@ -314,11 +314,19 @@ private predicate nodeCandFwd1(Node node, Configuration config) {
     )
     or
     // flow out of a callable
-    exists(DataFlowCall call, ReturnNodeExt ret, ReturnKindExt kind |
-      nodeCandFwd1(ret, config) and
-      getReturnPosition(ret) = viableReturnPos(call, kind) and
+    exists(DataFlowCall call, ReturnPosition pos, ReturnKindExt kind |
+      nodeCandFwd1ReturnPosition(pos, config) and
+      pos = viableReturnPos(call, kind) and
       node = kind.getAnOutNode(call)
     )
+  )
+}
+
+pragma[noinline]
+private predicate nodeCandFwd1ReturnPosition(ReturnPosition pos, Configuration config) {
+  exists(ReturnNodeExt ret |
+    nodeCandFwd1(ret, config) and
+    getReturnPosition(ret) = pos
   )
 }
 
@@ -1885,7 +1893,7 @@ private predicate paramFlowsThrough(
   )
 }
 
-pragma[noinline]
+pragma[nomagic]
 private predicate pathThroughCallable0(
   DataFlowCall call, PathNodeMid mid, ReturnKindExt kind, CallContext cc, AccessPathNil apnil
 ) {

--- a/cpp/ql/src/semmle/code/cpp/dataflow/internal/DataFlowImpl4.qll
+++ b/cpp/ql/src/semmle/code/cpp/dataflow/internal/DataFlowImpl4.qll
@@ -317,7 +317,7 @@ private predicate nodeCandFwd1(Node node, Configuration config) {
     exists(DataFlowCall call, ReturnNodeExt ret, ReturnKindExt kind |
       nodeCandFwd1(ret, config) and
       getReturnPosition(ret) = viableReturnPos(call, kind) and
-      node = getAnOutNodeExt(call, kind)
+      node = kind.getAnOutNode(call)
     )
   )
 }
@@ -409,7 +409,7 @@ private predicate nodeCand1ReturnPosition(ReturnPosition pos, Configuration conf
   exists(DataFlowCall call, ReturnKindExt kind, Node out |
     nodeCand1(out, config) and
     pos = viableReturnPos(call, kind) and
-    out = getAnOutNodeExt(call, kind)
+    out = kind.getAnOutNode(call)
   )
 }
 
@@ -576,7 +576,7 @@ private predicate flowOutOfCallable(Node node1, Node node2, Configuration config
   not inBarrier(node2, config) and
   exists(DataFlowCall call, ReturnKindExt kind |
     getReturnPosition1(node1, unbind(config)) = viableReturnPos(call, kind) and
-    node2 = getAnOutNodeExt(call, kind)
+    node2 = kind.getAnOutNode(call)
   )
 }
 
@@ -1806,7 +1806,7 @@ private predicate pathOutOfCallable1(
 pragma[noinline]
 private predicate pathOutOfCallable(PathNodeMid mid, Node out, CallContext cc) {
   exists(ReturnKindExt kind, DataFlowCall call | pathOutOfCallable1(mid, call, kind, cc) |
-    out = getAnOutNodeExt(call, kind)
+    out = kind.getAnOutNode(call)
   )
 }
 
@@ -1905,7 +1905,7 @@ pragma[noinline]
 private predicate pathThroughCallable(PathNodeMid mid, Node out, CallContext cc, AccessPathNil apnil) {
   exists(DataFlowCall call, ReturnKindExt kind |
     pathThroughCallable0(call, mid, kind, cc, apnil) and
-    out = getAnOutNodeExt(call, kind)
+    out = kind.getAnOutNode(call)
   )
 }
 
@@ -1965,7 +1965,7 @@ private module FlowExploration {
       // flow out of a callable
       exists(DataFlowCall call, ReturnKindExt kind |
         getReturnPosition(node1) = viableReturnPos(call, kind) and
-        node2 = getAnOutNodeExt(call, kind)
+        node2 = kind.getAnOutNode(call)
       )
     |
       c1 = node1.getEnclosingCallable() and
@@ -2287,7 +2287,7 @@ private module FlowExploration {
     exists(ReturnKindExt kind, DataFlowCall call |
       partialPathOutOfCallable1(mid, call, kind, cc, ap, config)
     |
-      out = getAnOutNodeExt(call, kind)
+      out = kind.getAnOutNode(call)
     )
   }
 
@@ -2370,7 +2370,7 @@ private module FlowExploration {
   ) {
     exists(DataFlowCall call, ReturnKindExt kind |
       partialPathThroughCallable0(call, mid, kind, cc, apnil, config) and
-      out = getAnOutNodeExt(call, kind)
+      out = kind.getAnOutNode(call)
     )
   }
 

--- a/cpp/ql/src/semmle/code/cpp/dataflow/internal/DataFlowImpl4.qll
+++ b/cpp/ql/src/semmle/code/cpp/dataflow/internal/DataFlowImpl4.qll
@@ -1785,7 +1785,7 @@ private predicate pathOutOfCallable0(PathNodeMid mid, ReturnPosition pos, CallCo
   not innercc instanceof CallContextCall
 }
 
-pragma[noinline]
+pragma[nomagic]
 private predicate pathOutOfCallable1(
   PathNodeMid mid, DataFlowCall call, ReturnKindExt kind, CallContext cc
 ) {

--- a/cpp/ql/src/semmle/code/cpp/dataflow/internal/DataFlowImpl4.qll
+++ b/cpp/ql/src/semmle/code/cpp/dataflow/internal/DataFlowImpl4.qll
@@ -314,11 +314,19 @@ private predicate nodeCandFwd1(Node node, Configuration config) {
     )
     or
     // flow out of a callable
-    exists(DataFlowCall call, ReturnNodeExt ret, ReturnKindExt kind |
-      nodeCandFwd1(ret, config) and
-      getReturnPosition(ret) = viableReturnPos(call, kind) and
+    exists(DataFlowCall call, ReturnPosition pos, ReturnKindExt kind |
+      nodeCandFwd1ReturnPosition(pos, config) and
+      pos = viableReturnPos(call, kind) and
       node = kind.getAnOutNode(call)
     )
+  )
+}
+
+pragma[noinline]
+private predicate nodeCandFwd1ReturnPosition(ReturnPosition pos, Configuration config) {
+  exists(ReturnNodeExt ret |
+    nodeCandFwd1(ret, config) and
+    getReturnPosition(ret) = pos
   )
 }
 
@@ -1885,7 +1893,7 @@ private predicate paramFlowsThrough(
   )
 }
 
-pragma[noinline]
+pragma[nomagic]
 private predicate pathThroughCallable0(
   DataFlowCall call, PathNodeMid mid, ReturnKindExt kind, CallContext cc, AccessPathNil apnil
 ) {

--- a/cpp/ql/src/semmle/code/cpp/dataflow/internal/DataFlowImplLocal.qll
+++ b/cpp/ql/src/semmle/code/cpp/dataflow/internal/DataFlowImplLocal.qll
@@ -317,7 +317,7 @@ private predicate nodeCandFwd1(Node node, Configuration config) {
     exists(DataFlowCall call, ReturnNodeExt ret, ReturnKindExt kind |
       nodeCandFwd1(ret, config) and
       getReturnPosition(ret) = viableReturnPos(call, kind) and
-      node = getAnOutNodeExt(call, kind)
+      node = kind.getAnOutNode(call)
     )
   )
 }
@@ -409,7 +409,7 @@ private predicate nodeCand1ReturnPosition(ReturnPosition pos, Configuration conf
   exists(DataFlowCall call, ReturnKindExt kind, Node out |
     nodeCand1(out, config) and
     pos = viableReturnPos(call, kind) and
-    out = getAnOutNodeExt(call, kind)
+    out = kind.getAnOutNode(call)
   )
 }
 
@@ -576,7 +576,7 @@ private predicate flowOutOfCallable(Node node1, Node node2, Configuration config
   not inBarrier(node2, config) and
   exists(DataFlowCall call, ReturnKindExt kind |
     getReturnPosition1(node1, unbind(config)) = viableReturnPos(call, kind) and
-    node2 = getAnOutNodeExt(call, kind)
+    node2 = kind.getAnOutNode(call)
   )
 }
 
@@ -1806,7 +1806,7 @@ private predicate pathOutOfCallable1(
 pragma[noinline]
 private predicate pathOutOfCallable(PathNodeMid mid, Node out, CallContext cc) {
   exists(ReturnKindExt kind, DataFlowCall call | pathOutOfCallable1(mid, call, kind, cc) |
-    out = getAnOutNodeExt(call, kind)
+    out = kind.getAnOutNode(call)
   )
 }
 
@@ -1905,7 +1905,7 @@ pragma[noinline]
 private predicate pathThroughCallable(PathNodeMid mid, Node out, CallContext cc, AccessPathNil apnil) {
   exists(DataFlowCall call, ReturnKindExt kind |
     pathThroughCallable0(call, mid, kind, cc, apnil) and
-    out = getAnOutNodeExt(call, kind)
+    out = kind.getAnOutNode(call)
   )
 }
 
@@ -1965,7 +1965,7 @@ private module FlowExploration {
       // flow out of a callable
       exists(DataFlowCall call, ReturnKindExt kind |
         getReturnPosition(node1) = viableReturnPos(call, kind) and
-        node2 = getAnOutNodeExt(call, kind)
+        node2 = kind.getAnOutNode(call)
       )
     |
       c1 = node1.getEnclosingCallable() and
@@ -2287,7 +2287,7 @@ private module FlowExploration {
     exists(ReturnKindExt kind, DataFlowCall call |
       partialPathOutOfCallable1(mid, call, kind, cc, ap, config)
     |
-      out = getAnOutNodeExt(call, kind)
+      out = kind.getAnOutNode(call)
     )
   }
 
@@ -2370,7 +2370,7 @@ private module FlowExploration {
   ) {
     exists(DataFlowCall call, ReturnKindExt kind |
       partialPathThroughCallable0(call, mid, kind, cc, apnil, config) and
-      out = getAnOutNodeExt(call, kind)
+      out = kind.getAnOutNode(call)
     )
   }
 

--- a/cpp/ql/src/semmle/code/cpp/dataflow/internal/DataFlowImplLocal.qll
+++ b/cpp/ql/src/semmle/code/cpp/dataflow/internal/DataFlowImplLocal.qll
@@ -1785,7 +1785,7 @@ private predicate pathOutOfCallable0(PathNodeMid mid, ReturnPosition pos, CallCo
   not innercc instanceof CallContextCall
 }
 
-pragma[noinline]
+pragma[nomagic]
 private predicate pathOutOfCallable1(
   PathNodeMid mid, DataFlowCall call, ReturnKindExt kind, CallContext cc
 ) {

--- a/cpp/ql/src/semmle/code/cpp/dataflow/internal/DataFlowImplLocal.qll
+++ b/cpp/ql/src/semmle/code/cpp/dataflow/internal/DataFlowImplLocal.qll
@@ -314,11 +314,19 @@ private predicate nodeCandFwd1(Node node, Configuration config) {
     )
     or
     // flow out of a callable
-    exists(DataFlowCall call, ReturnNodeExt ret, ReturnKindExt kind |
-      nodeCandFwd1(ret, config) and
-      getReturnPosition(ret) = viableReturnPos(call, kind) and
+    exists(DataFlowCall call, ReturnPosition pos, ReturnKindExt kind |
+      nodeCandFwd1ReturnPosition(pos, config) and
+      pos = viableReturnPos(call, kind) and
       node = kind.getAnOutNode(call)
     )
+  )
+}
+
+pragma[noinline]
+private predicate nodeCandFwd1ReturnPosition(ReturnPosition pos, Configuration config) {
+  exists(ReturnNodeExt ret |
+    nodeCandFwd1(ret, config) and
+    getReturnPosition(ret) = pos
   )
 }
 
@@ -1885,7 +1893,7 @@ private predicate paramFlowsThrough(
   )
 }
 
-pragma[noinline]
+pragma[nomagic]
 private predicate pathThroughCallable0(
   DataFlowCall call, PathNodeMid mid, ReturnKindExt kind, CallContext cc, AccessPathNil apnil
 ) {

--- a/cpp/ql/src/semmle/code/cpp/ir/dataflow/internal/DataFlowImpl.qll
+++ b/cpp/ql/src/semmle/code/cpp/ir/dataflow/internal/DataFlowImpl.qll
@@ -317,7 +317,7 @@ private predicate nodeCandFwd1(Node node, Configuration config) {
     exists(DataFlowCall call, ReturnNodeExt ret, ReturnKindExt kind |
       nodeCandFwd1(ret, config) and
       getReturnPosition(ret) = viableReturnPos(call, kind) and
-      node = getAnOutNodeExt(call, kind)
+      node = kind.getAnOutNode(call)
     )
   )
 }
@@ -409,7 +409,7 @@ private predicate nodeCand1ReturnPosition(ReturnPosition pos, Configuration conf
   exists(DataFlowCall call, ReturnKindExt kind, Node out |
     nodeCand1(out, config) and
     pos = viableReturnPos(call, kind) and
-    out = getAnOutNodeExt(call, kind)
+    out = kind.getAnOutNode(call)
   )
 }
 
@@ -576,7 +576,7 @@ private predicate flowOutOfCallable(Node node1, Node node2, Configuration config
   not inBarrier(node2, config) and
   exists(DataFlowCall call, ReturnKindExt kind |
     getReturnPosition1(node1, unbind(config)) = viableReturnPos(call, kind) and
-    node2 = getAnOutNodeExt(call, kind)
+    node2 = kind.getAnOutNode(call)
   )
 }
 
@@ -1806,7 +1806,7 @@ private predicate pathOutOfCallable1(
 pragma[noinline]
 private predicate pathOutOfCallable(PathNodeMid mid, Node out, CallContext cc) {
   exists(ReturnKindExt kind, DataFlowCall call | pathOutOfCallable1(mid, call, kind, cc) |
-    out = getAnOutNodeExt(call, kind)
+    out = kind.getAnOutNode(call)
   )
 }
 
@@ -1905,7 +1905,7 @@ pragma[noinline]
 private predicate pathThroughCallable(PathNodeMid mid, Node out, CallContext cc, AccessPathNil apnil) {
   exists(DataFlowCall call, ReturnKindExt kind |
     pathThroughCallable0(call, mid, kind, cc, apnil) and
-    out = getAnOutNodeExt(call, kind)
+    out = kind.getAnOutNode(call)
   )
 }
 
@@ -1965,7 +1965,7 @@ private module FlowExploration {
       // flow out of a callable
       exists(DataFlowCall call, ReturnKindExt kind |
         getReturnPosition(node1) = viableReturnPos(call, kind) and
-        node2 = getAnOutNodeExt(call, kind)
+        node2 = kind.getAnOutNode(call)
       )
     |
       c1 = node1.getEnclosingCallable() and
@@ -2287,7 +2287,7 @@ private module FlowExploration {
     exists(ReturnKindExt kind, DataFlowCall call |
       partialPathOutOfCallable1(mid, call, kind, cc, ap, config)
     |
-      out = getAnOutNodeExt(call, kind)
+      out = kind.getAnOutNode(call)
     )
   }
 
@@ -2370,7 +2370,7 @@ private module FlowExploration {
   ) {
     exists(DataFlowCall call, ReturnKindExt kind |
       partialPathThroughCallable0(call, mid, kind, cc, apnil, config) and
-      out = getAnOutNodeExt(call, kind)
+      out = kind.getAnOutNode(call)
     )
   }
 

--- a/cpp/ql/src/semmle/code/cpp/ir/dataflow/internal/DataFlowImpl.qll
+++ b/cpp/ql/src/semmle/code/cpp/ir/dataflow/internal/DataFlowImpl.qll
@@ -1785,7 +1785,7 @@ private predicate pathOutOfCallable0(PathNodeMid mid, ReturnPosition pos, CallCo
   not innercc instanceof CallContextCall
 }
 
-pragma[noinline]
+pragma[nomagic]
 private predicate pathOutOfCallable1(
   PathNodeMid mid, DataFlowCall call, ReturnKindExt kind, CallContext cc
 ) {

--- a/cpp/ql/src/semmle/code/cpp/ir/dataflow/internal/DataFlowImpl.qll
+++ b/cpp/ql/src/semmle/code/cpp/ir/dataflow/internal/DataFlowImpl.qll
@@ -314,11 +314,19 @@ private predicate nodeCandFwd1(Node node, Configuration config) {
     )
     or
     // flow out of a callable
-    exists(DataFlowCall call, ReturnNodeExt ret, ReturnKindExt kind |
-      nodeCandFwd1(ret, config) and
-      getReturnPosition(ret) = viableReturnPos(call, kind) and
+    exists(DataFlowCall call, ReturnPosition pos, ReturnKindExt kind |
+      nodeCandFwd1ReturnPosition(pos, config) and
+      pos = viableReturnPos(call, kind) and
       node = kind.getAnOutNode(call)
     )
+  )
+}
+
+pragma[noinline]
+private predicate nodeCandFwd1ReturnPosition(ReturnPosition pos, Configuration config) {
+  exists(ReturnNodeExt ret |
+    nodeCandFwd1(ret, config) and
+    getReturnPosition(ret) = pos
   )
 }
 
@@ -1885,7 +1893,7 @@ private predicate paramFlowsThrough(
   )
 }
 
-pragma[noinline]
+pragma[nomagic]
 private predicate pathThroughCallable0(
   DataFlowCall call, PathNodeMid mid, ReturnKindExt kind, CallContext cc, AccessPathNil apnil
 ) {

--- a/cpp/ql/src/semmle/code/cpp/ir/dataflow/internal/DataFlowImpl2.qll
+++ b/cpp/ql/src/semmle/code/cpp/ir/dataflow/internal/DataFlowImpl2.qll
@@ -317,7 +317,7 @@ private predicate nodeCandFwd1(Node node, Configuration config) {
     exists(DataFlowCall call, ReturnNodeExt ret, ReturnKindExt kind |
       nodeCandFwd1(ret, config) and
       getReturnPosition(ret) = viableReturnPos(call, kind) and
-      node = getAnOutNodeExt(call, kind)
+      node = kind.getAnOutNode(call)
     )
   )
 }
@@ -409,7 +409,7 @@ private predicate nodeCand1ReturnPosition(ReturnPosition pos, Configuration conf
   exists(DataFlowCall call, ReturnKindExt kind, Node out |
     nodeCand1(out, config) and
     pos = viableReturnPos(call, kind) and
-    out = getAnOutNodeExt(call, kind)
+    out = kind.getAnOutNode(call)
   )
 }
 
@@ -576,7 +576,7 @@ private predicate flowOutOfCallable(Node node1, Node node2, Configuration config
   not inBarrier(node2, config) and
   exists(DataFlowCall call, ReturnKindExt kind |
     getReturnPosition1(node1, unbind(config)) = viableReturnPos(call, kind) and
-    node2 = getAnOutNodeExt(call, kind)
+    node2 = kind.getAnOutNode(call)
   )
 }
 
@@ -1806,7 +1806,7 @@ private predicate pathOutOfCallable1(
 pragma[noinline]
 private predicate pathOutOfCallable(PathNodeMid mid, Node out, CallContext cc) {
   exists(ReturnKindExt kind, DataFlowCall call | pathOutOfCallable1(mid, call, kind, cc) |
-    out = getAnOutNodeExt(call, kind)
+    out = kind.getAnOutNode(call)
   )
 }
 
@@ -1905,7 +1905,7 @@ pragma[noinline]
 private predicate pathThroughCallable(PathNodeMid mid, Node out, CallContext cc, AccessPathNil apnil) {
   exists(DataFlowCall call, ReturnKindExt kind |
     pathThroughCallable0(call, mid, kind, cc, apnil) and
-    out = getAnOutNodeExt(call, kind)
+    out = kind.getAnOutNode(call)
   )
 }
 
@@ -1965,7 +1965,7 @@ private module FlowExploration {
       // flow out of a callable
       exists(DataFlowCall call, ReturnKindExt kind |
         getReturnPosition(node1) = viableReturnPos(call, kind) and
-        node2 = getAnOutNodeExt(call, kind)
+        node2 = kind.getAnOutNode(call)
       )
     |
       c1 = node1.getEnclosingCallable() and
@@ -2287,7 +2287,7 @@ private module FlowExploration {
     exists(ReturnKindExt kind, DataFlowCall call |
       partialPathOutOfCallable1(mid, call, kind, cc, ap, config)
     |
-      out = getAnOutNodeExt(call, kind)
+      out = kind.getAnOutNode(call)
     )
   }
 
@@ -2370,7 +2370,7 @@ private module FlowExploration {
   ) {
     exists(DataFlowCall call, ReturnKindExt kind |
       partialPathThroughCallable0(call, mid, kind, cc, apnil, config) and
-      out = getAnOutNodeExt(call, kind)
+      out = kind.getAnOutNode(call)
     )
   }
 

--- a/cpp/ql/src/semmle/code/cpp/ir/dataflow/internal/DataFlowImpl2.qll
+++ b/cpp/ql/src/semmle/code/cpp/ir/dataflow/internal/DataFlowImpl2.qll
@@ -1785,7 +1785,7 @@ private predicate pathOutOfCallable0(PathNodeMid mid, ReturnPosition pos, CallCo
   not innercc instanceof CallContextCall
 }
 
-pragma[noinline]
+pragma[nomagic]
 private predicate pathOutOfCallable1(
   PathNodeMid mid, DataFlowCall call, ReturnKindExt kind, CallContext cc
 ) {

--- a/cpp/ql/src/semmle/code/cpp/ir/dataflow/internal/DataFlowImpl2.qll
+++ b/cpp/ql/src/semmle/code/cpp/ir/dataflow/internal/DataFlowImpl2.qll
@@ -314,11 +314,19 @@ private predicate nodeCandFwd1(Node node, Configuration config) {
     )
     or
     // flow out of a callable
-    exists(DataFlowCall call, ReturnNodeExt ret, ReturnKindExt kind |
-      nodeCandFwd1(ret, config) and
-      getReturnPosition(ret) = viableReturnPos(call, kind) and
+    exists(DataFlowCall call, ReturnPosition pos, ReturnKindExt kind |
+      nodeCandFwd1ReturnPosition(pos, config) and
+      pos = viableReturnPos(call, kind) and
       node = kind.getAnOutNode(call)
     )
+  )
+}
+
+pragma[noinline]
+private predicate nodeCandFwd1ReturnPosition(ReturnPosition pos, Configuration config) {
+  exists(ReturnNodeExt ret |
+    nodeCandFwd1(ret, config) and
+    getReturnPosition(ret) = pos
   )
 }
 
@@ -1885,7 +1893,7 @@ private predicate paramFlowsThrough(
   )
 }
 
-pragma[noinline]
+pragma[nomagic]
 private predicate pathThroughCallable0(
   DataFlowCall call, PathNodeMid mid, ReturnKindExt kind, CallContext cc, AccessPathNil apnil
 ) {

--- a/cpp/ql/src/semmle/code/cpp/ir/dataflow/internal/DataFlowImpl3.qll
+++ b/cpp/ql/src/semmle/code/cpp/ir/dataflow/internal/DataFlowImpl3.qll
@@ -317,7 +317,7 @@ private predicate nodeCandFwd1(Node node, Configuration config) {
     exists(DataFlowCall call, ReturnNodeExt ret, ReturnKindExt kind |
       nodeCandFwd1(ret, config) and
       getReturnPosition(ret) = viableReturnPos(call, kind) and
-      node = getAnOutNodeExt(call, kind)
+      node = kind.getAnOutNode(call)
     )
   )
 }
@@ -409,7 +409,7 @@ private predicate nodeCand1ReturnPosition(ReturnPosition pos, Configuration conf
   exists(DataFlowCall call, ReturnKindExt kind, Node out |
     nodeCand1(out, config) and
     pos = viableReturnPos(call, kind) and
-    out = getAnOutNodeExt(call, kind)
+    out = kind.getAnOutNode(call)
   )
 }
 
@@ -576,7 +576,7 @@ private predicate flowOutOfCallable(Node node1, Node node2, Configuration config
   not inBarrier(node2, config) and
   exists(DataFlowCall call, ReturnKindExt kind |
     getReturnPosition1(node1, unbind(config)) = viableReturnPos(call, kind) and
-    node2 = getAnOutNodeExt(call, kind)
+    node2 = kind.getAnOutNode(call)
   )
 }
 
@@ -1806,7 +1806,7 @@ private predicate pathOutOfCallable1(
 pragma[noinline]
 private predicate pathOutOfCallable(PathNodeMid mid, Node out, CallContext cc) {
   exists(ReturnKindExt kind, DataFlowCall call | pathOutOfCallable1(mid, call, kind, cc) |
-    out = getAnOutNodeExt(call, kind)
+    out = kind.getAnOutNode(call)
   )
 }
 
@@ -1905,7 +1905,7 @@ pragma[noinline]
 private predicate pathThroughCallable(PathNodeMid mid, Node out, CallContext cc, AccessPathNil apnil) {
   exists(DataFlowCall call, ReturnKindExt kind |
     pathThroughCallable0(call, mid, kind, cc, apnil) and
-    out = getAnOutNodeExt(call, kind)
+    out = kind.getAnOutNode(call)
   )
 }
 
@@ -1965,7 +1965,7 @@ private module FlowExploration {
       // flow out of a callable
       exists(DataFlowCall call, ReturnKindExt kind |
         getReturnPosition(node1) = viableReturnPos(call, kind) and
-        node2 = getAnOutNodeExt(call, kind)
+        node2 = kind.getAnOutNode(call)
       )
     |
       c1 = node1.getEnclosingCallable() and
@@ -2287,7 +2287,7 @@ private module FlowExploration {
     exists(ReturnKindExt kind, DataFlowCall call |
       partialPathOutOfCallable1(mid, call, kind, cc, ap, config)
     |
-      out = getAnOutNodeExt(call, kind)
+      out = kind.getAnOutNode(call)
     )
   }
 
@@ -2370,7 +2370,7 @@ private module FlowExploration {
   ) {
     exists(DataFlowCall call, ReturnKindExt kind |
       partialPathThroughCallable0(call, mid, kind, cc, apnil, config) and
-      out = getAnOutNodeExt(call, kind)
+      out = kind.getAnOutNode(call)
     )
   }
 

--- a/cpp/ql/src/semmle/code/cpp/ir/dataflow/internal/DataFlowImpl3.qll
+++ b/cpp/ql/src/semmle/code/cpp/ir/dataflow/internal/DataFlowImpl3.qll
@@ -1785,7 +1785,7 @@ private predicate pathOutOfCallable0(PathNodeMid mid, ReturnPosition pos, CallCo
   not innercc instanceof CallContextCall
 }
 
-pragma[noinline]
+pragma[nomagic]
 private predicate pathOutOfCallable1(
   PathNodeMid mid, DataFlowCall call, ReturnKindExt kind, CallContext cc
 ) {

--- a/cpp/ql/src/semmle/code/cpp/ir/dataflow/internal/DataFlowImpl3.qll
+++ b/cpp/ql/src/semmle/code/cpp/ir/dataflow/internal/DataFlowImpl3.qll
@@ -314,11 +314,19 @@ private predicate nodeCandFwd1(Node node, Configuration config) {
     )
     or
     // flow out of a callable
-    exists(DataFlowCall call, ReturnNodeExt ret, ReturnKindExt kind |
-      nodeCandFwd1(ret, config) and
-      getReturnPosition(ret) = viableReturnPos(call, kind) and
+    exists(DataFlowCall call, ReturnPosition pos, ReturnKindExt kind |
+      nodeCandFwd1ReturnPosition(pos, config) and
+      pos = viableReturnPos(call, kind) and
       node = kind.getAnOutNode(call)
     )
+  )
+}
+
+pragma[noinline]
+private predicate nodeCandFwd1ReturnPosition(ReturnPosition pos, Configuration config) {
+  exists(ReturnNodeExt ret |
+    nodeCandFwd1(ret, config) and
+    getReturnPosition(ret) = pos
   )
 }
 
@@ -1885,7 +1893,7 @@ private predicate paramFlowsThrough(
   )
 }
 
-pragma[noinline]
+pragma[nomagic]
 private predicate pathThroughCallable0(
   DataFlowCall call, PathNodeMid mid, ReturnKindExt kind, CallContext cc, AccessPathNil apnil
 ) {

--- a/cpp/ql/src/semmle/code/cpp/ir/dataflow/internal/DataFlowImpl4.qll
+++ b/cpp/ql/src/semmle/code/cpp/ir/dataflow/internal/DataFlowImpl4.qll
@@ -317,7 +317,7 @@ private predicate nodeCandFwd1(Node node, Configuration config) {
     exists(DataFlowCall call, ReturnNodeExt ret, ReturnKindExt kind |
       nodeCandFwd1(ret, config) and
       getReturnPosition(ret) = viableReturnPos(call, kind) and
-      node = getAnOutNodeExt(call, kind)
+      node = kind.getAnOutNode(call)
     )
   )
 }
@@ -409,7 +409,7 @@ private predicate nodeCand1ReturnPosition(ReturnPosition pos, Configuration conf
   exists(DataFlowCall call, ReturnKindExt kind, Node out |
     nodeCand1(out, config) and
     pos = viableReturnPos(call, kind) and
-    out = getAnOutNodeExt(call, kind)
+    out = kind.getAnOutNode(call)
   )
 }
 
@@ -576,7 +576,7 @@ private predicate flowOutOfCallable(Node node1, Node node2, Configuration config
   not inBarrier(node2, config) and
   exists(DataFlowCall call, ReturnKindExt kind |
     getReturnPosition1(node1, unbind(config)) = viableReturnPos(call, kind) and
-    node2 = getAnOutNodeExt(call, kind)
+    node2 = kind.getAnOutNode(call)
   )
 }
 
@@ -1806,7 +1806,7 @@ private predicate pathOutOfCallable1(
 pragma[noinline]
 private predicate pathOutOfCallable(PathNodeMid mid, Node out, CallContext cc) {
   exists(ReturnKindExt kind, DataFlowCall call | pathOutOfCallable1(mid, call, kind, cc) |
-    out = getAnOutNodeExt(call, kind)
+    out = kind.getAnOutNode(call)
   )
 }
 
@@ -1905,7 +1905,7 @@ pragma[noinline]
 private predicate pathThroughCallable(PathNodeMid mid, Node out, CallContext cc, AccessPathNil apnil) {
   exists(DataFlowCall call, ReturnKindExt kind |
     pathThroughCallable0(call, mid, kind, cc, apnil) and
-    out = getAnOutNodeExt(call, kind)
+    out = kind.getAnOutNode(call)
   )
 }
 
@@ -1965,7 +1965,7 @@ private module FlowExploration {
       // flow out of a callable
       exists(DataFlowCall call, ReturnKindExt kind |
         getReturnPosition(node1) = viableReturnPos(call, kind) and
-        node2 = getAnOutNodeExt(call, kind)
+        node2 = kind.getAnOutNode(call)
       )
     |
       c1 = node1.getEnclosingCallable() and
@@ -2287,7 +2287,7 @@ private module FlowExploration {
     exists(ReturnKindExt kind, DataFlowCall call |
       partialPathOutOfCallable1(mid, call, kind, cc, ap, config)
     |
-      out = getAnOutNodeExt(call, kind)
+      out = kind.getAnOutNode(call)
     )
   }
 
@@ -2370,7 +2370,7 @@ private module FlowExploration {
   ) {
     exists(DataFlowCall call, ReturnKindExt kind |
       partialPathThroughCallable0(call, mid, kind, cc, apnil, config) and
-      out = getAnOutNodeExt(call, kind)
+      out = kind.getAnOutNode(call)
     )
   }
 

--- a/cpp/ql/src/semmle/code/cpp/ir/dataflow/internal/DataFlowImpl4.qll
+++ b/cpp/ql/src/semmle/code/cpp/ir/dataflow/internal/DataFlowImpl4.qll
@@ -1785,7 +1785,7 @@ private predicate pathOutOfCallable0(PathNodeMid mid, ReturnPosition pos, CallCo
   not innercc instanceof CallContextCall
 }
 
-pragma[noinline]
+pragma[nomagic]
 private predicate pathOutOfCallable1(
   PathNodeMid mid, DataFlowCall call, ReturnKindExt kind, CallContext cc
 ) {

--- a/cpp/ql/src/semmle/code/cpp/ir/dataflow/internal/DataFlowImpl4.qll
+++ b/cpp/ql/src/semmle/code/cpp/ir/dataflow/internal/DataFlowImpl4.qll
@@ -314,11 +314,19 @@ private predicate nodeCandFwd1(Node node, Configuration config) {
     )
     or
     // flow out of a callable
-    exists(DataFlowCall call, ReturnNodeExt ret, ReturnKindExt kind |
-      nodeCandFwd1(ret, config) and
-      getReturnPosition(ret) = viableReturnPos(call, kind) and
+    exists(DataFlowCall call, ReturnPosition pos, ReturnKindExt kind |
+      nodeCandFwd1ReturnPosition(pos, config) and
+      pos = viableReturnPos(call, kind) and
       node = kind.getAnOutNode(call)
     )
+  )
+}
+
+pragma[noinline]
+private predicate nodeCandFwd1ReturnPosition(ReturnPosition pos, Configuration config) {
+  exists(ReturnNodeExt ret |
+    nodeCandFwd1(ret, config) and
+    getReturnPosition(ret) = pos
   )
 }
 
@@ -1885,7 +1893,7 @@ private predicate paramFlowsThrough(
   )
 }
 
-pragma[noinline]
+pragma[nomagic]
 private predicate pathThroughCallable0(
   DataFlowCall call, PathNodeMid mid, ReturnKindExt kind, CallContext cc, AccessPathNil apnil
 ) {

--- a/csharp/ql/src/semmle/code/csharp/dataflow/internal/DataFlowImpl.qll
+++ b/csharp/ql/src/semmle/code/csharp/dataflow/internal/DataFlowImpl.qll
@@ -317,7 +317,7 @@ private predicate nodeCandFwd1(Node node, Configuration config) {
     exists(DataFlowCall call, ReturnNodeExt ret, ReturnKindExt kind |
       nodeCandFwd1(ret, config) and
       getReturnPosition(ret) = viableReturnPos(call, kind) and
-      node = getAnOutNodeExt(call, kind)
+      node = kind.getAnOutNode(call)
     )
   )
 }
@@ -409,7 +409,7 @@ private predicate nodeCand1ReturnPosition(ReturnPosition pos, Configuration conf
   exists(DataFlowCall call, ReturnKindExt kind, Node out |
     nodeCand1(out, config) and
     pos = viableReturnPos(call, kind) and
-    out = getAnOutNodeExt(call, kind)
+    out = kind.getAnOutNode(call)
   )
 }
 
@@ -576,7 +576,7 @@ private predicate flowOutOfCallable(Node node1, Node node2, Configuration config
   not inBarrier(node2, config) and
   exists(DataFlowCall call, ReturnKindExt kind |
     getReturnPosition1(node1, unbind(config)) = viableReturnPos(call, kind) and
-    node2 = getAnOutNodeExt(call, kind)
+    node2 = kind.getAnOutNode(call)
   )
 }
 
@@ -1806,7 +1806,7 @@ private predicate pathOutOfCallable1(
 pragma[noinline]
 private predicate pathOutOfCallable(PathNodeMid mid, Node out, CallContext cc) {
   exists(ReturnKindExt kind, DataFlowCall call | pathOutOfCallable1(mid, call, kind, cc) |
-    out = getAnOutNodeExt(call, kind)
+    out = kind.getAnOutNode(call)
   )
 }
 
@@ -1905,7 +1905,7 @@ pragma[noinline]
 private predicate pathThroughCallable(PathNodeMid mid, Node out, CallContext cc, AccessPathNil apnil) {
   exists(DataFlowCall call, ReturnKindExt kind |
     pathThroughCallable0(call, mid, kind, cc, apnil) and
-    out = getAnOutNodeExt(call, kind)
+    out = kind.getAnOutNode(call)
   )
 }
 
@@ -1965,7 +1965,7 @@ private module FlowExploration {
       // flow out of a callable
       exists(DataFlowCall call, ReturnKindExt kind |
         getReturnPosition(node1) = viableReturnPos(call, kind) and
-        node2 = getAnOutNodeExt(call, kind)
+        node2 = kind.getAnOutNode(call)
       )
     |
       c1 = node1.getEnclosingCallable() and
@@ -2287,7 +2287,7 @@ private module FlowExploration {
     exists(ReturnKindExt kind, DataFlowCall call |
       partialPathOutOfCallable1(mid, call, kind, cc, ap, config)
     |
-      out = getAnOutNodeExt(call, kind)
+      out = kind.getAnOutNode(call)
     )
   }
 
@@ -2370,7 +2370,7 @@ private module FlowExploration {
   ) {
     exists(DataFlowCall call, ReturnKindExt kind |
       partialPathThroughCallable0(call, mid, kind, cc, apnil, config) and
-      out = getAnOutNodeExt(call, kind)
+      out = kind.getAnOutNode(call)
     )
   }
 

--- a/csharp/ql/src/semmle/code/csharp/dataflow/internal/DataFlowImpl.qll
+++ b/csharp/ql/src/semmle/code/csharp/dataflow/internal/DataFlowImpl.qll
@@ -1785,7 +1785,7 @@ private predicate pathOutOfCallable0(PathNodeMid mid, ReturnPosition pos, CallCo
   not innercc instanceof CallContextCall
 }
 
-pragma[noinline]
+pragma[nomagic]
 private predicate pathOutOfCallable1(
   PathNodeMid mid, DataFlowCall call, ReturnKindExt kind, CallContext cc
 ) {

--- a/csharp/ql/src/semmle/code/csharp/dataflow/internal/DataFlowImpl.qll
+++ b/csharp/ql/src/semmle/code/csharp/dataflow/internal/DataFlowImpl.qll
@@ -314,11 +314,19 @@ private predicate nodeCandFwd1(Node node, Configuration config) {
     )
     or
     // flow out of a callable
-    exists(DataFlowCall call, ReturnNodeExt ret, ReturnKindExt kind |
-      nodeCandFwd1(ret, config) and
-      getReturnPosition(ret) = viableReturnPos(call, kind) and
+    exists(DataFlowCall call, ReturnPosition pos, ReturnKindExt kind |
+      nodeCandFwd1ReturnPosition(pos, config) and
+      pos = viableReturnPos(call, kind) and
       node = kind.getAnOutNode(call)
     )
+  )
+}
+
+pragma[noinline]
+private predicate nodeCandFwd1ReturnPosition(ReturnPosition pos, Configuration config) {
+  exists(ReturnNodeExt ret |
+    nodeCandFwd1(ret, config) and
+    getReturnPosition(ret) = pos
   )
 }
 
@@ -1885,7 +1893,7 @@ private predicate paramFlowsThrough(
   )
 }
 
-pragma[noinline]
+pragma[nomagic]
 private predicate pathThroughCallable0(
   DataFlowCall call, PathNodeMid mid, ReturnKindExt kind, CallContext cc, AccessPathNil apnil
 ) {

--- a/csharp/ql/src/semmle/code/csharp/dataflow/internal/DataFlowImpl2.qll
+++ b/csharp/ql/src/semmle/code/csharp/dataflow/internal/DataFlowImpl2.qll
@@ -317,7 +317,7 @@ private predicate nodeCandFwd1(Node node, Configuration config) {
     exists(DataFlowCall call, ReturnNodeExt ret, ReturnKindExt kind |
       nodeCandFwd1(ret, config) and
       getReturnPosition(ret) = viableReturnPos(call, kind) and
-      node = getAnOutNodeExt(call, kind)
+      node = kind.getAnOutNode(call)
     )
   )
 }
@@ -409,7 +409,7 @@ private predicate nodeCand1ReturnPosition(ReturnPosition pos, Configuration conf
   exists(DataFlowCall call, ReturnKindExt kind, Node out |
     nodeCand1(out, config) and
     pos = viableReturnPos(call, kind) and
-    out = getAnOutNodeExt(call, kind)
+    out = kind.getAnOutNode(call)
   )
 }
 
@@ -576,7 +576,7 @@ private predicate flowOutOfCallable(Node node1, Node node2, Configuration config
   not inBarrier(node2, config) and
   exists(DataFlowCall call, ReturnKindExt kind |
     getReturnPosition1(node1, unbind(config)) = viableReturnPos(call, kind) and
-    node2 = getAnOutNodeExt(call, kind)
+    node2 = kind.getAnOutNode(call)
   )
 }
 
@@ -1806,7 +1806,7 @@ private predicate pathOutOfCallable1(
 pragma[noinline]
 private predicate pathOutOfCallable(PathNodeMid mid, Node out, CallContext cc) {
   exists(ReturnKindExt kind, DataFlowCall call | pathOutOfCallable1(mid, call, kind, cc) |
-    out = getAnOutNodeExt(call, kind)
+    out = kind.getAnOutNode(call)
   )
 }
 
@@ -1905,7 +1905,7 @@ pragma[noinline]
 private predicate pathThroughCallable(PathNodeMid mid, Node out, CallContext cc, AccessPathNil apnil) {
   exists(DataFlowCall call, ReturnKindExt kind |
     pathThroughCallable0(call, mid, kind, cc, apnil) and
-    out = getAnOutNodeExt(call, kind)
+    out = kind.getAnOutNode(call)
   )
 }
 
@@ -1965,7 +1965,7 @@ private module FlowExploration {
       // flow out of a callable
       exists(DataFlowCall call, ReturnKindExt kind |
         getReturnPosition(node1) = viableReturnPos(call, kind) and
-        node2 = getAnOutNodeExt(call, kind)
+        node2 = kind.getAnOutNode(call)
       )
     |
       c1 = node1.getEnclosingCallable() and
@@ -2287,7 +2287,7 @@ private module FlowExploration {
     exists(ReturnKindExt kind, DataFlowCall call |
       partialPathOutOfCallable1(mid, call, kind, cc, ap, config)
     |
-      out = getAnOutNodeExt(call, kind)
+      out = kind.getAnOutNode(call)
     )
   }
 
@@ -2370,7 +2370,7 @@ private module FlowExploration {
   ) {
     exists(DataFlowCall call, ReturnKindExt kind |
       partialPathThroughCallable0(call, mid, kind, cc, apnil, config) and
-      out = getAnOutNodeExt(call, kind)
+      out = kind.getAnOutNode(call)
     )
   }
 

--- a/csharp/ql/src/semmle/code/csharp/dataflow/internal/DataFlowImpl2.qll
+++ b/csharp/ql/src/semmle/code/csharp/dataflow/internal/DataFlowImpl2.qll
@@ -1785,7 +1785,7 @@ private predicate pathOutOfCallable0(PathNodeMid mid, ReturnPosition pos, CallCo
   not innercc instanceof CallContextCall
 }
 
-pragma[noinline]
+pragma[nomagic]
 private predicate pathOutOfCallable1(
   PathNodeMid mid, DataFlowCall call, ReturnKindExt kind, CallContext cc
 ) {

--- a/csharp/ql/src/semmle/code/csharp/dataflow/internal/DataFlowImpl2.qll
+++ b/csharp/ql/src/semmle/code/csharp/dataflow/internal/DataFlowImpl2.qll
@@ -314,11 +314,19 @@ private predicate nodeCandFwd1(Node node, Configuration config) {
     )
     or
     // flow out of a callable
-    exists(DataFlowCall call, ReturnNodeExt ret, ReturnKindExt kind |
-      nodeCandFwd1(ret, config) and
-      getReturnPosition(ret) = viableReturnPos(call, kind) and
+    exists(DataFlowCall call, ReturnPosition pos, ReturnKindExt kind |
+      nodeCandFwd1ReturnPosition(pos, config) and
+      pos = viableReturnPos(call, kind) and
       node = kind.getAnOutNode(call)
     )
+  )
+}
+
+pragma[noinline]
+private predicate nodeCandFwd1ReturnPosition(ReturnPosition pos, Configuration config) {
+  exists(ReturnNodeExt ret |
+    nodeCandFwd1(ret, config) and
+    getReturnPosition(ret) = pos
   )
 }
 
@@ -1885,7 +1893,7 @@ private predicate paramFlowsThrough(
   )
 }
 
-pragma[noinline]
+pragma[nomagic]
 private predicate pathThroughCallable0(
   DataFlowCall call, PathNodeMid mid, ReturnKindExt kind, CallContext cc, AccessPathNil apnil
 ) {

--- a/csharp/ql/src/semmle/code/csharp/dataflow/internal/DataFlowImpl3.qll
+++ b/csharp/ql/src/semmle/code/csharp/dataflow/internal/DataFlowImpl3.qll
@@ -317,7 +317,7 @@ private predicate nodeCandFwd1(Node node, Configuration config) {
     exists(DataFlowCall call, ReturnNodeExt ret, ReturnKindExt kind |
       nodeCandFwd1(ret, config) and
       getReturnPosition(ret) = viableReturnPos(call, kind) and
-      node = getAnOutNodeExt(call, kind)
+      node = kind.getAnOutNode(call)
     )
   )
 }
@@ -409,7 +409,7 @@ private predicate nodeCand1ReturnPosition(ReturnPosition pos, Configuration conf
   exists(DataFlowCall call, ReturnKindExt kind, Node out |
     nodeCand1(out, config) and
     pos = viableReturnPos(call, kind) and
-    out = getAnOutNodeExt(call, kind)
+    out = kind.getAnOutNode(call)
   )
 }
 
@@ -576,7 +576,7 @@ private predicate flowOutOfCallable(Node node1, Node node2, Configuration config
   not inBarrier(node2, config) and
   exists(DataFlowCall call, ReturnKindExt kind |
     getReturnPosition1(node1, unbind(config)) = viableReturnPos(call, kind) and
-    node2 = getAnOutNodeExt(call, kind)
+    node2 = kind.getAnOutNode(call)
   )
 }
 
@@ -1806,7 +1806,7 @@ private predicate pathOutOfCallable1(
 pragma[noinline]
 private predicate pathOutOfCallable(PathNodeMid mid, Node out, CallContext cc) {
   exists(ReturnKindExt kind, DataFlowCall call | pathOutOfCallable1(mid, call, kind, cc) |
-    out = getAnOutNodeExt(call, kind)
+    out = kind.getAnOutNode(call)
   )
 }
 
@@ -1905,7 +1905,7 @@ pragma[noinline]
 private predicate pathThroughCallable(PathNodeMid mid, Node out, CallContext cc, AccessPathNil apnil) {
   exists(DataFlowCall call, ReturnKindExt kind |
     pathThroughCallable0(call, mid, kind, cc, apnil) and
-    out = getAnOutNodeExt(call, kind)
+    out = kind.getAnOutNode(call)
   )
 }
 
@@ -1965,7 +1965,7 @@ private module FlowExploration {
       // flow out of a callable
       exists(DataFlowCall call, ReturnKindExt kind |
         getReturnPosition(node1) = viableReturnPos(call, kind) and
-        node2 = getAnOutNodeExt(call, kind)
+        node2 = kind.getAnOutNode(call)
       )
     |
       c1 = node1.getEnclosingCallable() and
@@ -2287,7 +2287,7 @@ private module FlowExploration {
     exists(ReturnKindExt kind, DataFlowCall call |
       partialPathOutOfCallable1(mid, call, kind, cc, ap, config)
     |
-      out = getAnOutNodeExt(call, kind)
+      out = kind.getAnOutNode(call)
     )
   }
 
@@ -2370,7 +2370,7 @@ private module FlowExploration {
   ) {
     exists(DataFlowCall call, ReturnKindExt kind |
       partialPathThroughCallable0(call, mid, kind, cc, apnil, config) and
-      out = getAnOutNodeExt(call, kind)
+      out = kind.getAnOutNode(call)
     )
   }
 

--- a/csharp/ql/src/semmle/code/csharp/dataflow/internal/DataFlowImpl3.qll
+++ b/csharp/ql/src/semmle/code/csharp/dataflow/internal/DataFlowImpl3.qll
@@ -1785,7 +1785,7 @@ private predicate pathOutOfCallable0(PathNodeMid mid, ReturnPosition pos, CallCo
   not innercc instanceof CallContextCall
 }
 
-pragma[noinline]
+pragma[nomagic]
 private predicate pathOutOfCallable1(
   PathNodeMid mid, DataFlowCall call, ReturnKindExt kind, CallContext cc
 ) {

--- a/csharp/ql/src/semmle/code/csharp/dataflow/internal/DataFlowImpl3.qll
+++ b/csharp/ql/src/semmle/code/csharp/dataflow/internal/DataFlowImpl3.qll
@@ -314,11 +314,19 @@ private predicate nodeCandFwd1(Node node, Configuration config) {
     )
     or
     // flow out of a callable
-    exists(DataFlowCall call, ReturnNodeExt ret, ReturnKindExt kind |
-      nodeCandFwd1(ret, config) and
-      getReturnPosition(ret) = viableReturnPos(call, kind) and
+    exists(DataFlowCall call, ReturnPosition pos, ReturnKindExt kind |
+      nodeCandFwd1ReturnPosition(pos, config) and
+      pos = viableReturnPos(call, kind) and
       node = kind.getAnOutNode(call)
     )
+  )
+}
+
+pragma[noinline]
+private predicate nodeCandFwd1ReturnPosition(ReturnPosition pos, Configuration config) {
+  exists(ReturnNodeExt ret |
+    nodeCandFwd1(ret, config) and
+    getReturnPosition(ret) = pos
   )
 }
 
@@ -1885,7 +1893,7 @@ private predicate paramFlowsThrough(
   )
 }
 
-pragma[noinline]
+pragma[nomagic]
 private predicate pathThroughCallable0(
   DataFlowCall call, PathNodeMid mid, ReturnKindExt kind, CallContext cc, AccessPathNil apnil
 ) {

--- a/csharp/ql/src/semmle/code/csharp/dataflow/internal/DataFlowImpl4.qll
+++ b/csharp/ql/src/semmle/code/csharp/dataflow/internal/DataFlowImpl4.qll
@@ -317,7 +317,7 @@ private predicate nodeCandFwd1(Node node, Configuration config) {
     exists(DataFlowCall call, ReturnNodeExt ret, ReturnKindExt kind |
       nodeCandFwd1(ret, config) and
       getReturnPosition(ret) = viableReturnPos(call, kind) and
-      node = getAnOutNodeExt(call, kind)
+      node = kind.getAnOutNode(call)
     )
   )
 }
@@ -409,7 +409,7 @@ private predicate nodeCand1ReturnPosition(ReturnPosition pos, Configuration conf
   exists(DataFlowCall call, ReturnKindExt kind, Node out |
     nodeCand1(out, config) and
     pos = viableReturnPos(call, kind) and
-    out = getAnOutNodeExt(call, kind)
+    out = kind.getAnOutNode(call)
   )
 }
 
@@ -576,7 +576,7 @@ private predicate flowOutOfCallable(Node node1, Node node2, Configuration config
   not inBarrier(node2, config) and
   exists(DataFlowCall call, ReturnKindExt kind |
     getReturnPosition1(node1, unbind(config)) = viableReturnPos(call, kind) and
-    node2 = getAnOutNodeExt(call, kind)
+    node2 = kind.getAnOutNode(call)
   )
 }
 
@@ -1806,7 +1806,7 @@ private predicate pathOutOfCallable1(
 pragma[noinline]
 private predicate pathOutOfCallable(PathNodeMid mid, Node out, CallContext cc) {
   exists(ReturnKindExt kind, DataFlowCall call | pathOutOfCallable1(mid, call, kind, cc) |
-    out = getAnOutNodeExt(call, kind)
+    out = kind.getAnOutNode(call)
   )
 }
 
@@ -1905,7 +1905,7 @@ pragma[noinline]
 private predicate pathThroughCallable(PathNodeMid mid, Node out, CallContext cc, AccessPathNil apnil) {
   exists(DataFlowCall call, ReturnKindExt kind |
     pathThroughCallable0(call, mid, kind, cc, apnil) and
-    out = getAnOutNodeExt(call, kind)
+    out = kind.getAnOutNode(call)
   )
 }
 
@@ -1965,7 +1965,7 @@ private module FlowExploration {
       // flow out of a callable
       exists(DataFlowCall call, ReturnKindExt kind |
         getReturnPosition(node1) = viableReturnPos(call, kind) and
-        node2 = getAnOutNodeExt(call, kind)
+        node2 = kind.getAnOutNode(call)
       )
     |
       c1 = node1.getEnclosingCallable() and
@@ -2287,7 +2287,7 @@ private module FlowExploration {
     exists(ReturnKindExt kind, DataFlowCall call |
       partialPathOutOfCallable1(mid, call, kind, cc, ap, config)
     |
-      out = getAnOutNodeExt(call, kind)
+      out = kind.getAnOutNode(call)
     )
   }
 
@@ -2370,7 +2370,7 @@ private module FlowExploration {
   ) {
     exists(DataFlowCall call, ReturnKindExt kind |
       partialPathThroughCallable0(call, mid, kind, cc, apnil, config) and
-      out = getAnOutNodeExt(call, kind)
+      out = kind.getAnOutNode(call)
     )
   }
 

--- a/csharp/ql/src/semmle/code/csharp/dataflow/internal/DataFlowImpl4.qll
+++ b/csharp/ql/src/semmle/code/csharp/dataflow/internal/DataFlowImpl4.qll
@@ -1785,7 +1785,7 @@ private predicate pathOutOfCallable0(PathNodeMid mid, ReturnPosition pos, CallCo
   not innercc instanceof CallContextCall
 }
 
-pragma[noinline]
+pragma[nomagic]
 private predicate pathOutOfCallable1(
   PathNodeMid mid, DataFlowCall call, ReturnKindExt kind, CallContext cc
 ) {

--- a/csharp/ql/src/semmle/code/csharp/dataflow/internal/DataFlowImpl4.qll
+++ b/csharp/ql/src/semmle/code/csharp/dataflow/internal/DataFlowImpl4.qll
@@ -314,11 +314,19 @@ private predicate nodeCandFwd1(Node node, Configuration config) {
     )
     or
     // flow out of a callable
-    exists(DataFlowCall call, ReturnNodeExt ret, ReturnKindExt kind |
-      nodeCandFwd1(ret, config) and
-      getReturnPosition(ret) = viableReturnPos(call, kind) and
+    exists(DataFlowCall call, ReturnPosition pos, ReturnKindExt kind |
+      nodeCandFwd1ReturnPosition(pos, config) and
+      pos = viableReturnPos(call, kind) and
       node = kind.getAnOutNode(call)
     )
+  )
+}
+
+pragma[noinline]
+private predicate nodeCandFwd1ReturnPosition(ReturnPosition pos, Configuration config) {
+  exists(ReturnNodeExt ret |
+    nodeCandFwd1(ret, config) and
+    getReturnPosition(ret) = pos
   )
 }
 
@@ -1885,7 +1893,7 @@ private predicate paramFlowsThrough(
   )
 }
 
-pragma[noinline]
+pragma[nomagic]
 private predicate pathThroughCallable0(
   DataFlowCall call, PathNodeMid mid, ReturnKindExt kind, CallContext cc, AccessPathNil apnil
 ) {

--- a/csharp/ql/src/semmle/code/csharp/dataflow/internal/DataFlowImpl5.qll
+++ b/csharp/ql/src/semmle/code/csharp/dataflow/internal/DataFlowImpl5.qll
@@ -317,7 +317,7 @@ private predicate nodeCandFwd1(Node node, Configuration config) {
     exists(DataFlowCall call, ReturnNodeExt ret, ReturnKindExt kind |
       nodeCandFwd1(ret, config) and
       getReturnPosition(ret) = viableReturnPos(call, kind) and
-      node = getAnOutNodeExt(call, kind)
+      node = kind.getAnOutNode(call)
     )
   )
 }
@@ -409,7 +409,7 @@ private predicate nodeCand1ReturnPosition(ReturnPosition pos, Configuration conf
   exists(DataFlowCall call, ReturnKindExt kind, Node out |
     nodeCand1(out, config) and
     pos = viableReturnPos(call, kind) and
-    out = getAnOutNodeExt(call, kind)
+    out = kind.getAnOutNode(call)
   )
 }
 
@@ -576,7 +576,7 @@ private predicate flowOutOfCallable(Node node1, Node node2, Configuration config
   not inBarrier(node2, config) and
   exists(DataFlowCall call, ReturnKindExt kind |
     getReturnPosition1(node1, unbind(config)) = viableReturnPos(call, kind) and
-    node2 = getAnOutNodeExt(call, kind)
+    node2 = kind.getAnOutNode(call)
   )
 }
 
@@ -1806,7 +1806,7 @@ private predicate pathOutOfCallable1(
 pragma[noinline]
 private predicate pathOutOfCallable(PathNodeMid mid, Node out, CallContext cc) {
   exists(ReturnKindExt kind, DataFlowCall call | pathOutOfCallable1(mid, call, kind, cc) |
-    out = getAnOutNodeExt(call, kind)
+    out = kind.getAnOutNode(call)
   )
 }
 
@@ -1905,7 +1905,7 @@ pragma[noinline]
 private predicate pathThroughCallable(PathNodeMid mid, Node out, CallContext cc, AccessPathNil apnil) {
   exists(DataFlowCall call, ReturnKindExt kind |
     pathThroughCallable0(call, mid, kind, cc, apnil) and
-    out = getAnOutNodeExt(call, kind)
+    out = kind.getAnOutNode(call)
   )
 }
 
@@ -1965,7 +1965,7 @@ private module FlowExploration {
       // flow out of a callable
       exists(DataFlowCall call, ReturnKindExt kind |
         getReturnPosition(node1) = viableReturnPos(call, kind) and
-        node2 = getAnOutNodeExt(call, kind)
+        node2 = kind.getAnOutNode(call)
       )
     |
       c1 = node1.getEnclosingCallable() and
@@ -2287,7 +2287,7 @@ private module FlowExploration {
     exists(ReturnKindExt kind, DataFlowCall call |
       partialPathOutOfCallable1(mid, call, kind, cc, ap, config)
     |
-      out = getAnOutNodeExt(call, kind)
+      out = kind.getAnOutNode(call)
     )
   }
 
@@ -2370,7 +2370,7 @@ private module FlowExploration {
   ) {
     exists(DataFlowCall call, ReturnKindExt kind |
       partialPathThroughCallable0(call, mid, kind, cc, apnil, config) and
-      out = getAnOutNodeExt(call, kind)
+      out = kind.getAnOutNode(call)
     )
   }
 

--- a/csharp/ql/src/semmle/code/csharp/dataflow/internal/DataFlowImpl5.qll
+++ b/csharp/ql/src/semmle/code/csharp/dataflow/internal/DataFlowImpl5.qll
@@ -1785,7 +1785,7 @@ private predicate pathOutOfCallable0(PathNodeMid mid, ReturnPosition pos, CallCo
   not innercc instanceof CallContextCall
 }
 
-pragma[noinline]
+pragma[nomagic]
 private predicate pathOutOfCallable1(
   PathNodeMid mid, DataFlowCall call, ReturnKindExt kind, CallContext cc
 ) {

--- a/csharp/ql/src/semmle/code/csharp/dataflow/internal/DataFlowImpl5.qll
+++ b/csharp/ql/src/semmle/code/csharp/dataflow/internal/DataFlowImpl5.qll
@@ -314,11 +314,19 @@ private predicate nodeCandFwd1(Node node, Configuration config) {
     )
     or
     // flow out of a callable
-    exists(DataFlowCall call, ReturnNodeExt ret, ReturnKindExt kind |
-      nodeCandFwd1(ret, config) and
-      getReturnPosition(ret) = viableReturnPos(call, kind) and
+    exists(DataFlowCall call, ReturnPosition pos, ReturnKindExt kind |
+      nodeCandFwd1ReturnPosition(pos, config) and
+      pos = viableReturnPos(call, kind) and
       node = kind.getAnOutNode(call)
     )
+  )
+}
+
+pragma[noinline]
+private predicate nodeCandFwd1ReturnPosition(ReturnPosition pos, Configuration config) {
+  exists(ReturnNodeExt ret |
+    nodeCandFwd1(ret, config) and
+    getReturnPosition(ret) = pos
   )
 }
 
@@ -1885,7 +1893,7 @@ private predicate paramFlowsThrough(
   )
 }
 
-pragma[noinline]
+pragma[nomagic]
 private predicate pathThroughCallable0(
   DataFlowCall call, PathNodeMid mid, ReturnKindExt kind, CallContext cc, AccessPathNil apnil
 ) {

--- a/java/ql/src/semmle/code/java/dataflow/internal/DataFlowImpl.qll
+++ b/java/ql/src/semmle/code/java/dataflow/internal/DataFlowImpl.qll
@@ -317,7 +317,7 @@ private predicate nodeCandFwd1(Node node, Configuration config) {
     exists(DataFlowCall call, ReturnNodeExt ret, ReturnKindExt kind |
       nodeCandFwd1(ret, config) and
       getReturnPosition(ret) = viableReturnPos(call, kind) and
-      node = getAnOutNodeExt(call, kind)
+      node = kind.getAnOutNode(call)
     )
   )
 }
@@ -409,7 +409,7 @@ private predicate nodeCand1ReturnPosition(ReturnPosition pos, Configuration conf
   exists(DataFlowCall call, ReturnKindExt kind, Node out |
     nodeCand1(out, config) and
     pos = viableReturnPos(call, kind) and
-    out = getAnOutNodeExt(call, kind)
+    out = kind.getAnOutNode(call)
   )
 }
 
@@ -576,7 +576,7 @@ private predicate flowOutOfCallable(Node node1, Node node2, Configuration config
   not inBarrier(node2, config) and
   exists(DataFlowCall call, ReturnKindExt kind |
     getReturnPosition1(node1, unbind(config)) = viableReturnPos(call, kind) and
-    node2 = getAnOutNodeExt(call, kind)
+    node2 = kind.getAnOutNode(call)
   )
 }
 
@@ -1806,7 +1806,7 @@ private predicate pathOutOfCallable1(
 pragma[noinline]
 private predicate pathOutOfCallable(PathNodeMid mid, Node out, CallContext cc) {
   exists(ReturnKindExt kind, DataFlowCall call | pathOutOfCallable1(mid, call, kind, cc) |
-    out = getAnOutNodeExt(call, kind)
+    out = kind.getAnOutNode(call)
   )
 }
 
@@ -1905,7 +1905,7 @@ pragma[noinline]
 private predicate pathThroughCallable(PathNodeMid mid, Node out, CallContext cc, AccessPathNil apnil) {
   exists(DataFlowCall call, ReturnKindExt kind |
     pathThroughCallable0(call, mid, kind, cc, apnil) and
-    out = getAnOutNodeExt(call, kind)
+    out = kind.getAnOutNode(call)
   )
 }
 
@@ -1965,7 +1965,7 @@ private module FlowExploration {
       // flow out of a callable
       exists(DataFlowCall call, ReturnKindExt kind |
         getReturnPosition(node1) = viableReturnPos(call, kind) and
-        node2 = getAnOutNodeExt(call, kind)
+        node2 = kind.getAnOutNode(call)
       )
     |
       c1 = node1.getEnclosingCallable() and
@@ -2287,7 +2287,7 @@ private module FlowExploration {
     exists(ReturnKindExt kind, DataFlowCall call |
       partialPathOutOfCallable1(mid, call, kind, cc, ap, config)
     |
-      out = getAnOutNodeExt(call, kind)
+      out = kind.getAnOutNode(call)
     )
   }
 
@@ -2370,7 +2370,7 @@ private module FlowExploration {
   ) {
     exists(DataFlowCall call, ReturnKindExt kind |
       partialPathThroughCallable0(call, mid, kind, cc, apnil, config) and
-      out = getAnOutNodeExt(call, kind)
+      out = kind.getAnOutNode(call)
     )
   }
 

--- a/java/ql/src/semmle/code/java/dataflow/internal/DataFlowImpl.qll
+++ b/java/ql/src/semmle/code/java/dataflow/internal/DataFlowImpl.qll
@@ -1785,7 +1785,7 @@ private predicate pathOutOfCallable0(PathNodeMid mid, ReturnPosition pos, CallCo
   not innercc instanceof CallContextCall
 }
 
-pragma[noinline]
+pragma[nomagic]
 private predicate pathOutOfCallable1(
   PathNodeMid mid, DataFlowCall call, ReturnKindExt kind, CallContext cc
 ) {

--- a/java/ql/src/semmle/code/java/dataflow/internal/DataFlowImpl.qll
+++ b/java/ql/src/semmle/code/java/dataflow/internal/DataFlowImpl.qll
@@ -314,11 +314,19 @@ private predicate nodeCandFwd1(Node node, Configuration config) {
     )
     or
     // flow out of a callable
-    exists(DataFlowCall call, ReturnNodeExt ret, ReturnKindExt kind |
-      nodeCandFwd1(ret, config) and
-      getReturnPosition(ret) = viableReturnPos(call, kind) and
+    exists(DataFlowCall call, ReturnPosition pos, ReturnKindExt kind |
+      nodeCandFwd1ReturnPosition(pos, config) and
+      pos = viableReturnPos(call, kind) and
       node = kind.getAnOutNode(call)
     )
+  )
+}
+
+pragma[noinline]
+private predicate nodeCandFwd1ReturnPosition(ReturnPosition pos, Configuration config) {
+  exists(ReturnNodeExt ret |
+    nodeCandFwd1(ret, config) and
+    getReturnPosition(ret) = pos
   )
 }
 
@@ -1885,7 +1893,7 @@ private predicate paramFlowsThrough(
   )
 }
 
-pragma[noinline]
+pragma[nomagic]
 private predicate pathThroughCallable0(
   DataFlowCall call, PathNodeMid mid, ReturnKindExt kind, CallContext cc, AccessPathNil apnil
 ) {

--- a/java/ql/src/semmle/code/java/dataflow/internal/DataFlowImpl2.qll
+++ b/java/ql/src/semmle/code/java/dataflow/internal/DataFlowImpl2.qll
@@ -317,7 +317,7 @@ private predicate nodeCandFwd1(Node node, Configuration config) {
     exists(DataFlowCall call, ReturnNodeExt ret, ReturnKindExt kind |
       nodeCandFwd1(ret, config) and
       getReturnPosition(ret) = viableReturnPos(call, kind) and
-      node = getAnOutNodeExt(call, kind)
+      node = kind.getAnOutNode(call)
     )
   )
 }
@@ -409,7 +409,7 @@ private predicate nodeCand1ReturnPosition(ReturnPosition pos, Configuration conf
   exists(DataFlowCall call, ReturnKindExt kind, Node out |
     nodeCand1(out, config) and
     pos = viableReturnPos(call, kind) and
-    out = getAnOutNodeExt(call, kind)
+    out = kind.getAnOutNode(call)
   )
 }
 
@@ -576,7 +576,7 @@ private predicate flowOutOfCallable(Node node1, Node node2, Configuration config
   not inBarrier(node2, config) and
   exists(DataFlowCall call, ReturnKindExt kind |
     getReturnPosition1(node1, unbind(config)) = viableReturnPos(call, kind) and
-    node2 = getAnOutNodeExt(call, kind)
+    node2 = kind.getAnOutNode(call)
   )
 }
 
@@ -1806,7 +1806,7 @@ private predicate pathOutOfCallable1(
 pragma[noinline]
 private predicate pathOutOfCallable(PathNodeMid mid, Node out, CallContext cc) {
   exists(ReturnKindExt kind, DataFlowCall call | pathOutOfCallable1(mid, call, kind, cc) |
-    out = getAnOutNodeExt(call, kind)
+    out = kind.getAnOutNode(call)
   )
 }
 
@@ -1905,7 +1905,7 @@ pragma[noinline]
 private predicate pathThroughCallable(PathNodeMid mid, Node out, CallContext cc, AccessPathNil apnil) {
   exists(DataFlowCall call, ReturnKindExt kind |
     pathThroughCallable0(call, mid, kind, cc, apnil) and
-    out = getAnOutNodeExt(call, kind)
+    out = kind.getAnOutNode(call)
   )
 }
 
@@ -1965,7 +1965,7 @@ private module FlowExploration {
       // flow out of a callable
       exists(DataFlowCall call, ReturnKindExt kind |
         getReturnPosition(node1) = viableReturnPos(call, kind) and
-        node2 = getAnOutNodeExt(call, kind)
+        node2 = kind.getAnOutNode(call)
       )
     |
       c1 = node1.getEnclosingCallable() and
@@ -2287,7 +2287,7 @@ private module FlowExploration {
     exists(ReturnKindExt kind, DataFlowCall call |
       partialPathOutOfCallable1(mid, call, kind, cc, ap, config)
     |
-      out = getAnOutNodeExt(call, kind)
+      out = kind.getAnOutNode(call)
     )
   }
 
@@ -2370,7 +2370,7 @@ private module FlowExploration {
   ) {
     exists(DataFlowCall call, ReturnKindExt kind |
       partialPathThroughCallable0(call, mid, kind, cc, apnil, config) and
-      out = getAnOutNodeExt(call, kind)
+      out = kind.getAnOutNode(call)
     )
   }
 

--- a/java/ql/src/semmle/code/java/dataflow/internal/DataFlowImpl2.qll
+++ b/java/ql/src/semmle/code/java/dataflow/internal/DataFlowImpl2.qll
@@ -1785,7 +1785,7 @@ private predicate pathOutOfCallable0(PathNodeMid mid, ReturnPosition pos, CallCo
   not innercc instanceof CallContextCall
 }
 
-pragma[noinline]
+pragma[nomagic]
 private predicate pathOutOfCallable1(
   PathNodeMid mid, DataFlowCall call, ReturnKindExt kind, CallContext cc
 ) {

--- a/java/ql/src/semmle/code/java/dataflow/internal/DataFlowImpl2.qll
+++ b/java/ql/src/semmle/code/java/dataflow/internal/DataFlowImpl2.qll
@@ -314,11 +314,19 @@ private predicate nodeCandFwd1(Node node, Configuration config) {
     )
     or
     // flow out of a callable
-    exists(DataFlowCall call, ReturnNodeExt ret, ReturnKindExt kind |
-      nodeCandFwd1(ret, config) and
-      getReturnPosition(ret) = viableReturnPos(call, kind) and
+    exists(DataFlowCall call, ReturnPosition pos, ReturnKindExt kind |
+      nodeCandFwd1ReturnPosition(pos, config) and
+      pos = viableReturnPos(call, kind) and
       node = kind.getAnOutNode(call)
     )
+  )
+}
+
+pragma[noinline]
+private predicate nodeCandFwd1ReturnPosition(ReturnPosition pos, Configuration config) {
+  exists(ReturnNodeExt ret |
+    nodeCandFwd1(ret, config) and
+    getReturnPosition(ret) = pos
   )
 }
 
@@ -1885,7 +1893,7 @@ private predicate paramFlowsThrough(
   )
 }
 
-pragma[noinline]
+pragma[nomagic]
 private predicate pathThroughCallable0(
   DataFlowCall call, PathNodeMid mid, ReturnKindExt kind, CallContext cc, AccessPathNil apnil
 ) {

--- a/java/ql/src/semmle/code/java/dataflow/internal/DataFlowImpl3.qll
+++ b/java/ql/src/semmle/code/java/dataflow/internal/DataFlowImpl3.qll
@@ -317,7 +317,7 @@ private predicate nodeCandFwd1(Node node, Configuration config) {
     exists(DataFlowCall call, ReturnNodeExt ret, ReturnKindExt kind |
       nodeCandFwd1(ret, config) and
       getReturnPosition(ret) = viableReturnPos(call, kind) and
-      node = getAnOutNodeExt(call, kind)
+      node = kind.getAnOutNode(call)
     )
   )
 }
@@ -409,7 +409,7 @@ private predicate nodeCand1ReturnPosition(ReturnPosition pos, Configuration conf
   exists(DataFlowCall call, ReturnKindExt kind, Node out |
     nodeCand1(out, config) and
     pos = viableReturnPos(call, kind) and
-    out = getAnOutNodeExt(call, kind)
+    out = kind.getAnOutNode(call)
   )
 }
 
@@ -576,7 +576,7 @@ private predicate flowOutOfCallable(Node node1, Node node2, Configuration config
   not inBarrier(node2, config) and
   exists(DataFlowCall call, ReturnKindExt kind |
     getReturnPosition1(node1, unbind(config)) = viableReturnPos(call, kind) and
-    node2 = getAnOutNodeExt(call, kind)
+    node2 = kind.getAnOutNode(call)
   )
 }
 
@@ -1806,7 +1806,7 @@ private predicate pathOutOfCallable1(
 pragma[noinline]
 private predicate pathOutOfCallable(PathNodeMid mid, Node out, CallContext cc) {
   exists(ReturnKindExt kind, DataFlowCall call | pathOutOfCallable1(mid, call, kind, cc) |
-    out = getAnOutNodeExt(call, kind)
+    out = kind.getAnOutNode(call)
   )
 }
 
@@ -1905,7 +1905,7 @@ pragma[noinline]
 private predicate pathThroughCallable(PathNodeMid mid, Node out, CallContext cc, AccessPathNil apnil) {
   exists(DataFlowCall call, ReturnKindExt kind |
     pathThroughCallable0(call, mid, kind, cc, apnil) and
-    out = getAnOutNodeExt(call, kind)
+    out = kind.getAnOutNode(call)
   )
 }
 
@@ -1965,7 +1965,7 @@ private module FlowExploration {
       // flow out of a callable
       exists(DataFlowCall call, ReturnKindExt kind |
         getReturnPosition(node1) = viableReturnPos(call, kind) and
-        node2 = getAnOutNodeExt(call, kind)
+        node2 = kind.getAnOutNode(call)
       )
     |
       c1 = node1.getEnclosingCallable() and
@@ -2287,7 +2287,7 @@ private module FlowExploration {
     exists(ReturnKindExt kind, DataFlowCall call |
       partialPathOutOfCallable1(mid, call, kind, cc, ap, config)
     |
-      out = getAnOutNodeExt(call, kind)
+      out = kind.getAnOutNode(call)
     )
   }
 
@@ -2370,7 +2370,7 @@ private module FlowExploration {
   ) {
     exists(DataFlowCall call, ReturnKindExt kind |
       partialPathThroughCallable0(call, mid, kind, cc, apnil, config) and
-      out = getAnOutNodeExt(call, kind)
+      out = kind.getAnOutNode(call)
     )
   }
 

--- a/java/ql/src/semmle/code/java/dataflow/internal/DataFlowImpl3.qll
+++ b/java/ql/src/semmle/code/java/dataflow/internal/DataFlowImpl3.qll
@@ -1785,7 +1785,7 @@ private predicate pathOutOfCallable0(PathNodeMid mid, ReturnPosition pos, CallCo
   not innercc instanceof CallContextCall
 }
 
-pragma[noinline]
+pragma[nomagic]
 private predicate pathOutOfCallable1(
   PathNodeMid mid, DataFlowCall call, ReturnKindExt kind, CallContext cc
 ) {

--- a/java/ql/src/semmle/code/java/dataflow/internal/DataFlowImpl3.qll
+++ b/java/ql/src/semmle/code/java/dataflow/internal/DataFlowImpl3.qll
@@ -314,11 +314,19 @@ private predicate nodeCandFwd1(Node node, Configuration config) {
     )
     or
     // flow out of a callable
-    exists(DataFlowCall call, ReturnNodeExt ret, ReturnKindExt kind |
-      nodeCandFwd1(ret, config) and
-      getReturnPosition(ret) = viableReturnPos(call, kind) and
+    exists(DataFlowCall call, ReturnPosition pos, ReturnKindExt kind |
+      nodeCandFwd1ReturnPosition(pos, config) and
+      pos = viableReturnPos(call, kind) and
       node = kind.getAnOutNode(call)
     )
+  )
+}
+
+pragma[noinline]
+private predicate nodeCandFwd1ReturnPosition(ReturnPosition pos, Configuration config) {
+  exists(ReturnNodeExt ret |
+    nodeCandFwd1(ret, config) and
+    getReturnPosition(ret) = pos
   )
 }
 
@@ -1885,7 +1893,7 @@ private predicate paramFlowsThrough(
   )
 }
 
-pragma[noinline]
+pragma[nomagic]
 private predicate pathThroughCallable0(
   DataFlowCall call, PathNodeMid mid, ReturnKindExt kind, CallContext cc, AccessPathNil apnil
 ) {

--- a/java/ql/src/semmle/code/java/dataflow/internal/DataFlowImpl4.qll
+++ b/java/ql/src/semmle/code/java/dataflow/internal/DataFlowImpl4.qll
@@ -317,7 +317,7 @@ private predicate nodeCandFwd1(Node node, Configuration config) {
     exists(DataFlowCall call, ReturnNodeExt ret, ReturnKindExt kind |
       nodeCandFwd1(ret, config) and
       getReturnPosition(ret) = viableReturnPos(call, kind) and
-      node = getAnOutNodeExt(call, kind)
+      node = kind.getAnOutNode(call)
     )
   )
 }
@@ -409,7 +409,7 @@ private predicate nodeCand1ReturnPosition(ReturnPosition pos, Configuration conf
   exists(DataFlowCall call, ReturnKindExt kind, Node out |
     nodeCand1(out, config) and
     pos = viableReturnPos(call, kind) and
-    out = getAnOutNodeExt(call, kind)
+    out = kind.getAnOutNode(call)
   )
 }
 
@@ -576,7 +576,7 @@ private predicate flowOutOfCallable(Node node1, Node node2, Configuration config
   not inBarrier(node2, config) and
   exists(DataFlowCall call, ReturnKindExt kind |
     getReturnPosition1(node1, unbind(config)) = viableReturnPos(call, kind) and
-    node2 = getAnOutNodeExt(call, kind)
+    node2 = kind.getAnOutNode(call)
   )
 }
 
@@ -1806,7 +1806,7 @@ private predicate pathOutOfCallable1(
 pragma[noinline]
 private predicate pathOutOfCallable(PathNodeMid mid, Node out, CallContext cc) {
   exists(ReturnKindExt kind, DataFlowCall call | pathOutOfCallable1(mid, call, kind, cc) |
-    out = getAnOutNodeExt(call, kind)
+    out = kind.getAnOutNode(call)
   )
 }
 
@@ -1905,7 +1905,7 @@ pragma[noinline]
 private predicate pathThroughCallable(PathNodeMid mid, Node out, CallContext cc, AccessPathNil apnil) {
   exists(DataFlowCall call, ReturnKindExt kind |
     pathThroughCallable0(call, mid, kind, cc, apnil) and
-    out = getAnOutNodeExt(call, kind)
+    out = kind.getAnOutNode(call)
   )
 }
 
@@ -1965,7 +1965,7 @@ private module FlowExploration {
       // flow out of a callable
       exists(DataFlowCall call, ReturnKindExt kind |
         getReturnPosition(node1) = viableReturnPos(call, kind) and
-        node2 = getAnOutNodeExt(call, kind)
+        node2 = kind.getAnOutNode(call)
       )
     |
       c1 = node1.getEnclosingCallable() and
@@ -2287,7 +2287,7 @@ private module FlowExploration {
     exists(ReturnKindExt kind, DataFlowCall call |
       partialPathOutOfCallable1(mid, call, kind, cc, ap, config)
     |
-      out = getAnOutNodeExt(call, kind)
+      out = kind.getAnOutNode(call)
     )
   }
 
@@ -2370,7 +2370,7 @@ private module FlowExploration {
   ) {
     exists(DataFlowCall call, ReturnKindExt kind |
       partialPathThroughCallable0(call, mid, kind, cc, apnil, config) and
-      out = getAnOutNodeExt(call, kind)
+      out = kind.getAnOutNode(call)
     )
   }
 

--- a/java/ql/src/semmle/code/java/dataflow/internal/DataFlowImpl4.qll
+++ b/java/ql/src/semmle/code/java/dataflow/internal/DataFlowImpl4.qll
@@ -1785,7 +1785,7 @@ private predicate pathOutOfCallable0(PathNodeMid mid, ReturnPosition pos, CallCo
   not innercc instanceof CallContextCall
 }
 
-pragma[noinline]
+pragma[nomagic]
 private predicate pathOutOfCallable1(
   PathNodeMid mid, DataFlowCall call, ReturnKindExt kind, CallContext cc
 ) {

--- a/java/ql/src/semmle/code/java/dataflow/internal/DataFlowImpl4.qll
+++ b/java/ql/src/semmle/code/java/dataflow/internal/DataFlowImpl4.qll
@@ -314,11 +314,19 @@ private predicate nodeCandFwd1(Node node, Configuration config) {
     )
     or
     // flow out of a callable
-    exists(DataFlowCall call, ReturnNodeExt ret, ReturnKindExt kind |
-      nodeCandFwd1(ret, config) and
-      getReturnPosition(ret) = viableReturnPos(call, kind) and
+    exists(DataFlowCall call, ReturnPosition pos, ReturnKindExt kind |
+      nodeCandFwd1ReturnPosition(pos, config) and
+      pos = viableReturnPos(call, kind) and
       node = kind.getAnOutNode(call)
     )
+  )
+}
+
+pragma[noinline]
+private predicate nodeCandFwd1ReturnPosition(ReturnPosition pos, Configuration config) {
+  exists(ReturnNodeExt ret |
+    nodeCandFwd1(ret, config) and
+    getReturnPosition(ret) = pos
   )
 }
 
@@ -1885,7 +1893,7 @@ private predicate paramFlowsThrough(
   )
 }
 
-pragma[noinline]
+pragma[nomagic]
 private predicate pathThroughCallable0(
   DataFlowCall call, PathNodeMid mid, ReturnKindExt kind, CallContext cc, AccessPathNil apnil
 ) {

--- a/java/ql/src/semmle/code/java/dataflow/internal/DataFlowImpl5.qll
+++ b/java/ql/src/semmle/code/java/dataflow/internal/DataFlowImpl5.qll
@@ -317,7 +317,7 @@ private predicate nodeCandFwd1(Node node, Configuration config) {
     exists(DataFlowCall call, ReturnNodeExt ret, ReturnKindExt kind |
       nodeCandFwd1(ret, config) and
       getReturnPosition(ret) = viableReturnPos(call, kind) and
-      node = getAnOutNodeExt(call, kind)
+      node = kind.getAnOutNode(call)
     )
   )
 }
@@ -409,7 +409,7 @@ private predicate nodeCand1ReturnPosition(ReturnPosition pos, Configuration conf
   exists(DataFlowCall call, ReturnKindExt kind, Node out |
     nodeCand1(out, config) and
     pos = viableReturnPos(call, kind) and
-    out = getAnOutNodeExt(call, kind)
+    out = kind.getAnOutNode(call)
   )
 }
 
@@ -576,7 +576,7 @@ private predicate flowOutOfCallable(Node node1, Node node2, Configuration config
   not inBarrier(node2, config) and
   exists(DataFlowCall call, ReturnKindExt kind |
     getReturnPosition1(node1, unbind(config)) = viableReturnPos(call, kind) and
-    node2 = getAnOutNodeExt(call, kind)
+    node2 = kind.getAnOutNode(call)
   )
 }
 
@@ -1806,7 +1806,7 @@ private predicate pathOutOfCallable1(
 pragma[noinline]
 private predicate pathOutOfCallable(PathNodeMid mid, Node out, CallContext cc) {
   exists(ReturnKindExt kind, DataFlowCall call | pathOutOfCallable1(mid, call, kind, cc) |
-    out = getAnOutNodeExt(call, kind)
+    out = kind.getAnOutNode(call)
   )
 }
 
@@ -1905,7 +1905,7 @@ pragma[noinline]
 private predicate pathThroughCallable(PathNodeMid mid, Node out, CallContext cc, AccessPathNil apnil) {
   exists(DataFlowCall call, ReturnKindExt kind |
     pathThroughCallable0(call, mid, kind, cc, apnil) and
-    out = getAnOutNodeExt(call, kind)
+    out = kind.getAnOutNode(call)
   )
 }
 
@@ -1965,7 +1965,7 @@ private module FlowExploration {
       // flow out of a callable
       exists(DataFlowCall call, ReturnKindExt kind |
         getReturnPosition(node1) = viableReturnPos(call, kind) and
-        node2 = getAnOutNodeExt(call, kind)
+        node2 = kind.getAnOutNode(call)
       )
     |
       c1 = node1.getEnclosingCallable() and
@@ -2287,7 +2287,7 @@ private module FlowExploration {
     exists(ReturnKindExt kind, DataFlowCall call |
       partialPathOutOfCallable1(mid, call, kind, cc, ap, config)
     |
-      out = getAnOutNodeExt(call, kind)
+      out = kind.getAnOutNode(call)
     )
   }
 
@@ -2370,7 +2370,7 @@ private module FlowExploration {
   ) {
     exists(DataFlowCall call, ReturnKindExt kind |
       partialPathThroughCallable0(call, mid, kind, cc, apnil, config) and
-      out = getAnOutNodeExt(call, kind)
+      out = kind.getAnOutNode(call)
     )
   }
 

--- a/java/ql/src/semmle/code/java/dataflow/internal/DataFlowImpl5.qll
+++ b/java/ql/src/semmle/code/java/dataflow/internal/DataFlowImpl5.qll
@@ -1785,7 +1785,7 @@ private predicate pathOutOfCallable0(PathNodeMid mid, ReturnPosition pos, CallCo
   not innercc instanceof CallContextCall
 }
 
-pragma[noinline]
+pragma[nomagic]
 private predicate pathOutOfCallable1(
   PathNodeMid mid, DataFlowCall call, ReturnKindExt kind, CallContext cc
 ) {

--- a/java/ql/src/semmle/code/java/dataflow/internal/DataFlowImpl5.qll
+++ b/java/ql/src/semmle/code/java/dataflow/internal/DataFlowImpl5.qll
@@ -314,11 +314,19 @@ private predicate nodeCandFwd1(Node node, Configuration config) {
     )
     or
     // flow out of a callable
-    exists(DataFlowCall call, ReturnNodeExt ret, ReturnKindExt kind |
-      nodeCandFwd1(ret, config) and
-      getReturnPosition(ret) = viableReturnPos(call, kind) and
+    exists(DataFlowCall call, ReturnPosition pos, ReturnKindExt kind |
+      nodeCandFwd1ReturnPosition(pos, config) and
+      pos = viableReturnPos(call, kind) and
       node = kind.getAnOutNode(call)
     )
+  )
+}
+
+pragma[noinline]
+private predicate nodeCandFwd1ReturnPosition(ReturnPosition pos, Configuration config) {
+  exists(ReturnNodeExt ret |
+    nodeCandFwd1(ret, config) and
+    getReturnPosition(ret) = pos
   )
 }
 
@@ -1885,7 +1893,7 @@ private predicate paramFlowsThrough(
   )
 }
 
-pragma[noinline]
+pragma[nomagic]
 private predicate pathThroughCallable0(
   DataFlowCall call, PathNodeMid mid, ReturnKindExt kind, CallContext cc, AccessPathNil apnil
 ) {

--- a/java/ql/src/semmle/code/java/dataflow/internal/DataFlowUtil.qll
+++ b/java/ql/src/semmle/code/java/dataflow/internal/DataFlowUtil.qll
@@ -23,7 +23,7 @@ private newtype TNode =
   TExplicitExprPostUpdate(Expr e) {
     explicitInstanceArgument(_, e)
     or
-    e instanceof Argument
+    e instanceof Argument and not e.getType() instanceof ImmutableType
     or
     exists(FieldAccess fa | fa.getField() instanceof InstanceField and e = fa.getQualifier())
   } or


### PR DESCRIPTION
This merges the two kinds of return flow (value flow from `ReturnNode` to `OutNode` and parameter updates through `PostUpdateNode`s) to reduce the number of cases in the data flow implementation.