### PR TITLE
C++: Rudimentary support for IR data flow virtual dispatch

### DIFF
--- a/cpp/ql/src/semmle/code/cpp/ir/dataflow/DefaultTaintTracking.qll
+++ b/cpp/ql/src/semmle/code/cpp/ir/dataflow/DefaultTaintTracking.qll
@@ -2,6 +2,7 @@ import cpp
 import semmle.code.cpp.security.Security
 private import semmle.code.cpp.ir.dataflow.DataFlow
 private import semmle.code.cpp.ir.IR
+private import semmle.code.cpp.ir.dataflow.internal.DataFlowDispatch as Dispatch
 
 /**
  * A predictable instruction is one where an external user can predict
@@ -145,7 +146,8 @@ GlobalOrNamespaceVariable globalVarFromId(string id) {
 }
 
 Function resolveCall(Call call) {
-  // TODO: improve virtual dispatch. This will help in the test for
-  // `UncontrolledProcessOperation.ql`.
-  result = call.getTarget()
+  exists(CallInstruction callInstruction |
+    callInstruction.getAST() = call and
+    result = Dispatch::viableCallable(callInstruction)
+  )
 }

--- a/cpp/ql/src/semmle/code/cpp/ir/dataflow/internal/DataFlowUtil.qll
+++ b/cpp/ql/src/semmle/code/cpp/ir/dataflow/internal/DataFlowUtil.qll
@@ -205,7 +205,8 @@ private predicate simpleInstructionLocalFlowStep(Instruction iFrom, Instruction 
   iTo.(CopyInstruction).getSourceValue() = iFrom or
   iTo.(PhiInstruction).getAnOperand().getDef() = iFrom or
   // Treat all conversions as flow, even conversions between different numeric types.
-  iTo.(ConvertInstruction).getUnary() = iFrom
+  iTo.(ConvertInstruction).getUnary() = iFrom or
+  iTo.(InheritanceConversionInstruction).getUnary() = iFrom
 }
 
 /**

--- a/cpp/ql/test/library-tests/dataflow/dataflow-tests/dispatch.cpp
+++ b/cpp/ql/test/library-tests/dataflow/dataflow-tests/dispatch.cpp
@@ -28,17 +28,17 @@ struct Bottom : Middle {
 void VirtualDispatch(Bottom *bottomPtr, Bottom &bottomRef) {
   Top *topPtr = bottomPtr, &topRef = bottomRef;
 
-  sink(topPtr->isSource1()); // flow [NOT DETECTED]
+  sink(topPtr->isSource1()); // flow [NOT DETECTED by AST]
   sink(topPtr->isSource2()); // flow [NOT DETECTED by AST]
-  topPtr->isSink(source()); // flow [NOT DETECTED]
+  topPtr->isSink(source()); // flow [NOT DETECTED by AST]
 
   sink(topPtr->notSource1()); // no flow [FALSE POSITIVE]
   sink(topPtr->notSource2()); // no flow [FALSE POSITIVE]
   topPtr->notSink(source()); // no flow [FALSE POSITIVE]
 
-  sink(topRef.isSource1()); // flow [NOT DETECTED]
+  sink(topRef.isSource1()); // flow [NOT DETECTED by AST]
   sink(topRef.isSource2()); // flow [NOT DETECTED by AST]
-  topRef.isSink(source()); // flow [NOT DETECTED]
+  topRef.isSink(source()); // flow [NOT DETECTED by AST]
 
   sink(topRef.notSource1()); // no flow [FALSE POSITIVE]
   sink(topRef.notSource2()); // no flow [FALSE POSITIVE]

--- a/cpp/ql/test/library-tests/dataflow/dataflow-tests/dispatch.cpp
+++ b/cpp/ql/test/library-tests/dataflow/dataflow-tests/dispatch.cpp
@@ -1,0 +1,46 @@
+int source();
+void sink(int);
+
+// This class has the opposite behavior of what the member function names suggest.
+struct Top {
+  virtual int isSource1() { return 0; }
+  virtual int isSource2() { return 0; }
+  virtual void isSink(int x) { }
+  virtual int notSource1() { return source(); }
+  virtual int notSource2() { return source(); }
+  virtual void notSink(int x) { sink(x); }
+};
+
+// This class has the correct behavior for just the functions ending in 2.
+struct Middle : Top {
+  int isSource2() override { return source(); }
+  int notSource2() override { return 0; }
+};
+
+// This class has all the behavior suggested by the function names.
+struct Bottom : Middle {
+  int isSource1() override { return source(); }
+  void isSink(int x) override { sink(x); }
+  int notSource1() override { return 0; }
+  void notSink(int x) override { }
+};
+
+void VirtualDispatch(Bottom *bottomPtr, Bottom &bottomRef) {
+  Top *topPtr = bottomPtr, &topRef = bottomRef;
+
+  sink(topPtr->isSource1()); // flow [NOT DETECTED]
+  sink(topPtr->isSource2()); // flow [NOT DETECTED by AST]
+  topPtr->isSink(source()); // flow [NOT DETECTED]
+
+  sink(topPtr->notSource1()); // no flow [FALSE POSITIVE]
+  sink(topPtr->notSource2()); // no flow [FALSE POSITIVE]
+  topPtr->notSink(source()); // no flow [FALSE POSITIVE]
+
+  sink(topRef.isSource1()); // flow [NOT DETECTED]
+  sink(topRef.isSource2()); // flow [NOT DETECTED by AST]
+  topRef.isSink(source()); // flow [NOT DETECTED]
+
+  sink(topRef.notSource1()); // no flow [FALSE POSITIVE]
+  sink(topRef.notSource2()); // no flow [FALSE POSITIVE]
+  topRef.notSink(source()); // no flow [FALSE POSITIVE]
+}

--- a/cpp/ql/test/library-tests/dataflow/dataflow-tests/test.expected
+++ b/cpp/ql/test/library-tests/dataflow/dataflow-tests/test.expected
@@ -15,6 +15,12 @@
 | clang.cpp:30:27:30:34 | call to getFirst | clang.cpp:28:27:28:32 | call to source |
 | clang.cpp:37:10:37:11 | m2 | clang.cpp:34:32:34:37 | call to source |
 | clang.cpp:45:17:45:18 | m2 | clang.cpp:43:35:43:40 | call to source |
+| dispatch.cpp:11:38:11:38 | x | dispatch.cpp:37:19:37:24 | call to source |
+| dispatch.cpp:11:38:11:38 | x | dispatch.cpp:45:18:45:23 | call to source |
+| dispatch.cpp:35:16:35:25 | call to notSource1 | dispatch.cpp:9:37:9:42 | call to source |
+| dispatch.cpp:36:16:36:25 | call to notSource2 | dispatch.cpp:10:37:10:42 | call to source |
+| dispatch.cpp:43:15:43:24 | call to notSource1 | dispatch.cpp:9:37:9:42 | call to source |
+| dispatch.cpp:44:15:44:24 | call to notSource2 | dispatch.cpp:10:37:10:42 | call to source |
 | lambdas.cpp:14:3:14:6 | t | lambdas.cpp:8:10:8:15 | call to source |
 | lambdas.cpp:18:8:18:8 | call to operator() | lambdas.cpp:8:10:8:15 | call to source |
 | lambdas.cpp:21:3:21:6 | t | lambdas.cpp:8:10:8:15 | call to source |

--- a/cpp/ql/test/library-tests/dataflow/dataflow-tests/test_diff.expected
+++ b/cpp/ql/test/library-tests/dataflow/dataflow-tests/test_diff.expected
@@ -5,6 +5,8 @@
 | clang.cpp:28:27:28:32 | clang.cpp:29:27:29:28 | AST only |
 | clang.cpp:28:27:28:32 | clang.cpp:30:27:30:34 | AST only |
 | clang.cpp:39:42:39:47 | clang.cpp:41:18:41:19 | IR only |
+| dispatch.cpp:16:37:16:42 | dispatch.cpp:32:16:32:24 | IR only |
+| dispatch.cpp:16:37:16:42 | dispatch.cpp:40:15:40:23 | IR only |
 | lambdas.cpp:8:10:8:15 | lambdas.cpp:14:3:14:6 | AST only |
 | lambdas.cpp:8:10:8:15 | lambdas.cpp:18:8:18:8 | AST only |
 | lambdas.cpp:8:10:8:15 | lambdas.cpp:21:3:21:6 | AST only |

--- a/cpp/ql/test/library-tests/dataflow/dataflow-tests/test_diff.expected
+++ b/cpp/ql/test/library-tests/dataflow/dataflow-tests/test_diff.expected
@@ -7,6 +7,10 @@
 | clang.cpp:39:42:39:47 | clang.cpp:41:18:41:19 | IR only |
 | dispatch.cpp:16:37:16:42 | dispatch.cpp:32:16:32:24 | IR only |
 | dispatch.cpp:16:37:16:42 | dispatch.cpp:40:15:40:23 | IR only |
+| dispatch.cpp:22:37:22:42 | dispatch.cpp:31:16:31:24 | IR only |
+| dispatch.cpp:22:37:22:42 | dispatch.cpp:39:15:39:23 | IR only |
+| dispatch.cpp:33:18:33:23 | dispatch.cpp:23:38:23:38 | IR only |
+| dispatch.cpp:41:17:41:22 | dispatch.cpp:23:38:23:38 | IR only |
 | lambdas.cpp:8:10:8:15 | lambdas.cpp:14:3:14:6 | AST only |
 | lambdas.cpp:8:10:8:15 | lambdas.cpp:18:8:18:8 | AST only |
 | lambdas.cpp:8:10:8:15 | lambdas.cpp:21:3:21:6 | AST only |

--- a/cpp/ql/test/library-tests/dataflow/dataflow-tests/test_ir.expected
+++ b/cpp/ql/test/library-tests/dataflow/dataflow-tests/test_ir.expected
@@ -14,9 +14,13 @@
 | clang.cpp:45:17:45:18 | Load: m2 | clang.cpp:43:35:43:40 | Call: call to source |
 | dispatch.cpp:11:38:11:38 | Load: x | dispatch.cpp:37:19:37:24 | Call: call to source |
 | dispatch.cpp:11:38:11:38 | Load: x | dispatch.cpp:45:18:45:23 | Call: call to source |
+| dispatch.cpp:23:38:23:38 | Load: x | dispatch.cpp:33:18:33:23 | Call: call to source |
+| dispatch.cpp:23:38:23:38 | Load: x | dispatch.cpp:41:17:41:22 | Call: call to source |
+| dispatch.cpp:31:16:31:24 | Call: call to isSource1 | dispatch.cpp:22:37:22:42 | Call: call to source |
 | dispatch.cpp:32:16:32:24 | Call: call to isSource2 | dispatch.cpp:16:37:16:42 | Call: call to source |
 | dispatch.cpp:35:16:35:25 | Call: call to notSource1 | dispatch.cpp:9:37:9:42 | Call: call to source |
 | dispatch.cpp:36:16:36:25 | Call: call to notSource2 | dispatch.cpp:10:37:10:42 | Call: call to source |
+| dispatch.cpp:39:15:39:23 | Call: call to isSource1 | dispatch.cpp:22:37:22:42 | Call: call to source |
 | dispatch.cpp:40:15:40:23 | Call: call to isSource2 | dispatch.cpp:16:37:16:42 | Call: call to source |
 | dispatch.cpp:43:15:43:24 | Call: call to notSource1 | dispatch.cpp:9:37:9:42 | Call: call to source |
 | dispatch.cpp:44:15:44:24 | Call: call to notSource2 | dispatch.cpp:10:37:10:42 | Call: call to source |

--- a/cpp/ql/test/library-tests/dataflow/dataflow-tests/test_ir.expected
+++ b/cpp/ql/test/library-tests/dataflow/dataflow-tests/test_ir.expected
@@ -12,6 +12,14 @@
 | clang.cpp:37:10:37:11 | Load: m2 | clang.cpp:34:32:34:37 | Call: call to source |
 | clang.cpp:41:18:41:19 | Load: m2 | clang.cpp:39:42:39:47 | Call: call to source |
 | clang.cpp:45:17:45:18 | Load: m2 | clang.cpp:43:35:43:40 | Call: call to source |
+| dispatch.cpp:11:38:11:38 | Load: x | dispatch.cpp:37:19:37:24 | Call: call to source |
+| dispatch.cpp:11:38:11:38 | Load: x | dispatch.cpp:45:18:45:23 | Call: call to source |
+| dispatch.cpp:32:16:32:24 | Call: call to isSource2 | dispatch.cpp:16:37:16:42 | Call: call to source |
+| dispatch.cpp:35:16:35:25 | Call: call to notSource1 | dispatch.cpp:9:37:9:42 | Call: call to source |
+| dispatch.cpp:36:16:36:25 | Call: call to notSource2 | dispatch.cpp:10:37:10:42 | Call: call to source |
+| dispatch.cpp:40:15:40:23 | Call: call to isSource2 | dispatch.cpp:16:37:16:42 | Call: call to source |
+| dispatch.cpp:43:15:43:24 | Call: call to notSource1 | dispatch.cpp:9:37:9:42 | Call: call to source |
+| dispatch.cpp:44:15:44:24 | Call: call to notSource2 | dispatch.cpp:10:37:10:42 | Call: call to source |
 | test.cpp:7:8:7:9 | Load: t1 | test.cpp:6:12:6:17 | Call: call to source |
 | test.cpp:9:8:9:9 | Load: t1 | test.cpp:6:12:6:17 | Call: call to source |
 | test.cpp:10:8:10:9 | Load: t2 | test.cpp:6:12:6:17 | Call: call to source |


### PR DESCRIPTION
This virtual dispatch support is not up to par with the one in `security.TaintTracking`, but it's enough to handle the two examples of virtual dispatch we have in our qltests: [`UncontrolledProcessOperation/test.cpp` in this repo](https://github.com/Semmle/ql/blob/2bcd418c23b984d055647ffaac4672bda843b341/cpp/ql/test/query-tests/Security/CWE/CWE-114/semmle/UncontrolledProcessOperation/test.cpp#L43) and `UncontrolledProcessOperation/test.cpp` in the internal repo.