### PR TITLE
Update data-flow note to match that for C/C++

### DIFF
--- a/change-notes/1.23/analysis-java.md
+++ b/change-notes/1.23/analysis-java.md
@@ -22,7 +22,7 @@ The following changes in version 1.23 affect Java analysis in all applications.
 ## Changes to libraries
 
 The data-flow library has been extended with a new feature to aid debugging. 
-If you want to explore the possible flow from a source, replace
-`isSink(Node n) { any() }` with the new `Configuration::hasPartialFlow` predicate. 
-This gives a more complete picture of the partial flow paths from a given source. 
+Previously, to explore the possible flow from all sources you could specify `isSink(Node n) { any() }` on a configuration. 
+Now you can use the new `Configuration::hasPartialFlow` predicate, 
+which gives a more complete picture of the partial flow paths from a given source, including flow that doesn't reach any sink.
 The feature is disabled by default and can be enabled for individual configurations by overriding `int explorationLimit()`.


### PR DESCRIPTION
@yo-h and @aschackmull - apologies for raising a further update to this file. This updates the shared text about `Configuration::hasPartialFlow` to match what was agreed with the C/C++ and C# teams, who felt that I'd changed the meaning of the original text.

See https://github.com/Semmle/ql/pull/2434#discussion_r350268500 for the discussion.