### PR TITLE
JavaScript: Improve double-escaping query

### DIFF
--- a/change-notes/1.23/analysis-javascript.md
+++ b/change-notes/1.23/analysis-javascript.md
@@ -31,6 +31,7 @@
 
 | **Query**                      | **Expected impact**          | **Change**                                                                |
 |--------------------------------|------------------------------|---------------------------------------------------------------------------|
+| Double escaping or unescaping (`js/double-escaping`) | More results | This rule now detects additional escaping and unescaping functions. |
 | Incomplete string escaping or encoding (`js/incomplete-sanitization`) | Fewer false-positive results | This rule now recognizes additional ways delimiters can be stripped away. |
 | Client-side cross-site scripting (`js/xss`) | More results, fewer false-positive results | More potential vulnerabilities involving functions that manipulate DOM attributes are now recognized, and more sanitizers are detected. |
 | Code injection (`js/code-injection`) | More results | More potential vulnerabilities involving functions that manipulate DOM event handler attributes are now recognized. |

--- a/javascript/ql/src/Security/CWE-116/DoubleEscaping.qhelp
+++ b/javascript/ql/src/Security/CWE-116/DoubleEscaping.qhelp
@@ -10,8 +10,8 @@ attacks such as cross-site scripting. One particular example of this is HTML ent
 where HTML special characters are replaced by HTML character entities to prevent them from being
 interpreted as HTML markup. For example, the less-than character is encoded as <code>&amp;lt;</code>
 and the double-quote character as <code>&amp;quot;</code>.
-Other examples include backslash-escaping for including untrusted data in string literals and
-percent-encoding for URI components.
+Other examples include backslash escaping or JSON encoding for including untrusted data in string
+literals, and percent-encoding for URI components.
 </p>
 <p>
 The reverse process of replacing escape sequences with the characters they represent is known as

