### PR TITLE
C#: Add `-L` flag to autobuilder `curl` invocation

### DIFF
--- a/csharp/autobuilder/Semmle.Autobuild.Tests/BuildScripts.cs
+++ b/csharp/autobuilder/Semmle.Autobuild.Tests/BuildScripts.cs
@@ -902,7 +902,7 @@ namespace Semmle.Extraction.Tests
         {
             Actions.RunProcess["dotnet --list-sdks"] = 0;
             Actions.RunProcessOut["dotnet --list-sdks"] = "2.1.2 [C:\\Program Files\\dotnet\\sdks]\n2.1.4 [C:\\Program Files\\dotnet\\sdks]";
-            Actions.RunProcess[@"curl -sO https://dot.net/v1/dotnet-install.sh"] = 0;
+            Actions.RunProcess[@"curl -L -sO https://dot.net/v1/dotnet-install.sh"] = 0;
             Actions.RunProcess[@"chmod u+x dotnet-install.sh"] = 0;
             Actions.RunProcess[@"./dotnet-install.sh --channel release --version 2.1.3 --install-dir C:\Project/.dotnet"] = 0;
             Actions.RunProcess[@"rm dotnet-install.sh"] = 0;
@@ -938,7 +938,7 @@ namespace Semmle.Extraction.Tests
         {
             Actions.RunProcess["dotnet --list-sdks"] = 0;
             Actions.RunProcessOut["dotnet --list-sdks"] = "2.1.3 [C:\\Program Files\\dotnet\\sdks]\n2.1.4 [C:\\Program Files\\dotnet\\sdks]";
-            Actions.RunProcess[@"curl -sO https://dot.net/v1/dotnet-install.sh"] = 0;
+            Actions.RunProcess[@"curl -L -sO https://dot.net/v1/dotnet-install.sh"] = 0;
             Actions.RunProcess[@"chmod u+x dotnet-install.sh"] = 0;
             Actions.RunProcess[@"./dotnet-install.sh --channel release --version 2.1.3 --install-dir C:\Project/.dotnet"] = 0;
             Actions.RunProcess[@"rm dotnet-install.sh"] = 0;

--- a/csharp/autobuilder/Semmle.Autobuild/DotNetRule.cs
+++ b/csharp/autobuilder/Semmle.Autobuild/DotNetRule.cs
@@ -196,6 +196,7 @@ Invoke-Command -ScriptBlock $ScriptBlock";
                     {
                         var curl = new CommandBuilder(builder.Actions).
                             RunCommand("curl").
+                            Argument("-L").
                             Argument("-sO").
                             Argument("https://dot.net/v1/dotnet-install.sh");
 


### PR DESCRIPTION
Turns out that `https://dot.net/v1/dotnet-install.sh` has moved to `https://dotnet.microsoft.com/download/dotnet-core/scripts/v1/dotnet-install.sh`.
Instead of updating the URL in the code, I prefer to keep the old URL (which is still referenced in the documentation), and let `curl` handle the redirect.