### PR TITLE
JS: fix the `NodeJS::Require`performance regression

### DIFF
--- a/javascript/ql/src/semmle/javascript/NodeJS.qll
+++ b/javascript/ql/src/semmle/javascript/NodeJS.qll
@@ -163,11 +163,9 @@ private predicate moduleInFile(Module m, File f) { m.getFile() = f }
  */
 class Require extends CallExpr, Import {
   Require() {
-    exists(RequireVariable req |
-      this.getCallee() = req.getAnAccess() and
-      // `mjs` files explicitly disallow `require`
-      not getFile().getExtension() = "mjs"
-    )
+    any(RequireVariable req).getAnAccess() = getCallee() and
+    // `mjs` files explicitly disallow `require`
+    not getFile().getExtension() = "mjs"
   }
 
   override PathExpr getImportedPath() { result = getArgument(0) }

--- a/javascript/ql/src/semmle/javascript/NodeJS.qll
+++ b/javascript/ql/src/semmle/javascript/NodeJS.qll
@@ -162,6 +162,7 @@ private predicate moduleInFile(Module m, File f) { m.getFile() = f }
  * ```
  */
 class Require extends CallExpr, Import {
+  cached
   Require() {
     any(RequireVariable req).getAnAccess() = getCallee() and
     // `mjs` files explicitly disallow `require`


### PR DESCRIPTION
This thouroughly fixes the performance of the regression in #2347.

Caching the charpred of `NodeJS::Require` seems reasonable since it makes us handle `require` and `import` with equal performance in the later stages. When `NodeJS::Require` is not explicitly cached, we may need to reevaluate non-trivial predicates to identify it, whereas the syntactic `import` always is identified for free in practice.

I am still running evaluations, but a preliminary [evaluation](https://git.semmle.com/esben/dist-compare-reports/tree/js/fix-mjs-check_1574856802693) shows that #2347 with `cached` is faster on definitions.ql than the master branch it was merged into!