### PR TITLE
JavaScript: Replace qltest `semmle-extractor-options` comments with `options` files.

### DIFF
--- a/javascript/ql/test/library-tests/CFG/CFG.expected
+++ b/javascript/ql/test/library-tests/CFG/CFG.expected
@@ -546,7 +546,7 @@
 | classes | 39 | static x = 5; | 39 | t = cla ... () {} } |
 | classes | 39 | t | 39 | A |
 | classes | 39 | t = cla ... () {} } | 39 | t |
-| classes | 39 | t = cla ... () {} } | 42 | exit node of <toplevel> |
+| classes | 39 | t = cla ... () {} } | 40 | exit node of <toplevel> |
 | classes | 39 | x | 39 | 5 |
 | classes | 39 | {} | 39 | exit node of () {} |
 | decorated_parameter | 1 | C | 2 | foo |
@@ -625,7 +625,7 @@
 | fields | 8 | {} | 8 | exit node of () {} |
 | fields | 11 | A | 12 | constructor |
 | fields | 11 | B | 11 | A |
-| fields | 11 | class B ... \\n  z;\\n} | 21 | exit node of <toplevel> |
+| fields | 11 | class B ... \\n  z;\\n} | 19 | exit node of <toplevel> |
 | fields | 12 | constru ... er;\\n  } | 11 | class B ... \\n  z;\\n} |
 | fields | 12 | constructor | 12 | function in constru ... er;\\n  } |
 | fields | 12 | entry node of () {\\n   ... er;\\n  } | 12 | {\\n    b ... er;\\n  } |
@@ -680,7 +680,7 @@
 | globals | 19 | h | 20 | {\\n} |
 | globals | 20 | {\\n} | 21 | exit node of function\\n h()\\n{\\n} |
 | mixedMembers | 1 | Mixed | 3 | constructor |
-| mixedMembers | 1 | class M ... z) {}\\n} | 7 | exit node of <toplevel> |
+| mixedMembers | 1 | class M ... z) {}\\n} | 6 | exit node of <toplevel> |
 | mixedMembers | 1 | entry node of <toplevel> | 1 | Mixed |
 | mixedMembers | 2 | 3 | 2 | x = 3 |
 | mixedMembers | 2 | x | 2 | 3 |
@@ -746,7 +746,7 @@
 | staticFields | 2 | C | 2 | new C() |
 | staticFields | 2 | instance | 2 | C |
 | staticFields | 2 | new C() | 2 | static  ... ew C(); |
-| staticFields | 2 | static  ... ew C(); | 7 | exit node of <toplevel> |
+| staticFields | 2 | static  ... ew C(); | 4 | exit node of <toplevel> |
 | staticFieldsTS | 1 | C | 1 | constructor |
 | staticFieldsTS | 1 | class C ...  C();\\n} | 2 | instance |
 | staticFieldsTS | 1 | constructor | 1 | function in constructor() {} |

--- a/javascript/ql/test/library-tests/CFG/classes.js
+++ b/javascript/ql/test/library-tests/CFG/classes.js
@@ -37,5 +37,3 @@ t = class extends A { f() {} }
 t = class extends A { x = 5; f() {} }
 t = class extends A { static x = 5; f() {} }
 t = class extends A { static x = 5; f() {} constructor() {} }
-
-// semmle-extractor-options: --experimental

--- a/javascript/ql/test/library-tests/CFG/fields.js
+++ b/javascript/ql/test/library-tests/CFG/fields.js
@@ -16,5 +16,3 @@ class B extends A {
   }
   z;
 }
-
-// semmle-extractor-options: --experimental

--- a/javascript/ql/test/library-tests/CFG/mixedMembers.js
+++ b/javascript/ql/test/library-tests/CFG/mixedMembers.js
@@ -3,5 +3,3 @@ class Mixed {
   constructor(y) {}
   method(z) {}
 }
-
-// semmle-extractor-options: --experimental

--- a/javascript/ql/test/library-tests/CFG/options
+++ b/javascript/ql/test/library-tests/CFG/options
@@ -1,0 +1,1 @@
+semmle-extractor-options: --experimental

--- a/javascript/ql/test/library-tests/CFG/staticFields.js
+++ b/javascript/ql/test/library-tests/CFG/staticFields.js
@@ -1,6 +1,3 @@
 class C {
   static instance = new C();
 }
-
-// semmle-extractor-options: --experimental
-

--- a/javascript/ql/test/library-tests/Classes/fields.js
+++ b/javascript/ql/test/library-tests/Classes/fields.js
@@ -2,5 +2,3 @@ class C {
   x;
   y = 42
 }
-
-// semmle-extractor-options: --experimental

--- a/javascript/ql/test/library-tests/Classes/options
+++ b/javascript/ql/test/library-tests/Classes/options
@@ -1,0 +1,1 @@
+semmle-extractor-options: --experimental

--- a/javascript/ql/test/library-tests/Comprehensions/comprehensions.js
+++ b/javascript/ql/test/library-tests/Comprehensions/comprehensions.js
@@ -8,5 +8,3 @@ year;
 year;
 (for (i of numbers) for (j of letters) i+j);
 (for (i of numbers) for (j of letters) if (i<j) i+j);
-
-//semmle-extractor-options: --experimental

--- a/javascript/ql/test/library-tests/Comprehensions/options
+++ b/javascript/ql/test/library-tests/Comprehensions/options
@@ -1,0 +1,1 @@
+semmle-extractor-options: --experimental

--- a/javascript/ql/test/library-tests/DataFlow/flowStep.expected
+++ b/javascript/ql/test/library-tests/DataFlow/flowStep.expected
@@ -142,11 +142,11 @@
 | tst.js:111:29:111:31 | o2c | tst.js:111:6:111:38 | v2c |
 | tst.js:111:36:111:38 | o2d | tst.js:111:6:111:32 | [v2a, v ...  = o2c] |
 | tst.js:115:1:115:12 | reflective call | tst.js:115:1:115:12 | Array.call() |
-| tst.ts:1:1:1:1 | A | tst.ts:1:11:1:11 | A |
+| tst.ts:1:1:1:1 | A | tst.ts:1:18:1:18 | A |
 | tst.ts:1:1:1:1 | A | tst.ts:7:1:7:0 | A |
-| tst.ts:1:1:5:1 | A | tst.ts:7:1:7:0 | A |
-| tst.ts:1:1:5:1 | A | tst.ts:11:11:11:11 | A |
-| tst.ts:1:1:5:1 | namespa ... lysed\\n} | tst.ts:1:1:5:1 | A |
+| tst.ts:1:8:5:1 | A | tst.ts:7:1:7:0 | A |
+| tst.ts:1:8:5:1 | A | tst.ts:11:11:11:11 | A |
+| tst.ts:1:8:5:1 | namespa ... lysed\\n} | tst.ts:1:8:5:1 | A |
 | tst.ts:2:14:2:19 | x | tst.ts:4:3:4:3 | x |
 | tst.ts:2:18:2:19 | 42 | tst.ts:2:14:2:19 | x |
 | tst.ts:7:1:7:0 | A | tst.ts:8:3:8:3 | A |

--- a/javascript/ql/test/library-tests/DataFlow/options
+++ b/javascript/ql/test/library-tests/DataFlow/options
@@ -1,0 +1,1 @@
+semmle-extractor-options: --experimental

--- a/javascript/ql/test/library-tests/DataFlow/tst.js
+++ b/javascript/ql/test/library-tests/DataFlow/tst.js
@@ -113,5 +113,3 @@ x ?? y;                           // flow through short-circuiting operator
 });
 
 Array.call()  // flow from implicit call to `Array` to `Array.call`
-
-// semmle-extractor-options: --experimental

--- a/javascript/ql/test/library-tests/DataFlow/tst.ts
+++ b/javascript/ql/test/library-tests/DataFlow/tst.ts
@@ -1,4 +1,4 @@
-namespace A {
+export namespace A {
   export let x = 42;
   setX();
   x;                                     // global namespace exports are incompletely analysed
@@ -11,5 +11,3 @@ function setX() {
 var nd2 = A.x as number;                 // flow through type assertions
 
 class StringList extends List<string> {} // flow through expressions with type arguments
-
-// semmle-extractor-options: --source-type module

--- a/javascript/ql/test/library-tests/Decorators/options
+++ b/javascript/ql/test/library-tests/Decorators/options
@@ -1,0 +1,1 @@
+semmle-extractor-options: --experimental

--- a/javascript/ql/test/library-tests/Decorators/tst.js
+++ b/javascript/ql/test/library-tests/Decorators/tst.js
@@ -7,5 +7,3 @@ var o = {
   get bar() { return 42 },
   set bar(v) { }
 };
-
-// semmle-extractor-options: --experimental

--- a/javascript/ql/test/library-tests/DefUse/es2015.js
+++ b/javascript/ql/test/library-tests/DefUse/es2015.js
@@ -4,5 +4,3 @@ for (let fn in fns)
 function getSquares() {
   return [for (i of [0, 1, 2]) i*i];
 }
-
-//semmle-extractor-options: --experimental

--- a/javascript/ql/test/library-tests/DefUse/options
+++ b/javascript/ql/test/library-tests/DefUse/options
@@ -1,0 +1,1 @@
+semmle-extractor-options: --experimental

--- a/javascript/ql/test/library-tests/Errors/options
+++ b/javascript/ql/test/library-tests/Errors/options
@@ -1,0 +1,1 @@
+semmle-extractor-options: --tolerate-parse-errors

--- a/javascript/ql/test/library-tests/Errors/setters.js
+++ b/javascript/ql/test/library-tests/Errors/setters.js
@@ -8,5 +8,3 @@ var o = {
   set y(...ys) {},
   set z(z, ...zs) {}
 };
-
-// semmle-extractor-options: --tolerate-parse-errors

--- a/javascript/ql/test/library-tests/Errors/tst.js
+++ b/javascript/ql/test/library-tests/Errors/tst.js
@@ -1,4 +1,2 @@
   while
 }
-
-// semmle-extractor-options: --tolerate-parse-errors

--- a/javascript/ql/test/library-tests/Expr/legacyletexpr.js
+++ b/javascript/ql/test/library-tests/Expr/legacyletexpr.js
@@ -1,3 +1,1 @@
 console.log(let (x = 23, y = 19) x + y);
-
-//semmle-extractor-options: --experimental

--- a/javascript/ql/test/library-tests/Expr/mozextensions.js
+++ b/javascript/ql/test/library-tests/Expr/mozextensions.js
@@ -1,3 +1,1 @@
 array.map(function(x) x+1);
-
-//semmle-extractor-options: --experimental

--- a/javascript/ql/test/library-tests/Expr/options
+++ b/javascript/ql/test/library-tests/Expr/options
@@ -1,0 +1,1 @@
+semmle-extractor-options: --experimental

--- a/javascript/ql/test/library-tests/Expr/tests.expected
+++ b/javascript/ql/test/library-tests/Expr/tests.expected
@@ -682,29 +682,29 @@ test_getTopLevel
 | functions.js:7:4:7:4 | x | functions.js:1:1:10:7 | <toplevel> |
 | functions.js:7:7:7:16 | in_f_again | functions.js:1:1:10:7 | <toplevel> |
 | functions.js:10:1:10:6 | global | functions.js:1:1:10:7 | <toplevel> |
-| legacyletexpr.js:1:1:1:7 | console | legacyletexpr.js:1:1:3:42 | <toplevel> |
-| legacyletexpr.js:1:1:1:11 | console.log | legacyletexpr.js:1:1:3:42 | <toplevel> |
-| legacyletexpr.js:1:1:1:39 | console ...  x + y) | legacyletexpr.js:1:1:3:42 | <toplevel> |
-| legacyletexpr.js:1:9:1:11 | log | legacyletexpr.js:1:1:3:42 | <toplevel> |
-| legacyletexpr.js:1:13:1:38 | let (x  ... ) x + y | legacyletexpr.js:1:1:3:42 | <toplevel> |
-| legacyletexpr.js:1:18:1:18 | x | legacyletexpr.js:1:1:3:42 | <toplevel> |
-| legacyletexpr.js:1:18:1:23 | x = 23 | legacyletexpr.js:1:1:3:42 | <toplevel> |
-| legacyletexpr.js:1:22:1:23 | 23 | legacyletexpr.js:1:1:3:42 | <toplevel> |
-| legacyletexpr.js:1:26:1:26 | y | legacyletexpr.js:1:1:3:42 | <toplevel> |
-| legacyletexpr.js:1:26:1:31 | y = 19 | legacyletexpr.js:1:1:3:42 | <toplevel> |
-| legacyletexpr.js:1:30:1:31 | 19 | legacyletexpr.js:1:1:3:42 | <toplevel> |
-| legacyletexpr.js:1:34:1:34 | x | legacyletexpr.js:1:1:3:42 | <toplevel> |
-| legacyletexpr.js:1:34:1:38 | x + y | legacyletexpr.js:1:1:3:42 | <toplevel> |
-| legacyletexpr.js:1:38:1:38 | y | legacyletexpr.js:1:1:3:42 | <toplevel> |
-| mozextensions.js:1:1:1:5 | array | mozextensions.js:1:1:3:42 | <toplevel> |
-| mozextensions.js:1:1:1:9 | array.map | mozextensions.js:1:1:3:42 | <toplevel> |
-| mozextensions.js:1:1:1:26 | array.m ... x) x+1) | mozextensions.js:1:1:3:42 | <toplevel> |
-| mozextensions.js:1:7:1:9 | map | mozextensions.js:1:1:3:42 | <toplevel> |
-| mozextensions.js:1:11:1:25 | function(x) x+1 | mozextensions.js:1:1:3:42 | <toplevel> |
-| mozextensions.js:1:20:1:20 | x | mozextensions.js:1:1:3:42 | <toplevel> |
-| mozextensions.js:1:23:1:23 | x | mozextensions.js:1:1:3:42 | <toplevel> |
-| mozextensions.js:1:23:1:25 | x+1 | mozextensions.js:1:1:3:42 | <toplevel> |
-| mozextensions.js:1:25:1:25 | 1 | mozextensions.js:1:1:3:42 | <toplevel> |
+| legacyletexpr.js:1:1:1:7 | console | legacyletexpr.js:1:1:2:0 | <toplevel> |
+| legacyletexpr.js:1:1:1:11 | console.log | legacyletexpr.js:1:1:2:0 | <toplevel> |
+| legacyletexpr.js:1:1:1:39 | console ...  x + y) | legacyletexpr.js:1:1:2:0 | <toplevel> |
+| legacyletexpr.js:1:9:1:11 | log | legacyletexpr.js:1:1:2:0 | <toplevel> |
+| legacyletexpr.js:1:13:1:38 | let (x  ... ) x + y | legacyletexpr.js:1:1:2:0 | <toplevel> |
+| legacyletexpr.js:1:18:1:18 | x | legacyletexpr.js:1:1:2:0 | <toplevel> |
+| legacyletexpr.js:1:18:1:23 | x = 23 | legacyletexpr.js:1:1:2:0 | <toplevel> |
+| legacyletexpr.js:1:22:1:23 | 23 | legacyletexpr.js:1:1:2:0 | <toplevel> |
+| legacyletexpr.js:1:26:1:26 | y | legacyletexpr.js:1:1:2:0 | <toplevel> |
+| legacyletexpr.js:1:26:1:31 | y = 19 | legacyletexpr.js:1:1:2:0 | <toplevel> |
+| legacyletexpr.js:1:30:1:31 | 19 | legacyletexpr.js:1:1:2:0 | <toplevel> |
+| legacyletexpr.js:1:34:1:34 | x | legacyletexpr.js:1:1:2:0 | <toplevel> |
+| legacyletexpr.js:1:34:1:38 | x + y | legacyletexpr.js:1:1:2:0 | <toplevel> |
+| legacyletexpr.js:1:38:1:38 | y | legacyletexpr.js:1:1:2:0 | <toplevel> |
+| mozextensions.js:1:1:1:5 | array | mozextensions.js:1:1:2:0 | <toplevel> |
+| mozextensions.js:1:1:1:9 | array.map | mozextensions.js:1:1:2:0 | <toplevel> |
+| mozextensions.js:1:1:1:26 | array.m ... x) x+1) | mozextensions.js:1:1:2:0 | <toplevel> |
+| mozextensions.js:1:7:1:9 | map | mozextensions.js:1:1:2:0 | <toplevel> |
+| mozextensions.js:1:11:1:25 | function(x) x+1 | mozextensions.js:1:1:2:0 | <toplevel> |
+| mozextensions.js:1:20:1:20 | x | mozextensions.js:1:1:2:0 | <toplevel> |
+| mozextensions.js:1:23:1:23 | x | mozextensions.js:1:1:2:0 | <toplevel> |
+| mozextensions.js:1:23:1:25 | x+1 | mozextensions.js:1:1:2:0 | <toplevel> |
+| mozextensions.js:1:25:1:25 | 1 | mozextensions.js:1:1:2:0 | <toplevel> |
 | nullSensitiveContexts.js:7:1:7:3 | foo | nullSensitiveContexts.js:1:1:61:0 | <toplevel> |
 | nullSensitiveContexts.js:7:1:7:8 | foo[bar] | nullSensitiveContexts.js:1:1:61:0 | <toplevel> |
 | nullSensitiveContexts.js:7:5:7:7 | bar | nullSensitiveContexts.js:1:1:61:0 | <toplevel> |
@@ -1922,25 +1922,25 @@ test_getContainer
 | functions.js:7:4:7:4 | x | functions.js:1:1:9:1 | functio ... \\t\\t});\\n} |
 | functions.js:7:7:7:16 | in_f_again | functions.js:1:1:9:1 | functio ... \\t\\t});\\n} |
 | functions.js:10:1:10:6 | global | functions.js:1:1:10:7 | <toplevel> |
