### PR TITLE
Java: Add a query for suspicious date format patterns.

### DIFF
--- a/change-notes/1.24/analysis-java.md
+++ b/change-notes/1.24/analysis-java.md
@@ -11,6 +11,7 @@ The following changes in version 1.24 affect Java analysis in all applications.
 | **Query**                   | **Tags**  | **Purpose**                                                        |
 |-----------------------------|-----------|--------------------------------------------------------------------|
 | Failure to use HTTPS or SFTP URL in Maven artifact upload/download (`java/maven/non-https-url`) | security, external/cwe/cwe-300, external/cwe/cwe-319, external/cwe/cwe-494, external/cwe/cwe-829 | Finds use of insecure protocols during Maven dependency resolution. Results are shown on LGTM by default. |
+| Suspicious date format (`java/suspicious-date-format`) | correctness | Finds date format patterns that use placeholders that are likely to be incorrect. |
 
 ## Changes to existing queries
 

--- a/java/ql/src/Likely Bugs/Likely Typos/SuspiciousDateFormat.java
+++ b/java/ql/src/Likely Bugs/Likely Typos/SuspiciousDateFormat.java
@@ -1,0 +1,1 @@
+System.out.println(new SimpleDateFormat("YYYY-MM-dd").format(new Date()));

--- a/java/ql/src/Likely Bugs/Likely Typos/SuspiciousDateFormat.qhelp
+++ b/java/ql/src/Likely Bugs/Likely Typos/SuspiciousDateFormat.qhelp
@@ -1,0 +1,36 @@
+<!DOCTYPE qhelp PUBLIC
+  "-//Semmle//qhelp//EN"
+  "qhelp.dtd">
+<qhelp>
+
+
+<overview>
+<p>
+Some <code>SimpleDateFormat</code> patterns might not work correctly at the end of the calendar
+year, due to use of the <code>Y</code> placeholder (representing the ISO 8601 week year), rather
+than <code>y</code> representing the actual year.
+</p>
+</overview>
+
+<recommendation>
+<p>
+  Ensure the format pattern's use of <code>Y</code> is correct, and if not replace it with <code>y</code>.
+</p>
+</recommendation>
+
+<example>
+<p>
+  The following example uses the date format <code>YYYY-MM-dd</code>.
+  On the 30th of December 2019, this code will output "2020-12-30", rather than the intended "2019-12-30".
+</p>
+<sample src="SuspiciousDateFormat.java" />
+</example>
+
+<references>
+<li>
+  Java Platform, Standard Edition 7, API Specification:
+  <a href="https://docs.oracle.com/javase/7/docs/api/java/text/SimpleDateFormat.html">SimpleDateFormat</a>.
+</li>
+</references>
+
+</qhelp>

--- a/java/ql/src/Likely Bugs/Likely Typos/SuspiciousDateFormat.qhelp
+++ b/java/ql/src/Likely Bugs/Likely Typos/SuspiciousDateFormat.qhelp
@@ -6,9 +6,12 @@
 
 <overview>
 <p>
-Some <code>SimpleDateFormat</code> patterns might not work correctly at the end of the calendar
-year, due to use of the <code>Y</code> placeholder (representing the ISO 8601 week year), rather
-than <code>y</code> representing the actual year.
+  The Java <code>SimpleDateFormat</code> class provides many placeholders so that you can define
+  precisely the date format required. However, this also makes it easy to define a pattern that
+  doesn't behave exactly as you intended. The most common mistake is to use the <code>Y</code>
+  placeholder (which represents the ISO 8601 week year), rather than <code>y</code> (which
+  represents the actual year). In this case, the date reported will appear correct until the end
+  of the year, when the "week year" may differ from the actual year.
 </p>
 </overview>
 
@@ -24,6 +27,9 @@ than <code>y</code> representing the actual year.
   On the 30th of December 2019, this code will output "2020-12-30", rather than the intended "2019-12-30".
 </p>
 <sample src="SuspiciousDateFormat.java" />
