### PR TITLE
C++: Downgrade ExprHasNoEffect to medium precision

### DIFF
--- a/cpp/ql/src/Likely Bugs/Likely Typos/ExprHasNoEffect.ql
+++ b/cpp/ql/src/Likely Bugs/Likely Typos/ExprHasNoEffect.ql
@@ -4,7 +4,7 @@
  *              result of a typo.
  * @kind problem
  * @problem.severity warning
- * @precision high
+ * @precision medium
  * @id cpp/useless-expression
  * @tags maintainability
  *       correctness


### PR DESCRIPTION
We keep adding special cases to this query, but a quick glance over [its results on lgtm.com](https://lgtm.com/rules/2165170567/alerts/) shows that we have many more special cases to cover.

The fundamental problem with this query is that it doesn't know where the encapsulation barriers are. As a consequence, the query will flag calls like `destroy_my_object(&my_object);` when the `destroy_my_object` function has no effect _in the particular version and configuration_ we've extracted.

It pains me to suggest hiding this query on LGTM after we've put so much time into improving its results. I hope we can revive it some day when our user interface has evolved to better tolerate imperfect queries.

Fixes #2298 (see https://github.slack.com/archives/CP0MHKV6E/p1574086207203400 for a diagnosis). If we agree to merge this change, I'll add a 1.24 change note.