### PR TITLE
codeqlmanifest: explicitly chain to ./codeql if we have it

### DIFF
--- a/.codeqlmanifest.json
+++ b/.codeqlmanifest.json
@@ -1,3 +1,4 @@
 { "provide": [ "*/ql/src/qlpack.yml",
                "misc/legacy-support/*/qlpack.yml",
-               "misc/suite-helpers/qlpack.yml" ] }
+               "misc/suite-helpers/qlpack.yml",
+               "codeql/.codeqlmanifest.json" ] }


### PR DESCRIPTION
Without this, the `.gitignore` entry for `/codeql` is pretty pointless.