### PR TITLE
C#: Add `precision` tag to `cs/deserialized-delegate`

### DIFF
--- a/change-notes/1.23/analysis-csharp.md
+++ b/change-notes/1.23/analysis-csharp.md
@@ -8,6 +8,7 @@ The following changes in version 1.23 affect C# analysis in all applications.
 
 | **Query**                   | **Tags**  | **Purpose**                                                        |
 |-----------------------------|-----------|--------------------------------------------------------------------|
+| Deserialized delegate (`cs/deserialized-delegate`) | security | Finds unsafe deserialization of delegate types. |
 | Unsafe year argument for 'DateTime' constructor (`cs/unsafe-year-construction`) | reliability, date-time | Finds incorrect manipulation of `DateTime` values, which could lead to invalid dates. |
 | Mishandling the Japanese era start date (`cs/mishandling-japanese-era`) | reliability, date-time | Finds hard-coded Japanese era start dates that could be invalid. |
 

--- a/change-notes/1.23/analysis-csharp.md
+++ b/change-notes/1.23/analysis-csharp.md
@@ -8,7 +8,7 @@ The following changes in version 1.23 affect C# analysis in all applications.
 
 | **Query**                   | **Tags**  | **Purpose**                                                        |
 |-----------------------------|-----------|--------------------------------------------------------------------|
-| Deserialized delegate (`cs/deserialized-delegate`) | security | Finds unsafe deserialization of delegate types. |
+| Deserialized delegate (`cs/deserialized-delegate`) | security, external/cwe/cwe-502 | Finds unsafe deserialization of delegate types. |
 | Unsafe year argument for 'DateTime' constructor (`cs/unsafe-year-construction`) | reliability, date-time | Finds incorrect manipulation of `DateTime` values, which could lead to invalid dates. |
 | Mishandling the Japanese era start date (`cs/mishandling-japanese-era`) | reliability, date-time | Finds hard-coded Japanese era start dates that could be invalid. |
 

--- a/csharp/ql/src/Security Features/CWE-502/DeserializedDelegate.ql
+++ b/csharp/ql/src/Security Features/CWE-502/DeserializedDelegate.ql
@@ -5,12 +5,9 @@
  * @kind problem
  * @id cs/deserialized-delegate
  * @problem.severity warning
+ * @precision high
  * @tags security
  *       external/cwe/cwe-502
- */
-
-/*
- * consider: @precision high
  */
 
 import csharp


### PR DESCRIPTION
[Query run on LGTM.com](https://lgtm.com/query/6472037786527322227/) shows no results on my set of sample projects.

@jf205 : In addition to the change not change, could you also take a look at the qhelp for this query (not actually modified on this PR)? Thanks.