### PR TITLE
Adds CodeQL query to detect weak (duplicated) encryption keys for ASP.NET Telerik

### DIFF
--- a/csharp/ql/src/Security Features/CWE-310/TelerikRepeatedEncryptionKey.qhelp
+++ b/csharp/ql/src/Security Features/CWE-310/TelerikRepeatedEncryptionKey.qhelp
@@ -1,0 +1,71 @@
+<!DOCTYPE qhelp PUBLIC
+  "-//Semmle//qhelp//EN"
+  "qhelp.dtd">
+<qhelp>
+
+	<overview>
+		<p>
+			ASP.NET Telerik upload allows developers to easily
+			manage file
+			uploads. The transmission between the client and the
+			server must be
+			encrypted and impossible to decode, so the data cannot
+			be used by a
+			malicious entity in an attack against the server. The
+			main security
+			recommendation for Telerik is setting custom unique
+			strong random
+			values for
+			<code>Telerik.AsyncUpload.ConfigurationEncryptionKey</code>
+			and
+			<code>Telerik.Upload.ConfigurationHashKey</code>
+			.
+		</p>
+
+	</overview>
+	<recommendation>
+
+		<p>
+			Set a custom unique strong random value for
+			<code>Telerik.AsyncUpload.ConfigurationEncryptionKey</code>.
+		</p>
+		<p>
+			Set a custom unique strong random value for
+			<code>Telerik.Upload.ConfigurationHashKey</code>.
+		</p>
+
+	</recommendation>
+	<example>
+
+		<p>
+			The following example shows a secure configuration for Telerik Upload
+			in the file
+			<code>Web.config</code>
+			.
+		</p>
+
+		<sample src="Web.config.TelerikRepeatedEncryptionKey.good" />
+
+	</example>
+	<references>
+
+		<li>
+			Telerik:
+			<a
+				href="https://docs.telerik.com/devtools/aspnet-ajax/controls/asyncupload/security">Security Recommendations</a>
+			.
+		</li>
+		<li>
+			Telerik:
+			<a
+				href="https://www.telerik.com/support/kb/aspnet-ajax/details/cryptographic-weakness">Cryptographic Weakness</a>
+			.
+		</li>
+		<li>
+			Exploitation:
+			<a
+				href="https://captmeelo.com/pentest/2018/08/03/pwning-with-telerik.html">Pwning Web Applications via Telerik Web UI</a>
+			.
+		</li>
+	</references>
+</qhelp>

--- a/csharp/ql/src/Security Features/CWE-310/TelerikRepeatedEncryptionKey.ql
+++ b/csharp/ql/src/Security Features/CWE-310/TelerikRepeatedEncryptionKey.ql
@@ -1,0 +1,19 @@
+/**
+ * @name Non unique encryption keys in Telerik Upload in ASP.NET
+ * @description Setting a weak encryption key for ASP.NET Telerik Upload may allow attacks against
+ *              the application.
+ * @kind problem
+ */
+
+import csharp
+
+from XMLAttribute a, XMLAttribute b
+where
+  a.getName() = "key" and
+  a.getValue() = "Telerik.AsyncUpload.ConfigurationEncryptionKey" and
+  b.getName() = "key" and
+  b.getValue() = "Telerik.Upload.ConfigurationHashKey" and
+  a.getElement().getAttributeValue("value") = b.getElement().getAttributeValue("value")
+select a,
+  "Non unique (duplicated) Telerik Upload encryption key (" +
+    a.getElement().getAttributeValue("value").toString() + ")."

--- a/csharp/ql/src/Security Features/CWE-310/Web.config.TelerikRepeatedEncryptionKey.good
+++ b/csharp/ql/src/Security Features/CWE-310/Web.config.TelerikRepeatedEncryptionKey.good
@@ -1,0 +1,5 @@
+<appSettings>
+        <add key="Telerik.AsyncUpload.ConfigurationEncryptionKey" value="YOUR-FIRST-UNIQUE-STRONG-RANDOM-VALUE-UNIQUE-TO-YOUR-APP" />
+        <add key="Telerik.Upload.ConfigurationHashKey" value="YOUR-SECOND-UNIQUE-STRONG-RANDOM-VALUE-UNIQUE-TO-YOUR-APP" />
+        <add key="Telerik.Upload.AllowedCustomMetaDataTypes" value="Telerik.Web.UI.AsyncUploadConfiguration" />
+</appSettings>


### PR DESCRIPTION
ASP.NET Telerik upload allows developers to easily manage file uploads. The transmission between the client and the server must be encrypted and impossible to decode, so the data cannot be used by a malicious entity in an attack against the server. The main security recommendation for Telerik is setting custom unique strong random values for `Telerik.AsyncUpload.ConfigurationEncryptionKey` and `Telerik.Upload.ConfigurationHashKey`.

This PR includes a CodeQL query to detect applications that are using the same key for both fields while they should have been unique:
* https://docs.telerik.com/devtools/aspnet-ajax/controls/asyncupload/security
* https://www.telerik.com/support/kb/aspnet-ajax/details/cryptographic-weakness
* https://captmeelo.com/pentest/2018/08/03/pwning-with-telerik.html
			.