### PR TITLE
CodeQL query to check for insecure MaxLengthRequest values in ASP.NET applications

### DIFF
--- a/csharp/ql/src/Security Features/CWE-016/ASPNetMaxRequestLength.qhelp
+++ b/csharp/ql/src/Security Features/CWE-016/ASPNetMaxRequestLength.qhelp
@@ -3,56 +3,45 @@
   "qhelp.dtd">
 <qhelp>
 
-	<overview>
-		<p>
-			The
-			<code>maxRequestLength</code>
-			attribute sets the limit for the input stream buffering
-			threshold in
-			KB. Attackers can use large requests to cause denial-of-service
-			attacks.
-		</p>
-	</overview>
-	<recommendation>
+  <overview>
+    <p>
+      The <code>maxRequestLength</code> attribute sets the limit for the input
+      stream buffering threshold in KB. Attackers can use large requests to cause
+      denial-of-service attacks.
+    </p>
+  </overview>
+  <recommendation>
 
-		<p>
-			The recommended value is 4096 KB but you should try setting it as
-			small
-			as possible according
-			to business requirements.
-		</p>
+    <p>
+      The recommended value is 4096 KB but you should try setting it as
+      small as possible according to business requirements.
+    </p>
 
-	</recommendation>
-	<example>
+  </recommendation>
+  <example>
 
-		<p>
-			The following example shows the
-			<code>maxRequestLength</code>
-			attribute set to a high value
-			(255 MB) in a
-			<code>Web.config</code>
-			file for ASP.NET:
-		</p>
+    <p>
+      The following example shows the <code>maxRequestLength</code>
+      attribute set to a high value (255 MB) in a <code>Web.config</code>
+      file for ASP.NET:
+    </p>
 
-		<sample src="Web.config.ASPNetMaxRequestLength.bad" />
+    <sample src="Web.config.ASPNetMaxRequestLength.bad" />
 
-		<p>
-			Unless such a high value is strictly needed, it is better to set
-			the
-			recommended value (4096 KB):
-		</p>
+    <p>
+      Unless such a high value is strictly needed, it is better to set
+      the recommended value (4096 KB):
+    </p>
 
-		<sample src="Web.config.ASPNetMaxRequestLength.good" />
+    <sample src="Web.config.ASPNetMaxRequestLength.good" />
 
-	</example>
+  </example>
 
-	<references>
+  <references>
 
-		<li>
-			.NET API:
-			<a
-				href="https://docs.microsoft.com/en-us/dotnet/api/system.web.configuration.httpruntimesection.maxrequestlength?view=netframework-4.8">MaxRequestLength limit to prevent denial of service attacks</a>
-			.
-		</li>
-	</references>
+    <li>
+      MSDN:
+      <a href="https://docs.microsoft.com/en-us/dotnet/api/system.web.configuration.httpruntimesection.maxrequestlength?view=netframework-4.8">HttpRuntimeSection.MaxRequestLength Property</a>.
+    </li>
+  </references>
 </qhelp>

--- a/csharp/ql/src/Security Features/CWE-016/ASPNetMaxRequestLength.qhelp
+++ b/csharp/ql/src/Security Features/CWE-016/ASPNetMaxRequestLength.qhelp
@@ -1,0 +1,55 @@
+<!DOCTYPE qhelp PUBLIC
+  "-//Semmle//qhelp//EN"
+  "qhelp.dtd">
+<qhelp>
+
+	<overview>
+		<p>
+			The
+			<code>maxRequestLength</code>
+			attribute sets the limit for the input stream buffering
+			threshold in KB. Attackers can use large requests to cause denial-of-service
+			attacks.
+		</p>
+	</overview>
+	<recommendation>
+
+		<p>
+			The recommended value is 4096 KB but you should try setting it as small
+			as possible according
+			to business requirements.
+		</p>
+
+	</recommendation>
+	<example>
+
+		<p>
+			The following example shows the
+			<code>maxRequestLength</code>
+			attribute set to a high value
+			(255 MB) in a
+			<code>Web.config</code>
+			file for ASP.NET:
+		</p>
+
+		<sample src="Web.config.ASPNetMaxRequestLength.bad" />
+
+		<p>
+			Unless such a high value is strictly needed, it is better to set the
+			recommended value (4096 KB):
+		</p>
+
+		<sample src="Web.config.ASPNetMaxRequestLength.good" />
+
+	</example>
+
+	<references>
+
+		<li>
+			.NET API:
+			<a
+				href="https://docs.microsoft.com/en-us/dotnet/api/system.web.configuration.httpruntimesection.maxrequestlength?view=netframework-4.8">MaxRequestLength limit to prevent denial of service attacks</a>
+			.
+		</li>
+	</references>
+</qhelp>

--- a/csharp/ql/src/Security Features/CWE-016/ASPNetMaxRequestLength.qhelp
+++ b/csharp/ql/src/Security Features/CWE-016/ASPNetMaxRequestLength.qhelp
@@ -8,14 +8,16 @@
 			The
 			<code>maxRequestLength</code>
 			attribute sets the limit for the input stream buffering
-			threshold in KB. Attackers can use large requests to cause denial-of-service
+			threshold in
+			KB. Attackers can use large requests to cause denial-of-service
 			attacks.
 		</p>
 	</overview>
 	<recommendation>
 
 		<p>
-			The recommended value is 4096 KB but you should try setting it as small
+			The recommended value is 4096 KB but you should try setting it as
+			small
 			as possible according
 			to business requirements.
 		</p>
