### PR TITLE
Java: Replace ad-hoc TestClass detection.

### DIFF
--- a/change-notes/1.24/analysis-java.md
+++ b/change-notes/1.24/analysis-java.md
@@ -15,3 +15,11 @@ The following changes in version 1.24 affect Java analysis in all applications.
 
 ## Changes to libraries
 
+* Identification of test classes have been improved. Previously, one of the
+  match conditions would classify any class with a name containing the string
+  "Test" as a test class, but now this matching has been replaced with one that
+  looks for the occurrence of actual unit-test annotations. This affects the
+  general file classification mechanism and thus suppression of alerts, and
+  also any security queries using taint tracking, as test classes act as
+  default barriers stopping taint flow.
+

--- a/change-notes/1.24/analysis-java.md
+++ b/change-notes/1.24/analysis-java.md
@@ -15,11 +15,10 @@ The following changes in version 1.24 affect Java analysis in all applications.
 
 ## Changes to libraries
 
-* Identification of test classes have been improved. Previously, one of the
+* Identification of test classes has been improved. Previously, one of the
   match conditions would classify any class with a name containing the string
   "Test" as a test class, but now this matching has been replaced with one that
   looks for the occurrence of actual unit-test annotations. This affects the
   general file classification mechanism and thus suppression of alerts, and
   also any security queries using taint tracking, as test classes act as
   default barriers stopping taint flow.
-

--- a/java/ql/src/semmle/code/java/UnitTests.qll
+++ b/java/ql/src/semmle/code/java/UnitTests.qll
@@ -36,14 +36,32 @@ class TearDownMethod extends Method {
   }
 }
 
+private class TestRelatedAnnotation extends Annotation {
+  TestRelatedAnnotation() {
+    this.getType().getPackage().hasName("org.testng.annotations") or
+    this.getType().getPackage().hasName("org.junit") or
+    this.getType().getPackage().hasName("org.junit.runner") or
+    this.getType().getPackage().hasName("org.junit.jupiter.api") or
+    this.getType().getPackage().hasName("org.junit.jupiter.params")
+  }
+}
+
+private class TestRelatedMethod extends Method {
+  TestRelatedMethod() { this.getAnAnnotation() instanceof TestRelatedAnnotation }
+}
+
 /**
- * A class detected to be a test class, either because it is a JUnit test class
- * or because its name or the name of one of its super-types contains the substring "Test".
+ * A class detected to be a test class, either because it or one of its super-types
+ * and/or enclosing types contains a test method or method with a unit-test-related
+ * annotation.
  */
 class TestClass extends Class {
   TestClass() {
     this instanceof JUnit38TestClass or
-    this.getASupertype*().getSourceDeclaration().getName().matches("%Test%")
+    exists(TestMethod m | m.getDeclaringType() = this) or
+    exists(TestRelatedMethod m | m.getDeclaringType() = this) or
+    this.getASourceSupertype() instanceof TestClass or
+    this.getEnclosingType() instanceof TestClass
   }
 }
 


### PR DESCRIPTION
Test code as determined by `TestClass` is treated as a default barrier in taint tracking configurations.  This has posed some problems resulting in FNs due to a very ad-hoc test class classification, namely any class that has a name containing the string "Test" or inheriting from any such class.  This PR replaces this ad-hoc matching with one based on the occurrence of actual unit test annotations.