### PR TITLE
TS: Rename type table trap to avoid name clash

### DIFF
--- a/javascript/extractor/src/com/semmle/js/extractor/AutoBuild.java
+++ b/javascript/extractor/src/com/semmle/js/extractor/AutoBuild.java
@@ -777,7 +777,10 @@ public class AutoBuild {
   }
 
   private void extractTypeTable(Path fileHandle, TypeTable table) {
-    TrapWriter trapWriter = outputConfig.getTrapWriterFactory().mkTrapWriter(fileHandle.toFile());
+    TrapWriter trapWriter =
+        outputConfig
+            .getTrapWriterFactory()
+            .mkTrapWriter(new File(fileHandle.toString() + ".codeql-typescript-typetable"));
     try {
       new TypeExtractor(trapWriter, table).extract();
     } finally {

--- a/javascript/extractor/src/com/semmle/js/extractor/Main.java
+++ b/javascript/extractor/src/com/semmle/js/extractor/Main.java
@@ -195,7 +195,13 @@ public class Main {
   }
 
   private void extractTypeTable(File fileHandle, TypeTable table) {
-    TrapWriter trapWriter = extractorOutputConfig.getTrapWriterFactory().mkTrapWriter(fileHandle);
+    TrapWriter trapWriter =
+        extractorOutputConfig
+            .getTrapWriterFactory()
+            .mkTrapWriter(
+                new File(
+                    fileHandle.getParentFile(),
+                    fileHandle.getName() + ".codeql-typescript-typetable"));
     try {
       new TypeExtractor(trapWriter, table).extract();
     } finally {


### PR DESCRIPTION
Renames the TRAP file containing type table so it doesn't clash with a file generated by the JSON extractor. Previously, if the `tsconfig.json` file was extracted as JSON, it would override the type table.