### PR TITLE
Multiplication overflow not possible due to type width

### DIFF
--- a/cpp/ql/src/Likely Bugs/Arithmetic/IntMultToLong.ql
+++ b/cpp/ql/src/Likely Bugs/Arithmetic/IntMultToLong.ql
@@ -132,6 +132,8 @@ class SubAnalyzableExpr extends AnalyzableExpr, SubExpr {
 }
 
 class VarAnalyzableExpr extends AnalyzableExpr, VariableAccess {
+  VarAnalyzableExpr() { not exists(this.getQualifier()) }
+
   override float maxValue() {
     exists(SsaDefinition def, Variable v |
       def.getAUse(v) = this and
@@ -140,7 +142,7 @@ class VarAnalyzableExpr extends AnalyzableExpr, VariableAccess {
       // variable the largest possible value it can hold
       if exists(def.getDefiningValue(v))
       then result = def.getDefiningValue(v).(AnalyzableExpr).maxValue()
-      else result = exprMaxVal(this)
+      else result = upperBound(this)
     )
   }
 
@@ -149,7 +151,7 @@ class VarAnalyzableExpr extends AnalyzableExpr, VariableAccess {
       def.getAUse(v) = this and
       if exists(def.getDefiningValue(v))
       then result = def.getDefiningValue(v).(AnalyzableExpr).minValue()
-      else result = exprMinVal(this)
+      else result = lowerBound(this)
     )
   }
 }
@@ -206,9 +208,9 @@ where
     ) and
     e.(Literal).getType().getSize() = t2.getSize()
   ) and
-  // only report if cannot prove that the result of the
+  // only report if we cannot prove that the result of the
   // multiplication will be less (resp. greater) than the
-  // maximum (resp. minimum) number we can store.
+  // maximum (resp. minimum) number we can compute.
   overflows(me, t1)
 select me,
   "Multiplication result may overflow '" + me.getType().toString() + "' before it is converted to '"

