### PR TITLE
CPP: Fully support n$ in format strings

### DIFF
--- a/change-notes/1.23/analysis-cpp.md
+++ b/change-notes/1.23/analysis-cpp.md
@@ -25,6 +25,7 @@ The following changes in version 1.23 affect C/C++ analysis in all applications.
 | Unclear comparison precedence (`cpp/comparison-precedence`) | Fewer false positive results | False positives involving template classes and functions have been fixed. |
 | Comparison of narrow type with wide type in loop condition (`cpp/comparison-with-wider-type`) | Higher precision | The precision of this query has been increased to "high" as the alerts from this query have proved to be valuable on real-world projects. With this precision, results are now displayed by default in LGTM. |
 | Non-constant format string (`cpp/non-constant-format`) | Fewer false positive results | Fixed false positives resulting from mistmatching declarations of a formatting function. |
+| Wrong type of arguments to formatting function (`cpp/wrong-type-format-argument`) | More correct results and fewer false positive results | This query now understands explicitly specified argument numbers in format strings, such as the `1$` in `%1$s`. |
 
 ## Changes to libraries
 

--- a/cpp/ql/src/semmle/code/cpp/commons/Printf.qll
+++ b/cpp/ql/src/semmle/code/cpp/commons/Printf.qll
@@ -800,21 +800,24 @@ class FormatLiteral extends Literal {
   int getFormatArgumentIndexFor(int n, int mode) {
     hasFormatArgumentIndexFor(n, mode) and
     result = count(int n2, int mode2 |
-      hasFormatArgumentIndexFor(n2, mode2) and
-      (
-        n2 < n
-        or
-        n2 = n and
-        mode2 < mode
+        hasFormatArgumentIndexFor(n2, mode2) and
+        (
+          n2 < n
+          or
+          n2 = n and
+          mode2 < mode
+        )
       )
-    )
   }
 
   /**
    * Gets the number of arguments required by the nth conversion specifier
    * of this format string.
+   *
+   * DEPRECATED.  This was a helper function for `getNumArgNeeded` and is no
+   * longer required.
    */
-  int getNumArgNeeded(int n) {
+  deprecated int getNumArgNeeded(int n) {
     exists(this.getConvSpecOffset(n)) and
     result = count(int mode | hasFormatArgumentIndexFor(n, mode))
   }
@@ -828,7 +831,7 @@ class FormatLiteral extends Literal {
       // At least one conversion specifier has a parameter field, in which case,
       // they all should have.
       result = max(string s | this.getParameterField(_) = s + "$" | s.toInt())
-    else result = sum(int n, int toSum | toSum = this.getNumArgNeeded(n) | toSum)
+    else result = count(int n, int mode | hasFormatArgumentIndexFor(n, mode))
   }
 
   /**

--- a/cpp/ql/src/semmle/code/cpp/commons/Printf.qll
+++ b/cpp/ql/src/semmle/code/cpp/commons/Printf.qll
@@ -844,14 +844,10 @@ class FormatLiteral extends Literal {
    */
   int getFormatArgumentIndexFor(int n, int mode) {
     hasFormatArgumentIndexFor(n, mode) and
-    result = count(int n2, int mode2 |
-        hasFormatArgumentIndexFor(n2, mode2) and
-        (
-          n2 < n
-          or
-          n2 = n and
-          mode2 < mode
-        )
+    (3 * n) + mode = rank[result + 1](int n2, int mode2 |
+        hasFormatArgumentIndexFor(n2, mode2)
+      |
+        (3 * n2) + mode2
       )
   }
 

--- a/cpp/ql/src/semmle/code/cpp/commons/Printf.qll
+++ b/cpp/ql/src/semmle/code/cpp/commons/Printf.qll
@@ -854,11 +854,8 @@ class FormatLiteral extends Literal {
   /**
    * Gets the number of arguments required by the nth conversion specifier
    * of this format string.
-   *
-   * DEPRECATED.  This was a helper function for `getNumArgNeeded` and is no
-   * longer required.
    */
-  deprecated int getNumArgNeeded(int n) {
+  int getNumArgNeeded(int n) {
     exists(this.getConvSpecOffset(n)) and
     result = count(int mode | hasFormatArgumentIndexFor(n, mode))
   }

--- a/cpp/ql/src/semmle/code/cpp/commons/Printf.qll
+++ b/cpp/ql/src/semmle/code/cpp/commons/Printf.qll
@@ -137,10 +137,10 @@ class FormattingFunctionCall extends Expr {
     exists(FormatLiteral fl |
       fl = this.getFormat() and
       (
-        result = this.getFormatArgument(fl.getParameterFieldPositional(n))
+        result = this.getFormatArgument(fl.getParameterFieldValue(n))
         or
         result = this.getFormatArgument(fl.getFormatArgumentIndexFor(n, 2)) and
-        not exists(fl.getParameterFieldPositional(n))
+        not exists(fl.getParameterFieldValue(n))
       )
     )
   }
@@ -154,10 +154,10 @@ class FormattingFunctionCall extends Expr {
     exists(FormatLiteral fl |
       fl = this.getFormat() and
       (
-        result = this.getFormatArgument(fl.getMinFieldWidthPositional(n))
+        result = this.getFormatArgument(fl.getMinFieldWidthParameterFieldValue(n))
         or
         result = this.getFormatArgument(fl.getFormatArgumentIndexFor(n, 0)) and
-        not exists(fl.getMinFieldWidthPositional(n))
+        not exists(fl.getMinFieldWidthParameterFieldValue(n))
       )
     )
   }
@@ -171,10 +171,10 @@ class FormattingFunctionCall extends Expr {
     exists(FormatLiteral fl |
       fl = this.getFormat() and
       (
-        result = this.getFormatArgument(fl.getPrecisionPositional(n))
+        result = this.getFormatArgument(fl.getPrecisionParameterFieldValue(n))
         or
         result = this.getFormatArgument(fl.getFormatArgumentIndexFor(n, 1)) and
-        not exists(fl.getPrecisionPositional(n))
+        not exists(fl.getPrecisionParameterFieldValue(n))
       )
     )
   }
@@ -379,7 +379,7 @@ class FormatLiteral extends Literal {
    * Gets the parameter field of the nth conversion specifier (if it has one) as a
    * zero-based number.
    */
-  int getParameterFieldPositional(int n) {
+  int getParameterFieldValue(int n) {
     result = this.getParameterField(n).regexpCapture("([0-9]*)\\$", 1).toInt() - 1
   }
 
@@ -454,9 +454,9 @@ class FormatLiteral extends Literal {
 
   /**
    * Gets the zero-based parameter number of the minimum field width of the nth
-   * conversion specifier, if it is implicit and uses a positional parameter.
+   * conversion specifier, if it is implicit and uses a parameter field (such as `*1$`).
    */
-  int getMinFieldWidthPositional(int n) {
+  int getMinFieldWidthParameterFieldValue(int n) {
     result = this.getMinFieldWidthOpt(n).regexpCapture("\\*([0-9]*)\\$", 1).toInt() - 1
   }
 
@@ -492,9 +492,9 @@ class FormatLiteral extends Literal {
 
   /**
    * Gets the zero-based parameter number of the precision of the nth conversion
-   * specifier, if it is implicit and uses a positional parameter.
+   * specifier, if it is implicit and uses a parameter field (such as `*1$`).
    */
-  int getPrecisionPositional(int n) {
+  int getPrecisionParameterFieldValue(int n) {
     result = this.getPrecisionOpt(n).regexpCapture("\\.\\*([0-9]*)\\$", 1).toInt() - 1
   }
 
@@ -837,8 +837,8 @@ class FormatLiteral extends Literal {
   }
 
   /**
-   * Gets the format argument index for the nth conversion specifier of this format
-   * string (if `mode = 2`), it's minimum field width (if `mode = 0`) or it's
+   * Gets the computed format argument index for the nth conversion specifier of this
+   * format string (if `mode = 2`), it's minimum field width (if `mode = 0`) or it's
    * precision (if `mode = 1`).  Has no result if that element is not present.  Does
    * not account for positional arguments (`$`).
    */

--- a/cpp/ql/test/query-tests/Likely Bugs/Format/WrongTypeFormatArguments/Linux_signed_chars/WrongTypeFormatArguments.expected
+++ b/cpp/ql/test/query-tests/Likely Bugs/Format/WrongTypeFormatArguments/Linux_signed_chars/WrongTypeFormatArguments.expected
@@ -16,8 +16,8 @@
 | printf1.h:114:18:114:18 | d | This argument should be of type 'long double' but is of type 'double' |
 | printf1.h:147:19:147:19 | i | This argument should be of type 'long long' but is of type 'int' |
 | printf1.h:148:19:148:20 | ui | This argument should be of type 'unsigned long long' but is of type 'unsigned int' |
-| printf1.h:159:18:159:18 | i | This argument should be of type 'char *' but is of type 'int' |
 | printf1.h:160:18:160:18 | i | This argument should be of type 'char *' but is of type 'int' |
+| printf1.h:161:21:161:21 | s | This argument should be of type 'int' but is of type 'char *' |
 | printf1.h:167:17:167:17 | i | This argument should be of type 'char *' but is of type 'int' |
 | printf1.h:168:18:168:18 | i | This argument should be of type 'char *' but is of type 'int' |
 | printf1.h:169:19:169:19 | i | This argument should be of type 'char *' but is of type 'int' |
@@ -35,18 +35,24 @@
 | printf1.h:192:19:192:19 | s | This argument should be of type 'int' but is of type 'char *' |
 | printf1.h:193:22:193:22 | s | This argument should be of type 'int' but is of type 'char *' |
 | printf1.h:194:25:194:25 | i | This argument should be of type 'char *' but is of type 'int' |
-| printf1.h:213:28:213:28 | s | This argument should be of type 'int' but is of type 'char *' |
+| printf1.h:198:24:198:24 | s | This argument should be of type 'int' but is of type 'char *' |
+| printf1.h:199:21:199:21 | i | This argument should be of type 'char *' but is of type 'int' |
+| printf1.h:202:26:202:26 | s | This argument should be of type 'int' but is of type 'char *' |
+| printf1.h:203:23:203:23 | i | This argument should be of type 'char *' but is of type 'int' |
+| printf1.h:206:25:206:25 | s | This argument should be of type 'int' but is of type 'char *' |
+| printf1.h:207:22:207:22 | i | This argument should be of type 'char *' but is of type 'int' |
+| printf1.h:210:26:210:26 | s | This argument should be of type 'int' but is of type 'char *' |
+| printf1.h:211:23:211:23 | i | This argument should be of type 'char *' but is of type 'int' |
 | printf1.h:214:28:214:28 | s | This argument should be of type 'int' but is of type 'char *' |
 | printf1.h:215:28:215:28 | s | This argument should be of type 'int' but is of type 'char *' |
-| printf1.h:216:28:216:28 | s | This argument should be of type 'int' but is of type 'char *' |
+| printf1.h:216:25:216:25 | i | This argument should be of type 'char *' but is of type 'int' |
 | printf1.h:221:18:221:18 | s | This argument should be of type 'int' but is of type 'char *' |
 | printf1.h:222:20:222:20 | s | This argument should be of type 'int' but is of type 'char *' |
-| printf1.h:233:22:233:22 | s | This argument should be of type 'int' but is of type 'char *' |
-| printf1.h:233:25:233:25 | i | This argument should be of type 'char *' but is of type 'int' |
-| printf1.h:234:22:234:22 | s | This argument should be of type 'int' but is of type 'char *' |
+| printf1.h:225:23:225:23 | i | This argument should be of type 'char *' but is of type 'int' |
+| printf1.h:228:24:228:24 | i | This argument should be of type 'char *' but is of type 'int' |
+| printf1.h:231:25:231:25 | i | This argument should be of type 'char *' but is of type 'int' |
 | printf1.h:234:25:234:25 | i | This argument should be of type 'char *' but is of type 'int' |
 | printf1.h:235:22:235:22 | s | This argument should be of type 'int' but is of type 'char *' |
-| printf1.h:235:25:235:25 | i | This argument should be of type 'char *' but is of type 'int' |
 | real_world.h:61:21:61:22 | & ... | This argument should be of type 'int *' but is of type 'short *' |
 | real_world.h:62:22:62:23 | & ... | This argument should be of type 'short *' but is of type 'int *' |
 | real_world.h:63:22:63:24 | & ... | This argument should be of type 'short *' but is of type 'unsigned int *' |

--- a/cpp/ql/test/query-tests/Likely Bugs/Format/WrongTypeFormatArguments/Linux_signed_chars/WrongTypeFormatArguments.expected
+++ b/cpp/ql/test/query-tests/Likely Bugs/Format/WrongTypeFormatArguments/Linux_signed_chars/WrongTypeFormatArguments.expected
@@ -16,6 +16,37 @@
 | printf1.h:114:18:114:18 | d | This argument should be of type 'long double' but is of type 'double' |
 | printf1.h:147:19:147:19 | i | This argument should be of type 'long long' but is of type 'int' |
 | printf1.h:148:19:148:20 | ui | This argument should be of type 'unsigned long long' but is of type 'unsigned int' |
+| printf1.h:159:18:159:18 | i | This argument should be of type 'char *' but is of type 'int' |
+| printf1.h:160:18:160:18 | i | This argument should be of type 'char *' but is of type 'int' |
+| printf1.h:167:17:167:17 | i | This argument should be of type 'char *' but is of type 'int' |
+| printf1.h:168:18:168:18 | i | This argument should be of type 'char *' but is of type 'int' |
+| printf1.h:169:19:169:19 | i | This argument should be of type 'char *' but is of type 'int' |
+| printf1.h:174:17:174:17 | s | This argument should be of type 'int' but is of type 'char *' |
+| printf1.h:175:18:175:18 | s | This argument should be of type 'int' but is of type 'char *' |
+| printf1.h:176:19:176:19 | s | This argument should be of type 'int' but is of type 'char *' |
+| printf1.h:180:17:180:17 | s | This argument should be of type 'int' but is of type 'char *' |
+| printf1.h:181:20:181:20 | i | This argument should be of type 'char *' but is of type 'int' |
+| printf1.h:183:18:183:18 | s | This argument should be of type 'int' but is of type 'char *' |
+| printf1.h:184:21:184:21 | i | This argument should be of type 'char *' but is of type 'int' |
+| printf1.h:186:19:186:19 | s | This argument should be of type 'int' but is of type 'char *' |
+| printf1.h:187:22:187:22 | i | This argument should be of type 'char *' but is of type 'int' |
+| printf1.h:189:19:189:19 | s | This argument should be of type 'int' but is of type 'char *' |
+| printf1.h:190:22:190:22 | i | This argument should be of type 'char *' but is of type 'int' |
+| printf1.h:192:19:192:19 | s | This argument should be of type 'int' but is of type 'char *' |
+| printf1.h:193:22:193:22 | s | This argument should be of type 'int' but is of type 'char *' |
+| printf1.h:194:25:194:25 | i | This argument should be of type 'char *' but is of type 'int' |
+| printf1.h:213:28:213:28 | s | This argument should be of type 'int' but is of type 'char *' |
+| printf1.h:214:28:214:28 | s | This argument should be of type 'int' but is of type 'char *' |
+| printf1.h:215:28:215:28 | s | This argument should be of type 'int' but is of type 'char *' |
+| printf1.h:216:28:216:28 | s | This argument should be of type 'int' but is of type 'char *' |
+| printf1.h:221:18:221:18 | s | This argument should be of type 'int' but is of type 'char *' |
+| printf1.h:222:20:222:20 | s | This argument should be of type 'int' but is of type 'char *' |
+| printf1.h:233:22:233:22 | s | This argument should be of type 'int' but is of type 'char *' |
+| printf1.h:233:25:233:25 | i | This argument should be of type 'char *' but is of type 'int' |
+| printf1.h:234:22:234:22 | s | This argument should be of type 'int' but is of type 'char *' |
+| printf1.h:234:25:234:25 | i | This argument should be of type 'char *' but is of type 'int' |
+| printf1.h:235:22:235:22 | s | This argument should be of type 'int' but is of type 'char *' |
+| printf1.h:235:25:235:25 | i | This argument should be of type 'char *' but is of type 'int' |
 | real_world.h:61:21:61:22 | & ... | This argument should be of type 'int *' but is of type 'short *' |
 | real_world.h:62:22:62:23 | & ... | This argument should be of type 'short *' but is of type 'int *' |
 | real_world.h:63:22:63:24 | & ... | This argument should be of type 'short *' but is of type 'unsigned int *' |

--- a/cpp/ql/test/query-tests/Likely Bugs/Format/WrongTypeFormatArguments/Linux_signed_chars/printf1.h
+++ b/cpp/ql/test/query-tests/Likely Bugs/Format/WrongTypeFormatArguments/Linux_signed_chars/printf1.h
@@ -156,9 +156,9 @@ void complexFormatSymbols(int i, const char *s)
 {
   // positional arguments
   printf("%1$i", i, s); // GOOD
-  printf("%2$s", i, s); // GOOD [FALSE POSITIVE]
+  printf("%2$s", i, s); // GOOD
   printf("%1$s", i, s); // BAD
-  printf("%2$i", i, s); // BAD [NOT DETECTED]
+  printf("%2$i", i, s); // BAD
 
   // width / precision
   printf("%4i", i); // GOOD
@@ -195,22 +195,22 @@ void complexFormatSymbols(int i, const char *s)
 
   // positional arguments mixed with variable width / precision
   printf("%2$*1$s", i, s); // GOOD
-  printf("%2$*2$s", i, s); // BAD [NOT DETECTED]
-  printf("%1$*1$s", i, s); // BAD [NOT DETECTED]
+  printf("%2$*2$s", i, s); // BAD
+  printf("%1$*1$s", i, s); // BAD
 
   printf("%2$*1$.4s", i, s); // GOOD
-  printf("%2$*2$.4s", i, s); // BAD [NOT DETECTED]
-  printf("%1$*1$.4s", i, s); // BAD [NOT DETECTED]
+  printf("%2$*2$.4s", i, s); // BAD
+  printf("%1$*1$.4s", i, s); // BAD
 
   printf("%2$.*1$s", i, s); // GOOD
-  printf("%2$.*2$s", i, s); // BAD [NOT DETECTED]
-  printf("%1$.*1$s", i, s); // BAD [NOT DETECTED]
+  printf("%2$.*2$s", i, s); // BAD
+  printf("%1$.*1$s", i, s); // BAD
 
   printf("%2$4.*1$s", i, s); // GOOD
-  printf("%2$4.*2$s", i, s); // BAD [NOT DETECTED]
-  printf("%1$4.*1$s", i, s); // BAD [NOT DETECTED]
+  printf("%2$4.*2$s", i, s); // BAD
+  printf("%1$4.*1$s", i, s); // BAD
 
-  printf("%2$*1$.*1$s", i, s); // GOOD [FALSE POSITIVE]
+  printf("%2$*1$.*1$s", i, s); // GOOD
   printf("%2$*2$.*1$s", i, s); // BAD
   printf("%2$*1$.*2$s", i, s); // BAD
   printf("%1$*1$.*1$s", i, s); // BAD
@@ -222,15 +222,15 @@ void complexFormatSymbols(int i, const char *s)
   printf("%1$-4i", s); // BAD
 
   printf("%1$-4s", s, i); // GOOD
-  printf("%2$-4s", s, i); // BAD [NOT DETECTED]
+  printf("%2$-4s", s, i); // BAD
 
   printf("%1$-.4s", s, i); // GOOD
-  printf("%2$-.4s", s, i); // BAD [NOT DETECTED]
+  printf("%2$-.4s", s, i); // BAD
 
   printf("%1$-4.4s", s, i); // GOOD
-  printf("%2$-4.4s", s, i); // BAD [NOT DETECTED]
- 
-  printf("%1$-*2$s", s, i); // GOOD [FALSE POSITIVE x2]
-  printf("%2$-*2$s", s, i); // BAD [ADDITIONAL RESULT IS A FALSE POSITIVE]
-  printf("%1$-*1$s", s, i); // BAD [ADDITIONAL RESULT IS A FALSE POSITIVE]
+  printf("%2$-4.4s", s, i); // BAD
+
+  printf("%1$-*2$s", s, i); // GOOD
+  printf("%2$-*2$s", s, i); // BAD
+  printf("%1$-*1$s", s, i); // BAD
 }

--- a/cpp/ql/test/query-tests/Likely Bugs/Format/WrongTypeFormatArguments/Linux_signed_chars/printf1.h
+++ b/cpp/ql/test/query-tests/Likely Bugs/Format/WrongTypeFormatArguments/Linux_signed_chars/printf1.h
@@ -151,3 +151,86 @@ void fun4()
   printf("%qi\n", ll); // GOOD
   printf("%qu\n", ull); // GOOD
 }
+
+void complexFormatSymbols(int i, const char *s)
+{
+  // positional arguments
+  printf("%1$i", i, s); // GOOD
+  printf("%2$s", i, s); // GOOD [FALSE POSITIVE]
+  printf("%1$s", i, s); // BAD
+  printf("%2$i", i, s); // BAD [NOT DETECTED]
+
+  // width / precision
+  printf("%4i", i); // GOOD
+  printf("%.4i", i); // GOOD
+  printf("%4.4i", i); // GOOD
+  printf("%4s", i); // BAD
+  printf("%.4s", i); // BAD
+  printf("%4.4s", i); // BAD
+
+  printf("%4s", s); // GOOD
+  printf("%.4s", s); // GOOD
+  printf("%4.4s", s); // GOOD
+  printf("%4i", s); // BAD
+  printf("%.4i", s); // BAD
+  printf("%4.4i", s); // BAD
+
+  // variable width / precision
+  printf("%*s", i, s); // GOOD
+  printf("%*s", s, s); // BAD
+  printf("%*s", i, i); // BAD
+  printf("%.*s", i, s); // GOOD
+  printf("%.*s", s, s); // BAD
+  printf("%.*s", i, i); // BAD
+  printf("%*.4s", i, s); // GOOD
+  printf("%*.4s", s, s); // BAD
+  printf("%*.4s", i, i); // BAD
+  printf("%4.*s", i, s); // GOOD
+  printf("%4.*s", s, s); // BAD
+  printf("%4.*s", i, i); // BAD
+  printf("%*.*s", i, i, s); // GOOD
+  printf("%*.*s", s, i, s); // BAD
+  printf("%*.*s", i, s, s); // BAD
+  printf("%*.*s", i, i, i); // BAD
+
+  // positional arguments mixed with variable width / precision
+  printf("%2$*1$s", i, s); // GOOD
+  printf("%2$*2$s", i, s); // BAD [NOT DETECTED]
+  printf("%1$*1$s", i, s); // BAD [NOT DETECTED]
+
+  printf("%2$*1$.4s", i, s); // GOOD
+  printf("%2$*2$.4s", i, s); // BAD [NOT DETECTED]
+  printf("%1$*1$.4s", i, s); // BAD [NOT DETECTED]
+
+  printf("%2$.*1$s", i, s); // GOOD
+  printf("%2$.*2$s", i, s); // BAD [NOT DETECTED]
+  printf("%1$.*1$s", i, s); // BAD [NOT DETECTED]
+
+  printf("%2$4.*1$s", i, s); // GOOD
+  printf("%2$4.*2$s", i, s); // BAD [NOT DETECTED]
+  printf("%1$4.*1$s", i, s); // BAD [NOT DETECTED]
+
+  printf("%2$*1$.*1$s", i, s); // GOOD [FALSE POSITIVE]
+  printf("%2$*2$.*1$s", i, s); // BAD
+  printf("%2$*1$.*2$s", i, s); // BAD
+  printf("%1$*1$.*1$s", i, s); // BAD
+
+  // left justify flag
+  printf("%-4s", s); // GOOD
+  printf("%1$-4s", s); // GOOD
+  printf("%-4i", s); // BAD
+  printf("%1$-4i", s); // BAD
+
+  printf("%1$-4s", s, i); // GOOD
+  printf("%2$-4s", s, i); // BAD [NOT DETECTED]
+
+  printf("%1$-.4s", s, i); // GOOD
+  printf("%2$-.4s", s, i); // BAD [NOT DETECTED]
+
+  printf("%1$-4.4s", s, i); // GOOD
+  printf("%2$-4.4s", s, i); // BAD [NOT DETECTED]
+ 
+  printf("%1$-*2$s", s, i); // GOOD [FALSE POSITIVE x2]
+  printf("%2$-*2$s", s, i); // BAD [ADDITIONAL RESULT IS A FALSE POSITIVE]
+  printf("%1$-*1$s", s, i); // BAD [ADDITIONAL RESULT IS A FALSE POSITIVE]
+}


### PR DESCRIPTION
Support parameter specifiers (or whatever they're called) like `1$` in format strings, an extension which allows the format string to control the order in which format parameters are consumed.  Previously we recognized these (i.e. parsed a format string containing them correctly), but did not use them to compute argument positions - so it was as if they weren't there.  I've verified that my changes here fix the issues reported in https://github.com/Semmle/ql/issues/2182.

In addition to fully supporting these, I've added test cases, and cleaned up the surrounding logic for computing format argument positions somewhat (motivated by trying to avoid duplicating logic).

I think we still have something of a terminology problem in this file as we don't refer to all of the format string features by the clearest and most standard names possible.  However, fixing this would involve changing the names of public predicates, potentially breaking third party queries.