### PR TITLE
Update links to OWASP cheat sheet

### DIFF
--- a/cpp/ql/src/Security/CWE/CWE-079/CgiXss.qhelp
+++ b/cpp/ql/src/Security/CWE/CWE-079/CgiXss.qhelp
@@ -34,7 +34,7 @@ characters before writing to the HTML page.</p>
 
 <li>
 OWASP:
-<a href="https://www.owasp.org/index.php/XSS_%28Cross_Site_Scripting%29_Prevention_Cheat_Sheet">XSS
+<a href="https://cheatsheetseries.owasp.org/cheatsheets/Cross_Site_Scripting_Prevention_Cheat_Sheet.html">XSS
 (Cross Site Scripting) Prevention Cheat Sheet</a>.
 </li>
 <li>

--- a/csharp/ql/src/Security Features/CWE-079/XSS.qhelp
+++ b/csharp/ql/src/Security Features/CWE-079/XSS.qhelp
@@ -29,7 +29,7 @@ leaving the website vulnerable to cross-site scripting.</p>
 
 <li>
 OWASP:
-<a href="https://www.owasp.org/index.php/XSS_%28Cross_Site_Scripting%29_Prevention_Cheat_Sheet">XSS
+<a href="https://cheatsheetseries.owasp.org/cheatsheets/Cross_Site_Scripting_Prevention_Cheat_Sheet.html">XSS
 (Cross Site Scripting) Prevention Cheat Sheet</a>.
 </li>
 <li>

--- a/csharp/ql/src/Security Features/CWE-090/LDAPInjection.qhelp
+++ b/csharp/ql/src/Security Features/CWE-090/LDAPInjection.qhelp
@@ -33,7 +33,7 @@ the query cannot be changed by a malicious user.</p>
 </example>
 
 <references>
-<li>OWASP: <a href="https://www.owasp.org/index.php?title=LDAP_Injection_Prevention_Cheat_Sheet">LDAP Injection Prevention Cheat Sheet</a>.</li>
+<li>OWASP: <a href="https://cheatsheetseries.owasp.org/cheatsheets/LDAP_Injection_Prevention_Cheat_Sheet.html">LDAP Injection Prevention Cheat Sheet</a>.</li>
 <li>OWASP: <a href="https://www.owasp.org/index.php/Preventing_LDAP_Injection_in_Java">Preventing LDAP Injection in Java</a>.</li>
 <li>AntiXSS doc: <a href="http://www.nudoq.org/#!/Packages/AntiXSS/AntiXssLibrary/Encoder/M/LdapFilterEncode">LdapFilterEncode</a>.</li>
 <li>AntiXSS doc: <a href="http://www.nudoq.org/#!/Packages/AntiXSS/AntiXssLibrary/Encoder/M/LdapDistinguishedNameEncode">LdapDistinguishedNameEncode</a>.</li>

--- a/csharp/ql/src/Security Features/CWE-451/MissingXFrameOptions.qhelp
+++ b/csharp/ql/src/Security Features/CWE-451/MissingXFrameOptions.qhelp
@@ -51,7 +51,7 @@ This next example shows how to specify the <code>X-Frame-Options</code> header w
 
 <li>
 OWASP:
-<a href="https://www.owasp.org/index.php/Clickjacking_Defense_Cheat_Sheet">Clickjacking Defense Cheat Sheet</a>.
+<a href="https://cheatsheetseries.owasp.org/cheatsheets/Clickjacking_Defense_Cheat_Sheet.html">Clickjacking Defense Cheat Sheet</a>.
 </li>
 <li>
 Mozilla:

--- a/csharp/ql/src/Security Features/CWE-601/UrlRedirect.qhelp
+++ b/csharp/ql/src/Security Features/CWE-601/UrlRedirect.qhelp
@@ -32,7 +32,7 @@ It also shows how to remedy the problem by validating the user input against a k
 
 <li>
 OWASP:
-<a href="https://www.owasp.org/index.php/Unvalidated_Redirects_and_Forwards_Cheat_Sheet">XSS
+<a href="https://cheatsheetseries.owasp.org/cheatsheets/Unvalidated_Redirects_and_Forwards_Cheat_Sheet.html">XSS
 Unvalidated Redirects and Forwards Cheat Sheet</a>.
 </li>
 <li>

