### PR TITLE
CPP: Exclude functions containing asm from cpp/missing-return

### DIFF
--- a/change-notes/1.24/analysis-cpp.md
+++ b/change-notes/1.24/analysis-cpp.md
@@ -17,6 +17,7 @@ The following changes in version 1.24 affect C/C++ analysis in all applications.
 | No space for zero terminator (`cpp/no-space-for-terminator`) | More true positive results | This query now identifies a wider variety of buffer allocations using the `semmle.code.cpp.models.interfaces.Allocation` library. |
 | Memory is never freed (`cpp/memory-never-freed`) | More true positive results | This query now identifies a wider variety of buffer allocations using the `semmle.code.cpp.models.interfaces.Allocation` library. |
 | Memory may not be freed (`cpp/memory-may-not-be-freed`) | More true positive results | This query now identifies a wider variety of buffer allocations using the `semmle.code.cpp.models.interfaces.Allocation` library. |
+| Missing return statement (`cpp/missing-return`) | Fewer false positive results | Functions containing `asm` statements are no longer highlighted by this query. |
 | Hard-coded Japanese era start date (`cpp/japanese-era/exact-era-date`) |  | This query is no longer run on LGTM. |
 | No space for zero terminator (`cpp/no-space-for-terminator`) | Fewer false positive results | This query has been modified to be more conservative when identifying which pointers point to null-terminated strings.  This approach produces fewer, more accurate results. |
 | Unsafe array for days of the year (`cpp/leap-year/unsafe-array-for-days-of-the-year`) |  | This query is no longer run on LGTM. |

--- a/cpp/ql/src/jsf/4.13 Functions/AV Rule 114.ql
+++ b/cpp/ql/src/jsf/4.13 Functions/AV Rule 114.ql
@@ -46,6 +46,10 @@ predicate functionImperfectlyExtracted(Function f) {
   exists(ErrorExpr ee | ee.getEnclosingFunction() = f)
   or
   count(f.getType()) > 1
+  or
+  // an `AsmStmt` isn't strictly 'imperfectly extracted', but it's beyond the scope
+  // of this analysis.
+  exists(AsmStmt asm | asm.getEnclosingFunction() = f)
 }
 
 from Stmt stmt, string msg, Function f, ControlFlowNode blame

--- a/cpp/ql/test/query-tests/jsf/4.13 Functions/AV Rule 114/AV Rule 114.expected
+++ b/cpp/ql/test/query-tests/jsf/4.13 Functions/AV Rule 114/AV Rule 114.expected
@@ -3,7 +3,6 @@
 | test.c:8:5:8:14 | declaration | Function f2 should return a value of type int but does not return a value here |
 | test.c:25:9:25:14 | ExprStmt | Function f4 should return a value of type int but does not return a value here |
 | test.c:39:9:39:14 | ExprStmt | Function f6 should return a value of type int but does not return a value here |
-| test.c:100:2:100:18 | asm statement | Function f14 should return a value of type int but does not return a value here |
 | test.cpp:16:1:18:1 | { ... } | Function g2 should return a value of type MyValue but does not return a value here |
 | test.cpp:48:2:48:26 | if (...) ...  | Function g7 should return a value of type MyValue but does not return a value here |
 | test.cpp:74:1:76:1 | { ... } | Function g10 should return a value of type second but does not return a value here |

--- a/cpp/ql/test/query-tests/jsf/4.13 Functions/AV Rule 114/AV Rule 114.expected
+++ b/cpp/ql/test/query-tests/jsf/4.13 Functions/AV Rule 114/AV Rule 114.expected
@@ -3,6 +3,7 @@
 | test.c:8:5:8:14 | declaration | Function f2 should return a value of type int but does not return a value here |
 | test.c:25:9:25:14 | ExprStmt | Function f4 should return a value of type int but does not return a value here |
 | test.c:39:9:39:14 | ExprStmt | Function f6 should return a value of type int but does not return a value here |
+| test.c:100:2:100:18 | asm statement | Function f14 should return a value of type int but does not return a value here |
 | test.cpp:16:1:18:1 | { ... } | Function g2 should return a value of type MyValue but does not return a value here |
 | test.cpp:48:2:48:26 | if (...) ...  | Function g7 should return a value of type MyValue but does not return a value here |
 | test.cpp:74:1:76:1 | { ... } | Function g10 should return a value of type second but does not return a value here |

--- a/cpp/ql/test/query-tests/jsf/4.13 Functions/AV Rule 114/test.c
+++ b/cpp/ql/test/query-tests/jsf/4.13 Functions/AV Rule 114/test.c
@@ -97,5 +97,5 @@ void f13_func(int x)
 
 int f14()
 {
-	__asm__("rdtsc"); // GOOD [FALSE POSITIVE]
+	__asm__("rdtsc"); // GOOD
 }

--- a/cpp/ql/test/query-tests/jsf/4.13 Functions/AV Rule 114/test.c
+++ b/cpp/ql/test/query-tests/jsf/4.13 Functions/AV Rule 114/test.c
@@ -94,3 +94,8 @@ void f13_func(int x)
 {
 	if (x < 10) return; // GOOD
 }
+
+int f14()
+{
+	__asm__("rdtsc"); // GOOD [FALSE POSITIVE]
+}


### PR DESCRIPTION
Fixes https://github.com/Semmle/ql/issues/2595.