### PR TITLE
JS: New query: missing await

### DIFF
--- a/javascript/config/suites/javascript/correctness-core
+++ b/javascript/config/suites/javascript/correctness-core
@@ -16,6 +16,7 @@
 + semmlecode-javascript-queries/Expressions/DuplicateSwitchCase.ql: /Correctness/Expressions
 + semmlecode-javascript-queries/Expressions/HeterogeneousComparison.ql: /Correctness/Expressions
 + semmlecode-javascript-queries/Expressions/MisspelledVariableName.ql: /Correctness/Expressions
++ semmlecode-javascript-queries/Expressions/MissingAwait.ql: /Correctness/Expressions
 + semmlecode-javascript-queries/Expressions/MissingDotLengthInComparison.ql: /Correctness/Expressions
 + semmlecode-javascript-queries/Expressions/ShiftOutOfRange.ql: /Correctness/Expressions
 + semmlecode-javascript-queries/Expressions/RedundantExpression.ql: /Correctness/Expressions

--- a/javascript/ql/src/Expressions/MissingAwait.qhelp
+++ b/javascript/ql/src/Expressions/MissingAwait.qhelp
@@ -4,62 +4,45 @@
 <qhelp>
 <overview>
 <p>
-In JavaScript, <code>async</code> functions always return a Promise object.
-</p>
-
-<p>
-PLACEHOLDER
+In JavaScript, <code>async</code> functions always return a promise object.
+To obtain the underlying value of the promise, the `await` operator or a call to `then` should be used.
+Attempting to use a Promise object instead of its underlying value can lead to expected behavior.
 </p>
 
 </overview>
 <recommendation>
 
 <p>
-PLACEHOLDER
+Use the `await` operator to get the value contained in the promise.
+Alternatively, call `then` on the promise and use the value passed to the callback.
 </p>
 
 </recommendation>
 <example>
 
 <p>
-PLACEHOLDER
+In the following example, the <code>getData</code> function returns a promise,
+and the caller checks if the returned promise is <code>null</code>:
 </p>
 
-<sample src="examples/ImplicitOperandConversion.js" />
+<sample src="examples/MissingAwait.js" />
 
 <p>
-PLACEHOLDER
+However, the null check does not work as expected. The <code>return null</code> statement
+on line 2 actually returns a <em>promise</em> containing the <code>null</code> value.
+Since the promise object itself is not equal to <code>null</code>, the error check is bypassed.
 </p>
 
 <p>
-PLACEHOLDER
+The issue can be corrected by inserting <code>await</code> before the promise:
 </p>
 
-<sample src="examples/ImplicitOperandConversionGood.js" />
-
-<p>
-PLACEHOLDER
-</p>
-
-<sample src="examples/ImplicitOperandConversion2.js" />
-
-<p>
-PLACEHOLDER
-</p>
-
-<sample src="examples/ImplicitOperandConversion2Good.js" />
-
-<p>
-PLACEHOLDER
-</p>
-
-<sample src="examples/ImplicitOperandConversion2Good2.js" />
+<sample src="examples/MissingAwaitGood.js" />
 
 </example>
 <references>
-
-
-<li>Ecma International, <i>ECMAScript Language Definition</i>, 5.1 Edition, Section 9. ECMA, 2011.</li>
-
+<li>MDN: <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Using_promises">Using promises</a></li>
+<li>MDN: <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/async_function">Async functions</a></li>
+<li>MDN: <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/await">Await operator</a></li>
 </references>
 </qhelp>

