### PR TITLE
JS: Add process.env as source in js/clear-text-logging

### DIFF
--- a/change-notes/1.23/analysis-javascript.md
+++ b/change-notes/1.23/analysis-javascript.md
@@ -53,6 +53,7 @@
 | Uncontrolled command line (`js/command-line-injection`) | More results | This query now treats responses from servers as untrusted. |
 | Uncontrolled data used in path expression (`js/path-injection`) | Fewer false-positive results | This query now recognizes calls to Express `sendFile` as safe in some cases. |
 | Unknown directive (`js/unknown-directive`) | Fewer false positive results | This query no longer flags uses of ":", which is sometimes used like a directive. |
+| Clear-text logging of sensitive information (`js/clear-text-logging`) | More results | More results involving `process.env` and indirect calls to logging methods are recognized. |
 
 ## Changes to libraries
 

--- a/change-notes/1.23/analysis-javascript.md
+++ b/change-notes/1.23/analysis-javascript.md
@@ -53,7 +53,6 @@
 | Uncontrolled command line (`js/command-line-injection`) | More results | This query now treats responses from servers as untrusted. |
 | Uncontrolled data used in path expression (`js/path-injection`) | Fewer false-positive results | This query now recognizes calls to Express `sendFile` as safe in some cases. |
 | Unknown directive (`js/unknown-directive`) | Fewer false positive results | This query no longer flags uses of ":", which is sometimes used like a directive. |
-| Clear-text logging of sensitive information (`js/clear-text-logging`) | More results | More results involving `process.env` and indirect calls to logging methods are recognized. |
 
 ## Changes to libraries
 

--- a/change-notes/1.24/analysis-javascript.md
+++ b/change-notes/1.24/analysis-javascript.md
@@ -1,0 +1,19 @@
+# Improvements to JavaScript analysis
+
+## General improvements
+
+
+## New queries
+
+| **Query**                                                                 | **Tags**                                                          | **Purpose**                                                                                                                                                                            |
+|---------------------------------------------------------------------------|-------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+
+
+## Changes to existing queries
+
+| **Query**                      | **Expected impact**          | **Change**                                                                |
+|--------------------------------|------------------------------|---------------------------------------------------------------------------|
+| Clear-text logging of sensitive information (`js/clear-text-logging`) | More results | More results involving `process.env` and indirect calls to logging methods are recognized. |
+
+## Changes to libraries
+

--- a/javascript/ql/src/semmle/javascript/dataflow/TaintTracking.qll
+++ b/javascript/ql/src/semmle/javascript/dataflow/TaintTracking.qll
@@ -669,7 +669,7 @@ module TaintTracking {
 
     override predicate step(DataFlow::Node pred, DataFlow::Node succ) {
       succ = this and
-      this.(DataFlow::CallNode).getAnArgument() = pred
+      this.getAnArgument() = pred
     }
   }
 

--- a/javascript/ql/src/semmle/javascript/dataflow/TaintTracking.qll
+++ b/javascript/ql/src/semmle/javascript/dataflow/TaintTracking.qll
@@ -660,6 +660,20 @@ module TaintTracking {
   }
 
   /**
+   * A taint step through the NodeJS function `util.inspect(..)`.
+   */
+  class UtilInspectTaintStep extends AdditionalTaintStep, DataFlow::InvokeNode {
+    UtilInspectTaintStep() {
+      this =  DataFlow::moduleImport("util").getAMethodCall("inspect")
+    }
+
+    override predicate step(DataFlow::Node pred, DataFlow::Node succ) {
+      succ = this and
+      this.(DataFlow::CallNode).getAnArgument() = pred
+    }
+  }
+
+  /**
    * A conditional checking a tainted string against a regular expression, which is
    * considered to be a sanitizer for all configurations.
    */

