### PR TITLE
C++/C#: Fix getIRTypeForPRValue join order

### DIFF
--- a/cpp/ql/src/semmle/code/cpp/ir/implementation/IRType.qll
+++ b/cpp/ql/src/semmle/code/cpp/ir/implementation/IRType.qll
@@ -42,6 +42,10 @@ class IRType extends TIRType {
    *
    * This will hold for all `IRType` objects except `IRUnknownType`.
    */
+  // This predicate is overridden with `pragma[noinline]` in every leaf subclass.
+  // This allows callers to ask for things like _the_ floating-point type of
+  // size 4 without getting a join that first finds all types of size 4 and
+  // _then_ restricts them to floating-point types.
   int getByteSize() { none() }
 
   /**
@@ -104,8 +108,6 @@ private class IRSizedType extends IRType {
     this = TIRFunctionAddressType(byteSize) or
     this = TIROpaqueType(_, byteSize)
   }
-
-  final override int getByteSize() { result = byteSize }
 }
 
 /**
@@ -117,6 +119,9 @@ class IRBooleanType extends IRSizedType, TIRBooleanType {
   final override Language::LanguageType getCanonicalLanguageType() {
     result = Language::getCanonicalBooleanType(byteSize)
   }
+
+  pragma[noinline]
+  final override int getByteSize() { result = byteSize }
 }
 
 /**
@@ -141,6 +146,9 @@ class IRSignedIntegerType extends IRNumericType, TIRSignedIntegerType {
   final override Language::LanguageType getCanonicalLanguageType() {
     result = Language::getCanonicalSignedIntegerType(byteSize)
   }
+
+  pragma[noinline]
+  final override int getByteSize() { result = byteSize }
 }
 
 /**
@@ -153,6 +161,9 @@ class IRUnsignedIntegerType extends IRNumericType, TIRUnsignedIntegerType {
   final override Language::LanguageType getCanonicalLanguageType() {
     result = Language::getCanonicalUnsignedIntegerType(byteSize)
   }
+
+  pragma[noinline]
+  final override int getByteSize() { result = byteSize }
 }
 
 /**
@@ -164,6 +175,9 @@ class IRFloatingPointType extends IRNumericType, TIRFloatingPointType {
   final override Language::LanguageType getCanonicalLanguageType() {
     result = Language::getCanonicalFloatingPointType(byteSize)
   }
+
+  pragma[noinline]
+  final override int getByteSize() { result = byteSize }
 }
 
 /**
@@ -178,6 +192,9 @@ class IRAddressType extends IRSizedType, TIRAddressType {
   final override Language::LanguageType getCanonicalLanguageType() {
     result = Language::getCanonicalAddressType(byteSize)
   }
+
+  pragma[noinline]
+  final override int getByteSize() { result = byteSize }
 }
 
 /**
@@ -190,6 +207,9 @@ class IRFunctionAddressType extends IRSizedType, TIRFunctionAddressType {
   final override Language::LanguageType getCanonicalLanguageType() {
     result = Language::getCanonicalFunctionAddressType(byteSize)
   }
+
+  pragma[noinline]
+  final override int getByteSize() { result = byteSize }
 }
 
 /**
@@ -218,6 +238,9 @@ class IROpaqueType extends IRSizedType, TIROpaqueType {
    * same size.
    */
   final Language::OpaqueTypeTag getTag() { result = tag }
+
+  pragma[noinline]
+  final override int getByteSize() { result = byteSize }
 }
 
 module IRTypeSanity {

--- a/csharp/ql/src/semmle/code/csharp/ir/implementation/IRType.qll
+++ b/csharp/ql/src/semmle/code/csharp/ir/implementation/IRType.qll
@@ -42,6 +42,10 @@ class IRType extends TIRType {
    *
    * This will hold for all `IRType` objects except `IRUnknownType`.
    */
+  // This predicate is overridden with `pragma[noinline]` in every leaf subclass.
+  // This allows callers to ask for things like _the_ floating-point type of
+  // size 4 without getting a join that first finds all types of size 4 and
+  // _then_ restricts them to floating-point types.
   int getByteSize() { none() }
 
   /**
@@ -104,8 +108,6 @@ private class IRSizedType extends IRType {
     this = TIRFunctionAddressType(byteSize) or
     this = TIROpaqueType(_, byteSize)
   }
-
-  final override int getByteSize() { result = byteSize }
 }
 
 /**
@@ -117,6 +119,9 @@ class IRBooleanType extends IRSizedType, TIRBooleanType {
   final override Language::LanguageType getCanonicalLanguageType() {
     result = Language::getCanonicalBooleanType(byteSize)
   }
+
+  pragma[noinline]
+  final override int getByteSize() { result = byteSize }
 }
 
 /**
@@ -141,6 +146,9 @@ class IRSignedIntegerType extends IRNumericType, TIRSignedIntegerType {
   final override Language::LanguageType getCanonicalLanguageType() {
     result = Language::getCanonicalSignedIntegerType(byteSize)
   }
+
+  pragma[noinline]
+  final override int getByteSize() { result = byteSize }
 }
 
 /**
@@ -153,6 +161,9 @@ class IRUnsignedIntegerType extends IRNumericType, TIRUnsignedIntegerType {
   final override Language::LanguageType getCanonicalLanguageType() {
     result = Language::getCanonicalUnsignedIntegerType(byteSize)
   }
+
+  pragma[noinline]
+  final override int getByteSize() { result = byteSize }
 }
 
 /**
@@ -164,6 +175,9 @@ class IRFloatingPointType extends IRNumericType, TIRFloatingPointType {
   final override Language::LanguageType getCanonicalLanguageType() {
     result = Language::getCanonicalFloatingPointType(byteSize)
   }
+
+  pragma[noinline]
+  final override int getByteSize() { result = byteSize }
 }
 
 /**
@@ -178,6 +192,9 @@ class IRAddressType extends IRSizedType, TIRAddressType {
   final override Language::LanguageType getCanonicalLanguageType() {
     result = Language::getCanonicalAddressType(byteSize)
   }
+
+  pragma[noinline]
+  final override int getByteSize() { result = byteSize }
 }
 
 /**
@@ -190,6 +207,9 @@ class IRFunctionAddressType extends IRSizedType, TIRFunctionAddressType {
   final override Language::LanguageType getCanonicalLanguageType() {
     result = Language::getCanonicalFunctionAddressType(byteSize)
   }
+
+  pragma[noinline]
+  final override int getByteSize() { result = byteSize }
 }
 
 /**
@@ -218,6 +238,9 @@ class IROpaqueType extends IRSizedType, TIROpaqueType {
    * same size.
    */
   final Language::OpaqueTypeTag getTag() { result = tag }
+
+  pragma[noinline]
+  final override int getByteSize() { result = byteSize }
 }
 
 module IRTypeSanity {


### PR DESCRIPTION
This predicate was taking 39s on a snapshot of Facebook Fizz because it had disjuncts like this:

    43685     ~0%     {1} r34 = JOIN Type::FunctionPointerIshType#f AS L WITH Type::Type::getUnspecifiedType_dispred#ff_10#join_rhs AS R ON FIRST 1 OUTPUT R.<1>
    43685     ~1%     {2} r35 = JOIN r34 WITH CppType::getTypeSize#ff AS R ON FIRST 1 OUTPUT R.<1>, r34.<0>
    170371500 ~2%     {2} r36 = JOIN r35 WITH IRType::IRSizedType#ff_10#join_rhs AS R ON FIRST 1 OUTPUT R.<1>, r35.<1>
    43685     ~6%     {2} r37 = JOIN r36 WITH IRType::IRFunctionAddressType#class#ff AS R ON FIRST 1 OUTPUT r36.<1>, r36.<0>

Instead of fixing the joins in `getIRTypeForPRValue` itself, I've changed the `IRType::getByteSize` predicate such that the optimiser knows how to join with it efficiently.

The disjunct shown above now looks like this instead:

    43685  ~0%     {1} r26 = JOIN Type::FunctionPointerIshType#f AS L WITH Type::Type::getUnspecifiedType_dispred#ff_10#join_rhs AS R ON FIRST 1 OUTPUT R.<1>
    43685  ~1%     {2} r27 = JOIN r26 WITH CppType::getTypeSize#ff AS R ON FIRST 1 OUTPUT R.<1>, r26.<0>
    43685  ~6%     {2} r28 = JOIN r27 WITH IRType::IRFunctionAddressType::getByteSize#ff_10#join_rhs AS R ON FIRST 1 OUTPUT r27.<1>, R.<1>