### PR TITLE
TS: Blacklist cyclic property fallthroughFlowNode

### DIFF
--- a/javascript/extractor/lib/typescript/src/main.ts
+++ b/javascript/extractor/lib/typescript/src/main.ts
@@ -126,7 +126,7 @@ function checkCycle(root: any) {
 function isBlacklistedProperty(k: string) {
     return k === "parent" || k === "pos" || k === "end"
         || k === "symbol" || k === "localSymbol"
-        || k === "flowNode" || k === "returnFlowNode" || k === "endFlowNode"
+        || k === "flowNode" || k === "returnFlowNode" || k === "endFlowNode" || k === "fallthroughFlowNode"
         || k === "nextContainer" || k === "locals"
         || k === "bindDiagnostics" || k === "bindSuggestionDiagnostics";
 }


### PR DESCRIPTION
Fixes an extractor crash involving a new cyclic property, presumably arising when the inferred type of a variable depends on fallthrough in a switch statement.

I haven't been able to reproduce in a small test case, but I've confirmed that it fixes the three cases of cyclic JSON crashes that came up during the dist upgrade.