### PR TITLE
QL docs: Update links to blog/demos

### DIFF
--- a/docs/language/learn-ql/ql-training.rst
+++ b/docs/language/learn-ql/ql-training.rst
@@ -6,7 +6,7 @@ CodeQL and variant analysis
 
 `Variant analysis <https://semmle.com/variant-analysis>`__ is the process of using a known vulnerability as a seed to find similar problems in your code. Security engineers typically perform variant analysis to identify possible vulnerabilities and to ensure that these threats are properly fixed across multiple code bases.
 
-`CodeQL <https://semmle.com/ql>`__ is the code analysis engine that underpins LGTM, Semmle's community driven security analysis platform. Together, CodeQL and LGTM provide continuous monitoring and scalable variant analysis for your projects, even if you don’t have your own team of dedicated security engineers. You can read more about using CodeQL and LGTM in variant analysis in the `Semmle blog <https://blog.semmle.com/tags/variant-analysis>`__.
+`CodeQL <https://semmle.com/ql>`__ is the code analysis engine that underpins LGTM, Semmle's community driven security analysis platform. Together, CodeQL and LGTM provide continuous monitoring and scalable variant analysis for your projects, even if you don’t have your own team of dedicated security engineers. You can read more about using CodeQL and LGTM in variant analysis on the `Security Lab research page <https://securitylab.github.com/research>`__.
 
 CodeQL is easy to learn, and exploring code using CodeQL is the most efficient way to perform variant analysis. 
 
@@ -62,5 +62,4 @@ More resources
 
 - If you are completely new to CodeQL, look at our introductory topics in :doc:`Learning CodeQL <index>`.
 - To find more detailed information about how to write queries for specific languages, visit the links in :ref:`Writing CodeQL queries <writing-ql-queries>`.
-- To read more about how CodeQL queries have been used in Semmle's security research, and to read about new CodeQL developments, visit the `Semmle blog <https://blog.semmle.com>`__. 
-- Find more examples of queries written by Semmle's own security researchers in the `Semmle Demos repository <https://github.com/semmle/demos>`__ on GitHub.
+- To see examples of CodeQL queries that have been used to find security vulnerabilities and bugs in open-source software projects, visit the `GitHub Security Lab website <https://securitylab.github.com/research>`__ and the associated `repository <https://github.com/github/security-lab>`__.

--- a/docs/language/learn-ql/writing-queries/path-queries.rst
+++ b/docs/language/learn-ql/writing-queries/path-queries.rst
@@ -37,7 +37,7 @@ The easiest way to get started writing your own path query is to modify one of t
 - `JavaScript path queries <https://help.semmle.com/wiki/label/js/path-problem>`__
 - `Python path queries <https://help.semmle.com/wiki/label/python/path-problem>`__
  
-The Security lab researchers have used path queries to find security vulnerabilities in various open source projects. To see articles describing how these queries were written, as well as other posts describing other aspects of security research such as exploiting vulnerabilities, see the `GitHub Security Lab website <https://securitylab.github.com/research>`__.
+The Security Lab researchers have used path queries to find security vulnerabilities in various open source projects. To see articles describing how these queries were written, as well as other posts describing other aspects of security research such as exploiting vulnerabilities, see the `GitHub Security Lab website <https://securitylab.github.com/research>`__.
 
 Constructing a path query
 =========================

--- a/docs/language/ql-training/cpp/snprintf.rst
+++ b/docs/language/ql-training/cpp/snprintf.rst
@@ -65,7 +65,7 @@ RCE in rsyslog
     }
 
 - Disclosed as `CVE-2018-1000140 <https://nvd.nist.gov/vuln/detail/CVE-2018-1000140>`__.
-- Blog post: `https://blog.semmle.com/librelp-buffer-overflow-cve-2018-1000140/ <https://blog.semmle.com/librelp-buffer-overflow-cve-2018-1000140/>`__.
+- Blog post: https://securitylab.github.com/research/librelp-buffer-overflow-cve-2018-1000140
 
 Finding the RCE yourself
 ========================

--- a/docs/language/ql-training/java/apache-struts-java.rst
+++ b/docs/language/ql-training/java/apache-struts-java.rst
@@ -58,7 +58,7 @@ RCE in Apache Struts
 
 - Disclosed as `CVE-2017-9805 <http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2017-9805>`__
 
-- Blog post: https://blog.semmle.com/apache-struts-vulnerability-cve-2017-9805/
+- Blog post: https://securitylab.github.com/research/apache-struts-vulnerability-cve-2017-9805
 
 Finding the RCE yourself
 ========================
@@ -134,4 +134,4 @@ Model answer, step 4
      and sink.getNode() instanceof UnsafeDeserializationSink
    select sink.getNode().(UnsafeDeserializationSink).getMethodAccess(), source, sink, "Unsafe    deserialization of $@.", source, "user input"
 
-More full-featured version: https://github.com/Semmle/demos/tree/master/ql_demos/java/Apache_Struts_CVE-2017-9805
+More full-featured version: https://github.com/github/security-lab/tree/master/CodeQL_Queries/java/Apache_Struts_CVE-2017-9805

--- a/docs/language/ql-training/java/global-data-flow-java.rst
+++ b/docs/language/ql-training/java/global-data-flow-java.rst
@@ -53,8 +53,8 @@ Code injection in Apache struts
 
 .. note::
 
-   More details on the CVE can be found here: https://blog.semmle.com/apache-struts-CVE-2018-11776/ and 
-   https://github.com/Semmle/demos/tree/master/ql_demos/java/Apache_Struts_CVE-2018-11776
+   More details on the CVE can be found here: https://securitylab.github.com/research/apache-struts-CVE-2018-11776 and 
+   https://github.com/github/security-lab/tree/master/CodeQL_Queries/java/Apache_Struts_CVE-2018-11776
 
    More details on OGNL can be found here: https://commons.apache.org/proper/commons-ognl/
 


### PR DESCRIPTION
- https://github.com/semmle/demos repo has been moved to https://github.com/github/security-lab.
- Since I was updating some parts of the training slides, I also changed the remaining blog post links.

(I'll update the relevant issues.) 