### PR TITLE
CPP: Exclude template classes from cpp/assignment-does-not-return-this

### DIFF
--- a/change-notes/1.24/analysis-cpp.md
+++ b/change-notes/1.24/analysis-cpp.md
@@ -19,6 +19,7 @@ The following changes in version 1.24 affect C/C++ analysis in all applications.
 | Memory may not be freed (`cpp/memory-may-not-be-freed`) | More true positive results | This query now identifies a wider variety of buffer allocations using the `semmle.code.cpp.models.interfaces.Allocation` library. |
 | Hard-coded Japanese era start date (`cpp/japanese-era/exact-era-date`) |  | This query is no longer run on LGTM. |
 | No space for zero terminator (`cpp/no-space-for-terminator`) | Fewer false positive results | This query has been modified to be more conservative when identifying which pointers point to null-terminated strings.  This approach produces fewer, more accurate results. |
+| Overloaded assignment does not return 'this' (`cpp/assignment-does-not-return-this`) | Fewer false positive results | This query no longer reports incorrect results in template classes. |
 | Unsafe array for days of the year (`cpp/leap-year/unsafe-array-for-days-of-the-year`) |  | This query is no longer run on LGTM. |
 
 ## Changes to libraries

--- a/cpp/ql/src/jsf/4.10 Classes/AV Rule 82.ql
+++ b/cpp/ql/src/jsf/4.10 Classes/AV Rule 82.ql
@@ -93,6 +93,10 @@ predicate assignOperatorWithWrongResult(Operator op, string msg) {
 
 from Operator op, string msg
 where
-  assignOperatorWithWrongType(op, msg) or
-  assignOperatorWithWrongResult(op, msg)
+  (
+    assignOperatorWithWrongType(op, msg) or
+    assignOperatorWithWrongResult(op, msg)
+  ) and
+  // exclude template classes which may have incomplete function bodies
+  not op.getDeclaringType() instanceof TemplateClass
 select op, msg

--- a/cpp/ql/src/jsf/4.10 Classes/AV Rule 82.ql
+++ b/cpp/ql/src/jsf/4.10 Classes/AV Rule 82.ql
@@ -97,6 +97,6 @@ where
     assignOperatorWithWrongType(op, msg) or
     assignOperatorWithWrongResult(op, msg)
   ) and
-  // exclude template classes which may have incomplete function bodies
-  not op.getDeclaringType() instanceof TemplateClass
+  // exclude code in templates which may be incomplete
+  not op.isFromUninstantiatedTemplate(_)
 select op, msg

--- a/cpp/ql/test/query-tests/jsf/4.10 Classes/AV Rule 82/AV Rule 82.cpp
+++ b/cpp/ql/test/query-tests/jsf/4.10 Classes/AV Rule 82/AV Rule 82.cpp
@@ -201,6 +201,18 @@ struct TemplatedAssignmentBad {
   }
 };
 
+template<class T>
+class Obj3 {
+public:
+  Obj3<T> &subFunc(const Obj3<T> &other) {
+    return *this;
+  }
+
+  Obj3<T> &operator=(const Obj3<T> &other) {
+    return subFunc(other); // GOOD (returns *this) [FALSE POSITIVE]
+  }
+};
+
 int main() {
   Container c;
   c = c;
@@ -211,5 +223,7 @@ int main() {
   taGood = 3;
   TemplatedAssignmentBad taBad;
   taBad = 4;
+  Obj3<int> obj3_a, obj3_b;
+  obj3_a = obj3_b;
   return 0;
 }

--- a/cpp/ql/test/query-tests/jsf/4.10 Classes/AV Rule 82/AV Rule 82.cpp
+++ b/cpp/ql/test/query-tests/jsf/4.10 Classes/AV Rule 82/AV Rule 82.cpp
@@ -209,7 +209,7 @@ public:
   }
 
   Obj3<T> &operator=(const Obj3<T> &other) {
-    return subFunc(other); // GOOD (returns *this) [FALSE POSITIVE]
+    return subFunc(other); // GOOD (returns *this)
   }
 };
 

--- a/cpp/ql/test/query-tests/jsf/4.10 Classes/AV Rule 82/AV Rule 82.expected
+++ b/cpp/ql/test/query-tests/jsf/4.10 Classes/AV Rule 82/AV Rule 82.expected
@@ -3,3 +3,4 @@
 | AV Rule 82.cpp:63:29:63:29 | operator= | Assignment operator in class TemplateReturnAssignment<int> does not return a reference to *this. |
 | AV Rule 82.cpp:63:29:63:37 | operator= | Assignment operator in class TemplateReturnAssignment<T> does not return a reference to *this. |
 | AV Rule 82.cpp:199:52:199:52 | operator= | Assignment operator in class TemplatedAssignmentBad should have return type TemplatedAssignmentBad&. Otherwise a copy is created at each call. |
+| AV Rule 82.cpp:211:12:211:20 | operator= | Assignment operator in class Obj3<T> does not return a reference to *this. |

--- a/cpp/ql/test/query-tests/jsf/4.10 Classes/AV Rule 82/AV Rule 82.expected
+++ b/cpp/ql/test/query-tests/jsf/4.10 Classes/AV Rule 82/AV Rule 82.expected
@@ -1,6 +1,4 @@
 | AV Rule 82.cpp:18:9:18:17 | operator= | Assignment operator in class Bad1 does not return a reference to *this. |
 | AV Rule 82.cpp:24:8:24:16 | operator= | Assignment operator in class Bad2 should have return type Bad2&. Otherwise a copy is created at each call. |
 | AV Rule 82.cpp:63:29:63:29 | operator= | Assignment operator in class TemplateReturnAssignment<int> does not return a reference to *this. |
-| AV Rule 82.cpp:63:29:63:37 | operator= | Assignment operator in class TemplateReturnAssignment<T> does not return a reference to *this. |
 | AV Rule 82.cpp:199:52:199:52 | operator= | Assignment operator in class TemplatedAssignmentBad should have return type TemplatedAssignmentBad&. Otherwise a copy is created at each call. |
-| AV Rule 82.cpp:211:12:211:20 | operator= | Assignment operator in class Obj3<T> does not return a reference to *this. |


### PR DESCRIPTION
It's the usual problem with template classes, that they may be missing data we'd expect to be there in normal classes (in this case the expression of a `return` statement).  Issues are still reported in template class instantiations.

Fixes https://github.com/Semmle/ql/issues/2600.