### PR TITLE
TS: Do not pass --verbose to yarn

### DIFF
--- a/javascript/extractor/src/com/semmle/js/extractor/AutoBuild.java
+++ b/javascript/extractor/src/com/semmle/js/extractor/AutoBuild.java
@@ -599,7 +599,6 @@ public class AutoBuild {
                 Arrays.asList(
                     "yarn",
                     "install",
-                    "--verbose",
                     "--non-interactive",
                     "--ignore-scripts",
                     "--ignore-platform",


### PR DESCRIPTION
Yarn gets a little too verbose for this to make sense.

For example for [this project](https://lgtm.com/projects/g/jhipster/jhipster-sample-app/logs/languages/lang:javascript) the build log becomes 110k lines, of which 109k are yarn verbose messages.