### PR TITLE
JavaScript: Improve type inference for destructuring assignments.

### DIFF
--- a/javascript/ql/src/semmle/javascript/dataflow/internal/VariableTypeInference.qll
+++ b/javascript/ql/src/semmle/javascript/dataflow/internal/VariableTypeInference.qll
@@ -223,7 +223,11 @@ abstract class AnalyzedSsaDefinition extends SsaDefinition {
  * Flow analysis for SSA definitions corresponding to `VarDef`s.
  */
 private class AnalyzedExplicitDefinition extends AnalyzedSsaDefinition, SsaExplicitDefinition {
-  override AbstractValue getAnRhsValue() { result = getDef().(AnalyzedVarDef).getAnAssignedValue() }
+  override AbstractValue getAnRhsValue() {
+    result = getDef().(AnalyzedVarDef).getAnAssignedValue()
+    or
+    result = getRhsNode().analyze().getALocalValue()
+  }
 }
 
 /**

--- a/javascript/ql/src/semmle/javascript/dataflow/internal/VariableTypeInference.qll
+++ b/javascript/ql/src/semmle/javascript/dataflow/internal/VariableTypeInference.qll
@@ -245,6 +245,8 @@ private class AnalyzedVariableCapture extends AnalyzedSsaDefinition, SsaVariable
     exists(LocalVariable v | v = getSourceVariable() |
       result = v.(AnalyzedCapturedVariable).getALocalValue()
       or
+      result = any(AnalyzedExplicitDefinition def | def.getSourceVariable() = v).getAnRhsValue()
+      or
       not guaranteedToBeInitialized(v) and result = getImplicitInitValue(v)
     )
   }

--- a/javascript/ql/test/library-tests/CallGraphs/AnnotatedTest/client.js
+++ b/javascript/ql/test/library-tests/CallGraphs/AnnotatedTest/client.js
@@ -1,0 +1,7 @@
+const lib = require("./lib"),
+      { f } = require("./lib");
+
+/** calls:lib.f */
+lib.f();
+/** calls:lib.f */
+f();

--- a/javascript/ql/test/library-tests/CallGraphs/AnnotatedTest/client.js
+++ b/javascript/ql/test/library-tests/CallGraphs/AnnotatedTest/client.js
@@ -5,3 +5,8 @@ const lib = require("./lib"),
 lib.f();
 /** calls:lib.f */
 f();
+
+(function() {
+  /** calls:lib.f */
+  f();
+})();

--- a/javascript/ql/test/library-tests/CallGraphs/AnnotatedTest/lib.js
+++ b/javascript/ql/test/library-tests/CallGraphs/AnnotatedTest/lib.js
@@ -1,0 +1,3 @@
+module.exports.f =
+  /** name:lib.f */
+ function() {};

--- a/javascript/ql/test/library-tests/Flow/abseval.expected
+++ b/javascript/ql/test/library-tests/Flow/abseval.expected
@@ -80,6 +80,7 @@
 | classAccessors.js:12:9:12:11 | myZ | classAccessors.js:12:15:12:20 | this.z | file://:0:0:0:0 | indefinite value (call) |
 | classAccessors.js:12:9:12:11 | myZ | classAccessors.js:12:15:12:20 | this.z | file://:0:0:0:0 | indefinite value (heap) |
 | destructuring.js:2:7:2:24 | { x, y = (z = x) } | destructuring.js:2:28:2:28 | o | file://:0:0:0:0 | indefinite value (call) |
+| destructuring.js:3:7:3:8 | z1 | destructuring.js:3:12:3:12 | z | file://:0:0:0:0 | indefinite value (call) |
 | destructuring.js:3:7:3:8 | z1 | destructuring.js:3:12:3:12 | z | file://:0:0:0:0 | indefinite value (heap) |
 | es2015.js:1:5:1:7 | Sup | es2015.js:1:11:6:1 | class { ... ;\\n  }\\n} | es2015.js:1:11:6:1 | class Sup |
 | es2015.js:4:9:4:12 | ctor | es2015.js:4:16:4:25 | new.target | file://:0:0:0:0 | indefinite value (call) |


### PR DESCRIPTION
Our type inference is sadly not quite in sync with our SSA graph yet, so it wasn't taking advantage of the latter's handling of destructuring assignments.

Fully switching the type inference over to using SSA is a worthwhile but non-trivial task. This PR makes a first step in that direction by complementing the existing type inference with more SSA information, while leaving the existing machinery in place.

A full evaluation is almost done, except for gecko-dev which mysteriously failed during trap import and had to be rerun. Results are promising, but I'm marking this as WIP for now.

This fixes ODASA-8150.