### PR TITLE
JS: Treat the LHS of a for-of loop as a PropRead

### DIFF
--- a/javascript/ql/src/semmle/javascript/dataflow/DataFlow.qll
+++ b/javascript/ql/src/semmle/javascript/dataflow/DataFlow.qll
@@ -741,7 +741,8 @@ module DataFlow {
     PropReadAsSourceNode() {
       this = TPropNode(any(PropertyPattern p)) or
       this instanceof RestPatternNode or
-      this instanceof ElementPatternNode
+      this instanceof ElementPatternNode or
+      this = lvalueNode(any(ForOfStmt stmt).getLValue())
     }
   }
 
@@ -824,6 +825,24 @@ module DataFlow {
     override Expr getPropertyNameExpr() { result = astNode.getImported() }
 
     override string getPropertyName() { result = astNode.getImportedName() }
+  }
+
+  /**
+   * The left-hand side of a `for..of` statement, seen as a property read
+   * on the object being iterated over.
+   */
+  private class ForOfLvalueAsPropRead extends PropRead {
+    ForOfStmt stmt;
+
+    ForOfLvalueAsPropRead() {
+      this = lvalueNode(stmt.getLValue())
+    }
+
+    override Node getBase() { result = stmt.getIterationDomain().flow() }
+
+    override Expr getPropertyNameExpr() { none() }
+
+    override string getPropertyName() { none() }
   }
 
   /**

--- a/javascript/ql/test/library-tests/DataFlow/flowStep.expected
+++ b/javascript/ql/test/library-tests/DataFlow/flowStep.expected
@@ -7,6 +7,11 @@
 | sources.js:3:11:3:11 | x | sources.js:4:10:4:10 | x |
 | sources.js:4:10:4:13 | x+19 | sources.js:3:1:5:6 | (functi ... \\n})(23) |
 | sources.js:5:4:5:5 | 23 | sources.js:3:11:3:11 | x |
+| sources.js:9:14:9:18 | array | sources.js:10:19:10:23 | array |
+| sources.js:9:14:9:18 | array | sources.js:11:23:11:27 | array |
+| sources.js:10:12:10:14 | key | sources.js:10:28:10:30 | key |
+| sources.js:11:12:11:18 | key | sources.js:11:32:11:34 | key |
+| sources.js:11:14:11:16 | key | sources.js:11:12:11:18 | key |
 | tst.js:1:1:1:1 | x | tst.js:28:2:28:1 | x |
 | tst.js:1:1:1:1 | x | tst.js:32:1:32:0 | x |
 | tst.js:1:10:1:11 | fs | tst.js:1:10:1:11 | fs |

--- a/javascript/ql/test/library-tests/DataFlow/incomplete.expected
+++ b/javascript/ql/test/library-tests/DataFlow/incomplete.expected
@@ -8,6 +8,11 @@
 | sources.js:1:6:1:11 | exceptional return of anonymous function | call |
 | sources.js:3:1:5:6 | exceptional return of (functi ... \\n})(23) | call |
 | sources.js:3:2:5:1 | exceptional return of anonymous function | call |
+| sources.js:9:1:12:1 | exceptional return of function foo | call |
+| sources.js:9:14:9:18 | array | call |
+| sources.js:10:12:10:14 | key | heap |
+| sources.js:11:12:11:18 | key | heap |
+| sources.js:11:14:11:16 | key | heap |
 | tst.js:1:10:1:11 | fs | import |
 | tst.js:16:1:20:9 | exceptional return of (functi ... ("arg") | call |
 | tst.js:16:2:20:1 | exceptional return of function f | call |

--- a/javascript/ql/test/library-tests/DataFlow/parameters.expected
+++ b/javascript/ql/test/library-tests/DataFlow/parameters.expected
@@ -1,5 +1,6 @@
 | sources.js:1:6:1:6 | x |
 | sources.js:3:11:3:11 | x |
+| sources.js:9:14:9:18 | array |
 | tst.js:16:13:16:13 | a |
 | tst.js:32:12:32:12 | b |
 | tst.js:87:11:87:24 | { p: x, ...o } |

--- a/javascript/ql/test/library-tests/DataFlow/sources.expected
+++ b/javascript/ql/test/library-tests/DataFlow/sources.expected
@@ -13,6 +13,12 @@
 | sources.js:3:2:5:1 | functio ... x+19;\\n} |
 | sources.js:3:11:3:11 | x |
 | sources.js:7:1:7:3 | /x/ |
+| sources.js:9:1:9:0 | this |
+| sources.js:9:1:12:1 | functio ... ey; }\\n} |
+| sources.js:9:14:9:18 | array |
+| sources.js:10:12:10:14 | key |
+| sources.js:11:12:11:18 | { key } |
+| sources.js:11:14:11:16 | key |
 | tst.js:1:1:1:0 | this |
 | tst.js:1:1:1:24 | import  ... m 'fs'; |
 | tst.js:1:10:1:11 | fs |
@@ -60,6 +66,7 @@
 | tst.js:72:9:72:9 | p |
 | tst.js:72:9:72:11 | p() |
 | tst.js:75:9:75:21 | import('foo') |
+| tst.js:80:10:80:10 | v |
 | tst.js:83:11:83:28 | [ for (v of o) v ] |
 | tst.js:85:11:85:28 | ( for (v of o) v ) |
 | tst.js:87:1:96:2 | (functi ... r: 0\\n}) |

--- a/javascript/ql/test/library-tests/DataFlow/sources.js
+++ b/javascript/ql/test/library-tests/DataFlow/sources.js
@@ -5,3 +5,8 @@ new (x => x);
 })(23);
 
 /x/;
+
+function foo(array) {
+  for (let key of array) { key; }
+  for (let { key } of array) { key; }
+}


### PR DESCRIPTION
[Evaluation](https://git.semmle.com/asger/dist-compare-reports/tree/for-of-propread_1572943617874) shows that there is a bit of overhead in doing this, but I think it's worth it.