### PR TITLE
C++: Suppress ExprHasNoEffect on template code

### DIFF
--- a/cpp/ql/src/Likely Bugs/Likely Typos/ExprHasNoEffect.ql
+++ b/cpp/ql/src/Likely Bugs/Likely Typos/ExprHasNoEffect.ql
@@ -84,6 +84,7 @@ where
   not peivc.getEnclosingFunction().isDefaulted() and
   not exists(Macro m | peivc = m.getAnInvocation().getAnExpandedElement()) and
   not peivc.isFromTemplateInstantiation(_) and
+  not peivc.isFromUninstantiatedTemplate(_) and
   parent = peivc.getParent() and
   not parent.isInMacroExpansion() and
   not parent instanceof PureExprInVoidContext and

--- a/cpp/ql/test/query-tests/Likely Bugs/Likely Typos/ExprHasNoEffect/ExprHasNoEffect.expected
+++ b/cpp/ql/test/query-tests/Likely Bugs/Likely Typos/ExprHasNoEffect/ExprHasNoEffect.expected
@@ -25,8 +25,6 @@
 | test.c:25:5:25:16 | ... ? ... : ... | This expression has no effect. | test.c:25:5:25:16 | ... ? ... : ... |  |
 | test.c:26:15:26:16 | 32 | This expression has no effect. | test.c:26:15:26:16 | 32 |  |
 | test.c:27:9:27:10 | 33 | This expression has no effect. | test.c:27:9:27:10 | 33 |  |
-| test.cpp:24:3:24:3 | call to operator++ | This expression has no effect (because $@ has no external side effects). | test.cpp:9:14:9:23 | operator++ | operator++ |
-| test.cpp:25:3:25:3 | call to operator++ | This expression has no effect (because $@ has no external side effects). | test.cpp:9:14:9:23 | operator++ | operator++ |
 | test.cpp:62:5:62:5 | call to operator= | This expression has no effect (because $@ has no external side effects). | test.cpp:47:14:47:22 | operator= | operator= |
 | test.cpp:65:5:65:5 | call to operator= | This expression has no effect (because $@ has no external side effects). | test.cpp:55:7:55:7 | operator= | operator= |
 | volatile.c:9:5:9:5 | c | This expression has no effect. | volatile.c:9:5:9:5 | c |  |

--- a/cpp/ql/test/query-tests/Likely Bugs/Likely Typos/ExprHasNoEffect/test.cpp
+++ b/cpp/ql/test/query-tests/Likely Bugs/Likely Typos/ExprHasNoEffect/test.cpp
@@ -21,8 +21,8 @@ public:
 		MyIterator arg1, arg2;
 		_It arg3;
 
-		++arg1; // pure, does nothing
-		++arg2; // pure, does nothing
+		++arg1; // pure, does nothing [NOT DETECTED]
+		++arg2; // pure, does nothing [NOT DETECTED]
 		++arg3; // not pure in all cases (when _It is int this has a side-effect)
 
 		return arg2;


### PR DESCRIPTION
Fixes #2298 (see https://github.slack.com/archives/CP0MHKV6E/p1574086207203400 for a diagnosis).

Supersedes #2384.