### PR TITLE
Python: Use `import python` consistently in all queries.

### DIFF
--- a/python/ql/src/Filters/NotGenerated.ql
+++ b/python/ql/src/Filters/NotGenerated.ql
@@ -4,6 +4,7 @@
  * @kind file-classifier
  * @id py/not-generated-file-filter
  */
+import python
 import external.DefectFilter
 import semmle.python.filters.GeneratedCode
 

--- a/python/ql/src/Filters/NotTest.ql
+++ b/python/ql/src/Filters/NotTest.ql
@@ -4,6 +4,7 @@
  * @kind file-classifier
  * @id py/not-test-file-filter
  */
+import python
 import external.DefectFilter
 import semmle.python.filters.Tests
 

--- a/python/ql/src/Security/CWE-798/HardcodedCredentials.ql
+++ b/python/ql/src/Security/CWE-798/HardcodedCredentials.ql
@@ -11,6 +11,7 @@
  *       external/cwe/cwe-798
  */
 
+import python
 import semmle.python.security.TaintTracking
 import semmle.python.filters.Tests
 

--- a/python/ql/src/external/DuplicateBlock.ql
+++ b/python/ql/src/external/DuplicateBlock.ql
@@ -14,6 +14,7 @@
  * @precision medium
  * @id py/duplicate-block
  */
+import python
 import CodeDuplication
 
 predicate sorted_by_location(DuplicateBlock x, DuplicateBlock y) {


### PR DESCRIPTION
The Python counterpart to #2447. I want to run a performance comparison before merging this, to see if it improves performance for the queries involved.