-| legacyletexpr.js:1:1:1:7 | console | legacyletexpr.js:1:1:3:42 | <toplevel> |
-| legacyletexpr.js:1:1:1:11 | console.log | legacyletexpr.js:1:1:3:42 | <toplevel> |
-| legacyletexpr.js:1:1:1:39 | console ...  x + y) | legacyletexpr.js:1:1:3:42 | <toplevel> |
-| legacyletexpr.js:1:9:1:11 | log | legacyletexpr.js:1:1:3:42 | <toplevel> |
-| legacyletexpr.js:1:13:1:38 | let (x  ... ) x + y | legacyletexpr.js:1:1:3:42 | <toplevel> |
-| legacyletexpr.js:1:18:1:18 | x | legacyletexpr.js:1:1:3:42 | <toplevel> |
-| legacyletexpr.js:1:18:1:23 | x = 23 | legacyletexpr.js:1:1:3:42 | <toplevel> |
-| legacyletexpr.js:1:22:1:23 | 23 | legacyletexpr.js:1:1:3:42 | <toplevel> |
-| legacyletexpr.js:1:26:1:26 | y | legacyletexpr.js:1:1:3:42 | <toplevel> |
-| legacyletexpr.js:1:26:1:31 | y = 19 | legacyletexpr.js:1:1:3:42 | <toplevel> |
-| legacyletexpr.js:1:30:1:31 | 19 | legacyletexpr.js:1:1:3:42 | <toplevel> |
-| legacyletexpr.js:1:34:1:34 | x | legacyletexpr.js:1:1:3:42 | <toplevel> |
-| legacyletexpr.js:1:34:1:38 | x + y | legacyletexpr.js:1:1:3:42 | <toplevel> |
-| legacyletexpr.js:1:38:1:38 | y | legacyletexpr.js:1:1:3:42 | <toplevel> |
-| mozextensions.js:1:1:1:5 | array | mozextensions.js:1:1:3:42 | <toplevel> |
-| mozextensions.js:1:1:1:9 | array.map | mozextensions.js:1:1:3:42 | <toplevel> |
-| mozextensions.js:1:1:1:26 | array.m ... x) x+1) | mozextensions.js:1:1:3:42 | <toplevel> |
-| mozextensions.js:1:7:1:9 | map | mozextensions.js:1:1:3:42 | <toplevel> |
-| mozextensions.js:1:11:1:25 | function(x) x+1 | mozextensions.js:1:1:3:42 | <toplevel> |
+| legacyletexpr.js:1:1:1:7 | console | legacyletexpr.js:1:1:2:0 | <toplevel> |
+| legacyletexpr.js:1:1:1:11 | console.log | legacyletexpr.js:1:1:2:0 | <toplevel> |
+| legacyletexpr.js:1:1:1:39 | console ...  x + y) | legacyletexpr.js:1:1:2:0 | <toplevel> |
+| legacyletexpr.js:1:9:1:11 | log | legacyletexpr.js:1:1:2:0 | <toplevel> |
+| legacyletexpr.js:1:13:1:38 | let (x  ... ) x + y | legacyletexpr.js:1:1:2:0 | <toplevel> |
+| legacyletexpr.js:1:18:1:18 | x | legacyletexpr.js:1:1:2:0 | <toplevel> |
+| legacyletexpr.js:1:18:1:23 | x = 23 | legacyletexpr.js:1:1:2:0 | <toplevel> |
+| legacyletexpr.js:1:22:1:23 | 23 | legacyletexpr.js:1:1:2:0 | <toplevel> |
+| legacyletexpr.js:1:26:1:26 | y | legacyletexpr.js:1:1:2:0 | <toplevel> |
+| legacyletexpr.js:1:26:1:31 | y = 19 | legacyletexpr.js:1:1:2:0 | <toplevel> |
+| legacyletexpr.js:1:30:1:31 | 19 | legacyletexpr.js:1:1:2:0 | <toplevel> |
+| legacyletexpr.js:1:34:1:34 | x | legacyletexpr.js:1:1:2:0 | <toplevel> |
+| legacyletexpr.js:1:34:1:38 | x + y | legacyletexpr.js:1:1:2:0 | <toplevel> |
+| legacyletexpr.js:1:38:1:38 | y | legacyletexpr.js:1:1:2:0 | <toplevel> |
+| mozextensions.js:1:1:1:5 | array | mozextensions.js:1:1:2:0 | <toplevel> |
+| mozextensions.js:1:1:1:9 | array.map | mozextensions.js:1:1:2:0 | <toplevel> |
+| mozextensions.js:1:1:1:26 | array.m ... x) x+1) | mozextensions.js:1:1:2:0 | <toplevel> |
+| mozextensions.js:1:7:1:9 | map | mozextensions.js:1:1:2:0 | <toplevel> |
+| mozextensions.js:1:11:1:25 | function(x) x+1 | mozextensions.js:1:1:2:0 | <toplevel> |
 | mozextensions.js:1:20:1:20 | x | mozextensions.js:1:11:1:25 | function(x) x+1 |
 | mozextensions.js:1:23:1:23 | x | mozextensions.js:1:11:1:25 | function(x) x+1 |
 | mozextensions.js:1:23:1:25 | x+1 | mozextensions.js:1:11:1:25 | function(x) x+1 |

--- a/javascript/ql/test/library-tests/Externs/Point.js
+++ b/javascript/ql/test/library-tests/Externs/Point.js
@@ -17,4 +17,4 @@ Point.prototype['final'];
 /** @type {!Point} */
 var aPoint;
 
-//semmle-extractor-options: --externs
+/** @externs */

--- a/javascript/ql/test/library-tests/Flow/AbstractValues.expected
+++ b/javascript/ql/test/library-tests/Flow/AbstractValues.expected
@@ -194,8 +194,8 @@
 | n.js:2:1:2:15 | function g |
 | n.js:2:1:2:15 | instance of function g |
 | n.js:3:16:3:23 | object literal |
-| namespace-reexport.js:1:1:4:0 | exports object of module namespace-reexport |
-| namespace-reexport.js:1:1:4:0 | module object of module namespace-reexport |
+| namespace-reexport.js:1:1:2:0 | exports object of module namespace-reexport |
+| namespace-reexport.js:1:1:2:0 | module object of module namespace-reexport |
 | nestedImport.js:1:1:13:0 | exports object of module nestedImport |
 | nestedImport.js:1:1:13:0 | module object of module nestedImport |
 | nestedImport.js:9:1:12:1 | function tst |
@@ -235,14 +235,14 @@
 | objlit.js:43:12:45:3 | object literal |
 | reexport-d.js:1:1:2:0 | exports object of module reexport-d |
 | reexport-d.js:1:1:2:0 | module object of module reexport-d |
-| reexport-mixins.js:1:1:4:0 | exports object of module reexport-mixins |
-| reexport-mixins.js:1:1:4:0 | module object of module reexport-mixins |
+| reexport-mixins.js:1:1:2:0 | exports object of module reexport-mixins |
+| reexport-mixins.js:1:1:2:0 | module object of module reexport-mixins |
 | reexport-unknown.js:1:1:2:0 | exports object of module reexport-unknown |
 | reexport-unknown.js:1:1:2:0 | module object of module reexport-unknown |
 | reexport/client/src/index.js:1:1:3:0 | exports object of module index |
 | reexport/client/src/index.js:1:1:3:0 | module object of module index |
-| reexport/lib/index.js:1:1:4:0 | exports object of module index |
-| reexport/lib/index.js:1:1:4:0 | module object of module index |
+| reexport/lib/index.js:1:1:2:0 | exports object of module index |
+| reexport/lib/index.js:1:1:2:0 | module object of module index |
 | reexport/lib/src/utils/util.js:1:1:3:0 | exports object of module util |
 | reexport/lib/src/utils/util.js:1:1:3:0 | module object of module util |
 | refinements.js:1:1:8:1 | function f1 |
@@ -341,8 +341,8 @@
 | tst.js:174:1:183:1 | function awaitFlow |
 | tst.mjs:1:1:4:0 | exports object of module tst |
 | tst.mjs:1:1:4:0 | module object of module tst |
-| tst.ts:1:1:15:0 | exports object of module tst |
-| tst.ts:1:1:15:0 | module object of module tst |
+| tst.ts:1:1:13:0 | exports object of module tst |
+| tst.ts:1:1:13:0 | module object of module tst |
 | tst.ts:8:1:10:1 | function setX |
 | tst.ts:8:1:10:1 | instance of function setX |
 | with.js:1:1:17:1 | function f |

--- a/javascript/ql/test/library-tests/Flow/namespace-reexport.js
+++ b/javascript/ql/test/library-tests/Flow/namespace-reexport.js
@@ -1,3 +1,1 @@
 export * as h from './h';
-
-// semmle-extractor-options: --experimental

--- a/javascript/ql/test/library-tests/Flow/options
+++ b/javascript/ql/test/library-tests/Flow/options
@@ -1,0 +1,1 @@
+semmle-extractor-options: --experimental

--- a/javascript/ql/test/library-tests/Flow/reexport-mixins.js
+++ b/javascript/ql/test/library-tests/Flow/reexport-mixins.js
@@ -1,3 +1,1 @@
 export default from './mixins';
-
-// semmle-extractor-options: --experimental

--- a/javascript/ql/test/library-tests/Flow/reexport/lib/index.js
+++ b/javascript/ql/test/library-tests/Flow/reexport/lib/index.js
@@ -1,3 +1,1 @@
 export data from './src/utils/util'
-
-// semmle-extractor-options: --experimental

--- a/javascript/ql/test/library-tests/Flow/reexport/lib/options
+++ b/javascript/ql/test/library-tests/Flow/reexport/lib/options
@@ -1,0 +1,1 @@
+semmle-extractor-options: --experimental

--- a/javascript/ql/test/library-tests/Flow/tst.ts
+++ b/javascript/ql/test/library-tests/Flow/tst.ts
@@ -1,4 +1,4 @@
-namespace A {
+export namespace A {
   export let x = 42;
   setX();
   let x2 = x;
@@ -10,5 +10,3 @@ function setX() {
 }
 
 let a = A;
-
-// semmle-extractor-options: --source-type module

--- a/javascript/ql/test/library-tests/Functions/exprclosures.js
+++ b/javascript/ql/test/library-tests/Functions/exprclosures.js
@@ -1,3 +1,1 @@
 a.map(function(x) x+1);
-
-//semmle-extractor-options: --experimental

--- a/javascript/ql/test/library-tests/Functions/options
+++ b/javascript/ql/test/library-tests/Functions/options
@@ -1,0 +1,1 @@
+semmle-extractor-options: --experimental

--- a/javascript/ql/test/library-tests/HTML/HtmlText/HtmlText.html
+++ b/javascript/ql/test/library-tests/HTML/HtmlText/HtmlText.html
@@ -1,4 +1,4 @@
-//  semmle-extractor-options: --html all
+
 <html>
   <body>
   (1) as child #0

--- a/javascript/ql/test/library-tests/HTML/HtmlText/options
+++ b/javascript/ql/test/library-tests/HTML/HtmlText/options
@@ -1,0 +1,1 @@
+semmle-extractor-options: --html all

--- a/javascript/ql/test/library-tests/InterProceduralFlow/callback.js
+++ b/javascript/ql/test/library-tests/InterProceduralFlow/callback.js
@@ -28,4 +28,4 @@ let source3 = "source3";
 call2(source3, store);
 call2(source3, confounder);
 
-// semmle-extractor-options: --source-type module
+export default 0;

--- a/javascript/ql/test/library-tests/InterProceduralFlow/properties2.js
+++ b/javascript/ql/test/library-tests/InterProceduralFlow/properties2.js
@@ -42,4 +42,4 @@ var o5 = {};
 setP(o5, "not a source");
 var sink10 = getP(o5);
 
-// semmle-extractor-options: --source-type module
+export default 0;

--- a/javascript/ql/test/library-tests/JSON/JSONError.expected
+++ b/javascript/ql/test/library-tests/JSON/JSONError.expected
@@ -1,2 +1,1 @@
 | invalid.json:3:1:3:1 | Error: Comments are not legal in JSON. |
-| invalid.json:4:1:4:1 | Error: Comments are not legal in JSON. |

--- a/javascript/ql/test/library-tests/JSON/invalid.json
+++ b/javascript/ql/test/library-tests/JSON/invalid.json
@@ -1,4 +1,3 @@
 "hi"
 
 // JSON doesn't have comments
-// semmle-extractor-options: --tolerate-parse-errors

--- a/javascript/ql/test/library-tests/JSON/options
+++ b/javascript/ql/test/library-tests/JSON/options
@@ -1,0 +1,1 @@
+semmle-extractor-options: --tolerate-parse-errors

--- a/javascript/ql/test/library-tests/Lines/Lines.expected
+++ b/javascript/ql/test/library-tests/Lines/Lines.expected
@@ -1,4 +1,4 @@
-| tst1.js:1:1:1:55 | abc // semmle-extractor-options: --extract-program-text | abc // semmle-extractor-options: --extract-program-text | \n |
+| tst1.js:1:1:1:3 | abc | abc | \n |
 | tst1.js:2:1:2:3 | def | def | \r |
 | tst1.js:3:1:3:3 | ghi | ghi | \r\n |
 | tst1.js:4:1:4:3 | jkl | jkl | \n |
@@ -6,13 +6,13 @@
 | tst1.js:6:1:6:3 | mno | mno | \u2028 |
 | tst1.js:7:1:7:0 |  |  | \n |
 | tst1.js:8:1:8:3 | pqr | pqr | \u2029 |
-| tst1.js:9:1:9:3 | stu | stu |  |
-| tst2.js:1:1:1:63 | first_line  // semmle-extractor-options: --extract-program-text | first_line  // semmle-extractor-options: --extract-program-text | \n |
-| tst3.js:1:1:1:56 | 42;  // semmle-extractor-options: --extract-program-text | 42;  // semmle-extractor-options: --extract-program-text | \n |
+| tst1.js:9:1:9:3 | stu | stu | \n |
+| tst2.js:1:1:1:10 | first_line | first_line | \n |
+| tst3.js:1:1:1:3 | 42; | 42; | \n |
 | tst3.js:2:1:2:4 | \t42; | \t42; | \n |
 | tst3.js:3:1:3:5 | \t\t42; | \t\t42; | \n |
 | tst3.js:4:1:4:6 | \t\t\t42; | \t\t\t42; | \n |
 | tst3.js:5:1:5:6 | \t\t 42; | \t\t 42; | \n |
 | tst3.js:6:1:6:6 | \t \t42; | \t \t42; | \n |
 | tst3.js:7:1:7:7 |     42; |     42; | \n |
-| tst3.js:8:1:8:5 |   42; |   42; |  |
+| tst3.js:8:1:8:5 |   42; |   42; | \n |

--- a/javascript/ql/test/library-tests/Lines/options
+++ b/javascript/ql/test/library-tests/Lines/options
@@ -1,0 +1,1 @@
+semmle-extractor-options: --extract-program-text

--- a/javascript/ql/test/library-tests/Lines/tst1.js
+++ b/javascript/ql/test/library-tests/Lines/tst1.js
@@ -1,4 +1,4 @@
-abc // semmle-extractor-options: --extract-program-text
+abc
 defghi
 jkl
 mno 

--- a/javascript/ql/test/library-tests/Lines/tst2.js
+++ b/javascript/ql/test/library-tests/Lines/tst2.js
@@ -1,1 +1,1 @@
-first_line  // semmle-extractor-options: --extract-program-text
+first_line

--- a/javascript/ql/test/library-tests/Lines/tst3.js
+++ b/javascript/ql/test/library-tests/Lines/tst3.js
@@ -1,4 +1,4 @@
-42;  // semmle-extractor-options: --extract-program-text
+42;
 	42;
 		42;
 			42;

--- a/javascript/ql/test/library-tests/LocalObjects/options
+++ b/javascript/ql/test/library-tests/LocalObjects/options
@@ -1,0 +1,1 @@
+semmle-extractor-options: --experimental

--- a/javascript/ql/test/library-tests/LocalObjects/tst.js
+++ b/javascript/ql/test/library-tests/LocalObjects/tst.js
@@ -89,5 +89,3 @@
 	let bound = {};
 	bound::unknown();
 });
-
-// semmle-extractor-options: --experimental

--- a/javascript/ql/test/library-tests/Modules/b.js
+++ b/javascript/ql/test/library-tests/Modules/b.js
@@ -5,5 +5,3 @@ f();
 export { f as g };
 
 export f2 from './a';
-
-// semmle-extractor-options: --experimental

--- a/javascript/ql/test/library-tests/Modules/m/c.js
+++ b/javascript/ql/test/library-tests/Modules/m/c.js
@@ -3,5 +3,3 @@ import * as b from '../b';
 b.g();
 
 export { g as h } from '../b';
-
-// semmle-extractor-options: --experimental

--- a/javascript/ql/test/library-tests/Modules/m/options
+++ b/javascript/ql/test/library-tests/Modules/m/options
@@ -1,0 +1,1 @@
+semmle-extractor-options: --experimental

--- a/javascript/ql/test/library-tests/Modules/options
+++ b/javascript/ql/test/library-tests/Modules/options
@@ -1,0 +1,1 @@
+semmle-extractor-options: --experimental

--- a/javascript/ql/test/library-tests/Modules/tests.expected
+++ b/javascript/ql/test/library-tests/Modules/tests.expected
@@ -104,15 +104,15 @@ test_Module_exports
 | a.js:1:1:5:32 | <toplevel> | default | a.js:1:1:3:1 | export  ... n 23;\\n} |
 | a.js:1:1:5:32 | <toplevel> | x | a.js:5:1:5:32 | export  ...  } = o; |
 | a.js:1:1:5:32 | <toplevel> | y | a.js:5:1:5:32 | export  ...  } = o; |
-| b.js:1:1:10:0 | <toplevel> | f2 | b.js:7:1:7:21 | export  ...  './a'; |
-| b.js:1:1:10:0 | <toplevel> | g | b.js:5:1:5:18 | export { f as g }; |
+| b.js:1:1:8:0 | <toplevel> | f2 | b.js:7:1:7:21 | export  ...  './a'; |
+| b.js:1:1:8:0 | <toplevel> | g | b.js:5:1:5:18 | export { f as g }; |
 | e.js:1:1:4:0 | <toplevel> | g | e.js:3:1:3:35 | export  ...  './a'; |
 | e.js:1:1:4:0 | <toplevel> | x | e.js:2:1:2:16 | export { x, y }; |
 | e.js:1:1:4:0 | <toplevel> | y | e.js:2:1:2:16 | export { x, y }; |
 | es2015_require.js:1:1:3:25 | <toplevel> | default | es2015_require.js:3:1:3:25 | export  ... ss C {} |
 | export-in-mjs.mjs:1:1:1:34 | <toplevel> | exported_from_mjs | export-in-mjs.mjs:1:1:1:34 | export  ... s = 42; |
 | f.ts:1:1:6:0 | <toplevel> | foo | f.ts:5:1:5:24 | export  ... oo() {} |
-| m/c.js:1:1:8:0 | <toplevel> | h | m/c.js:5:1:5:30 | export  ... '../b'; |
+| m/c.js:1:1:6:0 | <toplevel> | h | m/c.js:5:1:5:30 | export  ... '../b'; |
 | tst.html:4:23:8:0 | <toplevel> | y | tst.html:7:3:7:22 | export const y = 42; |
 test_ExportDefaultDeclarations
 | a.js:1:1:3:1 | export  ... n 23;\\n} |

--- a/javascript/ql/test/library-tests/NPM/ImportedModule.expected
+++ b/javascript/ql/test/library-tests/NPM/ImportedModule.expected
@@ -1,6 +1,6 @@
-| src/lib/tst2.js:1:1:1:13 | require("..") | src/index.js:1:1:5:0 | <toplevel> |
-| src/node_modules/nested/tst3.js:1:1:1:29 | require ... odule') | src/node_modules/third-party-module/fancy.js:1:1:5:0 | <toplevel> |
+| src/lib/tst2.js:1:1:1:13 | require("..") | src/index.js:1:1:4:0 | <toplevel> |
+| src/node_modules/nested/tst3.js:1:1:1:29 | require ... odule') | src/node_modules/third-party-module/fancy.js:1:1:4:0 | <toplevel> |
 | src/node_modules/nested/tst3.js:2:1:2:12 | require('a') | src/node_modules/nested/node_modules/a/index.js:1:1:1:25 | <toplevel> |
-| src/node_modules/tst2.js:1:1:1:38 | require ... cy.js') | src/node_modules/third-party-module/fancy.js:1:1:5:0 | <toplevel> |
-| src/tst2.js:1:1:1:12 | require(".") | src/index.js:1:1:5:0 | <toplevel> |
-| src/tst.js:1:1:1:38 | require ... cy.js') | src/node_modules/third-party-module/fancy.js:1:1:5:0 | <toplevel> |
+| src/node_modules/tst2.js:1:1:1:38 | require ... cy.js') | src/node_modules/third-party-module/fancy.js:1:1:4:0 | <toplevel> |
+| src/tst2.js:1:1:1:12 | require(".") | src/index.js:1:1:4:0 | <toplevel> |
+| src/tst.js:1:1:1:38 | require ... cy.js') | src/node_modules/third-party-module/fancy.js:1:1:4:0 | <toplevel> |

--- a/javascript/ql/test/library-tests/NPM/Modules.expected
+++ b/javascript/ql/test/library-tests/NPM/Modules.expected
@@ -1,9 +1,9 @@
 | b | src/node_modules/b/lib/index.js:1:1:2:0 | <toplevel> |
 | b | src/node_modules/b/lib/index.ts:1:1:2:0 | <toplevel> |
 | c | src/node_modules/c/src/index.js:1:1:2:0 | <toplevel> |
