### PR TITLE
Python: Fix non-container FP relating to `MappingProxyType`.

### DIFF
--- a/python/ql/src/Expressions/ContainsNonContainer.ql
+++ b/python/ql/src/Expressions/ContainsNonContainer.ql
@@ -15,19 +15,20 @@ import semmle.python.pointsto.PointsTo
 
 predicate rhs_in_expr(ControlFlowNode rhs, Compare cmp) {
     exists(Cmpop op, int i | cmp.getOp(i) = op and cmp.getComparator(i) = rhs.getNode() |
-           op instanceof In or op instanceof NotIn
+        op instanceof In or op instanceof NotIn
     )
 }
 
 from ControlFlowNode non_seq, Compare cmp, Value v, ClassValue cls, ControlFlowNode origin
-where rhs_in_expr(non_seq, cmp) and
-non_seq.pointsTo(_, v, origin) and
-v.getClass() = cls and
-not Types::failedInference(cls, _) and
-not cls.hasAttribute("__contains__") and
-not cls.hasAttribute("__iter__") and
-not cls.hasAttribute("__getitem__") and
-not cls = ClassValue::nonetype() and
-not cls = Value::named("types.MappingProxyType")
-
-select cmp, "This test may raise an Exception as the $@ may be of non-container class $@.", origin, "target", cls, cls.getName()
+where
+    rhs_in_expr(non_seq, cmp) and
+    non_seq.pointsTo(_, v, origin) and
+    v.getClass() = cls and
+    not Types::failedInference(cls, _) and
+    not cls.hasAttribute("__contains__") and
+    not cls.hasAttribute("__iter__") and
+    not cls.hasAttribute("__getitem__") and
+    not cls = ClassValue::nonetype() and
+    not cls = Value::named("types.MappingProxyType")
+select cmp, "This test may raise an Exception as the $@ may be of non-container class $@.", origin,
+    "target", cls, cls.getName()

--- a/python/ql/src/semmle/python/objects/ObjectAPI.qll
+++ b/python/ql/src/semmle/python/objects/ObjectAPI.qll
@@ -660,4 +660,9 @@ module ClassValue {
         result = TBuiltinClassObject(Builtin::special("ModuleType"))
     }
 
+    /** Get the `ClassValue` for the `NoneType` class. */
+    ClassValue nonetype() {
+        result = TBuiltinClassObject(Builtin::special("NoneType"))
+    }
+
 }

--- a/python/ql/test/query-tests/Expressions/general/expressions_test.py
+++ b/python/ql/test/query-tests/Expressions/general/expressions_test.py
@@ -234,3 +234,11 @@ def func():
     except TypeError:
       return 1
     return 0
+
+# False positive for py/member-test-non-container
+
+# Container wrapped in MappingProxyType
+from types import MappingProxyType
+
+def mpt_arg(d=MappingProxyType({})):
+    return 1 in d


### PR DESCRIPTION
Fixes #2307.

Also modernises the query to use the `Value` API.