### PR TITLE
Documentation: fix invalid `@precision` value

### DIFF
--- a/docs/query-metadata-style-guide.md
+++ b/docs/query-metadata-style-guide.md
@@ -113,7 +113,7 @@ Alert queries (`@kind problem` or `path-problem`) support two further properties
     *   `low `
     *   `medium `
     *   `high `
-    *   `very high`
+    *   `very-high`
 *   `@problem.severity`–defines the level of severity of the alert: 
     *   `error`–an issue that is likely to cause incorrect program behavior, for example a crash or vulnerability.
     *   `warning`–an issue that indicates a potential problem in the code, or makes the code fragile if another (unrelated) part of code is changed.


### PR DESCRIPTION
Getting this correct in the query metadata is required for LGTM to interpret the precision correctly.

It looks as though this typo may have [affected an external contribution](https://github.com/Semmle/ql/pull/2413#discussion_r350509685).