### PR TITLE
Java: Add ConditionalExpr to overflow candidate pattern.

### DIFF
--- a/java/ql/src/Likely Bugs/Comparison/UselessComparisonTest.ql
+++ b/java/ql/src/Likely Bugs/Comparison/UselessComparisonTest.ql
@@ -132,6 +132,11 @@ Expr overFlowCand() {
   result.(AssignExpr).getRhs() = overFlowCand()
   or
   result.(LocalVariableDeclExpr).getInit() = overFlowCand()
+  or
+  exists(ConditionalExpr c | c = result |
+    c.getTrueExpr() = overFlowCand() and
+    c.getFalseExpr() = overFlowCand()
+  )
 }
 
 predicate positiveOrNegative(Expr e) { positive(e) or negative(e) }

--- a/java/ql/test/query-tests/UselessComparisonTest/A.java
+++ b/java/ql/test/query-tests/UselessComparisonTest/A.java
@@ -121,6 +121,11 @@ public class A {
     }
   }
 
+  void overflowTests2(int[] a, boolean b) {
+    int newlen = b ? (a.length + 1) << 1 : (a.length >> 1) + a.length;
+    if (newlen < 0) overflow();
+  }
+
   static final long VAL = 100L;
 
   long overflowAwareIncrease(long x) {


### PR DESCRIPTION
This updates the overflow candidate patterns in `UselessComparisonTest.ql` to catch a few more tests involving `ConditionalExpr`. This fixes the FP reported on https://github.com/Semmle/ql/issues/2234