### PR TITLE
Java: allow single-line `/* ... */` comments for alert suppression

### DIFF
--- a/change-notes/1.24/analysis-java.md
+++ b/change-notes/1.24/analysis-java.md
@@ -2,6 +2,10 @@
 
 The following changes in version 1.24 affect Java analysis in all applications.
 
+## General improvements
+
+* Alert suppression can now be done with single-line block comments (`/* ... */`) as well as line comments (`// ...`).
+
 ## New queries
 
 | **Query**                   | **Tags**  | **Purpose**                                                        |

--- a/java/ql/src/AlertSuppression.ql
+++ b/java/ql/src/AlertSuppression.ql
@@ -14,7 +14,12 @@ class SuppressionComment extends Javadoc {
   string annotation;
 
   SuppressionComment() {
-    isEolComment(this) and
+    // suppression comments must be single-line
+    (
+      isEolComment(this)
+      or
+      isNormalComment(this) and exists(int line | hasLocationInfo(_, line, _, line, _))
+    ) and
     exists(string text | text = getChild(0).getText() |
       // match `lgtm[...]` anywhere in the comment
       annotation = text.regexpFind("(?i)\\blgtm\\s*\\[[^\\]]*\\]", _, _)

--- a/java/ql/test/query-tests/AlertSuppression/AlertSuppression.expected
+++ b/java/ql/test/query-tests/AlertSuppression/AlertSuppression.expected
@@ -8,6 +8,7 @@
 | Test.java:8:1:8:18 | // lgtm: blah blah |  lgtm: blah blah | lgtm | Test.java:8:1:8:18 | suppression range |
 | Test.java:9:1:9:32 | // lgtm blah blah #falsepositive |  lgtm blah blah #falsepositive | lgtm | Test.java:9:1:9:32 | suppression range |
 | Test.java:10:1:10:36 | //lgtm  [java/confusing-method-name] | lgtm  [java/confusing-method-name] | lgtm  [java/confusing-method-name] | Test.java:10:1:10:36 | suppression range |
+| Test.java:11:1:11:10 | /* lgtm */ | lgtm | lgtm | Test.java:11:1:11:10 | suppression range |
 | Test.java:12:1:12:9 | // lgtm[] |  lgtm[] | lgtm[] | Test.java:12:1:12:9 | suppression range |
 | Test.java:14:1:14:6 | //lgtm | lgtm | lgtm | Test.java:14:1:14:6 | suppression range |
 | Test.java:15:1:15:7 | //\tlgtm | \tlgtm | lgtm | Test.java:15:1:15:7 | suppression range |
@@ -22,6 +23,10 @@
 | Test.java:27:1:27:78 | //lgtm[java/confusing-method-name] and lgtm[java/non-short-circuit-evaluation] | lgtm[java/confusing-method-name] and lgtm[java/non-short-circuit-evaluation] | lgtm[java/non-short-circuit-evaluation] | Test.java:27:1:27:78 | suppression range |
 | Test.java:28:1:28:40 | //lgtm[java/confusing-method-name]; lgtm | lgtm[java/confusing-method-name]; lgtm | lgtm | Test.java:28:1:28:40 | suppression range |
 | Test.java:28:1:28:40 | //lgtm[java/confusing-method-name]; lgtm | lgtm[java/confusing-method-name]; lgtm | lgtm[java/confusing-method-name] | Test.java:28:1:28:40 | suppression range |
+| Test.java:29:1:29:12 | /* lgtm[] */ | lgtm[] | lgtm[] | Test.java:29:1:29:12 | suppression range |
+| Test.java:30:1:30:38 | /* lgtm[java/confusing-method-name] */ | lgtm[java/confusing-method-name] | lgtm[java/confusing-method-name] | Test.java:30:1:30:38 | suppression range |
+| Test.java:36:1:36:52 | /* lgtm[@tag:nullness,java/confusing-method-name] */ | lgtm[@tag:nullness,java/confusing-method-name] | lgtm[@tag:nullness,java/confusing-method-name] | Test.java:36:1:36:52 | suppression range |
+| Test.java:37:1:37:25 | /* lgtm[@tag:nullness] */ | lgtm[@tag:nullness] | lgtm[@tag:nullness] | Test.java:37:1:37:25 | suppression range |
 | TestWindows.java:1:22:1:29 | // lgtm |  lgtm | lgtm | TestWindows.java:1:1:1:29 | suppression range |
 | TestWindows.java:2:1:2:36 | // lgtm[java/confusing-method-name] |  lgtm[java/confusing-method-name] | lgtm[java/confusing-method-name] | TestWindows.java:2:1:2:36 | suppression range |
 | TestWindows.java:3:1:3:71 | // lgtm[java/confusing-method-name, java/non-short-circuit-evaluation] |  lgtm[java/confusing-method-name, java/non-short-circuit-evaluation] | lgtm[java/confusing-method-name, java/non-short-circuit-evaluation] | TestWindows.java:3:1:3:71 | suppression range |
@@ -32,6 +37,7 @@
 | TestWindows.java:8:1:8:19 | // lgtm: blah blah |  lgtm: blah blah | lgtm | TestWindows.java:8:1:8:19 | suppression range |
 | TestWindows.java:9:1:9:33 | // lgtm blah blah #falsepositive |  lgtm blah blah #falsepositive | lgtm | TestWindows.java:9:1:9:33 | suppression range |
 | TestWindows.java:10:1:10:37 | //lgtm  [java/confusing-method-name] | lgtm  [java/confusing-method-name] | lgtm  [java/confusing-method-name] | TestWindows.java:10:1:10:37 | suppression range |
+| TestWindows.java:11:1:11:10 | /* lgtm */ | lgtm | lgtm | TestWindows.java:11:1:11:10 | suppression range |
 | TestWindows.java:12:1:12:10 | // lgtm[] |  lgtm[] | lgtm[] | TestWindows.java:12:1:12:10 | suppression range |
 | TestWindows.java:14:1:14:7 | //lgtm | lgtm | lgtm | TestWindows.java:14:1:14:7 | suppression range |
 | TestWindows.java:15:1:15:8 | //\tlgtm | \tlgtm | lgtm | TestWindows.java:15:1:15:8 | suppression range |
@@ -46,3 +52,7 @@
 | TestWindows.java:27:1:27:79 | //lgtm[java/confusing-method-name] and lgtm[java/non-short-circuit-evaluation] | lgtm[java/confusing-method-name] and lgtm[java/non-short-circuit-evaluation] | lgtm[java/non-short-circuit-evaluation] | TestWindows.java:27:1:27:79 | suppression range |
 | TestWindows.java:28:1:28:41 | //lgtm[java/confusing-method-name]; lgtm | lgtm[java/confusing-method-name]; lgtm | lgtm | TestWindows.java:28:1:28:41 | suppression range |
 | TestWindows.java:28:1:28:41 | //lgtm[java/confusing-method-name]; lgtm | lgtm[java/confusing-method-name]; lgtm | lgtm[java/confusing-method-name] | TestWindows.java:28:1:28:41 | suppression range |
+| TestWindows.java:29:1:29:12 | /* lgtm[] */ | lgtm[] | lgtm[] | TestWindows.java:29:1:29:12 | suppression range |
+| TestWindows.java:30:1:30:38 | /* lgtm[java/confusing-method-name] */ | lgtm[java/confusing-method-name] | lgtm[java/confusing-method-name] | TestWindows.java:30:1:30:38 | suppression range |
+| TestWindows.java:36:1:36:52 | /* lgtm[@tag:nullness,java/confusing-method-name] */ | lgtm[@tag:nullness,java/confusing-method-name] | lgtm[@tag:nullness,java/confusing-method-name] | TestWindows.java:36:1:36:52 | suppression range |
+| TestWindows.java:37:1:37:25 | /* lgtm[@tag:nullness] */ | lgtm[@tag:nullness] | lgtm[@tag:nullness] | TestWindows.java:37:1:37:25 | suppression range |

--- a/java/ql/test/query-tests/AlertSuppression/Test.java
+++ b/java/ql/test/query-tests/AlertSuppression/Test.java
@@ -26,3 +26,13 @@ class Test {} // lgtm
 // LGTM[java/confusing-method-name]
 //lgtm[java/confusing-method-name] and lgtm[java/non-short-circuit-evaluation]
 //lgtm[java/confusing-method-name]; lgtm
+/* lgtm[] */
+/* lgtm[java/confusing-method-name] */
+/* lgtm
+*/
+/* lgtm
+
+*/
+/* lgtm[@tag:nullness,java/confusing-method-name] */
+/* lgtm[@tag:nullness] */
+/** lgtm[] */

--- a/java/ql/test/query-tests/AlertSuppression/TestWindows.java
+++ b/java/ql/test/query-tests/AlertSuppression/TestWindows.java
@@ -26,3 +26,13 @@ class TestWindows {} // lgtm
 // LGTM[java/confusing-method-name]
 //lgtm[java/confusing-method-name] and lgtm[java/non-short-circuit-evaluation]
 //lgtm[java/confusing-method-name]; lgtm
+/* lgtm[] */
+/* lgtm[java/confusing-method-name] */
+/* lgtm
+*/
+/* lgtm
+
+*/
+/* lgtm[@tag:nullness,java/confusing-method-name] */
+/* lgtm[@tag:nullness] */
+/** lgtm[] */


### PR DESCRIPTION
Analogous to #2573 for cross-language consistency.