### PR TITLE
JavaScript: Introduce `localTaintStep` predicate.

### DIFF
--- a/javascript/ql/src/semmle/javascript/dataflow/DataFlow.qll
+++ b/javascript/ql/src/semmle/javascript/dataflow/DataFlow.qll
@@ -1573,4 +1573,6 @@ module DataFlow {
   import Configuration
   import TrackedNodes
   import TypeTracking
+
+  predicate localTaintStep = TaintTracking::localTaintStep/2;
 }

--- a/javascript/ql/src/semmle/javascript/dataflow/TaintTracking.qll
+++ b/javascript/ql/src/semmle/javascript/dataflow/TaintTracking.qll
@@ -885,4 +885,12 @@ module TaintTracking {
 
     override predicate appliesTo(Configuration cfg) { any() }
   }
+
+  /**
+   * Holds if taint propagates from `pred` to `succ` in one local (intra-procedural) step.
+   */
+  predicate localTaintStep(DataFlow::Node pred, DataFlow::Node succ) {
+    DataFlow::localFlowStep(pred, succ) or
+    any(AdditionalTaintStep s).step(pred, succ)
+  }
 }


### PR DESCRIPTION
It's sometimes useful for exploratory queries, and the other languages have it as well.