### PR TITLE
Adds fix for __init_subclass__ bug.

### DIFF
--- a/python/ql/src/Functions/NonSelf.ql
+++ b/python/ql/src/Functions/NonSelf.ql
@@ -38,6 +38,7 @@ where
     not is_type_method(fv) and
     fv.getScope() = f and
     not f.getName() = "lambda" and
+    not f.getName() = "__init_subclass__" and
     not used_in_defining_scope(fv) and
     (
         (

--- a/python/ql/src/Functions/NonSelf.ql
+++ b/python/ql/src/Functions/NonSelf.ql
@@ -31,6 +31,7 @@ where
         cls.isNewStyle() and
         not name = "__new__" and
         not name = "__metaclass__" and
+        not name = "__init_subclass__" and
         /* declared in scope */
         f.getScope() = cls.getScope()
     ) and
@@ -38,7 +39,6 @@ where
     not is_type_method(fv) and
     fv.getScope() = f and
     not f.getName() = "lambda" and
-    not f.getName() = "__init_subclass__" and
     not used_in_defining_scope(fv) and
     (
         (

--- a/python/ql/test/query-tests/Functions/general/parameter_names.py
+++ b/python/ql/test/query-tests/Functions/general/parameter_names.py
@@ -117,3 +117,18 @@ class Z(zope.interface.Interface):
         pass
 
 Z().meth(0)
+
+
+
+# The `__init_subclass__` method is a new method introduced into Python 3.6
+# which does not follow the normal conventions, and is in fact a class method
+# despite not being marked as such with other means. The name alone is what
+# makes it such. As a consequence, the query `py/not-named-self` and other
+# relevant queries need to account for this.
+#
+# This has come up in the wild via LGTM as a false positive. For example,
+# https://docs.python.org/3/reference/datamodel.html#customizing-class-creation
+
+class InitSubclass(object):
+    def __init_subclass__(cls):
+        pass


### PR DESCRIPTION
Fixes various GH issues, such as

https://github.com/Semmle/ql/issues/2366

wherein `__init_subclasses_` was mistakenly being interpreted as an instance method but the spec says it's a class method.

Probably there is some room for future refactoring of this query to make it clear what the parts are doing and how they relate to the purpose.