### PR TITLE
C++ tests: generalize arguments tests

### DIFF
--- a/cpp/ql/test/library-tests/arguments/arguments.expected
+++ b/cpp/ql/test/library-tests/arguments/arguments.expected
@@ -12,7 +12,7 @@
 | arguments.c | 12 | linux_x86_64 |
 | arguments.c | 13 | --gcc |
 | arguments.c | 14 | --predefined_macros |
-| arguments.c | 15 | <root>/tools/qltest/predefined_macros |
+| arguments.c | 15 | <tools>/qltest/predefined_macros |
 | arguments.c | 16 | -w |
 | arguments.c | 17 | -Werror |
 | arguments.c | 18 | arguments.c |

--- a/cpp/ql/test/library-tests/arguments/arguments.ql
+++ b/cpp/ql/test/library-tests/arguments/arguments.ql
@@ -7,5 +7,5 @@ where
   s = c
         .getArgument(i)
         .replaceAll("\\", "/")
-        .regexpReplaceAll(".*(tools/qltest/predefined_macros)", "<root>/$1")
+        .regexpReplaceAll(".*(/qltest/predefined_macros)", "<tools>$1")
 select c.getAFileCompiled().toString(), i, s


### PR DESCRIPTION
With the coming `codeql test` support, the `predefined_macros` file will not necessarily be located under a `tools` directory. Change the test to hide more of its actual path, so it will work in both cases.