--- a/javascript/ql/src/semmle/javascript/dataflow/TaintTracking.qll
+++ b/javascript/ql/src/semmle/javascript/dataflow/TaintTracking.qll
@@ -660,11 +660,11 @@ module TaintTracking {
   }
 
   /**
-   * A taint step through the NodeJS function `util.inspect(..)`.
+   * A taint step through the Node.JS function `util.inspect(..)`.
    */
   class UtilInspectTaintStep extends AdditionalTaintStep, DataFlow::InvokeNode {
     UtilInspectTaintStep() {
-      this =  DataFlow::moduleImport("util").getAMethodCall("inspect")
+      this = DataFlow::moduleImport("util").getAMemberCall("inspect")
     }
 
     override predicate step(DataFlow::Node pred, DataFlow::Node succ) {

--- a/javascript/ql/src/semmle/javascript/frameworks/Logging.qll
+++ b/javascript/ql/src/semmle/javascript/frameworks/Logging.qll
@@ -62,7 +62,40 @@ private module Console {
       then result = getArgument([1 .. getNumArgument()])
       else result = getAnArgument()
     }
+
+    /**
+     * Gets the name of the console logging method, e.g. "log", "error", "assert", etc.
+     */
+    string getName() {
+      result = name
+    }
   }
+
+ /**
+  * A call to a function that forwards all arguments to some console logging mechanism.
+  * The called function contain a single statement similar to: `console.log.apply(this, arguments)`.
+  */
+ class IndirectConsoleLoggerCall extends LoggerCall {
+   ConsoleLoggerCall consoleCall;
+   DataFlow::MethodCallNode applyCall;
+
+   IndirectConsoleLoggerCall() {
+     forex(Function f | f = this.getACallee() |
+       f.getNumBodyStmt() = 1 and
+       consoleCall.getContainer() = f and
+       applyCall.getContainer() = f and
+       applyCall.getMethodName() = "apply" and
+       applyCall.getReceiver() = consoleCall.getCalleeNode() and
+       applyCall.getArgument(1).asExpr().(VarAccess).getName() = "arguments"
+     )
+   }
+
+   override DataFlow::Node getAMessageComponent() {
+      if consoleCall.getName() = "assert"
+      then result = getArgument([1 .. getNumArgument()])
+      else result = getAnArgument()
+   }
+ }
 }
 
 /**

--- a/javascript/ql/src/semmle/javascript/frameworks/Logging.qll
+++ b/javascript/ql/src/semmle/javascript/frameworks/Logging.qll
@@ -61,6 +61,8 @@ private module Console {
       if name = "assert"
       then result = getArgument([1 .. getNumArgument()])
       else result = getAnArgument()
+      or
+      result = getASpreadArgument()
     }
 
     /**
@@ -70,32 +72,6 @@ private module Console {
       result = name
     }
   }
-
- /**
-  * A call to a function that forwards all arguments to some console logging mechanism.
-  * The called function contain a single statement similar to: `console.log.apply(this, arguments)`.
-  */
- class IndirectConsoleLoggerCall extends LoggerCall {
-   ConsoleLoggerCall consoleCall;
-   DataFlow::MethodCallNode applyCall;
-
-   IndirectConsoleLoggerCall() {
-     forex(Function f | f = this.getACallee() |
-       f.getNumBodyStmt() = 1 and
-       consoleCall.getContainer() = f and
-       applyCall.getContainer() = f and
-       applyCall.getMethodName() = "apply" and
-       applyCall.getReceiver() = consoleCall.getCalleeNode() and
-       applyCall.getArgument(1).asExpr().(VarAccess).getName() = "arguments"
-     )
-   }
-
-   override DataFlow::Node getAMessageComponent() {
-      if consoleCall.getName() = "assert"
-      then result = getArgument([1 .. getNumArgument()])
-      else result = getAnArgument()
-   }
- }
 }
 
 /**

--- a/javascript/ql/src/semmle/javascript/security/dataflow/CleartextLogging.qll
+++ b/javascript/ql/src/semmle/javascript/security/dataflow/CleartextLogging.qll
@@ -36,10 +36,8 @@ module CleartextLogging {
 
     override predicate isSanitizerEdge(DataFlow::Node pred, DataFlow::Node succ, DataFlow::FlowLabel lbl) {
       // Only unknown property reads on `process.env` propagate taint.
-      not lbl instanceof ProcessEnvLabel and 
+      (not lbl instanceof ProcessEnvLabel or exists(succ.(DataFlow::PropRead).getPropertyName())) and 
       succ.(DataFlow::PropRead).getBase() = pred
-      or 
-      exists(succ.(DataFlow::PropRead).getPropertyName())
     }
        
     override predicate isAdditionalFlowStep(

--- a/javascript/ql/src/semmle/javascript/security/dataflow/CleartextLogging.qll
+++ b/javascript/ql/src/semmle/javascript/security/dataflow/CleartextLogging.qll
@@ -50,6 +50,16 @@ module CleartextLogging {
       // Taint step through a `str.replace(..)` call.
       trg.(DataFlow::MethodCallNode).getCalleeName() = "replace" and
       trg.(DataFlow::MethodCallNode).getReceiver() = src
+      or
+      // Taint through the arguments object.
+      exists(DataFlow::CallNode call, Function f, VarAccess var |
+        src = call.getAnArgument() and
+        f = call.getACallee() and
+        not call.isImprecise() and
+        var.getName() = "arguments" and
+        var.getContainer() = f and
+        trg.asExpr() = var
+      )
     }
   }
 }

--- a/javascript/ql/src/semmle/javascript/security/dataflow/CleartextLogging.qll
+++ b/javascript/ql/src/semmle/javascript/security/dataflow/CleartextLogging.qll
@@ -35,8 +35,8 @@ module CleartextLogging {
     override predicate isSanitizer(DataFlow::Node node) { node instanceof Barrier }
 
     override predicate isSanitizerEdge(DataFlow::Node pred, DataFlow::Node succ, DataFlow::FlowLabel lbl) {
-      // Only unknown property reads on `process.env` propagate taint.
-      (not lbl instanceof ProcessEnvLabel or exists(succ.(DataFlow::PropRead).getPropertyName())) and 
+      // Only unknown property reads on sensitive objects propagate taint.
+      (not lbl instanceof PartiallySensitiveMap or exists(succ.(DataFlow::PropRead).getPropertyName())) and 
       succ.(DataFlow::PropRead).getBase() = pred
     }
        
@@ -44,7 +44,7 @@ module CleartextLogging {
       DataFlow::Node src, DataFlow::Node trg, DataFlow::FlowLabel inlbl, DataFlow::FlowLabel outlbl
     ) {
       trg.(DataFlow::PropRead).getBase() = src and
-      inlbl instanceof ProcessEnvLabel and 
+      inlbl instanceof PartiallySensitiveMap and 
       outlbl.isData() 
     }
     

--- a/javascript/ql/src/semmle/javascript/security/dataflow/CleartextLogging.qll
+++ b/javascript/ql/src/semmle/javascript/security/dataflow/CleartextLogging.qll
@@ -42,6 +42,14 @@ module CleartextLogging {
         write.getRhs() = src and
         trg.(DataFlow::SourceNode).flowsTo(write.getBase())
       )
+      or
+      // Taint step through `util.inspect(..)` from Node.js
+      trg = DataFlow::moduleImport("util").getAMethodCall("inspect") and
+      trg.(DataFlow::CallNode).getAnArgument() = src
+      or
+      // Taint step through a `str.replace(..)` call.
+      trg.(DataFlow::MethodCallNode).getCalleeName() = "replace" and
+      trg.(DataFlow::MethodCallNode).getReceiver() = src
     }
   }
 }

--- a/javascript/ql/src/semmle/javascript/security/dataflow/CleartextLogging.qll
+++ b/javascript/ql/src/semmle/javascript/security/dataflow/CleartextLogging.qll
@@ -34,20 +34,10 @@ module CleartextLogging {
 
     override predicate isSanitizer(DataFlow::Node node) { node instanceof Barrier }
 
-    override predicate isSanitizerEdge(DataFlow::Node pred, DataFlow::Node succ, DataFlow::FlowLabel lbl) {
-      // Only unknown property reads on sensitive objects propagate taint.
-      (not lbl instanceof PartiallySensitiveMap or exists(succ.(DataFlow::PropRead).getPropertyName())) and 
+    override predicate isSanitizerEdge(DataFlow::Node pred, DataFlow::Node succ) {
       succ.(DataFlow::PropRead).getBase() = pred
     }
        
-    override predicate isAdditionalFlowStep(
-      DataFlow::Node src, DataFlow::Node trg, DataFlow::FlowLabel inlbl, DataFlow::FlowLabel outlbl
-    ) {
-      trg.(DataFlow::PropRead).getBase() = src and
-      inlbl instanceof PartiallySensitiveMap and 
-      outlbl.isData() 
-    }
-    
     override predicate isAdditionalTaintStep(DataFlow::Node src, DataFlow::Node trg) {
       // A taint propagating data flow edge through objects: a tainted write taints the entire object.
       exists(DataFlow::PropWrite write |

--- a/javascript/ql/src/semmle/javascript/security/dataflow/CleartextLogging.qll
+++ b/javascript/ql/src/semmle/javascript/security/dataflow/CleartextLogging.qll
@@ -13,7 +13,7 @@ module CleartextLogging {
   import CleartextLoggingCustomizations::CleartextLogging
 
   /**
-   * A dataflow tracking configuration for clear-text logging of sensitive information.
+   * A taint tracking configuration for clear-text logging of sensitive information.
    *
    * This configuration identifies flows from `Source`s, which are sources of
    * sensitive data, to `Sink`s, which is an abstract class representing all
@@ -21,35 +21,39 @@ module CleartextLogging {
    * added either by extending the relevant class, or by subclassing this configuration itself,
    * and amending the sources and sinks.
    */
