### PR TITLE
Java: Include non-null final fields in clearlyNotNull.

### DIFF
--- a/change-notes/1.24/analysis-java.md
+++ b/change-notes/1.24/analysis-java.md
@@ -11,7 +11,9 @@ The following changes in version 1.24 affect Java analysis in all applications.
 
 | **Query**                    | **Expected impact**    | **Change**                        |
 |------------------------------|------------------------|-----------------------------------|
+| Dereferenced variable may be null (`java/dereferenced-value-may-be-null`) | Fewer false positives | Final fields with a non-null initializer are no longer reported. |
 | Expression always evaluates to the same value (`java/evaluation-to-constant`) | Fewer false positives | Expressions of the form `0 * x` are usually intended and no longer reported. |
+| Useless null check (`java/useless-null-check`) | More true positives | Useless checks on final fields with a non-null initializer are now reported. |
 
 ## Changes to libraries
 

--- a/java/ql/src/semmle/code/java/dataflow/NullGuards.qll
+++ b/java/ql/src/semmle/code/java/dataflow/NullGuards.qll
@@ -101,6 +101,12 @@ predicate clearlyNotNull(SsaVariable v, Expr reason) {
     v.(SsaImplicitInit).captures(captured) and
     clearlyNotNull(captured, reason)
   )
+  or
+  exists(Field f |
+    v.getSourceVariable().getVariable() = f and
+    f.isFinal() and
+    f.getInitializer() = clearlyNotNullExpr(reason)
+  )
 }
 
 /** Gets an expression that is provably not `null`. */

--- a/java/ql/test/query-tests/Nullness/C.java
+++ b/java/ql/test/query-tests/Nullness/C.java
@@ -159,4 +159,13 @@ public class C {
       obj.hashCode(); // OK
     }
   }
+
+  private final Object finalObj = new Object();
+
+  public void ex12() {
+    finalObj.hashCode(); // OK
+    if (finalObj != null) {
+      finalObj.hashCode(); // OK
+    }
+  }
 }

--- a/java/ql/test/query-tests/UselessNullCheck/A.java
+++ b/java/ql/test/query-tests/UselessNullCheck/A.java
@@ -44,4 +44,13 @@ public class A {
     }
     return null;
   }
+
+  private final Object finalObj = new Object();
+
+  public void ex12() {
+    finalObj.hashCode();
+    if (finalObj != null) { // Useless check
+      finalObj.hashCode();
+    }
+  }
 }

--- a/java/ql/test/query-tests/UselessNullCheck/UselessNullCheck.expected
+++ b/java/ql/test/query-tests/UselessNullCheck/UselessNullCheck.expected
@@ -5,3 +5,4 @@
 | A.java:31:11:31:19 | ... != ... | This check is useless, $@ cannot be null here, since $@ always is non-null. | A.java:31:11:31:11 | x | x | A.java:29:17:29:20 | this | this |
 | A.java:40:14:40:25 | ... != ... | This check is useless, since $@ always is non-null. | A.java:40:14:40:17 | this | this | A.java:40:14:40:17 | this | this |
 | A.java:42:9:42:17 | ... != ... | This check is useless, $@ cannot be null here, since it is guarded by $@. | A.java:42:9:42:9 | x | x | A.java:39:9:39:17 | ... == ... | ... == ... |
+| A.java:52:9:52:24 | ... != ... | This check is useless, $@ cannot be null here, since $@ always is non-null. | A.java:52:9:52:16 | finalObj | finalObj | A.java:48:35:48:46 | new Object(...) | new Object(...) |


### PR DESCRIPTION
Fixes https://github.com/Semmle/ql/issues/2553

This adds references to final fields with initializers that are clearly not null to the `clearlyNotNull` predicate.  This fixes the FP and FN in the referenced issue.