+<p>
+  The correct pattern in this case would be <code>yyyy-MM-dd</code> instead of <code>YYYY-MM-dd</code>.
+</p>
 </example>
 
 <references>

--- a/java/ql/src/Likely Bugs/Likely Typos/SuspiciousDateFormat.ql
+++ b/java/ql/src/Likely Bugs/Likely Typos/SuspiciousDateFormat.ql
@@ -1,0 +1,19 @@
+/**
+ * @name Suspicious date format
+ * @description Some date format patterns don't work as they might seem.
+ * @kind problem
+ * @problem.severity warning
+ * @precision high
+ * @id java/suspicious-date-format
+ * @tags correctness
+ */
+
+import java
+
+from ConstructorCall c, string format
+where
+  c.getConstructedType().hasQualifiedName("java.text", "SimpleDateFormat") and
+  format = c.getArgument(0).(StringLiteral).getValue() and
+  format.matches("%Y%") and
+  format.matches("%M%")
+select c, "Date formatter is passed a suspicious pattern \"" + format + "\"."

--- a/java/ql/src/Likely Bugs/Likely Typos/SuspiciousDateFormat.ql
+++ b/java/ql/src/Likely Bugs/Likely Typos/SuspiciousDateFormat.ql
@@ -1,6 +1,6 @@
 /**
  * @name Suspicious date format
- * @description Some date format patterns don't work as they might seem.
+ * @description Using a data format that includes both 'M' and 'Y' is likely to give unexpected results.
  * @kind problem
  * @problem.severity warning
  * @precision high

--- a/java/ql/test/query-tests/SuspiciousDateFormat/A.java
+++ b/java/ql/test/query-tests/SuspiciousDateFormat/A.java
@@ -1,0 +1,10 @@
+import java.text.SimpleDateFormat;
+import java.util.Date;
+
+public class A {
+	public static void main(String[] args) {
+		System.out.println(new SimpleDateFormat("yyyy-MM-dd").format(new Date())); // OK
+		System.out.println(new SimpleDateFormat("YYYY-ww").format(new Date())); // OK
+		System.out.println(new SimpleDateFormat("YYYY-MM-dd").format(new Date())); // BAD
+	}
+}

--- a/java/ql/test/query-tests/SuspiciousDateFormat/SuspiciousDateFormat.expected
+++ b/java/ql/test/query-tests/SuspiciousDateFormat/SuspiciousDateFormat.expected
@@ -1,0 +1,1 @@
+| A.java:8:22:8:55 | new SimpleDateFormat(...) | Date formatter is passed a suspicious pattern "YYYY-MM-dd". |

--- a/java/ql/test/query-tests/SuspiciousDateFormat/SuspiciousDateFormat.qlref
+++ b/java/ql/test/query-tests/SuspiciousDateFormat/SuspiciousDateFormat.qlref
@@ -1,0 +1,1 @@
+Likely Bugs/Likely Typos/SuspiciousDateFormat.ql


### PR DESCRIPTION
:wave:

This adds a query that looks for Java `SimpleDateFormat` constructors that are passed patterns containing both "Y" and "M". "Y" represents the ISO 8601 week year, but "M" represents the standard calendar month, so using both in conjunction yields strange results that were probably not intended.

Using "Y" instead of "y" is a particularly easy mistake to make, even with extensive testing, because the majority of the year the formatter will return the correct value. It's only when everyone is having a relaxing holiday break that the latent bug will appear. :laughing:

This query [yields 70 results on LGTM.com projects](https://lgtm.com/query/3464192845627103176/), with all the results appearing to be true positives.

Some of the format patterns in the results are totally invalid (containing placeholders that are not recognized at all), but many would appear to work correctly until the end of the year, only then returning an incorrect result. Potentially there is room to further expand this query to detect syntactically invalid patterns too, but that would require a bit more sophisticated parsing of the pattern to remove quoted strings.