### PR TITLE
C#: Tests for default interface methods

### DIFF
--- a/csharp/ql/test/library-tests/csharp8/DefaultInterfaceMethods.cs
+++ b/csharp/ql/test/library-tests/csharp8/DefaultInterfaceMethods.cs
@@ -1,0 +1,27 @@
+using System;
+
+interface IPerson
+{
+    string Name { get; }
+
+    string Greeting
+    {
+        get => "Hello";
+        set { }
+    }
+
+    string Greet(string name) => Greeting + " " + name;
+
+    string GreetingString => Greet(Name);
+
+    void Greet();
+}
+
+class Person : IPerson
+{
+    public string Name => "Petra";
+
+    string IPerson.Greeting { get => "Howdy"; set { } }
+
+    public void Greet() { }
+}

--- a/csharp/ql/test/library-tests/csharp8/DefaultInterfaceMethods.expected
+++ b/csharp/ql/test/library-tests/csharp8/DefaultInterfaceMethods.expected
@@ -1,0 +1,4 @@
+| DefaultInterfaceMethods.cs:9:9:9:11 | get_Greeting |
+| DefaultInterfaceMethods.cs:10:9:10:11 | set_Greeting |
+| DefaultInterfaceMethods.cs:13:12:13:16 | Greet |
+| DefaultInterfaceMethods.cs:15:30:15:40 | get_GreetingString |

--- a/csharp/ql/test/library-tests/csharp8/DefaultInterfaceMethods.ql
+++ b/csharp/ql/test/library-tests/csharp8/DefaultInterfaceMethods.ql
@@ -1,6 +1,6 @@
 import csharp
 
-class DefaultInterfaceMethod extends Method {
+class DefaultInterfaceMethod extends Callable {
   DefaultInterfaceMethod() {
     this.hasBody() and
     this.getDeclaringType() instanceof Interface


### PR DESCRIPTION
~~To be merged after extractor upgrade to .NET Core 3.0. Only the last commit needs to be reviewed.~~

This PR only contains tests for default interface methods.

It's possible that further down the line, various assumptions about interface methods will need to be changed for example in the dispatch library, but that is future work.

Does it need a change note?