### PR TITLE
C++: Suppress PointlessSelfComparison.ql on templates 

### DIFF
--- a/cpp/ql/src/Likely Bugs/Arithmetic/PointlessSelfComparison.ql
+++ b/cpp/ql/src/Likely Bugs/Arithmetic/PointlessSelfComparison.ql
@@ -19,6 +19,7 @@ where
   pointlessSelfComparison(cmp) and
   not nanTest(cmp) and
   not overflowTest(cmp) and
+  not cmp.isFromTemplateInstantiation(_) and
   not exists(MacroInvocation mi |
     // cmp is in mi
     mi.getAnExpandedElement() = cmp and

--- a/cpp/ql/test/query-tests/Likely Bugs/Arithmetic/BadAdditionOverflowCheck/PointlessSelfComparison.expected
+++ b/cpp/ql/test/query-tests/Likely Bugs/Arithmetic/BadAdditionOverflowCheck/PointlessSelfComparison.expected
@@ -1,9 +1,4 @@
-| templates.cpp:20:5:20:25 | ... < ... | Self comparison. |
-| templates.cpp:21:5:21:25 | ... < ... | Self comparison. |
-| templates.cpp:21:5:21:25 | ... < ... | Self comparison. |
-| templates.cpp:22:5:22:25 | ... < ... | Self comparison. |
-| templates.cpp:22:5:22:25 | ... < ... | Self comparison. |
-| templates.cpp:22:5:22:25 | ... < ... | Self comparison. |
+| templates.cpp:17:5:17:25 | ... < ... | Self comparison. |
 | test.cpp:13:11:13:21 | ... == ... | Self comparison. |
 | test.cpp:79:11:79:32 | ... == ... | Self comparison. |
 | test.cpp:83:10:83:15 | ... == ... | Self comparison. |

--- a/cpp/ql/test/query-tests/Likely Bugs/Arithmetic/BadAdditionOverflowCheck/PointlessSelfComparison.expected
+++ b/cpp/ql/test/query-tests/Likely Bugs/Arithmetic/BadAdditionOverflowCheck/PointlessSelfComparison.expected
@@ -1,3 +1,9 @@
+| templates.cpp:20:5:20:25 | ... < ... | Self comparison. |
+| templates.cpp:21:5:21:25 | ... < ... | Self comparison. |
+| templates.cpp:21:5:21:25 | ... < ... | Self comparison. |
+| templates.cpp:22:5:22:25 | ... < ... | Self comparison. |
+| templates.cpp:22:5:22:25 | ... < ... | Self comparison. |
+| templates.cpp:22:5:22:25 | ... < ... | Self comparison. |
 | test.cpp:13:11:13:21 | ... == ... | Self comparison. |
 | test.cpp:79:11:79:32 | ... == ... | Self comparison. |
 | test.cpp:83:10:83:15 | ... == ... | Self comparison. |

--- a/cpp/ql/test/query-tests/Likely Bugs/Arithmetic/BadAdditionOverflowCheck/templates.cpp
+++ b/cpp/ql/test/query-tests/Likely Bugs/Arithmetic/BadAdditionOverflowCheck/templates.cpp
@@ -1,0 +1,22 @@
+struct C1 {
+  static const int value = 5;
+};
+
+struct C2 {
+  static const int value = 6;
+};
+
+template<typename T1, typename T2>
+bool compareValues() {
+  // Not all instantiations have T1 and T2 equal. Even if that's the case for
+  // all instantiations in the program, there could still be more such
+  // instantiations outside.
+  return
+    T1::value < T2::value || // GOOD [FALSE POSITIVE]
+    T1::value < T1::value || // BAD
+    C1::value < C1::value ; // BAD
+}
+
+bool callCompareValues() {
+  return compareValues<C1, C2> || compareValues<C1, C1>();
+}

--- a/cpp/ql/test/query-tests/Likely Bugs/Arithmetic/BadAdditionOverflowCheck/templates.cpp
+++ b/cpp/ql/test/query-tests/Likely Bugs/Arithmetic/BadAdditionOverflowCheck/templates.cpp
@@ -12,8 +12,8 @@ bool compareValues() {
   // all instantiations in the program, there could still be more such
   // instantiations outside.
   return
-    T1::value < T2::value || // GOOD [FALSE POSITIVE]
-    T1::value < T1::value || // BAD
+    T1::value < T2::value || // GOOD
+    T1::value < T1::value || // BAD [NOT DETECTED]
     C1::value < C1::value ; // BAD
 }
 


### PR DESCRIPTION
This problem was spotted by @matt-gretton-dann. See https://github.slack.com/archives/CP0LHP150/p1573465693370500.