### PR TITLE
Java: Nullness library: track instanceof expressions in correlated conditions

### DIFF
--- a/java/ql/src/semmle/code/java/dataflow/NullGuards.qll
+++ b/java/ql/src/semmle/code/java/dataflow/NullGuards.qll
@@ -24,6 +24,12 @@ Expr enumConstEquality(Expr e, boolean polarity, EnumConstant c) {
   )
 }
 
+/** Gets an instanceof expression of `v` with type `type` */
+InstanceOfExpr instanceofExpr(SsaVariable v, Expr type) {
+  result.getTypeName() = type and
+  result.getExpr() = v.getAUse()
+}
+
 /** Gets an expression that is provably not `null`. */
 Expr clearlyNotNullExpr(Expr reason) {
   result instanceof ClassInstanceExpr and reason = result

--- a/java/ql/src/semmle/code/java/dataflow/NullGuards.qll
+++ b/java/ql/src/semmle/code/java/dataflow/NullGuards.qll
@@ -36,7 +36,6 @@ InstanceOfExpr instanceofExpr(SsaVariable v, Type type) {
  */
 EqualityTest varEqualityTestExpr(SsaVariable v1, SsaVariable v2, boolean isEqualExpr) {
   result.hasOperands(v1.getAUse(), v2.getAUse()) and
-  result instanceof EqualityTest and
   isEqualExpr = result.polarity()
 }
 

--- a/java/ql/src/semmle/code/java/dataflow/NullGuards.qll
+++ b/java/ql/src/semmle/code/java/dataflow/NullGuards.qll
@@ -25,30 +25,19 @@ Expr enumConstEquality(Expr e, boolean polarity, EnumConstant c) {
 }
 
 /** Gets an instanceof expression of `v` with type `type` */
-InstanceOfExpr instanceofExpr(SsaVariable v, Expr type) {
-  result.getTypeName() = type and
+InstanceOfExpr instanceofExpr(SsaVariable v, Type type) {
+  result.getTypeName().getType() = type and
   result.getExpr() = v.getAUse()
 }
 
 /**
- * Gets an expression of the form `v1` == `v2` or `v1` != `v2`.
+ * Gets an expression of the form `v1 == v2` or `v1 != v2`.
  * The predicate is symmetric in `v1` and `v2`.
  */
-BinaryExpr varComparisonExpr(SsaVariable v1, SsaVariable v2, boolean isEqualExpr) {
-  (
-    result.getLeftOperand() = v1.getAUse() and
-    result.getRightOperand() = v2.getAUse()
-    or
-    result.getLeftOperand() = v2.getAUse() and
-    result.getRightOperand() = v1.getAUse()
-  ) and
-  (
-    result instanceof EQExpr and
-    isEqualExpr = true
-    or
-    result instanceof NEExpr and
-    isEqualExpr = false
-  )
+EqualityTest varEqualityTestExpr(SsaVariable v1, SsaVariable v2, boolean isEqualExpr) {
+  result.hasOperands(v1.getAUse(), v2.getAUse()) and
+  result instanceof EqualityTest and
+  isEqualExpr = result.polarity()
 }
 
 /** Gets an expression that is provably not `null`. */

--- a/java/ql/src/semmle/code/java/dataflow/NullGuards.qll
+++ b/java/ql/src/semmle/code/java/dataflow/NullGuards.qll
@@ -30,6 +30,27 @@ InstanceOfExpr instanceofExpr(SsaVariable v, Expr type) {
   result.getExpr() = v.getAUse()
 }
 
+/**
+ * Gets an expression of the form `v1` == `v2` or `v1` != `v2`.
+ * The predicate is symmetric in `v1` and `v2`.
+ */
+BinaryExpr varComparisonExpr(SsaVariable v1, SsaVariable v2, boolean isEqualExpr) {
+  (
+    result.getLeftOperand() = v1.getAUse() and
+    result.getRightOperand() = v2.getAUse()
+    or
+    result.getLeftOperand() = v2.getAUse() and
+    result.getRightOperand() = v1.getAUse()
+  ) and
+  (
+    result instanceof EQExpr and
+    isEqualExpr = true
+    or
+    result instanceof NEExpr and
+    isEqualExpr = false
+  )
+}
+
 /** Gets an expression that is provably not `null`. */
 Expr clearlyNotNullExpr(Expr reason) {
   result instanceof ClassInstanceExpr and reason = result

--- a/java/ql/src/semmle/code/java/dataflow/Nullness.qll
+++ b/java/ql/src/semmle/code/java/dataflow/Nullness.qll
@@ -516,16 +516,15 @@ private predicate correlatedConditions(
       inverted = pol1.booleanXor(pol2)
     )
     or
-    exists(SsaVariable v, Expr t1, Expr t2 |
-      cond1.getCondition() = instanceofExpr(v, t1) and
-      cond2.getCondition() = instanceofExpr(v, t2) and
-      t1.getType() = t2.getType() and
+    exists(SsaVariable v, Type type |
+      cond1.getCondition() = instanceofExpr(v, type) and
+      cond2.getCondition() = instanceofExpr(v, type) and
       inverted = false
     )
     or
     exists(SsaVariable v1, SsaVariable v2, boolean branch1, boolean branch2  |
-      cond1.getCondition() = varComparisonExpr(v1, v2, branch1) and
-      cond2.getCondition() = varComparisonExpr(v1, v2, branch2) and
+      cond1.getCondition() = varEqualityTestExpr(v1, v2, branch1) and
+      cond2.getCondition() = varEqualityTestExpr(v1, v2, branch2) and
       inverted = branch1.booleanXor(branch2)
     )
   )

--- a/java/ql/src/semmle/code/java/dataflow/Nullness.qll
+++ b/java/ql/src/semmle/code/java/dataflow/Nullness.qll
@@ -522,7 +522,7 @@ private predicate correlatedConditions(
       inverted = false
     )
     or
-    exists(SsaVariable v1, SsaVariable v2, boolean branch1, boolean branch2  |
+    exists(SsaVariable v1, SsaVariable v2, boolean branch1, boolean branch2 |
       cond1.getCondition() = varEqualityTestExpr(v1, v2, branch1) and
       cond2.getCondition() = varEqualityTestExpr(v1, v2, branch2) and
       inverted = branch1.booleanXor(branch2)

--- a/java/ql/src/semmle/code/java/dataflow/Nullness.qll
+++ b/java/ql/src/semmle/code/java/dataflow/Nullness.qll
@@ -515,6 +515,13 @@ private predicate correlatedConditions(
       cond2.getCondition() = enumConstEquality(v.getAUse(), pol2, c) and
       inverted = pol1.booleanXor(pol2)
     )
+    or
+    exists(SsaVariable v, Expr t1, Expr t2 |
+      cond1.getCondition() = instanceofExpr(v, t1) and
+      cond2.getCondition() = instanceofExpr(v, t2) and
+      t1.getType() = t2.getType() and
+      inverted = false
+    )
   )
 }
 

--- a/java/ql/src/semmle/code/java/dataflow/Nullness.qll
+++ b/java/ql/src/semmle/code/java/dataflow/Nullness.qll
@@ -522,6 +522,12 @@ private predicate correlatedConditions(
       t1.getType() = t2.getType() and
       inverted = false
     )
+    or
+    exists(SsaVariable v1, SsaVariable v2, boolean branch1, boolean branch2  |
+      cond1.getCondition() = varComparisonExpr(v1, v2, branch1) and
+      cond2.getCondition() = varComparisonExpr(v1, v2, branch2) and
+      inverted = branch1.booleanXor(branch2)
+    )
   )
 }
 

--- a/java/ql/test/query-tests/Nullness/B.java
+++ b/java/ql/test/query-tests/Nullness/B.java
@@ -344,4 +344,31 @@ public class B {
       x.hashCode(); // OK
     }
   }
+
+  public void corrConds5(Object y, Object z) {
+    Object x = null;
+    if(y == z) {
+      x = new Object();
+    }
+    if(y == z) {
+      x.hashCode(); // OK
+    }
+
+    Object x2 = null;
+    if(y != z) {
+      x2 = new Object();
+    }
+    if(y != z) {
+      x2.hashCode(); // OK
+    }
+
+    Object x3 = null;
+    if(y != z) {
+      x3 = new Object();
+    }
+    if(!(y == z)) {
+      x3.hashCode(); // OK
+    }
+  }
+
 }

--- a/java/ql/test/query-tests/Nullness/B.java
+++ b/java/ql/test/query-tests/Nullness/B.java
@@ -324,4 +324,24 @@ public class B {
     if (x != null) y.hashCode(); // OK
     if (y != null) x.hashCode(); // OK
   }
+
+  public void corrConds3(Object y) {
+    Object x = null;
+    if(y instanceof String) {
+      x = new Object();
+    }
+    if(y instanceof String) {
+      x.hashCode(); // OK
+    }
+  }
+
+  public void corrConds4(Object y) {
+    Object x = null;
+    if(!(y instanceof String)) {
+      x = new Object();
+    }
+    if(!(y instanceof String)) {
+      x.hashCode(); // OK
+    }
+  }
 }

