### PR TITLE
JavaScript: Use type tracking instead of auxiliary data-flow configuration to track indirect command arguments.

### DIFF
--- a/javascript/ql/test/query-tests/Security/CWE-078/CommandInjection.expected
+++ b/javascript/ql/test/query-tests/Security/CWE-078/CommandInjection.expected
@@ -22,48 +22,12 @@ nodes
 | child_process-test.js:25:13:25:31 | "foo" + cmd + "bar" |
 | child_process-test.js:25:13:25:31 | "foo" + cmd + "bar" |
 | child_process-test.js:25:21:25:23 | cmd |
-| child_process-test.js:36:7:36:20 | sh |
-| child_process-test.js:36:12:36:20 | 'cmd.exe' |
-| child_process-test.js:36:12:36:20 | 'cmd.exe' |
-| child_process-test.js:38:7:38:20 | sh |
-| child_process-test.js:38:12:38:20 | '/bin/sh' |
-| child_process-test.js:38:12:38:20 | '/bin/sh' |
-| child_process-test.js:39:14:39:15 | sh |
-| child_process-test.js:39:14:39:15 | sh |
-| child_process-test.js:39:18:39:30 | [ flag, cmd ] |
-| child_process-test.js:39:18:39:30 | [ flag, cmd ] |
-| child_process-test.js:39:18:39:30 | [ flag, cmd ] |
 | child_process-test.js:39:26:39:28 | cmd |
 | child_process-test.js:39:26:39:28 | cmd |
-| child_process-test.js:41:9:41:17 | args |
-| child_process-test.js:41:16:41:17 | [] |
-| child_process-test.js:41:16:41:17 | [] |
 | child_process-test.js:43:15:43:17 | cmd |
 | child_process-test.js:43:15:43:17 | cmd |
-| child_process-test.js:44:17:44:27 | "/bin/bash" |
-| child_process-test.js:44:17:44:27 | "/bin/bash" |
-| child_process-test.js:44:17:44:27 | "/bin/bash" |
-| child_process-test.js:44:30:44:33 | args |
-| child_process-test.js:44:30:44:33 | args |
-| child_process-test.js:46:9:46:12 | "sh" |
-| child_process-test.js:46:9:46:12 | "sh" |
-| child_process-test.js:46:15:46:18 | args |
-| child_process-test.js:48:9:48:17 | args |
-| child_process-test.js:48:16:48:17 | [] |
-| child_process-test.js:48:16:48:17 | [] |
 | child_process-test.js:50:15:50:17 | cmd |
 | child_process-test.js:50:15:50:17 | cmd |
-| child_process-test.js:51:17:51:32 | `/bin` + "/bash" |
-| child_process-test.js:51:17:51:32 | `/bin` + "/bash" |
-| child_process-test.js:51:17:51:32 | `/bin` + "/bash" |
-| child_process-test.js:51:35:51:38 | args |
-| child_process-test.js:51:35:51:38 | args |
-| child_process-test.js:55:14:55:16 | cmd |
-| child_process-test.js:55:19:55:22 | args |
-| child_process-test.js:56:12:56:14 | cmd |
-| child_process-test.js:56:12:56:14 | cmd |
-| child_process-test.js:56:17:56:20 | args |
-| child_process-test.js:56:17:56:20 | args |
 | execSeries.js:3:20:3:22 | arr |
 | execSeries.js:6:14:6:16 | arr |
 | execSeries.js:6:14:6:21 | arr[i++] |
@@ -114,9 +78,6 @@ nodes
 | third-party-command-injection.js:5:20:5:26 | command |
 | third-party-command-injection.js:6:21:6:27 | command |
 | third-party-command-injection.js:6:21:6:27 | command |
