### PR TITLE
TS: Add option to install dependencies

### DIFF
--- a/javascript/extractor/src/com/semmle/js/extractor/AutoBuild.java
+++ b/javascript/extractor/src/com/semmle/js/extractor/AutoBuild.java
@@ -211,10 +211,11 @@ public class AutoBuild {
     this.typeScriptMode =
         getEnumFromEnvVar("LGTM_INDEX_TYPESCRIPT", TypeScriptMode.class, TypeScriptMode.FULL);
     this.defaultEncoding = getEnvVar("LGTM_INDEX_DEFAULT_ENCODING");
-    this.installDependencies = Boolean.valueOf(getEnvVar("LGTM_TYPESCRIPT_INSTALL_DEPS"));
+    this.installDependencies = Boolean.valueOf(getEnvVar("LGTM_INDEX_TYPESCRIPT_INSTALL_DEPS"));
     this.installDependenciesTimeout =
         Env.systemEnv()
-            .getInt("LGTM_TYPESCRIPT_INSTALL_DEPS_TIMEOUT", INSTALL_DEPENDENCIES_DEFAULT_TIMEOUT);
+            .getInt(
+                "LGTM_INDEX_TYPESCRIPT_INSTALL_DEPS_TIMEOUT", INSTALL_DEPENDENCIES_DEFAULT_TIMEOUT);
     setupFileTypes();
     setupXmlMode();
     setupMatchers();

--- a/javascript/extractor/src/com/semmle/js/extractor/AutoBuild.java
+++ b/javascript/extractor/src/com/semmle/js/extractor/AutoBuild.java
@@ -600,10 +600,12 @@ public class AutoBuild {
                     "yarn",
                     "install",
                     "--verbose",
+                    "--non-interactive",
                     "--ignore-scripts",
                     "--ignore-platform",
                     "--ignore-engines",
                     "--ignore-optional",
+                    "--no-default-rc",
                     "--no-bin-links",
                     "--pure-lockfile"));
         pb.directory(file.getParent().toFile());

--- a/javascript/extractor/src/com/semmle/js/extractor/test/AutoBuildTests.java
+++ b/javascript/extractor/src/com/semmle/js/extractor/test/AutoBuildTests.java
@@ -129,6 +129,11 @@ public class AutoBuildTests {
         }
 
         @Override
+        protected void installDependencies(Set<Path> filesToExtract) {
+          // never install dependencies during testing
+        }
+
+        @Override
         protected void extractXml() throws IOException {
           Files.walkFileTree(
               LGTM_SRC,


### PR DESCRIPTION
If the environment variable `LGTM_TYPESCRIPT_INSTALL_DEPS` is `true`, AutoBuild will now run `yarn` from each folder containing a `package.json` file, if the project contains at least one `tsconfig.json` file.

We do this so TypeScript can find the `.d.ts` files it needs for type checking. We don't extract the contents of `node_modules` folders.

The intent is to manually set this variable for few projects at first, and later set it in the worker config. 

Marking as WIP as I'd like to run it through an evaluation first.