--- a/javascript/ql/src/Security/CWE-116/DoubleEscaping.ql
+++ b/javascript/ql/src/Security/CWE-116/DoubleEscaping.ql
@@ -116,16 +116,12 @@ abstract class Replacement extends DataFlow::Node {
   /**
    * Gets the previous replacement in this chain of replacements.
    */
-  Replacement getPreviousReplacement() {
-    result.getOutput() = getASimplePredecessor*(getInput())
-  }
+  Replacement getPreviousReplacement() { result.getOutput() = getASimplePredecessor*(getInput()) }
 
   /**
    * Gets the next replacement in this chain of replacements.
    */
-  Replacement getNextReplacement() {
-    this = result.getPreviousReplacement()
-  }
+  Replacement getNextReplacement() { this = result.getPreviousReplacement() }
 
   /**
    * Gets an earlier replacement in this chain of replacements that
@@ -182,35 +178,25 @@ class GlobalStringReplacement extends Replacement, DataFlow::MethodCallNode {
     )
   }
 
-  override DataFlow::Node getInput() {
-    result = this.getReceiver()
-  }
+  override DataFlow::Node getInput() { result = this.getReceiver() }
 
-  override DataFlow::SourceNode getOutput() {
-    result = this
-  }
+  override DataFlow::SourceNode getOutput() { result = this }
 }
 
 /**
  * A call to `JSON.stringify`, viewed as a string replacement.
  */
 class JsonStringifyReplacement extends Replacement, DataFlow::CallNode {
-  JsonStringifyReplacement() {
-    this = DataFlow::globalVarRef("JSON").getAMemberCall("stringify")
-  }
+  JsonStringifyReplacement() { this = DataFlow::globalVarRef("JSON").getAMemberCall("stringify") }
 
   override predicate replaces(string input, string output) {
     input = "\\" and output = "\\\\"
     // the other replacements are not relevant for this query
   }
 
-  override DataFlow::Node getInput() {
-    result = this.getArgument(0)
-  }
+  override DataFlow::Node getInput() { result = this.getArgument(0) }
 
-  override DataFlow::SourceNode getOutput() {
-    result = this
-  }
+  override DataFlow::SourceNode getOutput() { result = this }
 }
 
 /**
@@ -219,22 +205,16 @@ class JsonStringifyReplacement extends Replacement, DataFlow::CallNode {
 class JsonParseReplacement extends Replacement {
   JsonParserCall self;
 
-  JsonParseReplacement() {
-    this = self
-  }
+  JsonParseReplacement() { this = self }
 
   override predicate replaces(string input, string output) {
     input = "\\\\" and output = "\\"
     // the other replacements are not relevant for this query
   }
 
-  override DataFlow::Node getInput() {
-    result = self.getInput()
-  }
+  override DataFlow::Node getInput() { result = self.getInput() }
 
-  override DataFlow::SourceNode getOutput() {
-    result = self.getOutput()
-  }
+  override DataFlow::SourceNode getOutput() { result = self.getOutput() }
 }
 
 /**
@@ -252,17 +232,11 @@ class WrappedReplacement extends Replacement, DataFlow::CallNode {
     )
   }
 
-  override predicate replaces(string input, string output) {
-    inner.replaces(input, output)
-  }
+  override predicate replaces(string input, string output) { inner.replaces(input, output) }
 
-  override DataFlow::Node getInput() {
-    result = getArgument(i)
-  }
+  override DataFlow::Node getInput() { result = getArgument(i) }
 
-  override DataFlow::SourceNode getOutput() {
-    result = this
-  }
+  override DataFlow::SourceNode getOutput() { result = this }
 }
 
 from Replacement primary, Replacement supplementary, string message, string metachar

--- a/javascript/ql/src/Security/CWE-116/DoubleEscaping.ql
+++ b/javascript/ql/src/Security/CWE-116/DoubleEscaping.ql
@@ -221,6 +221,34 @@ class JsonParseReplacement extends Replacement {
   }
 }
 
+/**
+ * A string replacement wrapped in a utility function.
+ */
+class WrappedReplacement extends Replacement, DataFlow::CallNode {
+  int i;
+
+  Replacement inner;
+
+  WrappedReplacement() {
+    exists(DataFlow::FunctionNode wrapped | wrapped.getFunction() = getACallee() |
+      wrapped.getParameter(i).flowsTo(inner.getInput()) and
+      inner.getOutput().flowsTo(wrapped.getAReturn())
+    )
+  }
+
+  override predicate replaces(string input, string output) {
+    inner.replaces(input, output)
+  }
+
+  override DataFlow::Node getInput() {
+    result = getArgument(i)
+  }
+
+  override DataFlow::SourceNode getOutput() {
+    result = this
+  }
+}
+
 from Replacement primary, Replacement supplementary, string message, string metachar
 where
   primary.escapes(metachar, _) and

--- a/javascript/ql/src/Security/CWE-116/DoubleEscaping.ql
+++ b/javascript/ql/src/Security/CWE-116/DoubleEscaping.ql
@@ -54,11 +54,11 @@ DataFlow::Node getASimplePredecessor(DataFlow::Node nd) {
  * into a form described by regular expression `regex`.
  */
 predicate escapingScheme(string metachar, string regex) {
-  metachar = "&" and regex = "&.*;"
+  metachar = "&" and regex = "&.+;"
   or
-  metachar = "%" and regex = "%.*"
+  metachar = "%" and regex = "%.+"
   or
-  metachar = "\\" and regex = "\\\\.*"
+  metachar = "\\" and regex = "\\\\.+"
 }
 
 /**

--- a/javascript/ql/src/Security/CWE-116/DoubleEscaping.ql
+++ b/javascript/ql/src/Security/CWE-116/DoubleEscaping.ql
@@ -156,6 +156,14 @@ class GlobalStringReplacement extends Replacement, DataFlow::MethodCallNode {
   override predicate replaces(string input, string output) {
     input = getStringValue(pattern) and
     output = this.getArgument(1).getStringValue()
+    or
+    exists(DataFlow::FunctionNode replacer, DataFlow::PropRead pr, DataFlow::ObjectLiteralNode map |
+      replacer = getCallback(1) and
+      replacer.getParameter(0).flowsToExpr(pr.getPropertyNameExpr()) and
+      pr = map.getAPropertyRead() and
+      pr.flowsTo(replacer.getAReturn()) and
+      map.asExpr().(ObjectExpr).getPropertyByName(input).getInit().getStringValue() = output
+    )
   }
 
   override DataFlow::Node getInput() {

--- a/javascript/ql/src/Security/CWE-116/DoubleEscaping.ql
+++ b/javascript/ql/src/Security/CWE-116/DoubleEscaping.ql
@@ -135,7 +135,9 @@ abstract class Replacement extends DataFlow::Node {
     exists(Replacement pred | pred = this.getPreviousReplacement() |
       if pred.escapes(_, metachar)
       then result = pred
-      else result = pred.getAnEarlierEscaping(metachar)
+      else (
+        not pred.unescapes(metachar, _) and result = pred.getAnEarlierEscaping(metachar)
+      )
     )
   }
 
@@ -147,7 +149,9 @@ abstract class Replacement extends DataFlow::Node {
     exists(Replacement succ | this = succ.getPreviousReplacement() |
       if succ.unescapes(metachar, _)
       then result = succ
-      else result = succ.getALaterUnescaping(metachar)
+      else (
+        not succ.escapes(_, metachar) and result = succ.getALaterUnescaping(metachar)
+      )
     )
   }
 }

--- a/javascript/ql/src/Security/CWE-116/DoubleEscaping.ql
+++ b/javascript/ql/src/Security/CWE-116/DoubleEscaping.ql
@@ -167,6 +167,52 @@ class GlobalStringReplacement extends Replacement, DataFlow::MethodCallNode {
   }
 }
 
+/**
+ * A call to `JSON.stringify`, viewed as a string replacement.
+ */
+class JsonStringifyReplacement extends Replacement, DataFlow::CallNode {
+  JsonStringifyReplacement() {
+    this = DataFlow::globalVarRef("JSON").getAMemberCall("stringify")
+  }
+
+  override predicate replaces(string input, string output) {
+    input = "\\" and output = "\\\\"
+    // the other replacements are not relevant for this query
+  }
+
+  override DataFlow::Node getInput() {
+    result = this.getArgument(0)
+  }
+
+  override DataFlow::SourceNode getOutput() {
+    result = this
+  }
+}
+
+/**
+ * A call to `JSON.parse`, viewed as a string replacement.
+ */
+class JsonParseReplacement extends Replacement {
+  JsonParserCall self;
+
+  JsonParseReplacement() {
+    this = self
+  }
+
+  override predicate replaces(string input, string output) {
+    input = "\\\\" and output = "\\"
+    // the other replacements are not relevant for this query
+  }
+
+  override DataFlow::Node getInput() {
+    result = self.getInput()
+  }
+
+  override DataFlow::SourceNode getOutput() {
+    result = self.getOutput()
+  }
+}
+
 from Replacement primary, Replacement supplementary, string message, string metachar
 where
   primary.escapes(metachar, _) and

--- a/javascript/ql/src/Security/CWE-116/DoubleEscaping.ql
+++ b/javascript/ql/src/Security/CWE-116/DoubleEscaping.ql
@@ -46,7 +46,12 @@ string getStringValue(RegExpLiteral rl) {
  */
 DataFlow::Node getASimplePredecessor(DataFlow::Node nd) {
   result = nd.getAPredecessor() and
-  not nd.(DataFlow::SsaDefinitionNode).getSsaVariable().getDefinition() instanceof SsaPhiNode
+  not exists(SsaDefinition ssa |
+    ssa = nd.(DataFlow::SsaDefinitionNode).getSsaVariable().getDefinition()
+  |
+    ssa instanceof SsaPhiNode or
+    ssa instanceof SsaVariableCapture
+  )
 }
 
 /**

--- a/javascript/ql/src/Security/CWE-116/DoubleEscaping.ql
+++ b/javascript/ql/src/Security/CWE-116/DoubleEscaping.ql
@@ -116,6 +116,13 @@ abstract class Replacement extends DataFlow::Node {
   }
 
   /**
+   * Gets the next replacement in this chain of replacements.
+   */
+  Replacement getNextReplacement() {
+    this = result.getPreviousReplacement()
+  }
+
+  /**
    * Gets an earlier replacement in this chain of replacements that
    * performs an escaping.
    */
@@ -231,8 +238,8 @@ class WrappedReplacement extends Replacement, DataFlow::CallNode {
 
   WrappedReplacement() {
     exists(DataFlow::FunctionNode wrapped | wrapped.getFunction() = getACallee() |
-      wrapped.getParameter(i).flowsTo(inner.getInput()) and
-      inner.getOutput().flowsTo(wrapped.getAReturn())
+      wrapped.getParameter(i).flowsTo(inner.getPreviousReplacement*().getInput()) and
+      inner.getNextReplacement*().getOutput().flowsTo(wrapped.getAReturn())
     )
   }
 

--- a/javascript/ql/test/query-tests/Security/CWE-116/DoubleEscaping/DoubleEscaping.expected
+++ b/javascript/ql/test/query-tests/Security/CWE-116/DoubleEscaping/DoubleEscaping.expected
@@ -9,3 +9,4 @@
 | tst.js:86:10:86:22 | JSON.parse(s) | This replacement may produce '\\' characters that are double-unescaped $@. | tst.js:86:10:86:47 | JSON.pa ... g, "<") | here |
 | tst.js:99:10:99:66 | s.repla ... &amp;") | This replacement may double-escape '&' characters from $@. | tst.js:99:10:99:43 | s.repla ... epl[c]) | here |
 | tst.js:107:10:107:53 | encodeD ... &amp;") | This replacement may double-escape '&' characters from $@. | tst.js:107:10:107:30 | encodeD ... otes(s) | here |
+| tst.js:115:10:115:47 | encodeQ ... &amp;") | This replacement may double-escape '&' characters from $@. | tst.js:115:10:115:24 | encodeQuotes(s) | here |

--- a/javascript/ql/test/query-tests/Security/CWE-116/DoubleEscaping/DoubleEscaping.expected
+++ b/javascript/ql/test/query-tests/Security/CWE-116/DoubleEscaping/DoubleEscaping.expected
@@ -5,3 +5,5 @@
 | tst.js:53:10:53:33 | s.repla ... , '\\\\') | This replacement may produce '\\' characters that are double-unescaped $@. | tst.js:53:10:54:33 | s.repla ... , '\\'') | here |
 | tst.js:60:7:60:28 | s.repla ...  '%25') | This replacement may double-escape '%' characters from $@. | tst.js:59:7:59:28 | s.repla ...  '%26') | here |
 | tst.js:68:10:70:38 | s.repla ... &amp;") | This replacement may double-escape '&' characters from $@. | tst.js:68:10:69:39 | s.repla ... apos;") | here |
