### PR TITLE
CPP: Speed up isCompiledAsC.

### DIFF
--- a/cpp/ql/src/Likely Bugs/Underspecified Functions/MistypedFunctionArguments.ql
+++ b/cpp/ql/src/Likely Bugs/Underspecified Functions/MistypedFunctionArguments.ql
@@ -84,10 +84,10 @@ predicate hasZeroParamDecl(Function f) {
 }
 
 // True if this file (or header) was compiled as a C file
-predicate isCompiledAsC(Function f) {
-  exists(File file | file.compiledAsC() |
-    file = f.getFile() or file.getAnIncludedFile+() = f.getFile()
-  )
+predicate isCompiledAsC(File f) {
+  f.compiledAsC()
+  or
+  exists(File src | isCompiledAsC(src) | src.getAnIncludedFile() = f)
 }
 
 from FunctionCall fc, Function f, Parameter p
@@ -95,7 +95,7 @@ where
   f = fc.getTarget() and
   p = f.getAParameter() and
   hasZeroParamDecl(f) and
-  isCompiledAsC(f) and
+  isCompiledAsC(f.getFile()) and
   not f.isVarargs() and
   not f instanceof BuiltInFunction and
   p.getIndex() < fc.getNumberOfArguments() and

--- a/cpp/ql/src/Likely Bugs/Underspecified Functions/TooFewArguments.ql
+++ b/cpp/ql/src/Likely Bugs/Underspecified Functions/TooFewArguments.ql
@@ -24,10 +24,10 @@ predicate hasZeroParamDecl(Function f) {
 }
 
 // True if this file (or header) was compiled as a C file
-predicate isCompiledAsC(Function f) {
-  exists(File file | file.compiledAsC() |
-    file = f.getFile() or file.getAnIncludedFile+() = f.getFile()
-  )
+predicate isCompiledAsC(File f) {
+  f.compiledAsC()
+  or
+  exists(File src | isCompiledAsC(src) | src.getAnIncludedFile() = f)
 }
 
 from FunctionCall fc, Function f
@@ -36,7 +36,7 @@ where
   not f.isVarargs() and
   not f instanceof BuiltInFunction and
   hasZeroParamDecl(f) and
-  isCompiledAsC(f) and
+  isCompiledAsC(f.getFile()) and
   // There is an explicit declaration of the function whose parameter count is larger
   // than the number of call arguments
   exists(FunctionDeclarationEntry fde | fde = f.getADeclarationEntry() |

--- a/cpp/ql/src/Likely Bugs/Underspecified Functions/TooManyArguments.ql
+++ b/cpp/ql/src/Likely Bugs/Underspecified Functions/TooManyArguments.ql
@@ -25,10 +25,10 @@ predicate hasZeroParamDecl(Function f) {
 }
 
 // True if this file (or header) was compiled as a C file
-predicate isCompiledAsC(Function f) {
-  exists(File file | file.compiledAsC() |
-    file = f.getFile() or file.getAnIncludedFile+() = f.getFile()
-  )
+predicate isCompiledAsC(File f) {
+  f.compiledAsC()
+  or
+  exists(File src | isCompiledAsC(src) | src.getAnIncludedFile() = f)
 }
 
 from FunctionCall fc, Function f
@@ -36,7 +36,7 @@ where
   f = fc.getTarget() and
   not f.isVarargs() and
   hasZeroParamDecl(f) and
-  isCompiledAsC(f) and
+  isCompiledAsC(f.getFile()) and
   exists(f.getBlock()) and
   // There must not exist a declaration with the number of parameters
   // at least as large as the number of call arguments


### PR DESCRIPTION
This predicate (with copies in three queries) was fast on most snapshots, but blew up on Chromium (taking 4m47s; now negligible).

Note that it's not clear excluding CPP files ever effects results.  I found no cases where it did on 85 LGTM projects, for any of the three queries.  And there's a test case that looks like it's designed to cover this but it passes even if the exclusion is removed.  I'm tempted to remove the `isCompiledAsC` lines entirely, but I'd be happier doing so if I understood the whole story (and it's no longer significant from a performance perspective).