### PR TITLE
Java/C++/C#: Bugfix for field flow through reverse read.

### DIFF
--- a/cpp/ql/src/semmle/code/cpp/dataflow/internal/DataFlowImplCommon.qll
+++ b/cpp/ql/src/semmle/code/cpp/dataflow/internal/DataFlowImplCommon.qll
@@ -360,7 +360,7 @@ private module ImplCommon {
      */
     cached
     predicate read(Node node1, Content f, Node node2) {
-      readStep(node1, f, node2) and storeStep(_, f, _)
+      readStep(node1, f, node2)
       or
       exists(DataFlowCall call, ReturnKind kind |
         read0(call, kind, node1, f) and

--- a/cpp/ql/src/semmle/code/cpp/ir/dataflow/internal/DataFlowImplCommon.qll
+++ b/cpp/ql/src/semmle/code/cpp/ir/dataflow/internal/DataFlowImplCommon.qll
@@ -360,7 +360,7 @@ private module ImplCommon {
      */
     cached
     predicate read(Node node1, Content f, Node node2) {
-      readStep(node1, f, node2) and storeStep(_, f, _)
+      readStep(node1, f, node2)
       or
       exists(DataFlowCall call, ReturnKind kind |
         read0(call, kind, node1, f) and

--- a/csharp/ql/src/semmle/code/csharp/dataflow/internal/DataFlowImplCommon.qll
+++ b/csharp/ql/src/semmle/code/csharp/dataflow/internal/DataFlowImplCommon.qll
@@ -360,7 +360,7 @@ private module ImplCommon {
      */
     cached
     predicate read(Node node1, Content f, Node node2) {
-      readStep(node1, f, node2) and storeStep(_, f, _)
+      readStep(node1, f, node2)
       or
       exists(DataFlowCall call, ReturnKind kind |
         read0(call, kind, node1, f) and

--- a/java/ql/src/semmle/code/java/dataflow/internal/DataFlowImplCommon.qll
+++ b/java/ql/src/semmle/code/java/dataflow/internal/DataFlowImplCommon.qll
@@ -360,7 +360,7 @@ private module ImplCommon {
      */
     cached
     predicate read(Node node1, Content f, Node node2) {
-      readStep(node1, f, node2) and storeStep(_, f, _)
+      readStep(node1, f, node2)
       or
       exists(DataFlowCall call, ReturnKind kind |
         read0(call, kind, node1, f) and

--- a/java/ql/test/library-tests/dataflow/fields/E.java
+++ b/java/ql/test/library-tests/dataflow/fields/E.java
@@ -1,0 +1,32 @@
+public class E {
+  static Object src() { return new Object(); }
+  static void sink(Object obj) {}
+
+  static class Buffer { Object content; }
+  static class BufHolder { Buffer buf; }
+  static class Packet { BufHolder data; }
+
+  static void recv(Buffer buf) {
+    buf.content = src();
+  }
+
+  static void foo(Buffer raw, BufHolder bh, Packet p) {
+    recv(raw);
+    recv(bh.buf);
+    recv(p.data.buf);
+
+    sink(raw.content);
+
+    BufHolder bh2 = bh;
+    sink(bh2.buf.content);
+
+    Packet p2 = p;
+    sink(p2.data.buf.content);
+
+    handlepacket(p);
+  }
+
+  static void handlepacket(Packet p) {
+    sink(p.data.buf.content);
+  }
+}

--- a/java/ql/test/library-tests/dataflow/fields/flow.expected
+++ b/java/ql/test/library-tests/dataflow/fields/flow.expected
@@ -22,3 +22,7 @@
 | D.java:19:14:19:23 | new Elem(...) | D.java:33:10:33:31 | getElem(...) |
 | D.java:26:14:26:23 | new Elem(...) | D.java:33:10:33:31 | getElem(...) |
 | D.java:37:14:37:23 | new Elem(...) | D.java:44:10:44:26 | boxfield.box.elem |
+| E.java:2:32:2:43 | new Object(...) | E.java:18:10:18:20 | raw.content |
+| E.java:2:32:2:43 | new Object(...) | E.java:21:10:21:24 | bh2.buf.content |
+| E.java:2:32:2:43 | new Object(...) | E.java:24:10:24:28 | p2.data.buf.content |
+| E.java:2:32:2:43 | new Object(...) | E.java:30:10:30:27 | p.data.buf.content |


### PR DESCRIPTION
The restriction of the `read` relation to only those fields that had a `storeStep` made sense before we added support for treating reverse reads as stores, but it should have been removed when we added that step.

Without this change the added test case would only exhibit flow to the first of the four sinks.

The first pruning step of the data-flow implementation already restricts reads to those for which a corresponding store has been seen during forward flow, so if no reverse reads are encountered this change shouldn't add any tuples to the data-flow pruning sequence.