### PR TITLE
JS: remove FP in use-of-returnless-function FP related to super() calls

### DIFF
--- a/javascript/ql/src/Statements/UseOfReturnlessFunction.ql
+++ b/javascript/ql/src/Statements/UseOfReturnlessFunction.ql
@@ -222,6 +222,7 @@ where
   not lastStatementHasNoEffect(func) and
   // anonymous one-shot closure. Those are used in weird ways and we ignore them.
   not oneshotClosure(call) and
-  not hasNonVoidReturnType(func)
+  not hasNonVoidReturnType(func) and
+  not call.getEnclosingExpr() instanceof SuperCall
 select
   call, msg, func, name

--- a/javascript/ql/test/query-tests/Statements/UseOfReturnlessFunction/tst.js
+++ b/javascript/ql/test/query-tests/Statements/UseOfReturnlessFunction/tst.js
@@ -93,3 +93,15 @@
 +function() {
     console.log("FOO");
 }.call(this);
+
+class Foo {
+	constructor() {
+		console.log("FOO");
+	}
+}
+
+class Bar extends Foo {
+	constructor() {
+		console.log(super()); // OK.
+	}
+}


### PR DESCRIPTION
Motivated by these false positives: https://lgtm.com/projects/g/Pomax/Font.js/alerts?id=js%2Fuse-of-returnless-function&mode=list