### PR TITLE
JS: Type-track regexp objects and more fine-grained sanitizer guards

### DIFF
--- a/javascript/ql/src/semmle/javascript/Expr.qll
+++ b/javascript/ql/src/semmle/javascript/Expr.qll
@@ -454,16 +454,16 @@ class RegExpLiteral extends @regexpliteral, Literal, RegExpParent {
   string getFlags() { result = getValue().regexpCapture(".*/(\\w*)$", 1) }
 
   /** Holds if this regular expression has an `m` flag. */
-  predicate isMultiline() { getFlags().matches("%m%") }
+  predicate isMultiline() { RegExp::isMultiline(getFlags()) }
 
   /** Holds if this regular expression has a `g` flag. */
-  predicate isGlobal() { getFlags().matches("%g%") }
+  predicate isGlobal() { RegExp::isGlobal(getFlags()) }
 
   /** Holds if this regular expression has an `i` flag. */
-  predicate isIgnoreCase() { getFlags().matches("%i%") }
+  predicate isIgnoreCase() { RegExp::isIgnoreCase(getFlags()) }
 
   /** Holds if this regular expression has an `s` flag. */
-  predicate isDotAll() { getFlags().matches("%s%") }
+  predicate isDotAll() { RegExp::isDotAll(getFlags()) }
 }
 
 /**

--- a/javascript/ql/src/semmle/javascript/Regexp.qll
+++ b/javascript/ql/src/semmle/javascript/Regexp.qll
@@ -990,7 +990,7 @@ module RegExp {
   }
 
   /**
-   * Holds if `term` is matches any character except for explicitly listed exceptions.
+   * Holds if `term` matches any character except for explicitly listed exceptions.
    *
    * For example, holds for `.`, `[^<>]`, or `\W`, but not for `[a-z]`, `\w`, or `[^\W\S]`.
    */
