### PR TITLE
C++: IR data flow through total chi operands

### DIFF
--- a/cpp/ql/src/semmle/code/cpp/ir/dataflow/internal/DataFlowUtil.qll
+++ b/cpp/ql/src/semmle/code/cpp/ir/dataflow/internal/DataFlowUtil.qll
@@ -59,10 +59,12 @@ class Node extends TIRDataFlowNode {
   Parameter asParameter() { result = instr.(InitializeParameterInstruction).getParameter() }
 
   /**
+   * DEPRECATED: See UninitializedNode.
+   *
    * Gets the uninitialized local variable corresponding to this node, if
    * any.
    */
-  LocalVariable asUninitialized() { result = instr.(UninitializedInstruction).getLocalVariable() }
+  LocalVariable asUninitialized() { none() }
 
   /**
    * Gets an upper bound on the type of this node.
@@ -140,15 +142,19 @@ private class ThisParameterNode extends Node {
 }
 
 /**
+ * DEPRECATED: Data flow was never an accurate way to determine what
+ * expressions might be uninitialized. It errs on the side of saying that
+ * everything is uninitialized, and this is even worse in the IR because the IR
+ * doesn't use syntactic hints to rule out variables that are definitely
+ * initialized.
+ *
  * The value of an uninitialized local variable, viewed as a node in a data
  * flow graph.
  */
-class UninitializedNode extends Node {
-  override UninitializedInstruction instr;
+deprecated class UninitializedNode extends Node {
+  UninitializedNode() { none() }
 
-  LocalVariable getLocalVariable() { result = instr.getLocalVariable() }
-
-  override string toString() { result = this.getLocalVariable().toString() }
+  LocalVariable getLocalVariable() { none() }
 }
 
 /**

--- a/cpp/ql/test/library-tests/dataflow/dataflow-tests/test_diff.expected
+++ b/cpp/ql/test/library-tests/dataflow/dataflow-tests/test_diff.expected
@@ -29,6 +29,9 @@
 | ref.cpp:109:15:109:20 | ref.cpp:132:13:132:15 | AST only |
 | ref.cpp:122:23:122:28 | ref.cpp:123:13:123:15 | AST only |
 | ref.cpp:125:19:125:24 | ref.cpp:126:13:126:15 | AST only |
+| test.cpp:75:7:75:8 | test.cpp:76:8:76:9 | AST only |
+| test.cpp:83:7:83:8 | test.cpp:84:8:84:18 | AST only |
+| test.cpp:83:7:83:8 | test.cpp:86:8:86:9 | AST only |
 | test.cpp:89:28:89:34 | test.cpp:92:8:92:14 | IR only |
 | test.cpp:100:13:100:18 | test.cpp:103:10:103:12 | AST only |
 | test.cpp:109:9:109:14 | test.cpp:110:10:110:12 | IR only |

--- a/cpp/ql/test/library-tests/dataflow/dataflow-tests/test_ir.expected
+++ b/cpp/ql/test/library-tests/dataflow/dataflow-tests/test_ir.expected
@@ -31,9 +31,6 @@
 | test.cpp:31:8:31:8 | c | test.cpp:36:13:36:18 | call to source |
 | test.cpp:58:10:58:10 | t | test.cpp:50:14:50:19 | call to source |
 | test.cpp:71:8:71:9 | x4 | test.cpp:66:30:66:36 | source1 |
-| test.cpp:76:8:76:9 | u1 | test.cpp:75:7:75:8 | u1 |
-| test.cpp:84:8:84:18 | ... ? ... : ... | test.cpp:83:7:83:8 | u2 |
-| test.cpp:86:8:86:9 | i1 | test.cpp:83:7:83:8 | u2 |
 | test.cpp:90:8:90:14 | source1 | test.cpp:89:28:89:34 | source1 |
 | test.cpp:92:8:92:14 | source1 | test.cpp:89:28:89:34 | source1 |
 | test.cpp:110:10:110:12 | (reference dereference) | test.cpp:109:9:109:14 | call to source |

--- a/cpp/ql/test/library-tests/dataflow/taint-tests/test_diff.expected
+++ b/cpp/ql/test/library-tests/dataflow/taint-tests/test_diff.expected
@@ -22,6 +22,5 @@
 | taint.cpp:250:8:250:8 | taint.cpp:223:10:223:15 | AST only |
 | taint.cpp:256:8:256:8 | taint.cpp:223:10:223:15 | AST only |
 | taint.cpp:261:7:261:7 | taint.cpp:258:7:258:12 | AST only |
-| taint.cpp:350:7:350:7 | taint.cpp:330:6:330:11 | AST only |
 | taint.cpp:351:7:351:7 | taint.cpp:330:6:330:11 | AST only |
 | taint.cpp:352:7:352:7 | taint.cpp:330:6:330:11 | AST only |

--- a/cpp/ql/test/library-tests/dataflow/taint-tests/test_ir.expected
+++ b/cpp/ql/test/library-tests/dataflow/taint-tests/test_ir.expected
@@ -14,3 +14,4 @@
 | taint.cpp:290:7:290:7 | x | taint.cpp:275:6:275:11 | call to source |
 | taint.cpp:291:7:291:7 | y | taint.cpp:275:6:275:11 | call to source |
 | taint.cpp:337:7:337:7 | t | taint.cpp:330:6:330:11 | call to source |
+| taint.cpp:350:7:350:7 | t | taint.cpp:330:6:330:11 | call to source |


### PR DESCRIPTION
This is what's proposed in https://jira.semmle.com/browse/CPP-478, except that I think the description I wrote in that Jira ticket is wrong: only for _partial_ chi operands should we worry about what kind of chi node it is. All _total_ operands should be fine. I've written a long code comment to try and explain why it's a good idea to add this flow.

To my surprise, flow through total chi inputs only affects a single qltest result. To my even bigger surprise, there was no effect whatsoever on our `security.TaintTracking` tests via `DefaultTaintTracking`. I tested this using [the guide in CPP-462](https://jira.semmle.com/browse/CPP-462?focusedCommentId=100099&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-100099). I assume there's no effect because the security tests tend to be stripped of any unrelated use of the taint-carrying variables.

Allowing flow through total chi inputs broke whatever was working of the `UninitializedNode` functionality in the data flow library. The first commit in this PR deprecates `UninitializedNode` for IR data flow. I think it's a separate discussion whether we should deprecate it for AST data flow. I would think it's been useless in practice since CPP-379.