-  class Configuration extends DataFlow::Configuration {
+  class Configuration extends TaintTracking::Configuration {
     Configuration() { this = "CleartextLogging" }
 
-    override predicate isSource(DataFlow::Node source) { source instanceof Source }
+    override predicate isSource(DataFlow::Node source, DataFlow::FlowLabel lbl) {
+      source.(Source).getLabel() = lbl
+    }
 
-    override predicate isSink(DataFlow::Node sink) { sink instanceof Sink }
+    override predicate isSink(DataFlow::Node sink, DataFlow::FlowLabel lbl) {
+      sink.(Sink).getLabel() = lbl
+    }
 
-    override predicate isBarrier(DataFlow::Node node) { node instanceof Barrier }
+    override predicate isSanitizer(DataFlow::Node node) { node instanceof Barrier }
 
-    override predicate isAdditionalFlowStep(DataFlow::Node src, DataFlow::Node trg) {
-      StringConcatenation::taintStep(src, trg)
-      or
-      exists(string name | name = "toString" or name = "valueOf" |
-        src.(DataFlow::SourceNode).getAMethodCall(name) = trg
-      )
-      or
+    override predicate isSanitizerEdge(DataFlow::Node pred, DataFlow::Node succ, DataFlow::FlowLabel lbl) {
+      // Property reads do not propagate taint.
+      not lbl instanceof ProcessEnvLabel and 
+      succ.(DataFlow::PropRead).getBase() = pred
+    }
+       
+    override predicate isAdditionalFlowStep(
+      DataFlow::Node src, DataFlow::Node trg, DataFlow::FlowLabel inlbl, DataFlow::FlowLabel outlbl
+    ) {
+      trg.(DataFlow::PropRead).getBase() = src and
+      inlbl instanceof ProcessEnvLabel and 
+      outlbl.isData() 
+    }
+    
+    override predicate isAdditionalTaintStep(DataFlow::Node src, DataFlow::Node trg) {
       // A taint propagating data flow edge through objects: a tainted write taints the entire object.
       exists(DataFlow::PropWrite write |
         write.getRhs() = src and
         trg.(DataFlow::SourceNode).flowsTo(write.getBase())
       )
-      or
-      // Taint step through `util.inspect(..)` from Node.js
-      trg = DataFlow::moduleImport("util").getAMethodCall("inspect") and
-      trg.(DataFlow::CallNode).getAnArgument() = src
-      or
-      // Taint step through a `str.replace(..)` call.
-      trg.(DataFlow::MethodCallNode).getCalleeName() = "replace" and
-      trg.(DataFlow::MethodCallNode).getReceiver() = src
       or
       // Taint through the arguments object.
       exists(DataFlow::CallNode call, Function f, VarAccess var |

--- a/javascript/ql/src/semmle/javascript/security/dataflow/CleartextLoggingCustomizations.qll
+++ b/javascript/ql/src/semmle/javascript/security/dataflow/CleartextLoggingCustomizations.qll
@@ -32,6 +32,22 @@ module CleartextLogging {
    * A barrier for clear-text logging of sensitive information.
    */
   abstract class Barrier extends DataFlow::Node { }
+  
+  /**
+   * A call to `.replace()` that seems to mask 
+   */
+  class MaskingReplacer extends Barrier, DataFlow::MethodCallNode {
+  	MaskingReplacer() {
+  	  this.getCalleeName() = "replace" and
+  	  exists(RegExpLiteral reg| 
+  	    reg = this.getArgument(0).getALocalSource().asExpr() and
+  	    reg.getFlags().regexpMatch("(?i).*g.*") and
+  	    reg.getRoot().getRawValue().regexpMatch(".*\\..*")
+  	  ) 
+  	  and
+  	  this.getArgument(1).asExpr() instanceof StringLiteral
+  	}
+  }
 
   /**
    * An argument to a logging mechanism.

--- a/javascript/ql/src/semmle/javascript/security/dataflow/CleartextLoggingCustomizations.qll
+++ b/javascript/ql/src/semmle/javascript/security/dataflow/CleartextLoggingCustomizations.qll
@@ -148,7 +148,7 @@ module CleartextLogging {
 
   private class ProcessEnvSource extends Source {
     ProcessEnvSource() {
-      this = DataFlow::globalVarRef("process").getAPropertyRead("env")
+      this = NodeJSLib::process().getAPropertyRead("env")
     }
 
     override string describe() { result = "process environment" }

--- a/javascript/ql/src/semmle/javascript/security/dataflow/CleartextLoggingCustomizations.qll
+++ b/javascript/ql/src/semmle/javascript/security/dataflow/CleartextLoggingCustomizations.qll
@@ -15,12 +15,18 @@ module CleartextLogging {
   abstract class Source extends DataFlow::Node {
     /** Gets a string that describes the type of this data flow source. */
     abstract string describe();
+    
+    abstract DataFlow::FlowLabel getLabel();
   }
 
   /**
    * A data flow sink for clear-text logging of sensitive information.
    */
-  abstract class Sink extends DataFlow::Node { }
+  abstract class Sink extends DataFlow::Node {
+    DataFlow::FlowLabel getLabel() {
+      result.isDataOrTaint()
+    }
+  }
 
   /**
    * A barrier for clear-text logging of sensitive information.
@@ -107,6 +113,10 @@ module CleartextLogging {
     }
 
     override string describe() { result = "an access to " + name }
+    
+    override DataFlow::FlowLabel getLabel() {
+      result.isData()
+    }
   }
 
   /** An access to a variable or property that might contain a password. */
@@ -131,6 +141,10 @@ module CleartextLogging {
     }
 
     override string describe() { result = "an access to " + name }
+    
+    override DataFlow::FlowLabel getLabel() {
+      result.isData()
+    }
   }
 
   /** A call that might return a password. */
@@ -143,14 +157,28 @@ module CleartextLogging {
     }
 
     override string describe() { result = "a call to " + name }
+    
+    override DataFlow::FlowLabel getLabel() {
+      result.isData()
+    }
   }
 
 
-  private class ProcessEnvSource extends Source {
+  class ProcessEnvSource extends Source {
     ProcessEnvSource() {
       this = NodeJSLib::process().getAPropertyRead("env")
     }
 
     override string describe() { result = "process environment" }
+    
+    override DataFlow::FlowLabel getLabel() {
+      result.isData() or 
+      result instanceof ProcessEnvLabel
+    }
+  }
+  class ProcessEnvLabel extends DataFlow::FlowLabel{
+    ProcessEnvLabel() {
+      this = "processEnv"
+    }
   }
 }

--- a/javascript/ql/src/semmle/javascript/security/dataflow/CleartextLoggingCustomizations.qll
+++ b/javascript/ql/src/semmle/javascript/security/dataflow/CleartextLoggingCustomizations.qll
@@ -144,4 +144,13 @@ module CleartextLogging {
 
     override string describe() { result = "a call to " + name }
   }
+
+
+  private class ProcessEnvSource extends Source {
+    ProcessEnvSource() {
+      this = DataFlow::globalVarRef("process").getAPropertyRead("env")
+    }
+
+    override string describe() { result = "process environment" }
+  }
 }

--- a/javascript/ql/src/semmle/javascript/security/dataflow/CleartextLoggingCustomizations.qll
+++ b/javascript/ql/src/semmle/javascript/security/dataflow/CleartextLoggingCustomizations.qll
@@ -34,19 +34,19 @@ module CleartextLogging {
   abstract class Barrier extends DataFlow::Node { }
   
   /**
-   * A call to `.replace()` that seems to mask 
+   * A call to `.replace()` that seems to mask sensitive information.
    */
   class MaskingReplacer extends Barrier, DataFlow::MethodCallNode {
-  	MaskingReplacer() {
-  	  this.getCalleeName() = "replace" and
-  	  exists(RegExpLiteral reg| 
-  	    reg = this.getArgument(0).getALocalSource().asExpr() and
-  	    reg.getFlags().regexpMatch("(?i).*g.*") and
-  	    reg.getRoot().getRawValue().regexpMatch(".*\\..*")
-  	  ) 
-  	  and
-  	  this.getArgument(1).asExpr() instanceof StringLiteral
-  	}
+    MaskingReplacer() {
+      this.getCalleeName() = "replace" and
+      exists(RegExpLiteral reg |
+        reg = this.getArgument(0).getALocalSource().asExpr() and
+        reg.isGlobal() and
+        any(RegExpDot term).getLiteral() = reg
+      )
+      and
+      exists(this.getArgument(1).getStringValue())
+    }
   }
 
   /**

--- a/javascript/ql/src/semmle/javascript/security/dataflow/CleartextLoggingCustomizations.qll
+++ b/javascript/ql/src/semmle/javascript/security/dataflow/CleartextLoggingCustomizations.qll
@@ -163,7 +163,7 @@ module CleartextLogging {
     }
   }
 
-
+  /** An access to the sensitive object `process.env`. */
   class ProcessEnvSource extends Source {
     ProcessEnvSource() {
       this = NodeJSLib::process().getAPropertyRead("env")
@@ -173,11 +173,16 @@ module CleartextLogging {
     
     override DataFlow::FlowLabel getLabel() {
       result.isData() or 
-      result instanceof ProcessEnvLabel
+      result instanceof PartiallySensitiveMap
     }
   }
-  class ProcessEnvLabel extends DataFlow::FlowLabel{
-    ProcessEnvLabel() {
+  
+  /**
+   * A flow label describing a map that might contain sensitive information in some properties.
+   * Property reads on such maps where the property name is fixed is unlikely to leak sensitive information. 
+   */
+  class PartiallySensitiveMap extends DataFlow::FlowLabel {
+    PartiallySensitiveMap() {
       this = "processEnv"
     }
   }

--- a/javascript/ql/src/semmle/javascript/security/dataflow/CleartextLoggingCustomizations.qll
+++ b/javascript/ql/src/semmle/javascript/security/dataflow/CleartextLoggingCustomizations.qll
@@ -199,7 +199,7 @@ module CleartextLogging {
    */
   class PartiallySensitiveMap extends DataFlow::FlowLabel {
     PartiallySensitiveMap() {
-      this = "processEnv"
+      this = "PartiallySensitiveMap"
     }
   }
 }

--- a/javascript/ql/test/query-tests/Security/CWE-312/CleartextLogging.expected
+++ b/javascript/ql/test/query-tests/Security/CWE-312/CleartextLogging.expected
@@ -120,10 +120,14 @@ nodes
 | passwords.js:156:17:156:27 | process.env |
 | passwords.js:156:17:156:27 | process.env |
 | passwords.js:156:17:156:27 | process.env |
-| passwords.js:158:17:158:27 | process.env |
-| passwords.js:158:17:158:27 | process.env |
-| passwords.js:158:17:158:42 | process ...  "bar"] |
-| passwords.js:158:17:158:42 | process ...  "bar"] |
+| passwords.js:163:14:163:21 | password |
+| passwords.js:163:14:163:21 | password |
+| passwords.js:163:14:163:41 | passwor ... g, "*") |
+| passwords.js:163:14:163:41 | passwor ... g, "*") |
+| passwords.js:164:14:164:21 | password |
+| passwords.js:164:14:164:21 | password |
+| passwords.js:164:14:164:42 | passwor ... g, "*") |
+| passwords.js:164:14:164:42 | passwor ... g, "*") |
 | passwords_in_browser1.js:2:13:2:20 | password |
 | passwords_in_browser1.js:2:13:2:20 | password |
 | passwords_in_browser1.js:2:13:2:20 | password |
@@ -260,6 +264,14 @@ edges
 | passwords.js:154:21:154:28 | procdesc | passwords.js:142:26:142:34 | arguments |
 | passwords.js:154:21:154:28 | procdesc | passwords.js:142:26:142:34 | arguments |
 | passwords.js:156:17:156:27 | process.env | passwords.js:156:17:156:27 | process.env |
+| passwords.js:163:14:163:21 | password | passwords.js:163:14:163:41 | passwor ... g, "*") |
+| passwords.js:163:14:163:21 | password | passwords.js:163:14:163:41 | passwor ... g, "*") |
+| passwords.js:163:14:163:21 | password | passwords.js:163:14:163:41 | passwor ... g, "*") |
+| passwords.js:163:14:163:21 | password | passwords.js:163:14:163:41 | passwor ... g, "*") |
+| passwords.js:164:14:164:21 | password | passwords.js:164:14:164:42 | passwor ... g, "*") |
+| passwords.js:164:14:164:21 | password | passwords.js:164:14:164:42 | passwor ... g, "*") |
+| passwords.js:164:14:164:21 | password | passwords.js:164:14:164:42 | passwor ... g, "*") |
+| passwords.js:164:14:164:21 | password | passwords.js:164:14:164:42 | passwor ... g, "*") |
 | passwords_in_browser1.js:2:13:2:20 | password | passwords_in_browser1.js:2:13:2:20 | password |
 | passwords_in_browser2.js:2:13:2:20 | password | passwords_in_browser2.js:2:13:2:20 | password |
 | passwords_in_server_1.js:6:13:6:20 | password | passwords_in_server_1.js:6:13:6:20 | password |
