### PR TITLE
JS: Ignore strict-mode-call-stack-introspection for expr stmts

### DIFF
--- a/change-notes/1.24/analysis-javascript.md
+++ b/change-notes/1.24/analysis-javascript.md
@@ -29,6 +29,7 @@
 | Incomplete string escaping or encoding (`js/incomplete-sanitization`) | Fewer false positive results | This query now recognizes additional cases where a single replacement is likely to be intentional. |
 | Unbound event handler receiver (`js/unbound-event-handler-receiver`) | Fewer false positive results | This query now recognizes additional ways event handler receivers can be bound. | 
 | Expression has no effect (`js/useless-expression`) | Fewer false positive results | The query now recognizes block-level flow type annotations. |
+| Use of call stack introspection in strict mode (`js/strict-mode-call-stack-introspection`) | Fewer false positive results | The query no longer flags expression statements. |
 
 ## Changes to libraries
 

--- a/javascript/ql/src/LanguageFeatures/StrictModeCallStackIntrospection.ql
+++ b/javascript/ql/src/LanguageFeatures/StrictModeCallStackIntrospection.ql
@@ -32,5 +32,6 @@ where
   acc.accesses(baseNode.asExpr(), prop) and
   acc.getContainer().isStrict() and
   illegalPropAccess(baseNode.getAValue(), base, prop) and
-  forex(AbstractValue av | av = baseNode.getAValue() | illegalPropAccess(av, _, prop))
+  forex(AbstractValue av | av = baseNode.getAValue() | illegalPropAccess(av, _, prop)) and
+  not acc = any(ExprStmt stmt).getExpr() // reported by js/useless-expression
 select acc, "Strict mode code cannot use " + base + "." + prop + "."

--- a/javascript/ql/test/query-tests/LanguageFeatures/StrictModeCallStackIntrospection/StrictModeCallStackIntrospection.expected
+++ b/javascript/ql/test/query-tests/LanguageFeatures/StrictModeCallStackIntrospection/StrictModeCallStackIntrospection.expected
@@ -1,7 +1,7 @@
 | tst.js:5:30:5:45 | arguments.callee | Strict mode code cannot use arguments.callee. |
 | tst.js:7:21:7:36 | arguments.callee | Strict mode code cannot use arguments.callee. |
 | tst.js:9:20:9:27 | f.caller | Strict mode code cannot use Function.prototype.caller. |
-| tst.js:11:8:11:18 | f.arguments | Strict mode code cannot use Function.prototype.arguments. |
-| tst.js:18:3:18:18 | arguments.callee | Strict mode code cannot use arguments.callee. |
-| tst.js:31:5:31:14 | foo.caller | Strict mode code cannot use Function.prototype.caller. |
-| tst.js:31:5:31:14 | foo.caller | Strict mode code cannot use arguments.caller. |
+| tst.js:11:17:11:27 | f.arguments | Strict mode code cannot use Function.prototype.arguments. |
+| tst.js:18:10:18:25 | arguments.callee | Strict mode code cannot use arguments.callee. |
+| tst.js:31:12:31:21 | foo.caller | Strict mode code cannot use Function.prototype.caller. |
+| tst.js:31:12:31:21 | foo.caller | Strict mode code cannot use arguments.caller. |

--- a/javascript/ql/test/query-tests/LanguageFeatures/StrictModeCallStackIntrospection/tst.js
+++ b/javascript/ql/test/query-tests/LanguageFeatures/StrictModeCallStackIntrospection/tst.js
@@ -8,14 +8,14 @@ var o = {
        // BAD
        console.log(f.caller);
        // BAD
-       f.arguments;
+       this.y = f.arguments;
        this.x = x;
      }
 };
 
 var D = class extends function() {
   // BAD
-  arguments.callee;
+  return arguments.callee;
 } {};
 
 function g() {
@@ -28,6 +28,11 @@ function g() {
   function h() {
     var foo = Math.random() > 0.5 ? h : arguments;
     // BAD
-    foo.caller;
+    return foo.caller;
   }
+})();
+
+(function() {
+  'use strict';
+  arguments.caller; // OK - avoid duplicate alert from useless-expression
 })();


### PR DESCRIPTION
Avoids the duplicate alert [here](https://lgtm.com/projects/g/ljharb/es-abstract/snapshot/a0800679d508ef15d31fe84283fc6a522277ca23/files/GetIntrinsic.js?sort=name&dir=ASC&mode=heatmap#xbd19a52cddeabb11:1).