### PR TITLE
Docs: update terminology in markdown files (SD-4059)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,4 +1,4 @@
-# Contributing to QL
+# Contributing to CodeQL
 
 We welcome contributions to our standard library and standard checks. Got an idea for a new check, or how to improve an existing query? Then please go ahead and open a pull request!
 
@@ -9,13 +9,13 @@ Before we accept your pull request, we require that you have agreed to our Contr
 If you have an idea for a query that you would like to share with other Semmle users, please open a pull request to add it to this repository. 
 Follow the steps below to help other users understand what your query does, and to ensure that your query is consistent with the other Semmle queries.
 
-1. **Consult the QL documentation for query writers**
+1. **Consult the documentation for query writers**
 
-   There is lots of useful documentation to help you write QL, ranging from information about query file structure to language-specific tutorials. For more information on the documentation available, see [Writing QL queries](https://help.semmle.com/QL/learn-ql/writing-queries/writing-queries.html) on [help.semmle.com](https://help.semmle.com).
+   There is lots of useful documentation to help you write queries, ranging from information about query file structure to tutorials for specific target languages. For more information on the documentation available, see [Writing CodeQL queries](https://help.semmle.com/QL/learn-ql/writing-queries/writing-queries.html) on [help.semmle.com](https://help.semmle.com).
 
-2. **Format your QL correctly**
+2. **Format your code correctly**
 
-   All of Semmle's standard QL queries and libraries are uniformly formatted for clarity and consistency, so we strongly recommend that all QL contributions follow the same formatting guidelines. If you use QL for Eclipse, you can auto-format your query in the [QL editor](https://help.semmle.com/ql-for-eclipse/Content/WebHelp/ql-editor.html). For more information, see the [QL style guide](https://github.com/Semmle/ql/blob/master/docs/ql-style-guide.md).
+   All of Semmle's standard queries and libraries are uniformly formatted for clarity and consistency, so we strongly recommend that all contributions follow the same formatting guidelines. If you use QL for Eclipse, you can auto-format your query in the [QL editor](https://help.semmle.com/ql-for-eclipse/Content/WebHelp/ql-editor.html). For more information, see the [CodeQL style guide](https://github.com/Semmle/ql/blob/master/docs/ql-style-guide.md).
 
 3. **Make sure your query has the correct metadata**
 
@@ -29,7 +29,7 @@ Follow the steps below to help other users understand what your query does, and 
    The `select` statement of your query must be compatible with the query type (determined by the `@kind` metadata property) for alert or path results to be displayed correctly in LGTM and QL for Eclipse.
    For more information on `select` statement format, see [Introduction to query files](https://help.semmle.com/QL/learn-ql/writing-queries/introduction-to-queries.html#select-clause) on help.semmle.com.
 
-5. **Save your query in a `.ql` file in correct language directory in this repository**
+5. **Save your query in a `.ql` file in the correct language directory in this repository**
 
    There are five language-specific directories in this repository:
    
@@ -54,7 +54,7 @@ repositories, which might be made public. We might also use this information
 to contact you in relation to your contributions, as well as in the
 normal course of software development. We also store records of your
 CLA agreements. Under GDPR legislation, we do this
-on the basis of our legitimate interest in creating the QL product.
+on the basis of our legitimate interest in creating the CodeQL product.
 
 Please do get in touch (privacy@semmle.com) if you have any questions about
 this or our data protection policies.

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ This open source repository contains the standard CodeQL libraries and queries t
 ## How do I learn CodeQL and run queries?
 
 There is [extensive documentation](https://help.semmle.com/QL/learn-ql/) on getting started with writing CodeQL.
-You can use the [interactive query console](https://lgtm.com/help/lgtm/using-query-console) on LGTM.com or the [QL for Eclipse](https://lgtm.com/help/lgtm/running-queries-ide) plugin to try out your queries on any open-source project that's currently being analyzed.
+You can use the [interactive query console](https://lgtm.com/help/lgtm/using-query-console) on LGTM.com or the [QL for Eclipse](https://lgtm.com/help/lgtm/running-queries-ide) plugin to try out your queries on any open source project that's currently being analyzed.
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -1,16 +1,16 @@
-# Semmle QL
+# CodeQL
 
-This open source repository contains the standard QL libraries and queries that power [LGTM](https://lgtm.com), and the other products that [Semmle](https://semmle.com) makes available to its customers worldwide.
+This open source repository contains the standard CodeQL libraries and queries that power [LGTM](https://lgtm.com), and the other products that [Semmle](https://semmle.com) makes available to its customers worldwide.
 
-## How do I learn QL and run queries?
+## How do I learn CodeQL and run queries?
 
-There is [extensive documentation](https://help.semmle.com/QL/learn-ql/) on getting started with writing QL.
+There is [extensive documentation](https://help.semmle.com/QL/learn-ql/) on getting started with writing CodeQL.
 You can use the [interactive query console](https://lgtm.com/help/lgtm/using-query-console) on LGTM.com or the [QL for Eclipse](https://lgtm.com/help/lgtm/running-queries-ide) plugin to try out your queries on any open-source project that's currently being analyzed.
 
 ## Contributing
 
-We welcome contributions to our standard library and standard checks. Do you have an idea for a new check, or how to improve an existing query? Then please go ahead and open a pull request! Before you do, though, please take the time to read our [contributing guidelines](CONTRIBUTING.md). You can also consult our [style guides](https://github.com/Semmle/ql/tree/master/docs) to learn how to format your QL for consistency and clarity, how to write query metadata, and how to write query help documentation for your query.
+We welcome contributions to our standard library and standard checks. Do you have an idea for a new check, or how to improve an existing query? Then please go ahead and open a pull request! Before you do, though, please take the time to read our [contributing guidelines](CONTRIBUTING.md). You can also consult our [style guides](https://github.com/Semmle/ql/tree/master/docs) to learn how to format your code for consistency and clarity, how to write query metadata, and how to write query help documentation for your query.
 
 ## License
 
-The QL queries in this repository are licensed under [Apache License 2.0](LICENSE) by [Semmle](https://semmle.com).
+The code in this repository is licensed under [Apache License 2.0](LICENSE) by [Semmle](https://semmle.com).

--- a/change-notes/1.23/analysis-cpp.md
+++ b/change-notes/1.23/analysis-cpp.md
@@ -24,7 +24,7 @@ The following changes in version 1.23 affect C/C++ analysis in all applications.
 | Unclear comparison precedence (`cpp/comparison-precedence`) | Fewer false positive results | False positives involving template classes and functions have been fixed. |
 | Comparison of narrow type with wide type in loop condition (`cpp/comparison-with-wider-type`) | Higher precision | The precision of this query has been increased to "high" as the alerts from this query have proved to be valuable on real-world projects. With this precision, results are now displayed by default in LGTM. |
 
-## Changes to QL libraries
+## Changes to libraries
 
 * The data-flow library has been extended with a new feature to aid debugging.
   Instead of specifying `isSink(Node n) { any() }` on a configuration to

--- a/change-notes/1.23/analysis-csharp.md
+++ b/change-notes/1.23/analysis-csharp.md
@@ -24,7 +24,7 @@ The following changes in version 1.23 affect C# analysis in all applications.
 
 * `nameof` expressions are now extracted correctly when the name is a namespace.
 
-## Changes to QL libraries
+## Changes to libraries
 
 * The new class `NamespaceAccess` models accesses to namespaces, for example in `nameof` expressions.
 * The data-flow library now makes it easier to specify barriers/sanitizers

--- a/change-notes/1.23/analysis-java.md
+++ b/change-notes/1.23/analysis-java.md
@@ -19,7 +19,7 @@ The following changes in version 1.23 affect Java analysis in all applications.
 | Query built without neutralizing special characters (`java/concatenated-sql-query`) | More results | The query now identifies arguments to `Statement.executeLargeUpdate` and `Connection.prepareCall` as SQL expressions sinks. |
 | Useless comparison test (`java/constant-comparison`) | Fewer false positives | Additional overflow check patterns are now recognized and no longer reported. |
 
-## Changes to QL libraries
+## Changes to libraries
 
 * The data-flow library has been extended with a new feature to aid debugging.
   Instead of specifying `isSink(Node n) { any() }` on a configuration to

--- a/change-notes/1.23/analysis-javascript.md
+++ b/change-notes/1.23/analysis-javascript.md
@@ -46,7 +46,7 @@
 | Uncontrolled data used in path expression (`js/path-injection`) | Fewer false-positive results | This query now recognizes calls to Express `sendFile` as safe in some cases. |
 | Unknown directive (`js/unknown-directive`) | Fewer false positive results | This query no longer flags uses of ":", which is sometimes used like a directive. |
 
-## Changes to QL libraries
+## Changes to libraries
 
 * `Expr.getDocumentation()` now handles chain assignments.
 

--- a/change-notes/support/README.md
+++ b/change-notes/support/README.md
@@ -1,6 +1,6 @@
 # Files moved to ``docs`` directory
 
-Now that all of the QL documentation is in this repository,
+Now that all of the CodeQL documentation is in this repository,
 notes on the languages, compilers, and frameworks supported have moved.
 They're now stored as part of the Sphinx ``support`` project with the other documentation:
 ``docs/language/support``.

--- a/docs/ql-style-guide.md
+++ b/docs/ql-style-guide.md
@@ -1,8 +1,8 @@
-# QL Style Guide
+# CodeQL style guide
 
 ## Introduction
 
-This document describes how to format the QL code you contribute to this repository. It covers aspects such as layout, white-space, naming, and documentation. Adhering to consistent standards makes code easier to read and maintain. Of course, these are only guidelines, and can be overridden as the need arises on a case-by-case basis. Where existing code deviates from these guidelines, prefer consistency with the surrounding code.
+This document describes how to format the code you contribute to this repository. It covers aspects such as layout, white-space, naming, and documentation. Adhering to consistent standards makes code easier to read and maintain. Of course, these are only guidelines, and can be overridden as the need arises on a case-by-case basis. Where existing code deviates from these guidelines, prefer consistency with the surrounding code.
 Note, if you use QL for Eclipse, you can auto-format your query in the [QL editor](https://help.semmle.com/ql-for-eclipse/Content/WebHelp/ql-editor.html).
 
 Words in *italic* are defined in the [Glossary](#glossary).

--- a/docs/query-metadata-style-guide.md
+++ b/docs/query-metadata-style-guide.md
@@ -13,7 +13,7 @@ Query files have the extension `.ql`. Each file has two distinct areas:
     *   [Learning CodeQL](https://help.semmle.com/QL/learn-ql/index.html)
     *   [QL language handbook](https://help.semmle.com/QL/ql-handbook/index.html)
     *   [QL language specification](https://help.semmle.com/QL/ql-spec/language.html)
-    *   [QL style guide](https://github.com/Semmle/ql/blob/master/docs/ql-style-guide.md) 
+    *   [CodeQL style guide](https://github.com/Semmle/ql/blob/master/docs/ql-style-guide.md) 
 
 
 For examples of query files for the languages supported by CodeQL, visit the following links: 

--- a/docs/query-metadata-style-guide.md
+++ b/docs/query-metadata-style-guide.md
@@ -1,6 +1,5 @@
 # Query file metadata and alert message style guide
 
-
 ## Introduction
 
 This document outlines the structure of Semmle query files. You should adopt this structure when contributing custom queries to this repository, in order to ensure that new queries are consistent with the standard Semmle queries.
@@ -11,13 +10,13 @@ Query files have the extension `.ql`. Each file has two distinct areas:
 
 *   Metadata area–displayed at the top of the file, contains the metadata that defines how results for the query are interpreted and gives a brief description of the purpose of the query.
 *   Query definition–defined using QL. The query includes a select statement, which defines the content and format of the results. For further information about writing QL, see the following topics:
-    *   [Learning QL](https://help.semmle.com/QL/learn-ql/index.html)
+    *   [Learning CodeQL](https://help.semmle.com/QL/learn-ql/index.html)
     *   [QL language handbook](https://help.semmle.com/QL/ql-handbook/index.html)
     *   [QL language specification](https://help.semmle.com/QL/ql-spec/language.html)
     *   [QL style guide](https://github.com/Semmle/ql/blob/master/docs/ql-style-guide.md) 
 
 
-For examples of query files for the languages supported by Semmle, visit the following links: 
+For examples of query files for the languages supported by CodeQL, visit the following links: 
 
 *   [C/C++ queries](https://help.semmle.com/wiki/display/CCPPOBJ/)
 *   [C# queries](https://help.semmle.com/wiki/display/CSHARP/)
@@ -178,4 +177,4 @@ For examples of select clauses and alert messages, see the query source files at
 *   [JavaScript queries](https://help.semmle.com/wiki/display/JS/)
 *   [Python queries](https://help.semmle.com/wiki/display/PYTHON/)
 
-For further information on query writing, see  [Writing QL queries](https://help.semmle.com/QL/learn-ql/ql/writing-queries/writing-queries.html). For more information on learning QL, see [Learning QL](https://help.semmle.com/QL/learn-ql/index.html).
+For further information on query writing, see  [Writing CodeQL queries](https://help.semmle.com/QL/learn-ql/ql/writing-queries/writing-queries.html). For more information on learning CodeQL, see [Learning CodeQL](https://help.semmle.com/QL/learn-ql/index.html).


### PR DESCRIPTION
This PR is closely related to #2180.

@p0 - if you have time to check that I've made the right call on QL vs CodeQL in these files that would be great. There were a couple of places I've left "QL" where I wasn't entirely sure.

When we merge this, I suggest we revise the repository description to something like: "The standard libraries and queries that power LGTM.com, CodeQL, and other Semmle products".

**Can we change the `CONTRIBUTING.md` file without requiring people to re-sign the CLA?** If not, and if there are further changes expected to that file, I'll drop that change from this PR.

@shati-patel, @jf205, @sj - for information mostly, but do comment if you spot any errors.