### PR TITLE
JS: model React's getDerivedStateFromError

### DIFF
--- a/change-notes/1.24/analysis-javascript.md
+++ b/change-notes/1.24/analysis-javascript.md
@@ -2,6 +2,8 @@
 
 ## General improvements
 
+* Support for the following frameworks and libraries has been improved:
+  - [react](https://www.npmjs.com/package/react)
 
 ## New queries
 

--- a/javascript/ql/src/semmle/javascript/frameworks/React.qll
+++ b/javascript/ql/src/semmle/javascript/frameworks/React.qll
@@ -136,7 +136,12 @@ abstract class ReactComponent extends ASTNode {
         result = arg0
     )
     or
-    result.flowsToExpr(getStaticMethod("getDerivedStateFromProps").getAReturnedExpr())
+    exists(string staticMember |
+      staticMember = "getDerivedStateFromProps" or
+      staticMember = "getDerivedStateFromError"
+    |
+      result.flowsToExpr(getStaticMethod(staticMember).getAReturnedExpr())
+    )
     or
     // shouldComponentUpdate: (nextProps, nextState)
     result = DataFlow::parameterNode(getInstanceMethod("shouldComponentUpdate").getParameter(1))

--- a/javascript/ql/test/query-tests/React/UnusedOrUndefinedStateProperty/issue-2389.reduced.js
+++ b/javascript/ql/test/query-tests/React/UnusedOrUndefinedStateProperty/issue-2389.reduced.js
@@ -1,0 +1,12 @@
+import React from "react"
+
+class C extends React.Component {
+	static getDerivedStateFromError(error) {
+		return { error }
+	}
+
+	render() {
+		this.state.error;
+	}
+}
+


### PR DESCRIPTION
Fixes #2389.

To avoid conflicts, I have not added the change-notes yet: merging can wait until the next dist-upgrade.

React.qll could use a bit of modernization, but that is for a separate PR.