### PR TITLE
C#: Fix some IR types that didn't compile.

### DIFF
--- a/csharp/ql/src/semmle/code/csharp/ir/implementation/unaliased_ssa/internal/reachability/ReachableBlockInternal.qll
+++ b/csharp/ql/src/semmle/code/csharp/ir/implementation/unaliased_ssa/internal/reachability/ReachableBlockInternal.qll
@@ -1,2 +1,2 @@
-import semmle.code.cpp.ir.implementation.unaliased_ssa.IR as IR
-import semmle.code.cpp.ir.implementation.unaliased_ssa.constant.ConstantAnalysis as ConstantAnalysis
+import semmle.code.csharp.ir.implementation.unaliased_ssa.IR as IR
+import semmle.code.csharp.ir.implementation.unaliased_ssa.constant.ConstantAnalysis as ConstantAnalysis

--- a/csharp/ql/src/semmle/code/csharp/ir/internal/TIRVariable.qll
+++ b/csharp/ql/src/semmle/code/csharp/ir/internal/TIRVariable.qll
@@ -9,6 +9,8 @@ newtype TIRVariable =
     Construction::functionHasIR(callable) and
     var.getCallable() = callable
   } or
-  TIRTempVariable(Callable callable, Language::AST ast, TempVariableTag tag, Type type) {
+  TIRTempVariable(
+    Callable callable, Language::AST ast, TempVariableTag tag, Language::LanguageType type
+  ) {
     Construction::hasTempVariable(callable, ast, tag, type)
   }


### PR DESCRIPTION
@dave-bartolomeo These changes crept into the C# side but didn't cause a problem until someone attempted `odasa qldoc`. I think this should fix the issue. To reproduce: `./build target/packs/pack-csharp-qldoc.zip`

There's a wider problem here though - even thought the qltests pass, qldoc could still break if it attempts to scan code that does not compile. This is a risk for the C# IR code which often gets synced between folders even though the C# side is not exercised.