--- a/cpp/ql/src/Likely Bugs/Arithmetic/IntMultToLong.ql
+++ b/cpp/ql/src/Likely Bugs/Arithmetic/IntMultToLong.ql
@@ -132,7 +132,7 @@ class SubAnalyzableExpr extends AnalyzableExpr, SubExpr {
 }
 
 class VarAnalyzableExpr extends AnalyzableExpr, VariableAccess {
-  VarAnalyzableExpr() { not exists(this.getQualifier()) }
+  VarAnalyzableExpr() { this.getTarget() instanceof StackVariable }
 
   override float maxValue() {
     exists(SsaDefinition def, Variable v |

--- a/cpp/ql/test/query-tests/Likely Bugs/Arithmetic/IntMultToLong/IntMultToLong.c
+++ b/cpp/ql/test/query-tests/Likely Bugs/Arithmetic/IntMultToLong/IntMultToLong.c
@@ -118,3 +118,11 @@ void g2(struct A* a, short n) {
     ulong1 = (a->s - 1) * ((*a).s + 1); // GOOD
     ulong2 = a->i * (*a).i; // BAD
 }
+
+int global_i;
+unsigned char global_uchar;
+void g3() {
+    unsigned long ulong1, ulong2;
+    ulong1 = global_i * global_i; // BAD
+    ulong2 = (global_uchar + 1) * 2; // GOOD
+}

--- a/cpp/ql/test/query-tests/Likely Bugs/Arithmetic/IntMultToLong/IntMultToLong.c
+++ b/cpp/ql/test/query-tests/Likely Bugs/Arithmetic/IntMultToLong/IntMultToLong.c
@@ -92,3 +92,13 @@ void use_printf(float f, double d)
 size_t three_chars(unsigned char a, unsigned char b, unsigned char c) {
     return a * b * c; // at most 16581375
 }
+
+void g(unsigned char a, unsigned char b, unsigned char b2, int c) {
+    unsigned long d, e, f, g, h;
+    d = (a + 1) * (b + 1); // GOOD [FALSE POSITIVE]
+    e = (c + 1) * (b + 1); // BAD
+    h = (a + 1) * (b + 1) * (b2 + 1); // GOOD [FALSE POSITIVE]
+
+    f = (a + (a + 1)) * (b + 1); // GOOD [FALSE POSITIVE]
+    g = (c + (a + 1)) * (b + 1); // BAD
+}

--- a/cpp/ql/test/query-tests/Likely Bugs/Arithmetic/IntMultToLong/IntMultToLong.c
+++ b/cpp/ql/test/query-tests/Likely Bugs/Arithmetic/IntMultToLong/IntMultToLong.c
@@ -95,10 +95,10 @@ size_t three_chars(unsigned char a, unsigned char b, unsigned char c) {
 
 void g(unsigned char a, unsigned char b, unsigned char b2, int c) {
     unsigned long d, e, f, g, h;
-    d = (a + 1) * (b + 1); // GOOD [FALSE POSITIVE]
+    d = (a + 1) * (b + 1); // GOOD
     e = (c + 1) * (b + 1); // BAD
-    h = (a + 1) * (b + 1) * (b2 + 1); // GOOD [FALSE POSITIVE]
+    h = (a + 1) * (b + 1) * (b2 + 1); // GOOD
 
-    f = (a + (a + 1)) * (b + 1); // GOOD [FALSE POSITIVE]
+    f = (a + (a + 1)) * (b + 1); // GOOD
     g = (c + (a + 1)) * (b + 1); // BAD
 }

--- a/cpp/ql/test/query-tests/Likely Bugs/Arithmetic/IntMultToLong/IntMultToLong.c
+++ b/cpp/ql/test/query-tests/Likely Bugs/Arithmetic/IntMultToLong/IntMultToLong.c
@@ -93,12 +93,12 @@ size_t three_chars(unsigned char a, unsigned char b, unsigned char c) {
     return a * b * c; // at most 16581375
 }
 
-void g(unsigned char a, unsigned char b, unsigned char b2, int c) {
-    unsigned long d, e, f, g, h;
-    d = (a + 1) * (b + 1); // GOOD
-    e = (c + 1) * (b + 1); // BAD
-    h = (a + 1) * (b + 1) * (b2 + 1); // GOOD
+void g(unsigned char uchar1, unsigned char uchar2, unsigned char uchar3, int i) {
+    unsigned long ulong1, ulong2, ulong3, ulong4, ulong5;
+    ulong1 = (uchar1 + 1) * (uchar2 + 1); // GOOD
+    ulong2 = (i + 1) * (uchar2 + 1); // BAD
+    ulong3 = (uchar1 + 1) * (uchar2 + 1) * (uchar3 + 1); // GOOD
 
-    f = (a + (a + 1)) * (b + 1); // GOOD
-    g = (c + (a + 1)) * (b + 1); // BAD
+    ulong4 = (uchar1 + (uchar1 + 1)) * (uchar2 + 1); // GOOD
+    ulong5 = (i + (uchar1 + 1)) * (uchar2 + 1); // BAD
 }

--- a/cpp/ql/test/query-tests/Likely Bugs/Arithmetic/IntMultToLong/IntMultToLong.c
+++ b/cpp/ql/test/query-tests/Likely Bugs/Arithmetic/IntMultToLong/IntMultToLong.c
@@ -101,4 +101,9 @@ void g(unsigned char uchar1, unsigned char uchar2, unsigned char uchar3, int i) 
 
     ulong4 = (uchar1 + (uchar1 + 1)) * (uchar2 + 1); // GOOD
     ulong5 = (i + (uchar1 + 1)) * (uchar2 + 1); // BAD
+
+    ulong5 = (uchar1 + 1073741824) * uchar2; // BAD [NOT DETECTED]
+    ulong5 = (uchar1 + (1 << 30)) * uchar2; // BAD [NOT DETECTED]
+    ulong5 = uchar1 * uchar1 * uchar1 * uchar2 * uchar2 * uchar2; // BAD [NOT DETECTED]
+    ulong5 = (uchar1 + (unsigned short)(-1)) * (uchar2 + (unsigned short)(-1)); // BAD
 }

--- a/cpp/ql/test/query-tests/Likely Bugs/Arithmetic/IntMultToLong/IntMultToLong.c
+++ b/cpp/ql/test/query-tests/Likely Bugs/Arithmetic/IntMultToLong/IntMultToLong.c
@@ -107,3 +107,14 @@ void g(unsigned char uchar1, unsigned char uchar2, unsigned char uchar3, int i) 
     ulong5 = uchar1 * uchar1 * uchar1 * uchar2 * uchar2 * uchar2; // BAD [NOT DETECTED]
     ulong5 = (uchar1 + (unsigned short)(-1)) * (uchar2 + (unsigned short)(-1)); // BAD
 }
+
+struct A {
+    short s;
+    int i;
+};
+
+void g2(struct A* a, short n) {
+    unsigned long ulong1, ulong2;
+    ulong1 = (a->s - 1) * ((*a).s + 1); // GOOD
+    ulong2 = a->i * (*a).i; // BAD
+}

--- a/cpp/ql/test/query-tests/Likely Bugs/Arithmetic/IntMultToLong/IntMultToLong.expected
+++ b/cpp/ql/test/query-tests/Likely Bugs/Arithmetic/IntMultToLong/IntMultToLong.expected
@@ -7,3 +7,8 @@
 | IntMultToLong.c:61:23:61:33 | ... * ... | Multiplication result may overflow 'int' before it is converted to 'long long'. |
 | IntMultToLong.c:63:23:63:40 | ... * ... | Multiplication result may overflow 'int' before it is converted to 'long long'. |
 | IntMultToLong.c:75:9:75:13 | ... * ... | Multiplication result may overflow 'int' before it is converted to 'size_t'. |
+| IntMultToLong.c:98:9:98:25 | ... * ... | Multiplication result may overflow 'int' before it is converted to 'unsigned long'. |
+| IntMultToLong.c:99:9:99:25 | ... * ... | Multiplication result may overflow 'int' before it is converted to 'unsigned long'. |
+| IntMultToLong.c:100:9:100:36 | ... * ... | Multiplication result may overflow 'int' before it is converted to 'unsigned long'. |
+| IntMultToLong.c:102:9:102:31 | ... * ... | Multiplication result may overflow 'int' before it is converted to 'unsigned long'. |
+| IntMultToLong.c:103:9:103:31 | ... * ... | Multiplication result may overflow 'int' before it is converted to 'unsigned long'. |

--- a/cpp/ql/test/query-tests/Likely Bugs/Arithmetic/IntMultToLong/IntMultToLong.expected
+++ b/cpp/ql/test/query-tests/Likely Bugs/Arithmetic/IntMultToLong/IntMultToLong.expected
@@ -7,8 +7,5 @@
 | IntMultToLong.c:61:23:61:33 | ... * ... | Multiplication result may overflow 'int' before it is converted to 'long long'. |
 | IntMultToLong.c:63:23:63:40 | ... * ... | Multiplication result may overflow 'int' before it is converted to 'long long'. |
 | IntMultToLong.c:75:9:75:13 | ... * ... | Multiplication result may overflow 'int' before it is converted to 'size_t'. |
-| IntMultToLong.c:98:9:98:25 | ... * ... | Multiplication result may overflow 'int' before it is converted to 'unsigned long'. |
 | IntMultToLong.c:99:9:99:25 | ... * ... | Multiplication result may overflow 'int' before it is converted to 'unsigned long'. |
-| IntMultToLong.c:100:9:100:36 | ... * ... | Multiplication result may overflow 'int' before it is converted to 'unsigned long'. |
-| IntMultToLong.c:102:9:102:31 | ... * ... | Multiplication result may overflow 'int' before it is converted to 'unsigned long'. |
 | IntMultToLong.c:103:9:103:31 | ... * ... | Multiplication result may overflow 'int' before it is converted to 'unsigned long'. |

--- a/cpp/ql/test/query-tests/Likely Bugs/Arithmetic/IntMultToLong/IntMultToLong.expected
+++ b/cpp/ql/test/query-tests/Likely Bugs/Arithmetic/IntMultToLong/IntMultToLong.expected
@@ -10,3 +10,4 @@
 | IntMultToLong.c:99:14:99:35 | ... * ... | Multiplication result may overflow 'int' before it is converted to 'unsigned long'. |
 | IntMultToLong.c:103:14:103:46 | ... * ... | Multiplication result may overflow 'int' before it is converted to 'unsigned long'. |
 | IntMultToLong.c:108:14:108:78 | ... * ... | Multiplication result may overflow 'int' before it is converted to 'unsigned long'. |
+| IntMultToLong.c:119:14:119:26 | ... * ... | Multiplication result may overflow 'int' before it is converted to 'unsigned long'. |

--- a/cpp/ql/test/query-tests/Likely Bugs/Arithmetic/IntMultToLong/IntMultToLong.expected
+++ b/cpp/ql/test/query-tests/Likely Bugs/Arithmetic/IntMultToLong/IntMultToLong.expected
@@ -11,3 +11,4 @@
 | IntMultToLong.c:103:14:103:46 | ... * ... | Multiplication result may overflow 'int' before it is converted to 'unsigned long'. |
 | IntMultToLong.c:108:14:108:78 | ... * ... | Multiplication result may overflow 'int' before it is converted to 'unsigned long'. |
 | IntMultToLong.c:119:14:119:26 | ... * ... | Multiplication result may overflow 'int' before it is converted to 'unsigned long'. |
+| IntMultToLong.c:126:14:126:32 | ... * ... | Multiplication result may overflow 'int' before it is converted to 'unsigned long'. |

--- a/cpp/ql/test/query-tests/Likely Bugs/Arithmetic/IntMultToLong/IntMultToLong.expected
+++ b/cpp/ql/test/query-tests/Likely Bugs/Arithmetic/IntMultToLong/IntMultToLong.expected
@@ -7,5 +7,6 @@
 | IntMultToLong.c:61:23:61:33 | ... * ... | Multiplication result may overflow 'int' before it is converted to 'long long'. |
 | IntMultToLong.c:63:23:63:40 | ... * ... | Multiplication result may overflow 'int' before it is converted to 'long long'. |
 | IntMultToLong.c:75:9:75:13 | ... * ... | Multiplication result may overflow 'int' before it is converted to 'size_t'. |
-| IntMultToLong.c:99:9:99:25 | ... * ... | Multiplication result may overflow 'int' before it is converted to 'unsigned long'. |
-| IntMultToLong.c:103:9:103:31 | ... * ... | Multiplication result may overflow 'int' before it is converted to 'unsigned long'. |
+| IntMultToLong.c:99:14:99:35 | ... * ... | Multiplication result may overflow 'int' before it is converted to 'unsigned long'. |
+| IntMultToLong.c:103:14:103:46 | ... * ... | Multiplication result may overflow 'int' before it is converted to 'unsigned long'. |
+| IntMultToLong.c:108:14:108:78 | ... * ... | Multiplication result may overflow 'int' before it is converted to 'unsigned long'. |


### PR DESCRIPTION
This PR fixes the false positive reported in #2561.

Differences query: https://lgtm.com/query/3029067271222385694/

I have included 3 tests (from @jbj), all of which are currently not detected due to excluding values of "small types":

```
predicate likelySmall(Expr e) {
  ...
  or
  e.getType().getSize() <= 1
  or
  ...
}
```

However, it might be worth discussing whether we should still exclude such values from the analysis now that we're using `SimpleRangeAnalysis`.