### PR TITLE
C++: Don't check if a Field is static

### DIFF
--- a/cpp/ql/src/semmle/code/cpp/dataflow/internal/DataFlowPrivate.qll
+++ b/cpp/ql/src/semmle/code/cpp/dataflow/internal/DataFlowPrivate.qll
@@ -219,7 +219,6 @@ predicate storeStep(Node node1, Content f, PostUpdateNode node2) {
       node1.asExpr() = a and
       a.getLValue() = fa
     ) and
-    not fa.getTarget().isStatic() and
     node2.getPreUpdateNode().asExpr() = fa.getQualifier() and
     f.(FieldContent).getField() = fa.getTarget()
   )

--- a/cpp/ql/src/semmle/code/cpp/dataflow/internal/FlowVar.qll
+++ b/cpp/ql/src/semmle/code/cpp/dataflow/internal/FlowVar.qll
@@ -133,8 +133,7 @@ private module PartialDefinitions {
     TReferenceArgument(Expr arg, VariableAccess va) { referenceArgument(va, arg) }
 
   private predicate isInstanceFieldWrite(FieldAccess fa, ControlFlowNode node) {
-    not fa.getTarget().isStatic() and
-    assignmentLikeOperation(node, fa.getTarget(), fa, _)
+    assignmentLikeOperation(node, _, fa, _)
   }
 
   class PartialDefinition extends TPartialDefinition {


### PR DESCRIPTION
A `Field` in the C++ QL libraries can't be static, but I'd for some reason written two checks for `Field`s being static in the data-flow library.