### PR TITLE
C++: Add test for template-params in attributes

### DIFF
--- a/cpp/ql/test/library-tests/attributes/template_param_attributes/test.cpp
+++ b/cpp/ql/test/library-tests/attributes/template_param_attributes/test.cpp
@@ -1,0 +1,8 @@
+template <int i>
+struct [[align(i)]] myStruct {
+    int j;
+};
+myStruct<128> s;
+
+template <int x> int foo() __attribute__((aligned(x))) { return 1; }
+int bar() { return foo<1024>(); }

--- a/cpp/ql/test/library-tests/attributes/template_param_attributes/test.expected
+++ b/cpp/ql/test/library-tests/attributes/template_param_attributes/test.expected
@@ -1,0 +1,4 @@
+| test.cpp:2:10:2:14 | align | test.cpp:2:16:2:16 | 128 |
+| test.cpp:2:10:2:14 | align | test.cpp:2:16:2:16 | i |
+| test.cpp:7:43:7:49 | aligned | test.cpp:7:51:7:51 | 1024 |
+| test.cpp:7:43:7:49 | aligned | test.cpp:7:51:7:51 | x |

--- a/cpp/ql/test/library-tests/attributes/template_param_attributes/test.ql
+++ b/cpp/ql/test/library-tests/attributes/template_param_attributes/test.ql
@@ -1,0 +1,5 @@
+import cpp
+
+from Attribute attr, AttributeArgument attrarg
+where attrarg = attr.getAnArgument()
+select attr, attrarg


### PR DESCRIPTION
Test for an internal extractor change (internal PR: https://git.semmle.com/Semmle/code/pull/35209)

Note that I haven't been able to generate a test which acts on variable templates.