### PR TITLE
Python: Add AST classes for walrus operator.

### DIFF
--- a/python/ql/src/semmle/python/AstGenerated.qll
+++ b/python/ql/src/semmle/python/AstGenerated.qll
@@ -93,6 +93,26 @@ library class Assign_ extends @py_Assign, Stmt {
 
 }
 
+library class AssignExpr_ extends @py_AssignExpr, Expr {
+
+
+    /** Gets the value of this assignment expression. */
+    Expr getValue() {
+        py_exprs(result, _, this, 2)
+    }
+
+
+    /** Gets the target of this assignment expression. */
+    Expr getTarget() {
+        py_exprs(result, _, this, 3)
+    }
+
+    override string toString() {
+        result = "AssignExpr"
+    }
+
+}
+
 library class Attribute_ extends @py_Attribute, Expr {
 
 

--- a/python/ql/src/semmle/python/Exprs.qll
+++ b/python/ql/src/semmle/python/Exprs.qll
@@ -128,6 +128,14 @@ class Expr extends Expr_, AstNode {
 
 }
 
+/** An assignment expression, such as `x := y` */
+class AssignExpr extends AssignExpr_ {
+    override Expr getASubExpression() {
+        result = this.getValue() or
+        result = this.getTarget()
+    }
+}
+
 /** An attribute expression, such as `value.attr` */
 class Attribute extends Attribute_ {
 


### PR DESCRIPTION
Happily, these were already present in the `dbscheme`.