### PR TITLE
CodeQL training: update QL4E links and provide database instructions

### DIFF
--- a/docs/language/ql-training/_static-training/slides-semmle-2/static/theme/css/default.css
+++ b/docs/language/ql-training/_static-training/slides-semmle-2/static/theme/css/default.css
@@ -1667,6 +1667,15 @@ li > ul > li {
   margin-bottom: 0;
 }
 
+.admonition.note ol {
+  width: 90%;
+  margin-left: 2.2em;
+}
+
+.admonition.note ol > li {
+  margin-top: 0.5em;
+}
+
 /*
  * extra styles for more appropriate for syntax highlighting
  *

--- a/docs/language/ql-training/cpp/bad-overflow-guard.rst
+++ b/docs/language/ql-training/cpp/bad-overflow-guard.rst
@@ -11,7 +11,7 @@ Setup
 
 For this example you should download:
 
-- `QL for Eclipse <https://help.semmle.com/ql-for-eclipse/Content/WebHelp/install-plugin-free.html>`__
+- `CodeQL for Visual Studio Code <https://help.semmle.com/codeql/codeql-for-vscode/procedures/setting-up.html>`__
 - `ChakraCore database <https://downloads.lgtm.com/snapshots/cpp/microsoft/chakracore/ChakraCore-revision-2017-April-12--18-13-26.zip>`__
 
 .. note::

--- a/docs/language/ql-training/cpp/control-flow-cpp.rst
+++ b/docs/language/ql-training/cpp/control-flow-cpp.rst
@@ -13,7 +13,7 @@ Setup
 
 For this example you should download:
 
-- `QL for Eclipse <https://help.semmle.com/ql-for-eclipse/Content/WebHelp/install-plugin-free.html>`__
+- `CodeQL for Visual Studio Code <https://help.semmle.com/codeql/codeql-for-vscode/procedures/setting-up.html>`__
 - `ChakraCore database <https://downloads.lgtm.com/snapshots/cpp/microsoft/chakracore/ChakraCore-revision-2017-April-12--18-13-26.zip>`__
 
 .. note::

--- a/docs/language/ql-training/cpp/data-flow-cpp.rst
+++ b/docs/language/ql-training/cpp/data-flow-cpp.rst
@@ -11,7 +11,7 @@ Setup
 
 For this example you should download:
 
-- `QL for Eclipse <https://help.semmle.com/ql-for-eclipse/Content/WebHelp/install-plugin-free.html>`__
+- `CodeQL for Visual Studio Code <https://help.semmle.com/codeql/codeql-for-vscode/procedures/setting-up.html>`__
 - `dotnet/coreclr database <http://downloads.lgtm.com/snapshots/cpp/dotnet/coreclr/dotnet_coreclr_fbe0c77.zip>`__
 
 .. note::

--- a/docs/language/ql-training/cpp/global-data-flow-cpp.rst
+++ b/docs/language/ql-training/cpp/global-data-flow-cpp.rst
@@ -11,7 +11,7 @@ Setup
 
 For this example you should download:
 
-- `QL for Eclipse <https://help.semmle.com/ql-for-eclipse/Content/WebHelp/install-plugin-free.html>`__
+- `CodeQL for Visual Studio Code <https://help.semmle.com/codeql/codeql-for-vscode/procedures/setting-up.html>`__
 - `dotnet/coreclr database <http://downloads.lgtm.com/snapshots/cpp/dotnet/coreclr/dotnet_coreclr_fbe0c77.zip>`__
 
 .. note::

--- a/docs/language/ql-training/cpp/intro-ql-cpp.rst
+++ b/docs/language/ql-training/cpp/intro-ql-cpp.rst
@@ -11,7 +11,7 @@ Setup
 
 For this example you should download:
 
-- `QL for Eclipse <https://help.semmle.com/ql-for-eclipse/Content/WebHelp/install-plugin-free.html>`__
+- `CodeQL for Visual Studio Code <https://help.semmle.com/codeql/codeql-for-vscode/procedures/setting-up.html>`__
 - `exiv2 database <http://downloads.lgtm.com/snapshots/cpp/exiv2/Exiv2_exiv2_b090f4d.zip>`__
 
 .. note::

--- a/docs/language/ql-training/cpp/snprintf.rst
+++ b/docs/language/ql-training/cpp/snprintf.rst
@@ -11,7 +11,7 @@ Setup
 
 For this example you should download:
 
-- `QL for Eclipse <https://help.semmle.com/ql-for-eclipse/Content/WebHelp/install-plugin-free.html>`__
+- `CodeQL for Visual Studio Code <https://help.semmle.com/codeql/codeql-for-vscode/procedures/setting-up.html>`__
 - `rsyslog database <https://downloads.lgtm.com/snapshots/cpp/rsyslog/rsyslog/rsyslog-all-revision-2018-April-27--14-12-31.zip>`__
 
 .. note::

--- a/docs/language/ql-training/java/apache-struts-java.rst
+++ b/docs/language/ql-training/java/apache-struts-java.rst
@@ -15,7 +15,7 @@ Setup
 
 For this example you should download:
 
-- `QL for Eclipse <https://help.semmle.com/ql-for-eclipse/Content/WebHelp/install-plugin-free.html>`__
+- `CodeQL for Visual Studio Code <https://help.semmle.com/codeql/codeql-for-vscode/procedures/setting-up.html>`__
 - `Apache Struts database <https://downloads.lgtm.com/snapshots/java/apache/struts/apache-struts-7fd1622-CVE-2018-11776.zip>`__
 
 .. note::

--- a/docs/language/ql-training/java/data-flow-java.rst
+++ b/docs/language/ql-training/java/data-flow-java.rst
@@ -11,7 +11,7 @@ Setup
 
 For this example you should download:
 
-- `QL for Eclipse <https://help.semmle.com/ql-for-eclipse/Content/WebHelp/install-plugin-free.html>`__
+- `CodeQL for Visual Studio Code <https://help.semmle.com/codeql/codeql-for-vscode/procedures/setting-up.html>`__
 - `VIVO Vitro database <http://downloads.lgtm.com/snapshots/java/vivo-project/Vitro/vivo-project_Vitro_java-srcVersion_47ae42c01954432c3c3b92d5d163551ce367f510-dist_odasa-lgtm-2019-04-23-7ceff95-linux64.zip>`__
 
 .. note::

--- a/docs/language/ql-training/java/global-data-flow-java.rst
+++ b/docs/language/ql-training/java/global-data-flow-java.rst
@@ -11,7 +11,7 @@ Setup
 
 For this example you should download:
 
-- `QL for Eclipse <https://help.semmle.com/ql-for-eclipse/Content/WebHelp/install-plugin-free.html>`__
+- `CodeQL for Visual Studio Code <https://help.semmle.com/codeql/codeql-for-vscode/procedures/setting-up.html>`__
 - `Apache Struts database <https://downloads.lgtm.com/snapshots/java/apache/struts/apache-struts-7fd1622-CVE-2018-11776.zip>`__
 
 .. note::

--- a/docs/language/ql-training/java/intro-ql-java.rst
+++ b/docs/language/ql-training/java/intro-ql-java.rst
@@ -11,7 +11,7 @@ Setup
 
 For this example you should download:
 
-- `QL for Eclipse <https://help.semmle.com/ql-for-eclipse/Content/WebHelp/install-plugin-free.html>`__
+- `CodeQL for Visual Studio Code <https://help.semmle.com/codeql/codeql-for-vscode/procedures/setting-up.html>`__
 - `Apache Struts database <https://downloads.lgtm.com/snapshots/java/apache/struts/apache-struts-7fd1622-CVE-2018-11776.zip>`__
 
 .. note::

--- a/docs/language/ql-training/java/intro-ql-java.rst
+++ b/docs/language/ql-training/java/intro-ql-java.rst
@@ -105,8 +105,8 @@ Each query library also implicitly defines a module.
 
 .. note::
 
-  Queries are always contained in query files with the file extension ``.ql``. `Quick queries <https://help.semmle.com/ql-for-eclipse/Content/WebHelp/quick-query.html>`__, run in `QL for Eclipse <https://help.semmle.com/ql-for-eclipse/Content/WebHelp/home-page.html>`__, are no exception: the quick query window maintains a temporary QL file in the background.
-
+  Queries are always contained in query files with the file extension ``.ql``. 
+  
   Parts of queries can be lifted into `library files <https://help.semmle.com/QL/ql-handbook/modules.html#library-modules>`__ with the extension ``.qll``. Definitions within such libraries can be brought into scope using “import” statements, and similarly QLL files can import each other’s definitions using “import” statements.
 
   Logic can be encapsulated as user-defined `predicates <https://help.semmle.com/QL/ql-handbook/predicates.html>`__ and `classes <https://help.semmle.com/QL/ql-handbook/types.html#classes>`__, and organized into `modules <https://help.semmle.com/QL/ql-handbook/modules.html>`__. Each QLL file implicitly defines a module, but QL and QLL files can also contain explicit module definitions, as we will see later.

--- a/docs/language/ql-training/java/query-injection-java.rst
+++ b/docs/language/ql-training/java/query-injection-java.rst
@@ -11,7 +11,7 @@ Setup
 
 For this example you should download:
 
-- `QL for Eclipse <https://help.semmle.com/ql-for-eclipse/Content/WebHelp/install-plugin-free.html>`__
+- `CodeQL for Visual Studio Code <https://help.semmle.com/codeql/codeql-for-vscode/procedures/setting-up.html>`__
 - `VIVO Vitro database <http://downloads.lgtm.com/snapshots/java/vivo-project/Vitro/vivo-project_Vitro_java-srcVersion_47ae42c01954432c3c3b92d5d163551ce367f510-dist_odasa-lgtm-2019-04-23-7ceff95-linux64.zip>`__
 
 .. note::

--- a/docs/language/ql-training/slide-snippets/database-note.rst
+++ b/docs/language/ql-training/slide-snippets/database-note.rst
@@ -1,1 +1,9 @@
-Note that results generated in the query console are likely to differ to those generated in the QL plugin as LGTM.com analyzes the most recent revisions of each project that has been added–the CodeQL database available to download above is based on an historical version of the codebase.
+You can download the database as a zip file by clicking the link on the slide above. To use the database in CodeQL for Visual Studio Code:
+
+#. Unzip the file
+#. Add the unzipped database to Visual Studio Code
+#. Upgrade the database if necessary
+
+For further information, see `Using the extension <https://help.semmle.com/codeql/codeql-for-vscode/procedures/using-extension.html>`__ in the CodeQL for Visual Studio Code help.
+
+Note that results generated in the query console are likely to differ to those generated in CodeQL for Visual Studio Code as LGTM.com analyzes the most recent revisions of each project that has been added–the CodeQL database available to download above is based on an historical version of the codebase.

--- a/docs/language/ql-training/slide-snippets/intro-ql-general.rst
+++ b/docs/language/ql-training/slide-snippets/intro-ql-general.rst
@@ -109,7 +109,7 @@ Analysis overview
 
   Queries are written in `QL <https://semmle.com/ql>`__ and usually depend on one or more of the `standard CodeQL libraries <https://github.com/semmle/ql>`__ (and of course you can write your own custom libraries). They are compiled into an efficiently executable format by the QL compiler and then run on a CodeQL database by the QL evaluator, either on a remote worker machine or locally on a developer’s machine.
 
-  Query results can be interpreted and presented in a variety of ways, including displaying them in an `IDE plugin <https://lgtm.com/help/lgtm/running-queries-ide>`__ such as QL for Eclipse, or in a web dashboard as on `LGTM <https://lgtm.com/help/lgtm/about-lgtm>`__.
+  Query results can be interpreted and presented in a variety of ways, including displaying them in an `IDE extension <https://lgtm.com/help/lgtm/running-queries-ide>`__ such as CodeQL for Visual Studio Code, or in a web dashboard as on `LGTM <https://lgtm.com/help/lgtm/about-lgtm>`__.
 
 Introducing QL
 ==============


### PR DESCRIPTION
This PR addresses https://github.com/github/pe-security-codeql/issues/172 
Specifically, links to QL for Eclipse have been updated to CodeQL for VS Code and very brief instructions about unzipping/upgrading databases have been added.

For example, see the notes here: http://docteam.internal.semmle.com/james/ql-training/172/cpp/bad-overflow-guard.html#2