-| test-package | src/index.js:1:1:5:0 | <toplevel> |
+| test-package | src/index.js:1:1:4:0 | <toplevel> |
 | test-package | src/lib/tst2.js:1:1:1:14 | <toplevel> |
-| test-package | src/lib/tst.js:1:1:5:0 | <toplevel> |
+| test-package | src/lib/tst.js:1:1:4:0 | <toplevel> |
 | test-package | src/tst2.js:1:1:1:13 | <toplevel> |
 | test-package | src/tst.js:1:1:2:38 | <toplevel> |
-| third-party-module | src/node_modules/third-party-module/fancy.js:1:1:5:0 | <toplevel> |
+| third-party-module | src/node_modules/third-party-module/fancy.js:1:1:4:0 | <toplevel> |

--- a/javascript/ql/test/library-tests/NPM/NPMPackage_getMainModule.expected
+++ b/javascript/ql/test/library-tests/NPM/NPMPackage_getMainModule.expected
@@ -1,4 +1,4 @@
 | b | src/node_modules/b/lib/index.ts:1:1:2:0 | <toplevel> |
 | c | src/node_modules/c/src/index.js:1:1:2:0 | <toplevel> |
-| test-package | src/index.js:1:1:5:0 | <toplevel> |
-| third-party-module | src/node_modules/third-party-module/fancy.js:1:1:5:0 | <toplevel> |
+| test-package | src/index.js:1:1:4:0 | <toplevel> |
+| third-party-module | src/node_modules/third-party-module/fancy.js:1:1:4:0 | <toplevel> |

--- a/javascript/ql/test/library-tests/NPM/src/index.js
+++ b/javascript/ql/test/library-tests/NPM/src/index.js
@@ -1,4 +1,3 @@
 alert("Hello");
 
-// semmle-extractor-options: --platform
-// semmle-extractor-options: node
+require("process");

--- a/javascript/ql/test/library-tests/NPM/src/lib/tst.js
+++ b/javascript/ql/test/library-tests/NPM/src/lib/tst.js
@@ -1,4 +1,3 @@
 alert("world");
 
-// semmle-extractor-options: --platform
-// semmle-extractor-options: node
+require("process");

--- a/javascript/ql/test/library-tests/NPM/src/node_modules/third-party-module/fancy.js
+++ b/javascript/ql/test/library-tests/NPM/src/node_modules/third-party-module/fancy.js
@@ -1,4 +1,3 @@
 ('alert' in this ? alert : console.log)("Hello");
 
-// semmle-extractor-options: --platform
-// semmle-extractor-options: node
+require("process");

--- a/javascript/ql/test/library-tests/NodeJS/Module_getAnImport.expected
+++ b/javascript/ql/test/library-tests/NodeJS/Module_getAnImport.expected
@@ -9,6 +9,7 @@
 | b.js:1:1:8:0 | <toplevel> | b.js:1:1:1:18 | require('./sub/c') |
 | d.js:1:1:7:15 | <toplevel> | d.js:1:1:1:38 | require ... s/ini') |
 | d.js:1:1:7:15 | <toplevel> | d.js:7:1:7:14 | require('foo') |
+| e.js:1:1:6:0 | <toplevel> | e.js:5:1:5:18 | require("process") |
 | index.js:1:1:3:0 | <toplevel> | index.js:1:12:1:26 | require('path') |
 | index.js:1:1:3:0 | <toplevel> | index.js:2:1:2:41 | require ... b.js")) |
 | mjs-files/require-from-js.js:1:1:4:0 | <toplevel> | mjs-files/require-from-js.js:1:12:1:36 | require ... on-me') |

--- a/javascript/ql/test/library-tests/NodeJS/Module_getAnImportedModule.expected
+++ b/javascript/ql/test/library-tests/NodeJS/Module_getAnImportedModule.expected
@@ -1,6 +1,6 @@
 | a.js:1:1:14:0 | <toplevel> | b.js:1:1:8:0 | <toplevel> |
 | a.js:1:1:14:0 | <toplevel> | d.js:1:1:7:15 | <toplevel> |
-| a.js:1:1:14:0 | <toplevel> | e.js:1:1:7:0 | <toplevel> |
+| a.js:1:1:14:0 | <toplevel> | e.js:1:1:6:0 | <toplevel> |
 | a.js:1:1:14:0 | <toplevel> | index.js:1:1:3:0 | <toplevel> |
 | a.js:1:1:14:0 | <toplevel> | sub/c.js:1:1:4:0 | <toplevel> |
 | b.js:1:1:8:0 | <toplevel> | sub/c.js:1:1:4:0 | <toplevel> |

--- a/javascript/ql/test/library-tests/NodeJS/Modules.expected
+++ b/javascript/ql/test/library-tests/NodeJS/Modules.expected
@@ -1,7 +1,7 @@
 | a.js:1:1:14:0 | <toplevel> | a.js:0:0:0:0 | a.js | a.js | a |
 | b.js:1:1:8:0 | <toplevel> | b.js:0:0:0:0 | b.js | b.js | b |
 | d.js:1:1:7:15 | <toplevel> | d.js:0:0:0:0 | d.js | d.js | d |
-| e.js:1:1:7:0 | <toplevel> | e.js:0:0:0:0 | e.js | e.js | e |
+| e.js:1:1:6:0 | <toplevel> | e.js:0:0:0:0 | e.js | e.js | e |
 | index.js:1:1:3:0 | <toplevel> | index.js:0:0:0:0 | index.js | index.js | index |
 | mjs-files/require-from-js.js:1:1:4:0 | <toplevel> | mjs-files/require-from-js.js:0:0:0:0 | mjs-files/require-from-js.js | mjs-files/require-from-js.js | require-from-js |
 | sub/c.js:1:1:4:0 | <toplevel> | sub/c.js:0:0:0:0 | sub/c.js | sub/c.js | c |

--- a/javascript/ql/test/library-tests/NodeJS/Require.expected
+++ b/javascript/ql/test/library-tests/NodeJS/Require.expected
@@ -9,6 +9,7 @@
 | b.js:1:1:1:18 | require('./sub/c') |
 | d.js:1:1:1:38 | require ... s/ini') |
 | d.js:7:1:7:14 | require('foo') |
+| e.js:5:1:5:18 | require("process") |
 | f.js:2:1:2:7 | r("fs") |
 | index.js:1:12:1:26 | require('path') |
 | index.js:2:1:2:41 | require ... b.js")) |

--- a/javascript/ql/test/library-tests/NodeJS/RequireImport.expected
+++ b/javascript/ql/test/library-tests/NodeJS/RequireImport.expected
@@ -3,7 +3,7 @@
 | a.js:4:6:4:29 | require ... /d.js') | ./sub/../d.js | d.js:1:1:7:15 | <toplevel> |
 | a.js:7:1:7:18 | require('./sub/c') | ./sub/c | sub/c.js:1:1:4:0 | <toplevel> |
 | a.js:10:1:10:18 | require(__dirname) |  | index.js:1:1:3:0 | <toplevel> |
-| a.js:11:1:11:25 | require ... + '/e') | /e | e.js:1:1:7:0 | <toplevel> |
+| a.js:11:1:11:25 | require ... + '/e') | /e | e.js:1:1:6:0 | <toplevel> |
 | a.js:12:1:12:28 | require ...  + 'c') | ./sub/c | sub/c.js:1:1:4:0 | <toplevel> |
 | b.js:1:1:1:18 | require('./sub/c') | ./sub/c | sub/c.js:1:1:4:0 | <toplevel> |
 | d.js:7:1:7:14 | require('foo') | foo | sub/f.js:1:1:4:17 | <toplevel> |

--- a/javascript/ql/test/library-tests/NodeJS/e.js
+++ b/javascript/ql/test/library-tests/NodeJS/e.js
@@ -2,5 +2,4 @@
 	require('./a.js');
 })();
 
-// semmle-extractor-options: --platform
-// semmle-extractor-options: node
+require("process");

--- a/javascript/ql/test/library-tests/OptionalChaining/options
+++ b/javascript/ql/test/library-tests/OptionalChaining/options
@@ -1,0 +1,1 @@
+semmle-extractor-options: --experimental

--- a/javascript/ql/test/library-tests/OptionalChaining/short-circuiting.js
+++ b/javascript/ql/test/library-tests/OptionalChaining/short-circuiting.js
@@ -13,4 +13,3 @@
     DUMP(o3);
     DUMP(o4);
 });
-// semmle-extractor-options: --experimental

--- a/javascript/ql/test/library-tests/OptionalChaining/tst.js
+++ b/javascript/ql/test/library-tests/OptionalChaining/tst.js
@@ -13,5 +13,3 @@ a?.m().b;
 a.m?.().b;
 a.m()?.b;
 a?.m?.()?.b;
-
-// semmle-extractor-options: --experimental

--- a/javascript/ql/test/library-tests/PropWrite/tests.expected
+++ b/javascript/ql/test/library-tests/PropWrite/tests.expected
@@ -1,55 +1,55 @@
 test_getAPropertyRead
-| tst.js:1:1:1:0 | this | tst.js:23:15:23:29 | this.someMethod |
-| tst.js:1:1:1:0 | this | tst.js:24:36:24:45 | this.state |
-| tst.js:14:5:14:11 | console | tst.js:14:5:14:15 | console.log |
-| tst.js:17:5:17:11 | console | tst.js:17:5:17:15 | console.log |
-| tst.js:23:15:23:29 | this.someMethod | tst.js:23:15:23:34 | this.someMethod.bind |
-| tst.js:24:36:24:45 | this.state | tst.js:24:36:24:50 | this.state.name |
-| tst.js:34:6:34:7 | vv | tst.js:34:6:34:10 | vv.pp |
-| tst.js:35:6:35:8 | vvv | tst.js:35:6:35:12 | vvv.ppp |
-| tst.js:35:6:35:12 | vvv.ppp | tst.js:35:6:35:16 | vvv.ppp.qqq |
-| tst.js:45:3:45:9 | console | tst.js:45:3:45:13 | console.log |
-| tst.js:45:15:45:17 | obj | tst.js:45:15:45:20 | obj[p] |
+| tst.js:1:1:1:0 | this | tst.js:22:15:22:29 | this.someMethod |
+| tst.js:1:1:1:0 | this | tst.js:23:36:23:45 | this.state |
+| tst.js:13:5:13:11 | console | tst.js:13:5:13:15 | console.log |
+| tst.js:16:5:16:11 | console | tst.js:16:5:16:15 | console.log |
+| tst.js:22:15:22:29 | this.someMethod | tst.js:22:15:22:34 | this.someMethod.bind |
+| tst.js:23:36:23:45 | this.state | tst.js:23:36:23:50 | this.state.name |
+| tst.js:33:6:33:7 | vv | tst.js:33:6:33:10 | vv.pp |
+| tst.js:34:6:34:8 | vvv | tst.js:34:6:34:12 | vvv.ppp |
+| tst.js:34:6:34:12 | vvv.ppp | tst.js:34:6:34:16 | vvv.ppp.qqq |
+| tst.js:44:3:44:9 | console | tst.js:44:3:44:13 | console.log |
+| tst.js:44:15:44:17 | obj | tst.js:44:15:44:20 | obj[p] |
 test_getAPropertyReference
 | classes.ts:3:21:3:20 | this | classes.ts:4:3:4:24 | instanc ...  foo(); |
 | classes.ts:8:3:8:2 | this | classes.ts:8:15:8:35 | public  ... erField |
 | classes.ts:12:5:12:4 | this | classes.ts:12:17:12:37 | public  ... erField |
 | classes.ts:16:5:16:4 | this | classes.ts:16:17:16:37 | public  ... erField |
-| tst.js:1:1:1:0 | this | tst.js:23:15:23:29 | this.someMethod |
-| tst.js:1:1:1:0 | this | tst.js:24:36:24:45 | this.state |
-| tst.js:2:11:10:1 | {\\n    x ...     }\\n} | tst.js:3:5:3:8 | x: 4 |
-| tst.js:2:11:10:1 | {\\n    x ...     }\\n} | tst.js:4:5:6:5 | func: f ... ;\\n    } |
-| tst.js:2:11:10:1 | {\\n    x ...     }\\n} | tst.js:7:5:9:5 | f() {\\n  ... ;\\n    } |
-| tst.js:12:1:19:1 | class C ... ;\\n  }\\n} | tst.js:13:3:15:3 | static  ... x);\\n  } |
-| tst.js:14:5:14:11 | console | tst.js:14:5:14:15 | console.log |
-| tst.js:17:5:17:11 | console | tst.js:17:5:17:15 | console.log |
-| tst.js:21:1:21:1 | C | tst.js:21:1:21:6 | C.prop |
-| tst.js:23:15:23:29 | this.someMethod | tst.js:23:15:23:34 | this.someMethod.bind |
-| tst.js:24:8:24:57 | <div on ... }</div> | tst.js:24:13:24:27 | onClick={click} |
-| tst.js:24:36:24:45 | this.state | tst.js:24:36:24:50 | this.state.name |
-| tst.js:26:2:29:1 | {\\n  get ... v) {}\\n} | tst.js:27:3:27:26 | get x() ... null; } |
-| tst.js:26:2:29:1 | {\\n  get ... v) {}\\n} | tst.js:28:3:28:13 | set y(v) {} |
-| tst.js:31:2:36:1 | {\\n    n ... q]: 4\\n} | tst.js:32:5:32:8 | n: 1 |
-| tst.js:31:2:36:1 | {\\n    n ... q]: 4\\n} | tst.js:33:5:33:10 | [v]: 2 |
-| tst.js:31:2:36:1 | {\\n    n ... q]: 4\\n} | tst.js:34:5:34:14 | [vv.pp]: 3 |
-| tst.js:31:2:36:1 | {\\n    n ... q]: 4\\n} | tst.js:35:5:35:20 | [vvv.ppp.qqq]: 4 |
-| tst.js:34:6:34:7 | vv | tst.js:34:6:34:10 | vv.pp |
-| tst.js:35:6:35:8 | vvv | tst.js:35:6:35:12 | vvv.ppp |
-| tst.js:35:6:35:12 | vvv.ppp | tst.js:35:6:35:16 | vvv.ppp.qqq |
-| tst.js:38:12:38:26 | ["a", "b", "c"] | tst.js:38:13:38:15 | "a" |
-| tst.js:38:12:38:26 | ["a", "b", "c"] | tst.js:38:18:38:20 | "b" |
-| tst.js:38:12:38:26 | ["a", "b", "c"] | tst.js:38:23:38:25 | "c" |
-| tst.js:39:12:39:23 | ["a", , "c"] | tst.js:39:13:39:15 | "a" |
-| tst.js:39:12:39:23 | ["a", , "c"] | tst.js:39:20:39:22 | "c" |
-| tst.js:40:12:40:23 | [, "b", "c"] | tst.js:40:15:40:17 | "b" |
-| tst.js:40:12:40:23 | [, "b", "c"] | tst.js:40:20:40:22 | "c" |
-| tst.js:41:12:41:22 | ["a", "b",] | tst.js:41:13:41:15 | "a" |
-| tst.js:41:12:41:22 | ["a", "b",] | tst.js:41:18:41:20 | "b" |
-| tst.js:42:12:42:30 | ["a", ...arr3, "d"] | tst.js:42:13:42:15 | "a" |
-| tst.js:42:12:42:30 | ["a", ...arr3, "d"] | tst.js:42:18:42:24 | ...arr3 |
-| tst.js:42:12:42:30 | ["a", ...arr3, "d"] | tst.js:42:27:42:29 | "d" |
-| tst.js:45:3:45:9 | console | tst.js:45:3:45:13 | console.log |
-| tst.js:45:15:45:17 | obj | tst.js:45:15:45:20 | obj[p] |
+| tst.js:1:1:1:0 | this | tst.js:22:15:22:29 | this.someMethod |
+| tst.js:1:1:1:0 | this | tst.js:23:36:23:45 | this.state |
+| tst.js:1:11:9:1 | {\\n    x ...     }\\n} | tst.js:2:5:2:8 | x: 4 |
+| tst.js:1:11:9:1 | {\\n    x ...     }\\n} | tst.js:3:5:5:5 | func: f ... ;\\n    } |
+| tst.js:1:11:9:1 | {\\n    x ...     }\\n} | tst.js:6:5:8:5 | f() {\\n  ... ;\\n    } |
+| tst.js:11:1:18:1 | class C ... ;\\n  }\\n} | tst.js:12:3:14:3 | static  ... x);\\n  } |
+| tst.js:13:5:13:11 | console | tst.js:13:5:13:15 | console.log |
+| tst.js:16:5:16:11 | console | tst.js:16:5:16:15 | console.log |
+| tst.js:20:1:20:1 | C | tst.js:20:1:20:6 | C.prop |
+| tst.js:22:15:22:29 | this.someMethod | tst.js:22:15:22:34 | this.someMethod.bind |
+| tst.js:23:8:23:57 | <div on ... }</div> | tst.js:23:13:23:27 | onClick={click} |
+| tst.js:23:36:23:45 | this.state | tst.js:23:36:23:50 | this.state.name |
+| tst.js:25:2:28:1 | {\\n  get ... v) {}\\n} | tst.js:26:3:26:26 | get x() ... null; } |
+| tst.js:25:2:28:1 | {\\n  get ... v) {}\\n} | tst.js:27:3:27:13 | set y(v) {} |
+| tst.js:30:2:35:1 | {\\n    n ... q]: 4\\n} | tst.js:31:5:31:8 | n: 1 |
+| tst.js:30:2:35:1 | {\\n    n ... q]: 4\\n} | tst.js:32:5:32:10 | [v]: 2 |
+| tst.js:30:2:35:1 | {\\n    n ... q]: 4\\n} | tst.js:33:5:33:14 | [vv.pp]: 3 |
+| tst.js:30:2:35:1 | {\\n    n ... q]: 4\\n} | tst.js:34:5:34:20 | [vvv.ppp.qqq]: 4 |
+| tst.js:33:6:33:7 | vv | tst.js:33:6:33:10 | vv.pp |
+| tst.js:34:6:34:8 | vvv | tst.js:34:6:34:12 | vvv.ppp |
+| tst.js:34:6:34:12 | vvv.ppp | tst.js:34:6:34:16 | vvv.ppp.qqq |
+| tst.js:37:12:37:26 | ["a", "b", "c"] | tst.js:37:13:37:15 | "a" |
+| tst.js:37:12:37:26 | ["a", "b", "c"] | tst.js:37:18:37:20 | "b" |
+| tst.js:37:12:37:26 | ["a", "b", "c"] | tst.js:37:23:37:25 | "c" |
+| tst.js:38:12:38:23 | ["a", , "c"] | tst.js:38:13:38:15 | "a" |
+| tst.js:38:12:38:23 | ["a", , "c"] | tst.js:38:20:38:22 | "c" |
+| tst.js:39:12:39:23 | [, "b", "c"] | tst.js:39:15:39:17 | "b" |
+| tst.js:39:12:39:23 | [, "b", "c"] | tst.js:39:20:39:22 | "c" |
+| tst.js:40:12:40:22 | ["a", "b",] | tst.js:40:13:40:15 | "a" |
+| tst.js:40:12:40:22 | ["a", "b",] | tst.js:40:18:40:20 | "b" |
+| tst.js:41:12:41:30 | ["a", ...arr3, "d"] | tst.js:41:13:41:15 | "a" |
+| tst.js:41:12:41:30 | ["a", ...arr3, "d"] | tst.js:41:18:41:24 | ...arr3 |
+| tst.js:41:12:41:30 | ["a", ...arr3, "d"] | tst.js:41:27:41:29 | "d" |
+| tst.js:44:3:44:9 | console | tst.js:44:3:44:13 | console.log |
+| tst.js:44:15:44:17 | obj | tst.js:44:15:44:20 | obj[p] |
 test_getAPropertySource
 | classes.ts:3:21:3:20 | this | instanceField | classes.ts:4:19:4:23 | foo() |
 | classes.ts:8:3:8:2 | this | parameterField | classes.ts:8:22:8:35 | parameterField |
