### PR TITLE
Learning CodeQL docs: add COBOL notes and remove links

### DIFF
--- a/docs/language/global-sphinx-files/global-conf.py
+++ b/docs/language/global-sphinx-files/global-conf.py
@@ -56,9 +56,9 @@ def setup(sphinx):
 # built documents.
 #
 # The short X.Y version.
-version = u'1.22.1'
+version = u'1.23'
 # The full version, including alpha/beta/rc tags.
-release = u'1.22.1'
+release = u'1.23'
 copyright = u'2019 Semmle Ltd'
 author = u'Semmle Ltd'
 

--- a/docs/language/learn-ql/cobol/introduce-libraries-cobol.rst
+++ b/docs/language/learn-ql/cobol/introduce-libraries-cobol.rst
@@ -149,4 +149,3 @@ What next?
 ----------
 
 -  Find out more about QL in the `QL language handbook <https://help.semmle.com/QL/ql-handbook/index.html>`__ and `QL language specification <https://help.semmle.com/QL/ql-spec/language.html>`__.
--  Learn more about the query console in `Using the query console <https://lgtm.com/help/lgtm/using-query-console>`__.

--- a/docs/language/learn-ql/cobol/ql-for-cobol.rst
+++ b/docs/language/learn-ql/cobol/ql-for-cobol.rst
@@ -6,15 +6,15 @@ CodeQL for COBOL
    :hidden:
 
    introduce-libraries-cobol
-   
+
+.. include:: ../../support/cobol-note.rst
+
 This page provides an overview of the CodeQL for COBOL documentation that is currently available.
 
--  `Basic COBOL query <https://lgtm.com/help/lgtm/console/ql-cobol-basic-example>`__ describes how to write and run queries using LGTM.
 -  :doc:`Introducing the CodeQL libraries for COBOL <introduce-libraries-cobol>` introduces the standard libraries used to write queries for COBOL code.
 
 
 Other resources
 ---------------
 
--  For the queries used in LGTM, display a `COBOL query <https://lgtm.com/search?q=language%3Acobol&t=rules>`__ and click **Open in query console** to see the code used to find alerts.
 -  For more information about the library for COBOL see the `CodeQL library for COBOL <https://help.semmle.com/qldoc/cobol/>`__.

--- a/docs/language/ql-training/conf.py
+++ b/docs/language/ql-training/conf.py
@@ -86,9 +86,9 @@ htmlhelp_basename = 'CodeQL training'
 # built documents.
 #
 # The short X.Y version.
-version = u'1.22'
+version = u'1.23'
 # The full version, including alpha/beta/rc tags.
-release = u'1.22'
+release = u'1.23'
 copyright = u'2019 Semmle Ltd'
 author = u'Semmle Ltd'
 

--- a/docs/language/support/cobol-note.rst
+++ b/docs/language/support/cobol-note.rst
@@ -1,0 +1,5 @@
+.. pull-quote:: Important
+
+   CodeQL for COBOL is being deprecated after the 1.23 release of CodeQL. 
+   Future releases, starting with 1.24, will no longer contain support for analyzing COBOL source code. 
+   We are not aware of any customers who will be affected by this change. If you do have any concerns, please contact your account manager.

--- a/docs/language/support/conf.py
+++ b/docs/language/support/conf.py
@@ -80,4 +80,4 @@ htmlhelp_basename = 'Supported languages and frameworks'
 
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.
-exclude_patterns = ['read-me-project.rst']
+exclude_patterns = ['read-me-project.rst', 'cobol-note.rst']

--- a/docs/language/support/framework-support.rst
+++ b/docs/language/support/framework-support.rst
@@ -24,6 +24,8 @@ C# built-in support
 COBOL built-in support
 ===================================
 
+.. include:: cobol-note.rst
+
 * Embedded SQL
 * Embedded CICS
 

--- a/docs/language/support/language-support.rst
+++ b/docs/language/support/language-support.rst
@@ -10,6 +10,8 @@ Customers with any questions should contact their usual Semmle contact with any 
 If you're not a customer yet, contact us at info@semmle.com 
 with any questions you have about language and compiler support.
 
+.. include:: cobol-note.rst
+
 .. csv-table::
      :file: versions-compilers.csv
      :header-rows: 1


### PR DESCRIPTION
This PR adds notes (in the form of a snippet) about the future of COBOL support to 'CodeQL for COBOL' in the 'Learning CodeQL' project and in a couple of places in the 'Support' project. The two links to the soon-to-be-removed LGTM URLs have also been deleted. 

@felicitymay, do you think these notes appear in the correct places?

I've also bumped the version number for the projects that use `global-conf/py` and the 'CodeQL training' project.