### PR TITLE
C++: Restrict the output of IR Range Analysis to the best bounds

### DIFF
--- a/cpp/ql/test/library-tests/rangeanalysis/rangeanalysis/RangeAnalysis.expected
+++ b/cpp/ql/test/library-tests/rangeanalysis/rangeanalysis/RangeAnalysis.expected
@@ -51,7 +51,6 @@
 | test.cpp:163:12:163:12 | Load: x | test.cpp:153:23:153:23 | InitializeParameter: y | -1 | false | CompareNE: ... != ... | test.cpp:160:9:160:16 | test.cpp:160:9:160:16 |
 | test.cpp:163:12:163:12 | Load: x | test.cpp:153:23:153:23 | InitializeParameter: y | -1 | true | CompareLT: ... < ... | test.cpp:154:6:154:10 | test.cpp:154:6:154:10 |
 | test.cpp:163:12:163:12 | Load: x | test.cpp:153:23:153:23 | InitializeParameter: y | -1 | true | CompareNE: ... != ... | test.cpp:160:9:160:16 | test.cpp:160:9:160:16 |
-| test.cpp:167:12:167:12 | Load: x | test.cpp:153:23:153:23 | InitializeParameter: y | 0 | false | CompareLT: ... < ... | test.cpp:154:6:154:10 | test.cpp:154:6:154:10 |
 | test.cpp:167:12:167:12 | Load: x | test.cpp:153:23:153:23 | InitializeParameter: y | 1 | false | CompareEQ: ... == ... | test.cpp:166:9:166:16 | test.cpp:166:9:166:16 |
 | test.cpp:167:12:167:12 | Load: x | test.cpp:153:23:153:23 | InitializeParameter: y | 1 | true | CompareEQ: ... == ... | test.cpp:166:9:166:16 | test.cpp:166:9:166:16 |
 | test.cpp:169:12:169:12 | Load: x | test.cpp:153:23:153:23 | InitializeParameter: y | 0 | false | CompareLT: ... < ... | test.cpp:154:6:154:10 | test.cpp:154:6:154:10 |

--- a/cpp/ql/test/library-tests/rangeanalysis/rangeanalysis/RangeAnalysis.ql
+++ b/cpp/ql/test/library-tests/rangeanalysis/rangeanalysis/RangeAnalysis.ql
@@ -11,13 +11,7 @@ query predicate instructionBounds(
     or
     exists(ReturnValueInstruction retInstr | retInstr.getReturnValueOperand() = i.getAUse())
   ) and
-  (
-    upper = true and
-    delta = min(int d | boundedInstruction(i, b, d, upper, reason))
-    or
-    upper = false and
-    delta = max(int d | boundedInstruction(i, b, d, upper, reason))
-  ) and
+  boundedInstruction(i, b, delta, upper, reason) and
   not valueNumber(b.getInstruction()) = valueNumber(i) and
   if reason instanceof CondReason
   then reasonLoc = reason.(CondReason).getCond().getLocation()


### PR DESCRIPTION
This is a port of #1890. We had a restriction to the best bound in the qltest, but it was slightly broken since it chose the best bound only within each `reason`. This version follows the Java library and picks the best bound across all `reason`s, then reconstructs the reason.