### PR TITLE
Python: Support forward references inside return type annotations.

### DIFF
--- a/python/ql/src/Imports/UnusedImport.ql
+++ b/python/ql/src/Imports/UnusedImport.ql
@@ -64,9 +64,11 @@ private string doctest_in_scope(Scope scope) {
 pragma[noinline]
 private string typehint_annotation_in_file(File file) {
     exists(StrConst annotation |
-        annotation = any(Arguments a).getAnAnnotation()
+        annotation = any(Arguments a).getAnAnnotation().getASubExpression*()
         or
-        annotation = any(AnnAssign a).getAnnotation()
+        annotation = any(AnnAssign a).getAnnotation().getASubExpression*()
+        or
+        annotation = any(FunctionExpr f).getReturns().getASubExpression*()
     |
         annotation.pointsTo(Value::forString(result)) and
         file = annotation.getLocation().getFile()

--- a/python/ql/test/query-tests/Imports/unused/imports_test.py
+++ b/python/ql/test/query-tests/Imports/unused/imports_test.py
@@ -90,3 +90,24 @@ def func(x: 'Optional[only_used_in_parameter_annotation]'):
 import only_used_in_annotated_assignment
 
 var : 'Optional[only_used_in_annotated_assignment]' = 5
+
+import used_in_return_type
+
+def look_at_my_return_type() -> 'Optional[used_in_return_type]':
+    pass
+
+# Uses inside strings appearing as subexpressions of an annotation:
+
+import subexpression_parameter_annotation
+
+def bar(x: Optional['subexpression_parameter_annotation']):
+    pass
+
+import subexpression_assignment_annotation
+
+var3 : Optional['subexpression_assignment_annotation'] = None
+
+import subexpression_return_type
+
+def baz() -> Optional['subexpression_return_type']:
+    pass


### PR DESCRIPTION
Should fix #2407.

Also allows for the string containing the forward reference to appear inside a
subexpression of the type annotation.

This needs to be performance tested before merging.