@@ -301,6 +313,8 @@ edges
 | passwords.js:142:26:142:34 | arguments | passwords.js:150:21:150:31 | process.env | passwords.js:142:26:142:34 | arguments | Sensitive data returned by $@ is logged here. | passwords.js:150:21:150:31 | process.env | process environment |
 | passwords.js:142:26:142:34 | arguments | passwords.js:152:33:152:43 | process.env | passwords.js:142:26:142:34 | arguments | Sensitive data returned by $@ is logged here. | passwords.js:152:33:152:43 | process.env | process environment |
 | passwords.js:156:17:156:27 | process.env | passwords.js:156:17:156:27 | process.env | passwords.js:156:17:156:27 | process.env | Sensitive data returned by $@ is logged here. | passwords.js:156:17:156:27 | process.env | process environment |
+| passwords.js:163:14:163:41 | passwor ... g, "*") | passwords.js:163:14:163:21 | password | passwords.js:163:14:163:41 | passwor ... g, "*") | Sensitive data returned by $@ is logged here. | passwords.js:163:14:163:21 | password | an access to password |
+| passwords.js:164:14:164:42 | passwor ... g, "*") | passwords.js:164:14:164:21 | password | passwords.js:164:14:164:42 | passwor ... g, "*") | Sensitive data returned by $@ is logged here. | passwords.js:164:14:164:21 | password | an access to password |
 | passwords_in_server_1.js:6:13:6:20 | password | passwords_in_server_1.js:6:13:6:20 | password | passwords_in_server_1.js:6:13:6:20 | password | Sensitive data returned by $@ is logged here. | passwords_in_server_1.js:6:13:6:20 | password | an access to password |
 | passwords_in_server_2.js:3:13:3:20 | password | passwords_in_server_2.js:3:13:3:20 | password | passwords_in_server_2.js:3:13:3:20 | password | Sensitive data returned by $@ is logged here. | passwords_in_server_2.js:3:13:3:20 | password | an access to password |
 | passwords_in_server_3.js:2:13:2:20 | password | passwords_in_server_3.js:2:13:2:20 | password | passwords_in_server_3.js:2:13:2:20 | password | Sensitive data returned by $@ is logged here. | passwords_in_server_3.js:2:13:2:20 | password | an access to password |

--- a/javascript/ql/test/query-tests/Security/CWE-312/CleartextLogging.expected
+++ b/javascript/ql/test/query-tests/Security/CWE-312/CleartextLogging.expected
@@ -105,27 +105,16 @@ nodes
 | passwords.js:137:17:137:24 | config.y |
 | passwords.js:137:17:137:24 | config.y |
 | passwords.js:142:26:142:34 | arguments |
-<<<<<<< HEAD
-| passwords.js:147:12:147:19 | password |
-| passwords.js:149:21:149:28 | config.x |
-| passwords.js:150:21:150:31 | process.env |
-=======
 | passwords.js:142:26:142:34 | arguments |
 | passwords.js:147:12:147:19 | password |
 | passwords.js:147:12:147:19 | password |
 | passwords.js:149:21:149:28 | config.x |
 | passwords.js:150:21:150:31 | process.env |
 | passwords.js:150:21:150:31 | process.env |
->>>>>>> remove type cast, and fix expected test results
 | passwords.js:152:9:152:63 | procdesc |
 | passwords.js:152:20:152:44 | Util.in ... ss.env) |
 | passwords.js:152:20:152:63 | Util.in ... /g, '') |
 | passwords.js:152:33:152:43 | process.env |
-<<<<<<< HEAD
-| passwords.js:154:21:154:28 | procdesc |
-| passwords.js:156:17:156:27 | process.env |
-| passwords.js:158:17:158:27 | process.env |
-=======
 | passwords.js:152:33:152:43 | process.env |
 | passwords.js:154:21:154:28 | procdesc |
 | passwords.js:156:17:156:27 | process.env |
@@ -134,7 +123,6 @@ nodes
 | passwords.js:158:17:158:27 | process.env |
 | passwords.js:158:17:158:27 | process.env |
 | passwords.js:158:17:158:42 | process ...  "bar"] |
->>>>>>> remove type cast, and fix expected test results
 | passwords.js:158:17:158:42 | process ...  "bar"] |
 | passwords_in_browser1.js:2:13:2:20 | password |
 | passwords_in_browser1.js:2:13:2:20 | password |
@@ -272,10 +260,6 @@ edges
 | passwords.js:154:21:154:28 | procdesc | passwords.js:142:26:142:34 | arguments |
 | passwords.js:154:21:154:28 | procdesc | passwords.js:142:26:142:34 | arguments |
 | passwords.js:156:17:156:27 | process.env | passwords.js:156:17:156:27 | process.env |
-| passwords.js:158:17:158:27 | process.env | passwords.js:158:17:158:42 | process ...  "bar"] |
-| passwords.js:158:17:158:27 | process.env | passwords.js:158:17:158:42 | process ...  "bar"] |
-| passwords.js:158:17:158:27 | process.env | passwords.js:158:17:158:42 | process ...  "bar"] |
-| passwords.js:158:17:158:27 | process.env | passwords.js:158:17:158:42 | process ...  "bar"] |
 | passwords_in_browser1.js:2:13:2:20 | password | passwords_in_browser1.js:2:13:2:20 | password |
 | passwords_in_browser2.js:2:13:2:20 | password | passwords_in_browser2.js:2:13:2:20 | password |
 | passwords_in_server_1.js:6:13:6:20 | password | passwords_in_server_1.js:6:13:6:20 | password |
@@ -317,7 +301,6 @@ edges
 | passwords.js:142:26:142:34 | arguments | passwords.js:150:21:150:31 | process.env | passwords.js:142:26:142:34 | arguments | Sensitive data returned by $@ is logged here. | passwords.js:150:21:150:31 | process.env | process environment |
 | passwords.js:142:26:142:34 | arguments | passwords.js:152:33:152:43 | process.env | passwords.js:142:26:142:34 | arguments | Sensitive data returned by $@ is logged here. | passwords.js:152:33:152:43 | process.env | process environment |
 | passwords.js:156:17:156:27 | process.env | passwords.js:156:17:156:27 | process.env | passwords.js:156:17:156:27 | process.env | Sensitive data returned by $@ is logged here. | passwords.js:156:17:156:27 | process.env | process environment |
-| passwords.js:158:17:158:42 | process ...  "bar"] | passwords.js:158:17:158:27 | process.env | passwords.js:158:17:158:42 | process ...  "bar"] | Sensitive data returned by $@ is logged here. | passwords.js:158:17:158:27 | process.env | process environment |
 | passwords_in_server_1.js:6:13:6:20 | password | passwords_in_server_1.js:6:13:6:20 | password | passwords_in_server_1.js:6:13:6:20 | password | Sensitive data returned by $@ is logged here. | passwords_in_server_1.js:6:13:6:20 | password | an access to password |
 | passwords_in_server_2.js:3:13:3:20 | password | passwords_in_server_2.js:3:13:3:20 | password | passwords_in_server_2.js:3:13:3:20 | password | Sensitive data returned by $@ is logged here. | passwords_in_server_2.js:3:13:3:20 | password | an access to password |
 | passwords_in_server_3.js:2:13:2:20 | password | passwords_in_server_3.js:2:13:2:20 | password | passwords_in_server_3.js:2:13:2:20 | password | Sensitive data returned by $@ is logged here. | passwords_in_server_3.js:2:13:2:20 | password | an access to password |

--- a/javascript/ql/test/query-tests/Security/CWE-312/CleartextLogging.expected
+++ b/javascript/ql/test/query-tests/Security/CWE-312/CleartextLogging.expected
@@ -114,8 +114,8 @@ nodes
 | passwords.js:152:33:152:43 | process.env |
 | passwords.js:154:21:154:28 | procdesc |
 | passwords.js:156:17:156:27 | process.env |
