### PR TITLE
Add check for disabled CSRF protection in Spring

### DIFF
--- a/java/ql/src/Security/CWE/CWE-352/SpringCSRFProtection.java
+++ b/java/ql/src/Security/CWE/CWE-352/SpringCSRFProtection.java
@@ -1,0 +1,17 @@
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter;
+
+@EnableWebSecurity
+@Configuration
+public class WebSecurityConfig extends WebSecurityConfigurerAdapter {
+  @Override
+  protected void configure(HttpSecurity http) throws Exception {
+    http
+      .csrf(csrf ->
+        // BAD - CSRF protection shouldn't be disabled
+        csrf.disable() 
+      );
+  }
+}

--- a/java/ql/src/Security/CWE/CWE-352/SpringCSRFProtection.qhelp
+++ b/java/ql/src/Security/CWE/CWE-352/SpringCSRFProtection.qhelp
@@ -2,29 +2,28 @@
 <qhelp>
 
 <overview>
-<p>When a web server is designed to receive a request from a client without any mechanism 
-for verifying that it was intentionally sent, then it might be possible for an attacker 
-to trick a client into making an unintentional request to the web server which will be treated 
-as an authentic request. This can be done via a URL, image load, XMLHttpRequest, etc. and can 
+<p>When you set up a web server to receive a request from a client without any mechanism
+for verifying that it was intentionally sent, then it is vulnerable to attack. An attacker can
+trick a client into making an unintended request to the web server that will be treated as
+an authentic request. This can be done via a URL, image load, XMLHttpRequest, etc. and can 
 result in exposure of data or unintended code execution.</p>
 </overview>
 
 <recommendation>
-<p>Cross-Site Request Forgery (CSRF) protection is enabled by default in Spring with Java 
-configuration. It's recommended to not disable this.</p>
+<p>Cross-Site Request Forgery (CSRF) protection is enabled by default. Spring's recommendation
+is to use CSRF protection for any request that could be processed by a browser client by normal
+users.</p>
 </recommendation>
 
 <example>
-<p>The following example shows the Spring Java configuration with CSRF protection disabled.</p>
+<p>The following example shows the Spring Java configuration with CSRF protection disabled.
+This type of configuration should only be used if you are creating a service that is used only
+by non-browser clients.</p>
 
 <sample src="SpringCSRFProtection.java" />
 </example>
 
 <references>
-<li>
-CWE:
-<a href="https://cwe.mitre.org/data/definitions/352.html">CWE-352: Cross-Site Request Forgery (CSRF)</a>.
-</li>
 <li>
 OWASP:
 <a href="https://www.owasp.org/index.php/Cross-Site_Request_Forgery_(CSRF)">Cross-Site Request Forgery (CSRF)</a>.

--- a/java/ql/src/Security/CWE/CWE-352/SpringCSRFProtection.qhelp
+++ b/java/ql/src/Security/CWE/CWE-352/SpringCSRFProtection.qhelp
@@ -10,7 +10,7 @@ result in exposure of data or unintended code execution.</p>
 </overview>
 
 <recommendation>
-<p>Cross-Site Request Forgery (CSRF) protection is enabled by default. Spring's recommendation
+<p>When you use Spring, Cross-Site Request Forgery (CSRF) protection is enabled by default. Spring's recommendation
 is to use CSRF protection for any request that could be processed by a browser client by normal
 users.</p>
 </recommendation>

--- a/java/ql/src/Security/CWE/CWE-352/SpringCSRFProtection.qhelp
+++ b/java/ql/src/Security/CWE/CWE-352/SpringCSRFProtection.qhelp
@@ -1,0 +1,39 @@
+<!DOCTYPE qhelp SYSTEM "qhelp.dtd">
+<qhelp>
+
+<overview>
+<p>When a web server is designed to receive a request from a client without any mechanism 
+for verifying that it was intentionally sent, then it might be possible for an attacker 
+to trick a client into making an unintentional request to the web server which will be treated 
+as an authentic request. This can be done via a URL, image load, XMLHttpRequest, etc. and can 
+result in exposure of data or unintended code execution.</p>
+</overview>
+
+<recommendation>
+<p>Cross-Site Request Forgery (CSRF) protection is enabled by default in Spring with Java 
+configuration. It's recommended to not disable this.</p>
+</recommendation>
+
+<example>
+<p>The following example shows the Spring Java configuration with CSRF protection disabled.</p>
+
+<sample src="SpringCSRFProtection.java" />
+</example>
+
+<references>
+<li>
+CWE:
+<a href="https://cwe.mitre.org/data/definitions/352.html">CWE-352: Cross-Site Request Forgery (CSRF)</a>.
+</li>
+<li>
+OWASP:
+<a href="https://www.owasp.org/index.php/Cross-Site_Request_Forgery_(CSRF)">Cross-Site Request Forgery (CSRF)</a>.
+</li>
+<li>
+Spring Security Reference:
+<a href="https://docs.spring.io/spring-security/site/docs/current/reference/html5/#servlet-csrf">
+  Cross Site Request Forgery (CSRF) for Servlet Environments
+</a>.
+</li>
+</references>
+</qhelp>

