### PR TITLE
Python: Always enable legacy taint tracking configuration

### DIFF
--- a/python/ql/src/semmle/python/dataflow/Legacy.qll
+++ b/python/ql/src/semmle/python/dataflow/Legacy.qll
@@ -33,26 +33,18 @@ private class LegacyConfiguration extends TaintTracking::Configuration {
     }
 
     override predicate isSource(TaintSource src) {
-        isValid() and
         src = src
     }
 
     override predicate isSink(TaintSink sink) {
-        isValid() and
         sink = sink
     }
 
     override predicate isSanitizer(Sanitizer sanitizer) {
-        isValid() and
         sanitizer = sanitizer
     }
 
-    private predicate isValid() {
-        not exists(TaintTracking::Configuration config | config != this)
-    }
-
     override predicate isAdditionalFlowStep(DataFlow::Node src, DataFlow::Node dest) {
-        isValid() and
         exists(DataFlowExtension::DataFlowNode legacyExtension |
             src.asCfgNode() = legacyExtension
             |
@@ -67,7 +59,6 @@ private class LegacyConfiguration extends TaintTracking::Configuration {
     }
 
     override predicate isAdditionalFlowStep(DataFlow::Node src, DataFlow::Node dest, TaintKind srckind, TaintKind destkind) {
-        isValid() and
         exists(DataFlowExtension::DataFlowNode legacyExtension |
             src.asCfgNode() = legacyExtension
             |
@@ -76,7 +67,6 @@ private class LegacyConfiguration extends TaintTracking::Configuration {
     }
 
     override predicate isBarrierEdge(DataFlow::Node src, DataFlow::Node dest) {
-        isValid() and
         (
             exists(DataFlowExtension::DataFlowVariable legacyExtension |
                 src.asVariable() = legacyExtension and
@@ -91,4 +81,3 @@ private class LegacyConfiguration extends TaintTracking::Configuration {
     }
 
 }
-

--- a/python/ql/test/library-tests/taint/config/RockPaperScissors.expected
+++ b/python/ql/test/library-tests/taint/config/RockPaperScissors.expected
@@ -28,6 +28,12 @@ edges
 | rockpaperscissors.py:25:9:25:9 | rock | rockpaperscissors.py:25:9:25:16 | scissors |
 | rockpaperscissors.py:25:9:25:16 | scissors | rockpaperscissors.py:25:9:25:23 | paper |
 | rockpaperscissors.py:25:9:25:23 | paper | rockpaperscissors.py:26:14:26:14 | paper |
+| sanitizer.py:9:9:9:20 | SQL injection | sanitizer.py:13:19:13:19 | SQL injection |
+| sanitizer.py:16:9:16:20 | Command injection | sanitizer.py:20:20:20:20 | Command injection |
+| sanitizer.py:24:9:24:20 | SQL injection | sanitizer.py:26:19:26:19 | SQL injection |
+| sanitizer.py:24:9:24:20 | SQL injection | sanitizer.py:28:19:28:19 | SQL injection |
+| sanitizer.py:31:9:31:20 | Command injection | sanitizer.py:33:20:33:20 | Command injection |
+| sanitizer.py:31:9:31:20 | Command injection | sanitizer.py:35:20:35:20 | Command injection |
 | test.py:6:9:6:14 | simple.test | test.py:7:10:7:10 | simple.test |
 | test.py:10:12:10:17 | simple.test | test.py:16:9:16:16 | simple.test |
 | test.py:10:12:10:17 | simple.test | test.py:24:9:24:16 | simple.test |

--- a/python/ql/test/library-tests/taint/config/Simple.expected
+++ b/python/ql/test/library-tests/taint/config/Simple.expected
@@ -28,6 +28,12 @@ edges
 | rockpaperscissors.py:25:9:25:9 | rock | rockpaperscissors.py:25:9:25:16 | scissors |
 | rockpaperscissors.py:25:9:25:16 | scissors | rockpaperscissors.py:25:9:25:23 | paper |
 | rockpaperscissors.py:25:9:25:23 | paper | rockpaperscissors.py:26:14:26:14 | paper |
+| sanitizer.py:9:9:9:20 | SQL injection | sanitizer.py:13:19:13:19 | SQL injection |
+| sanitizer.py:16:9:16:20 | Command injection | sanitizer.py:20:20:20:20 | Command injection |
+| sanitizer.py:24:9:24:20 | SQL injection | sanitizer.py:26:19:26:19 | SQL injection |
+| sanitizer.py:24:9:24:20 | SQL injection | sanitizer.py:28:19:28:19 | SQL injection |
+| sanitizer.py:31:9:31:20 | Command injection | sanitizer.py:33:20:33:20 | Command injection |
+| sanitizer.py:31:9:31:20 | Command injection | sanitizer.py:35:20:35:20 | Command injection |
 | test.py:6:9:6:14 | simple.test | test.py:7:10:7:10 | simple.test |
 | test.py:10:12:10:17 | simple.test | test.py:16:9:16:16 | simple.test |
 | test.py:10:12:10:17 | simple.test | test.py:24:9:24:16 | simple.test |

--- a/python/ql/test/query-tests/Security/CWE-022/PathInjection.expected
+++ b/python/ql/test/query-tests/Security/CWE-022/PathInjection.expected
@@ -1,16 +1,29 @@
 edges
 | path_injection.py:9:12:9:23 | dict of externally controlled string | path_injection.py:9:12:9:39 | externally controlled string |
+| path_injection.py:9:12:9:23 | dict of externally controlled string | path_injection.py:9:12:9:39 | externally controlled string |
+| path_injection.py:9:12:9:39 | externally controlled string | path_injection.py:10:40:10:43 | externally controlled string |
 | path_injection.py:9:12:9:39 | externally controlled string | path_injection.py:10:40:10:43 | externally controlled string |
 | path_injection.py:10:40:10:43 | externally controlled string | path_injection.py:10:14:10:44 | externally controlled string |
+| path_injection.py:10:40:10:43 | externally controlled string | path_injection.py:10:14:10:44 | externally controlled string |
+| path_injection.py:15:12:15:23 | dict of externally controlled string | path_injection.py:15:12:15:39 | externally controlled string |
 | path_injection.py:15:12:15:23 | dict of externally controlled string | path_injection.py:15:12:15:39 | externally controlled string |
 | path_injection.py:15:12:15:39 | externally controlled string | path_injection.py:16:56:16:59 | externally controlled string |
+| path_injection.py:15:12:15:39 | externally controlled string | path_injection.py:16:56:16:59 | externally controlled string |
+| path_injection.py:16:13:16:61 | normalized path | path_injection.py:17:14:17:18 | normalized path |
 | path_injection.py:16:13:16:61 | normalized path | path_injection.py:17:14:17:18 | normalized path |
 | path_injection.py:16:30:16:60 | externally controlled string | path_injection.py:16:13:16:61 | normalized path |
+| path_injection.py:16:30:16:60 | externally controlled string | path_injection.py:16:13:16:61 | normalized path |
+| path_injection.py:16:56:16:59 | externally controlled string | path_injection.py:16:30:16:60 | externally controlled string |
 | path_injection.py:16:56:16:59 | externally controlled string | path_injection.py:16:30:16:60 | externally controlled string |
 | path_injection.py:24:12:24:23 | dict of externally controlled string | path_injection.py:24:12:24:39 | externally controlled string |
+| path_injection.py:24:12:24:23 | dict of externally controlled string | path_injection.py:24:12:24:39 | externally controlled string |
+| path_injection.py:24:12:24:39 | externally controlled string | path_injection.py:25:56:25:59 | externally controlled string |
 | path_injection.py:24:12:24:39 | externally controlled string | path_injection.py:25:56:25:59 | externally controlled string |
 | path_injection.py:25:13:25:61 | normalized path | path_injection.py:28:14:28:18 | normalized path |
+| path_injection.py:25:13:25:61 | normalized path | path_injection.py:28:14:28:18 | normalized path |
 | path_injection.py:25:30:25:60 | externally controlled string | path_injection.py:25:13:25:61 | normalized path |
+| path_injection.py:25:30:25:60 | externally controlled string | path_injection.py:25:13:25:61 | normalized path |
+| path_injection.py:25:56:25:59 | externally controlled string | path_injection.py:25:30:25:60 | externally controlled string |
 | path_injection.py:25:56:25:59 | externally controlled string | path_injection.py:25:30:25:60 | externally controlled string |
 #select
 | path_injection.py:10:14:10:44 | Attribute() | path_injection.py:9:12:9:23 | dict of externally controlled string | path_injection.py:10:14:10:44 | externally controlled string | This path depends on $@. | path_injection.py:9:12:9:23 | Attribute | a user-provided value |

--- a/python/ql/test/query-tests/Security/CWE-022/TarSlip.expected
+++ b/python/ql/test/query-tests/Security/CWE-022/TarSlip.expected
@@ -1,11 +1,19 @@
 edges
 | tarslip.py:12:7:12:39 | tarfile.open | tarslip.py:13:1:13:3 | tarfile.open |
+| tarslip.py:12:7:12:39 | tarfile.open | tarslip.py:13:1:13:3 | tarfile.open |
+| tarslip.py:16:7:16:39 | tarfile.open | tarslip.py:17:14:17:16 | tarfile.open |
 | tarslip.py:16:7:16:39 | tarfile.open | tarslip.py:17:14:17:16 | tarfile.open |
 | tarslip.py:17:1:17:17 | tarfile.entry | tarslip.py:18:17:18:21 | tarfile.entry |
+| tarslip.py:17:1:17:17 | tarfile.entry | tarslip.py:18:17:18:21 | tarfile.entry |
+| tarslip.py:17:14:17:16 | tarfile.open | tarslip.py:17:1:17:17 | tarfile.entry |
 | tarslip.py:17:14:17:16 | tarfile.open | tarslip.py:17:1:17:17 | tarfile.entry |
 | tarslip.py:33:7:33:39 | tarfile.open | tarslip.py:34:14:34:16 | tarfile.open |
+| tarslip.py:33:7:33:39 | tarfile.open | tarslip.py:34:14:34:16 | tarfile.open |
+| tarslip.py:34:1:34:17 | tarfile.entry | tarslip.py:37:17:37:21 | tarfile.entry |
 | tarslip.py:34:1:34:17 | tarfile.entry | tarslip.py:37:17:37:21 | tarfile.entry |
 | tarslip.py:34:14:34:16 | tarfile.open | tarslip.py:34:1:34:17 | tarfile.entry |
+| tarslip.py:34:14:34:16 | tarfile.open | tarslip.py:34:1:34:17 | tarfile.entry |
+| tarslip.py:40:7:40:39 | tarfile.open | tarslip.py:41:24:41:26 | tarfile.open |
 | tarslip.py:40:7:40:39 | tarfile.open | tarslip.py:41:24:41:26 | tarfile.open |
 #select
 | tarslip.py:13:1:13:3 | tar | tarslip.py:12:7:12:39 | tarfile.open | tarslip.py:13:1:13:3 | tarfile.open | Extraction of tarfile from $@ | tarslip.py:12:7:12:39 | Attribute() | a potentially untrusted source |

--- a/python/ql/test/query-tests/Security/CWE-078/CommandInjection.expected
+++ b/python/ql/test/query-tests/Security/CWE-078/CommandInjection.expected
@@ -1,15 +1,27 @@
 edges
 | command_injection.py:10:13:10:24 | dict of externally controlled string | command_injection.py:10:13:10:41 | externally controlled string |
+| command_injection.py:10:13:10:24 | dict of externally controlled string | command_injection.py:10:13:10:41 | externally controlled string |
+| command_injection.py:10:13:10:41 | externally controlled string | command_injection.py:12:23:12:27 | externally controlled string |
 | command_injection.py:10:13:10:41 | externally controlled string | command_injection.py:12:23:12:27 | externally controlled string |
 | command_injection.py:12:23:12:27 | externally controlled string | command_injection.py:12:15:12:27 | externally controlled string |
+| command_injection.py:12:23:12:27 | externally controlled string | command_injection.py:12:15:12:27 | externally controlled string |
+| command_injection.py:17:13:17:24 | dict of externally controlled string | command_injection.py:17:13:17:41 | externally controlled string |
 | command_injection.py:17:13:17:24 | dict of externally controlled string | command_injection.py:17:13:17:41 | externally controlled string |
 | command_injection.py:17:13:17:41 | externally controlled string | command_injection.py:19:29:19:33 | externally controlled string |
+| command_injection.py:17:13:17:41 | externally controlled string | command_injection.py:19:29:19:33 | externally controlled string |
+| command_injection.py:19:29:19:33 | externally controlled string | command_injection.py:19:22:19:34 | sequence of externally controlled string |
 | command_injection.py:19:29:19:33 | externally controlled string | command_injection.py:19:22:19:34 | sequence of externally controlled string |
 | command_injection.py:24:11:24:22 | dict of externally controlled string | command_injection.py:24:11:24:37 | externally controlled string |
+| command_injection.py:24:11:24:22 | dict of externally controlled string | command_injection.py:24:11:24:37 | externally controlled string |
+| command_injection.py:24:11:24:37 | externally controlled string | command_injection.py:25:23:25:25 | externally controlled string |
 | command_injection.py:24:11:24:37 | externally controlled string | command_injection.py:25:23:25:25 | externally controlled string |
 | command_injection.py:25:23:25:25 | externally controlled string | command_injection.py:25:22:25:36 | first item in sequence of externally controlled string |
+| command_injection.py:25:23:25:25 | externally controlled string | command_injection.py:25:22:25:36 | first item in sequence of externally controlled string |
+| command_injection.py:30:13:30:24 | dict of externally controlled string | command_injection.py:30:13:30:41 | externally controlled string |
 | command_injection.py:30:13:30:24 | dict of externally controlled string | command_injection.py:30:13:30:41 | externally controlled string |
 | command_injection.py:30:13:30:41 | externally controlled string | command_injection.py:32:22:32:26 | externally controlled string |
+| command_injection.py:30:13:30:41 | externally controlled string | command_injection.py:32:22:32:26 | externally controlled string |
+| command_injection.py:32:22:32:26 | externally controlled string | command_injection.py:32:14:32:26 | externally controlled string |
 | command_injection.py:32:22:32:26 | externally controlled string | command_injection.py:32:14:32:26 | externally controlled string |
 #select
 | command_injection.py:12:15:12:27 | BinaryExpr | command_injection.py:10:13:10:24 | dict of externally controlled string | command_injection.py:12:15:12:27 | externally controlled string | This command depends on $@. | command_injection.py:10:13:10:24 | Attribute | a user-provided value |

--- a/python/ql/test/query-tests/Security/CWE-079/ReflectedXss.expected
+++ b/python/ql/test/query-tests/Security/CWE-079/ReflectedXss.expected
@@ -1,8 +1,13 @@
 edges
 | ../lib/flask/__init__.py:14:19:14:20 | externally controlled string | ../lib/flask/__init__.py:16:25:16:26 | externally controlled string |
+| ../lib/flask/__init__.py:14:19:14:20 | externally controlled string | ../lib/flask/__init__.py:16:25:16:26 | externally controlled string |
+| reflected_xss.py:7:18:7:29 | dict of externally controlled string | reflected_xss.py:7:18:7:45 | externally controlled string |
 | reflected_xss.py:7:18:7:29 | dict of externally controlled string | reflected_xss.py:7:18:7:45 | externally controlled string |
 | reflected_xss.py:7:18:7:45 | externally controlled string | reflected_xss.py:8:44:8:53 | externally controlled string |
+| reflected_xss.py:7:18:7:45 | externally controlled string | reflected_xss.py:8:44:8:53 | externally controlled string |
 | reflected_xss.py:8:26:8:53 | externally controlled string | ../lib/flask/__init__.py:14:19:14:20 | externally controlled string |
+| reflected_xss.py:8:26:8:53 | externally controlled string | ../lib/flask/__init__.py:14:19:14:20 | externally controlled string |
+| reflected_xss.py:8:44:8:53 | externally controlled string | reflected_xss.py:8:26:8:53 | externally controlled string |
 | reflected_xss.py:8:44:8:53 | externally controlled string | reflected_xss.py:8:26:8:53 | externally controlled string |
 #select
 | ../lib/flask/__init__.py:16:25:16:26 | rv | reflected_xss.py:7:18:7:29 | dict of externally controlled string | ../lib/flask/__init__.py:16:25:16:26 | externally controlled string | Cross-site scripting vulnerability due to $@. | reflected_xss.py:7:18:7:29 | Attribute | user-provided value |

--- a/python/ql/test/query-tests/Security/CWE-089/SqlInjection.expected
+++ b/python/ql/test/query-tests/Security/CWE-089/SqlInjection.expected
@@ -1,11 +1,19 @@
 edges
 | sql_injection.py:12:24:12:31 | externally controlled string | sql_injection.py:19:70:19:77 | externally controlled string |
+| sql_injection.py:12:24:12:31 | externally controlled string | sql_injection.py:19:70:19:77 | externally controlled string |
+| sql_injection.py:12:24:12:31 | externally controlled string | sql_injection.py:22:88:22:95 | externally controlled string |
 | sql_injection.py:12:24:12:31 | externally controlled string | sql_injection.py:22:88:22:95 | externally controlled string |
 | sql_injection.py:12:24:12:31 | externally controlled string | sql_injection.py:23:76:23:83 | externally controlled string |
+| sql_injection.py:12:24:12:31 | externally controlled string | sql_injection.py:23:76:23:83 | externally controlled string |
+| sql_injection.py:12:24:12:31 | externally controlled string | sql_injection.py:24:78:24:85 | externally controlled string |
 | sql_injection.py:12:24:12:31 | externally controlled string | sql_injection.py:24:78:24:85 | externally controlled string |
 | sql_injection.py:19:70:19:77 | externally controlled string | sql_injection.py:19:24:19:77 | externally controlled string |
+| sql_injection.py:19:70:19:77 | externally controlled string | sql_injection.py:19:24:19:77 | externally controlled string |
+| sql_injection.py:22:88:22:95 | externally controlled string | sql_injection.py:22:38:22:95 | externally controlled string |
 | sql_injection.py:22:88:22:95 | externally controlled string | sql_injection.py:22:38:22:95 | externally controlled string |
 | sql_injection.py:23:76:23:83 | externally controlled string | sql_injection.py:23:26:23:83 | externally controlled string |
+| sql_injection.py:23:76:23:83 | externally controlled string | sql_injection.py:23:26:23:83 | externally controlled string |
+| sql_injection.py:24:78:24:85 | externally controlled string | sql_injection.py:24:28:24:85 | externally controlled string |
 | sql_injection.py:24:78:24:85 | externally controlled string | sql_injection.py:24:28:24:85 | externally controlled string |
 #select
 | sql_injection.py:19:24:19:77 | BinaryExpr | sql_injection.py:12:24:12:31 | externally controlled string | sql_injection.py:19:24:19:77 | externally controlled string | This SQL query depends on $@. | sql_injection.py:12:24:12:31 | username | a user-provided value |

--- a/python/ql/test/query-tests/Security/CWE-094/CodeInjection.expected
+++ b/python/ql/test/query-tests/Security/CWE-094/CodeInjection.expected
@@ -1,8 +1,13 @@
 edges
 | code_injection.py:4:20:4:26 | django.request.HttpRequest | code_injection.py:6:22:6:28 | django.request.HttpRequest |
+| code_injection.py:4:20:4:26 | django.request.HttpRequest | code_injection.py:6:22:6:28 | django.request.HttpRequest |
+| code_injection.py:6:22:6:28 | django.request.HttpRequest | code_injection.py:6:22:6:33 | django.http.request.QueryDict |
 | code_injection.py:6:22:6:28 | django.request.HttpRequest | code_injection.py:6:22:6:33 | django.http.request.QueryDict |
 | code_injection.py:6:22:6:33 | django.http.request.QueryDict | code_injection.py:6:22:6:55 | externally controlled string |
+| code_injection.py:6:22:6:33 | django.http.request.QueryDict | code_injection.py:6:22:6:55 | externally controlled string |
 | code_injection.py:6:22:6:55 | externally controlled string | code_injection.py:7:34:7:43 | externally controlled string |
+| code_injection.py:6:22:6:55 | externally controlled string | code_injection.py:7:34:7:43 | externally controlled string |
+| code_injection.py:7:34:7:43 | externally controlled string | code_injection.py:7:14:7:44 | externally controlled string |
 | code_injection.py:7:34:7:43 | externally controlled string | code_injection.py:7:14:7:44 | externally controlled string |
 #select
 | code_injection.py:7:14:7:44 | Attribute() | code_injection.py:4:20:4:26 | django.request.HttpRequest | code_injection.py:7:14:7:44 | externally controlled string | $@ flows to here and is interpreted as code. | code_injection.py:4:20:4:26 | request | User-provided value |

--- a/python/ql/test/query-tests/Security/CWE-209/StackTraceExposure.expected
+++ b/python/ql/test/query-tests/Security/CWE-209/StackTraceExposure.expected
@@ -1,5 +1,7 @@
 edges
 | test.py:33:15:33:36 | exception info | test.py:34:29:34:31 | exception info |
+| test.py:33:15:33:36 | exception info | test.py:34:29:34:31 | exception info |
+| test.py:34:29:34:31 | exception info | test.py:34:16:34:32 | exception info |
 | test.py:34:29:34:31 | exception info | test.py:34:16:34:32 | exception info |
 #select
 | test.py:16:16:16:37 | Attribute() | test.py:16:16:16:37 | exception info | test.py:16:16:16:37 | exception info | $@ may be exposed to an external user | test.py:16:16:16:37 | Attribute() | Error information |

--- a/python/ql/test/query-tests/Security/CWE-312/CleartextLogging.expected
+++ b/python/ql/test/query-tests/Security/CWE-312/CleartextLogging.expected
@@ -1,5 +1,8 @@
 edges
+| password_in_cookie.py:7:16:7:43 | a password | password_in_cookie.py:9:33:9:40 | a password |
 | test.py:7:16:7:29 | a password | test.py:8:35:8:42 | a password |
+| test.py:7:16:7:29 | a password | test.py:8:35:8:42 | a password |
+| test.py:20:12:20:21 | a certificate or key | test.py:22:20:22:23 | a certificate or key |
 #select
 | test.py:8:35:8:42 | password | test.py:7:16:7:29 | a password | test.py:8:35:8:42 | a password | Sensitive data returned by $@ is logged here. | test.py:7:16:7:29 | get_password() | a call returning a password |
 | test.py:14:30:14:39 | get_cert() | test.py:14:30:14:39 | a certificate or key | test.py:14:30:14:39 | a certificate or key | Sensitive data returned by $@ is logged here. | test.py:14:30:14:39 | get_cert() | a call returning a certificate or key |

--- a/python/ql/test/query-tests/Security/CWE-312/CleartextStorage.expected
+++ b/python/ql/test/query-tests/Security/CWE-312/CleartextStorage.expected
@@ -1,5 +1,8 @@
 edges
 | password_in_cookie.py:7:16:7:43 | a password | password_in_cookie.py:9:33:9:40 | a password |
+| password_in_cookie.py:7:16:7:43 | a password | password_in_cookie.py:9:33:9:40 | a password |
+| test.py:7:16:7:29 | a password | test.py:8:35:8:42 | a password |
+| test.py:20:12:20:21 | a certificate or key | test.py:22:20:22:23 | a certificate or key |
 | test.py:20:12:20:21 | a certificate or key | test.py:22:20:22:23 | a certificate or key |
 #select
 | password_in_cookie.py:9:33:9:40 | password | password_in_cookie.py:7:16:7:43 | a password | password_in_cookie.py:9:33:9:40 | a password | Sensitive data from $@ is stored here. | password_in_cookie.py:7:16:7:43 | Attribute() | a request parameter containing a password |

--- a/python/ql/test/query-tests/Security/CWE-327/TestNode.expected
+++ b/python/ql/test/query-tests/Security/CWE-327/TestNode.expected
@@ -5,3 +5,8 @@
 | Taint cryptography.encryptor.RC4 | test_cryptography.py:7:17:7:34 | test_cryptography.py:7 | test_cryptography.py:7:17:7:34 | Attribute() |  |
 | Taint cryptography.encryptor.RC4 | test_cryptography.py:8:12:8:20 | test_cryptography.py:8 | test_cryptography.py:8:12:8:20 | encryptor |  |
 | Taint cryptography.encryptor.RC4 | test_cryptography.py:8:42:8:50 | test_cryptography.py:8 | test_cryptography.py:8:42:8:50 | encryptor |  |
+| Taint sensitive.data.password | test_cryptography.py:5:17:5:30 | test_cryptography.py:5 | test_cryptography.py:5:17:5:30 | get_password() |  |
+| Taint sensitive.data.password | test_cryptography.py:8:29:8:37 | test_cryptography.py:8 | test_cryptography.py:8:29:8:37 | dangerous |  |
+| Taint sensitive.data.password | test_cryptography.py:8:42:8:50 | test_cryptography.py:8 | test_cryptography.py:8:42:8:50 | encryptor |  |
+| Taint sensitive.data.password | test_pycrypto.py:5:17:5:30 | test_pycrypto.py:5 | test_pycrypto.py:5:17:5:30 | get_password() |  |
+| Taint sensitive.data.password | test_pycrypto.py:7:27:7:35 | test_pycrypto.py:7 | test_pycrypto.py:7:27:7:35 | dangerous |  |

--- a/python/ql/test/query-tests/Security/CWE-502/UnsafeDeserialization.expected
+++ b/python/ql/test/query-tests/Security/CWE-502/UnsafeDeserialization.expected
@@ -1,8 +1,13 @@
 edges
 | test.py:11:15:11:26 | dict of externally controlled string | test.py:11:15:11:41 | externally controlled string |
+| test.py:11:15:11:26 | dict of externally controlled string | test.py:11:15:11:41 | externally controlled string |
+| test.py:11:15:11:41 | externally controlled string | test.py:12:18:12:24 | externally controlled string |
 | test.py:11:15:11:41 | externally controlled string | test.py:12:18:12:24 | externally controlled string |
 | test.py:11:15:11:41 | externally controlled string | test.py:13:15:13:21 | externally controlled string |
+| test.py:11:15:11:41 | externally controlled string | test.py:13:15:13:21 | externally controlled string |
 | test.py:11:15:11:41 | externally controlled string | test.py:14:19:14:25 | externally controlled string |
+| test.py:11:15:11:41 | externally controlled string | test.py:14:19:14:25 | externally controlled string |
+| test.py:11:15:11:41 | externally controlled string | test.py:16:16:16:22 | externally controlled string |
 | test.py:11:15:11:41 | externally controlled string | test.py:16:16:16:22 | externally controlled string |
 #select
 | test.py:12:18:12:24 | payload | test.py:11:15:11:26 | dict of externally controlled string | test.py:12:18:12:24 | externally controlled string | Deserializing of $@. | test.py:11:15:11:26 | Attribute | untrusted input |

--- a/python/ql/test/query-tests/Security/CWE-601/UrlRedirect.expected
+++ b/python/ql/test/query-tests/Security/CWE-601/UrlRedirect.expected
@@ -1,5 +1,7 @@
 edges
 | test.py:7:22:7:33 | dict of externally controlled string | test.py:7:22:7:51 | externally controlled string |
+| test.py:7:22:7:33 | dict of externally controlled string | test.py:7:22:7:51 | externally controlled string |
+| test.py:7:22:7:51 | externally controlled string | test.py:8:21:8:26 | externally controlled string |
 | test.py:7:22:7:51 | externally controlled string | test.py:8:21:8:26 | externally controlled string |
 #select
 | test.py:8:21:8:26 | target | test.py:7:22:7:33 | dict of externally controlled string | test.py:8:21:8:26 | externally controlled string | Untrusted URL redirection due to $@. | test.py:7:22:7:33 | Attribute | a user-provided value |


### PR DESCRIPTION
If the legacy configuration is only enabled if there are no other
configurations, defining a configuration in an imported library can lead to
unwanted results. For example, code that uses `any(MyTaintKind t).taints(node)`
would *stop* working, if it did not define its own configuration. (this actually
happened to us)

We performed a dist-compare to ensure there is not a performance degration by
doing this. Results at https://git.semmle.com/gist/rasmuswl/a1eca07f3a92f5f65ee78d733e5d260e