### PR TITLE
JavaScript: Add libraries for forward and backward data-flow exploration.

### DIFF
--- a/javascript/ql/src/semmle/javascript/dataflow/BackwardExploration.qll
+++ b/javascript/ql/src/semmle/javascript/dataflow/BackwardExploration.qll
@@ -1,0 +1,44 @@
+/**
+ * Provides machinery for performing backward data-flow exploration.
+ *
+ * Importing this module effectively makes all data-flow and taint-tracking configurations
+ * ignore their `isSource` predicate. Instead, flow is tracked from any _initial node_ (that is,
+ * a node without incoming flow) to a sink node. All initial nodes are then treated as source
+ * nodes.
+ *
+ * Data-flow exploration cannot be used with configurations depending on other configurations.
+ *
+ * NOTE: This library should only be used for debugging, not in production code. Backward
+ * exploration in particular does not scale on non-trivial code bases and hence is of limited
+ * usefulness as it stands.
+ */
+
+import javascript
+
+private class BackwardExploringConfiguration extends DataFlow::Configuration {
+  DataFlow::Configuration cfg;
+
+  BackwardExploringConfiguration() {
+    this = cfg
+  }
+
+  override predicate isSource(DataFlow::Node node) { any() }
+
+  override predicate isSource(DataFlow::Node node, DataFlow::FlowLabel lbl) { any() }
+
+  override predicate hasFlow(DataFlow::Node source, DataFlow::Node sink) {
+    exists(DataFlow::PathNode src, DataFlow::PathNode snk | hasFlowPath(src, snk) |
+      source = src.getNode() and
+      sink = snk.getNode()
+    )
+  }
+
+  override predicate hasFlowPath(DataFlow::SourcePathNode source, DataFlow::SinkPathNode sink) {
+    exists(DataFlow::MidPathNode first |
+      source.getConfiguration() = this and
+      source.getASuccessor() = first and
+      not exists(DataFlow::MidPathNode mid | mid.getASuccessor() = first) and
+      first.getASuccessor*() = sink
+    )
+  }
+}

--- a/javascript/ql/src/semmle/javascript/dataflow/ForwardExploration.qll
+++ b/javascript/ql/src/semmle/javascript/dataflow/ForwardExploration.qll
@@ -1,0 +1,42 @@
+/**
+ * Provides machinery for performing forward data-flow exploration.
+ *
+ * Importing this module effectively makes all data-flow and taint-tracking configurations
+ * ignore their `isSink` predicate. Instead, flow is tracked from source nodes as far as
+ * possible, until a _terminal node_ (that is, a node without any outgoing flow) is reached.
+ * All terminal nodes are then treated as sink nodes.
+ *
+ * Data-flow exploration cannot be used with configurations depending on other configurations.
+ *
+ * NOTE: This library should only be used for debugging, not in production code.
+ */
+
+import javascript
+
+private class ForwardExploringConfiguration extends DataFlow::Configuration {
+  DataFlow::Configuration cfg;
+
+  ForwardExploringConfiguration() {
+    this = cfg
+  }
+
+  override predicate isSink(DataFlow::Node node) { any() }
+
+  override predicate isSink(DataFlow::Node node, DataFlow::FlowLabel lbl) { any() }
+
+  override predicate hasFlow(DataFlow::Node source, DataFlow::Node sink) {
+    exists(DataFlow::PathNode src, DataFlow::PathNode snk | hasFlowPath(src, snk) |
+      source = src.getNode() and
+      sink = snk.getNode()
+    )
+  }
+
+  override predicate hasFlowPath(DataFlow::SourcePathNode source, DataFlow::SinkPathNode sink) {
+    exists(DataFlow::MidPathNode last |
+      source.getConfiguration() = this and
+      source.getASuccessor*() = last and
+      not last.getASuccessor() instanceof DataFlow::MidPathNode and
+      last.getASuccessor() = sink
+    )
+  }
+}


### PR DESCRIPTION
This follows a different approach from https://github.com/Semmle/ql/pull/1759. Instead of adding an alternative API with partial path nodes and partial paths, we provide a library that one can import into an existing query and thereby switch on (forward) data-flow exploration. Another difference is that instead of relying on an exploration limit we report all maximal paths starting at source nodes, that is, all paths that begin with a source node and end at a node that has no successor in the path graph.

Once imported, the library will, in fact, switch _all_ configurations to exploration mode. This would yield extremely confusing results for queries using configurations that depend on themselves or each other, but due to the way the exploration library is implemented this will cause a negative-recursion error anyway. Not the best failure mode, but it is documented in the library's header comment. (We have a small number of standard queries that use mutually recursive configurations, so they cannot currently use data-flow exploration. I am working on changing that, but that's for a separate PR.)

Of course, the whole concept can be dualised to backward flow-exploration, looking for paths starting a nodes without a predecessor and ending at a sink. This PR also includes a library for doing that, but with the current implementation of the data-flow library this only scales on very small snapshots (as explained in the library's header comment).

I'm not entirely sure this is the right approach to data-flow exploration. Past experience suggests that cleverness using abstract classes eventually comes back to bite us, and that may well be the case here. On the bright side, the exploration libraries are entirely orthogonal to the rest of the data-flow library, so if they turn out to be a bad idea we can deprecate and remove them very easily.