### PR TITLE
JavaScript: Share code between `DoubleEscaping` and `IncompleteSanitization`.

### DIFF
--- a/change-notes/1.24/analysis-javascript.md
+++ b/change-notes/1.24/analysis-javascript.md
@@ -16,6 +16,7 @@
 | **Query**                      | **Expected impact**          | **Change**                                                                |
 |--------------------------------|------------------------------|---------------------------------------------------------------------------|
 | Clear-text logging of sensitive information (`js/clear-text-logging`) | More results | More results involving `process.env` and indirect calls to logging methods are recognized. |
+| Incomplete string escaping or encoding (`js/incomplete-sanitization`) | Fewer false positive results | This query now recognizes additional cases where a single replacement is likely to be intentional. |
 | Unbound event handler receiver (`js/unbound-event-handler-receiver`) | Fewer false positive results | This query now recognizes additional ways event handler receivers can be bound. | 
 
 ## Changes to libraries

--- a/javascript/ql/src/Security/CWE-116/DoubleEscaping.ql
+++ b/javascript/ql/src/Security/CWE-116/DoubleEscaping.ql
@@ -41,23 +41,26 @@ predicate escapingScheme(string metachar, string regex) {
 }
 
 /**
- * A method call that performs string replacement.
+ * A call to `String.prototype.replace` that replaces all instances of a pattern.
  */