--- a/javascript/ql/src/Expressions/MissingAwait.qhelp
+++ b/javascript/ql/src/Expressions/MissingAwait.qhelp
@@ -1,0 +1,65 @@
+<!DOCTYPE qhelp PUBLIC
+  "-//Semmle//qhelp//EN"
+  "qhelp.dtd">
+<qhelp>
+<overview>
+<p>
+In JavaScript, <code>async</code> functions always return a Promise object.
+</p>
+
+<p>
+PLACEHOLDER
+</p>
+
+</overview>
+<recommendation>
+
+<p>
+PLACEHOLDER
+</p>
+
+</recommendation>
+<example>
+
+<p>
+PLACEHOLDER
+</p>
+
+<sample src="examples/ImplicitOperandConversion.js" />
+
+<p>
+PLACEHOLDER
+</p>
+
+<p>
+PLACEHOLDER
+</p>
+
+<sample src="examples/ImplicitOperandConversionGood.js" />
+
+<p>
+PLACEHOLDER
+</p>
+
+<sample src="examples/ImplicitOperandConversion2.js" />
+
+<p>
+PLACEHOLDER
+</p>
+
+<sample src="examples/ImplicitOperandConversion2Good.js" />
+
+<p>
+PLACEHOLDER
+</p>
+
+<sample src="examples/ImplicitOperandConversion2Good2.js" />
+
+</example>
+<references>
+
+
+<li>Ecma International, <i>ECMAScript Language Definition</i>, 5.1 Edition, Section 9. ECMA, 2011.</li>
+
+</references>
+</qhelp>

--- a/javascript/ql/src/Expressions/MissingAwait.qhelp
+++ b/javascript/ql/src/Expressions/MissingAwait.qhelp
@@ -5,16 +5,16 @@
 <overview>
 <p>
 In JavaScript, <code>async</code> functions always return a promise object.
-To obtain the underlying value of the promise, the <code>await</code. operator or a call to <code>then</code. should be used.
-Attempting to use a Promise object instead of its underlying value can lead to expected behavior.
+To obtain the underlying value of the promise, the <code>await</code> operator or a call to <code>then</code> should be used.
+Attempting to use a Promise object instead of its underlying value can lead to unexpected behavior.
 </p>
 
 </overview>
 <recommendation>
 
 <p>
-Use the <code>await</code. operator to get the value contained in the promise.
-Alternatively, call <code>then</code. on the promise and use the value passed to the callback.
+Use the <code>await</code> operator to get the value contained in the promise.
+Alternatively, call <code>then</code> on the promise and use the value passed to the callback.
 </p>
 
 </recommendation>

--- a/javascript/ql/src/Expressions/MissingAwait.qhelp
+++ b/javascript/ql/src/Expressions/MissingAwait.qhelp
@@ -6,7 +6,7 @@
 <p>
 In JavaScript, <code>async</code> functions always return a promise object.
 To obtain the underlying value of the promise, the <code>await</code> operator or a call to <code>then</code> should be used.
-Attempting to use a Promise object instead of its underlying value can lead to unexpected behavior.
+Attempting to use a promise object instead of its underlying value can lead to unexpected behavior.
 </p>
 
 </overview>

--- a/javascript/ql/src/Expressions/MissingAwait.qhelp
+++ b/javascript/ql/src/Expressions/MissingAwait.qhelp
@@ -5,7 +5,7 @@
 <overview>
 <p>
 In JavaScript, <code>async</code> functions always return a promise object.
-To obtain the underlying value of the promise, the `await` operator or a call to `then` should be used.
+To obtain the underlying value of the promise, the <code>await</code. operator or a call to <code>then</code. should be used.
 Attempting to use a Promise object instead of its underlying value can lead to expected behavior.
 </p>
 
@@ -13,8 +13,8 @@ Attempting to use a Promise object instead of its underlying value can lead to e
 <recommendation>
 
 <p>
-Use the `await` operator to get the value contained in the promise.
-Alternatively, call `then` on the promise and use the value passed to the callback.
+Use the <code>await</code. operator to get the value contained in the promise.
+Alternatively, call <code>then</code. on the promise and use the value passed to the callback.
 </p>
 
 </recommendation>

--- a/javascript/ql/src/Expressions/MissingAwait.qhelp
+++ b/javascript/ql/src/Expressions/MissingAwait.qhelp
@@ -5,7 +5,7 @@
 <overview>
 <p>
 In JavaScript, <code>async</code> functions always return a promise object.
