### PR TITLE
JavaScript: Fix characteristic predicate of `XMLParent`.

### DIFF
--- a/javascript/ql/src/semmle/javascript/XML.qll
+++ b/javascript/ql/src/semmle/javascript/XML.qll
@@ -34,6 +34,12 @@ abstract class XMLLocatable extends @xmllocatable {
  * both of which can contain other elements.
  */
 class XMLParent extends @xmlparent {
+  XMLParent() {
+    // explicitly restrict `this` to be either an `XMLElement` or an `XMLFile`;
+    // the type `@xmlparent` currently also includes non-XML files
+    this instanceof @xmlelement or xmlEncoding(this, _)
+  }
+
   /**
    * Gets a printable representation of this XML parent.
    * (Intended to be overridden in subclasses.)


### PR DESCRIPTION
The database type `@xmlparent` is defined a bit too loosely in that it includes all of `@file`, not just XML files. This meant that non-XML files were instances of `XMLParent` but not of any of its subtypes, thereby inheriting the default `none()`-implementation of `getName()`, causing their `toString()` predicates to be empty.

Fixing the extent of `@xmlparent` would involve fiddling with the extractor/dbscheme, while fixing `XMLParent` can be done at the QL level, so that's what I've done instead.

Fixes #2517.