### PR TITLE
C++/Docs: add example based on NtohlArrayNoBound

### DIFF
--- a/docs/language/learn-ql/cpp/dataflow.rst
+++ b/docs/language/learn-ql/cpp/dataflow.rst
@@ -244,7 +244,7 @@ The following data flow configuration tracks data flow from environment variable
    select fopen, "This 'fopen' uses data from $@.",
      getenv, "call to 'getenv'"
 
-The following taint tracking configuration tracks data from a call to ``ntohl`` to an array index operation. It uses the ``Guards`` library to recognize expressions that have been bounds checked and avoid propagating taint through them. It also uses ``isAdditionalTaintStep`` to add flow from loop bounds to loop indexes.
+The following taint-tracking configuration tracks data from a call to ``ntohl`` to an array index operation. It uses the ``Guards`` library to recognize expressions that have been bounds-checked and defines ``isSanitizer`` to prevent taint from propagating through them. It also uses ``isAdditionalTaintStep`` to add flow from loop bounds to loop indexes.
 
 .. code-block:: ql
 

--- a/docs/language/learn-ql/cpp/dataflow.rst
+++ b/docs/language/learn-ql/cpp/dataflow.rst
@@ -244,7 +244,7 @@ The following data flow configuration tracks data flow from environment variable
    select fopen, "This 'fopen' uses data from $@.",
      getenv, "call to 'getenv'"
 
-The following taint-tracking configuration tracks data from a call to ``ntohl`` to an array index operation. It uses the ``Guards`` library to recognize expressions that have been bounds-checked and defines ``isSanitizer`` to prevent taint from propagating through them. It also uses ``isAdditionalTaintStep`` to add flow from loop bounds to loop indexes.
+The following taint-tracking configuration tracks data from a call to ``ntohl`` to an array index operation. It uses the ``Guards`` library to recognize expressions that have been bounds-checked, and defines ``isSanitizer`` to prevent taint from propagating through them. It also uses ``isAdditionalTaintStep`` to add flow from loop bounds to loop indexes.
 
 .. code-block:: ql
 

--- a/docs/language/learn-ql/cpp/dataflow.rst
+++ b/docs/language/learn-ql/cpp/dataflow.rst
@@ -244,6 +244,41 @@ The following data flow configuration tracks data flow from environment variable
    select fopen, "This 'fopen' uses data from $@.",
      getenv, "call to 'getenv'"
 
+The following taint tracking configuration tracks data from a call to ``ntohl`` to an array index operation. It uses the ``Guards`` library to recognize expressions that have been bounds checked and avoid propagating taint through them.
+
+.. code-block:: ql
+
+  import cpp
+  import semmle.code.cpp.controlflow.Guards
+  import semmle.code.cpp.dataflow.TaintTracking
+
+  class NetworkToBufferSizeConfiguration extends DataFlow::Configuration {
+    NetworkToBufferSizeConfiguration() { this = "NetworkToBufferSizeConfiguration" }
+
+    override predicate isSource(DataFlow::Node node) {
+      node.asExpr().(FunctionCall).getTarget().hasGlobalName("ntohl")
+    }
+
+    override predicate isSink(DataFlow::Node node) {
+      exists(ArrayExpr ae | node.asExpr() = ae.getArrayOffset())
+    }
+
+    override predicate isBarrier(DataFlow::Node node) {
+      exists(GuardCondition gc, Variable v |
+        gc.getAChild*() = v.getAnAccess() and
+        node.asExpr() = v.getAnAccess() and
+        gc.controls(node.asExpr().getBasicBlock(), _)
+      )
+    }
+  }
+
+  from DataFlow::Node ntohl, DataFlow::Node offset, NetworkToBufferSizeConfiguration conf
+  where conf.hasFlow(ntohl, offset)
+  select offset, "This array offset may be influenced by $@.", ntohl,
+    "converted data from the network"
+
+
+
 Exercises
 ~~~~~~~~~
 


### PR DESCRIPTION
This adds a simple example of using the taint tracking library, including overriding the `isSanitizer` predicate, to the data flow library documentation.