### PR TITLE
Python: Limit what functions we treat as returning sensitive data

### DIFF
--- a/python/ql/src/semmle/python/security/SensitiveData.qll
+++ b/python/ql/src/semmle/python/security/SensitiveData.qll
@@ -112,12 +112,6 @@ module SensitiveData {
 
     private SensitiveData fromFunction(Value func) {
         result = HeuristicNames::getSensitiveDataForName(func.getName())
-        or
-        // This is particularly to pick up methods with an argument like "password", which
-        // may indicate a lookup.
-        exists(string name | name = func.(PythonFunctionValue).getScope().getAnArg().asName().getId() |
-            result = HeuristicNames::getSensitiveDataForName(name)
-        )
     }
 
     abstract class Source extends TaintSource {


### PR DESCRIPTION
Before this change, any function that has a parameter that was called
password/credentials would be treated as returning sensitive data of that
kind. `py/clear-text-logging-sensitive-data` would alert if one of these are
logged, which has a LOT of false-positives.