### PR TITLE
JS: Generalize global access paths to include local ones

### DIFF
--- a/javascript/ql/src/semmle/javascript/Closure.qll
+++ b/javascript/ql/src/semmle/javascript/Closure.qll
@@ -230,7 +230,7 @@ module Closure {
    * Gets the closure namespace path addressed by the given data flow node, if any.
    */
   string getClosureNamespaceFromSourceNode(DataFlow::SourceNode node) {
-    result = GlobalAccessPath::getAccessPath(node) and
+    node = AccessPath::getAReferenceOrAssignmentTo(result) and
     hasClosureNamespacePrefix(result)
   }
 
@@ -238,7 +238,7 @@ module Closure {
    * Gets the closure namespace path written to by the given property write, if any.
    */
   string getWrittenClosureNamespace(DataFlow::PropWrite node) {
-    result = GlobalAccessPath::fromRhs(node.getRhs()) and
+    node.getRhs() = AccessPath::getAnAssignmentTo(result) and
     hasClosureNamespacePrefix(result)
   }
 

--- a/javascript/ql/src/semmle/javascript/GlobalAccessPaths.qll
+++ b/javascript/ql/src/semmle/javascript/GlobalAccessPaths.qll
@@ -184,13 +184,13 @@ module GlobalAccessPath {
    */
   cached
   string fromRhs(DataFlow::Node node, Root root) {
-    exists(DataFlow::SourceNode base, string baseName, string name |
-      node = base.getAPropertyWrite(name).getRhs() and
-      result = baseName + "." + name
+    exists(DataFlow::PropWrite write, string baseName |
+      node = write.getRhs() and
+      result = baseName + "." + write.getPropertyName()
     |
-      baseName = fromReference(base, root)
+      baseName = fromReference(write.getBase(), root)
       or
-      baseName = fromRhs(base, root)
+      baseName = fromRhs(write.getBase(), root)
     )
     or
     exists(GlobalVariable var |

--- a/javascript/ql/src/semmle/javascript/GlobalAccessPaths.qll
+++ b/javascript/ql/src/semmle/javascript/GlobalAccessPaths.qll
@@ -165,7 +165,7 @@ module AccessPath {
   }
 
   /**
-   * Holds if there is an assignment to `accessPath` in `file`, not counting
+   * Holds if there is an assignment to the global `accessPath` in `file`, not counting
    * self-assignments.
    */
   private predicate isAssignedInFile(string accessPath, File file) {

--- a/javascript/ql/src/semmle/javascript/JSDoc.qll
+++ b/javascript/ql/src/semmle/javascript/JSDoc.qll
@@ -582,7 +582,7 @@ module JSDoc {
      * within this container.
      */
     string resolveAlias(string alias) {
-      result = GlobalAccessPath::getAccessPath(getNodeFromAlias(alias))
+      getNodeFromAlias(alias) = AccessPath::getAReferenceOrAssignmentTo(result)
     }
 
     /**

--- a/javascript/ql/src/semmle/javascript/dataflow/Nodes.qll
+++ b/javascript/ql/src/semmle/javascript/dataflow/Nodes.qll
@@ -965,7 +965,7 @@ module ClassNode {
       )
       or
       exists(string name |
-        GlobalAccessPath::fromRhs(this) = name and
+        this = AccessPath::getAnAssignmentTo(name) and
         result = getAPrototypeReferenceInFile(name, getFile())
       )
       or

--- a/javascript/ql/src/semmle/javascript/dataflow/Nodes.qll
+++ b/javascript/ql/src/semmle/javascript/dataflow/Nodes.qll
@@ -771,11 +771,7 @@ class ClassNode extends DataFlow::SourceNode {
    */
   pragma[noinline]
   predicate hasQualifiedName(string name) {
-    exists(DataFlow::Node rhs |
-      getAClassReference().flowsTo(rhs) and
-      name = GlobalAccessPath::fromRhs(rhs) and
-      GlobalAccessPath::isAssignedInUniqueFile(name)
-    )
+    getAClassReference().flowsTo(AccessPath::getAnAssignmentTo(name))
   }
 }
 
@@ -883,7 +879,7 @@ module ClassNode {
   }
 
   private DataFlow::PropRef getAPrototypeReferenceInFile(string name, File f) {
-    GlobalAccessPath::getAccessPath(result.getBase()) = name and
+    result.getBase() = AccessPath::getAReferenceOrAssignmentTo(name) and
     result.getPropertyName() = "prototype" and
     result.getFile() = f
   }
@@ -904,7 +900,7 @@ module ClassNode {
         )
         or
         exists(string name |
-          name = GlobalAccessPath::fromRhs(this) and
+          this = AccessPath::getAnAssignmentTo(name) and
           exists(getAPrototypeReferenceInFile(name, getFile()))
         )
       )

--- a/javascript/ql/src/semmle/javascript/dataflow/TypeTracking.qll
+++ b/javascript/ql/src/semmle/javascript/dataflow/TypeTracking.qll
@@ -13,10 +13,9 @@ private class PropertyName extends string {
   PropertyName() {
     this = any(DataFlow::PropRef pr).getPropertyName()
     or
-    GlobalAccessPath::isAssignedInUniqueFile(this)
+    AccessPath::isAssignedInUniqueFile(this)
     or
-    this = GlobalAccessPath::fromRhs(_, _) and
-    this != ""
+    exists(AccessPath::getAnAssignmentTo(_, this))
   }
 }
 
@@ -100,31 +99,29 @@ module StepSummary {
     or
     // Store to global access path
     exists(string name |
-      name = GlobalAccessPath::fromRhs(pred) and
-      GlobalAccessPath::isAssignedInUniqueFile(name) and
+      pred = AccessPath::getAnAssignmentTo(name) and
+      AccessPath::isAssignedInUniqueFile(name) and
       succ = DataFlow::globalAccessPathRootPseudoNode() and
       summary = StoreStep(name)
     )
     or
     // Load from global access path
     exists(string name |
-      name = GlobalAccessPath::fromReference(succ) and
-      GlobalAccessPath::isAssignedInUniqueFile(name) and
+      succ = AccessPath::getAReferenceTo(name) and
+      AccessPath::isAssignedInUniqueFile(name) and
       pred = DataFlow::globalAccessPathRootPseudoNode() and
       summary = LoadStep(name)
     )
     or
     // Store to non-global access path
     exists(string name |
-      name = GlobalAccessPath::fromRhs(pred, succ) and
-      succ != DataFlow::globalAccessPathRootPseudoNode() and
+      pred = AccessPath::getAnAssignmentTo(succ, name) and
       summary = StoreStep(name)
     )
     or
     // Load from non-global access path
     exists(string name |
-      name = GlobalAccessPath::fromReference(succ, pred) and
-      pred != DataFlow::globalAccessPathRootPseudoNode() and
+      succ = AccessPath::getAReferenceTo(pred, name) and
       summary = LoadStep(name) and
       name != ""
     )

--- a/javascript/ql/src/semmle/javascript/dataflow/internal/CallGraphs.qll
+++ b/javascript/ql/src/semmle/javascript/dataflow/internal/CallGraphs.qll
@@ -43,7 +43,7 @@ module CallGraph {
     or
     imprecision = 0 and
     t.start() and
-    GlobalAccessPath::step(function, result)
+    AccessPath::step(function, result)
     or
     imprecision = 0 and
     exists(DataFlow::ClassNode cls |

--- a/javascript/ql/src/semmle/javascript/dataflow/internal/CallGraphs.qll
+++ b/javascript/ql/src/semmle/javascript/dataflow/internal/CallGraphs.qll
@@ -43,11 +43,7 @@ module CallGraph {
     or
     imprecision = 0 and
     t.start() and
-    exists(string name |
-      GlobalAccessPath::isAssignedInUniqueFile(name) and
-      GlobalAccessPath::fromRhs(function) = name and
-      GlobalAccessPath::fromReference(result) = name
-    )
+    GlobalAccessPath::step(function, result)
     or
     imprecision = 0 and
     exists(DataFlow::ClassNode cls |

--- a/javascript/ql/test/library-tests/CallGraphs/AnnotatedTest/access-path.js
+++ b/javascript/ql/test/library-tests/CallGraphs/AnnotatedTest/access-path.js
@@ -1,0 +1,39 @@
+function foo() {
+  let self = this;
+
+  /** name:direct */
+  self.foo.bar.direct = function() {};
+
+  /** calls:direct */
+  self.foo.bar.direct();
+
+  self.foo.bar = {
+    /** name:baz */
+    baz() {},
+    bong() {
+      /** calls:baz */
+      self.foo.bar.baz();
+    }
+  }
+
+  /** calls:baz */
+  self.foo.bar.baz();
+
+  self.foo.bar.Class = class {
+    /** name:m */
+    m() {}
+  }
+
+  self.foo.bar.instance = new self.foo.bar.Class();
+
+  /** calls:m */
+  self.foo.bar.instance.m();
+
+  let unknownObject = unknownCall();
+
+  /** name:direct2 */
+  unknownObject.bar.baz.direct = function() {};
+
+  /** calls:direct2 */
+  unknownObject.bar.baz.direct();
+}

--- a/javascript/ql/test/library-tests/GlobalAccessPaths/GlobalAccessPaths.expected
+++ b/javascript/ql/test/library-tests/GlobalAccessPaths/GlobalAccessPaths.expected
@@ -1,4 +1,4 @@
-test_fromReference
+test_getAReferenceTo
 | other_ns.js:2:11:2:12 | ns | NS |
 | other_ns.js:3:3:3:4 | ns | NS |
 | other_ns.js:3:3:3:8 | ns.foo | NS.foo |
@@ -39,6 +39,7 @@ test_fromReference
 | test.js:12:19:12:25 | foo.bar | foo.bar |
 | test.js:13:7:13:15 | something | something |
 | test.js:14:5:14:23 | notUnique | bar.baz |
+| test.js:14:5:14:23 | notUnique = bar.baz | bar.baz |
 | test.js:14:17:14:19 | bar | bar |
 | test.js:14:17:14:23 | bar.baz | bar.baz |
 | test.js:22:11:22:12 | ns | NS |
@@ -54,10 +55,11 @@ test_fromReference
 | test.js:33:9:33:16 | bar = {} | foo.bar |
 | test.js:33:22:33:24 | foo | foo |
 | test.js:39:3:39:20 | lazyInit | foo.bar |
+| test.js:39:3:39:20 | lazyInit = foo.bar | foo.bar |
 | test.js:39:14:39:16 | foo | foo |
 | test.js:39:14:39:20 | foo.bar | foo.bar |
 | test.js:40:3:40:10 | lazyInit | foo.bar |
-test_fromRhs
+test_getAnAssignmentTo
 | other_ns.js:4:9:4:16 | NS \|\| {} | NS |
 | other_ns.js:6:12:6:13 | {} | Conflict |
 | test.js:1:1:20:1 | functio ... ss {}\\n} | f |

--- a/javascript/ql/test/library-tests/GlobalAccessPaths/GlobalAccessPaths.ql
+++ b/javascript/ql/test/library-tests/GlobalAccessPaths/GlobalAccessPaths.ql
@@ -1,9 +1,11 @@
 import javascript
 
-query string test_fromReference(DataFlow::Node node) {
-  result = GlobalAccessPath::fromReference(node)
+query string test_getAReferenceTo(DataFlow::Node node) {
+  node = AccessPath::getAReferenceTo(result)
 }
 
-query string test_fromRhs(DataFlow::Node node) { result = GlobalAccessPath::fromRhs(node) }
+query string test_getAnAssignmentTo(DataFlow::Node node) {
+  node = AccessPath::getAnAssignmentTo(result)
+}
 
-query string test_assignedUnique() { GlobalAccessPath::isAssignedInUniqueFile(result) }
+query string test_assignedUnique() { AccessPath::isAssignedInUniqueFile(result) }


### PR DESCRIPTION
Renames the `GlobalAccessPath` module to `AccessPath` and generalizes it to deal with access paths relative to a given `SourceNode` root.

The predicates `GlobalAccessPath::{fromReference,fromRhs}` are helpful internally, but felt clunky as part of the public API so we now expose `AccessPath::{getAReferenceTo,getAnAssignmentTo}` instead.

Type tracking can step through these access paths. This is modelled as store/loads edges that step into/out of the root node using the whole access path as if it was a single property name.

This means we treat `x.foo.bar` and `x["foo.bar"]` as the same thing, which is a bit sleazy but probably fine for type tracking purposes. We could tag the strings to avoid this potential clash if we're willing to pay the overhead.

There is a modest [performance cost](https://git.semmle.com/asger/dist-compare-reports/tree/access-paths-with-source-node-root_1572313952849) and an equally modest number of [new call edges](https://git.semmle.com/asger/dist-compare-reports/tree/access-paths-with-source-node-root_1572296803306).