### PR TITLE
Python: include zope web tests from internal repo

### DIFF
--- a/python/ql/test/library-tests/web/zope/Test.expected
+++ b/python/ql/test/library-tests/web/zope/Test.expected
@@ -1,0 +1,3 @@
+| 12 | ControlFlowNode for implementer | class implementer | resources/lib/python/lib/zope/interface/declarations.py:352 |
+| 13 | ControlFlowNode for IThing | class IThing | test.py:4 |
+| 14 | ControlFlowNode for Thing | class Thing | test.py:9 |

--- a/python/ql/test/library-tests/web/zope/Test.expected
+++ b/python/ql/test/library-tests/web/zope/Test.expected
@@ -1,3 +1,3 @@
-| 12 | ControlFlowNode for implementer | class implementer | resources/lib/python/lib/zope/interface/declarations.py:352 |
+| 12 | ControlFlowNode for implementer | class implementer | ../../../query-tests/Security/lib/zope/interface/__init__.py:5 |
 | 13 | ControlFlowNode for IThing | class IThing | test.py:4 |
 | 14 | ControlFlowNode for Thing | class Thing | test.py:9 |

--- a/python/ql/test/library-tests/web/zope/Test.ql
+++ b/python/ql/test/library-tests/web/zope/Test.ql
@@ -1,0 +1,10 @@
+import python
+import semmle.python.TestUtils
+
+from ControlFlowNode f, Object o, ControlFlowNode x
+where
+    exists(ExprStmt s | s.getValue().getAFlowNode() = f) and
+    f.refersTo(o, x) and
+    f.getLocation().getFile().getBaseName() = "test.py"
+select f.getLocation().getStartLine(), f.toString(), o.toString(),
+    remove_library_prefix(x.getLocation())

--- a/python/ql/test/library-tests/web/zope/Test.ql
+++ b/python/ql/test/library-tests/web/zope/Test.ql
@@ -1,10 +1,10 @@
 import python
 import semmle.python.TestUtils
 
-from ControlFlowNode f, Object o, ControlFlowNode x
+from ControlFlowNode f, Value v, ControlFlowNode x
 where
     exists(ExprStmt s | s.getValue().getAFlowNode() = f) and
-    f.refersTo(o, x) and
+    f.pointsTo(v, x) and
     f.getLocation().getFile().getBaseName() = "test.py"
-select f.getLocation().getStartLine(), f.toString(), o.toString(),
+select f.getLocation().getStartLine(), f.toString(), v.toString(),
     remove_library_prefix(x.getLocation())

--- a/python/ql/test/library-tests/web/zope/options
+++ b/python/ql/test/library-tests/web/zope/options
@@ -1,1 +1,1 @@
-semmle-extractor-options: --max-import-depth=3 -p ../../../../resources/lib/python/lib/ --respect-init=False
+semmle-extractor-options: --max-import-depth=3 -p ../../../query-tests/Security/lib/

--- a/python/ql/test/library-tests/web/zope/options
+++ b/python/ql/test/library-tests/web/zope/options
@@ -1,0 +1,1 @@
+semmle-extractor-options: --max-import-depth=3 -p ../../../../resources/lib/python/lib/ --respect-init=False

--- a/python/ql/test/library-tests/web/zope/test.py
+++ b/python/ql/test/library-tests/web/zope/test.py
@@ -1,0 +1,14 @@
+
+from zope.interface import Interface, implementer
+
+class IThing(Interface):
+    pass
+
+
+@implementer(IThing)
+class Thing(object):
+    pass
+
+implementer
+IThing
+Thing

--- a/python/ql/test/query-tests/Security/lib/zope/interface/__init__.py
+++ b/python/ql/test/query-tests/Security/lib/zope/interface/__init__.py
@@ -1,0 +1,9 @@
+class Interface():
+    pass
+
+
+class implementer:
+
+    def __call__(self, ob):
+        ...
+        return ob


### PR DESCRIPTION
As the only part of the web modernisation, there was not any dedicated web library support for Zope, only these tests.

We do have the [python/ql/src/semmle/python/libraries/Zope.qll](https://github.com/Semmle/ql/blob/5271d6a06374a03156c55c0a9b3955bf9325d592/python/ql/src/semmle/python/libraries/Zope.qll) file, but that isn't even used in this test  `¯\_(ツ)_/¯`