--- a/csharp/ql/src/Security Features/CWE-611/UseXmlSecureResolver.qhelp
+++ b/csharp/ql/src/Security Features/CWE-611/UseXmlSecureResolver.qhelp
@@ -38,7 +38,7 @@ The solution is to set the <code>DtdProcessing</code> property to <code>DtdProce
 
 <li>
 OWASP:
-<a href="https://www.owasp.org/index.php/XML_External_Entity_(XXE)_Prevention_Cheat_Sheet">XML External Entity (XXE) Prevention Cheat Sheet</a>.
+<a href="https://cheatsheetseries.owasp.org/cheatsheets/XML_External_Entity_Prevention_Cheat_Sheet.html">XML External Entity (XXE) Prevention Cheat Sheet</a>.
 </li>
 <li>
 Microsoft Docs: <a href="https://msdn.microsoft.com/en-us/library/system.xml.xmlreadersettings(v=vs.110).aspx#Anchor_6">System.XML: Security considerations</a>.

--- a/java/ql/src/Security/CWE/CWE-079/XSS.qhelp
+++ b/java/ql/src/Security/CWE/CWE-079/XSS.qhelp
@@ -29,7 +29,7 @@ leaving the website vulnerable to cross-site scripting.</p>
 
 <li>
 OWASP:
-<a href="https://www.owasp.org/index.php/XSS_%28Cross_Site_Scripting%29_Prevention_Cheat_Sheet">XSS
+<a href="https://cheatsheetseries.owasp.org/cheatsheets/Cross_Site_Scripting_Prevention_Cheat_Sheet.html">XSS
 (Cross Site Scripting) Prevention Cheat Sheet</a>.
 </li>
 <li>

--- a/java/ql/src/Security/CWE/CWE-089/SqlTainted.qhelp
+++ b/java/ql/src/Security/CWE/CWE-089/SqlTainted.qhelp
@@ -67,7 +67,7 @@ in the environment variable or user-supplied value are not given any special tre
 
 <li>
 OWASP:
-<a href="https://www.owasp.org/index.php/SQL_Injection_Prevention_Cheat_Sheet">SQL
+<a href="https://cheatsheetseries.owasp.org/cheatsheets/SQL_Injection_Prevention_Cheat_Sheet.html">SQL
 Injection Prevention Cheat Sheet</a>.
 </li>
 <li>The CERT Oracle Secure Coding Standard for Java:

--- a/java/ql/src/Security/CWE/CWE-089/SqlUnescaped.qhelp
+++ b/java/ql/src/Security/CWE/CWE-089/SqlUnescaped.qhelp
@@ -39,7 +39,7 @@ treatment.</p>
 
 <li>
 OWASP:
-<a href="https://www.owasp.org/index.php/SQL_Injection_Prevention_Cheat_Sheet">SQL
+<a href="https://cheatsheetseries.owasp.org/cheatsheets/SQL_Injection_Prevention_Cheat_Sheet.html">SQL
 Injection Prevention Cheat Sheet</a>.
 </li>
 <li>The CERT Oracle Secure Coding Standard for Java:

--- a/java/ql/src/Security/CWE/CWE-319/HttpsUrls.qhelp
+++ b/java/ql/src/Security/CWE/CWE-319/HttpsUrls.qhelp
@@ -37,7 +37,7 @@ connection is a secure SSL connection.</p>
 Class HttpsURLConnection</a>.</li>
 <li>
 OWASP:
-<a href="https://www.owasp.org/index.php/Transport_Layer_Protection_Cheat_Sheet">Transport Layer Protection Cheat Sheet</a>.
+<a href="https://cheatsheetseries.owasp.org/cheatsheets/Transport_Layer_Protection_Cheat_Sheet.html">Transport Layer Protection Cheat Sheet</a>.
 </li>
 
 

--- a/java/ql/src/Security/CWE/CWE-319/UseSSL.qhelp
+++ b/java/ql/src/Security/CWE/CWE-319/UseSSL.qhelp
@@ -38,7 +38,7 @@ Class HttpsURLConnection</a>.</li>
 Class SSLSocket</a>.</li>
 <li>
 OWASP:
-<a href="https://www.owasp.org/index.php/Transport_Layer_Protection_Cheat_Sheet">Transport Layer Protection Cheat Sheet</a>.
+<a href="https://cheatsheetseries.owasp.org/cheatsheets/Transport_Layer_Protection_Cheat_Sheet.html">Transport Layer Protection Cheat Sheet</a>.
 </li>
 
 

