### PR TITLE
JS: Make extractor aware of CodeQL env vars

### DIFF
--- a/javascript/extractor/src/com/semmle/js/extractor/AutoBuild.java
+++ b/javascript/extractor/src/com/semmle/js/extractor/AutoBuild.java
@@ -205,7 +205,7 @@ public class AutoBuild {
 
   public AutoBuild() {
     this.LGTM_SRC = toRealPath(getPathFromEnvVar("LGTM_SRC"));
-    this.SEMMLE_DIST = getPathFromEnvVar(Env.Var.SEMMLE_DIST.toString());
+    this.SEMMLE_DIST = Paths.get(EnvironmentVariables.getExtractorRoot());
     this.outputConfig = new ExtractorOutputConfig(LegacyLanguage.JAVASCRIPT);
     this.trapCache = mkTrapCache();
     this.typeScriptMode =

--- a/javascript/extractor/src/com/semmle/js/extractor/EnvironmentVariables.java
+++ b/javascript/extractor/src/com/semmle/js/extractor/EnvironmentVariables.java
@@ -1,0 +1,34 @@
+package com.semmle.js.extractor;
+
+import com.semmle.util.exception.UserError;
+import com.semmle.util.process.Env;
+import com.semmle.util.process.Env.Var;
+
+public class EnvironmentVariables {
+  public static final String CODEQL_EXTRACTOR_JAVASCRIPT_ROOT_ENV_VAR =
+      "CODEQL_EXTRACTOR_JAVASCRIPT_ROOT";
+
+  /**
+   * Gets the extractor root based on the <code>CODEQL_EXTRACTOR_JAVASCRIPT_ROOT</code> or <code>
+   * SEMMLE_DIST</code> or environment variable, or <code>null</code> if neither is set.
+   */
+  public static String tryGetExtractorRoot() {
+    String env = Env.systemEnv().get(CODEQL_EXTRACTOR_JAVASCRIPT_ROOT_ENV_VAR);
+    if (env != null && !env.isEmpty()) return env;
+    env = Env.systemEnv().get(Var.SEMMLE_DIST);
+    if (env != null && !env.isEmpty()) return env;
+    return null;
+  }
+
+  /**
+   * Gets the extractor root based on the <code>CODEQL_EXTRACTOR_JAVASCRIPT_ROOT</code> or <code>
+   * SEMMLE_DIST</code> or environment variable, or throws a UserError if neither is set.
+   */
+  public static String getExtractorRoot() {
+    String env = tryGetExtractorRoot();
+    if (env == null) {
+      throw new UserError("SEMMLE_DIST or CODEQL_EXTRACTOR_JAVASCRIPT_ROOT must be set");
+    }
+    return env;
+  }
+}

--- a/javascript/extractor/src/com/semmle/js/extractor/FileExtractor.java
+++ b/javascript/extractor/src/com/semmle/js/extractor/FileExtractor.java
@@ -1,16 +1,5 @@
 package com.semmle.js.extractor;
 
-import java.io.BufferedReader;
-import java.io.File;
-import java.io.FileInputStream;
-import java.io.FileReader;
-import java.io.IOException;
-import java.nio.charset.Charset;
-import java.nio.charset.StandardCharsets;
-import java.util.LinkedHashSet;
-import java.util.Set;
-import java.util.regex.Pattern;
-
 import com.semmle.js.extractor.ExtractionMetrics.ExtractionPhase;
 import com.semmle.js.extractor.trapcache.CachingTrapWriter;
 import com.semmle.js.extractor.trapcache.ITrapCache;
@@ -21,6 +10,16 @@ import com.semmle.util.files.FileUtil;
 import com.semmle.util.io.WholeIO;
 import com.semmle.util.trap.TrapWriter;
 import com.semmle.util.trap.TrapWriter.Label;
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileReader;
+import java.io.IOException;
+import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
+import java.util.LinkedHashSet;
+import java.util.Set;
+import java.util.regex.Pattern;
 
 /**
  * The file extractor extracts a single file and handles source archive population and TRAP caching;
@@ -156,8 +155,7 @@ public class FileExtractor {
           byte[] bytes = new byte[fileHeaderSize];
           int length = fis.read(bytes);
 
-          if (length == -1)
-            return false;
+          if (length == -1) return false;
 
           // Avoid invalid or unprintable UTF-8 files.
           if (config.getDefaultEncoding().equals("UTF-8") && hasUnprintableUtf8(bytes, length)) {

--- a/javascript/extractor/src/com/semmle/js/parser/TypeScriptParser.java
+++ b/javascript/extractor/src/com/semmle/js/parser/TypeScriptParser.java
@@ -7,6 +7,7 @@ import com.google.gson.JsonObject;
 import com.google.gson.JsonParseException;
 import com.google.gson.JsonParser;
 import com.google.gson.JsonPrimitive;
+import com.semmle.js.extractor.EnvironmentVariables;
 import com.semmle.js.extractor.ExtractionMetrics;
 import com.semmle.js.parser.JSParser.Result;
 import com.semmle.ts.extractor.TypeTable;
@@ -290,14 +291,12 @@ public class TypeScriptParser {
     File parserWrapper;
     LogbackUtils.getLogger(AbstractProcessBuilder.class).setLevel(Level.INFO);
     String explicitPath = Env.systemEnv().get(PARSER_WRAPPER_PATH_ENV_VAR);
-    String semmleDistVar = Env.systemEnv().get(Env.Var.SEMMLE_DIST.name());
     if (explicitPath != null) {
       parserWrapper = new File(explicitPath);
-    } else if (semmleDistVar != null && !semmleDistVar.isEmpty()) {
-      parserWrapper = new File(semmleDistVar, "tools/typescript-parser-wrapper/main.js");
     } else {
-      throw new CatastrophicError(
-          "Could not find TypeScript parser: " + Env.Var.SEMMLE_DIST.name() + " is not set.");
+      parserWrapper =
+          new File(
+              EnvironmentVariables.getExtractorRoot(), "tools/typescript-parser-wrapper/main.js");
     }
     if (!parserWrapper.isFile())
       throw new ResourceError(


### PR DESCRIPTION
`CODEQL_EXTRACTOR_JAVASCRIPT_ROOT` is the new `SEMMLE_DIST`.

Drive-by change: auto-format FileExtractor.java

/cc @hmakholm