@@ -57,10 +57,10 @@ test_getAPropertySource
 | classes.ts:12:5:12:4 | this | parameterField | classes.ts:12:41:12:42 | {} |
 | classes.ts:16:5:16:4 | this | parameterField | classes.ts:16:24:16:37 | parameterField |
 | classes.ts:16:5:16:4 | this | parameterField | classes.ts:16:41:16:42 | {} |
-| tst.js:2:11:10:1 | {\\n    x ...     }\\n} | f | tst.js:7:6:9:5 | () {\\n   ... ;\\n    } |
-| tst.js:2:11:10:1 | {\\n    x ...     }\\n} | func | tst.js:4:11:6:5 | functio ... ;\\n    } |
-| tst.js:12:1:19:1 | class C ... ;\\n  }\\n} | func | tst.js:13:14:15:3 | (x) {\\n  ... x);\\n  } |
-| tst.js:24:8:24:57 | <div on ... }</div> | onClick | tst.js:24:22:24:26 | click |
+| tst.js:1:11:9:1 | {\\n    x ...     }\\n} | f | tst.js:6:6:8:5 | () {\\n   ... ;\\n    } |
+| tst.js:1:11:9:1 | {\\n    x ...     }\\n} | func | tst.js:3:11:5:5 | functio ... ;\\n    } |
+| tst.js:11:1:18:1 | class C ... ;\\n  }\\n} | func | tst.js:12:14:14:3 | (x) {\\n  ... x);\\n  } |
+| tst.js:23:8:23:57 | <div on ... }</div> | onClick | tst.js:23:22:23:26 | click |
 test_PropWritePropName
 | classes.ts:3:21:3:20 | constructor() {} | constructor |
 | classes.ts:4:3:4:24 | instanc ...  foo(); | instanceField |
@@ -70,123 +70,123 @@ test_PropWritePropName
 | classes.ts:12:17:12:37 | public  ... erField | parameterField |
 | classes.ts:16:5:16:46 | constru ...  {}) {} | constructor |
 | classes.ts:16:17:16:37 | public  ... erField | parameterField |
-| tst.js:3:5:3:8 | x: 4 | x |
-| tst.js:4:5:6:5 | func: f ... ;\\n    } | func |
-| tst.js:7:5:9:5 | f() {\\n  ... ;\\n    } | f |
-| tst.js:12:9:12:8 | constructor() {} | constructor |
-| tst.js:13:3:15:3 | static  ... x);\\n  } | func |
-| tst.js:16:3:18:3 | f(x) {\\n ... x);\\n  } | f |
-| tst.js:21:1:21:6 | C.prop | prop |
-| tst.js:24:13:24:27 | onClick={click} | onClick |
-| tst.js:27:3:27:26 | get x() ... null; } | x |
-| tst.js:28:3:28:13 | set y(v) {} | y |
-| tst.js:32:5:32:8 | n: 1 | n |
+| tst.js:2:5:2:8 | x: 4 | x |
+| tst.js:3:5:5:5 | func: f ... ;\\n    } | func |
+| tst.js:6:5:8:5 | f() {\\n  ... ;\\n    } | f |
+| tst.js:11:9:11:8 | constructor() {} | constructor |
+| tst.js:12:3:14:3 | static  ... x);\\n  } | func |
+| tst.js:15:3:17:3 | f(x) {\\n ... x);\\n  } | f |
+| tst.js:20:1:20:6 | C.prop | prop |
+| tst.js:23:13:23:27 | onClick={click} | onClick |
+| tst.js:26:3:26:26 | get x() ... null; } | x |
+| tst.js:27:3:27:13 | set y(v) {} | y |
+| tst.js:31:5:31:8 | n: 1 | n |
 test_getAPropertyRead2
-| tst.js:1:1:1:0 | this | someMethod | tst.js:23:15:23:29 | this.someMethod |
-| tst.js:1:1:1:0 | this | state | tst.js:24:36:24:45 | this.state |
-| tst.js:14:5:14:11 | console | log | tst.js:14:5:14:15 | console.log |
-| tst.js:17:5:17:11 | console | log | tst.js:17:5:17:15 | console.log |
-| tst.js:23:15:23:29 | this.someMethod | bind | tst.js:23:15:23:34 | this.someMethod.bind |
-| tst.js:24:36:24:45 | this.state | name | tst.js:24:36:24:50 | this.state.name |
-| tst.js:34:6:34:7 | vv | pp | tst.js:34:6:34:10 | vv.pp |
-| tst.js:35:6:35:8 | vvv | ppp | tst.js:35:6:35:12 | vvv.ppp |
-| tst.js:35:6:35:12 | vvv.ppp | qqq | tst.js:35:6:35:16 | vvv.ppp.qqq |
-| tst.js:45:3:45:9 | console | log | tst.js:45:3:45:13 | console.log |
+| tst.js:1:1:1:0 | this | someMethod | tst.js:22:15:22:29 | this.someMethod |
+| tst.js:1:1:1:0 | this | state | tst.js:23:36:23:45 | this.state |
+| tst.js:13:5:13:11 | console | log | tst.js:13:5:13:15 | console.log |
+| tst.js:16:5:16:11 | console | log | tst.js:16:5:16:15 | console.log |
+| tst.js:22:15:22:29 | this.someMethod | bind | tst.js:22:15:22:34 | this.someMethod.bind |
+| tst.js:23:36:23:45 | this.state | name | tst.js:23:36:23:50 | this.state.name |
+| tst.js:33:6:33:7 | vv | pp | tst.js:33:6:33:10 | vv.pp |
+| tst.js:34:6:34:8 | vvv | ppp | tst.js:34:6:34:12 | vvv.ppp |
+| tst.js:34:6:34:12 | vvv.ppp | qqq | tst.js:34:6:34:16 | vvv.ppp.qqq |
+| tst.js:44:3:44:9 | console | log | tst.js:44:3:44:13 | console.log |
 test_getAPropertyReference2
 | classes.ts:3:21:3:20 | this | instanceField | classes.ts:4:3:4:24 | instanc ...  foo(); |
 | classes.ts:8:3:8:2 | this | parameterField | classes.ts:8:15:8:35 | public  ... erField |
 | classes.ts:12:5:12:4 | this | parameterField | classes.ts:12:17:12:37 | public  ... erField |
 | classes.ts:16:5:16:4 | this | parameterField | classes.ts:16:17:16:37 | public  ... erField |
-| tst.js:1:1:1:0 | this | someMethod | tst.js:23:15:23:29 | this.someMethod |
-| tst.js:1:1:1:0 | this | state | tst.js:24:36:24:45 | this.state |
-| tst.js:2:11:10:1 | {\\n    x ...     }\\n} | f | tst.js:7:5:9:5 | f() {\\n  ... ;\\n    } |
-| tst.js:2:11:10:1 | {\\n    x ...     }\\n} | func | tst.js:4:5:6:5 | func: f ... ;\\n    } |
-| tst.js:2:11:10:1 | {\\n    x ...     }\\n} | x | tst.js:3:5:3:8 | x: 4 |
-| tst.js:12:1:19:1 | class C ... ;\\n  }\\n} | func | tst.js:13:3:15:3 | static  ... x);\\n  } |
-| tst.js:14:5:14:11 | console | log | tst.js:14:5:14:15 | console.log |
-| tst.js:17:5:17:11 | console | log | tst.js:17:5:17:15 | console.log |
-| tst.js:21:1:21:1 | C | prop | tst.js:21:1:21:6 | C.prop |
-| tst.js:23:15:23:29 | this.someMethod | bind | tst.js:23:15:23:34 | this.someMethod.bind |
-| tst.js:24:8:24:57 | <div on ... }</div> | onClick | tst.js:24:13:24:27 | onClick={click} |
-| tst.js:24:36:24:45 | this.state | name | tst.js:24:36:24:50 | this.state.name |
-| tst.js:26:2:29:1 | {\\n  get ... v) {}\\n} | x | tst.js:27:3:27:26 | get x() ... null; } |
-| tst.js:26:2:29:1 | {\\n  get ... v) {}\\n} | y | tst.js:28:3:28:13 | set y(v) {} |
-| tst.js:31:2:36:1 | {\\n    n ... q]: 4\\n} | n | tst.js:32:5:32:8 | n: 1 |
-| tst.js:34:6:34:7 | vv | pp | tst.js:34:6:34:10 | vv.pp |
-| tst.js:35:6:35:8 | vvv | ppp | tst.js:35:6:35:12 | vvv.ppp |
-| tst.js:35:6:35:12 | vvv.ppp | qqq | tst.js:35:6:35:16 | vvv.ppp.qqq |
-| tst.js:45:3:45:9 | console | log | tst.js:45:3:45:13 | console.log |
+| tst.js:1:1:1:0 | this | someMethod | tst.js:22:15:22:29 | this.someMethod |
+| tst.js:1:1:1:0 | this | state | tst.js:23:36:23:45 | this.state |
+| tst.js:1:11:9:1 | {\\n    x ...     }\\n} | f | tst.js:6:5:8:5 | f() {\\n  ... ;\\n    } |
+| tst.js:1:11:9:1 | {\\n    x ...     }\\n} | func | tst.js:3:5:5:5 | func: f ... ;\\n    } |
+| tst.js:1:11:9:1 | {\\n    x ...     }\\n} | x | tst.js:2:5:2:8 | x: 4 |
+| tst.js:11:1:18:1 | class C ... ;\\n  }\\n} | func | tst.js:12:3:14:3 | static  ... x);\\n  } |
+| tst.js:13:5:13:11 | console | log | tst.js:13:5:13:15 | console.log |
+| tst.js:16:5:16:11 | console | log | tst.js:16:5:16:15 | console.log |
+| tst.js:20:1:20:1 | C | prop | tst.js:20:1:20:6 | C.prop |
+| tst.js:22:15:22:29 | this.someMethod | bind | tst.js:22:15:22:34 | this.someMethod.bind |
+| tst.js:23:8:23:57 | <div on ... }</div> | onClick | tst.js:23:13:23:27 | onClick={click} |
+| tst.js:23:36:23:45 | this.state | name | tst.js:23:36:23:50 | this.state.name |
+| tst.js:25:2:28:1 | {\\n  get ... v) {}\\n} | x | tst.js:26:3:26:26 | get x() ... null; } |
+| tst.js:25:2:28:1 | {\\n  get ... v) {}\\n} | y | tst.js:27:3:27:13 | set y(v) {} |
+| tst.js:30:2:35:1 | {\\n    n ... q]: 4\\n} | n | tst.js:31:5:31:8 | n: 1 |
+| tst.js:33:6:33:7 | vv | pp | tst.js:33:6:33:10 | vv.pp |
+| tst.js:34:6:34:8 | vvv | ppp | tst.js:34:6:34:12 | vvv.ppp |
+| tst.js:34:6:34:12 | vvv.ppp | qqq | tst.js:34:6:34:16 | vvv.ppp.qqq |
+| tst.js:44:3:44:9 | console | log | tst.js:44:3:44:13 | console.log |
 test_hasPropertyWrite
 | classes.ts:3:21:3:20 | this | instanceField | classes.ts:4:19:4:23 | foo() |
 | classes.ts:8:3:8:2 | this | parameterField | classes.ts:8:22:8:35 | parameterField |
 | classes.ts:12:5:12:4 | this | parameterField | classes.ts:12:24:12:37 | parameterField |
 | classes.ts:16:5:16:4 | this | parameterField | classes.ts:16:24:16:37 | parameterField |
 | classes.ts:16:5:16:4 | this | parameterField | classes.ts:16:41:16:42 | {} |
-| tst.js:2:11:10:1 | {\\n    x ...     }\\n} | f | tst.js:7:6:9:5 | () {\\n   ... ;\\n    } |
-| tst.js:2:11:10:1 | {\\n    x ...     }\\n} | func | tst.js:4:11:6:5 | functio ... ;\\n    } |
-| tst.js:2:11:10:1 | {\\n    x ...     }\\n} | x | tst.js:3:8:3:8 | 4 |
-| tst.js:12:1:19:1 | class C ... ;\\n  }\\n} | func | tst.js:13:14:15:3 | (x) {\\n  ... x);\\n  } |
-| tst.js:21:1:21:1 | C | prop | tst.js:21:10:21:11 | 56 |
-| tst.js:24:8:24:57 | <div on ... }</div> | onClick | tst.js:24:22:24:26 | click |
-| tst.js:31:2:36:1 | {\\n    n ... q]: 4\\n} | n | tst.js:32:8:32:8 | 1 |
+| tst.js:1:11:9:1 | {\\n    x ...     }\\n} | f | tst.js:6:6:8:5 | () {\\n   ... ;\\n    } |
+| tst.js:1:11:9:1 | {\\n    x ...     }\\n} | func | tst.js:3:11:5:5 | functio ... ;\\n    } |
+| tst.js:1:11:9:1 | {\\n    x ...     }\\n} | x | tst.js:2:8:2:8 | 4 |
+| tst.js:11:1:18:1 | class C ... ;\\n  }\\n} | func | tst.js:12:14:14:3 | (x) {\\n  ... x);\\n  } |
+| tst.js:20:1:20:1 | C | prop | tst.js:20:10:20:11 | 56 |
+| tst.js:23:8:23:57 | <div on ... }</div> | onClick | tst.js:23:22:23:26 | click |
+| tst.js:30:2:35:1 | {\\n    n ... q]: 4\\n} | n | tst.js:31:8:31:8 | 1 |
 test_PropWriteBase
 | classes.ts:4:3:4:24 | instanc ...  foo(); | classes.ts:3:21:3:20 | this |
 | classes.ts:8:15:8:35 | public  ... erField | classes.ts:8:3:8:2 | this |
 | classes.ts:12:17:12:37 | public  ... erField | classes.ts:12:5:12:4 | this |
 | classes.ts:16:17:16:37 | public  ... erField | classes.ts:16:5:16:4 | this |
-| tst.js:3:5:3:8 | x: 4 | tst.js:2:11:10:1 | {\\n    x ...     }\\n} |
-| tst.js:4:5:6:5 | func: f ... ;\\n    } | tst.js:2:11:10:1 | {\\n    x ...     }\\n} |
-| tst.js:7:5:9:5 | f() {\\n  ... ;\\n    } | tst.js:2:11:10:1 | {\\n    x ...     }\\n} |
-| tst.js:13:3:15:3 | static  ... x);\\n  } | tst.js:12:1:19:1 | class C ... ;\\n  }\\n} |
-| tst.js:21:1:21:6 | C.prop | tst.js:21:1:21:1 | C |
-| tst.js:24:13:24:27 | onClick={click} | tst.js:24:8:24:57 | <div on ... }</div> |
-| tst.js:27:3:27:26 | get x() ... null; } | tst.js:26:2:29:1 | {\\n  get ... v) {}\\n} |
-| tst.js:28:3:28:13 | set y(v) {} | tst.js:26:2:29:1 | {\\n  get ... v) {}\\n} |
-| tst.js:32:5:32:8 | n: 1 | tst.js:31:2:36:1 | {\\n    n ... q]: 4\\n} |
-| tst.js:33:5:33:10 | [v]: 2 | tst.js:31:2:36:1 | {\\n    n ... q]: 4\\n} |
-| tst.js:34:5:34:14 | [vv.pp]: 3 | tst.js:31:2:36:1 | {\\n    n ... q]: 4\\n} |
-| tst.js:35:5:35:20 | [vvv.ppp.qqq]: 4 | tst.js:31:2:36:1 | {\\n    n ... q]: 4\\n} |
-| tst.js:38:13:38:15 | "a" | tst.js:38:12:38:26 | ["a", "b", "c"] |
-| tst.js:38:18:38:20 | "b" | tst.js:38:12:38:26 | ["a", "b", "c"] |
-| tst.js:38:23:38:25 | "c" | tst.js:38:12:38:26 | ["a", "b", "c"] |
-| tst.js:39:13:39:15 | "a" | tst.js:39:12:39:23 | ["a", , "c"] |
-| tst.js:39:20:39:22 | "c" | tst.js:39:12:39:23 | ["a", , "c"] |
-| tst.js:40:15:40:17 | "b" | tst.js:40:12:40:23 | [, "b", "c"] |
-| tst.js:40:20:40:22 | "c" | tst.js:40:12:40:23 | [, "b", "c"] |
-| tst.js:41:13:41:15 | "a" | tst.js:41:12:41:22 | ["a", "b",] |
-| tst.js:41:18:41:20 | "b" | tst.js:41:12:41:22 | ["a", "b",] |
-| tst.js:42:13:42:15 | "a" | tst.js:42:12:42:30 | ["a", ...arr3, "d"] |
-| tst.js:42:18:42:24 | ...arr3 | tst.js:42:12:42:30 | ["a", ...arr3, "d"] |
-| tst.js:42:27:42:29 | "d" | tst.js:42:12:42:30 | ["a", ...arr3, "d"] |
+| tst.js:2:5:2:8 | x: 4 | tst.js:1:11:9:1 | {\\n    x ...     }\\n} |
+| tst.js:3:5:5:5 | func: f ... ;\\n    } | tst.js:1:11:9:1 | {\\n    x ...     }\\n} |
+| tst.js:6:5:8:5 | f() {\\n  ... ;\\n    } | tst.js:1:11:9:1 | {\\n    x ...     }\\n} |
+| tst.js:12:3:14:3 | static  ... x);\\n  } | tst.js:11:1:18:1 | class C ... ;\\n  }\\n} |
+| tst.js:20:1:20:6 | C.prop | tst.js:20:1:20:1 | C |
+| tst.js:23:13:23:27 | onClick={click} | tst.js:23:8:23:57 | <div on ... }</div> |
+| tst.js:26:3:26:26 | get x() ... null; } | tst.js:25:2:28:1 | {\\n  get ... v) {}\\n} |
+| tst.js:27:3:27:13 | set y(v) {} | tst.js:25:2:28:1 | {\\n  get ... v) {}\\n} |
+| tst.js:31:5:31:8 | n: 1 | tst.js:30:2:35:1 | {\\n    n ... q]: 4\\n} |
+| tst.js:32:5:32:10 | [v]: 2 | tst.js:30:2:35:1 | {\\n    n ... q]: 4\\n} |
+| tst.js:33:5:33:14 | [vv.pp]: 3 | tst.js:30:2:35:1 | {\\n    n ... q]: 4\\n} |
+| tst.js:34:5:34:20 | [vvv.ppp.qqq]: 4 | tst.js:30:2:35:1 | {\\n    n ... q]: 4\\n} |
+| tst.js:37:13:37:15 | "a" | tst.js:37:12:37:26 | ["a", "b", "c"] |
+| tst.js:37:18:37:20 | "b" | tst.js:37:12:37:26 | ["a", "b", "c"] |
+| tst.js:37:23:37:25 | "c" | tst.js:37:12:37:26 | ["a", "b", "c"] |
+| tst.js:38:13:38:15 | "a" | tst.js:38:12:38:23 | ["a", , "c"] |
+| tst.js:38:20:38:22 | "c" | tst.js:38:12:38:23 | ["a", , "c"] |
+| tst.js:39:15:39:17 | "b" | tst.js:39:12:39:23 | [, "b", "c"] |
+| tst.js:39:20:39:22 | "c" | tst.js:39:12:39:23 | [, "b", "c"] |
+| tst.js:40:13:40:15 | "a" | tst.js:40:12:40:22 | ["a", "b",] |
+| tst.js:40:18:40:20 | "b" | tst.js:40:12:40:22 | ["a", "b",] |
+| tst.js:41:13:41:15 | "a" | tst.js:41:12:41:30 | ["a", ...arr3, "d"] |
+| tst.js:41:18:41:24 | ...arr3 | tst.js:41:12:41:30 | ["a", ...arr3, "d"] |
+| tst.js:41:27:41:29 | "d" | tst.js:41:12:41:30 | ["a", ...arr3, "d"] |
 test_getAPropertyWrite
 | classes.ts:3:21:3:20 | this | classes.ts:4:3:4:24 | instanc ...  foo(); |
 | classes.ts:8:3:8:2 | this | classes.ts:8:15:8:35 | public  ... erField |
 | classes.ts:12:5:12:4 | this | classes.ts:12:17:12:37 | public  ... erField |
 | classes.ts:16:5:16:4 | this | classes.ts:16:17:16:37 | public  ... erField |
