### PR TITLE
Java: Fix a number of performance issues when toString is cached.

### DIFF
--- a/java/ql/src/Violations of Best Practice/Boxed Types/BoxedVariable.ql
+++ b/java/ql/src/Violations of Best Practice/Boxed Types/BoxedVariable.ql
@@ -39,6 +39,9 @@ predicate notDeliberatelyBoxed(LocalBoxedVar v) {
   )
 }
 
+pragma[nomagic]
+int callableGetNumberOfParameters(Callable c) { result = c.getNumberOfParameters() }
+
 /**
  * Replacing the type of a boxed variable with the corresponding primitive type may affect
  * overload resolution. If this is the case then the boxing is most likely intentional and
@@ -52,7 +55,7 @@ predicate affectsOverload(LocalBoxedVar v) {
     c1.getParameterType(i) instanceof RefType and
     c2.getParameterType(i) instanceof PrimitiveType and
     c1.getName() = c2.getName() and
-    c1.getNumberOfParameters() = c2.getNumberOfParameters()
+    callableGetNumberOfParameters(c1) = callableGetNumberOfParameters(c2)
   )
 }
 

--- a/java/ql/src/semmle/code/Location.qll
+++ b/java/ql/src/semmle/code/Location.qll
@@ -84,6 +84,7 @@ class Top extends @top {
   int getNumberOfCommentLines() { numlines(this, _, _, result) }
 
   /** Gets a textual representation of this element. */
+  cached
   string toString() { hasName(this, result) }
 }
 

--- a/java/ql/src/semmle/code/java/deadcode/DeadCode.qll
+++ b/java/ql/src/semmle/code/java/deadcode/DeadCode.qll
@@ -301,7 +301,7 @@ class RootdefCallable extends Callable {
   }
 }
 
-pragma[noinline]
+pragma[nomagic]
 private predicate overrideAccess(Callable c, int i) {
   exists(Method m | m.overridesOrInstantiates+(c) | exists(m.getParameter(i).getAnAccess()))
 }


### PR DESCRIPTION
This fixes the performance of `UselessParameter.ql`, `BoxedVariable.ql` and `FLinesOfCommentedCode.ql` on jdk11 when `toString` is being cached as reported on https://github.com/Semmle/ql/pull/2204.  There were two cases of bad magic being introduced.  The predicate `jsniComment` was a bit different in that it was already badly join-ordered, but wasn't being evaluated due to a sentinel check - caching `toString` somehow changed this, so it was being evaluated (to 0 tuples).