### PR TITLE
Assign where compare meant false positives

### DIFF
--- a/cpp/ql/src/Likely Bugs/Likely Typos/AssignWhereCompareMeant.ql
+++ b/cpp/ql/src/Likely Bugs/Likely Typos/AssignWhereCompareMeant.ql
@@ -65,7 +65,8 @@ class BooleanControllingAssignmentInStmt extends BooleanControllingAssignment {
  */
 predicate candidateResult(BooleanControllingAssignment ae) {
   ae.getRValue().isConstant() and
-  not ae.isWhitelisted()
+  not ae.isWhitelisted() and
+  not ae.getRValue() instanceof StringLiteral
 }
 
 /**

--- a/cpp/ql/src/Likely Bugs/Likely Typos/AssignWhereCompareMeant.ql
+++ b/cpp/ql/src/Likely Bugs/Likely Typos/AssignWhereCompareMeant.ql
@@ -81,5 +81,6 @@ predicate candidateVariable(Variable v) {
 from BooleanControllingAssignment ae, UndefReachability undef
 where
   candidateResult(ae) and
+  not ae.isFromUninstantiatedTemplate(_) and
   not undef.reaches(_, ae.getLValue().(VariableAccess).getTarget(), ae.getLValue())
 select ae, "Use of '=' where '==' may have been intended."

--- a/cpp/ql/test/query-tests/Likely Bugs/Likely Typos/AssignWhereCompareMeant/AssignWhereCompareMeant.expected
+++ b/cpp/ql/test/query-tests/Likely Bugs/Likely Typos/AssignWhereCompareMeant/AssignWhereCompareMeant.expected
@@ -14,11 +14,8 @@
 | test.cpp:84:7:84:11 | ... = ... | Use of '=' where '==' may have been intended. |
 | test.cpp:92:17:92:22 | ... = ... | Use of '=' where '==' may have been intended. |
 | test.cpp:113:6:113:10 | ... = ... | Use of '=' where '==' may have been intended. |
-| test.cpp:129:17:129:21 | ... = ... | Use of '=' where '==' may have been intended. |
 | test.cpp:134:19:134:23 | ... = ... | Use of '=' where '==' may have been intended. |
 | test.cpp:138:21:138:25 | ... = ... | Use of '=' where '==' may have been intended. |
-| test.cpp:141:7:141:11 | ... = ... | Use of '=' where '==' may have been intended. |
 | test.cpp:144:32:144:36 | ... = ... | Use of '=' where '==' may have been intended. |
-| test.cpp:147:41:147:45 | ... = ... | Use of '=' where '==' may have been intended. |
 | test.cpp:150:32:150:36 | ... = ... | Use of '=' where '==' may have been intended. |
 | test.cpp:153:46:153:50 | ... = ... | Use of '=' where '==' may have been intended. |

--- a/cpp/ql/test/query-tests/Likely Bugs/Likely Typos/AssignWhereCompareMeant/AssignWhereCompareMeant.expected
+++ b/cpp/ql/test/query-tests/Likely Bugs/Likely Typos/AssignWhereCompareMeant/AssignWhereCompareMeant.expected
@@ -14,3 +14,11 @@
 | test.cpp:84:7:84:11 | ... = ... | Use of '=' where '==' may have been intended. |
 | test.cpp:92:17:92:22 | ... = ... | Use of '=' where '==' may have been intended. |
 | test.cpp:113:6:113:10 | ... = ... | Use of '=' where '==' may have been intended. |
+| test.cpp:129:17:129:21 | ... = ... | Use of '=' where '==' may have been intended. |
+| test.cpp:134:19:134:23 | ... = ... | Use of '=' where '==' may have been intended. |
+| test.cpp:138:21:138:25 | ... = ... | Use of '=' where '==' may have been intended. |
+| test.cpp:141:7:141:11 | ... = ... | Use of '=' where '==' may have been intended. |
+| test.cpp:144:32:144:36 | ... = ... | Use of '=' where '==' may have been intended. |
+| test.cpp:147:41:147:45 | ... = ... | Use of '=' where '==' may have been intended. |
+| test.cpp:150:32:150:36 | ... = ... | Use of '=' where '==' may have been intended. |
+| test.cpp:153:46:153:50 | ... = ... | Use of '=' where '==' may have been intended. |

--- a/cpp/ql/test/query-tests/Likely Bugs/Likely Typos/AssignWhereCompareMeant/AssignWhereCompareMeant.expected
+++ b/cpp/ql/test/query-tests/Likely Bugs/Likely Typos/AssignWhereCompareMeant/AssignWhereCompareMeant.expected
@@ -14,4 +14,3 @@
 | test.cpp:84:7:84:11 | ... = ... | Use of '=' where '==' may have been intended. |
 | test.cpp:92:17:92:22 | ... = ... | Use of '=' where '==' may have been intended. |
 | test.cpp:113:6:113:10 | ... = ... | Use of '=' where '==' may have been intended. |
-| test.cpp:124:6:124:15 | ... = ... | Use of '=' where '==' may have been intended. |

--- a/cpp/ql/test/query-tests/Likely Bugs/Likely Typos/AssignWhereCompareMeant/AssignWhereCompareMeant.expected
+++ b/cpp/ql/test/query-tests/Likely Bugs/Likely Typos/AssignWhereCompareMeant/AssignWhereCompareMeant.expected
@@ -13,3 +13,6 @@
 | test.cpp:82:7:82:11 | ... = ... | Use of '=' where '==' may have been intended. |
 | test.cpp:84:7:84:11 | ... = ... | Use of '=' where '==' may have been intended. |
 | test.cpp:92:17:92:22 | ... = ... | Use of '=' where '==' may have been intended. |
+| test.cpp:105:6:105:10 | ... = ... | Use of '=' where '==' may have been intended. |
+| test.cpp:113:6:113:10 | ... = ... | Use of '=' where '==' may have been intended. |
+| test.cpp:113:6:113:10 | ... = ... | Use of '=' where '==' may have been intended. |

--- a/cpp/ql/test/query-tests/Likely Bugs/Likely Typos/AssignWhereCompareMeant/AssignWhereCompareMeant.expected
+++ b/cpp/ql/test/query-tests/Likely Bugs/Likely Typos/AssignWhereCompareMeant/AssignWhereCompareMeant.expected
@@ -14,3 +14,4 @@
 | test.cpp:84:7:84:11 | ... = ... | Use of '=' where '==' may have been intended. |
 | test.cpp:92:17:92:22 | ... = ... | Use of '=' where '==' may have been intended. |
 | test.cpp:113:6:113:10 | ... = ... | Use of '=' where '==' may have been intended. |
+| test.cpp:124:6:124:15 | ... = ... | Use of '=' where '==' may have been intended. |

--- a/cpp/ql/test/query-tests/Likely Bugs/Likely Typos/AssignWhereCompareMeant/AssignWhereCompareMeant.expected
+++ b/cpp/ql/test/query-tests/Likely Bugs/Likely Typos/AssignWhereCompareMeant/AssignWhereCompareMeant.expected
@@ -13,6 +13,4 @@
 | test.cpp:82:7:82:11 | ... = ... | Use of '=' where '==' may have been intended. |
 | test.cpp:84:7:84:11 | ... = ... | Use of '=' where '==' may have been intended. |
 | test.cpp:92:17:92:22 | ... = ... | Use of '=' where '==' may have been intended. |
-| test.cpp:105:6:105:10 | ... = ... | Use of '=' where '==' may have been intended. |
-| test.cpp:113:6:113:10 | ... = ... | Use of '=' where '==' may have been intended. |
 | test.cpp:113:6:113:10 | ... = ... | Use of '=' where '==' may have been intended. |

--- a/cpp/ql/test/query-tests/Likely Bugs/Likely Typos/AssignWhereCompareMeant/test.cpp
+++ b/cpp/ql/test/query-tests/Likely Bugs/Likely Typos/AssignWhereCompareMeant/test.cpp
@@ -124,3 +124,32 @@ void f2() {
   if(sz = "def") { // GOOD: a == comparison with a string literal is probably not the intent here
   }
 }
+
+void f3(int x, int y) {
+  if(x == 1 && (y = 2)) { // GOOD [FALSE POSITIVE]: the programmer seems to be okay with unparenthesized
+                          // comparison operands, so the parenthesis was used to mark this
+                          // as an assignment
+  }
+
+  if((x == 1) && (y = 2)) { // BAD
+  }
+
+  long z = x;
+  if(((z == 42) || (y = 2)) && (x == 1)) { // BAD
+  }
+
+  if((y = 2) && (x == z || x == 1)) { // GOOD [FALSE POSITIVE]
+  }
+
+  if(((x == 42) || x == 1) && (y = 2)) { // BAD
+  }
+
+  if(x == 10 || (x == 42 && x == 1) && (y = 2)) { // GOOD [FALSE POSITIVE]
+  }
+
+  if(x == 10 || ((x == 42) && (y = 2)) && (z == 1)) { // BAD
+  }
+
+  if((x == 10) || ((z == z) && (x == 1)) && (y = 2)) { // BAD
+  }
+}

--- a/cpp/ql/test/query-tests/Likely Bugs/Likely Typos/AssignWhereCompareMeant/test.cpp
+++ b/cpp/ql/test/query-tests/Likely Bugs/Likely Typos/AssignWhereCompareMeant/test.cpp
@@ -121,6 +121,6 @@ void f() {
 void f2() {
   const char* sz = "abc";
 
-  if(sz = "def") { // GOOD [FALSE POSITIVE]: a == comparison with a string literal is probably not the intent here
+  if(sz = "def") { // GOOD: a == comparison with a string literal is probably not the intent here
   }
 }

--- a/cpp/ql/test/query-tests/Likely Bugs/Likely Typos/AssignWhereCompareMeant/test.cpp
+++ b/cpp/ql/test/query-tests/Likely Bugs/Likely Typos/AssignWhereCompareMeant/test.cpp
@@ -102,7 +102,7 @@ void g(int *i_p, int cond) {
 template<typename>
 void h() {
   int x;
-  if(x = 0) { // GOOD [FALSE POSITIVE]: x is not initialized so this is probably intensional
+  if(x = 0) { // GOOD: x is not initialized so this is probably intensional
   }
 
   int y = 0;

--- a/cpp/ql/test/query-tests/Likely Bugs/Likely Typos/AssignWhereCompareMeant/test.cpp
+++ b/cpp/ql/test/query-tests/Likely Bugs/Likely Typos/AssignWhereCompareMeant/test.cpp
@@ -98,3 +98,22 @@ void g(int *i_p, int cond) {
   if (y = 1) { // GOOD: y might not be initialized so it is probably intentional.
   }
 }
+
+template<typename>
+void h() {
+  int x;
+  if(x = 0) { // GOOD [FALSE POSITIVE]: x is not initialized so this is probably intensional
+  }
+
+  int y = 0;
+  if((y = 1)) { // GOOD
+  }
+
+  int z = 0;
+  if(z = 1) { // BAD
+  }
+}
+
+void f() {
+  h<int>();
+}

--- a/cpp/ql/test/query-tests/Likely Bugs/Likely Typos/AssignWhereCompareMeant/test.cpp
+++ b/cpp/ql/test/query-tests/Likely Bugs/Likely Typos/AssignWhereCompareMeant/test.cpp
@@ -126,7 +126,7 @@ void f2() {
 }
 
 void f3(int x, int y) {
-  if(x == 1 && (y = 2)) { // GOOD [FALSE POSITIVE]: the programmer seems to be okay with unparenthesized
+  if(x == 1 && (y = 2)) { // GOOD: the programmer seems to be okay with unparenthesized
                           // comparison operands, so the parenthesis was used to mark this
                           // as an assignment
   }
@@ -138,13 +138,13 @@ void f3(int x, int y) {
   if(((z == 42) || (y = 2)) && (x == 1)) { // BAD
   }
 
-  if((y = 2) && (x == z || x == 1)) { // GOOD [FALSE POSITIVE]
+  if((y = 2) && (x == z || x == 1)) { // GOOD
   }
 
   if(((x == 42) || x == 1) && (y = 2)) { // BAD
   }
 
-  if(x == 10 || (x == 42 && x == 1) && (y = 2)) { // GOOD [FALSE POSITIVE]
+  if(x == 10 || (x == 42 && x == 1) && (y = 2)) { // GOOD
   }
 
   if(x == 10 || ((x == 42) && (y = 2)) && (z == 1)) { // BAD

--- a/cpp/ql/test/query-tests/Likely Bugs/Likely Typos/AssignWhereCompareMeant/test.cpp
+++ b/cpp/ql/test/query-tests/Likely Bugs/Likely Typos/AssignWhereCompareMeant/test.cpp
@@ -117,3 +117,10 @@ void h() {
 void f() {
   h<int>();
 }
+
+void f2() {
+  const char* sz = "abc";
+
+  if(sz = "def") { // GOOD [FALSE POSITIVE]: a == comparison with a string literal is probably not the intent here
+  }
+}


### PR DESCRIPTION
Implements the techniques for reducing the false positive rate of the query `cpp/assign-where-compare-meant` as described in https://jira.semmle.com/browse/CPP-483.

Differences query: https://lgtm.com/query/8401788255056547968/