### PR TITLE
Cache the computation of core toString predicates for cpp c# and java.

### DIFF
--- a/cpp/ql/src/semmle/code/cpp/Element.qll
+++ b/cpp/ql/src/semmle/code/cpp/Element.qll
@@ -47,6 +47,7 @@ pragma[inline]
  */
 class ElementBase extends @element {
   /** Gets a textual representation of this element. */
+  cached
   string toString() { none() }
 
   /**

--- a/csharp/ql/src/semmle/code/dotnet/Element.qll
+++ b/csharp/ql/src/semmle/code/dotnet/Element.qll
@@ -10,6 +10,7 @@ import semmle.code.csharp.Location
  */
 class Element extends @dotnet_element {
   /** Gets a textual representation of this element. */
+  cached
   string toString() { none() }
 
   /** Gets the location of this element. */

--- a/java/ql/src/semmle/code/Location.qll
+++ b/java/ql/src/semmle/code/Location.qll
@@ -84,6 +84,7 @@ class Top extends @top {
   int getNumberOfCommentLines() { numlines(this, _, _, result) }
 
   /** Gets a textual representation of this element. */
+  cached
   string toString() { hasName(this, result) }
 }
 


### PR DESCRIPTION
This improves the performance of running many queries when `toString`s of results are computed.