### PR TITLE
Python: Improve qldoc for ClassValue::getABaseType

### DIFF
--- a/python/ql/src/semmle/python/objects/ObjectAPI.qll
+++ b/python/ql/src/semmle/python/objects/ObjectAPI.qll
@@ -384,12 +384,12 @@ class ClassValue extends Value {
         Types::failedInference(this, reason)
     }
 
-    /** Gets the nth base class of this class */
+    /** Gets the nth immediate base type of this class. */
     ClassValue getBaseType(int n) {
         result = Types::getBase(this, n)
     }
 
-    /** Gets a base class of this class */
+    /** Gets an immediate base type of this class. */
     ClassValue getABaseType() {
         result = Types::getBase(this, _)
     }


### PR DESCRIPTION
Hopefully it is more clear that you can get multiple results from getABaseType
because of multiple inheritance, and no because we are following the chain of
inheritance