-To obtain the underlying value of the promise, the <code>await</code> operator or a call to <code>then</code> should be used.
+To obtain the underlying value of the promise, use the <code>await</code> operator or call the <code>then</code> method.
 Attempting to use a promise object instead of its underlying value can lead to unexpected behavior.
 </p>
 

--- a/javascript/ql/src/Expressions/MissingAwait.ql
+++ b/javascript/ql/src/Expressions/MissingAwait.ql
@@ -46,6 +46,14 @@ predicate isBadPromiseContext(Expr expr) {
   expr = any(UnaryExpr e).getOperand()
   or
   expr = any(UpdateExpr e).getOperand()
+  or
+  expr = any(ConditionalExpr e).getCondition()
+  or
+  expr = any(IfStmt stmt).getCondition()
+  or
+  expr = any(ForInStmt stmt).getIterationDomain()
+  or
+  expr = any(IndexExpr e).getIndex()
 }
 
 string tryGetPromiseExplanation(Expr e) {

--- a/javascript/ql/src/Expressions/MissingAwait.ql
+++ b/javascript/ql/src/Expressions/MissingAwait.ql
@@ -1,0 +1,68 @@
+/**
+ * @name Missing await
+ * @description Using a promise without awaiting its result can cause unexpected behavior.
+ * @kind problem
+ * @problem.severity warning
+ * @id js/missing-await
+ * @tags correctness
+ * @precision high
+ */
+
+import javascript
+
+predicate isAsyncCall(DataFlow::CallNode call) {
+  forex(Function callee | call.getACallee() = callee | callee.isAsync())
+}
+
+/**
+ * Holds if `node` is always a promise.
+ */
+predicate isPromise(DataFlow::SourceNode node, boolean nullable) {
+  isAsyncCall(node) and
+  nullable = false
+  or
+  not isAsyncCall(node) and
+  node.asExpr().getType() instanceof PromiseType and
+  nullable = true
+}
+
+/**
+ * Holds the result of `e` is used in a way that doesn't make sense for Promise objects.
+ */
+predicate isBadPromiseContext(Expr expr) {
+  exists(BinaryExpr binary |
+    expr = binary.getAnOperand() and
+    not binary instanceof LogicalExpr and
+    not binary instanceof InstanceofExpr
+  )
+  or
+  expr = any(LogicalBinaryExpr e).getLeftOperand()
+  or
+  expr = any(UnaryExpr e).getOperand()
+  or
+  expr = any(UpdateExpr e).getOperand()
+}
+
+string tryGetPromiseExplanation(Expr e) {
+  result = "The value '" + e.(VarAccess).getName() + "' is always a promise."
+  or
+  result = "The call to '" + e.(CallExpr).getCalleeName() + "' always returns a promise."
+}
+
+string getPromiseExplanation(Expr e) {
+  result = tryGetPromiseExplanation(e)
+  or
+  not exists(tryGetPromiseExplanation(e)) and
+  result = "This value is always a promise."
+}
+
+from Expr expr, boolean nullable
+where
+  isBadPromiseContext(expr) and
+  isPromise(expr.flow().getImmediatePredecessor*(), nullable) and
+  (
+    nullable = false
+    or
+    expr.inNullSensitiveContext()
+  )
+select expr, "Missing await. " + getPromiseExplanation(expr)

--- a/javascript/ql/src/Expressions/MissingAwait.ql
+++ b/javascript/ql/src/Expressions/MissingAwait.ql
@@ -1,6 +1,6 @@
 /**
  * @name Missing await
- * @description Using a promise without awaiting its result can cause unexpected behavior.
+ * @description Using a promise without awaiting its result can lead to unexpected behavior.
  * @kind problem
  * @problem.severity warning
  * @id js/missing-await
@@ -10,7 +10,12 @@
 
 import javascript
 
+/**
+ * Holds if `call` is a call to an `async` function.
+ */
 predicate isAsyncCall(DataFlow::CallNode call) {
+  // If a callee is known, and all known callees are async, assume all
+  // possible callees are async.
   forex(Function callee | call.getACallee() = callee | callee.isAsync())
 }
 

--- a/javascript/ql/src/Expressions/examples/MissingAwait.js
+++ b/javascript/ql/src/Expressions/examples/MissingAwait.js
@@ -1,0 +1,14 @@
+async function getData(id) {
+  let req = await fetch(`https://example.com/data?id=${id}`);
+  if (!req.ok) return null;
+  return req.json();
+}
+
+async function showData(id) {
+  let data = getData(id);
+  if (data == null) {
+    console.warn("No data for: " + id);
+    return;
+  }
+  // ...
+}

--- a/javascript/ql/src/Expressions/examples/MissingAwaitGood.js
+++ b/javascript/ql/src/Expressions/examples/MissingAwaitGood.js
@@ -1,0 +1,14 @@
+async function getData(id) {
+  let req = await fetch(`https://example.com/data?id=${id}`);
+  if (!req.ok) return null;
+  return req.json();
+}
+
+async function showData(id) {
+  let data = await getData(id);
+  if (data == null) {
+    console.warn("No data for: " + id);
+    return;
+  }
+  // ...
+}

--- a/javascript/ql/src/semmle/javascript/SSA.qll
+++ b/javascript/ql/src/semmle/javascript/SSA.qll
@@ -662,6 +662,29 @@ class SsaPhiNode extends SsaPseudoDefinition, TPhi {
     endcolumn = startcolumn and
     getBasicBlock().getLocation().hasLocationInfo(filepath, startline, startcolumn, _, _)
   }
+
+  /**
+   * If all inputs to this phi node are (transitive) refinements of the same variable,
+   * gets that variable.
+   */
+  SsaVariable getRephinedVariable() {
+    forex(SsaVariable input | input = getAnInput() |
+      result = getRefinedVariable(input)
+    )
+  }
+}
+
+/**
+ * Gets the input to the given refinement node or rephinement node.
+ */
+private SsaVariable getRefinedVariable(SsaVariable v) {
+  result = getRefinedVariable(v.(SsaRefinementNode).getAnInput())
+  or
+  result = getRefinedVariable(v.(SsaPhiNode).getRephinedVariable())
+  or
+  not v instanceof SsaRefinementNode and
+  not v instanceof SsaPhiNode and
+  result = v
 }
 
 /**

--- a/javascript/ql/src/semmle/javascript/dataflow/DataFlow.qll
+++ b/javascript/ql/src/semmle/javascript/dataflow/DataFlow.qll
@@ -208,6 +208,11 @@ module DataFlow {
         result = TSsaDefNode(refinement.getAnInput())
       )
       or
+      exists(SsaPhiNode phi |
+        this = TSsaDefNode(phi) and
+        result = TSsaDefNode(phi.getRephinedVariable())
+      )
+      or
       // IIFE call -> return value of IIFE
       exists(Function fun |
         localCall(this.asExpr(), fun) and

--- a/javascript/ql/test/query-tests/Expressions/MissingAwait/MissingAwait.expected
+++ b/javascript/ql/test/query-tests/Expressions/MissingAwait/MissingAwait.expected
@@ -1,2 +1,9 @@
 | tst.js:8:9:8:13 | thing | Missing await. The value 'thing' is always a promise. |
-| tst.js:32:12:32:16 | thing | Missing await. The value 'thing' is always a promise. |
+| tst.js:10:9:10:13 | thing | Missing await. The value 'thing' is always a promise. |
+| tst.js:12:15:12:19 | thing | Missing await. The value 'thing' is always a promise. |
+| tst.js:14:19:14:23 | thing | Missing await. The value 'thing' is always a promise. |
+| tst.js:19:19:19:23 | thing | Missing await. The value 'thing' is always a promise. |
+| tst.js:20:9:20:13 | thing | Missing await. The value 'thing' is always a promise. |
+| tst.js:22:15:22:19 | thing | Missing await. The value 'thing' is always a promise. |
+| tst.js:25:13:25:17 | thing | Missing await. The value 'thing' is always a promise. |
+| tst.js:48:12:48:16 | thing | Missing await. The value 'thing' is always a promise. |

--- a/javascript/ql/test/query-tests/Expressions/MissingAwait/MissingAwait.expected
+++ b/javascript/ql/test/query-tests/Expressions/MissingAwait/MissingAwait.expected
@@ -1,0 +1,2 @@
+| tst.js:8:9:8:13 | thing | Missing await. The value 'thing' is always a promise. |
+| tst.js:32:12:32:16 | thing | Missing await. The value 'thing' is always a promise. |

--- a/javascript/ql/test/query-tests/Expressions/MissingAwait/MissingAwait.qlref
+++ b/javascript/ql/test/query-tests/Expressions/MissingAwait/MissingAwait.qlref
@@ -1,0 +1,1 @@
+Expressions/MissingAwait.ql

--- a/javascript/ql/test/query-tests/Expressions/MissingAwait/tst.js
+++ b/javascript/ql/test/query-tests/Expressions/MissingAwait/tst.js
@@ -1,0 +1,47 @@
+async function getThing() {
+    return something();
+}
+
+function useThing() {
+    let thing = getThing();
+
+    if (thing === undefined) {} // NOT OK
+
+    if (thing == null) {} // NOT OK
+
+    return thing + "bar"; // NOT OK
+}
+
+async function useThingCorrectly() {
+    let thing = await getThing();
+
+    if (thing === undefined) {} // OK
+
+    if (thing == null) {} // OK
+
+    return thing + "bar"; // OK
+}
+
+async function useThingCorrectly2() {
+    let thing = getThing();
+
+    if (await thing === undefined) {} // OK
+
+    if (await thing == null) {} // OK
+
+    return thing + "bar"; // NOT OK
+}
+
+function getThingSync() {
+    return something();
+}
+
+function useThingPossiblySync(b) {
+    let thing = b ? getThing() : getThingSync();
+
+    if (thing === undefined) {} // OK
+
+    if (thing == null) {} // OK
+
+    return thing + "bar"; // NOT OK - but we don't flag it
+}

--- a/javascript/ql/test/query-tests/Expressions/MissingAwait/tst.js
+++ b/javascript/ql/test/query-tests/Expressions/MissingAwait/tst.js
@@ -9,7 +9,23 @@ function useThing() {
 
     if (thing == null) {} // NOT OK
 
-    return thing + "bar"; // NOT OK
+    something(thing ? 1 : 2); // NOT OK
+
+    for (let x in thing) { // NOT OK
+        something(x);
+    }
+
+    let obj = something();
+    something(obj[thing]); // NOT OK
+    obj[thing] = 5; // NOT OK
+
+    something(thing + "bar"); // NOT OK
+
+    if (something()) {
+        if (thing) { // NOT OK
+            something(3);
+        }
+    }
 }
 
 async function useThingCorrectly() {


### PR DESCRIPTION
Adds a query to flag cases where a promise was used, but where the intention most likely to use the *result* of the promise instead.

Null checks are particularly interesting here. `async` functions never return `null`, and so a null check will silently fail.

We use the call graph and static types to recognize promises, although I'm not sure how much use we get from the static types are here, as we probably only flag what the type checker would have flagged anyway. As seen [here](https://lgtm.com/query/1641902221870274096/) it gets noisy if we assume something of a promise type is non-nullable, so we can't use them to flag null checks.

Contains a drive-by change to `getImmediatePredecessor` to make it step through phi nodes whose operands are all refinements of the same value. I couldn't resist calling such nodes *rephinement* nodes.

Still need to run an evaluation, especially of the second commit.