--- a/java/ql/src/Security/CWE/CWE-319/UseSSLSocketFactories.qhelp
+++ b/java/ql/src/Security/CWE/CWE-319/UseSSLSocketFactories.qhelp
@@ -33,7 +33,7 @@ uses explicit SSL factories, which are preferable.</p>
 Class SSLSocketFactory</a>.</li>
 <li>
 OWASP:
-<a href="https://www.owasp.org/index.php/Transport_Layer_Protection_Cheat_Sheet">Transport Layer Protection Cheat Sheet</a>.
+<a href="https://cheatsheetseries.owasp.org/cheatsheets/Transport_Layer_Protection_Cheat_Sheet.html">Transport Layer Protection Cheat Sheet</a>.
 </li>
 
 

--- a/java/ql/src/Security/CWE/CWE-502/UnsafeDeserialization.qhelp
+++ b/java/ql/src/Security/CWE/CWE-502/UnsafeDeserialization.qhelp
@@ -58,7 +58,7 @@ OWASP vulnerability description:
 </li>
 <li>
 OWASP guidance on deserializing objects:
-<a href="https://www.owasp.org/index.php/Deserialization_Cheat_Sheet">Deserialization Cheat Sheet</a>.
+<a href="https://cheatsheetseries.owasp.org/cheatsheets/Deserialization_Cheat_Sheet.html">Deserialization Cheat Sheet</a>.
 </li>
 <li>
 Talks by Chris Frohoff &amp; Gabriel Lawrence:

--- a/java/ql/src/Security/CWE/CWE-611/XXE.qhelp
+++ b/java/ql/src/Security/CWE/CWE-611/XXE.qhelp
@@ -52,7 +52,7 @@ OWASP vulnerability description:
 </li>
 <li>
 OWASP guidance on parsing xml files:
-<a href="https://www.owasp.org/index.php/XML_External_Entity_(XXE)_Prevention_Cheat_Sheet#Java">XXE Prevention Cheat Sheet</a>.
+<a href="https://cheatsheetseries.owasp.org/cheatsheets/XML_External_Entity_Prevention_Cheat_Sheet.html#java">XXE Prevention Cheat Sheet</a>.
 </li>
 <li>
 Paper by Timothy Morgen:

--- a/java/ql/src/semmle/code/java/security/XmlParsers.qll
+++ b/java/ql/src/semmle/code/java/security/XmlParsers.qll
@@ -49,7 +49,7 @@ abstract class ParserConfig extends MethodAccess {
 }
 
 /*
- *  https://www.owasp.org/index.php/XML_External_Entity_(XXE)_Prevention_Cheat_Sheet#DocumentBuilder
+ * https://cheatsheetseries.owasp.org/cheatsheets/XML_External_Entity_Prevention_Cheat_Sheet.html#jaxp-documentbuilderfactory-saxparserfactory-and-dom4j
  */
 
 /** The class `javax.xml.parsers.DocumentBuilderFactory`. */
@@ -227,7 +227,7 @@ class SafeDocumentBuilder extends DocumentBuilderConstruction {
 }
 
 /*
- * https://www.owasp.org/index.php/XML_External_Entity_(XXE)_Prevention_Cheat_Sheet#XMLInputFactory_.28a_StAX_parser.29
+ * https://cheatsheetseries.owasp.org/cheatsheets/XML_External_Entity_Prevention_Cheat_Sheet.html#xmlinputfactory-a-stax-parser
  */
 
 /** The class `javax.xml.stream.XMLInputFactory`. */
@@ -353,7 +353,7 @@ class SafeXmlInputFactory extends VarAccess {
 }
 
 /*
- * https://www.owasp.org/index.php/XML_External_Entity_(XXE)_Prevention_Cheat_Sheet#SAXBuilder
+ * https://cheatsheetseries.owasp.org/cheatsheets/XML_External_Entity_Prevention_Cheat_Sheet.html#saxbuilder
  */
 
 /**
@@ -429,7 +429,7 @@ class SafeSAXBuilder extends VarAccess {
 
 /*
  * The case in
- * https://www.owasp.org/index.php/XML_External_Entity_(XXE)_Prevention_Cheat_Sheet#Unmarshaller
+ * https://cheatsheetseries.owasp.org/cheatsheets/XML_External_Entity_Prevention_Cheat_Sheet.html#jaxb-unmarshaller
  * will be split into two, one covers a SAXParser as a sink, the other the SAXSource as a sink.
  */
 
@@ -545,7 +545,7 @@ class SafeSAXParser extends MethodAccess {
   }
 }
 
