### PR TITLE
CPP: Add tests of NtohlArrayNoBoundOpenSource.ql.

### DIFF
--- a/cpp/ql/test/query-tests/Likely Bugs/Memory Management/Buffer Overflow/NtohlArrayNoBound/NtohlArrayNoBound.expected
+++ b/cpp/ql/test/query-tests/Likely Bugs/Memory Management/Buffer Overflow/NtohlArrayNoBound/NtohlArrayNoBound.expected
@@ -1,0 +1,8 @@
+| test.cpp:12:25:12:29 | call to ntohl | Unchecked use of data from network function $@ | test.cpp:12:25:12:29 | call to ntohl | call to ntohl |
+| test.cpp:21:26:21:29 | len2 | Unchecked use of data from network function $@ | test.cpp:10:16:10:20 | call to ntohl | call to ntohl |
+| test.cpp:31:26:31:29 | len2 | Unchecked use of data from network function $@ | test.cpp:10:16:10:20 | call to ntohl | call to ntohl |
+| test.cpp:61:26:61:29 | len2 | Unchecked use of data from network function $@ | test.cpp:10:16:10:20 | call to ntohl | call to ntohl |
+| test.cpp:64:9:64:12 | len2 | Unchecked use of data from network function $@ | test.cpp:10:16:10:20 | call to ntohl | call to ntohl |
+| test.cpp:73:10:73:13 | lens | Unchecked use of data from network function $@ | test.cpp:10:16:10:20 | call to ntohl | call to ntohl |
+| test.cpp:86:10:86:13 | len3 | Unchecked use of data from network function $@ | test.cpp:85:10:85:14 | call to ntohl | call to ntohl |
+| test.cpp:94:9:94:11 | len | Unchecked use of data from network function $@ | test.cpp:99:8:99:12 | call to ntohl | call to ntohl |

--- a/cpp/ql/test/query-tests/Likely Bugs/Memory Management/Buffer Overflow/NtohlArrayNoBound/NtohlArrayNoBound.qlref
+++ b/cpp/ql/test/query-tests/Likely Bugs/Memory Management/Buffer Overflow/NtohlArrayNoBound/NtohlArrayNoBound.qlref
@@ -1,0 +1,1 @@
+Likely Bugs/Memory Management/Buffer Overflow/NtohlArrayNoBoundOpenSource.ql

--- a/cpp/ql/test/query-tests/Likely Bugs/Memory Management/Buffer Overflow/NtohlArrayNoBound/test.cpp
+++ b/cpp/ql/test/query-tests/Likely Bugs/Memory Management/Buffer Overflow/NtohlArrayNoBound/test.cpp
@@ -1,0 +1,100 @@
+
+typedef unsigned int size_t;
+void *memcpy(void *s1, const void *s2, size_t n);
+size_t strlen(const char *s);
+int ntohl(int x);
+
+void test1(const char *source, size_t len)
+{
+	char buffer[256];
+	size_t len2 = ntohl(len);
+
+	memcpy(buffer, source, ntohl(len)); // BAD
+
+	if (len2 < 256)
+	{
+		memcpy(buffer, source, len2); // GOOD
+	}
+
+	if (source != 0)
+	{
+		memcpy(buffer, source, len2); // BAD
+	}
+
+	if ((len2 < 256) && (source != 0))
+	{
+		memcpy(buffer, source, len2); // GOOD
+	}
+
+	if ((len2 < 256) || (source != 0))
+	{
+		memcpy(buffer, source, len2); // BAD
+	}
+
+	if (len2 < 256)
+	{
+		if (source != 0)
+		{
+			memcpy(buffer, source, len2); // GOOD
+		}
+	}
+
+	if (len2 >= 256)
+	{
+		// fail
+	} else {
+		memcpy(buffer, source, len2); // GOOD
+	}
+
+	if (len2 + 1 < 256)
+	{
+		memcpy(buffer, source, len2 + 1); // GOOD
+	}
+
+	if (strlen(source) < 256)
+	{
+		memcpy(buffer, source, strlen(source)); // GOOD
+	}
+
+	if (strlen(source) < 256)
+	{
+		memcpy(buffer, source, len2); // BAD
+	}
+
+	buffer[len2] = 0; // BAD
+
+	if (len2 < 256)
+	{
+		buffer[len2] = 0; // GOOD
+	}
+
+	{
+		unsigned short lens = len2;
+		buffer[lens] = 0; // BAD
+	}
+
+	if (len2 < 256)
+	{
+		unsigned short lens = len2;
+		buffer[lens] = 0; // GOOD
+	}
+
+	size_t len3 = 0;
+	if (len3 < 256)
+	{
+		len3 = ntohl(len);
+		buffer[len3] = 0; // BAD
+	}
+}
+
+void test2(size_t len)
+{
+	char buffer[256];
+
+	buffer[len] = 0; // BAD
+}
+
+void test3(size_t len)
+{
+	test2(ntohl(len));
+}


### PR DESCRIPTION
Add tests of NtohlArrayNoBoundOpenSource.ql.

I looked into speeding up this query but made no gains; and with a suitably warmed up cache it turns out this query is reasonably quick already.