### PR TITLE
Python: Prevent bad magic in `Expr::pointsTo/1`.

### DIFF
--- a/python/ql/src/semmle/python/Exprs.qll
+++ b/python/ql/src/semmle/python/Exprs.qll
@@ -122,6 +122,7 @@ class Expr extends Expr_, AstNode {
 
     /** Holds if this expression might "point-to" to `value`.
      */
+    pragma [nomagic]
     predicate pointsTo(Value value) {
         this.pointsTo(value, _)
     }


### PR DESCRIPTION
For some reason, this problem is not apparent when running the query locally, but popped up on a `dist-compare`. Here are some of the salient aspects:

```
[2019-11-08 02:02:10] (1731s) Clause timing report:
[2019-11-08 02:02:10] (1731s)
[2019-11-08 02:02:10]
        UnusedImport.ql-9:m#Exprs::Expr::pointsTo_dispred#bf ..................... 28m41s
        UnusedImport.ql-9:UnusedImport::imported_module_used_in_doctest#f ........ 6.1s
        UnusedImport.ql-9:UnusedImport::imported_module_used_in_typehint#f ....... 2.7s
        UnusedImport.ql-9:AstExtended::AstNode::getAFlowNode_dispred#ff .......... 319ms
        UnusedImport.ql-9:UnusedImport::global_name_used#bb ...................... 196ms
```

And the corresponding RA for the offending predicate

```
  m#Exprs::Expr::pointsTo_dispred#bf(unique int this) :-
    {1} r1 = SCAN ObjectAPI::Value::forString#ff AS I OUTPUT I.<0>
    {1} r2 = STREAM DEDUP r1
    {3} r3 = JOIN r2 WITH Module::Module::getFile_dispred#ff AS R CARTESIAN PRODUCT OUTPUT R.<0>, r2.<0>, R.<1>
    {3} r4 = JOIN r3 WITH Stmts::Stmt::getScope_dispred#bf_10#join_rhs AS R ON FIRST 1 OUTPUT R.<1>, r3.<1>, r3.<2>
    {3} r5 = JOIN r4 WITH AstGenerated::Import_::getAName_dispred#ff AS R ON FIRST 1 OUTPUT R.<1>, r4.<1>, r4.<2>
    {3} r6 = JOIN r5 WITH AstGenerated::Alias_::getAsname_dispred#ff AS R ON FIRST 1 OUTPUT R.<1>, r5.<1>, r5.<2>
    {3} r7 = JOIN r6 WITH Exprs::Name::getId_dispred#bf AS R ON FIRST 1 OUTPUT r6.<1>, r6.<2>, (".*\b" ++ R.<1> ++ "\b.*")
    {3} r8 = JOIN r7 WITH PRIMITIVE regexpMatch#bb ON r7.<0>,r7.<2>
    {1} r9 = SCAN r8 OUTPUT r8.<1>
    {1} r10 = JOIN r9 WITH Files::Location::getFile_dispred#ff_10#join_rhs AS R ON FIRST 1 OUTPUT R.<1>
    {1} r11 = JOIN r10 WITH Exprs::Expr::getLocation_dispred#bf_10#join_rhs AS R ON FIRST 1 OUTPUT R.<1>
    {1} r12 = JOIN r11 WITH AstGenerated::Arguments_::getAnAnnotation_dispred#ff_1#join_rhs AS R ON FIRST 1 OUTPUT r11.<0>
    {1} r13 = JOIN r11 WITH AstGenerated::AnnAssign_::getAnnotation_dispred#ff_1#join_rhs AS R ON FIRST 1 OUTPUT r11.<0>
    {1} r14 = r12 \/ r13
    {1} r15 = SCAN AstGenerated::Alias_::getValue_dispred#ff AS I OUTPUT I.<1>
    {1} r16 = r14 \/ r15
    return r16
```
