### PR TITLE
C++/Java/JavaScript/Python: Unify XML libraries.

### DIFF
--- a/config/identical-files.json
+++ b/config/identical-files.json
@@ -265,5 +265,11 @@
   "C# IR ValueNumberingImports": [
     "csharp/ql/src/semmle/code/csharp/ir/implementation/raw/gvn/internal/ValueNumberingImports.qll",
     "csharp/ql/src/semmle/code/csharp/ir/implementation/unaliased_ssa/gvn/internal/ValueNumberingImports.qll"
+  ],
+  "XML": [
+    "cpp/ql/src/semmle/code/cpp/XML.qll",
+    "java/ql/src/semmle/code/xml/XML.qll",
+    "javascript/ql/src/semmle/javascript/XML.qll",
+    "python/ql/src/semmle/python/xml/XML.qll"
   ]
 }

--- a/cpp/ql/src/semmle/code/cpp/XML.qll
+++ b/cpp/ql/src/semmle/code/cpp/XML.qll
@@ -115,15 +115,13 @@ class XMLFile extends XMLParent, File {
   override string toString() { result = XMLParent.super.toString() }
 
   /** Gets the name of this XML file. */
-  override string getName() { files(this, result, _, _, _) }
+  override string getName() { result = File.super.getAbsolutePath() }
 
   /** Gets the path of this XML file. */
-  string getPath() { files(this, _, result, _, _) }
+  string getPath() { result = getAbsolutePath() }
 
   /** Gets the path of the folder that contains this XML file. */
-  string getFolder() {
-    result = this.getPath().substring(0, this.getPath().length() - this.getName().length())
-  }
+  string getFolder() { result = getParentContainer().getAbsolutePath() }
 
   /** Gets the encoding of this XML file. */
   string getEncoding() { xmlEncoding(this, result) }

--- a/cpp/ql/src/semmle/code/cpp/XML.qll
+++ b/cpp/ql/src/semmle/code/cpp/XML.qll
@@ -2,7 +2,7 @@
  * Provides classes and predicates for working with XML files and their content.
  */
 
-import semmle.code.cpp.Location
+import semmle.files.FileSystem
 
 /** An XML element that has a location. */
 abstract class XMLLocatable extends @xmllocatable {

--- a/cpp/ql/src/semmle/code/cpp/XML.qll
+++ b/cpp/ql/src/semmle/code/cpp/XML.qll
@@ -117,11 +117,19 @@ class XMLFile extends XMLParent, File {
   /** Gets the name of this XML file. */
   override string getName() { result = File.super.getAbsolutePath() }
 
-  /** Gets the path of this XML file. */
-  string getPath() { result = getAbsolutePath() }
+  /**
+   * DEPRECATED: Use `getAbsolutePath()` instead.
+   *
+   * Gets the path of this XML file.
+   */
+  deprecated string getPath() { result = getAbsolutePath() }
 
-  /** Gets the path of the folder that contains this XML file. */
-  string getFolder() { result = getParentContainer().getAbsolutePath() }
+  /**
+   * DEPRECATED: Use `getParentContainer().getAbsolutePath()` instead.
+   *
+   * Gets the path of the folder that contains this XML file.
+   */
+  deprecated string getFolder() { result = getParentContainer().getAbsolutePath() }
 
   /** Gets the encoding of this XML file. */
   string getEncoding() { xmlEncoding(this, result) }

--- a/cpp/ql/src/semmle/code/cpp/XML.qll
+++ b/cpp/ql/src/semmle/code/cpp/XML.qll
@@ -10,8 +10,11 @@ abstract class XMLLocatable extends @xmllocatable {
   Location getLocation() { xmllocations(this, result) }
 
   /**
-   * Holds if this element has the specified location information,
-   * including file path, start line, start column, end line and end column.
+   * Holds if this element is at the specified location.
+   * The location spans column `startcolumn` of line `startline` to
+   * column `endcolumn` of line `endline` in file `filepath`.
+   * For more information, see
+   * [Locations](https://help.semmle.com/QL/learn-ql/ql/locations.html).
    */
   predicate hasLocationInfo(
     string filepath, int startline, int startcolumn, int endline, int endcolumn
@@ -22,7 +25,7 @@ abstract class XMLLocatable extends @xmllocatable {
     )
   }
 
-  /** Gets a printable representation of this element. */
+  /** Gets a textual representation of this element. */
   abstract string toString();
 }
 
@@ -135,7 +138,17 @@ class XMLFile extends XMLParent, File {
   XMLDTD getADTD() { xmlDTDs(result, _, _, _, this) }
 }
 
-/** A "Document Type Definition" of an XML file. */
+/**
+ * An XML document type definition (DTD).
+ *
+ * Example:
+ *
+ * ```
+ * <!ELEMENT person (firstName, lastName?)>
+ * <!ELEMENT firstName (#PCDATA)>
+ * <!ELEMENT lastName (#PCDATA)>
+ * ```
+ */
 class XMLDTD extends @xmldtd {
   /** Gets the name of the root element of this DTD. */
   string getRoot() { xmlDTDs(this, result, _, _, _) }
@@ -162,7 +175,17 @@ class XMLDTD extends @xmldtd {
   }
 }
 
-/** An XML tag in an XML file. */
+/**
+ * An XML element in an XML file.
+ *
+ * Example:
+ *
+ * ```
+ * <manifest xmlns:android="http://schemas.android.com/apk/res/android"
+ *           package="com.example.exampleapp" android:versionCode="1">
+ * </manifest>
+ * ```
+ */
 class XMLElement extends @xmlelement, XMLParent, XMLLocatable {
   /** Holds if this XML element has the given `name`. */
   predicate hasName(string name) { name = getName() }
@@ -207,7 +230,16 @@ class XMLElement extends @xmlelement, XMLParent, XMLLocatable {
   override string toString() { result = XMLParent.super.toString() }
 }
 
-/** An attribute that occurs inside an XML element. */
+/**
+ * An attribute that occurs inside an XML element.
+ *
+ * Examples:
+ *
+ * ```
+ * package="com.example.exampleapp"
+ * android:versionCode="1"
+ * ```
+ */
 class XMLAttribute extends @xmlattribute, XMLLocatable {
   /** Gets the name of this attribute. */
   string getName() { xmlAttrs(this, _, result, _, _, _) }
@@ -228,7 +260,15 @@ class XMLAttribute extends @xmlattribute, XMLLocatable {
   override string toString() { result = this.getName() + "=" + this.getValue() }
 }
 
-/** A namespace used in an XML file */
+/**
+ * A namespace used in an XML file.
+ *
+ * Example:
+ *
+ * ```
+ * xmlns:android="http://schemas.android.com/apk/res/android"
+ * ```
+ */
 class XMLNamespace extends @xmlnamespace {
   /** Gets the prefix of this namespace. */
   string getPrefix() { xmlNs(this, result, _, _) }
@@ -247,7 +287,15 @@ class XMLNamespace extends @xmlnamespace {
   }
 }
 
-/** A comment of the form `<!-- ... -->` is an XML comment. */
+/**
+ * A comment in an XML file.
+ *
+ * Example:
+ *
+ * ```
+ * <!-- This is a comment. -->
+ * ```
+ */
 class XMLComment extends @xmlcomment, XMLLocatable {
   /** Gets the text content of this XML comment. */
   string getText() { xmlComments(this, result, _, _) }
@@ -262,6 +310,12 @@ class XMLComment extends @xmlcomment, XMLLocatable {
 /**
  * A sequence of characters that occurs between opening and
  * closing tags of an XML element, excluding other elements.
+ *
+ * Example:
+ *
+ * ```
+ * <content>This is a sequence of characters.</content>
+ * ```
  */
 class XMLCharacters extends @xmlcharacters, XMLLocatable {
   /** Gets the content of this character sequence. */

--- a/cpp/ql/src/semmle/code/cpp/XML.qll
+++ b/cpp/ql/src/semmle/code/cpp/XML.qll
@@ -20,7 +20,7 @@ abstract class XMLLocatable extends @xmllocatable {
     string filepath, int startline, int startcolumn, int endline, int endcolumn
   ) {
     exists(File f, Location l | l = this.getLocation() |
-      locations_default(l, unresolveElement(f), startline, startcolumn, endline, endcolumn) and
+      locations_default(l, f, startline, startcolumn, endline, endcolumn) and
       filepath = f.getAbsolutePath()
     )
   }

--- a/java/ql/src/semmle/code/xml/XML.qll
+++ b/java/ql/src/semmle/code/xml/XML.qll
@@ -2,7 +2,7 @@
  * Provides classes and predicates for working with XML files and their content.
  */
 
-import semmle.code.Location
+import semmle.files.FileSystem
 
 /** An XML element that has a location. */
 abstract class XMLLocatable extends @xmllocatable {

--- a/java/ql/src/semmle/code/xml/XML.qll
+++ b/java/ql/src/semmle/code/xml/XML.qll
@@ -88,7 +88,10 @@ class XMLParent extends @xmlparent {
     )
   }
 
-  /** Append all the character sequences of this XML parent from left to right, separated by a space. */
+  /**
+   * Gets the result of appending all the character sequences of this XML parent from
+   * left to right, separated by a space.
+   */
   string allCharactersString() {
     result = concat(string chars, int pos |
         xmlChars(_, chars, this, pos, _, _)

--- a/java/ql/src/semmle/code/xml/XML.qll
+++ b/java/ql/src/semmle/code/xml/XML.qll
@@ -117,6 +117,20 @@ class XMLFile extends XMLParent, File {
   /** Gets the name of this XML file. */
   override string getName() { result = File.super.getAbsolutePath() }
 
+  /**
+   * DEPRECATED: Use `getAbsolutePath()` instead.
+   *
+   * Gets the path of this XML file.
+   */
+  deprecated string getPath() { result = getAbsolutePath() }
+
+  /**
+   * DEPRECATED: Use `getParentContainer().getAbsolutePath()` instead.
+   *
+   * Gets the path of the folder that contains this XML file.
+   */
+  deprecated string getFolder() { result = getParentContainer().getAbsolutePath() }
+
   /** Gets the encoding of this XML file. */
   string getEncoding() { xmlEncoding(this, result) }
 

--- a/javascript/ql/src/semmle/javascript/XML.qll
+++ b/javascript/ql/src/semmle/javascript/XML.qll
@@ -88,7 +88,10 @@ class XMLParent extends @xmlparent {
     )
   }
 
-  /** Append all the character sequences of this XML parent from left to right, separated by a space. */
+  /**
+   * Gets the result of appending all the character sequences of this XML parent from
+   * left to right, separated by a space.
+   */
   string allCharactersString() {
     result = concat(string chars, int pos |
         xmlChars(_, chars, this, pos, _, _)

--- a/javascript/ql/src/semmle/javascript/XML.qll
+++ b/javascript/ql/src/semmle/javascript/XML.qll
@@ -2,7 +2,7 @@
  * Provides classes and predicates for working with XML files and their content.
  */
 
-import javascript
+import semmle.files.FileSystem
 
 /** An XML element that has a location. */
 abstract class XMLLocatable extends @xmllocatable {

--- a/javascript/ql/src/semmle/javascript/XML.qll
+++ b/javascript/ql/src/semmle/javascript/XML.qll
@@ -117,6 +117,20 @@ class XMLFile extends XMLParent, File {
   /** Gets the name of this XML file. */
   override string getName() { result = File.super.getAbsolutePath() }
 
+  /**
+   * DEPRECATED: Use `getAbsolutePath()` instead.
+   *
+   * Gets the path of this XML file.
+   */
+  deprecated string getPath() { result = getAbsolutePath() }
+
+  /**
+   * DEPRECATED: Use `getParentContainer().getAbsolutePath()` instead.
+   *
+   * Gets the path of the folder that contains this XML file.
+   */
+  deprecated string getFolder() { result = getParentContainer().getAbsolutePath() }
+
   /** Gets the encoding of this XML file. */
   string getEncoding() { xmlEncoding(this, result) }
 

--- a/python/ql/src/semmle/python/xml/XML.qll
+++ b/python/ql/src/semmle/python/xml/XML.qll
@@ -7,15 +7,17 @@ import semmle.python.Files
 /** An XML element that has a location. */
 abstract class XMLLocatable extends @xmllocatable {
   /** The source location for this element. */
-  Location getLocation() { xmllocations(this,result) }
+  Location getLocation() { xmllocations(this, result) }
 
   /**
    * Whether this element has the specified location information,
    * including file path, start line, start column, end line and end column.
    */
-  predicate hasLocationInfo(string filepath, int startline, int startcolumn, int endline, int endcolumn) {
+  predicate hasLocationInfo(
+    string filepath, int startline, int startcolumn, int endline, int endcolumn
+  ) {
     exists(File f, Location l | l = this.getLocation() |
-      locations_default(l,f,startline,startcolumn,endline,endcolumn) and
+      locations_default(l, f, startline, startcolumn, endline, endcolumn) and
       filepath = f.getName()
     )
   }
@@ -29,7 +31,6 @@ abstract class XMLLocatable extends @xmllocatable {
  * both of which can contain other elements.
  */
 class XMLParent extends @xmlparent {
-
   XMLParent() {
     // explicitly restrict `this` to be either an `XMLElement` or an `XMLFile`;
     // the type `@xmlparent` currently also includes non-XML files
@@ -43,58 +44,56 @@ class XMLParent extends @xmlparent {
   /*abstract*/ string getName() { result = "parent" }
 
   /** The file to which this XML parent belongs. */
-  XMLFile getFile() { result = this or xmlElements(this,_,_,_,result) }
+  XMLFile getFile() { result = this or xmlElements(this, _, _, _, result) }
 
   /** The child element at a specified index of this XML parent. */
   XMLElement getChild(int index) { xmlElements(result, _, this, index, _) }
 
   /** A child element of this XML parent. */
-  XMLElement getAChild() { xmlElements(result,_,this,_,_) }
+  XMLElement getAChild() { xmlElements(result, _, this, _, _) }
 
   /** A child element of this XML parent with the given `name`. */
-  XMLElement getAChild(string name) { xmlElements(result,_,this,_,_) and result.hasName(name) }
+  XMLElement getAChild(string name) { xmlElements(result, _, this, _, _) and result.hasName(name) }
 
   /** A comment that is a child of this XML parent. */
-  XMLComment getAComment() { xmlComments(result,_,this,_) }
+  XMLComment getAComment() { xmlComments(result, _, this, _) }
 
   /** A character sequence that is a child of this XML parent. */
-  XMLCharacters getACharactersSet() { xmlChars(result,_,this,_,_,_)  }
+  XMLCharacters getACharactersSet() { xmlChars(result, _, this, _, _, _) }
 
   /** The depth in the tree. (Overridden in XMLElement.) */
   int getDepth() { result = 0 }
 
   /** The number of child XML elements of this XML parent. */
-  int getNumberOfChildren() {
-    result = count(XMLElement e | xmlElements(e,_,this,_,_))
-  }
+  int getNumberOfChildren() { result = count(XMLElement e | xmlElements(e, _, this, _, _)) }
 
   /** The number of places in the body of this XML parent where text occurs. */
-  int getNumberOfCharacterSets() {
-    result = count(int pos | xmlChars(_,_,this,pos,_,_))
-  }
+  int getNumberOfCharacterSets() { result = count(int pos | xmlChars(_, _, this, pos, _, _)) }
 
   /**
    * Append the character sequences of this XML parent from left to right, separated by a space,
    * up to a specified (zero-based) index.
    */
   string charsSetUpTo(int n) {
-    (n = 0 and xmlChars(_,result,this,0,_,_)) or
-    (n > 0 and exists(string chars | xmlChars(_,chars,this,n,_,_) |
-                         result = this.charsSetUpTo(n-1) + " " + chars))
+    n = 0 and xmlChars(_, result, this, 0, _, _)
+    or
+    n > 0 and
+    exists(string chars | xmlChars(_, chars, this, n, _, _) |
+      result = this.charsSetUpTo(n - 1) + " " + chars
+    )
   }
 
   /** Append all the character sequences of this XML parent from left to right, separated by a space. */
   string allCharactersString() {
     exists(int n | n = this.getNumberOfCharacterSets() |
-      (n = 0 and result = "") or
-      (n > 0 and result = this.charsSetUpTo(n-1))
+      n = 0 and result = ""
+      or
+      n > 0 and result = this.charsSetUpTo(n - 1)
     )
   }
 
   /** The text value contained in this XML parent. */
-  string getTextValue() {
-    result = allCharactersString()
-  }
+  string getTextValue() { result = allCharactersString() }
 
   /** A printable representation of this XML parent. */
   string toString() { result = this.getName() }
@@ -102,65 +101,59 @@ class XMLParent extends @xmlparent {
 
 /** An XML file. */
 class XMLFile extends XMLParent, File {
-  XMLFile() {
-    xmlEncoding(this,_)
-  }
+  XMLFile() { xmlEncoding(this, _) }
 
   /** A printable representation of this XML file. */
-  override
-  string toString() { result = XMLParent.super.toString() }
+  override string toString() { result = XMLParent.super.toString() }
 
   /** The name of this XML file. */
-  override
-  string getName() { files(this,result,_,_,_) }
+  override string getName() { files(this, result, _, _, _) }
 
   /** The path of this XML file. */
-  string getPath() { files(this,_,result,_,_) }
+  string getPath() { files(this, _, result, _, _) }
 
   /** The path of the folder that contains this XML file. */
   string getFolder() {
-    result = this.getPath().substring(0, this.getPath().length()-this.getName().length())
+    result = this.getPath().substring(0, this.getPath().length() - this.getName().length())
   }
 
   /** The encoding of this XML file. */
-  string getEncoding() { xmlEncoding(this,result) }
+  string getEncoding() { xmlEncoding(this, result) }
 
   /** The XML file itself. */
-  override
-  XMLFile getFile() { result = this }
+  override XMLFile getFile() { result = this }
 
   /** A top-most element in an XML file. */
   XMLElement getARootElement() { result = this.getAChild() }
 
   /** A DTD associated with this XML file. */
-  XMLDTD getADTD() { xmlDTDs(result,_,_,_,this) }
+  XMLDTD getADTD() { xmlDTDs(result, _, _, _, this) }
 }
 
 /** A "Document Type Definition" of an XML file. */
 class XMLDTD extends @xmldtd {
   /** The name of the root element of this DTD. */
-  string getRoot() { xmlDTDs(this,result,_,_,_) }
+  string getRoot() { xmlDTDs(this, result, _, _, _) }
 
   /** The public ID of this DTD. */
-  string getPublicId() { xmlDTDs(this,_,result,_,_) }
+  string getPublicId() { xmlDTDs(this, _, result, _, _) }
 
   /** The system ID of this DTD. */
-  string getSystemId() { xmlDTDs(this,_,_,result,_) }
+  string getSystemId() { xmlDTDs(this, _, _, result, _) }
 
   /** Whether this DTD is public. */
-  predicate isPublic() { not xmlDTDs(this,_,"",_,_) }
+  predicate isPublic() { not xmlDTDs(this, _, "", _, _) }
 
   /** The parent of this DTD. */
-  XMLParent getParent() { xmlDTDs(this,_,_,_,result) }
+  XMLParent getParent() { xmlDTDs(this, _, _, _, result) }
 
   /** A printable representation of this DTD. */
   string toString() {
-    (this.isPublic() and result = this.getRoot() + " PUBLIC '" +
-                                  this.getPublicId() + "' '" +
-                                  this.getSystemId() + "'") or
-    (not this.isPublic() and result = this.getRoot() +
-                                      " SYSTEM '" +
-                                      this.getSystemId() + "'")
+    this.isPublic() and
+    result = this.getRoot() + " PUBLIC '" + this.getPublicId() + "' '" + this.getSystemId() + "'"
+    or
+    not this.isPublic() and
+    result = this.getRoot() + " SYSTEM '" + this.getSystemId() + "'"
   }
 }
 
@@ -170,71 +163,61 @@ class XMLElement extends @xmlelement, XMLParent, XMLLocatable {
   predicate hasName(string name) { name = getName() }
 
   /** The name of this XML element. */
-  override
-  string getName() { xmlElements(this,result,_,_,_) }
+  override string getName() { xmlElements(this, result, _, _, _) }
 
   /** The XML file in which this XML element occurs. */
-  override
-  XMLFile getFile() { xmlElements(this,_,_,_,result) }
+  override XMLFile getFile() { xmlElements(this, _, _, _, result) }
 
   /** The parent of this XML element. */
-  XMLParent getParent() { xmlElements(this,_,result,_,_) }
+  XMLParent getParent() { xmlElements(this, _, result, _, _) }
 
   /** The index of this XML element among its parent's children. */
   int getIndex() { xmlElements(this, _, _, result, _) }
 
   /** Whether this XML element has a namespace. */
-  predicate hasNamespace() { xmlHasNs(this,_,_) }
+  predicate hasNamespace() { xmlHasNs(this, _, _) }
 
   /** The namespace of this XML element, if any. */
-  XMLNamespace getNamespace() { xmlHasNs(this,result,_) }
+  XMLNamespace getNamespace() { xmlHasNs(this, result, _) }
 
   /** The index of this XML element among its parent's children. */
-  int getElementPositionIndex() { xmlElements(this,_,_,result,_) }
+  int getElementPositionIndex() { xmlElements(this, _, _, result, _) }
 
   /** The depth of this element within the XML file tree structure. */
-  override
-  int getDepth() { result = this.getParent().getDepth() + 1 }
+  override int getDepth() { result = this.getParent().getDepth() + 1 }
 
   /** An XML attribute of this XML element. */
   XMLAttribute getAnAttribute() { result.getElement() = this }
 
   /** The attribute with the specified `name`, if any. */
-  XMLAttribute getAttribute(string name) {
-    result.getElement() = this and result.getName() = name
-  }
+  XMLAttribute getAttribute(string name) { result.getElement() = this and result.getName() = name }
 
   /** Whether this XML element has an attribute with the specified `name`. */
-  predicate hasAttribute(string name) {
-    exists(XMLAttribute a| a = this.getAttribute(name))
-  }
+  predicate hasAttribute(string name) { exists(XMLAttribute a | a = this.getAttribute(name)) }
 
   /** The value of the attribute with the specified `name`, if any. */
-  string getAttributeValue(string name) {
-    result = this.getAttribute(name).getValue()
-  }
+  string getAttributeValue(string name) { result = this.getAttribute(name).getValue() }
 
   /** A printable representation of this XML element. */
-  override
-  string toString() { result = XMLParent.super.toString() }
+  override string toString() { result = XMLParent.super.toString() }
 }
 
 /** An attribute that occurs inside an XML element. */
 class XMLAttribute extends @xmlattribute, XMLLocatable {
   /** The name of this attribute. */
-  string getName() { xmlAttrs(this,_,result,_,_,_) }
+  string getName() { xmlAttrs(this, _, result, _, _, _) }
 
   /** The XML element to which this attribute belongs. */
-  XMLElement getElement() { xmlAttrs(this,result,_,_,_,_) }
+  XMLElement getElement() { xmlAttrs(this, result, _, _, _, _) }
 
   /** Whether this attribute has a namespace. */
-  predicate hasNamespace() { xmlHasNs(this,_,_) }
+  predicate hasNamespace() { xmlHasNs(this, _, _) }
 
   /** The namespace of this attribute, if any. */
-  XMLNamespace getNamespace() { xmlHasNs(this,result,_) }
+  XMLNamespace getNamespace() { xmlHasNs(this, result, _) }
 
   /** The value of this attribute. */
-  string getValue() { xmlAttrs(this,_,_,result,_,_) }
+  string getValue() { xmlAttrs(this, _, _, result, _, _) }
 
   /** A printable representation of this XML attribute. */
   override string toString() { result = this.getName() + "=" + this.getValue() }
@@ -243,28 +226,29 @@ class XMLAttribute extends @xmlattribute, XMLLocatable {
 /** A namespace used in an XML file */
 class XMLNamespace extends @xmlnamespace {
   /** The prefix of this namespace. */
-  string getPrefix() { xmlNs(this,result,_,_) }
+  string getPrefix() { xmlNs(this, result, _, _) }
 
   /** The URI of this namespace. */
-  string getURI() { xmlNs(this,_,result,_) }
+  string getURI() { xmlNs(this, _, result, _) }
 
   /** Whether this namespace has no prefix. */
   predicate isDefault() { this.getPrefix() = "" }
 
   /** A printable representation of this XML namespace. */
   string toString() {
-    (this.isDefault() and result = this.getURI()) or
-    (not this.isDefault() and result = this.getPrefix() + ":" + this.getURI())
+    this.isDefault() and result = this.getURI()
+    or
+    not this.isDefault() and result = this.getPrefix() + ":" + this.getURI()
   }
 }
 
 /** A comment of the form `<!-- ... -->` is an XML comment. */
 class XMLComment extends @xmlcomment, XMLLocatable {
   /** The text content of this XML comment. */
-  string getText() { xmlComments(this,result,_,_) }
+  string getText() { xmlComments(this, result, _, _) }
 
   /** The parent of this XML comment. */
-  XMLParent getParent() { xmlComments(this,_,result,_) }
+  XMLParent getParent() { xmlComments(this, _, result, _) }
 
   /** A printable representation of this XML comment. */
   override string toString() { result = this.getText() }
@@ -276,13 +260,13 @@ class XMLComment extends @xmlcomment, XMLLocatable {
  */
 class XMLCharacters extends @xmlcharacters, XMLLocatable {
   /** The content of this character sequence. */
-  string getCharacters() { xmlChars(this,result,_,_,_,_) }
+  string getCharacters() { xmlChars(this, result, _, _, _, _) }
 
   /** The parent of this character sequence. */
-  XMLParent getParent() { xmlChars(this,_,result,_,_,_) }
+  XMLParent getParent() { xmlChars(this, _, result, _, _, _) }
 
   /** Whether this character sequence is CDATA. */
-  predicate isCDATA() { xmlChars(this,_,_,_,1,_) }
+  predicate isCDATA() { xmlChars(this, _, _, _, 1, _) }
 
   /** A printable representation of this XML character sequence. */
   override string toString() { result = this.getCharacters() }

--- a/python/ql/src/semmle/python/xml/XML.qll
+++ b/python/ql/src/semmle/python/xml/XML.qll
@@ -21,7 +21,7 @@ abstract class XMLLocatable extends @xmllocatable {
   ) {
     exists(File f, Location l | l = this.getLocation() |
       locations_default(l, f, startline, startcolumn, endline, endcolumn) and
-      filepath = f.getName()
+      filepath = f.getAbsolutePath()
     )
   }
 

--- a/python/ql/src/semmle/python/xml/XML.qll
+++ b/python/ql/src/semmle/python/xml/XML.qll
@@ -1,17 +1,20 @@
 /**
- * A library for working with XML files and their content.
+ * Provides classes and predicates for working with XML files and their content.
  */
 
 import semmle.files.FileSystem
 
 /** An XML element that has a location. */
 abstract class XMLLocatable extends @xmllocatable {
-  /** The source location for this element. */
+  /** Gets the source location for this element. */
   Location getLocation() { xmllocations(this, result) }
 
   /**
-   * Whether this element has the specified location information,
-   * including file path, start line, start column, end line and end column.
+   * Holds if this element is at the specified location.
+   * The location spans column `startcolumn` of line `startline` to
+   * column `endcolumn` of line `endline` in file `filepath`.
+   * For more information, see
+   * [Locations](https://help.semmle.com/QL/learn-ql/ql/locations.html).
    */
   predicate hasLocationInfo(
     string filepath, int startline, int startcolumn, int endline, int endcolumn
@@ -22,7 +25,7 @@ abstract class XMLLocatable extends @xmllocatable {
     )
   }
 
-  /** A printable representation of this element. */
+  /** Gets a textual representation of this element. */
   abstract string toString();
 }
 
@@ -38,36 +41,36 @@ class XMLParent extends @xmlparent {
   }
 
   /**
-   * A printable representation of this XML parent.
+   * Gets a printable representation of this XML parent.
    * (Intended to be overridden in subclasses.)
    */
   /*abstract*/ string getName() { result = "parent" }
 
-  /** The file to which this XML parent belongs. */
+  /** Gets the file to which this XML parent belongs. */
   XMLFile getFile() { result = this or xmlElements(this, _, _, _, result) }
 
-  /** The child element at a specified index of this XML parent. */
+  /** Gets the child element at a specified index of this XML parent. */
   XMLElement getChild(int index) { xmlElements(result, _, this, index, _) }
 
-  /** A child element of this XML parent. */
+  /** Gets a child element of this XML parent. */
   XMLElement getAChild() { xmlElements(result, _, this, _, _) }
 
-  /** A child element of this XML parent with the given `name`. */
+  /** Gets a child element of this XML parent with the given `name`. */
   XMLElement getAChild(string name) { xmlElements(result, _, this, _, _) and result.hasName(name) }
 
-  /** A comment that is a child of this XML parent. */
+  /** Gets a comment that is a child of this XML parent. */
   XMLComment getAComment() { xmlComments(result, _, this, _) }
 
-  /** A character sequence that is a child of this XML parent. */
+  /** Gets a character sequence that is a child of this XML parent. */
   XMLCharacters getACharactersSet() { xmlChars(result, _, this, _, _, _) }
 
-  /** The depth in the tree. (Overridden in XMLElement.) */
+  /** Gets the depth in the tree. (Overridden in XMLElement.) */
   int getDepth() { result = 0 }
 
-  /** The number of child XML elements of this XML parent. */
+  /** Gets the number of child XML elements of this XML parent. */
   int getNumberOfChildren() { result = count(XMLElement e | xmlElements(e, _, this, _, _)) }
 
-  /** The number of places in the body of this XML parent where text occurs. */
+  /** Gets the number of places in the body of this XML parent where text occurs. */
   int getNumberOfCharacterSets() { result = count(int pos | xmlChars(_, _, this, pos, _, _)) }
 
   /**
@@ -83,7 +86,10 @@ class XMLParent extends @xmlparent {
     )
   }
 
-  /** Append all the character sequences of this XML parent from left to right, separated by a space. */
+  /**
+   * Gets the result of appending all the character sequences of this XML parent from
+   * left to right, separated by a space.
+   */
   string allCharactersString() {
     exists(int n | n = this.getNumberOfCharacterSets() |
       n = 0 and result = ""
@@ -92,10 +98,10 @@ class XMLParent extends @xmlparent {
     )
   }
 
-  /** The text value contained in this XML parent. */
+  /** Gets the text value contained in this XML parent. */
   string getTextValue() { result = allCharactersString() }
 
-  /** A printable representation of this XML parent. */
+  /** Gets a printable representation of this XML parent. */
   string toString() { result = this.getName() }
 }
 
@@ -103,7 +109,7 @@ class XMLParent extends @xmlparent {
 class XMLFile extends XMLParent, File {
   XMLFile() { xmlEncoding(this, _) }
 
-  /** A printable representation of this XML file. */
+  /** Gets a printable representation of this XML file. */
   override string toString() { result = XMLParent.super.toString() }
 
   /** The name of this XML file. */
@@ -117,37 +123,47 @@ class XMLFile extends XMLParent, File {
     result = this.getPath().substring(0, this.getPath().length() - this.getName().length())
   }
 
-  /** The encoding of this XML file. */
+  /** Gets the encoding of this XML file. */
   string getEncoding() { xmlEncoding(this, result) }
 
-  /** The XML file itself. */
+  /** Gets the XML file itself. */
   override XMLFile getFile() { result = this }
 
-  /** A top-most element in an XML file. */
+  /** Gets a top-most element in an XML file. */
   XMLElement getARootElement() { result = this.getAChild() }
 
-  /** A DTD associated with this XML file. */
+  /** Gets a DTD associated with this XML file. */
   XMLDTD getADTD() { xmlDTDs(result, _, _, _, this) }
 }
 
-/** A "Document Type Definition" of an XML file. */
+/**
+ * An XML document type definition (DTD).
+ *
+ * Example:
+ *
+ * ```
+ * <!ELEMENT person (firstName, lastName?)>
+ * <!ELEMENT firstName (#PCDATA)>
+ * <!ELEMENT lastName (#PCDATA)>
+ * ```
+ */
 class XMLDTD extends @xmldtd {
-  /** The name of the root element of this DTD. */
+  /** Gets the name of the root element of this DTD. */
   string getRoot() { xmlDTDs(this, result, _, _, _) }
 
-  /** The public ID of this DTD. */
+  /** Gets the public ID of this DTD. */
   string getPublicId() { xmlDTDs(this, _, result, _, _) }
 
-  /** The system ID of this DTD. */
+  /** Gets the system ID of this DTD. */
   string getSystemId() { xmlDTDs(this, _, _, result, _) }
 
-  /** Whether this DTD is public. */
+  /** Holds if this DTD is public. */
   predicate isPublic() { not xmlDTDs(this, _, "", _, _) }
 
-  /** The parent of this DTD. */
+  /** Gets the parent of this DTD. */
   XMLParent getParent() { xmlDTDs(this, _, _, _, result) }
 
-  /** A printable representation of this DTD. */
+  /** Gets a printable representation of this DTD. */
   string toString() {
     this.isPublic() and
     result = this.getRoot() + " PUBLIC '" + this.getPublicId() + "' '" + this.getSystemId() + "'"
@@ -157,84 +173,111 @@ class XMLDTD extends @xmldtd {
   }
 }
 
-/** An XML tag in an XML file. */
+/**
+ * An XML element in an XML file.
+ *
+ * Example:
+ *
+ * ```
+ * <manifest xmlns:android="http://schemas.android.com/apk/res/android"
+ *           package="com.example.exampleapp" android:versionCode="1">
+ * </manifest>
+ * ```
+ */
 class XMLElement extends @xmlelement, XMLParent, XMLLocatable {
-  /** Whether this XML element has the given `name`. */
+  /** Holds if this XML element has the given `name`. */
   predicate hasName(string name) { name = getName() }
 
-  /** The name of this XML element. */
+  /** Gets the name of this XML element. */
   override string getName() { xmlElements(this, result, _, _, _) }
 
-  /** The XML file in which this XML element occurs. */
+  /** Gets the XML file in which this XML element occurs. */
   override XMLFile getFile() { xmlElements(this, _, _, _, result) }
 
-  /** The parent of this XML element. */
+  /** Gets the parent of this XML element. */
   XMLParent getParent() { xmlElements(this, _, result, _, _) }
 
-  /** The index of this XML element among its parent's children. */
+  /** Gets the index of this XML element among its parent's children. */
   int getIndex() { xmlElements(this, _, _, result, _) }
 
-  /** Whether this XML element has a namespace. */
+  /** Holds if this XML element has a namespace. */
   predicate hasNamespace() { xmlHasNs(this, _, _) }
 
-  /** The namespace of this XML element, if any. */
+  /** Gets the namespace of this XML element, if any. */
   XMLNamespace getNamespace() { xmlHasNs(this, result, _) }
 
-  /** The index of this XML element among its parent's children. */
+  /** Gets the index of this XML element among its parent's children. */
   int getElementPositionIndex() { xmlElements(this, _, _, result, _) }
 
-  /** The depth of this element within the XML file tree structure. */
+  /** Gets the depth of this element within the XML file tree structure. */
   override int getDepth() { result = this.getParent().getDepth() + 1 }
 
-  /** An XML attribute of this XML element. */
+  /** Gets an XML attribute of this XML element. */
   XMLAttribute getAnAttribute() { result.getElement() = this }
 
-  /** The attribute with the specified `name`, if any. */
+  /** Gets the attribute with the specified `name`, if any. */
   XMLAttribute getAttribute(string name) { result.getElement() = this and result.getName() = name }
 
-  /** Whether this XML element has an attribute with the specified `name`. */
+  /** Holds if this XML element has an attribute with the specified `name`. */
   predicate hasAttribute(string name) { exists(XMLAttribute a | a = this.getAttribute(name)) }
 
-  /** The value of the attribute with the specified `name`, if any. */
+  /** Gets the value of the attribute with the specified `name`, if any. */
   string getAttributeValue(string name) { result = this.getAttribute(name).getValue() }
 
-  /** A printable representation of this XML element. */
+  /** Gets a printable representation of this XML element. */
   override string toString() { result = XMLParent.super.toString() }
 }
 
-/** An attribute that occurs inside an XML element. */
+/**
+ * An attribute that occurs inside an XML element.
+ *
+ * Examples:
+ *
+ * ```
+ * package="com.example.exampleapp"
+ * android:versionCode="1"
+ * ```
+ */
 class XMLAttribute extends @xmlattribute, XMLLocatable {
-  /** The name of this attribute. */
+  /** Gets the name of this attribute. */
   string getName() { xmlAttrs(this, _, result, _, _, _) }
 
-  /** The XML element to which this attribute belongs. */
+  /** Gets the XML element to which this attribute belongs. */
   XMLElement getElement() { xmlAttrs(this, result, _, _, _, _) }
 
-  /** Whether this attribute has a namespace. */
+  /** Holds if this attribute has a namespace. */
   predicate hasNamespace() { xmlHasNs(this, _, _) }
 
-  /** The namespace of this attribute, if any. */
+  /** Gets the namespace of this attribute, if any. */
   XMLNamespace getNamespace() { xmlHasNs(this, result, _) }
 
-  /** The value of this attribute. */
+  /** Gets the value of this attribute. */
   string getValue() { xmlAttrs(this, _, _, result, _, _) }
 
-  /** A printable representation of this XML attribute. */
+  /** Gets a printable representation of this XML attribute. */
   override string toString() { result = this.getName() + "=" + this.getValue() }
 }
 
-/** A namespace used in an XML file */
+/**
+ * A namespace used in an XML file.
+ *
+ * Example:
+ *
+ * ```
+ * xmlns:android="http://schemas.android.com/apk/res/android"
+ * ```
+ */
 class XMLNamespace extends @xmlnamespace {
-  /** The prefix of this namespace. */
+  /** Gets the prefix of this namespace. */
   string getPrefix() { xmlNs(this, result, _, _) }
 
-  /** The URI of this namespace. */
+  /** Gets the URI of this namespace. */
   string getURI() { xmlNs(this, _, result, _) }
 
-  /** Whether this namespace has no prefix. */
+  /** Holds if this namespace has no prefix. */
   predicate isDefault() { this.getPrefix() = "" }
 
-  /** A printable representation of this XML namespace. */
+  /** Gets a printable representation of this XML namespace. */
   string toString() {
     this.isDefault() and result = this.getURI()
     or
@@ -242,32 +285,46 @@ class XMLNamespace extends @xmlnamespace {
   }
 }
 
-/** A comment of the form `<!-- ... -->` is an XML comment. */
+/**
+ * A comment in an XML file.
+ *
+ * Example:
+ *
+ * ```
+ * <!-- This is a comment. -->
+ * ```
+ */
 class XMLComment extends @xmlcomment, XMLLocatable {
-  /** The text content of this XML comment. */
+  /** Gets the text content of this XML comment. */
   string getText() { xmlComments(this, result, _, _) }
 
-  /** The parent of this XML comment. */
+  /** Gets the parent of this XML comment. */
   XMLParent getParent() { xmlComments(this, _, result, _) }
 
-  /** A printable representation of this XML comment. */
+  /** Gets a printable representation of this XML comment. */
   override string toString() { result = this.getText() }
 }
 
 /**
  * A sequence of characters that occurs between opening and
  * closing tags of an XML element, excluding other elements.
+ *
+ * Example:
+ *
+ * ```
+ * <content>This is a sequence of characters.</content>
+ * ```
  */
 class XMLCharacters extends @xmlcharacters, XMLLocatable {
-  /** The content of this character sequence. */
+  /** Gets the content of this character sequence. */
   string getCharacters() { xmlChars(this, result, _, _, _, _) }
 
-  /** The parent of this character sequence. */
+  /** Gets the parent of this character sequence. */
   XMLParent getParent() { xmlChars(this, _, result, _, _, _) }
 
-  /** Whether this character sequence is CDATA. */
+  /** Holds if this character sequence is CDATA. */
   predicate isCDATA() { xmlChars(this, _, _, _, 1, _) }
 
-  /** A printable representation of this XML character sequence. */
+  /** Gets a printable representation of this XML character sequence. */
   override string toString() { result = this.getCharacters() }
 }

--- a/python/ql/src/semmle/python/xml/XML.qll
+++ b/python/ql/src/semmle/python/xml/XML.qll
@@ -117,11 +117,19 @@ class XMLFile extends XMLParent, File {
   /** Gets the name of this XML file. */
   override string getName() { result = File.super.getAbsolutePath() }
 
-  /** Gets the path of this XML file. */
-  string getPath() { result = getAbsolutePath() }
+  /**
+   * DEPRECATED: Use `getAbsolutePath()` instead.
+   *
+   * Gets the path of this XML file.
+   */
+  deprecated string getPath() { result = getAbsolutePath() }
 
-  /** Gets the path of the folder that contains this XML file. */
-  string getFolder() { result = getParentContainer().getAbsolutePath() }
+  /**
+   * DEPRECATED: Use `getParentContainer().getAbsolutePath()` instead.
+   *
+   * Gets the path of the folder that contains this XML file.
+   */
+  deprecated string getFolder() { result = getParentContainer().getAbsolutePath() }
 
   /** Gets the encoding of this XML file. */
   string getEncoding() { xmlEncoding(this, result) }

--- a/python/ql/src/semmle/python/xml/XML.qll
+++ b/python/ql/src/semmle/python/xml/XML.qll
@@ -114,16 +114,14 @@ class XMLFile extends XMLParent, File {
   /** Gets a printable representation of this XML file. */
   override string toString() { result = XMLParent.super.toString() }
 
-  /** The name of this XML file. */
-  override string getName() { files(this, result, _, _, _) }
+  /** Gets the name of this XML file. */
+  override string getName() { result = File.super.getAbsolutePath() }
 
-  /** The path of this XML file. */
-  string getPath() { files(this, _, result, _, _) }
+  /** Gets the path of this XML file. */
+  string getPath() { result = getAbsolutePath() }
 
-  /** The path of the folder that contains this XML file. */
-  string getFolder() {
-    result = this.getPath().substring(0, this.getPath().length() - this.getName().length())
-  }
+  /** Gets the path of the folder that contains this XML file. */
+  string getFolder() { result = getParentContainer().getAbsolutePath() }
 
   /** Gets the encoding of this XML file. */
   string getEncoding() { xmlEncoding(this, result) }

--- a/python/ql/src/semmle/python/xml/XML.qll
+++ b/python/ql/src/semmle/python/xml/XML.qll
@@ -74,10 +74,12 @@ class XMLParent extends @xmlparent {
   int getNumberOfCharacterSets() { result = count(int pos | xmlChars(_, _, this, pos, _, _)) }
 
   /**
+   * DEPRECATED: Internal.
+   *
    * Append the character sequences of this XML parent from left to right, separated by a space,
    * up to a specified (zero-based) index.
    */
-  string charsSetUpTo(int n) {
+  deprecated string charsSetUpTo(int n) {
     n = 0 and xmlChars(_, result, this, 0, _, _)
     or
     n > 0 and
@@ -91,11 +93,11 @@ class XMLParent extends @xmlparent {
    * left to right, separated by a space.
    */
   string allCharactersString() {
-    exists(int n | n = this.getNumberOfCharacterSets() |
-      n = 0 and result = ""
-      or
-      n > 0 and result = this.charsSetUpTo(n - 1)
-    )
+    result = concat(string chars, int pos |
+        xmlChars(_, chars, this, pos, _, _)
+      |
+        chars, " " order by pos
+      )
   }
 
   /** Gets the text value contained in this XML parent. */

--- a/python/ql/src/semmle/python/xml/XML.qll
+++ b/python/ql/src/semmle/python/xml/XML.qll
@@ -2,7 +2,7 @@
  * A library for working with XML files and their content.
  */
 
-import semmle.python.Files
+import semmle.files.FileSystem
 
 /** An XML element that has a location. */
 abstract class XMLLocatable extends @xmllocatable {

--- a/python/ql/src/semmle/python/xml/XML.qll
+++ b/python/ql/src/semmle/python/xml/XML.qll
@@ -44,7 +44,7 @@ class XMLParent extends @xmlparent {
    * Gets a printable representation of this XML parent.
    * (Intended to be overridden in subclasses.)
    */
-  /*abstract*/ string getName() { result = "parent" }
+  abstract string getName();
 
   /** Gets the file to which this XML parent belongs. */
   XMLFile getFile() { result = this or xmlElements(this, _, _, _, result) }


### PR DESCRIPTION
This PR tweaks the XML.qll libraries of these four languages to become identical, and adds them to `config/identical-files.json` so we can keep them consistent going forward.

C# isn't currently part of the mix, since it has a few minor API differences. I hope we can work around those, but that's for a separate PR.

I'd appreciate reviews from each of the language teams on the commits concerning their language.

In particular, I'd like C++ eyes on https://github.com/Semmle/ql/commit/bccdf5963109210ded41b3851481c6f042e06951, which was the only real difference I could see among the four copies of the XML library.

Python and C++ provide predicates `XMLFile.getPath` and `XMLFile.getFolder` that don't exist in the other languages. As explained in https://github.com/Semmle/ql/commit/47c1fc735888eb5b43a4d83e9a20838b50fe9d33, their current implementation is broken. I have fixed them, but then deprecated them since there are perfectly good alternatives available. To ensure consistency, I have added the predicates to Java and JavaScript as well. Alternatively, we could just drop them, though technically that would be an API change.