### PR TITLE
1.22: Update for support info for CodeQL term change

### DIFF
--- a/docs/language/global-sphinx-files/_templates/layout.html
+++ b/docs/language/global-sphinx-files/_templates/layout.html
@@ -59,9 +59,9 @@
             </div>
             <div class="linkcontainer">
                 <div class="linkbar">
-                    <a href="https://help.semmle.com/QL/learn-ql/" target="_blank">Learn QL</a>
-                    <a href="https://help.semmle.com/QL/learn-ql/ql-training.html" target="_blank">QL for variant analysis</a>
-                    <a href="https://help.semmle.com/QL/ql-tools.html" target="_blank">QL tools</a>
+                    <a href="https://help.semmle.com/QL/learn-ql/" target="_blank">Learn CodeQL</a>
+                    <a href="https://help.semmle.com/QL/learn-ql/ql-training.html" target="_blank">Variant analysis</a>
+                    <a href="https://help.semmle.com/QL/ql-tools.html" target="_blank">Tools</a>
                     <a href="https://help.semmle.com/QL/ql-explore-queries.html" target="_blank">Queries</a>
                     <a href="https://help.semmle.com/QL/ql-reference-topics.html" target="_blank">Reference</a>
                     <a href="https://blog.semmle.com" target="_blank">Blog</a>
@@ -77,7 +77,7 @@
 <div class="wrapper">
     
     <div class="navBox" >
-         <p>Start writing QL in the <a href="https://lgtm.com/query">Query console</a> on <a href="https://lgtm.com">LGTM.com</a>.</p>
+         <p>Start writing queries in the <a href="https://lgtm.com/query">Query console</a> on <a href="https://lgtm.com">LGTM.com</a>.</p>
              
          <div id="searchbox" style="display: none" role="search">
                 <h3>Quick search</h3>

--- a/docs/language/support/conf.py
+++ b/docs/language/support/conf.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# QL and LGTM support info build configuration file, created 
+# CodeQL and LGTM support info build configuration file, created 
 # on Tuesday 19th February.
 #
 # This file is execfile()d with the current directory set to its

--- a/docs/language/support/framework-support.rst
+++ b/docs/language/support/framework-support.rst
@@ -1,7 +1,7 @@
 Frameworks and libraries
 ########################
 
-The QL libraries and queries in version |version| have been explicitly checked against the libraries and frameworks listed below.
+The libraries and queries in version |version| have been explicitly checked against the libraries and frameworks listed below.
 
 .. pull-quote::
 

--- a/docs/language/support/index.rst
+++ b/docs/language/support/index.rst
@@ -1,7 +1,7 @@
 Supported languages and frameworks
 ##################################
 
-These pages describe the languages and frameworks supported in the latest enterprise release of QL and LGTM. 
+These pages describe the languages and frameworks supported in the latest enterprise release of CodeQL and LGTM. (CodeQL was previously known as QL.) 
 Users of `LGTM.com <https://lgtm.com/>`_ may find that additional features are supported because it's updated more frequently.
 
 For details see:
@@ -11,4 +11,4 @@ For details see:
   language-support.rst
   framework-support.rst
 
-For details of the QL libraries, see `QL standard libraries <https://help.semmle.com/QL/ql-libraries.html>`_.
+For details of the CodeQL libraries, see `CodeQL standard libraries <https://help.semmle.com/QL/ql-libraries.html>`_.

--- a/docs/language/support/language-support.rst
+++ b/docs/language/support/language-support.rst
@@ -1,7 +1,8 @@
 Languages and compilers
 #######################
 
-QL and LGTM version |version| support analysis of the following languages compiled by the following compilers.
+CodeQL and LGTM version |version| support analysis of the following languages compiled by the following compilers.
+(CodeQL was previously known as QL.)
 
 Note that where there are several versions or dialects of a language, the supported variants are listed.
 If your code requires a particular version of a compiler, check that this version is included below. 


### PR DESCRIPTION
This updates the Sphinx project to match the currently published version of these pages. It also ports the global layout changes to the 1.22 branch.

Preview: http://docteam.internal.semmle.com/felicity/support-9nov2019-4

@jf205 - please can you review when time allows. (Initially, I had a link to the https://help.semmle.com/QL/learn-ql/terminology-note.html topic, but then I realized that that wasn't on this branch so removed it.)