### PR TITLE
C++: Prevent cached stages from being re-evaluated

### DIFF
--- a/cpp/ql/src/semmle/code/cpp/Enclosing.qll
+++ b/cpp/ql/src/semmle/code/cpp/Enclosing.qll
@@ -13,6 +13,11 @@ Element stmtEnclosingElement(Stmt s) {
 /**
  * Gets the enclosing element of expression `e`.
  */
+// The `pragma[nomagic]` is a workaround to prevent this cached stage (and all
+// subsequent stages) from being evaluated twice. See QL-888. It has the effect
+// of making the `Conversion` class predicate get the same optimization in all
+// queries.
+pragma[nomagic]
 cached
 Element exprEnclosingElement(Expr e) {
   result = exprEnclosingElement(e.getParent())


### PR DESCRIPTION
Before this change, evaluating `cpp/constant-comparison` followed by `cpp/signed-overflow-check` would result in re-evaluation of almost all the cached stages they share: CFG, basic blocks, SSA, and range analysis. The same effect could be seen on `cpp/bad-strncpy-size`, which also uses the GVN library.