### PR TITLE
JS: Fix imports spuriously being resolved to a .js file

### DIFF
--- a/javascript/ql/src/semmle/javascript/Modules.qll
+++ b/javascript/ql/src/semmle/javascript/Modules.qll
@@ -88,6 +88,7 @@ abstract class Module extends TopLevel {
         result = f.getJavaScriptFile(path.getBaseName())
         or
         // If a js file was not found look for a file that compiles to js
+        path.getExtension() = ".js" and
         not exists(f.getJavaScriptFile(path.getBaseName())) and
         result = f.getJavaScriptFile(path.getStem())
       )

--- a/javascript/ql/src/semmle/javascript/Paths.qll
+++ b/javascript/ql/src/semmle/javascript/Paths.qll
@@ -129,6 +129,14 @@ abstract class PathString extends string {
   string getDirName() { result = this.regexpCapture(pathRegex(), 1) }
 
   /**
+   * Gets the extension of the folder or file this path refers to, that is, the suffix of the base name
+   * starting at the last dot character, if there is one.
+   *
+   * Has no result if the base name does not contain a dot.
+   */
+  string getExtension() { result = this.regexpCapture(pathRegex(), 4) }
+
+  /**
    * Gets the absolute path that the sub-path consisting of the first `n`
    * components of this path refers to when resolved relative to the
    * given `root` folder.
@@ -207,6 +215,14 @@ abstract class PathExpr extends PathExprBase {
 
   /** Gets the stem, that is, base name without extension, of the folder or file this path refers to. */
   string getStem() { result = getValue().(PathString).getStem() }
+
+  /**
+   * Gets the extension of the folder or file this path refers to, that is, the suffix of the base name
+   * starting at the last dot character, if there is one.
+   *
+   * Has no result if the base name does not contain a dot.
+   */
+  string getExtension() { result = getValue().(PathString).getExtension() }
 
   /**
    * Gets the file or folder that the first `n` components of this path refer to

--- a/javascript/ql/test/library-tests/Modules/importcss.js
+++ b/javascript/ql/test/library-tests/Modules/importcss.js
@@ -1,0 +1,3 @@
+import A from "./a.css";
+
+A.bar();

--- a/javascript/ql/test/library-tests/Modules/tests.expected
+++ b/javascript/ql/test/library-tests/Modules/tests.expected
@@ -7,6 +7,7 @@ test_ImportSpecifiers
 | g.ts:1:9:1:11 | foo | g.ts:1:9:1:11 | foo |
 | import-in-mjs.mjs:1:8:1:24 | exported_from_mjs | import-in-mjs.mjs:1:8:1:24 | exported_from_mjs |
 | import-ts-with-js-extension.ts:1:10:1:12 | foo | import-ts-with-js-extension.ts:1:10:1:12 | foo |
+| importcss.js:1:8:1:8 | A | importcss.js:1:8:1:8 | A |
 | m/c.js:1:8:1:13 | * as b | m/c.js:1:13:1:13 | b |
 | tst.html:5:10:5:10 | f | tst.html:5:10:5:10 | f |
 | unresolved.js:1:8:1:8 | f | unresolved.js:1:8:1:8 | f |
@@ -37,6 +38,7 @@ test_ImportDefaultSpecifiers
 | b.js:1:8:1:8 | f |
 | f.ts:1:8:1:8 | g |
 | import-in-mjs.mjs:1:8:1:24 | exported_from_mjs |
+| importcss.js:1:8:1:8 | A |
 | tst.html:5:10:5:10 | f |
 | unresolved.js:1:8:1:8 | f |
 test_getImportedName
@@ -47,6 +49,7 @@ test_getImportedName
 | g.ts:1:9:1:11 | foo | foo |
 | import-in-mjs.mjs:1:8:1:24 | exported_from_mjs | default |
 | import-ts-with-js-extension.ts:1:10:1:12 | foo | foo |
+| importcss.js:1:8:1:8 | A | default |
 | tst.html:5:10:5:10 | f | default |
 | unresolved.js:1:8:1:8 | f | default |
 test_ExportDeclarations
@@ -70,6 +73,7 @@ test_getAnImportedModule
 | library-tests/Modules/f.ts | library-tests/Modules/e.js |
 | library-tests/Modules/g.ts | library-tests/Modules/f.ts |
 | library-tests/Modules/import-ts-with-js-extension.ts | library-tests/Modules/f.ts |
+| library-tests/Modules/importcss.js | library-tests/Modules/a.js |
 | library-tests/Modules/m/c.js | library-tests/Modules/b.js |
 test_getSourceNode
 | a.js:1:1:3:1 | export  ... n 23;\\n} | default | a.js:1:16:3:1 | functio ... n 23;\\n} |
@@ -93,6 +97,7 @@ test_Imports
 | g.ts:1:1:1:23 | import  ... m './f' | g.ts:1:19:1:23 | './f' | 1 |
 | import-in-mjs.mjs:1:1:1:46 | import  ... n-mjs'; | import-in-mjs.mjs:1:31:1:45 | 'export-in-mjs' | 1 |
 | import-ts-with-js-extension.ts:1:1:1:29 | import  ... /f.js"; | import-ts-with-js-extension.ts:1:21:1:28 | "./f.js" | 1 |
+| importcss.js:1:1:1:24 | import  ... a.css"; | importcss.js:1:15:1:23 | "./a.css" | 1 |
 | m/c.js:1:1:1:26 | import  ... '../b'; | m/c.js:1:20:1:25 | '../b' | 1 |
 | tst.html:5:3:5:20 | import f from 'a'; | tst.html:5:17:5:19 | 'a' | 1 |
 | unresolved.js:1:1:1:18 | import f from 'a'; | unresolved.js:1:15:1:17 | 'a' | 1 |

--- a/javascript/ql/test/library-tests/Modules/tests.expected
+++ b/javascript/ql/test/library-tests/Modules/tests.expected
@@ -73,7 +73,6 @@ test_getAnImportedModule
 | library-tests/Modules/f.ts | library-tests/Modules/e.js |
 | library-tests/Modules/g.ts | library-tests/Modules/f.ts |
 | library-tests/Modules/import-ts-with-js-extension.ts | library-tests/Modules/f.ts |
-| library-tests/Modules/importcss.js | library-tests/Modules/a.js |
 | library-tests/Modules/m/c.js | library-tests/Modules/b.js |
 test_getSourceNode
 | a.js:1:1:3:1 | export  ... n 23;\\n} | default | a.js:1:16:3:1 | functio ... n 23;\\n} |


### PR DESCRIPTION
Fixes a bug introduced in https://github.com/Semmle/ql/pull/2433, which caused imports with extensions such as `.css` to be resolved to a `.js` file.