### PR TITLE
CPP: Speed up nullCheckAssert in InconsistentCheckReturnNull.ql.

### DIFF
--- a/cpp/ql/src/Likely Bugs/InconsistentCheckReturnNull.ql
+++ b/cpp/ql/src/Likely Bugs/InconsistentCheckReturnNull.ql
@@ -25,10 +25,14 @@ predicate assertInvocation(File f, int line) {
   )
 }
 
-predicate nullCheckAssert(Expr e, Variable v, Declaration qualifier) {
-  nullCheckInCondition(e, v, qualifier) and
+class InterestingExpr extends Expr {
+  InterestingExpr() { nullCheckInCondition(this, _, _) }
+}
+
+predicate nullCheckAssert(InterestingExpr e, Variable v, Declaration qualifier) {
   exists(File f, int i |
-    e.getLocation().getStartLine() = i and e.getFile() = f and assertInvocation(f, i)
+    e.getLocation().getStartLine() = i and e.getFile() = f and assertInvocation(f, i) and
+    nullCheckInCondition(e, v, qualifier)
   )
 }
 

--- a/cpp/ql/src/Likely Bugs/InconsistentCheckReturnNull.ql
+++ b/cpp/ql/src/Likely Bugs/InconsistentCheckReturnNull.ql
@@ -31,7 +31,9 @@ class InterestingExpr extends Expr {
 
 predicate nullCheckAssert(InterestingExpr e, Variable v, Declaration qualifier) {
   exists(File f, int i |
-    e.getLocation().getStartLine() = i and e.getFile() = f and assertInvocation(f, i) and
+    e.getLocation().getStartLine() = i and
+    e.getFile() = f and
+    assertInvocation(f, i) and
     nullCheckInCondition(e, v, qualifier)
   )
 }


### PR DESCRIPTION
`nullCheckAssert` was unnecessarily slow on large projects.