### PR TITLE
C++: Sort through the leap year and japanese era queries

### DIFF
--- a/change-notes/1.24/analysis-cpp.md
+++ b/change-notes/1.24/analysis-cpp.md
@@ -15,6 +15,7 @@ The following changes in version 1.24 affect C/C++ analysis in all applications.
 |----------------------------|------------------------|------------------------------------------------------------------|
 | Hard-coded Japanese era start date (`cpp/japanese-era/exact-era-date`) |  | This query is no longer run on LGTM. |
 | No space for zero terminator (`cpp/no-space-for-terminator`) | Fewer false positive results | This query has been modified to be more conservative when identifying which pointers point to null-terminated strings.  This approach produces fewer, more accurate results. |
+| Unsafe array for days of the year (`cpp/leap-year/unsafe-array-for-days-of-the-year`) |  | This query is no longer run on LGTM. |
 
 ## Changes to libraries
 

--- a/cpp/ql/src/Best Practices/Magic Constants/JapaneseEraDate.ql
+++ b/cpp/ql/src/Best Practices/Magic Constants/JapaneseEraDate.ql
@@ -5,7 +5,8 @@
  * @problem.severity warning
  * @id cpp/japanese-era/exact-era-date
  * @precision low
- * @tags reliability
+ * @tags maintainability
+ *       reliability
  *       japanese-era
  */
 

--- a/cpp/ql/src/Likely Bugs/Leap Year/Adding365DaysPerYear.ql
+++ b/cpp/ql/src/Likely Bugs/Leap Year/Adding365DaysPerYear.ql
@@ -8,6 +8,7 @@
  * @id cpp/leap-year/adding-365-days-per-year
  * @precision medium
  * @tags leap-year
+ *       correctness
  */
 
 import cpp

--- a/cpp/ql/src/Likely Bugs/Leap Year/UncheckedLeapYearAfterYearModification.ql
+++ b/cpp/ql/src/Likely Bugs/Leap Year/UncheckedLeapYearAfterYearModification.ql
@@ -6,6 +6,7 @@
  * @id cpp/leap-year/unchecked-after-arithmetic-year-modification
  * @precision medium
  * @tags leap-year
+ *       correctness
  */
 
 import cpp

--- a/cpp/ql/src/Likely Bugs/Leap Year/UncheckedReturnValueForTimeFunctions.ql
+++ b/cpp/ql/src/Likely Bugs/Leap Year/UncheckedReturnValueForTimeFunctions.ql
@@ -8,6 +8,7 @@
  * @id cpp/leap-year/unchecked-return-value-for-time-conversion-function
  * @precision medium
  * @tags leap-year
+ *       correctness
  */
 
 import cpp

--- a/cpp/ql/src/Likely Bugs/Leap Year/UnsafeArrayForDaysOfYear.ql
+++ b/cpp/ql/src/Likely Bugs/Leap Year/UnsafeArrayForDaysOfYear.ql
@@ -5,7 +5,7 @@
  * @kind problem
  * @problem.severity warning
  * @id cpp/leap-year/unsafe-array-for-days-of-the-year
- * @precision medium
+ * @precision low
  * @tags security
  *       leap-year
  */

--- a/cpp/ql/src/semmle/code/cpp/commons/DateTime.qll
+++ b/cpp/ql/src/semmle/code/cpp/commons/DateTime.qll
@@ -10,22 +10,23 @@ import cpp
 class PackedTimeType extends Type {
   PackedTimeType() {
     this.getName() = "_FILETIME" or
-    this.getName().matches("_FILETIME %")
+    this.(DerivedType).getBaseType*().getName() = "_FILETIME"
   }
 }
 
+private predicate timeType(string typeName) {
+  typeName = "_SYSTEMTIME" or
+  typeName = "SYSTEMTIME" or
+  typeName = "tm"
+}
 /**
  * A type that is used to represent times and dates in an 'unpacked' form, that is,
  * with separate fields for day, month, year etc.
  */
 class UnpackedTimeType extends Type {
   UnpackedTimeType() {
-    this.getName() = "_SYSTEMTIME" or
-    this.getName() = "SYSTEMTIME" or
-    this.getName() = "tm" or
-    this.getName().matches("_SYSTEMTIME %") or
-    this.getName().matches("SYSTEMTIME %") or
-    this.getName().matches("tm %")
+    timeType(this.getName()) or
+    timeType(this.(DerivedType).getBaseType*().getName())
   }
 }
 

--- a/cpp/ql/src/semmle/code/cpp/commons/DateTime.qll
+++ b/cpp/ql/src/semmle/code/cpp/commons/DateTime.qll
@@ -19,6 +19,7 @@ private predicate timeType(string typeName) {
   typeName = "SYSTEMTIME" or
   typeName = "tm"
 }
+
 /**
  * A type that is used to represent times and dates in an 'unpacked' form, that is,
  * with separate fields for day, month, year etc.


### PR DESCRIPTION
I've reviewed the results of the leap year + japanese era dates queries, which are currently run but not displayed by default on LGTM.  I've also done a bit of cleanup and tagging.

Adding365DaysPerYear.ql (https://lgtm.com/rules/1509196026030/alerts/)
 - some good results
 - some of the results don't even seem to contain the number 365; this query either needs path explanations so we can see what's going on, or (more likely?) restricting to local dataflow.

I think we can make the results better, but it will require some work/iteration (which is probably not a priority).  Should we drop it off LGTM or leave it running/hidden with the intent to come back to this in February perhaps?

UncheckedLeapYearAfterYearModification.ql (https://lgtm.com/rules/1509209928660/alerts/)
 - many of the results of this query look good at a glance
 - false positive where the year is being encoded differently, rather than modified
 - false positive where the month and day are set immediately afterwards, rather than checking
   for leap year
 - adding 100 is common (when the century is being assumed); I'm not sure whether or not these cases are problematic

We can definitely make the results better, but I think there will always be quite a number of false positives for this one.  I'm inclined to drop it off LGTM rather than leaving it running/hidden for the forseeable future but I'd like a second opinion.

UncheckedReturnValueForTimeFunctions.ql (https://lgtm.com/rules/1509204275387/alerts/)
 - only three results, but I think they're good
 - I think all of the functions this checks are Windows specific, so perhaps we shouldn't expect to see huge numbers of results for it on LGTM

What do we think about promoting this from warning-medium to warning-high, so that it's displayed by default?

UnsafeArrayForDaysOfYear.ql (https://lgtm.com/rules/1509186658915/alerts/)
 - many of these results are not reported at a sensible/useful location
 - some of the results appear to be coincidental?
 - very disappointing

Demoted from warning-medium to warning-low; will no longer be computed for LGTM

JapaneseEraDate.ql (https://lgtm.com/rules/1510017876327/alerts/)

This was already demoted from warning-medium to warning-low recently in https://github.com/Semmle/ql/pull/2528, because there are only three results and they're all bad.