-| tst.js:2:11:10:1 | {\\n    x ...     }\\n} | tst.js:3:5:3:8 | x: 4 |
-| tst.js:2:11:10:1 | {\\n    x ...     }\\n} | tst.js:4:5:6:5 | func: f ... ;\\n    } |
-| tst.js:2:11:10:1 | {\\n    x ...     }\\n} | tst.js:7:5:9:5 | f() {\\n  ... ;\\n    } |
-| tst.js:12:1:19:1 | class C ... ;\\n  }\\n} | tst.js:13:3:15:3 | static  ... x);\\n  } |
-| tst.js:21:1:21:1 | C | tst.js:21:1:21:6 | C.prop |
-| tst.js:24:8:24:57 | <div on ... }</div> | tst.js:24:13:24:27 | onClick={click} |
-| tst.js:26:2:29:1 | {\\n  get ... v) {}\\n} | tst.js:27:3:27:26 | get x() ... null; } |
-| tst.js:26:2:29:1 | {\\n  get ... v) {}\\n} | tst.js:28:3:28:13 | set y(v) {} |
-| tst.js:31:2:36:1 | {\\n    n ... q]: 4\\n} | tst.js:32:5:32:8 | n: 1 |
-| tst.js:31:2:36:1 | {\\n    n ... q]: 4\\n} | tst.js:33:5:33:10 | [v]: 2 |
-| tst.js:31:2:36:1 | {\\n    n ... q]: 4\\n} | tst.js:34:5:34:14 | [vv.pp]: 3 |
-| tst.js:31:2:36:1 | {\\n    n ... q]: 4\\n} | tst.js:35:5:35:20 | [vvv.ppp.qqq]: 4 |
-| tst.js:38:12:38:26 | ["a", "b", "c"] | tst.js:38:13:38:15 | "a" |
-| tst.js:38:12:38:26 | ["a", "b", "c"] | tst.js:38:18:38:20 | "b" |
-| tst.js:38:12:38:26 | ["a", "b", "c"] | tst.js:38:23:38:25 | "c" |
-| tst.js:39:12:39:23 | ["a", , "c"] | tst.js:39:13:39:15 | "a" |
-| tst.js:39:12:39:23 | ["a", , "c"] | tst.js:39:20:39:22 | "c" |
-| tst.js:40:12:40:23 | [, "b", "c"] | tst.js:40:15:40:17 | "b" |
-| tst.js:40:12:40:23 | [, "b", "c"] | tst.js:40:20:40:22 | "c" |
-| tst.js:41:12:41:22 | ["a", "b",] | tst.js:41:13:41:15 | "a" |
-| tst.js:41:12:41:22 | ["a", "b",] | tst.js:41:18:41:20 | "b" |
-| tst.js:42:12:42:30 | ["a", ...arr3, "d"] | tst.js:42:13:42:15 | "a" |
-| tst.js:42:12:42:30 | ["a", ...arr3, "d"] | tst.js:42:18:42:24 | ...arr3 |
-| tst.js:42:12:42:30 | ["a", ...arr3, "d"] | tst.js:42:27:42:29 | "d" |
+| tst.js:1:11:9:1 | {\\n    x ...     }\\n} | tst.js:2:5:2:8 | x: 4 |
+| tst.js:1:11:9:1 | {\\n    x ...     }\\n} | tst.js:3:5:5:5 | func: f ... ;\\n    } |
+| tst.js:1:11:9:1 | {\\n    x ...     }\\n} | tst.js:6:5:8:5 | f() {\\n  ... ;\\n    } |
+| tst.js:11:1:18:1 | class C ... ;\\n  }\\n} | tst.js:12:3:14:3 | static  ... x);\\n  } |
+| tst.js:20:1:20:1 | C | tst.js:20:1:20:6 | C.prop |
+| tst.js:23:8:23:57 | <div on ... }</div> | tst.js:23:13:23:27 | onClick={click} |
+| tst.js:25:2:28:1 | {\\n  get ... v) {}\\n} | tst.js:26:3:26:26 | get x() ... null; } |
+| tst.js:25:2:28:1 | {\\n  get ... v) {}\\n} | tst.js:27:3:27:13 | set y(v) {} |
+| tst.js:30:2:35:1 | {\\n    n ... q]: 4\\n} | tst.js:31:5:31:8 | n: 1 |
+| tst.js:30:2:35:1 | {\\n    n ... q]: 4\\n} | tst.js:32:5:32:10 | [v]: 2 |
+| tst.js:30:2:35:1 | {\\n    n ... q]: 4\\n} | tst.js:33:5:33:14 | [vv.pp]: 3 |
+| tst.js:30:2:35:1 | {\\n    n ... q]: 4\\n} | tst.js:34:5:34:20 | [vvv.ppp.qqq]: 4 |
+| tst.js:37:12:37:26 | ["a", "b", "c"] | tst.js:37:13:37:15 | "a" |
+| tst.js:37:12:37:26 | ["a", "b", "c"] | tst.js:37:18:37:20 | "b" |
+| tst.js:37:12:37:26 | ["a", "b", "c"] | tst.js:37:23:37:25 | "c" |
+| tst.js:38:12:38:23 | ["a", , "c"] | tst.js:38:13:38:15 | "a" |
+| tst.js:38:12:38:23 | ["a", , "c"] | tst.js:38:20:38:22 | "c" |
+| tst.js:39:12:39:23 | [, "b", "c"] | tst.js:39:15:39:17 | "b" |
+| tst.js:39:12:39:23 | [, "b", "c"] | tst.js:39:20:39:22 | "c" |
+| tst.js:40:12:40:22 | ["a", "b",] | tst.js:40:13:40:15 | "a" |
+| tst.js:40:12:40:22 | ["a", "b",] | tst.js:40:18:40:20 | "b" |
+| tst.js:41:12:41:30 | ["a", ...arr3, "d"] | tst.js:41:13:41:15 | "a" |
+| tst.js:41:12:41:30 | ["a", ...arr3, "d"] | tst.js:41:18:41:24 | ...arr3 |
+| tst.js:41:12:41:30 | ["a", ...arr3, "d"] | tst.js:41:27:41:29 | "d" |
 test_PropWrite
 | classes.ts:3:21:3:20 | constructor() {} |
 | classes.ts:4:3:4:24 | instanc ...  foo(); |
@@ -196,46 +196,46 @@ test_PropWrite
 | classes.ts:12:17:12:37 | public  ... erField |
 | classes.ts:16:5:16:46 | constru ...  {}) {} |
 | classes.ts:16:17:16:37 | public  ... erField |
-| tst.js:3:5:3:8 | x: 4 |
-| tst.js:4:5:6:5 | func: f ... ;\\n    } |
-| tst.js:7:5:9:5 | f() {\\n  ... ;\\n    } |
-| tst.js:12:9:12:8 | constructor() {} |
-| tst.js:13:3:15:3 | static  ... x);\\n  } |
-| tst.js:16:3:18:3 | f(x) {\\n ... x);\\n  } |
-| tst.js:21:1:21:6 | C.prop |
-| tst.js:24:13:24:27 | onClick={click} |
-| tst.js:27:3:27:26 | get x() ... null; } |
-| tst.js:28:3:28:13 | set y(v) {} |
-| tst.js:32:5:32:8 | n: 1 |
-| tst.js:33:5:33:10 | [v]: 2 |
-| tst.js:34:5:34:14 | [vv.pp]: 3 |
-| tst.js:35:5:35:20 | [vvv.ppp.qqq]: 4 |
+| tst.js:2:5:2:8 | x: 4 |
+| tst.js:3:5:5:5 | func: f ... ;\\n    } |
+| tst.js:6:5:8:5 | f() {\\n  ... ;\\n    } |
+| tst.js:11:9:11:8 | constructor() {} |
+| tst.js:12:3:14:3 | static  ... x);\\n  } |
+| tst.js:15:3:17:3 | f(x) {\\n ... x);\\n  } |
+| tst.js:20:1:20:6 | C.prop |
+| tst.js:23:13:23:27 | onClick={click} |
+| tst.js:26:3:26:26 | get x() ... null; } |
+| tst.js:27:3:27:13 | set y(v) {} |
+| tst.js:31:5:31:8 | n: 1 |
+| tst.js:32:5:32:10 | [v]: 2 |
+| tst.js:33:5:33:14 | [vv.pp]: 3 |
+| tst.js:34:5:34:20 | [vvv.ppp.qqq]: 4 |
+| tst.js:37:13:37:15 | "a" |
+| tst.js:37:18:37:20 | "b" |
+| tst.js:37:23:37:25 | "c" |
 | tst.js:38:13:38:15 | "a" |
-| tst.js:38:18:38:20 | "b" |
-| tst.js:38:23:38:25 | "c" |
-| tst.js:39:13:39:15 | "a" |
+| tst.js:38:20:38:22 | "c" |
+| tst.js:39:15:39:17 | "b" |
 | tst.js:39:20:39:22 | "c" |
-| tst.js:40:15:40:17 | "b" |
-| tst.js:40:20:40:22 | "c" |
+| tst.js:40:13:40:15 | "a" |
+| tst.js:40:18:40:20 | "b" |
 | tst.js:41:13:41:15 | "a" |
-| tst.js:41:18:41:20 | "b" |
-| tst.js:42:13:42:15 | "a" |
-| tst.js:42:18:42:24 | ...arr3 |
-| tst.js:42:27:42:29 | "d" |
+| tst.js:41:18:41:24 | ...arr3 |
+| tst.js:41:27:41:29 | "d" |
 test_getAPropertyWrite2
 | classes.ts:3:21:3:20 | this | instanceField | classes.ts:4:3:4:24 | instanc ...  foo(); |
 | classes.ts:8:3:8:2 | this | parameterField | classes.ts:8:15:8:35 | public  ... erField |
 | classes.ts:12:5:12:4 | this | parameterField | classes.ts:12:17:12:37 | public  ... erField |
 | classes.ts:16:5:16:4 | this | parameterField | classes.ts:16:17:16:37 | public  ... erField |
-| tst.js:2:11:10:1 | {\\n    x ...     }\\n} | f | tst.js:7:5:9:5 | f() {\\n  ... ;\\n    } |
-| tst.js:2:11:10:1 | {\\n    x ...     }\\n} | func | tst.js:4:5:6:5 | func: f ... ;\\n    } |
-| tst.js:2:11:10:1 | {\\n    x ...     }\\n} | x | tst.js:3:5:3:8 | x: 4 |
-| tst.js:12:1:19:1 | class C ... ;\\n  }\\n} | func | tst.js:13:3:15:3 | static  ... x);\\n  } |
-| tst.js:21:1:21:1 | C | prop | tst.js:21:1:21:6 | C.prop |
-| tst.js:24:8:24:57 | <div on ... }</div> | onClick | tst.js:24:13:24:27 | onClick={click} |
-| tst.js:26:2:29:1 | {\\n  get ... v) {}\\n} | x | tst.js:27:3:27:26 | get x() ... null; } |
-| tst.js:26:2:29:1 | {\\n  get ... v) {}\\n} | y | tst.js:28:3:28:13 | set y(v) {} |
-| tst.js:31:2:36:1 | {\\n    n ... q]: 4\\n} | n | tst.js:32:5:32:8 | n: 1 |
+| tst.js:1:11:9:1 | {\\n    x ...     }\\n} | f | tst.js:6:5:8:5 | f() {\\n  ... ;\\n    } |
+| tst.js:1:11:9:1 | {\\n    x ...     }\\n} | func | tst.js:3:5:5:5 | func: f ... ;\\n    } |
+| tst.js:1:11:9:1 | {\\n    x ...     }\\n} | x | tst.js:2:5:2:8 | x: 4 |
+| tst.js:11:1:18:1 | class C ... ;\\n  }\\n} | func | tst.js:12:3:14:3 | static  ... x);\\n  } |
+| tst.js:20:1:20:1 | C | prop | tst.js:20:1:20:6 | C.prop |
+| tst.js:23:8:23:57 | <div on ... }</div> | onClick | tst.js:23:13:23:27 | onClick={click} |
+| tst.js:25:2:28:1 | {\\n  get ... v) {}\\n} | x | tst.js:26:3:26:26 | get x() ... null; } |
+| tst.js:25:2:28:1 | {\\n  get ... v) {}\\n} | y | tst.js:27:3:27:13 | set y(v) {} |
+| tst.js:30:2:35:1 | {\\n    n ... q]: 4\\n} | n | tst.js:31:5:31:8 | n: 1 |
 test_PropWriteRhs
 | classes.ts:3:21:3:20 | constructor() {} | classes.ts:3:21:3:20 | () {} |
 | classes.ts:4:3:4:24 | instanc ...  foo(); | classes.ts:4:19:4:23 | foo() |
@@ -246,27 +246,27 @@ test_PropWriteRhs
 | classes.ts:16:5:16:46 | constru ...  {}) {} | classes.ts:16:5:16:46 | constru ...  {}) {} |
 | classes.ts:16:17:16:37 | public  ... erField | classes.ts:16:24:16:37 | parameterField |
 | classes.ts:16:17:16:37 | public  ... erField | classes.ts:16:41:16:42 | {} |
-| tst.js:3:5:3:8 | x: 4 | tst.js:3:8:3:8 | 4 |
-| tst.js:4:5:6:5 | func: f ... ;\\n    } | tst.js:4:11:6:5 | functio ... ;\\n    } |
-| tst.js:7:5:9:5 | f() {\\n  ... ;\\n    } | tst.js:7:6:9:5 | () {\\n   ... ;\\n    } |
-| tst.js:12:9:12:8 | constructor() {} | tst.js:12:9:12:8 | () {} |
-| tst.js:13:3:15:3 | static  ... x);\\n  } | tst.js:13:14:15:3 | (x) {\\n  ... x);\\n  } |
-| tst.js:16:3:18:3 | f(x) {\\n ... x);\\n  } | tst.js:16:4:18:3 | (x) {\\n  ... x);\\n  } |
-| tst.js:21:1:21:6 | C.prop | tst.js:21:10:21:11 | 56 |
-| tst.js:24:13:24:27 | onClick={click} | tst.js:24:22:24:26 | click |
-| tst.js:32:5:32:8 | n: 1 | tst.js:32:8:32:8 | 1 |
-| tst.js:33:5:33:10 | [v]: 2 | tst.js:33:10:33:10 | 2 |
-| tst.js:34:5:34:14 | [vv.pp]: 3 | tst.js:34:14:34:14 | 3 |
-| tst.js:35:5:35:20 | [vvv.ppp.qqq]: 4 | tst.js:35:20:35:20 | 4 |
+| tst.js:2:5:2:8 | x: 4 | tst.js:2:8:2:8 | 4 |
+| tst.js:3:5:5:5 | func: f ... ;\\n    } | tst.js:3:11:5:5 | functio ... ;\\n    } |
+| tst.js:6:5:8:5 | f() {\\n  ... ;\\n    } | tst.js:6:6:8:5 | () {\\n   ... ;\\n    } |
+| tst.js:11:9:11:8 | constructor() {} | tst.js:11:9:11:8 | () {} |
+| tst.js:12:3:14:3 | static  ... x);\\n  } | tst.js:12:14:14:3 | (x) {\\n  ... x);\\n  } |
+| tst.js:15:3:17:3 | f(x) {\\n ... x);\\n  } | tst.js:15:4:17:3 | (x) {\\n  ... x);\\n  } |
+| tst.js:20:1:20:6 | C.prop | tst.js:20:10:20:11 | 56 |
+| tst.js:23:13:23:27 | onClick={click} | tst.js:23:22:23:26 | click |
+| tst.js:31:5:31:8 | n: 1 | tst.js:31:8:31:8 | 1 |
+| tst.js:32:5:32:10 | [v]: 2 | tst.js:32:10:32:10 | 2 |
+| tst.js:33:5:33:14 | [vv.pp]: 3 | tst.js:33:14:33:14 | 3 |
+| tst.js:34:5:34:20 | [vvv.ppp.qqq]: 4 | tst.js:34:20:34:20 | 4 |
+| tst.js:37:13:37:15 | "a" | tst.js:37:13:37:15 | "a" |
+| tst.js:37:18:37:20 | "b" | tst.js:37:18:37:20 | "b" |
+| tst.js:37:23:37:25 | "c" | tst.js:37:23:37:25 | "c" |
 | tst.js:38:13:38:15 | "a" | tst.js:38:13:38:15 | "a" |
-| tst.js:38:18:38:20 | "b" | tst.js:38:18:38:20 | "b" |
-| tst.js:38:23:38:25 | "c" | tst.js:38:23:38:25 | "c" |
-| tst.js:39:13:39:15 | "a" | tst.js:39:13:39:15 | "a" |
+| tst.js:38:20:38:22 | "c" | tst.js:38:20:38:22 | "c" |
+| tst.js:39:15:39:17 | "b" | tst.js:39:15:39:17 | "b" |
 | tst.js:39:20:39:22 | "c" | tst.js:39:20:39:22 | "c" |
-| tst.js:40:15:40:17 | "b" | tst.js:40:15:40:17 | "b" |
-| tst.js:40:20:40:22 | "c" | tst.js:40:20:40:22 | "c" |
+| tst.js:40:13:40:15 | "a" | tst.js:40:13:40:15 | "a" |
+| tst.js:40:18:40:20 | "b" | tst.js:40:18:40:20 | "b" |
 | tst.js:41:13:41:15 | "a" | tst.js:41:13:41:15 | "a" |
-| tst.js:41:18:41:20 | "b" | tst.js:41:18:41:20 | "b" |
-| tst.js:42:13:42:15 | "a" | tst.js:42:13:42:15 | "a" |
-| tst.js:42:18:42:24 | ...arr3 | tst.js:42:18:42:24 | ...arr3 |
-| tst.js:42:27:42:29 | "d" | tst.js:42:27:42:29 | "d" |
+| tst.js:41:18:41:24 | ...arr3 | tst.js:41:18:41:24 | ...arr3 |
+| tst.js:41:27:41:29 | "d" | tst.js:41:27:41:29 | "d" |