--- a/java/ql/src/Security/CWE/CWE-352/SpringCSRFProtection.ql
+++ b/java/ql/src/Security/CWE/CWE-352/SpringCSRFProtection.ql
@@ -1,7 +1,7 @@
 /**
  * @name Disabled Spring CSRF protection
  * @description Disabling CSRF protection makes the application vulnerable to
- *              Cross-Site Request Forgery (CSRF) attack.
+ *              a Cross-Site Request Forgery (CSRF) attack.
  * @kind problem
  * @problem.severity error
  * @precision high

--- a/java/ql/src/Security/CWE/CWE-352/SpringCSRFProtection.ql
+++ b/java/ql/src/Security/CWE/CWE-352/SpringCSRFProtection.ql
@@ -1,0 +1,22 @@
+/**
+ * @name Disabled Spring CSRF protection
+ * @description Disabling CSRF protection makes the application vulnerable to
+ *              Cross-Site Request Forgery (CSRF) attack.
+ * @kind problem
+ * @problem.severity error
+ * @precision high
+ * @id java/spring-disabled-csrf-protection
+ * @tags security
+ *       external/cwe/cwe-352
+ */
+
+import java
+
+from MethodAccess call, Method method
+where
+  call.getMethod() = method and
+  method.hasName("disable") and
+  method.getDeclaringType().getQualifiedName().regexpMatch(
+    "org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer<CsrfConfigurer<.*>,.*>"
+  )
+select call, "CSRF vulnerability due to protection being disabled."

--- a/java/ql/src/Security/CWE/CWE-352/SpringCSRFProtection.ql
+++ b/java/ql/src/Security/CWE/CWE-352/SpringCSRFProtection.ql
@@ -15,8 +15,8 @@ import java
 from MethodAccess call
 where
   call.getMethod().hasName("disable") and
-  call.getReceiverType().hasQualifiedName(
-    "org.springframework.security.config.annotation.web.configurers",
-    "CsrfConfigurer<HttpSecurity>"
-  )
+  call
+      .getReceiverType()
+      .hasQualifiedName("org.springframework.security.config.annotation.web.configurers",
+        "CsrfConfigurer<HttpSecurity>")
 select call, "CSRF vulnerability due to protection being disabled."

--- a/java/ql/src/Security/CWE/CWE-352/SpringCSRFProtection.ql
+++ b/java/ql/src/Security/CWE/CWE-352/SpringCSRFProtection.ql
@@ -12,11 +12,11 @@
 
 import java
 
-from MethodAccess call, Method method
+from MethodAccess call
 where
-  call.getMethod() = method and
-  method.hasName("disable") and
-  method.getDeclaringType().getQualifiedName().regexpMatch(
-    "org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer<CsrfConfigurer<.*>,.*>"
+  call.getMethod().hasName("disable") and
+  call.getReceiverType().hasQualifiedName(
+    "org.springframework.security.config.annotation.web.configurers",
+    "CsrfConfigurer<HttpSecurity>"
   )
 select call, "CSRF vulnerability due to protection being disabled."


### PR DESCRIPTION
Spring has built-in CSRF protection. However, it's possible to disable it, which most likely makes the application vulnerable to Cross-Site Request Forgery (CWE-352).

Spring CSRF protection can be disabled via Java configuration (more details [here](https://docs.spring.io/spring-security/site/docs/current/reference/html5/#servlet-csrf-configure-disable)):

```java
@Configuration
@EnableWebSecurity
public class WebSecurityConfig extends WebSecurityConfigurerAdapter {
  @Override
  protected void configure(HttpSecurity http) {
    http
      .csrf(csrf ->
        csrf.disable()
      );
  }
}
```

This PR adds a CodeQL check which finds all invocations of `CsrfConfigurer.disable()` method.