### PR TITLE
Python: Fix divergence in tuple `toString`.

### DIFF
--- a/python/ql/src/semmle/python/objects/Sequences.qll
+++ b/python/ql/src/semmle/python/objects/Sequences.qll
@@ -53,7 +53,13 @@ abstract class TupleObjectInternal extends SequenceObjectInternal {
     }
 
     private string item(int n) {
-        result = this.getItem(n).toString()
+        exists(ObjectInternal item | item = this.getItem(n) |
+            // To avoid infinite recursion, nested tuples are replaced with the string "...".
+            if item instanceof TupleObjectInternal then
+                result = "(...)"
+            else
+                result = item.toString()
+        )
         or
         n in [0..this.length()-1] and
         not exists(this.getItem(n)) and result = "?"


### PR DESCRIPTION
Our definition of `toString` for the internal tuple objects we create during the
points-to analysis may have been a _tad_ too ambitious. In particular, it can
easily lead to non-termination, e.g. using the following piece of code:

```python
x = ()
while True:
    x = (x, x)
```

This commit cuts off the infinite recursion by replacing _nested_ tuples with
the string "...". In particular this means even non-recursive tuples will be cut
off at that point, so that the following tuples

```python
(1, "2")
((3, 4), [5, 6])
(1, 2, 3, 4, 5)
```

get the following string representations.

```
"(int 1, '2', )"
"(..., List, )"
"(int 1, int 2, int 3, 2 more...)"
```