-| passwords.js:157:17:157:27 | process.env |
-| passwords.js:157:17:157:32 | process.env.PATH |
+| passwords.js:158:17:158:27 | process.env |
+| passwords.js:158:17:158:42 | process ...  "bar"] |
 | passwords_in_browser1.js:2:13:2:20 | password |
 | passwords_in_browser1.js:2:13:2:20 | password |
 | passwords_in_browser1.js:2:13:2:20 | password |
@@ -235,7 +235,7 @@ edges
 | passwords.js:152:20:152:63 | Util.in ... /g, '') | passwords.js:152:9:152:63 | procdesc |
 | passwords.js:152:33:152:43 | process.env | passwords.js:152:20:152:44 | Util.in ... ss.env) |
 | passwords.js:154:21:154:28 | procdesc | passwords.js:142:26:142:34 | arguments |
-| passwords.js:157:17:157:27 | process.env | passwords.js:157:17:157:32 | process.env.PATH |
+| passwords.js:158:17:158:27 | process.env | passwords.js:158:17:158:42 | process ...  "bar"] |
 | passwords_in_server_5.js:4:7:4:24 | req.query.password | passwords_in_server_5.js:7:12:7:12 | x |
 | passwords_in_server_5.js:7:12:7:12 | x | passwords_in_server_5.js:8:17:8:17 | x |
 | passwords_in_server_5.js:7:12:7:12 | x | passwords_in_server_5.js:8:17:8:17 | x |
@@ -270,7 +270,7 @@ edges
 | passwords.js:142:26:142:34 | arguments | passwords.js:150:21:150:31 | process.env | passwords.js:142:26:142:34 | arguments | Sensitive data returned by $@ is logged here. | passwords.js:150:21:150:31 | process.env | process environment |
 | passwords.js:142:26:142:34 | arguments | passwords.js:152:33:152:43 | process.env | passwords.js:142:26:142:34 | arguments | Sensitive data returned by $@ is logged here. | passwords.js:152:33:152:43 | process.env | process environment |
 | passwords.js:156:17:156:27 | process.env | passwords.js:156:17:156:27 | process.env | passwords.js:156:17:156:27 | process.env | Sensitive data returned by $@ is logged here. | passwords.js:156:17:156:27 | process.env | process environment |
-| passwords.js:157:17:157:32 | process.env.PATH | passwords.js:157:17:157:27 | process.env | passwords.js:157:17:157:32 | process.env.PATH | Sensitive data returned by $@ is logged here. | passwords.js:157:17:157:27 | process.env | process environment |
+| passwords.js:158:17:158:42 | process ...  "bar"] | passwords.js:158:17:158:27 | process.env | passwords.js:158:17:158:42 | process ...  "bar"] | Sensitive data returned by $@ is logged here. | passwords.js:158:17:158:27 | process.env | process environment |
 | passwords_in_server_1.js:6:13:6:20 | password | passwords_in_server_1.js:6:13:6:20 | password | passwords_in_server_1.js:6:13:6:20 | password | Sensitive data returned by $@ is logged here. | passwords_in_server_1.js:6:13:6:20 | password | an access to password |
 | passwords_in_server_2.js:3:13:3:20 | password | passwords_in_server_2.js:3:13:3:20 | password | passwords_in_server_2.js:3:13:3:20 | password | Sensitive data returned by $@ is logged here. | passwords_in_server_2.js:3:13:3:20 | password | an access to password |
 | passwords_in_server_3.js:2:13:2:20 | password | passwords_in_server_3.js:2:13:2:20 | password | passwords_in_server_3.js:2:13:2:20 | password | Sensitive data returned by $@ is logged here. | passwords_in_server_3.js:2:13:2:20 | password | an access to password |

--- a/javascript/ql/test/query-tests/Security/CWE-312/CleartextLogging.expected
+++ b/javascript/ql/test/query-tests/Security/CWE-312/CleartextLogging.expected
@@ -240,9 +240,6 @@ edges
 | passwords.js:131:12:131:24 | getPassword() | passwords.js:127:18:132:5 | {\\n      ... )\\n    } |
 | passwords.js:131:12:131:24 | getPassword() | passwords.js:127:18:132:5 | {\\n      ... )\\n    } |
 | passwords.js:131:12:131:24 | getPassword() | passwords.js:137:17:137:24 | config.y |
-| passwords.js:147:12:147:19 | password | passwords.js:149:21:149:28 | config.x |
-| passwords.js:149:21:149:28 | config.x | passwords.js:142:26:142:34 | arguments |
-| passwords.js:150:21:150:31 | process.env | passwords.js:142:26:142:34 | arguments |
 | passwords.js:131:12:131:24 | getPassword() | passwords.js:137:17:137:24 | config.y |
 | passwords.js:131:12:131:24 | getPassword() | passwords.js:137:17:137:24 | config.y |
 | passwords.js:131:12:131:24 | getPassword() | passwords.js:137:17:137:24 | config.y |
@@ -258,8 +255,6 @@ edges
 | passwords.js:152:20:152:44 | Util.in ... ss.env) | passwords.js:152:20:152:63 | Util.in ... /g, '') |
 | passwords.js:152:20:152:63 | Util.in ... /g, '') | passwords.js:152:9:152:63 | procdesc |
 | passwords.js:152:33:152:43 | process.env | passwords.js:152:20:152:44 | Util.in ... ss.env) |
-| passwords.js:154:21:154:28 | procdesc | passwords.js:142:26:142:34 | arguments |
-| passwords.js:158:17:158:27 | process.env | passwords.js:158:17:158:42 | process ...  "bar"] |
 | passwords.js:152:33:152:43 | process.env | passwords.js:152:20:152:44 | Util.in ... ss.env) |
 | passwords.js:154:21:154:28 | procdesc | passwords.js:142:26:142:34 | arguments |
 | passwords.js:154:21:154:28 | procdesc | passwords.js:142:26:142:34 | arguments |

--- a/javascript/ql/test/query-tests/Security/CWE-312/CleartextLogging.expected
+++ b/javascript/ql/test/query-tests/Security/CWE-312/CleartextLogging.expected
@@ -101,6 +101,7 @@ nodes
 | passwords.js:136:17:136:24 | config.x |
 | passwords.js:137:17:137:24 | config.y |
 | passwords.js:137:17:137:24 | config.y |
+| passwords.js:142:26:142:34 | arguments |
 | passwords.js:147:12:147:19 | password |
 | passwords.js:149:21:149:28 | config.x |
 | passwords.js:150:21:150:31 | process.env |
@@ -109,6 +110,7 @@ nodes
 | passwords.js:152:20:152:63 | Util.in ... /g, '') |
 | passwords.js:152:33:152:43 | process.env |
 | passwords.js:154:21:154:28 | procdesc |
+| passwords.js:156:17:156:27 | process.env |
 | passwords_in_browser1.js:2:13:2:20 | password |
 | passwords_in_browser1.js:2:13:2:20 | password |
 | passwords_in_browser1.js:2:13:2:20 | password |
@@ -219,10 +221,13 @@ edges
 | passwords.js:131:12:131:24 | getPassword() | passwords.js:127:18:132:5 | {\\n      ... )\\n    } |
 | passwords.js:131:12:131:24 | getPassword() | passwords.js:137:17:137:24 | config.y |
 | passwords.js:147:12:147:19 | password | passwords.js:149:21:149:28 | config.x |
+| passwords.js:149:21:149:28 | config.x | passwords.js:142:26:142:34 | arguments |
+| passwords.js:150:21:150:31 | process.env | passwords.js:142:26:142:34 | arguments |
 | passwords.js:152:9:152:63 | procdesc | passwords.js:154:21:154:28 | procdesc |
 | passwords.js:152:20:152:44 | Util.in ... ss.env) | passwords.js:152:20:152:63 | Util.in ... /g, '') |
 | passwords.js:152:20:152:63 | Util.in ... /g, '') | passwords.js:152:9:152:63 | procdesc |
 | passwords.js:152:33:152:43 | process.env | passwords.js:152:20:152:44 | Util.in ... ss.env) |
+| passwords.js:154:21:154:28 | procdesc | passwords.js:142:26:142:34 | arguments |
 | passwords_in_server_5.js:4:7:4:24 | req.query.password | passwords_in_server_5.js:7:12:7:12 | x |
 | passwords_in_server_5.js:7:12:7:12 | x | passwords_in_server_5.js:8:17:8:17 | x |
 | passwords_in_server_5.js:7:12:7:12 | x | passwords_in_server_5.js:8:17:8:17 | x |
