### PR TITLE
TS: Handle monorepos by rewriting package.json

### DIFF
--- a/javascript/extractor/lib/typescript/src/common.ts
+++ b/javascript/extractor/lib/typescript/src/common.ts
@@ -7,7 +7,7 @@ import { VirtualSourceRoot } from "./virtual_source_root";
  * Extracts the package name from the prefix of an import string.
  */
 const packageNameRex = /^(?:@[\w.-]+[/\\])?\w[\w.-]*(?=[/\\]|$)/;
-const extensions = ['.ts', '.tsx', '.d.ts'];
+const extensions = ['.ts', '.tsx', '.d.ts', '.js', '.jsx'];
 
 export class Project {
   public program: ts.Program = null;

--- a/javascript/extractor/lib/typescript/src/common.ts
+++ b/javascript/extractor/lib/typescript/src/common.ts
@@ -14,8 +14,13 @@ export class Project {
   private host: ts.CompilerHost;
   private resolutionCache: ts.ModuleResolutionCache;
 
-  constructor(public tsConfig: string, public config: ts.ParsedCommandLine, public typeTable: TypeTable, public packageLocations: PackageLocationMap,
+  constructor(
+        public tsConfig: string,
+        public config: ts.ParsedCommandLine,
+        public typeTable: TypeTable,
+        public packageEntryPoints: Map<string, string>,
         public virtualSourceRoot: VirtualSourceRoot) {
+
     this.resolveModuleNames = this.resolveModuleNames.bind(this);
 
     this.resolutionCache = ts.createModuleResolutionCache(pathlib.dirname(tsConfig), ts.sys.realpath, config.options);
@@ -75,7 +80,7 @@ export class Project {
     let packageName = packageNameMatch[0];
 
     // Get the overridden location of this package, if one exists.
-    let packageEntryPoint = this.packageLocations.get(packageName);
+    let packageEntryPoint = this.packageEntryPoints.get(packageName);
     if (packageEntryPoint == null) {
       // The package is not overridden, but we have established that it begins with a valid package name.
       // Do a lookup in the virtual source root (where dependencies are installed) by changing the 'containing file'.
@@ -116,5 +121,3 @@ export class Project {
     return null;
   }
 }
-
-export type PackageLocationMap = Map<string, string>;

--- a/javascript/extractor/lib/typescript/src/common.ts
+++ b/javascript/extractor/lib/typescript/src/common.ts
@@ -88,7 +88,7 @@ export class Project {
 
     // If the requested module name is exactly the overridden package name,
     // return the entry point file (it is not necessarily called `index.ts`).
-    if (moduleName.length === packageName.length) {
+    if (moduleName === packageName) {
       return { resolvedFileName: packageEntryPoint, isExternalLibraryImport: true };
     }
 

--- a/javascript/extractor/lib/typescript/src/main.ts
+++ b/javascript/extractor/lib/typescript/src/main.ts
@@ -48,6 +48,7 @@ interface ParseCommand {
 interface OpenProjectCommand {
     command: "open-project";
     tsConfig: string;
+    virtualSourceRoot: string | null;
     packageEntryPoints: [string, string][];
     packageJsonFiles: [string, string][];
 }
@@ -261,7 +262,7 @@ function handleOpenProjectCommand(command: OpenProjectCommand) {
 
     let packageEntryPoints = new Map(command.packageEntryPoints);
     let packageJsonFiles = new Map(command.packageJsonFiles);
-    let virtualSourceRoot = new VirtualSourceRoot(process.cwd(), process.env["CODEQL_EXTRACTOR_JAVASCRIPT_SCRATCH_DIR"]);
+    let virtualSourceRoot = new VirtualSourceRoot(process.cwd(), command.virtualSourceRoot);
 
     /**
      * Rewrites path segments of form `node_modules/PACK/suffix` to be relative to
@@ -582,6 +583,7 @@ if (process.argv.length > 2) {
             tsConfig: argument,
             packageEntryPoints: [],
             packageJsonFiles: [],
+            virtualSourceRoot: null,
         });
         for (let sf of state.project.program.getSourceFiles()) {
             if (pathlib.basename(sf.fileName) === "lib.d.ts") continue;

--- a/javascript/extractor/lib/typescript/src/main.ts
+++ b/javascript/extractor/lib/typescript/src/main.ts
@@ -316,7 +316,9 @@ function handleOpenProjectCommand(command: OpenProjectCommand) {
 
     let diagnostics = program.getSemanticDiagnostics()
         .filter(d => d.category === ts.DiagnosticCategory.Error);
-    console.warn('TypeScript: reported ' + diagnostics.length + ' semantic errors.');
+    if (diagnostics.length > 0) {
+        console.warn('TypeScript: reported ' + diagnostics.length + ' semantic errors.');
+    }
     for (let diagnostic of diagnostics) {
         let text = diagnostic.messageText;
         if (text && typeof text !== 'string') {

--- a/javascript/extractor/lib/typescript/src/main.ts
+++ b/javascript/extractor/lib/typescript/src/main.ts
@@ -47,6 +47,7 @@ interface ParseCommand {
 interface OpenProjectCommand {
     command: "open-project";
     tsConfig: string;
+    packageLocations: [string, string][];
 }
 interface CloseProjectCommand {
     command: "close-project";
@@ -255,7 +256,7 @@ function handleOpenProjectCommand(command: OpenProjectCommand) {
         readFile: ts.sys.readFile,
     };
     let config = ts.parseJsonConfigFileContent(tsConfig.config, parseConfigHost, basePath);
-    let project = new Project(tsConfigFilename, config, state.typeTable);
+    let project = new Project(tsConfigFilename, config, state.typeTable, new Map(command.packageLocations));
     project.load();
 
     state.project = project;
@@ -529,6 +530,7 @@ if (process.argv.length > 2) {
         handleOpenProjectCommand({
             command: "open-project",
             tsConfig: argument,
+            packageLocations: [],
         });
         for (let sf of state.project.program.getSourceFiles()) {
             if (pathlib.basename(sf.fileName) === "lib.d.ts") continue;

--- a/javascript/extractor/lib/typescript/src/main.ts
+++ b/javascript/extractor/lib/typescript/src/main.ts
@@ -318,7 +318,7 @@ function handleOpenProjectCommand(command: OpenProjectCommand) {
     console.warn('TypeScript: reported ' + diagnostics.length + ' semantic errors.');
     for (let diagnostic of diagnostics) {
         let text = diagnostic.messageText;
-        if (typeof text !== 'string') {
+        if (text && typeof text !== 'string') {
             text = text.messageText;
         }
         let locationStr = '';

--- a/javascript/extractor/lib/typescript/src/main.ts
+++ b/javascript/extractor/lib/typescript/src/main.ts
@@ -262,6 +262,23 @@ function handleOpenProjectCommand(command: OpenProjectCommand) {
     let program = project.program;
     let typeChecker = program.getTypeChecker();
 
+    let diagnostics = program.getSemanticDiagnostics()
+        .filter(d => d.category === ts.DiagnosticCategory.Error);
+    console.warn('TypeScript: reported ' + diagnostics.length + ' semantic errors.');
+    for (let diagnostic of diagnostics) {
+        let text = diagnostic.messageText;
+        if (typeof text !== 'string') {
+            text = text.messageText;
+        }
+        let locationStr = '';
+        let { file } = diagnostic;
+        if (file != null) {
+            let { line, character } = file.getLineAndCharacterOfPosition(diagnostic.start);
+            locationStr = `${file.fileName}:${line}:${character}`;
+        }
+        console.warn(`TypeScript: ${locationStr} ${text}`);
+    }
+
     // Associate external module names with the corresponding file symbols.
     // We need these mappings to identify which module a given external type comes from.
     // The TypeScript API lets us resolve a module name to a source file, but there is no

--- a/javascript/extractor/lib/typescript/src/main.ts
+++ b/javascript/extractor/lib/typescript/src/main.ts
@@ -37,7 +37,7 @@ import * as readline from "readline";
 import * as ts from "./typescript";
 import * as ast_extractor from "./ast_extractor";
 
-import { Project, PackageLocationMap } from "./common";
+import { Project } from "./common";
 import { TypeTable } from "./type_table";
 import { VirtualSourceRoot } from "./virtual_source_root";
 

--- a/javascript/extractor/lib/typescript/src/main.ts
+++ b/javascript/extractor/lib/typescript/src/main.ts
@@ -245,6 +245,12 @@ function parseSingleFile(filename: string): {ast: ts.SourceFile, code: string} {
     return {ast, code};
 }
 
+/**
+ * Matches a path segment referencing a package in a node_modules folder, and extracts
+ * two capture groups: the package name, and the relative path in the package.
+ *
+ * For example `lib/node_modules/@foo/bar/src/index.js` extracts the capture groups [`@foo/bar`, `src/index.js`].
+ */
 const nodeModulesRex = /[/\\]node_modules[/\\]((?:@[\w.-]+[/\\])?\w[\w.-]*)[/\\](.*)/;
 
 function handleOpenProjectCommand(command: OpenProjectCommand) {

--- a/javascript/extractor/lib/typescript/src/virtual_source_root.ts
+++ b/javascript/extractor/lib/typescript/src/virtual_source_root.ts
@@ -17,7 +17,7 @@ export class VirtualSourceRoot {
   ) {}
 
   /**
-   * Maps a path under the real source root to the corresonding path in the virtual source root.
+   * Maps a path under the real source root to the corresponding path in the virtual source root.
    */
   public toVirtualPath(path: string) {
     if (!this.virtualSourceRoot) return null;
@@ -27,7 +27,7 @@ export class VirtualSourceRoot {
   }
 
   /**
-   * Maps a path under the real source root to the corresonding path in the virtual source root.
+   * Maps a path under the real source root to the corresponding path in the virtual source root.
    */
   public toVirtualPathIfFileExists(path: string) {
     let virtualPath = this.toVirtualPath(path);

--- a/javascript/extractor/lib/typescript/src/virtual_source_root.ts
+++ b/javascript/extractor/lib/typescript/src/virtual_source_root.ts
@@ -8,7 +8,10 @@ export class VirtualSourceRoot {
   constructor(
     private sourceRoot: string,
 
-    /** Directory whose folder structure mirrors the real source root, but with `node_modules` installed. */
+    /**
+     * Directory whose folder structure mirrors the real source root, but with `node_modules` installed,
+     * or undefined if no virtual source root exists.
+     */
     private virtualSourceRoot: string,
   ) {}
 
@@ -16,6 +19,7 @@ export class VirtualSourceRoot {
    * Maps a path under the real source root to the corresonding path in the virtual source root.
    */
   public toVirtualPath(path: string) {
+    if (!this.virtualSourceRoot) return null;
     let relative = pathlib.relative(this.sourceRoot, path);
     if (relative.startsWith('..') || pathlib.isAbsolute(relative)) return null;
     return pathlib.join(this.virtualSourceRoot, relative);

--- a/javascript/extractor/lib/typescript/src/virtual_source_root.ts
+++ b/javascript/extractor/lib/typescript/src/virtual_source_root.ts
@@ -2,7 +2,8 @@ import * as pathlib from "path";
 import * as ts from "./typescript";
 
 /**
- * Mapping from the source root to the virtual source root.
+ * Mapping from the real source root to the virtual source root,
+ * a directory whose folder structure mirrors the real source root, but with `node_modules` installed.
  */
 export class VirtualSourceRoot {
   constructor(

--- a/javascript/extractor/lib/typescript/src/virtual_source_root.ts
+++ b/javascript/extractor/lib/typescript/src/virtual_source_root.ts
@@ -1,0 +1,34 @@
+import * as pathlib from "path";
+import * as ts from "./typescript";
+
+/**
+ * Mapping from the source root to the virtual source root.
+ */
+export class VirtualSourceRoot {
+  constructor(
+    private sourceRoot: string,
+
+    /** Directory whose folder structure mirrors the real source root, but with `node_modules` installed. */
+    private virtualSourceRoot: string,
+  ) {}
+
+  /**
+   * Maps a path under the real source root to the corresonding path in the virtual source root.
+   */
+  public toVirtualPath(path: string) {
+    let relative = pathlib.relative(this.sourceRoot, path);
+    if (relative.startsWith('..') || pathlib.isAbsolute(relative)) return null;
+    return pathlib.join(this.virtualSourceRoot, relative);
+  }
+
+  /**
+   * Maps a path under the real source root to the corresonding path in the virtual source root.
+   */
+  public toVirtualPathIfFileExists(path: string) {
+    let virtualPath = this.toVirtualPath(path);
+    if (virtualPath != null && ts.sys.fileExists(virtualPath)) {
+        return virtualPath;
+    }
+    return null;
+  }
+}

--- a/javascript/extractor/src/com/semmle/js/extractor/AutoBuild.java
+++ b/javascript/extractor/src/com/semmle/js/extractor/AutoBuild.java
@@ -784,7 +784,7 @@ public class AutoBuild {
       }
     }
 
-    return new DependencyInstallationResult(packageMainFile, packagesInRepo);
+    return new DependencyInstallationResult(virtualSourceRoot, packageMainFile, packagesInRepo);
   }
 
   /**

--- a/javascript/extractor/src/com/semmle/js/extractor/AutoBuild.java
+++ b/javascript/extractor/src/com/semmle/js/extractor/AutoBuild.java
@@ -397,7 +397,7 @@ public class AutoBuild {
     for (FileType filetype : defaultExtract)
       for (String extension : filetype.getExtensions()) patterns.add("**/*" + extension);
 
-    // include .eslintrc files and package.json files
+    // include .eslintrc files, package.json files, and tsconfig.json files
     patterns.add("**/.eslintrc*");
     patterns.add("**/package.json");
     patterns.add("**/tsconfig.json");
@@ -601,7 +601,7 @@ public class AutoBuild {
   }
 
   /**
-   * Returns an existing file named <code>dir/stem.ext</code> where <code>ext</code> is any
+   * Returns an existing file named <code>dir/stem.ext</code> where <code>.ext</code> is any
    * of the given extensions, or <code>null</code> if no such file exists.
    */
   private static Path tryResolveWithExtensions(Path dir, String stem, Iterable<String> extensions) {
@@ -708,7 +708,7 @@ public class AutoBuild {
                 // Remove dependency on local package
                 propsToRemove.add(packageName);
               } else {
-                // Remove file dependency on a package that don't exist in the checkout.
+                // Remove file dependency on a package that doesn't exist in the checkout.
                 String dependency = getChildAsString(dependencyObj, packageName);
                 if (dependency != null && (dependency.startsWith("file:") || dependency.startsWith("./") || dependency.startsWith("../"))) {
                     if (dependency.startsWith("file:")) {

--- a/javascript/extractor/src/com/semmle/js/extractor/AutoBuild.java
+++ b/javascript/extractor/src/com/semmle/js/extractor/AutoBuild.java
@@ -801,15 +801,6 @@ public class AutoBuild {
       return resolved;
     }
 
-    // Get the "main" property from the package.json
-    // This usually refers to the compiled output, such as `./out/foo.js` but may hint as to
-    // the name of main file ("foo" in this case).
-    String mainStr = null;
-    JsonElement mainElm = packageJson.get("main");
-    if (mainElm instanceof JsonPrimitive && ((JsonPrimitive)mainElm).isString()) {
-      mainStr = mainElm.getAsString();
-    }
-
     // Look for source files `./src` if it exists
     Path sourceDir = packageDir.resolve("src");
     if (Files.isDirectory(sourceDir)) {
@@ -818,6 +809,11 @@ public class AutoBuild {
       if (resolved != null) {
         return resolved;
       }
+
+      // Get the "main" property from the package.json
+      // This usually refers to the compiled output, such as `./out/foo.js` but may hint as to
+      // the name of main file ("foo" in this case).
+      String mainStr = getChildAsString(packageJson, "main");
 
       // If "main" was defined, try to map it to a file in `src`.
       // For example `out/dist/foo.bundle.js` might be mapped back to `src/foo.ts`.

--- a/javascript/extractor/src/com/semmle/js/extractor/AutoBuild.java
+++ b/javascript/extractor/src/com/semmle/js/extractor/AutoBuild.java
@@ -202,7 +202,6 @@ public class AutoBuild {
   private final Set<String> xmlExtensions = new LinkedHashSet<>();
   private ProjectLayout filters;
   private final Path LGTM_SRC, SEMMLE_DIST;
-  private final Path scratchDir;
   private final TypeScriptMode typeScriptMode;
   private final String defaultEncoding;
   private ExecutorService threadPool;
@@ -216,7 +215,6 @@ public class AutoBuild {
   public AutoBuild() {
     this.LGTM_SRC = toRealPath(getPathFromEnvVar("LGTM_SRC"));
     this.SEMMLE_DIST = Paths.get(EnvironmentVariables.getExtractorRoot());
-    this.scratchDir = Paths.get(EnvironmentVariables.getScratchDir());
     this.outputConfig = new ExtractorOutputConfig(LegacyLanguage.JAVASCRIPT);
     this.trapCache = mkTrapCache();
     this.typeScriptMode =
@@ -643,7 +641,7 @@ public class AutoBuild {
    * Some packages must be downloaded while others exist within the same repo ("monorepos")
    * but are not in a location where TypeScript would look for it.
    * <p>
-   * Downloaded packages are intalled under {@link #scratchDir}, in a mirrored directory hierarchy
+   * Downloaded packages are intalled under <tt>SCRATCH_DIR</tt>, in a mirrored directory hierarchy
    * we call the "virtual source root".
    * Each <tt>package.json</tt> file is rewritten and copied to the virtual source root,
    * where <tt>yarn install</tt> is invoked.
@@ -662,7 +660,7 @@ public class AutoBuild {
     }
     
     final Path sourceRoot = Paths.get(".").toAbsolutePath();
-    final Path virtualSourceRoot = this.scratchDir.toAbsolutePath(); 
+    final Path virtualSourceRoot = Paths.get(EnvironmentVariables.getScratchDir()).toAbsolutePath();
 
     // Read all package.json files and index them by name.
     Map<Path, JsonObject> packageJsonFiles = new LinkedHashMap<>();

--- a/javascript/extractor/src/com/semmle/js/extractor/AutoBuild.java
+++ b/javascript/extractor/src/com/semmle/js/extractor/AutoBuild.java
@@ -782,7 +782,7 @@ public class AutoBuild {
       }
     }
 
-    return new DependencyInstallationResult(packageMainFile);
+    return new DependencyInstallationResult(packageMainFile, packagesInRepo);
   }
 
   /**

--- a/javascript/extractor/src/com/semmle/js/extractor/AutoBuild.java
+++ b/javascript/extractor/src/com/semmle/js/extractor/AutoBuild.java
@@ -709,12 +709,12 @@ public class AutoBuild {
                 propsToRemove.add(packageName);
               } else {
                 // Remove file dependency on a package that don't exist in the checkout.
-                String dependecy = getChildAsString(dependencyObj, packageName);
-                if (dependecy != null && (dependecy.startsWith("file:") || dependecy.startsWith("./") || dependecy.startsWith("../"))) {
-                    if (dependecy.startsWith("file:")) {
-                      dependecy = dependecy.substring("file:".length());
+                String dependency = getChildAsString(dependencyObj, packageName);
+                if (dependency != null && (dependency.startsWith("file:") || dependency.startsWith("./") || dependency.startsWith("../"))) {
+                    if (dependency.startsWith("file:")) {
+                      dependency = dependency.substring("file:".length());
                     }
-                    Path resolvedPackage = path.getParent().resolve(dependecy + "/package.json");
+                    Path resolvedPackage = path.getParent().resolve(dependency + "/package.json");
                     if (!Files.exists(resolvedPackage)) {
                       propsToRemove.add(packageName);
                     }

--- a/javascript/extractor/src/com/semmle/js/extractor/DependencyInstallationResult.java
+++ b/javascript/extractor/src/com/semmle/js/extractor/DependencyInstallationResult.java
@@ -6,17 +6,29 @@ import java.util.Map;
 
 /** Contains the results of installing dependencies. */
 public class DependencyInstallationResult {
+  private Path virtualSourceRoot;
   private Map<String, Path> packageEntryPoints;
   private Map<String, Path> packageJsonFiles;
 
   public static final DependencyInstallationResult empty =
-      new DependencyInstallationResult(Collections.emptyMap(), Collections.emptyMap());
+      new DependencyInstallationResult(null, Collections.emptyMap(), Collections.emptyMap());
 
   public DependencyInstallationResult(
+      Path virtualSourceRoot,
       Map<String, Path> packageEntryPoints,
       Map<String, Path> packageJsonFiles) {
     this.packageEntryPoints = packageEntryPoints;
     this.packageJsonFiles = packageJsonFiles;
+  }
+
+  /**
+   * Returns the virtual source root or <code>null</code> if no virtual source root exists.
+   *
+   * The virtual source root is a directory hierarchy that mirrors the real source
+   * root, where dependencies are installed.
+   */
+  public Path getVirtualSourceRoot() {
+    return virtualSourceRoot;
   }
 
   /**

--- a/javascript/extractor/src/com/semmle/js/extractor/DependencyInstallationResult.java
+++ b/javascript/extractor/src/com/semmle/js/extractor/DependencyInstallationResult.java
@@ -6,20 +6,31 @@ import java.util.Map;
 
 /** Contains the results of installing dependencies. */
 public class DependencyInstallationResult {
-  private Map<String, Path> packageLocations;
+  private Map<String, Path> packageEntryPoints;
+  private Map<String, Path> packageJsonFiles;
 
   public static final DependencyInstallationResult empty =
-      new DependencyInstallationResult(Collections.emptyMap());
+      new DependencyInstallationResult(Collections.emptyMap(), Collections.emptyMap());
 
-  public DependencyInstallationResult(Map<String, Path> localPackages) {
-    this.packageLocations = localPackages;
+  public DependencyInstallationResult(
+      Map<String, Path> packageEntryPoints,
+      Map<String, Path> packageJsonFiles) {
+    this.packageEntryPoints = packageEntryPoints;
+    this.packageJsonFiles = packageJsonFiles;
   }
 
   /**
    * Returns the mapping from package names to the TypeScript file that should
    * act as its main entry point.
    */
-  public Map<String, Path> getPackageLocations() {
-    return packageLocations;
+  public Map<String, Path> getPackageEntryPoints() {
+    return packageEntryPoints;
+  }
+
+  /**
+   * Returns the mapping from package name to corresponding package.json.
+   */
+  public Map<String, Path> getPackageJsonFiles() {
+    return packageJsonFiles;
   }
 }

--- a/javascript/extractor/src/com/semmle/js/extractor/DependencyInstallationResult.java
+++ b/javascript/extractor/src/com/semmle/js/extractor/DependencyInstallationResult.java
@@ -1,0 +1,26 @@
+package com.semmle.js.extractor;
+
+import java.nio.file.Path;
+import java.util.Collections;
+import java.util.Map;
+
+/**
+ * Contains the results of installing dependencies.
+ */
+public class DependencyInstallationResult {
+  private Map<Path, Path> originalFiles;
+  
+  public static final DependencyInstallationResult empty = new DependencyInstallationResult(Collections.emptyMap());
+
+  public DependencyInstallationResult(Map<Path, Path> originalFiles) {
+    this.originalFiles = originalFiles;
+  }
+
+  /**
+   * Returns the mapping from files left behind by dependency installation to
+   * the backups of those files, to be restored after extraction.
+   */
+  public Map<Path, Path> getOriginalFiles() {
+    return originalFiles;
+  }
+}

--- a/javascript/extractor/src/com/semmle/js/extractor/DependencyInstallationResult.java
+++ b/javascript/extractor/src/com/semmle/js/extractor/DependencyInstallationResult.java
@@ -4,23 +4,22 @@ import java.nio.file.Path;
 import java.util.Collections;
 import java.util.Map;
 
-/**
- * Contains the results of installing dependencies.
- */
+/** Contains the results of installing dependencies. */
 public class DependencyInstallationResult {
-  private Map<Path, Path> originalFiles;
-  
-  public static final DependencyInstallationResult empty = new DependencyInstallationResult(Collections.emptyMap());
+  private Map<String, Path> packageLocations;
 
-  public DependencyInstallationResult(Map<Path, Path> originalFiles) {
-    this.originalFiles = originalFiles;
+  public static final DependencyInstallationResult empty =
+      new DependencyInstallationResult(Collections.emptyMap());
+
+  public DependencyInstallationResult(Map<String, Path> localPackages) {
+    this.packageLocations = localPackages;
   }
 
   /**
-   * Returns the mapping from files left behind by dependency installation to
-   * the backups of those files, to be restored after extraction.
+   * Returns the mapping from package names to the TypeScript file that should
+   * act as its main entry point.
    */
-  public Map<Path, Path> getOriginalFiles() {
-    return originalFiles;
+  public Map<String, Path> getPackageLocations() {
+    return packageLocations;
   }
 }

--- a/javascript/extractor/src/com/semmle/js/extractor/EnvironmentVariables.java
+++ b/javascript/extractor/src/com/semmle/js/extractor/EnvironmentVariables.java
@@ -7,6 +7,9 @@ import com.semmle.util.process.Env.Var;
 public class EnvironmentVariables {
   public static final String CODEQL_EXTRACTOR_JAVASCRIPT_ROOT_ENV_VAR =
       "CODEQL_EXTRACTOR_JAVASCRIPT_ROOT";
+ 
+  public static final String CODEQL_EXTRACTOR_JAVASCRIPT_SCRATCH_DIR_ENV_VAR =
+      "CODEQL_EXTRACTOR_JAVASCRIPT_SCRATCH_DIR";
 
   /**
    * Gets the extractor root based on the <code>CODEQL_EXTRACTOR_JAVASCRIPT_ROOT</code> or <code>
@@ -28,6 +31,14 @@ public class EnvironmentVariables {
     String env = tryGetExtractorRoot();
     if (env == null) {
       throw new UserError("SEMMLE_DIST or CODEQL_EXTRACTOR_JAVASCRIPT_ROOT must be set");
+    }
+    return env;
+  }
+
+  public static String getScratchDir() {
+    String env = Env.systemEnv().get(CODEQL_EXTRACTOR_JAVASCRIPT_SCRATCH_DIR_ENV_VAR);
+    if (env == null) {
+      throw new UserError(CODEQL_EXTRACTOR_JAVASCRIPT_SCRATCH_DIR_ENV_VAR + " must be set");
     }
     return env;
   }

--- a/javascript/extractor/src/com/semmle/js/extractor/EnvironmentVariables.java
+++ b/javascript/extractor/src/com/semmle/js/extractor/EnvironmentVariables.java
@@ -11,15 +11,18 @@ public class EnvironmentVariables {
   public static final String CODEQL_EXTRACTOR_JAVASCRIPT_SCRATCH_DIR_ENV_VAR =
       "CODEQL_EXTRACTOR_JAVASCRIPT_SCRATCH_DIR";
 
+  public static final String LGTM_WORKSPACE_ENV_VAR =
+      "LGTM_WORKSPACE";
+
   /**
    * Gets the extractor root based on the <code>CODEQL_EXTRACTOR_JAVASCRIPT_ROOT</code> or <code>
    * SEMMLE_DIST</code> or environment variable, or <code>null</code> if neither is set.
    */
   public static String tryGetExtractorRoot() {
-    String env = Env.systemEnv().get(CODEQL_EXTRACTOR_JAVASCRIPT_ROOT_ENV_VAR);
-    if (env != null && !env.isEmpty()) return env;
-    env = Env.systemEnv().get(Var.SEMMLE_DIST);
-    if (env != null && !env.isEmpty()) return env;
+    String env = Env.systemEnv().getNonEmpty(CODEQL_EXTRACTOR_JAVASCRIPT_ROOT_ENV_VAR);
+    if (env != null) return env;
+    env = Env.systemEnv().getNonEmpty(Var.SEMMLE_DIST);
+    if (env != null) return env;
     return null;
   }
 
@@ -35,11 +38,15 @@ public class EnvironmentVariables {
     return env;
   }
 
+  /**
+   * Gets the scratch directory from the appropriate environment variable.
+   */
   public static String getScratchDir() {
-    String env = Env.systemEnv().get(CODEQL_EXTRACTOR_JAVASCRIPT_SCRATCH_DIR_ENV_VAR);
-    if (env == null) {
-      throw new UserError(CODEQL_EXTRACTOR_JAVASCRIPT_SCRATCH_DIR_ENV_VAR + " must be set");
-    }
-    return env;
+    String env = Env.systemEnv().getNonEmpty(CODEQL_EXTRACTOR_JAVASCRIPT_SCRATCH_DIR_ENV_VAR);
+    if (env != null) return env;
+    env = Env.systemEnv().getNonEmpty(LGTM_WORKSPACE_ENV_VAR);
+    if (env != null) return env;
+
+    throw new UserError(CODEQL_EXTRACTOR_JAVASCRIPT_SCRATCH_DIR_ENV_VAR + " or " + LGTM_WORKSPACE_ENV_VAR + " must be set");
   }
 }

--- a/javascript/extractor/src/com/semmle/js/extractor/Main.java
+++ b/javascript/extractor/src/com/semmle/js/extractor/Main.java
@@ -140,7 +140,7 @@ public class Main {
     for (File projectFile : projectFiles) {
 
       long start = verboseLogStartTimer(ap, "Opening project " + projectFile);
-      ParsedProject project = tsParser.openProject(projectFile);
+      ParsedProject project = tsParser.openProject(projectFile, DependencyInstallationResult.empty);
       verboseLogEndTimer(ap, start);
       // Extract all files belonging to this project which are also matched
       // by our include/exclude filters.

--- a/javascript/extractor/src/com/semmle/js/extractor/test/AutoBuildTests.java
+++ b/javascript/extractor/src/com/semmle/js/extractor/test/AutoBuildTests.java
@@ -20,6 +20,7 @@ import java.nio.file.SimpleFileVisitor;
 import java.nio.file.attribute.BasicFileAttributes;
 import java.nio.file.attribute.DosFileAttributeView;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
@@ -129,8 +130,14 @@ public class AutoBuildTests {
         }
 
         @Override
-        protected void installDependencies(Set<Path> filesToExtract) {
+        protected void restoreOriginalFiles(java.util.Map<Path, Path> originalFiles) {
+          // Do nothing
+        }
+
+        @Override
+        protected Map<Path, Path> installDependencies(Set<Path> filesToExtract) {
           // never install dependencies during testing
+          return Collections.emptyMap();
         }
 
         @Override

--- a/javascript/extractor/src/com/semmle/js/extractor/test/AutoBuildTests.java
+++ b/javascript/extractor/src/com/semmle/js/extractor/test/AutoBuildTests.java
@@ -1,14 +1,5 @@
 package com.semmle.js.extractor.test;
 
-import com.semmle.js.extractor.AutoBuild;
-import com.semmle.js.extractor.ExtractorState;
-import com.semmle.js.extractor.FileExtractor;
-import com.semmle.js.extractor.FileExtractor.FileType;
-import com.semmle.util.data.StringUtil;
-import com.semmle.util.exception.UserError;
-import com.semmle.util.files.FileUtil;
-import com.semmle.util.files.FileUtil8;
-import com.semmle.util.process.Env;
 import java.io.File;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
@@ -20,17 +11,28 @@ import java.nio.file.SimpleFileVisitor;
 import java.nio.file.attribute.BasicFileAttributes;
 import java.nio.file.attribute.DosFileAttributeView;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Assume;
 import org.junit.Before;
 import org.junit.Test;
+
+import com.semmle.js.extractor.AutoBuild;
+import com.semmle.js.extractor.DependencyInstallationResult;
+import com.semmle.js.extractor.ExtractorState;
+import com.semmle.js.extractor.FileExtractor;
+import com.semmle.js.extractor.FileExtractor.FileType;
+import com.semmle.util.data.StringUtil;
+import com.semmle.util.exception.UserError;
+import com.semmle.util.files.FileUtil;
+import com.semmle.util.files.FileUtil8;
+import com.semmle.util.process.Env;
 
 public class AutoBuildTests {
   private Path SEMMLE_DIST, LGTM_SRC;
@@ -135,9 +137,9 @@ public class AutoBuildTests {
         }
 
         @Override
-        protected Map<Path, Path> installDependencies(Set<Path> filesToExtract) {
+        protected DependencyInstallationResult installDependencies(Set<Path> filesToExtract) {
           // never install dependencies during testing
-          return Collections.emptyMap();
+          return DependencyInstallationResult.empty;
         }
 
         @Override

--- a/javascript/extractor/src/com/semmle/js/extractor/test/AutoBuildTests.java
+++ b/javascript/extractor/src/com/semmle/js/extractor/test/AutoBuildTests.java
@@ -132,11 +132,6 @@ public class AutoBuildTests {
         }
 
         @Override
-        protected void restoreOriginalFiles(java.util.Map<Path, Path> originalFiles) {
-          // Do nothing
-        }
-
-        @Override
         protected DependencyInstallationResult installDependencies(Set<Path> filesToExtract) {
           // never install dependencies during testing
           return DependencyInstallationResult.empty;

--- a/javascript/extractor/src/com/semmle/js/parser/TypeScriptParser.java
+++ b/javascript/extractor/src/com/semmle/js/parser/TypeScriptParser.java
@@ -20,6 +20,7 @@ import java.util.Map;
 
 import com.google.gson.JsonArray;
 import com.google.gson.JsonElement;
+import com.google.gson.JsonNull;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonParseException;
 import com.google.gson.JsonParser;
@@ -435,6 +436,9 @@ public class TypeScriptParser {
     request.add("tsConfig", new JsonPrimitive(tsConfigFile.getPath()));
     request.add("packageEntryPoints", mapToArray(deps.getPackageEntryPoints()));
     request.add("packageJsonFiles", mapToArray(deps.getPackageJsonFiles()));
+    request.add("virtualSourceRoot", deps.getVirtualSourceRoot() == null
+        ? JsonNull.INSTANCE
+        : new JsonPrimitive(deps.getVirtualSourceRoot().toString()));
     JsonObject response = talkToParserWrapper(request);
     try {
       checkResponseType(response, "project-opened");

--- a/javascript/extractor/src/com/semmle/js/parser/TypeScriptParser.java
+++ b/javascript/extractor/src/com/semmle/js/parser/TypeScriptParser.java
@@ -1,12 +1,28 @@
 package com.semmle.js.parser;
 
-import ch.qos.logback.classic.Level;
+import java.io.BufferedReader;
+import java.io.BufferedWriter;
+import java.io.ByteArrayOutputStream;
+import java.io.Closeable;
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.io.OutputStream;
+import java.io.OutputStreamWriter;
+import java.lang.ProcessBuilder.Redirect;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
 import com.google.gson.JsonArray;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonParseException;
 import com.google.gson.JsonParser;
 import com.google.gson.JsonPrimitive;
+import com.semmle.js.extractor.DependencyInstallationResult;
 import com.semmle.js.extractor.EnvironmentVariables;
 import com.semmle.js.extractor.ExtractionMetrics;
 import com.semmle.js.parser.JSParser.Result;
@@ -23,21 +39,8 @@ import com.semmle.util.logging.LogbackUtils;
 import com.semmle.util.process.AbstractProcessBuilder;
 import com.semmle.util.process.Builder;
 import com.semmle.util.process.Env;
-import java.io.BufferedReader;
-import java.io.BufferedWriter;
-import java.io.ByteArrayOutputStream;
-import java.io.Closeable;
-import java.io.File;
-import java.io.IOException;
-import java.io.InputStream;
-import java.io.InputStreamReader;
-import java.io.OutputStream;
-import java.io.OutputStreamWriter;
-import java.lang.ProcessBuilder.Redirect;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.List;
+
+import ch.qos.logback.classic.Level;
 
 /**
  * The Java half of our wrapper for invoking the TypeScript parser.
@@ -409,10 +412,20 @@ public class TypeScriptParser {
    *
    * <p>Only one project should be opened at once.
    */
-  public ParsedProject openProject(File tsConfigFile) {
+  public ParsedProject openProject(File tsConfigFile, DependencyInstallationResult deps) {
     JsonObject request = new JsonObject();
     request.add("command", new JsonPrimitive("open-project"));
     request.add("tsConfig", new JsonPrimitive(tsConfigFile.getPath()));
+    JsonArray packageLocations = new JsonArray();
+    deps.getPackageLocations()
+        .forEach(
+            (packageName, packageDir) -> {
+              JsonArray entry = new JsonArray();
+              entry.add(packageName);
+              entry.add(packageDir.toString());
+              packageLocations.add(entry);
+            });
+    request.add("packageLocations", packageLocations);
     JsonObject response = talkToParserWrapper(request);
     try {
       checkResponseType(response, "project-opened");


### PR DESCRIPTION
Extends the dependency-installation support to handle monorepos, that is, repositories containing multiple packages. This also includes repos containing packages that haven't been published to NPM, such as our own `vscode-codeql`.

Update: it now works as follows:
- Rewrite package.json files and save them under `SCRATCH_DIR`, removing references to packages that exist in the same repo.
- Run `yarn install` for each package.json file in `SCRATCH_DIR`.
- Override hooks in the TypeScript compiler host to resolve packages in `SCRATCH_DIR` or to a package that exists in the same repo.

Original (obsolete) PR description
------
~~It works as follows:~~
- ~~For each `package.json` file with name, install a symlink to it in `<source_root>/node_modules`.~~
- ~~Delete all mentions of the above package.json files from `dependencies` etc.~~
- ~~Rewrite the `main` field to `./src` so TypeScript can find the contents of the package in terms of its original source files. Typically `main` refers to a non-existing file such as `./out/index.js` which won't exist unless we run the full build. (Normally TypeScript would use the `.d.ts` files in the `out` directory)~~
- ~~Run `yarn install` for each `package.json` file, as before.~~
- ~~Extract TypeScript files.~~
- ~~Restore original `package.json` files. We don't clean up `node_modules` folders as there isn't a concrete reason for doing so at the moment.~~

~~It's a bit dirty to rewrite files on disk, but keep in mind that this is only intended to use on LGTM. Users of the `codeql` CLI should install dependencies themselves before extracting.~~