### PR TITLE
JS: remove FP from js/regexpinjection where no regexp was constructed

### DIFF
--- a/javascript/ql/src/semmle/javascript/Regexp.qll
+++ b/javascript/ql/src/semmle/javascript/Regexp.qll
@@ -810,7 +810,8 @@ predicate isInterpretedAsRegExp(DataFlow::Node source) {
     // The argument of a call that coerces the argument to a regular expression.
     exists(MethodCallExpr mce, string methodName |
       mce.getReceiver().analyze().getAType() = TTString() and
-      mce.getMethodName() = methodName
+      mce.getMethodName() = methodName and
+      not exists(DataFlow::FunctionNode func | func = DataFlow::valueNode(mce.getCallee()).getAFunctionValue() | not func.getFunction().inExternsFile())
     |
       methodName = "match" and source.asExpr() = mce.getArgument(0) and mce.getNumArgument() = 1
       or

--- a/javascript/ql/src/semmle/javascript/Regexp.qll
+++ b/javascript/ql/src/semmle/javascript/Regexp.qll
@@ -818,23 +818,23 @@ predicate isInterpretedAsRegExp(DataFlow::Node source) {
     source = DataFlow::globalVarRef("RegExp").getAnInvocation().getArgument(0)
     or
     // The argument of a call that coerces the argument to a regular expression.
-    exists(MethodCallExpr mce, string methodName |
+    exists(DataFlow::MethodCallNode mce, string methodName |
       mce.getReceiver().analyze().getAType() = TTString() and
       mce.getMethodName() = methodName and
       not exists(Function func |
-        func = any(DataFlow::MethodCallNode call | call.getEnclosingExpr() = mce).getACallee()
+        func = mce.getACallee()
       |
         not isNativeStringMethod(func, methodName)
       )
     |
-      methodName = "match" and source.asExpr() = mce.getArgument(0) and mce.getNumArgument() = 1
+      methodName = "match" and source = mce.getArgument(0) and mce.getNumArgument() = 1
       or
       methodName = "search" and
-      source.asExpr() = mce.getArgument(0) and
+      source = mce.getArgument(0) and
       mce.getNumArgument() = 1 and
       // "search" is a common method name, and so we exclude chained accesses
       // because `String.prototype.search` returns a number
-      not exists(PropAccess p | p.getBase() = mce)
+      not exists(PropAccess p | p.getBase() = mce.getEnclosingExpr())
     )
   )
 }

--- a/javascript/ql/test/query-tests/Security/CWE-730/RegExpInjection.js
+++ b/javascript/ql/test/query-tests/Security/CWE-730/RegExpInjection.js
@@ -50,4 +50,13 @@ app.get('/findKey', function(req, res) {
   URI(`${protocol}://${host}${path}`).search(input); // OK, but still flagged
   URI(`${protocol}://${host}${path}`).search(input).href(); // OK
   unknown.search(input).unknown; // OK
+
+});
+
+import * as Search from './search';
+
+app.get('/findKey', function(req, res) {
+  var key = req.param("key"), input = req.param("input");
+
+  Search.search(input); // OK!
 });

--- a/javascript/ql/test/query-tests/Security/CWE-730/search.js
+++ b/javascript/ql/test/query-tests/Security/CWE-730/search.js
@@ -1,0 +1,6 @@
+module.someOtherExport = true;
+
+
+export function search(query) {
+	// Do nothing!
+}


### PR DESCRIPTION
Fixes this FP: https://gist.github.com/esbena/9906d698fe8b8e0bc53128af36e01c5f#file-changes-results-unclassified_added-md-L5076

The FP happened because our heuristic for `isInterpretedAsRegExp` was a little to broad.  
`Search.search(..)` does not interpret its arguments as RegExp. 
`isInterpretedAsRegExp` flagged `Search.search(..)` because the method was called `search`, and `Search` could maybe be a string because `Search` is a global variable. 

My proposed fix is to check whether there exists a callee that is a non-extern function.  
Because if such a function exists, then it's likely not a call to a native API, which is what the heuristic is looking for.  

[An evaluation on our  `defaults.slugs` show no change in results, except for the FP mentioned](https://git.semmle.com/erik/dist-compare-reports/tree/profiling-js-max.northeurope.cloudapp.azure.com_1576604917204).  
And performance also seems OK. 

[I did a re-run of the slowest benchmarks (gecko-dev in particular)](https://git.semmle.com/erik/dist-compare-reports/tree/profiling-js-max.northeurope.cloudapp.azure.com_1576687364729). And it seems the performance slowdowns in the first run was just a fluke. 