### PR TITLE
JS: add support for import.meta expressions in JavaScript

### DIFF
--- a/change-notes/1.24/analysis-javascript.md
+++ b/change-notes/1.24/analysis-javascript.md
@@ -27,4 +27,4 @@
 ## Changes to libraries
 
 * The predicates `RegExpTerm.getSuccessor` and `RegExpTerm.getPredecessor` have been changed to reflect textual, not operational, matching order. This only makes a difference in lookbehind assertions, which are operationally matched backwards. Previously, `getSuccessor` would mimick this, so in an assertion `(?<=ab)` the term `b` would be considered the predecessor, not the successor, of `a`. Textually, however, `a` is still matched before `b`, and this is the order we now follow.
-
+* `import.meta` expressions no longer result in a syntax error in JavaScript files.

--- a/change-notes/1.24/analysis-javascript.md
+++ b/change-notes/1.24/analysis-javascript.md
@@ -27,4 +27,3 @@
 ## Changes to libraries
 
 * The predicates `RegExpTerm.getSuccessor` and `RegExpTerm.getPredecessor` have been changed to reflect textual, not operational, matching order. This only makes a difference in lookbehind assertions, which are operationally matched backwards. Previously, `getSuccessor` would mimick this, so in an assertion `(?<=ab)` the term `b` would be considered the predecessor, not the successor, of `a`. Textually, however, `a` is still matched before `b`, and this is the order we now follow.
-* `import.meta` expressions no longer result in a syntax error in JavaScript files.

--- a/change-notes/1.24/extractor-javascript.md
+++ b/change-notes/1.24/extractor-javascript.md
@@ -1,0 +1,7 @@
+[[ condition: enterprise-only ]]
+
+# Improvements to JavaScript analysis
+
+## Changes to code extraction
+
+* `import.meta` expressions no longer result in a syntax error in JavaScript files.

