### PR TITLE
Java: support JDK 13

### DIFF
--- a/java/ql/src/config/semmlecode.dbscheme
+++ b/java/ql/src/config/semmlecode.dbscheme
@@ -494,6 +494,7 @@ case @stmt.kind of
 | 20 = @superconstructorinvocationstmt
 | 21 = @case
 | 22 = @catchclause
+| 23 = @yieldstmt
 ;
 
 #keyset[parent,idx]

--- a/java/ql/src/config/semmlecode.dbscheme.stats
+++ b/java/ql/src/config/semmlecode.dbscheme.stats
@@ -189,6 +189,10 @@
 <v>28672</v>
 </e>
 <e>
+<k>@yieldstmt</k>
+<v>100</v>
+</e>
+<e>
 <k>@arrayaccess</k>
 <v>53561</v>
 </e>

--- a/java/ql/src/semmle/code/java/Completion.qll
+++ b/java/ql/src/semmle/code/java/Completion.qll
@@ -52,13 +52,13 @@ newtype Completion =
     (innerValue = true or innerValue = false)
   } or
   /**
-   * The expression or statement completes via a `break` statement without a value.
+   * The expression or statement completes via a `break` statement.
    */
   BreakCompletion(MaybeLabel l) or
   /**
-   * The expression or statement completes via a value `break` statement.
+   * The expression or statement completes via a `yield` statement.
    */
-  ValueBreakCompletion(NormalOrBooleanCompletion c) or
+  YieldCompletion(NormalOrBooleanCompletion c) or
   /**
    * The expression or statement completes via a `continue` statement.
    */

--- a/java/ql/src/semmle/code/java/Expr.qll
+++ b/java/ql/src/semmle/code/java/Expr.qll
@@ -1084,7 +1084,7 @@ class ConditionalExpr extends Expr, @conditionalexpr {
 }
 
 /**
- * PREVIEW FEATURE in Java 12. Subject to removal in a future release.
+ * PREVIEW FEATURE in Java 13. Subject to removal in a future release.
  *
  * A `switch` expression.
  */
