### PR TITLE
C#: Handle tuple expressions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,5 @@
 
 # It's useful (though not required) to be able to unpack codeql in the ql checkout itself
 /codeql/
+.vscode/settings.json
+csharp/extractor/Semmle.Extraction.CSharp.Driver/Properties/launchSettings.json

--- a/change-notes/1.24/analysis-csharp.md
+++ b/change-notes/1.24/analysis-csharp.md
@@ -18,6 +18,8 @@ The following changes in version 1.24 affect C# analysis in all applications.
 
 ## Changes to code extraction
 
+* Tuple expressions, for example `(int,bool)` in `default((int,bool))` are now extracted correctly.
+
 ## Changes to libraries
 
 * The taint tracking library now tracks flow through (implicit or explicit) conversion operator calls.

--- a/csharp/extractor/Semmle.Extraction.CSharp/Entities/Expressions/Factory.cs
+++ b/csharp/extractor/Semmle.Extraction.CSharp/Entities/Expressions/Factory.cs
@@ -129,6 +129,7 @@ namespace Semmle.Extraction.CSharp.Entities.Expressions
                     case SyntaxKind.ArrayType:
                     case SyntaxKind.PredefinedType:
                     case SyntaxKind.NullableType:
+                    case SyntaxKind.TupleType:
                         return TypeAccess.Create(info);
 
                     case SyntaxKind.TypeOfExpression:

--- a/csharp/ql/test/library-tests/expressions/Tuples1.expected
+++ b/csharp/ql/test/library-tests/expressions/Tuples1.expected
@@ -1,0 +1,4 @@
+| expressions.cs:492:29:492:41 | access to type (Int32,String) | expressions.cs:492:29:492:41 | (Int32,String) |
+| expressions.cs:493:29:493:49 | access to type (Boolean,Int32[],Object) | expressions.cs:493:29:493:49 | (Boolean,Int32[],Object) |
+| expressions.cs:494:28:494:40 | access to type (Int32,String) | expressions.cs:492:29:492:41 | (Int32,String) |
+| expressions.cs:495:28:495:49 | access to type (Boolean,Int32[],dynamic) | expressions.cs:495:28:495:49 | (Boolean,Int32[],dynamic) |

--- a/csharp/ql/test/library-tests/expressions/Tuples1.ql
+++ b/csharp/ql/test/library-tests/expressions/Tuples1.ql
@@ -1,0 +1,5 @@
+import csharp
+
+from TypeAccess access, TupleType type
+where type = access.getTarget()
+select access, type

--- a/csharp/ql/test/library-tests/expressions/expressions.cs
+++ b/csharp/ql/test/library-tests/expressions/expressions.cs
@@ -484,4 +484,15 @@ namespace Expressions
         const int d = 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 +
                       1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1;
     }
+
+    class TupleExprs
+    {
+        void Test()
+        {
+            var a = default((int, string));
+            var b = default((bool, int[], object));
+            var x = typeof((int, string));
+            var y = typeof((bool, int[], dynamic));
+        }
+    }
 }


### PR DESCRIPTION
Extract tuple expressions, for example the body of `default((int,string))`. Previously this expression would not be extracted and there would be an error in `csharp.log`.

Fixes https://github.com/github/codeql-csharp-team/issues/3