+| tst.js:74:10:77:10 | JSON.st ...       ) | This replacement may double-escape '\\' characters from $@. | tst.js:75:12:76:37 | s.repla ... u003E") | here |
+| tst.js:86:10:86:22 | JSON.parse(s) | This replacement may produce '\\' characters that are double-unescaped $@. | tst.js:86:10:86:47 | JSON.pa ... g, "<") | here |

--- a/javascript/ql/test/query-tests/Security/CWE-116/DoubleEscaping/DoubleEscaping.expected
+++ b/javascript/ql/test/query-tests/Security/CWE-116/DoubleEscaping/DoubleEscaping.expected
@@ -7,3 +7,4 @@
 | tst.js:68:10:70:38 | s.repla ... &amp;") | This replacement may double-escape '&' characters from $@. | tst.js:68:10:69:39 | s.repla ... apos;") | here |
 | tst.js:74:10:77:10 | JSON.st ...       ) | This replacement may double-escape '\\' characters from $@. | tst.js:75:12:76:37 | s.repla ... u003E") | here |
 | tst.js:86:10:86:22 | JSON.parse(s) | This replacement may produce '\\' characters that are double-unescaped $@. | tst.js:86:10:86:47 | JSON.pa ... g, "<") | here |
+| tst.js:99:10:99:66 | s.repla ... &amp;") | This replacement may double-escape '&' characters from $@. | tst.js:99:10:99:43 | s.repla ... epl[c]) | here |

