### PR TITLE
C++: Minimal caching of the IR type system

### DIFF
--- a/cpp/ql/src/semmle/code/cpp/ir/implementation/IRType.qll
+++ b/cpp/ql/src/semmle/code/cpp/ir/implementation/IRType.qll
@@ -4,6 +4,7 @@
 
 private import internal.IRTypeInternal
 
+cached
 private newtype TIRType =
   TIRVoidType() or
   TIRUnknownType() or

--- a/cpp/ql/src/semmle/code/cpp/ir/internal/CppType.qll
+++ b/cpp/ql/src/semmle/code/cpp/ir/internal/CppType.qll
@@ -175,6 +175,7 @@ private IRType getIRTypeForPRValue(Type type) {
   )
 }
 
+cached
 private newtype TCppType =
   TPRValueType(Type type) { exists(getIRTypeForPRValue(type)) } or
   TFunctionGLValueType() or
@@ -203,6 +204,7 @@ class CppType extends TCppType {
    * Gets the `IRType` that represents this `CppType`. Many different `CppType`s can map to a single
    * `IRType`.
    */
+  cached
   IRType getIRType() { none() }
 
   /**

--- a/csharp/ql/src/semmle/code/csharp/ir/implementation/IRType.qll
+++ b/csharp/ql/src/semmle/code/csharp/ir/implementation/IRType.qll
@@ -4,6 +4,7 @@
 
 private import internal.IRTypeInternal
 
+cached
 private newtype TIRType =
   TIRVoidType() or
   TIRUnknownType() or

--- a/csharp/ql/src/semmle/code/csharp/ir/internal/CSharpType.qll
+++ b/csharp/ql/src/semmle/code/csharp/ir/internal/CSharpType.qll
@@ -144,6 +144,7 @@ private IRType getIRTypeForPRValue(Type type) {
 
 string getOpaqueTagIdentityString(Type tag) { result = tag.getQualifiedName() }
 
+cached
 private newtype TCSharpType =
   TPRValueType(Type type) { exists(getIRTypeForPRValue(type)) } or
   TGLValueAddressType(Type type) { any() } or
@@ -163,6 +164,7 @@ class CSharpType extends TCSharpType {
    * Gets the `IRType` that represents this `CSharpType`. Many different `CSharpType`s can map to a
    * single `IRType`.
    */
+  cached
   abstract IRType getIRType();
 
   /**


### PR DESCRIPTION
(follow-up to #2008)

This was the minimal amount of predicates I could easily cache without introducing extra cached stages. The predicates that are not cached here, like `CppType::getTypeSize` and `getCanonicalLanguageType`, appear to be cheap.

I've tested that this avoids recomputation of the IR type system by running

    grep -c 'Starting to evaluate predicate CppType::CppType::getIRType_dispred'

on the evaluator log for `IRSanity.ql`. It drops from 4 to 1. The pretty-printed DIL drops from 79,175 lines to 76,326 lines.