### PR TITLE
C++: Add a sample class in PrintAST.ql

### DIFF
--- a/cpp/ql/src/semmle/code/cpp/PrintAST.ql
+++ b/cpp/ql/src/semmle/code/cpp/PrintAST.ql
@@ -7,3 +7,12 @@
 
 import cpp
 import PrintAST
+
+/**
+ * Temporarily tweak this class or make a copy to control which functions are
+ * printed.
+ */
+class Cfg extends PrintASTConfiguration {
+  /** Holds if the AST for `func` should be printed. */
+  override predicate shouldPrintFunction(Function func) { any() }
+}

--- a/cpp/ql/src/semmle/code/cpp/PrintAST.ql
+++ b/cpp/ql/src/semmle/code/cpp/PrintAST.ql
@@ -13,6 +13,9 @@ import PrintAST
  * printed.
  */
 class Cfg extends PrintASTConfiguration {
-  /** Holds if the AST for `func` should be printed. */
+  /**
+   * TWEAK THIS PREDICATE AS NEEDED.
+   * Holds if the AST for `func` should be printed.
+   */
   override predicate shouldPrintFunction(Function func) { any() }
 }


### PR DESCRIPTION
I've found myself typing out this class whenever I want to print the AST of one function. I hope it will be useful to others too.

Or is there a better way?