--- a/java/ql/test/query-tests/Nullness/NullMaybe.expected
+++ b/java/ql/test/query-tests/Nullness/NullMaybe.expected
@@ -17,8 +17,6 @@
 | B.java:190:7:190:7 | o | Variable $@ may be null here because of $@ assignment. | B.java:178:5:178:20 | Object o | o | B.java:186:5:186:12 | ...=... | this |
 | B.java:279:7:279:7 | a | Variable $@ may be null here because of $@ assignment. | B.java:276:5:276:19 | int[] a | a | B.java:276:11:276:18 | a | this |
 | B.java:292:7:292:7 | b | Variable $@ may be null here because of $@ assignment. | B.java:287:5:287:44 | int[] b | b | B.java:287:11:287:43 | b | this |
-| B.java:334:7:334:7 | x | Variable $@ may be null here because of $@ assignment. | B.java:329:5:329:20 | Object x | x | B.java:329:12:329:19 | x | this |
-| B.java:344:7:344:7 | x | Variable $@ may be null here because of $@ assignment. | B.java:339:5:339:20 | Object x | x | B.java:339:12:339:19 | x | this |
 | C.java:9:44:9:45 | a2 | Variable $@ may be null here as suggested by $@ null guard. | C.java:6:5:6:23 | long[][] a2 | a2 | C.java:7:34:7:54 | ... != ... | this |
 | C.java:9:44:9:45 | a2 | Variable $@ may be null here because of $@ assignment. | C.java:6:5:6:23 | long[][] a2 | a2 | C.java:6:14:6:22 | a2 | this |
 | C.java:10:17:10:18 | a3 | Variable $@ may be null here as suggested by $@ null guard. | C.java:8:5:8:21 | long[] a3 | a3 | C.java:9:38:9:58 | ... != ... | this |