-/* SAXReader: https://www.owasp.org/index.php/XML_External_Entity_(XXE)_Prevention_Cheat_Sheet#SAXReader */
+/* SAXReader: https://cheatsheetseries.owasp.org/cheatsheets/XML_External_Entity_Prevention_Cheat_Sheet.html#saxreader */
 /**
  * The class `org.dom4j.io.SAXReader`.
  */
@@ -621,7 +621,7 @@ class SafeSAXReader extends VarAccess {
   }
 }
 
-/* https://www.owasp.org/index.php/XML_External_Entity_(XXE)_Prevention_Cheat_Sheet#XMLReader */
+/* https://cheatsheetseries.owasp.org/cheatsheets/XML_External_Entity_Prevention_Cheat_Sheet.html#xmlreader */
 /** The class `org.xml.sax.XMLReader`. */
 class XMLReader extends RefType {
   XMLReader() { this.hasQualifiedName("org.xml.sax", "XMLReader") }
@@ -756,7 +756,7 @@ class CreatedSafeXMLReader extends Call {
 
 /*
  * SAXSource in
- * https://www.owasp.org/index.php/XML_External_Entity_(XXE)_Prevention_Cheat_Sheet#Unmarshaller
+ * https://cheatsheetseries.owasp.org/cheatsheets/XML_External_Entity_Prevention_Cheat_Sheet.html#jaxb-unmarshaller
  */
 
 /** The class `javax.xml.transform.sax.SAXSource` */
@@ -811,7 +811,7 @@ class SafeSAXSource extends Expr {
   }
 }
 
-/* Transformer: https://www.owasp.org/index.php/XML_External_Entity_(XXE)_Prevention_Cheat_Sheet#TransformerFactory */
+/* Transformer: https://cheatsheetseries.owasp.org/cheatsheets/XML_External_Entity_Prevention_Cheat_Sheet.html#transformerfactory */
 /** An access to a method use for configuring a transformer or schema. */
 abstract class TransformerConfig extends MethodAccess {
   /** Holds if the configuration is disabled */
@@ -975,7 +975,7 @@ class SafeTransformer extends MethodAccess {
 }
 
 /*
- * SAXTransformer: https://www.owasp.org/index.php/XML_External_Entity_(XXE)_Prevention_Cheat_Sheet#SAXTransformerFactory
+ * SAXTransformer: https://cheatsheetseries.owasp.org/cheatsheets/XML_External_Entity_Prevention_Cheat_Sheet.html#saxtransformerfactory
  * Has an extra method called newFilter.
  */
 
@@ -996,7 +996,7 @@ class SAXTransformerFactoryNewXMLFilter extends XmlParserCall {
   }
 }
 
-/* Schema: https://www.owasp.org/index.php/XML_External_Entity_(XXE)_Prevention_Cheat_Sheet#SchemaFactory */
+/* Schema: https://cheatsheetseries.owasp.org/cheatsheets/XML_External_Entity_Prevention_Cheat_Sheet.html#schemafactory */
 /** The class `javax.xml.validation.SchemaFactory`. */
 class SchemaFactory extends RefType {
   SchemaFactory() { this.hasQualifiedName("javax.xml.validation", "SchemaFactory") }
@@ -1060,7 +1060,7 @@ class SafeSchemaFactory extends VarAccess {
   }
 }
 
-/* Unmarshaller: https://www.owasp.org/index.php/XML_External_Entity_(XXE)_Prevention_Cheat_Sheet#Unmarshaller */
+/* Unmarshaller: https://cheatsheetseries.owasp.org/cheatsheets/XML_External_Entity_Prevention_Cheat_Sheet.html#jaxb-unmarshaller */
 /** The class `javax.xml.bind.Unmarshaller`. */
 class XmlUnmarshaller extends RefType {
   XmlUnmarshaller() { this.hasQualifiedName("javax.xml.bind", "Unmarshaller") }
@@ -1081,7 +1081,7 @@ class XmlUnmarshal extends XmlParserCall {
   override predicate isSafe() { none() }
 }
 
-/* XPathExpression: https://www.owasp.org/index.php/XML_External_Entity_(XXE)_Prevention_Cheat_Sheet#XPathExpression */
+/* XPathExpression: https://cheatsheetseries.owasp.org/cheatsheets/XML_External_Entity_Prevention_Cheat_Sheet.html#xpathexpression */
 /** The class `javax.xml.xpath.XPathExpression`. */
 class XPathExpression extends RefType {
   XPathExpression() { this.hasQualifiedName("javax.xml.xpath", "XPathExpression") }

--- a/javascript/ql/src/Security/CWE-020/IncompleteHostnameRegExp.qhelp
+++ b/javascript/ql/src/Security/CWE-020/IncompleteHostnameRegExp.qhelp
@@ -68,6 +68,6 @@
 	<references>
 		<li>MDN: <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Regular_Expressions">Regular Expressions</a></li>
 		<li>OWASP: <a href="https://www.owasp.org/index.php/Server_Side_Request_Forgery">SSRF</a></li>
-		<li>OWASP: <a href="https://www.owasp.org/index.php/Unvalidated_Redirects_and_Forwards_Cheat_Sheet">XSS Unvalidated Redirects and Forwards Cheat Sheet</a>.</li>
+		<li>OWASP: <a href="https://cheatsheetseries.owasp.org/cheatsheets/Unvalidated_Redirects_and_Forwards_Cheat_Sheet.html">XSS Unvalidated Redirects and Forwards Cheat Sheet</a>.</li>
 	</references>
 </qhelp>

--- a/javascript/ql/src/Security/CWE-020/IncompleteUrlSubstringSanitization.qhelp
+++ b/javascript/ql/src/Security/CWE-020/IncompleteUrlSubstringSanitization.qhelp
@@ -83,6 +83,6 @@
 
 	<references>
 		<li>OWASP: <a href="https://www.owasp.org/index.php/Server_Side_Request_Forgery">SSRF</a></li>
-		<li>OWASP: <a href="https://www.owasp.org/index.php/Unvalidated_Redirects_and_Forwards_Cheat_Sheet">XSS Unvalidated Redirects and Forwards Cheat Sheet</a>.</li>
+		<li>OWASP: <a href="https://cheatsheetseries.owasp.org/cheatsheets/Unvalidated_Redirects_and_Forwards_Cheat_Sheet.html">XSS Unvalidated Redirects and Forwards Cheat Sheet</a>.</li>
 	</references>
 </qhelp>

--- a/javascript/ql/src/Security/CWE-020/MissingRegExpAnchor.qhelp
+++ b/javascript/ql/src/Security/CWE-020/MissingRegExpAnchor.qhelp
@@ -71,6 +71,6 @@
 	<references>
 		<li>MDN: <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Regular_Expressions">Regular Expressions</a></li>
 		<li>OWASP: <a href="https://www.owasp.org/index.php/Server_Side_Request_Forgery">SSRF</a></li>
-		<li>OWASP: <a href="https://www.owasp.org/index.php/Unvalidated_Redirects_and_Forwards_Cheat_Sheet">XSS Unvalidated Redirects and Forwards Cheat Sheet</a>.</li>
+		<li>OWASP: <a href="https://cheatsheetseries.owasp.org/cheatsheets/Unvalidated_Redirects_and_Forwards_Cheat_Sheet.html">XSS Unvalidated Redirects and Forwards Cheat Sheet</a>.</li>
 	</references>
 </qhelp>

--- a/javascript/ql/src/Security/CWE-079/ReflectedXss.qhelp
+++ b/javascript/ql/src/Security/CWE-079/ReflectedXss.qhelp
@@ -37,7 +37,7 @@ Sanitizing the user-controlled data prevents the vulnerability:
 <references>
 <li>
 OWASP:
-<a href="https://www.owasp.org/index.php/XSS_%28Cross_Site_Scripting%29_Prevention_Cheat_Sheet">XSS
+<a href="https://cheatsheetseries.owasp.org/cheatsheets/Cross_Site_Scripting_Prevention_Cheat_Sheet.html">XSS
 (Cross Site Scripting) Prevention Cheat Sheet</a>.
 </li>
 <li>

--- a/javascript/ql/src/Security/CWE-079/StoredXss.qhelp
+++ b/javascript/ql/src/Security/CWE-079/StoredXss.qhelp
@@ -48,7 +48,7 @@
 <references>
 	<li>
 		OWASP:
-		<a href="https://www.owasp.org/index.php/XSS_%28Cross_Site_Scripting%29_Prevention_Cheat_Sheet">XSS
+		<a href="https://cheatsheetseries.owasp.org/cheatsheets/Cross_Site_Scripting_Prevention_Cheat_Sheet.html">XSS
 		(Cross Site Scripting) Prevention Cheat Sheet</a>.
 	</li>
 	<li>

--- a/javascript/ql/src/Security/CWE-079/Xss.qhelp
+++ b/javascript/ql/src/Security/CWE-079/Xss.qhelp
@@ -33,12 +33,12 @@ leaving the website vulnerable to cross-site scripting.
 <references>
 <li>
 OWASP:
-<a href="https://www.owasp.org/index.php/DOM_based_XSS_Prevention_Cheat_Sheet">DOM based
+<a href="https://cheatsheetseries.owasp.org/cheatsheets/DOM_based_XSS_Prevention_Cheat_Sheet.html">DOM based
 XSS Prevention Cheat Sheet</a>.
 </li>
 <li>
 OWASP:
-<a href="https://github.com/OWASP/CheatSheetSeries/blob/master/cheatsheets/Cross_Site_Scripting_Prevention_Cheat_Sheet.md">XSS
+<a href="https://cheatsheetseries.owasp.org/cheatsheets/Cross_Site_Scripting_Prevention_Cheat_Sheet.html">XSS
 (Cross Site Scripting) Prevention Cheat Sheet</a>.
 </li>
 <li>

--- a/javascript/ql/src/Security/CWE-327/BrokenCryptoAlgorithm.qhelp
+++ b/javascript/ql/src/Security/CWE-327/BrokenCryptoAlgorithm.qhelp
@@ -45,7 +45,7 @@
 		<li>NIST, FIPS 140 Annex a: <a href="http://csrc.nist.gov/publications/fips/fips140-2/fips1402annexa.pdf"> Approved Security Functions</a>.</li>
 		<li>NIST, SP 800-131A: <a href="http://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-131Ar1.pdf"> Transitions: Recommendation for Transitioning the Use of Cryptographic Algorithms and Key Lengths</a>.</li>
 		<li>OWASP: <a
-		href="https://www.owasp.org/index.php/Cryptographic_Storage_Cheat_Sheet#Rule_-_Use_strong_approved_cryptographic_algorithms">Rule
+		href="https://cheatsheetseries.owasp.org/cheatsheets/Cryptographic_Storage_Cheat_Sheet.html#rule---use-strong-approved-authenticated-encryption">Rule
 		- Use strong approved cryptographic algorithms</a>.
 		</li>
 	</references>

--- a/javascript/ql/src/Security/CWE-451/MissingXFrameOptions.qhelp
+++ b/javascript/ql/src/Security/CWE-451/MissingXFrameOptions.qhelp
@@ -67,7 +67,7 @@
 
     <li>
       OWASP:
-      <a href="https://www.owasp.org/index.php/Clickjacking_Defense_Cheat_Sheet">Clickjacking Defense Cheat Sheet</a>.
+      <a href="https://cheatsheetseries.owasp.org/cheatsheets/Clickjacking_Defense_Cheat_Sheet.html">Clickjacking Defense Cheat Sheet</a>.
     </li>
     <li>
       Mozilla:

--- a/javascript/ql/src/Security/CWE-502/UnsafeDeserialization.qhelp
+++ b/javascript/ql/src/Security/CWE-502/UnsafeDeserialization.qhelp
@@ -41,7 +41,7 @@ OWASP vulnerability description:
 </li>
 <li>
 OWASP guidance on deserializing objects:
-<a href="https://www.owasp.org/index.php/Deserialization_Cheat_Sheet">Deserialization Cheat Sheet</a>.
+<a href="https://cheatsheetseries.owasp.org/cheatsheets/Deserialization_Cheat_Sheet.html">Deserialization Cheat Sheet</a>.
 </li>
 <li>
 Neal Poole:

--- a/javascript/ql/src/Security/CWE-601/ClientSideUrlRedirect.qhelp
+++ b/javascript/ql/src/Security/CWE-601/ClientSideUrlRedirect.qhelp
@@ -31,7 +31,7 @@ website of their choosing, which facilitates phishing attacks:
 </example>
 
 <references>
-<li>OWASP: <a href="https://www.owasp.org/index.php/Unvalidated_Redirects_and_Forwards_Cheat_Sheet">
+<li>OWASP: <a href="https://cheatsheetseries.owasp.org/cheatsheets/Unvalidated_Redirects_and_Forwards_Cheat_Sheet.html">
   XSS Unvalidated Redirects and Forwards Cheat Sheet</a>.</li>
 </references>
 

--- a/javascript/ql/src/Security/CWE-601/ServerSideUrlRedirect.qhelp
+++ b/javascript/ql/src/Security/CWE-601/ServerSideUrlRedirect.qhelp
@@ -35,7 +35,7 @@ before doing the redirection:
 </example>
 
 <references>
-<li>OWASP: <a href="https://www.owasp.org/index.php/Unvalidated_Redirects_and_Forwards_Cheat_Sheet">
+<li>OWASP: <a href="https://cheatsheetseries.owasp.org/cheatsheets/Unvalidated_Redirects_and_Forwards_Cheat_Sheet.html">
   XSS Unvalidated Redirects and Forwards Cheat Sheet</a>.</li>
 </references>
 

--- a/javascript/ql/src/Security/CWE-770/MissingRateLimiting.qhelp
+++ b/javascript/ql/src/Security/CWE-770/MissingRateLimiting.qhelp
@@ -36,7 +36,7 @@ can be used:
 <references>
 <li>
 OWASP:
-<a href="https://www.owasp.org/index.php/Denial_of_Service_Cheat_Sheet">Denial of Service Cheat Sheet</a>.
+<a href="https://cheatsheetseries.owasp.org/cheatsheets/Denial_of_Service_Cheat_Sheet.html">Denial of Service Cheat Sheet</a>.
 </li>
 <li>
 Wikipedia: <a href="https://en.wikipedia.org/wiki/Denial-of-service_attack">Denial-of-service attack</a>.

--- a/javascript/ql/src/Security/CWE-916/InsufficientPasswordHash.qhelp
+++ b/javascript/ql/src/Security/CWE-916/InsufficientPasswordHash.qhelp
@@ -50,6 +50,6 @@
 </example>
 
 <references>
-	<li>OWASP: <a href="https://www.owasp.org/index.php/Password_Storage_Cheat_Sheet">Password storage</a>.</li>
+	<li>OWASP: <a href="https://cheatsheetseries.owasp.org/cheatsheets/Password_Storage_Cheat_Sheet.html">Password storage</a>.</li>
 </references>
 </qhelp>

--- a/python/ql/src/Security/CWE-020/IncompleteHostnameRegExp.qhelp
+++ b/python/ql/src/Security/CWE-020/IncompleteHostnameRegExp.qhelp
@@ -64,6 +64,6 @@
 
     <references>
         <li>OWASP: <a href="https://www.owasp.org/index.php/Server_Side_Request_Forgery">SSRF</a></li>
-        <li>OWASP: <a href="https://www.owasp.org/index.php/Unvalidated_Redirects_and_Forwards_Cheat_Sheet">XSS Unvalidated Redirects and Forwards Cheat Sheet</a>.</li>
+        <li>OWASP: <a href="https://cheatsheetseries.owasp.org/cheatsheets/Unvalidated_Redirects_and_Forwards_Cheat_Sheet.html">XSS Unvalidated Redirects and Forwards Cheat Sheet</a>.</li>
     </references>
 </qhelp>

--- a/python/ql/src/Security/CWE-020/IncompleteUrlSubstringSanitization.qhelp
+++ b/python/ql/src/Security/CWE-020/IncompleteUrlSubstringSanitization.qhelp
@@ -80,6 +80,6 @@
 
     <references>
         <li>OWASP: <a href="https://www.owasp.org/index.php/Server_Side_Request_Forgery">SSRF</a></li>
-        <li>OWASP: <a href="https://www.owasp.org/index.php/Unvalidated_Redirects_and_Forwards_Cheat_Sheet">XSS Unvalidated Redirects and Forwards Cheat Sheet</a>.</li>
+        <li>OWASP: <a href="https://cheatsheetseries.owasp.org/cheatsheets/Unvalidated_Redirects_and_Forwards_Cheat_Sheet.html">XSS Unvalidated Redirects and Forwards Cheat Sheet</a>.</li>
     </references>
 </qhelp>

--- a/python/ql/src/Security/CWE-079/Jinja2WithoutEscaping.qhelp
+++ b/python/ql/src/Security/CWE-079/Jinja2WithoutEscaping.qhelp
@@ -38,7 +38,7 @@ Jinja2: <a href="http://jinja.pocoo.org/docs/2.10/api/">API</a>.
 Wikipedia: <a href="http://en.wikipedia.org/wiki/Cross-site_scripting">Cross-site scripting</a>.
 </li>
 <li>
-OWASP: <a href="https://www.owasp.org/index.php/XSS_(Cross_Site_Scripting)_Prevention_Cheat_Sheet">XSS (Cross Site Scripting) Prevention Cheat Sheet</a>.
+OWASP: <a href="https://cheatsheetseries.owasp.org/cheatsheets/Cross_Site_Scripting_Prevention_Cheat_Sheet.html">XSS (Cross Site Scripting) Prevention Cheat Sheet</a>.
 </li>
 </references>
 </qhelp>

--- a/python/ql/src/Security/CWE-079/ReflectedXss.qhelp
+++ b/python/ql/src/Security/CWE-079/ReflectedXss.qhelp
@@ -31,7 +31,7 @@ The second view is safe as <code>first_name</code> is escaped, so it is not vuln
 <references>
 <li>
 OWASP:
-<a href="https://www.owasp.org/index.php/XSS_%28Cross_Site_Scripting%29_Prevention_Cheat_Sheet">XSS
+<a href="https://cheatsheetseries.owasp.org/cheatsheets/Cross_Site_Scripting_Prevention_Cheat_Sheet.html">XSS
 (Cross Site Scripting) Prevention Cheat Sheet</a>.
 </li>
 <li>

--- a/python/ql/src/Security/CWE-089/SqlInjection.qhelp
+++ b/python/ql/src/Security/CWE-089/SqlInjection.qhelp
@@ -51,6 +51,6 @@ vulnerable to SQL injection attacks. In this example, if <code>username</code> w
 
 <references>
 <li>Wikipedia: <a href="https://en.wikipedia.org/wiki/SQL_injection">SQL injection</a>.</li>
-<li>OWASP: <a href="https://www.owasp.org/index.php/SQL_Injection_Prevention_Cheat_Sheet">SQL Injection Prevention Cheat Sheet</a>.</li>
+<li>OWASP: <a href="https://cheatsheetseries.owasp.org/cheatsheets/SQL_Injection_Prevention_Cheat_Sheet.html">SQL Injection Prevention Cheat Sheet</a>.</li>
 </references>
 </qhelp>

--- a/python/ql/src/Security/CWE-327/BrokenCryptoAlgorithm.qhelp
+++ b/python/ql/src/Security/CWE-327/BrokenCryptoAlgorithm.qhelp
@@ -49,7 +49,7 @@
           <li>NIST, FIPS 140 Annex a: <a href="http://csrc.nist.gov/publications/fips/fips140-2/fips1402annexa.pdf"> Approved Security Functions</a>.</li>
           <li>NIST, SP 800-131A: <a href="http://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-131Ar1.pdf"> Transitions: Recommendation for Transitioning the Use of Cryptographic Algorithms and Key Lengths</a>.</li>
           <li>OWASP: <a
-          href="https://www.owasp.org/index.php/Cryptographic_Storage_Cheat_Sheet#Rule_-_Use_strong_approved_cryptographic_algorithms">Rule
+          href="https://cheatsheetseries.owasp.org/cheatsheets/Cryptographic_Storage_Cheat_Sheet.html#rule---use-strong-approved-authenticated-encryption">Rule
           - Use strong approved cryptographic algorithms</a>.
           </li>
      </references>

--- a/python/ql/src/Security/CWE-502/UnsafeDeserialization.qhelp
+++ b/python/ql/src/Security/CWE-502/UnsafeDeserialization.qhelp
@@ -49,7 +49,7 @@ OWASP vulnerability description:
 </li>
 <li>
 OWASP guidance on deserializing objects:
-<a href="https://www.owasp.org/index.php/Deserialization_Cheat_Sheet">Deserialization Cheat Sheet</a>.
+<a href="https://cheatsheetseries.owasp.org/cheatsheets/Deserialization_Cheat_Sheet.html">Deserialization Cheat Sheet</a>.
 </li>
 <li>
 Talks by Chris Frohoff &amp; Gabriel Lawrence:

--- a/python/ql/src/Security/CWE-601/UrlRedirect.qhelp
+++ b/python/ql/src/Security/CWE-601/UrlRedirect.qhelp
@@ -35,7 +35,7 @@ before doing the redirection:
 </example>
 
 <references>
-<li>OWASP: <a href="https://www.owasp.org/index.php/Unvalidated_Redirects_and_Forwards_Cheat_Sheet">
+<li>OWASP: <a href="https://cheatsheetseries.owasp.org/cheatsheets/Unvalidated_Redirects_and_Forwards_Cheat_Sheet.html">
   XSS Unvalidated Redirects and Forwards Cheat Sheet</a>.</li>
 </references>
 


### PR DESCRIPTION
OWASP has moved their cheatsheet to Github pages, so I've updated the qhelp links accordingly.