### PR TITLE
Actions: Automatically add language-specific labels to pull requests.

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,8 +1,8 @@
-C++:
+"C++":
   - cpp/**/*
   - change-notes/**/*cpp*
 
-C#:
+"C#":
   - csharp/**/*
   - change-notes/**/*csharp*
 

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -21,3 +21,4 @@ Python:
 documentation:
   - **/*.qhelp
   - **/*.md
+  - docs/**/*

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,23 @@
+C++:
+  - cpp/**/*
+  - change-notes/**/*cpp*
+
+C#:
+  - csharp/**/*
+  - change-notes/**/*csharp*
+
+Java:
+  - java/**/*
+  - change-notes/**/*java.*
+
+JS:
+  - javascript/**/*
+  - change-notes/**/*javascript*
+
+Python:
+  - python/**/*
+  - change-notes/**/*python*
+
+documentation:
+  - **/*.qhelp
+  - **/*.md

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -1,0 +1,11 @@
+name: "Pull Request Labeler"
+on:
+- pull_request
+
+jobs:
+  triage:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/labeler@v2
+      with:
+        repo-token: "${{ secrets.GITHUB_TOKEN }}"


### PR DESCRIPTION
This seems like a cool feature, so I went ahead and created a configuration file for all of the languages in this repo. Also adds the `documentation` label to all PRs that modify `.qhelp` and `.md` files.
See more about this feature here:

https://github.com/actions/labeler/blob/master/README.md

(Ping @hvitved @jbj @aschackmull @max-schaefer @felicitymay)