### PR TITLE
C++: Stricter loop-variant check

### DIFF
--- a/cpp/ql/src/Security/CWE/CWE-190/ComparisonWithWiderType.ql
+++ b/cpp/ql/src/Security/CWE/CWE-190/ComparisonWithWiderType.ql
@@ -44,7 +44,7 @@ Element friendlyLoc(Expr e) {
   not e instanceof Access and not e instanceof Call and result = e
 }
 
-from Loop l, RelationalOperation rel, Expr small, Expr large
+from Loop l, RelationalOperation rel, VariableAccess small, Expr large
 where
   small = rel.getLesserOperand() and
   large = rel.getGreaterOperand() and
@@ -60,7 +60,7 @@ where
   not getComparisonSize(large.(SubExpr).getLeftOperand().getExplicitlyConverted()) <= getComparisonSize(small) and
   not getComparisonSize(large.(RShiftExpr).getLeftOperand().getExplicitlyConverted()) <= getComparisonSize(small) and
   // ignore loop-invariant smaller variables
-  loopVariant(small.getAChild*(), l)
+  loopVariant(small, l)
 select rel,
   "Comparison between $@ of type " + small.getType().getName() + " and $@ of wider type " +
     large.getType().getName() + ".", friendlyLoc(small), small.toString(), friendlyLoc(large),


### PR DESCRIPTION
Fixes #2425. I've proposed this as a 1.23 hotfix since it's a very local change and fixes FPs on so many prominent projects.

From the commit message:
> The `loopVariant` predicate in `ComparisonWithWiderType.ql` is intended
> to identify loop counters, but it was too much of a stretch to apply it
> to any subexpression of the small side of the comparison.
>
> This change fixes two false positives on arvidn/libtorrent and many
> others seen in the wild (on Linux, CoreCLR, ffmpeg, ...).

I've tested the change by adding _the negation_ of `loopVariant(small, l)` to the current query so it selects the results that will now be _removed_. This shows that [the two FPs go away on arvidn/libtorrent](https://lgtm.com/query/4534603557926274703/). I've checked only the first two pages of [the results on our 88 test projects](https://lgtm.com/query/4552693110689242384/), but they all look like FPs to me, so I'll be glad to get rid of them.

I've tested performance on one medium-sized project (ChakraCore), and there was no difference from before.