### PR TITLE
C++: compute overlap on irvars with vvar indexes

### DIFF
--- a/cpp/ql/src/semmle/code/cpp/ir/implementation/aliased_ssa/internal/AliasedSSA.qll
+++ b/cpp/ql/src/semmle/code/cpp/ir/implementation/aliased_ssa/internal/AliasedSSA.qll
@@ -401,9 +401,7 @@ private predicate isRelatableMemoryLocation(VariableMemoryLocation vml) {
   vml.getStartBitOffset() != Ints::unknown()
 }
 
-private predicate isCoveredOffset(
-  IRVariable var, int offsetRank, VariableMemoryLocation vml
-) {
+private predicate isCoveredOffset(IRVariable var, int offsetRank, VariableMemoryLocation vml) {
   exists(int startRank, int endRank, VirtualVariable vvar |
     vml.getStartBitOffset() = rank[startRank](IntValue offset_ | isRelevantOffset(vvar, offset_)) and
     vml.getEndBitOffset() = rank[endRank](IntValue offset_ | isRelevantOffset(vvar, offset_)) and


### PR DESCRIPTION
Followup to #2570. Computes the offset indexes using a rank aggregate over `VirtualVariable` and then computes overlap by joining on `IRVariable`. 