### PR TITLE
remove duplicate reflectiveCallNode method, and removing redundant getExpr() method

### DIFF
--- a/javascript/ql/src/semmle/javascript/dataflow/Configuration.qll
+++ b/javascript/ql/src/semmle/javascript/dataflow/Configuration.qll
@@ -308,7 +308,7 @@ abstract class BarrierGuardNode extends DataFlow::Node {
     exists(SsaRefinementNode ref, boolean outcome |
       nd = DataFlow::ssaDefinitionNode(ref) and
       forex(SsaVariable input | input = ref.getAnInput() |
-        getExpr() = ref.getGuard().getTest() and
+        getEnclosingExpr() = ref.getGuard().getTest() and
         outcome = ref.getGuard().(ConditionGuardNode).getOutcome() and
         barrierGuardBlocksExpr(this, outcome, input.getAUse(), label)
       )
@@ -317,18 +317,11 @@ abstract class BarrierGuardNode extends DataFlow::Node {
     // 2) `nd` is an instance of an access path `p`, and dominated by a barrier for `p`
     exists(AccessPath p, BasicBlock bb, ConditionGuardNode cond, boolean outcome |
       nd = DataFlow::valueNode(p.getAnInstanceIn(bb)) and
-      getExpr() = cond.getTest() and
+      getEnclosingExpr() = cond.getTest() and
       outcome = cond.getOutcome() and
       barrierGuardBlocksAccessPath(this, outcome, p, label) and
       cond.dominates(bb)
     )
-  }
-
-  /** Gets the corresponding expression, including that of reflective calls. */
-  private Expr getExpr() {
-    result = asExpr()
-    or
-    this = DataFlow::reflectiveCallNode(result)
   }
 
   /**

--- a/javascript/ql/src/semmle/javascript/dataflow/DataFlow.qll
+++ b/javascript/ql/src/semmle/javascript/dataflow/DataFlow.qll
@@ -1004,16 +1004,6 @@ module DataFlow {
    * callee, `x` as the receiver, and `y` as the first argument.
    */
   DataFlow::InvokeNode reflectiveCallNode(InvokeExpr expr) { result = TReflectiveCallNode(expr, _) }
-  
-
-  /**
-   * Gets a data flow node representing the underlying call performed by the given
-   * call to `Function.prototype.call` or `Function.prototype.apply`.
-   *
-   * For example, for an expression `fn.call(x, y)`, this gets a call node with `fn` as the
-   * callee, `x` as the receiver, and `y` as the first argument.
-   */
-  DataFlow::InvokeNode reflectiveCallNode(InvokeExpr expr) { result = TReflectiveCallNode(expr, _) }
 
   /**
    * Provides classes representing various kinds of calls.


### PR DESCRIPTION
Merging https://github.com/Semmle/ql/pull/2297 introduced a semantic conflict. 

Specifically the `reflectiveCallNode` method was duplicated. 

I also went and changed the code from https://github.com/Semmle/ql/pull/2251 to use the new `DataFlow::getEnclosingExpr()` to remove some related code-duplication. 

Lets see that the tests pass before pushing the merge button. 