--- a/javascript/ql/test/query-tests/Security/CWE-116/DoubleEscaping/DoubleEscaping.expected
+++ b/javascript/ql/test/query-tests/Security/CWE-116/DoubleEscaping/DoubleEscaping.expected
@@ -8,3 +8,4 @@
 | tst.js:74:10:77:10 | JSON.st ...       ) | This replacement may double-escape '\\' characters from $@. | tst.js:75:12:76:37 | s.repla ... u003E") | here |
 | tst.js:86:10:86:22 | JSON.parse(s) | This replacement may produce '\\' characters that are double-unescaped $@. | tst.js:86:10:86:47 | JSON.pa ... g, "<") | here |
 | tst.js:99:10:99:66 | s.repla ... &amp;") | This replacement may double-escape '&' characters from $@. | tst.js:99:10:99:43 | s.repla ... epl[c]) | here |
+| tst.js:107:10:107:53 | encodeD ... &amp;") | This replacement may double-escape '&' characters from $@. | tst.js:107:10:107:30 | encodeD ... otes(s) | here |

--- a/javascript/ql/test/query-tests/Security/CWE-116/DoubleEscaping/tst.js
+++ b/javascript/ql/test/query-tests/Security/CWE-116/DoubleEscaping/tst.js
@@ -69,3 +69,23 @@ function badEncode(s) {
           .replace(indirect2, "&apos;")
           .replace(indirect3, "&amp;");
 }
