### PR TITLE
C++: Minor tweaks to ExprInVoidContext

### DIFF
--- a/cpp/ql/src/semmle/code/cpp/commons/VoidContext.qll
+++ b/cpp/ql/src/semmle/code/cpp/commons/VoidContext.qll
@@ -1,9 +1,10 @@
 import semmle.code.cpp.exprs.Expr
 
 /**
+ * DEPRECATED: This class has not been useful.
  * An expression that is used to qualify some other expression.
  */
-class Qualifier extends Expr {
+deprecated class Qualifier extends Expr {
   Qualifier() {
     exists(VariableAccess a | a.getQualifier() = this) or
     exists(Call c | c.getQualifier() = this) or
@@ -36,6 +37,5 @@ private predicate exprInVoidContext(Expr e) {
     or
     exists(CommaExpr c | c.getRightOperand() = e and c instanceof ExprInVoidContext)
   ) and
-  not e instanceof Qualifier and
   not e.getActualType() instanceof VoidType
 }

--- a/cpp/ql/src/semmle/code/cpp/commons/VoidContext.qll
+++ b/cpp/ql/src/semmle/code/cpp/commons/VoidContext.qll
@@ -1,10 +1,9 @@
 import semmle.code.cpp.exprs.Expr
 
 /**
- * DEPRECATED: This class has not been useful.
  * An expression that is used to qualify some other expression.
  */
-deprecated class Qualifier extends Expr {
+class Qualifier extends Expr {
   Qualifier() {
     exists(VariableAccess a | a.getQualifier() = this) or
     exists(Call c | c.getQualifier() = this) or

--- a/cpp/ql/src/semmle/code/cpp/commons/VoidContext.qll
+++ b/cpp/ql/src/semmle/code/cpp/commons/VoidContext.qll
@@ -36,6 +36,8 @@ private predicate exprInVoidContext(Expr e) {
     exists(CommaExpr c | c.getLeftOperand() = e)
     or
     exists(CommaExpr c | c.getRightOperand() = e and c instanceof ExprInVoidContext)
+    or
+    exists(ForStmt for | for.getUpdate() = e)
   ) and
   not e.getActualType() instanceof VoidType
 }


### PR DESCRIPTION
These tweaks to `ExprInVoidContext` fell out of my work on #1999. See also https://github.slack.com/archives/CP75PA8Q1/p1571817660005700.

I've tested on four large snapshots that removing the `Qualifier` case from `exprInVoidContext` makes no difference.