### PR TITLE
CPP: Make NoSpaceForZeroTerminator.ql more conservative.

### DIFF
--- a/change-notes/1.24/analysis-cpp.md
+++ b/change-notes/1.24/analysis-cpp.md
@@ -1,0 +1,20 @@
+# Improvements to C/C++ analysis
+
+The following changes in version 1.24 affect C/C++ analysis in all applications.
+
+## General improvements
+
+## New queries
+
+| **Query**                   | **Tags**  | **Purpose**                                                        |
+|-----------------------------|-----------|--------------------------------------------------------------------|
+
+## Changes to existing queries
+
+| **Query**                  | **Expected impact**    | **Change**                                                       |
+|----------------------------|------------------------|------------------------------------------------------------------|
+| No space for zero terminator (`cpp/no-space-for-terminator`) | Fewer false positive results | This query has been modified to be more conservative when identifying which pointers point to null-terminated strings.  This approach produces fewer, more accurate results. |
+
+## Changes to libraries
+
+* 

--- a/cpp/ql/src/Security/CWE/CWE-131/NoSpaceForZeroTerminator.ql
+++ b/cpp/ql/src/Security/CWE/CWE-131/NoSpaceForZeroTerminator.ql
@@ -21,16 +21,12 @@ import semmle.code.cpp.models.interfaces.ArrayFunction
 class MallocCall extends FunctionCall {
   MallocCall() { this.getTarget().hasGlobalOrStdName("malloc") }
 
-  Expr getAllocatedSize() {
-    result = this.getArgument(0)
-  }
+  Expr getAllocatedSize() { result = this.getArgument(0) }
 }
 
 predicate terminationProblem(MallocCall malloc, string msg) {
   // malloc(strlen(...))
-  exists(StrlenCall strlen |
-    DataFlow::localExprFlow(strlen, malloc.getAllocatedSize())
-  ) and
+  exists(StrlenCall strlen | DataFlow::localExprFlow(strlen, malloc.getAllocatedSize())) and
   // flows into a null-terminated string function
   exists(ArrayFunction af, FunctionCall fc, int arg |
     DataFlow::localExprFlow(malloc, fc.getArgument(arg)) and

--- a/cpp/ql/src/Security/CWE/CWE-131/NoSpaceForZeroTerminator.ql
+++ b/cpp/ql/src/Security/CWE/CWE-131/NoSpaceForZeroTerminator.ql
@@ -22,19 +22,15 @@ class MallocCall extends FunctionCall {
   MallocCall() { this.getTarget().hasGlobalOrStdName("malloc") }
 
   Expr getAllocatedSize() {
-    if this.getArgument(0) instanceof VariableAccess
-    then
-      exists(LocalScopeVariable v, ControlFlowNode def |
-        definitionUsePair(v, def, this.getArgument(0)) and
-        exprDefinition(v, def, result)
-      )
-    else result = this.getArgument(0)
+    result = this.getArgument(0)
   }
 }
 
 predicate terminationProblem(MallocCall malloc, string msg) {
   // malloc(strlen(...))
-  malloc.getAllocatedSize() instanceof StrlenCall and
+  exists(StrlenCall strlen |
+    DataFlow::localExprFlow(strlen, malloc.getAllocatedSize())
+  ) and
   // flows into a null-terminated string function
   exists(ArrayFunction af, FunctionCall fc, int arg |
     DataFlow::localExprFlow(malloc, fc.getArgument(arg)) and

--- a/cpp/ql/test/query-tests/Security/CWE/CWE-131/semmle/NoSpaceForZeroTerminator/NoSpaceForZeroTerminator.expected
+++ b/cpp/ql/test/query-tests/Security/CWE/CWE-131/semmle/NoSpaceForZeroTerminator/NoSpaceForZeroTerminator.expected
@@ -2,3 +2,10 @@
 | test.c:32:20:32:25 | call to malloc | This allocation does not include space to null-terminate the string. |
 | test.c:49:20:49:25 | call to malloc | This allocation does not include space to null-terminate the string. |
 | test.cpp:24:35:24:40 | call to malloc | This allocation does not include space to null-terminate the string. |
+| test.cpp:45:28:45:33 | call to malloc | This allocation does not include space to null-terminate the string. |
+| test.cpp:55:28:55:33 | call to malloc | This allocation does not include space to null-terminate the string. |
+| test.cpp:63:28:63:33 | call to malloc | This allocation does not include space to null-terminate the string. |
+| test.cpp:71:28:71:33 | call to malloc | This allocation does not include space to null-terminate the string. |
+| test.cpp:79:28:79:33 | call to malloc | This allocation does not include space to null-terminate the string. |
+| test.cpp:89:35:89:40 | call to malloc | This allocation does not include space to null-terminate the string. |
+| test.cpp:99:28:99:33 | call to malloc | This allocation does not include space to null-terminate the string. |

--- a/cpp/ql/test/query-tests/Security/CWE/CWE-131/semmle/NoSpaceForZeroTerminator/NoSpaceForZeroTerminator.expected
+++ b/cpp/ql/test/query-tests/Security/CWE/CWE-131/semmle/NoSpaceForZeroTerminator/NoSpaceForZeroTerminator.expected
@@ -1,12 +1,6 @@
-| test2.cpp:35:28:35:33 | call to malloc | This allocation does not include space to null-terminate the string. |
 | test.c:16:20:16:25 | call to malloc | This allocation does not include space to null-terminate the string. |
 | test.c:32:20:32:25 | call to malloc | This allocation does not include space to null-terminate the string. |
 | test.c:49:20:49:25 | call to malloc | This allocation does not include space to null-terminate the string. |
 | test.cpp:24:35:24:40 | call to malloc | This allocation does not include space to null-terminate the string. |
-| test.cpp:45:28:45:33 | call to malloc | This allocation does not include space to null-terminate the string. |
-| test.cpp:55:28:55:33 | call to malloc | This allocation does not include space to null-terminate the string. |
 | test.cpp:63:28:63:33 | call to malloc | This allocation does not include space to null-terminate the string. |
 | test.cpp:71:28:71:33 | call to malloc | This allocation does not include space to null-terminate the string. |
-| test.cpp:79:28:79:33 | call to malloc | This allocation does not include space to null-terminate the string. |
-| test.cpp:89:35:89:40 | call to malloc | This allocation does not include space to null-terminate the string. |
-| test.cpp:99:28:99:33 | call to malloc | This allocation does not include space to null-terminate the string. |

--- a/cpp/ql/test/query-tests/Security/CWE/CWE-131/semmle/NoSpaceForZeroTerminator/NoSpaceForZeroTerminator.expected
+++ b/cpp/ql/test/query-tests/Security/CWE/CWE-131/semmle/NoSpaceForZeroTerminator/NoSpaceForZeroTerminator.expected
@@ -1,3 +1,4 @@
+| test2.cpp:35:28:35:33 | call to malloc | This allocation does not include space to null-terminate the string. |
 | test.c:16:20:16:25 | call to malloc | This allocation does not include space to null-terminate the string. |
 | test.c:32:20:32:25 | call to malloc | This allocation does not include space to null-terminate the string. |
 | test.c:49:20:49:25 | call to malloc | This allocation does not include space to null-terminate the string. |

--- a/cpp/ql/test/query-tests/Security/CWE/CWE-131/semmle/NoSpaceForZeroTerminator/NoSpaceForZeroTerminator.expected
+++ b/cpp/ql/test/query-tests/Security/CWE/CWE-131/semmle/NoSpaceForZeroTerminator/NoSpaceForZeroTerminator.expected
@@ -1,4 +1,4 @@
-| test.c:15:20:15:25 | call to malloc | This allocation does not include space to null-terminate the string. |
-| test.c:29:20:29:25 | call to malloc | This allocation does not include space to null-terminate the string. |
-| test.c:44:20:44:25 | call to malloc | This allocation does not include space to null-terminate the string. |
-| test.cpp:18:35:18:40 | call to malloc | This allocation does not include space to null-terminate the string. |
+| test.c:16:20:16:25 | call to malloc | This allocation does not include space to null-terminate the string. |
+| test.c:32:20:32:25 | call to malloc | This allocation does not include space to null-terminate the string. |
+| test.c:49:20:49:25 | call to malloc | This allocation does not include space to null-terminate the string. |
+| test.cpp:24:35:24:40 | call to malloc | This allocation does not include space to null-terminate the string. |

--- a/cpp/ql/test/query-tests/Security/CWE/CWE-131/semmle/NoSpaceForZeroTerminator/test.c
+++ b/cpp/ql/test/query-tests/Security/CWE/CWE-131/semmle/NoSpaceForZeroTerminator/test.c
@@ -7,18 +7,21 @@
 typedef unsigned long size_t;
 void *malloc(size_t size);
 void free(void *ptr);
+char *strcpy(char *s1, const char *s2);
 
 //// Test code /////
 
 void bad0(char *str) {
     // BAD -- Not allocating space for '\0' terminator
     char *buffer = malloc(strlen(str));
+    strcpy(buffer, str);
     free(buffer);
 }
 
 void good0(char *str) {
     // GOOD -- Allocating extra byte for terminator
     char *buffer = malloc(strlen(str)+1);
+    strcpy(buffer, str);
     free(buffer);
 }
 
@@ -27,6 +30,7 @@ void bad1(char *str) {
     int len = strlen(str);
     // BAD -- Not allocating space for '\0' terminator
     char *buffer = malloc(len);
+    strcpy(buffer, str);
     free(buffer);
 }
 
@@ -34,6 +38,7 @@ void good1(char *str) {
     int len = strlen(str);
     // GOOD -- Allocating extra byte for terminator
     char *buffer = malloc(len+1);
+    strcpy(buffer, str);
     free(buffer);
 }
 
@@ -42,6 +47,7 @@ void bad2(char *str) {
     int len = strlen(str);
     // BAD -- Not allocating space for '\0' terminator
     char *buffer = malloc(len);
+    strcpy(buffer, str);
     free(buffer);
 }
 
@@ -49,18 +55,21 @@ void good2(char *str) {
     int len = strlen(str)+1;
     // GOOD -- Allocating extra byte for terminator
     char *buffer = malloc(len);
+    strcpy(buffer, str);
     free(buffer);
 }
 
 void bad3(char *str) {
     // BAD -- Not allocating space for '\0' terminator [NOT DETECTED]
     char *buffer = malloc(strlen(str) * sizeof(char));
+    strcpy(buffer, str);
     free(buffer);
 }
 
 void good3(char *str) {
     // GOOD -- Allocating extra byte for terminator
     char *buffer = malloc((strlen(str) + 1) * sizeof(char));
+    strcpy(buffer, str);
     free(buffer);
 }
 

--- a/cpp/ql/test/query-tests/Security/CWE/CWE-131/semmle/NoSpaceForZeroTerminator/test.cpp
+++ b/cpp/ql/test/query-tests/Security/CWE/CWE-131/semmle/NoSpaceForZeroTerminator/test.cpp
@@ -100,3 +100,10 @@ void good2(char *str, char *dest) {
     decode(buffer, str);
     free(buffer);
 }
+
+void bad9(wchar_t *wstr) {
+    // BAD -- using new [NOT DETECTED]
+    wchar_t *wbuffer = new wchar_t[wcslen(wstr)];
+    wcscpy(wbuffer, wstr);
+    delete wbuffer;
+}

--- a/cpp/ql/test/query-tests/Security/CWE/CWE-131/semmle/NoSpaceForZeroTerminator/test.cpp
+++ b/cpp/ql/test/query-tests/Security/CWE/CWE-131/semmle/NoSpaceForZeroTerminator/test.cpp
@@ -41,7 +41,7 @@ void good1(wchar_t *wstr) {
 }
 
 void bad3(char *str) {
-    // BAD -- zero-termination proved by sprintf (as destination)
+    // BAD -- zero-termination proved by sprintf (as destination) [NOT DETECTED]
     char *buffer = (char *)malloc(strlen(str));
     sprintf(buffer, "%s", str);
     free(buffer);
@@ -51,7 +51,7 @@ void decode(char *dest, char *src);
 void wdecode(wchar_t *dest, wchar_t *src);
 
 void bad4(char *str) {
-    // BAD -- zero-termination proved by wprintf (as parameter)
+    // BAD -- zero-termination proved by wprintf (as parameter) [NOT DETECTED]
     char *buffer = (char *)malloc(strlen(str));
     decode(buffer, str);
     wprintf(L"%s", buffer);
@@ -75,7 +75,7 @@ void bad6(char *str, char *dest) {
 }
 
 void bad7(char *str, char *str2) {
-    // BAD -- zero-termination proved by strcmp
+    // BAD -- zero-termination proved by strcmp [NOT DETECTED]
     char *buffer = (char *)malloc(strlen(str));
     decode(buffer, str);
     if (strcmp(buffer, str2) == 0) {
@@ -85,7 +85,7 @@ void bad7(char *str, char *str2) {
 }
 
 void bad8(wchar_t *str) {
-    // BAD -- zero-termination proved by wcslen
+    // BAD -- zero-termination proved by wcslen [NOT DETECTED]
     wchar_t *wbuffer = (wchar_t *)malloc(wcslen(str));
     wdecode(wbuffer, str);
     if (wcslen(wbuffer) == 0) {
@@ -95,7 +95,7 @@ void bad8(wchar_t *str) {
 }
 
 void good2(char *str, char *dest) {
-    // GOOD -- zero-termination not proven [FALSE POSITIVE]
+    // GOOD -- zero-termination not proven
     char *buffer = (char *)malloc(strlen(str));
     decode(buffer, str);
     free(buffer);

--- a/cpp/ql/test/query-tests/Security/CWE/CWE-131/semmle/NoSpaceForZeroTerminator/test.cpp
+++ b/cpp/ql/test/query-tests/Security/CWE/CWE-131/semmle/NoSpaceForZeroTerminator/test.cpp
@@ -10,23 +10,32 @@ typedef unsigned long size_t;
 void *malloc(size_t size);
 void free(void *ptr);
 size_t wcslen(const wchar_t *s);
+wchar_t* wcscpy(wchar_t* s1, const wchar_t* s2);
+
+
+
+
+
 
 //// Test code /////
 
 void bad1(wchar_t *wstr) {
     // BAD -- Not allocating space for '\0' terminator
     wchar_t *wbuffer = (wchar_t *)malloc(wcslen(wstr));
+    wcscpy(wbuffer, wstr);
     free(wbuffer);
 }
 
 void bad2(wchar_t *wstr) {
     // BAD -- Not allocating space for '\0' terminator [NOT DETECTED]
     wchar_t *wbuffer = (wchar_t *)malloc(wcslen(wstr) * sizeof(wchar_t));
+    wcscpy(wbuffer, wstr);
     free(wbuffer);
 }
 
 void good1(wchar_t *wstr) {
     // GOOD -- Allocating extra character for terminator
     wchar_t *wbuffer = (wchar_t *)malloc((wcslen(wstr) + 1) * sizeof(wchar_t));
+    wcscpy(wbuffer, wstr);
     free(wbuffer);
 }

--- a/cpp/ql/test/query-tests/Security/CWE/CWE-131/semmle/NoSpaceForZeroTerminator/test.cpp
+++ b/cpp/ql/test/query-tests/Security/CWE/CWE-131/semmle/NoSpaceForZeroTerminator/test.cpp
@@ -11,11 +11,11 @@ void *malloc(size_t size);
 void free(void *ptr);
 size_t wcslen(const wchar_t *s);
 wchar_t* wcscpy(wchar_t* s1, const wchar_t* s2);
-
-
-
-
-
+int sprintf(char *s, const char *format, ...);
+int wprintf(const wchar_t *format, ...);
+char *strcat(char *s1, const char *s2);
+size_t strlen(const char *s);
+int strcmp(const char *s1, const char *s2);
 
 //// Test code /////
 
@@ -38,4 +38,65 @@ void good1(wchar_t *wstr) {
     wchar_t *wbuffer = (wchar_t *)malloc((wcslen(wstr) + 1) * sizeof(wchar_t));
     wcscpy(wbuffer, wstr);
     free(wbuffer);
+}
+
+void bad3(char *str) {
+    // BAD -- zero-termination proved by sprintf (as destination)
+    char *buffer = (char *)malloc(strlen(str));
+    sprintf(buffer, "%s", str);
+    free(buffer);
+}
+
+void decode(char *dest, char *src);
+void wdecode(wchar_t *dest, wchar_t *src);
+
+void bad4(char *str) {
+    // BAD -- zero-termination proved by wprintf (as parameter)
+    char *buffer = (char *)malloc(strlen(str));
+    decode(buffer, str);
+    wprintf(L"%s", buffer);
+    free(buffer);
+}
+
+void bad5(char *str) {
+    // BAD -- zero-termination proved by strcat (as destination)
+    char *buffer = (char *)malloc(strlen(str));
+    buffer[0] = 0;
+    strcat(buffer, str);
+    free(buffer);
+}
+
+void bad6(char *str, char *dest) {
+    // BAD -- zero-termination proved by strcat (as source)
+    char *buffer = (char *)malloc(strlen(str));
+    decode(buffer, str);
+    strcat(dest, buffer);
+    free(buffer);
+}
+
+void bad7(char *str, char *str2) {
+    // BAD -- zero-termination proved by strcmp
+    char *buffer = (char *)malloc(strlen(str));
+    decode(buffer, str);
+    if (strcmp(buffer, str2) == 0) {
+        // ...
+    }
+    free(buffer);
+}
+
+void bad8(wchar_t *str) {
+    // BAD -- zero-termination proved by wcslen
+    wchar_t *wbuffer = (wchar_t *)malloc(wcslen(str));
+    wdecode(wbuffer, str);
+    if (wcslen(wbuffer) == 0) {
+        // ...
+    }
+    free(wbuffer);
+}
+
+void good2(char *str, char *dest) {
+    // GOOD -- zero-termination not proven [FALSE POSITIVE]
+    char *buffer = (char *)malloc(strlen(str));
+    decode(buffer, str);
+    free(buffer);
 }

--- a/cpp/ql/test/query-tests/Security/CWE/CWE-131/semmle/NoSpaceForZeroTerminator/test2.cpp
+++ b/cpp/ql/test/query-tests/Security/CWE/CWE-131/semmle/NoSpaceForZeroTerminator/test2.cpp
@@ -14,13 +14,16 @@ namespace std
 	template <class T> class allocator {
 	public:
 		allocator() throw();
+		typedef size_t size_type;
 	};
 	
 	template<class charT, class traits = char_traits<charT>, class Allocator = allocator<charT> >
 	class basic_string {
 	public:
+		typedef typename Allocator::size_type size_type;
 		explicit basic_string(const Allocator& a = Allocator());
 		basic_string(const charT* s, const Allocator& a = Allocator());
+		basic_string(const charT* s, size_type n, const Allocator& a = Allocator()); 
 
 		const charT* c_str() const;
 	};
@@ -36,3 +39,12 @@ void bad1(char *str) {
     std::string str2(buffer);
     free(buffer);
 }
+
+void good1(char *str) {
+    // GOOD --- copy does not overrun due to size limit
+    char *buffer = (char *)malloc(strlen(str));
+    std::string str2(buffer, strlen(str));
+    free(buffer);
+}
+
+

--- a/cpp/ql/test/query-tests/Security/CWE/CWE-131/semmle/NoSpaceForZeroTerminator/test2.cpp
+++ b/cpp/ql/test/query-tests/Security/CWE/CWE-131/semmle/NoSpaceForZeroTerminator/test2.cpp
@@ -31,7 +31,7 @@ namespace std
 //// Test code /////
 
 void bad1(char *str) {
-    // BAD -- Not allocating space for '\0' terminator
+    // BAD -- Not allocating space for '\0' terminator [NOT DETECTED]
     char *buffer = (char *)malloc(strlen(str));
     std::string str2(buffer);
     free(buffer);

--- a/cpp/ql/test/query-tests/Security/CWE/CWE-131/semmle/NoSpaceForZeroTerminator/test2.cpp
+++ b/cpp/ql/test/query-tests/Security/CWE/CWE-131/semmle/NoSpaceForZeroTerminator/test2.cpp
@@ -1,0 +1,38 @@
+
+///// Library functions //////
+
+typedef unsigned long size_t;
+
+void *malloc(size_t size);
+void free(void *ptr);
+size_t strlen(const char *s);
+
+namespace std
+{
+	template<class charT> struct char_traits;
+
+	template <class T> class allocator {
+	public:
+		allocator() throw();
+	};
+	
+	template<class charT, class traits = char_traits<charT>, class Allocator = allocator<charT> >
+	class basic_string {
+	public:
+		explicit basic_string(const Allocator& a = Allocator());
+		basic_string(const charT* s, const Allocator& a = Allocator());
+
+		const charT* c_str() const;
+	};
+
+	typedef basic_string<char> string;
+}
+
+//// Test code /////
+
+void bad1(char *str) {
+    // BAD -- Not allocating space for '\0' terminator
+    char *buffer = (char *)malloc(strlen(str));
+    std::string str2(buffer);
+    free(buffer);
+}


### PR DESCRIPTION
Make NoSpaceForZeroTerminator.ql more conservative by requiring evidence that the string pointer is a null-terminated string, rather than assuming that it is unless we find evidence that it isn't.  This results in fewer, more accurate results (for example it should solve https://github.com/Semmle/ql/issues/2363).

A few notes:
 - weirdly, I can't actually reproduce https://github.com/Semmle/ql/issues/2363 locally, so can't confirm that fix.
 - I experimented with a non-local dataflow version of the query that would report paths, but generally the results it found were local anyway and the paths weren't interesting.  I think I prefer sticking to the (simpler, cached, presumably faster) local dataflow version.  I still have the code for the other version if anyone wants a look.
 - we've lost quite a lot of results in the tests, this is because we don't model enough things as `ArrayFunction`s in the models library yet.  I will make a couple of follow-up PRs to address this and fix all-but-one of the lost results.