@@ -999,11 +999,13 @@ module RegExp {
     or
     term.(RegExpCharacterClassEscape).getValue().isUppercase()
     or
+    // [^a-z]
     exists(RegExpCharacterClass cls | term = cls |
       cls.isInverted() and
       not cls.getAChild().(RegExpCharacterClassEscape).getValue().isUppercase()
     )
     or
+    // [\W]
     exists(RegExpCharacterClass cls | term = cls |
       not cls.isInverted() and
       cls.getAChild().(RegExpCharacterClassEscape).getValue().isUppercase()
@@ -1024,6 +1026,7 @@ module RegExp {
       isFullyAnchoredTerm(term) and
       not isWildcardLike(term.getAChild*())
       or
+      // Character set restrictions like `/[^a-z]/.test(x)` sanitize in the false case
       outcome = false and
       exists(RegExpTerm root |
         root = term
@@ -1043,7 +1046,7 @@ module RegExp {
   RegExpTerm getRegExpObjectFromNode(DataFlow::Node node) {
     exists(DataFlow::RegExpCreationNode regexp |
       regexp.getAReference().flowsTo(node) and
-      result = regexp.getRegExpTerm()
+      result = regexp.getRoot()
     )
   }
 

--- a/javascript/ql/src/semmle/javascript/Regexp.qll
+++ b/javascript/ql/src/semmle/javascript/Regexp.qll
@@ -113,9 +113,7 @@ class RegExpTerm extends Locatable, @regexpterm {
   /**
    * Holds if this is the root term of a regular expression.
    */
-  predicate isRootTerm() {
-    not getParent() instanceof RegExpTerm
-  }
+  predicate isRootTerm() { not getParent() instanceof RegExpTerm }
 
   /**
    * Gets the outermost term of this regular expression.
@@ -130,9 +128,7 @@ class RegExpTerm extends Locatable, @regexpterm {
   /**
    * Holds if this term occurs as part of a regular expression literal.
    */
-  predicate isPartOfRegExpLiteral() {
-    exists(getLiteral())
-  }
+  predicate isPartOfRegExpLiteral() { exists(getLiteral()) }
 
   /**
    * Holds if this term occurs as part of a string literal.
@@ -140,9 +136,7 @@ class RegExpTerm extends Locatable, @regexpterm {
    * This predicate holds regardless of whether the string literal is actually
    * used as a regular expression. See `isUsedAsRegExp`.
    */
-  predicate isPartOfStringLiteral() {
-    getRootTerm().getParent() instanceof StringLiteral
-  }
+  predicate isPartOfStringLiteral() { getRootTerm().getParent() instanceof StringLiteral }
 
   /**
    * Holds if this term is part of a regular expression literal, or a string literal
@@ -344,8 +338,7 @@ class RegExpAnchor extends RegExpTerm, @regexp_anchor {
  * ^
  * ```
  */
-class RegExpCaret extends RegExpAnchor, @regexp_caret {
-}
+class RegExpCaret extends RegExpAnchor, @regexp_caret { }
 
 /**
  * A dollar assertion `$` matching the end of a line.
@@ -356,8 +349,7 @@ class RegExpCaret extends RegExpAnchor, @regexp_caret {
  * $
  * ```
  */
-class RegExpDollar extends RegExpAnchor, @regexp_dollar {
-}
+class RegExpDollar extends RegExpAnchor, @regexp_dollar { }
 
 /**
  * A word boundary assertion.
@@ -939,4 +931,41 @@ private class StringRegExpPatternSource extends RegExpPatternSource {
   override string getPattern() { result = getStringValue() }
 
   override RegExpTerm getRegExpTerm() { result = asExpr().(StringLiteral).asRegExp() }
+}
+
+module RegExp {
+  /** Gets the string `"?"` used to represent a regular expression whose flags are unknown. */
+  string unknownFlag() { result = "?" }
+
+  /** Holds `flags` includes the `m` flag. */
+  bindingset[flags]
+  predicate isMultiline(string flags) { flags.matches("%m%") }
+
+  /** Holds `flags` includes the `g` flag. */
+  bindingset[flags]
+  predicate isGlobal(string flags) { flags.matches("%g%") }
+
+  /** Holds `flags` includes the `i` flag. */
+  bindingset[flags]
+  predicate isIgnoreCase(string flags) { flags.matches("%i%") }
+
+  /** Holds `flags` includes the `s` flag. */
+  bindingset[flags]
+  predicate isDotAll(string flags) { flags.matches("%s%") }
+
+  /** Holds `flags` includes the `m` flag or is the unknown flag `?`. */
+  bindingset[flags]
+  predicate maybeMultiline(string flags) { flags = unknownFlag() or isMultiline(flags) }
+
+  /** Holds `flags` includes the `g` flag or is the unknown flag `?`. */
+  bindingset[flags]
+  predicate maybeGlobal(string flags) { flags = unknownFlag() or isGlobal(flags) }
+
+  /** Holds `flags` includes the `i` flag or is the unknown flag `?`. */
+  bindingset[flags]
+  predicate maybeIgnoreCase(string flags) { flags = unknownFlag() or isIgnoreCase(flags) }
+
+  /** Holds `flags` includes the `s` flag or is the unknown flag `?`. */
+  bindingset[flags]
+  predicate maybeDotAll(string flags) { flags = unknownFlag() or isDotAll(flags) }
 }

--- a/javascript/ql/src/semmle/javascript/Regexp.qll
+++ b/javascript/ql/src/semmle/javascript/Regexp.qll
@@ -945,27 +945,27 @@ module RegExp {
   bindingset[flags]
   predicate isGlobal(string flags) { flags.matches("%g%") }
 
-  /** Holds `flags` includes the `i` flag. */
+  /** Holds if `flags` includes the `i` flag. */
   bindingset[flags]
   predicate isIgnoreCase(string flags) { flags.matches("%i%") }
 
-  /** Holds `flags` includes the `s` flag. */
+  /** Holds if `flags` includes the `s` flag. */
   bindingset[flags]
   predicate isDotAll(string flags) { flags.matches("%s%") }
 
-  /** Holds `flags` includes the `m` flag or is the unknown flag `?`. */
+  /** Holds if `flags` includes the `m` flag or is the unknown flag `?`. */
   bindingset[flags]
   predicate maybeMultiline(string flags) { flags = unknownFlag() or isMultiline(flags) }
 
-  /** Holds `flags` includes the `g` flag or is the unknown flag `?`. */
+  /** Holds if `flags` includes the `g` flag or is the unknown flag `?`. */
   bindingset[flags]
   predicate maybeGlobal(string flags) { flags = unknownFlag() or isGlobal(flags) }
 
-  /** Holds `flags` includes the `i` flag or is the unknown flag `?`. */
+  /** Holds if `flags` includes the `i` flag or is the unknown flag `?`. */
   bindingset[flags]
   predicate maybeIgnoreCase(string flags) { flags = unknownFlag() or isIgnoreCase(flags) }
 
-  /** Holds `flags` includes the `s` flag or is the unknown flag `?`. */
+  /** Holds if `flags` includes the `s` flag or is the unknown flag `?`. */
   bindingset[flags]
   predicate maybeDotAll(string flags) { flags = unknownFlag() or isDotAll(flags) }
 

--- a/javascript/ql/src/semmle/javascript/Regexp.qll
+++ b/javascript/ql/src/semmle/javascript/Regexp.qll
@@ -937,7 +937,7 @@ module RegExp {
   /** Gets the string `"?"` used to represent a regular expression whose flags are unknown. */
   string unknownFlag() { result = "?" }
 
-  /** Holds `flags` includes the `m` flag. */
+  /** Holds if `flags` includes the `m` flag. */
   bindingset[flags]
   predicate isMultiline(string flags) { flags.matches("%m%") }
 

--- a/javascript/ql/src/semmle/javascript/Regexp.qll
+++ b/javascript/ql/src/semmle/javascript/Regexp.qll
@@ -941,7 +941,7 @@ module RegExp {
   bindingset[flags]
   predicate isMultiline(string flags) { flags.matches("%m%") }
 
-  /** Holds `flags` includes the `g` flag. */
+  /** Holds if `flags` includes the `g` flag. */
   bindingset[flags]
   predicate isGlobal(string flags) { flags.matches("%g%") }
 

--- a/javascript/ql/src/semmle/javascript/dataflow/Nodes.qll
+++ b/javascript/ql/src/semmle/javascript/dataflow/Nodes.qll
@@ -546,6 +546,11 @@ class RegExpLiteralNode extends DataFlow::ValueNode, DataFlow::SourceNode {
 
   /** Gets the root term of this regular expression. */
   RegExpTerm getRoot() { result = astNode.getRoot() }
+
+  /** Gets the flags of this regular expression literal. */
+  string getFlags() {
+    result = astNode.getFlags()
+  }
 }
 
 /**
@@ -1331,9 +1336,10 @@ class RegExpConstructorInvokeNode extends DataFlow::InvokeNode {
   }
 
   /**
-   * Gets the AST of the regular expression created here, if it is constant.
+   * Gets the AST of the regular expression created here, provided that the
+   * first argument is a string literal.
    */
-  RegExpTerm getRegExpTerm() {
+  RegExpTerm getRoot() {
     result = getArgument(0).asExpr().(StringLiteral).asRegExp()
   }
 
@@ -1363,28 +1369,6 @@ class RegExpConstructorInvokeNode extends DataFlow::InvokeNode {
 }
 
 /**
- * A data flow node corresponding to a regular expression literal.
- *
- * Example:
- * ```js
- * /[a-z]+/i
- * ```
- */
-class RegExpLiteralNode extends DataFlow::SourceNode, DataFlow::ValueNode {
-  override RegExpLiteral astNode;
-
-  /** Gets the root term of this regular expression literal. */
-  RegExpTerm getRegExpTerm() {
-    result = astNode.getRoot()
-  }
-
-  /** Gets the flags of this regular expression literal. */
-  string getFlags() {
-    result = astNode.getFlags()
-  }
-}
-
-/**
  * A data flow node corresponding to a regular expression literal or
  * an invocation of the `RegExp` constructor.
  *
@@ -1406,9 +1390,9 @@ class RegExpCreationNode extends DataFlow::SourceNode {
    *
    * Has no result for calls to `RegExp` with a non-constant argument.
    */
-  RegExpTerm getRegExpTerm() {
-    result = this.(RegExpConstructorInvokeNode).getRegExpTerm() or
-    result = this.(RegExpLiteralNode).getRegExpTerm()
+  RegExpTerm getRoot() {
+    result = this.(RegExpConstructorInvokeNode).getRoot() or
+    result = this.(RegExpLiteralNode).getRoot()
   }
 
   /**

--- a/javascript/ql/src/semmle/javascript/dataflow/Nodes.qll
+++ b/javascript/ql/src/semmle/javascript/dataflow/Nodes.qll
@@ -1315,3 +1315,131 @@ module PartialInvokeNode {
  * This contributes additional argument-passing flow edges that should be added to all data flow configurations.
  */
 deprecated class AdditionalPartialInvokeNode = PartialInvokeNode::Range;
+
+/**
+ * An invocation of the `RegExp` constructor.
+ *
+ * Example:
+ * ```js
+ * new RegExp("#[a-z]+", "g");
+ * RegExp("^\w*$");
+ * ```
+ */
+class RegExpConstructorInvokeNode extends DataFlow::InvokeNode {
+  RegExpConstructorInvokeNode() {
+    this = DataFlow::globalVarRef("RegExp").getAnInvocation()
+  }
+
+  /**
+   * Gets the AST of the regular expression created here, if it is constant.
+   */
+  RegExpTerm getRegExpTerm() {
+    result = getArgument(0).asExpr().(StringLiteral).asRegExp()
+  }
+
+  /**
+   * Gets the flags provided in the second argument, or an empty string if no
+   * flags are provided.
+   *
+   * Has no result if the flags are provided but are not constant.
+   */
+  string getFlags() {
+    result = getArgument(1).getStringValue()
+    or
+    not exists(getArgument(1)) and
+    result = ""
+  }
+
+  /**
+   * Gets the flags provided in the second argument, or an empty string if no
+   * flags are provided, or the string `"?"` if the provided flags are not known.
+   */
+  string tryGetFlags() {
+    result = getFlags()
+    or
+    not exists(getFlags()) and
+    result = RegExp::unknownFlag()
+  }
+}
+
+/**
+ * A data flow node corresponding to a regular expression literal.
+ *
+ * Example:
+ * ```js
+ * /[a-z]+/i
+ * ```
+ */
+class RegExpLiteralNode extends DataFlow::SourceNode, DataFlow::ValueNode {
+  override RegExpLiteral astNode;
+
+  /** Gets the root term of this regular expression literal. */
+  RegExpTerm getRegExpTerm() {
+    result = astNode.getRoot()
+  }
+
+  /** Gets the flags of this regular expression literal. */
+  string getFlags() {
+    result = astNode.getFlags()
+  }
+}
+
+/**
+ * A data flow node corresponding to a regular expression literal or
+ * an invocation of the `RegExp` constructor.
+ *
+ * Examples:
+ * ```js
+ * new RegExp("#[a-z]+", "g");
+ * RegExp("^\w*$");
+ * /[a-z]+/i
+ * ```
+ */
+class RegExpCreationNode extends DataFlow::SourceNode {
+  RegExpCreationNode() {
+    this instanceof RegExpConstructorInvokeNode or
+    this instanceof RegExpLiteralNode
+  }
+
+  /**
+   * Gets the root term of the created regular expression, if it is known.
+   *
+   * Has no result for calls to `RegExp` with a non-constant argument.
+   */
+  RegExpTerm getRegExpTerm() {
+    result = this.(RegExpConstructorInvokeNode).getRegExpTerm() or
+    result = this.(RegExpLiteralNode).getRegExpTerm()
+  }
+
+  /**
+   * Gets the provided regular expression flags, if they are known.
+   */
+  string getFlags() {
+    result = this.(RegExpConstructorInvokeNode).getFlags() or
+    result = this.(RegExpLiteralNode).getFlags()
+  }
+
+  /**
+   * Gets the flags provided in the second argument, or an empty string if no
+   * flags are provided, or the string `"?"` if the provided flags are not known.
+   */
+  string tryGetFlags() {
+    result = this.(RegExpConstructorInvokeNode).tryGetFlags() or
+    result = this.(RegExpLiteralNode).getFlags()
+  }
+
+  /** Gets a data flow node referring to this regular expression. */
+  private DataFlow::SourceNode getAReference(DataFlow::TypeTracker t) {
+    t.start() and
+    result = this
+    or
+    exists(DataFlow::TypeTracker t2 |
+      result = getAReference(t2).track(t2, t)
+    )
+  }
+
+  /** Gets a data flow node referring to this regular expression. */
+  DataFlow::SourceNode getAReference() {
+    result = getAReference(DataFlow::TypeTracker::end())
+  }
+}

--- a/javascript/ql/test/library-tests/TaintBarriers/SanitizingGuard.expected
+++ b/javascript/ql/test/library-tests/TaintBarriers/SanitizingGuard.expected
@@ -1,7 +1,5 @@
-| tst.js:5:9:5:19 | /x/.test(v) | ExampleConfiguration | false | tst.js:5:18:5:18 | v |
-| tst.js:5:9:5:19 | /x/.test(v) | ExampleConfiguration | true | tst.js:5:18:5:18 | v |
-| tst.js:11:9:11:20 | v.match(/x/) | ExampleConfiguration | false | tst.js:11:9:11:9 | v |
-| tst.js:11:9:11:20 | v.match(/x/) | ExampleConfiguration | true | tst.js:11:9:11:9 | v |
+| tst.js:5:9:5:21 | /^x$/.test(v) | ExampleConfiguration | true | tst.js:5:20:5:20 | v |
+| tst.js:11:9:11:25 | v.match(/[^a-z]/) | ExampleConfiguration | false | tst.js:11:9:11:9 | v |
 | tst.js:23:9:23:27 | o.hasOwnProperty(v) | ExampleConfiguration | true | tst.js:23:26:23:26 | v |
 | tst.js:35:9:35:14 | v in o | ExampleConfiguration | true | tst.js:35:9:35:9 | v |
 | tst.js:47:9:47:25 | o[v] == undefined | ExampleConfiguration | false | tst.js:47:11:47:11 | v |

--- a/javascript/ql/test/library-tests/TaintBarriers/TaintedSink.expected
+++ b/javascript/ql/test/library-tests/TaintBarriers/TaintedSink.expected
@@ -1,4 +1,6 @@
 | tst.js:3:10:3:10 | v | tst.js:2:13:2:20 | SOURCE() |
+| tst.js:8:14:8:14 | v | tst.js:2:13:2:20 | SOURCE() |
+| tst.js:12:14:12:14 | v | tst.js:2:13:2:20 | SOURCE() |
 | tst.js:21:10:21:10 | v | tst.js:20:13:20:20 | SOURCE() |
 | tst.js:26:14:26:14 | v | tst.js:20:13:20:20 | SOURCE() |
 | tst.js:33:10:33:10 | v | tst.js:32:13:32:20 | SOURCE() |

--- a/javascript/ql/test/library-tests/TaintBarriers/isBarrier.expected
+++ b/javascript/ql/test/library-tests/TaintBarriers/isBarrier.expected
@@ -1,6 +1,4 @@
 | tst.js:6:14:6:14 | v | ExampleConfiguration |
-| tst.js:8:14:8:14 | v | ExampleConfiguration |
-| tst.js:12:14:12:14 | v | ExampleConfiguration |
 | tst.js:14:14:14:14 | v | ExampleConfiguration |
 | tst.js:24:14:24:14 | v | ExampleConfiguration |
 | tst.js:36:14:36:14 | v | ExampleConfiguration |

--- a/javascript/ql/test/library-tests/TaintBarriers/tst.js
+++ b/javascript/ql/test/library-tests/TaintBarriers/tst.js
@@ -2,16 +2,16 @@ function SanitizingRegExpTest () {
     var v = SOURCE();
     SINK(v);
 
-    if (/x/.test(v)) {
-        SINK(v);
+    if (/^x$/.test(v)) {
+        SINK(v); // sanitized
     } else {
         SINK(v);
     }
 
-    if (v.match(/x/)) {
+    if (v.match(/[^a-z]/)) {
         SINK(v);
     } else {
-        SINK(v);
+        SINK(v); // sanitized
     }
 
 }

--- a/javascript/ql/test/query-tests/Security/CWE-079/ExceptionXss.expected
+++ b/javascript/ql/test/query-tests/Security/CWE-079/ExceptionXss.expected
@@ -59,16 +59,16 @@ nodes
 | exception-xss.js:129:10:129:10 | e |
 | exception-xss.js:130:18:130:18 | e |
 | exception-xss.js:130:18:130:18 | e |
-| tst.js:298:9:298:16 | location |
-| tst.js:298:9:298:16 | location |
-| tst.js:299:10:299:10 | e |
-| tst.js:300:20:300:20 | e |
-| tst.js:300:20:300:20 | e |
-| tst.js:305:10:305:17 | location |
-| tst.js:305:10:305:17 | location |
-| tst.js:307:10:307:10 | e |
-| tst.js:308:20:308:20 | e |
-| tst.js:308:20:308:20 | e |
+| tst.js:304:9:304:16 | location |
+| tst.js:304:9:304:16 | location |
+| tst.js:305:10:305:10 | e |
+| tst.js:306:20:306:20 | e |
+| tst.js:306:20:306:20 | e |
+| tst.js:311:10:311:17 | location |
+| tst.js:311:10:311:17 | location |
+| tst.js:313:10:313:10 | e |
+| tst.js:314:20:314:20 | e |
+| tst.js:314:20:314:20 | e |
 edges
 | exception-xss.js:2:9:2:31 | foo | exception-xss.js:9:11:9:13 | foo |
 | exception-xss.js:2:9:2:31 | foo | exception-xss.js:15:9:15:11 | foo |
@@ -127,14 +127,14 @@ edges
 | exception-xss.js:128:11:128:52 | session ... ssion') | exception-xss.js:129:10:129:10 | e |
 | exception-xss.js:129:10:129:10 | e | exception-xss.js:130:18:130:18 | e |
 | exception-xss.js:129:10:129:10 | e | exception-xss.js:130:18:130:18 | e |
-| tst.js:298:9:298:16 | location | tst.js:299:10:299:10 | e |
-| tst.js:298:9:298:16 | location | tst.js:299:10:299:10 | e |
-| tst.js:299:10:299:10 | e | tst.js:300:20:300:20 | e |
-| tst.js:299:10:299:10 | e | tst.js:300:20:300:20 | e |
-| tst.js:305:10:305:17 | location | tst.js:307:10:307:10 | e |
-| tst.js:305:10:305:17 | location | tst.js:307:10:307:10 | e |
-| tst.js:307:10:307:10 | e | tst.js:308:20:308:20 | e |
-| tst.js:307:10:307:10 | e | tst.js:308:20:308:20 | e |
+| tst.js:304:9:304:16 | location | tst.js:305:10:305:10 | e |
+| tst.js:304:9:304:16 | location | tst.js:305:10:305:10 | e |
+| tst.js:305:10:305:10 | e | tst.js:306:20:306:20 | e |
+| tst.js:305:10:305:10 | e | tst.js:306:20:306:20 | e |
+| tst.js:311:10:311:17 | location | tst.js:313:10:313:10 | e |
+| tst.js:311:10:311:17 | location | tst.js:313:10:313:10 | e |
+| tst.js:313:10:313:10 | e | tst.js:314:20:314:20 | e |
+| tst.js:313:10:313:10 | e | tst.js:314:20:314:20 | e |
 #select
 | exception-xss.js:11:18:11:18 | e | exception-xss.js:2:15:2:31 | document.location | exception-xss.js:11:18:11:18 | e | Cross-site scripting vulnerability due to $@. | exception-xss.js:2:15:2:31 | document.location | user-provided value |
 | exception-xss.js:17:18:17:18 | e | exception-xss.js:2:15:2:31 | document.location | exception-xss.js:17:18:17:18 | e | Cross-site scripting vulnerability due to $@. | exception-xss.js:2:15:2:31 | document.location | user-provided value |
@@ -147,5 +147,5 @@ edges
 | exception-xss.js:107:18:107:18 | e | exception-xss.js:2:15:2:31 | document.location | exception-xss.js:107:18:107:18 | e | Cross-site scripting vulnerability due to $@. | exception-xss.js:2:15:2:31 | document.location | user-provided value |
 | exception-xss.js:119:14:119:30 | "Exception: " + e | exception-xss.js:117:13:117:25 | req.params.id | exception-xss.js:119:14:119:30 | "Exception: " + e | Cross-site scripting vulnerability due to $@. | exception-xss.js:117:13:117:25 | req.params.id | user-provided value |
 | exception-xss.js:130:18:130:18 | e | exception-xss.js:125:48:125:64 | document.location | exception-xss.js:130:18:130:18 | e | Cross-site scripting vulnerability due to $@. | exception-xss.js:125:48:125:64 | document.location | user-provided value |
-| tst.js:300:20:300:20 | e | tst.js:298:9:298:16 | location | tst.js:300:20:300:20 | e | Cross-site scripting vulnerability due to $@. | tst.js:298:9:298:16 | location | user-provided value |
-| tst.js:308:20:308:20 | e | tst.js:305:10:305:17 | location | tst.js:308:20:308:20 | e | Cross-site scripting vulnerability due to $@. | tst.js:305:10:305:17 | location | user-provided value |
+| tst.js:306:20:306:20 | e | tst.js:304:9:304:16 | location | tst.js:306:20:306:20 | e | Cross-site scripting vulnerability due to $@. | tst.js:304:9:304:16 | location | user-provided value |
+| tst.js:314:20:314:20 | e | tst.js:311:10:311:17 | location | tst.js:314:20:314:20 | e | Cross-site scripting vulnerability due to $@. | tst.js:311:10:311:17 | location | user-provided value |

--- a/javascript/ql/test/query-tests/Security/CWE-079/Xss.expected
+++ b/javascript/ql/test/query-tests/Security/CWE-079/Xss.expected
@@ -234,103 +234,105 @@ nodes
 | tst.js:110:11:110:44 | documen ... bstr(1) |
 | tst.js:113:18:113:18 | v |
 | tst.js:113:18:113:18 | v |
-| tst.js:145:29:145:43 | window.location |
-| tst.js:145:29:145:43 | window.location |
-| tst.js:145:29:145:50 | window. ... .search |
-| tst.js:148:29:148:29 | v |
-| tst.js:148:49:148:49 | v |
-| tst.js:148:49:148:49 | v |
-| tst.js:152:29:152:46 | xssSourceService() |
-| tst.js:152:29:152:46 | xssSourceService() |
-| tst.js:155:40:155:54 | window.location |
-| tst.js:155:40:155:54 | window.location |
-| tst.js:155:40:155:61 | window. ... .search |
-| tst.js:174:9:174:41 | target |
-| tst.js:174:18:174:34 | document.location |
-| tst.js:174:18:174:34 | document.location |
-| tst.js:174:18:174:41 | documen ... .search |
-| tst.js:177:28:177:33 | target |
-| tst.js:177:28:177:33 | target |
-| tst.js:181:9:181:42 | tainted |
-| tst.js:181:19:181:35 | document.location |
-| tst.js:181:19:181:35 | document.location |
-| tst.js:181:19:181:42 | documen ... .search |
-| tst.js:183:31:183:37 | tainted |
-| tst.js:183:31:183:37 | tainted |
-| tst.js:185:42:185:48 | tainted |
-| tst.js:185:42:185:48 | tainted |
-| tst.js:186:33:186:39 | tainted |
-| tst.js:186:33:186:39 | tainted |
-| tst.js:188:54:188:60 | tainted |
-| tst.js:188:54:188:60 | tainted |
-| tst.js:189:45:189:51 | tainted |
-| tst.js:189:45:189:51 | tainted |
-| tst.js:194:9:194:42 | tainted |
-| tst.js:194:19:194:35 | document.location |
-| tst.js:194:19:194:35 | document.location |
-| tst.js:194:19:194:42 | documen ... .search |
-| tst.js:196:67:196:73 | tainted |
-| tst.js:196:67:196:73 | tainted |
-| tst.js:197:67:197:73 | tainted |
-| tst.js:197:67:197:73 | tainted |
-| tst.js:201:35:201:41 | tainted |
-| tst.js:203:46:203:52 | tainted |
-| tst.js:204:38:204:44 | tainted |
-| tst.js:205:35:205:41 | tainted |
-| tst.js:209:28:209:46 | this.state.tainted1 |
-| tst.js:209:28:209:46 | this.state.tainted1 |
-| tst.js:210:28:210:46 | this.state.tainted2 |
-| tst.js:210:28:210:46 | this.state.tainted2 |
-| tst.js:211:28:211:46 | this.state.tainted3 |
-| tst.js:211:28:211:46 | this.state.tainted3 |
-| tst.js:215:32:215:49 | prevState.tainted4 |
-| tst.js:215:32:215:49 | prevState.tainted4 |
-| tst.js:222:28:222:46 | this.props.tainted1 |
-| tst.js:222:28:222:46 | this.props.tainted1 |
-| tst.js:223:28:223:46 | this.props.tainted2 |
-| tst.js:223:28:223:46 | this.props.tainted2 |
-| tst.js:224:28:224:46 | this.props.tainted3 |
-| tst.js:224:28:224:46 | this.props.tainted3 |
-| tst.js:228:32:228:49 | prevProps.tainted4 |
-| tst.js:228:32:228:49 | prevProps.tainted4 |
-| tst.js:233:35:233:41 | tainted |
-| tst.js:235:20:235:26 | tainted |
-| tst.js:237:23:237:29 | tainted |
-| tst.js:238:23:238:29 | tainted |
-| tst.js:244:39:244:55 | props.propTainted |
-| tst.js:248:60:248:82 | this.st ... Tainted |
-| tst.js:248:60:248:82 | this.st ... Tainted |
-| tst.js:252:23:252:29 | tainted |
-| tst.js:256:7:256:17 | window.name |
-| tst.js:256:7:256:17 | window.name |
-| tst.js:256:7:256:17 | window.name |
-| tst.js:257:7:257:10 | name |
-| tst.js:257:7:257:10 | name |
-| tst.js:257:7:257:10 | name |
-| tst.js:261:11:261:21 | window.name |
-| tst.js:261:11:261:21 | window.name |
-| tst.js:261:11:261:21 | window.name |
-| tst.js:277:22:277:29 | location |
-| tst.js:277:22:277:29 | location |
-| tst.js:277:22:277:29 | location |
-| tst.js:282:9:282:29 | tainted |
-| tst.js:282:19:282:29 | window.name |
-| tst.js:282:19:282:29 | window.name |
-| tst.js:285:59:285:65 | tainted |
-| tst.js:285:59:285:65 | tainted |
-| tst.js:298:9:298:16 | location |
-| tst.js:298:9:298:16 | location |
-| tst.js:299:10:299:10 | e |
-| tst.js:300:20:300:20 | e |
-| tst.js:300:20:300:20 | e |
-| tst.js:305:10:305:17 | location |
-| tst.js:305:10:305:17 | location |
-| tst.js:307:10:307:10 | e |
-| tst.js:308:20:308:20 | e |
-| tst.js:308:20:308:20 | e |
-| tst.js:313:35:313:42 | location |
-| tst.js:313:35:313:42 | location |
-| tst.js:313:35:313:42 | location |
+| tst.js:139:18:139:18 | v |
+| tst.js:139:18:139:18 | v |
+| tst.js:151:29:151:43 | window.location |
+| tst.js:151:29:151:43 | window.location |
+| tst.js:151:29:151:50 | window. ... .search |
+| tst.js:154:29:154:29 | v |
+| tst.js:154:49:154:49 | v |
+| tst.js:154:49:154:49 | v |
+| tst.js:158:29:158:46 | xssSourceService() |
+| tst.js:158:29:158:46 | xssSourceService() |
+| tst.js:161:40:161:54 | window.location |
+| tst.js:161:40:161:54 | window.location |
+| tst.js:161:40:161:61 | window. ... .search |
+| tst.js:180:9:180:41 | target |
+| tst.js:180:18:180:34 | document.location |
+| tst.js:180:18:180:34 | document.location |
+| tst.js:180:18:180:41 | documen ... .search |
+| tst.js:183:28:183:33 | target |
+| tst.js:183:28:183:33 | target |
+| tst.js:187:9:187:42 | tainted |
+| tst.js:187:19:187:35 | document.location |
+| tst.js:187:19:187:35 | document.location |
+| tst.js:187:19:187:42 | documen ... .search |
+| tst.js:189:31:189:37 | tainted |
+| tst.js:189:31:189:37 | tainted |
+| tst.js:191:42:191:48 | tainted |
+| tst.js:191:42:191:48 | tainted |
+| tst.js:192:33:192:39 | tainted |
+| tst.js:192:33:192:39 | tainted |
+| tst.js:194:54:194:60 | tainted |
+| tst.js:194:54:194:60 | tainted |
+| tst.js:195:45:195:51 | tainted |
+| tst.js:195:45:195:51 | tainted |
+| tst.js:200:9:200:42 | tainted |
+| tst.js:200:19:200:35 | document.location |
+| tst.js:200:19:200:35 | document.location |
+| tst.js:200:19:200:42 | documen ... .search |
+| tst.js:202:67:202:73 | tainted |
+| tst.js:202:67:202:73 | tainted |
+| tst.js:203:67:203:73 | tainted |
+| tst.js:203:67:203:73 | tainted |
+| tst.js:207:35:207:41 | tainted |
+| tst.js:209:46:209:52 | tainted |
+| tst.js:210:38:210:44 | tainted |
+| tst.js:211:35:211:41 | tainted |
+| tst.js:215:28:215:46 | this.state.tainted1 |
+| tst.js:215:28:215:46 | this.state.tainted1 |
+| tst.js:216:28:216:46 | this.state.tainted2 |
+| tst.js:216:28:216:46 | this.state.tainted2 |
+| tst.js:217:28:217:46 | this.state.tainted3 |
+| tst.js:217:28:217:46 | this.state.tainted3 |
+| tst.js:221:32:221:49 | prevState.tainted4 |
+| tst.js:221:32:221:49 | prevState.tainted4 |
+| tst.js:228:28:228:46 | this.props.tainted1 |
+| tst.js:228:28:228:46 | this.props.tainted1 |
+| tst.js:229:28:229:46 | this.props.tainted2 |
+| tst.js:229:28:229:46 | this.props.tainted2 |
+| tst.js:230:28:230:46 | this.props.tainted3 |
+| tst.js:230:28:230:46 | this.props.tainted3 |
+| tst.js:234:32:234:49 | prevProps.tainted4 |
+| tst.js:234:32:234:49 | prevProps.tainted4 |
+| tst.js:239:35:239:41 | tainted |
+| tst.js:241:20:241:26 | tainted |
+| tst.js:243:23:243:29 | tainted |
+| tst.js:244:23:244:29 | tainted |
+| tst.js:250:39:250:55 | props.propTainted |
+| tst.js:254:60:254:82 | this.st ... Tainted |
+| tst.js:254:60:254:82 | this.st ... Tainted |
+| tst.js:258:23:258:29 | tainted |
+| tst.js:262:7:262:17 | window.name |
+| tst.js:262:7:262:17 | window.name |
+| tst.js:262:7:262:17 | window.name |
+| tst.js:263:7:263:10 | name |
+| tst.js:263:7:263:10 | name |
+| tst.js:263:7:263:10 | name |
+| tst.js:267:11:267:21 | window.name |
+| tst.js:267:11:267:21 | window.name |
+| tst.js:267:11:267:21 | window.name |
+| tst.js:283:22:283:29 | location |
+| tst.js:283:22:283:29 | location |
+| tst.js:283:22:283:29 | location |
+| tst.js:288:9:288:29 | tainted |
+| tst.js:288:19:288:29 | window.name |
+| tst.js:288:19:288:29 | window.name |
+| tst.js:291:59:291:65 | tainted |
+| tst.js:291:59:291:65 | tainted |
+| tst.js:304:9:304:16 | location |
+| tst.js:304:9:304:16 | location |
+| tst.js:305:10:305:10 | e |
+| tst.js:306:20:306:20 | e |
+| tst.js:306:20:306:20 | e |
+| tst.js:311:10:311:17 | location |
+| tst.js:311:10:311:17 | location |
+| tst.js:313:10:313:10 | e |
+| tst.js:314:20:314:20 | e |
+| tst.js:314:20:314:20 | e |
+| tst.js:319:35:319:42 | location |
+| tst.js:319:35:319:42 | location |
+| tst.js:319:35:319:42 | location |
 | typeahead.js:20:13:20:45 | target |
 | typeahead.js:20:22:20:38 | document.location |
 | typeahead.js:20:22:20:38 | document.location |
@@ -555,89 +557,91 @@ edges
 | tst.js:105:25:105:41 | document.location | tst.js:105:25:105:48 | documen ... .search |
 | tst.js:110:7:110:44 | v | tst.js:113:18:113:18 | v |
 | tst.js:110:7:110:44 | v | tst.js:113:18:113:18 | v |
+| tst.js:110:7:110:44 | v | tst.js:139:18:139:18 | v |
+| tst.js:110:7:110:44 | v | tst.js:139:18:139:18 | v |
 | tst.js:110:11:110:27 | document.location | tst.js:110:11:110:34 | documen ... .search |
 | tst.js:110:11:110:27 | document.location | tst.js:110:11:110:34 | documen ... .search |
 | tst.js:110:11:110:34 | documen ... .search | tst.js:110:11:110:44 | documen ... bstr(1) |
 | tst.js:110:11:110:44 | documen ... bstr(1) | tst.js:110:7:110:44 | v |
-| tst.js:145:29:145:43 | window.location | tst.js:145:29:145:50 | window. ... .search |
-| tst.js:145:29:145:43 | window.location | tst.js:145:29:145:50 | window. ... .search |
-| tst.js:145:29:145:50 | window. ... .search | tst.js:148:29:148:29 | v |
-| tst.js:148:29:148:29 | v | tst.js:148:49:148:49 | v |
-| tst.js:148:29:148:29 | v | tst.js:148:49:148:49 | v |
-| tst.js:155:40:155:54 | window.location | tst.js:155:40:155:61 | window. ... .search |
-| tst.js:155:40:155:54 | window.location | tst.js:155:40:155:61 | window. ... .search |
-| tst.js:155:40:155:61 | window. ... .search | tst.js:152:29:152:46 | xssSourceService() |
-| tst.js:155:40:155:61 | window. ... .search | tst.js:152:29:152:46 | xssSourceService() |
-| tst.js:174:9:174:41 | target | tst.js:177:28:177:33 | target |
-| tst.js:174:9:174:41 | target | tst.js:177:28:177:33 | target |
-| tst.js:174:18:174:34 | document.location | tst.js:174:18:174:41 | documen ... .search |
-| tst.js:174:18:174:34 | document.location | tst.js:174:18:174:41 | documen ... .search |
-| tst.js:174:18:174:41 | documen ... .search | tst.js:174:9:174:41 | target |
-| tst.js:181:9:181:42 | tainted | tst.js:183:31:183:37 | tainted |
-| tst.js:181:9:181:42 | tainted | tst.js:183:31:183:37 | tainted |
-| tst.js:181:9:181:42 | tainted | tst.js:185:42:185:48 | tainted |
-| tst.js:181:9:181:42 | tainted | tst.js:185:42:185:48 | tainted |
-| tst.js:181:9:181:42 | tainted | tst.js:186:33:186:39 | tainted |
-| tst.js:181:9:181:42 | tainted | tst.js:186:33:186:39 | tainted |
-| tst.js:181:9:181:42 | tainted | tst.js:188:54:188:60 | tainted |
-| tst.js:181:9:181:42 | tainted | tst.js:188:54:188:60 | tainted |
-| tst.js:181:9:181:42 | tainted | tst.js:189:45:189:51 | tainted |
-| tst.js:181:9:181:42 | tainted | tst.js:189:45:189:51 | tainted |
-| tst.js:181:19:181:35 | document.location | tst.js:181:19:181:42 | documen ... .search |
-| tst.js:181:19:181:35 | document.location | tst.js:181:19:181:42 | documen ... .search |
-| tst.js:181:19:181:42 | documen ... .search | tst.js:181:9:181:42 | tainted |
-| tst.js:194:9:194:42 | tainted | tst.js:196:67:196:73 | tainted |
-| tst.js:194:9:194:42 | tainted | tst.js:196:67:196:73 | tainted |
-| tst.js:194:9:194:42 | tainted | tst.js:197:67:197:73 | tainted |
-| tst.js:194:9:194:42 | tainted | tst.js:197:67:197:73 | tainted |
-| tst.js:194:9:194:42 | tainted | tst.js:201:35:201:41 | tainted |
-| tst.js:194:9:194:42 | tainted | tst.js:203:46:203:52 | tainted |
-| tst.js:194:9:194:42 | tainted | tst.js:204:38:204:44 | tainted |
-| tst.js:194:9:194:42 | tainted | tst.js:205:35:205:41 | tainted |
-| tst.js:194:9:194:42 | tainted | tst.js:233:35:233:41 | tainted |
-| tst.js:194:9:194:42 | tainted | tst.js:235:20:235:26 | tainted |
-| tst.js:194:9:194:42 | tainted | tst.js:237:23:237:29 | tainted |
-| tst.js:194:9:194:42 | tainted | tst.js:238:23:238:29 | tainted |
-| tst.js:194:9:194:42 | tainted | tst.js:252:23:252:29 | tainted |
-| tst.js:194:19:194:35 | document.location | tst.js:194:19:194:42 | documen ... .search |
-| tst.js:194:19:194:35 | document.location | tst.js:194:19:194:42 | documen ... .search |
-| tst.js:194:19:194:42 | documen ... .search | tst.js:194:9:194:42 | tainted |
-| tst.js:201:35:201:41 | tainted | tst.js:209:28:209:46 | this.state.tainted1 |
-| tst.js:201:35:201:41 | tainted | tst.js:209:28:209:46 | this.state.tainted1 |
-| tst.js:203:46:203:52 | tainted | tst.js:210:28:210:46 | this.state.tainted2 |
-| tst.js:203:46:203:52 | tainted | tst.js:210:28:210:46 | this.state.tainted2 |
-| tst.js:204:38:204:44 | tainted | tst.js:211:28:211:46 | this.state.tainted3 |
-| tst.js:204:38:204:44 | tainted | tst.js:211:28:211:46 | this.state.tainted3 |
-| tst.js:205:35:205:41 | tainted | tst.js:215:32:215:49 | prevState.tainted4 |
-| tst.js:205:35:205:41 | tainted | tst.js:215:32:215:49 | prevState.tainted4 |
-| tst.js:233:35:233:41 | tainted | tst.js:222:28:222:46 | this.props.tainted1 |
-| tst.js:233:35:233:41 | tainted | tst.js:222:28:222:46 | this.props.tainted1 |
-| tst.js:235:20:235:26 | tainted | tst.js:223:28:223:46 | this.props.tainted2 |
-| tst.js:235:20:235:26 | tainted | tst.js:223:28:223:46 | this.props.tainted2 |
-| tst.js:237:23:237:29 | tainted | tst.js:224:28:224:46 | this.props.tainted3 |
-| tst.js:237:23:237:29 | tainted | tst.js:224:28:224:46 | this.props.tainted3 |
-| tst.js:238:23:238:29 | tainted | tst.js:228:32:228:49 | prevProps.tainted4 |
-| tst.js:238:23:238:29 | tainted | tst.js:228:32:228:49 | prevProps.tainted4 |
-| tst.js:244:39:244:55 | props.propTainted | tst.js:248:60:248:82 | this.st ... Tainted |
-| tst.js:244:39:244:55 | props.propTainted | tst.js:248:60:248:82 | this.st ... Tainted |
-| tst.js:252:23:252:29 | tainted | tst.js:244:39:244:55 | props.propTainted |
-| tst.js:256:7:256:17 | window.name | tst.js:256:7:256:17 | window.name |
-| tst.js:257:7:257:10 | name | tst.js:257:7:257:10 | name |
-| tst.js:261:11:261:21 | window.name | tst.js:261:11:261:21 | window.name |
-| tst.js:277:22:277:29 | location | tst.js:277:22:277:29 | location |
-| tst.js:282:9:282:29 | tainted | tst.js:285:59:285:65 | tainted |
-| tst.js:282:9:282:29 | tainted | tst.js:285:59:285:65 | tainted |
-| tst.js:282:19:282:29 | window.name | tst.js:282:9:282:29 | tainted |
-| tst.js:282:19:282:29 | window.name | tst.js:282:9:282:29 | tainted |
-| tst.js:298:9:298:16 | location | tst.js:299:10:299:10 | e |
-| tst.js:298:9:298:16 | location | tst.js:299:10:299:10 | e |
-| tst.js:299:10:299:10 | e | tst.js:300:20:300:20 | e |
-| tst.js:299:10:299:10 | e | tst.js:300:20:300:20 | e |
-| tst.js:305:10:305:17 | location | tst.js:307:10:307:10 | e |
-| tst.js:305:10:305:17 | location | tst.js:307:10:307:10 | e |
-| tst.js:307:10:307:10 | e | tst.js:308:20:308:20 | e |
-| tst.js:307:10:307:10 | e | tst.js:308:20:308:20 | e |
-| tst.js:313:35:313:42 | location | tst.js:313:35:313:42 | location |
+| tst.js:151:29:151:43 | window.location | tst.js:151:29:151:50 | window. ... .search |
+| tst.js:151:29:151:43 | window.location | tst.js:151:29:151:50 | window. ... .search |
+| tst.js:151:29:151:50 | window. ... .search | tst.js:154:29:154:29 | v |
+| tst.js:154:29:154:29 | v | tst.js:154:49:154:49 | v |
+| tst.js:154:29:154:29 | v | tst.js:154:49:154:49 | v |
+| tst.js:161:40:161:54 | window.location | tst.js:161:40:161:61 | window. ... .search |
+| tst.js:161:40:161:54 | window.location | tst.js:161:40:161:61 | window. ... .search |
+| tst.js:161:40:161:61 | window. ... .search | tst.js:158:29:158:46 | xssSourceService() |
+| tst.js:161:40:161:61 | window. ... .search | tst.js:158:29:158:46 | xssSourceService() |
+| tst.js:180:9:180:41 | target | tst.js:183:28:183:33 | target |
+| tst.js:180:9:180:41 | target | tst.js:183:28:183:33 | target |
+| tst.js:180:18:180:34 | document.location | tst.js:180:18:180:41 | documen ... .search |
+| tst.js:180:18:180:34 | document.location | tst.js:180:18:180:41 | documen ... .search |
+| tst.js:180:18:180:41 | documen ... .search | tst.js:180:9:180:41 | target |
+| tst.js:187:9:187:42 | tainted | tst.js:189:31:189:37 | tainted |
+| tst.js:187:9:187:42 | tainted | tst.js:189:31:189:37 | tainted |
+| tst.js:187:9:187:42 | tainted | tst.js:191:42:191:48 | tainted |
+| tst.js:187:9:187:42 | tainted | tst.js:191:42:191:48 | tainted |
+| tst.js:187:9:187:42 | tainted | tst.js:192:33:192:39 | tainted |
+| tst.js:187:9:187:42 | tainted | tst.js:192:33:192:39 | tainted |
+| tst.js:187:9:187:42 | tainted | tst.js:194:54:194:60 | tainted |
+| tst.js:187:9:187:42 | tainted | tst.js:194:54:194:60 | tainted |
+| tst.js:187:9:187:42 | tainted | tst.js:195:45:195:51 | tainted |
+| tst.js:187:9:187:42 | tainted | tst.js:195:45:195:51 | tainted |
+| tst.js:187:19:187:35 | document.location | tst.js:187:19:187:42 | documen ... .search |
+| tst.js:187:19:187:35 | document.location | tst.js:187:19:187:42 | documen ... .search |
+| tst.js:187:19:187:42 | documen ... .search | tst.js:187:9:187:42 | tainted |
+| tst.js:200:9:200:42 | tainted | tst.js:202:67:202:73 | tainted |
+| tst.js:200:9:200:42 | tainted | tst.js:202:67:202:73 | tainted |
+| tst.js:200:9:200:42 | tainted | tst.js:203:67:203:73 | tainted |
+| tst.js:200:9:200:42 | tainted | tst.js:203:67:203:73 | tainted |
+| tst.js:200:9:200:42 | tainted | tst.js:207:35:207:41 | tainted |
+| tst.js:200:9:200:42 | tainted | tst.js:209:46:209:52 | tainted |
+| tst.js:200:9:200:42 | tainted | tst.js:210:38:210:44 | tainted |
+| tst.js:200:9:200:42 | tainted | tst.js:211:35:211:41 | tainted |
+| tst.js:200:9:200:42 | tainted | tst.js:239:35:239:41 | tainted |
+| tst.js:200:9:200:42 | tainted | tst.js:241:20:241:26 | tainted |
+| tst.js:200:9:200:42 | tainted | tst.js:243:23:243:29 | tainted |
+| tst.js:200:9:200:42 | tainted | tst.js:244:23:244:29 | tainted |
+| tst.js:200:9:200:42 | tainted | tst.js:258:23:258:29 | tainted |
+| tst.js:200:19:200:35 | document.location | tst.js:200:19:200:42 | documen ... .search |
+| tst.js:200:19:200:35 | document.location | tst.js:200:19:200:42 | documen ... .search |
+| tst.js:200:19:200:42 | documen ... .search | tst.js:200:9:200:42 | tainted |
+| tst.js:207:35:207:41 | tainted | tst.js:215:28:215:46 | this.state.tainted1 |
+| tst.js:207:35:207:41 | tainted | tst.js:215:28:215:46 | this.state.tainted1 |
+| tst.js:209:46:209:52 | tainted | tst.js:216:28:216:46 | this.state.tainted2 |
+| tst.js:209:46:209:52 | tainted | tst.js:216:28:216:46 | this.state.tainted2 |
+| tst.js:210:38:210:44 | tainted | tst.js:217:28:217:46 | this.state.tainted3 |
+| tst.js:210:38:210:44 | tainted | tst.js:217:28:217:46 | this.state.tainted3 |
+| tst.js:211:35:211:41 | tainted | tst.js:221:32:221:49 | prevState.tainted4 |
+| tst.js:211:35:211:41 | tainted | tst.js:221:32:221:49 | prevState.tainted4 |
+| tst.js:239:35:239:41 | tainted | tst.js:228:28:228:46 | this.props.tainted1 |
+| tst.js:239:35:239:41 | tainted | tst.js:228:28:228:46 | this.props.tainted1 |
+| tst.js:241:20:241:26 | tainted | tst.js:229:28:229:46 | this.props.tainted2 |
+| tst.js:241:20:241:26 | tainted | tst.js:229:28:229:46 | this.props.tainted2 |
+| tst.js:243:23:243:29 | tainted | tst.js:230:28:230:46 | this.props.tainted3 |
+| tst.js:243:23:243:29 | tainted | tst.js:230:28:230:46 | this.props.tainted3 |
+| tst.js:244:23:244:29 | tainted | tst.js:234:32:234:49 | prevProps.tainted4 |
+| tst.js:244:23:244:29 | tainted | tst.js:234:32:234:49 | prevProps.tainted4 |
+| tst.js:250:39:250:55 | props.propTainted | tst.js:254:60:254:82 | this.st ... Tainted |
+| tst.js:250:39:250:55 | props.propTainted | tst.js:254:60:254:82 | this.st ... Tainted |
+| tst.js:258:23:258:29 | tainted | tst.js:250:39:250:55 | props.propTainted |
+| tst.js:262:7:262:17 | window.name | tst.js:262:7:262:17 | window.name |
+| tst.js:263:7:263:10 | name | tst.js:263:7:263:10 | name |
+| tst.js:267:11:267:21 | window.name | tst.js:267:11:267:21 | window.name |
+| tst.js:283:22:283:29 | location | tst.js:283:22:283:29 | location |
+| tst.js:288:9:288:29 | tainted | tst.js:291:59:291:65 | tainted |
+| tst.js:288:9:288:29 | tainted | tst.js:291:59:291:65 | tainted |
+| tst.js:288:19:288:29 | window.name | tst.js:288:9:288:29 | tainted |
+| tst.js:288:19:288:29 | window.name | tst.js:288:9:288:29 | tainted |
+| tst.js:304:9:304:16 | location | tst.js:305:10:305:10 | e |
+| tst.js:304:9:304:16 | location | tst.js:305:10:305:10 | e |
+| tst.js:305:10:305:10 | e | tst.js:306:20:306:20 | e |
+| tst.js:305:10:305:10 | e | tst.js:306:20:306:20 | e |
+| tst.js:311:10:311:17 | location | tst.js:313:10:313:10 | e |
+| tst.js:311:10:311:17 | location | tst.js:313:10:313:10 | e |
+| tst.js:313:10:313:10 | e | tst.js:314:20:314:20 | e |
+| tst.js:313:10:313:10 | e | tst.js:314:20:314:20 | e |
+| tst.js:319:35:319:42 | location | tst.js:319:35:319:42 | location |
 | typeahead.js:20:13:20:45 | target | typeahead.js:21:12:21:17 | target |
 | typeahead.js:20:22:20:38 | document.location | typeahead.js:20:22:20:45 | documen ... .search |
 | typeahead.js:20:22:20:38 | document.location | typeahead.js:20:22:20:45 | documen ... .search |
@@ -709,33 +713,34 @@ edges
 | tst.js:99:30:99:53 | documen ... .search | tst.js:99:30:99:46 | document.location | tst.js:99:30:99:53 | documen ... .search | Cross-site scripting vulnerability due to $@. | tst.js:99:30:99:46 | document.location | user-provided value |
 | tst.js:105:25:105:48 | documen ... .search | tst.js:105:25:105:41 | document.location | tst.js:105:25:105:48 | documen ... .search | Cross-site scripting vulnerability due to $@. | tst.js:105:25:105:41 | document.location | user-provided value |
 | tst.js:113:18:113:18 | v | tst.js:110:11:110:27 | document.location | tst.js:113:18:113:18 | v | Cross-site scripting vulnerability due to $@. | tst.js:110:11:110:27 | document.location | user-provided value |
-| tst.js:148:49:148:49 | v | tst.js:145:29:145:43 | window.location | tst.js:148:49:148:49 | v | Cross-site scripting vulnerability due to $@. | tst.js:145:29:145:43 | window.location | user-provided value |
-| tst.js:152:29:152:46 | xssSourceService() | tst.js:155:40:155:54 | window.location | tst.js:152:29:152:46 | xssSourceService() | Cross-site scripting vulnerability due to $@. | tst.js:155:40:155:54 | window.location | user-provided value |
-| tst.js:177:28:177:33 | target | tst.js:174:18:174:34 | document.location | tst.js:177:28:177:33 | target | Cross-site scripting vulnerability due to $@. | tst.js:174:18:174:34 | document.location | user-provided value |
-| tst.js:183:31:183:37 | tainted | tst.js:181:19:181:35 | document.location | tst.js:183:31:183:37 | tainted | Cross-site scripting vulnerability due to $@. | tst.js:181:19:181:35 | document.location | user-provided value |
-| tst.js:185:42:185:48 | tainted | tst.js:181:19:181:35 | document.location | tst.js:185:42:185:48 | tainted | Cross-site scripting vulnerability due to $@. | tst.js:181:19:181:35 | document.location | user-provided value |
-| tst.js:186:33:186:39 | tainted | tst.js:181:19:181:35 | document.location | tst.js:186:33:186:39 | tainted | Cross-site scripting vulnerability due to $@. | tst.js:181:19:181:35 | document.location | user-provided value |
-| tst.js:188:54:188:60 | tainted | tst.js:181:19:181:35 | document.location | tst.js:188:54:188:60 | tainted | Cross-site scripting vulnerability due to $@. | tst.js:181:19:181:35 | document.location | user-provided value |
-| tst.js:189:45:189:51 | tainted | tst.js:181:19:181:35 | document.location | tst.js:189:45:189:51 | tainted | Cross-site scripting vulnerability due to $@. | tst.js:181:19:181:35 | document.location | user-provided value |
-| tst.js:196:67:196:73 | tainted | tst.js:194:19:194:35 | document.location | tst.js:196:67:196:73 | tainted | Cross-site scripting vulnerability due to $@. | tst.js:194:19:194:35 | document.location | user-provided value |
-| tst.js:197:67:197:73 | tainted | tst.js:194:19:194:35 | document.location | tst.js:197:67:197:73 | tainted | Cross-site scripting vulnerability due to $@. | tst.js:194:19:194:35 | document.location | user-provided value |
-| tst.js:209:28:209:46 | this.state.tainted1 | tst.js:194:19:194:35 | document.location | tst.js:209:28:209:46 | this.state.tainted1 | Cross-site scripting vulnerability due to $@. | tst.js:194:19:194:35 | document.location | user-provided value |
-| tst.js:210:28:210:46 | this.state.tainted2 | tst.js:194:19:194:35 | document.location | tst.js:210:28:210:46 | this.state.tainted2 | Cross-site scripting vulnerability due to $@. | tst.js:194:19:194:35 | document.location | user-provided value |
-| tst.js:211:28:211:46 | this.state.tainted3 | tst.js:194:19:194:35 | document.location | tst.js:211:28:211:46 | this.state.tainted3 | Cross-site scripting vulnerability due to $@. | tst.js:194:19:194:35 | document.location | user-provided value |
-| tst.js:215:32:215:49 | prevState.tainted4 | tst.js:194:19:194:35 | document.location | tst.js:215:32:215:49 | prevState.tainted4 | Cross-site scripting vulnerability due to $@. | tst.js:194:19:194:35 | document.location | user-provided value |
-| tst.js:222:28:222:46 | this.props.tainted1 | tst.js:194:19:194:35 | document.location | tst.js:222:28:222:46 | this.props.tainted1 | Cross-site scripting vulnerability due to $@. | tst.js:194:19:194:35 | document.location | user-provided value |
-| tst.js:223:28:223:46 | this.props.tainted2 | tst.js:194:19:194:35 | document.location | tst.js:223:28:223:46 | this.props.tainted2 | Cross-site scripting vulnerability due to $@. | tst.js:194:19:194:35 | document.location | user-provided value |
-| tst.js:224:28:224:46 | this.props.tainted3 | tst.js:194:19:194:35 | document.location | tst.js:224:28:224:46 | this.props.tainted3 | Cross-site scripting vulnerability due to $@. | tst.js:194:19:194:35 | document.location | user-provided value |
-| tst.js:228:32:228:49 | prevProps.tainted4 | tst.js:194:19:194:35 | document.location | tst.js:228:32:228:49 | prevProps.tainted4 | Cross-site scripting vulnerability due to $@. | tst.js:194:19:194:35 | document.location | user-provided value |
-| tst.js:248:60:248:82 | this.st ... Tainted | tst.js:194:19:194:35 | document.location | tst.js:248:60:248:82 | this.st ... Tainted | Cross-site scripting vulnerability due to $@. | tst.js:194:19:194:35 | document.location | user-provided value |
-| tst.js:256:7:256:17 | window.name | tst.js:256:7:256:17 | window.name | tst.js:256:7:256:17 | window.name | Cross-site scripting vulnerability due to $@. | tst.js:256:7:256:17 | window.name | user-provided value |
-| tst.js:257:7:257:10 | name | tst.js:257:7:257:10 | name | tst.js:257:7:257:10 | name | Cross-site scripting vulnerability due to $@. | tst.js:257:7:257:10 | name | user-provided value |
-| tst.js:261:11:261:21 | window.name | tst.js:261:11:261:21 | window.name | tst.js:261:11:261:21 | window.name | Cross-site scripting vulnerability due to $@. | tst.js:261:11:261:21 | window.name | user-provided value |
-| tst.js:277:22:277:29 | location | tst.js:277:22:277:29 | location | tst.js:277:22:277:29 | location | Cross-site scripting vulnerability due to $@. | tst.js:277:22:277:29 | location | user-provided value |
-| tst.js:285:59:285:65 | tainted | tst.js:282:19:282:29 | window.name | tst.js:285:59:285:65 | tainted | Cross-site scripting vulnerability due to $@. | tst.js:282:19:282:29 | window.name | user-provided value |
-| tst.js:300:20:300:20 | e | tst.js:298:9:298:16 | location | tst.js:300:20:300:20 | e | Cross-site scripting vulnerability due to $@. | tst.js:298:9:298:16 | location | user-provided value |
-| tst.js:308:20:308:20 | e | tst.js:305:10:305:17 | location | tst.js:308:20:308:20 | e | Cross-site scripting vulnerability due to $@. | tst.js:305:10:305:17 | location | user-provided value |
-| tst.js:313:35:313:42 | location | tst.js:313:35:313:42 | location | tst.js:313:35:313:42 | location | Cross-site scripting vulnerability due to $@. | tst.js:313:35:313:42 | location | user-provided value |
+| tst.js:139:18:139:18 | v | tst.js:110:11:110:27 | document.location | tst.js:139:18:139:18 | v | Cross-site scripting vulnerability due to $@. | tst.js:110:11:110:27 | document.location | user-provided value |
+| tst.js:154:49:154:49 | v | tst.js:151:29:151:43 | window.location | tst.js:154:49:154:49 | v | Cross-site scripting vulnerability due to $@. | tst.js:151:29:151:43 | window.location | user-provided value |
+| tst.js:158:29:158:46 | xssSourceService() | tst.js:161:40:161:54 | window.location | tst.js:158:29:158:46 | xssSourceService() | Cross-site scripting vulnerability due to $@. | tst.js:161:40:161:54 | window.location | user-provided value |
+| tst.js:183:28:183:33 | target | tst.js:180:18:180:34 | document.location | tst.js:183:28:183:33 | target | Cross-site scripting vulnerability due to $@. | tst.js:180:18:180:34 | document.location | user-provided value |
+| tst.js:189:31:189:37 | tainted | tst.js:187:19:187:35 | document.location | tst.js:189:31:189:37 | tainted | Cross-site scripting vulnerability due to $@. | tst.js:187:19:187:35 | document.location | user-provided value |
+| tst.js:191:42:191:48 | tainted | tst.js:187:19:187:35 | document.location | tst.js:191:42:191:48 | tainted | Cross-site scripting vulnerability due to $@. | tst.js:187:19:187:35 | document.location | user-provided value |
+| tst.js:192:33:192:39 | tainted | tst.js:187:19:187:35 | document.location | tst.js:192:33:192:39 | tainted | Cross-site scripting vulnerability due to $@. | tst.js:187:19:187:35 | document.location | user-provided value |
+| tst.js:194:54:194:60 | tainted | tst.js:187:19:187:35 | document.location | tst.js:194:54:194:60 | tainted | Cross-site scripting vulnerability due to $@. | tst.js:187:19:187:35 | document.location | user-provided value |
+| tst.js:195:45:195:51 | tainted | tst.js:187:19:187:35 | document.location | tst.js:195:45:195:51 | tainted | Cross-site scripting vulnerability due to $@. | tst.js:187:19:187:35 | document.location | user-provided value |
+| tst.js:202:67:202:73 | tainted | tst.js:200:19:200:35 | document.location | tst.js:202:67:202:73 | tainted | Cross-site scripting vulnerability due to $@. | tst.js:200:19:200:35 | document.location | user-provided value |
+| tst.js:203:67:203:73 | tainted | tst.js:200:19:200:35 | document.location | tst.js:203:67:203:73 | tainted | Cross-site scripting vulnerability due to $@. | tst.js:200:19:200:35 | document.location | user-provided value |
+| tst.js:215:28:215:46 | this.state.tainted1 | tst.js:200:19:200:35 | document.location | tst.js:215:28:215:46 | this.state.tainted1 | Cross-site scripting vulnerability due to $@. | tst.js:200:19:200:35 | document.location | user-provided value |
+| tst.js:216:28:216:46 | this.state.tainted2 | tst.js:200:19:200:35 | document.location | tst.js:216:28:216:46 | this.state.tainted2 | Cross-site scripting vulnerability due to $@. | tst.js:200:19:200:35 | document.location | user-provided value |
+| tst.js:217:28:217:46 | this.state.tainted3 | tst.js:200:19:200:35 | document.location | tst.js:217:28:217:46 | this.state.tainted3 | Cross-site scripting vulnerability due to $@. | tst.js:200:19:200:35 | document.location | user-provided value |
+| tst.js:221:32:221:49 | prevState.tainted4 | tst.js:200:19:200:35 | document.location | tst.js:221:32:221:49 | prevState.tainted4 | Cross-site scripting vulnerability due to $@. | tst.js:200:19:200:35 | document.location | user-provided value |
+| tst.js:228:28:228:46 | this.props.tainted1 | tst.js:200:19:200:35 | document.location | tst.js:228:28:228:46 | this.props.tainted1 | Cross-site scripting vulnerability due to $@. | tst.js:200:19:200:35 | document.location | user-provided value |
+| tst.js:229:28:229:46 | this.props.tainted2 | tst.js:200:19:200:35 | document.location | tst.js:229:28:229:46 | this.props.tainted2 | Cross-site scripting vulnerability due to $@. | tst.js:200:19:200:35 | document.location | user-provided value |
+| tst.js:230:28:230:46 | this.props.tainted3 | tst.js:200:19:200:35 | document.location | tst.js:230:28:230:46 | this.props.tainted3 | Cross-site scripting vulnerability due to $@. | tst.js:200:19:200:35 | document.location | user-provided value |
+| tst.js:234:32:234:49 | prevProps.tainted4 | tst.js:200:19:200:35 | document.location | tst.js:234:32:234:49 | prevProps.tainted4 | Cross-site scripting vulnerability due to $@. | tst.js:200:19:200:35 | document.location | user-provided value |
+| tst.js:254:60:254:82 | this.st ... Tainted | tst.js:200:19:200:35 | document.location | tst.js:254:60:254:82 | this.st ... Tainted | Cross-site scripting vulnerability due to $@. | tst.js:200:19:200:35 | document.location | user-provided value |
+| tst.js:262:7:262:17 | window.name | tst.js:262:7:262:17 | window.name | tst.js:262:7:262:17 | window.name | Cross-site scripting vulnerability due to $@. | tst.js:262:7:262:17 | window.name | user-provided value |
+| tst.js:263:7:263:10 | name | tst.js:263:7:263:10 | name | tst.js:263:7:263:10 | name | Cross-site scripting vulnerability due to $@. | tst.js:263:7:263:10 | name | user-provided value |
+| tst.js:267:11:267:21 | window.name | tst.js:267:11:267:21 | window.name | tst.js:267:11:267:21 | window.name | Cross-site scripting vulnerability due to $@. | tst.js:267:11:267:21 | window.name | user-provided value |
+| tst.js:283:22:283:29 | location | tst.js:283:22:283:29 | location | tst.js:283:22:283:29 | location | Cross-site scripting vulnerability due to $@. | tst.js:283:22:283:29 | location | user-provided value |
+| tst.js:291:59:291:65 | tainted | tst.js:288:19:288:29 | window.name | tst.js:291:59:291:65 | tainted | Cross-site scripting vulnerability due to $@. | tst.js:288:19:288:29 | window.name | user-provided value |
+| tst.js:306:20:306:20 | e | tst.js:304:9:304:16 | location | tst.js:306:20:306:20 | e | Cross-site scripting vulnerability due to $@. | tst.js:304:9:304:16 | location | user-provided value |
+| tst.js:314:20:314:20 | e | tst.js:311:10:311:17 | location | tst.js:314:20:314:20 | e | Cross-site scripting vulnerability due to $@. | tst.js:311:10:311:17 | location | user-provided value |
+| tst.js:319:35:319:42 | location | tst.js:319:35:319:42 | location | tst.js:319:35:319:42 | location | Cross-site scripting vulnerability due to $@. | tst.js:319:35:319:42 | location | user-provided value |
 | typeahead.js:25:18:25:20 | val | typeahead.js:20:22:20:38 | document.location | typeahead.js:25:18:25:20 | val | Cross-site scripting vulnerability due to $@. | typeahead.js:20:22:20:38 | document.location | user-provided value |
 | v-html.vue:2:8:2:23 | v-html=tainted | v-html.vue:6:42:6:58 | document.location | v-html.vue:2:8:2:23 | v-html=tainted | Cross-site scripting vulnerability due to $@. | v-html.vue:6:42:6:58 | document.location | user-provided value |
 | winjs.js:3:43:3:49 | tainted | winjs.js:2:17:2:33 | document.location | winjs.js:3:43:3:49 | tainted | Cross-site scripting vulnerability due to $@. | winjs.js:2:17:2:33 | document.location | user-provided value |

--- a/javascript/ql/test/query-tests/Security/CWE-079/XssWithAdditionalSources.expected
+++ b/javascript/ql/test/query-tests/Security/CWE-079/XssWithAdditionalSources.expected
@@ -234,103 +234,105 @@ nodes
 | tst.js:110:11:110:44 | documen ... bstr(1) |
 | tst.js:113:18:113:18 | v |
 | tst.js:113:18:113:18 | v |
-| tst.js:145:29:145:43 | window.location |
-| tst.js:145:29:145:43 | window.location |
-| tst.js:145:29:145:50 | window. ... .search |
-| tst.js:148:29:148:29 | v |
-| tst.js:148:49:148:49 | v |
-| tst.js:148:49:148:49 | v |
-| tst.js:152:29:152:46 | xssSourceService() |
-| tst.js:152:29:152:46 | xssSourceService() |
-| tst.js:155:40:155:54 | window.location |
-| tst.js:155:40:155:54 | window.location |
-| tst.js:155:40:155:61 | window. ... .search |
-| tst.js:174:9:174:41 | target |
-| tst.js:174:18:174:34 | document.location |
-| tst.js:174:18:174:34 | document.location |
-| tst.js:174:18:174:41 | documen ... .search |
-| tst.js:177:28:177:33 | target |
-| tst.js:177:28:177:33 | target |
-| tst.js:181:9:181:42 | tainted |
-| tst.js:181:19:181:35 | document.location |
-| tst.js:181:19:181:35 | document.location |
-| tst.js:181:19:181:42 | documen ... .search |
-| tst.js:183:31:183:37 | tainted |
-| tst.js:183:31:183:37 | tainted |
-| tst.js:185:42:185:48 | tainted |
-| tst.js:185:42:185:48 | tainted |
-| tst.js:186:33:186:39 | tainted |
-| tst.js:186:33:186:39 | tainted |
-| tst.js:188:54:188:60 | tainted |
-| tst.js:188:54:188:60 | tainted |
-| tst.js:189:45:189:51 | tainted |
-| tst.js:189:45:189:51 | tainted |
-| tst.js:194:9:194:42 | tainted |
-| tst.js:194:19:194:35 | document.location |
-| tst.js:194:19:194:35 | document.location |
-| tst.js:194:19:194:42 | documen ... .search |
-| tst.js:196:67:196:73 | tainted |
-| tst.js:196:67:196:73 | tainted |
-| tst.js:197:67:197:73 | tainted |
-| tst.js:197:67:197:73 | tainted |
-| tst.js:201:35:201:41 | tainted |
-| tst.js:203:46:203:52 | tainted |
-| tst.js:204:38:204:44 | tainted |
-| tst.js:205:35:205:41 | tainted |
-| tst.js:209:28:209:46 | this.state.tainted1 |
-| tst.js:209:28:209:46 | this.state.tainted1 |
-| tst.js:210:28:210:46 | this.state.tainted2 |
-| tst.js:210:28:210:46 | this.state.tainted2 |
-| tst.js:211:28:211:46 | this.state.tainted3 |
-| tst.js:211:28:211:46 | this.state.tainted3 |
-| tst.js:215:32:215:49 | prevState.tainted4 |
-| tst.js:215:32:215:49 | prevState.tainted4 |
-| tst.js:222:28:222:46 | this.props.tainted1 |
-| tst.js:222:28:222:46 | this.props.tainted1 |
-| tst.js:223:28:223:46 | this.props.tainted2 |
-| tst.js:223:28:223:46 | this.props.tainted2 |
-| tst.js:224:28:224:46 | this.props.tainted3 |
-| tst.js:224:28:224:46 | this.props.tainted3 |
-| tst.js:228:32:228:49 | prevProps.tainted4 |
-| tst.js:228:32:228:49 | prevProps.tainted4 |
-| tst.js:233:35:233:41 | tainted |
-| tst.js:235:20:235:26 | tainted |
-| tst.js:237:23:237:29 | tainted |
-| tst.js:238:23:238:29 | tainted |
-| tst.js:244:39:244:55 | props.propTainted |
-| tst.js:248:60:248:82 | this.st ... Tainted |
-| tst.js:248:60:248:82 | this.st ... Tainted |
-| tst.js:252:23:252:29 | tainted |
-| tst.js:256:7:256:17 | window.name |
-| tst.js:256:7:256:17 | window.name |
-| tst.js:256:7:256:17 | window.name |
-| tst.js:257:7:257:10 | name |
-| tst.js:257:7:257:10 | name |
-| tst.js:257:7:257:10 | name |
-| tst.js:261:11:261:21 | window.name |
-| tst.js:261:11:261:21 | window.name |
-| tst.js:261:11:261:21 | window.name |
-| tst.js:277:22:277:29 | location |
-| tst.js:277:22:277:29 | location |
-| tst.js:277:22:277:29 | location |
-| tst.js:282:9:282:29 | tainted |
-| tst.js:282:19:282:29 | window.name |
-| tst.js:282:19:282:29 | window.name |
-| tst.js:285:59:285:65 | tainted |
-| tst.js:285:59:285:65 | tainted |
-| tst.js:298:9:298:16 | location |
-| tst.js:298:9:298:16 | location |
-| tst.js:299:10:299:10 | e |
-| tst.js:300:20:300:20 | e |
-| tst.js:300:20:300:20 | e |
-| tst.js:305:10:305:17 | location |
-| tst.js:305:10:305:17 | location |
-| tst.js:307:10:307:10 | e |
-| tst.js:308:20:308:20 | e |
-| tst.js:308:20:308:20 | e |
-| tst.js:313:35:313:42 | location |
-| tst.js:313:35:313:42 | location |
-| tst.js:313:35:313:42 | location |
+| tst.js:139:18:139:18 | v |
+| tst.js:139:18:139:18 | v |
+| tst.js:151:29:151:43 | window.location |
+| tst.js:151:29:151:43 | window.location |
+| tst.js:151:29:151:50 | window. ... .search |
+| tst.js:154:29:154:29 | v |
+| tst.js:154:49:154:49 | v |
+| tst.js:154:49:154:49 | v |
+| tst.js:158:29:158:46 | xssSourceService() |
+| tst.js:158:29:158:46 | xssSourceService() |
+| tst.js:161:40:161:54 | window.location |
+| tst.js:161:40:161:54 | window.location |
+| tst.js:161:40:161:61 | window. ... .search |
+| tst.js:180:9:180:41 | target |
+| tst.js:180:18:180:34 | document.location |
+| tst.js:180:18:180:34 | document.location |
+| tst.js:180:18:180:41 | documen ... .search |
+| tst.js:183:28:183:33 | target |
+| tst.js:183:28:183:33 | target |
+| tst.js:187:9:187:42 | tainted |
+| tst.js:187:19:187:35 | document.location |
+| tst.js:187:19:187:35 | document.location |
+| tst.js:187:19:187:42 | documen ... .search |
+| tst.js:189:31:189:37 | tainted |
+| tst.js:189:31:189:37 | tainted |
+| tst.js:191:42:191:48 | tainted |
+| tst.js:191:42:191:48 | tainted |
+| tst.js:192:33:192:39 | tainted |
+| tst.js:192:33:192:39 | tainted |
+| tst.js:194:54:194:60 | tainted |
+| tst.js:194:54:194:60 | tainted |
+| tst.js:195:45:195:51 | tainted |
+| tst.js:195:45:195:51 | tainted |
+| tst.js:200:9:200:42 | tainted |
+| tst.js:200:19:200:35 | document.location |
+| tst.js:200:19:200:35 | document.location |
+| tst.js:200:19:200:42 | documen ... .search |
+| tst.js:202:67:202:73 | tainted |
+| tst.js:202:67:202:73 | tainted |
+| tst.js:203:67:203:73 | tainted |
+| tst.js:203:67:203:73 | tainted |
+| tst.js:207:35:207:41 | tainted |
+| tst.js:209:46:209:52 | tainted |
+| tst.js:210:38:210:44 | tainted |
+| tst.js:211:35:211:41 | tainted |
+| tst.js:215:28:215:46 | this.state.tainted1 |
+| tst.js:215:28:215:46 | this.state.tainted1 |
+| tst.js:216:28:216:46 | this.state.tainted2 |
+| tst.js:216:28:216:46 | this.state.tainted2 |
+| tst.js:217:28:217:46 | this.state.tainted3 |
+| tst.js:217:28:217:46 | this.state.tainted3 |
+| tst.js:221:32:221:49 | prevState.tainted4 |
+| tst.js:221:32:221:49 | prevState.tainted4 |
+| tst.js:228:28:228:46 | this.props.tainted1 |
+| tst.js:228:28:228:46 | this.props.tainted1 |
+| tst.js:229:28:229:46 | this.props.tainted2 |
+| tst.js:229:28:229:46 | this.props.tainted2 |
+| tst.js:230:28:230:46 | this.props.tainted3 |
+| tst.js:230:28:230:46 | this.props.tainted3 |
+| tst.js:234:32:234:49 | prevProps.tainted4 |
+| tst.js:234:32:234:49 | prevProps.tainted4 |
+| tst.js:239:35:239:41 | tainted |
+| tst.js:241:20:241:26 | tainted |
+| tst.js:243:23:243:29 | tainted |
+| tst.js:244:23:244:29 | tainted |
+| tst.js:250:39:250:55 | props.propTainted |
+| tst.js:254:60:254:82 | this.st ... Tainted |
+| tst.js:254:60:254:82 | this.st ... Tainted |
+| tst.js:258:23:258:29 | tainted |
+| tst.js:262:7:262:17 | window.name |
+| tst.js:262:7:262:17 | window.name |
+| tst.js:262:7:262:17 | window.name |
+| tst.js:263:7:263:10 | name |
+| tst.js:263:7:263:10 | name |
+| tst.js:263:7:263:10 | name |
+| tst.js:267:11:267:21 | window.name |
+| tst.js:267:11:267:21 | window.name |
+| tst.js:267:11:267:21 | window.name |
+| tst.js:283:22:283:29 | location |
+| tst.js:283:22:283:29 | location |
+| tst.js:283:22:283:29 | location |
+| tst.js:288:9:288:29 | tainted |
+| tst.js:288:19:288:29 | window.name |
+| tst.js:288:19:288:29 | window.name |
+| tst.js:291:59:291:65 | tainted |
+| tst.js:291:59:291:65 | tainted |
+| tst.js:304:9:304:16 | location |
+| tst.js:304:9:304:16 | location |
+| tst.js:305:10:305:10 | e |
+| tst.js:306:20:306:20 | e |
+| tst.js:306:20:306:20 | e |
+| tst.js:311:10:311:17 | location |
+| tst.js:311:10:311:17 | location |
+| tst.js:313:10:313:10 | e |
+| tst.js:314:20:314:20 | e |
+| tst.js:314:20:314:20 | e |
+| tst.js:319:35:319:42 | location |
+| tst.js:319:35:319:42 | location |
+| tst.js:319:35:319:42 | location |
 | typeahead.js:9:28:9:30 | loc |
 | typeahead.js:9:28:9:30 | loc |
 | typeahead.js:10:16:10:18 | loc |
@@ -559,89 +561,91 @@ edges
 | tst.js:105:25:105:41 | document.location | tst.js:105:25:105:48 | documen ... .search |
 | tst.js:110:7:110:44 | v | tst.js:113:18:113:18 | v |
 | tst.js:110:7:110:44 | v | tst.js:113:18:113:18 | v |
+| tst.js:110:7:110:44 | v | tst.js:139:18:139:18 | v |
+| tst.js:110:7:110:44 | v | tst.js:139:18:139:18 | v |
 | tst.js:110:11:110:27 | document.location | tst.js:110:11:110:34 | documen ... .search |
 | tst.js:110:11:110:27 | document.location | tst.js:110:11:110:34 | documen ... .search |
 | tst.js:110:11:110:34 | documen ... .search | tst.js:110:11:110:44 | documen ... bstr(1) |
 | tst.js:110:11:110:44 | documen ... bstr(1) | tst.js:110:7:110:44 | v |
-| tst.js:145:29:145:43 | window.location | tst.js:145:29:145:50 | window. ... .search |
-| tst.js:145:29:145:43 | window.location | tst.js:145:29:145:50 | window. ... .search |
-| tst.js:145:29:145:50 | window. ... .search | tst.js:148:29:148:29 | v |
-| tst.js:148:29:148:29 | v | tst.js:148:49:148:49 | v |
-| tst.js:148:29:148:29 | v | tst.js:148:49:148:49 | v |
-| tst.js:155:40:155:54 | window.location | tst.js:155:40:155:61 | window. ... .search |
-| tst.js:155:40:155:54 | window.location | tst.js:155:40:155:61 | window. ... .search |
-| tst.js:155:40:155:61 | window. ... .search | tst.js:152:29:152:46 | xssSourceService() |
-| tst.js:155:40:155:61 | window. ... .search | tst.js:152:29:152:46 | xssSourceService() |
-| tst.js:174:9:174:41 | target | tst.js:177:28:177:33 | target |
-| tst.js:174:9:174:41 | target | tst.js:177:28:177:33 | target |
-| tst.js:174:18:174:34 | document.location | tst.js:174:18:174:41 | documen ... .search |
-| tst.js:174:18:174:34 | document.location | tst.js:174:18:174:41 | documen ... .search |
-| tst.js:174:18:174:41 | documen ... .search | tst.js:174:9:174:41 | target |
-| tst.js:181:9:181:42 | tainted | tst.js:183:31:183:37 | tainted |
-| tst.js:181:9:181:42 | tainted | tst.js:183:31:183:37 | tainted |
-| tst.js:181:9:181:42 | tainted | tst.js:185:42:185:48 | tainted |
-| tst.js:181:9:181:42 | tainted | tst.js:185:42:185:48 | tainted |
-| tst.js:181:9:181:42 | tainted | tst.js:186:33:186:39 | tainted |
-| tst.js:181:9:181:42 | tainted | tst.js:186:33:186:39 | tainted |
-| tst.js:181:9:181:42 | tainted | tst.js:188:54:188:60 | tainted |
-| tst.js:181:9:181:42 | tainted | tst.js:188:54:188:60 | tainted |
-| tst.js:181:9:181:42 | tainted | tst.js:189:45:189:51 | tainted |
-| tst.js:181:9:181:42 | tainted | tst.js:189:45:189:51 | tainted |
-| tst.js:181:19:181:35 | document.location | tst.js:181:19:181:42 | documen ... .search |
-| tst.js:181:19:181:35 | document.location | tst.js:181:19:181:42 | documen ... .search |
-| tst.js:181:19:181:42 | documen ... .search | tst.js:181:9:181:42 | tainted |
-| tst.js:194:9:194:42 | tainted | tst.js:196:67:196:73 | tainted |
-| tst.js:194:9:194:42 | tainted | tst.js:196:67:196:73 | tainted |
-| tst.js:194:9:194:42 | tainted | tst.js:197:67:197:73 | tainted |
-| tst.js:194:9:194:42 | tainted | tst.js:197:67:197:73 | tainted |
-| tst.js:194:9:194:42 | tainted | tst.js:201:35:201:41 | tainted |
-| tst.js:194:9:194:42 | tainted | tst.js:203:46:203:52 | tainted |
-| tst.js:194:9:194:42 | tainted | tst.js:204:38:204:44 | tainted |
-| tst.js:194:9:194:42 | tainted | tst.js:205:35:205:41 | tainted |
-| tst.js:194:9:194:42 | tainted | tst.js:233:35:233:41 | tainted |
-| tst.js:194:9:194:42 | tainted | tst.js:235:20:235:26 | tainted |
-| tst.js:194:9:194:42 | tainted | tst.js:237:23:237:29 | tainted |
-| tst.js:194:9:194:42 | tainted | tst.js:238:23:238:29 | tainted |
-| tst.js:194:9:194:42 | tainted | tst.js:252:23:252:29 | tainted |
-| tst.js:194:19:194:35 | document.location | tst.js:194:19:194:42 | documen ... .search |
-| tst.js:194:19:194:35 | document.location | tst.js:194:19:194:42 | documen ... .search |
-| tst.js:194:19:194:42 | documen ... .search | tst.js:194:9:194:42 | tainted |
-| tst.js:201:35:201:41 | tainted | tst.js:209:28:209:46 | this.state.tainted1 |
-| tst.js:201:35:201:41 | tainted | tst.js:209:28:209:46 | this.state.tainted1 |
-| tst.js:203:46:203:52 | tainted | tst.js:210:28:210:46 | this.state.tainted2 |
-| tst.js:203:46:203:52 | tainted | tst.js:210:28:210:46 | this.state.tainted2 |
-| tst.js:204:38:204:44 | tainted | tst.js:211:28:211:46 | this.state.tainted3 |
-| tst.js:204:38:204:44 | tainted | tst.js:211:28:211:46 | this.state.tainted3 |
-| tst.js:205:35:205:41 | tainted | tst.js:215:32:215:49 | prevState.tainted4 |
-| tst.js:205:35:205:41 | tainted | tst.js:215:32:215:49 | prevState.tainted4 |
-| tst.js:233:35:233:41 | tainted | tst.js:222:28:222:46 | this.props.tainted1 |
-| tst.js:233:35:233:41 | tainted | tst.js:222:28:222:46 | this.props.tainted1 |
-| tst.js:235:20:235:26 | tainted | tst.js:223:28:223:46 | this.props.tainted2 |
-| tst.js:235:20:235:26 | tainted | tst.js:223:28:223:46 | this.props.tainted2 |
-| tst.js:237:23:237:29 | tainted | tst.js:224:28:224:46 | this.props.tainted3 |
-| tst.js:237:23:237:29 | tainted | tst.js:224:28:224:46 | this.props.tainted3 |
-| tst.js:238:23:238:29 | tainted | tst.js:228:32:228:49 | prevProps.tainted4 |
-| tst.js:238:23:238:29 | tainted | tst.js:228:32:228:49 | prevProps.tainted4 |
-| tst.js:244:39:244:55 | props.propTainted | tst.js:248:60:248:82 | this.st ... Tainted |
-| tst.js:244:39:244:55 | props.propTainted | tst.js:248:60:248:82 | this.st ... Tainted |
-| tst.js:252:23:252:29 | tainted | tst.js:244:39:244:55 | props.propTainted |
-| tst.js:256:7:256:17 | window.name | tst.js:256:7:256:17 | window.name |
-| tst.js:257:7:257:10 | name | tst.js:257:7:257:10 | name |
-| tst.js:261:11:261:21 | window.name | tst.js:261:11:261:21 | window.name |
-| tst.js:277:22:277:29 | location | tst.js:277:22:277:29 | location |
-| tst.js:282:9:282:29 | tainted | tst.js:285:59:285:65 | tainted |
-| tst.js:282:9:282:29 | tainted | tst.js:285:59:285:65 | tainted |
-| tst.js:282:19:282:29 | window.name | tst.js:282:9:282:29 | tainted |
-| tst.js:282:19:282:29 | window.name | tst.js:282:9:282:29 | tainted |
-| tst.js:298:9:298:16 | location | tst.js:299:10:299:10 | e |
-| tst.js:298:9:298:16 | location | tst.js:299:10:299:10 | e |
-| tst.js:299:10:299:10 | e | tst.js:300:20:300:20 | e |
-| tst.js:299:10:299:10 | e | tst.js:300:20:300:20 | e |
-| tst.js:305:10:305:17 | location | tst.js:307:10:307:10 | e |
-| tst.js:305:10:305:17 | location | tst.js:307:10:307:10 | e |
-| tst.js:307:10:307:10 | e | tst.js:308:20:308:20 | e |
-| tst.js:307:10:307:10 | e | tst.js:308:20:308:20 | e |
-| tst.js:313:35:313:42 | location | tst.js:313:35:313:42 | location |
+| tst.js:151:29:151:43 | window.location | tst.js:151:29:151:50 | window. ... .search |
+| tst.js:151:29:151:43 | window.location | tst.js:151:29:151:50 | window. ... .search |
+| tst.js:151:29:151:50 | window. ... .search | tst.js:154:29:154:29 | v |
+| tst.js:154:29:154:29 | v | tst.js:154:49:154:49 | v |
+| tst.js:154:29:154:29 | v | tst.js:154:49:154:49 | v |
+| tst.js:161:40:161:54 | window.location | tst.js:161:40:161:61 | window. ... .search |
+| tst.js:161:40:161:54 | window.location | tst.js:161:40:161:61 | window. ... .search |
+| tst.js:161:40:161:61 | window. ... .search | tst.js:158:29:158:46 | xssSourceService() |
+| tst.js:161:40:161:61 | window. ... .search | tst.js:158:29:158:46 | xssSourceService() |
+| tst.js:180:9:180:41 | target | tst.js:183:28:183:33 | target |
+| tst.js:180:9:180:41 | target | tst.js:183:28:183:33 | target |
+| tst.js:180:18:180:34 | document.location | tst.js:180:18:180:41 | documen ... .search |
+| tst.js:180:18:180:34 | document.location | tst.js:180:18:180:41 | documen ... .search |
+| tst.js:180:18:180:41 | documen ... .search | tst.js:180:9:180:41 | target |
+| tst.js:187:9:187:42 | tainted | tst.js:189:31:189:37 | tainted |
+| tst.js:187:9:187:42 | tainted | tst.js:189:31:189:37 | tainted |
+| tst.js:187:9:187:42 | tainted | tst.js:191:42:191:48 | tainted |
+| tst.js:187:9:187:42 | tainted | tst.js:191:42:191:48 | tainted |
+| tst.js:187:9:187:42 | tainted | tst.js:192:33:192:39 | tainted |
+| tst.js:187:9:187:42 | tainted | tst.js:192:33:192:39 | tainted |
+| tst.js:187:9:187:42 | tainted | tst.js:194:54:194:60 | tainted |
+| tst.js:187:9:187:42 | tainted | tst.js:194:54:194:60 | tainted |
+| tst.js:187:9:187:42 | tainted | tst.js:195:45:195:51 | tainted |
+| tst.js:187:9:187:42 | tainted | tst.js:195:45:195:51 | tainted |
+| tst.js:187:19:187:35 | document.location | tst.js:187:19:187:42 | documen ... .search |
+| tst.js:187:19:187:35 | document.location | tst.js:187:19:187:42 | documen ... .search |
+| tst.js:187:19:187:42 | documen ... .search | tst.js:187:9:187:42 | tainted |
+| tst.js:200:9:200:42 | tainted | tst.js:202:67:202:73 | tainted |
+| tst.js:200:9:200:42 | tainted | tst.js:202:67:202:73 | tainted |
+| tst.js:200:9:200:42 | tainted | tst.js:203:67:203:73 | tainted |
+| tst.js:200:9:200:42 | tainted | tst.js:203:67:203:73 | tainted |
+| tst.js:200:9:200:42 | tainted | tst.js:207:35:207:41 | tainted |
+| tst.js:200:9:200:42 | tainted | tst.js:209:46:209:52 | tainted |
+| tst.js:200:9:200:42 | tainted | tst.js:210:38:210:44 | tainted |
+| tst.js:200:9:200:42 | tainted | tst.js:211:35:211:41 | tainted |
+| tst.js:200:9:200:42 | tainted | tst.js:239:35:239:41 | tainted |
+| tst.js:200:9:200:42 | tainted | tst.js:241:20:241:26 | tainted |
+| tst.js:200:9:200:42 | tainted | tst.js:243:23:243:29 | tainted |
+| tst.js:200:9:200:42 | tainted | tst.js:244:23:244:29 | tainted |
+| tst.js:200:9:200:42 | tainted | tst.js:258:23:258:29 | tainted |
+| tst.js:200:19:200:35 | document.location | tst.js:200:19:200:42 | documen ... .search |
+| tst.js:200:19:200:35 | document.location | tst.js:200:19:200:42 | documen ... .search |
+| tst.js:200:19:200:42 | documen ... .search | tst.js:200:9:200:42 | tainted |
+| tst.js:207:35:207:41 | tainted | tst.js:215:28:215:46 | this.state.tainted1 |
+| tst.js:207:35:207:41 | tainted | tst.js:215:28:215:46 | this.state.tainted1 |
+| tst.js:209:46:209:52 | tainted | tst.js:216:28:216:46 | this.state.tainted2 |
+| tst.js:209:46:209:52 | tainted | tst.js:216:28:216:46 | this.state.tainted2 |
+| tst.js:210:38:210:44 | tainted | tst.js:217:28:217:46 | this.state.tainted3 |
+| tst.js:210:38:210:44 | tainted | tst.js:217:28:217:46 | this.state.tainted3 |
+| tst.js:211:35:211:41 | tainted | tst.js:221:32:221:49 | prevState.tainted4 |
+| tst.js:211:35:211:41 | tainted | tst.js:221:32:221:49 | prevState.tainted4 |
+| tst.js:239:35:239:41 | tainted | tst.js:228:28:228:46 | this.props.tainted1 |
+| tst.js:239:35:239:41 | tainted | tst.js:228:28:228:46 | this.props.tainted1 |
+| tst.js:241:20:241:26 | tainted | tst.js:229:28:229:46 | this.props.tainted2 |
+| tst.js:241:20:241:26 | tainted | tst.js:229:28:229:46 | this.props.tainted2 |
+| tst.js:243:23:243:29 | tainted | tst.js:230:28:230:46 | this.props.tainted3 |
+| tst.js:243:23:243:29 | tainted | tst.js:230:28:230:46 | this.props.tainted3 |
+| tst.js:244:23:244:29 | tainted | tst.js:234:32:234:49 | prevProps.tainted4 |
+| tst.js:244:23:244:29 | tainted | tst.js:234:32:234:49 | prevProps.tainted4 |
+| tst.js:250:39:250:55 | props.propTainted | tst.js:254:60:254:82 | this.st ... Tainted |
+| tst.js:250:39:250:55 | props.propTainted | tst.js:254:60:254:82 | this.st ... Tainted |
+| tst.js:258:23:258:29 | tainted | tst.js:250:39:250:55 | props.propTainted |
+| tst.js:262:7:262:17 | window.name | tst.js:262:7:262:17 | window.name |
+| tst.js:263:7:263:10 | name | tst.js:263:7:263:10 | name |
+| tst.js:267:11:267:21 | window.name | tst.js:267:11:267:21 | window.name |
+| tst.js:283:22:283:29 | location | tst.js:283:22:283:29 | location |
+| tst.js:288:9:288:29 | tainted | tst.js:291:59:291:65 | tainted |
+| tst.js:288:9:288:29 | tainted | tst.js:291:59:291:65 | tainted |
+| tst.js:288:19:288:29 | window.name | tst.js:288:9:288:29 | tainted |
+| tst.js:288:19:288:29 | window.name | tst.js:288:9:288:29 | tainted |
+| tst.js:304:9:304:16 | location | tst.js:305:10:305:10 | e |
+| tst.js:304:9:304:16 | location | tst.js:305:10:305:10 | e |
+| tst.js:305:10:305:10 | e | tst.js:306:20:306:20 | e |
+| tst.js:305:10:305:10 | e | tst.js:306:20:306:20 | e |
+| tst.js:311:10:311:17 | location | tst.js:313:10:313:10 | e |
+| tst.js:311:10:311:17 | location | tst.js:313:10:313:10 | e |
+| tst.js:313:10:313:10 | e | tst.js:314:20:314:20 | e |
+| tst.js:313:10:313:10 | e | tst.js:314:20:314:20 | e |
+| tst.js:319:35:319:42 | location | tst.js:319:35:319:42 | location |
 | typeahead.js:9:28:9:30 | loc | typeahead.js:10:16:10:18 | loc |
 | typeahead.js:9:28:9:30 | loc | typeahead.js:10:16:10:18 | loc |
 | typeahead.js:9:28:9:30 | loc | typeahead.js:10:16:10:18 | loc |

--- a/javascript/ql/test/query-tests/Security/CWE-079/tst.js
+++ b/javascript/ql/test/query-tests/Security/CWE-079/tst.js
@@ -132,7 +132,7 @@ function tst() {
       document.write(v);
   }
 
-  if (!(/\d+/.test(v)))
+  if (!(/^\d+$/.test(v)))
     return;
 
   // OK

--- a/javascript/ql/test/query-tests/Security/CWE-079/tst.js
+++ b/javascript/ql/test/query-tests/Security/CWE-079/tst.js
@@ -132,6 +132,12 @@ function tst() {
       document.write(v);
   }
 
+  if (!(/\d+/.test(v))) // not effective - matches "123<script>...</script>"
+    return;
+
+  // NOT OK
+  document.write(v);
+
   if (!(/^\d+$/.test(v)))
     return;
 

--- a/javascript/ql/test/query-tests/Security/CWE-601/ServerSideUrlRedirect/ServerSideUrlRedirect.expected
+++ b/javascript/ql/test/query-tests/Security/CWE-601/ServerSideUrlRedirect/ServerSideUrlRedirect.expected
@@ -54,6 +54,8 @@ nodes
 | koa.js:8:18:8:20 | url |
 | koa.js:14:16:14:18 | url |
 | koa.js:14:16:14:18 | url |
+| koa.js:20:16:20:18 | url |
+| koa.js:20:16:20:18 | url |
 | node.js:6:7:6:52 | target |
 | node.js:6:16:6:39 | url.par ... , true) |
 | node.js:6:16:6:45 | url.par ... ).query |
@@ -131,6 +133,8 @@ edges
 | koa.js:6:6:6:27 | url | koa.js:8:18:8:20 | url |
 | koa.js:6:6:6:27 | url | koa.js:14:16:14:18 | url |
 | koa.js:6:6:6:27 | url | koa.js:14:16:14:18 | url |
+| koa.js:6:6:6:27 | url | koa.js:20:16:20:18 | url |
+| koa.js:6:6:6:27 | url | koa.js:20:16:20:18 | url |
 | koa.js:6:12:6:27 | ctx.query.target | koa.js:6:6:6:27 | url |
 | koa.js:6:12:6:27 | ctx.query.target | koa.js:6:6:6:27 | url |
 | koa.js:8:18:8:20 | url | koa.js:8:15:8:26 | `${url}${x}` |
@@ -180,6 +184,7 @@ edges
 | koa.js:7:15:7:17 | url | koa.js:6:12:6:27 | ctx.query.target | koa.js:7:15:7:17 | url | Untrusted URL redirection due to $@. | koa.js:6:12:6:27 | ctx.query.target | user-provided value |
 | koa.js:8:15:8:26 | `${url}${x}` | koa.js:6:12:6:27 | ctx.query.target | koa.js:8:15:8:26 | `${url}${x}` | Untrusted URL redirection due to $@. | koa.js:6:12:6:27 | ctx.query.target | user-provided value |
 | koa.js:14:16:14:18 | url | koa.js:6:12:6:27 | ctx.query.target | koa.js:14:16:14:18 | url | Untrusted URL redirection due to $@. | koa.js:6:12:6:27 | ctx.query.target | user-provided value |
+| koa.js:20:16:20:18 | url | koa.js:6:12:6:27 | ctx.query.target | koa.js:20:16:20:18 | url | Untrusted URL redirection due to $@. | koa.js:6:12:6:27 | ctx.query.target | user-provided value |
 | node.js:7:34:7:39 | target | node.js:6:26:6:32 | req.url | node.js:7:34:7:39 | target | Untrusted URL redirection due to $@. | node.js:6:26:6:32 | req.url | user-provided value |
 | node.js:15:34:15:45 | '/' + target | node.js:11:26:11:32 | req.url | node.js:15:34:15:45 | '/' + target | Untrusted URL redirection due to $@. | node.js:11:26:11:32 | req.url | user-provided value |
 | node.js:32:34:32:55 | target  ... =" + me | node.js:29:26:29:32 | req.url | node.js:32:34:32:55 | target  ... =" + me | Untrusted URL redirection due to $@. | node.js:29:26:29:32 | req.url | user-provided value |

--- a/javascript/ql/test/query-tests/Security/CWE-601/ServerSideUrlRedirect/koa.js
+++ b/javascript/ql/test/query-tests/Security/CWE-601/ServerSideUrlRedirect/koa.js
@@ -14,6 +14,12 @@ app.use(async ctx => {
 		ctx.redirect(url); // NOT OK
 	}
 
+	if(!url || isCrossDomainRedirect || url.match(VALID)) {
+		ctx.redirect('/'); // OK
+	} else {
+		ctx.redirect(url); // possibly OK - flagged anyway
+	}
+
 	if(!url || isCrossDomainRedirect || url.match(/[^\w/-]/)) {
 		ctx.redirect('/'); // OK
 	} else {

--- a/javascript/ql/test/query-tests/Security/CWE-601/ServerSideUrlRedirect/koa.js
+++ b/javascript/ql/test/query-tests/Security/CWE-601/ServerSideUrlRedirect/koa.js
@@ -1,5 +1,5 @@
 const Koa = require('koa');
-const url = require('url');
+const urlLib = require('url');
 const app = new Koa();
 
 app.use(async ctx => {
@@ -7,14 +7,14 @@ app.use(async ctx => {
 	ctx.redirect(url); // NOT OK
 	ctx.redirect(`${url}${x}`); // NOT OK
 
-	var isCrossDomainRedirect = url.parse(url || '', false, true).hostname;
+	var isCrossDomainRedirect = urlLib.parse(url || '', false, true).hostname;
 	if(!url || isCrossDomainRedirect) {
 		ctx.redirect('/'); // OK
 	} else {
 		ctx.redirect(url); // NOT OK
 	}
 
-	if(!url || isCrossDomainRedirect || ! url.match(VALID)) {
+	if(!url || isCrossDomainRedirect || url.match(/[^\w/-]/)) {
 		ctx.redirect('/'); // OK
 	} else {
 		ctx.redirect(url); // OK


### PR DESCRIPTION
Adds forward type-tracking for regexp literals and `RegExp` objects and a common type for working with them. These are them used to reason more precisely about sanitizer guards.

Regexp-based sanitizer guards would previously sanitize their input in both outcomes regardless of the RegExp in question. There is currently no way for a taint-tracking configuration to opt out of a sanitizer guard which makes it difficult for a custom query to explore flow past such a guard.

This refines the analysis of such guards based on two observations:
- If the regex is not anchored on both ends, there can always be tainted data before/after the match, so it won't sanitize in the true outcome. For example, `/foo|bar/.test(x)` allows `foo<script>alert(1)</script>`.
- Blacklists are rarely effective, e.g. `/<script/i.test(x)` doesn't actually sanitize `x` in the false case. Regexes that work well in the false outcome are usually those that restrict the character set, such as `/[^a-z]/.test(x)` which ensures that `x` can only contain `a-z` characters in the false case.

In cases where the above are too permissive, my feeling is that we can add query-specific sanitizer guards for the remaining cases. I have another WIP branch which analyzes which specific meta-characters can propagate through guards and `replace` calls, but I'll leave that for another PR.

[Evaluation](https://git.semmle.com/asger/dist-compare-reports/tree/regexp-sanitizer-guards_1574308370550) shows that there is a bit of a cost to doing this. We get one new result, since we recognize that [this guard](https://github.com/nodejs/node/blob/86f0b7595c8c43fffcc702ffee6ef52072238325/deps/npm/lib/utils/escape-exec-path.js#L25) sanitizes the false outcome (not both outcomes). Unfortunately it's a FP as we don't recognize that the `replace` call in the true branch acts as a sanitizer, but that's not the fault of this PR.