### PR TITLE
Supported languages: update COBOL info

### DIFF
--- a/docs/language/global-sphinx-files/global-conf.py
+++ b/docs/language/global-sphinx-files/global-conf.py
@@ -56,9 +56,9 @@ def setup(sphinx):
 # built documents.
 #
 # The short X.Y version.
-version = u'1.22.1'
+version = u'1.24'
 # The full version, including alpha/beta/rc tags.
-release = u'1.22.1'
+release = u'1.24'
 copyright = u'2019 Semmle Ltd'
 author = u'Semmle Ltd'
 

--- a/docs/language/ql-training/conf.py
+++ b/docs/language/ql-training/conf.py
@@ -86,9 +86,9 @@ htmlhelp_basename = 'CodeQL training'
 # built documents.
 #
 # The short X.Y version.
-version = u'1.22'
+version = u'1.24'
 # The full version, including alpha/beta/rc tags.
-release = u'1.22'
+release = u'1.24'
 copyright = u'2019 Semmle Ltd'
 author = u'Semmle Ltd'
 

--- a/docs/language/support/framework-support.rst
+++ b/docs/language/support/framework-support.rst
@@ -21,13 +21,6 @@ C# built-in support
      :class: fullWidthTable
      :widths: auto
 
-COBOL built-in support
-===================================
-
-* Embedded SQL
-* Embedded CICS
-
-
 Java built-in support
 ==================================
 

--- a/docs/language/support/language-support.rst
+++ b/docs/language/support/language-support.rst
@@ -21,8 +21,7 @@ with any questions you have about language and compiler support.
     .. [1] Support for the clang-cl compiler is preliminary.
     .. [2] Support for the Arm Compiler (armcc) is preliminary.
     .. [3] In addition, support is included for the preview features of C# 8.0 and .NET Core 3.0.
-    .. [4] The best results are achieved with COBOL code that stays close to the ANSI 85 standard.  
-    .. [5] Builds that execute on Java 6 to 12 can be analyzed. The analysis understands Java 12 language features.
-    .. [6] ECJ is supported when the build invokes it via the Maven Compiler plugin or the Takari Lifecycle plugin.
-    .. [7] JSX and Flow code, YAML, JSON, HTML, and XML files may also be analyzed with JavaScript files. 
-    .. [8] TypeScript analysis is performed by running the JavaScript extractor with TypeScript enabled. This is the default for LGTM.   
+    .. [4] Builds that execute on Java 6 to 12 can be analyzed. The analysis understands Java 12 language features.
+    .. [5] ECJ is supported when the build invokes it via the Maven Compiler plugin or the Takari Lifecycle plugin.
+    .. [6] JSX and Flow code, YAML, JSON, HTML, and XML files may also be analyzed with JavaScript files. 
+    .. [7] TypeScript analysis is performed by running the JavaScript extractor with TypeScript enabled. This is the default for LGTM.   

--- a/docs/language/support/versions-compilers.csv
+++ b/docs/language/support/versions-compilers.csv
@@ -9,11 +9,10 @@ Arm Compiler 5.0 [2]_.","``.cpp``, ``.c++``, ``.cxx``, ``.hpp``, ``.hh``, ``.h++
 C#,C# up to 7.3. with .NET up to 4.8 [3]_.,"Microsoft Visual Studio up to 2019, 
 
 .NET Core up to 2.2","``.sln``, ``.csproj``, ``.cs``, ``.cshtml``, ``.xaml``"
-COBOL,ANSI 85 or newer [4]_.,Not applicable,"``.cbl``, ``.CBL``, ``.cpy``, ``.CPY``, ``.copy``, ``.COPY``"
 Go (aka Golang), "Go up to 1.13", "Go 1.11 or more recent", ``.go``
-Java,"Java 6 to 12 [5]_.","javac (OpenJDK and Oracle JDK),
+Java,"Java 6 to 12 [4]_.","javac (OpenJDK and Oracle JDK),
 
-Eclipse compiler for Java (ECJ) [6]_.",``.java``
-JavaScript,ECMAScript 2019 or lower,Not applicable,"``.js``, ``.jsx``, ``.mjs``, ``.es``, ``.es6``, ``.htm``, ``.html``, ``.xhm``, ``.xhtml``, ``.vue``, ``.json``, ``.yaml``, ``.yml``, ``.raml``, ``.xml`` [7]_."
+Eclipse compiler for Java (ECJ) [5]_.",``.java``
+JavaScript,ECMAScript 2019 or lower,Not applicable,"``.js``, ``.jsx``, ``.mjs``, ``.es``, ``.es6``, ``.htm``, ``.html``, ``.xhm``, ``.xhtml``, ``.vue``, ``.json``, ``.yaml``, ``.yml``, ``.raml``, ``.xml`` [6]_."
 Python,"2.7, 3.5, 3.6, 3.7",Not applicable,``.py``
-TypeScript [8]_.,"2.6-3.5",Standard TypeScript compiler,"``.ts``, ``.tsx``"
+TypeScript [7]_.,"2.6-3.5",Standard TypeScript compiler,"``.ts``, ``.tsx``"


### PR DESCRIPTION
This PR removes COBOL from the supported languages on the master branch. It seems unnecessary to add any additional notes, since we already have an explanatory note explaining the deprecation for the 1.23 release.