-abstract class Replacement extends DataFlow::Node {
-  /**
-   * Holds if this replacement replaces the string `input` with `output`.
-   */
-  abstract predicate replaces(string input, string output);
+class Replacement extends StringReplaceCall {
+  Replacement() {
+    isGlobal()
+  }
 
   /**
    * Gets the input of this replacement.
    */
-  abstract DataFlow::Node getInput();
+  DataFlow::Node getInput() {
+    result = this.getReceiver()
+  }
 
   /**
    * Gets the output of this replacement.
    */
-  abstract DataFlow::SourceNode getOutput();
+  DataFlow::SourceNode getOutput() {
+    result = this
+  }
 
   /**
    * Holds if this replacement escapes `char` using `metachar`.
@@ -120,27 +123,6 @@ abstract class Replacement extends DataFlow::Node {
         not succ.escapes(_, metachar) and result = succ.getALaterUnescaping(metachar)
       )
     )
-  }
-}
-
-/**
- * A call to `String.prototype.replace` that replaces all instances of a pattern.
- */
-class GlobalStringReplacement extends Replacement, StringReplaceCall {
-  GlobalStringReplacement() {
-    isGlobal()
-  }
-
-  override predicate replaces(string input, string output) {
-    StringReplaceCall.super.replaces(input, output)
-  }
-
-  override DataFlow::Node getInput() {
-    result = this.getReceiver()
-  }
-
-  override DataFlow::SourceNode getOutput() {
-    result = this
   }
 }
 

--- a/javascript/ql/src/Security/CWE-116/DoubleEscaping.ql
+++ b/javascript/ql/src/Security/CWE-116/DoubleEscaping.ql
@@ -54,11 +54,11 @@ DataFlow::Node getASimplePredecessor(DataFlow::Node nd) {
  * into a form described by regular expression `regex`.
  */
 predicate escapingScheme(string metachar, string regex) {
-  metachar = "&" and regex = "&.*;"
+  metachar = "&" and regex = "&.+;"
   or
-  metachar = "%" and regex = "%.*"
+  metachar = "%" and regex = "%.+"
   or
-  metachar = "\\" and regex = "\\\\.*"
+  metachar = "\\" and regex = "\\\\.+"
 }
 
 /**

--- a/javascript/ql/src/Security/CWE-116/DoubleEscaping.ql
+++ b/javascript/ql/src/Security/CWE-116/DoubleEscaping.ql
@@ -156,6 +156,14 @@ class GlobalStringReplacement extends Replacement, DataFlow::MethodCallNode {
   override predicate replaces(string input, string output) {
     input = getStringValue(pattern) and
     output = this.getArgument(1).getStringValue()
+    or
+    exists(DataFlow::FunctionNode replacer, DataFlow::PropRead pr, DataFlow::ObjectLiteralNode map |
+      replacer = getCallback(1) and
+      replacer.getParameter(0).flowsToExpr(pr.getPropertyNameExpr()) and
+      pr = map.getAPropertyRead() and
+      pr.flowsTo(replacer.getAReturn()) and
+      map.asExpr().(ObjectExpr).getPropertyByName(input).getInit().getStringValue() = output
+    )
   }
 
   override DataFlow::Node getInput() {

--- a/javascript/ql/src/Security/CWE-116/DoubleEscaping.ql
+++ b/javascript/ql/src/Security/CWE-116/DoubleEscaping.ql
@@ -128,7 +128,9 @@ abstract class Replacement extends DataFlow::Node {
     exists(Replacement pred | pred = this.getPreviousReplacement() |
       if pred.escapes(_, metachar)
       then result = pred
-      else result = pred.getAnEarlierEscaping(metachar)
+      else (
+        not pred.unescapes(metachar, _) and result = pred.getAnEarlierEscaping(metachar)
+      )
     )
   }
 
@@ -140,7 +142,9 @@ abstract class Replacement extends DataFlow::Node {
     exists(Replacement succ | this = succ.getPreviousReplacement() |
       if succ.unescapes(metachar, _)
       then result = succ
-      else result = succ.getALaterUnescaping(metachar)
+      else (
+        not succ.escapes(_, metachar) and result = succ.getALaterUnescaping(metachar)
+      )
     )
   }
 }

--- a/javascript/ql/src/Security/CWE-116/DoubleEscaping.ql
+++ b/javascript/ql/src/Security/CWE-116/DoubleEscaping.ql
@@ -46,7 +46,12 @@ string getStringValue(RegExpLiteral rl) {
  */
 DataFlow::Node getASimplePredecessor(DataFlow::Node nd) {
   result = nd.getAPredecessor() and
-  not nd.(DataFlow::SsaDefinitionNode).getSsaVariable().getDefinition() instanceof SsaPhiNode
+  not exists(SsaDefinition ssa |
+    ssa = nd.(DataFlow::SsaDefinitionNode).getSsaVariable().getDefinition()
+  |
+    ssa instanceof SsaPhiNode or
+    ssa instanceof SsaVariableCapture
+  )
 }
 
 /**

--- a/javascript/ql/src/Security/CWE-116/DoubleEscaping.ql
+++ b/javascript/ql/src/Security/CWE-116/DoubleEscaping.ql
@@ -126,27 +126,13 @@ abstract class Replacement extends DataFlow::Node {
 /**
  * A call to `String.prototype.replace` that replaces all instances of a pattern.
  */
-class GlobalStringReplacement extends Replacement, DataFlow::MethodCallNode {
-  RegExpLiteral pattern;
-
+class GlobalStringReplacement extends Replacement, StringReplaceCall {
   GlobalStringReplacement() {
-    this.getMethodName() = "replace" and
-    pattern.flow().(DataFlow::SourceNode).flowsTo(this.getArgument(0)) and
-    this.getNumArgument() = 2 and
-    pattern.isGlobal()
+    isGlobal()
   }
 
   override predicate replaces(string input, string output) {
-    input = pattern.getRoot().getConstantValue() and
-    output = this.getArgument(1).getStringValue()
-    or
-    exists(DataFlow::FunctionNode replacer, DataFlow::PropRead pr, DataFlow::ObjectLiteralNode map |
-      replacer = getCallback(1) and
-      replacer.getParameter(0).flowsToExpr(pr.getPropertyNameExpr()) and
-      pr = map.getAPropertyRead() and
-      pr.flowsTo(replacer.getAReturn()) and
-      map.asExpr().(ObjectExpr).getPropertyByName(input).getInit().getStringValue() = output
-    )
+    StringReplaceCall.super.replaces(input, output)
   }
 
   override DataFlow::Node getInput() {

--- a/javascript/ql/src/Security/CWE-116/IncompleteSanitization.ql
+++ b/javascript/ql/src/Security/CWE-116/IncompleteSanitization.ql
@@ -21,22 +21,9 @@ string metachar() { result = "'\"\\&<>\n\r\t*|{}[]%$".charAt(_) }
 
 /** Gets a string matched by `e` in a `replace` call. */
 string getAMatchedString(Expr e) {
-  result = getAMatchedConstant(e.(RegExpLiteral).getRoot()).getValue()
+  result = e.(RegExpLiteral).getRoot().getAMatchedString()
   or
   result = e.getStringValue()
-}
-
-/** Gets a constant matched by `t`. */
-RegExpConstant getAMatchedConstant(RegExpTerm t) {
-  result = t
-  or
-  result = getAMatchedConstant(t.(RegExpAlt).getAlternative())
-  or
-  result = getAMatchedConstant(t.(RegExpGroup).getAChild())
-  or
-  exists(RegExpCharacterClass recc | recc = t and not recc.isInverted() |
-    result = getAMatchedConstant(recc.getAChild())
-  )
 }
 
 /** Holds if `t` is simple, that is, a union of constants. */

--- a/javascript/ql/src/Security/CWE-116/IncompleteSanitization.ql
+++ b/javascript/ql/src/Security/CWE-116/IncompleteSanitization.ql
@@ -32,11 +32,19 @@ predicate isSimple(RegExpTerm t) {
   or
   isSimple(t.(RegExpGroup).getAChild())
   or
-  (
-    t instanceof RegExpAlt
-    or
-    t instanceof RegExpCharacterClass and not t.(RegExpCharacterClass).isInverted()
-  ) and
+  isSimpleCharacterClass(t)
+  or
+  isSimpleAlt(t)
+}
+
+/** Holds if `t` is a non-inverted character class that contains no ranges. */
+predicate isSimpleCharacterClass(RegExpCharacterClass t) {
+  not t.isInverted() and
+  forall(RegExpTerm ch | ch = t.getAChild() | isSimple(ch))
+}
+
+/** Holds if `t` is an alternation of simple terms. */
+predicate isSimpleAlt(RegExpAlt t) {
   forall(RegExpTerm ch | ch = t.getAChild() | isSimple(ch))
 }
 

--- a/javascript/ql/src/semmle/javascript/Regexp.qll
+++ b/javascript/ql/src/semmle/javascript/Regexp.qll
@@ -185,6 +185,11 @@ class RegExpTerm extends Locatable, @regexpterm {
    * into account.
    */
   string getConstantValue() { none() }
+
+  /**
+   * Gets a string that is matched by this regular-expression term.
+   */
+  string getAMatchedString() { result = getConstantValue() }
 }
 
 /**
@@ -280,6 +285,8 @@ class RegExpAlt extends RegExpTerm, @regexp_alt {
   int getNumAlternative() { result = getNumChild() }
 
   override predicate isNullable() { getAlternative().isNullable() }
+
+  override string getAMatchedString() { result = getAlternative().getAMatchedString() }
 }
 
 /**
@@ -574,6 +581,8 @@ class RegExpGroup extends RegExpTerm, @regexp_group {
   override predicate isNullable() { getAChild().isNullable() }
 
   override string getConstantValue() { result = getAChild().getConstantValue() }
+
+  override string getAMatchedString() { result = getAChild().getAMatchedString() }
 }
 
 /**
@@ -759,6 +768,10 @@ class RegExpCharacterClass extends RegExpTerm, @regexp_char_class {
   predicate isInverted() { isInverted(this) }
 
   override predicate isNullable() { none() }
+
+  override string getAMatchedString() {
+    not isInverted() and result = getAChild().getAMatchedString()
+  }
 }
 
 /**

--- a/javascript/ql/src/semmle/javascript/Regexp.qll
+++ b/javascript/ql/src/semmle/javascript/Regexp.qll
@@ -311,13 +311,19 @@ class RegExpSequence extends RegExpTerm, @regexp_seq {
     forall(RegExpTerm child | child = getAChild() | child.isNullable())
   }
 
-  language[monotonicAggregates]
   override string getConstantValue() {
-    // note: due to use of monotonic aggregates, this `strictconcat` will fail if
-    // `getConstantValue` is undefined for any child
-    result = strictconcat(RegExpTerm ch, int i | ch = getChild(i) |
-      ch.getConstantValue() order by i
-    )
+    result = getConstantValue(0)
+  }
+
+  /**
+   * Gets the single string matched by the `i`th child and all following children of
+   * this sequence, if any.
+   */
+  private string getConstantValue(int i) {
+    i = getNumChild() and
+    result = ""
+    or
+    result = getChild(i).getConstantValue() + getConstantValue(i+1)
   }
 }
 

--- a/javascript/ql/src/semmle/javascript/StandardLibrary.qll
+++ b/javascript/ql/src/semmle/javascript/StandardLibrary.qll
@@ -281,7 +281,7 @@ class StringReplaceCall extends DataFlow::MethodCallNode {
   }
 
   /**
-   * Holds if this is a global replacement, that is, the first argument is a regulare expression
+   * Holds if this is a global replacement, that is, the first argument is a regular expression
    * with the `g` flag.
    */
   predicate isGlobal() {
@@ -303,7 +303,7 @@ class StringReplaceCall extends DataFlow::MethodCallNode {
       replacer.getParameter(0).flowsToExpr(pr.getPropertyNameExpr()) and
       pr = map.getAPropertyRead() and
       pr.flowsTo(replacer.getAReturn()) and
-      map.asExpr().(ObjectExpr).getPropertyByName(old).getInit().getStringValue() = new
+      map.hasPropertyWrite(old, any(DataFlow::Node repl | repl.getStringValue() = new))
     )
   }
 }

--- a/javascript/ql/src/semmle/javascript/StandardLibrary.qll
+++ b/javascript/ql/src/semmle/javascript/StandardLibrary.qll
@@ -248,3 +248,62 @@ private class IteratorExceptionStep extends DataFlow::MethodCallNode, DataFlow::
     succ = this.getExceptionalReturn()
   }
 }
+
+/**
+ * A call to `String.prototype.replace`.
+ *
+ * We heuristically include any call to a method called `replace`, provided it either
+ * has exactly two arguments, or local data flow suggests that the receiver may be a string.
+ */
+class StringReplaceCall extends DataFlow::MethodCallNode {
+  StringReplaceCall() {
+    getMethodName() = "replace" and
+    (getNumArgument() = 2 or getReceiver().mayHaveStringValue(_))
+  }
+
+  /** Gets the regular expression passed as the first argument to `replace`, if any. */
+  DataFlow::RegExpLiteralNode getRegExp() {
+    result.flowsTo(getArgument(0))
+  }
+
+  /** Gets a string that is being replaced by this call. */
+  string getAReplacedString() {
+    result = getRegExp().getRoot().getAMatchedString() or
+    getArgument(0).mayHaveStringValue(result)
+  }
+
+  /**
+   * Gets the second argument of this call to `replace`, which is either a string
+   * or a callback.
+   */
+  DataFlow::Node getRawReplacement() {
+    result = getArgument(1)
+  }
+
+  /**
+   * Holds if this is a global replacement, that is, the first argument is a regulare expression
+   * with the `g` flag.
+   */
+  predicate isGlobal() {
+    getRegExp().isGlobal()
+  }
+
+  /**
+   * Holds if this call to `replace` replaces `old` with `new`.
+   */
+  predicate replaces(string old, string new) {
+    exists(string rawNew |
+      old = getAReplacedString() and
+      getRawReplacement().mayHaveStringValue(rawNew) and
+      new = rawNew.replaceAll("$&", old)
+    )
+    or
+    exists(DataFlow::FunctionNode replacer, DataFlow::PropRead pr, DataFlow::ObjectLiteralNode map |
+      replacer = getCallback(1) and
+      replacer.getParameter(0).flowsToExpr(pr.getPropertyNameExpr()) and
+      pr = map.getAPropertyRead() and
+      pr.flowsTo(replacer.getAReturn()) and
+      map.asExpr().(ObjectExpr).getPropertyByName(old).getInit().getStringValue() = new
+    )
+  }
+}

--- a/javascript/ql/src/semmle/javascript/dataflow/Nodes.qll
+++ b/javascript/ql/src/semmle/javascript/dataflow/Nodes.qll
@@ -531,6 +531,24 @@ class ArrayLiteralNode extends DataFlow::ValueNode, DataFlow::SourceNode {
 }
 
 /**
+ * A data-flow node corresponding to a regular-expression literal.
+ *
+ * Examples:
+ * ```js
+ * /https?/i
+ * ```
+ */
+class RegExpLiteralNode extends DataFlow::ValueNode, DataFlow::SourceNode {
+  override RegExpLiteral astNode;
+
+  /** Holds if this regular expression has a `g` flag. */
+  predicate isGlobal() { astNode.isGlobal() }
+
+  /** Gets the root term of this regular expression. */
+  RegExpTerm getRoot() { result = astNode.getRoot() }
+}
+
+/**
  * A data flow node corresponding to a `new Array()` or `Array()` invocation.
  *
  * Examples:

--- a/javascript/ql/test/query-tests/Security/CWE-116/DoubleEscaping/DoubleEscaping.expected
+++ b/javascript/ql/test/query-tests/Security/CWE-116/DoubleEscaping/DoubleEscaping.expected
@@ -5,3 +5,4 @@
 | tst.js:53:10:53:33 | s.repla ... , '\\\\') | This replacement may produce '\\' characters that are double-unescaped $@. | tst.js:53:10:54:33 | s.repla ... , '\\'') | here |
 | tst.js:60:7:60:28 | s.repla ...  '%25') | This replacement may double-escape '%' characters from $@. | tst.js:59:7:59:28 | s.repla ...  '%26') | here |
 | tst.js:68:10:70:38 | s.repla ... &amp;") | This replacement may double-escape '&' characters from $@. | tst.js:68:10:69:39 | s.repla ... apos;") | here |
+| tst.js:79:10:79:66 | s.repla ... &amp;") | This replacement may double-escape '&' characters from $@. | tst.js:79:10:79:43 | s.repla ... epl[c]) | here |

--- a/javascript/ql/test/query-tests/Security/CWE-116/DoubleEscaping/tst.js
+++ b/javascript/ql/test/query-tests/Security/CWE-116/DoubleEscaping/tst.js
@@ -78,3 +78,8 @@ function badEncodeWithReplacer(s) {
   };
   return s.replace(/["']/g, (c) => repl[c]).replace(/&/g, "&amp;");
 }
+
+// dubious, but out of scope for this query
+function badRoundtrip(s) {
+  return s.replace(/\\\\/g, "\\").replace(/\\/g, "\\\\");
+}

--- a/javascript/ql/test/query-tests/Security/CWE-116/DoubleEscaping/tst.js
+++ b/javascript/ql/test/query-tests/Security/CWE-116/DoubleEscaping/tst.js
@@ -90,3 +90,7 @@ function testWithCapturedVar(x) {
     captured = captured.replace(/\\/g, "\\\\");
   })();
 }
+
+function encodeDecodeEncode(s) {
+ return goodEncode(goodDecode(goodEncode(s)));
+}

--- a/javascript/ql/test/query-tests/Security/CWE-116/DoubleEscaping/tst.js
+++ b/javascript/ql/test/query-tests/Security/CWE-116/DoubleEscaping/tst.js
@@ -83,3 +83,10 @@ function badEncodeWithReplacer(s) {
 function badRoundtrip(s) {
   return s.replace(/\\\\/g, "\\").replace(/\\/g, "\\\\");
 }
+
+function testWithCapturedVar(x) {
+  var captured = x;
+  (function() {
+    captured = captured.replace(/\\/g, "\\\\");
+  })();
+}

--- a/javascript/ql/test/query-tests/Security/CWE-116/DoubleEscaping/tst.js
+++ b/javascript/ql/test/query-tests/Security/CWE-116/DoubleEscaping/tst.js
@@ -69,3 +69,12 @@ function badEncode(s) {
           .replace(indirect2, "&apos;")
           .replace(indirect3, "&amp;");
 }
+
+function badEncodeWithReplacer(s) {
+  var repl = {
+    '"': "&quot;",
+    "'": "&apos;",
+    "&": "&amp;"
+  };
+  return s.replace(/["']/g, (c) => repl[c]).replace(/&/g, "&amp;");
+}


### PR DESCRIPTION
Also includes a few other bits and pieces salvaged from the ill-fated https://github.com/Semmle/ql/pull/2247 and its successors that never saw the light of day.

[Evaluation](https://git.semmle.com/max/dist-compare-reports/blob/master/js/odasa-8179/report.md) (internal link) shows no performance changes, a few new results (false positives exposed, but not created, by this PR) and a few fixed results (false positives, specifically fixed by this PR).