@@ -1117,7 +1117,7 @@ class SwitchExpr extends Expr, @switchexpr {
   Expr getAResult() {
     result = getACase().getRuleExpression()
     or
-    exists(BreakStmt break | break.(JumpStmt).getTarget() = this and result = break.getValue())
+    exists(YieldStmt yield | yield.(JumpStmt).getTarget() = this and result = yield.getValue())
   }
 
   /** Gets a printable representation of this expression. */

--- a/java/ql/src/semmle/code/java/Statement.qll
+++ b/java/ql/src/semmle/code/java/Statement.qll
@@ -582,8 +582,7 @@ class JumpStmt extends Stmt {
     (
       result instanceof LoopStmt
       or
-      (this instanceof BreakStmt or this instanceof YieldStmt) and
-      result instanceof SwitchStmt
+      this instanceof BreakStmt and result instanceof SwitchStmt
     )
   }
 

--- a/java/ql/src/semmle/code/java/Statement.qll
+++ b/java/ql/src/semmle/code/java/Statement.qll
@@ -417,7 +417,7 @@ class SwitchCase extends Stmt, @case {
   SwitchStmt getSwitch() { result.getACase() = this }
 
   /**
-   * PREVIEW FEATURE in Java 12. Subject to removal in a future release.
+   * PREVIEW FEATURE in Java 13. Subject to removal in a future release.
    *
    * Gets the switch expression to which this case belongs, if any.
    */
@@ -432,7 +432,7 @@ class SwitchCase extends Stmt, @case {
   }
 
   /**
-   * PREVIEW FEATURE in Java 12. Subject to removal in a future release.
+   * PREVIEW FEATURE in Java 13. Subject to removal in a future release.
    *
    * Holds if this `case` is a switch labeled rule of the form `... -> ...`.
    */
@@ -443,14 +443,14 @@ class SwitchCase extends Stmt, @case {
   }
 
   /**
-   * PREVIEW FEATURE in Java 12. Subject to removal in a future release.
+   * PREVIEW FEATURE in Java 13. Subject to removal in a future release.
    *
    * Gets the expression on the right-hand side of the arrow, if any.
    */
   Expr getRuleExpression() { result.getParent() = this and result.getIndex() = -1 }
 
   /**
-   * PREVIEW FEATURE in Java 12. Subject to removal in a future release.
+   * PREVIEW FEATURE in Java 13. Subject to removal in a future release.
    *
    * Gets the statement on the right-hand side of the arrow, if any.
    */
@@ -465,7 +465,7 @@ class ConstCase extends SwitchCase {
   Expr getValue() { result.getParent() = this and result.getIndex() = 0 }
 
   /**
-   * PREVIEW FEATURE in Java 12. Subject to removal in a future release.
+   * PREVIEW FEATURE in Java 13. Subject to removal in a future release.
    *
    * Gets the `case` constant at the specified index.
    */
@@ -558,10 +558,11 @@ class ThrowStmt extends Stmt, @throwstmt {
   }
 }
 
-/** A `break` or `continue` statement. */
+/** A `break`, `yield` or `continue` statement. */
 class JumpStmt extends Stmt {
   JumpStmt() {
     this instanceof BreakStmt or
+    this instanceof YieldStmt or
     this instanceof ContinueStmt
   }
 
@@ -581,13 +582,12 @@ class JumpStmt extends Stmt {
     (
       result instanceof LoopStmt
       or
-      this instanceof BreakStmt and result instanceof SwitchStmt
+      (this instanceof BreakStmt or this instanceof YieldStmt) and
+      result instanceof SwitchStmt
     )
   }
 
-  private SwitchExpr getSwitchExprTarget() {
-    this.(BreakStmt).hasValue() and result = this.getParent+()
-  }
+  private SwitchExpr getSwitchExprTarget() { result = this.(YieldStmt).getParent+() }
 
   private StmtParent getEnclosingTarget() {
     result = getSwitchExprTarget()
@@ -598,7 +598,7 @@ class JumpStmt extends Stmt {
   }
 
   /**
-   * Gets the statement or `switch` expression that this `break` or `continue` jumps to.
+   * Gets the statement or `switch` expression that this `break`, `yield` or `continue` jumps to.
    */
   StmtParent getTarget() {
     result = getLabelTarget()
@@ -615,32 +615,29 @@ class BreakStmt extends Stmt, @breakstmt {
   /** Holds if this `break` statement has an explicit label. */
   predicate hasLabel() { exists(string s | s = this.getLabel()) }
 
-  /**
-   * PREVIEW FEATURE in Java 12. Subject to removal in a future release.
-   *
-   * Gets the value of this `break` statement, if any.
-   */
-  Expr getValue() { result.getParent() = this }
-
-  /**
-   * PREVIEW FEATURE in Java 12. Subject to removal in a future release.
-   *
-   * Holds if this `break` statement has a value.
-   */
-  predicate hasValue() { exists(Expr e | e.getParent() = this) }
-
   /** Gets a printable representation of this statement. May include more detail than `toString()`. */
   override string pp() {
-    if this.hasLabel()
-    then result = "break " + this.getLabel()
-    else
-      if this.hasValue()
-      then result = "break ..."
-      else result = "break"
+    if this.hasLabel() then result = "break " + this.getLabel() else result = "break"
   }
 
   /** This statement's Halstead ID (used to compute Halstead metrics). */
   override string getHalsteadID() { result = "BreakStmt" }
+}
+
+/**
+ * PREVIEW FEATURE in Java 13. Subject to removal in a future release.
+ *
+ * A `yield` statement.
+ */
+class YieldStmt extends Stmt, @yieldstmt {
+  /**
+   * Gets the value of this `yield` statement.
+   */
+  Expr getValue() { result.getParent() = this }
+
+  override string pp() { result = "yield ..." }
+
+  override string getHalsteadID() { result = "YieldStmt" }
 }
 
 /** A `continue` statement. */

--- a/java/ql/test/library-tests/guards12/options
+++ b/java/ql/test/library-tests/guards12/options
@@ -1,1 +1,1 @@
-//semmle-extractor-options: --javac-args --enable-preview -source 12 -target 12
+//semmle-extractor-options: --javac-args --enable-preview -source 13 -target 13


### PR DESCRIPTION
Should be merged together with the corresponding internal PR.

This PR includes the QL changes to support analysis of switch expressions in JDK 13 - still a preview feature, but the break-with-value statement in JDK 12 was renamed to `yield` in JDK 13.