### PR TITLE
JavaScript: Fix timeouts on bwip-js.

### DIFF
--- a/javascript/ql/src/semmle/javascript/dataflow/Configuration.qll
+++ b/javascript/ql/src/semmle/javascript/dataflow/Configuration.qll
@@ -1071,6 +1071,18 @@ private MidPathNode finalMidNode(SinkPathNode snk) {
 }
 
 /**
+ * Holds if `nd` is a mid node wrapping `(predNd, cfg, summary)`, and there is a flow step
+ * from `predNd` to `succNd` under `cfg` with summary `newSummary`.
+ *
+ * This helper predicate exists to clarify the intended join order in `getASuccessor` below.
+ */
+pragma[noinline]
+private predicate midNodeStep(PathNode nd, DataFlow::Node predNd, Configuration cfg, PathSummary summary, DataFlow::Node succNd, PathSummary newSummary) {
+  nd = MkMidNode(predNd, cfg, summary) and
+  flowStep(predNd, id(cfg), succNd, newSummary)
+}
+
+/**
  * Gets a node to which data from `nd` may flow in one step.
  */
 private PathNode getASuccessor(PathNode nd) {
@@ -1079,8 +1091,7 @@ private PathNode getASuccessor(PathNode nd) {
   or
   // mid node to mid node
   exists(Configuration cfg, DataFlow::Node predNd, PathSummary summary, DataFlow::Node succNd, PathSummary newSummary |
-    nd = MkMidNode(predNd, cfg, summary) and
-    flowStep(predNd, id(cfg), succNd, newSummary) and
+    midNodeStep(nd, predNd, cfg, summary, succNd, newSummary) and
     result = MkMidNode(succNd, id(cfg), summary.append(newSummary))
   )
   or

--- a/javascript/ql/src/semmle/javascript/dataflow/Configuration.qll
+++ b/javascript/ql/src/semmle/javascript/dataflow/Configuration.qll
@@ -938,8 +938,8 @@ private predicate onPath(DataFlow::Node nd, DataFlow::Configuration cfg, PathSum
   or
   exists(DataFlow::Node mid, PathSummary stepSummary |
     reachableFromSource(nd, cfg, summary) and
-    flowStep(nd, cfg, mid, stepSummary) and
-    onPath(mid, cfg, summary.append(stepSummary))
+    flowStep(nd, id(cfg), mid, stepSummary) and
+    onPath(mid, id(cfg), summary.append(stepSummary))
   )
 }
 


### PR DESCRIPTION
These were caused by two seemingly independent join mis-orderings which must have crept in fairly recently (certainly post-1.23).

I have verified that this PR fixes the original timeouts, a larger evaluation is ongoing.