### PR TITLE
Java: Update change note to cover #2304 and #2346.

### DIFF
--- a/change-notes/1.23/analysis-java.md
+++ b/change-notes/1.23/analysis-java.md
@@ -17,7 +17,7 @@ The following changes in version 1.23 affect Java analysis in all applications.
 | Query built from user-controlled sources (`java/sql-injection`) | More results | The query now identifies arguments to `Statement.executeLargeUpdate` and `Connection.prepareCall` as SQL expressions sinks. |
 | Query built from local-user-controlled sources (`java/sql-injection-local`) | More results | The query now identifies arguments to `Statement.executeLargeUpdate` and `Connection.prepareCall` as SQL expressions sinks. |
 | Query built without neutralizing special characters (`java/concatenated-sql-query`) | More results | The query now identifies arguments to `Statement.executeLargeUpdate` and `Connection.prepareCall` as SQL expressions sinks. |
-| Useless comparison test (`java/constant-comparison`) | Fewer false positives | Additional overflow check patterns are now recognized and no longer reported. |
+| Useless comparison test (`java/constant-comparison`) | Fewer false positives | Additional overflow check patterns are now recognized and no longer reported. Also, a few bug fixes in the range analysis for floating-point variables means a further reduction in false positives. |
 
 ## Changes to libraries
 


### PR DESCRIPTION
Extend change note to cover the range analysis bug fixes.  #2305 was already sufficiently covered by the existing change note.