### PR TITLE
CPP: Resolve some hidden queries

### DIFF
--- a/change-notes/1.24/analysis-cpp.md
+++ b/change-notes/1.24/analysis-cpp.md
@@ -13,6 +13,7 @@ The following changes in version 1.24 affect C/C++ analysis in all applications.
 
 | **Query**                  | **Expected impact**    | **Change**                                                       |
 |----------------------------|------------------------|------------------------------------------------------------------|
+| Hard-coded Japanese era start date (`cpp/japanese-era/exact-era-date`) |  | This query is no longer run on LGTM. |
 | No space for zero terminator (`cpp/no-space-for-terminator`) | Fewer false positive results | This query has been modified to be more conservative when identifying which pointers point to null-terminated strings.  This approach produces fewer, more accurate results. |
 
 ## Changes to libraries

--- a/cpp/ql/src/Architecture/FeatureEnvy.ql
+++ b/cpp/ql/src/Architecture/FeatureEnvy.ql
@@ -3,7 +3,7 @@
  * @description A function that uses more functions and variables from another file than functions and variables from its own file. This function might be better placed in the other file, to avoid exposing internals of the file it depends on.
  * @kind problem
  * @problem.severity recommendation
- * @precision high
+ * @precision medium
  * @id cpp/feature-envy
  * @tags maintainability
  *       modularity

--- a/cpp/ql/src/Architecture/InappropriateIntimacy.ql
+++ b/cpp/ql/src/Architecture/InappropriateIntimacy.ql
@@ -3,7 +3,7 @@
  * @description Two files share too much information about each other (accessing many operations or variables in both directions). It would be better to invert some of the dependencies to reduce the coupling between the two files.
  * @kind problem
  * @problem.severity recommendation
- * @precision high
+ * @precision medium
  * @id cpp/file-intimacy
  * @tags maintainability
  *       modularity

--- a/cpp/ql/src/Architecture/Refactoring Opportunities/ClassesWithManyFields.ql
+++ b/cpp/ql/src/Architecture/Refactoring Opportunities/ClassesWithManyFields.ql
@@ -3,7 +3,7 @@
  * @description Finds classes with many fields; they could probably be refactored by breaking them down into smaller classes, and using composition.
  * @kind problem
  * @problem.severity recommendation
- * @precision high
+ * @precision medium
  * @id cpp/class-many-fields
  * @tags maintainability
  *       statistical

--- a/cpp/ql/src/Best Practices/Magic Constants/JapaneseEraDate.ql
+++ b/cpp/ql/src/Best Practices/Magic Constants/JapaneseEraDate.ql
@@ -4,7 +4,7 @@
  * @kind problem
  * @problem.severity warning
  * @id cpp/japanese-era/exact-era-date
- * @precision medium
+ * @precision low
  * @tags reliability
  *       japanese-era
  */


### PR DESCRIPTION
Demoted some of the weaker run-but-not-displayed-by-default queries on LGTM to save compute time:

- 	JapaneseEraDate.ql; there were only [three results](https://lgtm.com/rules/1510017876327/alerts/), in one project, all false positives (the query *is* useful to some of our customers with specific concerns, however).
- 	InappropriateIntimacy.ql; this is an old query that we'd describe as 'opinionated' (that is, users will often disagree with it's 'opinion'), except that it doesn't quite explicitly state what it expects you to do about each result.  There are [lots of alerts](https://lgtm.com/rules/2151900538/alerts/) but in most cases, the design looks quite intentional and I don't think I'd be inclined to change it based on the alert.
- 	FeatureEnvy.ql ([results](https://lgtm.com/rules/2163190798/alerts/)).  Jonas said the results aren't good on Linux.  In addition what it's suggesting fairly often amounts to merging stuff from more specialized files into more general files or places where the functionality is used - giving the code less structure.
- 	ClassesWithManyFields.ql ([results](https://lgtm.com/rules/2158670639/alerts/)).  We could probably improve this query by increasing the threshold (say from 15 to 30), but we'll still be left with an 'opinionated' query that I don't think many people will care for.

For https://jira.semmle.com/browse/CPP-371