@@ -35,7 +37,8 @@
 		<sample src="Web.config.ASPNetMaxRequestLength.bad" />
 
 		<p>
-			Unless such a high value is strictly needed, it is better to set the
+			Unless such a high value is strictly needed, it is better to set
+			the
 			recommended value (4096 KB):
 		</p>
 

--- a/csharp/ql/src/Security Features/CWE-016/ASPNetMaxRequestLength.ql
+++ b/csharp/ql/src/Security Features/CWE-016/ASPNetMaxRequestLength.ql
@@ -1,9 +1,13 @@
 /**
- * @name Large maxRequestLength value
+ * @name Large 'maxRequestLength' value
  * @description Setting a large 'maxRequestLength' value may render a webpage vulnerable to
  *              denial-of-service attacks.
  * @kind problem
  * @problem.severity warning
+ * @id cs/web/large-max-request-length
+ * @tags security
+ *       frameworks/asp.net
+ *       external/cwe/cwe-16
  */
 
 import csharp

--- a/csharp/ql/src/Security Features/CWE-016/ASPNetMaxRequestLength.ql
+++ b/csharp/ql/src/Security Features/CWE-016/ASPNetMaxRequestLength.ql
@@ -1,0 +1,18 @@
+/**
+ * @name Large maxRequestLength value
+ * @description Setting a large 'maxRequestLength' value may render a webpage vulnerable to
+ *              denial-of-service attacks.
+ * @kind problem
+ * @problem.severity warning
+ */
+
+import csharp
+import semmle.code.asp.WebConfig
+
+from SystemWebXMLElement web, XMLAttribute maxReqLength
+where
+  maxReqLength = web
+        .getAChild(any(string s | s.toLowerCase() = "httpruntime"))
+        .getAttribute(any(string s | s.toLowerCase() = "maxrequestlength")) and
+  maxReqLength.getValue().toInt() > 4096
+select maxReqLength, "Large 'maxRequestLength' value (" + maxReqLength.getValue() + " KB)."

--- a/csharp/ql/src/Security Features/CWE-016/Web.config.ASPNetMaxRequestLength.bad
+++ b/csharp/ql/src/Security Features/CWE-016/Web.config.ASPNetMaxRequestLength.bad
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<configuration>
+  <system.web>
+    <httpRuntime maxRequestLength="255000" />
+  </system.web>
+</configuration>

--- a/csharp/ql/src/Security Features/CWE-016/Web.config.ASPNetMaxRequestLength.good
+++ b/csharp/ql/src/Security Features/CWE-016/Web.config.ASPNetMaxRequestLength.good
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<configuration>
+  <system.web>
+    <httpRuntime maxRequestLength="4096" />
+  </system.web>
+</configuration>

--- a/csharp/ql/test/query-tests/Security Features/CWE-016/ASPNetMaxRequestLength.cs
+++ b/csharp/ql/test/query-tests/Security Features/CWE-016/ASPNetMaxRequestLength.cs
@@ -1,0 +1,5 @@
+// Dummy class for extraction purposes
+public class ASPNetMaxRequestLengthDummyClass
+{
+
+}

--- a/csharp/ql/test/query-tests/Security Features/CWE-016/ASPNetMaxRequestLength.expected
+++ b/csharp/ql/test/query-tests/Security Features/CWE-016/ASPNetMaxRequestLength.expected
@@ -1,0 +1,1 @@
+| bad/Web.config:4:5:4:46 | maxRequestLength=262144 | Large 'maxRequestLength' value (262144). |

--- a/csharp/ql/test/query-tests/Security Features/CWE-016/ASPNetMaxRequestLength.expected
+++ b/csharp/ql/test/query-tests/Security Features/CWE-016/ASPNetMaxRequestLength.expected
@@ -1,1 +1,1 @@
-| bad/Web.config:4:5:4:46 | maxRequestLength=262144 | Large 'maxRequestLength' value (262144). |
+| bad/Web.config:4:5:4:46 | maxRequestLength=262144 | Large 'maxRequestLength' value (262144 KB). |

--- a/csharp/ql/test/query-tests/Security Features/CWE-016/ASPNetMaxRequestLength.qlref
+++ b/csharp/ql/test/query-tests/Security Features/CWE-016/ASPNetMaxRequestLength.qlref
@@ -1,0 +1,1 @@
+Security Features/CWE-016/ASPNetMaxRequestLength.ql

--- a/csharp/ql/test/query-tests/Security Features/CWE-016/Web.config
+++ b/csharp/ql/test/query-tests/Security Features/CWE-016/Web.config
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<configuration>
+  <system.web>
+    <httpRuntime maxRequestLength="4096" />
+  </system.web>
+</configuration>

--- a/csharp/ql/test/query-tests/Security Features/CWE-016/bad/Web.config
+++ b/csharp/ql/test/query-tests/Security Features/CWE-016/bad/Web.config
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<configuration>
+  <system.web>
+    <httpRuntime maxRequestLength="262144" />
+  </system.web>
+</configuration>


### PR DESCRIPTION
The directive `maxRequestLength` sets the limit for the input stream buffering threshold in KB. Attackers can use large requests to cause denial-of-service attacks.

This PR includes a CodeQL query to detect applications with larger values than the recommended one:
https://docs.microsoft.com/en-us/dotnet/api/system.web.configuration.httpruntimesection.maxrequestlength?view=netframework-4.8

