### PR TITLE
Query cpp/unused-static-variable was producing incorrect results for constexpr variables

### DIFF
--- a/cpp/ql/src/Best Practices/Unused Entities/UnusedStaticVariables.ql
+++ b/cpp/ql/src/Best Practices/Unused Entities/UnusedStaticVariables.ql
@@ -21,6 +21,7 @@ from Variable v
 where
   v.isStatic() and
   v.hasDefinition() and
+  not v.isConstexpr() and
   not exists(VariableAccess a | a.getTarget() = v) and
   not v instanceof MemberVariable and
   not declarationHasSideEffects(v) and


### PR DESCRIPTION
Made the query check that the variable is not constexpr before it will issue a warning.
This stops it producing false positives where the only uses, and therefore appearances in the AST, are constexpr, which results in the value of the variable rather than the variable itself appearing in the AST.