### PR TITLE
Python: Fix several bad join orders.

### DIFF
--- a/python/ql/src/semmle/python/essa/Essa.qll
+++ b/python/ql/src/semmle/python/essa/Essa.qll
@@ -50,8 +50,16 @@ class EssaVariable extends TEssaDefinition {
      * Note that this differs from `EssaVariable.getAUse()`.
      */
     ControlFlowNode getASourceUse() {
+        exists(SsaSourceVariable var |
+            result = use_for_var(var) and
+            result = var.getASourceUse()
+        )
+    }
+
+    pragma[nomagic]
+    private ControlFlowNode use_for_var(SsaSourceVariable var) {
         result = this.getAUse() and
-        result = this.getSourceVariable().getASourceUse()
+        var = this.getSourceVariable()
     }
 
     /** Gets the scope of this variable. */
@@ -268,11 +276,16 @@ class PhiFunction extends EssaDefinition, TPhiFunction {
         not exists(this.inputEdgeRefinement(result))
     }
 
+    pragma[noinline]
+    private SsaSourceVariable pred_var(BasicBlock pred) {
+        result = this.getSourceVariable() and
+        pred = this.nonPiInput()
+    }
+
     /** Gets another definition of the same source variable that reaches this definition. */
     private EssaDefinition reachingDefinition(BasicBlock pred) {
         result.getScope() = this.getScope() and
-        result.getSourceVariable() = this.getSourceVariable() and
-        pred = this.nonPiInput() and
+        result.getSourceVariable() = pred_var(pred) and
         result.reachesEndOfBlock(pred)
     }
 


### PR DESCRIPTION
Performance on `taers232c/GAMADV-X` (which exhibited pathological behaviour in
the most recent dist upgrade) went from ~670s to ~313s on
`py/hardcoded-credentials`.

There are still a few tuple counts in the 10-100 million range, but this commit
takes care of all of the ones that numbered in the billions. (A single tuple
count in the 100-1000 million range remains, but it appears to be less critical,
taking only two seconds to calculate.)