### PR TITLE
Java: Improve performance by normalizing import order to reduce cache invalidation.

### DIFF
--- a/java/ql/src/Security/CWE/CWE-078/ExecTainted.ql
+++ b/java/ql/src/Security/CWE/CWE-078/ExecTainted.ql
@@ -11,7 +11,7 @@
  *       external/cwe/cwe-088
  */
 
-import semmle.code.java.Expr
+import java
 import semmle.code.java.dataflow.FlowSources
 import semmle.code.java.security.ExternalProcess
 import ExecCommon

--- a/java/ql/src/Security/CWE/CWE-078/ExecUnescaped.ql
+++ b/java/ql/src/Security/CWE/CWE-078/ExecUnescaped.ql
@@ -11,7 +11,7 @@
  *       external/cwe/cwe-088
  */
 
-import semmle.code.java.Expr
+import java
 import semmle.code.java.security.ExternalProcess
 import ExecCommon
 

--- a/java/ql/src/Security/CWE/CWE-089/SqlTainted.ql
+++ b/java/ql/src/Security/CWE/CWE-089/SqlTainted.ql
@@ -10,7 +10,7 @@
  *       external/cwe/cwe-089
  */
 
-import semmle.code.java.Expr
+import java
 import semmle.code.java.dataflow.FlowSources
 import SqlInjectionLib
 import DataFlow::PathGraph

--- a/java/ql/src/Security/CWE/CWE-089/SqlUnescaped.ql
+++ b/java/ql/src/Security/CWE/CWE-089/SqlUnescaped.ql
@@ -10,6 +10,7 @@
  *       external/cwe/cwe-089
  */
 
+import java
 import semmle.code.java.security.SqlUnescapedLib
 import SqlInjectionLib
 


### PR DESCRIPTION
We had a couple of queries that didn't start with `import java`. This meant that imports were resolved in a different order for those queries resulting in slight DIL differences leading to recomputation of the virtual dispatch stage and all dependent stages (SSA etc.).

I've verified locally by running all queries on a small snapshot that this removes the recomputation of the cached stages. This small change should thus be a clear performance improvement when running all queries.