@@ -253,9 +258,10 @@ edges
 | passwords.js:135:17:135:22 | config | passwords.js:131:12:131:24 | getPassword() | passwords.js:135:17:135:22 | config | Sensitive data returned by $@ is logged here. | passwords.js:131:12:131:24 | getPassword() | a call to getPassword |
 | passwords.js:136:17:136:24 | config.x | passwords.js:130:12:130:19 | password | passwords.js:136:17:136:24 | config.x | Sensitive data returned by $@ is logged here. | passwords.js:130:12:130:19 | password | an access to password |
 | passwords.js:137:17:137:24 | config.y | passwords.js:131:12:131:24 | getPassword() | passwords.js:137:17:137:24 | config.y | Sensitive data returned by $@ is logged here. | passwords.js:131:12:131:24 | getPassword() | a call to getPassword |
-| passwords.js:149:21:149:28 | config.x | passwords.js:147:12:147:19 | password | passwords.js:149:21:149:28 | config.x | Sensitive data returned by $@ is logged here. | passwords.js:147:12:147:19 | password | an access to password |
-| passwords.js:150:21:150:31 | process.env | passwords.js:150:21:150:31 | process.env | passwords.js:150:21:150:31 | process.env | Sensitive data returned by $@ is logged here. | passwords.js:150:21:150:31 | process.env | process environment |
-| passwords.js:154:21:154:28 | procdesc | passwords.js:152:33:152:43 | process.env | passwords.js:154:21:154:28 | procdesc | Sensitive data returned by $@ is logged here. | passwords.js:152:33:152:43 | process.env | process environment |
+| passwords.js:142:26:142:34 | arguments | passwords.js:147:12:147:19 | password | passwords.js:142:26:142:34 | arguments | Sensitive data returned by $@ is logged here. | passwords.js:147:12:147:19 | password | an access to password |
+| passwords.js:142:26:142:34 | arguments | passwords.js:150:21:150:31 | process.env | passwords.js:142:26:142:34 | arguments | Sensitive data returned by $@ is logged here. | passwords.js:150:21:150:31 | process.env | process environment |
+| passwords.js:142:26:142:34 | arguments | passwords.js:152:33:152:43 | process.env | passwords.js:142:26:142:34 | arguments | Sensitive data returned by $@ is logged here. | passwords.js:152:33:152:43 | process.env | process environment |
+| passwords.js:156:17:156:27 | process.env | passwords.js:156:17:156:27 | process.env | passwords.js:156:17:156:27 | process.env | Sensitive data returned by $@ is logged here. | passwords.js:156:17:156:27 | process.env | process environment |
 | passwords_in_server_1.js:6:13:6:20 | password | passwords_in_server_1.js:6:13:6:20 | password | passwords_in_server_1.js:6:13:6:20 | password | Sensitive data returned by $@ is logged here. | passwords_in_server_1.js:6:13:6:20 | password | an access to password |
 | passwords_in_server_2.js:3:13:3:20 | password | passwords_in_server_2.js:3:13:3:20 | password | passwords_in_server_2.js:3:13:3:20 | password | Sensitive data returned by $@ is logged here. | passwords_in_server_2.js:3:13:3:20 | password | an access to password |
 | passwords_in_server_3.js:2:13:2:20 | password | passwords_in_server_3.js:2:13:2:20 | password | passwords_in_server_3.js:2:13:2:20 | password | Sensitive data returned by $@ is logged here. | passwords_in_server_3.js:2:13:2:20 | password | an access to password |

--- a/javascript/ql/test/query-tests/Security/CWE-312/CleartextLogging.expected
+++ b/javascript/ql/test/query-tests/Security/CWE-312/CleartextLogging.expected
@@ -101,6 +101,14 @@ nodes
 | passwords.js:136:17:136:24 | config.x |
 | passwords.js:137:17:137:24 | config.y |
 | passwords.js:137:17:137:24 | config.y |
+| passwords.js:147:12:147:19 | password |
+| passwords.js:149:21:149:28 | config.x |
+| passwords.js:150:21:150:31 | process.env |
+| passwords.js:152:9:152:63 | procdesc |
+| passwords.js:152:20:152:44 | Util.in ... ss.env) |
+| passwords.js:152:20:152:63 | Util.in ... /g, '') |
+| passwords.js:152:33:152:43 | process.env |
+| passwords.js:154:21:154:28 | procdesc |
 | passwords_in_browser1.js:2:13:2:20 | password |
 | passwords_in_browser1.js:2:13:2:20 | password |
 | passwords_in_browser1.js:2:13:2:20 | password |
@@ -210,16 +218,11 @@ edges
 | passwords.js:131:12:131:24 | getPassword() | passwords.js:127:18:132:5 | {\\n      ... )\\n    } |
 | passwords.js:131:12:131:24 | getPassword() | passwords.js:127:18:132:5 | {\\n      ... )\\n    } |
 | passwords.js:131:12:131:24 | getPassword() | passwords.js:137:17:137:24 | config.y |
-| passwords.js:131:12:131:24 | getPassword() | passwords.js:137:17:137:24 | config.y |
-| passwords.js:131:12:131:24 | getPassword() | passwords.js:137:17:137:24 | config.y |
-| passwords.js:131:12:131:24 | getPassword() | passwords.js:137:17:137:24 | config.y |
-| passwords_in_browser1.js:2:13:2:20 | password | passwords_in_browser1.js:2:13:2:20 | password |
-| passwords_in_browser2.js:2:13:2:20 | password | passwords_in_browser2.js:2:13:2:20 | password |
-| passwords_in_server_1.js:6:13:6:20 | password | passwords_in_server_1.js:6:13:6:20 | password |
-| passwords_in_server_2.js:3:13:3:20 | password | passwords_in_server_2.js:3:13:3:20 | password |
-| passwords_in_server_3.js:2:13:2:20 | password | passwords_in_server_3.js:2:13:2:20 | password |
-| passwords_in_server_4.js:2:13:2:20 | password | passwords_in_server_4.js:2:13:2:20 | password |
-| passwords_in_server_5.js:4:7:4:24 | req.query.password | passwords_in_server_5.js:7:12:7:12 | x |
+| passwords.js:147:12:147:19 | password | passwords.js:149:21:149:28 | config.x |
+| passwords.js:152:9:152:63 | procdesc | passwords.js:154:21:154:28 | procdesc |
+| passwords.js:152:20:152:44 | Util.in ... ss.env) | passwords.js:152:20:152:63 | Util.in ... /g, '') |
+| passwords.js:152:20:152:63 | Util.in ... /g, '') | passwords.js:152:9:152:63 | procdesc |
+| passwords.js:152:33:152:43 | process.env | passwords.js:152:20:152:44 | Util.in ... ss.env) |
 | passwords_in_server_5.js:4:7:4:24 | req.query.password | passwords_in_server_5.js:7:12:7:12 | x |
 | passwords_in_server_5.js:7:12:7:12 | x | passwords_in_server_5.js:8:17:8:17 | x |
 | passwords_in_server_5.js:7:12:7:12 | x | passwords_in_server_5.js:8:17:8:17 | x |
@@ -250,6 +253,9 @@ edges
 | passwords.js:135:17:135:22 | config | passwords.js:131:12:131:24 | getPassword() | passwords.js:135:17:135:22 | config | Sensitive data returned by $@ is logged here. | passwords.js:131:12:131:24 | getPassword() | a call to getPassword |
 | passwords.js:136:17:136:24 | config.x | passwords.js:130:12:130:19 | password | passwords.js:136:17:136:24 | config.x | Sensitive data returned by $@ is logged here. | passwords.js:130:12:130:19 | password | an access to password |
 | passwords.js:137:17:137:24 | config.y | passwords.js:131:12:131:24 | getPassword() | passwords.js:137:17:137:24 | config.y | Sensitive data returned by $@ is logged here. | passwords.js:131:12:131:24 | getPassword() | a call to getPassword |
+| passwords.js:149:21:149:28 | config.x | passwords.js:147:12:147:19 | password | passwords.js:149:21:149:28 | config.x | Sensitive data returned by $@ is logged here. | passwords.js:147:12:147:19 | password | an access to password |
+| passwords.js:150:21:150:31 | process.env | passwords.js:150:21:150:31 | process.env | passwords.js:150:21:150:31 | process.env | Sensitive data returned by $@ is logged here. | passwords.js:150:21:150:31 | process.env | process environment |
+| passwords.js:154:21:154:28 | procdesc | passwords.js:152:33:152:43 | process.env | passwords.js:154:21:154:28 | procdesc | Sensitive data returned by $@ is logged here. | passwords.js:152:33:152:43 | process.env | process environment |
 | passwords_in_server_1.js:6:13:6:20 | password | passwords_in_server_1.js:6:13:6:20 | password | passwords_in_server_1.js:6:13:6:20 | password | Sensitive data returned by $@ is logged here. | passwords_in_server_1.js:6:13:6:20 | password | an access to password |
 | passwords_in_server_2.js:3:13:3:20 | password | passwords_in_server_2.js:3:13:3:20 | password | passwords_in_server_2.js:3:13:3:20 | password | Sensitive data returned by $@ is logged here. | passwords_in_server_2.js:3:13:3:20 | password | an access to password |
 | passwords_in_server_3.js:2:13:2:20 | password | passwords_in_server_3.js:2:13:2:20 | password | passwords_in_server_3.js:2:13:2:20 | password | Sensitive data returned by $@ is logged here. | passwords_in_server_3.js:2:13:2:20 | password | an access to password |

