### PR TITLE
Add `qlpack.yml` files for test folders.

### DIFF
--- a/cpp/ql/test/qlpack.yml
+++ b/cpp/ql/test/qlpack.yml
@@ -1,0 +1,3 @@
+name: codeql-cpp-tests
+version: 0.0.0
+libraryPathDependencies: codeql-cpp

--- a/csharp/ql/test/qlpack.yml
+++ b/csharp/ql/test/qlpack.yml
@@ -1,0 +1,3 @@
+name: codeql-csharp-tests
+version: 0.0.0
+libraryPathDependencies: codeql-csharp

--- a/java/ql/test/qlpack.yml
+++ b/java/ql/test/qlpack.yml
@@ -1,0 +1,3 @@
+name: codeql-java-tests
+version: 0.0.0
+libraryPathDependencies: codeql-java

--- a/javascript/ql/test/qlpack.yml
+++ b/javascript/ql/test/qlpack.yml
@@ -1,0 +1,3 @@
+name: codeql-javascript-tests
+version: 0.0.0
+libraryPathDependencies: codeql-javascript

--- a/python/ql/test/qlpack.yml
+++ b/python/ql/test/qlpack.yml
@@ -1,0 +1,3 @@
+name: codeql-python-tests
+version: 0.0.0
+libraryPathDependencies: codeql-python


### PR DESCRIPTION
As discussed on Slack, this allows the extension to correctly compile `.ql` and `.qll` files in these folders. 