### PR TITLE
C# extractor: Catch exceptions when generating trap

### DIFF
--- a/csharp/extractor/Semmle.Extraction.CIL/Factories.cs
+++ b/csharp/extractor/Semmle.Extraction.CIL/Factories.cs
@@ -28,7 +28,7 @@ namespace Semmle.Extraction.CIL
             else
             {
                 e.Label = cx.GetNewLabel();
-                cx.DefineLabel(e, cx.TrapWriter.Writer);
+                cx.DefineLabel(e, cx.TrapWriter.Writer, cx.Extractor);
                 ids.Add(e, e.Label);
                 cx.PopulateLater(() =>
                 {
@@ -76,7 +76,7 @@ namespace Semmle.Extraction.CIL
             {
                 e = new PrimitiveType(this, code);
                 e.Label = cx.GetNewLabel();
-                cx.DefineLabel(e, cx.TrapWriter.Writer);
+                cx.DefineLabel(e, cx.TrapWriter.Writer, cx.Extractor);
                 primitiveTypes[(int)code] = e;
             }
 

--- a/csharp/extractor/Semmle.Extraction/Context.cs
+++ b/csharp/extractor/Semmle.Extraction/Context.cs
@@ -57,19 +57,19 @@ namespace Semmle.Extraction
         // A recursion guard against writing to the trap file whilst writing an id to the trap file.
         bool WritingLabel = false;
 
-        public void DefineLabel(IEntity entity, TextWriter trapFile)
+        public void DefineLabel(IEntity entity, TextWriter trapFile, IExtractor extractor)
         {
             if (WritingLabel)
             {
                 // Don't define a label whilst writing a label.
-                PopulateLater(() => DefineLabel(entity, trapFile));
+                PopulateLater(() => DefineLabel(entity, trapFile, extractor));
             }
             else
             {
                 try
                 {
                     WritingLabel = true;
-                    entity.DefineLabel(trapFile);
+                    entity.DefineLabel(trapFile, extractor);
                 }
                 finally
                 {
@@ -102,7 +102,7 @@ namespace Semmle.Extraction
                     entity.Label = label;
                     entityLabelCache[entity] = label;
 
-                    DefineLabel(entity, TrapWriter.Writer);
+                    DefineLabel(entity, TrapWriter.Writer, Extractor);
 
                     if (entity.NeedsPopulation)
                         Populate(init as ISymbol, entity);
@@ -148,7 +148,7 @@ namespace Semmle.Extraction
 
                 objectEntityCache[init] = entity;
 
-                DefineLabel(entity, TrapWriter.Writer);
+                DefineLabel(entity, TrapWriter.Writer, Extractor);
                 if (entity.NeedsPopulation)
                     Populate(init as ISymbol, entity);
 

--- a/csharp/extractor/Semmle.Extraction/Entity.cs
+++ b/csharp/extractor/Semmle.Extraction/Entity.cs
@@ -1,4 +1,5 @@
 using Microsoft.CodeAnalysis;
+using System;
 using System.IO;
 
 namespace Semmle.Extraction
@@ -141,11 +142,19 @@ namespace Semmle.Extraction
         public static Entity CreateEntity2<Type, Entity>(this ICachedEntityFactory<Type, Entity> factory, Context cx, Type init)
             where Entity : ICachedEntity => cx.CreateEntity2(factory, init);
 
-        public static void DefineLabel(this IEntity entity, TextWriter trapFile)
+        public static void DefineLabel(this IEntity entity, TextWriter trapFile, IExtractor extractor)
         {
             trapFile.WriteLabel(entity);
             trapFile.Write("=");
-            entity.WriteQuotedId(trapFile);
+            try
+            {
+                entity.WriteQuotedId(trapFile);
+            }
+            catch(Exception ex)  // lgtm[cs/catch-of-all-exceptions]
+            {
+                trapFile.WriteLine("\"");
+                extractor.Message(new Message("Unhandled exception generating id", entity.ToString(), null, ex.StackTrace.ToString()));
+            }
             trapFile.WriteLine();
         }
 

--- a/csharp/extractor/Semmle.Extraction/TrapExtensions.cs
+++ b/csharp/extractor/Semmle.Extraction/TrapExtensions.cs
@@ -19,6 +19,12 @@ namespace Semmle.Extraction
 
         public static void WriteSubId(this TextWriter trapFile, IEntity entity)
         {
+            if (entity is null)
+            {
+                trapFile.Write("<null>");
+                return;
+            }
+
             trapFile.Write('{');
             trapFile.WriteLabel(entity);
             trapFile.Write('}');


### PR DESCRIPTION
Add more exception handling when generating trap-ids, as this can corrupt the trap file.

Also write `<null>` for a sub-id, in case it is passed a null value.
