### PR TITLE
Add io.netty.handler.codec.http.DefaultHttpResponse to Netty Response Splitting Detection

### DIFF
--- a/java/ql/src/Security/CWE/CWE-113/NettyResponseSplitting.java
+++ b/java/ql/src/Security/CWE/CWE-113/NettyResponseSplitting.java
@@ -5,5 +5,11 @@ public class ResponseSplitting {
     private final DefaultHttpHeaders badHeaders = new DefaultHttpHeaders(false);
 
     // GOOD: Verifies headers passed don't contain CRLF characters
-    private final DefaultHttpHeaders badHeaders = new DefaultHttpHeaders();
+    private final DefaultHttpHeaders goodHeaders = new DefaultHttpHeaders();
+
+    // BAD: Disables the internal response splitting verification
+    private final DefaultHttpResponse badResponse = new DefaultHttpResponse(version, httpResponseStatus, false);
+
+    // GOOD: Verifies headers passed don't contain CRLF characters
+    private final DefaultHttpResponse goodResponse = new DefaultHttpResponse(version, httpResponseStatus);
 }

--- a/java/ql/src/Security/CWE/CWE-113/NettyResponseSplitting.ql
+++ b/java/ql/src/Security/CWE/CWE-113/NettyResponseSplitting.ql
@@ -13,8 +13,21 @@
 
 import java
 
-from ClassInstanceExpr new
-where
-  new.getConstructedType().hasQualifiedName("io.netty.handler.codec.http", "DefaultHttpHeaders") and
-  new.getArgument(0).getProperExpr().(BooleanLiteral).getBooleanValue() = false
-select new, "Response-splitting vulnerability due to verification being disabled."
+abstract private class InsecureNettyObjectCreation extends ClassInstanceExpr { }
+
+private class InsecureDefaultHttpHeadersClassInstantiation extends InsecureNettyObjectCreation {
+  InsecureDefaultHttpHeadersClassInstantiation() {
+    getConstructedType().hasQualifiedName("io.netty.handler.codec.http", "DefaultHttpHeaders") and
+    getArgument(0).getProperExpr().(BooleanLiteral).getBooleanValue() = false
+  }
+}
+
+private class InsecureDefaultHttpResponseClassInstantiation extends InsecureNettyObjectCreation {
+  InsecureDefaultHttpResponseClassInstantiation() {
+    getConstructedType().hasQualifiedName("io.netty.handler.codec.http", "DefaultHttpResponse") and
+    getArgument(2).getProperExpr().(BooleanLiteral).getBooleanValue() = false
+  }
+}
+
+from InsecureNettyObjectCreation new
+select new, "Response-splitting vulnerability due to header value verification being disabled."

--- a/java/ql/src/Security/CWE/CWE-113/NettyResponseSplitting.ql
+++ b/java/ql/src/Security/CWE/CWE-113/NettyResponseSplitting.ql
@@ -18,14 +18,14 @@ abstract private class InsecureNettyObjectCreation extends ClassInstanceExpr { }
 private class InsecureDefaultHttpHeadersClassInstantiation extends InsecureNettyObjectCreation {
   InsecureDefaultHttpHeadersClassInstantiation() {
     getConstructedType().hasQualifiedName("io.netty.handler.codec.http", "DefaultHttpHeaders") and
-    getArgument(0).getProperExpr().(BooleanLiteral).getBooleanValue() = false
+    getArgument(0).(CompileTimeConstantExpr).getBooleanValue() = false
   }
 }
 
 private class InsecureDefaultHttpResponseClassInstantiation extends InsecureNettyObjectCreation {
   InsecureDefaultHttpResponseClassInstantiation() {
     getConstructedType().hasQualifiedName("io.netty.handler.codec.http", "DefaultHttpResponse") and
-    getArgument(2).getProperExpr().(BooleanLiteral).getBooleanValue() = false
+    getArgument(2).(CompileTimeConstantExpr).getBooleanValue() = false
   }
 }
 


### PR DESCRIPTION
Related: #2185
Related: https://github.com/github/security-lab/issues/22