--- a/java/ql/test/query-tests/Nullness/NullMaybe.expected
+++ b/java/ql/test/query-tests/Nullness/NullMaybe.expected
@@ -17,9 +17,6 @@
 | B.java:190:7:190:7 | o | Variable $@ may be null here because of $@ assignment. | B.java:178:5:178:20 | Object o | o | B.java:186:5:186:12 | ...=... | this |
 | B.java:279:7:279:7 | a | Variable $@ may be null here because of $@ assignment. | B.java:276:5:276:19 | int[] a | a | B.java:276:11:276:18 | a | this |
 | B.java:292:7:292:7 | b | Variable $@ may be null here because of $@ assignment. | B.java:287:5:287:44 | int[] b | b | B.java:287:11:287:43 | b | this |
-| B.java:354:7:354:7 | x | Variable $@ may be null here because of $@ assignment. | B.java:349:5:349:20 | Object x | x | B.java:349:12:349:19 | x | this |
-| B.java:362:7:362:8 | x2 | Variable $@ may be null here because of $@ assignment. | B.java:357:5:357:21 | Object x2 | x2 | B.java:357:12:357:20 | x2 | this |
-| B.java:370:7:370:8 | x3 | Variable $@ may be null here because of $@ assignment. | B.java:365:5:365:21 | Object x3 | x3 | B.java:365:12:365:20 | x3 | this |
 | C.java:9:44:9:45 | a2 | Variable $@ may be null here as suggested by $@ null guard. | C.java:6:5:6:23 | long[][] a2 | a2 | C.java:7:34:7:54 | ... != ... | this |
 | C.java:9:44:9:45 | a2 | Variable $@ may be null here because of $@ assignment. | C.java:6:5:6:23 | long[][] a2 | a2 | C.java:6:14:6:22 | a2 | this |
 | C.java:10:17:10:18 | a3 | Variable $@ may be null here as suggested by $@ null guard. | C.java:8:5:8:21 | long[] a3 | a3 | C.java:9:38:9:58 | ... != ... | this |

