### PR TITLE
C++: Use getASTVariable in DefaultTaintTracking

### DIFF
--- a/cpp/ql/src/semmle/code/cpp/ir/dataflow/DefaultTaintTracking.qll
+++ b/cpp/ql/src/semmle/code/cpp/ir/dataflow/DefaultTaintTracking.qll
@@ -37,7 +37,7 @@ private class DefaultTaintTrackingCfg extends DataFlow::Configuration {
 }
 
 private predicate accessesVariable(CopyInstruction copy, Variable var) {
-  exists(VariableAddressInstruction va | va.getVariable().getAST() = var |
+  exists(VariableAddressInstruction va | va.getASTVariable() = var |
     copy.(StoreInstruction).getDestinationAddress() = va
     or
     copy.(LoadInstruction).getSourceAddress() = va


### PR DESCRIPTION
This library is not yet used in a query or test, so it broke silently when `VariableAddressInstruction.getVariable` was removed in #2082.