### PR TITLE
JS: Cap length of string extracted as a RegExp

### DIFF
--- a/javascript/extractor/src/com/semmle/js/extractor/ASTExtractor.java
+++ b/javascript/extractor/src/com/semmle/js/extractor/ASTExtractor.java
@@ -520,7 +520,7 @@ public class ASTExtractor {
         OffsetTranslation offsets = new OffsetTranslation();
         offsets.set(0, 1); // skip the initial '/'
         regexpExtractor.extract(source.substring(1, source.lastIndexOf('/')), offsets, nd, false);
-      } else if (nd.isStringLiteral() && !c.isInsideType()) {
+      } else if (nd.isStringLiteral() && !c.isInsideType() && nd.getRaw().length() < 100) {
         regexpExtractor.extract(valueString, makeStringLiteralOffsets(nd.getRaw()), nd, true);
       }
       return key;

--- a/javascript/extractor/src/com/semmle/js/extractor/ASTExtractor.java
+++ b/javascript/extractor/src/com/semmle/js/extractor/ASTExtractor.java
@@ -520,7 +520,7 @@ public class ASTExtractor {
         OffsetTranslation offsets = new OffsetTranslation();
         offsets.set(0, 1); // skip the initial '/'
         regexpExtractor.extract(source.substring(1, source.lastIndexOf('/')), offsets, nd, false);
-      } else if (nd.isStringLiteral() && !c.isInsideType() && nd.getRaw().length() < 100) {
+      } else if (nd.isStringLiteral() && !c.isInsideType() && nd.getRaw().length() < 1000) {
         regexpExtractor.extract(valueString, makeStringLiteralOffsets(nd.getRaw()), nd, true);
       }
       return key;

--- a/javascript/extractor/src/com/semmle/js/extractor/Main.java
+++ b/javascript/extractor/src/com/semmle/js/extractor/Main.java
@@ -37,7 +37,7 @@ public class Main {
    * A version identifier that should be updated every time the extractor changes in such a way that
    * it may produce different tuples for the same file under the same {@link ExtractorConfig}.
    */
-  public static final String EXTRACTOR_VERSION = "2019-10-23";
+  public static final String EXTRACTOR_VERSION = "2019-11-17";
 
   public static final Pattern NEWLINE = Pattern.compile("\n");
 


### PR DESCRIPTION
Fixes extraction of gecko-dev. Still waiting on evaluation of the second commit.

@calumgrant we'd like to get this into the dist upgrade.