--- a/javascript/ql/test/query-tests/Security/CWE-312/CleartextLogging.expected
+++ b/javascript/ql/test/query-tests/Security/CWE-312/CleartextLogging.expected
@@ -105,16 +105,36 @@ nodes
 | passwords.js:137:17:137:24 | config.y |
 | passwords.js:137:17:137:24 | config.y |
 | passwords.js:142:26:142:34 | arguments |
+<<<<<<< HEAD
 | passwords.js:147:12:147:19 | password |
 | passwords.js:149:21:149:28 | config.x |
 | passwords.js:150:21:150:31 | process.env |
+=======
+| passwords.js:142:26:142:34 | arguments |
+| passwords.js:147:12:147:19 | password |
+| passwords.js:147:12:147:19 | password |
+| passwords.js:149:21:149:28 | config.x |
+| passwords.js:150:21:150:31 | process.env |
+| passwords.js:150:21:150:31 | process.env |
+>>>>>>> remove type cast, and fix expected test results
 | passwords.js:152:9:152:63 | procdesc |
 | passwords.js:152:20:152:44 | Util.in ... ss.env) |
 | passwords.js:152:20:152:63 | Util.in ... /g, '') |
 | passwords.js:152:33:152:43 | process.env |
+<<<<<<< HEAD
 | passwords.js:154:21:154:28 | procdesc |
 | passwords.js:156:17:156:27 | process.env |
 | passwords.js:158:17:158:27 | process.env |
+=======
+| passwords.js:152:33:152:43 | process.env |
+| passwords.js:154:21:154:28 | procdesc |
+| passwords.js:156:17:156:27 | process.env |
+| passwords.js:156:17:156:27 | process.env |
+| passwords.js:156:17:156:27 | process.env |
+| passwords.js:158:17:158:27 | process.env |
+| passwords.js:158:17:158:27 | process.env |
+| passwords.js:158:17:158:42 | process ...  "bar"] |
+>>>>>>> remove type cast, and fix expected test results
 | passwords.js:158:17:158:42 | process ...  "bar"] |
 | passwords_in_browser1.js:2:13:2:20 | password |
 | passwords_in_browser1.js:2:13:2:20 | password |
@@ -215,6 +235,7 @@ edges
 | passwords.js:127:9:132:5 | config | passwords.js:135:17:135:22 | config |
 | passwords.js:127:9:132:5 | config | passwords.js:135:17:135:22 | config |
 | passwords.js:127:9:132:5 | config | passwords.js:135:17:135:22 | config |
+| passwords.js:127:9:132:5 | config | passwords.js:135:17:135:22 | config |
 | passwords.js:127:18:132:5 | {\\n      ... )\\n    } | passwords.js:127:9:132:5 | config |
 | passwords.js:127:18:132:5 | {\\n      ... )\\n    } | passwords.js:127:9:132:5 | config |
 | passwords.js:127:18:132:5 | {\\n      ... )\\n    } | passwords.js:127:9:132:5 | config |
@@ -230,12 +251,38 @@ edges
 | passwords.js:147:12:147:19 | password | passwords.js:149:21:149:28 | config.x |
 | passwords.js:149:21:149:28 | config.x | passwords.js:142:26:142:34 | arguments |
 | passwords.js:150:21:150:31 | process.env | passwords.js:142:26:142:34 | arguments |
+| passwords.js:131:12:131:24 | getPassword() | passwords.js:137:17:137:24 | config.y |
+| passwords.js:131:12:131:24 | getPassword() | passwords.js:137:17:137:24 | config.y |
+| passwords.js:131:12:131:24 | getPassword() | passwords.js:137:17:137:24 | config.y |
+| passwords.js:147:12:147:19 | password | passwords.js:149:21:149:28 | config.x |
+| passwords.js:147:12:147:19 | password | passwords.js:149:21:149:28 | config.x |
+| passwords.js:149:21:149:28 | config.x | passwords.js:142:26:142:34 | arguments |
+| passwords.js:149:21:149:28 | config.x | passwords.js:142:26:142:34 | arguments |
+| passwords.js:150:21:150:31 | process.env | passwords.js:142:26:142:34 | arguments |
+| passwords.js:150:21:150:31 | process.env | passwords.js:142:26:142:34 | arguments |
+| passwords.js:150:21:150:31 | process.env | passwords.js:142:26:142:34 | arguments |
+| passwords.js:150:21:150:31 | process.env | passwords.js:142:26:142:34 | arguments |
 | passwords.js:152:9:152:63 | procdesc | passwords.js:154:21:154:28 | procdesc |
 | passwords.js:152:20:152:44 | Util.in ... ss.env) | passwords.js:152:20:152:63 | Util.in ... /g, '') |
 | passwords.js:152:20:152:63 | Util.in ... /g, '') | passwords.js:152:9:152:63 | procdesc |
 | passwords.js:152:33:152:43 | process.env | passwords.js:152:20:152:44 | Util.in ... ss.env) |
 | passwords.js:154:21:154:28 | procdesc | passwords.js:142:26:142:34 | arguments |
 | passwords.js:158:17:158:27 | process.env | passwords.js:158:17:158:42 | process ...  "bar"] |
+| passwords.js:152:33:152:43 | process.env | passwords.js:152:20:152:44 | Util.in ... ss.env) |
+| passwords.js:154:21:154:28 | procdesc | passwords.js:142:26:142:34 | arguments |
+| passwords.js:154:21:154:28 | procdesc | passwords.js:142:26:142:34 | arguments |
+| passwords.js:156:17:156:27 | process.env | passwords.js:156:17:156:27 | process.env |
+| passwords.js:158:17:158:27 | process.env | passwords.js:158:17:158:42 | process ...  "bar"] |
+| passwords.js:158:17:158:27 | process.env | passwords.js:158:17:158:42 | process ...  "bar"] |
+| passwords.js:158:17:158:27 | process.env | passwords.js:158:17:158:42 | process ...  "bar"] |
+| passwords.js:158:17:158:27 | process.env | passwords.js:158:17:158:42 | process ...  "bar"] |
+| passwords_in_browser1.js:2:13:2:20 | password | passwords_in_browser1.js:2:13:2:20 | password |
+| passwords_in_browser2.js:2:13:2:20 | password | passwords_in_browser2.js:2:13:2:20 | password |
+| passwords_in_server_1.js:6:13:6:20 | password | passwords_in_server_1.js:6:13:6:20 | password |
+| passwords_in_server_2.js:3:13:3:20 | password | passwords_in_server_2.js:3:13:3:20 | password |
+| passwords_in_server_3.js:2:13:2:20 | password | passwords_in_server_3.js:2:13:2:20 | password |
+| passwords_in_server_4.js:2:13:2:20 | password | passwords_in_server_4.js:2:13:2:20 | password |
+| passwords_in_server_5.js:4:7:4:24 | req.query.password | passwords_in_server_5.js:7:12:7:12 | x |
 | passwords_in_server_5.js:4:7:4:24 | req.query.password | passwords_in_server_5.js:7:12:7:12 | x |
 | passwords_in_server_5.js:7:12:7:12 | x | passwords_in_server_5.js:8:17:8:17 | x |
 | passwords_in_server_5.js:7:12:7:12 | x | passwords_in_server_5.js:8:17:8:17 | x |

--- a/javascript/ql/test/query-tests/Security/CWE-312/CleartextLogging.expected
+++ b/javascript/ql/test/query-tests/Security/CWE-312/CleartextLogging.expected
@@ -89,12 +89,15 @@ nodes
 | passwords.js:123:31:123:38 | password |
 | passwords.js:123:31:123:48 | password.valueOf() |
 | passwords.js:127:9:132:5 | config |
