### PR TITLE
Docs: Update references to QL for Eclipse

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -15,7 +15,7 @@ Follow the steps below to help other users understand what your query does, and 
 
 2. **Format your code correctly**
 
-   All of Semmle's standard queries and libraries are uniformly formatted for clarity and consistency, so we strongly recommend that all contributions follow the same formatting guidelines. If you use QL for Eclipse, you can auto-format your query in the [QL editor](https://help.semmle.com/ql-for-eclipse/Content/WebHelp/ql-editor.html). For more information, see the [CodeQL style guide](https://github.com/Semmle/ql/blob/master/docs/ql-style-guide.md).
+   All of Semmle's standard queries and libraries are uniformly formatted for clarity and consistency, so we strongly recommend that all contributions follow the same formatting guidelines. If you use CodeQL for VS Code, you can autoformat your query in the [Editor](https://help.semmle.com/codeql/codeql-for-vscode/reference/editor.html#autoformatting). For more information, see the [CodeQL style guide](https://github.com/Semmle/ql/blob/master/docs/ql-style-guide.md).
 
 3. **Make sure your query has the correct metadata**
 

--- a/docs/language/learn-ql/ql-training.rst
+++ b/docs/language/learn-ql/ql-training.rst
@@ -25,7 +25,7 @@ When you have selected a presentation, use |arrow-r| and |arrow-l| to navigate b
 Press **p** to view the additional notes on slides that have an information icon |info| in the top right corner, and press **f** to enter full-screen mode.
 
 The presentations contain a number of query examples.
-We recommend that you download `QL for Eclipse <https://help.semmle.com/ql-for-eclipse/Content/WebHelp/home-page.html>`__ and import the example database for each presentation so that you can find the bugs mentioned in the slides. 
+We recommend that you download `CodeQL for Visual Studio Code <https://help.semmle.com/codeql/codeql-for-vscode/procedures/setting-up.html>`__ and add the example database for each presentation so that you can find the bugs mentioned in the slides. 
 
 
 .. pull-quote:: 

--- a/docs/language/ql-training/cpp/intro-ql-cpp.rst
+++ b/docs/language/ql-training/cpp/intro-ql-cpp.rst
@@ -106,7 +106,7 @@ Each query library also implicitly defines a module.
 
 .. note::
 
-  Queries are always contained in query files with the file extension ``.ql``. `Quick queries <https://help.semmle.com/ql-for-eclipse/Content/WebHelp/quick-query.html>`__, run in `QL for Eclipse <https://help.semmle.com/ql-for-eclipse/Content/WebHelp/home-page.html>`__, are no exception: the quick query window maintains a temporary query file in the background.
+  Queries are always contained in query files with the file extension ``.ql``.
 
   Parts of queries can be lifted into `library files <https://help.semmle.com/QL/ql-handbook/modules.html#library-modules>`__ with the extension ``.qll``. Definitions within such libraries can be brought into scope using ``import`` statements, and similarly QLL files can import each other’s definitions using “import” statements.
 

--- a/docs/language/ql-training/template.rst
+++ b/docs/language/ql-training/template.rst
@@ -27,7 +27,7 @@ Template slide deck
    
    Second subheading
 
-.. Set up slide. Include link to QL4E snapshots required for examples 
+.. Set up slide. Include link to CodeQL databases required for examples 
 
 .. rst-class:: setup
 
@@ -36,8 +36,8 @@ Setup
 
 For this example you should download:
 
-- `QL for Eclipse <https://help.semmle.com/ql-for-eclipse/Content/WebHelp/install-plugin-free.html>`__
-- A snapshot
+- `CodeQL for Visual Studio Code <https://help.semmle.com/codeql/codeql-for-vscode/procedures/setting-up.html>`__
+- A CodeQL database
 
 .. note::
 

--- a/docs/ql-style-guide.md
+++ b/docs/ql-style-guide.md
@@ -3,7 +3,7 @@
 ## Introduction
 
 This document describes how to format the code you contribute to this repository. It covers aspects such as layout, white-space, naming, and documentation. Adhering to consistent standards makes code easier to read and maintain. Of course, these are only guidelines, and can be overridden as the need arises on a case-by-case basis. Where existing code deviates from these guidelines, prefer consistency with the surrounding code.
-Note, if you use QL for Eclipse, you can auto-format your query in the [QL editor](https://help.semmle.com/ql-for-eclipse/Content/WebHelp/ql-editor.html).
+Note, if you use CodeQL for VS Code, you can autoformat your query in the [Editor](https://help.semmle.com/codeql/codeql-for-vscode/reference/editor.html#autoformatting).
 
 Words in *italic* are defined in the [Glossary](#glossary).
 


### PR DESCRIPTION
Found a few more outdated mentions. I've targetted `rc/1.23`, but this isn't a hugely important change (and we don't necessarily have to republish the help). 

@jf205, could you review/merge please?