### PR TITLE
Python: Fix false positive for `py/use-of-input`.

### DIFF
--- a/python/ql/src/Expressions/UseofInput.ql
+++ b/python/ql/src/Expressions/UseofInput.ql
@@ -14,5 +14,8 @@ import python
 
 from CallNode call, Context context, ControlFlowNode func
 where
-context.getAVersion().includes(2, _) and call.getFunction() = func and func.refersTo(context, Object::builtin("input"), _, _)
+    context.getAVersion().includes(2, _) and
+    call.getFunction() = func and
+    func.pointsTo(context, Value::named("input"), _) and
+    not func.pointsTo(context, Value::named("raw_input"), _)
 select call, "The unsafe built-in function 'input' is used."

--- a/python/ql/test/2/query-tests/Expressions/safe_input.py
+++ b/python/ql/test/2/query-tests/Expressions/safe_input.py
@@ -1,0 +1,10 @@
+try:
+    input = raw_input
+except NameError:
+    pass
+
+def use_of_input():
+    return input()
+
+print(use_of_input())
+


### PR DESCRIPTION
Fixes #1969.

The points-to analysis does not know that the assignment `input = raw_input`
cannot fail under Python 2, and so there are two possible values that `input`
could point-to after exiting the exception handler: the built-in `input`, or the
built-in `raw_input`. In the latter case we do not want to report the alert, and
so adding a check that the given function does not point-to the built-in
`raw_input` suffices.