### PR TITLE
README.md: Don't speak of QL4E anymore

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ This open source repository contains the standard CodeQL libraries and queries t
 ## How do I learn CodeQL and run queries?
 
 There is [extensive documentation](https://help.semmle.com/QL/learn-ql/) on getting started with writing CodeQL.
-You can use the [interactive query console](https://lgtm.com/help/lgtm/using-query-console) on LGTM.com or the [CodeQL for Visual Studio Code](https://lgtm.com/help/lgtm/running-queries-ide) extension to try out your queries on any open source project that's currently being analyzed.
+You can use the [interactive query console](https://lgtm.com/help/lgtm/using-query-console) on LGTM.com or the [CodeQL for Visual Studio Code](https://help.semmle.com/codeql/codeql-for-vscode.html) extension to try out your queries on any open source project that's currently being analyzed.
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ This open source repository contains the standard CodeQL libraries and queries t
 ## How do I learn CodeQL and run queries?
 
 There is [extensive documentation](https://help.semmle.com/QL/learn-ql/) on getting started with writing CodeQL.
-You can use the [interactive query console](https://lgtm.com/help/lgtm/using-query-console) on LGTM.com or the [QL for Eclipse](https://lgtm.com/help/lgtm/running-queries-ide) plugin to try out your queries on any open source project that's currently being analyzed.
+You can use the [interactive query console](https://lgtm.com/help/lgtm/using-query-console) on LGTM.com or the [CodeQL for Visual Studio Code](https://lgtm.com/help/lgtm/running-queries-ide) extension to try out your queries on any open source project that's currently being analyzed.
 
 ## Contributing
 


### PR DESCRIPTION
The _target_ of this link in `README.md` has been updated to recommend the VSC plugin, but the link text still says Eclipse.

(Perhaps this ought to go to 1.23).