+| passwords.js:127:9:132:5 | config |
+| passwords.js:127:18:132:5 | {\\n      ... )\\n    } |
 | passwords.js:127:18:132:5 | {\\n      ... )\\n    } |
 | passwords.js:127:18:132:5 | {\\n      ... )\\n    } |
 | passwords.js:130:12:130:19 | password |
 | passwords.js:130:12:130:19 | password |
 | passwords.js:131:12:131:24 | getPassword() |
 | passwords.js:131:12:131:24 | getPassword() |
+| passwords.js:135:17:135:22 | config |
 | passwords.js:135:17:135:22 | config |
 | passwords.js:135:17:135:22 | config |
 | passwords.js:136:17:136:24 | config.x |
@@ -111,6 +114,8 @@ nodes
 | passwords.js:152:33:152:43 | process.env |
 | passwords.js:154:21:154:28 | procdesc |
 | passwords.js:156:17:156:27 | process.env |
+| passwords.js:157:17:157:27 | process.env |
+| passwords.js:157:17:157:32 | process.env.PATH |
 | passwords_in_browser1.js:2:13:2:20 | password |
 | passwords_in_browser1.js:2:13:2:20 | password |
 | passwords_in_browser1.js:2:13:2:20 | password |
@@ -209,6 +214,8 @@ edges
 | passwords.js:123:31:123:48 | password.valueOf() | passwords.js:123:17:123:48 | name +  ... lueOf() |
 | passwords.js:127:9:132:5 | config | passwords.js:135:17:135:22 | config |
 | passwords.js:127:9:132:5 | config | passwords.js:135:17:135:22 | config |
+| passwords.js:127:9:132:5 | config | passwords.js:135:17:135:22 | config |
+| passwords.js:127:18:132:5 | {\\n      ... )\\n    } | passwords.js:127:9:132:5 | config |
 | passwords.js:127:18:132:5 | {\\n      ... )\\n    } | passwords.js:127:9:132:5 | config |
 | passwords.js:127:18:132:5 | {\\n      ... )\\n    } | passwords.js:127:9:132:5 | config |
 | passwords.js:130:12:130:19 | password | passwords.js:127:18:132:5 | {\\n      ... )\\n    } |
@@ -228,6 +235,7 @@ edges
 | passwords.js:152:20:152:63 | Util.in ... /g, '') | passwords.js:152:9:152:63 | procdesc |
 | passwords.js:152:33:152:43 | process.env | passwords.js:152:20:152:44 | Util.in ... ss.env) |
 | passwords.js:154:21:154:28 | procdesc | passwords.js:142:26:142:34 | arguments |
+| passwords.js:157:17:157:27 | process.env | passwords.js:157:17:157:32 | process.env.PATH |
 | passwords_in_server_5.js:4:7:4:24 | req.query.password | passwords_in_server_5.js:7:12:7:12 | x |
 | passwords_in_server_5.js:7:12:7:12 | x | passwords_in_server_5.js:8:17:8:17 | x |
 | passwords_in_server_5.js:7:12:7:12 | x | passwords_in_server_5.js:8:17:8:17 | x |
@@ -262,6 +270,7 @@ edges
 | passwords.js:142:26:142:34 | arguments | passwords.js:150:21:150:31 | process.env | passwords.js:142:26:142:34 | arguments | Sensitive data returned by $@ is logged here. | passwords.js:150:21:150:31 | process.env | process environment |
 | passwords.js:142:26:142:34 | arguments | passwords.js:152:33:152:43 | process.env | passwords.js:142:26:142:34 | arguments | Sensitive data returned by $@ is logged here. | passwords.js:152:33:152:43 | process.env | process environment |
 | passwords.js:156:17:156:27 | process.env | passwords.js:156:17:156:27 | process.env | passwords.js:156:17:156:27 | process.env | Sensitive data returned by $@ is logged here. | passwords.js:156:17:156:27 | process.env | process environment |
+| passwords.js:157:17:157:32 | process.env.PATH | passwords.js:157:17:157:27 | process.env | passwords.js:157:17:157:32 | process.env.PATH | Sensitive data returned by $@ is logged here. | passwords.js:157:17:157:27 | process.env | process environment |
 | passwords_in_server_1.js:6:13:6:20 | password | passwords_in_server_1.js:6:13:6:20 | password | passwords_in_server_1.js:6:13:6:20 | password | Sensitive data returned by $@ is logged here. | passwords_in_server_1.js:6:13:6:20 | password | an access to password |
 | passwords_in_server_2.js:3:13:3:20 | password | passwords_in_server_2.js:3:13:3:20 | password | passwords_in_server_2.js:3:13:3:20 | password | Sensitive data returned by $@ is logged here. | passwords_in_server_2.js:3:13:3:20 | password | an access to password |
 | passwords_in_server_3.js:2:13:2:20 | password | passwords_in_server_3.js:2:13:2:20 | password | passwords_in_server_3.js:2:13:2:20 | password | Sensitive data returned by $@ is logged here. | passwords_in_server_3.js:2:13:2:20 | password | an access to password |

--- a/javascript/ql/test/query-tests/Security/CWE-312/passwords.js
+++ b/javascript/ql/test/query-tests/Security/CWE-312/passwords.js
@@ -155,5 +155,5 @@ var Util = require('util');
 
     console.log(process.env); // NOT OK
     console.log(process.env.PATH); // OK.
-    console.log(process.env["foo" + "bar"]); // NOT OK.
+    console.log(process.env["foo" + "bar"]); // OK.
 });

--- a/javascript/ql/test/query-tests/Security/CWE-312/passwords.js
+++ b/javascript/ql/test/query-tests/Security/CWE-312/passwords.js
@@ -152,4 +152,7 @@ var Util = require('util');
     var procdesc = Util.inspect(process.env).replace(/\n/g, '')
 
     indirectLogCall(procdesc); // NOT OK
+
+    console.log(process.env); // NOT OK
+    console.log(process.env.PATH); // <- Should be marked, but isn't. Hopefully fixed when introducing flow-labels.
 });

--- a/javascript/ql/test/query-tests/Security/CWE-312/passwords.js
+++ b/javascript/ql/test/query-tests/Security/CWE-312/passwords.js
@@ -137,3 +137,19 @@
     console.log(config.y); // NOT OK
     console.log(config[x]); // OK (probably)
 });
+
+function indirectLogCall() {
+	console.log.apply(this, arguments);
+}
+var Util = require('util');
+(function() {
+    var config = {
+        x: password
+    };
+    indirectLogCall(config.x); // NOT OK
+    indirectLogCall(process.env); // NOT OK
+
+    var procdesc = Util.inspect(process.env).replace(/\n/g, '')
+
+    indirectLogCall(procdesc); // NOT OK
+});

--- a/javascript/ql/test/query-tests/Security/CWE-312/passwords.js
+++ b/javascript/ql/test/query-tests/Security/CWE-312/passwords.js
@@ -154,5 +154,6 @@ var Util = require('util');
     indirectLogCall(procdesc); // NOT OK
 
     console.log(process.env); // NOT OK
-    console.log(process.env.PATH); // NOT OK.
+    console.log(process.env.PATH); // OK.
+    console.log(process.env["foo" + "bar"]); // NOT OK.
 });

--- a/javascript/ql/test/query-tests/Security/CWE-312/passwords.js
+++ b/javascript/ql/test/query-tests/Security/CWE-312/passwords.js
@@ -154,5 +154,5 @@ var Util = require('util');
     indirectLogCall(procdesc); // NOT OK
 
     console.log(process.env); // NOT OK
-    console.log(process.env.PATH); // <- Should be marked, but isn't. Hopefully fixed when introducing flow-labels.
+    console.log(process.env.PATH); // NOT OK.
 });

--- a/javascript/ql/test/query-tests/Security/CWE-312/passwords.js
+++ b/javascript/ql/test/query-tests/Security/CWE-312/passwords.js
@@ -157,3 +157,9 @@ var Util = require('util');
     console.log(process.env.PATH); // OK.
     console.log(process.env["foo" + "bar"]); // OK.
 });
+
+(function () {
+	console.log(password.replace(/./g, "*")); // OK!
+	console.log(password.replace(/\./g, "*")); // NOT OK!
+	console.log(password.replace(/foo/g, "*")); // NOT OK!
+})();


### PR DESCRIPTION
Now the query is able to detect this CVE: https://snyk.io/vuln/SNYK-JS-SENECA-460597

The [fix commit](https://github.com/senecajs/seneca/commit/b0565ba52048b83783186876cec23dd3f851e9ff) is still marked by the query. 

I've found no new results other than the above (but I haven't used the Chris API). 

I've added the extra taint-steps directly into the `Configuration` as it is a dataflow tracking configuration and not a taint tracking configuration. (Changing the configuration to use taint tracking causes way to much to be marked in the tests). 

Performance on a in-progress version was great, and I'm currently running dist-compare on this version. 