### PR TITLE
QL packs: bump versions to 1.0.0

### DIFF
--- a/cpp/ql/src/qlpack.yml
+++ b/cpp/ql/src/qlpack.yml
@@ -1,4 +1,4 @@
 name: codeql-cpp
-version: 0.0.0
+version: 1.0.0
 dbscheme: semmlecode.cpp.dbscheme
 suites: codeql-suites

--- a/csharp/ql/src/qlpack.yml
+++ b/csharp/ql/src/qlpack.yml
@@ -1,4 +1,4 @@
 name: codeql-csharp
-version: 0.0.0
+version: 1.0.0
 dbscheme: semmlecode.csharp.dbscheme
 suites: codeql-suites

--- a/java/ql/src/qlpack.yml
+++ b/java/ql/src/qlpack.yml
@@ -1,4 +1,4 @@
 name: codeql-java
-version: 0.0.0
+version: 1.0.0
 dbscheme: config/semmlecode.dbscheme
 suites: codeql-suites

--- a/javascript/ql/src/qlpack.yml
+++ b/javascript/ql/src/qlpack.yml
@@ -1,4 +1,4 @@
 name: codeql-javascript
-version: 0.0.0
+version: 1.0.0
 dbscheme: semmlecode.javascript.dbscheme
 suites: codeql-suites

--- a/misc/legacy-support/cpp/qlpack.yml
+++ b/misc/legacy-support/cpp/qlpack.yml
@@ -1,4 +1,4 @@
 name: legacy-libraries-cpp
-version: 0.0.0
+version: 1.0.0
 libraryPathDependencies:
   - codeql-cpp

--- a/misc/legacy-support/csharp/qlpack.yml
+++ b/misc/legacy-support/csharp/qlpack.yml
@@ -1,4 +1,4 @@
 name: legacy-libraries-csharp
-version: 0.0.0
+version: 1.0.0
 libraryPathDependencies:
   - codeql-csharp

--- a/misc/legacy-support/java/qlpack.yml
+++ b/misc/legacy-support/java/qlpack.yml
@@ -1,4 +1,4 @@
 name: legacy-libraries-java
-version: 0.0.0
+version: 1.0.0
 libraryPathDependencies:
   - codeql-java

--- a/misc/legacy-support/javascript/qlpack.yml
+++ b/misc/legacy-support/javascript/qlpack.yml
@@ -1,4 +1,4 @@
 name: legacy-libraries-javascript
-version: 0.0.0
+version: 1.0.0
 libraryPathDependencies:
   - codeql-javascript

--- a/misc/legacy-support/python/qlpack.yml
+++ b/misc/legacy-support/python/qlpack.yml
@@ -1,4 +1,4 @@
 name: legacy-libraries-python
-version: 0.0.0
+version: 1.0.0
 libraryPathDependencies:
   - codeql-python

--- a/misc/suite-helpers/qlpack.yml
+++ b/misc/suite-helpers/qlpack.yml
@@ -1,2 +1,2 @@
 name: codeql-suite-helpers
-version: 0.0.0
+version: 1.0.0

--- a/python/ql/src/qlpack.yml
+++ b/python/ql/src/qlpack.yml
@@ -1,4 +1,4 @@
 name: codeql-python
-version: 0.0.0
+version: 1.0.0
 dbscheme: semmlecode.python.dbscheme
 suites: codeql-suites


### PR DESCRIPTION
The syntax seems to be fairly stable now, so let's bump the version to 1.0.0.