### PR TITLE
TS: Suppress output from compiler tracing

### DIFF
--- a/javascript/extractor/lib/typescript/src/common.ts
+++ b/javascript/extractor/lib/typescript/src/common.ts
@@ -12,7 +12,9 @@ export class Project {
   }
 
   public load(): void {
-    this.program = ts.createProgram(this.config.fileNames, this.config.options);
+    let host = ts.createCompilerHost(this.config.options, true);
+    host.trace = undefined; // Disable tracing which would otherwise go to standard out
+    this.program = ts.createProgram(this.config.fileNames, this.config.options, host);
     this.typeTable.setProgram(this.program);
   }
 

--- a/javascript/ql/test/library-tests/TypeScript/RegressionTests/TraceResolution/node_modules/@types/foo/index.d.ts
+++ b/javascript/ql/test/library-tests/TypeScript/RegressionTests/TraceResolution/node_modules/@types/foo/index.d.ts
@@ -1,0 +1,1 @@
+export function foo();

--- a/javascript/ql/test/library-tests/TypeScript/RegressionTests/TraceResolution/test.expected
+++ b/javascript/ql/test/library-tests/TypeScript/RegressionTests/TraceResolution/test.expected
@@ -1,0 +1,6 @@
+| node_modules/@types/foo/index.d.ts:1:17:1:19 | foo | () => any |
+| test.ts:1:10:1:12 | foo | () => any |
+| test.ts:1:10:1:12 | foo | () => any |
+| test.ts:1:21:1:25 | "foo" | any |
+| test.ts:3:1:3:3 | foo | () => any |
+| test.ts:3:1:3:5 | foo() | any |

--- a/javascript/ql/test/library-tests/TypeScript/RegressionTests/TraceResolution/test.ql
+++ b/javascript/ql/test/library-tests/TypeScript/RegressionTests/TraceResolution/test.ql
@@ -1,0 +1,3 @@
+import javascript
+
+from Expr e select e, e.getType()

--- a/javascript/ql/test/library-tests/TypeScript/RegressionTests/TraceResolution/test.ts
+++ b/javascript/ql/test/library-tests/TypeScript/RegressionTests/TraceResolution/test.ts
@@ -1,0 +1,3 @@
+import { foo } from "foo";
+
+foo();

--- a/javascript/ql/test/library-tests/TypeScript/RegressionTests/TraceResolution/tsconfig.json
+++ b/javascript/ql/test/library-tests/TypeScript/RegressionTests/TraceResolution/tsconfig.json
@@ -1,0 +1,6 @@
+{
+  "include": ["."],
+  "compilerOptions": {
+    "traceResolution": true
+  }
+}


### PR DESCRIPTION
If `traceResolution: true` was set in a `tsconfig.json` file, the TypeScript compiler would print messages to stdout, interfering with the JSON-based communication between the two extractor processes.

TypeScript exposes a `trace` callback in the compiler host, which defaults to something like `console.log` - we now set it to `undefined` which suppresses the trace output.