-| tst_shell-command-injection-from-environment.js:4:25:4:61 | ['-rf', ... temp")] |
-| tst_shell-command-injection-from-environment.js:4:25:4:61 | ['-rf', ... temp")] |
-| tst_shell-command-injection-from-environment.js:4:25:4:61 | ['-rf', ... temp")] |
 edges
 | child_process-test.js:6:9:6:49 | cmd | child_process-test.js:17:13:17:15 | cmd |
 | child_process-test.js:6:9:6:49 | cmd | child_process-test.js:17:13:17:15 | cmd |
@@ -146,33 +107,6 @@ edges
 | child_process-test.js:6:25:6:31 | req.url | child_process-test.js:6:15:6:38 | url.par ... , true) |
 | child_process-test.js:25:21:25:23 | cmd | child_process-test.js:25:13:25:31 | "foo" + cmd + "bar" |
 | child_process-test.js:25:21:25:23 | cmd | child_process-test.js:25:13:25:31 | "foo" + cmd + "bar" |
-| child_process-test.js:36:7:36:20 | sh | child_process-test.js:39:14:39:15 | sh |
-| child_process-test.js:36:7:36:20 | sh | child_process-test.js:39:14:39:15 | sh |
-| child_process-test.js:36:12:36:20 | 'cmd.exe' | child_process-test.js:36:7:36:20 | sh |
-| child_process-test.js:36:12:36:20 | 'cmd.exe' | child_process-test.js:36:7:36:20 | sh |
-| child_process-test.js:38:7:38:20 | sh | child_process-test.js:39:14:39:15 | sh |
-| child_process-test.js:38:7:38:20 | sh | child_process-test.js:39:14:39:15 | sh |
-| child_process-test.js:38:12:38:20 | '/bin/sh' | child_process-test.js:38:7:38:20 | sh |
-| child_process-test.js:38:12:38:20 | '/bin/sh' | child_process-test.js:38:7:38:20 | sh |
-| child_process-test.js:39:18:39:30 | [ flag, cmd ] | child_process-test.js:39:18:39:30 | [ flag, cmd ] |
-| child_process-test.js:41:9:41:17 | args | child_process-test.js:44:30:44:33 | args |
-| child_process-test.js:41:9:41:17 | args | child_process-test.js:44:30:44:33 | args |
-| child_process-test.js:41:9:41:17 | args | child_process-test.js:46:15:46:18 | args |
-| child_process-test.js:41:16:41:17 | [] | child_process-test.js:41:9:41:17 | args |
-| child_process-test.js:41:16:41:17 | [] | child_process-test.js:41:9:41:17 | args |
-| child_process-test.js:44:17:44:27 | "/bin/bash" | child_process-test.js:44:17:44:27 | "/bin/bash" |
-| child_process-test.js:46:9:46:12 | "sh" | child_process-test.js:55:14:55:16 | cmd |
-| child_process-test.js:46:9:46:12 | "sh" | child_process-test.js:55:14:55:16 | cmd |
-| child_process-test.js:46:15:46:18 | args | child_process-test.js:55:19:55:22 | args |
-| child_process-test.js:48:9:48:17 | args | child_process-test.js:51:35:51:38 | args |
-| child_process-test.js:48:9:48:17 | args | child_process-test.js:51:35:51:38 | args |
-| child_process-test.js:48:16:48:17 | [] | child_process-test.js:48:9:48:17 | args |
-| child_process-test.js:48:16:48:17 | [] | child_process-test.js:48:9:48:17 | args |
-| child_process-test.js:51:17:51:32 | `/bin` + "/bash" | child_process-test.js:51:17:51:32 | `/bin` + "/bash" |
-| child_process-test.js:55:14:55:16 | cmd | child_process-test.js:56:12:56:14 | cmd |
-| child_process-test.js:55:14:55:16 | cmd | child_process-test.js:56:12:56:14 | cmd |
-| child_process-test.js:55:19:55:22 | args | child_process-test.js:56:17:56:20 | args |
-| child_process-test.js:55:19:55:22 | args | child_process-test.js:56:17:56:20 | args |
 | execSeries.js:3:20:3:22 | arr | execSeries.js:6:14:6:16 | arr |
 | execSeries.js:6:14:6:16 | arr | execSeries.js:6:14:6:21 | arr[i++] |
 | execSeries.js:6:14:6:21 | arr[i++] | execSeries.js:14:24:14:30 | command |
@@ -222,7 +156,6 @@ edges
 | third-party-command-injection.js:5:20:5:26 | command | third-party-command-injection.js:6:21:6:27 | command |
 | third-party-command-injection.js:5:20:5:26 | command | third-party-command-injection.js:6:21:6:27 | command |
 | third-party-command-injection.js:5:20:5:26 | command | third-party-command-injection.js:6:21:6:27 | command |
-| tst_shell-command-injection-from-environment.js:4:25:4:61 | ['-rf', ... temp")] | tst_shell-command-injection-from-environment.js:4:25:4:61 | ['-rf', ... temp")] |
 #select
 | child_process-test.js:17:13:17:15 | cmd | child_process-test.js:6:25:6:31 | req.url | child_process-test.js:17:13:17:15 | cmd | This command depends on $@. | child_process-test.js:6:25:6:31 | req.url | a user-provided value |
 | child_process-test.js:18:17:18:19 | cmd | child_process-test.js:6:25:6:31 | req.url | child_process-test.js:18:17:18:19 | cmd | This command depends on $@. | child_process-test.js:6:25:6:31 | req.url | a user-provided value |

--- a/javascript/ql/test/query-tests/Security/CWE-078/IndirectCommandInjection.expected
+++ b/javascript/ql/test/query-tests/Security/CWE-078/IndirectCommandInjection.expected
@@ -1,40 +1,4 @@
 nodes
-| child_process-test.js:36:7:36:20 | sh |
-| child_process-test.js:36:12:36:20 | 'cmd.exe' |
-| child_process-test.js:36:12:36:20 | 'cmd.exe' |
-| child_process-test.js:38:7:38:20 | sh |
-| child_process-test.js:38:12:38:20 | '/bin/sh' |
-| child_process-test.js:38:12:38:20 | '/bin/sh' |
-| child_process-test.js:39:14:39:15 | sh |
-| child_process-test.js:39:14:39:15 | sh |
-| child_process-test.js:39:18:39:30 | [ flag, cmd ] |
-| child_process-test.js:39:18:39:30 | [ flag, cmd ] |
-| child_process-test.js:39:18:39:30 | [ flag, cmd ] |
-| child_process-test.js:41:9:41:17 | args |
-| child_process-test.js:41:16:41:17 | [] |
-| child_process-test.js:41:16:41:17 | [] |
-| child_process-test.js:44:17:44:27 | "/bin/bash" |
-| child_process-test.js:44:17:44:27 | "/bin/bash" |
-| child_process-test.js:44:17:44:27 | "/bin/bash" |
-| child_process-test.js:44:30:44:33 | args |
-| child_process-test.js:44:30:44:33 | args |
-| child_process-test.js:46:9:46:12 | "sh" |
-| child_process-test.js:46:9:46:12 | "sh" |
-| child_process-test.js:46:15:46:18 | args |
-| child_process-test.js:48:9:48:17 | args |
-| child_process-test.js:48:16:48:17 | [] |
-| child_process-test.js:48:16:48:17 | [] |
-| child_process-test.js:51:17:51:32 | `/bin` + "/bash" |
-| child_process-test.js:51:17:51:32 | `/bin` + "/bash" |
-| child_process-test.js:51:17:51:32 | `/bin` + "/bash" |
-| child_process-test.js:51:35:51:38 | args |
-| child_process-test.js:51:35:51:38 | args |
-| child_process-test.js:55:14:55:16 | cmd |
-| child_process-test.js:55:19:55:22 | args |
-| child_process-test.js:56:12:56:14 | cmd |
-| child_process-test.js:56:12:56:14 | cmd |
-| child_process-test.js:56:17:56:20 | args |
-| child_process-test.js:56:17:56:20 | args |
 | command-line-parameter-command-injection.js:4:10:4:21 | process.argv |
 | command-line-parameter-command-injection.js:4:10:4:21 | process.argv |
 | command-line-parameter-command-injection.js:4:10:4:21 | process.argv |
@@ -84,37 +48,7 @@ nodes
 | command-line-parameter-command-injection.js:27:14:27:57 | `node $ ... ption"` |
 | command-line-parameter-command-injection.js:27:32:27:35 | args |
 | command-line-parameter-command-injection.js:27:32:27:45 | args.join(' ') |
-| tst_shell-command-injection-from-environment.js:4:25:4:61 | ['-rf', ... temp")] |
-| tst_shell-command-injection-from-environment.js:4:25:4:61 | ['-rf', ... temp")] |
-| tst_shell-command-injection-from-environment.js:4:25:4:61 | ['-rf', ... temp")] |
 edges
-| child_process-test.js:36:7:36:20 | sh | child_process-test.js:39:14:39:15 | sh |
-| child_process-test.js:36:7:36:20 | sh | child_process-test.js:39:14:39:15 | sh |
-| child_process-test.js:36:12:36:20 | 'cmd.exe' | child_process-test.js:36:7:36:20 | sh |
-| child_process-test.js:36:12:36:20 | 'cmd.exe' | child_process-test.js:36:7:36:20 | sh |
-| child_process-test.js:38:7:38:20 | sh | child_process-test.js:39:14:39:15 | sh |
-| child_process-test.js:38:7:38:20 | sh | child_process-test.js:39:14:39:15 | sh |
-| child_process-test.js:38:12:38:20 | '/bin/sh' | child_process-test.js:38:7:38:20 | sh |
-| child_process-test.js:38:12:38:20 | '/bin/sh' | child_process-test.js:38:7:38:20 | sh |
-| child_process-test.js:39:18:39:30 | [ flag, cmd ] | child_process-test.js:39:18:39:30 | [ flag, cmd ] |
-| child_process-test.js:41:9:41:17 | args | child_process-test.js:44:30:44:33 | args |
-| child_process-test.js:41:9:41:17 | args | child_process-test.js:44:30:44:33 | args |
-| child_process-test.js:41:9:41:17 | args | child_process-test.js:46:15:46:18 | args |
-| child_process-test.js:41:16:41:17 | [] | child_process-test.js:41:9:41:17 | args |
-| child_process-test.js:41:16:41:17 | [] | child_process-test.js:41:9:41:17 | args |
-| child_process-test.js:44:17:44:27 | "/bin/bash" | child_process-test.js:44:17:44:27 | "/bin/bash" |
-| child_process-test.js:46:9:46:12 | "sh" | child_process-test.js:55:14:55:16 | cmd |
-| child_process-test.js:46:9:46:12 | "sh" | child_process-test.js:55:14:55:16 | cmd |
-| child_process-test.js:46:15:46:18 | args | child_process-test.js:55:19:55:22 | args |
-| child_process-test.js:48:9:48:17 | args | child_process-test.js:51:35:51:38 | args |
-| child_process-test.js:48:9:48:17 | args | child_process-test.js:51:35:51:38 | args |
-| child_process-test.js:48:16:48:17 | [] | child_process-test.js:48:9:48:17 | args |
-| child_process-test.js:48:16:48:17 | [] | child_process-test.js:48:9:48:17 | args |
-| child_process-test.js:51:17:51:32 | `/bin` + "/bash" | child_process-test.js:51:17:51:32 | `/bin` + "/bash" |
-| child_process-test.js:55:14:55:16 | cmd | child_process-test.js:56:12:56:14 | cmd |
-| child_process-test.js:55:14:55:16 | cmd | child_process-test.js:56:12:56:14 | cmd |
-| child_process-test.js:55:19:55:22 | args | child_process-test.js:56:17:56:20 | args |
-| child_process-test.js:55:19:55:22 | args | child_process-test.js:56:17:56:20 | args |
 | command-line-parameter-command-injection.js:4:10:4:21 | process.argv | command-line-parameter-command-injection.js:4:10:4:21 | process.argv |
 | command-line-parameter-command-injection.js:8:22:8:33 | process.argv | command-line-parameter-command-injection.js:8:22:8:36 | process.argv[2] |
 | command-line-parameter-command-injection.js:8:22:8:33 | process.argv | command-line-parameter-command-injection.js:8:22:8:36 | process.argv[2] |
@@ -159,7 +93,6 @@ edges
 | command-line-parameter-command-injection.js:27:32:27:35 | args | command-line-parameter-command-injection.js:27:32:27:45 | args.join(' ') |
 | command-line-parameter-command-injection.js:27:32:27:45 | args.join(' ') | command-line-parameter-command-injection.js:27:14:27:57 | `node $ ... ption"` |
 | command-line-parameter-command-injection.js:27:32:27:45 | args.join(' ') | command-line-parameter-command-injection.js:27:14:27:57 | `node $ ... ption"` |
-| tst_shell-command-injection-from-environment.js:4:25:4:61 | ['-rf', ... temp")] | tst_shell-command-injection-from-environment.js:4:25:4:61 | ['-rf', ... temp")] |
 #select
 | command-line-parameter-command-injection.js:4:10:4:21 | process.argv | command-line-parameter-command-injection.js:4:10:4:21 | process.argv | command-line-parameter-command-injection.js:4:10:4:21 | process.argv | This command depends on an unsanitized $@. | command-line-parameter-command-injection.js:4:10:4:21 | process.argv | command-line argument |
 | command-line-parameter-command-injection.js:8:10:8:36 | "cmd.sh ... argv[2] | command-line-parameter-command-injection.js:8:22:8:33 | process.argv | command-line-parameter-command-injection.js:8:10:8:36 | "cmd.sh ... argv[2] | This command depends on an unsanitized $@. | command-line-parameter-command-injection.js:8:22:8:33 | process.argv | command-line argument |

--- a/javascript/ql/test/query-tests/Security/CWE-078/ShellCommandInjectionFromEnvironment.expected
+++ b/javascript/ql/test/query-tests/Security/CWE-078/ShellCommandInjectionFromEnvironment.expected
@@ -1,77 +1,10 @@
 nodes
-| child_process-test.js:36:7:36:20 | sh |
-| child_process-test.js:36:12:36:20 | 'cmd.exe' |
-| child_process-test.js:36:12:36:20 | 'cmd.exe' |
-| child_process-test.js:38:7:38:20 | sh |
-| child_process-test.js:38:12:38:20 | '/bin/sh' |
-| child_process-test.js:38:12:38:20 | '/bin/sh' |
-| child_process-test.js:39:14:39:15 | sh |
-| child_process-test.js:39:14:39:15 | sh |
-| child_process-test.js:39:18:39:30 | [ flag, cmd ] |
-| child_process-test.js:39:18:39:30 | [ flag, cmd ] |
-| child_process-test.js:39:18:39:30 | [ flag, cmd ] |
-| child_process-test.js:41:9:41:17 | args |
-| child_process-test.js:41:16:41:17 | [] |
-| child_process-test.js:41:16:41:17 | [] |
-| child_process-test.js:44:17:44:27 | "/bin/bash" |
-| child_process-test.js:44:17:44:27 | "/bin/bash" |
-| child_process-test.js:44:17:44:27 | "/bin/bash" |
-| child_process-test.js:44:30:44:33 | args |
-| child_process-test.js:44:30:44:33 | args |
-| child_process-test.js:46:9:46:12 | "sh" |
-| child_process-test.js:46:9:46:12 | "sh" |
-| child_process-test.js:46:15:46:18 | args |
-| child_process-test.js:48:9:48:17 | args |
-| child_process-test.js:48:16:48:17 | [] |
-| child_process-test.js:48:16:48:17 | [] |
-| child_process-test.js:51:17:51:32 | `/bin` + "/bash" |
-| child_process-test.js:51:17:51:32 | `/bin` + "/bash" |
-| child_process-test.js:51:17:51:32 | `/bin` + "/bash" |
-| child_process-test.js:51:35:51:38 | args |
-| child_process-test.js:51:35:51:38 | args |
-| child_process-test.js:55:14:55:16 | cmd |
-| child_process-test.js:55:19:55:22 | args |
-| child_process-test.js:56:12:56:14 | cmd |
-| child_process-test.js:56:12:56:14 | cmd |
-| child_process-test.js:56:17:56:20 | args |
-| child_process-test.js:56:17:56:20 | args |
-| tst_shell-command-injection-from-environment.js:4:25:4:61 | ['-rf', ... temp")] |
-| tst_shell-command-injection-from-environment.js:4:25:4:61 | ['-rf', ... temp")] |
-| tst_shell-command-injection-from-environment.js:4:25:4:61 | ['-rf', ... temp")] |
 | tst_shell-command-injection-from-environment.js:5:14:5:53 | 'rm -rf ... "temp") |
 | tst_shell-command-injection-from-environment.js:5:14:5:53 | 'rm -rf ... "temp") |
 | tst_shell-command-injection-from-environment.js:5:26:5:53 | path.jo ... "temp") |
 | tst_shell-command-injection-from-environment.js:5:36:5:44 | __dirname |
 | tst_shell-command-injection-from-environment.js:5:36:5:44 | __dirname |
 edges
-| child_process-test.js:36:7:36:20 | sh | child_process-test.js:39:14:39:15 | sh |
-| child_process-test.js:36:7:36:20 | sh | child_process-test.js:39:14:39:15 | sh |
-| child_process-test.js:36:12:36:20 | 'cmd.exe' | child_process-test.js:36:7:36:20 | sh |
-| child_process-test.js:36:12:36:20 | 'cmd.exe' | child_process-test.js:36:7:36:20 | sh |
-| child_process-test.js:38:7:38:20 | sh | child_process-test.js:39:14:39:15 | sh |
-| child_process-test.js:38:7:38:20 | sh | child_process-test.js:39:14:39:15 | sh |
-| child_process-test.js:38:12:38:20 | '/bin/sh' | child_process-test.js:38:7:38:20 | sh |
-| child_process-test.js:38:12:38:20 | '/bin/sh' | child_process-test.js:38:7:38:20 | sh |
-| child_process-test.js:39:18:39:30 | [ flag, cmd ] | child_process-test.js:39:18:39:30 | [ flag, cmd ] |
-| child_process-test.js:41:9:41:17 | args | child_process-test.js:44:30:44:33 | args |
-| child_process-test.js:41:9:41:17 | args | child_process-test.js:44:30:44:33 | args |
-| child_process-test.js:41:9:41:17 | args | child_process-test.js:46:15:46:18 | args |
-| child_process-test.js:41:16:41:17 | [] | child_process-test.js:41:9:41:17 | args |
-| child_process-test.js:41:16:41:17 | [] | child_process-test.js:41:9:41:17 | args |
-| child_process-test.js:44:17:44:27 | "/bin/bash" | child_process-test.js:44:17:44:27 | "/bin/bash" |
-| child_process-test.js:46:9:46:12 | "sh" | child_process-test.js:55:14:55:16 | cmd |
-| child_process-test.js:46:9:46:12 | "sh" | child_process-test.js:55:14:55:16 | cmd |
-| child_process-test.js:46:15:46:18 | args | child_process-test.js:55:19:55:22 | args |
-| child_process-test.js:48:9:48:17 | args | child_process-test.js:51:35:51:38 | args |
-| child_process-test.js:48:9:48:17 | args | child_process-test.js:51:35:51:38 | args |
-| child_process-test.js:48:16:48:17 | [] | child_process-test.js:48:9:48:17 | args |
-| child_process-test.js:48:16:48:17 | [] | child_process-test.js:48:9:48:17 | args |
-| child_process-test.js:51:17:51:32 | `/bin` + "/bash" | child_process-test.js:51:17:51:32 | `/bin` + "/bash" |
-| child_process-test.js:55:14:55:16 | cmd | child_process-test.js:56:12:56:14 | cmd |
-| child_process-test.js:55:14:55:16 | cmd | child_process-test.js:56:12:56:14 | cmd |
-| child_process-test.js:55:19:55:22 | args | child_process-test.js:56:17:56:20 | args |
-| child_process-test.js:55:19:55:22 | args | child_process-test.js:56:17:56:20 | args |
-| tst_shell-command-injection-from-environment.js:4:25:4:61 | ['-rf', ... temp")] | tst_shell-command-injection-from-environment.js:4:25:4:61 | ['-rf', ... temp")] |
 | tst_shell-command-injection-from-environment.js:5:26:5:53 | path.jo ... "temp") | tst_shell-command-injection-from-environment.js:5:14:5:53 | 'rm -rf ... "temp") |
 | tst_shell-command-injection-from-environment.js:5:26:5:53 | path.jo ... "temp") | tst_shell-command-injection-from-environment.js:5:14:5:53 | 'rm -rf ... "temp") |
 | tst_shell-command-injection-from-environment.js:5:36:5:44 | __dirname | tst_shell-command-injection-from-environment.js:5:26:5:53 | path.jo ... "temp") |


### PR DESCRIPTION
This makes it possible to use data-flow exploration (https://github.com/Semmle/ql/pull/2236) with the command-injection queries. Performance-wise it's a [very slight win](https://git.semmle.com/max/dist-compare-reports/blob/master/js/indirect-command-argument-data-flow/report.md) on nightly.slugs, with no result changes.