--- a/javascript/ql/test/library-tests/PropWrite/tst.js
+++ b/javascript/ql/test/library-tests/PropWrite/tst.js
@@ -1,4 +1,3 @@
-// semmle-extractor-options: --experimental
 var obj = {
     x: 4,
     func: function() {

--- a/javascript/ql/test/library-tests/SpreadRestProperties/tst.js
+++ b/javascript/ql/test/library-tests/SpreadRestProperties/tst.js
@@ -1,4 +1,2 @@
 var q = { ...o, x: 42, ...p };
 let { x, ...r } = q, { z } = {};
-
-// semmle-extractor-options: --experimental

--- a/javascript/ql/test/library-tests/TaintTracking/exceptions.js
+++ b/javascript/ql/test/library-tests/TaintTracking/exceptions.js
@@ -169,5 +169,3 @@ function throwThoughLibrary(xs) {
     sink(e); // OK - doesn't catch exception from event listener
   }
 }
-
-// semmle-extractor-options: --experimental

--- a/javascript/ql/test/library-tests/Templates/templates-revised.js
+++ b/javascript/ql/test/library-tests/Templates/templates-revised.js
@@ -1,3 +1,1 @@
 tag `\unvalid escape sequence`;
-
-// semmle-extractor-options: --experimental

--- a/javascript/ql/test/library-tests/ThisExpr/options
+++ b/javascript/ql/test/library-tests/ThisExpr/options
@@ -1,0 +1,1 @@
+semmle-extractor-options: --experimental

--- a/javascript/ql/test/library-tests/ThisExpr/tst.js
+++ b/javascript/ql/test/library-tests/ThisExpr/tst.js
@@ -146,4 +146,3 @@ class C_lodash {
     }
 
 }
-//semmle-extractor-options: --experimental

--- a/javascript/ql/test/library-tests/TrailingFunctionCommas/tst.js
+++ b/javascript/ql/test/library-tests/TrailingFunctionCommas/tst.js
@@ -31,5 +31,3 @@ new h2(23, 42,);
 x => x;
 
 function f4(x = 42,) {}
-
-// semmle-extractor-options: --experimental

--- a/javascript/ql/test/library-tests/TypeInference/NullishCoalescing/options
+++ b/javascript/ql/test/library-tests/TypeInference/NullishCoalescing/options
@@ -1,0 +1,1 @@
+semmle-extractor-options: --experimental

--- a/javascript/ql/test/library-tests/TypeInference/NullishCoalescing/tst.js
+++ b/javascript/ql/test/library-tests/TypeInference/NullishCoalescing/tst.js
@@ -21,4 +21,3 @@
 
     v7 = x ?? {};
 });
-// semmle-extractor-options: --experimental

--- a/javascript/ql/test/library-tests/TypeInference/OptionalChaining/options
+++ b/javascript/ql/test/library-tests/TypeInference/OptionalChaining/options
@@ -1,0 +1,1 @@
+semmle-extractor-options: --experimental

--- a/javascript/ql/test/library-tests/TypeInference/OptionalChaining/tst.js
+++ b/javascript/ql/test/library-tests/TypeInference/OptionalChaining/tst.js
@@ -22,4 +22,3 @@
     var v11 = h();
     var v12 = h?.();
 });
-// semmle-extractor-options: --experimental

--- a/javascript/ql/test/library-tests/TypeScript/Modifiers/options
+++ b/javascript/ql/test/library-tests/TypeScript/Modifiers/options
@@ -1,0 +1,1 @@
+semmle-extractor-options: --extract-program-text

--- a/javascript/ql/test/library-tests/TypeScript/Modifiers/tst.ts
+++ b/javascript/ql/test/library-tests/TypeScript/Modifiers/tst.ts
@@ -113,5 +113,3 @@ interface InterfaceFields {
   z?: number;
   readonly w?: number;
 }
-
-// semmle-extractor-options: --extract-program-text

--- a/javascript/ql/test/library-tests/TypeScript/SyntaxErrors/jsdocTypes.ts
+++ b/javascript/ql/test/library-tests/TypeScript/SyntaxErrors/jsdocTypes.ts
@@ -23,5 +23,3 @@ var nns: Array<?number>;
 var dns: Array<!number>;
 var anys: Array<*>;
 var vars: Array<...number>;
-
-// semmle-extractor-options: --tolerate-parse-errors

--- a/javascript/ql/test/library-tests/TypeScript/SyntaxErrors/options
+++ b/javascript/ql/test/library-tests/TypeScript/SyntaxErrors/options
@@ -1,0 +1,1 @@
+semmle-extractor-options: --tolerate-parse-errors

--- a/javascript/ql/test/library-tests/YAML/YAMLError.expected
+++ b/javascript/ql/test/library-tests/YAML/YAMLError.expected
@@ -1,1 +1,1 @@
-| err.yaml:4:1:4:1 | found unexpected end of stream |
+| err.yaml:3:1:3:1 | found unexpected end of stream |

--- a/javascript/ql/test/library-tests/YAML/err.yaml
+++ b/javascript/ql/test/library-tests/YAML/err.yaml
@@ -1,3 +1,2 @@
 "unterminated string
-# semmle-extractor-options: --tolerate-parse-errors
 

--- a/javascript/ql/test/library-tests/YAML/options
+++ b/javascript/ql/test/library-tests/YAML/options
@@ -1,0 +1,1 @@
+semmle-extractor-options: --tolerate-parse-errors

--- a/javascript/ql/test/library-tests/frameworks/AngularJS/expressions/scopes/options
+++ b/javascript/ql/test/library-tests/frameworks/AngularJS/expressions/scopes/options
@@ -1,0 +1,1 @@
+semmle-extractor-options: --html all

--- a/javascript/ql/test/library-tests/frameworks/AngularJS/expressions/scopes/tst.html
+++ b/javascript/ql/test/library-tests/frameworks/AngularJS/expressions/scopes/tst.html
@@ -17,4 +17,3 @@
   <my-template-directive />
 
 </div>
-// semmle-extractor-options: --html all

--- a/javascript/ql/test/library-tests/frameworks/AngularJS/expressions/sources/HtmlText.html
+++ b/javascript/ql/test/library-tests/frameworks/AngularJS/expressions/sources/HtmlText.html
@@ -7,4 +7,3 @@
 <div>
   {{myExpr3}}
 </div>
-semmle-extractor-options: --html all

--- a/javascript/ql/test/library-tests/frameworks/AngularJS/expressions/sources/options
+++ b/javascript/ql/test/library-tests/frameworks/AngularJS/expressions/sources/options
@@ -1,0 +1,1 @@
+semmle-extractor-options: --html all

--- a/javascript/ql/test/library-tests/frameworks/Express/options
+++ b/javascript/ql/test/library-tests/frameworks/Express/options
@@ -1,0 +1,1 @@
+semmle-extractor-options: --tolerate-parse-errors

--- a/javascript/ql/test/library-tests/frameworks/ReactJS/options
+++ b/javascript/ql/test/library-tests/frameworks/ReactJS/options
@@ -1,0 +1,1 @@
+semmle-extractor-options: --experimental

--- a/javascript/ql/test/library-tests/frameworks/ReactJS/statePropertyReads.js
+++ b/javascript/ql/test/library-tests/frameworks/ReactJS/statePropertyReads.js
@@ -11,5 +11,3 @@ class Reads extends React.Component {
         prevState.p4;
     }
 }
-
-//semmle-extractor-options: --experimental

--- a/javascript/ql/test/library-tests/frameworks/ReactJS/statePropertyWrites.js
+++ b/javascript/ql/test/library-tests/frameworks/ReactJS/statePropertyWrites.js
@@ -43,5 +43,3 @@ React.createClass({
     };
   }
 });
-
-//semmle-extractor-options: --experimental

--- a/javascript/ql/test/library-tests/frameworks/SQL/mssql1.js
+++ b/javascript/ql/test/library-tests/frameworks/SQL/mssql1.js
@@ -10,5 +10,3 @@ async () => {
         // ... error checks 
     }
 }
-
-// semmle-extractor-options: --experimental

--- a/javascript/ql/test/library-tests/stmts/conditionals.js
+++ b/javascript/ql/test/library-tests/stmts/conditionals.js
@@ -1,4 +1,4 @@
-if (true) // semmle-extractor-options: --extract-program-text
+if (true)
     ;
 if (b)
     ;

--- a/javascript/ql/test/library-tests/stmts/es2015.js
+++ b/javascript/ql/test/library-tests/stmts/es2015.js
@@ -1,2 +1,2 @@
-for (var x of [1, 2, 3]) // semmle-extractor-options: --extract-program-text
+for (var x of [1, 2, 3])
 	console.log(x);

--- a/javascript/ql/test/library-tests/stmts/foreach.js
+++ b/javascript/ql/test/library-tests/stmts/foreach.js
@@ -6,5 +6,3 @@ for each (var item in obj) {
 }
 
 console.log(sum); // logs "26", which is 5+13+8
-
-//semmle-extractor-options: --experimental --extract-program-text

--- a/javascript/ql/test/library-tests/stmts/functions.js
+++ b/javascript/ql/test/library-tests/stmts/functions.js
@@ -1,4 +1,4 @@
-function g(x, y) { // semmle-extractor-options: --extract-program-text
+function g(x, y) {
     return x+y;
 }
 

--- a/javascript/ql/test/library-tests/stmts/guardedCatch.js
+++ b/javascript/ql/test/library-tests/stmts/guardedCatch.js
@@ -7,5 +7,3 @@ function f(g) {
 		console.log("something else!");
 	}
 }
-
-//semmle-extractor-options: --experimental --extract-program-text

--- a/javascript/ql/test/library-tests/stmts/jscript.js
+++ b/javascript/ql/test/library-tests/stmts/jscript.js
@@ -1,5 +1,3 @@
 function window::onload() {}
 
 window.onload = function onload() {}
-
-//semmle-extractor-options: --experimental --extract-program-text

--- a/javascript/ql/test/library-tests/stmts/legacyletstmt.js
+++ b/javascript/ql/test/library-tests/stmts/legacyletstmt.js
@@ -1,5 +1,3 @@
 let (x = 23, y = 19) {
   console.log(x + y);
 }
-
-//semmle-extractor-options: --experimental --extract-program-text

--- a/javascript/ql/test/library-tests/stmts/loops.js
+++ b/javascript/ql/test/library-tests/stmts/loops.js
@@ -1,4 +1,4 @@
-while(true) // semmle-extractor-options: --extract-program-text
+while(true)
     ;
 outer: for(a; b; c) {
     for(;;)

--- a/javascript/ql/test/library-tests/stmts/options
+++ b/javascript/ql/test/library-tests/stmts/options
@@ -1,0 +1,1 @@
+semmle-extractor-options: --experimental

--- a/javascript/ql/test/library-tests/stmts/options
+++ b/javascript/ql/test/library-tests/stmts/options
@@ -1,1 +1,1 @@
-semmle-extractor-options: --experimental
+semmle-extractor-options: --experimental --extract-program-text

--- a/javascript/ql/test/library-tests/stmts/others.js
+++ b/javascript/ql/test/library-tests/stmts/others.js
@@ -1,4 +1,4 @@
-with(a) { // semmle-extractor-options: --extract-program-text
+with(a) {
 }
 debugger;
 var x = 23, y;

--- a/javascript/ql/test/library-tests/stmts/tests.expected
+++ b/javascript/ql/test/library-tests/stmts/tests.expected
@@ -4,14 +4,11 @@ test_LetStmt
 test_LineTerminators
 | conditionals.js:12:1:12:1 | } |
 | functions.js:9:1:9:1 | } |
-| guardedCatch.js:11:1:11:65 | //semmle-extractor-options: --experimental --extract-program-text |
-| jscript.js:5:1:5:65 | //semmle-extractor-options: --experimental --extract-program-text |
-| legacyletstmt.js:5:1:5:65 | //semmle-extractor-options: --experimental --extract-program-text |
 | loops.js:22:1:22:18 | for (x = 0 in xs); |
 | others.js:4:1:4:14 | var x = 23, y; |
 | try.js:5:1:5:29 | try {} catch(x) {} finally {} |
 test_EnclosingStmt
-| conditionals.js:1:5:1:8 | true | conditionals.js:1:1:2:5 | if (tru ... t\\n    ; |
+| conditionals.js:1:5:1:8 | true | conditionals.js:1:1:2:5 | if (true)\\n    ; |
 | conditionals.js:3:5:3:5 | b | conditionals.js:3:1:6:5 | if (b)\\n ... e\\n    ; |
 | conditionals.js:7:9:7:9 | b | conditionals.js:7:1:12:1 | switch  ... ault:\\n} |
 | conditionals.js:8:6:8:7 | 23 | conditionals.js:8:1:8:8 | case 23: |
@@ -96,7 +93,7 @@ test_EnclosingStmt
 | legacyletstmt.js:2:15:2:15 | x | legacyletstmt.js:2:3:2:21 | console.log(x + y); |
 | legacyletstmt.js:2:15:2:19 | x + y | legacyletstmt.js:2:3:2:21 | console.log(x + y); |
 | legacyletstmt.js:2:19:2:19 | y | legacyletstmt.js:2:3:2:21 | console.log(x + y); |
-| loops.js:1:7:1:10 | true | loops.js:1:1:2:5 | while(t ... t\\n    ; |
+| loops.js:1:7:1:10 | true | loops.js:1:1:2:5 | while(true)\\n    ; |
 | loops.js:3:1:3:5 | outer | loops.js:3:1:11:1 | outer:  ... inue;\\n} |
 | loops.js:3:12:3:12 | a | loops.js:3:8:11:1 | for(a;  ... inue;\\n} |
 | loops.js:3:15:3:15 | b | loops.js:3:8:11:1 | for(a;  ... inue;\\n} |
@@ -129,7 +126,7 @@ test_EnclosingStmt
 | loops.js:22:6:22:6 | x | loops.js:22:1:22:18 | for (x = 0 in xs); |
 | loops.js:22:10:22:10 | 0 | loops.js:22:1:22:18 | for (x = 0 in xs); |
 | loops.js:22:15:22:16 | xs | loops.js:22:1:22:18 | for (x = 0 in xs); |
-| others.js:1:6:1:6 | a | others.js:1:1:2:1 | with(a) ... -text\\n} |
+| others.js:1:6:1:6 | a | others.js:1:1:2:1 | with(a) {\\n} |
 | others.js:4:5:4:5 | x | others.js:4:1:4:14 | var x = 23, y; |
 | others.js:4:5:4:10 | x = 23 | others.js:4:1:4:14 | var x = 23, y; |
 | others.js:4:9:4:10 | 23 | others.js:4:1:4:14 | var x = 23, y; |
@@ -140,7 +137,7 @@ test_EnclosingStmt
 | try.js:5:14:5:14 | x | try.js:5:8:5:18 | catch(x) {} |
 test_NumCatchClauses
 | guardedCatch.js:2:2:8:2 | try {\\n\\t ... !");\\n\\t} | 2 |
-| try.js:1:1:3:16 | try { / ... ) { ; } | 1 |
+| try.js:1:1:3:16 | try {\\n  ... ) { ; } | 1 |
 | try.js:4:1:4:20 | try {} finally { ; } | 0 |
 | try.js:5:1:5:29 | try {}  ... ally {} | 1 |
 test_DoubleColonMethods
@@ -151,7 +148,7 @@ test_SemicolonInsertion
 test_getGuard
 | guardedCatch.js:4:4:6:2 | catch ( ... !");\\n\\t} | guardedCatch.js:4:16:4:33 | e instanceof Error |
 test_Containers
-| conditionals.js:1:1:2:5 | if (tru ... t\\n    ; | conditionals.js:1:1:12:1 | <toplevel> |
+| conditionals.js:1:1:2:5 | if (true)\\n    ; | conditionals.js:1:1:12:1 | <toplevel> |
 | conditionals.js:2:5:2:5 | ; | conditionals.js:1:1:12:1 | <toplevel> |
 | conditionals.js:3:1:6:5 | if (b)\\n ... e\\n    ; | conditionals.js:1:1:12:1 | <toplevel> |
 | conditionals.js:4:5:4:5 | ; | conditionals.js:1:1:12:1 | <toplevel> |
@@ -164,22 +161,22 @@ test_Containers
 | es2015.js:1:1:2:16 | for (va ... log(x); | es2015.js:1:1:3:0 | <toplevel> |
 | es2015.js:1:6:1:10 | var x | es2015.js:1:1:3:0 | <toplevel> |
 | es2015.js:2:2:2:16 | console.log(x); | es2015.js:1:1:3:0 | <toplevel> |
-| foreach.js:1:1:1:12 | var sum = 0; | foreach.js:1:1:11:0 | <toplevel> |
-| foreach.js:2:1:2:42 | var obj ... p3: 8}; | foreach.js:1:1:11:0 | <toplevel> |
-| foreach.js:4:1:6:1 | for eac ... item;\\n} | foreach.js:1:1:11:0 | <toplevel> |
-| foreach.js:4:11:4:18 | var item | foreach.js:1:1:11:0 | <toplevel> |
-| foreach.js:4:28:6:1 | {\\n  sum += item;\\n} | foreach.js:1:1:11:0 | <toplevel> |
-| foreach.js:5:3:5:14 | sum += item; | foreach.js:1:1:11:0 | <toplevel> |
-| foreach.js:8:1:8:17 | console.log(sum); | foreach.js:1:1:11:0 | <toplevel> |
+| foreach.js:1:1:1:12 | var sum = 0; | foreach.js:1:1:9:0 | <toplevel> |
+| foreach.js:2:1:2:42 | var obj ... p3: 8}; | foreach.js:1:1:9:0 | <toplevel> |
+| foreach.js:4:1:6:1 | for eac ... item;\\n} | foreach.js:1:1:9:0 | <toplevel> |
+| foreach.js:4:11:4:18 | var item | foreach.js:1:1:9:0 | <toplevel> |
+| foreach.js:4:28:6:1 | {\\n  sum += item;\\n} | foreach.js:1:1:9:0 | <toplevel> |
+| foreach.js:5:3:5:14 | sum += item; | foreach.js:1:1:9:0 | <toplevel> |
+| foreach.js:8:1:8:17 | console.log(sum); | foreach.js:1:1:9:0 | <toplevel> |
 | functions.js:1:1:3:1 | functio ...  x+y;\\n} | functions.js:1:1:9:1 | <toplevel> |
-| functions.js:1:18:3:1 | { // se ...  x+y;\\n} | functions.js:1:1:3:1 | functio ...  x+y;\\n} |
+| functions.js:1:18:3:1 | {\\n    return x+y;\\n} | functions.js:1:1:3:1 | functio ...  x+y;\\n} |
 | functions.js:2:5:2:15 | return x+y; | functions.js:1:1:3:1 | functio ...  x+y;\\n} |
 | functions.js:5:1:5:15 | function h() {} | functions.js:1:1:9:1 | <toplevel> |
 | functions.js:5:14:5:15 | {} | functions.js:5:1:5:15 | function h() {} |
 | functions.js:7:1:9:1 | k = fun ... turn;\\n} | functions.js:1:1:9:1 | <toplevel> |
 | functions.js:7:16:9:1 | {\\n    return;\\n} | functions.js:7:5:9:1 | functio ... turn;\\n} |
 | functions.js:8:5:8:11 | return; | functions.js:7:5:9:1 | functio ... turn;\\n} |
-| guardedCatch.js:1:1:9:1 | functio ... );\\n\\t}\\n} | guardedCatch.js:1:1:11:65 | <toplevel> |
+| guardedCatch.js:1:1:9:1 | functio ... );\\n\\t}\\n} | guardedCatch.js:1:1:10:0 | <toplevel> |
 | guardedCatch.js:1:15:9:1 | {\\n\\ttry  ... );\\n\\t}\\n} | guardedCatch.js:1:1:9:1 | functio ... );\\n\\t}\\n} |
 | guardedCatch.js:2:2:8:2 | try {\\n\\t ... !");\\n\\t} | guardedCatch.js:1:1:9:1 | functio ... );\\n\\t}\\n} |
 | guardedCatch.js:2:6:4:2 | {\\n\\t\\tg();\\n\\t} | guardedCatch.js:1:1:9:1 | functio ... );\\n\\t}\\n} |