--- a/javascript/extractor/src/com/semmle/jcorn/ESNextParser.java
+++ b/javascript/extractor/src/com/semmle/jcorn/ESNextParser.java
@@ -240,6 +240,9 @@ public class ESNextParser extends JSXParser {
     if (this.type == TokenType._import) {
       Position startLoc = this.startLoc;
       this.next();
+      if (this.type == TokenType.dot) {
+        return parseImportMeta(startLoc);
+      }
       this.expect(TokenType.parenL);
       return parseDynamicImport(startLoc);
     }
@@ -411,6 +414,20 @@ public class ESNextParser extends JSXParser {
     } else {
       return super.parseImportRest(loc);
     }
+  }
+
+  /**
+   * Parses an import.meta expression, assuming that the initial "import" has been consumed.
+   */
+  private MetaProperty parseImportMeta(Position loc) {
+    Identifier meta = new Identifier(new SourceLocation(loc), "import");
+    this.next();
+    Position propertyLoc = this.startLoc;
+    Identifier property = this.parseIdent(true);
+    if (!property.getName().equals("meta")) {
+      this.unexpected(propertyLoc);
+    }
+    return this.finishNode(new MetaProperty(new SourceLocation(loc), meta, property));
   }
 
   /**

--- a/javascript/extractor/src/com/semmle/jcorn/ESNextParser.java
+++ b/javascript/extractor/src/com/semmle/jcorn/ESNextParser.java
@@ -420,13 +420,13 @@ public class ESNextParser extends JSXParser {
    * Parses an import.meta expression, assuming that the initial "import" and "." has been consumed.
    */
   private MetaProperty parseImportMeta(Position loc) {
-    Identifier importIdentifier = new Identifier(new SourceLocation(loc), "import");
     Position propertyLoc = this.startLoc;
     Identifier property = this.parseIdent(true);
     if (!property.getName().equals("meta")) {
       this.unexpected(propertyLoc);
     }
-    return this.finishNode(new MetaProperty(new SourceLocation(loc), importIdentifier, property));
+    return this.finishNode(
+      new MetaProperty(new SourceLocation(loc), new Identifier(new SourceLocation(loc), "import"), property));
   }
 
   /**

--- a/javascript/extractor/src/com/semmle/jcorn/ESNextParser.java
+++ b/javascript/extractor/src/com/semmle/jcorn/ESNextParser.java
@@ -240,7 +240,7 @@ public class ESNextParser extends JSXParser {
     if (this.type == TokenType._import) {
       Position startLoc = this.startLoc;
       this.next();
-      if (this.type == TokenType.dot) {
+      if (this.eat(TokenType.dot)) {
         return parseImportMeta(startLoc);
       }
       this.expect(TokenType.parenL);
@@ -417,17 +417,16 @@ public class ESNextParser extends JSXParser {
   }
 
   /**
-   * Parses an import.meta expression, assuming that the initial "import" has been consumed.
+   * Parses an import.meta expression, assuming that the initial "import" and "." has been consumed.
    */
   private MetaProperty parseImportMeta(Position loc) {
-    Identifier meta = new Identifier(new SourceLocation(loc), "import");
-    this.next();
+    Identifier importIdentifier = new Identifier(new SourceLocation(loc), "import");
     Position propertyLoc = this.startLoc;
     Identifier property = this.parseIdent(true);
     if (!property.getName().equals("meta")) {
       this.unexpected(propertyLoc);
     }
-    return this.finishNode(new MetaProperty(new SourceLocation(loc), meta, property));
+    return this.finishNode(new MetaProperty(new SourceLocation(loc), importIdentifier, property));
   }
 
   /**

--- a/javascript/extractor/src/com/semmle/js/ast/MetaProperty.java
+++ b/javascript/extractor/src/com/semmle/js/ast/MetaProperty.java
@@ -3,8 +3,8 @@ package com.semmle.js.ast;
 /**
  * A meta property access (cf. ECMAScript 2015 Language Specification, Chapter 12.3.8).
  *
- * <p>Currently the only recognised meta properties are <code>new.target</code> and <code>
- * function.sent</code>.
+ * <p>Currently the only recognised meta properties are <code>new.target</code>, 
+ * <code>import.meta</code> and <code> function.sent</code>.
  */
 public class MetaProperty extends Expression {
   private final Identifier meta, property;

--- a/javascript/ql/test/library-tests/Modules/ImportMeta.qll
+++ b/javascript/ql/test/library-tests/Modules/ImportMeta.qll
@@ -1,0 +1,5 @@
+import semmle.javascript.ES2015Modules
+
+query predicate test_ImportMetaExpr(ImportMetaExpr meta) {
+  any()
+}

--- a/javascript/ql/test/library-tests/Modules/importmeta.js
+++ b/javascript/ql/test/library-tests/Modules/importmeta.js
@@ -1,0 +1,1 @@
+var foo = new URL('../cli.svg', import.meta.url).pathname;

--- a/javascript/ql/test/library-tests/Modules/tests.expected
+++ b/javascript/ql/test/library-tests/Modules/tests.expected
@@ -26,6 +26,8 @@ test_getExportedName
 | m/c.js:5:10:5:15 | g as h | g |
 test_OtherImports
 | es2015_require.js:1:11:1:24 | require('./d') | d.js:1:1:5:0 | <toplevel> |
+test_ImportMetaExpr
+| importmeta.js:1:33:1:43 | import.meta |
 test_ReExportDeclarations
 | b.js:7:1:7:21 | export  ...  './a'; | b.js:7:16:7:20 | './a' |
 | d.js:4:1:4:20 | export * from 'm/c'; | d.js:4:15:4:19 | 'm/c' |
@@ -102,6 +104,7 @@ test_NamedImportSpecifier
 test_GlobalVariableRef
 | a.js:5:31:5:31 | o |
 | exports.js:3:9:3:15 | exports |
+| importmeta.js:1:15:1:17 | URL |
 | tst.html:6:3:6:7 | alert |
 test_BulkReExportDeclarations
 | d.js:4:1:4:20 | export * from 'm/c'; |

--- a/javascript/ql/test/library-tests/Modules/tests.ql
+++ b/javascript/ql/test/library-tests/Modules/tests.ql
@@ -2,6 +2,7 @@ import ImportSpecifiers
 import getLocalName
 import getExportedName
 import OtherImports
+import ImportMeta
 import ReExportDeclarations
 import ImportDefaultSpecifiers
 import getImportedName


### PR DESCRIPTION
My [earlier pull request](https://github.com/Semmle/ql/pull/2169) added support for `import.meta` expressions in TypeScript, but we never got around to supporting `import.meta` JavaScript. 

This PR adds support for `import.meta` in JavaScript, and fixes the syntax errors mentioned in [this issue](https://github.com/Semmle/ql/issues/2158). 

No db upgrade is required, as the previous TypeScript PR already added most of the required code. 