### PR TITLE
JS: fix the check for an "mjs" extension on an extensionless file

### DIFF
--- a/javascript/ql/src/semmle/javascript/NodeJS.qll
+++ b/javascript/ql/src/semmle/javascript/NodeJS.qll
@@ -166,7 +166,7 @@ class Require extends CallExpr, Import {
     exists(RequireVariable req |
       this.getCallee() = req.getAnAccess() and
       // `mjs` files explicitly disallow `require`
-      getFile().getExtension() != "mjs"
+      not getFile().getExtension() = "mjs"
     )
   }
 


### PR DESCRIPTION
This bugfix allows us to resolve `require`-imports in files without extensions.

The fix enables us to flag: CVE-2018-16479.

An evaluation is on the way.

It is (apparently) tricky to make qltest test the fix, but it has been confirmed locally with `codeql ...` invocations that this fix works.

I am opening this PR now to get it into the 1.23 workflow.