@@ -190,14 +187,14 @@ test_Containers
 | guardedCatch.js:6:4:8:2 | catch ( ... !");\\n\\t} | guardedCatch.js:1:1:9:1 | functio ... );\\n\\t}\\n} |
 | guardedCatch.js:6:14:8:2 | {\\n\\t\\tcon ... !");\\n\\t} | guardedCatch.js:1:1:9:1 | functio ... );\\n\\t}\\n} |
 | guardedCatch.js:7:3:7:33 | console ... lse!"); | guardedCatch.js:1:1:9:1 | functio ... );\\n\\t}\\n} |
-| jscript.js:1:1:1:28 | functio ... ad() {} | jscript.js:1:1:5:65 | <toplevel> |
+| jscript.js:1:1:1:28 | functio ... ad() {} | jscript.js:1:1:4:0 | <toplevel> |
 | jscript.js:1:27:1:28 | {} | jscript.js:1:1:1:28 | functio ... ad() {} |
-| jscript.js:3:1:3:36 | window. ... ad() {} | jscript.js:1:1:5:65 | <toplevel> |
+| jscript.js:3:1:3:36 | window. ... ad() {} | jscript.js:1:1:4:0 | <toplevel> |
 | jscript.js:3:35:3:36 | {} | jscript.js:3:17:3:36 | function onload() {} |
-| legacyletstmt.js:1:1:3:1 | let (x  ... + y);\\n} | legacyletstmt.js:1:1:5:65 | <toplevel> |
-| legacyletstmt.js:1:22:3:1 | {\\n  con ... + y);\\n} | legacyletstmt.js:1:1:5:65 | <toplevel> |
-| legacyletstmt.js:2:3:2:21 | console.log(x + y); | legacyletstmt.js:1:1:5:65 | <toplevel> |
-| loops.js:1:1:2:5 | while(t ... t\\n    ; | loops.js:1:1:22:18 | <toplevel> |
+| legacyletstmt.js:1:1:3:1 | let (x  ... + y);\\n} | legacyletstmt.js:1:1:4:0 | <toplevel> |
+| legacyletstmt.js:1:22:3:1 | {\\n  con ... + y);\\n} | legacyletstmt.js:1:1:4:0 | <toplevel> |
+| legacyletstmt.js:2:3:2:21 | console.log(x + y); | legacyletstmt.js:1:1:4:0 | <toplevel> |
+| loops.js:1:1:2:5 | while(true)\\n    ; | loops.js:1:1:22:18 | <toplevel> |
 | loops.js:2:5:2:5 | ; | loops.js:1:1:22:18 | <toplevel> |
 | loops.js:3:1:11:1 | outer:  ... inue;\\n} | loops.js:1:1:22:18 | <toplevel> |
 | loops.js:3:8:11:1 | for(a;  ... inue;\\n} | loops.js:1:1:22:18 | <toplevel> |
@@ -223,12 +220,12 @@ test_Containers
 | loops.js:21:16:21:16 | ; | loops.js:1:1:22:18 | <toplevel> |
 | loops.js:22:1:22:18 | for (x = 0 in xs); | loops.js:1:1:22:18 | <toplevel> |
 | loops.js:22:18:22:18 | ; | loops.js:1:1:22:18 | <toplevel> |
-| others.js:1:1:2:1 | with(a) ... -text\\n} | others.js:1:1:4:14 | <toplevel> |
-| others.js:1:9:2:1 | { // se ... -text\\n} | others.js:1:1:4:14 | <toplevel> |
+| others.js:1:1:2:1 | with(a) {\\n} | others.js:1:1:4:14 | <toplevel> |
+| others.js:1:9:2:1 | {\\n} | others.js:1:1:4:14 | <toplevel> |
 | others.js:3:1:3:9 | debugger; | others.js:1:1:4:14 | <toplevel> |
 | others.js:4:1:4:14 | var x = 23, y; | others.js:1:1:4:14 | <toplevel> |
-| try.js:1:1:3:16 | try { / ... ) { ; } | try.js:1:1:5:29 | <toplevel> |
-| try.js:1:5:3:1 | { // se ...  "!";\\n} | try.js:1:1:5:29 | <toplevel> |
+| try.js:1:1:3:16 | try {\\n  ... ) { ; } | try.js:1:1:5:29 | <toplevel> |
+| try.js:1:5:3:1 | {\\n    throw "!";\\n} | try.js:1:1:5:29 | <toplevel> |
 | try.js:2:5:2:14 | throw "!"; | try.js:1:1:5:29 | <toplevel> |
 | try.js:3:3:3:16 | catch(x) { ; } | try.js:1:1:5:29 | <toplevel> |
 | try.js:3:12:3:16 | { ; } | try.js:1:1:5:29 | <toplevel> |

--- a/javascript/ql/test/library-tests/stmts/try.js
+++ b/javascript/ql/test/library-tests/stmts/try.js
@@ -1,4 +1,4 @@
-try { // semmle-extractor-options: --extract-program-text
+try {
     throw "!";
 } catch(x) { ; }
 try {} finally { ; }

--- a/javascript/ql/test/library-tests/variables/getDeclaringContainer.expected
+++ b/javascript/ql/test/library-tests/variables/getDeclaringContainer.expected
@@ -24,7 +24,7 @@
 | x | defaultargs.js:3:3:3:25 | functio ... = x) {} |
 | x | defaultargs.js:4:3:4:51 | functio ... [0]) {} |
 | x | for.js:1:2:5:1 | functio ...    x;\\n} |
-| x | legacyletstmt.js:1:1:9:42 | <toplevel> |
+| x | legacyletstmt.js:1:1:8:0 | <toplevel> |
 | x | let.js:1:1:22:0 | <toplevel> |
 | x | let.js:1:1:22:0 | <toplevel> |
 | x | let.js:1:1:22:0 | <toplevel> |
@@ -36,7 +36,7 @@
 | x | variables.js:13:1:23:1 | functio ... z;\\n\\t}\\n} |
 | y | defaultargs.js:3:3:3:25 | functio ... = x) {} |
 | y | defaultargs.js:4:3:4:51 | functio ... [0]) {} |
-| y | legacyletstmt.js:1:1:9:42 | <toplevel> |
+| y | legacyletstmt.js:1:1:8:0 | <toplevel> |
 | y | let.js:1:1:22:0 | <toplevel> |
 | y | let.js:14:1:21:1 | functio ...     }\\n} |
 | y | typeoftype.ts:3:3:5:3 | functio ... e x\\n  } |

--- a/javascript/ql/test/library-tests/variables/legacyletstmt.js
+++ b/javascript/ql/test/library-tests/variables/legacyletstmt.js
@@ -5,5 +5,3 @@ let (x = 23, y = 19) {
 }
 
 console.log(x - y);
-
-//semmle-extractor-options: --experimental

--- a/javascript/ql/test/library-tests/variables/options
+++ b/javascript/ql/test/library-tests/variables/options
@@ -1,0 +1,1 @@
+semmle-extractor-options: --experimental

--- a/javascript/ql/test/query-tests/AngularJS/DuplicateDependency/options
+++ b/javascript/ql/test/query-tests/AngularJS/DuplicateDependency/options
@@ -1,0 +1,1 @@
+semmle-extractor-options: --tolerate-parse-errors

--- a/javascript/ql/test/query-tests/DOM/HTML/AmbiguousIdAttribute.html
+++ b/javascript/ql/test/query-tests/DOM/HTML/AmbiguousIdAttribute.html
@@ -4,5 +4,4 @@
 <li id="first">First element
 <li id="first">Second element
 </ul>
-semmle-extractor-options: --html elements
 </body>

--- a/javascript/ql/test/query-tests/DOM/HTML/AmbiguousIdAttributeGood.html
+++ b/javascript/ql/test/query-tests/DOM/HTML/AmbiguousIdAttributeGood.html
@@ -10,5 +10,4 @@
 <li class="duplicate-class">duplicate-class</li>
 <li class="duplicate-class">duplicate-class</li>
 </ul>
-semmle-extractor-options: --html elements
 </body>

--- a/javascript/ql/test/query-tests/DOM/HTML/ConflictingAttributes.html
+++ b/javascript/ql/test/query-tests/DOM/HTML/ConflictingAttributes.html
@@ -1,2 +1,1 @@
 <a href="http://semmle.com" href="https://semmle.com">Semmle</a>
-semmle-extractor-options: --html elements

--- a/javascript/ql/test/query-tests/DOM/HTML/ConflictingAttributesGood.html
+++ b/javascript/ql/test/query-tests/DOM/HTML/ConflictingAttributesGood.html
@@ -1,2 +1,1 @@
 <a href="https://semmle.com">Semmle</a>
-semmle-extractor-options: --html elements

--- a/javascript/ql/test/query-tests/DOM/HTML/DuplicateAttributes.html
+++ b/javascript/ql/test/query-tests/DOM/HTML/DuplicateAttributes.html
@@ -1,2 +1,1 @@
 <a href="https://semmle.com" href="https://semmle.com">Semmle</a>
-semmle-extractor-options: --html elements

--- a/javascript/ql/test/query-tests/DOM/HTML/DuplicateAttributesGood.html
+++ b/javascript/ql/test/query-tests/DOM/HTML/DuplicateAttributesGood.html
@@ -1,2 +1,1 @@
 <a href="https://semmle.com">Semmle</a>
-semmle-extractor-options: --html elements

--- a/javascript/ql/test/query-tests/DOM/HTML/MalformedIdAttribute.html
+++ b/javascript/ql/test/query-tests/DOM/HTML/MalformedIdAttribute.html
@@ -1,2 +1,1 @@
 <div id="heading important">An important heading</div>
-semmle-extractor-options: --html elements

--- a/javascript/ql/test/query-tests/DOM/HTML/MalformedIdAttributeGood.html
+++ b/javascript/ql/test/query-tests/DOM/HTML/MalformedIdAttributeGood.html
@@ -1,2 +1,1 @@
 <div class="heading important">An important heading</div>
-semmle-extractor-options: --html elements

--- a/javascript/ql/test/query-tests/DOM/HTML/options
+++ b/javascript/ql/test/query-tests/DOM/HTML/options
@@ -1,0 +1,1 @@
+semmle-extractor-options: --html elements

--- a/javascript/ql/test/query-tests/Declarations/ArgumentsRedefined/externs.js
+++ b/javascript/ql/test/query-tests/Declarations/ArgumentsRedefined/externs.js
@@ -1,3 +1,3 @@
 var arguments;
 
-//semmle-extractor-options: --externs
+/** @externs */

--- a/javascript/ql/test/query-tests/Declarations/DeadStoreOfGlobal/externs.js
+++ b/javascript/ql/test/query-tests/Declarations/DeadStoreOfGlobal/externs.js
@@ -38,4 +38,4 @@ function Worker(opt_arg0) {}
  */
 Worker.prototype.onmessage = function() {};
 
-//semmle-extractor-options: --externs
+/** @externs */

--- a/javascript/ql/test/query-tests/Declarations/DeadStoreOfLocal/fields.js
+++ b/javascript/ql/test/query-tests/Declarations/DeadStoreOfLocal/fields.js
@@ -3,5 +3,3 @@ var x = 42;
 class C {
   myX = x
 }
-
-// semmle-extractor-options: --experimental --source-type module

--- a/javascript/ql/test/query-tests/Declarations/DeadStoreOfLocal/options
+++ b/javascript/ql/test/query-tests/Declarations/DeadStoreOfLocal/options
@@ -1,0 +1,1 @@
+semmle-extractor-options: --experimental

--- a/javascript/ql/test/query-tests/Declarations/DeadStoreOfProperty/externs.js
+++ b/javascript/ql/test/query-tests/Declarations/DeadStoreOfProperty/externs.js
@@ -40,4 +40,4 @@ function Element() {}
  */
 Element.prototype.clientTop;
 
-//semmle-extractor-options: --externs
+/** @externs */

--- a/javascript/ql/test/query-tests/Declarations/RedeclaredVariable/externs.js
+++ b/javascript/ql/test/query-tests/Declarations/RedeclaredVariable/externs.js
@@ -2,4 +2,4 @@
 var f = function() {};
 var f = function(x) {};
 
-//semmle-extractor-options: --externs
+/** @externs */

--- a/javascript/ql/test/query-tests/Declarations/RedeclaredVariable/restprops.js
+++ b/javascript/ql/test/query-tests/Declarations/RedeclaredVariable/restprops.js
@@ -1,4 +1,2 @@
 var f = ({...p}) => {};
 var g = ({...p}) => {};
-
-// semmle-extractor-options: --experimental

--- a/javascript/ql/test/query-tests/Declarations/TooManyParameters/externs.js
+++ b/javascript/ql/test/query-tests/Declarations/TooManyParameters/externs.js
@@ -1,4 +1,4 @@
 // OK: overly long parameter lists in external APIs aren't the fault of the externs definitions
 function f(a, b, c, d, e, f, g, h) {}
 
-//semmle-extractor-options: --externs
+/** @externs */

--- a/javascript/ql/test/query-tests/Declarations/UniqueParameterNames/options
+++ b/javascript/ql/test/query-tests/Declarations/UniqueParameterNames/options
@@ -1,0 +1,1 @@
+semmle-extractor-options: --tolerate-parse-errors

--- a/javascript/ql/test/query-tests/Declarations/UniqueParameterNames/tst.js
+++ b/javascript/ql/test/query-tests/Declarations/UniqueParameterNames/tst.js
@@ -12,5 +12,3 @@ this.addPropertyListener(prop.name, function(_, _, _, a) {
 function f(x, y, x) {
   'use strict';
 }
-
-// semmle-extractor-options: --tolerate-parse-errors

--- a/javascript/ql/test/query-tests/Declarations/UnusedParameter/externs.js
+++ b/javascript/ql/test/query-tests/Declarations/UnusedParameter/externs.js
@@ -1,3 +1,3 @@
 function String(str) {}
 
-//semmle-extractor-options: --externs
+/** @externs */

--- a/javascript/ql/test/query-tests/Declarations/UnusedParameter/restprops.js
+++ b/javascript/ql/test/query-tests/Declarations/UnusedParameter/restprops.js
@@ -1,5 +1,3 @@
 function f({ x, ...ys }) {
   return ys;
 }
-
-// semmle-extractor-options: --experimental

--- a/javascript/ql/test/query-tests/Declarations/UnusedVariable/funbind.js
+++ b/javascript/ql/test/query-tests/Declarations/UnusedVariable/funbind.js
@@ -2,5 +2,3 @@ function test(bar, e) {
   let foo = bar;
   e.target::foo::baz();
 }
-
-// semmle-extractor-options: --experimental

--- a/javascript/ql/test/query-tests/Declarations/UnusedVariable/options
+++ b/javascript/ql/test/query-tests/Declarations/UnusedVariable/options
@@ -1,0 +1,1 @@
+semmle-extractor-options: --experimental

--- a/javascript/ql/test/query-tests/Declarations/UnusedVariable/restprops.js
+++ b/javascript/ql/test/query-tests/Declarations/UnusedVariable/restprops.js
@@ -2,5 +2,3 @@ function f(o) {
   let { x, ...ys } = o;
   return ys;
 }
-
-// semmle-extractor-options: --experimental

--- a/javascript/ql/test/query-tests/Expressions/ExprHasNoEffect/externs.js
+++ b/javascript/ql/test/query-tests/Expressions/ExprHasNoEffect/externs.js
@@ -53,4 +53,4 @@ function Error() {}
  */
 function SyntaxError() {}
 
-//semmle-extractor-options: --externs
+/** @externs */

--- a/javascript/ql/test/query-tests/Expressions/HeterogeneousComparison/options
+++ b/javascript/ql/test/query-tests/Expressions/HeterogeneousComparison/options
@@ -1,0 +1,1 @@
+semmle-extractor-options: --experimental

--- a/javascript/ql/test/query-tests/Expressions/HeterogeneousComparison/tst.js
+++ b/javascript/ql/test/query-tests/Expressions/HeterogeneousComparison/tst.js
@@ -232,5 +232,3 @@ function l() {
 function f(...x) {
     x === 42
 };
-
-// semmle-extractor-options: --experimental

--- a/javascript/ql/test/query-tests/Expressions/ImplicitOperandConversion/options
+++ b/javascript/ql/test/query-tests/Expressions/ImplicitOperandConversion/options
@@ -1,0 +1,1 @@
+semmle-extractor-options: --experimental

--- a/javascript/ql/test/query-tests/Expressions/ImplicitOperandConversion/tst.js
+++ b/javascript/ql/test/query-tests/Expressions/ImplicitOperandConversion/tst.js
@@ -107,4 +107,3 @@ function l() {
     g();
 });
 
-// semmle-extractor-options: --experimental

--- a/javascript/ql/test/query-tests/Expressions/SelfAssignment/externs.js
+++ b/javascript/ql/test/query-tests/Expressions/SelfAssignment/externs.js
@@ -36,4 +36,4 @@ function Element() {}
 
 Element.prototype.innerHTML;
 
-// semmle-extractor-options: --externs
+/** @externs */

--- a/javascript/ql/test/query-tests/Expressions/SelfAssignment/jsdoc.js
+++ b/javascript/ql/test/query-tests/Expressions/SelfAssignment/jsdoc.js
@@ -11,5 +11,3 @@ class C extends Q {
     this.arg = this.arg; // NOT OK
   }
 }
-
-// semmle-extractor-options: --experimental

--- a/javascript/ql/test/query-tests/Expressions/ShiftOutOfRange/options
+++ b/javascript/ql/test/query-tests/Expressions/ShiftOutOfRange/options
@@ -1,0 +1,1 @@
+semmle-extractor-options: --experimental

--- a/javascript/ql/test/query-tests/Expressions/ShiftOutOfRange/tst.js
+++ b/javascript/ql/test/query-tests/Expressions/ShiftOutOfRange/tst.js
@@ -1,4 +1,2 @@
 var n = 1<<40; // NOT OK
 var n2 = BigInt(1) << 40n; // OK
-
-// semmle-extractor-options: --experimental

--- a/javascript/ql/test/query-tests/Expressions/SuspiciousInvocation/fields.js
+++ b/javascript/ql/test/query-tests/Expressions/SuspiciousInvocation/fields.js
@@ -3,5 +3,3 @@ class A {
 }
 
 class B {}
-
-// semmle-extractor-options: --experimental --source-type module

--- a/javascript/ql/test/query-tests/Expressions/SuspiciousInvocation/optional-chaining.js
+++ b/javascript/ql/test/query-tests/Expressions/SuspiciousInvocation/optional-chaining.js
@@ -7,4 +7,3 @@
     b();
     b?.();
 });
-// semmle-extractor-options: --experimental

--- a/javascript/ql/test/query-tests/Expressions/SuspiciousInvocation/options
+++ b/javascript/ql/test/query-tests/Expressions/SuspiciousInvocation/options
@@ -1,0 +1,1 @@
+semmle-extractor-options: --experimental

--- a/javascript/ql/test/query-tests/Expressions/SuspiciousPropAccess/optional-chaining.js
+++ b/javascript/ql/test/query-tests/Expressions/SuspiciousPropAccess/optional-chaining.js
@@ -7,4 +7,3 @@
     b.p;
     b?.p;
 });
-// semmle-extractor-options: --experimental

--- a/javascript/ql/test/query-tests/Expressions/SuspiciousPropAccess/options
+++ b/javascript/ql/test/query-tests/Expressions/SuspiciousPropAccess/options
@@ -1,0 +1,1 @@
+semmle-extractor-options: --experimental

