### PR TITLE
Python: Add `toString` information for all classes without such.

### DIFF
--- a/python/ql/src/external/CodeDuplication.qll
+++ b/python/ql/src/external/CodeDuplication.qll
@@ -93,7 +93,7 @@ class Copy extends @duplication_or_similarity
     }
 
     /** Gets a textual representation of this element. */
-    string toString() { none() }
+    string toString() { result = "Copy" }
 
     /**
      * Gets a block that extends this one, that is, its first token is also

--- a/python/ql/src/semmle/python/Exprs.qll
+++ b/python/ql/src/semmle/python/Exprs.qll
@@ -419,7 +419,7 @@ abstract class Num extends Num_, ImmutableLiteral {
 
     /* We want to declare this abstract, but currently we cannot. */
     override string toString() {
-        none() 
+        result = "Num with missing toString"
     }
 
 }

--- a/python/ql/src/semmle/python/Keywords.qll
+++ b/python/ql/src/semmle/python/Keywords.qll
@@ -60,7 +60,7 @@ abstract class DictUnpackingOrKeyword extends DictItem {
     abstract Expr getValue();
 
     override string toString() {
-        none() 
+        result = "DictUnpackingOrKeyword with missing toString"
     }
 
 }
@@ -70,7 +70,7 @@ abstract class DictDisplayItem extends DictItem {
     abstract Expr getValue();
 
     override string toString() {
-        none() 
+        result = "DictDisplayItem with missing toString"
     }
 
 }

--- a/python/ql/src/semmle/python/pointsto/PointsTo.qll
+++ b/python/ql/src/semmle/python/pointsto/PointsTo.qll
@@ -13,7 +13,7 @@ library class CfgOrigin extends @py_object {
 
     string toString() {
         /* Not to be displayed */
-        none()
+        result = "CfgOrigin"
     }
 
     /** Get a `ControlFlowNode` from `this` or `here`.
@@ -68,7 +68,7 @@ module CfgOrigin {
 //
 //    string toString() {
 //        /* Not to be displayed */
-//        none()
+//        result = "CfgOrigin"
 //    }
 //
 //    /** Get a `ControlFlowNode` from `this` or `here`.

--- a/python/ql/src/semmle/python/types/Extensions.qll
+++ b/python/ql/src/semmle/python/types/Extensions.qll
@@ -20,7 +20,7 @@ import semmle.python.objects.ObjectInternal
 
 abstract class PointsToExtension extends @py_flow_node {
 
-    string toString() { none() }
+    string toString() { result = "PointsToExtension with missing toString" }
 
     abstract predicate pointsTo(Context context, ObjectInternal value, ControlFlowNode origin);
 
@@ -36,7 +36,7 @@ abstract class PointsToExtension extends @py_flow_node {
 /** DEPRECATED -- Use PointsToExtension instead */
 deprecated abstract class CustomPointsToFact extends @py_flow_node {
 
-    string toString() { none() }
+    string toString() { result = "CustomPointsToFact with missing toString" }
 
     abstract predicate pointsTo(Context context, Object value, ClassObject cls, ControlFlowNode origin);
 


### PR DESCRIPTION
Having `toString()` defined to be `none()` is a major headache when debugging,
as `toString`-less results are silently elided. This PR puts dummy `toString`s
in place of the `none()`s.

(I am mostly creating this to see if it impacts our tests and/or the
performance. If not, we may as well merge it.)