### PR TITLE
Java: Allow explicit zero multiplication in java/evaluation-to-constant.

### DIFF
--- a/change-notes/1.24/analysis-java.md
+++ b/change-notes/1.24/analysis-java.md
@@ -1,0 +1,17 @@
+# Improvements to Java analysis
+
+The following changes in version 1.24 affect Java analysis in all applications.
+
+## New queries
+
+| **Query**                   | **Tags**  | **Purpose**                                                        |
+|-----------------------------|-----------|--------------------------------------------------------------------|
+
+## Changes to existing queries
+
+| **Query**                    | **Expected impact**    | **Change**                        |
+|------------------------------|------------------------|-----------------------------------|
+| Expression always evaluates to the same value (`java/evaluation-to-constant`) | Fewer false positives | Expressions of the form `0 * x` are usually intended and no longer reported. |
+
+## Changes to libraries
+

--- a/java/ql/src/Likely Bugs/Arithmetic/ConstantExpAppearsNonConstant.ql
+++ b/java/ql/src/Likely Bugs/Arithmetic/ConstantExpAppearsNonConstant.ql
@@ -74,6 +74,8 @@ where
     not child instanceof Annotation
   ) and
   not e instanceof CompileTimeConstantExpr and
+  // Exclude explicit zero multiplication.
+  not e.(MulExpr).getAnOperand().(IntegerLiteral).getIntValue() = 0 and
   // Exclude expressions that appear to be disabled deliberately (e.g. `false && ...`).
   not e.(AndLogicalExpr).getAnOperand().(BooleanLiteral).getBooleanValue() = false
 select e, "Expression always evaluates to the same value."

--- a/java/ql/test/query-tests/ConstantExpAppearsNonConstant/ConstantExpAppearsNonConstant.expected
+++ b/java/ql/test/query-tests/ConstantExpAppearsNonConstant/ConstantExpAppearsNonConstant.expected
@@ -1,7 +1,7 @@
-| Test.java:18:33:18:49 | ... * ... | Expression always evaluates to the same value. |
-| Test.java:19:34:19:50 | ... * ... | Expression always evaluates to the same value. |
-| Test.java:20:29:20:48 | ... * ... | Expression always evaluates to the same value. |
-| Test.java:21:32:21:50 | ... * ... | Expression always evaluates to the same value. |
+| Test.java:18:33:18:53 | ... * ... | Expression always evaluates to the same value. |
+| Test.java:19:34:19:54 | ... * ... | Expression always evaluates to the same value. |
+| Test.java:20:29:20:58 | ... * ... | Expression always evaluates to the same value. |
+| Test.java:21:32:21:69 | ... * ... | Expression always evaluates to the same value. |
 | Test.java:27:28:27:44 | ... % ... | Expression always evaluates to the same value. |
 | Test.java:29:29:29:48 | ... % ... | Expression always evaluates to the same value. |
 | Test.java:30:32:30:50 | ... % ... | Expression always evaluates to the same value. |

--- a/java/ql/test/query-tests/ConstantExpAppearsNonConstant/Test.java
+++ b/java/ql/test/query-tests/ConstantExpAppearsNonConstant/Test.java
@@ -15,11 +15,11 @@ class Test{
 	int mul_constant_left = 0 * 60 * 60 * 24; //OK
 	int mul_constant_right = 60 * 60 * 24 * 0; //OK
 	int mul_is_not_constant = rnd.nextInt() * 1; //OK
-	int mul_is_constant_int_left = 0 * rnd.nextInt(); //NOT OK
-	int mul_is_constant_int_right = rnd.nextInt() * 0; //NOT OK
-	long mul_is_constant_hex = rnd.nextLong() * 0x0; //NOT OK
-	long mul_is_constant_binary = rnd.nextLong() * 00; //NOT OK
-
+	int mul_is_constant_int_left = (0+0) * rnd.nextInt(); //NOT OK
+	int mul_is_constant_int_right = rnd.nextInt() * (1-1); //NOT OK
+	long mul_is_constant_hex = rnd.nextLong() * (0x0F & 0xF0); //NOT OK
+	long mul_is_constant_binary = rnd.nextLong() * (0b010101 & 0b101010); //NOT OK
+	int mul_explicit_zero = rnd.nextInt() * 0; //OK (deliberate zero multiplication)
 	//Remainder by 1
 	int rem_not_constant = 42 % 6; //OK
 	int rem_constant = 60 % 1; //OK


### PR DESCRIPTION
Fixes https://github.com/Semmle/ql/issues/2440.

Looking over the lgtm.com results for this, they generally appear intentional, which makes them FPs.