--- a/javascript/ql/test/query-tests/Expressions/SuspiciousPropAccess/yield_in_non_generator.js
+++ b/javascript/ql/test/query-tests/Expressions/SuspiciousPropAccess/yield_in_non_generator.js
@@ -4,5 +4,3 @@ function outer() {
   }
   inner().next()
 }
-
-// semmle-extractor-options: --experimental

--- a/javascript/ql/test/query-tests/Expressions/UnboundEventHandlerReceiver/options
+++ b/javascript/ql/test/query-tests/Expressions/UnboundEventHandlerReceiver/options
@@ -1,0 +1,1 @@
+semmle-extractor-options: --experimental

--- a/javascript/ql/test/query-tests/Expressions/UnboundEventHandlerReceiver/tst.js
+++ b/javascript/ql/test/query-tests/Expressions/UnboundEventHandlerReceiver/tst.js
@@ -172,5 +172,3 @@ class Component4 extends React.Component {
         this.setState({ });
     }
 }
-
-// semmle-extractor-options: --experimental

--- a/javascript/ql/test/query-tests/JSDoc/BadParamTag/externs.js
+++ b/javascript/ql/test/query-tests/JSDoc/BadParamTag/externs.js
@@ -3,4 +3,4 @@
  */
 function f(x) {}
 
-//semmle-extractor-options: --externs
+/** @externs */

--- a/javascript/ql/test/query-tests/LanguageFeatures/ExpressionClosures/foreach.js
+++ b/javascript/ql/test/query-tests/LanguageFeatures/ExpressionClosures/foreach.js
@@ -6,5 +6,3 @@ for each (var item in obj) {
 }
 
 console.log(sum); // logs "26", which is 5+13+8
-
-//semmle-extractor-options: --experimental

--- a/javascript/ql/test/query-tests/LanguageFeatures/ExpressionClosures/jscript.js
+++ b/javascript/ql/test/query-tests/LanguageFeatures/ExpressionClosures/jscript.js
@@ -1,5 +1,3 @@
 function window::onload() {}
 
 window.onload = function onload() {}
-
-//semmle-extractor-options: --experimental

--- a/javascript/ql/test/query-tests/LanguageFeatures/ExpressionClosures/letExpr.js
+++ b/javascript/ql/test/query-tests/LanguageFeatures/ExpressionClosures/letExpr.js
@@ -3,5 +3,3 @@ var x = 42, y = 19;
 console.log(let (x = 23, y = 19) x + y);
 
 console.log(x - y);
-
-//semmle-extractor-options: --experimental

--- a/javascript/ql/test/query-tests/LanguageFeatures/ExpressionClosures/letStmt.js
+++ b/javascript/ql/test/query-tests/LanguageFeatures/ExpressionClosures/letStmt.js
@@ -5,5 +5,3 @@ let (x = 23, y = 19) {
 }
 
 console.log(x - y);
-
-//semmle-extractor-options: --experimental

--- a/javascript/ql/test/query-tests/LanguageFeatures/ExpressionClosures/options
+++ b/javascript/ql/test/query-tests/LanguageFeatures/ExpressionClosures/options
@@ -1,0 +1,1 @@
+semmle-extractor-options: --experimental

--- a/javascript/ql/test/query-tests/LanguageFeatures/ExpressionClosures/postfixComprehension.js
+++ b/javascript/ql/test/query-tests/LanguageFeatures/ExpressionClosures/postfixComprehension.js
@@ -2,5 +2,3 @@ var numbers = [1, 2, 3, 4, 5];
 var squares = [i*i for (i of numbers)];
 var specialKeyCodes = [for (keyCodeName of Object.keys(SPECIAL_CODES_MAP))
     SPECIAL_CODES_MAP[keyCodeName]];
-
-//semmle-extractor-options: --experimental

--- a/javascript/ql/test/query-tests/LanguageFeatures/ExpressionClosures/tst.js
+++ b/javascript/ql/test/query-tests/LanguageFeatures/ExpressionClosures/tst.js
@@ -6,5 +6,3 @@
 
 // OK
 [1, 2, 3].map((x) => x * x);
-
-//semmle-extractor-options: --experimental

--- a/javascript/ql/test/query-tests/LanguageFeatures/ForInComprehensionBlocks/options
+++ b/javascript/ql/test/query-tests/LanguageFeatures/ForInComprehensionBlocks/options
@@ -1,0 +1,1 @@
+semmle-extractor-options: --experimental

--- a/javascript/ql/test/query-tests/LanguageFeatures/ForInComprehensionBlocks/tst.js
+++ b/javascript/ql/test/query-tests/LanguageFeatures/ForInComprehensionBlocks/tst.js
@@ -1,4 +1,2 @@
 var a = [23,,42];
 var desc = [for(i in a) i + " = a[" + i + "]"];
-
-//semmle-extractor-options: --experimental

--- a/javascript/ql/test/query-tests/LanguageFeatures/IllegalInvocation/tst.js
+++ b/javascript/ql/test/query-tests/LanguageFeatures/IllegalInvocation/tst.js
@@ -60,5 +60,3 @@ function invoke(fn) {
 }
 invoke(C);
 invoke(function() {});
-
-//semmle-extractor-options: --experimental

--- a/javascript/ql/test/query-tests/LanguageFeatures/InconsistentNew/externs.js
+++ b/javascript/ql/test/query-tests/LanguageFeatures/InconsistentNew/externs.js
@@ -7,4 +7,4 @@ String.prototype.toString = function() {};
 function Array() {}
 Array.prototype.toString = function() {};
 
-//semmle-extractor-options: --externs
+/** @externs */

--- a/javascript/ql/test/query-tests/LanguageFeatures/SemicolonInsertion/SemicolonInsertion.expected
+++ b/javascript/ql/test/query-tests/LanguageFeatures/SemicolonInsertion/SemicolonInsertion.expected
@@ -1,4 +1,4 @@
 | export.js:5:8:5:17 | var x = 42 | Avoid automated semicolon insertion (95% of all statements in $@ have an explicit semicolon). | export.js:1:1:29:0 | <toplevel> | the enclosing script |
-| jscript.js:3:1:3:36 | window. ... ad() {} | Avoid automated semicolon insertion (95% of all statements in $@ have an explicit semicolon). | jscript.js:1:1:27:42 | <toplevel> | the enclosing script |
+| jscript.js:3:1:3:36 | window. ... ad() {} | Avoid automated semicolon insertion (95% of all statements in $@ have an explicit semicolon). | jscript.js:1:1:26:0 | <toplevel> | the enclosing script |
 | tst.js:5:1:5:3 | var a = ... : 2\\n  } | Avoid automated semicolon insertion (91% of all statements in $@ have an explicit semicolon). | tst.js:1:1:42:1 | functio ... oo();\\n} | the enclosing function |
 | tst.js:7:3:7:10 | return 1 | Avoid automated semicolon insertion (91% of all statements in $@ have an explicit semicolon). | tst.js:1:1:42:1 | functio ... oo();\\n} | the enclosing function |

--- a/javascript/ql/test/query-tests/LanguageFeatures/SemicolonInsertion/jscript.js
+++ b/javascript/ql/test/query-tests/LanguageFeatures/SemicolonInsertion/jscript.js
@@ -23,5 +23,3 @@ foo();
 foo();
 foo();
 foo();
-
-//semmle-extractor-options: --experimental

--- a/javascript/ql/test/query-tests/LanguageFeatures/SemicolonInsertion/options
+++ b/javascript/ql/test/query-tests/LanguageFeatures/SemicolonInsertion/options
@@ -1,0 +1,1 @@
+semmle-extractor-options: --experimental

--- a/javascript/ql/test/query-tests/LanguageFeatures/SpuriousArguments/externs.js
+++ b/javascript/ql/test/query-tests/LanguageFeatures/SpuriousArguments/externs.js
@@ -39,4 +39,4 @@ function Number() {}
 
 Number.parseFloat = function(num) {};
 
-//semmle-extractor-options: --externs
+/** @externs */

--- a/javascript/ql/test/query-tests/LanguageFeatures/SyntaxError/options
+++ b/javascript/ql/test/query-tests/LanguageFeatures/SyntaxError/options
@@ -1,0 +1,1 @@
+semmle-extractor-options: --tolerate-parse-errors

--- a/javascript/ql/test/query-tests/LanguageFeatures/SyntaxError/tst.js
+++ b/javascript/ql/test/query-tests/LanguageFeatures/SyntaxError/tst.js
@@ -1,4 +1,2 @@
 function findBox() {
   return $("box.important
-
-// semmle-extractor-options: --tolerate-parse-errors

--- a/javascript/ql/test/query-tests/LanguageFeatures/YieldInNonGenerator/options
+++ b/javascript/ql/test/query-tests/LanguageFeatures/YieldInNonGenerator/options
@@ -1,0 +1,1 @@
+semmle-extractor-options: --experimental

--- a/javascript/ql/test/query-tests/LanguageFeatures/YieldInNonGenerator/tst.js
+++ b/javascript/ql/test/query-tests/LanguageFeatures/YieldInNonGenerator/tst.js
@@ -4,6 +4,3 @@ function idMaker(){
         // NOT OK
         yield index++;
 }
-
-//semmle-extractor-options: --experimental
-

--- a/javascript/ql/test/query-tests/NodeJS/DubiousImport/DubiousImport.expected
+++ b/javascript/ql/test/query-tests/NodeJS/DubiousImport/DubiousImport.expected
@@ -1,5 +1,5 @@
 | a.js:1:11:1:28 | require('./b').foo | Module $@ does not export symbol foo. | b.js:1:1:5:21 | <toplevel> | b |
 | main.js:5:1:5:5 | b.foo | Module $@ does not export symbol foo. | b.js:1:1:5:21 | <toplevel> | b |
 | main.js:15:1:15:9 | fs.renmae | Module $@ does not export symbol renmae. | fs.js:1:1:15:0 | <toplevel> | fs |
-| main.js:23:1:23:5 | l.bar | Module $@ does not export symbol bar. | l.js:1:1:7:52 | <toplevel> | l |
+| main.js:23:1:23:5 | l.bar | Module $@ does not export symbol bar. | l.js:1:1:6:0 | <toplevel> | l |
 | multi_import.js:16:3:16:10 | mod2.bar | Module $@ does not export symbol bar. | b.js:1:1:5:21 | <toplevel> | b |

--- a/javascript/ql/test/query-tests/NodeJS/DubiousImport/externs.js
+++ b/javascript/ql/test/query-tests/NodeJS/DubiousImport/externs.js
@@ -615,4 +615,4 @@ Array.some = function(arr, callback, opt_context) {};
  */
 Array.isArray = function(arr) {};
 
-//semmle-extractor-options: --externs
+/** @externs */

--- a/javascript/ql/test/query-tests/NodeJS/DubiousImport/f.js
+++ b/javascript/ql/test/query-tests/NodeJS/DubiousImport/f.js
@@ -4,5 +4,4 @@
 	module.exports = me;
 }(module));
 
-// semmle-extractor-options: --platform
-// semmle-extractor-options: node
+require("process"); // ensure this is treated as Node.js code

--- a/javascript/ql/test/query-tests/NodeJS/DubiousImport/fs-monkeypatch.js
+++ b/javascript/ql/test/query-tests/NodeJS/DubiousImport/fs-monkeypatch.js
@@ -2,4 +2,4 @@ var fs = require('fs');
 
 fs.move = fs.rename;
 
-//semmle-extractor-options: --externs
+/** @externs */

--- a/javascript/ql/test/query-tests/NodeJS/DubiousImport/fs.js
+++ b/javascript/ql/test/query-tests/NodeJS/DubiousImport/fs.js
@@ -11,4 +11,4 @@ fs.rename;
 
 module.exports = fs;
 
-//semmle-extractor-options: --externs
+/** @externs */

--- a/javascript/ql/test/query-tests/NodeJS/DubiousImport/l.js
+++ b/javascript/ql/test/query-tests/NodeJS/DubiousImport/l.js
@@ -3,5 +3,3 @@ class C {
 }
 
 module.exports = C;
-
-// semmle-extractor-options: --abort-on-parse-errors

--- a/javascript/ql/test/query-tests/NodeJS/DubiousImport/m.js
+++ b/javascript/ql/test/query-tests/NodeJS/DubiousImport/m.js
@@ -5,5 +5,3 @@ var props = {
 module.exports = {
   ...props
 };
-
-// semmle-extractor-options: --experimental

--- a/javascript/ql/test/query-tests/NodeJS/UnusedDependency/src/other.js
+++ b/javascript/ql/test/query-tests/NodeJS/UnusedDependency/src/other.js
@@ -1,4 +1,2 @@
 import hipsterness from 'react';
 import curry from 'lodash/function/curry';
-
-//semmle-extractor-options: --platform node

--- a/javascript/ql/test/query-tests/Performance/ReDoS/tst.js
+++ b/javascript/ql/test/query-tests/Performance/ReDoS/tst.js
@@ -84,5 +84,3 @@ var bad16 = /(.|\n)*!/s;
 
 // GOOD
 var good8 = /([\w.]+)*/;
-
-// semmle-extractor-options: --experimental

--- a/javascript/ql/test/query-tests/React/DirectStateMutation/options
+++ b/javascript/ql/test/query-tests/React/DirectStateMutation/options
@@ -1,0 +1,1 @@
+semmle-extractor-options: --experimental

--- a/javascript/ql/test/query-tests/React/DirectStateMutation/valid9.js
+++ b/javascript/ql/test/query-tests/React/DirectStateMutation/valid9.js
@@ -11,5 +11,3 @@ React.createClass({
     };
   }
 });
-
-//semmle-extractor-options: --experimental

--- a/javascript/ql/test/query-tests/React/UnusedOrUndefinedStateProperty/issue7506.js
+++ b/javascript/ql/test/query-tests/React/UnusedOrUndefinedStateProperty/issue7506.js
@@ -19,5 +19,3 @@ class C2 extends React.Component {
     const { p1: p2 } = state
   }
 }
-
-// semmle-extractor-options: --experimental

--- a/javascript/ql/test/query-tests/React/UnusedOrUndefinedStateProperty/options
+++ b/javascript/ql/test/query-tests/React/UnusedOrUndefinedStateProperty/options
@@ -1,0 +1,1 @@
+semmle-extractor-options: --experimental

--- a/javascript/ql/test/query-tests/React/UnusedOrUndefinedStateProperty/undefined.js
+++ b/javascript/ql/test/query-tests/React/UnusedOrUndefinedStateProperty/undefined.js
@@ -166,5 +166,3 @@ class C11 extends React.Component {
         this.state.writeIn_getDerivedStateFromProps; // OK
     }
 }
-
-//semmle-extractor-options: --experimental

--- a/javascript/ql/test/query-tests/React/UnusedOrUndefinedStateProperty/unused.js
+++ b/javascript/ql/test/query-tests/React/UnusedOrUndefinedStateProperty/unused.js
@@ -72,5 +72,3 @@ class C6 extends React.Component {
     }
 
 }
-
-//semmle-extractor-options: --experimental

--- a/javascript/ql/test/query-tests/Security/CWE-089/untyped/tst2.js
+++ b/javascript/ql/test/query-tests/Security/CWE-089/untyped/tst2.js
@@ -8,5 +8,3 @@ app.get('/post/:id', async function(req, res) {
   // NOT OK
   new sql.Request().query("select * from mytable where id = '" + req.params.id + "'");
 });
-
-// semmle-extractor-options: --experimental

--- a/javascript/ql/test/query-tests/Security/CWE-089/untyped/tst4.js
+++ b/javascript/ql/test/query-tests/Security/CWE-089/untyped/tst4.js
@@ -7,5 +7,3 @@ angular.module('myApp', ['ngRoute'])
 .controller('FindPost', function($routeParams) {
   db.get('SELECT * FROM Post WHERE id = "' + $routeParams.id + '"');
 });
-
-// semmle-extractor-options: --platform node

--- a/javascript/ql/test/query-tests/Statements/ReturnOutsideFunction/node.js
+++ b/javascript/ql/test/query-tests/Statements/ReturnOutsideFunction/node.js
@@ -1,5 +1,4 @@
 // not a syntax error, but still NOT OK
 return 42;
 
-// semmle-extractor-options: --platform
-// semmle-extractor-options: node
+require("path") // ensure this is treated as Node.js code

--- a/javascript/ql/test/query-tests/Statements/UselessConditional/UselessConditional.js
+++ b/javascript/ql/test/query-tests/Statements/UselessConditional/UselessConditional.js
@@ -176,5 +176,3 @@ async function awaitFlow(){
 	if (v) { // OK
 	}
 });
-
-// semmle-extractor-options: --experimental

--- a/javascript/ql/test/query-tests/Statements/UselessConditional/options
+++ b/javascript/ql/test/query-tests/Statements/UselessConditional/options
@@ -1,0 +1,1 @@
+semmle-extractor-options: --experimental

--- a/javascript/ql/test/query-tests/filters/ClassifyFiles/nonbmp.js
+++ b/javascript/ql/test/query-tests/filters/ClassifyFiles/nonbmp.js
@@ -1,3 +1,1 @@
 😼😼
-
-// semmle-extractor-options: --tolerate-parse-errors

--- a/javascript/ql/test/query-tests/filters/ClassifyFiles/options
+++ b/javascript/ql/test/query-tests/filters/ClassifyFiles/options
@@ -1,0 +1,1 @@
+semmle-extractor-options: --tolerate-parse-errors

--- a/javascript/ql/test/query-tests/filters/ClassifyFiles/some-template.html
+++ b/javascript/ql/test/query-tests/filters/ClassifyFiles/some-template.html
@@ -1,4 +1,3 @@
 <script type="text/javascript">
 %some made-up template syntax
 </script>
-semmle-extractor-options: --tolerate-parse-errors

--- a/javascript/ql/test/query-tests/filters/ClassifyFiles/templ.js
+++ b/javascript/ql/test/query-tests/filters/ClassifyFiles/templ.js
@@ -3,4 +3,3 @@ common.autofocus('#id_password');
 {% else %}
 common.autofocus('#id_username');
 {% endif %}
-// semmle-extractor-options: --tolerate-parse-errors

--- a/javascript/ql/test/query-tests/filters/ClassifyFiles/tmpl.html
+++ b/javascript/ql/test/query-tests/filters/ClassifyFiles/tmpl.html
@@ -5,4 +5,3 @@ common.autofocus('#id_password');
 common.autofocus('#id_username');
 {% endif %}
 </script>
-semmle-extractor-options: --tolerate-parse-errors

--- a/javascript/ql/test/query-tests/filters/ClassifyFiles/tmpl2.html
+++ b/javascript/ql/test/query-tests/filters/ClassifyFiles/tmpl2.html
@@ -5,4 +5,3 @@
     {{/config}}
   }
 </script>
-semmle-extractor-options: --tolerate-parse-errors

--- a/javascript/ql/test/tutorials/Introducing the JavaScript libraries/m.js
+++ b/javascript/ql/test/tutorials/Introducing the JavaScript libraries/m.js
@@ -1,2 +1,2 @@
-// semmle-extractor-options: --platform
-// semmle-extractor-options: node
+require("process")
+;

--- a/javascript/ql/test/tutorials/Introducing the JavaScript libraries/options
+++ b/javascript/ql/test/tutorials/Introducing the JavaScript libraries/options
@@ -1,0 +1,1 @@
+semmle-extractor-options: --tolerate-parse-errors


### PR DESCRIPTION
I removed `--experimental` options that are no longer required. In fact, I think it would make sense for qltest to always pass `--experimental` (like LGTM does), but that is for a separate PR.

The options `--externs`, `--platform node` and `--source-type module` apply to a single file and hence cannot easily be replaced with `options` file. However, in all three cases the same behaviour can be achieved by adding a comment/code snippet, so that's what I've done.