### PR TITLE
JS: Add change note for js/missing-await

### DIFF
--- a/change-notes/1.24/analysis-javascript.md
+++ b/change-notes/1.24/analysis-javascript.md
@@ -20,6 +20,7 @@
 |---------------------------------------------------------------------------------|-------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | Cross-site scripting through exception (`js/xss-through-exception`) | security, external/cwe/cwe-079, external/cwe/cwe-116              | Highlights potential XSS vulnerabilities where an exception is written to the DOM. Results are not shown on LGTM by default. |
 | Regular expression always matches (`js/regex/always-matches`) | correctness, regular-expressions | Highlights regular expression checks that trivially succeed by matching an empty substring. Results are shown on LGTM by default. |
+| Missing await (`js/missing-await`) | correctness | Highlights expressions that operate directly on a promise object in a non-sensical way, instead of awaiting its result. Results are shown on LGTM by default. |
 
 ## Changes to existing queries
 

--- a/change-notes/1.24/analysis-javascript.md
+++ b/change-notes/1.24/analysis-javascript.md
@@ -20,7 +20,7 @@
 |---------------------------------------------------------------------------------|-------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | Cross-site scripting through exception (`js/xss-through-exception`) | security, external/cwe/cwe-079, external/cwe/cwe-116              | Highlights potential XSS vulnerabilities where an exception is written to the DOM. Results are not shown on LGTM by default. |
 | Regular expression always matches (`js/regex/always-matches`) | correctness, regular-expressions | Highlights regular expression checks that trivially succeed by matching an empty substring. Results are shown on LGTM by default. |
-| Missing await (`js/missing-await`) | correctness | Highlights expressions that operate directly on a promise object in a non-sensical way, instead of awaiting its result. Results are shown on LGTM by default. |
+| Missing await (`js/missing-await`) | correctness | Highlights expressions that operate directly on a promise object in a nonsensical way, instead of awaiting its result. Results are shown on LGTM by default. |
 
 ## Changes to existing queries
 


### PR DESCRIPTION
Adds the missing change note from https://github.com/Semmle/ql/pull/2525.

@mchammer01 thanks for pointing this out - could you take a quick look?