--- a/java/ql/test/query-tests/Nullness/NullMaybe.expected
+++ b/java/ql/test/query-tests/Nullness/NullMaybe.expected
@@ -17,6 +17,9 @@
 | B.java:190:7:190:7 | o | Variable $@ may be null here because of $@ assignment. | B.java:178:5:178:20 | Object o | o | B.java:186:5:186:12 | ...=... | this |
 | B.java:279:7:279:7 | a | Variable $@ may be null here because of $@ assignment. | B.java:276:5:276:19 | int[] a | a | B.java:276:11:276:18 | a | this |
 | B.java:292:7:292:7 | b | Variable $@ may be null here because of $@ assignment. | B.java:287:5:287:44 | int[] b | b | B.java:287:11:287:43 | b | this |
+| B.java:354:7:354:7 | x | Variable $@ may be null here because of $@ assignment. | B.java:349:5:349:20 | Object x | x | B.java:349:12:349:19 | x | this |
+| B.java:362:7:362:8 | x2 | Variable $@ may be null here because of $@ assignment. | B.java:357:5:357:21 | Object x2 | x2 | B.java:357:12:357:20 | x2 | this |
+| B.java:370:7:370:8 | x3 | Variable $@ may be null here because of $@ assignment. | B.java:365:5:365:21 | Object x3 | x3 | B.java:365:12:365:20 | x3 | this |
 | C.java:9:44:9:45 | a2 | Variable $@ may be null here as suggested by $@ null guard. | C.java:6:5:6:23 | long[][] a2 | a2 | C.java:7:34:7:54 | ... != ... | this |
 | C.java:9:44:9:45 | a2 | Variable $@ may be null here because of $@ assignment. | C.java:6:5:6:23 | long[][] a2 | a2 | C.java:6:14:6:22 | a2 | this |
 | C.java:10:17:10:18 | a3 | Variable $@ may be null here as suggested by $@ null guard. | C.java:8:5:8:21 | long[] a3 | a3 | C.java:9:38:9:58 | ... != ... | this |

--- a/java/ql/test/query-tests/Nullness/NullMaybe.expected
+++ b/java/ql/test/query-tests/Nullness/NullMaybe.expected
@@ -17,6 +17,8 @@
 | B.java:190:7:190:7 | o | Variable $@ may be null here because of $@ assignment. | B.java:178:5:178:20 | Object o | o | B.java:186:5:186:12 | ...=... | this |
 | B.java:279:7:279:7 | a | Variable $@ may be null here because of $@ assignment. | B.java:276:5:276:19 | int[] a | a | B.java:276:11:276:18 | a | this |
 | B.java:292:7:292:7 | b | Variable $@ may be null here because of $@ assignment. | B.java:287:5:287:44 | int[] b | b | B.java:287:11:287:43 | b | this |
+| B.java:334:7:334:7 | x | Variable $@ may be null here because of $@ assignment. | B.java:329:5:329:20 | Object x | x | B.java:329:12:329:19 | x | this |
+| B.java:344:7:344:7 | x | Variable $@ may be null here because of $@ assignment. | B.java:339:5:339:20 | Object x | x | B.java:339:12:339:19 | x | this |
 | C.java:9:44:9:45 | a2 | Variable $@ may be null here as suggested by $@ null guard. | C.java:6:5:6:23 | long[][] a2 | a2 | C.java:7:34:7:54 | ... != ... | this |
 | C.java:9:44:9:45 | a2 | Variable $@ may be null here because of $@ assignment. | C.java:6:5:6:23 | long[][] a2 | a2 | C.java:6:14:6:22 | a2 | this |
 | C.java:10:17:10:18 | a3 | Variable $@ may be null here as suggested by $@ null guard. | C.java:8:5:8:21 | long[] a3 | a3 | C.java:9:38:9:58 | ... != ... | this |


### PR DESCRIPTION
This fixes a FP on apache kafka, see #2238 .
@aschackmull 