### PR TITLE
CodeQL support docs: remove some full stops

### DIFF
--- a/docs/language/support/versions-compilers.csv
+++ b/docs/language/support/versions-compilers.csv
@@ -5,15 +5,15 @@ GNU extensions (up to GCC 8.3),
 
 Microsoft extensions (up to VS 2019),
 
-Arm Compiler 5.0 [2]_.","``.cpp``, ``.c++``, ``.cxx``, ``.hpp``, ``.hh``, ``.h++``, ``.hxx``, ``.c``, ``.cc``, ``.h``"
-C#,C# up to 8.0. with .NET up to 4.8 [3]_.,"Microsoft Visual Studio up to 2019, 
+Arm Compiler 5.0 [2]_","``.cpp``, ``.c++``, ``.cxx``, ``.hpp``, ``.hh``, ``.h++``, ``.hxx``, ``.c``, ``.cc``, ``.h``"
+C#,C# up to 8.0. with .NET up to 4.8 [3]_,"Microsoft Visual Studio up to 2019, 
 
 .NET Core up to 3.0","``.sln``, ``.csproj``, ``.cs``, ``.cshtml``, ``.xaml``"
-COBOL,ANSI 85 or newer [4]_.,Not applicable,"``.cbl``, ``.CBL``, ``.cpy``, ``.CPY``, ``.copy``, ``.COPY``"
+COBOL,ANSI 85 or newer [4]_,Not applicable,"``.cbl``, ``.CBL``, ``.cpy``, ``.CPY``, ``.copy``, ``.COPY``"
 Go (aka Golang), "Go up to 1.13", "Go 1.11 or more recent", ``.go``
-Java,"Java 6 to 13 [5]_.","javac (OpenJDK and Oracle JDK),
+Java,"Java 6 to 13 [5]_","javac (OpenJDK and Oracle JDK),
 
-Eclipse compiler for Java (ECJ) [6]_.",``.java``
-JavaScript,ECMAScript 2019 or lower,Not applicable,"``.js``, ``.jsx``, ``.mjs``, ``.es``, ``.es6``, ``.htm``, ``.html``, ``.xhm``, ``.xhtml``, ``.vue``, ``.json``, ``.yaml``, ``.yml``, ``.raml``, ``.xml`` [7]_."
+Eclipse compiler for Java (ECJ) [6]_",``.java``
+JavaScript,ECMAScript 2019 or lower,Not applicable,"``.js``, ``.jsx``, ``.mjs``, ``.es``, ``.es6``, ``.htm``, ``.html``, ``.xhm``, ``.xhtml``, ``.vue``, ``.json``, ``.yaml``, ``.yml``, ``.raml``, ``.xml`` [7]_"
 Python,"2.7, 3.5, 3.6, 3.7, 3.8",Not applicable,``.py``
-TypeScript [8]_.,"2.6-3.7",Standard TypeScript compiler,"``.ts``, ``.tsx``"
+TypeScript [8]_,"2.6-3.7",Standard TypeScript compiler,"``.ts``, ``.tsx``"


### PR DESCRIPTION
While reviewing #2499 I noticed that in the tables we used full stops after foot notes links, but nowhere else. It looked a bit odd. Since it wasn't related to the changes in that PR, I've made changes in a new one.