+
+function badEscape1(s) {
+  return JSON.stringify(
+           s.replace(/</g, "\\u003C")
+            .replace(/>/g, "\\u003E")
+         );
+}
+
+function goodEscape1(s) {
+  return JSON.stringify(s)
+             .replace(/</g, "\\u003C").replace(/>/g, "\\u003E");
+}
+
+function badUnescape2(s) {
+  return JSON.parse(s).replace(/\\u003C/g, "<").replace(/\\u003E/g, ">");
+}
+
+function goodUnescape2(s) {
+  return JSON.parse(s.replace(/\\u003C/g, "<").replace(/\\u003E/g, ">"));
+}

--- a/javascript/ql/test/query-tests/Security/CWE-116/DoubleEscaping/tst.js
+++ b/javascript/ql/test/query-tests/Security/CWE-116/DoubleEscaping/tst.js
@@ -114,3 +114,12 @@ function encodeQuotes(s) {
 function badWrappedEncode2(s) {
   return encodeQuotes(s).replace(/&/g, "&amp;");
 }
+
+function roundtrip(s) {
+  return JSON.parse(JSON.stringify(s));
+}
+
+// dubious, but out of scope for this query
+function badRoundtrip(s) {
+  return s.replace(/\\\\/g, "\\").replace(/\\/g, "\\\\");
+}

--- a/javascript/ql/test/query-tests/Security/CWE-116/DoubleEscaping/tst.js
+++ b/javascript/ql/test/query-tests/Security/CWE-116/DoubleEscaping/tst.js
@@ -123,3 +123,10 @@ function roundtrip(s) {
 function badRoundtrip(s) {
   return s.replace(/\\\\/g, "\\").replace(/\\/g, "\\\\");
 }
+
+function testWithCapturedVar(x) {
+  var captured = x;
+  (function() {
+    captured = captured.replace(/\\/g, "\\\\");
+  })();
+}

--- a/javascript/ql/test/query-tests/Security/CWE-116/DoubleEscaping/tst.js
+++ b/javascript/ql/test/query-tests/Security/CWE-116/DoubleEscaping/tst.js
@@ -98,3 +98,11 @@ function badEncodeWithReplacer(s) {
   };
   return s.replace(/["']/g, (c) => repl[c]).replace(/&/g, "&amp;");
 }
+
+function encodeDoubleQuotes(s) {
+  return s.replace(/"/g, "&quot;");
+}
+
+function badWrappedEncode(s) {
+  return encodeDoubleQuotes(s).replace(/&/g, "&amp;");
+}

--- a/javascript/ql/test/query-tests/Security/CWE-116/DoubleEscaping/tst.js
+++ b/javascript/ql/test/query-tests/Security/CWE-116/DoubleEscaping/tst.js
@@ -130,3 +130,7 @@ function testWithCapturedVar(x) {
     captured = captured.replace(/\\/g, "\\\\");
   })();
 }
+
+function cloneAndStringify(s) {
+  return JSON.stringify(JSON.parse(JSON.stringify(s)));
+}

--- a/javascript/ql/test/query-tests/Security/CWE-116/DoubleEscaping/tst.js
+++ b/javascript/ql/test/query-tests/Security/CWE-116/DoubleEscaping/tst.js
@@ -89,3 +89,12 @@ function badUnescape2(s) {
 function goodUnescape2(s) {
   return JSON.parse(s.replace(/\\u003C/g, "<").replace(/\\u003E/g, ">"));
 }
+
+function badEncodeWithReplacer(s) {
+  var repl = {
+    '"': "&quot;",
+    "'": "&apos;",
+    "&": "&amp;"
+  };
+  return s.replace(/["']/g, (c) => repl[c]).replace(/&/g, "&amp;");
+}

--- a/javascript/ql/test/query-tests/Security/CWE-116/DoubleEscaping/tst.js
+++ b/javascript/ql/test/query-tests/Security/CWE-116/DoubleEscaping/tst.js
@@ -106,3 +106,11 @@ function encodeDoubleQuotes(s) {
 function badWrappedEncode(s) {
   return encodeDoubleQuotes(s).replace(/&/g, "&amp;");
 }
+
+function encodeQuotes(s) {
+  return s.replace(/"/g, "&quot;").replace(/'/g, "&apos;");
+}
+
+function badWrappedEncode2(s) {
+  return encodeQuotes(s).replace(/&/g, "&amp;");
+}


### PR DESCRIPTION
The query can now spot the vulnerability fixed in https://github.com/Rich-Harris/devalue/commit/14cae90d1fcd5e0083e3a1741238e017684890d7.

Results of an [evaluation](https://git.semmle.com/max/dist-compare-reports/blob/master/js/odasa-8149/report.md) (internal link) are a bit mixed: the ten results on `uirecorder` are fine in the sense that we would have flagged them before if `escapeStr` had been inlined. That being said the double-replacement may well be intentional.

Similar comments apply to most of the other results: the two double-encoding/decoding results on gatsby look pretty intentional, and while I can't quite wrap my head around what webpack is trying to do, it also looks like they're doing it on purpose.

Finally, the result on etherpad-lite is a false positive resulting from inadequate summarisation of wrapped replacements: we only record one replacement per function, but in this case the function performs two, one after another.

That last result suggests that we may want to think about turning this query into a data-flow query with flow labels recording the various escaped states. That should properly handle this case, and is in general more powerful.

Perfomance-wise, the improvements come at a moderate price; note that timings are for definitions.ql+DoubleEscaping. [Here](https://git.semmle.com/max/dist-compare-reports/blob/master/js/odasa-8149/report2.md) is another report showing just the change in evaluation time for DoubleEscaping itself from the same run; for most snapshots the absolute change is very small.